### PR TITLE
loader: resolve TPOFF64 from shared TLS layout

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -144,8 +144,8 @@ if(TARGET prosper_core)
     add_test(NAME guest_tls_align COMMAND test_guest_tls_align)
   endif()
 
-  # DTPMOD64 cross-module TLS resolution (#136): a TLS import resolves to the DEFINING module's
-  # tls_modid, not the relocating module's. Pure unit test (synthetic Module/LoadedImage).
+  # Cross-module TLS resolution (#136/#338): dynamic and initial-exec relocations resolve through
+  # the DEFINING module's id, symbol offset, and shared static layout. Pure synthetic unit test.
   add_executable(test_dtpmod_tls tests/test_dtpmod_tls.cpp)
   target_link_libraries(test_dtpmod_tls PRIVATE prosper_core)
   add_test(NAME dtpmod_tls_cross_module COMMAND test_dtpmod_tls)

--- a/prosper/src/host/boot_program.cpp
+++ b/prosper/src/host/boot_program.cpp
@@ -120,9 +120,11 @@ bool boot_program(const std::string& d, Program& p, std::string* err,
 
     set_app0_root(d);
     for (auto& img : p.imgs) if (!map_image(img, &e)) return fail("map failed: " + e);
-    { std::vector<TlsModuleDesc> td; for (auto& t : p.tls_templates) td.push_back({t.init_va, t.filesz, t.memsz, t.align});
-      set_tls_modules(td.data(), td.size());              // __tls_get_addr for loaded modules (real libc.prx)
-      guest_tls_set_templates(td.data(), td.size()); }    // guest initial-exec %fs TLS (Linux/Windows default on)
+    {
+        // General-dynamic and initial-exec TLS consume the same descriptors and module-id order.
+        set_tls_modules(p.tls_templates.data(), p.tls_templates.size());
+        guest_tls_set_templates(p.tls_templates.data(), p.tls_templates.size());
+    }
 
     // C++ exception unwinding: give each module's .eh_frame_hdr + text segment to the unwinder.
     { static std::vector<std::string> names; names.reserve(p.imgs.size());

--- a/prosper/src/host/guest_tls.cpp
+++ b/prosper/src/host/guest_tls.cpp
@@ -13,6 +13,7 @@
 // (exec_image_linux.cpp), which read the stashed host %fs from [guestTP + GUEST_TCB_HOSTFS_OFF].
 #if defined(__linux__) || defined(__APPLE__)
 #include "../hle/dispatch.hpp"
+#include "../loader/tls_layout.hpp"
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
@@ -28,7 +29,6 @@ namespace {
     bool     g_enabled = false;
     bool     g_configured = false;
 
-    inline uint64_t align_up(uint64_t v, uint64_t a) { return a ? (v + a - 1) & ~(a - 1) : v; }
     inline uint64_t rd_fsbase() { uint64_t v; __asm__ volatile("rdfsbase %0" : "=r"(v)); return v; }
     inline void     wr_fsbase(uint64_t v) { __asm__ volatile("wrfsbase %0" : : "r"(v)); }
 }
@@ -67,17 +67,9 @@ void guest_tls_set_templates(const TlsModuleDesc* descs, size_t count) {
     // block at the wrong offset -> every %fs:-N read resolved off (#143). For the common p_align<=16
     // case the per-module offsets are identical to before (round_up up a 16-multiple running total by
     // 16 == the old per-size rounding), so nothing changes there.
-    g_below.assign(g_mods.size(), 0);
-    uint64_t off = 0, max_align = 16;
-    for (size_t i = 1; i < g_mods.size(); i++) {
-        uint64_t a = g_mods[i].align ? g_mods[i].align : 16;
-        if (a > max_align) max_align = a;
-        off = align_up(off + g_mods[i].memsz, a);
-        g_below[i] = off;
-    }
-    // Round the total (hence the TP position within the page-aligned block) up to the max module
-    // align, with a 64-byte floor preserved from the original (TCB/cache-line headroom).
-    g_total_below = align_up(off, max_align < 64 ? 64 : max_align);
+    const StaticTlsLayout layout = make_static_tls_layout(g_mods.data(), g_mods.size());
+    g_below = layout.module_below;
+    g_total_below = layout.total_below;
     g_configured = true;
     if (getenv("PROSPER_TLSLOG"))
         fprintf(stderr, "[tls] guest-fs %s; static TLS below TP = 0x%llx bytes\n",
@@ -219,6 +211,7 @@ uint64_t guest_tls_total_below() { return g_total_below; }
 #define WIN32_LEAN_AND_MEAN
 #endif
 #include "../hle/dispatch.hpp"
+#include "../loader/tls_layout.hpp"
 #include <windows.h>
 #include <cstdint>
 #include <cstddef>
@@ -235,7 +228,6 @@ namespace {
     bool g_enabled = false, g_configured = false;
     thread_local uint64_t t_guest_tp = 0;
 
-    inline uint64_t align_up(uint64_t v, uint64_t a) { return a ? (v + a - 1) & ~(a - 1) : v; }
     inline uint64_t rd_fsbase() { uint64_t v; __asm__ volatile("rdfsbase %0" : "=r"(v)); return v; }
     inline void     wr_fsbase(uint64_t v) { __asm__ volatile("wrfsbase %0" : : "r"(v)); }
 }
@@ -250,15 +242,9 @@ void guest_tls_set_templates(const TlsModuleDesc* descs, size_t count) {
     // x86-64 Variant II static-TLS layout (same math as the Linux path): each module's block sits
     // BELOW the thread pointer at a distance rounded to its PT_TLS p_align, so a symbol at byte X
     // reads at %fs:(X - off[i]) — exactly the tpoff the guest static linker baked in.
-    g_below.assign(g_mods.size(), 0);
-    uint64_t off = 0, max_align = 16;
-    for (size_t i = 1; i < g_mods.size(); i++) {
-        uint64_t a = g_mods[i].align ? g_mods[i].align : 16;
-        if (a > max_align) max_align = a;
-        off = align_up(off + g_mods[i].memsz, a);
-        g_below[i] = off;
-    }
-    g_total_below = align_up(off, max_align < 64 ? 64 : max_align);
+    const StaticTlsLayout layout = make_static_tls_layout(g_mods.data(), g_mods.size());
+    g_below = layout.module_below;
+    g_total_below = layout.total_below;
     g_configured = true;
     if (getenv("PROSPER_TLSLOG"))
         fprintf(stderr, "[tls] guest-fs %s (win/fsgsbase); static TLS below TP = 0x%llx bytes\n",

--- a/prosper/src/loader/linker.cpp
+++ b/prosper/src/loader/linker.cpp
@@ -1,4 +1,5 @@
 #include "linker.hpp"
+#include "tls_layout.hpp"
 #include <unordered_map>
 #include <cstring>
 #include <cstdio>
@@ -90,9 +91,15 @@ bool link_program(const std::vector<LinkInput>& inputs, uint64_t stub_base,
                 tls_symbols_by_nid.emplace(s.nid, TlsSymbolLocation{ mid, s.value });
     }
 
+    // Initial-exec TLS relocations must use the exact Variant-II layout later used to allocate each
+    // thread's static TLS. Computing it through the shared helper prevents linker/allocator drift.
+    const StaticTlsLayout static_tls =
+        make_static_tls_layout(out.tls_templates.data(), out.tls_templates.size());
+
     // --- Pass 3: apply relocations now that all import addresses are known. ---
     for (size_t i = 0; i < out.mods.size(); i++)
-        apply_relocations(*out.mods[i], out.imgs[i], &tls_symbols_by_nid);
+        apply_relocations(*out.mods[i], out.imgs[i], &tls_symbols_by_nid,
+                          &static_tls.module_below);
 
     // --- Collect init functions for dependent modules (module 0 = main exe runs its
     // own ctors via _start; PRX modules need their init_array run by the loader). We run

--- a/prosper/src/loader/linker.hpp
+++ b/prosper/src/loader/linker.hpp
@@ -15,17 +15,12 @@ namespace prosper {
 
 struct LinkInput { std::string path; uint64_t base; };
 
-// Per-module TLS template for the general-dynamic model (__tls_get_addr). init_va points at the
-// module's mapped tdata (guest==host address, since we map at guest base); a per-thread block of
-// `memsz` is allocated lazily, `filesz` bytes copied from init_va, the rest zeroed (tbss).
-struct TlsTemplate { uint64_t init_va = 0, filesz = 0, memsz = 0, align = 0; };
-
 struct Program {
     std::vector<std::unique_ptr<Module>> mods;   // unique_ptr: stable addresses for imports[]
     std::vector<LoadedImage>             imgs;    // parallel to mods
     std::vector<ImportSlot>              slots;   // unresolved imports -> stub slots
     std::vector<uint64_t>                init_fns; // dependent-module init fns, in call order
-    std::vector<TlsTemplate>             tls_templates; // indexed by module TLS id (0 = unused)
+    std::vector<TlsModuleDesc>           tls_templates; // indexed by module TLS id (0 = unused)
     uint64_t entry = 0;                            // main module entry
     uint64_t stub_base = 0, stub_size = 96;   // 96 contains the largest guest-%fs swap stub (94 bytes)
 

--- a/prosper/src/loader/tls_layout.hpp
+++ b/prosper/src/loader/tls_layout.hpp
@@ -1,0 +1,42 @@
+// tls_layout.hpp — pure x86-64 Variant-II static-TLS layout shared by the linker and allocator.
+#pragma once
+
+#include "../hle/dispatch.hpp"
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace prosper {
+
+struct StaticTlsLayout {
+    // Distance from the thread pointer to each module's block start. Index 0 is reserved.
+    std::vector<uint64_t> module_below;
+    uint64_t total_below = 0;
+};
+
+inline uint64_t static_tls_align_up(uint64_t value, uint64_t align) {
+    return align ? (value + align - 1) & ~(align - 1) : value;
+}
+
+// x86-64 Variant II (TLS_TCB_AT_TP): modules are packed below TP in module-id order. A symbol at
+// in-block byte S therefore has a thread-pointer-relative offset S - module_below[modid]. Keeping
+// this calculation shared is correctness-critical: the linker-baked TPOFF64 value and the runtime
+// allocator must describe the same byte.
+inline StaticTlsLayout make_static_tls_layout(const TlsModuleDesc* descs, size_t count) {
+    StaticTlsLayout layout;
+    layout.module_below.assign(count, 0);
+    if (!descs || count == 0) return layout;
+
+    uint64_t offset = 0;
+    uint64_t max_align = 16;
+    for (size_t i = 1; i < count; i++) {
+        const uint64_t align = descs[i].align ? descs[i].align : 16;
+        if (align > max_align) max_align = align;
+        offset = static_tls_align_up(offset + descs[i].memsz, align);
+        layout.module_below[i] = offset;
+    }
+    layout.total_below = static_tls_align_up(offset, max_align < 64 ? 64 : max_align);
+    return layout;
+}
+
+} // namespace prosper

--- a/prosper/src/self/module.cpp
+++ b/prosper/src/self/module.cpp
@@ -255,7 +255,8 @@ void bind_imports_to_stubs(const Module& m, LoadedImage& img, uint64_t stub_base
 }
 
 size_t apply_relocations(const Module& m, LoadedImage& img,
-                         const TlsSymbolMap* tls_symbols_by_nid) {
+                         const TlsSymbolMap* tls_symbols_by_nid,
+                         const std::vector<uint64_t>* tls_module_below) {
     size_t applied = 0;
     auto write64 = [&](uint64_t va, uint64_t val) -> bool {
         uint8_t* p = img.at(va);
@@ -345,13 +346,48 @@ size_t apply_relocations(const Module& m, LoadedImage& img,
                 if (write64(va, sv + (uint64_t)r.addend)) applied++;
                 break;
             }
+            case R_X86_64_TPOFF64: {
+                // x86-64 Variant II: TPOFF64 = S + A - distance(TP, defining module block).
+                // The distance comes from the same helper used by guest_tls_set_templates, so the
+                // linker-baked offset and runtime allocation cannot independently drift (#338).
+                uint32_t modid = img.tls_modid;
+                uint64_t sv = 0;
+                bool resolved = r.sym && r.sym < m.symbols.size();
+                if (resolved) {
+                    const Symbol& sym = m.symbols[r.sym];
+                    sv = sym.value;
+                    if (sym.is_import) {
+                        resolved = false;
+                        if (tls_symbols_by_nid) {
+                            auto it = tls_symbols_by_nid->find(sym.nid);
+                            if (it != tls_symbols_by_nid->end()) {
+                                modid = it->second.modid;
+                                sv = it->second.offset;
+                                resolved = true;
+                            }
+                        }
+                    }
+                }
+                resolved = resolved && modid != 0 && tls_module_below &&
+                           modid < tls_module_below->size() && (*tls_module_below)[modid] != 0;
+                if (!resolved) {
+                    uint64_t& cnt = unhandled[r.type];
+                    if (cnt == 0)
+                        fprintf(stderr, "[reloc] WARNING: unresolved TPOFF64 in %s — "
+                                "static TLS offset left unapplied (issue #338)\n", m.path.c_str());
+                    cnt++;
+                    break;
+                }
+                const uint64_t tpoff = sv + (uint64_t)r.addend - (*tls_module_below)[modid];
+                if (write64(va, tpoff)) applied++;
+                break;
+            }
             default: {
                 // Make an unhandled TLS relocation LOUD (once per type) even without
                 // PROSPER_RELOC_HISTO: a silently-skipped TLS reloc leaves the GOT slot 0, so the guest
                 // reads/writes thread-local storage at the wrong (often zero) offset and corrupts it
-                // INVISIBLY. The notable gap is TPOFF64 (18) — declared in module.hpp but with no case
-                // here (its correct value needs the guest static-TLS layout; types 19-23 are other TLS
-                // models). No current title emits these (verified), so this never fires today; when one
+                // INVISIBLY. Types 19-23 are other unsupported TLS models. No current title emits
+                // these (verified), so this never fires today; when one
                 // does, it fails visibly instead of silently corrupting TLS. #338.
                 uint64_t& cnt = unhandled[r.type];
                 if (cnt == 0 && r.type >= 16 && r.type <= 23)
@@ -367,7 +403,7 @@ size_t apply_relocations(const Module& m, LoadedImage& img,
                 (unsigned long long)img.base, m.relocs.size(), applied);
         for (auto& kv : histo)
             fprintf(stderr, "[reloc]   type %u: %llu%s\n", kv.first, (unsigned long long)kv.second,
-                    unhandled.count(kv.first) ? "  <<< UNHANDLED (silently skipped)" : "");
+                    unhandled.count(kv.first) ? "  <<< UNHANDLED/FALLBACK" : "");
     }
     return applied;
 }

--- a/prosper/src/self/module.hpp
+++ b/prosper/src/self/module.hpp
@@ -140,10 +140,11 @@ void bind_imports_to_stubs(const Module& m, LoadedImage& img,
 // Apply all relocations into img.mem. Symbol relocs use img.import_addr for imports
 // and the module's own symbol values for internal defs. Returns #applied.
 // `tls_symbols_by_nid` (optional) maps an exported TLS symbol's NID to its defining module id and
-// in-block offset. Cross-module DTPMOD64/DTPOFF64 relocations must use both halves of the same record
-// so __tls_get_addr selects the right module and object (#136/#338). Null -> module-local resolution
-// only (correct for the common case; a cross-module TLS import is then logged unhandled).
+// in-block offset. Cross-module TLS relocations must use both halves of the same record. TPOFF64 also
+// requires `tls_module_below`, the shared Variant-II distance below TP indexed by module id. Missing
+// information is logged and left unapplied rather than baking a silently incorrect static offset.
 size_t apply_relocations(const Module& m, LoadedImage& img,
-                         const TlsSymbolMap* tls_symbols_by_nid = nullptr);
+                         const TlsSymbolMap* tls_symbols_by_nid = nullptr,
+                         const std::vector<uint64_t>* tls_module_below = nullptr);
 
 } // namespace prosper

--- a/prosper/tests/test_dtpmod_tls.cpp
+++ b/prosper/tests/test_dtpmod_tls.cpp
@@ -1,11 +1,13 @@
-// test_dtpmod_tls — the DTPMOD64/DTPOFF64 tls_index pair must resolve a cross-module TLS reference
-// to the DEFINING module's id and in-block symbol offset, not the relocating module/zero import
-// value (#136/#338). Builds synthetic Module + LoadedImage and drives apply_relocations directly.
+// test_dtpmod_tls — dynamic and initial-exec TLS relocations must resolve a cross-module reference
+// through the DEFINING module's id, in-block symbol offset, and shared static layout (#136/#338).
+// Builds a synthetic Module + LoadedImage and drives apply_relocations directly.
 #include "../src/self/module.hpp"
+#include "../src/loader/tls_layout.hpp"
 #include <cstdio>
 #include <cstdint>
 #include <cstring>
 #include <unordered_map>
+#include <vector>
 
 using namespace prosper;
 
@@ -23,6 +25,7 @@ int main() {
     // Module with TLS assigned id 5; symbol[1] is a cross-module TLS IMPORT (nid "TLSX"),
     // symbol[2] is a module-local TLS def. Each symbol gets the paired module/offset relocations.
     Module m;
+    m.path = "synthetic-tls-module";
     m.symbols.resize(3);
     m.symbols[1].nid = "TLSX"; m.symbols[1].is_import = true;  m.symbols[1].value = 0;
     m.symbols[2].nid = "local"; m.symbols[2].is_import = false; m.symbols[2].value = 0x40;
@@ -30,6 +33,18 @@ int main() {
     m.relocs.push_back({ /*offset*/ 0x08, R_X86_64_DTPMOD64, /*sym*/ 2, /*addend*/ 0, false });
     m.relocs.push_back({ /*offset*/ 0x10, R_X86_64_DTPOFF64, /*sym*/ 1, /*addend*/ 0x18, false });
     m.relocs.push_back({ /*offset*/ 0x18, R_X86_64_DTPOFF64, /*sym*/ 2, /*addend*/ 0x08, false });
+    m.relocs.push_back({ /*offset*/ 0x20, R_X86_64_TPOFF64, /*sym*/ 1, /*addend*/ 0x18, false });
+    m.relocs.push_back({ /*offset*/ 0x28, R_X86_64_TPOFF64, /*sym*/ 2, /*addend*/ 0x08, false });
+
+    std::vector<TlsModuleDesc> descs(10);
+    for (size_t i = 1; i < descs.size(); i++) descs[i].align = 16;
+    descs[1].memsz = 0x10; descs[2].memsz = 0x10; descs[3].memsz = 0x10;
+    descs[4].memsz = 0x10; descs[5].memsz = 0x40; descs[6].memsz = 0x10;
+    descs[7].memsz = 0x10; descs[8].memsz = 0x10; descs[9].memsz = 0x50;
+    const StaticTlsLayout layout = make_static_tls_layout(descs.data(), descs.size());
+    const std::vector<uint64_t>& module_below = layout.module_below;
+    CHECK(module_below[5] == 0x80 && module_below[9] == 0x100,
+          "shared Variant-II layout places local/defining blocks at the expected TP distances");
 
     auto make_img = [&]() {
         LoadedImage img;
@@ -43,14 +58,18 @@ int main() {
     {
         TlsSymbolMap tls_by_nid{ {"TLSX", { /*modid*/ 9, /*offset*/ 0x88 }} };
         LoadedImage img = make_img();
-        size_t applied = apply_relocations(m, img, &tls_by_nid);
-        CHECK(applied == 4, "both tls_index pairs applied");
+        size_t applied = apply_relocations(m, img, &tls_by_nid, &module_below);
+        CHECK(applied == 6, "dynamic and initial-exec TLS relocations applied");
         CHECK(rd64(img, 0x00) == 9, "cross-module TLS import resolves to the DEFINING module id (9), not 5");
         CHECK(rd64(img, 0x08) == 5, "module-local TLS resolves to this module's id (5)");
         CHECK(rd64(img, 0x10) == 0xa0,
               "cross-module TLS import resolves to defining symbol offset 0x88 plus addend 0x18");
         CHECK(rd64(img, 0x18) == 0x48,
               "module-local TLS offset remains local symbol value 0x40 plus addend 0x08");
+        CHECK(rd64(img, 0x20) == UINT64_C(0xffffffffffffffa0),
+              "cross-module TPOFF64 uses defining offset/addend 0xa0 minus defining block distance 0x100");
+        CHECK(rd64(img, 0x28) == UINT64_C(0xffffffffffffffc8),
+              "module-local TPOFF64 uses local offset/addend 0x48 minus local block distance 0x80");
     }
 
     // 2. WITHOUT a resolver (the old behavior / a table-less caller): the import can't be resolved,
@@ -64,6 +83,10 @@ int main() {
               "no resolver: cross-module offset falls back to zero symbol value plus addend");
         CHECK(rd64(img, 0x18) == 0x48,
               "no resolver: module-local TLS offset is still resolved locally");
+        CHECK(rd64(img, 0x20) == 0,
+              "no resolver: cross-module TPOFF64 is left unapplied instead of baking a wrong offset");
+        CHECK(rd64(img, 0x28) == 0,
+              "no layout: module-local TPOFF64 is left unapplied instead of guessing allocator math");
         (void)applied;
     }
 
@@ -71,10 +94,14 @@ int main() {
     {
         TlsSymbolMap tls_by_nid{ {"OTHER", { /*modid*/ 7, /*offset*/ 0x30 }} };
         LoadedImage img = make_img();
-        apply_relocations(m, img, &tls_by_nid);
+        apply_relocations(m, img, &tls_by_nid, &module_below);
         CHECK(rd64(img, 0x00) == 5, "import absent from the map falls back to the local id");
         CHECK(rd64(img, 0x10) == 0x18,
               "import absent from the map falls back to zero symbol offset plus addend");
+        CHECK(rd64(img, 0x20) == 0,
+              "import absent from the map leaves cross-module TPOFF64 unapplied");
+        CHECK(rd64(img, 0x28) == UINT64_C(0xffffffffffffffc8),
+              "an unknown import does not prevent local TPOFF64 resolution");
     }
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }

--- a/prosper/tests/test_guest_tls_align.cpp
+++ b/prosper/tests/test_guest_tls_align.cpp
@@ -3,6 +3,7 @@
 // block at the wrong distance below the thread pointer and every initial-exec %fs:-N access resolves
 // off. Drives guest_tls_set_templates and reads back the per-module offsets. Linux-only.
 #include "../src/hle/dispatch.hpp"
+#include "../src/loader/tls_layout.hpp"
 #include <cstdio>
 #include <cstdint>
 #include <cstdlib>
@@ -31,6 +32,7 @@ int main() {
         { 0, 0, /*memsz*/0x10, /*align*/16 },
     };
     guest_tls_set_templates(descs.data(), descs.size());
+    const StaticTlsLayout layout = make_static_tls_layout(descs.data(), descs.size());
 #if defined(__linux__)
     CHECK(guest_tls_enabled(), "guest initial-exec TLS is enabled by default on Linux");
 #endif
@@ -40,10 +42,15 @@ int main() {
     uint64_t exp2 = align_up(exp1 + 0x10, 16);       // = 0x50
     CHECK(guest_tls_module_below(1) == exp1, "module 1 offset rounds to its real p_align 64 (0x40, was 0x30)");
     CHECK(guest_tls_module_below(2) == exp2, "module 2 offset accumulates from module 1 (0x50)");
+    CHECK(layout.module_below[1] == guest_tls_module_below(1) &&
+          layout.module_below[2] == guest_tls_module_below(2),
+          "shared linker layout exactly matches the runtime allocator offsets");
     CHECK(guest_tls_module_below(1) != 0x30, "the old 16-byte rounding (0x30) is NOT used for p_align 64");
     // TP must be aligned to the max module align (64 here), so the total is >= exp2 rounded to 64.
     CHECK(guest_tls_total_below() >= exp2 && (guest_tls_total_below() % 64) == 0,
           "total below TP is a multiple of the max module align (64)");
+    CHECK(layout.total_below == guest_tls_total_below(),
+          "shared linker layout exactly matches the allocator's total size");
 
     // Regression: the common p_align <= 16 case is byte-identical to the old per-size rounding
     // (round_up of a 16-multiple running total by 16 == summing round_up(memsz,16)).


### PR DESCRIPTION
Closes #338

## Summary
- centralize the x86-64 Variant-II static-TLS layout used by both the linker and per-thread allocator
- implement `R_X86_64_TPOFF64` as symbol offset + addend - defining module distance below TP
- resolve imported TLS symbols through the same defining module/offset record as DTPMOD64/DTPOFF64
- leave unresolved static offsets unapplied with a loud warning instead of baking guessed layout math
- add synthetic local, cross-module, addend, and unresolved regression coverage

## Focused checks run before publishing
- Linux: `test_dtpmod_tls` and `test_guest_tls_align` passed
- Windows: `test_dtpmod_tls.exe` passed
- no game, renderer, capture, or snapshot workflow was run