### PR TITLE
fix(fault-handler): raw_write + g_base labels on the default nullpage/lazy-commit path (#1075)

### DIFF
--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -1728,11 +1728,12 @@ namespace {
                 int n = snprintf(b, sizeof b, "[lazy-commit] %s page=0x%llx rip=0x%llx\n",
                                  ok ? "mapped" : "MMAP-FAILED", (unsigned long long)(uint64_t)(uintptr_t)page,
                                  (unsigned long long)PROSPER_GREGS(uc2)[REG_RIP]);
-                // RAW syscall, NOT glibc write(): this handler can run on a thread whose %fs is the
-                // GUEST TCB (PROSPER_GUEST_FS), and glibc write()'s cancellation prologue reads the
-                // TCB through %fs — a nested SIGSEGV inside the handler killed the process (the UE4
-                // boot's silent exit-139).
-                syscall(SYS_write, 2, b, (size_t)n);
+                // raw_write (raw_syscall.hpp), NOT glibc write() OR syscall(): this handler can run on a
+                // thread whose %fs is the GUEST TCB (PROSPER_GUEST_FS). glibc write()'s cancellation
+                // prologue reads the TCB through %fs, and even glibc's syscall() wrapper stores errno
+                // via %fs on write failure — either is a nested SIGSEGV inside the handler that killed
+                // the process (the UE4 boot's silent exit-139; #1071/#1075).
+                raw_write(2, b, (uint64_t)n);
                 if (ok) return;   // re-execute against the now-backed page
             }
         }
@@ -1789,8 +1790,8 @@ namespace {
                     char b[128];
                     int n = snprintf(b, sizeof b, "[nullpage] #%d addr=0x%llx rip=eboot+0x%llx\n",
                                      (int)g_null_page_count, (unsigned long long)a,
-                                     (unsigned long long)(rip - 0x400000000ull));
-                    syscall(SYS_write, 2, b, (size_t)n);   /* raw: glibc write() reads the TCB via %fs (guest-fs unsafe in this handler) */
+                                     (unsigned long long)(rip - g_base));
+                    raw_write(2, b, (uint64_t)n);   /* raw_syscall: no errno/TLS access, %fs-safe in the handler (#1075) */
                     nullpage_deep_dump(uc, rip);   // issue-#312 attribution dump (registers + heap + GPU ring)
                     return;   // re-execute; the null read now sees zero
                 }
@@ -1802,7 +1803,7 @@ namespace {
                                  "[nullpage] BACKING DENIED addr=0x%llx rip=eboot+0x%llx err=%ld"
                                  " (vm.mmap_min_addr/CAP_SYS_RAWIO)\n",
                                  (unsigned long long)a,
-                                 (unsigned long long)(rip - 0x400000000ull), mr);
+                                 (unsigned long long)(rip - g_base), mr);
                 raw_write(2, b, (uint64_t)n);   /* not even glibc syscall(): it stores errno via %fs on failure */
             }
         }


### PR DESCRIPTION
fix(fault-handler): raw_write + g_base labels on the default nullpage/lazy-commit path (#1075)

Two follow-ups from the #1074/#1071 fault-handler %fs-safety work, scoped to the
DEFAULT fault path (the writes that fire without any PROSPER_* debug flag on a
guest-%fs thread):

1. raw_write instead of syscall(SYS_write) for the lazy-commit and nullpage-success
   diagnostics (exec_image_linux.cpp:1735, :1793). glibc's syscall() wrapper stores
   errno through %fs when the write fails (closed stderr / broken pipe in
   daemonized/CI runs); on a guest-%fs thread that store faults inside the handler —
   the exact #1071 nested-SIGSEGV class. raw_write (raw_syscall.hpp) issues the
   syscall in-register and never touches errno/TLS. (The nullpage-denied write at
   :1806 was already raw_write from #1074.)

2. The two [nullpage] lines labeled RIP as eboot+0x… using a hard-coded 0x400000000
   base while the real eboot base is g_base (BOOT_EBOOT=0x410000000), so the label
   was off by 0x10000000 from the WORKER-THREAD FAULT report's image+0x… for the same
   PC. Both now use `rip - g_base`, matching the fatal report (:1916).

Scope: the ~77 remaining syscall(SYS_write) sites are debug-dump helpers gated behind
PROSPER_HWBP / PROSPER_HWWATCH / PROSPER_KSCAN (only fire during explicit debugging,
lower #1071 risk) — left for a follow-up sweep; #1075 stays open for them plus the
cosmetic test_raw_syscall.cpp ordering note. Diagnostic-output-only: fault-handling
behavior (map page + re-execute) is unchanged.

Verification (local, Linux): ctest 130/130 green.

Addresses #1075.