### PR TITLE
fix(renderer): honor VideoOut scanout extent

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -2215,6 +2215,17 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     uint32_t gw = w, gh = h;
                     const uint32_t present_w = prosper::gpu::present_width();
                     const uint32_t present_h = prosper::gpu::present_height();
+                    bool is_vo = false;
+                    for (int i = 0; i < vo_n && !is_vo; i++)
+                        is_vo = base && base == prosper_vo_buffer_addr(i);
+                    // VideoOut registration is the visible scanout contract. CB_COLOR0_ATTRIB2 can
+                    // describe an overallocated backing surface (Terminator reports 4096x4096 for a
+                    // 1920x1080 scanout), which must not become the persistent target extent or the
+                    // final cache lookup will reject the rendered frame.
+                    if (is_vo && present_w && present_h) {
+                        native_w = present_w;
+                        native_h = present_h;
+                    }
                     // A depth prepass may bind a tiny/dummy color target with CB_TARGET_MASK=0 while
                     // rasterizing the full-size guest depth surface. Keying persistent DS from that
                     // irrelevant color extent creates a small depth image that the later lighting pass
@@ -2307,9 +2318,6 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             sit->second.format == pass_format && sit->second.rgba &&
                             sit->second.rgba->size() == pass_bytes)
                             seed = sit->second.rgba->data(); }
-                    bool is_vo = false;
-                    for (int i = 0; i < vo_n && !is_vo; i++)
-                        is_vo = base && base == prosper_vo_buffer_addr(i);
                     bool sampled_exact_later = false;
                     bool feedback_later = false;
                     if (live_gpu_targets && base) {

--- a/prosper/tests/test_gpu_capture_render.cpp
+++ b/prosper/tests/test_gpu_capture_render.cpp
@@ -639,6 +639,24 @@ int main() {
               "missing sampled image receives a full-surface nonblack poison texture instead of zero");
     }
 
+    // VideoOut's registered dimensions are authoritative even when CB_COLOR0_ATTRIB2 describes a
+    // larger backing allocation. Treating this 256x256 declaration as the visible extent scales the
+    // pass to 128x128 and prevents the final 64x64 scanout lookup from publishing the rendered frame.
+    // Keep this last because publishing a registered front buffer intentionally makes it the source
+    // selected by later callbacks.
+    DrawItem oversized_scanout = replay.items[0];
+    oversized_scanout.color0_base = reinterpret_cast<uint64_t>(scanout0.data());
+    oversized_scanout.color0_width = PRESENT_W * 2;
+    oversized_scanout.color0_height = PRESENT_H * 2;
+    std::vector<uint8_t> scanout_pixels = render_submit_items({oversized_scanout}, W, H);
+    CHECK(scanout_pixels.size() == static_cast<size_t>(W) * H * 4,
+          "registered scanout uses the VideoOut extent instead of its oversized CB allocation");
+    if (scanout_pixels.size() == static_cast<size_t>(W) * H * 4) {
+        const uint8_t* center = &scanout_pixels[(static_cast<size_t>(H / 2) * W + W / 2) * 4];
+        CHECK(center[0] > 0xC0 && center[1] < 0x40 && center[2] < 0x40,
+              "oversized registered scanout still publishes its rendered pixels");
+    }
+
     if (fails) { std::printf("== FAIL: %d ==\n", fails); return 1; }
     std::printf("== PASS ==\n"); return 0;
 }


### PR DESCRIPTION
## Summary

- Treat registered VideoOut dimensions as authoritative for scanout render targets.
- Preserve CB_COLOR0_ATTRIB2 extents for non-VideoOut offscreen targets.
- Add a regression for an oversized scanout backing allocation.

## Root cause

Terminator 2D registers a 1920x1080 VideoOut surface but reports a 4096x4096 CB color allocation. The renderer cached that target at the allocation extent, while final presentation required a cache entry matching 1920x1080. Rendering completed, but no composited frame could be published and screenshots fell back to black raw scanout memory.

## Impact

Terminator now publishes real composited frames and visibly reaches the Reef Entertainment splash instead of remaining black. Offscreen render targets continue using their native CB extents.

## Validation

- `cmake --build prosper/build-terminator --target test_gpu_capture_render -j2`
- `./prosper/build-terminator/test_gpu_capture_render`
- 5-second Terminator live run: source `composited`, frame sequence 201, present count 203, 1920x1080 output, visible Reef Entertainment splash

Refs #1107