### PR TITLE
fix(hle): detect recursive static-init in __cxa_guard_acquire/call_once (#979)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -247,6 +247,11 @@ if(TARGET prosper_core)
   target_link_libraries(test_http PRIVATE prosper_core)
   add_test(NAME http_hle COMMAND test_http)
 
+  add_executable(test_guard_recursion tests/test_guard_recursion.cpp)
+  target_link_libraries(test_guard_recursion PRIVATE prosper_core Threads::Threads)
+  add_test(NAME guard_recursion COMMAND test_guard_recursion)
+  set_tests_properties(guard_recursion PROPERTIES TIMEOUT 30)
+
   add_executable(test_font tests/test_font.cpp)
   target_link_libraries(test_font PRIVATE prosper_core)
   add_test(NAME font_hle COMMAND test_font)

--- a/prosper/src/hle/hle_libc.cpp
+++ b/prosper/src/hle/hle_libc.cpp
@@ -17,6 +17,8 @@
 #include <atomic>
 #include <mutex>
 #include <condition_variable>
+#include <thread>
+#include <unordered_map>
 
 // setjmp/longjmp — the guest's Boehm GC calls setjmp to flush callee-saved registers to a
 // buffer so it can scan them as GC roots (and the runtime uses it for exception unwinding).
@@ -492,7 +494,27 @@ HLE(h_cxa_finalize){ return 0; }
 // exactly one thread and blocks the rest until release/abort. Contenders park on one global
 // mutex/condvar pair (init is cold; the winner runs its constructor OUTSIDE the lock, so
 // independent guards cannot deadlock each other); the fast path stays a lock-free acquire-load.
-namespace { std::mutex g_guard_mx; std::condition_variable g_guard_cv; }
+//
+// Recursion (#979): the thread that claimed a guard runs the initializer; if THAT initializer
+// re-enters the SAME guard (a lazy singleton whose constructor touches itself), the old code saw
+// busy=1 (which the thread itself set) and blocked on the condvar — a self-deadlock (it waits for
+// itself to release). The Itanium C++ ABI forbids recursive initialization; PS5's libc++abi aborts
+// with "recursive_init". We track the claiming thread per in-flight guard/flag in g_init_owner and,
+// on re-entry by the same thread, break the deadlock without re-running the initializer (guard ->
+// return 0 "don't run", once -> return 1 "already done") and log loudly rather than aborting the
+// whole emulator over one guest's dubious static. A different thread contending is unchanged: it is
+// not the owner, so it falls through to wait() exactly as before. The map only ever holds the
+// handful of guards/flags CURRENTLY initializing (an entry is erased on release/abort/completion),
+// so it cannot grow unboundedly. CONFIDENCE: MED — correct guests never take this path (they would
+// abort on hardware too); the value is converting a silent hang into a visible, non-fatal event.
+namespace {
+    std::mutex g_guard_mx;
+    std::condition_variable g_guard_cv;
+    // in-flight guard/flag address -> the thread that claimed it (recursion detection). Guarded by
+    // g_guard_mx. Keyed by host address; a guest thread runs its HLE calls on its own host thread,
+    // so std::this_thread::get_id() is a stable per-guest-thread identity across acquire/init/re-entry.
+    std::unordered_map<const void*, std::thread::id> g_init_owner;
+}
 HLE(h_guard_acquire) {
     auto* g = (std::atomic<uint8_t>*)P(a0);
     if (g->load(std::memory_order_acquire)) return 0;      // already initialized
@@ -500,7 +522,19 @@ HLE(h_guard_acquire) {
     for (;;) {
         if (g->load(std::memory_order_acquire)) return 0;  // init finished while we waited
         uint8_t* busy = (uint8_t*)g + 1;
-        if (!*busy) { *busy = 1; return 1; }               // we win: caller runs the initializer
+        if (!*busy) {                                      // we win: caller runs the initializer
+            *busy = 1;
+            g_init_owner[g] = std::this_thread::get_id();
+            return 1;
+        }
+        auto owner = g_init_owner.find(g);
+        if (owner != g_init_owner.end() && owner->second == std::this_thread::get_id()) {
+            // Same thread re-entering its own in-flight guard = recursive static init (ABI-illegal).
+            // Blocking here would deadlock on ourselves; return 0 (don't re-run) instead.
+            std::fprintf(stderr, "[hle] __cxa_guard_acquire: recursive initialization of guard %p by "
+                                 "the same thread (guest C++ ABI violation); not re-running\n", (void*)g);
+            return 0;
+        }
         g_guard_cv.wait(lk);
     }
 }
@@ -508,13 +542,14 @@ HLE(h_guard_release) {
     auto* g = (std::atomic<uint8_t>*)P(a0);
     { std::lock_guard<std::mutex> lk(g_guard_mx);
       ((uint8_t*)g)[1] = 0;
+      g_init_owner.erase(g);
       g->store(1, std::memory_order_release); }
     g_guard_cv.notify_all();
     return 0;
 }
 HLE(h_guard_abort) {   // initializer threw: clear busy so another thread can retry
     auto* g = (std::atomic<uint8_t>*)P(a0);
-    { std::lock_guard<std::mutex> lk(g_guard_mx); ((uint8_t*)g)[1] = 0; }
+    { std::lock_guard<std::mutex> lk(g_guard_mx); ((uint8_t*)g)[1] = 0; g_init_owner.erase(g); }
     g_guard_cv.notify_all();
     return 0;
 }
@@ -534,13 +569,25 @@ HLE(h_execute_once) {
         std::unique_lock<std::mutex> lk(g_guard_mx);
         uint32_t v = flag->load(std::memory_order_acquire);
         if (v == 1) return 1;
-        if (v == 2) { g_guard_cv.wait(lk); continue; }              // another thread is running it
+        if (v == 2) {                                               // an init is running
+            auto owner = g_init_owner.find(flag);
+            if (owner != g_init_owner.end() && owner->second == std::this_thread::get_id()) {
+                // Same thread re-entering call_once on its own in-flight flag = recursive init
+                // (UB per the standard; would self-deadlock). Treat as done without re-running.
+                std::fprintf(stderr, "[hle] std::call_once: recursive execution of once_flag %p by the "
+                                     "same thread (guest UB); not re-running\n", (void*)flag);
+                return 1;
+            }
+            g_guard_cv.wait(lk); continue;                          // another thread is running it
+        }
         flag->store(2, std::memory_order_relaxed);
+        g_init_owner[flag] = std::this_thread::get_id();
         lk.unlock();
         void* ctx = nullptr;
         int r = cb ? cb((void*)P(a0), (void*)P(a2), &ctx) : 1;
         lk.lock();
         flag->store(r ? 1u : 0u, std::memory_order_release);        // failure -> retryable next call
+        g_init_owner.erase(flag);
         lk.unlock();
         g_guard_cv.notify_all();
         return (uint64_t)(r ? 1 : 0);

--- a/prosper/tests/test_guard_recursion.cpp
+++ b/prosper/tests/test_guard_recursion.cpp
@@ -1,0 +1,158 @@
+// test_guard_recursion — #979: __cxa_guard_acquire / std::call_once recursion must not self-deadlock.
+//
+// The Itanium C++ ABI static-init guard (h_guard_acquire) and std::call_once core (h_execute_once)
+// let exactly one thread run the initializer and block the rest. Before #979 the winner tracked no
+// owner, so if the initializer re-entered the SAME guard/flag on the SAME thread (a lazy singleton
+// whose constructor touches itself), the re-entry saw the busy/running state it had set itself and
+// blocked on the shared condvar — a self-deadlock (waiting for itself to release). These tests prove
+// (1) same-thread recursion now returns without blocking and without re-running the initializer, and
+// (2) the multi-thread one-winner contract (#490) is preserved unchanged.
+//
+// P() in hle_libc.cpp is the identity map (guest addr == host addr), so a test can hand these HLEs
+// real host pointers via the registry (Hle::lookup) and call them directly.
+#include "../src/hle/dispatch.hpp"
+#include "../src/hle/nid.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <future>
+#include <memory>
+#include <thread>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { std::printf("  [FAIL] %s\n", m); ++fails; } \
+                         else std::printf("  [ok]   %s\n", m); } while (0)
+
+// Run fn on a fresh detached thread; return true if it finished within `ms`, false if it appears to
+// have deadlocked. A detached thread + shared promise means a genuine deadlock leaves a blocked
+// thread rather than hanging the whole test (the test reports the failure and moves on); with the
+// fix in place nothing ever deadlocks, so no thread is leaked on a passing run.
+template <class F>
+static bool run_bounded(F fn, int ms) {
+    auto p = std::make_shared<std::promise<void>>();
+    auto fut = p->get_future();
+    std::thread([fn, p]() mutable { fn(); p->set_value(); }).detach();
+    return fut.wait_for(std::chrono::milliseconds(ms)) == std::future_status::ready;
+}
+
+static HleFn g_acquire = nullptr, g_release = nullptr;
+static HleFn g_once = nullptr;
+
+static inline uint64_t U(void* p) { return (uint64_t)(uintptr_t)p; }
+
+// --- std::call_once callback that recursively re-enters call_once on its own flag ---------------
+static uint64_t g_once_flag_addr = 0;
+static uint64_t g_once_cb_addr = 0;
+static std::atomic<int> g_once_cb_calls{0};
+static std::atomic<uint64_t> g_once_recursive_ret{~0ull};
+static int once_recursive_cb(void* /*flag*/, void* /*arg*/, void** /*ctx*/) {
+    g_once_cb_calls.fetch_add(1);
+    // Re-enter call_once on the SAME flag from within its own initializer (guest UB / recursion).
+    g_once_recursive_ret.store(g_once(g_once_flag_addr, g_once_cb_addr, 0, 0, 0, 0));
+    return 1;  // success
+}
+// A plain callback that just counts, for the concurrent one-run test.
+static std::atomic<int> g_once_plain_calls{0};
+static int once_plain_cb(void*, void*, void**) { g_once_plain_calls.fetch_add(1); return 1; }
+
+int main() {
+    std::printf("== test_guard_recursion ==\n");
+    register_builtin_hle();
+    g_acquire = Hle::lookup(nid_hash("__cxa_guard_acquire"));
+    g_release = Hle::lookup(nid_hash("__cxa_guard_release"));
+    g_once    = Hle::lookup(nid_hash("_ZSt13_Execute_onceRSt9once_flagPFiPvS1_PS1_ES1_"));
+    CHECK(g_acquire && g_release, "__cxa_guard_acquire/release registered");
+    CHECK(g_once, "std::_Execute_once (call_once core) registered");
+    if (!g_acquire || !g_release || !g_once) return 1;
+
+    // (1) Guard recursion on the same thread must NOT deadlock and must NOT re-hand the initializer.
+    {
+        uint64_t guard = 0;                       // byte0=initialized, byte1=busy
+        std::atomic<uint64_t> r1{~0ull}, r2{~0ull};
+        bool done = run_bounded([&] {
+            r1.store(g_acquire(U(&guard), 0, 0, 0, 0, 0));   // win -> 1, runs initializer
+            r2.store(g_acquire(U(&guard), 0, 0, 0, 0, 0));   // recursion -> pre-#979 deadlock
+        }, 3000);
+        CHECK(done, "recursive __cxa_guard_acquire returns (no self-deadlock)");
+        CHECK(r1.load() == 1, "first acquire wins (returns 1)");
+        CHECK(r2.load() == 0, "recursive acquire returns 0 (do not re-run initializer)");
+        // Guard was never released, so it must still read uninitialized (byte0 == 0): the recursive
+        // return-0 is 'skip re-init', NOT a spurious 'already initialized' completion.
+        CHECK((guard & 0xff) == 0, "recursion did not mark the guard initialized");
+        if (r1.load() == 1) g_release(U(&guard), 0, 0, 0, 0, 0);   // clean up the in-flight guard
+    }
+
+    // (2) Two threads racing the SAME fresh guard: exactly one wins (1), the other blocks then gets 0.
+    //     Proves the #490 one-winner contract is unchanged by the owner tracking.
+    {
+        uint64_t guard = 0;
+        std::atomic<int> winners{0}, zeros{0};
+        bool done = run_bounded([&] {
+            auto worker = [&] {
+                uint64_t r = g_acquire(U(&guard), 0, 0, 0, 0, 0);
+                if (r == 1) {
+                    winners.fetch_add(1);
+                    std::this_thread::sleep_for(std::chrono::milliseconds(20));  // hold the init
+                    g_release(U(&guard), 0, 0, 0, 0, 0);
+                } else if (r == 0) {
+                    zeros.fetch_add(1);
+                }
+            };
+            std::thread a(worker), b(worker);
+            a.join(); b.join();
+        }, 3000);
+        CHECK(done, "concurrent guard race completes (no deadlock)");
+        CHECK(winners.load() == 1, "exactly one thread wins the guard");
+        CHECK(zeros.load() == 1, "the other thread returns 0 after release");
+    }
+
+    // (3) std::call_once recursion on the same thread must NOT deadlock; the callback runs once and
+    //     the recursive call_once reports done (1) without re-entering the callback.
+    {
+        uint32_t flag = 0;
+        g_once_flag_addr = U(&flag);
+        g_once_cb_addr = U((void*)&once_recursive_cb);
+        g_once_cb_calls.store(0);
+        g_once_recursive_ret.store(~0ull);
+        std::atomic<uint64_t> outer{~0ull};
+        bool done = run_bounded([&] {
+            outer.store(g_once(U(&flag), U((void*)&once_recursive_cb), 0, 0, 0, 0));
+        }, 3000);
+        CHECK(done, "recursive std::call_once returns (no self-deadlock)");
+        CHECK(g_once_cb_calls.load() == 1, "call_once callback runs exactly once under recursion");
+        CHECK(g_once_recursive_ret.load() == 1, "recursive call_once reports done (1) without re-running");
+        CHECK(outer.load() == 1, "outer call_once succeeds");
+    }
+
+    // (4) Two threads racing a fresh once_flag run the callback exactly once; both return 1.
+    {
+        uint32_t flag = 0;
+        g_once_plain_calls.store(0);
+        std::atomic<int> ones{0};
+        bool done = run_bounded([&] {
+            auto worker = [&] {
+                uint64_t r = g_once(U(&flag), U((void*)&once_plain_cb), 0, 0, 0, 0);
+                if (r == 1) ones.fetch_add(1);
+            };
+            std::thread a(worker), b(worker);
+            a.join(); b.join();
+        }, 3000);
+        CHECK(done, "concurrent call_once race completes (no deadlock)");
+        CHECK(g_once_plain_calls.load() == 1, "call_once callback runs exactly once across threads");
+        CHECK(ones.load() == 2, "both threads see call_once as done (return 1)");
+    }
+
+    std::printf(fails ? "FAILED (%d)\n" : "PASSED\n", fails);
+    // A regression that reintroduces the self-deadlock leaves a worker thread blocked on the shared
+    // condvar (run_bounded returns false, the CHECK above fails). Returning normally would then run
+    // static destructors while that thread waits on g_guard_cv — UB that can hang process exit. Exit
+    // immediately with the verdict instead, so a regressed build fails fast and cleanly rather than
+    // hanging until the ctest timeout. On a passing run no thread is leaked, so this is just a return.
+    std::fflush(stdout);
+    std::_Exit(fails ? 1 : 0);
+}


### PR DESCRIPTION
## Issue
Fixes #979.

## Failure scenario
`h_guard_acquire` (prosper's `__cxa_guard_acquire`, `hle_libc.cpp`) and `h_execute_once` (the `std::call_once` core) let exactly one thread run an initializer and block the rest on a shared condvar (`g_guard_cv`). Neither tracked *which* thread claimed the guard/flag. So when an initializer re-enters the **same** guard/flag on the **same** thread — a lazy singleton whose constructor touches itself — the re-entry sees the busy/running state it set itself and calls `g_guard_cv.wait()`, waiting for itself to release. **Self-deadlock**: the guest thread hangs silently, forever.

## Contract / fix
The Itanium C++ ABI forbids recursive static init; PS5's libc++abi aborts on it. This patch:
- Tracks the claiming thread per in-flight guard/flag in a small side map `g_init_owner` (keyed by address, guarded by the existing `g_guard_mx`; `std::this_thread::get_id()` is a stable per-guest-thread identity because each guest thread runs its HLE calls on its own host thread).
- On re-entry by the **same** thread, breaks the deadlock **without re-running the initializer** — the guard returns `0` ("do not run"), `call_once` returns `1` ("already done") — and logs loudly.
- Rather than aborting the whole emulator over one guest's dubious static, it stays non-fatal: a correct guest never takes this path, and converting a silent hang into a visible event is the goal.

## Unaffected behavior (deliberately preserved)
- **Different-thread contention is unchanged**: a contender is not the owner, so it still `wait()`s exactly as before — the #490 one-winner / concurrent-double-construction contract holds.
- Entries are erased on release/abort/completion, so the map only ever holds the handful of guards/flags *currently* initializing (cannot grow unboundedly).

## Risks
- Synchronization/ABI-sensitive path shared by every title → **requesting independent review** (also flagged in the issue).
- Thread-id reuse edge: if a thread claimed a guard, died mid-init without release/abort, and its id were reused by a new thread that then touched the *same* guard, that new thread would see a false-recursion and get `0`. This requires an already-catastrophic abandoned-in-flight-init; returning `0` there is no worse than the alternatives. Not a new hazard.

## Verification (Linux, this box)
- `cmake --build` clean; **`ctest` 131/131 green** (adds `guard_recursion`, test #28).
- New `tests/test_guard_recursion.cpp` (16 checks) proves same-thread recursion on **both** the guard and `call_once` returns without deadlock and without re-running the initializer, and that the multi-thread one-winner / run-once contracts are preserved.
- **Confirmed the test fails without the fix**: reverting only `hle_libc.cpp` makes the 5 recursion-specific checks fail (they deadlock; the test `_Exit`s fast+clean rather than hanging). CONFIDENCE: MED, marked in-code.

Not a rendered-output change; no snapshot needed.