### PR TITLE
test(snapshot): add Terminator 2D menu-reach regression guard

### DIFF
--- a/prosper/tools/snapshot/snapshots.json
+++ b/prosper/tools/snapshot/snapshots.json
@@ -375,6 +375,57 @@
         }
       ],
       "min_nonblack_ratio": 0.5
+    },
+    {
+      "name": "terminator-boot",
+      "dump": "PPSA25872-app0",
+      "scale": 4,
+      "timeout": 62,
+      "capture_after_seconds": 25,
+      "capture_before_seconds": 49,
+      "pad_script": null,
+      "savedata_policy": "fresh",
+      "env": {},
+      "min_colors": 300,
+      "min_qualifying_frames": 6,
+      "min_pixel_changes": 1,
+      "min_structural_similarity": 0.85,
+      "min_structural_matches": 10,
+      "min_content_match_ratio": 0.65,
+      "dims": [
+        480,
+        270
+      ],
+      "review": "Approved 16 composited images from two independent runs on 2026-07-22; intended scene, layers, and progression visually confirmed.",
+      "_note": "Menu-reach guard for Terminator 2D: NO FATE (PPSA25872, Unity/IL2CPP). A headless boot from a fresh save renders the T2 chrome logo and the Terminator-in-flames intro, then reaches the main menu (\"TERMINATOR 2D / NO FATE / START / OPTIONS / HIGH SCORES\") at ~30s. The menu is a static 335-color screen: 19 consecutive frames are byte-identical and match the reference at SSIM 1.0. Window 25-49s captures the boot intro plus the menu plateau (boot->menu transition gives the required pixel changes). The attract character-bio cutscene and demo gameplay after ~49s reproduce but are intentionally excluded: their animation drifts run-to-run and cannot SSIM-match static references. Captured via capture_content at scale=4 with the tool-default PROSPER_FAULT_ONSTACK=1 (Linux write-watch armed); the boot reaches the menu with the write-watch active, so #1147 is NOT the cause of the separate scale=1 headless slowdown tracked in #1181. Scope matches the user-verified checkpoint: reach the main menu.",
+      "structural_references": [
+        {
+          "luma16x9": "607c7584775d7d7782755c797f7e755f7476968b7178737a9c7c72758a947d6e6876938e6d6b6d5e5e6767738798706661848b9e6b5a787b575c517b8aa37750747185876c71737955646f767c87776a6781786e6c686675597b6774836a72664c886e6564494e5e4531477878675e4b5b6c5e7387533040534e19306c685d535c8178a36576493a3f34495079907c56",
+          "average_hash": "470043ebeb4bff5b",
+          "difference_hash": "9e94d68e9e9a9296"
+        },
+        {
+          "luma16x9": "34373c3d3b3c3e3b3b3e42525c4f3e34364b3f44453a36453c34393f3f5f836c3a83866b423d3f3e54505c6d7e68867c3d7093a049728392a69b878c868737593c607dbd6da1b8bcb09c8f75583d29444e8aadd793aaa38a75525451514b4f466fadaaa16d675b533d302f303028303f415348454f3e3a3a414344464744382c2f2f3235434a40373436353635342f2a",
+          "average_hash": "00030f3e7ef38000",
+          "difference_hash": "c8c75ef8f2c6158a"
+        },
+        {
+          "luma16x9": "3d2d1e262d32373a3f434134271e2e3d3738222a2f35393e4245453b2c1f35313c322930353a4144474848413324414d8875676460545b676d5d594c405485a8bb834c47525b5f6b645055483d4484a19b653b424d61635e5852574a40355f5556493e42484c5957524b44403d3a3c303a3c434a544f54514f4d48413c3e3e433d3d4d5d6165685659524d49424d3f37",
+          "average_hash": "3e1c19bdff900000",
+          "difference_hash": "b870717937616161"
+        },
+        {
+          "luma16x9": "15171e262d32373a3f434134271e1c1b171b222a2f35393e4245453b2c1f1c1b191e2930353a41444748484133241c1b2a50676460545b676d5d594c4054532b22364c47525b5f6b655055493d44392328333b424e62645e5852594b403528202d393d42474c5754524a45403c3a2d23363f4348525052504e4f44413d3c3c304f5152575c6a675c605251504a4b464a",
+          "average_hash": "ff3e3c3cfe381010",
+          "difference_hash": "f8f0f0f8b6e0e0e0"
+        },
+        {
+          "luma16x9": "6a7b878379697d85847a687c858679666f7592856e766f86b4896f6f8790796c6378949a6c5e6e78607257768aa46f57688185976f6577815a50617985987a607075847a6b6d7377705069787b7e77665a82766b6a626c6c688e5a7681696b5d4f8061616c4c6c6559415f7d725c5a4b6471708278522845433b1e34787b715b57817280726e2a261f2a4f69738b7954",
+          "average_hash": "4642286bef4bffff",
+          "difference_hash": "8e96d29e969ab292"
+        }
+      ],
+      "min_nonblack_ratio": 0.85
     }
   ]
 }


