### PR TITLE
perf(renderer): retain Evergate texture bindings

### DIFF
--- a/prosper/docs/FRONTEND_APP.md
+++ b/prosper/docs/FRONTEND_APP.md
@@ -289,8 +289,10 @@ readability checks without copying large texture sources before comparing them. 
 
 The Vulkan backend may retain an optimal sampled image only when that exact frontend validation
 supplies a nonzero content-version ID. Cache hits skip image allocation, staging allocation, pixel
-copy, transfer commands, and upload barriers; per-draw views, swizzles, and samplers remain callback
-local. The cache is bounded to 256 MiB and 1024 allocations by default. Set
+copy, transfer commands, and upload barriers. Exact image-view and sampler contracts over a retained
+image remain resident with that image, under a 32-contract per-image bound; set
+`PROSPER_NO_BACKEND_PERSISTENT_TEXTURE_BINDINGS=1` to retain images while restoring callback-local
+bindings for an A/B. The image cache is bounded to 1 GiB and 1024 allocations by default. Set
 `PROSPER_BACKEND_TEXTURE_CACHE_MB=<MiB>` to change the byte budget or
 `PROSPER_NO_BACKEND_PERSISTENT_TEXTURES=1` for a forced-upload A/B. Backend timing reports
 `persistent=hits/misses` and the current cache bytes. The frontend decoded-pixel budget and backend

--- a/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
+++ b/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
@@ -245,6 +245,35 @@ ranges are not an FPS claim. The isolated layout bucket consistently removes abo
 submit. This is a bounded CPU improvement; GPU fence waits and draw/resource realization remain the dominant
 Evergate costs.
 
+## Evergate backend resource references and texture residency (2026-07-19)
+
+A deferred-submit prototype proved that removing intermediate CPU waits alone is not sufficient. It reduced
+the readback-free wait bucket from roughly 33 ms to below 1 ms, but retaining complete call-local resource
+graphs made the matched backend window slower (77.6 ms versus 71.9 ms) and produced fewer presented frames.
+The prototype was removed. Future multi-target submission work must share command/resource ownership rather
+than queueing several independently realized calls.
+
+The next exact phase probe found avoidable work inside each independent call. A 462-draw Evergate pass spent
+8.09 ms deep-copying every draw's `FrameResource` vectors into backend bookkeeping, although later recording
+needed only descriptor sets, pipelines, index buffers, and scissors. Using the immutable `BackendDraw`
+resources by reference and keeping descriptor-construction arrays local reduced the closest 460-draw sample's
+draw setup from 43.60 ms to 22.21 ms; its GPU wait remained approximately 27-28 ms.
+
+Texture residency was the next larger mechanism. The dense pass referenced about 960 texture bindings but
+only 43-44 distinct exact image/view/sampler contracts. The old 256 MiB backend image budget thrashed that
+working set. Even a 512 MiB control sat at 502.3 MiB and still evicted and reuploaded a 16 MiB image on each
+dense call. The default backend image budget is therefore 1 GiB, matching the already-bounded frontend decode
+budget; this is a cap, not a preallocation. A warmed 1 GiB run reported 43 persistent image hits, zero uploads,
+and about 2.8 ms of texture-binding work in a 479-draw pass.
+
+Exact image-view/sampler bindings now live with their persistent image instead of being recreated on every
+callback. Each image retains at most 32 complete contracts and evicts only a binding not referenced by the
+current call. `PROSPER_NO_BACKEND_PERSISTENT_TEXTURE_BINDINGS=1` restores callback-local bindings, while
+`PROSPER_BACKEND_TEXTURE_CACHE_MB` still controls image residency. The Vulkan regression test covers the
+initial binding miss, the next-call hit, byte-identical output, and bounded eviction without destroying the
+current call's binding. Later end-to-end controls coincided with unrelated GPU saturation, so the cache and
+CPU phase counters above are used for attribution rather than presenting those wall-clock rates as FPS gains.
+
 ## Dead Cells backend upload duplication (2026-07-15)
 
 Dead Cells exposed a second duplication layer after the frontend decode caches. The frontend correctly
