### PR TITLE
perf(gpu): skip unchanged pooled compute uploads

### DIFF
--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -828,7 +828,12 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 if (vkMapMemory(ctx.device, buffers[i].memory, 0, resource->size, 0, &mapped) != VK_SUCCESS) break;
                 const uint8_t* source = resource_bytes(resource);
                 if (trace) buffers[i].before_hash = fnv1a(source, resource->size);
-                std::memcpy(mapped, source, resource->size);
+                // Pooled host-visible allocations retain their previous contents. Compare them with
+                // current guest memory before uploading: an exact match is safe to reuse even when a
+                // different resource owned the allocation previously, while any guest CPU mutation
+                // still takes the ordinary full-copy path.
+                if (std::memcmp(mapped, source, resource->size) != 0)
+                    std::memcpy(mapped, source, resource->size);
                 vkUnmapMemory(ctx.device, buffers[i].memory);
             }
 


### PR DESCRIPTION
## Goal

Reduce synchronous live-compute upload cost observed while bringing up Terminator 2D (`PPSA25872`).

## Change and invariant

Host-visible Vulkan allocations retained by the compute memory pool keep their previous bytes. Before uploading a guest buffer, compare the complete current guest range with the allocation and skip only a byte-identical `memcpy`. This makes no resource-identity or dirty-state assumption: a different prior owner is safe because equality is checked over the full declared range, and any guest CPU mutation takes the existing copy path. Dispatch, readback, guest-GPU invalidation, and writer provenance are unchanged.

## Verification

Exact head author checks:

- `ctest --test-dir prosper/build-terminator -R ^game_compute_exec$ --output-on-failure` — pass. The production test exercises pooled reuse, repeated idempotent dispatch, and a subsequent guest-buffer mutation.
- Terminator direct `boot_trace` A/B on AMD Radeon 8060S (RADV), same 20-second route: compute average `3.04 ms` → `0.69 ms`; calls completed `5,500` → `21,725` (~3.95x throughput / 4.4x lower average call time).
- Full `prosper-app` with SDL3 audio/pad and the direct Vulkan route publishes 1,909 frames and runs approximately 20–76 FPS rather than the original ~1 FPS.
- Direct screenshot acceptance still remains on the Reef Entertainment logo through 80 seconds, so this PR claims throughput progress, not progression past the splash.

## Risk

Shared compute backend, but the optimization is guarded by exact byte equality on coherent host-visible memory. Please independently review the Vulkan memory-pool/content-retention assumption and confirm that the changed-input test would catch an incorrectly skipped upload.