### PR TITLE
diag(gpu): trace EOP registration race (#987)

### DIFF
--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -415,6 +415,11 @@ namespace {
     // ComputeN ring id). Filter GraphicsCore=-14 (shadPS4 equeue.h).
     constexpr int16_t EVFILT_GRAPHICS_CORE = -14;
     std::vector<FlipReg> g_eop_regs;   // same (eq,id,udata) shape
+    // #987 diagnostic: a completion snapshot taken before any EOP source is registered is currently
+    // delivered to zero queues. Count those observations under the same mutex as registration so the
+    // PROSPER_EOPLOG ordering is exact. This is diagnostic only: the count is never replayed.
+    uint64_t g_eop_zero_consumer_count = 0;
+    bool eoplog() { static const bool enabled = getenv("PROSPER_EOPLOG") != nullptr; return enabled; }
     // Registered user-event sources: (eq,id,udata) the game added via sceKernelAddUserEvent and may later
     // trigger. Declared here (before the pump) so the diagnostic PROSPER_PUMP_USEREV heartbeat can fire them.
     struct UserReg { uint64_t eq; int64_t id; uint64_t udata; };
@@ -509,7 +514,21 @@ void prosper_eq_add_vblank(uint64_t eq, int64_t ident, uint64_t udata) {
 }
 // Exposed to the AGC submit path (hle_agc.cpp). Register a GPU EOP event source (sceGnmAddEqEvent).
 void prosper_eq_add_eop(uint64_t eq, int64_t id, uint64_t udata) {
-    std::lock_guard lk(g_eq_mx); g_eop_regs.push_back({ eq, id, udata });
+    size_t registration_count = 0;
+    uint64_t zero_consumer_count = 0;
+    uint64_t registration_ns = 0;
+    {
+        std::lock_guard lk(g_eq_mx);
+        g_eop_regs.push_back({ eq, id, udata });
+        registration_count = g_eop_regs.size();
+        zero_consumer_count = g_eop_zero_consumer_count;
+        registration_ns = real_ns();
+    }
+    if (eoplog())
+        fprintf(stderr, "[eoprace] t_ns=%llu EOP source registered eq=0x%llx id=%lld "
+                        "(regs=%zu zero-consumer-completions=%llu)\n",
+                (unsigned long long)registration_ns, (unsigned long long)eq, (long long)id,
+                registration_count, (unsigned long long)zero_consumer_count);
 }
 // Fire the registered EOP events — called when a submit completes. Posts TriggerEvent(ident=id,
 // filter=GraphicsCore, data=id, udata) to each registered equeue, matching shadPS4's IRQ handler.
@@ -532,7 +551,20 @@ namespace {
         // is a discrete count, never a level. PROSPER_EOP_COALESCE restores the old behavior.
         static const bool coalesce = getenv("PROSPER_EOP_COALESCE") != nullptr;
         std::vector<FlipReg> regs;
-        { std::lock_guard lk(g_eq_mx); regs = g_eop_regs; }
+        uint64_t zero_consumer_ordinal = 0;
+        uint64_t snapshot_ns = 0;
+        {
+            std::lock_guard lk(g_eq_mx);
+            regs = g_eop_regs;
+            if (regs.empty()) {
+                zero_consumer_ordinal = ++g_eop_zero_consumer_count;
+                snapshot_ns = real_ns();
+            }
+        }
+        if (zero_consumer_ordinal && eoplog())
+            fprintf(stderr, "[eoprace] t_ns=%llu EOP completion snapshot had 0 registered "
+                            "queues (zero-consumer ordinal=%llu)\n",
+                    (unsigned long long)snapshot_ns, (unsigned long long)zero_consumer_ordinal);
         for (auto& r : regs) {
             SceKEvent e{}; e.ident = r.ident; e.filter = EVFILT_GRAPHICS_CORE; e.data = r.ident; e.udata = r.udata;
             eq_post(r.eq, e, coalesce);

--- a/prosper/tests/test_equeue_events.cpp
+++ b/prosper/tests/test_equeue_events.cpp
@@ -7,12 +7,15 @@
 #include "../src/hle/dispatch.hpp"
 #include "../src/hle/nid.hpp"
 #include <cstdio>
+#include <cstdlib>
 #include <cstdint>
 #include <cstring>
 #include <chrono>
 #include <thread>
 
 using namespace prosper;
+
+namespace prosper { void prosper_eq_trigger_eop(); }
 
 static int fails = 0;
 #define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
@@ -25,6 +28,11 @@ static_assert(sizeof(KEvent) == 0x20, "SceKernelEvent must be 0x20 bytes");
 
 int main() {
     printf("== test_equeue_events ==\n");
+#ifdef _WIN32
+    _putenv_s("PROSPER_EOP_SYNC", "1");
+#else
+    setenv("PROSPER_EOP_SYNC", "1", 1);
+#endif
     register_builtin_hle();
 
     auto create  = Hle::lookup(nid_hash("sceKernelCreateEqueue"));
@@ -43,6 +51,10 @@ int main() {
     uint64_t eq = 0;
     create((uint64_t)(uintptr_t)&eq, 0, 0, 0, 0, 0);
     CHECK(eq != 0, "CreateEqueue produced a handle");
+
+    // #987 diagnostic path: observe one completion before any EOP source is registered. The gated
+    // counter/log must remain observation-only; registration below must not receive a phantom replay.
+    prosper_eq_trigger_eop();
 
     // --- User event: register id=999 with a udata, trigger it, then WaitEqueue should return it. ---
     const int64_t kId = 999; const uint64_t kUdata = 0xCAFEF00D;
@@ -75,6 +87,8 @@ int main() {
     if (addeq && submit) {
         const int64_t kEop = 0x40; const uint64_t kEopUdata = 0x1234BEEF;
         addeq(eq, (uint64_t)kEop, kEopUdata, 0, 0, 0);
+        CHECK(getcount(eq, 0, 0, 0, 0, 0) == 0,
+              "pre-registration EOP diagnostic does not replay or alter queue behavior");
         // Minimal valid Dcb: a single DRAW_RESET packet (2 dwords). header = 0xC0000000 | (op<<8) | (r<<2).
         uint32_t dcbbuf[2] = { 0xC0000000u | (0x10u << 8) | (0x05u << 2), 0 };  // IT_NOP=0x10, R_DRAW_RESET=0x05
         struct Packet { uint32_t* addr; uint32_t dw_num; uint8_t pad[4]; } pkt{ dcbbuf, 2, {0,0,0,0} };


### PR DESCRIPTION
Diagnostic-only slice for #987. PROSPER_EOPLOG=1 now timestamps and numbers EOP completion snapshots taken with zero registered consumers, and each later EOP-source registration reports the current registration and zero-consumer counts. The count is protected by the existing event-queue mutex and is never replayed, so scheduling, delivery, coalescing, and queue behavior are unchanged. The equeue regression explicitly fires a pre-registration completion and proves no phantom event is delivered after registration. Focused checks: Linux 3/3; Windows 3/3; gated output shows ordinal 1 carried into the registration trace. No game fix is claimed, and no snapshots were run; a live rare macOS wedge remains necessary before changing behavior.