### PR TITLE
perf(compute): bind renderer-owned color targets directly instead of readback + re-upload

### DIFF
--- a/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
+++ b/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
@@ -853,30 +853,32 @@ import, including on every failure path. `PROSPER_NO_DIRECT_RTT_BIND=1` forces t
 Functional result, Blasphemous 2 title route: **731 direct binds, zero fallbacks to the host path,
 zero validation errors** -- every renderer-owned sampled binding in that route took the fast path.
 
-Throughput, measured on an **idle** machine through `tools/perf/ab_compute.sh`, 3 alternating reps of
-150 s on `load-save-first-station.pad` (a real gameplay scene, not a menu):
+Throughput, measured on an **idle** machine through `tools/perf/ab_compute.sh`, **4 reps with the arm
+order alternating by rep parity**, 150 s each on `load-save-first-station.pad` (a real gameplay scene,
+not a menu):
 
-| | compute, run-wide | compute, gameplay tail | gameplay frame rate |
-|---|---|---|---|
-| host path (`PROSPER_NO_DIRECT_RTT_BIND=1`) | 7.60 ms | 7.84 ms | 13.0 fps |
-| direct bind | 5.94 ms | 5.88 ms | 14.0 fps |
-| | **-21.8%** | **-25.0%** | **+7.7%** |
+| | compute, gameplay tail | gameplay frame rate |
+|---|---|---|
+| host path (`PROSPER_NO_DIRECT_RTT_BIND=1`) | 7.75 ms | 13.3 fps |
+| direct bind | 5.97 ms | 16.6 fps |
+| | **-23.0%** | **+24.3%** |
 
-Every enabled run beat every disabled run on all three metrics, and the compute memory pool drops
-**80.1 -> 63.7 MiB** (9 -> 7 cached allocations) as the per-dispatch staging buffer and the duplicate
-image disappear.
+Split by order, to show the warm-up confound is not producing the result: OFF-first gives -23.7% /
++22.3%, ON-first gives -22.3% / +26.6%. The compute memory pool drops **80.1 -> 63.7 MiB** (9 -> 7
+cached allocations) as the per-dispatch staging buffer and the duplicate image disappear.
 
-**A 25% stage win is a 7.7% frame win, and the two must never be reported interchangeably.** Frame
-time goes 76.7 -> 71.2 ms, about 5.4 ms saved per frame.
+**Always alternate the arm order.** An earlier 3-rep sweep ran OFF before ON every time, handing the
+second arm every warm-up benefit there is -- on-disk pipeline caches, GPU clock ramp, page cache -- and
+that arm was the one being advocated. Repetition does not detect a systematic bias; only alternating or
+randomising the order does. Here the bias turned out to be small, but it was not knowable in advance.
 
-**The accounting does NOT fully close, and an earlier revision of this section wrongly claimed it did.**
-The route runs 5.28 compute calls per frame, so removing 1.66 ms from each predicts an **8.5 ms** frame
-saving; only **5.4 ms** (64%) materialised. Measured non-compute time per frame *rose* 36.7 -> 39.8 ms
-across the arms. The most likely confound is the fixed wall clock: both arms run 150 s, so the faster
-arm renders more frames (2450 vs 2298) and therefore progresses FURTHER along the route, rendering
-different -- and here evidently heavier -- content. A fixed-wall-clock A/B does not compare identical
-scenes. Treat the 5.4 ms as the honest observed figure and the 8.5 ms as an upper bound; closing this
-gap needs a fixed-WORK route (equal frame counts or a fixed scene) rather than a fixed-duration one.
+**The compute delta reproduces; its frame-rate translation does not.** Across two independent sessions
+the compute saving was stable (-25.0% then -23.0%), while the measured frame-rate benefit ranged from
+**+7.7% to +24.3%**, with the host-path arm steady near 13 fps and the direct-bind arm varying between
+14.0 and 17.5 fps. The fast path is conditional by design -- it is taken only while the persistent
+image is the authoritative copy -- so how often it applies can legitimately vary between runs, and
+absolute frame rates from different sessions are not comparable. Quote within-session deltas, and
+treat any single frame-rate figure here as indicative rather than exact.
 
 ### Distance to a playable frame rate
 
@@ -885,8 +887,10 @@ gap needs a fixed-WORK route (equal frame counts or a fixed scene) rather than a
 | frame time | **71.2 ms (14.0 fps)** | 33.3 ms | 16.7 ms |
 | required | -- | **2.14x faster** (remove 37.9 ms) | **4.27x faster** (remove 54.5 ms) |
 
-Composition of the current 71.2 ms frame: **compute 31.4 ms (44%)** (5.28 calls x 5.94 ms) and
-**everything else 39.8 ms (56%)**.
+Composition of the current frame, from the earlier session's 71.2 ms measurement: **compute 31.4 ms
+(44%)** (5.28 calls x 5.94 ms) and **everything else 39.8 ms (56%)**. A later session measured the same
+build at 60 ms (16.6 fps); see the variance note above, and re-derive the split rather than reusing
+these absolutes.
 
 **Compute alone is 94% of a 30 fps budget and 188% of a 60 fps budget.** Even if every non-compute cost
 went to zero, compute as it stands would still miss 60 fps by roughly 2x. So 60 fps is not reachable by

--- a/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
+++ b/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
@@ -856,15 +856,22 @@ zero validation errors** -- every renderer-owned sampled binding in that route t
 Throughput, measured on an **idle** machine through `tools/perf/ab_compute.sh`, 3 alternating reps of
 150 s on `load-save-first-station.pad` (a real gameplay scene, not a menu):
 
-| | run-wide mean | gameplay-tail mean |
-|---|---|---|
-| host path (`PROSPER_NO_DIRECT_RTT_BIND=1`) | 7.60 ms | 7.84 ms |
-| direct bind | 5.94 ms | 5.88 ms |
-| | **-21.8%** | **-25.0%** |
+| | compute, run-wide | compute, gameplay tail | gameplay frame rate |
+|---|---|---|---|
+| host path (`PROSPER_NO_DIRECT_RTT_BIND=1`) | 7.60 ms | 7.84 ms | 13.0 fps |
+| direct bind | 5.94 ms | 5.88 ms | 14.0 fps |
+| | **-21.8%** | **-25.0%** | **+7.7%** |
 
-Every enabled run beat every disabled run on both metrics, and the compute memory pool drops
+Every enabled run beat every disabled run on all three metrics, and the compute memory pool drops
 **80.1 -> 63.7 MiB** (9 -> 7 cached allocations) as the per-dispatch staging buffer and the duplicate
 image disappear.
+
+**A 25% stage win is a 7.7% frame win, and the two must never be reported interchangeably.** Frame
+time goes 76.8 -> 71.3 ms, i.e. about 5.5 ms saved per frame, which is exactly the ~2.8 compute calls
+per frame times the 1.96 ms this removes from each. The accounting closes -- but the honest headline is
+that gameplay remains **about 14 fps**: this change removes 5.5 ms from a 71 ms frame and leaves the
+other 71 ms untouched. Any further work on this umbrella should profile where that remainder goes
+rather than continuing to optimise compute-side RTT handling, which is now a minority cost.
 
 **Measure gameplay, not only menus.** An earlier pass measured the title-screen route and reported
 about 13%. Gameplay is a different draw and dispatch mix and showed a *larger* win, but the direction

--- a/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
+++ b/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
@@ -867,11 +867,33 @@ Every enabled run beat every disabled run on all three metrics, and the compute 
 image disappear.
 
 **A 25% stage win is a 7.7% frame win, and the two must never be reported interchangeably.** Frame
-time goes 76.8 -> 71.3 ms, i.e. about 5.5 ms saved per frame, which is exactly the ~2.8 compute calls
-per frame times the 1.96 ms this removes from each. The accounting closes -- but the honest headline is
-that gameplay remains **about 14 fps**: this change removes 5.5 ms from a 71 ms frame and leaves the
-other 71 ms untouched. Any further work on this umbrella should profile where that remainder goes
-rather than continuing to optimise compute-side RTT handling, which is now a minority cost.
+time goes 76.7 -> 71.2 ms, about 5.4 ms saved per frame.
+
+**The accounting does NOT fully close, and an earlier revision of this section wrongly claimed it did.**
+The route runs 5.28 compute calls per frame, so removing 1.66 ms from each predicts an **8.5 ms** frame
+saving; only **5.4 ms** (64%) materialised. Measured non-compute time per frame *rose* 36.7 -> 39.8 ms
+across the arms. The most likely confound is the fixed wall clock: both arms run 150 s, so the faster
+arm renders more frames (2450 vs 2298) and therefore progresses FURTHER along the route, rendering
+different -- and here evidently heavier -- content. A fixed-wall-clock A/B does not compare identical
+scenes. Treat the 5.4 ms as the honest observed figure and the 8.5 ms as an upper bound; closing this
+gap needs a fixed-WORK route (equal frame counts or a fixed scene) rather than a fixed-duration one.
+
+### Distance to a playable frame rate
+
+| | current | 30 fps | 60 fps |
+|---|---|---|---|
+| frame time | **71.2 ms (14.0 fps)** | 33.3 ms | 16.7 ms |
+| required | -- | **2.14x faster** (remove 37.9 ms) | **4.27x faster** (remove 54.5 ms) |
+
+Composition of the current 71.2 ms frame: **compute 31.4 ms (44%)** (5.28 calls x 5.94 ms) and
+**everything else 39.8 ms (56%)**.
+
+**Compute alone is 94% of a 30 fps budget and 188% of a 60 fps budget.** Even if every non-compute cost
+went to zero, compute as it stands would still miss 60 fps by roughly 2x. So 60 fps is not reachable by
+optimising the non-compute remainder: the number of dispatches per frame, or their cost, has to fall by
+a large multiple. That is a different class of work from the per-dispatch savings in #1091/#1095 --
+which have now taken the per-call cost from 7.60 to 5.94 ms and removed the readback/re-upload
+entirely, leaving the remaining per-call cost to be attacked structurally.
 
 **Measure gameplay, not only menus.** An earlier pass measured the title-screen route and reported
 about 13%. Gameplay is a different draw and dispatch mix and showed a *larger* win, but the direction

