### PR TITLE
fix(file): implement sceKernelUtimes timestamps

### DIFF
--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -22,6 +22,7 @@
 #include <sys/stat.h>
 #ifndef _WIN32
 #include <unistd.h>
+#include <sys/time.h>    // utimes: sceKernelUtimes timestamp preservation
 #include <sys/syscall.h>
 #include <dirent.h>      // opendir/readdir: savedata0_list_dirs (sceSaveDataDirNameSearch, #299)
 #include <sys/uio.h>     // process_vm_readv: fault-safe guest-memory reads for the APR diagnostics
@@ -421,6 +422,12 @@ namespace {
         int64_t size = 0, blocks = 0;
         uint32_t blksize = 0;
     };
+
+    struct GuestTimeval {
+        int64_t sec;
+        int64_t usec;
+    };
+    static_assert(sizeof(GuestTimeval) == 0x10, "SceKernelTimeval ABI");
 
     int64_t blocks_512_for_size(int64_t size) {
         return size > 0 ? (size + 511) / 512 : 0;
@@ -1426,6 +1433,64 @@ HLE(k_check_reachability) {
     if (::access(host.c_str(), 0) == 0) return 0;
     return file_sce_error(errno);
 }
+HLE(k_utimes) {
+    if (!a0) return file_sce_error(EFAULT);
+    const auto* guest_times = a1 ? (const GuestTimeval*)P(a1) : nullptr;
+    if (guest_times && (guest_times[0].usec < 0 || guest_times[0].usec >= 1000000 ||
+                        guest_times[1].usec < 0 || guest_times[1].usec >= 1000000))
+        return file_sce_error(EINVAL);
+    const std::string host = translate(CS(a0));
+#ifndef _WIN32
+    struct timeval host_times[2];
+    if (guest_times) {
+        for (size_t i = 0; i < 2; ++i) {
+            host_times[i].tv_sec = (time_t)guest_times[i].sec;
+            host_times[i].tv_usec = (suseconds_t)guest_times[i].usec;
+        }
+    }
+    const int result = ::utimes(host.c_str(), guest_times ? host_times : nullptr);
+    return result == 0 ? 0 : file_sce_error(errno);
+#else
+    auto to_file_time = [](const GuestTimeval& value, FILETIME* out) {
+        constexpr int64_t kUnixToWindowsEpochSeconds = 11644473600ll;
+        constexpr uint64_t kTicksPerSecond = 10000000ull;
+        uint64_t epoch_seconds;
+        if (value.sec < 0) {
+            if (value.sec < -kUnixToWindowsEpochSeconds) return false;
+            epoch_seconds = (uint64_t)(value.sec + kUnixToWindowsEpochSeconds);
+        } else {
+            const uint64_t sec = (uint64_t)value.sec;
+            if (sec > UINT64_MAX / kTicksPerSecond - (uint64_t)kUnixToWindowsEpochSeconds)
+                return false;
+            epoch_seconds = sec + (uint64_t)kUnixToWindowsEpochSeconds;
+        }
+        const uint64_t subsecond = (uint64_t)value.usec * 10ull;
+        if (epoch_seconds > (UINT64_MAX - subsecond) / kTicksPerSecond) return false;
+        const uint64_t ticks = epoch_seconds * kTicksPerSecond + subsecond;
+        out->dwLowDateTime = (DWORD)ticks;
+        out->dwHighDateTime = (DWORD)(ticks >> 32);
+        return true;
+    };
+    FILETIME access_time{}, modify_time{};
+    if (guest_times) {
+        if (!to_file_time(guest_times[0], &access_time) ||
+            !to_file_time(guest_times[1], &modify_time))
+            return file_sce_error(EOVERFLOW);
+    } else {
+        GetSystemTimeAsFileTime(&access_time);
+        modify_time = access_time;
+    }
+    HANDLE file = CreateFileA(host.c_str(), FILE_WRITE_ATTRIBUTES,
+                              FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                              nullptr, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, nullptr);
+    if (file == INVALID_HANDLE_VALUE)
+        return file_sce_error(windows_directory_errno(GetLastError()));
+    const BOOL updated = SetFileTime(file, nullptr, &access_time, &modify_time);
+    const DWORD error = updated ? ERROR_SUCCESS : GetLastError();
+    CloseHandle(file);
+    return updated ? 0 : file_sce_error(windows_directory_errno(error));
+#endif
+}
 HLE(f_access){ std::string h = translate(CS(a0)); return (uint64_t)(int64_t)::access(h.c_str(), (int)a1); }
 HLE(f_mkdir) { std::string h = translate(CS(a0));   // sceKernelMkdir(path, mode)
 #ifdef _WIN32
@@ -2170,6 +2235,7 @@ void register_file_hle() {
     R("fdatasync", f_fdatasync); R("sceKernelFdatasync", k_fdatasync); // data-only durability
     R("sceKernelSync", k_sync); // whole-filesystem/process-file flush (was fake success)
     R("sceKernelCheckReachability", k_check_reachability); // truthful file/directory existence
+    R("sceKernelUtimes", k_utimes); // preserve guest access/modify timestamps (incl. touch-now)
     R("sceKernelTruncate", k_truncate);      // path-based sibling (same corruption class)
     R("sceKernelFstat", k_fstat);
     // Low-level POSIX wrappers with the internal leading-underscore names. Real libc.prx implements

--- a/prosper/tests/test_file_binary.cpp
+++ b/prosper/tests/test_file_binary.cpp
@@ -38,6 +38,12 @@ static constexpr uint64_t kGuestONonblock = 0x0004;
 static constexpr uint64_t kGuestOAppend = 0x0008;
 static constexpr uint64_t kGuestOSync = 0x0080;
 
+struct GuestTimeval {
+    int64_t sec;
+    int64_t usec;
+};
+static_assert(sizeof(GuestTimeval) == 0x10, "SceKernelTimeval ABI");
+
 int main() {
     std::printf("== test_file_binary ==\n");
     const char* path = "prosper-test-file-binary.tmp";
@@ -98,6 +104,7 @@ int main() {
     HleFn kernel_fdatasync_fn = Hle::lookup(nid_hash("sceKernelFdatasync"));
     HleFn kernel_sync_fn = Hle::lookup(nid_hash("sceKernelSync"));
     HleFn kernel_reachability_fn = Hle::lookup(nid_hash("sceKernelCheckReachability"));
+    HleFn kernel_utimes_fn = Hle::lookup(nid_hash("sceKernelUtimes"));
     HleFn getdents_fn = Hle::lookup(nid_hash("getdents"));
     HleFn kernel_getdents_fn = Hle::lookup(nid_hash("sceKernelGetdents"));
     HleFn getdirentries_fn = Hle::lookup(nid_hash("getdirentries"));
@@ -119,7 +126,7 @@ int main() {
               kernel_rmdir_fn && unlink_fn && kernel_unlink_fn && rename_fn &&
               kernel_rename_fn && kernel_truncate_fn && kernel_ftruncate_fn && fsync_fn &&
               kernel_fsync_fn && fdatasync_fn && kernel_fdatasync_fn && kernel_sync_fn &&
-              kernel_reachability_fn && getdents_fn &&
+              kernel_reachability_fn && kernel_utimes_fn && getdents_fn &&
               kernel_getdents_fn && getdirentries_fn && kernel_getdirentries_fn && stat_fn &&
               kernel_stat_fn && fstat_fn && kernel_fstat_fn && lstat_fn && kernel_lstat_fn &&
               fcntl_fn && kernel_fcntl_fn,
@@ -158,6 +165,81 @@ int main() {
     CHECK(kernel_reachability_fn &&
               kernel_reachability_fn((uint64_t)(uintptr_t)reachable_directory.c_str(), 0, 0, 0, 0, 0) == 0,
           "sceKernelCheckReachability finds a translated guest directory");
+    GuestTimeval explicit_times[2]{{1700000001, 123456}, {1700000002, 654321}};
+    CHECK(kernel_utimes_fn &&
+              kernel_utimes_fn((uint64_t)(uintptr_t)reachable_file.c_str(),
+                                (uint64_t)(uintptr_t)explicit_times, 0, 0, 0, 0) == 0,
+          "sceKernelUtimes applies explicit timestamps to a translated guest file");
+    CHECK(kernel_utimes_fn &&
+              kernel_utimes_fn((uint64_t)(uintptr_t)reachable_directory.c_str(),
+                                (uint64_t)(uintptr_t)explicit_times, 0, 0, 0, 0) == 0,
+          "sceKernelUtimes applies explicit timestamps to a translated guest directory");
+    std::array<uint8_t, 0x78> timestamp_stat{};
+    CHECK(kernel_stat_fn &&
+              kernel_stat_fn((uint64_t)(uintptr_t)reachable_file.c_str(),
+                             (uint64_t)(uintptr_t)timestamp_stat.data(), 0, 0, 0, 0) == 0 &&
+              *(const int64_t*)(timestamp_stat.data() + 0x18) == explicit_times[0].sec &&
+              *(const int64_t*)(timestamp_stat.data() + 0x28) == explicit_times[1].sec,
+          "sceKernelUtimes preserves explicit access/modify seconds");
+#ifdef _WIN32
+    HANDLE timestamp_handle = CreateFileA(path, FILE_READ_ATTRIBUTES,
+        FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, nullptr, OPEN_EXISTING, 0, nullptr);
+    FILETIME access_time{}, modify_time{};
+    const BOOL read_times = timestamp_handle != INVALID_HANDLE_VALUE &&
+        GetFileTime(timestamp_handle, nullptr, &access_time, &modify_time);
+    auto filetime_ticks = [](const FILETIME& value) {
+        return (uint64_t)value.dwLowDateTime | ((uint64_t)value.dwHighDateTime << 32);
+    };
+    constexpr uint64_t kUnixToWindowsEpochSeconds = 11644473600ull;
+    constexpr uint64_t kTicksPerSecond = 10000000ull;
+    CHECK(read_times &&
+              filetime_ticks(access_time) ==
+                  ((uint64_t)explicit_times[0].sec + kUnixToWindowsEpochSeconds) * kTicksPerSecond +
+                      (uint64_t)explicit_times[0].usec * 10 &&
+              filetime_ticks(modify_time) ==
+                  ((uint64_t)explicit_times[1].sec + kUnixToWindowsEpochSeconds) * kTicksPerSecond +
+                      (uint64_t)explicit_times[1].usec * 10,
+          "sceKernelUtimes preserves explicit Windows microseconds");
+    if (timestamp_handle != INVALID_HANDLE_VALUE) CloseHandle(timestamp_handle);
+#else
+    // The source tree can live on WSL's /mnt/c mount, whose metadata bridge truncates subsecond
+    // timestamps. Exercise microsecond preservation on the native temporary filesystem instead.
+    const std::string precision_path =
+        (std::filesystem::temp_directory_path() / "prosper-test-utimes-precision.tmp").string();
+    FILE* precision_file = std::fopen(precision_path.c_str(), "wb");
+    CHECK(precision_file != nullptr, "create native-filesystem timestamp fixture");
+    if (precision_file) std::fclose(precision_file);
+    timestamp_stat.fill(0);
+    CHECK(precision_file && kernel_utimes_fn && kernel_stat_fn &&
+              kernel_utimes_fn((uint64_t)(uintptr_t)precision_path.c_str(),
+                                (uint64_t)(uintptr_t)explicit_times, 0, 0, 0, 0) == 0 &&
+              kernel_stat_fn((uint64_t)(uintptr_t)precision_path.c_str(),
+                             (uint64_t)(uintptr_t)timestamp_stat.data(), 0, 0, 0, 0) == 0 &&
+              *(const int64_t*)(timestamp_stat.data() + 0x20) == explicit_times[0].usec * 1000 &&
+              *(const int64_t*)(timestamp_stat.data() + 0x30) == explicit_times[1].usec * 1000,
+          "sceKernelUtimes preserves explicit POSIX microseconds");
+    std::filesystem::remove(precision_path, remove_error);
+#endif
+    GuestTimeval invalid_times[2]{{1700000001, 1000000}, {1700000002, 0}};
+    CHECK(kernel_utimes_fn &&
+              kernel_utimes_fn((uint64_t)(uintptr_t)reachable_file.c_str(),
+                                (uint64_t)(uintptr_t)invalid_times, 0, 0, 0, 0) == 0x80020016u,
+          "sceKernelUtimes rejects an out-of-range microsecond field");
+    timestamp_stat.fill(0);
+    CHECK(kernel_stat_fn &&
+              kernel_stat_fn((uint64_t)(uintptr_t)reachable_file.c_str(),
+                             (uint64_t)(uintptr_t)timestamp_stat.data(), 0, 0, 0, 0) == 0 &&
+              *(const int64_t*)(timestamp_stat.data() + 0x28) == explicit_times[1].sec,
+          "rejected sceKernelUtimes leaves the modify time unchanged");
+    CHECK(kernel_utimes_fn &&
+              kernel_utimes_fn((uint64_t)(uintptr_t)reachable_file.c_str(), 0, 0, 0, 0, 0) == 0,
+          "sceKernelUtimes supports null-times touch-now semantics");
+    timestamp_stat.fill(0);
+    CHECK(kernel_stat_fn &&
+              kernel_stat_fn((uint64_t)(uintptr_t)reachable_file.c_str(),
+                             (uint64_t)(uintptr_t)timestamp_stat.data(), 0, 0, 0, 0) == 0 &&
+              *(const int64_t*)(timestamp_stat.data() + 0x28) > explicit_times[1].sec,
+          "touch-now sceKernelUtimes advances the modify time");
 #ifdef _WIN32
     // Windows has no CRT directory-open API, but a directory HANDLE can be attached to a CRT fd.
     // The zero-entry stub must still publish the defined starting offset through basep.
@@ -334,6 +416,12 @@ int main() {
               kernel_reachability_fn((uint64_t)(uintptr_t)overlong_path.c_str(), 0, 0, 0, 0, 0) ==
                   0x8002003fu,
           "sceKernelCheckReachability enforces the 255-byte console path bound");
+    CHECK(kernel_utimes_fn &&
+              kernel_utimes_fn((uint64_t)(uintptr_t)unreachable_file.c_str(), 0, 0, 0, 0, 0) ==
+                  0x80020002u,
+          "sceKernelUtimes returns SCE_KERNEL_ERROR_ENOENT for a missing path");
+    CHECK(kernel_utimes_fn && kernel_utimes_fn(0, 0, 0, 0, 0, 0) == 0x8002000eu,
+          "sceKernelUtimes returns SCE_KERNEL_ERROR_EFAULT for a null path");
 
     // The stat-family libc names preserve -1 plus errno, while their kernel siblings return
     // a 32-bit SCE error directly. Neither contract may overwrite the guest buffer on failure.

--- a/prosper/tests/test_file_binary.cpp
+++ b/prosper/tests/test_file_binary.cpp
@@ -18,6 +18,8 @@
 #define WIN32_LEAN_AND_MEAN
 #endif
 #include <windows.h>
+#else
+#include <unistd.h>
 #endif
 
 using namespace prosper;
@@ -204,13 +206,13 @@ int main() {
 #else
     // The source tree can live on WSL's /mnt/c mount, whose metadata bridge truncates subsecond
     // timestamps. Exercise microsecond preservation on the native temporary filesystem instead.
-    const std::string precision_path =
-        (std::filesystem::temp_directory_path() / "prosper-test-utimes-precision.tmp").string();
-    FILE* precision_file = std::fopen(precision_path.c_str(), "wb");
-    CHECK(precision_file != nullptr, "create native-filesystem timestamp fixture");
-    if (precision_file) std::fclose(precision_file);
+    std::string precision_path =
+        (std::filesystem::temp_directory_path() / "prosper-test-utimes-precision-XXXXXX").string();
+    const int precision_fd = ::mkstemp(precision_path.data());
+    CHECK(precision_fd >= 0, "create unique native-filesystem timestamp fixture");
+    if (precision_fd >= 0) ::close(precision_fd);
     timestamp_stat.fill(0);
-    CHECK(precision_file && kernel_utimes_fn && kernel_stat_fn &&
+    CHECK(precision_fd >= 0 && kernel_utimes_fn && kernel_stat_fn &&
               kernel_utimes_fn((uint64_t)(uintptr_t)precision_path.c_str(),
                                 (uint64_t)(uintptr_t)explicit_times, 0, 0, 0, 0) == 0 &&
               kernel_stat_fn((uint64_t)(uintptr_t)precision_path.c_str(),


### PR DESCRIPTION
Closes part of #389.

## Summary
- implement the verified `sceKernelUtimes(const char*, timeval[2])` ABI
- preserve explicit access/modify microseconds and support null-times touch semantics
- support translated files and directories on POSIX and Windows with SCE error translation
- add cross-platform filesystem regressions for precision, invalid input, missing/null paths, and touch-now behavior

## Author pre-PR checks
- Linux: `file_binary_roundtrip` passed
- Windows: `file_binary_roundtrip` passed
- `git diff --check` passed

No game or snapshot workflow was run.