### PR TITLE
fix(audio): AJM gapless skip/total trim so one-shot SFX report EOS (#1097)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -384,6 +384,13 @@ if(TARGET prosper_core)
   target_link_libraries(test_atrac9 PRIVATE prosper_core)
   add_test(NAME atrac9_decode COMMAND test_atrac9)
 
+  # AJM batch-2.0 gapless decode semantics (#1097): skip/total trim, exact EOS landing of
+  # uiTotalDecodedSamples, post-EOS silence, and program re-arm. FMOD's codec recycling keys off
+  # the exact EOS; without it one-shot SFX exhaust the codec pool. Pure, no game dump; runs in CI.
+  add_executable(test_ajm2_gapless tests/test_ajm2_gapless.cpp)
+  target_link_libraries(test_ajm2_gapless PRIVATE prosper_core)
+  add_test(NAME ajm2_gapless COMMAND test_ajm2_gapless)
+
   # APR container registry + size-keyed read matching (issue #62): stable ids, path dedup, and
   # the ambiguity/chunk-read refusal the read-submit path relies on. Pure, no game dump needed.
   add_executable(test_apr_registry tests/test_apr_registry.cpp)

--- a/prosper/scripts/blasphemous2/sfx-retrigger.pad
+++ b/prosper/scripts/blasphemous2/sfx-retrigger.pad
@@ -1,0 +1,31 @@
+# Blasphemous 2 - #1097 one-shot SFX retrigger repro.
+# Loads the first-Prie-Dieu save (same repeating-Cross prelude as load-save-first-station.pad),
+# then presses Square (attack) several times with multi-second gaps. Under PROSPER_AUDIOLOG the
+# AJM lifecycle around press 1 vs press 2 is the diagnostic: does the guest issue a decode for
+# the SFX again, and through which instance?
+# Requires the Prie Dieu save in PROSPER_SAVE0 (see load-save-first-station.pad header).
+1-2:cross
+6-7:cross
+11-12:cross
+16-17:cross
+21-22:cross
+26-27:cross
+31-32:cross
+36-37:cross
+41-42:cross
+46-47:cross
+51-52:cross
+56-57:cross
+61-62:cross
+66-67:cross
+71-72:cross
+76-77:cross
+81-82:cross
+86-87:cross
+91-92:cross
+# gameplay by ~95s; attacks with clean gaps:
+100-101:square
+106-107:square
+112-113:square
+118-119:square
+124-125:square

--- a/prosper/src/hle/hle_audio.cpp
+++ b/prosper/src/hle/hle_audio.cpp
@@ -1002,9 +1002,11 @@ struct AjmAt9Inst {
     uint8_t  config[4] = {0};
     bool     have_config = false;
     std::unique_ptr<Atrac9Decoder> dec;   // persistent per instance: preserves MDCT overlap across blocks
-    uint32_t skip_samples = 0;            // gapless front-delay (encoder priming), for future trim
-    uint64_t total_samples = 0;           // gapless total (end trim)
-    uint64_t decoded_samples = 0;         // running count of decoded sample-frames (for the sideband)
+    uint32_t skip_samples = 0;            // gapless program: priming frames to drop at program start
+    uint64_t total_samples = 0;           // gapless program: trimmed frames to deliver (0 = no program)
+    uint32_t skip_remaining = 0;          // frames still to drop (counts down from skip_samples)
+    uint64_t gapless_delivered = 0;       // trimmed frames delivered for the CURRENT program
+    uint64_t decoded_samples = 0;         // cumulative delivered sample-frames (no-program sideband)
     // PCM decoded but not yet delivered to a guest output buffer. Lives with the decoder (NOT per
     // batch): the decoder state already spans batches, so a spill must too — dropping it at a batch
     // boundary would lose audio the guest was told (via iSizeConsumed) it had received.
@@ -1018,6 +1020,13 @@ struct AjmDecJob {
 // SCE_AJM_ERROR_INVALID_PARAMETER — the AJM error space (see the constants above); -1 is not a value
 // the guest's error mapping recognizes.
 constexpr int32_t kAjm2ErrDecode = (int32_t)0x80930005;
+// Monotonic milliseconds for [ajm2] diagnostics: pad-script presses are scheduled in wall seconds,
+// so timestamped lifecycle logs let a press at a known time be matched to its AJM traffic (#1097).
+uint64_t ajm2_log_ms() {
+    static const auto t0 = std::chrono::steady_clock::now();
+    return (uint64_t)std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - t0).count();
+}
 std::mutex g_ajm2_mx;
 std::map<uint32_t, AjmAt9Inst> g_ajm2_inst;               // instance id -> decode state
 std::map<uint64_t, std::vector<AjmDecJob>> g_ajm2_jobs;   // batchInfo -> queued decode jobs
@@ -1316,6 +1325,14 @@ void ajm2_decode_batch(std::vector<AjmDecJob>& jobs) {
 
         for (size_t k = ji; k < je; ++k) {
             AjmDecJob& job = jobs[k];
+            AjmAt9Inst& I = it->second;
+            // A programmed gapless decode (#1097): drop `skip` priming frames at the program start,
+            // deliver EXACTLY `total` trimmed frames, then pin the reported total there with no
+            // further PCM. FMOD's channel-end and codec-slot recycling key off that exact landing;
+            // overshooting it (whole raw superframes, cumulative counter) left every one-shot SFX
+            // "still playing" forever, so codec slots were never recycled and the pool exhausted
+            // after ~32 sounds -- every later sound silent.
+            const bool prog = I.total_samples > 0;
             // Over-allocate by a full superframe: LibAtrac9's bit reader is unbounded, so a truncated
             // or corrupt block's parse may step past the nominal superframe. decode_superframe still
             // rejects such a parse, but the read must land in memory we own.
@@ -1326,38 +1343,72 @@ void ajm2_decode_batch(std::vector<AjmDecJob>& jobs) {
             const uint32_t out_cap = job.out_size - (job.out_size % frame_bytes);
             uint32_t in_cur = 0, produced = 0;
             int32_t err = 0;
-            auto write_out = [&](const int16_t* src, uint32_t nbytes) -> uint32_t {
-                const uint32_t room = out_cap - produced;
-                uint32_t w = std::min(nbytes, room);
-                w -= w % frame_bytes;
-                if (!w) return 0;
-                if (!audio_store_bytes(job.out_addr + produced, src, w)) { err = kAjm2ErrDecode; return 0; }
-                produced += w;
+            // Deliver `nframes` at `src`: end-trim against the program total, then write what the
+            // output has room for. Returns the number of frames written; `spill` gets the within-
+            // total remainder (room starvation), while beyond-total frames are discarded.
+            auto deliver = [&](const int16_t* src, uint32_t nframes,
+                               const int16_t** spill, uint32_t* spill_frames) -> uint32_t {
+                *spill = nullptr; *spill_frames = 0;
+                if (prog) {
+                    const uint64_t left = I.total_samples > I.gapless_delivered
+                                              ? I.total_samples - I.gapless_delivered : 0;
+                    if (nframes > left) nframes = (uint32_t)left;
+                }
+                const uint32_t room_frames = (out_cap - produced) / frame_bytes;
+                const uint32_t w = std::min(nframes, room_frames);
+                if (w) {
+                    if (!audio_store_bytes(job.out_addr + produced, src,
+                                           w * frame_bytes)) { err = kAjm2ErrDecode; return 0; }
+                    produced += w * frame_bytes;
+                    I.gapless_delivered += w;
+                }
+                *spill = src + (size_t)w * ch;
+                *spill_frames = nframes - w;
                 return w;
             };
             // 1. Drain carry-over PCM (decoded earlier, not yet delivered) into this output first.
+            //    Carry holds post-skip frames, so only the total/room trims apply here.
             if (!carry.empty() && produced < out_cap) {
-                const uint32_t cbytes = (uint32_t)(carry.size() * sizeof(int16_t));
-                const uint32_t w = write_out(carry.data(), cbytes);
-                if (w >= cbytes) carry.clear();
-                else if (w) carry.erase(carry.begin(), carry.begin() + w / sizeof(int16_t));
+                const uint32_t cframes = (uint32_t)(carry.size() / ch);
+                const int16_t* spill = nullptr; uint32_t spill_frames = 0;
+                deliver(carry.data(), cframes, &spill, &spill_frames);
+                if (!err) {
+                    if (spill_frames)
+                        carry.erase(carry.begin(),
+                                    carry.end() - (size_t)spill_frames * ch);
+                    else
+                        carry.clear();
+                }
             }
             // 2. Decode this block's superframes into the remaining space. Stop BEFORE decoding once
-            //    the output is full so `iSizeConsumed` never covers PCM the guest did not receive.
-            while (!err && produced < out_cap && in_cur + (uint32_t)sfb <= got) {
+            //    the output is full (so `iSizeConsumed` never covers PCM the guest did not receive)
+            //    or the gapless program is complete (post-EOS input produces nothing).
+            while (!err && produced < out_cap && in_cur + (uint32_t)sfb <= got &&
+                   !(prog && I.gapless_delivered >= I.total_samples)) {
                 if (dec->decode_superframe(in.data() + in_cur, pcm.data(),
                                            (int)(got - in_cur)) < 0) { err = kAjm2ErrDecode; break; }
                 in_cur += (uint32_t)sfb;
-                const uint32_t w = write_out(pcm.data(), sf_out_bytes);
+                const int16_t* block = pcm.data();
+                uint32_t nframes = (uint32_t)sfs;
+                if (prog && I.skip_remaining) {     // priming skip: stream-order, decode-time drop
+                    const uint32_t drop = std::min(I.skip_remaining, nframes);
+                    I.skip_remaining -= drop;
+                    block += (size_t)drop * ch;
+                    nframes -= drop;
+                }
+                const int16_t* spill = nullptr; uint32_t spill_frames = 0;
+                deliver(block, nframes, &spill, &spill_frames);
                 if (err) break;
-                if (w < sf_out_bytes)                                   // spilled: carry the rest forward
-                    carry.insert(carry.end(), pcm.begin() + w / sizeof(int16_t), pcm.end());
+                if (spill_frames)                                       // spilled: carry forward
+                    carry.insert(carry.end(), spill, spill + (size_t)spill_frames * ch);
             }
-            it->second.decoded_samples += produced / frame_bytes;
-            ajm2_write_result(job.result_addr, err, in_cur, produced, it->second.decoded_samples);
+            I.decoded_samples += produced / frame_bytes;
+            ajm2_write_result(job.result_addr, err, in_cur, produced,
+                              prog ? I.gapless_delivered : I.decoded_samples);
             if (log)
-                fprintf(stderr, "[ajm2] decode inst=%u in=%zu/%u out=%u -> %u consumed, %u PCM, carry=%zu%s\n",
-                        inst_id, got, job.in_size, job.out_size, in_cur, produced,
+                fprintf(stderr, "[ajm2] t=%llums decode inst=%u in=%zu/%u out=%u -> %u consumed, %u PCM, total=%llu carry=%zu%s\n",
+                        (unsigned long long)ajm2_log_ms(), inst_id, got, job.in_size, job.out_size,
+                        in_cur, produced, (unsigned long long)it->second.decoded_samples,
                         carry.size() * sizeof(int16_t), err ? " ERR" : "");
         }
         ji = je;
@@ -1372,11 +1423,29 @@ HLE10(ajm_batch_job_initialize) {
     const bool have = a2 && audio_read_bytes(a2, cfg, 4) && cfg[0] == 0xFE;
     std::lock_guard<std::mutex> lk(g_ajm2_mx);
     AjmAt9Inst& inst = g_ajm2_inst[(uint32_t)a1];
-    if (have && (!inst.have_config || std::memcmp(inst.config, cfg, 4) != 0)) {
+    const bool config_changed =
+        have && (!inst.have_config || std::memcmp(inst.config, cfg, 4) != 0);
+    if (getenv("PROSPER_AUDIOLOG")) {   // #1097: every re-init, with the state it inherits
+        static std::atomic<uint64_t> n{0};
+        const uint64_t k = n.fetch_add(1);
+        if (k < 400 || (k % 100) == 0)
+            fprintf(stderr, "[ajm2] t=%llums JobInitialize inst=%llu config=%02x%02x%02x%02x "
+                    "changed=%d inherited_decoded=%llu\n",
+                    (unsigned long long)ajm2_log_ms(), (unsigned long long)a1,
+                    cfg[0], cfg[1], cfg[2], cfg[3], config_changed ? 1 : 0,
+                    (unsigned long long)inst.decoded_samples);
+    }
+    if (config_changed) {
         std::memcpy(inst.config, cfg, 4);
         inst.have_config = true;
         inst.dec = std::make_unique<Atrac9Decoder>();
         if (!inst.dec->init(cfg)) inst.dec.reset();
+        // A different stream format on a reused slot: drop the old stream's pending PCM and
+        // program state; the guest programs a fresh gapless spec for the new sound (#1097).
+        inst.carry.clear();
+        inst.skip_remaining = 0;
+        inst.gapless_delivered = 0;
+        inst.total_samples = 0;
         if (getenv("PROSPER_AUDIOLOG"))
             fprintf(stderr, "[ajm2] JobInitialize inst=%llu config=%02x%02x%02x%02x decoder=%s\n",
                     (unsigned long long)a1, cfg[0], cfg[1], cfg[2], cfg[3],
@@ -1393,6 +1462,20 @@ HLE10(ajm_batch_job_gapless) {
     AjmAt9Inst& inst = g_ajm2_inst[(uint32_t)a1];
     inst.total_samples = g[0];
     inst.skip_samples = g[1];
+    // A gapless spec (re)starts the decode PROGRAM (#1097): the skip applies from here, the
+    // delivered counter restarts (FMOD re-arms at a loop boundary and expects the next pass to
+    // count 0..total again), and pending spill PCM belongs to the previous program -- a reused
+    // codec slot must never emit the prior sound's tail into the new one.
+    inst.skip_remaining = g[1];
+    inst.gapless_delivered = 0;
+    inst.carry.clear();
+    if (getenv("PROSPER_AUDIOLOG")) {   // #1097 lifecycle evidence
+        static std::atomic<uint64_t> n{0};
+        const uint64_t k = n.fetch_add(1);
+        if (k < 400 || (k % 100) == 0)
+            fprintf(stderr, "[ajm2] t=%llums SetGapless inst=%llu total=%u skip=%u\n",
+                    (unsigned long long)ajm2_log_ms(), (unsigned long long)a1, g[0], g[1]);
+    }
     return 0;
 }
 HLE10(ajm_batch_job_decode) {

--- a/prosper/src/hle/hle_audio.cpp
+++ b/prosper/src/hle/hle_audio.cpp
@@ -1360,7 +1360,7 @@ void ajm2_decode_batch(std::vector<AjmDecJob>& jobs) {
                     if (!audio_store_bytes(job.out_addr + produced, src,
                                            w * frame_bytes)) { err = kAjm2ErrDecode; return 0; }
                     produced += w * frame_bytes;
-                    I.gapless_delivered += w;
+                    if (prog) I.gapless_delivered += w;   // only meaningful for a gapless program
                 }
                 *spill = src + (size_t)w * ch;
                 *spill_frames = nframes - w;

--- a/prosper/tests/test_ajm2_gapless.cpp
+++ b/prosper/tests/test_ajm2_gapless.cpp
@@ -118,6 +118,69 @@ int main() {
           "re-armed program's total restarts and lands exactly on the new total");
     CHECK(sb3.iSizeProduced == kTotal2 * frame_bytes, "re-armed program delivers the new total");
 
+    // --- Streaming a gapless program through a TINY output buffer across many jobs (review #1097).
+    // Exercises the subtlest paths the big-buffer cases skip: room-starvation spill UNDER an active
+    // gapless program, the carry erase-tail branch, and multi-batch program continuation. Feeds input
+    // the way a real guest does -- advancing by each job's reported iSizeConsumed -- and accumulates
+    // the delivered PCM, which must equal reference[skip .. skip+total] and land exactly on total.
+    const uint32_t inst3 = 9;
+    const uint32_t kSkip3 = (uint32_t)sfs + 137;             // skip spans MORE than one superframe
+    const uint64_t kTotal3 = raw_frames - kSkip3 - 500;
+    uint32_t gapless3[2] = {(uint32_t)kTotal3, kSkip3};
+    job_init(batch, inst3, addr(kAt9Config), 8, addr(&sb), 0, 0, 0, 0, 0);
+    job_gapl(batch, inst3, addr(gapless3), 1, addr(&sb), 0, 0, 0, 0, 0);
+
+    // CONTROL: single job, whole input, output sized to EXACTLY total. Isolates the code's
+    // skip>superframe + total-cap from the multi-job streaming model.
+    {
+        Sideband sc{};
+        std::vector<uint8_t> exact((size_t)kTotal3 * frame_bytes, 0);
+        job_dec(batch, inst3, addr(kAt9Data), kAt9DataLen, addr(exact.data()), exact.size(),
+                addr(&sc), 0, 0, 0);
+        batch_go(0, batch, 0, 0, 0, 0, 0, 0, 0, 0);
+        CHECK(sc.uiTotalDecodedSamples == kTotal3 &&
+              std::memcmp(exact.data(), reference.data()+(size_t)kSkip3*ch,
+                          (size_t)kTotal3*frame_bytes)==0,
+              "control: single-job skip>superframe + total-cap lands exactly");
+    }
+    // Fresh instance for the streaming test: the control above decoded inst3 to stream-end, and
+    // re-arming gapless resets the trim counters but NOT the Atrac9Decoder's MDCT position, so the
+    // streaming pass needs its own instance (new id -> fresh decoder on first JobInitialize).
+    const uint32_t inst4 = 10;
+    job_init(batch, inst4, addr(kAt9Config), 8, addr(&sb), 0, 0, 0, 0, 0);
+    job_gapl(batch, inst4, addr(gapless3), 1, addr(&sb), 0, 0, 0, 0, 0);
+
+    std::vector<int16_t> collected;
+    const uint32_t tiny = (uint32_t)(300 * ch) * sizeof(int16_t);   // ~300 frames per job
+    std::vector<uint8_t> tinyout(tiny, 0);
+    uint32_t in_off = 0; int guard = 0; bool tiny_ok = true;
+    while (guard++ < 100000) {
+        Sideband s{};
+        const uint32_t in_left = (in_off < kAt9DataLen) ? (kAt9DataLen - in_off) : 0;
+        // Real feed while input remains; once exhausted, a valid sub-superframe input that decodes
+        // nothing new but lets the handler accept the job and drain the carry (mirrors the guest's
+        // next feed, whose carry-drain runs first).
+        const uint64_t din = in_left ? addr(kAt9Data + in_off) : addr(kAt9Data);
+        const uint32_t dsz = in_left ? in_left : 1u;
+        job_dec(batch, inst4, din, dsz, addr(tinyout.data()), tinyout.size(), addr(&s), 0, 0, 0);
+        batch_go(0, batch, 0, 0, 0, 0, 0, 0, 0, 0);
+        if (s.iResult != 0) { tiny_ok = false; break; }
+        const uint32_t got_frames = s.iSizeProduced / frame_bytes;
+        collected.insert(collected.end(),
+                         reinterpret_cast<const int16_t*>(tinyout.data()),
+                         reinterpret_cast<const int16_t*>(tinyout.data()) + (size_t)got_frames * ch);
+        in_off += s.iSizeConsumed;
+        if (s.uiTotalDecodedSamples >= kTotal3) break;      // program complete
+        if (in_left == 0 && s.iSizeProduced == 0) break;    // input gone and carry drained
+    }
+    CHECK(tiny_ok, "tiny-buffer streaming has no decode error");
+    CHECK(collected.size() == (size_t)kTotal3 * ch,
+          "tiny-buffer streaming delivers exactly total frames across many jobs");
+    CHECK(collected.size() == (size_t)kTotal3 * ch &&
+          std::memcmp(collected.data(), reference.data() + (size_t)kSkip3 * ch,
+                      (size_t)kTotal3 * frame_bytes) == 0,
+          "tiny-buffer streamed PCM equals reference[skip..skip+total] (multi-superframe skip)");
+
     // A fresh instance with NO gapless program keeps the historical cumulative behavior
     // (streaming titles that never program gapless must not change).
     const uint32_t inst2 = 8;

--- a/prosper/tests/test_ajm2_gapless.cpp
+++ b/prosper/tests/test_ajm2_gapless.cpp
@@ -1,0 +1,135 @@
+// test_ajm2_gapless (#1097) — the AJM batch-2.0 decode path implements REAL gapless semantics.
+//
+// FMOD on PS5 programs every ATRAC9 stream with sceAjmBatchJobSetGaplessDecode{total, skip}: the
+// decoder must drop `skip` priming sample-frames at the start of the program, deliver EXACTLY
+// `total` trimmed frames, and then report end-of-stream by pinning uiTotalDecodedSamples at
+// `total` with no further PCM. FMOD's channel-end / codec-recycling logic keys off that exact
+// landing: with prosper's old behavior (whole superframes, no trim, cumulative raw counter) the
+// reported total OVERSHOT the programmed total, FMOD never saw a one-shot SFX finish, never
+// recycled its AJM codec slot, and after ~32 sounds every later SFX was silent (#1097).
+//
+// Drives the real HLE handlers (host pointers stand in for guest addresses, as in test_ajm) over
+// the shared 16-superframe test vector, with reference PCM built by the same Atrac9Decoder glue
+// that test_atrac9 proves bit-exact against LibAtrac9.
+#include "../src/hle/dispatch.hpp"
+#include "../src/hle/nid.hpp"
+#include "../src/hle/atrac9_decode.hpp"
+#include "at9_testvec.h"
+#include <cstdio>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+using Hle10Fn = uint64_t (*)(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t,
+                             uint64_t, uint64_t, uint64_t, uint64_t);
+
+struct Sideband {
+    int32_t iResult; int32_t iCodecResult;
+    uint32_t iSizeConsumed; uint32_t iSizeProduced;
+    uint64_t uiTotalDecodedSamples;
+};
+static_assert(sizeof(Sideband) == 24, "AJM decode sideband is 24 bytes");
+
+static uint64_t addr(const void* p) { return (uint64_t)(uintptr_t)p; }
+
+int main() {
+    printf("== test_ajm2_gapless ==\n");
+    register_builtin_hle();
+
+    auto job_init = reinterpret_cast<Hle10Fn>(Hle::lookup(nid_hash("sceAjmBatchJobInitialize")));
+    auto job_gapl = reinterpret_cast<Hle10Fn>(Hle::lookup(nid_hash("sceAjmBatchJobSetGaplessDecode")));
+    auto job_dec  = reinterpret_cast<Hle10Fn>(Hle::lookup(nid_hash("sceAjmBatchJobDecode")));
+    auto batch_go = reinterpret_cast<Hle10Fn>(Hle::lookup(nid_hash("sceAjmBatchStart")));
+    CHECK(job_init && job_gapl && job_dec && batch_go, "batch-2.0 handlers registered");
+    if (!(job_init && job_gapl && job_dec && batch_go)) return 1;
+
+    // Reference PCM: the full 16-superframe decode, bit-exact per test_atrac9.
+    Atrac9Decoder ref;
+    CHECK(ref.init(kAt9Config), "reference decoder init");
+    if (!ref.valid()) return 1;
+    const int ch = ref.channels();
+    const uint32_t frame_bytes = (uint32_t)ch * sizeof(int16_t);
+    const int sfb = ref.superframe_bytes();
+    const int sfs = ref.superframe_samples();
+    const uint32_t nsf = kAt9DataLen / (uint32_t)sfb;
+    std::vector<int16_t> reference;
+    { std::vector<int16_t> sf((size_t)sfs * ch);
+      for (uint32_t i = 0; i < nsf; i++) {
+          CHECK(ref.decode_superframe(kAt9Data + (size_t)i * sfb, sf.data()) == sfs,
+                "reference superframe decodes");
+          reference.insert(reference.end(), sf.begin(), sf.end());
+      } }
+    const uint64_t raw_frames = (uint64_t)nsf * sfs;
+
+    // A one-shot's gapless program: skip 256 priming frames, deliver a total that ends INSIDE the
+    // final superframe (mirrors real AT9 files: raw = skip + total + end padding).
+    const uint32_t kSkip = 256;
+    const uint64_t kTotal = raw_frames - kSkip - 100;
+
+    uint64_t batch = 0x1000;                      // opaque key, only identity matters
+    const uint32_t inst = 7;
+    Sideband sb{};
+    uint32_t gapless[2] = {(uint32_t)kTotal, kSkip};
+    std::vector<uint8_t> out(reference.size() * sizeof(int16_t) + 4096, 0xAA);
+
+    job_init(batch, inst, addr(kAt9Config), 8, addr(&sb), 0, 0, 0, 0, 0);
+    job_gapl(batch, inst, addr(gapless), 1, addr(&sb), 0, 0, 0, 0, 0);
+    std::memset(&sb, 0, sizeof sb);
+    job_dec(batch, inst, addr(kAt9Data), kAt9DataLen, addr(out.data()), out.size(),
+            addr(&sb), 0, 0, 0);
+    batch_go(0, batch, 0, 0, 0, 0, 0, 0, 0, 0);
+
+    CHECK(sb.iResult == 0, "one-shot decode succeeds");
+    CHECK(sb.uiTotalDecodedSamples == kTotal,
+          "uiTotalDecodedSamples lands EXACTLY on the gapless total (EOS)");
+    CHECK(sb.iSizeProduced == kTotal * frame_bytes,
+          "produced PCM is exactly total trimmed frames");
+    // Content: delivery starts AFTER the skip -> output[0..] == reference[skip..skip+total].
+    CHECK(std::memcmp(out.data(), reference.data() + (size_t)kSkip * ch,
+                      (size_t)kTotal * frame_bytes) == 0,
+          "delivered PCM equals reference with the priming skip dropped");
+
+    // After EOS: more input must produce NOTHING and the total must stay pinned at `total`.
+    Sideband sb2{};
+    job_dec(batch, inst, addr(kAt9Data), (uint32_t)sfb, addr(out.data()), out.size(),
+            addr(&sb2), 0, 0, 0);
+    batch_go(0, batch, 0, 0, 0, 0, 0, 0, 0, 0);
+    CHECK(sb2.iResult == 0, "post-EOS decode is not an error");
+    CHECK(sb2.iSizeProduced == 0, "post-EOS decode produces no PCM");
+    CHECK(sb2.uiTotalDecodedSamples == kTotal, "post-EOS total stays pinned at the gapless total");
+
+    // Re-arming gapless starts a NEW program (FMOD's loop path): counter restarts, skip applies
+    // again, and delivery is exactly the new total.
+    const uint64_t kTotal2 = (uint64_t)sfs;       // one superframe's worth, ends inside sf 2
+    uint32_t gapless2[2] = {(uint32_t)kTotal2, kSkip};
+    Sideband sb3{};
+    job_gapl(batch, inst, addr(gapless2), 1, addr(&sb3), 0, 0, 0, 0, 0);
+    job_dec(batch, inst, addr(kAt9Data), (uint32_t)(2 * sfb), addr(out.data()), out.size(),
+            addr(&sb3), 0, 0, 0);
+    batch_go(0, batch, 0, 0, 0, 0, 0, 0, 0, 0);
+    CHECK(sb3.iResult == 0, "re-armed program decodes");
+    CHECK(sb3.uiTotalDecodedSamples == kTotal2,
+          "re-armed program's total restarts and lands exactly on the new total");
+    CHECK(sb3.iSizeProduced == kTotal2 * frame_bytes, "re-armed program delivers the new total");
+
+    // A fresh instance with NO gapless program keeps the historical cumulative behavior
+    // (streaming titles that never program gapless must not change).
+    const uint32_t inst2 = 8;
+    Sideband sb4{};
+    job_init(batch, inst2, addr(kAt9Config), 8, addr(&sb4), 0, 0, 0, 0, 0);
+    job_dec(batch, inst2, addr(kAt9Data), kAt9DataLen, addr(out.data()), out.size(),
+            addr(&sb4), 0, 0, 0);
+    batch_go(0, batch, 0, 0, 0, 0, 0, 0, 0, 0);
+    CHECK(sb4.iResult == 0, "no-gapless instance decodes");
+    CHECK(sb4.uiTotalDecodedSamples == raw_frames,
+          "no-gapless instance keeps the cumulative raw-frame counter");
+
+    printf(fails ? "test_ajm2_gapless: %d FAILURE(S)\n" : "test_ajm2_gapless: all ok\n", fails);
+    return fails ? 1 : 0;
+}


### PR DESCRIPTION
Fixes #1097.

## Symptom

In Blasphemous 2 gameplay, the attack SFX plays on the first Square press and every subsequent attack
is **silent** — the character animates but makes no sound. Reported live; reproduced headlessly with
`scripts/blasphemous2/sfx-retrigger.pad` (loads the first-Prie-Dieu save, presses Square repeatedly).

## Root cause

Traced with timestamped `[ajm2]` lifecycle logging. FMOD programs every ATRAC9 stream via
`sceAjmBatchJobSetGaplessDecode{total, skip}` and keys its **channel-end and AJM codec-slot recycling**
off the decode landing **exactly** on `total`: drop `skip` priming frames, deliver exactly `total`
trimmed frames, then pin `uiTotalDecodedSamples` at `total` with no further PCM.

prosper ignored the gapless spec — it delivered whole raw superframes and reported a **cumulative
raw-frame counter that overshot `total`**. FMOD never saw a one-shot finish, never recycled the codec
slot, and once the pool filled (~32 sounds) every later SFX was silent.

## Evidence (same route, per one-shot SFX instance, gapless total 24576)

| | EXACT landing | OVERSHOOT | short-fed |
|---|---|---|---|
| before | 1 | **15** | 8 |
| after | **16** | **0** | 8 |

The 8 short-fed are the guest supplying less input than `total` — unchanged and correct (you cannot
decode frames from input you were not given). Overshoot is eliminated.

## Fix

In `ajm2_decode_batch`, when an instance has a gapless program (`total_samples > 0`): drop
`skip_remaining` priming frames at decode time (stream order), cap delivery at
`total - gapless_delivered`, stop decoding once the program is complete (post-EOS input yields no PCM),
and report `gapless_delivered` as `uiTotalDecodedSamples`. `SetGapless` (re)starts the program (skip
re-applies, counter restarts, pending spill dropped so a reused slot never emits the prior sound's
tail); a config change on a reused slot clears the same state.

**Instances that never program gapless keep the exact cumulative behavior** — gated on `total_samples`,
a strict no-op for the streaming path.

## Affected / unaffected

- Affected: AJM batch-2.0 gapless one-shot decode (Blasphemous 2 SFX).
- Unaffected: no-gapless AJM instances (streaming), and titles not on the AJM-2.0 path. **Evergate
  exercises 0 `SetGapless` / 0 AJM decode** (verified — provably unaffected); Dead Cells music uses
  NGS2, not AJM.

## Verification

- **`test_ajm2_gapless`** (new, CI, no game dump): drives the real HLE handlers over the shared
  16-superframe vector; asserts exact EOS landing, priming-skip content offset, post-EOS silence with
  the total pinned, program re-arm restarting the counter, and the no-gapless cumulative path
  preserved. **Fails on the old code (7 failures), passes after.**
- `ctest` **123/123**.
- Before/after overshoot A/B as above.
- No rendered-output change (audio only), so no snapshot impact.

## Honest verification limit

The decode-side mechanism is proven (unit test + A/B), but **final confirmation that the attack is
audible on the 2nd press needs listening** — the SFX cannot be isolated from the mixed 8-channel output
headlessly. Requesting the reporter confirm by ear post-merge.

## Risk

Low. The behavioral change is confined to the gapless path and is more faithful to the published AJM
sideband contract (`uiTotalDecodedSamples`). The streaming path is a proven no-op.
