### PR TITLE
Input replay: add pad-read route anchors

### DIFF
--- a/prosper/docs/INPUT_REPLAY.md
+++ b/prosper/docs/INPUT_REPLAY.md
@@ -46,9 +46,9 @@ We already have the seed: **`PROSPER_PAD_SCRIPT` (#202)** — a scripted `PadBac
   `right-stick-{left,right,up,down}` directions. Seconds points use `PROSPER_PAD_HOLD` ms
   (default 300); flip/read points use their count-axis holds above. Explicit ranges always use their
   exclusive end.
-- **Anchored to the first successful input-state read**: seconds and flips retain their existing
-  first-read origins; pad reads number successful `scePadRead`/`scePadReadState` calls from zero.
-  Controller-information queries and rejected reads do not advance any route axis.
+- **Anchored at the established origins**: seconds and flips retain their existing first-pad-poll
+  origin. Pad reads number successful `scePadRead`/`scePadReadState` calls from zero; controller-
+  information queries and rejected reads do not advance the pad-read axis.
 - Pad reports CONNECTED whenever a script is set. Parse + time-eval are pure and unit-tested in `pad.cpp`.
 - Explicit wall-clock ranges are sampled only when the game polls the pad. A short range can fall
   entirely between polls under slow synchronous rendering. Use longer holds with neutral gaps,

--- a/prosper/docs/INPUT_REPLAY.md
+++ b/prosper/docs/INPUT_REPLAY.md
@@ -46,8 +46,9 @@ We already have the seed: **`PROSPER_PAD_SCRIPT` (#202)** — a scripted `PadBac
   `right-stick-{left,right,up,down}` directions. Seconds points use `PROSPER_PAD_HOLD` ms
   (default 300); flip/read points use their count-axis holds above. Explicit ranges always use their
   exclusive end.
-- **Anchored to the first pad poll**: seconds and flips retain their existing first-poll origins;
-  pad reads are numbered from zero at that same first snapshot.
+- **Anchored to the first successful input-state read**: seconds and flips retain their existing
+  first-read origins; pad reads number successful `scePadRead`/`scePadReadState` calls from zero.
+  Controller-information queries and rejected reads do not advance any route axis.
 - Pad reports CONNECTED whenever a script is set. Parse + time-eval are pure and unit-tested in `pad.cpp`.
 - Explicit wall-clock ranges are sampled only when the game polls the pad. A short range can fall
   entirely between polls under slow synchronous rendering. Use longer holds with neutral gaps,
@@ -66,7 +67,7 @@ validation that does not depend on presentation speed.
 ### 1. Frame/pad-read-anchored, file-loadable scripts (core) - implemented
 - **Anchor to game frames, not wall-time.** Keep the "first pad poll" origin (robust to load time), but measure progress in **flips since first poll** (game logic frames), not elapsed seconds. The Messenger is a fixed-timestep platformer, so wall-time drifts vs game frames on slow llvmpipe vs a fast GPU — frame anchoring makes `f300:cross` reproduce everywhere. Add an `f<frame>:` entry syntax alongside the existing `<seconds>:` (kept for back-compat).
 - **Anchor to pad reads when presentation is not the clock.** `p1200-1240:cross` holds Cross for
-  guest controller snapshots 1200 through 1239. This axis advances when synchronous rendering pauses
+  successful guest input-state reads 1200 through 1239. This axis advances when synchronous rendering pauses
   display flips and cannot miss between polls like a short wall-time range. The transition log prints
   the live read index so routes can be calibrated without a code change.
 - **Load from a file.** `PROSPER_PAD_SCRIPT=@path` reads a multi-line script file, so long routes live in the repo, not an env string.

--- a/prosper/docs/INPUT_REPLAY.md
+++ b/prosper/docs/INPUT_REPLAY.md
@@ -1,20 +1,23 @@
 # Input replay & checkpoints — reaching a game state to reproduce a bug
 
-> **Status (2026-07-12): frame anchoring, route loading/recording, and the opt-in deterministic clock have landed.**
-> Current master supports inline `PROSPER_PAD_SCRIPT` entries anchored as `fN:`/`fA-B:` and
-> `PROSPER_DET_CLOCK=1` (fixed `1/PROSPER_DET_FPS`, default 60, per flip). Before the first flip the
+> **Status (2026-07-19): frame/pad-read anchoring, route loading/recording, and the opt-in deterministic clock have landed.**
+> Current master supports inline `PROSPER_PAD_SCRIPT` entries anchored as `fN:`/`fA-B:` (display
+> flips) or `pN:`/`pA-B:` (pad reads), alongside the existing seconds axis. Point entries use
+> `PROSPER_PAD_FRAME_HOLD` or `PROSPER_PAD_READ_HOLD` (both default 8) on their count axis. It also
+> supports `PROSPER_DET_CLOCK=1` (fixed `1/PROSPER_DET_FPS`, default 60, per flip). Before the first flip the
 > monotonic clock follows host time so initialization can progress; afterward it intentionally pauses
 > between flips. Realtime/RTC clocks remain tied to host time. `PROSPER_PAD_SCRIPT=@path` loads newline-
-> separated routes with comments, explicit time/flip ranges, and full-deflection stick directions such
+> separated routes with comments, explicit time/flip/read ranges, and full-deflection stick directions such
 > as `left-stick-left`. `PROSPER_PAD_RECORD=path` records the
 > final button stream on that same flip axis; `prosper-app --record path` exposes it interactively.
-> `PROSPER_PAD_SCRIPT_LOG=1` logs state transitions as the game observes them at pad polls.
+> `PROSPER_PAD_SCRIPT_LOG=1` logs state transitions with the elapsed time, flip, and pad-read index
+> as the game observes them.
 > `PROSPER_PAD_SCRIPT_RELOAD=1` live-reloads an `@file` route after a changed file remains
-> stable across two metadata polls. Existing time and flip anchors are preserved, so an agent can
+> stable across two metadata polls. Existing time, flip, and read anchors are preserved, so an agent can
 > append future input windows during a long exploratory run without restarting the title.
 > The first checked-in route, `scripts/messenger/reach-intro-story.pad`, repeatedly reaches the opening
-> story but still has small narration-phase drift. Deeper routes and a precise pad-read screenshot
-> checkpoint axis remain open in #302. The original design follows.
+> story but still has small narration-phase drift. Capturing directly onto the pad-read axis and
+> semantic checkpoint validation remain open in #302. The original design follows.
 
 ## The problem
 
@@ -36,26 +39,36 @@ We already have the seed: **`PROSPER_PAD_SCRIPT` (#202)** — a scripted `PadBac
 
 ## What exists today (`PROSPER_PAD_SCRIPT`, #202)
 
-- Format: `;`-separated `<seconds>:<action>[+action…]`, e.g. `3:start;9:cross;16:left-stick-left+cross`.
+- Format: `;`- or newline-separated `<anchor>:<action>[+action…]`, where an anchor is seconds,
+  `fN`/`fA-B` display flips, or `pN`/`pA-B` pad reads. For example:
+  `3:start;f300-340:cross;p1200-1240:left-stick-left+cross`.
 - Actions are button names or full-deflection `left-stick-{left,right,up,down}` and
-  `right-stick-{left,right,up,down}` directions. Each entry holds its actions for
-  `PROSPER_PAD_HOLD` ms (default 300) starting at `<seconds>`.
-- **Anchored to the first pad poll** (t=0 = "the game first read the controller" ≈ menu appeared) — robust to asset-load time.
+  `right-stick-{left,right,up,down}` directions. Seconds points use `PROSPER_PAD_HOLD` ms
+  (default 300); flip/read points use their count-axis holds above. Explicit ranges always use their
+  exclusive end.
+- **Anchored to the first pad poll**: seconds and flips retain their existing first-poll origins;
+  pad reads are numbered from zero at that same first snapshot.
 - Pad reports CONNECTED whenever a script is set. Parse + time-eval are pure and unit-tested in `pad.cpp`.
 - Explicit wall-clock ranges are sampled only when the game polls the pad. A short range can fall
   entirely between polls under slow synchronous rendering. Use longer holds with neutral gaps,
-  prefer flip-anchored ranges when the title keeps presenting, and enable
+  prefer flip-anchored ranges when the title keeps presenting, or pad-read ranges when presentation
+  pauses but the game continues polling. Enable
   `PROSPER_PAD_SCRIPT_LOG=1` to verify delivery rather than inferring it from the route text.
 - For exploratory `@file` routes, set `PROSPER_PAD_SCRIPT_RELOAD=1`. A changed route is debounced
   for 250 ms and replaces the active route only after a complete stable read; read/stat failures
-  retain the last valid route. Reload does not reset the first-poll wall-clock or flip origin.
+  retain the last valid route. Reload does not reset the first-poll wall-clock, flip, or read origin.
 
-Good bones. Two gaps for reaching deep states reliably: the clock is **wall-time**, and scripts are an env string (fine for a few presses, not for a long route).
+The remaining work is deeper route calibration, pad-read-axis recording, and semantic checkpoint
+validation that does not depend on presentation speed.
 
 ## Design
 
-### 1. Frame-anchored, file-loadable scripts (core) - implemented
+### 1. Frame/pad-read-anchored, file-loadable scripts (core) - implemented
 - **Anchor to game frames, not wall-time.** Keep the "first pad poll" origin (robust to load time), but measure progress in **flips since first poll** (game logic frames), not elapsed seconds. The Messenger is a fixed-timestep platformer, so wall-time drifts vs game frames on slow llvmpipe vs a fast GPU — frame anchoring makes `f300:cross` reproduce everywhere. Add an `f<frame>:` entry syntax alongside the existing `<seconds>:` (kept for back-compat).
+- **Anchor to pad reads when presentation is not the clock.** `p1200-1240:cross` holds Cross for
+  guest controller snapshots 1200 through 1239. This axis advances when synchronous rendering pauses
+  display flips and cannot miss between polls like a short wall-time range. The transition log prints
+  the live read index so routes can be calibrated without a code change.
 - **Load from a file.** `PROSPER_PAD_SCRIPT=@path` reads a multi-line script file, so long routes live in the repo, not an env string.
 - **Richer input.** Explicit ranges and full-deflection analog stick directions are implemented;
   proportional axis values remain future work.

--- a/prosper/src/hle/hle_pad.cpp
+++ b/prosper/src/hle/hle_pad.cpp
@@ -73,7 +73,7 @@ uint64_t now_us() {
 // script is set the pad reports
 // CONNECTED for the whole run (a menu that gates on a controller sees one).
 //
-// Timing is anchored to the FIRST input poll, not process start: the game only reads the pad once it
+// Timing is anchored to the FIRST successful input-state read, not process start: the game only reads the pad once it
 // reaches the interactive menu, so t=0 == "menu appeared" — robust to how long asset loading takes.
 // CONFIDENCE: HIGH (mechanism); MED (that the game's submit maps to OPTIONS="Start" / CROSS).
 // The parse + time-eval live in pad.cpp (pure, unit-tested); this file supplies getenv + the clock.
@@ -242,8 +242,8 @@ int64_t pad_frame_now() {
     return flips >= base ? (int64_t)(flips - base) : 0;
 }
 
-// Pad-read anchor: each controller snapshot is one read, numbered from zero at the first poll. This
-// advances even when presentation is paused by synchronous rendering.
+// Pad-read anchor: each successful scePadRead/scePadReadState call is one read, numbered from zero.
+// Metadata queries and rejected reads do not consume it; it advances even when presentation is paused.
 std::atomic<uint64_t> g_pad_read_count{0};
 
 int64_t pad_read_hold() {
@@ -351,17 +351,22 @@ void pad_record(int64_t frame, uint32_t buttons) {
 // installed, prosper_core's default backend reports ONE connected controller with neutral input (a PS5
 // title can gate progression on a pad being present, so dev/testing needs one). PROSPER_PAD_PRESS adds
 // a synthetic CROSS; PROSPER_PAD_SCRIPT adds a timed controller sequence — device-independent test drivers.
-HostPadState snapshot(int /*handle*/, const char* what) {
+HostPadState poll_controller(int /*handle*/, const char* what, bool consume_input_read) {
     HostPadState s;   // filled by the backend below (default: one connected, neutral controller)
     pad_backend()->poll(0, s);
     if (getenv("PROSPER_PAD_PRESS")) {
         s.connected = true;
         s.buttons  |= SCE_PAD_BUTTON_CROSS;
     }
-    const int64_t frame = pad_frame_now();
-    const int64_t read = pad_read_now();
-    apply_pad_script(s, frame, read);
-    pad_record(frame, s.buttons);
+    // Information queries report script-driven connectivity, but they must not advance pN routes.
+    // Only calls that return an input state consume a pad-read anchor.
+    if (pad_script_runtime().configured()) s.connected = true;
+    if (consume_input_read) {
+        const int64_t frame = pad_frame_now();
+        const int64_t read = pad_read_now();
+        apply_pad_script(s, frame, read);
+        pad_record(frame, s.buttons);
+    }
     padlog_once(what, &s);
     return s;
 }
@@ -387,7 +392,7 @@ HLE(pad_is_valid_handle) { return a0 >= 1 ? 1 : 0; }
 // scePadReadState(handle, ScePadData* out) -> 0 on success. One current snapshot.
 HLE(pad_read_state) {
     if (!a1) return 0;
-    HostPadState s = snapshot((int)a0, __func__);
+    HostPadState s = poll_controller((int)a0, __func__, true);
     pad_fill_data((ScePadData*)PW(a1), s, now_us(), s.connected ? 1 : 0);
     return 0;
 }
@@ -397,7 +402,7 @@ HLE(pad_read_state) {
 HLE(pad_read) {
     int num = (int)(int64_t)a2;
     if (!a1 || num < 1) return 0;
-    HostPadState s = snapshot((int)a0, __func__);
+    HostPadState s = poll_controller((int)a0, __func__, true);
     pad_fill_data((ScePadData*)PW(a1), s, now_us(), s.connected ? 1 : 0);
     return 1;   // one state written
 }
@@ -405,7 +410,7 @@ HLE(pad_read) {
 // scePadGetControllerInformation(handle, ScePadControllerInformation* out) -> 0.
 HLE(pad_get_info) {
     if (!a1) return 0;
-    HostPadState s = snapshot((int)a0, __func__);
+    HostPadState s = poll_controller((int)a0, __func__, false);
     pad_fill_controller_info((ScePadControllerInformation*)PW(a1), s.connected, s.connected ? 1 : 0);
     return 0;
 }

--- a/prosper/src/hle/hle_pad.cpp
+++ b/prosper/src/hle/hle_pad.cpp
@@ -73,8 +73,8 @@ uint64_t now_us() {
 // script is set the pad reports
 // CONNECTED for the whole run (a menu that gates on a controller sees one).
 //
-// Timing is anchored to the FIRST successful input-state read, not process start: the game only reads the pad once it
-// reaches the interactive menu, so t=0 == "menu appeared" — robust to how long asset loading takes.
+// Timing is anchored to the FIRST pad poll, not process start: the game only polls once it reaches
+// the interactive menu, so t=0 == "menu appeared" — robust to how long asset loading takes.
 // CONFIDENCE: HIGH (mechanism); MED (that the game's submit maps to OPTIONS="Start" / CROSS).
 // The parse + time-eval live in pad.cpp (pure, unit-tested); this file supplies getenv + the clock.
 double pad_hold_secs();
@@ -358,15 +358,13 @@ HostPadState poll_controller(int /*handle*/, const char* what, bool consume_inpu
         s.connected = true;
         s.buttons  |= SCE_PAD_BUTTON_CROSS;
     }
-    // Information queries report script-driven connectivity, but they must not advance pN routes.
-    // Only calls that return an input state consume a pad-read anchor.
-    if (pad_script_runtime().configured()) s.connected = true;
-    if (consume_input_read) {
-        const int64_t frame = pad_frame_now();
-        const int64_t read = pad_read_now();
-        apply_pad_script(s, frame, read);
-        pad_record(frame, s.buttons);
-    }
+    // Preserve the established seconds/flip origins and recording behavior on every pad poll. A
+    // metadata query evaluates those axes with no read index, so only successful input-state calls
+    // can activate or advance pN routes.
+    const int64_t frame = pad_frame_now();
+    const int64_t read = consume_input_read ? pad_read_now() : -1;
+    apply_pad_script(s, frame, read);
+    pad_record(frame, s.buttons);
     padlog_once(what, &s);
     return s;
 }

--- a/prosper/src/hle/hle_pad.cpp
+++ b/prosper/src/hle/hle_pad.cpp
@@ -65,10 +65,11 @@ uint64_t now_us() {
 
 // --- PROSPER_PAD_SCRIPT: hardware-free timed button sequence -------------------------------------
 // Drives a scripted controller so a headless run can navigate menus and gameplay with no host device.
-// Format: a ';'-separated list of "<seconds>:<action>[+..]" entries; actions are buttons or full-stick
+// Format: a ';'-separated list of "<anchor>:<action>[+..]" entries; actions are buttons or full-stick
 // directions such as "left-stick-left". Prefix with '@' to load a route
-// file; files may use newlines, comments, and explicit ranges such as "f300-340:cross". Time points
-// use PROSPER_PAD_HOLD ms (default 300); flip points use PROSPER_PAD_FRAME_HOLD (default 8). When a
+// file; files may use newlines, comments, and explicit ranges such as "f300-340:cross" and
+// "p1200-1240:cross". Time points use PROSPER_PAD_HOLD ms (default 300); flip points use
+// PROSPER_PAD_FRAME_HOLD (default 8); pad-read points use PROSPER_PAD_READ_HOLD (default 8). When a
 // script is set the pad reports
 // CONNECTED for the whole run (a menu that gates on a controller sees one).
 //
@@ -78,6 +79,7 @@ uint64_t now_us() {
 // The parse + time-eval live in pad.cpp (pure, unit-tested); this file supplies getenv + the clock.
 double pad_hold_secs();
 int64_t pad_frame_hold();
+int64_t pad_read_hold();
 
 struct PadScriptFileStamp {
     std::filesystem::file_time_type write_time{};
@@ -106,7 +108,7 @@ std::optional<PadScriptFileStamp> pad_script_file_stamp(const std::filesystem::p
 }
 
 // Long exploratory boots can discover a new prompt minutes into a route. Opt-in @file reload keeps
-// the original time/flip anchors while allowing future windows to be appended without rebooting.
+// the original time/flip/read anchors while allowing future windows to be appended without rebooting.
 // A changed stamp must remain stable across two 250 ms polls, and a replacement is published only
 // after a complete read whose metadata is still unchanged. Pad readers serialize here, so no thread
 // can observe a vector while another replaces it.
@@ -133,10 +135,11 @@ public:
 
     bool configured() const { return !source_.empty(); }
 
-    PadScriptState state_at(double elapsed, int64_t frame) {
+    PadScriptState state_at(double elapsed, int64_t frame, int64_t read) {
         std::lock_guard<std::mutex> lock(mutex_);
         refresh_locked();
-        return pad_script_state_at(script_, elapsed, pad_hold_secs(), frame, pad_frame_hold());
+        return pad_script_state_at(script_, elapsed, pad_hold_secs(), frame, pad_frame_hold(),
+                                   read, pad_read_hold());
     }
 
 private:
@@ -239,8 +242,26 @@ int64_t pad_frame_now() {
     return flips >= base ? (int64_t)(flips - base) : 0;
 }
 
+// Pad-read anchor: each controller snapshot is one read, numbered from zero at the first poll. This
+// advances even when presentation is paused by synchronous rendering.
+std::atomic<uint64_t> g_pad_read_count{0};
+
+int64_t pad_read_hold() {
+    static const int64_t h = [] {
+        const char* e = getenv("PROSPER_PAD_READ_HOLD");
+        return e ? (int64_t)atoll(e) : 8;
+    }();
+    return h;
+}
+
+int64_t pad_read_now() {
+    const uint64_t read = g_pad_read_count.fetch_add(1, std::memory_order_relaxed);
+    const uint64_t max = static_cast<uint64_t>(std::numeric_limits<int64_t>::max());
+    return read <= max ? static_cast<int64_t>(read) : std::numeric_limits<int64_t>::max();
+}
+
 // Overlay any active scripted press onto `s`. Returns true if a script is driving the pad.
-bool apply_pad_script(HostPadState& s, int64_t frame) {
+bool apply_pad_script(HostPadState& s, int64_t frame, int64_t read) {
     auto& script = pad_script_runtime();
     if (!script.configured()) return false;
     s.connected = true;                                     // a controller is present for the whole run
@@ -250,7 +271,7 @@ bool apply_pad_script(HostPadState& s, int64_t frame) {
         if (g_pad_t0_us.compare_exchange_strong(expect, now)) t0 = now; else t0 = expect;
     }
     double elapsed = (now_us() - t0) / 1e6;
-    const PadScriptState scripted = script.state_at(elapsed, frame);
+    const PadScriptState scripted = script.state_at(elapsed, frame, read);
     if (pad_script_log()) {
         const auto encoded_direction = [](int8_t value) { return uint64_t(uint8_t(value + 1)); };
         const uint64_t signature = uint64_t(scripted.button_mask) |
@@ -271,8 +292,8 @@ bool apply_pad_script(HostPadState& s, int64_t frame) {
                 append_axis(scripted.right_x < 0 ? "right-stick-left" : scripted.right_x > 0 ? "right-stick-right" : "right-stick-x-center");
             if (scripted.axis_mask & PAD_SCRIPT_RIGHT_Y)
                 append_axis(scripted.right_y < 0 ? "right-stick-up" : scripted.right_y > 0 ? "right-stick-down" : "right-stick-y-center");
-            fprintf(stderr, "[pad-script] elapsed=%.3f frame=%lld buttons=%s%s%s\n", elapsed,
-                    (long long)frame, buttons.empty() ? "neutral" : buttons.c_str(),
+            fprintf(stderr, "[pad-script] elapsed=%.3f frame=%lld read=%lld buttons=%s%s%s\n", elapsed,
+                    (long long)frame, (long long)read, buttons.empty() ? "neutral" : buttons.c_str(),
                     axes.empty() ? "" : " axes=", axes.c_str());
         }
     }
@@ -338,7 +359,8 @@ HostPadState snapshot(int /*handle*/, const char* what) {
         s.buttons  |= SCE_PAD_BUTTON_CROSS;
     }
     const int64_t frame = pad_frame_now();
-    apply_pad_script(s, frame);
+    const int64_t read = pad_read_now();
+    apply_pad_script(s, frame, read);
     pad_record(frame, s.buttons);
     padlog_once(what, &s);
     return s;

--- a/prosper/src/input/pad.cpp
+++ b/prosper/src/input/pad.cpp
@@ -178,19 +178,30 @@ std::vector<PadScriptEntry> parse_pad_script(const std::string& spec) {
             out = value;
             return true;
         };
+        auto parse_count = [](const std::string& text, double& out) {
+            // Validate the decimal spelling before converting to double. Near 2^53, strtod can
+            // otherwise round a fractional token to an integer and make it look like a valid count.
+            constexpr uint64_t kMaxExactInteger = 9007199254740991ULL;  // 2^53 - 1
+            if (text.empty()) return false;
+            uint64_t value = 0;
+            for (const char ch : text) {
+                if (ch < '0' || ch > '9') return false;
+                const uint64_t digit = static_cast<uint64_t>(ch - '0');
+                if (value > (kMaxExactInteger - digit) / 10) return false;
+                value = value * 10 + digit;
+            }
+            out = static_cast<double>(value);
+            return true;
+        };
+        const bool count_anchored = frame_anchored || read_anchored;
+        const auto parse_anchor = [&](const std::string& text, double& out) {
+            return count_anchored ? parse_count(text, out) : parse_number(text, out);
+        };
         double start = 0.0, end = 0.0;
-        if (!parse_number(trim(window.substr(0, dash)), start)) continue;
+        if (!parse_anchor(trim(window.substr(0, dash)), start)) continue;
         if (dash != std::string::npos) {
-            if (!parse_number(trim(window.substr(dash + 1)), end) || end <= start) continue;
+            if (!parse_anchor(trim(window.substr(dash + 1)), end) || end <= start) continue;
         }
-        // Count anchors are integers. Keep them exactly representable in the double-backed entry so
-        // evaluation cannot silently round or overflow while converting to int64_t.
-        constexpr double kMaxExactInteger = 9007199254740991.0;  // 2^53 - 1
-        if ((frame_anchored || read_anchored) &&
-            (start != std::floor(start) || start > kMaxExactInteger ||
-             (dash != std::string::npos &&
-              (end != std::floor(end) || end > kMaxExactInteger))))
-            continue;
         std::string btns = tok.substr(colon + 1);
         uint32_t mask = 0;
         uint8_t axis_mask = 0;

--- a/prosper/src/input/pad.cpp
+++ b/prosper/src/input/pad.cpp
@@ -9,6 +9,7 @@
 #include <atomic>
 #include <cmath>
 #include <fstream>
+#include <limits>
 #include <sstream>
 
 namespace prosper::input {
@@ -165,9 +166,10 @@ std::vector<PadScriptEntry> parse_pad_script(const std::string& spec) {
         size_t colon = tok.find(':');
         if (colon == std::string::npos) continue;
         std::string head = trim(tok.substr(0, colon));
-        // A leading 'f' marks a FRAME-anchored entry ("f300:cross" -> flip 300); else it's seconds.
+        // Leading 'f' and 'p' select flips and pad reads since the first poll; else it's seconds.
         bool frame_anchored = (!head.empty() && (head[0] == 'f' || head[0] == 'F'));
-        std::string window = frame_anchored ? head.substr(1) : head;
+        bool read_anchored = (!head.empty() && (head[0] == 'p' || head[0] == 'P'));
+        std::string window = (frame_anchored || read_anchored) ? head.substr(1) : head;
         size_t dash = window.find('-', 1);
         auto parse_number = [](const std::string& text, double& out) {
             char* end = nullptr;
@@ -181,6 +183,14 @@ std::vector<PadScriptEntry> parse_pad_script(const std::string& spec) {
         if (dash != std::string::npos) {
             if (!parse_number(trim(window.substr(dash + 1)), end) || end <= start) continue;
         }
+        // Count anchors are integers. Keep them exactly representable in the double-backed entry so
+        // evaluation cannot silently round or overflow while converting to int64_t.
+        constexpr double kMaxExactInteger = 9007199254740991.0;  // 2^53 - 1
+        if ((frame_anchored || read_anchored) &&
+            (start != std::floor(start) || start > kMaxExactInteger ||
+             (dash != std::string::npos &&
+              (end != std::floor(end) || end > kMaxExactInteger))))
+            continue;
         std::string btns = tok.substr(colon + 1);
         uint32_t mask = 0;
         uint8_t axis_mask = 0;
@@ -202,7 +212,7 @@ std::vector<PadScriptEntry> parse_pad_script(const std::string& spec) {
         }
         auto direction = [](int value) -> int8_t { return value < 0 ? -1 : value > 0 ? 1 : 0; };
         if (mask || axis_mask) {
-            PadScriptEntry entry{start, mask, frame_anchored, end};
+            PadScriptEntry entry{start, mask, frame_anchored, read_anchored, end};
             entry.left_x = direction(left_x); entry.left_y = direction(left_y);
             entry.right_x = direction(right_x); entry.right_y = direction(right_y);
             entry.axis_mask = axis_mask;
@@ -231,15 +241,29 @@ std::vector<PadScriptEntry> load_pad_script(const std::string& source, std::stri
 }
 
 PadScriptState pad_script_state_at(const std::vector<PadScriptEntry>& script, double elapsed_secs,
-                                   double hold_secs, int64_t frame_count, int64_t frame_hold) {
+                                   double hold_secs, int64_t frame_count, int64_t frame_hold,
+                                   int64_t read_count, int64_t read_hold) {
     PadScriptState state;
     int left_x = 0, left_y = 0, right_x = 0, right_y = 0;
+    const auto count_active = [](const PadScriptEntry& entry, int64_t count, int64_t hold) {
+        if (count < 0 || hold <= 0) return false;
+        const int64_t start = static_cast<int64_t>(entry.t_secs);
+        int64_t end = 0;
+        if (entry.end > entry.t_secs) {
+            end = static_cast<int64_t>(entry.end);
+        } else if (start > std::numeric_limits<int64_t>::max() - hold) {
+            end = std::numeric_limits<int64_t>::max();
+        } else {
+            end = start + hold;
+        }
+        return count >= start && count < end;
+    };
     for (const auto& e : script) {
         bool active = false;
-        if (e.frame_anchored) {
-            int64_t f = (int64_t)e.t_secs;   // frame number lives in t_secs for frame-anchored entries
-            int64_t end = e.end > e.t_secs ? (int64_t)e.end : f + frame_hold;
-            active = frame_count >= 0 && frame_count >= f && frame_count < end;
+        if (e.read_anchored) {
+            active = count_active(e, read_count, read_hold);
+        } else if (e.frame_anchored) {
+            active = count_active(e, frame_count, frame_hold);
         } else {
             double end = e.end > e.t_secs ? e.end : e.t_secs + hold_secs;
             active = elapsed_secs >= e.t_secs && elapsed_secs < end;
@@ -268,8 +292,10 @@ void pad_apply_script_state(HostPadState& target, const PadScriptState& scripted
 }
 
 uint32_t pad_script_buttons_at(const std::vector<PadScriptEntry>& script, double elapsed_secs, double hold_secs,
-                               int64_t frame_count, int64_t frame_hold) {
-    return pad_script_state_at(script, elapsed_secs, hold_secs, frame_count, frame_hold).button_mask;
+                               int64_t frame_count, int64_t frame_hold,
+                               int64_t read_count, int64_t read_hold) {
+    return pad_script_state_at(script, elapsed_secs, hold_secs, frame_count, frame_hold,
+                               read_count, read_hold).button_mask;
 }
 
 } // namespace prosper::input

--- a/prosper/src/input/pad.hpp
+++ b/prosper/src/input/pad.hpp
@@ -139,7 +139,7 @@ uint32_t pad_trigger_buttons(uint8_t l2, uint8_t r2);
 // ---- Scripted input (PROSPER_PAD_SCRIPT) — pure, unit-tested -----------------------------------
 // A timed controller sequence lets a headless run drive menus and gameplay with no host device
 // (issue #163). These helpers are pure (no env, no clock) so parse + time evaluation is verifiable; the HLE
-// (hle_pad.cpp) supplies getenv + the wall clock and anchors t=0 to the first successful state read.
+// (hle_pad.cpp) supplies getenv + the wall clock and anchors t=0 to the first pad poll.
 // t_secs holds wall-clock seconds by default, a flip number when frame_anchored, or a pad-read number
 // when read_anchored. `p300:cross` is independent of wall time and presentation rate, which keeps a
 // route usable when synchronous rendering changes both. See #302.
@@ -182,7 +182,7 @@ std::string pad_button_names(uint32_t mask);
 
 // Parse ';'- or newline-separated entries. Actions are '+'-joined button names and/or full-stick
 // directions such as "left-stick-left" and "right-stick-up". A time token starting with 'f' is
-// frame-anchored (flips since the first state read); one starting with 'p' is pad-read-anchored
+// frame-anchored (flips since the first pad poll); one starting with 'p' is pad-read-anchored
 // (successful scePadRead/scePadReadState calls, numbered from zero). All anchors accept explicit ranges
 // ("3-4.5:cross", "f300-340:cross",
 // "p1200-1240:cross"); '#' starts a comment. Malformed entries and entries with no recognized action

--- a/prosper/src/input/pad.hpp
+++ b/prosper/src/input/pad.hpp
@@ -139,7 +139,7 @@ uint32_t pad_trigger_buttons(uint8_t l2, uint8_t r2);
 // ---- Scripted input (PROSPER_PAD_SCRIPT) — pure, unit-tested -----------------------------------
 // A timed controller sequence lets a headless run drive menus and gameplay with no host device
 // (issue #163). These helpers are pure (no env, no clock) so parse + time evaluation is verifiable; the HLE
-// (hle_pad.cpp) supplies getenv + the wall clock and anchors t=0 to the first input poll.
+// (hle_pad.cpp) supplies getenv + the wall clock and anchors t=0 to the first successful state read.
 // t_secs holds wall-clock seconds by default, a flip number when frame_anchored, or a pad-read number
 // when read_anchored. `p300:cross` is independent of wall time and presentation rate, which keeps a
 // route usable when synchronous rendering changes both. See #302.
@@ -182,8 +182,9 @@ std::string pad_button_names(uint32_t mask);
 
 // Parse ';'- or newline-separated entries. Actions are '+'-joined button names and/or full-stick
 // directions such as "left-stick-left" and "right-stick-up". A time token starting with 'f' is
-// frame-anchored (flips since the first poll); one starting with 'p' is pad-read-anchored (snapshots
-// since the first poll). All anchors accept explicit ranges ("3-4.5:cross", "f300-340:cross",
+// frame-anchored (flips since the first state read); one starting with 'p' is pad-read-anchored
+// (successful scePadRead/scePadReadState calls, numbered from zero). All anchors accept explicit ranges
+// ("3-4.5:cross", "f300-340:cross",
 // "p1200-1240:cross"); '#' starts a comment. Malformed entries and entries with no recognized action
 // are dropped.
 std::vector<PadScriptEntry> parse_pad_script(const std::string& spec);

--- a/prosper/src/input/pad.hpp
+++ b/prosper/src/input/pad.hpp
@@ -140,14 +140,14 @@ uint32_t pad_trigger_buttons(uint8_t l2, uint8_t r2);
 // A timed controller sequence lets a headless run drive menus and gameplay with no host device
 // (issue #163). These helpers are pure (no env, no clock) so parse + time evaluation is verifiable; the HLE
 // (hle_pad.cpp) supplies getenv + the wall clock and anchors t=0 to the first input poll.
-// t_secs holds a wall-clock time (default) OR, when frame_anchored, a FRAME NUMBER (flips since the
-// first poll). Frame-anchoring is boot-speed-invariant: `f300:cross` fires at the same game state on a
-// fast GPU and slow llvmpipe, where a wall-clock `10:cross` would drift — essential for deterministic
-// menu-reach across builds (bisect/regression repro). See #302.
+// t_secs holds wall-clock seconds by default, a flip number when frame_anchored, or a pad-read number
+// when read_anchored. `p300:cross` is independent of wall time and presentation rate, which keeps a
+// route usable when synchronous rendering changes both. See #302.
 struct PadScriptEntry {
     double t_secs;
     uint32_t button_mask;
     bool frame_anchored = false;
+    bool read_anchored = false;
     double end = 0.0;  // exclusive explicit range end; 0 uses the configured default hold
     int8_t left_x = 0;   // -1=left, 0=neutral/unspecified, +1=right
     int8_t left_y = 0;   // -1=up,   0=neutral/unspecified, +1=down
@@ -181,10 +181,11 @@ uint32_t pad_button_by_name(const std::string& name);
 std::string pad_button_names(uint32_t mask);
 
 // Parse ';'- or newline-separated entries. Actions are '+'-joined button names and/or full-stick
-// directions such as "left-stick-left" and "right-stick-up". An entry whose time token starts with 'f' is
-// FRAME-anchored: "f300:cross" fires at flip 300 since the first poll. Both anchors accept explicit
-// ranges ("3-4.5:cross", "f300-340:cross"); '#' starts a comment. Malformed entries and entries with
-// no recognized action are dropped.
+// directions such as "left-stick-left" and "right-stick-up". A time token starting with 'f' is
+// frame-anchored (flips since the first poll); one starting with 'p' is pad-read-anchored (snapshots
+// since the first poll). All anchors accept explicit ranges ("3-4.5:cross", "f300-340:cross",
+// "p1200-1240:cross"); '#' starts a comment. Malformed entries and entries with no recognized action
+// are dropped.
 std::vector<PadScriptEntry> parse_pad_script(const std::string& spec);
 
 // Parse an inline script, or load and parse one from disk when `source` starts with '@'. Relative
@@ -194,7 +195,8 @@ std::vector<PadScriptEntry> load_pad_script(const std::string& source, std::stri
 // Full scripted controller state now. Active entries combine buttons and full-deflection stick
 // directions; opposing directions on one axis cancel to an explicitly centered axis.
 PadScriptState pad_script_state_at(const std::vector<PadScriptEntry>& script, double elapsed_secs,
-                                   double hold_secs, int64_t frame_count = -1, int64_t frame_hold = 8);
+                                   double hold_secs, int64_t frame_count = -1, int64_t frame_hold = 8,
+                                   int64_t read_count = -1, int64_t read_hold = 8);
 
 // Overlay a scripted state onto a host snapshot. Buttons combine with the backend; only explicitly
 // active script axes replace their host values.
@@ -202,10 +204,12 @@ void pad_apply_script_state(HostPadState& target, const PadScriptState& scripted
 
 // Buttons held now: OR of every entry whose window contains the current time. A seconds-anchored entry
 // matches [t, t+hold_secs) against `elapsed_secs`; a frame-anchored entry matches [f, f+frame_hold)
-// against `frame_count` (pass -1 when no frame count is available -> frame entries never fire).
-// An explicit range uses its exclusive `end`; point entries use hold_secs/frame_hold.
+// against `frame_count`; a read-anchored entry matches [p, p+read_hold) against `read_count`.
+// Pass -1 when a count is unavailable so entries on that axis never fire. An explicit range uses its
+// exclusive `end`; point entries use the configured hold for their axis.
 uint32_t pad_script_buttons_at(const std::vector<PadScriptEntry>& script, double elapsed_secs, double hold_secs,
-                               int64_t frame_count = -1, int64_t frame_hold = 8);
+                               int64_t frame_count = -1, int64_t frame_hold = 8,
+                               int64_t read_count = -1, int64_t read_hold = 8);
 
 // ---- Pluggable host backend (mirrors AudioSink / audio_set_sink) -------------------------------
 //

--- a/prosper/tests/test_pad.cpp
+++ b/prosper/tests/test_pad.cpp
@@ -215,7 +215,40 @@ int main() {
         CHECK(pad_script_buttons_at(fs, 5.1, hold, /*no frame info*/-1, fhold) == SCE_PAD_BUTTON_OPTIONS,
               "frame: seconds entry still fires with frame_count=-1; frame entry does not");
 
-        // File syntax: newlines/comments, explicit time/frame ranges, and @path loading.
+        // Pad-read anchors (#302): "p<N>:" fires on controller snapshot N, independent of time/flips.
+        auto reads = parse_pad_script("p100:cross;P120-125:options;7:circle;f40:square");
+        CHECK(reads.size() == 4, "read: seconds/frame/read entries parse together");
+        CHECK(reads[0].read_anchored && !reads[0].frame_anchored &&
+              reads[0].t_secs == 100.0 && reads[0].button_mask == SCE_PAD_BUTTON_CROSS,
+              "read: 'p100:cross' parses pad-read-anchored at 100");
+        CHECK(reads[1].read_anchored && reads[1].t_secs == 120.0 && reads[1].end == 125.0,
+              "read: explicit range preserves its exclusive end");
+        const int64_t rhold = 4;
+        CHECK(pad_script_buttons_at(reads, 999.0, hold, 999, fhold, 99, rhold) == 0,
+              "read: before point window -> none despite unrelated time/frame values");
+        CHECK(pad_script_buttons_at(reads, 999.0, hold, 999, fhold, 100, rhold) ==
+                  SCE_PAD_BUTTON_CROSS,
+              "read: point starts at the requested pad read");
+        CHECK(pad_script_buttons_at(reads, 999.0, hold, 999, fhold, 103, rhold) ==
+                  SCE_PAD_BUTTON_CROSS,
+              "read: point uses the configured default read hold");
+        CHECK(pad_script_buttons_at(reads, 999.0, hold, 999, fhold, 104, rhold) == 0,
+              "read: point ends exclusively");
+        CHECK(pad_script_buttons_at(reads, 0.0, hold, 0, fhold, 124, rhold) ==
+                  SCE_PAD_BUTTON_OPTIONS,
+              "read: explicit range is active before its end");
+        CHECK(pad_script_buttons_at(reads, 0.0, hold, 0, fhold, 125, rhold) == 0,
+              "read: explicit range ends exclusively");
+        CHECK(pad_script_buttons_at(reads, 7.1, hold, -1, fhold, -1, rhold) ==
+                  SCE_PAD_BUTTON_CIRCLE,
+              "read: unavailable count suppresses read entries without affecting seconds entries");
+        auto invalid_counts = parse_pad_script(
+            "p1.5:cross;p9007199254740992:cross;f2.5:cross;p5:circle");
+        CHECK(invalid_counts.size() == 1 && invalid_counts[0].read_anchored &&
+              invalid_counts[0].t_secs == 5.0,
+              "read: fractional or inexact count anchors are rejected");
+
+        // File syntax: newlines/comments, explicit time/frame/read ranges, and @path loading.
         auto ranges = parse_pad_script("# checkpoint\n f10-20:cross # hold\n3-4.5:up+cross\n");
         CHECK(ranges.size() == 2, "route: comments/newlines parse two entries");
         CHECK(ranges[0].frame_anchored && ranges[0].t_secs == 10.0 && ranges[0].end == 20.0,
@@ -232,11 +265,12 @@ int main() {
         const auto unique = std::chrono::steady_clock::now().time_since_epoch().count();
         const auto route_path = std::filesystem::temp_directory_path() /
                                 ("prosper_test_pad_route_" + std::to_string(unique) + ".pad");
-        { std::ofstream route(route_path); route << "# loaded route\nf7-12:options\n"; }
+        { std::ofstream route(route_path); route << "# loaded route\nf7-12:options\np20-24:cross\n"; }
         std::string route_error;
         auto loaded = load_pad_script("@" + route_path.string(), &route_error);
-        CHECK(route_error.empty() && loaded.size() == 1 && loaded[0].frame_anchored && loaded[0].end == 12.0,
-              "route: @path loads and parses a file");
+        CHECK(route_error.empty() && loaded.size() == 2 && loaded[0].frame_anchored &&
+              loaded[0].end == 12.0 && loaded[1].read_anchored && loaded[1].end == 24.0,
+              "route: @path loads and parses flip/read entries");
         std::filesystem::remove(route_path);
         auto missing = load_pad_script("@/this/prosper/route/does/not/exist.pad", &route_error);
         CHECK(missing.empty() && !route_error.empty(), "route: missing @path reports an error");

--- a/prosper/tests/test_pad.cpp
+++ b/prosper/tests/test_pad.cpp
@@ -14,6 +14,7 @@
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
+#include <thread>
 
 using namespace prosper;
 using namespace prosper::input;
@@ -115,7 +116,7 @@ int main() {
     {
         // Explicit one-read windows make counter movement visible. Metadata queries below must not
         // consume either window; the first two successful input reads must see p0 and p1 in order.
-        set_test_env("PROSPER_PAD_SCRIPT", "p0-1:cross;p1-2:options");
+        set_test_env("PROSPER_PAD_SCRIPT", "0-0.05:triangle;p0-1:cross;p1-2:options");
         register_builtin_hle();
         HleFn read_state = Hle::lookup(nid_hash("scePadReadState"));
         HleFn read       = Hle::lookup(nid_hash("scePadRead"));
@@ -131,6 +132,10 @@ int main() {
                   "scePadGetControllerInformation -> 0 (OK)");
             CHECK(ci.connected == 1, "info query sees script-driven controller connectivity");
         }
+
+        // The legacy seconds origin is the first pad poll, including an information query. If the
+        // origin moved to the first state read, the short Triangle window would incorrectly fire below.
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
         if (read) {
             ScePadData unused{};
@@ -149,7 +154,7 @@ int main() {
             CHECK(d.left_stick_x == 0x80, "readstate: sticks centered");
             CHECK(d.orientation_w == 1.0f, "readstate: identity orientation");
             CHECK(d.buttons == SCE_PAD_BUTTON_CROSS,
-                  "readstate: metadata query did not consume p0 input window");
+                  "readstate: metadata preserves seconds origin without consuming p0 input window");
         }
 
         if (read) {

--- a/prosper/tests/test_pad.cpp
+++ b/prosper/tests/test_pad.cpp
@@ -11,6 +11,7 @@
 #include <cstring>
 #include <cstddef>
 #include <chrono>
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 
@@ -20,6 +21,14 @@ using namespace prosper::input;
 static int fails = 0;
 #define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
                          else       { printf("  [ok]   %s\n", m); } } while (0)
+
+static void set_test_env(const char* name, const char* value) {
+#ifdef _WIN32
+    _putenv_s(name, value);
+#else
+    setenv(name, value, 1);
+#endif
+}
 
 int main() {
     printf("== test_pad ==\n");
@@ -101,9 +110,12 @@ int main() {
         CHECK(ci.stick_dead_zone_left == ci.stick_dead_zone_right, "info: symmetric dead zone");
     }
 
-    // (6) HLE registration + full-struct fill (no PROSPER_PAD -> neutral input, but ONE controller is
-    // connected by default: the built-in NeutralPadBackend now presents a connected pad for dev/testing).
+    // (6) HLE registration + full-struct fill. The built-in NeutralPadBackend presents one connected
+    // controller for development/testing; the short route also verifies input-read counter ownership.
     {
+        // Explicit one-read windows make counter movement visible. Metadata queries below must not
+        // consume either window; the first two successful input reads must see p0 and p1 in order.
+        set_test_env("PROSPER_PAD_SCRIPT", "p0-1:cross;p1-2:options");
         register_builtin_hle();
         HleFn read_state = Hle::lookup(nid_hash("scePadReadState"));
         HleFn read       = Hle::lookup(nid_hash("scePadRead"));
@@ -112,6 +124,20 @@ int main() {
         CHECK(read_state && read && get_info && open, "pad HLE functions registered");
 
         if (open) CHECK(open(1, 0, 0, 0, 0, 0) >= 1, "scePadOpen -> positive handle");
+
+        if (get_info) {
+            ScePadControllerInformation ci{};
+            CHECK(get_info(1, (uint64_t)(uintptr_t)&ci, 0, 0, 0, 0) == 0,
+                  "scePadGetControllerInformation -> 0 (OK)");
+            CHECK(ci.connected == 1, "info query sees script-driven controller connectivity");
+        }
+
+        if (read) {
+            ScePadData unused{};
+            CHECK(read(1, 0, 1, 0, 0, 0) == 0 &&
+                  read(1, (uint64_t)(uintptr_t)&unused, 0, 0, 0, 0) == 0,
+                  "failed scePadRead calls do not consume input windows");
+        }
 
         if (read_state) {
             ScePadData d;
@@ -122,13 +148,22 @@ int main() {
             CHECK(d.connected == 1, "readstate: one controller connected by default (dev/testing default)");
             CHECK(d.left_stick_x == 0x80, "readstate: sticks centered");
             CHECK(d.orientation_w == 1.0f, "readstate: identity orientation");
+            CHECK(d.buttons == SCE_PAD_BUTTON_CROSS,
+                  "readstate: metadata query did not consume p0 input window");
         }
 
         if (read) {
+            if (get_info) {
+                ScePadControllerInformation ci{};
+                get_info(1, (uint64_t)(uintptr_t)&ci, 0, 0, 0, 0);
+            }
             ScePadData d;
             uint64_t n = read(1, (uint64_t)(uintptr_t)&d, 4 /*num*/, 0, 0, 0);
             CHECK(n == 1, "scePadRead -> 1 state");
+            CHECK(d.buttons == SCE_PAD_BUTTON_OPTIONS,
+                  "scePadRead: intervening metadata query did not consume p1 input window");
         }
+        set_test_env("PROSPER_PAD_SCRIPT", "");
     }
 
     // (7) PROSPER_PAD_SCRIPT pure helpers — parse + time-eval (drives menus headless, issue #163).
@@ -215,7 +250,7 @@ int main() {
         CHECK(pad_script_buttons_at(fs, 5.1, hold, /*no frame info*/-1, fhold) == SCE_PAD_BUTTON_OPTIONS,
               "frame: seconds entry still fires with frame_count=-1; frame entry does not");
 
-        // Pad-read anchors (#302): "p<N>:" fires on controller snapshot N, independent of time/flips.
+        // Pad-read anchors (#302): "p<N>:" fires on successful state read N, independent of time/flips.
         auto reads = parse_pad_script("p100:cross;P120-125:options;7:circle;f40:square");
         CHECK(reads.size() == 4, "read: seconds/frame/read entries parse together");
         CHECK(reads[0].read_anchored && !reads[0].frame_anchored &&
@@ -243,10 +278,11 @@ int main() {
                   SCE_PAD_BUTTON_CIRCLE,
               "read: unavailable count suppresses read entries without affecting seconds entries");
         auto invalid_counts = parse_pad_script(
-            "p1.5:cross;p9007199254740992:cross;f2.5:cross;p5:circle");
+            "p1.5:cross;p9007199254740992:cross;f2.5:cross;"
+            "p9007199254740990.5:cross;p1-9007199254740990.5:cross;p5:circle");
         CHECK(invalid_counts.size() == 1 && invalid_counts[0].read_anchored &&
               invalid_counts[0].t_secs == 5.0,
-              "read: fractional or inexact count anchors are rejected");
+              "read: fractional or inexact count anchors are rejected before conversion");
 
         // File syntax: newlines/comments, explicit time/frame/read ranges, and @path loading.
         auto ranges = parse_pad_script("# checkpoint\n f10-20:cross # hold\n3-4.5:up+cross\n");

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -49,7 +49,8 @@ programmatic check (ctest exit code, `spirv-val`, a snapshot hash) over eyeballi
 
 To drive any runner through a longer input route, set
 `PROSPER_PAD_SCRIPT=@scripts/<title>/reach-<state>.pad`. Route files use the same
-seconds/flip syntax as inline scripts, accept one entry per line, `#` comments,
+seconds/flip/pad-read syntax as inline scripts (`3:`, `f300:`, or `p1200:`), accept one entry per
+line, `#` comments,
 and explicit ranges such as `f300-340:cross`. Full-deflection stick actions use names such as
 `left-stick-left` and can be combined with buttons using `+`. See `docs/INPUT_REPLAY.md`.
 Set `PROSPER_PAD_RECORD=<path>` on any runner, or use `prosper-app --record <path>`, to capture the
@@ -57,10 +58,12 @@ final button stream in that format. Completed button intervals are flushed immed
 directions are supported for playback but are not yet emitted by the recorder.
 Set `PROSPER_PAD_SCRIPT_LOG=1` to log each scripted state transition observed at a pad poll.
 For long exploratory runs, add `PROSPER_PAD_SCRIPT_RELOAD=1` to live-reload an `@file` route while
-preserving its original time/flip origin; append only future windows and confirm the reload log.
+preserving its original time/flip/read origin; append only future windows and confirm the reload log.
 Wall-clock ranges can be skipped entirely when their duration is shorter than the interval between
-polls, especially under synchronous software rendering; use poll-safe holds with neutral gaps or
-flip-anchored ranges for reproducible routes.
+polls, especially under synchronous software rendering; use poll-safe holds with neutral gaps,
+flip-anchored ranges while presentation advances, or `pA-B:` ranges keyed to the pad-read index printed
+by `PROSPER_PAD_SCRIPT_LOG=1`. Point entries use `PROSPER_PAD_FRAME_HOLD` or
+`PROSPER_PAD_READ_HOLD` (both default 8) on their count axis.
 
 Capture one draw-carrying renderer invocation with:
 

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -65,7 +65,8 @@ flip-anchored ranges while presentation advances, or `pA-B:` ranges keyed to the
 by `PROSPER_PAD_SCRIPT_LOG=1`. Point entries use `PROSPER_PAD_FRAME_HOLD` or
 `PROSPER_PAD_READ_HOLD` (both default 8) on their count axis.
 Pad-read indices advance only for successful `scePadRead`/`scePadReadState` calls; controller metadata
-queries and rejected reads do not consume route entries.
+queries and rejected reads do not consume pad-read entries. Seconds and flips keep their first-pad-poll
+origin for compatibility with existing routes.
 
 Capture one draw-carrying renderer invocation with:
 

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -64,6 +64,8 @@ polls, especially under synchronous software rendering; use poll-safe holds with
 flip-anchored ranges while presentation advances, or `pA-B:` ranges keyed to the pad-read index printed
 by `PROSPER_PAD_SCRIPT_LOG=1`. Point entries use `PROSPER_PAD_FRAME_HOLD` or
 `PROSPER_PAD_READ_HOLD` (both default 8) on their count axis.
+Pad-read indices advance only for successful `scePadRead`/`scePadReadState` calls; controller metadata
+queries and rejected reads do not consume route entries.
 
 Capture one draw-carrying renderer invocation with:
 


### PR DESCRIPTION
## Summary

- add pN and pA-B route anchors keyed to controller snapshots since the first pad poll
- keep seconds and display-flip route semantics unchanged
- add an independent default read hold, include the read index in transition logs, and preserve the read origin across live route reloads
- document the new axis for game-route calibration and cover point/range/file/error semantics

## Why

Wall-time presses can occur between pad polls during slow synchronous rendering, while display-flip anchors stop advancing when presentation is paused. A pad-read axis lets a route target the input stream the game actually observes.

## Validation

- Windows focused pad_input test: passed
- Linux focused pad_input test: passed
- Native Windows Messenger run with p0-3:options and p3-6:cross: logged Options at read 0, Cross at read 3, neutral at read 6, then exited after 10 presented frames
- No game/image snapshots were run

Full author-owned verification will be posted for the exact PR head.

Advances #302.