### PR TITLE
fix(hle): implement APR WriteAddress completion primitive (GTA V title-screen stall, #1149)

### DIFF
--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -21,6 +21,7 @@ inline constexpr uint64_t kHugeReserveLen = 0x2000000000ull;   // 128 GiB
 #include "../host/posix_shim.hpp"
 #include <sys/mman.h>
 #include <sys/syscall.h>
+#include <sys/uio.h>   // process_vm_writev — fault-safe APR completion write (#1149)
 #include <unistd.h>
 #include <fcntl.h>
 #ifdef __linux__
@@ -1213,6 +1214,47 @@ HLE(k_ampr_getsize) {
 }
 HLE(k_ampr_x3) { return ampr_arglog("Qs1xtplKo0U", a0, a1, a2, a3, a4, a5); }
 HLE(k_ampr_x4) { return ampr_arglog("GuchCTefuZw", a0, a1, a2, a3, a4, a5); }
+
+// --- APR command-buffer WriteAddress (NID j0+3uJMxYJY) — the APR completion-notification primitive
+// (issue #1149). The NID is taken verbatim from GTA V (PPSA04263)'s import table; its exact firmware
+// name is not in the PS5 3.20 dump (and does NOT hash from Kyty's guessed
+// "sceAmprCommandBufferWriteAddress"), so the name is unverified — the behavior below is re-derived
+// from the guest's use and confirmed against a live capture, NOT copied from a secondary source.
+// Signature: (cb, u64* address, u64 value, u32 flags).
+// It appends a "write value -> *address" command to the APR command buffer; the APR engine performs
+// that write when the buffer executes, in command-buffer order (i.e. AFTER the reads queued before
+// it). The guest uses it as a load-completion signal: it pre-sets *address to a "pending" sentinel,
+// appends WriteAddress(address, doneValue), then spin-polls *address for doneValue on a waiter thread.
+//
+// prosper serves the APR ReadFile commands SYNCHRONOUSLY at append time (see f_apr_read_submit /
+// mQ16-QdKv7k in hle_file.cpp): every read queued before this WriteAddress is already complete when
+// this call is made. The completion condition the write represents is therefore already satisfied, so
+// we perform the write here, immediately — consistent with prosper's eager-read model and correct in
+// command order (the write only ever follows its reads). Fault-safe (process_vm_writev refuses an
+// unmapped guest VA instead of faulting the HLE — see issue #1154); *value* is written verbatim (the
+// guest polls for the exact token it queued — GTA increments it per submit: 0, then 4, 5, 6, ...).
+//
+// Live GTA V evidence: post-intro streaming appends one such command per small metadata buffer, e.g.
+//   j0+3uJMxYJY(cb=0x20001f13f0, addr=cb+0x40, value=0)   with *addr pre-set to 0xffffffffffffffff.
+// prosper previously stubbed the NID (returned 0, wrote nothing), so *address stayed pending forever
+// and the RAGE main thread busy-waited (eboot+0x2b5f0e0 sched_yield loop) on the load future's ready
+// flag gated behind this write — the title-screen-frontier stall. Performing the write lets the load
+// complete and the game advances past the intro into further streaming. CONFIDENCE: HIGH (ABI +
+// address/value verified live; the write clears the stall and the boot progresses).
+namespace { bool wa_log() { static int v = getenv("PROSPER_FILELOG") ? 1 : 0; return v; } }
+HLE(k_ampr_write_address) {   // j0+3uJMxYJY (cb, address, value, flags)
+    (void)a0; (void)a3;
+    if (a1) {
+        struct iovec local { &a2, sizeof(a2) };
+        struct iovec remote { (void*)(uintptr_t)a1, sizeof(a2) };
+        ssize_t n = process_vm_writev(getpid(), &local, 1, &remote, 1, 0);
+        if (wa_log())
+            fprintf(stderr, "[apr] write-address *0x%llx = 0x%llx (%s)\n",
+                    (unsigned long long)a1, (unsigned long long)a2,
+                    n == (ssize_t)sizeof(a2) ? "OK" : "UNMAPPED");
+    }
+    return 0;
+}
 // --- APR completion-event plumbing (issues #115/#180/#208). Live-captured surface:
 //   sSAUCCU1dv4(eq=APREventQueue, id=0x74fe+ring, 0, 0, 0x43, 0)  — register APR ids on an equeue
 //     (called 6x, rings 0..5, by the guest listener-ctx ctor eboot+0x22a0670)
@@ -1630,6 +1672,10 @@ void register_kernel_mem_hle() {
     Hle::register_fn("H896Pt-yB4I", (HleFn)k_apr_cb_set_equeue, "AprCbSetEventQueue?");
     Hle::register_fn("ASoW5WE-UPo", (HleFn)k_apr_submit,        "AprSubmitCommandBuffer?");
     Hle::register_fn("GnxKOHEawhk", (HleFn)k_ampr_u3,           "AmprUnknown3");
+    // APR completion-notification write, performed eagerly (#1149). NID from GTA V's import table; the
+    // exact firmware name is unknown (not in the 3.20 dump, and it does not hash from Kyty's guessed
+    // "sceAmprCommandBufferWriteAddress"), so the label carries a "?" per the unverified-name convention.
+    Hle::register_fn("j0+3uJMxYJY", (HleFn)k_ampr_write_address, "sceAmprCommandBufferWriteAddress?");
 }
 
 } // namespace prosper

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -1230,9 +1230,21 @@ HLE(k_ampr_x4) { return ampr_arglog("GuchCTefuZw", a0, a1, a2, a3, a4, a5); }
 // mQ16-QdKv7k in hle_file.cpp): every read queued before this WriteAddress is already complete when
 // this call is made. The completion condition the write represents is therefore already satisfied, so
 // we perform the write here, immediately — consistent with prosper's eager-read model and correct in
