### PR TITLE
gpu: resolve moved compute store descriptors

### DIFF
--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -1336,6 +1336,11 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
     constexpr size_t kFoldSgprs = 128;
     std::array<uint32_t, kFoldSgprs> val{};                 // concrete SGPR values
     std::bitset<kFoldSgprs> val_known;
+    // Entry-user-data identity attached to an otherwise ordinary scalar value. This is narrower
+    // than descriptor provenance: it only proves that four s_mov_b32 copies reassembled four
+    // consecutive entry dwords, without arithmetic or a load changing any word.
+    std::array<uint32_t, kFoldSgprs> val_seed_origin{};
+    std::bitset<kFoldSgprs> val_seed_origin_known;
     // Descriptor provenance attached to the CURRENT scalar value. Unlike the load-time snapshots
     // below, this follows s_mov shuffles and is cleared by arithmetic/data writes. A key-less value
     // uses exact consuming-pc provenance, matching the recompiler after scalar spills.
@@ -1366,16 +1371,24 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
             val[(size_t)r] = v;
             val_known.set((size_t)r);
             val_srt_key_known.reset((size_t)r);
+            val_seed_origin_known.reset((size_t)r);
         }
     };
     auto forget = [&](int r) {
         if (valid_reg(r)) {
             val_known.reset((size_t)r);
             val_srt_key_known.reset((size_t)r);
+            val_seed_origin_known.reset((size_t)r);
         }
     };
-    for (uint32_t i = 0; i < nsgpr; i++)
-        set_value((int)(user_sgpr_base + i), user_sgprs[i]);
+    for (uint32_t i = 0; i < nsgpr; i++) {
+        const int reg = (int)(user_sgpr_base + i);
+        set_value(reg, user_sgprs[i]);
+        if (valid_reg(reg)) {
+            val_seed_origin[(size_t)reg] = i;
+            val_seed_origin_known.set((size_t)reg);
+        }
+    }
 
     // A direct sharp lives in the initial user-data SGPR block rather than arriving through an
     // s_load. It remains a usable load-time descriptor only while none of its SGPRs has subsequently
@@ -1434,11 +1447,20 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                         in.src[0].kind == OperandKind::SGPR && valid_reg(in.src[0].value) &&
                         val_srt_key_known.test((size_t)in.src[0].value) &&
                         (source_key = val_srt_key[(size_t)in.src[0].value], true);
