### PR TITLE
fix(loader): resolve preload module paths case-insensitively (#1006)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -347,6 +347,14 @@ if(TARGET prosper_core)
     add_test(NAME win_kernel_is_stack COMMAND test_win_kernel_is_stack)
   endif()
 
+  # Boot preload path case correction (#1006): a module present with different casing than the
+  # hard-coded preload path (Blasphemous 2 / Evergate's Il2CppUserAssemblies.prx on a case-sensitive
+  # host filesystem) must resolve to the real on-disk entry instead of being dropped as absent.
+  # Pure std::filesystem against a temp tree; no game dump needed.
+  add_executable(test_module_path_case tests/test_module_path_case.cpp)
+  target_link_libraries(test_module_path_case PRIVATE prosper_core)
+  add_test(NAME module_path_case COMMAND test_module_path_case)
+
   # APR container registry + size-keyed read matching (issue #62): stable ids, path dedup, and
   # the ambiguity/chunk-read refusal the read-submit path relies on. Pure, no game dump needed.
   add_executable(test_apr_registry tests/test_apr_registry.cpp)

--- a/prosper/src/host/boot_program.cpp
+++ b/prosper/src/host/boot_program.cpp
@@ -3,6 +3,46 @@
 // (Linux/macOS: exec_image_linux.cpp; Windows: exec_image_win.cpp).
 #include "boot_program.hpp"
 
+#include <cctype>
+#include <filesystem>
+#include <system_error>
+
+namespace prosper {
+
+// See boot_program.hpp. The fixed preload list names each module with ONE hard-coded casing, but
+// titles disagree: The Messenger ships "Il2cppUserAssemblies.prx" while Blasphemous 2 / Evergate ship
+// "Il2CppUserAssemblies.prx". On case-insensitive hosts (NTFS / WSL DrvFs / default APFS) fopen()
+// opens either spelling — which is the only reason the wrong-case probe ever "worked". On a
+// case-sensitive Linux filesystem it misses, the module is silently dropped as absent, and the
+// guest's runtime sceKernelLoadStartModule gets ENOENT and null-jumps (SIGSEGV at rip=0, #1006).
+// PS5 module paths are effectively case-insensitive (matching the runtime basename compare in
+// hle_kernel.cpp), so correct each missing component against the real directory entry instead.
+// Pure std::filesystem; never throws (error_code overloads), and an unreadable/missing parent just
+// yields `want` unchanged so the caller's existing absence handling applies.
+std::string resolve_module_path_case(const std::string& want) {
+    namespace fs = std::filesystem;
+    std::error_code ec;
+    if (want.empty() || fs::exists(fs::path(want), ec)) return want;   // exact case (or case-insensitive FS)
+    const fs::path p(want);
+    const std::string parent = p.parent_path().string();
+    if (parent.empty() || parent == want) return want;                 // no ancestor left to correct
+    const std::string dir = resolve_module_path_case(parent);          // fix ancestor casing first
+    const std::string base = p.filename().string();
+    auto ieq = [](const std::string& a, const std::string& b) {
+        if (a.size() != b.size()) return false;
+        for (size_t i = 0; i < a.size(); i++)
+            if (std::tolower((unsigned char)a[i]) != std::tolower((unsigned char)b[i])) return false;
+        return true;
+    };
+    for (const auto& e : fs::directory_iterator(dir, fs::directory_options::skip_permission_denied, ec)) {
+        const std::string real = e.path().filename().string();
+        if (ieq(real, base)) return (fs::path(dir) / real).string();
+    }
+    return want;   // no case-insensitive match either — genuinely absent
+}
+
+} // namespace prosper
+
 #if defined(__linux__) || defined(__APPLE__) || defined(_WIN32)
 #include "host/exec_image.hpp"
 #include "hle/dispatch.hpp"
@@ -49,8 +89,15 @@ bool boot_program(const std::string& d, Program& p, std::string* err,
                 in[i].path.find("PSNCommon.prx") != std::string::npos ||
                 in[i].path.find("SaveData.prx") != std::string::npos) in.erase(in.begin() + (ptrdiff_t)i);
     // Cross-title tolerance: drop dependent modules whose file doesn't exist in this dump (the eboot
-    // at index 0 is always kept; each module keeps its fixed base).
+    // at index 0 is always kept; each module keeps its fixed base). Resolve each hard-coded casing to
+    // the real on-disk entry first so a case-only mismatch (#1006) doesn't drop a present module on a
+    // case-sensitive host filesystem.
     for (size_t i = in.size(); i-- > 1; ) {
+        std::string resolved = resolve_module_path_case(in[i].path);
+        if (resolved != in[i].path) {
+            printf("module path case-corrected: %s -> %s\n", in[i].path.c_str(), resolved.c_str());
+            in[i].path = std::move(resolved);
+        }
         if (FILE* f = fopen(in[i].path.c_str(), "rb")) fclose(f);
         else { printf("skipping absent module: %s\n", in[i].path.c_str()); in.erase(in.begin() + (ptrdiff_t)i); }
     }

--- a/prosper/src/host/boot_program.hpp
+++ b/prosper/src/host/boot_program.hpp
@@ -44,4 +44,13 @@ inline constexpr uint64_t BOOT_STUB     = 0x600000000ull;
 bool boot_program(const std::string& dump_root, Program& out, std::string* err,
                   const std::function<void()>& after_hle_registered = {});
 
+// Resolve `want` to the real on-disk entry, correcting case-only mismatches component by component
+// (#1006). The boot preload list hard-codes one casing per module path, but titles disagree (The
+// Messenger ships "Il2cppUserAssemblies.prx"; Blasphemous 2 / Evergate ship
+// "Il2CppUserAssemblies.prx"), and PS5 module paths are effectively case-insensitive — so a
+// case-sensitive host filesystem must not decide module presence by exact-case probe. Returns the
+// corrected path, or `want` unchanged when the path already exists or no entry matches (the caller's
+// absence handling then applies as before). Exposed for boot_program's preload loop and its unit test.
+std::string resolve_module_path_case(const std::string& want);
+
 } // namespace prosper

