### PR TITLE
hle: implement sceKernelAprResolveFilepathsWithPrefixToIdsAndFileSizes (GTA V RAGE archive load)

### DIFF
--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -1836,16 +1836,21 @@ int prosper_apr_match_by_size(uint64_t size, std::string* out_path) {
         if (f.size == size) { if (n++ == 0 && out_path) *out_path = f.path; }
     return n;
 }
-HLE(f_apr_resolve) {
-    const char** paths = (const char**)P(a0);
-    int count = (int)(int64_t)a1;
-    uint32_t* out_ids   = (uint32_t*)P(a2);
-    uint64_t* out_sizes = (uint64_t*)P(a3);
-    uint32_t* out_flags = (uint32_t*)P(a4);
+// Shared body for both APR resolve entry points. `prefix` (may be empty/null) is a guest-path
+// prefix prepended to each entry before /app0 translation — GTA V (PPSA04263, RAGE) calls the
+// WithPrefix variant, DOLL (PPSA17942, UE4) the non-prefix one. Each resolved container is stat'd
+// and assigned a stable 1-based id recorded in the APR registry so the read/stat paths can find
+// its host file. Returning without populating the id/size outputs (the old EINVAL/success stub)
+// makes APR proceed on garbage ids and wild-write over the allocator, so every entry writes all
+// three outputs.
+static uint64_t apr_resolve_impl(const char* prefix, const char** paths, int count,
+                                 uint32_t* out_ids, uint64_t* out_sizes, uint32_t* out_flags) {
     if (!paths || count <= 0) return 0x80020016ull;   // EINVAL
     for (int i = 0; i < count; i++) {
         const char* gp = paths[i];
-        std::string host = gp ? translate(gp) : std::string();
+        std::string guest = gp ? std::string(gp) : std::string();
+        if (prefix && prefix[0] && !guest.empty()) guest = std::string(prefix) + guest;
+        std::string host = guest.empty() ? std::string() : translate(guest.c_str());
         uint64_t size = 0; uint32_t id = 0;
 #ifndef _WIN32
         struct stat st;
@@ -1855,7 +1860,7 @@ HLE(f_apr_resolve) {
         if (!host.empty() && ::_stat64(host.c_str(), &st) == 0) size = (uint64_t)st.st_size;
 #endif
         else { if (out_ids) out_ids[i] = 0; if (out_sizes) out_sizes[i] = 0; if (out_flags) out_flags[i] = 0;
-               if (filelog()) fprintf(stderr, "[apr] resolve MISS %s\n", gp ? gp : "(null)"); continue; }
+               if (filelog()) fprintf(stderr, "[apr] resolve MISS %s\n", guest.empty() ? "(null)" : guest.c_str()); continue; }
         // Warn loudly (unconditionally) when a DIFFERENT container shares this size: the read
         // path is size-keyed (see f_apr_read_submit) and will refuse such reads as ambiguous.
         std::string clash; int same_size = prosper_apr_match_by_size(size, &clash);
@@ -1867,9 +1872,22 @@ HLE(f_apr_resolve) {
         if (out_ids)   out_ids[i]   = id;
         if (out_sizes) out_sizes[i] = size;
         if (out_flags) out_flags[i] = 0;
-        if (filelog()) fprintf(stderr, "[apr] resolve %s -> id=%u size=%llu\n", gp, id, (unsigned long long)size);
+        if (filelog()) fprintf(stderr, "[apr] resolve %s -> id=%u size=%llu\n", guest.c_str(), id, (unsigned long long)size);
     }
     return 0;
+}
+HLE(f_apr_resolve) {
+    return apr_resolve_impl(nullptr, (const char**)P(a0), (int)(int64_t)a1,
+                            (uint32_t*)P(a2), (uint64_t*)P(a3), (uint32_t*)P(a4));
+}
+// sceKernelAprResolveFilepathsWithPrefixToIdsAndFileSizes(const char* prefix, const char** paths,
+//   int count, uint32_t* outIds, uint64_t* outSizes, uint32_t* outFlags) — GTA V's RAGE resource
+// loader entry. ABI recovered from live guest disassembly (PPSA04263, [RAGE] Main Thr): rdi=prefix
+// (empty ""), rsi=paths (paths[0]="/app0/ps5/audio/sfx/ANIMALS.rpf"), rdx=count(1), then the three
+// output arrays. Same contract as the non-prefix twin with one leading prefix arg.
+HLE(f_apr_resolve_with_prefix) {
+    return apr_resolve_impl((const char*)P(a0), (const char**)P(a1), (int)(int64_t)a2,
+                            (uint32_t*)P(a3), (uint64_t*)P(a4), (uint32_t*)P(a5));
 }
 
 // libSceAmpr::mQ16-QdKv7k — the APR read SUBMIT (identified by tracing readFile eboot 0x59b6110 ->
@@ -2393,6 +2411,7 @@ void register_file_hle() {
     Hle::register_fn("5TgME6AYty4", (HleFn)k_aio_delete,       "sceKernelAioDeleteRequest");
     Hle::register_fn("fR521KIGgb8", (HleFn)k_aio_cancel,       "sceKernelAioCancelRequest");
     R("sceKernelAprResolveFilepathsToIdsAndFileSizes", f_apr_resolve);   // real APR resolve (was EINVAL)
+    R("sceKernelAprResolveFilepathsWithPrefixToIdsAndFileSizes", f_apr_resolve_with_prefix);  // GTA V (#1130)
     // libSceAmpr sceAmprAprCommandBufferReadFile (NID name recovered by brute-force). The Linux
     // entry is an asm shim that snapshots rsp so the handler can read the stack args (arg7 = file
     // offset); see f_apr_read_submit_entry above.

--- a/prosper/tests/test_apr_registry.cpp
+++ b/prosper/tests/test_apr_registry.cpp
@@ -12,6 +12,7 @@
 #include <vector>
 #include "../src/host/exec_image.hpp"
 #include "../src/hle/dispatch.hpp"
+#include "../src/hle/nid.hpp"
 
 namespace prosper {
     uint32_t    prosper_apr_register(const std::string& path, uint64_t size);
@@ -152,6 +153,67 @@ int main() {
           "ordinary embedded completion record still publishes byte count");
 
     std::remove(fixture_path);
+    prosper_apr_reset_for_test();
+
+    // sceKernelAprResolveFilepathsWithPrefixToIdsAndFileSizes (GTA V / PPSA04263, RAGE, issue #1130):
+    // the prefix-taking twin of the plain resolve. It must prepend `prefix` to each guest path,
+    // stat the resolved container, and WRITE all three output arrays (id/size/flags). Stubbing it to
+    // success without populating the outputs makes RAGE proceed on a garbage file id (0xffffffff was
+    // observed live at the next GetFileStat) and wild-write over its allocator. translate() passes a
+    // non-mount path through unchanged, so a relative fixture path exercises the real handler.
+    auto resolve_prefix = Hle::lookup(nid_hash("sceKernelAprResolveFilepathsWithPrefixToIdsAndFileSizes"));
+    auto resolve_plain  = Hle::lookup(nid_hash("sceKernelAprResolveFilepathsToIdsAndFileSizes"));
+    CHECK(nid_hash("sceKernelAprResolveFilepathsWithPrefixToIdsAndFileSizes") == "w5fcCG+t31g",
+          "WithPrefix resolve hashes to the PS5 3.20 import NID");
+    CHECK(resolve_prefix != nullptr && resolve_plain != nullptr, "both APR resolve entries registered");
+
+    const char* wp_full = "prosper-test-apr-prefix.tmp";   // prefix + tail == this path
+    const char* wp_prefix = "prosper-test-apr-";
+    const char* wp_tail   = "prefix.tmp";
+    std::array<uint8_t, 321> wp_bytes{};
+    for (size_t i = 0; i < wp_bytes.size(); ++i) wp_bytes[i] = (uint8_t)(i * 13u + 5u);
+    if (FILE* wf = std::fopen(wp_full, "wb")) { std::fwrite(wp_bytes.data(), 1, wp_bytes.size(), wf); std::fclose(wf); }
+
+    if (resolve_prefix && resolve_plain) {
+        // The prefix path is prepended: prefix="prosper-test-apr-", paths[0]="prefix.tmp".
+        const char* paths[1] = { wp_tail };
+        uint32_t ids[1] = { 0xdeadbeef }; uint64_t sizes[1] = { 0xdead }; uint32_t flags[1] = { 0xdead };
+        uint64_t r = resolve_prefix((uint64_t)(uintptr_t)wp_prefix, (uint64_t)(uintptr_t)paths, 1,
+                                    (uint64_t)(uintptr_t)ids, (uint64_t)(uintptr_t)sizes, (uint64_t)(uintptr_t)flags);
+        CHECK(r == 0, "WithPrefix resolve returns success");
+        CHECK(sizes[0] == wp_bytes.size(),
+              "WithPrefix resolve prepends the prefix and stats the combined path");
+        CHECK(ids[0] >= 1 && flags[0] == 0, "WithPrefix resolve populates id and flags");
+        CHECK(prosper_apr_path_for_id(ids[0]) == wp_full,
+              "WithPrefix registers the combined host path under the returned id");
+
+        // An empty prefix must behave exactly like the plain (non-prefix) resolve.
+        prosper_apr_reset_for_test();
+        const char* full_paths[1] = { wp_full };
+        uint32_t id_wp = 0, id_plain = 0; uint64_t sz_wp = 0, sz_plain = 0; uint32_t fl_wp = 1, fl_plain = 1;
+        resolve_prefix((uint64_t)(uintptr_t)"", (uint64_t)(uintptr_t)full_paths, 1,
+                       (uint64_t)(uintptr_t)&id_wp, (uint64_t)(uintptr_t)&sz_wp, (uint64_t)(uintptr_t)&fl_wp);
+        prosper_apr_reset_for_test();
+        resolve_plain((uint64_t)(uintptr_t)full_paths, 1,
+                      (uint64_t)(uintptr_t)&id_plain, (uint64_t)(uintptr_t)&sz_plain, (uint64_t)(uintptr_t)&fl_plain, 0);
+        CHECK(id_wp == id_plain && sz_wp == sz_plain && sz_wp == wp_bytes.size() && fl_wp == 0,
+              "empty prefix matches the plain resolve");
+
+        // A missing container zeroes its outputs (no garbage id) rather than failing the batch.
+        prosper_apr_reset_for_test();
+        const char* miss_paths[1] = { "prosper-test-apr-does-not-exist.tmp" };
+        uint32_t miss_id = 0x55; uint64_t miss_sz = 0x55; uint32_t miss_fl = 0x55;
+        uint64_t rm = resolve_prefix((uint64_t)(uintptr_t)"", (uint64_t)(uintptr_t)miss_paths, 1,
+                                     (uint64_t)(uintptr_t)&miss_id, (uint64_t)(uintptr_t)&miss_sz,
+                                     (uint64_t)(uintptr_t)&miss_fl);
+        CHECK(rm == 0 && miss_id == 0 && miss_sz == 0 && miss_fl == 0,
+              "unresolvable container zeroes its outputs");
+
+        // A null paths pointer / non-positive count is rejected without touching memory.
+        CHECK((uint32_t)resolve_prefix((uint64_t)(uintptr_t)"", 0, 1, 0, 0, 0) == 0x80020016u,
+              "WithPrefix resolve rejects a null paths array");
+    }
+    std::remove(wp_full);
     prosper_apr_reset_for_test();
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }


### PR DESCRIPTION
## Issue
Fixes #1130.

## Failure scenario
*Grand Theft Auto V* (`PPSA04263`, RAGE) loads RPF archives through the APR path. Its resource loader calls the **prefix-taking** resolve entry (`sceKernelAprResolveFilepathsWithPrefixToIdsAndFileSizes`, `libkernel::w5fcCG+t31g`), which prosper never registered — so it fell through to the generic unimplemented stub (`return 0`, outputs untouched). Live `[RAGE] Main Thr` disassembly:

```
sceKernelAprResolveFilepathsWithPrefixToIdsAndFileSizes(
    rdi=prefix (empty ""),  rsi=paths (paths[0]="/app0/ps5/audio/sfx/ANIMALS.rpf"),
    rdx=count (1),  rcx=outIds, r8=outSizes, r9=outFlags)
```

With outputs unwritten, RAGE read a **garbage file id (`0xffffffff` observed live at the very next `sceKernelAprGetFileStat`)** and would wild-write over its allocator — the exact hazard the existing plain-resolve handler documents.

## Contract / approach
The WithPrefix variant is the plain resolve with one leading `prefix` arg, prepended to each guest path before /app0 translation. Extracted the shared body into `apr_resolve_impl(prefix, paths, count, outIds, outSizes, outFlags)`; `f_apr_resolve` passes `prefix=nullptr`, the new `f_apr_resolve_with_prefix` passes the real prefix. Each entry stats the resolved container and writes all three outputs (id/size/flags), registering a stable 1-based id → host path so the read/stat paths can find it. ABI recovered from the disassembly above.

With the fix the APR read path executes for real:
```
[apr] read-submit id=271 .../update/update2.rpf -> dst=0x1559c00000(guest) off=0x86400 size=4822 got=4822 OK
```

## Affected / unaffected
- Affected: adds registration + handler for the WithPrefix resolve NID; refactors the plain resolve to share the body (behavior identical — `prefix=nullptr`).
- Unaffected: the AMPR read-submit path, size-keyed matching, and the existing plain-resolve callers (DOLL / Evergate). All prior `test_apr_registry` cases unchanged and green.

## Risk
Low–medium (reverse-engineered ABI). The refactor preserves the plain path exactly; the new path is exercised by a unit test through the NID registry. `prefix` prepending is guarded (`prefix && prefix[0]`).

## Verification (exact head)
```
cmake --build prosper/build-linux -j16 && ctest      # 128/128 pass
ctest -R apr_registry -V
```
New `test_apr_registry` cases: NID hash check, prefix prepending + combined-path stat, all-outputs populated, id→host-path registration, empty-prefix parity with the plain resolve, unresolvable-container output zeroing, null-array rejection.

Not a rendered-progression PR: this advances GTA V's boot from the DirectMemoryQuery fix (#1129) into real RPF/APR archive reads and audio init; it reaches a later RAGE `int $0x41` fatal (tracked separately). No new rendered checkpoint yet.
