### PR TITLE
fix(host): restore guest %fs on signal-handler return-to-guest paths (GTA V TLS crash, #1155)

### DIFF
--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -1828,10 +1828,11 @@ namespace {
                 return;   // re-execute from the reader's skip label
             }
         }
-        // Fatal crash path (all diagnostic/stepping cases above already returned). If this thread was
-        // running on OUR guest %fs, restore the host %fs NOW so the host-libc reporting below (snprintf/
-        // write) + the siglongjmp-return into host C++ don't double-fault reading guest TLS as glibc's TCB.
-        // No-op when guest-fs is off. (The GC RT-signal handler is separate and keeps the guest %fs.)
+        // Fault-report path (env-gated diagnostic/stepping cases above already returned; the int-0x41
+        // skip and PROSPER_FAULT_SKIP return-to-guest cases are handled a few lines below). If this
+        // thread was running on OUR guest %fs, switch to the host %fs NOW so the host-libc reporting
+        // below (snprintf/write) + the siglongjmp-return into host C++ don't double-fault reading guest
+        // TLS as glibc's TCB. No-op when guest-fs is off. (The GC RT-signal handler keeps the guest %fs.)
         // Capture the guest %fs (scoped) rather than dropping it: the paths below that RETURN to guest
         // code (int $0x41 skip, PROSPER_FAULT_SKIP) must restore it first — sigreturn does NOT restore
         // fs_base on x86-64, so resuming the guest after a host-%fs swap would run guest code (incl. its

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -11,6 +11,7 @@
 #if defined(__linux__) || defined(__APPLE__)
 #include "posix_shim.hpp"
 #include <sys/mman.h>
+#include <sys/prctl.h>   // PR_GET_NAME — #1155 fault-thread name in the TLS probe
 #include <signal.h>
 #include <setjmp.h>
 #include <pthread.h>
