### PR TITLE
gpu(shader): implement the MUBUF 32-bit atomic RMW family (#590)

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -5005,8 +5005,9 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 // 32-bit atomic RMW family (RDNA2 MUBUF opcodes 0x30..0x3b). Each does
                 // mem = mem OP VDATA and returns the PRE-op value in VDATA. They all share the generic
                 // OpAtomic<Op>(ptr, Device, AcqRel, value) shape emitted by cbuf_atomic_rtn. VDATA is one
-                // dword. CMPSWAP (0x31, two-operand), INC/DEC (0x3c/0x3d, wrap semantics), and the x2
-                // 64-bit variants stay deferred (fail-visible) — they need distinct lowering.
+                // dword. CMPSWAP (0x31, two-operand), CSUB (0x34, conditional-subtract), INC/DEC
+                // (0x3c/0x3d, wrap semantics), and the x2 64-bit variants stay deferred (fail-visible)
+                // via the default case below — they need distinct lowering, not a plain RMW.
                 case 0x30: n = 1; is_atomic = true; atomic_op = Op_AtomicExchange; break; // swap
                 case 0x32: n = 1; is_atomic = true; atomic_op = Op_AtomicIAdd;     break; // add
                 case 0x33: n = 1; is_atomic = true; atomic_op = Op_AtomicISub;     break; // sub

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -48,7 +48,8 @@ enum : uint32_t {
     Op_ImageRead=98, Op_ImageWrite=99, Op_ImageQuerySizeLod=103, Op_ImageQueryLevels=106,
     Op_TypeArray=28, Op_ControlBarrier=224, Op_AtomicExchange=229, Op_AtomicIAdd=234,
     Op_AtomicISub=235,
-    Op_AtomicUMin=237, Op_AtomicUMax=239,
+    Op_AtomicSMin=236, Op_AtomicUMin=237, Op_AtomicSMax=238, Op_AtomicUMax=239,
+    Op_AtomicAnd=240, Op_AtomicOr=241, Op_AtomicXor=242,
     Op_DPdx=207, Op_DPdy=208,   // screen-space derivatives (Fragment; plain Shader capability)
     Op_Phi=245, Op_LoopMerge=246,
     Op_SelectionMerge=247, Op_Label=248, Op_Branch=249, Op_BranchConditional=250, Op_Switch=251,
@@ -4977,6 +4978,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // later register consumers, so reject until status-return semantics are implemented.
             if (in.fmt == Rdna2Format::MTBUF && in.mtbuf_tfe) { ok = false; return true; }
             uint32_t n = 0; bool is_format = false, is_store = false, is_atomic = false;
+            uint32_t atomic_op = 0;   // SPIR-V atomic RMW opcode for is_atomic (set by the switch)
             bool raw_subword = false, raw_signed = false;
             uint32_t raw_bits = 32;
             switch (in.opcode) {
@@ -5000,7 +5002,21 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 case 0x5: n = 2; is_format = true; is_store = true; break;   // buffer_store_format_xy
                 case 0x6: n = 3; is_format = true; is_store = true; break;   // buffer_store_format_xyz
                 case 0x7: n = 4; is_format = true; is_store = true; break;   // buffer_store_format_xyzw
-                case 0x38: n = 1; is_atomic = true; break; // buffer_atomic_umax: mem=max_u32(mem,VDATA), VDATA=old
+                // 32-bit atomic RMW family (RDNA2 MUBUF opcodes 0x30..0x3b). Each does
+                // mem = mem OP VDATA and returns the PRE-op value in VDATA. They all share the generic
+                // OpAtomic<Op>(ptr, Device, AcqRel, value) shape emitted by cbuf_atomic_rtn. VDATA is one
+                // dword. CMPSWAP (0x31, two-operand), INC/DEC (0x3c/0x3d, wrap semantics), and the x2
+                // 64-bit variants stay deferred (fail-visible) — they need distinct lowering.
+                case 0x30: n = 1; is_atomic = true; atomic_op = Op_AtomicExchange; break; // swap
+                case 0x32: n = 1; is_atomic = true; atomic_op = Op_AtomicIAdd;     break; // add
+                case 0x33: n = 1; is_atomic = true; atomic_op = Op_AtomicISub;     break; // sub
+                case 0x35: n = 1; is_atomic = true; atomic_op = Op_AtomicSMin;     break; // smin (signed)
+                case 0x36: n = 1; is_atomic = true; atomic_op = Op_AtomicUMin;     break; // umin (unsigned)
+                case 0x37: n = 1; is_atomic = true; atomic_op = Op_AtomicSMax;     break; // smax (signed)
+                case 0x38: n = 1; is_atomic = true; atomic_op = Op_AtomicUMax;     break; // umax (unsigned)
+                case 0x39: n = 1; is_atomic = true; atomic_op = Op_AtomicAnd;      break; // and
+                case 0x3a: n = 1; is_atomic = true; atomic_op = Op_AtomicOr;       break; // or
+                case 0x3b: n = 1; is_atomic = true; atomic_op = Op_AtomicXor;      break; // xor
                 default: ok = false; return true;           // remaining typed/atomic opcodes deferred
             }
             uint32_t offset = in.literal & 0xFFFu;
@@ -5278,7 +5294,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 const uint32_t old = vreg_old(b, rs, d);
                 const auto it = rs.vreg.find(d);
                 const uint32_t value = it == rs.vreg.end() ? b.uconst(0) : it->second;
-                const uint32_t pre = b.cbuf_atomic_rtn(Op_AtomicUMax, idx, value, binding,
+                const uint32_t pre = b.cbuf_atomic_rtn(atomic_op, idx, value, binding,
                                                        rs.exec_narrowed, rs.exec, old);
                 // ISA 8.1 / Table 98: for atomics GLC means "return pre-op value to VGPR". With
                 // GLC=0 hardware leaves VDATA untouched (it still holds the DATA operand) — the

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -952,6 +952,47 @@ int main() {
               bad24mt_store_xy00 == 0,
           "MTBUF XYZW store honors XY00 format width and leaves the adjacent dword untouched");
 
+    // Kernel 24atomic (#590): the MUBUF 32-bit atomic RMW family. buffer_atomic_add over a binding-3
+    // storage buffer — all N dispatched lanes each add 3 to element 0, so the final memory word is 3N.
+    // This exercises the opcode -> SPIR-V-atomic mapping end-to-end through the proven cbuf_atomic_rtn
+    // path (real Vulkan atomic accumulation, not just recompile).
+    ShaderResourceTable rt_atomic;
+    { ShaderResource ab{}; ab.cls = ResourceClass::ConstantBuffer; ab.format = DataFormat::Uint32;
+      ab.num_components = 1; ab.binding = 3; ab.stride = 4; ab.sgpr_base = 8; ab.fetch_pc = 1;
+      rt_atomic.resources.push_back(ab); }
+    const uint32_t code_atomic_add[] = {
+        0x7e020283u,               // v_mov_b32 v1, 3                 (the value to add)
+        0xe0c80000u, 0x80020100u,  // buffer_atomic_add v1, v0, s[8:11]  (op 0x32, element 0)
+        0xbf810000u,
+    };
+    std::vector<uint32_t> spv_atomic_add = recompile_valu(
+        code_atomic_add, std::size(code_atomic_add), 1, 0, &rt_atomic);
+    std::vector<uint32_t> atomic_buf_in(1, 0), atomic_buf_out;
+    std::vector<float> atomic_dummy(N, 0.0f);
+    prosper::test::run_compute(spv_atomic_add, atomic_dummy, N, N, {}, atomic_buf_in, &atomic_buf_out);
+    CHECK(!spv_atomic_add.empty() && atomic_buf_out.size() == 1 &&
+              atomic_buf_out[0] == (uint32_t)N * 3u,
+          "#590: buffer_atomic_add accumulates N lanes x 3 into element 0 (= 3N)");
+
+    // The rest of the 32-bit RMW family recompiles to valid SPIR-V (same emit, different atomic op).
+    const uint32_t atomic_op_dw0[] = {
+        0xE0C00000u,   // buffer_atomic_swap (0x30)
+        0xE0CC0000u,   // buffer_atomic_sub  (0x33)
+        0xE0D40000u,   // buffer_atomic_smin (0x35)
+        0xE0D80000u,   // buffer_atomic_umin (0x36)
+        0xE0DC0000u,   // buffer_atomic_smax (0x37)
+        0xE0E40000u,   // buffer_atomic_and  (0x39)
+        0xE0E80000u,   // buffer_atomic_or   (0x3a)
+        0xE0EC0000u,   // buffer_atomic_xor  (0x3b)
+    };
+    uint32_t atomic_bad = 0;
+    for (uint32_t dw0 : atomic_op_dw0) {
+        const uint32_t code[] = { 0x7e020283u, dw0, 0x80020100u, 0xbf810000u };
+        if (recompile_valu(code, std::size(code), 1, 0, &rt_atomic).empty()) ++atomic_bad;
+    }
+    CHECK(atomic_bad == 0,
+          "#590: swap/sub/smin/umin/smax/and/or/xor MUBUF atomics all recompile to SPIR-V");
+
     // Kernel 24b (#150): the SAME unorm8x4 fetch but with a NON-dword-aligned inst offset (offset:2).
     // The packed unpack extracts components at static byte offsets from a dword-aligned base and drops
     // addr&3, so a non-aligned element base would decode the wrong bits — it must be REJECTED (the

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -993,6 +993,21 @@ int main() {
     CHECK(atomic_bad == 0,
           "#590: swap/sub/smin/umin/smax/and/or/xor MUBUF atomics all recompile to SPIR-V");
 
+    // Behaviorally verify a bitwise atomic too (catches an op transposition among the recompile-only
+    // set): element 0 starts at 4 and every lane ORs 3, so the idempotent result is 4|3 = 7 — distinct
+    // from add (4+3N), max (4), swap (3), and (0), and xor (4 for even N).
+    const uint32_t code_atomic_or[] = {
+        0x7e020283u,               // v_mov_b32 v1, 3
+        0xe0e80000u, 0x80020100u,  // buffer_atomic_or v1, v0, s[8:11]  (op 0x3a)
+        0xbf810000u,
+    };
+    std::vector<uint32_t> spv_atomic_or = recompile_valu(
+        code_atomic_or, std::size(code_atomic_or), 1, 0, &rt_atomic);
+    std::vector<uint32_t> or_buf_in(1, 4u), or_buf_out;
+    prosper::test::run_compute(spv_atomic_or, atomic_dummy, N, N, {}, or_buf_in, &or_buf_out);
+    CHECK(!spv_atomic_or.empty() && or_buf_out.size() == 1 && or_buf_out[0] == 7u,
+          "#590: buffer_atomic_or is idempotent (4 | 3 = 7), distinct from add/max/swap");
+
     // Kernel 24b (#150): the SAME unorm8x4 fetch but with a NON-dword-aligned inst offset (offset:2).
     // The packed unpack extracts components at static byte offsets from a dword-aligned base and drops
     // addr&3, so a non-aligned element base would decode the wrong bits — it must be REJECTED (the


### PR DESCRIPTION
## Goal
Close a concrete RDNA2 opcode-coverage gap in the recompiler (relates #590): the MUBUF atomic family. This came out of "compare with the AMD ISA — I thought we'd covered all of it."

## Failure scenario
The recompiler's MUBUF case implemented exactly **one** atomic — `buffer_atomic_umax` (op 0x38) — and every other atomic opcode hit `default: ok = false` and dropped the whole shader. DOLL (PPSA17942) post-process compute kernels use `buffer_atomic_add` (op 0x32), so they rejected (`[cfg-recompile-reject] fmt=12 op=0x32`).

## Change
Per the AMD RDNA2 ISA MUBUF opcode table, map the full **32-bit atomic RMW family** to its SPIR-V atomic op and route it through the already-proven `cbuf_atomic_rtn` emit (the same path `umax` used):

| op | instr | SPIR-V |
|----|-------|--------|
| 0x30 | swap | OpAtomicExchange |
| 0x32 | add  | OpAtomicIAdd |
| 0x33 | sub  | OpAtomicISub |
| 0x35 | smin | OpAtomicSMin |
| 0x36 | umin | OpAtomicUMin |
| 0x37 | smax | OpAtomicSMax |
| 0x38 | umax | OpAtomicUMax (unchanged) |
| 0x39 | and  | OpAtomicAnd |
| 0x3a | or   | OpAtomicOr |
| 0x3b | xor  | OpAtomicXor |

Adds the five missing SPIR-V atomic op enums (SMin=236, SMax=238, And=240, Or=241, Xor=242). **Deferred, fail-visible:** CMPSWAP (0x31, two-operand), INC/DEC (0x3c/0x3d, GPU wrap semantics), and the x2 64-bit variants — they need distinct lowering, so they still reject loudly rather than mis-compile.

## Verification
- New `test_rdna2_to_spirv` **execution** case: `buffer_atomic_add` on a binding-3 storage buffer, all N dispatched lanes add 3 to element 0 → asserts the final word == 3N through real Vulkan atomic accumulation (not just a recompile). Confirmed **384 = 128×3**.
- The other 8 RMW opcodes assert non-empty recompiles.
- Full Linux `ctest` green for all recompiler/render tests (the 3 red are Messenger-dump-specific in this PPSA17942 worktree, unrelated).

## Not yet fixed (tracked #590)
The remaining DOLL post-process shaders still need the nested-loop + `s_barrier` CFG structurizing, so this doesn't on its own recompile them — it removes the atomic-opcode blocker. No progression screenshot claimed.

## Risk
Low. Reuses the proven atomic emit; each opcode maps to a standard SPIR-V atomic; execution test gates the add path and spirv-val passes.
