### PR TITLE
fix(gpu/compute): render single-layer 2D-array storage images (DOLL boot splash now visible) (#319)

### DIFF
--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -630,7 +630,13 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             const bool dim_1d = r->img_dim == 0;
             const bool dim_3d = r->img_dim == 2;
             const bool dim_2d_array = r->img_dim == 5 && r->depth_compare;
-            if (!dim_1d && r->img_dim != 1 && !dim_3d && !dim_2d_array) {
+            // A SINGLE-LAYER 2D array (img_dim==5, depth==1, no depth-compare) is byte-identical to a
+            // plain 2D image (one layer, same tiling), so it flows through the 2D path below unchanged.
+            // The general multi-layer/array case stays deferred to #657. DOLL's post-process compute
+            // declares its mask/LUT surfaces this way; skipping them left the tonemap sampling an empty
+            // surface -> a zero mask -> black composite even though the scene renders (#319/#657).
+            const bool dim_2d_single = r->img_dim == 5 && !r->depth_compare && r->depth == 1;
+            if (!dim_1d && r->img_dim != 1 && !dim_3d && !dim_2d_array && !dim_2d_single) {
                 skip_image(r, "layered image deferred to #657"); break;
             }
             if (dim_1d && r->height != 1) { skip_image(r, "1D image has non-unit height"); break; }


### PR DESCRIPTION
## Summary
Fixes the fully-black DQ VII (DOLL / PPSA17942) title/boot composite — DOLL now renders its
**boot splash sequence (HEXA DRIVE, CRIWARE logos) crisply at native 3840×2160**, where every
prior capture was byte-identical near-black.

## Root cause (traced end to end)
The scene geometry drew fine all along (237 non-black RTT passes, 2461/2609 texture-sample
hits), but the final composite multiplied the scene by a **compute-produced mask that was all
zeros**. Provenance (`PROSPER_RTTLOG` + `PROSPER_PROVENANCE_DIM` + `PROSPER_RESOURCE_HASH_DIM`)
showed the compute dispatch feeding that mask sampled a storage image that `live_compute.cpp`
skipped as `layered image deferred to #657`. Those UE4 post-process surfaces are declared as
2D **arrays** (`img_dim==5`) but with `depth==1` and no depth-compare — i.e. a **single layer**,
byte-identical to a plain 2D image.

## Fix (7 lines)
Accept the single-layer degenerate case (`img_dim==5 && depth==1 && !depth_compare`) and route
it through the existing 2D create/upload/detile/writeback path (arrayLayers=1, 2D image/view,
2D detile). The general multi-layer/array case stays correctly deferred to #657. Verified no
other `img_dim` site special-cases it (the writeback's `array_depth` at line ~1393 still
requires `depth_compare`).

## Affected / not affected
Shared `live_compute.cpp`. DOLL: black → visible. Multi-layer arrays: unchanged (still #657).
`test_compute_exec` stays green. Messenger regression check: (in progress; will post result).

## Verification
- `test_compute_exec` PASS.
- DOLL Linux (`boot_trace`, direct 3840×2160, no diagnostic forcing): first visible frames —
  maxpix 1 → 255, 31 content frames, HEXA DRIVE + CRIWARE splash logos render correctly.

Relates to #319 (black composite), #657 (general layered/array capture — still open for the
multi-layer case), #590 (companion storage-format work).
