### PR TITLE
hle: DirectMemoryQuery not-found returns the EACCES enumeration terminator (GTA V boot spin)

### DIFF
--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -823,7 +823,10 @@ HLE(k_direct_memory_query) {
         if (d.start > a0 && (!next || d.start < next->start)) next = &d;
     }
     const DMem* r = hit ? hit : ((a1 & 1) ? next : nullptr);
-    if (!r) { MLOG("dmem_query(0x%llx) -> none\n", (unsigned long long)a0); return 0x8002000e; }
+    // No region at/after the offset: EACCES is the enumeration terminator. GTA V (PPSA04263)
+    // walks query(offset,1)/offset=info.end and its ONLY loop exit compares against 0x8002000d;
+    // any other value reads as success with a zeroed info block and the walk spins forever (#1129).
+    if (!r) { MLOG("dmem_query(0x%llx) -> none (EACCES)\n", (unsigned long long)a0); return 0x8002000dull; }
     if (sz >= 0x08) *(uint64_t*)(info + 0x00) = r->start;
     if (sz >= 0x10) *(uint64_t*)(info + 0x08) = r->end;
     if (sz >= 0x14) *(int32_t*)(info + 0x10) = r->type;
@@ -3849,7 +3852,8 @@ HLE(k_direct_memory_query) {
         if (d.start > a0 && (!next || d.start < next->start)) next = &d;
     }
     const DMem* r = hit ? hit : ((a1 & 1) ? next : nullptr);
-    if (!r) return 0x8002000eull;
+    // EACCES terminates guest enumeration walks — same contract as the Linux variant (#1129).
+    if (!r) return 0x8002000dull;
     if (sz >= 0x08) *(uint64_t*)(info + 0x00) = r->start;
     if (sz >= 0x10) *(uint64_t*)(info + 0x08) = r->end;
     if (sz >= 0x14) *(int32_t*)(info + 0x10) = r->type;

--- a/prosper/tests/test_dmem.cpp
+++ b/prosper/tests/test_dmem.cpp
@@ -696,6 +696,22 @@ int main() {
         printf("== FAIL ==\n"); return 1;
     }
 
