### PR TITLE
fix(host): %fs-safe, fail-visible NULL_PAGE backing in the Linux fault handler

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -173,6 +173,13 @@ if(TARGET prosper_core)
   add_executable(test_fs_emu tests/test_fs_emu.cpp)
   add_test(NAME fs_emu_decode COMMAND test_fs_emu)
 
+  # Signal-handler-safe raw syscalls (src/host/raw_syscall.hpp): the fault_handler's
+  # PROSPER_NULL_PAGE backing must not touch errno/TLS on guest-%fs threads (issue #1071).
+  if(UNIX AND NOT APPLE)
+    add_executable(test_raw_syscall tests/test_raw_syscall.cpp)
+    add_test(NAME raw_syscall COMMAND test_raw_syscall)
+  endif()
+
   # sceAudioOut HLE: format decode, port lifecycle, PCM forwarding, volume, batch, error paths
   # (via a capturing AudioSink — headless, no device).
   add_executable(test_audio tests/test_audio.cpp)

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -3,6 +3,7 @@
 #include "exec_image.hpp"
 #include "sse4a.hpp"
 #include "fs_emu.hpp"
+#include "raw_syscall.hpp"
 #include "../hle/nid.hpp"
 #include "../hle/dispatch.hpp"
 
@@ -1563,8 +1564,12 @@ namespace {
             // must NOT be re-backed — those are the real chain endpoints; let them terminate + report.
             unsigned pg = (unsigned)(a >> 12);
             if (a < 0x10000ull && a != rip && pg < 16 && !(g_null_page_mask & (1u << pg))) {
-                void* page = (void*)(a & ~(uint64_t)0xfff);
-                if (mmap(page, 0x1000, PROT_READ, MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0) == page) {
+                uint64_t page = a & ~(uint64_t)0xfff;
+                // Raw syscall, NOT glibc mmap()/syscall(): both store errno through %fs on
+                // failure, and %fs is guest TLS on this thread — the store itself faults inside
+                // the handler and kills the process before any report (issue #1071).
+                long mr = raw_mmap_fixed_ro(page, 0x1000);
+                if (mr == 0) {
                     g_null_page_mask |= (1u << pg);
                     g_null_page_count = g_null_page_count + 1;
                     char b[128];
@@ -1575,6 +1580,16 @@ namespace {
                     nullpage_deep_dump(uc, rip);   // issue-#312 attribution dump (registers + heap + GPU ring)
                     return;   // re-execute; the null read now sees zero
                 }
+                // Fail-visible: low mappings need CAP_SYS_RAWIO once addr < vm.mmap_min_addr
+                // (default 65536), so unprivileged/containerized hosts land here. Fall through
+                // to the normal fatal report instead of silently retrying.
+                char b[160];
+                int n = snprintf(b, sizeof b,
+                                 "[nullpage] BACKING DENIED addr=0x%llx rip=eboot+0x%llx err=%ld"
+                                 " (vm.mmap_min_addr/CAP_SYS_RAWIO)\n",
+                                 (unsigned long long)a,
+                                 (unsigned long long)(rip - 0x400000000ull), mr);
+                syscall(SYS_write, 2, b, (size_t)n);   /* raw: glibc write() reads the TCB via %fs (guest-fs unsafe in this handler) */
             }
         }
         // Null-companion skip probe (diagnostic; see g_skip_null_companion). Redirect the reader past

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -1589,7 +1589,7 @@ namespace {
                                  " (vm.mmap_min_addr/CAP_SYS_RAWIO)\n",
                                  (unsigned long long)a,
                                  (unsigned long long)(rip - 0x400000000ull), mr);
-                syscall(SYS_write, 2, b, (size_t)n);   /* raw: glibc write() reads the TCB via %fs (guest-fs unsafe in this handler) */
+                raw_write(2, b, (uint64_t)n);   /* not even glibc syscall(): it stores errno via %fs on failure */
             }
         }
         // Null-companion skip probe (diagnostic; see g_skip_null_companion). Redirect the reader past

