### PR TITLE
scripts(blasphemous2): title-screen idle route for audio observation

### DIFF
--- a/prosper/scripts/blasphemous2/README.md
+++ b/prosper/scripts/blasphemous2/README.md
@@ -71,3 +71,26 @@ The title's optional `libfmodstudio.prx` and `libfmod.prx` must be prelinked as
 described by #638/#640. A run that stops before the first studio logo has not
 reached the #641 marker fix; a run that faults at guest `eboot+0x11f79d0` has not
 picked up the #642 URI parser.
+
+## Title-screen route (audio observation)
+
+`title-screen-idle.pad` presses Cross once to dismiss the intro, then sends **no further input** so the
+game rests on the title screen and its ambience/music soundtrack can start (it begins a few seconds
+after the title appears). The `reach-first-gameplay.pad` route deliberately presses Cross every three
+seconds and drives straight past this state, so the title soundtrack never plays under it — use the
+idle route whenever you are observing title/menu audio.
+
+Audio is verifiable without a human listening: `PROSPER_AUDIO_DUMP=<path>` records the final mixed
+output, so a run can be asserted on level/coverage.
+
+```bash
+PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 \
+PROSPER_VULKAN_LIB=libvulkan.so.1 PROSPER_AUDIO_DUMP=/tmp/t.raw \
+PROSPER_PAD_SCRIPT=@scripts/blasphemous2/title-screen-idle.pad \
+  ./build-linux/prosper-app --dump <PPSA13579-app0>
+# measure per-second peak/coverage of /tmp/t.raw.port16.raw
+```
+
+A healthy title screen holds a sustained non-zero level (coverage >80%). As of 2026-07-20 it does not:
+frame rate starves FMOD's per-frame update so streaming voices cannot be fed, leaving long silences
+(#1080, blocked on the performance issue #1082).

--- a/prosper/scripts/blasphemous2/title-screen-idle.pad
+++ b/prosper/scripts/blasphemous2/title-screen-idle.pad
@@ -1,0 +1,6 @@
+# Blasphemous 2 — reach the TITLE SCREEN and idle there.
+# One Cross press dismisses the intro/logo, then NO further input so the title screen's
+# ambience/music soundtrack can start (it begins a few seconds after the title appears).
+# Used for audio observation; the reach-first-gameplay route deliberately presses through
+# this state and never lets the title soundtrack play.
+1-2:cross


### PR DESCRIPTION
## Why

`reach-first-gameplay.pad` presses Cross every three seconds, which drives straight past the title screen. The title/menu soundtrack starts a few seconds *after* the title appears, so it never gets a chance to play under that route — which is why the missing-music symptom in #1080 was initially hard to observe.

`title-screen-idle.pad` presses Cross **once** to dismiss the intro and then sends no further input, resting on the title screen.

## Also documents: audio is verifiable without a human listening

`PROSPER_AUDIO_DUMP=<path>` records the **final mixed output**, so a run can be asserted on level/coverage rather than by ear. A healthy title screen holds a sustained non-zero level (coverage >80%).

## What this route established (#1080)

Using it, the missing Blasphemous 2 music/ambience is **not an audio defect** — it is starvation from low frame rate (#1082). Same route, same build, only `PROSPER_RENDER_EVERY=20` added so the guest isn't blocked on rendering:

| run | title ambience decoded | output coverage |
|---|---|---|
| normal (~1–10 fps) | 22.6 s | **21.6%** |
| render-throttled | 63.4 s | **86.4%** |

The decoder is healthy throughout (full-scale PCM, 0 errors); FMOD's per-frame `System::update()` simply cannot feed a streaming voice at ~1 fps. Short one-shot SFX are unaffected, matching the reported "SFX perfect, music/ambience missing."

## Scope

Docs/scripts only — **no code change**, no behavior change, nothing to regress. The `PROSPER_RENDER_EVERY` throttle above is used strictly as a diagnostic A/B (per the charter it is not for interactive or acceptance runs); the committed route itself uses faithful defaults.