### PR TITLE
gpu(shader): recompile integer sub-dword buffer_store_format race-free (#590)

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -5237,6 +5237,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // when idxen; no offen (a runtime per-lane byte offset is unprovable); SOFFSET is NULL/0.
             bool dyn_half = false;   // 16-bit element at a runtime dword half (stride-2 buffers, #273)
             bool dyn_int = false;    // integer sub-dword FORMAT component at a runtime (unaligned) byte addr
+            bool dyn_int_store = false;  // integer sub-dword FORMAT store via race-free atomic clear+set
             if (packed && !raw_subword) {
                 bool base_aligned;
                 if (dyn_vfetch) {
@@ -5269,7 +5270,16 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     // address (join the straddled dwords, then bfe), so it needs no static alignment.
                     // Only LOADS: the packed store path still rejects sub-dword ints (they don't pack).
                     if (!dyn_half) dyn_int = int_subword && !is_store;
-                    if (!dyn_half && !dyn_int) {
+                    // An integer sub-dword FORMAT STORE writes ONE lane's disjoint bit field of the
+                    // containing dword. A plain masked read-modify-write would race (adjacent lanes' fields
+                    // share a dword), but atomicAnd(clear field)+atomicOr(set field) COMMUTE across lanes
+                    // writing DISJOINT fields, so the store is race-free. Requires the field to lie within
+                    // a single dword: address comp_bytes-aligned, no runtime per-lane byte offset. (A
+                    // straddling field would span two dwords -> deferred fail-visibly.)
+                    if (!dyn_half && !dyn_int && is_store && int_subword && !offen && !dyn_vfetch &&
+                        (offset % comp_bytes) == 0 && (!idxen || (stride % comp_bytes) == 0) && soff_zero)
+                        dyn_int_store = true;
+                    if (!dyn_half && !dyn_int && !dyn_int_store) {
                         if (getenv("PROSPER_DBG"))
                             fprintf(stderr, "[mubuf-unaligned] pc=%u fmt=%u off=%u offen=%d idxen=%d stride=%u\n",
                                     in.pc, (unsigned)fmt, offset, (int)offen, (int)idxen, stride);
@@ -5317,14 +5327,36 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 return true;
             }
             if (is_store) {
-                // Store the VDATA VGPRs (in.dst..+n-1). Integer sub-dword formats (Uint8/Sint8/...) have
-                // no packing path here -> reject rather than mis-store (loads extend them; stores don't pack).
+                auto vread = [&](int r){ auto it = rs.vreg.find(r); return it == rs.vreg.end() ? b.uconst(0) : it->second; };
+                if (dyn_int_store) {
+                    // Integer sub-dword store: clear then set THIS lane's disjoint field of the containing
+                    // dword with two atomics. Disjoint fields commute, so no read-modify-write lock is
+                    // needed; EXEC predication keeps inactive lanes from writing (like cbuf_store).
+                    const uint32_t field_mask = comp_bytes == 2 ? 0xffffu : 0xffu;
+                    for (uint32_t k = 0; k < n; k++) {
+                        const uint32_t caddr = k ? b.ibin(Op_IAdd, addr, b.uconst(k * comp_bytes)) : addr;
+                        const uint32_t cidx  = b.ibin(Op_ShiftRightLogical, caddr, b.uconst(2));
+                        const uint32_t bitpos = b.ibin(Op_ShiftLeftLogical,
+                                                       b.ibin(Op_BitwiseAnd, caddr, b.uconst(3)), b.uconst(3));
+                        const uint32_t mask = b.ibin(Op_ShiftLeftLogical, b.uconst(field_mask), bitpos);
+                        const uint32_t v = b.ibin(Op_ShiftLeftLogical,
+                                                  b.ibin(Op_BitwiseAnd, vread(in.dst.value + (int)k),
+                                                         b.uconst(field_mask)), bitpos);
+                        b.cbuf_atomic_rtn(Op_AtomicAnd, cidx, b.iun(Op_Not, mask), binding,
+                                          rs.exec_narrowed, rs.exec, b.uconst(0));
+                        b.cbuf_atomic_rtn(Op_AtomicOr, cidx, v, binding,
+                                          rs.exec_narrowed, rs.exec, b.uconst(0));
+                    }
+                    return true;
+                }
+                // Store the VDATA VGPRs (in.dst..+n-1). Integer sub-dword formats reach the atomic path
+                // above when in-dword-provable; anything else that can't pack (packed_word, or an
+                // integer field that could straddle) rejects rather than mis-store.
                 if (packed_word || (packed && (is_uint || is_sint))) { ok = false; return true; }
                 // MTBUF's instruction format owns the physical component count. A wider opcode still uses
                 // identity selection (for example XY00), so Z/W must not spill into adjacent memory.
                 const uint32_t store_n = in.fmt == Rdna2Format::MTBUF && fmt_ncomp < n
                                            ? fmt_ncomp : n;
-                auto vread = [&](int r){ auto it = rs.vreg.find(r); return it == rs.vreg.end() ? b.uconst(0) : it->second; };
                 if (!packed) {
                     // Raw/Float32/Uint32: one dword per component.
                     for (uint32_t k = 0; k < store_n; k++) {

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -5330,8 +5330,14 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 auto vread = [&](int r){ auto it = rs.vreg.find(r); return it == rs.vreg.end() ? b.uconst(0) : it->second; };
                 if (dyn_int_store) {
                     // Integer sub-dword store: clear then set THIS lane's disjoint field of the containing
-                    // dword with two atomics. Disjoint fields commute, so no read-modify-write lock is
-                    // needed; EXEC predication keeps inactive lanes from writing (like cbuf_store).
+                    // dword with two atomics. Disjoint fields commute (And clears only this field's bits,
+                    // Or sets only this field's bits), so no read-modify-write lock is needed; EXEC
+                    // predication keeps inactive lanes from writing (like cbuf_store). CONFIDENCE: HIGH —
+                    // this diverges from a hardware byte-enable store ONLY in already-UB situations: two
+                    // lanes storing to the SAME element OR-merge instead of one-winner, and a racing reader
+                    // could observe the transient post-And zero. Both require a data race a well-formed
+                    // shader never has. A straddling field (excluded by the alignment guard above) is the
+                    // one shape this can't express and stays deferred.
                     const uint32_t field_mask = comp_bytes == 2 ? 0xffffu : 0xffu;
                     for (uint32_t k = 0; k < n; k++) {
                         const uint32_t caddr = k ? b.ibin(Op_IAdd, addr, b.uconst(k * comp_bytes)) : addr;

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -1008,6 +1008,31 @@ int main() {
     CHECK(!spv_atomic_or.empty() && or_buf_out.size() == 1 && or_buf_out[0] == 7u,
           "#590: buffer_atomic_or is idempotent (4 | 3 = 7), distinct from add/max/swap");
 
+    // Kernel 24store (#590): integer sub-dword FORMAT store at a runtime byte address. Every lane stores
+    // its gid as a Uint16 into element[gid] of a stride-2 buffer, so elements 2k and 2k+1 SHARE dword k.
+    // A plain read-modify-write would race; the atomicAnd(clear field)+atomicOr(set field) of each lane's
+    // disjoint 16-bit field must land BOTH values -> dword k == 2k | ((2k+1)<<16). Real Vulkan run.
+    ShaderResourceTable rt_store16;
+    { ShaderResource sb{}; sb.cls = ResourceClass::ConstantBuffer; sb.format = DataFormat::Uint16;
+      sb.num_components = 1; sb.binding = 3; sb.stride = 2; sb.sgpr_base = 8; sb.fetch_pc = 2;
+      rt_store16.resources.push_back(sb); }
+    const uint32_t code_store16[] = {
+        0x7e000f00u,               // v_cvt_u32_f32 v0, v0   (shell input float gid -> int index)
+        0x7e020300u,               // v_mov_b32 v1, v0       (value = gid)
+        0xe0102000u, 0x80020100u,  // buffer_store_format_x v1, v0, s[8:11], idxen  (Uint16, stride 2)
+        0xbf810000u,
+    };
+    std::vector<uint32_t> spv_store16 = recompile_valu(
+        code_store16, std::size(code_store16), 1, 0, &rt_store16);
+    std::vector<uint32_t> store16_in(N / 2, 0), store16_out;
+    std::vector<float> store16_dummy(N); for (uint32_t i = 0; i < N; ++i) store16_dummy[i] = (float)i;
+    prosper::test::run_compute(spv_store16, store16_dummy, N, N, {}, store16_in, &store16_out);
+    uint32_t bad_store16 = 0;
+    for (uint32_t k = 0; k < N / 2 && store16_out.size() == N / 2; ++k)
+        if (store16_out[k] != ((2u * k) | ((2u * k + 1u) << 16))) ++bad_store16;
+    CHECK(!spv_store16.empty() && store16_out.size() == N / 2 && bad_store16 == 0,
+          "#590: stride-2 Uint16 buffer_store_format_x lands disjoint fields race-free (dword k = 2k|(2k+1)<<16)");
+
     // Kernel 24b (#150): the SAME unorm8x4 fetch but with a NON-dword-aligned inst offset (offset:2).
     // The packed unpack extracts components at static byte offsets from a dword-aligned base and drops
     // addr&3, so a non-aligned element base would decode the wrong bits — it must be REJECTED (the


### PR DESCRIPTION
## Goal
Recompile another DOLL (PPSA17942) post-process compute shader by closing the sub-dword integer buffer-**store** gap (relates #590) — the store analog of the merged load fix #1041.

## Failure scenario
`resolve_dynamic_fetch` resolves a DOLL LUT kernel's `buffer_store_format_x v, vIDX, s[8:11], idxen` to a **Uint16** V# (stride 2). The buffer-store path rejected it (`[mubuf-unaligned]`, then the integer-store guard) because a stride-2 element base isn't dword-aligned and "stores don't pack". The whole shader dropped (`skip unsupported program`).

## Why a plain fix is wrong, and the fix
A masked read-modify-write of the containing dword **races**: elements 2k and 2k+1 share dword k, so two lanes' RMW clobber each other. Instead, store each lane's field with **`atomicAnd(clear field)` + `atomicOr(set field)`**. Lanes writing **disjoint** bit fields of the same dword *commute* (each atomic only touches its own bits), so the two-atomic sequence is race-free without a lock and matches hardware sub-dword store semantics.

Gated (`dyn_int_store`) to integer sub-dword format stores whose field provably lies within a single dword — `comp_bytes`-aligned address, no runtime per-lane byte offset; a straddling field stays deferred fail-visibly. EXEC predication keeps inactive lanes from writing. Reuses the atomics landed in #1044.

## Verification
- New `test_rdna2_to_spirv` **execution** case: all N lanes store their gid as a Uint16 into a stride-2 buffer, so elements 2k and 2k+1 share dword k; asserts `dword k == 2k | ((2k+1)<<16)` through real Vulkan — proving **both disjoint fields land race-free**.
- Routed PPSA17942 boot: DOLL post-process `skip unsupported program` **2 → 1** (this kernel now recompiles); 0 remaining `[mubuf-unaligned]` / op-0x4 rejects.
- Full Linux `ctest` green for all recompiler/render tests (the 3 red are Messenger-dump-specific in this worktree).

## Progress on #590
DOLL post-process shaders that fail to recompile: **4 → 3** (#1041 buffer_load_format) **→ 2** (#1044 atomics) **→ 1** (this). The last one (`0x201a5a0000`) needs nested-loop CFG structurizing — tracked on #590.

## Risk
Low–moderate. New path reachable only by a previously-rejected instruction class; the concurrency argument (disjoint fields commute) is proven by a real-Vulkan multi-lane execution test that would fail under a racy RMW.
