### PR TITLE
fix(file): make reachability checks truthful (#389)

### DIFF
--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -1413,6 +1413,19 @@ HLE(k_truncate) { uint64_t r = f_truncate(a0, a1, a2, a3, a4, a5); int e = errno
 HLE(k_ftruncate){ uint64_t r = f_ftruncate(a0, a1, a2, a3, a4, a5); int e = errno; return kernel_file_result32(r, e); }
 HLE(k_fsync)    { uint64_t r = f_fsync(a0, a1, a2, a3, a4, a5);    int e = errno; return kernel_file_result32(r, e); }
 HLE(k_fdatasync){ uint64_t r = f_fdatasync(a0, a1, a2, a3, a4, a5); int e = errno; return kernel_file_result32(r, e); }
+HLE(k_check_reachability) {
+    // Verified PS5/PS4 contract: a translated file OR directory is reachable. The old missing-import
+    // path returned success for every spelling, so guests could take content-loading branches for
+    // files that did not exist. Keep the console's 255-byte path bound and kernel error contract.
+    if (!a0) return file_sce_error(EINVAL);
+    const char* guest = CS(a0);
+    size_t length = 0;
+    while (length <= 255 && guest[length]) ++length;
+    if (length > 255) return file_sce_error(ENAMETOOLONG);
+    const std::string host = translate(guest);
+    if (::access(host.c_str(), 0) == 0) return 0;
+    return file_sce_error(errno);
+}
 HLE(f_access){ std::string h = translate(CS(a0)); return (uint64_t)(int64_t)::access(h.c_str(), (int)a1); }
 HLE(f_mkdir) { std::string h = translate(CS(a0));   // sceKernelMkdir(path, mode)
 #ifdef _WIN32
@@ -2156,6 +2169,7 @@ void register_file_hle() {
     R("fsync", f_fsync);       R("sceKernelFsync", k_fsync);       // real descriptor durability
     R("fdatasync", f_fdatasync); R("sceKernelFdatasync", k_fdatasync); // data-only durability
     R("sceKernelSync", k_sync); // whole-filesystem/process-file flush (was fake success)
+    R("sceKernelCheckReachability", k_check_reachability); // truthful file/directory existence
     R("sceKernelTruncate", k_truncate);      // path-based sibling (same corruption class)
     R("sceKernelFstat", k_fstat);
     // Low-level POSIX wrappers with the internal leading-underscore names. Real libc.prx implements

--- a/prosper/tests/test_file_binary.cpp
+++ b/prosper/tests/test_file_binary.cpp
@@ -97,6 +97,7 @@ int main() {
     HleFn fdatasync_fn = Hle::lookup(nid_hash("fdatasync"));
     HleFn kernel_fdatasync_fn = Hle::lookup(nid_hash("sceKernelFdatasync"));
     HleFn kernel_sync_fn = Hle::lookup(nid_hash("sceKernelSync"));
+    HleFn kernel_reachability_fn = Hle::lookup(nid_hash("sceKernelCheckReachability"));
     HleFn getdents_fn = Hle::lookup(nid_hash("getdents"));
     HleFn kernel_getdents_fn = Hle::lookup(nid_hash("sceKernelGetdents"));
     HleFn getdirentries_fn = Hle::lookup(nid_hash("getdirentries"));
@@ -117,7 +118,8 @@ int main() {
               dup2_fn && kernel_dup2_fn && mkdir_fn && kernel_mkdir_fn && rmdir_fn &&
               kernel_rmdir_fn && unlink_fn && kernel_unlink_fn && rename_fn &&
               kernel_rename_fn && kernel_truncate_fn && kernel_ftruncate_fn && fsync_fn &&
-              kernel_fsync_fn && fdatasync_fn && kernel_fdatasync_fn && kernel_sync_fn && getdents_fn &&
+              kernel_fsync_fn && fdatasync_fn && kernel_fdatasync_fn && kernel_sync_fn &&
+              kernel_reachability_fn && getdents_fn &&
               kernel_getdents_fn && getdirentries_fn && kernel_getdirentries_fn && stat_fn &&
               kernel_stat_fn && fstat_fn && kernel_fstat_fn && lstat_fn && kernel_lstat_fn &&
               fcntl_fn && kernel_fcntl_fn,
@@ -147,6 +149,15 @@ int main() {
     CHECK(duplicate_errno == EEXIST, "mkdir preserves EEXIST for the caller");
     CHECK(kernel_mkdir_duplicate == 0x80020011u,
           "sceKernelMkdir returns SCE_KERNEL_ERROR_EEXIST directly");
+    set_app0_root(std::filesystem::current_path().string());
+    const std::string reachable_file = std::string("/app0/") + path;
+    const std::string reachable_directory = std::string("/app0/") + dir_path;
+    CHECK(kernel_reachability_fn &&
+              kernel_reachability_fn((uint64_t)(uintptr_t)reachable_file.c_str(), 0, 0, 0, 0, 0) == 0,
+          "sceKernelCheckReachability finds a translated guest file");
+    CHECK(kernel_reachability_fn &&
+              kernel_reachability_fn((uint64_t)(uintptr_t)reachable_directory.c_str(), 0, 0, 0, 0, 0) == 0,
+          "sceKernelCheckReachability finds a translated guest directory");
 #ifdef _WIN32
     // Windows has no CRT directory-open API, but a directory HANDLE can be attached to a CRT fd.
     // The zero-entry stub must still publish the defined starting offset through basep.
@@ -311,6 +322,18 @@ int main() {
           "libc open retains the -1 plus errno contract");
     CHECK((uint32_t)kernel_missing == 0x80020002u,
           "sceKernelOpen returns SCE_KERNEL_ERROR_ENOENT directly");
+    const std::string unreachable_file = std::string("/app0/") + missing_path;
+    std::string overlong_path(256, 'a');
+    CHECK(kernel_reachability_fn &&
+              kernel_reachability_fn((uint64_t)(uintptr_t)unreachable_file.c_str(), 0, 0, 0, 0, 0) ==
+                  0x80020002u,
+          "sceKernelCheckReachability returns SCE_KERNEL_ERROR_ENOENT for a missing path");
+    CHECK(kernel_reachability_fn && kernel_reachability_fn(0, 0, 0, 0, 0, 0) == 0x80020016u,
+          "sceKernelCheckReachability returns SCE_KERNEL_ERROR_EINVAL for a null path");
+    CHECK(kernel_reachability_fn &&
+              kernel_reachability_fn((uint64_t)(uintptr_t)overlong_path.c_str(), 0, 0, 0, 0, 0) ==
+                  0x8002003fu,
+          "sceKernelCheckReachability enforces the 255-byte console path bound");
 
     // The stat-family libc names preserve -1 plus errno, while their kernel siblings return
     // a 32-bit SCE error directly. Neither contract may overwrite the guest buffer on failure.


### PR DESCRIPTION
## Summary

- register sceKernelCheckReachability instead of returning default fake success
- apply the shared guest-to-host mount translation for files and directories
- return SCE ENOENT, EINVAL, and ENAMETOOLONG for the verified failure contracts
- add focused Linux/Windows coverage for translated files/directories, missing paths, null, and the 255-byte bound

## Development checks

- Linux: ile_binary_roundtrip passed
- Windows MinGW: ile_binary_roundtrip passed
- no games, snapshots, or captures run

Refs #389