### PR TITLE
tools(guest_bt): symbolicated guest-thread backtraces across the HLE stub

### DIFF
--- a/prosper/tools/guest_bt/.gitignore
+++ b/prosper/tools/guest_bt/.gitignore
@@ -1,0 +1,2 @@
+.cache/
+__pycache__/

--- a/prosper/tools/guest_bt/README.md
+++ b/prosper/tools/guest_bt/README.md
@@ -1,0 +1,85 @@
+# guest_bt — symbolicated GUEST-thread backtraces for prosper
+
+Answer *"what is this guest thread actually doing / waiting for?"* with a real call stack — including
+**managed C# method names** for IL2CPP/Unity titles — for any live or frozen prosper process.
+
+## Why gdb alone can't do this
+
+Two things defeat gdb's native unwinder on a prosper guest thread:
+
+1. **No frame pointers.** Unity's engine and IL2CPP-compiled C# are built `-fomit-frame-pointer`, so
+   gdb's fallback `rbp`-chain walk produces garbage. Correct unwinding needs each module's DWARF CFI
+   (`.eh_frame`) — but `tools/il2cpp/prx_to_elf.py` flattens the guest modules **without a section
+   header table** (it targets Il2CppDumper, which only reads program headers), so gdb finds no
+   `.eh_frame` section and never engages its DWARF unwinder.
+2. **The HLE stub boundary.** When guest code calls a Sony library function, it calls a prosper-
+   *synthesized* import stub in the `BOOT_STUB` region (`0x600000000`) which swaps `%fs` and tail-calls
+   the C++ HLE. That stub has no CFI at all, so even a CFI-aware unwinder dies at it with a bogus
+   `saved-rip = 0` — exactly the frame between the C++ HLE and the guest caller.
+
+`guest_bt` fixes both: it re-sections the flattened module ELFs so gdb gets real `.eh_frame` (and a
+`.symtab` of managed method names), and it teaches gdb to step *through* the stub with a custom
+unwinder derived from the swap-stub's fixed stack layout.
+
+## Pieces
+
+| file | role |
+|---|---|
+| `mk_sym_elf.py` | add a section header table (`.text`, `.eh_frame` located via `PT_GNU_EH_FRAME`, and an optional `.symtab` from an Il2CppDumper `script.json`) to a flattened module ELF |
+| `guest_bt_gdb.py` | gdb plugin: `add-symbol-file` each module at its runtime base, register the stub unwinder, expose `guest-bt [thread]` / `guest-bt-all` |
+| `guest_bt.py` | driver: parse a `PROSPER_INITLOG` module map, build/cache the sectioned ELFs, run gdb with the plugin |
+
+## Recipe
+
+1. Run the title once with the module map (and, for managed names, capture nothing extra — the map is
+   all `guest_bt.py` needs):
+
+       PROSPER_INITLOG=1 PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 \
+         ./screenshot <dump>-app0 ... 2> run.log
+
+2. (IL2CPP titles, once) build a managed symbol map — see `tools/il2cpp/README.md` — and keep the
+   resulting `script.json`.
+
+3. Backtrace a live/frozen instance:
+
+       python3 tools/guest_bt/guest_bt.py --pid $(pgrep -f <TITLEID> | head -1) \
+           --initlog run.log --il2cpp-script /path/script.json --all
+
+   `--thread GameUpdate` (id or name; kernel names are truncated to 15 chars, substring-matched) limits
+   it to one thread; omit `--all`/`--thread` to backtrace the currently-selected thread.
+
+The sectioned ELFs are cached under `tools/guest_bt/.cache/` (override with `--cache`), so repeat runs
+against the same title are instant.
+
+## Example (Terminator 2D, PPSA25872, a thread blocked in an HLE wait)
+
+```
+#1  prosper::k_wait_on_address(...)
+#2  0x60000ba9d in ??? ()                              <- HLE stub (bridged by the custom unwinder)
+#7  System.Threading.WaitHandle$$WaitOneNative
+#8  System.Threading.WaitHandle$$InternalWaitOne
+#9  Unity.PSN.PS5.Async.WorkerThread$$RunProc          <- named managed frame
+#10 System.Threading.ExecutionContext$$RunInternal
+#16 prosper::thread_trampoline(void*)
+```
+
+## The stub-unwind rule (how the bridge works)
+
+The `%fs`-swap stub (`emit_swap_stub` in `src/host/exec_image_linux.cpp`) pushes five qwords
+(`r11` + the four re-pushed stack args) and then `call`s the HLE. So at the stub's return site the
+guest caller's frame is a fixed distance away:
+
+    caller_sp = stub_frame_sp + 0x30      # 5 pushes (0x28) + the call's return slot
+    caller_pc = *(stub_frame_sp + 0x28)   # the guest return address the stub will `ret` to
+
+and every callee-saved register (`rbp rbx r12-r15`) is passed through unchanged — the stub only
+clobbers `rax/r10/r11`. If prosper's stub codegen ever changes this push sequence, update the offsets
+in `guest_bt_gdb.py._StubUnwinder` (and this note) together.
+
+## Limits
+
+- Managed (IL2CPP, `0x440000000..`) frames get method names; the Unity **player** eboot
+  (`0x410000000`) and system PRXs are stripped C++, so those frames show as bare `module+offset`.
+- The unwind is only as good as the modules' `.eh_frame`; a frame whose module ships no CFI ends the
+  walk. `mk_sym_elf.py` reports which modules had CFI.
+- Linux/`%fs`-swap stubs only. The Windows/macOS stub shapes differ; the rule would need porting.

