### PR TITLE
fix(tools): keep debug shader coverage null-safe

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -5093,11 +5093,14 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                         uint32_t srt_tag = 0;
                         const bool has_srt_tag = sreg_srt_range_tag(
                             rs, in.src[1].value, 4, srt_tag);
+                        const ShaderResource* tagged_res = has_srt_tag && rt
+                                                               ? rt->by_srt_offset(srt_tag)
+                                                               : nullptr;
                         fprintf(stderr, "[mubuf-unresolved] pc=%u srsrc=s%d srt_tag=%s0x%x key_res=%s (%zu res)\n",
                                 in.pc, in.src[1].value, has_srt_tag ? "" : "NONE ",
                                 has_srt_tag ? srt_tag : 0u,
-                                has_srt_tag && rt->by_srt_offset(srt_tag) ? "yes" : "null",
-                                rt->resources.size());
+                                !rt ? "no-table" : (tagged_res ? "yes" : "null"),
+                                rt ? rt->resources.size() : 0u);
                     }
                     ok = false; return true;
                 }

--- a/prosper/tests/test_recompile_coverage.cpp
+++ b/prosper/tests/test_recompile_coverage.cpp
@@ -3,6 +3,7 @@
 // data-driven coverage report over the real game shaders (shader_histo).
 #include "../src/gpu/rdna2_to_spirv.hpp"
 #include "../src/gpu/shader_resources.hpp"
+#include <cstdlib>
 #include <cstdio>
 #include <vector>
 
@@ -26,11 +27,21 @@ int main() {
     // MTBUF needs a resolved V# binding, so the table-less coverage pass must classify it as
     // recompilable-in-context rather than truly unsupported.
     const uint32_t mtbuf_code[] = { 0xe8b02000u, 0x80020100u, 0xBF810000u };
+#ifdef _WIN32
+    _putenv_s("PROSPER_DBG", "1");
+#else
+    setenv("PROSPER_DBG", "1", 1);
+#endif
     RecompileCoverage mtbuf = recompile_coverage(mtbuf_code,
                                                   sizeof(mtbuf_code)/sizeof(mtbuf_code[0]));
+#ifdef _WIN32
+    _putenv_s("PROSPER_DBG", "");
+#else
+    unsetenv("PROSPER_DBG");
+#endif
     CHECK(mtbuf.total == 1 && mtbuf.table_dependent == 1 && mtbuf.unsupported == 0 &&
           mtbuf.first_bad_fmt < 0,
-          "MTBUF typed loads are reported as resource-table-dependent coverage");
+          "MTBUF typed loads remain null-safe under debug coverage and report table dependence");
     const uint32_t mtbuf_d16_code[] = { 0xe8682000u, 0x80220000u, 0xBF810000u };
     RecompileCoverage mtbuf_d16 = recompile_coverage(
         mtbuf_d16_code, sizeof(mtbuf_d16_code)/sizeof(mtbuf_d16_code[0]));


### PR DESCRIPTION
Fixes #1013.

## Failure scenario

`PROSPER_DBG=1 shader_inspect <shader> --stage ...` crashed while its table-less `recompile_coverage` pass inspected a typed buffer load. The unresolved-resource diagnostic dereferenced the intentionally null `ShaderResourceTable`, so the tool hid the actual stage rejection that it was meant to diagnose.

## Change

- Report `key_res=no-table` and a zero resource count when coverage has no resource table.
- Exercise the typed-MTBUF coverage path with `PROSPER_DBG` enabled in the existing cross-platform regression.

The production resource-resolution behavior is unchanged. This only makes the gated diagnostic null-safe; unresolved resources still reject fail-visibly.

## Risk

Low and confined to diagnostic formatting plus test environment setup. The table-present diagnostic preserves its existing lookup and count behavior.

## Verification

Exact head `b673ab79d21bbe062c87a79f25a53b0ee9f4389f`:

- `powershell -File prosper/tools/verify-pr.ps1 core`
  - Linux build: pass
  - Linux ctest: 119/119 pass
  - Windows build: pass
  - Windows ctest: 91/91 pass
- Real Astro VS `0x5002a9a00`: `PROSPER_DBG=1 shader_inspect ... --stage vertex` now exits normally with `stage-recompile ... rejected` and identifies the first contextual rejection at PC 17.
- `git diff --check`: pass

This PR does not claim visible game progression, so no game screenshot is applicable.