### PR TITLE
recompiler: emit V_ADD_CO_U32 family (VOP3B carry-out add/sub)

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -4756,6 +4756,31 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     else if (in.sdst.kind == OperandKind::SGPR) rs.sreg_bool[in.sdst.value] = carry_masked;
                     else ok = false;
                 }
+            } else if (in.opcode == 0x30F || in.opcode == 0x310 || in.opcode == 0x319) {
+                // v_add_co_u32 (0x30F) / v_sub_co_u32 (0x310) / v_subrev_co_u32 (0x319): 32-bit add/
+                // subtract that writes a carry/borrow-out to the VOP3B sdst mask (VCC or an SGPR pair).
+                // No carry-IN — that is the _co_ci_ family (VOP2 0x28-0x2A / VOP3B 0x128-0x12A). Mirrors
+                // the VOP2 e32 carry emit (0x28-0x2A above) plus the v_mad_u64_u32 carry-out sdst write.
+                // GTA V (PPSA04263) UI/content compute shaders use these; the missing op dropped the whole
+                // shader, so its output texture rendered as bare untextured triangles (#1163/#1165).
+                // CONFIDENCE: HIGH (RDNA2 ISA 6.5/3.9; coverage test in test_recompile_coverage).
+                const uint32_t a = val(in.src[0]), c = val(in.src[1]);
+                uint32_t d, carry;
+                if (in.opcode == 0x30F) {                     // a + c ; carry = unsigned overflow
+                    d = b.ibin(Op_IAdd, a, c);
+                    carry = b.ucmp(Op_ULessThan, d, a);
+                } else {                                      // sub: a-c ; subrev: c-a ; borrow = x < y
+                    const uint32_t x = in.opcode == 0x310 ? a : c;
+                    const uint32_t y = in.opcode == 0x310 ? c : a;
+                    d = b.ibin(Op_ISub, x, y);
+                    carry = b.ucmp(Op_ULessThan, x, y);
+                }
+                vreg[in.dst.value] = d;
+                // ISA 3.9 carry-mask rule: an EXEC-inactive lane's bit is written 0, not its raw carry.
+                const uint32_t carry_masked = rs.exec_narrowed ? b.land(rs.exec, carry) : carry;
+                if (in.sdst.value == 106 || in.sdst.value == 107) rs.vcc = carry_masked;
+                else if (in.sdst.kind == OperandKind::SGPR) rs.sreg_bool[in.sdst.value] = carry_masked;
+                else ok = false;
             } else if (in.opcode == 0x169) {                          // v_mul_lo_u32
                 vreg[in.dst.value] = b.ibin(Op_IMul, val(in.src[0]), val(in.src[1]));
             } else if (in.opcode == 0x16a) {                          // v_mul_hi_u32 (high 32 bits)

--- a/prosper/tests/test_recompile_coverage.cpp
+++ b/prosper/tests/test_recompile_coverage.cpp
@@ -23,6 +23,32 @@ int main() {
     CHECK(a.total == 2 && a.alu == 2 && a.unsupported == 0 && a.first_bad_fmt < 0,
           "a fully-handled ALU kernel reports 100% coverage");
 
+    // v_add_co_u32 / v_sub_co_u32 / v_subrev_co_u32 (VOP3B carry-out add/subtract, ops 0x30F/0x310/
+    // 0x319). GTA V's (PPSA04263) texture-decode compute kernel advances a 64-bit flat source pointer
+    // with v_add_co_u32; before this op emitted, the whole kernel was rejected at first_bad_op=0x30f,
+    // so the decoded texture never rendered (#1163/#1165 investigation). Encodings are byte-identical
+    // to that kernel's pc=0030 instruction: op in bits[25:16], sdst=vcc, dst=v1, src0=s12, src1=v6.
+    const uint32_t co_code[] = {
+        0xd70f6a01u, 0x00020c0cu,   // v_add_co_u32    v1, vcc, s12, v6
+        0xd7106a01u, 0x00020c0cu,   // v_sub_co_u32    v1, vcc, s12, v6
+        0xd7196a01u, 0x00020c0cu,   // v_subrev_co_u32 v1, vcc, s12, v6
+        0xBF810000u,                // s_endpgm
+    };
+    RecompileCoverage co = recompile_coverage(co_code, sizeof(co_code)/sizeof(co_code[0]));
+    CHECK(co.total == 3 && co.alu == 3 && co.unsupported == 0 && co.first_bad_fmt < 0,
+          "v_add/sub/subrev_co_u32 (VOP3B carry-out) recompile as supported ALU");
+
+    // Coverage only inspects emit_alu's `ok` flag and discards the SPIR-V; also prove v_add_co_u32
+    // lowers to a real, well-formed module (VGPR operands this time: v2 = v0 + v1, carry->vcc). Without
+    // the emit branch recompile_valu returns {}; with it, a valid module (magic 0x07230203) is produced.
+    const uint32_t co_valu[] = {
+        0xd70f6a02u, 0x00020300u,   // v_add_co_u32 v2, vcc, v0, v1
+        0xBF810000u,                // s_endpgm
+    };
+    std::vector<uint32_t> co_spv = recompile_valu(co_valu, sizeof(co_valu)/sizeof(co_valu[0]), 2, 2);
+    CHECK(!co_spv.empty() && co_spv[0] == 0x07230203u,
+          "v_add_co_u32 lowers to a valid compute SPIR-V module");
+
     // tbuffer_load_format_x v0, v0, s[8:11], 0 format:32_FLOAT ; s_endpgm.
     // MTBUF needs a resolved V# binding, so the table-less coverage pass must classify it as
     // recompilable-in-context rather than truly unsupported.


### PR DESCRIPTION
## What & why

`emit_alu` (RDNA2→SPIR-V recompiler) did not handle the VOP3B **carry-out-only** add/subtract family:

| op | mnemonic |
|----|----------|
| 0x30F | `v_add_co_u32` |
| 0x310 | `v_sub_co_u32` |
| 0x319 | `v_subrev_co_u32` |

It already had the carry-**in** variants (`v_add_co_ci_u32`: VOP2 0x28-0x2A / VOP3B 0x128-0x12A) and the compound `v_mad_u64_u32` (0x176), but not these. Any shader containing one was rejected at that instruction (`[recompile-reject] … op=0x30f`) and the entire program was dropped.

## Failure scenario

GTA V (PPSA04263) fills its loading-screen collages, legal/disclaimer text (#1165), and main-menu art (#1163) with a `memory→image` texture-decode compute kernel, `exec_cs_2042d47600`, that advances a 64-bit source pointer with `v_add_co_u32` before a `flat_load_ubyte`. Recompilation bailed at op 0x30F, so the decoded texture was never produced and the fullscreen quad sampling it showed only its vertex-shaded triangles.

## Approach

New `emit_alu` branch:
- destination VGPR ← `IAdd` (add) / `ISub` (sub: `a-c`; subrev: `c-a`);
- carry/borrow-out ← `ULessThan` (`sum < a` for add; `minuend < subtrahend` for sub/subrev);
- carry written to the VOP3B `sdst` mask (VCC or an SGPR pair) through the **same EXEC-masked path** as `v_mad_u64_u32`'s carry-out (an inactive lane contributes 0, per ISA 3.9). No carry-in.

The single primary-destination VGPR is written directly (no `predicate_write`), matching `v_mad_u64_u32`'s lo-write and `v_mul_lo`; only extra registers (e.g. a hi-dword) need explicit EXEC predication.

## Behavioral contract / invariants

- Only shaders that **contain** ops 0x30F/0x310/0x319 change path; all others are byte-identical (new `else if` in the VOP3 chain).
- A shader previously rejected solely at one of these ops now recompiles and executes; one still blocked by a later unsupported op stays rejected (fail-visible), unchanged.
- Carry semantics reuse the proven primitives already used by `v_mad_u64_u32` and the VOP2 carry ops.

## Scope note (does NOT close #1163/#1165)

This is a **prerequisite**, not the full fix. It only advanced `exec_cs_2042d47600`'s rejection from pc=0030 (op 0x30F) to pc=0040 (`flat_load_ubyte`). The closing blocker is **general `FLAT_LOAD`** (raw 64-bit-address memory reads), a from-scratch GPU memory-model frontier tracked in **#1171**. `Fixes #1170` (the op itself); #1163/#1165 stay open pending #1171.

## Tests

- `test_recompile_coverage`: new assertion that the three ops recompile as supported ALU (`unsupported==0`, `first_bad_fmt<0`), using **byte-identical encodings** from the GTA kernel's pc=0030 instruction (`0xd70f6a01,0x00020c0c` = `v_add_co_u32 v1, vcc, s12, v6`). Without the fix this fails with `first_bad_op=0x30f`.
- `ctest` (Linux) — **127/127** with the Messenger dump. Under the GTA dump (`GAME_DUMP=PPSA04263`) two loader tests (`module_loads_eboot`, `boot_reaches_first_syscall`) fail because they assert Messenger import counts; both **pass** after reconfiguring to `PPSA24651` — a pre-existing dump-config artifact, unrelated to this change.
- `snapshot.py check` — **all four routes OK, exit 0** (no rendering regression):
  - `messenger-scene`: OK (29 frames)
  - `evergate-title`: OK (52,599 colors)
  - `dead-cells-gameplay`: OK (compute-heavy; 9,669 colors, 44 frames)
  - `blasphemous2-gameplay`: OK (1920×1080, 98 frames)

## Risk

Low. Trivial ALU lowering reusing verified carry primitives; spirv-val-gated; no title's rendered shader in the snapshot set was observed to newly-recompile (GTA's only 0x30F user still rejects at the FLAT load).