-// command order (the write only ever follows its reads). Fault-safe (process_vm_writev refuses an
-// unmapped guest VA instead of faulting the HLE — see issue #1154); *value* is written verbatim (the
-// guest polls for the exact token it queued — GTA increments it per submit: 0, then 4, 5, 6, ...).
+// command order (the write only ever follows its reads). *value* is written verbatim (the guest polls
+// for the exact token it queued — GTA increments it per submit: 0, then 4, 5, 6, ...).
+//
+// Residual hazard (documented, not hit by the observed protocol): because the write fires at
+// append-time rather than at an explicit submit, a title that re-armed *address to its pending
+// sentinel AFTER appending WriteAddress but BEFORE submitting would lose this completion. GTA pre-arms
+// the sentinel FIRST (verified: *addr is already 0xffffffffffffffff when this call is made), so the
+// ordering is safe here; revisit if a future title's WriteAddress completion is dropped.
+//
+// The write is fault-safe (never faults the HLE on a bad guest VA — see issue #1154) AND commits
+// lazy-reserved pages the way the SIGSEGV fault handler does: process_vm_writev cannot fault through
+// prosper's lazy-commit handler, so a target in a guest-RESERVED-but-untouched range would EFAULT even
+// though a real guest write would succeed — so we commit-and-retry, exactly like apr_write_guest_dst
+// in hle_file.cpp. A genuinely undeliverable completion write is logged LOUDLY (unconditionally): a
+// silently dropped completion is precisely the invisible stall this fix exists to remove.
 //
 // Live GTA V evidence: post-intro streaming appends one such command per small metadata buffer, e.g.
 //   j0+3uJMxYJY(cb=0x20001f13f0, addr=cb+0x40, value=0)   with *addr pre-set to 0xffffffffffffffff.
@@ -1242,17 +1254,34 @@ HLE(k_ampr_x4) { return ampr_arglog("GuchCTefuZw", a0, a1, a2, a3, a4, a5); }
 // complete and the game advances past the intro into further streaming. CONFIDENCE: HIGH (ABI +
 // address/value verified live; the write clears the stall and the boot progresses).
 namespace { bool wa_log() { static int v = getenv("PROSPER_FILELOG") ? 1 : 0; return v; } }
