### PR TITLE
gpu: lower fragment GDS wave allocation

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -54,8 +54,7 @@ enum : uint32_t {
     Op_Phi=245, Op_LoopMerge=246,
     Op_SelectionMerge=247, Op_Label=248, Op_Branch=249, Op_BranchConditional=250, Op_Switch=251,
     Op_EmitVertex=218, Op_EndPrimitive=219,
-    Op_Kill=252, Op_Return=253, Op_GroupNonUniformElect=333, Op_GroupNonUniformAny=335,
-    Op_GroupNonUniformBroadcastFirst=338,
+    Op_Kill=252, Op_Return=253, Op_GroupNonUniformAny=335,
     Op_GroupNonUniformIAdd=349,
     Op_GroupNonUniformQuadSwap=366,
 };
@@ -67,7 +66,7 @@ enum : uint32_t { Glsl_FAbs=4, Glsl_RoundEven=2, Glsl_Trunc=3, Glsl_Floor=8, Gls
                   Glsl_NMin=79, Glsl_NMax=80 };   // NaN-aware min/max: one-NaN operand -> the other operand
 enum : uint32_t {
     Cap_Shader=1, Cap_Geometry=2, Cap_Int64=11, Cap_GroupNonUniform=61, Cap_GroupNonUniformVote=62,
-    Cap_GroupNonUniformArithmetic=63, Cap_GroupNonUniformBallot=64, Cap_GroupNonUniformQuad=68,
+    Cap_GroupNonUniformArithmetic=63, Cap_GroupNonUniformQuad=68,
     Addr_Logical=0, Mem_GLSL450=1, Exec_Vertex=0, Exec_Geometry=3, Exec_Fragment=4, Exec_GLCompute=5,
     EM_OriginUpperLeft=7, EM_DepthReplacing=12, EM_LocalSize=17, EM_Triangles=22,
     EM_OutputVertices=26, EM_OutputTriangleStrip=29,
@@ -219,7 +218,7 @@ struct SpirvCompute {
     bool     is_fragment=0;                          // true in the fragment shell (gates VINTRP interp)
     bool     is_compute=0;                            // true in the compute shell (gates LDS / s_barrier)
     bool     uses_barrier=0;                          // guest or synthesized workgroup barrier emitted
-    bool     declared_subgroup=0, declared_subgroup_arithmetic=0, declared_subgroup_ballot=0;
+    bool     declared_subgroup=0, declared_subgroup_arithmetic=0;
     uint32_t v_subgroup_localid=0, t_ptr_in_u32=0;
     uint32_t v_helper_invocation=0, t_ptr_in_bool=0;
     uint32_t v_internal_gds=0, t_ptr_gds_u32=0;
@@ -514,17 +513,15 @@ struct SpirvCompute {
             put(caps, Op_Capability, {Cap_GroupNonUniformArithmetic});
             declared_subgroup_arithmetic = true;
         }
-        if (!declared_subgroup_ballot) {
-            put(caps, Op_Capability, {Cap_GroupNonUniformBallot});
-            declared_subgroup_ballot = true;
-        }
         const uint32_t active_bit = land(exec_bit, logical_not(helper_invocation()));
         const uint32_t contribution = sel(active_bit, uconst(1), uconst(0));
         uint32_t count = id();
         put(code, Op_GroupNonUniformIAdd,
             {t_u32, count, uconst(Scope_Subgroup), GroupOp_Reduce, contribution});
-        uint32_t elected = id();
-        put(code, Op_GroupNonUniformElect, {t_bool, elected, uconst(Scope_Subgroup)});
+        uint32_t prefix = id();
+        put(code, Op_GroupNonUniformIAdd,
+            {t_u32, prefix, uconst(Scope_Subgroup), GroupOp_ExclusiveScan, contribution});
+        const uint32_t elected = land(active_bit, ucmp(Op_IEqual, prefix, uconst(0)));
         const uint32_t entry = cur_block, leader = id(), merge = id();
         put(code, Op_SelectionMerge, {merge, 0});
         put(code, Op_BranchConditional, {elected, leader, merge});
@@ -542,8 +539,8 @@ struct SpirvCompute {
         const uint32_t local_old = emit_phi_2way(
             t_u32, leader_old, leader_end, uconst(0), entry);
         uint32_t old = id();
-        put(code, Op_GroupNonUniformBroadcastFirst,
-            {t_u32, old, uconst(Scope_Subgroup), local_old});
+        put(code, Op_GroupNonUniformIAdd,
+            {t_u32, old, uconst(Scope_Subgroup), GroupOp_Reduce, local_old});
         return old;
     }
     bool declared_subgroup_quad = false;
@@ -5995,7 +5992,9 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 auto m0 = rs.sreg.find(124);
                 if (!allow_wave || m0 == rs.sreg.end()) { ok = false; return true; }
                 const uint32_t base = b.ibin(Op_BitwiseAnd, m0->second, b.uconst(0xFFFFu));
-                const uint32_t byte_addr = b.ibin(Op_IAdd, base, b.uconst(in.literal));
+                const uint32_t byte_addr = b.ibin(
+                    Op_BitwiseAnd, b.ibin(Op_IAdd, base, b.uconst(in.literal)),
+                    b.uconst(0xFFFFu));
                 const uint32_t idx = b.ibin(Op_ShiftRightLogical, byte_addr, b.uconst(2));
                 const uint32_t old = vreg_old(b, rs, in.dst.value);
                 if (b.is_fragment && in.ds_gds) {

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -54,7 +54,8 @@ enum : uint32_t {
     Op_Phi=245, Op_LoopMerge=246,
     Op_SelectionMerge=247, Op_Label=248, Op_Branch=249, Op_BranchConditional=250, Op_Switch=251,
     Op_EmitVertex=218, Op_EndPrimitive=219,
-    Op_Kill=252, Op_Return=253, Op_GroupNonUniformAny=335,
+    Op_Kill=252, Op_Return=253, Op_GroupNonUniformElect=333, Op_GroupNonUniformAny=335,
+    Op_GroupNonUniformBroadcastFirst=338,
     Op_GroupNonUniformIAdd=349,
     Op_GroupNonUniformQuadSwap=366,
 };
@@ -66,7 +67,7 @@ enum : uint32_t { Glsl_FAbs=4, Glsl_RoundEven=2, Glsl_Trunc=3, Glsl_Floor=8, Gls
                   Glsl_NMin=79, Glsl_NMax=80 };   // NaN-aware min/max: one-NaN operand -> the other operand
 enum : uint32_t {
     Cap_Shader=1, Cap_Geometry=2, Cap_Int64=11, Cap_GroupNonUniform=61, Cap_GroupNonUniformVote=62,
-    Cap_GroupNonUniformArithmetic=63, Cap_GroupNonUniformQuad=68,
+    Cap_GroupNonUniformArithmetic=63, Cap_GroupNonUniformBallot=64, Cap_GroupNonUniformQuad=68,
     Addr_Logical=0, Mem_GLSL450=1, Exec_Vertex=0, Exec_Geometry=3, Exec_Fragment=4, Exec_GLCompute=5,
     EM_OriginUpperLeft=7, EM_DepthReplacing=12, EM_LocalSize=17, EM_Triangles=22,
     EM_OutputVertices=26, EM_OutputTriangleStrip=29,
@@ -88,10 +89,11 @@ enum : uint32_t {
     Dec_Block=2, Dec_ArrayStride=6, Dec_BuiltIn=11, Dec_NoPerspective=13, Dec_Flat=14,
     Dec_Centroid=16, Dec_Sample=17, Dec_Location=30, Dec_Binding=33,
     Dec_DescriptorSet=34, Dec_Offset=35,
-    BI_Position=0, BI_FragCoord=15, BI_FragDepth=22, BI_WorkgroupId=26, BI_LocalInvocationId=27,
+    BI_Position=0, BI_FragCoord=15, BI_FragDepth=22, BI_HelperInvocation=23,
+    BI_WorkgroupId=26, BI_LocalInvocationId=27,
     BI_GlobalInvocationId=28, BI_SubgroupLocalInvocationId=41,
     BI_VertexIndex=42, BI_InstanceIndex=43,
-    GroupOp_ExclusiveScan=2,
+    GroupOp_Reduce=0, GroupOp_ExclusiveScan=2,
 };
 
 uint32_t fbits(float f) { uint32_t u; std::memcpy(&u, &f, 4); return u; }
@@ -217,8 +219,10 @@ struct SpirvCompute {
     bool     is_fragment=0;                          // true in the fragment shell (gates VINTRP interp)
     bool     is_compute=0;                            // true in the compute shell (gates LDS / s_barrier)
     bool     uses_barrier=0;                          // guest or synthesized workgroup barrier emitted
-    bool     declared_subgroup=0, declared_subgroup_arithmetic=0;
+    bool     declared_subgroup=0, declared_subgroup_arithmetic=0, declared_subgroup_ballot=0;
     uint32_t v_subgroup_localid=0, t_ptr_in_u32=0;
+    uint32_t v_helper_invocation=0, t_ptr_in_bool=0;
+    uint32_t v_internal_gds=0, t_ptr_gds_u32=0;
     // Descriptor set for this stage's resources. VS and PS share ONE Vulkan pipeline, so they must NOT
     // reuse binding numbers within one set (both stages number their cbuf/texture from binding 2 -> a
     // set-0 collision made the descriptor layout invalid, corrupting the VS's reads -> degenerate
@@ -467,6 +471,80 @@ struct SpirvCompute {
         put(code, Op_GroupNonUniformIAdd,
             {t_u32, prefix, uconst(Scope_Subgroup), GroupOp_ExclusiveScan, selected});
         return ibin(Op_IAdd, acc_bits, prefix);
+    }
+    uint32_t helper_invocation() {
+        if (!v_helper_invocation) {
+            t_ptr_in_bool = id();
+            put(types, Op_TypePointer, {t_ptr_in_bool, SC_Input, t_bool});
+            v_helper_invocation = id();
+            put(types, Op_Variable, {t_ptr_in_bool, v_helper_invocation, SC_Input});
+            put(deco, Op_Decorate,
+                {v_helper_invocation, Dec_BuiltIn, BI_HelperInvocation});
+            iface.push_back(v_helper_invocation);
+        }
+        uint32_t result = id();
+        put(code, Op_Load, {t_bool, result, v_helper_invocation});
+        return result;
+    }
+    void declare_internal_gds() {
+        if (v_internal_gds) return;
+        uint32_t runtime_array = id(), block = id(), block_ptr = id();
+        put(deco, Op_Decorate, {runtime_array, Dec_ArrayStride, 4});
+        put(deco, Op_MemberDecorate, {block, 0, Dec_Offset, 0});
+        put(deco, Op_Decorate, {block, Dec_Block});
+        put(types, Op_TypeRuntimeArray, {runtime_array, t_u32});
+        put(types, Op_TypeStruct, {block, runtime_array});
+        put(types, Op_TypePointer, {block_ptr, SC_StorageBuffer, block});
+        t_ptr_gds_u32 = id();
+        put(types, Op_TypePointer, {t_ptr_gds_u32, SC_StorageBuffer, t_u32});
+        v_internal_gds = id();
+        put(types, Op_Variable, {block_ptr, v_internal_gds, SC_StorageBuffer});
+        put(deco, Op_Decorate, {v_internal_gds, Dec_DescriptorSet, 1});
+        put(deco, Op_Decorate, {v_internal_gds, Dec_Binding, 0});
+    }
+    // Fragment GDS append/consume is one device-global atomic per hardware wave. Helper
+    // invocations participate in the subgroup operations but cannot consume guest counter slots.
+    uint32_t fragment_gds_append(uint32_t index, uint32_t exec_bit, bool consume) {
+        declare_internal_gds();
+        if (!declared_subgroup) {
+            put(caps, Op_Capability, {Cap_GroupNonUniform});
+            declared_subgroup = true;
+        }
+        if (!declared_subgroup_arithmetic) {
+            put(caps, Op_Capability, {Cap_GroupNonUniformArithmetic});
+            declared_subgroup_arithmetic = true;
+        }
+        if (!declared_subgroup_ballot) {
+            put(caps, Op_Capability, {Cap_GroupNonUniformBallot});
+            declared_subgroup_ballot = true;
+        }
+        const uint32_t active_bit = land(exec_bit, logical_not(helper_invocation()));
+        const uint32_t contribution = sel(active_bit, uconst(1), uconst(0));
+        uint32_t count = id();
+        put(code, Op_GroupNonUniformIAdd,
+            {t_u32, count, uconst(Scope_Subgroup), GroupOp_Reduce, contribution});
+        uint32_t elected = id();
+        put(code, Op_GroupNonUniformElect, {t_bool, elected, uconst(Scope_Subgroup)});
+        const uint32_t entry = cur_block, leader = id(), merge = id();
+        put(code, Op_SelectionMerge, {merge, 0});
+        put(code, Op_BranchConditional, {elected, leader, merge});
+        put(code, Op_Label, {leader}); cur_block = leader;
+        uint32_t pointer = id();
+        putv(code, Op_AccessChain,
+             {t_ptr_gds_u32, pointer, v_internal_gds, uconst(0), index});
+        uint32_t leader_old = id();
+        put(code, consume ? Op_AtomicISub : Op_AtomicIAdd,
+            {t_u32, leader_old, pointer, uconst(Scope_Device),
+             uconst(MemSem_UniformAcqRel), count});
+        const uint32_t leader_end = cur_block;
+        put(code, Op_Branch, {merge});
+        put(code, Op_Label, {merge}); cur_block = merge;
+        const uint32_t local_old = emit_phi_2way(
+            t_u32, leader_old, leader_end, uconst(0), entry);
+        uint32_t old = id();
+        put(code, Op_GroupNonUniformBroadcastFirst,
+            {t_u32, old, uconst(Scope_Subgroup), local_old});
+        return old;
     }
     bool declared_subgroup_quad = false;
     uint32_t subgroup_quad_swap(uint32_t value, uint32_t direction) {
@@ -5913,6 +5991,26 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 predicate_write(b, rs, in.dst.value, old);
                 return true;
             }
+            if (in.opcode == 0x3d || in.opcode == 0x3e) {
+                auto m0 = rs.sreg.find(124);
+                if (!allow_wave || m0 == rs.sreg.end()) { ok = false; return true; }
+                const uint32_t base = b.ibin(Op_BitwiseAnd, m0->second, b.uconst(0xFFFFu));
+                const uint32_t byte_addr = b.ibin(Op_IAdd, base, b.uconst(in.literal));
+                const uint32_t idx = b.ibin(Op_ShiftRightLogical, byte_addr, b.uconst(2));
+                const uint32_t old = vreg_old(b, rs, in.dst.value);
+                if (b.is_fragment && in.ds_gds) {
+                    rs.vreg[in.dst.value] = b.fragment_gds_append(
+                        idx, rs.exec, in.opcode == 0x3d);
+                } else if (b.is_compute) {
+                    b.declare_lds();
+                    rs.vreg[in.dst.value] = b.wave_append(
+                        idx, rs.exec, in.opcode == 0x3d);
+                } else {
+                    ok = false; return true;
+                }
+                predicate_write(b, rs, in.dst.value, old);
+                return true;
+            }
             // LDS (workgroup shared memory), compute-only. Byte address = ADDR VGPR + instruction
             // offset; the backing store is dword-indexed. gfx10 ds_write2_b64 carries two independent
             // 8-bit offsets in units of 64-bit elements, while ds_write_b64 uses the ordinary 16-bit
@@ -5929,22 +6027,6 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             }
             b.declare_lds();
             auto vread = [&](int r){ auto it = rs.vreg.find(r); return it == rs.vreg.end() ? b.uconst(0) : it->second; };
-            if (in.opcode == 0x3d || in.opcode == 0x3e) { // ds_consume/append: wave-wide LDS counter allocation
-                // AMD RDNA2 ISA 12.13: address = M0[15:0] + byte offset; atomically subtract/add
-                // popcount(EXEC) once for the wave and broadcast the pre-op value to valid lanes.
-                auto m0 = rs.sreg.find(124);
-                if (!allow_wave || m0 == rs.sreg.end() ||
-                    (b.wave_size != 32 && b.wave_size != 64)) {
-                    ok = false; return true;
-                }
-                const uint32_t base = b.ibin(Op_BitwiseAnd, m0->second, b.uconst(0xFFFFu));
-                const uint32_t byte_addr = b.ibin(Op_IAdd, base, b.uconst(in.literal));
-                const uint32_t idx = b.ibin(Op_ShiftRightLogical, byte_addr, b.uconst(2));
-                const uint32_t old = vreg_old(b, rs, in.dst.value);
-                rs.vreg[in.dst.value] = b.wave_append(idx, rs.exec, in.opcode == 0x3d);
-                predicate_write(b, rs, in.dst.value, old);
-                return true;
-            }
             if (in.opcode == 0x4e) {                    // ds_write2_b64: two VGPR pairs at offset0/offset1
                 const uint32_t base = b.ibin(Op_ShiftRightLogical, vread(in.src[0].value), b.uconst(2));
                 const uint32_t idx0 = b.ibin(Op_IAdd, base, b.uconst((in.literal & 0xFFu) * 2u));
@@ -8388,6 +8470,29 @@ uint32_t fragment_spirv_required_subgroup_size(const std::vector<uint32_t>& spir
         offset += words;
     }
     return 0;
+}
+
+bool fragment_spirv_uses_internal_gds(const std::vector<uint32_t>& spirv) {
+    if (spirv.size() < 5 || spirv[0] != 0x07230203u) return false;
+    std::unordered_map<uint32_t, uint32_t> sets, bindings;
+    for (size_t offset = 5; offset < spirv.size();) {
+        const uint32_t instruction = spirv[offset];
+        const uint32_t words = instruction >> 16;
+        const uint32_t opcode = instruction & 0xffffu;
+        if (!words || words > spirv.size() - offset) return false;
+        if (opcode == Op_Decorate && words == 4) {
+            if (spirv[offset + 2] == Dec_DescriptorSet)
+                sets[spirv[offset + 1]] = spirv[offset + 3];
+            else if (spirv[offset + 2] == Dec_Binding)
+                bindings[spirv[offset + 1]] = spirv[offset + 3];
+        }
+        offset += words;
+    }
+    for (const auto& [variable, set] : sets) {
+        auto binding = bindings.find(variable);
+        if (set == 1 && binding != bindings.end() && binding->second == 0) return true;
+    }
+    return false;
 }
 
 std::vector<uint32_t> recompile_vertex(const uint32_t* code, size_t dwords,

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -465,7 +465,11 @@ struct SpirvCompute {
         const uint32_t in_half = lo
             ? ucmp(Op_ULessThan, lane, uconst(32))
             : ucmp(Op_UGreaterThanEqual, lane, uconst(32));
-        const uint32_t selected = sel(land(mask_bit, in_half), uconst(1), uconst(0));
+        // Helper invocations execute subgroup operations under WQM but are not guest lanes and
+        // cannot own GDS allocation slots. Excluding them here keeps MBCNT's prefix exactly aligned
+        // with fragment GDS append/consume's non-helper population.
+        const uint32_t guest_lane = land(mask_bit, logical_not(helper_invocation()));
+        const uint32_t selected = sel(land(guest_lane, in_half), uconst(1), uconst(0));
         uint32_t prefix = id();
         put(code, Op_GroupNonUniformIAdd,
             {t_u32, prefix, uconst(Scope_Subgroup), GroupOp_ExclusiveScan, selected});

--- a/prosper/src/gpu/rdna2_to_spirv.hpp
+++ b/prosper/src/gpu/rdna2_to_spirv.hpp
@@ -151,6 +151,7 @@ std::vector<uint32_t> recompile_fragment(const uint32_t* code, size_t dwords,
 // Recompiled fragment wave operations use native Vulkan subgroup instructions and therefore require
 // an exact 64-lane subgroup. Returns zero for ordinary modules and 64 for that explicit contract.
 uint32_t fragment_spirv_required_subgroup_size(const std::vector<uint32_t>& spirv);
+bool fragment_spirv_uses_internal_gds(const std::vector<uint32_t>& spirv);
 
 // Packed RGBA component-enable nibbles for the first realized color export to MRT0/MRT1. EXP.EN is
 // an attachment write mask, not a request to source disabled VGPRs; callers intersect this with the

--- a/prosper/src/gpu/shader_resources.cpp
+++ b/prosper/src/gpu/shader_resources.cpp
@@ -543,6 +543,13 @@ DescriptorValidationReport validate_spirv_descriptor_interface(
         if (d.set != expected_set)
             report.issues.push_back({DescriptorIssueCode::SetMismatch, true, d.set, d.binding, d.kind});
 
+        // Fragment set 1 binding 0 is reserved for the renderer-owned 64 KiB GDS backing.
+        // It has no guest descriptor-table entry; the live and replay backends inject it from
+        // the SPIR-V contract so capture artifacts remain self-contained.
+        const bool internal_gds = expected_stage == SpirvShaderStage::Fragment &&
+            d.set == 1 && d.binding == 0 && d.kind == SpirvDescriptorKind::StorageBuffer;
+        if (internal_gds) continue;
+
         std::vector<const ShaderResource*> matches;
         if (runtime) for (const auto& r : runtime->resources)
             if (r.binding == d.binding && r.cls != ResourceClass::Sampler) matches.push_back(&r);

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -90,6 +90,9 @@ struct FrameResource {
     // within one synchronous call only when both this identity and the complete captured bytes match;
     // zero keeps synthetic/replay resources conservatively distinct.
     uint64_t buffer_identity = 0;
+    // Backend-owned PS5 GDS storage. Unlike guest/capture buffers this is one persistent,
+    // zero-initialized 64 KiB allocation shared across ordered render calls.
+    bool is_internal_gds = false;
     const uint8_t* tex_rgba = nullptr;   // non-null => a texture; then tw/th are its dimensions
     uint32_t tw = 0, th = 0, td = 1;
     uint32_t img_dim = 1;             // ShaderResource/MIMG dim (1=2D, 2=3D); depth-1 3D stays 3D
@@ -422,6 +425,7 @@ struct RenderVkCtx {
     VkDeviceSize storage_buffer_alignment = 1;
     bool aniso_enabled = false; float max_aniso_limit = 1.0f;
     bool logic_op_enabled = false; bool ok = false;
+    bool fragment_stores_atomics = false;
     bool subgroup_size_control = false;
     uint32_t min_subgroup_size = 0, max_subgroup_size = 0;
     VkShaderStageFlags required_subgroup_size_stages = 0;
@@ -475,6 +479,7 @@ inline const RenderVkCtx& render_vk_ctx() {
         feats.shaderStorageImageWriteWithoutFormat = supported.shaderStorageImageWriteWithoutFormat;
         feats.vertexPipelineStoresAndAtomics = supported.vertexPipelineStoresAndAtomics;
         feats.fragmentStoresAndAtomics = supported.fragmentStoresAndAtomics;
+        r.fragment_stores_atomics = supported.fragmentStoresAndAtomics;
         // robustImageAccess (VK_EXT_image_robustness): OpImageRead OOB must return zero (#131). Guarded.
         // Device extensions accumulate into a vector so the (optional) image-robustness and (macOS)
         // portability-subset extensions coexist.
@@ -1066,6 +1071,29 @@ inline void release_render_host_buffer(VkDevice device, RenderHostBuffer buffer)
     }
     for (RenderHostBuffer& old : evicted) destroy_render_host_buffer(device, old);
     if (buffer.buffer) destroy_render_host_buffer(device, buffer);
+}
+
+inline const RenderHostBuffer& render_internal_gds_buffer() {
+    static const RenderHostBuffer buffer = [] {
+        constexpr VkDeviceSize kGdsBytes = 64u * 1024u;
+        RenderHostBuffer result = acquire_render_host_buffer(render_vk_ctx(), kGdsBytes);
+        if (result.mapped) std::memset(result.mapped, 0, static_cast<size_t>(kGdsBytes));
+        return result;
+    }();
+    return buffer;
+}
+
+inline void reset_internal_gds_for_test() {
+    const RenderHostBuffer& buffer = render_internal_gds_buffer();
+    if (buffer.mapped) std::memset(buffer.mapped, 0, 64u * 1024u);
+}
+
+inline uint32_t read_internal_gds_for_test(uint32_t byte_offset) {
+    const RenderHostBuffer& buffer = render_internal_gds_buffer();
+    if (!buffer.mapped || byte_offset > 64u * 1024u - sizeof(uint32_t)) return 0;
+    uint32_t value = 0;
+    std::memcpy(&value, static_cast<const uint8_t*>(buffer.mapped) + byte_offset, sizeof(value));
+    return value;
 }
 
 inline RenderHostBufferPoolStats render_host_buffer_pool_stats() {
@@ -2075,6 +2103,17 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         return bits;
     };
     std::vector<DV> dv(draws.size());
+    std::vector<std::vector<FrameResource>> effective_resources(draws.size());
+    for (size_t i = 0; i < draws.size(); ++i) {
+        effective_resources[i] = draws[i].R;
+        if (prosper::gpu::fragment_spirv_uses_internal_gds(draws[i].fs_words())) {
+            FrameResource gds;
+            gds.set = 1;
+            gds.binding = 0;
+            gds.is_internal_gds = true;
+            effective_resources[i].push_back(std::move(gds));
+        }
+    }
     std::vector<SharedTextureUpload> texture_uploads;
     std::unordered_map<TextureUploadKey, size_t, TextureUploadKeyHash> texture_upload_indices;
     const bool share_texture_uploads = getenv("PROSPER_NO_BACKEND_TEXTURE_SHARE") == nullptr;
@@ -2130,10 +2169,10 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     uint64_t storage_buffers = 0;
     uint64_t sampled_images = 0;
     uint64_t storage_images = 0;
-    for (const BackendDraw& draw : draws) {
-        if (draw.R.empty()) continue;
+    for (const auto& resources : effective_resources) {
+        if (resources.empty()) continue;
         uint32_t set_count = 1;
-        for (const FrameResource& resource : draw.R) {
+        for (const FrameResource& resource : resources) {
             set_count = std::max(set_count, resource.set + 1);
             if (!resource.is_texture()) {
                 ++storage_buffers;
@@ -2175,13 +2214,18 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         DV& v = dv[di];
         const uint32_t required_fragment_subgroup_size =
             prosper::gpu::fragment_spirv_required_subgroup_size(bd_fs);
+        const bool uses_internal_gds =
+            prosper::gpu::fragment_spirv_uses_internal_gds(bd_fs);
         if (required_fragment_subgroup_size &&
             (!ctx.subgroup_size_control ||
              required_fragment_subgroup_size < ctx.min_subgroup_size ||
              required_fragment_subgroup_size > ctx.max_subgroup_size ||
              !(ctx.required_subgroup_size_stages & VK_SHADER_STAGE_FRAGMENT_BIT) ||
              !(ctx.subgroup_stages & VK_SHADER_STAGE_FRAGMENT_BIT) ||
-             !(ctx.subgroup_operations & VK_SUBGROUP_FEATURE_ARITHMETIC_BIT))) {
+             !(ctx.subgroup_operations & VK_SUBGROUP_FEATURE_ARITHMETIC_BIT) ||
+             (uses_internal_gds &&
+              (!(ctx.subgroup_operations & VK_SUBGROUP_FEATURE_BALLOT_BIT) ||
+               !ctx.fragment_stores_atomics)))) {
             const uint64_t shader_key = bd.fs_identity
                 ? bd.fs_identity : hash_buffer_words(bd_fs.data(), bd_fs.size());
             static std::mutex log_mutex;
@@ -2191,11 +2235,13 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                 std::fprintf(stderr,
                              "[render] skip draw: fragment shader requires subgroup size %u "
                              "(device range %u..%u required-stages=0x%x subgroup-stages=0x%x "
-                             "ops=0x%x control=%d)\n",
+                             "ops=0x%x control=%d gds=%d fragment-atomics=%d)\n",
                              required_fragment_subgroup_size, ctx.min_subgroup_size,
                              ctx.max_subgroup_size, ctx.required_subgroup_size_stages,
                              ctx.subgroup_stages, ctx.subgroup_operations,
-                             static_cast<int>(ctx.subgroup_size_control));
+                             static_cast<int>(ctx.subgroup_size_control),
+                             static_cast<int>(uses_internal_gds),
+                             static_cast<int>(ctx.fragment_stores_atomics));
             continue;
         }
         if (backend_trace) {
@@ -2385,7 +2431,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         // Descriptor resources for this draw (two-set: VS=set0, PS=set1 — same layout as the single path).
         const auto setup_fixed_ready = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
         if (timing_enabled) setup_fixed_ms += setup_elapsed_ms(setup_shaders_ready, setup_fixed_ready);
-        const auto& R = bd.R;
+        const auto& R = effective_resources[di];
         v.use_desc = !R.empty();
         for (auto& r : R) v.n_sets = std::max(v.n_sets, r.set + 1);
         std::vector<VkDescriptorSetLayout> dsls(v.n_sets, VK_NULL_HANDLE);
@@ -2686,6 +2732,16 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                     wr[i].descriptorType = lb[i].descriptorType; wr[i].pImageInfo = &dii[i];
                 } else {
                     lb[i].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER; lb[i].stageFlags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
+                    if (r.is_internal_gds) {
+                        const RenderHostBuffer& gds = render_internal_gds_buffer();
+                        if (!gds.buffer) continue;
+                        dbi[i] = {gds.buffer, 0, 64u * 1024u};
+                        wr[i] = {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET};
+                        wr[i].dstBinding = r.binding; wr[i].descriptorCount = 1;
+                        wr[i].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+                        wr[i].pBufferInfo = &dbi[i];
+                        continue;
+                    }
                     const uint32_t* words = r.buffer_words_data();
                     size_t word_count = r.buffer_word_count();
                     if (!words || !word_count) {

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -2223,9 +2223,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
              !(ctx.required_subgroup_size_stages & VK_SHADER_STAGE_FRAGMENT_BIT) ||
              !(ctx.subgroup_stages & VK_SHADER_STAGE_FRAGMENT_BIT) ||
              !(ctx.subgroup_operations & VK_SUBGROUP_FEATURE_ARITHMETIC_BIT) ||
-             (uses_internal_gds &&
-              (!(ctx.subgroup_operations & VK_SUBGROUP_FEATURE_BALLOT_BIT) ||
-               !ctx.fragment_stores_atomics)))) {
+             (uses_internal_gds && !ctx.fragment_stores_atomics))) {
             const uint64_t shader_key = bd.fs_identity
                 ? bd.fs_identity : hash_buffer_words(bd_fs.data(), bd_fs.size());
             static std::mutex log_mutex;
@@ -2242,6 +2240,14 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                              static_cast<int>(ctx.subgroup_size_control),
                              static_cast<int>(uses_internal_gds),
                              static_cast<int>(ctx.fragment_stores_atomics));
+            continue;
+        }
+        if (uses_internal_gds && !render_internal_gds_buffer().buffer) {
+            static std::once_flag logged;
+            std::call_once(logged, [] {
+                std::fprintf(stderr,
+                             "[render] skip draw: failed to allocate persistent GDS buffer\n");
+            });
             continue;
         }
         if (backend_trace) {
@@ -2734,7 +2740,6 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                     lb[i].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER; lb[i].stageFlags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
                     if (r.is_internal_gds) {
                         const RenderHostBuffer& gds = render_internal_gds_buffer();
-                        if (!gds.buffer) continue;
                         dbi[i] = {gds.buffer, 0, 64u * 1024u};
                         wr[i] = {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET};
                         wr[i].dstBinding = r.binding; wr[i].descriptorCount = 1;

--- a/prosper/tests/test_recompiled_fragment.cpp
+++ b/prosper/tests/test_recompiled_fragment.cpp
@@ -61,9 +61,8 @@ int main() {
         (wave_ctx.required_subgroup_size_stages & VK_SHADER_STAGE_FRAGMENT_BIT) &&
         (wave_ctx.subgroup_stages & VK_SHADER_STAGE_FRAGMENT_BIT) &&
         (wave_ctx.subgroup_operations & VK_SUBGROUP_FEATURE_ARITHMETIC_BIT);
-    const bool supports_fragment_gds = supports_fragment_wave64 &&
-        (wave_ctx.subgroup_operations & VK_SUBGROUP_FEATURE_BALLOT_BIT) &&
-        wave_ctx.fragment_stores_atomics;
+    const bool supports_fragment_gds =
+        supports_fragment_wave64 && wave_ctx.fragment_stores_atomics;
     std::vector<uint8_t> wave_px = prosper::test::render_triangle_rgba(vert, wave_frag, W, H);
     const bool wave_rendered = wave_px.size() == static_cast<size_t>(W) * H * 4;
     const uint8_t* wave_center = wave_rendered
@@ -115,6 +114,63 @@ int main() {
     } else {
         CHECK(!supports_fragment_gds && !gds_px.empty(),
               "device without fragment wave64/GDS support skips compaction draw fail-visible");
+    }
+
+    // Implicit-LOD sampling forces whole-quad execution on RADV. Primitive-edge helper lanes must
+    // participate in subgroup arithmetic without becoming the atomic leader or consuming slots.
+    const uint32_t gds_wqm_ps[] = {
+        0x7E0002FFu, 0x3E800000u, 0x7E0202FFu, 0x3E800000u,
+        0xF0800F08u, 0x00820000u, // image_sample v[0:3], v[0:1], s[8:15], s[16:19]
+        0xD7660007u, 0x0001007Fu, 0xBEFC0380u,
+        0xD8FA0014u, 0x06000000u,
+        0xD7650000u, 0x00020E7Eu, 0x4A140106u, 0x36001481u, 0x7E000D00u,
+        0x7E020280u, 0x7E040280u, 0x7E0602F2u,
+        0xF800180Fu, 0x03020100u, 0xBF810000u,
+    };
+    ShaderResourceTable gds_wqm_rt;
+    ShaderResource gds_wqm_texture{};
+    gds_wqm_texture.cls = ResourceClass::Texture;
+    gds_wqm_texture.binding = 4; gds_wqm_texture.img_dim = 1;
+    gds_wqm_texture.width = 2; gds_wqm_texture.height = 2;
+    gds_wqm_texture.sgpr_base = 8;
+    gds_wqm_rt.resources.push_back(gds_wqm_texture);
+    std::vector<uint32_t> gds_wqm_frag = recompile_fragment(
+        gds_wqm_ps, std::size(gds_wqm_ps), &gds_wqm_rt);
+    const uint8_t wqm_texels[16] = {
+        255,255,255,255, 255,255,255,255,
+        255,255,255,255, 255,255,255,255,
+    };
+    prosper::test::TexDesc gds_wqm_tex{4, 2, 2, wqm_texels};
+    prosper::test::reset_internal_gds_for_test();
+    std::vector<uint8_t> gds_wqm_px = prosper::test::render_triangle_rgba(
+        vert, gds_wqm_frag, W, H, nullptr, nullptr, nullptr, &gds_wqm_tex);
+    if (supports_fragment_gds && gds_wqm_px.size() == static_cast<size_t>(W) * H * 4) {
+        uint32_t covered = 0, red = 0;
+        for (size_t i = 0; i < gds_wqm_px.size(); i += 4) {
+            if (gds_wqm_px[i + 2] < 0x40) {
+                ++covered;
+                if (gds_wqm_px[i] > 0x80) ++red;
+            }
+        }
+        CHECK(prosper::test::read_internal_gds_for_test(20) == covered,
+              "WQM helper lanes neither lead the GDS atomic nor consume counter slots");
+        CHECK(red == covered / 2,
+              "WQM append-base + MBCNT-prefix allocation remains unique and contiguous");
+    } else {
+        CHECK(!supports_fragment_gds && !gds_wqm_px.empty(),
+              "unsupported device skips WQM GDS compaction draw fail-visible");
+    }
+
+    if (supports_fragment_gds) {
+        std::vector<uint32_t> gds_consume_ps(gds_ps, gds_ps + std::size(gds_ps));
+        gds_consume_ps[3] = 0xD8F60014u; // ds_consume v6 offset:20 gds
+        std::vector<uint32_t> gds_consume_frag = recompile_fragment(
+            gds_consume_ps.data(), gds_consume_ps.size());
+        std::vector<uint8_t> gds_consume_px = prosper::test::render_triangle_rgba(
+            vert, gds_consume_frag, W, H);
+        CHECK(gds_consume_px.size() == static_cast<size_t>(W) * H * 4 &&
+                  prosper::test::read_internal_gds_for_test(20) == 0,
+              "GDS consume subtracts one covered-fragment allocation across all waves");
     }
 
     // Astro Bot's early foreground pass exports only R/G (EN=0x3). AMD's EXP contract preserves

--- a/prosper/tests/test_recompiled_fragment.cpp
+++ b/prosper/tests/test_recompiled_fragment.cpp
@@ -61,6 +61,9 @@ int main() {
         (wave_ctx.required_subgroup_size_stages & VK_SHADER_STAGE_FRAGMENT_BIT) &&
         (wave_ctx.subgroup_stages & VK_SHADER_STAGE_FRAGMENT_BIT) &&
         (wave_ctx.subgroup_operations & VK_SUBGROUP_FEATURE_ARITHMETIC_BIT);
+    const bool supports_fragment_gds = supports_fragment_wave64 &&
+        (wave_ctx.subgroup_operations & VK_SUBGROUP_FEATURE_BALLOT_BIT) &&
+        wave_ctx.fragment_stores_atomics;
     std::vector<uint8_t> wave_px = prosper::test::render_triangle_rgba(vert, wave_frag, W, H);
     const bool wave_rendered = wave_px.size() == static_cast<size_t>(W) * H * 4;
     const uint8_t* wave_center = wave_rendered
@@ -71,6 +74,48 @@ int main() {
           supports_fragment_wave64
               ? "device enforced wave64 and executed fragment MBCNT"
               : "device without fragment wave64 skipped MBCNT draw fail-visible");
+
+    // Astro's compaction sequence allocates popcount(EXEC) slots from a device-global GDS
+    // counter, then adds the MBCNT prefix. Export the allocated index parity so both returned
+    // values are observable, and independently verify that helper invocations consumed no slots.
+    const uint32_t gds_ps[] = {
+        0xD7660007u, 0x0001007Fu, // v_mbcnt_hi_u32_b32 v7, exec_hi, 0
+        0xBEFC0380u,              // s_mov_b32 m0, 0
+        0xD8FA0014u, 0x06000000u, // ds_append v6 offset:20 gds
+        0xD7650000u, 0x00020E7Eu, // v_mbcnt_lo_u32_b32 v0, exec_lo, v7
+        0x4A140106u,              // v_add_nc_u32 v10, v6, v0
+        0x36001481u,              // v_and_b32 v0, 1, v10
+        0x7E000D00u,              // v_cvt_f32_u32 v0, v0
+        0x7E020280u, 0x7E040280u, 0x7E0602F2u,
+        0xF800180Fu, 0x03020100u, 0xBF810000u,
+    };
+    std::vector<uint32_t> gds_frag = recompile_fragment(gds_ps, std::size(gds_ps));
+    CHECK(!gds_frag.empty(), "recompiled Astro fragment MBCNT + GDS append compaction sequence");
+    CHECK(fragment_spirv_uses_internal_gds(gds_frag),
+          "fragment GDS module advertises its backend-owned persistent descriptor");
+    CHECK(validate_spirv_descriptor_interface(
+              gds_frag, nullptr, 1, SpirvShaderStage::Fragment, false).ok(),
+          "descriptor validation accepts renderer-owned GDS without a guest table entry");
+    prosper::test::reset_internal_gds_for_test();
+    std::vector<uint8_t> gds_px = prosper::test::render_triangle_rgba(vert, gds_frag, W, H);
+    if (supports_fragment_gds && gds_px.size() == static_cast<size_t>(W) * H * 4) {
+        uint32_t covered = 0, red = 0;
+        for (size_t i = 0; i < gds_px.size(); i += 4) {
+            if (gds_px[i + 2] < 0x40) {
+                ++covered;
+                if (gds_px[i] > 0x80) ++red;
+            }
+        }
+        CHECK(prosper::test::read_internal_gds_for_test(20) == covered,
+              "GDS counter advances once per covered non-helper fragment across all waves");
+        printf("  GDS covered=%u red=%u counter=%u\n", covered, red,
+               prosper::test::read_internal_gds_for_test(20));
+        CHECK(red == covered / 2,
+              "export observes unique append-base + MBCNT-prefix allocation parity");
+    } else {
+        CHECK(!supports_fragment_gds && !gds_px.empty(),
+              "device without fragment wave64/GDS support skips compaction draw fail-visible");
+    }
 
     // Astro Bot's early foreground pass exports only R/G (EN=0x3). AMD's EXP contract preserves
     // disabled destination components; the live executor therefore intersects EN with the Vulkan

--- a/prosper/tests/test_recompiled_fragment.cpp
+++ b/prosper/tests/test_recompiled_fragment.cpp
@@ -124,7 +124,8 @@ int main() {
         0xD7660007u, 0x0001007Fu, 0xBEFC0380u,
         0xD8FA0014u, 0x06000000u,
         0xD7650000u, 0x00020E7Eu, 0x4A140106u, 0x36001481u, 0x7E000D00u,
-        0x7E020280u, 0x7E040280u, 0x7E0602F2u,
+        // Keep sampled v3 live as export alpha so RADV cannot DCE the implicit-LOD sample/WQM.
+        0x7E020280u, 0x7E040280u,
         0xF800180Fu, 0x03020100u, 0xBF810000u,
     };
     ShaderResourceTable gds_wqm_rt;
@@ -145,17 +146,20 @@ int main() {
     std::vector<uint8_t> gds_wqm_px = prosper::test::render_triangle_rgba(
         vert, gds_wqm_frag, W, H, nullptr, nullptr, nullptr, &gds_wqm_tex);
     if (supports_fragment_gds && gds_wqm_px.size() == static_cast<size_t>(W) * H * 4) {
-        uint32_t covered = 0, red = 0;
+        uint32_t covered = 0, red = 0, sampled_alpha = 0;
         for (size_t i = 0; i < gds_wqm_px.size(); i += 4) {
             if (gds_wqm_px[i + 2] < 0x40) {
                 ++covered;
                 if (gds_wqm_px[i] > 0x80) ++red;
+                if (gds_wqm_px[i + 3] > 0x80) ++sampled_alpha;
             }
         }
         CHECK(prosper::test::read_internal_gds_for_test(20) == covered,
               "WQM helper lanes neither lead the GDS atomic nor consume counter slots");
         CHECK(red == covered / 2,
               "WQM append-base + MBCNT-prefix allocation remains unique and contiguous");
+        CHECK(sampled_alpha == covered,
+              "WQM regression keeps implicit-LOD sampled alpha live through export");
     } else {
         CHECK(!supports_fragment_gds && !gds_wqm_px.empty(),
               "unsupported device skips WQM GDS compaction draw fail-visible");

--- a/prosper/tools/spv_validate/spv_validate.cpp
+++ b/prosper/tools/spv_validate/spv_validate.cpp
@@ -49,6 +49,12 @@ int main(int argc, char** argv) {
     // Fragment: solid green (EXP MRT0).
     { const uint32_t c[] = {0x7E000280u,0x7E0202F2u,0x7E040280u,0x7E0602F2u,0xF800180Fu,0x03020100u,0xBF810000u};
       dump(dir, "fragment_color", recompile_fragment(c, sizeof(c)/4)); }
+    // Fragment: Astro's exact wave64 MBCNT + device-global append allocation shape.
+    { const uint32_t c[] = {
+          0xD7660007u,0x0001007Fu,0xBEFC0380u,0xD8FA0014u,0x06000000u,
+          0xD7650000u,0x00020E7Eu,0x4A140106u,0x36001481u,0x7E000D00u,
+          0x7E020280u,0x7E040280u,0x7E0602F2u,0xF800180Fu,0x03020100u,0xBF810000u};
+      dump(dir, "fragment_gds_append", recompile_fragment(c, sizeof(c)/4)); }
     // Fragment private spill/fill (Function-storage declaration in the graphics shell).
     { const uint32_t c[] = {0xdc704010u,0x00000000u,0x7e000280u,0xdc304010u,0x00000000u,
                             0xf800000fu,0x00000000u,0xBF810000u};

--- a/prosper/tools/spv_validate/spv_validate.cpp
+++ b/prosper/tools/spv_validate/spv_validate.cpp
@@ -55,6 +55,23 @@ int main(int argc, char** argv) {
           0xD7650000u,0x00020E7Eu,0x4A140106u,0x36001481u,0x7E000D00u,
           0x7E020280u,0x7E040280u,0x7E0602F2u,0xF800180Fu,0x03020100u,0xBF810000u};
       dump(dir, "fragment_gds_append", recompile_fragment(c, sizeof(c)/4)); }
+    // Same allocation with a live implicit-LOD sample: sampled alpha reaches EXP and forces WQM.
+    { const uint32_t c[] = {
+          0x7E0002FFu,0x3E800000u,0x7E0202FFu,0x3E800000u,
+          0xF0800F08u,0x00820000u,0xD7660007u,0x0001007Fu,0xBEFC0380u,
+          0xD8FA0014u,0x06000000u,0xD7650000u,0x00020E7Eu,0x4A140106u,
+          0x36001481u,0x7E000D00u,0x7E020280u,0x7E040280u,
+          0xF800180Fu,0x03020100u,0xBF810000u};
+      ShaderResourceTable rt; ShaderResource t{}; t.cls=ResourceClass::Texture;
+      t.binding=4; t.img_dim=1; t.width=2; t.height=2; t.sgpr_base=8;
+      rt.resources.push_back(t);
+      dump(dir, "fragment_gds_wqm", recompile_fragment(c, sizeof(c)/4, &rt)); }
+    // Consume shares the same wave allocator but subtracts the non-helper population.
+    { const uint32_t c[] = {
+          0xD7660007u,0x0001007Fu,0xBEFC0380u,0xD8F60014u,0x06000000u,
+          0xD7650000u,0x00020E7Eu,0x4A140106u,0x36001481u,0x7E000D00u,
+          0x7E020280u,0x7E040280u,0x7E0602F2u,0xF800180Fu,0x03020100u,0xBF810000u};
+      dump(dir, "fragment_gds_consume", recompile_fragment(c, sizeof(c)/4)); }
     // Fragment private spill/fill (Function-storage declaration in the graphics shell).
     { const uint32_t c[] = {0xdc704010u,0x00000000u,0x7e000280u,0xdc304010u,0x00000000u,
                             0xf800000fu,0x00000000u,0xBF810000u};


### PR DESCRIPTION
## Summary

- lower fragment `ds_append`/`ds_consume` GDS packets to one device-scoped storage-buffer atomic per enforced wave64 subgroup
- exclude helper invocations from counter allocation and preserve EXEC-predicated destination writes
- inject a persistent renderer-owned 64 KiB GDS descriptor across live and replay render calls
- keep unsupported subgroup/fragment-atomic devices fail-visible

## Evidence

Astro Bot shader `0x50054ab00` reaches the exact sequence this implements: fragment MBCNT, `ds_append v6 offset:20 gds`, then MBCNT prefix consumption. The focused Vulkan regression observes the returned append-base + MBCNT prefix as unique parity and verifies the mapped counter advances exactly once per covered non-helper fragment.

## Validation

- full Linux build
- `ctest --test-dir build-linux --output-on-failure -j8` (121/121)
- focused fragment test on RADV wave64
- focused fragment test on llvmpipe subgroup8 (fail-visible skip)
- `PROSPER_GAME_ROOT=/home/mattias800/repos/ps5ys python3 tools/snapshot/snapshot.py check`
  - Messenger 29/29
  - Evergate 9/9
  - Dead Cells 44/44
  - Blasphemous 2 98/98

Closes the GDS-append portion of #1076; the issue remains open for the next live Astro frontier.