### PR TITLE
feat(frontend): present save progress non-modally

### DIFF
--- a/prosper/docs/FRONTEND_APP.md
+++ b/prosper/docs/FRONTEND_APP.md
@@ -427,7 +427,8 @@ duplicate. Until then the app is fully functional via `--test-pattern` (and any 
   shows the composited game (verified `--dump … --frames 3`).
 - **P1 — audio** ✅ **done**: `prosper-app` installs the SDL3 `AudioSink` (`sceAudioOut` → host).
 - **P2 — controllers** ✅ **done**: installs the SDL3 `PadBackend` (host gamepad → `libScePad`).
-- **P3 — polish** (in progress): resize/fullscreen and present-mode selection are implemented;
+- **P3 — polish** (in progress): resize/fullscreen, present-mode selection, and non-modal SaveData
+  percentage progress presentation are implemented;
   pause/quit UX remains.
   Native Windows build/run packaging is done via `scripts/run-windows.ps1`. Cooperative guest-stop
   at a flip boundary is a follow-up (today the

--- a/prosper/frontends/dialog_sdl3/dialog_helpers.cpp
+++ b/prosper/frontends/dialog_sdl3/dialog_helpers.cpp
@@ -252,6 +252,40 @@ SaveDataRequest read_savedata_request(uint64_t param) {
         request.buttons = save_user_buttons(0);
         request.error = true;
         request.supported = true;
+        return request;
+    }
+
+    if (request.mode == SAVE_DATA_DIALOG_MODE_PROGRESS_BAR) {
+        const uint64_t progress = local_field<uint64_t>(outer, 0x68);
+        if (!progress) return request;
+        // ProgressBarParam prefix: barType@0, pad@4, msg@8, sysMsgType@16. The only documented
+        // bar type is PERCENTAGE=0; reading just the owned prefix avoids relying on reserved size.
+        std::array<uint8_t, 20> progress_param{};
+        if (!guest_read_bytes(progress, progress_param.data(), progress_param.size()) ||
+            local_field<uint32_t>(progress_param, 0x00) != 0)
+            return request;
+        const uint64_t message = local_field<uint64_t>(progress_param, 0x08);
+        if (message) {
+            if (!guest_string(message, request.message)) return request;
+        } else {
+            switch (local_field<uint32_t>(progress_param, 0x10)) {
+            case 0: // INVALID: intentionally no message
+                break;
+            case 1: // PROGRESS: choose the inherited action-specific system text
+                request.message = request.displayType == 1 ? "Saving..." :
+                                  request.displayType == 2 ? "Loading..." :
+                                  request.displayType == 3 ? "Deleting..." : "";
+                break;
+            case 2: // RESTORE
+                request.message = "Restoring saved data...";
+                break;
+            default:
+                return request;
+            }
+        }
+        request.progress = true;
+        request.cancelable = false;
+        request.supported = true;
     }
     return request;
 }
@@ -273,9 +307,10 @@ void SaveDataDialogState::open(SaveDataRequest request) {
     if (!generation_) ++generation_; // zero is reserved for "no ticket"
     request_ = std::move(request);
     button_ = 0;
+    progress_ = 0;
     canceled_ = false;
     status_ = 2 /*RUNNING*/;
-    pending_generation_ = generation_;
+    pending_generation_ = request_.progress ? 0 : generation_;
 }
 
 int SaveDataDialogState::status() const {
@@ -315,6 +350,34 @@ void SaveDataDialogState::complete(uint64_t generation, int clicked) {
 SaveDataResultSnapshot SaveDataDialogState::result_snapshot() const {
     std::lock_guard<std::mutex> lock(mx_);
     return {request_, button_, canceled_};
+}
+
+void SaveDataDialogState::progress_inc(uint32_t target, uint32_t delta) {
+    std::lock_guard<std::mutex> lock(mx_);
+    if (target != 0 || status_ != 2 /*RUNNING*/ || !request_.progress) return;
+    progress_ = delta > UINT32_MAX - progress_ ? UINT32_MAX : progress_ + delta;
+}
+
+void SaveDataDialogState::progress_set(uint32_t target, uint32_t value) {
+    std::lock_guard<std::mutex> lock(mx_);
+    if (target != 0 || status_ != 2 /*RUNNING*/ || !request_.progress) return;
+    progress_ = value;
+}
+
+void SaveDataDialogState::finish_progress(uint64_t generation) {
+    std::lock_guard<std::mutex> lock(mx_);
+    if (!generation || generation_ != generation || status_ != 2 /*RUNNING*/ ||
+        !request_.progress)
+        return;
+    button_ = 0;
+    canceled_ = false;
+    status_ = 3 /*FINISHED: preserve the core's neutral headless fallback*/;
+}
+
+SaveDataProgressSnapshot SaveDataDialogState::progress_snapshot() const {
+    std::lock_guard<std::mutex> lock(mx_);
+    if (status_ != 2 /*RUNNING*/ || !request_.progress) return {};
+    return {generation_, request_, progress_};
 }
 
 // --- ImeDialog text entry ---

--- a/prosper/frontends/dialog_sdl3/dialog_helpers.hpp
+++ b/prosper/frontends/dialog_sdl3/dialog_helpers.hpp
@@ -55,6 +55,7 @@ struct SaveDataRequest {
     bool supported = false;       // false -> frontend declines ownership; core keeps headless policy
     bool error = false;           // choose the error rather than information message-box style
     bool cancelable = true;       // false when OptionBack::DISABLE forbids a back/cancel outcome
+    bool progress = false;        // non-modal PROGRESS_BAR request; guest Close owns completion
     uint32_t mode = 0;
     uint32_t displayType = 0;     // 1=SAVE, 2=LOAD, 3=DELETE
     uint64_t userData = 0;
@@ -76,6 +77,13 @@ struct SaveDataResultSnapshot {
     bool canceled = false;
 };
 
+struct SaveDataProgressSnapshot {
+    uint64_t generation = 0;
+    SaveDataRequest request{};
+    uint32_t value = 0;
+    explicit operator bool() const { return generation != 0; }
+};
+
 class SaveDataDialogState {
 public:
     void open(SaveDataRequest request);
@@ -85,20 +93,25 @@ public:
     bool active(uint64_t generation) const;
     void complete(uint64_t generation, int clicked);
     SaveDataResultSnapshot result_snapshot() const;
+    void progress_inc(uint32_t target, uint32_t delta);
+    void progress_set(uint32_t target, uint32_t value);
+    void finish_progress(uint64_t generation);
+    SaveDataProgressSnapshot progress_snapshot() const;
 
 private:
     mutable std::mutex mx_;
     SaveDataRequest request_{};
     int status_ = 0;
     uint32_t button_ = 0;
+    uint32_t progress_ = 0;
     bool canceled_ = false;
     uint64_t generation_ = 0;
     uint64_t pending_generation_ = 0;
 };
 
 // Parse the supported non-list modes into an owned request safe to retain until the SDL main-thread
-// pump runs. USER_MSG, ordinary SYSTEM_MSG confirmations/notices, and ERROR_CODE are supported.
-// LIST and progress/no-button modes deliberately return supported=false until their dedicated UI exists.
+// pump runs. USER_MSG, ordinary SYSTEM_MSG confirmations/notices, ERROR_CODE, and non-modal
+// PROGRESS_BAR are supported. LIST deliberately returns supported=false until its virtual-slot UI exists.
 SaveDataRequest read_savedata_request(uint64_t param);
 
 // Write only fields owned by the service: mode/result/buttonId/userData. Caller-provided dirName and

--- a/prosper/frontends/dialog_sdl3/dialog_sdl3.hpp
+++ b/prosper/frontends/dialog_sdl3/dialog_sdl3.hpp
@@ -2,8 +2,8 @@
 //
 // Built only when -DPROSPER_APP=ON (needs SDL3 video). Installs a PlatformUi that shows real
 // SDL_ShowMessageBox dialogs for the guest's MsgDialog / ErrorDialog, so a windowed session presents
-// them instead of the core's headless auto-dismiss. ImeDialog text entry (which needs a custom text
-// field, not a message box) is not handled yet, so it falls back to the core's headless default.
+// them instead of the core's headless auto-dismiss. Custom main-thread windows provide ImeDialog text
+// entry, SaveData confirmations, and non-modal SaveData percentage progress.
 #pragma once
 
 namespace prosper {
@@ -16,8 +16,8 @@ bool install_sdl3_platform_ui();
 void shutdown_sdl3_platform_ui();
 
 // Pump pending interactive UI on the MAIN thread — call once per frame from the app's event/present
-// loop. The ImeDialog text-entry modal (SDL windowing is main-thread only) runs here; MsgDialog/
-// ErrorDialog use SDL_ShowMessageBox directly and don't need it. Safe to call when nothing is pending.
+// loop. ImeDialog/SaveData UI (SDL windowing is main-thread only) runs here; MsgDialog/ErrorDialog use
+// SDL_ShowMessageBox directly and don't need it. Safe to call when nothing is pending.
 void sdl_platform_ui_pump();
 
 } // namespace prosper

--- a/prosper/frontends/dialog_sdl3/platform_ui_sdl3.cpp
+++ b/prosper/frontends/dialog_sdl3/platform_ui_sdl3.cpp
@@ -7,6 +7,7 @@
 #include "dialog_helpers.hpp"
 #include "hle/platform_ui.hpp"
 #include <SDL3/SDL.h>
+#include <algorithm>
 #include <atomic>
 #include <cstdio>
 #include <cstring>
@@ -190,9 +191,12 @@ struct SdlPlatformUi : PlatformUi {
     void errorDialogClose() override { err_status.store(0); }
 
     // SaveDataDialog. Open copies the guest request; the prosper-app main-thread pump owns SDL UI.
-    // LIST/progress modes are declined until their dedicated virtual-slot UI exists, preserving the
-    // core's established headless auto-dismiss for those modes.
+    // Modal notices and the non-modal progress window share the same generation-safe state. LIST is
+    // still declined until its dedicated virtual-slot UI exists, preserving the headless fallback.
     SaveDataDialogState save_state;
+    SDL_Window* save_progress_window = nullptr;
+    SDL_Renderer* save_progress_renderer = nullptr;
+    uint64_t save_progress_generation = 0;
 
     bool saveDataDialogOpen(uint64_t param) override {
         SaveDataRequest request = read_savedata_request(param);
@@ -206,7 +210,60 @@ struct SdlPlatformUi : PlatformUi {
         write_savedata_result(result, snapshot.request, snapshot.buttonId, snapshot.canceled);
         return (int)snapshot.buttonId;
     }
+    void saveDataDialogProgressBarInc(uint32_t target, uint32_t delta) override {
+        save_state.progress_inc(target, delta);
+    }
+    void saveDataDialogProgressBarSetValue(uint32_t target, uint32_t value) override {
+        save_state.progress_set(target, value);
+    }
     void saveDataDialogClose() override { save_state.close(); }
+
+    void close_progress_window() {
+        if (save_progress_renderer) SDL_DestroyRenderer(save_progress_renderer);
+        if (save_progress_window) SDL_DestroyWindow(save_progress_window);
+        save_progress_renderer = nullptr;
+        save_progress_window = nullptr;
+        save_progress_generation = 0;
+    }
+
+    bool render_progress(const SaveDataProgressSnapshot& progress) {
+        if (!progress) {
+            close_progress_window();
+            return true;
+        }
+        if (progress.generation != save_progress_generation) {
+            close_progress_window();
+            const SDL_WindowFlags flags = SDL_WINDOW_ALWAYS_ON_TOP | SDL_WINDOW_UTILITY |
+                                          SDL_WINDOW_NOT_FOCUSABLE;
+            if (!SDL_CreateWindowAndRenderer("prosper - Saved Data", 560, 160, flags,
+                                             &save_progress_window, &save_progress_renderer)) {
+                SDL_Log("prosper: saved-data progress window failed: %s", SDL_GetError());
+                return false;
+            }
+            save_progress_generation = progress.generation;
+        }
+
+        const uint32_t percent = std::min(progress.value, 100u);
+        SDL_SetRenderDrawColor(save_progress_renderer, 28, 30, 40, 255);
+        SDL_RenderClear(save_progress_renderer);
+        SDL_SetRenderDrawColor(save_progress_renderer, 235, 235, 240, 255);
+        const char* message = progress.request.message.empty() ?
+            "Saved data operation in progress..." : progress.request.message.c_str();
+        SDL_RenderDebugText(save_progress_renderer, 24.0f, 28.0f, message);
+
+        SDL_FRect outline{40.0f, 86.0f, 480.0f, 28.0f};
+        SDL_SetRenderDrawColor(save_progress_renderer, 220, 220, 230, 255);
+        SDL_RenderRect(save_progress_renderer, &outline);
+        SDL_FRect fill{42.0f, 88.0f, 4.76f * percent, 24.0f};
+        SDL_SetRenderDrawColor(save_progress_renderer, 76, 132, 214, 255);
+        SDL_RenderFillRect(save_progress_renderer, &fill);
+        char percent_text[16] = {};
+        std::snprintf(percent_text, sizeof percent_text, "%u%%", percent);
+        SDL_SetRenderDrawColor(save_progress_renderer, 245, 245, 250, 255);
+        SDL_RenderDebugText(save_progress_renderer, 264.0f, 124.0f, percent_text);
+        SDL_RenderPresent(save_progress_renderer);
+        return true;
+    }
 
     // Ime keyboard presence: a windowed session runs on a host with a keyboard, so report one (#347).
     // This makes sceImeKeyboardGetResourceId/GetInfo report a connected keyboard, enabling a title's
@@ -246,6 +303,9 @@ struct SdlPlatformUi : PlatformUi {
     // MAIN-thread: if a text dialog is pending, run its modal to completion (writes the guest buffer,
     // then flips status to FINISHED so the guest's next poll — and its buffer read — see it).
     void pump() {
+        const SaveDataProgressSnapshot progress = save_state.progress_snapshot();
+        if (!render_progress(progress) && progress)
+            save_state.finish_progress(progress.generation);
         const SaveDataModalTicket ticket = save_state.take_pending();
         if (ticket) {
             auto active = [this, generation = ticket.generation] {
@@ -261,6 +321,11 @@ struct SdlPlatformUi : PlatformUi {
             ime_status.store(2 /*Finished*/);
         }
     }
+
+    void shutdown() {
+        save_state.close();
+        close_progress_window();
+    }
 };
 
 SdlPlatformUi g_sdl_ui;
@@ -269,12 +334,12 @@ SdlPlatformUi g_sdl_ui;
 
 bool install_sdl3_platform_ui() {
     set_platform_ui(&g_sdl_ui);
-    SDL_Log("prosper: SDL3 dialog backend installed (Msg/Error/SaveData + Ime text entry)");
+    SDL_Log("prosper: SDL3 dialog backend installed (Msg/Error/SaveData progress + Ime text entry)");
     return true;
 }
 void shutdown_sdl3_platform_ui() {
     set_platform_ui(nullptr);
-    g_sdl_ui.saveDataDialogClose();
+    g_sdl_ui.shutdown();
 }
 void sdl_platform_ui_pump() { g_sdl_ui.pump(); }
 

--- a/prosper/frontends/dialog_sdl3/test_dialog_helpers.cpp
+++ b/prosper/frontends/dialog_sdl3/test_dialog_helpers.cpp
@@ -150,6 +150,43 @@ int main() {
         CHECK(!read_savedata_request((uint64_t)(uintptr_t)save_param).supported,
               "SaveDataDialog progress message declines modal ownership");
 
+        uint8_t progress[24] = {};
+        uint32_t bar_type = 0 /*PERCENTAGE*/, progress_system = 1 /*PROGRESS*/;
+        const char* progress_message = "Writing checkpoint...";
+        uint64_t progress_message_ptr = (uint64_t)(uintptr_t)progress_message;
+        uint64_t progress_ptr = (uint64_t)(uintptr_t)progress;
+        std::memcpy(progress + 0, &bar_type, 4);
+        std::memcpy(progress + 8, &progress_message_ptr, 8);
+        std::memcpy(progress + 16, &progress_system, 4);
+        save_mode = SAVE_DATA_DIALOG_MODE_PROGRESS_BAR;
+        display_type = 1 /*SAVE*/;
+        std::memcpy(save_param + 0x34, &save_mode, 4);
+        std::memcpy(save_param + 0x38, &display_type, 4);
+        std::memcpy(save_param + 0x68, &progress_ptr, 8);
+        request = read_savedata_request((uint64_t)(uintptr_t)save_param);
+        CHECK(request.supported && request.progress && !request.cancelable &&
+                  request.message == progress_message,
+              "SaveDataDialog PROGRESS_BAR copies a custom message for non-modal ownership");
+
+        progress_message_ptr = 0;
+        display_type = 2 /*LOAD*/;
+        std::memcpy(progress + 8, &progress_message_ptr, 8);
+        std::memcpy(save_param + 0x38, &display_type, 4);
+        request = read_savedata_request((uint64_t)(uintptr_t)save_param);
+        CHECK(request.supported && request.progress && request.message == "Loading...",
+              "SaveDataDialog PROGRESS system message follows the display operation");
+        progress_system = 2 /*RESTORE*/;
+        std::memcpy(progress + 16, &progress_system, 4);
+        request = read_savedata_request((uint64_t)(uintptr_t)save_param);
+        CHECK(request.supported && request.message == "Restoring saved data...",
+              "SaveDataDialog RESTORE system message is retained by the progress request");
+        bar_type = 1; std::memcpy(progress + 0, &bar_type, 4);
+        CHECK(!read_savedata_request((uint64_t)(uintptr_t)save_param).supported,
+              "SaveDataDialog rejects an unknown progress-bar type");
+        progress_ptr = 1; std::memcpy(save_param + 0x68, &progress_ptr, 8);
+        CHECK(!read_savedata_request((uint64_t)(uintptr_t)save_param).supported,
+              "SaveDataDialog rejects an unreadable progress parameter without crashing");
+
         uint8_t error[36] = {};
         uint32_t error_code = 0x809F000F;
         std::memcpy(error, &error_code, 4);
@@ -265,6 +302,37 @@ int main() {
         std::memcpy(&lifecycle_button, lifecycle_result + 8, 4);
         CHECK(lifecycle_common == 1 && lifecycle_button == 0,
               "SaveData lifecycle canceled completion writes USER_CANCELED + INVALID");
+
+        SaveDataRequest progress_request;
+        progress_request.supported = true;
+        progress_request.progress = true;
+        progress_request.mode = SAVE_DATA_DIALOG_MODE_PROGRESS_BAR;
+        progress_request.message = "Saving...";
+        state.open(progress_request);
+        CHECK(!state.take_pending(),
+              "SaveData progress never enters the blocking modal ticket path");
+        SaveDataProgressSnapshot progress = state.progress_snapshot();
+        CHECK(progress && progress.value == 0 && progress.request.message == "Saving...",
+              "SaveData progress starts at zero with an owned request snapshot");
+        state.progress_inc(1 /*unsupported target*/, 50);
+        state.progress_inc(0, 35);
+        state.progress_set(0, 80);
+        state.progress_inc(0, 5);
+        CHECK(state.progress_snapshot().value == 85,
+              "SaveData progress ignores other targets and applies set/increment in order");
+        const uint64_t old_progress_generation = progress.generation;
+        state.open(progress_request);
+        SaveDataProgressSnapshot replacement_progress = state.progress_snapshot();
+        state.finish_progress(old_progress_generation);
+        CHECK(replacement_progress && replacement_progress.generation != old_progress_generation &&
+                  state.status() == 2 && state.progress_snapshot().value == 0,
+              "SaveData progress re-Open invalidates stale finish and resets percentage");
+        state.finish_progress(replacement_progress.generation);
+        SaveDataResultSnapshot progress_result = state.result_snapshot();
+        CHECK(state.status() == 3 && !state.progress_snapshot() &&
+                  !progress_result.canceled && progress_result.buttonId == 0,
+              "SaveData progress UI failure finishes with the neutral headless result");
+        state.close();
     }
 
     // --- ImeDialog: read_ime_request from a synthetic OrbisImeDialogParam (96 bytes) ---

--- a/prosper/frontends/prosper-app/README.md
+++ b/prosper/frontends/prosper-app/README.md
@@ -83,6 +83,11 @@ For frontend A/B diagnostics, `PROSPER_APP_DISABLE_AUDIO=1`, `PROSPER_APP_DISABL
 the core's realtime silent audio sink, keyboard/scripted pad input, or headless dialog auto-dismiss.
 These switches isolate frontend-specific behavior without requiring a separate build.
 
+The SDL dialog backend presents message/error/save confirmations, IME text entry, and SaveData
+percentage progress. Progress uses a non-focusable utility window updated from the app's main thread,
+so the title keeps presenting and retains keyboard/controller focus. SaveData LIST selection remains a
+separate virtual-slot follow-up; prosper never opens an arbitrary host file picker for guest save data.
+
 - Two Vulkan contexts by design (`docs/FRONTEND_APP.md`): the core renders headless; the app owns a
   separate presentation device; frames cross as CPU pixels via `present_readback`.
 - On window-close the guest thread is detached and reclaimed by process exit (a cooperative

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -590,7 +590,12 @@ int main(int argc, char** argv) {
         SDL_Event ev;
         while (SDL_PollEvent(&ev)) {
             if (ev.type == SDL_EVENT_QUIT) running = false;
-            else if (ev.type == SDL_EVENT_KEY_DOWN || ev.type == SDL_EVENT_KEY_UP) {
+            else if (ev.type == SDL_EVENT_WINDOW_CLOSE_REQUESTED &&
+                     ev.window.windowID == appWindowId) {
+                // A progress utility window means the app window is not necessarily SDL's last
+                // window, so closing it no longer guarantees a synthesized SDL_EVENT_QUIT.
+                running = false;
+            } else if (ev.type == SDL_EVENT_KEY_DOWN || ev.type == SDL_EVENT_KEY_UP) {
                 prosper::frontend::AppWindowKey key{};
                 key.app_window = ev.key.windowID == appWindowId;
                 key.pressed = ev.key.down;


### PR DESCRIPTION
## Summary
- parse the inherited SaveDataDialog `PROGRESS_BAR` contract with fault-contained guest reads and operation-specific fallback text
- retain target-0 percentage updates in the existing generation-safe owner state while leaving modal requests unchanged
- create, update, and destroy a non-focusable SDL utility progress window from the app main-thread pump
- preserve headless auto-dismiss and leave LIST/virtual-slot selection as a separate follow-up

Progresses #772 (non-modal progress presentation slice only).

ABI reference: https://github.com/shadps4-emu/shadPS4/blob/bfb0122bbe3c1dc7c71d4973d321869c0eb5e015/src/core/libraries/save_data/dialog/savedatadialog_ui.h

## Focused author checks
- Linux `test_dialog_helpers`: PASS
- Windows `test_dialog_helpers.exe`: PASS
- Linux/Windows `dialog_helpers` and `platform_ui` ctest selections: PASS
- Windows `prosper-app.exe` target: built successfully after rebasing to live master
- `git diff --check`: PASS

No game runs, snapshots, or captures were used.