### PR TITLE
fix(test): tolerate process-vanish races in snapshot_guard_logic (#1069)

### DIFF
--- a/prosper/tools/snapshot/test_snapshot.py
+++ b/prosper/tools/snapshot/test_snapshot.py
@@ -56,7 +56,13 @@ while True:
                     child_pid = int(pid_file.read())
                 self.assertTrue(self._process_is_running(child_pid))
 
-                os.kill(harness.pid, signal.SIGKILL)
+                # Tolerate the harness already being gone: an absent harness still satisfies the
+                # property under test (the child must not outlive it). Guards a benign TOCTOU race
+                # with the harness's own exit that otherwise surfaces as a spurious ERROR (#1069).
+                try:
+                    os.kill(harness.pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
                 harness.wait(timeout=5)
                 deadline = time.time() + 10
                 while time.time() < deadline and self._process_is_running(child_pid):
@@ -66,19 +72,34 @@ while True:
                     "snapshot child survived the harness's uncatchable termination",
                 )
             finally:
+                # Cleanup only. A ProcessLookupError here means the target exited between the check and
+                # the signal (a benign TOCTOU race with the process's own death) — that is the desired
+                # end state, so tolerate it rather than turning a passing run into a spurious ERROR
+                # (#1069). _process_is_running already tolerates a vanished PID via FileNotFoundError.
                 if harness.poll() is None:
-                    harness.kill()
-                    harness.wait(timeout=5)
+                    try:
+                        harness.kill()
+                        harness.wait(timeout=5)
+                    except ProcessLookupError:
+                        pass
                 if child_pid is not None and self._process_is_running(child_pid):
-                    os.kill(child_pid, signal.SIGKILL)
+                    try:
+                        os.kill(child_pid, signal.SIGKILL)
+                    except ProcessLookupError:
+                        pass
 
     @staticmethod
     def _process_is_running(pid):
+        # A process that exits while we inspect /proc surfaces as one of three benign vanish signals,
+        # all meaning "not running" (#1069): FileNotFoundError if /proc/<pid> is already gone at open;
+        # ProcessLookupError if the process exits between open and read() (this was the actual CI flake —
+        # the original code caught only FileNotFoundError); and an empty/partial stat (IndexError) if it
+        # is torn down mid-read. Any of these = the PID is not a live, non-zombie process.
         try:
             with open(f"/proc/{pid}/stat") as stat_file:
                 state = stat_file.read().split()[2]
             return state != "Z"
-        except FileNotFoundError:
+        except (FileNotFoundError, ProcessLookupError, IndexError):
             return False
 
     def test_content_window_requires_multiple_frames_and_progression(self):


### PR DESCRIPTION
## Goal
Fix #1069: `snapshot_guard_logic` (`test_snapshot_child_dies_when_harness_is_killed`)
intermittently ERROR'd on CI with `ProcessLookupError: [Errno 3] No such process`,
while passing on every rerun and other platform.

## Root cause (corrected)
The issue guessed the `os.kill` calls. Reproducing the flake and capturing the full
traceback shows the actual source is **`_process_is_running`**:
```
File ".../test_snapshot.py", line 68, in ... while ... self._process_is_running(child_pid)
File ".../test_snapshot.py", line 95, in _process_is_running
    state = stat_file.read().split()[2]
ProcessLookupError: [Errno 3] No such process
```
`open("/proc/<pid>/stat")` succeeds while the process still exists, but `read()`
raises **ProcessLookupError** if the process exits between `open()` and `read()`. The
`except` caught only `FileNotFoundError`, so that benign vanish escaped as a test ERROR.

## Fix
- `_process_is_running` treats `FileNotFoundError`, `ProcessLookupError`, and a
  torn-down empty/partial stat (`IndexError`) all as "not running" — a PID that
  vanishes mid-inspection is definitionally not a live process.
- Harden the signal-side TOCTOU the issue also mentioned: the deliberate harness kill
  and the `finally` cleanup kills tolerate an already-exited target (that is the
  desired end state; it must not become a spurious ERROR).

## Verification (local, Linux)
- Reproduced the flake pre-fix (ProcessLookupError from the `_process_is_running` line).
- Post-fix: isolated test **80/80** clean; full suite **60×** with **0** ProcessLookupError;
  all 8 tests pass.
- An unrelated `child survived` assertion appeared only **1/60** under abnormal tight-loop
  saturation of the whole suite and **0/80** in isolation — a SIGKILL-delivery-under-load
  artifact of the stress loop, not the reported flake. 10s is already a generous deadline
  for an uncatchable kill, so left as-is.

## Risk
Very low — test-only; the change only broadens which benign process-vanish signals count
as "not running".

Fixes #1069.
