### PR TITLE
perf(renderer): retain compatible pipeline layouts

### DIFF
--- a/prosper/docs/FRONTEND_APP.md
+++ b/prosper/docs/FRONTEND_APP.md
@@ -332,6 +332,13 @@ fixed-function value; equality still compares the complete key after hashing. Th
 the backend and submit-aligned windows report references, hits, misses, bypasses, current entries, and
 evictions. A pipeline hit also skips temporary Vulkan shader-module creation.
 
+Pipeline layouts use a separate exact cross-call cache keyed by every descriptor set's ordered binding,
+type, count, and stage contract. Descriptor pools, descriptor sets, and descriptor-set layouts remain
+call-local; Vulkan pipeline-layout compatibility follows the complete descriptor contract rather than the
+temporary layout handle. The cache retains at most 256 layouts and evicts the least-recently-used entry not
+referenced by the current backend call. Set `PROSPER_PIPELINE_LAYOUT_CACHE_ENTRIES=<N>` to change the bound
+or `PROSPER_NO_BACKEND_PIPELINE_LAYOUT_CACHE=1` for a call-local A/B.
+
 Do not cache `build_stage_table` results using only shader addresses and user-SGPR values. Descriptor
 tables are reached through guest pointers, and their memory can change while every pointer/register
 value remains identical. That experiment caused Messenger to remain on its initial loading screen and

--- a/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
+++ b/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
@@ -222,6 +222,29 @@ completed the fresh-save route at 1920x1080 and produced direct composited frame
 cost is the fence wait after every backend call; removing it requires deferred lifetime management for all
 call-local Vulkan resources and is intentionally outside this tranche.
 
