### PR TITLE
diag: cycling IME autokey + PROSPER_PRESENT_NZLOG content proxy (#320)

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -2812,14 +2812,21 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
             // PROSPER_DUMP_CONTENT=<min-nonzero-bytes>: dump ONLY frames whose framebuffer has at least
             // that many nonzero bytes — catches the intermittent content submits the periodic dump misses.
             size_t content_thr = 0; if (const char* c = getenv("PROSPER_DUMP_CONTENT")) content_thr = (size_t)atol(c);
+            // PROSPER_PRESENT_NZLOG=N: log the presented frame's nonzero-byte count every N frames WITHOUT
+            // writing any image. A memory-safe content proxy for long progression runs — dumping BMPs to a
+            // tmpfs frame dir exhausts RAM, this does not. 0/unset disables.
+            static const int nzlog_every = [] { const char* e = getenv("PROSPER_PRESENT_NZLOG");
+                                                return e ? (int)atol(e) : 0; }();
             size_t px_nz = 0;
-            if (dump_bmps) for (uint8_t b : px) px_nz += (b != 0);
+            if (dump_bmps || nzlog_every) for (uint8_t b : px) px_nz += (b != 0);
             if (px.empty()) {
                 fprintf(stderr, "[render] frame %d: Vulkan render FAILED (%ux%u)\n", n, w, h);
             } else if (dump_bmps && ((content_thr && px_nz >= content_thr) || (!content_thr && (n < 60 || n % 10 == 0)))) {
                 char fn[512]; snprintf(fn, sizeof fn, "%s/frame_%04d.bmp", frame_dir.c_str(), n);
                 prosper::test::dump_bmp(fn, px, w, h);
                 fprintf(stderr, "[render] frame %d rendered (%ux%u) nz=%zu -> %s\n", n, w, h, px_nz, fn);
+            } else if (nzlog_every && !px.empty() && (n % nzlog_every == 0)) {
+                fprintf(stderr, "[render-nz] frame %d (%ux%u) nz=%zu\n", n, w, h, px_nz);
             }
             if (timing_enabled) {
                 pending_timing.callbacks++;

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -1062,17 +1062,34 @@ void ime_deliver(uint64_t handler, const ImeKeyEvent& ev) {
 // PROSPER_IME_AUTOKEY=1: deliver a repeating Enter down/up pulse so headless routes advance a
 // "press any button" / menu that reads the IME keyboard. Diagnostic/verification lever; the real
 // per-key input comes from a frontend via ime_push_key (below). PROSPER_IME_AUTOKEY_HID overrides
-// the HID usage (default 0x28 Enter). Cadence: down, then up two ticks later, repeating.
+// the HID usage (default 0x28 Enter) and accepts a comma-separated LIST (e.g. "0x28,0x2c,0x1d") that
+// is cycled one key per press-window — so a single headless run can probe which key a dialog accepts.
+// Cadence: down, then up two ticks later, then the next key in the list two windows later.
 void ime_autokey_tick(uint64_t handler) {
     static const int on = [] { const char* e = getenv("PROSPER_IME_AUTOKEY");
                                return e && strtol(e, nullptr, 0) != 0 ? 1 : 0; }();
     if (!on) return;
-    static const uint16_t hid = [] { const char* e = getenv("PROSPER_IME_AUTOKEY_HID");
-                                     return (uint16_t)(e ? strtol(e, nullptr, 0) : 0x28); }();
+    static const std::vector<uint16_t> hids = [] {
+        std::vector<uint16_t> v;
+        const char* e = getenv("PROSPER_IME_AUTOKEY_HID");
+        if (e && *e) for (const char* p = e; *p; ) {
+            char* end = nullptr; long val = strtol(p, &end, 0);
+            if (end == p) break;
+            v.push_back((uint16_t)val);
+            p = (*end == ',') ? end + 1 : end;
+        }
+        if (v.empty()) v.push_back(0x28);   // default Enter
+        return v;
+    }();
     static std::atomic<uint64_t> tick{0};
     uint64_t t = tick.fetch_add(1);
-    if ((t % 90) == 0)      ime_deliver(handler, {hid, true});
-    else if ((t % 90) == 2) ime_deliver(handler, {hid, false});
+    const uint16_t hid = hids[(t / 90) % hids.size()];
+    if ((t % 90) == 0) {
+        ime_deliver(handler, {hid, true});
+        if (svclog()) fprintf(stderr, "[ime-autokey] deliver hid=0x%x down\n", hid);
+    } else if ((t % 90) == 2) {
+        ime_deliver(handler, {hid, false});
+    }
 }
 } // namespace
 


### PR DESCRIPTION
## Goal
Two small, gated, reusable diagnostics that supported the Alex Kidd (PPSA02664) intro-progression investigation for #320. Both are off by default and change no control flow on the default boot — pure observation.

## What & why
**1. `PROSPER_IME_AUTOKEY_HID` now accepts a comma-separated HID list** (e.g. `"0x28,0x2c,0x1d"`). `ime_autokey_tick` cycles one key per press-window, so a single headless run can probe which keysym a keyboard-driven dialog accepts (PPSA02664 reads input only via IME, never scePad). Under `PROSPER_SVCLOG` each delivered key logs a `[ime-autokey] deliver hid=0x.. down` line. Previously the autokey could only pulse one fixed key, so probing N candidate keys meant N full runs.

**2. `PROSPER_PRESENT_NZLOG=N`** logs the presented frame's nonzero-byte count every N frames **without writing any image** (`[render-nz] frame N (WxH) nz=..`). A memory-safe content proxy for long progression runs: dumping BMPs to a tmpfs frame dir exhausts host RAM (tmpfs is RAM-backed) and can wedge the box; this reads back the already-present pixels and only counts them.

## Behavioral contract
- Default boot (neither env set): byte-for-byte unchanged. `nzlog_every` defaults to 0 (disabled); the autokey list defaults to the single `0x28` (Enter) it used before.
- `PROSPER_PRESENT_NZLOG` only adds an `else if` branch that runs when BMP dumping is not already taking the frame — it never suppresses an existing dump.

## Affected / unaffected
- Affected: `ime_autokey_tick` (list parse + cycle), the present-callback content-log block.
- Unaffected: the IME event delivery ABI, the BMP dump path, all render output.

## Verification
- `cmake --build build-linux -j8 --target boot_trace` — clean.
- Exercised live headless: the cycling autokey delivered all 6 probed keys (~87 each) and `[ime-autokey]` logged them; `PROSPER_PRESENT_NZLOG=30` produced `[render-nz]` lines with correct nz over a 4790-frame run with zero image writes and flat host memory.

## Risk
Minimal — gated diagnostics, no default-path change. `area:messenger`/shared-infra lane (shared frontend + IME HLE).