### PR TITLE
app: add fullscreen window controls

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -284,6 +284,10 @@ if(TARGET prosper_core)
   target_link_libraries(test_prosper_app_pad_overlay PRIVATE prosper_core)
   add_test(NAME prosper_app_pad_overlay COMMAND test_prosper_app_pad_overlay)
 
+  add_executable(test_prosper_app_window_controls frontends/prosper-app/test_window_controls.cpp)
+  target_include_directories(test_prosper_app_window_controls PRIVATE frontends/prosper-app)
+  add_test(NAME prosper_app_window_controls COMMAND test_prosper_app_window_controls)
+
   add_executable(test_sync_on_address tests/test_sync_on_address.cpp)
   target_link_libraries(test_sync_on_address PRIVATE prosper_core)
   add_test(NAME sync_on_address COMMAND test_sync_on_address)

--- a/prosper/docs/FRONTEND_APP.md
+++ b/prosper/docs/FRONTEND_APP.md
@@ -120,6 +120,8 @@ init:  SDL_Init(VIDEO|AUDIO|GAMECONTROLLER); create window;
        start the guest run-loop on its own thread.
 
 frame: SDL_PollEvent → on SDL_QUIT / window-close: prosper_request_stop(); break;
+       F11 / Alt+Enter toggles borderless desktop fullscreen;
+       pixel-size change → recreate the Vulkan swapchain before the next present;
        if present_count() advanced since last shown:
            lease = present_acquire_rendered_frame();
            upload lease.rgba → VkImage; blit/scale VkImage → acquired swapchain image; vkQueuePresentKHR;
