### PR TITLE
host: handle guest int 0x41 (RAGE debugbreak) as a no-op — GTA V intro renders without the FAULT_SKIP crutch

### DIFF
--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -86,6 +86,7 @@ namespace {
     // trustworthy way to inspect deep crashes (e.g. the null std::ctype facet at eboot+0x3b5ea6).
     bool g_faultmem = false;
     bool g_faultlog = false;
+    bool g_int41_skip = true;   // guest int $0x41 (RAGE debugbreak) -> skip; PROSPER_NO_INT41_SKIP disables (#1138)
     // Probe pipe for probe_readable() below — a pipe write imports the source pages (EFAULT on
     // unmapped memory) where a /dev/null write does not. O_NONBLOCK so a full pipe can never
     // block the fault handler; drained after every probe.
@@ -1855,11 +1856,10 @@ namespace {
         // other title is unaffected (none emit int 0x41). The rip page is mapped+exec (the trap was
         // fetched from it), so a direct 2-byte read guarded by the guest band is safe in-handler.
         // Disable with PROSPER_NO_INT41_SKIP to fall back to the fatal path for debugging.
-        if (sig == SIGSEGV && g_base && g_fault_rip >= g_base &&
+        if (g_int41_skip && sig == SIGSEGV && g_base && g_fault_rip >= g_base &&
             g_fault_rip < g_base + 0x100000000ull) {
-            static const bool disabled = getenv("PROSPER_NO_INT41_SKIP") != nullptr;
             const auto* ins = (const uint8_t*)g_fault_rip;
-            if (!disabled && ins[0] == 0xCDu && ins[1] == 0x41u) {
+            if (ins[0] == 0xCDu && ins[1] == 0x41u) {
                 static std::atomic<int> logged{0};
                 if (logged.fetch_add(1) < 8) {
                     char b[96];
@@ -2159,6 +2159,7 @@ void install_sigaltstack() {
 
 void install_trap_handler() {
     g_faultmem = getenv("PROSPER_FAULTMEM") != nullptr;   // read once (getenv is not signal-safe)
+    g_int41_skip = getenv("PROSPER_NO_INT41_SKIP") == nullptr;   // read once (getenv is not signal-safe) — #1138
     // Expose the perf HW write-watch to HLE code (dispatch.hpp g_hwwatch_hook): lets an HLE-side
     // diagnostic arm a watch on a runtime-discovered guest slot (one watch; extra calls ignored).
     // Installs the SIGTRAP handler on demand (the watch may be armed without PROSPER_HWBP).

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -1845,6 +1845,33 @@ namespace {
         g_r14 = (uint64_t)g[REG_R14]; g_r15 = (uint64_t)g[REG_R15];
         g_trap_sig = sig;
         g_trap_kind = (sig == SIGILL) ? 3 : 2;
+        // Guest `int $0x41` (opcode CD 41) is RAGE's software breakpoint / assert trap (GTA V,
+        // PPSA04263, #1138). On PS5 an int with a userspace-illegal vector raises #GP; the kernel's
+        // trap handler, with no debugger attached, simply returns past it — so the game continues to
+        // its OWN error-reporting/recovery code after the trap. prosper must emulate the same "no
+        // debugger → skip the breakpoint" behavior, or the trap SIGSEGVs and kills the thread (the
+        // reason GTA V needed the PROSPER_FAULT_SKIP=0x2b2c463:0x2b2c465 diagnostic crutch just to
+        // render its intro). Only fires for a guest-module rip whose bytes really are CD 41; every
+        // other title is unaffected (none emit int 0x41). The rip page is mapped+exec (the trap was
+        // fetched from it), so a direct 2-byte read guarded by the guest band is safe in-handler.
+        // Disable with PROSPER_NO_INT41_SKIP to fall back to the fatal path for debugging.
+        if (sig == SIGSEGV && g_base && g_fault_rip >= g_base &&
+            g_fault_rip < g_base + 0x100000000ull) {
+            static const bool disabled = getenv("PROSPER_NO_INT41_SKIP") != nullptr;
+            const auto* ins = (const uint8_t*)g_fault_rip;
+            if (!disabled && ins[0] == 0xCDu && ins[1] == 0x41u) {
+                static std::atomic<int> logged{0};
+                if (logged.fetch_add(1) < 8) {
+                    char b[96];
+                    int n = snprintf(b, sizeof b,
+                        "[int41] guest int $0x41 (debugbreak) at eboot+0x%llx -> skipped\n",
+                        (unsigned long long)(g_fault_rip - g_base));
+                    syscall(SYS_write, 2, b, (size_t)n);
+                }
+                g[REG_RIP] = g_fault_rip + 2;   // advance past the 2-byte int instruction
+                return;
+            }
+        }
         // PROSPER_FAULT_SKIP="<fault-off>[:<resume-off>]" DIAGNOSTIC (bring-up, NOT a fix): when a fault
         // hits at eboot+<fault-off>, set rax=0 and resume the guest at eboot+<resume-off> (default
         // fault-off+4, i.e. skip one short instruction). Lets the guest survive ONE specific crash so


### PR DESCRIPTION
## Summary
Makes *Grand Theft Auto V* (`PPSA04263`, RAGE) render its animated Rockstar Games intro with **only `PROSPER_GUEST_FS=1`** — removing the `PROSPER_FAULT_SKIP=0x2b2c463:0x2b2c465` diagnostic crutch it previously needed.

## Failure scenario
RAGE issues `int $0x41` (opcode `CD 41`) as its software breakpoint / assert trap (GTA V hits it on the resource-streamer thread at `eboot+0x2b2c463`). On PS5 an int with a userspace-illegal vector raises `#GP`; the kernel's trap handler, with **no debugger attached, simply returns past it**, so the game continues to its own error-reporting/recovery code. prosper didn't handle it — the trap raised SIGSEGV and killed the thread, so the frame loop died and GTA needed a hardcoded `PROSPER_FAULT_SKIP` offset just to get through the intro.

## Fix
The SIGSEGV handler (`exec_image_linux.cpp`) now, before the fatal path, checks whether the faulting rip is in the guest module band and its bytes are `CD 41`; if so it advances rip past the 2-byte instruction and resumes (rate-limited `[int41]` log). This emulates the real "no debugger → skip the breakpoint" kernel behavior. Same resume mechanism the existing `PROSPER_FAULT_SKIP` path used to skip this exact trap.

## Affected / unaffected
- Affected: a guest `int 0x41` is now a resumable no-op instead of a fatal SIGSEGV. Opt out with `PROSPER_NO_INT41_SKIP`.
- Unaffected: every other title — the guard requires the exact `CD 41` opcode in the guest band, and no Unity/UE4/Godot title (Messenger/Dead Cells/B2/Evergate/DOLL) emits `int 0x41`. The in-handler 2-byte read is safe: the rip page is mapped+exec (the trap was fetched from it).

## Risk
Low. Blast radius is code that actually executes `int 0x41` (RAGE only). Skipping is the correct emulation — RAGE's own error-handling code runs *after* the breakpoint, so this doesn't mask real fatals (the game's fatal path, if any, still runs).

## Verification (exact head)
- `cmake --build prosper/build-linux -j16 && ctest` → **128/128 pass**
- `python3 prosper/tools/snapshot/snapshot.py check` → **PASS all 4 baselines** (messenger-scene, evergate-title, dead-cells-gameplay, blasphemous2-gameplay).
- Live GTA V: `PROSPER_GUEST_FS=1 ./prosper-app --dump PPSA04263-app0` (no FAULT_SKIP) → `[int41] guest int $0x41 (debugbreak) at eboot+0x2b2c463 -> skipped`, 0 worker faults, renders the intro (111 content frames). Post-intro job stall is separate (#1149).

Fixes #1138
