### PR TITLE
perf(compute): hoist the format dispatch out of the storage-image unpack loop

### DIFF
--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -393,6 +393,83 @@ void storage_unpack_texel(const uint8_t* src, prosper::gpu::DataFormat f, uint32
         }
     }
 }
+// Unpack `count` consecutive texels (source stride `src_stride`) into `count` RGBA32 quads.
+//
+// storage_unpack_texel re-derives the format for every texel AND re-enters a switch for every
+// component, so a full-resolution storage image pays ~texels function calls plus ~4x texels switch
+// dispatches. That dominated compute image setup (measured: ~56 ms per image-bearing dispatch on
+// Blasphemous 2's menu, against 0.39 ms of actual GPU dispatch). This hoists the format dispatch out
+// of the loop so each specialized path is a tight typed loop.
+//
+// Every specialized path is bit-identical to storage_unpack_texel by construction; formats without a
+// specialization fall through to the per-texel helper, and PROSPER_VERIFY_UNPACK=1 checks the two
+// against each other at runtime.
+void storage_unpack_range(const uint8_t* src, size_t src_stride, prosper::gpu::DataFormat f,
+                          uint32_t ncomp, size_t count, uint32_t* out) {
+    using DF = prosper::gpu::DataFormat;
+    const uint32_t one_f32 = 0x3f800000u;
+    const bool integer_fmt = f == DF::Uint8 || f == DF::Sint8 || f == DF::Uint16 ||
+                             f == DF::Sint16 || f == DF::Uint32 || f == DF::Sint32;
+    const uint32_t alpha_default = integer_fmt ? 1u : one_f32;
+    const uint32_t n = ncomp < 4u ? ncomp : 4u;
+    auto defaults = [&](uint32_t* o) { o[0] = o[1] = o[2] = 0; o[3] = alpha_default; };
+    switch (f) {
+        case DF::Unorm8:
+            for (size_t t = 0; t < count; ++t) {
+                const uint8_t* p = src + t * src_stride; uint32_t* o = out + t * 4; defaults(o);
+                for (uint32_t c = 0; c < n; ++c) { float v = p[c] / 255.0f; std::memcpy(&o[c], &v, 4); }
+            }
+            return;
+        case DF::Float16:
+            for (size_t t = 0; t < count; ++t) {
+                const uint8_t* p = src + t * src_stride; uint32_t* o = out + t * 4; defaults(o);
+                for (uint32_t c = 0; c < n; ++c) {
+                    float v = prosper::gpu::half_to_float(
+                        static_cast<uint16_t>(p[c * 2] | (p[c * 2 + 1] << 8)));
+                    std::memcpy(&o[c], &v, 4);
+                }
+            }
+            return;
+        case DF::Uint8:
+            for (size_t t = 0; t < count; ++t) {
+                const uint8_t* p = src + t * src_stride; uint32_t* o = out + t * 4; defaults(o);
+                for (uint32_t c = 0; c < n; ++c) o[c] = p[c];
+            }
+            return;
+        case DF::Sint8:
+            for (size_t t = 0; t < count; ++t) {
+                const uint8_t* p = src + t * src_stride; uint32_t* o = out + t * 4; defaults(o);
+                for (uint32_t c = 0; c < n; ++c)
+                    o[c] = static_cast<uint32_t>(static_cast<int32_t>(static_cast<int8_t>(p[c])));
+            }
+            return;
+        case DF::Uint16:
+            for (size_t t = 0; t < count; ++t) {
+                const uint8_t* p = src + t * src_stride; uint32_t* o = out + t * 4; defaults(o);
+                for (uint32_t c = 0; c < n; ++c)
+                    o[c] = static_cast<uint32_t>(p[c * 2] | (p[c * 2 + 1] << 8));
+            }
+            return;
+        case DF::Sint16:
+            for (size_t t = 0; t < count; ++t) {
+                const uint8_t* p = src + t * src_stride; uint32_t* o = out + t * 4; defaults(o);
+                for (uint32_t c = 0; c < n; ++c)
+                    o[c] = static_cast<uint32_t>(static_cast<int32_t>(static_cast<int16_t>(
+                        p[c * 2] | (p[c * 2 + 1] << 8))));
+            }
+            return;
+        case DF::Float32: case DF::Uint32: case DF::Sint32:
+            for (size_t t = 0; t < count; ++t) {
+                const uint8_t* p = src + t * src_stride; uint32_t* o = out + t * 4; defaults(o);
+                for (uint32_t c = 0; c < n; ++c) std::memcpy(&o[c], p + c * 4, 4);
+            }
+            return;
+        default:                                  // packed formats keep the general per-texel path
+            for (size_t t = 0; t < count; ++t)
+                storage_unpack_texel(src + t * src_stride, f, ncomp, out + t * 4);
+            return;
+    }
+}
 void storage_pack_texel(const uint32_t in[4], prosper::gpu::DataFormat f, uint32_t ncomp, uint8_t* dst) {
     using DF = prosper::gpu::DataFormat;
     if (f == DF::Float10_11_11) {
@@ -932,9 +1009,33 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     if (trace) bi.before_hash = fnv1a(src, guest_bytes);
                     std::memcpy(linear.data(), src, linear.size());
                 }
-                for (size_t t = 0; t < texels; t++)
-                    storage_unpack_texel(linear.data() + t * guest_texel, r->format, nc,
-                                         reinterpret_cast<uint32_t*>(upload.data()) + t * 4);
+                storage_unpack_range(linear.data(), guest_texel, r->format, nc, texels,
+                                     reinterpret_cast<uint32_t*>(upload.data()));
+                static const bool verify_unpack = std::getenv("PROSPER_VERIFY_UNPACK") != nullptr;
+                if (verify_unpack) {
+                    // Fail-visible A/B: the specialized range unpack must be bit-identical to the
+                    // per-texel path it replaces. Reports the whole divergence (count + first texel)
+                    // and identifies the binding, and logs the clean case too so a verified run is
+                    // self-proving rather than merely silent.
+                    uint32_t expect[4];
+                    const uint32_t* got = reinterpret_cast<const uint32_t*>(upload.data());
+                    size_t bad = 0, first_bad = 0;
+                    for (size_t t = 0; t < texels; ++t) {
+                        storage_unpack_texel(linear.data() + t * guest_texel, r->format, nc, expect);
+                        if (std::memcmp(expect, got + t * 4, sizeof expect) != 0) {
+                            if (!bad) first_bad = t;
+                            ++bad;
+                        }
+                    }
+                    std::fprintf(stderr,
+                                 "[compute] unpack-verify binding=%u addr=0x%llx fmt=%u nc=%u "
+                                 "texels=%zu mismatches=%zu%s\n",
+                                 bi.binding, (unsigned long long)r->gpu_addr,
+                                 (unsigned)r->format, nc, texels, bad,
+                                 bad ? " MISMATCH" : "");
+                    if (bad)
+                        std::fprintf(stderr, "[compute]   first mismatching texel=%zu\n", first_bad);
+                }
             } else {
                 const uint32_t bpb = bc_block_bytes(r->format);
                 const uint32_t cb = data_format_bytes(r->format);


### PR DESCRIPTION
## Problem

Blasphemous 2's title/menu runs at ~1–12 fps on a **real GPU** (RADV STRIX_HALO). Profiling (`PROSPER_RENDER_TIMING` + `PROSPER_COMPUTE_PHASE_TIMING`, faithful defaults) shows the frontend is essentially free and the backend is everything:

```
per submit: total=76.81 ms  backend=76.28 ms
            realize_draws=0.39  tables=0.21  shader_lookup=0.07  publish=0.00
compute:    calls=8425  dispatches=1 each  avg_ms=14.31
```

Per-dispatch phases put the cost in **image setup, not the GPU**:

| phase | ms |
|---|---:|
| **setup** | **7.73** |
| writeback | 2.56 |
| pack | 1.48 |
| layout | 0.97 |
| **dispatch (real GPU work)** | **0.39** |

and setup splits into buffers **0.12 ms** (the existing pool works) vs images **9.82 ms**. By dispatch kind:

| kind | count | image setup |
|---|---:|---:|
| binds no images | 4192 | **0.00 ms** |
| binds 2 images | 936 | **~56 ms each** |

≈ **52 s of a 90 s run** spent preparing images to perform 0.39 ms of dispatch each.

## Fix

The hot loop is `storage_unpack_texel` — a **non-inlined call per texel** that re-derives the format and **re-enters a switch per component**, so a full-resolution image pays ~texels calls and ~4×texels switch dispatches. `storage_unpack_range` hoists the format dispatch out of the loop, leaving a tight typed loop per format. Packed formats (`Float10_11_11`, `Unorm2_10_10_10`) keep the general per-texel path.

| | before | after |
|---|---:|---:|
| compute call avg | 14.31 ms | **10.70 ms** |
| image setup | 55.99 ms | **39.10 ms** |
| app rate (menu) | 12.5 fps | **14.7 fps** |

## Correctness

Each specialized path is bit-identical to the helper it replaces by construction, and `PROSPER_VERIFY_UNPACK=1` runs **both** paths and reports any divergence — a routed Blasphemous 2 run reported **0 mismatches across 4245 dispatches**. Behavior is otherwise unchanged: no format coverage added or removed, no ordering or lifetime change.

## Deliberately NOT included (a useful negative result)

The same images are re-prepared constantly — an instrumented run showed **800 preparations producing only 2 distinct results**. A validated cross-dispatch cache of the prepared CPU bytes (graphics-texture-cache-style exact source validation) reached **99.7% hits (1193/3)** and moved **neither setup time nor frame rate**, while costing **240 MiB**.

That negative result localizes the remaining cost: these images are ~40 MB each, so every dispatch still memcpys and **uploads ~32 MB of staging data**. Caching CPU bytes cannot avoid that, so the cache was removed rather than shipped as a 240 MiB regression. **The real remaining win is reusing the `VkImage` across dispatches**, which needs its own correctness contract for *storage* images (written by the dispatch, written back to guest memory) — recorded on #1082 for a separate reviewed change.

## Verification

- `ctest` **118/118**
- Snapshot guard **OK on all four routes**: messenger-scene, evergate-title, dead-cells-gameplay, blasphemous2-gameplay
- `PROSPER_VERIFY_UNPACK` clean (0/4245)

`Refs #1082` (does not close it — this is the first of the identified wins).

## Review note

Pixel-affecting hot path: worth an independent read on whether each specialized branch exactly reproduces `storage_unpack_texel`'s semantics, especially the missing-channel defaults (integer formats default alpha to integer `1`, others to float `1.0`) and the `ncomp > 4` / narrow-component cases.