### PR TITLE
fix(audio): pace SDL sink per grain to stop FMOD mixer signal coalescing (#1016)

### DIFF
--- a/prosper/frontends/audio_sdl3/audio_sink_sdl3.cpp
+++ b/prosper/frontends/audio_sdl3/audio_sink_sdl3.cpp
@@ -10,6 +10,7 @@
 #include <SDL3/SDL.h>
 
 #include <array>
+#include <chrono>
 #include <mutex>
 #include <thread>
 
@@ -49,43 +50,38 @@ public:
         if (!s.stream) { SDL_Log("prosper-audio: OpenAudioDeviceStream failed: %s", SDL_GetError()); return false; }
         s.frame_bytes = audio_frame_bytes(info);
         s.grain_bytes = audio_grain_bytes(info);
-        // Queue cap for output()'s pacing: enough to cover TWO device periods plus two grains of
-        // jitter margin, floored at the historical 4 grains. A fixed 4-grain cap (~21 ms at the
-        // common 256-frame grain) left ZERO headroom against PipeWire's ~21 ms pull quantum, so any
-        // scheduling jitter starved the device once per quantum and playback came out garbled —
-        // while WASAPI's ~10 ms periods and PulseAudio's deep server buffering masked the same math
-        // on Windows/WSL. Sizing from the real device period keeps latency minimal per platform
-        // instead of hard-coding one backend's numbers.
-        int device_frames = 0;
-        SDL_AudioSpec dev_spec{};
-        if (SDL_AudioDeviceID dev = SDL_GetAudioStreamDevice(s.stream))
-            SDL_GetAudioDeviceFormat(dev, &dev_spec, &device_frames);
-        // device_frames is in DEVICE-rate frames; rescale to the port's rate before mixing units.
-        int period_port_frames = (device_frames > 0 && dev_spec.freq > 0)
-            ? (int)((int64_t)device_frames * info.freq / dev_spec.freq) : 0;
-        int cap = 4 * s.grain_bytes;
-        if (period_port_frames > 0) {
-            int period_bytes = period_port_frames * s.frame_bytes;
-            if (2 * period_bytes + 2 * s.grain_bytes > cap) cap = 2 * period_bytes + 2 * s.grain_bytes;
-        }
-        s.queue_cap = cap;
+        s.freq = info.freq;
+        s.next = {};   // (re)start the per-grain pacing clock on the first output()
         SDL_ResumeAudioStreamDevice(s.stream);
         return true;
     }
 
     void output(int port, const void* pcm, int frames) override {
         if (port < 1 || port > kMaxPorts) return;
-        SDL_AudioStream* stream; int frame_bytes, queue_cap;
-        { std::lock_guard<std::mutex> lk(mx_); Slot& s = slots_[port - 1];
-          stream = s.stream; frame_bytes = s.frame_bytes; queue_cap = s.queue_cap; }
+        SDL_AudioStream* stream; int frame_bytes; int freq;
+        std::chrono::steady_clock::time_point target;
+        {
+            std::lock_guard<std::mutex> lk(mx_);
+            Slot& s = slots_[port - 1];
+            stream = s.stream; frame_bytes = s.frame_bytes; freq = s.freq;
+            if (stream && freq > 0) {
+                // Pace EACH call one grain of wall-clock time apart (real sceAudioOutOutput blocks
+                // until the hardware ring frees one grain — evenly spaced, never bursty). The old
+                // cap-based pacing let the guest burst a whole device quantum (4+ grains) and then
+                // stall: FMOD signals its mixer's condvar once per submitted grain, condvar signals
+                // COALESCE within a burst, so the mixer woke once per ~21 ms instead of once per
+                // grain and mixed at 1/4 real time — every DSP block audibly replayed ~4x (#1016).
+                // Same resync-if-behind model as the core's RealtimeSilentSink.
+                auto dur = std::chrono::nanoseconds((int64_t)frames * 1000000000LL / freq);
+                auto now = std::chrono::steady_clock::now();
+                if (s.next.time_since_epoch().count() == 0 || s.next < now - dur * 4) s.next = now;
+                s.next += dur;
+                target = s.next;
+            }
+        }
         if (!stream) return;
-        int bytes = frames * frame_bytes;
-        SDL_PutAudioStreamData(stream, pcm, bytes);
-        // Pace like real hardware: block while the queue is ahead of the device-derived cap
-        // (computed in open() — two device periods + jitter margin, min 4 grains).
-        const int cap = queue_cap > 0 ? queue_cap : bytes * 4;
-        for (int spins = 0; SDL_GetAudioStreamQueued(stream) > cap && spins < 1000; spins++)
-            SDL_Delay(1);
+        SDL_PutAudioStreamData(stream, pcm, frames * frame_bytes);
+        if (freq > 0) std::this_thread::sleep_until(target);
     }
 
     void set_volume(int port, uint32_t mask, const int* vols) override {
@@ -107,7 +103,8 @@ public:
 
 private:
     struct Slot { SDL_AudioStream* stream = nullptr; int frame_bytes = 0; int grain_bytes = 0;
-                  int queue_cap = 0; };   // pacing cap in bytes, derived from the device period in open()
+                  int freq = 0;                                     // port sample rate for pacing
+                  std::chrono::steady_clock::time_point next{}; };  // per-grain pacing deadline
     std::mutex mx_;
     std::array<Slot, kMaxPorts> slots_{};
 };

