### PR TITLE
fix(audio): protect SDL stream during output (#855)

### DIFF
--- a/prosper/frontends/audio_sdl3/audio_sink_sdl3.cpp
+++ b/prosper/frontends/audio_sdl3/audio_sink_sdl3.cpp
@@ -58,13 +58,14 @@ public:
 
     void output(int port, const void* pcm, int frames) override {
         if (port < 1 || port > kMaxPorts) return;
-        SDL_AudioStream* stream; int frame_bytes; int freq;
-        std::chrono::steady_clock::time_point target;
+        int freq = 0;
+        std::chrono::steady_clock::time_point target{};
         {
             std::lock_guard<std::mutex> lk(mx_);
             Slot& s = slots_[port - 1];
-            stream = s.stream; frame_bytes = s.frame_bytes; freq = s.freq;
-            if (stream && freq > 0) {
+            if (!s.stream) return;
+            freq = s.freq;
+            if (freq > 0) {
                 // Pace EACH call one grain of wall-clock time apart (real sceAudioOutOutput blocks
                 // until the hardware ring frees one grain — evenly spaced, never bursty). The old
                 // cap-based pacing let the guest burst a whole device quantum (4+ grains) and then
@@ -78,9 +79,13 @@ public:
                 s.next += dur;
                 target = s.next;
             }
+            // Keep the stream protected until SDL has consumed this call. sceAudioOutOutput and
+            // sceAudioOutClose may run on different guest audio threads; copying s.stream out of
+            // the lock let close()/open()/quit() destroy it immediately before this call (#855).
+            // The pacing sleep remains outside the lock, so lifecycle calls wait only for SDL's
+            // synchronous queue copy rather than for an entire audio grain.
+            SDL_PutAudioStreamData(s.stream, pcm, frames * s.frame_bytes);
         }
-        if (!stream) return;
-        SDL_PutAudioStreamData(stream, pcm, frames * frame_bytes);
         if (freq > 0) std::this_thread::sleep_until(target);
     }
 

--- a/prosper/frontends/audio_sdl3/test_audio_sdl3.cpp
+++ b/prosper/frontends/audio_sdl3/test_audio_sdl3.cpp
@@ -5,9 +5,11 @@
 #include "../../src/hle/dispatch.hpp"
 #include "../../src/hle/nid.hpp"
 #include "../../src/hle/audio.hpp"
+#include <atomic>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
+#include <thread>
 #include <vector>
 
 using namespace prosper;
@@ -50,6 +52,36 @@ int main() {
         int vols[2] = { 20000, 20000 };
         CHECK(call("sceAudioOutSetVolume", (uint64_t)h, 0x3, PTR(vols)) == 0);
         CHECK(call("sceAudioOutClose", (uint64_t)h) == 0);
+
+        // Output and lifecycle calls can arrive from different guest audio threads. Exercise the
+        // exact #855 boundary repeatedly: close/reopen must not destroy an SDL_AudioStream while
+        // output() is queueing into it. Completion without a host fault is the lifetime contract;
+        // every dummy-device reopen must also succeed.
+        AudioPortInfo race_info;
+        race_info.grain = 1;
+        AudioSink* sink = audio_sink();
+        CHECK(sink->open(1, race_info));
+        std::atomic<bool> start{false};
+        std::atomic<int> outputs{0};
+        int16_t race_pcm[2] = {123, -123};
+        std::thread output_thread([&] {
+            while (!start.load(std::memory_order_acquire)) std::this_thread::yield();
+            for (int i = 0; i < 100; ++i) {
+                sink->output(1, race_pcm, 1);
+                outputs.fetch_add(1, std::memory_order_relaxed);
+            }
+        });
+        start.store(true, std::memory_order_release);
+        while (outputs.load(std::memory_order_acquire) == 0) std::this_thread::yield();
+        bool all_reopens_succeeded = true;
+        for (int i = 0; i < 50; ++i) {
+            sink->close(1);
+            all_reopens_succeeded &= sink->open(1, race_info);
+        }
+        output_thread.join();
+        CHECK(all_reopens_succeeded);
+        CHECK(outputs.load(std::memory_order_relaxed) == 100);
+        sink->close(1);
 
         shutdown_sdl3_audio_sink();
         CHECK(audio_sink() != nullptr);   // default silent sink restored


### PR DESCRIPTION
## Summary
- keep each SDL audio stream protected through `SDL_PutAudioStreamData`
- prevent concurrent guest Close/Open/shutdown from destroying a copied raw stream before use
- keep the audio-grain pacing sleep outside the lifecycle mutex
- stress concurrent output and close/reopen against SDL's dummy device

## Verification before PR
- `cmake --build prosper/build-mingw-app --target test_audio_sdl3 -j 2`
- `ctest --test-dir prosper/build-mingw-app -R audio_sdl3 --output-on-failure` (1/1 passed)
- `git diff --check`

## Scope
This addresses the concrete SDL stream-lifetime race in #855. It does not change the sparse-volume contract and does not claim the live game fault is fully resolved without a later Windows A/B. No snapshots or game runs were performed.