### PR TITLE
gpu: let the compute backend adopt the renderer's Vulkan device (#1091 phase 1)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -1138,3 +1138,12 @@ if(TARGET prosper-app AND TARGET prosper_video_vaapi)
   target_compile_definitions(prosper-app PRIVATE PROSPER_VIDEO_VAAPI=1)
   message(STATUS "prosper-app: FFmpeg/VA-API video enabled")
 endif()
+
+# Shared-device adoption guard (#1091). prosper_live_renderer only exists in frontend-enabled
+# configurations and is defined later in this file than the core test block, so register this
+# after the fact and only when the target is actually present.
+if(TARGET prosper_live_renderer AND TARGET prosper_core)
+  add_executable(test_shared_vulkan_device tests/test_shared_vulkan_device.cpp)
+  target_link_libraries(test_shared_vulkan_device PRIVATE prosper_live_renderer prosper_core)
+  add_test(NAME shared_vulkan_device COMMAND test_shared_vulkan_device)
+endif()

--- a/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
+++ b/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
@@ -753,8 +753,10 @@ After shared publication, the Dead Cells post-parse loading workload is the most
 These numbers explain why another small CPU lookup cache is not a credible path to 60 FPS. The
 renderer currently creates transient Vulkan objects, waits, and reads back at each ordered backend
 boundary. A durable improvement needs persistent resources and coordinated graphics/compute ownership.
