### PR TITLE
feat(app): add explicit Vulkan present-mode selection (#352)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -288,6 +288,10 @@ if(TARGET prosper_core)
   target_include_directories(test_prosper_app_window_controls PRIVATE frontends/prosper-app)
   add_test(NAME prosper_app_window_controls COMMAND test_prosper_app_window_controls)
 
+  add_executable(test_prosper_app_present_mode frontends/prosper-app/test_present_mode.cpp)
+  target_include_directories(test_prosper_app_present_mode PRIVATE frontends/prosper-app)
+  add_test(NAME prosper_app_present_mode COMMAND test_prosper_app_present_mode)
+
   add_executable(test_sync_on_address tests/test_sync_on_address.cpp)
   target_link_libraries(test_sync_on_address PRIVATE prosper_core)
   add_test(NAME sync_on_address COMMAND test_sync_on_address)

--- a/prosper/docs/FRONTEND_APP.md
+++ b/prosper/docs/FRONTEND_APP.md
@@ -427,8 +427,8 @@ duplicate. Until then the app is fully functional via `--test-pattern` (and any 
   shows the composited game (verified `--dump … --frames 3`).
 - **P1 — audio** ✅ **done**: `prosper-app` installs the SDL3 `AudioSink` (`sceAudioOut` → host).
 - **P2 — controllers** ✅ **done**: installs the SDL3 `PadBackend` (host gamepad → `libScePad`).
-- **P3 — polish** (in progress): resize/fullscreen is implemented; pause/quit UX and
-  present-mode/latency tuning remain.
+- **P3 — polish** (in progress): resize/fullscreen and present-mode selection are implemented;
+  pause/quit UX remains.
   Native Windows build/run packaging is done via `scripts/run-windows.ps1`. Cooperative guest-stop
   at a flip boundary is a follow-up (today the
   guest thread is detached at window-close and reclaimed by process exit).
@@ -440,7 +440,8 @@ duplicate. Until then the app is fully functional via `--test-pattern` (and any 
 - **The run/stop hook touches the run harness** (`boot_trace`/how the guest loop is driven), which the
   render-frontier and audio workstreams also use — coordinate; keep the fixed-budget CI path intact.
 - **`feat/audio-sdl3` overlap** — P1 must build on that branch, not fork it.
-- **Present latency/vsync** is intentionally FIFO today; low-latency present-mode selection remains
-  P3 work.
+- **Present latency/vsync** defaults to FIFO. `--present-mode mailbox` opts into low-latency vsync,
+  and `--present-mode immediate` explicitly permits tearing; unsupported optional modes fall back to
+  FIFO with a diagnostic.
 - **Later zero-copy** (`external_memory`) is deliberately deferred; the readback seam is the v1 answer.
 - **area:** shared/host infrastructure — needs an `area:` decision and coordination before build.

--- a/prosper/docs/WINDOWS_RELEASE.md
+++ b/prosper/docs/WINDOWS_RELEASE.md
@@ -50,6 +50,9 @@ $env:PROSPER_SAVEDATA_DIR = "$PWD/savedata"
 `-force-gfx-direct` is the current Unity default. For a title that must not receive it, launch with
 `-GuestArgs ''`.
 
+Presentation defaults to FIFO vsync. Pass `-PresentMode mailbox` for low-latency vsync or
+`-PresentMode immediate` to permit tearing; either optional mode falls back to FIFO when unsupported.
+
 ## Input and exit
 
 SDL3 automatically uses a connected controller as pad 0. Keyboard input is composed over it:

--- a/prosper/frontends/prosper-app/README.md
+++ b/prosper/frontends/prosper-app/README.md
@@ -37,6 +37,9 @@ It reuses `prosper/build-mingw-app` on later runs. Use `-NoBuild` to skip the co
 CMake, Ninja, and MinGW-w64 UCRT are required; the launcher discovers the standard winget WinLibs
 installation automatically.
 
+Pass `-PresentMode mailbox` (low-latency vsync) or `-PresentMode immediate` (tearing permitted) to
+the Windows launcher when the driver supports it. The default is FIFO.
+
 WSLg remains an alternate way to run the Linux build, but it is no longer the primary Windows path.
 Prebuilt Windows archives include `start-prosper.ps1`; see `prosper/docs/WINDOWS_RELEASE.md` for the
 no-UI launch command, save-data selection, keyboard map, and runtime requirements.
@@ -59,6 +62,8 @@ F11 or Alt+Enter toggles borderless desktop fullscreen. Esc or closing the windo
 - `--dump <app0>` — boot and display the PS5 title at this app0 directory (positional path also works).
 - `--test-pattern` — feed a synthetic animated frame through the real present path (no guest).
 - `--frames N` — present N frames then exit 0 (non-interactive smoke; exit 1 if it couldn't).
+- `--present-mode fifo|mailbox|immediate` — choose swapchain latency behavior. FIFO is the default;
+  mailbox is low-latency vsync, and immediate may tear. Unsupported optional modes fall back to FIFO.
 - `--record PATH` — record the final controller stream to a replayable `PROSPER_PAD_SCRIPT` route.
   Missing parent directories are created; release the last held button before stopping so its interval
   is closed and flushed.

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -20,6 +20,7 @@
 #include "loader/linker.hpp"           // Program
 #include "input/pad.hpp"               // keyboard -> libScePad (HostPadState / PadBackend)
 #include "pad_overlay.hpp"              // keyboard pad 0 composed over the physical controller backend
+#include "present_mode.hpp"             // explicit swapchain latency/vsync policy, pure regression seam
 #include "window_controls.hpp"           // debounced app-window shortcuts, pure regression seam
 #ifdef PROSPER_HAVE_LIVE_RENDERER
 #include "live_renderer.hpp"           // shared DrawItem->Vulkan compositor (register_live_renderer)
@@ -177,7 +178,8 @@ bool pick_device(Vk& vk) {
     return true;
 }
 
-bool create_swapchain(Vk& vk, uint32_t w, uint32_t h) {
+bool create_swapchain(Vk& vk, uint32_t w, uint32_t h,
+                      prosper::frontend::AppPresentMode requestedPresentMode) {
     VkSurfaceCapabilitiesKHR caps; vkGetPhysicalDeviceSurfaceCapabilitiesKHR(vk.phys, vk.surface, &caps);
     vk.scExtent = caps.currentExtent.width != UINT32_MAX ? caps.currentExtent : VkExtent2D{w, h};
     if (vk.scExtent.width == 0 || vk.scExtent.height == 0) return false;   // minimized
@@ -189,6 +191,29 @@ bool create_swapchain(Vk& vk, uint32_t w, uint32_t h) {
 
     uint32_t imgCount = caps.minImageCount + 1;
     if (caps.maxImageCount && imgCount > caps.maxImageCount) imgCount = caps.maxImageCount;
+
+    uint32_t modeN = 0;
+    VKCHECK(vkGetPhysicalDeviceSurfacePresentModesKHR(vk.phys, vk.surface, &modeN, nullptr),
+            "vkGetPhysicalDeviceSurfacePresentModesKHR(count)");
+    std::vector<VkPresentModeKHR> modes(modeN);
+    VKCHECK(vkGetPhysicalDeviceSurfacePresentModesKHR(vk.phys, vk.surface, &modeN, modes.data()),
+            "vkGetPhysicalDeviceSurfacePresentModesKHR(list)");
+    const bool hasMailbox = std::find(modes.begin(), modes.end(), VK_PRESENT_MODE_MAILBOX_KHR) != modes.end();
+    const bool hasImmediate = std::find(modes.begin(), modes.end(), VK_PRESENT_MODE_IMMEDIATE_KHR) != modes.end();
+    const auto selectedPresentMode = prosper::frontend::select_present_mode(
+        requestedPresentMode, hasMailbox, hasImmediate);
+    VkPresentModeKHR vkPresentMode = VK_PRESENT_MODE_FIFO_KHR;
+    if (selectedPresentMode.mode == prosper::frontend::AppPresentMode::mailbox)
+        vkPresentMode = VK_PRESENT_MODE_MAILBOX_KHR;
+    else if (selectedPresentMode.mode == prosper::frontend::AppPresentMode::immediate)
+        vkPresentMode = VK_PRESENT_MODE_IMMEDIATE_KHR;
+    if (selectedPresentMode.fell_back) {
+        fprintf(stderr, "[app] requested present mode %s is unsupported; falling back to fifo\n",
+                prosper::frontend::present_mode_name(requestedPresentMode));
+    }
+    fprintf(stderr, "[app] present mode: %s\n",
+            prosper::frontend::present_mode_name(selectedPresentMode.mode));
+
     VkSwapchainCreateInfoKHR si{VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR};
     si.surface = vk.surface; si.minImageCount = imgCount; si.imageFormat = vk.scFormat;
     si.imageColorSpace = cs; si.imageExtent = vk.scExtent; si.imageArrayLayers = 1;
@@ -196,7 +221,7 @@ bool create_swapchain(Vk& vk, uint32_t w, uint32_t h) {
     si.imageSharingMode = VK_SHARING_MODE_EXCLUSIVE;
     si.preTransform = caps.currentTransform;
     si.compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
-    si.presentMode = VK_PRESENT_MODE_FIFO_KHR;   // vsync
+    si.presentMode = vkPresentMode;
     si.clipped = VK_TRUE;
     VKCHECK(vkCreateSwapchainKHR(vk.device, &si, nullptr, &vk.swapchain), "vkCreateSwapchainKHR");
     uint32_t n = 0; vkGetSwapchainImagesKHR(vk.device, vk.swapchain, &n, nullptr);
@@ -356,12 +381,20 @@ void poll_keyboard(const bool* keyboard, bool enter_maps_to_options) {
 
 int main(int argc, char** argv) {
     bool testPattern = false; int exitAfter = 0; uint32_t winW = 1280, winH = 720;
+    prosper::frontend::AppPresentMode requestedPresentMode = prosper::frontend::AppPresentMode::fifo;
     std::string dump;
     for (int i = 1; i < argc; i++) {
         std::string a = argv[i];
         if (a == "--test-pattern") testPattern = true;
         else if (a == "--frames" && i + 1 < argc) exitAfter = atoi(argv[++i]);   // present N frames then exit (CI/smoke)
         else if (a == "--dump" && i + 1 < argc) dump = argv[++i];                // boot the game at this app0 dir
+        else if (a == "--present-mode") {
+            if (i + 1 >= argc ||
+                !prosper::frontend::parse_present_mode(argv[++i], requestedPresentMode)) {
+                fprintf(stderr, "prosper-app: --present-mode requires fifo, mailbox, or immediate\n");
+                return 2;
+            }
+        }
         else if (a == "--record" && i + 1 < argc) {
             if (!set_environment("PROSPER_PAD_RECORD", argv[++i])) {
                 fprintf(stderr, "prosper-app: failed to set PROSPER_PAD_RECORD\n");
@@ -486,7 +519,7 @@ int main(int argc, char** argv) {
     if (!create_instance(vk, win) || !pick_device(vk)) return 1;
     // Initial swapchain sized to the window; recreated on resize / out-of-date.
     { int dw = 0, dh = 0; SDL_GetWindowSizeInPixels(win, &dw, &dh);
-      if (!create_swapchain(vk, (uint32_t)dw, (uint32_t)dh)) return 1; }
+      if (!create_swapchain(vk, (uint32_t)dw, (uint32_t)dh, requestedPresentMode)) return 1; }
 
     VkCommandPoolCreateInfo cpi{VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO};
     cpi.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT; cpi.queueFamilyIndex = vk.qfamily;
@@ -609,7 +642,8 @@ int main(int argc, char** argv) {
             vkDeviceWaitIdle(vk.device);
             if (vk.swapchain) vkDestroySwapchainKHR(vk.device, vk.swapchain, nullptr);
             vk.swapchain = VK_NULL_HANDLE;
-            if (!create_swapchain(vk, static_cast<uint32_t>(dw), static_cast<uint32_t>(dh))) {
+            if (!create_swapchain(vk, static_cast<uint32_t>(dw), static_cast<uint32_t>(dh),
+                                  requestedPresentMode)) {
                 fprintf(stderr, "[app] could not recreate the swapchain after a window-size change\n");
                 running = false;
                 break;

--- a/prosper/frontends/prosper-app/present_mode.hpp
+++ b/prosper/frontends/prosper-app/present_mode.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <string_view>
+
+namespace prosper::frontend {
+
+enum class AppPresentMode {
+    fifo,
+    mailbox,
+    immediate,
+};
+
+struct AppPresentModeSelection {
+    AppPresentMode mode = AppPresentMode::fifo;
+    bool fell_back = false;
+};
+
+constexpr const char* present_mode_name(AppPresentMode mode) {
+    switch (mode) {
+    case AppPresentMode::fifo: return "fifo";
+    case AppPresentMode::mailbox: return "mailbox";
+    case AppPresentMode::immediate: return "immediate";
+    }
+    return "fifo";
+}
+
+constexpr bool parse_present_mode(std::string_view text, AppPresentMode& mode) {
+    if (text == "fifo") mode = AppPresentMode::fifo;
+    else if (text == "mailbox") mode = AppPresentMode::mailbox;
+    else if (text == "immediate") mode = AppPresentMode::immediate;
+    else return false;
+    return true;
+}
+
+// FIFO is guaranteed by Vulkan. The optional modes are never selected implicitly: mailbox keeps
+// vsync with a replaceable queue, while immediate may tear and therefore requires an explicit request.
+constexpr AppPresentModeSelection select_present_mode(AppPresentMode requested,
+                                                       bool mailbox_supported,
+                                                       bool immediate_supported) {
+    if (requested == AppPresentMode::mailbox && !mailbox_supported)
+        return {AppPresentMode::fifo, true};
+    if (requested == AppPresentMode::immediate && !immediate_supported)
+        return {AppPresentMode::fifo, true};
+    return {requested, false};
+}
+
+} // namespace prosper::frontend

--- a/prosper/frontends/prosper-app/test_present_mode.cpp
+++ b/prosper/frontends/prosper-app/test_present_mode.cpp
@@ -1,0 +1,48 @@
+#include "present_mode.hpp"
+
+#include <cstdio>
+
+using prosper::frontend::AppPresentMode;
+using prosper::frontend::parse_present_mode;
+using prosper::frontend::present_mode_name;
+using prosper::frontend::select_present_mode;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { std::printf("  [FAIL] %s\n", m); ++fails; } \
+                         else       { std::printf("  [ok]   %s\n", m); } } while (0)
+
+int main() {
+    std::printf("== test_prosper_app_present_mode ==\n");
+
+    AppPresentMode mode = AppPresentMode::fifo;
+    CHECK(parse_present_mode("mailbox", mode) && mode == AppPresentMode::mailbox,
+          "mailbox option parses");
+    CHECK(parse_present_mode("immediate", mode) && mode == AppPresentMode::immediate,
+          "immediate option parses");
+    CHECK(parse_present_mode("fifo", mode) && mode == AppPresentMode::fifo,
+          "fifo option parses");
+    CHECK(!parse_present_mode("adaptive", mode) && mode == AppPresentMode::fifo,
+          "unknown option is rejected without changing the selection");
+
+    auto selected = select_present_mode(AppPresentMode::fifo, true, true);
+    CHECK(selected.mode == AppPresentMode::fifo && !selected.fell_back,
+          "FIFO remains selected even when optional modes are available");
+    selected = select_present_mode(AppPresentMode::mailbox, true, false);
+    CHECK(selected.mode == AppPresentMode::mailbox && !selected.fell_back,
+          "supported mailbox mode is selected");
+    selected = select_present_mode(AppPresentMode::mailbox, false, true);
+    CHECK(selected.mode == AppPresentMode::fifo && selected.fell_back,
+          "unsupported mailbox mode falls back to FIFO");
+    selected = select_present_mode(AppPresentMode::immediate, false, true);
+    CHECK(selected.mode == AppPresentMode::immediate && !selected.fell_back,
+          "supported immediate mode is selected");
+    selected = select_present_mode(AppPresentMode::immediate, true, false);
+    CHECK(selected.mode == AppPresentMode::fifo && selected.fell_back,
+          "unsupported immediate mode falls back to FIFO");
+    CHECK(std::string_view(present_mode_name(AppPresentMode::mailbox)) == "mailbox",
+          "selected modes have stable log names");
+
+    if (fails) { std::printf("== FAIL: %d ==\n", fails); return 1; }
+    std::printf("== PASS ==\n");
+    return 0;
+}

--- a/prosper/scripts/run-windows.ps1
+++ b/prosper/scripts/run-windows.ps1
@@ -9,6 +9,8 @@ param(
     [string]$Record,
     [int]$Frames = 0,
     [int]$Jobs = 8,
+    [ValidateSet('fifo', 'mailbox', 'immediate')]
+    [string]$PresentMode = 'fifo',
     [switch]$TestPattern,
     [switch]$NoBuild
 )
@@ -107,6 +109,7 @@ if ($TestPattern) {
     $runArgs += @('--dump', $Dump)
 }
 if ($Frames -gt 0) { $runArgs += @('--frames', "$Frames") }
+if ($PresentMode -ne 'fifo') { $runArgs += @('--present-mode', $PresentMode) }
 if ($Record) { $runArgs += @('--record', [IO.Path]::GetFullPath($Record)) }
 
 Write-Host "Starting $app"

--- a/prosper/scripts/run-windows.ps1
+++ b/prosper/scripts/run-windows.ps1
@@ -109,7 +109,7 @@ if ($TestPattern) {
     $runArgs += @('--dump', $Dump)
 }
 if ($Frames -gt 0) { $runArgs += @('--frames', "$Frames") }
-if ($PresentMode -ne 'fifo') { $runArgs += @('--present-mode', $PresentMode) }
+if ($PresentMode -ne 'fifo') { $runArgs += @('--present-mode', $PresentMode.ToLowerInvariant()) }
 if ($Record) { $runArgs += @('--record', [IO.Path]::GetFullPath($Record)) }
 
 Write-Host "Starting $app"

--- a/prosper/scripts/start-prosper.ps1
+++ b/prosper/scripts/start-prosper.ps1
@@ -7,6 +7,8 @@ param(
     [string]$GuestArgs = '-force-gfx-direct',
     [string]$Record,
     [int]$Frames = 0,
+    [ValidateSet('fifo', 'mailbox', 'immediate')]
+    [string]$PresentMode = 'fifo',
     [switch]$TestPattern
 )
 
@@ -36,6 +38,7 @@ if ($TestPattern) {
 }
 
 if ($Frames -gt 0) { $runArgs += @('--frames', "$Frames") }
+if ($PresentMode -ne 'fifo') { $runArgs += @('--present-mode', $PresentMode) }
 if ($Record) {
     $recordPath = [IO.Path]::GetFullPath($Record)
     $recordParent = Split-Path -Parent $recordPath

--- a/prosper/scripts/start-prosper.ps1
+++ b/prosper/scripts/start-prosper.ps1
@@ -38,7 +38,7 @@ if ($TestPattern) {
 }
 
 if ($Frames -gt 0) { $runArgs += @('--frames', "$Frames") }
-if ($PresentMode -ne 'fifo') { $runArgs += @('--present-mode', $PresentMode) }
+if ($PresentMode -ne 'fifo') { $runArgs += @('--present-mode', $PresentMode.ToLowerInvariant()) }
 if ($Record) {
     $recordPath = [IO.Path]::GetFullPath($Record)
     $recordParent = Split-Path -Parent $recordPath


### PR DESCRIPTION
## Summary
- add an explicit `--present-mode fifo|mailbox|immediate` swapchain policy while preserving FIFO as the default
- query optional surface modes, use supported opt-in mailbox/immediate modes, and fall back to FIFO with a diagnostic
- expose the choice through both Windows launchers and document the completed #352 polish slice
- add pure parser/selection regression coverage

## Author checks before PR
- Windows: built `test_prosper_app_present_mode` and full `prosper-app.exe`; focused ctest passed
- Linux: built and ran `test_prosper_app_present_mode`; focused ctest passed
- PowerShell parser accepted both launcher scripts
- native Vulkan smoke: `prosper-app.exe --test-pattern --frames 3 --present-mode mailbox` selected mailbox and exited 0
- no snapshots, captures, or game runs

Refs #352