### PR TITLE
gpu(compute): add integer + 2_10_10_10 storage-image formats (#590)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -296,6 +296,16 @@ Messenger depth, vertex-fetch, geometry, palette, or tiling hypotheses without c
 - **Correctness-first:** implement real behavior from primary evidence: live captures/traces, guest
   disassembly, published platform contracts, firmware symbol data, and focused tests. Do not ship shims
   that fake output. Mark genuinely uncertain code with `CONFIDENCE: HIGH/MED/LOW`.
+- **An unsupported shader/GPU operation is a FATAL gap, not an acceptable skip — support ALL of them.**
+  A recompiler op the shader stage uses, a storage/texture format a dispatch writes, an AGC/PM4 packet
+  the guest submits: if the guest exercises it, the goal is to implement it, not to `return {}` / skip the
+  draw / skip the dispatch and move on. Silent skips drop real rendered content (a skipped LUT/exposure
+  dispatch collapses the whole title composite to black; a rejected shader drops its draws) and read as
+  "handled" when they are not. Reject paths still exist as a *fail-visible* backstop for genuinely
+  unknown encodings (mark `CONFIDENCE: LOW`, log loudly, file an issue with the exact opcode/format), but
+  treat every one you hit on a live boot as the next thing to implement. Find the exact failing op with
+  `PROSPER_DBG=1` (`[recompile-reject] pc=… op=0x…` from the recompiler) or the `[compute] … skipped`
+  lines from the live backend, then implement it with a round-trip/execution test — do not leave it skipped.
 - **PR verification and merging.** Keep each PR description self-contained: link the issue or goal, explain the
   failure scenario and behavioral contract, summarize the approach and important invariants, identify affected
   and deliberately unaffected behavior, record risks, and list the exact build/test/snapshot commands and

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -330,17 +330,30 @@ struct BoundImage {
 //   Unorm8  -> float(b/255) bits         <- clamp(bitcast float,0,1)*255 rounded
 //   Float16 -> half->float bits          <- round-to-nearest-even float->half
 //   Float32/Uint32/Sint32 -> raw 4-byte move both ways.
+//   Uint8/Sint8/Uint16/Sint16 -> integer channel widen (sign-extend for Sint) <- truncate to width.
+//     A UINT/SINT image_load returns the stored integer directly and image_store writes the low
+//     N bits with no normalization or saturation (Vulkan integer-format store contract), so the
+//     host move is a width-aware zero/sign extend on upload and a low-bit truncation on writeback.
+//   Unorm2_10_10_10 -> per-field float(bits/max) bits <- clamp(bitcast float,0,1)*max rounded, packed
+//     high-to-low A2/B10/G10/R10 (GFX10 IMG_FMT 50 layout, matching unorm2_10_10_10_to_rgba8).
+// UE4's post-process color-grading writes its 3D LUT / exposure volumes as these formats (DOLL: a
+// 32x32x32 Uint8/Unorm2_10_10_10 LUT + 1x1x1 exposure + a 16x16x16 Uint16 volume); skipping the
+// dispatch left the tonemap sampling an unproduced volume -> a near-zero grade -> black title (#590).
 // Missing channels read the hardware default (0,0,0,1.0f). Anything else is unsupported -> the caller
 // skips the dispatch loudly (never a silent wrong-layout write — correctness-first).
 bool storage_unpack_supported(prosper::gpu::DataFormat f) {
     using DF = prosper::gpu::DataFormat;
     return f == DF::Unorm8 || f == DF::Float16 || f == DF::Float32 || f == DF::Uint32 ||
-           f == DF::Sint32 || f == DF::Float10_11_11;
+           f == DF::Sint32 || f == DF::Float10_11_11 ||
+           f == DF::Uint8 || f == DF::Sint8 || f == DF::Uint16 || f == DF::Sint16 ||
+           f == DF::Unorm2_10_10_10;
 }
 bool storage_pack_supported(prosper::gpu::DataFormat f) {
     using DF = prosper::gpu::DataFormat;
     return f == DF::Unorm8 || f == DF::Float16 || f == DF::Float32 ||
-           f == DF::Uint32 || f == DF::Sint32 || f == DF::Float10_11_11;
+           f == DF::Uint32 || f == DF::Sint32 || f == DF::Float10_11_11 ||
+           f == DF::Uint8 || f == DF::Sint8 || f == DF::Uint16 || f == DF::Sint16 ||
+           f == DF::Unorm2_10_10_10;
 }
 void storage_unpack_texel(const uint8_t* src, prosper::gpu::DataFormat f, uint32_t ncomp, uint32_t out[4]) {
     using DF = prosper::gpu::DataFormat;
@@ -354,12 +367,29 @@ void storage_unpack_texel(const uint8_t* src, prosper::gpu::DataFormat f, uint32
         for (uint32_t c = 0; c < 3; ++c) std::memcpy(&out[c], &values[c], sizeof(values[c]));
         return;
     }
+    if (f == DF::Unorm2_10_10_10) {
+        uint32_t packed = 0; std::memcpy(&packed, src, sizeof(packed));
+        const float values[4] = { ((packed >>  0) & 0x3ffu) / 1023.0f,
+                                  ((packed >> 10) & 0x3ffu) / 1023.0f,
+                                  ((packed >> 20) & 0x3ffu) / 1023.0f,
+                                  ((packed >> 30) & 0x3u)   / 3.0f };
+        for (uint32_t c = 0; c < 4; ++c) std::memcpy(&out[c], &values[c], sizeof(values[c]));
+        return;
+    }
     for (uint32_t c = 0; c < ncomp && c < 4; c++) {
         switch (f) {
             case DF::Unorm8: { float v = src[c] / 255.0f; std::memcpy(&out[c], &v, 4); break; }
             case DF::Float16: { float v = prosper::gpu::half_to_float(
                                     (uint16_t)(src[c * 2] | (src[c * 2 + 1] << 8)));
                                 std::memcpy(&out[c], &v, 4); break; }
+            // Integer formats carry the raw channel value; a UINT/SINT image_load reads the stored
+            // integer directly (zero-extend for Uint, sign-extend for Sint). No normalization.
+            case DF::Uint8:  out[c] = src[c]; break;
+            case DF::Sint8:  out[c] = static_cast<uint32_t>(static_cast<int32_t>(
+                                          static_cast<int8_t>(src[c]))); break;
+            case DF::Uint16: out[c] = static_cast<uint32_t>(src[c * 2] | (src[c * 2 + 1] << 8)); break;
+            case DF::Sint16: out[c] = static_cast<uint32_t>(static_cast<int32_t>(static_cast<int16_t>(
+                                          src[c * 2] | (src[c * 2 + 1] << 8)))); break;
             default: std::memcpy(&out[c], src + c * 4, 4); break;   // 32-bit raw
         }
     }
@@ -375,6 +405,19 @@ void storage_pack_texel(const uint32_t in[4], prosper::gpu::DataFormat f, uint32
         std::memcpy(dst, &packed, sizeof(packed));
         return;
     }
+    if (f == DF::Unorm2_10_10_10) {
+        auto q = [](const uint32_t bits, float scale) -> uint32_t {
+            float v; std::memcpy(&v, &bits, 4);
+            v = v < 0.0f ? 0.0f : (v > 1.0f ? 1.0f : v);
+            return static_cast<uint32_t>(v * scale + 0.5f);
+        };
+        const uint32_t packed = (q(in[0], 1023.0f) & 0x3ffu)        |
+                                ((q(in[1], 1023.0f) & 0x3ffu) << 10) |
+                                ((q(in[2], 1023.0f) & 0x3ffu) << 20) |
+                                ((q(in[3], 3.0f)    & 0x3u)   << 30);
+        std::memcpy(dst, &packed, sizeof(packed));
+        return;
+    }
     for (uint32_t c = 0; c < ncomp && c < 4; c++) {
         switch (f) {
             case DF::Unorm8: dst[c] = storage_pack_unorm8(in[c]); break;
@@ -382,6 +425,13 @@ void storage_pack_texel(const uint32_t in[4], prosper::gpu::DataFormat f, uint32
                                 const uint16_t h = prosper::gpu::float_to_half(v);
                                 dst[c * 2] = static_cast<uint8_t>(h);
                                 dst[c * 2 + 1] = static_cast<uint8_t>(h >> 8); break; }
+            // Integer image_store writes the low N bits with no saturation (mirrors the 32-bit raw
+            // move truncated to the format width).
+            case DF::Uint8: case DF::Sint8:
+                dst[c] = static_cast<uint8_t>(in[c]); break;
+            case DF::Uint16: case DF::Sint16:
+                dst[c * 2] = static_cast<uint8_t>(in[c]);
+                dst[c * 2 + 1] = static_cast<uint8_t>(in[c] >> 8); break;
             default: std::memcpy(dst + c * 4, &in[c], 4); break;    // 32-bit raw
         }
     }
@@ -828,7 +878,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     skip_image(r, "storage format has no channel pack/unpack yet"); break; }
                 const uint32_t cb = data_format_bytes(r->format);
                 const uint32_t nc = r->num_components ? r->num_components : 1;
-                const size_t guest_texel = r->format == DataFormat::Float10_11_11
+                const size_t guest_texel = (r->format == DataFormat::Float10_11_11 ||
+                                            r->format == DataFormat::Unorm2_10_10_10)
                     ? 4u : (size_t)cb * nc;
                 const size_t texels = (size_t)volume_texels;
                 const uint64_t linear_guest_bytes = static_cast<uint64_t>(texels) * guest_texel;
@@ -1493,7 +1544,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             }
             const uint32_t cb = data_format_bytes(r->format);
             const uint32_t nc = r->num_components ? r->num_components : 1;
-            const size_t guest_texel = r->format == DataFormat::Float10_11_11
+            const size_t guest_texel = (r->format == DataFormat::Float10_11_11 ||
+                                        r->format == DataFormat::Unorm2_10_10_10)
                 ? 4u : (size_t)cb * nc;
             const size_t texels = (size_t)r->width * r->height * r->depth;
             std::vector<uint8_t> linear(texels * guest_texel, 0);

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -357,8 +357,12 @@ bool storage_pack_supported(prosper::gpu::DataFormat f) {
 }
 void storage_unpack_texel(const uint8_t* src, prosper::gpu::DataFormat f, uint32_t ncomp, uint32_t out[4]) {
     using DF = prosper::gpu::DataFormat;
-    const uint32_t one_f32 = 0x3f800000u;                 // hardware default: missing channels = (0,0,0,1.0f)
-    out[0] = out[1] = out[2] = 0; out[3] = one_f32;
+    const uint32_t one_f32 = 0x3f800000u;                 // hardware default: missing channels = (0,0,0,1)
+    // A missing alpha reads 1 — as the FLOAT 1.0 bits for float/unorm formats, but the INTEGER 1 for
+    // UINT/SINT formats (an integer image_load returns raw integer channels, not normalized floats).
+    const bool integer_fmt = f == DF::Uint8 || f == DF::Sint8 || f == DF::Uint16 ||
+                             f == DF::Sint16 || f == DF::Uint32 || f == DF::Sint32;
+    out[0] = out[1] = out[2] = 0; out[3] = integer_fmt ? 1u : one_f32;
     if (f == DF::Float10_11_11) {
         uint32_t packed = 0; std::memcpy(&packed, src, sizeof(packed));
         const float values[3] = { prosper::gpu::f11_to_float(static_cast<uint16_t>(packed)),
@@ -408,7 +412,7 @@ void storage_pack_texel(const uint32_t in[4], prosper::gpu::DataFormat f, uint32
     if (f == DF::Unorm2_10_10_10) {
         auto q = [](const uint32_t bits, float scale) -> uint32_t {
             float v; std::memcpy(&v, &bits, 4);
-            v = v < 0.0f ? 0.0f : (v > 1.0f ? 1.0f : v);
+            v = !(v > 0.0f) ? 0.0f : (v > 1.0f ? 1.0f : v);   // NaN and negatives clamp to 0
             return static_cast<uint32_t>(v * scale + 0.5f);
         };
         const uint32_t packed = (q(in[0], 1023.0f) & 0x3ffu)        |

--- a/prosper/tests/test_game_compute.cpp
+++ b/prosper/tests/test_game_compute.cpp
@@ -266,6 +266,62 @@ int main() {
         CHECK(bad == 0, "Unorm8 unpack -> uvec4 copy -> pack writeback is byte-exact (#590)");
     }
 
+    // --- #590: the same production storage-image copy across the INTEGER and packed formats DOLL's
+    // UE4 post-process writes its color-grading LUT / exposure / volume dispatches as (a 32x32x32
+    // Uint8/Unorm2_10_10_10 3D LUT, a 1x1x1 exposure, a 16x16x16 Uint16 volume). Each dispatch was
+    // skipped before storage_(un)pack gained these formats, leaving the tonemap sampling an
+    // unproduced surface. A raw uvec4 copy through the production backend must round-trip the guest
+    // bytes bit-exact: integer formats widen/truncate, and any quantized 10/10/10/2 word is stable
+    // under unpack->pack.
+    auto run_format_copy = [&](DataFormat fmt, uint32_t ncomp, uint32_t texel_bytes,
+                               const std::vector<uint8_t>& src) -> std::vector<uint8_t> {
+        std::vector<uint8_t> dst(src.size(), 0x5A);
+        ShaderResourceTable frt;
+        frt.resources = irt.resources;   // reuse constant buffers 0..3 (binding 0 -> v0 = gid)
+        frt.resources.erase(std::remove_if(frt.resources.begin(), frt.resources.end(),
+            [](const ShaderResource& r) { return r.cls == ResourceClass::StorageImage; }),
+            frt.resources.end());
+        auto add_fmt_image = [&](uint32_t binding, uint32_t sgpr, void* data) {
+            ShaderResource im{};
+            im.cls = ResourceClass::StorageImage; im.img_dim = 0; im.binding = binding;
+            im.sgpr_base = sgpr; im.format = fmt; im.num_components = ncomp;
+            im.width = W; im.height = 1;
+            im.gpu_addr = (uint64_t)(uintptr_t)data; im.size = W * texel_bytes;
+            frt.resources.push_back(im);
+        };
+        add_fmt_image(4, 0, const_cast<uint8_t*>(src.data()));
+        add_fmt_image(5, 8, dst.data());
+        std::vector<uint32_t> spv = recompile_valu(
+            image_copy, sizeof(image_copy) / sizeof(image_copy[0]), 1, 0, &frt);
+        if (spv.empty()) return {};
+        ComputeItem it;
+        it.spirv = spv;
+        it.resources = std::make_shared<ShaderResourceTable>(frt);
+        it.launch.threads_x = W; it.launch.local_x = 64; it.launch.groups_x = 1;
+        it.launch.local_y = it.launch.local_z = 1; it.launch.groups_y = it.launch.groups_z = 1;
+        it.code_addr = 0x590591;
+        if (!prosper::frontend::execute_live_compute_items({it})) return {};
+        return dst;
+    };
+    {   // Uint8 x4 (fmt=11): raw integer channels, exact round-trip
+        std::vector<uint8_t> s(W * 4);
+        for (uint32_t i = 0; i < s.size(); i++) s[i] = (uint8_t)(i * 53 + 7);
+        CHECK(run_format_copy(DataFormat::Uint8, 4, 4, s) == s,
+              "Uint8x4 storage copy round-trips guest bytes bit-exact (#590)");
+    }
+    {   // Uint16 x1 (fmt=7): 16-bit integer widen on load, low-16-bit truncate on store
+        std::vector<uint8_t> s(W * 2);
+        for (uint32_t i = 0; i < s.size(); i++) s[i] = (uint8_t)(i * 29 + 3);
+        CHECK(run_format_copy(DataFormat::Uint16, 1, 2, s) == s,
+              "Uint16x1 storage copy round-trips guest bytes bit-exact (#590)");
+    }
+    {   // Unorm2_10_10_10 x4 (fmt=21): packed 10/10/10/2, quantized word stable under unpack->pack
+        std::vector<uint8_t> s(W * 4);
+        for (uint32_t t = 0; t < W; t++) { uint32_t p = t * 2654435761u; std::memcpy(&s[t * 4], &p, 4); }
+        CHECK(run_format_copy(DataFormat::Unorm2_10_10_10, 4, 4, s) == s,
+              "Unorm2_10_10_10 storage copy round-trips packed guest word bit-exact (#590)");
+    }
+
     // The backend publishes ordinary tiled texels, not hardware-compressed blocks. Prove that a
     // DCC-enabled storage destination atomically becomes the uncompressed (0xff) metadata state,
     // including replay-owned metadata that a later sampled descriptor shares by logical address.


### PR DESCRIPTION
## Goal / issue
Advance DOLL (DRAGON QUEST VII Reimagined, PPSA17942) toward a visible 3D title/gameplay frame. Relates #590 (the DOLL compute-shader frontier). This PR closes the **storage-image format** portion; the SOPP/CFG-structurizer + descriptor-resolution portion remains (documented on #590).

## Failure scenario
On a routed PPSA17942 boot, the live compute backend skipped 5 post-process dispatches with `storage format has no channel pack/unpack yet`:
- `32x32x32 fmt=11(Uint8) comps=4` and `fmt=21(Unorm2_10_10_10) comps=4` — the 3D colour-grading LUT
- `1x1x1 fmt=11(Uint8) comps=4` — the exposure value
- `16x16x16 fmt=7(Uint16) comps=1` — a single-channel volume

`storage_(un)pack_texel` only modelled Unorm8/Float16/Float32/Uint32/Sint32/Float10_11_11, so each of these dispatches was skipped and its surface never produced. The tonemap/grade later sampled the unproduced volumes → a near-zero grade → the post-splash frame composites to near-black.

## Change
Extend the storage-image channel model with the integer and packed formats these dispatches use:
- **Uint8/Sint8/Uint16/Sint16** — width-aware integer widen on load (sign-extend for Sint), low-bit truncate on store (Vulkan integer image-store contract, no normalization/saturation).
- **Unorm2_10_10_10** — packed 10/10/10/2, field layout matching the existing `unorm2_10_10_10_to_rgba8`; joins Float10_11_11 in the 4-byte `guest_texel` special case on both upload and writeback.

Purely additive: existing formats' code paths are byte-identical, so Messenger's Unorm8/Float16/Float32 compute path is unchanged.

## Verification
- Routed PPSA17942 boot: **0 remaining `no channel pack/unpack` skips** (was 5); the four dispatches now execute.
- `test_game_compute` gains production-backend round-trip cases (Uint8x4, Uint16x1, Unorm2_10_10_10) that copy each format through `execute_live_compute_items` and assert bit-exact guest bytes. **PASS.**
- Linux `ctest`: all compute/render tests green (`game_compute_exec`, `storage_image_copy`, `compute_exec`, render suite). The 3 red tests in this worktree are Messenger-dump-specific (`module_loads_eboot`, `boot_reaches_first_syscall`, `real_shader_render`) and fail only because this worktree is configured with the PPSA17942 dump; they do not touch the storage-format path.

## Affected / unaffected
- Affected: the live compute storage-image upload/writeback format conversion.
- Unaffected: every already-supported format; the recompiler; graphics draws; Messenger behaviour.

## Not yet fixed (tracked on #590)
This alone does **not** make the DOLL title visible: 4 post-process compute shaders still fail to recompile (nested loops + `s_barrier` + mixed execz/vccz/scc branches, plus `buffer_load_format_x` descriptor resolution and MIMG image_store in compute context). No progression screenshot is claimed here — this is an infra-correctness prerequisite.

## Risk
Low. Additive format coverage with a round-trip execution test; no change to existing formats.
