### PR TITLE
fix(avplayer): gracefully skip an unopenable source instead of hanging the title (#1105)

### DIFF
--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -638,7 +638,10 @@ static uint64_t avp_add_source(uint64_t handle, const char* guest_path) {
                 p.paused = false; p.stop_fired = false;
                 p.texture_frames.clear(); p.texture_frame_bytes = 0; p.next_texture_frame = 0;
                 p.backend = nullptr; p.backend_id = -1;
-                p.width = 0; p.height = 0; p.fps = 0.0f;
+                // Non-zero placeholder dims/fps: a title that queries GetStreamInfo up-front (before it
+                // discovers the immediate EOF) then gets a benign aspect (w/h) and never a 0x0 surface or
+                // a divide-by-zero. The source still delivers zero frames and EOFs on the first poll.
+                p.width = 1920; p.height = 1080; p.fps = 30.0f;
                 p.has_audio = false; p.audio_channels = 0; p.audio_rate = 0; p.duration_ms = 0;
                 obj = p.ev_obj; cb = p.ev_cb;
                 if (p.auto_start) { p.playing = true; play = true; }

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -607,11 +607,47 @@ static uint64_t avp_add_source(uint64_t handle, const char* guest_path) {
         selected_backend->close(backend_id);
         backend_id = -1;
     }
+    // #1105 test lever: force a total source-open failure to exercise the graceful immediate-EOF path
+    // (an undecodable source) without needing a corrupt media file. Off by default.
+    if (backend_id >= 0 && getenv("PROSPER_AVP_FORCE_FAIL")) {
+        selected_backend->close(backend_id);
+        backend_id = -1;
+    }
     const bool synthetic = backend_id < 0 && avp_synth_enabled();
     if (backend_id < 0 && !synthetic) {
-        if (avp_log()) fprintf(stderr, "[avp] source open failed guest='%s' host='%s' backend=%d\n",
+        // #1105: a source that cannot be opened (corrupt file, missing codec, demux error) must not hang
+        // the title. Returning an error with no lifecycle event leaves a title whose intro state machine
+        // waits for the movie to finish deadlocked in its black scene (the #320 shape). Instead set up an
+        // EMPTY source and drive it to a graceful immediate EOF: fire AVP_READY (so the title starts it),
+        // and the first IsActive/GetVideoData poll finds no backend and no synthetic frames (:506 / :760)
+        // and fires AVP_STOP — the game skips the unplayable movie and proceeds.
+        if (avp_log()) fprintf(stderr, "[avp] source open failed guest='%s' host='%s' backend=%d -> "
+                               "graceful skip (empty source, immediate EOF)\n",
                                guest_path, host_path.c_str(), selected_backend != nullptr);
-        return 0x806a0001ull;
+        void* obj = nullptr; AvpEventCb cb = nullptr; bool play = false, player_missing = false;
+        {
+            std::lock_guard<std::mutex> lk(g_avp_mx);
+            auto it = g_avp.find(handle);
+            if (it == g_avp.end()) {
+                player_missing = true;
+            } else {
+                AvpPlayer& p = it->second;
+                p.guest_path = guest_path;
+                p.have_source = true; p.synthetic = false;
+                p.poll = 0; p.audio_poll = 0; p.active_poll = 0; p.last_ts_ms = 0;
+                p.paused = false; p.stop_fired = false;
+                p.texture_frames.clear(); p.texture_frame_bytes = 0; p.next_texture_frame = 0;
+                p.backend = nullptr; p.backend_id = -1;
+                p.width = 0; p.height = 0; p.fps = 0.0f;
+                p.has_audio = false; p.audio_channels = 0; p.audio_rate = 0; p.duration_ms = 0;
+                obj = p.ev_obj; cb = p.ev_cb;
+                if (p.auto_start) { p.playing = true; play = true; }
+            }
+        }
+        if (player_missing) return 0x80000000ull;
+        avp_fire(obj, cb, AVP_READY);
+        if (play) avp_fire(obj, cb, AVP_PLAY);
+        return 0;
     }
 
     const uint32_t video_width = synthetic ? 1920u : stream.width;

--- a/prosper/tests/test_avplayer.cpp
+++ b/prosper/tests/test_avplayer.cpp
@@ -235,6 +235,19 @@ int main() {
           "the first IsActive poll fires STOP (immediate EOF) so the while(IsActive) loop ends");
     close(failed_handle, 0, 0, 0, 0, 0);
 
+    // Same graceful skip on the auto_start branch (the shape PPSA02664 actually uses): AddSource fires
+    // READY and PLAY itself, then the first IsActive poll fires STOP.
+    AvpInitData auto_data = data;
+    auto_data.auto_start = 1;
+    event_count = 0;
+    uint64_t auto_failed = init((uint64_t)(uintptr_t)&auto_data, 0, 0, 0, 0, 0);
+    CHECK(add(auto_failed, (uint64_t)(uintptr_t)missing_source, 0, 0, 0, 0) == 0 &&
+              event_count == 2 && events[0] == 2 && events[1] == 3,
+          "auto_start unopenable source: AddSource fires READY then PLAY (graceful skip begins)");
+    CHECK(active(auto_failed, 0, 0, 0, 0, 0) == 0 && event_count == 3 && events[2] == 1,
+          "auto_start skipped source reaches STOP on the first IsActive poll");
+    close(auto_failed, 0, 0, 0, 0, 0);
+
     fake.fail_open = false;
     event_count = 0;
     texture_alloc_count = texture_free_count = 0;

--- a/prosper/tests/test_avplayer.cpp
+++ b/prosper/tests/test_avplayer.cpp
@@ -205,8 +205,10 @@ int main() {
     // IsActive must report "not active" so the game's while(IsActive) playback loop ends and it advances.
     CHECK(active(out, 0, 0, 0, 0, 0) == 0, "sceAvPlayerIsActive -> 0 (finished, proceed)");
 
-    // A missing native source must stay failed: no READY callback, no streams, and no implicit black
-    // frames. The same backend then proves /app0 translation and real stream metadata/frame handoff.
+    // An unopenable native source must be SKIPPED GRACEFULLY, not left hanging (#1105): AddSource sets
+    // up an empty source and drives the normal lifecycle to an immediate EOF instead of returning a bare
+    // error with no event. The same backend then proves /app0 translation and real stream metadata/frame
+    // handoff.
     set_synthetic_frames(nullptr);
     set_app0_root("C:/prosper-test-app0");
     CHECK(resolve_guest_path("movie.mp4") == "C:/prosper-test-app0/movie.mp4",
@@ -221,10 +223,16 @@ int main() {
     fake.fail_open = true;
     uint64_t failed_handle = init((uint64_t)(uintptr_t)&data, 0, 0, 0, 0, 0);
     const char missing_source[] = "/app0/missing.mp4";
-    CHECK(add(failed_handle, (uint64_t)(uintptr_t)missing_source, 0, 0, 0, 0) != 0,
-          "native source-open failure is returned instead of selecting synthetic playback");
-    CHECK(streams(failed_handle, 0, 0, 0, 0, 0) == 0 && event_count == 0,
-          "failed source has no streams and fires no READY callback");
+    CHECK(add(failed_handle, (uint64_t)(uintptr_t)missing_source, 0, 0, 0, 0) == 0,
+          "unopenable source is skipped gracefully: AddSource succeeds instead of hanging (#1105)");
+    CHECK(event_count == 1 && events[0] == 2,
+          "AddSource on an unopenable source fires READY (the source lifecycle begins)");
+    CHECK(streams(failed_handle, 0, 0, 0, 0, 0) == 1,
+          "the skipped source presents as a single empty video stream (immediate EOF, no frames)");
+    CHECK(start(failed_handle, 0, 0, 0, 0, 0) == 0 && event_count == 2 && events[1] == 3,
+          "Start on the skipped source fires PLAY (this player is not auto_start)");
+    CHECK(active(failed_handle, 0, 0, 0, 0, 0) == 0 && event_count == 3 && events[2] == 1,
+          "the first IsActive poll fires STOP (immediate EOF) so the while(IsActive) loop ends");
     close(failed_handle, 0, 0, 0, 0, 0);
 
     fake.fail_open = false;


### PR DESCRIPTION
fix(avplayer): gracefully skip an unopenable source instead of hanging the title (#1105)

Follow-up from #1104. When a video source genuinely cannot be opened (corrupt file,
missing codec, demux error), sceAvPlayerAddSource returned an error and fired NO
lifecycle event. A title whose intro state machine loops `while (IsActive)` waiting
for the movie to finish then deadlocks in its black intro scene — the #320 hang
shape, now for the uncommon undecodable case instead of the no-backend case.

Fix: on total source-open failure, set up an EMPTY source (have_source=true,
backend=nullptr, synthetic=false) and drive the normal lifecycle to an immediate
EOF, exactly as a zero-length movie would: AddSource fires AVP_READY (and AVP_PLAY
if auto_start), the title Starts it, then the first sceAvPlayerIsActive /
GetVideoData poll finds no backend and no synthetic frames (the existing
fallthrough at hle_service.cpp:506 / :760) and fires AVP_STOP. IsActive returns 0,
the game's playback loop ends, and it skips the unplayable movie and proceeds.
AddSource now returns success (the movie "played" and instantly finished) rather
than a bare error.

Defense-in-depth: a title must never deadlock because an optional intro movie won't
decode.

Scope/affected: the source-open-FAILURE path of sceAvPlayerAddSource only. The
common path (a decodable movie, or the PROSPER_AVP_SYNTH_FRAMES synthetic fallback)
is unchanged. Adds PROSPER_AVP_FORCE_FAIL (off by default) to exercise the failure
path against a real title without a corrupt media file.

Verification (local, Linux):
- LIVE: PPSA02664 (Alex Kidd) with PROSPER_AVP_FORCE_FAIL=1 forces its intro
  (/app0/Media/StreamingAssets/introscs.mp4) to fail. AVP log shows READY(0x02) ->
  PLAY(0x03) -> STOP(0x01), and the game advances past the black intro to its main
  menu ("ALEX KIDD IN MIRACLE WORLD", LOAD/NEW GAME/OPTIONS/CREDITS) — 17k-20k-color
  animated frames instead of a static black hang.
- UNIT: tests/test_avplayer.cpp's unopenable-source case updated from the old
  no-event contract to the graceful lifecycle (READY on AddSource, PLAY on Start,
  STOP on the first IsActive poll; one empty video stream). ctest 131/131 green.

Fixes #1105.