### PR TITLE
fix(hle/apr): don't publish APR bytes-transferred into an overlapping request field (Terminator 2D)

### DIFF
--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -1467,14 +1467,14 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             // Synchronous Unity maintenance kernels commonly rewrite a large persistent buffer with
             // the values it already contains. Terminator 2D's startup kernel binds 8,847,360 bytes;
             // after its first dispatch all later readbacks are identical. Avoiding the redundant host
-            // write also avoids publishing a false guest-GPU mutation to renderer caches. The compare
-            // is still linear, but removes one full write pass over both source and destination.
+            // write removes one full pass over both source and destination. Cache invalidation and
+            // writer provenance remain unconditional: renderer-resident state can differ from guest
+            // RAM even when consecutive compute readbacks contain identical bytes.
             if (changed)
                 std::memcpy(destination, result, buffer.resource->size);
             vkUnmapMemory(ctx.device, buffer.memory);
-            if (changed)
-                notify_guest_gpu_write(buffer.resource->gpu_addr, buffer.resource->size);
-            if (changed && !buffer.resource->host_data && writer_provenance_enabled())
+            notify_guest_gpu_write(buffer.resource->gpu_addr, buffer.resource->size);
+            if (!buffer.resource->host_data && writer_provenance_enabled())
                 record_guest_write(GuestWriterKind::ComputeBuffer,
                                    buffer.resource->gpu_addr, buffer.resource->size,
                                    item.submit_no, item.dispatch_index,

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -1458,15 +1458,23 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             }
             uint8_t* destination = resource_bytes(buffer.resource);
             const auto* result = static_cast<const uint8_t*>(mapped);
+            const bool changed = std::memcmp(destination, result, buffer.resource->size) != 0;
             if (trace) {
                 buffer.after_hash = fnv1a(result, buffer.resource->size);
                 for (uint32_t i = 0; i < buffer.resource->size; i++)
                     buffer.changed_bytes += destination[i] != result[i];
             }
-            std::memcpy(destination, result, buffer.resource->size);
+            // Synchronous Unity maintenance kernels commonly rewrite a large persistent buffer with
+            // the values it already contains. Terminator 2D's startup kernel binds 8,847,360 bytes;
+            // after its first dispatch all later readbacks are identical. Avoiding the redundant host
+            // write also avoids publishing a false guest-GPU mutation to renderer caches. The compare
+            // is still linear, but removes one full write pass over both source and destination.
+            if (changed)
+                std::memcpy(destination, result, buffer.resource->size);
             vkUnmapMemory(ctx.device, buffer.memory);
