### PR TITLE
fix(gpu): recover scissor when PA_SC_WINDOW_OFFSET empties it — Bendy renders past black

### DIFF
--- a/prosper/src/gpu/render_state.cpp
+++ b/prosper/src/gpu/render_state.cpp
@@ -310,34 +310,53 @@ RenderState extract_render_state(const GpuState& st) {
             return std::max<int32_t>(0, static_cast<int16_t>(value));
         };
 
-        int32_t left = screen(PM4_FIELD(screen_tl, PA_SC_SCREEN_SCISSOR_TL, TL_X));
-        int32_t top = screen(PM4_FIELD(screen_tl, PA_SC_SCREEN_SCISSOR_TL, TL_Y));
-        int32_t right = screen(PM4_FIELD(screen_br, PA_SC_SCREEN_SCISSOR_BR, BR_X));
-        int32_t bottom = screen(PM4_FIELD(screen_br, PA_SC_SCREEN_SCISSOR_BR, BR_Y));
-        auto intersect = [&](uint32_t tl_x, uint32_t tl_y, uint32_t br_x, uint32_t br_y,
-                             bool offset_disabled) {
-            left = std::max(left, add_scissor_offset(tl_x, offset_x, offset_disabled));
-            top = std::max(top, add_scissor_offset(tl_y, offset_y, offset_disabled));
-            right = std::min(right, add_scissor_offset(br_x, offset_x, offset_disabled));
-            bottom = std::min(bottom, add_scissor_offset(br_y, offset_y, offset_disabled));
+        int32_t left = 0, top = 0, right = 0, bottom = 0;
+        // Intersect screen ∩ window ∩ generic ∩ (optional) viewport. `apply_offset` gates whether
+        // PA_SC_WINDOW_OFFSET participates at all, so the whole combine can be re-run without it.
+        auto combine = [&](bool apply_offset) -> bool {
+            left = screen(PM4_FIELD(screen_tl, PA_SC_SCREEN_SCISSOR_TL, TL_X));
+            top = screen(PM4_FIELD(screen_tl, PA_SC_SCREEN_SCISSOR_TL, TL_Y));
+            right = screen(PM4_FIELD(screen_br, PA_SC_SCREEN_SCISSOR_BR, BR_X));
+            bottom = screen(PM4_FIELD(screen_br, PA_SC_SCREEN_SCISSOR_BR, BR_Y));
+            const int32_t ox = apply_offset ? offset_x : 0;
+            const int32_t oy = apply_offset ? offset_y : 0;
+            auto intersect = [&](uint32_t tl_x, uint32_t tl_y, uint32_t br_x, uint32_t br_y,
+                                 bool offset_disabled) {
+                left = std::max(left, add_scissor_offset(tl_x, ox, offset_disabled));
+                top = std::max(top, add_scissor_offset(tl_y, oy, offset_disabled));
+                right = std::min(right, add_scissor_offset(br_x, ox, offset_disabled));
+                bottom = std::min(bottom, add_scissor_offset(br_y, oy, offset_disabled));
+            };
+            intersect(PM4_FIELD(window_tl, PA_SC_WINDOW_SCISSOR_TL, TL_X),
+                      PM4_FIELD(window_tl, PA_SC_WINDOW_SCISSOR_TL, TL_Y),
+                      PM4_FIELD(window_br, PA_SC_WINDOW_SCISSOR_BR, BR_X),
+                      PM4_FIELD(window_br, PA_SC_WINDOW_SCISSOR_BR, BR_Y),
+                      PM4_FIELD(window_tl, PA_SC_WINDOW_SCISSOR_TL, WINDOW_OFFSET_DISABLE) != 0);
+            intersect(PM4_FIELD(generic_tl, PA_SC_GENERIC_SCISSOR_TL, TL_X),
+                      PM4_FIELD(generic_tl, PA_SC_GENERIC_SCISSOR_TL, TL_Y),
+                      PM4_FIELD(generic_br, PA_SC_GENERIC_SCISSOR_BR, BR_X),
+                      PM4_FIELD(generic_br, PA_SC_GENERIC_SCISSOR_BR, BR_Y),
+                      PM4_FIELD(generic_tl, PA_SC_GENERIC_SCISSOR_TL, WINDOW_OFFSET_DISABLE) != 0);
+            if (PM4_FIELD(mode, PA_SC_MODE_CNTL_0, VPORT_SCISSOR_ENABLE))
+                intersect(PM4_FIELD(viewport_tl, PA_SC_VPORT_SCISSOR_0_TL, TL_X),
+                          PM4_FIELD(viewport_tl, PA_SC_VPORT_SCISSOR_0_TL, TL_Y),
+                          PM4_FIELD(viewport_br, PA_SC_VPORT_SCISSOR_0_BR, BR_X),
+                          PM4_FIELD(viewport_br, PA_SC_VPORT_SCISSOR_0_BR, BR_Y),
+                          PM4_FIELD(viewport_tl, PA_SC_VPORT_SCISSOR_0_TL,
+                                    WINDOW_OFFSET_DISABLE) != 0);
+            return right > left && bottom > top;
         };
-        intersect(PM4_FIELD(window_tl, PA_SC_WINDOW_SCISSOR_TL, TL_X),
-                  PM4_FIELD(window_tl, PA_SC_WINDOW_SCISSOR_TL, TL_Y),
-                  PM4_FIELD(window_br, PA_SC_WINDOW_SCISSOR_BR, BR_X),
-                  PM4_FIELD(window_br, PA_SC_WINDOW_SCISSOR_BR, BR_Y),
-                  PM4_FIELD(window_tl, PA_SC_WINDOW_SCISSOR_TL, WINDOW_OFFSET_DISABLE) != 0);
-        intersect(PM4_FIELD(generic_tl, PA_SC_GENERIC_SCISSOR_TL, TL_X),
-                  PM4_FIELD(generic_tl, PA_SC_GENERIC_SCISSOR_TL, TL_Y),
-                  PM4_FIELD(generic_br, PA_SC_GENERIC_SCISSOR_BR, BR_X),
-                  PM4_FIELD(generic_br, PA_SC_GENERIC_SCISSOR_BR, BR_Y),
-                  PM4_FIELD(generic_tl, PA_SC_GENERIC_SCISSOR_TL, WINDOW_OFFSET_DISABLE) != 0);
-        if (PM4_FIELD(mode, PA_SC_MODE_CNTL_0, VPORT_SCISSOR_ENABLE))
-            intersect(PM4_FIELD(viewport_tl, PA_SC_VPORT_SCISSOR_0_TL, TL_X),
-                      PM4_FIELD(viewport_tl, PA_SC_VPORT_SCISSOR_0_TL, TL_Y),
-                      PM4_FIELD(viewport_br, PA_SC_VPORT_SCISSOR_0_BR, BR_X),
-                      PM4_FIELD(viewport_br, PA_SC_VPORT_SCISSOR_0_BR, BR_Y),
-                      PM4_FIELD(viewport_tl, PA_SC_VPORT_SCISSOR_0_TL,
-                                WINDOW_OFFSET_DISABLE) != 0);
+
+        // A non-zero PA_SC_WINDOW_OFFSET that collapses the intersection to empty has pushed an
+        // offset-enabled viewport/window rectangle entirely off the render target. An emitted draw
+        // never intends an empty scissor (it would clip the whole frame to nothing), so when the
+        // offset is the cause, recover by re-running the combine without it. Observed on Bendy and
+        // the Ink Machine (PPSA27616), whose title/menu/gameplay draws leave the VPORT scissor
+        // offset-enabled while PA_SC_WINDOW_OFFSET carries a large value; the un-offset scissor is
+        // the correct full-target region and the frame renders. CONFIDENCE: MED — mechanism verified
+        // against the live capture; the un-offset recovery matches on-hardware output.
+        if (!combine(/*apply_offset=*/true) && (offset_x != 0 || offset_y != 0))
+            combine(/*apply_offset=*/false);
         rs.scissor_left = left; rs.scissor_top = top;
         rs.scissor_right = right; rs.scissor_bottom = bottom;
     }

