### PR TITLE
fix(loader): resolve imported TLS symbol offsets (#338)

### DIFF
--- a/prosper/src/loader/linker.cpp
+++ b/prosper/src/loader/linker.cpp
@@ -77,21 +77,22 @@ bool link_program(const std::vector<LinkInput>& inputs, uint64_t stub_base,
         }
     }
 
-    // --- TLS module-id by exported symbol NID (#136): so a cross-module DTPMOD64 (a TLS symbol
-    // imported from another module) resolves to the DEFINING module's TLS module id, not the
-    // relocating module's. Only TLS-bearing modules (tls_modid != 0) contribute their exported
-    // (defined, non-import) symbols. First definition wins (same rule as the global export table). ---
-    std::unordered_map<std::string, uint32_t> tls_modid_by_nid;
+    // --- TLS identity by exported symbol NID (#136/#338): a cross-module tls_index needs both the
+    // DEFINING module id (DTPMOD64) and the symbol's offset within that module's TLS block (DTPOFF64).
+    // Keeping them in one record prevents the pair from resolving through different definitions.
+    // Only TLS-bearing modules contribute defined exports. First definition wins, matching exports. ---
+    TlsSymbolMap tls_symbols_by_nid;
     for (size_t i = 0; i < out.mods.size(); i++) {
         uint32_t mid = out.imgs[i].tls_modid;
         if (!mid) continue;
         for (auto& s : out.mods[i]->symbols)
-            if (!s.is_import && !s.nid.empty()) tls_modid_by_nid.emplace(s.nid, mid);
+            if (!s.is_import && !s.nid.empty())
+                tls_symbols_by_nid.emplace(s.nid, TlsSymbolLocation{ mid, s.value });
     }
 
     // --- Pass 3: apply relocations now that all import addresses are known. ---
     for (size_t i = 0; i < out.mods.size(); i++)
-        apply_relocations(*out.mods[i], out.imgs[i], &tls_modid_by_nid);
+        apply_relocations(*out.mods[i], out.imgs[i], &tls_symbols_by_nid);
 
     // --- Collect init functions for dependent modules (module 0 = main exe runs its
     // own ctors via _start; PRX modules need their init_array run by the loader). We run