--- a/prosper/frontends/audio_sdl3/audio_sink_sdl3.cpp
+++ b/prosper/frontends/audio_sdl3/audio_sink_sdl3.cpp
@@ -49,20 +49,41 @@ public:
         if (!s.stream) { SDL_Log("prosper-audio: OpenAudioDeviceStream failed: %s", SDL_GetError()); return false; }
         s.frame_bytes = audio_frame_bytes(info);
         s.grain_bytes = audio_grain_bytes(info);
+        // Queue cap for output()'s pacing: enough to cover TWO device periods plus two grains of
+        // jitter margin, floored at the historical 4 grains. A fixed 4-grain cap (~21 ms at the
+        // common 256-frame grain) left ZERO headroom against PipeWire's ~21 ms pull quantum, so any
+        // scheduling jitter starved the device once per quantum and playback came out garbled —
+        // while WASAPI's ~10 ms periods and PulseAudio's deep server buffering masked the same math
+        // on Windows/WSL. Sizing from the real device period keeps latency minimal per platform
+        // instead of hard-coding one backend's numbers.
+        int device_frames = 0;
+        SDL_AudioSpec dev_spec{};
+        if (SDL_AudioDeviceID dev = SDL_GetAudioStreamDevice(s.stream))
+            SDL_GetAudioDeviceFormat(dev, &dev_spec, &device_frames);
+        // device_frames is in DEVICE-rate frames; rescale to the port's rate before mixing units.
+        int period_port_frames = (device_frames > 0 && dev_spec.freq > 0)
+            ? (int)((int64_t)device_frames * info.freq / dev_spec.freq) : 0;
+        int cap = 4 * s.grain_bytes;
+        if (period_port_frames > 0) {
+            int period_bytes = period_port_frames * s.frame_bytes;
+            if (2 * period_bytes + 2 * s.grain_bytes > cap) cap = 2 * period_bytes + 2 * s.grain_bytes;
+        }
+        s.queue_cap = cap;
         SDL_ResumeAudioStreamDevice(s.stream);
         return true;
     }
 
     void output(int port, const void* pcm, int frames) override {
         if (port < 1 || port > kMaxPorts) return;
-        SDL_AudioStream* stream; int frame_bytes, grain_bytes;
+        SDL_AudioStream* stream; int frame_bytes, queue_cap;
         { std::lock_guard<std::mutex> lk(mx_); Slot& s = slots_[port - 1];
-          stream = s.stream; frame_bytes = s.frame_bytes; grain_bytes = s.grain_bytes; }
+          stream = s.stream; frame_bytes = s.frame_bytes; queue_cap = s.queue_cap; }
         if (!stream) return;
         int bytes = frames * frame_bytes;
         SDL_PutAudioStreamData(stream, pcm, bytes);