--- a/prosper/tools/guest_bt/guest_bt.py
+++ b/prosper/tools/guest_bt/guest_bt.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# guest_bt.py — driver for the prosper guest-stack unwinder.
+#
+# One command turns a live/frozen prosper process into symbolicated GUEST backtraces (managed IL2CPP
+# method names included), stepping through prosper's synthesized HLE import stubs that defeat gdb's
+# native unwinder. See tools/guest_bt/README.md for the how/why.
+#
+# Typical use (attach to a running title and dump every guest thread):
+#   python3 tools/guest_bt/guest_bt.py --pid $(pgrep -f PPSA25872 | head -1) \
+#       --initlog run.log --dump /path/PPSA25872-app0 --all
+#
+# --initlog is any file containing prosper's `[initlog] module N base=0x.. path=..` lines (run the
+# title once with PROSPER_INITLOG=1). The driver flattens+sections each module (cached under --cache)
+# and, for the IL2CPP module, reuses an Il2CppDumper script.json for managed symbol names if one is
+# found next to the dump or passed via --il2cpp-script.
+import argparse, json, os, re, subprocess, sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+PRX2ELF = os.path.join(HERE, '..', 'il2cpp', 'prx_to_elf.py')
+MKSYM = os.path.join(HERE, 'mk_sym_elf.py')
+PLUGIN = os.path.join(HERE, 'guest_bt_gdb.py')
+IL2CPP_LO, IL2CPP_HI = 0x440000000, 0x4c0000000   # the il2cpp guest-address window (hle_file.cpp)
+
+def sh(cmd):
+    subprocess.run(cmd, check=True)
+
+def parse_initlog(path):
+    mods = []
+    rx = re.compile(r'\[initlog\] module \d+ base=0x([0-9a-f]+) .*path=(\S+)')
+    for ln in open(path, errors='replace'):
+        m = rx.search(ln)
+        if m:
+            mods.append((int(m.group(1), 16), m.group(2)))
+    if not mods:
+        sys.exit('guest_bt: no [initlog] lines in %s (run the title with PROSPER_INITLOG=1)' % path)
+    return mods
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--pid', type=int, required=True)
+    ap.add_argument('--initlog', required=True, help='file with prosper [initlog] module lines')
+    ap.add_argument('--dump', help='<TITLE>-app0 dir (to locate global-metadata.dat for symbol names)')
+    ap.add_argument('--il2cpp-script', help='Il2CppDumper script.json (managed method names)')
+    ap.add_argument('--cache', default=os.path.join(HERE, '.cache'))
+    ap.add_argument('--stub-base', default='0x600000000')
+    ap.add_argument('--stub-size', type=int, default=96)
+    ap.add_argument('--thread', help='thread id or name (e.g. GameUpdate); default = all')
+    ap.add_argument('--all', action='store_true', help='backtrace every guest thread')
+    ap.add_argument('--gdb', default='gdb')
+    args = ap.parse_args()
+
+    os.makedirs(args.cache, exist_ok=True)
+    mods = parse_initlog(args.initlog)
+
+    # locate an il2cpp script.json for managed symbolication (optional but high-value)
+    script = args.il2cpp_script
+    if not script and args.dump:
+        for cand in (os.path.join(args.cache, 'il2out', 'script.json'),):
+            if os.path.exists(cand):
+                script = cand
+                break
+
+    cfg_mods = []
+    for base, path in mods:
+        if not os.path.exists(path):
+            print('guest_bt: WARNING module missing on disk, skipping: %s' % path)
+            continue
+        tag = re.sub(r'\W+', '_', os.path.basename(path)) + ('_%x' % base)
+        flat = os.path.join(args.cache, tag + '.flat.elf')
+        sym = os.path.join(args.cache, tag + '.sym.elf')
+        if not os.path.exists(flat):
+            sh([sys.executable, PRX2ELF, path, flat])
+        if not os.path.exists(sym):
+            cmd = [sys.executable, MKSYM, flat, sym]
+            if script and IL2CPP_LO <= base < IL2CPP_HI:
+                cmd += ['--symbols', script]
+            sh(cmd)
+        cfg_mods.append({'elf': sym, 'base': '0x%x' % base})
+
+    cfg = {'modules': cfg_mods, 'stub_base': args.stub_base,
+           'stub_size': args.stub_size, 'stub_count': 65536}
+    cfg_path = os.path.join(args.cache, 'gbt_config.json')
+    json.dump(cfg, open(cfg_path, 'w'), indent=2)
+
+    cmd = args.thread or ''
+    gdb_cmd = 'guest-bt-all' if (args.all or not cmd) else ('guest-bt %s' % cmd)
+    env = dict(os.environ, PROSPER_GBT_CONFIG=cfg_path)
+    subprocess.run([args.gdb, '-p', str(args.pid), '-batch',
+                    '-ex', 'set debuginfod enabled off', '-ex', 'set pagination off',
+                    '-ex', 'source %s' % PLUGIN, '-ex', gdb_cmd], env=env)
+
+if __name__ == '__main__':
+    main()

