### PR TITLE
fix(hle): guard savedata0_mount against a path-traversal dirName (#1203)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -391,6 +391,10 @@ if(TARGET prosper_core)
   target_link_libraries(test_file_binary PRIVATE prosper_core)
   add_test(NAME file_binary_roundtrip COMMAND test_file_binary)
 
+  add_executable(test_savedata_dirname tests/test_savedata_dirname.cpp)
+  target_link_libraries(test_savedata_dirname PRIVATE prosper_core)
+  add_test(NAME savedata_dirname_guard COMMAND test_savedata_dirname)
+
   add_executable(test_service_logging tests/test_service_logging.cpp)
   target_link_libraries(test_service_logging PRIVATE prosper_core)
   add_test(NAME service_logging_unmapped_args COMMAND test_service_logging)

--- a/prosper/src/hle/dispatch.hpp
+++ b/prosper/src/hle/dispatch.hpp
@@ -82,6 +82,10 @@ std::string resolve_guest_path(const char* guest_path);
 // (open-or-create) semantics, including whether MountResult should report CREATED or OPENED.
 enum class SaveDataMountPolicy { Open, Create, OpenOrCreate };
 enum class SaveDataMountOutcome { NotFound, Exists, Opened, Created };
+// A guest save dirName must be a SINGLE directory component under the host save root — reject empty,
+// "." / "..", and any embedded '/' or '\\' so a crafted/garbled name can't traverse out of the sandbox.
+// Shared by savedata0_mount and savedata0_dir_mtime so the guard can't exist in only one of them.
+bool savedata_dirname_ok(const std::string& dirname);
 SaveDataMountOutcome savedata0_mount(const char* dirname, SaveDataMountPolicy policy);
 bool savedata0_umount();
 std::vector<std::string> savedata0_list_dirs();   // existing save dirs under the host save root (#299)

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -582,8 +582,15 @@ std::string resolve_guest_path(const char* guest_path) {
 // (sceSaveDataMount* HLEs, hle_service.cpp). CREATE is exclusive, while OpenOrCreate (CREATE2)
 // opens an existing directory or creates a missing one. The outcome lets the HLE write an honest
 // MountResult status instead of deriving CREATED from the requested mode.
+bool savedata_dirname_ok(const std::string& dirname) {
+    return !dirname.empty() && dirname != "." && dirname != ".." &&
+           dirname.find('/') == std::string::npos && dirname.find('\\') == std::string::npos;
+}
 SaveDataMountOutcome savedata0_mount(const char* dirname, SaveDataMountPolicy policy) {
-    if (!dirname || !*dirname) return SaveDataMountOutcome::NotFound;
+    // Reject an empty / traversal dirName before composing the host path — otherwise a name like
+    // "../foo" would stat/create a directory OUTSIDE the save sandbox root (savedata0_dir_mtime already
+    // guards this; sharing savedata_dirname_ok keeps the two paths from diverging again).
+    if (!dirname || !savedata_dirname_ok(dirname)) return SaveDataMountOutcome::NotFound;
     std::string d = save0_base() + "/" + dirname;
     bool exists = false;
 #ifdef _WIN32
@@ -648,9 +655,7 @@ std::vector<std::string> savedata0_list_dirs() {
 
 bool savedata0_dir_mtime(const std::string& dirname, int64_t& modified) {
     modified = 0;
-    if (dirname.empty() || dirname == "." || dirname == ".." ||
-        dirname.find('/') != std::string::npos || dirname.find('\\') != std::string::npos)
-        return false;
+    if (!savedata_dirname_ok(dirname)) return false;
     const std::string dir = save0_base() + "/" + dirname;
     const std::string param = dir + "/sce_sys/param.sfo";
 #ifdef _WIN32

--- a/prosper/tests/test_savedata_dirname.cpp
+++ b/prosper/tests/test_savedata_dirname.cpp
@@ -1,0 +1,42 @@
+// test_savedata_dirname — a guest save dirName must be a single directory component under the host
+// save root. savedata_dirname_ok is the shared guard for savedata0_mount and savedata0_dir_mtime, so
+// a crafted/garbled name (empty, "." / "..", or one with an embedded separator) can never traverse
+// out of the sandbox to stat/create a directory elsewhere. Pure predicate — no filesystem.
+#include "../src/hle/dispatch.hpp"
+#include <cstdio>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { std::printf("  [FAIL] %s\n", m); ++fails; } \
+                         else std::printf("  [ok]   %s\n", m); } while (0)
+
+int main() {
+    std::printf("== test_savedata_dirname ==\n");
+
+    // Accepted: a normal single-component save directory name.
+    CHECK(savedata_dirname_ok("SAVEDATA00"), "a normal save dir name is accepted");
+    CHECK(savedata_dirname_ok("save_slot_1"), "underscore/digit name accepted");
+
+    // Rejected: empty, current/parent dir, and any embedded path separator (traversal).
+    CHECK(!savedata_dirname_ok(""),           "empty name rejected");
+    CHECK(!savedata_dirname_ok("."),          "'.' rejected");
+    CHECK(!savedata_dirname_ok(".."),         "'..' rejected");
+    CHECK(!savedata_dirname_ok("../foo"),     "'../foo' parent traversal rejected");
+    CHECK(!savedata_dirname_ok("a/b"),        "forward-slash component rejected");
+    CHECK(!savedata_dirname_ok("a\\b"),       "backslash component rejected");
+    CHECK(!savedata_dirname_ok("foo/../bar"), "embedded '..' via slash rejected");
+    CHECK(!savedata_dirname_ok("/etc/passwd"),"absolute path rejected");
+
+    // Call-site integration: savedata0_mount must apply the guard BEFORE composing save0_base()+name,
+    // so a traversal name is rejected without ever stat()/mkdir()ing a host directory outside the
+    // sandbox. Create policy is discriminating: without the guard, "../escape" would be mkdir'd and
+    // return Created; with it, the name is rejected up front -> NotFound and nothing is created.
+    CHECK(savedata0_mount("../escape", SaveDataMountPolicy::Create) == SaveDataMountOutcome::NotFound,
+          "savedata0_mount('../escape', Create) -> NotFound (no host dir created outside the sandbox)");
+    CHECK(savedata0_mount("a/b", SaveDataMountPolicy::OpenOrCreate) == SaveDataMountOutcome::NotFound,
+          "savedata0_mount('a/b', OpenOrCreate) -> NotFound (embedded separator rejected)");
+
+    std::printf(fails ? "FAILED (%d)\n" : "PASSED\n", fails);
+    return fails ? 1 : 0;
+}


### PR DESCRIPTION
## Issue
Fixes #1203. Found by a bug-hunt of the file-I/O path.

## Failure scenario
`savedata0_mount` (`hle_file.cpp:585`) built a host path from the guest save `dirName` with **no traversal guard**, while its twin `savedata0_dir_mtime` (line 649) already rejected `.`/`..`/embedded `/`|`\`. A `dirName` like `../../foo` would `stat`/`mkdir` a directory **outside** the savedata sandbox root (exclusive CREATE would create it and report Created). `dirName` comes from the guest `sceSaveDataMount*` struct and is passed straight through. **Latent** (non-adversarial guest) but a real divergence bug — the guard lived in one of two twin functions.

## Fix
Extract a shared `savedata_dirname_ok()` predicate (declared in dispatch.hpp), used by **both** functions — single source of truth so the guard can't diverge again. `savedata0_mount` now returns `NotFound` for a bad name **before** touching the filesystem.

## Affected / unaffected
- **`savedata0_dir_mtime`**: behavior unchanged (identical rejection set, now via the shared predicate).
- **`savedata0_mount`**: only changed for empty/traversal names (now `NotFound` up front); valid single-component names behave exactly as before.

## Risks
Persistent-data / path-handling change → **requesting review**. Small; the one judgment is the rejection set, which mirrors the existing sibling.

## Verification (Linux)
- `cmake --build` clean; **`ctest` 133/133** (adds `savedata_dirname_guard`).
- `test_savedata_dirname` unit-tests the predicate (accepts a normal component; rejects empty/`.`/`..`/`../foo`/`a/b`/`a\b`/absolute) **and** asserts `savedata0_mount("../escape", Create) == NotFound` at the call site.
- **Confirmed it fails without the fix**: reverting the mount guard makes the call-site check fail (it returns `Created`, having mkdir'd the escape dir).

Not a rendered-output change; no snapshot needed.