--- a/prosper/tests/test_module_path_case.cpp
+++ b/prosper/tests/test_module_path_case.cpp
@@ -1,0 +1,68 @@
+// test_module_path_case — guards resolve_module_path_case (#1006): the boot preloader must find a
+// module whose on-disk casing differs from the hard-coded preload path. The Messenger ships
+// "Il2cppUserAssemblies.prx" while Blasphemous 2 / Evergate ship "Il2CppUserAssemblies.prx"; on a
+// case-sensitive host filesystem the old exact-case fopen probe silently dropped the present module,
+// and the guest's runtime sceKernelLoadStartModule ENOENT then null-jumped (SIGSEGV at rip=0).
+// On a case-INSENSITIVE filesystem (NTFS / default APFS) the wrong-case probes below open the real
+// file directly, so resolution legitimately returns the input unchanged — both outcomes are accepted
+// where they are equivalent, and the "present either way" checks are the cross-platform contract.
+#include "../src/host/boot_program.hpp"
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+namespace fs = std::filesystem;
+using prosper::resolve_module_path_case;
+
+static int fails = 0;
+#define CHECK(cond, msg) do { if (!(cond)) { printf("  [FAIL] %s\n", msg); fails++; } \
+                              else        { printf("  [ok]   %s\n", msg); } } while (0)
+
+int main() {
+    std::error_code ec;
+    const fs::path root = fs::temp_directory_path() / "prosper_test_module_path_case";
+    fs::remove_all(root, ec);                       // stale run debris
+    fs::create_directories(root / "Media" / "Modules");
+    { std::ofstream(root / "Media" / "Modules" / "Il2CppUserAssemblies.prx") << "x"; }  // uppercase C on disk
+
+    const std::string base = root.string();
+
+    // Exact-case path: exists, returned unchanged.
+    const std::string exact = base + "/Media/Modules/Il2CppUserAssemblies.prx";
+    CHECK(resolve_module_path_case(exact) == exact, "exact-case path returned unchanged");
+
+    // The #1006 scenario: preload list says lowercase "Il2cpp", disk has uppercase "Il2Cpp".
+    // On a case-sensitive FS the result is the corrected real name; on a case-insensitive FS the
+    // wrong-case path already opens, so it comes back unchanged. Either way it must reference the
+    // real file (fs::exists true) — that is the property boot_program's absence check relies on.
+    const std::string wrongBase = base + "/Media/Modules/Il2cppUserAssemblies.prx";
+    const std::string r1 = resolve_module_path_case(wrongBase);
+    CHECK(fs::exists(fs::path(r1)), "wrong-case basename resolves to a present file");
+    CHECK(fs::path(r1).parent_path() == fs::path(wrongBase).parent_path(),
+          "resolution stays inside the requested directory");
+
+    // Case mismatch in an intermediate DIRECTORY component as well ("media/modules/...").
+    const std::string wrongDirs = base + "/media/modules/IL2CPPUSERASSEMBLIES.PRX";
+    const std::string r2 = resolve_module_path_case(wrongDirs);
+    CHECK(fs::exists(fs::path(r2)), "wrong-case directory components resolve to the present file");
+
+    // Genuinely absent file: input returned unchanged so the caller's skip path still triggers.
+    const std::string missing = base + "/Media/Modules/DoesNotExist.prx";
+    CHECK(resolve_module_path_case(missing) == missing, "absent file returned unchanged");
+
+    // Whole directory chain absent: unchanged, no throw.
+    const std::string noDir = base + "/NoSuchDir/Nested/Nope.prx";
+    CHECK(resolve_module_path_case(noDir) == noDir, "absent directory chain returned unchanged");
+
+    // Name that differs by more than case must NOT match ("Il2cppUserAssemblies2.prx").
+    const std::string lenDiff = base + "/Media/Modules/Il2cppUserAssemblies2.prx";
+    CHECK(resolve_module_path_case(lenDiff) == lenDiff, "length-differing name is not case-matched");
+
+    // Empty input: unchanged, no throw.
+    CHECK(resolve_module_path_case("").empty(), "empty path returned unchanged");
+
+    fs::remove_all(root, ec);
+    printf(fails ? "test_module_path_case: %d FAILURE(S)\n" : "test_module_path_case: all ok\n", fails);
+    return fails ? 1 : 0;
+}


