### PR TITLE
fix(file): implement sceKernelSync durability flush (#389)

### DIFF
--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -1367,6 +1367,12 @@ HLE(f_fdatasync) {
     return (uint64_t)(int64_t)::fdatasync((int)a0);
 #endif
 }
+HLE(k_sync) {
+    // sceKernelSync is the descriptor-free, whole-filesystem durability barrier. Unlike fsync it
+    // has no failure result to translate: the BSD/POSIX primitive returns void.
+    ::sync();
+    return 0;
+}
 #else
 HLE(f_stat)  { std::string h = translate(CS(a0)); struct _stat64 st; int r = ::_stat64(h.c_str(), &st); if (r == 0 && a1) to_sce_stat64(st, (uint8_t*)P(a1)); return (uint64_t)(int64_t)r; }
 HLE(f_fstat) { struct _stat64 st; std::string directory_path;
@@ -1385,6 +1391,13 @@ HLE(f_fsync) { ScopedCrtInvalidParameterHandler suppress_invalid_parameter;
 // The Windows CRT has no data-only durability primitive. _commit is the same stronger fallback
 // used for fsync and, unlike the missing-import stub, reports invalid descriptors truthfully.
 HLE(f_fdatasync) { return f_fsync(a0,a1,a2,a3,a4,a5); }
+HLE(k_sync) {
+    // Windows has no whole-filesystem sync primitive. Flush every process-owned stdio stream so
+    // buffered guest/libc writes at least reach the OS cache; descriptor callers that need a
+    // durable per-file barrier use the real sceKernelFsync/Fdatasync handlers above.
+    (void)::_flushall();
+    return 0;
+}
 #endif
 
 // These file APIs have signed 32-bit results. Kernel exports return the translated SCE error
@@ -2142,6 +2155,7 @@ void register_file_hle() {
     R("lstat", f_lstat);   R("sceKernelLstat", k_lstat);     // was MISSING -> uninitialized stat buffer
     R("fsync", f_fsync);       R("sceKernelFsync", k_fsync);       // real descriptor durability
     R("fdatasync", f_fdatasync); R("sceKernelFdatasync", k_fdatasync); // data-only durability
+    R("sceKernelSync", k_sync); // whole-filesystem/process-file flush (was fake success)
     R("sceKernelTruncate", k_truncate);      // path-based sibling (same corruption class)
     R("sceKernelFstat", k_fstat);
     // Low-level POSIX wrappers with the internal leading-underscore names. Real libc.prx implements

--- a/prosper/tests/test_file_binary.cpp
+++ b/prosper/tests/test_file_binary.cpp
@@ -96,6 +96,7 @@ int main() {
     HleFn kernel_fsync_fn = Hle::lookup(nid_hash("sceKernelFsync"));
     HleFn fdatasync_fn = Hle::lookup(nid_hash("fdatasync"));
     HleFn kernel_fdatasync_fn = Hle::lookup(nid_hash("sceKernelFdatasync"));
+    HleFn kernel_sync_fn = Hle::lookup(nid_hash("sceKernelSync"));
     HleFn getdents_fn = Hle::lookup(nid_hash("getdents"));
     HleFn kernel_getdents_fn = Hle::lookup(nid_hash("sceKernelGetdents"));
     HleFn getdirentries_fn = Hle::lookup(nid_hash("getdirentries"));
@@ -116,11 +117,13 @@ int main() {
               dup2_fn && kernel_dup2_fn && mkdir_fn && kernel_mkdir_fn && rmdir_fn &&
               kernel_rmdir_fn && unlink_fn && kernel_unlink_fn && rename_fn &&
               kernel_rename_fn && kernel_truncate_fn && kernel_ftruncate_fn && fsync_fn &&
-              kernel_fsync_fn && fdatasync_fn && kernel_fdatasync_fn && getdents_fn &&
+              kernel_fsync_fn && fdatasync_fn && kernel_fdatasync_fn && kernel_sync_fn && getdents_fn &&
               kernel_getdents_fn && getdirentries_fn && kernel_getdirentries_fn && stat_fn &&
               kernel_stat_fn && fstat_fn && kernel_fstat_fn && lstat_fn && kernel_lstat_fn &&
               fcntl_fn && kernel_fcntl_fn,
           "file HLE functions registered");
+    CHECK(kernel_sync_fn && kernel_sync_fn(0, 0, 0, 0, 0, 0) == 0,
+          "sceKernelSync performs the host-wide/process-file flush and returns success");
     std::array<uint8_t, 64> dir_buffer{};
 
     // Creating an existing directory is a failure, not an idempotent success. Linux previously


### PR DESCRIPTION
## Summary

- register sceKernelSync instead of falling through to fake success
- call native whole-filesystem sync() on POSIX
- use a documented process-stream flush fallback on Windows, while retaining sceKernelFsync/sceKernelFdatasync for strong per-descriptor barriers
- cover registration and the success contract in the cross-platform filesystem regression

## Development checks

- Linux: ile_binary_roundtrip passed
- Windows MinGW: ile_binary_roundtrip passed
- no games, snapshots, or captures run

Refs #389