--- a/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
+++ b/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
@@ -850,16 +850,33 @@ The borrowed image gets its own view (preserving T# `DST_SEL` swizzle routing), 
 renderer's own tracking stays true. The cache entry is pinned per successful import and released per
 import, including on every failure path. `PROSPER_NO_DIRECT_RTT_BIND=1` forces the host path for A/B.
 
-Blasphemous 2 title route, 3 alternating reps: 731 direct binds, zero fallbacks to the host path, zero
-validation errors. Compute call **7.63 -> 6.62 ms** mean (about 13%), with every enabled run faster than
-every disabled run, and the compute memory pool dropping **80.1 -> 63.7 MiB** (9 -> 7 cached
-allocations) as the per-dispatch staging buffer and duplicate image disappear.
+Functional result, Blasphemous 2 title route: **731 direct binds, zero fallbacks to the host path,
+zero validation errors** -- every renderer-owned sampled binding in that route took the fast path.
 
-**Route caveat.** These numbers come from a title-screen/menu route. That scene's draw and dispatch mix
-is not representative of gameplay, and optimizations must be validated on both -- a change that helps a
-UI-heavy scene can be neutral once real geometry and lighting dominate. Use the tail of the rolling
-`[render-window] compute ... avg_ms` line (reset every 25 calls) to measure a gameplay section without
-diluting it with loading and menus. Tracked on [#1082](https://github.com/mattias800/ps5ys/issues/1082).
+Throughput, measured on an **idle** machine through `tools/perf/ab_compute.sh`, 3 alternating reps of
+150 s on `load-save-first-station.pad` (a real gameplay scene, not a menu):
+
+| | run-wide mean | gameplay-tail mean |
+|---|---|---|
+| host path (`PROSPER_NO_DIRECT_RTT_BIND=1`) | 7.60 ms | 7.84 ms |
+| direct bind | 5.94 ms | 5.88 ms |
+| | **-21.8%** | **-25.0%** |
+
+Every enabled run beat every disabled run on both metrics, and the compute memory pool drops
+**80.1 -> 63.7 MiB** (9 -> 7 cached allocations) as the per-dispatch staging buffer and the duplicate
+image disappear.
+
+**Measure gameplay, not only menus.** An earlier pass measured the title-screen route and reported
+about 13%. Gameplay is a different draw and dispatch mix and showed a *larger* win, but the direction
+could equally have gone the other way -- a change that helps a UI-heavy scene can be neutral once real
+geometry and lighting dominate. Report the gameplay portion separately rather than averaging it with
+loading and menus: `ab_compute.sh` prints both the run-wide mean and the mean of the trailing
+`[render-window]` rolling averages for exactly this reason (#1082).
+
+**Record the conditions, not just the number.** The first title-route measurement was taken while an
+interactive session was using the same GPU, which makes it unattributable -- performance has no
+equivalent of ctest's exit code. `ab_compute.sh` therefore refuses to run when another `prosper-app`
+is alive and stamps the commit, route, reps and duration onto its output.
 
 ## Next renderer step
 

--- a/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
+++ b/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
@@ -809,6 +809,58 @@ GC suspension continue. The same binary and route can pass on a retry. This is t
 [#712](https://github.com/mattias800/ps5ys/issues/712); do not misclassify it as a renderer-cache
 regression without checking the submit count and suspend logs.
 
+## Renderer-owned RTT sampling: direct image binding (#1091 phase 1 / #1095 phase 2)
+
+The renderer and the compute backend historically created SEPARATE Vulkan devices, so a surface the
+renderer owned could not be handed to a dispatch at all. Sampling one cost a full GPU->CPU readback of
+the persistent color target, a per-texel conversion, a fresh `VkImage`, and a re-upload of those same
+pixels to the GPU. `live_renderer.cpp` recorded the constraint directly: "Compute cannot import that
+color attachment directly."
+
+Phase 1 (#1091, merged as #1092) removed the premise: the renderer publishes its `VkDevice`, physical
+device, queue and queue family through `SharedVulkanContext`, and compute ADOPTS that context when it
+is present and feature-adequate. An adopted context is *borrowed* -- the consumer destroys none of it.
+Compute still creates its own device when no renderer is registered, so headless compute-only use is
+unaffected. Phase 1 is an enabler, not an optimization: a 3-rep A/B measured no throughput change
+(7.74 ms / 45.1 fps shared vs 7.85 ms / 46.0 fps separate), which is the intended result.
+
+Phase 2 (#1095) takes the win. **Measure the binding mix before designing the import.** Instrumentation
+showed renderer-owned compute bindings run about **1000 sampled to 1 storage** -- essentially all
+read-only. That deleted the two hardest requirements from the original sketch: no
+`VK_IMAGE_USAGE_STORAGE_BIT` is needed (`SAMPLED_BIT` is already set on persistent targets), and there
+is no guest writeback contract to preserve, because nothing is written. Every renderer-owned sampled
+binding in the measured route had a single shape: `Unorm8` x4 against an rgba8 target.
+
+Two rules keep the fast path honest, and both are load-bearing:
+
+- **Authority.** The import is offered only while the persistent Vulkan image is the authoritative copy
+  -- exactly when the existing reader would have had to materialize it (`!surface.rgba` or a size
+  mismatch, and `surface.gpu_valid`). The CPU RTT copy and the GPU image are kept coherent by
+  *invalidation*, not by one always being fresher, so whenever a CPU snapshot exists it may be the newer
+  truth (#780) and the snapshot path must still be used. Importing unconditionally would silently
+  resurrect stale pixels.
+- **Exactness.** Only a sampled, non-aliased, single-layer `Unorm8` x4 view whose extent, format and
+  device all match falls through. That shape's host path is a plain `memcpy` into a
+  `VK_FORMAT_R8G8B8A8_UNORM` image, which is precisely what the direct bind produces, so the fast path
+  is byte-identical rather than merely close. `rgba16f` targets deliberately keep the host path: the
+  format selector has no RGBA16F option and converts them down to UNORM8.
+
+The borrowed image gets its own view (preserving T# `DST_SEL` swizzle routing), is barriered into the
+`GENERAL` layout the descriptors declare, and is restored to the layout its owner left it in so the
+renderer's own tracking stays true. The cache entry is pinned per successful import and released per
+import, including on every failure path. `PROSPER_NO_DIRECT_RTT_BIND=1` forces the host path for A/B.
+
+Blasphemous 2 title route, 3 alternating reps: 731 direct binds, zero fallbacks to the host path, zero
+validation errors. Compute call **7.63 -> 6.62 ms** mean (about 13%), with every enabled run faster than
+every disabled run, and the compute memory pool dropping **80.1 -> 63.7 MiB** (9 -> 7 cached
+allocations) as the per-dispatch staging buffer and duplicate image disappear.
+
+**Route caveat.** These numbers come from a title-screen/menu route. That scene's draw and dispatch mix
+is not representative of gameplay, and optimizations must be validated on both -- a change that helps a
+UI-heavy scene can be neutral once real geometry and lighting dominate. Use the tail of the rolling
+`[render-window] compute ... avg_ms` line (reset every 25 calls) to measure a gameplay section without
+diluting it with loading and menus. Tracked on [#1082](https://github.com/mattias800/ps5ys/issues/1082).
+
 ## Next renderer step
 
 Bring up a representative Unreal/3D workload and collect the same stage timings plus a corrected

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -373,10 +373,10 @@ struct BoundImage {
     uint32_t imported_saved_layout = 0;      // VkImageLayout the renderer left the image in
     // Several bindings can borrow the SAME renderer image without being folded together, because
     // the import contract is looser than the alias contract (it ignores sampler state, T# size and
-    // img_dim 1-vs-5). Exactly one of them owns the layout transitions: a second barrier pair would
-    // declare oldLayout=saved on an image already in GENERAL, which is an invalid transition a
-    // driver may treat as a discard.
-    bool imported_barrier_owner = false;
+    // img_dim 1-vs-5). Exactly one of them must emit the layout transitions: a second barrier pair
+    // would declare oldLayout=saved on an image already in GENERAL, which is an invalid transition a
+    // driver may treat as a discard. Ownership is derived at the barrier loops rather than stored
+    // here -- see imported_barrier_owner().
     uint64_t before_hash = 0, after_hash = 0; // trace-only storage-image writeback evidence
     uint64_t nonzero_channels = 0;
 };
@@ -886,14 +886,6 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         bi.imported_addr = r->gpu_addr;
                         bi.imported_saved_layout = import.layout;
                         bi.image = static_cast<VkImage>(import.image);
-                        bi.imported_barrier_owner = true;
-                        for (size_t prior = 0; prior < i; prior++) {
-                            if (images[prior].imported &&
-                                images[prior].imported_addr == r->gpu_addr) {
-                                bi.imported_barrier_owner = false;   // an earlier binding transitions it
-                                break;
-                            }
-                        }
                         live_target.width = import.width;
                         live_target.height = import.height;
                         live_target.format = import.format;
@@ -1648,13 +1640,26 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         VkCommandBufferBeginInfo begin{VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO};
         begin.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
         if (!vk_ok(vkBeginCommandBuffer(command, &begin), "command-begin")) break;
+        // Exactly one binding emits the layout transitions for each borrowed renderer image. The
+        // hazard is per-VkImage, so ownership is keyed on the handle, and it is derived over the
+        // bindings that actually REACH these loops (non-aliased ones) rather than decided at import
+        // time -- an owner chosen earlier could later be folded into an alias, leaving the image
+        // transitioned zero times while descriptors still declare GENERAL.
+        auto imported_barrier_owner = [&](size_t index) {
+            const BoundImage& self = images[index];
+            for (size_t prior = 0; prior < index; prior++)
+                if (images[prior].imported && images[prior].alias_of == SIZE_MAX &&
+                    images[prior].image == self.image)
+                    return false;
+            return true;
+        };
         // Upload every image: UNDEFINED -> TRANSFER_DST, copy the staged texels in, -> GENERAL.
         for (size_t i = 0; i < images.size(); i++) {
             const BoundImage& bi = images[i];
             if (bi.alias_of != SIZE_MAX) continue;
             const ShaderResource* r = bi.resource;
             if (bi.imported) {
-                if (!bi.imported_barrier_owner) continue;   // another binding transitions this image
+                if (!imported_barrier_owner(i)) continue;   // another binding transitions this image
                 // Borrowed renderer image (#1095): nothing to upload. Make the renderer's writes
                 // visible to this dispatch and move it into the GENERAL layout the descriptors
                 // declare. The matching barrier after the dispatch puts it back.
@@ -1711,8 +1716,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         vkCmdDispatch(command, item.launch.groups_x, item.launch.groups_y, item.launch.groups_z);
         // Hand every borrowed renderer image back in the layout its owner left it in (#1095), so the
         // renderer's own layout tracking stays true whether or not a dispatch consumed the target.
-        for (const BoundImage& bi : images) {
-            if (!bi.imported || !bi.imported_barrier_owner || bi.alias_of != SIZE_MAX) continue;
+        for (size_t i = 0; i < images.size(); i++) {
+            const BoundImage& bi = images[i];
+            if (!bi.imported || bi.alias_of != SIZE_MAX || !imported_barrier_owner(i)) continue;
             VkImageMemoryBarrier restore{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
             restore.srcAccessMask = VK_ACCESS_SHADER_READ_BIT;
             // The renderer's next use of a persistent target is frequently vkCmdCopyImageToBuffer
@@ -1763,8 +1769,10 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                    30ull * 1000 * 1000 * 1000), "queue-wait")) {
             // cleanup() destroys the command buffer and releases the borrowed image's pin. With a
             // renderer-owned image bound, in-flight work still references it and its layout
-            // transitions, so drain the queue first rather than freeing it underneath the GPU --
-            // the same fallback readback_persistent_color_target uses on a failed wait.
+            // transitions, so drain the queue first rather than freeing it underneath the GPU.
+            // readback_persistent_color_target uses the same drain but PROMOTES a successful drain
+            // to success; this item stays failed either way, which is the conservative choice for a
+            // dispatch whose results we can no longer trust.
             if (vkQueueWaitIdle(ctx.queue) != VK_SUCCESS && trace)
                 std::fprintf(stderr, "[compute]   queue drain after fence timeout failed\n");
             break;

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -365,6 +365,12 @@ struct BoundImage {
     size_t alias_of = SIZE_MAX;         // exact sampled/storage binding sharing an earlier image/view
     uint8_t* dcc_metadata = nullptr;    // DCC control bytes to mark uncompressed after writeback
     size_t dcc_metadata_bytes = 0;
+    // Borrowed renderer-owned image bound in place (#1095). `image` is then owned by the live
+    // renderer: it must not be destroyed here, its layout must be restored, and the pin taken at
+    // import time must be released.
+    bool imported = false;
+    uint64_t imported_addr = 0;
+    uint32_t imported_saved_layout = 0;      // VkImageLayout the renderer left the image in
     uint64_t before_hash = 0, after_hash = 0; // trace-only storage-image writeback evidence
     uint64_t nonzero_channels = 0;
 };
@@ -696,10 +702,15 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             if (buffer.memory) ctx.release_memory(buffer.memory);
         }
         for (size_t i = 0; i < images.size(); i++) {
+            // A pin is taken per successful import, so it is released per import -- including for a
+            // binding that a later alias check folded into an earlier one (#1095).
+            if (images[i].imported) release_live_render_target_image(images[i].imported_addr);
             if (images[i].alias_of != SIZE_MAX) continue;
             if (images[i].sampler) vkDestroySampler(ctx.device, images[i].sampler, nullptr);
             if (images[i].view) vkDestroyImageView(ctx.device, images[i].view, nullptr);
-            if (images[i].image) vkDestroyImage(ctx.device, images[i].image, nullptr);
+            // An imported image belongs to the live renderer: release the pin, destroy nothing.
+            if (images[i].image && !images[i].imported)
+                vkDestroyImage(ctx.device, images[i].image, nullptr);
             if (images[i].memory) ctx.release_memory(images[i].memory);
             if (staging[i]) vkDestroyBuffer(ctx.device, staging[i], nullptr);
             if (staging_memory[i]) ctx.release_memory(staging_memory[i]);
@@ -851,7 +862,40 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             // writeback publishes ordinary guest bytes and invalidates the renderer-owned copy.
             LiveTargetSnapshot live_target;
             bool renderer_owned = !r->in_mip_tail && is_live_render_target(r->gpu_addr);
-            if (renderer_owned) {
+            // Bind the renderer's own image when it is the authoritative copy and this binding
+            // matches it EXACTLY (#1095, phase 2 of #1091). Restricted to a sampled Unorm8x4 view of
+            // an rgba8 target because that is the one shape whose host path is a plain memcpy into a
+            // VK_FORMAT_R8G8B8A8_UNORM image -- the direct bind is then byte-identical, and it skips
+            // a full readback plus a re-upload of those same pixels to the same device. Every other
+            // shape (notably rgba16f, which the host path converts down to UNORM8) keeps that path.
+            if (renderer_owned && !bi.storage && !dim_1d && !dim_3d && !dim_2d_array &&
+                r->depth == 1 && !r->depth_compare && r->format == DataFormat::Unorm8 &&
+                (r->num_components ? r->num_components : 1) == 4) {
+                LiveTargetImageImport import;
+                if (import_live_render_target_image(r->gpu_addr, import)) {
+                    if (import.format == LiveTargetPixelFormat::Rgba8Unorm &&
+                        import.width == r->width && import.height == r->height &&
+                        import.device == static_cast<void*>(ctx.device)) {
+                        bi.imported = true;
+                        bi.imported_addr = r->gpu_addr;
+                        bi.imported_saved_layout = import.layout;
+                        bi.image = static_cast<VkImage>(import.image);
+                        live_target.width = import.width;
+                        live_target.height = import.height;
+                        live_target.format = import.format;
+                        if (trace)
+                            std::fprintf(stderr,
+                                         "[compute]   bound renderer RTT in place binding=%u "
+                                         "addr=0x%llx extent=%ux%u format=rgba8\n",
+                                         bi.binding, (unsigned long long)r->gpu_addr,
+                                         r->width, r->height);
+                    } else {
+                        // Not our exact contract (a different device or a stale aliased view).
+                        release_live_render_target_image(r->gpu_addr);
+                    }
+                }
+            }
+            if (renderer_owned && !bi.imported) {
                 if (dim_3d || r->depth != 1 ||
                     !read_live_render_target(r->gpu_addr, live_target) || !live_target.pixels) {
                     skip_image(r, "renderer-owned RTT has no readable snapshot"); break;
@@ -992,8 +1036,11 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             staging_bytes[i] = sbytes;
 
             // Fill the upload staging bytes.
-            std::vector<uint8_t> upload((size_t)sbytes, 0);
-            if (bi.storage) {
+            std::vector<uint8_t> upload(bi.imported ? size_t{0} : (size_t)sbytes, 0);
+            if (bi.imported) {
+                // The renderer's image is the source: there is nothing to convert or stage.
+                bi.guest_bytes = 0;
+            } else if (bi.storage) {
                 if (r->tile_mode && !tile_mode_is_tiled(r->tile_mode)) {
                     skip_image(r, "storage tile mode has no supported address pattern"); break;
                 }
@@ -1322,26 +1369,29 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 }
             }
 
-            // Staging buffer (host-visible) holding the upload bytes; reused for storage readback.
-            VkBufferCreateInfo sci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
-            sci.size = sbytes;
-            sci.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
-            if (!vk_ok(vkCreateBuffer(ctx.device, &sci, nullptr, &staging[i]),
-                       "image-staging-buffer")) { images_ready = false; break; }
-            VkMemoryRequirements sreq{};
-            vkGetBufferMemoryRequirements(ctx.device, staging[i], &sreq);
-            const uint32_t staging_memory_type = ctx.host_memory_type(sreq.memoryTypeBits);
-            staging_memory[i] = ctx.allocate_memory(sreq.size, staging_memory_type);
-            if (!vk_handle_ok(staging_memory[i], "image-staging-memory") ||
-                !vk_ok(vkBindBufferMemory(ctx.device, staging[i], staging_memory[i], 0),
-                       "image-staging-bind")) {
-                images_ready = false; break; }
-            { void* mapped = nullptr;
-              if (!vk_ok(vkMapMemory(ctx.device, staging_memory[i], 0, sbytes, 0, &mapped),
-                         "image-staging-map")) {
-                  images_ready = false; break; }
-              std::memcpy(mapped, upload.data(), (size_t)sbytes);
-              vkUnmapMemory(ctx.device, staging_memory[i]); }
+            // Staging buffer (host-visible) holding the upload bytes; reused for storage
+            // readback. An imported renderer image supplies its own pixels, so it needs none.
+            if (!bi.imported) {
+                VkBufferCreateInfo sci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
+                sci.size = sbytes;
+                sci.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+                if (!vk_ok(vkCreateBuffer(ctx.device, &sci, nullptr, &staging[i]),
+                           "image-staging-buffer")) { images_ready = false; break; }
+                VkMemoryRequirements sreq{};
+                vkGetBufferMemoryRequirements(ctx.device, staging[i], &sreq);
+                const uint32_t staging_memory_type = ctx.host_memory_type(sreq.memoryTypeBits);
+                staging_memory[i] = ctx.allocate_memory(sreq.size, staging_memory_type);
+                if (!vk_handle_ok(staging_memory[i], "image-staging-memory") ||
+                    !vk_ok(vkBindBufferMemory(ctx.device, staging[i], staging_memory[i], 0),
+                           "image-staging-bind")) {
+                    images_ready = false; break; }
+                { void* mapped = nullptr;
+                  if (!vk_ok(vkMapMemory(ctx.device, staging_memory[i], 0, sbytes, 0, &mapped),
+                             "image-staging-map")) {
+                      images_ready = false; break; }
+                  std::memcpy(mapped, upload.data(), (size_t)sbytes);
+                  vkUnmapMemory(ctx.device, staging_memory[i]); }
+            }
 
             // Device-local image.
             VkImageCreateInfo ici{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
@@ -1375,15 +1425,19 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                     : VK_IMAGE_USAGE_SAMPLED_BIT) |
                         VK_IMAGE_USAGE_TRANSFER_DST_BIT;
             ici.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-            if (!vk_ok(vkCreateImage(ctx.device, &ici, nullptr, &bi.image),
-                       "image-create")) { images_ready = false; break; }
-            VkMemoryRequirements ireq{};
-            vkGetImageMemoryRequirements(ctx.device, bi.image, &ireq);
-            const uint32_t image_memory_type = device_memory_type(ireq.memoryTypeBits);
-            bi.memory = ctx.allocate_memory(ireq.size, image_memory_type);
-            if (!vk_handle_ok(bi.memory, "image-memory") ||
-                !vk_ok(vkBindImageMemory(ctx.device, bi.image, bi.memory, 0), "image-bind")) {
-                images_ready = false; break; }
+            // An imported binding already holds the renderer's image; only the view/sampler below
+            // are ours to create. `ici` is still filled above so the view matches its format/layers.
+            if (!bi.imported) {
+                if (!vk_ok(vkCreateImage(ctx.device, &ici, nullptr, &bi.image),
+                           "image-create")) { images_ready = false; break; }
+                VkMemoryRequirements ireq{};
+                vkGetImageMemoryRequirements(ctx.device, bi.image, &ireq);
+                const uint32_t image_memory_type = device_memory_type(ireq.memoryTypeBits);
+                bi.memory = ctx.allocate_memory(ireq.size, image_memory_type);
+                if (!vk_handle_ok(bi.memory, "image-memory") ||
+                    !vk_ok(vkBindImageMemory(ctx.device, bi.image, bi.memory, 0), "image-bind")) {
+                    images_ready = false; break; }
+            }
             VkImageViewCreateInfo vci{VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO};
             vci.image = bi.image;
             vci.viewType = dim_1d ? VK_IMAGE_VIEW_TYPE_1D
@@ -1585,6 +1639,25 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             const BoundImage& bi = images[i];
             if (bi.alias_of != SIZE_MAX) continue;
             const ShaderResource* r = bi.resource;
+            if (bi.imported) {
+                // Borrowed renderer image (#1095): nothing to upload. Make the renderer's writes
+                // visible to this dispatch and move it into the GENERAL layout the descriptors
+                // declare. The matching barrier after the dispatch puts it back.
+                VkImageMemoryBarrier to_general{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
+                to_general.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT |
+                                           VK_ACCESS_TRANSFER_WRITE_BIT | VK_ACCESS_SHADER_WRITE_BIT;
+                to_general.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+                to_general.oldLayout = static_cast<VkImageLayout>(bi.imported_saved_layout);
+                to_general.newLayout = VK_IMAGE_LAYOUT_GENERAL;
+                to_general.srcQueueFamilyIndex = to_general.dstQueueFamilyIndex =
+                    VK_QUEUE_FAMILY_IGNORED;
+                to_general.image = bi.image;
+                to_general.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+                vkCmdPipelineBarrier(command, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+                                     VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, 0, 0, nullptr, 0, nullptr,
+                                     1, &to_general);
+                continue;
+            }
             VkImageMemoryBarrier to_dst{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
             to_dst.srcAccessMask = 0;
             to_dst.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
@@ -1621,6 +1694,23 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                static_cast<uint32_t>(item.user_sgprs.size() * sizeof(uint32_t)),
                                item.user_sgprs.data());
         vkCmdDispatch(command, item.launch.groups_x, item.launch.groups_y, item.launch.groups_z);
+        // Hand every borrowed renderer image back in the layout its owner left it in (#1095), so the
+        // renderer's own layout tracking stays true whether or not a dispatch consumed the target.
+        for (const BoundImage& bi : images) {
+            if (!bi.imported || bi.alias_of != SIZE_MAX) continue;
+            VkImageMemoryBarrier restore{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
+            restore.srcAccessMask = VK_ACCESS_SHADER_READ_BIT;
+            restore.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT |
+                                    VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT | VK_ACCESS_SHADER_READ_BIT;
+            restore.oldLayout = VK_IMAGE_LAYOUT_GENERAL;
+            restore.newLayout = static_cast<VkImageLayout>(bi.imported_saved_layout);
+            restore.srcQueueFamilyIndex = restore.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+            restore.image = bi.image;
+            restore.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+            vkCmdPipelineBarrier(command, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                                 VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0, nullptr, 0, nullptr,
+                                 1, &restore);
+        }
         // Storage images: copy the written texels back into the staging buffer for guest writeback.
         for (size_t i = 0; i < images.size(); i++) {
             const BoundImage& bi = images[i];

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -371,6 +371,12 @@ struct BoundImage {
     bool imported = false;
     uint64_t imported_addr = 0;
     uint32_t imported_saved_layout = 0;      // VkImageLayout the renderer left the image in
+    // Several bindings can borrow the SAME renderer image without being folded together, because
+    // the import contract is looser than the alias contract (it ignores sampler state, T# size and
+    // img_dim 1-vs-5). Exactly one of them owns the layout transitions: a second barrier pair would
+    // declare oldLayout=saved on an image already in GENERAL, which is an invalid transition a
+    // driver may treat as a discard.
+    bool imported_barrier_owner = false;
     uint64_t before_hash = 0, after_hash = 0; // trace-only storage-image writeback evidence
     uint64_t nonzero_channels = 0;
 };
@@ -880,6 +886,14 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         bi.imported_addr = r->gpu_addr;
                         bi.imported_saved_layout = import.layout;
                         bi.image = static_cast<VkImage>(import.image);
+                        bi.imported_barrier_owner = true;
+                        for (size_t prior = 0; prior < i; prior++) {
+                            if (images[prior].imported &&
+                                images[prior].imported_addr == r->gpu_addr) {
+                                bi.imported_barrier_owner = false;   // an earlier binding transitions it
+                                break;
+                            }
+                        }
                         live_target.width = import.width;
                         live_target.height = import.height;
                         live_target.format = import.format;
@@ -1640,6 +1654,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             if (bi.alias_of != SIZE_MAX) continue;
             const ShaderResource* r = bi.resource;
             if (bi.imported) {
+                if (!bi.imported_barrier_owner) continue;   // another binding transitions this image
                 // Borrowed renderer image (#1095): nothing to upload. Make the renderer's writes
                 // visible to this dispatch and move it into the GENERAL layout the descriptors
                 // declare. The matching barrier after the dispatch puts it back.
@@ -1697,11 +1712,14 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         // Hand every borrowed renderer image back in the layout its owner left it in (#1095), so the
         // renderer's own layout tracking stays true whether or not a dispatch consumed the target.
         for (const BoundImage& bi : images) {
-            if (!bi.imported || bi.alias_of != SIZE_MAX) continue;
+            if (!bi.imported || !bi.imported_barrier_owner || bi.alias_of != SIZE_MAX) continue;
             VkImageMemoryBarrier restore{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
             restore.srcAccessMask = VK_ACCESS_SHADER_READ_BIT;
+            // The renderer's next use of a persistent target is frequently vkCmdCopyImageToBuffer
+            // or a scanout blit, so make the transition visible to transfer access as well.
             restore.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT |
-                                    VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT | VK_ACCESS_SHADER_READ_BIT;
+                                    VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT | VK_ACCESS_SHADER_READ_BIT |
+                                    VK_ACCESS_TRANSFER_READ_BIT | VK_ACCESS_TRANSFER_WRITE_BIT;
             restore.oldLayout = VK_IMAGE_LAYOUT_GENERAL;
             restore.newLayout = static_cast<VkImageLayout>(bi.imported_saved_layout);
             restore.srcQueueFamilyIndex = restore.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
@@ -1742,7 +1760,15 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         if (!vk_ok(vkQueueSubmit(ctx.queue, 1, &submit, fence), "queue-submit")) break;
         if (trace) std::fprintf(stderr, "[compute]   waiting for dispatch\n");
         if (!vk_ok(vkWaitForFences(ctx.device, 1, &fence, VK_TRUE,
-                                   30ull * 1000 * 1000 * 1000), "queue-wait")) break;
+                                   30ull * 1000 * 1000 * 1000), "queue-wait")) {
+            // cleanup() destroys the command buffer and releases the borrowed image's pin. With a
+            // renderer-owned image bound, in-flight work still references it and its layout
+            // transitions, so drain the queue first rather than freeing it underneath the GPU --
+            // the same fallback readback_persistent_color_target uses on a failed wait.
+            if (vkQueueWaitIdle(ctx.queue) != VK_SUCCESS && trace)
+                std::fprintf(stderr, "[compute]   queue drain after fence timeout failed\n");
+            break;
+        }
         if (trace) std::fprintf(stderr, "[compute]   dispatch complete\n");
         phase_dispatch = ComputeClock::now();
 

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -27,6 +27,7 @@
 #include <string>
 #include <vector>
 #include <set>
+#include <tuple>
 #include <unordered_map>
 
 // Classify a guest address: 0 => not within a reserved/committed guest mapping (see hle_kernel_mem).
@@ -323,6 +324,66 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 : prosper::gpu::LiveTargetPixelFormat::Rgba8Unorm;
             snapshot.pixels = surface.rgba;
             return true;
+        });
+    // Phase 2 of #1091 (#1095): with one shared device the compute backend can sample the renderer's
+    // persistent image in place. Offer it ONLY while that image is the authoritative copy -- exactly
+    // the case the reader above would have had to materialize. Whenever a CPU snapshot exists it may
+    // be the newer truth (a guest GPU write drops the CPU copy and invalidates the GPU target
+    // independently, #780), so the caller must keep using the snapshot path there.
+    // One dispatch can bind the same target through several descriptors, so pins are counted: the
+    // compute backend releases once per successful import and the entry drops at zero.
+    struct PinnedImport { uint32_t width, height; VkFormat format; uint32_t count; };
+    static std::unordered_map<uint64_t, PinnedImport> pinned_imports;
+    const bool direct_bind = !getenv("PROSPER_NO_DIRECT_RTT_BIND");
+    prosper::gpu::set_live_target_image_importer(
+        [invalidate_ds, direct_bind](uint64_t addr, prosper::gpu::LiveTargetImageImport& import) {
+            if (!direct_bind) return false;
+            drain_guest_gpu_writes(g_rtt, invalidate_ds);
+            auto it = g_rtt.find(addr);
+            if (it == g_rtt.end()) return false;
+            RttSurf& surface = it->second;
+            if (!surface.w || !surface.h || !surface.gpu_valid) return false;
+            const VkFormat format = prosper::test::backend_color_format(surface.format);
+            // Map the backend format explicitly and fail closed. A direct bind hands the consumer a
+            // real VkImage, so an unrecognized format must decline rather than be reported as rgba8:
+            // the consumer would then build a mismatched view over the renderer's image.
+            prosper::gpu::LiveTargetPixelFormat pixel_format;
+            if (format == VK_FORMAT_R8G8B8A8_UNORM)
+                pixel_format = prosper::gpu::LiveTargetPixelFormat::Rgba8Unorm;
+            else if (format == VK_FORMAT_R16G16B16A16_SFLOAT)
+                pixel_format = prosper::gpu::LiveTargetPixelFormat::Rgba16Float;
+            else
+                return false;
+            const uint32_t bytes_per_pixel = prosper::test::backend_color_bytes_per_pixel(format);
+            if (!bytes_per_pixel) return false;
+            const uint64_t texels = static_cast<uint64_t>(surface.w) * surface.h;
+            if (texels > UINT64_MAX / bytes_per_pixel) return false;
+            const uint64_t expected = texels * bytes_per_pixel;
+            if (surface.rgba && surface.rgba->size() == expected) return false;  // CPU copy is truth
+            const prosper::test::RenderVkCtx& ctx = prosper::test::render_vk_ctx();
+            if (!ctx.ok) return false;
+            prosper::test::PersistentColorTargetImage* target =
+                prosper::test::find_persistent_color_target(addr, surface.w, surface.h, format);
+            if (!target || !target->image || target->layout == VK_IMAGE_LAYOUT_UNDEFINED) return false;
+            if (!prosper::test::pin_persistent_color_target(addr, surface.w, surface.h, format))
+                return false;
+            target->last_use = ++prosper::test::persistent_color_target_generation();
+            PinnedImport& pin = pinned_imports[addr];
+            pin = {surface.w, surface.h, format, pin.count + 1};
+            import.width = surface.w;
+            import.height = surface.h;
+            import.format = pixel_format;
+            import.image = target->image;
+            import.device = ctx.dev;
+            import.layout = static_cast<uint32_t>(target->layout);
+            return true;
+        },
+        [](uint64_t addr) {
+            auto pinned = pinned_imports.find(addr);
+            if (pinned == pinned_imports.end()) return;
+            PinnedImport& pin = pinned->second;
+            prosper::test::unpin_persistent_color_target(addr, pin.width, pin.height, pin.format);
+            if (--pin.count == 0) pinned_imports.erase(pinned);
         });
     prosper::gpu::set_live_target_byte_range_reader(
         [invalidate_ds](uint64_t addr, uint32_t bytes, std::vector<uint8_t>& output) {

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -27,7 +27,6 @@
 #include <string>
 #include <vector>
 #include <set>
-#include <tuple>
 #include <unordered_map>
 
 // Classify a guest address: 0 => not within a reserved/committed guest mapping (see hle_kernel_mem).
@@ -368,7 +367,14 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
             if (!prosper::test::pin_persistent_color_target(addr, surface.w, surface.h, format))
                 return false;
             target->last_use = ++prosper::test::persistent_color_target_generation();
+            // The unpin key is {addr, w, h, format}. A repeat import that disagreed with the
+            // recorded key would corrupt the outstanding pin's release, so decline instead.
             PinnedImport& pin = pinned_imports[addr];
+            if (pin.count &&
+                (pin.width != surface.w || pin.height != surface.h || pin.format != format)) {
+                prosper::test::unpin_persistent_color_target(addr, surface.w, surface.h, format);
+                return false;
+            }
             pin = {surface.w, surface.h, format, pin.count + 1};
             import.width = surface.w;
             import.height = surface.h;

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -333,6 +333,11 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
     // compute backend releases once per successful import and the entry drops at zero.
     struct PinnedImport { uint32_t width, height; VkFormat format; uint32_t count; };
     static std::unordered_map<uint64_t, PinnedImport> pinned_imports;
+    // gpu_replay registers a renderer from more than one entry point, so this can run twice in a
+    // process. Pins are taken and released within a single dispatch, so the map is empty between
+    // them; clear it anyway so a second registration cannot inherit counts for a cache that no
+    // longer holds those entries.
+    pinned_imports.clear();
     const bool direct_bind = !getenv("PROSPER_NO_DIRECT_RTT_BIND");
     prosper::gpu::set_live_target_image_importer(
         [invalidate_ds, direct_bind](uint64_t addr, prosper::gpu::LiveTargetImageImport& import) {

--- a/prosper/scripts/blasphemous2/README.md
+++ b/prosper/scripts/blasphemous2/README.md
@@ -3,6 +3,26 @@
 Reusable `PROSPER_PAD_SCRIPT` routes for Blasphemous 2 (`PPSA13579`). Run tools
 from `prosper/` so relative script paths resolve.
 
+## Loading a save (preferred for gameplay measurement)
+
+`load-save-first-station.pad` boots, leaves the title, opens "Pilgrimage", and loads an existing
+save at the first Prie Dieu, reaching real gameplay in under two minutes. Prefer it over
+`reach-first-gameplay.pad` for anything that measures or guards GAMEPLAY: the exploratory route
+needs roughly 380 s and every press is a guess against cinematic and tutorial pacing, so a build
+that loads at a different speed silently desynchronises the whole route and measures the wrong
+scene.
+
+It requires save data to exist. A reference copy of the first-station save is kept in
+`saves/savedata0-backup-2026-07-20/` (`slot1/segmentSlot` plus `slot0/segmentGlobal`); restore it
+into the `PROSPER_SAVE0` root (default `/tmp/prosper-savedata0`) before running if that root has
+been cleared. Note the save root is SHARED across titles, not per-game.
+
+The route presses Cross once per five seconds rather than at three fixed offsets. The wall time at
+which each screen becomes ready swings widely with the rendering policy -- the same route reaches
+the title within seconds under `prosper-app` but needs about a minute under full-resolution
+`screenshot` capture -- so it repeats instead of guessing. Surplus presses land in gameplay as
+jumps, which is harmless and keeps both arms of an A/B identical.
+
 ## Current Route
 
 `reach-first-gameplay.pad` is an exploratory Cross route anchored to the

--- a/prosper/scripts/blasphemous2/load-save-first-station.pad
+++ b/prosper/scripts/blasphemous2/load-save-first-station.pad
@@ -1,8 +1,15 @@
 # Blasphemous 2 - LOAD the first-save-station save and land in gameplay.
 #
-# Requires an existing save (a Prie Dieu save at the first station). A reference copy lives in
-# saves/savedata0-backup-2026-07-20/ (slot1/segmentSlot); restore it into the PROSPER_SAVE0 root
-# before running if the live save data has been cleared.
+# Requires an existing save: a Prie Dieu save at the first station, in the PROSPER_SAVE0 root
+# (default /tmp/prosper-savedata0, which is SHARED across titles rather than per-game). The save is
+# NOT committed -- it is a local artifact, since a game save is title data rather than source. To
+# regenerate it: run the title normally, play to the first Prie Dieu and save there; the game writes
+# slot1/segmentSlot plus slot0/segmentGlobal. Keep a copy outside /tmp, which does not survive a
+# reboot.
+#
+# This route is deliberately NOT wired into tools/snapshot/snapshots.json: guards declaring
+# savedata_policy "fresh" get isolated, empty save roots (#1102), so a save-dependent route cannot be
+# a guard without a committed fixture and a "preserve" policy.
 #
 # This replaces the long exploratory reach-first-gameplay route for gameplay measurement. That route
 # sits through the studio logos, EULA, opening cinematic and the bile-flask/movement tutorials, so it

--- a/prosper/scripts/blasphemous2/load-save-first-station.pad
+++ b/prosper/scripts/blasphemous2/load-save-first-station.pad
@@ -1,0 +1,39 @@
+# Blasphemous 2 - LOAD the first-save-station save and land in gameplay.
+#
+# Requires an existing save (a Prie Dieu save at the first station). A reference copy lives in
+# saves/savedata0-backup-2026-07-20/ (slot1/segmentSlot); restore it into the PROSPER_SAVE0 root
+# before running if the live save data has been cleared.
+#
+# This replaces the long exploratory reach-first-gameplay route for gameplay measurement. That route
+# sits through the studio logos, EULA, opening cinematic and the bile-flask/movement tutorials, so it
+# needs roughly 380 s of wall clock and every press is a timing guess against tutorial pacing.
+# Loading a save reaches real gameplay in well under two minutes and depends on no tutorial state.
+#
+# Confirmations needed: Cross leaves the "Press X to continue" title, Cross opens "Pilgrimage",
+# the save list takes a moment to populate, and Cross loads the highlighted save.
+#
+# The presses REPEAT every five seconds rather than firing three times at fixed offsets, because the
+# wall time at which each screen becomes ready swings widely with the rendering policy: the same
+# route reaches the title in a few seconds under prosper-app but needs roughly a minute under
+# full-resolution screenshot capture. Holds are one second because synchronous native-resolution
+# rendering can leave this title only two or three pad polls per second. Surplus presses land in
+# gameplay as jumps, which is harmless and keeps both arms of an A/B identical.
+1-2:cross
+6-7:cross
+11-12:cross
+16-17:cross
+21-22:cross
+26-27:cross
+31-32:cross
+36-37:cross
+41-42:cross
+46-47:cross
+51-52:cross
+56-57:cross
+61-62:cross
+66-67:cross
+71-72:cross
+76-77:cross
+81-82:cross
+86-87:cross
+91-92:cross

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -430,6 +430,35 @@ struct LiveTargetSnapshot {
 using LiveTargetReaderFn = std::function<bool(uint64_t gpu_addr, LiveTargetSnapshot& snapshot)>;
 void set_live_target_reader(LiveTargetReaderFn fn);
 bool read_live_render_target(uint64_t gpu_addr, LiveTargetSnapshot& snapshot);
+
+// Direct GPU import of a renderer-owned color target (#1095, phase 2 of #1091). Once graphics and
+// compute share one VkDevice, a dispatch that SAMPLES a renderer-owned surface can read the
+// renderer's persistent image in place instead of forcing a GPU->CPU readback and an immediate
+// re-upload of the very same pixels to the very same device.
+//
+// AUTHORITY RULE: the import is offered only while the persistent Vulkan image is the authoritative
+// copy of the surface -- exactly the case where read_live_render_target() would have had to
+// materialize it. Whenever a CPU RTT snapshot already exists it may be the NEWER truth (a guest GPU
+// write discards the CPU copy and invalidates the GPU target independently, #780), so the caller
+// must fall back to the snapshot path rather than assume the two agree.
+//
+// The image is BORROWED: the caller must not destroy it, must restore `layout` before returning, and
+// must call release_live_render_target_image() to drop the pin that keeps the renderer's cache from
+// evicting the entry mid-dispatch. Handles stay opaque so this layer keeps no Vulkan dependency.
+struct LiveTargetImageImport {
+    uint32_t width = 0, height = 0;
+    LiveTargetPixelFormat format = LiveTargetPixelFormat::Rgba8Unorm;
+    void* image = nullptr;    // VkImage owned by the live renderer
+    void* device = nullptr;   // VkDevice it belongs to; the caller must be running on that device
+    uint32_t layout = 0;      // VkImageLayout the renderer left it in -- restore it after the dispatch
+    bool valid() const { return image && device && width && height; }
+};
+using LiveTargetImageImportFn = std::function<bool(uint64_t gpu_addr, LiveTargetImageImport& import)>;
+using LiveTargetImageReleaseFn = std::function<void(uint64_t gpu_addr)>;
+void set_live_target_image_importer(LiveTargetImageImportFn import_fn,
+                                    LiveTargetImageReleaseFn release_fn);
+bool import_live_render_target_image(uint64_t gpu_addr, LiveTargetImageImport& import);
+void release_live_render_target_image(uint64_t gpu_addr);
 // Shared Vulkan device (#1091 phase 1). live_compute historically created its own VkInstance/VkDevice,
 // so a renderer-owned image could never be bound to a dispatch and had to round-trip through host
 // memory. The live renderer publishes its already-created device here; the compute backend ADOPTS it

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -4069,7 +4069,13 @@ bool import_live_render_target_image(uint64_t gpu_addr, LiveTargetImageImport& i
     import = LiveTargetImageImport{};
     if (!g_live_target_image_import) return false;
     if (!g_live_target_image_import(gpu_addr, import)) { import = LiveTargetImageImport{}; return false; }
-    if (!import.valid()) { import = LiveTargetImageImport{}; return false; }
+    if (!import.valid()) {
+        // The importer pinned the entry before returning true; drop that pin rather than leaking a
+        // permanently un-evictable cache entry if a future importer breaks the contract.
+        release_live_render_target_image(gpu_addr);
+        import = LiveTargetImageImport{};
+        return false;
+    }
     return true;
 }
 void release_live_render_target_image(uint64_t gpu_addr) {

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -4057,6 +4057,24 @@ bool is_live_render_target(uint64_t gpu_addr) {
 }
 static LiveTargetReaderFn g_live_target_reader;
 void set_live_target_reader(LiveTargetReaderFn fn) { g_live_target_reader = std::move(fn); }
+
+static LiveTargetImageImportFn g_live_target_image_import;
+static LiveTargetImageReleaseFn g_live_target_image_release;
+void set_live_target_image_importer(LiveTargetImageImportFn import_fn,
+                                    LiveTargetImageReleaseFn release_fn) {
+    g_live_target_image_import = std::move(import_fn);
+    g_live_target_image_release = std::move(release_fn);
+}
+bool import_live_render_target_image(uint64_t gpu_addr, LiveTargetImageImport& import) {
+    import = LiveTargetImageImport{};
+    if (!g_live_target_image_import) return false;
+    if (!g_live_target_image_import(gpu_addr, import)) { import = LiveTargetImageImport{}; return false; }
+    if (!import.valid()) { import = LiveTargetImageImport{}; return false; }
+    return true;
+}
+void release_live_render_target_image(uint64_t gpu_addr) {
+    if (g_live_target_image_release) g_live_target_image_release(gpu_addr);
+}
 static SharedVulkanContext g_shared_vulkan;
 void set_shared_vulkan_context(const SharedVulkanContext& context) { g_shared_vulkan = context; }
 SharedVulkanContext shared_vulkan_context() { return g_shared_vulkan; }

--- a/prosper/tools/perf/ab_compute.sh
+++ b/prosper/tools/perf/ab_compute.sh
@@ -17,9 +17,10 @@ ROUTE="${2:?route .pad file}"
 DUMP="${3:?game dump dir}"
 REPS="${4:-3}"
 SECS="${5:-60}"
+cd "$(dirname "$0")/../.."
+# Resolve AFTER the cd so a relative AB_OUT_DIR is created where it is later written.
 OUT="${AB_OUT_DIR:-$(mktemp -d)}"
 mkdir -p "$OUT" || { echo "cannot create output dir: $OUT" >&2; exit 2; }
-cd "$(dirname "$0")/../.."
 
 # --- refuse to measure against a contended GPU -------------------------------------------------
 # Match the EXECUTABLE, not any command line containing the string -- a -f match also catches the
@@ -61,10 +62,25 @@ tail_fps() {
 
 bad=0
 for rep in $(seq 1 "$REPS"); do
-  off=$(run "off_$rep" "$SWITCH");  offt=$(tail_window "off_$rep");  offf=$(tail_fps "off_$rep")
-  on=$(run  "on_$rep"  "");         ont=$(tail_window "on_$rep");   onf=$(tail_fps "on_$rep")
-  echo "rep$rep  compute ms/call  OFF run=${off:-n/a} tail=${offt:-n/a}   ON run=${on:-n/a} tail=${ont:-n/a}"
-  echo "rep$rep  frame rate       OFF tail=${offf:-n/a} fps            ON tail=${onf:-n/a} fps"
+  # Re-check contention every rep: a competing process can start mid-sweep, and a startup-only
+  # check would let it silently skew the remaining reps.
+  if [ "$(pgrep -x prosper-app | wc -l)" -gt 0 ]; then
+    echo "ABORTING at rep$rep: another prosper-app started mid-sweep" >&2; exit 2
+  fi
+  # ALTERNATE the arm order by rep parity. Running one arm consistently first hands the second arm
+  # every warm-up benefit there is -- on-disk pipeline caches, GPU clock ramp, page cache -- which
+  # systematically favours it. With a fixed order that bias is indistinguishable from the effect
+  # being measured, and it flatters whichever arm is scheduled second.
+  if [ $((rep % 2)) -eq 1 ]; then
+    off=$(run "off_$rep" "$SWITCH"); on=$(run "on_$rep" "")
+  else
+    on=$(run "on_$rep" ""); off=$(run "off_$rep" "$SWITCH")
+  fi
+  offt=$(tail_window "off_$rep");  offf=$(tail_fps "off_$rep")
+  ont=$(tail_window "on_$rep");    onf=$(tail_fps "on_$rep")
+  order=$([ $((rep % 2)) -eq 1 ] && echo "OFF-first" || echo "ON-first")
+  echo "rep$rep ($order)  compute ms/call  OFF run=${off:-n/a} tail=${offt:-n/a}   ON run=${on:-n/a} tail=${ont:-n/a}"
+  echo "rep$rep ($order)  frame rate       OFF tail=${offf:-n/a} fps            ON tail=${onf:-n/a} fps"
   # A run that produced no timing is a FAILED measurement, not a zero result. Reporting n/a and
   # exiting 0 would let a harness that never launched anything read as a clean benchmark.
   for v in "$off" "$on"; do [ -n "$v" ] || bad=1; done

--- a/prosper/tools/perf/ab_compute.sh
+++ b/prosper/tools/perf/ab_compute.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# A/B one PROSPER_* switch against a routed live run and report the compute-call cost.
+#
+# WHY THIS EXISTS: a timing number carries no evidence of the conditions it was taken under. This
+# machine is shared by several agents and a human, so a benchmark can silently run against a busy
+# GPU and produce a number nobody can attribute. ctest has an exit code; performance does not --
+# so this harness REFUSES to run when another prosper-app is alive, and records the conditions
+# alongside the result.
+#
+# Usage: ab_compute.sh <switch=value> <route.pad> <dump-dir> [reps] [seconds]
+#   e.g. ab_compute.sh PROSPER_NO_DIRECT_RTT_BIND=1 scripts/blasphemous2/title-screen-idle.pad \
+#          /home/mattias800/repos/ps5ys/PPSA13579-app0 3 60
+# The switch names the OFF (baseline) condition; ON is the same run with the switch unset.
+set -u
+SWITCH="${1:?switch=value naming the OFF condition}"
+ROUTE="${2:?route .pad file}"
+DUMP="${3:?game dump dir}"
+REPS="${4:-3}"
+SECS="${5:-60}"
+OUT="${AB_OUT_DIR:-$(mktemp -d)}"
+cd "$(dirname "$0")/../.."
+
+# --- refuse to measure against a contended GPU -------------------------------------------------
+# Match the EXECUTABLE, not any command line containing the string -- a -f match also catches the
+# wrapper shells that invoked this script, which would make the guard fire against itself.
+others=$(pgrep -x prosper-app | wc -l)
+if [ "$others" -gt 0 ]; then
+  echo "REFUSING TO MEASURE: $others prosper-app process(es) already running." >&2
+  echo "Another agent or an interactive session is using the GPU; timings would be unattributable." >&2
+  pgrep -ax prosper-app >&2
+  exit 2
+fi
+if [ ! -d "$DUMP" ]; then echo "dump not found: $DUMP" >&2; exit 2; fi
+if [ ! -f "$ROUTE" ]; then echo "route not found: $ROUTE" >&2; exit 2; fi
+
+echo "# ab_compute  commit=$(git rev-parse --short HEAD)$(git diff --quiet || echo '+dirty')"
+echo "# route=$ROUTE  reps=$REPS  seconds=$SECS  off_switch=$SWITCH"
+echo "# started=$(date -u +%Y-%m-%dT%H:%M:%SZ)  logs=$OUT"
+
+run() { # $1=label  $2=extra env ("" for ON)
+  env SDL_AUDIO_DRIVER=dummy PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct \
+      PROSPER_RENDER=1 PROSPER_VULKAN_LIB=libvulkan.so.1 PROSPER_RENDER_TIMING=1 $2 \
+      PROSPER_PAD_SCRIPT="@$ROUTE" \
+      timeout "$SECS" ./build-linux/prosper-app --dump "$DUMP" > "$OUT/$1.log" 2>&1
+  # run-wide mean; for a long route prefer the rolling-window tail (see --tail below)
+  grep '\[render-timing\] compute calls=' "$OUT/$1.log" | tail -1 \
+    | sed -E 's/.*avg_ms=([0-9.]+).*/\1/'
+}
+tail_window() { # mean of the last N rolling windows = the route's tail (skips menus/loading)
+  grep '\[render-window\] compute' "$OUT/$1.log" | tail -"${AB_TAIL_WINDOWS:-20}" \
+    | sed -E 's/.*avg_ms=([0-9.]+).*/\1/' | awk '{s+=$1;n++} END {if(n) printf "%.2f", s/n}'
+}
+
+for rep in $(seq 1 "$REPS"); do
+  off=$(run "off_$rep" "$SWITCH");  offt=$(tail_window "off_$rep")
+  on=$(run  "on_$rep"  "");         ont=$(tail_window "on_$rep")
+  echo "rep$rep  OFF run=${off:-n/a} tail=${offt:-n/a}   ON run=${on:-n/a} tail=${ont:-n/a}  (ms/compute call)"
+done
+echo "# finished=$(date -u +%Y-%m-%dT%H:%M:%SZ)"

--- a/prosper/tools/perf/ab_compute.sh
+++ b/prosper/tools/perf/ab_compute.sh
@@ -18,6 +18,7 @@ DUMP="${3:?game dump dir}"
 REPS="${4:-3}"
 SECS="${5:-60}"
 OUT="${AB_OUT_DIR:-$(mktemp -d)}"
+mkdir -p "$OUT" || { echo "cannot create output dir: $OUT" >&2; exit 2; }
 cd "$(dirname "$0")/../.."
 
 # --- refuse to measure against a contended GPU -------------------------------------------------
@@ -51,9 +52,17 @@ tail_window() { # mean of the last N rolling windows = the route's tail (skips m
     | sed -E 's/.*avg_ms=([0-9.]+).*/\1/' | awk '{s+=$1;n++} END {if(n) printf "%.2f", s/n}'
 }
 
+bad=0
 for rep in $(seq 1 "$REPS"); do
   off=$(run "off_$rep" "$SWITCH");  offt=$(tail_window "off_$rep")
   on=$(run  "on_$rep"  "");         ont=$(tail_window "on_$rep")
   echo "rep$rep  OFF run=${off:-n/a} tail=${offt:-n/a}   ON run=${on:-n/a} tail=${ont:-n/a}  (ms/compute call)"
+  # A run that produced no timing is a FAILED measurement, not a zero result. Reporting n/a and
+  # exiting 0 would let a harness that never launched anything read as a clean benchmark.
+  for v in "$off" "$on"; do [ -n "$v" ] || bad=1; done
 done
 echo "# finished=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+if [ "$bad" -ne 0 ]; then
+  echo "MEASUREMENT FAILED: at least one run produced no [render-timing] output; see $OUT" >&2
+  exit 1
+fi

--- a/prosper/tools/perf/ab_compute.sh
+++ b/prosper/tools/perf/ab_compute.sh
@@ -51,12 +51,20 @@ tail_window() { # mean of the last N rolling windows = the route's tail (skips m
   grep '\[render-window\] compute' "$OUT/$1.log" | tail -"${AB_TAIL_WINDOWS:-20}" \
     | sed -E 's/.*avg_ms=([0-9.]+).*/\1/' | awk '{s+=$1;n++} END {if(n) printf "%.2f", s/n}'
 }
+# FRAME RATE is the metric a user actually feels, and it is NOT interchangeable with the compute
+# cost above: a large win on one stage converts to a much smaller win on the frame if that stage is
+# a minority of frame time. Always report both, or a change looks better than it is.
+tail_fps() {
+  grep -oE '^\[app\] [0-9.]+ fps' "$OUT/$1.log" | grep -oE '[0-9.]+' \
+    | tail -"${AB_TAIL_WINDOWS:-20}" | awk '{s+=$1;n++} END {if(n) printf "%.1f", s/n}'
+}
 
 bad=0
 for rep in $(seq 1 "$REPS"); do
-  off=$(run "off_$rep" "$SWITCH");  offt=$(tail_window "off_$rep")
-  on=$(run  "on_$rep"  "");         ont=$(tail_window "on_$rep")
-  echo "rep$rep  OFF run=${off:-n/a} tail=${offt:-n/a}   ON run=${on:-n/a} tail=${ont:-n/a}  (ms/compute call)"
+  off=$(run "off_$rep" "$SWITCH");  offt=$(tail_window "off_$rep");  offf=$(tail_fps "off_$rep")
+  on=$(run  "on_$rep"  "");         ont=$(tail_window "on_$rep");   onf=$(tail_fps "on_$rep")
+  echo "rep$rep  compute ms/call  OFF run=${off:-n/a} tail=${offt:-n/a}   ON run=${on:-n/a} tail=${ont:-n/a}"
+  echo "rep$rep  frame rate       OFF tail=${offf:-n/a} fps            ON tail=${onf:-n/a} fps"
   # A run that produced no timing is a FAILED measurement, not a zero result. Reporting n/a and
   # exiting 0 would let a harness that never launched anything read as a clean benchmark.
   for v in "$off" "$on"; do [ -n "$v" ] || bad=1; done

--- a/prosper/tools/snapshot/snapshot.py
+++ b/prosper/tools/snapshot/snapshot.py
@@ -169,9 +169,18 @@ def apply_entry_env(env, entry, tmp):
         env.setdefault("PROSPER_PAD_SCRIPT_LOG", "1")
     save_policy = entry.get("savedata_policy")
     if save_policy == "fresh":
+        # prosper has TWO independent save roots and a fresh console state needs BOTH redirected:
+        #   PROSPER_SAVEDATA_DIR -> SaveDataMemory slots (the entire save path for Unity titles)
+        #   PROSPER_SAVE0        -> the /savedata0 file mount (Blasphemous 2 writes slot0/slot1 here)
+        # Redirecting only the first left file-mount titles reading the developer's real saves, so a
+        # route that assumes a new game could silently run against existing progress -- which both
+        # produces false failures and can mask real ones. Both roots are per-run temp dirs.
         save_dir = os.path.join(tmp, "savedata")
         os.makedirs(save_dir, exist_ok=True)
         env["PROSPER_SAVEDATA_DIR"] = save_dir
+        save0_dir = os.path.join(tmp, "savedata0")
+        os.makedirs(save0_dir, exist_ok=True)
+        env["PROSPER_SAVE0"] = save0_dir
     elif save_policy not in (None, "preserve"):
         raise RuntimeError(f"unknown savedata_policy={save_policy!r}; use fresh or preserve")
 

--- a/prosper/tools/snapshot/test_snapshot.py
+++ b/prosper/tools/snapshot/test_snapshot.py
@@ -172,7 +172,16 @@ while True:
             self.assertEqual("@" + route, env["PROSPER_PAD_SCRIPT"])
             self.assertEqual("1", env["PROSPER_PAD_SCRIPT_LOG"])
             self.assertEqual("yes", env["EXTRA"])
+            # BOTH save roots must be redirected into the run's temp dir, or a "fresh" guard
+            # inherits the developer's real saves: PROSPER_SAVEDATA_DIR covers SaveDataMemory (the
+            # Unity titles) and PROSPER_SAVE0 covers the /savedata0 file mount (Blasphemous 2).
+            # Leaving either on its shared /tmp default lets existing progress carry a blind route
+            # past the content it guards, so the guard can pass without rendering that scene (#1102).
             self.assertTrue(os.path.isdir(env["PROSPER_SAVEDATA_DIR"]))
+            self.assertTrue(os.path.isdir(env["PROSPER_SAVE0"]))
+            self.assertTrue(env["PROSPER_SAVEDATA_DIR"].startswith(tmp))
+            self.assertTrue(env["PROSPER_SAVE0"].startswith(tmp))
+            self.assertNotEqual(env["PROSPER_SAVEDATA_DIR"], env["PROSPER_SAVE0"])
 
     def test_structural_similarity_tolerates_small_changes_but_rejects_missing_layer(self):
         reference = (100,) * (16 * 9)


### PR DESCRIPTION
Fixes #1095. Phase 2 of #1091 (phase 1 = device unification, merged as #1092).

## Failure scenario

When a compute dispatch sampled a surface owned by the live renderer, prosper:

1. read the persistent Vulkan color target back to the CPU,
2. converted it texel by texel into a staging buffer,
3. created a fresh `VkImage` and uploaded ~8.3 MB back to the same device.

All of that reconstructed an image that was **already resident on that device in that format**.
`live_renderer.cpp` recorded why: *"Compute cannot import that color attachment directly."* That was
true when graphics and compute owned separate `VkDevice`s. #1092 removed the premise.

## Measurement first, which changed the design

Instrumenting the bindings showed renderer-owned compute bindings run **1000 sampled to 1 storage** --
essentially all read-only. That deleted the two hardest requirements from the original phase-2 sketch:

- no `VK_IMAGE_USAGE_STORAGE_BIT` is needed (`SAMPLED_BIT` is already set on persistent targets), and
- there is **no guest writeback contract to preserve**, because nothing is written.

Every renderer-owned sampled binding in the route had one shape: `Unorm8` x4 against an rgba8 target.

## Behavioral contract

A renderer-side seam hands compute the existing `VkImage`. Two rules keep it honest:

- **Authority.** Offered only while the persistent image is the authoritative copy -- exactly when the
  existing reader would have had to materialize it (`!surface.rgba` or size mismatch, and
  `surface.gpu_valid`). The CPU RTT copy and the GPU image are kept coherent by *invalidation*, not by
  one always being fresher, so when a CPU snapshot exists it may be the newer truth (#780) and the
  snapshot path is still used. Importing unconditionally would silently resurrect stale pixels.
- **Exactness.** Only a sampled, non-aliased, single-layer `Unorm8` x4 view whose extent, format and
  device all match. That shape's host path is a plain `memcpy` into a `VK_FORMAT_R8G8B8A8_UNORM` image
  -- precisely what the direct bind produces -- so the fast path is **byte-identical**, not merely
  close. `rgba16f` deliberately keeps the host path: the format selector has no RGBA16F option and
  converts those down to UNORM8.

Compute creates its own view (preserving T# `DST_SEL` swizzle routing), barriers the image into the
`GENERAL` layout the descriptors declare, and restores the layout its owner left it in. The cache entry
is pinned per successful import and released per import, on every failure path.
`PROSPER_NO_DIRECT_RTT_BIND=1` forces the host path for A/B.

## Independent review found a blocking defect

An independent review found a **silent output-corruption** path, now fixed. Several bindings can borrow
the *same* renderer image without being folded together, because the import contract is deliberately
looser than the alias contract (it ignores sampler state, T# size, and `img_dim` 1-vs-5). Each then
emitted its own layout transition, so the second declared `oldLayout=SHADER_READ_ONLY` on an image
already in `GENERAL`. A barrier whose `oldLayout` is neither `UNDEFINED` nor the current layout is
invalid and a driver may treat it as a **discard**, so sampled texels could silently become garbage.

Exactly one binding now owns the transitions; the others still create their own view/sampler and still
balance their pin. Non-imported bindings never had this problem because each creates its own image --
the hazard came from sharing a borrowed one. The Blasphemous 2 route did not expose it (731 binds, 0
validation errors), but a passing route is not proof the shape cannot occur, and multiple views of one
base are already documented in this code for Astro Bot and Dead Cells.

Also from review: queue drain on fence timeout; pin release on a rejected import; transfer visibility
on the restore barrier; decline on a repeat import that disagrees with the recorded pin key.

## Affected / deliberately unaffected

- **Affected:** compute dispatches sampling a renderer-owned rgba8 RTT at an exactly matching extent.
- **Unaffected:** storage bindings, rgba16f targets, depth, arrays, 1D/3D, mip tails, aliased bindings,
  and every path with no live renderer (headless compute still creates its own device).
- **Capture/bundle oracles unaffected** (reviewer-verified): `live_gpu_targets` is false under every
  capture mode, so `gpu_valid` is never set and the importer always declines there.

## Results

Functional, Blasphemous 2 title route: **731 direct binds, 0 fallbacks, 0 validation errors.**

Throughput on an **idle** machine via `tools/perf/ab_compute.sh`, **4 reps with the arm order
alternating by rep parity**, 150 s each on the save-backed gameplay route:

| | compute (gameplay tail) | gameplay frame rate |
|---|---|---|
| host path | 7.75 ms | 13.3 fps |
| direct bind | 5.97 ms | 16.6 fps |
| | **-23.0%** | **+24.3%** |

Split by order (OFF-first: -23.7% / +22.3%; ON-first: -22.3% / +26.6%), so the warm-up confound is not
producing the result. Compute memory pool **80.1 -> 63.7 MiB** (9 -> 7 cached allocations).

**Two corrections to earlier revisions of this description, both found by re-review:**

1. The original figures came from a sweep that ran **OFF before ON every time**, handing the second arm
   every warm-up benefit -- and that was the arm being advocated. Repetition does not detect a
   systematic bias; only alternating does. Re-measured above; the bias was real but small.
2. An earlier revision reported **+7.7%** frame rate. Across two sessions the compute delta reproduces
   tightly (-25.0% then -23.0%) but its frame-rate translation does **not** (+7.7% to +24.3%), with the
   host arm steady near 13 fps and the direct-bind arm ranging 14.0-17.5. The fast path is conditional
   by design -- taken only while the persistent image is authoritative -- so how often it applies can
   legitimately vary run to run. Treat within-session deltas as the result and any single absolute fps
   figure as indicative.

### Distance to a playable frame rate

| | current | 30 fps | 60 fps |
|---|---|---|---|
| frame time | **71.2 ms (14.0 fps)** | 33.3 ms | 16.7 ms |
| required | -- | **2.14x** (remove 37.9 ms) | **4.27x** (remove 54.5 ms) |

The 71.2 ms frame is **compute 31.4 ms (44%)** and **everything else 39.8 ms (56%)**. Compute alone is
**94% of a 30 fps budget and 188% of a 60 fps budget**, so 60 fps cannot be reached by optimising the
non-compute remainder -- dispatch count or per-dispatch cost has to fall by a large multiple. Recorded
on #1082.

## Also in this PR

- `scripts/blasphemous2/load-save-first-station.pad` -- loads a first-Prie-Dieu save into real gameplay
  in under two minutes, replacing the ~380 s tutorial-timing-dependent route for gameplay measurement.
  Verified by full-resolution capture (player, full HUD, foreground/background art, lighting).
- `tools/perf/ab_compute.sh` -- refuses to measure while another `prosper-app` holds the GPU, stamps
  commit/route/reps/duration, reports compute cost **and** frame rate, and exits non-zero if a run
  produced no timing. Written because the first title-route measurement was taken against a live
  interactive session and had to be discarded as unattributable.

## Verification

- `ctest`: **120/120 green**.
- Build clean; `git diff --check` clean.
- Live route: 731 direct binds, 0 fallbacks, 0 validation errors.
- 3-rep idle A/B as above.
- `python3 tools/snapshot/snapshot.py check`: **in progress**, result posted below before merge. This is
  the output-identity gate that matters most here, since the change alters how sampled RTT data reaches
  compute; rendered output must be identical.

## Risks

- The fast path shares one image across stages, so a layout or synchronization error corrupts pixels
  rather than failing loudly. Mitigated by restricting to a provably byte-identical shape, restoring the
  owner's layout, single-owner barriers, and the snapshot gate.
- The authority rule is the correctness crux: if the CPU/GPU coherence model ever changes so that a
  present CPU snapshot no longer implies "possibly newer", the predicate must be revisited.


