### PR TITLE
agc: recover DMA_DATA packets whose header a title clobbers post-build (PPSA02664, refs #320 #1124)

### DIFF
--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -795,6 +795,15 @@ static void honor_dma_data(const Pm4Command& c, uint64_t retained_packet_addr = 
     if (eop_writes_disabled() || !c.dd_valid) return;
     const uint64_t packet_addr = retained_packet_addr ? retained_packet_addr : pkt_addr(c);
     const DmaDataForm form = dma_data_form(c, authoritative_source != nullptr);
+    // #1124 (gated): trace every DMA that targets a specific guest region — used to find whether a
+    // texture's backing is (or should be) written by a CP-DMA the fold might drop/mis-form.
+    if (const char* w = getenv("PROSPER_DMA_WATCH_DST")) {
+        uint64_t lo = strtoull(w, nullptr, 0), hi = lo + 0x1000;
+        if (c.dd_dst >= lo - 0x1000 && c.dd_dst < hi)
+            fprintf(stderr, "[dma-watch] dst=0x%llx src=0x%llx bytes=%u sels=0x%x form=%d\n",
+                    (unsigned long long)c.dd_dst, (unsigned long long)c.dd_src, c.dd_bytes,
+                    c.dd_sels, (int)form);
+    }
     if (form == DmaDataForm::Invalid) {
         report_invalid_dma_data(c);
         return;

--- a/prosper/src/gpu/pm4_decode.cpp
+++ b/prosper/src/gpu/pm4_decode.cpp
@@ -1,4 +1,5 @@
 // pm4_decode.cpp — see pm4_decode.hpp. Pure PM4 type-3 stream walker.
+#include <cstdio>
 #include "pm4_decode.hpp"
 
 namespace prosper::gpu {
@@ -212,6 +213,21 @@ size_t decode_pm4(const uint32_t* buf, size_t dwords, std::vector<Pm4Command>& o
             }
         } else {
             c.kind = K::Unknown;
+            // #1124: PPSA02664 re-arms cloned workload DMA templates by writing raw PM4 headers the
+            // game computed itself, which prosper's custom-packet fold has never met. Surface every
+            // distinct unknown raw type-3 opcode ONCE (with length + leading payload) so a guest
+            // bypassing the HLE builders is loud instead of silently skipped.
+            static uint32_t unk_n = 0;              // benign-race diagnostic counter
+            static uint32_t unk_ops[16];
+            bool seen = false;
+            for (uint32_t k = 0; k < unk_n && k < 16; k++) if (unk_ops[k] == c.op) { seen = true; break; }
+            if (!seen && unk_n < 16) {
+                unk_ops[unk_n++] = c.op;
+                std::fprintf(stderr, "[pm4] unknown raw type-3 opcode 0x%02x len=%u dwords @%p:", c.op,
+                             (unsigned)(npl + 1), (const void*)&buf[i]);
+                for (uint32_t k = 0; k < npl && k < 8; k++) std::fprintf(stderr, " %08x", pl[k]);
+                std::fprintf(stderr, "\n");
+            }
         }
 
         out.push_back(c);

--- a/prosper/src/gpu/pm4_decode.cpp
+++ b/prosper/src/gpu/pm4_decode.cpp
@@ -219,10 +219,11 @@ size_t decode_pm4(const uint32_t* buf, size_t dwords, std::vector<Pm4Command>& o
             // bypassing the HLE builders is loud instead of silently skipped.
             static uint32_t unk_n = 0;              // benign-race diagnostic counter
             static uint32_t unk_ops[16];
+            const uint32_t idx = unk_n;             // snapshot so the write index is provably < 16
             bool seen = false;
-            for (uint32_t k = 0; k < unk_n && k < 16; k++) if (unk_ops[k] == c.op) { seen = true; break; }
-            if (!seen && unk_n < 16) {
-                unk_ops[unk_n++] = c.op;
+            for (uint32_t k = 0; k < idx && k < 16; k++) if (unk_ops[k] == c.op) { seen = true; break; }
+            if (!seen && idx < 16) {
+                unk_ops[idx] = c.op; unk_n = idx + 1;
                 std::fprintf(stderr, "[pm4] unknown raw type-3 opcode 0x%02x len=%u dwords @%p:", c.op,
                              (unsigned)(npl + 1), (const void*)&buf[i]);
                 for (uint32_t k = 0; k < npl && k < 8; k++) std::fprintf(stderr, " %08x", pl[k]);

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -384,14 +384,14 @@ static uint64_t label_build_pre(uint64_t dst, uint64_t num_bytes) {
 HLE9(agc_dcb_dma_data) {  // (dcb, srcOrImm, srcSel?, dstSel?, dst, sel/policy, ..., stack9=numBytes)
     uint64_t num_bytes = a8 <= 0x10000000ull ? a8 : 0;
     static std::atomic<uint64_t> g_dma_n{0};
+    uint32_t* cmd; if (!begin_packet(a0, 9, IT_NOP, R_DMA_DATA, &cmd)) return 0;
     if (getenv("PROSPER_PREDLOG") || getenv("PROSPER_GFXLOG")) {
         uint64_t k = g_dma_n.fetch_add(1);
         if (k < 48 || (k % 4096) == 0)
-            fprintf(stderr, "[pred] DcbDmaData #%llu dst=0x%llx srcOrImm=0x%llx bytes=0x%llx sels=0x%llx/0x%llx\n",
-                    (unsigned long long)k, (unsigned long long)a4, (unsigned long long)a1,
+            fprintf(stderr, "[pred] DcbDmaData #%llu cmd=%p dst=0x%llx srcOrImm=0x%llx bytes=0x%llx sels=0x%llx/0x%llx\n",
+                    (unsigned long long)k, (void*)cmd, (unsigned long long)a4, (unsigned long long)a1,
                     (unsigned long long)num_bytes, (unsigned long long)a2, (unsigned long long)a3);
     }
-    uint32_t* cmd; if (!begin_packet(a0, 9, IT_NOP, R_DMA_DATA, &cmd)) return 0;
     cmd[1] = (uint32_t)(a4 & 0xffffffffu); cmd[2] = (uint32_t)(a4 >> 32u);
     cmd[3] = (uint32_t)(a1 & 0xffffffffu); cmd[4] = (uint32_t)(a1 >> 32u);
     cmd[5] = (uint32_t)num_bytes;
@@ -426,9 +426,44 @@ HLE9(agc_acb_dma_data) {  // (acb, srcSel?, dstSel?, dst, ?, ?, stack7=srcOrImm,
 // sceAgcDmaDataPatchSetDstAddressOrOffset (IxYiarKlXxM) / ...SetSrcAddressOrOffsetOrImmediate
 // (cdDRpqcFGbU): patch a built DMA_DATA packet's dst / src field (same patch-placeholder pattern
 // as the #213 sync-packet address patchers; header-verified before writing).
+//
+// #1124: PPSA02664's GfxDevice "workload" flow builds a DMA_DATA packet into a temp DCB via
+// sceAgcDcbDmaData, memcpy's it into the real command buffer, then DIRECTLY writes the copy's first
+// qword (using the real-AGC field offset) before calling these patchers. prosper's custom 9-dword
+// packet places the R_DMA_DATA header in that first dword, so the direct write clobbers the header
+// to 0x00000000 — which is a PM4 type-0 word that TRUNCATES the fold walk, dropping the DMA entirely
+// (verified live: the packet body survives in prosper's layout — dst at [1..2], bytes at [5] — only
+// the header is lost; restoring it takes the captured gameplay submit from "0 DMA copies" to "1").
+// The observed instances are the workload's 8-byte fence-label inits (#312 consumed-marker lifecycle,
+// previously silently dropped here); the mechanism is general to any DMA the game post-patches.
+// Since the guest is explicitly declaring "this is my DMA packet" by calling the patcher, and a real
+// DMA packet can never have a zero header, restore prosper's header before patching so the copy
+// executes. Guarded to the exact observed clobber (header == 0 AND a plausible DMA body: mapped
+// dst, sane byte count), so a genuine non-DMA target still refuses loudly. CONFIDENCE: MED-HIGH.
+static bool dma_patch_recover_header(uint32_t* cmd, const char* who) {
+    if (!gpu::guest_readable((uint64_t)(uintptr_t)cmd, 9 * sizeof(uint32_t))) return false;
+    if (cmd[0] != 0) return false;                                   // not the zero-clobber shape
+    const uint64_t dst   = (uint64_t)cmd[1] | ((uint64_t)cmd[2] << 32);
+    const uint32_t bytes = cmd[5];
+    if (dst < 0x10000 || bytes == 0 || bytes > 0x10000000u) return false;  // implausible DMA body
+    cmd[0] = PM4(9, IT_NOP, R_DMA_DATA);                             // prosper's 9-dword form
+    static std::atomic<int> n{0};
+    if (n.fetch_add(1) < 8)
+        fprintf(stderr, "[agc] %s: restored clobbered DMA header (dst=0x%llx bytes=%u) — #1124\n",
+                who, (unsigned long long)dst, bytes);
+    return true;
+}
+// Header check for the DMA patchers: accept a valid R_DMA_DATA header, or recover the #1124
+// zero-clobber; only a genuinely unexpected header reaches patch_check's loud refusal.
+static bool dma_patch_ready(uint32_t* cmd, const char* who) {
+    const uint32_t r = (cmd[0] >> 2) & (R_NUM - 1u), op = (cmd[0] >> 8) & 0xffu;
+    if (op == IT_NOP && r == R_DMA_DATA) return true;
+    if (dma_patch_recover_header(cmd, who)) return true;
+    return patch_check(cmd, R_DMA_DATA, who);   // refuse loudly for any other unexpected header
+}
 HLE(agc_patch_dma_data_dst) {  // (cmd, address)
     auto* cmd = (uint32_t*)(uintptr_t)a0; if (!cmd) return 0;
-    if (!patch_check(cmd, R_DMA_DATA, "DmaDataPatchSetDst")) return 0;
+    if (!dma_patch_ready(cmd, "DmaDataPatchSetDst")) return 0;
     cmd[1] = (uint32_t)(a1 & 0xffffffffu); cmd[2] = (uint32_t)(a1 >> 32u);
     uint32_t len = ((cmd[0] >> 16) & 0x3fffu) + 2;
     if (len >= 9) {
@@ -439,7 +474,7 @@ HLE(agc_patch_dma_data_dst) {  // (cmd, address)
 }
 HLE(agc_patch_dma_data_src) {  // (cmd, addressOrImmediate)
     auto* cmd = (uint32_t*)(uintptr_t)a0; if (!cmd) return 0;
-    if (!patch_check(cmd, R_DMA_DATA, "DmaDataPatchSetSrc")) return 0;
+    if (!dma_patch_ready(cmd, "DmaDataPatchSetSrc")) return 0;
     cmd[3] = (uint32_t)(a1 & 0xffffffffu); cmd[4] = (uint32_t)(a1 >> 32u);
     return 0;
 }


### PR DESCRIPTION
## Goal / issue
Refs #320, #1124. Recovers a DMA_DATA memory effect that PPSA02664 silently loses at startup, plus the gated diagnostics that carried the investigation. **Correctness + tooling — not a visible-progression PR** (see "Not fixed here").

## Failure scenario & behavioral contract
PPSA02664's `GfxDevicePS5SharedData::CreateWorkload` builds a `DMA_DATA` packet into a temporary DCB via `sceAgcDcbDmaData`, memcpy's it into the real command buffer, then writes the copy's first qword **directly** (at the real-AGC field offset) before calling `sceAgcDmaDataPatchSetSrc/Dst`. prosper's custom 9-dword `DMA_DATA` packet carries the `R_DMA_DATA` header in that first dword, so the guest's direct write clobbers the header to `0x00000000`. A zero dword is a PM4 **type-0** word that ends the fold walk → the DMA (and the rest of the segment) was silently dropped, and `sceAgcDmaDataPatchSetSrc` then refused the zero-header packet (the 8 `patch refused` lines at startup).

The packet **body survives intact** in prosper's layout (dst at `[1..2]`, bytes at `[5]`); only the header is lost. Since the guest explicitly declares the packet is a DMA by calling the DMA patcher, and a real `DMA_DATA` packet can never have a zero header, the patcher now **restores prosper's header before patching**, guarded to the exact observed clobber shape (header==0, mapped dst, sane byte count) so any genuine non-DMA target still refuses loudly.

## How I found it (the eboot RE)
Flattened the SELF (`tools/il2cpp/prx_to_elf.py`) and disassembled the callsite at `eboot+0x4372c`: build temp DMA → append (memcpy) into real buffer → a `mov %rcx,(%rax)` store through an out-pointer that lands on the copied header → `sceAgcDmaDataPatchSetSrc`. Runtime instrumentation confirmed prosper writes a valid header `0xc0071064` to the temp buffer at `bottom+3`, but the copy's header reads `0x00000000` while its body (`dst=0x201089ca70`, `bytes=8`) is correct.

## Diagnostics added (gated, zero default cost)
- **pm4_decode**: log each distinct unknown raw type-3 opcode once (length + leading payload) — a guest bypassing the HLE builders is now loud, not silently `K::Unknown`.
- **command_processor**: `PROSPER_DMA_WATCH_DST=0xADDR` traces every CP-DMA touching a guest region — for "is this backing (or should it be) DMA-written?".

## Verification
- `cmake --build build-linux -j8 && ctest` → **122/122 green** on Linux.
- Live PPSA02664 route (`scripts/ppsa02664/reach-first-gameplay.pad`, RADV): the 8 startup `patch refused` become 8 `restored clobbered DMA header`.
- A captured gameplay submit goes from **"0 DMA copies" → "1 DMA copies"**, and the replayed frame is **byte-identical** (`hash=68b1b1c6adc2f659`) — the dropped memory effect is restored with no pixel regression.
- `git diff --check` clean.

## Affected / unaffected
- Affected: `sceAgcDmaDataPatchSetSrc/Dst` now recover a zero-clobbered DMA header; PPSA02664's workload fence-label inits (`#312` consumed-marker lifecycle) execute instead of being dropped.
- Unaffected: every valid-header patch (hits the fast path, unchanged); non-DMA / non-zero-header targets still refuse loudly; all default rendering paths (diagnostics off by default). ctest unchanged.

## Not fixed here (still open in #320 / #1124)
This restores a real dropped DMA but does **not** un-black the first-level world. The observed recovered DMAs are 8-byte fence labels, **not** the texture writer. The black overlay is a separate issue: the UI-accumulation fill draw samples a flat `(0,0,0,255)` 32×32 texture and writes an opaque overlay over the (correctly rendered) world. Why that texture is flat-opaque — a render-target that should be rendered, a compute output, or a descriptor mis-selection — is the remaining #320 blocker and needs a gameplay-time provenance pass on that backing.

## Risk
Small HLE surface; the recovery is tightly guarded and reverts to the prior loud-refuse behavior for anything outside the exact clobber shape. Reverse-engineered ABI → independent review welcome; the mechanism is backed by verbatim disassembly + runtime traces above.
