### PR TITLE
hle: sceAvPlayerCurrentTime + Alex Kidd UDS CreateEvent shape (PPSA02664, refs #320)

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -2306,7 +2306,24 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             sit->second.w == gw && sit->second.h == gh &&
                             sit->second.format == pass_format && sit->second.rgba &&
                             sit->second.rgba->size() == pass_bytes)
-                            seed = sit->second.rgba->data(); }
+                            seed = sit->second.rgba->data();
+                        // Gated seed-decision diagnostic: a pass that should LOAD prior target
+                        // content but silently falls back to its clear color erases everything the
+                        // earlier pass produced (an opaque-black clear wipes a transparent UI RT —
+                        // #320's dialogue overlay). Make the decision and its reason visible.
+                        if (rtt_log && !seed && !gpu_seed_available) {
+                            if (sit == g_rtt.end())
+                                fprintf(stderr, "[rtt] seed miss target=0x%llx reason=no-entry\n",
+                                        (unsigned long long)base);
+                            else
+                                fprintf(stderr,
+                                        "[rtt] seed miss target=0x%llx reason=mismatch "
+                                        "entry=%ux%u fmt=%d rgba=%zu want=%ux%u fmt=%d bytes=%zu\n",
+                                        (unsigned long long)base, sit->second.w, sit->second.h,
+                                        (int)sit->second.format,
+                                        sit->second.rgba ? sit->second.rgba->size() : (size_t)0,
+                                        gw, gh, (int)pass_format, pass_bytes);
+                        } }
                     bool is_vo = false;
                     for (int i = 0; i < vo_n && !is_vo; i++)
                         is_vo = base && base == prosper_vo_buffer_addr(i);

