### PR TITLE
fix(audio): add paced headless AudioIn core

### DIFF
--- a/prosper/src/hle/hle_audio.cpp
+++ b/prosper/src/hle/hle_audio.cpp
@@ -110,6 +110,7 @@ Port* port_of(int handle) {
 // --- public backend hooks (audio.hpp) ---------------------------------------------------
 void audio_set_sink(AudioSink* sink) { g_sink.store(sink ? sink : &g_default_sink); }
 AudioSink* audio_sink() { return g_sink.load(); }
+static void audio_in_reset_ports();
 
 void audio_decode_format(uint32_t param, int& channels, AudioFmt& fmt) {
     switch (param & 0xff) {                                   // SceAudioOutParamFormat (low byte)
@@ -141,12 +142,15 @@ int audio_peak_channel_volume(uint32_t mask, const int* vols) {
 
 void audio_reset() {
     AudioSink* s = audio_sink();
-    std::lock_guard<std::mutex> lk(g_mx);
-    for (int i = 0; i < kMaxPorts; i++) {
-        if (g_ports[i].in_use && s) s->close(i + 1);
-        g_ports[i] = Port{};
+    {
+        std::lock_guard<std::mutex> lk(g_mx);
+        for (int i = 0; i < kMaxPorts; i++) {
+            if (g_ports[i].in_use && s) s->close(i + 1);
+            g_ports[i] = Port{};
+        }
+        g_sink.store(&g_default_sink);
     }
-    g_sink.store(&g_default_sink);
+    audio_in_reset_ports();
 }
 
 // --- legacy-path diagnostics --------------------------------------------------------------
@@ -515,6 +519,11 @@ int audio_in_port_id(uint64_t raw_handle) {
 }
 
 } // namespace
+
+static void audio_in_reset_ports() {
+    std::lock_guard<std::mutex> lk(g_audio_in_mx);
+    for (auto& port : g_audio_in_ports) port = {};
+}
 
 HLE(audio_in_init) { return 0; }
 

--- a/prosper/src/hle/hle_audio.cpp
+++ b/prosper/src/hle/hle_audio.cpp
@@ -1,8 +1,8 @@
-// hle_audio.cpp — libSceAudioOut HLE, backed by a pluggable AudioSink (see audio.hpp).
+// hle_audio.cpp — libSceAudioOut/AudioIn HLE, with pluggable output (see audio.hpp).
 //
 // Decodes the PS5 sceAudioOut* calls into port lifecycle + interleaved PCM grains and forwards
-// them to the installed backend. prosper_core ships only the headless default (silent, real-time
-// paced) so it stays dependency-free; a concrete frontend (SDL3, ...) installs itself via
+// them to the installed backend. The inherited AudioIn core provides deterministic paced silence.
+// prosper_core stays dependency-free; a concrete output frontend (SDL3, ...) installs itself via
 // audio_set_sink() from outside the core.
 #include "dispatch.hpp"
 #include "nid.hpp"
@@ -476,6 +476,109 @@ bool a2_store_u64(uint64_t dst, uint64_t v) { return audio_store_bytes(dst, &v, 
 bool a2_store_zeros(uint64_t dst, size_t n) {
     std::vector<uint8_t> z(n, 0);
     return audio_store_bytes(dst, z.data(), n);
+}
+
+// ---- libSceAudioIn: headless, silent, real-time paced ----------------------------------
+//
+// The inherited PS4/PS5 core ABI has seven ports. Handles carry the public 0x30000000 tag,
+// the port type in bits 16..23, and a zero-based port id in bits 0..7. We deliberately do not
+// open a host microphone: returning exact-size silence gives privacy-preserving deterministic
+// behavior, while grain/frequency pacing preserves the blocking capture-thread contract.
+namespace {
+
+constexpr int      kAudioInMaxPorts  = 7;
+constexpr uint32_t kAudioInHandleTag = 0x30000000u;
+constexpr uint64_t kAudioInErrInvalidHandle = (uint64_t)(int64_t)(int32_t)0x80260101;
+constexpr uint64_t kAudioInErrInvalidSize   = (uint64_t)(int64_t)(int32_t)0x80260102;
+constexpr uint64_t kAudioInErrInvalidFreq   = (uint64_t)(int64_t)(int32_t)0x80260103;
+constexpr uint64_t kAudioInErrInvalidPtr    = (uint64_t)(int64_t)(int32_t)0x80260105;
+constexpr uint64_t kAudioInErrInvalidParam  = (uint64_t)(int64_t)(int32_t)0x80260106;
+constexpr uint64_t kAudioInErrPortFull      = (uint64_t)(int64_t)(int32_t)0x80260107;
+constexpr uint64_t kAudioInErrNotOpened     = (uint64_t)(int64_t)(int32_t)0x80260109;
+
+struct AudioInPort {
+    bool in_use = false;
+    uint32_t grain = 0;
+    uint32_t freq = 0;
+    uint32_t channels = 0;
+    std::chrono::steady_clock::time_point next{};
+};
+
+std::mutex  g_audio_in_mx;
+AudioInPort g_audio_in_ports[kAudioInMaxPorts];
+
+int audio_in_port_id(uint64_t raw_handle) {
+    uint32_t handle = (uint32_t)raw_handle;
+    if ((handle & 0x7f000000u) != kAudioInHandleTag) return -1;
+    uint32_t id = handle & 0xffu;
+    return id < kAudioInMaxPorts ? (int)id : -1;
+}
+
+} // namespace
+
+HLE(audio_in_init) { return 0; }
+
+// sceAudioInOpen(userId, type, index, len, freq, param) -> tagged handle or AudioIn error.
+// Public formats are S16 mono (0) and S16 stereo (2); supported rates are 16/48 kHz and the
+// hardware grain limit is 1..2048 frames. userId/type/index policy is left to the guest-facing
+// service just as in the reference implementation; type is retained in the opaque handle.
+HLE(audio_in_open) {
+    (void)a0; (void)a2;
+    uint32_t grain = (uint32_t)a3;
+    uint32_t freq = (uint32_t)a4;
+    uint32_t format = (uint32_t)a5;
+    if (!grain || grain > 2048) return kAudioInErrInvalidSize;
+    if (freq != 16000 && freq != 48000) return kAudioInErrInvalidFreq;
+    uint32_t channels;
+    if (format == 0) channels = 1;
+    else if (format == 2) channels = 2;
+    else return kAudioInErrInvalidParam;
+
+    std::lock_guard<std::mutex> lk(g_audio_in_mx);
+    for (int id = 0; id < kAudioInMaxPorts; id++) {
+        if (g_audio_in_ports[id].in_use) continue;
+        g_audio_in_ports[id] = {true, grain, freq, channels, {}};
+        return (uint32_t)(kAudioInHandleTag | (((uint32_t)a1 & 0xffu) << 16) | (uint32_t)id);
+    }
+    return kAudioInErrPortFull;
+}
+
+// sceAudioInInput(handle, dst) blocks for one capture grain and returns frames captured. The
+// null backend writes exactly grain*channels S16 samples. Fault-safe output preserves the HLE
+// process when a guest supplies an inaccessible range.
+HLE(audio_in_input) {
+    int id = audio_in_port_id(a0);
+    if (id < 0) return kAudioInErrInvalidHandle;
+    if (!a1) return kAudioInErrInvalidPtr;
+
+    std::chrono::steady_clock::time_point deadline;
+    uint32_t grain;
+    {
+        std::lock_guard<std::mutex> lk(g_audio_in_mx);
+        AudioInPort& port = g_audio_in_ports[id];
+        if (!port.in_use) return kAudioInErrNotOpened;
+        size_t bytes = (size_t)port.grain * port.channels * sizeof(int16_t);
+        if (!a2_store_zeros(a1, bytes)) return kAudioInErrInvalidPtr;
+
+        grain = port.grain;
+        auto now = std::chrono::steady_clock::now();
+        auto duration = std::chrono::nanoseconds((uint64_t)port.grain * 1000000000ull / port.freq);
+        if (port.next.time_since_epoch().count() == 0 || port.next < now - duration * 4)
+            port.next = now;
+        port.next += duration;
+        deadline = port.next;
+    }
+    if (deadline > std::chrono::steady_clock::now()) std::this_thread::sleep_until(deadline);
+    return grain;
+}
+
+HLE(audio_in_close) {
+    int id = audio_in_port_id(a0);
+    if (id < 0) return kAudioInErrInvalidHandle;
+    std::lock_guard<std::mutex> lk(g_audio_in_mx);
+    if (!g_audio_in_ports[id].in_use) return kAudioInErrNotOpened;
+    g_audio_in_ports[id] = {};
+    return 0;
 }
 
 constexpr uint64_t kA2ErrInvalid = (uint64_t)(int64_t)(int32_t)0x80260003;   // AudioOut error space
@@ -1325,6 +1428,11 @@ void register_audio_hle() {
     R("sceAudioOutSetVolume", audio_set_volume);
     R("sceAudioOutClose", audio_close);
     R("sceAudioOutGetPortState", audio_get_port_state);
+    // libSceAudioIn inherited core: deterministic null microphone with real-time capture pacing.
+    R("sceAudioInInit", audio_in_init);
+    R("sceAudioInOpen", audio_in_open);
+    R("sceAudioInInput", audio_in_input);
+    R("sceAudioInClose", audio_in_close);
     // libSceAudioOut2 (PS5) — see the probe block above.
     R("sceAudioOut2Initialize", audio2_initialize);
     R("sceAudioOut2ContextResetParam", audio2_ctx_reset_param);

--- a/prosper/tests/test_audio.cpp
+++ b/prosper/tests/test_audio.cpp
@@ -7,6 +7,7 @@
 #include "../src/hle/dispatch.hpp"
 #include "../src/hle/nid.hpp"
 #include "../src/hle/audio.hpp"
+#include <chrono>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
@@ -189,7 +190,52 @@ int main() {
                                                           // ports (Kyty/shadPS4 both return a single grain)
     CHECK(sink.outs.size() == 2);                         // ...but both valid entries are still forwarded
 
-    // --- 10. libSceNgs2 silent lifecycle: sizes, handles, state, and render output -------------
+    // --- 10. libSceAudioIn: tagged lifecycle, exact silence, errors, exhaustion, pacing -------
+    CHECK(call("sceAudioInInit") == 0);
+    CHECK((int32_t)call("sceAudioInOpen", 1, 1, 0, 0, 16000, 0) == (int32_t)0x80260102);
+    CHECK((int32_t)call("sceAudioInOpen", 1, 1, 0, 2049, 16000, 0) == (int32_t)0x80260102);
+    CHECK((int32_t)call("sceAudioInOpen", 1, 1, 0, 320, 44100, 0) == (int32_t)0x80260103);
+    CHECK((int32_t)call("sceAudioInOpen", 1, 1, 0, 320, 16000, 1) == (int32_t)0x80260106);
+
+    int64_t hi = call("sceAudioInOpen", 1, 1 /* GENERAL */, 0, 320, 16000, 0 /* S16 mono */);
+    CHECK(hi >= 0 && ((uint32_t)hi & 0x7f000000u) == 0x30000000u);
+    CHECK((int32_t)call("sceAudioInInput", (uint64_t)hi, 0) == (int32_t)0x80260105);
+    CHECK((int32_t)call("sceAudioInInput", (uint64_t)hi, 1) == (int32_t)0x80260105);
+
+    std::vector<uint8_t> mic(320 * 2 + 2, 0xA5);
+    auto mic_start = std::chrono::steady_clock::now();
+    CHECK(call("sceAudioInInput", (uint64_t)hi, PTR(mic.data() + 1)) == 320);
+    auto mic_elapsed = std::chrono::steady_clock::now() - mic_start;
+    CHECK(mic_elapsed >= std::chrono::milliseconds(10));  // 320 / 16 kHz = 20 ms; tolerate coarse clocks
+    CHECK(mic.front() == 0xA5 && mic.back() == 0xA5);     // exact-size write canaries
+    for (size_t i = 1; i + 1 < mic.size(); i++) CHECK(mic[i] == 0);
+
+    CHECK(call("sceAudioInClose", (uint64_t)hi) == 0);
+    memset(mic.data() + 1, 0x5A, mic.size() - 2);
+    CHECK((int32_t)call("sceAudioInInput", (uint64_t)hi, PTR(mic.data() + 1)) ==
+          (int32_t)0x80260109);
+    for (size_t i = 1; i + 1 < mic.size(); i++) CHECK(mic[i] == 0x5A); // closed handle leaves output
+    CHECK((int32_t)call("sceAudioInClose", (uint64_t)hi) == (int32_t)0x80260109);
+    CHECK((int32_t)call("sceAudioInInput", 1, PTR(mic.data() + 1)) == (int32_t)0x80260101);
+    CHECK((int32_t)call("sceAudioInClose", 1) == (int32_t)0x80260101);
+
+    int64_t stereo_hi = call("sceAudioInOpen", 1, 0, 0, 64, 48000, 2 /* S16 stereo */);
+    std::vector<uint8_t> stereo_mic(64 * 2 * 2 + 2, 0xC7);
+    CHECK(call("sceAudioInInput", (uint64_t)stereo_hi, PTR(stereo_mic.data() + 1)) == 64);
+    CHECK(stereo_mic.front() == 0xC7 && stereo_mic.back() == 0xC7);
+    for (size_t i = 1; i + 1 < stereo_mic.size(); i++) CHECK(stereo_mic[i] == 0);
+    CHECK(call("sceAudioInClose", (uint64_t)stereo_hi) == 0);
+
+    int64_t input_handles[7];
+    for (int i = 0; i < 7; i++) {
+        input_handles[i] = call("sceAudioInOpen", 1, 0, i, 64, 48000, 2 /* S16 stereo */);
+        CHECK(input_handles[i] >= 0);
+        for (int j = 0; j < i; j++) CHECK(input_handles[i] != input_handles[j]);
+    }
+    CHECK((int32_t)call("sceAudioInOpen", 1, 0, 7, 64, 48000, 2) == (int32_t)0x80260107);
+    for (int i = 0; i < 7; i++) CHECK(call("sceAudioInClose", (uint64_t)input_handles[i]) == 0);
+
+    // --- 11. libSceNgs2 silent lifecycle: sizes, handles, state, and render output -------------
     struct BufferInfo { uint64_t host_buffer, host_buffer_size, reserved[5], user_data; };
     struct RackOption {
         uint64_t size; char name[16]; uint32_t flags, max_grain, max_voices,

--- a/prosper/tests/test_audio.cpp
+++ b/prosper/tests/test_audio.cpp
@@ -233,7 +233,17 @@ int main() {
         for (int j = 0; j < i; j++) CHECK(input_handles[i] != input_handles[j]);
     }
     CHECK((int32_t)call("sceAudioInOpen", 1, 0, 7, 64, 48000, 2) == (int32_t)0x80260107);
-    for (int i = 0; i < 7; i++) CHECK(call("sceAudioInClose", (uint64_t)input_handles[i]) == 0);
+    audio_reset();
+    memset(stereo_mic.data() + 1, 0x3C, stereo_mic.size() - 2);
+    CHECK((int32_t)call("sceAudioInInput", (uint64_t)input_handles[0], PTR(stereo_mic.data() + 1)) ==
+          (int32_t)0x80260109);
+    for (size_t i = 1; i + 1 < stereo_mic.size(); i++) CHECK(stereo_mic[i] == 0x3C);
+    for (int i = 0; i < 7; i++) {
+        input_handles[i] = call("sceAudioInOpen", 1, 0, i, 64, 48000, 2);
+        CHECK(input_handles[i] >= 0);                     // reset released every input slot
+    }
+    CHECK((int32_t)call("sceAudioInOpen", 1, 0, 7, 64, 48000, 2) == (int32_t)0x80260107);
+    audio_reset();
 
     // --- 11. libSceNgs2 silent lifecycle: sizes, handles, state, and render output -------------
     struct BufferInfo { uint64_t host_buffer, host_buffer_size, reserved[5], user_data; };

--- a/prosper/tests/test_hle_registered.cpp
+++ b/prosper/tests/test_hle_registered.cpp
@@ -46,6 +46,7 @@ int main() {
         // audio (headless / pluggable backend)
         "sceAudioOutInit", "sceAudioOutOpen", "sceAudioOutOutput", "sceAudioOutOutputs",
         "sceAudioOutSetVolume", "sceAudioOutClose", "sceAudioOutGetPortState",
+        "sceAudioInInit", "sceAudioInOpen", "sceAudioInInput", "sceAudioInClose",
     };
     for (const char* n : names) must(n);
     // sync_on_address futex is registered by raw NID (no symbol name) — check it directly.


### PR DESCRIPTION
﻿Part of #396 (F3 headless AudioIn core slice).

## What changed
- registers the inherited `sceAudioInInit`, `sceAudioInOpen`, `sceAudioInInput`, and `sceAudioInClose` surface
- validates the public 1..2048-frame grain, 16/48 kHz rates, and S16 mono/stereo formats with exact signed AudioIn errors
- allocates the seven public tagged input-port handles and enforces live/closed/exhausted lifecycle behavior
- writes exact-size deterministic silence through the fault-safe guest-store path and paces each read to `grain / frequency` so capture loops do not busy-spin

## Verification
- Linux focused build + `ctest -R '^(audio_hle|hle_functions_registered)$'`: 2/2 passed
- Windows focused build + `ctest -R '^(audio_hle|hle_functions_registered)$'`: 2/2 passed
- `git diff --check`: passed

Coverage includes mono and stereo write canaries, inaccessible/null outputs, exact error values, close/use-after-close, all seven ports plus exhaustion, and a 20 ms pacing lower bound.

## Risk / deliberately unaffected
- This is a deterministic null microphone; it does not capture host microphone data.
- AudioIn extension/device/HQ/configuration APIs and the broader AJM decode backlog remain outside this slice.
- No game, snapshot, capture, renderer, or desktop-parity work is included.
