### PR TITLE
gpu(shader): structurize nested divergent EXEC/VCC-exit loops

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -2688,17 +2688,48 @@ std::vector<DivLoop> detect_divergent_loops(const std::vector<Rdna2Inst>& ins,
         backedge_execnz.push_back(in.opcode == 0x09);
     }
     if (out.empty()) return out;
-    // Loops must be strictly DISJOINT and in order (nested loops are not modeled). Backward branches
-    // appear in pc order, so headers must too — and each loop must end before the next begins.
-    for (size_t i = 1; i < out.size(); i++)
-        if (out[i].header_pc < out[i - 1].exit_pc) return {};
-    // Pass 2: validate each loop's interior branches and find the canonical exit + breaks.
+    // Loops may be strictly DISJOINT (sequential) or PROPERLY NESTED (#590 — DOLL's post-process
+    // kernel iterates an inner table loop inside an outer row loop). Pass 1 collected loops in
+    // BACK-EDGE pc order (an inner back-edge precedes its outer's); re-sort by header so the list is
+    // in emission order — emit_structured consumes loops by header pc, and emitting an outer body
+    // recursively reaches the inner loop first because its header lies inside that range. Then
+    // validate every pair as either disjoint-in-order or properly nested; partial overlap (an
+    // unstructured region) still rejects loudly.
+    {
+        std::vector<size_t> order(out.size());
+        for (size_t i = 0; i < order.size(); i++) order[i] = i;
+        std::sort(order.begin(), order.end(),
+                  [&](size_t a, size_t c) { return out[a].header_pc < out[c].header_pc; });
+        std::vector<DivLoop> sorted_loops; std::vector<bool> sorted_execnz;
+        sorted_loops.reserve(out.size()); sorted_execnz.reserve(out.size());
+        for (size_t i : order) { sorted_loops.push_back(out[i]); sorted_execnz.push_back(backedge_execnz[i]); }
+        out.swap(sorted_loops); backedge_execnz.swap(sorted_execnz);
+    }
+    for (size_t i = 0; i < out.size(); i++)
+        for (size_t j = i + 1; j < out.size(); j++) {
+            const DivLoop& A = out[i]; const DivLoop& B = out[j];   // A.header_pc <= B.header_pc
+            if (A.header_pc == B.header_pc) return {};              // shared header: not modeled
+            const bool disjoint = B.header_pc >= A.exit_pc;
+            const bool nested   = B.exit_pc <= A.backedge_pc;       // B entirely inside A's body
+            if (!disjoint && !nested) return {};                    // partial overlap: unstructured
+        }
+    // Pass 2: validate each loop's interior branches and find the canonical exit + breaks. A branch
+    // inside a NESTED child loop belongs to the child (which validates itself in its own pass-2
+    // iteration) — skip it here, including the child's backward back-edge, which is exactly the
+    // "second back-edge inside" that used to reject nesting outright.
+    auto inside_nested_child = [&out](const DivLoop& L, uint32_t pc) {
+        for (const auto& C : out)
+            if (C.header_pc > L.header_pc && C.exit_pc <= L.backedge_pc &&
+                pc >= C.header_pc && pc <= C.backedge_pc) return true;
+        return false;
+    };
     for (size_t li = 0; li < out.size(); li++) {
         DivLoop& L = out[li];
         const bool execnz = backedge_execnz[li];
         for (const auto& in : ins) {
             if (in.is_end || in.pc >= L.backedge_pc) break;
             if (in.pc < L.header_pc || in.fmt != Rdna2Format::SOPP) continue;
+            if (inside_nested_child(L, in.pc)) continue;
             switch (in.opcode) {
                 case 0x02: case 0x04: case 0x05: case 0x06: case 0x07: case 0x08: case 0x09: break;
                 default: continue;   // hints
@@ -2745,6 +2776,12 @@ std::vector<DivLoop> detect_divergent_loops(const std::vector<Rdna2Inst>& ins,
         // immediately re-test EXEC (empty condition region) — see the shape comment.
         if (execnz && L.exit_branch_pc != L.header_pc) return {};
     }
+    // A nested child must lie entirely within its parent's BODY: after the parent's canonical exit
+    // test (the condition region [header, exit_branch) stays branch-free) and before its back-edge.
+    for (size_t i = 0; i < out.size(); i++)
+        for (size_t j = i + 1; j < out.size(); j++)
+            if (out[j].exit_pc <= out[i].backedge_pc &&        // nested per the classification above
+                out[j].header_pc <= out[i].exit_branch_pc) return {};
     // Pass 3: no branch from OUTSIDE a loop may target its interior (an unstructured entry edge).
     for (const auto& in : ins) {
         if (in.is_end) break;
@@ -7502,10 +7539,16 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
             //     workgroup-divergent control flow (UB). DOLL's blocked light/fill kernels are
             //     straight-line bodies, so nothing observed is lost. CONFIDENCE: MED-HIGH (shared
             //     emit machinery; spirv-val + coverage tests + Messenger guard gate it).
+            // Condition::Vcc loops are accepted under the detector's uniformity proof (#615/#590).
+            // Condition::Exec loops (#590 — DOLL's nested post-process kernel is the observed compute
+            // case) lower with the same per-invocation model as the fragment shell: this invocation
+            // iterates while ITS EXEC bit holds after the header's v_cmpx recompute. Both flavors
+            // require the barrier/LDS/cross-lane-free body below — the per-invocation trip count can
+            // differ across a workgroup, so a barrier inside the loop would be workgroup-divergent
+            // control flow (UB); barriers AFTER the loop are fine (the loop merge reconverges).
             bool compute_ok = !Ls.empty();
             for (const auto& L : Ls) {
                 if (!compute_ok) break;
-                if (L.condition != DivLoop::Condition::Vcc) { compute_ok = false; break; }
                 for (const auto& in : ins) {
                     if (in.is_end || in.pc >= L.exit_pc) break;
                     if (in.pc < L.header_pc) continue;
@@ -7513,6 +7556,26 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                         (in.fmt == Rdna2Format::SOPP && in.opcode == 0x0a) ||
                         (in.fmt == Rdna2Format::VOP3 &&
                          (in.opcode == 0x365 || in.opcode == 0x366))) { compute_ok = false; break; }
+                }
+                // Fail-visible marker for the per-invocation approximation's one known divergence: a
+                // POST-loop read of an SGPR advanced inside an Exec-condition loop. With a lane-varying
+                // bound, hardware advances in-loop scalars to the wave's MAX trip count while the
+                // per-invocation lowering yields each invocation its own exit value. Uniform bounds
+                // (all observed shapes) are exact. Diagnose loudly instead of silently diverging; if a
+                // real kernel trips this AND has a varying bound, that is the evidence to revisit.
+                if (compute_ok && L.condition == DivLoop::Condition::Exec && getenv("PROSPER_DBG")) {
+                    std::set<int> lv, lsr;
+                    loop_written_regs(ins, L.header_pc, L.backedge_pc, lv, lsr);
+                    for (const auto& in : ins) {
+                        if (in.is_end) break;
+                        if (in.pc < L.exit_pc) continue;
+                        for (uint32_t oi = 0; oi < in.n_src; ++oi)
+                            if (in.src[oi].kind == OperandKind::SGPR && lsr.count((int)in.src[oi].value))
+                                fprintf(stderr,
+                                        "[compute-exec-loop] post-loop read of loop-advanced s%u at pc=%u "
+                                        "(per-invocation value; wave max-trip on hardware)\n",
+                                        (unsigned)in.src[oi].value, in.pc);
+                    }
                 }
             }
             if (!compute_ok) Ls.clear();   // unchanged behavior: the branch reaches emit_alu -> loud reject

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -3692,6 +3692,82 @@ int main() {
     CHECK(gotA12.size() == 1 && gotA12[0] == -32767.0f,
           "A12: straddling signed private short reloads with correct sign extension");
 
+    // NESTED divergent EXEC-exit loops in COMPUTE (#590 — DOLL's last post-process kernel shape:
+    // an inner table loop entirely inside an outer row loop, both v_cmpx/execz-exit with backward
+    // s_branch back-edges, s_barrier AFTER the loops). Per-invocation lowering: this invocation
+    // iterates while its own EXEC bit holds. outer 3 iterations x inner 4 iterations accumulate
+    // v3 += 0.0625 twelve times = 0.75; the outer body adds v2 += 0.25 three times = 0.75.
+    {
+        const uint32_t nested_cs[] = {
+            0x7E020283u,               //  0: v_mov_b32 v1, 3        (outer bound)
+            0x7E080284u,               //  1: v_mov_b32 v4, 4        (inner bound)
+            0xBE800380u,               //  2: s_mov_b32 s0, 0        (outer counter)
+            0x7E040280u,               //  3: v_mov_b32 v2, 0
+            0x7E060280u,               //  4: v_mov_b32 v3, 0
+            0x7E0A02F2u,               //  5: v_mov_b32 v5, 1.0
+            0xBE82047Eu,               //  6: s_mov_b64 s[2:3], exec (outer save)
+            0x7DA20200u,               //  7: OUTER_HDR: v_cmpx_lt_u32 s0, v1
+            0xBF88000Du,               //  8: s_cbranch_execz +13 -> 22 (OUTER_EXIT)
+            0xBE810380u,               //  9: s_mov_b32 s1, 0        (inner counter reset)
+            0xBE84047Eu,               // 10: s_mov_b64 s[4:5], exec (inner save)
+            0x7DA20801u,               // 11: INNER_HDR: v_cmpx_lt_u32 s1, v4
+            0xBF880004u,               // 12: s_cbranch_execz +4 -> 17 (INNER_EXIT)
+            0x060606FFu, 0x3D800000u,  // 13: v_add_f32 v3, 0.0625, v3
+            0x81018101u,               // 15: s_add_i32 s1, s1, 1
+            0xBF82FFFAu,               // 16: s_branch -6 -> 11 (INNER back-edge)
+            0xBEFE0404u,               // 17: INNER_EXIT: s_mov_b64 exec, s[4:5]
+            0x060404FFu, 0x3E800000u,  // 18: v_add_f32 v2, 0.25, v2
+            0x81008100u,               // 20: s_add_i32 s0, s0, 1
+            0xBF82FFF1u,               // 21: s_branch -15 -> 7 (OUTER back-edge)
+            0xBEFE0402u,               // 22: OUTER_EXIT: s_mov_b64 exec, s[2:3]
+            0xBF8A0000u,               // 23: s_barrier (post-loop, uniform: reconverged merge)
+            0xBF810000u,               // 24: s_endpgm
+        };
+        std::vector<uint32_t> spvNL = recompile_valu(nested_cs, std::size(nested_cs), 1, 3);
+        CHECK(!spvNL.empty(), "#590: recompiled NESTED exec-exit loops (compute) -> SPIR-V");
+        std::vector<float> inNL(64, 0.0f);
+        std::vector<float> gotNL = prosper::test::run_compute(spvNL, inNL, 64, 64);
+        uint32_t badNL = 0;
+        for (uint32_t i = 0; i < 64 && gotNL.size() == 64; ++i)
+            if (std::fabs(gotNL[i] - 0.75f) > 1e-3f) ++badNL;
+        if (gotNL.size() == 64)
+            printf("  nested-loop out[0]=%g out[63]=%g expect 0.75\n", gotNL[0], gotNL[63]);
+        CHECK(gotNL.size() == 64 && badNL == 0,
+              "#590: nested loops run 3x4 iterations (inner accumulates 12 x 0.0625 = 0.75)");
+
+        // The outer accumulator proves the OUTER body's tail (after the inner loop's exit + exec
+        // restore) executes exactly once per outer iteration.
+        std::vector<uint32_t> spvNL2 = recompile_valu(nested_cs, std::size(nested_cs), 1, 2);
+        std::vector<float> gotNL2 = prosper::test::run_compute(spvNL2, inNL, 64, 64);
+        CHECK(gotNL2.size() == 64 && std::fabs(gotNL2[0] - 0.75f) < 1e-3f,
+              "#590: outer body tail runs 3 times (3 x 0.25 = 0.75) after each inner-loop exit");
+    }
+
+    // PARTIALLY OVERLAPPING loops (back-edge into another loop's body without proper nesting) must
+    // not be accepted by the STRUCTURIZER. In compute they may legitimately fall to the CFG
+    // state-machine dispatcher (faithful wave emulation) — so this stream carries a mid-region
+    // s_barrier, which disqualifies the dispatcher too: the only remaining outcome is a loud reject.
+    {
+        const uint32_t overlap_cs[] = {
+            0xBE800380u,               //  0: s_mov_b32 s0, 0
+            0x7E020284u,               //  1: v_mov_b32 v1, 4
+            0x7DA20200u,               //  2: A_HDR: v_cmpx_lt_u32 s0, v1
+            0xBF880007u,               //  3: s_cbranch_execz +7 -> 11
+            0x7DA20200u,               //  4: B_HDR: v_cmpx_lt_u32 s0, v1
+            0xBF880007u,               //  5: s_cbranch_execz +7 -> 13
+            0xBF8A0000u,               //  6: s_barrier (disqualifies the dispatcher fallback)
+            0x81008100u,               //  7: s0++
+            0xBF82FFF9u,               //  8: s_branch -7 -> 2 (A back-edge; A=[2,8], exit 9)
+            0x81008100u,               //  9: s0++
+            0xBF82FFF9u,               // 10: s_branch -7 -> 4 (B back-edge; B=[4,10] overlaps A, not nested)
+            0x7E040280u,               // 11: v_mov_b32 v2, 0
+            0x7E040280u,               // 12: v_mov_b32 v2, 0
+            0xBF810000u,               // 13: s_endpgm
+        };
+        CHECK(recompile_valu(overlap_cs, std::size(overlap_cs), 1, 2).empty(),
+              "#590: partially-overlapping loops remain REJECTED (unstructured region)");
+    }
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;

--- a/prosper/tests/test_recompiled_fragment.cpp
+++ b/prosper/tests/test_recompiled_fragment.cpp
@@ -284,6 +284,71 @@ int main() {
         }
     }
 
+    // NESTED DIVERGENT EXECZ-EXIT LOOPS (#590 — DOLL's last post-process kernel shape, fragment
+    // shell): an inner table loop entirely inside an outer row loop, both v_cmpx/execz-exit with
+    // backward s_branch back-edges, with an exec save around the inner loop and a restore at its
+    // exit. outer 3 x inner 4: v3 += 0.0625 twelve times = 0.75 (green), v2 += 0.25 three times in
+    // the outer body tail = 0.75 (red/blue) -> gray (0.75, 0.75, 0.75, 1.0).
+    {
+        const uint32_t ps[] = {
+            0x7E020283u,               //  0: v_mov_b32 v1, 3        (outer bound)
+            0x7E080284u,               //  1: v_mov_b32 v4, 4        (inner bound)
+            0xBE800380u,               //  2: s_mov_b32 s0, 0
+            0x7E040280u,               //  3: v_mov_b32 v2, 0
+            0x7E060280u,               //  4: v_mov_b32 v3, 0
+            0x7E0A02F2u,               //  5: v_mov_b32 v5, 1.0
+            0xBE82047Eu,               //  6: s_mov_b64 s[2:3], exec
+            0x7DA20200u,               //  7: OUTER_HDR: v_cmpx_lt_u32 s0, v1
+            0xBF88000Du,               //  8: s_cbranch_execz +13 -> 22 (OUTER_EXIT)
+            0xBE810380u,               //  9: s_mov_b32 s1, 0
+            0xBE84047Eu,               // 10: s_mov_b64 s[4:5], exec
+            0x7DA20801u,               // 11: INNER_HDR: v_cmpx_lt_u32 s1, v4
+            0xBF880004u,               // 12: s_cbranch_execz +4 -> 17 (INNER_EXIT)
+            0x060606FFu, 0x3D800000u,  // 13: v_add_f32 v3, 0.0625, v3
+            0x81018101u,               // 15: s_add_i32 s1, s1, 1
+            0xBF82FFFAu,               // 16: s_branch -6 -> 11 (INNER back-edge)
+            0xBEFE0404u,               // 17: INNER_EXIT: s_mov_b64 exec, s[4:5]
+            0x060404FFu, 0x3E800000u,  // 18: v_add_f32 v2, 0.25, v2
+            0x81008100u,               // 20: s_add_i32 s0, s0, 1
+            0xBF82FFF1u,               // 21: s_branch -15 -> 7 (OUTER back-edge)
+            0xBEFE0402u,               // 22: OUTER_EXIT: s_mov_b64 exec, s[2:3]
+            0xF800180Fu, 0x05020302u,  // 23: exp mrt0 v2, v3, v2, v5 done vm
+            0xBF810000u,               // 25: s_endpgm
+        };
+        std::vector<uint32_t> frg = recompile_fragment(ps, sizeof(ps)/sizeof(ps[0]));
+        CHECK(!frg.empty(), "#590: recompiled NESTED execz-exit loops PS -> SPIR-V");
+        if (!frg.empty()) {
+            std::vector<uint8_t> px2 = prosper::test::render_triangle_rgba(vert, frg, W, H);
+            CHECK(px2.size() == (size_t)W*H*4, "rendered the nested-loop PS");
+            if (px2.size() == (size_t)W*H*4) {
+                const uint8_t* cc = &px2[((size_t)(H/2) * W + W/2) * 4];
+                printf("  nested loops center=(%u,%u,%u,%u) expect ~(191,191,191,255)\n",
+                       cc[0],cc[1],cc[2],cc[3]);
+                CHECK(cc[0] > 0xA8 && cc[0] < 0xD8 && cc[1] > 0xA8 && cc[1] < 0xD8 &&
+                      cc[2] > 0xA8 && cc[2] < 0xD8,
+                      "#590: nested loops 3x4: inner 12 x 0.0625 and outer 3 x 0.25 both = 0.75");
+            }
+        }
+
+        // Partially-overlapping loops (a back-edge into another loop's body without proper nesting)
+        // remain rejected in the fragment shell (no dispatcher fallback exists there).
+        const uint32_t overlap_ps[] = {
+            0xBE800380u, 0x7E020284u,
+            0x7DA20200u,               //  2: A_HDR: v_cmpx_lt_u32 s0, v1
+            0xBF880006u,               //  3: s_cbranch_execz +6 -> 10
+            0x7DA20200u,               //  4: B_HDR
+            0xBF880006u,               //  5: s_cbranch_execz +6 -> 12
+            0x81008100u,               //  6: s0++
+            0xBF82FFFAu,               //  7: s_branch -6 -> 2 (A back-edge; A=[2,7])
+            0x81008100u,               //  8: s0++
+            0xBF82FFFAu,               //  9: s_branch -6 -> 4 (B back-edge; B=[4,9] overlaps A)
+            0xF800180Fu, 0x05020302u,  // 10: export
+            0xBF810000u,               // 12: s_endpgm
+        };
+        CHECK(recompile_fragment(overlap_ps, sizeof(overlap_ps)/sizeof(overlap_ps[0])).empty(),
+              "#590: partially-overlapping loops remain REJECTED (fragment)");
+    }
+
     // SCALAR-SPILL lane slots (#273): v_writelane_b32 packs two scalars into v10's lanes 3/7 and
     // v_readlane_b32 restores them; export uses the round-tripped values -> (0.25, 1.0, 0.25, 1.0).
     {

--- a/prosper/tools/spv_validate/spv_validate.cpp
+++ b/prosper/tools/spv_validate/spv_validate.cpp
@@ -223,6 +223,23 @@ int main(int argc, char** argv) {
                             0x00010E06u,0xD7600007u,0x0001070Au,0xD7600008u,0x00010F0Au,0x7E000207u,
                             0x7E020208u,0xF800180Fu,0x01000100u,0xBF810000u};
       dump(dir, "fragment_lane_slots", recompile_fragment(c, sizeof(c)/4, nullptr)); }
+    // NESTED divergent execz-exit loops (#590/#1067 — DOLL's last post-process kernel shape): an
+    // inner table loop entirely inside an outer row loop, execz exits + backward s_branch
+    // back-edges, an exec save around the inner loop, post-loop s_barrier (compute). Locks the
+    // nested OpLoopMerge emission under strict validation for BOTH shells; the execution twins
+    // live in test_rdna2_to_spirv / test_recompiled_fragment.
+    { const uint32_t c[] = {0x7E020283u,0x7E080284u,0xBE800380u,0x7E040280u,0x7E060280u,0x7E0A02F2u,
+                            0xBE82047Eu,0x7DA20200u,0xBF88000Du,0xBE810380u,0xBE84047Eu,0x7DA20801u,
+                            0xBF880004u,0x060606FFu,0x3D800000u,0x81018101u,0xBF82FFFAu,0xBEFE0404u,
+                            0x060404FFu,0x3E800000u,0x81008100u,0xBF82FFF1u,0xBEFE0402u,0xBF8A0000u,
+                            0xBF810000u};
+      dump(dir, "compute_nested_exec_loops", recompile_valu(c, sizeof(c)/4, 1, 3)); }
+    { const uint32_t c[] = {0x7E020283u,0x7E080284u,0xBE800380u,0x7E040280u,0x7E060280u,0x7E0A02F2u,
+                            0xBE82047Eu,0x7DA20200u,0xBF88000Du,0xBE810380u,0xBE84047Eu,0x7DA20801u,
+                            0xBF880004u,0x060606FFu,0x3D800000u,0x81018101u,0xBF82FFFAu,0xBEFE0404u,
+                            0x060404FFu,0x3E800000u,0x81008100u,0xBF82FFF1u,0xBEFE0402u,
+                            0xF800180Fu,0x05020302u,0xBF810000u};
+      dump(dir, "fragment_nested_exec_loops", recompile_fragment(c, sizeof(c)/4, nullptr)); }
 
     if (fails) { printf("== FAIL: %d shader(s) failed recompile/validation ==\n", fails); return 1; }
     printf("== PASS%s ==\n", have_val ? " (all modules pass spirv-val)" : " (recompiled; spirv-val not found)");


### PR DESCRIPTION
## Problem

`Fixes #1067` (split from umbrella #590; handoff: `docs/DOLL_POSTPROCESS_HANDOFF.md` / PR #1057). DOLL's (PPSA17942) **last** failing post-process compute shader, `exec_cs_201a5a0000`, is two **properly nested** divergent execz-exit loops (inner `[50,69]` entirely inside outer `[42,74]`, both with backward `s_branch` back-edges) followed by post-loop `s_barrier`s. `detect_divergent_loops` modeled only disjoint sequential loops — the inner back-edge inside the outer body hit the explicit `return {}` nested-loop reject, so the shader was skipped and its post-process surface never produced (the #319 black-composite family).

## Key insight

The **emission machinery already recurses**: `emit_divloop` emits its body via `emit_structured`, which consumes loops by header pc — an inner loop inside an outer body range emits naturally as a nested `OpLoopMerge` with its own phis/exec state. Only *detection* (and the compute Vcc-only guard) blocked the shape, so the change is deliberately concentrated there.

## Approach

- **Detection** (`detect_divergent_loops`): sort candidate loops by header pc (pass 1 collects them in back-edge order, which lists an inner before its outer) and validate every pair as *disjoint-in-order* or *properly nested*; partial overlap still rejects loudly. A parent's interior validation skips branches owned by a nested child (including the child's back-edge — exactly the old "second back-edge inside" reject); the child validates itself. A nested child must begin after its parent's canonical exit test, preserving the branch-free condition-region invariant. Pass 3 (no entry edges into a loop interior) is unchanged and still holds with nesting.
- **Compute guard**: accept `Condition::Exec` loops — per-invocation lowering identical to the fragment shell (this invocation iterates while *its* EXEC bit holds), with the unchanged barrier/LDS/cross-lane-free body requirement. DOLL's kernel is the observed compute case the old Vcc-only comment was explicitly waiting for. Barriers **after** a loop remain legal (the loop merge reconverges).

## Verification (structurizer changes are correctness-critical — execution-gated, not recompile-success-gated)

- **Compute execution test** (real Vulkan): nested 3×4 loops with a post-loop `s_barrier` — inner accumulator lands **exactly 12 × 0.0625 = 0.75** on all 64 invocations, and a second run proves the outer body tail (after the inner loop's exit + exec restore) runs **exactly 3 × 0.25 = 0.75**.
- **Fragment execution test**: same nested shape renders the **exact** (191,191,191,255) center pixel.
- **Negative tests, both shells**: partially-overlapping loops (a back-edge into another loop's body without proper nesting) remain rejected. The compute negative carries a mid-region barrier so the CFG state-machine dispatcher (which may *legitimately* take unstructured compute CFGs) cannot claim it.
- **Full `ctest`: 117/117** on exact head.
- Snapshot guard run recorded below (Dead Cells/Messenger/Evergate/Blasphemous 2 exercise many single-loop/multi-if shaders; the detection change is additive — disjoint-loop classification is order-preserving and single-loop paths are untouched).

## Deliberately unaffected

Single loops, sequential loops, forward-if regions, the counted-loop path, and the compute CFG dispatcher fallback are all behaviorally unchanged. Shaders that previously structurized keep byte-identical emission paths.

## Remaining (tracked on #590)

The live DOLL A/B — `exec_cs_201a5a0000` recompiles + the title composite past the splashes gains content — needs the PPSA17942 dump, which is not present on this machine.