### PR TITLE
gpu(diag): rate-limit repeated recompile rejection logs

### DIFF
--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -99,6 +99,13 @@ bool guest_readable(uint64_t addr, uint32_t bytes);
 // into a host fault.
 bool guest_writable(uint64_t addr, uint32_t bytes);
 
+// PROSPER_DBG can encounter the same failed shader pair millions of times in a draw loop. Return
+// true for the first and power-of-two occurrences so diagnostics retain recurrence/count evidence
+// without letting repeated failures bury the unique recompiler rejection that caused them.
+bool should_log_recompile_reject(uint64_t es_addr, uint64_t ps_addr,
+                                 size_t vs_words, size_t gs_words, size_t fs_words,
+                                 uint64_t* occurrence);
+
 // Convert the untrusted byte size published by an AGC shader header into the exact instruction
 // span that dynamic descriptor folding may probe and decode. Exposed so the safety/work bound has
 // direct regression coverage instead of being inferred from whether a large guest range is mapped.
@@ -715,13 +722,18 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
                 g_dyntrace_force = false;
             }
         }
-        if (getenv("PROSPER_DBG"))
+        uint64_t reject_occurrence = 0;
+        if (getenv("PROSPER_DBG") &&
+            should_log_recompile_reject(rs.es_addr, rs.ps_addr,
+                                        vs_words.size(), gs.size(), fs_words.size(),
+                                        &reject_occurrence))
             fprintf(stderr, "[exec-recompile-reject] es=0x%llx ps=0x%llx vs=%zu gs=%zu fs=%zu "
-                            "prim=%u topo=%u ena=%08x addr=%08x order=%llu\n",
+                            "prim=%u topo=%u ena=%08x addr=%08x order=%llu occurrence=%llu\n",
                     (unsigned long long)rs.es_addr, (unsigned long long)rs.ps_addr,
                     vs_words.size(), gs.size(), fs_words.size(), rs.prim_type, resolved_pipeline.topology,
                     rs.ps_input_ena, rs.ps_input_addr,
-                    (unsigned long long)(draw ? draw->command_order : 0));
+                    (unsigned long long)(draw ? draw->command_order : 0),
+                    (unsigned long long)reject_occurrence);
         if (const char* dd = getenv("PROSPER_SHADER_DUMP")) {
             for (auto [tag, addr] : {std::pair{"vs", rs.es_addr}, std::pair{"ps", rs.ps_addr}}) {
                 if (!addr || !guest_readable(addr, sizeof(uint32_t))) continue;

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -23,6 +23,7 @@
 #include <condition_variable>
 #include <filesystem>
 #include <iterator>
+#include <map>
 #include <mutex>
 #include <set>
 #include <tuple>
@@ -45,6 +46,20 @@
 extern "C" const void* prosper_agc_shader_header_for_code(uint64_t code_addr);
 
 namespace prosper::gpu {
+
+bool should_log_recompile_reject(uint64_t es_addr, uint64_t ps_addr,
+                                 size_t vs_words, size_t gs_words, size_t fs_words,
+                                 uint64_t* occurrence) {
+    using Key = std::tuple<uint64_t, uint64_t, size_t, size_t, size_t>;
+    static std::mutex mutex;
+    static std::map<Key, uint64_t> counts;
+    std::lock_guard<std::mutex> lock(mutex);
+    uint64_t& count = counts[{es_addr, ps_addr, vs_words, gs_words, fs_words}];
+    if (count != UINT64_MAX) ++count;
+    if (occurrence) *occurrence = count;
+    return count != 0 && (count & (count - 1)) == 0;
+}
+
 namespace {
 LiveRenderFn g_live;   // empty until the runtime/test registers a device-backed renderer
 LiveComputeFn g_compute;   // synchronous compute backend, registered with the live Vulkan frontend

--- a/prosper/tests/test_gpu_execute.cpp
+++ b/prosper/tests/test_gpu_execute.cpp
@@ -43,6 +43,25 @@ int main() {
     printf("== test_gpu_execute ==\n");
     const uint32_t W = 64, H = 64;
 
+    uint64_t occurrence = 0;
+    CHECK(should_log_recompile_reject(0xfeed0001, 0xfeed0002, 0, 0, 0, &occurrence) &&
+          occurrence == 1,
+          "recompile rejection limiter logs a shader pair's first occurrence");
+    CHECK(should_log_recompile_reject(0xfeed0001, 0xfeed0002, 0, 0, 0, &occurrence) &&
+          occurrence == 2,
+          "recompile rejection limiter logs the second power-of-two occurrence");
+    CHECK(!should_log_recompile_reject(0xfeed0001, 0xfeed0002, 0, 0, 0, &occurrence) &&
+          occurrence == 3,
+          "recompile rejection limiter suppresses a non-power-of-two repeat");
+    CHECK(should_log_recompile_reject(0xfeed0001, 0xfeed0002, 0, 0, 0, &occurrence) &&
+          occurrence == 4 &&
+          !should_log_recompile_reject(0xfeed0001, 0xfeed0002, 0, 0, 0, &occurrence) &&
+          occurrence == 5,
+          "recompile rejection limiter reports exponential recurrence counts");
+    CHECK(should_log_recompile_reject(0xfeed0001, 0xfeed0003, 0, 0, 0, &occurrence) &&
+          occurrence == 1,
+          "recompile rejection limiter tracks distinct shader pairs independently");
+
     // Build the GpuState the CommandProcessor produces for one green fullscreen-triangle draw.
     GpuState st;
     set_pgm(st, P::SPI_SHADER_PGM_LO_ES, P::SPI_SHADER_PGM_HI_ES, kVs);


### PR DESCRIPTION
## Summary

- rate-limit repeated `[exec-recompile-reject]` diagnostics per rejected shader pair and shader shape
- retain the first occurrence and power-of-two recurrence evidence
- include the occurrence count in emitted diagnostics
- add direct regression coverage for suppression and independent keys

## Why

With `PROSPER_DBG=1`, a title stuck retrying the same rejected draw can emit hundreds of thousands of identical lines. That buries the unique rejection evidence and creates very large logs without adding diagnostic value.

This change affects only debug logging after shader recompilation has already failed. Shader translation, rendering, failure handling, and non-debug runs are unchanged.

## Validation

- `git diff --check`
- focused `test_gpu_execute` on AMD Radeon 8060S
- full build with `GAME_DUMP=/home/mattias800/repos/ps5ys/PPSA24651-app0`
- full CTest: 120/120 passed

Fixes #1077
