### PR TITLE
feat(recompiler): support IMAGE_SAMPLE_C_LZ for 2D and CUBE shadow maps

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -856,6 +856,21 @@ struct SpirvCompute {
         const uint32_t bits = bcu(result);
         out[0] = out[1] = out[2] = out[3] = bits;
     }
+    // IMAGE_SAMPLE_C_LZ on a plain 2D depth texture (a spot/directional shadow map): compare the
+    // sampled depth against DREF at explicit LOD zero. Coordinates are (u,v); the comparison result
+    // is scalar and RDNA writes that value for the requested dmask component. Same lowering as the
+    // 2D_ARRAY form without the layer coordinate (used by Bendy's shadow pass, dim=1).
+    void image_sample_dref_lz_2d(uint32_t binding, uint32_t u_bits, uint32_t v_bits,
+                                 uint32_t dref_bits, uint32_t out[4]) {
+        uint32_t si = id(); put(code, Op_Load, {tex_binding_simg[binding], si, tex_var[binding]});
+        uint32_t coord = id();
+        put(code, Op_CompositeConstruct, {t_v2f(), coord, bcf(u_bits), bcf(v_bits)});
+        uint32_t result = id();
+        put(code, Op_ImageSampleDrefExplicitLod,
+            {t_f32, result, si, coord, bcf(dref_bits), ImgOp_Lod, fconstf(0.0f)});
+        const uint32_t bits = bcu(result);
+        out[0] = out[1] = out[2] = out[3] = bits;
+    }
     // image_sample_b 2D: implicit-LOD sample with an LOD BIAS (bias_bits float). Bias only means
     // anything with implicit LOD (fragment derivatives); outside the fragment stage the op resolves
     // like the other samples there — explicit LOD 0 (bias dropped, matching image_sample_2d's rule).
@@ -5927,8 +5942,13 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 // (y-1)) / 6 at base LOD (mips aren't uploaded; a >0 LOD clamps to the one level).
                 // The in-face clamp stops bilinear bleed across face seams. CONFIDENCE: MED — the
                 // coordinate convention is Mesa-verified; face memory layout is validated visually.
-                if (!is_sample && !is_sample_l && !is_sample_lz && !is_sample_b) { ok = false; return true; }
-                const uint32_t ci = is_sample_b ? 1u : 0u;              // _b: bias occupies vaddr0
+                // _c_lz on a CUBE is a point-light shadow cubemap: dref occupies vaddr0 (ISA 8.2.5
+                // dref-first), face coords follow, and the compare lowers onto the same stacked-face
+                // 2D depth image. CONFIDENCE: LOW — the stacked-face compare is not yet frame-validated;
+                // it renders the shadow draw instead of skipping it (which blacks the composite).
+                if (!is_sample && !is_sample_l && !is_sample_lz && !is_sample_b && !is_sample_c_lz) { ok = false; return true; }
+                if (is_sample_c_lz && (uint_texture || !res->depth_compare)) { ok = false; return true; }
+                const uint32_t ci = (is_sample_b || is_sample_c_lz) ? 1u : 0u;   // _b: bias, _c_lz: dref occupies vaddr0
                 uint32_t x = vread(cvg(ci)), y = vread(cvg(ci + 1)), fid = vread(cvg(ci + 2));
                 const uint32_t one = b.uconst(fbits(1.0f)), zero = b.uconst(fbits(0.0f));
                 uint32_t uf = b.fbin(Op_FSub, x, one);
@@ -5936,8 +5956,13 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 uint32_t layer = b.fext1(Glsl_RoundEven,
                                      b.fext2(Glsl_FMax, b.fext2(Glsl_FMin, fid, b.uconst(fbits(5.0f))), zero));
                 uint32_t v6 = b.fbin(Op_FMul, b.fbin(Op_FAdd, layer, vf), b.uconst(fbits(1.0f / 6.0f)));