@@ -291,9 +320,9 @@ Dead Cells loading submit referenced 54 textures. Eleven distinct uploads remain
 
 The frontend cache now exact-validates linear `Unorm8x4` sources as well as tiled sources. A validated
 content version receives a monotonic ID; any source-byte or readable-prefix change creates a new ID.
-The Vulkan backend retains only images with such an ID, under a 256 MiB / 1024-entry default bound.
+The Vulkan backend retains only images with such an ID, under a bounded cache.
 Render targets, storage images, captured host backing, and unvalidated formats never receive an ID.
-Per-call views and samplers remain independent, so descriptor swizzles and filtering are unchanged.
+Exact view and sampler contracts remain independent, so descriptor swizzles and filtering are unchanged.
 
 Native Windows / RTX 4090, same RelWithDebInfo binary, fresh saves, documented full-render route, and
 matched 110-second samples:

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -214,6 +214,10 @@ struct BackendResourceReuseStats {
     size_t persistent_pipeline_layout_misses = 0;
     size_t persistent_pipeline_layout_entries = 0;
     size_t persistent_pipeline_layout_evictions = 0;
+    size_t persistent_texture_binding_hits = 0;
+    size_t persistent_texture_binding_misses = 0;
+    size_t persistent_texture_binding_entries = 0;
+    size_t persistent_texture_binding_evictions = 0;
 };
 
 inline BackendResourceReuseStats& backend_resource_reuse_stats_storage() {
@@ -1660,12 +1664,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     const auto timing_target_ready = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
     struct DV {
         VkShaderModule vs = VK_NULL_HANDLE, gs = VK_NULL_HANDLE, fs = VK_NULL_HANDLE;
-        std::vector<FrameResource> R;
-        std::vector<VkDescriptorSetLayout> dsls; std::vector<VkDescriptorSet> dsets;
-        std::vector<std::vector<uint64_t>> descriptor_layout_keys;
-        std::vector<VkBuffer> sbuf;
-        std::vector<size_t> texture_upload;
-        std::vector<VkImageView> tview; std::vector<VkSampler> tsamp;
+        std::vector<VkDescriptorSet> dsets;
         VkPipelineLayout layout = VK_NULL_HANDLE; VkPipeline pipe = VK_NULL_HANDLE;
         VkBuffer ibuf = VK_NULL_HANDLE; VkDeviceMemory ibmem = VK_NULL_HANDLE;   // index buffer (indexed draws)
         VkRect2D scissor{};
@@ -1728,11 +1727,32 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
             return h;
         }
     };
+    struct TextureBindingKey {
+        std::array<uint64_t, 22> words{};
+        bool operator==(const TextureBindingKey&) const = default;
+    };
+    struct TextureBindingKeyHash {
+        size_t operator()(const TextureBindingKey& key) const {
+            uint64_t hash = 1469598103934665603ull;
+            for (uint64_t word : key.words) {
+                hash ^= word;
+                hash *= 1099511628211ull;
+            }
+            return static_cast<size_t>(hash);
+        }
+    };
+    struct PersistentTextureBinding {
+        VkImageView view = VK_NULL_HANDLE;
+        VkSampler sampler = VK_NULL_HANDLE;
+        uint64_t last_use = 0;
+    };
     struct PersistentTextureImage {
         VkImage image = VK_NULL_HANDLE;
         VkDeviceMemory memory = VK_NULL_HANDLE;
         VkDeviceSize bytes = 0;
         uint64_t last_use = 0;
+        std::unordered_map<TextureBindingKey, PersistentTextureBinding,
+                           TextureBindingKeyHash> bindings;
     };
     static std::unordered_map<PersistentTextureKey, PersistentTextureImage,
                               PersistentTextureKeyHash> persistent_texture_images;
