### PR TITLE
pad: validate live input handle lifecycle (#391 F3)

### DIFF
--- a/prosper/src/hle/hle_pad.cpp
+++ b/prosper/src/hle/hle_pad.cpp
@@ -28,6 +28,7 @@
 #include <mutex>
 #include <optional>
 #include <string>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -42,6 +43,26 @@ using namespace prosper::input;
 namespace {
 
 std::atomic<int> g_pad_handle{1};
+std::mutex g_pad_handle_mx;
+std::unordered_set<int32_t> g_pad_handles;
+
+constexpr uint64_t kPadErrorInvalidHandle =
+    (uint64_t)(int64_t)(int32_t)0x80920003u;
+
+// Retain handle validity through each input operation so Close cannot retire the handle between
+// validation and its poll/output side effects.
+class PadHandleGuard {
+public:
+    explicit PadHandleGuard(uint64_t handle)
+        : lock_(g_pad_handle_mx),
+          valid_(g_pad_handles.contains((int32_t)handle)) {}
+
+    bool valid() const { return valid_; }
+
+private:
+    std::unique_lock<std::mutex> lock_;
+    bool valid_;
+};
 
 // PROSPER_PADLOG=1: trace pad calls (rate-limited) so a boot run shows the game polling input.
 bool padlog() { static const bool on = getenv("PROSPER_PADLOG") != nullptr; return on; }
@@ -387,24 +408,43 @@ HostPadState poll_controller(int /*handle*/, const char* what, bool consume_inpu
 
 } // namespace
 
-// scePadInit / scePadClose / effector no-ops -> OK.
+// scePadInit / effector no-ops -> OK.
 HLE(pad_ok) { if (padlog()) fprintf(stderr, "[pad] init/ok call\n"); return 0; }
 
 // scePadOpen(userId, type, index, param) -> positive handle.
-HLE(pad_open) { int h = g_pad_handle.fetch_add(1);
+HLE(pad_open) {
+    const int h = g_pad_handle.fetch_add(1);
+    {
+        std::lock_guard<std::mutex> lock(g_pad_handle_mx);
+        g_pad_handles.insert(h);
+    }
     if (padlog()) fprintf(stderr, "[pad] OPEN userId=%llu type=%llu index=%llu -> handle=%d\n",
                           (unsigned long long)a0, (unsigned long long)a1, (unsigned long long)a2, h);
-    return (uint64_t)h; }
+    return (uint64_t)h;
+}
+
+// scePadClose(handle) -> OK exactly once, then INVALID_HANDLE for an unknown/retired handle.
+HLE(pad_close) {
+    const int32_t handle = (int32_t)a0;
+    std::lock_guard<std::mutex> lock(g_pad_handle_mx);
+    if (g_pad_handles.erase(handle) == 0) return kPadErrorInvalidHandle;
+    if (padlog()) fprintf(stderr, "[pad] CLOSE handle=%d\n", handle);
+    return 0;
+}
 
 // scePadGetHandle(userId, type, index) -> handle (games that opened once may re-query it).
 HLE(pad_get_handle) { return 1; }
 
-// scePadIsValidHandle(handle) -> nonzero if the handle is an open pad. Was MISSING -> returned 0, which a
-// caller reads as "invalid". Our handles start at 1, so report valid for any positive handle.
-HLE(pad_is_valid_handle) { return a0 >= 1 ? 1 : 0; }
+// scePadIsValidHandle(handle) -> nonzero only while the handle remains open.
+HLE(pad_is_valid_handle) {
+    std::lock_guard<std::mutex> lock(g_pad_handle_mx);
+    return g_pad_handles.contains((int32_t)a0) ? 1 : 0;
+}
 
 // scePadReadState(handle, ScePadData* out) -> 0 on success. One current snapshot.
 HLE(pad_read_state) {
+    PadHandleGuard handle(a0);
+    if (!handle.valid()) return kPadErrorInvalidHandle;
     if (!a1) return 0;
     HostPadState s = poll_controller((int)a0, __func__, true);
     pad_fill_data((ScePadData*)PW(a1), s, now_us(), s.connected ? 1 : 0);
@@ -414,6 +454,8 @@ HLE(pad_read_state) {
 // scePadRead(handle, ScePadData* out, int num) -> number of states written (>=1). We report the
 // single current state (no historical buffering yet), which is a valid, common driver behavior.
 HLE(pad_read) {
+    PadHandleGuard handle(a0);
+    if (!handle.valid()) return kPadErrorInvalidHandle;
     int num = (int)(int64_t)a2;
     if (!a1 || num < 1) return 0;
     HostPadState s = poll_controller((int)a0, __func__, true);
@@ -423,6 +465,8 @@ HLE(pad_read) {
 
 // scePadGetControllerInformation(handle, ScePadControllerInformation* out) -> 0.
 HLE(pad_get_info) {
+    PadHandleGuard handle(a0);
+    if (!handle.valid()) return kPadErrorInvalidHandle;
     if (!a1) return 0;
     HostPadState s = poll_controller((int)a0, __func__, false);
     pad_fill_controller_info((ScePadControllerInformation*)PW(a1), s.connected, s.connected ? 1 : 0);
@@ -458,7 +502,7 @@ void register_pad_hle() {
     R("scePadOpen", pad_open);
     R("scePadOpenExt", pad_open);              // was MISSING -> returned 0 (read as a valid handle 0 / error)
     R("scePadIsValidHandle", pad_is_valid_handle);   // was MISSING -> 0 = "invalid"
-    R("scePadClose", pad_ok);
+    R("scePadClose", pad_close);
     R("scePadGetHandle", pad_get_handle);
     R("scePadGetControllerInformation", pad_get_info);
     R("scePadDeviceClassGetExtendedInformation", pad_ext_info);

--- a/prosper/tests/test_pad.cpp
+++ b/prosper/tests/test_pad.cpp
@@ -122,13 +122,64 @@ int main() {
         HleFn read       = Hle::lookup(nid_hash("scePadRead"));
         HleFn get_info   = Hle::lookup(nid_hash("scePadGetControllerInformation"));
         HleFn open       = Hle::lookup(nid_hash("scePadOpen"));
-        CHECK(read_state && read && get_info && open, "pad HLE functions registered");
+        HleFn open_ext   = Hle::lookup(nid_hash("scePadOpenExt"));
+        HleFn close      = Hle::lookup(nid_hash("scePadClose"));
+        HleFn is_valid   = Hle::lookup(nid_hash("scePadIsValidHandle"));
+        CHECK(read_state && read && get_info && open && open_ext && close && is_valid,
+              "pad HLE functions registered");
 
-        if (open) CHECK(open(1, 0, 0, 0, 0, 0) >= 1, "scePadOpen -> positive handle");
+        const uint64_t handle = open ? open(1, 0, 0, 0, 0, 0) : 0;
+        const uint64_t ext_handle = open_ext ? open_ext(1, 0, 1, 0, 0, 0) : 0;
+        CHECK(handle >= 1, "scePadOpen -> positive handle");
+        CHECK(ext_handle >= 1 && ext_handle != handle,
+              "scePadOpenExt -> distinct positive handle");
+        if (is_valid) {
+            CHECK(is_valid(handle, 0, 0, 0, 0, 0) == 1,
+                  "scePadIsValidHandle accepts the opened handle");
+            CHECK(is_valid(ext_handle, 0, 0, 0, 0, 0) == 1,
+                  "scePadIsValidHandle accepts the OpenExt handle");
+            CHECK(is_valid(handle + 0x1000, 0, 0, 0, 0, 0) == 0,
+                  "scePadIsValidHandle rejects an unknown positive handle");
+        }
+
+        constexpr uint64_t invalid_handle = 0xffffffff80920003ull;
+        const uint64_t unknown = handle + 0x1000;
+        if (close)
+            CHECK(close(unknown, 0, 0, 0, 0, 0) == invalid_handle,
+                  "scePadClose rejects an unknown handle");
+
+        // Invalid-handle failures happen before polling or touching output. The later valid reads
+        // therefore still consume the scripted p0 and p1 windows in order.
+        ScePadData invalid_data;
+        std::memset(&invalid_data, 0x5a, sizeof invalid_data);
+        ScePadControllerInformation invalid_info;
+        std::memset(&invalid_info, 0x6b, sizeof invalid_info);
+        if (read_state)
+            CHECK(read_state(unknown, (uint64_t)(uintptr_t)&invalid_data, 0, 0, 0, 0) ==
+                      invalid_handle,
+                  "scePadReadState rejects an unknown handle");
+        if (read)
+            CHECK(read(unknown, (uint64_t)(uintptr_t)&invalid_data, 1, 0, 0, 0) ==
+                      invalid_handle,
+                  "scePadRead rejects an unknown handle");
+        if (get_info)
+            CHECK(get_info(unknown, (uint64_t)(uintptr_t)&invalid_info, 0, 0, 0, 0) ==
+                      invalid_handle,
+                  "scePadGetControllerInformation rejects an unknown handle");
+        bool invalid_data_untouched = true;
+        const auto* invalid_data_bytes = reinterpret_cast<const uint8_t*>(&invalid_data);
+        for (size_t i = 0; i < sizeof invalid_data; ++i)
+            invalid_data_untouched &= invalid_data_bytes[i] == 0x5a;
+        bool invalid_info_untouched = true;
+        const auto* invalid_info_bytes = reinterpret_cast<const uint8_t*>(&invalid_info);
+        for (size_t i = 0; i < sizeof invalid_info; ++i)
+            invalid_info_untouched &= invalid_info_bytes[i] == 0x6b;
+        CHECK(invalid_data_untouched && invalid_info_untouched,
+              "invalid-handle Pad calls leave outputs untouched");
 
         if (get_info) {
             ScePadControllerInformation ci{};
-            CHECK(get_info(1, (uint64_t)(uintptr_t)&ci, 0, 0, 0, 0) == 0,
+            CHECK(get_info(handle, (uint64_t)(uintptr_t)&ci, 0, 0, 0, 0) == 0,
                   "scePadGetControllerInformation -> 0 (OK)");
             CHECK(ci.connected == 1, "info query sees script-driven controller connectivity");
         }
@@ -139,15 +190,15 @@ int main() {
 
         if (read) {
             ScePadData unused{};
-            CHECK(read(1, 0, 1, 0, 0, 0) == 0 &&
-                  read(1, (uint64_t)(uintptr_t)&unused, 0, 0, 0, 0) == 0,
+            CHECK(read(handle, 0, 1, 0, 0, 0) == 0 &&
+                  read(handle, (uint64_t)(uintptr_t)&unused, 0, 0, 0, 0) == 0,
                   "failed scePadRead calls do not consume input windows");
         }
 
         if (read_state) {
             ScePadData d;
             memset(&d, 0x5A, sizeof(d));
-            uint64_t r = read_state(1, (uint64_t)(uintptr_t)&d, 0, 0, 0, 0);
+            uint64_t r = read_state(handle, (uint64_t)(uintptr_t)&d, 0, 0, 0, 0);
             CHECK(r == 0, "scePadReadState -> 0 (OK)");
             // The struct's TAIL (bytes the old 48-byte stub never touched) must now be written:
             CHECK(d.connected == 1, "readstate: one controller connected by default (dev/testing default)");
@@ -160,13 +211,32 @@ int main() {
         if (read) {
             if (get_info) {
                 ScePadControllerInformation ci{};
-                get_info(1, (uint64_t)(uintptr_t)&ci, 0, 0, 0, 0);
+                get_info(handle, (uint64_t)(uintptr_t)&ci, 0, 0, 0, 0);
             }
             ScePadData d;
-            uint64_t n = read(1, (uint64_t)(uintptr_t)&d, 4 /*num*/, 0, 0, 0);
+            uint64_t n = read(handle, (uint64_t)(uintptr_t)&d, 4 /*num*/, 0, 0, 0);
             CHECK(n == 1, "scePadRead -> 1 state");
             CHECK(d.buttons == SCE_PAD_BUTTON_OPTIONS,
                   "scePadRead: intervening metadata query did not consume p1 input window");
+        }
+        if (close && is_valid) {
+            CHECK(close(handle, 0, 0, 0, 0, 0) == 0,
+                  "scePadClose retires the opened handle");
+            CHECK(close(ext_handle, 0, 0, 0, 0, 0) == 0,
+                  "scePadClose retires the OpenExt handle");
+            CHECK(is_valid(handle, 0, 0, 0, 0, 0) == 0,
+                  "scePadIsValidHandle rejects a closed handle");
+            CHECK(is_valid(ext_handle, 0, 0, 0, 0, 0) == 0,
+                  "scePadIsValidHandle rejects a closed OpenExt handle");
+            std::memset(&invalid_data, 0x7c, sizeof invalid_data);
+            CHECK(read_state(handle, (uint64_t)(uintptr_t)&invalid_data, 0, 0, 0, 0) ==
+                      invalid_handle && close(handle, 0, 0, 0, 0, 0) == invalid_handle,
+                  "closed handles stay invalid for input and repeated close");
+            bool closed_output_untouched = true;
+            for (size_t i = 0; i < sizeof invalid_data; ++i)
+                closed_output_untouched &= invalid_data_bytes[i] == 0x7c;
+            CHECK(closed_output_untouched,
+                  "closed-handle input leaves output untouched");
         }
         set_test_env("PROSPER_PAD_SCRIPT", "");
     }


### PR DESCRIPTION
## Summary
- track live handles returned by `scePadOpen` and `scePadOpenExt`
- make `scePadIsValidHandle` and `scePadClose` reflect the live handle set
- reject unknown or closed handles in state reads and controller-information queries with the documented `0x80920003` invalid-handle error
- keep rejected operations from polling input or modifying guest output

Addresses #391 F3. The tracker currently lists `0x80920004`; public PS5 references identify that as already-opened, while invalid-handle is `0x80920003`.

## Focused checks
- Linux `test_pad`: PASS
- Windows `test_pad.exe`: PASS

The full author verifier and independent inspection are run after posting this ready PR, per the repository workflow.

## Deliberate scope
This does not infer unverified null-output, `scePadGetHandle`, effector, or broader controller semantics.