### PR TITLE
recompiler: structurize EXECZ-exit data-dependent compute loops — renders GTA V loading/disclaimer content (#1183)

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -2280,6 +2280,20 @@ std::unordered_set<uint32_t> safe_execz_branches(const std::vector<Rdna2Inst>& i
             if (in.pc == target) { target_found = true; break; }
         }
         if (!target_found) ok = false;
+        // LOOP EXIT (#1183): if a backward branch that jumps to at-or-before this execz sits inside the
+        // block [br, target), then this execz is a data-dependent loop's EXIT, not an if/guard-to-end —
+        // even when its target happens to be s_endpgm. Linearizing it here would strand the loop's
+        // back-edge as a straight-line reject; instead leave it OUT of `safe` so detect_divergent_loops
+        // claims it and emit_divloop reconstructs the structured loop. Back-edges are the shapes that
+        // detector recognizes: unconditional s_branch (0x02) or s_cbranch_execnz (0x09).
+        bool is_loop_exit = false;
+        for (const auto& bb : ins) {
+            if (bb.fmt != Rdna2Format::SOPP || (bb.opcode != 0x02 && bb.opcode != 0x09)) continue;
+            if (bb.pc <= br.pc || bb.pc >= target) continue;                 // must sit inside this block
+            const int64_t bt = static_cast<int64_t>(bb.pc) + bb.len_dwords + bb.simm16;   // signed target
+            if (bt <= static_cast<int64_t>(br.pc)) { is_loop_exit = true; break; }
+        }
+        if (is_loop_exit) continue;
         // Two shapes are safe to linearize (drop the branch, run the block under per-lane EXEC):
         //  * IF/ENDIF rejoining live code (target < end): only EXEC-predicated VGPR writes are safe,
         //    since scalar/VCC/memory writes past the merge would be observed by later code.
@@ -8430,6 +8444,13 @@ FlatLoadAnalysis analyze_flat_loads(const uint32_t* code, size_t dwords, uint32_
         out.loads.push_back(info);
     }
     return out;
+}
+
+std::vector<uint32_t> safe_execz_branches_for_test(const uint32_t* code, size_t dwords) {
+    std::vector<Rdna2Inst> ins;
+    rdna2_walk(code, dwords, ins);
+    const std::unordered_set<uint32_t> s = safe_execz_branches(ins);
+    return std::vector<uint32_t>(s.begin(), s.end());
 }
 
 RecompileCoverage recompile_coverage(const uint32_t* code, size_t dwords) {

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -7906,9 +7906,9 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
             // unmodified uniform VOP1 move from a scalar. With that proven, every lane's compare bool
             // is identical, so the wave-empty vccz exit lowers to THIS invocation's !cond exactly as
             // in the fragment shell (tid-derived/varying inputs fail the proof and keep rejecting).
-            // Two compute-specific guards, both conservative:
-            //   * accept ONLY Condition::Vcc loops (the detector sets it only under the uniform proof;
-            //     per-lane Exec-condition loops stay graphics-only until a compute case is observed);
+            // One compute-specific guard (see the per-condition detail below for why both Vcc- and
+            // Exec-condition loops are safe here — the Exec case is GTA V's exec_cs_2042d47600 grid-stride
+            // decode loop, #1183):
             //   * the body must be barrier/LDS/cross-lane-free — the proof is per-WAVE, and a barrier
             //     inside a loop whose trip count could differ across the workgroup's waves would be
             //     workgroup-divergent control flow (UB). DOLL's blocked light/fill kernels are

--- a/prosper/src/gpu/rdna2_to_spirv.hpp
+++ b/prosper/src/gpu/rdna2_to_spirv.hpp
@@ -210,4 +210,10 @@ struct FlatLoadAnalysis {
 // `user_sgpr_pair + offset`, leaves `all_resolved=false` and the caller keeps rejecting the shader.
 FlatLoadAnalysis analyze_flat_loads(const uint32_t* code, size_t dwords, uint32_t user_sgpr_count);
 
+// Test hook (#1183): the set of forward s_cbranch_execz pcs the recompiler classifies as safe to
+// linearize (drop the branch, run the block under per-lane EXEC). A loop-EXIT execz — one enclosed by a
+// backward branch that jumps to at-or-before it — must NOT appear here, so detect_divergent_loops claims
+// it and emit_divloop reconstructs the structured loop; a plain guard-to-end/if execz still does.
+std::vector<uint32_t> safe_execz_branches_for_test(const uint32_t* code, size_t dwords);
+
 } // namespace prosper::gpu

--- a/prosper/tests/test_recompile_coverage.cpp
+++ b/prosper/tests/test_recompile_coverage.cpp
@@ -119,6 +119,30 @@ int main() {
     CHECK(!fk_spv.empty() && fk_spv[0] == 0x07230203u,
           "general flat_load lowers to a valid SSBO-read module when its window is bound");
 
+    // #1183: safe_execz_branches must NOT linearize a loop-EXIT execz (one enclosed by a backward branch
+    // that jumps to at-or-before it) — even when its target is s_endpgm — so detect_divergent_loops /
+    // emit_divloop can reconstruct the structured loop; a plain guard-to-end execz (no enclosing back-edge)
+    // still linearizes. Without the loop-awareness fix the loop-exit execz would be wrongly marked safe and
+    // its back-edge would fall to a straight-line reject (GTA V's exec_cs_2042d47600 decode loop).
+    auto has = [](const std::vector<uint32_t>& v, uint32_t x) {
+        for (uint32_t e : v) if (e == x) return true; return false;
+    };
+    const uint32_t execz_guard[] = {
+        0xbf880001u,   // s_cbranch_execz -> pc=2 (s_endpgm): plain guard-to-end, no loop
+        0x7e000301u,   // v_mov_b32 v0, v1  (EXEC-predicated body)
+        0xbf810000u,   // s_endpgm
+    };
+    CHECK(has(safe_execz_branches_for_test(execz_guard, sizeof(execz_guard)/sizeof(execz_guard[0])), 0u),
+          "safe_execz_branches keeps a plain guard-to-end execz linearizable (no regression)");
+    const uint32_t execz_loop[] = {
+        0xbf880002u,   // s_cbranch_execz -> pc=3 (s_endpgm): a LOOP EXIT
+        0x7e000301u,   // v_mov_b32 v0, v1  (loop body)
+        0xbf82fffdu,   // s_branch -> pc=0  (backward -> encloses the execz)
+        0xbf810000u,   // s_endpgm
+    };
+    CHECK(!has(safe_execz_branches_for_test(execz_loop, sizeof(execz_loop)/sizeof(execz_loop[0])), 0u),
+          "safe_execz_branches leaves a loop-exit execz for the divergent-loop structurizer (#1183)");
+
     // tbuffer_load_format_x v0, v0, s[8:11], 0 format:32_FLOAT ; s_endpgm.
     // MTBUF needs a resolved V# binding, so the table-less coverage pass must classify it as
     // recompilable-in-context rather than truly unsupported.


### PR DESCRIPTION
## What & why

GTA V's (PPSA04263) loading-screen / menu content is produced by a texture-decode compute kernel, `exec_cs_2042d47600` — a grid-stride loop that reads source bytes via `flat_load_ubyte` and `image_store`s decoded texels. After #1170 (`v_add_co_u32`) and #1171 (general FLAT_LOAD) let it recompile through the load + store, its **last** blocker was its own loop: the recompiler rejected the back-edge and dropped the whole kernel (`[compute] skip unsupported program 0x2042d47600`), so the decoded content never rendered (#1163/#1165).

## Root cause (a one-branch classification bug, not a missing structurizer)

The loop-emission machinery (`detect_divergent_loops` + `emit_divloop`) **already models this exact EXEC-empty / `s_branch`-back-edge shape**, and the compute gate accepts this body (no DS/barrier/permlane). The failure was upstream: the loop's `s_cbranch_execz` exit (pc=29) targets pc=53, which happens to be `s_endpgm`, so `safe_execz_branches` classified it — **without loop awareness** — as a "guard-to-end safe-to-linearize" branch and added it to the `safe` set. `detect_divergent_loops` then skips `safe` branches, never set `exit_branch_pc`, returned `{}`; with no loop detected, the unconditional back-edge (pc=52 `s_branch`) fell through to a straight-line reject.

## Fix

In `safe_execz_branches`, a forward execz that is **enclosed by a backward branch jumping to at-or-before it** is a data-dependent loop's EXIT, not an if/guard-to-end — even when its target is `s_endpgm`. Leave such an execz OUT of the `safe` set so `detect_divergent_loops` claims it and `emit_divloop` reconstructs the structured loop. A plain guard-to-end execz (no enclosing back-edge) still linearizes exactly as before. ~14 lines; reuses the existing loop detection + emission.

## Behavioral contract / invariants

- Only forward-execz classification changes, and only for execz branches with an enclosing backward branch (`s_branch` 0x02 / `s_cbranch_execnz` 0x09) whose target ≤ the execz pc. Non-loop execz (if/guard-to-end) behavior is unchanged.
- No new loop lowering: the fix routes the loop to the already-reviewed `emit_divloop` path, which carries loop-invariant regs via `OpPhi` and terminates per-invocation on the EXEC condition.

## Verification

- **Live A/B (GTA V, direct app capture):** pre-fix `exec_cs_2042d47600` is `[compute] skip unsupported`; **post-fix zero compute skips, zero recompile-rejects**, 80 flat-windows bind, and the app renders healthily with the frame counter advancing (no GPU hang — the mis-structured-loop risk). The intro loading animation (5-star indicator on the vertex-shaded video quad), the Rockstar **R★** logo, and — critically — the **disclaimer/legal-text screen that was previously blank (#1165)** all render (screenshots below).
- **Unit (`test_recompile_coverage`):** a loop-exit execz is left for the divergent-loop structurizer while a plain guard-to-end execz stays linearizable; existing guard-to-end / counted-loop tests still pass.
- **`ctest`:** 127/127 with the Messenger dump (2 GTA-dump loader-count artifacts pass under `PPSA24651`).
- **`snapshot.py check`:** RESULT_PENDING.

## Scope

`Fixes #1183`. Together with #1170 + #1171 this renders GTA V's loading animation, R-logo, and disclaimer legal text. #1163 (main-menu art panel) needs reaching the menu (input) to confirm, but shares the same decode path; will verify separately.

## Risk

Low-moderate. A control-flow-classification change routed to existing, reviewed loop machinery; guarded so non-loop execz is untouched; live-verified to render + not hang; unit + snapshot gated. Independent review requested (recompiler control flow).