@@ -1744,7 +1764,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         getenv("PROSPER_NO_BACKEND_PERSISTENT_TEXTURES") == nullptr;
     const VkDeviceSize persistent_texture_limit = []() -> VkDeviceSize {
         const char* value = getenv("PROSPER_BACKEND_TEXTURE_CACHE_MB");
-        const uint64_t mib = value ? strtoull(value, nullptr, 10) : 256ull;
+        const uint64_t mib = value ? strtoull(value, nullptr, 10) : 1024ull;
         if (mib > UINT64_MAX / (1024ull * 1024ull)) return VkDeviceSize{UINT64_MAX};
         return static_cast<VkDeviceSize>(mib) * 1024ull * 1024ull;
     }();
@@ -1784,23 +1804,10 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         RenderHostBuffer buffer;
         VkDeviceSize used = 0;
     };
-    struct TextureBindingKey {
-        std::array<uint64_t, 22> words{};
-        bool operator==(const TextureBindingKey&) const = default;
-    };
-    struct TextureBindingKeyHash {
-        size_t operator()(const TextureBindingKey& key) const {
-            uint64_t hash = 1469598103934665603ull;
-            for (uint64_t word : key.words) {
-                hash ^= word;
-                hash *= 1099511628211ull;
-            }
-            return static_cast<size_t>(hash);
-        }
-    };
     struct SharedTextureBinding {
         VkImageView view = VK_NULL_HANDLE;
         VkSampler sampler = VK_NULL_HANDLE;
+        bool persistent = false;
     };
     struct SharedPipelineLayout {
         VkPipelineLayout handle = VK_NULL_HANDLE;
@@ -2142,14 +2149,12 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         // Descriptor resources for this draw (two-set: VS=set0, PS=set1 — same layout as the single path).
         const auto setup_fixed_ready = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
         if (timing_enabled) setup_fixed_ms += setup_elapsed_ms(setup_shaders_ready, setup_fixed_ready);
-        v.R = bd.R; auto& R = v.R;
+        const auto& R = bd.R;
         v.use_desc = !R.empty();
         for (auto& r : R) v.n_sets = std::max(v.n_sets, r.set + 1);
-        v.dsls.assign(v.n_sets, VK_NULL_HANDLE); v.dsets.assign(v.n_sets, VK_NULL_HANDLE);
-        v.descriptor_layout_keys.resize(v.n_sets);
-        v.sbuf.assign(R.size(), VK_NULL_HANDLE);
-        v.texture_upload.assign(R.size(), SIZE_MAX);
-        v.tview.assign(R.size(), VK_NULL_HANDLE); v.tsamp.assign(R.size(), VK_NULL_HANDLE);
+        std::vector<VkDescriptorSetLayout> dsls(v.n_sets, VK_NULL_HANDLE);
+        v.dsets.assign(v.n_sets, VK_NULL_HANDLE);
+        std::vector<std::vector<uint64_t>> descriptor_layout_keys(v.n_sets);
         if (v.use_desc) {
             std::vector<VkDescriptorSetLayoutBinding> lb(R.size());
             std::vector<VkDescriptorBufferInfo> dbi(R.size());
@@ -2270,7 +2275,6 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                             vkUnmapMemory(dev, upload.staging_memory);
                         }
                     }
-                    v.texture_upload[i] = upload_index;
                     const SharedTextureUpload& upload = texture_uploads[upload_index];
                     VkImageViewCreateInfo tvci{VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO};
                     // NOTE(#263): r.srgb carries whether the T# is a gamma-encoded (sRGB) surface, but we
