### PR TITLE
fix(evergate): stabilize realtime input route

### DIFF
--- a/prosper/scripts/evergate/README.md
+++ b/prosper/scripts/evergate/README.md
@@ -2,8 +2,18 @@
 
 `reach-main-menu.pad` keeps a synthetic controller connected but neutral so the title screen remains
 visible. `reach-first-gameplay.pad` repeatedly taps Cross through the opening logos, title screen,
-and first save slot. Its timing is anchored to the first pad poll and leaves ten seconds for native
-Windows initialization before sending twelve Cross pulses.
+and first save slot. Its wall-time windows are intended for the accelerated screenshot command below,
+where hundreds of render submits are deliberately skipped.
+
+`reach-first-gameplay-realtime.pad` expresses the same twelve Cross/neutral edges on the guest's pad-read
+axis. Use it for native-resolution interactive and performance runs. A synchronous render can take longer
+than a wall-time pulse, causing two pulses to merge or a complete press/release to pass between polls; the
+read-anchored route cannot lose those edges. Do not use it with snapshot acceleration: skipped render submits
+let the guest consume the early read ranges before wall-time-driven logos finish.
+
+The realtime route was validated from a fresh save with the native Windows frontend rendering every submit
+at 1920x1080: all twelve Cross/neutral edges appeared in `PROSPER_PAD_SCRIPT_LOG`, and retained captures
+progressed from save-slot selection through the transition into the opening scene.
 
 ## Headless screenshot acceptance
 
@@ -41,7 +51,7 @@ PROSPER_GUEST_FS=1 \
 PROSPER_GUEST_ARGS=-force-gfx-direct \
 PROSPER_RENDER_EVERY=1 \
 PROSPER_RENDER_SCALE=1 \
-PROSPER_PAD_SCRIPT=@scripts/evergate/reach-first-gameplay.pad \
+PROSPER_PAD_SCRIPT=@scripts/evergate/reach-first-gameplay-realtime.pad \
   ./build-linux-app/prosper-app --dump /path/to/PPSA01885-app0
 ```
 

--- a/prosper/scripts/evergate/reach-first-gameplay-realtime.pad
+++ b/prosper/scripts/evergate/reach-first-gameplay-realtime.pad
@@ -1,0 +1,16 @@
+# Evergate (PPSA01885): full-render route through the title menu and first save slot.
+# Pad-read anchoring preserves every Cross/neutral edge when synchronous rendering makes wall time
+# advance between guest polls. Keep this route for native-resolution interactive/performance runs;
+# the accelerated screenshot route must remain wall-time anchored because it skips render submits.
+p16-21:cross
+p31-40:cross
+p51-56:cross
+p64-69:cross
+p77-82:cross
+p89-96:cross
+p103-108:cross
+p117-125:cross
+p134-140:cross
+p144-148:cross
+p156-162:cross
+p173-178:cross


### PR DESCRIPTION
## Problem

Evergate's existing fresh-save route uses fixed wall-time Cross pulses. During native-resolution full rendering, a slow synchronous backend call can span an entire press/release window or merge adjacent pulses, leaving the title/menu waiting for an input edge and making automated performance runs look stuck.

The accelerated screenshot workflow has the opposite constraint: it skips hundreds of render submits, so the guest consumes early pad-read ranges before wall-time-driven logos finish. One route cannot reliably serve both modes.

## Change

- Keep `reach-first-gameplay.pad` unchanged for accelerated screenshots.
- Add `reach-first-gameplay-realtime.pad`, expressing the same twelve Cross/neutral edges on the guest pad-read axis.
- Use and document the read-anchored route only for native-resolution interactive/performance runs.

## Verification

- Native Windows screenshot frontend, fresh save, 1920x1080, every render submit enabled.
- `PROSPER_PAD_SCRIPT_LOG` observed all twelve Cross/neutral transitions at their exact read boundaries.
- Captures progressed from title to save-slot selection, through the transition, and into the opening scene over a 180-second run.
- No boot fault, capture timeout, stale frame, or loading stall occurred.
- Windows `pad_input` test passed.
- Privacy scan and `git diff --check` passed.

## Scope and risk

This changes no emulator, renderer, snapshot baseline, or existing accelerated route. It adds a dedicated performance-harness input file and updates its documentation. The split is intentional: using the read-anchored route with snapshot acceleration is documented as unsupported.