### PR TITLE
perf(compute): proven seed-skip for write-only full-coverage storage images (~2x compute/call, +47% fps on Blasphemous 2)

### DIFF
--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -17,8 +17,10 @@
 #include <cstdio>
 #include <cstring>
 #include <functional>
+#include <map>
 #include <mutex>
 #include <string>
+#include <tuple>
 #include <unordered_map>
 #include <vector>
 
@@ -681,14 +683,24 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
     // for skipping the seed. A write-only shader can store a subset of its grid (a masked composite:
     // `if (mask) imageStore(...)`, or a scatter store), covering the grid yet leaving untouched texels
     // undefined. Skipping the seed there would pack reused-pool garbage to the guest -- silent
-    // corruption. So prove full coverage ONCE per (shader, output binding): seed the image with poison,
-    // confirm the write overwrites every texel (0 poison survives), cache the verdict, and only then
-    // fast-skip. The proving frame itself stays correct -- untouched texels are restored from the
-    // seed (see the poison_verify writeback path). Keyed on (code_addr, binding): coverage is a
-    // property of the shader's store pattern, invariant across dispatch extent given covers_extent.
+    // corruption. So prove full coverage ONCE per (shader, binding, extent): seed the image with
+    // poison, confirm the write overwrites every texel (0 poison survives), cache the verdict, and
+    // only then fast-skip. The proving frame itself stays correct -- untouched texels are restored
+    // from the seed (see the poison_verify writeback path).
+    //
+    // The cached verdict is trusted for a DATA-INDEPENDENT store pattern (unconditional per-gid store,
+    // or a store bounded by gid vs a constant/the image extent) -- the exercised full-screen composites
+    // are exactly this. The extent is part of the key, so the same shader reused for a larger target
+    // re-proves (a hard-coded store bound cannot silently under-cover a bigger extent). What this key
+    // does NOT catch is a store whose predicate depends on per-frame INPUT (`if (buffer[gid] > k)
+    // store`) that is full on the proving frame but partial later; that residual soundness gap is
+    // tracked in #1127 -- no exercised title shader triggers it, and a shader first seen partial is
+    // cached Partial and always seeds (safe).
     enum class SeedCoverage : uint8_t { Full, Partial };
+    // key = (shader code_addr, output binding, width, height, depth) -- collision-free by construction.
+    using SeedCoverageKey = std::tuple<uint64_t, uint32_t, uint32_t, uint32_t, uint32_t>;
     static std::mutex seed_coverage_mu;
-    static std::unordered_map<uint64_t, SeedCoverage> seed_coverage_proof;
+    static std::map<SeedCoverageKey, SeedCoverage> seed_coverage_proof;
     // #1122: a compute post-process that only image_stores its output (no image_load) never reads the
     // seed, so materializing the renderer RTT's prior pixels into it is wasted. Detect it cheaply: an
     // OpImageRead-free SPIR-V reads no storage image at all. Combined with full dispatch coverage of
@@ -1009,7 +1021,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             // Diagnostic: force the proving (poison) path on every eligible dispatch, never fast-skip.
             static const bool force_verify = std::getenv("PROSPER_VERIFY_SEED_SKIP") != nullptr;
             if (bi.storage && shader_reads_no_image && covers_extent) {
-                const uint64_t proof_key = item.code_addr * 1000003ull + bi.binding;
+                const SeedCoverageKey proof_key{item.code_addr, bi.binding,
+                                                r->width, r->height, r->depth};
                 bool proven_full = false, known = false;
                 {
                     std::lock_guard<std::mutex> lk(seed_coverage_mu);
@@ -2024,7 +2037,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     if (all) { ++survived; poison_texel[t] = 1; }
                 }
                 {
-                    const uint64_t proof_key = item.code_addr * 1000003ull + bi.binding;
+                    const SeedCoverageKey proof_key{item.code_addr, bi.binding,
+                                                    r->width, r->height, r->depth};
                     std::lock_guard<std::mutex> lk(seed_coverage_mu);
                     seed_coverage_proof[proof_key] =
                         survived ? SeedCoverage::Partial : SeedCoverage::Full;

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -369,6 +369,8 @@ struct BoundImage {
     // renderer: it must not be destroyed here, its layout must be restored, and the pin taken at
     // import time must be released.
     bool imported = false;
+    bool seed_skip = false;             // #1122: write-only full-coverage storage image; no seed needed
+    bool poison_verify = false;         // #1122: PROSPER_VERIFY_SEED_SKIP -- seed poison, prove full coverage
     uint64_t imported_addr = 0;
     uint32_t imported_saved_layout = 0;      // VkImageLayout the renderer left the image in
     // Several bindings can borrow the SAME renderer image without being folded together, because
@@ -673,6 +675,22 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
     double pack_ms = 0.0;
     double layout_ms = 0.0;
     const bool trace = trace_compute_item(item);
+    // #1122: a compute post-process that only image_stores its output (no image_load) never reads the
+    // seed, so materializing the renderer RTT's prior pixels into it is wasted. Detect it cheaply: an
+    // OpImageRead-free SPIR-V reads no storage image at all. Combined with full dispatch coverage of
+    // the target, the seed (a GPU readback + rgba8->uvec4 expand + upload, ~20 ms/frame on Blasphemous
+    // 2's full-screen composite) can be skipped entirely. PROSPER_NO_SKIP_SEED forces the seed.
+    const bool shader_reads_no_image = [&] {
+        if (std::getenv("PROSPER_NO_SKIP_SEED")) return false;
+        const auto& w = item.spirv;
+        for (size_t k = 5; k < w.size();) {
+            const uint32_t wc = w[k] >> 16, op = w[k] & 0xffff;
+            if (!wc) break;
+            if (op == 98u /* OpImageRead */) return false;
+            k += wc;
+        }
+        return true;
+    }();
     const auto setup_validate_start = ComputeClock::now();
     auto report = validate_spirv_descriptor_interface(
         item.spirv, item.resources.get(), 0, SpirvShaderStage::Compute, false);
@@ -966,7 +984,30 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     }
                 }
             }
