### PR TITLE
fix(hle): normalize guest paths so translate() can't escape the sandbox (#1205)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -395,6 +395,10 @@ if(TARGET prosper_core)
   target_link_libraries(test_savedata_dirname PRIVATE prosper_core)
   add_test(NAME savedata_dirname_guard COMMAND test_savedata_dirname)
 
+  add_executable(test_translate_sandbox tests/test_translate_sandbox.cpp)
+  target_link_libraries(test_translate_sandbox PRIVATE prosper_core)
+  add_test(NAME translate_sandbox_guard COMMAND test_translate_sandbox)
+
   add_executable(test_service_logging tests/test_service_logging.cpp)
   target_link_libraries(test_service_logging PRIVATE prosper_core)
   add_test(NAME service_logging_unmapped_args COMMAND test_service_logging)

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -14,6 +14,7 @@
 #include <cerrno>
 #include <climits>
 #include <string>
+#include <optional>      // #1205: sandbox_normalize_subpath escape check
 #include <mutex>
 #include <atomic>        // sceKernelAio* submit-id/state table
 #include <map>
@@ -466,6 +467,29 @@ namespace {
             if (guest.find(sub) != std::string::npos) return true;
         return false;
     }
+    // Lexically normalize a virtual sub-path (the part AFTER a /app0|/temp0|/savedata0 root),
+    // treating both '/' and '\\' as separators. Collapses "." and applies ".." within the sub-path.
+    // Returns the normalized sub-path (leading '/', e.g. "/a/../b" -> "/b", "" for the root itself) if
+    // it stays AT OR BELOW the root, or std::nullopt if a ".." climbs above it (a sandbox escape).
+    // Purely lexical — no filesystem access. Only invoked when the sub-path contains "..", so a normal
+    // path never reaches it and is composed byte-for-byte as before. CONFIDENCE: HIGH (pure string op).
+    std::optional<std::string> sandbox_normalize_subpath(const std::string& sub) {
+        std::vector<std::string> stack;
+        size_t i = 0;
+        auto is_sep = [](char c) { return c == '/' || c == '\\'; };
+        while (i < sub.size()) {
+            while (i < sub.size() && is_sep(sub[i])) i++;
+            size_t j = i; while (j < sub.size() && !is_sep(sub[j])) j++;
+            std::string comp = sub.substr(i, j - i);
+            i = j;
+            if (comp.empty() || comp == ".") continue;
+            if (comp == "..") { if (stack.empty()) return std::nullopt; stack.pop_back(); continue; }
+            stack.push_back(comp);
+        }
+        std::string out;
+        for (const auto& c : stack) { out += '/'; out += c; }
+        return out;
+    }
     std::string translate(const char* guest) {
         if (!guest) return {};
         std::string p = guest;
@@ -474,14 +498,32 @@ namespace {
             if (filelog()) fprintf(stderr, "[file] DENIED (PROSPER_DENY_SUBSTR) '%s'\n", guest);
             return "/prosper-denied" + p;
         }
-        // Map /app0[/...] -> <root>[/...], /temp0[/...] -> scratch dir,
-        // /savedata0[/...] -> the currently mounted save dir; other paths as-is.
+        // Map /app0[/...] -> <root>[/...], /temp0[/...] -> scratch dir, /savedata0[/...] -> the mounted
+        // save dir; other paths as-is. Guest paths are the game's own and normally contain no ".." —
+        // but a path that climbs above its virtual root (e.g. "/savedata0/../x") would otherwise compose
+        // a host path OUTSIDE the sandbox. Only when a ".." is present do we lexically normalize the
+        // sub-path and reject an escape (#1205); normal paths are byte-identical to before, and a benign
+        // in-sandbox ".." resolves to the same host file it would have anyway.
         std::string save0;
         if (p.rfind("/savedata0", 0) == 0) { std::lock_guard<std::mutex> lk(g_save0_mx); save0 = g_save0; }
-        std::string h = (p.rfind("/app0", 0) == 0)       ? g_app0 + p.substr(5)
-                      : (p.rfind("/temp0", 0) == 0)      ? temp0_root() + p.substr(6)
-                      : !save0.empty()                   ? save0 + p.substr(10)
-                      : p;
+        std::string root; size_t vlen = 0;
+        if      (p.rfind("/app0", 0) == 0)  { root = g_app0;       vlen = 5;  }
+        else if (p.rfind("/temp0", 0) == 0) { root = temp0_root(); vlen = 6;  }
+        else if (!save0.empty())            { root = save0;        vlen = 10; }
+        else {
+            if (filelog()) fprintf(stderr, "[file] open '%s' -> '%s'\n", guest, p.c_str());
+            return p;
+        }
+        std::string sub = p.substr(vlen);
+        if (sub.find("..") != std::string::npos) {
+            std::optional<std::string> norm = sandbox_normalize_subpath(sub);
+            if (!norm) {
+                if (filelog()) fprintf(stderr, "[file] DENIED (sandbox traversal) '%s'\n", guest);
+                return "/prosper-denied" + p;
+            }
+            sub = *norm;
+        }
+        std::string h = root + sub;
         if (filelog()) fprintf(stderr, "[file] open '%s' -> '%s'\n", guest, h.c_str());
         return h;
     }

