### PR TITLE
fix(gpu): honor disabled CB color mode (#919)

### DIFF
--- a/prosper/src/gpu/pm4_registers.hpp
+++ b/prosper/src/gpu/pm4_registers.hpp
@@ -402,6 +402,7 @@ constexpr uint32_t DB_SHADER_CONTROL_CONSERVATIVE_Z_EXPORT_MASK  = 0x3;
 constexpr uint32_t CB_COLOR_CONTROL            = 0x202;
 constexpr uint32_t CB_COLOR_CONTROL_MODE_SHIFT = 4;
 constexpr uint32_t CB_COLOR_CONTROL_MODE_MASK  = 0x7;
+constexpr uint32_t CB_COLOR_CONTROL_MODE_DISABLE = 0;
 constexpr uint32_t CB_COLOR_CONTROL_MODE_NORMAL = 1;
 constexpr uint32_t CB_COLOR_CONTROL_MODE_DCC_DECOMPRESS = 6;
 constexpr uint32_t CB_COLOR_CONTROL_ROP3_SHIFT = 16;

--- a/prosper/src/gpu/render_state.cpp
+++ b/prosper/src/gpu/render_state.cpp
@@ -47,6 +47,21 @@ int32_t scale_scissor_boundary(int32_t value, float scale, bool lower) {
         static_cast<double>(std::numeric_limits<int32_t>::max())));
 }
 
+void warn_unsupported_cb_color_mode(uint32_t mode) {
+    static std::mutex mutex;
+    static uint32_t seen_modes = 0;
+    bool first = false;
+    {
+        std::lock_guard lock(mutex);
+        const uint32_t bit = 1u << (mode & P::CB_COLOR_CONTROL_MODE_MASK);
+        first = (seen_modes & bit) == 0;
+        seen_modes |= bit;
+    }
+    if (first)
+        fprintf(stderr, "[gpu] resolve_pipeline_state: unsupported CB_COLOR_CONTROL.MODE=%u "
+                        "-> ordinary draw fallback\n", mode);
+}
+
 // sRGB (gamma-encoded) 8-bit sample -> linear [0,1]. VkClearColorValue's float channels are LINEAR
 // for an sRGB attachment (Vulkan re-encodes on store), so an sRGB fast-clear word must be linearized
 // here to round-trip to the exact stored byte. Identity at 0 and 1, so black/white are exact.
