### PR TITLE
feat(frontend): select virtual save slots

### DIFF
--- a/prosper/docs/FRONTEND_APP.md
+++ b/prosper/docs/FRONTEND_APP.md
@@ -428,7 +428,8 @@ duplicate. Until then the app is fully functional via `--test-pattern` (and any 
 - **P1 — audio** ✅ **done**: `prosper-app` installs the SDL3 `AudioSink` (`sceAudioOut` → host).
 - **P2 — controllers** ✅ **done**: installs the SDL3 `PadBackend` (host gamepad → `libScePad`).
 - **P3 — polish** (in progress): resize/fullscreen, present-mode selection, and non-modal SaveData
-  percentage progress presentation are implemented;
+  percentage progress presentation and SaveData virtual-slot LIST selection are implemented. The LIST
+  boundary retains only guest virtual directory names and never exposes a host file picker;
   pause/quit UX remains.
   Native Windows build/run packaging is done via `scripts/run-windows.ps1`. Cooperative guest-stop
   at a flip boundary is a follow-up (today the

--- a/prosper/frontends/dialog_sdl3/dialog_helpers.cpp
+++ b/prosper/frontends/dialog_sdl3/dialog_helpers.cpp
@@ -124,6 +124,25 @@ bool guest_string(uint64_t address, std::string& out) {
     return false;
 }
 
+bool guest_dir_name(uint64_t address, std::string& out) {
+    std::array<char, 32> name{};
+    if (!guest_read_bytes(address, name.data(), name.size())) return false;
+    const char* end = (const char*)std::memchr(name.data(), 0, name.size());
+    if (!end) return false; // the result ABI needs a bounded, NUL-terminated 32-byte name
+    out.assign(name.data(), (size_t)(end - name.data()));
+    return true;
+}
+
+bool read_save_back_option(const std::array<uint8_t, 0x98>& outer, bool& enabled) {
+    enabled = true;
+    const uint64_t option = local_field<uint64_t>(outer, 0x78);
+    if (!option) return true;
+    uint32_t value = 0;
+    if (!guest_read_bytes(option, &value, sizeof value)) return false;
+    enabled = value == 0; // OptionBack::ENABLE=0, DISABLE=1
+    return true;
+}
+
 MsgButtons save_user_buttons(uint32_t type) {
     switch (type) {
     case 0: return {1, {"OK", nullptr, nullptr}, {1, 0, 0}};
@@ -155,6 +174,73 @@ SaveDataRequest read_savedata_request(uint64_t param) {
     request.mode = local_field<uint32_t>(outer, 0x34);
     request.displayType = local_field<uint32_t>(outer, 0x38);
     request.userData = local_field<uint64_t>(outer, 0x70);
+
+    if (request.mode == SAVE_DATA_DIALOG_MODE_LIST) {
+        if (request.displayType < 1 || request.displayType > 3) return request;
+        bool back_enabled = true;
+        if (!read_save_back_option(outer, back_enabled)) return request;
+        request.cancelable = back_enabled;
+
+        const uint64_t items_address = local_field<uint64_t>(outer, 0x48);
+        if (!items_address) return request;
+        // SaveDialogItems owned prefix through itemStyle: dirName@0x10, count@0x18,
+        // newItem@0x20, focusPos@0x28, focusPosDirName@0x30, itemStyle@0x38.
+        std::array<uint8_t, 0x3c> items{};
+        if (!guest_read_bytes(items_address, items.data(), items.size())) return request;
+        const uint64_t names_address = local_field<uint64_t>(items, 0x10);
+        const uint32_t names_count = local_field<uint32_t>(items, 0x18);
+        constexpr uint32_t MAX_SLOT_NAMES = 1024;
+        if (names_count > MAX_SLOT_NAMES || (names_count && !names_address)) return request;
+
+        const uint64_t new_item_address = local_field<uint64_t>(items, 0x20);
+        if (request.displayType == 1 && new_item_address) {
+            uint64_t title_address = 0;
+            if (!guest_read_bytes(new_item_address, &title_address, sizeof title_address))
+                return request;
+            SaveDataSlot slot;
+            if (title_address && !guest_string(title_address, slot.label)) return request;
+            if (slot.label.empty()) slot.label = "New Save";
+            request.slots.push_back(std::move(slot));
+        }
+
+        for (uint32_t i = 0; i < names_count; ++i) {
+            if (names_address > UINT64_MAX - (uint64_t)i * 32u) return SaveDataRequest{};
+            SaveDataSlot slot;
+            if (!guest_dir_name(names_address + (uint64_t)i * 32u, slot.dirName))
+                return SaveDataRequest{};
+            if (slot.dirName.empty()) continue;
+            slot.label = slot.dirName;
+            request.slots.push_back(std::move(slot));
+        }
+
+        const uint32_t focus = local_field<uint32_t>(items, 0x28);
+        if (!request.slots.empty()) {
+            if (focus == 1 || focus == 3 || focus == 5) {
+                request.initialSlot = request.slots.size() - 1;
+            } else if ((focus == 2 || focus == 4) && request.slots.front().dirName.empty() &&
+                       request.slots.size() > 1) {
+                request.initialSlot = 1; // DATAHEAD/DATALATEST skip the SAVE new-item entry
+            } else if (focus == 6) {
+                const uint64_t focus_name_address = local_field<uint64_t>(items, 0x30);
+                std::string focus_name;
+                if (!focus_name_address || !guest_dir_name(focus_name_address, focus_name))
+                    return SaveDataRequest{};
+                const auto found = std::find_if(request.slots.begin(), request.slots.end(),
+                    [&](const SaveDataSlot& slot) { return slot.dirName == focus_name; });
+                if (found != request.slots.end())
+                    request.initialSlot = (size_t)(found - request.slots.begin());
+            }
+        } else if (!request.cancelable) {
+            return request; // avoid owning a list with neither a selectable item nor a Back path
+        }
+
+        request.message = request.displayType == 1 ? "Select where to save." :
+                          request.displayType == 2 ? "Select saved data to load." :
+                                                     "Select saved data to delete.";
+        request.slotList = true;
+        request.supported = true;
+        return request;
+    }
 
     if (request.mode == SAVE_DATA_DIALOG_MODE_USER_MSG) {
         const uint64_t user = local_field<uint64_t>(outer, 0x50);
@@ -228,12 +314,7 @@ SaveDataRequest read_savedata_request(uint64_t param) {
         }
         if (type == 10 || type == 11 || type == 13) {
             bool back_enabled = true; // OptionBack defaults to ENABLE when the pointer is absent.
-            const uint64_t option = local_field<uint64_t>(outer, 0x78);
-            if (option) {
-                uint32_t option_back = 0;
-                if (!guest_read_bytes(option, &option_back, sizeof option_back)) return request;
-                back_enabled = option_back == 0; // ENABLE=0, DISABLE=1
-            }
+            if (!read_save_back_option(outer, back_enabled)) return request;
             request.cancelable = back_enabled;
             request.buttons = save_user_buttons(back_enabled ? 3u : 0u);
         }
@@ -291,7 +372,7 @@ SaveDataRequest read_savedata_request(uint64_t param) {
 }
 
 void write_savedata_result(uint64_t result, const SaveDataRequest& request,
-                           uint32_t buttonId, bool canceled) {
+                           uint32_t buttonId, bool canceled, const std::string& dirName) {
     if (!result || result > UINT64_MAX - 0x20) return;
     const uint32_t common_result = canceled ? 1u : 0u;
     const uint32_t guest_button = canceled ? 0u : buttonId;
@@ -299,6 +380,15 @@ void write_savedata_result(uint64_t result, const SaveDataRequest& request,
     (void)guest_write_bytes(result + 0x04, &common_result, sizeof common_result);
     (void)guest_write_bytes(result + 0x08, &guest_button, sizeof guest_button);
     (void)guest_write_bytes(result + 0x20, &request.userData, sizeof request.userData);
+    if (request.mode == SAVE_DATA_DIALOG_MODE_LIST) {
+        uint64_t output = 0;
+        if (guest_read_bytes(result + 0x10, &output, sizeof output) && output) {
+            std::array<char, 32> name{};
+            const size_t length = std::min(dirName.size(), name.size() - 1);
+            std::memcpy(name.data(), dirName.data(), length);
+            (void)guest_write_bytes(output, name.data(), name.size());
+        }
+    }
 }
 
 void SaveDataDialogState::open(SaveDataRequest request) {
@@ -309,6 +399,7 @@ void SaveDataDialogState::open(SaveDataRequest request) {
     button_ = 0;
     progress_ = 0;
     canceled_ = false;
+    dir_name_.clear();
     status_ = 2 /*RUNNING*/;
     pending_generation_ = request_.progress ? 0 : generation_;
 }
@@ -347,9 +438,23 @@ void SaveDataDialogState::complete(uint64_t generation, int clicked) {
     status_ = 3 /*FINISHED*/;
 }
 
+void SaveDataDialogState::complete_list(uint64_t generation, int selected) {
+    std::lock_guard<std::mutex> lock(mx_);
+    if (status_ != 2 || generation != generation_ || !request_.slotList) return;
+    if (selected >= 0 && (size_t)selected < request_.slots.size()) {
+        dir_name_ = request_.slots[(size_t)selected].dirName;
+        canceled_ = false;
+    } else {
+        dir_name_.clear();
+        canceled_ = true;
+    }
+    button_ = 0; // LIST selection has no button id
+    status_ = 3 /*FINISHED*/;
+}
+
 SaveDataResultSnapshot SaveDataDialogState::result_snapshot() const {
     std::lock_guard<std::mutex> lock(mx_);
-    return {request_, button_, canceled_};
+    return {request_, button_, canceled_, dir_name_};
 }
 
 void SaveDataDialogState::progress_inc(uint32_t target, uint32_t delta) {

--- a/prosper/frontends/dialog_sdl3/dialog_helpers.cpp
+++ b/prosper/frontends/dialog_sdl3/dialog_helpers.cpp
@@ -163,7 +163,7 @@ const char* save_action(uint32_t display_type) {
 
 } // namespace
 
-SaveDataRequest read_savedata_request(uint64_t param) {
+SaveDataRequest read_savedata_request(uint64_t param, SaveDataSlotTimeLookup slotTime) {
     SaveDataRequest request;
     if (!param) return request;
     std::array<uint8_t, 0x98> outer{};
@@ -215,11 +215,30 @@ SaveDataRequest read_savedata_request(uint64_t param) {
 
         const uint32_t focus = local_field<uint32_t>(items, 0x28);
         if (!request.slots.empty()) {
-            if (focus == 1 || focus == 3 || focus == 5) {
+            if (focus == 1 || focus == 3) {
                 request.initialSlot = request.slots.size() - 1;
-            } else if ((focus == 2 || focus == 4) && request.slots.front().dirName.empty() &&
+            } else if (focus == 2 && request.slots.front().dirName.empty() &&
                        request.slots.size() > 1) {
-                request.initialSlot = 1; // DATAHEAD/DATALATEST skip the SAVE new-item entry
+                request.initialSlot = 1; // DATAHEAD skips the SAVE new-item entry
+            } else if (focus == 4 || focus == 5) {
+                if (!slotTime) return SaveDataRequest{};
+                bool found_time = false;
+                int64_t best_time = 0;
+                for (size_t index = 0; index < request.slots.size(); ++index) {
+                    const SaveDataSlot& slot = request.slots[index];
+                    if (slot.dirName.empty()) continue;
+                    int64_t modified = 0;
+                    if (!slotTime(slot.dirName, modified)) continue;
+                    if (!found_time || (focus == 4 ? modified > best_time : modified < best_time)) {
+                        found_time = true;
+                        best_time = modified;
+                        request.initialSlot = index;
+                    }
+                }
+                if (!found_time) {
+                    if (!request.slots.front().dirName.empty()) return SaveDataRequest{};
+                    request.initialSlot = 0; // reference UI focuses the new item when no data exists
+                }
             } else if (focus == 6) {
                 const uint64_t focus_name_address = local_field<uint64_t>(items, 0x30);
                 std::string focus_name;

--- a/prosper/frontends/dialog_sdl3/dialog_helpers.cpp
+++ b/prosper/frontends/dialog_sdl3/dialog_helpers.cpp
@@ -236,7 +236,8 @@ SaveDataRequest read_savedata_request(uint64_t param, SaveDataSlotTimeLookup slo
                     }
                 }
                 if (!found_time) {
-                    if (!request.slots.front().dirName.empty()) return SaveDataRequest{};
+                    if (request.slots.size() != 1 || !request.slots.front().dirName.empty())
+                        return SaveDataRequest{};
                     request.initialSlot = 0; // reference UI focuses the new item when no data exists
                 }
             } else if (focus == 6) {

--- a/prosper/frontends/dialog_sdl3/dialog_helpers.hpp
+++ b/prosper/frontends/dialog_sdl3/dialog_helpers.hpp
@@ -122,10 +122,14 @@ private:
     uint64_t pending_generation_ = 0;
 };
 
+using SaveDataSlotTimeLookup = bool (*)(const std::string& dirName, int64_t& modified);
+
 // Parse supported modes into an owned request safe to retain until the SDL main-thread pump runs.
 // LIST retains only guest-provided virtual directory names/new-item text; no host path is exposed.
 // USER_MSG, ordinary SYSTEM_MSG confirmations/notices, ERROR_CODE, and PROGRESS_BAR are also supported.
-SaveDataRequest read_savedata_request(uint64_t param);
+// Date-based LIST focus uses the optional virtual-slot metadata lookup and declines when no dated
+// guest slot can be resolved instead of substituting positional focus.
+SaveDataRequest read_savedata_request(uint64_t param, SaveDataSlotTimeLookup slotTime = nullptr);
 
 // Write fields owned by the service: mode/result/buttonId/userData and, for LIST, the selected virtual
 // directory through the caller-provided dirName pointer. The param output pointer, ABI pad, and all

--- a/prosper/frontends/dialog_sdl3/dialog_helpers.hpp
+++ b/prosper/frontends/dialog_sdl3/dialog_helpers.hpp
@@ -9,9 +9,11 @@
 //   DialogResult:         u32 mode @0 ; Result result @4 ; ButtonId buttonId @8 ; u8 reserved[32]
 //   ErrorDialog param:    s32 size @0 ; s32 errorCode @4 ; s32 userId @8 ; s32 reserved @12
 #pragma once
+#include <cstddef>
 #include <cstdint>
 #include <mutex>
 #include <string>
+#include <vector>
 
 namespace prosper {
 
@@ -39,8 +41,8 @@ uint32_t read_error_code(uint64_t param);
 
 // --- SaveDataDialog ---
 // Param layout (0x98 bytes): CommonDialog::BaseParam[0x30], size@0x30, mode@0x34,
-// dispType@0x38, then nested pointers userMsg@0x50, systemMsg@0x58, errorCode@0x60,
-// progress@0x68, userData@0x70, option@0x78. Result layout (0x48 bytes):
+// dispType@0x38, then nested pointers items@0x48, userMsg@0x50, systemMsg@0x58,
+// errorCode@0x60, progress@0x68, userData@0x70, option@0x78. Result layout (0x48 bytes):
 // mode/result/buttonId @0/4/8, caller-owned dirName/param pointers @0x10/0x18,
 // userData @0x20, reserved[32] @0x28. These offsets match the PS4/PS5 inherited ABI.
 enum : uint32_t {
@@ -51,15 +53,23 @@ enum : uint32_t {
     SAVE_DATA_DIALOG_MODE_PROGRESS_BAR = 5,
 };
 
+struct SaveDataSlot {
+    std::string dirName;          // guest virtual directory name; empty selects the SAVE new-item
+    std::string label;            // owned display label; never a host path
+};
+
 struct SaveDataRequest {
     bool supported = false;       // false -> frontend declines ownership; core keeps headless policy
     bool error = false;           // choose the error rather than information message-box style
     bool cancelable = true;       // false when OptionBack::DISABLE forbids a back/cancel outcome
     bool progress = false;        // non-modal PROGRESS_BAR request; guest Close owns completion
+    bool slotList = false;        // modal LIST request backed only by guest-provided virtual slots
     uint32_t mode = 0;
     uint32_t displayType = 0;     // 1=SAVE, 2=LOAD, 3=DELETE
     uint64_t userData = 0;
+    size_t initialSlot = 0;
     std::string message;
+    std::vector<SaveDataSlot> slots;
     MsgButtons buttons{0, {nullptr, nullptr, nullptr}, {0, 0, 0}};
 };
 
@@ -75,6 +85,7 @@ struct SaveDataResultSnapshot {
     SaveDataRequest request{};
     uint32_t buttonId = 0;
     bool canceled = false;
+    std::string dirName;
 };
 
 struct SaveDataProgressSnapshot {
@@ -92,6 +103,7 @@ public:
     SaveDataModalTicket take_pending();
     bool active(uint64_t generation) const;
     void complete(uint64_t generation, int clicked);
+    void complete_list(uint64_t generation, int selected);
     SaveDataResultSnapshot result_snapshot() const;
     void progress_inc(uint32_t target, uint32_t delta);
     void progress_set(uint32_t target, uint32_t value);
@@ -105,20 +117,23 @@ private:
     uint32_t button_ = 0;
     uint32_t progress_ = 0;
     bool canceled_ = false;
+    std::string dir_name_;
     uint64_t generation_ = 0;
     uint64_t pending_generation_ = 0;
 };
 
-// Parse the supported non-list modes into an owned request safe to retain until the SDL main-thread
-// pump runs. USER_MSG, ordinary SYSTEM_MSG confirmations/notices, ERROR_CODE, and non-modal
-// PROGRESS_BAR are supported. LIST deliberately returns supported=false until its virtual-slot UI exists.
+// Parse supported modes into an owned request safe to retain until the SDL main-thread pump runs.
+// LIST retains only guest-provided virtual directory names/new-item text; no host path is exposed.
+// USER_MSG, ordinary SYSTEM_MSG confirmations/notices, ERROR_CODE, and PROGRESS_BAR are also supported.
 SaveDataRequest read_savedata_request(uint64_t param);
 
-// Write only fields owned by the service: mode/result/buttonId/userData. Caller-provided dirName and
-// param output pointers, the ABI pad, and all reserved bytes remain untouched. `canceled` writes
-// CommonDialog::Result::USER_CANCELED and ButtonId::INVALID. An unreadable result pointer is ignored.
+// Write fields owned by the service: mode/result/buttonId/userData and, for LIST, the selected virtual
+// directory through the caller-provided dirName pointer. The param output pointer, ABI pad, and all
+// reserved bytes remain untouched. `canceled` writes USER_CANCELED, INVALID, and an empty LIST name.
+// Unreadable result/output pointers are ignored.
 void write_savedata_result(uint64_t result, const SaveDataRequest& request,
-                           uint32_t buttonId, bool canceled);
+                           uint32_t buttonId, bool canceled,
+                           const std::string& dirName = {});
 
 // --- ImeDialog (text entry) --- offsets from shadPS4 ime/ime_common.h OrbisImeDialogParam:
 //   user_id@0 type@4 ... max_text_length@36(u32) input_text_buffer@40(char16_t*) ... title@72(char16_t*)

--- a/prosper/frontends/dialog_sdl3/platform_ui_sdl3.cpp
+++ b/prosper/frontends/dialog_sdl3/platform_ui_sdl3.cpp
@@ -101,6 +101,14 @@ int run_savedata_modal(const SaveDataRequest& req, Active&& active) {
             if (ev.type == SDL_EVENT_QUIT) {
                 done = true;
             } else if (ev.type == SDL_EVENT_WINDOW_CLOSE_REQUESTED &&
+                       ev.window.windowID != window_id) {
+                // The app window is no longer SDL's last window while this modal exists. Preserve
+                // its close request as an app quit instead of draining it inside the modal loop.
+                SDL_Event quit{};
+                quit.type = SDL_EVENT_QUIT;
+                SDL_PushEvent(&quit);
+                done = true;
+            } else if (ev.type == SDL_EVENT_WINDOW_CLOSE_REQUESTED &&
                        ev.window.windowID == window_id && req.cancelable) {
                 done = true;
             } else if (ev.type == SDL_EVENT_KEY_DOWN && ev.key.windowID == window_id) {
@@ -159,6 +167,120 @@ int run_savedata_modal(const SaveDataRequest& req, Active&& active) {
     return still_active ? clicked : -2;
 }
 
+// Dedicated virtual-slot LIST modal. It renders only guest-provided directory identifiers and an
+// optional SAVE new-item label; no host filesystem path or picker crosses the frontend boundary.
+// Returns the selected slot index, -1 for cancel, or -2 when a guest Close/re-Open invalidates it.
+template<typename Active>
+int run_savedata_list(const SaveDataRequest& req, Active&& active) {
+    if (!active()) return -2;
+    SDL_Window* win = nullptr;
+    SDL_Renderer* ren = nullptr;
+    if (!SDL_CreateWindowAndRenderer("prosper - Saved Data", 640, 400, 0, &win, &ren)) {
+        SDL_Log("prosper: saved-data list window failed: %s", SDL_GetError());
+        return -1;
+    }
+    const SDL_WindowID window_id = SDL_GetWindowID(win);
+    constexpr size_t visible_rows = 8;
+    constexpr float row_x = 28.0f, row_y = 68.0f, row_w = 584.0f, row_h = 34.0f;
+    size_t selected = req.slots.empty() ? 0 : std::min(req.initialSlot, req.slots.size() - 1);
+    size_t first = selected >= visible_rows ? selected - visible_rows + 1 : 0;
+    int result = -1;
+    bool done = false;
+    auto reveal = [&] {
+        if (selected < first) first = selected;
+        if (selected >= first + visible_rows) first = selected - visible_rows + 1;
+    };
+
+    while (!done && active()) {
+        SDL_Event ev;
+        while (SDL_PollEvent(&ev)) {
+            if (ev.type == SDL_EVENT_QUIT) {
+                done = true;
+            } else if (ev.type == SDL_EVENT_WINDOW_CLOSE_REQUESTED &&
+                       ev.window.windowID != window_id) {
+                SDL_Event quit{};
+                quit.type = SDL_EVENT_QUIT;
+                SDL_PushEvent(&quit);
+                done = true;
+            } else if (ev.type == SDL_EVENT_WINDOW_CLOSE_REQUESTED &&
+                       ev.window.windowID == window_id && req.cancelable) {
+                done = true;
+            } else if (ev.type == SDL_EVENT_KEY_DOWN && ev.key.windowID == window_id) {
+                if ((ev.key.key == SDLK_UP || ev.key.key == SDLK_KP_8) && selected > 0) {
+                    --selected;
+                    reveal();
+                } else if ((ev.key.key == SDLK_DOWN || ev.key.key == SDLK_KP_2) &&
+                           selected + 1 < req.slots.size()) {
+                    ++selected;
+                    reveal();
+                } else if (ev.key.key == SDLK_HOME && !req.slots.empty()) {
+                    selected = 0;
+                    reveal();
+                } else if (ev.key.key == SDLK_END && !req.slots.empty()) {
+                    selected = req.slots.size() - 1;
+                    reveal();
+                } else if ((ev.key.key == SDLK_RETURN || ev.key.key == SDLK_KP_ENTER) &&
+                           !req.slots.empty()) {
+                    result = (int)selected;
+                    done = true;
+                } else if (ev.key.key == SDLK_ESCAPE && req.cancelable) {
+                    done = true;
+                }
+            } else if (ev.type == SDL_EVENT_MOUSE_WHEEL &&
+                       ev.wheel.windowID == window_id && !req.slots.empty()) {
+                if (ev.wheel.y > 0 && selected > 0) --selected;
+                if (ev.wheel.y < 0 && selected + 1 < req.slots.size()) ++selected;
+                reveal();
+            } else if (ev.type == SDL_EVENT_MOUSE_BUTTON_DOWN &&
+                       ev.button.windowID == window_id && ev.button.button == SDL_BUTTON_LEFT) {
+                if (ev.button.x >= row_x && ev.button.x <= row_x + row_w &&
+                    ev.button.y >= row_y) {
+                    const size_t row = (size_t)((ev.button.y - row_y) / row_h);
+                    const size_t index = first + row;
+                    if (row < visible_rows && index < req.slots.size()) {
+                        selected = index;
+                        result = (int)selected;
+                        done = true;
+                    }
+                }
+            }
+        }
+
+        SDL_SetRenderDrawColor(ren, 28, 30, 40, 255);
+        SDL_RenderClear(ren);
+        SDL_SetRenderDrawColor(ren, 235, 235, 240, 255);
+        SDL_RenderDebugText(ren, 28.0f, 24.0f, req.message.c_str());
+        if (req.slots.empty()) {
+            SDL_RenderDebugText(ren, 28.0f, 84.0f, "There is no saved data.");
+        } else {
+            const size_t end = std::min(req.slots.size(), first + visible_rows);
+            for (size_t index = first; index < end; ++index) {
+                const float y = row_y + (float)(index - first) * row_h;
+                SDL_FRect row{row_x, y, row_w, row_h - 4.0f};
+                if (index == selected) {
+                    SDL_SetRenderDrawColor(ren, 76, 132, 214, 255);
+                    SDL_RenderFillRect(ren, &row);
+                }
+                SDL_SetRenderDrawColor(ren, 210, 214, 225, 255);
+                SDL_RenderRect(ren, &row);
+                const SaveDataSlot& slot = req.slots[index];
+                const std::string label = slot.dirName.empty() ?
+                    std::string("[New Save] ") + slot.label : slot.label;
+                SDL_RenderDebugText(ren, row.x + 12.0f, row.y + 10.0f, label.c_str());
+            }
+        }
+        SDL_SetRenderDrawColor(ren, 220, 220, 230, 255);
+        SDL_RenderDebugText(ren, 28.0f, 372.0f,
+                            req.cancelable ? "Enter = Select     Esc = Back" : "Enter = Select");
+        SDL_RenderPresent(ren);
+        SDL_Delay(8);
+    }
+    const bool still_active = active();
+    SDL_DestroyRenderer(ren);
+    SDL_DestroyWindow(win);
+    return still_active ? result : -2;
+}
+
 struct SdlPlatformUi : PlatformUi {
     std::atomic<int>      msg_status{0}, err_status{0};
     std::atomic<uint32_t> msg_btn{1 /*OK*/};
@@ -191,8 +313,7 @@ struct SdlPlatformUi : PlatformUi {
     void errorDialogClose() override { err_status.store(0); }
 
     // SaveDataDialog. Open copies the guest request; the prosper-app main-thread pump owns SDL UI.
-    // Modal notices and the non-modal progress window share the same generation-safe state. LIST is
-    // still declined until its dedicated virtual-slot UI exists, preserving the headless fallback.
+    // Modal notices/LIST and the non-modal progress window share the same generation-safe state.
     SaveDataDialogState save_state;
     SDL_Window* save_progress_window = nullptr;
     SDL_Renderer* save_progress_renderer = nullptr;
@@ -207,7 +328,8 @@ struct SdlPlatformUi : PlatformUi {
     int saveDataDialogStatus() override { return save_state.status(); }
     int saveDataDialogResult(uint64_t result) override {
         const SaveDataResultSnapshot snapshot = save_state.result_snapshot();
-        write_savedata_result(result, snapshot.request, snapshot.buttonId, snapshot.canceled);
+        write_savedata_result(result, snapshot.request, snapshot.buttonId, snapshot.canceled,
+                              snapshot.dirName);
         return (int)snapshot.buttonId;
     }
     void saveDataDialogProgressBarInc(uint32_t target, uint32_t delta) override {
@@ -311,8 +433,13 @@ struct SdlPlatformUi : PlatformUi {
             auto active = [this, generation = ticket.generation] {
                 return save_state.active(generation);
             };
-            const int clicked = run_savedata_modal(ticket.request, active);
-            if (clicked != -2) save_state.complete(ticket.generation, clicked);
+            if (ticket.request.slotList) {
+                const int selected = run_savedata_list(ticket.request, active);
+                if (selected != -2) save_state.complete_list(ticket.generation, selected);
+            } else {
+                const int clicked = run_savedata_modal(ticket.request, active);
+                if (clicked != -2) save_state.complete(ticket.generation, clicked);
+            }
         }
         if (ime_pending.exchange(false)) {
             ImeRequest r; { std::lock_guard<std::mutex> lk(ime_mx); r = ime_req; }
@@ -334,7 +461,7 @@ SdlPlatformUi g_sdl_ui;
 
 bool install_sdl3_platform_ui() {
     set_platform_ui(&g_sdl_ui);
-    SDL_Log("prosper: SDL3 dialog backend installed (Msg/Error/SaveData progress + Ime text entry)");
+    SDL_Log("prosper: SDL3 dialog backend installed (Msg/Error/SaveData list+progress + Ime text entry)");
     return true;
 }
 void shutdown_sdl3_platform_ui() {

--- a/prosper/frontends/dialog_sdl3/platform_ui_sdl3.cpp
+++ b/prosper/frontends/dialog_sdl3/platform_ui_sdl3.cpp
@@ -5,6 +5,7 @@
 // modal), records the result, and reports FINISHED; the next poll returns it.
 #include "dialog_sdl3.hpp"
 #include "dialog_helpers.hpp"
+#include "hle/dispatch.hpp"
 #include "hle/platform_ui.hpp"
 #include <SDL3/SDL.h>
 #include <algorithm>
@@ -99,7 +100,9 @@ int run_savedata_modal(const SaveDataRequest& req, Active&& active) {
         SDL_Event ev;
         while (SDL_PollEvent(&ev)) {
             if (ev.type == SDL_EVENT_QUIT) {
+                SDL_PushEvent(&ev);
                 done = true;
+                break;
             } else if (ev.type == SDL_EVENT_WINDOW_CLOSE_REQUESTED &&
                        ev.window.windowID != window_id) {
                 // The app window is no longer SDL's last window while this modal exists. Preserve
@@ -108,6 +111,7 @@ int run_savedata_modal(const SaveDataRequest& req, Active&& active) {
                 quit.type = SDL_EVENT_QUIT;
                 SDL_PushEvent(&quit);
                 done = true;
+                break;
             } else if (ev.type == SDL_EVENT_WINDOW_CLOSE_REQUESTED &&
                        ev.window.windowID == window_id && req.cancelable) {
                 done = true;
@@ -195,13 +199,16 @@ int run_savedata_list(const SaveDataRequest& req, Active&& active) {
         SDL_Event ev;
         while (SDL_PollEvent(&ev)) {
             if (ev.type == SDL_EVENT_QUIT) {
+                SDL_PushEvent(&ev);
                 done = true;
+                break;
             } else if (ev.type == SDL_EVENT_WINDOW_CLOSE_REQUESTED &&
                        ev.window.windowID != window_id) {
                 SDL_Event quit{};
                 quit.type = SDL_EVENT_QUIT;
                 SDL_PushEvent(&quit);
                 done = true;
+                break;
             } else if (ev.type == SDL_EVENT_WINDOW_CLOSE_REQUESTED &&
                        ev.window.windowID == window_id && req.cancelable) {
                 done = true;
@@ -320,7 +327,7 @@ struct SdlPlatformUi : PlatformUi {
     uint64_t save_progress_generation = 0;
 
     bool saveDataDialogOpen(uint64_t param) override {
-        SaveDataRequest request = read_savedata_request(param);
+        SaveDataRequest request = read_savedata_request(param, savedata0_dir_mtime);
         if (!request.supported) return false;
         save_state.open(std::move(request));
         return true;

--- a/prosper/frontends/dialog_sdl3/test_dialog_helpers.cpp
+++ b/prosper/frontends/dialog_sdl3/test_dialog_helpers.cpp
@@ -230,11 +230,93 @@ int main() {
         save_message_ptr = (uint64_t)(uintptr_t)save_message;
         std::memcpy(user + 8, &save_message_ptr, 8);
 
+        char dir_names[3][32] = {};
+        std::memcpy(dir_names[0], "SlotOne", 8);
+        std::memcpy(dir_names[2], "SlotTwo", 8); // empty entries are skipped
+        char focus_name[32] = "SlotTwo";
+        const char* new_title = "Create New Save";
+        uint8_t new_item[56] = {};
+        uint64_t new_title_ptr = (uint64_t)(uintptr_t)new_title;
+        std::memcpy(new_item + 0, &new_title_ptr, 8);
+        uint8_t items[0x3c] = {};
+        uint64_t dir_names_ptr = (uint64_t)(uintptr_t)dir_names;
+        uint32_t dir_names_count = 3;
+        uint64_t new_item_ptr = (uint64_t)(uintptr_t)new_item;
+        uint32_t focus_pos = 6 /*DIRNAME*/;
+        uint64_t focus_name_ptr = (uint64_t)(uintptr_t)focus_name;
+        std::memcpy(items + 0x10, &dir_names_ptr, 8);
+        std::memcpy(items + 0x18, &dir_names_count, 4);
+        std::memcpy(items + 0x20, &new_item_ptr, 8);
+        std::memcpy(items + 0x28, &focus_pos, 4);
+        std::memcpy(items + 0x30, &focus_name_ptr, 8);
+        uint64_t items_ptr = (uint64_t)(uintptr_t)items;
         save_mode = SAVE_DATA_DIALOG_MODE_LIST;
+        display_type = 1 /*SAVE*/;
         std::memcpy(save_param + 0x34, &save_mode, 4);
-        CHECK(!read_savedata_request((uint64_t)(uintptr_t)save_param).supported,
-              "SaveDataDialog LIST declines until the virtual-slot UI is implemented");
+        std::memcpy(save_param + 0x38, &display_type, 4);
+        std::memcpy(save_param + 0x48, &items_ptr, 8);
+        request = read_savedata_request((uint64_t)(uintptr_t)save_param);
+        CHECK(request.supported && request.slotList && request.cancelable &&
+                  request.slots.size() == 3 && request.slots[0].dirName.empty() &&
+                  request.slots[0].label == new_title && request.slots[1].dirName == "SlotOne" &&
+                  request.slots[2].dirName == "SlotTwo" && request.initialSlot == 2,
+              "SaveDataDialog LIST owns guest virtual slots, new-item text, and DIRNAME focus");
 
+        uint8_t list_name[40]; std::memset(list_name, 0xAB, sizeof list_name);
+        uint8_t list_result[0x48]; std::memset(list_result, 0xCD, sizeof list_result);
+        uint64_t list_name_ptr = (uint64_t)(uintptr_t)(list_name + 4);
+        uint64_t list_param_ptr = 0x1122334455667788ull;
+        std::memcpy(list_result + 0x10, &list_name_ptr, 8);
+        std::memcpy(list_result + 0x18, &list_param_ptr, 8);
+        write_savedata_result((uint64_t)(uintptr_t)list_result, request, 0, false, "SlotTwo");
+        uint32_t list_common = 99, list_button = 99;
+        uint64_t retained_name_ptr = 0, retained_param_ptr = 0;
+        std::memcpy(&list_common, list_result + 4, 4);
+        std::memcpy(&list_button, list_result + 8, 4);
+        std::memcpy(&retained_name_ptr, list_result + 0x10, 8);
+        std::memcpy(&retained_param_ptr, list_result + 0x18, 8);
+        CHECK(list_common == 0 && list_button == 0 &&
+                  std::strcmp((char*)list_name + 4, "SlotTwo") == 0 &&
+                  list_name[3] == 0xAB && list_name[36] == 0xAB,
+              "SaveDataDialog LIST writes OK/INVALID and a bounded selected virtual directory");
+        CHECK(retained_name_ptr == list_name_ptr && retained_param_ptr == list_param_ptr &&
+                  list_result[0x0c] == 0xCD && list_result[0x28] == 0xCD &&
+                  list_result[0x47] == 0xCD,
+              "SaveDataDialog LIST preserves output pointers, ABI pad, param target, and reserved tail");
+        write_savedata_result((uint64_t)(uintptr_t)list_result, request, 0, true);
+        std::memcpy(&list_common, list_result + 4, 4);
+        CHECK(list_common == 1 && list_name[4] == 0,
+              "SaveDataDialog canceled LIST result clears the directory and reports USER_CANCELED");
+
+        focus_pos = 1 /*LISTTAIL*/;
+        display_type = 2 /*LOAD: newItem must be ignored*/;
+        std::memcpy(items + 0x28, &focus_pos, 4);
+        std::memcpy(save_param + 0x38, &display_type, 4);
+        request = read_savedata_request((uint64_t)(uintptr_t)save_param);
+        CHECK(request.supported && request.slots.size() == 2 &&
+                  request.slots[0].dirName == "SlotOne" && request.initialSlot == 1,
+              "SaveDataDialog LOAD LIST ignores SAVE new-item data and honors tail focus");
+
+        dir_names_count = 1025;
+        std::memcpy(items + 0x18, &dir_names_count, 4);
+        CHECK(!read_savedata_request((uint64_t)(uintptr_t)save_param).supported,
+              "SaveDataDialog LIST rejects an unreasonable guest slot count");
+        dir_names_count = 3;
+        dir_names_ptr = 1;
+        std::memcpy(items + 0x18, &dir_names_count, 4);
+        std::memcpy(items + 0x10, &dir_names_ptr, 8);
+        CHECK(!read_savedata_request((uint64_t)(uintptr_t)save_param).supported,
+              "SaveDataDialog LIST rejects an unreadable directory array without crashing");
+        dir_names_ptr = (uint64_t)(uintptr_t)dir_names;
+        std::memcpy(items + 0x10, &dir_names_ptr, 8);
+        items_ptr = 1;
+        std::memcpy(save_param + 0x48, &items_ptr, 8);
+        CHECK(!read_savedata_request((uint64_t)(uintptr_t)save_param).supported,
+              "SaveDataDialog LIST rejects an unreadable items pointer without crashing");
+        items_ptr = (uint64_t)(uintptr_t)items;
+        std::memcpy(save_param + 0x48, &items_ptr, 8);
+
+        request = {};
         request.mode = SAVE_DATA_DIALOG_MODE_USER_MSG;
         request.userData = user_data;
         uint8_t save_result[0x48]; std::memset(save_result, 0xAB, sizeof save_result);
@@ -302,6 +384,25 @@ int main() {
         std::memcpy(&lifecycle_button, lifecycle_result + 8, 4);
         CHECK(lifecycle_common == 1 && lifecycle_button == 0,
               "SaveData lifecycle canceled completion writes USER_CANCELED + INVALID");
+
+        SaveDataRequest list_request;
+        list_request.supported = true;
+        list_request.slotList = true;
+        list_request.mode = SAVE_DATA_DIALOG_MODE_LIST;
+        list_request.slots = {{"SlotOne", "SlotOne"}, {"SlotTwo", "SlotTwo"}};
+        state.open(list_request);
+        SaveDataModalTicket list_ticket = state.take_pending();
+        state.complete_list(list_ticket.generation, 1);
+        SaveDataResultSnapshot list_snapshot = state.result_snapshot();
+        CHECK(state.status() == 3 && !list_snapshot.canceled && list_snapshot.buttonId == 0 &&
+                  list_snapshot.dirName == "SlotTwo",
+              "SaveData LIST lifecycle publishes only the selected virtual directory");
+        state.open(list_request);
+        list_ticket = state.take_pending();
+        state.complete_list(list_ticket.generation, -1);
+        list_snapshot = state.result_snapshot();
+        CHECK(state.status() == 3 && list_snapshot.canceled && list_snapshot.dirName.empty(),
+              "SaveData LIST lifecycle maps Back to USER_CANCELED with an empty directory");
 
         SaveDataRequest progress_request;
         progress_request.supported = true;

--- a/prosper/frontends/dialog_sdl3/test_dialog_helpers.cpp
+++ b/prosper/frontends/dialog_sdl3/test_dialog_helpers.cpp
@@ -12,6 +12,12 @@ static int fails = 0;
 #define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
                          else       { printf("  [ok]   %s\n", m); } } while (0)
 
+static bool slot_time(const std::string& dir_name, int64_t& modified) {
+    if (dir_name == "SlotOne") { modified = 10; return true; }
+    if (dir_name == "SlotTwo") { modified = 20; return true; }
+    return false;
+}
+
 int main() {
     printf("== test_dialog_helpers ==\n");
 
@@ -296,6 +302,19 @@ int main() {
         CHECK(request.supported && request.slots.size() == 2 &&
                   request.slots[0].dirName == "SlotOne" && request.initialSlot == 1,
               "SaveDataDialog LOAD LIST ignores SAVE new-item data and honors tail focus");
+
+        focus_pos = 4 /*DATALATEST*/;
+        std::memcpy(items + 0x28, &focus_pos, 4);
+        CHECK(!read_savedata_request((uint64_t)(uintptr_t)save_param).supported,
+              "SaveDataDialog date focus declines when virtual-slot metadata is unavailable");
+        request = read_savedata_request((uint64_t)(uintptr_t)save_param, slot_time);
+        CHECK(request.supported && request.initialSlot == 1,
+              "SaveDataDialog DATALATEST focuses the newest virtual slot by metadata time");
+        focus_pos = 5 /*DATAOLDEST*/;
+        std::memcpy(items + 0x28, &focus_pos, 4);
+        request = read_savedata_request((uint64_t)(uintptr_t)save_param, slot_time);
+        CHECK(request.supported && request.initialSlot == 0,
+              "SaveDataDialog DATAOLDEST focuses the oldest virtual slot by metadata time");
 
         dir_names_count = 1025;
         std::memcpy(items + 0x18, &dir_names_count, 4);

--- a/prosper/frontends/dialog_sdl3/test_dialog_helpers.cpp
+++ b/prosper/frontends/dialog_sdl3/test_dialog_helpers.cpp
@@ -18,6 +18,8 @@ static bool slot_time(const std::string& dir_name, int64_t& modified) {
     return false;
 }
 
+static bool no_slot_time(const std::string&, int64_t&) { return false; }
+
 int main() {
     printf("== test_dialog_helpers ==\n");
 
@@ -315,6 +317,19 @@ int main() {
         request = read_savedata_request((uint64_t)(uintptr_t)save_param, slot_time);
         CHECK(request.supported && request.initialSlot == 0,
               "SaveDataDialog DATAOLDEST focuses the oldest virtual slot by metadata time");
+
+        display_type = 1 /*SAVE*/;
+        focus_pos = 4 /*DATALATEST*/;
+        std::memcpy(save_param + 0x38, &display_type, 4);
+        std::memcpy(items + 0x28, &focus_pos, 4);
+        CHECK(!read_savedata_request((uint64_t)(uintptr_t)save_param, no_slot_time).supported,
+              "SaveDataDialog date focus declines new-item plus unresolved existing slots");
+        dir_names_count = 0;
+        std::memcpy(items + 0x18, &dir_names_count, 4);
+        request = read_savedata_request((uint64_t)(uintptr_t)save_param, no_slot_time);
+        CHECK(request.supported && request.slots.size() == 1 && request.initialSlot == 0 &&
+                  request.slots[0].dirName.empty(),
+              "SaveDataDialog date focus selects the new item only when no data slots exist");
 
         dir_names_count = 1025;
         std::memcpy(items + 0x18, &dir_names_count, 4);

--- a/prosper/frontends/prosper-app/README.md
+++ b/prosper/frontends/prosper-app/README.md
@@ -83,10 +83,11 @@ For frontend A/B diagnostics, `PROSPER_APP_DISABLE_AUDIO=1`, `PROSPER_APP_DISABL
 the core's realtime silent audio sink, keyboard/scripted pad input, or headless dialog auto-dismiss.
 These switches isolate frontend-specific behavior without requiring a separate build.
 
-The SDL dialog backend presents message/error/save confirmations, IME text entry, and SaveData
-percentage progress. Progress uses a non-focusable utility window updated from the app's main thread,
-so the title keeps presenting and retains keyboard/controller focus. SaveData LIST selection remains a
-separate virtual-slot follow-up; prosper never opens an arbitrary host file picker for guest save data.
+The SDL dialog backend presents message/error/save confirmations, IME text entry, SaveData virtual-slot
+lists, and SaveData percentage progress. LIST uses only guest-provided virtual directory identifiers and
+an optional new-save item; prosper never exposes a host path or opens an arbitrary host file picker.
+Progress uses a non-focusable utility window updated from the app's main thread, so the title keeps
+presenting and retains keyboard/controller focus.
 
 - Two Vulkan contexts by design (`docs/FRONTEND_APP.md`): the core renders headless; the app owns a
   separate presentation device; frames cross as CPU pixels via `present_readback`.

--- a/prosper/src/hle/dispatch.hpp
+++ b/prosper/src/hle/dispatch.hpp
@@ -82,6 +82,9 @@ std::string resolve_guest_path(const char* guest_path);
 bool savedata0_mount(const char* dirname, bool create);
 void savedata0_umount();
 std::vector<std::string> savedata0_list_dirs();   // existing save dirs under the host save root (#299)
+// Read a virtual save slot's param.sfo modification time (or directory time if absent). Rejects names
+// that are not a single guest directory component; used only for SaveDataDialog date-focus ordering.
+bool savedata0_dir_mtime(const std::string& dirname, int64_t& modified);
 // PS5 system services (user/NP/mouse/appcontent/dialog); called by register_builtin_hle().
 void register_service_hle();
 // libSceHttp local URI helpers; called by register_builtin_hle().

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -549,13 +549,19 @@ bool savedata0_dir_mtime(const std::string& dirname, int64_t& modified) {
     const std::string param = dir + "/sce_sys/param.sfo";
 #ifdef _WIN32
     struct _stat64 st{};
-    if (_stat64(param.c_str(), &st) != 0 && _stat64(dir.c_str(), &st) != 0) return false;
-    if (!(st.st_mode & _S_IFREG) && !(st.st_mode & _S_IFDIR)) return false;
+    if (_stat64(param.c_str(), &st) == 0) {
+        if (!(st.st_mode & _S_IFREG)) return false;
+    } else if (_stat64(dir.c_str(), &st) != 0 || !(st.st_mode & _S_IFDIR)) {
+        return false;
+    }
     modified = (int64_t)st.st_mtime;
 #else
     struct stat st{};
-    if (::stat(param.c_str(), &st) != 0 && ::stat(dir.c_str(), &st) != 0) return false;
-    if (!S_ISREG(st.st_mode) && !S_ISDIR(st.st_mode)) return false;
+    if (::stat(param.c_str(), &st) == 0) {
+        if (!S_ISREG(st.st_mode)) return false;
+    } else if (::stat(dir.c_str(), &st) != 0 || !S_ISDIR(st.st_mode)) {
+        return false;
+    }
     modified = (int64_t)st.st_mtim.tv_sec * 1000000000ll + st.st_mtim.tv_nsec;
 #endif
     return true;

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -540,6 +540,27 @@ std::vector<std::string> savedata0_list_dirs() {
     return out;
 }
 
+bool savedata0_dir_mtime(const std::string& dirname, int64_t& modified) {
+    modified = 0;
+    if (dirname.empty() || dirname == "." || dirname == ".." ||
+        dirname.find('/') != std::string::npos || dirname.find('\\') != std::string::npos)
+        return false;
+    const std::string dir = save0_base() + "/" + dirname;
+    const std::string param = dir + "/sce_sys/param.sfo";
+#ifdef _WIN32
+    struct _stat64 st{};
+    if (_stat64(param.c_str(), &st) != 0 && _stat64(dir.c_str(), &st) != 0) return false;
+    if (!(st.st_mode & _S_IFREG) && !(st.st_mode & _S_IFDIR)) return false;
+    modified = (int64_t)st.st_mtime;
+#else
+    struct stat st{};
+    if (::stat(param.c_str(), &st) != 0 && ::stat(dir.c_str(), &st) != 0) return false;
+    if (!S_ISREG(st.st_mode) && !S_ISDIR(st.st_mode)) return false;
+    modified = (int64_t)st.st_mtim.tv_sec * 1000000000ll + st.st_mtim.tv_nsec;
+#endif
+    return true;
+}
+
 // Translate a host (Linux) struct stat into the FreeBSD/Orbis SceKernelStat layout the
 // guest expects: 0x78 bytes, different field order. Writing the host layout (144 bytes,
 // different offsets) both gives wrong values AND overruns the guest's 0x78-byte buffer


### PR DESCRIPTION
## Summary
- parse SaveDataDialog LIST/item parameters into owned guest virtual-slot entries, including SAVE-mode new-item text and focus/back policy
- render/select those entries in a generation-safe SDL main-thread modal, with no host paths or file picker, and return the selected guest directory through the caller-owned result output
- cover malformed guest pointers/counts, bounded result writes, selection/cancel lifecycle, and document the frontend behavior

The inherited ABI offsets and LIST result behavior were checked against the pinned shadPS4 reference: https://github.com/shadps4-emu/shadPS4/blob/bfb0122bbe3c1dc7c71d4973d321869c0eb5e015/src/core/libraries/save_data/dialog/savedatadialog_ui.h

Closes #772

## Author pre-PR checks
- Linux `test_dialog_helpers`: PASS
- Windows `test_dialog_helpers.exe`: PASS
- Linux/Windows selected `platform_ui|dialog_helpers` ctest: PASS
- MinGW `prosper-app` build: PASS
- no games, snapshots, or captures run

## Review focus
- exact LIST/SaveDialogItems offsets and fixed-width directory handling
- fault-contained guest reads/writes and preservation of output pointers/reserved bytes
- selection/cancel/generation ownership and new-item empty-directory semantics
- SDL main-thread modal event routing, scrolling/selection, and app-window close forwarding
- headless, existing modal, and progress behavior remain unchanged