### PR TITLE
fix(prosper-app): bound swapchain acquire so an occluded window can't stall the app/guest (#1182)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -315,6 +315,19 @@ if(TARGET prosper_core)
   target_include_directories(test_prosper_app_present_mode PRIVATE frontends/prosper-app)
   add_test(NAME prosper_app_present_mode COMMAND test_prosper_app_present_mode)
 
+  # Bounded-acquire present classification (#1182). Needs Vulkan HEADERS only (VkResult enum), no loader
+  # call — link Vulkan::Vulkan purely for its include dirs. Guarded so a headers-less host skips it
+  # gracefully; every platform that builds prosper-app has Vulkan available.
+  if(NOT TARGET Vulkan::Vulkan)
+    find_package(Vulkan QUIET)
+  endif()
+  if(TARGET Vulkan::Vulkan)
+    add_executable(test_prosper_app_present_policy frontends/prosper-app/test_present_policy.cpp)
+    target_include_directories(test_prosper_app_present_policy PRIVATE frontends/prosper-app)
+    target_link_libraries(test_prosper_app_present_policy PRIVATE Vulkan::Vulkan)
+    add_test(NAME prosper_app_present_policy COMMAND test_prosper_app_present_policy)
+  endif()
+
   add_executable(test_sync_on_address tests/test_sync_on_address.cpp)
   target_link_libraries(test_sync_on_address PRIVATE prosper_core)
   add_test(NAME sync_on_address COMMAND test_sync_on_address)

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -296,6 +296,11 @@ prosper::frontend::PresentAttempt present_frame(Vk& vk, const uint8_t* rgba, uin
     case prosper::frontend::AcquireAction::recreate: return PresentAttempt::out_of_date;
     case prosper::frontend::AcquireAction::proceed:  break;
     }
+    // Load-bearing ordering: vkResetFences MUST stay after the skip/recreate early-returns above. A skip
+    // leaves inFlight signaled (from the last real present) so the next frame's vkWaitForFences returns
+    // immediately; hoisting this reset above the acquire would leave inFlight unsignaled on a skip with no
+    // paired submit to re-signal it, and the next vkWaitForFences would hang. The reset is always paired
+    // with the vkQueueSubmit(..., inFlight) below.
     vkResetFences(vk.device, 1, &vk.inFlight);
     vkResetCommandBuffer(vk.cmd, 0);
 

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -22,6 +22,7 @@
 #include "pad_overlay.hpp"              // keyboard pad 0 composed over the physical controller backend
 #include "hle/ime_input.hpp"           // #1093: forward host keyboard keys to the guest IME path
 #include "present_mode.hpp"             // explicit swapchain latency/vsync policy, pure regression seam
+#include "present_policy.hpp"           // bounded-acquire present classification (#1182), pure seam
 #include "window_controls.hpp"           // debounced app-window shortcuts, pure regression seam
 #ifdef PROSPER_HAVE_LIVE_RENDERER
 #include "live_renderer.hpp"           // shared DrawItem->Vulkan compositor (register_live_renderer)
@@ -274,14 +275,27 @@ void barrier(VkCommandBuffer c, VkImage img, VkImageLayout from, VkImageLayout t
 }
 
 // Present one guest RGBA frame (w*h, 4 bytes/pixel) to the window, scaling to the swapchain extent.
