### PR TITLE
fix(gpu): bound failed-compute-shader dump to the proven-readable window (#1209)

### DIFF
--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -3069,9 +3069,12 @@ std::vector<ComputeItem> realize_compute_dispatches(
                 // path was the only dumper, so a failing dispatch's CFG could not be mapped offline.
                 // Keep the established 64 KiB diagnostic window: some compiler-generated branches
                 // jump thousands of dwords forward even when the first rejection is near the entry.
-                // The registered shader mapping is already proven readable by the decoder.
+                // Bound the raw fwrite to the bytes the decoder actually PROVED readable
+                // (registered_shader_dwords is guest_readable-checked and capped at 0x4000 dwords ==
+                // 64 KiB), not a fixed 0x10000 — a short shader at the tail of its mapping would
+                // otherwise over-read past the mapped page into a SIGSEGV inside the dump (#1209).
                 if (const char* dd = getenv("PROSPER_SHADER_DUMP")) {
-                    constexpr size_t dump_bytes = 0x10000;
+                    const size_t dump_bytes = std::min(shader_dwords * sizeof(uint32_t), size_t(0x10000));
                     char fn[512];
                     snprintf(fn, sizeof fn, "%s/exec_cs_%llx.bin", dd,
                              (unsigned long long)code_addr);


### PR DESCRIPTION
## Issue
Fixes #1209 — latent OOB read in the `PROSPER_SHADER_DUMP` diagnostic path.

## Failure scenario
`gpu_executor.cpp` `realize_compute_dispatches`, "skip unsupported program" branch, `fwrite`d a **fixed `0x10000` (64 KiB)** from `code_addr`. Only `registered_shader_dwords()` bytes are proven readable — that helper is `guest_readable`-checked and capped at `0x4000` dwords. A short compute shader mapped at the tail of its segment → the fixed 64 KiB read runs past the mapped page → **SIGSEGV inside the dump**.

`recompile_compute` on the line above also passes `0x10000` but self-terminates at `s_endpgm`, so it is safe; only the raw `fwrite` was unbounded.

## Fix
```cpp
const size_t dump_bytes = std::min(shader_dwords * sizeof(uint32_t), size_t(0x10000));
```
`shader_dwords` is already in scope (declared at the loop-body top, used by `resolve_dynamic_fetch`) and is `<= 0x4000` dwords `== 64 KiB` and `guest_readable`-proven. Preserves the full diagnostic window for a large shader; never reads past what the decoder proved mapped.

## Scope / risk
- **Diagnostic-path-only**: inside `if (getenv("PROSPER_SHADER_DUMP"))` + only on a failing compute recompile. **Not reachable from a guest command stream.** No behavior change on any rendered/recompile path (so no snapshot needed).
- Mechanical, in-scope clamp; verification risk is nil (dev-env dump only). Provenance: a systematic adversarial memory-safety hunt of `gpu_executor.cpp` (otherwise fully CLEAN — the file uses the canonical wrap-safe bounds form throughout).

## Verification
- `cmake --build` clean; `ctest` **135/135** on Linux.