@@ -2378,18 +2382,69 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                     } else {
                         binding_index = shared_texture_bindings.size();
                         SharedTextureBinding binding;
-                        vkCreateImageView(dev, &tvci, nullptr, &binding.view);
-                        if (!r.is_storage_image)
-                            vkCreateSampler(dev, &sci, nullptr, &binding.sampler);
+                        const bool persistent_bindings_enabled = share_backend_resources &&
+                            persistent_textures_enabled &&
+                            getenv("PROSPER_NO_BACKEND_PERSISTENT_TEXTURE_BINDINGS") == nullptr;
+                        auto persistent_image = persistent_texture_images.end();
+                        if (persistent_bindings_enabled && upload.persistent_hit &&
+                            upload.persistent_id && !r.is_storage_image) {
+                            persistent_image = persistent_texture_images.find(
+                                {upload.persistent_id, upload.key.width, upload.key.height,
+                                 upload.key.depth, upload.key.img_dim, upload.key.format});
+                        }
+                        if (persistent_image != persistent_texture_images.end()) {
+                            auto cached_binding = persistent_image->second.bindings.find(binding_key);
+                            if (cached_binding != persistent_image->second.bindings.end()) {
+                                cached_binding->second.last_use = texture_generation;
+                                binding.view = cached_binding->second.view;
+                                binding.sampler = cached_binding->second.sampler;
+                                binding.persistent = true;
+                                ++resource_reuse_stats.persistent_texture_binding_hits;
+                            } else {
+                                ++resource_reuse_stats.persistent_texture_binding_misses;
+                                constexpr size_t max_bindings_per_texture = 32;
+                                if (persistent_image->second.bindings.size() >=
+                                    max_bindings_per_texture) {
+                                    auto victim = persistent_image->second.bindings.end();
+                                    for (auto it = persistent_image->second.bindings.begin();
+                                         it != persistent_image->second.bindings.end(); ++it) {
+                                        if (it->second.last_use == texture_generation) continue;
+                                        if (victim == persistent_image->second.bindings.end() ||
+                                            it->second.last_use < victim->second.last_use)
+                                            victim = it;
+                                    }
+                                    if (victim != persistent_image->second.bindings.end()) {
+                                        if (victim->second.sampler)
+                                            vkDestroySampler(dev, victim->second.sampler, nullptr);
+                                        if (victim->second.view)
+                                            vkDestroyImageView(dev, victim->second.view, nullptr);
+                                        persistent_image->second.bindings.erase(victim);
+                                        ++resource_reuse_stats.persistent_texture_binding_evictions;
+                                    }
+                                }
+                                vkCreateImageView(dev, &tvci, nullptr, &binding.view);
+                                vkCreateSampler(dev, &sci, nullptr, &binding.sampler);
+                                if (persistent_image->second.bindings.size() <
+                                    max_bindings_per_texture) {
+                                    persistent_image->second.bindings.emplace(
+                                        binding_key, PersistentTextureBinding{
+                                            binding.view, binding.sampler, texture_generation});
+                                    binding.persistent = true;
+                                }
+                            }
+                        } else {
+                            vkCreateImageView(dev, &tvci, nullptr, &binding.view);
+                            if (!r.is_storage_image)
+                                vkCreateSampler(dev, &sci, nullptr, &binding.sampler);
+                        }
                         shared_texture_bindings.push_back(binding);
                         shared_texture_binding_indices.emplace(binding_key, binding_index);
                         ++resource_reuse_stats.unique_texture_bindings;
                     }
-                    v.tview[i] = shared_texture_bindings[binding_index].view;
-                    v.tsamp[i] = shared_texture_bindings[binding_index].sampler;
                     const VkImageLayout image_layout = r.is_storage_image
                         ? VK_IMAGE_LAYOUT_GENERAL : VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-                    dii[i] = {v.tsamp[i], v.tview[i], image_layout};
+                    dii[i] = {shared_texture_bindings[binding_index].sampler,
+                              shared_texture_bindings[binding_index].view, image_layout};
                     wr[i] = {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET}; wr[i].dstBinding = r.binding; wr[i].descriptorCount = 1;
                     wr[i].descriptorType = lb[i].descriptorType; wr[i].pImageInfo = &dii[i];
                 } else {
@@ -2450,8 +2505,8 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                         shared_buffer_indices.emplace(buffer_key, buffer_index);
                         ++resource_reuse_stats.unique_buffers;
                     }
