### PR TITLE
recompiler: general FLAT_LOAD via windowed SSBO — texture-decode reads from raw guest pointers (#1171)

### DIFF
--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -2949,12 +2949,23 @@ std::vector<ComputeItem> realize_compute_dispatches(
         // load to an indexed read at (address - base). Pushed before assign_convention_bindings so each
         // window gets a distinct binding; an unmapped base leaves the load unresolved (fail-visible).
         {
+            // Bound the analysis by the ACTUAL user-SGPR count, not kUserSgprs (32). The emit indexes the
+            // push-constant block, which is sized to config.user_sgprs.size() = min(user_count, kUserSgprs);
+            // a base resolved in [user_count, 31] would make the emit's load_push_constant index past that
+            // block (spirv-val would fail-visible, but keep the analysis and push-constant widths consistent).
+            const uint32_t fw_user_count = std::min<uint32_t>(
+                (rd(ds.sh, P::COMPUTE_PGM_RSRC2) >> P::COMPUTE_PGM_RSRC2_USER_SGPR_SHIFT) &
+                    P::COMPUTE_PGM_RSRC2_USER_SGPR_MASK,
+                kUserSgprs);
             const FlatLoadAnalysis fla = analyze_flat_loads(
                 reinterpret_cast<const uint32_t*>(static_cast<uintptr_t>(code_addr)),
-                shader_dwords, kUserSgprs);
-            constexpr uint32_t kFlatWindowMax = 0x10000000u;   // 256 MiB cap on the per-dispatch copy
+                shader_dwords, fw_user_count);
+            // 256 MiB cap on the per-dispatch copy. TODO(#1183): the decode loop reads only base..base+N;
+            // size the window from that access footprint (or the destination image extent) once the loop
+            // executes, instead of the whole containing-allocation remainder.
+            constexpr uint32_t kFlatWindowMax = 0x10000000u;
             for (const auto& fl : fla.loads) {
-                if (fl.base_sgpr < 0 || static_cast<uint32_t>(fl.base_sgpr) + 1u >= kUserSgprs) continue;
+                if (fl.base_sgpr < 0 || static_cast<uint32_t>(fl.base_sgpr) + 1u >= fw_user_count) continue;
                 const uint64_t base = static_cast<uint64_t>(sgprs[fl.base_sgpr]) |
                                       (static_cast<uint64_t>(sgprs[fl.base_sgpr + 1]) << 32);
                 host::GuestReadableRange range{};

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -2942,6 +2942,37 @@ std::vector<ComputeItem> realize_compute_dispatches(
                 resource.size = required;
             }
         }
+        // FLAT-window resources (#1171): a general flat_load reads a byte/dword from a raw 64-bit guest
+        // pointer held in user SGPRs (not a V# descriptor, so build/add above never saw it). Resolve each
+        // such load to its base SGPR pair, read the base pointer from THIS dispatch's user SGPRs, bind the
+        // containing guest allocation as an SSBO, and key it by the load's pc so the recompiler lowers the
+        // load to an indexed read at (address - base). Pushed before assign_convention_bindings so each
+        // window gets a distinct binding; an unmapped base leaves the load unresolved (fail-visible).
+        {
+            const FlatLoadAnalysis fla = analyze_flat_loads(
+                reinterpret_cast<const uint32_t*>(static_cast<uintptr_t>(code_addr)),
+                shader_dwords, kUserSgprs);
+            constexpr uint32_t kFlatWindowMax = 0x10000000u;   // 256 MiB cap on the per-dispatch copy
+            for (const auto& fl : fla.loads) {
+                if (fl.base_sgpr < 0 || static_cast<uint32_t>(fl.base_sgpr) + 1u >= kUserSgprs) continue;
+                const uint64_t base = static_cast<uint64_t>(sgprs[fl.base_sgpr]) |
+                                      (static_cast<uint64_t>(sgprs[fl.base_sgpr + 1]) << 32);
+                host::GuestReadableRange range{};
+                if (!host::guest_readable_mapping_containing(base, base + 1, range) || range.end <= base)
+                    continue;                                  // unmapped base -> stay fail-visible
+                const uint64_t avail = range.end - base;
+                ShaderResource w;
+                w.cls = ResourceClass::ConstantBuffer;         // read-only SSBO (declare_cbufs + cbuf_load)
+                w.gpu_addr = base;
+                w.size = static_cast<uint32_t>(std::min<uint64_t>(avail, kFlatWindowMax));
+                w.fetch_pc = fl.load_pc;
+                w.flat_base_sgpr = static_cast<uint32_t>(fl.base_sgpr);
+                table->resources.push_back(w);
+                if (std::getenv("PROSPER_DBG"))
+                    std::fprintf(stderr, "[flat-window] pc=%u base=s%d addr=0x%llx size=%u\n",
+                                 fl.load_pc, fl.base_sgpr, (unsigned long long)base, w.size);
+            }
+        }
         assign_convention_bindings(*table, 2);
         {
             std::vector<Rdna2Inst> decoded;

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -5205,6 +5205,56 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
         }
         case Rdna2Format::FLAT: {
             const FlatAccessInfo access = flat_access_info(in.opcode);
+            // General (non-scratch) FLAT LOAD from a raw 64-bit guest address (#1171). If the executor
+            // resolved this load's base pointer to user SGPRs s[flat_base_sgpr : +1] and bound the
+            // containing guest allocation as an SSBO (a ConstantBuffer-class resource keyed by this
+            // load's pc), lower it to an indexed read of that window at byte offset (address_lo -
+            // base_lo). base_lo is the ORIGINAL push-constant value (the address the executor bound the
+            // window at), so the module stays dispatch-independent and correct even if the shader later
+            // reuses the base SGPR. Unresolved forms fall through to the scratch/reject path below.
+            const ShaderResource* fw =
+                (rt && access.valid && !access.store && !in.flat_lds &&
+                 in.src[0].kind == OperandKind::VGPR &&
+                 in.src[1].kind == OperandKind::Special && in.src[1].value == 125)
+                    ? rt->by_fetch_pc(in.pc) : nullptr;
+            if (fw && fw->flat_base_sgpr != 0xFFFFFFFFu) {
+                const uint32_t addr_lo = val(in.src[0]);                     // low dword of the address
+                const uint32_t base_lo = b.load_push_constant(fw->flat_base_sgpr);
+                const uint32_t byte0 = b.ibin(Op_ISub, addr_lo, base_lo);    // byte offset in the window
+                for (uint32_t c = 0; c < access.components; ++c) {
+                    const uint32_t addr = access.bits == 32
+                        ? b.ibin(Op_IAdd, byte0, b.uconst(c * 4)) : byte0;
+                    const uint32_t idx = b.ibin(Op_ShiftRightLogical, addr, b.uconst(2));
+                    uint32_t value;
+                    if (access.bits == 32) {
+                        value = b.cbuf_load(idx, fw->binding);
+                    } else {
+                        // Sub-dword (ubyte/ushort) extract, mirroring the MUBUF raw path: a 16-bit
+                        // access may begin at byte 3 and straddle two dwords, so join the adjacent words.
+                        const uint32_t dw0 = b.cbuf_load(idx, fw->binding);
+                        const uint32_t byte_in_dw = b.ibin(Op_BitwiseAnd, addr, b.uconst(3));
+                        const uint32_t shift = b.ibin(Op_ShiftLeftLogical, byte_in_dw, b.uconst(3));
+                        uint32_t joined = b.ibin(Op_ShiftRightLogical, dw0, shift);
+                        if (access.bits == 16) {
+                            const uint32_t dw1 =
+                                b.cbuf_load(b.ibin(Op_IAdd, idx, b.uconst(1)), fw->binding);
+                            const uint32_t inv_shift = b.ibin(Op_BitwiseAnd,
+                                b.ibin(Op_ISub, b.uconst(32), shift), b.uconst(31));
+                            const uint32_t upper = b.ibin(Op_ShiftLeftLogical, dw1, inv_shift);
+                            joined = b.ibin(Op_BitwiseOr, joined,
+                                b.sel(b.ucmp(Op_IEqual, shift, b.uconst(0)), b.uconst(0), upper));
+                        }
+                        value = access.sign_extend
+                            ? b.bfe_s(joined, b.uconst(0), b.uconst(access.bits))
+                            : b.bfe_u(joined, b.uconst(0), b.uconst(access.bits));
+                    }
+                    const int reg = in.dst.value + static_cast<int>(c);
+                    const uint32_t old_value = vreg_old(b, rs, reg);
+                    rs.vreg[reg] = value;
+                    predicate_write(b, rs, reg, old_value);
+                }
+                return true;
+            }
             // Model the compiler's private spill area only. Each generated shader invocation owns
             // one Function-storage array, so the entry-provided hardware base has no host-visible
             // address to preserve. Other FLAT/GLOBAL forms remain deliberately unsupported.

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -5220,7 +5220,12 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             if (fw && fw->flat_base_sgpr != 0xFFFFFFFFu) {
                 const uint32_t addr_lo = val(in.src[0]);                     // low dword of the address
                 const uint32_t base_lo = b.load_push_constant(fw->flat_base_sgpr);
-                const uint32_t byte0 = b.ibin(Op_ISub, addr_lo, base_lo);    // byte offset in the window
+                // Byte offset in the window: (address - base) mod 2^32, which equals the true offset for
+                // any 0 <= offset < window <= 256 MiB (the low-dword subtraction wraps complementarily to
+                // the address's own IAdd). A negative offset (address < base) becomes a huge unsigned index
+                // -> out-of-window -> robustBufferAccess returns 0 (defined, but a loose-bounds divergence
+                // from HW; decode kernels use non-negative offsets).
+                const uint32_t byte0 = b.ibin(Op_ISub, addr_lo, base_lo);
                 for (uint32_t c = 0; c < access.components; ++c) {
                     const uint32_t addr = access.bits == 32
                         ? b.ibin(Op_IAdd, byte0, b.uconst(c * 4)) : byte0;

--- a/prosper/src/gpu/shader_resources.hpp
+++ b/prosper/src/gpu/shader_resources.hpp
@@ -124,6 +124,14 @@ struct ShaderResource {
     //     resurrected through an older metadata resource. 0xFFFFFFFF = unset.
     uint32_t      fetch_pc      = 0xFFFFFFFFu;
 
+    // FLAT-window (#1171) provenance: for a general flat_load whose 64-bit source pointer lives in the
+    // consecutive user SGPRs s[flat_base_sgpr : +1], the executor binds the containing guest allocation
+    // as this SSBO (keyed by the load's fetch_pc) and the emitter lowers the load to an indexed read at
+    // (address - base). Kept SEPARATE from sgpr_base so the direct-descriptor SGPR routing does not
+    // divert the base pointer into sreg_input; the emitter reads it straight from the push constants.
+    // 0xFFFFFFFF = not a flat window.
+    uint32_t      flat_base_sgpr = 0xFFFFFFFFu;
+
     // Texture-only (cls == Texture). img_dim mirrors the MIMG dim field (1D=0, 2D=1, 3D=2, ...).
     // width/height/depth are the complete base-level extent (depth is >1 for 3D only), used by image
     // queries, uploads, and image_load/texelFetch. sampler_sgpr_base = the paired sampler's S# base SGPR (SSAMP); with a Vulkan

--- a/prosper/tests/test_recompile_coverage.cpp
+++ b/prosper/tests/test_recompile_coverage.cpp
@@ -91,6 +91,34 @@ int main() {
     CHECK(fls.any && !fls.all_resolved && fls.loads.size() == 1 && fls.loads[0].base_sgpr < 0,
           "analyze_flat_loads rejects a non-consecutive base SGPR pair (s12 low / s15 high)");
 
+    // FLAT-window emit (#1171 piece 2): with a ConstantBuffer resource keyed by the flat_load's pc plus
+    // flat_base_sgpr, recompile_compute LOWERS the general flat_load to a windowed SSBO read; without
+    // the bound window it stays fail-visible (empty module).
+    const uint32_t flat_kernel[] = {
+        0xd70f6a01u, 0x00020c0cu,   // v_add_co_u32    v1, vcc, s12, v6
+        0x50041af9u, 0x86860680u,   // v_add_co_ci_u32 v2 (sdwa), s13
+        0xdc200000u, 0x007d0001u,   // flat_load_ubyte v0, v[1:2]
+        0xBF810000u,                // s_endpgm
+    };
+    const size_t nfk = sizeof(flat_kernel)/sizeof(flat_kernel[0]);
+    ComputeShaderConfig fcfg;
+    fcfg.user_sgprs.assign(16, 0);   // 16 user SGPRs; s12/s13 hold the (per-dispatch) base pointer
+    CHECK(recompile_compute(flat_kernel, nfk, nullptr, fcfg).empty(),
+          "general flat_load with no bound window still rejects the shader (fail-visible)");
+    FlatLoadAnalysis fka = analyze_flat_loads(flat_kernel, nfk, 16);
+    ShaderResourceTable frt;
+    ShaderResource fwin;
+    fwin.cls = ResourceClass::ConstantBuffer;
+    fwin.binding = 4;
+    fwin.gpu_addr = 0x1000000000ull;
+    fwin.size = 4096;
+    fwin.fetch_pc = fka.loads[0].load_pc;
+    fwin.flat_base_sgpr = static_cast<uint32_t>(fka.loads[0].base_sgpr);   // s12
+    frt.resources.push_back(fwin);
+    std::vector<uint32_t> fk_spv = recompile_compute(flat_kernel, nfk, &frt, fcfg);
+    CHECK(!fk_spv.empty() && fk_spv[0] == 0x07230203u,
+          "general flat_load lowers to a valid SSBO-read module when its window is bound");
+
     // tbuffer_load_format_x v0, v0, s[8:11], 0 format:32_FLOAT ; s_endpgm.
     // MTBUF needs a resolved V# binding, so the table-less coverage pass must classify it as
     // recompilable-in-context rather than truly unsupported.


### PR DESCRIPTION
## What & why

Implements **general FLAT_LOAD** in the compute recompiler — reading a byte/short/dword from a raw 64-bit guest address held in a VGPR pair, which prosper previously modeled only for the compiler's private scratch spill. Builds on the merged base-tracing analysis (#1180). Closes #1171.

The blocking case is GTA V's (PPSA04263) texture-decode compute kernel `exec_cs_2042d47600`, which reads its source pixels via `flat_load_ubyte v[1:2]` from a kernel-arg base pointer + per-lane offset (#1163/#1165).

## Approach — flat-address → windowed SSBO (reuses the existing buffer path)

- **Executor (piece 3, `gpu_executor.cpp`):** for each general flat load `analyze_flat_loads` resolves, read the base pointer from this dispatch's user SGPRs, find the containing guest allocation (`guest_readable_mapping_containing`), and register a `ConstantBuffer`-class window resource (`gpu_addr`=base, `size`=min(remainder, 256 MiB), `fetch_pc`=load pc, `flat_base_sgpr`=base SGPR). The existing `live_compute` path then creates the host-visible SSBO, `memcpy`s the guest bytes, and binds it — no new upload code.
- **Recompiler (piece 2, `rdna2_to_spirv.cpp`):** in the FLAT case, `rt->by_fetch_pc(in.pc)` resolves the window; the load lowers to `SSBO[(address_lo − base_lo) >> 2]` with the sub-dword (ubyte/ushort) extract mirrored from the MUBUF raw path (incl. the 16-bit two-dword straddle). `base_lo` is read straight from the **push constants** (the original dispatch value the window was bound at), so the reusable module is correct even if the shader later reuses the base SGPR.
- **Rejected `buffer_device_address`:** the emitted SPIR-V uses the `Logical` addressing model and prosper has no device-address infra; this reuses ~90% of existing machinery instead. Full design: `docs/FLAT_LOAD_DESIGN.md` (from #1180).

## Behavioral contract / invariants

- **No change for existing shaders.** The new emit path activates only when a resource with `flat_base_sgpr != 0xFFFFFFFF` is resolved by the load's pc; every other shader falls through to the unchanged scratch/reject path. `flat_base_sgpr` is kept separate from `sgpr_base` so direct-descriptor SGPR routing doesn't divert the base pointer into `sreg_input`.
- **Fail-visible preserved:** a store/atomic/LDS/global-with-saddr form, a non-`base+offset` address, or an unmapped base leaves the load unresolved and the shader rejected, exactly as before.
- Read-only (FLAT stores out of scope).

## Verification

- **Unit (`test_recompile_coverage`):** with a bound window the kernel recompiles to a valid SSBO-read module; without it the general flat_load still rejects (empty). Base-tracing tests from #1180 retained.
- **Live (GTA V):** `[flat-window] pc=40 base=s12 addr=0x204003b240 size=256MiB` binds on the real kernel (80 dispatches), and the load lowers — the recompile-reject advances from the FLAT load (pc=40) to the kernel's next blocker, a data-dependent EXECZ-exit loop (`s_branch pc=52→3`), now tracked as **#1183**.
- **`snapshot.py check`:** all 4 routes OK, exit 0 (messenger, evergate, dead-cells, blasphemous2) — no rendering regression.
- **`ctest`:** 127/127 with the Messenger dump (the 2 GTA-dump loader-count artifacts pass under `PPSA24651`).

## Scope / honesty

Closes #1171 (general FLAT_LOAD is implemented). It does **not** by itself render #1163/#1165 — `exec_cs_2042d47600` still needs the loop structurizer (#1183) to execute. End-to-end **numeric** read correctness is therefore not yet exercisable on a live shader; it rests on unit-verified valid SPIR-V + construction that mirrors the proven MUBUF sub-dword extract, and will be exercisable once #1183 lands. CONFIDENCE: MED on runtime numeric correctness; HIGH on resolve/bind/lower (live-verified) and no-regression (snapshot).

## Risk

Low-moderate. Additive path gated on a distinct resource field; reuses the proven SSBO upload + sub-dword extract; snapshot-clean. The main unproven aspect (numeric read on a live shader) is called out above and warrants a careful review of the offset + extract math.