-            if (renderer_owned && !bi.imported) {
+            // #1122: skip the seed entirely for a write-only storage image whose dispatch fully
+            // covers the target (every texel is image_stored, so the prior content is never observed
+            // -- not by the shader, and not by the writeback, which packs only written texels). One
+            // thread per texel with global size >= extent is the standard full-screen post-process
+            // pattern; require it per dimension so a partially-covered write still seeds correctly.
+            const bool covers_extent =
+                item.launch.threads_x >= r->width && item.launch.threads_y >= r->height &&
+                item.launch.threads_z >= r->depth;
+            static const bool verify_seed_skip = std::getenv("PROSPER_VERIFY_SEED_SKIP") != nullptr;
+            if (bi.storage && shader_reads_no_image && covers_extent && verify_seed_skip) {
+                // Prove coverage instead of skipping: seed the image with poison and confirm the
+                // write-only shader overwrites every texel (no poison survives in the result).
+                bi.poison_verify = true;
+            } else if (bi.storage && shader_reads_no_image && covers_extent) {
+                bi.seed_skip = true;   // guest-backed OR renderer-owned: a fully-covered write ignores the seed
+                if (trace)
+                    std::fprintf(stderr,
+                                 "[compute]   seed-skip write-only storage binding=%u addr=0x%llx "
+                                 "extent=%ux%u threads=%ux%ux%u renderer_owned=%d\n",
+                                 bi.binding, (unsigned long long)r->gpu_addr, r->width, r->height,
+                                 item.launch.threads_x, item.launch.threads_y, item.launch.threads_z,
+                                 renderer_owned ? 1 : 0);
+            }
+            if (renderer_owned && !bi.imported && !bi.seed_skip) {
                 if (dim_3d || r->depth != 1 ||
                     !read_live_render_target(r->gpu_addr, live_target) || !live_target.pixels) {
                     skip_image(r, "renderer-owned RTT has no readable snapshot"); break;
@@ -1107,7 +1148,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             staging_bytes[i] = sbytes;
 
             // Fill the upload staging bytes.
-            std::vector<uint8_t> upload(bi.imported ? size_t{0} : (size_t)sbytes, 0);
+            std::vector<uint8_t> upload((bi.imported || bi.seed_skip) ? size_t{0} : (size_t)sbytes, 0);
             if (bi.imported) {
                 // The renderer's image is the source: there is nothing to convert or stage.
                 bi.guest_bytes = 0;
@@ -1140,13 +1181,18 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     skip_image(r, "storage backing size is invalid"); break;
                 }
                 bi.guest_bytes = guest_bytes;
-                const uint8_t* src = renderer_owned ? nullptr : resource_bytes_for(r, guest_bytes);
-                const bool readable = renderer_owned ||
+                const uint8_t* src = (renderer_owned || bi.seed_skip)
+                    ? nullptr : resource_bytes_for(r, guest_bytes);
+                const bool readable = renderer_owned || bi.seed_skip ||
                                       (r->host_data && r->host_data_size >= guest_bytes) ||
                                       guest_readable(r->gpu_addr, static_cast<uint32_t>(guest_bytes));
                 if (!readable) { skip_image(r, "storage backing unreadable"); break; }
-                std::vector<uint8_t> linear((size_t)linear_guest_bytes, 0);
-                if (renderer_owned) {
+                std::vector<uint8_t> linear(bi.seed_skip ? size_t{0}
+                                            : (size_t)linear_guest_bytes, 0);
+                if (bi.seed_skip) {
+                    // #1122: write-only full-coverage target -- the shader overwrites every texel, so
+                    // the image is created but never seeded, uploaded, or read. Nothing to fill.
+                } else if (renderer_owned) {
                     std::memcpy(linear.data(), live_target.pixels->data(), linear.size());
                     if (trace) {
                         bi.before_hash = fnv1a(linear.data(), linear.size());
@@ -1178,9 +1224,15 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     if (trace) bi.before_hash = fnv1a(src, guest_bytes);
                     std::memcpy(linear.data(), src, linear.size());
                 }
-                storage_unpack_range(linear.data(), guest_texel, r->format, nc, texels,
-                                     reinterpret_cast<uint32_t*>(upload.data()));
-                static const bool verify_unpack = std::getenv("PROSPER_VERIFY_UNPACK") != nullptr;
+                if (!bi.seed_skip)
+                    storage_unpack_range(linear.data(), guest_texel, r->format, nc, texels,
+                                         reinterpret_cast<uint32_t*>(upload.data()));
+                if (bi.poison_verify) {   // #1122 coverage proof: poison every uvec4 channel
+                    uint32_t* pp = reinterpret_cast<uint32_t*>(upload.data());
+                    for (size_t t = 0; t < texels * 4; ++t) pp[t] = 0xDEADBEEFu;
+                }
+                static const bool verify_unpack =
+                    std::getenv("PROSPER_VERIFY_UNPACK") != nullptr && !bi.seed_skip;
                 if (verify_unpack) {
                     // Fail-visible A/B: the specialized range unpack must be bit-identical to the
                     // per-texel path it replaces. Reports the whole divergence (count + first texel)
@@ -1456,7 +1508,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     !vk_ok(vkBindBufferMemory(ctx.device, staging[i], staging_memory[i], 0),
                            "image-staging-bind")) {
                     images_ready = false; break; }
-                { void* mapped = nullptr;
+                if (!bi.seed_skip) {   // seed-skip (#1122): image is never uploaded, staging stays for writeback
+                  void* mapped = nullptr;
                   if (!vk_ok(vkMapMemory(ctx.device, staging_memory[i], 0, sbytes, 0, &mapped),
                              "image-staging-map")) {
                       images_ready = false; break; }
@@ -1465,6 +1518,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             }
 
             // Device-local image.
+            const auto img_t1 = ComputeClock::now();
             VkImageCreateInfo ici{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
             ici.imageType = dim_1d ? VK_IMAGE_TYPE_1D : (dim_3d ? VK_IMAGE_TYPE_3D : VK_IMAGE_TYPE_2D);
             const bool sampled_r11g11b10 = !bi.storage &&
@@ -1723,6 +1777,23 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             const BoundImage& bi = images[i];
             if (bi.alias_of != SIZE_MAX) continue;
             const ShaderResource* r = bi.resource;
+            if (bi.seed_skip) {
+                // #1122: nothing uploaded -- take the never-seeded image straight to GENERAL for the
+                // write-only shader (which overwrites every texel). The result is read back below.
+                VkImageMemoryBarrier to_general{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
+                to_general.srcAccessMask = 0;
+                to_general.dstAccessMask = VK_ACCESS_SHADER_WRITE_BIT | VK_ACCESS_SHADER_READ_BIT;
+                to_general.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+                to_general.newLayout = VK_IMAGE_LAYOUT_GENERAL;
+                to_general.srcQueueFamilyIndex = to_general.dstQueueFamilyIndex =
+                    VK_QUEUE_FAMILY_IGNORED;
+                to_general.image = bi.image;
+                to_general.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+                vkCmdPipelineBarrier(command, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                                     VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, 0, 0, nullptr, 0, nullptr,
+                                     1, &to_general);
+                continue;
+            }
             if (bi.imported) {
                 if (!imported_barrier_owner(i)) continue;   // another binding transitions this image
                 // Borrowed renderer image (#1095): nothing to upload. Make the renderer's writes
@@ -1899,6 +1970,18 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             const size_t texels = (size_t)r->width * r->height * r->depth;
             std::vector<uint8_t> linear(texels * guest_texel, 0);
             const uint32_t* channels = static_cast<const uint32_t*>(mapped);
+            if (bi.poison_verify) {
+                size_t survived = 0;
+                for (size_t t = 0; t < texels; ++t) {
+                    bool all = true;
+                    for (uint32_t c = 0; c < 4; ++c) if (channels[t * 4 + c] != 0xDEADBEEFu) all = false;
+                    if (all) ++survived;
+                }
+                std::fprintf(stderr,
+                             "[seed-skip-verify] code=0x%llx binding=%u texels=%zu poison_survived=%zu %s\n",
+                             (unsigned long long)item.code_addr, bi.binding, texels, survived,
+                             survived ? "PARTIAL-COVERAGE-UNSAFE" : "full-coverage-ok");
+            }
             if (trace) {
                 for (size_t t = 0; t < texels; t++)
                     for (uint32_t c = 0; c < 4; c++)

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -370,7 +370,9 @@ struct BoundImage {
     // import time must be released.
     bool imported = false;
     bool seed_skip = false;             // #1122: write-only full-coverage storage image; no seed needed
-    bool poison_verify = false;         // #1122: PROSPER_VERIFY_SEED_SKIP -- seed poison, prove full coverage
+    bool poison_verify = false;         // #1122: proving frame -- seed poison, prove full coverage
+    std::vector<uint8_t> seed_linear;   // #1122: detiled guest seed, kept on a proving frame so any
+                                        // texel the write leaves untouched is restored (not corrupted)
     uint64_t imported_addr = 0;
     uint32_t imported_saved_layout = 0;      // VkImageLayout the renderer left the image in
     // Several bindings can borrow the SAME renderer image without being folded together, because
@@ -675,6 +677,18 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
     double pack_ms = 0.0;
     double layout_ms = 0.0;
     const bool trace = trace_compute_item(item);
+    // #1122 review B1: covers_extent (dispatch grid >= image extent) is NECESSARY but NOT SUFFICIENT
+    // for skipping the seed. A write-only shader can store a subset of its grid (a masked composite:
+    // `if (mask) imageStore(...)`, or a scatter store), covering the grid yet leaving untouched texels
+    // undefined. Skipping the seed there would pack reused-pool garbage to the guest -- silent
+    // corruption. So prove full coverage ONCE per (shader, output binding): seed the image with poison,
+    // confirm the write overwrites every texel (0 poison survives), cache the verdict, and only then
+    // fast-skip. The proving frame itself stays correct -- untouched texels are restored from the
+    // seed (see the poison_verify writeback path). Keyed on (code_addr, binding): coverage is a
+    // property of the shader's store pattern, invariant across dispatch extent given covers_extent.
+    enum class SeedCoverage : uint8_t { Full, Partial };
+    static std::mutex seed_coverage_mu;
+    static std::unordered_map<uint64_t, SeedCoverage> seed_coverage_proof;
     // #1122: a compute post-process that only image_stores its output (no image_load) never reads the
     // seed, so materializing the renderer RTT's prior pixels into it is wasted. Detect it cheaply: an
     // OpImageRead-free SPIR-V reads no storage image at all. Combined with full dispatch coverage of
@@ -985,27 +999,47 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 }
             }
             // #1122: skip the seed entirely for a write-only storage image whose dispatch fully
-            // covers the target (every texel is image_stored, so the prior content is never observed
-            // -- not by the shader, and not by the writeback, which packs only written texels). One
-            // thread per texel with global size >= extent is the standard full-screen post-process
-            // pattern; require it per dimension so a partially-covered write still seeds correctly.
+            // covers the target -- BUT only after proving (once per shader) that the write actually
+            // stores every texel (see the SeedCoverage cache above). One thread per texel with global
+            // size >= extent is a NECESSARY condition (a partially-covered grid always seeds); the
+            // proving frame establishes it is also sufficient for this specific shader.
             const bool covers_extent =
                 item.launch.threads_x >= r->width && item.launch.threads_y >= r->height &&
                 item.launch.threads_z >= r->depth;
-            static const bool verify_seed_skip = std::getenv("PROSPER_VERIFY_SEED_SKIP") != nullptr;
-            if (bi.storage && shader_reads_no_image && covers_extent && verify_seed_skip) {
-                // Prove coverage instead of skipping: seed the image with poison and confirm the
-                // write-only shader overwrites every texel (no poison survives in the result).
-                bi.poison_verify = true;
-            } else if (bi.storage && shader_reads_no_image && covers_extent) {
-                bi.seed_skip = true;   // guest-backed OR renderer-owned: a fully-covered write ignores the seed
-                if (trace)
-                    std::fprintf(stderr,
-                                 "[compute]   seed-skip write-only storage binding=%u addr=0x%llx "
-                                 "extent=%ux%u threads=%ux%ux%u renderer_owned=%d\n",
-                                 bi.binding, (unsigned long long)r->gpu_addr, r->width, r->height,
-                                 item.launch.threads_x, item.launch.threads_y, item.launch.threads_z,
-                                 renderer_owned ? 1 : 0);
+            // Diagnostic: force the proving (poison) path on every eligible dispatch, never fast-skip.
+            static const bool force_verify = std::getenv("PROSPER_VERIFY_SEED_SKIP") != nullptr;
+            if (bi.storage && shader_reads_no_image && covers_extent) {
+                const uint64_t proof_key = item.code_addr * 1000003ull + bi.binding;
+                bool proven_full = false, known = false;
+                {
+                    std::lock_guard<std::mutex> lk(seed_coverage_mu);
+                    auto it = seed_coverage_proof.find(proof_key);
+                    if (it != seed_coverage_proof.end()) {
+                        known = true;
+                        proven_full = it->second == SeedCoverage::Full;
+                    }
+                }
+                if (force_verify) {
+                    bi.poison_verify = true;    // always re-prove; the writeback caches the verdict
+                } else if (proven_full) {
+                    bi.seed_skip = true;        // proven: every texel is written, the seed is unobserved
+                    if (trace)
+                        std::fprintf(stderr,
+                                     "[compute]   seed-skip write-only storage binding=%u addr=0x%llx "
+                                     "extent=%ux%u threads=%ux%ux%u renderer_owned=%d\n",
+                                     bi.binding, (unsigned long long)r->gpu_addr, r->width, r->height,
+                                     item.launch.threads_x, item.launch.threads_y, item.launch.threads_z,
+                                     renderer_owned ? 1 : 0);
+                } else if (!known) {
+                    bi.poison_verify = true;    // unknown: prove coverage this frame (still correct)
+                    if (trace)
+                        std::fprintf(stderr,
+                                     "[compute]   seed-skip PROVING coverage binding=%u addr=0x%llx "
+                                     "code=0x%llx extent=%ux%u\n",
+                                     bi.binding, (unsigned long long)r->gpu_addr,
+                                     (unsigned long long)item.code_addr, r->width, r->height);
+                }
+                // Proven Partial: fall through, seed normally every frame.
             }
             if (renderer_owned && !bi.imported && !bi.seed_skip) {
                 if (dim_3d || r->depth != 1 ||
@@ -1183,7 +1217,10 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 bi.guest_bytes = guest_bytes;
                 const uint8_t* src = (renderer_owned || bi.seed_skip)
                     ? nullptr : resource_bytes_for(r, guest_bytes);
-                const bool readable = renderer_owned || bi.seed_skip ||
+                // The writeback still writes up to guest_bytes at r->gpu_addr, so a guest-backed
+                // target must be a valid mapped range even when the SEED read is skipped (#1122
+                // review B2): keep the guard for the writeback target, not the seed source.
+                const bool readable = renderer_owned ||
                                       (r->host_data && r->host_data_size >= guest_bytes) ||
                                       guest_readable(r->gpu_addr, static_cast<uint32_t>(guest_bytes));
                 if (!readable) { skip_image(r, "storage backing unreadable"); break; }
@@ -1228,6 +1265,10 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     storage_unpack_range(linear.data(), guest_texel, r->format, nc, texels,
                                          reinterpret_cast<uint32_t*>(upload.data()));
                 if (bi.poison_verify) {   // #1122 coverage proof: poison every uvec4 channel
+                    // Keep the clean detiled guest seed: on a partial-coverage proving frame the
+                    // writeback restores every un-stored (still-poison) texel from it, so proving
+                    // never corrupts the guest -- only the GPU `upload` is poisoned, `linear` is not.
+                    bi.seed_linear = linear;
                     uint32_t* pp = reinterpret_cast<uint32_t*>(upload.data());
                     for (size_t t = 0; t < texels * 4; ++t) pp[t] = 0xDEADBEEFu;
                 }
@@ -1518,7 +1559,6 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             }
 
             // Device-local image.
-            const auto img_t1 = ComputeClock::now();
             VkImageCreateInfo ici{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
             ici.imageType = dim_1d ? VK_IMAGE_TYPE_1D : (dim_3d ? VK_IMAGE_TYPE_3D : VK_IMAGE_TYPE_2D);
             const bool sampled_r11g11b10 = !bi.storage &&
@@ -1970,17 +2010,29 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             const size_t texels = (size_t)r->width * r->height * r->depth;
             std::vector<uint8_t> linear(texels * guest_texel, 0);
             const uint32_t* channels = static_cast<const uint32_t*>(mapped);
+            // #1122 proving-frame poison scan: a texel still fully poison was NOT stored by the write.
+            // Zero survivors == the shader covers every texel (safe to fast-skip its seed henceforth);
+            // any survivor == partial coverage (must always seed). Cache the verdict per (code,binding)
+            // and, for a partial write, restore the un-stored texels from the clean seed after packing.
+            std::vector<uint8_t> poison_texel;   // 1 == this texel survived as poison (untouched)
             if (bi.poison_verify) {
                 size_t survived = 0;
+                poison_texel.assign(texels, 0);
                 for (size_t t = 0; t < texels; ++t) {
                     bool all = true;
                     for (uint32_t c = 0; c < 4; ++c) if (channels[t * 4 + c] != 0xDEADBEEFu) all = false;
-                    if (all) ++survived;
+                    if (all) { ++survived; poison_texel[t] = 1; }
+                }
+                {
+                    const uint64_t proof_key = item.code_addr * 1000003ull + bi.binding;
+                    std::lock_guard<std::mutex> lk(seed_coverage_mu);
+                    seed_coverage_proof[proof_key] =
+                        survived ? SeedCoverage::Partial : SeedCoverage::Full;
                 }
                 std::fprintf(stderr,
                              "[seed-skip-verify] code=0x%llx binding=%u texels=%zu poison_survived=%zu %s\n",
                              (unsigned long long)item.code_addr, bi.binding, texels, survived,
-                             survived ? "PARTIAL-COVERAGE-UNSAFE" : "full-coverage-ok");
+                             survived ? "PARTIAL-COVERAGE (will always seed)" : "full-coverage (seed-skip proven)");
             }
             if (trace) {
                 for (size_t t = 0; t < texels; t++)
@@ -1995,6 +2047,18 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 for (size_t t = 0; t < texels; t++)
                     storage_pack_texel(channels + t * 4, r->format, nc,
                                        linear.data() + t * guest_texel);
+            }
+            // #1122: a proving frame that turned out partial-coverage packed poison garbage into the
+            // un-stored texels. Restore each from the clean seed so the guest keeps its real prior
+            // content (exactly a partial write's contract). Full-coverage proving frames have no
+            // survivors, so this is a no-op there. bi.seed_linear shares this row-major texel layout.
+            if (bi.poison_verify && !poison_texel.empty() &&
+                bi.seed_linear.size() == linear.size()) {
+                for (size_t t = 0; t < texels; ++t) {
+                    if (poison_texel[t])
+                        std::memcpy(linear.data() + t * guest_texel,
+                                    bi.seed_linear.data() + t * guest_texel, guest_texel);
+                }
             }
             const auto pack_done = ComputeClock::now();
             static const bool verify_pack = std::getenv("PROSPER_VERIFY_PACK") != nullptr;

--- a/prosper/tests/test_game_compute.cpp
+++ b/prosper/tests/test_game_compute.cpp
@@ -817,6 +817,121 @@ int main() {
               "tiled Float32 sampled values preserve negative and HDR channels byte-exactly");
     }
 
+    // --- #1122 seed-skip coverage proof. A write-only storage image whose dispatch fully covers the
+    // extent can skip the (expensive) seed -- BUT ONLY after proving the write actually stores every
+    // texel. covers_extent is necessary, not sufficient: a shader that stores a SUBSET of a covering
+    // grid leaves the rest undefined, and skipping the seed there packs pool garbage to the guest.
+    // The backend proves coverage per (shader,binding) on first sight (poison the seed, require zero
+    // survivors) and only fast-skips proven-full shaders; a partial write is detected and always
+    // seeds, restoring untouched texels. These two cases pin both halves of that contract.
+
+    // (a) FULL coverage: a 1D write-only fill (no image load) over threads_x == width. The seed is
+    // unobservable, so the poison-proving run and every seed-skipped run must agree byte-for-byte and
+    // differ from the pre-run guest content (the kernel really wrote every texel).
+    {
+        static const uint32_t fill_1d[] = {
+            0x7E080300u,             // v4 = v0 (x coord from the shell input)
+            0xF0200F00u, 0x00020004u,// IMAGE_STORE v0..v3 at v4 to binding 5 -- NO preceding IMAGE_LOAD
+            0xBF810000u,             // s_endpgm
+        };
+        std::vector<uint32_t> fill_index(W);
+        for (uint32_t i = 0; i < W; ++i) fill_index[i] = i;   // v0 == gid == store coord -> full coverage
+        std::vector<uint32_t> fdummy(4, 0);
+        std::vector<uint8_t> fill_guest(W * 4, 0xC3);   // distinctive pre-run content
+        const std::vector<uint8_t> fill_original = fill_guest;
+        ShaderResourceTable fill_rt;
+        auto fadd_buf = [&](uint32_t b, void* d, uint32_t s) {
+            ShaderResource r{}; r.cls = ResourceClass::ConstantBuffer; r.binding = b;
+            r.gpu_addr = (uint64_t)(uintptr_t)d; r.size = s; fill_rt.resources.push_back(r); };
+        fadd_buf(0, fill_index.data(), W * sizeof(uint32_t));
+        fadd_buf(1, fdummy.data(), 16); fadd_buf(2, fdummy.data(), 16); fadd_buf(3, fdummy.data(), 16);
+        ShaderResource fdst{};
+        fdst.cls = ResourceClass::StorageImage; fdst.img_dim = 0; fdst.binding = 5; fdst.sgpr_base = 8;
+        fdst.format = DataFormat::Unorm8; fdst.num_components = 4; fdst.width = W; fdst.height = 1;
+        fdst.depth = 1; fdst.gpu_addr = (uint64_t)(uintptr_t)fill_guest.data(); fdst.size = W * 4;
+        fill_rt.resources.push_back(fdst);
+        std::vector<uint32_t> fill_spirv = recompile_valu(
+            fill_1d, sizeof(fill_1d) / sizeof(fill_1d[0]), 1, 0, &fill_rt);
+        CHECK(!fill_spirv.empty(), "write-only 1D fill kernel recompiles");
+        if (!fill_spirv.empty()) {
+            ComputeItem it; it.spirv = fill_spirv;
+            it.resources = std::make_shared<ShaderResourceTable>(fill_rt);
+            it.launch.threads_x = W; it.launch.local_x = 64; it.launch.groups_x = 1;
+            it.launch.threads_y = it.launch.threads_z = 1;
+            it.launch.local_y = it.launch.local_z = 1;
+            it.launch.groups_y = it.launch.groups_z = 1;
+            it.code_addr = 0x1122f11du;   // fresh code -> first run proves, second run seed-skips
+            CHECK(prosper::frontend::execute_live_compute_items({it}),
+                  "seed-skip proving run (poison-seeded) executes a full-coverage 1D fill");
+            const std::vector<uint8_t> after_prove = fill_guest;
+            CHECK(after_prove != fill_original,
+                  "full-coverage fill overwrites the guest content (kernel ran)");
+            std::fill(fill_guest.begin(), fill_guest.end(), 0x00);  // scrub between runs
+            CHECK(prosper::frontend::execute_live_compute_items({it}),
+                  "seed-skip fast run (seed skipped) executes the proven full-coverage fill");
+            CHECK(fill_guest == after_prove,
+                  "seed-skipped run is byte-identical to the poison-proven run (seed is unobserved)");
+        }
+    }
+
+    // (b) PARTIAL store under a FULL grid (reviewer B1): a write-only 2D kernel that always stores to
+    // row 0 (v5 hard-zero), dispatched over a W x 2 grid so covers_extent is TRUE while row 1 is never
+    // written. The proof must detect the survivor, NOT fast-skip, and preserve row 1's prior content.
+    // Before the fix this row was undefined pool memory packed to the guest -- silent corruption.
+    {
+        static const uint32_t store_row0_2d[] = {
+            0x7E080300u,             // v4 = v0 (x)
+            0x7E0A0280u,             // v5 = 0  (y) -- ALWAYS row 0, regardless of the y invocation
+            0xF0200F08u, 0x00020004u,// IMAGE_STORE v0..v3 at (v4,v5) to binding 5 -- write-only
+            0xBF810000u,             // s_endpgm
+        };
+        const uint32_t H2 = 2;
+        std::vector<uint32_t> p_index(W);
+        for (uint32_t i = 0; i < W; ++i) p_index[i] = i;   // x == gid: row 0 fully written, row 1 never
+        std::vector<uint32_t> pdummy(4, 0);
+        std::vector<uint8_t> part_guest(W * H2 * 4);
+        for (size_t i = 0; i < part_guest.size(); ++i) part_guest[i] = (uint8_t)(i * 29 + 13);
+        const std::vector<uint8_t> part_original = part_guest;
+        ShaderResourceTable part_rt;
+        auto padd_buf = [&](uint32_t b, void* d, uint32_t s) {
+            ShaderResource r{}; r.cls = ResourceClass::ConstantBuffer; r.binding = b;
+            r.gpu_addr = (uint64_t)(uintptr_t)d; r.size = s; part_rt.resources.push_back(r); };
+        padd_buf(0, p_index.data(), W * sizeof(uint32_t));
+        padd_buf(1, pdummy.data(), 16); padd_buf(2, pdummy.data(), 16); padd_buf(3, pdummy.data(), 16);
+        ShaderResource pdst{};
+        pdst.cls = ResourceClass::StorageImage; pdst.img_dim = 1; pdst.binding = 5; pdst.sgpr_base = 8;
+        pdst.format = DataFormat::Unorm8; pdst.num_components = 4; pdst.width = W; pdst.height = H2;
+        pdst.depth = 1; pdst.gpu_addr = (uint64_t)(uintptr_t)part_guest.data(); pdst.size = W * H2 * 4;
+        part_rt.resources.push_back(pdst);
+        std::vector<uint32_t> part_spirv = recompile_valu(
+            store_row0_2d, sizeof(store_row0_2d) / sizeof(store_row0_2d[0]), 1, 0, &part_rt);
+        CHECK(!part_spirv.empty(), "write-only 2D row-0 store kernel recompiles");
+        if (!part_spirv.empty()) {
+            ComputeItem it; it.spirv = part_spirv;
+            it.resources = std::make_shared<ShaderResourceTable>(part_rt);
+            it.launch.threads_x = W; it.launch.local_x = 64; it.launch.groups_x = 1;
+            it.launch.threads_y = H2; it.launch.local_y = 1; it.launch.groups_y = H2;
+            it.launch.threads_z = 1; it.launch.local_z = 1; it.launch.groups_z = 1;
+            it.code_addr = 0x1122f22du;
+            const size_t row_bytes = (size_t)W * 4;
+            // Two runs: the first proves (poison) and detects partial coverage; the second uses the
+            // cached "Partial" verdict and seeds normally. Row 1 must survive on BOTH.
+            for (int run = 0; run < 2; ++run) {
+                CHECK(prosper::frontend::execute_live_compute_items({it}),
+                      run == 0 ? "partial-store proving run executes"
+                               : "partial-store cached (always-seed) run executes");
+                const bool row1_preserved = std::memcmp(part_guest.data() + row_bytes,
+                                                        part_original.data() + row_bytes, row_bytes) == 0;
+                CHECK(row1_preserved,
+                      run == 0 ? "B1: full-grid partial store preserves untouched row on the proving run"
+                               : "B1: full-grid partial store preserves untouched row once proven partial");
+                const bool row0_written = std::memcmp(part_guest.data(),
+                                                      part_original.data(), row_bytes) != 0;
+                CHECK(row0_written, "partial store did write the covered row (kernel ran)");
+            }
+        }
+    }
+
     if (fails) {
         std::printf("== FAIL: %d ==\n", fails);
         return 1;


### PR DESCRIPTION
## What & why

Fixes #1122.

Blasphemous 2 gameplay runs at ~14–21 fps. Profiling isolated the frame cost to **one** compute kernel,
`0x2011d45d00` — a full-screen 1920×1080 post-process whose output storage image (binding 6) was being
**CPU-materialized as a seed every frame**: read the target back GPU→CPU, expand rgba8→uvec4 (8.3→33 MB),
and upload it — ~20 ms/frame — even though the shader is **write-only** (it never reads that image).
Materializing pixels the shader never observes is pure waste.

This PR skips that seed for a write-only storage image **once it is proven** that the dispatch stores every
texel of the target. The remaining GPU work and the guest writeback are unchanged.

## Correctness contract (the load-bearing part)

A write-only shader whose dispatch grid merely *covers* the extent does **not** necessarily write every
texel — a masked composite (`if (mask) imageStore(...)`) or a scatter store covers the grid yet writes a
subset, and the untouched texels must keep their prior content. Skipping the seed there would pack undefined
memory to the guest — silent corruption.

So the seed is skipped **only after per-shader proof**:

- On first sight of an eligible dispatch (write-only storage output + grid ≥ extent), the target is seeded
  with **poison** and the result scanned. **Zero poison survivors ⇒ the shader wrote every texel** (safe to
  fast-skip henceforth); any survivor ⇒ partial coverage ⇒ always seed. The verdict is cached per
  `(shader code_addr, binding)`.
- The **proving frame is itself correct**: any texel the write leaves untouched (still poison) is restored
  from the clean detiled seed before writeback, so proving never corrupts the guest — even for a partial
  shader.
- The guest-backed writeback still validates its target range (`guest_readable`) before writing, so a stale
  descriptor cannot fault or wild-write.

On Blasphemous 2, the real kernel proves cleanly:

```
[seed-skip-verify] code=0x2011d45d00 binding=6 texels=2073600 poison_survived=0 full-coverage (seed-skip proven)
```

(0 of 2,073,600 = 1920×1080 texels survive → genuinely full-coverage.)

## Results (Blasphemous 2, first-station gameplay, RADV STRIX_HALO)

`tools/perf/ab_compute.sh`, 4 reps, alternating arm order, off-switch `PROSPER_NO_SKIP_SEED=1`, on the
**exact PR head** (commit 7819a3c, 4/4 valid reps):

| metric | seed ON (baseline) | seed-skip ON | delta |
|---|---|---|---|
| compute ms/call (tail, 4-rep avg) | ~5.0 ms | ~1.9 ms | **−61% (~2.6×)** |
| frame rate (tail, 4-rep avg) | ~19.0 fps | ~32.3 fps | **+69%** (range +43%…+81%; best rep 19.6→35.4) |

Per-rep fps: 18.7→33.7, 19.6→35.4, 19.0→27.2, 18.9→32.9. The compute-per-call reduction reproduces
tightly every rep; the fps translation is session/order-variable (documented for this route) but strongly
positive in every rep — best reps approach 2×.

## Behavioral scope

- **Affected**: write-only storage-image compute dispatches that fully cover their target (proven per shader).
  Currently only Blasphemous 2's full-screen kernel qualifies in our routes.
- **Unaffected**: shaders that read their storage image (still seeded), partially-covering dispatches (still
  seeded), renderer-owned direct-bind path (#1095), and the guest writeback/coherence contract (#780/#1095).
- The proving frame costs one normal seed per shader at startup; steady state is the fast path.

## Diagnostics

- `PROSPER_NO_SKIP_SEED=1` — force the seed always (the A/B off-switch).
- `PROSPER_VERIFY_SEED_SKIP=1` — re-prove coverage every frame and log survivors (never fast-skip).

## Independent review

- The initial commit (61895df) was independently reviewed and flagged two **blocking** issues — a
  necessary-but-not-sufficient coverage predicate (B1) and a dropped writeback-target guard (B2). Both
  are fixed in 7819a3c, and the review's recommended regression (a full-grid partial-store test) is
  included.
- The corrected head was **re-reviewed adversarially and APPROVED** — no blocking issues; it independently
  confirmed the B2 guard, the B1 static-subset closure, proving-frame layout equivalence, poison
  soundness in the safe direction (a collision can only push a verdict toward Partial/always-seed, never
  a wrong Full), renderer-owned proving correctness, the Vulkan barrier chain, and sequential-execution
  concurrency safety.
- The re-review's two non-blocking notes are addressed in 34b7f9d: the proof key now includes the extent
  and is collision-free (closes the "same shader, larger target" sub-case + the hash-collision note).
  The one residual, genuinely **data-dependent** coverage gap (a store predicate on per-frame input that
  is full on the proving frame but partial later) is documented in-code and tracked in **#1127** — no
  exercised title shader triggers it, and a shader first seen partial is cached Partial and always seeds.

## Verification

- `ctest` — 123/123 pass, including two new `test_game_compute` cases:
  - full-coverage fill: poison-proven run ≡ seed-skipped run, byte-identical, differs from pre-run content;
  - **reviewer B1**: a full-grid partial store (row 0 written, row 1 untouched) detects the survivor, never
    fast-skips, and preserves row 1 on both the proving and cached-partial runs (this fails without the fix).
- Snapshot — all four routes **OK** (no cross-title regression):
  - `blasphemous2-gameplay`: 1920×1080, 98/98 structural + non-black matches, richest 2267 colors (full-color gameplay preserved)
  - `messenger-scene`: 29/29 structural + non-black matches
  - `evergate-title`: 9/9 structural + non-black matches, richest 52612 colors
  - `dead-cells-gameplay`: 44/44 structural + non-black matches, richest 10296 colors

## Relationship to the issue

Issue #1122 proposed a full direct GPU storage-bind (extending #1095) so untouched texels retain live content
regardless of coverage. This PR achieves the issue's **performance goal** via a proven-safe seed-skip, which
is correct for the full-coverage kernel that dominates the frame. A full storage direct-bind remains a future
option for partial-coverage write-only shaders (which today correctly fall back to seeding); tracked as
follow-up rather than blocking this win.
