### PR TITLE
perf(executor): reuse analyzed shader content hashes

### DIFF
--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -139,6 +139,7 @@ struct ShaderCompileKey {
     // Aliases ShaderCodeAnalysis::code and keeps that immutable analysis alive. Warm lookups used to
     // copy and re-hash the complete raw program for every draw before reaching the shader cache.
     std::shared_ptr<const std::vector<uint32_t>> code;
+    uint64_t code_hash = 0;
     std::vector<ShaderResourceCompileKey> resources;
     size_t cached_hash = 0;
 
@@ -167,6 +168,12 @@ static uint64_t hash_mix(uint64_t hash, uint64_t value) {
     return hash;
 }
 
+static uint64_t hash_shader_code(const std::vector<uint32_t>& code) {
+    uint64_t hash = 1469598103934665603ull;
+    for (uint32_t word : code) hash = hash_mix(hash, word);
+    return hash;
+}
+
 struct ShaderCompileKeyHash {
     static size_t compute(const ShaderCompileKey& key) {
         uint64_t hash = 1469598103934665603ull;
@@ -187,8 +194,7 @@ struct ShaderCompileKeyHash {
         hash = hash_mix(hash, key.has_pcrel_dispatch);
         if (key.has_pcrel_dispatch) hash = hash_mix(hash, key.pcrel_dispatch_target);
         hash = hash_mix(hash, key.code ? key.code->size() : 0u);
-        if (key.code)
-            for (uint32_t word : *key.code) hash = hash_mix(hash, word);
+        hash = hash_mix(hash, key.code_hash);
         hash = hash_mix(hash, key.resources.size());
         for (const auto& resource : key.resources) {
             hash = hash_mix(hash, resource.cls);
@@ -248,6 +254,7 @@ struct ShaderDecodeCache {
 
 struct ShaderCodeAnalysis {
     std::vector<uint32_t> code;
+    uint64_t code_hash = 0;
     PcrelDispatchInfo pcrel_dispatch;
     uint64_t identity = 0;
     size_t source_dwords = 0;
@@ -547,6 +554,7 @@ std::shared_ptr<const ShaderCodeAnalysis> analyze_shader_code_cached(const uint3
         const size_t span = rdna2_recompile_code_span(code, dwords);
         result->bounded_span = span < dwords;
         if (code && span) result->code.assign(code, code + span);
+        result->code_hash = hash_shader_code(result->code);
         result->pcrel_dispatch = rdna2_pcrel_dispatch_info(code, dwords);
         result->bytes = static_cast<uint64_t>(result->code.size()) * sizeof(uint32_t) +
                         static_cast<uint64_t>(result->pcrel_dispatch.target_pcs.size()) *
@@ -757,6 +765,7 @@ ShaderCompileKey make_shader_compile_key(ShaderProgramStage stage, const uint32_
         // embedded lookup table after ENDPGM; retain that proven tail so cached recompilation sees the
         // same blob as the direct path and table contents participate in the cache identity.
         key.code = std::shared_ptr<const std::vector<uint32_t>>(analysis, &analysis->code);
+        key.code_hash = analysis->code_hash;
     }
     if (resources) {
         key.resources.reserve(resources->resources.size());

--- a/prosper/tests/test_shader_recompile_cache.cpp
+++ b/prosper/tests/test_shader_recompile_cache.cpp
@@ -334,9 +334,10 @@ int main() {
     (void)recompile_graphics_shader_cached(
         ShaderProgramStage::Fragment, mutable_ps.data(), mutable_ps.size(), nullptr);
     analysis_stats = shader_analysis_cache_stats();
+    stats = shader_recompile_cache_stats();
     CHECK(analysis_stats.hits == 1 && analysis_stats.misses == 2 &&
-              analysis_stats.invalidations == 1,
-          "same-address shader mutation invalidates immutable analysis before reuse");
+              analysis_stats.invalidations == 1 && stats.hits == 1 && stats.misses == 2,
+          "same-address shader mutation invalidates analysis and misses the compiled cache");
 
     // Live realization retains the cache allocation directly. Repeated hits must share one immutable
     // word vector, and eviction/reset must not invalidate a DrawItem that still owns that version.


### PR DESCRIPTION
Closes #1051.

## Executive summary

Evergate is now rendering correctly at native resolution on both desktop frontends, but its Windows performance remains highly scene-dependent. The title/menu can approach roughly 20 FPS, while the draw-heavy opening transition still sits near 6 FPS. The broader 20-30 FPS goal is therefore **not finished**.

This PR lands one measured, correctness-preserving executor improvement before development moves from a Windows+WSL workstation to a native Linux machine. Warm shader-cache lookups no longer re-hash every raw shader dword on every draw. On three matched 469-489-draw Evergate windows, the repeat candidate reduced worker-summed shader lookup by 20.5%, draw realization by 8.4%, and executor submit time by 11.2%.

The rest of this description is intentionally a detailed handoff: it records the exact contract, test reasoning, benchmark method, previous experiments, current bottleneck decomposition, native-Linux commands, and ranked next work so investigation can resume without rediscovery.

## Failure scenario

Evergate's dense opening transition repeatedly realizes roughly 470-490 graphics draws per submit. `ShaderCodeAnalysis` already owns an immutable, exact copy of the bounded guest shader program. Nevertheless, every call to `ShaderCompileKeyHash::compute` walked the complete copied program again before performing a warm compiled-shader cache lookup.

In the dense route, a submit contains about 940-980 warm shader-cache hits. The raw code is unchanged, compilation misses are effectively zero, and the same analysis objects are repeatedly byte-validated. Re-hashing the entire program on every lookup was duplicate CPU work in an already CPU-bound parallel realization stage.

## Implementation

- `ShaderCodeAnalysis` now computes and stores a stable 64-bit content hash at the moment it copies the exact bounded shader program.
- `ShaderCompileKey` carries that derived hash beside the aliasing shared pointer that keeps the immutable analysis code alive.
- `ShaderCompileKeyHash::compute` mixes the code length and cached content hash instead of walking every raw dword again.
- `ShaderCompileKey::operator==` still compares complete shader byte vectors. A hash collision therefore remains benign and cannot reuse incorrect SPIR-V.
- Address-local analysis validation is unchanged. If guest shader bytes mutate at the same address, the analysis cache invalidates the old object, creates a new exact copy and content hash, and the compiled cache misses.
- Resource compile keys, pixel/system input mappings, PC-relative dispatch selection, shader compilation, runtime resource tables, and rendered output are deliberately unchanged.

The change is 14 inserted/changed lines across the executor and its focused cache regression.

## Hash/equality invariant and review resolution

The important `unordered_map` invariant is that keys considered equal must hash equally. Using an analysis identity or guest address as the cached value would violate that invariant for byte-identical shaders mapped at different addresses.

The regression suite already proves both sides:

1. It compiles a vertex shader from one allocation, copies identical dwords into a distinct allocation, then requires a compiled-cache hit with unchanged miss and entry counts. An identity/address-derived hash would select a different bucket, producing an extra miss and entry, so this assertion would fail.
2. It recompiles from one mutable allocation, mutates an instruction in place, and requires both analysis invalidation and a new compiled-cache miss. A stale address-only key would fail this assertion.

An initial review comment raised the first case as missing. A focused re-review inspected the existing relocated-allocation assertion, confirmed it catches the hypothesized bug, confirmed the mutation assertion covers stale same-address reuse, and approved the rebased exact head. Full-code equality remains the collision authority.

## Windows performance protocol

Hardware and run configuration:

- Native Windows desktop app
- Intel Core i7-13700K (16 cores / 24 logical processors)
- NVIDIA GeForce RTX 4090
- Fresh isolated save for every run
- Native guest output: `PROSPER_RENDER_SCALE=1`
- Every graphics submit rendered: `PROSPER_RENDER_EVERY=1`
- Eight draw-realization workers
- Immediate present mode
- `PROSPER_RENDER_TIMING=1`
- Guest filesystem and direct graphics enabled
- Identical pad-read-anchored route through logos, title/save selection, and the opening transition

The benchmark compares 25-submit windows with nearly identical average draw counts. Whole-submit backend timings fluctuate, so the candidate was repeated and the intended shader-lookup phase was evaluated separately from unrelated table/backend movement.

### Matched dense-transition windows

| Draws/submit | Master total | Candidate total | Master realization | Candidate realization | Master shader lookup | Candidate shader lookup |
|---:|---:|---:|---:|---:|---:|---:|
| 488.2 / 488.8 | 133.07 ms | 117.98 ms | 40.15 ms | 36.46 ms | 92.50 worker-ms | 72.15 worker-ms |
| 477.0 / 477.8 | 132.68 ms | 114.89 ms | 40.50 ms | 35.83 ms | 91.33 worker-ms | 71.23 worker-ms |
| 469.3 / 469.2 | 125.31 ms | 114.20 ms | 37.65 ms | 36.05 ms | 86.23 worker-ms | 71.31 worker-ms |
| **Mean** | **130.35 ms** | **115.69 ms** | **39.43 ms** | **36.11 ms** | **90.02 worker-ms** | **71.56 worker-ms** |
| **Change** |  | **-11.2%** |  | **-8.4%** |  | **-20.5%** |

The app's coarse counter improved from about 5.7-6.0 FPS in the comparable dense region to about 6.3-6.6 FPS. That is useful but far below the long-term 20-30 FPS target.

### Candidate dense-window decomposition

At roughly 478-489 draws/submit after this patch:

- Executor total: about 115-118 ms/submit
- Draw realization wall time: about 36 ms
- Executor backend: about 79-81 ms
- Worker-summed table construction: about 133-135 ms
- Worker-summed shader lookup: about 71-72 ms
- Table metadata: about 64 ms worker-summed
- Dynamic fold: about 58 ms worker-summed
- Table resource finalization: about 2 ms worker-summed
- Frontend total: about 68-70 ms/submit
- Frontend resource construction: about 43 ms/submit
- Texture work inside construction: about 29 ms/submit
- Buffer/view work inside construction: about 6 ms/submit

Frontend and executor counters describe different pipeline portions and should not be naively added into a single frame time. The app FPS and matched stage deltas are the acceptance signals.

## Work already landed before this PR

- PR #1036 replaced owning per-draw storage-buffer copies with direct non-owning views where lifetime/provenance permits. It reduced the representative route by roughly 8.8% and resource construction by about 11.4 ms.
- Correct native-resolution/pacing defaults were landed so interactive/performance runs use scale 1 and render every submit. Snapshot acceleration must never be reused for performance measurements.
- Evergate title and gameplay snapshot coverage is present and rendering now looks visually correct on Windows and Linux.
- Recent compute/recompiler and direct scalar-buffer fixes are included in the current master base; this PR was rebased after #1030 and the patch replay is range-diff identical.

## Investigations that did not help

Do not repeat these without new evidence:

### #1040 — Windows cross-submit texture validation

Dense submits perform roughly 42-45 exact comparisons over about 127-129 MiB each, consuming around 23-29 ms in texture construction. The source mappings observed on Windows are writable physical aliases, not private/flexible allocations. Windows write-watch is unavailable for them. Passive write-watch produced zero eligible mappings; page-protection fault tracking is unsafe with the guest SysV red-zone behavior; parallel exact compare was neutral or slower. Hash/TTL shortcuts were rejected because they weaken exact mutation detection. The issue remains open for a genuinely exact solution.

### #1045 — exact submit/draw realization cache

A cache keyed first by `GpuState*`, then by exact program/user-register/interpolation content, produced effectively no reuse in dense submits (about one hit per ~940 misses). Draw inputs genuinely vary. The experiment was reverted and the issue closed.

### #1047 — shader decode-cache lock scope

Moving guest readability and byte comparison outside the global decode-cache mutex preserved correctness tests but made the representative Evergate run worse (about 113 ms at ~488 draws versus roughly 100 ms in the preceding control). It was reverted and closed.

### #1049 — skip writeback for proven read-only compute buffers

SPIR-V reflection was extended experimentally to detect stores/copies/buffer atomics and skip live-compute writeback/notifications for read-only buffers. Tests passed after avoiding LDS-atomic false positives, but Evergate showed no overlapping compute writes and no texture-validation reuse improvement. Timings were neutral. It was fully reverted and closed.

### Draw-realization worker count

The 13700K has 24 logical CPUs, but more workers are worse. At the dense transition, 16 workers increased realization to roughly 47 ms and total submit time to roughly 148 ms. Four workers also landed around 50 ms realization / 151 ms total. Eight workers remain the best tested balance; the stage is limited by cache/memory contention as well as parallel work.

## Ranked next investigations on native Linux

The performance objective remains open. Recommended order:

1. **Reuse one exact shader analysis throughout a draw.** The pixel program is currently analyzed/byte-validated while building its stage table, again for interpolation layout, and again for its compiled-shader key; the vertex program is validated during its compiled lookup. Pass an immutable analysis handle through one draw realization so validation happens once per program/version. Preserve exact same-address mutation detection at the draw boundary; do not introduce address/TTL shortcuts. This is the closest follow-up to this PR and directly targets the remaining shader-lookup cost.
2. **Cache static AGC metadata plans.** `build_shader_resources` repeatedly validates and walks static header metadata arrays for each stage/draw, while descriptor values in SGPRs remain dynamic. Consider an immutable layout/plan owned by the registered shader header, then apply current SGPR/EUD values per draw. The cache identity must invalidate if metadata can mutate; verify that lifetime contract before coding.
3. **Replace repeated sparse register lookups.** `read_user_sgprs` performs 32 `unordered_map` probes per block, with multiple blocks per stage and about 950 stage-table calls in a dense submit. A dense register snapshot or faster immutable per-draw register file could remove several milliseconds without changing semantics.
4. **Reduce exact texture-validation work only with exact write evidence.** This is still one of the largest frontend costs, but prior Windows mechanisms were unsuitable. Native Linux may provide different mapping/write-tracking options; first characterize allocation types and mutation frequency there. Any solution must detect guest writes exactly before reusing uploaded data.
5. **Reduce backend synchronization.** Dense submits contain about 14 backend callbacks, six queue submissions/fence waits, roughly 5-7 ms of GPU wait, and 2.5-3 ms of readback in the Windows measurements. Cross-span ordering/batching may help, but this is higher risk and must preserve render-target/readback dependencies.

## Native Linux setup and validation

From a fresh Linux clone/worktree, keep game dumps and save data outside Git. Use the repository's documented dependencies and configure a RelWithDebInfo app build, for example:

```sh
cmake -S prosper -B prosper/build-linux \
  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
  -DPROSPER_APP=ON \
  -DPROSPER_AUDIO_SDL3=ON \
  -DPROSPER_PAD_SDL3=ON
cmake --build prosper/build-linux -j8
ctest --test-dir prosper/build-linux --output-on-failure
```

Renderer-affecting changes require every snapshot guard:

```sh
cd prosper
PROSPER_BOOT_TRACE=build-linux/boot_trace \
PROSPER_SCREENSHOT=build-linux/screenshot \
  python3 tools/snapshot/snapshot.py check
```

For interactive/native-resolution Evergate from `prosper/`:

```sh
PROSPER_GUEST_FS=1 \
PROSPER_GUEST_ARGS=-force-gfx-direct \
PROSPER_RENDER_EVERY=1 \
PROSPER_RENDER_SCALE=1 \
PROSPER_PAD_SCRIPT=@scripts/evergate/reach-first-gameplay-realtime.pad \
  ./build-linux/prosper-app --dump /path/to/PPSA01885-app0
```

For profiling, additionally set `PROSPER_RENDER_TIMING=1`, use immediate present if supported, use a fresh `PROSPER_SAVEDATA_DIR`, and ensure `PROSPER_RENDER_EVERY_FOR_MS` is unset. Keep `PROSPER_DRAW_REALIZE_THREADS=8` for cross-machine comparison first; sweep only after establishing the native-Linux baseline.

The committed realtime route contains the validated progression edges. On a faster build that consumes pad reads before wall-time-driven transitions complete, append these extra read-anchored Cross pulses locally (do not use this extended route for snapshot acceleration):

```text
p190-195:cross
p205-210:cross
p220-225:cross
p235-240:cross
p250-255:cross
p265-270:cross
p280-285:cross
p295-300:cross
p310-315:cross
p325-330:cross
p340-345:cross
p355-360:cross
p370-375:cross
p385-390:cross
p400-405:cross
p415-420:cross
p430-435:cross
p445-450:cross
p460-465:cross
p475-480:cross
p490-495:cross
```

A valid performance run must reach the draw-heavy intro transition/new-game opening. Title-idle samples are not representative. Compare 25-submit windows at matched draw counts, report realization wall time separately from worker-summed subphases, and repeat candidates because backend scheduling is noisy.

## Verification and merge gates

Completed on the rebased exact patch:

- Focused Windows build of `test_shader_recompile_cache` — pass
- Focused Windows `test_shader_recompile_cache.exe` — pass
- `git diff --check` — pass
- Rebase range-diff against the reviewed pre-rebase commit — identical
- Independent exact-head review — approved; the earlier test concern was explicitly cleared

Completed exact-head verification at `10fe613ea92f4b441afd86cf54f756eb1beebf59` against `origin/master@f13b90cf88834a9ce963a04a74715aab0fada41b`:

- Linux build — pass
- Linux ctest — 116/116 pass
- Windows build — pass
- Windows ctest — 95/95 pass
- All snapshot guards — pass: Messenger scene, Evergate title, Dead Cells gameplay, and Blasphemous II gameplay
- Refreshed GitHub Actions — Linux, Linux App, Windows MinGW, Windows App, macOS, and macOS App all pass

No screenshot is attached because this is a performance-only cache-key change: it does not advance a visible checkpoint or intentionally change pixels.

## Handoff state

After this PR merges, no further optimization work will be started from the Windows/WSL workstation. Resume on native Linux from current remote master, reproduce the realtime route with scale 1/render-every 1, establish a new Linux baseline, and begin with the ranked analysis-reuse investigation above. The 20-30 FPS objective remains explicitly open.