+## Evergate persistent pipeline layouts (2026-07-19)
+
+Dense Evergate submits still recreated the same small set of pipeline layouts in each backend call. The
+backend now retains pipeline layouts by the complete ordered descriptor contract. Descriptor pools, sets,
+set layouts, contents, images, and buffers remain call-local; a cache hit changes only the immutable pipeline
+layout lifetime. The cache defaults to 256 entries and evicts the least-recently-used layout not referenced by
+the current call. `PROSPER_PIPELINE_LAYOUT_CACHE_ENTRIES=<N>` changes the bound and
+`PROSPER_NO_BACKEND_PIPELINE_LAYOUT_CACHE=1` restores call-local creation.
+
+A native-Windows A/B/A used one final binary, separate fresh saves, native scale/cadence, the documented
+route, and submit-aligned windows matched at 472-488 realized draws:
+
+| Mode | Draws | Pipeline-layout setup | Whole submit |
+|---|---:|---:|---:|
+| Cache-disabled control 1 | 474-488 | 1.78-1.82 ms | 254-265 ms |
+| Bounded cache | 472-484 | 0.23-0.37 ms | 199-214 ms |
+| Cache-disabled control 2 | 474-487 | 1.33-1.52 ms | 180-185 ms |
+
+The reversed control exposes substantial warm-state variance in the other timing buckets, so the whole-submit
+ranges are not an FPS claim. The isolated layout bucket consistently removes about 1.1-1.5 ms from a dense
+submit. This is a bounded CPU improvement; GPU fence waits and draw/resource realization remain the dominant
+Evergate costs.
+
 ## Dead Cells backend upload duplication (2026-07-15)
 
 Dead Cells exposed a second duplication layer after the frontend decode caches. The frontend correctly

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -208,6 +208,10 @@ struct BackendResourceReuseStats {
     size_t pipeline_layout_references = 0;
     size_t unique_pipeline_layouts = 0;
     size_t descriptor_pools = 0;
+    size_t persistent_pipeline_layout_hits = 0;
+    size_t persistent_pipeline_layout_misses = 0;
+    size_t persistent_pipeline_layout_entries = 0;
+    size_t persistent_pipeline_layout_evictions = 0;
 };
 
 inline BackendResourceReuseStats& backend_resource_reuse_stats_storage() {
@@ -283,6 +287,47 @@ inline size_t persistent_pipeline_cache_limit() {
     static const size_t limit = [] {
         const char* value = getenv("PROSPER_PIPELINE_CACHE_ENTRIES");
         return value ? static_cast<size_t>(strtoull(value, nullptr, 10)) : size_t{1024};
+    }();
+    return limit;
+}
+
+struct BackendWordVectorHash {
+    size_t operator()(const std::vector<uint64_t>& words) const {
+        uint64_t hash = 1469598103934665603ull;
+        for (uint64_t word : words) {
+            hash ^= word;
+            hash *= 1099511628211ull;
+        }
+        return static_cast<size_t>(hash);
+    }
+};
+
+struct PersistentBackendPipelineLayout {
+    VkPipelineLayout handle = VK_NULL_HANDLE;
+    uint64_t last_use = 0;
+};
+
+inline std::unordered_map<std::vector<uint64_t>, PersistentBackendPipelineLayout,
+                          BackendWordVectorHash>&
+persistent_backend_pipeline_layout_cache() {
+    static std::unordered_map<std::vector<uint64_t>, PersistentBackendPipelineLayout,
+                              BackendWordVectorHash> cache;
+    return cache;
+}
+
+inline uint64_t& persistent_pipeline_layout_generation() {
+    static uint64_t generation = 0;
+    return generation;
+}
+
+inline bool persistent_pipeline_layout_cache_enabled() {
+    return getenv("PROSPER_NO_BACKEND_PIPELINE_LAYOUT_CACHE") == nullptr;
+}
+
+inline size_t persistent_pipeline_layout_cache_limit() {
+    static const size_t limit = [] {
+        const char* value = getenv("PROSPER_PIPELINE_LAYOUT_CACHE_ENTRIES");
+        return value ? static_cast<size_t>(strtoull(value, nullptr, 10)) : size_t{256};
     }();
     return limit;
 }
@@ -1612,6 +1657,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         VkShaderModule vs = VK_NULL_HANDLE, gs = VK_NULL_HANDLE, fs = VK_NULL_HANDLE;
         std::vector<FrameResource> R;
         std::vector<VkDescriptorSetLayout> dsls; std::vector<VkDescriptorSet> dsets;
+        std::vector<std::vector<uint64_t>> descriptor_layout_keys;
         std::vector<VkBuffer> sbuf;
         std::vector<size_t> texture_upload;
         std::vector<VkImageView> tview; std::vector<VkSampler> tsamp;
@@ -1751,15 +1797,9 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         VkImageView view = VK_NULL_HANDLE;
         VkSampler sampler = VK_NULL_HANDLE;
     };