--- a/prosper/src/host/raw_syscall.hpp
+++ b/prosper/src/host/raw_syscall.hpp
@@ -32,6 +32,17 @@ inline long raw_mmap_fixed_ro(uint64_t addr, uint64_t len) {
     return (uint64_t)ret == addr ? 0 : -EINVAL;                  // MAP_FIXED must land at addr
 }
 
+// write(2) without errno/TLS access: returns the byte count or a negative errno value.
+// For handler diagnostics; callers may ignore the result (best-effort logging).
+inline long raw_write(int fd, const void* buf, uint64_t len) {
+    long ret;
+    __asm__ volatile("syscall"
+                     : "=a"(ret)
+                     : "0"((long)SYS_write), "D"((long)fd), "S"(buf), "d"(len)
+                     : "rcx", "r11", "memory");
+    return ret;
+}
+
 } // namespace prosper
 
 #endif // __linux__ && __x86_64__

--- a/prosper/src/host/raw_syscall.hpp
+++ b/prosper/src/host/raw_syscall.hpp
@@ -7,11 +7,12 @@
 // syscall instruction directly and return -errno in-register; they never touch errno or TLS.
 #pragma once
 
-#if defined(__linux__) && defined(__x86_64__)
-
 #include <cerrno>
 #include <cstdint>
 #include <sys/mman.h>