--- a/prosper/tools/guest_bt/guest_bt_gdb.py
+++ b/prosper/tools/guest_bt/guest_bt_gdb.py
@@ -1,0 +1,126 @@
+# guest_bt_gdb.py — gdb plugin: symbolicated backtraces of prosper GUEST threads.
+#
+# The problem it solves: a guest thread blocked in an HLE (e.g. sceKernelWaitOnAddress) has, on its
+# stack, guest frames that gdb refuses to unwind — Unity/IL2CPP is built without frame pointers, and
+# prosper's synthesized import STUB (BOOT_STUB=0x600000000, no `.eh_frame`) sits between the C++ HLE
+# and the guest caller, so gdb's unwind dies at the stub with a bogus saved-rip=0.
+#
+# This plugin fixes both halves:
+#   * loads each guest module's flattened+sectioned ELF (see mk_sym_elf.py) at its runtime base, so
+#     gdb's DWARF unwinder has the modules' real CFI + a `.symtab` (managed method names for free), and
+#   * registers a custom Unwinder for the stub region that steps THROUGH a stub frame to the guest
+#     caller using the fixed swap-stub layout (5 pushes of 0x28 + the `call r10`):
+#         caller_sp  = stub_frame_sp + 0x30
+#         caller_pc  = *(stub_frame_sp + 0x28)          # the guest return address
+#     with all callee-saved registers passed through unchanged (the stub clobbers only rax/r10/r11).
+#
+# Config comes from the JSON file named by env PROSPER_GBT_CONFIG:
+#   { "modules": [ {"elf": "...", "base": "0x410000000"}, ... ],
+#     "stub_base": "0x600000000", "stub_size": 96, "stub_ret_off": 61 }
+# stub_ret_off is informational; the unwind rule keys only on PC being inside the stub region.
+#
+# Command:  guest-bt <thread-id-or-name>     e.g.  guest-bt GameUpdate
+import gdb, json, os, struct
+import gdb.unwinder
+
+_CFG = {}
+_STUB_LO = _STUB_HI = 0
+
+def _load_config():
+    global _CFG, _STUB_LO, _STUB_HI
+    path = os.environ.get('PROSPER_GBT_CONFIG')
+    if not path:
+        raise gdb.GdbError('PROSPER_GBT_CONFIG not set')
+    _CFG = json.load(open(path))
+    sb = int(_CFG['stub_base'], 0)
+    ss = int(_CFG.get('stub_size', 96))
+    n = int(_CFG.get('stub_count', 65536))
+    _STUB_LO, _STUB_HI = sb, sb + ss * n
+    for m in _CFG['modules']:
+        base = int(m['base'], 0)
+        try:
+            gdb.execute('add-symbol-file %s 0x%x' % (m['elf'], base), to_string=True)
+        except gdb.error as e:
+            print('guest-bt: add-symbol-file %s failed: %s' % (m['elf'], e))
+
+class _StubUnwinder(gdb.unwinder.Unwinder):
+    def __init__(self):
+        super().__init__('prosper-hle-stub')
+
+    def __call__(self, pending):
+        pc = int(pending.read_register('pc').cast(gdb.lookup_type('unsigned long')))
+        if not (_STUB_LO <= pc < _STUB_HI):
+            return None
+        sp = int(pending.read_register('sp').cast(gdb.lookup_type('unsigned long')))
+        caller_sp = sp + 0x30
+        try:
+            raw = gdb.selected_inferior().read_memory(sp + 0x28, 8)
+        except gdb.MemoryError:
+            return None
+        caller_pc = struct.unpack('<Q', raw)[0]
+        if caller_pc == 0:
+            return None
+        # FrameId(sp, pc): identify THIS (stub) frame by its CFA and pc.
+        fid = gdb.unwinder.FrameId(caller_sp, pc)
+        info = pending.create_unwind_info(fid)
+        ulong = gdb.lookup_type('unsigned long')
+        info.add_saved_register('pc', gdb.Value(caller_pc).cast(ulong))
+        info.add_saved_register('sp', gdb.Value(caller_sp).cast(ulong))
+        # Callee-saved survive the stub unchanged -> pass the inner-frame values straight through so
+        # the guest module's CFI can keep unwinding from a correct register file.
+        for r in ('rbp', 'rbx', 'r12', 'r13', 'r14', 'r15'):
+            try:
+                info.add_saved_register(r, pending.read_register(r))
+            except gdb.error:
+                pass
+        return info
+
+def _pick_thread(arg):
+    arg = (arg or '').strip()
+    inf = gdb.selected_inferior()
+    if not arg:
+        return gdb.selected_thread()
+    for t in inf.threads():
+        if str(t.num) == arg:
+            return t
+        name = t.name or ''
+        if name == arg or (t.ptid[1] and str(t.ptid[1]) == arg):
+            return t
+    # substring match on name (thread names are truncated by the kernel to 15 chars)
+    for t in inf.threads():
+        if arg[:15] in (t.name or ''):
+            return t
+    raise gdb.GdbError('no thread matching %r' % arg)
+
+class GuestBt(gdb.Command):
+    """guest-bt [thread] — symbolicated backtrace of a prosper guest thread across the HLE stub."""
+    def __init__(self):
+        super().__init__('guest-bt', gdb.COMMAND_STACK)
+
+    def invoke(self, arg, from_tty):
+        t = _pick_thread(arg)
+        t.switch()
+        print('=== guest-bt thread %s "%s" (LWP %s) ===' %
+              (t.num, t.name or '?', t.ptid[1]))
+        gdb.execute('bt')
+
+class GuestBtAll(gdb.Command):
+    """guest-bt-all — symbolicated backtrace of EVERY prosper guest thread (skips pure-host idlers)."""
+    def __init__(self):
+        super().__init__('guest-bt-all', gdb.COMMAND_STACK)
+
+    def invoke(self, arg, from_tty):
+        for t in gdb.selected_inferior().threads():
+            t.switch()
+            print('\n=== thread %s "%s" (LWP %s) ===' % (t.num, t.name or '?', t.ptid[1]))
+            try:
+                gdb.execute('bt')
+            except gdb.error as e:
+                print('  <bt failed: %s>' % e)
+
+_load_config()
+gdb.unwinder.register_unwinder(None, _StubUnwinder(), replace=True)
+GuestBt()
+GuestBtAll()
+print('guest-bt: loaded (%d modules, stub [0x%x,0x%x))' %
+      (len(_CFG.get('modules', [])), _STUB_LO, _STUB_HI))

