### PR TITLE
fix(apr): register the direct APR read (vWU-odnS+fU) on Windows (#984)

### DIFF
--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -53,6 +53,11 @@
 #include <cmath>
 #include <chrono>
 #include <thread>
+#include <mutex>
+#include <condition_variable>
+#ifdef _WIN32
+#include <windows.h>
+#endif
 
 using namespace prosper;
 
@@ -351,7 +356,168 @@ void poll_keyboard() {
 
 } // namespace
 
+#ifdef _WIN32
+// PROSPER_WIN_EXIT_TRACE: catch and backtrace whoever terminates the process. The Windows app has
+// exited silently with code 0 during guest bring-up with no logged exit path, no unhandled exception,
+// and no clean shutdown — meaning some thread funnels into ExitProcess/TerminateProcess directly.
+// Inline-hook both (12-byte absolute-jump patch) to print the return-address stack before passing the
+// call through. A terminal function, so re-entrancy on the unpatch/forward is safe.
+namespace {
+uint8_t g_ep_saved[12], g_tp_saved[12];
+void* g_ep_addr = nullptr;
+void* g_tp_addr = nullptr;
+void log_exit_backtrace(const char* who, unsigned code) {
+    fprintf(stderr, "[app] WIN_EXIT_TRACE: %s(code=%u) tid=%lu — backtrace:\n",
+            who, code, (unsigned long)GetCurrentThreadId());
+    void* frames[40]; USHORT n = CaptureStackBackTrace(0, 40, frames, nullptr);
+    HMODULE self = GetModuleHandleW(nullptr);
+    for (USHORT i = 0; i < n; i++) {
+        HMODULE mod = nullptr;
+        GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                           (LPCWSTR)frames[i], &mod);
+        wchar_t name[MAX_PATH] = L"?"; if (mod) GetModuleFileNameW(mod, name, MAX_PATH);
+        const wchar_t* base = wcsrchr(name, L'\\'); base = base ? base + 1 : name;
+        fprintf(stderr, "    [%2u] %p  off=+0x%llx  %ls%s\n", i, frames[i],
+                mod ? (unsigned long long)((uintptr_t)frames[i] - (uintptr_t)mod) : 0ull,
+                base, mod == self ? "  <-- app" : "");
+    }
+    fflush(nullptr);
+}
+void install_exit_trap(const char* dll, const char* fn, void* thunk, uint8_t* saved, void** slot) {
+    HMODULE h = GetModuleHandleA(dll); if (!h) return;
+    void* addr = (void*)GetProcAddress(h, fn); if (!addr) return;
+    *slot = addr;
+    DWORD old; if (!VirtualProtect(addr, 12, PAGE_EXECUTE_READWRITE, &old)) return;
+    memcpy(saved, addr, 12);
+    uint8_t patch[12] = { 0x48, 0xB8 };                 // mov rax, imm64
+    memcpy(patch + 2, &thunk, 8);
+    patch[10] = 0xFF; patch[11] = 0xE0;                 // jmp rax
+    memcpy(addr, patch, 12);
+    VirtualProtect(addr, 12, old, &old);
+    FlushInstructionCache(GetCurrentProcess(), addr, 12);
+}
+[[noreturn]] void WINAPI hook_ExitProcess(UINT code) {
+    log_exit_backtrace("ExitProcess", code);
+    DWORD old; VirtualProtect(g_ep_addr, 12, PAGE_EXECUTE_READWRITE, &old);
+    memcpy(g_ep_addr, g_ep_saved, 12); VirtualProtect(g_ep_addr, 12, old, &old);
+    FlushInstructionCache(GetCurrentProcess(), g_ep_addr, 12);
+    ((decltype(&ExitProcess))g_ep_addr)(code);
+    for (;;) {}
+}
+BOOL WINAPI hook_TerminateProcess(HANDLE proc, UINT code) {
+    if (proc == GetCurrentProcess() || proc == (HANDLE)-1)
+        log_exit_backtrace("TerminateProcess(self)", code);
+    DWORD old; VirtualProtect(g_tp_addr, 12, PAGE_EXECUTE_READWRITE, &old);
+    memcpy(g_tp_addr, g_tp_saved, 12); VirtualProtect(g_tp_addr, 12, old, &old);
+    FlushInstructionCache(GetCurrentProcess(), g_tp_addr, 12);
+    return ((decltype(&TerminateProcess))g_tp_addr)(proc, code);
+}
+// ntdll funnels: kernel32!ExitProcess -> ntdll!RtlExitUserProcess -> ntdll!NtTerminateProcess.
+// Hooking NtTerminateProcess catches ALL termination (including RtlExitUserThread's last-thread path
+// and any code that skips kernel32). Signature: NtTerminateProcess(HANDLE, NTSTATUS).
+uint8_t g_rep_saved[12], g_ntp_saved[12];
+void* g_rep_addr = nullptr;
+void* g_ntp_addr = nullptr;
+[[noreturn]] void WINAPI hook_RtlExitUserProcess(UINT code) {
+    log_exit_backtrace("RtlExitUserProcess", code);
+    DWORD old; VirtualProtect(g_rep_addr, 12, PAGE_EXECUTE_READWRITE, &old);
+    memcpy(g_rep_addr, g_rep_saved, 12); VirtualProtect(g_rep_addr, 12, old, &old);
+    FlushInstructionCache(GetCurrentProcess(), g_rep_addr, 12);
+    ((void(WINAPI*)(UINT))g_rep_addr)(code);
+    for (;;) {}
+}
+LONG WINAPI hook_NtTerminateProcess(HANDLE proc, LONG status) {
+    // proc==NULL terminates the current process (RtlExitUserProcess uses NULL); handle self too.
+    if (proc == nullptr || proc == GetCurrentProcess() || proc == (HANDLE)-1)
+        log_exit_backtrace("NtTerminateProcess", (unsigned)status);
+    DWORD old; VirtualProtect(g_ntp_addr, 12, PAGE_EXECUTE_READWRITE, &old);
+    memcpy(g_ntp_addr, g_ntp_saved, 12); VirtualProtect(g_ntp_addr, 12, old, &old);
+    FlushInstructionCache(GetCurrentProcess(), g_ntp_addr, 12);
+    return ((LONG(WINAPI*)(HANDLE, LONG))g_ntp_addr)(proc, status);
+}
+uint8_t g_ntt_saved[12];
+void* g_ntt_addr = nullptr;
+DWORD g_ntt_ssn = 0;   // NtTerminateThread syscall number (from the original stub's mov eax,imm32)
+// Forward NtTerminateThread via a raw syscall so the inline patch stays permanently installed — a
+// self-termination never returns, so the usual unpatch/call/re-arm loses the hook after the first
+// catch and misses the LAST thread exit (the one that ends the process). Win64 stub is
+// 4C 8B D1 (mov r10,rcx) / B8 ssn (mov eax,ssn) / syscall — ssn lives at saved[4..7].
+LONG WINAPI hook_NtTerminateThread(HANDLE thr, LONG status) {
+    if (thr == nullptr || thr == GetCurrentThread() || thr == (HANDLE)-2)
+        log_exit_backtrace("NtTerminateThread(self)", (unsigned)status);
+    LONG out;
+    __asm__ volatile(
+        "movl %1, %%eax\n\t"
+        "movq %2, %%r10\n\t"
+        "movq %3, %%rdx\n\t"
+        "syscall\n\t"
+        "movl %%eax, %0\n\t"
+        : "=r"(out)
+        : "r"(g_ntt_ssn), "r"(thr), "r"((uint64_t)(int64_t)status)
+        : "rax", "r10", "rdx", "r11", "rcx", "memory");
+    return out;
+}
+void install_win_exit_trace() {
+    install_exit_trap("kernel32.dll", "ExitProcess", (void*)&hook_ExitProcess, g_ep_saved, &g_ep_addr);
+    install_exit_trap("kernel32.dll", "TerminateProcess", (void*)&hook_TerminateProcess, g_tp_saved, &g_tp_addr);
+    install_exit_trap("ntdll.dll", "RtlExitUserProcess", (void*)&hook_RtlExitUserProcess, g_rep_saved, &g_rep_addr);
+    install_exit_trap("ntdll.dll", "NtTerminateProcess", (void*)&hook_NtTerminateProcess, g_ntp_saved, &g_ntp_addr);
+    // NtTerminateThread forwards via a raw syscall (see hook), which needs the stub's syscall number.
+    // Only install this hook if the stub matches the expected 4C 8B D1 / B8 <ssn> form — otherwise a
+    // format mismatch would forward with a wrong number and break every thread exit. Extract from the
+    // live function bytes BEFORE patching, and skip the hook entirely if it doesn't match.
+    if (HMODULE nt = GetModuleHandleA("ntdll.dll")) {
+        if (auto* p = (const uint8_t*)GetProcAddress(nt, "NtTerminateThread")) {
+            if (p[0] == 0x4C && p[1] == 0x8B && p[2] == 0xD1 && p[3] == 0xB8) {
+                g_ntt_ssn = *(const uint32_t*)(p + 4);
+                install_exit_trap("ntdll.dll", "NtTerminateThread", (void*)&hook_NtTerminateThread, g_ntt_saved, &g_ntt_addr);
+            }
+        }
+    }
+    fprintf(stderr, "[app] WIN_EXIT_TRACE installed (EP=%p TP=%p RtlEUP=%p NtTP=%p NtTT=%p ssn=0x%lx)\n",
+            g_ep_addr, g_tp_addr, g_rep_addr, g_ntp_addr, g_ntt_addr, (unsigned long)g_ntt_ssn);
+}
+}  // namespace
+#endif
+
+// Present-layer readiness gate. On Windows, SDL_CreateWindow (with SDL_WINDOW_VULKAN, which loads
+// the NVIDIA Vulkan ICD and creates the HWND) crashes the process to a silent exit(0) when the guest
+// thread runs concurrently — the guest's process-wide vectored exception handler and its large
+// address-space reservations race the window/driver bring-up. Booting the guest only AFTER the whole
+// present layer (window + Vulkan device + swapchain) is up removes the race. The window comes up in a
+// few ms, so the boot delay is negligible. Gated to Windows so Linux/macOS startup is byte-identical.
+namespace {
+std::mutex g_present_ready_mx;
+std::condition_variable g_present_ready_cv;
+bool g_present_ready = false;
+void wait_present_ready() {
+    std::unique_lock<std::mutex> lk(g_present_ready_mx);
+    g_present_ready_cv.wait(lk, [] { return g_present_ready; });
+}
+void signal_present_ready() {
+    { std::lock_guard<std::mutex> lk(g_present_ready_mx); g_present_ready = true; }
+    g_present_ready_cv.notify_all();
+}
+}  // namespace
+
 int main(int argc, char** argv) {
+    // Unbuffered stderr: on Windows the CRT fully buffers stderr when redirected to a file, so an
+    // abrupt process exit (guest exit(), unhandled fault) drops the last diagnostics — exactly the
+    // lines that explain the exit. Line/char buffering keeps the crash tail intact. (Harmless on
+    // POSIX where stderr is already unbuffered.)
+    setvbuf(stderr, nullptr, _IONBF, 0);
+#ifdef _WIN32
+    if (getenv("PROSPER_WIN_EXIT_TRACE")) install_win_exit_trace();
+    SetUnhandledExceptionFilter([](EXCEPTION_POINTERS* ep) -> LONG {
+        fprintf(stderr, "[app] unhandled exception code=0x%08lx rip=0x%llx addr=0x%llx\n",
+                (unsigned long)ep->ExceptionRecord->ExceptionCode,
+                (unsigned long long)(uintptr_t)ep->ExceptionRecord->ExceptionAddress,
+                ep->ExceptionRecord->NumberParameters >= 2
+                    ? (unsigned long long)ep->ExceptionRecord->ExceptionInformation[1] : 0ull);
+        fflush(nullptr);
+        return EXCEPTION_CONTINUE_SEARCH;
+    });
+#endif
     bool testPattern = false; int exitAfter = 0; uint32_t winW = 1280, winH = 720;
     std::string dump;
     for (int i = 1; i < argc; i++) {
@@ -435,6 +601,9 @@ int main(int argc, char** argv) {
         };
         if (!boot_program(dump, prog, &err, install_backends)) { fprintf(stderr, "[app] boot failed: %s\n", err.c_str()); return 1; }
         guestThread = std::thread([]{
+#ifdef _WIN32
+            wait_present_ready();   // don't race SDL_CreateWindow / Vulkan bring-up (silent exit(0))
+#endif
             const BootResult result = run_entry(prog.imgs[0]);
             fprintf(stderr,
                     "[app] guest thread ended: kind=%d detail=%s rip=0x%llx addr=0x%llx "
@@ -499,6 +668,7 @@ int main(int argc, char** argv) {
 
     fprintf(stderr, "[app] window up (%s). Close the window or press Esc to quit.\n",
             testPattern ? "test-pattern" : "waiting for guest frames");
+    signal_present_ready();   // present layer is up: release the guest boot (Windows gate; no-op elsewhere)
 
     // Keyboard controls augment SDL pad 0; the fallback keeps physical pads and their analog state.
     prosper::input::pad_set_backend(&g_keyboard_pad);

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -630,7 +630,13 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             const bool dim_1d = r->img_dim == 0;
             const bool dim_3d = r->img_dim == 2;
             const bool dim_2d_array = r->img_dim == 5 && r->depth_compare;
-            if (!dim_1d && r->img_dim != 1 && !dim_3d && !dim_2d_array) {
+            // A SINGLE-LAYER 2D array (img_dim==5, depth==1, no depth-compare) is byte-identical to a
+            // plain 2D image (one layer, same tiling), so it flows through the 2D path below unchanged.
+            // The general multi-layer/array case stays deferred to #657. DOLL's post-process compute
+            // declares its mask/LUT surfaces this way; skipping them left the tonemap sampling an empty
+            // surface -> a zero mask -> black composite even though the scene renders (#319/#657).
+            const bool dim_2d_single = r->img_dim == 5 && !r->depth_compare && r->depth == 1;
+            if (!dim_1d && r->img_dim != 1 && !dim_3d && !dim_2d_array && !dim_2d_single) {
                 skip_image(r, "layered image deferred to #657"); break;
             }
             if (dim_1d && r->height != 1) { skip_image(r, "1D image has non-unit height"); break; }

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -2099,6 +2099,45 @@ HLE(f_apr_read_direct) {
 }
 // APR completion-token plumbing (hle_kernel_time.cpp) — see the k_apr_submit block in
 // hle_kernel_mem.cpp for the recovered contract.
+#else
+// Windows port of the APR DIRECT read (#984). The POSIX version above uses mmap/pread, so it was
+// only compiled/registered on Linux — leaving vWU-odnS+fU as the unimplemented-stub 0 on Windows.
+// That silently skipped the CreateGlobalShaderMap direct read (GlobalShaderCache-SF_PS5.bin out of
+// pakchunk0), so the shader precache never completed, FAPREventQueueListener blocked on an empty
+// APREventQueue, and the game never reached GPU submission (main spun broadcasting a condvar). Same
+// synchronous whole-range read + guest DMA-write, over stdio + windows_prepare_guest_write. No
+// completion event, matching the Linux path and the #208 listener contract.
+HLE(f_apr_read_direct) {
+    uint64_t id = a0, dst = a1, size = a2, offset = a3;
+    std::string host = prosper_apr_path_for_id((uint32_t)id);
+    if (host.empty()) {
+        if (filelog()) fprintf(stderr, "[apr] read-direct(win): no file for id=%llu\n", (unsigned long long)id);
+        return 0x80020016ull;
+    }
+    uint64_t fsize = 0;
+    { struct _stat64 st{}; if (::_stat64(host.c_str(), &st) == 0) fsize = (uint64_t)st.st_size; }
+    if (offset > fsize) offset = fsize;
+    if (size > fsize - offset) size = fsize - offset;
+    void* slot = ::malloc(size ? (size_t)size : 16);
+    if (!slot) return 0x80020016ull;
+    size_t got = 0;
+    if (size) {
+        FILE* f = ::fopen(host.c_str(), "rb");
+        if (!f) { ::free(slot); return 0x80020016ull; }
+        if (_fseeki64(f, (__int64)offset, SEEK_SET) == 0) got = ::fread(slot, 1, (size_t)size, f);
+        ::fclose(f);
+    }
+    bool ok = (uint64_t)got == size;
+    if (ok && size) {
+        if (windows_prepare_guest_write(dst, size)) memcpy((void*)(uintptr_t)dst, slot, (size_t)size);
+        else ok = false;
+    }
+    ::free(slot);
+    if (filelog()) fprintf(stderr, "[apr] read-direct(win) id=%llu %s -> dst=0x%llx off=0x%llx size=%llu %s\n",
+                           (unsigned long long)id, host.c_str(), (unsigned long long)dst,
+                           (unsigned long long)offset, (unsigned long long)size, ok ? "OK" : "FAIL");
+    return ok ? 0 : 0x80020016ull;
+}
 #endif
 
 void register_file_hle() {
@@ -2160,6 +2199,11 @@ void register_file_hle() {
     Hle::register_fn("vWU-odnS+fU", (HleFn)f_apr_read_direct, "AprReadFileDirect?");
 #else
     Hle::register_fn("mQ16-QdKv7k", (HleFn)f_apr_read_submit, "sceAmprAprCommandBufferReadFile");
+    // The direct (whole-range) APR read — completion-less, consumed synchronously by the guest
+    // (issue #115). Now registered on Windows too (#984): without it, vWU-odnS+fU fell through to the
+    // unimplemented stub and the shader-cache direct read never happened, wedging the boot at the
+    // CreateGlobalShaderMap precache.
+    Hle::register_fn("vWU-odnS+fU", (HleFn)f_apr_read_direct, "AprReadFileDirect?");
 #endif
     #undef R
 }

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -993,6 +993,30 @@ bool prepare_guest_windows_stack(ULONG_PTR* out_low, ULONG_PTR* out_high) {
     return true;
 }
 
+#ifdef _WIN32
+// #997: a guest worker thread that calls scePthreadExit must NOT reach host pthread_exit — winpthreads'
+// pthread_exit unwinds (RtlUnwind) back through the hand-written prosper_call_guest_* bridge and the
+// guest frames, none of which carry x64 .pdata unwind info, so RtlUnwind fails and RtlRaiseStatus
+// (STATUS_UNSUCCESSFUL) terminates the whole PROCESS kernel-side — no catchable user-mode exception,
+// exit ~0xC00000FF, first observed as DOLL's ~4s death when its first "TAsync" async-loader worker
+// exits. Escape back to win_thread_trampoline via __builtin_longjmp instead (a plain SP/register
+// restore, no SEH unwind — the same technique exec_image_win.cpp's t_jb uses for guest faults), and
+// let the trampoline run the ordinary cleanup + winpthreads exit, exactly like a normal-return worker.
+static thread_local void*    t_thread_exit_jb[5];
+static thread_local int      t_thread_exit_armed = 0;
+static thread_local uint64_t t_thread_exit_rv = 0;
+static thread_local void*    t_saved_teb_base = nullptr;
+static thread_local void*    t_saved_teb_limit = nullptr;
+static thread_local int      t_teb_swapped = 0;
+// True while the current thread is inside a win_thread_trampoline guest call with the longjmp armed.
+bool win_thread_exit_armed() { return t_thread_exit_armed != 0; }
+[[noreturn]] void win_thread_exit_longjmp(uint64_t rv) {
+    t_thread_exit_rv = rv;
+    t_thread_exit_armed = 0;
+    __builtin_longjmp(t_thread_exit_jb, 1);
+}
+#endif
+
 void* win_thread_trampoline(void* p) {
     auto* ts = (WinThreadStart*)p;
     while (!ts->name_published.load(std::memory_order_acquire)) std::this_thread::yield();
@@ -1027,16 +1051,33 @@ void* win_thread_trampoline(void* p) {
     guest_tls_activate_thread();   // this worker's guest %fs TCB (FSGSBASE); no-op if the gate is off
     void* rv = nullptr;
     if (entry) {
-        if (guest_stack) {
-            NT_TIB* tib = (NT_TIB*)NtCurrentTeb();
-            void* saved_base = tib->StackBase; void* saved_limit = tib->StackLimit;
-            tib->StackLimit = guest_stack;
-            tib->StackBase = (void*)((uintptr_t)guest_stack + guest_stack_size);
-            rv = (void*)(uintptr_t)prosper_call_guest_on_stack(
-                (uintptr_t)guest_stack + guest_stack_size, entry, (uint64_t)(uintptr_t)arg, 0);
-            tib->StackLimit = saved_limit; tib->StackBase = saved_base;
+        // Arm the scePthreadExit escape (see win_thread_exit_longjmp / #997). __builtin_setjmp returns
+        // 0 on the direct path and non-zero when k_pthread_exit longjmps back here.
+        if (__builtin_setjmp(t_thread_exit_jb) == 0) {
+            t_thread_exit_armed = 1;
+            if (guest_stack) {
+                NT_TIB* tib = (NT_TIB*)NtCurrentTeb();
+                t_saved_teb_base = tib->StackBase; t_saved_teb_limit = tib->StackLimit;
+                t_teb_swapped = 1;
+                tib->StackLimit = guest_stack;
+                tib->StackBase = (void*)((uintptr_t)guest_stack + guest_stack_size);
+                rv = (void*)(uintptr_t)prosper_call_guest_on_stack(
+                    (uintptr_t)guest_stack + guest_stack_size, entry, (uint64_t)(uintptr_t)arg, 0);
+                tib->StackLimit = t_saved_teb_limit; tib->StackBase = t_saved_teb_base;
+                t_teb_swapped = 0;
+            } else {
+                rv = (void*)(uintptr_t)prosper_call_guest_sysv(entry, (uint64_t)(uintptr_t)arg, 0);
+            }
+            t_thread_exit_armed = 0;
         } else {
-            rv = (void*)(uintptr_t)prosper_call_guest_sysv(entry, (uint64_t)(uintptr_t)arg, 0);
+            // Returned via scePthreadExit's __builtin_longjmp: recover the exit value and undo any TEB
+            // stack swap the guest_stack path left in place (the longjmp skipped its inline restore).
+            rv = (void*)(uintptr_t)t_thread_exit_rv;
+            if (t_teb_swapped) {
+                NT_TIB* tib = (NT_TIB*)NtCurrentTeb();
+                tib->StackBase = t_saved_teb_base; tib->StackLimit = t_saved_teb_limit;
+                t_teb_swapped = 0;
+            }
         }
     }
     tls_dtv_purge_current_thread();
@@ -1154,6 +1195,16 @@ HLE(k_pthread_exit)   {
     // thread-exit path: purge the exiting thread's __tls_get_addr DTV first (#68) and drop its stack
     // registration (#138 — pthread ids recycle). HLE handlers run under the HOST %fs (the import
     // stubs swap), so the host libc below is safe. No-op for threads that never touched either.
+#ifdef _WIN32
+    // #997: for a guest WORKER thread (entered through win_thread_trampoline), escape back to the
+    // trampoline via __builtin_longjmp rather than host pthread_exit, whose SEH unwind through the
+    // un-unwindable guest / prosper_call_guest_* frames raises RtlRaiseStatus and kills the process.
+    // The trampoline then runs the single normal-exit cleanup path. The main guest thread is not
+    // armed (it never runs through win_thread_trampoline), so it keeps the pthread_exit fallback.
+    if (win_thread_exit_armed()) {
+        win_thread_exit_longjmp(a0);   // does not return
+    }
+#endif
     tls_dtv_purge_current_thread();
     retire_guest_thread_name((uint64_t)(uintptr_t)pthread_self(), 0);
 #if defined(__linux__) || defined(__APPLE__)

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -4023,6 +4023,54 @@ HLE(k_query_memory_protection) {
 // (the Linux path models them). Registered by raw NID for parity.
 HLE(k_ampr_ok) { return 0; }
 
+// APR batched-read completion machinery (#984). Ported from the Linux path (register_kernel_mem_hle
+// above) — it was Windows-only-stubbed to k_ampr_ok, so the FAPREventQueueListener blocked forever
+// waiting for completion events that never posted after asset streaming. Pure platform-independent
+// bookkeeping + event posting via the shared prosper_eq_* helpers (hle_kernel_time.cpp). The token
+// contract, and the #180 crash-safety (only H896-BOUND cbs post events; unbound sync reads do not),
+// are preserved verbatim from k_apr_submit — see that function's comment for the full contract.
+uint64_t prosper_apr_next_token(unsigned ring);                          // hle_kernel_time.cpp
+void     prosper_eq_add_apr(uint64_t eq, int64_t id);                    // "
+void     prosper_eq_post_apr_token(uint64_t eq, int64_t id, uint64_t token); // " (tag echo, #208)
+namespace {
+    struct WinAprBoundCb { uint64_t cb, tag, eq; int64_t id; };
+    std::mutex g_win_apr_bound_mx;
+    std::vector<WinAprBoundCb> g_win_apr_bound_cbs;
+    bool win_apr_cb_bound(uint64_t cb, WinAprBoundCb* out) {
+        std::lock_guard<std::mutex> lk(g_win_apr_bound_mx);
+        for (auto& b : g_win_apr_bound_cbs) if (b.cb == cb) { if (out) *out = b; return true; }
+        return false;
+    }
+}
+HLE(k_apr_set_equeue) {          // sSAUCCU1dv4 (eq, id, 0, 0, 0x43, 0): register APR ids on an equeue
+    if (a0) prosper_eq_add_apr(a0, (int64_t)a1);
+    return 0;
+}
+HLE(k_apr_cb_set_equeue) {       // H896Pt-yB4I (cb, eq, id, tag, 0, flags): bind cb -> (eq,id,tag)
+    if (a1) prosper_eq_add_apr(a1, (int64_t)a2);
+    if (a0) {
+        std::lock_guard<std::mutex> lk(g_win_apr_bound_mx);
+        bool seen = false;
+        for (auto& b : g_win_apr_bound_cbs)
+            if (b.cb == a0) { b.tag = a3; b.eq = a1; b.id = (int64_t)a2; seen = true; break; }
+        if (!seen) g_win_apr_bound_cbs.push_back({ a0, a3, a1, (int64_t)a2 });
+    }
+    return 0;
+}
+HLE(k_apr_submit) {              // ASoW5WE-UPo (cb, ring_1based, out1, out2): submit + post completion
+    unsigned ring = a1 ? (unsigned)(a1 - 1) & 0x3f : 0;
+    WinAprBoundCb bc{};
+    const bool bound = win_apr_cb_bound(a0, &bc);
+    const bool tag_echo = bound && bc.tag && bc.eq;   // BOUND streaming cb -> post the tag verbatim
+    uint64_t token = tag_echo ? bc.tag : prosper_apr_next_token(ring);
+    if (!bound) {   // unbound sync/mount flow: hand the token through the out slots, post NO event (#180)
+        if (a2 > 0xffff) *(uint64_t*)(uintptr_t)a2 = token;
+        if (a3 > 0xffff) *(uint64_t*)(uintptr_t)a3 = token;
+    }
+    if (tag_echo) prosper_eq_post_apr_token(bc.eq, bc.id, bc.tag);
+    return 0;
+}
+
 namespace {
 std::mutex g_sync_mx;
 std::condition_variable g_sync_cv;
@@ -4172,9 +4220,9 @@ void register_kernel_mem_hle() {
     Hle::register_fn("tZDDEo2tE5k", (HleFn)k_ampr_ok, "sceAmprCommandBufferGetSize");
     Hle::register_fn("Qs1xtplKo0U", (HleFn)k_ampr_ok, "sceAmprAprCommandBufferDestructor");
     Hle::register_fn("GuchCTefuZw", (HleFn)k_ampr_ok, "sceAmprCommandBufferDestructor");
-    Hle::register_fn("sSAUCCU1dv4", (HleFn)k_ampr_ok, "AprSetEventQueue?");
-    Hle::register_fn("H896Pt-yB4I", (HleFn)k_ampr_ok, "AprCbSetEventQueue?");
-    Hle::register_fn("ASoW5WE-UPo", (HleFn)k_ampr_ok, "AprSubmitCommandBuffer?");
+    Hle::register_fn("sSAUCCU1dv4", (HleFn)k_apr_set_equeue,    "AprSetEventQueue?");      // #984
+    Hle::register_fn("H896Pt-yB4I", (HleFn)k_apr_cb_set_equeue, "AprCbSetEventQueue?");    // #984
+    Hle::register_fn("ASoW5WE-UPo", (HleFn)k_apr_submit,        "AprSubmitCommandBuffer?"); // #984
     Hle::register_fn("GnxKOHEawhk", (HleFn)k_ampr_ok, "AmprUnknown3");
 }
 

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -651,7 +651,13 @@ HLE(k_reserve_vrange) {
         MLOG("reserve(fixed) -> 0x%llx len=0x%llx align=0x%llx\n", (unsigned long long)p, (unsigned long long)a1, (unsigned long long)align);
         return 0;
     }
-    if (hint) {
+    // #946/#312: a HUGE non-fixed reservation (UE MallocBinned3's 512 GiB arena, hint 0x1000000000)
+    // must NOT be searched from its low hint — placing the giant arena at 0x1000000000 overlaps
+    // prosper's low guest-VA structures (race). Fall through to map_guest_auto (searches from
+    // kGuestAutoMapBase 0x2000000000, above the low hint), leaving 0x1000000000 free for the small
+    // metadata pool the guest reserves next with the same hint. Mirrors the Windows win_reserve fix.
+    constexpr uint64_t kBigReserveArena = 0x2000000000ull;   // 128 GiB — only the flex arena is this large
+    if (hint && a1 < kBigReserveArena) {
         // Non-fixed hint: search for a free range starting at the hint. Probe candidates with
         // MAP_FIXED_NOREPLACE (also catches host mappings the tracker doesn't know); on a miss,
         // skip past whichever TRACKED mapping covers the candidate (fast-forwards the search past
@@ -1960,7 +1966,12 @@ namespace {
     // rejected 1-8 TiB gap (Astro observed 0x2d980000000), after which sceLibcMspaceCreate returns
     // null even though the pages are accessible.
     constexpr uint64_t kGuestAutoVaMin = 0x2000000000ull;   // 128 GiB
-    constexpr uint64_t kGuestAutoVaMax = 0xfbffffffffull;  // inclusive; one byte below a 64 KiB boundary
+    // Inclusive upper bound for guest auto-map / placeholder / flex-arena placement. Raised from the
+    // historical ~1 TiB to ~4 TiB (matching the Linux kGuestAutoMapLimit) so UE's 512 GiB MallocBinned3
+    // arena fits comfortably IN-window alongside auto-maps without fragmenting them out of space (#946):
+    // a tight window forced the arena to a host-chosen out-of-window base, and arena-relative batchmaps
+    // then exceeded the window and ENOMEM'd. One byte below a 64 KiB boundary (0x40000000000).
+    constexpr uint64_t kGuestAutoVaMax = 0x3ffffffffffull;
 
     // A paging-file SEC_RESERVE section avoids a 16 GiB commit charge, but every first guest touch
     // raises a Windows access violation. Windows builds its exception-dispatch frame below RSP
@@ -2946,6 +2957,30 @@ namespace {
     // Reserve (no commit). Modern Windows placeholders can be partitioned at the guest's 16 KiB
     // page boundary and later replaced by either a section view or private pages.
     void* win_reserve(uint64_t hint, uint64_t len, bool fixed, uint64_t align) {
+        // #946/#312: a HUGE non-fixed reservation (UE MallocBinned3's 512 GiB arena, hint 0x1000000000)
+        // must not be placed AT its low hint. sceKernelReserveVirtualRange without MAP_FIXED treats the
+        // hint as a SEARCH START, not a fixed address (BSD mmap contract). Honoring the low hint for the
+        // giant arena is a race: when 0x1000000000 is free at reserve time the arena grabs it, overlapping
+        // prosper's low guest-VA structures and wedging the guest into a re-entrant __cxa_guard deadlock
+        // (A/B-confirmed: hang runs reserve -> 0x1000000000; boot runs reserve -> a high base). Place the
+        // arena INSIDE the guest auto-map window [kGuestAutoVaMin, kGuestAutoVaMax] via the window-bounded
+        // placeholder path ONLY -- never an unconstrained VirtualAlloc(nullptr), which can land it above
+        // kGuestAutoVaMax where the guest's arena-relative batchmaps then exceed the window and ENOMEM (a
+        // second wedge). In-window it stays contiguous with, and skipped by, later auto-maps; the small
+        // metadata pool the guest reserves next with the same hint then takes the low hint. Same root as
+        // the Linux #312 MallocBinned3 corruption (cross-linked). If placeholders are unavailable this
+        // returns ENOMEM rather than a dangerous out-of-window base.
+        constexpr uint64_t kBigReserveArena = 0x2000000000ull;   // 128 GiB -- only the flex arena is this large
+        if (!fixed && hint && len >= kBigReserveArena) {
+            std::lock_guard<std::mutex> lk(g_dview_mx);
+            AcquiredPlaceholder acquired = acquire_placeholder_locked(kGuestAutoVaMin, len, align, false);
+            if (!acquired.address)
+                acquired = acquire_placeholder_locked(0, len, align, false);   // any window-bounded spot
+            if (!acquired.address) return nullptr;                             // in-window ENOMEM (never OOB)
+            const uint64_t base = static_cast<uint64_t>(reinterpret_cast<uintptr_t>(acquired.address));
+            remember_guest_placeholder_locked(base, len);
+            return acquired.address;
+        }
         {
             std::lock_guard<std::mutex> lk(g_dview_mx);
             AcquiredPlaceholder acquired =

--- a/prosper/src/host/exec_image_win.cpp
+++ b/prosper/src/host/exec_image_win.cpp
@@ -446,7 +446,25 @@ namespace {
         // Zero the full destination register (correct for REX.W/32-bit mov and movzx/movsx of a 0 source).
         DWORD64* creg[16] = { &c->Rax, &c->Rcx, &c->Rdx, &c->Rbx, &c->Rsp, &c->Rbp, &c->Rsi, &c->Rdi,
                               &c->R8, &c->R9, &c->R10, &c->R11, &c->R12, &c->R13, &c->R14, &c->R15 };
-        *creg[reg] = 0;
+        // A guest fs-relative read faults at a LOW linear address only when the fs base has drifted to 0
+        // (Windows zeroes it on kernel transitions). Re-applying the base in the VEH does NOT persist past
+        // the exception return (it re-zeroes -> infinite re-fault loop, observed), so instead EMULATE the
+        // read from the guest TCB: for a 64-bit `mov reg, %fs:disp`, fault_addr is the fs offset, so the
+        // value is *(guest_tp + fault_addr). Fixes eboot+0x24d3c3c (`mov %fs:0x0,%rax` on an APR/IO worker
+        // whose base drifted). Narrower reads / null-field reads keep zero-emulation. (#984)
+        uint64_t fs_tp = 0;
+        { bool is_fs = false, rexw = false; size_t k = 0;
+          for (; k < 15; k++) { uint8_t b = p[k];
+              if (b == 0x64) { is_fs = true; continue; }
+              if (b == 0x65 || b == 0x66 || b == 0x67 || b == 0xF0 || b == 0xF2 || b == 0xF3 ||
+                  b == 0x2E || b == 0x36 || b == 0x3E || b == 0x26) continue;
+              if ((b & 0xF0) == 0x40) { rexw = (b & 0x08) != 0; continue; }     // REX
+              break; }                                                          // opcode
+          if (is_fs && rexw && p[k] == 0x8b) fs_tp = guest_fs_current_tp(); }   // 64-bit mov reg, fs:disp
+        if (fs_tp && addr_readable(fs_tp + fault_addr))
+            *creg[reg] = *(const uint64_t*)(uintptr_t)(fs_tp + fault_addr);
+        else
+            *creg[reg] = 0;
         c->Rip += (uint64_t)insn_len;
         long n = InterlockedIncrement(&g_null_page_count);
         if (getenv("PROSPER_NULL_PAGE_LOG") && n <= 64) {


### PR DESCRIPTION
## Summary
The libSceAmpr **direct whole-range read** (`vWU-odnS+fU` / AprReadFileDirect) was registered only under `#ifndef _WIN32` (its Linux body uses `mmap`/`pread`). On Windows the NID fell through to the **unimplemented stub (returns 0)**, so UE's `CreateGlobalShaderMap` direct read of `GlobalShaderCache-SF_PS5.bin` out of pakchunk0 silently did nothing → the shader precache never completed → `FAPREventQueueListener` blocked forever on an empty APREventQueue → the GameThread spun broadcasting a condvar and **never reached GPU submission** (0 frames), despite booting and building its 23-thread FTaskGraph pool.

## Fix
Add a Windows `f_apr_read_direct` using the same stdio + `windows_prepare_guest_write` path as the existing Windows batched read (`f_apr_read_submit`): synchronous whole-range read into a staging buffer, then guest DMA-write. No completion event (matches the Linux path + the #208 listener contract). Register `vWU-odnS+fU` on Windows.

## Verification (Windows, MinGW)
Before: 0 APR direct reads, condvar spin ~467/35 s, 0 GPU frames.
After: **222 APR reads** of pakchunk0-ps5.pak/.utoc (all `got==size OK`), **condvar spin gone (467 → 0)**, reaches **GPU/AGC submission**. Progression then advances to a separate guest-%fs worker fault at eboot+0x24d3c3c (tracked separately, next wall).

## Scope / risk
Windows-only (new `#else` branch + one registration); Linux path untouched (still registers/implements the read). Depends on #982 (arena-placement fix) to boot far enough to reach this call.

Fixes #984.