### PR TITLE
fix(gpu): resolve paired alpha blend factors (#919)

### DIFF
--- a/prosper/src/gpu/render_state.cpp
+++ b/prosper/src/gpu/render_state.cpp
@@ -448,17 +448,17 @@ ResolvedPipelineState resolve_pipeline_state(const RenderState& rs) {
         }
     }
 
-    ps.blend_enable            = rs.blend_enable;
-    ps.src_color_blend_factor  = vk_blend_factor(rs.color_src_blend);
-    ps.dst_color_blend_factor  = vk_blend_factor(rs.color_dst_blend);
-    ps.color_blend_op          = vk_blend_op(rs.color_comb_fcn);
+    ps.blend_enable = rs.blend_enable;
+    vk_blend_factors(rs.color_src_blend, rs.color_dst_blend,
+                     ps.src_color_blend_factor, ps.dst_color_blend_factor);
+    ps.color_blend_op = vk_blend_op(rs.color_comb_fcn);
     // Alpha blend factors/op (#381): use the separate ALPHA_* fields when SEPARATE_ALPHA_BLEND is set,
     // else mirror the color factors (RDNA2 behavior — Kyty GraphicsRender). The backend reads these
     // directly, so it no longer has to reuse the color factors for the alpha channel (which corrupted
     // stored dst-alpha on any target later read back — RTT composites, alpha-test/text layers).
     if (rs.separate_alpha_blend) {
-        ps.src_alpha_blend_factor = vk_blend_factor(rs.alpha_src_blend);
-        ps.dst_alpha_blend_factor = vk_blend_factor(rs.alpha_dst_blend);
+        vk_blend_factors(rs.alpha_src_blend, rs.alpha_dst_blend,
+                         ps.src_alpha_blend_factor, ps.dst_alpha_blend_factor);
         ps.alpha_blend_op         = vk_blend_op(rs.alpha_comb_fcn);
     } else {
         ps.src_alpha_blend_factor = ps.src_color_blend_factor;
@@ -467,12 +467,12 @@ ResolvedPipelineState resolve_pipeline_state(const RenderState& rs) {
     }
 
     ps.blend1_enable = rs.blend1_enable;
-    ps.src_color_blend_factor1 = vk_blend_factor(rs.color1_src_blend);
-    ps.dst_color_blend_factor1 = vk_blend_factor(rs.color1_dst_blend);
+    vk_blend_factors(rs.color1_src_blend, rs.color1_dst_blend,
+                     ps.src_color_blend_factor1, ps.dst_color_blend_factor1);
     ps.color_blend_op1 = vk_blend_op(rs.color1_comb_fcn);
     if (rs.separate_alpha_blend1) {
-        ps.src_alpha_blend_factor1 = vk_blend_factor(rs.alpha1_src_blend);
-        ps.dst_alpha_blend_factor1 = vk_blend_factor(rs.alpha1_dst_blend);
+        vk_blend_factors(rs.alpha1_src_blend, rs.alpha1_dst_blend,
+                         ps.src_alpha_blend_factor1, ps.dst_alpha_blend_factor1);
         ps.alpha_blend_op1 = vk_blend_op(rs.alpha1_comb_fcn);
     } else {
         ps.src_alpha_blend_factor1 = ps.src_color_blend_factor1;

--- a/prosper/src/gpu/vk_translate.cpp
+++ b/prosper/src/gpu/vk_translate.cpp
@@ -177,11 +177,10 @@ uint32_t vk_blend_factor(uint32_t f) {
         case 0x14: return 13;  // OneMinusConstAlpha-> ONE_MINUS_CONSTANT_ALPHA
         default: break;
     }
-    // BOTH_SRC_ALPHA/BOTH_INV_SRC_ALPHA (0x0b/0x0c) program the paired source and destination
-    // factors on RDNA2 and have no single VkBlendFactor equivalent. Keep the established ZERO
-    // fallback until the pipeline grows a dual-output path, but never make that mis-render silent.
-    // Log arbitrary unknown values through the same path so corrupt register state is diagnosable
-    // without flooding this per-draw translation.
+    // BOTH_SRC_ALPHA/BOTH_INV_SRC_ALPHA (0x0b/0x0c) are paired source-state shorthands and have no
+    // single VkBlendFactor equivalent. vk_blend_factors handles their valid source-field use. Keep
+    // direct calls (including invalid destination-field use) fail-visible, along with arbitrary
+    // unknown values, without flooding this per-draw translation.
     static std::set<uint32_t> logged;
     static std::mutex logged_mu;
     {
@@ -191,6 +190,25 @@ uint32_t vk_blend_factor(uint32_t f) {
                             "-> VK_BLEND_FACTOR_ZERO\n", f);
     }
     return 0;
+}
+
+void vk_blend_factors(uint32_t rdna2_src_factor, uint32_t rdna2_dst_factor,
+                      uint32_t& vk_src_factor, uint32_t& vk_dst_factor) {
+    // AMD documents 0x0b/0x0c as the obsolete Direct3D "both" modes. They are source-state-only
+    // shorthands which override the destination selection; they are unrelated to the distinct
+    // SRC1_* dual-source factors at 0x0f..0x12.
+    if (rdna2_src_factor == 0x0bu) {         // BOTH_SRC_ALPHA
+        vk_src_factor = 6u;                  // VK_BLEND_FACTOR_SRC_ALPHA
+        vk_dst_factor = 7u;                  // VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA
+        return;
+    }
+    if (rdna2_src_factor == 0x0cu) {         // BOTH_INV_SRC_ALPHA
+        vk_src_factor = 7u;                  // VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA
+        vk_dst_factor = 6u;                  // VK_BLEND_FACTOR_SRC_ALPHA
+        return;
+    }
+    vk_src_factor = vk_blend_factor(rdna2_src_factor);
+    vk_dst_factor = vk_blend_factor(rdna2_dst_factor);
 }
 
 uint32_t vk_blend_op(uint32_t comb_fcn) {

--- a/prosper/src/gpu/vk_translate.hpp
+++ b/prosper/src/gpu/vk_translate.hpp
@@ -82,6 +82,12 @@ inline uint32_t vk_stencil_op(uint32_t op) {
 // DstColor=8 -> VK DST_COLOR=4). Per Kyty GraphicsRender.cpp. Unknown -> ZERO.
 uint32_t vk_blend_factor(uint32_t rdna2_factor);
 
+// Resolve a source/destination factor pair. The obsolete BOTH_SRC_ALPHA (11) and
+// BOTH_INV_SRC_ALPHA (12) source factors override the destination selection, so they must be
+// translated together rather than as independent VkBlendFactors. Other pairs use vk_blend_factor.
+void vk_blend_factors(uint32_t rdna2_src_factor, uint32_t rdna2_dst_factor,
+                      uint32_t& vk_src_factor, uint32_t& vk_dst_factor);
+
 // Map an RDNA2 COLOR_COMB_FCN to a VkBlendOp value (0=ADD,1=SUB,2=MIN,3=MAX,4=REV_SUB ->
 // VK ADD=0,SUB=1,MIN=3,MAX=4,REV_SUB=2). Unknown -> ADD.
 uint32_t vk_blend_op(uint32_t comb_fcn);

--- a/prosper/tests/test_pipeline_render.cpp
+++ b/prosper/tests/test_pipeline_render.cpp
@@ -85,6 +85,60 @@ int main() {
         CHECK(r > 128 && g < 128 && b > 128, "additive blend: red over blue -> magenta (blend state honored)");
     } else { CHECK(false, "additive blend render produced a frame"); }
 
+    // AMD's obsolete BOTH_* source factors program a complementary source/destination pair and
+    // override the destination field. Patch the fragment shader's sole 1.0 alpha constant to 0.25;
+    // red-over-blue then gives (0.25, 0, 0.75) for BOTH_SRC_ALPHA and the inverse for BOTH_INV.
+    {
+        std::vector<uint32_t> quarter_alpha_frag = frag;
+        bool patched_alpha = false;
+        for (uint32_t& word : quarter_alpha_frag) {
+            if (word == 0x3f800000u) {
+                word = 0x3e800000u;
+                patched_alpha = true;
+                break;
+            }
+        }
+        CHECK(patched_alpha, "patched triangle fragment alpha from 1.0 to 0.25");
+
+        auto resolve_both = [](uint32_t source_factor) {
+            namespace Pm4 = prosper::agc::Pm4;
+            GpuState st;
+            st.uc[Pm4::VGT_PRIMITIVE_TYPE] = 4;
+            st.cx[Pm4::CB_TARGET_MASK] = 0xFu;
+            st.cx[Pm4::CB_BLEND0_CONTROL] =
+                (source_factor << Pm4::CB_BLEND0_CONTROL_COLOR_SRCBLEND_SHIFT) |
+                (0u << Pm4::CB_BLEND0_CONTROL_COLOR_DESTBLEND_SHIFT) |
+                (1u << Pm4::CB_BLEND0_CONTROL_ENABLE_SHIFT);
+            return resolve_pipeline_state(extract_render_state(st));
+        };
+
+        ResolvedPipelineState both_src = resolve_both(0x0bu);
+        CHECK(both_src.blend_enable && both_src.src_color_blend_factor == 6u &&
+                  both_src.dst_color_blend_factor == 7u,
+              "raw BOTH_SRC_ALPHA overrides ZERO dst with SRC_ALPHA/ONE_MINUS_SRC_ALPHA");
+        std::vector<uint8_t> img_both_src =
+            render_triangle_rgba(vert, quarter_alpha_frag, W, H, &both_src);
+        if (img_both_src.size() == (size_t)W * H * 4) {
+            uint8_t r = img_both_src[center], g = img_both_src[center + 1], b = img_both_src[center + 2];
+            printf("  center (both src)    = (%u,%u,%u)\n", r, g, b);
+            CHECK(r > 40 && r < 90 && g < 16 && b > 165 && b < 215,
+                  "BOTH_SRC_ALPHA: quarter-alpha red over blue -> quarter red, three-quarter blue");
+        } else { CHECK(false, "BOTH_SRC_ALPHA render produced a frame"); }
+
+        ResolvedPipelineState both_inv = resolve_both(0x0cu);
+        CHECK(both_inv.blend_enable && both_inv.src_color_blend_factor == 7u &&
+                  both_inv.dst_color_blend_factor == 6u,
+              "raw BOTH_INV_SRC_ALPHA overrides ZERO dst with inverse paired factors");
+        std::vector<uint8_t> img_both_inv =
+            render_triangle_rgba(vert, quarter_alpha_frag, W, H, &both_inv);
+        if (img_both_inv.size() == (size_t)W * H * 4) {
+            uint8_t r = img_both_inv[center], g = img_both_inv[center + 1], b = img_both_inv[center + 2];
+            printf("  center (both inv)    = (%u,%u,%u)\n", r, g, b);
+            CHECK(r > 165 && r < 215 && g < 16 && b > 40 && b < 90,
+                  "BOTH_INV_SRC_ALPHA: quarter-alpha red over blue -> three-quarter red, quarter blue");
+        } else { CHECK(false, "BOTH_INV_SRC_ALPHA render produced a frame"); }
+    }
+
     // Logic op honored: AMD ROP3 XOR (0x66) combines the red fragment with the blue destination,
     // producing magenta. The operation is decoded from real CB_COLOR_CONTROL state and reaches the
     // VkPipelineColorBlendStateCreateInfo, proving the full register-to-pixel path.

--- a/prosper/tests/test_render_state.cpp
+++ b/prosper/tests/test_render_state.cpp
@@ -382,13 +382,35 @@ int main() {
     });
     CHECK(both_src_alpha == 0u && both_src_alpha_duplicate == 0u &&
               both_inv_src_alpha == 0u,
-          "unsupported RDNA2 dual-output blend factors retain the fail-visible ZERO fallback");
+          "paired blend factors retain the fail-visible single-factor ZERO fallback");
     CHECK(unknown_blend == 0u,
           "unknown RDNA2 blend factor retains the fail-visible ZERO fallback");
     CHECK(occurrence_count(blend_diagnostics, "factor=0xb ") == 1u &&
               occurrence_count(blend_diagnostics, "factor=0xc ") == 1u &&
               occurrence_count(blend_diagnostics, "factor=0x7f ") == 1u,
           "unsupported blend diagnostics emit once per distinct factor");
+    {
+        RenderState paired{};
+        paired.color_src_blend = 0x0bu;  // BOTH_SRC_ALPHA
+        paired.color_dst_blend = 0x00u;  // overridden by the paired source mode
+        paired.separate_alpha_blend = true;
+        paired.alpha_src_blend = 0x0cu;  // BOTH_INV_SRC_ALPHA
+        paired.alpha_dst_blend = 0x01u;  // overridden by the paired source mode
+        paired.color1_src_blend = 0x0cu;
+        paired.color1_dst_blend = 0x00u;
+        paired.separate_alpha_blend1 = true;
+        paired.alpha1_src_blend = 0x0bu;
+        paired.alpha1_dst_blend = 0x01u;
+        const ResolvedPipelineState resolved = resolve_pipeline_state(paired);
+        CHECK(resolved.src_color_blend_factor == 6u && resolved.dst_color_blend_factor == 7u,
+              "BOTH_SRC_ALPHA resolves to SRC_ALPHA/ONE_MINUS_SRC_ALPHA and overrides dst");
+        CHECK(resolved.src_alpha_blend_factor == 7u && resolved.dst_alpha_blend_factor == 6u,
+              "separate alpha BOTH_INV_SRC_ALPHA resolves to inverse paired factors");
+        CHECK(resolved.src_color_blend_factor1 == 7u && resolved.dst_color_blend_factor1 == 6u,
+              "MRT1 BOTH_INV_SRC_ALPHA resolves to inverse paired factors");
+        CHECK(resolved.src_alpha_blend_factor1 == 6u && resolved.dst_alpha_blend_factor1 == 7u,
+              "MRT1 separate alpha BOTH_SRC_ALPHA resolves to paired factors");
+    }
     CHECK(vk_blend_op(2u) == 3u, "RDNA2 comb Min(2) -> VK MIN(3) (non-identity)");
 
     // #381: separate alpha blend. The extractor's rs (bit 29 clear) mirrors color into alpha on resolve;


### PR DESCRIPTION
## Summary
- resolve raw source `BOTH_SRC_ALPHA` (0x0b) as `SRC_ALPHA` / `ONE_MINUS_SRC_ALPHA`
- resolve raw source `BOTH_INV_SRC_ALPHA` (0x0c) as the inverse pair
- apply the paired override to MRT0/MRT1 color and separate-alpha state
- retain the existing fail-visible ZERO fallback for invalid single-factor/destination-only uses and unknown values

## Semantics correction
These values are obsolete paired source-state shorthands, not dual-source blending. AMD's register guide labels 11/12 deprecated, and Direct3D documents that they override the destination selection. The actual dual-source hardware values are the separate `SRC1_*` factors 15-18.

References:
- https://docs.amd.com/v/u/en-US/evergreen_3D_registers_v2
- https://learn.microsoft.com/en-us/windows/win32/direct3d9/d3dblend

## Focused verification
- Windows: `test_render_state` passed
- Linux/WSL: `test_render_state` passed
- Linux/WSL Vulkan: `test_pipeline_render` passed
  - `BOTH_SRC_ALPHA`: quarter-alpha red over blue = `(64,0,191)`
  - `BOTH_INV_SRC_ALPHA`: quarter-alpha red over blue = `(191,0,64)`

No snapshots or captures were run.

Refs #919