--- a/prosper/tools/guest_bt/guest_bt_gdb.py
+++ b/prosper/tools/guest_bt/guest_bt_gdb.py
@@ -24,18 +24,26 @@ import gdb, json, os, struct
 import gdb.unwinder
 
 _CFG = {}
-_STUB_LO = _STUB_HI = 0
+_STUB_LO = _STUB_HI = _STUB_SIZE = 0
+# The ONLY stub PC that legitimately appears on the stack as a return address is the `call r10` return
+# site inside a slot: offset 61 for an implemented HLE (emit_impl_swap) and 66 for an unimplemented one
+# (emit_unimpl_swap has a 5-byte `mov edi,idx` prologue). Requiring the frame PC to land on one of these
+# slot offsets stops the rule from misfiring on a thread caught EXECUTING mid-stub (rip at some other
+# offset), whose live rsp is not the HLE CFA the rule assumes. Overridable via config "stub_ret_offsets".
+_STUB_RET_OFFS = (61, 66)
 
 def _load_config():
-    global _CFG, _STUB_LO, _STUB_HI
+    global _CFG, _STUB_LO, _STUB_HI, _STUB_SIZE, _STUB_RET_OFFS
     path = os.environ.get('PROSPER_GBT_CONFIG')
     if not path:
         raise gdb.GdbError('PROSPER_GBT_CONFIG not set')
     _CFG = json.load(open(path))
     sb = int(_CFG['stub_base'], 0)
-    ss = int(_CFG.get('stub_size', 96))
+    _STUB_SIZE = int(_CFG.get('stub_size', 96))
     n = int(_CFG.get('stub_count', 65536))
-    _STUB_LO, _STUB_HI = sb, sb + ss * n
+    _STUB_LO, _STUB_HI = sb, sb + _STUB_SIZE * n
+    if 'stub_ret_offsets' in _CFG:
+        _STUB_RET_OFFS = tuple(int(x) for x in _CFG['stub_ret_offsets'])
     for m in _CFG['modules']:
         base = int(m['base'], 0)
         try:
@@ -51,6 +59,8 @@ class _StubUnwinder(gdb.unwinder.Unwinder):
         pc = int(pending.read_register('pc').cast(gdb.lookup_type('unsigned long')))
         if not (_STUB_LO <= pc < _STUB_HI):
             return None
+        if (pc - _STUB_LO) % _STUB_SIZE not in _STUB_RET_OFFS:
+            return None   # a stub PC that isn't a `call r10` return site -> thread executing mid-stub
         sp = int(pending.read_register('sp').cast(gdb.lookup_type('unsigned long')))
         caller_sp = sp + 0x30
         try:

--- a/prosper/tools/guest_bt/mk_sym_elf.py
+++ b/prosper/tools/guest_bt/mk_sym_elf.py
@@ -53,31 +53,41 @@ def main(src, dst, script=None):
     loads = [p for p in phdrs if p['type'] == PT_LOAD and p['filesz'] > 0]
     # .text := the first executable LOAD (PF_X == 1); its whole span is fine for symbol/addr lookup.
     exe = next((p for p in loads if p['flags'] & 1), loads[0])
