### PR TITLE
gpu: honor AGC draw instance counts

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -1900,6 +1900,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     bd.vs_identity = refvs ? 0 : it.vs_identity;
                     bd.fs_identity = fs_ov ? 0 : it.fs_identity;
                     bd.vcount = refvs ? 3u : it.vertex_count;
+                    bd.instance_count = it.instance_count;
                     bd.ps     = nops ? nullptr : &it.ps;
                     bd.R      = build_R(it, it.vrt.get(), it.prt.get());
                     if (!prosper::gpu::validate_runtime_descriptor_contract(
@@ -1913,8 +1914,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     // Skipped under REFVS — the reference VS is a 3-vertex non-indexed fullscreen triangle.
                     if (!refvs) bd.indices = it.indices;
                     if (getenv("PROSPER_GFXLOG")) fprintf(stderr,
-                        "[render] item %zu: %zu resources vcount=%u nidx=%zu topo=%u mask=0x%x blend=%d\n",
-                        bds.size(), bd.R.size(), bd.vcount, bd.indices.size(), it.ps.topology,
+                        "[render] item %zu: %zu resources vcount=%u instances=%u nidx=%zu topo=%u mask=0x%x blend=%d\n",
+                        bds.size(), bd.R.size(), bd.vcount, bd.instance_count, bd.indices.size(), it.ps.topology,
                         it.ps.color_write_mask, (int)it.ps.blend_enable);
                     // RTTLOG per-draw detail (render-window-only, unlike the GFXLOG firehose): enough
                     // state to diagnose a pass whose inputs HIT the RTT cache yet outputs nothing —

--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -1475,8 +1475,7 @@ void GpuState::apply(const Pm4Command& c) {
             state_dirty_ = true;
             break;
         case K::SetNumInstances:
-            // The command processor treats a zero payload as the single-instance default.
-            num_instances = c.instance_count ? c.instance_count : 1u;
+            num_instances = c.instance_count;
             state_dirty_ = true;
             break;
         case K::SetIndexBase:

--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -1474,6 +1474,11 @@ void GpuState::apply(const Pm4Command& c) {
             index_type = c.index_size;
             state_dirty_ = true;
             break;
+        case K::SetNumInstances:
+            // The command processor treats a zero payload as the single-instance default.
+            num_instances = c.instance_count ? c.instance_count : 1u;
+            state_dirty_ = true;
+            break;
         case K::SetIndexBase:
             index_base = c.ib_addr;   // bind index-buffer base (issue #232)
             break;
@@ -1493,12 +1498,14 @@ void GpuState::apply(const Pm4Command& c) {
             if (state_dirty_ || !last_snapshot_) {
                 auto snap = std::make_shared<GpuState>();
                 snap->cx = cx; snap->sh = sh; snap->uc = uc; snap->index_type = index_type;
+                snap->num_instances = num_instances;
                 last_snapshot_ = std::move(snap);
                 state_dirty_ = false;
             }
             uint32_t elem = index_type ? 4u : 2u;
             Draw d;
             d.index_count = c.index_count ? c.index_count : index_num;
+            d.instance_count = num_instances;
             d.state = last_snapshot_;
             if (index_base && d.index_count) {
                 d.indexed = true;
@@ -1522,11 +1529,13 @@ void GpuState::apply(const Pm4Command& c) {
             if (state_dirty_ || !last_snapshot_) {
                 auto snap = std::make_shared<GpuState>();
                 snap->cx = cx; snap->sh = sh; snap->uc = uc; snap->index_type = index_type;
+                snap->num_instances = num_instances;
                 last_snapshot_ = std::move(snap);
                 state_dirty_ = false;
             }
             Draw d;
             d.index_count = c.index_count;
+            d.instance_count = num_instances;
             d.state = last_snapshot_;
             if (c.kind == K::DrawIndex) {
                 // Mark as indexed only when the packet was fully decoded — a short packet's addr/
@@ -1682,6 +1691,7 @@ void GpuState::apply(const Pm4Command& c) {
             if (state_dirty_ || !last_snapshot_) {
                 auto snap = std::make_shared<GpuState>();
                 snap->cx = cx; snap->sh = sh; snap->uc = uc; snap->index_type = index_type;
+                snap->num_instances = num_instances;
                 last_snapshot_ = std::move(snap);
                 state_dirty_ = false;
             }

--- a/prosper/src/gpu/command_processor.hpp
+++ b/prosper/src/gpu/command_processor.hpp
@@ -24,7 +24,7 @@ struct ShaderReg { uint32_t offset; uint32_t value; };
 struct GpuState {
     std::unordered_map<uint32_t, uint32_t> cx, sh, uc;   // register files by offset
     uint32_t index_type = 0;                             // last SetIndexType
-    uint32_t num_instances = 1;                          // last SetNumInstances (hardware default)
+    uint32_t num_instances = 1;                          // default before SetNumInstances; zero discards
     // Gen5 indexed-draw binding state (issue #232, DOLL/UE4 geometry). SetIndexBuffer/SetIndexCount
     // set these; DrawIndexOffset consumes them to emit an indexed Draw. Persist across draws within a
     // submit (as on hardware) until re-set.

--- a/prosper/src/gpu/command_processor.hpp
+++ b/prosper/src/gpu/command_processor.hpp
@@ -24,6 +24,7 @@ struct ShaderReg { uint32_t offset; uint32_t value; };
 struct GpuState {
     std::unordered_map<uint32_t, uint32_t> cx, sh, uc;   // register files by offset
     uint32_t index_type = 0;                             // last SetIndexType
+    uint32_t num_instances = 1;                          // last SetNumInstances (hardware default)
     // Gen5 indexed-draw binding state (issue #232, DOLL/UE4 geometry). SetIndexBuffer/SetIndexCount
     // set these; DrawIndexOffset consumes them to emit an indexed Draw. Persist across draws within a
     // submit (as on hardware) until re-set.
@@ -43,6 +44,7 @@ struct GpuState {
     // 1 = 32-bit). The executor fetches the index data and renders with vkCmdDrawIndexed (#64).
     struct Draw {
         uint32_t index_count;
+        uint32_t instance_count = 1;
         std::shared_ptr<const GpuState> state;
         bool     indexed = false;
         uint64_t index_addr = 0;

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -37,7 +37,7 @@ namespace prosper::gpu {
 namespace {
 
 constexpr char kMagic[8] = {'P','R','G','P','C','A','P','\0'};
-constexpr uint32_t kVersion = 19;
+constexpr uint32_t kVersion = 20;
 constexpr uint32_t kEndian = 0x01020304u;
 constexpr uint64_t kMaxFileBytes = 4ull << 30;
 constexpr uint64_t kMaxBlobBytes = 1ull << 30;
@@ -935,6 +935,7 @@ bool capture_submit_items(const std::vector<DrawItem>& draws,
     for (const auto& d : draws) {
         GpuCapturedDraw c; c.vs = d.vs; c.gs = d.gs; c.fs = d.fs;
         c.ps = d.ps; c.vertex_count = d.vertex_count;
+        c.instance_count = d.instance_count;
         c.indices = d.indices; c.color0_base = d.color0_base;
         c.color0_width = d.color0_width; c.color0_height = d.color0_height;
         c.color1_base = d.color1_base;
@@ -1438,6 +1439,10 @@ bool serialize_gpu_capture(const GpuCaptureFile& c, std::vector<uint8_t>& bytes,
         w.u32(draw.vs_raw_shader_index);
         w.u32(draw.fs_raw_shader_index);
     }
+    // v20 retains the hardware instance count per realized draw. Older captures default to one,
+    // matching the command-processor and Vulkan defaults before IT_NUM_INSTANCES was consumed.
+    w.u32(static_cast<uint32_t>(c.draws.size()));
+    for (const auto& draw : c.draws) w.u32(draw.instance_count);
     if (w.data.size() > kMaxFileBytes) { error = "capture file exceeds 4 GiB"; return false; }
     bytes = std::move(w.data);
     return true;
@@ -1930,6 +1935,14 @@ bool deserialize_gpu_capture(const std::vector<uint8_t>& bytes, GpuCaptureFile& 
             if (!r.u32(draw.vs_raw_shader_index) || !r.u32(draw.fs_raw_shader_index))
                 return false;
     }
+    if (version >= 20) {
+        uint32_t draw_count = 0;
+        if (!r.u32(draw_count) || draw_count != c.draws.size()) {
+            error = "invalid draw instance-count state count"; return false;
+        }
+        for (auto& draw : c.draws)
+            if (!r.u32(draw.instance_count)) return false;
+    }
     if (version >= 7 && !validate_failure_diagnostics(c, error)) return false;
     if (r.left) { error = "capture has trailing data"; return false; }
     return true;
@@ -2002,6 +2015,7 @@ bool materialize_gpu_replay(const GpuCaptureFile& c, GpuReplayFrame& out, std::s
     for (const auto& x : c.draws) {
         DrawItem d; d.vs = x.vs; d.gs = x.gs; d.fs = x.fs;
         d.ps = x.ps; d.vertex_count = x.vertex_count;
+        d.instance_count = x.instance_count;
         d.indices = x.indices; d.color0_base = x.color0_base;
         d.color0_width = x.color0_width; d.color0_height = x.color0_height;
         d.color1_base = x.color1_base;

--- a/prosper/src/gpu/gpu_capture.hpp
+++ b/prosper/src/gpu/gpu_capture.hpp
@@ -66,6 +66,7 @@ struct GpuCapturedDraw {
     GpuCapturedTable vrt;
     GpuCapturedTable prt;
     uint32_t vertex_count = 3;
+    uint32_t instance_count = 1;
     std::vector<uint32_t> indices;
     uint64_t color0_base = 0;
     uint32_t color0_width = 0, color0_height = 0;

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -52,6 +52,7 @@ struct DrawItem {
     ResolvedPipelineState ps;                         // THIS draw's fixed-function state
     std::shared_ptr<ShaderResourceTable> vrt, prt;    // may be null
     uint32_t vertex_count = 3;
+    uint32_t instance_count = 1;
     // Indexed draw (sceAgcDcbDrawIndex): the guest index buffer, fetched from 1:1-mapped memory and
     // widened to 32-bit. Non-empty -> the backend must render with vkCmdDrawIndexed (gl_VertexIndex
     // then IS the fetched index, which the recompiled VS uses for its storage-buffer vertex fetch);
@@ -969,6 +970,9 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
     out.vs_guest_addr = rs.es_addr; out.fs_guest_addr = rs.ps_addr;
     out.vs_identity = vs_identity; out.fs_identity = fs_identity; out.ps = ps;
     out.vrt = std::move(vrt); out.prt = std::move(prt); out.vertex_count = vertex_count;
+    // The draw record is authoritative even in folded mode: register state may change after the
+    // last draw, while IT_NUM_INSTANCES belongs to the draw at the moment it executes.
+    out.instance_count = draw ? draw->instance_count : ds.num_instances;
     out.color0_base = rs.color0_base;   // render-to-texture: the target this draw writes into (#167)
     out.color0_width = rs.color0_width; out.color0_height = rs.color0_height; // per-target extent (#526)
     out.color1_base = rs.color1_base;

--- a/prosper/src/gpu/pm4_decode.cpp
+++ b/prosper/src/gpu/pm4_decode.cpp
@@ -46,6 +46,9 @@ size_t decode_pm4(const uint32_t* buf, size_t dwords, std::vector<Pm4Command>& o
         if (c.op == IT_INDEX_TYPE) {
             c.kind = K::SetIndexType;
             if (npl >= 1) c.index_size = pl[0];
+        } else if (c.op == IT_NUM_INSTANCES) {
+            c.kind = K::SetNumInstances;
+            if (npl >= 1) c.instance_count = pl[0];
         } else if (c.op == IT_EVENT_WRITE) {
             c.kind = K::EventWrite;
             if (npl >= 1) c.event_type = pl[0] & 0xffu;

--- a/prosper/src/gpu/pm4_decode.hpp
+++ b/prosper/src/gpu/pm4_decode.hpp
@@ -17,7 +17,7 @@ namespace prosper::gpu {
 
 // IT_* opcodes and the R_* sub-opcodes carried inside IT_NOP (mirror hle_agc.cpp).
 enum : uint32_t {
-    IT_NOP = 0x10, IT_INDEX_TYPE = 0x2A, IT_EVENT_WRITE = 0x46,
+    IT_NOP = 0x10, IT_INDEX_TYPE = 0x2A, IT_NUM_INSTANCES = 0x2F, IT_EVENT_WRITE = 0x46,
     IT_SET_CONTEXT_REG = 0x69, IT_SET_SH_REG = 0x76, IT_SET_UCONFIG_REG = 0x79,
 };
 enum : uint32_t {
@@ -49,6 +49,7 @@ enum class RegClass { Cx, Sh, Uc };
 struct Pm4Command {
     enum class Kind {
         DrawReset, WaitFlipDone, PushMarker, PopMarker, SetRegDirect, SetRegsIndirect, SetIndexType,
+        SetNumInstances,
         DrawIndex, DrawIndexAuto, EventWrite, AcquireMem, WriteData, WaitRegMem, Flip, ReleaseMem,
         DispatchDirect, SetIndexBase, SetIndexCount, DrawIndexOffset, Jump, SetPredication,
         DmaData, Unknown,
@@ -69,6 +70,7 @@ struct Pm4Command {
     uint64_t regs_vaddr = 0;             // SetRegsIndirect: guest addr of the register array
     uint32_t index_count = 0;            // DrawIndexAuto / DrawIndex
     uint32_t index_size = 0;             // SetIndexType
+    uint32_t instance_count = 1;         // SetNumInstances
 
     // CbDispatch (sceAgcCbDispatch -> R_DISPATCH_DIRECT, hle_agc.cpp). This is a prosper custom
     // packet, not raw hardware DISPATCH_DIRECT: payload [0..2] retains raw API dimensions x/y/z.

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -1283,6 +1283,7 @@ HLE(agc_driver_submit_dcb) {  // (const Packet* packet)
                 case K::SetRegDirect:    return "SetRegDirect";
                 case K::SetRegsIndirect: return "SetRegsIndirect";
                 case K::SetIndexType:    return "SetIndexType";
+                case K::SetNumInstances: return "SetNumInstances";
                 case K::DrawIndex:       return "DrawIndex";
                 case K::DrawIndexAuto:   return "DrawIndexAuto";
                 case K::EventWrite:      return "EventWrite";

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -161,7 +161,8 @@ inline BackendColorTargetStats backend_color_target_stats() {
 // When `tex` is non-null, its RGBA8 texels are uploaded to a sampled VkImage and bound as a combined
 // image sampler at tex->binding — how a recompiled pixel shader's image_sample reaches a real texture.
 // One draw for the multi-draw backend: recompiled VS+PS SPIR-V, its resolved fixed-function state, its
-// set-tagged resources, and its vertex count. render_draws_rgba records ALL of a submit's draws into ONE
+// set-tagged resources, vertex count, and instance count. render_draws_rgba records ALL of a submit's
+// draws into ONE
 // render pass (clear once, then per-draw pipeline+descriptors+draw) so a multi-draw frame composites
 // correctly. render_triangle_rgba is a thin single-draw wrapper (below).
 struct BackendDraw {
@@ -170,10 +171,11 @@ struct BackendDraw {
     const prosper::gpu::ResolvedPipelineState* ps = nullptr;   // null -> triangle-list, write RGBA, no depth
     std::vector<FrameResource> R;                              // set-tagged resources (empty -> no descriptors)
     uint32_t vcount = 3;
+    uint32_t instance_count = 1;
     // Indexed draw: 32-bit index data (the executor widens guest 16-bit indices). Non-empty -> the draw
     // is recorded as vkCmdBindIndexBuffer + vkCmdDrawIndexed(indices.size()), so gl_VertexIndex is the
     // fetched index — exactly what the recompiled VS's storage-buffer vertex fetch expects. Empty ->
-    // plain vkCmdDraw(vcount).
+    // plain vkCmdDraw(vcount). Both paths preserve instance_count.
     std::vector<uint32_t> indices;
 };
 
@@ -1664,7 +1666,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         VkPipelineLayout layout = VK_NULL_HANDLE; VkPipeline pipe = VK_NULL_HANDLE;
         VkBuffer ibuf = VK_NULL_HANDLE; VkDeviceMemory ibmem = VK_NULL_HANDLE;   // index buffer (indexed draws)
         VkRect2D scissor{};
-        uint32_t n_sets = 1, vcount = 3, icount = 0;
+        uint32_t n_sets = 1, vcount = 3, icount = 0, instance_count = 1;
         bool use_desc = false, ok = false, pipeline_cached = false;
     };
     struct TextureUploadKey {
@@ -1970,6 +1972,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         const auto setup_shaders_ready = setup_begin;
         const prosper::gpu::ResolvedPipelineState* ps = bd.ps;
         v.vcount = bd.vcount;
+        v.instance_count = bd.instance_count;
         v.scissor = {{0, 0}, {W, H}};
         if (ps && ps->has_scissor) {
             const int64_t left = std::clamp<int64_t>(ps->scissor_left, 0, W);
@@ -2904,9 +2907,9 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         if (v.use_desc) vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, v.layout, 0, v.n_sets, v.dsets.data(), 0, nullptr);
         if (v.icount) {
             vkCmdBindIndexBuffer(cmd, v.ibuf, 0, VK_INDEX_TYPE_UINT32);
-            vkCmdDrawIndexed(cmd, v.icount, 1, 0, 0, 0);
+            vkCmdDrawIndexed(cmd, v.icount, v.instance_count, 0, 0, 0);
         } else {
-            vkCmdDraw(cmd, v.vcount, 1, 0, 0);
+            vkCmdDraw(cmd, v.vcount, v.instance_count, 0, 0);
         }
     }
     vkCmdEndRenderPass(cmd);
@@ -3039,8 +3042,8 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                 for (size_t di = 0; di < dv.size(); di++) { auto& v = dv[di]; if (!v.ok) continue; if ((int)di == kk) continue;
                     vkCmdBindPipeline(c2, VK_PIPELINE_BIND_POINT_GRAPHICS, v.pipe);
                     if (v.use_desc) vkCmdBindDescriptorSets(c2, VK_PIPELINE_BIND_POINT_GRAPHICS, v.layout, 0, v.n_sets, v.dsets.data(), 0, nullptr);
-                    if (v.icount) { vkCmdBindIndexBuffer(c2, v.ibuf, 0, VK_INDEX_TYPE_UINT32); vkCmdDrawIndexed(c2, v.icount, 1, 0, 0, 0); }
-                    else vkCmdDraw(c2, v.vcount, 1, 0, 0);
+                    if (v.icount) { vkCmdBindIndexBuffer(c2, v.ibuf, 0, VK_INDEX_TYPE_UINT32); vkCmdDrawIndexed(c2, v.icount, v.instance_count, 0, 0, 0); }
+                    else vkCmdDraw(c2, v.vcount, v.instance_count, 0, 0);
                 }
                 vkCmdEndRenderPass(c2);
                 vkCmdCopyImageToBuffer(c2, img, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, rb, 1, &cp2);

--- a/prosper/tests/test_command_processor.cpp
+++ b/prosper/tests/test_command_processor.cpp
@@ -41,13 +41,14 @@ int main() {
     auto setcx = Hle::lookup("ZvwO9euwYzc");   // SetCxRegistersIndirect
     auto setsh = Hle::lookup("-HOOCn0JY48");   // SetShRegistersIndirect
     auto draw  = Hle::lookup("Yw0jKSqop+E");   // DrawIndexAuto
+    auto instances = Hle::lookup("tSBxhAPyytQ"); // SetNumInstances
     auto dispatch = Hle::lookup("k3GhuSNmBLU"); // DispatchDirect
     auto setcx_direct = Hle::lookup("LHFXRrlTPD8"); // SetCxRegisterDirect (#395 F5)
     auto setsh_direct = Hle::lookup("pFLArOT53+w"); // SetShRegisterDirect (#395 F5)
     auto setuc_direct = Hle::lookup("w4-d0n60hdo"); // SetUcRegisterDirect (#395 F5)
-    CHECK(reset && idx && setcx && setsh && draw && dispatch &&
+    CHECK(reset && idx && setcx && setsh && draw && instances && dispatch &&
           setcx_direct && setsh_direct && setuc_direct, "AGC Dcb builders registered");
-    if (!(reset && idx && setcx && setsh && draw && dispatch &&
+    if (!(reset && idx && setcx && setsh && draw && instances && dispatch &&
           setcx_direct && setsh_direct && setuc_direct)) { printf("== FAIL ==\n"); return 1; }
 
     uint32_t buffer[256];
@@ -71,7 +72,9 @@ int main() {
     setcx_direct(D, pack_reg(0xA318u, 0xCCCCCCCCu), 0, 0, 0, 0);
     setsh_direct(D, pack_reg(0x2C0Du, 0xDDDDDDDDu), 0, 0, 0, 0);
     setuc_direct(D, pack_reg(0x0123u, 0xEEEEEEEEu), 0, 0, 0, 0);
+    instances(D, 3, 0, 0, 0, 0);
     draw(D, 0x0300, 0, 0, 0, 0);
+    instances(D, 0, 0, 0, 0, 0);
     draw(D, 0x0006, 0, 0, 0, 0);
 
     GpuState st;
@@ -98,6 +101,12 @@ int main() {
     CHECK(st.draws.size() == 2, "2 draws recorded");
     CHECK(st.draws.size() == 2 && st.draws[0].index_count == 0x0300, "draw0 index_count = 0x300");
     CHECK(st.draws.size() == 2 && st.draws[1].index_count == 0x0006, "draw1 index_count = 0x6");
+    CHECK(st.draws.size() == 2 && st.draws[0].instance_count == 3 && st.draws[0].state &&
+              st.draws[0].state->num_instances == 3,
+          "draw0 record and snapshot retain SetNumInstances(3)");
+    CHECK(st.draws.size() == 2 && st.draws[1].instance_count == 1 && st.draws[1].state &&
+              st.draws[1].state->num_instances == 1,
+          "draw1 normalizes SetNumInstances(0) to the single-instance default");
 
     // SET_SH_REG (IT_SET_SH_REG=0x76) sets a RANGE: payload[0]=start offset, payload[1..]=consecutive
     // values. The driver uploads the whole user-data descriptor block this way, so the decode+apply MUST

--- a/prosper/tests/test_command_processor.cpp
+++ b/prosper/tests/test_command_processor.cpp
@@ -104,9 +104,9 @@ int main() {
     CHECK(st.draws.size() == 2 && st.draws[0].instance_count == 3 && st.draws[0].state &&
               st.draws[0].state->num_instances == 3,
           "draw0 record and snapshot retain SetNumInstances(3)");
-    CHECK(st.draws.size() == 2 && st.draws[1].instance_count == 1 && st.draws[1].state &&
-              st.draws[1].state->num_instances == 1,
-          "draw1 normalizes SetNumInstances(0) to the single-instance default");
+    CHECK(st.draws.size() == 2 && st.draws[1].instance_count == 0 && st.draws[1].state &&
+              st.draws[1].state->num_instances == 0,
+          "draw1 retains SetNumInstances(0) as a zero-instance no-op");
 
     // SET_SH_REG (IT_SET_SH_REG=0x76) sets a RANGE: payload[0]=start offset, payload[1..]=consecutive
     // values. The driver uploads the whole user-data descriptor block this way, so the decode+apply MUST

--- a/prosper/tests/test_gpu_capture.cpp
+++ b/prosper/tests/test_gpu_capture.cpp
@@ -79,7 +79,8 @@ int main() {
     DrawItem draw; draw.vs = {0x07230203, 1, 2}; draw.fs = {0x07230203, 3}; draw.vrt = table;
     draw.vs_guest_addr = reinterpret_cast<uint64_t>(kDiagnosticVs);
     draw.fs_guest_addr = reinterpret_cast<uint64_t>(kDiagnosticBadPs);
-    draw.vertex_count = 6; draw.indices = {0, 1, 2, 2, 3, 0}; draw.color0_base = 0x2000;
+    draw.vertex_count = 6; draw.instance_count = 3;
+    draw.indices = {0, 1, 2, 2, 3, 0}; draw.color0_base = 0x2000;
     draw.color0_width = 1024; draw.color0_height = 32;
     draw.color1_base = 0x3000; draw.color1_width = 1024; draw.color1_height = 32;
     draw.draw_index = 7; draw.command_order = 123;
@@ -131,6 +132,8 @@ int main() {
     CHECK(captured.shader_versions.size() == 2 && captured.operations.size() == 1 &&
           captured.operations[0].source_index == 7 && captured.operations[0].realized,
           "capture indexes unique shaders and retains operation provenance");
+    CHECK(captured.draws.size() == 1 && captured.draws[0].instance_count == 3,
+          "capture retains the realized draw instance count");
     CHECK(captured.raw_shader_versions.size() == 2 &&
           captured.draws[0].vs_raw_shader_index < captured.raw_shader_versions.size() &&
           captured.draws[0].fs_raw_shader_index < captured.raw_shader_versions.size() &&
@@ -177,8 +180,9 @@ int main() {
               scalar_capture.computes[0].resources.resources.empty(),
           "#636: capture ignores unconsumed descriptor-looking scalar arguments");
 
-    // v17 appends scissor state without changing the legacy pipeline prefix. Remove v19's realized
-    // raw-stage indices, v18's geometry index, then the v17 tail to recover a byte-exact v16 capture.
+    // v17 appends scissor state without changing the legacy pipeline prefix. Remove v20's instance
+    // count, v19's realized raw-stage indices, v18's geometry index, then the v17 tail to recover a
+    // byte-exact v16 capture.
     GpuCaptureFile v16_scissor_source = captured;
     v16_scissor_source.raw_shader_versions.clear();
     v16_scissor_source.draws[0].vs_raw_shader_index = 0xFFFFFFFFu;
@@ -189,6 +193,7 @@ int main() {
               v16_scissor_bytes.size() >= 25,
           "v17 capture serializes effective guest scissor state");
     if (v16_scissor_bytes.size() >= 25) {
+        v16_scissor_bytes.resize(v16_scissor_bytes.size() - 8); // v20 draw count + instance count
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - 12); // v19 count + two raw indices
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - 8); // v18 draw count + no-GS sentinel
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - 25);
@@ -332,6 +337,7 @@ int main() {
           "writer rejects an out-of-bounds DCC metadata reference");
     CHECK(serialize_gpu_capture(volume_capture, volume_bytes, error),
           "recreated valid v12 DCC bytes after malformed-reference check");
+    volume_bytes.resize(volume_bytes.size() - 8); // v20 draw count + instance count
     volume_bytes.resize(volume_bytes.size() - 12); // v19 count + two raw indices
     volume_bytes.resize(volume_bytes.size() - 8); // v18 draw count + no-GS sentinel
     volume_bytes.resize(volume_bytes.size() - 25); // v17 one-draw scissor tail, zero failures
@@ -393,6 +399,17 @@ int main() {
     CHECK(write_gpu_capture(path.string(), captured, error), "versioned capture writes atomically");
     GpuCaptureFile loaded;
     CHECK(read_gpu_capture(path.string(), loaded, error), "versioned capture reads back");
+    std::vector<uint8_t> v19_bytes;
+    GpuCaptureFile v19_loaded;
+    CHECK(serialize_gpu_capture(captured, v19_bytes, error) && v19_bytes.size() >= 12,
+          "v20 capture serializes the instance-count extension");
+    if (v19_bytes.size() >= 12) {
+        v19_bytes.resize(v19_bytes.size() - 8); // v20 draw count + one instance count
+        v19_bytes[8] = 19; v19_bytes[9] = v19_bytes[10] = v19_bytes[11] = 0;
+    }
+    CHECK(deserialize_gpu_capture(v19_bytes, v19_loaded, error) &&
+              v19_loaded.draws[0].instance_count == 1,
+          "v19 capture reopens with the historical one-instance default");
     CHECK(loaded.metadata.submit_index == 42 && loaded.metadata.title_id == "PPSA24651" &&
           loaded.metadata.renderer_env.size() == 2 && loaded.metadata.renderer_env[0].first == "PROSPER_RTT_PERTARGET" &&
           loaded.draws.size() == 1 && loaded.draws[0].indices.size() == 6, "metadata and draw data round-trip");
@@ -423,6 +440,8 @@ int main() {
     CHECK(loaded.shader_versions.size() == 2 && loaded.draws[0].draw_index == 7 &&
           loaded.draws[0].command_order == 123 && loaded.operations[0].source_index == 7,
           "content versions and draw operation identity round-trip");
+    CHECK(loaded.draws[0].instance_count == 3,
+          "v20 realized draw instance count round-trips");
     CHECK(loaded.raw_shader_versions.size() == 2 &&
           loaded.draws[0].vs_raw_shader_index < loaded.raw_shader_versions.size() &&
           loaded.draws[0].fs_raw_shader_index < loaded.raw_shader_versions.size(),
@@ -477,6 +496,8 @@ int main() {
           "an empty renderer result does not become a valid replay oracle");
     CHECK(replay.items[0].draw_index == 7 && replay.items[0].command_order == 123,
           "materialized draw retains its source operation identity");
+    CHECK(replay.items[0].instance_count == 3,
+          "materialized replay retains the draw instance count");
     CHECK(replay.items[0].vs_raw_shader_index == loaded.draws[0].vs_raw_shader_index &&
           replay.items[0].fs_raw_shader_index == loaded.draws[0].fs_raw_shader_index,
           "materialized replay exposes both realized raw-stage identities");
@@ -752,11 +773,12 @@ int main() {
     legacy_source.draws[0].fs_raw_shader_index = 0xFFFFFFFFu;
     std::vector<uint8_t> legacy_bytes;
     CHECK(serialize_gpu_capture(legacy_source, legacy_bytes, error) && legacy_bytes.size() >= 32,
-          "created a diagnostic-free v19 payload for legacy-reader fixtures");
+          "created a diagnostic-free v20 payload for legacy-reader fixtures");
     std::vector<uint8_t> v13_bytes = legacy_bytes;
     if (v13_bytes.size() >= 32) {
         const size_t legacy_resource_count = legacy_source.draws[0].vrt.resources.size() +
                                              legacy_source.draws[0].prt.resources.size();
+        v13_bytes.resize(v13_bytes.size() - 8); // v20 draw count + instance count
         v13_bytes.resize(v13_bytes.size() - 12); // v19 count + two raw indices
         v13_bytes.resize(v13_bytes.size() - 8); // v18 draw count + no-GS sentinel
         v13_bytes.resize(v13_bytes.size() - 25); // v17 one-draw scissor tail, zero failures
@@ -776,6 +798,7 @@ int main() {
     if (legacy_bytes.size() >= 32) {
         const size_t legacy_resource_count = legacy_source.draws[0].vrt.resources.size() +
                                              legacy_source.draws[0].prt.resources.size();
+        legacy_bytes.resize(legacy_bytes.size() - 8); // v20 draw count + instance count
         legacy_bytes.resize(legacy_bytes.size() - 12); // v19 count + two raw indices
         legacy_bytes.resize(legacy_bytes.size() - 8); // v18 draw count + no-GS sentinel
         legacy_bytes.resize(legacy_bytes.size() - 25); // v17 one-draw scissor tail, zero failures
@@ -821,9 +844,9 @@ int main() {
     CHECK(deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
           !legacy_loaded.failure_diagnostics_available && legacy_loaded.failure_diagnostics.empty(),
           "v6 capture reopens with failed-operation diagnostics reported unavailable");
-    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 20;
+    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 21;
     CHECK(!deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
-          error == "unsupported capture version 20",
+          error == "unsupported capture version 21",
           "future capture versions fail with a concrete version error");
 
     GpuCaptureFile bad_hash = mixed;

--- a/prosper/tests/test_gpu_execute.cpp
+++ b/prosper/tests/test_gpu_execute.cpp
@@ -49,7 +49,12 @@ int main() {
     set_pgm(st, P::SPI_SHADER_PGM_LO_PS, P::SPI_SHADER_PGM_HI_PS, kPs);
     st.uc[P::VGT_PRIMITIVE_TYPE] = 4;     // triangle list
     st.cx[P::CB_TARGET_MASK]     = 0xF;   // write RGBA
-    st.draws.push_back({3});
+    st.num_instances = 4;
+    GpuState::Draw source_draw;
+    source_draw.index_count = 3;
+    source_draw.instance_count = 4;
+    st.draws.push_back(source_draw);
+    st.num_instances = 0; // later state must not rewrite the already-recorded draw in folded mode
 
     // The executor core, with the offscreen Vulkan renderer supplied as the backend (as the HLE will
     // supply the live-device renderer). execute_gpustate does recompile + resolve + render internally.
@@ -69,6 +74,8 @@ int main() {
     uint32_t green = 0, total = 0;
     for (uint32_t y : {0u, H/2, H-1}) for (uint32_t x : {0u, W/2, W-1}) { total++; if (isGreen(x, y)) green++; }
     CHECK(green == total, "GpuState -> executor -> GREEN frame (full recompile+resolve+render spine)");
+    CHECK(realized_draw.instance_count == 4,
+          "draw realization retains the folded hardware instance count");
 
     // DCC_DECOMPRESS binds a graphics helper whose color export is interpreted by the hardware as a
     // metadata operation. Prosper stores only materialized Vulkan color, so realization substitutes

--- a/prosper/tests/test_multidraw_render.cpp
+++ b/prosper/tests/test_multidraw_render.cpp
@@ -98,14 +98,25 @@ int main() {
     {
         prosper::test::BackendDraw one;
         one.vs = vs; one.fs = quarter_red; one.ps = &additive; one.vcount = 3;
+        prosper::test::BackendDraw zero = one; zero.instance_count = 0;
+        prosper::test::BackendDraw zero_indexed = zero; zero_indexed.indices = {0, 1, 2};
         prosper::test::BackendDraw three = one; three.instance_count = 3;
         prosper::test::BackendDraw three_indexed = three; three_indexed.indices = {0, 1, 2};
+        const std::vector<uint8_t> px_zero = prosper::test::render_draws_rgba({zero}, W, H);
+        const std::vector<uint8_t> px_zero_indexed =
+            prosper::test::render_draws_rgba({zero_indexed}, W, H);
         const std::vector<uint8_t> px_one = prosper::test::render_draws_rgba({one}, W, H);
         const std::vector<uint8_t> px_three = prosper::test::render_draws_rgba({three}, W, H);
         const std::vector<uint8_t> px_three_indexed =
             prosper::test::render_draws_rgba({three_indexed}, W, H);
+        const uint8_t* zero_center = center(px_zero);
         const uint8_t* one_center = center(px_one);
         const uint8_t* three_center = center(px_three);
+        CHECK(zero_center && zero_center[0] < 0x40 && zero_center[1] < 0x40 &&
+                  zero_center[2] > 0xC0,
+              "zero non-indexed instances leave the blue clear untouched");
+        CHECK(!px_zero.empty() && px_zero_indexed == px_zero,
+              "zero indexed instances are the same no-op");
         CHECK(one_center && one_center[0] >= 48 && one_center[0] <= 80,
               "one additive quarter-red instance contributes one layer");
         CHECK(three_center && one_center && three_center[0] >= one_center[0] + 96 &&

--- a/prosper/tests/test_multidraw_render.cpp
+++ b/prosper/tests/test_multidraw_render.cpp
@@ -60,9 +60,16 @@ int main() {
     // EXP mrt0). Inline consts: 0xF2 = 1.0f, 0x80 = 0.0f.  RED = (1,0,0,1)  GREEN = (0,1,0,1).
     static const uint32_t kRedPs[]   = {0x7E0002F2u, 0x7E020280u, 0x7E040280u, 0x7E0602F2u, 0xF800180Fu, 0x03020100u, 0xBF810000u};
     static const uint32_t kGreenPs[] = {0x7E000280u, 0x7E0202F2u, 0x7E040280u, 0x7E0602F2u, 0xF800180Fu, 0x03020100u, 0xBF810000u};
+    static const uint32_t kQuarterRedPs[] = {
+        0x7E0002FFu, 0x3E800000u, 0x7E020280u, 0x7E040280u, 0x7E0602F2u,
+        0xF800180Fu, 0x03020100u, 0xBF810000u,
+    };
     std::vector<uint32_t> red   = recompile_fragment(kRedPs,   sizeof(kRedPs)   / 4, nullptr);
     std::vector<uint32_t> green = recompile_fragment(kGreenPs, sizeof(kGreenPs) / 4, nullptr);
-    CHECK(!vs.empty() && !red.empty() && !green.empty(), "fullscreen VS + red/green PS available");
+    std::vector<uint32_t> quarter_red = recompile_fragment(
+        kQuarterRedPs, sizeof(kQuarterRedPs) / 4, nullptr);
+    CHECK(!vs.empty() && !red.empty() && !green.empty() && !quarter_red.empty(),
+          "fullscreen VS + red/green/quarter-red PS available");
 
     ResolvedPipelineState opaque{};
     opaque.topology = 3 /*VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST*/; opaque.color_write_mask = 0xF;
@@ -83,6 +90,29 @@ int main() {
         CHECK(px.size() == (size_t)W * H * 4, "single-draw path rendered a frame");
         const uint8_t* c = center(px);
         if (c) CHECK(c[0] > 0xC0 && c[1] < 0x40 && c[2] < 0x40, "one opaque red draw -> RED center");
+    }
+
+    // Hardware instance count reaches both Vulkan submission paths. Additive quarter-red makes the
+    // number of identical instances directly observable: one instance contributes ~64 red, while
+    // three contribute ~192. The indexed sibling must produce the same pixels.
+    {
+        prosper::test::BackendDraw one;
+        one.vs = vs; one.fs = quarter_red; one.ps = &additive; one.vcount = 3;
+        prosper::test::BackendDraw three = one; three.instance_count = 3;
+        prosper::test::BackendDraw three_indexed = three; three_indexed.indices = {0, 1, 2};
+        const std::vector<uint8_t> px_one = prosper::test::render_draws_rgba({one}, W, H);
+        const std::vector<uint8_t> px_three = prosper::test::render_draws_rgba({three}, W, H);
+        const std::vector<uint8_t> px_three_indexed =
+            prosper::test::render_draws_rgba({three_indexed}, W, H);
+        const uint8_t* one_center = center(px_one);
+        const uint8_t* three_center = center(px_three);
+        CHECK(one_center && one_center[0] >= 48 && one_center[0] <= 80,
+              "one additive quarter-red instance contributes one layer");
+        CHECK(three_center && one_center && three_center[0] >= one_center[0] + 96 &&
+                  three_center[0] >= 160 && three_center[0] <= 224,
+              "three non-indexed instances contribute three additive layers");
+        CHECK(!px_three.empty() && px_three_indexed == px_three,
+              "indexed and non-indexed Vulkan draws consume the same instance count");
     }
 
     // Red opaque THEN green additive, in one submit -> yellow center (both composited into one target).

--- a/prosper/tests/test_pm4_decode.cpp
+++ b/prosper/tests/test_pm4_decode.cpp
@@ -37,13 +37,14 @@ int main() {
     auto evt   = Hle::lookup("aJf+j5yntiU");   // EventWrite
     auto push  = Hle::lookup("+kSrjIVxKFE");   // PushMarker (#641)
     auto pop   = Hle::lookup("H7uZqCoNuWk");   // PopMarker (#641)
+    auto instances = Hle::lookup("tSBxhAPyytQ"); // SetNumInstances
     auto setcx_direct = Hle::lookup("LHFXRrlTPD8"); // SetCxRegisterDirect (#395 F5)
     auto setsh_direct = Hle::lookup("pFLArOT53+w"); // SetShRegisterDirect (#395 F5)
     auto setuc_direct = Hle::lookup("w4-d0n60hdo"); // SetUcRegisterDirect (#395 F5)
-    CHECK(reset && idx && setcx && p_add && p_adr && draw && drawi && evt && push && pop &&
+    CHECK(reset && idx && setcx && p_add && p_adr && draw && drawi && evt && push && pop && instances &&
           setcx_direct && setsh_direct && setuc_direct,
           "AGC Dcb builders registered");
-    if (!(reset && idx && setcx && p_add && p_adr && draw && drawi && evt && push && pop &&
+    if (!(reset && idx && setcx && p_add && p_adr && draw && drawi && evt && push && pop && instances &&
           setcx_direct && setsh_direct && setuc_direct)) {
         printf("== FAIL ==\n"); return 1;
     }
@@ -68,6 +69,7 @@ int main() {
     setcx_direct(D, pack_reg(0x100, 0x11111111), 0, 0, 0, 0);
     setsh_direct(D, pack_reg(0x200, 0x22222222), 0, 0, 0, 0);
     setuc_direct(D, pack_reg(0x300, 0x33333333), 0, 0, 0, 0);
+    instances(D, 7, 0, 0, 0, 0);
     draw(D, /*index_count*/ 0x1234, 0, 0, 0, 0);
     drawi(D, /*index_count*/ 0x0600, /*indices*/ 0xDEAD0000BEEF0040ull, /*modifier*/ 0x40000000ull, 0, 0);
     evt(D, /*event_type*/ 0x42, /*address*/ 0x1400ABCD00ull, 0, 0, 0);
@@ -79,8 +81,8 @@ int main() {
     std::vector<Pm4Command> ops;
     size_t consumed = decode_pm4(buffer, 256, ops);   // pass full buffer; decoder stops at the zero tail
     CHECK(consumed == used_dw, "decoder consumed exactly the built dwords (stops at zero pad)");
-    CHECK(ops.size() == 11, "decoded 11 packets");
-    if (ops.size() != 11) { printf("== FAIL: got %zu packets ==\n", ops.size()); return 1; }
+    CHECK(ops.size() == 12, "decoded 12 packets");
+    if (ops.size() != 12) { printf("== FAIL: got %zu packets ==\n", ops.size()); return 1; }
 
     using K = Pm4Command::Kind;
     CHECK(ops[0].kind == K::PushMarker && ops[0].marker_label &&
@@ -108,19 +110,21 @@ int main() {
           ops[6].reg_data && ops[6].reg_data[0] == 0x33333333,
           "op6 = SetUcRegisterDirect(offset/value)");
 
-    CHECK(ops[7].kind == K::DrawIndexAuto && ops[7].index_count == 0x1234, "op7 = DrawIndexAuto(0x1234)");
+    CHECK(ops[7].kind == K::SetNumInstances && ops[7].instance_count == 7,
+          "op7 = SetNumInstances(7)");
+    CHECK(ops[8].kind == K::DrawIndexAuto && ops[8].index_count == 0x1234, "op8 = DrawIndexAuto(0x1234)");
 
     // DrawIndex round-trip (issue #63): the builder wrote [1]=count, [2..3]=index addr, [4..5]=modifier;
     // the decoder must hand every field back (indexed draws were previously dropped as unknown NOPs).
-    CHECK(ops[8].kind == K::DrawIndex && ops[8].index_count == 0x0600, "op8 = DrawIndex(count=0x600)");
-    CHECK(ops[8].di_index_addr == 0xDEAD0000BEEF0040ull, "op8 index-buffer address round-trips");
-    CHECK(ops[8].di_modifier == 0x40000000ull && ops[8].di_valid, "op8 modifier round-trips (valid)");
+    CHECK(ops[9].kind == K::DrawIndex && ops[9].index_count == 0x0600, "op9 = DrawIndex(count=0x600)");
+    CHECK(ops[9].di_index_addr == 0xDEAD0000BEEF0040ull, "op9 index-buffer address round-trips");
+    CHECK(ops[9].di_modifier == 0x40000000ull && ops[9].di_valid, "op9 modifier round-trips (valid)");
 
-    CHECK(ops[9].kind == K::EventWrite && ops[9].event_type == 0x42, "op9 = EventWrite(0x42)");
+    CHECK(ops[10].kind == K::EventWrite && ops[10].event_type == 0x42, "op10 = EventWrite(0x42)");
     // Address-carrying EVENT_WRITE (#132): the widened packet now round-trips its destination
     // address (was discarded, so an address-carrying event lost its write target).
-    CHECK(ops[9].event_addr == 0x1400ABCD00ull, "op9 EventWrite address round-trips (was dropped)");
-    CHECK(ops[10].kind == K::PopMarker, "op10 = PopMarker");
+    CHECK(ops[10].event_addr == 0x1400ABCD00ull, "op10 EventWrite address round-trips (was dropped)");
+    CHECK(ops[11].kind == K::PopMarker, "op11 = PopMarker");
 
     // Every decoded packet's len must match its header, and the payload pointer must be in-buffer.
     bool spans_ok = true;


### PR DESCRIPTION
## Summary
- decode `IT_NUM_INSTANCES` and retain the effective count on each recorded draw
- carry instance counts through realization, capture v20/replay, and both Vulkan draw paths
- preserve an explicit zero packet payload as a hardware no-op while retaining the no-packet default of one
- add command-stream, state, capture, realization, and real Vulkan pixel regressions

Refs #395 (F2 only; the parent issue remains open for its other findings).

## Author checks run before PR
- Linux: `pm4_decode_stream`, `command_processor_apply`, `gpu_capture_roundtrip`, `multidraw_render`, `gpu_execute`
- Windows: `pm4_decode_stream`, `command_processor_apply`, `gpu_capture_roundtrip`
- focused zero-preservation rebuild/retest on Linux and Windows

No live-game run, image snapshot, or graphics-capture workflow was used.