@@ -423,7 +425,8 @@ duplicate. Until then the app is fully functional via `--test-pattern` (and any 
   shows the composited game (verified `--dump … --frames 3`).
 - **P1 — audio** ✅ **done**: `prosper-app` installs the SDL3 `AudioSink` (`sceAudioOut` → host).
 - **P2 — controllers** ✅ **done**: installs the SDL3 `PadBackend` (host gamepad → `libScePad`).
-- **P3 — polish** (in progress): resize/fullscreen, pause/quit UX, and present-mode/latency tuning.
+- **P3 — polish** (in progress): resize/fullscreen is implemented; pause/quit UX and
+  present-mode/latency tuning remain.
   Native Windows build/run packaging is done via `scripts/run-windows.ps1`. Cooperative guest-stop
   at a flip boundary is a follow-up (today the
   guest thread is detached at window-close and reclaimed by process exit).

--- a/prosper/docs/WINDOWS_RELEASE.md
+++ b/prosper/docs/WINDOWS_RELEASE.md
@@ -64,9 +64,11 @@ SDL3 automatically uses a connected controller as pad 0. Keyboard input is compo
 | U / O | L1 / R1 |
 | Y / H | L2 / R2 |
 | Enter | Options |
+| F11 or Alt+Enter | Toggle host-window fullscreen |
 | Escape | Exit |
 
-Closing the window also exits. Shutdown currently terminates the process after flushing logs because
+Alt+Enter is consumed by the host window and is not forwarded as the guest Options button. Closing
+the window also exits. Shutdown currently terminates the process after flushing logs because
 cooperative guest-thread teardown is not implemented yet.
 
 ## Smoke test and recordings

--- a/prosper/frontends/prosper-app/README.md
+++ b/prosper/frontends/prosper-app/README.md
@@ -52,7 +52,7 @@ PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct \
 ./build-app/prosper-app --test-pattern
 ```
 
-Esc or closing the window quits.
+F11 or Alt+Enter toggles borderless desktop fullscreen. Esc or closing the window quits.
 
 ## Options
 

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -318,10 +318,9 @@ void feed_test_pattern(uint32_t w, uint32_t h, uint64_t frame) {
 prosper::frontend::KeyboardPadOverlay g_keyboard_pad;
 
 // Snapshot the current keyboard into the overlay. Call from the thread that pumps SDL events.
-void poll_keyboard(bool enter_maps_to_options) {
+void poll_keyboard(const bool* keyboard, bool enter_maps_to_options) {
     using namespace prosper::input;
-    const bool* k = SDL_GetKeyboardState(nullptr);
-    auto d = [&](SDL_Scancode s){ return k[s]; };
+    auto d = [&](SDL_Scancode s){ return keyboard[s]; };
     bool up    = d(SDL_SCANCODE_UP)   || d(SDL_SCANCODE_W);
     bool down  = d(SDL_SCANCODE_DOWN) || d(SDL_SCANCODE_S);
     bool left  = d(SDL_SCANCODE_LEFT) || d(SDL_SCANCODE_A);
@@ -339,7 +338,8 @@ void poll_keyboard(bool enter_maps_to_options) {
     if (d(SDL_SCANCODE_O))     b |= SCE_PAD_BUTTON_R1;
     if (d(SDL_SCANCODE_Y))     b |= SCE_PAD_BUTTON_L2;
     if (d(SDL_SCANCODE_H))     b |= SCE_PAD_BUTTON_R2;
-    const bool enter_down = d(SDL_SCANCODE_RETURN) || d(SDL_SCANCODE_RETURN2);
+    const bool enter_down = d(SDL_SCANCODE_RETURN) || d(SDL_SCANCODE_RETURN2) ||
+                            d(SDL_SCANCODE_KP_ENTER);
     if (enter_down && enter_maps_to_options)
         b |= SCE_PAD_BUTTON_OPTIONS;   // menu/start; Alt+Enter belongs to the host window
     HostPadState st;
@@ -531,6 +531,9 @@ int main(int argc, char** argv) {
     bool swapchainDirty = false;
     const SDL_WindowID appWindowId = SDL_GetWindowID(win);
     prosper::frontend::AppWindowControls windowControls;
+    const SDL_WindowFlags initialWindowFlags = SDL_GetWindowFlags(win);
+    bool fullscreenRequested = (initialWindowFlags & SDL_WINDOW_FULLSCREEN) != 0;
+    windowControls.set_app_focus((initialWindowFlags & SDL_WINDOW_INPUT_FOCUS) != 0);
     while (running && !prosper_stop_requested()) {
         SDL_Event ev;
         while (SDL_PollEvent(&ev)) {
@@ -549,13 +552,16 @@ int main(int argc, char** argv) {
                     running = false;
                     break;
                 case prosper::frontend::AppWindowCommand::toggle_fullscreen: {
-                    const bool fullscreen =
-                        (SDL_GetWindowFlags(win) & SDL_WINDOW_FULLSCREEN) != 0;
-                    if (!SDL_SetWindowFullscreen(win, !fullscreen)) {
+                    // SDL may apply fullscreen requests asynchronously. Toggle the last accepted
+                    // target instead of reading a flag that can still describe the old state.
+                    const bool targetFullscreen = !fullscreenRequested;
+                    if (!SDL_SetWindowFullscreen(win, targetFullscreen)) {
                         fprintf(stderr, "[app] fullscreen toggle failed: %s\n", SDL_GetError());
                     } else {
+                        fullscreenRequested = targetFullscreen;
                         swapchainDirty = true;
-                        fprintf(stderr, "[app] fullscreen %s\n", fullscreen ? "off" : "on");
+                        fprintf(stderr, "[app] fullscreen %s requested\n",
+                                targetFullscreen ? "on" : "off");
                     }
                     break;
                 }
@@ -567,10 +573,32 @@ int main(int argc, char** argv) {
                 swapchainDirty = true;
             } else if (ev.type == SDL_EVENT_WINDOW_FOCUS_LOST &&
                        ev.window.windowID == appWindowId) {
-                windowControls.release_host_shortcuts();
+                windowControls.set_app_focus(false);
+            } else if (ev.type == SDL_EVENT_WINDOW_FOCUS_GAINED &&
+                       ev.window.windowID == appWindowId) {
+                windowControls.set_app_focus(true);
+            } else if (ev.type == SDL_EVENT_WINDOW_ENTER_FULLSCREEN &&
+                       ev.window.windowID == appWindowId) {
+                fullscreenRequested = true;
+            } else if (ev.type == SDL_EVENT_WINDOW_LEAVE_FULLSCREEN &&
+                       ev.window.windowID == appWindowId) {
+                fullscreenRequested = false;
             }
         }
         if (!running) break;
+
+        // Snapshot input before any minimized-window early exit. This clears released guest
+        // buttons even while swapchain recreation has to wait for a non-zero pixel extent.
+        const bool* keyboard = SDL_GetKeyboardState(nullptr);
+        const bool enterDown = keyboard[SDL_SCANCODE_RETURN] ||
+                               keyboard[SDL_SCANCODE_RETURN2] ||
+                               keyboard[SDL_SCANCODE_KP_ENTER];
+        windowControls.reconcile_enter(enterDown);
+        poll_keyboard(keyboard, windowControls.guest_options_allowed());
+#ifdef PROSPER_HAVE_DIALOG_SDL3
+        prosper::sdl_platform_ui_pump();   // run a pending ImeDialog text-entry modal on this (main) thread
+#endif
+
         if (swapchainDirty) {
             int dw = 0, dh = 0;
             SDL_GetWindowSizeInPixels(win, &dw, &dh);
@@ -588,12 +616,6 @@ int main(int argc, char** argv) {
             }
             swapchainDirty = false;
         }
-        // Snapshot key state for the guest's pad reads. The control state keeps an Alt+Enter chord
-        // host-owned until Enter is released, even if Alt is released first.
-        poll_keyboard(windowControls.guest_options_allowed());
-#ifdef PROSPER_HAVE_DIALOG_SDL3
-        prosper::sdl_platform_ui_pump();   // run a pending ImeDialog text-entry modal on this (main) thread
-#endif
         const auto loopNow = std::chrono::steady_clock::now();
         if (timedDumpPending && loopNow >= nextTimedDump) {
             ++timedDumpCount;

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -20,6 +20,7 @@
 #include "loader/linker.hpp"           // Program
 #include "input/pad.hpp"               // keyboard -> libScePad (HostPadState / PadBackend)
 #include "pad_overlay.hpp"              // keyboard pad 0 composed over the physical controller backend
+#include "window_controls.hpp"           // debounced app-window shortcuts, pure regression seam
 #ifdef PROSPER_HAVE_LIVE_RENDERER
 #include "live_renderer.hpp"           // shared DrawItem->Vulkan compositor (register_live_renderer)
 #endif
@@ -317,7 +318,7 @@ void feed_test_pattern(uint32_t w, uint32_t h, uint64_t frame) {
 prosper::frontend::KeyboardPadOverlay g_keyboard_pad;
 
 // Snapshot the current keyboard into the overlay. Call from the thread that pumps SDL events.
-void poll_keyboard() {
+void poll_keyboard(bool enter_maps_to_options) {
     using namespace prosper::input;
     const bool* k = SDL_GetKeyboardState(nullptr);
     auto d = [&](SDL_Scancode s){ return k[s]; };
@@ -338,7 +339,9 @@ void poll_keyboard() {
     if (d(SDL_SCANCODE_O))     b |= SCE_PAD_BUTTON_R1;
     if (d(SDL_SCANCODE_Y))     b |= SCE_PAD_BUTTON_L2;
     if (d(SDL_SCANCODE_H))     b |= SCE_PAD_BUTTON_R2;
-    if (d(SDL_SCANCODE_RETURN) || d(SDL_SCANCODE_RETURN2)) b |= SCE_PAD_BUTTON_OPTIONS;   // menu/start
+    const bool enter_down = d(SDL_SCANCODE_RETURN) || d(SDL_SCANCODE_RETURN2);
+    if (enter_down && enter_maps_to_options)
+        b |= SCE_PAD_BUTTON_OPTIONS;   // menu/start; Alt+Enter belongs to the host window
     HostPadState st;
     st.buttons = b;
     st.left_x  = left ? 0x00 : (right ? 0xff : 0x80);   // also drive the left stick, for stick-only titles
@@ -503,7 +506,8 @@ int main(int argc, char** argv) {
     // Keyboard controls augment SDL pad 0; the fallback keeps physical pads and their analog state.
     prosper::input::pad_set_backend(&g_keyboard_pad);
     fprintf(stderr, "[app] keyboard: WASD/Arrows=move  J/Space=Cross(jump)  K=Square(attack)  L=Circle  "
-                    "I=Triangle  U/O=L1/R1  Y/H=L2/R2  Enter=Options  Esc=quit\n");
+                    "I=Triangle  U/O=L1/R1  Y/H=L2/R2  Enter=Options  "
+                    "F11/Alt+Enter=fullscreen  Esc=quit\n");
 
     const bool frameTrace = getenv("PROSPER_APP_FRAME_TRACE") != nullptr;
     const char* stallDumpEnv = getenv("PROSPER_APP_STALL_DUMP_MS");
@@ -524,14 +528,69 @@ int main(int argc, char** argv) {
     unsigned timedDumpCount = 0;
     bool timedDumpPending = timedDumpMs > 0;
     bool running = true;
+    bool swapchainDirty = false;
+    const SDL_WindowID appWindowId = SDL_GetWindowID(win);
+    prosper::frontend::AppWindowControls windowControls;
     while (running && !prosper_stop_requested()) {
         SDL_Event ev;
         while (SDL_PollEvent(&ev)) {
             if (ev.type == SDL_EVENT_QUIT) running = false;
-            else if (ev.type == SDL_EVENT_KEY_DOWN && ev.key.key == SDLK_ESCAPE) running = false;
+            else if (ev.type == SDL_EVENT_KEY_DOWN || ev.type == SDL_EVENT_KEY_UP) {
+                prosper::frontend::AppWindowKey key{};
+                key.app_window = ev.key.windowID == appWindowId;
+                key.pressed = ev.key.down;
+                key.repeat = ev.key.repeat;
+                key.escape = ev.key.key == SDLK_ESCAPE;
+                key.f11 = ev.key.key == SDLK_F11;
+                key.enter = ev.key.key == SDLK_RETURN || ev.key.key == SDLK_KP_ENTER;
+                key.alt = (ev.key.mod & SDL_KMOD_ALT) != 0;
+                switch (windowControls.handle_key(key)) {
+                case prosper::frontend::AppWindowCommand::quit:
+                    running = false;
+                    break;
+                case prosper::frontend::AppWindowCommand::toggle_fullscreen: {
+                    const bool fullscreen =
+                        (SDL_GetWindowFlags(win) & SDL_WINDOW_FULLSCREEN) != 0;
+                    if (!SDL_SetWindowFullscreen(win, !fullscreen)) {
+                        fprintf(stderr, "[app] fullscreen toggle failed: %s\n", SDL_GetError());
+                    } else {
+                        swapchainDirty = true;
+                        fprintf(stderr, "[app] fullscreen %s\n", fullscreen ? "off" : "on");
+                    }
+                    break;
+                }
+                case prosper::frontend::AppWindowCommand::none:
+                    break;
+                }
+            } else if (ev.type == SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED &&
+                       ev.window.windowID == appWindowId) {
+                swapchainDirty = true;
+            } else if (ev.type == SDL_EVENT_WINDOW_FOCUS_LOST &&
+                       ev.window.windowID == appWindowId) {
+                windowControls.release_host_shortcuts();
+            }
         }
         if (!running) break;
-        poll_keyboard();   // snapshot key state for the guest's pad reads
+        if (swapchainDirty) {
+            int dw = 0, dh = 0;
+            SDL_GetWindowSizeInPixels(win, &dw, &dh);
+            if (dw <= 0 || dh <= 0) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(2));
+                continue;   // minimized or between fullscreen modes; retry after the next event
+            }
+            vkDeviceWaitIdle(vk.device);
+            if (vk.swapchain) vkDestroySwapchainKHR(vk.device, vk.swapchain, nullptr);
+            vk.swapchain = VK_NULL_HANDLE;
+            if (!create_swapchain(vk, static_cast<uint32_t>(dw), static_cast<uint32_t>(dh))) {
+                fprintf(stderr, "[app] could not recreate the swapchain after a window-size change\n");
+                running = false;
+                break;
+            }
+            swapchainDirty = false;
+        }
+        // Snapshot key state for the guest's pad reads. The control state keeps an Alt+Enter chord
+        // host-owned until Enter is released, even if Alt is released first.
+        poll_keyboard(windowControls.guest_options_allowed());
 #ifdef PROSPER_HAVE_DIALOG_SDL3
         prosper::sdl_platform_ui_pump();   // run a pending ImeDialog text-entry modal on this (main) thread
 #endif
@@ -569,11 +628,8 @@ int main(int argc, char** argv) {
             if (w == 0 || h == 0) { std::this_thread::sleep_for(std::chrono::milliseconds(2)); continue; }
             if (frame.rgba && frame.rgba->size() == (size_t)w * h * 4) {
                 if (!present_frame(vk, frame.rgba->data(), w, h)) {
-                    // out-of-date / resize: recreate the swapchain and retry next iteration.
-                    vkDeviceWaitIdle(vk.device);
-                    vkDestroySwapchainKHR(vk.device, vk.swapchain, nullptr); vk.swapchain = VK_NULL_HANDLE;
-                    int dw = 0, dh = 0; SDL_GetWindowSizeInPixels(win, &dw, &dh);
-                    create_swapchain(vk, (uint32_t)dw, (uint32_t)dh);
+                    // Out-of-date/suboptimal: share the resize/fullscreen recreation path next loop.
+                    swapchainDirty = true;
                 } else {
                     lastFrameSeq = frame.frame_seq; shown++;
                     lastFrameProgress = std::chrono::steady_clock::now();

--- a/prosper/frontends/prosper-app/test_window_controls.cpp
+++ b/prosper/frontends/prosper-app/test_window_controls.cpp
@@ -53,9 +53,17 @@ int main() {
     key.app_window = true;
     key.alt = true;
     controls.handle_key(key);
-    controls.release_host_shortcuts();
+    controls.set_app_focus(false);
+    controls.reconcile_enter(false);
+    CHECK(!controls.guest_options_allowed(),
+          "focus loss cannot release a host-owned Enter chord");
+    controls.set_app_focus(true);
+    controls.reconcile_enter(true);
+    CHECK(!controls.guest_options_allowed(),
+          "focus regain while Enter is held keeps guest Options suppressed");
+    controls.reconcile_enter(false);
     CHECK(controls.guest_options_allowed(),
-          "losing window focus clears host-shortcut suppression");
+          "post-focus keyboard reconciliation releases an unheld Enter chord");
 
     key = {};
     key.app_window = true;

--- a/prosper/frontends/prosper-app/test_window_controls.cpp
+++ b/prosper/frontends/prosper-app/test_window_controls.cpp
@@ -1,0 +1,70 @@
+#include "window_controls.hpp"
+
+#include <cstdio>
+
+using prosper::frontend::AppWindowCommand;
+using prosper::frontend::AppWindowControls;
+using prosper::frontend::AppWindowKey;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { std::printf("  [FAIL] %s\n", m); ++fails; } \
+                         else       { std::printf("  [ok]   %s\n", m); } } while (0)
+
+int main() {
+    std::printf("== test_prosper_app_window_controls ==\n");
+
+    AppWindowControls controls;
+    AppWindowKey key{};
+    key.app_window = true;
+    key.pressed = true;
+    key.f11 = true;
+    CHECK(controls.handle_key(key) == AppWindowCommand::toggle_fullscreen,
+          "F11 toggles fullscreen");
+
+    key.repeat = true;
+    CHECK(controls.handle_key(key) == AppWindowCommand::none,
+          "held F11 does not toggle repeatedly");
+
+    key = {};
+    key.app_window = true;
+    key.pressed = true;
+    key.enter = true;
+    key.alt = true;
+    CHECK(controls.handle_key(key) == AppWindowCommand::toggle_fullscreen,
+          "Alt+Enter toggles fullscreen");
+    CHECK(!controls.guest_options_allowed(),
+          "Alt+Enter is not forwarded as the guest Options button");
+    key.enter = false;
+    key.alt = false;
+    CHECK(controls.handle_key(key) == AppWindowCommand::none &&
+              !controls.guest_options_allowed(),
+          "releasing Alt first does not leak the held Enter chord to the guest");
+    key.enter = true;
+    key.pressed = false;
+    key.app_window = false;
+    CHECK(controls.handle_key(key) == AppWindowCommand::none &&
+              controls.guest_options_allowed(),
+          "releasing Enter after focus moves ends host-shortcut suppression");
+
+    key.pressed = true;
+    CHECK(controls.handle_key(key) == AppWindowCommand::none,
+          "another SDL window cannot toggle the game window");
+
+    key.app_window = true;
+    key.alt = true;
+    controls.handle_key(key);
+    controls.release_host_shortcuts();
+    CHECK(controls.guest_options_allowed(),
+          "losing window focus clears host-shortcut suppression");
+
+    key = {};
+    key.app_window = true;
+    key.pressed = true;
+    key.escape = true;
+    CHECK(controls.handle_key(key) == AppWindowCommand::quit,
+          "Escape retains the quit command");
+
+    if (fails) { std::printf("== FAIL: %d ==\n", fails); return 1; }
+    std::printf("== PASS ==\n");
+    return 0;
+}

--- a/prosper/frontends/prosper-app/window_controls.hpp
+++ b/prosper/frontends/prosper-app/window_controls.hpp
@@ -38,12 +38,20 @@ public:
         return !suppress_enter_options_;
     }
 
-    constexpr void release_host_shortcuts() {
-        suppress_enter_options_ = false;
+    constexpr void set_app_focus(bool focused) {
+        app_focused_ = focused;
+    }
+
+    // SDL can omit the key-up event while focus is elsewhere. Reconcile against its keyboard
+    // snapshot only while the app owns focus: a fullscreen transition must not expose an Enter
+    // key that is still physically held as the guest Options button.
+    constexpr void reconcile_enter(bool enter_down) {
+        if (app_focused_ && !enter_down) suppress_enter_options_ = false;
     }
 
 private:
     bool suppress_enter_options_ = false;
+    bool app_focused_ = true;
 };
 
 } // namespace prosper::frontend

--- a/prosper/frontends/prosper-app/window_controls.hpp
+++ b/prosper/frontends/prosper-app/window_controls.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+namespace prosper::frontend {
+
+enum class AppWindowCommand {
+    none,
+    quit,
+    toggle_fullscreen,
+};
+
+struct AppWindowKey {
+    bool app_window = false;
+    bool pressed = false;
+    bool repeat = false;
+    bool escape = false;
+    bool f11 = false;
+    bool enter = false;
+    bool alt = false;
+};
+
+class AppWindowControls {
+public:
+    constexpr AppWindowCommand handle_key(const AppWindowKey& key) {
+        // Key-up may be delivered after focus moved to a transient SDL window. It must still end a
+        // host-owned Alt+Enter chord or the guest Options button would remain suppressed forever.
+        if (key.enter && !key.pressed) suppress_enter_options_ = false;
+        if (!key.app_window) return AppWindowCommand::none;
+        if (key.enter) {
+            if (key.pressed && key.alt) suppress_enter_options_ = true;
+        }
+        if (!key.pressed || key.repeat) return AppWindowCommand::none;
+        if (key.escape) return AppWindowCommand::quit;
+        if (key.f11 || (key.enter && key.alt)) return AppWindowCommand::toggle_fullscreen;
+        return AppWindowCommand::none;
+    }
+
+    constexpr bool guest_options_allowed() const {
+        return !suppress_enter_options_;
+    }
+
+    constexpr void release_host_shortcuts() {
+        suppress_enter_options_ = false;
+    }
+
+private:
+    bool suppress_enter_options_ = false;
+};
+
+} // namespace prosper::frontend


### PR DESCRIPTION
Advances #352 (fullscreen-toggle slice only).

## What changed
- add debounced F11 and Alt+Enter borderless-desktop fullscreen controls to `prosper-app`
- keep Alt+Enter host-owned until Enter is released, so it cannot leak to the guest as Options
- coalesce SDL pixel-size/fullscreen changes through one Vulkan swapchain recreation path
- add a pure cross-platform control-state regression and update frontend/release documentation

Pause/resume, cooperative guest stop, and present-mode tuning remain separate #352 work.

## Author pre-PR checks
- native Windows full `prosper-app` build with SDL3/Vulkan
- Windows and Linux `prosper_app_window_controls`
- Windows and Linux `prosper_app_pad_overlay`
- native Windows `--test-pattern --frames 5` presented five frames and exited 0

No snapshots or frame captures were run. Full author verification and independent review follow on the exact PR head.