### PR TITLE
perf(executor): parallelize live draw realization

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -633,9 +633,11 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
             // Dump the FIRST item's recompiled SPIR-V (diagnostic; survives a mid-render crash).
             if (getenv("PROSPER_SHADER_DUMP") && !items.empty()) {
                 std::string d = getenv("PROSPER_SHADER_DUMP");
-                if (FILE* f = fopen((d + "/frame_vs.spv").c_str(), "wb")) { fwrite(items[0].vs.data(), 4, items[0].vs.size(), f); fclose(f); }
-                if (FILE* f = fopen((d + "/frame_fs.spv").c_str(), "wb")) { fwrite(items[0].fs.data(), 4, items[0].fs.size(), f); fclose(f); }
-                fprintf(stderr, "[render] dumped SPIR-V vs=%zu fs=%zu dwords\n", items[0].vs.size(), items[0].fs.size()); fflush(stderr);
+                const auto& dump_vs = items[0].vs_words();
+                const auto& dump_fs = items[0].fs_words();
+                if (FILE* f = fopen((d + "/frame_vs.spv").c_str(), "wb")) { fwrite(dump_vs.data(), 4, dump_vs.size(), f); fclose(f); }
+                if (FILE* f = fopen((d + "/frame_fs.spv").c_str(), "wb")) { fwrite(dump_fs.data(), 4, dump_fs.size(), f); fclose(f); }
+                fprintf(stderr, "[render] dumped SPIR-V vs=%zu fs=%zu dwords\n", dump_vs.size(), dump_fs.size()); fflush(stderr);
             }
             // Copy [a, a+n) into dst, but stop at the first 64KB block that is NOT within a reserved guest
             // mapping (prosper_reserved_range_state == 0). A resource's declared size (e.g. a 2048x1024
@@ -1891,17 +1893,23 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 for (const auto* itp : group) {
                     const auto& it = *itp;
                     prosper::test::BackendDraw bd;
-                    bd.vs     = refvs ? refvs_spv : it.vs;
-                    bd.gs     = refvs ? std::vector<uint32_t>{} : it.gs;
+                    if (refvs) {
+                        bd.vs = refvs_spv;
+                    } else if (it.vs_shared) {
+                        bd.vs_shared = it.vs_shared;
+                    } else {
+                        bd.vs = it.vs;
+                    }
+                    bd.gs = refvs ? std::vector<uint32_t>{} : it.gs;
                     // File and synthetic overrides have independent exact-match gates.
                     bool fs_ov = !ps_override.empty();
                     if (fs_ov && ps_override_is_file) {
-                        if (fs_match_mode == 1)      fs_ov = (it.fs == fs_match);   // valid match -> exact only
+                        if (fs_match_mode == 1)      fs_ov = (it.fs_words() == fs_match);   // valid match -> exact only
                         else if (fs_match_mode == 2) fs_ov = false;                // requested-but-invalid -> off
                         // mode 0 -> legacy global file override (unchanged)
                     }
                     if (fs_ov && ps_override_is_test) {
-                        if (testps_match_mode == 1)      fs_ov = (it.fs == testps_match);
+                        if (testps_match_mode == 1)      fs_ov = (it.fs_words() == testps_match);
                         else if (testps_match_mode == 2) fs_ov = false;
                         // mode 0 -> legacy global TESTPS override (unchanged)
                     }
@@ -1911,7 +1919,13 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     if (fs_ov && ps_override_is_test && testps_match_mode == 1)
                         fprintf(stderr, "[testps-match] synthetic override applied to draw#%llu\n",
                                 (unsigned long long)it.draw_index);
-                    bd.fs     = fs_ov ? ps_override : it.fs;
+                    if (fs_ov) {
+                        bd.fs = ps_override;
+                    } else if (it.fs_shared) {
+                        bd.fs_shared = it.fs_shared;
+                    } else {
+                        bd.fs = it.fs;
+                    }
                     bd.vs_identity = refvs ? 0 : it.vs_identity;
                     bd.fs_identity = fs_ov ? 0 : it.fs_identity;
                     bd.vcount = refvs ? 3u : it.vertex_count;
@@ -1919,12 +1933,12 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     bd.ps     = nops ? nullptr : &it.ps;
                     bd.R      = build_R(it, it.vrt.get(), it.prt.get());
                     if (!prosper::gpu::validate_runtime_descriptor_contract(
-                            "VS/backend", bd.vs, it.vrt.get(), 0, prosper::gpu::SpirvShaderStage::Vertex) ||
+                            "VS/backend", bd.vs_words(), it.vrt.get(), 0, prosper::gpu::SpirvShaderStage::Vertex) ||
                         !prosper::gpu::validate_runtime_descriptor_contract(
-                            "PS/backend", bd.fs, it.prt.get(), 1, prosper::gpu::SpirvShaderStage::Fragment))
+                            "PS/backend", bd.fs_words(), it.prt.get(), 1, prosper::gpu::SpirvShaderStage::Fragment))
                         continue;
-                    poison_R(bd.R, bd.vs, it.vrt.get(), 0, prosper::gpu::SpirvShaderStage::Vertex);
-                    poison_R(bd.R, bd.fs, it.prt.get(), 1, prosper::gpu::SpirvShaderStage::Fragment);
+                    poison_R(bd.R, bd.vs_words(), it.vrt.get(), 0, prosper::gpu::SpirvShaderStage::Vertex);
+                    poison_R(bd.R, bd.fs_words(), it.prt.get(), 1, prosper::gpu::SpirvShaderStage::Fragment);
                     // Indexed draw: hand the executor-fetched index data to the backend (vkCmdDrawIndexed).
                     // Skipped under REFVS — the reference VS is a 3-vertex non-indexed fullscreen triangle.
                     if (!refvs) bd.indices = it.indices;
@@ -2363,8 +2377,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                     (unsigned long long)base, k, render_pass.size(),
                                     (unsigned long long)draw->draw_index,
                                     (unsigned long long)draw->command_order,