### PR DESCRIPTION
Fixes #1006

## Failure scenario

On a **case-sensitive host filesystem** (native Linux ext4/btrfs), booting **Blasphemous 2 (PPSA13579)** or
**Evergate (PPSA01885)** crashes in early IL2CPP init:

```
unable to load /app0/Media/Modules/Il2CppUserAssemblies.prx, error:0x80020002
[app] guest thread ended: kind=2 detail=SIGSEGV at addr=(nil) rip=0x0
```

The preload list in `boot_program.cpp` hard-codes `Il2cppUserAssemblies.prx` (lowercase `cpp`); these titles
ship `Il2CppUserAssemblies.prx` (uppercase `C`). The exact-case `fopen` existence probe misses on a
case-sensitive filesystem, the module is silently dropped as absent, the guest's runtime
`sceKernelLoadStartModule` gets `SCE_KERNEL_ERROR_ENOENT`, and the game null-jumps. The bug was latent
because every prior dev/CI host was case-insensitive (WSL DrvFs / NTFS / default APFS), where the wrong-case
probe still opens the file.

## Behavioral contract

PS5 module paths are effectively case-insensitive — the runtime side already honors this via the
case-insensitive basename compare in `hle_kernel.cpp` (`module_handle_for_path`). This PR extends the same
contract to the boot-time on-disk probe: **module presence must not depend on the host filesystem's case
rules.**

## Approach

New `resolve_module_path_case()` (declared in `boot_program.hpp`, defined platform-independently in
`boot_program.cpp`): if the exact path exists, return it unchanged; otherwise correct each missing path
component against the real directory entry via a case-insensitive basename scan (ancestors first, so a
wrong-case intermediate directory is also corrected). Pure `std::filesystem` with `error_code` overloads —
never throws; an unmatched path returns unchanged so genuinely absent modules take the existing skip path
unchanged. The preload loop resolves each path before the `fopen` probe and logs any correction
(`module path case-corrected: ... -> ...`).

## Affected / deliberately unaffected

- **Affected:** case-sensitive hosts where a dump's module casing differs from the hard-coded list — the
  module now loads. All hard-coded preload paths (Il2Cpp, PS5Util, PSN*, SaveData, libfmod*, libc) gain the
  same robustness.
- **Unaffected:** case-insensitive hosts (the exact-path `fs::exists` short-circuits — zero behavior change);
  titles with matching casing (The Messenger) or without the module (Dead Cells); genuinely absent modules
  (still skipped, same log line); the runtime `LoadStartModule` matching (kept as is — it already handles
  request-side casing).

## Risks

- The directory scan runs only for paths that fail the exact probe, at boot, over module directories with a
  handful of entries — no steady-state cost.
- A dump containing two entries differing only by case would resolve to the first directory-iteration match;
  no real dump does this (and on case-insensitive filesystems such a pair cannot exist).

## Verification (exact-head, native Linux, Fedora 44 distrobox / btrfs / RADV STRIX_HALO)

- Build: full `cmake --build` green (with the separate pre-existing GCC-16 `<climits>` build break #1008
  patched locally; it is fixed by its own PR).
- New unit test: `ctest -R module_path_case` — 8/8 checks pass (exact-case identity, wrong-case basename,
  wrong-case directory components, containment, absent file, absent directory chain, non-case-only name
  mismatch, empty input).
- Full suite: 112 tests, 111 pass; the single failure (`gpu_capture_render_replay` DS byte-exact readback)
  is **pre-existing on unmodified master** in this environment, reproduced in an A/B at master+#1008-only,
  and tracked as #1009.
- Live A/B (prosper-app, `PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1`):
  - **Before:** B2 and Evergate crash as above, 0 frames presented.
  - **After:** `module path case-corrected: .../Il2cppUserAssemblies.prx -> .../Il2CppUserAssemblies.prx`,
    **linked 9 modules** (previously 3 — the Il2Cpp + FMOD + PS5Util set was dropped); Blasphemous 2 renders
    its opening cinematic and presented 1,269 frames to a clean shutdown; Evergate presented 400 frames
    (`--frames 400`) to a clean exit 0. No SIGSEGV in either run.
  - **Regression check:** Dead Cells (no such module) boots and plays unchanged on the same build.
- Snapshot guard: not run — the change affects module path resolution only; no recompiler/AGC/render-state/
  detile/executor/present code is touched.
- Windows/macOS: no behavior change by construction (exact-path short-circuit); not separately built here.
