### PR TITLE
fix(tools): add missing <climits> include in gpu_replay (#1008)

### DIFF
--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -9,6 +9,7 @@
 #include "render_runner.h"
 
 #include <algorithm>
+#include <climits>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>


### PR DESCRIPTION
Fixes #1008

## Failure scenario

`tools/gpu_replay/gpu_replay.cpp` uses `INT_MAX` (capped numeric option parsing, ~lines 1200/1206) without
including `<climits>`. On GCC 16.1 / Fedora 44 the transitive include is gone and the default
`cmake --build` of `master` fails ('INT_MAX' was not declared in this scope); the `gpu_capture_render_replay`
ctest then reports Not Run because its `gpu_replay` dependency never links. Older GCC / MinGW / MSVC leak the
constant in transitively, which is why CI stays green.

## Approach

Add the one missing standard include. No behavior change on toolchains that already compiled.

## Verification (exact-head, GCC 16.1.1, Fedora 44)

- Before: build of unmodified master fails at `gpu_replay.cpp.o` with the two INT_MAX errors.
- After: full 633-target build completes; `gpu_replay` links; `ctest -R gpu_capture_render_replay` now runs
  (its one failing DS byte-exact check on RADV is environmental and pre-existing — tracked separately as
  #1009, reproduced at this exact head).