### PR TITLE
hle: support legacy SaveData mounts

### DIFF
--- a/prosper/src/hle/dispatch.hpp
+++ b/prosper/src/hle/dispatch.hpp
@@ -78,9 +78,11 @@ void set_app0_root(const std::string& root);
 // Host frontends such as native media decoders must never receive raw /app0 paths.
 std::string resolve_guest_path(const char* guest_path);
 // Mount/unmount the guest "/savedata0" area onto a host dir named by the save's dirName.
-// create=true makes the dir; create=false fails if it doesn't exist. Unmount reports whether a
-// mount was active.
-bool savedata0_mount(const char* dirname, bool create);
+// The policy/result distinction preserves SaveData's exclusive CREATE versus CREATE2
+// (open-or-create) semantics, including whether MountResult should report CREATED or OPENED.
+enum class SaveDataMountPolicy { Open, Create, OpenOrCreate };
+enum class SaveDataMountOutcome { NotFound, Exists, Opened, Created };
+SaveDataMountOutcome savedata0_mount(const char* dirname, SaveDataMountPolicy policy);
 bool savedata0_umount();
 std::vector<std::string> savedata0_list_dirs();   // existing save dirs under the host save root (#299)
 // Read a virtual save slot's param.sfo modification time (or directory time if absent). Rejects names

--- a/prosper/src/hle/dispatch.hpp
+++ b/prosper/src/hle/dispatch.hpp
@@ -77,10 +77,11 @@ void set_app0_root(const std::string& root);
 // Resolve a guest filesystem path through the same mount table used by libkernel file I/O.
 // Host frontends such as native media decoders must never receive raw /app0 paths.
 std::string resolve_guest_path(const char* guest_path);
-// Mount/unmount the guest "/savedata0" area onto a host dir named by the save's dirName
-// (sceSaveDataMount3 HLE). create=true makes the dir; create=false fails if it doesn't exist.
+// Mount/unmount the guest "/savedata0" area onto a host dir named by the save's dirName.
+// create=true makes the dir; create=false fails if it doesn't exist. Unmount reports whether a
+// mount was active.
 bool savedata0_mount(const char* dirname, bool create);
-void savedata0_umount();
+bool savedata0_umount();
 std::vector<std::string> savedata0_list_dirs();   // existing save dirs under the host save root (#299)
 // Read a virtual save slot's param.sfo modification time (or directory time if absent). Rejects names
 // that are not a single guest directory component; used only for SaveDataDialog date-focus ordering.

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -578,7 +578,7 @@ std::string resolve_guest_path(const char* guest_path) {
 }
 
 // Mount / unmount the guest "/savedata0" area onto a host dir named by the save's dirName