--- a/prosper/tests/test_translate_sandbox.cpp
+++ b/prosper/tests/test_translate_sandbox.cpp
@@ -1,0 +1,48 @@
+// test_translate_sandbox — #1205: the guest-path -> host-path mapping (translate(), exercised via the
+// public resolve_guest_path) must not let a guest path climb OUT of its virtual root (/app0, /temp0,
+// /savedata0). A sub-path containing ".." is lexically normalized; one that escapes above the root is
+// denied. Normal paths and benign in-sandbox ".." are byte-for-byte unaffected (a benign ".." resolves
+// to the same host file it always would). No real filesystem access is needed — translate() is pure.
+#include "../src/hle/dispatch.hpp"
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { std::printf("  [FAIL] %s\n", m); ++fails; } \
+                         else std::printf("  [ok]   %s\n", m); } while (0)
+
+static bool denied(const std::string& r) { return r.rfind("/prosper-denied", 0) == 0; }
+
+int main() {
+    // g_app0 is cached on first use, so set the root before any translate() call.
+    setenv("PROSPER_APP0", "/hostroot/app0", 1);
+    std::printf("== test_translate_sandbox ==\n");
+
+    // Normal path: composed directly under the host root (identical to pre-#1205 behavior).
+    CHECK(resolve_guest_path("/app0/foo/bar") == "/hostroot/app0/foo/bar",
+          "normal /app0 path maps directly under the root");
+
+    // Benign in-sandbox '..': normalizes to the same host file the OS would have resolved anyway.
+    CHECK(resolve_guest_path("/app0/data/../config") == "/hostroot/app0/config",
+          "in-sandbox '..' normalizes to <root>/config");
+
+    // A filename that merely CONTAINS '..' as a substring is a normal component, not traversal.
+    CHECK(resolve_guest_path("/app0/foo..bar") == "/hostroot/app0/foo..bar",
+          "'foo..bar' is a normal filename, not a traversal");
+
+    // Escaping traversal: denied, and never composes the escaping host path.
+    {
+        std::string r = resolve_guest_path("/app0/../escape");
+        CHECK(denied(r), "'/app0/../escape' escaping the root is denied");
+        CHECK(r.find("/hostroot/app0/../") == std::string::npos,
+              "denied result does not compose the escaping host path");
+    }
+    CHECK(denied(resolve_guest_path("/app0/../../etc/passwd")), "double-'..' escape denied");
+    CHECK(denied(resolve_guest_path("/app0/a/../../b")),        "'..' popping past the root denied");
+
+    std::printf(fails ? "FAILED (%d)\n" : "PASSED\n", fails);
+    return fails ? 1 : 0;
+}

--- a/prosper/tests/test_translate_sandbox.cpp
+++ b/prosper/tests/test_translate_sandbox.cpp
@@ -18,7 +18,12 @@ static bool denied(const std::string& r) { return r.rfind("/prosper-denied", 0) 
 
 int main() {
     // g_app0 is cached on first use, so set the root before any translate() call.
+    // setenv is POSIX-only (MinGW-w64 lacks it); use _putenv_s on Windows.
+#ifdef _WIN32
+    _putenv_s("PROSPER_APP0", "/hostroot/app0");
+#else
     setenv("PROSPER_APP0", "/hostroot/app0", 1);
+#endif
     std::printf("== test_translate_sandbox ==\n");
 
     // Normal path: composed directly under the host root (identical to pre-#1205 behavior).


### PR DESCRIPTION
## Issue
Fixes #1205 (found during review of #1204).

## Failure scenario
`translate()` (hle_file.cpp) mapped every guest file path to a host path by prefix substitution with **no `..` normalization**: `/savedata0/../x` → `<save0>/../x`, `/app0/../../x` → escapes the read-only game-dump root. Every guest `fd`/`stat`/`open` flows through `translate()`, so this is broader than the #1204 mount-dirName sink.

## Fix
A purely-lexical `sandbox_normalize_subpath()` resolves `.`/`..` within the sub-path (after the virtual root), treats `/` and `\` as separators, and returns `nullopt` if a `..` climbs above the root. `translate()` invokes it **only when the sub-path contains `..`** and denies an escape (`/prosper-denied<path>`, the shape `deny_path` already uses).

## Affected / unaffected (deliberately zero-impact for titles)
- **No `..` in the path** → composed byte-for-byte as before (the common case, all real game paths).
- **Benign in-sandbox `..`** (e.g. `/app0/data/../config`) → normalizes to `<root>/config`, the exact host file the OS would have resolved anyway.
- **Escaping `..`** → denied. Latent / defense-in-depth (non-adversarial guest; no shipping title emits traversal).

## Risks
Touches the hot file-I/O `translate()` path → **requesting review**. Mitigated by the `..`-only guard (real paths never reach the new code) and the boot/file ctests exercising real file I/O.

## Verification (Linux)
- `cmake --build` clean; **`ctest` 134/134** (adds `translate_sandbox_guard`; boot/file tests that route real I/O through `translate()` unchanged).
- `test_translate_sandbox` drives `resolve_guest_path` (→ `translate`) with `PROSPER_APP0` set: normal path maps directly, in-sandbox `..` normalizes, `foo..bar` stays a filename, `/app0/../escape` + `../../etc` + `a/../../b` are denied.
- **Confirmed the escape checks FAIL without the fix.**

Not a rendered-output change; no snapshot needed.