### PR TITLE
Prefer hardware Vulkan devices for snapshots

### DIFF
--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -1,4 +1,5 @@
 #include "live_compute.hpp"
+#include "vulkan_device_select.hpp"
 
 #include "gpu/bc_decode.hpp"
 #include "gpu/gpu_capture.hpp"
@@ -222,19 +223,13 @@ struct VulkanComputeContext {
         if (!device_count) return false;
         std::vector<VkPhysicalDevice> devices(device_count);
         vkEnumeratePhysicalDevices(instance, &device_count, devices.data());
-        physical = devices[0];
-
-        uint32_t family_count = 0;
-        vkGetPhysicalDeviceQueueFamilyProperties(physical, &family_count, nullptr);
-        std::vector<VkQueueFamilyProperties> families(family_count);
-        vkGetPhysicalDeviceQueueFamilyProperties(physical, &family_count, families.data());
-        for (uint32_t i = 0; i < family_count; i++) {
-            if (families[i].queueFlags & VK_QUEUE_COMPUTE_BIT) {
-                queue_family = i;
-                break;
-            }
-        }
-        if (queue_family == UINT32_MAX) return false;
+        const auto selection = select_vulkan_device(devices, VK_QUEUE_COMPUTE_BIT);
+        physical = selection.device;
+        queue_family = selection.queue_family;
+        if (!physical || queue_family == UINT32_MAX) return false;
+        std::fprintf(stderr, "[compute] Vulkan device: %s (%s)\n",
+                     selection.properties.deviceName,
+                     vulkan_device_type_name(selection.properties.deviceType));
 
         float priority = 1.0f;
         VkDeviceQueueCreateInfo qci{VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO};

--- a/prosper/frontends/shared/vulkan_device_select.hpp
+++ b/prosper/frontends/shared/vulkan_device_select.hpp
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <vulkan/vulkan.h>
+
+#include <cstdint>
+#include <vector>
+
+namespace prosper::frontend {
+
+struct VulkanDeviceSelection {
+    VkPhysicalDevice device = VK_NULL_HANDLE;
+    uint32_t queue_family = UINT32_MAX;
+    VkPhysicalDeviceProperties properties{};
+};
+
+constexpr int vulkan_device_type_rank(VkPhysicalDeviceType type) {
+    switch (type) {
+    case VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU: return 5;
+    case VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU: return 4;
+    case VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU: return 3;
+    case VK_PHYSICAL_DEVICE_TYPE_OTHER: return 2;
+    case VK_PHYSICAL_DEVICE_TYPE_CPU: return 1;
+    default: return 0;
+    }
+}
+
+static_assert(vulkan_device_type_rank(VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU) >
+              vulkan_device_type_rank(VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU));
+static_assert(vulkan_device_type_rank(VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU) >
+              vulkan_device_type_rank(VK_PHYSICAL_DEVICE_TYPE_CPU));
+
+// Vulkan does not promise that physical devices are enumerated in performance order. Prefer a
+// hardware GPU when one supports the queue and robustness contract, while retaining llvmpipe and
+// other CPU implementations as a headless fallback.
+inline VulkanDeviceSelection select_vulkan_device(
+    const std::vector<VkPhysicalDevice>& devices, VkQueueFlags required_queue_flags) {
+    VulkanDeviceSelection best;
+    int best_rank = -1;
+    for (VkPhysicalDevice device : devices) {
+        VkPhysicalDeviceFeatures features{};
+        vkGetPhysicalDeviceFeatures(device, &features);
+        if (!features.robustBufferAccess) continue;
+
+        uint32_t family_count = 0;
+        vkGetPhysicalDeviceQueueFamilyProperties(device, &family_count, nullptr);
+        std::vector<VkQueueFamilyProperties> families(family_count);
+        vkGetPhysicalDeviceQueueFamilyProperties(device, &family_count, families.data());
+        uint32_t queue_family = UINT32_MAX;
+        for (uint32_t i = 0; i < family_count; ++i) {
+            if ((families[i].queueFlags & required_queue_flags) == required_queue_flags) {
+                queue_family = i;
+                break;
+            }
+        }
+        if (queue_family == UINT32_MAX) continue;
+
+        VkPhysicalDeviceProperties properties{};
+        vkGetPhysicalDeviceProperties(device, &properties);
+        const int rank = vulkan_device_type_rank(properties.deviceType);
+        if (rank > best_rank) {
+            best = {device, queue_family, properties};
+            best_rank = rank;
+        }
+    }
+    return best;
+}
+
+inline const char* vulkan_device_type_name(VkPhysicalDeviceType type) {
+    switch (type) {
+    case VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU: return "discrete GPU";
+    case VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU: return "integrated GPU";
+    case VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU: return "virtual GPU";
+    case VK_PHYSICAL_DEVICE_TYPE_CPU: return "CPU";
+    default: return "other";
+    }
+}
+
+} // namespace prosper::frontend

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -6,6 +6,7 @@
 #include <vulkan/vulkan.h>
 #include "../src/gpu/gpu_capture.hpp"
 #include "../src/gpu/render_state.hpp"
+#include "../frontends/shared/vulkan_device_select.hpp"
 #include <algorithm>
 #include <array>
 #include <chrono>
@@ -401,11 +402,13 @@ inline const RenderVkCtx& render_vk_ctx() {
         uint32_t nd = 0; vkEnumeratePhysicalDevices(r.inst, &nd, nullptr);
         if (!nd) return r;
         std::vector<VkPhysicalDevice> devs(nd); vkEnumeratePhysicalDevices(r.inst, &nd, devs.data());
-        r.phys = devs[0];
-        uint32_t nqf = 0; vkGetPhysicalDeviceQueueFamilyProperties(r.phys, &nqf, nullptr);
-        std::vector<VkQueueFamilyProperties> qf(nqf); vkGetPhysicalDeviceQueueFamilyProperties(r.phys, &nqf, qf.data());
-        for (uint32_t i = 0; i < nqf; i++) if (qf[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) { r.qfi = i; break; }
-        if (r.qfi == UINT32_MAX) return r;
+        const auto selection = prosper::frontend::select_vulkan_device(devs, VK_QUEUE_GRAPHICS_BIT);
+        r.phys = selection.device;
+        r.qfi = selection.queue_family;
+        if (!r.phys || r.qfi == UINT32_MAX) return r;
+        std::fprintf(stderr, "[render] Vulkan device: %s (%s)\n",
+                     selection.properties.deviceName,
+                     prosper::frontend::vulkan_device_type_name(selection.properties.deviceType));
         float prio = 1.0f;
         VkDeviceQueueCreateInfo qci{VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO};
         qci.queueFamilyIndex = r.qfi; qci.queueCount = 1; qci.pQueuePriorities = &prio;

--- a/prosper/tests/test_gpu_capture_render.cpp
+++ b/prosper/tests/test_gpu_capture_render.cpp
@@ -598,8 +598,11 @@ int main() {
     ds_seed.depth_valid = true; ds_seed.stencil_valid = true;
     ds_seed.depth.resize(4u * 3u * 4u);
     ds_seed.stencil.resize(4u * 3u);
-    for (size_t i = 0; i < ds_seed.depth.size(); ++i)
-        ds_seed.depth[i] = static_cast<uint8_t>(i * 17u + 3u);
+    for (size_t i = 0; i < ds_seed.depth.size() / sizeof(float); ++i) {
+        const float value = static_cast<float>(i + 1) /
+                            static_cast<float>(ds_seed.depth.size() / sizeof(float) + 1);
+        std::memcpy(ds_seed.depth.data() + i * sizeof(float), &value, sizeof(value));
+    }
     for (size_t i = 0; i < ds_seed.stencil.size(); ++i)
         ds_seed.stencil[i] = static_cast<uint8_t>(i * 11u + 1u);
     CHECK(restore_gpu_replay_ds_seeds({ds_seed}, error),

--- a/prosper/tools/screenshot/README.md
+++ b/prosper/tools/screenshot/README.md
@@ -88,6 +88,11 @@ diagnostic target/resource overrides can preserve producers without saving early
 warmup gates are additive when both are supplied. `--timeout` covers
 the entire run, including warmup.
 
+The renderer prefers discrete, integrated, and virtual GPUs (in that order) over CPU Vulkan devices.
+llvmpipe remains the automatic fallback when no usable hardware Vulkan device is available. The selected
+graphics and compute devices are printed in the run log, so snapshot performance does not depend on the
+loader's unspecified physical-device enumeration order.
+
 Renderer cadence is useful when the sequence itself must include boot, so a complete warmup is not
 appropriate. Sparse rendering can omit temporal producers and is therefore not a gameplay oracle by
 itself. Pair `--render-every N` with `--render-every-for-seconds S` to accelerate a long intro, then

--- a/prosper/tools/snapshot/README.md
+++ b/prosper/tools/snapshot/README.md
@@ -28,6 +28,10 @@ render state, texture decode/detiling, executor behavior, or presentation.
 representative presented PNGs, the boot log, and structured per-frame evidence
 in `tools/snapshot/failures/`.
 
+Snapshot rendering uses the shared renderer's hardware-first Vulkan selection: discrete, integrated,
+and virtual GPUs are preferred over CPU devices, with llvmpipe used only when no usable GPU is exposed.
+The selected device is printed in each retained run log.
+
 ## Guard Modes
 
 ### Routed content guard


### PR DESCRIPTION
## What changed

- prefer discrete, integrated, and virtual Vulkan GPUs over CPU devices in the shared graphics and compute renderer
- retain llvmpipe as the automatic fallback when no usable hardware GPU is exposed
- log the selected Vulkan devices in snapshot run logs
- make the persistent D32 depth checkpoint regression use valid finite depth values
- document hardware-first snapshot rendering

## Why

Vulkan physical-device enumeration is not a performance ordering. Selecting device zero could therefore run the very expensive real-game snapshot suite on llvmpipe even when a hardware GPU was available.

The focused `gpu_capture_render_replay` failure was separate: it uploaded arbitrary bytes, including invalid/NaN values, into a `D32_SFLOAT` plane and expected a byte-exact round trip. Hardware drivers may canonicalize those values. Valid finite depth samples preserve the intended checkpoint round-trip contract portably.

## Validation

- `gpu_capture_render_replay` on AMD RADV
- `gpu_capture_render_replay` with `VK_DRIVER_FILES=/usr/share/vulkan/icd.d/lvp_icd.x86_64.json`
- `vulkan_offscreen_clear` on AMD RADV
- `python3 tools/snapshot/test_snapshot.py` (8 tests)
- `git diff --check`

Real-game snapshots remain local-only and are not run by CI. Linux core CI disables Vulkan; frontend Vulkan CI is build-only.