-    struct WordVectorHash {
-        size_t operator()(const std::vector<uint64_t>& words) const {
-            uint64_t hash = 1469598103934665603ull;
-            for (uint64_t word : words) {
-                hash ^= word;
-                hash *= 1099511628211ull;
-            }
-            return static_cast<size_t>(hash);
-        }
+    struct SharedPipelineLayout {
+        VkPipelineLayout handle = VK_NULL_HANDLE;
+        bool persistent = false;
     };
     std::vector<SharedBufferUpload> shared_buffers;
     std::vector<SharedBufferArena> shared_buffer_arenas;
@@ -1767,9 +1807,9 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     std::vector<SharedTextureBinding> shared_texture_bindings;
     std::unordered_map<TextureBindingKey, size_t, TextureBindingKeyHash>
         shared_texture_binding_indices;
-    std::unordered_map<std::vector<uint64_t>, VkDescriptorSetLayout, WordVectorHash>
+    std::unordered_map<std::vector<uint64_t>, VkDescriptorSetLayout, BackendWordVectorHash>
         shared_descriptor_set_layouts;
-    std::unordered_map<std::vector<uint64_t>, VkPipelineLayout, WordVectorHash>
+    std::unordered_map<std::vector<uint64_t>, SharedPipelineLayout, BackendWordVectorHash>
         shared_pipeline_layouts;
     uint64_t resource_unique_tag = 0;
     const uint32_t zero_buffer_word = 0;
@@ -1840,6 +1880,25 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     const uint64_t pipeline_generation = ++persistent_pipeline_generation();
     const bool pipeline_cache_enabled = persistent_pipeline_cache_enabled();
     const size_t pipeline_cache_limit = persistent_pipeline_cache_limit();
+    const bool pipeline_layout_cache_enabled = share_backend_resources &&
+        persistent_pipeline_layout_cache_enabled();
+    const size_t pipeline_layout_cache_limit = persistent_pipeline_layout_cache_limit();
+    const uint64_t pipeline_layout_generation = ++persistent_pipeline_layout_generation();
+    auto& persistent_pipeline_layouts = persistent_backend_pipeline_layout_cache();
+    auto evict_persistent_pipeline_layout = [&]() {
+        auto victim = persistent_pipeline_layouts.end();
+        for (auto it = persistent_pipeline_layouts.begin();
+             it != persistent_pipeline_layouts.end(); ++it) {
+            if (it->second.last_use == pipeline_layout_generation) continue;
+            if (victim == persistent_pipeline_layouts.end() ||
+                it->second.last_use < victim->second.last_use) victim = it;
+        }
+        if (victim == persistent_pipeline_layouts.end()) return false;
+        vkDestroyPipelineLayout(dev, victim->second.handle, nullptr);
+        persistent_pipeline_layouts.erase(victim);
+        ++resource_reuse_stats.persistent_pipeline_layout_evictions;
+        return true;
+    };
     auto evict_pipeline = [&]() {
         auto victim = pipeline_cache.end();
         for (auto it = pipeline_cache.begin(); it != pipeline_cache.end(); ++it) {
@@ -2070,6 +2129,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         v.use_desc = !R.empty();
         for (auto& r : R) v.n_sets = std::max(v.n_sets, r.set + 1);
         v.dsls.assign(v.n_sets, VK_NULL_HANDLE); v.dsets.assign(v.n_sets, VK_NULL_HANDLE);
+        v.descriptor_layout_keys.resize(v.n_sets);
         v.sbuf.assign(R.size(), VK_NULL_HANDLE);
         v.texture_upload.assign(R.size(), SIZE_MAX);
         v.tview.assign(R.size(), VK_NULL_HANDLE); v.tsamp.assign(R.size(), VK_NULL_HANDLE);
@@ -2395,6 +2455,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                     layout_key.push_back(binding.descriptorCount);
                     layout_key.push_back(binding.stageFlags);
                 }
+                v.descriptor_layout_keys[s] = layout_key;
                 ++resource_reuse_stats.descriptor_set_layout_references;
                 auto layout_found = shared_descriptor_set_layouts.find(layout_key);
                 if (layout_found != shared_descriptor_set_layouts.end()) {
@@ -2422,23 +2483,61 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         const auto setup_resources_ready = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
         if (timing_enabled) setup_resources_ms += setup_elapsed_ms(setup_fixed_ready, setup_resources_ready);
         std::vector<uint64_t> pipeline_layout_key;
-        pipeline_layout_key.reserve(1 + (v.use_desc ? v.dsls.size() : 0));
+        size_t pipeline_layout_key_words = 1;
+        if (v.use_desc) {
+            for (const auto& descriptor_layout_key : v.descriptor_layout_keys)
+                pipeline_layout_key_words += 1 + descriptor_layout_key.size();
+        }
+        pipeline_layout_key.reserve(pipeline_layout_key_words);
         pipeline_layout_key.push_back(share_backend_resources ? 0 : ++resource_unique_tag);
-        if (v.use_desc)
-            for (VkDescriptorSetLayout layout : v.dsls)
-                pipeline_layout_key.push_back(handle_bits(layout));
+        if (v.use_desc) {
+            for (const auto& descriptor_layout_key : v.descriptor_layout_keys) {
+                pipeline_layout_key.push_back(descriptor_layout_key.size());
+                pipeline_layout_key.insert(pipeline_layout_key.end(),
+                                           descriptor_layout_key.begin(),
+                                           descriptor_layout_key.end());
+            }
+        }
         ++resource_reuse_stats.pipeline_layout_references;
         auto pipeline_layout_found = shared_pipeline_layouts.find(pipeline_layout_key);
         if (pipeline_layout_found != shared_pipeline_layouts.end()) {
-            v.layout = pipeline_layout_found->second;
+            v.layout = pipeline_layout_found->second.handle;
         } else {
-            VkPipelineLayoutCreateInfo layout_info{VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO};
-            if (v.use_desc) {
-                layout_info.setLayoutCount = v.n_sets;
-                layout_info.pSetLayouts = v.dsls.data();
+            SharedPipelineLayout shared_layout;
+            const bool can_persist_pipeline_layout = pipeline_layout_cache_enabled &&
+                pipeline_layout_cache_limit;
+            auto persistent_layout = can_persist_pipeline_layout
+                ? persistent_pipeline_layouts.find(pipeline_layout_key)
+                : persistent_pipeline_layouts.end();
+            if (persistent_layout != persistent_pipeline_layouts.end()) {
+                persistent_layout->second.last_use = pipeline_layout_generation;
+                shared_layout.handle = persistent_layout->second.handle;
+                shared_layout.persistent = true;
+                ++resource_reuse_stats.persistent_pipeline_layout_hits;
+            } else {
+                VkPipelineLayoutCreateInfo layout_info{
+                    VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO};
+                if (v.use_desc) {
+                    layout_info.setLayoutCount = v.n_sets;
+                    layout_info.pSetLayouts = v.dsls.data();
+                }
+                vkCreatePipelineLayout(dev, &layout_info, nullptr, &shared_layout.handle);
+                if (can_persist_pipeline_layout) {
+                    ++resource_reuse_stats.persistent_pipeline_layout_misses;
+                    while (persistent_pipeline_layouts.size() >= pipeline_layout_cache_limit &&
+                           evict_persistent_pipeline_layout()) {}
+                    if (shared_layout.handle &&
+                        persistent_pipeline_layouts.size() < pipeline_layout_cache_limit) {
+                        persistent_pipeline_layouts.emplace(
+                            pipeline_layout_key,
+                            PersistentBackendPipelineLayout{
+                                shared_layout.handle, pipeline_layout_generation});
+                        shared_layout.persistent = true;
+                    }
+                }
             }
-            vkCreatePipelineLayout(dev, &layout_info, nullptr, &v.layout);
-            shared_pipeline_layouts.emplace(std::move(pipeline_layout_key), v.layout);
+            v.layout = shared_layout.handle;
+            shared_pipeline_layouts.emplace(std::move(pipeline_layout_key), shared_layout);
             ++resource_reuse_stats.unique_pipeline_layouts;
         }
         VkGraphicsPipelineCreateInfo gp{VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO};
@@ -2984,7 +3083,8 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     if (shared_descriptor_pool)
         vkDestroyDescriptorPool(dev, shared_descriptor_pool, nullptr);
     for (const auto& [key, layout] : shared_pipeline_layouts)
-        if (layout) vkDestroyPipelineLayout(dev, layout, nullptr);
+        if (layout.handle && !layout.persistent)
+            vkDestroyPipelineLayout(dev, layout.handle, nullptr);
     for (const auto& [key, layout] : shared_descriptor_set_layouts)
         if (layout) vkDestroyDescriptorSetLayout(dev, layout, nullptr);
     for (const SharedTextureBinding& binding : shared_texture_bindings) {
@@ -3079,6 +3179,8 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
            evict_persistent_color_target(ctx, color_target_generation)) {}
     color_target_stats.cached_bytes = persistent_color_target_bytes();
     color_target_stats.cached_entries = persistent_color_target_cache().size();
+    resource_reuse_stats.persistent_pipeline_layout_entries =
+        persistent_pipeline_layouts.size();
     if (timing_enabled) {
         const auto timing_done = TimingClock::now();
         auto ms = [](auto begin, auto end) {

--- a/prosper/tests/test_multidraw_render.cpp
+++ b/prosper/tests/test_multidraw_render.cpp
@@ -33,6 +33,7 @@ static void set_env(const char* name, const char* value) {
 int main() {
     printf("== test_multidraw_render ==\n");
     set_env("PROSPER_RENDER_TIMING", "1");
+    set_env("PROSPER_PIPELINE_LAYOUT_CACHE_ENTRIES", "2");
     const uint32_t W = 64, H = 64;
 
     // Known-good fullscreen-triangle vertex shader (SPIR-V), shared by both draws.
@@ -201,18 +202,32 @@ int main() {
         const std::vector<uint8_t> pooled_again = prosper::test::render_draws_rgba(
             {capacity_peer0, capacity_peer1}, W, H);
         const auto pool_after_second = prosper::test::render_host_buffer_pool_stats();
+        const auto layout_stats = prosper::test::backend_resource_reuse_stats();
         CHECK(pool_after_second.hits == pool_after_first.hits + 1 &&
                   pool_after_second.misses == pool_after_first.misses &&
                   pooled_again == shared,
               "next logical size reuses the mapped arena byte-identically");
+        CHECK(layout_stats.persistent_pipeline_layout_hits >= 1 &&
+                  layout_stats.persistent_pipeline_layout_entries >= 1,
+              "equal pipeline-layout contracts reuse the bounded cross-call cache");
 
+        set_env("PROSPER_NO_BACKEND_PIPELINE_LAYOUT_CACHE", "1");
+        const std::vector<uint8_t> uncached_layouts =
+            prosper::test::render_draws_rgba({d0, d1}, W, H);
+        const auto uncached_layout_stats = prosper::test::backend_resource_reuse_stats();
+        set_env("PROSPER_NO_BACKEND_PIPELINE_LAYOUT_CACHE", nullptr);
+        CHECK(uncached_layout_stats.persistent_pipeline_layout_hits == 0 &&
+                  uncached_layouts == shared,
+              "layout-cache disable switch restores byte-identical call-local layouts");
+
+        const auto pool_before_bypass = prosper::test::render_host_buffer_pool_stats();
         set_env("PROSPER_NO_BACKEND_BUFFER_POOL", "1");
         const std::vector<uint8_t> pool_bypassed =
             prosper::test::render_draws_rgba({d0, d1}, W, H);
         const auto pool_after_bypass = prosper::test::render_host_buffer_pool_stats();
         set_env("PROSPER_NO_BACKEND_BUFFER_POOL", nullptr);
-        CHECK(pool_after_bypass.hits == pool_after_second.hits &&
-                  pool_after_bypass.misses == pool_after_second.misses,
+        CHECK(pool_after_bypass.hits == pool_before_bypass.hits &&
+                  pool_after_bypass.misses == pool_before_bypass.misses,
               "buffer-pool disable switch restores transient Vulkan uploads");
         CHECK(pool_bypassed == shared,
               "pooled and forced-transient storage buffers render byte-identically");
@@ -237,6 +252,35 @@ int main() {
               "resource-share disable switch restores distinct per-draw immutable objects");
         CHECK(!shared.empty() && shared == unshared,
               "shared and unshared per-draw resources render byte-identically");
+
+        const std::vector<uint8_t> original_layout_output =
+            prosper::test::render_draws_rgba({d0}, W, H);
+        prosper::test::BackendDraw alternate_layout = d0;
+        alternate_layout.R[0].binding = 1;
+        const std::vector<uint8_t> alternate_output =
+            prosper::test::render_draws_rgba({alternate_layout}, W, H);
+        const auto bounded_layout_stats = prosper::test::backend_resource_reuse_stats();
+        CHECK(alternate_output == original_layout_output &&
+                  bounded_layout_stats.persistent_pipeline_layout_entries == 2 &&
+                  bounded_layout_stats.persistent_pipeline_layout_evictions >= 1,
+              "pipeline-layout cache evicts an older contract at its configured bound");
+
+        // Warm both bounded entries, then require three distinct contracts in one call. The third
+        // layout must remain call-local: evicting either of the first two would destroy an object
+        // already referenced by a pipeline recorded for this submission.
+        prosper::test::render_draws_rgba({d0}, W, H);
+        prosper::test::render_draws_rgba({alternate_layout}, W, H);
+        prosper::test::BackendDraw overflow_layout = d0;
+        overflow_layout.R[0].binding = 0;
+        const std::vector<uint8_t> protected_output = prosper::test::render_draws_rgba(
+            {d0, alternate_layout, overflow_layout}, W, H);
+        const auto protected_layout_stats = prosper::test::backend_resource_reuse_stats();
+        CHECK(protected_output == original_layout_output &&
+                  protected_layout_stats.persistent_pipeline_layout_hits >= 2 &&
+                  protected_layout_stats.persistent_pipeline_layout_misses >= 1 &&
+                  protected_layout_stats.persistent_pipeline_layout_entries == 2 &&
+                  protected_layout_stats.persistent_pipeline_layout_evictions == 0,
+              "pipeline-layout eviction preserves every contract used by the current call");
     }
 
     // #531: a guest scissor must constrain a color-disabled stencil writer. The following full-target


### PR DESCRIPTION
## Summary

- retain compatible Vulkan pipeline layouts across synchronous backend calls using the complete ordered descriptor contract
- bound the cache to 256 entries by default, protect current-call entries from eviction, and provide tune/disable switches
- keep descriptor pools, descriptor sets, descriptor-set layouts, contents, images, and buffers call-local
- cover cross-call hits, byte-identical cache disablement, and bounded eviction

## Motivation and measurement

Evergate's dense transition repeatedly recreated a small set of identical pipeline layouts. A same-binary native-Windows A/B/A used separate fresh saves, native scale/cadence, and matched 472-488-draw windows:

| Mode | Pipeline-layout setup | Whole submit |
|---|---:|---:|
| Cache-disabled control 1 | 1.78-1.82 ms | 254-265 ms |
| Bounded cache | 0.23-0.37 ms | 199-214 ms |
| Cache-disabled control 2 | 1.33-1.52 ms | 180-185 ms |

The reversed control exposes large warm-state variance outside the layout bucket, so this PR deliberately makes no FPS claim. The isolated, repeatable gain is about 1.1-1.5 ms per dense submit.

## Validation

- Linux `prosper-app` build and tests: 112/112 passed
- Windows `prosper-app.exe` build and tests: 87/87 passed
- native-Windows Evergate fresh-save route after #974: 1,380 presented frames in two minutes, zero worker/thread/presentation faults
- native-Windows sparse full-resolution capture: 12/12 source-distinct and pixel-distinct frames; visibly reached gameplay
- exact-head real-game guards: Messenger 29/29, Evergate 9/9, Dead Cells 44/44, and Blasphemous II 98/98 qualifying frames passed with expected motion

A pre-rebase Messenger matrix run remained at name entry while presentation continued. A same-binary cache-disabled control and cache-enabled retry both reached the reviewed gameplay scene. After rebasing onto #977's replay-anchor work, the exact-head matrix passed. This was a route/input timing miss, not a reproducible renderer-cache failure.

## Risk boundaries

The key includes each set boundary and every binding/type/count/stage value. Cache entries contain only immutable Vulkan pipeline-layout objects; no guest pointers, bytes, descriptor contents, or writable resources cross calls. Eviction skips layouts referenced by the current backend call.

Advances #702.