+
+#if defined(__linux__) && defined(__x86_64__)
+
 #include <sys/syscall.h>
 
 namespace prosper {
@@ -45,4 +46,28 @@ inline long raw_write(int fd, const void* buf, uint64_t len) {
 
 } // namespace prosper
 
-#endif // __linux__ && __x86_64__
+#elif !defined(_WIN32)
+
+// Non-Linux POSIX (macOS): exec_image_linux.cpp is the shared POSIX substrate and compiles
+// here too. Host TLS is %gs-based on macOS x86-64, so libc's errno store never goes through
+// the guest's %fs — plain libc calls are handler-safe, and these wrappers just adapt them to
+// the same 0/-errno in-register contract the Linux asm versions provide.
+#include <unistd.h>
+
+namespace prosper {
+
+inline long raw_mmap_fixed_ro(uint64_t addr, uint64_t len) {
+    void* p = mmap((void*)addr, (size_t)len, PROT_READ,
+                   MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0);
+    if (p == MAP_FAILED) return -(long)errno;
+    return (uint64_t)p == addr ? 0 : -EINVAL;
+}
+
+inline long raw_write(int fd, const void* buf, uint64_t len) {
+    long r = (long)write(fd, buf, (size_t)len);
+    return r < 0 ? -(long)errno : r;
+}
+
+} // namespace prosper
+
+#endif // platform

--- a/prosper/src/host/raw_syscall.hpp
+++ b/prosper/src/host/raw_syscall.hpp
@@ -1,0 +1,37 @@
+// Signal-handler-safe raw syscalls (Linux x86-64).
+//
+// The Linux fault_handler runs on guest threads whose %fs base is GUEST TLS. Any glibc call
+// that can fail — including mmap() and even the glibc syscall() wrapper — stores errno through
+// %fs on the failure path, which faults *inside* the signal handler and kills the process with
+// a nested SIGSEGV instead of reaching the fatal report (issue #1071). Helpers here issue the
+// syscall instruction directly and return -errno in-register; they never touch errno or TLS.
+#pragma once
+
+#if defined(__linux__) && defined(__x86_64__)
+
+#include <cerrno>
+#include <cstdint>
+#include <sys/mman.h>
+#include <sys/syscall.h>
+
+namespace prosper {
+
+// Fixed, read-only, anonymous, private mapping of [addr, addr+len).
+// Returns 0 on success or a negative errno value. Async-signal-safe; no TLS/errno access.
+inline long raw_mmap_fixed_ro(uint64_t addr, uint64_t len) {
+    long ret;
+    register long r10 __asm__("r10") = MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED;
+    register long r8  __asm__("r8")  = -1;                       // fd
+    register long r9  __asm__("r9")  = 0;                        // offset
+    __asm__ volatile("syscall"
+                     : "=a"(ret)
+                     : "0"((long)SYS_mmap), "D"(addr), "S"(len), "d"((long)PROT_READ),
+                       "r"(r10), "r"(r8), "r"(r9)
+                     : "rcx", "r11", "memory");
+    if (ret < 0) return ret;                                     // kernel returns -errno directly
+    return (uint64_t)ret == addr ? 0 : -EINVAL;                  // MAP_FIXED must land at addr
+}
+
+} // namespace prosper
+
+#endif // __linux__ && __x86_64__

--- a/prosper/src/host/raw_syscall.hpp
+++ b/prosper/src/host/raw_syscall.hpp
@@ -7,12 +7,16 @@
 // syscall instruction directly and return -errno in-register; they never touch errno or TLS.
 #pragma once
 
+// NOTE: exec_image_linux.cpp includes this header above its own platform guard and is globbed
+// into prosper_core on every host, so the top level here must stay Windows/MinGW-clean (no
+// <sys/mman.h> — see posix_shim.hpp). The errno/TLS-free guarantee below holds for the Linux
+// x86-64 asm branch; the POSIX fallback branch is plain libc (safe there, see its comment).
 #include <cerrno>
 #include <cstdint>
-#include <sys/mman.h>
 
 #if defined(__linux__) && defined(__x86_64__)
 
+#include <sys/mman.h>
 #include <sys/syscall.h>
 
 namespace prosper {
@@ -52,6 +56,7 @@ inline long raw_write(int fd, const void* buf, uint64_t len) {
 // here too. Host TLS is %gs-based on macOS x86-64, so libc's errno store never goes through
 // the guest's %fs — plain libc calls are handler-safe, and these wrappers just adapt them to
 // the same 0/-errno in-register contract the Linux asm versions provide.
+#include <sys/mman.h>
 #include <unistd.h>
 
 namespace prosper {

--- a/prosper/tests/test_raw_syscall.cpp
+++ b/prosper/tests/test_raw_syscall.cpp
@@ -1,0 +1,54 @@
+// raw_mmap_fixed_ro: the %fs-safe fixed read-only anonymous mapping used by the Linux
+// fault_handler's PROSPER_NULL_PAGE backing (issue #1071). The handler runs on guest threads
+// whose %fs base is guest TLS, so neither glibc mmap() nor glibc syscall() may be used there:
+// both store errno through %fs on failure, which faults inside the signal handler and kills
+// the process. This helper must return -errno in-register and leave host errno/TLS untouched.
+#include "../src/host/raw_syscall.hpp"
+
+#include <cerrno>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <sys/mman.h>
+
+static int failures = 0;
+#define CHECK(cond, ...) do { if (!(cond)) { failures++; \
+    fprintf(stderr, "FAIL %s:%d: %s\n  ", __FILE__, __LINE__, #cond); \
+    fprintf(stderr, __VA_ARGS__); fprintf(stderr, "\n"); } } while (0)
+
+int main() {
+    // --- success: map a fixed read-only zero page at a known-free high address -------------
+    // Reserve an address range via the normal allocator, then release it and re-map it raw.
+    void* probe = mmap(nullptr, 0x2000, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    CHECK(probe != MAP_FAILED, "probe reservation failed: %s", strerror(errno));
+    uint64_t addr = (uint64_t)probe;
+    munmap(probe, 0x2000);
+
+    errno = 999;                                   // sentinel: raw path must not touch errno
+    long r = prosper::raw_mmap_fixed_ro(addr, 0x1000);
+    CHECK(r == 0, "expected success mapping at 0x%llx, got %ld", (unsigned long long)addr, r);
+    CHECK(errno == 999, "errno clobbered on success path: %d", errno);
+    if (r == 0) {
+        const volatile uint8_t* p = (const uint8_t*)addr;
+        uint8_t acc = 0;
+        for (int i = 0; i < 0x1000; i++) acc |= p[i];
+        CHECK(acc == 0, "mapped page not zero-filled (acc=0x%x)", acc);
+        munmap((void*)addr, 0x1000);
+    }
+
+    // --- failure: invalid length must report -EINVAL in-register, errno untouched ----------
+    errno = 999;
+    r = prosper::raw_mmap_fixed_ro(addr, 0);
+    CHECK(r == -EINVAL, "expected -EINVAL for len=0, got %ld", r);
+    CHECK(errno == 999, "errno clobbered on failure path: %d", errno);
+
+    // --- failure: unaligned fixed address must report -EINVAL, errno untouched -------------
+    errno = 999;
+    r = prosper::raw_mmap_fixed_ro(addr + 1, 0x1000);
+    CHECK(r == -EINVAL, "expected -EINVAL for unaligned addr, got %ld", r);
+    CHECK(errno == 999, "errno clobbered on failure path: %d", errno);
+
+    if (failures) { fprintf(stderr, "%d failure(s)\n", failures); return 1; }
+    printf("raw_syscall: all checks passed\n");
+    return 0;
+}

--- a/prosper/tests/test_raw_syscall.cpp
+++ b/prosper/tests/test_raw_syscall.cpp
@@ -10,12 +10,16 @@
 #include <cstdio>
 #include <cstring>
 #include <sys/mman.h>
+#include <unistd.h>
 
 static int failures = 0;
 #define CHECK(cond, ...) do { if (!(cond)) { failures++; \
     fprintf(stderr, "FAIL %s:%d: %s\n  ", __FILE__, __LINE__, #cond); \
     fprintf(stderr, __VA_ARGS__); fprintf(stderr, "\n"); } } while (0)
 
+#if !defined(__linux__) || !defined(__x86_64__)
+int main() { printf("raw_syscall: skipped (Linux x86-64 only)\n"); return 0; }
+#else
 int main() {
     // --- success: map a fixed read-only zero page at a known-free high address -------------
     // Reserve an address range via the normal allocator, then release it and re-map it raw.
@@ -48,7 +52,28 @@ int main() {
     CHECK(r == -EINVAL, "expected -EINVAL for unaligned addr, got %ld", r);
     CHECK(errno == 999, "errno clobbered on failure path: %d", errno);
 
+    // --- raw_write: success delivers the bytes, returns the count, errno untouched ---------
+    int fds[2];
+    CHECK(pipe(fds) == 0, "pipe failed: %s", strerror(errno));
+    errno = 999;
+    r = prosper::raw_write(fds[1], "abc", 3);
+    CHECK(errno == 999, "errno clobbered on raw_write success: %d", errno);
+    CHECK(r == 3, "expected 3 bytes written, got %ld", r);
+    if (r == 3) {                          // only read what was actually written — a blocking
+        char rb[4] = {0};                  // read on an empty pipe would hang a regressed build
+        CHECK(read(fds[0], rb, 3) == 3 && memcmp(rb, "abc", 3) == 0,
+              "pipe did not deliver raw_write bytes (got '%s')", rb);
+    }
+    close(fds[0]); close(fds[1]);
+
+    // --- raw_write: bad fd reports -EBADF in-register, errno untouched ---------------------
+    errno = 999;
+    r = prosper::raw_write(-1, "x", 1);
+    CHECK(r == -EBADF, "expected -EBADF for bad fd, got %ld", r);
+    CHECK(errno == 999, "errno clobbered on raw_write failure: %d", errno);
+
     if (failures) { fprintf(stderr, "%d failure(s)\n", failures); return 1; }
     printf("raw_syscall: all checks passed\n");
     return 0;
 }
+#endif


### PR DESCRIPTION
Fixes #1071

## Failure scenario

`PROSPER_NULL_PAGE=1` backs a low-address guest read fault by `mmap`ing a read-only zero page at the faulting address from inside the SIGSEGV handler (`src/host/exec_image_linux.cpp`). Two problems compound on any host where that mapping is denied (`MAP_FIXED` below `vm.mmap_min_addr=65536` requires `CAP_SYS_RAWIO` in the init userns — i.e. every unprivileged or containerized run; only the historical root-on-WSL setup ever succeeded):

1. The call was **glibc** `mmap()`. Its failure path stores `errno` through `%fs` — but on a guest thread `%fs` still holds guest TLS, so the store itself faults inside the handler: nested SIGSEGV, process death (exit 139 + core dump), **zero diagnostics**. Verified from the systemd core dump: crash at `mmap64+105` (`mov %eax,%fs:(%rdx)`) with `rdi=0 rsi=0x1000`, called from `fault_handler` on a guest thread (full stack in #1071). glibc's `syscall()` wrapper writes `errno` the same way, so it is equally unusable here.
2. The denial was silent even conceptually — no log, no fall-through report.

Observed live with Dragon Quest VII Reimagined (PPSA17942), whose known intermittent null/corrupt-pointer read at `eboot+0x2316acf` (the libc TLS small-block cache pop from #241; residual writer discussion in #312) triggers this path around frame ~167.

## Behavioral contract

- When the low-page mapping succeeds: behavior unchanged (page backed, `[nullpage]` log, deep dump, re-execute).
- When it is denied: the handler now emits one fail-visible line — `[nullpage] BACKING DENIED addr=… rip=… err=-N (vm.mmap_min_addr/CAP_SYS_RAWIO)` via raw `SYS_write` — and **falls through to the normal fatal fault report**, exactly as if `PROSPER_NULL_PAGE` were unset.
- The handler performs no glibc call that can touch `errno`/TLS on this path.

## Approach

New header `src/host/raw_syscall.hpp` (Linux x86-64 only): `raw_mmap_fixed_ro(addr,len)` issues the `syscall` instruction directly, returns `0` or `-errno` in-register, never touches `errno`/TLS, and treats a `MAP_FIXED` result at the wrong address as `-EINVAL`. The handler's null-page block uses it and logs denials. Everything else in the handler is untouched.

## Affected / unaffected

- Affected: Linux fault handler, `PROSPER_NULL_PAGE` path only (opt-in diagnostic, default off).
- Unaffected: default boot path, Windows/macOS hosts, renderer/output (no snapshot run needed — no render-path change), all other handler probes.

## Risks

- Inline-asm syscall correctness: covered by the unit test (success mapping content + two failure modes + `errno` preservation sentinel on all paths).
- The `rip - 0x400000000` "eboot+" labeling in the denial line follows the adjacent pre-existing `[nullpage]` convention (slightly misleading for non-eboot RIPs; kept for consistency).
- `prosper/CMakeLists.txt` is stored CRLF, so `git diff --check` flags the CR on any added line in that file; the 7-line addition matches the file's existing endings (the rest of the diff is check-clean).

## Verification (exact head 22b76d6, Linux worktree build)

- `cmake --build . -j16 && ctest` → **123/123 passed** (includes new `raw_syscall` test).
- TDD: `test_raw_syscall` observed failing (RED, stub `-ENOSYS`) before the implementation, passing after.
- Live A/B, DQ7R `PPSA17942`, `PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1`, unprivileged container:
  - **Before** (master `6074a9a`): nested SIGSEGV in handler, exit 139, core dump, no report.
  - **After** (this head, 3/3 runs): `[nullpage] BACKING DENIED addr=0x0 … err=-1` + full `WORKER-THREAD FAULT` report, exit 90.

## Out of scope

The guest-side null/corrupt pointer itself (DQ7R libc TLS-cache corruption, `SUSPECT-REL1-FORGE` correlation) — evidence recorded on #1071 and #312; a zero-read emulation diagnostic-parity idea is noted on #1071 as optional future work only.