### PR TITLE
hle: GTA V graphics/audio-init — AGC GetSize + AprGetFileStat + AudioOut2 speaker-array (clears pre-render fatal, first GPU frames)

### DIFF
--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -1498,8 +1498,31 @@ HLE(agc_cb_dispatch) {  // (buf, dimension_x, dimension_y, dimension_z, dispatch
     return (uint64_t)(uintptr_t)cmd;
 }
 
+// AGC command-buffer size queries (GTA V / PPSA04263, RAGE, issue #1137). A GetSize returns how many
+// BYTES a command will occupy so the guest can size its DrawCommandBuffer before building. RAGE's
+// render thread (eboot+0x2bfef.. / +0x2bffd..) sums these across a workload, some used directly as a
+// byte accumulator and some converted to dwords via (n+3)>>2, then rounds up to a 128-byte boundary
+// and allocates the guest DCB (AgcDcb.bottom..top). Stubbed to 0 the guest allocates a 128-byte buffer
+// and the builders overflow it -> corrupt submit -> RAGE fatal, before any GPU frame. Each returns the
+// matching builder's dword count * 4 (see the begin_packet(a0, N, ...) sizes below); the invariant is
+// only that reserved >= written, so a builder prosper hasn't implemented (Rewind) still reserves safely.
+// CONFIDENCE: MED — units (bytes) and the sum/allocate contract are pinned from live render-thread
+// disassembly; exact per-command dword counts mirror prosper's own builders.
+HLE(agc_dcb_jump_get_size)        { (void)a0; return 5u * 4u; }   // sceAgcDcbJump builds 5 dwords
+HLE(agc_dcb_acquire_mem_get_size) { (void)a0; return 8u * 4u; }   // sceAgc(Dcb|Acb)AcquireMem builds 8
+HLE(agc_dcb_rewind_get_size)      { (void)a0; return 2u * 4u; }   // PM4 REWIND, 2 dwords
+HLE(agc_cb_eop_action_get_size)   { (void)a0; return 9u * 4u; }   // sceAgcCbReleaseMem (EOP) builds 9
+// sceAgcCbNopGetSize(numDwords): the NOP is exactly the requested dword count (min 1). arg in a0.
+HLE(agc_cb_nop_get_size)          { uint32_t n = (uint32_t)a0; if (n == 0) n = 1; return (uint64_t)n * 4u; }
+
 void register_agc_hle() {
     #define RN(nid, fn) Hle::register_fn(nid, (HleFn)(fn), nid)
+    RN("VEGu4dixjUg", agc_dcb_jump_get_size);        // sceAgcDcbJumpGetSize (#1137)
+    RN("-vnlTPPXPrw", agc_dcb_acquire_mem_get_size); // sceAgcDcbAcquireMemGetSize
+    RN("ewobAQeMo5k", agc_dcb_acquire_mem_get_size); // sceAgcAcbAcquireMemGetSize (same size)
+    RN("QIXCsbipds0", agc_dcb_rewind_get_size);      // sceAgcDcbRewindGetSize
+    RN("hL7C0IRpWZI", agc_cb_eop_action_get_size);   // sceAgcCbQueueEndOfPipeActionGetSize
+    RN("t7PlZ9nt5Lc", agc_cb_nop_get_size);          // sceAgcCbNopGetSize
     RN("f3dg2CSgRKY", agc_create_shader);   // sceAgcCreateShader — populates the shader registry
     RN("AOLcoIkQDgM", agc_driver_query_resource_registration_user_memory_requirements);
     RN("uJziRsODk1c", agc_driver_get_resource_registration_max_name_length);

--- a/prosper/src/hle/hle_audio.cpp
+++ b/prosper/src/hle/hle_audio.cpp
@@ -640,6 +640,21 @@ HLE(audio2_ctx_query_memory) {
     return 0;
 }
 
+// sceAudioOut2GetSpeakerArrayMemorySize(...) -> size (GTA V / PPSA04263, RAGE, issue #1134).
+// RETURNS the speaker-array work-memory byte size directly (rax); the guest uses it verbatim as an
+// allocation size: `r15 = ret; ptr = allocator->alloc(r15, 0x10)`. Live [RAGE] disassembly at
+// eboot+0x2adf25e: arg rdi=8 (speaker/channel config). Stubbed to 0 the guest allocated a ZERO-byte
+// speaker-array buffer and then overran it, aborting RAGE audio/streaming init with its int 0x41
+// fatal — the deterministic pre-render crash on this title. Like sceAudioOut2ContextQueryMemory, the
+// null backend needs no real work memory; report a fixed, comfortably-large size so the allocation
+// succeeds and is big enough. The value's only observable effect is a successful, large-enough alloc.
+// CONFIDENCE: MED — return-is-size and the alloc use are pinned from disassembly; the exact SDK size
+// formula is unknown, so a generous fixed size is used (safe: the buffer is only ever zero-filled here).
+HLE(audio2_get_speaker_array_memory_size) {
+    A2LOG("sceAudioOut2GetSpeakerArrayMemorySize");
+    return 0x100000;   // 1 MiB, 0x10-aligned; matches the ContextQueryMemory null-backend precedent
+}
+
 // sceAudioOut2ContextCreate(param*, mem, memSize, Handle* outCtx) -> 0.
 HLE(audio2_ctx_create) {
     A2LOG("sceAudioOut2ContextCreate");
@@ -2207,6 +2222,7 @@ void register_audio_hle() {
     R("sceAudioOut2PortUnregister", audio2_port_unregister);
     R("sceAudioOut2GetSystemState", audio2_get_system_state);
     R("sceAudioOut2GetSpeakerInfo", audio2_get_speaker_info);
+    R("sceAudioOut2GetSpeakerArrayMemorySize", audio2_get_speaker_array_memory_size);  // GTA V (#1134)
     R("sceAudioOut2MasteringInit", audio2_mastering_init);
     R("sceAudioOut2MasteringTerm", audio2_mastering_term);
     R("sceAudioOut2MasteringSetParam", audio2_mastering_set_param);

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -1889,6 +1889,34 @@ HLE(f_apr_resolve_with_prefix) {
     return apr_resolve_impl((const char*)P(a0), (const char**)P(a1), (int)(int64_t)a2,
                             (uint32_t*)P(a3), (uint64_t*)P(a4), (uint32_t*)P(a5));
 }
+// sceKernelAprGetFileStat(uint32_t fileId, SceKernelStat* out) — GTA V (PPSA04263, RAGE, issue #1133).
+// ABI from live [RAGE] Main Thr disassembly: a0=fileId (a valid id from the WithPrefix resolve),
+// a1=stat buffer. Stubbing it to success without filling `out` made RAGE validate an uninitialized
+// stat (it converts the mtime as a FILETIME: imul 1e7 + epoch 0x19db1ded53e8000) and abort its
+// streaming init with a fatal (int 0x41). Look the id up in the APR registry, host-stat the file, and
+// write the standard SceKernelStat. CONFIDENCE: MED — id/buffer roles pinned from disassembly; the
+// SceKernelStat layout matches prosper's sceKernelStat/fstat writer.
+HLE(f_apr_get_file_stat) {
+    uint32_t id = (uint32_t)a0;
+    uint8_t* out = (uint8_t*)P(a1);
+    if (!out) return 0x80020016ull;   // EINVAL
+    std::string host = prosper_apr_path_for_id(id);
+    if (host.empty()) { if (filelog()) fprintf(stderr, "[apr] GetFileStat id=%u -> unknown id\n", id);
+                        return 0x80020002ull; }   // ENOENT
+#ifndef _WIN32
+    struct stat st;
+    if (::stat(host.c_str(), &st) != 0) { if (filelog()) fprintf(stderr, "[apr] GetFileStat id=%u stat('%s') failed\n", id, host.c_str());
+                                          return 0x80020002ull; }
+    write_sce_stat(from_host_stat(st), out);
+#else
+    struct _stat64 st;
+    if (::_stat64(host.c_str(), &st) != 0) return 0x80020002ull;
+    write_sce_stat(from_host_stat(st), out);
+#endif
+    if (filelog()) fprintf(stderr, "[apr] GetFileStat id=%u '%s' -> size=%lld\n",
+                           id, host.c_str(), (long long)st.st_size);
+    return 0;
+}
 
 // libSceAmpr::mQ16-QdKv7k — the APR read SUBMIT (identified by tracing readFile eboot 0x59b6110 ->
 // this import). Call shape: mQ16(reqFrame, outScratchPtr /*a1*/, outRecord /*a2*/, fileId /*a3*/,
@@ -2412,6 +2440,7 @@ void register_file_hle() {
     Hle::register_fn("fR521KIGgb8", (HleFn)k_aio_cancel,       "sceKernelAioCancelRequest");
     R("sceKernelAprResolveFilepathsToIdsAndFileSizes", f_apr_resolve);   // real APR resolve (was EINVAL)
     R("sceKernelAprResolveFilepathsWithPrefixToIdsAndFileSizes", f_apr_resolve_with_prefix);  // GTA V (#1130)
+    R("sceKernelAprGetFileStat", f_apr_get_file_stat);  // GTA V (#1133)
     // libSceAmpr sceAmprAprCommandBufferReadFile (NID name recovered by brute-force). The Linux
     // entry is an asm shim that snapshots rsp so the handler can read the stack args (arg7 = file
     // offset); see f_apr_read_submit_entry above.


### PR DESCRIPTION
## Summary
Takes *Grand Theft Auto V* (`PPSA04263`, RAGE) from **dying at an `int $0x41` fatal before any GPU work** to **clearing that fatal, submitting its first GPU frames, and running compute dispatches**. Three unimplemented user-space functions on the graphics/audio-init path — all returning 0 with untouched outputs — were the cause.

**Stacked on #1131 (#1129) and #1132 (#1130)** — those two prerequisite fixes are the first two commits here; the net-new change is the final commit (`hle: implement AGC GetSize, AprGetFileStat, AudioOut2 speaker-array size`). Review that commit; rebase drops the prereqs once #1131/#1132 merge.

## Failure scenario & fixes (all ABIs pinned from live `[RAGE]`-thread disassembly)
- **`sceAudioOut2GetSpeakerArrayMemorySize` (#1134) — the actual pre-render fatal.** It *returns* the speaker-array work-memory size in `rax`, which the guest uses verbatim as an allocation size (`r15 = ret; alloc(r15, 0x10)`). Stubbed to 0, the guest allocated a **0-byte** buffer and overran it, aborting audio init with `int $0x41` (deterministic, `eboot+0x2931628`). Implemented like the existing `sceAudioOut2ContextQueryMemory` null-backend precedent (fixed 1 MiB). Removing the stub is what lets the game reach the renderer.
- **`sceKernelAprGetFileStat` (#1133).** Returned 0 without filling its stat buffer; RAGE converts a buffer field as a FILETIME (`imul 1e7` + epoch `0x19db1ded53e8000`). Now looks the file id up in the APR registry, host-stats the file, and writes the standard `SceKernelStat` (reusing prosper's `write_sce_stat`).
- **AGC command-buffer `GetSize` cluster (#1137).** `sceAgcDcbJump/DcbAcquireMem/AcbAcquireMem/DcbRewind/CbNop/CbQueueEndOfPipeAction GetSize` returned 0, so the render thread's size accumulator reserved a 128-byte DrawCommandBuffer and the builders overflowed the guest `AgcDcb`. Each now returns its matching builder's dword count × 4 **bytes** (the render-thread accumulator is byte-based; some sizes are converted to dwords via `(n+3)>>2` — both confirmed by disassembly). Invariant: reserved ≥ written.

## Verification
- `cmake --build prosper/build-linux -j16 && ctest` → 128/128 pass (unchanged; `test_apr_registry` covers the WithPrefix resolve from #1132).
- Live route `PROSPER_GUEST_FS=1 ./prosper-app --dump PPSA04263-app0`: the `int $0x41` audio fatal is **gone**; the log shows GPU compute dispatches (`[compute] program ... 32x32x32`) and the frontend records a presented frame where before it recorded `0 presented frame(s)`. The game then reaches online/NP init and a **later, different** streamer fatal tracked in #1138.

## Honest scope / not claimed
This is **render-loop enablement**, not a verified visible milestone: the one frame captured before the #1138 fatal was truncated (write interrupted) and its visible portion was black (early-present). No title screen or confirmed on-screen content yet — so **no progression screenshot is attached** (per the repo rule that black/early-present output is not progression evidence). CONFIDENCE: MED (reverse-engineered ABIs; the speaker-array size is a generous null-backend value, safe because that buffer is only ever zero-filled here).

Fixes #1133
Fixes #1134
Fixes #1137
