### PR TITLE
videoout: preserve Gen5 DCC buffer attributes

### DIFF
--- a/prosper/src/hle/hle_graphics.cpp
+++ b/prosper/src/hle/hle_graphics.cpp
@@ -33,6 +33,9 @@ namespace prosper {
                                        uint64_t a3, uint64_t a4, uint64_t a5)
 #define HLE7(name) static PROSPER_SYSV_ABI uint64_t name(uint64_t a0, uint64_t a1, uint64_t a2, \
                                        uint64_t a3, uint64_t a4, uint64_t a5, uint64_t a6)
+#define HLE8(name) static PROSPER_SYSV_ABI uint64_t name(uint64_t a0, uint64_t a1, uint64_t a2, \
+                                       uint64_t a3, uint64_t a4, uint64_t a5, uint64_t a6, \
+                                       uint64_t a7)
 
 extern "C" uint64_t prosper_guest_tsc_ns(); // shared sceKernelReadTsc/process-time clock
 
@@ -513,9 +516,10 @@ HLE7(g_vo_set_buffer_attribute) {
 }
 
 // sceVideoOutSetBufferAttribute2 (PjS5uASwcV8): fill the caller's VideoOutBufferAttribute2 (0x50
-// bytes, Kyty layout) from (attr, pixel_format, tiling_mode, width, height, option, [dcc_control,
-// dcc_cb_clear on stack]). Mirrors Kyty's setter. Size-exact write.
-HLE(g_vo_set_buffer_attribute2) {  // a0=attr* a1=pixel_format a2=tiling a3=width a4=height a5=option
+// bytes, Kyty layout) from (attr, pixel_format, tiling_mode, width, height, option, dcc_control,
+// dcc_cb_clear). The final two arguments arrive in the guest's stack slots. Mirrors Kyty's setter.
+// Size-exact write.
+HLE8(g_vo_set_buffer_attribute2) {
     vo_argtrace("SetBufferAttribute2", a0,a1,a2,a3,a4,a5);
     if (!a0) return 0;
     uint8_t* p = (uint8_t*)(uintptr_t)a0; memset(p, 0, 0x50);
@@ -525,6 +529,8 @@ HLE(g_vo_set_buffer_attribute2) {  // a0=attr* a1=pixel_format a2=tiling a3=widt
     *(uint32_t*)(p + 0x10) = (uint32_t)a4;   // height
     *(uint64_t*)(p + 0x18) = a5;             // option
     *(uint64_t*)(p + 0x20) = a1;             // pixel_format
+    *(uint64_t*)(p + 0x28) = a7;             // dcc_cb_register_clear_color
+    *(uint32_t*)(p + 0x30) = (uint32_t)a6;   // dcc_control
     return 0;
 }
 

--- a/prosper/tests/test_gpu_capture_render.cpp
+++ b/prosper/tests/test_gpu_capture_render.cpp
@@ -18,6 +18,9 @@
 
 using namespace prosper::gpu;
 
+using Hle8Fn = uint64_t (*)(uint64_t, uint64_t, uint64_t, uint64_t,
+                            uint64_t, uint64_t, uint64_t, uint64_t);
+
 static int fails = 0;
 #define CHECK(c, m) do { if (!(c)) { std::printf("  [FAIL] %s\n", m); ++fails; } \
                          else std::printf("  [ok]   %s\n", m); } while (0)
@@ -56,7 +59,8 @@ int main() {
     prosper::register_builtin_hle();
     present_reset();
     auto open = prosper::Hle::lookup(prosper::nid_hash("sceVideoOutOpen"));
-    auto setba2 = prosper::Hle::lookup("PjS5uASwcV8");
+    auto setba2 = reinterpret_cast<Hle8Fn>(
+        prosper::Hle::lookup("PjS5uASwcV8"));
     auto regb2 = prosper::Hle::lookup("rKBUtgRrtbk");
     constexpr uint32_t PRESENT_W = 128, PRESENT_H = 128;
     std::vector<uint8_t> scanout0(PRESENT_W * PRESENT_H * 4u);
@@ -72,7 +76,7 @@ int main() {
     const uint64_t video_handle = open ? open(0, 0, 0, 0, 0, 0) : 0;
     if (setba2)
         setba2(reinterpret_cast<uint64_t>(scanout_attr), 0x8000000000000000ull,
-               0, PRESENT_W, PRESENT_H, 0);
+               0, PRESENT_W, PRESENT_H, 0, 0, 0);
     const uint64_t register_result = regb2
         ? regb2(video_handle, 0, 0, reinterpret_cast<uint64_t>(scanouts), 3,
                 reinterpret_cast<uint64_t>(scanout_attr))

--- a/prosper/tests/test_hle_stack_args.cpp
+++ b/prosper/tests/test_hle_stack_args.cpp
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <string>
 #include <vector>
 
@@ -67,10 +68,16 @@ __asm__(
 using GuestHle10 = uint64_t (__attribute__((sysv_abi)) *)(
     uint64_t, uint64_t, uint64_t, uint64_t, uint64_t,
     uint64_t, uint64_t, uint64_t, uint64_t, uint64_t);
+using GuestHle8 = uint64_t (__attribute__((sysv_abi)) *)(
+    uint64_t, uint64_t, uint64_t, uint64_t,
+    uint64_t, uint64_t, uint64_t, uint64_t);
 #else
 using GuestHle10 = uint64_t (*)(
     uint64_t, uint64_t, uint64_t, uint64_t, uint64_t,
     uint64_t, uint64_t, uint64_t, uint64_t, uint64_t);
+using GuestHle8 = uint64_t (*)(
+    uint64_t, uint64_t, uint64_t, uint64_t,
+    uint64_t, uint64_t, uint64_t, uint64_t);
 #endif
 
 int fails = 0;
@@ -97,12 +104,16 @@ int main(int argc, char** argv) {
 #endif
 
     constexpr const char* kNid = "test.hle.stack.args";
+    register_builtin_hle();
     Hle::register_fn(kNid, reinterpret_cast<HleFn>(&prosper_test_hle10_entry),
                      "prosper_test_hle10_entry");
     // Keep an unresolved import immediately before the implemented one. The largest Linux guest-FS
     // variant is the unresolved stub; it must fit its fixed 96-byte slot without corrupting its
     // neighbour.
-    const std::vector<ImportSlot> slots = {{"test", "test.hle.unimplemented"}, {"test", kNid}};
+    const std::vector<ImportSlot> slots = {
+        {"test", "test.hle.unimplemented"}, {"test", kNid},
+        {"libSceVideoOut", "PjS5uASwcV8"},
+    };
     std::string err;
     dispatch_init(&slots, nullptr);
     CHECK(install_stubs(slots, 0x710000000ull, 96, &err), "generated adjacent unresolved and executable import stubs");
@@ -178,6 +189,26 @@ after_hle_call:
         std::snprintf(what, sizeof what, "argument %d preserved (0x%016llx)", i + 1,
                       static_cast<unsigned long long>(kArgs[i]));
         CHECK(g_seen[i] == kArgs[i], what);
+    }
+
+    // Exercise a real eight-argument HLE through the same generated import path. This catches an
+    // accidental six-argument registration even if the generic ten-argument bridge still passes.
+    if (!guest_fs) {
+        uint8_t attr[0x58];
+        std::memset(attr, 0xee, sizeof attr);
+        constexpr uint64_t kDccClear = 0x8877665544332211ull;
+        constexpr uint32_t kDccControl = 0xa1b2c3d4u;
+        auto set_attribute2 = reinterpret_cast<GuestHle8>(
+            static_cast<uintptr_t>(stub_addr(2)));
+        CHECK(set_attribute2(reinterpret_cast<uint64_t>(attr), 0x8000000000000000ull,
+                             0, 1920, 1080, 0, kDccControl, kDccClear) == 0,
+              "real eight-argument VideoOut import returned success");
+        CHECK(*reinterpret_cast<const uint64_t*>(attr + 0x28) == kDccClear &&
+              *reinterpret_cast<const uint32_t*>(attr + 0x30) == kDccControl,
+              "real VideoOut import preserved stack arguments 7 and 8");
+        bool canary_untouched = true;
+        for (size_t i = 0x50; i < sizeof attr; ++i) canary_untouched &= attr[i] == 0xee;
+        CHECK(canary_untouched, "real VideoOut import retained the 0x50-byte write bound");
     }
 
     if (fails) {

--- a/prosper/tests/test_present.cpp
+++ b/prosper/tests/test_present.cpp
@@ -17,13 +17,17 @@ static int fails = 0;
 #define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
                          else       { printf("  [ok]   %s\n", m); } } while (0)
 
+using Hle8Fn = uint64_t (*)(uint64_t, uint64_t, uint64_t, uint64_t,
+                            uint64_t, uint64_t, uint64_t, uint64_t);
+
 int main() {
     printf("== test_present ==\n");
     register_builtin_hle();
     gpu::present_reset();
 
     auto open   = Hle::lookup(nid_hash("sceVideoOutOpen"));
-    auto setba2 = Hle::lookup("PjS5uASwcV8");   // SetBufferAttribute2
+    auto setba2 = reinterpret_cast<Hle8Fn>(
+        Hle::lookup("PjS5uASwcV8"));             // SetBufferAttribute2
     auto regb2  = Hle::lookup("rKBUtgRrtbk");   // RegisterBuffers2
     auto unreg  = Hle::lookup("N5KDtkIjjJ4");   // UnregisterBuffers
     auto flip   = Hle::lookup(nid_hash("sceVideoOutSubmitFlip"));
@@ -40,7 +44,8 @@ int main() {
 
     // SetBufferAttribute2 with our test dimensions, then RegisterBuffers2 with the 3 framebuffers.
     uint8_t attr[0x50]; memset(attr, 0, sizeof attr);
-    setba2((uint64_t)(uintptr_t)attr, 0x8000000000000000ull /*fmt*/, 0 /*tiling*/, W, H, 0 /*option*/);
+    setba2((uint64_t)(uintptr_t)attr, 0x8000000000000000ull /*fmt*/, 0 /*tiling*/, W, H,
+           0 /*option*/, 0 /*dcc control*/, 0 /*dcc clear*/);
     struct VOB { const void* data; const void* metadata; const void* reserved[2]; };
     VOB buffers[3] = { {fb0.data(),0,{0,0}}, {fb1.data(),0,{0,0}}, {fb2.data(),0,{0,0}} };
     uint64_t rc = regb2(handle, 0, 0, (uint64_t)(uintptr_t)buffers, 3, (uint64_t)(uintptr_t)attr);
@@ -86,7 +91,7 @@ int main() {
     std::vector<uint8_t> fb4(SMALL_BYTES, 0x66), fb5(SMALL_BYTES, 0x77);
     uint8_t small_attr[0x50]; memset(small_attr, 0, sizeof small_attr);
     setba2((uint64_t)(uintptr_t)small_attr, 0x8000000000000000ull,
-           0 /*tiling*/, SMALL_W, SMALL_H, 0 /*option*/);
+           0 /*tiling*/, SMALL_W, SMALL_H, 0 /*option*/, 0 /*dcc control*/, 0 /*dcc clear*/);
     VOB small_buffers[2] = { {fb4.data(),0,{0,0}}, {fb5.data(),0,{0,0}} };
     rc = regb2(handle, 1 /*set*/, 4 /*start*/, (uint64_t)(uintptr_t)small_buffers, 2,
                (uint64_t)(uintptr_t)small_attr);

--- a/prosper/tests/test_videoout.cpp
+++ b/prosper/tests/test_videoout.cpp
@@ -28,6 +28,8 @@ static int fails = 0;
 
 using Hle7Fn = uint64_t (*)(uint64_t, uint64_t, uint64_t, uint64_t,
                             uint64_t, uint64_t, uint64_t);
+using Hle8Fn = uint64_t (*)(uint64_t, uint64_t, uint64_t, uint64_t,
+                            uint64_t, uint64_t, uint64_t, uint64_t);
 
 int main() {
     printf("== test_videoout ==\n");
@@ -41,7 +43,8 @@ int main() {
     auto issup  = Hle::lookup("Nv8c-Kb+DUM");   // IsOutputSupported
     auto setba  = Hle::lookup(nid_hash("sceVideoOutSetBufferAttribute"));
     auto regb   = Hle::lookup(nid_hash("sceVideoOutRegisterBuffers"));
-    auto setba2 = Hle::lookup("PjS5uASwcV8");   // SetBufferAttribute2
+    auto setba2 = reinterpret_cast<Hle8Fn>(
+        Hle::lookup("PjS5uASwcV8"));             // SetBufferAttribute2
     auto regb2  = Hle::lookup("rKBUtgRrtbk");   // RegisterBuffers2
     auto unreg  = Hle::lookup("N5KDtkIjjJ4");   // UnregisterBuffers
     auto labels = Hle::lookup("OcQybQejHEY");   // GetBufferLabelAddress
@@ -280,13 +283,28 @@ int main() {
           prosper_vo_buffer_count() == 0 && prosper_vo_display_width() == 0,
           "legacy buffer group unregisters cleanly before Gen5 registration");
 
-    // SetBufferAttribute2 fills the 0x50 attribute struct from (fmt, tiling, w, h, option).
-    uint8_t attr[0x50]; memset(attr, 0xEE, sizeof attr);
+    // SetBufferAttribute2 fills exactly the 0x50-byte Gen5 attribute, including the two stack args.
+    uint8_t attr[0x58]; memset(attr, 0xEE, sizeof attr);
     uint64_t fmt = 0x8000000000000000ull;   // the PS5 format the game requests (A8R8G8B8 sRGB)
-    setba2((uint64_t)(uintptr_t)attr, fmt, 0 /*tiling*/, 1920, 1080, 0 /*option*/);
+    constexpr uint64_t option = 0x1122334455667788ull;
+    constexpr uint32_t dcc_control = 0xa1b2c3d4u;
+    constexpr uint64_t dcc_clear = 0x8877665544332211ull;
+    setba2((uint64_t)(uintptr_t)attr, fmt, 0 /*tiling*/, 1920, 1080, option,
+           dcc_control, dcc_clear);
     CHECK(*(uint32_t*)(attr + 0x0c) == 1920 && *(uint32_t*)(attr + 0x10) == 1080, "attribute width/height set");
     CHECK(*(uint64_t*)(attr + 0x20) == fmt, "attribute pixel_format set");
     CHECK(*(uint32_t*)(attr + 0x04) == 0, "attribute tiling_mode set");
+    CHECK(*(uint32_t*)(attr + 0x14) == 0 && *(uint64_t*)(attr + 0x18) == option,
+          "attribute pitch and option set");
+    CHECK(*(uint64_t*)(attr + 0x28) == dcc_clear &&
+          *(uint32_t*)(attr + 0x30) == dcc_control,
+          "attribute DCC clear color and control set from stack arguments");
+    bool attr_reserved_zero = true;
+    for (size_t i = 0x34; i < 0x50; ++i) attr_reserved_zero &= attr[i] == 0;
+    CHECK(attr_reserved_zero, "attribute pad and reserved fields initialized");
+    bool attr_canary_untouched = true;
+    for (size_t i = 0x50; i < sizeof attr; ++i) attr_canary_untouched &= attr[i] == 0xEE;
+    CHECK(attr_canary_untouched, "SetBufferAttribute2 writes exactly its 0x50-byte ABI struct");
 
     // ConfigureOutput accepts the (single advertised) mode.
     CHECK(cfg(handle, 1, 0, 0, 0, 0) == 0, "ConfigureOutput accepted");


### PR DESCRIPTION
## Summary

- give `sceVideoOutSetBufferAttribute2` its real eight-argument ABI
- preserve `dccCbRegisterClearColor` at `0x28` and `dccControl` at `0x30`
- update every direct test caller to use the full fixed-arity prototype
- exercise the real registered import through the Linux and Windows stack-argument bridge, with exact 0x50-byte/canary coverage

## Root cause

The handler was declared through the generic six-argument HLE prototype even though public PS5 headers and Kyty agree that the Gen5 setter takes eight arguments. Its two stack arguments were therefore never consumed, and the handler's initial memset silently left both DCC fields at zero.

The #394 tracker described `pitch_in_pixel` as the missing argument; the public ABI instead pins pitch to zero and identifies the omitted values as DCC control and DCC clear color.

## Validation

- Linux focused build and `test_videoout`, `test_present`, `test_gpu_capture_render`: PASS
- Linux `test_hle_stack_args` normal and guest-FS variants: PASS
- Windows focused build and `test_videoout`: PASS
- Windows `test_hle_stack_args` through the generated SysV-to-MS-x64 import bridge: PASS
- `git diff --check`: PASS

No game runs, snapshot workflow, or capture workflow were used.

Refs #394