### PR TITLE
fix(gpu): guard SetRegsIndirect's guest register-array read with guest_readable (#1199)

### DIFF
--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -1433,6 +1433,17 @@ void GpuState::apply(const Pm4Command& c) {
                 break;
             }
             if (c.regs_vaddr == 0 || c.num_regs == 0 || c.num_regs > kMaxRegsPerPacket) return;
+            // #312/#448: the indirect-register array lives in GUEST memory (regs_vaddr from the packet),
+            // and a freed/decommitted or recycled command buffer can leave it unmapped. Every other
+            // guest read in this file is guest_readable-guarded; this reader (up to 4096*8 = 32 KiB) was
+            // the one gap — an unmapped regs_vaddr would host-SIGSEGV in the loop below. Skip if unmapped.
+            if (!guest_readable(c.regs_vaddr, c.num_regs * (uint32_t)sizeof(ShaderReg))) {
+                static std::atomic<int> n{0};
+                if (n.fetch_add(1) < 24)
+                    fprintf(stderr, "[agc] SetRegsIndirect array unmapped — packet SKIPPED: vaddr=0x%llx num=%u\n",
+                            (unsigned long long)c.regs_vaddr, c.num_regs);
+                return;
+            }
             auto* regs = reinterpret_cast<const ShaderReg*>(static_cast<uintptr_t>(c.regs_vaddr));
             auto& file = (c.reg_class == RegClass::Cx) ? cx
                        : (c.reg_class == RegClass::Sh) ? sh : uc;

--- a/prosper/tests/test_command_processor.cpp
+++ b/prosper/tests/test_command_processor.cpp
@@ -126,6 +126,20 @@ int main() {
         CHECK(all, "SET_SH_REG range values sh[0x100..0x104] are the consecutive payload values");
     }
 
+    // SetRegsIndirect reads its {offset,value} array from GUEST memory (regs_vaddr from the packet).
+    // A freed/decommitted or recycled command buffer (#312) can leave that address unmapped; every
+    // other guest read in the command processor is guest_readable-guarded, and this one now is too.
+    // An unmapped regs array must be SKIPPED (no host OOB read), not dereferenced -> host SIGSEGV.
+    {
+        uint32_t cb[64]; memset(cb, 0, sizeof cb);
+        Dcb ud{}; ud.bottom = cb; ud.top = cb + 64; ud.cursor_up = cb; ud.cursor_down = cb + 64;
+        const uint64_t unmapped = 0x0000deadbeef0000ull;          // not in any host/guest mapping
+        setsh((uint64_t)(uintptr_t)&ud, unmapped, 4, 0, 0, 0);    // 4 regs @ an unmapped address
+        GpuState su;
+        run_cb(cb, 64, su);                                       // must return (guard skips), not SIGSEGV
+        CHECK(su.sh.empty(), "SetShRegsIndirect with an unmapped array is skipped (no OOB read, no regs applied)");
+    }
+
     // In-stream flip (sceAgcDcbSetFlip -> R_FLIP): the game flips via the Dcb, not the sceVideoOut
     // API, so the CommandProcessor MUST perform the videoout flip when it reaches the packet —
     // GetFlipStatus's count/flipArg/currentBuffer are what Unity's frame pacer polls before building


### PR DESCRIPTION
## Issue
Fixes #1199. Found by a systematic bug-hunt of the PM4/command-processor decode.

## Failure scenario
`Set{Cx,Sh,Uc}RegistersIndirect` apply (`command_processor.cpp:1426-1439`) reads up to `4096 * sizeof(ShaderReg)` = **32 KiB** from the packet-supplied **guest** pointer `regs_vaddr`, validating only the count (`num_regs <= kMaxRegsPerPacket`) — **no `guest_readable` check**. A freed/decommitted or recycled command buffer (#312 MallocBinned3 hazard) can leave `regs_vaddr` unmapped → the apply loop reads off an unmapped page → **host SIGSEGV**, no recovery.

Every *other* guest read in this file is already `guest_readable`-guarded (rel_addr, event_addr, dd_dst/src, wd_addr, wm_addr, jump_addr, pred_cond_addr — added incrementally in #380/#448/#449/#729). `SetRegsIndirect` was the one reader that never got that hardening.

## Fix
`if (!guest_readable(regs_vaddr, num_regs * sizeof(ShaderReg))) { rate-limited warn; return; }` — identical to the file's existing guards.

## Affected / unaffected
- **Unaffected:** every exercised path. Real titles keep the register array mapped → `guest_readable` is true → all registers still apply. The existing `test_command_processor` indirect test (real mapped `cx_regs`/`sh_regs`) is green and unchanged.
- **Changed only** when `regs_vaddr` is unmapped: the packet is skipped (registers not applied) instead of crashing.

## Risks
Memory-safety change on the GPU command path → **requesting independent review**. Small and mirrors 8 existing guards in the same file; the one judgment call is the `return`-vs-skip semantics (matches the adjacent invalid-packet `return` at :1426).

## Verification (Linux)
- `cmake --build` clean; **`ctest` 132/132**.
- New `test_command_processor` case builds a `SetShRegistersIndirect` packet at an unmapped address (`0xdeadbeef0000`) and asserts apply skips it (no regs applied, no crash).
- **Confirmed it SIGSEGVs (exit 139) when the guard is reverted** — genuinely discriminating.

Not a rendered-output change; no snapshot needed.