--- a/prosper/src/gpu/render_state.cpp
+++ b/prosper/src/gpu/render_state.cpp
@@ -230,6 +230,19 @@ RenderState extract_render_state(const GpuState& st) {
     rs.db_stencil_control   = st.cx.count(P::DB_STENCIL_CONTROL)   ? rd(st.cx, P::DB_STENCIL_CONTROL)   : 0u;
     rs.db_stencilrefmask    = st.cx.count(P::DB_STENCILREFMASK)    ? rd(st.cx, P::DB_STENCILREFMASK)    : 0u;
     rs.db_stencilrefmask_bf = st.cx.count(P::DB_STENCILREFMASK_BF) ? rd(st.cx, P::DB_STENCILREFMASK_BF) : 0u;
+    // PROSPER_STENCILLOG (gated, off by default): the guest's RAW depth/stencil register dwords per
+    // stencil-enabled draw — ground truth for compare/op decode questions (the translated fields
+    // above can be audited against exactly what the title programmed). Dedup on change.
+    if (rs.stencil_enable && getenv("PROSPER_STENCILLOG")) {
+        static thread_local uint32_t last_dc, last_sc, last_rm, last_rmb;
+        if (dc != last_dc || rs.db_stencil_control != last_sc ||
+            rs.db_stencilrefmask != last_rm || rs.db_stencilrefmask_bf != last_rmb) {
+            last_dc = dc; last_sc = rs.db_stencil_control;
+            last_rm = rs.db_stencilrefmask; last_rmb = rs.db_stencilrefmask_bf;
+            fprintf(stderr, "[stencil-raw] dc=%08x sc=%08x rm=%08x rmb=%08x\n",
+                    dc, rs.db_stencil_control, rs.db_stencilrefmask, rs.db_stencilrefmask_bf);
+        }
+    }
     rs.has_cb_color_control = st.cx.count(P::CB_COLOR_CONTROL) != 0;
     rs.cb_color_control  = rd(st.cx, P::CB_COLOR_CONTROL);
     rs.cb_blend0_control = bc;

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -637,7 +637,7 @@ static uint64_t avp_add_source(uint64_t handle, const char* guest_path) {
             AvpPlayer& p = it->second;
             p.guest_path = guest_path;
             p.have_source = true; p.synthetic = synthetic;
-            p.poll = 0; p.audio_poll = 0; p.active_poll = 0; p.paused = false; p.stop_fired = false;
+            p.poll = 0; p.audio_poll = 0; p.active_poll = 0; p.last_ts_ms = 0; p.paused = false; p.stop_fired = false;
             p.texture_frames = std::move(textures);
             p.texture_frame_bytes = texture_bytes;
             p.next_texture_frame = 0;
@@ -1900,18 +1900,21 @@ HLE(s_npuds_ok)     { return 0; }
 //  * Dead Cells: CreateEvent(name?, reserved, Event** a2, PropertyObject** a3) — a2 AND a3 are
 //    out-pointers.
 //  * Alex Kidd DX (PPSA02664, svc dump): CreateEvent(name a0="activityTerminate", ctx a1,
-//    Event** a2, 0, PropertyObject** a4, 0) — outs are a2 and a4, a3 is literal 0. The old
-//    a3-must-be-a-pointer guard returned NP-invalid-argument here, and the title retried every
-//    frame forever — holding its cutscene->gameplay transition on a black screen (#320).
-// Accept both: a2 is always the event out; the property out is a3 when pointer-like, else a4 in
-// the a3==0 shape. Never write through a possibly-garbage register that merely looks like a
-// pointer outside these two proven shapes. CONFIDENCE: LOW (guarded, observed-shape-only).
+//    Event** a2, 0, PropertyObject** a4, 0) — outs are a2 and a4, a3 is literal 0, a5 literal 0.
+//    The old a3-must-be-a-pointer guard returned NP-invalid-argument here, and the title retried
+//    every frame forever — holding its cutscene->gameplay transition on a black screen (#320).
+// Accept both: a2 is always the event out; the property out is a3 when pointer-like. The a4 form is
+// admitted ONLY for Alex Kidd's exact trailing shape (a3==0 AND a5==0) — svc_ptrish is a wide range
+// check that cannot by itself tell a real out-pointer from leftover-register garbage, so requiring
+// both trailing reserved words to be zero pins the write to the observed 6-arg layout. A different
+// title that legitimately passes a3==0 with a non-zero/garbage a5 hits neither property write and
+// still returns success (0), which is what actually stops the retry loop. CONFIDENCE: LOW.
 HLE(s_npuds_create_event) {
     svc_log("sceNpUniversalDataSystemCreateEvent", a0,a1,a2,a3,a4,a5);
     if (!svc_ptrish(a2)) return 0x80550003ull; // NP invalid argument
     *(uint64_t*)PW(a2) = g_handle.fetch_add(1);
-    if (svc_ptrish(a3))                     *(uint64_t*)PW(a3) = g_handle.fetch_add(1);
-    else if (a3 == 0 && svc_ptrish(a4))     *(uint64_t*)PW(a4) = g_handle.fetch_add(1);
+    if (svc_ptrish(a3))                                *(uint64_t*)PW(a3) = g_handle.fetch_add(1);
+    else if (a3 == 0 && a5 == 0 && svc_ptrish(a4))     *(uint64_t*)PW(a4) = g_handle.fetch_add(1);
     return 0;
 }
 HLE(s_npuds_post_event) {

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -248,6 +248,7 @@ struct AvpPlayer {
     uint64_t poll = 0;               // synthetic frames delivered through GetVideoData[Ex]
     uint64_t audio_poll = 0;
     uint64_t active_poll = 0;        // independent progress for IsActive-only playback loops
+    uint64_t last_ts_ms = 0;         // newest delivered frame timestamp (sceAvPlayerCurrentTime)
     // When the title supplies its AvPlayer texture allocator, decoded NV12 must be written into those
     // guest-visible buffers.  A host vector is invisible to the title's pre-wired texture descriptors.
     std::vector<uint8_t*> texture_frames;
@@ -738,6 +739,7 @@ HLE(s_avp_getvideodata) {
                 if (avp_stage_video(p, vf, staged, pitch)) {
                     fi->p_data = staged;
                     fi->timestamp = vf.pts_us / 1000;
+                    p.last_ts_ms = fi->timestamp;
                     fi->d0 = vf.width; fi->d1 = vf.height; fi->d2 = 0; fi->d3 = 0;
                     result = 1;
                 }
@@ -751,6 +753,7 @@ HLE(s_avp_getvideodata) {
             uint8_t* staged = nullptr;
             if (avp_stage_synthetic(p, staged)) {
                 fi->p_data = staged; fi->timestamp = p.poll * 33ull; // ~30fps PTS (ms)
+                p.last_ts_ms = fi->timestamp;
                 fi->d0 = p.width; fi->d1 = p.height; fi->d2 = 0; fi->d3 = 0;
                 p.poll++; result = 1;
             }
@@ -782,6 +785,7 @@ HLE(s_avp_getvideodataex) {
                 if (avp_stage_video(p, vf, staged, pitch)) {
                     fi->p_data = staged;
                     fi->timestamp = vf.pts_us / 1000;
+                    p.last_ts_ms = fi->timestamp;
                     fi->details.video = {}; fi->details.video.width = vf.width; fi->details.video.height = vf.height;
                     fi->details.video.aspect = vf.height ? (float)vf.width / (float)vf.height : 0.0f;
                     fi->details.video.pitch = pitch;
@@ -796,6 +800,7 @@ HLE(s_avp_getvideodataex) {
             uint8_t* staged = nullptr;
             if (avp_stage_synthetic(p, staged)) {
                 fi->p_data = staged; fi->timestamp = p.poll * 33ull;
+                p.last_ts_ms = fi->timestamp;
                 fi->details.video = {}; fi->details.video.width = p.width; fi->details.video.height = p.height;
                 fi->details.video.aspect = (float)p.width / (float)p.height; fi->details.video.pitch = p.width;
                 fi->details.video.luma_bd = 8; fi->details.video.chroma_bd = 8;
@@ -829,6 +834,7 @@ HLE(s_avp_getaudiodata)   {   // bool sceAvPlayerGetAudioData(handle, AvPlayerFr
         p.audio.resize(sample_count);
         memcpy(p.audio.data(), af.pcm, sample_count * sizeof(int16_t));
         fi->p_data = reinterpret_cast<uint8_t*>(p.audio.data()); fi->timestamp = af.pts_us / 1000;
+        if (fi->timestamp > p.last_ts_ms) p.last_ts_ms = fi->timestamp;
         AvpAudio details{(uint16_t)af.channels, {}, af.sample_rate,
                          (uint32_t)(af.samples * af.channels * sizeof(int16_t)), {}};
         memcpy(&fi->d0, &details, sizeof(details));
@@ -839,12 +845,27 @@ HLE(s_avp_getaudiodata)   {   // bool sceAvPlayerGetAudioData(handle, AvPlayerFr
     if (p.audio.size() != samples * channels) p.audio.assign(samples * channels, 0);
     fi->p_data = (uint8_t*)p.audio.data();
     fi->timestamp = p.audio_poll * 21ull; // 1024/48 kHz, milliseconds
+    if (fi->timestamp > p.last_ts_ms) p.last_ts_ms = fi->timestamp;
     AvpAudio details{2, {}, 48000, samples * channels * sizeof(int16_t), {}};
     memcpy(&fi->d0, &details, sizeof(details));
     p.audio_poll++;
     if (avp_log()) fprintf(stderr, "[avp] audio handle=0x%llx result=1 poll=%llu\n",
                            (unsigned long long)a0, (unsigned long long)p.audio_poll);
     return 1;
+}
+// u64 sceAvPlayerCurrentTime(handle) — current playback position in MILLISECONDS. Returns the
+// newest delivered frame timestamp (video, or audio when audio leads), 0 before the first frame or
+// for an unknown handle. Alex Kidd DX's pre-level cutscene runner polls this to pace/finish the
+// sequence; the old unresolved-import 0 held its fade-to-black over an already-running level
+// forever (#320). Fires no guest callbacks, so no AVP_CALLBACK_ENTRY shim is needed.
+HLE(s_avp_current_time) {
+    svc_log("sceAvPlayerCurrentTime", a0,a1,a2,a3,a4,a5);
+    std::lock_guard<std::mutex> lk(g_avp_mx);
+    auto it = g_avp.find(a0);
+    const uint64_t now_ms = it == g_avp.end() ? 0 : it->second.last_ts_ms;
+    if (avp_log()) fprintf(stderr, "[avp] current-time handle=0x%llx -> %llu ms\n",
+                           (unsigned long long)a0, (unsigned long long)now_ms);
+    return now_ms;
 }
 HLE(s_avp_stop) {   // s32 sceAvPlayerStop(handle)
     svc_log("sceAvPlayerStop", a0,a1,a2,a3,a4,a5);
@@ -1875,14 +1896,22 @@ HLE(s_share_ok) { return 0; }
 HLE(s_npuds_create) { svc_log("sceNpUniversalDataSystemCreate*", a0,a1,a2,a3,a4,a5);
                       if (svc_ptrish(a0)) *(int32_t*)PW(a0) = 1; return 0; }
 HLE(s_npuds_ok)     { return 0; }
-// Dead Cells' wrappers pin CreateEvent(name, reserved, Event**, PropertyObject**) and pass both
-// returned opaque objects to the setter/post/destroy family. They are never dereferenced by the
-// guest. Allocate stable non-null ids and keep the offline telemetry sink inert.
+// Two observed CreateEvent call shapes (both write opaque ids the guest never dereferences):
+//  * Dead Cells: CreateEvent(name?, reserved, Event** a2, PropertyObject** a3) — a2 AND a3 are
+//    out-pointers.
+//  * Alex Kidd DX (PPSA02664, svc dump): CreateEvent(name a0="activityTerminate", ctx a1,
+//    Event** a2, 0, PropertyObject** a4, 0) — outs are a2 and a4, a3 is literal 0. The old
+//    a3-must-be-a-pointer guard returned NP-invalid-argument here, and the title retried every
+//    frame forever — holding its cutscene->gameplay transition on a black screen (#320).
+// Accept both: a2 is always the event out; the property out is a3 when pointer-like, else a4 in
+// the a3==0 shape. Never write through a possibly-garbage register that merely looks like a
+// pointer outside these two proven shapes. CONFIDENCE: LOW (guarded, observed-shape-only).
 HLE(s_npuds_create_event) {
     svc_log("sceNpUniversalDataSystemCreateEvent", a0,a1,a2,a3,a4,a5);
-    if (!svc_ptrish(a2) || !svc_ptrish(a3)) return 0x80550003ull; // NP invalid argument
+    if (!svc_ptrish(a2)) return 0x80550003ull; // NP invalid argument
     *(uint64_t*)PW(a2) = g_handle.fetch_add(1);
-    *(uint64_t*)PW(a3) = g_handle.fetch_add(1);
+    if (svc_ptrish(a3))                     *(uint64_t*)PW(a3) = g_handle.fetch_add(1);
+    else if (a3 == 0 && svc_ptrish(a4))     *(uint64_t*)PW(a4) = g_handle.fetch_add(1);
     return 0;
 }
 HLE(s_npuds_post_event) {
@@ -2293,6 +2322,7 @@ void register_service_hle() {
     // consumes GetVideoDataEx; returning the generic unresolved-import zero meant "no streams" and
     // left its logo movie state machine permanently resident even after synthetic EOF.
     Hle::register_fn("hdTyRzCXQeQ", (HleFn)s_avp_streamcount,   "sceAvPlayerStreamCount");
+    Hle::register_fn("wwM99gjFf1Y", (HleFn)s_avp_current_time,  "sceAvPlayerCurrentTime");
     Hle::register_fn("d8FcbzfAdQw", (HleFn)s_avp_getstreaminfo, "sceAvPlayerGetStreamInfo");
     Hle::register_fn("ctTAcF5DiKQ", (HleFn)s_avp_getstreaminfoex, "sceAvPlayerGetStreamInfoEx");
     Hle::register_fn("ODJK2sn9w4A", (HleFn)s_avp_stream_ok, "sceAvPlayerEnableStream");

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -1702,6 +1702,12 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     }
     if (const char* v = getenv("PROSPER_STENCIL_CLEAR"))
         stencil_clear = static_cast<uint32_t>(strtoul(v, nullptr, 0)) & 0xFFu;
+    // Diagnostic A/B twin of PROSPER_STENCIL_CLEAR: override the derived initial depth value.
+    // The #371 approximation picks the compare-appropriate always-pass value; sweeping this
+    // instead reveals whether a pass's draws sit at DIFFERENT depths (a mid value culls some
+    // draws but not others), i.e. whether real guest depth contents would gate them.
+    if (const char* v = getenv("PROSPER_DEPTH_CLEAR"))
+        depth_clear = strtof(v, nullptr);
     if (getenv("PROSPER_NO_DEPTH"))   use_depth = false;     // diag: isolate depth-test rejection
     if (getenv("PROSPER_NO_STENCIL")) use_stencil = false;   // diag: isolate stencil masking
     const bool use_ds = use_depth || use_stencil;
@@ -2498,6 +2504,22 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                 s.passOp      = (VkStencilOp)ps->stencil_pass_op[fb];
                 s.depthFailOp = (VkStencilOp)ps->stencil_depth_fail_op[fb];
                 s.compareOp   = (VkCompareOp)ps->stencil_compare_op[fb];
+                // PROSPER_STENCIL_MIRROR=1 (diagnostic A/B ONLY — NOT hardware semantics): mirror
+                // the asymmetric compare ops, i.e. evaluate `stencil OP ref` instead of Vulkan's
+                // `ref OP stencil`. RDNA2 STENCILFUNC is ref-on-left 1:1 with VkCompareOp (radeonsi
+                // programs PIPE_FUNC straight into the field), so this switch deliberately DIVERGES
+                // from hardware — its use is isolating whether a suspect draw's coverage is
+                // stencil-gated (flipping GREATER<->LESS suppresses/expands it) without touching
+                // any other state. Symmetric ops (EQUAL/NOTEQUAL/ALWAYS/NEVER) are unaffected.
+                if (getenv("PROSPER_STENCIL_MIRROR")) {
+                    switch (s.compareOp) {
+                        case VK_COMPARE_OP_LESS:             s.compareOp = VK_COMPARE_OP_GREATER; break;
+                        case VK_COMPARE_OP_GREATER:          s.compareOp = VK_COMPARE_OP_LESS; break;
+                        case VK_COMPARE_OP_LESS_OR_EQUAL:    s.compareOp = VK_COMPARE_OP_GREATER_OR_EQUAL; break;
+                        case VK_COMPARE_OP_GREATER_OR_EQUAL: s.compareOp = VK_COMPARE_OP_LESS_OR_EQUAL; break;
+                        default: break;
+                    }
+                }
                 s.compareMask = ps->stencil_compare_mask[fb];
                 s.writeMask   = ps->stencil_write_mask[fb];
                 // AMD splits the stencil reference: STENCILTESTVAL is the COMPARE reference, but a REPLACE

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -335,6 +335,12 @@ void inspect_frame(const prosper::gpu::GpuReplayFrame& replay) {
                         reinterpret_cast<const uint8_t*>(d.vs.data()), d.vs.size() * 4)),
                     d.fs.size(), static_cast<unsigned long long>(prosper::gpu::gpu_capture_hash(
                         reinterpret_cast<const uint8_t*>(d.fs.data()), d.fs.size() * 4)));
+        // Blend detail: UI compositing correctness hangs on the exact color AND alpha factor
+        // programming (a separate-alpha UI backdrop writes a different alpha than its color
+        // factors imply — #320's dialogue overlay), so make the full equation inspectable.
+        std::printf("  blend color=%u,%u op=%u alpha=%u,%u aop=%u\n",
+                    d.ps.src_color_blend_factor, d.ps.dst_color_blend_factor, d.ps.color_blend_op,
+                    d.ps.src_alpha_blend_factor, d.ps.dst_alpha_blend_factor, d.ps.alpha_blend_op);
         std::printf("  stencil clear=%u cmp=%u/%u fail=%u/%u pass=%u/%u zfail=%u/%u "
                     "ref=%u/%u opval=%u/%u cmask=%02x/%02x wmask=%02x/%02x\n",
                     d.ps.stencil_clear_value, d.ps.stencil_compare_op[0], d.ps.stencil_compare_op[1],


### PR DESCRIPTION
## Goal / issue
Refs #320 (PPSA02664 black gameplay world). Two live-verified HLE progression fixes for Alex Kidd DX's New Game route, plus the gated diagnostics that carried the investigation.

## Failure scenario & behavioral contract

**`sceAvPlayerCurrentTime` (NID `wwM99gjFf1Y`)** was an unresolved import returning a permanent 0. The title's pre-level cutscene runner polls it every frame to pace its sequence video. Implemented per the published contract — current playback position in milliseconds — by tracking the newest delivered frame timestamp per player (video timestamps from `GetVideoData[Ex]` real + synthetic paths; audio timestamps advance the clock monotonically when audio leads).

**`sceNpUniversalDataSystemCreateEvent`** assumed Dead Cells' shape `(name?, reserved, Event** a2, PropertyObject** a3)` and returned `0x80550003` (NP invalid argument) unless BOTH `a2` and `a3` were pointers. Alex Kidd calls `CreateEvent(name a0="activityTerminate", ctx a1, Event** a2, 0, PropertyObject** a4, 0)` — captured verbatim in a `PROSPER_SVCLOG` dump — so every call failed and the title retried once per frame, forever. The handler now accepts both observed shapes: `a2` is always the event out; the property out is `a3` when pointer-like, else `a4` in the `a3==0` shape. No write goes through any register that merely looks like a pointer outside the two proven shapes. `CONFIDENCE: LOW` (guarded, observed-shape-only), matching the existing block's convention.

## Live verification (route: `scripts/ppsa02664/reach-first-gameplay.pad` + circle presses, RADV, Linux)
- Before: `[prosper] unimplemented: libSceAvPlayer::wwM99gjFf1Y -> returning 0`; steady-state SVC histogram during the post-cutscene hold showed `sceNpUniversalDataSystemCreateEvent` retried 1106× per 6 s sample.
- After: AVP trace shows the title polling `IsActive`+`GetVideoDataEx`+`CurrentTime` in a healthy loop, receiving 3036→3136 ms, then a clean guest-initiated `Stop → IsActive → Close` teardown; the UDS activity lifecycle completes (5× CreateEvent/PostEvent/DestroyEvent, 4× SetString) and the retry loop is gone (steady state polls only `sceImeUpdate`).
- `ctest` 122/122 green on Linux.

## Diagnostics commit (all gated, zero default cost)
- `PROSPER_STENCILLOG`: per-stencil-draw RAW guest DS register dwords, deduped on change — audits translated fields against exactly what the title programmed.
- `PROSPER_STENCIL_MIRROR`: A/B-ONLY asymmetric-compare operand mirror. Deliberately diverges from hardware (RDNA2 STENCILFUNC is ref-on-left 1:1 with VkCompareOp per radeonsi's direct PIPE_FUNC programming) — used to isolate stencil-gated coverage.
- `PROSPER_DEPTH_CLEAR`: override the #371 compare-derived initial depth value for depth-discrimination sweeps.
- `gpu_replay --inspect` now prints the full per-draw blend equation (color+alpha factors/ops).
- `[rtt]` seed-miss log under `PROSPER_RTTLOG`: makes a LOAD→clear-color fallback (which erases prior pass content) visible with its reason.

## Affected / unaffected
- Affected: PPSA02664 cutscene video pacing + activity-event lifecycle; any future title calling `sceAvPlayerCurrentTime`.
- Unaffected: Dead Cells' CreateEvent shape (still writes `a2`+`a3`); all default rendering paths (diagnostics off by default). The remaining post-cutscene black hold is a separate, still-open gate tracked in #320.

## Risk
Small HLE surface; the CreateEvent widening only adds a write to `a4` in the exact observed `a3==0` shape. Reverse-engineered ABI → review welcome, but both shapes are backed by verbatim arg dumps.
