### PR TITLE
gpu/recompiler: lower RDNA2 MIMG op 0xa0 as image_sample — GTA V renders its Rockstar intro (was fully black)

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -8334,7 +8334,8 @@ RecompileCoverage recompile_coverage(const uint32_t* code, size_t dwords) {
                     // (0x27) from a 3D texture; sample_b (0x25) and gather4_lz (0x47) are 2D. 2D_ARRAY (dim 5)
                     // is accepted for all sample paths and handled as its base 2D slice (array index dropped,
                     // #325) — so array-sampling draws recompile+render instead of being skipped.
-                    if (i.opcode == 0x20u || i.opcode == 0x27u) return i.mimg_dim == 1u || i.mimg_dim == 2u || i.mimg_dim == 5u;
+                    // 0xa0 is the high-bit sibling of image_sample (0x20), lowered identically (GTA V, #1145).
+                    if (i.opcode == 0x20u || i.opcode == 0x27u || i.opcode == 0xa0u) return i.mimg_dim == 1u || i.mimg_dim == 2u || i.mimg_dim == 5u;
                     if (i.opcode == 0x2fu) return i.mimg_dim == 5u; // IMAGE_SAMPLE_C_LZ 2D_ARRAY
                     if (i.opcode == 0x24u || i.opcode == 0x25u || i.opcode == 0x47u) return i.mimg_dim == 1u || i.mimg_dim == 5u;
                     return false;

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -5869,7 +5869,16 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // image_sample_lz = 0x27 (LOD 0), image_gather4_lz = 0x47 (2x2 single-channel gather,
             // base level), image_load = 0x00 (integer texel fetch). Opcodes round-trip-verified
             // via llvm-mc gfx1010 (#273).
-            const bool is_sample = (in.opcode == 0x20), is_load = (in.opcode == 0x00);
+            // op 0xa0 = the high-bit sibling of IMAGE_SAMPLE (0x20): the decoder builds the 8-bit
+            // MIMG opcode as ((word0&1)<<7)|bits[24:18], so 0xa0 = 0x80|0x20. GTA V's (PPSA04263,
+            // RAGE) intro/composite pipeline (es=0x2042d6a200 / ps=0x2042d83c00) issues it as a plain
+            // 2D texture sample; rejecting it dropped that pipeline's draws and blacked the whole
+            // frame (#1140). Lowered as an ordinary implicit-LOD sample it renders the animated
+            // Rockstar Games intro logo correctly (live PPSA04263 capture). CONFIDENCE: MED — the base
+            // op and the "samples a 2D texture" behavior are live-title evidence; the exact high-bit
+            // family (an RDNA2 gfx10.3 sample variant) is not yet llvm-mc round-trip-verified, so a
+            // future title exercising its distinguishing modifier may need a dedicated lowering.
+            const bool is_sample = (in.opcode == 0x20) || (in.opcode == 0xa0), is_load = (in.opcode == 0x00);
             const bool is_sample_l = (in.opcode == 0x24), is_sample_lz = (in.opcode == 0x27);
             const bool is_sample_b = (in.opcode == 0x25), is_gather_lz = (in.opcode == 0x47);
             const bool is_sample_c_lz = (in.opcode == 0x2f);


### PR DESCRIPTION
## Summary
Takes *Grand Theft Auto V* (`PPSA04263`, RAGE) from a **fully black frame loop** to rendering its **animated Rockstar Games intro logo** — the first visible GTA V content in prosper. The black was a single unimplemented recompiler op, not the video/streaming subsystem previously suspected.

## Failure scenario
With the merged graphics-init fixes, GTA V runs a full frame loop (744 submits, 2235 draws/frame) but presents black. `PROSPER_DBG=1` pins it:
```
[recompile-reject] pc=20 words=f0800109,00c00904 fmt=14(MIMG) op=0xa0 dmask=0x1 dim=1 len=2
[exec-recompile-reject] es=0x2042d6a200 ps=0x2042d83c00 ... occurrence=1..256
```
The RDNA2→SPIR-V recompiler rejects **op 0xa0**, dropping GTA's composite/intro pipeline (`es=0x2042d6a200 / ps=0x2042d83c00`) across hundreds of draws → the whole frame blanks.

## Root cause & fix
op 0xa0 = the **high-bit sibling of `IMAGE_SAMPLE` (0x20)**. The MIMG opcode is 8 bits, assembled by the decoder as `((word0&1)<<7)|bits[24:18]` = `0x80|0x20`. It's on a second encoding axis a base-opcode audit misses, and no prior Unity/UE4/Godot title (Messenger/Dead Cells/B2/Evergate/DOLL) emitted it — so it was correctly a *fail-visible reject* until a title (GTA/RAGE) exercised it.

The fix lowers op 0xa0 as an ordinary implicit-LOD 2D `image_sample` in the MIMG dispatch (`prosper/src/gpu/rdna2_to_spirv.cpp`). One line + documentation.

## Visual result (reviewed with the project owner)
The live capture renders the **animated Rockstar Games R★ intro logo** with its signature lens-flare/scanline "TV warming up" aesthetic (frames vary through the animation). Reproduce:
```
PROSPER_GUEST_FS=1 PROSPER_FAULT_SKIP=0x2b2c463:0x2b2c465 \
PROSPER_APP_DUMP_FRAMES=1 PROSPER_DUMP_CONTENT=40000 PROSPER_FRAME_DIR=<dir> \
./prosper-app --dump PPSA04263-app0
```
Before this change: 0 non-black frames over a 10-minute run. After: 111 content frames, the richest with ~1000 distinct colors showing the logo. (Game imagery is gitignored/local-only per repo policy; screenshots were captured via the standard frame-dump frontend and reviewed by the owner. The `int 0x41` FAULT_SKIP is a separate soft-trap tracked in #1138, needed to keep the loop alive.)

## Affected / unaffected
- Affected: MIMG op 0xa0 now recompiles as a 2D sample instead of rejecting.
- Unaffected: every other op; the change is a pure addition to a previously-rejecting path, so it can only turn a *dropped* shader into a *rendered* one. No working title emits op 0xa0.

## Risk
Low. It only affects shaders that were already being rejected (dropped). CONFIDENCE: MED — the base op and 2D-sample behavior are live-title evidence and it renders correctly; the exact high-bit family (an RDNA2 gfx10.3 sample variant) is not yet llvm-mc round-trip-verified (follow-up in the issue).

## Verification (exact head)
- `cmake --build prosper/build-linux -j16 && ctest` → **128/128 pass**
- `python3 prosper/tools/snapshot/snapshot.py check` → **PASS all 4 baselines** (messenger-scene, evergate-title, dead-cells-gameplay, blasphemous2-gameplay) — no regression.

Fixes #1145
