### PR TITLE
fix(loader): bound guest-declared reloc/symbol table sizes to the file (#1219)

### DIFF
--- a/prosper/src/self/module.cpp
+++ b/prosper/src/self/module.cpp
@@ -194,6 +194,13 @@ std::optional<Module> Module::load(const std::string& path, std::string* err) {
     size_t nsym = m.syment ? (m.symtabsz / m.syment) : 0;
     if (nsym == 0 && sym_foff >= 0 && m.strtab_va > m.symtab_va) // fallback: symtab..strtab
         nsym = (m.strtab_va - m.symtab_va) / m.syment;
+    // Bound the symbol count to what the file can hold from sym_foff, so a malformed symtab size (or a
+    // strtab_va far past symtab_va) can't push billions of zero-filled symbols into m.symbols (OOM). #1219.
+    if (sym_foff >= 0 && m.syment) {
+        uint64_t sym_bytes = clamp_table_bytes((uint64_t)sym_foff, (uint64_t)nsym * m.syment,
+                                               (uint64_t)m.file.size());
+        nsym = (size_t)(sym_bytes / m.syment);
+    }
     for (size_t i = 0; i < nsym && sym_foff >= 0; i++) {
         auto s = rd<Sym>(m.file, (size_t)sym_foff + i * m.syment);
         Symbol sym; sym.raw = m.str_at(s.st_name); sym.shndx = s.st_shndx; sym.value = s.st_value;
@@ -216,6 +223,9 @@ std::optional<Module> Module::load(const std::string& path, std::string* err) {
     auto read_relocs = [&](uint64_t va, uint64_t sz, bool plt) {
         int64_t fo = m.va2foff(va);
         if (fo < 0) return;
+        // Bound the guest-declared DT_RELASZ/DT_PLTRELSZ to the file: a table can't run past EOF, and
+        // without this a malformed size pushes sz/24 zero-filled relocs into m.relocs (OOM). #1219.
+        sz = clamp_table_bytes((uint64_t)fo, sz, (uint64_t)m.file.size());
         for (uint64_t o = 0; o + sizeof(Rela) <= sz; o += sizeof(Rela)) {
             auto r = rd<Rela>(m.file, (size_t)fo + o);
             m.relocs.push_back({ r.r_offset, (uint32_t)(r.r_info & 0xffffffff),

--- a/prosper/src/self/module.hpp
+++ b/prosper/src/self/module.hpp
@@ -22,6 +22,17 @@ inline bool self_read_ok(uint64_t off, uint64_t need, uint64_t total) {
     return need <= total && off <= total - need;
 }
 
+// Clamp a guest-declared table size (DT_RELASZ / DT_PLTRELSZ, or a symtab span) to the bytes that
+// actually exist in the file from the table's file offset. A relocation/symbol table cannot legitimately
+// extend past the file, so a malformed dump declaring a huge size must not drive an enormous
+// relocs/symbols vector (OOM). Returns 0 when the table's file offset is already at/after EOF; never
+// underflows (the offset<size branch guarantees a positive remainder).
+inline uint64_t clamp_table_bytes(uint64_t table_file_off, uint64_t declared_bytes, uint64_t file_size) {
+    if (table_file_off >= file_size) return 0;
+    uint64_t avail = file_size - table_file_off;
+    return declared_bytes < avail ? declared_bytes : avail;
+}
+
 // ---- raw ELF/Sony structures we care about --------------------------------
 enum : uint32_t {
     PT_LOAD = 1, PT_DYNAMIC = 2, PT_TLS = 7,

--- a/prosper/tests/test_self_bounds.cpp
+++ b/prosper/tests/test_self_bounds.cpp
@@ -126,9 +126,26 @@ static void test_build_image_bounds() {
     }
 }
 
+// clamp_table_bytes bounds a guest-declared reloc/symbol table size to the file (#1219). Without it a
+// malformed DT_RELASZ/DT_PLTRELSZ/symtab size drives an enormous relocs/symbols vector -> OOM.
+static void test_clamp_table_bytes() {
+    CHECK(clamp_table_bytes(0, 240, 1000) == 240,          "table fully inside file: unchanged");
+    CHECK(clamp_table_bytes(100, 900, 1000) == 900,        "table exactly reaching EOF: unchanged");
+    CHECK(clamp_table_bytes(100, UINT64_MAX, 1000) == 900, "huge declared size clamped to file remainder");
+    CHECK(clamp_table_bytes(1000, 240, 1000) == 0,         "table offset == EOF -> 0 bytes");
+    CHECK(clamp_table_bytes(2000, 240, 1000) == 0,         "table offset past EOF -> 0 bytes (no underflow)");
+    CHECK(clamp_table_bytes(999, 240, 1000) == 1,          "offset one byte before EOF -> 1 byte");
+    CHECK(clamp_table_bytes(500, 100, 1000) == 100,        "small table well inside file: unchanged");
+    // The concrete OOM guard: a UINT64_MAX DT_RELASZ over a 240-byte file yields at most 240/24 = 10
+    // relocs, not ~7.7e17 — the value the RELA loop actually iterates.
+    CHECK(clamp_table_bytes(0, UINT64_MAX, 240) / 24 == 10, "huge DT_RELASZ -> bounded reloc count");
+    CHECK(clamp_table_bytes(0, 0, 1000) == 0,              "zero declared size stays zero");
+}
+
 int main() {
     printf("== test_self_bounds (SELF/ELF/loader malformed-input hardening) ==\n");
     test_self_read_ok();
+    test_clamp_table_bytes();
     test_str_at();
     test_at_last_byte_needs_guard();
     test_build_image_bounds();


### PR DESCRIPTION
## Issue
Fixes #1219 — a malformed/truncated dump declaring a huge `DT_RELASZ`/`DT_PLTRELSZ`/symtab size drives an enormous `m.relocs`/`m.symbols` allocation → OOM. (DoS, not OOB — `rd<T>` zero-fills out-of-file reads; a full memory-safety hunt of the reloc-apply path was otherwise CLEAN. This is the one robustness gap it surfaced.)

## Failure scenario
`read_relocs` (module.cpp) loops `for (o=0; o + sizeof(Rela) <= sz; ...)` with `sz` = guest `DT_RELASZ`/`DT_PLTRELSZ`; `nsym = symtabsz / syment`. The reads are bounded but the **counts** aren't — `sz/24` relocs / `nsym` symbols get pushed into a vector regardless of file size.

## Fix
New `clamp_table_bytes(table_file_off, declared_bytes, file_size)` in module.hpp (same overflow-safe spirit as `self_read_ok` from #1198): `min(declared, file_size - off)`, 0 past EOF, no underflow. Applied to `DT_RELASZ`/`DT_PLTRELSZ` in `read_relocs` and to cap `nsym` to `(file_size - sym_foff)/syment`.

**A table can't legitimately extend past the file, so real dumps are byte-for-byte unchanged** (declared ≤ file remainder → returned verbatim); only a malformed size is bounded. `nsym * syment` can't overflow (it reconstructs ≤ the original span ≤ `UINT64_MAX`).

## Verification
- `ctest` **138/138** — `test_self_bounds` gains `test_clamp_table_bytes` (unchanged-when-inside; huge→clamped; at/past EOF→0; and the concrete `UINT64_MAX DT_RELASZ over a 240-byte file → 10 relocs, not 7.7e17` guard).

Requesting an independent review per the untrusted-bounds/loader guidance.