### PR TITLE
pad: implement extended controller information (#391 F2)

### DIFF
--- a/prosper/src/hle/hle_pad.cpp
+++ b/prosper/src/hle/hle_pad.cpp
@@ -473,6 +473,20 @@ HLE(pad_get_info) {
     return 0;
 }
 
+// scePadGetExtControllerInformation(handle, ScePadExtendedControllerInformation* out) -> 0.
+// The inherited public layout is exactly 0x2c bytes: the 0x1c controller-info base followed by
+// padType1/padType2, capability, alignment, and an 8-byte device-class union. A standard pad has no
+// device-class extension, so the tail remains zero while the base reports current connection state.
+HLE(pad_get_ext_controller_info) {
+    PadHandleGuard handle(a0);
+    if (!handle.valid()) return kPadErrorInvalidHandle;
+    if (!a1) return 0;
+    HostPadState s = poll_controller((int)a0, __func__, false);
+    pad_fill_extended_controller_info((ScePadExtendedControllerInformation*)PW(a1), s.connected,
+                                      s.connected ? 1 : 0);
+    return 0;
+}
+
 // scePadDeviceClassGetExtendedInformation(handle, out*) -> 0. Report a zeroed extended-info block
 // (standard device class, no extra capabilities). OrbisPadDeviceClassExtendedInformation is exactly
 // 20 bytes (0x14): deviceClass(4) + reserved[4](4) + a 12-byte classData union (shadPS4 pad.h). Writing
@@ -505,6 +519,7 @@ void register_pad_hle() {
     R("scePadClose", pad_close);
     R("scePadGetHandle", pad_get_handle);
     R("scePadGetControllerInformation", pad_get_info);
+    R("scePadGetExtControllerInformation", pad_get_ext_controller_info);
     R("scePadDeviceClassGetExtendedInformation", pad_ext_info);
     R("scePadReadState", pad_read_state);
     R("scePadRead", pad_read);

--- a/prosper/src/input/pad.cpp
+++ b/prosper/src/input/pad.cpp
@@ -31,6 +31,11 @@ static_assert(offsetof(ScePadData, device_unique_data) == 0x6c, "device_unique_d
 
 static_assert(sizeof(ScePadControllerInformation) == 28, "ScePadControllerInformation must be 28 bytes (Sony reserve[8], #283)");
 static_assert(offsetof(ScePadControllerInformation, device_class) == 0x10, "device_class");
+static_assert(sizeof(ScePadExtendedControllerInformation) == 44,
+              "ScePadExtendedControllerInformation must be 44 bytes");
+static_assert(offsetof(ScePadExtendedControllerInformation, pad_type1) == 0x1c, "pad_type1");
+static_assert(offsetof(ScePadExtendedControllerInformation, capability) == 0x20, "capability");
+static_assert(offsetof(ScePadExtendedControllerInformation, class_data) == 0x24, "class_data");
 
 uint8_t pad_axis_u8(int raw, int min, int max) {
     if (max <= min) return 0x80;
@@ -109,6 +114,13 @@ void pad_fill_controller_info(ScePadControllerInformation* out, bool connected, 
     out->connected_count = connected_count;
     out->connected       = connected ? 1 : 0;
     out->device_class    = 0;       // SCE_PAD_DEVICE_CLASS_STANDARD
+}
+
+void pad_fill_extended_controller_info(ScePadExtendedControllerInformation* out, bool connected,
+                                       uint8_t connected_count) {
+    if (!out) return;
+    std::memset(out, 0, sizeof(*out));
+    pad_fill_controller_info(&out->base, connected, connected_count);
 }
 
 // --- Scripted input (PROSPER_PAD_SCRIPT) pure helpers — see pad.hpp -----------------------------

--- a/prosper/src/input/pad.hpp
+++ b/prosper/src/input/pad.hpp
@@ -99,7 +99,7 @@ struct ScePadData {
     uint8_t  device_unique_data[12];        // 0x6c
 };                                          // 0x78 = 120 bytes
 
-// ScePadControllerInformation — scePadGetControllerInformation. 32 bytes (trailing reserve).
+// ScePadControllerInformation — scePadGetControllerInformation. 28 bytes (trailing reserve).
 struct ScePadControllerInformation {
     float    touch_pixel_density;           // 0x00
     uint16_t touch_resolution_x;            // 0x04
@@ -116,6 +116,17 @@ struct ScePadControllerInformation {
                                             // a 32-byte struct overran the game's 28-byte stack buffer
                                             // into its stack canary -> __stack_chk_fail crash, #283)
 
+// ScePadExtendedControllerInformation. The standard-pad extension is zero; device-specific
+// controllers interpret class_data according to capability.
+struct ScePadExtendedControllerInformation {
+    ScePadControllerInformation base;        // 0x00
+    uint16_t pad_type1;                      // 0x1c
+    uint16_t pad_type2;                      // 0x1e
+    uint8_t  capability;                     // 0x20
+    uint8_t  ext_pad[3];                     // 0x21 (align class-data union to 4)
+    uint8_t  class_data[8];                  // 0x24
+};                                           // 0x2c = 44 bytes
+
 // ---- Pure mapping (no hardware, no globals) ---------------------------------------------------
 
 // Fill a full ScePadData from a host snapshot. Zeroes the struct first (motion/touch reported as
@@ -124,6 +135,10 @@ void pad_fill_data(ScePadData* out, const HostPadState& s, uint64_t timestamp, u
 
 // Fill ScePadControllerInformation for a DualSense-class pad.
 void pad_fill_controller_info(ScePadControllerInformation* out, bool connected, uint8_t connected_count);
+
+// Fill the exact extended controller-info layout for a standard DualSense-class pad.
+void pad_fill_extended_controller_info(ScePadExtendedControllerInformation* out, bool connected,
+                                       uint8_t connected_count);
 
 // Normalize a raw axis reading in [min,max] to the Sony 0..255 range (clamped).
 uint8_t pad_axis_u8(int raw, int min, int max);

--- a/prosper/tests/test_pad.cpp
+++ b/prosper/tests/test_pad.cpp
@@ -47,6 +47,14 @@ int main() {
     // 0x1c after the struct. A 32-byte struct overran that 28-byte buffer -> canary crash (#283).
     CHECK(sizeof(ScePadControllerInformation) == 28, "sizeof(ScePadControllerInformation) == 28");
     CHECK(offsetof(ScePadControllerInformation, device_class) == 0x10, "device_class @ 0x10");
+    CHECK(sizeof(ScePadExtendedControllerInformation) == 44,
+          "sizeof(ScePadExtendedControllerInformation) == 44");
+    CHECK(offsetof(ScePadExtendedControllerInformation, pad_type1) == 0x1c,
+          "extended pad_type1 @ 0x1c");
+    CHECK(offsetof(ScePadExtendedControllerInformation, capability) == 0x20,
+          "extended capability @ 0x20");
+    CHECK(offsetof(ScePadExtendedControllerInformation, class_data) == 0x24,
+          "extended class_data @ 0x24");
 
     // (2) Neutral state -> centered sticks, zero buttons, released triggers, identity orientation.
     {
@@ -109,6 +117,19 @@ int main() {
         CHECK(ci.connected_count == 1, "info: connected_count");
         CHECK(ci.device_class == 0, "info: standard device class");
         CHECK(ci.stick_dead_zone_left == ci.stick_dead_zone_right, "info: symmetric dead zone");
+
+        ScePadExtendedControllerInformation ext;
+        memset(&ext, 0xAA, sizeof(ext));
+        pad_fill_extended_controller_info(&ext, true, 1);
+        CHECK(ext.base.connected == 1 && ext.base.connected_count == 1,
+              "extended info: populated controller-info base");
+        bool extension_zero = true;
+        const auto* extension_bytes = reinterpret_cast<const uint8_t*>(&ext.pad_type1);
+        for (size_t i = 0; i < sizeof(ext) -
+                                   offsetof(ScePadExtendedControllerInformation, pad_type1);
+             ++i)
+            extension_zero &= extension_bytes[i] == 0;
+        CHECK(extension_zero, "extended info: standard-pad extension zeroed");
     }
 
     // (6) HLE registration + full-struct fill. The built-in NeutralPadBackend presents one connected
@@ -118,14 +139,17 @@ int main() {
         // consume either window; the first two successful input reads must see p0 and p1 in order.
         set_test_env("PROSPER_PAD_SCRIPT", "0-0.05:triangle;p0-1:cross;p1-2:options");
         register_builtin_hle();
+        CHECK(nid_hash("scePadGetExtControllerInformation") == "hGbf2QTBmqc",
+              "scePadGetExtControllerInformation hashes to its public NID");
         HleFn read_state = Hle::lookup(nid_hash("scePadReadState"));
         HleFn read       = Hle::lookup(nid_hash("scePadRead"));
         HleFn get_info   = Hle::lookup(nid_hash("scePadGetControllerInformation"));
+        HleFn get_ext_info = Hle::lookup(nid_hash("scePadGetExtControllerInformation"));
         HleFn open       = Hle::lookup(nid_hash("scePadOpen"));
         HleFn open_ext   = Hle::lookup(nid_hash("scePadOpenExt"));
         HleFn close      = Hle::lookup(nid_hash("scePadClose"));
         HleFn is_valid   = Hle::lookup(nid_hash("scePadIsValidHandle"));
-        CHECK(read_state && read && get_info && open && open_ext && close && is_valid,
+        CHECK(read_state && read && get_info && get_ext_info && open && open_ext && close && is_valid,
               "pad HLE functions registered");
 
         const uint64_t handle = open ? open(1, 0, 0, 0, 0, 0) : 0;
@@ -154,6 +178,8 @@ int main() {
         std::memset(&invalid_data, 0x5a, sizeof invalid_data);
         ScePadControllerInformation invalid_info;
         std::memset(&invalid_info, 0x6b, sizeof invalid_info);
+        ScePadExtendedControllerInformation invalid_ext_info;
+        std::memset(&invalid_ext_info, 0x4d, sizeof invalid_ext_info);
         if (read_state)
             CHECK(read_state(unknown, (uint64_t)(uintptr_t)&invalid_data, 0, 0, 0, 0) ==
                       invalid_handle,
@@ -166,6 +192,10 @@ int main() {
             CHECK(get_info(unknown, (uint64_t)(uintptr_t)&invalid_info, 0, 0, 0, 0) ==
                       invalid_handle,
                   "scePadGetControllerInformation rejects an unknown handle");
+        if (get_ext_info)
+            CHECK(get_ext_info(unknown, (uint64_t)(uintptr_t)&invalid_ext_info, 0, 0, 0, 0) ==
+                      invalid_handle,
+                  "scePadGetExtControllerInformation rejects an unknown handle");
         bool invalid_data_untouched = true;
         const auto* invalid_data_bytes = reinterpret_cast<const uint8_t*>(&invalid_data);
         for (size_t i = 0; i < sizeof invalid_data; ++i)
@@ -174,7 +204,11 @@ int main() {
         const auto* invalid_info_bytes = reinterpret_cast<const uint8_t*>(&invalid_info);
         for (size_t i = 0; i < sizeof invalid_info; ++i)
             invalid_info_untouched &= invalid_info_bytes[i] == 0x6b;
-        CHECK(invalid_data_untouched && invalid_info_untouched,
+        bool invalid_ext_info_untouched = true;
+        const auto* invalid_ext_info_bytes = reinterpret_cast<const uint8_t*>(&invalid_ext_info);
+        for (size_t i = 0; i < sizeof invalid_ext_info; ++i)
+            invalid_ext_info_untouched &= invalid_ext_info_bytes[i] == 0x4d;
+        CHECK(invalid_data_untouched && invalid_info_untouched && invalid_ext_info_untouched,
               "invalid-handle Pad calls leave outputs untouched");
 
         if (get_info) {
@@ -182,6 +216,28 @@ int main() {
             CHECK(get_info(handle, (uint64_t)(uintptr_t)&ci, 0, 0, 0, 0) == 0,
                   "scePadGetControllerInformation -> 0 (OK)");
             CHECK(ci.connected == 1, "info query sees script-driven controller connectivity");
+        }
+        if (get_ext_info) {
+            struct {
+                ScePadExtendedControllerInformation info;
+                uint8_t canary[12];
+            } guarded;
+            std::memset(&guarded, 0xa7, sizeof guarded);
+            CHECK(get_ext_info(handle, (uint64_t)(uintptr_t)&guarded.info, 0, 0, 0, 0) == 0,
+                  "scePadGetExtControllerInformation -> 0 (OK)");
+            CHECK(guarded.info.base.connected == 1 && guarded.info.base.device_class == 0,
+                  "extended info reports a connected standard controller");
+            bool extension_zero = true;
+            const auto* extension_bytes =
+                reinterpret_cast<const uint8_t*>(&guarded.info.pad_type1);
+            for (size_t i = 0; i < sizeof guarded.info -
+                                       offsetof(ScePadExtendedControllerInformation, pad_type1);
+                 ++i)
+                extension_zero &= extension_bytes[i] == 0;
+            bool canary_untouched = true;
+            for (uint8_t byte : guarded.canary) canary_untouched &= byte == 0xa7;
+            CHECK(extension_zero && canary_untouched,
+                  "extended info writes exactly 0x2c bytes and zeroes its extension");
         }
 
         // The legacy seconds origin is the first pad poll, including an information query. If the
@@ -229,14 +285,21 @@ int main() {
             CHECK(is_valid(ext_handle, 0, 0, 0, 0, 0) == 0,
                   "scePadIsValidHandle rejects a closed OpenExt handle");
             std::memset(&invalid_data, 0x7c, sizeof invalid_data);
+            std::memset(&invalid_ext_info, 0x3e, sizeof invalid_ext_info);
             CHECK(read_state(handle, (uint64_t)(uintptr_t)&invalid_data, 0, 0, 0, 0) ==
                       invalid_handle && close(handle, 0, 0, 0, 0, 0) == invalid_handle,
                   "closed handles stay invalid for input and repeated close");
+            CHECK(get_ext_info(handle, (uint64_t)(uintptr_t)&invalid_ext_info, 0, 0, 0, 0) ==
+                      invalid_handle,
+                  "scePadGetExtControllerInformation rejects a closed handle");
             bool closed_output_untouched = true;
             for (size_t i = 0; i < sizeof invalid_data; ++i)
                 closed_output_untouched &= invalid_data_bytes[i] == 0x7c;
-            CHECK(closed_output_untouched,
-                  "closed-handle input leaves output untouched");
+            bool closed_ext_output_untouched = true;
+            for (size_t i = 0; i < sizeof invalid_ext_info; ++i)
+                closed_ext_output_untouched &= invalid_ext_info_bytes[i] == 0x3e;
+            CHECK(closed_output_untouched && closed_ext_output_untouched,
+                  "closed-handle Pad calls leave output untouched");
         }
         set_test_env("PROSPER_PAD_SCRIPT", "");
     }


### PR DESCRIPTION
## Summary
- register the missing `scePadGetExtControllerInformation` export (`hGbf2QTBmqc`)
- define the inherited 0x2c-byte extended controller-information ABI with compile-time size and offset guards
- populate its normal 0x1c-byte base while zeroing the standard-pad extension
- validate and retain live handles through the metadata poll, leaving rejected output untouched
- add exact-write canary, public-NID, layout, unknown-handle, and closed-handle regressions

Addresses #391 F2's remaining extended-controller-information export.

Reference: the current public shadPS4 [`OrbisPadExtendedControllerInformation`](https://github.com/shadps4-emu/shadPS4/blob/main/src/core/libraries/pad/pad.h) layout and implementation.

## Focused checks
- Linux `test_pad`: PASS
- Windows `test_pad.exe`: PASS

The full author verifier and independent inspection are run after posting this ready PR, per the repository workflow.

## Deliberate scope
No changes to null-output semantics, `scePadGetHandle`, effectors, touch geometry, reconnect behavior, games, snapshots, or captures.