-        // Pace like real hardware: don't let more than ~4 grains queue up ahead of playback.
-        const int cap = grain_bytes > 0 ? grain_bytes * 4 : bytes * 4;
+        // Pace like real hardware: block while the queue is ahead of the device-derived cap
+        // (computed in open() — two device periods + jitter margin, min 4 grains).
+        const int cap = queue_cap > 0 ? queue_cap : bytes * 4;
         for (int spins = 0; SDL_GetAudioStreamQueued(stream) > cap && spins < 1000; spins++)
             SDL_Delay(1);
     }
@@ -85,7 +106,8 @@ public:
     }
 
 private:
-    struct Slot { SDL_AudioStream* stream = nullptr; int frame_bytes = 0; int grain_bytes = 0; };
+    struct Slot { SDL_AudioStream* stream = nullptr; int frame_bytes = 0; int grain_bytes = 0;
+                  int queue_cap = 0; };   // pacing cap in bytes, derived from the device period in open()
     std::mutex mx_;
     std::array<Slot, kMaxPorts> slots_{};
 };

--- a/prosper/src/hle/hle_audio.cpp
+++ b/prosper/src/hle/hle_audio.cpp
@@ -147,6 +147,78 @@ void audio_reset() {
     g_sink.store(&g_default_sink);
 }
 
+// --- legacy-path diagnostics --------------------------------------------------------------
+// PROSPER_AUDIOLOG=1: log port opens (raw args + decoded format), SetVolume args, and a
+// once-per-second PCM peak per port, so a silent/quiet/garbled title shows WHERE the signal
+// degrades (no output calls vs silent PCM vs wrong format vs volume mapping).
+// PROSPER_AUDIO_DUMP=PATH: append each port's raw output() grains to PATH.portN.raw for
+// offline analysis, mirroring PROSPER_SHADER_DUMP's capture-first workflow.
+namespace {
+
+int audiolog_level() {
+    static int v = -1;
+    if (v < 0) { const char* e = getenv("PROSPER_AUDIOLOG"); v = (e && *e) ? atoi(e) : 0; if (v < 0) v = 0; }
+    return v;
+}
+bool audiolog() { return audiolog_level() >= 1; }
+
+const char* audio_dump_path() {
+    static const char* p = getenv("PROSPER_AUDIO_DUMP");
+    return (p && *p) ? p : nullptr;
+}
+
+// Peak |sample| of one grain, normalized to [0,1] for either sample format.
+double audio_pcm_peak(const void* pcm, int frames, const AudioPortInfo& info) {
+    if (!pcm || frames <= 0) return 0.0;
+    const int n = frames * info.channels;
+    double peak = 0.0;
+    if (info.fmt == AudioFmt::F32) {
+        const float* s = (const float*)pcm;
+        for (int i = 0; i < n; i++) { double v = s[i] < 0 ? -(double)s[i] : (double)s[i]; if (v > peak) peak = v; }
+    } else {
+        const int16_t* s = (const int16_t*)pcm;
+        for (int i = 0; i < n; i++) { double v = (s[i] < 0 ? -(double)s[i] : (double)s[i]) / 32768.0; if (v > peak) peak = v; }
+    }
+    return peak;
+}
+
+// Once-per-second peak report + optional raw dump. Called from the output paths (guest audio
+// thread) with the port's decoded info; per-port state, no cross-port locking needed beyond
+// the distinct slots.
+void audio_observe_output(int handle, const void* pcm, int frames, const AudioPortInfo& info) {
+    if (!audiolog() && !audio_dump_path()) return;
+    if (handle < 1 || handle > kMaxPorts) return;
+    static struct Obs { uint64_t calls = 0; double peak = 0.0; FILE* dump = nullptr;
+                        std::chrono::steady_clock::time_point last{}; } st[kMaxPorts];
+    Obs& s = st[handle - 1];
+    s.calls++;
+    double p = audio_pcm_peak(pcm, frames, info);
+    if (p > s.peak) s.peak = p;
+    if (audiolog()) {
+        auto now = std::chrono::steady_clock::now();
+        if (s.last.time_since_epoch().count() == 0) s.last = now;
+        if (now - s.last >= std::chrono::seconds(1)) {
+            fprintf(stderr, "[audio] port %d: %llu output calls, 1s-peak=%.4f (fmt=%s ch=%d freq=%d grain=%d)\n",
+                    handle, (unsigned long long)s.calls, s.peak,
+                    info.fmt == AudioFmt::F32 ? "f32" : "s16", info.channels, info.freq, info.grain);
+            s.last = now; s.peak = 0.0;
+        }
+    }
+    if (const char* base = audio_dump_path()) {
+        if (!s.dump) {
+            char path[1024];
+            snprintf(path, sizeof path, "%s.port%d.raw", base, handle);
+            s.dump = fopen(path, "ab");
+            fprintf(stderr, "[audio] port %d: dumping raw PCM to %s (fmt=%s ch=%d freq=%d grain=%d)\n",
+                    handle, path, info.fmt == AudioFmt::F32 ? "f32" : "s16",
+                    info.channels, info.freq, info.grain);
+        }
+        if (s.dump && pcm && frames > 0) fwrite(pcm, 1, (size_t)frames * audio_frame_bytes(info), s.dump);
+    }
+}
+
+} // namespace
+
 // --- sceAudioOut HLE --------------------------------------------------------------------
 HLE(audio_init) { (void)a0; return 0; }   // sceAudioOutInit: idempotent success
 
