### PR TITLE
feat(gpu): execute compute GDS dword stores

### DIFF
--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -1870,7 +1870,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             if (changed)
                 std::memcpy(destination, result, buffer.resource->size);
             vkUnmapMemory(ctx.device, buffer.memory);
-            notify_guest_gpu_write(buffer.resource->gpu_addr, buffer.resource->size);
+            if (buffer.resource->gpu_addr)
+                notify_guest_gpu_write(buffer.resource->gpu_addr, buffer.resource->size);
             if (!buffer.resource->host_data && writer_provenance_enabled())
                 record_guest_write(GuestWriterKind::ComputeBuffer,
                                    buffer.resource->gpu_addr, buffer.resource->size,

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -8,6 +8,7 @@
 
 #include "bc_decode.hpp"
 #include "rdna2_decode.hpp"
+#include "rdna2_to_spirv.hpp"
 #include "tile.hpp"
 
 #include <algorithm>
@@ -37,7 +38,7 @@ namespace prosper::gpu {
 namespace {
 
 constexpr char kMagic[8] = {'P','R','G','P','C','A','P','\0'};
-constexpr uint32_t kVersion = 21;
+constexpr uint32_t kVersion = 22;
 constexpr uint32_t kEndian = 0x01020304u;
 constexpr uint64_t kMaxFileBytes = 4ull << 30;
 constexpr uint64_t kMaxBlobBytes = 1ull << 30;
@@ -369,6 +370,11 @@ struct Interval {
     uint32_t blob_index = 0xFFFFFFFFu;
 };
 
+bool is_compute_internal_gds(const ShaderResource& r) {
+    return r.binding == kComputeInternalGdsBinding && r.gpu_addr == 0 &&
+           r.cls == ResourceClass::ConstantBuffer && r.size == 64u * 1024u && r.stride == 4;
+}
+
 bool collect_intervals(const std::vector<DrawItem>& draws,
                        const std::vector<ComputeItem>& computes,
                        const std::vector<GpuState::DmaCopy>& dma_copies,
@@ -378,6 +384,7 @@ bool collect_intervals(const std::vector<DrawItem>& draws,
     auto add_table = [&](const ShaderResourceTable* t) -> bool {
         if (!t) return true;
         for (const auto& r : t->resources) {
+            if (is_compute_internal_gds(r)) continue;
             uint64_t n = resource_footprint(r);
             if (n) {
                 if (n > kMaxBlobBytes || r.gpu_addr > std::numeric_limits<uint64_t>::max() - n) {
@@ -455,7 +462,13 @@ bool capture_table(const ShaderResourceTable* src, const std::vector<Interval>& 
         c.metadata_size = dcc_metadata_footprint(r);
         c.resource.dcc_metadata_size = c.metadata_size;
         uint64_t n = resource_footprint(r);
-        if (n && include_resource_data &&
+        if (is_compute_internal_gds(r) && include_resource_data) {
+            if (!r.host_data || r.host_data_size < n) {
+                error = "compute GDS resource has no complete host backing";
+                return false;
+            }
+            c.internal_bytes.assign(r.host_data, r.host_data + n);
+        } else if (n && include_resource_data &&
             !assign_blob_range(intervals, r.gpu_addr, n, c.blob_index, c.blob_offset,
                                "resource was not assigned to a capture blob", error)) return false;
         if (c.metadata_size && include_resource_data &&
@@ -1462,6 +1475,26 @@ bool serialize_gpu_capture(const GpuCaptureFile& c, std::vector<uint8_t>& bytes,
     w.u32(static_cast<uint32_t>(c.failure_diagnostics.size()));
     for (const auto& diagnostic : c.failure_diagnostics)
         if (diagnostic.pipeline_present) write_logic_op_pipeline(w, diagnostic.pipeline);
+    // v22 explicitly captures host-backed compute GDS state. Unlike guest-addressed resources,
+    // this state has no valid capture interval; one shared replay instance preserves dispatch order.
+    w.u32(static_cast<uint32_t>(resource_depth_count));
+    auto write_internal_state = [&](const GpuCapturedTable& table) {
+        for (const auto& captured : table.resources) {
+            const bool internal = is_compute_internal_gds(captured.resource);
+            if ((!internal && !captured.internal_bytes.empty()) ||
+                (internal && !captured.internal_bytes.empty() &&
+                 captured.internal_bytes.size() != resource_footprint(captured.resource))) {
+                error = "invalid compute GDS capture state";
+                return false;
+            }
+            w.bytes(captured.internal_bytes);
+        }
+        return true;
+    };
+    for (const auto& draw : c.draws)
+        if (!write_internal_state(draw.vrt) || !write_internal_state(draw.prt)) return false;
+    for (const auto& compute : c.computes)
+        if (!write_internal_state(compute.resources)) return false;
     if (w.data.size() > kMaxFileBytes) { error = "capture file exceeds 4 GiB"; return false; }
     bytes = std::move(w.data);
     return true;
@@ -1977,6 +2010,35 @@ bool deserialize_gpu_capture(const std::vector<uint8_t>& bytes, GpuCaptureFile& 
             if (diagnostic.pipeline_present && !read_logic_op_pipeline(r, diagnostic.pipeline))
                 return false;
     }
+    if (version >= 22) {
+        uint64_t expected_states = 0;
+        for (const auto& draw : c.draws)
+            expected_states += draw.vrt.resources.size() + draw.prt.resources.size();
+        for (const auto& compute : c.computes)
+            expected_states += compute.resources.resources.size();
+        uint32_t state_count = 0;
+        if (!r.u32(state_count) || state_count != expected_states) {
+            error = "invalid compute GDS state count";
+            return false;
+        }
+        auto read_internal_state = [&](GpuCapturedTable& table) {
+            for (auto& captured : table.resources) {
+                if (!r.bytes(captured.internal_bytes)) return false;
+                const bool internal = is_compute_internal_gds(captured.resource);
+                if ((!internal && !captured.internal_bytes.empty()) ||
+                    (internal && !captured.internal_bytes.empty() &&
+                     captured.internal_bytes.size() != resource_footprint(captured.resource))) {
+                    error = "invalid compute GDS capture state";
+                    return false;
+                }
+            }
+            return true;
+        };
+        for (auto& draw : c.draws)
+            if (!read_internal_state(draw.vrt) || !read_internal_state(draw.prt)) return false;
+        for (auto& compute : c.computes)
+            if (!read_internal_state(compute.resources)) return false;
+    }
     if (version >= 7 && !validate_failure_diagnostics(c, error)) return false;
     if (r.left) { error = "capture has trailing data"; return false; }
     return true;
@@ -2000,6 +2062,7 @@ bool materialize_gpu_replay(const GpuCaptureFile& c, GpuReplayFrame& out, std::s
     resource_reference_count += c.dma_copies.size() * 2;
     out.resource_instances.reserve(resource_reference_count * 2);
     std::map<std::pair<uint32_t, uint64_t>, size_t> instance_by_version_and_base;
+    std::map<uint32_t, size_t> internal_instance_by_binding;
     auto bind_range = [&](uint32_t blob_index, uint64_t blob_offset, uint64_t guest_addr,
                           uint64_t need, uint8_t*& host_data, uint64_t& host_data_size,
                           const char* invalid_error, const char* exceeds_error,
@@ -2029,12 +2092,24 @@ bool materialize_gpu_replay(const GpuCaptureFile& c, GpuReplayFrame& out, std::s
             r.dcc_metadata_size = x.metadata_size;
             r.dcc_metadata_host_data = nullptr;
             r.dcc_metadata_host_data_size = 0;
-            if (!bind_range(x.blob_index, x.blob_offset, r.gpu_addr, resource_footprint(r),
+            if (!x.internal_bytes.empty()) {
+                auto [it, inserted] = internal_instance_by_binding.emplace(
+                    r.binding, out.resource_instances.size());
+                if (inserted)
+                    out.resource_instances.push_back({0, 0xFFFFFFFFu, x.internal_bytes});
+                auto& instance = out.resource_instances[it->second].bytes;
+                if (!inserted && instance != x.internal_bytes) {
+                    error = "compute GDS resources disagree on initial state";
+                    return false;
+                }
+                r.host_data = instance.data();
+                r.host_data_size = instance.size();
+            } else if (!bind_range(x.blob_index, x.blob_offset, r.gpu_addr, resource_footprint(r),
                             r.host_data, r.host_data_size,
                             "resource references an invalid capture blob",
                             "resource footprint exceeds capture blob",
-                            "resource blob offset exceeds its logical address") ||
-                !bind_range(x.metadata_blob_index, x.metadata_blob_offset, r.metadata_addr,
+                            "resource blob offset exceeds its logical address")) return false;
+            if (!bind_range(x.metadata_blob_index, x.metadata_blob_offset, r.metadata_addr,
                             x.metadata_size, r.dcc_metadata_host_data,
                             r.dcc_metadata_host_data_size,
                             "resource DCC metadata references an invalid capture blob",

--- a/prosper/src/gpu/gpu_capture.hpp
+++ b/prosper/src/gpu/gpu_capture.hpp
@@ -51,6 +51,9 @@ struct GpuCapturedResource {
     uint64_t metadata_size = 0;
     uint32_t metadata_blob_index = 0xFFFFFFFFu;
     uint64_t metadata_blob_offset = 0;
+    // GPU-internal resources have no guest address. Capture their initial contents explicitly;
+    // ordered replay materializes one shared instance so mutations remain visible to later work.
+    std::vector<uint8_t> internal_bytes;
 };
 
 struct GpuCapturedTable {

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -65,6 +65,7 @@ LiveRenderFn g_live;   // empty until the runtime/test registers a device-backed
 LiveComputeFn g_compute;   // synchronous compute backend, registered with the live Vulkan frontend
 GuestGpuWriteObserver g_guest_gpu_write_observer;
 thread_local LiveRenderPhase g_live_phase;
+std::array<uint8_t, 64 * 1024> g_compute_gds{};
 
 struct GuestGpuWriteRange {
     uint64_t addr = 0;
@@ -2907,6 +2908,26 @@ std::vector<ComputeItem> realize_compute_dispatches(
             }
         }
         assign_convention_bindings(*table, 2);
+        {
+            std::vector<Rdna2Inst> decoded;
+            rdna2_walk(reinterpret_cast<const uint32_t*>(static_cast<uintptr_t>(code_addr)),
+                       shader_dwords, decoded);
+            const bool uses_gds = std::any_of(decoded.begin(), decoded.end(), [](const auto& in) {
+                return in.fmt == Rdna2Format::DS && in.ds_gds && in.opcode == 0x0d;
+            });
+            if (uses_gds) {
+                ShaderResource gds;
+                gds.cls = ResourceClass::ConstantBuffer;
+                gds.format = DataFormat::Uint32;
+                gds.num_components = 1;
+                gds.binding = kComputeInternalGdsBinding;
+                gds.size = static_cast<uint32_t>(g_compute_gds.size());
+                gds.stride = 4;
+                gds.host_data = g_compute_gds.data();
+                gds.host_data_size = g_compute_gds.size();
+                table->resources.push_back(gds);
+            }
+        }
 
         const uint32_t rsrc2 = rd(ds.sh, P::COMPUTE_PGM_RSRC2);
         auto field = [&](uint32_t shift, uint32_t mask) { return (rsrc2 >> shift) & mask; };

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -489,7 +489,7 @@ struct SpirvCompute {
         put(code, Op_Load, {t_bool, result, v_helper_invocation});
         return result;
     }
-    void declare_internal_gds() {
+    void declare_internal_gds(uint32_t set = 1, uint32_t binding = 0) {
         if (v_internal_gds) return;
         uint32_t runtime_array = id(), block = id(), block_ptr = id();
         put(deco, Op_Decorate, {runtime_array, Dec_ArrayStride, 4});
@@ -502,8 +502,25 @@ struct SpirvCompute {
         put(types, Op_TypePointer, {t_ptr_gds_u32, SC_StorageBuffer, t_u32});
         v_internal_gds = id();
         put(types, Op_Variable, {block_ptr, v_internal_gds, SC_StorageBuffer});
-        put(deco, Op_Decorate, {v_internal_gds, Dec_DescriptorSet, 1});
-        put(deco, Op_Decorate, {v_internal_gds, Dec_Binding, 0});
+        put(deco, Op_Decorate, {v_internal_gds, Dec_DescriptorSet, set});
+        put(deco, Op_Decorate, {v_internal_gds, Dec_Binding, binding});
+    }
+    void compute_gds_store(uint32_t index, uint32_t value, bool predicated, uint32_t pred) {
+        declare_internal_gds(0, kComputeInternalGdsBinding);
+        auto emit = [&]() {
+            uint32_t pointer = id();
+            putv(code, Op_AccessChain,
+                 {t_ptr_gds_u32, pointer, v_internal_gds, uconst(0), index});
+            put(code, Op_Store, {pointer, value});
+        };
+        if (!predicated) { emit(); return; }
+        uint32_t then = id(), merge = id();
+        put(code, Op_SelectionMerge, {merge, 0});
+        put(code, Op_BranchConditional, {pred, then, merge});
+        put(code, Op_Label, {then}); cur_block = then;
+        emit();
+        put(code, Op_Branch, {merge});
+        put(code, Op_Label, {merge}); cur_block = merge;
     }
     // Fragment GDS append/consume is one device-global atomic per hardware wave. Helper
     // invocations participate in the subgroup operations but cannot consume guest counter slots.
@@ -5964,7 +5981,8 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // existing wave_append model was landed and live-validated against exactly those
             // packets (#554/#580). Kept as a documented per-workgroup approximation of the
             // device-global counter (exact for the exercised dispatch shapes). CONFIDENCE: MED.
-            if (in.ds_gds && in.opcode != 0x3d && in.opcode != 0x3e) { ok = false; return true; }
+            if (in.ds_gds && in.opcode != 0x3d && in.opcode != 0x3e &&
+                !(b.is_compute && in.opcode == 0x0d)) { ok = false; return true; }
             // ds_write_addtid_b32 (0xb0) / ds_read_addtid_b32 (0xb1) in a GRAPHICS stage (#273):
             // a per-lane VGPR spill through LDS (addr = M0 + offset + tid*4) — DOLL's title post
             // PSes spill v15 before their accumulation loop and reload it after. Per-invocation the
@@ -6074,7 +6092,13 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 return true;
             }
             uint32_t addr = b.ibin(Op_IAdd, vread(in.src[0].value), b.uconst(in.literal));
+            if (in.ds_gds)
+                addr = b.ibin(Op_BitwiseAnd, addr, b.uconst(0xFFFFu));
             uint32_t idx  = b.ibin(Op_ShiftRightLogical, addr, b.uconst(2));
+            if (in.ds_gds && in.opcode == 0x0d) {
+                b.compute_gds_store(idx, vread(in.src[1].value), rs.exec_narrowed, rs.exec);
+                return true;
+            }
             if (in.opcode == 0x00) {                     // ds_add_u32: LDS += DATA0, no VGPR return
                 b.lds_atomic(Op_AtomicIAdd, idx, vread(in.src[1].value),
                              rs.exec_narrowed, rs.exec);

--- a/prosper/src/gpu/rdna2_to_spirv.hpp
+++ b/prosper/src/gpu/rdna2_to_spirv.hpp
@@ -18,6 +18,8 @@
 
 namespace prosper::gpu {
 
+inline constexpr uint32_t kComputeInternalGdsBinding = 127;
+
 struct ShaderResourceTable;   // resource-binding contract (shader_resources.hpp); optional to recompile_valu
 struct Rdna2Inst;
 

--- a/prosper/tests/test_game_compute.cpp
+++ b/prosper/tests/test_game_compute.cpp
@@ -219,7 +219,8 @@ int main() {
         0xbf810000u,
     };
     static const uint32_t gds_exec_store[] = {
-        0x7e0202ffu, 0xcafebabeu,  // v1 = value; v0 retains local invocation id
+        0x34000082u,               // v_lshlrev_b32 v0, 2, v0 (one dword per lane)
+        0x7e0202ffu, 0xcafebabeu,  // v1 = value
         0x7da40080u,               // v_cmpx_eq_u32 0, v0
         0xd8360000u, 0x00000100u,  // only lane zero stores at byte address 0
         0xbf810000u,
@@ -282,7 +283,8 @@ int main() {
     set_guest_gpu_write_observer({});
     const auto* gds_words = reinterpret_cast<const uint32_t*>(
         gds_replay.computes[0].resources->resources[0].host_data);
-    CHECK(gds_words && gds_words[0] == 0xcafebabeu && gds_words[1] == 0xdeadbeefu,
+    CHECK(gds_words && gds_words[0] == 0xcafebabeu && gds_words[1] == 0xdeadbeefu &&
+              gds_words[2] == 0 && gds_words[3] == 0,
           "GDS stores honor 16-bit address wrap, EXEC predication, and cross-dispatch persistence");
     CHECK(gds_notifications == 0,
           "GPU-internal GDS writeback does not invalidate guest address zero");

--- a/prosper/tests/test_game_compute.cpp
+++ b/prosper/tests/test_game_compute.cpp
@@ -1,9 +1,11 @@
 #include "../src/gpu/rdna2_to_spirv.hpp"
+#include "../src/gpu/gpu_capture.hpp"
 #include "../src/gpu/shader_resources.hpp"
 #include "../src/gpu/tile.hpp"
 #include "live_compute.hpp"
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <cstdint>
 #include <cstdlib>
@@ -205,6 +207,85 @@ int main() {
         for (uint32_t component = 0; component < 4; ++component)
             replay_padding_untouched &= replay_owned[record * 4 + component] == 0xdddddddd;
     CHECK(replay_padding_untouched, "captured/replay-owned backing preserves padded invocations");
+
+    // Terminator 2D's startup uses device-global GDS. Capture its initial host-backed state, then
+    // execute two ordered replay dispatches against the same materialized 64 KiB instance. The
+    // first store wraps its byte address to 16 bits; the second narrows EXEC to lane zero. If the
+    // store ignores EXEC, lanes 1..3 overwrite the first dispatch's dword at wrapped address 4.
+    static const uint32_t gds_wrap_store[] = {
+        0x7e0002ffu, 0x00010004u,  // v0 = byte address 0x10004 -> GDS byte address 4
+        0x7e0202ffu, 0xdeadbeefu,  // v1 = value
+        0xd8360000u, 0x00000100u,  // ds_write_b32 v0, v1 gds
+        0xbf810000u,
+    };
+    static const uint32_t gds_exec_store[] = {
+        0x7e0202ffu, 0xcafebabeu,  // v1 = value; v0 retains local invocation id
+        0x7da40080u,               // v_cmpx_eq_u32 0, v0
+        0xd8360000u, 0x00000100u,  // only lane zero stores at byte address 0
+        0xbf810000u,
+    };
+    std::array<uint8_t, 64 * 1024> gds_initial{};
+    ShaderResource gds_resource;
+    gds_resource.cls = ResourceClass::ConstantBuffer;
+    gds_resource.format = DataFormat::Uint32;
+    gds_resource.num_components = 1;
+    gds_resource.binding = kComputeInternalGdsBinding;
+    gds_resource.size = gds_initial.size();
+    gds_resource.stride = 4;
+    gds_resource.host_data = gds_initial.data();
+    gds_resource.host_data_size = gds_initial.size();
+    auto gds_table = std::make_shared<ShaderResourceTable>();
+    gds_table->resources.push_back(gds_resource);
+    ComputeShaderConfig gds_config;
+    auto make_gds_item = [&](const uint32_t* code_words, size_t word_count,
+                             uint32_t threads, uint64_t order) {
+        ComputeItem gds_item;
+        gds_item.spirv = recompile_compute(code_words, word_count, gds_table.get(), gds_config);
+        gds_item.resources = gds_table;
+        gds_item.launch.threads_x = threads;
+        gds_item.launch.local_x = threads;
+        gds_item.launch.local_y = gds_item.launch.local_z = 1;
+        gds_item.launch.groups_x = gds_item.launch.groups_y = gds_item.launch.groups_z = 1;
+        gds_item.dispatch_index = order;
+        gds_item.command_order = order;
+        return gds_item;
+    };
+    ComputeItem gds_first = make_gds_item(gds_wrap_store, std::size(gds_wrap_store), 1, 10);
+    ComputeItem gds_second = make_gds_item(gds_exec_store, std::size(gds_exec_store), 4, 20);
+    CHECK(!gds_first.spirv.empty() && !gds_second.spirv.empty(),
+          "compute GDS wrap and EXEC kernels recompile");
+    GpuCaptureFile gds_capture;
+    GpuCaptureMetadata gds_metadata;
+    std::string gds_error;
+    const std::vector<SubmitOperation> gds_operations = {
+        {SubmitOperationKind::Dispatch, 10, 10},
+        {SubmitOperationKind::Dispatch, 20, 20},
+    };
+    CHECK(capture_submit_items({}, {gds_first, gds_second}, gds_operations, gds_metadata,
+                               [](uint64_t, uint8_t*, size_t) { return size_t{0}; },
+                               gds_capture, gds_error),
+          "capture records host-backed compute GDS without reading guest address zero");
+    std::vector<uint8_t> gds_capture_bytes;
+    GpuCaptureFile gds_loaded;
+    GpuReplayFrame gds_replay;
+    CHECK(serialize_gpu_capture(gds_capture, gds_capture_bytes, gds_error) &&
+          deserialize_gpu_capture(gds_capture_bytes, gds_loaded, gds_error) &&
+          materialize_gpu_replay(gds_loaded, gds_replay, gds_error) &&
+          gds_replay.computes.size() == 2 &&
+          gds_replay.computes[0].resources->resources[0].host_data ==
+              gds_replay.computes[1].resources->resources[0].host_data,
+          "capture v22 materializes one persistent GDS instance across ordered dispatches");
+    uint32_t gds_notifications = 0;
+    set_guest_gpu_write_observer([&](uint64_t, uint64_t) { ++gds_notifications; });
+    CHECK(prosper::frontend::execute_live_compute_items(gds_replay.computes),
+          "production live backend executes captured GDS stores");
+    set_guest_gpu_write_observer({});
+    const auto* gds_words = reinterpret_cast<const uint32_t*>(
+        gds_replay.computes[0].resources->resources[0].host_data);
+    CHECK(gds_words && gds_words[0] == 0xcafebabeu && gds_words[1] == 0xdeadbeefu,
+          "GDS stores honor 16-bit address wrap, EXEC predication, and cross-dispatch persistence");
+    CHECK(gds_notifications == 0,
+          "GPU-internal GDS writeback does not invalidate guest address zero");
 
     // --- #590: the live backend's storage-IMAGE path. The same 1D image-copy kernel that
     // test_storage_image_copy proves against the raw harness, executed through the PRODUCTION

--- a/prosper/tests/test_gpu_capture.cpp
+++ b/prosper/tests/test_gpu_capture.cpp
@@ -196,7 +196,8 @@ int main() {
               scalar_capture.computes[0].resources.resources.empty(),
           "#636: capture ignores unconsumed descriptor-looking scalar arguments");
 
-    // v17 appends scissor state without changing the legacy pipeline prefix. Remove v21's logic op,
+    // v17 appends scissor state without changing the legacy pipeline prefix. Remove v22's internal
+    // resource state, v21's logic op,
     // v20's instance count, v19's realized raw-stage indices, v18's geometry index, then the v17 tail
     // to recover a byte-exact v16 capture.
     GpuCaptureFile v16_scissor_source = captured;
@@ -209,6 +210,7 @@ int main() {
               v16_scissor_bytes.size() >= 25,
           "v17 capture serializes effective guest scissor state");
     if (v16_scissor_bytes.size() >= 25) {
+        v16_scissor_bytes.resize(v16_scissor_bytes.size() - 28); // v22 count + three empty vectors
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - 13); // v21 one draw + zero failures
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - 8); // v20 draw count + instance count
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - 12); // v19 count + two raw indices
@@ -354,6 +356,7 @@ int main() {
           "writer rejects an out-of-bounds DCC metadata reference");
     CHECK(serialize_gpu_capture(volume_capture, volume_bytes, error),
           "recreated valid v12 DCC bytes after malformed-reference check");
+    volume_bytes.resize(volume_bytes.size() - 12); // v22 count + one empty vector
     volume_bytes.resize(volume_bytes.size() - 13); // v21 one logic-op draw + zero failures
     volume_bytes.resize(volume_bytes.size() - 8); // v20 draw count + instance count
     volume_bytes.resize(volume_bytes.size() - 12); // v19 count + two raw indices
@@ -422,6 +425,7 @@ int main() {
     CHECK(serialize_gpu_capture(captured, v20_bytes, error) && v20_bytes.size() >= 21,
           "v21 capture serializes the logic-op extension");
     if (v20_bytes.size() >= 21) {
+        v20_bytes.resize(v20_bytes.size() - 28); // v22 count + three empty vectors
         v20_bytes.resize(v20_bytes.size() - 13); // v21 one logic-op draw + zero failures
         v20_bytes[8] = 20; v20_bytes[9] = v20_bytes[10] = v20_bytes[11] = 0;
     }
@@ -809,11 +813,12 @@ int main() {
     legacy_source.draws[0].fs_raw_shader_index = 0xFFFFFFFFu;
     std::vector<uint8_t> legacy_bytes;
     CHECK(serialize_gpu_capture(legacy_source, legacy_bytes, error) && legacy_bytes.size() >= 32,
-          "created a diagnostic-free v21 payload for legacy-reader fixtures");
+          "created a diagnostic-free v22 payload for legacy-reader fixtures");
     std::vector<uint8_t> v13_bytes = legacy_bytes;
     if (v13_bytes.size() >= 32) {
         const size_t legacy_resource_count = legacy_source.draws[0].vrt.resources.size() +
                                              legacy_source.draws[0].prt.resources.size();
+        v13_bytes.resize(v13_bytes.size() - (4 + 8 * legacy_resource_count)); // v22
         v13_bytes.resize(v13_bytes.size() - 13); // v21 one logic-op draw + zero failures
         v13_bytes.resize(v13_bytes.size() - 8); // v20 draw count + instance count
         v13_bytes.resize(v13_bytes.size() - 12); // v19 count + two raw indices
@@ -835,6 +840,7 @@ int main() {
     if (legacy_bytes.size() >= 32) {
         const size_t legacy_resource_count = legacy_source.draws[0].vrt.resources.size() +
                                              legacy_source.draws[0].prt.resources.size();
+        legacy_bytes.resize(legacy_bytes.size() - (4 + 8 * legacy_resource_count)); // v22
         legacy_bytes.resize(legacy_bytes.size() - 13); // v21 one logic-op draw + zero failures
         legacy_bytes.resize(legacy_bytes.size() - 8); // v20 draw count + instance count
         legacy_bytes.resize(legacy_bytes.size() - 12); // v19 count + two raw indices
@@ -882,9 +888,9 @@ int main() {
     CHECK(deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
           !legacy_loaded.failure_diagnostics_available && legacy_loaded.failure_diagnostics.empty(),
           "v6 capture reopens with failed-operation diagnostics reported unavailable");
-    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 22;
+    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 23;
     CHECK(!deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
-          error == "unsupported capture version 22",
+          error == "unsupported capture version 23",
           "future capture versions fail with a concrete version error");
 
     GpuCaptureFile bad_hash = mixed;

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -1407,6 +1407,33 @@ int main() {
     CHECK(got32b4.size()==1 && std::fabs(got32b4[0]-28.0f)<1e-3f,
           "kernel 32b4 wide LDS reads/writes preserve all three/four consecutive dwords");
 
+    // Terminator 2D's startup clear writes a device-global GDS dword. Compute GDS must use the
+    // backend-owned persistent buffer, not the per-workgroup LDS array.
+    const uint32_t compute_gds_write[] = {
+        0xd8360000u, 0x00000100u,  // ds_write_b32 v0, v1 gds
+        0xbf810000u,
+    };
+    ShaderResourceTable compute_gds_table;
+    ShaderResource compute_gds_resource;
+    compute_gds_resource.cls = ResourceClass::ConstantBuffer;
+    compute_gds_resource.format = DataFormat::Uint32;
+    compute_gds_resource.num_components = 1;
+    compute_gds_resource.binding = kComputeInternalGdsBinding;
+    compute_gds_resource.size = 64 * 1024;
+    compute_gds_resource.stride = 4;
+    std::array<uint8_t, 64 * 1024> compute_gds_backing{};
+    compute_gds_resource.host_data = compute_gds_backing.data();
+    compute_gds_resource.host_data_size = compute_gds_backing.size();
+    compute_gds_table.resources.push_back(compute_gds_resource);
+    ComputeShaderConfig compute_gds_config;
+    std::vector<uint32_t> compute_gds_spv = recompile_compute(
+        compute_gds_write, std::size(compute_gds_write), &compute_gds_table,
+        compute_gds_config);
+    CHECK(!compute_gds_spv.empty(), "compute GDS ds_write_b32 recompiles to SPIR-V");
+    CHECK(validate_spirv_descriptor_interface(
+              compute_gds_spv, &compute_gds_table, 0, SpirvShaderStage::Compute, false).ok(),
+          "compute GDS module binds the persistent backend-owned buffer");
+
     // Kernel 32b5: Astro's exact DS_APPEND word. Initialize the LDS counter to 10, narrow EXEC to
     // the first 32 lanes, then append. Hardware performs one atomic +32 and broadcasts old=10 only
     // to active lanes; inactive lanes preserve their old v8=99. Reading the new counter (42) makes


### PR DESCRIPTION
## Summary

- lower compute `ds_write_b32 ... gds` to a persistent device-global storage buffer instead of rejecting it or treating it as workgroup LDS
- materialize the backend-owned 64 KiB GDS resource only for compute shaders that use this exact operation
- keep the internal backing out of guest GPU-write invalidation because it has no guest address
- preserve the initial GDS bytes explicitly in capture v22 and materialize one shared replay-owned instance across ordered dispatches

## Failure scenario and contract

Terminator 2D submits a 6,144-thread startup kernel whose final instruction is the exact GFX10 word `d8360000,00000100` (`ds_write_b32 v0, v1 gds`). Prosper rejected the dispatch at PC 16. GDS is device-global and persistent across workgroups/dispatches, so lowering it to the existing per-workgroup LDS model would be incorrect. This change binds one process-persistent 64 KiB host-backed storage buffer at an internal compute binding and masks byte addresses to the architectural 16-bit GDS range. Other GDS opcodes remain fail-visible.

GDS has no guest virtual address. Capture therefore does not fabricate an address-zero guest interval: v22 records the internal initial bytes in a versioned resource tail, and replay aliases every ordered reference to one owned mutable instance. Metadata-only captures continue to leave bytes explicitly unavailable.

## Verification

Exact head `a8004f50dd58828a75c14ac4a193fc479f7ca9d5`:

- `cmake --build prosper/build-terminator -j8 --target test_gpu_capture test_game_compute test_rdna2_to_spirv`: PASS
- `ctest --test-dir prosper/build-terminator --output-on-failure -R 'gpu_capture_roundtrip|game_compute_exec|rdna2_to_spirv'`: 3/3 PASS
- production Vulkan execution regression proves the value, 16-bit byte-address wrap, EXEC predication, host writeback, capture serialization/materialization, persistence across two dispatches, and absence of guest address-zero invalidation
- full snapshot check: PASS for Messenger scene, Evergate title, Dead Cells gameplay, and Blasphemous 2 gameplay
- live `boot_trace` on PPSA25872: the formerly rejected `0x201aff9a00` dispatch executes successfully (`threads=6144`, `groups=96`, binding 127), with no GPUVM fault
- direct `screenshot` route on Linux/RADV, six captures over 60 seconds with pulsed Cross input: stable Reef Entertainment logo, CRC `a7e8097d`; this PR does not claim visible progression

## Risk and scope

The new lowering is limited to compute `ds_write_b32` with the GDS bit. Fragment GDS append/consume behavior, compute LDS, guest buffers, and all other GDS operations are unchanged. The backing is process-persistent and submit execution is serialized by the existing GPU submit path. Capture format v22 remains backward-readable through v1.

Part of #1107.