### PR DESCRIPTION
## Goal

Terminator 2D: NO FATE (PPSA25872, Unity/IL2CPP) boots and reaches its main menu
and attract sequence on current master, and was manually visually verified (the
user reached the menu and recorded gameplay). This adds the bring-up ladder's
**step 6** — a deterministic snapshot guard — for the checkpoint the user verified:
reaching the main menu. Refs #1110.

## Failure scenario the guard catches

A recompiler / AGC-decode / loader / libc-libkernel HLE regression that blanks a
shader, drops a draw, or stalls the boot makes the main menu never render. Today
nothing catches that automatically for T2. The new `terminator-boot` content
route asserts the correct 335-color menu is reached from a cold boot, so such a
regression fails the guard without a human in the loop.

## Behavioral contract

A fresh-save headless boot renders the T2 chrome logo and the Terminator-in-flames
intro, then reaches the main menu (`TERMINATOR 2D / NO FATE / START / OPTIONS /
HIGH SCORES`) at ~30s. The menu is a **static 335-color screen**: 19 consecutive
frames are byte-identical (`crc 002bbfdb`) and match the structural references at
SSIM 1.0. The guard requires, in the 25–49s window:

- `min_colors=300` — the menu is 335c (a blanked/black boot is ~1 color → fails).
- `min_structural_matches=10`, `min_content_match_ratio=0.65` — captured frames
  matching a reference at SSIM ≥ 0.85. Required = max(10, ceil(24·0.65)=16)=16;
  a fresh `check` observes **22**.
- `min_pixel_changes=1` — the boot→menu transition (observed **4**), proving a live
  boot rather than a single frozen frame.
- `min_nonblack_ratio=0.85` — the menu is fully non-black.

## Approach / invariants

- **Window scoped to the deterministic menu plateau.** The attract character-bio
  cutscene and demo gameplay after ~49s reproduce, but their animation drifts
  run-to-run and cannot SSIM-match static references — including them would make
  the SSIM-ratio contract flaky. The guard is intentionally scoped to the
  oracle-verified rung (the menu). A later, oracle-verified gameplay guard can
  extend coverage.
- **Only compact structural luminance signatures** (`luma16x9` + average/difference
  hashes) are stored — no game imagery — per the snapshot tool's repo contract.
- Route runs via `capture_content` at scale=4 with the tool-default
  `PROSPER_FAULT_ONSTACK=1` (the merged Linux write-watch #1147 **armed**).

## Affected / unaffected

- **Affected:** adds one snapshot route (`tools/snapshot/snapshots.json`). No code,
  no other route touched (`git diff --stat` = 1 file, +51).
- **Unaffected:** all existing routes and their baselines are byte-identical.

## Note on #1147 / #1181

The route reaches the menu with the write-watch (`PROSPER_FAULT_ONSTACK=1`) active,
which **disproves** the earlier hypothesis that #1147 wedges the headless boot. The
separate scale=1 headless slowdown remains tracked in #1181 (not caused by the
write-watch).

## Risk

Low — data-only. The main risk is guard flakiness; mitigated by scoping to the
byte-identical menu plateau (SSIM 1.0) and leaving margin on every threshold
(matches 22 vs 16; changes 4 vs 1; nonblack 24 vs 16). The menu appeared at ~30.1s
in all five recorded runs (deterministic to <1s).

## Verification (local; PPSA25872 dump is gitignored, snapshot is local-only)

```
python3 tools/snapshot/snapshot.py verify terminator-boot
# CONTENT-STABLE (richest=381/335, qualifying=20/20, changes=5/4, dims 480x270)
# -> inspected all 16 review images from both runs: T2 logo, flames intro,
#    menu slide-in, settled menu — all clean, correct, reproducible.

python3 tools/snapshot/snapshot.py update terminator-boot --reviewed
# approved 5 structural references

python3 tools/snapshot/snapshot.py check terminator-boot
# OK (480x270, frames=24, qualifying=20, richest=335 colors,
#     pixel_changes=4, structural_matches=22, nonblack_matches=24)
```
