### PR TITLE
test: fix reserve_placement Windows CI flake (shrink huge reservations to 160 GiB)

### DIFF
--- a/prosper/tests/test_reserve_placement.cpp
+++ b/prosper/tests/test_reserve_placement.cpp
@@ -70,9 +70,16 @@ static bool span_is_free(uint64_t base, uint64_t len) {
 }
 
 static constexpr uint64_t kArenaHint  = 0x1000000000ull;   // 64 GiB — DQ7's live hint
-static constexpr uint64_t kArenaLen   = 0x8000000000ull;   // 512 GiB
 static constexpr uint64_t kArenaAlign = 0x200000ull;       // 2 MiB — DQ7's live align
 static constexpr uint64_t kHugeMin    = 0x2000000000ull;   // 128 GiB redirect threshold
+// DQ7's real arena is 512 GiB, but the redirect CONTRACT only needs a reservation >= the 128 GiB
+// threshold — and a 512 GiB reservation is fragile on the Windows CI runner: host high-entropy
+// ASLR scatters small allocations across the 880 GiB auto window, so a single mid-window occupant
+// can fragment it below 512 GiB contiguous and the reserve legitimately ENOMEMs (observed flaking
+// case 1). A 160 GiB "huge" reservation clears the threshold and reliably fits a free span in the
+// window regardless of occupancy, keeping the test deterministic while still exercising the huge
+// path (the real 512 GiB size is not load-bearing for any assertion here).
+static constexpr uint64_t kArenaLen   = 0x2800000000ull;   // 160 GiB (>= 128 GiB threshold)
 
 #ifdef __APPLE__
 // The macOS CI job runs x86_64 tests under Rosetta 2, whose VM tracking makes this test's


### PR DESCRIPTION
Test-only. Fixes a flaky **required** test I introduced in #1084 that now intermittently reds Windows MinGW CI on unrelated PRs (observed on #1094).

## Failure

`reserve_placement` reserves 512 GiB "huge" arenas to exercise the #312/#946 redirect. On the Windows MinGW runner, host high-entropy ASLR scatters small allocations across the 880 GiB guest auto window `[0x2000000000, 0xfbffffffff]`; a single mid-window occupant fragments it below 512 GiB contiguous, so `win_reserve` legitimately ENOMEMs and case 1 (`huge non-fixed reserve succeeds`) fails. Host-address-space-dependent → flaky. (Linux's ~3.9 TiB window hides it; Rosetta is already skipped for a different reason.)

## Fix

The 512 GiB size mirrors DQ7's real arena but is **not load-bearing** — the redirect contract only requires a reservation `>= kHugeMin` (128 GiB). Use **160 GiB**, which clears the threshold and reliably fits a contiguous free span regardless of window occupancy. Every assertion (redirect off the low hint, in-window, alignment, vacated-hint reuse, threshold boundary, idempotency-containment) is unchanged; only the reservation magnitude shrinks. Windows band coverage is retained.

## Verification

- Linux: 14/14 checks green (`case1` arena at `0x2000000000`, ends `0x4800000000`; `case2b`/`case5` redirects fit in-window).
- The fix strictly reduces address-space pressure, so the Windows geometry that flaked can no longer occur.

Relates to #1084.