-                                    (unsigned long long)spirv_hash(draw->vs),
-                                    (unsigned long long)spirv_hash(draw->fs),
+                                    (unsigned long long)spirv_hash(draw->vs_words()),
+                                    (unsigned long long)spirv_hash(draw->fs_words()),
                                     draw->ps.color_write_mask, (int)draw->ps.blend_enable,
                                     draw->ps.src_color_blend_factor,
                                     draw->ps.dst_color_blend_factor,

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -945,7 +945,7 @@ bool capture_submit_items(const std::vector<DrawItem>& draws,
     uint64_t raw_shader_words = 0;
     std::map<uint64_t, uint32_t> raw_shader_index_by_address;
     for (const auto& d : draws) {
-        GpuCapturedDraw c; c.vs = d.vs; c.gs = d.gs; c.fs = d.fs;
+        GpuCapturedDraw c; c.vs = d.vs_words(); c.gs = d.gs_words(); c.fs = d.fs_words();
         c.ps = d.ps; c.vertex_count = d.vertex_count;
         c.instance_count = d.instance_count;
         c.indices = d.indices; c.color0_base = d.color0_base;

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -32,6 +32,8 @@ namespace prosper::gpu {
 
 struct ShaderResourceTable;   // fwd (shader_resources.hpp); passed to the backend so it can bind resources
 
+using SharedShaderWords = std::shared_ptr<const std::vector<uint32_t>>;
+
 // One realized draw of a submit: recompiled VS+PS SPIR-V, the draw's OWN resolved fixed-function
 // state, the two stages' resource tables (so the backend can bind the constant/vertex buffers +
 // textures the shaders declare, reading their bytes from 1:1-mapped guest memory), and its vertex
@@ -41,6 +43,11 @@ struct ShaderResourceTable;   // fwd (shader_resources.hpp); passed to the backe
 // correctly instead of collapsing onto a single draw. The tables may be null (color-only shaders).
 struct DrawItem {
     std::vector<uint32_t> vs, gs, fs;                 // recompiled/generated SPIR-V
+    // The live path can retain warm-cache shader modules by shared ownership instead of copying the
+    // same SPIR-V words twice per draw (cache -> DrawItem -> BackendDraw). Capture/replay and direct
+    // tests keep using the owned vectors above. Consumers must use the accessors so both forms are
+    // equivalent; a shared value is immutable and remains valid if its cache entry is evicted.
+    SharedShaderWords vs_shared, fs_shared;
     uint64_t vs_guest_addr = 0, fs_guest_addr = 0;    // diagnostic/source identity in guest VA space
     // Content-addressed raw RDNA2 versions owned by a materialized capture. Live draw items leave
     // these unset; capture assigns them from the guest addresses above and replay restores them.
@@ -69,6 +76,10 @@ struct DrawItem {
     uint32_t color1_width = 0, color1_height = 0;
     uint64_t draw_index = 0;
     uint64_t command_order = 0;
+
+    const std::vector<uint32_t>& vs_words() const { return vs_shared ? *vs_shared : vs; }
+    const std::vector<uint32_t>& gs_words() const { return gs; }
+    const std::vector<uint32_t>& fs_words() const { return fs_shared ? *fs_shared : fs; }
 };
 
 // The pluggable Vulkan backend: render the submit's draw items into one image and return W*H*4 RGBA8
@@ -280,6 +291,12 @@ std::vector<uint32_t> recompile_graphics_shader_cached(ShaderProgramStage stage,
                                                        const PixelInputMapping* pixel_inputs = nullptr,
                                                        const PixelSystemInputMapping* system_inputs = nullptr,
                                                        uint64_t* cache_identity = nullptr);
+SharedShaderWords recompile_graphics_shader_cached_shared(
+    ShaderProgramStage stage, const uint32_t* code, size_t dwords,
+    const ShaderResourceTable* resources = nullptr,
+    const PixelInputMapping* pixel_inputs = nullptr,
+    const PixelSystemInputMapping* system_inputs = nullptr,
+    uint64_t* cache_identity = nullptr);
 ShaderRecompileCacheStats shader_recompile_cache_stats();
 void clear_shader_recompile_cache();
 
@@ -303,6 +320,14 @@ struct StageTablePhaseStats {
 };
 void record_stage_table_phases(double metadata_ms, double dynamic_fold_ms, double resources_ms);
 StageTablePhaseStats stage_table_phase_stats();
+
+struct ParallelDrawRealizationStats {
+    uint64_t batches = 0;
+    uint64_t semantic_draws = 0;
+    uint64_t worker_threads = 0;  // sum of participating threads, including the submit thread
+    double wall_ms = 0.0;
+};
+ParallelDrawRealizationStats parallel_draw_realization_stats();
 
 enum class RealizationFailureReason : uint8_t {
     None,
@@ -474,7 +499,8 @@ inline bool index_buffer_is_unannounced_32bit(const uint16_t* p16, const uint32_
 // (folded-state, one item) and PROSPER_PERDRAW (per-draw) paths so their per-draw handling is identical.
 inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, uint32_t vcount_hint,
                               uint32_t max_shader_dwords, bool log, DrawItem& out,
-                              OperationRealizationFailure* failure = nullptr) {
+                              OperationRealizationFailure* failure = nullptr,
+                              bool retain_shared_shader_words = false) {
     RenderState rs = extract_render_state(ds);
     if (failure) {
         *failure = {};
@@ -581,12 +607,23 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
         reinterpret_cast<const uint32_t*>(static_cast<uintptr_t>(rs.ps_addr)),
         max_shader_dwords, system_input_ptr);
     uint64_t vs_identity = 0, fs_identity = 0;
-    std::vector<uint32_t> vs = recompile_graphics_shader_cached(
-        ShaderProgramStage::Vertex, (const uint32_t*)(uintptr_t)rs.es_addr,
-        max_shader_dwords, vrt.get(), pixel_input_ptr, nullptr, &vs_identity);
-    std::vector<uint32_t> fs = recompile_graphics_shader_cached(
-        ShaderProgramStage::Fragment, (const uint32_t*)(uintptr_t)rs.ps_addr,
-        max_shader_dwords, prt.get(), nullptr, system_input_ptr, &fs_identity);
+    SharedShaderWords vs_shared, fs_shared;
+    std::vector<uint32_t> vs, fs;
+    if (retain_shared_shader_words) {
+        vs_shared = recompile_graphics_shader_cached_shared(
+            ShaderProgramStage::Vertex, (const uint32_t*)(uintptr_t)rs.es_addr,
+            max_shader_dwords, vrt.get(), pixel_input_ptr, nullptr, &vs_identity);
+        fs_shared = recompile_graphics_shader_cached_shared(
+            ShaderProgramStage::Fragment, (const uint32_t*)(uintptr_t)rs.ps_addr,
+            max_shader_dwords, prt.get(), nullptr, system_input_ptr, &fs_identity);
+    } else {
+        vs = recompile_graphics_shader_cached(
+            ShaderProgramStage::Vertex, (const uint32_t*)(uintptr_t)rs.es_addr,
+            max_shader_dwords, vrt.get(), pixel_input_ptr, nullptr, &vs_identity);
+        fs = recompile_graphics_shader_cached(
+            ShaderProgramStage::Fragment, (const uint32_t*)(uintptr_t)rs.ps_addr,
+            max_shader_dwords, prt.get(), nullptr, system_input_ptr, &fs_identity);
+    }
     // CB_COLOR_CONTROL.DCC_DECOMPRESS interprets the bound AGC metadata helper, rather than its
     // ordinary fragment-color export. The operation bits can remain folded into a later graphics
     // submit even though the guest's utility sequence has restored normal mode by then, so MODE alone
@@ -611,9 +648,12 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
         };
         static const std::vector<uint32_t> kNullExportFragment =
             recompile_fragment(kNullExportProgram, std::size(kNullExportProgram));
+        fs_shared.reset();
         fs = kNullExportFragment;
         fs_identity = 0;
     }
+    const std::vector<uint32_t>& vs_words = vs_shared ? *vs_shared : vs;
+    const std::vector<uint32_t>& fs_words = fs_shared ? *fs_shared : fs;
     std::vector<uint32_t> gs;
     if (interpolation.requires_geometry && interpolation.valid) {
         // Geometry `Triangles` accepts list, strip, and fan input assembly. Points/lines cannot
@@ -628,14 +668,14 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
             std::chrono::duration<double, std::milli>(table_done - table_start).count(),
             std::chrono::duration<double, std::milli>(shader_done - table_done).count());
     }
-    add_stage_diagnostic(ShaderProgramStage::Vertex, rs.es_addr, vrt, vs);
-    add_stage_diagnostic(ShaderProgramStage::Fragment, rs.ps_addr, prt, fs);
+    add_stage_diagnostic(ShaderProgramStage::Vertex, rs.es_addr, vrt, vs_words);
+    add_stage_diagnostic(ShaderProgramStage::Fragment, rs.ps_addr, prt, fs_words);
     if (const char* dd = getenv("PROSPER_VS_DUMP")) {   // diag: dump successful VS SPIR-V + raw RDNA2 for inspection
         static int nd = 0;
-        if (nd < 3 && !vs.empty()) {
+        if (nd < 3 && !vs_words.empty()) {
             char fn[512];
             snprintf(fn, sizeof fn, "%s/vs_%d_%llx.spv", dd, nd, (unsigned long long)rs.es_addr);
-            if (FILE* f = fopen(fn, "wb")) { fwrite(vs.data(), 4, vs.size(), f); fclose(f); }
+            if (FILE* f = fopen(fn, "wb")) { fwrite(vs_words.data(), 4, vs_words.size(), f); fclose(f); }
             snprintf(fn, sizeof fn, "%s/vs_%d_%llx.bin", dd, nd, (unsigned long long)rs.es_addr);
             if (FILE* f = fopen(fn, "wb")) { fwrite((const void*)(uintptr_t)rs.es_addr, 1, 4096, f); fclose(f); }
             // Also dump the paired PS raw RDNA2 (the recompile-guard fixture needs both stages, #228).
@@ -644,12 +684,12 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
             nd++;
         }
     }
-    if (vs.empty() || fs.empty() || (interpolation.requires_geometry && gs.empty())) {
+    if (vs_words.empty() || fs_words.empty() || (interpolation.requires_geometry && gs.empty())) {
         if (failure) failure->reason = RealizationFailureReason::ShaderRecompile;
         // PROSPER_DYNTRACE_FAIL=1: replay the FAILED vertex stage's resource build with the
         // dynamic-fetch walk trace + user-data block dump forced on (once per distinct VS), so the
         // failing draw's exact seeding/s_load chain is captured without knowing its address up front.
-        if (vs.empty() && getenv("PROSPER_DYNTRACE_FAIL")) {
+        if (vs_words.empty() && getenv("PROSPER_DYNTRACE_FAIL")) {
             static std::set<uint64_t> traced;
             if (traced.insert(rs.es_addr).second) {
                 fprintf(stderr, "[dynfail] replaying VS 0x%llx resource build with trace:\n",
@@ -660,7 +700,7 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
             }
         }
         // Same replay for a FAILED pixel stage (#273 — the PS-side descriptor-resolution walls).
-        if (fs.empty() && getenv("PROSPER_DYNTRACE_FAIL")) {
+        if (fs_words.empty() && getenv("PROSPER_DYNTRACE_FAIL")) {
             static std::set<uint64_t> traced_ps;
             if (traced_ps.insert(rs.ps_addr).second) {
                 fprintf(stderr, "[dynfail] replaying PS 0x%llx resource build with trace:\n",
@@ -674,7 +714,7 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
             fprintf(stderr, "[exec-recompile-reject] es=0x%llx ps=0x%llx vs=%zu gs=%zu fs=%zu "
                             "prim=%u topo=%u ena=%08x addr=%08x order=%llu\n",
                     (unsigned long long)rs.es_addr, (unsigned long long)rs.ps_addr,
-                    vs.size(), gs.size(), fs.size(), rs.prim_type, resolved_pipeline.topology,
+                    vs_words.size(), gs.size(), fs_words.size(), rs.prim_type, resolved_pipeline.topology,
                     rs.ps_input_ena, rs.ps_input_addr,
                     (unsigned long long)(draw ? draw->command_order : 0));
         if (const char* dd = getenv("PROSPER_SHADER_DUMP")) {
@@ -699,7 +739,7 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
                             "es=0x%llx ps=0x%llx color0=0x%llx/%ux%u "
                             "depth=%d/%d/op%u clear=%d/%g base=0x%llx/0x%llx "
                             "stencil=%d clear=%d/%u base=0x%llx/0x%llx)\n",
-                    vs.size(), gs.size(), fs.size(),
+                    vs_words.size(), gs.size(), fs_words.size(),
                     (unsigned long long)(draw ? draw->command_order : 0),
                     (unsigned long long)rs.es_addr, (unsigned long long)rs.ps_addr,
                     (unsigned long long)rs.color0_base, rs.color0_width, rs.color0_height,
@@ -719,8 +759,8 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
         }
         return false;
     }
-    if (!validate_runtime_descriptor_contract("VS", vs, vrt.get(), 0, SpirvShaderStage::Vertex) ||
-        !validate_runtime_descriptor_contract("PS", fs, prt.get(), 1, SpirvShaderStage::Fragment)) {
+    if (!validate_runtime_descriptor_contract("VS", vs_words, vrt.get(), 0, SpirvShaderStage::Vertex) ||
+        !validate_runtime_descriptor_contract("PS", fs_words, prt.get(), 1, SpirvShaderStage::Fragment)) {
         if (failure) failure->reason = RealizationFailureReason::DescriptorContract;
         if (log) fprintf(stderr, "[exec] skip draw: strict descriptor contract failed "
                                 "(es=0x%llx ps=0x%llx color0=0x%llx)\n",
@@ -956,17 +996,18 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
                 // The RECOMPILED VS SPIR-V — disassemble offline (spirv-dis) to trace the gl_Position export
                 // op-by-op against the RDNA2 source and find the mis-modeled op / bad matrix input. #257.
                 snprintf(fn, sizeof fn, "%s/caption_recompiled_%llx.spv", dd, (unsigned long long)rs.es_addr);
-                if (FILE* f = fopen(fn, "wb")) { fwrite(vs.data(), 4, vs.size(), f); fclose(f); }
+                if (FILE* f = fopen(fn, "wb")) { fwrite(vs_words.data(), 4, vs_words.size(), f); fclose(f); }
                 // The recompiled PIXEL shader — the text is invisible because the PS discards every fragment
                 // (SDF alpha-test). Dump it (spirv-dis) to inspect the discard condition + atlas sample. #257.
                 snprintf(fn, sizeof fn, "%s/caption_ps_%llx.spv", dd, (unsigned long long)rs.ps_addr);
-                if (FILE* f = fopen(fn, "wb")) { fwrite(fs.data(), 4, fs.size(), f); fclose(f); }
+                if (FILE* f = fopen(fn, "wb")) { fwrite(fs_words.data(), 4, fs_words.size(), f); fclose(f); }
                 snprintf(fn, sizeof fn, "%s/caption_ps_raw_%llx.bin", dd, (unsigned long long)rs.ps_addr);
                 if (FILE* f = fopen(fn, "wb")) { fwrite((const void*)(uintptr_t)rs.ps_addr, 1, 8192, f); fclose(f); }
             }
         }
     }
     out.vs = std::move(vs); out.gs = std::move(gs); out.fs = std::move(fs);
+    out.vs_shared = std::move(vs_shared); out.fs_shared = std::move(fs_shared);
     out.vs_guest_addr = rs.es_addr; out.fs_guest_addr = rs.ps_addr;
     out.vs_identity = vs_identity; out.fs_identity = fs_identity; out.ps = ps;
     out.vrt = std::move(vrt); out.prt = std::move(prt); out.vertex_count = vertex_count;
@@ -979,6 +1020,15 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
     out.color1_width = rs.color1_width; out.color1_height = rs.color1_height;
     return true;
 }
+
+// Live submits with hundreds of immutable draw snapshots can realize those snapshots concurrently.
+// The implementation owns a bounded persistent worker set, writes one result slot per semantic draw,
+// and compacts those slots in original PM4 order. `attempted` distinguishes an ineligible batch from
+// a batch in which every draw was legitimately filtered out, so callers only take the serial fallback
+// in the former case.
+std::vector<DrawItem> realize_gpustate_draws_parallel(
+    const GpuState& st, uint32_t max_shader_dwords, bool log,
+    bool retain_shared_shader_words, bool* attempted = nullptr);
 
 // Recompile + resolve a GpuState's draws and render them via `render`. Default: ONE item from the folded
 // end state, realized as the submit's LAST draw — the folded register file IS the state at the last
@@ -998,7 +1048,9 @@ inline std::vector<DrawItem> realize_gpustate_draws(const GpuState& st,
                                                     uint32_t max_shader_dwords = 0x10000,
                                                     float vp_scale_x = 1.0f,
                                                     float vp_scale_y = 1.0f,
-                                                    std::vector<OperationRealizationFailure>* failures = nullptr) {
+                                                    std::vector<OperationRealizationFailure>* failures = nullptr,
+                                                    bool retain_shared_shader_words = false,
+                                                    bool allow_parallel = true) {
     if (failures) failures->clear();
     if (st.draws.empty()) return {};
     // PROSPER_EXECLOG: just the per-draw bail-point/skip logs, without PROSPER_GFXLOG's per-packet
@@ -1018,18 +1070,27 @@ inline std::vector<DrawItem> realize_gpustate_draws(const GpuState& st,
                          (!force_folded && (st.draws.size() > 1 || !st.dispatches.empty()));
     std::vector<DrawItem> items;
     if (perdraw) {
-        for (size_t i = 0; i < st.draws.size(); i++) {
-            DrawItem it;
-            OperationRealizationFailure failure;
-            if (realize_draw_item(st.state_at_draw(i), &st.draws[i], st.draws[i].index_count,
-                                  max_shader_dwords, log, it, failures ? &failure : nullptr)) {
-                it.draw_index = i;
-                it.command_order = st.draws[i].command_order;
-                items.push_back(std::move(it));
-            } else if (failures) {
-                failure.index = i;
-                failure.command_order = st.draws[i].command_order;
-                failures->push_back(std::move(failure));
+        bool parallel_attempted = false;
+        if (allow_parallel && !failures)
+            items = realize_gpustate_draws_parallel(
+                st, max_shader_dwords, log, retain_shared_shader_words,
+                &parallel_attempted);
+        if (!parallel_attempted) {
+            for (size_t i = 0; i < st.draws.size(); i++) {
+                DrawItem it;
+                OperationRealizationFailure failure;
+                if (realize_draw_item(st.state_at_draw(i), &st.draws[i], st.draws[i].index_count,
+                                      max_shader_dwords, log, it,
+                                      failures ? &failure : nullptr,
+                                      retain_shared_shader_words)) {
+                    it.draw_index = i;
+                    it.command_order = st.draws[i].command_order;
+                    items.push_back(std::move(it));
+                } else if (failures) {
+                    failure.index = i;
+                    failure.command_order = st.draws[i].command_order;
+                    failures->push_back(std::move(failure));
+                }
             }
         }
     } else {
@@ -1041,7 +1102,8 @@ inline std::vector<DrawItem> realize_gpustate_draws(const GpuState& st,
                 OperationRealizationFailure failure;
                 const bool would_realize = realize_draw_item(
                     st.state_at_draw(i), &st.draws[i], st.draws[i].index_count,
-                    max_shader_dwords, log, ignored, &failure);
+                    max_shader_dwords, log, ignored, &failure,
+                    retain_shared_shader_words);
                 if (would_realize) failure.reason = RealizationFailureReason::Filtered;
                 failure.index = i;
                 failure.command_order = st.draws[i].command_order;
@@ -1053,7 +1115,8 @@ inline std::vector<DrawItem> realize_gpustate_draws(const GpuState& st,
         const GpuState::Draw& last = st.draws.back();
         OperationRealizationFailure failure;
         if (realize_draw_item(st, &last, last.index_count, max_shader_dwords, log, it,
-                              failures ? &failure : nullptr)) {
+                              failures ? &failure : nullptr,
+                              retain_shared_shader_words)) {
             it.draw_index = st.draws.size() - 1;
             it.command_order = last.command_order;
             items.push_back(std::move(it));

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -136,10 +136,26 @@ struct ShaderCompileKey {
     PixelSystemInputMapping system_inputs{};
     bool has_pcrel_dispatch = false;
     uint32_t pcrel_dispatch_target = UINT32_MAX;
-    std::vector<uint32_t> code;
+    // Aliases ShaderCodeAnalysis::code and keeps that immutable analysis alive. Warm lookups used to
+    // copy and re-hash the complete raw program for every draw before reaching the shader cache.
+    std::shared_ptr<const std::vector<uint32_t>> code;
     std::vector<ShaderResourceCompileKey> resources;
+    size_t cached_hash = 0;
 
-    bool operator==(const ShaderCompileKey&) const = default;
+    bool operator==(const ShaderCompileKey& other) const {
+        const bool same_code = code == other.code ||
+            (code && other.code && *code == *other.code);
+        return stage == other.stage &&
+               has_resource_table == other.has_resource_table &&
+               force_position_w == other.force_position_w &&
+               has_pixel_inputs == other.has_pixel_inputs &&
+               pixel_inputs == other.pixel_inputs &&
+               has_system_inputs == other.has_system_inputs &&
+               system_inputs == other.system_inputs &&
+               has_pcrel_dispatch == other.has_pcrel_dispatch &&
+               pcrel_dispatch_target == other.pcrel_dispatch_target &&
+               resources == other.resources && same_code;
+    }
 };
 
 static uint64_t hash_mix(uint64_t hash, uint64_t value) {
@@ -152,7 +168,7 @@ static uint64_t hash_mix(uint64_t hash, uint64_t value) {
 }
 
 struct ShaderCompileKeyHash {
-    size_t operator()(const ShaderCompileKey& key) const {
+    static size_t compute(const ShaderCompileKey& key) {
         uint64_t hash = 1469598103934665603ull;
         hash = hash_mix(hash, static_cast<uint32_t>(key.stage));
         hash = hash_mix(hash, key.has_resource_table);
@@ -170,8 +186,9 @@ struct ShaderCompileKeyHash {
         }
         hash = hash_mix(hash, key.has_pcrel_dispatch);
         if (key.has_pcrel_dispatch) hash = hash_mix(hash, key.pcrel_dispatch_target);
-        hash = hash_mix(hash, key.code.size());
-        for (uint32_t word : key.code) hash = hash_mix(hash, word);
+        hash = hash_mix(hash, key.code ? key.code->size() : 0u);
+        if (key.code)
+            for (uint32_t word : *key.code) hash = hash_mix(hash, word);
         hash = hash_mix(hash, key.resources.size());
         for (const auto& resource : key.resources) {
             hash = hash_mix(hash, resource.cls);
@@ -185,6 +202,8 @@ struct ShaderCompileKeyHash {
         }
         return static_cast<size_t>(hash);
     }
+
+    size_t operator()(const ShaderCompileKey& key) const { return key.cached_hash; }
 };
 
 struct CachedShader {
@@ -596,7 +615,7 @@ uint64_t shader_cache_limit_bytes() {
 }
 
 uint64_t shader_cache_entry_bytes(const ShaderCompileKey& key, const std::vector<uint32_t>& spirv) {
-    return static_cast<uint64_t>(key.code.size()) * sizeof(uint32_t) +
+    return static_cast<uint64_t>(key.code ? key.code->size() : 0u) * sizeof(uint32_t) +
            static_cast<uint64_t>(key.resources.size()) * sizeof(ShaderResourceCompileKey) +
            (key.has_pixel_inputs ? sizeof(PixelInputMapping) : 0u) +
            (key.has_system_inputs ? sizeof(PixelSystemInputMapping) : 0u) +
@@ -708,7 +727,7 @@ ShaderCompileKey make_shader_compile_key(ShaderProgramStage stage, const uint32_
         // Most shaders end at S_ENDPGM. A compiler-generated s_getpc_b64 V# may instead address an
         // embedded lookup table after ENDPGM; retain that proven tail so cached recompilation sees the
         // same blob as the direct path and table contents participate in the cache identity.
-        key.code = analysis->code;
+        key.code = std::shared_ptr<const std::vector<uint32_t>>(analysis, &analysis->code);
     }
     if (resources) {
         key.resources.reserve(resources->resources.size());
@@ -720,17 +739,19 @@ ShaderCompileKey make_shader_compile_key(ShaderProgramStage stage, const uint32_
             });
         }
     }
+    key.cached_hash = ShaderCompileKeyHash::compute(key);
     return key;
 }
 
 std::vector<uint32_t> compile_graphics_shader(ShaderProgramStage stage, const ShaderCompileKey& key,
                                               const ShaderResourceTable* resources) {
-    const uint32_t* code = key.code.empty() ? nullptr : key.code.data();
+    const uint32_t* code = !key.code || key.code->empty() ? nullptr : key.code->data();
+    const size_t code_size = key.code ? key.code->size() : 0u;
     if (stage == ShaderProgramStage::Vertex)
-        return recompile_vertex(code, key.code.size(), resources,
+        return recompile_vertex(code, code_size, resources,
                                 key.has_pixel_inputs ? &key.pixel_inputs : nullptr);
     if (stage == ShaderProgramStage::Fragment)
-        return recompile_fragment(code, key.code.size(), resources,
+        return recompile_fragment(code, code_size, resources,
                                   key.has_system_inputs ? &key.system_inputs : nullptr,
                                   key.has_pcrel_dispatch ? key.pcrel_dispatch_target : UINT32_MAX);
     return {};
@@ -739,12 +760,12 @@ std::vector<uint32_t> compile_graphics_shader(ShaderProgramStage stage, const Sh
 void maybe_dump_successful_shader(ShaderProgramStage stage, const ShaderCompileKey& key,
                                   const std::vector<uint32_t>& spirv) {
     const char* directory = getenv("PROSPER_SHADER_DUMP_SUCCESS");
-    if (!directory || !*directory || key.code.empty() || spirv.empty()) return;
+    if (!directory || !*directory || !key.code || key.code->empty() || spirv.empty()) return;
 
     const uint64_t spirv_hash = gpu_capture_hash(
         reinterpret_cast<const uint8_t*>(spirv.data()), spirv.size() * sizeof(uint32_t));
     const uint64_t raw_hash = gpu_capture_hash(
-        reinterpret_cast<const uint8_t*>(key.code.data()), key.code.size() * sizeof(uint32_t));
+        reinterpret_cast<const uint8_t*>(key.code->data()), key.code->size() * sizeof(uint32_t));
     static std::mutex dump_mutex;
     static std::set<std::tuple<uint32_t, uint64_t, uint64_t>> dumped;
     std::lock_guard lock(dump_mutex);
@@ -767,16 +788,16 @@ void maybe_dump_successful_shader(ShaderProgramStage stage, const ShaderCompileK
              static_cast<unsigned long long>(raw_hash));
     FILE* raw = fopen(raw_path, "wb");
     FILE* translated = fopen(spirv_path, "wb");
-    const size_t raw_bytes = key.code.size() * sizeof(uint32_t);
+    const size_t raw_bytes = key.code->size() * sizeof(uint32_t);
     const size_t spirv_bytes = spirv.size() * sizeof(uint32_t);
     const bool ok = raw && translated &&
-        fwrite(key.code.data(), 1, raw_bytes, raw) == raw_bytes &&
+        fwrite(key.code->data(), 1, raw_bytes, raw) == raw_bytes &&
         fwrite(spirv.data(), 1, spirv_bytes, translated) == spirv_bytes;
     if (raw) fclose(raw);
     if (translated) fclose(translated);
     fprintf(stderr, "[shader-dump] %s spv=%016llx raw=%016llx words=%zu/%zu result=%s\n", tag,
             static_cast<unsigned long long>(spirv_hash),
-            static_cast<unsigned long long>(raw_hash), key.code.size(), spirv.size(),
+            static_cast<unsigned long long>(raw_hash), key.code->size(), spirv.size(),
             ok ? "written" : "failed");
 }
 

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -502,6 +502,13 @@ std::shared_ptr<const DecodedShader> decode_shader_cached(const uint32_t* code, 
 
     auto decoded = decode();
     std::lock_guard lock(cache.mutex);
+    // Another cold worker may have populated this address while decode ran. Replace it only after
+    // removing its accounted bytes; returned shared_ptrs remain valid independently of the map entry.
+    auto concurrent = cache.entries.find(address);
+    if (concurrent != cache.entries.end()) {
+        cache.stats.bytes -= concurrent->second.shader->bytes;
+        cache.entries.erase(concurrent);
+    }
     constexpr size_t max_entries = 4096;
     const uint64_t limit = shader_decode_cache_limit_bytes();
     while (!cache.entries.empty() &&
@@ -3515,17 +3522,30 @@ struct DrawRealizationBatch {
 };
 
 // One process-lifetime worker set avoids creating dozens of host threads for every guest submit.
-// AGC submits are serialized, so the pool deliberately supports one batch at a time. The submit
-// thread participates as slot zero; each persistent worker owns a stable measurement slot.
+// The pool deliberately supports one batch at a time; callers are serialized at run() even when
+// independent submit threads arrive concurrently. The submit thread participates as slot zero;
+// each persistent worker owns a stable measurement slot.
 class DrawRealizationPool {
 public:
     explicit DrawRealizationPool(size_t workers) {
         workers_.reserve(workers);
-        for (size_t i = 0; i < workers; ++i)
-            workers_.emplace_back([this, i] { worker_main(i); });
+        try {
+            for (size_t i = 0; i < workers; ++i)
+                workers_.emplace_back([this, i] { worker_main(i); });
+        } catch (...) {
+            {
+                std::lock_guard lock(mutex_);
+                stopping_ = true;
+                ++generation_;
+            }
+            work_cv_.notify_all();
+            for (auto& worker : workers_) if (worker.joinable()) worker.join();
+            throw;
+        }
     }
 
     ~DrawRealizationPool() {
+        std::lock_guard run_lock(run_mutex_);
         {
             std::lock_guard lock(mutex_);
             stopping_ = true;
@@ -3538,6 +3558,7 @@ public:
     size_t worker_count() const { return workers_.size(); }
 
     void run(const std::shared_ptr<DrawRealizationBatch>& batch, size_t workers_to_use) {
+        std::lock_guard run_lock(run_mutex_);
         workers_to_use = std::min(workers_to_use, workers_.size());
         batch->worker_participants = workers_to_use;
         batch->remaining.store(workers_to_use, std::memory_order_relaxed);
@@ -3617,6 +3638,7 @@ private:
     }
 
     std::vector<std::thread> workers_;
+    std::mutex run_mutex_;
     std::mutex mutex_;
     std::condition_variable work_cv_;
     std::shared_ptr<DrawRealizationBatch> active_;

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -20,11 +20,13 @@
 #include <algorithm>
 #include <atomic>
 #include <bitset>
+#include <condition_variable>
 #include <filesystem>
 #include <iterator>
 #include <mutex>
 #include <set>
 #include <tuple>
+#include <thread>
 #include <vector>
 #include <unordered_map>
 #ifdef _WIN32
@@ -186,7 +188,7 @@ struct ShaderCompileKeyHash {
 };
 
 struct CachedShader {
-    std::vector<uint32_t> spirv;
+    SharedShaderWords spirv;
     uint64_t identity = 0;
     uint64_t last_use = 0;
     uint64_t bytes = 0;
@@ -853,12 +855,10 @@ FragmentInterpolationLayout fragment_interpolation_layout_cached(
     return layout;
 }
 
-std::vector<uint32_t> recompile_graphics_shader_cached(ShaderProgramStage stage,
-                                                       const uint32_t* code, size_t dwords,
-                                                       const ShaderResourceTable* resources,
-                                                       const PixelInputMapping* pixel_inputs,
-                                                       const PixelSystemInputMapping* system_inputs,
-                                                       uint64_t* cache_identity) {
+SharedShaderWords recompile_graphics_shader_cached_shared(
+        ShaderProgramStage stage, const uint32_t* code, size_t dwords,
+        const ShaderResourceTable* resources, const PixelInputMapping* pixel_inputs,
+        const PixelSystemInputMapping* system_inputs, uint64_t* cache_identity) {
     if (cache_identity) *cache_identity = 0;
     ShaderCompileKey key = make_shader_compile_key(stage, code, dwords, resources, pixel_inputs,
                                                    system_inputs);
@@ -868,8 +868,9 @@ std::vector<uint32_t> recompile_graphics_shader_cached(ShaderProgramStage stage,
             std::lock_guard lock(cache.mutex);
             ++cache.stats.bypasses;
         }
-        std::vector<uint32_t> spirv = compile_graphics_shader(stage, key, resources);
-        maybe_dump_successful_shader(stage, key, spirv);
+        auto spirv = std::make_shared<const std::vector<uint32_t>>(
+            compile_graphics_shader(stage, key, resources));
+        maybe_dump_successful_shader(stage, key, *spirv);
         return spirv;
     }
 
@@ -880,19 +881,20 @@ std::vector<uint32_t> recompile_graphics_shader_cached(ShaderProgramStage stage,
         ++cache.stats.hits;
         found->second.last_use = ++cache.use_counter;
         if (cache_identity) *cache_identity = found->second.identity;
-        maybe_dump_successful_shader(stage, key, found->second.spirv);
+        maybe_dump_successful_shader(stage, key, *found->second.spirv);
         return found->second.spirv;
     }
 
     const auto start = std::chrono::steady_clock::now();
-    std::vector<uint32_t> spirv = compile_graphics_shader(stage, key, resources);
-    maybe_dump_successful_shader(stage, key, spirv);
+    auto spirv = std::make_shared<const std::vector<uint32_t>>(
+        compile_graphics_shader(stage, key, resources));
+    maybe_dump_successful_shader(stage, key, *spirv);
     const auto end = std::chrono::steady_clock::now();
     ++cache.stats.misses;
     cache.stats.compile_ms += std::chrono::duration<double, std::milli>(end - start).count();
 
     constexpr size_t max_entries = 4096;
-    const uint64_t bytes = shader_cache_entry_bytes(key, spirv);
+    const uint64_t bytes = shader_cache_entry_bytes(key, *spirv);
     const uint64_t limit = shader_cache_limit_bytes();
     while (!cache.entries.empty() &&
            (cache.entries.size() >= max_entries || cache.stats.bytes + bytes > limit)) {
@@ -915,6 +917,15 @@ std::vector<uint32_t> recompile_graphics_shader_cached(ShaderProgramStage stage,
     }
     cache.stats.entries = cache.entries.size();
     return spirv;
+}
+
+std::vector<uint32_t> recompile_graphics_shader_cached(
+        ShaderProgramStage stage, const uint32_t* code, size_t dwords,
+        const ShaderResourceTable* resources, const PixelInputMapping* pixel_inputs,
+        const PixelSystemInputMapping* system_inputs, uint64_t* cache_identity) {
+    SharedShaderWords words = recompile_graphics_shader_cached_shared(
+        stage, code, dwords, resources, pixel_inputs, system_inputs, cache_identity);
+    return words ? *words : std::vector<uint32_t>{};
 }
 
 ShaderRecompileCacheStats shader_recompile_cache_stats() {
@@ -3441,6 +3452,339 @@ OrderedSubmitResult execute_ordered_items(const std::vector<SubmitOperation>& op
 }
 
 namespace {
+
+struct DrawRealizationBatch {
+    using Callback = void (*)(void*, size_t);
+    using DrawCallback = void (*)(void*, size_t, size_t);
+
+    void* context = nullptr;
+    Callback begin = nullptr;
+    DrawCallback draw = nullptr;
+    Callback end = nullptr;
+    size_t count = 0;
+    size_t worker_participants = 0;
+    std::atomic<size_t> next{0};
+    std::atomic<size_t> remaining{0};
+    std::mutex done_mutex;
+    std::condition_variable done_cv;
+    std::mutex error_mutex;
+    std::exception_ptr error;
+};
+
+// One process-lifetime worker set avoids creating dozens of host threads for every guest submit.
+// AGC submits are serialized, so the pool deliberately supports one batch at a time. The submit
+// thread participates as slot zero; each persistent worker owns a stable measurement slot.
+class DrawRealizationPool {
+public:
+    explicit DrawRealizationPool(size_t workers) {
+        workers_.reserve(workers);
+        for (size_t i = 0; i < workers; ++i)
+            workers_.emplace_back([this, i] { worker_main(i); });
+    }
+
+    ~DrawRealizationPool() {
+        {
+            std::lock_guard lock(mutex_);
+            stopping_ = true;
+            ++generation_;
+        }
+        work_cv_.notify_all();
+        for (auto& worker : workers_) if (worker.joinable()) worker.join();
+    }
+
+    size_t worker_count() const { return workers_.size(); }
+
+    void run(const std::shared_ptr<DrawRealizationBatch>& batch, size_t workers_to_use) {
+        workers_to_use = std::min(workers_to_use, workers_.size());
+        batch->worker_participants = workers_to_use;
+        batch->remaining.store(workers_to_use, std::memory_order_relaxed);
+        {
+            std::lock_guard lock(mutex_);
+            active_ = batch;
+            ++generation_;
+        }
+        work_cv_.notify_all();
+
+        run_participant(batch, 0);
+        if (workers_to_use) {
+            std::unique_lock lock(batch->done_mutex);
+            batch->done_cv.wait(lock, [&] {
+                return batch->remaining.load(std::memory_order_acquire) == 0;
+            });
+        }
+        // Do not retain the caller-owned context through the process-lifetime pool. A worker that
+        // woke for this generation but was not selected may still hold its own shared batch reference;
+        // clearing the pool reference is safe after every selected worker has completed.
+        {
+            std::lock_guard lock(mutex_);
+            if (active_ == batch) active_.reset();
+        }
+        if (batch->error) std::rethrow_exception(batch->error);
+    }
+
+private:
+    static void remember_error(const std::shared_ptr<DrawRealizationBatch>& batch) {
+        std::lock_guard lock(batch->error_mutex);
+        if (!batch->error) batch->error = std::current_exception();
+    }
+
+    static void run_participant(const std::shared_ptr<DrawRealizationBatch>& batch,
+                                size_t measurement_slot) {
+        bool began = false;
+        try {
+            if (batch->begin) batch->begin(batch->context, measurement_slot);
+            began = true;
+            constexpr size_t kGrain = 4;
+            for (;;) {
+                const size_t first = batch->next.fetch_add(kGrain, std::memory_order_relaxed);
+                if (first >= batch->count) break;
+                const size_t last = std::min(first + kGrain, batch->count);
+                for (size_t draw = first; draw < last; ++draw)
+                    batch->draw(batch->context, draw, measurement_slot);
+            }
+        } catch (...) {
+            remember_error(batch);
+        }
+        if (began && batch->end) {
+            try { batch->end(batch->context, measurement_slot); }
+            catch (...) { remember_error(batch); }
+        }
+    }
+
+    void worker_main(size_t worker_index) {
+        uint64_t seen_generation = 0;
+        for (;;) {
+            std::shared_ptr<DrawRealizationBatch> batch;
+            {
+                std::unique_lock lock(mutex_);
+                work_cv_.wait(lock, [&] {
+                    return stopping_ || generation_ != seen_generation;
+                });
+                if (stopping_) return;
+                seen_generation = generation_;
+                batch = active_;
+            }
+            if (!batch || worker_index >= batch->worker_participants) continue;
+            run_participant(batch, worker_index + 1);
+            if (batch->remaining.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+                std::lock_guard lock(batch->done_mutex);
+                batch->done_cv.notify_one();
+            }
+        }
+    }
+
+    std::vector<std::thread> workers_;
+    std::mutex mutex_;
+    std::condition_variable work_cv_;
+    std::shared_ptr<DrawRealizationBatch> active_;
+    uint64_t generation_ = 0;
+    bool stopping_ = false;
+};
+
+size_t configured_draw_realization_threads() {
+    static const size_t threads = [] {
+        const unsigned hardware = std::thread::hardware_concurrency();
+        size_t result = std::min<size_t>(hardware ? hardware : 4u, 8u);
+        if (const char* value = std::getenv("PROSPER_DRAW_REALIZE_THREADS")) {
+            char* end = nullptr;
+            const unsigned long parsed = std::strtoul(value, &end, 10);
+            if (end != value && *end == '\0') result = std::clamp<size_t>(parsed, 1u, 32u);
+        }
+        return std::max<size_t>(result, 1u);
+    }();
+    return threads;
+}
+
+size_t parallel_draw_minimum() {
+    static const size_t minimum = [] {
+        size_t result = 32;
+        if (const char* value = std::getenv("PROSPER_DRAW_REALIZE_MIN_DRAWS")) {
+            char* end = nullptr;
+            const unsigned long parsed = std::strtoul(value, &end, 10);
+            if (end != value && *end == '\0') result = std::clamp<size_t>(parsed, 2u, 4096u);
+        }
+        return result;
+    }();
+    return minimum;
+}
+
+bool parallel_draw_diagnostic_active(bool log) {
+    if (log || std::getenv("PROSPER_SERIAL_DRAW_REALIZE")) return true;
+    static constexpr const char* diagnostics[] = {
+        "PROSPER_RTLOG", "PROSPER_INTERPLOG", "PROSPER_RESDUMP",
+        "PROSPER_DYNTRACE_FAIL", "PROSPER_DRAWDIAG", "PROSPER_ONLY_ATLAS",
+        "PROSPER_CAPTION_DIAG", "PROSPER_VS_DUMP", "PROSPER_SHADER_DUMP",
+        "PROSPER_SHADER_DUMP_SUCCESS", "PROSPER_DRAWLOG", "PROSPER_DBG",
+        "PROSPER_STAGE_FOLD_PROFILE", "PROSPER_DESCRIPTOR_VALIDATE",
+        "PROSPER_NO_SHADER_CACHE",
+    };
+    for (const char* name : diagnostics)
+        if (std::getenv(name)) return true;
+    return false;
+}
+
+DrawRealizationPool& draw_realization_pool() {
+    static DrawRealizationPool pool(configured_draw_realization_threads() - 1);
+    return pool;
+}
+
+struct ParallelDrawSlot {
+    DrawItem item;
+    bool realized = false;
+};
+
+struct ParallelWorkerMeasurement {
+    DrawRealizationPhaseStats draw_before;
+    StageTablePhaseStats table_before;
+    DrawRealizationPhaseStats draw_delta;
+    StageTablePhaseStats table_delta;
+    uint64_t readable_calls = 0;
+    uint64_t readable_hits = 0;
+    uint64_t readable_os_probes = 0;
+    std::unique_ptr<GuestReadableSubmitScope> readable_scope;
+};
+
+struct ParallelDrawContext {
+    const GpuState* state = nullptr;
+    uint32_t max_shader_dwords = 0;
+    bool retain_shared_shader_words = false;
+    bool parent_readable_active = false;
+    std::vector<ParallelDrawSlot> slots;
+    std::vector<ParallelWorkerMeasurement> measurements;
+};
+
+void parallel_draw_worker_begin(void* opaque, size_t worker_slot) {
+    auto& context = *static_cast<ParallelDrawContext*>(opaque);
+    auto& measurement = context.measurements[worker_slot];
+    if (worker_slot != 0)
+        measurement.readable_scope = std::make_unique<GuestReadableSubmitScope>();
+    measurement.draw_before = draw_realization_phase_stats();
+    measurement.table_before = stage_table_phase_stats();
+}
+
+void parallel_draw_worker_execute(void* opaque, size_t draw_index, size_t) {
+    auto& context = *static_cast<ParallelDrawContext*>(opaque);
+    const GpuState& state = *context.state;
+    const GpuState::Draw& draw = state.draws[draw_index];
+    ParallelDrawSlot& slot = context.slots[draw_index];
+    slot.realized = realize_draw_item(
+        state.state_at_draw(draw_index), &draw, draw.index_count,
+        context.max_shader_dwords, false, slot.item, nullptr,
+        context.retain_shared_shader_words);
+    if (slot.realized) {
+        slot.item.draw_index = draw_index;
+        slot.item.command_order = draw.command_order;
+    }
+}
+
+void parallel_draw_worker_end(void* opaque, size_t worker_slot) {
+    auto& context = *static_cast<ParallelDrawContext*>(opaque);
+    auto& measurement = context.measurements[worker_slot];
+    const DrawRealizationPhaseStats draw_after = draw_realization_phase_stats();
+    const StageTablePhaseStats table_after = stage_table_phase_stats();
+    measurement.draw_delta = {
+        draw_after.draws - measurement.draw_before.draws,
+        draw_after.table_ms - measurement.draw_before.table_ms,
+        draw_after.shader_ms - measurement.draw_before.shader_ms,
+    };
+    measurement.table_delta = {
+        table_after.calls - measurement.table_before.calls,
+        table_after.metadata_ms - measurement.table_before.metadata_ms,
+        table_after.dynamic_fold_ms - measurement.table_before.dynamic_fold_ms,
+        table_after.resources_ms - measurement.table_before.resources_ms,
+    };
+    if (worker_slot != 0) {
+        measurement.readable_calls = g_guest_readable_cache.calls;
+        measurement.readable_hits = g_guest_readable_cache.hits;
+        measurement.readable_os_probes = g_guest_readable_cache.os_probes;
+        measurement.readable_scope.reset();
+    }
+}
+
+struct ParallelDrawStatsState {
+    std::mutex mutex;
+    ParallelDrawRealizationStats totals;
+};
+
+ParallelDrawStatsState& parallel_draw_stats_state() {
+    static ParallelDrawStatsState state;
+    return state;
+}
+
+} // namespace
+
+ParallelDrawRealizationStats parallel_draw_realization_stats() {
+    auto& state = parallel_draw_stats_state();
+    std::lock_guard lock(state.mutex);
+    return state.totals;
+}
+
+std::vector<DrawItem> realize_gpustate_draws_parallel(
+        const GpuState& st, uint32_t max_shader_dwords, bool log,
+        bool retain_shared_shader_words, bool* attempted) {
+    if (attempted) *attempted = false;
+    const size_t thread_count = configured_draw_realization_threads();
+    if (thread_count < 2 || st.draws.size() < parallel_draw_minimum() ||
+        parallel_draw_diagnostic_active(log))
+        return {};
+    if (attempted) *attempted = true;
+
+    DrawRealizationPool& pool = draw_realization_pool();
+    const size_t worker_count = std::min(pool.worker_count(), thread_count - 1);
+    ParallelDrawContext context;
+    context.state = &st;
+    context.max_shader_dwords = max_shader_dwords;
+    context.retain_shared_shader_words = retain_shared_shader_words;
+    context.parent_readable_active = g_guest_readable_cache.active;
+    context.slots.resize(st.draws.size());
+    context.measurements.resize(worker_count + 1);
+
+    auto batch = std::make_shared<DrawRealizationBatch>();
+    batch->context = &context;
+    batch->begin = parallel_draw_worker_begin;
+    batch->draw = parallel_draw_worker_execute;
+    batch->end = parallel_draw_worker_end;
+    batch->count = st.draws.size();
+    const auto begin = std::chrono::steady_clock::now();
+    pool.run(batch, worker_count);
+    const auto end = std::chrono::steady_clock::now();
+
+    // The parent thread's phase/readability counters feed the existing submit timing report. Worker
+    // thread-local deltas must be merged explicitly so parallel work is not mislabeled as "other".
+    for (size_t i = 1; i < context.measurements.size(); ++i) {
+        const auto& measurement = context.measurements[i];
+        g_draw_realization_phases.draws += measurement.draw_delta.draws;
+        g_draw_realization_phases.table_ms += measurement.draw_delta.table_ms;
+        g_draw_realization_phases.shader_ms += measurement.draw_delta.shader_ms;
+        g_stage_table_phases.calls += measurement.table_delta.calls;
+        g_stage_table_phases.metadata_ms += measurement.table_delta.metadata_ms;
+        g_stage_table_phases.dynamic_fold_ms += measurement.table_delta.dynamic_fold_ms;
+        g_stage_table_phases.resources_ms += measurement.table_delta.resources_ms;
+        if (context.parent_readable_active) {
+            g_guest_readable_cache.calls += measurement.readable_calls;
+            g_guest_readable_cache.hits += measurement.readable_hits;
+            g_guest_readable_cache.os_probes += measurement.readable_os_probes;
+        }
+    }
+
+    {
+        auto& stats = parallel_draw_stats_state();
+        std::lock_guard lock(stats.mutex);
+        ++stats.totals.batches;
+        stats.totals.semantic_draws += st.draws.size();
+        stats.totals.worker_threads += worker_count + 1;
+        stats.totals.wall_ms +=
+            std::chrono::duration<double, std::milli>(end - begin).count();
+    }
+
+    std::vector<DrawItem> items;
+    items.reserve(st.draws.size());
+    for (auto& slot : context.slots)
+        if (slot.realized) items.push_back(std::move(slot.item));
+    return items;
+}
+
+namespace {
 enum class RetainedSubmitKind : uint8_t { Draw, Dispatch, DmaCopy, MemoryEffect };
 struct RetainedSubmitOperation {
     RetainedSubmitKind kind;
@@ -3465,7 +3809,8 @@ bool realize_retained_draw(const GpuState& st, size_t index, float scale_x, floa
     const GpuState& draw_state = per_draw ? st.state_at_draw(index) : st;
     const GpuState::Draw& draw = st.draws[index];
     const bool log = getenv("PROSPER_GFXLOG") != nullptr || getenv("PROSPER_EXECLOG") != nullptr;
-    if (!realize_draw_item(draw_state, &draw, draw.index_count, 0x10000, log, item)) return false;
+    if (!realize_draw_item(draw_state, &draw, draw.index_count, 0x10000, log, item,
+                           nullptr, true)) return false;
     item.draw_index = index;
     item.command_order = draw.command_order;
     if (scale_x != 1.0f || scale_y != 1.0f)
@@ -3695,6 +4040,8 @@ bool execute_ordered_and_present(const GpuState& st, uint32_t width, uint32_t he
         ? draw_realization_phase_stats() : DrawRealizationPhaseStats{};
     const StageTablePhaseStats table_phases_before = timing_enabled
         ? stage_table_phase_stats() : StageTablePhaseStats{};
+    const ParallelDrawRealizationStats parallel_before = timing_enabled
+        ? parallel_draw_realization_stats() : ParallelDrawRealizationStats{};
     uint32_t fw = present_width(), fh = present_height();
     float sx = fw ? (float)width / (float)fw : 1.0f;
     float sy = fh ? (float)height / (float)fh : 1.0f;
@@ -3702,7 +4049,8 @@ bool execute_ordered_and_present(const GpuState& st, uint32_t width, uint32_t he
     // A DMA-bearing submit realizes consumers at their ordered position below. Pre-realizing here
     // would snapshot old indices/descriptors/shader bytes before the copy updates their backing.
     std::vector<DrawItem> draws = !has_ordered_dma && g_live && width && height
-        ? realize_gpustate_draws(st, 0x10000, sx, sy) : std::vector<DrawItem>{};
+        ? realize_gpustate_draws(st, 0x10000, sx, sy, nullptr, true)
+        : std::vector<DrawItem>{};
     const ShaderRecompileCacheStats shader_after = timing_enabled
         ? shader_recompile_cache_stats() : ShaderRecompileCacheStats{};
     const ShaderDecodeCacheStats decode_after = timing_enabled
@@ -3711,6 +4059,8 @@ bool execute_ordered_and_present(const GpuState& st, uint32_t width, uint32_t he
         ? draw_realization_phase_stats() : DrawRealizationPhaseStats{};
     const StageTablePhaseStats table_phases_after = timing_enabled
         ? stage_table_phase_stats() : StageTablePhaseStats{};
+    const ParallelDrawRealizationStats parallel_after = timing_enabled
+        ? parallel_draw_realization_stats() : ParallelDrawRealizationStats{};
     const auto timing_draws_ready = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
     std::vector<ComputeItem> computes = !has_ordered_dma && g_compute
         ? realize_compute_dispatches(st, submit_no) : std::vector<ComputeItem>{};
@@ -3747,9 +4097,11 @@ bool execute_ordered_and_present(const GpuState& st, uint32_t width, uint32_t he
             uint64_t shader_hits = 0, shader_misses = 0, shader_bypasses = 0;
             uint64_t decode_hits = 0, decode_misses = 0, decode_invalidations = 0;
             uint64_t readable_calls = 0, readable_hits = 0, readable_os_probes = 0;
+            uint64_t parallel_batches = 0, parallel_draws = 0, parallel_threads = 0;
             double realize_draws = 0, realize_compute = 0, plan = 0, backend = 0, publish = 0;
             double table_build = 0, shader_lookup = 0, shader_compile = 0;
             double table_metadata = 0, table_dynamic_fold = 0, table_resources = 0;
+            double parallel_wall = 0;
         };
         static TimingTotals totals;
         static TimingTotals window;
@@ -3767,6 +4119,10 @@ bool execute_ordered_and_present(const GpuState& st, uint32_t width, uint32_t he
             timing.readable_calls += g_guest_readable_cache.calls;
             timing.readable_hits += g_guest_readable_cache.hits;
             timing.readable_os_probes += g_guest_readable_cache.os_probes;
+            timing.parallel_batches += parallel_after.batches - parallel_before.batches;
+            timing.parallel_draws += parallel_after.semantic_draws - parallel_before.semantic_draws;
+            timing.parallel_threads += parallel_after.worker_threads - parallel_before.worker_threads;
+            timing.parallel_wall += parallel_after.wall_ms - parallel_before.wall_ms;
             timing.realize_draws += ms(timing_start, timing_draws_ready);
             timing.realize_compute += ms(timing_draws_ready, timing_compute_ready);
             timing.plan += ms(timing_compute_ready, timing_plan_ready);
@@ -3805,6 +4161,7 @@ bool execute_ordered_and_present(const GpuState& st, uint32_t width, uint32_t he
                          "readable: hit=%.1f/%.1f os=%.1f "
                          "avg_ms: total=%.2f realize_draws=%.2f tables=%.2f shader_lookup=%.2f "
                          "shader_compile=%.2f table_parts: metadata=%.2f fold=%.2f resources=%.2f "
+                         "parallel: batches=%.2f draws=%.1f threads=%.1f wall=%.2f "
                          "realize_compute=%.2f plan=%.2f backend=%.2f publish=%.2f\n",
                          (unsigned long long)window.submits, window.draws / wn,
                          window.dispatches / wn, window.render_spans / wn,
@@ -3817,6 +4174,12 @@ bool execute_ordered_and_present(const GpuState& st, uint32_t width, uint32_t he
                          window.shader_lookup / wn, window.shader_compile / wn,
                          window.table_metadata / wn, window.table_dynamic_fold / wn,
                          window.table_resources / wn,
+                         window.parallel_batches / wn, window.parallel_draws / wn,
+                         window.parallel_batches
+                             ? static_cast<double>(window.parallel_threads) /
+                                   static_cast<double>(window.parallel_batches)
+                             : 0.0,
+                         window.parallel_wall / wn,
                          window.realize_compute / wn, window.plan / wn, window.backend / wn,
                          window.publish / wn);
             window = {};
@@ -3835,7 +4198,8 @@ bool execute_and_present(const GpuState& st, uint32_t width, uint32_t height, bo
     uint32_t fw = present_width(), fh = present_height();
     float sx = fw ? (float)width  / (float)fw : 1.0f;
     float sy = fh ? (float)height / (float)fh : 1.0f;
-    std::vector<DrawItem> items = realize_gpustate_draws(st, 0x10000, sx, sy);
+    std::vector<DrawItem> items = realize_gpustate_draws(
+        st, 0x10000, sx, sy, nullptr, true);
     if (items.empty()) return false;
     std::vector<SubmitOperation> operations;
     operations.reserve(items.size());

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -558,33 +558,55 @@ std::shared_ptr<const ShaderCodeAnalysis> analyze_shader_code_cached(const uint3
     }
 
     const uintptr_t address = reinterpret_cast<uintptr_t>(code);
-    {
+    // Copy the immutable candidate under the mutex, then validate guest bytes without it. Dense draw
+    // realization performs these exact checks from several workers; holding one global cache mutex
+    // across guest_readable + memcmp otherwise serializes every warm lookup.
+    for (;;) {
+        std::shared_ptr<const ShaderCodeAnalysis> cached;
+        {
+            std::lock_guard lock(cache.mutex);
+            auto found = cache.entries.find(address);
+            if (found == cache.entries.end()) {
+                ++cache.stats.misses;
+                break;
+            }
+            cached = found->second.analysis;
+        }
+        const bool compatible_length = cached->bounded_span
+            ? cached->code.size() <= dwords : cached->source_dwords == dwords;
+        const uint64_t code_bytes = static_cast<uint64_t>(cached->code.size()) * sizeof(uint32_t);
+        const bool readable = code_bytes == 0 ||
+                              (code_bytes <= UINT32_MAX &&
+                               guest_readable(address, static_cast<uint32_t>(code_bytes)));
+        const bool matches = compatible_length && readable &&
+            (code_bytes == 0 ||
+             memcmp(code, cached->code.data(), static_cast<size_t>(code_bytes)) == 0);
+
         std::lock_guard lock(cache.mutex);
         auto found = cache.entries.find(address);
-        if (found != cache.entries.end()) {
-            const auto& cached = found->second.analysis;
-            const bool compatible_length = cached->bounded_span
-                ? cached->code.size() <= dwords : cached->source_dwords == dwords;
-            const uint64_t code_bytes = static_cast<uint64_t>(cached->code.size()) * sizeof(uint32_t);
-            const bool readable = code_bytes == 0 ||
-                                  (code_bytes <= UINT32_MAX &&
-                                   guest_readable(address, static_cast<uint32_t>(code_bytes)));
-            if (compatible_length && readable &&
-                (code_bytes == 0 ||
-                 memcmp(code, cached->code.data(), static_cast<size_t>(code_bytes)) == 0)) {
-                ++cache.stats.hits;
-                found->second.last_use = ++cache.use_counter;
-                return cached;
-            }
-            cache.stats.bytes -= cached->bytes;
-            cache.entries.erase(found);
-            ++cache.stats.invalidations;
+        if (found == cache.entries.end() || found->second.analysis != cached)
+            continue; // Evicted/replaced while unlocked: validate the current version instead.
+        if (matches) {
+            ++cache.stats.hits;
+            found->second.last_use = ++cache.use_counter;
+            return cached;
         }
+        cache.stats.bytes -= cached->bytes;
+        cache.entries.erase(found);
+        ++cache.stats.invalidations;
         ++cache.stats.misses;
+        break;
     }
 
     auto analysis = analyze();
     std::lock_guard lock(cache.mutex);
+    // Another cold worker may have populated this address while analysis ran. Keep exact byte
+    // accounting when replacing it; each returned shared_ptr remains independently valid.
+    auto concurrent = cache.entries.find(address);
+    if (concurrent != cache.entries.end()) {
+        cache.stats.bytes -= concurrent->second.analysis->bytes;
+        cache.entries.erase(concurrent);
+    }
     constexpr size_t max_entries = 4096;
     const uint64_t limit = shader_analysis_cache_limit_bytes();
     while (!cache.entries.empty() &&

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -167,6 +167,7 @@ inline BackendColorTargetStats backend_color_target_stats() {
 // correctly. render_triangle_rgba is a thin single-draw wrapper (below).
 struct BackendDraw {
     std::vector<uint32_t> vs, gs, fs;
+    prosper::gpu::SharedShaderWords vs_shared, fs_shared;
     uint64_t vs_identity = 0, fs_identity = 0;
     const prosper::gpu::ResolvedPipelineState* ps = nullptr;   // null -> triangle-list, write RGBA, no depth
     std::vector<FrameResource> R;                              // set-tagged resources (empty -> no descriptors)
@@ -177,6 +178,10 @@ struct BackendDraw {
     // fetched index — exactly what the recompiled VS's storage-buffer vertex fetch expects. Empty ->
     // plain vkCmdDraw(vcount). Both paths preserve instance_count.
     std::vector<uint32_t> indices;
+
+    const std::vector<uint32_t>& vs_words() const { return vs_shared ? *vs_shared : vs; }
+    const std::vector<uint32_t>& gs_words() const { return gs; }
+    const std::vector<uint32_t>& fs_words() const { return fs_shared ? *fs_shared : fs; }
 };
 
 struct BackendTextureUploadStats {
@@ -2100,12 +2105,15 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     for (size_t di = 0; di < draws.size(); di++) {
         const auto setup_begin = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
         const BackendDraw& bd = draws[di];
+        const std::vector<uint32_t>& bd_vs = bd.vs_words();
+        const std::vector<uint32_t>& bd_gs = bd.gs_words();
+        const std::vector<uint32_t>& bd_fs = bd.fs_words();
         DV& v = dv[di];
         if (backend_trace) {
             fprintf(stderr,
                     "[backend-trace] draw=%zu/%zu begin extent=%ux%u vs=%zu gs=%zu fs=%zu "
                     "vs_id=%016llx fs_id=%016llx resources=%zu\n",
-                    di, draws.size(), W, H, bd.vs.size(), bd.gs.size(), bd.fs.size(),
+                    di, draws.size(), W, H, bd_vs.size(), bd_gs.size(), bd_fs.size(),
                     (unsigned long long)bd.vs_identity,
                     (unsigned long long)bd.fs_identity, bd.R.size());
             fflush(stderr);
@@ -2145,8 +2153,8 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         }
         VkPipelineShaderStageCreateInfo st[3]{};
         st[0] = {VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO}; st[0].stage = VK_SHADER_STAGE_VERTEX_BIT; st[0].module = v.vs; st[0].pName = "main";
-        const uint32_t fragment_stage_index = bd.gs.empty() ? 1u : 2u;
-        if (!bd.gs.empty()) {
+        const uint32_t fragment_stage_index = bd_gs.empty() ? 1u : 2u;
+        if (!bd_gs.empty()) {
             st[1] = {VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO};
             st[1].stage = VK_SHADER_STAGE_GEOMETRY_BIT; st[1].module = v.gs; st[1].pName = "main";
         }
@@ -2748,7 +2756,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
             ++resource_reuse_stats.unique_pipeline_layouts;
         }
         VkGraphicsPipelineCreateInfo gp{VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO};
-        gp.stageCount = bd.gs.empty() ? 2u : 3u; gp.pStages = st;
+        gp.stageCount = bd_gs.empty() ? 2u : 3u; gp.pStages = st;
         gp.pVertexInputState = &vin; gp.pInputAssemblyState = &ia;
         gp.pViewportState = &vpst; gp.pRasterizationState = &rs; gp.pMultisampleState = &ms;
         gp.pColorBlendState = &cb; gp.pDynamicState = &dynamic_state;
@@ -2782,19 +2790,19 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                 append(static_cast<uint32_t>(bd.vs_identity));
                 append(static_cast<uint32_t>(bd.vs_identity >> 32));
             } else {
-                append(static_cast<uint32_t>(bd.vs.size()));
-                for (uint32_t word : bd.vs) append(word);
+                append(static_cast<uint32_t>(bd_vs.size()));
+                for (uint32_t word : bd_vs) append(word);
             }
             append(bd.fs_identity != 0);
             if (bd.fs_identity) {
                 append(static_cast<uint32_t>(bd.fs_identity));
                 append(static_cast<uint32_t>(bd.fs_identity >> 32));
             } else {
-                append(static_cast<uint32_t>(bd.fs.size()));
-                for (uint32_t word : bd.fs) append(word);
+                append(static_cast<uint32_t>(bd_fs.size()));
+                for (uint32_t word : bd_fs) append(word);
             }
-            append(static_cast<uint32_t>(bd.gs.size()));
-            for (uint32_t word : bd.gs) append(word);
+            append(static_cast<uint32_t>(bd_gs.size()));
+            for (uint32_t word : bd_gs) append(word);
             append(v.use_desc); append(v.n_sets);
             // A pair of shader-cache identities names the exact compile keys, including every
             // descriptor's class and binding. External/replay shaders have identity zero and keep
@@ -2862,8 +2870,8 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                 fprintf(stderr, "[backend-trace] draw=%zu create-shaders begin\n", di);
                 fflush(stderr);
             }
-            v.vs = mkmod(bd.vs); v.gs = bd.gs.empty() ? VK_NULL_HANDLE : mkmod(bd.gs);
-            v.fs = mkmod(bd.fs);
+            v.vs = mkmod(bd_vs); v.gs = bd_gs.empty() ? VK_NULL_HANDLE : mkmod(bd_gs);
+            v.fs = mkmod(bd_fs);
             if (backend_trace) {
                 fprintf(stderr,
                         "[backend-trace] draw=%zu create-shaders end vs=%p gs=%p fs=%p\n",
@@ -2874,14 +2882,14 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                 ? TimingClock::now() : TimingClock::time_point{};
             if (timing_enabled)
                 setup_shader_ms += setup_elapsed_ms(setup_shader_begin, setup_shader_ready);
-            if (!v.vs || !v.fs || (!bd.gs.empty() && !v.gs)) {
+            if (!v.vs || !v.fs || (!bd_gs.empty() && !v.gs)) {
                 if (timing_enabled)
                     setup_pipeline_ms += setup_elapsed_ms(
                         setup_resources_ready, setup_pipeline_key_ready);
                 continue;   // rejected SPIR-V -> skip this draw
             }
             st[0].module = v.vs;
-            if (!bd.gs.empty()) st[1].module = v.gs;
+            if (!bd_gs.empty()) st[1].module = v.gs;
             st[fragment_stage_index].module = v.fs;
             setup_pipeline_create_begin = setup_shader_ready;
             if (backend_trace) {

--- a/prosper/tests/test_agc_shader.cpp
+++ b/prosper/tests/test_agc_shader.cpp
@@ -1,6 +1,7 @@
 // test_agc_shader -- focused guards for sceAgcCreateShader's guest-visible side effects.
 #include "../src/hle/dispatch.hpp"
 #include "../src/gpu/gpu_execute.hpp"
+#include "../src/gpu/pm4_registers.hpp"
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
@@ -302,6 +303,133 @@ int main() {
     CHECK(packed_buffer && packed_buffer->format == prosper::gpu::DataFormat::Unorm2_10_10_10 &&
           packed_buffer->size == 7u * sizeof(uint32_t),
           "zero-record packed V# size uses one physical dword per drawn record");
+
+    // Hundreds of draw snapshots dominate Evergate's opening transition. Prime the exact serial
+    // result, then realize the same immutable snapshots through the live parallel/shared-word path.
+    // The worker completion order is intentionally unconstrained; compaction must still return the
+    // original PM4 order and every semantic field must match the serial oracle.
+    alignas(256) static const uint32_t parallel_vs[] = {
+        0x36020081u, 0x2C040081u, 0x7E020D01u, 0x7E040D02u, 0x7E0A02F6u,
+        0x7E0C02F2u, 0x10020B01u, 0x08020D01u, 0x10040B02u, 0x08040D02u,
+        0x7E060280u, 0x7E0802F2u, 0xF80008CFu, 0x04030201u, 0xBF810000u,
+    };
+    alignas(256) static const uint32_t parallel_ps[] = {
+        0x7E000280u, 0x7E0202F2u, 0x7E040280u, 0x7E0602F2u,
+        0xF800180Fu, 0x03020100u, 0xBF810000u,
+    };
+    Shader parallel_vs_header{};
+    parallel_vs_header.file_header = 0x34333231u;
+    parallel_vs_header.version = 0x18u;
+    parallel_vs_header.shader_size = sizeof(parallel_vs);
+    parallel_vs_header.type = 2;
+    dst = nullptr;
+    const uint64_t parallel_vs_rc = create_shader(
+        reinterpret_cast<uint64_t>(&dst), reinterpret_cast<uint64_t>(&parallel_vs_header),
+        reinterpret_cast<uint64_t>(parallel_vs), 0, 0, 0);
+    Shader parallel_ps_header{};
+    parallel_ps_header.file_header = 0x34333231u;
+    parallel_ps_header.version = 0x18u;
+    parallel_ps_header.shader_size = sizeof(parallel_ps);
+    parallel_ps_header.type = 1;
+    dst = nullptr;
+    const uint64_t parallel_ps_rc = create_shader(
+        reinterpret_cast<uint64_t>(&dst), reinterpret_cast<uint64_t>(&parallel_ps_header),
+        reinterpret_cast<uint64_t>(parallel_ps), 0, 0, 0);
+    CHECK(parallel_vs_rc == 0 && parallel_ps_rc == 0,
+          "parallel-realization shaders enter the AGC registry");
+
+    namespace P = prosper::agc::Pm4;
+    prosper::gpu::GpuState parallel_state;
+    auto set_pgm = [&](uint32_t lo, uint32_t hi, const void* code) {
+        const uint64_t address = reinterpret_cast<uint64_t>(code);
+        parallel_state.sh[lo] = static_cast<uint32_t>(address >> 8);
+        parallel_state.sh[hi] = static_cast<uint32_t>((address >> 40) & 0xffu);
+    };
+    set_pgm(P::SPI_SHADER_PGM_LO_ES, P::SPI_SHADER_PGM_HI_ES, parallel_vs);
+    set_pgm(P::SPI_SHADER_PGM_LO_PS, P::SPI_SHADER_PGM_HI_PS, parallel_ps);
+    parallel_state.uc[P::VGT_PRIMITIVE_TYPE] = 4;
+    parallel_state.cx[P::CB_TARGET_MASK] = 0xf;
+    parallel_state.draws.resize(128);
+    for (size_t i = 0; i < parallel_state.draws.size(); ++i) {
+        parallel_state.draws[i].index_count = 3;
+        parallel_state.draws[i].command_order = 1000 + i * 3;
+    }
+    prosper::gpu::clear_shader_recompile_cache();
+    const auto serial_draws = prosper::gpu::realize_gpustate_draws(
+        parallel_state, 0x10000, 1.0f, 1.0f, nullptr, false, false);
+    const auto parallel_before = prosper::gpu::parallel_draw_realization_stats();
+    const auto parallel_draws = prosper::gpu::realize_gpustate_draws(
+        parallel_state, 0x10000, 1.0f, 1.0f, nullptr, true, true);
+    const auto parallel_after = prosper::gpu::parallel_draw_realization_stats();
+    bool equivalent = serial_draws.size() == parallel_state.draws.size() &&
+                      parallel_draws.size() == serial_draws.size();
+    for (size_t i = 0; equivalent && i < serial_draws.size(); ++i) {
+        const auto& serial = serial_draws[i];
+        const auto& parallel = parallel_draws[i];
+        equivalent = serial.draw_index == i && parallel.draw_index == i &&
+            serial.command_order == parallel.command_order &&
+            serial.vertex_count == parallel.vertex_count &&
+            serial.instance_count == parallel.instance_count &&
+            serial.indices == parallel.indices && serial.vs_words() == parallel.vs_words() &&
+            serial.gs_words() == parallel.gs_words() && serial.fs_words() == parallel.fs_words() &&
+            serial.vs_identity == parallel.vs_identity &&
+            serial.fs_identity == parallel.fs_identity &&
+            serial.ps.topology == parallel.ps.topology &&
+            serial.ps.color_write_mask == parallel.ps.color_write_mask &&
+            serial.ps.blend_enable == parallel.ps.blend_enable &&
+            serial.color0_base == parallel.color0_base &&
+            serial.color0_width == parallel.color0_width &&
+            serial.color0_height == parallel.color0_height &&
+            parallel.vs_shared && parallel.fs_shared &&
+            !parallel.vs_shared->empty() && !parallel.fs_shared->empty() &&
+            parallel.vs.empty() && parallel.fs.empty();
+    }
+    CHECK(equivalent,
+          "parallel shared-word realization is field- and order-equivalent to serial realization");
+    CHECK(parallel_after.batches == parallel_before.batches + 1 &&
+              parallel_after.semantic_draws ==
+                  parallel_before.semantic_draws + parallel_state.draws.size() &&
+              parallel_after.worker_threads > parallel_before.worker_threads,
+          "dense draw realization records one multi-threaded batch");
+
+    // Exercise persistent-worker generation changes repeatedly. This catches an early return or a
+    // stale batch/context reference that a single batch cannot expose, while warm shader-cache reuse
+    // keeps the stress loop small and deterministic.
+    const auto repeated_before = prosper::gpu::parallel_draw_realization_stats();
+    bool repeated_ok = true;
+    constexpr size_t kRepeatedBatches = 64;
+    for (size_t batch = 0; batch < kRepeatedBatches && repeated_ok; ++batch) {
+        const auto repeated = prosper::gpu::realize_gpustate_draws(
+            parallel_state, 0x10000, 1.0f, 1.0f, nullptr, true, true);
+        repeated_ok = repeated.size() == parallel_state.draws.size();
+        for (size_t i = 0; repeated_ok && i < repeated.size(); ++i)
+            repeated_ok = repeated[i].draw_index == i &&
+                          repeated[i].command_order == parallel_state.draws[i].command_order &&
+                          repeated[i].vs_shared && repeated[i].fs_shared;
+    }
+    const auto repeated_after = prosper::gpu::parallel_draw_realization_stats();
+    CHECK(repeated_ok &&
+              repeated_after.batches == repeated_before.batches + kRepeatedBatches &&
+              repeated_after.semantic_draws == repeated_before.semantic_draws +
+                  kRepeatedBatches * parallel_state.draws.size(),
+          "persistent realization workers survive repeated batch generations");
+
+    // An attempted parallel batch can correctly produce no items. That must not be mistaken for
+    // "parallel disabled" and replay all draws serially. Each no-effect draw reaches both already-warm
+    // shader cache entries once; a serial retry would double this exact hit count.
+    prosper::gpu::GpuState filtered_state = parallel_state;
+    filtered_state.cx[P::CB_TARGET_MASK] = 0;
+    const auto filtered_parallel_before = prosper::gpu::parallel_draw_realization_stats();
+    const auto filtered_shader_before = prosper::gpu::shader_recompile_cache_stats();
+    const auto filtered_draws = prosper::gpu::realize_gpustate_draws(
+        filtered_state, 0x10000, 1.0f, 1.0f, nullptr, true, true);
+    const auto filtered_shader_after = prosper::gpu::shader_recompile_cache_stats();
+    const auto filtered_parallel_after = prosper::gpu::parallel_draw_realization_stats();
+    CHECK(filtered_draws.empty() &&
+              filtered_parallel_after.batches == filtered_parallel_before.batches + 1 &&
+              filtered_shader_after.hits ==
+                  filtered_shader_before.hits + filtered_state.draws.size() * 2,
+          "all-filtered parallel batch is not retried through the serial path");
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");

--- a/prosper/tests/test_agc_shader.cpp
+++ b/prosper/tests/test_agc_shader.cpp
@@ -357,10 +357,14 @@ int main() {
     prosper::gpu::clear_shader_recompile_cache();
     const auto serial_draws = prosper::gpu::realize_gpustate_draws(
         parallel_state, 0x10000, 1.0f, 1.0f, nullptr, false, false);
+    // Cold-start only the analysis layer so the parallel run races its two address-local inserts while
+    // retaining warm compiled shaders. Entry bytes must remain exact even if several workers miss.
+    prosper::gpu::clear_shader_analysis_cache();
     const auto parallel_before = prosper::gpu::parallel_draw_realization_stats();
     const auto parallel_draws = prosper::gpu::realize_gpustate_draws(
         parallel_state, 0x10000, 1.0f, 1.0f, nullptr, true, true);
     const auto parallel_after = prosper::gpu::parallel_draw_realization_stats();
+    const auto parallel_analysis = prosper::gpu::shader_analysis_cache_stats();
     bool equivalent = serial_draws.size() == parallel_state.draws.size() &&
                       parallel_draws.size() == serial_draws.size();
     for (size_t i = 0; equivalent && i < serial_draws.size(); ++i) {
@@ -391,6 +395,9 @@ int main() {
                   parallel_before.semantic_draws + parallel_state.draws.size() &&
               parallel_after.worker_threads > parallel_before.worker_threads,
           "dense draw realization records one multi-threaded batch");
+    CHECK(parallel_analysis.entries == 2 &&
+              parallel_analysis.bytes == sizeof(parallel_vs) + sizeof(parallel_ps),
+          "parallel cold analysis keeps exact entry and byte accounting");
 
     // Exercise persistent-worker generation changes repeatedly. This catches an early return or a
     // stale batch/context reference that a single batch cannot expose, while warm shader-cache reuse

--- a/prosper/tests/test_agc_shader.cpp
+++ b/prosper/tests/test_agc_shader.cpp
@@ -2,9 +2,12 @@
 #include "../src/hle/dispatch.hpp"
 #include "../src/gpu/gpu_execute.hpp"
 #include "../src/gpu/pm4_registers.hpp"
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
+#include <functional>
+#include <thread>
 #include <vector>
 
 using namespace prosper;
@@ -355,15 +358,19 @@ int main() {
         parallel_state.draws[i].command_order = 1000 + i * 3;
     }
     prosper::gpu::clear_shader_recompile_cache();
+    prosper::gpu::clear_shader_decode_cache();
     const auto serial_draws = prosper::gpu::realize_gpustate_draws(
         parallel_state, 0x10000, 1.0f, 1.0f, nullptr, false, false);
-    // Cold-start only the analysis layer so the parallel run races its two address-local inserts while
-    // retaining warm compiled shaders. Entry bytes must remain exact even if several workers miss.
+    const auto serial_decode = prosper::gpu::shader_decode_cache_stats();
+    // Cold-start the address-local decode and analysis layers so parallel workers race their two
+    // inserts while retaining warm compiled shaders. Entry bytes must remain exact under both races.
+    prosper::gpu::clear_shader_decode_cache();
     prosper::gpu::clear_shader_analysis_cache();
     const auto parallel_before = prosper::gpu::parallel_draw_realization_stats();
     const auto parallel_draws = prosper::gpu::realize_gpustate_draws(
         parallel_state, 0x10000, 1.0f, 1.0f, nullptr, true, true);
     const auto parallel_after = prosper::gpu::parallel_draw_realization_stats();
+    const auto parallel_decode = prosper::gpu::shader_decode_cache_stats();
     const auto parallel_analysis = prosper::gpu::shader_analysis_cache_stats();
     bool equivalent = serial_draws.size() == parallel_state.draws.size() &&
                       parallel_draws.size() == serial_draws.size();
@@ -398,6 +405,34 @@ int main() {
     CHECK(parallel_analysis.entries == 2 &&
               parallel_analysis.bytes == sizeof(parallel_vs) + sizeof(parallel_ps),
           "parallel cold analysis keeps exact entry and byte accounting");
+    CHECK(serial_decode.entries == 2 && parallel_decode.entries == serial_decode.entries &&
+              parallel_decode.bytes == serial_decode.bytes,
+          "parallel cold decode keeps exact entry and byte accounting");
+
+    // Public realization calls can arrive from independent submit threads. The process-lifetime
+    // pool must serialize whole batches instead of replacing the active generation mid-flight.
+    std::atomic<size_t> concurrent_ready{0};
+    std::atomic<bool> concurrent_start{false};
+    std::vector<prosper::gpu::DrawItem> concurrent_a, concurrent_b;
+    auto concurrent_realize = [&](std::vector<prosper::gpu::DrawItem>& output) {
+        concurrent_ready.fetch_add(1, std::memory_order_release);
+        while (!concurrent_start.load(std::memory_order_acquire)) std::this_thread::yield();
+        output = prosper::gpu::realize_gpustate_draws(
+            parallel_state, 0x10000, 1.0f, 1.0f, nullptr, true, true);
+    };
+    std::thread concurrent_thread_a(concurrent_realize, std::ref(concurrent_a));
+    std::thread concurrent_thread_b(concurrent_realize, std::ref(concurrent_b));
+    while (concurrent_ready.load(std::memory_order_acquire) != 2) std::this_thread::yield();
+    concurrent_start.store(true, std::memory_order_release);
+    concurrent_thread_a.join();
+    concurrent_thread_b.join();
+    bool concurrent_ok = concurrent_a.size() == parallel_state.draws.size() &&
+                         concurrent_b.size() == parallel_state.draws.size();
+    for (size_t i = 0; concurrent_ok && i < parallel_state.draws.size(); ++i)
+        concurrent_ok = concurrent_a[i].draw_index == i && concurrent_b[i].draw_index == i &&
+                        concurrent_a[i].command_order == parallel_state.draws[i].command_order &&
+                        concurrent_b[i].command_order == parallel_state.draws[i].command_order;
+    CHECK(concurrent_ok, "concurrent callers complete serialized realization batches in draw order");
 
     // Exercise persistent-worker generation changes repeatedly. This catches an early return or a
     // stale batch/context reference that a single batch cannot expose, while warm shader-cache reuse

--- a/prosper/tests/test_gpu_capture.cpp
+++ b/prosper/tests/test_gpu_capture.cpp
@@ -144,6 +144,21 @@ int main() {
               std::vector<uint32_t>(std::begin(kDiagnosticBadPs), std::end(kDiagnosticBadPs)),
           "realized draw captures exact bounded VS and FS RDNA2 streams");
 
+    DrawItem shared_shader_draw = draw;
+    shared_shader_draw.vs_shared =
+        std::make_shared<const std::vector<uint32_t>>(shared_shader_draw.vs);
+    shared_shader_draw.fs_shared =
+        std::make_shared<const std::vector<uint32_t>>(shared_shader_draw.fs);
+    shared_shader_draw.vs.clear();
+    shared_shader_draw.fs.clear();
+    GpuCaptureFile shared_shader_capture;
+    CHECK(capture_draw_items({shared_shader_draw}, meta, reader, shared_shader_capture,
+                             error, rtt_reader) &&
+              shared_shader_capture.draws.size() == 1 &&
+              shared_shader_capture.draws[0].vs == draw.vs &&
+              shared_shader_capture.draws[0].fs == draw.fs,
+          "live capture materializes shared shader words without dropping SPIR-V");
+
     // #636: a descriptor-looking scalar quartet with no matching MUBUF instruction is not a compute
     // resource. The capture path must therefore neither probe its guest address nor retain a blob.
     uint32_t scalar_sgprs[32] = {};

--- a/prosper/tests/test_gpu_execute.cpp
+++ b/prosper/tests/test_gpu_execute.cpp
@@ -64,7 +64,8 @@ int main() {
     auto backend = [&](const std::vector<DrawItem>& items) -> std::vector<uint8_t> {
         if (items.empty()) return {};
         realized_draw = items[0];
-        return prosper::test::render_triangle_rgba(items[0].vs, items[0].fs, W, H, &items[0].ps);
+        return prosper::test::render_triangle_rgba(
+            items[0].vs_words(), items[0].fs_words(), W, H, &items[0].ps);
     };
     std::vector<uint8_t> px = execute_gpustate(st, backend);
     CHECK(px.size() == (size_t)W * H * 4, "execute_gpustate rendered a frame from the GpuState");
@@ -143,8 +144,8 @@ int main() {
         ResolvedPipelineState fp16_dcc_state = items[0].ps;
         fp16_dcc_state.color0_format = VK_FORMAT_R16G16B16A16_SFLOAT;
         prosper::test::BackendDraw draw;
-        draw.vs = items[0].vs;
-        draw.fs = items[0].fs;
+        draw.vs = items[0].vs_words();
+        draw.fs = items[0].fs_words();
         draw.ps = &fp16_dcc_state;
         draw.vcount = items[0].vertex_count;
         prosper::test::BackendColorTarget target{
@@ -410,7 +411,7 @@ int main() {
     auto backend_idx = [&](const std::vector<DrawItem>& items) -> std::vector<uint8_t> {
         if (items.empty()) return {};
         prosper::test::BackendDraw d;
-        d.vs = items[0].vs; d.fs = items[0].fs; d.ps = &items[0].ps;
+        d.vs = items[0].vs_words(); d.fs = items[0].fs_words(); d.ps = &items[0].ps;
         d.vcount = items[0].vertex_count; d.indices = items[0].indices;
         return prosper::test::render_draws_rgba({std::move(d)}, W, H);
     };
@@ -567,7 +568,8 @@ int main() {
         if (items.empty()) return {};
         live_calls++;
         live_storage = std::make_shared<const std::vector<uint8_t>>(
-            prosper::test::render_triangle_rgba(items[0].vs, items[0].fs, w, h, &items[0].ps));
+            prosper::test::render_triangle_rgba(
+                items[0].vs_words(), items[0].fs_words(), w, h, &items[0].ps));
         return RenderedFrame(live_storage);
     });
     CHECK(have_submit_renderer(), "live renderer registered");

--- a/prosper/tests/test_shader_recompile_cache.cpp
+++ b/prosper/tests/test_shader_recompile_cache.cpp
@@ -328,6 +328,26 @@ int main() {
               analysis_stats.invalidations == 1,
           "same-address shader mutation invalidates immutable analysis before reuse");
 
+    // Live realization retains the cache allocation directly. Repeated hits must share one immutable
+    // word vector, and eviction/reset must not invalidate a DrawItem that still owns that version.
+    clear_shader_recompile_cache();
+    uint64_t shared_first_identity = 0, shared_second_identity = 0;
+    const SharedShaderWords shared_first = recompile_graphics_shader_cached_shared(
+        ShaderProgramStage::Vertex, kVs, std::size(kVs), &table, nullptr, nullptr,
+        &shared_first_identity);
+    const SharedShaderWords shared_second = recompile_graphics_shader_cached_shared(
+        ShaderProgramStage::Vertex, kVs, std::size(kVs), &table, nullptr, nullptr,
+        &shared_second_identity);
+    stats = shader_recompile_cache_stats();
+    CHECK(shared_first && shared_first == shared_second && *shared_first ==
+              recompile_vertex(kVs, std::size(kVs), &table) &&
+              shared_first_identity != 0 && shared_first_identity == shared_second_identity &&
+              stats.misses == 1 && stats.hits == 1,
+          "live shader-cache hits share one exact immutable SPIR-V allocation");
+    clear_shader_recompile_cache();
+    CHECK(shared_first && !shared_first->empty(),
+          "shared shader words outlive cache reset while a realized draw retains them");
+
     if (failures) {
         std::printf("== FAIL: %d ==\n", failures);
         return 1;

--- a/prosper/tests/test_shader_recompile_cache.cpp
+++ b/prosper/tests/test_shader_recompile_cache.cpp
@@ -125,6 +125,16 @@ int main() {
     CHECK(cached_rebound == direct_rebound && stats.misses == 2 && stats.entries == 2,
           "compile-time resource changes miss and remain byte-identical to the oracle");
 
+    // Guest programs with identical bytes may be mapped at different addresses. Shader analysis is
+    // address-local, but the compiled shader cache must still compare its immutable code by value.
+    std::vector<uint32_t> relocated_vs(kVs, kVs + std::size(kVs));
+    const auto relocated_cached = recompile_graphics_shader_cached(
+        ShaderProgramStage::Vertex, relocated_vs.data(), relocated_vs.size(), &table);
+    stats = shader_recompile_cache_stats();
+    CHECK(relocated_cached == cached_rebound && stats.hits == 3 && stats.misses == 2 &&
+              stats.entries == 2,
+          "byte-identical shader code at a different address reuses the compiled cache entry");
+
     const auto direct_ps = recompile_fragment(kPs, std::size(kPs), nullptr);
     const auto cached_ps = recompile_graphics_shader_cached(
         ShaderProgramStage::Fragment, kPs, std::size(kPs), nullptr);


### PR DESCRIPTION
Closes #1000

## What changed

- realize independent live draws through a persistent bounded worker pool while preserving PM4 draw order
- share immutable analyzed shader/SPIR-V storage instead of copying it into every live draw
- reuse precomputed shader hashes and validate immutable shader analyses outside the global cache mutex
- keep diagnostic/failure-sensitive paths conservative and serial
- retain owned shader words when materializing captures for replay

The default pool uses up to eight total realization threads. `PROSPER_DRAW_REALIZE_THREADS` and `PROSPER_DRAW_REALIZE_MIN_DRAWS` tune it; `PROSPER_SERIAL_DRAW_REALIZE` restores the serial path.

## Performance

On the same dense Evergate opening route on Windows:

- draw realization: 125.7 ms -> 33.4 ms (about 73% lower)
- dense-section frame rate: 4.5-4.9 FPS -> 7.0-7.8 FPS
- identical 360-frame route: 47.2 s -> 36.8 s

This exposes frontend resource building and backend work as the next dominant costs; it does not claim the overall performance target is finished.

## Validation

- Windows MinGW `prosper-app` build
- focused AGC realization, shader-cache, capture, and executor tests
- full Linux suite: 114/114 passing
- Messenger scene snapshot: 29/29 qualifying and matching frames
- Evergate title snapshot: 9/9 qualifying and matching frames
- Dead Cells gameplay snapshot: 44/44 qualifying and matching frames
- Blasphemous 2 gameplay snapshot: 98/98 qualifying and matching frames