### PR TITLE
feat(input): record routes by pad read

### DIFF
--- a/prosper/docs/INPUT_REPLAY.md
+++ b/prosper/docs/INPUT_REPLAY.md
@@ -1,6 +1,6 @@
 # Input replay & checkpoints — reaching a game state to reproduce a bug
 
-> **Status (2026-07-19): frame/pad-read anchoring, route loading/recording, and the opt-in deterministic clock have landed.**
+> **Status (2026-07-19): frame/pad-read anchoring and recording, route loading, and the opt-in deterministic clock have landed.**
 > Current master supports inline `PROSPER_PAD_SCRIPT` entries anchored as `fN:`/`fA-B:` (display
 > flips) or `pN:`/`pA-B:` (pad reads), alongside the existing seconds axis. Point entries use
 > `PROSPER_PAD_FRAME_HOLD` or `PROSPER_PAD_READ_HOLD` (both default 8) on their count axis. It also
@@ -9,15 +9,16 @@
 > between flips. Realtime/RTC clocks remain tied to host time. `PROSPER_PAD_SCRIPT=@path` loads newline-
 > separated routes with comments, explicit time/flip/read ranges, and full-deflection stick directions such
 > as `left-stick-left`. `PROSPER_PAD_RECORD=path` records the
-> final button stream on that same flip axis; `prosper-app --record path` exposes it interactively.
+> final button stream on the flip axis by default. Set `PROSPER_PAD_RECORD_AXIS=pad-read`, or pass
+> `prosper-app --record path --record-axis pad-read`, to emit successful-input-read `pA-B:` ranges.
 > `PROSPER_PAD_SCRIPT_LOG=1` logs state transitions with the elapsed time, flip, and pad-read index
 > as the game observes them.
 > `PROSPER_PAD_SCRIPT_RELOAD=1` live-reloads an `@file` route after a changed file remains
 > stable across two metadata polls. Existing time, flip, and read anchors are preserved, so an agent can
 > append future input windows during a long exploratory run without restarting the title.
 > The first checked-in route, `scripts/messenger/reach-intro-story.pad`, repeatedly reaches the opening
-> story but still has small narration-phase drift. Capturing directly onto the pad-read axis and
-> semantic checkpoint validation remain open in #302. The original design follows.
+> story but still has small narration-phase drift. Deeper route calibration and semantic checkpoint
+> validation remain open in #302. The original design follows.
 
 ## The problem
 
