### PR TITLE
fix(file): implement chmod metadata handlers

### DIFF
--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -186,6 +186,10 @@ namespace {
         case ERROR_ACCESS_DENIED:
         case ERROR_SHARING_VIOLATION:
             return EACCES;
+        case ERROR_INVALID_HANDLE:
+            return EBADF;
+        case ERROR_INVALID_PARAMETER:
+            return EINVAL;
         case ERROR_NOT_ENOUGH_MEMORY:
         case ERROR_OUTOFMEMORY:
             return ENOMEM;
@@ -252,6 +256,62 @@ namespace {
         if (it == g_windows_dirs.end()) return false;
         if (path) *path = it->second.path;
         return true;
+    }
+
+    int windows_set_guest_mode(HANDLE file, uint64_t mode) {
+        FILE_BASIC_INFO info{};
+        if (!GetFileInformationByHandleEx(file, FileBasicInfo, &info, sizeof info)) {
+            errno = windows_directory_errno(GetLastError());
+            return -1;
+        }
+        // Win32 has one meaningful permission bit: FILE_ATTRIBUTE_READONLY. Treat any guest
+        // owner/group/other write bit as writable and preserve every unrelated file attribute.
+        if (mode & 0222) info.FileAttributes &= ~FILE_ATTRIBUTE_READONLY;
+        else info.FileAttributes |= FILE_ATTRIBUTE_READONLY;
+        if (!SetFileInformationByHandle(file, FileBasicInfo, &info, sizeof info)) {
+            errno = windows_directory_errno(GetLastError());
+            return -1;
+        }
+        return 0;
+    }
+
+    int windows_chmod_path(const std::string& path, uint64_t mode) {
+        HANDLE file = CreateFileA(path.c_str(), FILE_READ_ATTRIBUTES | FILE_WRITE_ATTRIBUTES,
+                                  FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                                  nullptr, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, nullptr);
+        if (file == INVALID_HANDLE_VALUE) {
+            errno = windows_directory_errno(GetLastError());
+            return -1;
+        }
+        const int result = windows_set_guest_mode(file, mode);
+        const int error = result < 0 ? errno : 0;
+        CloseHandle(file);
+        if (result < 0) errno = error;
+        return result;
+    }
+
+    int windows_fchmod(int fd, uint64_t mode) {
+        std::string directory_path;
+        if (windows_directory_path(fd, &directory_path))
+            return windows_chmod_path(directory_path, mode);
+
+        ScopedCrtInvalidParameterHandler suppress_invalid_parameter;
+        const intptr_t raw = ::_get_osfhandle(fd);
+        if (raw == -1) {
+            errno = EBADF;
+            return -1;
+        }
+        HANDLE file = ReOpenFile((HANDLE)raw, FILE_READ_ATTRIBUTES | FILE_WRITE_ATTRIBUTES,
+                                 FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, 0);
+        if (file == INVALID_HANDLE_VALUE) {
+            errno = windows_directory_errno(GetLastError());
+            return -1;
+        }
+        const int result = windows_set_guest_mode(file, mode);
+        const int error = result < 0 ? errno : 0;
+        CloseHandle(file);
+        if (result < 0) errno = error;
+        return result;
     }
 
     bool windows_seek_directory(int fd, int64_t offset, int whence, int64_t* result) {
@@ -1364,6 +1424,10 @@ HLE(f_fstat) { struct stat st; int r = ::fstat((int)a0, &st); int err = r < 0 ? 
 // uninitialized garbage (wrong file type/size). We have no symlinks in the dump, so ::lstat == ::stat, but
 // the key fix is WRITING the buffer. fsync: was fake-success; flush for real save durability.
 HLE(f_lstat) { std::string h = translate(CS(a0)); struct stat st; int r = ::lstat(h.c_str(), &st); if (r == 0 && a1) to_sce_stat(st, (uint8_t*)P(a1)); return (uint64_t)(int64_t)r; }
+HLE(f_chmod) { if (!a0) { errno = EFAULT; return (uint64_t)(int64_t)-1; }
+               std::string h = translate(CS(a0));
+               return (uint64_t)(int64_t)::chmod(h.c_str(), (mode_t)a1); }
+HLE(f_fchmod){ return (uint64_t)(int64_t)::fchmod((int)a0, (mode_t)a1); }
 HLE(f_fsync) { return (uint64_t)(int64_t)::fsync((int)a0); }
 HLE(f_fdatasync) {
 #if defined(__APPLE__)
@@ -1393,6 +1457,10 @@ HLE(f_fstat) { struct _stat64 st; std::string directory_path;
                if (r < 0) errno = err;
                return (uint64_t)(int64_t)r; }
 HLE(f_lstat) { return f_stat(a0,a1,a2,a3,a4,a5); }
+HLE(f_chmod) { if (!a0) { errno = EFAULT; return (uint64_t)(int64_t)-1; }
+               std::string h = translate(CS(a0));
+               return (uint64_t)(int64_t)windows_chmod_path(h, a1); }
+HLE(f_fchmod){ return (uint64_t)(int64_t)windows_fchmod((int)a0, a1); }
 HLE(f_fsync) { ScopedCrtInvalidParameterHandler suppress_invalid_parameter;
                return (uint64_t)(int64_t)::_commit((int)a0); }
 // The Windows CRT has no data-only durability primitive. _commit is the same stronger fallback
@@ -1416,6 +1484,8 @@ static uint64_t kernel_file_result32(uint64_t result, int error) {
 HLE(k_stat)     { uint64_t r = f_stat(a0, a1, a2, a3, a4, a5);     int e = errno; return kernel_file_result32(r, e); }
 HLE(k_fstat)    { uint64_t r = f_fstat(a0, a1, a2, a3, a4, a5);    int e = errno; return kernel_file_result32(r, e); }
 HLE(k_lstat)    { uint64_t r = f_lstat(a0, a1, a2, a3, a4, a5);    int e = errno; return kernel_file_result32(r, e); }
+HLE(k_chmod)    { uint64_t r = f_chmod(a0, a1, a2, a3, a4, a5);    int e = errno; return kernel_file_result32(r, e); }
+HLE(k_fchmod)   { uint64_t r = f_fchmod(a0, a1, a2, a3, a4, a5);   int e = errno; return kernel_file_result32(r, e); }
 HLE(k_truncate) { uint64_t r = f_truncate(a0, a1, a2, a3, a4, a5); int e = errno; return kernel_file_result32(r, e); }
 HLE(k_ftruncate){ uint64_t r = f_ftruncate(a0, a1, a2, a3, a4, a5); int e = errno; return kernel_file_result32(r, e); }
 HLE(k_fsync)    { uint64_t r = f_fsync(a0, a1, a2, a3, a4, a5);    int e = errno; return kernel_file_result32(r, e); }
@@ -2227,6 +2297,7 @@ void register_file_hle() {
     R("fgetc", f_fgetc);   R("getc", f_fgetc);
     R("open", f_open);     R("close", f_close);   R("read", f_read);     R("write", f_write);
     R("lseek", f_lseek);   R("stat", f_stat);     R("fstat", f_fstat);   R("access", f_access);
+    R("chmod", f_chmod);   R("fchmod", f_fchmod);
     R("sceKernelOpen", k_open);  R("sceKernelClose", k_close); R("sceKernelRead", k_read);
     R("sceKernelWrite", k_write); R("sceKernelLseek", k_lseek); R("sceKernelStat", k_stat);
     R("sceKernelFtruncate", k_ftruncate);   // real resize (was fake-success -> corrupt saves)
@@ -2236,6 +2307,7 @@ void register_file_hle() {
     R("sceKernelSync", k_sync); // whole-filesystem/process-file flush (was fake success)
     R("sceKernelCheckReachability", k_check_reachability); // truthful file/directory existence
     R("sceKernelUtimes", k_utimes); // preserve guest access/modify timestamps (incl. touch-now)
+    R("sceKernelChmod", k_chmod); R("sceKernelFchmod", k_fchmod); // real guest mode changes
     R("sceKernelTruncate", k_truncate);      // path-based sibling (same corruption class)
     R("sceKernelFstat", k_fstat);
     // Low-level POSIX wrappers with the internal leading-underscore names. Real libc.prx implements

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -266,8 +266,19 @@ namespace {
         }
         // Win32 has one meaningful permission bit: FILE_ATTRIBUTE_READONLY. Treat any guest
         // owner/group/other write bit as writable and preserve every unrelated file attribute.
-        if (mode & 0222) info.FileAttributes &= ~FILE_ATTRIBUTE_READONLY;
-        else info.FileAttributes |= FILE_ATTRIBUTE_READONLY;
+        if (mode & 0222) {
+            info.FileAttributes &= ~FILE_ATTRIBUTE_READONLY;
+            if (info.FileAttributes == 0) info.FileAttributes = FILE_ATTRIBUTE_NORMAL;
+        } else {
+            info.FileAttributes &= ~FILE_ATTRIBUTE_NORMAL;
+            info.FileAttributes |= FILE_ATTRIBUTE_READONLY;
+        }
+        // Zero timestamps mean "leave unchanged" for FileBasicInfo. Replaying the values read
+        // above would race another handle and could roll a newer write/access time backwards.
+        info.CreationTime.QuadPart = 0;
+        info.LastAccessTime.QuadPart = 0;
+        info.LastWriteTime.QuadPart = 0;
+        info.ChangeTime.QuadPart = 0;
         if (!SetFileInformationByHandle(file, FileBasicInfo, &info, sizeof info)) {
             errno = windows_directory_errno(GetLastError());
             return -1;

--- a/prosper/tests/test_file_binary.cpp
+++ b/prosper/tests/test_file_binary.cpp
@@ -172,6 +172,22 @@ int main() {
     CHECK(kernel_reachability_fn &&
               kernel_reachability_fn((uint64_t)(uintptr_t)reachable_directory.c_str(), 0, 0, 0, 0, 0) == 0,
           "sceKernelCheckReachability finds a translated guest directory");
+#ifdef _WIN32
+    CHECK(SetFileAttributesA(path, FILE_ATTRIBUTE_NORMAL),
+          "prepare a normal-attribute Windows chmod fixture");
+    auto read_chmod_times = [&](FILETIME* access, FILETIME* modify) {
+        HANDLE file = CreateFileA(path, FILE_READ_ATTRIBUTES,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            nullptr, OPEN_EXISTING, 0, nullptr);
+        if (file == INVALID_HANDLE_VALUE) return false;
+        const BOOL result = GetFileTime(file, nullptr, access, modify);
+        CloseHandle(file);
+        return result != FALSE;
+    };
+    FILETIME chmod_access_before{}, chmod_modify_before{};
+    CHECK(read_chmod_times(&chmod_access_before, &chmod_modify_before),
+          "read Windows fixture timestamps before chmod");
+#endif
     CHECK(kernel_chmod_fn &&
               kernel_chmod_fn((uint64_t)(uintptr_t)reachable_file.c_str(), 0444, 0, 0, 0, 0) == 0,
           "sceKernelChmod makes a translated guest file read-only");
@@ -179,13 +195,23 @@ int main() {
               kernel_chmod_fn((uint64_t)(uintptr_t)reachable_directory.c_str(), 0555, 0, 0, 0, 0) == 0,
           "sceKernelChmod applies a mode to a translated guest directory");
 #ifdef _WIN32
-    CHECK((GetFileAttributesA(path) & FILE_ATTRIBUTE_READONLY) != 0,
-          "Windows sceKernelChmod maps a non-writable mode to the read-only attribute");
+    DWORD readonly_attributes = GetFileAttributesA(path);
+    CHECK((readonly_attributes & FILE_ATTRIBUTE_READONLY) != 0 &&
+              (readonly_attributes & FILE_ATTRIBUTE_NORMAL) == 0,
+          "Windows sceKernelChmod normalizes the read-only attribute set");
 #endif
     CHECK(kernel_chmod_fn &&
               kernel_chmod_fn((uint64_t)(uintptr_t)reachable_file.c_str(), 0644, 0, 0, 0, 0) == 0 &&
               kernel_chmod_fn((uint64_t)(uintptr_t)reachable_directory.c_str(), 0755, 0, 0, 0, 0) == 0,
           "sceKernelChmod restores writable fixture modes");
+#ifdef _WIN32
+    FILETIME chmod_access_after{}, chmod_modify_after{};
+    CHECK(GetFileAttributesA(path) == FILE_ATTRIBUTE_NORMAL &&
+              read_chmod_times(&chmod_access_after, &chmod_modify_after) &&
+              CompareFileTime(&chmod_access_before, &chmod_access_after) == 0 &&
+              CompareFileTime(&chmod_modify_before, &chmod_modify_after) == 0,
+          "Windows sceKernelChmod restores normal attributes without changing timestamps");
+#endif
     int64_t chmod_fd = open_fn
         ? (int64_t)open_fn((uint64_t)(uintptr_t)reachable_file.c_str(), 0, 0, 0, 0, 0)
         : -1;
@@ -194,15 +220,21 @@ int main() {
               kernel_fchmod_fn((uint64_t)chmod_fd, 0400, 0, 0, 0, 0) == 0,
           "sceKernelFchmod makes an open file read-only");
 #ifdef _WIN32
-    CHECK((GetFileAttributesA(path) & FILE_ATTRIBUTE_READONLY) != 0,
-          "Windows sceKernelFchmod updates the descriptor's file attribute");
+    readonly_attributes = GetFileAttributesA(path);
+    CHECK((readonly_attributes & FILE_ATTRIBUTE_READONLY) != 0 &&
+              (readonly_attributes & FILE_ATTRIBUTE_NORMAL) == 0,
+          "Windows sceKernelFchmod normalizes the descriptor's read-only attribute");
 #endif
     CHECK(chmod_fd >= 0 && kernel_fchmod_fn &&
               kernel_fchmod_fn((uint64_t)chmod_fd, 0600, 0, 0, 0, 0) == 0,
           "sceKernelFchmod restores a writable descriptor mode");
 #ifdef _WIN32
-    CHECK((GetFileAttributesA(path) & FILE_ATTRIBUTE_READONLY) == 0,
-          "Windows sceKernelFchmod clears read-only for a writable guest mode");
+    FILETIME fchmod_access_after{}, fchmod_modify_after{};
+    CHECK(GetFileAttributesA(path) == FILE_ATTRIBUTE_NORMAL &&
+              read_chmod_times(&fchmod_access_after, &fchmod_modify_after) &&
+              CompareFileTime(&chmod_access_before, &fchmod_access_after) == 0 &&
+              CompareFileTime(&chmod_modify_before, &fchmod_modify_after) == 0,
+          "Windows sceKernelFchmod restores normal attributes without changing timestamps");
 #endif
     if (chmod_fd >= 0 && close_fn) close_fn((uint64_t)chmod_fd, 0, 0, 0, 0, 0);
 #ifndef _WIN32

--- a/prosper/tests/test_file_binary.cpp
+++ b/prosper/tests/test_file_binary.cpp
@@ -107,6 +107,10 @@ int main() {
     HleFn kernel_sync_fn = Hle::lookup(nid_hash("sceKernelSync"));
     HleFn kernel_reachability_fn = Hle::lookup(nid_hash("sceKernelCheckReachability"));
     HleFn kernel_utimes_fn = Hle::lookup(nid_hash("sceKernelUtimes"));
+    HleFn chmod_fn = Hle::lookup(nid_hash("chmod"));
+    HleFn kernel_chmod_fn = Hle::lookup(nid_hash("sceKernelChmod"));
+    HleFn fchmod_fn = Hle::lookup(nid_hash("fchmod"));
+    HleFn kernel_fchmod_fn = Hle::lookup(nid_hash("sceKernelFchmod"));
     HleFn getdents_fn = Hle::lookup(nid_hash("getdents"));
     HleFn kernel_getdents_fn = Hle::lookup(nid_hash("sceKernelGetdents"));
     HleFn getdirentries_fn = Hle::lookup(nid_hash("getdirentries"));
@@ -128,7 +132,8 @@ int main() {
               kernel_rmdir_fn && unlink_fn && kernel_unlink_fn && rename_fn &&
               kernel_rename_fn && kernel_truncate_fn && kernel_ftruncate_fn && fsync_fn &&
               kernel_fsync_fn && fdatasync_fn && kernel_fdatasync_fn && kernel_sync_fn &&
-              kernel_reachability_fn && kernel_utimes_fn && getdents_fn &&
+              kernel_reachability_fn && kernel_utimes_fn && chmod_fn && kernel_chmod_fn &&
+              fchmod_fn && kernel_fchmod_fn && getdents_fn &&
               kernel_getdents_fn && getdirentries_fn && kernel_getdirentries_fn && stat_fn &&
               kernel_stat_fn && fstat_fn && kernel_fstat_fn && lstat_fn && kernel_lstat_fn &&
               fcntl_fn && kernel_fcntl_fn,
@@ -167,6 +172,63 @@ int main() {
     CHECK(kernel_reachability_fn &&
               kernel_reachability_fn((uint64_t)(uintptr_t)reachable_directory.c_str(), 0, 0, 0, 0, 0) == 0,
           "sceKernelCheckReachability finds a translated guest directory");
+    CHECK(kernel_chmod_fn &&
+              kernel_chmod_fn((uint64_t)(uintptr_t)reachable_file.c_str(), 0444, 0, 0, 0, 0) == 0,
+          "sceKernelChmod makes a translated guest file read-only");
+    CHECK(kernel_chmod_fn &&
+              kernel_chmod_fn((uint64_t)(uintptr_t)reachable_directory.c_str(), 0555, 0, 0, 0, 0) == 0,
+          "sceKernelChmod applies a mode to a translated guest directory");
+#ifdef _WIN32
+    CHECK((GetFileAttributesA(path) & FILE_ATTRIBUTE_READONLY) != 0,
+          "Windows sceKernelChmod maps a non-writable mode to the read-only attribute");
+#endif
+    CHECK(kernel_chmod_fn &&
+              kernel_chmod_fn((uint64_t)(uintptr_t)reachable_file.c_str(), 0644, 0, 0, 0, 0) == 0 &&
+              kernel_chmod_fn((uint64_t)(uintptr_t)reachable_directory.c_str(), 0755, 0, 0, 0, 0) == 0,
+          "sceKernelChmod restores writable fixture modes");
+    int64_t chmod_fd = open_fn
+        ? (int64_t)open_fn((uint64_t)(uintptr_t)reachable_file.c_str(), 0, 0, 0, 0, 0)
+        : -1;
+    CHECK(chmod_fd >= 3, "open a descriptor for sceKernelFchmod");
+    CHECK(chmod_fd >= 0 && kernel_fchmod_fn &&
+              kernel_fchmod_fn((uint64_t)chmod_fd, 0400, 0, 0, 0, 0) == 0,
+          "sceKernelFchmod makes an open file read-only");
+#ifdef _WIN32
+    CHECK((GetFileAttributesA(path) & FILE_ATTRIBUTE_READONLY) != 0,
+          "Windows sceKernelFchmod updates the descriptor's file attribute");
+#endif
+    CHECK(chmod_fd >= 0 && kernel_fchmod_fn &&
+              kernel_fchmod_fn((uint64_t)chmod_fd, 0600, 0, 0, 0, 0) == 0,
+          "sceKernelFchmod restores a writable descriptor mode");
+#ifdef _WIN32
+    CHECK((GetFileAttributesA(path) & FILE_ATTRIBUTE_READONLY) == 0,
+          "Windows sceKernelFchmod clears read-only for a writable guest mode");
+#endif
+    if (chmod_fd >= 0 && close_fn) close_fn((uint64_t)chmod_fd, 0, 0, 0, 0, 0);
+#ifndef _WIN32
+    // WSL's /mnt/c metadata bridge reports synthetic permission bits. Verify exact POSIX chmod
+    // behavior on a unique native-filesystem fixture while retaining /app0 translation above.
+    std::string mode_path =
+        (std::filesystem::temp_directory_path() / "prosper-test-chmod-mode-XXXXXX").string();
+    const int mode_fd = ::mkstemp(mode_path.data());
+    CHECK(mode_fd >= 0, "create unique native-filesystem mode fixture");
+    std::array<uint8_t, 0x78> mode_stat{};
+    CHECK(mode_fd >= 0 && kernel_chmod_fn && kernel_stat_fn &&
+              kernel_chmod_fn((uint64_t)(uintptr_t)mode_path.c_str(), 0444, 0, 0, 0, 0) == 0 &&
+              kernel_stat_fn((uint64_t)(uintptr_t)mode_path.c_str(),
+                             (uint64_t)(uintptr_t)mode_stat.data(), 0, 0, 0, 0) == 0 &&
+              (*(const uint16_t*)(mode_stat.data() + 0x08) & 0777) == 0444,
+          "POSIX sceKernelChmod preserves requested permission bits");
+    mode_stat.fill(0);
+    CHECK(mode_fd >= 0 && kernel_fchmod_fn && kernel_fstat_fn &&
+              kernel_fchmod_fn((uint64_t)mode_fd, 0600, 0, 0, 0, 0) == 0 &&
+              kernel_fstat_fn((uint64_t)mode_fd, (uint64_t)(uintptr_t)mode_stat.data(),
+                              0, 0, 0, 0) == 0 &&
+              (*(const uint16_t*)(mode_stat.data() + 0x08) & 0777) == 0600,
+          "POSIX sceKernelFchmod preserves descriptor permission bits");
+    if (mode_fd >= 0) ::close(mode_fd);
+    std::filesystem::remove(mode_path, remove_error);
+#endif
     GuestTimeval explicit_times[2]{{1700000001, 123456}, {1700000002, 654321}};
     CHECK(kernel_utimes_fn &&
               kernel_utimes_fn((uint64_t)(uintptr_t)reachable_file.c_str(),
@@ -424,6 +486,29 @@ int main() {
           "sceKernelUtimes returns SCE_KERNEL_ERROR_ENOENT for a missing path");
     CHECK(kernel_utimes_fn && kernel_utimes_fn(0, 0, 0, 0, 0, 0) == 0x8002000eu,
           "sceKernelUtimes returns SCE_KERNEL_ERROR_EFAULT for a null path");
+    errno = 0;
+    int64_t missing_chmod = chmod_fn
+        ? (int64_t)chmod_fn((uint64_t)(uintptr_t)unreachable_file.c_str(), 0600, 0, 0, 0, 0)
+        : 0;
+    int missing_chmod_errno = errno;
+    CHECK(missing_chmod == -1 && missing_chmod_errno == ENOENT,
+          "libc chmod retains -1 plus ENOENT");
+    CHECK(kernel_chmod_fn &&
+              kernel_chmod_fn((uint64_t)(uintptr_t)unreachable_file.c_str(),
+                              0600, 0, 0, 0, 0) == 0x80020002u,
+          "sceKernelChmod returns SCE_KERNEL_ERROR_ENOENT for a missing path");
+    CHECK(kernel_chmod_fn && kernel_chmod_fn(0, 0600, 0, 0, 0, 0) == 0x8002000eu,
+          "sceKernelChmod returns SCE_KERNEL_ERROR_EFAULT for a null path");
+    errno = 0;
+    int64_t invalid_fchmod = fchmod_fn
+        ? (int64_t)fchmod_fn(~uint64_t{0}, 0600, 0, 0, 0, 0)
+        : 0;
+    int invalid_fchmod_errno = errno;
+    CHECK(invalid_fchmod == -1 && invalid_fchmod_errno == EBADF,
+          "libc fchmod retains -1 plus EBADF");
+    CHECK(kernel_fchmod_fn &&
+              kernel_fchmod_fn(~uint64_t{0}, 0600, 0, 0, 0, 0) == 0x80020009u,
+          "sceKernelFchmod returns SCE_KERNEL_ERROR_EBADF for an invalid descriptor");
 
     // The stat-family libc names preserve -1 plus errno, while their kernel siblings return
     // a 32-bit SCE error directly. Neither contract may overwrite the guest buffer on failure.


### PR DESCRIPTION
Closes #389.

## Summary
- implement verified `sceKernelChmod(const char*, mode_t)` and `sceKernelFchmod(int, mode_t)` handlers
- preserve full POSIX permission modes for translated paths and descriptors
- map guest writability to the Windows read-only attribute for files, directories, and open descriptors
- preserve libc `-1` + `errno` while kernel exports return translated SCE errors
- add cross-platform behavior, translation, restoration, and failure-contract regressions

## Author pre-PR checks
- rebased cleanly onto `origin/master@e4439e2`
- Linux: `file_binary_roundtrip` passed
- Windows: `file_binary_roundtrip` passed
- `git diff --check origin/master...HEAD` passed

No game or snapshot workflow was run.