+                    uint32_t source_origin = 0;
+                    const bool source_origin_known =
+                        in.src[0].kind == OperandKind::SGPR && valid_reg(in.src[0].value) &&
+                        val_seed_origin_known.test((size_t)in.src[0].value) &&
+                        (source_origin = val_seed_origin[(size_t)in.src[0].value], true);
                     if (in.src[0].kind == OperandKind::Literal ? (v = in.literal, true) : srcval(in.src[0], v)) {
                         set_value(in.dst.value, v);
                         if (source_key_known && valid_reg(in.dst.value)) {
                             val_srt_key[(size_t)in.dst.value] = source_key;
                             val_srt_key_known.set((size_t)in.dst.value);
+                        }
+                        if (source_origin_known && valid_reg(in.dst.value)) {
+                            val_seed_origin[(size_t)in.dst.value] = source_origin;
+                            val_seed_origin_known.set((size_t)in.dst.value);
                         }
                     } else forget(in.dst.value);
                 } else if (in.dst.kind == OperandKind::SGPR) {
@@ -1772,7 +1794,20 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                         current_known &= known(srsrc + k, current[(size_t)k]);
                     const bool loaded_provenance = valid_reg(srsrc) &&
                                                    descr_known.test((size_t)srsrc);
-                    const bool direct_provenance = unchanged_seed_range(srsrc, 4);
+                    bool moved_direct_provenance = valid_reg(srsrc) && valid_reg(srsrc + 3);
+                    uint32_t first_origin = 0;
+                    for (int k = 0; k < 4 && moved_direct_provenance; ++k) {
+                        const size_t reg = (size_t)(srsrc + k);
+                        if (!val_seed_origin_known.test(reg)) {
+                            moved_direct_provenance = false;
+                        } else if (k == 0) {
+                            first_origin = val_seed_origin[reg];
+                        } else if (val_seed_origin[reg] != first_origin + (uint32_t)k) {
+                            moved_direct_provenance = false;
+                        }
+                    }
+                    const bool direct_provenance = unchanged_seed_range(srsrc, 4) ||
+                                                   moved_direct_provenance;
                     if (current_known && (loaded_provenance || direct_provenance)) {
                         // Publish the four values LIVE at the consumer. A modeled scalar patch is
                         // exact; an unmodeled/incompatible write becomes unknown and fails closed

--- a/prosper/src/gpu/shader_resources.cpp
+++ b/prosper/src/gpu/shader_resources.cpp
@@ -209,6 +209,17 @@ enum : uint32_t {
     OpStore = 62,
     OpAccessChain = 65,
     OpInBoundsAccessChain = 66,
+    OpAtomicLoad = 227,
+    OpAtomicStore = 228,
+    OpAtomicExchange = 229,
+    OpAtomicCompareExchange = 230,
+    OpAtomicCompareExchangeWeak = 231,
+    OpAtomicIIncrement = 232,
+    OpAtomicIDecrement = 233,
+    OpAtomicIAdd = 234,
+    OpAtomicXor = 242,
+    OpAtomicFlagTestAndSet = 318,
+    OpAtomicFlagClear = 319,
     OpDecorate = 71,
     OpMemberDecorate = 72,
 };
@@ -475,6 +486,17 @@ DescriptorValidationReport validate_spirv_descriptor_interface(
             uint32_t ptr = word(in, 2); mark(ptr);
             auto ai = accesses.find(ptr); if (ai != accesses.end()) mark(ai->second.variable);
         } else if (in.opcode == OpStore && n >= 1) {
+            uint32_t ptr = word(in, 0); mark(ptr);
+            auto ai = accesses.find(ptr); if (ai != accesses.end()) mark(ai->second.variable);
+        } else if (((in.opcode >= OpAtomicLoad && in.opcode <= OpAtomicIDecrement) ||
+                    (in.opcode >= OpAtomicIAdd && in.opcode <= OpAtomicXor) ||
+                    in.opcode == OpAtomicFlagTestAndSet) && n >= 3) {
+            // Result-producing atomic instructions place their pointer after result type/result id.
+            // A write-only atomic buffer is still part of the live descriptor interface.
+            uint32_t ptr = word(in, 2); mark(ptr);
+            auto ai = accesses.find(ptr); if (ai != accesses.end()) mark(ai->second.variable);
+        } else if ((in.opcode == OpAtomicStore || in.opcode == OpAtomicFlagClear) && n >= 1) {
+            // The two result-less atomic instructions place the pointer first, like OpStore.
             uint32_t ptr = word(in, 0); mark(ptr);
             auto ai = accesses.find(ptr); if (ai != accesses.end()) mark(ai->second.variable);
         } else if ((in.opcode == OpAccessChain || in.opcode == OpInBoundsAccessChain) && n >= 3) {

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -903,6 +903,44 @@ int main() {
                              &atomic_table, atomic_config).empty(),
           "#636: production resource table keeps stride-zero supported atomic realizable");
 
+    // Terminator 2D supplies descriptor dwords separately, then reassembles its destination V# in
+    // s[0:3] with four scalar moves immediately before format stores. This has no SRT-load tag and
+    // the destination range no longer equals its entry user data, but the four consecutive seed
+    // origins are exact provenance. Arithmetic or a shuffled word must still fail closed.
+    static uint32_t moved_store_output[16];
+    const uint64_t moved_store_base = (uint64_t)(uintptr_t)moved_store_output;
+    uint32_t moved_store_seed[9] = {};
+    moved_store_seed[5] = (uint32_t)moved_store_base;
+    moved_store_seed[6] = (uint32_t)(moved_store_base >> 32) | (4u << 16);
+    moved_store_seed[7] = 16;
+    moved_store_seed[8] = 0x10005004u;
+    const uint32_t moved_direct_store[] = {
+        0xBE800305u, 0xBE810306u, 0xBE820307u, 0xBE830308u,
+        0xE0142000u, 0x80000000u, // buffer_store_format_x v0, v0, s[0:3]
+        0xBF810000u,
+    };
+    ShaderResourceTable moved_store_table;
+    const std::vector<SrtUse> moved_store_uses = add_compute_buffer_resources(
+        moved_store_table, moved_direct_store, std::size(moved_direct_store),
+        moved_store_seed, std::size(moved_store_seed));
+    assign_convention_bindings(moved_store_table, 2);
+    CHECK(moved_store_uses.size() == 1 && moved_store_uses[0].use_pc == 4 &&
+              moved_store_table.resources.size() == 1 &&
+              moved_store_table.resources[0].gpu_addr == moved_store_base &&
+              moved_store_table.resources[0].fetch_pc == 4,
+          "moved consecutive entry dwords publish the exact format-store V#");
+    const uint32_t moved_shuffled_store[] = {
+        0xBE800305u, 0xBE810306u, 0xBE820308u, 0xBE830307u,
+        0xE0142000u, 0x80000000u,
+        0xBF810000u,
+    };
+    ShaderResourceTable moved_shuffled_table;
+    add_compute_buffer_resources(moved_shuffled_table, moved_shuffled_store,
+                                 std::size(moved_shuffled_store), moved_store_seed,
+                                 std::size(moved_store_seed));
+    CHECK(moved_shuffled_table.resources.empty(),
+          "shuffled entry dwords do not fabricate moved-descriptor provenance");
+
     // Kernel 5dr: once any T# SGPR is reloaded, the initial sharp is stale. An unresolved reload must
     // not silently resurrect it and fabricate a texture mapping for the later image operation.
     const uint32_t k5dr[] = {

--- a/prosper/tests/test_shader_resources.cpp
+++ b/prosper/tests/test_shader_resources.cpp
@@ -41,6 +41,14 @@ static std::vector<uint32_t> descriptor_test_spirv() {
     return s;
 }
 
+static std::vector<uint32_t> atomic_descriptor_test_spirv() {
+    std::vector<uint32_t> s = descriptor_test_spirv();
+    // %12 points at binding 10. AtomicAnd is result-producing, so its pointer is operand 2 after
+    // result type/result id. The descriptor is write-only and must still be reflected for binding.
+    emit(s, 240, {1, 13, 12, 6, 6, 6});                    // %13 = atomicAnd %12
+    return s;
+}
+
 static std::vector<uint32_t> image_test_spirv() {
     std::vector<uint32_t> s = {0x07230203u, 0x00010000u, 0, 16, 0};
     emit(s, 15, {4, 10, 0x6e69616d, 0});                    // OpEntryPoint Fragment %10 "main"
@@ -188,6 +196,14 @@ int main() {
           vr.descriptors[0].kind == SpirvDescriptorKind::StorageBuffer &&
           vr.descriptors[0].required_bytes == 20 && !vr.descriptors[0].dynamic_access,
           "constant access chain reflects storage-buffer binding 9 with a 20-byte minimum");
+
+    ShaderResource atomic = good; atomic.binding = 10;
+    ShaderResourceTable atomic_table; atomic_table.resources = {good, atomic};
+    const DescriptorValidationReport atomic_report = validate_spirv_descriptor_interface(
+        atomic_descriptor_test_spirv(), &atomic_table, 0, SpirvShaderStage::Vertex);
+    CHECK(atomic_report.ok() && atomic_report.descriptors.size() == 2 &&
+              atomic_report.descriptors[1].binding == 10,
+          "write-only atomic access reflects its storage-buffer descriptor");
 
     ShaderResourceTable missing;
     auto mr = validate_spirv_descriptor_interface(spv, &missing, 0, SpirvShaderStage::Vertex);


### PR DESCRIPTION
Closes the next compute blocker in #1107.

## Failure scenario

Terminator 2D reassembles its destination V# by copying entry user-data dwords s5-s8 into s0-s3, then issues four Uint16 format stores. The constant fold rejected the moved descriptor, leaving shader `0x20116ec900` unresolved. Once recovered, its packed stores lower to SPIR-V atomics; descriptor reflection ignored write-only atomic accesses, so the live backend bound only the eight source aliases and RADV faulted through the four unbound destination descriptors.

## Contract and approach

- Preserve entry-user-data identity through scalar `s_mov_b32` only; arithmetic, reloads, unknown writes, and shuffled words clear or fail provenance.
- Accept a moved direct V# only when all four current SGPR words originate from four consecutive entry dwords.
- Reflect all core SPIR-V buffer atomic pointer forms, including result-less AtomicStore/AtomicFlagClear, so write-only buffers are present in the runtime descriptor interface.
- Existing unchanged direct descriptors and s_load/SRT provenance are deliberately unaffected.

## Risk

The provenance rule is intentionally narrow, but it adds a new resource-recovery path. Atomic reflection covers the core atomic opcode families and can expose missing runtime bindings earlier; strict validation remains the safety gate.

## Verification

- `cmake --build prosper/build-terminator -j8 --target test_shader_resources test_dynfetch_fold prosper_core`
- `ctest --test-dir prosper/build-terminator --output-on-failure -R "shader_resources|dynfetch_fold"` — 2/2 passed
- `ctest --test-dir prosper/build-terminator --output-on-failure -j8` — 126/127 passed; only `module_loads_eboot` failed because this build points at Terminator (662 imports) while the default fixture expects 612
- Direct Terminator screenshot frontend run on Linux/RADV for 8 seconds: c900 repeatedly completed with 12 buffers bound and no GPUVM fault/device loss (previously faulted on the next submit)
- `git diff --check`

Snapshot automation could not run in this devcontainer: loading the host FFmpeg libraries required by the locally relinked screenshot frontend into the Python process causes a Python 3.14 C-API mismatch. No baseline is changed, and the direct frontend capture remains at the Reef splash, so this PR claims kernel execution/fault removal rather than visible progression.