-// (sceSaveDataMount3 HLE, hle_service.cpp). create=true makes the host dir (CREATE-mode mount);
+// (sceSaveDataMount* HLEs, hle_service.cpp). create=true makes the host dir (CREATE-mode mount);
 // create=false requires it to already exist (open-mode) and fails otherwise ("no such save").
 // Returns true on success with /savedata0 translation active.
 bool savedata0_mount(const char* dirname, bool create) {
@@ -597,7 +597,12 @@ bool savedata0_mount(const char* dirname, bool create) {
     g_save0 = d;
     return true;
 }
-void savedata0_umount() { std::lock_guard<std::mutex> lk(g_save0_mx); g_save0.clear(); }
+bool savedata0_umount() {
+    std::lock_guard<std::mutex> lk(g_save0_mx);
+    const bool was_mounted = !g_save0.empty();
+    g_save0.clear();
+    return was_mounted;
+}
 // List the save-dir names that exist under the host save root (each subdir is one save the guest created
 // via sceSaveDataMount3 create-mode). sceSaveDataDirNameSearch reports these so a prior session's saves
 // appear in the game's load/continue list (#299 — the saves persisted but were invisible).

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -578,24 +578,46 @@ std::string resolve_guest_path(const char* guest_path) {
 }
 
 // Mount / unmount the guest "/savedata0" area onto a host dir named by the save's dirName
-// (sceSaveDataMount* HLEs, hle_service.cpp). create=true makes the host dir (CREATE-mode mount);
-// create=false requires it to already exist (open-mode) and fails otherwise ("no such save").
-// Returns true on success with /savedata0 translation active.
-bool savedata0_mount(const char* dirname, bool create) {
-    if (!dirname || !*dirname) return false;
+// (sceSaveDataMount* HLEs, hle_service.cpp). CREATE is exclusive, while OpenOrCreate (CREATE2)
+// opens an existing directory or creates a missing one. The outcome lets the HLE write an honest
+// MountResult status instead of deriving CREATED from the requested mode.
+SaveDataMountOutcome savedata0_mount(const char* dirname, SaveDataMountPolicy policy) {
+    if (!dirname || !*dirname) return SaveDataMountOutcome::NotFound;
     std::string d = save0_base() + "/" + dirname;
+    bool exists = false;
 #ifdef _WIN32
-    if (create) _mkdir(d.c_str());
     struct _stat st{};
-    if (_stat(d.c_str(), &st) != 0 || !(st.st_mode & _S_IFDIR)) return false;
+    exists = _stat(d.c_str(), &st) == 0 && (st.st_mode & _S_IFDIR);
 #else
-    if (create) ::mkdir(d.c_str(), 0777);
     struct stat st{};
-    if (::stat(d.c_str(), &st) != 0 || !S_ISDIR(st.st_mode)) return false;
+    exists = ::stat(d.c_str(), &st) == 0 && S_ISDIR(st.st_mode);
 #endif
+    if (exists && policy == SaveDataMountPolicy::Create) return SaveDataMountOutcome::Exists;
+
+    bool created = false;
+    if (!exists) {
+        if (policy == SaveDataMountPolicy::Open) return SaveDataMountOutcome::NotFound;
+#ifdef _WIN32
+        created = _mkdir(d.c_str()) == 0;
+        if (!created) {
+            struct _stat retry{};
+            exists = _stat(d.c_str(), &retry) == 0 && (retry.st_mode & _S_IFDIR);
+        }
+#else
+        created = ::mkdir(d.c_str(), 0777) == 0;
+        if (!created) {
+            struct stat retry{};
+            exists = ::stat(d.c_str(), &retry) == 0 && S_ISDIR(retry.st_mode);
+        }
+#endif
+        if (!created && !exists) return SaveDataMountOutcome::NotFound;
+        // Another creator may have won between the stat and mkdir. Exclusive CREATE must still
+        // report EXISTS and must not activate the mount in that case.
+        if (!created && policy == SaveDataMountPolicy::Create) return SaveDataMountOutcome::Exists;
+    }
     std::lock_guard<std::mutex> lk(g_save0_mx);
     g_save0 = d;
-    return true;
+    return created ? SaveDataMountOutcome::Created : SaveDataMountOutcome::Opened;
 }
 bool savedata0_umount() {
     std::lock_guard<std::mutex> lk(g_save0_mx);

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -1425,6 +1425,7 @@ HLE(s_playgo_getlang) { if (!a1) return PLAYGO_ERR_BAD_POINTER;
 // MED on Mount3's arg order (mount-desc in, result out — matches every PS4 Mount variant);
 // LOW on Prepare/Commit internals (no-op success; PROSPER_SVCLOG captures their real args).
 static constexpr uint64_t SAVE_DATA_ERR_PARAMETER = 0x809F0000ull;
+static constexpr uint64_t SAVE_DATA_ERR_EXISTS = 0x809F0007ull;
 static constexpr uint64_t SAVE_DATA_ERR_NOT_FOUND = 0x809F0008ull;
 static constexpr uint64_t SAVE_DATA_ERR_NO_EVENT = 0x809F0018ull;
 namespace { std::atomic<unsigned> g_savedata_umount_events{0}; }
@@ -1612,8 +1613,16 @@ HLE(s_savemem_sync) {
 static uint64_t savedata_mount_common(const char* api, const char* dirname,
                                       uint32_t mode, uint64_t result_va) {
     if (!dirname || !*dirname || !result_va) return SAVE_DATA_ERR_PARAMETER;
-    const bool create = (mode & 0x24) != 0; // CREATE(4) | CREATE2(0x20, create-if-missing)
-    if (!savedata0_mount(dirname, create)) {
+    const SaveDataMountPolicy policy = (mode & 0x04) ? SaveDataMountPolicy::Create
+        : (mode & 0x20) ? SaveDataMountPolicy::OpenOrCreate
+                        : SaveDataMountPolicy::Open;
+    const SaveDataMountOutcome outcome = savedata0_mount(dirname, policy);
+    if (outcome == SaveDataMountOutcome::Exists) {
+        if (svclog()) fprintf(stderr, "[svc]   %s dir='%s' mode=%#x -> EXISTS\n",
+                              api, dirname, mode);
+        return SAVE_DATA_ERR_EXISTS;
+    }
+    if (outcome == SaveDataMountOutcome::NotFound) {
         if (svclog()) fprintf(stderr, "[svc]   %s dir='%s' mode=%#x -> NOT_FOUND\n",
                               api, dirname, mode);
         return SAVE_DATA_ERR_NOT_FOUND;
@@ -1621,9 +1630,10 @@ static uint64_t savedata_mount_common(const char* api, const char* dirname,
     uint8_t* result = (uint8_t*)PW(result_va);
     memset(result, 0, 0x40);
     memcpy(result, "/savedata0", 11);
-    *(uint32_t*)(result + 0x1c) = create ? 1u : 0u;
-    if (svclog()) fprintf(stderr, "[svc]   %s dir='%s' mode=%#x -> OK (create=%d)\n",
-                          api, dirname, mode, (int)create);
+    const bool created = outcome == SaveDataMountOutcome::Created;
+    *(uint32_t*)(result + 0x1c) = created ? 1u : 0u;
+    if (svclog()) fprintf(stderr, "[svc]   %s dir='%s' mode=%#x -> OK (created=%d)\n",
+                          api, dirname, mode, (int)created);
     return 0;
 }
 

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -1604,6 +1604,47 @@ HLE(s_savemem_sync) {
     savemem_store(userId, slotId, it->second);   // Sync commits the slot to disk (survives restart)
     return 0;
 }
+// All three pinned mount ABIs feed one backend/result writer. The PS4-inherited layouts come from
+// the public libSceSaveData ABI and retain their NIDs in the PS5 3.20 table:
+//   Mount:  dirName pointer @0x10, blocks @0x20, mode @0x28, size 0x50
+//   Mount2: dirName pointer @0x08, blocks @0x10, mode @0x18, size 0x40
+// Mount3's PS5-native layout is documented below. MountResult is the shared exact 0x40-byte shape.
+static uint64_t savedata_mount_common(const char* api, const char* dirname,
+                                      uint32_t mode, uint64_t result_va) {
+    if (!dirname || !*dirname || !result_va) return SAVE_DATA_ERR_PARAMETER;
+    const bool create = (mode & 0x24) != 0; // CREATE(4) | CREATE2(0x20, create-if-missing)
+    if (!savedata0_mount(dirname, create)) {
+        if (svclog()) fprintf(stderr, "[svc]   %s dir='%s' mode=%#x -> NOT_FOUND\n",
+                              api, dirname, mode);
+        return SAVE_DATA_ERR_NOT_FOUND;
+    }
+    uint8_t* result = (uint8_t*)PW(result_va);
+    memset(result, 0, 0x40);
+    memcpy(result, "/savedata0", 11);
+    *(uint32_t*)(result + 0x1c) = create ? 1u : 0u;
+    if (svclog()) fprintf(stderr, "[svc]   %s dir='%s' mode=%#x -> OK (create=%d)\n",
+                          api, dirname, mode, (int)create);
+    return 0;
+}
+
+HLE(s_savedata_mount) {
+    svc_log("sceSaveDataMount", a0,a1,a2,a3,a4,a5);
+    if (!a0 || !a1) return SAVE_DATA_ERR_PARAMETER;
+    const uint8_t* mount = (const uint8_t*)PW(a0);
+    const char* dirname = *(const char* const*)(mount + 0x10);
+    const uint32_t mode = *(const uint32_t*)(mount + 0x28);
+    return savedata_mount_common("Mount", dirname, mode, a1);
+}
+
+HLE(s_savedata_mount2) {
+    svc_log("sceSaveDataMount2", a0,a1,a2,a3,a4,a5);
+    if (!a0 || !a1) return SAVE_DATA_ERR_PARAMETER;
+    const uint8_t* mount = (const uint8_t*)PW(a0);
+    const char* dirname = *(const char* const*)(mount + 0x08);
+    const uint32_t mode = *(const uint32_t*)(mount + 0x18);
+    return savedata_mount_common("Mount2", dirname, mode, a1);
+}
+
 // sceSaveDataMount3(const Mount3* mount, MountResult* result). The mount desc layout is pinned
 // from DOLL's OWN wrapper (eboot+0x2251610 disassembly, matching the live capture):
 //   +0x00 u32 userId; +0x08 const char* dirName; +0x10 u64 blocks; +0x20 u32 mountMode;
@@ -1625,18 +1666,14 @@ HLE(s_savedata_mount3)  {
     const uint8_t* m = (const uint8_t*)PW(a0);
     const char* dirname = *(const char* const*)(m + 0x08);
     uint32_t mode = *(const uint32_t*)(m + 0x20);
-    if (!dirname) return SAVE_DATA_ERR_PARAMETER;
-    bool create = (mode & 0x24) != 0;   // CREATE(4) | CREATE2(0x20, create-if-missing; live: mode 0x20 remount)
-    if (!savedata0_mount(dirname, create)) {
-        if (svclog()) fprintf(stderr, "[svc]   Mount3 dir='%s' mode=%#x -> NOT_FOUND\n", dirname, mode);
-        return SAVE_DATA_ERR_NOT_FOUND;
-    }
-    uint8_t* r = (uint8_t*)PW(a1);
-    memset(r, 0, 0x40);
-    memcpy(r, "/savedata0", 11);
-    *(uint32_t*)(r + 0x1c) = create ? 1u : 0u;   // mountStatus: created vs opened
-    if (svclog()) fprintf(stderr, "[svc]   Mount3 dir='%s' mode=%#x -> OK (create=%d)\n", dirname, mode, (int)create);
-    return 0;
+    return savedata_mount_common("Mount3", dirname, mode, a1);
+}
+HLE(s_savedata_umount) {
+    svc_log("sceSaveDataUmount", a0,a1,a2,a3,a4,a5);
+    if (!a0) return SAVE_DATA_ERR_PARAMETER;
+    const char* mount_point = (const char*)PW(a0); // OrbisSaveDataMountPoint: char data[16]
+    if (strncmp(mount_point, "/savedata0", 16) != 0) return SAVE_DATA_ERR_NOT_FOUND;
+    return savedata0_umount() ? 0 : SAVE_DATA_ERR_NOT_FOUND;
 }
 HLE(s_savedata_umount2) {
     svc_log("sceSaveDataUmount2", a0,a1,a2,a3,a4,a5);
@@ -2205,7 +2242,10 @@ void register_service_hle() {
     Hle::register_fn("yKDy8S5yLA0", (HleFn)s_savedata_term,      "sceSaveDataTerminate");
     Hle::register_fn("gjRZNnw0JPE", (HleFn)s_savedata_txres,     "sceSaveDataCreateTransactionResource");
     Hle::register_fn("lJUQuaKqoKY", (HleFn)s_savedata_txres_del, "sceSaveDataDeleteTransactionResource");
+    Hle::register_fn("32HQAQdwM2o", (HleFn)s_savedata_mount,     "sceSaveDataMount");
+    Hle::register_fn("0z45PIH+SNI", (HleFn)s_savedata_mount2,    "sceSaveDataMount2");
     Hle::register_fn("ZP4e7rlzOUk", (HleFn)s_savedata_mount3,    "sceSaveDataMount3");
+    Hle::register_fn("BMR4F-Uek3E", (HleFn)s_savedata_umount,    "sceSaveDataUmount");
     Hle::register_fn("uW4vfTwMQVo", (HleFn)s_savedata_umount2,   "sceSaveDataUmount2");
     Hle::register_fn("sDCBrmc61XU", (HleFn)s_savedata_prepare,   "sceSaveDataPrepare");
     Hle::register_fn("ie7qhZ4X0Cc", (HleFn)s_savedata_commit,    "sceSaveDataCommit");

--- a/prosper/tests/test_savedata_ime.cpp
+++ b/prosper/tests/test_savedata_ime.cpp
@@ -208,6 +208,33 @@ int main() {
                   "legacy Umount of an inactive mount -> NOT_FOUND");
 
             memset(&guarded, 0xAB, sizeof guarded);
+            input2.mode = 4; // CREATE is exclusive
+            CHECK(mount2((uint64_t)(uintptr_t)&input2, (uint64_t)(uintptr_t)&guarded.result,
+                         0,0,0,0) == 0x809F0007ull,
+                  "Mount2 CREATE of an existing save -> EXISTS");
+            CHECK(all_bytes_are(&guarded, sizeof guarded, 0xAB) &&
+                  resolve_guest_path("/savedata0/probe.bin") == "/savedata0/probe.bin",
+                  "failed exclusive CREATE leaves its result untouched and does not mount");
+
+            memset(&guarded, 0xAB, sizeof guarded);
+            input2.mode = 0x20; // CREATE2 opens or creates
+            CHECK(mount2((uint64_t)(uintptr_t)&input2, (uint64_t)(uintptr_t)&guarded.result,
+                         0,0,0,0) == 0 && guarded.result.status == 0,
+                  "Mount2 CREATE2 opens an existing save with OPENED status");
+            CHECK(umount((uint64_t)(uintptr_t)guarded.result.mountPoint, 0,0,0,0,0) == 0,
+                  "legacy Umount releases the CREATE2-opened save");
+
+            SaveDirName create2_dir{}; memcpy(create2_dir.data, "LegacyCreate2", 14);
+            input2.dirName = &create2_dir;
+            memset(&guarded, 0xAB, sizeof guarded);
+            CHECK(mount2((uint64_t)(uintptr_t)&input2, (uint64_t)(uintptr_t)&guarded.result,
+                         0,0,0,0) == 0 && guarded.result.status == 1,
+                  "Mount2 CREATE2 creates a missing save with CREATED status");
+            CHECK(umount((uint64_t)(uintptr_t)guarded.result.mountPoint, 0,0,0,0,0) == 0,
+                  "legacy Umount releases the CREATE2-created save");
+
+            memset(&guarded, 0xAB, sizeof guarded);
+            input2.dirName = &dir2;
             input2.mode = 1;
             CHECK(mount2((uint64_t)(uintptr_t)&input2, (uint64_t)(uintptr_t)&guarded.result,
                          0,0,0,0) == 0 && guarded.result.status == 0,

--- a/prosper/tests/test_savedata_ime.cpp
+++ b/prosper/tests/test_savedata_ime.cpp
@@ -8,6 +8,13 @@
 #include <cstdint>
 #include <cstddef>
 #include <cstring>
+#include <filesystem>
+#include <string>
+#ifdef _WIN32
+#include <process.h>
+#else
+#include <unistd.h>
+#endif
 
 using namespace prosper;
 
@@ -24,20 +31,64 @@ struct Set2       { int32_t userId; uint8_t pad[4]; const MemData* data; const v
                     const void* icon; uint32_t dataNum; uint32_t slotId; uint8_t rsv[32]; };
 struct Get2       { int32_t userId; uint8_t pad[4]; MemData* data; const void* param;
                     const void* icon; uint32_t slotId; uint8_t rsv[28]; };
+struct SaveDirName { char data[32]; };
+struct LegacyMount {
+    int32_t userId; uint32_t pad; const void* titleId; const SaveDirName* dirName;
+    const void* fingerprint; uint64_t blocks; uint32_t mode; uint8_t reserved[32];
+};
+struct LegacyMount2 {
+    int32_t userId; uint32_t pad; const SaveDirName* dirName; uint64_t blocks;
+    uint32_t mode; uint8_t reserved[32]; uint32_t tailPad;
+};
+struct MountResult {
+    char mountPoint[16]; uint64_t requiredBlocks; uint32_t unused; uint32_t status;
+    uint8_t reserved[28]; uint32_t tailPad;
+};
 static_assert(offsetof(MemData, buf) == 0 && offsetof(MemData, bufSize) == 8 && offsetof(MemData, offset) == 16, "MemData");
 static_assert(offsetof(Setup2, userId) == 4 && offsetof(Setup2, memSize) == 8 && offsetof(Setup2, slotId) == 40, "Setup2");
 static_assert(offsetof(Set2, data) == 8 && offsetof(Set2, dataNum) == 32 && offsetof(Set2, slotId) == 36, "Set2");
 static_assert(offsetof(Get2, data) == 8 && offsetof(Get2, slotId) == 32, "Get2");
+static_assert(sizeof(LegacyMount) == 0x50 && offsetof(LegacyMount, dirName) == 0x10 &&
+              offsetof(LegacyMount, mode) == 0x28, "legacy Mount ABI");
+static_assert(sizeof(LegacyMount2) == 0x40 && offsetof(LegacyMount2, dirName) == 0x08 &&
+              offsetof(LegacyMount2, mode) == 0x18, "legacy Mount2 ABI");
+static_assert(sizeof(MountResult) == 0x40 && offsetof(MountResult, status) == 0x1c,
+              "SaveData MountResult ABI");
+
+static bool all_bytes_are(const void* data, size_t size, uint8_t value) {
+    const auto* bytes = static_cast<const uint8_t*>(data);
+    for (size_t i = 0; i < size; ++i) if (bytes[i] != value) return false;
+    return true;
+}
 
 int main() {
     printf("== test_savedata_ime ==\n");
-    // Hermeticity: SaveDataMemory now persists a synced slot to PROSPER_SAVEDATA_DIR (#432), which
-    // survives across ctest runs -- so the "fresh slot" check below would see a PRIOR run's file. Point
-    // it at a test-private dir and clear that run's slot file so fresh/resume are deterministic.
-#ifndef _WIN32
-    setenv("PROSPER_SAVEDATA_DIR", "/tmp/prosper-savemem-selftest", 1);
-    remove("/tmp/prosper-savemem-selftest/savemem_1_0.bin");
+    const int process_id =
+#ifdef _WIN32
+        _getpid();
+#else
+        (int)getpid();
 #endif
+    const std::filesystem::path test_root = std::filesystem::temp_directory_path() /
+        ("prosper-savedata-selftest-" + std::to_string(process_id));
+    const std::filesystem::path mount_root = test_root / "mount";
+    const std::filesystem::path memory_root = test_root / "memory";
+    std::error_code mount_ec;
+    std::filesystem::remove_all(test_root, mount_ec);
+    std::filesystem::create_directories(mount_root, mount_ec);
+    std::filesystem::create_directories(memory_root, mount_ec);
+    const std::string mount_root_string = mount_root.string();
+    const std::string memory_root_string = memory_root.string();
+#ifdef _WIN32
+    _putenv_s("PROSPER_SAVE0", mount_root_string.c_str());
+    _putenv_s("PROSPER_SAVEDATA_DIR", memory_root_string.c_str());
+#else
+    setenv("PROSPER_SAVE0", mount_root_string.c_str(), 1);
+    setenv("PROSPER_SAVEDATA_DIR", memory_root_string.c_str(), 1);
+#endif
+    // Hermeticity: SaveDataMemory now persists a synced slot to PROSPER_SAVEDATA_DIR (#432), which
+    // survives across ctest runs. Both save backends use this process-private root, so concurrent
+    // agents and repeated runs cannot turn the fresh-save assertions into order-dependent tests.
     register_builtin_hle();
 
     // ---- libSceImeDialog: auto-completing lifecycle ----
@@ -114,6 +165,91 @@ int main() {
         CHECK(get_v1(user + 1, (uint64_t)(uintptr_t)dst, sizeof dst, 0, 0, 0) == 0x809F0012ull,
               "v1 Get before Setup -> MEMORY_NOT_READY");
     }
+
+    // ---- PS4-inherited SaveData mount ABIs: exact layouts share the /savedata0 backend ----
+    {
+        HleFn mount = Hle::lookup("32HQAQdwM2o"), mount2 = Hle::lookup("0z45PIH+SNI"),
+              mount3 = Hle::lookup("ZP4e7rlzOUk"), umount = Hle::lookup("BMR4F-Uek3E");
+        CHECK(mount && mount2 && mount3 && umount,
+              "SaveData Mount/Mount2/Mount3/Umount functions registered");
+        if (mount && mount2 && mount3 && umount) {
+            SaveDirName dir2{}; memcpy(dir2.data, "LegacyMount2", 13);
+            LegacyMount2 input2{}; input2.userId = 1; input2.dirName = &dir2;
+            input2.blocks = 96; input2.mode = 1; // RDONLY: missing save must not be invented
+            struct GuardedResult { MountResult result; uint8_t canary[8]; } guarded;
+            memset(&guarded, 0xAB, sizeof guarded);
+            CHECK(mount2((uint64_t)(uintptr_t)&input2, (uint64_t)(uintptr_t)&guarded.result,
+                         0,0,0,0) == 0x809F0008ull,
+                  "Mount2 RDONLY of a missing save -> NOT_FOUND");
+            CHECK(all_bytes_are(&guarded, sizeof guarded, 0xAB),
+                  "failed Mount2 leaves its result and post-object canary untouched");
+
+            input2.mode = 4; // CREATE
+            CHECK(mount2((uint64_t)(uintptr_t)&input2, (uint64_t)(uintptr_t)&guarded.result,
+                         0,0,0,0) == 0,
+                  "Mount2 CREATE makes and mounts the named save");
+            CHECK(strcmp(guarded.result.mountPoint, "/savedata0") == 0 &&
+                  guarded.result.requiredBlocks == 0 && guarded.result.status == 1,
+                  "Mount2 writes the shared mount point and CREATED status");
+            CHECK(guarded.result.unused == 0 && guarded.result.tailPad == 0 &&
+                  all_bytes_are(guarded.result.reserved, sizeof guarded.result.reserved, 0),
+                  "Mount2 zero-initializes the complete result body");
+            CHECK(all_bytes_are(guarded.canary, sizeof guarded.canary, 0xAB),
+                  "Mount2 writes exactly the 0x40-byte result");
+            const auto expected2 = (mount_root / "LegacyMount2" / "probe.bin").lexically_normal();
+            CHECK(std::filesystem::path(resolve_guest_path("/savedata0/probe.bin")).lexically_normal() == expected2,
+                  "Mount2 activates /savedata0 path translation");
+
+            CHECK(umount((uint64_t)(uintptr_t)guarded.result.mountPoint, 0,0,0,0,0) == 0,
+                  "legacy Umount releases an active mount synchronously");
+            CHECK(resolve_guest_path("/savedata0/probe.bin") == "/savedata0/probe.bin",
+                  "legacy Umount removes /savedata0 path translation");
+            CHECK(umount((uint64_t)(uintptr_t)guarded.result.mountPoint, 0,0,0,0,0) == 0x809F0008ull,
+                  "legacy Umount of an inactive mount -> NOT_FOUND");
+
+            memset(&guarded, 0xAB, sizeof guarded);
+            input2.mode = 1;
+            CHECK(mount2((uint64_t)(uintptr_t)&input2, (uint64_t)(uintptr_t)&guarded.result,
+                         0,0,0,0) == 0 && guarded.result.status == 0,
+                  "Mount2 RDONLY opens an existing save with OPENED status");
+            CHECK(umount((uint64_t)(uintptr_t)guarded.result.mountPoint, 0,0,0,0,0) == 0,
+                  "legacy Umount releases the reopened save");
+
+            SaveDirName dir1{}; memcpy(dir1.data, "LegacyMount1", 13);
+            LegacyMount input1{}; input1.userId = 1;
+            input1.titleId = reinterpret_cast<const void*>(uintptr_t{1}); // decoy: dirName is @0x10
+            input1.dirName = &dir1; input1.blocks = 96; input1.mode = 4;
+            memset(&guarded, 0xAB, sizeof guarded);
+            CHECK(mount((uint64_t)(uintptr_t)&input1, (uint64_t)(uintptr_t)&guarded.result,
+                        0,0,0,0) == 0 && guarded.result.status == 1,
+                  "legacy Mount decodes its distinct dirName/mode offsets and creates the save");
+            const auto expected1 = (mount_root / "LegacyMount1" / "probe.bin").lexically_normal();
+            CHECK(std::filesystem::path(resolve_guest_path("/savedata0/probe.bin")).lexically_normal() == expected1,
+                  "legacy Mount activates the same /savedata0 backend");
+            CHECK(umount((uint64_t)(uintptr_t)guarded.result.mountPoint, 0,0,0,0,0) == 0,
+                  "legacy Umount releases the Mount-created save");
+
+            // The shared result writer must preserve the already-live PS5-native Mount3 ABI too.
+            SaveDirName dir3{}; memcpy(dir3.data, "NativeMount3", 13);
+            alignas(8) uint8_t input3[0x30]{};
+            *(const SaveDirName**)(input3 + 0x08) = &dir3;
+            *(uint64_t*)(input3 + 0x10) = 96;
+            *(uint32_t*)(input3 + 0x20) = 4;
+            memset(&guarded, 0xAB, sizeof guarded);
+            CHECK(mount3((uint64_t)(uintptr_t)input3, (uint64_t)(uintptr_t)&guarded.result,
+                         0,0,0,0) == 0 && guarded.result.status == 1,
+                  "shared mount helper preserves Mount3 create/result behavior");
+            CHECK(umount((uint64_t)(uintptr_t)guarded.result.mountPoint, 0,0,0,0,0) == 0,
+                  "legacy Umount releases a Mount3-created save");
+
+            CHECK(mount2(0, (uint64_t)(uintptr_t)&guarded.result, 0,0,0,0) == 0x809F0000ull &&
+                  mount2((uint64_t)(uintptr_t)&input2, 0, 0,0,0,0) == 0x809F0000ull &&
+                  umount(0,0,0,0,0,0) == 0x809F0000ull,
+                  "legacy mount lifecycle rejects null ABI pointers");
+        }
+    }
+
+    std::filesystem::remove_all(test_root, mount_ec);
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");


### PR DESCRIPTION
Part of #392

## Summary
- register the PS4-inherited `sceSaveDataMount`, `sceSaveDataMount2`, and synchronous `sceSaveDataUmount` NIDs retained by the PS5 3.20 table
- decode the pinned, distinct Mount/Mount2 ABI layouts and route both through Prosper's existing `/savedata0` backend
- share the exact 0x40-byte MountResult writer with the existing PS5-native Mount3 path
- make legacy Umount validate the mount point and distinguish active from already-unmounted state
- make the SaveData regression process-private so concurrent agents/reruns cannot share persistent test state

## Focused checks run before publishing
- Linux: rebuilt and ran `test_savedata_ime` — pass
- Windows: rebuilt and ran `test_savedata_ime.exe` — pass
- coverage includes missing/open/create behavior, untouched failure output, exact-size canary, zeroed result tail, path translation, synchronous unmount, distinct Mount ABI offsets, null pointers, and Mount3 regression
- no game, renderer, capture, or snapshot workflow was run

`Mount5`, unpinned variants, and LoadExec policy remain out of scope.