### PR TITLE
hle: fill HDR tone-map luminance query

### DIFF
--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -1103,17 +1103,17 @@ HLE(s_syss_safearea) {
     return 0;
 }
 
-// sceSystemServiceGetHdrToneMapLuminance(SceSystemServiceHdrToneMapLuminance* out). The PS5
-// structure is exactly three floats: max-full-frame, max, and min tone-map luminance. The imported
-// function previously fell through to success-without-output, so display setup consumed poisoned or
-// uninitialized values even though Prosper advertises an SDR output. Match the deterministic PS5
-// baseline used by Kyty: 80-nit full-frame content, 1000-nit peak mastering value, and zero minimum.
+// sceSystemServiceGetHdrToneMapLuminance(out). Kyty models the output as three floats in this order:
+// max-full-frame, max, and min tone-map luminance. The imported function previously fell through to
+// success-without-output, so display setup consumed poisoned values. Use Kyty's 80/1000/0 values as
+// a deterministic fallback; this does not advertise or implement an HDR presentation path.
+// CONFIDENCE: MED on the Kyty-derived 12-byte layout/order; LOW on the real-hardware values.
 struct SysHdrToneMapLuminance {
     float max_full_frame;
     float max;
     float min;
 };
-static_assert(sizeof(SysHdrToneMapLuminance) == 12, "PS5 HDR tone-map luminance ABI");
+static_assert(sizeof(SysHdrToneMapLuminance) == 12, "Kyty-modeled HDR tone-map luminance layout");
 HLE(s_syss_hdr_luminance) {
     auto* luminance = (SysHdrToneMapLuminance*)PW(a0);
     if (!luminance) return 0x80A10003ull;   // SYSTEM_SERVICE_ERROR_PARAMETER

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -1103,6 +1103,26 @@ HLE(s_syss_safearea) {
     return 0;
 }
 
+// sceSystemServiceGetHdrToneMapLuminance(SceSystemServiceHdrToneMapLuminance* out). The PS5
+// structure is exactly three floats: max-full-frame, max, and min tone-map luminance. The imported
+// function previously fell through to success-without-output, so display setup consumed poisoned or
+// uninitialized values even though Prosper advertises an SDR output. Match the deterministic PS5
+// baseline used by Kyty: 80-nit full-frame content, 1000-nit peak mastering value, and zero minimum.
+struct SysHdrToneMapLuminance {
+    float max_full_frame;
+    float max;
+    float min;
+};
+static_assert(sizeof(SysHdrToneMapLuminance) == 12, "PS5 HDR tone-map luminance ABI");
+HLE(s_syss_hdr_luminance) {
+    auto* luminance = (SysHdrToneMapLuminance*)PW(a0);
+    if (!luminance) return 0x80A10003ull;   // SYSTEM_SERVICE_ERROR_PARAMETER
+    luminance->max_full_frame = 80.0f;
+    luminance->max = 1000.0f;
+    luminance->min = 0.0f;
+    return 0;
+}
+
 // sceAppContentTemporaryDataMount2(option, SceAppContentMountPoint* mp) — mount the app's temp-data
 // area and write its guest path into mp. SceAppContentMountPoint = char data[16] (shadPS4
 // app_content.h; PS4/PS5 identical). shadPS4 writes exactly "/temp0\0" and returns 0. Our previous
@@ -2221,6 +2241,8 @@ void register_service_hle() {
     R("sceSystemServiceReceiveEvent", s_sysservice_receiveevent);   // NO_EVENT, don't leave the struct garbage
     // sceSystemServiceGetDisplaySafeAreaInfo (1n37q1Bvc5Y) — fill ratio=1.0 (see s_syss_safearea).
     Hle::register_fn("1n37q1Bvc5Y", (HleFn)s_syss_safearea, "sceSystemServiceGetDisplaySafeAreaInfo");
+    Hle::register_fn("mPpPxv5CZt4", (HleFn)s_syss_hdr_luminance,
+                     "sceSystemServiceGetHdrToneMapLuminance");
 
     // ---- Issue #232 services (raw NIDs; every pair verified against the PS5 3.20 stub tables) ----
     // libScePlayGo — everything installed & locus-local.

--- a/prosper/tests/test_service_getters.cpp
+++ b/prosper/tests/test_service_getters.cpp
@@ -191,6 +191,23 @@ int main() {
             CHECK(ratio == 1.0f, "GetDisplaySafeAreaInfo -> ratio 1.0 (full display, no viewport collapse)");
         } else CHECK(false, "sceSystemServiceGetDisplaySafeAreaInfo registered");
 
+        // sceSystemServiceGetHdrToneMapLuminance(out*) -> exact three-float PS5 ABI. A success-only
+        // stub left all three display-setup inputs poisoned, while an oversized fill would corrupt
+        // adjacent guest stack storage.
+        if (HleFn f = Hle::lookup("mPpPxv5CZt4")) {
+            struct GuardedLuminance { float value[3]; uint8_t canary[4]; } out;
+            memset(&out, 0xAB, sizeof out);
+            CHECK(f((uint64_t)(uintptr_t)&out.value, 0, 0, 0, 0, 0) == 0,
+                  "GetHdrToneMapLuminance -> OK");
+            CHECK(out.value[0] == 80.0f && out.value[1] == 1000.0f && out.value[2] == 0.0f,
+                  "GetHdrToneMapLuminance writes deterministic full-frame/peak/min values");
+            bool canary_ok = true;
+            for (uint8_t byte : out.canary) if (byte != 0xAB) canary_ok = false;
+            CHECK(canary_ok, "GetHdrToneMapLuminance writes exactly its 12-byte ABI object");
+            CHECK(f(0, 0, 0, 0, 0, 0) == 0x80A10003ull,
+                  "GetHdrToneMapLuminance rejects a null output pointer");
+        } else CHECK(false, "sceSystemServiceGetHdrToneMapLuminance registered");
+
         // sceAppContentTemporaryDataMount2(opt, char mp[16]) -> exactly "/temp0\0" (7 bytes), never 16.
         if (HleFn f = Hle::lookup("buYbeLOGWmA")) {
             char mp[16]; memset(mp, 0xAB, sizeof mp);

--- a/prosper/tests/test_service_getters.cpp
+++ b/prosper/tests/test_service_getters.cpp
@@ -191,19 +191,19 @@ int main() {
             CHECK(ratio == 1.0f, "GetDisplaySafeAreaInfo -> ratio 1.0 (full display, no viewport collapse)");
         } else CHECK(false, "sceSystemServiceGetDisplaySafeAreaInfo registered");
 
-        // sceSystemServiceGetHdrToneMapLuminance(out*) -> exact three-float PS5 ABI. A success-only
-        // stub left all three display-setup inputs poisoned, while an oversized fill would corrupt
-        // adjacent guest stack storage.
+        // sceSystemServiceGetHdrToneMapLuminance(out*) -> Kyty-derived three-float layout. A
+        // success-only stub left all three display-setup inputs poisoned, while an oversized fill
+        // would corrupt adjacent guest stack storage.
         if (HleFn f = Hle::lookup("mPpPxv5CZt4")) {
             struct GuardedLuminance { float value[3]; uint8_t canary[4]; } out;
             memset(&out, 0xAB, sizeof out);
             CHECK(f((uint64_t)(uintptr_t)&out.value, 0, 0, 0, 0, 0) == 0,
                   "GetHdrToneMapLuminance -> OK");
             CHECK(out.value[0] == 80.0f && out.value[1] == 1000.0f && out.value[2] == 0.0f,
-                  "GetHdrToneMapLuminance writes deterministic full-frame/peak/min values");
+                  "GetHdrToneMapLuminance writes the deterministic Kyty-derived fallback values");
             bool canary_ok = true;
             for (uint8_t byte : out.canary) if (byte != 0xAB) canary_ok = false;
-            CHECK(canary_ok, "GetHdrToneMapLuminance writes exactly its 12-byte ABI object");
+            CHECK(canary_ok, "GetHdrToneMapLuminance writes only its modeled 12-byte output");
             CHECK(f(0, 0, 0, 0, 0, 0) == 0x80A10003ull,
                   "GetHdrToneMapLuminance rejects a null output pointer");
         } else CHECK(false, "sceSystemServiceGetHdrToneMapLuminance registered");


### PR DESCRIPTION
Part of #664.`n`nRegisters sceSystemServiceGetHdrToneMapLuminance at the pinned PS5 3.20 NID and replaces success-without-output with a bounded 12-byte three-float output. The modeled field order, 80/1000/0 values, and parameter error are derived from Kyty PS5 SystemService; code comments explicitly mark MED confidence on that layout/order and LOW confidence on real-hardware values. Adds poisoned-output, canary, value, lookup, and null-pointer coverage.`n`nThis is only a deterministic query fallback. It does not claim hardware-accurate luminance values or add HDR swapchain, renderer, tone-mapping, or VideoOut format support. No game, snapshot, capture, or pause workflow is involved.