### PR TITLE
fix(gpu): recover direct scalar buffer resources

### DIFF
--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -125,17 +125,18 @@ struct DynFetch {
     uint32_t instruction_format = UINT32_MAX;
 };
 
-// One descriptor-TABLE use recovered by the same const-fold (#294): UE4 shaders load their T#/S#/V#
+// One descriptor use recovered by the same const-fold (#294): shaders may load their T#/S#/V#
 // descriptors with `s_load_dwordx4/x8 sN, s[ptr:ptr+1], <imm>` from a resource table whose pointer
-// sits in the user-data SGPRs, then consume them (image_sample SRSRC/SSAMP, s_buffer_load SBASE).
+// sits in the user-data SGPRs, or consume a V# placed directly in their entry user SGPRs. They then
+// use those descriptors through image_sample SRSRC/SSAMP or s_buffer_load SBASE.
 // The recompiler tags such a load's dest SGPRs with the load IMMEDIATE (sreg_srt) and resolves the
 // consumer via by_srt_offset(imm) — so `key` here is exactly that immediate, and build_stage_table
 // turns each use into a ShaderResource with srt_offset = key.
 struct SrtUse {
     int kind = 0;                    // 0 = texture (t8, + s4 sampler when resolved), 1 = constant buffer (v4)
     uint32_t key = 0;                // the s_load immediate byte offset (== emit_alu's sreg_srt tag);
-                                     // 0xFFFFFFFF = key-less (register-SOFFSET / negative-imm load — the
-                                     // recompiler then resolves the use by its instruction pc instead)
+                                     // 0xFFFFFFFF = key-less (direct entry V#, register-SOFFSET, or
+                                     // negative-imm load; resolve by the exact instruction pc instead)
     std::array<uint32_t, 8> t8{};    // T# dwords as loaded (kind 0)
     std::array<uint32_t, 4> v4{};    // V# dwords as loaded (kind 1)
     uint32_t instruction_format = UINT32_MAX; // MTBUF BUF_FMT override for kind 1

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -1545,9 +1545,14 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                             current_key_known = false;
                         }
                     }