+extern "C" int prosper_reserved_range_state(uint64_t addr);   // defined below (lazy-commit tracking)
 HLE(k_ampr_write_address) {   // j0+3uJMxYJY (cb, address, value, flags)
-    (void)a0; (void)a3;
-    if (a1) {
-        struct iovec local { &a2, sizeof(a2) };
-        struct iovec remote { (void*)(uintptr_t)a1, sizeof(a2) };
-        ssize_t n = process_vm_writev(getpid(), &local, 1, &remote, 1, 0);
-        if (wa_log())
-            fprintf(stderr, "[apr] write-address *0x%llx = 0x%llx (%s)\n",
-                    (unsigned long long)a1, (unsigned long long)a2,
-                    n == (ssize_t)sizeof(a2) ? "OK" : "UNMAPPED");
+    (void)a0;
+    if (!a1) return 0;
+    uint64_t value = a2;
+    struct iovec local { &value, sizeof(value) };
+    struct iovec remote { (void*)(uintptr_t)a1, sizeof(value) };
+    bool ok = process_vm_writev(getpid(), &local, 1, &remote, 1, 0) == (ssize_t)sizeof(value);
+    if (!ok) {
+        // Commit any covering 64 KiB pages that are lazy-reserved-but-untouched, then retry once.
+        bool committed = false;
+        for (uint64_t p = a1 & ~0xffffull; p < a1 + sizeof(value); p += 0x10000) {
+            unsigned char vec;
+            if (prosper_mincore((void*)(uintptr_t)p, 1, &vec) != 0 &&
+                prosper_reserved_range_state(p) == 1 &&
+                mmap((void*)(uintptr_t)p, 0x10000, PROT_READ | PROT_WRITE,
+                     MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0) == (void*)(uintptr_t)p)
+                committed = true;
+        }
+        if (committed)
+            ok = process_vm_writev(getpid(), &local, 1, &remote, 1, 0) == (ssize_t)sizeof(value);
     }
+    if (!ok)
+        fprintf(stderr, "[apr] write-address *0x%llx = 0x%llx UNMAPPED — completion write dropped\n",
+                (unsigned long long)a1, (unsigned long long)value);
+    else if (wa_log())
+        fprintf(stderr, "[apr] write-address *0x%llx = 0x%llx (a3=0x%llx) OK\n",
+                (unsigned long long)a1, (unsigned long long)value, (unsigned long long)a3);
     return 0;
 }
 // --- APR completion-event plumbing (issues #115/#180/#208). Live-captured surface:

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -4173,6 +4173,26 @@ HLE(k_query_memory_protection) {
 // (the Linux path models them). Registered by raw NID for parity.
 HLE(k_ampr_ok) { return 0; }
 
+// APR command-buffer WriteAddress (NID j0+3uJMxYJY) — the completion-notification write (#1149).
+// Windows sibling of the POSIX handler above (full contract documented there): write `value` (a2)
+// verbatim to `*address` (a1). Fault-safe via VirtualQuery — an uncommitted / non-writable / partially
+// mapped target is skipped rather than faulting the emulator (mirrors windows_prepare_guest_write).
+HLE(k_ampr_write_address) {   // j0+3uJMxYJY (cb, address, value, flags)
+    (void)a0; (void)a3;
+    if (a1) {
+        MEMORY_BASIC_INFORMATION mbi{};
+        constexpr DWORD kWritable = PAGE_READWRITE | PAGE_WRITECOPY |
+                                    PAGE_EXECUTE_READWRITE | PAGE_EXECUTE_WRITECOPY;
+        if (VirtualQuery(reinterpret_cast<void*>(static_cast<uintptr_t>(a1)), &mbi, sizeof(mbi)) &&
+            mbi.State == MEM_COMMIT && (mbi.Protect & kWritable) &&
+            static_cast<uintptr_t>(a1) + sizeof(uint64_t) <=
+                reinterpret_cast<uintptr_t>(mbi.BaseAddress) + mbi.RegionSize) {
+            *reinterpret_cast<uint64_t*>(static_cast<uintptr_t>(a1)) = a2;
+        }
+    }
+    return 0;
+}
+
 namespace {
 std::mutex g_sync_mx;
 std::condition_variable g_sync_cv;
@@ -4326,6 +4346,8 @@ void register_kernel_mem_hle() {
     Hle::register_fn("H896Pt-yB4I", (HleFn)k_ampr_ok, "AprCbSetEventQueue?");
     Hle::register_fn("ASoW5WE-UPo", (HleFn)k_ampr_ok, "AprSubmitCommandBuffer?");
     Hle::register_fn("GnxKOHEawhk", (HleFn)k_ampr_ok, "AmprUnknown3");
+    // APR completion-notification write (#1149) — real behavior on Windows too (see handler above).
+    Hle::register_fn("j0+3uJMxYJY", (HleFn)k_ampr_write_address, "sceAmprCommandBufferWriteAddress?");
 }
 
 } // namespace prosper

--- a/prosper/tests/test_apr_registry.cpp
+++ b/prosper/tests/test_apr_registry.cpp
@@ -10,6 +10,9 @@
 #include <cstring>
 #include <string>
 #include <vector>
+#ifndef _WIN32
+#include <sys/mman.h>   // mmap/munmap — WriteAddress fault-safety check (#1149/#1154)
+#endif
 #include "../src/host/exec_image.hpp"
 #include "../src/hle/dispatch.hpp"
 #include "../src/hle/nid.hpp"
@@ -252,6 +255,20 @@ int main() {
 
         // A null address must be a safe no-op (never fault the HLE).
         CHECK(write_address_guest(cb, 0, 0x2a, 0) == 0, "WriteAddress tolerates a null address");
+
+        // Fault-safety (issue #1154): a non-null but UNMAPPED target must not fault the HLE. Reserve
+        // then release a page so the address is valid-shaped but unmapped, and confirm the handler
+        // returns cleanly (it drops the undeliverable write and logs, rather than SIGSEGVing).
+#ifndef _WIN32
+        void* scratch = mmap(nullptr, 0x1000, PROT_READ | PROT_WRITE,
+                             MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        if (scratch != MAP_FAILED) {
+            uint64_t unmapped = (uint64_t)(uintptr_t)scratch;
+            munmap(scratch, 0x1000);
+            CHECK(write_address_guest(cb, unmapped, 0x2a, 0) == 0,
+                  "WriteAddress tolerates an unmapped target without faulting");
+        }
+#endif
     }
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }

--- a/prosper/tests/test_apr_registry.cpp
+++ b/prosper/tests/test_apr_registry.cpp
@@ -216,6 +216,44 @@ int main() {
     std::remove(wp_full);
     prosper_apr_reset_for_test();
 
+    // sceAmprCommandBufferWriteAddress (GTA V / PPSA04263, RAGE, issue #1149): the APR completion-
+    // notification primitive j0+3uJMxYJY(cb, address, value, flags). It must WRITE `value` to
+    // `*address` (the APR engine performs the queued write when the command buffer executes; prosper
+    // serves the reads eagerly, so the write happens here). RAGE pre-sets the target to a "pending"
+    // sentinel and a waiter thread spin-polls it for the queued value; stubbing the NID to a bare 0
+    // (writing nothing) left the target pending forever and hung the main thread on a load future
+    // (the title-screen stall). This regression FAILS against the old stub — nothing writes the value.
+    // The NID j0+3uJMxYJY is taken verbatim from GTA V's import table (its exact firmware name is not
+    // in the PS5 3.20 library dump — it does NOT hash from "sceAmprCommandBufferWriteAddress"; the
+    // KytyPS5 label is a guess). The NID is the authority, so the handler is registered by raw NID.
+    register_kernel_mem_hle();
+    HleFn write_address = Hle::lookup("j0+3uJMxYJY");
+    CHECK(write_address != nullptr, "AMPR WriteAddress HLE registered");
+    const std::vector<ImportSlot> wa_slots = {{"libSceAmpr", "j0+3uJMxYJY"}};
+    std::string wa_stub_error;
+    CHECK(install_stubs(wa_slots, 0x730000000ull, 96, &wa_stub_error),
+          "generated executable AMPR WriteAddress import stub");
+    using GuestWriteAddress = uint64_t (__attribute__((sysv_abi)) *)(
+        uint64_t, uint64_t, uint64_t, uint64_t);
+    auto write_address_guest = reinterpret_cast<GuestWriteAddress>(
+        static_cast<uintptr_t>(stub_addr(0)));
+    if (write_address && wa_stub_error.empty()) {
+        // The guest pre-arms the target with a pending sentinel and queues the completion value.
+        uint64_t target = 0xffffffffffffffffull;   // matches the live GTA V pre-set
+        uint64_t cb = 0x20001f13f0ull;              // opaque cb handle (not dereferenced)
+        uint64_t r = write_address_guest(cb, (uint64_t)(uintptr_t)&target, 0x2a, 0x60);
+        CHECK(r == 0, "WriteAddress returns success");
+        CHECK(target == 0x2a, "WriteAddress writes the queued value to the target (clears pending)");
+
+        // The value is written verbatim (RAGE increments a per-submit completion token, not always 0).
+        uint64_t token_target = 0;
+        write_address_guest(cb, (uint64_t)(uintptr_t)&token_target, 7, 0);
+        CHECK(token_target == 7, "WriteAddress writes an arbitrary token verbatim");
+
+        // A null address must be a safe no-op (never fault the HLE).
+        CHECK(write_address_guest(cb, 0, 0x2a, 0) == 0, "WriteAddress tolerates a null address");
+    }
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;


### PR DESCRIPTION
Fixes #1149.

## Failure scenario

GTA V (PPSA04263, RAGE) renders its Rockstar intro, then the `[RAGE] Main Thr` pins ~100% CPU spinning forever at `eboot+0x2b5f0e0` (a `sched_yield` loop) on a resource-load future's ready flag that is never set. No new frames present; the title screen is never reached. This is the "title-screen frontier" the issue tracked across three investigation passes.

## Root cause

The post-intro streaming builds small APR command buffers and, per buffer, appends the completion op imported under **NID `j0+3uJMxYJY`** — a *WriteAddress* command ("when this buffer executes, write `value` to `*address`"). The guest pattern is:

1. pre-set a target word to a pending sentinel (`0xffffffffffffffff`),
2. append `WriteAddress(address = cb+0x40, value = token)`,
3. a waiter thread spin-polls the word for `token`.

prosper had this NID **unimplemented** (the generic stub returned 0 and wrote nothing), so the target word stayed pending forever → the load never completed → the main thread's future never became ready → permanent spin.

Verified live: the ABI and exact `(address, value)` were captured directly from the running guest (`cb=0x20001f13f0, addr=cb+0x40, value=0`, with `*addr` pre-set to `-1`), and the missing call was pinpointed at the exact stall boundary in the APR trace.

## Approach & invariants

Implement the op: write `value` verbatim to `*address`, fault-safe via `process_vm_writev` (an unmapped guest VA is reported, never faults the HLE — cf. #1154).

prosper serves APR `ReadFile` commands **synchronously at append time** (`f_apr_read_submit` / `mQ16-QdKv7k`), so every read queued *before* a WriteAddress is already complete when the WriteAddress call is made. Performing the write immediately is therefore correct in command-buffer order (the completion write only ever follows its reads) and consistent with prosper's existing eager-read model — no deferred submit/execute machinery is needed, and no existing Ampr/APR behavior is changed.

`value` is written verbatim because RAGE polls for the exact token it queued (observed incrementing per submit: 0, then 4, 5, 6, …), not a fixed flag.

**Name provenance:** the NID is taken verbatim from GTA's import table. Its exact firmware name is unknown — it is absent from the PS5 3.20 library dump and does **not** hash from the guessed `sceAmprCommandBufferWriteAddress` (that hashes to `7DDN-GiK1pc`; the hash function is confirmed correct because `...WriteAddressOnCompletion` → the real `sJXyWHjP-F8`). The behavior is re-derived from the guest's own use, not copied from any secondary implementation; the registration label carries a `?` per the unverified-name convention.

## Affected / unaffected behavior

- **Affected:** only the code path invoking NID `j0+3uJMxYJY` (previously an unimplemented stub). No other title has exercised this NID.
- **Unaffected:** all existing APR/Ampr paths (`ReadFile`, resolve, submit, event-queue plumbing) are untouched. No renderer/recompiler/AGC/present code changes, so no snapshot impact.

## Result

The write clears the stall: the boot advances past the intro into sustained further streaming (23+ WriteAddress completions, `update.rpf`/`prosperoa.rpf`/many dlcpacks) until a **separate, later guest-TLS fault** at `eboot+0x2b1f0e5` — deterministic across runs, tracked as follow-up **#1155**, not part of this change. This PR removes a hard hang (boot progression); it does not itself reach a new *rendered* checkpoint, so there is no new screenshot to attach — the Rockstar intro renders both before and after.

## Risks

Low. Additive (one new NID handler), fault-safe write, no change to existing behavior. The one judgment call — writing at append-time rather than at an explicit submit — is safe under prosper's eager-read model and is the observed-correct behavior (the small buffers carrying WriteAddress are never submitted via `ASoW5WE-UPo` in the live trace; they execute via the synchronous read path).

## Tests

`tests/test_apr_registry.cpp` drives the handler through a generated guest-ABI stub and asserts it writes the queued value (and an arbitrary token) to the target while tolerating a null address. Confirmed it **fails against the old bare-0 stub** and passes with the fix.

## Verification (Linux)

```
cmake --build prosper/build-linux -j24 && ctest        # 127/127 pass
```
Live: `PROSPER_GUEST_FS=1 ./prosper-app --dump PPSA04263-app0` — before: infinite spin after intro; after: progresses past the stall to #1155.

Review requested: reverse-engineered API semantics in shared infra (`area:infra`).