-                    v.sbuf[i] = shared_buffers[buffer_index].buffer;
-                    dbi[i] = {v.sbuf[i], shared_buffers[buffer_index].offset,
+                    dbi[i] = {shared_buffers[buffer_index].buffer,
+                              shared_buffers[buffer_index].offset,
                               static_cast<VkDeviceSize>(word_count) * sizeof(uint32_t)};
                     wr[i] = {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET}; wr[i].dstBinding = r.binding; wr[i].descriptorCount = 1;
                     wr[i].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER; wr[i].pBufferInfo = &dbi[i];
@@ -2472,18 +2527,18 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                     layout_key.push_back(binding.descriptorCount);
                     layout_key.push_back(binding.stageFlags);
                 }
-                v.descriptor_layout_keys[s] = layout_key;
+                descriptor_layout_keys[s] = layout_key;
                 ++resource_reuse_stats.descriptor_set_layout_references;
                 auto layout_found = shared_descriptor_set_layouts.find(layout_key);
                 if (layout_found != shared_descriptor_set_layouts.end()) {
-                    v.dsls[s] = layout_found->second;
+                    dsls[s] = layout_found->second;
                 } else {
                     VkDescriptorSetLayoutCreateInfo layout_info{
                         VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO};
                     layout_info.bindingCount = static_cast<uint32_t>(slb.size());
                     layout_info.pBindings = slb.data();
-                    vkCreateDescriptorSetLayout(dev, &layout_info, nullptr, &v.dsls[s]);
-                    shared_descriptor_set_layouts.emplace(std::move(layout_key), v.dsls[s]);
+                    vkCreateDescriptorSetLayout(dev, &layout_info, nullptr, &dsls[s]);
+                    shared_descriptor_set_layouts.emplace(std::move(layout_key), dsls[s]);
                     ++resource_reuse_stats.unique_descriptor_set_layouts;
                 }
             }
@@ -2491,7 +2546,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                 VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO};
             allocate_info.descriptorPool = shared_descriptor_pool;
             allocate_info.descriptorSetCount = v.n_sets;
-            allocate_info.pSetLayouts = v.dsls.data();
+            allocate_info.pSetLayouts = dsls.data();
             vkAllocateDescriptorSets(dev, &allocate_info, v.dsets.data());
             for (size_t i = 0; i < R.size(); i++)
                 wr[i].dstSet = v.dsets[R[i].set];