@@ -59,8 +60,8 @@ We already have the seed: **`PROSPER_PAD_SCRIPT` (#202)** — a scripted `PadBac
   for 250 ms and replaces the active route only after a complete stable read; read/stat failures
   retain the last valid route. Reload does not reset the first-poll wall-clock, flip, or read origin.
 
-The remaining work is deeper route calibration, pad-read-axis recording, and semantic checkpoint
-validation that does not depend on presentation speed.
+The remaining work is deeper route calibration and semantic checkpoint validation that does not
+depend on presentation speed.
 
 ## Design
 
@@ -75,7 +76,11 @@ validation that does not depend on presentation speed.
   proportional axis values remain future work.
 
 ### 2. Record mode in `prosper-app` - implemented
-`prosper-app --dump <app0> --record <file>`: capture the human's keyboard/gamepad input **stamped by flip count**, writing a script file. This is how checkpoint scripts get *created* — play to the point once, get a reusable, committable route. (The app already snapshots keyboard state per frame; recording is writing that stream out, anchored to `present_count`.)
+`prosper-app --dump <app0> --record <file>` captures the human's keyboard/gamepad button input stamped
+by display-flip count and writes a script file. Add `--record-axis pad-read` to stamp it by successful
+guest input-state reads instead; controller-information queries and rejected reads neither initialize
+nor advance that recording. The flip axis remains the default for backward compatibility. This is how
+checkpoint scripts get *created* — play to the point once, get a reusable, committable route.
 
 ### 3. Checkpoint library + agent docs
 - `prosper/scripts/<title>/reach-*.pad` — **tiny text files, no game imagery, safe to commit** (unlike golden frames). Named by the state they reach: `reach-title-menu.pad`, `reach-level1.pad`, …
@@ -97,7 +102,8 @@ Determinism is iterative: frame-anchoring first, measure drift across repeated r
 
 1. Bug reported "at the shop". Report cites `reach-shop.pad`.
 2. Agent runs their tool with `PROSPER_PAD_SCRIPT=@scripts/messenger/reach-shop.pad` + whatever debug flags — lands at the shop, observes the bug, keeps every existing tool.
-3. New checkpoint needed? Play there once with `prosper-app --record`, commit the `.pad`.
+3. New checkpoint needed? Play there once with `prosper-app --record`; add
+   `--record-axis pad-read` when input polling is the more stable clock, then commit the `.pad`.
 4. Checkpoints double as regression coverage ("can we still reach level 3?") via the #248 harness.
 
 ## Build order

--- a/prosper/docs/WINDOWS_RELEASE.md
+++ b/prosper/docs/WINDOWS_RELEASE.md
@@ -88,7 +88,9 @@ Record controller/keyboard input as a replay route while playing:
 ./start-prosper.ps1 'D:/PS5/PPSA24651-app0' -Record "$PWD/routes/session.pad"
 ```
 
-Release the final held button before exiting so its interval can be written. Runtime logs are printed
+Add `-RecordAxis pad-read` when successful input-state reads are a more stable route clock than
+display presentation; flip recording remains the default. Release the final held button before
+exiting so its interval can be written. Runtime logs are printed
 to the PowerShell console; include those logs, the title ID, GPU/driver, and the release version when
 reporting a problem.
 

--- a/prosper/frontends/prosper-app/README.md
+++ b/prosper/frontends/prosper-app/README.md
@@ -67,6 +67,9 @@ F11 or Alt+Enter toggles borderless desktop fullscreen. Esc or closing the windo
 - `--record PATH` — record the final controller stream to a replayable `PROSPER_PAD_SCRIPT` route.
   Missing parent directories are created; release the last held button before stopping so its interval
   is closed and flushed.
+- `--record-axis flip|pad-read` — timestamp recorded intervals by display flips (the backward-compatible
+  default) or by successful guest input-state reads. Pad-read routes remain stable when presentation
+  pauses while the title continues polling input.
 
 ## Notes
 

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -395,9 +395,28 @@ int main(int argc, char** argv) {
                 return 2;
             }
         }
-        else if (a == "--record" && i + 1 < argc) {
+        else if (a == "--record") {
+            if (i + 1 >= argc) {
+                fprintf(stderr, "prosper-app: --record requires a path\n");
+                return 2;
+            }
             if (!set_environment("PROSPER_PAD_RECORD", argv[++i])) {
                 fprintf(stderr, "prosper-app: failed to set PROSPER_PAD_RECORD\n");
+                return 2;
+            }
+        }
+        else if (a == "--record-axis") {
+            if (i + 1 >= argc) {
+                fprintf(stderr, "prosper-app: --record-axis requires flip or pad-read\n");
+                return 2;
+            }
+            const std::string axis = argv[++i];
+            if (axis != "flip" && axis != "pad-read") {
+                fprintf(stderr, "prosper-app: --record-axis requires flip or pad-read\n");
+                return 2;
+            }
+            if (!set_environment("PROSPER_PAD_RECORD_AXIS", axis.c_str())) {
+                fprintf(stderr, "prosper-app: failed to set PROSPER_PAD_RECORD_AXIS\n");
                 return 2;
             }
         }

--- a/prosper/scripts/messenger/README.md
+++ b/prosper/scripts/messenger/README.md
@@ -29,5 +29,7 @@ PROSPER_PAD_SCRIPT=@scripts/messenger/reach-intro-story.pad \
   and keep `PROSPER_PAD_SCRIPT_LOG=1` enabled.
 
 Create another route with `prosper-app --record <path>` or
-`PROSPER_PAD_RECORD=<path>`, replay it with `PROSPER_PAD_SCRIPT=@path`, and only
+`PROSPER_PAD_RECORD=<path>`. Add `--record-axis pad-read` (or set
+`PROSPER_PAD_RECORD_AXIS=pad-read`) when pad polling is a more stable clock than presentation. Replay
+it with `PROSPER_PAD_SCRIPT=@path`, and only
 commit it after repeated current-master runs reach the state named by the file.

--- a/prosper/scripts/run-windows.ps1
+++ b/prosper/scripts/run-windows.ps1
@@ -7,6 +7,8 @@ param(
     [string]$GuestArgs = '-force-gfx-direct',
     [string]$SavedataDir,
     [string]$Record,
+    [ValidateSet('flip', 'pad-read')]
+    [string]$RecordAxis = 'flip',
     [int]$Frames = 0,
     [int]$Jobs = 8,
     [ValidateSet('fifo', 'mailbox', 'immediate')]
@@ -67,6 +69,9 @@ if (-not $TestPattern) {
         throw "Dump is not a directory: $Dump"
     }
 }
+if (-not $Record -and $RecordAxis -ne 'flip') {
+    throw '-RecordAxis requires -Record.'
+}
 
 $cmake = (Get-Command cmake -ErrorAction Stop).Source
 $cache = Join-Path $BuildDir 'CMakeCache.txt'
@@ -110,7 +115,12 @@ if ($TestPattern) {
 }
 if ($Frames -gt 0) { $runArgs += @('--frames', "$Frames") }
 if ($PresentMode -ne 'fifo') { $runArgs += @('--present-mode', $PresentMode.ToLowerInvariant()) }
-if ($Record) { $runArgs += @('--record', [IO.Path]::GetFullPath($Record)) }
+if ($Record) {
+    $runArgs += @('--record', [IO.Path]::GetFullPath($Record))
+    if ($RecordAxis -ne 'flip') {
+        $runArgs += @('--record-axis', $RecordAxis.ToLowerInvariant())
+    }
+}
 
 Write-Host "Starting $app"
 & $app @runArgs

--- a/prosper/scripts/start-prosper.ps1
+++ b/prosper/scripts/start-prosper.ps1
@@ -6,6 +6,8 @@ param(
     [string]$SavedataDir = (Join-Path $PSScriptRoot 'savedata'),
     [string]$GuestArgs = '-force-gfx-direct',
     [string]$Record,
+    [ValidateSet('flip', 'pad-read')]
+    [string]$RecordAxis = 'flip',
     [int]$Frames = 0,
     [ValidateSet('fifo', 'mailbox', 'immediate')]
     [string]$PresentMode = 'fifo',
@@ -17,6 +19,9 @@ $app = Join-Path $PSScriptRoot 'prosper-app.exe'
 
 if (-not (Test-Path -LiteralPath $app -PathType Leaf)) {
     throw "prosper-app.exe must be beside this script: $app"
+}
+if (-not $Record -and $RecordAxis -ne 'flip') {
+    throw '-RecordAxis requires -Record.'
 }
 
 $runArgs = @()
@@ -44,6 +49,9 @@ if ($Record) {
     $recordParent = Split-Path -Parent $recordPath
     if ($recordParent) { New-Item -ItemType Directory -Path $recordParent -Force | Out-Null }
     $runArgs += @('--record', $recordPath)
+    if ($RecordAxis -ne 'flip') {
+        $runArgs += @('--record-axis', $RecordAxis.ToLowerInvariant())
+    }
 }
 
 & $app @runArgs

--- a/prosper/src/hle/hle_pad.cpp
+++ b/prosper/src/hle/hle_pad.cpp
@@ -301,19 +301,36 @@ bool apply_pad_script(HostPadState& s, int64_t frame, int64_t read) {
     return true;
 }
 
-// Record the final button stream as explicit flip ranges. Completed intervals are flushed immediately;
-// only a button still held when a process is force-killed can be absent from the route tail.
-void pad_record(int64_t frame, uint32_t buttons) {
+PadRecordAxis pad_record_axis() {
+    static const PadRecordAxis axis = [] {
+        const char* configured = getenv("PROSPER_PAD_RECORD_AXIS");
+        if (!configured || !*configured || strcmp(configured, "flip") == 0)
+            return PadRecordAxis::display_flip;
+        if (strcmp(configured, "pad-read") == 0) return PadRecordAxis::pad_read;
+        fprintf(stderr,
+                "[pad] PROSPER_PAD_RECORD_AXIS: unknown value '%s'; using flip\n", configured);
+        return PadRecordAxis::display_flip;
+    }();
+    return axis;
+}
+
+// Record the final button stream as explicit flip or successful-pad-read ranges. Completed intervals
+// are flushed immediately; only a button still held when a process is force-killed can be absent from
+// the route tail. Metadata polls do not initialize or advance a pad-read-axis recording.
+void pad_record(int64_t frame, int64_t read, uint32_t buttons) {
     static const char* output = getenv("PROSPER_PAD_RECORD");
     if (!output || !*output) return;
+    const PadRecordAxis axis = pad_record_axis();
+    if (axis == PadRecordAxis::pad_read && read < 0) return;
+    const int64_t position = axis == PadRecordAxis::pad_read ? read : frame;
     struct Recorder {
+        explicit Recorder(PadRecordAxis selected) : state(selected) {}
         std::mutex mutex;
         bool initialized = false;
         FILE* file = nullptr;
-        uint32_t previous = 0;
-        int64_t start = 0;
+        PadRecordState state;
     };
-    static Recorder recorder;
+    static Recorder recorder(axis);
     std::lock_guard<std::mutex> lock(recorder.mutex);
     if (!recorder.initialized) {
         recorder.initialized = true;
@@ -324,27 +341,26 @@ void pad_record(int64_t frame, uint32_t buttons) {
             fprintf(stderr, "[pad] PROSPER_PAD_RECORD: cannot create '%s': %s\n",
                     path.parent_path().string().c_str(), ec.message().c_str());
         } else if ((recorder.file = fopen(output, "w"))) {
-            fprintf(recorder.file,
-                    "# recorded PROSPER_PAD_SCRIPT route; fN is display flips since first pad poll\n");
+            if (axis == PadRecordAxis::pad_read) {
+                fprintf(recorder.file,
+                        "# recorded PROSPER_PAD_SCRIPT route; pN is successful pad reads since first input-state read\n");
+            } else {
+                fprintf(recorder.file,
+                        "# recorded PROSPER_PAD_SCRIPT route; fN is display flips since first pad poll\n");
+            }
             fflush(recorder.file);
-            fprintf(stderr, "[pad] recording input route -> %s\n", output);
+            fprintf(stderr, "[pad] recording input route (%s axis) -> %s\n",
+                    axis == PadRecordAxis::pad_read ? "pad-read" : "flip", output);
         } else {
             fprintf(stderr, "[pad] PROSPER_PAD_RECORD: cannot open '%s': %s\n",
                     output, strerror(errno));
         }
     }
-    if (!recorder.file || buttons == recorder.previous) return;
-    if (recorder.previous) {
-        const int64_t end = std::max(frame, recorder.start + 1);
-        const std::string names = pad_button_names(recorder.previous);
-        if (!names.empty()) {
-            fprintf(recorder.file, "f%lld-%lld:%s\n", (long long)recorder.start,
-                    (long long)end, names.c_str());
-            fflush(recorder.file);
-        }
-    }
-    recorder.previous = buttons;
-    recorder.start = frame;
+    if (!recorder.file) return;
+    const std::string completed = recorder.state.observe(position, buttons);
+    if (completed.empty()) return;
+    fputs(completed.c_str(), recorder.file);
+    fflush(recorder.file);
 }
 
 // Snapshot the controller for a given pad handle via the installed backend. With no host frontend
@@ -364,7 +380,7 @@ HostPadState poll_controller(int /*handle*/, const char* what, bool consume_inpu
     const int64_t frame = pad_frame_now();
     const int64_t read = consume_input_read ? pad_read_now() : -1;
     apply_pad_script(s, frame, read);
-    pad_record(frame, s.buttons);
+    pad_record(frame, read, s.buttons);
     padlog_once(what, &s);
     return s;
 }

--- a/prosper/src/input/pad.cpp
+++ b/prosper/src/input/pad.cpp
@@ -148,6 +148,25 @@ std::string pad_button_names(uint32_t mask) {
     return result;
 }
 
+std::string PadRecordState::observe(int64_t position, uint32_t buttons) {
+    if (buttons == previous_) return {};
+
+    std::string completed;
+    if (previous_) {
+        // A press and release can be observed at the same count (for example, through two pad
+        // polls during one display flip). Preserve the existing recorder's non-empty range rule.
+        const int64_t end = position > start_ ? position : start_ + 1;
+        const std::string names = pad_button_names(previous_);
+        if (!names.empty()) {
+            completed = (axis_ == PadRecordAxis::pad_read ? "p" : "f") +
+                        std::to_string(start_) + "-" + std::to_string(end) + ":" + names + "\n";
+        }
+    }
+    previous_ = buttons;
+    start_ = position;
+    return completed;
+}
+
 std::vector<PadScriptEntry> parse_pad_script(const std::string& spec) {
     std::vector<PadScriptEntry> v;
     size_t i = 0;

--- a/prosper/src/input/pad.hpp
+++ b/prosper/src/input/pad.hpp
@@ -180,6 +180,26 @@ uint32_t pad_button_by_name(const std::string& name);
 // stable order so recorded routes have deterministic text.
 std::string pad_button_names(uint32_t mask);
 
+// Recording uses the same explicit-range syntax accepted by PROSPER_PAD_SCRIPT. Keep transition
+// tracking pure so interval boundaries and axis prefixes can be tested without an output file or
+// a controller backend. The caller supplies either the current display-flip or successful-read
+// position; observe() returns a completed interval when the button state changes.
+enum class PadRecordAxis : uint8_t {
+    display_flip,
+    pad_read,
+};
+
+class PadRecordState {
+public:
+    explicit PadRecordState(PadRecordAxis axis = PadRecordAxis::display_flip) : axis_(axis) {}
+    std::string observe(int64_t position, uint32_t buttons);
+
+private:
+    PadRecordAxis axis_;
+    uint32_t previous_ = 0;
+    int64_t start_ = 0;
+};
+
 // Parse ';'- or newline-separated entries. Actions are '+'-joined button names and/or full-stick
 // directions such as "left-stick-left" and "right-stick-up". A time token starting with 'f' is
 // frame-anchored (flips since the first pad poll); one starting with 'p' is pad-read-anchored

--- a/prosper/tests/test_pad.cpp
+++ b/prosper/tests/test_pad.cpp
@@ -189,6 +189,29 @@ int main() {
               (SCE_PAD_BUTTON_LEFT | SCE_PAD_BUTTON_SQUARE | SCE_PAD_BUTTON_R1),
               "names: recorded text round-trips through parser");
 
+        PadRecordState flip_record;
+        CHECK(flip_record.observe(9, 0).empty(), "record: initial neutral flip emits nothing");
+        CHECK(flip_record.observe(10, SCE_PAD_BUTTON_CROSS).empty(),
+              "record: flip press starts an interval");
+        CHECK(flip_record.observe(12, SCE_PAD_BUTTON_CROSS).empty(),
+              "record: unchanged flip state emits nothing");
+        CHECK(flip_record.observe(15, SCE_PAD_BUTTON_OPTIONS) == "f10-15:cross\n",
+              "record: flip transition closes the previous interval");
+        CHECK(flip_record.observe(15, 0) == "f15-16:options\n",
+              "record: same-flip release preserves a non-empty interval");
+
+        PadRecordState read_record(PadRecordAxis::pad_read);
+        CHECK(read_record.observe(3, SCE_PAD_BUTTON_UP | SCE_PAD_BUTTON_CROSS).empty(),
+              "record: pad-read press starts an interval");
+        const std::string read_interval = read_record.observe(5, 0);
+        CHECK(read_interval == "p3-5:up+cross\n",
+              "record: pad-read release emits a canonical p-range");
+        auto recorded_read = parse_pad_script(read_interval);
+        CHECK(recorded_read.size() == 1 && recorded_read[0].read_anchored &&
+              recorded_read[0].t_secs == 3.0 && recorded_read[0].end == 5.0 &&
+              recorded_read[0].button_mask == (SCE_PAD_BUTTON_UP | SCE_PAD_BUTTON_CROSS),
+              "record: pad-read interval round-trips through the route parser");
+
         auto s = parse_pad_script("3:start;9.5:cross;16:up+cross");
         CHECK(s.size() == 3, "parse: 3 entries");
         CHECK(s[0].t_secs == 3.0 && s[0].button_mask == SCE_PAD_BUTTON_OPTIONS, "parse: entry0 t/mask");

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -54,8 +54,10 @@ line, `#` comments,
 and explicit ranges such as `f300-340:cross`. Full-deflection stick actions use names such as
 `left-stick-left` and can be combined with buttons using `+`. See `docs/INPUT_REPLAY.md`.
 Set `PROSPER_PAD_RECORD=<path>` on any runner, or use `prosper-app --record <path>`, to capture the
-final button stream in that format. Completed button intervals are flushed immediately; scripted stick
-directions are supported for playback but are not yet emitted by the recorder.
+final button stream in that format. Recording uses `fA-B:` flip ranges by default; set
+`PROSPER_PAD_RECORD_AXIS=pad-read`, or add `prosper-app --record-axis pad-read`, for `pA-B:` ranges
+that advance only on successful input-state reads. Completed button intervals are flushed immediately;
+scripted stick directions are supported for playback but are not yet emitted by the recorder.
 Set `PROSPER_PAD_SCRIPT_LOG=1` to log each scripted state transition observed at a pad poll.
 For long exploratory runs, add `PROSPER_PAD_SCRIPT_RELOAD=1` to live-reload an `@file` route while
 preserving its original time/flip/read origin; append only future windows and confirm the reload log.


### PR DESCRIPTION
## Summary
- keep flip-count route recording as the backward-compatible default
- add an opt-in pad-read recording axis that emits replayable `pA-B:` intervals only from successful input-state reads
- expose the axis through prosper-app and both Windows launchers, with pure recorder-boundary coverage and updated workflow docs

Progresses #302 (pad-read recording slice only; deeper route calibration and semantic checkpoint validation remain).

## Focused author checks
- Linux `test_pad`: PASS
- Windows `test_pad.exe`: PASS
- Windows `prosper-app.exe` target: built successfully
- CLI missing/invalid/accepted `--record-axis` paths: PASS
- PowerShell syntax and mixed-case `Pad-Read` validation: PASS

No game runs, snapshots, or captures were used.