### PR TITLE
gpu(shader): recompile integer sub-dword buffer_load_format at runtime byte addr (#590)

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -5187,6 +5187,14 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                             fmt == DataFormat::Uint2_10_10_10);
             bool is_sint = (fmt == DataFormat::Sint8 || fmt == DataFormat::Sint16 ||
                             fmt == DataFormat::Sint2_10_10_10);
+            // A buffer_load_FORMAT whose V# type is a sub-dword integer (Uint8/Sint8/Uint16/Sint16)
+            // reads tightly-packed integer components at a RUNTIME byte address — exactly like the raw
+            // buffer_load_ubyte/ushort path, NOT the descriptor-defined statically-aligned packing the
+            // norm/half formats use. DOLL's post-process LUT compute kernels index a stride-1 Uint8
+            // table this way (`buffer_load_format_x v, vIDX, V#`, idxen), which the aligned packed path
+            // below wrongly rejected as unaligned. Handle it with a runtime byte/halfword extract.
+            const bool int_subword = is_format && !raw_subword && (is_uint || is_sint) &&
+                                     (comp_bytes == 1 || comp_bytes == 2);
             float norm = 0.0f;
             switch (fmt) {
                 case DataFormat::Unorm8:  norm = 255.0f;   break;
@@ -5211,6 +5219,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // the gap) rather than silently mis-decode. Aligned iff: inst offset %4==0; stride %4==0
             // when idxen; no offen (a runtime per-lane byte offset is unprovable); SOFFSET is NULL/0.
             bool dyn_half = false;   // 16-bit element at a runtime dword half (stride-2 buffers, #273)
+            bool dyn_int = false;    // integer sub-dword FORMAT component at a runtime (unaligned) byte addr
             if (packed && !raw_subword) {
                 bool base_aligned;
                 if (dyn_vfetch) {
@@ -5239,7 +5248,11 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                                      (in.src[2].kind == OperandKind::InlineInt && in.src[2].value == 0);
                     dyn_half = !packed_word && !is_store && n == 1 && comp_bytes == 2 && !offen && !dyn_vfetch &&
                                (offset & 1u) == 0 && (!idxen || (stride & 1u) == 0) && soff_zero;
-                    if (!dyn_half) {
+                    // An integer sub-dword FORMAT load extracts each component at its runtime byte
+                    // address (join the straddled dwords, then bfe), so it needs no static alignment.
+                    // Only LOADS: the packed store path still rejects sub-dword ints (they don't pack).
+                    if (!dyn_half) dyn_int = int_subword && !is_store;
+                    if (!dyn_half && !dyn_int) {
                         if (getenv("PROSPER_DBG"))
                             fprintf(stderr, "[mubuf-unaligned] pc=%u fmt=%u off=%u offen=%d idxen=%d stride=%u\n",
                                     in.pc, (unsigned)fmt, offset, (int)offen, (int)idxen, stride);
@@ -5390,6 +5403,26 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                           : is_uint ? b.bfe_u(dws, b.uconst(0), b.uconst(16))
                           : is_sint ? b.bfe_s(dws, b.uconst(0), b.uconst(16))
                                     : b.unpack_norm(dws, 0, 16, is_snorm, norm);
+                } else if (dyn_int) {
+                    // Integer sub-dword FORMAT component k at a runtime byte address (addr + k*comp_bytes):
+                    // shift the loaded dword right by (byteaddr&3)*8, join the next dword when a 16-bit
+                    // field straddles the boundary, then zero-/sign-extend the comp_bytes*8-bit field.
+                    // Mirrors the raw_subword path but per packed component (stride-1 Uint8, unaligned u16).
+                    const uint32_t caddr = k ? b.ibin(Op_IAdd, addr, b.uconst(k * comp_bytes)) : addr;
+                    const uint32_t cidx  = b.ibin(Op_ShiftRightLogical, caddr, b.uconst(2));
+                    const uint32_t shift = b.ibin(Op_ShiftLeftLogical,
+                                                  b.ibin(Op_BitwiseAnd, caddr, b.uconst(3)), b.uconst(3));
+                    uint32_t joined = b.ibin(Op_ShiftRightLogical, b.cbuf_load(cidx, binding), shift);
+                    if (comp_bytes == 2) {
+                        const uint32_t dw1 = b.cbuf_load(b.ibin(Op_IAdd, cidx, b.uconst(1)), binding);
+                        const uint32_t inv_shift = b.ibin(Op_BitwiseAnd,
+                            b.ibin(Op_ISub, b.uconst(32), shift), b.uconst(31));
+                        const uint32_t upper = b.ibin(Op_ShiftLeftLogical, dw1, inv_shift);
+                        joined = b.ibin(Op_BitwiseOr, joined,
+                                        b.sel(b.ucmp(Op_IEqual, shift, b.uconst(0)), b.uconst(0), upper));
+                    }
+                    value = is_sint ? b.bfe_s(joined, b.uconst(0), b.uconst(comp_bytes * 8))
+                                    : b.bfe_u(joined, b.uconst(0), b.uconst(comp_bytes * 8));
                 } else {
                     // Component k lives at byte k*comp_bytes within the element: pick its dword + field.
                     uint32_t byte_off = k * comp_bytes;

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -659,6 +659,34 @@ int main() {
                              &offset_compute_table, direct_copy_config).empty(),
           "#636: compute format-load keeps base B and applies nonzero instruction offset once");
 
+    // #590: a stride-1 Uint8 buffer_load_format_x at a runtime (non-dword-aligned) byte address.
+    // DOLL's post-process LUT compute kernels index a Uint8 table this way; the descriptor-defined
+    // aligned packed extraction rejected it (stride 1 is not 4-aligned) until the integer sub-dword
+    // dynamic-extract path. It must resolve the V# AND recompile to non-empty SPIR-V.
+    static uint32_t u8_table[4] = { 0x03020100u };            // 4 bytes {0,1,2,3}, one dword
+    const uint64_t u8_base = (uint64_t)(uintptr_t)u8_table;
+    uint32_t u8_seed[12] = {};
+    u8_seed[8]  = (uint32_t)u8_base;                          // V# at s[8:11]: base low
+    u8_seed[9]  = ((uint32_t)(u8_base >> 32) & 0xFFFFu) | (1u << 16);  // base hi | stride=1
+    u8_seed[10] = 4u;                                         // num_records = 4
+    u8_seed[11] = (5u << 12) | 4u;                            // format field 5 (8_UINT), dst_sel_x = X
+    const uint32_t u8_format_load[] = {
+        0xE0002000u, 0x80020000u,   // buffer_load_format_x v0, v0, s[8:11], 0 idxen
+        0xBF810000u,
+    };
+    ShaderResourceTable u8_table_rt;
+    add_compute_buffer_resources(u8_table_rt, u8_format_load, std::size(u8_format_load),
+                                 u8_seed, std::size(u8_seed));
+    assign_convention_bindings(u8_table_rt, 2);
+    ComputeShaderConfig u8_config;
+    u8_config.user_sgprs.assign(u8_seed, u8_seed + std::size(u8_seed));
+    u8_config.local_x = u8_config.local_y = u8_config.local_z = 1;
+    CHECK(u8_table_rt.by_fetch_pc(0) &&
+          u8_table_rt.by_fetch_pc(0)->format == DataFormat::Uint8 &&
+          !recompile_compute(u8_format_load, std::size(u8_format_load),
+                             &u8_table_rt, u8_config).empty(),
+          "#590: stride-1 Uint8 buffer_load_format_x recompiles via the integer sub-dword dynamic path");
+
     const uint32_t rewritten_copy_dest[] = {
         0xBE840380u,                // s_mov_b32 s4, 0 (seed destination is no longer live)
         0xE01C2000u, 0x80010101u,   // buffer_store_format_xyzw v[1:4], v1, s[4:7], 0 idxen


### PR DESCRIPTION
## Goal / issue
Reduce the DOLL (DRAGON QUEST VII Reimagined, PPSA17942) compute-shader recompile frontier (#590) so its post-process dispatches recompile instead of being skipped — a step toward the visible 3D title.

## Failure scenario
`resolve_dynamic_fetch` resolves a DOLL post-process compute kernel's `buffer_load_format_x v0, v0, s[8:11], idxen` to a **Uint8** V# (`format field 5`, stride 1, num_records 4). The recompiler's buffer-load path then treats it as a "packed" format load and requires the element base be provably 4-byte-aligned. A stride-1 idxen index is not (`stride & 3 != 0`), so it emitted `[mubuf-unaligned]` and returned empty → the whole kernel was skipped (`skip unsupported program`), leaving its LUT surface unproduced (part of the near-black post-splash title).

## Root cause
A `buffer_load_format` whose V# type is a sub-dword INTEGER (Uint8/Sint8/Uint16/Sint16) delivers raw integer components at a **runtime byte address** — identical to the `buffer_load_ubyte/ushort` (`raw_subword`) contract — not the statically-dword-aligned descriptor packing that UNORM/half formats use. The aligned path simply doesn't apply to it.

## Change (`rdna2_to_spirv.cpp`)
Add an integer sub-dword dynamic-extract path (`dyn_int`). For each component k, take the runtime byte address `addr + k*comp_bytes`, shift the loaded dword right by `(byteaddr & 3)*8`, join the next dword when a 16-bit field straddles the dword boundary, then zero-/sign-extend the `comp_bytes*8`-bit field — mirroring the existing `raw_subword` byte/short extraction, per packed component.

**Strictly additive:** `dyn_int` is set only inside the existing `!base_aligned` branch that previously rejected, and only for `is_format && (is_uint||is_sint) && comp_bytes∈{1,2}` LOADS. Aligned integer format loads keep the existing static extraction; stores are unchanged; no other format is affected.

## Verification
- Routed PPSA17942 boot: `skip unsupported program` **4 → 3** (the Uint8-LUT kernel now recompiles), **0** remaining `[mubuf-unaligned]` / `fmt=12 op=0x0` rejects.
- New `test_dynfetch_fold` case recompiles a stride-1 Uint8 `buffer_load_format_x` (resolves the V# as Uint8 and returns non-empty SPIR-V); it returns **empty without this fix**, so it's non-vacuous.
- Linux `ctest`: all recompiler/render/dynfetch/compute tests green (120 tests; the 3 red are Messenger-dump-specific — `module_loads_eboot`, `boot_reaches_first_syscall`, `real_shader_render` — failing only because this worktree is configured with the PPSA17942 dump, unrelated to this change).

## Not yet fixed (tracked #590)
The remaining 3 DOLL post-process shaders are the 3D-LUT generators and still fail on nested-loop + `s_barrier` CFG structurizing — the next step toward the visible title. No progression screenshot is claimed here.

## Risk
Low. Additive recompiler path reachable only by a previously-rejected instruction class, with a regression test that fails without it.
