### PR TITLE
fix(audio): report libSceVoice unavailable so GTA V reaches its title screen (#1158)

### DIFF
--- a/prosper/src/hle/hle_audio.cpp
+++ b/prosper/src/hle/hle_audio.cpp
@@ -2202,7 +2202,10 @@ HLE(ngs2_geom_calc_listener) {
 // a faithful null-backend voice implementation (init succeeds, ports return valid silent parameters)
 // is the alternative if a title ever needs working voice (tracked separately).
 HLE(voice_init_unavailable) {   // sceVoiceInit / sceVoiceInitHQ -> report voice unavailable
-    return (uint64_t)(int64_t)(int32_t)0x80410002;   // negative SCE_VOICE-class error (js-checked by guest)
+    // Negative SCE_VOICE-class error (facility 0x8041; the guest only sign-checks the return via `js`).
+    // Chosen as a HARD, non-retryable init failure: it is NOT the ALREADY_INITIALIZED code (0x80410004,
+    // which some engines treat as success), so the guest takes its "voice off" branch and does not retry.
+    return (uint64_t)(int64_t)(int32_t)0x80410002;
 }
 
 void register_audio_hle() {

--- a/prosper/src/hle/hle_audio.cpp
+++ b/prosper/src/hle/hle_audio.cpp
@@ -2187,10 +2187,33 @@ HLE(ngs2_geom_calc_listener) {
 
 #undef NGS2_LOG
 
+// --- libSceVoice (voice chat, #1158). prosper has no voice-capture backend (no microphone / network
+// voice path). GTA V (PPSA04263, RAGE) initialises voice at boot and, when it believes voice is up,
+// builds a voice context and sizes its ring buffers by DIVIDING by voice-parameter fields (bitrate,
+// samples-per-frame, ...) it obtains from the voice API — e.g. `x * 8000 / bitrate` at eboot+0x26043b0
+// and `x / ctx[+0x2dc0]` at eboot+0x2905... . prosper's generic unimplemented stubs returned 0 WITHOUT
+// writing those outputs, so several divisors were 0 → a cascade of guest integer #DE → SIGFPE.
+//
+// Report the subsystem as unavailable from sceVoiceInit: GTA treats a failed voice init as "voice
+// chat off" (a real state — e.g. voice disabled in system settings / no headset region) and skips its
+// entire voice-buffer setup, so none of the divide-by-zero math runs and boot continues to the title.
+// This is the honest model for a host with no voice hardware, and voice is not needed to reach the
+// title screen. CONFIDENCE: MED — verified live to clear the SIGFPE cascade and reach the GTA V title;
+// a faithful null-backend voice implementation (init succeeds, ports return valid silent parameters)
+// is the alternative if a title ever needs working voice (tracked separately).
+HLE(voice_init_unavailable) {   // sceVoiceInit / sceVoiceInitHQ -> report voice unavailable
+    return (uint64_t)(int64_t)(int32_t)0x80410002;   // negative SCE_VOICE-class error (js-checked by guest)
+}
+
 void register_audio_hle() {
     #define R(str, fn) Hle::register_fn(nid_hash(str), (HleFn)(fn), str)
     R("sceAudioOutInit", audio_init);
     R("sceAudioOutOpen", audio_open);
+    // libSceVoice: report voice unavailable so titles with no host voice backend skip voice-chat
+    // setup instead of #DE'ing on never-written voice-parameter divisors (GTA V, #1158). Both the
+    // standard and HQ init entry points get the same "unavailable" answer.
+    R("sceVoiceInit", voice_init_unavailable);
+    R("sceVoiceInitHQ", voice_init_unavailable);
     R("sceAudioOutOutput", audio_output);
     R("sceAudioOutOutputs", audio_outputs);
     R("sceAudioOutSetVolume", audio_set_volume);


### PR DESCRIPTION
Fixes #1158.

## Checkpoint reached (visible progression)

**GTA V (PPSA04263) now boots Rockstar intro → Grand Theft Auto V title screen** and runs its frame loop stably (208 content frames, 0 faults over the capture window; ~95 fps un-throttled) with no crash. Title, platform, checkpoint: *Grand Theft Auto V*, Linux, `prosper-app` (SDL3/Vulkan) frontend, **title screen** — captured directly with `PROSPER_APP_DUMP_FRAMES` (the GTA V logo + loading spinner render correctly; capture shared with the requester). This is the title-screen bring-up rung after #1149 (async-load completion) and #1155 (guest-%fs on int-0x41).

## Failure scenario

GTA V died with **SIGFPE (integer divide-by-zero)** after the intro. libSceVoice was entirely unimplemented, so prosper's generic stubs returned 0 **without writing their output parameters**. GTA's voice-init path then built a voice context and sized its ring buffers by dividing by never-written voice-parameter fields — a cascade of `#DE`: first `x * 8000 / bitrate` at `eboot+0x26043b0` (the `sceVoiceGetBitRate` output), then `x / ctx[+0x2dc0]` at `eboot+0x2905...` (a context field). prosper doesn't handle SIGFPE, so each was an uninformative core dump.

## Approach

prosper has **no voice-capture backend** (no microphone / network voice path). Report the subsystem as unavailable from `sceVoiceInit` / `sceVoiceInitHQ` (a negative SCE_VOICE-class error). GTA treats a failed voice init as "voice chat off" — a real platform state (voice disabled in settings / no headset region) — and **skips its entire voice-buffer setup**, so none of the divide-by-zero math runs and boot continues to the title.

This is the honest model for a host with no voice hardware, and voice is not needed to reach the title. A **faithful null-backend voice implementation** (init succeeds; ports return valid silent parameters so the buffer math has non-zero divisors) is the alternative if a title ever needs working voice — tracked as follow-up. `CONFIDENCE: MED` — live-verified to clear the SIGFPE cascade and reach the GTA V title.

## Affected / unaffected

- **Affected:** `sceVoiceInit` / `sceVoiceInitHQ` now return a negative error instead of the generic 0-stub. Downstream voice calls are consequently not exercised by GTA (it disables voice).
- **Unaffected:** all non-voice HLE; NGS2/AudioOut/AudioIn are untouched. No renderer/recompiler/AGC change → no snapshot impact.

## Risks

Low–medium. The judgment call is modelling voice as *unavailable* rather than *working-but-silent*. It is verified to reach the title for GTA V and is a real platform state; the faithful full-voice path is deferred. If a title requires voice to be up (rare for reaching a title/menu), it would need the null-backend implementation.

## Verification

- `cmake --build && ctest` → **127/127** on Linux (Messenger dump). (With `GAME_DUMP` = GTA V, the two Messenger-specific loader tests fail on Messenger import counts — a dump-config artifact.)
- Live: `PROSPER_GUEST_FS=1 ./prosper-app --dump PPSA04263-app0` — before: SIGFPE core dump after the intro; after: renders the GTA V title screen, 0 faults.

Review requested: reverse-engineered voice ABI + the unavailable-vs-null-backend judgment call (`area:infra`, `game:gta5`).