+    # gdb's single `add-symbol-file <elf> <base>` anchors ONE relocation delta on .text
+    # (delta = base - sh_addr(.text)), which then places BOTH the symbols and .eh_frame. That is only
+    # equal to the guest base when .text sits at vaddr 0 — which every PS5 SELF/PRX we load does. If a
+    # module ever breaks that, symbols and CFI would silently shift by exe['vaddr'] and produce a
+    # coherent-but-WRONG backtrace, so fail loudly instead.
+    if exe['vaddr'] != 0:
+        raise SystemExit('mk_sym_elf: executable LOAD is at vaddr 0x%x, not 0 — the single '
+                         'add-symbol-file base anchor would misplace symbols/.eh_frame' % exe['vaddr'])
 
-    # Locate .eh_frame via the .eh_frame_hdr the GNU_EH_FRAME segment points at.
+    # Locate .eh_frame via the .eh_frame_hdr the GNU_EH_FRAME segment points at. A module that ships no
+    # CFI is not fatal: emit .text (+ .symtab) so it still symbolicates, just without an unwind section
+    # (the walk simply ends at such a frame). guest_bt.py relies on this to never abort a whole run.
+    eh_frame_vaddr = eh_frame_off = eh_frame_size = 0
     ehh = next((p for p in phdrs if p['type'] == PT_GNU_EH_FRAME), None)
-    if not ehh:
-        raise SystemExit('mk_sym_elf: no PT_GNU_EH_FRAME — module ships no CFI')
-    ho = ehh['off']
-    ver, ptr_enc, cnt_enc, tbl_enc = b[ho], b[ho + 1], b[ho + 2], b[ho + 3]
-    assert ver == 1, 'eh_frame_hdr version %d' % ver
-    eh_frame_vaddr = read_encoded(b, ho + 4, ptr_enc, ehh['vaddr'] + 4)
-    # In a flattened ELF p_offset==p_vaddr, so file offset == vaddr for the loaded image.
-    eh_frame_off = eh_frame_vaddr
-    # Size: walk the CIE/FDE entries (each: u32 length, then body) until a 0-length terminator or the
-    # end of the containing LOAD — the EXACT extent, so a linear parser (pyelftools) never reads past
-    # the real CFI into unrelated segment bytes. A 64-bit-DWARF 0xffffffff length isn't used by
-    # .eh_frame, so treat it as a stop.
-    host = next(p for p in loads if p['vaddr'] <= eh_frame_vaddr < p['vaddr'] + p['filesz'])
-    seg_end = host['vaddr'] + host['filesz']
-    p = eh_frame_vaddr
-    while p + 4 <= seg_end:
-        ln = u32(b, p)
-        if ln == 0 or ln == 0xffffffff:
-            p += 4          # include the terminator word
-            break
-        p += 4 + ln
-    eh_frame_size = p - eh_frame_vaddr
+    if ehh:
+        ho = ehh['off']
+        ver, ptr_enc = b[ho], b[ho + 1]
+        assert ver == 1, 'eh_frame_hdr version %d' % ver
+        eh_frame_vaddr = read_encoded(b, ho + 4, ptr_enc, ehh['vaddr'] + 4)
+        # In a flattened ELF p_offset==p_vaddr, so file offset == vaddr for the loaded image.
+        eh_frame_off = eh_frame_vaddr
+        # Size: walk the CIE/FDE entries (each: u32 length, then body) until a 0-length terminator or
+        # the end of the containing LOAD — the EXACT extent, so a linear parser (pyelftools) never
+        # reads past the real CFI into unrelated segment bytes. .eh_frame is never 64-bit DWARF, so a
+        # 0xffffffff length is treated as a stop.
+        host = next(p for p in loads if p['vaddr'] <= eh_frame_vaddr < p['vaddr'] + p['filesz'])
+        seg_end = host['vaddr'] + host['filesz']
+        p = eh_frame_vaddr
+        while p + 4 <= seg_end:
+            ln = u32(b, p)
+            if ln == 0 or ln == 0xffffffff:
+                p += 4          # include the terminator word
+                break
+            p += 4 + ln
+        eh_frame_size = p - eh_frame_vaddr
 
     # --- build appended data: shstrtab, and (optional) symtab+strtab -------------------------------
     def cstr_table(names):
@@ -86,7 +96,8 @@ def main(src, dst, script=None):
             off[n] = len(blob); blob += n.encode() + b'\x00'
         return blob, off
 
-    sec_names = ['', '.text', '.eh_frame', '.shstrtab']
+    have_eh = eh_frame_size > 0
+    sec_names = ['', '.text'] + (['.eh_frame'] if have_eh else []) + ['.shstrtab']
     syms = []
     if script:
         sj = json.load(open(script))
@@ -95,7 +106,8 @@ def main(src, dst, script=None):
             if a is not None and n:
                 syms.append((a, n))
         syms.sort()