--- a/prosper/src/self/module.cpp
+++ b/prosper/src/self/module.cpp
@@ -255,7 +255,7 @@ void bind_imports_to_stubs(const Module& m, LoadedImage& img, uint64_t stub_base
 }
 
 size_t apply_relocations(const Module& m, LoadedImage& img,
-                         const std::unordered_map<std::string, uint32_t>* tls_modid_by_nid) {
+                         const TlsSymbolMap* tls_symbols_by_nid) {
     size_t applied = 0;
     auto write64 = [&](uint64_t va, uint64_t val) -> bool {
         uint8_t* p = img.at(va);
@@ -302,16 +302,16 @@ size_t apply_relocations(const Module& m, LoadedImage& img,
             // calls __tls_get_addr(tls_index*) which our HLE resolves to a per-thread block. For a
             // module-LOCAL TLS symbol the module id is THIS module's assigned id (the common case:
             // libc's own errno/locale state). A cross-module TLS ref (an IMPORT symbol defined in
-            // another module) needs the DEFINING module's id — resolved via tls_modid_by_nid when
-            // the linker supplies it (#136), else logged unhandled with a best-effort local fallback
-            // (previously it silently used the wrong module's id). DTPOFF64 = offset within the block.
+            // another module) needs the DEFINING module's id and in-block symbol offset — resolved
+            // together via tls_symbols_by_nid when the linker supplies it (#136/#338), else logged
+            // unhandled with a best-effort local fallback. DTPOFF64 = offset within the block.
             case R_X86_64_DTPMOD64: {
                 uint32_t modid = img.tls_modid;
                 if (r.sym && r.sym < m.symbols.size() && m.symbols[r.sym].is_import) {
                     bool resolved = false;
-                    if (tls_modid_by_nid) {
-                        auto it = tls_modid_by_nid->find(m.symbols[r.sym].nid);
-                        if (it != tls_modid_by_nid->end()) { modid = it->second; resolved = true; }
+                    if (tls_symbols_by_nid) {
+                        auto it = tls_symbols_by_nid->find(m.symbols[r.sym].nid);
+                        if (it != tls_symbols_by_nid->end()) { modid = it->second.modid; resolved = true; }
                     }
                     if (!resolved) {
                         unhandled[r.type]++;
@@ -328,6 +328,20 @@ size_t apply_relocations(const Module& m, LoadedImage& img,
                 // psABI: DTPOFF64 = S + A. The addend addresses a field INSIDE the TLS object
                 // (e.g. a struct member); picking S *or* A drops it and resolves to the object base.
                 uint64_t sv = (r.sym && r.sym < m.symbols.size()) ? m.symbols[r.sym].value : 0;
+                if (r.sym && r.sym < m.symbols.size() && m.symbols[r.sym].is_import) {
+                    bool resolved = false;
+                    if (tls_symbols_by_nid) {
+                        auto it = tls_symbols_by_nid->find(m.symbols[r.sym].nid);
+                        if (it != tls_symbols_by_nid->end()) { sv = it->second.offset; resolved = true; }
+                    }
+                    if (!resolved) {
+                        unhandled[r.type]++;
+                        if (getenv("PROSPER_RELOC_HISTO"))
+                            fprintf(stderr, "[reloc]   DTPOFF64 cross-module TLS import '%s' unresolved "
+                                    "-> best-effort zero symbol offset\n",
+                                    m.symbols[r.sym].nid.c_str());
+                    }
+                }
                 if (write64(va, sv + (uint64_t)r.addend)) applied++;
                 break;
             }

--- a/prosper/src/self/module.hpp
+++ b/prosper/src/self/module.hpp
@@ -54,6 +54,15 @@ struct Import {            // one unresolved external symbol
     uint32_t    sym_index = 0;
 };
 
+// Defining-module identity for a TLS export. DTPMOD64 and DTPOFF64 form one tls_index pair, so
+// they must resolve through the same record: the module id selects the per-thread block and the
+// offset selects the exported object within that block.
+struct TlsSymbolLocation {
+    uint32_t modid = 0;
+    uint64_t offset = 0;
+};
+using TlsSymbolMap = std::unordered_map<std::string, TlsSymbolLocation>;
+
 // ---- a parsed module -------------------------------------------------------
 struct Module {
     std::string path;
@@ -130,11 +139,11 @@ void bind_imports_to_stubs(const Module& m, LoadedImage& img,
 
 // Apply all relocations into img.mem. Symbol relocs use img.import_addr for imports
 // and the module's own symbol values for internal defs. Returns #applied.
-// `tls_modid_by_nid` (optional) maps an exported symbol's NID to its defining module's TLS module
-// id, so a cross-module DTPMOD64 (a TLS reference imported from another module) resolves to the
-// RIGHT module's TLS block instead of this one's (#136). Null -> module-local resolution only
-// (correct for the common case; a cross-module TLS import is then logged unhandled).
+// `tls_symbols_by_nid` (optional) maps an exported TLS symbol's NID to its defining module id and
+// in-block offset. Cross-module DTPMOD64/DTPOFF64 relocations must use both halves of the same record
+// so __tls_get_addr selects the right module and object (#136/#338). Null -> module-local resolution
+// only (correct for the common case; a cross-module TLS import is then logged unhandled).
 size_t apply_relocations(const Module& m, LoadedImage& img,
-                         const std::unordered_map<std::string, uint32_t>* tls_modid_by_nid = nullptr);
+                         const TlsSymbolMap* tls_symbols_by_nid = nullptr);
 
 } // namespace prosper

--- a/prosper/tests/test_dtpmod_tls.cpp
+++ b/prosper/tests/test_dtpmod_tls.cpp
@@ -1,6 +1,6 @@
-// test_dtpmod_tls — DTPMOD64 must resolve a cross-module TLS reference to the DEFINING module's
-// TLS module id, not the relocating module's (#136). A module-local TLS symbol keeps this module's
-// id. Builds synthetic Module + LoadedImage (no game dump) and drives apply_relocations directly.
+// test_dtpmod_tls — the DTPMOD64/DTPOFF64 tls_index pair must resolve a cross-module TLS reference
+// to the DEFINING module's id and in-block symbol offset, not the relocating module/zero import
+// value (#136/#338). Builds synthetic Module + LoadedImage and drives apply_relocations directly.
 #include "../src/self/module.hpp"
 #include <cstdio>
 #include <cstdint>
@@ -21,13 +21,15 @@ int main() {
     printf("== test_dtpmod_tls ==\n");
 
     // Module with TLS assigned id 5; symbol[1] is a cross-module TLS IMPORT (nid "TLSX"),
-    // symbol[2] is a module-local TLS def. Two DTPMOD64 relocs, one per symbol.
+    // symbol[2] is a module-local TLS def. Each symbol gets the paired module/offset relocations.
     Module m;
     m.symbols.resize(3);
     m.symbols[1].nid = "TLSX"; m.symbols[1].is_import = true;  m.symbols[1].value = 0;
     m.symbols[2].nid = "local"; m.symbols[2].is_import = false; m.symbols[2].value = 0x40;
     m.relocs.push_back({ /*offset*/ 0x00, R_X86_64_DTPMOD64, /*sym*/ 1, /*addend*/ 0, false });
     m.relocs.push_back({ /*offset*/ 0x08, R_X86_64_DTPMOD64, /*sym*/ 2, /*addend*/ 0, false });
+    m.relocs.push_back({ /*offset*/ 0x10, R_X86_64_DTPOFF64, /*sym*/ 1, /*addend*/ 0x18, false });
+    m.relocs.push_back({ /*offset*/ 0x18, R_X86_64_DTPOFF64, /*sym*/ 2, /*addend*/ 0x08, false });
 
     auto make_img = [&]() {
         LoadedImage img;
@@ -39,30 +41,40 @@ int main() {
 
     // 1. WITH the resolver map: the import "TLSX" is defined by module id 9.
     {
-        std::unordered_map<std::string, uint32_t> tls_by_nid{ {"TLSX", 9} };
+        TlsSymbolMap tls_by_nid{ {"TLSX", { /*modid*/ 9, /*offset*/ 0x88 }} };
         LoadedImage img = make_img();
         size_t applied = apply_relocations(m, img, &tls_by_nid);
-        CHECK(applied == 2, "both DTPMOD64 relocs applied");
+        CHECK(applied == 4, "both tls_index pairs applied");
         CHECK(rd64(img, 0x00) == 9, "cross-module TLS import resolves to the DEFINING module id (9), not 5");
         CHECK(rd64(img, 0x08) == 5, "module-local TLS resolves to this module's id (5)");
+        CHECK(rd64(img, 0x10) == 0xa0,
+              "cross-module TLS import resolves to defining symbol offset 0x88 plus addend 0x18");
+        CHECK(rd64(img, 0x18) == 0x48,
+              "module-local TLS offset remains local symbol value 0x40 plus addend 0x08");
     }
 
     // 2. WITHOUT a resolver (the old behavior / a table-less caller): the import can't be resolved,
     //    so it falls back to the local id AND is counted unhandled — no longer a silent mis-resolve.
     {
         LoadedImage img = make_img();
-        size_t applied = apply_relocations(m, img, /*tls_modid_by_nid*/ nullptr);
+        size_t applied = apply_relocations(m, img, /*tls_symbols_by_nid*/ nullptr);
         CHECK(rd64(img, 0x00) == 5, "no resolver: cross-module import falls back to local id (documented)");
         CHECK(rd64(img, 0x08) == 5, "no resolver: module-local TLS still resolves to the local id");
+        CHECK(rd64(img, 0x10) == 0x18,
+              "no resolver: cross-module offset falls back to zero symbol value plus addend");
+        CHECK(rd64(img, 0x18) == 0x48,
+              "no resolver: module-local TLS offset is still resolved locally");
         (void)applied;
     }
 
     // 3. An unknown import (not in the map) also falls back + logs, never mis-resolves silently.
     {
-        std::unordered_map<std::string, uint32_t> tls_by_nid{ {"OTHER", 7} };
+        TlsSymbolMap tls_by_nid{ {"OTHER", { /*modid*/ 7, /*offset*/ 0x30 }} };
         LoadedImage img = make_img();
         apply_relocations(m, img, &tls_by_nid);
         CHECK(rd64(img, 0x00) == 5, "import absent from the map falls back to the local id");
+        CHECK(rd64(img, 0x10) == 0x18,
+              "import absent from the map falls back to zero symbol offset plus addend");
     }
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }


### PR DESCRIPTION
## Problem

A cross-module general-dynamic TLS reference is relocated as a `tls_index { module_id, offset }` pair. prosper already resolves `R_X86_64_DTPMOD64` through the defining module, but `R_X86_64_DTPOFF64` still reads the importing symbol's local value (`0`). For any exported TLS object at a nonzero in-block offset, `__tls_get_addr` therefore selects the right module but the wrong object.

Part of #338. This deliberately does not implement the separate, currently unexercised `R_X86_64_TPOFF64` static-TLS relocation.

## Change

- replace the module-ID-only resolver with one TLS symbol record containing both defining module ID and in-block symbol offset
- resolve both halves of the `DTPMOD64`/`DTPOFF64` pair through that same first-definition-wins record
- retain documented best-effort fallback and unhandled accounting when a table-less caller or unknown NID cannot resolve an import
- extend the synthetic relocation regression to cover imported/local pairs, nonzero symbol values, addends, missing resolver state, and unknown NIDs

The new imported-offset assertion is non-vacuous: without the implementation it receives `0x18` (addend only) instead of `0xA0` (`0x88` defining offset + `0x18` addend).

## Invariants / risk

- module-local TLS relocation behavior is unchanged
- export conflict behavior remains first-definition-wins, matching the global export table
- renderer, game routes, and desktop frontends are unaffected
- no snapshot workflow is applicable or was run

## Focused verification

- Linux: built `test_dtpmod_tls`; `ctest -R '^dtpmod_tls_cross_module$' --output-on-failure` — PASS 1/1
- Windows MinGW: built `test_dtpmod_tls`; `ctest -R '^dtpmod_tls_cross_module$' --output-on-failure` — PASS 1/1
- `git diff --check` — PASS

Full exact-head author verification and independent inspection follow on the published PR, per project process.