### PR TITLE
fix(gpu): zero-fill sceAgcDcbWriteData packet tail on a null data pointer (#1201)

### DIFF
--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -599,7 +599,13 @@ HLE(agc_dcb_write_data) {  // sceAgcDcbWriteData(buf, dst, cache_policy, address
     cmd[1] = (uint32_t)a1;
     cmd[2] = (uint32_t)(a3 & 0xffffffffu); cmd[3] = (uint32_t)(a3 >> 32u);
     cmd[4] = num;
+    // The packet header declares 5+num dwords and cmd[4]=num tells the CommandProcessor how many inline
+    // data dwords follow; the CP writes all `num` of them to the destination. If a caller passes a null
+    // data pointer with num>0, the tail cmd[5..] would otherwise carry STALE ring-buffer memory that the
+    // CP then writes into guest memory (the exact stale-tail class fixed for draw_index_auto; the sibling
+    // set_sh_register_range_direct builder already zero-fills its tail). Zero-fill instead of leaking it.
     if (src) for (uint32_t i = 0; i < num; i++) cmd[5 + i] = src[i];
+    else     memset(cmd + 5, 0, (size_t)num * 4u);
     if (num <= 4) prosper_fence_journal_record((uint64_t)(uintptr_t)cmd, a3);   // #312 discriminator
     return (uint64_t)(uintptr_t)cmd;
 }

--- a/prosper/tests/test_command_processor.cpp
+++ b/prosper/tests/test_command_processor.cpp
@@ -140,6 +140,28 @@ int main() {
         CHECK(su.sh.empty(), "SetShRegsIndirect with an unmapped array is skipped (no OOB read, no regs applied)");
     }
 
+    // WriteData(null data, num>0): the packet declares 5+num dwords and cmd[4]=num tells the CP how many
+    // inline dwords to write to the destination. With a null data pointer the builder must zero-fill the
+    // tail cmd[5..], never leave STALE ring-buffer memory there (the CP would write that stale content
+    // into guest memory — the draw_index_auto stale-tail class). Build into a pre-dirtied buffer and
+    // check the emitted packet's data dwords are zero, not the sentinel.
+    {
+        auto writedata = Hle::lookup("i1jyy49AjXU");   // sceAgcDcbWriteData
+        CHECK(writedata != nullptr, "sceAgcDcbWriteData builder registered");
+        if (writedata) {
+            uint32_t cb[64];
+            for (auto& w : cb) w = 0xDEADBEEFu;        // pre-dirty: a stale tail would keep this sentinel
+            Dcb wd{}; wd.bottom = cb; wd.top = cb + 64; wd.cursor_up = cb; wd.cursor_down = cb + 64;
+            // (buf, dst, cache_policy, addr, data=null, num=4)
+            uint64_t pkt = writedata((uint64_t)(uintptr_t)&wd, 0x1000, 0, 0x2000, /*data=*/0, /*num=*/4);
+            CHECK(pkt != 0, "WriteData(null data) built a packet");
+            const uint32_t* p = (const uint32_t*)(uintptr_t)pkt;   // p[4]=num, p[5..8]=inline data dwords
+            CHECK(p && p[4] == 4, "WriteData packet declares num=4 inline dwords");
+            CHECK(p && p[5] == 0 && p[6] == 0 && p[7] == 0 && p[8] == 0,
+                  "WriteData(null data, num=4) zero-fills the packet tail (no stale ring memory)");
+        }
+    }
+
     // In-stream flip (sceAgcDcbSetFlip -> R_FLIP): the game flips via the Dcb, not the sceVideoOut
     // API, so the CommandProcessor MUST perform the videoout flip when it reaches the packet —
     // GetFlipStatus's count/flipArg/currentBuffer are what Unity's frame pacer polls before building


### PR DESCRIPTION
## Issue
Fixes #1201. Found by a bug-hunt of the AGC packet builders.

## Failure scenario
`agc_dcb_write_data` builds a `5+num`-dword WRITE_DATA packet; `cmd[4]=num` tells the CommandProcessor how many inline dwords to write to the destination. The inline copy was guarded on `src` with **no `else`**:
```c
cmd[4] = num;
if (src) for (i<num) cmd[5+i] = src[i];   // null src + num>0 -> cmd[5..] is STALE ring memory
```
A caller passing a **null data pointer with `num > 0`** leaves the packet tail as stale ring-buffer memory, which the CP (`honor_write_data`) then writes into guest memory. This is the same stale-tail class fixed for `draw_index_auto`, and the sibling builder `set_sh_register_range_direct` already zero-fills its tail.

Bounded (no OOB — `num<=0x3FFC`, decoder clamps the consumer to the packet size), so it's stale-content corruption, not a host-safety issue. **Latent**: no title passing null data + nonzero count was found.

## Fix
`else memset(cmd + 5, 0, num*4)` — mirrors the sibling builder. The one judgment call is zero-fill vs. reject-the-packet; zero-fill matches the sibling's established convention and is a strict improvement over leaking stale ring contents.

## Affected / unaffected
- **Unaffected:** the normal non-null-`src` path (every real title) — copies exactly as before.
- **Changed only** on a null (or, implicitly, absent) data pointer with `num>0`: deterministic zeros instead of stale ring memory.

## Not in this PR (filed on #1201)
The non-null `src` copy reads up to ~64 KB from an unvalidated guest pointer with no `guest_readable` guard. I deliberately did **not** add a probe here — it would put per-call page-probe syscalls on a hot GPU build path (descriptor uploads), a perf concern; tracked for a cache-aware approach.

## Verification (Linux)
- `cmake --build` clean; **`ctest` 132/132**.
- `test_command_processor` builds a `WriteData(null data, num=4)` packet into a pre-dirtied buffer and asserts the emitted tail is zeroed, not the sentinel.
- **Confirmed it FAILS without the `else`** (tail keeps the stale sentinel).

Not a rendered-output change; no snapshot needed.