@@ -2502,13 +2557,13 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         std::vector<uint64_t> pipeline_layout_key;
         size_t pipeline_layout_key_words = 1;
         if (v.use_desc) {
-            for (const auto& descriptor_layout_key : v.descriptor_layout_keys)
+            for (const auto& descriptor_layout_key : descriptor_layout_keys)
                 pipeline_layout_key_words += 1 + descriptor_layout_key.size();
         }
         pipeline_layout_key.reserve(pipeline_layout_key_words);
         pipeline_layout_key.push_back(share_backend_resources ? 0 : ++resource_unique_tag);
         if (v.use_desc) {
-            for (const auto& descriptor_layout_key : v.descriptor_layout_keys) {
+            for (const auto& descriptor_layout_key : descriptor_layout_keys) {
                 pipeline_layout_key.push_back(descriptor_layout_key.size());
                 pipeline_layout_key.insert(pipeline_layout_key.end(),
                                            descriptor_layout_key.begin(),
@@ -2536,7 +2591,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                     VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO};
                 if (v.use_desc) {
                     layout_info.setLayoutCount = v.n_sets;
-                    layout_info.pSetLayouts = v.dsls.data();
+                    layout_info.pSetLayouts = dsls.data();
                 }
                 vkCreatePipelineLayout(dev, &layout_info, nullptr, &shared_layout.handle);
                 if (can_persist_pipeline_layout) {
@@ -3045,7 +3100,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                                 (int)ps->blend_enable, ps->src_color_blend_factor, ps->dst_color_blend_factor,
                                 ps->color_write_mask, ps->viewport_y, ps->viewport_h,
                                 (int)ps->depth_test_enable, (int)ps->depth_write_enable);
-                int nt = 0; for (auto& r : v.R) if (r.is_texture()) { fprintf(stderr, " tex%d=%ux%u", nt, r.tw, r.th); nt++; }
+                int nt = 0; for (const auto& r : draws[di].R) if (r.is_texture()) { fprintf(stderr, " tex%d=%ux%u", nt, r.tw, r.th); nt++; }
                 fprintf(stderr, "\n");
             }
             VkBufferImageCopy cp2{}; cp2.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1}; cp2.imageExtent = {W, H, 1};
@@ -3106,8 +3161,10 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     for (const auto& [key, layout] : shared_descriptor_set_layouts)
         if (layout) vkDestroyDescriptorSetLayout(dev, layout, nullptr);
     for (const SharedTextureBinding& binding : shared_texture_bindings) {
-        if (binding.sampler) vkDestroySampler(dev, binding.sampler, nullptr);
-        if (binding.view) vkDestroyImageView(dev, binding.view, nullptr);
+        if (!binding.persistent) {
+            if (binding.sampler) vkDestroySampler(dev, binding.sampler, nullptr);
+            if (binding.view) vkDestroyImageView(dev, binding.view, nullptr);
+        }
     }
     for (const SharedBufferUpload& upload : shared_buffers) {
         if (upload.arena) {
@@ -3132,6 +3189,10 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                 it->second.last_use < victim->second.last_use) victim = it;
         }
         if (victim == persistent_texture_images.end()) return false;
+        for (const auto& [key, binding] : victim->second.bindings) {
+            if (binding.sampler) vkDestroySampler(dev, binding.sampler, nullptr);
+            if (binding.view) vkDestroyImageView(dev, binding.view, nullptr);
+        }
         vkDestroyImage(dev, victim->second.image, nullptr);
         vkFreeMemory(dev, victim->second.memory, nullptr);
         persistent_texture_bytes -= victim->second.bytes;
@@ -3160,6 +3221,8 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         }
     }
     while (persistent_texture_bytes > persistent_texture_limit && evict_persistent_texture()) {}
