### PR TITLE
fix(shader): implement RDNA2 unsigned-byte converts (#1021)

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -3972,6 +3972,13 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                                b.cvt_i2f(b.bfe_s(a, b.uconst(0), b.uconst(4))),
                                b.uconst(fbits(0.0625f)));
                     break;
+                // AMD RDNA2 ISA: select one unsigned byte from the source dword and convert it
+                // directly to f32. The opcode number selects BYTE_0 through BYTE_3.
+                case 0x11: case 0x12: case 0x13: case 0x14:
+                    d = b.cvt_u2f(b.bfe_u(a,
+                                          b.uconst(8u * (in.opcode - 0x11u)),
+                                          b.uconst(8)));
+                    break;
                 case 0x20: d = b.fext1(Glsl_Fract, a); break;         // v_fract_f32
                 case 0x21: d = b.fext1(Glsl_Trunc, a); break;         // v_trunc_f32
                 case 0x22: d = b.fext1(Glsl_Ceil, a); break;          // v_ceil_f32
@@ -4020,7 +4027,8 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // opcodes only (mirrors the VOP2/VOP3 fresult path; DOLL VS: `v_exp_f32_sdwa … clamp`).
             // A modifier on a non-float-result op would silently drop — reject loudly instead.
             if (ok && (in.omod || in.clamp)) switch (in.opcode) {
-                case 0x05: case 0x06: case 0x0B: case 0x0E: case 0x20: case 0x21: case 0x22: case 0x23: case 0x24:
+                case 0x05: case 0x06: case 0x0B: case 0x0E: case 0x11: case 0x12: case 0x13: case 0x14:
+                case 0x20: case 0x21: case 0x22: case 0x23: case 0x24:
                 case 0x25: case 0x27: case 0x2A: case 0x2B: case 0x2E: case 0x33: case 0x35: case 0x36:
                     if      (in.omod == 1) d = b.fbin(Op_FMul, d, b.uconst(fbits(2.0f)));
                     else if (in.omod == 2) d = b.fbin(Op_FMul, d, b.uconst(fbits(4.0f)));

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -3407,6 +3407,36 @@ int main() {
     CHECK(gotT32b.size() == 1 && gotT32b[0] == 17.0f && atomic_out_b.size() == 2 && atomic_out_b[1] == 42u,
           "T32b: GLC=1 buffer_atomic_umax returns the pre-op value and stores the maximum");
 
+    // T33 (#1021): Astro title vertex shaders use the VOP1 unsigned-byte conversion family.
+    // Convert all four bytes from v4 independently, then sum the exact f32 results in v0.
+    const uint32_t codeT33[] = {
+        0x7e002304u,                         // v_cvt_f32_ubyte0 v0, v4
+        0x7e022504u,                         // v_cvt_f32_ubyte1 v1, v4
+        0x7e042704u,                         // v_cvt_f32_ubyte2 v2, v4
+        0x7e062904u,                         // v_cvt_f32_ubyte3 v3, v4
+        0x06000300u,                         // v_add_f32 v0, v0, v1
+        0x06000500u,                         // v_add_f32 v0, v0, v2
+        0x06000700u,                         // v_add_f32 v0, v0, v3
+        0xbf810000u,
+    };
+    std::vector<uint32_t> spvT33 = recompile_valu(codeT33, std::size(codeT33), 5, 0);
+    CHECK(!spvT33.empty(), "recompiled T33 (Astro V_CVT_F32_UBYTE0..3) -> SPIR-V");
+    const uint32_t rawT33[] = {
+        0x00000000u, 0x01020304u, 0x10203040u, 0x11223344u,
+        0x3f800000u, 0x80000001u, 0x7e7d7c7bu, 0xdeadbeefu,
+    };
+    std::vector<float> inT33(std::size(rawT33) * 5, 0.0f), expT33(std::size(rawT33));
+    for (size_t i = 0; i < std::size(rawT33); ++i) {
+        std::memcpy(&inT33[i * 5 + 4], &rawT33[i], sizeof(uint32_t));
+        expT33[i] = static_cast<float>((rawT33[i] & 0xffu) + ((rawT33[i] >> 8) & 0xffu) +
+                                       ((rawT33[i] >> 16) & 0xffu) + (rawT33[i] >> 24));
+    }
+    std::vector<float> gotT33 = prosper::test::run_compute(
+        spvT33, inT33, static_cast<uint32_t>(std::size(rawT33)),
+        static_cast<uint32_t>(std::size(rawT33)));
+    CHECK(gotT33 == expT33,
+          "T33: UBYTE0..3 extract the selected unsigned byte and convert every result exactly");
+
     // --- 2026-07 ISA-audit semantic fixes (#879/#880) — execution kernels ---
 
     // A1 (#879): s_not_b32 writes SCC=(result!=0). ~0 = all-ones -> SCC=1 -> cselect 11;


### PR DESCRIPTION
## Summary
- implement RDNA2 `V_CVT_F32_UBYTE0..3` as unsigned byte extraction followed by `f32` conversion
- classify the four conversions as floating-point results for SDWA output modifiers
- add an execution-level Vulkan regression covering all four byte positions and multiple raw dwords

## Failure and contract
Astro title vertex shaders repeatedly rejected VOP1 opcode `0x12` (`V_CVT_F32_UBYTE1`), including VS `0x5002a9a00` at PC 1592 (`0x7e0c2410`). AMD's RDNA2 Shader ISA defines opcodes 17..20 (`0x11..0x14`) as selecting source bytes 0..3, zero-extending the selected byte, and converting it to f32.

This implements that full adjacent family from the official AMD contract rather than special-casing the observed word.

## Evidence
- Linux `test_rdna2_to_spirv`: PASS, including T33 executing generated SPIR-V on Vulkan with exact results
- captured Astro VS `0x5002a9a00`: generic unsupported count improves 62 -> 54; all eight `UBYTE1/2` instructions are now covered
- Windows: `rdna2_to_spirv.cpp` compiled and `prosper_core` linked with native MinGW; the later full-tree build stopped in unchanged `test_pthread_names.cpp` on a WinLibs assembler `.seh_handlerdata` error
- `git diff --check`: clean

This is a shared ISA fix, not a standalone game-progression claim, so no screenshot is attached. A routed visual Astro run follows after merge.

Closes #1021