### PR TITLE
recompiler: analyze_flat_loads — resolve general FLAT loads to a base SGPR pair (#1171 piece 1)

### DIFF
--- a/prosper/docs/FLAT_LOAD_DESIGN.md
+++ b/prosper/docs/FLAT_LOAD_DESIGN.md
@@ -1,0 +1,122 @@
+# General FLAT_LOAD design (#1171) — raw 64-bit-address memory reads in the compute recompiler
+
+**Status:** design / feasibility (2026-07-22). No implementation yet. Closing blocker for GTA V (PPSA04263)
+#1163/#1165 (loading-screen collage + missing legal text), whose content is produced by the rejected
+texture-decode compute kernel `exec_cs_2042d47600`.
+
+## The problem
+
+A general FLAT load reads from a raw 64-bit guest GPU virtual address held in a VGPR pair. prosper's
+recompiler only models FLAT for the compiler's private scratch spill (a per-invocation `SC_Function`
+array with no host address — `rdna2_to_spirv.cpp:5206-5241`, `analyze_static_scratch` :137-182). Every
+other FLAT/GLOBAL form fails-visible (`ok=false`), so any shader with a real flat load is dropped whole.
+
+The blocking kernel (`shader_inspect exec_cs_2042d47600.bin`) is a linear-buffer → image **decode loop**:
+
+```
+pc=0030 v_add_co_u32   v1, vcc, s12, v6      ; v[1:2] = s[12:13] + per-lane offset  (#1170 unblocked this)
+pc=0036 v_add_co_u32   v2, vcc, s13, ...     ; high dword of the address
+pc=0040 flat_load_ubyte v0, v[1:2]           ; <-- REJECTED: read src byte at a raw 64-bit address
+pc=0047-0049 v_mov      v1=v0,v2=v0,v3=v0    ; broadcast byte -> RGBA
+pc=0050 image_store     v[0:3], v[4:5], s[0:7]  ; write decoded texel (MIMG already supported)
+pc=0052 s_branch pc=3                        ; loop over pixels
+```
+
+The address is **`s[12:13]` (a 64-bit base pointer passed as a kernel argument in user-SGPRs) + a
+per-lane byte offset**. The base is a *resolvable kernel argument*, not an arbitrary runtime pointer —
+this is what makes the design tractable.
+
+## Why not `buffer_device_address` / PhysicalStorageBuffer
+
+The most "general" approach — expose guest memory at its guest VA via `VK_KHR_buffer_device_address` and
+dereference the 64-bit pointer directly — is **rejected**:
+- The emitted SPIR-V uses the `Logical` addressing model (`rdna2_to_spirv.cpp:1398`), which forbids
+  physical-storage pointers. Switching to `PhysicalStorageBuffer64` is a deep, cross-cutting change to
+  every emitted module.
+- It requires placing host buffers at an exact device address matching the guest VA, which no portable
+  Vulkan path guarantees (and llvmpipe, prosper's software renderer, would need it too).
+- prosper has **zero** device-address infra today (repo-wide grep: no `bufferDeviceAddress`,
+  `PhysicalStorageBuffer`, `VkDeviceAddress`).
+
+## The design: flat-address → windowed SSBO (reuses the existing buffer path)
+
+**Core idea.** Bind the guest allocation that contains the base pointer as an ordinary host-visible
+Vulkan SSBO — the *exact same* per-resource create + `memcpy`-from-guest + STORAGE_BUFFER path already
+used for MUBUF buffer loads (`live_compute.cpp:838-888`, `ShaderResource{gpu_addr,size,binding}` at
+`shader_resources.hpp:99-214`) — and lower the flat load to an indexed read into that SSBO.
+
+Because guest GPU VA == host virtual address (1:1 identity map; `exec_image_linux.cpp:1281`), the base
+pointer value *is* a host pointer, and the containing allocation's extent is already discoverable via
+`host::guest_readable_mapping_containing(base)` (`guest_memory_map.hpp:141`).
+
+### Recompiler side (`rdna2_to_spirv.cpp`)
+
+1. **`analyze_flat_loads` (new).** For each non-scratch FLAT load (`flat_segment != 1`, VADDR present,
+   `saddr == NULL(125)`, `access.valid`), const-fold the VADDR VGPR pair back to
+   `base_user_sgpr_pair + residual_offset`. This is the same class of const-fold already implemented for
+   descriptor recovery (`resolve_dynamic_fetch`, `add_compute_buffer_resources` at
+   `gpu_executor.cpp:2029-2121`), extended to VGPR dataflow tracing a `v_add_co_u32`/`v_add_co_ci_u32`
+   pair whose high/low addends are two consecutive user SGPRs. On success record
+   `{fetch_pc, base_sgpr_index, bits, sign_extend, dst}`; on failure keep today's fail-visible `ok=false`.
+2. **Declare one "flat window" SSBO binding** (`SC_StorageBuffer`, reusing `declare_cbufs` machinery at
+   `rdna2_to_spirv.cpp:1326-1355`) assigned by the resource table (below).
+3. **Emit the load** as an indexed SSBO read: the shader already computes `flat_address = base + offset`
+   in SSA, and `base` (= `s[12:13]`) is already a push-constant (`load_push_constant`, :1371-1378). So
+   `byte_offset = low32(flat_address64 - base64)` (which reduces to the residual offset the shader
+   already computed), then `SSBO_flat[byte_offset >> 2]` with the existing sub-dword extract used by
+   `buffer_load_ubyte/ushort` (`rdna2_to_spirv.cpp:5265-5268`). Read-only: no writeback.
+
+### Executor / resource side (`gpu_executor.cpp` compute discovery + `live_compute.cpp`)
+
+4. **Register a flat-window `ShaderResource`** during compute resource discovery (alongside
+   `add_compute_buffer_resources`, `gpu_executor.cpp:2798-2811`): read the traced base pointer from the
+   dispatch's user SGPRs — `gpu_addr = user_sgprs[i] | (user_sgprs[i+1] << 32)` (values already read by
+   `read_user_sgprs` :2796) — set `size = ` remaining bytes of the containing guest allocation
+   (`guest_readable_mapping_containing`, clamped to a max window, e.g. 256 MiB), and assign it a binding
+   via `assign_convention_bindings` (:2140-2149).
+5. **No new upload code.** `live_compute.cpp:838-888` already creates a host-visible SSBO of `size`,
+   `memcpy`s guest bytes from `(uint8_t*)(uintptr_t)gpu_addr`, and binds it as STORAGE_BUFFER, with
+   exact-range aliasing (:846-858). The flat window is just another resource in the table.
+
+### What is new vs. reused
+
+| Piece | New? |
+|-------|------|
+| Guest-memory → host-visible SSBO create + memcpy + bind | **Reused** (`live_compute.cpp:838-888`) |
+| `ShaderResource{gpu_addr,size,binding}` + `by_binding` | **Reused** (`shader_resources.hpp`) |
+| Push-constant delivery of `s[12:13]` base pointer | **Reused** (`load_push_constant`) |
+| Sub-dword (ubyte/ushort) extract from an SSBO dword | **Reused** (MUBUF raw_subword path) |
+| Containing-allocation lookup | **Reused** (`guest_readable_mapping_containing`) |
+| **Flat-address → base-SGPR-pair + offset const-fold** | **New** (extends `resolve_dynamic_fetch`) |
+| **Non-scratch FLAT load emission** using the window binding | **New** (~30 lines in the FLAT case) |
+| **Flat-window resource registration** from traced base | **New** (~20 lines in compute discovery) |
+
+## Bounds / correctness
+
+- **Window size.** A raw pointer carries no size (unlike a V#). Bind the containing guest allocation
+  (clamped to a max). Out-of-window indices read 0 via SSBO runtime-array robustness or an explicit
+  bounds check — a loose match to hardware's bounded-read contract. Confidence: MED; validate the window
+  covers the real access range on GTA.
+- **Base-tracing fragility.** If the flat address is not a `base_user_sgpr_pair + offset` shape (pointer
+  chasing, indirect tables), the const-fold fails and the load stays fail-visible — correct and safe, no
+  silent wrong data. Confidence: HIGH that the decode kernel is the simple shape; unknown coverage of
+  other titles.
+- **FLAT stores** (`0x18/0x1a/0x1c`) are out of scope here (read-only decode). A later store would need
+  writeback (the compute path already writes reflected SSBOs back).
+- **Non-compute FLAT** (graphics stages) is out of scope; this targets the compute decode path.
+
+## Implementation plan (reviewable pieces)
+
+1. **Base-tracing analysis** — pure, unit-testable in `test_dynfetch_fold` / a new test: assert the
+   decode kernel's flat address folds to `{s12, offset}`. No Vulkan.
+2. **FLAT load emission** — extend the FLAT case to emit the windowed SSBO read; round-trip via
+   `recompile_valu`/`recompile_compute`, spirv-val gated.
+3. **Executor flat-window registration** — reuse live_compute; unit-cover the resource shape.
+4. **End-to-end** — run GTA, confirm `exec_cs_2042d47600` recompiles + executes and the loading-screen
+   collage / legal text render against the user's #1163/#1165 oracles. Snapshot regression + review.
+
+## Empirical validation still to do
+
+- Capture the live dispatch's user SGPRs for `exec_cs_2042d47600` to confirm `s[12:13]` is a valid mapped
+  guest pointer in the GPU-memory range (`0x1000000000+`) and see the source allocation's extent.
+- Confirm the per-lane offset range stays within the chosen window.

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -8298,6 +8298,81 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
     return b.finish();
 }
 