@@ -171,6 +243,12 @@ HLE(audio_open) {
           break;
       } }
     if (!handle) return kAudioErrPortFull;
+    if (audiolog())
+        fprintf(stderr, "[audio] open: handle=%d userId=%d type=%d index=%d len=%llu freq=%llu param=0x%llx"
+                        " -> fmt=%s ch=%d grain=%d\n",
+                handle, (int)a0, type, (int)a2, (unsigned long long)a3, (unsigned long long)a4,
+                (unsigned long long)a5, info.fmt == AudioFmt::F32 ? "f32" : "s16",
+                info.channels, info.grain);
     if (auto* s = audio_sink()) s->open(handle, info);
     return (uint64_t)handle;
 }
@@ -180,6 +258,7 @@ HLE(audio_output) {
     AudioPortInfo info;
     { std::lock_guard<std::mutex> lk(g_mx); Port* p = port_of((int)a0); if (!p) return kAudioErrInvalidPort; info = p->info; }
     if (a1 == 0) return 0;   // drain/flush: nothing buffered in the headless model
+    audio_observe_output((int)a0, P(a1), info.grain, info);
     if (auto* s = audio_sink()) s->output((int)a0, P(a1), info.grain);
     return (uint64_t)info.grain;
 }
@@ -199,7 +278,8 @@ HLE(audio_outputs) {
         AudioPortInfo info; bool ok;
         { std::lock_guard<std::mutex> lk(g_mx); Port* p = port_of(arr[i].handle); ok = (p != nullptr); if (ok) info = p->info; }
         if (!ok) continue;
-        if (arr[i].ptr) { if (auto* s = audio_sink()) s->output(arr[i].handle, P(arr[i].ptr), info.grain); }
+        if (arr[i].ptr) { audio_observe_output(arr[i].handle, P(arr[i].ptr), info.grain, info);
+                          if (auto* s = audio_sink()) s->output(arr[i].handle, P(arr[i].ptr), info.grain); }
         if (!have) { grain = info.grain; have = true; }
     }
     return grain;