+    for (const auto& [key, image] : persistent_texture_images)
+        resource_reuse_stats.persistent_texture_binding_entries += image.bindings.size();
     texture_stats.persistent_cached_bytes = persistent_texture_bytes;
     for (auto& upload : texture_uploads) {
         if (upload.image && !upload.persistent_hit && !upload.borrowed_target)

--- a/prosper/tests/test_texture_sample_render.cpp
+++ b/prosper/tests/test_texture_sample_render.cpp
@@ -151,13 +151,40 @@ int main() {
         const auto first_stats = prosper::test::backend_texture_upload_stats();
         std::vector<uint8_t> reused = prosper::test::render_draws_rgba({draw}, W, H);
         const auto reused_stats = prosper::test::backend_texture_upload_stats();
+        const auto first_binding_stats = prosper::test::backend_resource_reuse_stats();
+        std::vector<uint8_t> reused_again = prosper::test::render_draws_rgba({draw}, W, H);
+        const auto reused_binding_stats = prosper::test::backend_resource_reuse_stats();
         CHECK(first_stats.persistent_misses == 1 && first_stats.unique_uploads == 1,
               "first exact-validated texture version is uploaded into the persistent cache");
         CHECK(reused_stats.persistent_hits == 1 && reused_stats.unique_uploads == 0 &&
-                  reused_stats.upload_bytes == 0,
+                   reused_stats.upload_bytes == 0,
               "same exact-validated texture version skips its next callback upload");
-        CHECK(!first.empty() && first == reused,
+        CHECK(first_binding_stats.persistent_texture_binding_misses == 1 &&
+                  first_binding_stats.persistent_texture_binding_hits == 0,
+              "first persistent-image reuse retains its exact image-view/sampler binding");
+        CHECK(reused_binding_stats.persistent_texture_binding_hits == 1 &&
+                  reused_binding_stats.persistent_texture_binding_misses == 0 &&
+                  reused_binding_stats.persistent_texture_binding_entries == 1,
+              "next callback reuses the retained exact texture binding");
+        CHECK(!first.empty() && first == reused && reused == reused_again,
               "persistent texture reuse renders byte-identically to its initial upload");
+
+        // Bound sampler/view contracts per persistent texture. Each call uses one distinct, valid
+        // single-mip LOD-bias contract; the 33rd retained contract evicts an idle older one without
+        // touching the binding used by the current call.
+        prosper::test::BackendResourceReuseStats bounded_binding_stats;
+        for (uint32_t i = 1; i <= 32; ++i) {
+            resource.lod_bias = static_cast<float>(i) / 64.0f;
+            draw.R = {resource};
+            std::vector<uint8_t> bounded = prosper::test::render_draws_rgba({draw}, W, H);
+            CHECK(!bounded.empty(), "bounded persistent texture binding renders");
+            bounded_binding_stats = prosper::test::backend_resource_reuse_stats();
+        }
+        CHECK(bounded_binding_stats.persistent_texture_binding_evictions == 1 &&
+                  bounded_binding_stats.persistent_texture_binding_entries == 32,
+              "persistent texture bindings evict an idle contract at the per-texture bound");
+        resource.lod_bias = 0.0f;
+        draw.R = {resource};
 
 #ifdef _WIN32
         _putenv_s("PROSPER_NO_BACKEND_PERSISTENT_TEXTURES", "1");


### PR DESCRIPTION
## Problem

Evergate's dense backend passes reference roughly 960 texture descriptors but only 43-44 distinct exact image/view/sampler contracts. The 256 MiB backend image cache repeatedly evicted and reuploaded the active set, and each draw also deep-copied resource vectors that backend recording only reads.

## Changes

- Read immutable draw resources in place and keep descriptor-construction arrays call-local instead of retaining redundant per-draw copies.
- Raise only the backend sampled-texture residency cap from 256 MiB to 1 GiB. This is an on-demand ceiling, not a preallocation; target and host-buffer budgets remain unchanged.
- Retain exact image-view/sampler contracts with persistent images, bounded to 32 contracts per image.
- Evict only bindings not referenced by the current callback, after prior GPU work has completed; destroy bindings before their owning image.
- Add `PROSPER_NO_BACKEND_PERSISTENT_TEXTURE_BINDINGS=1` for isolated A/B testing and expose hit/miss/entry/eviction counters.
- Extend the Vulkan regression to cover first binding retention, cross-callback reuse, byte-identical output, and bounded eviction.

## Evidence

A 462-draw Evergate pass spent 8.09 ms in redundant resource preparation and 43.60 ms in draw setup. The closest 460-draw run after removing the copies spent 0.16 ms and 22.21 ms respectively, while GPU wait remained approximately 27-28 ms.

The 512 MiB cache control stabilized near 502.3 MiB but still reuploaded one 16 MiB image per dense call. A warmed 1 GiB run held the working set, reported 43 persistent image hits with zero uploads, and reduced measured texture-binding work to about 2.8 ms in a 479-draw pass. Later wall-clock controls coincided with unrelated GPU saturation, so this PR does not claim an end-to-end FPS number from those runs.

## Verification

- Linux complete build and ctest: 114/114 passed.
- Windows native `prosper-app` target: built successfully.
- Focused Vulkan tests: `texture_sample_render` and `multidraw_render` passed after rebasing the merged instance-count change.
- Real-game guards passed: Evergate title, Messenger scene, Dead Cells gameplay, and Blasphemous 2 gameplay.
- Exact-head Evergate guard: 9/9 captured frames qualified, with all structural and non-black checks passing.
- `git diff --check`: clean.

## Risk and invariants

The lifetime-sensitive path is limited to exact-validated sampled textures. Storage images, render targets, unvalidated textures, descriptor contents, swizzles, filtering, and pipeline behavior are unchanged. The existing synchronous fence remains the safety boundary before any idle binding or image can be destroyed.