+// See FlatLoadInfo / analyze_flat_loads in the header (#1171). A `base + offset` flat address VGPR pair
+// v[N:N+1] is computed as vN = add(base_lo_sgpr, offset_lo) [carry-out] and v(N+1) =
+// add(base_hi_sgpr, offset_hi, carry) [carry-in], where s[base_lo:base_hi] are consecutive user SGPRs
+// holding a 64-bit guest pointer (the low kernel-arg pointer dword feeds the low address dword). We
+// identify the base by the NEAREST prior definition of each address dword being an integer add that
+// reads a user-range SGPR, and require the low dword to add the SGPR one below the high dword's.
+// Anything else (a non-add producer, a non-user SGPR, a store/atomic/LDS/global-with-saddr form) leaves
+// the load unresolved so the caller keeps failing visibly. flat_access_info lives in this TU's
+// anonymous namespace but is visible here (internal linkage is still TU-wide).
+FlatLoadAnalysis analyze_flat_loads(const uint32_t* code, size_t dwords, uint32_t user_sgpr_count) {
+    std::vector<Rdna2Inst> ins;
+    rdna2_walk(code, dwords, ins);
+    FlatLoadAnalysis out;
+
+    auto writes_vgpr = [](const Rdna2Inst& d, uint32_t reg) {
+        return d.dst.kind == OperandKind::VGPR && static_cast<uint32_t>(d.dst.value) == reg;
+    };
+    // If `d` is an integer add that could produce a 64-bit-pointer dword, return the user-range SGPR it
+    // adds (else -1). Recognizes the add_co / add_co_ci / add_nc forms a compiler emits for pointer
+    // arithmetic: VOP2 0x25 (add_nc) / 0x28 (add_co_ci), VOP3 0x30F (add_co) / 0x125 (add_nc) / 0x128
+    // (add_co_ci).
+    auto add_user_sgpr = [&](const Rdna2Inst& d) -> int32_t {
+        const bool is_add =
+            (d.fmt == Rdna2Format::VOP2 && (d.opcode == 0x25 || d.opcode == 0x28)) ||
+            (d.fmt == Rdna2Format::VOP3 &&
+             (d.opcode == 0x30F || d.opcode == 0x125 || d.opcode == 0x128));
+        if (!is_add) return -1;
+        for (int s = 0; s < 2; ++s)
+            if (d.src[s].kind == OperandKind::SGPR && d.src[s].value >= 0 &&
+                static_cast<uint32_t>(d.src[s].value) < user_sgpr_count)
+                return d.src[s].value;
+        return -1;
+    };
+    // The user-range SGPR added by the nearest prior writer of `reg` (or -1 if that writer is not a
+    // user-SGPR add). We trust only the immediate definition — a later non-add redefinition breaks the
+    // pattern and must not be skipped over.
+    auto prior_add_sgpr = [&](uint32_t reg, size_t before) -> int32_t {
+        for (size_t j = before; j-- > 0;)
+            if (!ins[j].is_end && writes_vgpr(ins[j], reg))
+                return add_user_sgpr(ins[j]);
+        return -1;
+    };
+
+    for (size_t i = 0; i < ins.size(); ++i) {
+        const Rdna2Inst& in = ins[i];
+        if (in.is_end) break;
+        if (in.fmt != Rdna2Format::FLAT) continue;
+        if (in.flat_segment == 1u) continue;   // scratch spill: analyze_static_scratch owns it
+        out.any = true;
+        const FlatAccessInfo access = flat_access_info(in.opcode);
+        FlatLoadInfo info;
+        info.load_pc = in.pc;
+        info.vaddr_lo_reg = in.src[0].kind == OperandKind::VGPR
+                                ? static_cast<uint32_t>(in.src[0].value) : 0u;
+        info.dst_reg = static_cast<uint32_t>(in.dst.value);
+        info.bits = access.bits;
+        info.components = access.components;
+        info.sign_extend = access.sign_extend;
+        // Resolvable only as a plain LOAD with a VGPR address pair and a null SADDR (true flat segment).
+        const bool shape = access.valid && !access.store && !in.flat_lds &&
+                           in.src[0].kind == OperandKind::VGPR &&
+                           in.src[1].kind == OperandKind::Special && in.src[1].value == 125;
+        if (shape) {
+            const uint32_t lo = info.vaddr_lo_reg, hi = lo + 1;
+            const int32_t hi_base = prior_add_sgpr(hi, i);
+            const int32_t lo_base = prior_add_sgpr(lo, i);
+            if (hi_base > 0 && lo_base == hi_base - 1)
+                info.base_sgpr = lo_base;
+        }
+        if (info.base_sgpr < 0) out.all_resolved = false;
+        out.loads.push_back(info);
+    }
+    return out;
+}
+
 RecompileCoverage recompile_coverage(const uint32_t* code, size_t dwords) {
     std::vector<Rdna2Inst> ins;
     rdna2_walk(code, dwords, ins);

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -8307,6 +8307,10 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
 // Anything else (a non-add producer, a non-user SGPR, a store/atomic/LDS/global-with-saddr form) leaves
 // the load unresolved so the caller keeps failing visibly. flat_access_info lives in this TU's
 // anonymous namespace but is visible here (internal linkage is still TU-wide).
+// Resolution is over LINEAR program order (not CFG-aware). That is exact for the target decode kernels
+// (the address adds sit in the same block immediately before the load) and the base is a loop-invariant
+// kernel-arg pointer, so the resolved base is stable across loop iterations; the executor's
+// guest_readable_mapping_containing validation is the runtime backstop against a bogus base.
 FlatLoadAnalysis analyze_flat_loads(const uint32_t* code, size_t dwords, uint32_t user_sgpr_count) {
     std::vector<Rdna2Inst> ins;
     rdna2_walk(code, dwords, ins);

--- a/prosper/src/gpu/rdna2_to_spirv.hpp
+++ b/prosper/src/gpu/rdna2_to_spirv.hpp
@@ -185,4 +185,29 @@ struct RecompileCoverage {
 };
 RecompileCoverage recompile_coverage(const uint32_t* code, size_t dwords);
 
+// A general (non-scratch) FLAT load resolved to a base user-SGPR pointer pair (#1171). The 64-bit
+// address VGPR pair of a `base + offset` flat access is `v[vaddr_lo_reg : vaddr_lo_reg+1]`, and the
+// base pointer's low/high dwords live in consecutive user SGPRs `s[base_sgpr : base_sgpr+1]`. With the
+// base identified, the executor can bind the containing guest allocation as an SSBO and the emitter can
+// lower the load to an indexed read.
+struct FlatLoadInfo {
+    uint32_t load_pc = 0;        // dword offset of the flat_load in the stream
+    uint32_t vaddr_lo_reg = 0;   // VADDR VGPR; the 64-bit address pair is v[vaddr_lo_reg : +1]
+    uint32_t dst_reg = 0;        // first destination VGPR
+    uint32_t bits = 0;           // access width in bits: 8 / 16 / 32
+    uint32_t components = 0;     // dword count (x1/x2/x3/x4)
+    bool     sign_extend = false;
+    int32_t  base_sgpr = -1;     // resolved base-pointer low-dword user-SGPR (high dword is +1); -1 = unresolved
+};
+struct FlatLoadAnalysis {
+    bool any = false;            // at least one general (non-scratch) FLAT memory op is present
+    bool all_resolved = true;    // every general FLAT op is a resolvable load (false => keep rejecting)
+    std::vector<FlatLoadInfo> loads;
+};
+// Identify general FLAT loads (segment != scratch) and resolve each to a base user-SGPR pointer pair,
+// so a windowed-SSBO lowering can replace today's fail-visible reject (#1171). Fail-visible by design:
+// any store/atomic/LDS/global-with-saddr form, or an address that does not reduce to
+// `user_sgpr_pair + offset`, leaves `all_resolved=false` and the caller keeps rejecting the shader.
+FlatLoadAnalysis analyze_flat_loads(const uint32_t* code, size_t dwords, uint32_t user_sgpr_count);
+
 } // namespace prosper::gpu

--- a/prosper/tests/test_recompile_coverage.cpp
+++ b/prosper/tests/test_recompile_coverage.cpp
@@ -49,6 +49,34 @@ int main() {
     CHECK(!co_spv.empty() && co_spv[0] == 0x07230203u,
           "v_add_co_u32 lowers to a valid compute SPIR-V module");
 
+    // analyze_flat_loads (#1171): resolve a general (non-scratch) flat_load's 64-bit address to its base
+    // user-SGPR pointer pair. Encodings are byte-identical to GTA V's texture-decode kernel
+    // exec_cs_2042d47600 (pc=0030/0040): the low address dword adds base-low s12, the high dword adds
+    // base-high s13, so v[1:2] = s[12:13] + offset and the resolved base is s12.
+    const uint32_t flat_code[] = {
+        0xd70f6a01u, 0x00020c0cu,   // v_add_co_u32    v1, vcc, s12, v6      (addr low  = s12 + v6)
+        0x50041af9u, 0x86860680u,   // v_add_co_ci_u32 v2, vcc, 0, s13 (sdwa) (addr high = s13 + carry)
+        0xdc200000u, 0x007d0001u,   // flat_load_ubyte v0, v[1:2]
+        0xBF810000u,                // s_endpgm
+    };
+    FlatLoadAnalysis fla = analyze_flat_loads(flat_code, sizeof(flat_code)/sizeof(flat_code[0]), 16);
+    CHECK(fla.any && fla.all_resolved && fla.loads.size() == 1 &&
+          fla.loads[0].base_sgpr == 12 && fla.loads[0].vaddr_lo_reg == 1 &&
+          fla.loads[0].dst_reg == 0 && fla.loads[0].bits == 8 && !fla.loads[0].sign_extend,
+          "analyze_flat_loads resolves v[1:2]=s[12:13]+offset flat_load_ubyte to base s12");
+
+    // Negative: an address whose HIGH dword is a plain VGPR move (not a user-SGPR add) is unresolvable,
+    // so the load stays fail-visible (all_resolved=false) rather than binding a bogus window.
+    const uint32_t flat_unres[] = {
+        0xd70f6a01u, 0x00020c0cu,   // v_add_co_u32    v1, vcc, s12, v6
+        0x7e040300u,                // v_mov_b32       v2, v0             (high dword not from a user SGPR)
+        0xdc200000u, 0x007d0001u,   // flat_load_ubyte v0, v[1:2]
+        0xBF810000u,                // s_endpgm
+    };
+    FlatLoadAnalysis flu = analyze_flat_loads(flat_unres, sizeof(flat_unres)/sizeof(flat_unres[0]), 16);
+    CHECK(flu.any && !flu.all_resolved && flu.loads.size() == 1 && flu.loads[0].base_sgpr < 0,
+          "analyze_flat_loads leaves a non-pointer-arithmetic flat address unresolved (fail-visible)");
+
     // tbuffer_load_format_x v0, v0, s[8:11], 0 format:32_FLOAT ; s_endpgm.
     // MTBUF needs a resolved V# binding, so the table-less coverage pass must classify it as
     // recompilable-in-context rather than truly unsupported.

--- a/prosper/tests/test_recompile_coverage.cpp
+++ b/prosper/tests/test_recompile_coverage.cpp
@@ -54,8 +54,8 @@ int main() {
     // exec_cs_2042d47600 (pc=0030/0040): the low address dword adds base-low s12, the high dword adds
     // base-high s13, so v[1:2] = s[12:13] + offset and the resolved base is s12.
     const uint32_t flat_code[] = {
-        0xd70f6a01u, 0x00020c0cu,   // v_add_co_u32    v1, vcc, s12, v6      (addr low  = s12 + v6)
-        0x50041af9u, 0x86860680u,   // v_add_co_ci_u32 v2, vcc, 0, s13 (sdwa) (addr high = s13 + carry)
+        0xd70f6a01u, 0x00020c0cu,   // v_add_co_u32    v1, vcc, s12, v6   (addr low  = s12 + v6)
+        0x50041af9u, 0x86860680u,   // v_add_co_ci_u32 v2 (sdwa), addend s13  (addr high = s13 + carry)
         0xdc200000u, 0x007d0001u,   // flat_load_ubyte v0, v[1:2]
         0xBF810000u,                // s_endpgm
     };
@@ -76,6 +76,20 @@ int main() {
     FlatLoadAnalysis flu = analyze_flat_loads(flat_unres, sizeof(flat_unres)/sizeof(flat_unres[0]), 16);
     CHECK(flu.any && !flu.all_resolved && flu.loads.size() == 1 && flu.loads[0].base_sgpr < 0,
           "analyze_flat_loads leaves a non-pointer-arithmetic flat address unresolved (fail-visible)");
+
+    // Negative: both dwords are valid user-SGPR adds but the base SGPRs are NON-CONSECUTIVE (low adds
+    // s12, high adds s15). This must stay unresolved — resolving it to s12 would bind an s[12:13] window
+    // for an address whose high dword is s15, i.e. silent wrong data. Guards the `lo_base==hi_base-1`
+    // invariant (without that clause this would wrongly resolve to base s12).
+    const uint32_t flat_split[] = {
+        0xd70f6a01u, 0x00020c0cu,   // v_add_co_u32    v1, vcc, s12, v6   (low base = s12)
+        0x5004000fu,                // v_add_co_ci_u32 v2, vcc, s15, v0   (high base = s15, NOT s13)
+        0xdc200000u, 0x007d0001u,   // flat_load_ubyte v0, v[1:2]
+        0xBF810000u,                // s_endpgm
+    };
+    FlatLoadAnalysis fls = analyze_flat_loads(flat_split, sizeof(flat_split)/sizeof(flat_split[0]), 16);
+    CHECK(fls.any && !fls.all_resolved && fls.loads.size() == 1 && fls.loads[0].base_sgpr < 0,
+          "analyze_flat_loads rejects a non-consecutive base SGPR pair (s12 low / s15 high)");
 
     // tbuffer_load_format_x v0, v0, s[8:11], 0 format:32_FLOAT ; s_endpgm.
     // MTBUF needs a resolved V# binding, so the table-less coverage pass must classify it as


### PR DESCRIPTION
## What & why (Piece 1 of #1171)

First, cleanly-separable piece of **general FLAT_LOAD** support — the closing blocker for GTA V (PPSA04263) #1163/#1165, whose loading-screen collage + legal text are produced by a texture-decode compute kernel (`exec_cs_2042d47600`) that reads a source byte at a raw 64-bit guest address and is currently rejected whole.

This PR adds:
- **`prosper/docs/FLAT_LOAD_DESIGN.md`** — the full design + feasibility (flat-address → windowed SSBO, reusing the existing per-resource host-visible SSBO path; `buffer_device_address` rejected because the emitted SPIR-V is `Logical`-addressing and prosper has zero device-address infra).
- **`analyze_flat_loads`** (`rdna2_to_spirv.{hpp,cpp}`) — identifies general (non-scratch) FLAT loads and resolves each 64-bit address VGPR pair to its base **user-SGPR pointer pair**. A `base + offset` address is `vN = add(base_lo_sgpr, offset)` and `v(N+1) = add(base_hi_sgpr, …, carry)` with `s[base_lo:base_hi]` two consecutive user SGPRs; we identify the base by the nearest prior definition of the high address dword being an integer add reading a user-range SGPR, with the low dword adding the SGPR one below. Anything else (store/atomic/LDS/global-with-saddr, or an address that doesn't reduce to `user_sgpr_pair + offset`) stays **unresolved / fail-visible**.

## Behavioral contract / invariants

- **No behavior change.** `analyze_flat_loads` is new and is called only by its test; no existing code path (emit, recompile, executor, render) is modified. The emitter + executor that *consume* `base_sgpr` — the windowed-SSBO lowering — are the immediate follow-up on this same branch/issue (pieces 2–3), landing before anything renders differently.
- Fail-visible is preserved: an unresolved flat load leaves `all_resolved=false`, so the caller keeps rejecting the shader exactly as today.

## Tests

- **`test_recompile_coverage`** (pure, CI): resolves the base to `s12` on **byte-identical encodings from GTA's `exec_cs_2042d47600`** (`v_add_co_u32 v1,vcc,s12,v6` low; the SDWA `v_add_co_ci_u32 v2,…,s13` high; `flat_load_ubyte v0,v[1:2]`); a negative case (high dword from a `v_mov`, not a user-SGPR add) stays unresolved. Both fail without the function.
- **`ctest`**: 127/127 with the Messenger dump. Under this branch's GTA dump (`GAME_DUMP=PPSA04263`) the two loader tests `module_loads_eboot` / `boot_reaches_first_syscall` fail because they assert Messenger import counts — a pre-existing dump-config artifact, unrelated to this change (both pass after reconfiguring to `PPSA24651`).
- **Snapshot: not applicable** — the change adds an unused-at-runtime analysis and touches no rendering path, so it cannot alter rendered output.

## Risk

Low. Pure static analysis; no runtime path changed; the base-tracing recognizes only the canonical pointer-arithmetic add forms and fails visibly otherwise.

## Scope

Advances #1171 (does **not** close it — the emit + executor pieces follow). Reviewable as a self-contained, tested building block.
