### PR TITLE
fix(gpu): fold PC-relative SMEM shader tables

### DIFF
--- a/prosper/docs/ASTROBOT_LINUX_HANDOFF_2026_07_19.md
+++ b/prosper/docs/ASTROBOT_LINUX_HANDOFF_2026_07_19.md
@@ -1,0 +1,584 @@
+# Astro Bot native-Linux graphics handoff (2026-07-19)
+
+> **Draft handoff — documentation only. Do not merge yet.** Tracks #1054 and continues the visual
+> correctness work after #825. The functional PC-relative scalar-table fix still belongs on this branch.
+
+This document hands the active Astro Bot (`PPSA21564`) graphics investigation from the Windows/WSL
+host to a native Linux development machine. It records the exact merged frontier, the currently proven
+failure, local-only evidence, dead ends and diagnostic caveats, a concrete implementation direction,
+and the acceptance checks for the real goal.
+
+The active focused tracker item is [#1054](https://github.com/mattias800/ps5ys/issues/1054). The
+historical umbrella [#825](https://github.com/mattias800/ps5ys/issues/825) is closed because control-flow
+progression through the first-level hub was achieved on Linux and Windows. That closure did **not** mean
+the native title graphics were complete. The current goal is stricter: obtain genuine nonblack Astro
+graphics from the normal Linux headless renderer, then validate the Linux app and cross-check Windows
+headless/app behavior.
+
+## Executive status
+
+- Start from remote `master`. At final handoff publication it is
+  `f13b90cf88834a9ce963a04a74715aab0fada41b`, including PR #1030 plus the subsequently merged
+  compute-shader and AudioIn work in PRs #1053 and #1055.
+- The handoff branch is `fix/issue-1054-astro-pcrel`. It is already pushed and claimed on #1054.
+- Astro reaches `title_controller_ship` and the title level starts on the established Linux diagnostic
+  route. Guest execution, input scripting, VideoOut flips, and substantial GPU submission all advance.
+- The current raw/composited headless title captures are still entirely black. This is not a screenshot
+  timing problem: manifests show thousands of presents and hundreds of composited frame publications
+  while every pixel remains black.
+- PR #1030 removed the immediately preceding pixel-shader resource failure at PC 137. The main title PS
+  `0x5002af200` now reaches PC 221 and rejects `s_getpc_b64 s[0:1]`.
+- PC 221 is **not** an indirect branch. It is the first of six compiler-generated constructions of the
+  same PC-relative 64-byte scalar constant buffer. The table is loaded with
+  `s_buffer_load_dwordx4` using a dynamically computed scalar byte offset.
+- A live `/proc/<pid>/mem` probe proves that the table begins at `code + 0x15f0`, 20 bytes after the
+  reported instruction blob ends at `code + 0x15dc`. The 64-byte payload is present and readable in the
+  guest mapping.
+- prosper already folds the analogous PC-relative **MUBUF** embedded-table idiom and already retains its
+  proven post-`s_endpgm` tail in shader cache keys. It does not recognize or fold this **SMEM scalar
+  buffer-load** form. Extending that narrowly proven mechanism is the next implementation, not adding a
+  generic `s_getpc_b64` no-op.
+- No functional #1054 fix has been written on this branch yet. This draft is deliberately a handoff,
+  not a claim that the shader or black output is fixed.
+
+## Repository and coordination state
+
+At the time this handoff was written:
+
+- `origin/master`: `f13b90c` (`Merge pull request #1055 ... audioin-core`)
+- active branch: `fix/issue-1054-astro-pcrel`
+- active issue: #1054, labeled `bug`, `area:infra`, `in-progress`, and `agent:astro-title`
+- no other open PR carries the `agent:astro-title` label
+- open PR #1052 (`perf(executor): reuse analyzed shader content hashes`) is green and clean, and touches:
+  - `prosper/src/gpu/gpu_executor.cpp`
+  - `prosper/tests/test_shader_recompile_cache.cpp`
+
+The branch was rebased onto that exact master tip immediately before publication. Fetch again before
+editing because this repository moves frequently. If #1052 has merged, rebase the handoff branch and
+inspect its cache-key/span changes before implementing #1054. The expected core #1054 work is mostly in
+`rdna2_to_spirv.cpp`, but cache-span regression coverage naturally overlaps
+`test_shader_recompile_cache.cpp`.
+
+Do not create a duplicate issue or branch. Continue #1054 on this branch and update the existing draft
+PR. This repository is an agent project; the owner explicitly requested that agents not request reviews
+from real people. Perform exact-head author verification and use CI, focused negative controls, and
+programmatic image evidence. Keep the PR draft until it contains a real fix and its required renderer
+verification.
+
+## What is already working
+
+The original #825 bring-up is extensive and should not be restarted:
+
+- SELF/ELF load and linking, guest `main`, worker threads, fibers, VideoOut, input, save data, and the
+  native ASOBI engine boot path work far beyond the issue's original fiber crash.
+- PR #837 reached the loading screen.
+- PR #842 advanced through title/world-map control flow.
+- PR #852 reached the title with native Windows video.
+- PR #876 established scripted Linux and Windows progression through the first-level hub.
+- PRs #922 and #961 restored/rendered the opening video surface.
+- PR #884 fixed Windows directory enumeration needed by Astro cinematics.
+- PR #970 fixed compute raw-buffer provenance across CFG joins for the Astro title path.
+- PR #1023 implemented the RDNA2 unsigned-byte conversion operations exposed by Astro.
+- PR #1030 recovered direct scalar-buffer resources, removing the title PS's PC 137 rejection.
+- The wider RDNA2 audit in PR #889 and subsequent shader fixes are on master. Treat current code and
+  the AMD RDNA 2 ISA guide as authoritative; do not revive old assumptions from pre-audit logs.
+
+The route documentation and committed app screenshots are in:
+
+- `scripts/astrobot/README.md`
+- `scripts/astrobot/reach-first-level.pad`
+- `scripts/astrobot/reach-first-level-windows.pad`
+- `docs/screenshots/issue-825-astrobot-linux-sony-presents.png`
+- `docs/screenshots/issue-825-astrobot-windows-sony-presents.png`
+- `docs/screenshots/issue-825-astrobot-windows-title.png`
+
+Those screenshots prove frontend/video/control-flow milestones. They do not prove that the current
+headless title render is correct.
+
+## Current proven rendering failure
+
+The strongest exact-head diagnostic for PR #1030 used:
+
+```sh
+PROSPER_GUEST_FS=1 \
+PROSPER_GUEST_ARGS=-force-gfx-direct \
+PROSPER_NO_COMPUTE=1 \
+PROSPER_AVP_SYNTH_FRAMES=120 \
+PROSPER_PAD_SCRIPT=@scripts/astrobot/reach-first-level.pad \
+PROSPER_PAD_SCRIPT_LOG=1 \
+PROSPER_DBG=1 \
+PROSPER_RENDER_SCALE=4 \
+  ./build-linux/screenshot /path/to/PPSA21564-app0 \
+    --output-dir /path/to/output --count 1 --seconds 1 --warmup-seconds 78
+```
+
+This was a **control-flow/shader diagnostic only**:
+
+- `PROSPER_NO_COMPUTE=1` deliberately disables guest compute.
+- `PROSPER_AVP_SYNTH_FRAMES=120` is synthetic video, not decoder acceptance.
+- `PROSPER_RENDER_SCALE=4` reduces resolution.
+
+It reached:
+
+```text
+LevelDocument Loaded: title_controller_ship [title]
+GAME: Level has started: title_controller_ship
+```
+
+and recorded:
+
+- present count: 3995
+- PC 137 rejects for title PS `0x5002af200`: 0
+- PC 221 rejects for that PS: 6
+- PC 221 word: `0xbe801f00` (`s_getpc_b64 s[0:1]`)
+- screenshot source: `raw_scanout`
+- `source_seq=3995`, `frame_seq=0`
+- `distinct_rgb_colors=1`, `nonblack_rgb_pixels=0`
+- CRC32 `08ed2210` (black 3840x2160 scanout)
+
+The earlier 60-image Linux run is also useful evidence. It began with raw scanout samples and later
+published composited frames. Its summary reported:
+
+- 60/60 requested images saved
+- 60 distinct source publications
+- 57 rendered/composited samples
+- maximum composited `frame_seq=621`
+- maximum present count 5551
+- all retained frames black (`nonblack_rgb_pixels=0`, one distinct RGB color)
+- pixel content remained identical for the final 56.14 seconds
+
+Therefore the black result is not explained by a dead flip loop or by sampling only before compositor
+publication. Real shader/draw failures remain.
+
+The diagnostic log is noisy: a long `PROSPER_DBG=1` run printed roughly 260,000 repeated
+`[exec-recompile-reject]` lines. Use a bounded run or filter/narrow diagnostics; do not repeat that
+volume unnecessarily.
+
+## PR #1030: the completed predecessor
+
+PR #1030 merged as `9c63435`. Its branch exact head was
+`b5f883ae11ce4f0ed92100f8f8f27909b156d537`.
+
+The title PS instruction at dword PC 137 is:
+
+```text
+s_buffer_load_dwordx2 s[0:1], s[24:27], vcc_lo offset:4
+```
+
+The V# was directly placed in entry SGPRs, while the dynamic offset was held in VCC_LO. The resource
+fold knew the V# value but previously published an `SrtUse` only when it also had an SRT key. The fix
+allows a fully known entry V# to be published as a keyless exact-consumer-PC resource. A production-path
+regression verifies resource creation, binding, and compute recompilation, and a negative control showed
+that reverting the production condition makes both new assertions fail.
+
+Verification recorded on the exact PR head:
+
+- Linux build: pass
+- Linux ctest: 121/121 pass
+- native Windows focused `agc_shader_create` and `dynfetch_fold`: 2/2 pass
+- hosted Linux, Linux App, Windows MinGW, Windows App, macOS, and macOS App: pass
+- Messenger snapshot: 29/29 qualifying and structural/nonblack, 8 pixel changes
+- Evergate: 9/9 qualifying and structural/nonblack, 8 pixel changes
+- Dead Cells: 44/44 qualifying and structural/nonblack, 43 pixel changes
+- Blasphemous II: 98/98 qualifying and structural/nonblack, 97 pixel changes
+
+The final merge combined #1030 with later master shader changes (#1041 and #1044). Those merges were
+textually clean, but the full four-title snapshot matrix was not rerun on merge commit `9c63435`.
+Run current-master/current-branch guards before publishing the next renderer change.
+
+## Exact PC-relative scalar-table evidence
+
+The failed raw shader is the pixel shader at guest address `0x5002af200`.
+
+The original failure dump is 5596 bytes / 1399 dwords and ends at:
+
+```text
+pc=1394 len=2 EXP
+pc=1396 len=2 EXP
+pc=1398 len=1 s_endpgm
+```
+
+There are six `s_getpc_b64 s[0:1]` sites at dword PCs:
+
+```text
+221, 349, 402, 530, 583, 710
+```
+
+Each computes the **same** absolute table base relative to the next instruction, exactly matching the
+AMD ISA's `D.u64 = PC + 4` contract:
+
+| getpc PC | next-PC byte | added byte literal | resolved byte offset |
+|---:|---:|---:|---:|
+| 221 | `222*4 = 0x378` | `0x1278` | `0x15f0` |
+| 349 | `350*4 = 0x578` | `0x1078` | `0x15f0` |
+| 402 | `403*4 = 0x64c` | `0x0fa4` | `0x15f0` |
+| 530 | `531*4 = 0x84c` | `0x0da4` | `0x15f0` |
+| 583 | `584*4 = 0x920` | `0x0cd0` | `0x15f0` |
+| 710 | `711*4 = 0xb1c` | `0x0ad4` | `0x15f0` |
+
+The first sequence is:
+
+```text
+pc=221  s_getpc_b64 s[0:1]
+pc=222  s_add_u32  s0, 0x1278, s0
+pc=224  s_addc_u32 s1, 0, s1
+pc=225  s_mov_b32  s2, 64
+pc=226  s_mov_b32  s3, 0x10005004
+...
+pc=233  s_buffer_load_dwordx4 s[4:7], s[0:3], s107
+...
+pc=241  s_buffer_load_dwordx4 s[8:11], s[0:3], s106
+```
+
+The scalar offsets are computed by preceding scalar bitfield/multiply operations and select rows from
+the 64-byte buffer. Other branches repeat the same descriptor construction and use the same pool.
+
+### Live guest-memory proof
+
+A one-off WSL diagnostic started the renderer, then read 8 KiB at guest address `0x5002af200` through
+the running process's `/proc/<pid>/mem`. This did not modify the emulator. The probe did not reach the
+title marker during its 110-second bound, so it is **memory-layout evidence only**, not a new progression
+run.
+
+Facts from the dump:
+
+- full dump SHA-256:
+  `CD5D7FA63E730F2860EE31F50ADA314FE32F43A941F093E9188155CF1B2F4AA6`
+- the first 5596 bytes are byte-for-byte equal to the existing failed shader dump
+- failed shader dump SHA-256:
+  `C51E9F8CD8D652728721EF6B868E548098ABF0E274B59BC26060ABBEE641ED6D`
+- `s_endpgm` finishes at byte `0x15dc`
+- bytes `0x15dc..0x15ef` are a 20-byte post-program/alignment region
+- the table starts at byte `0x15f0`
+- the table is exactly 16 dwords / 64 bytes
+
+Table words:
+
+```text
+00000000 00000000 3f800000 00000000
+3f800000 00000000 00000000 00000000
+3f800000 3f800000 00000000 00000000
+00000000 3f800000 00000000 00000000
+```
+
+Interpreted as floats:
+
+```text
+0 0 1 0
+1 0 0 0
+1 1 0 0
+0 1 0 0
+```
+
+The local-only artifacts on the originating Windows machine are:
+
+```text
+C:\Users\matti\Downloads\AstroBot-Linux-handoff-tail-probe.bin
+C:\Users\matti\Downloads\AstroBot-Linux-handoff-tail-probe.log
+C:\Users\matti\Downloads\AstroBot-shaders-current\exec_ps_5002af200.bin
+C:\Users\matti\Downloads\AstroBot-Linux-1030-title-diag.log
+C:\Users\matti\Downloads\AstroBot-Linux-1030-title-diag\
+C:\Users\matti\Downloads\AstroBot-linux-60-20260719-183308\
+```
+
+These contain title-derived data and remain gitignored/local-only. Do not commit them. Transfer the
+8 KiB probe privately to the Linux host if useful, or reproduce the bounded memory probe there.
+
+## AMD primary-source contracts
+
+Use the AMD RDNA 2 ISA guide linked from `CLAUDE.md` (document 70648), not a secondary emulator, for
+instruction semantics.
+
+Relevant contracts from the guide:
+
+- `S_GETPC_B64`: destination receives the byte address of the next instruction (`D.u64 = PC + 4`).
+- SMEM reads consecutive dwords into SGPRs without format conversion.
+- for scalar buffer reads, the descriptor contributes base, stride, and `num_records`.
+- the effective scalar address is descriptor base + instruction OFFSET + SOFFSET.
+- SOFFSET is an unsigned byte offset; the two low address bits are ignored for dword alignment.
+- for scalar buffer operations the instruction offset must be positive.
+- stride participates in bounds checking, not address multiplication.
+
+KytyPS5 is available as a secondary behavioral reference but was neither needed nor consulted for this
+failure. The live Astro bytes plus AMD semantics fully establish the current table shape. Do not copy
+code, tests, comments, or prose from another emulator.
+
+## Why the current recompiler rejects
+
+The existing implementation is deliberately fail-closed:
+
+- `detect_pcrel_tables` in `src/gpu/rdna2_to_spirv.cpp` recognizes a proven
+  `s_getpc_b64 -> add/addc -> V# -> MUBUF raw load` embedded-table idiom.
+- It records `MUBUF instruction PC -> copied table dwords` in
+  `RegState::mubuf_pcrel_tables`.
+- MUBUF emission folds the runtime index to a bounded SPIR-V select chain, returning zero out of bounds.
+- the fold runs before external-resource gating, because self-contained shader data needs no Vulkan
+  descriptor.
+- `rdna2_recompile_code_span` includes only the proven table tail, so cache ownership and identity retain
+  exactly the bytes that affect generated SPIR-V.
+- `s_getpc_b64` is accepted only when the prepass found such a table; otherwise it rejects rather than
+  allowing a PC value to leak into unmodeled address math.
+
+Astro's title PS uses the same address construction but consumes it with SMEM
+`s_buffer_load_dwordx4`, not MUBUF. The current prepass's SMEM case only kills overwritten scalar facts;
+it never records a PC-relative scalar table. `RegState::mubuf_pcrel_tables` stays empty, so the SOP1
+handler rejects at the first `s_getpc_b64` (PC 221).
+
+This explains both the exact failure and why generic support is unsafe: making `s_getpc_b64` a no-op
+would leave later address arithmetic operating on fabricated zeros and could emit plausible but wrong
+constants.
+
+## Recommended implementation shape
+
+This is a proposed design, not yet code. Preserve fail-visible behavior outside the fully proven idiom.
+
+1. Generalize PC-relative table analysis so it can return both:
+   - current MUBUF table loads (`instruction PC -> table dwords`)
+   - scalar-buffer SMEM table loads (`instruction PC -> table dwords`)
+
+   A small result struct is clearer than adding another output parameter to the existing unordered map.
+   Keep the code-blob required span alongside or continue reporting it through `required_dwords`.
+
+2. In the scalar-analysis walk, inspect SMEM **before** killing its destination facts. Recognize only
+   buffer-load opcodes `0x8..0xC`, initially only those exercised and tested. Require:
+   - SBASE low word has a live `s_getpc_b64`-derived byte offset
+   - the matching high word is proven by the paired `s_addc_u32 ... + 0`
+   - descriptor word 2 (`num_records`) is a known, nonzero, dword-aligned constant
+   - table base and length are dword aligned
+   - the table length is narrowly bounded (the existing 1024-byte ceiling is reasonable)
+   - no branch enters between the newest contributing fact and the load, using the existing entry
+     soundness rule
+   - the required tail is within the caller-provided readable code window before copying bytes
+
+   Descriptor word 3 need not affect address calculation per AMD, but recognizing the exact observed
+   `0x10005004` form can be an additional conservative gate if desired. Do not make the implementation
+   title-address-specific.
+
+3. Store each proven scalar load's table by its exact instruction PC. Multiple loads and all six Astro
+   setup sites may point to the same copied 16-dword payload.
+
+4. In SMEM emission, check the proven scalar-table map **before** `allow_smem` and external resource
+   binding. For a matched load:
+   - obtain the tracked SOFFSET scalar SSA value using the existing register-offset logic
+   - compute `(SOFFSET + instruction_offset) >> 2`
+   - for each returned dword, select the corresponding literal-pool word with the same bounded-select
+     pattern already used by MUBUF folding
+   - return zero for out-of-bounds indices, matching the bounded V# contract
+   - write the results to consecutive `rs.sreg` entries
+   - clear any stale `rs.sreg_srt` descriptor provenance on those data destinations
+
+5. Accept `s_getpc_b64` when **any** proven PC-relative table consumer exists, not only when the MUBUF
+   map is nonempty. Continue erasing the architectural PC pair instead of fabricating host/guest
+   addresses; the proven consumer is folded independently.
+
+6. Ensure `rdna2_recompile_code_span` includes byte `0x15f0 + 64 = 0x1630` for the live shape when its
+   caller supplies a sufficiently large readable window. This is critical:
+   - the owning cache copy must contain the literal pool
+   - table bytes must participate in the shader cache key
+   - failed/successful shader dumps should retain the proven tail
+   - changing a table word must invalidate/recompile rather than hit stale SPIR-V
+
+7. Do **not** broaden `registered_shader_dwords` or the dynamic descriptor fold to scan arbitrary bytes
+   after AGC `shader_size`. `tests/test_agc_shader.cpp` intentionally proves that descriptor discovery
+   cannot inspect a valid-looking fetch outside the registered header size. The graphics recompiler is
+   already called with a bounded readable maximum window and its span analysis can retain a narrowly
+   proven tail. Keep the generic AGC metadata safety contract intact.
+
+8. Keep arbitrary `s_getpc_b64`, PC-derived external pointers, unbounded tables, non-buffer SMEM forms,
+   unsupported address arithmetic, and untracked SOFFSET values rejected.
+
+## Required focused tests
+
+Add tests that prove behavior rather than mere decode acceptance:
+
+1. A compact synthetic program with:
+   - `s_getpc_b64`
+   - `s_add_u32` + `s_addc_u32`
+   - `num_records=64`
+   - a descriptor configuration word
+   - a tracked scalar byte offset
+   - `s_buffer_load_dwordx4`
+   - an observable scalar-to-vector/output use
+   - `s_endpgm`, alignment gap, and a 16-dword table tail
+
+   Execute the generated SPIR-V and assert selected table contents, not just nonempty output.
+
+2. Use at least two offsets (or two loads) so a broken implementation that always chooses table element
+   zero cannot pass.
+
+3. Assert `rdna2_recompile_code_span` includes the alignment gap and full table.
+
+4. Recompile through the graphics shader cache, mutate a table word, and assert a cache miss plus changed
+   SPIR-V/output. This proves the tail is in the owning key.
+
+5. Negative controls should reject:
+   - a bare `s_getpc_b64` with no proven table consumer
+   - omitted/truncated table tail
+   - an out-of-bound/unreasonably large `num_records`
+   - a broken high-half `s_addc` chain
+   - an unsupported/untracked scalar offset if it reaches emission
+
+6. Run a production negative control before publishing: temporarily disable only the new scalar-table
+   match and verify the new positive test and live shader fail at the expected frontier; restore it and
+   verify both pass.
+
+The existing MUBUF PC-relative tests around T12 in `test_rdna2_to_spirv.cpp` and the cache tests in
+`test_shader_recompile_cache.cpp` are the closest templates. Extend the project-owned mechanism; do not
+paste title shader bytes into the repository.
+
+## Native Linux execution plan
+
+### 1. Establish a clean native baseline
+
+```sh
+git fetch origin --prune
+git switch fix/issue-1054-astro-pcrel
+git rebase origin/master
+
+cd prosper
+cmake -S . -B build-linux -DCMAKE_BUILD_TYPE=RelWithDebInfo
+cmake --build build-linux -j"$(nproc)"
+ctest --test-dir build-linux --output-on-failure
+```
+
+Confirm Vulkan uses the intended hardware device, not llvmpipe, unless software rendering is an explicit
+A/B. Record GPU, driver, Vulkan implementation, and video decode path in the eventual PR evidence.
+
+### 2. Reproduce the exact shader frontier cheaply
+
+For rapid control-flow iteration, the documented synthetic/no-compute route is acceptable:
+
+```sh
+cd prosper
+PROSPER_GUEST_FS=1 \
+PROSPER_GUEST_ARGS=-force-gfx-direct \
+PROSPER_NO_COMPUTE=1 \
+PROSPER_AVP_SYNTH_FRAMES=120 \
+PROSPER_PAD_SCRIPT=@scripts/astrobot/reach-first-level.pad \
+PROSPER_PAD_SCRIPT_LOG=1 \
+PROSPER_DBG=1 \
+  timeout 180 ./build-linux/boot_trace /path/to/PPSA21564-app0 \
+  2>&1 | tee /tmp/astro-title-diag.log
+```
+
+Bound or filter debug logging. Prove the route reaches `title_controller_ship`, PC 221 disappears, and
+record the **next** exact `[recompile-reject]` PC/opcode. A successful fix to #1054 is not the final goal
+if another stage/op remains.
+
+### 3. Run the real Linux path
+
+Final correctness must remove the diagnostic shortcuts:
+
+- omit `PROSPER_NO_COMPUTE`
+- omit `PROSPER_AVP_SYNTH_FRAMES` on a host with working VA-API decode
+- keep `PROSPER_RENDER_SCALE=1`
+- keep `PROSPER_RENDER_EVERY=1`
+- do not use a timed sampling skip for acceptance
+
+Start with headless `screenshot`, then the Linux SDL app. The exact CLI options may evolve; consult
+`tools/screenshot/README.md` and `scripts/astrobot/README.md` on current master.
+
+### 4. Linux visual acceptance
+
+A genuine Linux headless success requires all of the following in one unmodified route:
+
+- expected guest checkpoint markers (title, main menu, or first level as targeted)
+- real renderer enabled and guest compute enabled
+- real Linux video decode where the captured phase depends on video
+- no forced guest-state patch or synthetic visual substitute
+- saved PNG from the normal screenshot frontend
+- manifest reports advancing source/presents
+- `nonblack_rgb_pixels > 0`
+- more than one distinct RGB color
+- visible title/scene content rather than a diagnostic clear/test pattern
+- no exercised shader/GPU operation left silently skipped
+
+Store representative images in the user's normal Downloads folder during iteration. When the draft PR
+becomes a real game-progress PR, attach representative direct screenshots and caption title, platform,
+frontend, route, and checkpoint as required by `CLAUDE.md`.
+
+### 5. Regression checks after renderer changes
+
+At minimum:
+
+```sh
+ctest --test-dir build-linux --output-on-failure
+python3 tools/snapshot/snapshot.py check
+```
+
+Run all configured known-title guards (Messenger, Evergate, Dead Cells, Blasphemous II), inspect their
+retained images, and record exact counts. Use `tools/verify-pr.ps1 renderer` only from a clean pushed
+head if the native Linux host can run PowerShell; otherwise perform and document equivalent commands.
+
+### 6. Cross-platform sequence after Linux is genuinely nonblack
+
+Only after the normal Linux headless result is real:
+
+1. Linux SDL app at the same checkpoint.
+2. Windows headless with the normal Windows route.
+3. Windows app with Media Foundation/DXVA, synthetic fallback unset.
+4. Compare manifests and screenshots, then isolate frontend-only differences from shared renderer
+   failures.
+
+Windows acceptance should log `decoder=hardware DXVA MFT` for the real video path. The existing Windows
+title screenshot is historical evidence, not proof that the current merged renderer matches Linux.
+
+## Diagnostic caveats and rejected shortcuts
+
+- A synthetic AVPlayer frame is useful for reaching later guest code but is not video-decode evidence.
+- `PROSPER_NO_COMPUTE=1` is useful for shader/control-flow diagnostics but cannot be used for graphics
+  acceptance; Astro has real compute producers in its composition chain.
+- `PROSPER_RENDER_SCALE>1` and `PROSPER_RENDER_EVERY>1` intentionally reduce work and are not final visual
+  correctness settings.
+- A rising present count does not prove pixels changed. Use manifest pixel metrics.
+- `source=raw_scanout` with `frame_seq=0` can still show that flips advance while no composited renderer
+  frame exists. It is not nonblack graphics evidence.
+- A black capture is diagnostic evidence only and must not be attached or described as progress.
+- Do not make unknown GPU operations return success/no-op. The charter treats every exercised unsupported
+  shader/GPU operation as the next fatal gap to implement.
+- Do not hard-code shader address `0x5002af200`, table offset `0x15f0`, or Astro-specific data in
+  production. Recognize the general compiler idiom with bounded evidence.
+- Do not read arbitrary post-header guest memory in dynamic descriptor folding. Retain only the exact
+  literal-pool span proven by the PC-relative analysis in the already bounded recompiler window.
+
+## Likely later shader frontiers
+
+Earlier logs have contained MIMG opcode `0x27` variants and VOP3/V_MBCNT-related failures after other
+shader fixes. The current title PS itself contains MIMG opcode `0x27` near PC 1367. Recent master changes
+have already implemented many operations, so do not assume an old log's order remains current. After
+each fix, rerun a bounded live diagnostic and take the next exact first failure from current master.
+
+The #1054 scalar table is the only currently proven immediate blocker. Avoid speculative implementation
+of later operations until the live frontier advances.
+
+## Handoff checklist
+
+- [ ] Fetch/rebase against current remote master and inspect newly merged GPU work.
+- [ ] Confirm #1054 and this branch still own the work; do not duplicate.
+- [ ] Build and run full tests natively on Linux.
+- [ ] Reproduce PC 221 on the diagnostic route.
+- [ ] Implement narrowly proven PC-relative SMEM scalar-table folding.
+- [ ] Add execution, span/cache, and fail-closed negative tests.
+- [ ] Demonstrate negative control.
+- [ ] Confirm PC 221 is gone and record the next live frontier.
+- [ ] Continue implementing every exercised GPU gap until real Linux pixels appear.
+- [ ] Run all known-title snapshot guards after each render-affecting change.
+- [ ] Capture genuine nonblack Linux headless PNGs and manifest evidence with normal settings.
+- [ ] Validate the Linux app.
+- [ ] Cross-check Windows headless and Windows app; fix frontend discrepancies.
+- [ ] Add direct screenshots to the progress PR when there is visible progress.
+- [ ] Keep the draft PR owned through verification and merge; do not leave a straggler.
+
+## Definition of done for the broader goal
+
+Do not close the broader visual task merely because #1054 recompiles. Completion requires current,
+direct evidence of:
+
+1. genuine nonblack Astro Bot graphics in Linux headless from the normal renderer;
+2. raw screenshot/manifest evidence stored and inspected;
+3. equivalent Linux app output;
+4. Windows headless/app cross-checks;
+5. any frontend discrepancy identified and fixed or explicitly tracked with exact evidence;
+6. applicable tests, all-title renderer guards, hosted CI, screenshots, and the final PR merged.
+
+Until those conditions hold, keep advancing the live failure frontier.

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -1904,10 +1904,11 @@ struct RegState {
     uint32_t scc = 0;          // scalar condition code (bool); set by s_cmp_*/SCC-writing SOP2, read by s_cselect
     uint32_t exec = 0;         // per-lane execution mask (bool); v_cmpx narrows it, output store honors it
     bool exec_narrowed = false; // true once EXEC is narrowed below all-lanes-on (so VGPR writes predicate)
-    // PC-relative EMBEDDED TABLES (#273): mubuf pc -> the table's dwords, resolved by
+    // PC-relative EMBEDDED TABLES (#273): load pc -> the table's dwords, resolved by
     // detect_pcrel_tables (an s_getpc_b64-derived V# whose num_records is a known constant). The
     // shader BLOB carries the table; the recompiler folds it into a compile-time constant lookup.
     std::unordered_map<uint32_t, std::vector<uint32_t>> mubuf_pcrel_tables;
+    std::unordered_map<uint32_t, std::vector<uint32_t>> smem_pcrel_tables;
     // SCALAR-SPILL VGPR (#273 — DOLL's big post PS): the compiler packs excess wave-uniform scalars
     // into one VGPR's lanes via `v_writelane_b32 vN, sX, <const lane>` and reads them back with
     // `v_readlane_b32 sY, vN, <const lane>`. Per-invocation each (vgpr, lane) slot is just a named
@@ -3415,9 +3416,11 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             }
             if (in.opcode == 0x1f) {   // s_getpc_b64
                 // Accepted ONLY when the pcrel pre-pass FOLDED an embedded-table load from this
-                // shader (rs.mubuf_pcrel_tables non-empty) — the pair then only feeds that folded
-                // chain. Otherwise the PC would flow into unmodeled address math: keep rejecting.
-                if (rs.mubuf_pcrel_tables.empty()) { ok = false; return true; }
+                // shader — the pair then only feeds that folded chain. Otherwise the PC would flow
+                // into unmodeled address math: keep rejecting.
+                if (rs.mubuf_pcrel_tables.empty() && rs.smem_pcrel_tables.empty()) {
+                    ok = false; return true;
+                }
                 for (int k = 0; k < 2; k++) {
                     rs.sreg.erase(in.dst.value + k); rs.sreg_srt.erase(in.dst.value + k);
                 }
@@ -4807,7 +4810,6 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // immediate byte offset (>>2 -> dword index); SBASE/descriptor base is folded into the
             // binding. N consecutive dwords -> SDATA..SDATA+N-1. Only the compute path binds the cbuf,
             // so reject in graphics stages (allow_smem=false). Register-offset SMEM not yet handled.
-            if (!allow_smem) { ok = false; return true; }
             uint32_t n = 0;
             switch (in.opcode) {
                 case 0x0: case 0x8: n = 1;  break;   // s_load_dword     / s_buffer_load_dword
@@ -4817,6 +4819,42 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 case 0x4: case 0xC: n = 16; break;   // s_load_dwordx16  / s_buffer_load_dwordx16
                 default: ok = false; return true;    // stores / others not yet
             }
+            // PC-relative scalar embedded table (#1054): this s_buffer_load consumes a descriptor
+            // built from s_getpc_b64 and a bounded table carried by the shader blob. Resolve it before
+            // the external-resource gate, exactly like the established MUBUF form. The byte offset is
+            // still the real tracked scalar value; an untracked SOFFSET remains fail-visible.
+            auto pcrel = rs.smem_pcrel_tables.find(in.pc);
+            if (pcrel != rs.smem_pcrel_tables.end()) {
+                uint32_t soff = 0;
+                const bool soff_null = in.src[1].kind == OperandKind::Special &&
+                                       in.src[1].value == 125;
+                if (soff_null) {
+                    soff = b.uconst(0);
+                } else if (in.src[1].kind == OperandKind::SGPR ||
+                           (in.src[1].kind == OperandKind::Special &&
+                            in.src[1].value >= 106 && in.src[1].value <= 123)) {
+                    auto tracked = rs.sreg.find(in.src[1].value);
+                    if (tracked == rs.sreg.end()) { ok = false; return true; }
+                    soff = tracked->second;
+                } else if (in.src[1].kind == OperandKind::InlineInt && in.src[1].value >= 0) {
+                    soff = b.uconst(static_cast<uint32_t>(in.src[1].value));
+                } else {
+                    ok = false; return true;
+                }
+                uint32_t idx = b.ibin(Op_ShiftRightLogical,
+                    b.ibin(Op_IAdd, soff, b.uconst(in.literal)), b.uconst(2));
+                for (uint32_t k = 0; k < n; ++k) {
+                    uint32_t kidx = k ? b.ibin(Op_IAdd, idx, b.uconst(k)) : idx;
+                    uint32_t value = b.uconst(0); // bounded V# OOB contract
+                    for (uint32_t t = 0; t < pcrel->second.size(); ++t)
+                        value = b.sel(b.ucmp(Op_IEqual, kidx, b.uconst(t)),
+                                      b.uconst(pcrel->second[t]), value);
+                    rs.sreg[in.dst.value + static_cast<int>(k)] = value;
+                    rs.sreg_srt.erase(in.dst.value + static_cast<int>(k));
+                }
+                return true;
+            }
+            if (!allow_smem) { ok = false; return true; }
             // SOFFSET handling. Immediate-only loads encode SOFFSET = SGPR_NULL (125). A register
             // SOFFSET adds an SGPR-computed byte offset:
             //  * a DESCRIPTOR s_load (x4/x8 = V#/T#) with a computed offset is the bindless fetch's
@@ -5942,10 +5980,15 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
 // the load) and returns: mubuf pc -> the table's dwords copied out of the blob.
 // CONFIDENCE: MED-HIGH — exact for the compiler idiom (verified against DOLL's dither PS); every
 // guard failure falls back to the old reject.
-std::unordered_map<uint32_t, std::vector<uint32_t>> detect_pcrel_tables(
+struct PcrelTables {
+    std::unordered_map<uint32_t, std::vector<uint32_t>> mubuf;
+    std::unordered_map<uint32_t, std::vector<uint32_t>> smem;
+};
+
+PcrelTables detect_pcrel_tables(
         const std::vector<Rdna2Inst>& ins, const uint32_t* code, size_t dwords,
         size_t* required_dwords = nullptr) {
-    std::unordered_map<uint32_t, std::vector<uint32_t>> out;
+    PcrelTables out;
     std::unordered_map<int, uint64_t> pcoff;   // reg -> byte offset into the code blob (pair LO half)
     std::unordered_set<int> pchi;              // regs holding the matching HI half
     std::unordered_map<int, uint32_t> kconst;  // reg -> compile-time constant (s_mov_b32 literal/inline)
@@ -6022,6 +6065,37 @@ std::unordered_map<uint32_t, std::vector<uint32_t>> detect_pcrel_tables(
                 uint32_t n = 1;
                 switch (in.opcode) { case 0x1: case 0x9: n=2; break; case 0x2: case 0xA: n=4; break;
                     case 0x3: case 0xB: n=8; break; case 0x4: case 0xC: n=16; break; default: break; }
+                // Scalar-buffer form of the same compiler idiom: SBASE is the getpc-built V#, while
+                // SOFFSET selects a row from the embedded table. Inspect it before killing SDATA facts.
+                const int sb = in.src[0].value;
+                if (in.opcode >= 0x8 && in.opcode <= 0xC && pcoff.count(sb) &&
+                    pchi.count(sb + 1) && kconst.count(sb + 2) && kconst.count(sb + 3)) {
+                    const uint32_t nrec = kconst[sb + 2];
+                    const uint64_t off = pcoff[sb];
+                    uint32_t newest = 0;
+                    for (int r : {sb, sb + 1, sb + 2, sb + 3}) {
+                        auto fact = fact_pc.find(r);
+                        if (fact != fact_pc.end() && fact->second > newest) newest = fact->second;
+                    }
+                    bool entered = false;
+                    for (uint32_t target : br_targets)
+                        if (target > newest && target <= in.pc) { entered = true; break; }
+                    const bool supported_soffset =
+                        (in.src[1].kind == OperandKind::Special && in.src[1].value == 125) ||
+                        in.src[1].kind == OperandKind::SGPR ||
+                        (in.src[1].kind == OperandKind::Special && in.src[1].value >= 106 &&
+                         in.src[1].value <= 123) ||
+                        (in.src[1].kind == OperandKind::InlineInt && in.src[1].value >= 0);
+                    if (!entered && supported_soffset && static_cast<int32_t>(in.literal) >= 0 &&
+                        !(off & 3u) && !(nrec & 3u) && nrec && nrec <= 1024 &&
+                        off / 4 + nrec / 4 <= dwords) {
+                        if (required_dwords)
+                            *required_dwords = std::max(*required_dwords,
+                                static_cast<size_t>(off / 4 + nrec / 4));
+                        out.smem[in.pc] = std::vector<uint32_t>(
+                            code + off / 4, code + off / 4 + nrec / 4);
+                    }
+                }
                 for (uint32_t k = 0; k < n; k++) kill(in.dst.value + (int)k);
                 break;
             }
@@ -6055,7 +6129,7 @@ std::unordered_map<uint32_t, std::vector<uint32_t>> detect_pcrel_tables(
                 if (required_dwords)
                     *required_dwords = std::max(*required_dwords,
                                                 static_cast<size_t>(off / 4 + nrec / 4));
-                out[in.pc] = std::vector<uint32_t>(code + off / 4, code + off / 4 + nrec / 4);
+                out.mubuf[in.pc] = std::vector<uint32_t>(code + off / 4, code + off / 4 + nrec / 4);
                 (void)offen;                                       // offen just adds the runtime index
                 break;
             }
@@ -6683,6 +6757,7 @@ bool emit_compute_cfg_state_machine(
         state.exec = b.load_function(b.t_bool, exec_var);
         state.exec_narrowed = true; // state-machine joins may carry a narrowed EXEC edge
         state.mubuf_pcrel_tables = initial.mubuf_pcrel_tables;
+        state.smem_pcrel_tables = initial.smem_pcrel_tables;
         return state;
     };
     auto save_state = [&](const RegState& state) {
@@ -7177,8 +7252,12 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                const std::function<bool(const Rdna2Inst&)>& exp_fn,
                const uint32_t* code = nullptr, size_t dwords = 0) {   // raw stream (forward-if target check)
     // Fold PC-relative embedded-table loads (s_getpc_b64-built V#s) before the walk — emit_alu's
-    // MUBUF/SOP1 handlers consult rs.mubuf_pcrel_tables (#273).
-    if (code) rs.mubuf_pcrel_tables = detect_pcrel_tables(ins, code, dwords);
+    // SMEM/MUBUF/SOP1 handlers consult the proven table maps (#273/#1054).
+    if (code) {
+        PcrelTables tables = detect_pcrel_tables(ins, code, dwords);
+        rs.mubuf_pcrel_tables = std::move(tables.mubuf);
+        rs.smem_pcrel_tables = std::move(tables.smem);
+    }
     std::unordered_set<uint32_t> effective_safe = safe;
     const std::unordered_set<uint32_t> dead_masks = dead_wave_mask_writes(ins);
     const CountedLoop L = detect_counted_loop(ins);

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -13,6 +13,7 @@
 #include "../src/gpu/agc_shader_layout.hpp"
 #include "../src/gpu/shader_resources.hpp"
 #include "compute_runner.h"
+#include <algorithm>
 #include <bit>
 #include <cstdio>
 #include <cmath>
@@ -3026,6 +3027,46 @@ int main() {
         codeT12vertex, sizeof(codeT12vertex)/4, nullptr);
     CHECK(!spvT12vertex.empty(),
           "T12 vertex: resource-free stage accepts a proven embedded-table MUBUF");
+
+    // Astro Bot's title pixel shader builds the same bounded descriptor but consumes it with SMEM.
+    // The scalar byte offset selects table[1], and x4 returns table[1..4]; summing the first two
+    // loaded SGPRs proves that the fold honors both the dynamic offset and consecutive destinations.
+    const uint32_t codeT12smem[] = {
+        0xbe801f00u,               // s_getpc_b64 s[0:1] (next-PC byte = 4)
+        0x800000ffu, 48u,          // s_add_u32 s0, 48, s0 (table byte = 52)
+        0x82010180u,               // s_addc_u32 s1, 0, s1
+        0xbe820394u,               // s_mov_b32 s2, 20 bytes
+        0xbe8303ffu, 0x10005004u,  // s_mov_b32 s3, V# config
+        0xbeea0384u,               // s_mov_b32 vcc_lo, 4 (select table[1])
+        0xf4280100u, 0xd4000000u,  // s_buffer_load_dwordx4 s[4:7], s[0:3], vcc_lo
+        0x80040504u,               // s_add_u32 s4, s4, s5 => 11 + 13
+        0x7e000c04u,               // v_cvt_f32_u32 v0, s4
+        0xbf810000u,               // s_endpgm
+        7u, 11u, 13u, 17u, 19u,
+    };
+    std::vector<uint32_t> spvT12smem = recompile_valu(
+        codeT12smem, std::size(codeT12smem), 1, 0);
+    CHECK(!spvT12smem.empty(), "T12 SMEM: PC-relative scalar table recompiles without a resource");
+    std::vector<float> gotT12smem = spvT12smem.empty() ? std::vector<float>{} :
+        prosper::test::run_compute(spvT12smem, inT12, N, N);
+    CHECK(gotT12smem.size() == N &&
+              std::all_of(gotT12smem.begin(), gotT12smem.end(), [](float value) { return value == 24.0f; }),
+          "T12 SMEM: dynamic byte offset and consecutive scalar table results are preserved");
+    CHECK(rdna2_recompile_code_span(codeT12smem, std::size(codeT12smem)) ==
+              std::size(codeT12smem),
+          "T12 SMEM: the full embedded scalar table participates in the owning code span");
+    std::vector<uint32_t> truncatedT12smem(
+        std::begin(codeT12smem), std::end(codeT12smem) - 1);
+    CHECK(recompile_valu(truncatedT12smem.data(), truncatedT12smem.size(), 1, 0).empty(),
+          "T12 SMEM: a truncated embedded table remains rejected");
+    std::vector<uint32_t> brokenHighT12smem(std::begin(codeT12smem), std::end(codeT12smem));
+    brokenHighT12smem[3] = 0x82010181u; // s_addc_u32 s1, 1, s1: not the proven high-half chain
+    CHECK(recompile_valu(brokenHighT12smem.data(), brokenHighT12smem.size(), 1, 0).empty(),
+          "T12 SMEM: a broken PC-relative high-half chain remains rejected");
+    std::vector<uint32_t> untrackedOffsetT12smem(std::begin(codeT12smem), std::end(codeT12smem));
+    untrackedOffsetT12smem[8] = 0x10000000u; // SOFFSET=s8, which has no tracked scalar value
+    CHECK(recompile_valu(untrackedOffsetT12smem.data(), untrackedOffsetT12smem.size(), 1, 0).empty(),
+          "T12 SMEM: an untracked scalar table offset remains rejected");
 
     // Kernel T13: UINT8x1 vertex fetch (#273 — DOLL's skinned scene VS bone-index attribute class).
     // buffer_load_format_x of a Uint8 element delivers the RAW integer (no normalization) in the VGPR.

--- a/prosper/tests/test_shader_recompile_cache.cpp
+++ b/prosper/tests/test_shader_recompile_cache.cpp
@@ -176,6 +176,39 @@ int main() {
               stats.misses == pcrel_stats.misses + 1,
           "embedded table contents participate in the shader cache key");
 
+    // Astro Bot's title PS uses SMEM rather than MUBUF to consume its getpc-built scalar table.
+    // The post-ENDPGM payload must be owned and hashed by the graphics cache in this form as well.
+    std::vector<uint32_t> pcrel_smem_ps = {
+        0xbe801f00u,               // s_getpc_b64 s[0:1]
+        0x800000ffu, 52u,          // table = next-PC byte 4 + 52 = byte 56
+        0x82010180u,               // s_addc_u32 s1, 0, s1
+        0xbe820394u,               // s_mov_b32 s2, 20 bytes
+        0xbe8303ffu, 0x10005004u,  // s_mov_b32 s3, V# config
+        0xbeea0384u,               // s_mov_b32 vcc_lo, 4
+        0xf4280100u, 0xd4000000u,  // s_buffer_load_dwordx4 s[4:7], s[0:3], vcc_lo
+        0x7e000204u,               // v_mov_b32 v0, s4
+        0xf800180fu, 0x00000000u,  // exp mrt0 v0,v0,v0,v0
+        0xbf810000u,               // s_endpgm
+        7u, 11u, 13u, 17u, 19u,
+    };
+    CHECK(rdna2_recompile_code_span(pcrel_smem_ps.data(), pcrel_smem_ps.size()) ==
+              pcrel_smem_ps.size(),
+          "PC-relative SMEM cache span includes the embedded scalar table tail");
+    const auto direct_pcrel_smem_ps = recompile_fragment(
+        pcrel_smem_ps.data(), pcrel_smem_ps.size(), nullptr);
+    const auto cached_pcrel_smem_ps = recompile_graphics_shader_cached(
+        ShaderProgramStage::Fragment, pcrel_smem_ps.data(), pcrel_smem_ps.size(), nullptr);
+    CHECK(!direct_pcrel_smem_ps.empty() && cached_pcrel_smem_ps == direct_pcrel_smem_ps,
+          "fragment cache retains a proven post-ENDPGM PC-relative SMEM table");
+    const auto pcrel_smem_stats = shader_recompile_cache_stats();
+    pcrel_smem_ps[pcrel_smem_ps.size() - 4] = 23u; // selected table[1]
+    const auto changed_pcrel_smem_ps = recompile_graphics_shader_cached(
+        ShaderProgramStage::Fragment, pcrel_smem_ps.data(), pcrel_smem_ps.size(), nullptr);
+    stats = shader_recompile_cache_stats();
+    CHECK(!changed_pcrel_smem_ps.empty() && changed_pcrel_smem_ps != cached_pcrel_smem_ps &&
+              stats.misses == pcrel_smem_stats.misses + 1,
+          "PC-relative SMEM table contents participate in the shader cache key");
+
     // A terminal if/else may build a PC-relative V# only in the second arm, after the first
     // s_endpgm. Span analysis must use the same extended instruction stream as emission. Stopping at
     // span pc20 immediately after the second end would omit four table dwords that can change SPIR-V.


### PR DESCRIPTION
## Goal

Advance #1054 by implementing the precisely identified Astro Bot title-shader blocker: compiler-generated PC-relative scalar tables consumed through `s_buffer_load_dword*` SMEM instructions.

This PR also retains the native-Linux investigation handoff on the branch. It does not claim nonblack Astro graphics yet; the Astro dump is not present on this host, so the next live shader frontier remains to be measured separately.

## Failure and contract

Astro's title pixel shader constructs a bounded four-word buffer descriptor from `s_getpc_b64`, with a 64-byte literal table just after `s_endpgm`, then performs scalar buffer loads using a tracked SGPR byte offset. Prosper already proved and folded the analogous MUBUF idiom, but SMEM killed its destination facts without recognizing the PC-relative descriptor. The first `s_getpc_b64` therefore rejected at PC 221.

Arbitrary PC values must remain unsupported. A scalar table is accepted only when the existing forward proof establishes:

- the low address comes from `s_getpc_b64` plus a constant;
- the paired high word comes from `s_addc_u32 ... + 0`;
- descriptor length and configuration words are known constants;
- no branch enters after the newest contributing fact;
- the table is aligned, nonempty, at most 1024 bytes, and completely inside the readable shader window;
- the SMEM opcode and SOFFSET form are supported.

Emission uses the real tracked SOFFSET plus the instruction byte offset, returns zero out of bounds, writes every consecutive SGPR result, and drops stale descriptor provenance. Unproven offsets and unrelated `s_getpc_b64` uses still reject.

## Cache ownership

The narrowly proven post-`s_endpgm` table span participates in the immutable shader copy and cache key. Mutating a selected scalar-table word produces a cache miss and changed SPIR-V.

## Deliberately unaffected

- external SMEM resource binding
- existing PC-relative MUBUF folding
- generic or pointer-producing `s_getpc_b64`
- unsupported scalar stores, negative offsets, oversized/truncated tables, and untracked SOFFSET values
- AGC registered shader-size scanning

## Risk

This is reverse-engineered shader-address behavior. The implementation stays fail-closed outside the exact compiler idiom and is covered by execution, bounds, negative-control, and cache-identity tests. The remaining limitation is lack of a local Astro dump for a live PC-221/next-frontier run on this host.

## Author verification (`6d3defe`)

- `cmake -S prosper -B prosper/build-linux -DCMAKE_BUILD_TYPE=RelWithDebInfo -DGAME_DUMP=/home/mattias800/repos/ps5ys/PPSA24651-app0`
- `cmake --build prosper/build-linux -j8`: pass
- `ctest --test-dir prosper/build-linux --output-on-failure -j8`: 120/120 pass
- `test_rdna2_to_spirv`: pass, including dynamic offset, consecutive result, truncated tail, broken high half, untracked offset, and code-span checks
- `test_shader_recompile_cache`: pass, including SMEM tail ownership and table-mutation cache miss
- production negative control: disabling only the new SMEM proof match makes both new positive test groups fail; restored before commit
- `PROSPER_GAME_ROOT=/home/mattias800/repos/ps5ys python3 tools/snapshot/snapshot.py check`:
  - Messenger: 29/29 qualifying, structural, and nonblack; 8 pixel changes
  - Evergate: 9/9 qualifying, structural, and nonblack; 8 pixel changes
  - Dead Cells: 44/44 qualifying, structural, and nonblack; 43 pixel changes
  - Blasphemous II: 98/98 qualifying, structural, and nonblack; 97 pixel changes
- `git diff --check`: pass

Independent Fable/xhigh review is required before merge. No screenshot is attached because this is a shader-correctness frontier advance, not yet visible Astro progression.
