### PR TITLE
perf(renderer): avoid frontend storage-buffer copies

### DIFF
--- a/prosper/docs/FRONTEND_APP.md
+++ b/prosper/docs/FRONTEND_APP.md
@@ -269,6 +269,15 @@ default budget (`PROSPER_COMPUTE_MEMORY_POOL_MB=<MiB>`). `PROSPER_NO_MEMORY_POOL
 graphics and compute pools. Decoded texture scratch vectors are also retained across callbacks; they
 are storage only, and every partial decode/read explicitly clears its unwritten tail.
 
+Storage buffers whose complete backing range passes the executor's generation-scoped readability guard
+are handed to the synchronous Vulkan backend as immutable views of unified guest memory. The backend hashes
+and copies every visible byte into its upload arena before returning; ordered submission batches retain only
+that completed Vulkan upload, never the guest pointer. This removes frontend allocation and copy work without
+adding cross-submit freshness or lifetime assumptions. Captured host backing follows the same rule only when
+it covers the complete requested range, and partial/unreadable ranges retain the zero-filled owned-copy
+fallback. Set `PROSPER_NO_FRONTEND_BUFFER_VIEW=1` to restore per-reference materialization for an A/B.
+Renderer timing reports buffer `views`, logical bytes, and bytes that still required materialization.
+
 Within one renderer callback, repeated guest-backed texture descriptions reuse the first decoded
 pixel buffer. A bounded process-wide cache also covers guest-backed linear and tiled 2D sampled
 textures in `Unorm8` component widths 1-4 and BC1-BC7 formats. Every cross-submit lookup validates

--- a/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
+++ b/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
@@ -274,6 +274,40 @@ initial binding miss, the next-call hit, byte-identical output, and bounded evic
 current call's binding. Later end-to-end controls coincided with unrelated GPU saturation, so the cache and
 CPU phase counters above are used for attribution rather than presenting those wall-clock rates as FPS gains.
 
+## Evergate direct frontend buffer views (2026-07-19)
+
+After parallel draw realization, dense Evergate submits still constructed roughly 3,300 storage-buffer
+resources for only about 4 MiB of logical bytes. The frontend allocated a zeroed byte vector, copied guest
+memory into it, then allocated and copied again into each `FrameResource`; the backend immediately hashed and
+uploaded those immutable bytes synchronously. Reusing materializations by guest identity was rejected after
+an exact A/B: only about one third of references repeated and the hash-map/ownership overhead made the buffer
+bucket 2-3 ms slower.
+
+The final path instead reuses the executor's mapping-generation-scoped readable-range cache. A complete
+readable guest or capture range becomes a non-owning immutable `FrameResource` view; the backend hashes and
+copies it into the mapped Vulkan upload arena before returning. Submission batching retains only the Vulkan
+objects after that point. Partial or unreadable ranges keep the existing zero-filled owned-copy fallback, and
+`PROSPER_NO_FRONTEND_BUFFER_VIEW=1` restores materialization for comparison.
+
+A native Windows / RTX 4090 A/B used one final RelWithDebInfo binary, separate fresh saves, native 1920x1080
+rendering on every submit, the documented read-anchored Evergate route, and six screenshots spaced over 360
+rendered frames. The table averages the two closest dense 25-submit windows (about 489/479 and 490/479 draws):
+
+| Measurement | Materialized control | Direct views |
+|---|---:|---:|
+| Draws / submit | 484.1 | 483.8 |
+| Frontend resource construction | 46.3 ms | 34.9 ms |
+| Buffer construction bucket | 13.1 ms | 5.1 ms |
+| Frontend callback total | 86.8 ms | 74.4 ms |
+| Backend execution | 39.1 ms | 38.5 ms |
+| Complete 360-frame route | 43.43 s | 39.62 s |
+
+The dense windows used direct views for all but roughly two of 3,300 buffer references and materialized less
+than 0.05 MiB per submit. Backend time remained flat, while frontend construction fell by about 11.4 ms and
+the complete route improved by 8.8%. Exact renderer snapshots remain the semantic guard; the next dominant
+Windows cost is cross-submit texture validation, which still compares roughly 129 MiB of encoded source per
+dense frame because page-protection write watches are not ABI-safe there.
+
 ## Dead Cells backend upload duplication (2026-07-15)
 
 Dead Cells exposed a second duplication layer after the frontend decode caches. The frontend correctly

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -488,13 +488,13 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 uint64_t color_target_writes = 0, color_target_write_hits = 0;
                 uint64_t color_target_sample_hits = 0, color_target_readbacks = 0;
                 uint64_t color_target_cached_bytes = 0, color_target_cached_entries = 0;
-                uint64_t textures = 0, texture_reuses = 0, buffers = 0;
+                uint64_t textures = 0, texture_reuses = 0, buffers = 0, buffer_views = 0;
                 uint64_t persistent_hits = 0, persistent_misses = 0, persistent_invalidations = 0;
                 uint64_t persistent_submit_reuses = 0, persistent_validations = 0;
                 uint64_t persistent_validation_bytes = 0;
                 uint64_t persistent_watch_reuses = 0, persistent_watch_dirty = 0;
                 uint64_t persistent_watch_unknown = 0, persistent_watch_disabled = 0;
-                uint64_t texture_bytes = 0, buffer_bytes = 0;
+                uint64_t texture_bytes = 0, buffer_bytes = 0, buffer_materialized_bytes = 0;
                 double texture_ms = 0, buffer_ms = 0;
             };
             struct RttTimingRecord {
@@ -694,6 +694,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
             static std::vector<std::vector<uint8_t>> texstore;
             size_t texstore_used = 0;
             std::unordered_map<TextureDecodeKey, DecodedTexture, TextureDecodeKeyHash> decoded_textures;
+            const bool use_direct_buffer_views =
+                getenv("PROSPER_NO_FRONTEND_BUFFER_VIEW") == nullptr;
             static std::unordered_map<TextureDecodeKey, PersistentDecodedTexture, TextureDecodeKeyHash>
                 persistent_decoded_textures;
             static size_t persistent_decoded_texture_bytes = 0;
@@ -735,6 +737,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     bool resource_persistent_submit_reuse = false;
                     bool resource_persistent_miss = false;
                     bool resource_persistent_invalidation = false;
+                    bool resource_buffer_view = false;
                     prosper::test::FrameResource fr; fr.binding = r.binding; fr.set = set;
                     fr.is_storage_image = r.cls == RC::StorageImage;
                     // Captured replays preserve the logical guest address for RT identity but provide
@@ -747,6 +750,29 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         size_t take = static_cast<size_t>(std::min<uint64_t>(n, r.host_data_size - off));
                         std::memcpy(dst, r.host_data + off, take);
                         return take;
+                    };
+                    // Avoid allocating and copying storage buffers that are already present in stable,
+                    // readable unified guest memory. The callback and backend upload are synchronous;
+                    // compute/DMA boundaries split graphics spans before this point. The submit-scoped
+                    // readability guard proves the complete range; an invalid tail retains the copied
+                    // fallback.
+                    auto direct_resource = [&](uint64_t addr, size_t n) -> const uint8_t* {
+                        if (!n || addr < 0x1000 || addr > UINT64_MAX - n ||
+                            (addr & (alignof(uint32_t) - 1))) return nullptr;
+                        if (r.host_data) {
+                            if (addr < r.gpu_addr) return nullptr;
+                            const uint64_t off = addr - r.gpu_addr;
+                            if (off > r.host_data_size || n > r.host_data_size - off) return nullptr;
+                            const uint8_t* source = r.host_data + off;
+                            return (reinterpret_cast<uintptr_t>(source) &
+                                    (alignof(uint32_t) - 1)) ? nullptr : source;
+                        }
+                        // Reuse the executor's submit-scoped range cache; on Windows the same guard
+                        // also materializes sparse direct-memory pages when necessary.
+                        if (n > UINT32_MAX ||
+                            !prosper::gpu::guest_readable(addr, static_cast<uint32_t>(n)))
+                            return nullptr;
+                        return reinterpret_cast<const uint8_t*>(static_cast<uintptr_t>(addr));
                     };
                     auto copy_dcc_metadata = [&](uint8_t* dst, size_t n) -> size_t {
                         if (!r.dcc_metadata_host_data)
@@ -1693,23 +1719,43 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     } else {
                         fr.buffer_identity = r.gpu_addr;
                         uint32_t nb = std::min(r.size ? r.size : 256u, 1u << 20) & ~3u;   // cap 1 MB, dword-aligned
-                        if (nb >= 4) {
-                            std::vector<uint8_t> tmp(nb, 0);
-                            if (copy_resource(tmp.data(), r.gpu_addr, nb) > 0)
-                                fr.dwords.assign((const uint32_t*)tmp.data(), (const uint32_t*)(tmp.data() + nb));
+                        if (use_direct_buffer_views && nb >= 4) {
+                            if (const uint8_t* source = direct_resource(r.gpu_addr, nb)) {
+                                fr.dwords_view = reinterpret_cast<const uint32_t*>(source);
+                                fr.dwords_view_count = nb / sizeof(uint32_t);
+                                resource_buffer_view = true;
+                            }
                         }
-                        if (fr.dwords.empty()) fr.dwords.assign(64, 0);
+                        if (!fr.dwords_view_count && use_direct_buffer_views) {
+                            if (nb >= 4) {
+                                fr.dwords.assign(nb / sizeof(uint32_t), 0);
+                                if (!copy_resource(reinterpret_cast<uint8_t*>(fr.dwords.data()),
+                                                   r.gpu_addr, nb))
+                                    fr.dwords.clear();
+                            }
+                            if (fr.dwords.empty()) fr.dwords.assign(64, 0);
+                        } else if (!use_direct_buffer_views) {
+                            if (nb >= 4) {
+                                std::vector<uint8_t> tmp(nb, 0);
+                                if (copy_resource(tmp.data(), r.gpu_addr, nb) > 0)
+                                    fr.dwords.assign(
+                                        reinterpret_cast<const uint32_t*>(tmp.data()),
+                                        reinterpret_cast<const uint32_t*>(tmp.data() + nb));
+                            }
+                            if (fr.dwords.empty()) fr.dwords.assign(64, 0);
+                        }
                         // PROSPER_CBLOG: log each constant buffer's first 4 dwords as floats, once per
                         // address. If a scene draw's color/tint CB is (0,0,0,0), the PS outputs black
                         // regardless of the (correctly-decoded) texture — the #300 black-scene suspect.
                         if (getenv("PROSPER_CBLOG") && r.cls == RC::ConstantBuffer) {
                             static std::set<uint64_t> cbseen;
                             if (cbseen.insert(r.gpu_addr).second) {
-                                const float* fp = (const float*)fr.dwords.data();
-                                size_t n = fr.dwords.size();
+                                const uint32_t* words = fr.buffer_words_data();
+                                size_t n = fr.buffer_word_count();
+                                const float* fp = reinterpret_cast<const float*>(words);
                                 fprintf(stderr, "[cb] bind=%u addr=0x%llx size=%u dw=%08x %08x %08x %08x  f=%.3f %.3f %.3f %.3f\n",
                                         r.binding, (unsigned long long)r.gpu_addr, (unsigned)r.size,
-                                        n>0?fr.dwords[0]:0, n>1?fr.dwords[1]:0, n>2?fr.dwords[2]:0, n>3?fr.dwords[3]:0,
+                                        n>0?words[0]:0, n>1?words[1]:0, n>2?words[2]:0, n>3?words[3]:0,
                                         n>0?fp[0]:0.f, n>1?fp[1]:0.f, n>2?fp[2]:0.f, n>3?fp[3]:0.f);
                             }
                         }
@@ -1746,8 +1792,12 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 }
                             }
                         } else {
+                            const size_t buffer_bytes = fr.buffer_word_count() * sizeof(uint32_t);
                             pending_timing.buffers++;
-                            pending_timing.buffer_bytes += static_cast<uint64_t>(fr.dwords.size()) * 4;
+                            pending_timing.buffer_views += resource_buffer_view;
+                            pending_timing.buffer_bytes += buffer_bytes;
+                            if (!resource_buffer_view)
+                                pending_timing.buffer_materialized_bytes += buffer_bytes;
                             pending_timing.buffer_ms += elapsed;
                         }
                     }
@@ -1786,7 +1836,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         d.kind == prosper::gpu::SpirvDescriptorKind::StorageImage;
                     const uint64_t available = first == resources.end() ? 0 :
                         (first->is_texture() ? (uint64_t)first->tw * first->th * first->td * 4
-                                             : first->dwords.size() * 4);
+                                             : first->buffer_word_count() * 4);
                     const bool wrong_type = first != resources.end() &&
                         (wants_buffer ? first->is_texture()
                                       : (!first->is_texture() ||
@@ -2642,13 +2692,13 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     uint64_t color_target_writes = 0, color_target_write_hits = 0;
                     uint64_t color_target_sample_hits = 0, color_target_readbacks = 0;
                     uint64_t color_target_cached_bytes = 0, color_target_cached_entries = 0;
-                    uint64_t textures = 0, texture_reuses = 0, buffers = 0;
+                    uint64_t textures = 0, texture_reuses = 0, buffers = 0, buffer_views = 0;
                     uint64_t persistent_hits = 0, persistent_misses = 0, persistent_invalidations = 0;
                     uint64_t persistent_submit_reuses = 0, persistent_validations = 0;
                     uint64_t persistent_validation_bytes = 0;
                     uint64_t persistent_watch_reuses = 0, persistent_watch_dirty = 0;
                     uint64_t persistent_watch_unknown = 0, persistent_watch_disabled = 0;
-                    uint64_t texture_bytes = 0, buffer_bytes = 0;
+                    uint64_t texture_bytes = 0, buffer_bytes = 0, buffer_materialized_bytes = 0;
                     double texture_ms = 0, buffer_ms = 0;
                 };
                 static TimingTotals totals;
@@ -2700,8 +2750,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     timing.persistent_watch_unknown += pending_timing.persistent_watch_unknown;
                     timing.persistent_watch_disabled += pending_timing.persistent_watch_disabled;
                     timing.buffers += pending_timing.buffers;
+                    timing.buffer_views += pending_timing.buffer_views;
                     timing.texture_bytes += pending_timing.texture_bytes;
                     timing.buffer_bytes += pending_timing.buffer_bytes;
+                    timing.buffer_materialized_bytes += pending_timing.buffer_materialized_bytes;
                     timing.texture_ms += pending_timing.texture_ms;
                     timing.buffer_ms += pending_timing.buffer_ms;
                 };
@@ -2776,12 +2828,16 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             totals.color_target_cached_bytes / (1024.0 * 1024.0));
                     fprintf(stderr,
                             "[render-timing] resources textures=%llu reused=%llu %.1f MiB %.2f ms/submit; "
-                            "buffers=%llu %.1f MiB %.2f ms/submit\n",
+                            "buffers=%llu views=%llu logical=%.1f MiB materialized=%.1f MiB "
+                            "%.2f ms/submit\n",
                             (unsigned long long)totals.textures,
                             (unsigned long long)totals.texture_reuses,
                             totals.texture_bytes / (1024.0 * 1024.0), totals.texture_ms / nsub,
                             (unsigned long long)totals.buffers,
-                            totals.buffer_bytes / (1024.0 * 1024.0), totals.buffer_ms / nsub);
+                            (unsigned long long)totals.buffer_views,
+                            totals.buffer_bytes / (1024.0 * 1024.0),
+                            totals.buffer_materialized_bytes / (1024.0 * 1024.0),
+                            totals.buffer_ms / nsub);
                     fprintf(stderr,
                             "[render-timing] texture_cache hits=%llu submit_reuse=%llu misses=%llu "
                             "watch_reuse=%llu watch_dirty=%llu watch_unknown=%llu watch_disabled=%llu "
@@ -2838,14 +2894,17 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             "[render-window] frontend submits=%llu callbacks=%.1f avg_ms: total=%.2f "
                             "build_resources=%.2f backend=%.2f output_copy=%.2f other=%.2f; "
                             "resources textures=%.1f "
-                            "reused=%.1f %.1f MiB %.2f ms buffers=%.1f %.1f MiB %.2f ms\n",
+                            "reused=%.1f %.1f MiB %.2f ms buffers=%.1f views=%.1f "
+                            "logical=%.1f MiB materialized=%.1f MiB %.2f ms\n",
                             (unsigned long long)window.submits, window.callbacks / wn,
                             window.total_ms / wn, window.build_resources_ms / wn,
                             window.backend_ms / wn, window.output_copy_ms / wn, window_other / wn,
                             window.textures / wn,
                             window.texture_reuses / wn,
                             window.texture_bytes / (wn * 1024.0 * 1024.0), window.texture_ms / wn,
-                            window.buffers / wn, window.buffer_bytes / (wn * 1024.0 * 1024.0),
+                            window.buffers / wn, window.buffer_views / wn,
+                            window.buffer_bytes / (wn * 1024.0 * 1024.0),
+                            window.buffer_materialized_bytes / (wn * 1024.0 * 1024.0),
                             window.buffer_ms / wn);
                     const double window_backend_detail_ms = window.backend_target_ms +
                         window.backend_draw_setup_ms + window.backend_record_upload_ms +

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -32,6 +32,10 @@ namespace prosper::gpu {
 
 struct ShaderResourceTable;   // fwd (shader_resources.hpp); passed to the backend so it can bind resources
 
+// Generation-scoped host-readability guard used while a synchronous GPU submit is active. Positive
+// mapping ranges are cached for that submit only and discarded before guest code can reuse an address.
+bool guest_readable(uint64_t address, uint32_t bytes);
+
 using SharedShaderWords = std::shared_ptr<const std::vector<uint32_t>>;
 
 // One realized draw of a submit: recompiled VS+PS SPIR-V, the draw's OWN resolved fixed-function

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -17,6 +17,7 @@
 #include <mutex>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 namespace prosper::test {
@@ -59,6 +60,15 @@ inline bool dump_bmp(const char* path, const std::vector<uint8_t>& px, uint32_t 
 struct TexDesc { uint32_t binding; uint32_t w; uint32_t h; const uint8_t* rgba;
                  uint32_t max_aniso_ratio = 0; };   // #275: S# anisotropy ratio (0 = isotropic)
 
+inline uint64_t hash_buffer_words(const uint32_t* words, size_t count) {
+    uint64_t hash = 1469598103934665603ull;
+    for (size_t word = 0; word < count; ++word) {
+        hash ^= words[word];
+        hash *= 1099511628211ull;
+    }
+    return hash;
+}
+
 // One resource for the general N-binding path (render_triangle_rgba's `gres`): a storage buffer
 // (dwords non-empty, tex_rgba null), combined image sampler, or storage image at `binding`. Lets a
 // real game shader that declares several buffers and images have each bound distinctly.
@@ -67,7 +77,13 @@ struct FrameResource {
     uint32_t set = 0;               // descriptor set: VS resources -> 0, PS resources -> 1 (they must not
                                     // share a set — both stages number bindings from 2, so one set would
                                     // collide binding 2/3 between stages and make the layout invalid).
-    std::vector<uint32_t> dwords;   // storage-buffer contents (empty -> a 1-dword zero buffer)
+    std::vector<uint32_t> dwords;   // owned storage-buffer contents (empty -> a 1-dword zero buffer)
+    // A production callback may point directly at a fully readable immutable guest/capture range.
+    // The backend consumes and uploads this view synchronously; an explicit submission batch retains
+    // only the completed Vulkan upload, never this pointer. Tests/replays may use the same contract
+    // when their backing outlives render_draws_rgba().
+    const uint32_t* dwords_view = nullptr;
+    size_t dwords_view_count = 0;
     // Exact guest resource identity for a storage buffer. The backend may share an immutable upload
     // within one synchronous call only when both this identity and the complete captured bytes match;
     // zero keeps synthetic/replay resources conservatively distinct.
@@ -106,6 +122,13 @@ struct FrameResource {
     // target is available, bind its GPU image directly instead of uploading `tex_rgba` again.
     // `tex_rgba` remains an optional conservative fallback for an invalidated/missing target.
     uint64_t persistent_render_target_id = 0;
+    const uint32_t* buffer_words_data() const {
+        return dwords_view && dwords_view_count
+            ? dwords_view : (dwords.empty() ? nullptr : dwords.data());
+    }
+    size_t buffer_word_count() const {
+        return dwords_view && dwords_view_count ? dwords_view_count : dwords.size();
+    }
     bool is_texture() const { return tex_rgba != nullptr || persistent_render_target_id != 0; }
 };
 
@@ -2591,13 +2614,13 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                     wr[i].descriptorType = lb[i].descriptorType; wr[i].pImageInfo = &dii[i];
                 } else {
                     lb[i].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER; lb[i].stageFlags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
-                    const uint32_t* words = r.dwords.empty() ? &zero_buffer_word : r.dwords.data();
-                    const size_t word_count = r.dwords.empty() ? 1 : r.dwords.size();
-                    uint64_t content_hash = 1469598103934665603ull;
-                    for (size_t word = 0; word < word_count; ++word) {
-                        content_hash ^= words[word];
-                        content_hash *= 1099511628211ull;
+                    const uint32_t* words = r.buffer_words_data();
+                    size_t word_count = r.buffer_word_count();
+                    if (!words || !word_count) {
+                        words = &zero_buffer_word;
+                        word_count = 1;
                     }
+                    const uint64_t content_hash = hash_buffer_words(words, word_count);
                     SharedBufferKey buffer_key{
                         words, word_count, r.buffer_identity, content_hash,
                         share_backend_resources && r.buffer_identity ? 0 : ++resource_unique_tag};

--- a/prosper/tests/test_multidraw_render.cpp
+++ b/prosper/tests/test_multidraw_render.cpp
@@ -273,6 +273,29 @@ int main() {
                   shared_stats.descriptor_pools == 1,
               "identical draw contracts share layouts and one call-wide descriptor pool");
 
+        // The live frontend can hand the synchronous backend a proven-readable immutable guest view
+        // instead of copying it into each FrameResource. Exercise that representation independently of
+        // guest memory and require it to preserve rendering plus exact-content upload reuse.
+        prosper::test::BackendDraw shared_contents0 = d0;
+        prosper::test::BackendDraw shared_contents1 = d1;
+        for (prosper::test::BackendDraw* draw : {&shared_contents0, &shared_contents1}) {
+            draw->R[0].dwords.clear();
+            draw->R[0].dwords_view = filler.dwords.data();
+            draw->R[0].dwords_view_count = filler.dwords.size();
+            draw->R[1].dwords.clear();
+            draw->R[1].dwords_view = buffer.dwords.data();
+            draw->R[1].dwords_view_count = buffer.dwords.size();
+        }
+        const std::vector<uint8_t> shared_contents = prosper::test::render_draws_rgba(
+            {shared_contents0, shared_contents1}, W, H);
+        const auto shared_contents_stats = prosper::test::backend_resource_reuse_stats();
+        const auto pool_after_shared_contents = prosper::test::render_host_buffer_pool_stats();
+        CHECK(shared_contents == shared,
+              "immutable buffer views render byte-identically to owned vectors");
+        CHECK(shared_contents_stats.buffer_references == 4 &&
+                  shared_contents_stats.unique_buffers == 2,
+              "immutable buffer views retain exact backend upload reuse");
+
         prosper::test::BackendDraw capacity_peer0 = d0;
         prosper::test::BackendDraw capacity_peer1 = d1;
         capacity_peer0.R[1].dwords.resize(61);
@@ -281,8 +304,8 @@ int main() {
             {capacity_peer0, capacity_peer1}, W, H);
         const auto pool_after_second = prosper::test::render_host_buffer_pool_stats();
         const auto layout_stats = prosper::test::backend_resource_reuse_stats();
-        CHECK(pool_after_second.hits == pool_after_first.hits + 1 &&
-                  pool_after_second.misses == pool_after_first.misses &&
+        CHECK(pool_after_second.hits == pool_after_shared_contents.hits + 1 &&
+                  pool_after_second.misses == pool_after_shared_contents.misses &&
                   pooled_again == shared,
               "next logical size reuses the mapped arena byte-identically");
         CHECK(layout_stats.persistent_pipeline_layout_hits >= 1 &&


### PR DESCRIPTION
Closes #1027

## Failure scenario

Dense Evergate frames realize roughly 3,300 storage-buffer references for only about 4 MiB of logical data. The frontend previously allocated a zero-filled byte vector, copied guest memory into it, then allocated and copied again into each FrameResource before the synchronous Vulkan backend immediately hashed and uploaded the same bytes.

## Approach and invariants

- Complete generation-guarded guest ranges and complete captured host ranges become non-owning immutable FrameResource views.
- The Vulkan backend hashes and copies every byte into its mapped upload arena before returning. Submission batches retain only completed Vulkan uploads, never guest pointers.
- Unreadable, partial, unaligned, empty, and oversized ranges keep the owned zero-filled fallback.
- PROSPER_NO_FRONTEND_BUFFER_VIEW=1 restores the former materialization path for comparison.
- Timing now separates logical bytes, direct views, and bytes that required materialization.

This affects frontend storage-buffer construction only. Texture decode/validation, image residency, render-target persistence, descriptor contracts, and cross-submit buffer ownership are unchanged.

## Native Windows A/B

One final RelWithDebInfo binary, fresh saves, native 1920x1080, render scale/every both 1, and the same 360-frame read-anchored Evergate route:

| Measurement | Materialized control | Direct views |
|---|---:|---:|
| Draws / submit | 484.1 | 483.8 |
| Frontend resource construction | 46.3 ms | 34.9 ms |
| Buffer construction | 13.1 ms | 5.1 ms |
| Frontend callback total | 86.8 ms | 74.4 ms |
| Backend execution | 39.1 ms | 38.5 ms |
| Complete route | 43.43 s | 39.62 s |

The route improves by 8.8%; dense resource construction drops by 11.4 ms without moving backend time.

## Verification

- Windows prosper-app and screenshot targets: built successfully
- Linux full build: passed
- Linux ctest: 115/115 passed
- evergate-title: 9/9 qualifying and structural matches
- messenger-scene: 29/29 qualifying and structural matches
- dead-cells-gameplay: 44/44 qualifying and structural matches
- blasphemous2-gameplay: 99/99 qualifying and structural matches

Exact-head author verification will be posted separately after PR publication.