-bool present_frame(Vk& vk, const uint8_t* rgba, uint32_t w, uint32_t h) {
-    if (!ensure_stage(vk, w, h)) return false;
+using prosper::frontend::PresentAttempt;
+
+prosper::frontend::PresentAttempt present_frame(Vk& vk, const uint8_t* rgba, uint32_t w, uint32_t h) {
+    if (!ensure_stage(vk, w, h)) return PresentAttempt::out_of_date;
     memcpy(vk.stageMapped, rgba, (size_t)w * h * 4);
 
     vkWaitForFences(vk.device, 1, &vk.inFlight, VK_TRUE, UINT64_MAX);
     uint32_t imgIndex = 0;
-    VkResult acq = vkAcquireNextImageKHR(vk.device, vk.swapchain, UINT64_MAX, vk.acquireSem, VK_NULL_HANDLE, &imgIndex);
-    if (acq == VK_ERROR_OUT_OF_DATE_KHR) return false;   // caller recreates
+    // Bound the acquire (#1182): an occluded/minimized window releases no swapchain image, and an
+    // infinite wait here would block the app main thread — freezing visible output, stalling SDL
+    // event/close handling, and (on the shared physical GPU) potentially the guest. A timeout is a
+    // benign SKIP: return without touching the swapchain and retry next loop. The guest keeps running
+    // on its own device regardless.
+    constexpr uint64_t kAcquireTimeoutNs = 100ull * 1000 * 1000;   // 100 ms — never hit while visible
+    VkResult acq = vkAcquireNextImageKHR(vk.device, vk.swapchain, kAcquireTimeoutNs, vk.acquireSem,
+                                         VK_NULL_HANDLE, &imgIndex);
+    switch (prosper::frontend::classify_acquire(acq)) {
+    case prosper::frontend::AcquireAction::skip:     return PresentAttempt::skipped;
+    case prosper::frontend::AcquireAction::recreate: return PresentAttempt::out_of_date;
+    case prosper::frontend::AcquireAction::proceed:  break;
+    }
     vkResetFences(vk.device, 1, &vk.inFlight);
     vkResetCommandBuffer(vk.cmd, 0);
 
@@ -319,7 +333,7 @@ bool present_frame(Vk& vk, const uint8_t* rgba, uint32_t w, uint32_t h) {
     pi.waitSemaphoreCount = 1; pi.pWaitSemaphores = &vk.presentSem;
     pi.swapchainCount = 1; pi.pSwapchains = &vk.swapchain; pi.pImageIndices = &imgIndex;
     VkResult pr = vkQueuePresentKHR(vk.queue, &pi);
-    return pr == VK_SUCCESS;
+    return prosper::frontend::classify_present(pr);
 }
 
 // Synthetic animated frame (no guest): a moving gradient fed through the REAL present layer, so the
@@ -765,9 +779,15 @@ int main(int argc, char** argv) {
             uint32_t h = frame.height;
             if (w == 0 || h == 0) { std::this_thread::sleep_for(std::chrono::milliseconds(2)); continue; }
             if (frame.rgba && frame.rgba->size() == (size_t)w * h * 4) {
-                if (!present_frame(vk, frame.rgba->data(), w, h)) {
+                PresentAttempt attempt = present_frame(vk, frame.rgba->data(), w, h);
+                if (attempt == PresentAttempt::out_of_date) {
                     // Out-of-date/suboptimal: share the resize/fullscreen recreation path next loop.
                     swapchainDirty = true;
+                } else if (attempt == PresentAttempt::skipped) {
+                    // Window occluded/minimized (#1182): no swapchain image within the bounded acquire.
+                    // Leave lastFrameSeq unchanged so we present the freshest frame once the window is
+                    // visible again, and do not mark the swapchain dirty. The guest keeps running.
+                    std::this_thread::sleep_for(std::chrono::milliseconds(4));
                 } else {
                     lastFrameSeq = frame.frame_seq; shown++;
                     lastFrameProgress = std::chrono::steady_clock::now();

--- a/prosper/frontends/prosper-app/present_policy.hpp
+++ b/prosper/frontends/prosper-app/present_policy.hpp
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <vulkan/vulkan_core.h>
+
+// Present policy for prosper-app (#1182). The app owns its OWN Vulkan device/queue, separate from the
+// core live renderer's headless device (main.cpp: "two Vulkan contexts by design"). The guest↔app frame
+// handoff is a lock-free CPU shared_ptr copy (present_acquire_rendered_frame), so the guest is NOT
+// back-pressured by the app present at the Vulkan level. The one place the app can hurt the guest — and
+// itself — is a BLOCKING swapchain acquire: `vkAcquireNextImageKHR(..., UINT64_MAX, ...)` blocks the app
+// main thread indefinitely when the compositor releases no image (window occluded/minimized). That
+// freezes visible output, stops SDL event/close handling, and (on the shared physical GPU) can stall the
+// guest. The fix is to bound the acquire and treat a timeout as a benign SKIP, not an error: the main
+// loop stays responsive and the guest keeps running. This header holds the pure result-classification so
+// it is unit-testable without a device (Vulkan headers only, no loader).
+
+namespace prosper::frontend {
+
+// Outcome of one present_frame attempt.
+enum class PresentAttempt {
+    presented,    // the rendered frame reached the swapchain
+    skipped,      // no swapchain image available within the bounded acquire (occluded/minimized) — retry
+    out_of_date,  // swapchain is stale/lost/unusable — recreate it before the next present
+};
+
+// What present_frame should do after a BOUNDED vkAcquireNextImageKHR.
+enum class AcquireAction { proceed, skip, recreate };
+
+// Classify vkAcquireNextImageKHR under a bounded (non-infinite) timeout.
+//  - VK_SUCCESS / VK_SUBOPTIMAL_KHR: an image was acquired (SUBOPTIMAL still yields a usable image) —
+//    proceed to blit + present. SUBOPTIMAL is handled at present time, matching the pre-#1182 behavior.
+//  - VK_TIMEOUT / VK_NOT_READY: no image was released in time — the window is occluded/minimized. This
+//    is the crux of #1182: skip this frame and keep the main loop responsive; do NOT treat it as an
+//    error and do NOT recreate the swapchain.
+//  - everything else (OUT_OF_DATE, DEVICE_LOST, SURFACE_LOST, ...): the swapchain must be rebuilt.
+constexpr AcquireAction classify_acquire(VkResult r) {
+    switch (r) {
+    case VK_SUCCESS:
+    case VK_SUBOPTIMAL_KHR:
+        return AcquireAction::proceed;
+    case VK_TIMEOUT:
+    case VK_NOT_READY:
+        return AcquireAction::skip;
+    default:
+        return AcquireAction::recreate;
+    }
+}
+
+// Classify vkQueuePresentKHR. Only VK_SUCCESS is a clean present; SUBOPTIMAL/OUT_OF_DATE (and any error)
+// request a swapchain rebuild. A present call does not time out, so there is no skip outcome here. This
+// preserves the pre-#1182 contract, where present_frame returned false (→ recreate) on anything but
+// VK_SUCCESS.
+constexpr PresentAttempt classify_present(VkResult r) {
+    return r == VK_SUCCESS ? PresentAttempt::presented : PresentAttempt::out_of_date;
+}
+
+} // namespace prosper::frontend

--- a/prosper/frontends/prosper-app/test_present_policy.cpp
+++ b/prosper/frontends/prosper-app/test_present_policy.cpp
@@ -1,0 +1,49 @@
+// Unit test for the prosper-app present policy (#1182): the classification that turns a bounded
+// vkAcquireNextImageKHR / vkQueuePresentKHR result into an action. The pre-#1182 code waited on the
+// acquire with UINT64_MAX and returned a bool (VK_SUCCESS → present, anything else → recreate). That
+// made an occluded/minimized window (no image released) block the app main thread forever. The fix
+// bounds the acquire and treats VK_TIMEOUT / VK_NOT_READY as a benign SKIP. These asserts pin that
+// contract; the VK_TIMEOUT/VK_NOT_READY → skip cases FAIL against any implementation that maps a
+// timeout to "recreate" or "present", which is exactly the behavior the fix introduces.
+
+#include "present_policy.hpp"
+
+#include <cstdio>
+
+using namespace prosper::frontend;
+
+static int failures = 0;
+#define CHECK(cond)                                                            \
+    do {                                                                       \
+        if (!(cond)) {                                                         \
+            std::fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond);\
+            ++failures;                                                        \
+        }                                                                      \
+    } while (0)
+
+int main() {
+    // Acquire: a usable image (SUCCESS or SUBOPTIMAL) → proceed to blit+present.
+    CHECK(classify_acquire(VK_SUCCESS) == AcquireAction::proceed);
+    CHECK(classify_acquire(VK_SUBOPTIMAL_KHR) == AcquireAction::proceed);
+
+    // Acquire: the crux of #1182 — a bounded timeout on an occluded/minimized window is a SKIP,
+    // never an error and never a swapchain rebuild.
+    CHECK(classify_acquire(VK_TIMEOUT) == AcquireAction::skip);
+    CHECK(classify_acquire(VK_NOT_READY) == AcquireAction::skip);
+
+    // Acquire: a stale/lost swapchain or device must be rebuilt.
+    CHECK(classify_acquire(VK_ERROR_OUT_OF_DATE_KHR) == AcquireAction::recreate);
+    CHECK(classify_acquire(VK_ERROR_DEVICE_LOST) == AcquireAction::recreate);
+    CHECK(classify_acquire(VK_ERROR_SURFACE_LOST_KHR) == AcquireAction::recreate);
+    CHECK(classify_acquire(VK_ERROR_OUT_OF_HOST_MEMORY) == AcquireAction::recreate);
+
+    // Present: only a clean VK_SUCCESS presents; SUBOPTIMAL/OUT_OF_DATE/errors request a rebuild,
+    // preserving the pre-#1182 "return false on anything but VK_SUCCESS" contract.
+    CHECK(classify_present(VK_SUCCESS) == PresentAttempt::presented);
+    CHECK(classify_present(VK_SUBOPTIMAL_KHR) == PresentAttempt::out_of_date);
+    CHECK(classify_present(VK_ERROR_OUT_OF_DATE_KHR) == PresentAttempt::out_of_date);
+    CHECK(classify_present(VK_ERROR_DEVICE_LOST) == PresentAttempt::out_of_date);
+
+    if (failures == 0) std::printf("present_policy: OK\n");
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Goal

Fix #1182: in `prosper-app`, when the window loses focus and is occluded/minimized,
the game appeared to **pause** until refocused, and the app became unresponsive
(couldn't use the terminal/tools while a game ran). PS5 has no window-focus concept,
so the game should keep running.

## Corrected root cause

The issue originally hypothesized a **shared Vulkan queue** serializing the guest
behind the app present. **That is wrong.** `prosper-app` owns its **own** Vulkan
device/queue, separate from the core live renderer's headless device (`main.cpp:14`:
"two Vulkan contexts by design"), and the guest→app frame handoff is a **lock-free
CPU `shared_ptr` copy** (`present_acquire_rendered_frame`, `videoout_present.cpp`).
The `[compute] adopted the renderer's device (shared, queue family 0)` log the issue
quoted is the **compute backend** adopting the **renderer's** device
(`live_compute.cpp:255`, #1091) — not the app.

The real defect is narrower: `present_frame` called
`vkAcquireNextImageKHR(..., UINT64_MAX, ...)` (`main.cpp:283`). When the compositor
releases no swapchain image (occluded/minimized window), that **infinite wait blocks
the app main thread** — freezing visible output, stalling SDL event/close handling,
and (on the shared physical GPU) potentially the guest.

## Fix

Bound the acquire to **100 ms** (never hit while the window is visible — acquire
returns immediately). A `VK_TIMEOUT` / `VK_NOT_READY` is a **benign SKIP**, not an
error: `present_frame` returns `skipped`, the loop leaves `lastFrameSeq` unchanged
(so it presents the freshest frame once visible again), does **not** mark the
swapchain dirty, and briefly sleeps. The guest keeps running on its own device
throughout, so alt-tabbing no longer pauses it and the app stays responsive.

## Testable seam + regression test

- New pure header `present_policy.hpp` classifies acquire/present `VkResult`s into
  `proceed` / `skip` / `recreate` (Vulkan headers only, no loader — unit-testable).
- New `test_present_policy.cpp` pins the contract, notably `VK_TIMEOUT` /
  `VK_NOT_READY → skip`. This **fails** against the pre-fix behavior (infinite wait,
  "anything but `VK_SUCCESS` → recreate").

## Affected / unaffected

- **Affected:** `prosper-app` present path only (Linux/desktop app). Per CLAUDE.md,
  desktop-app parity is not a merge requirement; other frontends retain behavior.
- **Unaffected:** the core renderer, recompiler, AGC decode, and the
  screenshot/snapshot frontend (a **different** binary) are untouched. Normal present
  is byte-identical when the window is visible (`acquire → VK_SUCCESS` immediately).

## Risk

Low. The only behavioral change is the previously-infinite acquire is now bounded;
the common path is unchanged. The 100 ms bound is far above any normal
frame-acquire latency, so no frames are dropped while visible.

## Verification (local, Linux)

```
# ctest (Messenger dump)
ctest  →  100% tests passed, 130/130  (incl. new prosper_app_present_policy)

# normal-present smoke (Terminator PPSA25872)
prosper-app --frames 150  →  presents 150 frames, [app] fps logs climb, exit 0
```

The occluded-window path is covered by the classifier unit test; the interactive
alt-tab/occlusion repro is not automatable headlessly and is left for **user visual
confirmation** (alt-tab away and back — the game should keep running, and the
terminal should stay usable).
