### PR TITLE
fix: round-trip guest thread names

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -270,6 +270,10 @@ if(TARGET prosper_core)
   target_link_libraries(test_pthread_sched_getters PRIVATE prosper_core)
   add_test(NAME pthread_sched_getters COMMAND test_pthread_sched_getters)
 
+  add_executable(test_pthread_names tests/test_pthread_names.cpp)
+  target_link_libraries(test_pthread_names PRIVATE prosper_core)
+  add_test(NAME pthread_names COMMAND test_pthread_names)
+
   # libScePad controller input: ScePadData layout + HostPadState mapping + HLE fill contract (pure).
   add_executable(test_pad tests/test_pad.cpp)
   target_link_libraries(test_pad PRIVATE prosper_core)

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -830,17 +830,6 @@ HLE(k_pthread_getname) {
     return 0;
 }
 
-HLE(k_pthread_getname_np) {
-    if (!a0) return 3;
-    if (!a1) return 14;
-    std::array<char, kGuestThreadNameSize> name{};
-    if (!get_guest_thread_name(a0, name)) return 3;
-    const size_t needed = strlen(name.data()) + 1;
-    if (a2 < needed) return 34;
-    memcpy((void*)(uintptr_t)a1, name.data(), needed);
-    return 0;
-}
-
 HLE(k_pthread_rename) {
     if (!a0) return 22;  // EINVAL
     if (!a1) return 0;   // Sony accepts a null name as a no-op
@@ -2912,6 +2901,9 @@ void register_kernel_hle() {
     R("scePthreadGetname", k_pthread_getname);
     R("scePthreadRename", k_pthread_rename);
     R("scePthreadSetName", k_pthread_rename);
+    R("pthread_getname_np", k_pthread_getname);
+    R("pthread_rename_np", k_pthread_rename);
+    R("pthread_set_name_np", k_pthread_rename);
     R("scePthreadGetstack", k_attr_getstackaddr);
     // TLS keys (POSIX + Sony names -> host pthread keys)
     R("pthread_key_create", k_key_create);   R("scePthreadKeyCreate", k_key_create);
@@ -2947,8 +2939,7 @@ void register_kernel_hle() {
     R("pthread_attr_setinheritsched", k_attr_noop);
     R("pthread_attr_setschedpolicy", k_attr_noop);  R("pthread_attr_setschedparam", k_attr_noop);
     R("pthread_attr_getstacksize", k_attr_getstacksize);
-    R("scePthreadAttrSetaffinity", k_attr_noop);
-    R("pthread_getname_np", k_pthread_getname_np); R("pthread_setname_np", k_pthread_rename);
+    R("scePthreadAttrSetaffinity", k_attr_noop); R("pthread_setname_np", k_attr_noop);
     // Plain libScePosix sem_* imports use the same guest object representation as scePthreadSem*.
     // Registering only the Sony-prefixed spellings left successful no-op imports in native engines.
     R("sem_init", k_sem_init);       R("sem_destroy", k_sem_destroy);

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -725,6 +725,130 @@ HLE(k_getprio)            { // scePthreadGetprio(thread, int* prio)
     return 0;
 }
 
+// Guest-visible names need their own registry: Linux truncates host names to 15 bytes, Darwin can
+// rename only the current host thread, and Windows uses thread descriptions. Generation tags keep
+// an exiting thread from erasing the name of a later thread that reuses the same pthread_t.
+namespace {
+constexpr size_t kGuestThreadNameSize = 32;
+struct GuestThreadName {
+    uint64_t generation = 0;
+    std::array<char, kGuestThreadNameSize> value{};
+};
+std::mutex g_guest_thread_name_mutex;
+std::unordered_map<uint64_t, GuestThreadName> g_guest_thread_names;
+std::atomic<uint64_t> g_guest_thread_name_generation{1};
+
+uint64_t next_guest_thread_name_generation() {
+    uint64_t generation = g_guest_thread_name_generation.fetch_add(1, std::memory_order_relaxed);
+    if (generation == 0)
+        generation = g_guest_thread_name_generation.fetch_add(1, std::memory_order_relaxed);
+    return generation;
+}
+
+std::array<char, kGuestThreadNameSize> bounded_guest_thread_name(const char* name) {
+    std::array<char, kGuestThreadNameSize> result{};
+    if (name) {
+        strncpy(result.data(), name, result.size() - 1);
+        result.back() = '\0';
+    }
+    return result;
+}
+
+bool publish_guest_thread_name(uint64_t thread, uint64_t generation, const char* name) noexcept {
+    std::lock_guard<std::mutex> lock(g_guest_thread_name_mutex);
+    try {
+        g_guest_thread_names[thread] = GuestThreadName{generation, bounded_guest_thread_name(name)};
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
+void retire_guest_thread_name(uint64_t thread, uint64_t generation) {
+    std::lock_guard<std::mutex> lock(g_guest_thread_name_mutex);
+    const auto it = g_guest_thread_names.find(thread);
+    if (it != g_guest_thread_names.end() && (!generation || it->second.generation == generation))
+        g_guest_thread_names.erase(it);
+}
+
+bool get_guest_thread_name(uint64_t thread, std::array<char, kGuestThreadNameSize>& name) {
+    std::lock_guard<std::mutex> lock(g_guest_thread_name_mutex);
+    const auto it = g_guest_thread_names.find(thread);
+    if (it != g_guest_thread_names.end()) {
+        name = it->second.value;
+        return true;
+    }
+    if (thread == (uint64_t)(uintptr_t)pthread_self()) {
+        name.fill('\0');
+        return true;
+    }
+    return false;
+}
+
+void set_host_thread_name(uint64_t thread, const char* name) {
+    char short_name[16]{};
+    if (name) strncpy(short_name, name, sizeof(short_name) - 1);
+#ifdef __APPLE__
+    if (thread == (uint64_t)(uintptr_t)pthread_self()) pthread_setname_np(short_name);
+#elif defined(__linux__)
+    pthread_setname_np((pthread_t)(uintptr_t)thread, short_name);
+#elif defined(_WIN32)
+    if (thread == (uint64_t)(uintptr_t)pthread_self()) {
+        wchar_t wide_name[kGuestThreadNameSize]{};
+        MultiByteToWideChar(CP_UTF8, 0, name ? name : "", -1, wide_name,
+                            static_cast<int>(kGuestThreadNameSize));
+        SetThreadDescription(GetCurrentThread(), wide_name);
+    }
+#endif
+}
+
+bool set_guest_thread_name(uint64_t thread, const char* name) {
+    std::lock_guard<std::mutex> lock(g_guest_thread_name_mutex);
+    auto it = g_guest_thread_names.find(thread);
+    if (it == g_guest_thread_names.end()) {
+        if (thread != (uint64_t)(uintptr_t)pthread_self()) return false;
+        try {
+            it = g_guest_thread_names.emplace(thread, GuestThreadName{}).first;
+        } catch (...) {
+            return false;
+        }
+    }
+    it->second.value = bounded_guest_thread_name(name);
+    // Serialize the host rename with registry retirement so a target cannot exit between the
+    // lifetime check above and pthread_setname_np receiving its host pthread_t.
+    set_host_thread_name(thread, name);
+    return true;
+}
+}
+
+HLE(k_pthread_getname) {
+    if (!a0) return 3;    // ESRCH
+    if (!a1) return 14;   // EFAULT
+    std::array<char, kGuestThreadNameSize> name{};
+    if (!get_guest_thread_name(a0, name)) return 3;
+    memcpy((void*)(uintptr_t)a1, name.data(), name.size());
+    return 0;
+}
+
+HLE(k_pthread_getname_np) {
+    if (!a0) return 3;
+    if (!a1) return 14;
+    std::array<char, kGuestThreadNameSize> name{};
+    if (!get_guest_thread_name(a0, name)) return 3;
+    const size_t needed = strlen(name.data()) + 1;
+    if (a2 < needed) return 34;
+    memcpy((void*)(uintptr_t)a1, name.data(), needed);
+    return 0;
+}
+
+HLE(k_pthread_rename) {
+    if (!a0) return 22;  // EINVAL
+    if (!a1) return 0;   // Sony accepts a null name as a no-op
+    const char* name = (const char*)(uintptr_t)a1;
+    if (!set_guest_thread_name(a0, name)) return 3;
+    return 0;
+}
+
 // --- thread creation: run the guest entry on a real host thread (ABI matches) ---
 // Worker stacks are GLIBC-OWNED (#138): create passes only a stacksize (honoring the guest attr),
 // so glibc allocates the stack and — crucially — RECLAIMS it when the thread is joined or a
@@ -742,13 +866,17 @@ struct ThreadStart {
     void* arg;
     void* guest_stack;
     size_t guest_stack_size;
-    char name[16];
+    char name[kGuestThreadNameSize];
+    uint64_t name_generation;
+    std::atomic<bool> name_published{false};
 };
 // Runs first on the new thread: register our own stack (keyed by our tid) BEFORE any guest code,
 // so an early GC_register_my_thread / stack-base query from this thread finds it. Closes a race
 // where a fast-starting worker ran before the parent's post-create registration → "Bad stack base".
 void* thread_trampoline(void* p) {
     auto* ts = (ThreadStart*)p;
+    while (!ts->name_published.load(std::memory_order_acquire)) std::this_thread::yield();
+    const uint64_t name_generation = ts->name_generation;
     void* registered_stack = ts->guest_stack;
     size_t registered_stack_size = ts->guest_stack_size;
     {
@@ -770,13 +898,19 @@ void* thread_trampoline(void* p) {
     // role names (GameThread, RenderThread, RHIThread, ...) instead of the binary name. Kernel
     // limit is 15 chars + NUL; host libc call, so it must run on the host %fs (we are).
 #ifdef __APPLE__
-    if (ts->name[0]) pthread_setname_np(ts->name);   // Darwin can only name the CURRENT thread (which this is)
+    if (ts->name[0]) {
+        char host_name[16]{}; strncpy(host_name, ts->name, sizeof(host_name) - 1);
+        pthread_setname_np(host_name);
+    }
 #else
-    if (ts->name[0]) pthread_setname_np(pthread_self(), ts->name);
+    if (ts->name[0]) {
+        char host_name[16]{}; strncpy(host_name, ts->name, sizeof(host_name) - 1);
+        pthread_setname_np(pthread_self(), host_name);
+    }
 #endif
     auto entry = ts->entry; void* arg = ts->arg;
     void* guest_stack = ts->guest_stack; size_t guest_stack_size = ts->guest_stack_size;
-    free(ts);   // all host libc — MUST run on the host %fs
+    delete ts;   // all host libc; MUST run on the host %fs
     // gated (PROSPER_GUEST_FS): give this guest worker its own guest TCB + static TLS and switch %fs to it
     // as the LAST host action before entering guest code (so guest initial-exec TLS — incl. libc.prx's
     // allocator arena/tcache — resolves to real guest storage, not the aliased host glibc TCB). The import
@@ -806,6 +940,7 @@ void* thread_trampoline(void* p) {
     (void)guest_fs_to_host_scoped();
     tls_dtv_purge_current_thread();
     unregister_thread_stack((uint64_t)pthread_self());   // ids recycle; stale bounds = wrong bounds (#138)
+    retire_guest_thread_name((uint64_t)(uintptr_t)pthread_self(), name_generation);
     return rv;
 }
 }
@@ -822,7 +957,9 @@ struct WinThreadStart {
     void* arg;
     void* guest_stack;
     size_t guest_stack_size;
-    char name[64];
+    char name[kGuestThreadNameSize];
+    uint64_t name_generation;
+    std::atomic<bool> name_published{false};
 };
 extern "C" uint64_t prosper_call_guest_sysv(uint64_t fn, uint64_t a0, uint64_t a1);
 extern "C" uint64_t prosper_call_guest_on_stack(uintptr_t stack_top, uint64_t fn,
@@ -869,10 +1006,12 @@ bool prepare_guest_windows_stack(ULONG_PTR* out_low, ULONG_PTR* out_high) {
 
 void* win_thread_trampoline(void* p) {
     auto* ts = (WinThreadStart*)p;
+    while (!ts->name_published.load(std::memory_order_acquire)) std::this_thread::yield();
+    const uint64_t name_generation = ts->name_generation;
     uint64_t entry = ts->entry; void* arg = ts->arg;
     void* guest_stack = ts->guest_stack; size_t guest_stack_size = ts->guest_stack_size;
     char name[sizeof(ts->name)]; memcpy(name, ts->name, sizeof(name));
-    free(ts);   // host libc: run on host %fs (before activate)
+    delete ts;   // host libc: run on host %fs (before activate)
     if (name[0]) {
         wchar_t wname[sizeof(name)]{};
         MultiByteToWideChar(CP_UTF8, 0, name, -1, wname, (int)(sizeof(wname) / sizeof(wname[0])));
@@ -917,6 +1056,7 @@ void* win_thread_trampoline(void* p) {
     unregister_thread_stack((uint64_t)GetCurrentThreadId());   // ids recycle; stale bounds = wrong bounds
     unregister_thread_stack(guest_thread);
     unregister_current_thread_handle(guest_thread);
+    retire_guest_thread_name(guest_thread, name_generation);
     return rv;
 }
 }
@@ -959,16 +1099,19 @@ HLE(k_pthread_create) {
     int attr_rc = pthread_attr_setstacksize(&la, supplied_stack ? kStackFloor : ssz);
     if (attr_rc) { pthread_attr_destroy(&la); return (uint64_t)(unsigned)attr_rc; }
     pthread_attr_setdetachstate(&la, detach);
-    auto* ts = (ThreadStart*)malloc(sizeof(ThreadStart));
+    auto* ts = new (std::nothrow) ThreadStart{};
     if (!ts) { pthread_attr_destroy(&la); return 12; }         // ENOMEM (FreeBSD and host agree)
     ts->entry = entry; ts->arg = arg;
     ts->guest_stack = supplied_stack; ts->guest_stack_size = supplied_stack_size;
+    ts->name_generation = next_guest_thread_name_generation();
     ts->name[0] = 0;
     if (a4) { strncpy(ts->name, (const char*)(uintptr_t)a4, sizeof(ts->name) - 1); ts->name[sizeof(ts->name) - 1] = 0; }
     int r = pthread_create(&tid, &la, thread_trampoline, ts);   // trampoline registers the stack first
     if (getenv("PROSPER_SYNCLOG")) fprintf(stderr, "[thread] pthread_create rc=%d\n", r);
     pthread_attr_destroy(&la);
-    if (r) { free(ts); return (uint64_t)r; }
+    if (r) { delete ts; return (uint64_t)r; }
+    (void)publish_guest_thread_name((uint64_t)(uintptr_t)tid, ts->name_generation, ts->name);
+    ts->name_published.store(true, std::memory_order_release);
 #else
     // Windows: route through win_thread_trampoline so the guest entry is called with the SysV ABI and
     // gets its guest %fs TCB — a bare pthread_create(entry, arg) mis-passes the arg (MS x64 vs SysV) and
@@ -993,15 +1136,18 @@ HLE(k_pthread_create) {
     pthread_attr_t la; pthread_attr_init(&la);
     pthread_attr_setstacksize(&la, supplied_stack ? kStackFloor : ssz);
     pthread_attr_setdetachstate(&la, detach);
-    auto* ts = (WinThreadStart*)malloc(sizeof(WinThreadStart));
+    auto* ts = new (std::nothrow) WinThreadStart{};
     if (!ts) { pthread_attr_destroy(&la); return 12; }          // ENOMEM (FreeBSD and host agree)
     ts->entry = (uint64_t)(uintptr_t)entry; ts->arg = arg;
     ts->guest_stack = supplied_stack; ts->guest_stack_size = supplied_stack_size;
+    ts->name_generation = next_guest_thread_name_generation();
     ts->name[0] = 0;
     if (a4) { strncpy(ts->name, (const char*)(uintptr_t)a4, sizeof(ts->name) - 1); ts->name[sizeof(ts->name) - 1] = 0; }
     int r = pthread_create(&tid, &la, win_thread_trampoline, ts);
     pthread_attr_destroy(&la);
-    if (r) { free(ts); return (uint64_t)r; }
+    if (r) { delete ts; return (uint64_t)r; }
+    (void)publish_guest_thread_name((uint64_t)(uintptr_t)tid, ts->name_generation, ts->name);
+    ts->name_published.store(true, std::memory_order_release);
 #endif
     if (a0) *(uint64_t*)a0 = (uint64_t)tid;
     return 0;
@@ -1020,6 +1166,7 @@ HLE(k_pthread_exit)   {
     // registration (#138 — pthread ids recycle). HLE handlers run under the HOST %fs (the import
     // stubs swap), so the host libc below is safe. No-op for threads that never touched either.
     tls_dtv_purge_current_thread();
+    retire_guest_thread_name((uint64_t)(uintptr_t)pthread_self(), 0);
 #if defined(__linux__) || defined(__APPLE__)
     unregister_thread_stack((uint64_t)pthread_self());
 #elif defined(_WIN32)
@@ -2762,6 +2909,9 @@ void register_kernel_hle() {
     R("scePthreadGetschedparam", k_getschedparam);  R("pthread_getschedparam", k_getschedparam);
     R("scePthreadSetschedparam", k_attr_noop);  R("scePthreadSetprio", k_attr_noop);
     R("scePthreadGetprio", k_getprio);
+    R("scePthreadGetname", k_pthread_getname);
+    R("scePthreadRename", k_pthread_rename);
+    R("scePthreadSetName", k_pthread_rename);
     R("scePthreadGetstack", k_attr_getstackaddr);
     // TLS keys (POSIX + Sony names -> host pthread keys)
     R("pthread_key_create", k_key_create);   R("scePthreadKeyCreate", k_key_create);
@@ -2797,7 +2947,8 @@ void register_kernel_hle() {
     R("pthread_attr_setinheritsched", k_attr_noop);
     R("pthread_attr_setschedpolicy", k_attr_noop);  R("pthread_attr_setschedparam", k_attr_noop);
     R("pthread_attr_getstacksize", k_attr_getstacksize);
-    R("scePthreadAttrSetaffinity", k_attr_noop); R("pthread_setname_np", k_attr_noop);
+    R("scePthreadAttrSetaffinity", k_attr_noop);
+    R("pthread_getname_np", k_pthread_getname_np); R("pthread_setname_np", k_pthread_rename);
     // Plain libScePosix sem_* imports use the same guest object representation as scePthreadSem*.
     // Registering only the Sony-prefixed spellings left successful no-op imports in native engines.
     R("sem_init", k_sem_init);       R("sem_destroy", k_sem_destroy);

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -1114,9 +1114,8 @@ void register_kernel_time_hle() {
     // their out-params (affinity mask 0xff, priority 700) — a Get* that returns success without
     // writing hands the caller uninitialized stack memory. register_kernel_time_hle() runs AFTER
     // register_kernel_hle(), so re-registering scePthreadGet{affinity,prio} to a bare k_ok here
-    // (last-write-wins) SILENTLY re-broke exactly that fix. Only scePthreadRename is unique to this
-    // file; leave the scheduling functions to hle_kernel.cpp.
-    R("scePthreadRename", k_ok);
+    // (last-write-wins) SILENTLY re-broke exactly that fix. Thread naming also has its real,
+    // guest-visible implementation in hle_kernel.cpp; leave the entire family there.
     R("sceKernelUuidCreate", k_uuid_create);
     R("_exit", k_exit);
     R("sceKernelDebugRaiseExceptionOnReleaseMode", k_debug_raise_release);

--- a/prosper/tests/test_pthread_names.cpp
+++ b/prosper/tests/test_pthread_names.cpp
@@ -38,12 +38,15 @@ int main() {
     HleFn rename = Hle::lookup(nid_hash("scePthreadRename"));
     HleFn set_name = Hle::lookup(nid_hash("scePthreadSetName"));
     HleFn posix_get = Hle::lookup(nid_hash("pthread_getname_np"));
-    HleFn posix_set = Hle::lookup(nid_hash("pthread_setname_np"));
+    HleFn posix_rename = Hle::lookup(nid_hash("pthread_rename_np"));
+    HleFn posix_set_name = Hle::lookup(nid_hash("pthread_set_name_np"));
     HleFn create = Hle::lookup(nid_hash("scePthreadCreate"));
     HleFn join = Hle::lookup(nid_hash("scePthreadJoin"));
-    CHECK(self && getname && rename && set_name && posix_get && posix_set && create && join,
+    CHECK(self && getname && rename && set_name && posix_get && posix_rename && posix_set_name &&
+              create && join,
           "Sony and POSIX thread-name functions are registered");
-    if (!self || !getname || !rename || !set_name || !posix_get || !posix_set || !create || !join)
+    if (!self || !getname || !rename || !set_name || !posix_get || !posix_rename ||
+        !posix_set_name || !create || !join)
         return 1;
 
     const uint64_t thread = self(0, 0, 0, 0, 0, 0);
@@ -71,18 +74,18 @@ int main() {
 
     std::array<unsigned char, 40> posix_out{};
     posix_out.fill(0x6c);
-    CHECK(posix_get(thread, (uint64_t)(uintptr_t)posix_out.data(), 8, 0, 0, 0) == 34,
-          "pthread_getname_np reports ERANGE for a short buffer");
-    CHECK(posix_out[0] == 0x6c, "short POSIX buffer is not partially overwritten");
-    CHECK(posix_get(thread, (uint64_t)(uintptr_t)posix_out.data(), 32, 0, 0, 0) == 0,
-          "pthread_getname_np accepts the complete guest name");
+    CHECK(posix_get(thread, (uint64_t)(uintptr_t)posix_out.data(), 0, 0, 0, 0) == 0,
+          "pthread_getname_np uses the fixed-width two-argument guest ABI");
     CHECK(strcmp((const char*)posix_out.data(), (const char*)sony_out.data()) == 0,
           "Sony and POSIX getters share one guest-visible name");
+    CHECK(posix_out[31] == 0 && posix_out[32] == 0x6c,
+          "POSIX getter writes exactly the 32-byte guest name field");
 
     static const char renamed_again[] = "io-worker";
-    CHECK(posix_set(thread, (uint64_t)(uintptr_t)renamed_again, 0, 0, 0, 0) == 0 &&
+    CHECK(posix_rename(thread, (uint64_t)(uintptr_t)renamed_again, 0, 0, 0, 0) == 0 &&
+          posix_set_name(thread, (uint64_t)(uintptr_t)renamed_again, 0, 0, 0, 0) == 0 &&
           set_name(thread, (uint64_t)(uintptr_t)renamed_again, 0, 0, 0, 0) == 0,
-          "POSIX setname and scePthreadSetName share the rename contract");
+          "POSIX rename/set-name and scePthreadSetName share the rename contract");
     sony_out.fill(0xa5);
     getname(thread, (uint64_t)(uintptr_t)sony_out.data(), 0, 0, 0, 0);
     CHECK(strcmp((const char*)sony_out.data(), renamed_again) == 0,

--- a/prosper/tests/test_pthread_names.cpp
+++ b/prosper/tests/test_pthread_names.cpp
@@ -1,0 +1,140 @@
+// test_pthread_names -- guest-visible names must round-trip instead of returning success with an
+// untouched output buffer. The contract is intentionally independent of host name limits/APIs.
+#include "../src/hle/dispatch.hpp"
+#include "../src/hle/nid.hpp"
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <thread>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+static std::atomic<bool> worker_started{false};
+static std::atomic<bool> worker_release{false};
+#ifdef _WIN32
+extern "C" __attribute__((sysv_abi)) void* named_worker(void*) {
+#else
+static void* named_worker(void*) {
+#endif
+    worker_started.store(true, std::memory_order_release);
+    while (!worker_release.load(std::memory_order_acquire)) std::this_thread::yield();
+    return (void*)0x386;
+}
+
+int main() {
+    printf("== test_pthread_names ==\n");
+    register_builtin_hle();
+
+    HleFn self = Hle::lookup(nid_hash("scePthreadSelf"));
+    HleFn getname = Hle::lookup(nid_hash("scePthreadGetname"));
+    HleFn rename = Hle::lookup(nid_hash("scePthreadRename"));
+    HleFn set_name = Hle::lookup(nid_hash("scePthreadSetName"));
+    HleFn posix_get = Hle::lookup(nid_hash("pthread_getname_np"));
+    HleFn posix_set = Hle::lookup(nid_hash("pthread_setname_np"));
+    HleFn create = Hle::lookup(nid_hash("scePthreadCreate"));
+    HleFn join = Hle::lookup(nid_hash("scePthreadJoin"));
+    CHECK(self && getname && rename && set_name && posix_get && posix_set && create && join,
+          "Sony and POSIX thread-name functions are registered");
+    if (!self || !getname || !rename || !set_name || !posix_get || !posix_set || !create || !join)
+        return 1;
+
+    const uint64_t thread = self(0, 0, 0, 0, 0, 0);
+    CHECK(thread != 0, "scePthreadSelf returns a usable thread handle");
+
+    std::array<unsigned char, 40> sony_out{};
+    sony_out.fill(0xa5);
+    CHECK(getname(thread, (uint64_t)(uintptr_t)sony_out.data(), 0, 0, 0, 0) == 0,
+          "unnamed current thread has a deterministic Sony result");
+    CHECK(sony_out[0] == 0 && sony_out[31] == 0,
+          "Sony getter writes and terminates its full 32-byte name field");
+    CHECK(sony_out[32] == 0xa5 && sony_out[39] == 0xa5,
+          "Sony getter does not write beyond the 32-byte ABI field");
+
+    static const char long_name[] = "render-worker-name-that-is-longer-than-thirty-one";
+    CHECK(rename(thread, (uint64_t)(uintptr_t)long_name, 0, 0, 0, 0) == 0,
+          "scePthreadRename accepts the current thread");
+    sony_out.fill(0xa5);
+    CHECK(getname(thread, (uint64_t)(uintptr_t)sony_out.data(), 0, 0, 0, 0) == 0,
+          "scePthreadGetname reads the renamed thread");
+    CHECK(std::string((const char*)sony_out.data()) == std::string(long_name).substr(0, 31),
+          "Sony name round-trip truncates deterministically to 31 bytes");
+    CHECK(sony_out[31] == 0 && sony_out[32] == 0xa5,
+          "truncated Sony name is terminated without overrunning the field");
+
+    std::array<unsigned char, 40> posix_out{};
+    posix_out.fill(0x6c);
+    CHECK(posix_get(thread, (uint64_t)(uintptr_t)posix_out.data(), 8, 0, 0, 0) == 34,
+          "pthread_getname_np reports ERANGE for a short buffer");
+    CHECK(posix_out[0] == 0x6c, "short POSIX buffer is not partially overwritten");
+    CHECK(posix_get(thread, (uint64_t)(uintptr_t)posix_out.data(), 32, 0, 0, 0) == 0,
+          "pthread_getname_np accepts the complete guest name");
+    CHECK(strcmp((const char*)posix_out.data(), (const char*)sony_out.data()) == 0,
+          "Sony and POSIX getters share one guest-visible name");
+
+    static const char renamed_again[] = "io-worker";
+    CHECK(posix_set(thread, (uint64_t)(uintptr_t)renamed_again, 0, 0, 0, 0) == 0 &&
+          set_name(thread, (uint64_t)(uintptr_t)renamed_again, 0, 0, 0, 0) == 0,
+          "POSIX setname and scePthreadSetName share the rename contract");
+    sony_out.fill(0xa5);
+    getname(thread, (uint64_t)(uintptr_t)sony_out.data(), 0, 0, 0, 0);
+    CHECK(strcmp((const char*)sony_out.data(), renamed_again) == 0,
+          "set-name aliases update the Sony getter result");
+    CHECK(rename(thread, 0, 0, 0, 0, 0) == 0,
+          "a null Sony rename is an accepted no-op");
+    sony_out.fill(0xa5);
+    getname(thread, (uint64_t)(uintptr_t)sony_out.data(), 0, 0, 0, 0);
+    CHECK(strcmp((const char*)sony_out.data(), renamed_again) == 0,
+          "null rename preserves the previous name");
+
+    CHECK(getname(0, (uint64_t)(uintptr_t)sony_out.data(), 0, 0, 0, 0) == 3,
+          "null thread returns ESRCH");
+    CHECK(getname(thread, 0, 0, 0, 0, 0) == 14,
+          "null Sony output returns EFAULT");
+    CHECK(getname(0x1122334455667788ull, (uint64_t)(uintptr_t)sony_out.data(), 0, 0, 0, 0) == 3,
+          "unknown thread returns ESRCH instead of success with garbage output");
+
+    // Creation publishes the requested name before returning. The worker stays alive while the
+    // parent reads and renames it, then normal exit must retire the generation-tagged registry row.
+    static const char created_name[] = "guest-created-render-worker";
+    uint64_t worker = 0;
+    worker_started.store(false, std::memory_order_relaxed);
+    worker_release.store(false, std::memory_order_relaxed);
+    CHECK(create((uint64_t)(uintptr_t)&worker, 0, (uint64_t)(uintptr_t)&named_worker, 0,
+                 (uint64_t)(uintptr_t)created_name, 0) == 0 && worker != 0,
+          "scePthreadCreate publishes a named worker");
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while (!worker_started.load(std::memory_order_acquire) &&
+           std::chrono::steady_clock::now() < deadline)
+        std::this_thread::yield();
+    CHECK(worker_started.load(std::memory_order_acquire), "named worker entered its guest function");
+    sony_out.fill(0xa5);
+    CHECK(getname(worker, (uint64_t)(uintptr_t)sony_out.data(), 0, 0, 0, 0) == 0 &&
+          strcmp((const char*)sony_out.data(), created_name) == 0,
+          "created thread's initial name is immediately guest-visible");
+    static const char worker_renamed[] = "renamed-worker";
+    CHECK(rename(worker, (uint64_t)(uintptr_t)worker_renamed, 0, 0, 0, 0) == 0,
+          "a live created thread can be renamed");
+    sony_out.fill(0xa5);
+    getname(worker, (uint64_t)(uintptr_t)sony_out.data(), 0, 0, 0, 0);
+    CHECK(strcmp((const char*)sony_out.data(), worker_renamed) == 0,
+          "created thread rename round-trips");
+    worker_release.store(true, std::memory_order_release);
+    void* worker_result = nullptr;
+    CHECK(join(worker, (uint64_t)(uintptr_t)&worker_result, 0, 0, 0, 0) == 0 &&
+          worker_result == (void*)0x386,
+          "named worker exits and joins normally");
+    CHECK(getname(worker, (uint64_t)(uintptr_t)sony_out.data(), 0, 0, 0, 0) == 3,
+          "exited thread name is retired before pthread_t reuse");
+
+    if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
+    printf("== PASS ==\n");
+    return 0;
+}


### PR DESCRIPTION
Advances #386 (F7 thread-name round-trip only).

## What changed
- add a generation-tagged guest thread-name registry with 32-byte Sony ABI semantics
- implement `scePthreadGetname`, `scePthreadRename`, `scePthreadSetName`, and matching POSIX accessors
- publish names before created guest threads start and retire them on thread exit
- stop the later kernel-time registration pass from shadowing the real rename handler
- add cross-platform coverage for bounds, errors, aliases, live-thread rename, join, and lifetime cleanup

## Author pre-PR checks
- Windows: `pthread_names`, `pthread_sched_getters`, `win_pthread_key_destructor`
- Linux: `pthread_names`, `pthread_sched_getters`, `thread_stack_registry`, `tls_dtv_purge_on_thread_exit`
- Messenger short runtime smoke reached asset loading without worker-thread failure; frame-file output was disabled and the 40-second window ended before presentation

Full author verification and independent review follow on this exact head. No snapshots were run.