-                    if (current_known && current_key_known) {
+                    if (current_known) {
                         pending_srt_use.kind = 1;
-                        pending_srt_use.key = current_key;
+                        // A V# may live directly in the entry user SGPRs without an AGC sharp or
+                        // preceding s_load (Astro's title PS uses s[24:27] this way). Its four live
+                        // dwords are still exact; only the table-offset provenance is absent. Publish
+                        // that descriptor by the unambiguous consuming PC, matching direct MIMG/MUBUF
+                        // discovery, instead of forcing the recompiler onto an unbound fallback cbuf.
+                        pending_srt_use.key = current_key_known ? current_key : 0xFFFFFFFFu;
                         for (int k = 0; k < 4; ++k)
                             pending_srt_use.v4[(size_t)k] = val[(size_t)(sbase + k)];
                         pending_srt_use.use_pc = in.pc;

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -423,6 +423,53 @@ int main() {
           direct_uses[0].s4[0] == seed5d[8] && direct_uses[0].s4[3] == seed5d[11],
           "direct user-SGPR T#/S# dwords are preserved");
 
+    // Astro's title PS consumes a V# placed directly in s[24:27] with a scalar offset computed in
+    // VCC_LO. No s_load gives that descriptor an SRT key, and AGC metadata need not publish a sharp
+    // for it. The fold nevertheless knows all four entry dwords and the exact offset, so retain the
+    // resource by the consuming SMEM pc. The production resource path must then give the fragment
+    // recompiler a real binding instead of its unbound binding-2 fallback.
+    static uint32_t direct_sbuffer_payload[64]{};
+    const uint64_t direct_sbuffer_base =
+        static_cast<uint64_t>(reinterpret_cast<uintptr_t>(direct_sbuffer_payload));
+    uint32_t direct_sbuffer_seed[28]{};
+    direct_sbuffer_seed[24] = static_cast<uint32_t>(direct_sbuffer_base);
+    direct_sbuffer_seed[25] =
+        (static_cast<uint32_t>(direct_sbuffer_base >> 32) & 0xffffu) | (4u << 16);
+    direct_sbuffer_seed[26] = std::size(direct_sbuffer_payload);
+    direct_sbuffer_seed[27] = 4u << 12;
+    const uint32_t direct_sbuffer[] = {
+        0xbeea03ffu, 0x00000010u,   // s_mov_b32 vcc_lo, 16
+        0xf424000cu, 0xd4000004u,   // s_buffer_load_dwordx2 s[0:1], s[24:27], vcc_lo offset:4
+        0xbf810000u,
+    };
+    std::vector<SrtUse> direct_sbuffer_uses;
+    resolve_dynamic_fetch(direct_sbuffer, std::size(direct_sbuffer),
+                          direct_sbuffer_seed, std::size(direct_sbuffer_seed), 0,
+                          &direct_sbuffer_uses);
+    CHECK(direct_sbuffer_uses.size() == 1 && direct_sbuffer_uses[0].kind == 1 &&
+              direct_sbuffer_uses[0].key == 0xffffffffu &&
+              direct_sbuffer_uses[0].use_pc == 2 &&
+              direct_sbuffer_uses[0].required_size == 28 &&
+              direct_sbuffer_uses[0].v4[0] == direct_sbuffer_seed[24] &&
+              direct_sbuffer_uses[0].v4[1] == direct_sbuffer_seed[25],
+          "#1029: direct user-SGPR V# resolves scalar buffer load by exact pc");
+    ShaderResourceTable direct_sbuffer_table;
+    add_compute_buffer_resources(direct_sbuffer_table, direct_sbuffer,
+                                 std::size(direct_sbuffer), direct_sbuffer_seed,
+                                 std::size(direct_sbuffer_seed));
+    assign_convention_bindings(direct_sbuffer_table, 2);
+    ComputeShaderConfig direct_sbuffer_config;
+    direct_sbuffer_config.user_sgprs.assign(
+        direct_sbuffer_seed, direct_sbuffer_seed + std::size(direct_sbuffer_seed));
+    direct_sbuffer_config.local_x = direct_sbuffer_config.local_y =
+        direct_sbuffer_config.local_z = 1;
+    CHECK(direct_sbuffer_table.resources.size() == 1 &&
+              direct_sbuffer_table.by_fetch_pc(2) &&
+              direct_sbuffer_table.by_fetch_pc(2)->binding == 2 &&
+              !recompile_compute(direct_sbuffer, std::size(direct_sbuffer),
+                                 &direct_sbuffer_table, direct_sbuffer_config).empty(),
+          "#1029: pc-keyed direct scalar buffer is bound and recompiles");
+
     // Evergate's title PS uses a bounded PC-relative dispatch. An omitted alternative reloads the
     // same T# SGPRs that the selected arm consumes directly; a linear fold used to walk that reload
     // and attach the alternative texture to the selected image_sample's pc. Specialize the fold to


### PR DESCRIPTION
Closes #1029.

## What changed

- retain an exact four-dword V# that arrives directly in entry user SGPRs, even when it has no SRT-offset provenance
- key that resource by its exact scalar-buffer consumer PC, matching the existing keyless resource path
- add a production-path regression covering dynamic VCC_LO SOFFSET, resource construction/binding, and successful recompilation

## Astro Bot evidence

On current `master`, title PS `0x5002af200` rejected its `s_buffer_load_dwordx2` at PC 137 and fell back to unbound cbuf binding 2. With this change the same instruction resolves to a real binding (observed bindings 34/36 depending on draw) and compilation advances to the next unsupported instruction at PC 221 (`s_getpc_b64`).

This is a shader-resource correctness checkpoint, not visible progression: the diagnostic Linux frame is still black, so no screenshot is attached as progression evidence.

## Verification so far

- `test_dynfetch_fold`: PASS
- `test_agc_shader`: PASS
- `test_rdna2_to_spirv`: PASS
- negative control: reverting only the production condition makes both new #1029 assertions fail; restoring it passes
- live Linux Astro route reaches `title_controller_ship`, resolves PC 137, and advances the main title PS reject frontier to PC 221

Full Linux/Windows build, ctest, snapshot gate, CI, and independent review are being completed on this exact pushed head.