### PR TITLE
perf(host): implement Linux GuestWriteWatch (texture dirty-tracking) — ~42x less texture cost (#1144)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -523,7 +523,7 @@ if(TARGET prosper_core)
   target_link_libraries(test_guest_read_cache_disabled PRIVATE prosper_core)
   add_test(NAME guest_read_cache_disabled COMMAND test_guest_read_cache_disabled)
 
-  if(WIN32)
+  if(WIN32 OR CMAKE_SYSTEM_NAME STREQUAL "Linux")
     add_executable(test_guest_write_watch tests/test_guest_write_watch.cpp)
     target_link_libraries(test_guest_write_watch PRIVATE prosper_core)
     add_test(NAME guest_write_watch COMMAND test_guest_write_watch)

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -7,6 +7,7 @@
 #include "dispatch.hpp"
 #include "nid.hpp"
 #include "heap_mutex.hpp"   // #707: keep the APR mutex off macOS __DATA
+#include "../host/guest_write_watch.hpp"   // #1144 B5: disarm texture watches before reading into guest mem
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -1131,6 +1132,11 @@ HLE(f_fcntl) {
 // null-derefs (the intermittent Il2cpp crash on the cutscene-scene load; see CUTSCENE_PROGRESSION.md).
 // Looping restores the full-read contract. Returns bytes read (== count on success), or -1/errno.
 static int64_t read_full(int fd, void* buf, size_t count, bool positioned, off_t off) {
+    // The kernel is about to store file bytes straight into this (identity-mapped) guest buffer. If it
+    // overlaps a read-only texture write-watch, the store would EFAULT; disarm the range first so the
+    // read succeeds, and mark it Dirty since its bytes are changing (#1144 B5). No-op off Linux / when
+    // nothing is armed.
+    host::guest_write_watch_notify_host_write(reinterpret_cast<uint64_t>(buf), count);
     size_t done = 0;
     while (done < count) {
         ssize_t r = positioned ? ::pread(fd, (char*)buf + done, count - done, off + (off_t)done)
@@ -1237,9 +1243,20 @@ HLE(f_pwrite) { return (uint64_t)write_full((int)a0, P(a1), (size_t)a2, true, (o
 // identity-mapped, so the guest iovec array and its buffers pass straight to host (p)readv/(p)writev.
 // These were MISSING -> the return-0 stub read as "0 bytes" (silent EOF for readv/preadv) / "0 written",
 // a corruption trap for any module that uses them (e.g. UE4's IO stack).
-HLE(f_readv)  { return (uint64_t)(int64_t)::readv((int)a0, (const struct iovec*)P(a1), (int)a2); }
+// Disarm any texture write-watch over each destination buffer of a vectored read before the kernel
+// stores into it, mirroring read_full (#1144 B5). No-op off Linux / when nothing is armed.
+static void disarm_iovec_watches(const struct iovec* v, int n) {
+    if (!v || n <= 0) return;
+    for (int i = 0; i < n; ++i)
+        if (v[i].iov_base && v[i].iov_len)
+            host::guest_write_watch_notify_host_write(
+                reinterpret_cast<uint64_t>(v[i].iov_base), v[i].iov_len);
+}
+HLE(f_readv)  { const struct iovec* v = (const struct iovec*)P(a1); disarm_iovec_watches(v, (int)a2);
+                return (uint64_t)(int64_t)::readv((int)a0, v, (int)a2); }
 HLE(f_writev) { return (uint64_t)(int64_t)::writev((int)a0, (const struct iovec*)P(a1), (int)a2); }
-HLE(f_preadv) { return (uint64_t)(int64_t)::preadv((int)a0, (const struct iovec*)P(a1), (int)a2, (off_t)a3); }
+HLE(f_preadv) { const struct iovec* v = (const struct iovec*)P(a1); disarm_iovec_watches(v, (int)a2);
+                return (uint64_t)(int64_t)::preadv((int)a0, v, (int)a2, (off_t)a3); }
 HLE(f_pwritev){ return (uint64_t)(int64_t)::pwritev((int)a0, (const struct iovec*)P(a1), (int)a2, (off_t)a3); }
 #else
 // Windows positioned/vectored IO. MinGW has no pread/pwrite/*v, and these previously returned -1

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -339,6 +339,11 @@ namespace {
         host::notify_guest_mapping_removed(base, len);
         for (const auto& m : retagged)
             host::notify_guest_mapping_added(m.base, m.size, m.committed && (prot & 0x1));
+        // Protection chokepoint for the texture write-watch (#1144 B3): a guest mprotect/mtypeprotect
+        // (or batch PROTECT) that flips a watched page's writability out from under our read-only arming
+        // must invalidate the watch — otherwise a subsequent CPU store would not fault yet the renderer
+        // would still read Unchanged. `guest_prot` carries the Sony bits the watch decodes.
+        host::guest_write_watch_notify_direct_mapping_protection(base, len, guest_prot);
     }
 
     // Re-tag direct mappings with a new memory type while preserving virtual-to-physical offset
@@ -586,8 +591,8 @@ namespace {
     // Map `len` bytes of the phys pool at `hint` (0 = anywhere). Falls back to anonymous memory
     // if the memfd is unavailable (still boots; loses aliasing). A zero-hint mapping honors the
     // caller's requested VA alignment; the old host-page-aligned mmap violated that ABI contract.
-    void* map_phys_at(uint64_t hint, uint64_t len, int prot, uint64_t phys, uint64_t align = 0,
-                      bool fixed = true) {
+    void* map_phys_at_impl(uint64_t hint, uint64_t len, int prot, uint64_t phys, uint64_t align,
+                           bool fixed) {
         int fd = dmem_fd();
         if (fd >= 0 && phys < kDmemBase + kDmemTotal) {
             if (!hint) {
@@ -632,6 +637,21 @@ namespace {
         if (!reserved) return nullptr;
         void* p = mmap(reserved, len, prot, MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0);
         if (p == MAP_FAILED) { munmap(reserved, len); return nullptr; }
+        return p;
+    }
+
+    // Single chokepoint for physical-dmem mapping. EVERY dmem alias (map_dmem, BatchMap MAP_DIRECT, Ampr
+    // push-map + its same-phys mirror) funnels through here, so the texture write-watch (#1144) learns
+    // the VA<->phys alias from one place — it can then arm every VA that maps a watched physical page,
+    // rather than only the ones a specific high-level API remembered to report (review B3). `prot` is
+    // host protection whose bits (READ=1/WRITE=2/EXEC=4) coincide with the Sony bits the watch decodes.
+    void* map_phys_at(uint64_t hint, uint64_t len, int prot, uint64_t phys, uint64_t align = 0,
+                      bool fixed = true) {
+        void* p = map_phys_at_impl(hint, len, prot, phys, align, fixed);
+        if (p)
+            host::guest_write_watch_notify_direct_mapping_added(
+                static_cast<uint64_t>(reinterpret_cast<uintptr_t>(p)), len, phys,
+                static_cast<uint32_t>(prot));
         return p;
     }
 }
@@ -849,12 +869,8 @@ static uint64_t map_dmem_impl(uint64_t addr_in_out, uint64_t len, uint64_t prot,
     if (addr_in_out) *(uint64_t*)addr_in_out = (uint64_t)p;
     track((uint64_t)p, len, host_prot(prot), static_cast<uint32_t>(prot), true,
           "direct", kVirtualQueryDirect, phys, memory_type);
-    // Feed the texture write-watch (#1144) the guest VA<->phys alias so it can dirty-track this
-    // dmem-backed GPU memory via mprotect instead of re-hashing it every submit. `prot` is the Sony
-    // protection (bit1 = CPU_WRITE), which the Linux GuestWriteWatch decodes directly. A new mapping
-    // over an already-watched phys page also invalidates that watch here (remap safety).
-    host::guest_write_watch_notify_direct_mapping_added((uint64_t)p, len, phys,
-                                                        static_cast<uint32_t>(prot));
+    // (The texture write-watch alias for this mapping is registered at the map_phys_at chokepoint above,
+    // which also covers BatchMap MAP_DIRECT and Ampr — see #1144 B3.)
     MLOG("map_dmem -> 0x%llx len=0x%llx phys=0x%llx prot=0x%llx flags=0x%llx align=0x%llx\n",
          (unsigned long long)p, (unsigned long long)len, (unsigned long long)phys,
          (unsigned long long)prot, (unsigned long long)flags, (unsigned long long)align);
@@ -1518,7 +1534,10 @@ HLE(k_batch_map) {
                               "batch-flex", kVirtualQueryFlexible);
                 break;
             }
-            case 1: if (start) { munmap((void*)(uintptr_t)start, len); untrack(start, len); } break;  // UNMAP
+            case 1: if (start) {                                                             // UNMAP
+                        host::guest_write_watch_notify_direct_mapping_removed(start, len);    // #1144 B3/B4
+                        munmap((void*)(uintptr_t)start, len); untrack(start, len);
+                    } break;
             case 2: case 4: {                                                            // PROTECT / TYPE_PROTECT
                 if (start) {
                     uint64_t protect_start = start, protect_len = len;

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -849,6 +849,12 @@ static uint64_t map_dmem_impl(uint64_t addr_in_out, uint64_t len, uint64_t prot,
     if (addr_in_out) *(uint64_t*)addr_in_out = (uint64_t)p;
     track((uint64_t)p, len, host_prot(prot), static_cast<uint32_t>(prot), true,
           "direct", kVirtualQueryDirect, phys, memory_type);
+    // Feed the texture write-watch (#1144) the guest VA<->phys alias so it can dirty-track this
+    // dmem-backed GPU memory via mprotect instead of re-hashing it every submit. `prot` is the Sony
+    // protection (bit1 = CPU_WRITE), which the Linux GuestWriteWatch decodes directly. A new mapping
+    // over an already-watched phys page also invalidates that watch here (remap safety).
+    host::guest_write_watch_notify_direct_mapping_added((uint64_t)p, len, phys,
+                                                        static_cast<uint32_t>(prot));
     MLOG("map_dmem -> 0x%llx len=0x%llx phys=0x%llx prot=0x%llx flags=0x%llx align=0x%llx\n",
          (unsigned long long)p, (unsigned long long)len, (unsigned long long)phys,
          (unsigned long long)prot, (unsigned long long)flags, (unsigned long long)align);
@@ -1037,6 +1043,10 @@ HLE(k_munmap) {
     constexpr uint64_t mask = kGuestPageSize - 1;
     if (!a0 || !a1 || (a0 & mask) || (a1 & mask) || a1 > UINT64_MAX - a0)
         return 0x80020016ull;
+    // Retire any texture write-watch over this VA BEFORE the pages disappear (#1144): invalidate the
+    // watch (its next query reads Dirty) and drop the alias so a later create can't mprotect a stale
+    // or reused mapping. Harmless for non-dmem ranges (no matching alias).
+    host::guest_write_watch_notify_direct_mapping_removed(a0, a1);
     if (munmap((void*)a0, a1) != 0) return 0x80020016ull;
     untrack(a0, a1);
     return 0;

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -2,6 +2,7 @@
 // on non-Linux so the shared (mingw) build is unaffected.
 #include "exec_image.hpp"
 #include "sse4a.hpp"
+#include "guest_write_watch.hpp"
 #include "fs_emu.hpp"
 #include "raw_syscall.hpp"
 #include "../hle/nid.hpp"
@@ -825,6 +826,13 @@ namespace {
         if ((sig == SIGSEGV || sig == SIGBUS) && try_emulate_fs_access((ucontext_t*)uctx, (uint64_t)si->si_addr))
             return;
 #endif
+        // Texture write-watch (#1144): a guest store into a page we armed read-only for cross-submit
+        // dirty-tracking. Restore the page (all its aliases) to writable, mark it dirty, and resume so
+        // the store re-executes. Returns false for any address we did not arm, so genuine guest faults
+        // fall through untouched. Only ever true when this handler is on the sigaltstack (red-zone-safe).
+        if (sig == SIGSEGV && si->si_addr &&
+            prosper::host::guest_write_watch_handle_fault(reinterpret_cast<uint64_t>(si->si_addr)))
+            return;
         // A SIGILL we did NOT emulate: log the faulting instruction bytes so the offending opcode can be
         // identified (another AMD-only ISA extension, or a decode miss in try_emulate_sse4a). #163-progress.
         if (sig == SIGILL) {
@@ -2060,6 +2068,10 @@ void install_trap_handler() {
     sa.sa_flags |= SA_ONSTACK;
 #endif
     if (getenv("PROSPER_FAULT_ONSTACK")) sa.sa_flags |= SA_ONSTACK;
+    // The texture write-watch (guest_write_watch.cpp) resolves its faults by return, not siglongjmp, so
+    // it is red-zone-safe ONLY when this handler runs on the sigaltstack. Tell it whether that holds;
+    // otherwise create() refuses to arm and callers keep the exact byte-comparison fallback (#1144).
+    prosper::host::guest_write_watch_set_fault_onstack((sa.sa_flags & SA_ONSTACK) != 0);
     sigemptyset(&sa.sa_mask);
     sigaction(SIGSEGV, &sa, nullptr);
     sigaction(SIGBUS,  &sa, nullptr);

--- a/prosper/src/host/guest_write_watch.cpp
+++ b/prosper/src/host/guest_write_watch.cpp
@@ -707,13 +707,24 @@ GuestWriteWatchStats guest_write_watch_stats() {
 }
 
 void guest_write_watch_set_fault_onstack(bool on_altstack) {
+#if defined(__linux__)
     state().fault_onstack.store(on_altstack, std::memory_order_release);
+#else
+    // Only Linux wires handle_fault to the write-protect fault (SIGSEGV). Darwin delivers a
+    // write-to-read-only-page fault as SIGBUS, which this handler is NOT hooked for, so an armed page's
+    // first guest store would crash. macOS uses SA_ONSTACK unconditionally, so without this guard the
+    // watch would arm and crash there. Keep fault_onstack false off Linux -> create() refuses to arm and
+    // callers keep the exact byte-comparison fallback (matching Windows). This is also the single switch
+    // that makes the whole watch (arming + the notify bookkeeping below) a no-op when the feature is off.
+    (void)on_altstack;
+#endif
 }
 
 void guest_write_watch_notify_direct_mapping_added(uint64_t addr, uint64_t size, uint64_t phys,
                                                     uint32_t protection) {
     if (!addr || !size || addr > UINT64_MAX - size || phys > UINT64_MAX - size) return;
     WatchState& w = state();
+    if (!w.fault_onstack.load(std::memory_order_acquire)) return;   // feature off -> table is never used
     std::lock_guard lock(w.mutex);
     const uint64_t begin = addr & ~(kPage - 1);
     const uint64_t end = (addr + size + kPage - 1) & ~(kPage - 1);
@@ -744,6 +755,7 @@ void guest_write_watch_notify_direct_mapping_added(uint64_t addr, uint64_t size,
 void guest_write_watch_notify_direct_mapping_removed(uint64_t addr, uint64_t size) {
     if (!addr || !size) return;
     WatchState& w = state();
+    if (!w.fault_onstack.load(std::memory_order_acquire)) return;   // feature off -> nothing tracked
     std::lock_guard lock(w.mutex);
     const uint64_t begin = addr & ~(kPage - 1);
     const uint64_t end = (addr + size + kPage - 1) & ~(kPage - 1);
@@ -756,15 +768,30 @@ void guest_write_watch_notify_direct_mapping_removed(uint64_t addr, uint64_t siz
 
 void guest_write_watch_notify_direct_mapping_protection(uint64_t addr, uint64_t size,
                                                         uint32_t protection) {
-    if (!addr || !size) return;
+    if (!addr || !size || addr > UINT64_MAX - size) return;
     WatchState& w = state();
+    if (!w.fault_onstack.load(std::memory_order_acquire)) return;   // feature off -> nothing tracked
     std::lock_guard lock(w.mutex);
     const uint64_t end = addr + size;
-    for (AliasRange& a : w.aliases)
-        if (a.addr < end && a.addr + a.size > addr) {
-            a.prot = protection;
-            invalidate_phys_range_locked(w, a.phys, a.phys + a.size);
-        }
+    // A guest re-protect may cover only PART of an alias. Overwriting the whole AliasRange.prot would
+    // mis-record the untouched remainder: if the change makes part read-only, the still-writable part
+    // would read as non-writable, a future create() would skip arming it, and a CPU write there would go
+    // undetected -> stale texture (review N2). Split each overlapping alias so ONLY the re-protected
+    // sub-range takes the new prot; the remainder keeps its own.
+    std::vector<AliasRange> split_out;
+    for (auto it = w.aliases.begin(); it != w.aliases.end();) {
+        const AliasRange a = *it;
+        const uint64_t a_end = a.addr + a.size;
+        if (!(a.addr < end && a_end > addr)) { ++it; continue; }
+        it = w.aliases.erase(it);
+        const uint64_t lo = std::max(a.addr, addr);   // re-protected sub-range [lo, hi)
+        const uint64_t hi = std::min(a_end, end);
+        if (a.addr < lo) split_out.push_back({a.addr, lo - a.addr, a.phys, a.prot});
+        split_out.push_back({lo, hi - lo, a.phys + (lo - a.addr), protection});
+        if (hi < a_end) split_out.push_back({hi, a_end - hi, a.phys + (hi - a.addr), a.prot});
+        invalidate_phys_range_locked(w, a.phys + (lo - a.addr), a.phys + (hi - a.addr));
+    }
+    for (const AliasRange& r : split_out) w.aliases.push_back(r);
 }
 
 void guest_write_watch_notify_physical_write(uint64_t phys, uint64_t size) {

--- a/prosper/src/host/guest_write_watch.cpp
+++ b/prosper/src/host/guest_write_watch.cpp
@@ -406,30 +406,352 @@ bool guest_write_watch_handle_fault(uint64_t addr) {
     return false;
 }
 
+void guest_write_watch_set_fault_onstack(bool) {}   // Windows never arms page-protection watches
+
 } // namespace prosper::host
 
-#else
+#else   // ---- Linux / macOS: real page-protection dirty-tracking (mprotect + SIGSEGV) --------------
+
+#include <sys/mman.h>
+
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+#include <vector>
 
 namespace prosper::host {
+namespace {
 
-GuestWriteWatch::~GuestWriteWatch() = default;
+constexpr uint64_t kPage = 0x1000;   // host page size (mprotect granularity)
+
+// Guest (Sony) protection flags -> host mmap prot, matching hle_kernel_mem.cpp host_prot():
+// bit0=CPU_READ, bit1=CPU_WRITE (implies read), bit2=EXEC. 0 == PROT_NONE.
+int host_prot(uint32_t p) {
+    int hp = 0;
+    if (p & 0x1) hp |= PROT_READ;
+    if (p & 0x2) hp |= PROT_READ | PROT_WRITE;
+    if (p & 0x4) hp |= PROT_EXEC;
+    return hp;
+}
+bool cpu_writable(uint32_t p) { return (p & 0x2) != 0; }
+
+struct AliasRange { uint64_t addr = 0, size = 0, phys = 0; uint32_t prot = 0; };
+struct PageAlias  { uint64_t addr = 0; uint32_t prot = 0; };
+// One physical page and every guest VA that currently maps it. `armed` == the pages are mprotect'd
+// read-only; a write fault clears it and bumps `generation` so any registration referencing this page
+// at the old generation reads Dirty.
+struct WatchedPage {
+    uint64_t phys = 0, generation = 0;
+    uint32_t references = 0;
+    bool armed = false;
+    std::vector<PageAlias> aliases;
+};
+struct RegistrationPage { WatchedPage* page = nullptr; uint64_t generation = 0; };
+struct Registration { std::vector<RegistrationPage> pages; };
+
+struct WatchState {
+    std::mutex mutex;
+    uint64_t next_id = 0;
+    std::vector<AliasRange> aliases;                                       // live dmem topology
+    std::unordered_map<uint64_t, std::unique_ptr<WatchedPage>> pages_by_phys;
+    std::unordered_map<uint64_t, WatchedPage*> pages_by_addr;              // page-aligned VA -> page
+    std::unordered_map<uint64_t, Registration> registrations;
+    std::atomic<bool> fault_onstack{false};                               // red-zone-safe gate
+};
+WatchState& state() { static WatchState* value = new WatchState; return *value; }
+
+struct AtomicStats {
+    std::atomic<uint64_t> create_attempts{0}, registrations{0}, registered_pages{0},
+        create_no_mapping{0}, create_incomplete_aliases{0}, create_protect_failures{0},
+        queries{0}, unchanged{0}, dirty{0}, unknown{0}, faults{0}, physical_writes{0}, rearms{0};
+};
+AtomicStats& stats() { static AtomicStats* value = new AtomicStats; return *value; }
+inline void bump(std::atomic<uint64_t>& c) { c.fetch_add(1, std::memory_order_relaxed); }
+
+const AliasRange* alias_at(const WatchState& w, uint64_t addr) {
+    for (const AliasRange& a : w.aliases)
+        if (addr >= a.addr && addr < a.addr + a.size) return &a;
+    return nullptr;
+}
+// All guest VAs currently mapping `phys` (page-granular). Returns false (leaving `out` empty) if the
+// page is unmapped or any alias is inaccessible (PROT_NONE) -> caller falls back to Unknown.
+bool collect_aliases(const WatchState& w, uint64_t phys, std::vector<PageAlias>& out) {
+    for (const AliasRange& a : w.aliases) {
+        if (phys < a.phys || phys + kPage > a.phys + a.size) continue;
+        if (a.prot == 0) return false;                    // PROT_NONE alias: cannot safely protect
+        out.push_back({a.addr + (phys - a.phys), a.prot});
+    }
+    return !out.empty();
+}
+
+// mprotect every writable alias of `pages` to read-only (arm) or back to its guest prot (disarm).
+// Read-only / PROT_NONE aliases are left untouched (a CPU store can't dirty them). Returns false and
+// rolls back on the first mprotect failure so the guest is never left with a wrong protection.
+bool set_pages_armed(const std::vector<WatchedPage*>& pages, bool arm) {
+    std::vector<std::pair<uint64_t, int>> done;   // (addr, prot-to-restore-on-rollback)
+    auto rollback = [&] {
+        for (auto it = done.rbegin(); it != done.rend(); ++it)
+            mprotect(reinterpret_cast<void*>(static_cast<uintptr_t>(it->first)), kPage, it->second);
+    };
+    for (WatchedPage* page : pages) {
+        if (!page || page->armed == arm) continue;
+        for (const PageAlias& al : page->aliases) {
+            if (!cpu_writable(al.prot)) continue;
+            const int full = host_prot(al.prot);
+            const int want = arm ? (full & ~PROT_WRITE) : full;
+            const int back = arm ? full : (full & ~PROT_WRITE);
+            if (mprotect(reinterpret_cast<void*>(static_cast<uintptr_t>(al.addr)), kPage, want) != 0) {
+                rollback();
+                return false;
+            }
+            done.push_back({al.addr, back});
+        }
+    }
+    for (WatchedPage* page : pages) if (page && page->armed != arm) page->armed = arm;
+    return true;
+}
+
+void release_registration_locked(WatchState& w,
+                                 std::unordered_map<uint64_t, Registration>::iterator reg) {
+    std::vector<WatchedPage*> released;
+    for (const RegistrationPage& rp : reg->second.pages) {
+        WatchedPage* page = rp.page;
+        if (!page || !page->references) continue;
+        if (--page->references) continue;
+        released.push_back(page);
+    }
+    set_pages_armed(released, false);
+    for (WatchedPage* page : released) {
+        for (const PageAlias& al : page->aliases) w.pages_by_addr.erase(al.addr);
+        w.pages_by_phys.erase(page->phys);
+    }
+    w.registrations.erase(reg);
+}
+
+// A dmem topology/protection change makes every currently-watched page overlapping the changed range
+// Dirty (bump generation) and unmapped from the address index; the next query reads Dirty/Unknown and
+// the renderer re-establishes a fresh watch. Called with the lock held.
+void invalidate_phys_range_locked(WatchState& w, uint64_t phys_begin, uint64_t phys_end) {
+    std::vector<WatchedPage*> hit;
+    for (auto& [phys, page] : w.pages_by_phys)
+        if (phys < phys_end && phys + kPage > phys_begin) hit.push_back(page.get());
+    set_pages_armed(hit, false);
+    for (WatchedPage* page : hit) page->generation++;
+}
+
+} // namespace
+
+GuestWriteWatch::~GuestWriteWatch() { reset(); }
 GuestWriteWatch::GuestWriteWatch(GuestWriteWatch&& other) noexcept
     : id_(std::exchange(other.id_, 0)) {}
 GuestWriteWatch& GuestWriteWatch::operator=(GuestWriteWatch&& other) noexcept {
-    if (this != &other) id_ = std::exchange(other.id_, 0);
+    if (this != &other) { reset(); id_ = std::exchange(other.id_, 0); }
     return *this;
 }
-GuestWriteWatch GuestWriteWatch::create(uint64_t, uint64_t) { return {}; }
-GuestWriteWatchQuery GuestWriteWatch::query() const { return GuestWriteWatchQuery::Unknown; }
-bool GuestWriteWatch::rearm() { return false; }
-void GuestWriteWatch::reset() { id_ = 0; }
-GuestWriteWatchStats guest_write_watch_stats() { return {}; }
-void guest_write_watch_notify_direct_mapping_added(uint64_t, uint64_t, uint64_t, uint32_t) {}
-void guest_write_watch_notify_direct_mapping_removed(uint64_t, uint64_t) {}
-void guest_write_watch_notify_direct_mapping_protection(uint64_t, uint64_t, uint32_t) {}
-void guest_write_watch_notify_physical_write(uint64_t, uint64_t) {}
-void guest_write_watch_invalidate_all() {}
-bool guest_write_watch_handle_fault(uint64_t) { return false; }
+
+GuestWriteWatch GuestWriteWatch::create(uint64_t addr, uint64_t size) {
+    bump(stats().create_attempts);
+    if (!addr || !size || addr > UINT64_MAX - size) return {};
+    WatchState& w = state();
+    // Red-zone safety: a write fault runs the SIGSEGV handler; without SA_ONSTACK the kernel writes the
+    // signal frame into the faulting store's red zone. Refuse until exec_image_linux confirms onstack.
+    if (!w.fault_onstack.load(std::memory_order_acquire)) { bump(stats().create_no_mapping); return {}; }
+
+    const uint64_t begin = addr & ~(kPage - 1);
+    const uint64_t end = (addr + size + kPage - 1) & ~(kPage - 1);
+    std::lock_guard lock(w.mutex);
+
+    // First pass: resolve every guest page to a physical page whose full alias set is known. Any gap
+    // (non-dmem heap, PROT_NONE alias, unmapped) aborts to Unknown WITHOUT touching protections.
+    struct Resolved { uint64_t phys; std::vector<PageAlias> aliases; };
+    std::vector<Resolved> resolved;
+    for (uint64_t va = begin; va < end; va += kPage) {
+        const AliasRange* a = alias_at(w, va);
+        if (!a) { bump(stats().create_no_mapping); return {}; }
+        const uint64_t phys = a->phys + (va - a->addr);
+        std::vector<PageAlias> al;
+        if (!collect_aliases(w, phys, al)) { bump(stats().create_incomplete_aliases); return {}; }
+        resolved.push_back({phys, std::move(al)});
+    }
+
+    // Second pass: get-or-create the WatchedPage per phys, arm newly-referenced pages, build the reg.
+    const uint64_t id = ++w.next_id;
+    Registration reg;
+    std::vector<WatchedPage*> to_arm;
+    for (Resolved& r : resolved) {
+        auto it = w.pages_by_phys.find(r.phys);
+        WatchedPage* page;
+        if (it == w.pages_by_phys.end()) {
+            auto up = std::make_unique<WatchedPage>();
+            up->phys = r.phys; up->aliases = std::move(r.aliases);
+            page = up.get();
+            w.pages_by_phys.emplace(r.phys, std::move(up));
+            for (const PageAlias& al : page->aliases) w.pages_by_addr[al.addr & ~(kPage - 1)] = page;
+            to_arm.push_back(page);
+        } else {
+            page = it->second.get();
+        }
+        page->references++;
+        reg.pages.push_back({page, page->generation});
+    }
+    if (!set_pages_armed(to_arm, true)) {
+        // Undo references + any pages we just created; report protect failure -> Unknown.
+        for (const RegistrationPage& rp : reg.pages)
+            if (rp.page && rp.page->references) rp.page->references--;
+        for (WatchedPage* page : to_arm) {
+            for (const PageAlias& al : page->aliases) w.pages_by_addr.erase(al.addr & ~(kPage - 1));
+            w.pages_by_phys.erase(page->phys);
+        }
+        bump(stats().create_protect_failures);
+        return {};
+    }
+    bump(stats().registrations);
+    stats().registered_pages.fetch_add(reg.pages.size(), std::memory_order_relaxed);
+    w.registrations.emplace(id, std::move(reg));
+    return GuestWriteWatch(id);
+}
+
+GuestWriteWatchQuery GuestWriteWatch::query() const {
+    bump(stats().queries);
+    if (!id_) { bump(stats().unknown); return GuestWriteWatchQuery::Unknown; }
+    WatchState& w = state();
+    std::lock_guard lock(w.mutex);
+    auto found = w.registrations.find(id_);
+    if (found == w.registrations.end()) { bump(stats().unknown); return GuestWriteWatchQuery::Unknown; }
+    for (const RegistrationPage& rp : found->second.pages) {
+        if (!rp.page || !rp.page->armed || rp.page->generation != rp.generation) {
+            bump(stats().dirty);
+            return GuestWriteWatchQuery::Dirty;
+        }
+    }
+    bump(stats().unchanged);
+    return GuestWriteWatchQuery::Unchanged;
+}
+
+bool GuestWriteWatch::rearm() {
+    if (!id_) return false;
+    WatchState& w = state();
+    std::lock_guard lock(w.mutex);
+    auto found = w.registrations.find(id_);
+    if (found == w.registrations.end()) return false;
+    std::vector<WatchedPage*> pages;
+    for (const RegistrationPage& rp : found->second.pages) if (rp.page) pages.push_back(rp.page);
+    if (!set_pages_armed(pages, true)) return false;   // couldn't re-protect -> caller re-creates
+    for (RegistrationPage& rp : found->second.pages) if (rp.page) rp.generation = rp.page->generation;
+    bump(stats().rearms);
+    return true;
+}
+
+void GuestWriteWatch::reset() {
+    if (!id_) return;
+    WatchState& w = state();
+    std::lock_guard lock(w.mutex);
+    auto found = w.registrations.find(id_);
+    if (found != w.registrations.end()) release_registration_locked(w, found);
+    id_ = 0;
+}
+
+GuestWriteWatchStats guest_write_watch_stats() {
+    AtomicStats& v = stats();
+    return {v.create_attempts.load(), v.registrations.load(), v.registered_pages.load(),
+            v.create_no_mapping.load(), v.create_incomplete_aliases.load(),
+            v.create_protect_failures.load(), v.queries.load(), v.unchanged.load(), v.dirty.load(),
+            v.unknown.load(), v.faults.load(), v.physical_writes.load(), v.rearms.load()};
+}
+
+void guest_write_watch_set_fault_onstack(bool on_altstack) {
+    state().fault_onstack.store(on_altstack, std::memory_order_release);
+}
+
+void guest_write_watch_notify_direct_mapping_added(uint64_t addr, uint64_t size, uint64_t phys,
+                                                    uint32_t protection) {
+    if (!addr || !size || addr > UINT64_MAX - size || phys > UINT64_MAX - size) return;
+    WatchState& w = state();
+    std::lock_guard lock(w.mutex);
+    // A new mapping over a watched phys range changes topology -> invalidate; then record the alias.
+    invalidate_phys_range_locked(w, phys, phys + size);
+    w.aliases.push_back({addr, size, phys, protection});
+}
+
+void guest_write_watch_notify_direct_mapping_removed(uint64_t addr, uint64_t size) {
+    if (!addr || !size) return;
+    WatchState& w = state();
+    std::lock_guard lock(w.mutex);
+    const uint64_t end = addr + size;
+    std::vector<uint64_t> dead_phys;
+    for (const AliasRange& a : w.aliases)
+        if (a.addr < end && a.addr + a.size > addr) dead_phys.push_back(a.phys);
+    for (uint64_t phys : dead_phys) invalidate_phys_range_locked(w, phys, phys + kPage);
+    w.aliases.erase(std::remove_if(w.aliases.begin(), w.aliases.end(),
+                                   [&](const AliasRange& a) {
+                                       return a.addr < end && a.addr + a.size > addr;
+                                   }),
+                    w.aliases.end());
+    // Pages whose every alias just vanished can never fault again; drop them from the addr index so a
+    // stale mprotect can't linger (their generation was already bumped above -> queries read Dirty).
+}
+
+void guest_write_watch_notify_direct_mapping_protection(uint64_t addr, uint64_t size,
+                                                        uint32_t protection) {
+    if (!addr || !size) return;
+    WatchState& w = state();
+    std::lock_guard lock(w.mutex);
+    const uint64_t end = addr + size;
+    for (AliasRange& a : w.aliases)
+        if (a.addr < end && a.addr + a.size > addr) {
+            a.prot = protection;
+            invalidate_phys_range_locked(w, a.phys, a.phys + a.size);
+        }
+}
+
+void guest_write_watch_notify_physical_write(uint64_t phys, uint64_t size) {
+    if (!size) return;
+    WatchState& w = state();
+    std::lock_guard lock(w.mutex);
+    bump(stats().physical_writes);
+    invalidate_phys_range_locked(w, phys, phys + size);
+}
+
+void guest_write_watch_invalidate_all() {
+    WatchState& w = state();
+    std::lock_guard lock(w.mutex);
+    std::vector<WatchedPage*> all;
+    all.reserve(w.pages_by_phys.size());
+    for (auto& [phys, page] : w.pages_by_phys) { (void)phys; all.push_back(page.get()); }
+    set_pages_armed(all, false);
+    for (WatchedPage* page : all) page->generation++;
+}
+
+// Called from the SIGSEGV handler (exec_image_linux fault_handler) for every write fault. Returns true
+// ONLY for an address we armed: it disarms that physical page's aliases (so the store re-executes and
+// succeeds) and bumps the generation so the owning registration reads Dirty. Returns false otherwise,
+// so a genuine guest fault is untouched. Must be async-signal-safe: a plain mutex is not, so this uses
+// try_lock and, on contention, leaves the page armed (the store re-faults and retries) rather than
+// blocking in signal context.
+bool guest_write_watch_handle_fault(uint64_t addr) {
+    WatchState& w = state();
+    if (!w.fault_onstack.load(std::memory_order_acquire)) return false;
+    std::unique_lock<std::mutex> lock(w.mutex, std::try_to_lock);
+    if (!lock.owns_lock()) return false;   // contended: not ours to resolve right now, let it re-fault
+    auto it = w.pages_by_addr.find(addr & ~(kPage - 1));
+    if (it == w.pages_by_addr.end() || !it->second || !it->second->armed) return false;
+    WatchedPage* page = it->second;
+    // Allocation-free (signal context): restore write directly on the page's aliases. mprotect is a
+    // syscall; the alias vector is already allocated and mutation-protected by the held lock. Do NOT
+    // call set_pages_armed here — its rollback vector would malloc, which can deadlock a thread caught
+    // mid-allocation. If an mprotect fails we still mark dirty; the worst case is a stale RO alias that
+    // re-faults into this same path.
+    for (const PageAlias& al : page->aliases)
+        if (cpu_writable(al.prot))
+            mprotect(reinterpret_cast<void*>(static_cast<uintptr_t>(al.addr)), kPage, host_prot(al.prot));
+    page->armed = false;
+    page->generation++;
+    bump(stats().faults);
+    return true;
+}
 
 } // namespace prosper::host
 

--- a/prosper/src/host/guest_write_watch.cpp
+++ b/prosper/src/host/guest_write_watch.cpp
@@ -401,6 +401,9 @@ void guest_write_watch_invalidate_all() {
     clear_locked(watch);
 }
 
+// Windows never arms pages (create() always refuses), so a host/kernel write can never EFAULT here.
+void guest_write_watch_notify_host_write(uint64_t, uint64_t) {}
+
 bool guest_write_watch_handle_fault(uint64_t addr) {
     (void)addr;
     return false;
@@ -412,6 +415,7 @@ void guest_write_watch_set_fault_onstack(bool) {}   // Windows never arms page-p
 
 #else   // ---- Linux / macOS: real page-protection dirty-tracking (mprotect + SIGSEGV) --------------
 
+#include <sched.h>
 #include <sys/mman.h>
 
 #include <algorithm>
@@ -475,6 +479,13 @@ const AliasRange* alias_at(const WatchState& w, uint64_t addr) {
     for (const AliasRange& a : w.aliases)
         if (addr >= a.addr && addr < a.addr + a.size) return &a;
     return nullptr;
+}
+// Does any recorded alias overlap [begin, end)? O(alias ranges). Lets the notify hooks skip the O(watched
+// pages) purge on the common path: a fresh VA (no reuse) or a non-dmem munmap (every guest heap free).
+bool va_range_has_alias(const WatchState& w, uint64_t begin, uint64_t end) {
+    for (const AliasRange& a : w.aliases)
+        if (a.addr < end && a.addr + a.size > begin) return true;
+    return false;
 }
 // All guest VAs currently mapping `phys` (page-granular). Returns false (leaving `out` empty) if the
 // page is unmapped or any alias is inaccessible (PROT_NONE) -> caller falls back to Unknown.
@@ -540,6 +551,39 @@ void invalidate_phys_range_locked(WatchState& w, uint64_t phys_begin, uint64_t p
         if (phys < phys_end && phys + kPage > phys_begin) hit.push_back(page.get());
     set_pages_armed(hit, false);
     for (WatchedPage* page : hit) page->generation++;
+}
+
+// Drop every page-granular alias whose VA falls in [begin, end) from its WatchedPage: remove it from the
+// page's alias list AND from the address index, and bump the page's generation (topology changed -> the
+// next query reads Dirty). This is what resolves review B4: no stale VA survives in pages_by_addr for a
+// later handle_fault to mprotect after the VA has been unmapped/reused. Does NOT mprotect the vanishing
+// VAs (the caller is unmapping/remapping them; the kernel drops their protection) and — critically — does
+// NOT free the WatchedPage: page lifetime is reference-counted and owned by release_registration_locked,
+// so freeing one here would dangle a live Registration's raw pointer. A page that loses its last alias
+// just lingers, disarmed and Dirty, until its owning registration resets. Called with the lock held.
+void purge_va_range_locked(WatchState& w, uint64_t begin, uint64_t end, bool remove_topology) {
+    for (auto& [phys, pageptr] : w.pages_by_phys) {
+        (void)phys;
+        WatchedPage* page = pageptr.get();
+        bool changed = false;
+        for (auto ai = page->aliases.begin(); ai != page->aliases.end();) {
+            const uint64_t apage = ai->addr & ~(kPage - 1);
+            if (apage < end && apage + kPage > begin) {
+                w.pages_by_addr.erase(apage);
+                ai = page->aliases.erase(ai);
+                changed = true;
+            } else {
+                ++ai;
+            }
+        }
+        if (changed) page->generation++;
+    }
+    if (remove_topology)
+        w.aliases.erase(std::remove_if(w.aliases.begin(), w.aliases.end(),
+                                       [&](const AliasRange& a) {
+                                           return a.addr < end && a.addr + a.size > begin;
+                                       }),
+                        w.aliases.end());
 }
 
 } // namespace
@@ -671,27 +715,43 @@ void guest_write_watch_notify_direct_mapping_added(uint64_t addr, uint64_t size,
     if (!addr || !size || addr > UINT64_MAX - size || phys > UINT64_MAX - size) return;
     WatchState& w = state();
     std::lock_guard lock(w.mutex);
-    // A new mapping over a watched phys range changes topology -> invalidate; then record the alias.
-    invalidate_phys_range_locked(w, phys, phys + size);
+    const uint64_t begin = addr & ~(kPage - 1);
+    const uint64_t end = (addr + size + kPage - 1) & ~(kPage - 1);
+    // VA-reuse safety: only if this VA range still carries stale coverage (rare: a MAP_FIXED reuse of a VA
+    // never unmapped) do we purge it and its topology before recording the new alias, so alias_at() can't
+    // resolve to the old phys. The common fresh-VA path skips the O(watched pages) scan.
+    if (va_range_has_alias(w, begin, end)) purge_va_range_locked(w, begin, end, /*remove_topology=*/true);
     w.aliases.push_back({addr, size, phys, protection});
+
+    // A new alias to an already-watched physical page must be armed too, or a write through it would not
+    // fault and the renderer would trust a stale texture (review B2). Same-phys aliasing does not change
+    // content, so we do NOT bump generation — we extend the page's alias set and arm the new VA in place.
+    if (!cpu_writable(protection) || w.pages_by_phys.empty()) return;   // nothing armed to extend
+    for (uint64_t off = 0; off < size; off += kPage) {
+        auto it = w.pages_by_phys.find(phys + off);
+        if (it == w.pages_by_phys.end()) continue;
+        WatchedPage* page = it->second.get();
+        const uint64_t va = (addr + off) & ~(kPage - 1);
+        page->aliases.push_back({va, protection});
+        w.pages_by_addr[va] = page;
+        if (page->armed &&
+            mprotect(reinterpret_cast<void*>(static_cast<uintptr_t>(va)), kPage,
+                     host_prot(protection) & ~PROT_WRITE) != 0)
+            page->generation++;   // couldn't arm the new alias -> mark Dirty so the renderer re-creates
+    }
 }
 
 void guest_write_watch_notify_direct_mapping_removed(uint64_t addr, uint64_t size) {
     if (!addr || !size) return;
     WatchState& w = state();
     std::lock_guard lock(w.mutex);
-    const uint64_t end = addr + size;
-    std::vector<uint64_t> dead_phys;
-    for (const AliasRange& a : w.aliases)
-        if (a.addr < end && a.addr + a.size > addr) dead_phys.push_back(a.phys);
-    for (uint64_t phys : dead_phys) invalidate_phys_range_locked(w, phys, phys + kPage);
-    w.aliases.erase(std::remove_if(w.aliases.begin(), w.aliases.end(),
-                                   [&](const AliasRange& a) {
-                                       return a.addr < end && a.addr + a.size > addr;
-                                   }),
-                    w.aliases.end());
-    // Pages whose every alias just vanished can never fault again; drop them from the addr index so a
-    // stale mprotect can't linger (their generation was already bumped above -> queries read Dirty).
+    const uint64_t begin = addr & ~(kPage - 1);
+    const uint64_t end = (addr + size + kPage - 1) & ~(kPage - 1);
+    // k_munmap calls this for EVERY unmap (including non-dmem heap frees); skip the O(watched pages) scan
+    // unless a dmem alias actually overlaps. When one does, drop coverage for EVERY page of the removed
+    // range (not just the first) and delete emptied pages so no stale WatchedPage / pages_by_addr entry
+    // survives to mprotect a reused VA later (review B4).
+    if (va_range_has_alias(w, begin, end)) purge_va_range_locked(w, begin, end, /*remove_topology=*/true);
 }
 
 void guest_write_watch_notify_direct_mapping_protection(uint64_t addr, uint64_t size,
@@ -715,6 +775,31 @@ void guest_write_watch_notify_physical_write(uint64_t phys, uint64_t size) {
     invalidate_phys_range_locked(w, phys, phys + size);
 }
 
+void guest_write_watch_notify_host_write(uint64_t addr, uint64_t size) {
+    if (!addr || !size || addr > UINT64_MAX - size) return;
+    WatchState& w = state();
+    // Hot path: the HLE calls this before EVERY read()/pread(), mostly into non-dmem heap buffers. When
+    // the feature is off (the default) nothing is ever armed, so skip without even taking the lock.
+    if (!w.fault_onstack.load(std::memory_order_acquire)) return;
+    std::lock_guard lock(w.mutex);
+    // A host/kernel store into an armed (read-only) guest page would EFAULT — e.g. sceKernelPread
+    // streaming texture bytes straight into a watched dmem buffer returns an I/O error where real
+    // hardware succeeds (review B5). The HLE calls this by guest VA range BEFORE such a write: restore
+    // write on the overlapping pages so the store lands, and bump their generation so the watch reads
+    // Dirty (the bytes are about to change). Runs in normal context, so set_pages_armed may allocate.
+    const uint64_t begin = addr & ~(kPage - 1);
+    const uint64_t end = (addr + size + kPage - 1) & ~(kPage - 1);
+    if (!va_range_has_alias(w, begin, end)) return;   // not a dmem buffer -> skip the per-page scan
+    std::vector<WatchedPage*> hit;
+    for (uint64_t va = begin; va < end; va += kPage) {
+        auto it = w.pages_by_addr.find(va);
+        if (it != w.pages_by_addr.end() && it->second) hit.push_back(it->second);
+    }
+    if (hit.empty()) return;
+    set_pages_armed(hit, false);
+    for (WatchedPage* page : hit) page->generation++;
+}
+
 void guest_write_watch_invalidate_all() {
     WatchState& w = state();
     std::lock_guard lock(w.mutex);
@@ -735,21 +820,38 @@ bool guest_write_watch_handle_fault(uint64_t addr) {
     WatchState& w = state();
     if (!w.fault_onstack.load(std::memory_order_acquire)) return false;
     std::unique_lock<std::mutex> lock(w.mutex, std::try_to_lock);
-    if (!lock.owns_lock()) return false;   // contended: not ours to resolve right now, let it re-fault
+    if (!lock.owns_lock()) {
+        // Contended. We CANNOT decide ownership without the lock (pages_by_addr is being mutated), and
+        // returning false here would fall through the caller's fault handler to a fatal _exit — even
+        // though this may well be a watched page whose store just raced an arm/rearm. Instead resume:
+        // the page is still read-only, so the store re-executes and re-faults, retrying until the lock
+        // frees. The lock is only ever held for bounded, non-blocking work (create/rearm/query/notify),
+        // so it always frees; a genuine (non-watched) fault then re-enters, wins the lock, and takes the
+        // false path below into the real fault handler. sched_yield keeps the retry from spinning hot.
+        sched_yield();
+        return true;
+    }
     auto it = w.pages_by_addr.find(addr & ~(kPage - 1));
     if (it == w.pages_by_addr.end() || !it->second || !it->second->armed) return false;
     WatchedPage* page = it->second;
     // Allocation-free (signal context): restore write directly on the page's aliases. mprotect is a
     // syscall; the alias vector is already allocated and mutation-protected by the held lock. Do NOT
     // call set_pages_armed here — its rollback vector would malloc, which can deadlock a thread caught
-    // mid-allocation. If an mprotect fails we still mark dirty; the worst case is a stale RO alias that
-    // re-faults into this same path.
-    for (const PageAlias& al : page->aliases)
-        if (cpu_writable(al.prot))
-            mprotect(reinterpret_cast<void*>(static_cast<uintptr_t>(al.addr)), kPage, host_prot(al.prot));
-    page->armed = false;
-    page->generation++;
+    // mid-allocation. Track whether the FAULTING alias itself was restored: if that mprotect failed the
+    // store would re-fault forever, so keep the page armed (retry) rather than clearing it and dropping
+    // into the fatal handler on the next fault. Disarming (RO->RW) merges VMAs and effectively never
+    // fails, so this is a belt-and-braces guard, not an expected path.
+    const uint64_t fault_page = addr & ~(kPage - 1);
+    bool faulting_alias_restored = true;
+    for (const PageAlias& al : page->aliases) {
+        if (!cpu_writable(al.prot)) continue;
+        const bool ok = mprotect(reinterpret_cast<void*>(static_cast<uintptr_t>(al.addr)), kPage,
+                                 host_prot(al.prot)) == 0;
+        if (!ok && (al.addr & ~(kPage - 1)) == fault_page) faulting_alias_restored = false;
+    }
+    page->generation++;   // the store is about to land -> the page is Dirty regardless
     bump(stats().faults);
+    if (faulting_alias_restored) page->armed = false;
     return true;
 }
 

--- a/prosper/src/host/guest_write_watch.hpp
+++ b/prosper/src/host/guest_write_watch.hpp
@@ -67,4 +67,11 @@ void guest_write_watch_invalidate_all();
 // page-fault write watches are unsafe for SysV guest code.
 bool guest_write_watch_handle_fault(uint64_t addr);
 
+// The Linux page-protection watch (mprotect + SIGSEGV) is only red-zone-safe when the SIGSEGV handler
+// runs on a sigaltstack (SA_ONSTACK): without it the kernel writes the signal frame into the guest's
+// SysV red zone, corrupting live locals of the faulting store. exec_image_linux reports whether the
+// fault handler is installed with SA_ONSTACK; until it is, `create` refuses to arm and callers keep
+// the exact byte-comparison fallback. No-op on other platforms.
+void guest_write_watch_set_fault_onstack(bool on_altstack);
+
 } // namespace prosper::host

--- a/prosper/src/host/guest_write_watch.hpp
+++ b/prosper/src/host/guest_write_watch.hpp
@@ -63,6 +63,12 @@ void guest_write_watch_notify_direct_mapping_protection(uint64_t addr, uint64_t 
 void guest_write_watch_notify_physical_write(uint64_t phys, uint64_t size);
 void guest_write_watch_invalidate_all();
 
+// Called by the HLE, by guest VA range, immediately BEFORE a host/kernel store into guest memory (e.g. a
+// read()/pread() that streams bytes straight into a guest dmem buffer). Restores write on any armed pages
+// the range overlaps so the store does not EFAULT, and marks them Dirty (the bytes are about to change).
+// No-op on Windows/macOS (no pages are ever armed there).
+void guest_write_watch_notify_host_write(uint64_t addr, uint64_t size);
+
 // Retained for the platform-neutral VEH interface; Windows currently returns false because
 // page-fault write watches are unsafe for SysV guest code.
 bool guest_write_watch_handle_fault(uint64_t addr);

--- a/prosper/tests/test_guest_write_watch.cpp
+++ b/prosper/tests/test_guest_write_watch.cpp
@@ -81,6 +81,7 @@ int main() {
 
 #else   // ---- Linux: exercise the real mprotect + SIGSEGV dirty-tracking (#1144) ------------------
 
+#include <cerrno>
 #include <csignal>
 #include <cstring>
 #include <sys/mman.h>
@@ -165,6 +166,60 @@ int main() {
     CHECK(watch.query() == GuestWriteWatchQuery::Unchanged, "clean before physical write");
     prosper::host::guest_write_watch_notify_physical_write(kPhys + page, page);
     CHECK(watch.query() == GuestWriteWatchQuery::Dirty, "physical write marks the watch Dirty");
+
+    // B2: an alias mapped AFTER the watch is armed must be armed too, or a write through it would not
+    // fault and the watch would wrongly read Unchanged (stale texture). notify_direct_mapping_added must
+    // extend the existing page's coverage in place — without a spurious Dirty for same-phys aliasing.
+    CHECK(watch.rearm(), "rearm before late-alias test");
+    CHECK(watch.query() == GuestWriteWatchQuery::Unchanged, "clean before late alias");
+    auto* c = static_cast<uint8_t*>(mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0));
+    CHECK(c != MAP_FAILED, "third alias mapped");
+    prosper::host::guest_write_watch_notify_direct_mapping_added(
+        reinterpret_cast<uint64_t>(c), size, kPhys, kCpuRw);
+    CHECK(watch.query() == GuestWriteWatchQuery::Unchanged,
+          "adding a same-phys alias does not spuriously dirty the watch");
+    c[page * 3 + 0x20] = 0x3c;   // write through the LATE alias
+    CHECK(c[page * 3 + 0x20] == 0x3c, "write through late alias lands");
+    CHECK(watch.query() == GuestWriteWatchQuery::Dirty,
+          "a write through an alias added AFTER arming is caught (B2)");
+
+    // B5: a real kernel write (::read) into an armed read-only page returns EFAULT — the exact failure a
+    // texture-streaming sceKernelPread would hit. Pre-announcing the write disarms the range so the store
+    // lands and the watch reads Dirty, matching read_full()'s guard.
+    CHECK(watch.rearm(), "rearm before kernel-write test");
+    {
+        int pf[2]; CHECK(pipe(pf) == 0, "pipe A created");
+        const char payload[8] = {9, 8, 7, 6, 5, 4, 3, 2};
+        CHECK(write(pf[1], payload, sizeof payload) == (ssize_t)sizeof payload, "payload A queued");
+        errno = 0;
+        const ssize_t blocked = read(pf[0], a + page * 3, sizeof payload);   // page armed RO -> EFAULT
+        CHECK(blocked < 0 && errno == EFAULT, "kernel write into an armed page is blocked (EFAULT)");
+        close(pf[0]); close(pf[1]);
+    }
+    {
+        int pf[2]; CHECK(pipe(pf) == 0, "pipe B created");
+        const char payload[8] = {1, 2, 3, 4, 5, 6, 7, 8};
+        CHECK(write(pf[1], payload, sizeof payload) == (ssize_t)sizeof payload, "payload B queued");
+        prosper::host::guest_write_watch_notify_host_write(
+            reinterpret_cast<uint64_t>(a + page * 3), sizeof payload);
+        const ssize_t got = read(pf[0], a + page * 3, sizeof payload);       // disarmed -> lands
+        CHECK(got == (ssize_t)sizeof payload, "kernel read into a pre-announced guest page succeeds (B5)");
+        CHECK(a[page * 3] == 1 && a[page * 3 + 7] == 8, "kernel-written bytes landed");
+        CHECK(watch.query() == GuestWriteWatchQuery::Dirty, "kernel write marks the watch Dirty (B5)");
+        close(pf[0]); close(pf[1]);
+    }
+
+    // B4: removing ONE alias of a multi-alias page must drop only that alias and keep the page covered by
+    // the survivors (not orphan a stale entry, and not stop faulting). Remove alias c; a write through a
+    // must still be caught.
+    prosper::host::guest_write_watch_notify_direct_mapping_removed(reinterpret_cast<uint64_t>(c), size);
+    CHECK(watch.rearm(), "rearm after removing one alias");
+    CHECK(watch.query() == GuestWriteWatchQuery::Unchanged, "clean after removing one alias");
+    a[page + 0x24] = 0x4b;   // write through a surviving alias
+    CHECK(a[page + 0x24] == 0x4b, "write through surviving alias lands");
+    CHECK(watch.query() == GuestWriteWatchQuery::Dirty,
+          "a page still covered by a surviving alias keeps faulting after a sibling alias is removed (B4)");
+    munmap(c, size);
 
     // A watch over a range with NO known mapping must return Unknown (exact fallback), not arm.
     GuestWriteWatch none = GuestWriteWatch::create(0x9000000000ULL, page);

--- a/prosper/tests/test_guest_write_watch.cpp
+++ b/prosper/tests/test_guest_write_watch.cpp
@@ -1,10 +1,5 @@
 #include "host/guest_write_watch.hpp"
 
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#endif
-#include <windows.h>
-
 #include <cstdint>
 #include <cstdio>
 
@@ -16,8 +11,14 @@ int failures = 0;
 #define CHECK(cond, msg) do { \
     if (!(cond)) { std::fprintf(stderr, "FAIL: %s\n", msg); ++failures; } \
 } while (0)
-
 } // namespace
+
+#ifdef _WIN32
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
 
 int main() {
     constexpr uint64_t kSize = 0x10000;
@@ -77,3 +78,116 @@ int main() {
     std::puts("== PASS ==");
     return 0;
 }
+
+#else   // ---- Linux: exercise the real mprotect + SIGSEGV dirty-tracking (#1144) ------------------
+
+#include <csignal>
+#include <cstring>
+#include <sys/mman.h>
+#include <unistd.h>
+
+namespace {
+// dmem is section-backed (one memfd, MAP_SHARED at multiple VAs) — mirror that so the alias handling
+// is exercised, not just a single mapping.
+constexpr uint32_t kCpuRw = 0x3;   // SCE CPU_READ|CPU_WRITE (see host_prot in guest_write_watch.cpp)
+
+void seg_handler(int sig, siginfo_t* si, void*) {
+    if (sig == SIGSEGV && si->si_addr &&
+        prosper::host::guest_write_watch_handle_fault(reinterpret_cast<uint64_t>(si->si_addr)))
+        return;                                   // resolved: page restored writable, store re-runs
+    // A fault we did not arm: fail loudly rather than loop forever.
+    const char m[] = "FAIL: unexpected SIGSEGV not owned by the write-watch\n";
+    (void)!write(2, m, sizeof m - 1);
+    _exit(2);
+}
+} // namespace
+
+int main() {
+    const size_t page = static_cast<size_t>(sysconf(_SC_PAGESIZE));
+    const size_t size = page * 4;
+
+    int fd = memfd_create("prosper-ww-test", 0);
+    CHECK(fd >= 0, "memfd created");
+    if (fd < 0) return 1;
+    CHECK(ftruncate(fd, static_cast<off_t>(size)) == 0, "memfd sized");
+
+    // Two MAP_SHARED aliases of the same physical (memfd offset 0) range.
+    auto* a = static_cast<uint8_t*>(mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0));
+    auto* b = static_cast<uint8_t*>(mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0));
+    CHECK(a != MAP_FAILED && b != MAP_FAILED, "two aliases mapped");
+    if (a == MAP_FAILED || b == MAP_FAILED) return 1;
+    constexpr uint64_t kPhys = 0x20000;   // arbitrary distinct phys base for the test
+
+    // Install the SIGSEGV handler on a sigaltstack (SA_ONSTACK) — the red-zone-safe configuration the
+    // real path requires; then tell the write-watch that onstack holds so create() will arm.
+    static uint8_t altbuf[128 * 1024];   // ample; SIGSTKSZ is not a compile-time constant on glibc
+    stack_t ss{}; ss.ss_sp = altbuf; ss.ss_size = sizeof altbuf; ss.ss_flags = 0;
+    CHECK(sigaltstack(&ss, nullptr) == 0, "sigaltstack installed");
+    struct sigaction sa{}; sa.sa_sigaction = seg_handler; sa.sa_flags = SA_SIGINFO | SA_ONSTACK;
+    sigemptyset(&sa.sa_mask);
+    CHECK(sigaction(SIGSEGV, &sa, nullptr) == 0, "SIGSEGV handler installed");
+
+    // Gate check: without onstack, create() must refuse (safe fallback).
+    prosper::host::guest_write_watch_set_fault_onstack(false);
+    prosper::host::guest_write_watch_notify_direct_mapping_added(
+        reinterpret_cast<uint64_t>(a), size, kPhys, kCpuRw);
+    prosper::host::guest_write_watch_notify_direct_mapping_added(
+        reinterpret_cast<uint64_t>(b), size, kPhys, kCpuRw);
+    GuestWriteWatch off = GuestWriteWatch::create(reinterpret_cast<uint64_t>(a), size);
+    CHECK(!static_cast<bool>(off), "create refuses to arm when the handler is not on the sigaltstack");
+
+    prosper::host::guest_write_watch_set_fault_onstack(true);
+
+    // Arm a watch over the whole range and confirm it starts Unchanged.
+    GuestWriteWatch watch = GuestWriteWatch::create(reinterpret_cast<uint64_t>(a), size);
+    CHECK(static_cast<bool>(watch), "watch armed over a fully-aliased dmem range");
+    CHECK(watch.query() == GuestWriteWatchQuery::Unchanged, "freshly armed watch reads Unchanged");
+
+    // Write through alias A -> faults -> handler restores write + marks dirty; the byte must land.
+    a[page + 0x40] = 0x5a;
+    CHECK(a[page + 0x40] == 0x5a, "write through alias A lands (no lost store)");
+    CHECK(watch.query() == GuestWriteWatchQuery::Dirty, "watch reads Dirty after a CPU write");
+
+    // Re-arm, don't write -> Unchanged again.
+    CHECK(watch.rearm(), "rearm succeeds");
+    CHECK(watch.query() == GuestWriteWatchQuery::Unchanged, "no write since rearm -> Unchanged");
+
+    // ALIAS COVERAGE: write through the OTHER alias B (same phys) must also be caught (both aliases
+    // were armed). This is the correctness crux — miss it and the renderer trusts a stale texture.
+    b[page * 2 + 0x8] = 0xa5;
+    CHECK(b[page * 2 + 0x8] == 0xa5, "write through alias B lands");
+    CHECK(a[page * 2 + 0x8] == 0xa5, "aliases share storage");
+    CHECK(watch.query() == GuestWriteWatchQuery::Dirty,
+          "write through a SECOND alias of the same phys is caught");
+
+    // A physical-write notification (GPU write) invalidates too.
+    CHECK(watch.rearm(), "rearm before physical-write test");
+    CHECK(watch.query() == GuestWriteWatchQuery::Unchanged, "clean before physical write");
+    prosper::host::guest_write_watch_notify_physical_write(kPhys + page, page);
+    CHECK(watch.query() == GuestWriteWatchQuery::Dirty, "physical write marks the watch Dirty");
+
+    // A watch over a range with NO known mapping must return Unknown (exact fallback), not arm.
+    GuestWriteWatch none = GuestWriteWatch::create(0x9000000000ULL, page);
+    CHECK(!static_cast<bool>(none), "create over an unmapped range yields Unknown");
+
+    watch.reset();
+    // After reset the pages are writable and stores fault no more (the handler would _exit(2) if a
+    // stale armed page remained). Touch both aliases to prove protections were fully restored.
+    a[0x10] = 0x1; b[page + 0x10] = 0x2;
+    CHECK(a[0x10] == 0x1 && b[page + 0x10] == 0x2, "reset restored writable protections");
+
+    prosper::host::guest_write_watch_notify_direct_mapping_removed(reinterpret_cast<uint64_t>(a), size);
+    prosper::host::guest_write_watch_notify_direct_mapping_removed(reinterpret_cast<uint64_t>(b), size);
+
+    const auto stats = prosper::host::guest_write_watch_stats();
+    CHECK(stats.registrations >= 1, "at least one watch armed");
+    CHECK(stats.faults >= 2, "both alias-A and alias-B write faults were handled");
+    CHECK(stats.rearms >= 2, "rearm path exercised");
+
+    munmap(a, size); munmap(b, size); close(fd);
+    if (failures) return 1;
+    std::puts("== PASS ==");
+    return 0;
+}
+
+#endif

--- a/prosper/tests/test_guest_write_watch.cpp
+++ b/prosper/tests/test_guest_write_watch.cpp
@@ -128,12 +128,17 @@ int main() {
     sigemptyset(&sa.sa_mask);
     CHECK(sigaction(SIGSEGV, &sa, nullptr) == 0, "SIGSEGV handler installed");
 
-    // Gate check: without onstack, create() must refuse (safe fallback).
-    prosper::host::guest_write_watch_set_fault_onstack(false);
+    // The real emulator calls set_fault_onstack(true) once at startup, before any dmem map records an
+    // alias (and the notify hooks only record while the feature is enabled). Mirror that: enable, record
+    // both aliases, THEN prove the gate refuses when the handler is turned back off.
+    prosper::host::guest_write_watch_set_fault_onstack(true);
     prosper::host::guest_write_watch_notify_direct_mapping_added(
         reinterpret_cast<uint64_t>(a), size, kPhys, kCpuRw);
     prosper::host::guest_write_watch_notify_direct_mapping_added(
         reinterpret_cast<uint64_t>(b), size, kPhys, kCpuRw);
+
+    // Gate check: with the handler NOT on the sigaltstack, create() must refuse (safe fallback).
+    prosper::host::guest_write_watch_set_fault_onstack(false);
     GuestWriteWatch off = GuestWriteWatch::create(reinterpret_cast<uint64_t>(a), size);
     CHECK(!static_cast<bool>(off), "create refuses to arm when the handler is not on the sigaltstack");
 
@@ -220,6 +225,34 @@ int main() {
     CHECK(watch.query() == GuestWriteWatchQuery::Dirty,
           "a page still covered by a surviving alias keeps faulting after a sibling alias is removed (B4)");
     munmap(c, size);
+
+    // N2: a partial re-protect must record ONLY the re-protected sub-range. Re-protect the MIDDLE page of
+    // a fresh 3-page mapping read-only; a watch over the FIRST page must still find it writable, arm it,
+    // and catch a write. If the whole alias's prot were overwritten, the outer page would read as
+    // non-writable, never arm, and the write would be missed (stale texture).
+    {
+        int fd2 = memfd_create("prosper-ww-n2", 0);
+        CHECK(fd2 >= 0 && ftruncate(fd2, static_cast<off_t>(page * 3)) == 0, "n2 memfd sized");
+        auto* m = static_cast<uint8_t*>(
+            mmap(nullptr, page * 3, PROT_READ | PROT_WRITE, MAP_SHARED, fd2, 0));
+        CHECK(m != MAP_FAILED, "n2 mapping");
+        constexpr uint64_t kN2Phys = 0x50000;   // distinct from kPhys above
+        prosper::host::guest_write_watch_notify_direct_mapping_added(
+            reinterpret_cast<uint64_t>(m), page * 3, kN2Phys, kCpuRw);
+        prosper::host::guest_write_watch_notify_direct_mapping_protection(
+            reinterpret_cast<uint64_t>(m) + page, page, 0x1 /* CPU_READ only */);
+        GuestWriteWatch outer = GuestWriteWatch::create(reinterpret_cast<uint64_t>(m), page);
+        CHECK(static_cast<bool>(outer), "a page outside a partial re-protect is still armable (N2)");
+        CHECK(outer.query() == GuestWriteWatchQuery::Unchanged, "outer page clean after arm");
+        m[0x30] = 0x9d;
+        CHECK(m[0x30] == 0x9d, "write to the outer page lands");
+        CHECK(outer.query() == GuestWriteWatchQuery::Dirty,
+              "a write to a page outside the re-protected sub-range is caught (N2)");
+        outer.reset();
+        prosper::host::guest_write_watch_notify_direct_mapping_removed(
+            reinterpret_cast<uint64_t>(m), page * 3);
+        munmap(m, page * 3); close(fd2);
+    }
 
     // A watch over a range with NO known mapping must return Unknown (exact fallback), not arm.
     GuestWriteWatch none = GuestWriteWatch::create(0x9000000000ULL, page);


### PR DESCRIPTION
## What & why

Fixes #1144.

`GuestWriteWatch` (guest-page dirty-tracking that lets the live renderer prove a texture unchanged across
GPU submits cheaply) was implemented only under `#ifdef _WIN32`, and even that returns `{}` (page-protection
watches corrupt the Windows SysV red zone). So on **every** platform the renderer fell back to
`validate_exact` — re-**hashing** a texture's source bytes on every submit. Texture-light titles absorb it;
**Terminator 2D (PPSA25872, ~9851 textures)** is throttled by it (#1110): `RENDER_TIMING` showed
`watch_unknown=100%`, `write_watch create=0`, hundreds of GiB of textures re-hashed per run.

On Linux the red-zone objection doesn't apply (`SA_ONSTACK` puts the signal frame on the sigaltstack), so
this implements real dirty-tracking there via **`mprotect(PROT_READ)` + SIGSEGV**, alias-aware for
section-backed dmem (one memfd `MAP_SHARED` at multiple VAs). When the watch can't cover a range cleanly it
returns `Unknown` and the exact fallback runs — it never returns a wrong `Unchanged`. Dormant by default
(Linux gates arming behind `PROSPER_FAULT_ONSTACK`); Windows/macOS behaviour is unchanged.

## Commits

1. **Implementation** (`fbec993`) — the Linux `GuestWriteWatch` + the fault-handler hook + dmem wiring.
2. **Review response** (`12e7d7b`) — addresses all six blocking findings from the independent review below.

## Review findings addressed (memory-safety-critical)

- **B1 — process-fatal race.** `handle_fault` returned `false` on `try_lock` contention, which falls through
  the caller's fault handler to a fatal `_exit`; contention is routine (a guest thread storing to an armed
  page while the renderer holds the lock across an arm/rearm). It now **resumes** on contention — the page
  is still read-only, so the store re-faults and retries until the always-bounded lock frees; a genuine
  non-watched fault then wins the lock and takes the real handler.
- **B5 — kernel-write EFAULT (fundamental to mprotect).** A guest `read()`/`pread()` streaming bytes straight
  into a watched read-only dmem buffer returned EFAULT where hardware succeeds. New `notify_host_write(va,
  size)` disarms + Dirties the range; the HLE calls it before every `read_full()` and vectored read. Zero-cost
  when the feature is off (single atomic load).
- **B2/B3/B4 — silent stale-texture corruption from incomplete coverage.** Only 2 of Linux's dmem mutation
  paths notified the watch. Now **every** dmem alias funnels through the `map_phys_at` chokepoint (map_dmem,
  BatchMap MAP_DIRECT, Ampr push-map + its same-phys mirror); protection changes funnel through the
  `retrack_prot` chokepoint (mprotect / mtypeprotect / batch PROTECT); BatchMap UNMAP now notifies removal.
  `notify_added` extends an already-watched page's alias set in place and arms the new VA (no spurious dirty
  for same-phys aliasing); `notify_removed` purges **every** page of the range and unindexes stale VAs so
  `handle_fault` can never mprotect a reused address.
- **B6.** `handle_fault` no longer clears `armed` when the faulting alias's own restore mprotect failed (that
  would drop the next fault into the fatal handler); it keeps the page armed to retry.

Also caught during self-review: `purge_va_range_locked` must **not** free a `WatchedPage` — page lifetime is
reference-counted (owned by `release_registration_locked`), so freeing one from a notify hook would dangle a
live `Registration`'s pointer (use-after-free in `query`/`rearm`). It now unindexes stale aliases without
freeing; an emptied-but-referenced page lingers harmlessly (reads Dirty) until its registration resets.

## Verification

- **ctest 129/129** — including new Linux `test_guest_write_watch` cases that each fail without their fix:
  an alias added AFTER arming is caught (B2); a real `::read` into an armed page returns EFAULT and
  pre-announcing it via `notify_host_write` lets the read land + marks Dirty (B5); removing one alias of a
  multi-alias page keeps the survivors faulting (B4); plus the original arm/write/Dirty, second-alias
  coverage, physical-write, unmapped→Unknown, onstack-gate, and reset paths.
- **Snapshots — all 4 routes pass with the write-watch LIVE** (`PROSPER_FAULT_ONSTACK=1`, so every fixed
  map/unmap/protect/read path is exercised under real multithreaded titles with pages armed):
  messenger-scene, evergate-title, dead-cells-gameplay, blasphemous2-gameplay — all `OK`, no crash/corruption.
- **Terminator 2D perf** (`PROSPER_RENDER_TIMING`, write-watch live): `write_watch create=645 ok=645
  faults=0 no_map=0`; `texture_cache watch_reuse=100% watch_unknown=0 validations=0` (zero byte re-hashing);
  steady-state texture materialization ~0.55 ms vs ~12.2 ms on the re-hash path. No crash across ~9375 submits.

## Scope / risk

- Linux `GuestWriteWatch` + dmem-allocator chokepoint wiring + the read-path guard + the fault-handler hook.
- Windows/macOS unaffected (Windows still refuses to arm; macOS gets the code but its dmem path doesn't feed
  the alias table, so it stays on the exact fallback — no regression).
- Advances #1110 (removes Terminator's texture-rehash throttle) but does not by itself claim Terminator
  reaches gameplay — the backend cost has other contributors, tracked separately.