-Shared CPU publication is complete; direct GPU-image presentation remains a later step because the app
-and headless renderer still own separate Vulkan devices.
+Shared CPU publication is complete; direct GPU-image presentation remains a later step. As of #1091
+phase 1 the compute backend ADOPTS the live renderer's Vulkan device instead of creating its own, so
+the two no longer own separate devices when the live renderer is registered; binding a renderer-owned
+image directly to a dispatch (phase 2) is what still remains.
 
 ## Capture correction and dependency evidence
 

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -110,6 +110,9 @@ struct VulkanComputeContext {
     // tests/image_compute_runner.h, the exec-diff harness for that contract). When the device lacks
     // the features, image-binding dispatches are skipped loudly instead of creating an invalid device.
     bool image_support = false;
+    // True when instance/device/queue were ADOPTED from the live renderer (#1091). A borrowed
+    // context is owned by the renderer: destroy our own pipelines/pools/memory, never its device.
+    bool borrowed = false;
 
     ~VulkanComputeContext() {
         release_cached_memory();
@@ -123,6 +126,7 @@ struct VulkanComputeContext {
                 vkDestroyDescriptorSetLayout(device, cached.descriptor_layout, nullptr);
         }
         if (pipeline_cache) vkDestroyPipelineCache(device, pipeline_cache, nullptr);
+        if (borrowed) return;                       // renderer owns the device/instance
         if (device) vkDestroyDevice(device, nullptr);
         if (instance) vkDestroyInstance(instance, nullptr);
     }
@@ -211,7 +215,54 @@ struct VulkanComputeContext {
         memory_pool.cached_allocations = 0;
     }
 
+    // A GRAPHICS queue family is not required by spec to also advertise COMPUTE, and the renderer
+    // selects its family on GRAPHICS alone. Dispatching on a family without COMPUTE is invalid usage,
+    // so verify before adopting rather than assuming the common family-0 layout.
+    static bool queue_family_supports_compute(VkPhysicalDevice phys, uint32_t family) {
+        if (!phys || family == UINT32_MAX) return false;
+        uint32_t count = 0;
+        vkGetPhysicalDeviceQueueFamilyProperties(phys, &count, nullptr);
+        if (family >= count) return false;
+        std::vector<VkQueueFamilyProperties> props(count);
+        vkGetPhysicalDeviceQueueFamilyProperties(phys, &count, props.data());
+        return (props[family].queueFlags & VK_QUEUE_COMPUTE_BIT) != 0;
+    }
+
     bool init() {
+        // Adopt the live renderer's device when it published one (#1091). Sharing a device is what
+        // makes it possible for a dispatch to bind a renderer-owned image at all; without it every
+        // such binding must round-trip through host memory. Declined when the renderer's device
+        // lacks the storage-image features this backend needs, and absent entirely in headless
+        // compute-only use (tests/test_game_compute.cpp), where the private device below is created
+        // exactly as before.
+        const prosper::gpu::SharedVulkanContext shared = prosper::gpu::shared_vulkan_context();
+        if (shared.valid() && shared.storage_image_read_without_format &&
+            shared.storage_image_write_without_format &&
+            queue_family_supports_compute(static_cast<VkPhysicalDevice>(shared.physical),
+                                          shared.queue_family)) {
+            instance = static_cast<VkInstance>(shared.instance);
+            physical = static_cast<VkPhysicalDevice>(shared.physical);
+            device = static_cast<VkDevice>(shared.device);
+            queue = static_cast<VkQueue>(shared.queue);
+            queue_family = shared.queue_family;
+            borrowed = true;
+            image_support = true;
+            VkPipelineCacheCreateInfo pcci{VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO};
+            if (vkCreatePipelineCache(device, &pcci, nullptr, &pipeline_cache) == VK_SUCCESS) {
+                vkGetPhysicalDeviceMemoryProperties(physical, &memory);
+                std::fprintf(stderr, "[compute] Vulkan device: adopted the renderer's device "
+                                     "(shared, queue family %u)\n", queue_family);
+                return true;
+            }
+            // Anything failing here must fall through to a private device rather than killing the
+            // whole compute backend for the run: adoption is an optimization, never a requirement.
+            // Release only what we created (nothing yet: the pipeline cache is what failed) and drop
+            // the borrowed handles so the private path below starts from a clean context.
+            instance = VK_NULL_HANDLE; physical = VK_NULL_HANDLE;
+            device = VK_NULL_HANDLE; queue = VK_NULL_HANDLE;
+            queue_family = UINT32_MAX; borrowed = false; image_support = false;
+            pipeline_cache = VK_NULL_HANDLE;
+        }
         VkApplicationInfo app{VK_STRUCTURE_TYPE_APPLICATION_INFO};
         app.apiVersion = VK_API_VERSION_1_1;
         VkInstanceCreateInfo ici{VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO};

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -225,6 +225,12 @@ struct PersistentDecodedTexture {
 }
 
 void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
+    // Create (and thereby PUBLISH) the renderer's Vulkan device up front so the compute backend can
+    // adopt it (#1091). Compute initializes lazily on its first dispatch, and titles routinely
+    // dispatch before their first draw -- without this the compute device would be created first and
+    // the two would never share. Only reached when the live renderer is registered, so headless
+    // compute-only use (tests/test_game_compute.cpp) still creates its own device.
+    (void)prosper::test::render_vk_ctx();
     static RttCache g_rtt;   // render-to-texture cache (#167)
     // Match boot_trace's progression-diagnostic contract: callers may register the graphics
     // renderer while deliberately leaving compute unregistered. This keeps semantic dispatches

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -430,6 +430,30 @@ struct LiveTargetSnapshot {
 using LiveTargetReaderFn = std::function<bool(uint64_t gpu_addr, LiveTargetSnapshot& snapshot)>;
 void set_live_target_reader(LiveTargetReaderFn fn);
 bool read_live_render_target(uint64_t gpu_addr, LiveTargetSnapshot& snapshot);
+// Shared Vulkan device (#1091 phase 1). live_compute historically created its own VkInstance/VkDevice,
+// so a renderer-owned image could never be bound to a dispatch and had to round-trip through host
+// memory. The live renderer publishes its already-created device here; the compute backend ADOPTS it
+// when it is present and feature-adequate, and otherwise creates its own exactly as before (compute
+// must keep working with no renderer at all -- see tests/test_game_compute.cpp).
+//
+// Handles are opaque so this layer keeps no Vulkan dependency; both sides cast to the real types.
+// An adopted context is BORROWED: the consumer owns none of these objects and must not destroy them.
+// Graphics and compute execute strictly sequentially on one thread (execute_ordered_gpustate), so a
+// shared queue needs no cross-thread synchronization.
+struct SharedVulkanContext {
+    void* instance = nullptr;
+    void* physical = nullptr;
+    void* device = nullptr;
+    void* queue = nullptr;
+    uint32_t queue_family = UINT32_MAX;
+    // Features the compute backend requires; when false it must decline the shared device.
+    bool storage_image_read_without_format = false;
+    bool storage_image_write_without_format = false;
+    bool valid() const { return instance && physical && device && queue && queue_family != UINT32_MAX; }
+};
+void set_shared_vulkan_context(const SharedVulkanContext& context);
+SharedVulkanContext shared_vulkan_context();
+
 // Ordered memory producers need the same authoritative storage version as live compute. A source
 // may begin inside a target, so the renderer validates the complete requested byte range instead of
 // exposing an unbounded pointer into its cache.

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -4057,6 +4057,9 @@ bool is_live_render_target(uint64_t gpu_addr) {
 }
 static LiveTargetReaderFn g_live_target_reader;
 void set_live_target_reader(LiveTargetReaderFn fn) { g_live_target_reader = std::move(fn); }
+static SharedVulkanContext g_shared_vulkan;
+void set_shared_vulkan_context(const SharedVulkanContext& context) { g_shared_vulkan = context; }
+SharedVulkanContext shared_vulkan_context() { return g_shared_vulkan; }
 bool read_live_render_target(uint64_t gpu_addr, LiveTargetSnapshot& snapshot) {
     snapshot = {};
     return g_live_target_reader && g_live_target_reader(gpu_addr, snapshot);

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -419,6 +419,12 @@ inline BackendRenderTimingStats backend_render_timing_stats() {
 // instance/physical-device/device/queue ONCE (lazy, thread-safe static init) and reuse it across every
 // call. Per-call Vulkan resources are created independently and are retained until their direct call
 // or explicit ordered submission batch completes. The context intentionally leaks at process exit.
+// LIFETIME INVARIANT: this context is intentionally never destroyed (no destructor; the device and
+// instance leak at process exit). The compute backend BORROWS this device (#1091) and its static
+// destructor calls vkDestroyPipeline/vkFreeMemory on it at exit, with unspecified cross-TU
+// destruction order. Adding a destructor here that destroys the device would therefore create an
+// immediate use-after-free in ~VulkanComputeContext. Do not add one without first giving compute an
+// explicit release-before-teardown handshake.
 struct RenderVkCtx {
     VkInstance inst = VK_NULL_HANDLE; VkPhysicalDevice phys = VK_NULL_HANDLE;
     VkDevice dev = VK_NULL_HANDLE; VkQueue queue = VK_NULL_HANDLE; uint32_t qfi = UINT32_MAX;
@@ -536,6 +542,26 @@ inline const RenderVkCtx& render_vk_ctx() {
         if (vkCreateDevice(r.phys, &dci, nullptr, &r.dev) != VK_SUCCESS || !r.dev) return r;
         vkGetDeviceQueue(r.dev, r.qfi, 0, &r.queue);
         r.ok = true;
+        // Publish this device so the compute backend can adopt it instead of creating a second one
+        // (#1091). Only the features compute needs are advertised; it declines the shared context if
+        // they are missing and creates its own device exactly as before. Graphics and compute run
+        // strictly sequentially on one thread, so sharing the queue needs no extra synchronization.
+        if (!std::getenv("PROSPER_NO_SHARED_VULKAN_DEVICE")) {
+            prosper::gpu::SharedVulkanContext shared;
+            shared.instance = r.inst;
+            shared.physical = r.phys;
+            shared.device = r.dev;
+            shared.queue = r.queue;
+            shared.queue_family = r.qfi;
+            // Publish what the device was actually CREATED with (feats), not what the physical
+            // device merely supports. They are equal today because feats.x = supported.x
+            // unconditionally, but the consumer's contract is "enabled here" -- if these ever became
+            // gated like aniso/logicOp are, publishing `supported` would let compute emit shaders
+            // declaring a capability the device never enabled.
+            shared.storage_image_read_without_format = feats.shaderStorageImageReadWithoutFormat;
+            shared.storage_image_write_without_format = feats.shaderStorageImageWriteWithoutFormat;
+            prosper::gpu::set_shared_vulkan_context(shared);
+        }
         return r;
     }();
     return c;

--- a/prosper/tests/test_shared_vulkan_device.cpp
+++ b/prosper/tests/test_shared_vulkan_device.cpp
@@ -1,0 +1,71 @@
+// test_shared_vulkan_device — the live renderer must PUBLISH its Vulkan device so the compute
+// backend can adopt it (#1091 phase 1).
+//
+// This guards a failure mode that is otherwise invisible: without it, deleting the publish call
+// leaves every other test green while the optimization silently reverts to two devices and the
+// host round trip it exists to remove. The published handles must also be the renderer's own, since
+// adopting a different device would be worse than not adopting at all.
+#include "../src/gpu/gpu_execute.hpp"
+#include "render_runner.h"
+#include "../frontends/shared/live_renderer.hpp"
+#include <string>
+#include <cstdio>
+
+static int fails = 0;
+#define CHECK(cond, msg) do { if (!(cond)) { printf("  [FAIL] %s\n", msg); fails++; } \
+                              else         { printf("  [ok]   %s\n", msg); } } while (0)
+
+int main() {
+    // Nothing published before the renderer initializes: headless compute-only use must keep
+    // creating its own device (tests/test_game_compute.cpp depends on this).
+    CHECK(!prosper::gpu::shared_vulkan_context().valid(),
+          "no shared context is published before the renderer initializes");
+
+    // THE load-bearing assertion: registering the live renderer must publish, WITHOUT anyone having
+    // called render_vk_ctx() first. Compute initializes lazily on its first dispatch and titles
+    // routinely dispatch before their first draw, so if publication waited for the first draw the
+    // compute device would win the race and the two would never share. Calling render_vk_ctx()
+    // directly here would hide that: it publishes internally, so the check must come first.
+    prosper::frontend::register_live_renderer(std::string(), false);
+    CHECK(prosper::gpu::shared_vulkan_context().valid() ||
+              !prosper::test::render_vk_ctx().ok,
+          "register_live_renderer() publishes the shared context (or no device exists at all)");
+
+    const prosper::test::RenderVkCtx& ctx = prosper::test::render_vk_ctx();
+    if (!ctx.ok) {
+        printf("test_shared_vulkan_device: no Vulkan device available, skipping\n");
+        return 0;                       // CI images without a usable ICD skip rather than fail
+    }
+
+    const prosper::gpu::SharedVulkanContext shared = prosper::gpu::shared_vulkan_context();
+    CHECK(shared.valid(), "renderer publishes a valid shared context once initialized");
+    CHECK(shared.device == static_cast<void*>(ctx.dev), "published device is the renderer's device");
+    CHECK(shared.queue == static_cast<void*>(ctx.queue), "published queue is the renderer's queue");
+    CHECK(shared.physical == static_cast<void*>(ctx.phys), "published physical device matches");
+    CHECK(shared.instance == static_cast<void*>(ctx.inst), "published instance matches");
+    CHECK(shared.queue_family == ctx.qfi, "published queue family matches");
+
+    // The compute backend only adopts when the storage-image features are enabled; a device without
+    // them must publish them as false so compute declines rather than emitting illegal capabilities.
+    VkPhysicalDeviceFeatures supported{};
+    vkGetPhysicalDeviceFeatures(ctx.phys, &supported);
+    CHECK(shared.storage_image_read_without_format ==
+              (supported.shaderStorageImageReadWithoutFormat == VK_TRUE),
+          "published storage-image READ flag reflects the device");
+    CHECK(shared.storage_image_write_without_format ==
+              (supported.shaderStorageImageWriteWithoutFormat == VK_TRUE),
+          "published storage-image WRITE flag reflects the device");
+
+    // Adopting a queue family without COMPUTE would make every dispatch invalid usage.
+    uint32_t count = 0;
+    vkGetPhysicalDeviceQueueFamilyProperties(ctx.phys, &count, nullptr);
+    std::vector<VkQueueFamilyProperties> props(count);
+    vkGetPhysicalDeviceQueueFamilyProperties(ctx.phys, &count, props.data());
+    CHECK(shared.queue_family < count &&
+          (props[shared.queue_family].queueFlags & VK_QUEUE_COMPUTE_BIT) != 0,
+          "published queue family supports COMPUTE (dispatches are legal on it)");
+
+    printf(fails ? "test_shared_vulkan_device: %d FAILURE(S)\n"
+                 : "test_shared_vulkan_device: all ok\n", fails);
+    return fails ? 1 : 0;
+}


### PR DESCRIPTION
## Problem

`live_compute` creates its **own** `VkInstance`/`VkDevice`, separate from the live renderer's. Two devices cannot share images, so a dispatch binding a renderer-owned color target must round-trip through host memory: read back GPU→CPU, detile/unpack on the CPU, upload ~33 MB back. Profiling Blasphemous 2's menu (#1082) measured **~36.8 ms readback + ~19.8 ms CPU prepare per image-bearing dispatch, against 0.39 ms of actual dispatch.**

That round trip is structural — it cannot be removed while the devices are separate.

## Scope: phase 1 only, deliberately behavior-preserving

This shares the device and **nothing else**. Compute still uploads and reads back exactly as before; only the device identity changes. Splitting it this way means any regression is isolated to *device selection* rather than tangled with new image-binding semantics. **Phase 2** (binding renderer-owned images directly, deleting the readback/prepare/upload) becomes possible once this lands.

## Mechanism

Follows the **existing publish/consume seam** the renderer already uses for live-target queries: it publishes its device/queue/physical via `set_shared_vulkan_context`, and compute adopts it.

Handles are **opaque** in `gpu_execute.hpp`, so that layer keeps no Vulkan dependency and `live_compute` gains no dependency on the renderer's header — which would invert layering and, worse, *create* a renderer device on first call in headless tests.

Adoption is **conditional, never mandatory**:
- declined when the published device lacks `shaderStorageImageRead/WriteWithoutFormat` → compute falls back to its own device
- absent entirely in headless compute-only use → private device created exactly as before (`tests/test_game_compute.cpp` covers this)
- `PROSPER_NO_SHARED_VULKAN_DEVICE=1` restores the two-device path for A/B

An adopted context is **borrowed**: compute destroys its own pipelines/pools/memory but never the device, queue, or instance.

## Two findings while implementing

1. **The renderer already enabled the storage-image features compute needs**, so no feature-union work was required — a simplification over the design in #1091.
2. **Publishing at first draw silently adopted nothing.** The first attempt built cleanly and changed nothing: the log showed `[compute] Vulkan device` *before* `[render] Vulkan device`, because titles routinely dispatch compute **before** their first draw, so compute's lazy init won the race. The renderer now creates and publishes its device in `register_live_renderer()`, which is only reached when the live renderer is in use. Worth flagging as the failure mode where a "successful" build ships a no-op.

## Why sharing the queue is safe

`execute_ordered_gpustate` walks **one** ordered operation list on a **single thread**, interleaving draw spans and dispatches in retained PM4 order (#584). Graphics and compute never submit concurrently, so the shared queue needs no cross-thread synchronization. This was the main risk in the design and it is simply not present.

## Verification

- `ctest` **119/119**, including the standalone compute test that runs with **no renderer**
- Snapshot guard **RC=0**, all four routes OK: messenger-scene, evergate-title, dead-cells-gameplay, blasphemous2-gameplay
- Live run logs `adopted the renderer's Vulkan device` and no longer creates a second compute device
- `PROSPER_NO_SHARED_VULKAN_DEVICE=1` verified to restore the previous behavior exactly (0 adoptions, 1 separate compute device)

## Review note

Structural change to Vulkan setup affecting every title and platform. Worth an independent read on: the borrowed-ownership teardown (compute must not destroy the renderer's device, and its caches must not outlive it), the adopt-or-decline predicate, whether `register_live_renderer()` is the right publish point on **all** frontends, and whether any path can reach compute with a *stale* published context (e.g. a renderer torn down and recreated).