### PR TITLE
ci: add --timeout 600 to ctest so a hung test fails fast (#1087)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         run: cmake --build prosper/build-ci
 
       - name: Test
-        run: ctest --test-dir prosper/build-ci --output-on-failure
+        run: ctest --test-dir prosper/build-ci --output-on-failure --timeout 600
 
   linux-app:
     name: Linux App
@@ -90,7 +90,7 @@ jobs:
 
       - name: Test
         shell: msys2 {0}
-        run: ctest --test-dir prosper/build-ci --output-on-failure
+        run: ctest --test-dir prosper/build-ci --output-on-failure --timeout 600
 
   windows-app:
     name: Windows App
@@ -133,7 +133,7 @@ jobs:
       - name: Test SDL audio and input seams
         shell: msys2 {0}
         run: >-
-          ctest --test-dir prosper/build-windows-app --output-on-failure
+          ctest --test-dir prosper/build-windows-app --output-on-failure --timeout 600
           -R '^(prosper_app_pad_overlay|audio_sdl3|pad_sdl3)$'
 
       - name: Verify portable runtime imports
@@ -202,7 +202,7 @@ jobs:
         run: cmake --build prosper/build-ci
 
       - name: Test
-        run: ctest --test-dir prosper/build-ci --output-on-failure
+        run: ctest --test-dir prosper/build-ci --output-on-failure --timeout 600
 
   macos-app:
     name: macOS App (SDL3 + MoltenVK)


### PR DESCRIPTION
## Issue
Fixes #1087.

## Problem
CI `ctest` passed no `--timeout`, so a hung test (the Rosetta VM-tracking pathology on #1084) produced no failure, no log, and no attribution — the job just ran until GitHub's **6 h** limit.

## Fix
Add `--timeout 600` to all four `ctest` invocations in `.github/workflows/ci.yml` (build-ci ×3 + build-windows-app). A hang now becomes a visible named-test **Timeout** failure within ~10 min.

## Why 600 s is safe (no spurious failures)
The whole current suite runs ~7 s locally; 600 s is ~200× that and far above any single legitimate test. **This PR's own CI run is the validation** — if 600 s were below any real test, this PR would fail here.

## Scope
CI-only. No product code, tests, or runtime behavior changed; `set_tests_properties(TIMEOUT ...)` per-test overrides (e.g. the 30 s I already set on `guard_recursion`) still take precedence over the ctest default.

Mechanical, self-validating config change.