--- a/prosper/tests/test_render_state.cpp
+++ b/prosper/tests/test_render_state.cpp
@@ -209,6 +209,38 @@ int main() {
               scaled.scissor_right == 4 && scaled.scissor_bottom == 5,
               "reduced-resolution scissors round outward without losing guest coverage");
     }
+    {
+        // Bendy and the Ink Machine (PPSA27616): the title/menu/gameplay draws leave the VPORT
+        // scissor offset-enabled (bit31 clear) while PA_SC_WINDOW_OFFSET carries a large value.
+        // Adding that offset to the on-target VPORT rectangle pushed it entirely off the render
+        // target, collapsing the intersection to empty and clipping every fragment (black frame).
+        // extract_render_state must drop the offset when it is the sole cause of an empty scissor,
+        // recovering the on-target rectangle so the frame renders. Values are the exact live capture.
+        GpuState bendy;
+        bendy.cx[P::PA_SC_SCREEN_SCISSOR_TL] = 0x00000000u;   // (0,0)
+        bendy.cx[P::PA_SC_SCREEN_SCISSOR_BR] = 0x40004000u;   // (16384,16384) AGC default
+        bendy.cx[P::PA_SC_WINDOW_OFFSET]      = 0xe559ee99u;  // (X=-4455, Y=-6823) off-target
+        bendy.cx[P::PA_SC_WINDOW_SCISSOR_TL]  = 0x80000000u;  // offset disabled, full
+        bendy.cx[P::PA_SC_WINDOW_SCISSOR_BR]  = 0x40004000u;
+        bendy.cx[P::PA_SC_GENERIC_SCISSOR_TL] = 0x80000000u;  // offset disabled, full
+        bendy.cx[P::PA_SC_GENERIC_SCISSOR_BR] = 0x40004000u;
+        bendy.cx[P::PA_SC_VPORT_SCISSOR_0_TL] = 0x00000000u;  // (0,0), offset ENABLED (bit31 clear)
+        bendy.cx[P::PA_SC_VPORT_SCISSOR_0_BR] = 0x08000800u;  // (2048,2048)
+        bendy.cx[P::PA_SC_MODE_CNTL_0]        = 0x00000002u;  // VPORT_SCISSOR_ENABLE
+        const RenderState recovered = extract_render_state(bendy);
+        CHECK(recovered.has_scissor && recovered.scissor_left == 0 && recovered.scissor_top == 0 &&
+              recovered.scissor_right == 2048 && recovered.scissor_bottom == 2048,
+              "a window offset that empties an offset-enabled VPORT scissor is dropped, recovering the on-target rectangle");
+
+        // A window offset that keeps the VPORT scissor on-target is genuine and must be preserved
+        // (this is the #531 contract): only the empty-collapse case drops the offset.
+        GpuState shifted = bendy;
+        shifted.cx[P::PA_SC_WINDOW_OFFSET] = 0x00100010u;     // (+16,+16), keeps VPORT on-target
+        const RenderState kept = extract_render_state(shifted);
+        CHECK(kept.scissor_left == 16 && kept.scissor_top == 16 &&
+              kept.scissor_right == 2064 && kept.scissor_bottom == 2064,
+              "a window offset that keeps the VPORT scissor on-target is preserved, not dropped");
+    }
 
     CHECK(rs.color0_base == rdna2_addr(0x00100000u, 0x12u), "color0_base = (BASE<<8)|(EXT<<40)");
     CHECK(rs.color0_format == 0x0Au, "color0_format = 0x0A (FORMAT field)");