-        sec_names = ['', '.text', '.eh_frame', '.symtab', '.strtab', '.shstrtab']
+        sec_names = ['', '.text'] + (['.eh_frame'] if have_eh else []) + \
+                    ['.symtab', '.strtab', '.shstrtab']
 
     shstr_blob, shstr_off = cstr_table(sec_names)
 
@@ -136,7 +148,8 @@ def main(src, dst, script=None):
     idx = {n: i for i, n in enumerate(sec_names)}
     headers = [b'\x00' * 64]  # null
     headers.append(sh('.text', 1, 0x6, exe['vaddr'], exe['off'], exe['filesz'], align=16))          # PROGBITS AX
-    headers.append(sh('.eh_frame', 1, 0x2, eh_frame_vaddr, eh_frame_off, eh_frame_size, align=8))   # PROGBITS A
+    if have_eh:
+        headers.append(sh('.eh_frame', 1, 0x2, eh_frame_vaddr, eh_frame_off, eh_frame_size, align=8))  # PROGBITS A
     if script:
         nsym = 1 + len(syms)
         headers.append(sh('.symtab', 2, 0, 0, part_off['.symtab'], nsym * 24,

--- a/prosper/tools/guest_bt/mk_sym_elf.py
+++ b/prosper/tools/guest_bt/mk_sym_elf.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+# mk_sym_elf.py — turn a prosper-flattened guest module ELF (from tools/il2cpp/prx_to_elf.py,
+# which drops the section-header table so p_offset==p_vaddr) into one gdb can actually UNWIND and
+# SYMBOLICATE:
+#
+#   * a `.eh_frame` section header pointing at the module's real DWARF CFI (located through the
+#     PT_GNU_EH_FRAME / .eh_frame_hdr segment) — without a section named ".eh_frame" gdb never
+#     engages its DWARF unwinder, so `bt` stalls the moment frame pointers are absent (all of
+#     Unity/IL2CPP), and
+#   * an optional `.symtab` synthesised from an Il2CppDumper `script.json`, so every managed method
+#     shows up by name in `bt` for free (no post-processing).
+#
+# The input must already be flattened (prx_to_elf.py output): p_offset==p_vaddr, e_shoff==0.
+# Usage:
+#   python3 mk_sym_elf.py <flattened.elf> <out.elf> [--symbols script.json]
+#
+# Adding sections is append-only (segments/LOAD data are untouched), so the result still loads at
+# the same guest base via `add-symbol-file <out.elf> <base>`.
+import struct, sys, json
+
+def u16(b, o): return struct.unpack_from('<H', b, o)[0]
+def u32(b, o): return struct.unpack_from('<I', b, o)[0]
+def u64(b, o): return struct.unpack_from('<Q', b, o)[0]
+
+# DWARF EH pointer-encoding decode, just enough for the .eh_frame_hdr's eh_frame_ptr field.
+def read_encoded(buf, off, enc, pc):
+    fmt = enc & 0x0f
+    if   fmt == 0x03: v = u32(buf, off); n = 4          # DW_EH_PE_udata4
+    elif fmt == 0x0b: v = struct.unpack_from('<i', buf, off)[0]; n = 4  # sdata4
+    elif fmt == 0x04: v = u64(buf, off); n = 8          # udata8
+    elif fmt == 0x0c: v = struct.unpack_from('<q', buf, off)[0]; n = 8  # sdata8
+    else: raise SystemExit('mk_sym_elf: unsupported eh_frame_hdr ptr enc 0x%x' % enc)
+    app = enc & 0x70
+    if   app == 0x00: base = 0            # absptr
+    elif app == 0x10: base = pc           # pcrel (relative to the field's own vaddr)
+    else: raise SystemExit('mk_sym_elf: unsupported eh_frame_hdr ptr application 0x%x' % app)
+    return base + v
+
+def main(src, dst, script=None):
+    b = bytearray(open(src, 'rb').read())
+    assert b[:4] == b'\x7fELF', 'not an ELF'
+    assert b[4] == 2, 'not ELF64'
+    e_phoff = u64(b, 0x20); e_phnum = u16(b, 0x38); e_phentsize = u16(b, 0x36)
+    if u64(b, 0x28) != 0:
+        raise SystemExit('mk_sym_elf: input already has a section header table (not a flattened ELF)')
+
+    phdrs = []
+    for i in range(e_phnum):
+        o = e_phoff + i * e_phentsize
+        phdrs.append(dict(type=u32(b, o), flags=u32(b, o + 4), off=u64(b, o + 8),
+                          vaddr=u64(b, o + 0x10), filesz=u64(b, o + 0x28), memsz=u64(b, o + 0x30)))
+    PT_LOAD, PT_GNU_EH_FRAME = 1, 0x6474e550
+    loads = [p for p in phdrs if p['type'] == PT_LOAD and p['filesz'] > 0]
+    # .text := the first executable LOAD (PF_X == 1); its whole span is fine for symbol/addr lookup.
+    exe = next((p for p in loads if p['flags'] & 1), loads[0])
+
+    # Locate .eh_frame via the .eh_frame_hdr the GNU_EH_FRAME segment points at.
+    ehh = next((p for p in phdrs if p['type'] == PT_GNU_EH_FRAME), None)
+    if not ehh:
+        raise SystemExit('mk_sym_elf: no PT_GNU_EH_FRAME — module ships no CFI')
+    ho = ehh['off']
+    ver, ptr_enc, cnt_enc, tbl_enc = b[ho], b[ho + 1], b[ho + 2], b[ho + 3]
+    assert ver == 1, 'eh_frame_hdr version %d' % ver
+    eh_frame_vaddr = read_encoded(b, ho + 4, ptr_enc, ehh['vaddr'] + 4)
+    # In a flattened ELF p_offset==p_vaddr, so file offset == vaddr for the loaded image.
+    eh_frame_off = eh_frame_vaddr
+    # Size: walk the CIE/FDE entries (each: u32 length, then body) until a 0-length terminator or the
+    # end of the containing LOAD — the EXACT extent, so a linear parser (pyelftools) never reads past
+    # the real CFI into unrelated segment bytes. A 64-bit-DWARF 0xffffffff length isn't used by
+    # .eh_frame, so treat it as a stop.
+    host = next(p for p in loads if p['vaddr'] <= eh_frame_vaddr < p['vaddr'] + p['filesz'])
+    seg_end = host['vaddr'] + host['filesz']
+    p = eh_frame_vaddr
+    while p + 4 <= seg_end:
+        ln = u32(b, p)
+        if ln == 0 or ln == 0xffffffff:
+            p += 4          # include the terminator word
+            break
+        p += 4 + ln
+    eh_frame_size = p - eh_frame_vaddr
+
+    # --- build appended data: shstrtab, and (optional) symtab+strtab -------------------------------
+    def cstr_table(names):
+        blob = b'\x00'; off = {}
+        for n in names:
+            off[n] = len(blob); blob += n.encode() + b'\x00'
+        return blob, off
+
+    sec_names = ['', '.text', '.eh_frame', '.shstrtab']
+    syms = []
+    if script:
+        sj = json.load(open(script))
+        for m in sj.get('ScriptMethod', []):
+            a = m.get('Address'); n = m.get('Name')
+            if a is not None and n:
+                syms.append((a, n))
+        syms.sort()
+        sec_names = ['', '.text', '.eh_frame', '.symtab', '.strtab', '.shstrtab']
+
+    shstr_blob, shstr_off = cstr_table(sec_names)
+
+    # Assemble the appended region: the section-name/string/symbol tables, then the section header
+    # table. Everything is appended after the original file bytes (the LOAD segments are untouched),
+    # each part 8-aligned. part_off records each part's absolute file offset for its section header.
+    parts = []          # (name, bytes)
+    strtab_len = 0
+    if script:
+        str_blob, str_o = cstr_table([n for _, n in syms])
+        strtab_len = len(str_blob)
+        # Elf64_Sym = name(4) info(1) other(1) shndx(2) value(8) size(8); index 0 is the null symbol.
+        symtab = bytearray(24)
+        STT_FUNC, STB_GLOBAL, text_shndx = 2, 1, 1
+        for a, n in syms:
+            symtab += struct.pack('<IBBHQQ', str_o[n], (STB_GLOBAL << 4) | STT_FUNC, 0, text_shndx, a, 0)
+        parts += [('.strtab', bytes(str_blob)), ('.symtab', bytes(symtab))]
+    parts.append(('.shstrtab', bytes(shstr_blob)))
+
+    blob = bytearray()
+    part_off = {}
+    def align8():
+        while (len(b) + len(blob)) % 8:
+            blob.append(0)
+    for name, data in parts:
+        align8()
+        part_off[name] = len(b) + len(blob)
+        blob += data
+    align8()
+    shoff = len(b) + len(blob)
+    blob_all = blob
+
+    # Build section headers
+    def sh(name, typ, flags, addr, off, size, link=0, info=0, align=1, entsize=0):
+        return struct.pack('<IIQQQQIIQQ', shstr_off[name], typ, flags, addr, off, size,
+                           link, info, align, entsize)
+
+    idx = {n: i for i, n in enumerate(sec_names)}
+    headers = [b'\x00' * 64]  # null
+    headers.append(sh('.text', 1, 0x6, exe['vaddr'], exe['off'], exe['filesz'], align=16))          # PROGBITS AX
+    headers.append(sh('.eh_frame', 1, 0x2, eh_frame_vaddr, eh_frame_off, eh_frame_size, align=8))   # PROGBITS A
+    if script:
+        nsym = 1 + len(syms)
+        headers.append(sh('.symtab', 2, 0, 0, part_off['.symtab'], nsym * 24,
+                          link=idx['.strtab'], info=1, align=8, entsize=24))                          # SYMTAB
+        headers.append(sh('.strtab', 3, 0, 0, part_off['.strtab'], strtab_len, align=1))               # STRTAB
+    headers.append(sh('.shstrtab', 3, 0, 0, part_off['.shstrtab'], len(shstr_blob), align=1))         # STRTAB
+
+    shtab = b''.join(headers)
+    out = bytes(b) + bytes(blob_all) + shtab
+    # patch ELF header: e_shoff, e_shentsize, e_shnum, e_shstrndx
+    out = bytearray(out)
+    struct.pack_into('<Q', out, 0x28, shoff)
+    struct.pack_into('<H', out, 0x3a, 64)              # e_shentsize
+    struct.pack_into('<H', out, 0x3c, len(headers))    # e_shnum
+    struct.pack_into('<H', out, 0x3e, len(sec_names) - 1)  # e_shstrndx (.shstrtab is last)
+    open(dst, 'wb').write(out)
+    print('mk_sym_elf: %s -> %s  .text@0x%x(0x%x) .eh_frame@0x%x(0x%x) syms=%d shoff=0x%x'
+          % (src, dst, exe['vaddr'], exe['filesz'], eh_frame_vaddr, eh_frame_size,
+             len(syms), shoff))
+
+if __name__ == '__main__':
+    args = sys.argv[1:]
+    script = None
+    if '--symbols' in args:
+        i = args.index('--symbols'); script = args[i + 1]; del args[i:i + 2]
+    if len(args) != 2:
+        raise SystemExit('usage: mk_sym_elf.py <flattened.elf> <out.elf> [--symbols script.json]')
+    main(args[0], args[1], script)


### PR DESCRIPTION
## What & why

A reusable guest-stack unwinder: *"what is this guest thread actually waiting for?"* answered with a
real call stack — **including managed C# method names** for IL2CPP/Unity titles — for any live or
frozen prosper process.

gdb alone can't do this:
1. **No frame pointers** — Unity/IL2CPP is built `-fomit-frame-pointer`, so gdb's `rbp`-chain fallback
   yields garbage and it needs the modules' DWARF `.eh_frame`. But `tools/il2cpp/prx_to_elf.py`
   flattens modules **without a section header table**, so gdb finds no `.eh_frame` section.
2. **The HLE stub boundary** — every guest→Sony-library call goes through a prosper-*synthesized*
   import stub in `BOOT_STUB` (`0x600000000`) that has no CFI, so even a CFI-aware unwinder dies at it
   with a bogus `saved-rip=0` — exactly the frame between the C++ HLE and the guest caller.

## Pieces

- **`mk_sym_elf.py`** — re-sections a flattened module ELF: synthesizes `.text`, `.eh_frame` (located
  via the `PT_GNU_EH_FRAME`/`.eh_frame_hdr` segment, sized by walking the exact CIE/FDE extent), and an
  optional `.symtab` from an Il2CppDumper `script.json` (managed method names show up in `bt` for free).
- **`guest_bt_gdb.py`** — gdb plugin: `add-symbol-file` each guest module at its runtime base + a custom
  `Unwinder` for the stub region. The rule is derived from `emit_swap_stub`'s fixed layout (5 pushes of
  `0x28` + the `call`): `caller_sp = stub_sp + 0x30`, `caller_pc = *(stub_sp + 0x28)`, callee-saved
  passed through unchanged (the stub clobbers only `rax/r10/r11`). gdb then unwinds the guest modules
  with their real CFI. Commands: `guest-bt [thread]`, `guest-bt-all`.
- **`guest_bt.py`** — driver: parse a `PROSPER_INITLOG` module map, flatten+section each module
  (cached), run gdb with the plugin. One command for any title.

## Verification

Ran on **Terminator 2D (PPSA25872)**, a thread blocked in `sceKernelWaitOnAddress`:

```
#1  prosper::k_wait_on_address(...)
#2  0x60000ba9d in ??? ()                       <- HLE stub, bridged
#7  System.Threading.WaitHandle$$WaitOneNative
#8  System.Threading.WaitHandle$$InternalWaitOne
#9  Unity.PSN.PS5.Async.WorkerThread$$RunProc   <- named managed frame
#10 System.Threading.ExecutionContext$$RunInternal
#16 prosper::thread_trampoline(void*)
```

Unwinds cleanly across all 83 threads. **The coherence is the correctness signal**: a wrong stub
offset produces nonsensical frames, not a valid `.NET` worker-park chain. It also immediately corrected
a live misdiagnosis on #1110 — the kernel-named "GameUpdate" thread is actually an idle PSN async
worker, not the Unity main loop.

## Scope / risk

- **Tool-only — no prosper build or runtime change** (all new files under `tools/guest_bt/`).
- Needs `pyelftools` + gdb-with-Python. Managed frames get names; the stripped Unity **player** eboot
  and system PRXs show as bare `module+offset`.
- **Linux `%fs`-swap stubs only** — the Windows/macOS stub shapes differ (documented in the README and
  a code comment; the offsets live in one place next to a pointer back to `emit_swap_stub`).
- CI can't exercise it (needs a live process + dump); verified manually as above.

Motivating use: **#1110** (Terminator 2D past-splash) and every future "what's this thread waiting
for" investigation.