### PR TITLE
gpu: lower fragment MBCNT with enforced wave64

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -445,16 +445,19 @@ struct SpirvCompute {
             put(deco, Op_Decorate, {v_subgroup_localid, Dec_Flat});
             iface.push_back(v_subgroup_localid);
         }
+        // Fragment lane ids model RDNA wave64 lanes, not the implementation's default subgroup.
+        // Arithmetic capability is also the self-contained module marker the backend reflects to
+        // enforce size 64; apply it even when an inline scalar mask only consumes the lane id.
+        if (is_fragment && !declared_subgroup_arithmetic) {
+            put(caps, Op_Capability, {Cap_GroupNonUniformArithmetic});
+            declared_subgroup_arithmetic = true;
+        }
         uint32_t lane = id();
         put(code, Op_Load, {t_u32, lane, v_subgroup_localid});
         return lane;
     }
     uint32_t fragment_mbcnt(uint32_t mask_bit, uint32_t acc_bits, bool lo) {
         if (!is_fragment) return 0;
-        if (!declared_subgroup_arithmetic) {
-            put(caps, Op_Capability, {Cap_GroupNonUniformArithmetic});
-            declared_subgroup_arithmetic = true;
-        }
         const uint32_t lane = subgroup_local_id();
         const uint32_t in_half = lo
             ? ucmp(Op_ULessThan, lane, uconst(32))

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -55,6 +55,7 @@ enum : uint32_t {
     Op_SelectionMerge=247, Op_Label=248, Op_Branch=249, Op_BranchConditional=250, Op_Switch=251,
     Op_EmitVertex=218, Op_EndPrimitive=219,
     Op_Kill=252, Op_Return=253, Op_GroupNonUniformAny=335,
+    Op_GroupNonUniformIAdd=349,
     Op_GroupNonUniformQuadSwap=366,
 };
 // GLSL.std.450 extended-instruction numbers.
@@ -65,7 +66,7 @@ enum : uint32_t { Glsl_FAbs=4, Glsl_RoundEven=2, Glsl_Trunc=3, Glsl_Floor=8, Gls
                   Glsl_NMin=79, Glsl_NMax=80 };   // NaN-aware min/max: one-NaN operand -> the other operand
 enum : uint32_t {
     Cap_Shader=1, Cap_Geometry=2, Cap_Int64=11, Cap_GroupNonUniform=61, Cap_GroupNonUniformVote=62,
-    Cap_GroupNonUniformQuad=68,
+    Cap_GroupNonUniformArithmetic=63, Cap_GroupNonUniformQuad=68,
     Addr_Logical=0, Mem_GLSL450=1, Exec_Vertex=0, Exec_Geometry=3, Exec_Fragment=4, Exec_GLCompute=5,
     EM_OriginUpperLeft=7, EM_DepthReplacing=12, EM_LocalSize=17, EM_Triangles=22,
     EM_OutputVertices=26, EM_OutputTriangleStrip=29,
@@ -88,7 +89,9 @@ enum : uint32_t {
     Dec_Centroid=16, Dec_Sample=17, Dec_Location=30, Dec_Binding=33,
     Dec_DescriptorSet=34, Dec_Offset=35,
     BI_Position=0, BI_FragCoord=15, BI_FragDepth=22, BI_WorkgroupId=26, BI_LocalInvocationId=27,
-    BI_GlobalInvocationId=28, BI_VertexIndex=42, BI_InstanceIndex=43,
+    BI_GlobalInvocationId=28, BI_SubgroupLocalInvocationId=41,
+    BI_VertexIndex=42, BI_InstanceIndex=43,
+    GroupOp_ExclusiveScan=2,
 };
 
 uint32_t fbits(float f) { uint32_t u; std::memcpy(&u, &f, 4); return u; }
@@ -214,6 +217,8 @@ struct SpirvCompute {
     bool     is_fragment=0;                          // true in the fragment shell (gates VINTRP interp)
     bool     is_compute=0;                            // true in the compute shell (gates LDS / s_barrier)
     bool     uses_barrier=0;                          // guest or synthesized workgroup barrier emitted
+    bool     declared_subgroup=0, declared_subgroup_arithmetic=0;
+    uint32_t v_subgroup_localid=0, t_ptr_in_u32=0;
     // Descriptor set for this stage's resources. VS and PS share ONE Vulkan pipeline, so they must NOT
     // reuse binding numbers within one set (both stages number their cbuf/texture from binding 2 -> a
     // set-0 collision made the descriptor layout invalid, corrupting the VS's reads -> degenerate
@@ -424,6 +429,41 @@ struct SpirvCompute {
         uint32_t result = id();
         put(code, Op_GroupNonUniformAny, {t_bool, result, uconst(Scope_Subgroup), value});
         return result;
+    }
+    uint32_t subgroup_local_id() {
+        if (!declared_subgroup) {
+            put(caps, Op_Capability, {Cap_GroupNonUniform});
+            declared_subgroup = true;
+        }
+        if (!v_subgroup_localid) {
+            t_ptr_in_u32 = id();
+            put(types, Op_TypePointer, {t_ptr_in_u32, SC_Input, t_u32});
+            v_subgroup_localid = id();
+            put(types, Op_Variable, {t_ptr_in_u32, v_subgroup_localid, SC_Input});
+            put(deco, Op_Decorate,
+                {v_subgroup_localid, Dec_BuiltIn, BI_SubgroupLocalInvocationId});
+            put(deco, Op_Decorate, {v_subgroup_localid, Dec_Flat});
+            iface.push_back(v_subgroup_localid);
+        }
+        uint32_t lane = id();
+        put(code, Op_Load, {t_u32, lane, v_subgroup_localid});
+        return lane;
+    }
+    uint32_t fragment_mbcnt(uint32_t mask_bit, uint32_t acc_bits, bool lo) {
+        if (!is_fragment) return 0;
+        if (!declared_subgroup_arithmetic) {
+            put(caps, Op_Capability, {Cap_GroupNonUniformArithmetic});
+            declared_subgroup_arithmetic = true;
+        }
+        const uint32_t lane = subgroup_local_id();
+        const uint32_t in_half = lo
+            ? ucmp(Op_ULessThan, lane, uconst(32))
+            : ucmp(Op_UGreaterThanEqual, lane, uconst(32));
+        const uint32_t selected = sel(land(mask_bit, in_half), uconst(1), uconst(0));
+        uint32_t prefix = id();
+        put(code, Op_GroupNonUniformIAdd,
+            {t_u32, prefix, uconst(Scope_Subgroup), GroupOp_ExclusiveScan, selected});
+        return ibin(Op_IAdd, acc_bits, prefix);
     }
     bool declared_subgroup_quad = false;
     uint32_t subgroup_quad_swap(uint32_t value, uint32_t direction) {
@@ -1966,7 +2006,8 @@ inline bool sreg_srt_range_tag(const RegState& rs, int base, uint32_t words, uin
 uint32_t inline_int_mask_bit(SpirvCompute& b, int value) {
     if (value == -1) return b.btrue();
     if (value == 0) return b.bfalse();
-    const uint32_t lane = b.ibin(Op_BitwiseAnd, b.linear_localid,
+    const uint32_t lane_id = b.is_fragment ? b.subgroup_local_id() : b.linear_localid;
+    const uint32_t lane = b.ibin(Op_BitwiseAnd, lane_id,
                                   b.uconst(b.wave_size - 1));
     const uint32_t bit = b.ibin(Op_BitwiseAnd, lane, b.uconst(31));
     const uint32_t high = b.ucmp(Op_UGreaterThanEqual, lane, b.uconst(32));
@@ -1982,7 +2023,8 @@ uint32_t inline_int_mask_bit(SpirvCompute& b, int value) {
 // operand. Lanes < 32 never contribute to the HI window, so their bit is 0.
 uint32_t inline_int_mask_bit_hi(SpirvCompute& b, int value) {
     if (value == 0) return b.bfalse();
-    const uint32_t lane = b.ibin(Op_BitwiseAnd, b.linear_localid, b.uconst(b.wave_size - 1));
+    const uint32_t lane_id = b.is_fragment ? b.subgroup_local_id() : b.linear_localid;
+    const uint32_t lane = b.ibin(Op_BitwiseAnd, lane_id, b.uconst(b.wave_size - 1));
     const uint32_t high = b.ucmp(Op_UGreaterThanEqual, lane, b.uconst(32));
     const uint32_t bit  = b.ibin(Op_BitwiseAnd, lane, b.uconst(31));   // lane-32 for lanes >= 32
     const uint32_t isset = b.ucmp(Op_INotEqual,
@@ -4743,16 +4785,20 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     if (in.sdst.value == 106 || in.sdst.value == 107) rs.vcc = cout_masked;
                     else if (in.sdst.kind == OperandKind::SGPR) rs.sreg_bool[in.sdst.value] = cout_masked;
                 }
-            } else if ((in.opcode == 0x365 || in.opcode == 0x366) && allow_wave && b.is_compute) {
+            } else if ((in.opcode == 0x365 || in.opcode == 0x366) && allow_wave &&
+                       (b.is_compute || b.is_fragment)) {
                 // v_mbcnt_lo/hi_u32_b32 (cross-lane): dst = src1 + count of lanes below this one whose mask
                 // bit (src0) is set, in the low/high 32. The per-lane "mask bit" comes from src0: EXEC
                 // (126/127) -> this lane's exec bool; inline -1 (all-ones) -> always set (mbcnt = lane
                 // index, the common "get my lane id" idiom, e.g. shader 037); inline 0 -> never; an SGPR
                 // pair -> that saved mask's bool. A general computed 32-bit mask VALUE isn't representable
-                // per-lane, so reject that. LDS+barriers (allow_wave => straight-line, barrier-uniform).
+                // per-lane, so reject that. Compute uses LDS+barriers at barrier-uniform sites;
+                // fragment uses a native exclusive subgroup sum with an enforced wave64 pipeline.
                 const uint32_t active = mbcnt_source_bit(
                     b, rs, in.src[0], in.opcode == 0x366);
-                if (active) vreg[in.dst.value] = b.mbcnt(active, val(in.src[1]), in.opcode == 0x365);
+                if (active) vreg[in.dst.value] = b.is_fragment
+                    ? b.fragment_mbcnt(active, val(in.src[1]), in.opcode == 0x365)
+                    : b.mbcnt(active, val(in.src[1]), in.opcode == 0x365);
                 else ok = false;
             } else if (in.opcode == 0x12F) {                          // v_cvt_pkrtz_f16_f32 = pack(s0->lo, s1->hi)
                 vreg[in.dst.value] = b.pack_half2x16_rtz(fv(0), fv(1)); // v_cvt_pkrtz VOP3: RTZ clamp (#452)
@@ -8324,6 +8370,21 @@ std::vector<uint32_t> recompile_fragment(const uint32_t* code, size_t dwords,
         return {};
     }
     return b.finish();
+}
+
+uint32_t fragment_spirv_required_subgroup_size(const std::vector<uint32_t>& spirv) {
+    if (spirv.size() < 5 || spirv[0] != 0x07230203u) return 0;
+    for (size_t offset = 5; offset < spirv.size();) {
+        const uint32_t instruction = spirv[offset];
+        const uint32_t words = instruction >> 16;
+        const uint32_t opcode = instruction & 0xffffu;
+        if (!words || words > spirv.size() - offset) return 0;
+        if (opcode == Op_Capability && words == 2 &&
+            spirv[offset + 1] == Cap_GroupNonUniformArithmetic)
+            return 64;
+        offset += words;
+    }
+    return 0;
 }
 
 std::vector<uint32_t> recompile_vertex(const uint32_t* code, size_t dwords,

--- a/prosper/src/gpu/rdna2_to_spirv.hpp
+++ b/prosper/src/gpu/rdna2_to_spirv.hpp
@@ -148,6 +148,10 @@ std::vector<uint32_t> recompile_fragment(const uint32_t* code, size_t dwords,
                                          uint32_t pcrel_dispatch_target = UINT32_MAX,
                                          const FragmentInterpolationLayout* interpolation = nullptr);
 
+// Recompiled fragment wave operations use native Vulkan subgroup instructions and therefore require
+// an exact 64-lane subgroup. Returns zero for ordinary modules and 64 for that explicit contract.
+uint32_t fragment_spirv_required_subgroup_size(const std::vector<uint32_t>& spirv);
+
 // Packed RGBA component-enable nibbles for the first realized color export to MRT0/MRT1. EXP.EN is
 // an attachment write mask, not a request to source disabled VGPRs; callers intersect this with the
 // fixed-function CB_TARGET_MASK/CB_SHADER_MASK before creating the Vulkan pipeline. This preserves

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -18,6 +18,7 @@
 #include <mutex>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -2181,14 +2182,20 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
              !(ctx.required_subgroup_size_stages & VK_SHADER_STAGE_FRAGMENT_BIT) ||
              !(ctx.subgroup_stages & VK_SHADER_STAGE_FRAGMENT_BIT) ||
              !(ctx.subgroup_operations & VK_SUBGROUP_FEATURE_ARITHMETIC_BIT))) {
-            std::fprintf(stderr,
-                         "[render] skip draw: fragment shader requires subgroup size %u "
-                         "(device range %u..%u required-stages=0x%x subgroup-stages=0x%x "
-                         "ops=0x%x control=%d)\n",
-                         required_fragment_subgroup_size, ctx.min_subgroup_size,
-                         ctx.max_subgroup_size, ctx.required_subgroup_size_stages,
-                         ctx.subgroup_stages, ctx.subgroup_operations,
-                         static_cast<int>(ctx.subgroup_size_control));
+            const uint64_t shader_key = bd.fs_identity
+                ? bd.fs_identity : hash_buffer_words(bd_fs.data(), bd_fs.size());
+            static std::mutex log_mutex;
+            static std::unordered_set<uint64_t> logged;
+            std::lock_guard<std::mutex> lock(log_mutex);
+            if (logged.insert(shader_key).second)
+                std::fprintf(stderr,
+                             "[render] skip draw: fragment shader requires subgroup size %u "
+                             "(device range %u..%u required-stages=0x%x subgroup-stages=0x%x "
+                             "ops=0x%x control=%d)\n",
+                             required_fragment_subgroup_size, ctx.min_subgroup_size,
+                             ctx.max_subgroup_size, ctx.required_subgroup_size_stages,
+                             ctx.subgroup_stages, ctx.subgroup_operations,
+                             static_cast<int>(ctx.subgroup_size_control));
             continue;
         }
         if (backend_trace) {

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -421,6 +421,11 @@ struct RenderVkCtx {
     VkDeviceSize storage_buffer_alignment = 1;
     bool aniso_enabled = false; float max_aniso_limit = 1.0f;
     bool logic_op_enabled = false; bool ok = false;
+    bool subgroup_size_control = false;
+    uint32_t min_subgroup_size = 0, max_subgroup_size = 0;
+    VkShaderStageFlags required_subgroup_size_stages = 0;
+    VkShaderStageFlags subgroup_stages = 0;
+    VkSubgroupFeatureFlags subgroup_operations = 0;
 };
 inline const RenderVkCtx& render_vk_ctx() {
     static RenderVkCtx c = [] {
@@ -474,6 +479,12 @@ inline const RenderVkCtx& render_vk_ctx() {
         // portability-subset extensions coexist.
         std::vector<const char*> dev_exts;
         VkPhysicalDeviceImageRobustnessFeaturesEXT irf{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_ROBUSTNESS_FEATURES_EXT};
+        VkPhysicalDeviceSubgroupSizeControlFeatures subgroup_features{
+            VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_FEATURES};
+        VkPhysicalDeviceSubgroupSizeControlProperties subgroup_properties{
+            VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_PROPERTIES};
+        VkPhysicalDeviceSubgroupProperties subgroup_core_properties{
+            VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_PROPERTIES};
         { uint32_t ne = 0; vkEnumerateDeviceExtensionProperties(r.phys, nullptr, &ne, nullptr);
           std::vector<VkExtensionProperties> de(ne);
           vkEnumerateDeviceExtensionProperties(r.phys, nullptr, &ne, de.data());
@@ -481,7 +492,33 @@ inline const RenderVkCtx& render_vk_ctx() {
               if (!strcmp(de[i].extensionName, "VK_EXT_image_robustness")) {
                   VkPhysicalDeviceFeatures2 f2{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2};
                   f2.pNext = &irf; vkGetPhysicalDeviceFeatures2(r.phys, &f2);
-                  if (irf.robustImageAccess) { dci.pNext = &irf; dev_exts.push_back("VK_EXT_image_robustness"); }
+                  if (irf.robustImageAccess) {
+                      irf.pNext = const_cast<void*>(dci.pNext);
+                      dci.pNext = &irf;
+                      dev_exts.push_back("VK_EXT_image_robustness");
+                  }
+              }
+              if (!strcmp(de[i].extensionName, VK_EXT_SUBGROUP_SIZE_CONTROL_EXTENSION_NAME)) {
+                  VkPhysicalDeviceFeatures2 f2{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2};
+                  f2.pNext = &subgroup_features;
+                  vkGetPhysicalDeviceFeatures2(r.phys, &f2);
+                  if (subgroup_features.subgroupSizeControl) {
+                      VkPhysicalDeviceProperties2 p2{
+                          VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2};
+                      p2.pNext = &subgroup_core_properties;
+                      subgroup_core_properties.pNext = &subgroup_properties;
+                      vkGetPhysicalDeviceProperties2(r.phys, &p2);
+                      subgroup_features.pNext = const_cast<void*>(dci.pNext);
+                      dci.pNext = &subgroup_features;
+                      dev_exts.push_back(VK_EXT_SUBGROUP_SIZE_CONTROL_EXTENSION_NAME);
+                      r.subgroup_size_control = true;
+                      r.min_subgroup_size = subgroup_properties.minSubgroupSize;
+                      r.max_subgroup_size = subgroup_properties.maxSubgroupSize;
+                      r.required_subgroup_size_stages =
+                          subgroup_properties.requiredSubgroupSizeStages;
+                      r.subgroup_stages = subgroup_core_properties.supportedStages;
+                      r.subgroup_operations = subgroup_core_properties.supportedOperations;
+                  }
               }
 #ifdef __APPLE__
               // Spec-mandated: must be enabled when advertised (MoltenVK always advertises it).
@@ -2135,6 +2172,25 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         const std::vector<uint32_t>& bd_gs = bd.gs_words();
         const std::vector<uint32_t>& bd_fs = bd.fs_words();
         DV& v = dv[di];
+        const uint32_t required_fragment_subgroup_size =
+            prosper::gpu::fragment_spirv_required_subgroup_size(bd_fs);
+        if (required_fragment_subgroup_size &&
+            (!ctx.subgroup_size_control ||
+             required_fragment_subgroup_size < ctx.min_subgroup_size ||
+             required_fragment_subgroup_size > ctx.max_subgroup_size ||
+             !(ctx.required_subgroup_size_stages & VK_SHADER_STAGE_FRAGMENT_BIT) ||
+             !(ctx.subgroup_stages & VK_SHADER_STAGE_FRAGMENT_BIT) ||
+             !(ctx.subgroup_operations & VK_SUBGROUP_FEATURE_ARITHMETIC_BIT))) {
+            std::fprintf(stderr,
+                         "[render] skip draw: fragment shader requires subgroup size %u "
+                         "(device range %u..%u required-stages=0x%x subgroup-stages=0x%x "
+                         "ops=0x%x control=%d)\n",
+                         required_fragment_subgroup_size, ctx.min_subgroup_size,
+                         ctx.max_subgroup_size, ctx.required_subgroup_size_stages,
+                         ctx.subgroup_stages, ctx.subgroup_operations,
+                         static_cast<int>(ctx.subgroup_size_control));
+            continue;
+        }
         if (backend_trace) {
             fprintf(stderr,
                     "[backend-trace] draw=%zu/%zu begin extent=%ux%u vs=%zu gs=%zu fs=%zu "
@@ -2178,6 +2234,8 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
             v.icount = (uint32_t)bd.indices.size();
         }
         VkPipelineShaderStageCreateInfo st[3]{};
+        VkPipelineShaderStageRequiredSubgroupSizeCreateInfo required_fragment_subgroup{
+            VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_REQUIRED_SUBGROUP_SIZE_CREATE_INFO};
         st[0] = {VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO}; st[0].stage = VK_SHADER_STAGE_VERTEX_BIT; st[0].module = v.vs; st[0].pName = "main";
         const uint32_t fragment_stage_index = bd_gs.empty() ? 1u : 2u;
         if (!bd_gs.empty()) {
@@ -2188,6 +2246,10 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         st[fragment_stage_index].stage = VK_SHADER_STAGE_FRAGMENT_BIT;
         st[fragment_stage_index].module = v.fs;
         st[fragment_stage_index].pName = "main";
+        if (required_fragment_subgroup_size) {
+            required_fragment_subgroup.requiredSubgroupSize = required_fragment_subgroup_size;
+            st[fragment_stage_index].pNext = &required_fragment_subgroup;
+        }
         VkPipelineVertexInputStateCreateInfo vin{VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO};
         VkPipelineInputAssemblyStateCreateInfo ia{VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO};
         ia.topology = ps ? (VkPrimitiveTopology)ps->topology : VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
@@ -2807,7 +2869,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                 memcpy(&word, &value, sizeof word);
                 append(word);
             };
-            append(6); // key schema version (framebuffer logic op)
+            append(7); // key schema version (fragment required subgroup size)
             append(W); append(H); append(color_count); append(static_cast<uint32_t>(FMT));
             append(static_cast<uint32_t>(FMT1)); append(use_ds); append(static_cast<uint32_t>(DFMT));
             const bool exact_shader_identities = bd.vs_identity && bd.fs_identity;
@@ -2827,6 +2889,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                 append(static_cast<uint32_t>(bd_fs.size()));
                 for (uint32_t word : bd_fs) append(word);
             }
+            append(required_fragment_subgroup_size);
             append(static_cast<uint32_t>(bd_gs.size()));
             for (uint32_t word : bd_gs) append(word);
             append(v.use_desc); append(v.n_sets);

--- a/prosper/tests/test_recompiled_fragment.cpp
+++ b/prosper/tests/test_recompiled_fragment.cpp
@@ -41,6 +41,37 @@ int main() {
     CHECK(c[1] > 0x80 && c[0] < 0x40 && c[2] < 0x40, "center pixel is GREEN (from the recompiled shader)");
     CHECK(k[2] > 0x80 && k[0] < 0x40 && k[1] < 0x40, "corner pixel is the BLUE clear");
 
+    // Fragment MBCNT is a real cross-lane operation. The lowering uses a native subgroup exclusive
+    // sum and marks the module as requiring an exact 64-lane subgroup. RADV can
+    // enforce that contract; llvmpipe is fixed at 8 and must reject the draw rather than execute
+    // silently wrong wave semantics.
+    const uint32_t wave_ps[] = {
+        0xD7650004u, 0x000100C1u, // v_mbcnt_lo_u32_b32 v4, -1, 0
+        0xD7660004u, 0x000208C1u, // v_mbcnt_hi_u32_b32 v4, -1, v4
+        0x7E000280u, 0x7E0202F2u, 0x7E040280u, 0x7E0602F2u,
+        0xF800180Fu, 0x03020100u, 0xBF810000u,
+    };
+    std::vector<uint32_t> wave_frag = recompile_fragment(wave_ps, std::size(wave_ps));
+    CHECK(!wave_frag.empty(), "recompiled fragment MBCNT through native subgroup exclusive sum");
+    CHECK(fragment_spirv_required_subgroup_size(wave_frag) == 64,
+          "fragment MBCNT module advertises its exact wave64 pipeline requirement");
+    const auto& wave_ctx = prosper::test::render_vk_ctx();
+    const bool supports_fragment_wave64 = wave_ctx.subgroup_size_control &&
+        wave_ctx.min_subgroup_size <= 64 && wave_ctx.max_subgroup_size >= 64 &&
+        (wave_ctx.required_subgroup_size_stages & VK_SHADER_STAGE_FRAGMENT_BIT) &&
+        (wave_ctx.subgroup_stages & VK_SHADER_STAGE_FRAGMENT_BIT) &&
+        (wave_ctx.subgroup_operations & VK_SUBGROUP_FEATURE_ARITHMETIC_BIT);
+    std::vector<uint8_t> wave_px = prosper::test::render_triangle_rgba(vert, wave_frag, W, H);
+    const bool wave_rendered = wave_px.size() == static_cast<size_t>(W) * H * 4;
+    const uint8_t* wave_center = wave_rendered
+        ? &wave_px[((static_cast<size_t>(H) / 2) * W + W / 2) * 4] : nullptr;
+    CHECK(supports_fragment_wave64
+              ? wave_rendered && wave_center[1] > 0x80 && wave_center[2] < 0x40
+              : wave_rendered && wave_center[2] > 0x80 && wave_center[1] < 0x40,
+          supports_fragment_wave64
+              ? "device enforced wave64 and executed fragment MBCNT"
+              : "device without fragment wave64 skipped MBCNT draw fail-visible");
+
     // Astro Bot's early foreground pass exports only R/G (EN=0x3). AMD's EXP contract preserves
     // disabled destination components; the live executor therefore intersects EN with the Vulkan
     // pipeline write mask. Prove both the exact rejected shader now recompiles and a partial draw


### PR DESCRIPTION
## Summary

- lower fragment `v_mbcnt_lo/hi_u32_b32` with a native Vulkan subgroup exclusive sum
- mark those generated fragment modules as requiring an exact 64-lane subgroup
- enable `VK_EXT_subgroup_size_control` and attach the required subgroup size to fragment pipeline creation
- reject the draw fail-visibly when the device cannot provide wave64 (llvmpipe is fixed at 8)
- cover both the RADV execution path and llvmpipe rejection path

## Why

Astro Bot's title pixel shader `0x50054ab00` begins its wave-compaction sequence with MBCNT. The existing implementation was exact only for compute because it used workgroup scratch and barriers; fragment shaders have no workgroup in which to reproduce that model.

On the available RADV device, Vulkan reports fragment subgroup-size control with a supported range of 32–64. Native subgroup arithmetic is therefore exact when the pipeline explicitly requires 64 lanes. The llvmpipe CI/fallback device reports a fixed subgroup size of 8, so it must skip this shader instead of silently computing incorrect prefix counts.

This PR intentionally does not lower the coupled GDS append. Live Astro advances from the former PC 3 MBCNT rejection to the exact next boundary, PC 7 `ds_append`; device-global append persistence will be a separate focused PR under #1076.

## Validation

- generated fragment module: `spirv-val --target-env vulkan1.1`
- focused `test_recompiled_fragment` on AMD Radeon 8060S / RADV: wave64 enforced and MBCNT pipeline executes
- focused `test_recompiled_fragment` with llvmpipe ICD: unsupported wave64 draw is skipped fail-visibly and the guard passes
- full build
- full CTest with Messenger fixture: 121/121 passed
- hardware snapshot matrix: Messenger, Evergate, Dead Cells gameplay, and Blasphemous 2 gameplay all passed
- live Astro scripted route reached `title_controller_ship` and `intro_next`; `0x50054ab00` first rejects at PC 7 `ds_append`, with no PC 3 MBCNT rejection

Part of #1076