-                b.declare_texture(res->binding, Dim_2D, uint_texture);
-                b.image_sample_lod_2d(res->binding, uf, v6, b.uconst(0), out);
+                if (is_sample_c_lz) {
+                    b.declare_texture(res->binding, Dim_2D, false, /*arrayed=*/false, /*depth=*/true);
+                    b.image_sample_dref_lz_2d(res->binding, uf, v6, vread(cvg(0)), out);
+                } else {
+                    b.declare_texture(res->binding, Dim_2D, uint_texture);
+                    b.image_sample_lod_2d(res->binding, uf, v6, b.uconst(0), out);
+                }
             } else if (dim3d) {
                 // 3D: implicit-LOD / LOD-0 sample, or an integer texel FETCH (image_load — DOLL's
                 // color-grade 3D LUT, #273).
@@ -5962,14 +5987,24 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 // four consecutive address VGPRs, dref at slot 0 per 8.2.5) and LLVM's own
                 // llvm.amdgcn.image.sample.c.lz lowering (dref before coords). CONFIDENCE: MED —
                 // the #825 lane must re-validate against a real rendered shadow once it lights up.
-                // Integer views and non-array dimensions are not legal for this lowering; reject
-                // rather than silently turning a comparison sample into an ordinary color read.
-                if (in.mimg_dim != 5u || uint_texture || !res->depth_compare) {
+                // Plain 2D (dim=1) is the ordinary spot/directional shadow map — same lowering with
+                // coords [dref,u,v] and no layer (Bendy's shadow pass, live PPSA27616). 2D_ARRAY
+                // (dim=5) adds the layer coord. Integer views and other dimensions are not legal for
+                // this lowering; reject rather than silently turning a comparison sample into an
+                // ordinary color read. CONFIDENCE: HIGH for 2D/2D_ARRAY (ISA 8.2.5 dref-first order,
+                // llvm-mc round-tripped; Dref sample is a standard SPIR-V op).
+                if ((in.mimg_dim != 1u && in.mimg_dim != 5u) || uint_texture || !res->depth_compare) {
                     ok = false; return true;
                 }
-                b.declare_texture(res->binding, Dim_2D, false, true, true);
-                b.image_sample_dref_lz_2d_array(
-                    res->binding, vread(cvg(1)), vread(cvg(2)), vread(cvg(3)), vread(cvg(0)), out);
+                if (in.mimg_dim == 5u) {
+                    b.declare_texture(res->binding, Dim_2D, false, /*arrayed=*/true, /*depth=*/true);
+                    b.image_sample_dref_lz_2d_array(
+                        res->binding, vread(cvg(1)), vread(cvg(2)), vread(cvg(3)), vread(cvg(0)), out);
+                } else {  // dim=1: plain 2D depth texture, coords [dref, u, v]
+                    b.declare_texture(res->binding, Dim_2D, false, /*arrayed=*/false, /*depth=*/true);
+                    b.image_sample_dref_lz_2d(
+                        res->binding, vread(cvg(1)), vread(cvg(2)), vread(cvg(0)), out);
+                }
             } else if (is_gather_lz || is_gather_lz_o) {
                 // gather4 dmask selects ONE channel (must be a single bit); the result is always the
                 // four texels of that channel -> 4 consecutive VDATA VGPRs, gather order preserved.
@@ -8336,7 +8371,9 @@ RecompileCoverage recompile_coverage(const uint32_t* code, size_t dwords) {
                     // #325) — so array-sampling draws recompile+render instead of being skipped.
                     // 0xa0 is the high-bit sibling of image_sample (0x20), lowered identically (GTA V, #1145).
                     if (i.opcode == 0x20u || i.opcode == 0x27u || i.opcode == 0xa0u) return i.mimg_dim == 1u || i.mimg_dim == 2u || i.mimg_dim == 5u;
-                    if (i.opcode == 0x2fu) return i.mimg_dim == 5u; // IMAGE_SAMPLE_C_LZ 2D_ARRAY
+                    // IMAGE_SAMPLE_C_LZ: 2D (spot/dir shadow), CUBE (point-light shadow, stacked-face
+                    // lowering), 2D_ARRAY (cascade). Depth-compare + non-uint enforced at emit.
+                    if (i.opcode == 0x2fu) return i.mimg_dim == 1u || i.mimg_dim == 3u || i.mimg_dim == 5u;
                     if (i.opcode == 0x24u || i.opcode == 0x25u || i.opcode == 0x47u) return i.mimg_dim == 1u || i.mimg_dim == 5u;
                     return false;
                 }

--- a/prosper/tests/test_recompile_coverage.cpp
+++ b/prosper/tests/test_recompile_coverage.cpp
@@ -385,6 +385,22 @@ int main() {
     CHECK(f.unsupported == 0 && f.table_dependent >= 1 && f.first_bad_fmt < 0,
           "#325: a 2D_ARRAY image_sample is recompilable-in-context (base slice), not unsupported");
 
+    // IMAGE_SAMPLE_C_LZ (op 0x2f) is a depth-compare shadow sample. It was accepted only for 2D_ARRAY
+    // (DIM=5); Bendy and the Ink Machine (PPSA27616) uses it for plain 2D (DIM=1, spot/directional
+    // shadow) and CUBE (DIM=3, point-light shadow) maps, which were rejected -> the whole shadow
+    // shader was skipped. Both now recompile (table_dependent -> needs the depth-compare T#/S#), not
+    // unsupported. Same 2D_ARRAY sample bytes with op 0x20->0x2f (bits[24:18]) and DIM 5->1/3 (bits[5:3]).
+    const uint32_t shadow2d[] = { 0xF0BC0F08u, 0x00A30000u, 0xBF810000u };  // C_LZ, DIM=1 (2D)
+    RecompileCoverage s2 = recompile_coverage(shadow2d, sizeof(shadow2d)/sizeof(shadow2d[0]));
+    printf("  shadow2d c_lz: total=%u table_dependent=%u unsupported=%u first_bad_fmt=%d\n",
+           s2.total, s2.table_dependent, s2.unsupported, s2.first_bad_fmt);
+    CHECK(s2.unsupported == 0 && s2.table_dependent >= 1 && s2.first_bad_fmt < 0,
+          "IMAGE_SAMPLE_C_LZ 2D (DIM=1) shadow sample is recompilable-in-context, not unsupported");
+    const uint32_t shadowcube[] = { 0xF0BC0F18u, 0x00A30000u, 0xBF810000u };  // C_LZ, DIM=3 (CUBE)
+    RecompileCoverage sc = recompile_coverage(shadowcube, sizeof(shadowcube)/sizeof(shadowcube[0]));
+    CHECK(sc.unsupported == 0 && sc.table_dependent >= 1 && sc.first_bad_fmt < 0,
+          "IMAGE_SAMPLE_C_LZ CUBE (DIM=3) shadow sample is recompilable-in-context, not unsupported");
+
     const uint32_t cvt_i4[] = { 0x7e001d00u, 0xBF810000u }; // v_cvt_off_f32_i4 v0,v0
     RecompileCoverage g = recompile_coverage(cvt_i4, sizeof(cvt_i4)/sizeof(cvt_i4[0]));
     CHECK(g.total == 1 && g.alu == 1 && g.unsupported == 0,


### PR DESCRIPTION
Fixes #1167. Refs #1164 (Bendy in-game frontier).

## Failure scenario
The RDNA2→SPIR-V recompiler accepted `IMAGE_SAMPLE_C_LZ` (MIMG op 0x2f, depth-compare shadow sample) **only for DIM=5 (2D_ARRAY)**. A shader that samples a plain **2D shadow map (DIM=1)** or a **CUBE shadow map (DIM=3)** with a compare sampler was rejected at the pre-scan gate (`rdna2_to_spirv.cpp:8339`) and the emit branches (~5930 CUBE, ~5967 C_LZ), so the whole shadow/lighting shader — and its draws — were silently skipped. Live Bendy and the Ink Machine (PPSA27616) first-room gameplay rejects op 0x2f DIM=1/DIM=3 up to 256×/frame — the **dominant in-game recompile reject**.

## Contract / approach
Route DIM=1 and DIM=3 through the existing depth-compare lowering (`Op_ImageSampleDrefExplicitLod`, already used by the DIM=5 path):
- New `image_sample_dref_lz_2d` builder — 2D, non-arrayed depth, coords `[dref,u,v]`.
- **DIM=1** → 2D builder. `CONFIDENCE: HIGH` — standard SPIR-V Dref op; the ISA 8.2.5 dref-first vaddr order is the same one the 2D_ARRAY path already uses and llvm-mc round-tripped.
- **DIM=3** → reuse the established CUBE stacked-face coordinate lowering (Mesa `ac_prepare_cube_coords`, already used for ordinary cube samples), then a 2D depth-compare at the computed face coords. `CONFIDENCE: LOW` — not yet frame-validated (see Verification caveat). It renders the draw instead of skipping it, per the charter's "implement, don't skip" rule.
- Pre-scan accepts DIM 1/3/5; emit still enforces depth-compare sampler + non-uint (otherwise reject, fail-visible).

## Affected / unaffected
- **Affected:** shaders using 2D/CUBE `IMAGE_SAMPLE_C_LZ` now recompile+render instead of being skipped. DIM=5 (2D_ARRAY) path is byte-for-byte unchanged.
- **Unaffected:** any shader not using op 0x2f DIM 1/3. Non-compare and integer views still reject at emit.

## Verification
- New `recompile_coverage` unit cases assert the 2D and CUBE C_LZ encodings recompile (`table_dependent`, `unsupported==0`), i.e. they are no longer rejected.
- `cmake --build build-linux -j8 && ctest` → **124/124 green** (all recompiler/spirv-val-gated tests included).
- Live PPSA27616 (`PROSPER_DBG=1`, pad route): the op 0x2f rejects are **eliminated** (only op 0x30 and op 0x7 remain, tracked in #1164).
- Snapshot regression (messenger-scene / dead-cells-gameplay / blasphemous2-gameplay) run locally with the dumps — results posted below.

## Caveat (honest)
This does **not** by itself render Bendy's in-game frame: the scene renders into a compute-lit target but the **composite/present chain stays black** (a separate defect, #1164), and op 0x30 / op 0x7 still reject. So there is no in-game progression screenshot yet — this is a focused recompiler correctness fix (a rejected op is a fatal gap per the charter). The DIM=3 CUBE lowering therefore can't yet be visually validated; reviewers should weigh the `CONFIDENCE: LOW` marking. If preferred, the CUBE half can be split out and held until the composite chain lets the shadow output be seen.