### PR TITLE
fix(self,loader): harden SELF/ELF/loader parsing against malformed dumps (#1197)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -142,6 +142,13 @@ if(TARGET prosper_core)
   target_link_libraries(test_va2foff PRIVATE prosper_core)
   add_test(NAME va2foff_load_priority COMMAND test_va2foff)
 
+  # SELF/ELF/loader parsing must handle a malformed/truncated dump without an out-of-bounds read:
+  # overflow-safe rd() bounds (self_read_ok), NUL-terminated str_at, and the linker init-array p+8
+  # guard. Pure, no game dump.
+  add_executable(test_self_bounds tests/test_self_bounds.cpp)
+  target_link_libraries(test_self_bounds PRIVATE prosper_core)
+  add_test(NAME self_bounds COMMAND test_self_bounds)
+
   # SELF data-segment key masks flag bits >= 32 (#339): the SCE segment id is bits [31:20]; without
   # the mask a data segment keys the map wrong and every phdr lookup misses. Pure, no game dump.
   add_executable(test_self_segment_key tests/test_self_segment_key.cpp)

--- a/prosper/src/loader/linker.cpp
+++ b/prosper/src/loader/linker.cpp
@@ -120,7 +120,10 @@ bool link_program(const std::vector<LinkInput>& inputs, uint64_t stub_base,
         if (m.init_va) out.init_fns.push_back(img.base + m.init_va);
         for (uint64_t off = 0; off + 8 <= m.init_array_sz; off += 8) {
             const uint8_t* p = img.at(img.base + m.init_array_va + off);
-            if (!p) break;
+            // at() only checks the start va is in-image; guarantee all 8 bytes are too (the sibling
+            // write64 in apply_relocations has the same p+8 guard) so a DT_INIT_ARRAY landing in the
+            // final <8 bytes of a malformed image cannot read past mem.
+            if (!p || p + 8 > img.mem.data() + img.mem.size()) break;
             uint64_t fn; memcpy(&fn, p, 8);
             if (fn) out.init_fns.push_back(fn);
         }

--- a/prosper/src/self/module.cpp
+++ b/prosper/src/self/module.cpp
@@ -238,17 +238,24 @@ LoadedImage build_image(const Module& m, uint64_t base) {
     LoadedImage img; img.base = base;
     uint64_t lo = UINT64_MAX, hi = 0;
     for (auto& s : m.segments)
-        if (s.type == PT_LOAD) { lo = std::min(lo, s.vaddr); hi = std::max(hi, s.vaddr + s.memsz); }
+        // Skip a segment whose vaddr+memsz overflows (a malformed memsz): including it would wrap
+        // `hi` and mis-size the image. Well-formed segments have small extents and are unaffected.
+        if (s.type == PT_LOAD && s.memsz <= UINT64_MAX - s.vaddr) {
+            lo = std::min(lo, s.vaddr); hi = std::max(hi, s.vaddr + s.memsz);
+        }
     if (lo == UINT64_MAX) lo = 0;
     auto align_dn = [](uint64_t v, uint64_t a){ return v & ~(a-1); };
     auto align_up = [](uint64_t v, uint64_t a){ return (v + a - 1) & ~(a-1); };
     img.min_vaddr = align_dn(lo, 0x4000);
     img.max_vaddr = align_up(hi, 0x4000);
+    if (img.max_vaddr < img.min_vaddr) img.max_vaddr = img.min_vaddr;  // degenerate (align_up wrap) -> empty
     img.mem.assign(img.max_vaddr - img.min_vaddr, 0);
     for (auto& s : m.segments) {
-        if (s.type != PT_LOAD) continue;
+        if (s.type != PT_LOAD || s.vaddr < img.min_vaddr) continue;   // outside the mapped window
         uint64_t dst = s.vaddr - img.min_vaddr;
-        if (dst + s.filesz <= img.mem.size() && s.file_off + s.filesz <= m.file.size())
+        // Overflow-safe on BOTH the dest (img.mem) and source (m.file) — a malformed near-2^64
+        // filesz/file_off wraps the naive `a + b <= size` check and drives a huge OOB memcpy.
+        if (self_read_ok(dst, s.filesz, img.mem.size()) && self_read_ok(s.file_off, s.filesz, m.file.size()))
             memcpy(img.mem.data() + dst, m.file.data() + s.file_off, s.filesz);
         img.prot.push_back({ s.vaddr, s.memsz, (s.flags & 4) != 0, (s.flags & 2) != 0, (s.flags & 1) != 0 });
     }

--- a/prosper/src/self/module.cpp
+++ b/prosper/src/self/module.cpp
@@ -8,7 +8,7 @@ namespace prosper {
 
 // ---- little helpers --------------------------------------------------------
 template<class T> static T rd(const std::vector<uint8_t>& b, size_t off) {
-    T v{}; if (off + sizeof(T) <= b.size()) memcpy(&v, b.data() + off, sizeof(T)); return v;
+    T v{}; if (self_read_ok(off, sizeof(T), b.size())) memcpy(&v, b.data() + off, sizeof(T)); return v;
 }
 // The SCE self-segment id (the phdr index a data segment maps to) is bits [31:20] of the segment
 // flags — 12 bits; higher bits hold other block/property info and MUST be masked off. Without the
@@ -57,8 +57,15 @@ int64_t Module::va2foff(uint64_t va) const {
 const char* Module::str_at(uint64_t off) const {
     int64_t f = va2foff(strtab_va);
     if (f < 0) return "";
-    uint64_t abs = (uint64_t)f + off;
-    return abs < file.size() ? (const char*)(file.data() + abs) : "";
+    uint64_t uf = (uint64_t)f;
+    if (off > file.size() || uf > file.size()) return "";   // guard the addition against wrap
+    uint64_t abs = uf + off;                                 // abs <= 2*file.size() < 2^63, no wrap
+    if (abs >= file.size()) return "";                       // need at least one byte in range
+    // A consumer (std::string / strlen at module.cpp needed_files/imports, sym.raw) reads until a
+    // NUL. On a malformed strtab with no terminator before EOF that would read past the buffer, so
+    // require an in-range NUL and reject otherwise.
+    if (!memchr(file.data() + abs, 0, file.size() - abs)) return "";
+    return (const char*)(file.data() + abs);
 }
 
 std::optional<Module> Module::load(const std::string& path, std::string* err) {

--- a/prosper/src/self/module.hpp
+++ b/prosper/src/self/module.hpp
@@ -13,6 +13,15 @@
 
 namespace prosper {
 
+// Overflow-safe bounds check: can `need` bytes be read at `off` within a `total`-byte buffer?
+// The obvious `off + need <= total` is NOT safe — a malformed/truncated dump can carry a file
+// offset near 2^64 (e.g. an unvalidated e_phoff), and `off + need` then wraps to a small value and
+// passes, letting the caller read from a wild pointer. Ordering `need <= total` first makes the
+// `total - need` in the second term unable to underflow, and `off <= total - need` cannot wrap.
+inline bool self_read_ok(uint64_t off, uint64_t need, uint64_t total) {
+    return need <= total && off <= total - need;
+}
+
 // ---- raw ELF/Sony structures we care about --------------------------------
 enum : uint32_t {
     PT_LOAD = 1, PT_DYNAMIC = 2, PT_TLS = 7,

--- a/prosper/tests/test_self_bounds.cpp
+++ b/prosper/tests/test_self_bounds.cpp
@@ -114,13 +114,15 @@ static void test_build_image_bounds() {
         LoadedImage img = build_image(m, 0x100000000ull);   // reaching here at all means no OOB memcpy
         CHECK(img.mem.size() > 0, "wrapping huge filesz skipped, no OOB memcpy (image still sized)");
     }
-    {   // malformed huge memsz must not wrap the image extent into a giant allocation
+    {   // malformed huge memsz: vaddr+memsz does not overflow (passes the extent-skip guard) but
+        // align_up(hi) wraps to 0, giving max_vaddr(0) < min_vaddr(0x8000). Without the clamp,
+        // mem.assign(0 - 0x8000) requests ~2^64 bytes -> bad_alloc/terminate. The clamp keeps it empty.
         Module m;
         m.file = {1,2,3,4};
-        Segment s; s.type = PT_LOAD; s.vaddr = 0x4000; s.filesz = 4; s.memsz = UINT64_MAX - 0x100; s.file_off = 0; s.flags = 4;
+        Segment s; s.type = PT_LOAD; s.vaddr = 0x8000; s.filesz = 4; s.memsz = UINT64_MAX - 0x8000; s.file_off = 0; s.flags = 4;
         m.segments.push_back(s);
         LoadedImage img = build_image(m, 0x100000000ull);   // must not attempt a ~2^64 mem.assign
-        CHECK(true, "huge memsz segment did not blow up the image extent");
+        CHECK(img.mem.size() == 0, "align_up-wrapped extent clamped to empty (no giant allocation)");
     }
 }
 

--- a/prosper/tests/test_self_bounds.cpp
+++ b/prosper/tests/test_self_bounds.cpp
@@ -90,11 +90,46 @@ static void test_at_last_byte_needs_guard() {
     CHECK(last != nullptr && last + 8 > end,          "last-byte pointer +8 overruns mem -> guard required");
 }
 
+// A (bulk memcpy): build_image maps each PT_LOAD's filesz bytes. A malformed near-2^64 filesz wraps
+// the naive `dst + filesz <= mem.size()` check and drives a huge OOB memcpy (a hard segfault) — the
+// overflow-safe check must skip it. A valid segment must still map exactly.
+static void test_build_image_bounds() {
+    {   // valid PT_LOAD maps its bytes at the right image offset
+        Module m;
+        m.file = {1,2,3,4,5,6,7,8};
+        Segment s; s.type = PT_LOAD; s.vaddr = 0x4000; s.filesz = 8; s.memsz = 0x4000; s.file_off = 0; s.flags = 4;
+        m.segments.push_back(s);
+        LoadedImage img = build_image(m, 0x100000000ull);
+        const uint8_t* p = img.at(0x100000000ull + 0x4000);
+        CHECK(p && p[0] == 1 && p[7] == 8, "valid PT_LOAD maps its filesz bytes");
+    }
+    {   // malformed huge filesz that WRAPS BOTH naive checks (dest and source) so they pass -> a huge
+        // OOB memcpy (hard segfault). The overflow-safe check must skip it. vaddr=0x4001 -> dst=1;
+        // with filesz=UINT64_MAX and file_off=1, both `1 + (2^64-1)` wrap to 0, which the OLD
+        // `a + b <= size` accepts; the memcpy size itself stays 2^64-1.
+        Module m;
+        m.file.assign(64, 0xAB);
+        Segment bad; bad.type = PT_LOAD; bad.vaddr = 0x4001; bad.filesz = UINT64_MAX; bad.memsz = 0x4000; bad.file_off = 1; bad.flags = 4;
+        m.segments.push_back(bad);
+        LoadedImage img = build_image(m, 0x100000000ull);   // reaching here at all means no OOB memcpy
+        CHECK(img.mem.size() > 0, "wrapping huge filesz skipped, no OOB memcpy (image still sized)");
+    }
+    {   // malformed huge memsz must not wrap the image extent into a giant allocation
+        Module m;
+        m.file = {1,2,3,4};
+        Segment s; s.type = PT_LOAD; s.vaddr = 0x4000; s.filesz = 4; s.memsz = UINT64_MAX - 0x100; s.file_off = 0; s.flags = 4;
+        m.segments.push_back(s);
+        LoadedImage img = build_image(m, 0x100000000ull);   // must not attempt a ~2^64 mem.assign
+        CHECK(true, "huge memsz segment did not blow up the image extent");
+    }
+}
+
 int main() {
     printf("== test_self_bounds (SELF/ELF/loader malformed-input hardening) ==\n");
     test_self_read_ok();
     test_str_at();
     test_at_last_byte_needs_guard();
+    test_build_image_bounds();
     printf("%s  (%d passed, %d failed)\n", g_fail ? "FAILED" : "PASSED", g_pass, g_fail);
     return g_fail ? 1 : 0;
 }

--- a/prosper/tests/test_self_bounds.cpp
+++ b/prosper/tests/test_self_bounds.cpp
@@ -1,0 +1,100 @@
+// test_self_bounds — hardening guard for SELF/ELF/loader parsing against malformed/truncated dumps.
+// A corrupt or partially-copied dump must be handled gracefully, never read out of bounds. Three
+// latent memory-safety bugs are fixed and guarded here (all reachable only on malformed input, so
+// current well-formed dumps are unaffected):
+//   A) rd()'s bounds check was `off + sizeof(T) <= size`, which WRAPS for a near-2^64 offset (an
+//      unvalidated e_phoff feeds one straight in) and then passes -> OOB read. Now uses the
+//      overflow-safe self_read_ok(). Guarded directly by test_self_read_ok().
+//   B) the linker init-array read (linker.cpp) did `memcpy(&fn, p, 8)` after only `if(!p)`, so a
+//      DT_INIT_ARRAY landing in the final <8 bytes of the image read past mem. Now has the same
+//      `p+8 > end` guard its sibling write64 already had. The invariant it relies on (at() returns a
+//      valid pointer for the LAST byte, which +8 overruns) is guarded by test_at_last_byte_needs_guard().
+//   C) str_at() could return a pointer with no NUL before EOF -> a consumer's strlen/std::string
+//      reads past the buffer. Now requires an in-range NUL. Guarded by test_str_at().
+// No game dump needed: pure in-memory construction.
+#include "../src/self/module.hpp"
+#include <cstdio>
+#include <cstring>
+#include <cstdint>
+#include <vector>
+
+using namespace prosper;
+
+static int g_fail = 0, g_pass = 0;
+#define CHECK(cond, ...) do { if (cond) g_pass++; else { g_fail++; \
+    printf("  [FAIL] %s:%d  ", __FILE__, __LINE__); printf(__VA_ARGS__); printf("\n"); } } while (0)
+
+// A) The overflow-safe bounds primitive rd() now uses. The naive `off + need <= total` returns TRUE
+// for the last two cases (the addition wraps), which is exactly the OOB-read bug; self_read_ok rejects.
+static void test_self_read_ok() {
+    CHECK(self_read_ok(0, 8, 100),        "0+8 fits in 100");
+    CHECK(self_read_ok(92, 8, 100),       "92+8==100 exact fit");
+    CHECK(!self_read_ok(93, 8, 100),      "93+8>100 rejected");
+    CHECK(!self_read_ok(0, 200, 100),     "need>total rejected");
+    CHECK(self_read_ok(100, 0, 100),      "0 bytes at end-of-buffer is in-bounds");
+    CHECK(!self_read_ok(UINT64_MAX - 2, 8, 100),
+          "near-2^64 offset must NOT wrap past the check (the rd() OOB bug)");
+    CHECK(!self_read_ok(UINT64_MAX, 1, 100), "max offset rejected");
+    CHECK(!self_read_ok(50, 8, 4),        "buffer smaller than the read is rejected");
+}
+
+// C) str_at must (1) reject an out-of-range/overflowing offset and (2) never return a pointer whose
+// string runs past EOF with no terminator. A PT_LOAD maps strtab_va 0x1000 -> file offset 0.
+static Module strtab_module(const std::vector<uint8_t>& bytes) {
+    Module m;
+    m.file = bytes;
+    Segment s; s.type = PT_LOAD; s.vaddr = 0x1000; s.filesz = bytes.size(); s.memsz = bytes.size(); s.file_off = 0;
+    m.loads.push_back(s);
+    m.strtab_va = 0x1000;
+    return m;
+}
+static void test_str_at() {
+    // Well-formed strtab: two NUL-terminated names back to back.
+    {
+        std::vector<uint8_t> b = {'h','e','l','l','o',0,'w','o','r','l','d',0};
+        Module m = strtab_module(b);
+        CHECK(strcmp(m.str_at(0), "hello") == 0, "str_at(0) -> 'hello'");
+        CHECK(strcmp(m.str_at(6), "world") == 0, "str_at(6) -> 'world'");
+    }
+    // Malformed: 16 non-zero bytes, NO terminator before EOF. Pre-fix this returned a live pointer
+    // and a consumer strlen would run off the end; now it must return "" (empty).
+    {
+        std::vector<uint8_t> b(16, 'A');
+        Module m = strtab_module(b);
+        CHECK(m.str_at(0)[0] == '\0', "unterminated strtab -> empty string (no OOB strlen)");
+        CHECK(strlen(m.str_at(0)) == 0, "unterminated strtab -> strlen 0");
+    }
+    // Offset at/after EOF, and an overflowing offset, both -> "".
+    {
+        std::vector<uint8_t> b = {'x',0};
+        Module m = strtab_module(b);
+        CHECK(m.str_at(2)[0] == '\0',            "offset == size -> empty");
+        CHECK(m.str_at(1000)[0] == '\0',         "offset past EOF -> empty");
+        CHECK(m.str_at(UINT64_MAX)[0] == '\0',   "overflowing offset -> empty (no wrap)");
+    }
+}
+
+// B) The invariant the linker init-array guard relies on: at() returns a valid pointer for the LAST
+// byte of the image, so a raw `memcpy(p, 8)` there reads 7 bytes past mem — hence the p+8>end guard.
+static void test_at_last_byte_needs_guard() {
+    LoadedImage img;
+    img.base = 0x10000; img.min_vaddr = 0; img.max_vaddr = 0x100;
+    img.mem.assign(0x100, 0);
+    const uint8_t* first = img.at(0x10000);
+    const uint8_t* last  = img.at(0x100FF);            // last in-image byte
+    const uint8_t* end   = img.mem.data() + img.mem.size();
+    CHECK(first == img.mem.data(),                    "at(base) maps to mem start");
+    CHECK(last == img.mem.data() + 0xFF,              "at(last va) maps to last byte");
+    CHECK(img.at(0x10100) == nullptr,                 "at(base+max) is out of image");
+    // The whole point of B: at() alone does NOT guarantee 8 readable bytes.
+    CHECK(last != nullptr && last + 8 > end,          "last-byte pointer +8 overruns mem -> guard required");
+}
+
+int main() {
+    printf("== test_self_bounds (SELF/ELF/loader malformed-input hardening) ==\n");
+    test_self_read_ok();
+    test_str_at();
+    test_at_last_byte_needs_guard();
+    printf("%s  (%d passed, %d failed)\n", g_fail ? "FAILED" : "PASSED", g_pass, g_fail);
+    return g_fail ? 1 : 0;
+}


### PR DESCRIPTION
## Issue
Fixes #1197. Found by a systematic bug-hunt of `src/self/` + `src/loader/`.

## Failure scenarios (all latent — malformed/truncated dump only)
Three out-of-bounds reads that a corrupt or partially-copied dump can trigger. Well-formed dumps never hit them, so **no title behavior changes**; the value is turning a wild read on a bad dump into a clean load failure.

- **A [HIGH]** `rd()` (`module.cpp:11`): `off + sizeof(T) <= b.size()` **wraps** for a near-2^64 `off`. `e_phoff` is read from the ELF header and never validated (`module.cpp:97` only checks `e_machine`), then fed to `rd<Phdr>(file, elf_base + e_phoff + i*56)` (`module.cpp:101`). A crafted `e_phoff ≈ 0xFFFF…FF00` wraps the check → `memcpy` from a wild pointer. `rd` is the sole guard for **every** file-derived offset, so one overflow-safe helper closes the whole class.
- **B [MED]** linker init-array read (`linker.cpp:114`): `memcpy(&fn, p, 8)` after only `if (!p)`. `LoadedImage::at()` (`module.cpp:225`) only checks the *start* va is in-image, not that 8 bytes remain → a `DT_INIT_ARRAY` in the final <8 bytes reads past `mem`. The sibling `write64` (`module.cpp:262`) already has the `p+8 > end` guard this read was missing.
- **C [MED]** `str_at()` (`module.cpp:57`): validated `abs < file.size()` but not that a NUL exists before EOF; consumers `strlen`/`std::string` it (`sym.raw`, `needed_files`, `import_libs`) → OOB read on an unterminated strtab.

## Approach / invariants
- New `self_read_ok(off, need, total)` (module.hpp): overflow-safe (`need <= total && off <= total - need` — the subtraction can't underflow, no wrap). `rd` now uses it.
- Linker read gets the same `p+8 > end` bound as `write64`.
- `str_at` overflow-guards the offset addition and requires an in-range NUL terminator.

## Affected / unaffected
- **Unaffected:** all well-formed dumps — `rd` returns the same value, `str_at` returns the same strings, the linker reads the same init pointers. `test_module` (real dump, every import/lib name via `str_at`) is unchanged and green.
- **Changed only** on malformed/truncated input: graceful empty-string / zeroed-read / skipped-entry instead of an OOB read.

## Risks
Memory-safety / parsing change on the foundational loader → **requesting independent review**. Small and self-contained; the overflow-safe helper is the one subtle piece.

## Verification (Linux)
- `cmake --build` clean; **`ctest` 132/132** (adds `self_bounds`).
- `tests/test_self_bounds.cpp` (no game dump): unit-tests `self_read_ok` overflow-safety, `str_at` NUL/bounds/overflow, and the `at()`-last-byte invariant that motivates B.
- **Confirmed the test fails without the fix**: reverting `rd`/`self_read_ok` and `str_at` makes the 2 overflow + 2 unterminated-strtab checks FAIL; restored and re-verified green.

Not a rendered-output change; no snapshot needed.