### PR TITLE
recompiler: fix counted-loop + waterfall coexistence crash (follow-up to #1116)

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -2570,7 +2570,7 @@ struct CountedLoop {
     uint32_t exit_branch_pc = 0;  // the s_cbranch_scc0/scc1 exit test (== backedge_pc for a do-while)
     uint32_t backedge_pc = 0;     // the backward branch (unconditional s_branch, or the scc back-edge)
     uint32_t exit_pc = 0;         // first pc after the loop (== backedge_pc + its length)
-    bool exit_on_scc0 = true;     // exit-test polarity: loop CONTINUES when SCC != (this flag ? 0 : 1)
+    bool exit_on_scc0 = true;     // exit-test polarity: true ⇔ the loop continues while SCC==1 (exits on SCC==0)
 };
 inline uint32_t branch_target(const Rdna2Inst& in) { return in.pc + in.len_dwords + (uint32_t)(int32_t)in.simm16; }
 
@@ -2578,19 +2578,23 @@ CountedLoop detect_counted_loop(const std::vector<Rdna2Inst>& ins) {
     CountedLoop L;
     // The single backward branch that closes the loop. A conditional scc0/scc1 back-edge is a
     // bottom-tested do-while; an unconditional s_branch is a top-tested loop.
+    // A backward s_cbranch_scc0/scc1 whose SCC is a 64-bit wave-mask reduction is a WATERFALL
+    // (once-through per invocation), NOT a loop back-edge — its cross-lane SCC has no representable
+    // per-lane value, and every emit path already consumes it via safe_branches/the linearizer.
+    // Waterfalls are excluded from the back-edge count entirely: SELECTING one would feed the loop
+    // emitter a poisoned SCC exit and mis-lower the divergent body (T19), and merely COUNTING one
+    // would reject a counted loop that legitimately coexists with a waterfall elsewhere in the same
+    // shader — a previously-recompilable combination (kernel 44d locks it).
+    const std::unordered_set<uint32_t> wf = waterfall_branches(ins);
     const Rdna2Inst* back = nullptr; int nback = 0;
     for (const auto& in : ins) {
         if (in.is_end) break;
-        if (in.fmt == Rdna2Format::SOPP && in.simm16 < 0 &&
-            (in.opcode == 0x02 || in.opcode == 0x04 || in.opcode == 0x05)) { back = &in; nback++; }
+        if (in.fmt != Rdna2Format::SOPP || in.simm16 >= 0) continue;
+        if (in.opcode == 0x02 ||
+            ((in.opcode == 0x04 || in.opcode == 0x05) && !wf.count(in.pc))) { back = &in; nback++; }
     }
     if (nback != 1) return L;                       // 0 -> no loop; >1 -> nested/multiple (unhandled)
     const bool do_while = (back->opcode != 0x02);   // conditional back-edge => bottom-tested
-    // A backward s_cbranch_scc0/scc1 whose SCC is a 64-bit wave-mask reduction is a WATERFALL loop
-    // (once-through per invocation), NOT a do-while counted loop — its cross-lane SCC has no
-    // representable per-lane value. Leave it to waterfall_branches()/the linearizer; treating it as a
-    // counted loop would feed the emitter a poisoned SCC exit and mis-lower the divergent body.
-    if (do_while && waterfall_branches(ins).count(back->pc)) return L;
     const uint32_t header = branch_target(*back);
     bool header_ok = false;
     for (const auto& in : ins) if (in.pc == header && in.pc < back->pc) { header_ok = true; break; }

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -2017,6 +2017,67 @@ int main() {
     printf("  kernel44c mismatches=%u (out[5]=%g expect=10)\n", bad44c, got44c.size()==N?got44c[5]:-1);
     CHECK(got44c.size()==N && bad44c==0, "recompiled kernel 44c (do-while scc0 loop sum 0..4) computes 10");
 
+    // Kernel 44d: COEXISTENCE lock — a top-tested counted loop (s_branch back-edge, kernel-43 shape)
+    //   AND a readfirstlane waterfall (T19 shape, backward s_cbranch_scc1 with wave-mask SCC) in ONE
+    //   kernel. The waterfall's backward scc branch must NOT count as a second loop back-edge (it is
+    //   classified by waterfall_branches and linearized via safe_branches); counting it would reject
+    //   the whole shader — a previously-recompilable combination (review finding on #320's do-while
+    //   change). out = table[u] + sum(0..4) = table[u] + 10, table = 5/7/9 for u = 0/1/2.
+    const uint32_t code44d[] = {
+        0x7E020F00u,              // v_cvt_u32_f32 v1, v0            (pc 0: index u)
+        0xBE86047Eu,              // s_mov_b64 s[6:7], exec          (pc 1: REMAIN = exec)
+        0x7E0402FFu, 0x40A00000u, // v_mov_b32 v2, 5.0f              (pc 2)
+        0x7E0602FFu, 0x40E00000u, // v_mov_b32 v3, 7.0f              (pc 4)
+        0x7E0802FFu, 0x41100000u, // v_mov_b32 v4, 9.0f              (pc 6)
+        0xB0020005u,              // s_movk_i32 s2, 5                (pc 8)
+        0xBE800380u,              // s_mov_b32 s0, 0                 (pc 9)
+        0x7E0C0280u,              // v_mov_b32 v6, 0                 (pc 10)
+        0xBF0A0200u,              // loop: s_cmp_lt_u32 s0, s2       (pc 11: header)
+        0xBF840003u,              // s_cbranch_scc0 exit(+3 -> 16)   (pc 12)
+        0x4A0C0C00u,              // v_add_nc_u32 v6, s0, v6         (pc 13)
+        0x81008100u,              // s_add_i32 s0, s0, 1             (pc 14)
+        0xBF82FFFBu,              // s_branch loop(-5 -> 11)         (pc 15)
+        0x7E080501u,              // exit: v_readfirstlane_b32 s4,v1 (pc 16: waterfall head)
+        0x7DA40204u,              // v_cmpx_eq_u32 s4, v1            (pc 17)
+        0xBEFC0304u,              // s_mov_b32 m0, s4                (pc 18)
+        0x7E0A8702u,              // v_movrels_b32 v5, v2            (pc 19)
+        0x8A867E06u,              // s_andn2_b64 s[6:7], s[6:7],exec (pc 20: wave-mask SCC)
+        0xBEFE0406u,              // s_mov_b64 exec, s[6:7]          (pc 21)
+        0xBF85FFF9u,              // s_cbranch_scc1 (-7 -> 16)       (pc 22: waterfall back-branch)
+        0xBEFE04C1u,              // s_mov_b64 exec, -1              (pc 23)
+        0x7E0C0D06u,              // v_cvt_f32_u32 v6, v6            (pc 24)
+        0x06000D05u,              // v_add_f32 v0, v5, v6            (pc 25)
+        0xBF810000u,              // s_endpgm                        (pc 26)
+    };
+    std::vector<uint32_t> spv44d = recompile_valu(code44d, sizeof(code44d)/sizeof(code44d[0]), 1, 0);
+    CHECK(!spv44d.empty(), "recompiled kernel 44d (counted loop + waterfall coexist) -> SPIR-V");
+    std::vector<float> in44d(8), exp44d(8);
+    const float tab44d[3] = { 5.0f, 7.0f, 9.0f };
+    for (uint32_t i = 0; i < 8; i++) { in44d[i] = (float)(i % 3); exp44d[i] = tab44d[i % 3] + 10.0f; }
+    std::vector<float> got44d = prosper::test::run_compute(spv44d, in44d, 8, 8);
+    uint32_t bad44d = 0; for (uint32_t i=0;i<8&&got44d.size()==8;i++) if (std::fabs(got44d[i]-exp44d[i])>1e-3f) bad44d++;
+    printf("  kernel44d mismatches=%u (out[1]=%g expect=%g)\n", bad44d, got44d.size()==8?got44d[1]:-1, exp44d[1]);
+    CHECK(got44d.size()==8 && bad44d==0, "kernel 44d: counted loop + waterfall compute table[u]+10");
+
+    // Kernel 44e: NEGATIVE — a do-while whose body also has a forward scc exit (an inner uniform
+    //   break). Two exit tests exceed the single-exit contract, so the detector must conservatively
+    //   reject (nexit != 0 for a do-while) and the shader stays fail-visible rather than mis-lowering.
+    //     s0=0; v1=0; loop: v1+=s0; s0++; if (s0==3) break; while (s0<5)
+    const uint32_t code44e[] = {
+        0xBE800380u,              // s_mov_b32 s0, 0                 (pc 0)
+        0x7E020280u,              // v_mov_b32 v1, 0                 (pc 1)
+        0x4A020200u,              // loop: v_add_nc_u32 v1, s0, v1   (pc 2: header)
+        0x81008100u,              // s_add_i32 s0, s0, 1             (pc 3)
+        0xBF068300u,              // s_cmp_eq_u32 s0, 3              (pc 4)
+        0xBF850002u,              // s_cbranch_scc1 exit(+2 -> 8)    (pc 5: inner break)
+        0xBF0A8500u,              // s_cmp_lt_u32 s0, 5              (pc 6)
+        0xBF85FFFAu,              // s_cbranch_scc1 loop(-6 -> 2)    (pc 7: do-while back-edge)
+        0x7E000D01u,              // exit: v_cvt_f32_u32 v0, v1      (pc 8)
+        0xBF810000u,              // s_endpgm                        (pc 9)
+    };
+    std::vector<uint32_t> spv44e = recompile_valu(code44e, sizeof(code44e)/sizeof(code44e[0]), 0, 0);
+    CHECK(spv44e.empty(), "kernel 44e: do-while with inner forward scc break conservatively rejects");
+
     // Kernel 45: EXEC-narrowed-state tracking regression (the review-flagged under-narrow bug). Save all-on
     //   exec to vcc; v_cmp overwrites vcc with a per-lane mask (lanes i<4); restore exec FROM vcc — exec is
     //   now narrowed, so v_mov v2,7 must be EXEC-predicated (only i<4 get 7; i>=4 keep 0). If the narrowed


### PR DESCRIPTION
## Goal
Follow-up to #1116 (merged at a049031), addressing the blocking finding from its independent review that landed **after** the merge. Refs #320.

## Failure scenario
#1116 widened `detect_counted_loop` to accept bottom-tested do-while SCC loops, but its back-edge scan counts **every** backward SOPP branch — `s_branch` (0x02) **and** `s_cbranch_scc0/scc1` (0x04/0x05). A readfirstlane **waterfall** (#273 — DOLL's skinned VS) ends in a backward `s_cbranch_scc` whose SCC is a 64-bit wave-mask reduction; that is not a loop back-edge (every emit path linearizes it via `safe_branches`). So a shader with a top-tested counted loop **plus** a waterfall elsewhere counts `nback == 2`.

Before #1116 that shader recompiled (only `s_branch` counted, `nback == 1`). After #1116 it doesn't just drop the draws — the combined shape **SIGSEGVs the recompiler** (verified: exit 139 on the pre-fix detector at the new kernel 44d). This is a live regression on master now.

## Fix
Compute `waterfall_branches()` once and **exclude those pcs from the back-edge count**. A waterfall can no longer be selected as, or counted as, the loop back-edge — restoring the pre-#1116 coexistence behavior while keeping #1116's do-while support. The now-redundant `do_while && waterfall_branches(...).count(...)` guard is removed and the second full-stream classification is dropped.

## Affected / unaffected
- **Fixed:** counted loop + waterfall in one shader recompiles again (no crash).
- **Unaffected:** pure do-while loops (#1116), pure counted loops, pure waterfalls, and all other shapes — identical behavior.

## Verification (exact head, native Linux / RADV)
- New **kernel 44d**: top-tested `s_branch` counted loop + T19-shape readfirstlane waterfall in one kernel, execution-checked to compute `table[u] + sum(0..4)` and spirv-val-gated. **Fails and SIGSEGVs on the pre-fix detector; passes with the fix.**
- New **kernel 44e** (negative): a do-while with an inner forward scc break must conservatively reject (locks `nexit != 0`).
- Existing 43/44/44b/44c and the T19 waterfall regressions still pass.
- `cmake --build -j32 && ctest` → **127/127 green**.
- Snapshot suite (`snapshot.py check`: messenger-scene / evergate-title / dead-cells-gameplay / blasphemous2-gameplay) — running; result appended before merge.
- `git diff --check` clean.

## Risk
Recompiler structured-control-flow change; independently reviewed already (this *is* the review fix from #1116). The negative-and-positive test pair proves the exact regression it guards.