### PR TITLE
fix(libc): match Sony Dinkumware ctype masks

### DIFF
--- a/prosper/src/hle/hle_libc.cpp
+++ b/prosper/src/hle/hle_libc.cpp
@@ -8,11 +8,11 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstdarg>
-#include <cctype>
 #include <cmath>
 #include <cwchar>
 #include <cerrno>
 #include <cstddef>
+#include <array>
 #include <limits>
 #include <atomic>
 #include <mutex>
@@ -432,30 +432,50 @@ HLE(h_putchar)   { return (uint64_t)(int64_t)putchar((int)a0); }
 HLE(h_fputs)     { return (uint64_t)(int64_t)fputs((const char*)P(a0), a1 ? (FILE*)P(a1) : stdout); }
 
 // --- locale / ctype (Dinkumware CRT: _Getpctype/_Getpt{o,}lower return table ptrs) ---
-// Tables have 257 entries; element [-1] is the EOF slot, so we return base+1 and the
-// guest indexes [c] for c in 0..255 (and [-1] for EOF). Classification bits follow the
-// common MSVCRT/Dinkumware layout; built from the host's ctype so they're correct.
+// The 257-entry C-locale table and masks match Dinkumware 5.00: _XD=0x01, _UP=0x02,
+// _SP=0x04, _PU=0x08, _LO=0x10, _DI=0x20, _CN=0x40, _BB=0x80, _XS=0x100,
+// _XA=0x200, and _XB=0x400. A captured PS5 guest inline isspace uses test 0x144,
+// exactly _CN|_SP|_XS, which pins Sony's contract. CONFIDENCE: HIGH.
+// Element [-1] is the EOF slot; bytes 0x80..0xff are unclassified in the C locale.
 namespace {
-    short g_ctype[257], g_tolow[257], g_toup[257];
-    bool  g_ctype_built = false;
-    void build_ctype() {
-        if (g_ctype_built) return;
-        g_ctype[0] = g_tolow[0] = g_toup[0] = 0;   // EOF slot
-        for (int c = 0; c < 256; c++) {
-            short m = 0;
-            if (isupper(c)) m |= 0x01; if (islower(c)) m |= 0x02; if (isdigit(c)) m |= 0x04;
-            if (isspace(c)) m |= 0x08; if (ispunct(c)) m |= 0x10; if (iscntrl(c)) m |= 0x20;
-            if (c == ' ' || c == '\t') m |= 0x40; if (isxdigit(c)) m |= 0x80;
-            g_ctype[c + 1] = m;
-            g_tolow[c + 1] = (short)tolower(c);
-            g_toup[c + 1]  = (short)toupper(c);
+    using CtypeTable = std::array<short, 257>;
+
+    constexpr CtypeTable make_ctype_table() {
+        CtypeTable table{};
+        for (int c = 0; c < 128; ++c) {
+            short mask = 0;
+            if (c <= 0x08 || (c >= 0x0e && c <= 0x1f) || c == 0x7f) mask |= 0x080; // _BB
+            if (c >= 0x09 && c <= 0x0d) mask |= 0x0c0;                              // _BB|_CN
+            if (c == '\t') mask |= 0x400;                                           // _XB
+            if (c == ' ') mask |= 0x004;                                            // _SP
+            if ((c >= '!' && c <= '/') || (c >= ':' && c <= '@') ||
+                (c >= '[' && c <= '`') || (c >= '{' && c <= '~')) mask |= 0x008;   // _PU
+            if (c >= '0' && c <= '9') mask |= 0x021;                                // _DI|_XD
+            if (c >= 'A' && c <= 'Z') mask |= short(0x002 | (c <= 'F' ? 0x001 : 0)); // _UP|_XD
+            if (c >= 'a' && c <= 'z') mask |= short(0x010 | (c <= 'f' ? 0x001 : 0)); // _LO|_XD
+            table[c + 1] = mask;
         }
-        g_ctype_built = true;
+        return table;
     }
+
+    constexpr CtypeTable make_case_table(bool upper) {
+        CtypeTable table{};
+        table[0] = -1; // EOF
+        for (int c = 0; c < 256; ++c) {
+            if (upper && c >= 'a' && c <= 'z') table[c + 1] = short(c - ('a' - 'A'));
+            else if (!upper && c >= 'A' && c <= 'Z') table[c + 1] = short(c + ('a' - 'A'));
+            else table[c + 1] = short(c);
+        }
+        return table;
+    }
+
+    constexpr CtypeTable g_ctype = make_ctype_table();
+    constexpr CtypeTable g_tolow = make_case_table(false);
+    constexpr CtypeTable g_toup = make_case_table(true);
 }
-HLE(h_getpctype)  { build_ctype(); return (uint64_t)(uintptr_t)(g_ctype + 1); }
-HLE(h_getptolow)  { build_ctype(); return (uint64_t)(uintptr_t)(g_tolow + 1); }
-HLE(h_getptoup)   { build_ctype(); return (uint64_t)(uintptr_t)(g_toup + 1); }
+HLE(h_getpctype)  { return (uint64_t)(uintptr_t)(g_ctype.data() + 1); }
+HLE(h_getptolow)  { return (uint64_t)(uintptr_t)(g_tolow.data() + 1); }
+HLE(h_getptoup)   { return (uint64_t)(uintptr_t)(g_toup.data() + 1); }
 // glibc contract: __ctype_get_mb_cur_max returns the VALUE of MB_CUR_MAX (size_t),
 // not a pointer. 1 in the "C" locale we present via setlocale.
 HLE(h_mbcurmax)   { return 1; }

--- a/prosper/tests/test_hle_registered.cpp
+++ b/prosper/tests/test_hle_registered.cpp
@@ -58,6 +58,52 @@ int main() {
         if (v != 1) { printf("  [FAIL] __ctype_get_mb_cur_max returned %llu, want 1 (the value, not a pointer)\n", (unsigned long long)v); fails++; }
     } else { printf("  [FAIL] not registered: __ctype_get_mb_cur_max\n"); fails++; }
 
+    // Sony's Dinkumware inline isspace uses (_Getpctype()[c] & 0x144), not the
+    // incompatible MSVCRT bit layout. Pin representative C-locale masks and EOF/case slots.
+    if (HleFn fn = Hle::lookup(nid_hash("_Getpctype"))) {
+        const auto* table = reinterpret_cast<const short*>(fn(0, 0, 0, 0, 0, 0));
+        struct Expected { unsigned char ch; short mask; };
+        constexpr Expected expected[] = {
+            {0x00, 0x080}, {'\t', 0x4c0}, {'\n', 0x0c0}, {' ', 0x004},
+            {'!', 0x008}, {'0', 0x021}, {'A', 0x003}, {'G', 0x002},
+            {'a', 0x011}, {'g', 0x010}, {0x7f, 0x080}, {0x80, 0x000}, {0xff, 0x000},
+        };
+        if (!table || table[-1] != 0) {
+            printf("  [FAIL] _Getpctype missing table or EOF slot\n");
+            fails++;
+        } else {
+            for (const auto& item : expected) {
+                if (table[item.ch] != item.mask) {
+                    printf("  [FAIL] _Getpctype[0x%02x] = 0x%x, want 0x%x\n",
+                           item.ch, unsigned(short(table[item.ch])), unsigned(short(item.mask)));
+                    fails++;
+                }
+            }
+            constexpr short dinkumware_isspace = 0x144; // _CN|_SP|_XS
+            if (!(table[' '] & dinkumware_isspace) || !(table['\t'] & dinkumware_isspace) ||
+                !(table['\n'] & dinkumware_isspace) || (table['A'] & dinkumware_isspace)) {
+                printf("  [FAIL] _Getpctype does not satisfy Dinkumware isspace mask 0x144\n");
+                fails++;
+            }
+        }
+    } else { printf("  [FAIL] not registered: _Getpctype\n"); fails++; }
+
+    if (HleFn lower = Hle::lookup(nid_hash("_Getptolower")); lower) {
+        const auto* table = reinterpret_cast<const short*>(lower(0, 0, 0, 0, 0, 0));
+        if (!table || table[-1] != -1 || table['A'] != 'a' || table['a'] != 'a' || table[0xff] != 0xff) {
+            printf("  [FAIL] _Getptolower C-locale/EOF table contract\n");
+            fails++;
+        }
+    } else { printf("  [FAIL] not registered: _Getptolower\n"); fails++; }
+
+    if (HleFn upper = Hle::lookup(nid_hash("_Getptoupper")); upper) {
+        const auto* table = reinterpret_cast<const short*>(upper(0, 0, 0, 0, 0, 0));
+        if (!table || table[-1] != -1 || table['a'] != 'A' || table['A'] != 'A' || table[0xff] != 0xff) {
+            printf("  [FAIL] _Getptoupper C-locale/EOF table contract\n");
+            fails++;
+        }
+    } else { printf("  [FAIL] not registered: _Getptoupper\n"); fails++; }
+
     if (HleFn fn = Hle::lookup(nid_hash("getpid"))) {
         uint64_t v = fn(0, 0, 0, 0, 0, 0);
         if (v == 0) { printf("  [FAIL] getpid returned kernel-special pid 0\n"); fails++; }


### PR DESCRIPTION
## Summary
- replace the incompatible MSVCRT-style `_Getpctype` masks with the Dinkumware 5.00 C-locale layout used by Sony's CRT
- make the classification/lower/upper tables immutable compile-time data and preserve the `[-1]` EOF contract
- pin representative masks, the captured guest `isspace` mask `0x144`, case conversion, high-byte behavior, and EOF slots in the registered-HLE regression

## Evidence
- the repository's captured guest callsite uses `test $0x144` after `_Getpctype`; `0x144` is exactly Dinkumware `_CN | _SP | _XS`
- the public Dinkumware/QNX 5.00 `ctype.h` and `xctype.c` define the masks and 257-entry table shape used here
- confidence is marked HIGH for the table contract; the implementation presents only the existing deterministic C locale

## Focused test run
- `cmake --build prosper/build-windows --target test_hle_registered -j 2`
- `ctest --test-dir prosper/build-windows -R '^hle_functions_registered$' --output-on-failure` (1/1 passed)

Closes #390