### PR TITLE
perf(hle): placement cursor for auto-mapped guest VA — ~10x faster macOS level loads (#983)

### DIFF
--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -456,6 +456,17 @@ namespace {
     // collision can skip directly past them instead of probing every 64 KiB page.
     constexpr uint64_t kGuestAutoMapBase  = 0x2000000000ull;
     constexpr uint64_t kGuestAutoMapLimit = 0x40000000000ull;
+    // Monotonic placement cursor for auto-mapped guest VA (#983). Restarting the linear probe in
+    // map_guest_from() from kGuestAutoMapBase on EVERY auto-map is O(N) in the live-mapping count,
+    // and on macOS each collided probe is a full mmap+munmap under Rosetta's VM tracking
+    // (prosper_mmap_noreplace emulates MAP_FIXED_NOREPLACE that way) — a level's tens of thousands
+    // of sceKernelMapDirectMemory calls degrade to O(N^2) Rosetta VM churn (minutes). Advancing a
+    // cursor past each successful placement makes the common case a single successful mmap.
+    // Correctness is unchanged: map_guest_from still uses NOREPLACE (never clobbers) and still scans
+    // g_maps for a free slot; the cursor only picks the STARTING hint, and map_guest_auto wraps back
+    // to the base to reclaim VA freed below the cursor. Atomic (lock-free) — concurrent mappers stay
+    // correct via NOREPLACE; the cursor is a hint, not a lock.
+    uint64_t g_auto_map_cursor = kGuestAutoMapBase;
     void* map_guest_from(uint64_t start, uint64_t len, int prot, uint64_t align) {
         const uint64_t page = (uint64_t)sysconf(_SC_PAGESIZE);
         if (align < page) align = page;
@@ -490,7 +501,23 @@ namespace {
     }
 
     void* map_guest_auto(uint64_t len, int prot, uint64_t align) {
-        return map_guest_from(kGuestAutoMapBase, len, prot, align);
+        // Start probing past the last successful placement (see g_auto_map_cursor, #983) instead of
+        // rescanning from kGuestAutoMapBase every call. If the tail is exhausted, wrap once to the
+        // base to reclaim VA freed below the cursor.
+        uint64_t hint = __atomic_load_n(&g_auto_map_cursor, __ATOMIC_RELAXED);
+        if (hint < kGuestAutoMapBase) hint = kGuestAutoMapBase;
+        void* p = map_guest_from(hint, len, prot, align);
+        if (!p && hint > kGuestAutoMapBase)
+            p = map_guest_from(kGuestAutoMapBase, len, prot, align);
+        if (p) {
+            // Advance the cursor monotonically to the end of this placement (only forward; VA below
+            // the cursor is reclaimed by the wrap above, never leaked).
+            uint64_t end = (uint64_t)p + len;
+            uint64_t cur = __atomic_load_n(&g_auto_map_cursor, __ATOMIC_RELAXED);
+            while (end > cur && !__atomic_compare_exchange_n(&g_auto_map_cursor, &cur, end, true,
+                                                             __ATOMIC_RELAXED, __ATOMIC_RELAXED)) {}
+        }
+        return p;
     }
 
     void* map_at(uint64_t hint, uint64_t len, int prot) {


### PR DESCRIPTION
Fixes #983.

## Problem / failure scenario
On macOS (guest under Rosetta), Blasphemous 2 (PPSA13579) takes ~236 s to load its first level; on hardware it is seconds. Profiling a load with macOS `sample` shows it is a **single-threaded CPU bottleneck in guest direct-memory mapping**, not the GPU path (the whole render path is ~7 s per `[render-timing]`). One thread spends ~100% of the sampled window in
`k_map_dmem` → `map_dmem_impl` → `map_phys_at` (the `!hint`/`reserve_aligned` branch) → `map_guest_from`; every other guest thread is parked in `k_sema_wait`/`k_ef_wait`/`k_mutex_lock` waiting for it. Process CPU ≈ 107% (one core).

## Root cause
`map_guest_from()` restarts its linear placement probe from the **fixed base** `kGuestAutoMapBase = 0x2000000000` on **every** auto-map (`map_guest_auto`). As live mappings accumulate during a load, each new `sceKernelMapDirectMemory` walks past all prior ones — O(N) per map, O(N²) over the load.

macOS amplifies it: `prosper_mmap_noreplace` has no `MAP_FIXED_NOREPLACE` (posix_shim.hpp) and emulates it by doing a real `mmap` **then `munmap`** whenever the hinted range is occupied — and the fixed-base restart guarantees a collision on essentially every call once the low region fills. Each collision is a full map+unmap pair, each incurring Rosetta VM-table churn. Inside `map_guest_from`, the cost is Rosetta's mmap interception (~3800 samples), not the syscall (~26).

This is shared infra (`hle_kernel_mem.cpp`) exercised by every title; the O(N²) restart wastes work on all platforms, worst on macOS.

## Fix
Advance a monotonic **placement cursor** (`g_auto_map_cursor`) in `map_guest_auto`: start the probe past the last successful placement (the first `mmap` then usually succeeds — no wasted map+unmap), and wrap back to `kGuestAutoMapBase` once if the tail is exhausted, to reclaim VA freed below the cursor. Lock-free (`__atomic_*`, matching the file's existing style); the cursor is a hint, not a lock.

### Invariants / why correctness is unchanged
- `map_guest_from` still uses `prosper_mmap_noreplace` (NOREPLACE) — it never clobbers an existing mapping — and still scans `g_maps` to skip occupants. The cursor only changes the **starting hint** of the search.
- Concurrent mappers stay correct: NOREPLACE guarantees exactly one winner per address; a loser collides and advances as before.
- VA below the cursor is not leaked — the wrap reclaims it; physical/anon backing is still freed on `munmap`.
- The guest treats the returned VA as opaque (any address in the auto range is valid); no semantic dependence on the specific address, so no title behavior changes.

## Affected / unaffected
- **Affected:** placement address chosen for auto-mapped guest VA (`sceKernelMapDirectMemory` with hint 0, `map_at(0,…)`, `reserve_aligned`). Faster on all platforms; dramatically faster on macOS.
- **Unaffected:** explicit-hint mappings, the memfd aliasing contract, `g_maps` tracking, `MAP_FIXED_NOREPLACE`/Darwin-emulation semantics, guest-visible values.

## Risk
Low. Single-file, ~20-line change to a placement heuristic; no ABI/semantic change. Main risk is VA-space exhaustion over an extremely long session (millions of never-reused maps) — bounded by the wrap-to-base fallback.

## Verification
- **macOS (Apple M1 Ultra, x86_64 build, guest under Rosetta), reach-first-gameplay route:** time for the guest to reach frame ~1000 dropped from **~265 s → ~25 s (~10×)**; the full first level (188 asset bundles incl. z04/z27) streams at ~60 fps with no crash. Baseline `frame=13 @ 236 s` → fix `frame=973 @ 26 s`.
- **Linux (x86_64, RelWithDebInfo):** `cmake --build` + full `ctest` — results posted below.

Note: an unrelated intermittent early-boot completion/fence stall (frame 0 + `suspendPoint` spam) exists on macOS independent of this change and is tracked separately; it is not introduced or affected by this PR.

### Linux ctest results (x86_64 container, RelWithDebInfo)
Build: clean. `ctest`: **106/115 passed**. The 9 failures are all pre-existing/environmental for this x86-on-arm container, **not introduced by this change**:
- `libc_alloc` — **proven pre-existing** via same-build-dir A/B: fails identically with master's `hle_kernel_mem.cpp` and with this change (it exercises the throwing `operator new` SIZE_MAX error path; both versions of `map_guest_auto` return `nullptr` for impossible sizes, so behavior is byte-identical).
- `snapshot_guard_logic` — flaky under parallel ctest load; passes when run solo.
- `pthread_names`, `fiber_hle`, `initfault_dump_survives`, `hle_stack_args_guest_fs`, `thread_stack_registry`, `tls_dtv_purge_on_thread_exit` — `ILLEGAL`/`SEGFAULT` from WRFSBASE/guest-`%fs` unsupported in this container.
- `rdna2_to_spirv_exec` — requires a hardware Vulkan device (software-only here).

Reviewer: please run the strongest applicable checks on your platform; on a native x86_64 Linux host the `%fs` tests should pass. This is a placement-heuristic change with no renderer/recompiler impact.