+    // sceKernelDirectMemoryQuery enumeration contract (issue #1129). GTA V (PPSA04263) walks
+    // allocated direct memory at boot as query(offset, flags=1) / offset = info.end, and its ONLY
+    // loop exit is return code 0x8002000d (EACCES). Returning any other error here (the old
+    // 0x8002000e) reads as success with a zeroed info block, so the guest re-queries offset 0
+    // forever. The pool is empty at this point in the test, so find-next must terminate at once.
+    auto dm_query = Hle::lookup(nid_hash("sceKernelDirectMemoryQuery"));
+    CHECK(nid_hash("sceKernelDirectMemoryQuery") == "BHouLQzh0X0",
+          "sceKernelDirectMemoryQuery hashes to the PS5 3.20 import NID");
+    CHECK(dm_query != nullptr, "DirectMemoryQuery registered");
+    uint8_t dmq_info[0x18];
+    memset(dmq_info, 0xa5, sizeof(dmq_info));
+    CHECK((uint32_t)dm_query(0, 1, (uint64_t)(uintptr_t)dmq_info, 0x18, 0, 0) == 0x8002000du,
+          "DirectMemoryQuery(0, find-next) on an empty pool -> EACCES terminator");
+    CHECK((uint32_t)dm_query(0, 0, (uint64_t)(uintptr_t)dmq_info, 0x18, 0, 0) == 0x8002000du,
+          "DirectMemoryQuery(0, exact) on an empty pool -> EACCES");
+
     CHECK((uint32_t)unmap(0, 0x4000, 0, 0, 0, 0) == 0x80020016u,
           "Munmap rejects a null address");
     CHECK((uint32_t)unmap(0x4000, 0, 0, 0, 0, 0) == 0x80020016u,
@@ -768,6 +784,19 @@ int main() {
     uint64_t ar = alloc(0, kEnd, 0x100000, 0x4000, 12, (uint64_t)(uintptr_t)&ap);
     CHECK(ar == 0 && ap == kBase,
           "PS5 memory type 12 succeeds after invalid allocations leave the pool untouched");
+    // With exactly one region allocated ([kBase, kBase+0x100000) type 12), the GTA V-style walk
+    // must visit it and then terminate: find-next from 0 returns the region, find-next from its
+    // end returns the EACCES terminator (issue #1129).
+    memset(dmq_info, 0, sizeof(dmq_info));
+    CHECK(dm_query(0, 1, (uint64_t)(uintptr_t)dmq_info, 0x18, 0, 0) == 0 &&
+              *(uint64_t*)(dmq_info + 0x00) == ap &&
+              *(uint64_t*)(dmq_info + 0x08) == ap + 0x100000 &&
+              *(int32_t*)(dmq_info + 0x10) == 12,
+          "DirectMemoryQuery(0, find-next) returns the sole region with exact bounds and type");
+    CHECK((uint32_t)dm_query(*(uint64_t*)(dmq_info + 0x08), 1,
+                             (uint64_t)(uintptr_t)dmq_info, 0x18, 0, 0) == 0x8002000du,
+          "DirectMemoryQuery(end, find-next) past the last region -> EACCES terminator");
+
     int32_t direct_type = -1;
     uint64_t direct_start = UINT64_MAX, direct_end = UINT64_MAX;
     CHECK(get_type(ap + 0x80000, (uint64_t)(uintptr_t)&direct_type,


### PR DESCRIPTION
## Issue
Fixes #1129.

## Failure scenario
On the first prosper boot of *Grand Theft Auto V* (`PPSA04263`, RAGE), the window opens but the guest thread spins at 100% CPU forever, before any rendering. Live disassembly (eboot base `0x410000000`, loop at `eboot+0x4b6612`) shows RAGE enumerating allocated direct memory:

```
xor  %edi,%edi                    ; offset = 0
loop:
mov  $0x18,%ecx / $0x1,%esi       ; infoSize=0x18, flags=1 (find-next)
call sceKernelDirectMemoryQuery   ; libkernel::BHouLQzh0X0
cmp  $0x8002000d,%eax             ; the ONLY loop exit: EACCES
je   done
mov  -0x40(%rbp),%rdi             ; offset = info->end
jmp  loop
```

The guest treats **`0x8002000d` (EACCES) as the end-of-enumeration terminator**. prosper's not-found path returned `0x8002000e` (errno 14) and zeroed the info block first, so the guest read `info->end == 0` and re-queried offset 0 forever.

## Contract / approach
`sceKernelDirectMemoryQuery` returns EACCES (`0x8002000d`) when no region exists at or after the queried offset — this is the documented walk terminator. Both platform variants of `k_direct_memory_query` now return `0x8002000d` instead of `0x8002000e`. This matches the file's own errno encoding (`0x8002xxxx` = POSIX errno; EACCES = 13 = 0x0d, already used at `hle_kernel_mem.cpp:1043` and `:933`).

## Affected / unaffected
- Affected: `sceKernelDirectMemoryQuery` not-found return, both `#ifdef __linux__` and Windows variants.
- Deliberately unaffected: the `sceKernelVirtualQuery` end-of-space path (also `0x8002000e`) is left alone — current Messenger/Dead Cells/B2/DQ7 boots exercise it and changing it needs its own title evidence.

## Risk
Low. The only behavioral change is the error code for an already-error return; no successful query path changes.

## Verification (exact head)
```
cmake --build prosper/build-linux -j16 && ctest      # 128/128 pass
ctest -R dmem -V                                     # new terminator cases green
```
`test_dmem` gains: empty-pool find-next → EACCES, one-region walk returns the region then EACCES past its end. Each fails on `master` and passes here.

Not a rendered-progression PR: this unblocks the first boot instruction, taking GTA V from "spins forever" to executing its real startup (RPF/APR loading). No new rendered checkpoint yet.
