### PR TITLE
recompiler: lower bottom-tested do-while SCC loops (PPSA02664 #320 partial)

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -2534,28 +2534,46 @@ std::unordered_set<uint32_t> waterfall_branches(const std::vector<Rdna2Inst>& in
     return out;
 }
 
-// A recognized COUNTED loop (the game's MSAA-resolve / accumulation shape): a single backward
-// unconditional branch (the back-edge) to a header, with exactly one forward SCC exit branch inside.
-// Anything more complex (nested loops, VCC/EXECNZ exits, multiple back-edges, mid-loop s_branch) is
-// rejected — the recompiler then falls back to the straight-line path (which fails on the loop, as before).
+// A recognized COUNTED loop (the game's MSAA-resolve / accumulation shape). Two accepted shapes:
+//   (a) TOP-tested: a single backward UNCONDITIONAL s_branch (the back-edge) to a header, with
+//       exactly one forward s_cbranch_scc0/scc1 exit inside the body — `for (...) {...}`.
+//   (b) BOTTOM-tested (do-while): the back-edge is ITSELF a backward s_cbranch_scc0/scc1; the loop
+//       continues while its SCC condition holds and exits by falling through — `do {...} while(...)`.
+//       This is what the compiler emits for a fixed-trip texture-accumulation loop whose whole body
+//       (including the s_cmp that sets the exit SCC) runs before the test. Alex Kidd's (PPSA02664)
+//       light/blur-accumulation pixel shaders use it, and rejecting it dropped their draws (#320).
+// Both are lowered by ONE emitter: shape (b) is modeled as exit_branch_pc == backedge_pc, so the
+// emitter emits the entire body as the "condition region" (runs every iteration incl. the exiting
+// one — exactly do-while), tests SCC at the bottom, and its "body region" (exit_branch+1..backedge)
+// is empty. Anything more complex (nested loops, VCC/EXECNZ exits, multiple back-edges, mid-loop
+// s_branch) is rejected — the recompiler then falls back to the straight-line path (as before).
 struct CountedLoop {
     bool found = false;
     uint32_t header_pc = 0;       // loop header (target of the back-edge; condition eval starts here)
-    uint32_t exit_branch_pc = 0;  // the forward s_cbranch_scc0/scc1 that leaves the loop
-    uint32_t backedge_pc = 0;     // the backward s_branch
+    uint32_t exit_branch_pc = 0;  // the s_cbranch_scc0/scc1 exit test (== backedge_pc for a do-while)
+    uint32_t backedge_pc = 0;     // the backward branch (unconditional s_branch, or the scc back-edge)
     uint32_t exit_pc = 0;         // first pc after the loop (== backedge_pc + its length)
-    bool exit_on_scc0 = true;     // s_cbranch_scc0 (exit when SCC==0) vs s_cbranch_scc1 (exit when SCC==1)
+    bool exit_on_scc0 = true;     // exit-test polarity: loop CONTINUES when SCC != (this flag ? 0 : 1)
 };
 inline uint32_t branch_target(const Rdna2Inst& in) { return in.pc + in.len_dwords + (uint32_t)(int32_t)in.simm16; }
 
 CountedLoop detect_counted_loop(const std::vector<Rdna2Inst>& ins) {
     CountedLoop L;
+    // The single backward branch that closes the loop. A conditional scc0/scc1 back-edge is a
+    // bottom-tested do-while; an unconditional s_branch is a top-tested loop.
     const Rdna2Inst* back = nullptr; int nback = 0;
     for (const auto& in : ins) {
         if (in.is_end) break;
-        if (in.fmt == Rdna2Format::SOPP && in.opcode == 0x02 && in.simm16 < 0) { back = &in; nback++; }
+        if (in.fmt == Rdna2Format::SOPP && in.simm16 < 0 &&
+            (in.opcode == 0x02 || in.opcode == 0x04 || in.opcode == 0x05)) { back = &in; nback++; }
     }
     if (nback != 1) return L;                       // 0 -> no loop; >1 -> nested/multiple (unhandled)
+    const bool do_while = (back->opcode != 0x02);   // conditional back-edge => bottom-tested
+    // A backward s_cbranch_scc0/scc1 whose SCC is a 64-bit wave-mask reduction is a WATERFALL loop
+    // (once-through per invocation), NOT a do-while counted loop — its cross-lane SCC has no
+    // representable per-lane value. Leave it to waterfall_branches()/the linearizer; treating it as a
+    // counted loop would feed the emitter a poisoned SCC exit and mis-lower the divergent body.
+    if (do_while && waterfall_branches(ins).count(back->pc)) return L;
     const uint32_t header = branch_target(*back);
     bool header_ok = false;
     for (const auto& in : ins) if (in.pc == header && in.pc < back->pc) { header_ok = true; break; }
@@ -2564,16 +2582,29 @@ CountedLoop detect_counted_loop(const std::vector<Rdna2Inst>& ins) {
     const Rdna2Inst* exitbr = nullptr; int nexit = 0;
     for (const auto& in : ins) {                    // scan the loop body [header, back-edge]
         if (in.pc < header || in.pc > back->pc || in.fmt != Rdna2Format::SOPP) continue;
+        if (&in == back) continue;                  // the back-edge is classified above, not here
         switch (in.opcode) {
             case 0x04: case 0x05:                   // s_cbranch_scc0 / scc1 — must be the single exit
                 if (branch_target(in) != exit_pc) return L;
                 exitbr = &in; nexit++; break;
-            case 0x02:                              // any s_branch other than the back-edge -> reject
-                if (&in != back) return L; break;
+            case 0x02:                              // any other s_branch -> reject
+                return L;
             case 0x06: case 0x07: case 0x09:        // vcc / execnz branches -> reject
                 return L;
             case 0x08: default: break;              // execz (forward, predication-handled) / hints ok
         }
+    }
+    if (do_while) {
+        // Bottom-tested: the conditional back-edge IS the exit test; no separate forward exit is
+        // allowed (a do-while with an inner uniform-if stays unsupported and rejects, conservatively).
+        // The back-edge is TAKEN (loops) while its SCC condition holds. exit_on_scc0 drives the
+        // emitter's loop_cond = (exit_on_scc0 ? SCC : !SCC), i.e. "continue when this is true": an
+        // s_cbranch_scc1 back-edge continues while SCC==1 (exit_on_scc0=true); scc0 continues while
+        // SCC==0 (exit_on_scc0=false).
+        if (nexit != 0) return L;
+        L.found = true; L.header_pc = header; L.exit_branch_pc = back->pc; L.backedge_pc = back->pc;
+        L.exit_pc = exit_pc; L.exit_on_scc0 = (back->opcode == 0x05);
+        return L;
     }
     if (nexit != 1) return L;
     L.found = true; L.header_pc = header; L.exit_branch_pc = exitbr->pc; L.backedge_pc = back->pc;

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -1955,6 +1955,41 @@ int main() {
     printf("  kernel44 mismatches=%u (out[5]=%g expect=40)\n", bad44, got44.size()==N?got44[5]:-1);
     CHECK(got44.size()==N && bad44==0, "recompiled kernel 44 (condition-region reg read after loop) computes 40");
 
+    // Kernel 44b: a BOTTOM-tested do-while loop whose back-edge is a conditional s_cbranch_scc1 (not
+    //   an unconditional s_branch + separate forward exit). The whole body runs, THEN the SCC test at
+    //   the bottom decides whether to loop — the shape Alex Kidd's (PPSA02664) light/blur-accumulation
+    //   pixel shaders use, which previously rejected and dropped their draws (#320). sum=0; i=0;
+    //   do { sum+=i; i++; } while (i<5)  =>  sum = 0+1+2+3+4 = 10.
+    //     s_mov s0,0 | v_mov v1,0
+    //   loop(header): v_add_nc_u32 v1,s0,v1 | s_add_i32 s0,s0,1 | s_cmp_lt_u32 s0,5 | s_cbranch_scc1 loop
+    //   exit: v_cvt_f32_u32 v0,v1 | s_endpgm
+    const uint32_t code44b[] = {
+        0xBE800380u, 0x7E020280u, 0x4A020200u, 0x81008100u, 0xBF0A8500u, 0xBF85FFFCu,
+        0x7E000D01u, 0xBF810000u,
+    };
+    std::vector<uint32_t> spv44b = recompile_valu(code44b, sizeof(code44b)/sizeof(code44b[0]), 0, 0);
+    CHECK(!spv44b.empty(), "recompiled kernel 44b (do-while s_cbranch_scc1 back-edge) -> SPIR-V");
+    std::vector<float> in44b(N); for (uint32_t i=0;i<N;i++) in44b[i]=(float)i;
+    std::vector<float> got44b = prosper::test::run_compute(spv44b, in44b, N, N);
+    uint32_t bad44b = 0; for (uint32_t i=0;i<N&&got44b.size()==N;i++) if (std::fabs(got44b[i]-10.0f)>1e-3f) bad44b++;
+    printf("  kernel44b mismatches=%u (out[5]=%g expect=10)\n", bad44b, got44b.size()==N?got44b[5]:-1);
+    CHECK(got44b.size()==N && bad44b==0, "recompiled kernel 44b (do-while scc1 loop sum 0..4) computes 10");
+
+    // Kernel 44c: the same do-while with the OPPOSITE back-edge polarity — s_cbranch_scc0 continues
+    //   while SCC==0. Exit test s_cmp_ge_u32 s0,5 (SCC = s0>=5), so the loop runs while s0<5. Same
+    //   result (10); guards the exit_on_scc0 polarity handling for the conditional back-edge.
+    const uint32_t code44c[] = {
+        0xBE800380u, 0x7E020280u, 0x4A020200u, 0x81008100u, 0xBF098500u, 0xBF84FFFCu,
+        0x7E000D01u, 0xBF810000u,
+    };
+    std::vector<uint32_t> spv44c = recompile_valu(code44c, sizeof(code44c)/sizeof(code44c[0]), 0, 0);
+    CHECK(!spv44c.empty(), "recompiled kernel 44c (do-while s_cbranch_scc0 back-edge) -> SPIR-V");
+    std::vector<float> in44c(N); for (uint32_t i=0;i<N;i++) in44c[i]=(float)i;
+    std::vector<float> got44c = prosper::test::run_compute(spv44c, in44c, N, N);
+    uint32_t bad44c = 0; for (uint32_t i=0;i<N&&got44c.size()==N;i++) if (std::fabs(got44c[i]-10.0f)>1e-3f) bad44c++;
+    printf("  kernel44c mismatches=%u (out[5]=%g expect=10)\n", bad44c, got44c.size()==N?got44c[5]:-1);
+    CHECK(got44c.size()==N && bad44c==0, "recompiled kernel 44c (do-while scc0 loop sum 0..4) computes 10");
+
     // Kernel 45: EXEC-narrowed-state tracking regression (the review-flagged under-narrow bug). Save all-on
     //   exec to vcc; v_cmp overwrites vcc with a per-lane mask (lanes i<4); restore exec FROM vcc — exec is
     //   now narrowed, so v_mov v2,7 must be EXEC-predicated (only i<4 get 7; i>=4 keep 0). If the narrowed


### PR DESCRIPTION
## Goal / issue
Refs #320 (PPSA02664 gameplay world renders black). This fixes one concrete, proven root cause: the RDNA2→SPIR-V recompiler dropping Alex Kidd's first-level pixel-shader draws because it could not lower a **bottom-tested do-while SCC loop**.

## Failure scenario & behavioral contract
`detect_counted_loop` recognized only **top-tested** loops — a backward *unconditional* `s_branch` back-edge plus a separate *forward* `s_cbranch_scc0/scc1` exit inside the body. Compilers emit a different shape for a fixed-trip accumulation loop whose whole body (including the `s_cmp` that sets the exit SCC) runs before the test: a **do-while** whose back-edge is *itself* a backward `s_cbranch_scc0/scc1`, with no separate forward exit. The detector missed it, so any shader using that shape returned `{}` and its draws were dropped.

Two PPSA02664 first-level pixel shaders (light/blur accumulation) close with exactly one backward `s_cbranch_scc1` (bodies pc 32..73 and 118..272). Both recompile-rejected on that op (`generic-coverage … unsupported=1 first=SOPP/0x5`), dropping their draws. Downstream draws then sampled the never-written target textures (observed `nz=0` for `0x2055390000` and `0x20580d0000` in the capsule) → black composite.

## Approach & invariants
Extend `detect_counted_loop` to also accept a conditional `scc0/scc1` back-edge, modeled as `exit_branch_pc == backedge_pc` so the **same** loop emitter lowers it:
- the entire body becomes the "condition region" (runs every iteration incl. the exiting one — exactly do-while semantics),
- SCC is tested at the bottom (`loop_cond = exit_on_scc0 ? SCC : !SCC`; scc1 back-edge ⇒ continue while SCC==1),
- the "body region" `[exit_branch+1, backedge)` is empty.

A backward `scc` branch whose SCC is a **64-bit wave-mask reduction** is a WATERFALL loop (once-through, cross-lane SCC with no representable per-lane value), NOT a do-while — it is explicitly excluded via the existing `waterfall_branches()` classifier so its divergent body is never fed a poisoned SCC exit. (Without this exclusion the divergent T19 waterfall regressed to a crash; the guard restores it.)

## Affected / unaffected behavior
- **Affected:** shaders with a bottom-tested `s_cbranch_scc0/scc1` do-while now recompile instead of being dropped.
- **Unaffected:** top-tested counted loops (back-edge classification unchanged for `s_branch`), waterfall loops (excluded), and all other CFG shapes (still rejected/handled as before). The change strictly *widens* coverage for a previously-rejected shape.

## Verification
- `test_rdna2_to_spirv`: new **kernel 44b** (do-while `s_cbranch_scc1`) and **44c** (`s_cbranch_scc0`), each execution-checked to compute `sum(0..4)=10` and spirv-val-gated; existing counted-loop (43/44) and waterfall (T19) regressions still pass.
- The two extracted real PPSA02664 shaders go from `unsupported=1 (SOPP/0x5)` → `unsupported=0` under `shader_inspect`.
- A fresh PPSA02664 gameplay capsule (RADV, live renderer) recompiles with **failed 3 → 0**, and its replay's distinct-color count rises 158 → 2888.
- `cmake --build build-linux -j8 && ctest` → **122/122 green** on Linux.
- `git diff --check` clean.

## Risk / scope
Recompiler structured-control-flow change → **independent review requested** before merge. Snapshot suite not run here (other titles' dumps unavailable on this native-Linux box; ctest is the primary gate).

## Not resolved by this PR
This removes the shader-recompile drops but does **not** by itself fully un-black the settled first-level world — the captured settled frame is still ~5.7% non-black. #320 stays open for the remaining composition cause(s).