@@ -215,6 +230,7 @@ RenderState extract_render_state(const GpuState& st) {
     rs.db_stencil_control   = st.cx.count(P::DB_STENCIL_CONTROL)   ? rd(st.cx, P::DB_STENCIL_CONTROL)   : 0u;
     rs.db_stencilrefmask    = st.cx.count(P::DB_STENCILREFMASK)    ? rd(st.cx, P::DB_STENCILREFMASK)    : 0u;
     rs.db_stencilrefmask_bf = st.cx.count(P::DB_STENCILREFMASK_BF) ? rd(st.cx, P::DB_STENCILREFMASK_BF) : 0u;
+    rs.has_cb_color_control = st.cx.count(P::CB_COLOR_CONTROL) != 0;
     rs.cb_color_control  = rd(st.cx, P::CB_COLOR_CONTROL);
     rs.cb_blend0_control = bc;
     // CB_TARGET_MASK (per-MRT color write mask). The AGC driver defaults it to write-all when the game
@@ -470,12 +486,27 @@ ResolvedPipelineState resolve_pipeline_state(const RenderState& rs) {
     ps.color_write_mask = effective_color_mask & 0xFu;
     ps.color1_write_mask = (effective_color_mask >> 4) & 0xFu;
 
+    // MODE=DISABLE suppresses color-buffer writes, not the whole draw: depth/stencil tests and
+    // updates still execute. An absent CB_COLOR_CONTROL retains the legacy normal-draw behavior;
+    // otherwise a zero-initialized synthetic RenderState would unexpectedly lose every color draw.
+    // DCC_DECOMPRESS is handled by the AGC helper-program path in gpu_execute.hpp. Other hardware
+    // metadata modes remain ordinary draws for compatibility, but are now visible instead of silent.
+    const uint32_t cb_mode = PM4_FIELD(rs.cb_color_control, CB_COLOR_CONTROL, MODE);
+    if (rs.has_cb_color_control) {
+        if (cb_mode == P::CB_COLOR_CONTROL_MODE_DISABLE) {
+            ps.color_write_mask = 0;
+            ps.color1_write_mask = 0;
+        } else if (cb_mode != P::CB_COLOR_CONTROL_MODE_NORMAL &&
+                   cb_mode != P::CB_COLOR_CONTROL_MODE_DCC_DECOMPRESS) {
+            warn_unsupported_cb_color_mode(cb_mode);
+        }
+    }
+
     // CB_COLOR_CONTROL.ROP3 is AMD's global raster operation. Vulkan exposes the same 16
     // source/destination Boolean functions as VkLogicOp. COPY stays disabled here: enabling Vulkan
     // COPY would suppress ordinary blending, while disabled COPY preserves the hardware's normal
     // blend-then-copy path. CB_BLENDn_CONTROL.DISABLE_ROP3 can opt an attachment out; Vulkan's logic
     // op is global, so a mixed two-target enable cannot be represented and falls back visibly to COPY.
-    const uint32_t cb_mode = PM4_FIELD(rs.cb_color_control, CB_COLOR_CONTROL, MODE);
     const uint32_t rop3 = PM4_FIELD(rs.cb_color_control, CB_COLOR_CONTROL, ROP3);
     uint32_t logic_op = 3;
     if (cb_mode == P::CB_COLOR_CONTROL_MODE_NORMAL && vk_logic_op(rop3, logic_op) && logic_op != 3u) {

--- a/prosper/src/gpu/render_state.hpp
+++ b/prosper/src/gpu/render_state.hpp
@@ -124,6 +124,10 @@ struct RenderState {
     uint32_t db_stencil_control   = 0;   // DB_STENCIL_CONTROL   (front/back stencil-fail / z-pass / z-fail ops)
     uint32_t db_stencilrefmask    = 0;   // DB_STENCILREFMASK    (front ref / compare-mask / write-mask)
     uint32_t db_stencilrefmask_bf = 0;   // DB_STENCILREFMASK_BF (back-face ref / compare-mask / write-mask)
+    // MODE=0 means DISABLE when the register was explicitly programmed, but zero is also the
+    // historical value of an absent register in synthetic/legacy streams. Retain presence so the
+    // resolver can honor a real disable without turning old direct RenderState users into no-ops.
+    bool     has_cb_color_control = false;
     uint32_t cb_color_control  = 0;   // CB_COLOR_CONTROL
     uint32_t cb_blend0_control = 0;   // CB_BLEND0_CONTROL
     uint32_t cb_target_mask    = 0;   // CB_TARGET_MASK (per-MRT write mask)

--- a/prosper/tests/test_multidraw_render.cpp
+++ b/prosper/tests/test_multidraw_render.cpp
@@ -92,6 +92,43 @@ int main() {
         if (c) CHECK(c[0] > 0xC0 && c[1] < 0x40 && c[2] < 0x40, "one opaque red draw -> RED center");
     }
 
+    // #919: an explicitly programmed CB_COLOR_CONTROL.MODE=DISABLE reaches Vulkan as zero color
+    // write masks, while the same draw can still populate stencil for a later color pass.
+    {
+        RenderState raw{};
+        raw.prim_type = 4; // triangle list
+        raw.cb_target_mask = raw.cb_shader_mask = 0xFu;
+        raw.has_cb_color_control = true;
+        raw.cb_color_control = 0; // MODE=DISABLE
+        ResolvedPipelineState disabled = resolve_pipeline_state(raw);
+        CHECK(disabled.color_write_mask == 0,
+              "explicit CB MODE=DISABLE reaches Vulkan with color writes disabled");
+
+        ResolvedPipelineState writer = disabled;
+        writer.stencil_enable = true;
+        writer.stencil_compare_op[0] = writer.stencil_compare_op[1] = 7; // ALWAYS
+        writer.stencil_pass_op[0] = writer.stencil_pass_op[1] = 2;       // REPLACE
+        writer.stencil_op_val[0] = writer.stencil_op_val[1] = 2;
+        writer.stencil_write_mask[0] = writer.stencil_write_mask[1] = 0xff;
+
+        prosper::test::BackendDraw w; w.vs = vs; w.fs = red; w.ps = &writer; w.vcount = 3;
+        const std::vector<uint8_t> suppressed = prosper::test::render_draws_rgba({w}, W, H);
+        const uint8_t* sc = center(suppressed);
+        CHECK(sc && sc[2] > 0xC0 && sc[0] < 0x40 && sc[1] < 0x40,
+              "CB MODE=DISABLE red fragment preserves the blue color attachment");
+
+        ResolvedPipelineState reader = opaque;
+        reader.stencil_enable = true;
+        reader.stencil_compare_op[0] = reader.stencil_compare_op[1] = 2; // EQUAL
+        reader.stencil_ref[0] = reader.stencil_ref[1] = 2;
+        reader.stencil_compare_mask[0] = reader.stencil_compare_mask[1] = 0xff;
+        prosper::test::BackendDraw r; r.vs = vs; r.fs = green; r.ps = &reader; r.vcount = 3;
+        const std::vector<uint8_t> consumed = prosper::test::render_draws_rgba({w, r}, W, H);
+        const uint8_t* cc = center(consumed);
+        CHECK(cc && cc[1] > 0xC0 && cc[0] < 0x40 && cc[2] < 0x40,
+              "CB MODE=DISABLE draw still writes stencil consumed by a later color pass");
+    }
+
     // Hardware instance count reaches both Vulkan submission paths. Additive quarter-red makes the
     // number of identical instances directly observable: one instance contributes ~64 red, while
     // three contribute ~192. The indexed sibling must produce the same pixels.

--- a/prosper/tests/test_render_state.cpp
+++ b/prosper/tests/test_render_state.cpp
@@ -413,9 +413,63 @@ int main() {
     }
 
     CHECK(rs.db_depth_control  == 0x00000046u, "db_depth_control raw preserved");
-    CHECK(rs.cb_color_control  == 0x00CC0010u, "cb_color_control raw preserved");
+    CHECK(rs.has_cb_color_control && rs.cb_color_control == 0x00CC0010u,
+          "programmed cb_color_control presence and raw value preserved");
     CHECK(rs.cb_target_mask    == 0x000000FFu, "cb_target_mask raw preserved");
     CHECK(rs.cb_shader_mask    == 0x000000F3u, "cb_shader_mask raw preserved");
+
+    // #919: an explicit MODE=DISABLE suppresses MRT writes but must not suppress depth/stencil.
+    // Presence matters because zero is also the historical value of an absent register in direct
+    // RenderState users. DCC_DECOMPRESS remains owned by the helper-program path in gpu_execute.hpp.
+    {
+        GpuState absent_state;
+        absent_state.cx[P::CB_TARGET_MASK] = 0xFFu;
+        absent_state.cx[P::CB_SHADER_MASK] = 0xFFu;
+        RenderState absent = extract_render_state(absent_state);
+        ResolvedPipelineState absent_ps = resolve_pipeline_state(absent);
+        CHECK(!absent.has_cb_color_control && absent_ps.color_write_mask == 0xFu &&
+                  absent_ps.color1_write_mask == 0xFu,
+              "absent CB_COLOR_CONTROL retains legacy color-write behavior");
+
+        RenderState disabled = absent;
+        disabled.has_cb_color_control = true;
+        disabled.cb_color_control =
+            P::CB_COLOR_CONTROL_MODE_DISABLE << P::CB_COLOR_CONTROL_MODE_SHIFT;
+        disabled.z_write_enable = true;
+        ResolvedPipelineState disabled_ps = resolve_pipeline_state(disabled);
+        CHECK(disabled_ps.color_write_mask == 0 && disabled_ps.color1_write_mask == 0,
+              "explicit CB MODE=DISABLE suppresses every MRT color-write mask");
+        CHECK(disabled_ps.depth_write_enable && has_depth_stencil_side_effect(disabled_ps),
+              "explicit CB MODE=DISABLE preserves depth/stencil side effects");
+
+        RenderState normal = absent;
+        normal.has_cb_color_control = true;
+        normal.cb_color_control =
+            P::CB_COLOR_CONTROL_MODE_NORMAL << P::CB_COLOR_CONTROL_MODE_SHIFT;
+        CHECK(resolve_pipeline_state(normal).color_write_mask == 0xFu,
+              "explicit CB MODE=NORMAL retains ordinary color writes");
+
+        RenderState dcc = absent;
+        dcc.has_cb_color_control = true;
+        dcc.cb_color_control =
+            P::CB_COLOR_CONTROL_MODE_DCC_DECOMPRESS << P::CB_COLOR_CONTROL_MODE_SHIFT;
+        CHECK(resolve_pipeline_state(dcc).color_write_mask == 0xFu,
+              "DCC decompress keeps its helper-program handling outside state resolution");
+
+        RenderState unsupported2 = absent;
+        unsupported2.has_cb_color_control = true;
+        unsupported2.cb_color_control = 2u << P::CB_COLOR_CONTROL_MODE_SHIFT;
+        RenderState unsupported3 = unsupported2;
+        unsupported3.cb_color_control = 3u << P::CB_COLOR_CONTROL_MODE_SHIFT;
+        const std::string mode_diagnostics = capture_stderr([&] {
+            (void)resolve_pipeline_state(unsupported2);
+            (void)resolve_pipeline_state(unsupported2);
+            (void)resolve_pipeline_state(unsupported3);
+        });
+        CHECK(occurrence_count(mode_diagnostics, "MODE=2 ") == 1u &&
+                  occurrence_count(mode_diagnostics, "MODE=3 ") == 1u,
+              "unmodeled CB modes log once per distinct value while retaining fallback behavior");
+    }
 
     // #309: CB fast-clear word extraction + format-aware decode in resolve_pipeline_state.
     CHECK(rs.color0_has_clear, "color0_has_clear = true (CLEAR_WORD programmed)");


### PR DESCRIPTION
## Summary
- distinguish an explicitly programmed `CB_COLOR_CONTROL` from an absent legacy register
- translate explicit `MODE=DISABLE` into zero Vulkan color-write masks without dropping depth/stencil effects
- retain the existing DCC-decompress helper path and log other unsupported modes once per value
- cover raw extraction, legacy fallback, both MRT masks, diagnostics, and real Vulkan color/stencil behavior

Refs #919. This is the CB MODE=DISABLE slice only; metadata resolve modes and actual dual-source blend-factor support remain separate.

## Focused author checks
- Windows `render_state_extract`: pass
- Windows `gpu_capture_roundtrip`: pass
- Linux `render_state_extract`, `multidraw_render`, `gpu_capture_roundtrip`, `pipeline_render`, `gpu_execute`: pass
- `git diff --check`: pass

No game snapshots or captures were run.