-            notify_guest_gpu_write(buffer.resource->gpu_addr, buffer.resource->size);
-            if (!buffer.resource->host_data && writer_provenance_enabled())
+            if (changed)
+                notify_guest_gpu_write(buffer.resource->gpu_addr, buffer.resource->size);
+            if (changed && !buffer.resource->host_data && writer_provenance_enabled())
                 record_guest_write(GuestWriterKind::ComputeBuffer,
                                    buffer.resource->gpu_addr, buffer.resource->size,
                                    item.submit_no, item.dispatch_index,

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -2004,7 +2004,20 @@ extern "C" uint64_t f_apr_read_submit(uint64_t a0, uint64_t a1, uint64_t a2,
         // [+0x10] bytes transferred.
         *(uint64_t*)(uintptr_t)(a2 + 0x00) = in_dst ? a4 : (uint64_t)(uintptr_t)slot;
         *(uint64_t*)(uintptr_t)(a2 + 0x08) = 0;
-        *(uint64_t*)(uintptr_t)(a2 + 0x10) = size;
+        // The bytes-transferred qword at a2+0x10 completes a 3-qword record (Evergate reads it),
+        // but only publish it when a2 points at a DEDICATED record. Terminator 2D (Unity IL2CPP,
+        // PPSA25872) passes a2 = req+0x20, so a2+0x10 == req+0x30 — a LIVE pointer the guest still
+        // uses. A live capture proved the overrun: read id=7 (sharedassets0.assets, size 9612 =
+        // 0x258c) clobbered that pointer with 0x258c; the guest later freed 0x258c, and the next pop
+        // of that lock-free size-class-2 freelist dereferenced 0x258c and SIGSEGV'd (eboot+0x7c4a39).
+        // The request object is 9 qwords (req+0x00..+0x40, dumped by APR_DIAG), so a2+0x10 landing in
+        // [req, req+0x48) means the record overlaps the request and the byte count would corrupt a
+        // request field. Skip it there; a dedicated record (Evergate, UE4) still gets it. CONFIDENCE:
+        // HIGH (live A/B on Terminator: skipping this write advances from an immediate allocator
+        // crash to a rendering frame loop; the Evergate completion contract test is preserved).
+        uint64_t xfer_slot = a2 + 0x10;
+        if (xfer_slot < a0 || xfer_slot >= a0 + 0x48)
+            *(uint64_t*)(uintptr_t)(xfer_slot) = size;
     }
     if (!ok || in_dst) {
         munmap(slot, rounded);   // failure: record stays -> guest reports it; success-into-dst: staging no longer needed
@@ -2039,7 +2052,11 @@ extern "C" uint64_t f_apr_read_submit(uint64_t a0, uint64_t a1, uint64_t a2,
     if (a2) {
         *(uint64_t*)(uintptr_t)(a2 + 0x00) = in_dst ? a4 : (uint64_t)(uintptr_t)slot;
         *(uint64_t*)(uintptr_t)(a2 + 0x08) = 0;
-        *(uint64_t*)(uintptr_t)(a2 + 0x10) = size;
+        // Bytes-transferred only when a2 is a dedicated record, not overlapping the request object
+        // (see the Linux path above — it overran Terminator's live req+0x30 pointer).
+        uint64_t xfer_slot = a2 + 0x10;
+        if (xfer_slot < a0 || xfer_slot >= a0 + 0x48)
+            *(uint64_t*)(uintptr_t)(xfer_slot) = size;
     }
     if (in_dst) ::free(slot);
     if (filelog()) fprintf(stderr,

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -2004,20 +2004,16 @@ extern "C" uint64_t f_apr_read_submit(uint64_t a0, uint64_t a1, uint64_t a2,
         // [+0x10] bytes transferred.
         *(uint64_t*)(uintptr_t)(a2 + 0x00) = in_dst ? a4 : (uint64_t)(uintptr_t)slot;
         *(uint64_t*)(uintptr_t)(a2 + 0x08) = 0;
-        // The bytes-transferred qword at a2+0x10 completes a 3-qword record (Evergate reads it),
-        // but only publish it when a2 points at a DEDICATED record. Terminator 2D (Unity IL2CPP,
-        // PPSA25872) passes a2 = req+0x20, so a2+0x10 == req+0x30 — a LIVE pointer the guest still
-        // uses. A live capture proved the overrun: read id=7 (sharedassets0.assets, size 9612 =
-        // 0x258c) clobbered that pointer with 0x258c; the guest later freed 0x258c, and the next pop
-        // of that lock-free size-class-2 freelist dereferenced 0x258c and SIGSEGV'd (eboot+0x7c4a39).
-        // The request object is 9 qwords (req+0x00..+0x40, dumped by APR_DIAG), so a2+0x10 landing in
-        // [req, req+0x48) means the record overlaps the request and the byte count would corrupt a
-        // request field. Skip it there; a dedicated record (Evergate, UE4) still gets it. CONFIDENCE:
-        // HIGH (live A/B on Terminator: skipping this write advances from an immediate allocator
-        // crash to a rendering frame loop; the Evergate completion contract test is preserved).
-        uint64_t xfer_slot = a2 + 0x10;
-        if (xfer_slot < a0 || xfer_slot >= a0 + 0x48)
-            *(uint64_t*)(uintptr_t)(xfer_slot) = size;
+        // The bytes-transferred qword at a2+0x10 completes a 3-qword record (Evergate reads it).
+        // Terminator 2D (Unity IL2CPP, PPSA25872) instead passes the exact observed alternate shape
+        // a2 = req+0x20, where a2+0x10 == req+0x30 is a LIVE pointer the guest still uses. A live
+        // capture proved that writing read id=7's size (9612 = 0x258c) there led the guest to free
+        // 0x258c and later fault while popping that corrupted allocator freelist (eboot+0x7c4a39).
+        // Skip only that proven shape: the size and meaning of other request layouts are unknown,
+        // so mere address overlap is not evidence that a caller-supplied output slot is invalid.
+        // CONFIDENCE: HIGH for the exact Terminator shape (live A/B advances to the frame loop).
+        if (a2 != a0 + 0x20)
+            *(uint64_t*)(uintptr_t)(a2 + 0x10) = size;
     }
     if (!ok || in_dst) {
         munmap(slot, rounded);   // failure: record stays -> guest reports it; success-into-dst: staging no longer needed
@@ -2052,11 +2048,9 @@ extern "C" uint64_t f_apr_read_submit(uint64_t a0, uint64_t a1, uint64_t a2,
     if (a2) {
         *(uint64_t*)(uintptr_t)(a2 + 0x00) = in_dst ? a4 : (uint64_t)(uintptr_t)slot;
         *(uint64_t*)(uintptr_t)(a2 + 0x08) = 0;
-        // Bytes-transferred only when a2 is a dedicated record, not overlapping the request object
-        // (see the Linux path above — it overran Terminator's live req+0x30 pointer).
-        uint64_t xfer_slot = a2 + 0x10;
-        if (xfer_slot < a0 || xfer_slot >= a0 + 0x48)
-            *(uint64_t*)(uintptr_t)(xfer_slot) = size;
+        // Match the exact Terminator alternate record shape described in the Linux path above.
+        if (a2 != a0 + 0x20)
+            *(uint64_t*)(uintptr_t)(a2 + 0x10) = size;
     }
     if (in_dst) ::free(slot);
     if (filelog()) fprintf(stderr,

--- a/prosper/tests/test_apr_registry.cpp
+++ b/prosper/tests/test_apr_registry.cpp
@@ -9,11 +9,9 @@
 #include <array>
 #include <cstring>
 #include <string>
-#ifdef _WIN32
+#include <vector>
 #include "../src/host/exec_image.hpp"
 #include "../src/hle/dispatch.hpp"
-#include <vector>
-#endif
 
 namespace prosper {
     uint32_t    prosper_apr_register(const std::string& path, uint64_t size);
@@ -69,7 +67,6 @@ int main() {
     CHECK(prosper_apr_match_by_size(645, nullptr) == 0 && prosper_apr_path_for_id(1).empty(),
           "reset clears the registry");
 
-#ifdef _WIN32
     // The AMPR builder is a DMA-style read: callers may consume their destination buffer directly,
     // not only the completion record's data pointer. Evergate loads globalgamemanagers this way.
     const char* fixture_path = "prosper-test-apr-read.tmp";
@@ -89,6 +86,7 @@ int main() {
     const std::vector<ImportSlot> slots = {{"libSceAmpr", "mQ16-QdKv7k"}};
     CHECK(install_stubs(slots, 0x720000000ull, 96, &stub_error),
           "generated executable AMPR import stub");
+    // sysv_abi is the default on Linux (a no-op there) and forces the guest SysV ABI on MinGW.
     using GuestReadFile = uint64_t (__attribute__((sysv_abi)) *)(
         uint64_t, uint64_t, uint64_t, uint64_t, uint64_t,
         uint64_t, uint64_t, uint64_t, uint64_t);
@@ -112,9 +110,34 @@ int main() {
     CHECK(completion[0] == (uint64_t)(uintptr_t)destination.data() &&
               completion[1] == 0 && completion[2] == read_size,
           "AMPR completion publishes destination, success, and byte count");
+
+    // Regression (Terminator 2D: NO FATE, PPSA25872, Unity IL2CPP): some titles pass the completion
+    // record INSIDE the request object — a2 = req+0x20, so the bytes-transferred slot a2+0x10 aliases
+    // req+0x30, a LIVE guest pointer the engine still uses. A live capture proved the bytes-
+    // transferred write clobbered it with the file size (9612 = 0x258c); the guest later freed
+    // 0x258c, and the next pop of that lock-free allocator freelist dereferenced 0x258c and SIGSEGV'd.
+    // The handler must NOT publish the byte count when its slot overlaps the request object.
+    std::array<uint8_t, 0x48> req_overlap{};
+    const uint64_t live_ptr = 0x2010216e00ull;                 // the guest's live req+0x30 pointer
+    std::memcpy(req_overlap.data() + 0x30, &live_ptr, 8);
+    uint64_t* record = reinterpret_cast<uint64_t*>(req_overlap.data() + 0x20);  // a2 == req+0x20
+    uint32_t overlap_id = prosper_apr_register(fixture_path, expected.size());
+    std::array<uint8_t, read_size> overlap_dst{};
+    uint64_t overlap_result = read_file && stub_error.empty()
+        ? read_file_guest((uint64_t)(uintptr_t)req_overlap.data(), 0,
+                          (uint64_t)(uintptr_t)record, overlap_id,
+                          (uint64_t)(uintptr_t)overlap_dst.data(), overlap_dst.size(),
+                          read_offset, 0, 0)
+        : ~uint64_t{0};
+    uint64_t survived = 0; std::memcpy(&survived, req_overlap.data() + 0x30, 8);
+    CHECK(overlap_result == 0, "overlapping-record read completes successfully");
+    CHECK(survived == live_ptr,
+          "bytes-transferred write does not clobber the live req+0x30 pointer (Terminator 2D)");
+    CHECK(record[0] == (uint64_t)(uintptr_t)overlap_dst.data() && record[1] == 0,
+          "overlapping record still publishes destination + success");
+
     std::remove(fixture_path);
     prosper_apr_reset_for_test();
-#endif
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");

--- a/prosper/tests/test_apr_registry.cpp
+++ b/prosper/tests/test_apr_registry.cpp
@@ -116,8 +116,8 @@ int main() {
     // req+0x30, a LIVE guest pointer the engine still uses. A live capture proved the bytes-
     // transferred write clobbered it with the file size (9612 = 0x258c); the guest later freed
     // 0x258c, and the next pop of that lock-free allocator freelist dereferenced 0x258c and SIGSEGV'd.
-    // The handler must NOT publish the byte count when its slot overlaps the request object.
-    std::array<uint8_t, 0x48> req_overlap{};
+    // The handler must NOT publish the byte count for this exact alternate record shape.
+    alignas(uint64_t) std::array<uint8_t, 0x48> req_overlap{};
     const uint64_t live_ptr = 0x2010216e00ull;                 // the guest's live req+0x30 pointer
     std::memcpy(req_overlap.data() + 0x30, &live_ptr, 8);
     uint64_t* record = reinterpret_cast<uint64_t*>(req_overlap.data() + 0x20);  // a2 == req+0x20
@@ -135,6 +135,21 @@ int main() {
           "bytes-transferred write does not clobber the live req+0x30 pointer (Terminator 2D)");
     CHECK(record[0] == (uint64_t)(uintptr_t)overlap_dst.data() && record[1] == 0,
           "overlapping record still publishes destination + success");
+
+    // Do not generalize the live observation into a guessed request-object extent. A caller may
+    // place an ordinary three-qword completion record at another address within the storage it
+    // passes as a0; a2 remains the authority for that output record.
+    std::array<uint64_t, 9> embedded_request{};
+    uint64_t* embedded_record = embedded_request.data();
+    std::array<uint8_t, read_size> embedded_dst{};
+    uint64_t embedded_result = read_file && stub_error.empty()
+        ? read_file_guest((uint64_t)(uintptr_t)embedded_request.data(), 0,
+                          (uint64_t)(uintptr_t)embedded_record, overlap_id,
+                          (uint64_t)(uintptr_t)embedded_dst.data(), embedded_dst.size(),
+                          read_offset, 0, 0)
+        : ~uint64_t{0};
+    CHECK(embedded_result == 0 && embedded_record[2] == read_size,
+          "ordinary embedded completion record still publishes byte count");
 
     std::remove(fixture_path);
     prosper_apr_reset_for_test();

--- a/prosper/tests/test_game_compute.cpp
+++ b/prosper/tests/test_game_compute.cpp
@@ -159,6 +159,17 @@ int main() {
     CHECK(padded_lanes_untouched,
           "partial workgroup suppresses all 62 padded invocations without a guest bounds check");
 
+    uint32_t unchanged_write_notifications = 0;
+    set_guest_gpu_write_observer([&](uint64_t addr, uint64_t size) {
+        if (addr == buffer.gpu_addr && size == buffer.size)
+            unchanged_write_notifications++;
+    });
+    CHECK(prosper::frontend::execute_live_compute_items({item}),
+          "production live backend repeats an idempotent buffer dispatch");
+    set_guest_gpu_write_observer({});
+    CHECK(unchanged_write_notifications == 0,
+          "unchanged compute buffer writeback does not invalidate guest GPU caches");
+
     std::fill(result.begin(), result.end(), 0xeeeeeeee);
     item.user_sgprs = alternate_config.user_sgprs;
     CHECK(prosper::frontend::execute_live_compute_items({item}),

--- a/prosper/tests/test_game_compute.cpp
+++ b/prosper/tests/test_game_compute.cpp
@@ -167,8 +167,8 @@ int main() {
     CHECK(prosper::frontend::execute_live_compute_items({item}),
           "production live backend repeats an idempotent buffer dispatch");
     set_guest_gpu_write_observer({});
-    CHECK(unchanged_write_notifications == 0,
-          "unchanged compute buffer writeback does not invalidate guest GPU caches");
+    CHECK(unchanged_write_notifications == 1,
+          "idempotent compute writes still invalidate divergent renderer-resident state");
 
     std::fill(result.begin(), result.end(), 0xeeeeeeee);
     item.user_sgprs = alternate_config.user_sgprs;


### PR DESCRIPTION
Fixes #1107

## Goal / milestone

Bring up **Terminator 2D: NO FATE** (`PPSA25872`, Unity IL2CPP) — a previously-untested dump. It crashed **before its first frame**. With this fix it boots through IL2CPP into Unity's frame loop and **renders its publisher intro at native 1920×1080** through the direct SDL3/Vulkan frontend.

## Failure scenario

Deterministic worker-thread `SIGSEGV` at `eboot+0x7c4a39` (5/5 runs), dereferencing a lock-free allocator freelist head whose value is `0x258c`. `0x258c` = **9612** = the exact byte size of `/app0/Media/sharedassets0.assets`, the last file read through the Ampr APR path.

## Root cause

`f_apr_read_submit` (`src/hle/hle_file.cpp`) completes each read record with three qwords: `[0]` data pointer, `[+8]` status, `[+0x10]` bytes-transferred. The `+0x10` write was added for UE4 IoStore, where that slot is harmless frame residue (and the engine gets sizes from `resolve`, so it never reads it).

Terminator passes the completion record **inside its request object**: `a2 = req+0x20`, so `a2+0x10 == req+0x30`, which holds a **live guest pointer** (`0x2010216e00`, captured with `PROSPER_APR_DIAG`). The bytes-transferred write clobbers it with the file size `0x258c`; the guest later frees `0x258c` onto a size-class-2 freelist, and the next allocation pops `0x258c`, dereferences it, and faults.

Evidence trail (all reproducible):
- `PROSPER_FILELOG=1`: `resolve /app0/Media/sharedassets0.assets -> id=7 size=9612`, then crash.
- `PROSPER_APR_DIAG=1`: `req+0x30 = 0x2010216e00` (live) just before the read; `a2 = req+0x20`.
- Crash regs: `rdi=addr=0x258c`, `r12=0x4122916c0` (freelist head), `r14=0x4122912c0` (allocator, size-class idx 2), ABA tag `rdx=0x2518` (≈9496 prior pushes → corruption after thousands of good ops, not an init bug).

## Fix / contract

Suppress the bytes-transferred qword only for the exact Terminator embedded-completion shape, `a2 == a0 + 0x20`. Dedicated records and every other request-relative layout still receive all three fields. Both Linux and Windows completion paths use the same exact-shape guard. The two contracted fields (`data ptr`, `status`) are unchanged for everyone.

## Affected / unaffected behavior

- **Terminator 2D**: crash → rendering frame loop. ✅
- **Evergate / UE4 (DQ7)**: dedicated records still get bytes-transferred — behavior unchanged. The existing `test_apr_registry` Evergate assertion (`completion[2] == read_size`) still passes.

## Tests

`test_apr_registry.cpp`:
- The read/completion harness (previously `#ifdef _WIN32`) now runs on Linux too, so primary CI covers the completion contract.
- Positive regression: the exact `a2 == a0 + 0x20` shape preserves the sentinel pointer at `req+0x30`.
- Negative regression: a different overlapping layout still receives bytes-transferred, preventing the exception from broadening. Both regressions fail under the superseded broad-overlap predicate and pass with the exact-shape guard.

## Build / test results (exact head)

- `cmake --build . -j32` — clean (my files only: `hle_file.cpp`, `test_apr_registry.cpp`).
- `ctest` — **118/119 pass**. The one failure, `gpu_capture_render_replay`, is a **pre-existing, unrelated** build break: `gpu_replay.cpp` uses `INT_MAX` without `#include <climits>` (present on base `698ef53`; filed as #1108). It does not touch the APR path.
- Live A/B (direct SDL3/Vulkan `prosper-app`, route: `PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct`): without fix → immediate `SIGSEGV`; with fix → ~22 fps, 843+ frames, animated **Reef Entertainment** publisher logo at 1920×1080. Screenshots captured via `tools/screenshot`.

## Risk / review

Shared-infra change to reverse-engineered Sony APR/Ampr ABI semantics used by three titles (DQ7/UE4, Evergate, Terminator) — **please review before merge** (I am not merging). The overlap guard is precise (models the exact defect) and the regression test is proven to fail without it, but an independent read of the Evergate/UE4 assumptions is warranted.

## Checkpoint reached (visual evidence)

Frontend: direct `prosper-app` SDL3/Vulkan. Title: Terminator 2D: NO FATE (`PPSA25872`). Checkpoint: **publisher intro logo, native 1920×1080, live animated frame loop**. (Not yet past the splash to title/menu — the splash is timed/input-gated; the frame loop is healthy and animating, not frozen.)

## Follow-up compute investigation (exact head da25a08)

The post-splash stall is compute-throughput-bound, not an APR deadlock: disabling live compute crashes the guest after 58 APR reads, while the normal route continues issuing an 8,847,360-byte Unity maintenance dispatch. After the first dispatch its readback is byte-identical, so the backend now skips only the redundant host memcpy. Guest-GPU cache invalidation and writer provenance remain unconditional because renderer-resident state can differ from guest RAM even for idempotent writes.

- Focused regression: repeated idempotent compute writes still publish exactly one cache invalidation; `game_compute_exec` passes.
- Terminator A/B, same direct boot route: average compute call 5.84 ms → 3.04 ms; 30-second dispatch count 4,500 → 8,550 (~1.9× throughput).
- Corrected-head 20-second confirmation: 5,500 calls at 3.04 ms average.
- This improves startup throughput but does not yet establish progression beyond the splash.