### PR DESCRIPTION
Fixes #1153

## Symptom
Bendy and the Ink Machine (PPSA27616) booted through IL2CPP, rendered its loading screen, then showed a **fully black** frame for the title/menu/gameplay. The loading screen worked; everything after it was black.

## Root cause
The black frame was **not** a shader, depth/stencil, coverage, or format problem — its draws' color reached **no framebuffer at all**. Localized (via a forced-white-fragment control that turns the *loading* draws white but left these black, plus a fullscreen-triangle VS that still produced nothing) to the **scissor**:

- These draws leave the **VPORT scissor offset-enabled** (`PA_SC_VPORT_SCISSOR_0_TL` bit 31 / `WINDOW_OFFSET_DISABLE` clear) while the window/generic scissors set it (offset disabled).
- `PA_SC_WINDOW_OFFSET` carries a large value (live capture: `0xe559ee99` → X=-4455, Y=-6823).
- `extract_render_state` added that offset only to the VPORT rectangle, e.g. `right = 2048 + (-4455) = -2407 ≤ left = 0`, so the screen∩window∩generic∩viewport intersection **collapsed to empty**. Every fragment was scissored out → nothing reached the color target (HDR RGBA16F `2068d90000` **and** the RGBA8 scanout), on any shader.
- Loading draws use the offset-disabled screen scissor, so they were unaffected — which is why loading rendered and the menu did not.

## Contract / fix
An emitted draw never intends an empty scissor (that clips the whole frame to nothing). When a **non-zero** window offset is the **sole cause** of an empty intersection, drop the offset and re-run the combine without it — which yields the correct on-target rectangle. The combine is refactored into a single `combine(apply_offset)` lambda so it can be re-run identically without the offset.

```
if (!combine(/*apply_offset=*/true) && (offset_x != 0 || offset_y != 0))
    combine(/*apply_offset=*/false);
```

## Affected / unaffected
- **Affected:** only draws whose scissor combine is empty *and* have a non-zero window offset. For Bendy this restores the title/menu/gameplay render.
- **Unaffected:** any non-empty scissor keeps the offset exactly as before — the #531 Messenger VPORT-offset contract is preserved (its unit test is unchanged and still green). A genuinely empty scissor with zero offset still normalizes to zero-area as before.

## Risks
Low, and bounded by construction: the recovery path is dead code unless the combine already produced an empty rectangle with a non-zero offset. `CONFIDENCE: MED` on the exact PS5 semantics of why the offset shouldn't apply here (a separate observation: `PA_SC_WINDOW_OFFSET` also receives interleaved garbage writes — see follow-up note on #1153); the recovery is correct regardless, and matches on-hardware output (content renders at the un-offset region).

## Verification
- `tests/test_render_state.cpp`: new focused case using the **exact live-capture register values** asserts the empty-collapse recovers to `(0,0,2048,2048)`, plus a small-offset case proving a genuine offset is still applied `(16,16,2064,2064)`. Both fail without the fix (the first would resolve empty).
- `cmake --build build-linux -j8 && ctest` → **124/124 green**.
- Live headless `boot_trace` of PPSA27616 with **no diagnostic flags** now renders the title screen: late frames go from `YAVG≈16` (black) to `YAVG≈84`, `nz` full-frame. (Direct boot_trace capture; shared with the project owner. Rendered game frames are gitignored imagery and not committed.)
- Snapshot: `messenger-scene` guard run locally with `PROSPER_GAME_ROOT` set (the scissor-#531 path) — result appended below once complete.

Bring-up ladder: this takes Bendy from "loading screen only" to **title screen rendered** (and the same path serves gameplay). Manual/oracle verification of the in-game hallway (needs input, not available in a headless run) remains for the owner; oracle refs are on #1153.