### PR TITLE
feat(hle): deliver sceImeUpdate keyboard events to the guest handler (#1093)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -392,13 +392,15 @@ if(TARGET prosper_core)
 
   # Direct-memory allocate/available (issue #99): AvailableDirectMemorySize reports the largest
   # free aligned block in the search window and writes both out-params (was a total-size stub).
-  add_executable(test_ime_input tests/test_ime_input.cpp)
-  target_link_libraries(test_ime_input PRIVATE prosper_core)
-  add_test(NAME ime_input COMMAND test_ime_input)
-
   add_executable(test_dmem tests/test_dmem.cpp)
   target_link_libraries(test_dmem PRIVATE prosper_core)
   add_test(NAME dmem_available COMMAND test_dmem)
+
+  # IME keyboard event delivery (issue #1093): sceImeUpdate must invoke the guest handler
+  # per queued key event; the old stub delivered none.
+  add_executable(test_ime_input tests/test_ime_input.cpp)
+  target_link_libraries(test_ime_input PRIVATE prosper_core)
+  add_test(NAME ime_input COMMAND test_ime_input)
 
   # Huge non-fixed sceKernelReserveVirtualRange placement (#312/#946): the 512 GiB UE arena
   # must be steered off its low hint into the guest auto window (see test for the contract).

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -392,6 +392,10 @@ if(TARGET prosper_core)
 
   # Direct-memory allocate/available (issue #99): AvailableDirectMemorySize reports the largest
   # free aligned block in the search window and writes both out-params (was a total-size stub).
+  add_executable(test_ime_input tests/test_ime_input.cpp)
+  target_link_libraries(test_ime_input PRIVATE prosper_core)
+  add_test(NAME ime_input COMMAND test_ime_input)
+
   add_executable(test_dmem tests/test_dmem.cpp)
   target_link_libraries(test_dmem PRIVATE prosper_core)
   add_test(NAME dmem_available COMMAND test_dmem)

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -20,6 +20,7 @@
 #include "loader/linker.hpp"           // Program
 #include "input/pad.hpp"               // keyboard -> libScePad (HostPadState / PadBackend)
 #include "pad_overlay.hpp"              // keyboard pad 0 composed over the physical controller backend
+#include "hle/ime_input.hpp"           // #1093: forward host keyboard keys to the guest IME path
 #include "present_mode.hpp"             // explicit swapchain latency/vsync policy, pure regression seam
 #include "window_controls.hpp"           // debounced app-window shortcuts, pure regression seam
 #ifdef PROSPER_HAVE_LIVE_RENDERER
@@ -604,6 +605,12 @@ int main(int argc, char** argv) {
                 key.f11 = ev.key.key == SDLK_F11;
                 key.enter = ev.key.key == SDLK_RETURN || ev.key.key == SDLK_KP_ENTER;
                 key.alt = (ev.key.mod & SDL_KMOD_ALT) != 0;
+                // #1093: forward app-window keys to the guest's IME keyboard path. Titles like
+                // PPSA02664 read input through sceImeUpdate, not libScePad. SDL3 scancodes ARE USB
+                // HID usage ids for the keyboard page — exactly the keycode the guest event wants.
+                // Deliver clean press/release edges (skip auto-repeat).
+                if (key.app_window && !ev.key.repeat)
+                    prosper::ime_push_key((uint16_t)ev.key.scancode, ev.key.down);
                 switch (windowControls.handle_key(key)) {
                 case prosper::frontend::AppWindowCommand::quit:
                     running = false;

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -18,6 +18,7 @@
 #include <cstdlib>
 #include <atomic>
 #include <algorithm>
+#include <deque>
 #include <mutex>
 #include <unordered_map>
 #include <vector>
@@ -1004,8 +1005,74 @@ HLE(s_mouse_read)     { if (a1) memset(PW(a1), 0, 0x18); return 0; }
 // on the device/status enum "disconnected" == 0.
 //   OrbisImeKeyboardResourceIdArray: user_id@0(s32) resource_id[5]@4(u32)                     size 24
 //   OrbisImeKeyboardInfo: user_id@0 device@4 type@8 repeat_delay@12 repeat_rate@16 status@20 rsv[12]@24  size 36
-HLE(s_ime_kbd_open) { svc_log("sceImeKeyboardOpen", a0,a1,a2,a3,a4,a5); return 0; }  // register handler; no events to deliver
-HLE(s_ime_update)   { svc_log("sceImeUpdate", a0,a1,a2,a3,a4,a5); return 0; }        // pump the queue: no events
+// --- IME keyboard event injection (issue #1093) -------------------------------------------------
+// PPSA02664 (Alex Kidd) reads its "press any button" / menu input ONLY through the IME keyboard
+// path: it opens a keyboard and calls sceImeUpdate(handler) every frame, and never touches
+// libScePad or sceUserService. sceImeUpdate must invoke handler(arg, &event) for each queued
+// keyboard event; the old stub returned without calling, delivered no input, and the title never
+// advanced (injected pad input was inert — the game wasn't reading the pad).
+//
+// Event ABI derived directly from the guest handler at eboot+0xf2c540 (PPSA02664 disassembly):
+//   handler(rdi=arg, rsi=SceImeEvent*)   — rdi is unused by this title's handler.
+//   SceImeEvent:  +0x00 u32 id   (0x101 = KEY_DOWN, 0x102 = KEY_UP; 0x103..0x106 = other kbd events)
+//                 +0x08 u16 keycode  (USB HID usage id; indexes the guest's keycode->bit table)
+//                 +0x0a u16 (modifier/char)   +0x0c u32 (status)
+//   KEY_DOWN sets the guest's current + newly-pressed keyboard bitmasks; KEY_UP clears them.
+// HID keycodes verified against the guest's table: Enter=0x28, Space=0x2c, Z=0x1d, A=0x04.
+// CONFIDENCE: HIGH on the id/keycode/offset layout (read from the guest handler + its HID table).
+namespace {
+struct ImeKeyEvent { uint16_t hid; bool down; };
+std::mutex g_ime_mx;
+std::deque<ImeKeyEvent> g_ime_queue;
+
+void ime_deliver(uint64_t handler, const ImeKeyEvent& ev) {
+    if (!handler) return;
+    alignas(16) uint8_t e[0x40] = {0};
+    *(uint32_t*)(e + 0x00) = ev.down ? 0x101u : 0x102u;
+    *(uint16_t*)(e + 0x08) = ev.hid;
+    // Guest handler is SysV-ABI and runs on the guest thread (guest %fs active) — call directly,
+    // exactly as h_qsort calls the guest comparator.
+    ((void (*)(uint64_t, void*))(uintptr_t)handler)(0, e);
+}
+
+// PROSPER_IME_AUTOKEY=1: deliver a repeating Enter down/up pulse so headless routes advance a
+// "press any button" / menu that reads the IME keyboard. Diagnostic/verification lever; the real
+// per-key input comes from a frontend via ime_push_key (below). PROSPER_IME_AUTOKEY_HID overrides
+// the HID usage (default 0x28 Enter). Cadence: down, then up two ticks later, repeating.
+void ime_autokey_tick(uint64_t handler) {
+    static const int on = [] { const char* e = getenv("PROSPER_IME_AUTOKEY");
+                               return e && strtol(e, nullptr, 0) != 0 ? 1 : 0; }();
+    if (!on) return;
+    static const uint16_t hid = [] { const char* e = getenv("PROSPER_IME_AUTOKEY_HID");
+                                     return (uint16_t)(e ? strtol(e, nullptr, 0) : 0x28); }();
+    static std::atomic<uint64_t> tick{0};
+    uint64_t t = tick.fetch_add(1);
+    if ((t % 90) == 0)      ime_deliver(handler, {hid, true});
+    else if ((t % 90) == 2) ime_deliver(handler, {hid, false});
+}
+} // namespace
+
+// Frontend seam (declared in ime_input.hpp): push a keyboard key (USB HID usage id) into the IME
+// queue; drained on the next sceImeUpdate. Thread-safe (called from the frontend's input thread).
+// Mirrors pad_set_backend's role for libScePad.
+void ime_push_key(uint16_t hid_usage, bool down) {
+    std::lock_guard<std::mutex> lk(g_ime_mx);
+    g_ime_queue.push_back({hid_usage, down});
+}
+
+HLE(s_ime_kbd_open) { svc_log("sceImeKeyboardOpen", a0,a1,a2,a3,a4,a5); return 0; }  // handler comes via sceImeUpdate
+HLE(s_ime_update)   {
+    svc_log("sceImeUpdate", a0,a1,a2,a3,a4,a5);
+    ime_autokey_tick(a0);                       // a0 = the guest event handler
+    for (;;) {
+        ImeKeyEvent ev;
+        { std::lock_guard<std::mutex> lk(g_ime_mx);
+          if (g_ime_queue.empty()) break;
+          ev = g_ime_queue.front(); g_ime_queue.pop_front(); }
+        ime_deliver(a0, ev);
+    }
+    return 0;
+}
 // sceImeKeyboardGetResourceId(userId, OrbisImeKeyboardResourceIdArray* out): report the user's keyboard
 // resource ids. Headless -> none (all-zero). A registered PlatformUi (a windowed frontend with a host
 // keyboard) reports its own ids, so a title enables keyboard input (#347).

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -1031,8 +1031,11 @@ void ime_deliver(uint64_t handler, const ImeKeyEvent& ev) {
     *(uint32_t*)(e + 0x00) = ev.down ? 0x101u : 0x102u;
     *(uint16_t*)(e + 0x08) = ev.hid;
     // Guest handler is SysV-ABI and runs on the guest thread (guest %fs active) — call directly,
-    // exactly as h_qsort calls the guest comparator.
-    ((void (*)(uint64_t, void*))(uintptr_t)handler)(0, e);
+    // exactly as h_qsort calls the guest comparator. arg (rdi) is passed 0: PPSA02664's handler
+    // ignores it; a title whose handler consumes the Open-registered arg is not yet modeled (it
+    // would need the arg captured from the sceImeKeyboardOpen param). The PROSPER_SYSV_ABI marker
+    // documents the host->guest boundary (currently expands empty; see dispatch.hpp).
+    ((void (PROSPER_SYSV_ABI *)(uint64_t, void*))(uintptr_t)handler)(0, e);
 }
 
 // PROSPER_IME_AUTOKEY=1: deliver a repeating Enter down/up pulse so headless routes advance a

--- a/prosper/src/hle/ime_input.hpp
+++ b/prosper/src/hle/ime_input.hpp
@@ -1,0 +1,15 @@
+// IME keyboard input seam (issue #1093). A frontend (or a headless route) pushes keyboard keys,
+// identified by USB HID usage id, into a queue that sceImeUpdate drains — invoking the guest's
+// registered event handler per event. Mirrors pad.hpp's pad_set_backend seam for libScePad.
+//
+// Titles that read input through sceImeKeyboardOpen + sceImeUpdate (e.g. PPSA02664) never touch
+// libScePad, so their keyboard input must arrive on this path. Common HID usage ids:
+//   Enter=0x28  Space=0x2c  Escape=0x29  A..Z=0x04..0x1d  Right=0x4f Left=0x50 Down=0x51 Up=0x52
+#pragma once
+#include <cstdint>
+
+namespace prosper {
+// Push one keyboard key transition (USB HID usage id) into the IME event queue. Thread-safe;
+// drained on the next sceImeUpdate on the guest thread. `down` = key press, else release.
+void ime_push_key(uint16_t hid_usage, bool down);
+}

--- a/prosper/tests/test_ime_input.cpp
+++ b/prosper/tests/test_ime_input.cpp
@@ -1,0 +1,71 @@
+// test_ime_input — sceImeUpdate must invoke the guest's registered handler once per queued
+// keyboard event, building the SceImeEvent shape the guest handler reads (issue #1093, ABI derived
+// from PPSA02664's handler at eboot+0xf2c540):
+//   handler(rdi=arg, rsi=SceImeEvent*); event +0x00 u32 id (0x101=down, 0x102=up), +0x08 u16 keycode.
+// A no-event stub (the old behavior) delivered no input, so titles reading input through the IME
+// keyboard path never saw a keypress. Drives the real HLE via the NID registry.
+#include "../src/hle/dispatch.hpp"
+#include "../src/hle/nid.hpp"
+#include "../src/hle/ime_input.hpp"
+#include <cstdio>
+#include <cstdint>
+#include <vector>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+// Fake guest handler: records each delivered event's id + keycode.
+struct Rec { uint32_t id; uint16_t keycode; };
+static std::vector<Rec> g_rec;
+static void fake_handler(uint64_t /*arg*/, void* ev) {
+    auto* e = (uint8_t*)ev;
+    g_rec.push_back({*(uint32_t*)(e + 0x00), *(uint16_t*)(e + 0x08)});
+}
+
+int main() {
+    printf("== test_ime_input ==\n");
+    register_builtin_hle();
+    auto update = reinterpret_cast<uint64_t (*)(uint64_t,uint64_t,uint64_t,uint64_t,uint64_t,uint64_t,uint64_t)>(
+        Hle::lookup(nid_hash("sceImeUpdate")));
+    CHECK(update != nullptr, "sceImeUpdate registered");
+    if (!update) { printf("fails=%d\n", fails); return 1; }
+    const uint64_t H = (uint64_t)(uintptr_t)&fake_handler;
+
+    // No queued events -> handler is never called (a title with no input this frame).
+    g_rec.clear();
+    update(H, 0, 0, 0, 0, 0, 0);
+    CHECK(g_rec.empty(), "no events -> handler not invoked");
+
+    // Enter down then up -> two deliveries, correct ids and keycode (HID Enter = 0x28).
+    g_rec.clear();
+    ime_push_key(0x28, true);
+    ime_push_key(0x28, false);
+    update(H, 0, 0, 0, 0, 0, 0);
+    CHECK(g_rec.size() == 2, "both queued key events delivered in one update");
+    if (g_rec.size() == 2) {
+        CHECK(g_rec[0].id == 0x101 && g_rec[0].keycode == 0x28, "key DOWN -> id 0x101, keycode 0x28");
+        CHECK(g_rec[1].id == 0x102 && g_rec[1].keycode == 0x28, "key UP   -> id 0x102, keycode 0x28");
+    }
+
+    // FIFO order across keys, and the queue drains fully (empty on the next update).
+    g_rec.clear();
+    ime_push_key(0x2c, true);   // Space
+    ime_push_key(0x1d, true);   // Z
+    update(H, 0, 0, 0, 0, 0, 0);
+    CHECK(g_rec.size() == 2 && g_rec[0].keycode == 0x2c && g_rec[1].keycode == 0x1d,
+          "events delivered in FIFO order");
+    g_rec.clear();
+    update(H, 0, 0, 0, 0, 0, 0);
+    CHECK(g_rec.empty(), "queue fully drained (no re-delivery)");
+
+    // A null handler must not crash (a title may pump before registering).
+    ime_push_key(0x28, true);
+    update(0, 0, 0, 0, 0, 0, 0);
+    CHECK(true, "null handler tolerated");
+
+    printf("fails=%d\n", fails);
+    return fails ? 1 : 0;
+}


### PR DESCRIPTION
Fixes #1093 (the dead IME input path). Does **not** by itself resolve PPSA02664's black screen — see Scope.

## Failure

`sceImeUpdate` was a no-op stub that returned without invoking the guest's registered event handler. Any title reading input through the IME keyboard path (`sceImeKeyboardOpen` + per-frame `sceImeUpdate`) therefore received **no keyboard input at all**. PPSA02664 (Alex Kidd) uses exactly this path and never touches libScePad or sceUserService (proven by a full `PROSPER_SVCLOG` census: `sceImeUpdate` is its only per-frame input poll).

## Fix

An IME key-event queue drained on the guest thread inside `sceImeUpdate`, invoking `handler(arg, &event)` once per queued event. `ime_push_key(hid_usage, down)` (`ime_input.hpp`) is the frontend/route seam, mirroring `pad_set_backend` for libScePad.

**Event ABI derived from primary evidence** — the guest handler's disassembly (`eboot+0xf2c540`, base-pinned via self_dump) and its HID keycode→bit table:
- `handler(rdi=arg, rsi=SceImeEvent*)` — `arg` unused by this title's handler.
- `SceImeEvent`: `+0x00` u32 id (**0x101 = KEY_DOWN, 0x102 = KEY_UP**; 0x103–0x106 other kbd events), `+0x08` u16 keycode (USB HID usage id), `+0x0a` u16, `+0x0c` u32.
- KEY_DOWN sets the guest's current + newly-pressed keyboard bitmasks; KEY_UP clears them.

**Verified live**: delivering HID `0x28` (Enter) sets/clears **bit 13** in the guest's keyboard current and newly-pressed bitmasks (`newly[0]=0x2000`), exactly as the handler intends — the delivery is correct at the guest-state level.

## Scope (honest)

This fixes the dead input path and is verified correct, but a **90 s auto-Enter run produces zero logical progression** on PPSA02664 (no new scene, assets, or pad enumeration). So that title's post-logo black screen is **not IME-gated** — it renders ~13 draws/frame that composite to fully black, a graphics-composition issue in the #320/#710 family, tracked there. This PR is reusable infrastructure for any IME-keyboard-input title, not the Alex Kidd progression fix.

## Verification

- `test_ime_input` (new): drives the real HLE via the NID registry with a fake handler; pins id/keycode (0x101/0x102, HID 0x28), FIFO order, full drain, and null-handler tolerance. RED against the old stub (handler never invoked). 
- Full `ctest` **126/126** (Linux).
- Live guest-state verification as above (Enter → bit 13).

## Risk

The guest handler is SysV-ABI and runs on the guest thread with guest `%fs` active, so it is called directly (exactly as `h_qsort` calls the guest comparator). No existing behavior changes when the queue is empty (the common path). `PROSPER_IME_AUTOKEY` is an off-by-default headless-route diagnostic.

Independent review warranted: reverse-engineered guest-ABI semantics.