@@ -1832,7 +1833,13 @@ namespace {
         // running on OUR guest %fs, restore the host %fs NOW so the host-libc reporting below (snprintf/
         // write) + the siglongjmp-return into host C++ don't double-fault reading guest TLS as glibc's TCB.
         // No-op when guest-fs is off. (The GC RT-signal handler is separate and keeps the guest %fs.)
-        guest_fs_enter_host_for_signal();
+        // Capture the guest %fs (scoped) rather than dropping it: the paths below that RETURN to guest
+        // code (int $0x41 skip, PROSPER_FAULT_SKIP) must restore it first — sigreturn does NOT restore
+        // fs_base on x86-64, so resuming the guest after a host-%fs swap would run guest code (incl. its
+        // %fs-relative TLS reads) on the host glibc TCB. That leaked host %fs after every int-0x41 skip
+        // was the RAGE `[RAGE] Main Thr` TLS crash at eboot+0x2b1f0e5 (#1155: TLS[-0x10] read host
+        // garbage 0x3d and dereferenced it). CONFIDENCE: HIGH (live probe: thread on host TCB at fault).
+        const uint64_t saved_guest_fs = guest_fs_to_host_scoped();
         if (g_faultlog) {
             char b[128]; auto* uc = (ucontext_t*)uctx;
             int n = snprintf(b, sizeof b, "[fault] sig=%d addr=%p rip=0x%llx armed=%d tid=%ld\n",
@@ -1877,6 +1884,7 @@ namespace {
                     syscall(SYS_write, 2, b, (size_t)n);
                 }
                 g[REG_RIP] = g_fault_rip + 2;   // advance past the 2-byte int instruction
+                guest_fs_restore_scoped(saved_guest_fs);   // resume guest on its guest %fs, not host (#1155)
                 return;
             }
         }
@@ -1890,7 +1898,8 @@ namespace {
             uint64_t foff = strtoull(fsk, nullptr, 0);
             const char* colon = strchr(fsk, ':');
             uint64_t roff = colon ? strtoull(colon + 1, nullptr, 0) : foff + 4;
-            if (g_base && g_fault_rip == g_base + foff) { g[REG_RAX] = 0; g[REG_RIP] = g_base + roff; return; }
+            if (g_base && g_fault_rip == g_base + foff) { g[REG_RAX] = 0; g[REG_RIP] = g_base + roff;
+                guest_fs_restore_scoped(saved_guest_fs); return; }   // resume guest on guest %fs (#1155)
         }
         dump_fault_mem();   // no-op unless PROSPER_FAULTMEM is set
         // Dump the HWBP ring on the recoverable (armed/main-thread) crash too — the deser fault is kind=2.
@@ -1917,6 +1926,21 @@ namespace {
                 rdb(g_fault_rip+4), rdb(g_fault_rip+5), rdb(g_fault_rip+6), rdb(g_fault_rip+7),
                 (unsigned long long)(probe_readable(g_rsp) ? *(const uint64_t*)g_rsp : 0));
             syscall(SYS_write, 2,ib, m);
+            // Guest-%fs attribution (#1155): is the faulting thread running guest code on OUR guest TCB
+            // or leaked onto the host glibc TCB? The guest loads its TCB self-pointer with `mov %fs:0x0`;
+            // at a fault right after, that value is still in rax (the common landing reg) and equals the
+            // fs base. Our guest TCBs carry the "PROS" magic at +0x108; a mismatch means guest code ran
+            // on the host TCB, so any %fs-relative TLS read returned host garbage (the #1155 fault class,
+            // now fixed by restoring guest %fs on signal-handler return-to-guest paths above).
+            {
+                char nm[16] = {0}; prctl(PR_GET_NAME, (unsigned long)nm, 0, 0, 0);
+                bool on_guest_tcb = probe_readable(g_rax + 0x108) &&
+                                    *(const uint32_t*)(uintptr_t)(g_rax + 0x108) == 0x50524F53u;
+                char tb[160];
+                int t = snprintf(tb, sizeof tb, "[fault] thread='%s' fs(rax)=0x%llx on-guest-TCB=%s\n",
+                                 nm, (unsigned long long)g_rax, on_guest_tcb ? "yes" : "NO(host-%fs leak?)");
+                syscall(SYS_write, 2, tb, (size_t)t);
+            }
             // #694: guest control-flow backtrace at the worker fault. When the fault is an intermittent
             // bad-pointer jump (e.g. the Blasphemous 2 asset-load worker reaching non-exec Rosetta memory
             // with ret@[rsp]=0x0), rip is uninformative garbage; the only way to attribute it to a guest

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -11,7 +11,6 @@
 #if defined(__linux__) || defined(__APPLE__)
 #include "posix_shim.hpp"
 #include <sys/mman.h>
-#include <sys/prctl.h>   // PR_GET_NAME — #1155 fault-thread name in the TLS probe
 #include <signal.h>
 #include <setjmp.h>
 #include <pthread.h>
@@ -1933,7 +1932,7 @@ namespace {
             // on the host TCB, so any %fs-relative TLS read returned host garbage (the #1155 fault class,
             // now fixed by restoring guest %fs on signal-handler return-to-guest paths above).
             {
-                char nm[16] = {0}; prctl(PR_GET_NAME, (unsigned long)nm, 0, 0, 0);
+                char nm[16] = {0}; pthread_getname_np(pthread_self(), nm, sizeof nm);   // portable (Linux+macOS)
                 bool on_guest_tcb = probe_readable(g_rax + 0x108) &&
                                     *(const uint32_t*)(uintptr_t)(g_rax + 0x108) == 0x50524F53u;
                 char tb[160];


### PR DESCRIPTION
Fixes #1155.

## Failure scenario

GTA V (PPSA04263, RAGE) crashes deterministically after the intro. `[RAGE] Main Thr` faults at `eboot+0x2b1f0e5`, in a constructor that reads a thread-local:
```
mov %fs:0x0,%rax      ; rax = TCB self-pointer (thread pointer)
mov -0x10(%rax),%rdx  ; rdx = TLS[-0x10]
...
movzbl 0x1018(%rdx),%r10d   ; FAULT — rdx=0x3d, addr 0x1055
```
`rdx` (=`TLS[-0x10]`) comes back `0x3d`, a non-pointer, and gets dereferenced.

## Root cause (live-verified)

A fault-time `%fs` probe showed the crashing thread was running guest code on the **host glibc `%fs`**, not its prosper guest TCB: the value it read from `%fs:0x0` had no `"PROS"` magic at `+0x108`. The eboot's `tpoff -0x10` lives in `.tbss`, so a correctly-initialised guest TLS block reads **0** there and the guest's own null-check (`test rdx,rdx; je`) skips the deref — the `0x3d` is host glibc TLS garbage read through the wrong TCB.

**How the guest got onto host `%fs`:** the SIGSEGV handler swaps `%fs` guest→host on entry (so its host-libc reporting runs on the host TCB). Then the **int `$0x41` debugbreak skip** (#1138) and `PROSPER_FAULT_SKIP` paths resume the guest with `REG_RIP += 2; return;`. On x86-64, **`sigreturn` does not restore `fs_base`**, so the guest resumes on the host `%fs`. RAGE fires int 0x41 constantly, so every skip leaked the thread onto host `%fs` until its next `%fs`-relative TLS read dereferenced host garbage.

## Fix

Capture the guest `%fs` via `guest_fs_to_host_scoped()` at the swap point and call `guest_fs_restore_scoped()` before **both** return-to-guest paths (int-0x41 skip, `PROSPER_FAULT_SKIP`), so guest code always resumes on its own TCB. The fatal/recovery paths (host-libc reporting + `siglongjmp` into host C++) keep host `%fs` exactly as before — they never return to guest code. This reuses the same scoped-swap helpers the handler already uses for `hwbp_dump_ring`.

Also adds a one-line fault-time attribution (`[fault] thread=… on-guest-TCB=yes/NO`) so future host-`%fs` leaks in this class (cf. #644, #89) are diagnosable at a glance.

## Affected / unaffected behavior

- **Affected:** only the two SIGSEGV-handler paths that resume guest execution. They now restore guest `%fs` first.
- **Unaffected:** the fatal report path, the `siglongjmp` recovery path, and the HWBP/HWWATCH diagnostic paths (which already balance their own scoped swap). No change when guest-fs is disabled (`guest_fs_*_scoped` are no-ops off a guest TCB). Not a renderer/recompiler/AGC change → no snapshot impact.

## Result

The `eboot+0x2b1f0e5` TLS fault is gone; RAGE progresses past the intro (8 int-0x41 skips handled, 270 APR reads) into further init, where it hits a **separate SIGFPE** during `libSceVoice` setup — tracked as follow-up, not part of this change. This removes a hard crash (boot progression); no new *rendered* checkpoint yet, so no new screenshot (the intro renders both before and after).

## Risks

Low. Three-line behavioral change confined to the crash handler's return-to-guest paths, using existing tested helpers. The x86-64 `sigreturn`-doesn't-restore-`fs_base` premise is confirmed by the live probe (thread on host TCB at fault) and by the pre-existing code already managing `%fs` explicitly across the handler.

## Testing / verification

- `cmake --build && ctest` — **127/127** on Linux (Messenger dump). (With `GAME_DUMP` pointed at GTA V, `module_loads_eboot`/`boot_reaches_first_syscall` fail on Messenger-specific import counts — a dump-config artifact, unrelated to this change.)
- Live: `PROSPER_GUEST_FS=1 ./prosper-app --dump PPSA04263-app0` — before: deterministic SIGSEGV at `eboot+0x2b1f0e5`; after: fault gone, progresses to the separate SIGFPE.

A unit test for this path is impractical (it requires driving the installed SIGSEGV handler with a fabricated int-0x41 fault on a live guest TCB); verification is the deterministic live A/B plus the green suite. Review requested: reverse-engineered `%fs`/signal semantics in shared infra (`area:infra`).