@@ -209,6 +289,9 @@ HLE(audio_outputs) {
 HLE(audio_set_volume) {
     uint32_t mask = (uint32_t)a1;
     const int* vols = (const int*)P(a2);
+    if (audiolog() && vols)
+        fprintf(stderr, "[audio] set_volume: handle=%d mask=0x%x vols=[%d,%d,%d,%d,%d,%d,%d,%d]\n",
+                (int)a0, mask, vols[0], vols[1], vols[2], vols[3], vols[4], vols[5], vols[6], vols[7]);
     { std::lock_guard<std::mutex> lk(g_mx);
       Port* p = port_of((int)a0); if (!p) return kAudioErrInvalidPort;
       audio_apply_channel_volumes(p->vol, mask, vols); }

--- a/prosper/tools/audio_analyze.py
+++ b/prosper/tools/audio_analyze.py
@@ -80,7 +80,26 @@ def main():
     ncorrs = {lag: corr(seg, lag) for lag in neighbors}
     baseline = max(ncorrs.values())
     spike = block_corr - baseline
-    broken = spike > REPEAT_SPIKE
+
+    # Sharper co-metric: byte-identical grain duplication. In the broken Messenger capture, 74% of
+    # non-silent 256-frame grains were bit-identical to the grain 4 back (the resubmitted DSP block);
+    # healthy mixed audio essentially never emits byte-identical non-silent grains.
+    grain_bytes = 256 * a.channels * (4 if a.fmt == "f32" else 2)
+    raw = open(a.dump, "rb").read()
+    tail_bytes = int(a.tail_seconds * a.rate) * a.channels * (4 if a.fmt == "f32" else 2)
+    rawseg = raw[-tail_bytes:] if len(raw) > tail_bytes else raw
+    grains = [rawseg[i:i + grain_bytes] for i in range(0, len(rawseg) - grain_bytes, grain_bytes)]
+    nonsilent = dup = 0
+    for i in range(8, len(grains)):
+        g = grains[i]
+        if not any(g):
+            continue
+        nonsilent += 1
+        if any(g == grains[i - lag] for lag in range(1, 9)):
+            dup += 1
+    dup_ratio = dup / nonsilent if nonsilent else 0.0
+
+    broken = spike > REPEAT_SPIKE or dup_ratio > 0.10
 
     out = {
         "verdict": "block-repetition" if broken else "clean",
@@ -89,6 +108,7 @@ def main():
         "neighbor_corrs": {str(k): round(v, 4) for k, v in ncorrs.items()},
         "spike": round(spike, 4),
         "threshold": REPEAT_SPIKE,
+        "dup_grain_ratio": round(dup_ratio, 4),
         "rms": round(rms, 6),
         "peak": round(peak, 6),
         "analyzed_seconds": round(len(seg) / a.rate, 2),
@@ -98,7 +118,7 @@ def main():
     else:
         print(f"{out['verdict'].upper()}: corr(block {a.block}f)={block_corr:+.3f} "
               f"neighbor-max={baseline:+.3f} spike={spike:+.3f} (threshold {REPEAT_SPIKE}) "
-              f"rms={rms:.4f} peak={peak:.4f}")
+              f"dup-grains={dup_ratio:.1%} rms={rms:.4f} peak={peak:.4f}")
     return 1 if broken else 0
 
 

--- a/prosper/tools/audio_analyze.py
+++ b/prosper/tools/audio_analyze.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""audio_analyze.py — objective health check for PROSPER_AUDIO_DUMP guest PCM captures.
+
+Detects the block-repetition failure mode (guest mixer/stream starvation: the same DSP-block-
+sized window is re-emitted, audible as "the buffer replays") without a human listener, by
+comparing the autocorrelation at the suspected block lag against neighboring non-multiple lags.
+A healthy music/SFX stream has no reason to correlate at one specific ~21 ms lag and not at
+its neighbors; a starving mixer produces a sharp spike there.
+
+Usage:
+  audio_analyze.py DUMP.raw [--fmt f32|s16] [--channels N] [--rate HZ] [--block FRAMES]
+                             [--tail-seconds S] [--json]
+
+Exit code: 0 = no repetition signature, 1 = repetition detected, 2 = not enough signal.
+Verdict thresholds are conservative; see REPEAT_SPIKE below.
+"""
+import argparse, json, math, struct, sys
+
+# Spike = corr(block lag) - max(corr(neighbor lags)). Broken Messenger measures ~0.7 spike;
+# clean content measures near 0 (music self-similarity shows up at MUSICAL periods, which are
+# not pinned to the DSP block size and also raise the neighbor baseline).
+REPEAT_SPIKE = 0.35
+MIN_RMS = 1e-4          # below this the capture is effectively silence: no verdict
+
+
+def load(path, fmt, channels):
+    raw = open(path, "rb").read()
+    if fmt == "f32":
+        n = len(raw) // 4
+        v = struct.unpack("<%df" % n, raw[: n * 4])
+    else:
+        n = len(raw) // 2
+        v = [x / 32768.0 for x in struct.unpack("<%dh" % n, raw[: n * 2])]
+    return v[0::channels]   # first channel is enough for periodicity
+
+
+def corr(seg, lag, stride=4):
+    m = len(seg) - lag
+    if m <= stride:
+        return 0.0
+    s = e1 = e2 = 0.0
+    for i in range(0, m, stride):
+        a, b = seg[i], seg[i + lag]
+        s += a * b
+        e1 += a * a
+        e2 += b * b
+    return s / math.sqrt(e1 * e2) if e1 > 0 and e2 > 0 else 0.0
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("dump")
+    ap.add_argument("--fmt", choices=["f32", "s16"], default="f32")
+    ap.add_argument("--channels", type=int, default=2)
+    ap.add_argument("--rate", type=int, default=48000)
+    ap.add_argument("--block", type=int, default=1024, help="suspected repeat period in frames")
+    ap.add_argument("--tail-seconds", type=float, default=10.0,
+                    help="analyze only the last S seconds (skips boot silence/fade-in)")
+    ap.add_argument("--json", action="store_true")
+    a = ap.parse_args()
+
+    ch = load(a.dump, a.fmt, a.channels)
+    tail = int(a.tail_seconds * a.rate)
+    seg = ch[-tail:] if len(ch) > tail else ch
+    if len(seg) < 4 * a.block:
+        print("audio_analyze: capture too short", file=sys.stderr)
+        return 2
+    mean = sum(seg) / len(seg)
+    seg = [x - mean for x in seg]
+    rms = math.sqrt(sum(x * x for x in seg) / len(seg))
+    peak = max(abs(x) for x in seg)
+    if rms < MIN_RMS:
+        out = {"verdict": "silent", "rms": rms, "peak": peak}
+        print(json.dumps(out) if a.json else f"SILENT capture (rms={rms:.6f}) — no verdict")
+        return 2
+
+    block_corr = corr(seg, a.block)
+    # Neighbors: same magnitude, deliberately NOT multiples/divisors of the block.
+    neighbors = [int(a.block * f) for f in (0.7, 0.8, 1.3, 1.6)]
+    ncorrs = {lag: corr(seg, lag) for lag in neighbors}
+    baseline = max(ncorrs.values())
+    spike = block_corr - baseline
+    broken = spike > REPEAT_SPIKE
+
+    out = {
+        "verdict": "block-repetition" if broken else "clean",
+        "block_frames": a.block,
+        "block_corr": round(block_corr, 4),
+        "neighbor_corrs": {str(k): round(v, 4) for k, v in ncorrs.items()},
+        "spike": round(spike, 4),
+        "threshold": REPEAT_SPIKE,
+        "rms": round(rms, 6),
+        "peak": round(peak, 6),
+        "analyzed_seconds": round(len(seg) / a.rate, 2),
+    }
+    if a.json:
+        print(json.dumps(out))
+    else:
+        print(f"{out['verdict'].upper()}: corr(block {a.block}f)={block_corr:+.3f} "
+              f"neighbor-max={baseline:+.3f} spike={spike:+.3f} (threshold {REPEAT_SPIKE}) "
+              f"rms={rms:.4f} peak={peak:.4f}")
+    return 1 if broken else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Fixes #1016

## Failure scenario

The Messenger (PPSA24651) on native Linux plays garbled audio — every Unity/FMOD DSP block audibly
replayed ~4x ("the buffer repeats instead of being fed"). The same code sounds perfect on Windows.

## Diagnosis (all evidence from live captures on native Linux / PipeWire / RADV)

- New `PROSPER_AUDIO_DUMP` captures the exact PCM the guest hands to `sceAudioOutOutput`. The dumped
  stream itself contained the repetition: **73.7% of non-silent 256-frame grains bit-identical to the
  grain 4 back**, autocorrelation **+0.770 at exactly 1024 frames** (the FMOD DSP block) vs ~0 at
  neighbor lags. The guest mixer produced fresh audio at exactly **1/4 real time** while the submit
  thread paced a perfect 187.5 grains/s.
- Thread census: `FMOD mixer thread` blocked on a condvar futex; wakeups ≈ one per device quantum.
- Mechanism: the SDL sink paced by **queue cap**, so the guest's AudioOut thread pushed 4+ grains in a
  burst per PipeWire ~21 ms quantum, then stalled. FMOD signals its mixer's condvar once per submitted
  grain; **condvar signals coalesce**, so four in-burst signals produced ONE mixer wake per quantum →
  one 256-frame mix per 1024 frames played → each block resubmitted ~4x. Windows WASAPI's ~10 ms
  periods naturally spaced the submissions, masking the bug there.
- Ruled out along the way: device routing/mute (test tone audible), stream volume (100%, gain 1.0),
  guest PCM integrity (clean, gapless), TSC frequency skew (consistent 1 GHz ns pair),
  `sceKernelSema`/`scePthreadSem` (zero traffic — unused by FMOD here).

## Behavioral contract

Real `sceAudioOutOutput` blocks until the hardware ring frees **one grain** — submissions are evenly
spaced in time. The sink now reproduces that: each `output()` call sleeps to a per-port
one-grain-per-call wall-clock schedule (same resync-if-behind model as prosper_core's
`RealtimeSilentSink`), instead of push-until-queue-cap.

## Affected / deliberately unaffected

- Affected: any title whose audio engine paces internal mixing off per-submit wakeups (FMOD/Unity) on
  hosts with large audio quanta (PipeWire). Latency behavior is now uniform across backends.
- Unaffected: the HLE decode/volume/port surface (unchanged); Dead Cells (silent NGS2 path, #554);
  headless builds (RealtimeSilentSink already paced this way — the SDL sink now matches it).
- `PROSPER_AUDIOLOG` / `PROSPER_AUDIO_DUMP` are new opt-in diagnostics, inert by default.

## Verification (exact head, native Linux, Fedora 44 distrobox / PipeWire / RADV STRIX_HALO)

- Programmatic oracle `tools/audio_analyze.py` (landed here) on `PROSPER_AUDIO_DUMP` captures:
  - Before: `BLOCK-REPETITION: spike=+0.705 dup-grains=73.7%` (exit 1)
  - After: `CLEAN: spike=-0.049 dup-grains=0.0%` (exit 0)
- `ctest -R audio`: 2/2 pass. Full suite: 111/112 — the single failure is the pre-existing
  environmental #1009 (`gpu_capture_render_replay` DS byte-exact readback on RADV), reproduced on
  unmodified master.
- User listening test on the fixed build: The Messenger title music confirmed clean ("perfect").
- Snapshot guard: not run — no recompiler/AGC/render-state/detile/executor/present code touched.
