### PR TITLE
fix(gpu): bound the #1122 seed-skip trust window by periodically re-proving (#1127)

### DIFF
--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -1,4 +1,5 @@
 #include "live_compute.hpp"
+#include "seed_reprove.hpp"
 #include "vulkan_device_select.hpp"
 
 #include "gpu/bc_decode.hpp"
@@ -697,10 +698,22 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
     // tracked in #1127 -- no exercised title shader triggers it, and a shader first seen partial is
     // cached Partial and always seeds (safe).
     enum class SeedCoverage : uint8_t { Full, Partial };
+    // #1127: 'prove once, trust forever' is unsound for a DATA-DEPENDENT store (full on the proving
+    // frame, partial later). Re-prove a Full verdict every kSeedReproveInterval fast-skips: a shader
+    // that ever covers partially is then re-cached Partial and always seeds, bounding the corruption
+    // window from unbounded to <= interval fast-skips. A genuinely data-independent full-writer (the
+    // exercised full-screen composites) re-proves to Full each time -- no rendered-output change, ~1
+    // extra poison frame per interval. skips counts fast-skips taken since the last (re-)proof.
+    struct SeedVerdict { SeedCoverage cov = SeedCoverage::Partial; uint32_t skips = 0; };
     // key = (shader code_addr, output binding, width, height, depth) -- collision-free by construction.
     using SeedCoverageKey = std::tuple<uint64_t, uint32_t, uint32_t, uint32_t, uint32_t>;
     static std::mutex seed_coverage_mu;
-    static std::map<SeedCoverageKey, SeedCoverage> seed_coverage_proof;
+    static std::map<SeedCoverageKey, SeedVerdict> seed_coverage_proof;
+    // PROSPER_SEED_REPROVE=N: re-prove every N fast-skips (default 256; explicit 0 disables = old
+    // prove-once). Parsed fail-safe -- garbage/overflow keeps the 256 default rather than silently
+    // disabling the safety (see seed_reprove_interval_from_env).
+    static const uint32_t kSeedReproveInterval =
+        seed_reprove_interval_from_env(std::getenv("PROSPER_SEED_REPROVE"), 256u);
     // #1122: a compute post-process that only image_stores its output (no image_load) never reads the
     // seed, so materializing the renderer RTT's prior pixels into it is wasted. Detect it cheaply: an
     // OpImageRead-free SPIR-V reads no storage image at all. Combined with full dispatch coverage of
@@ -1023,17 +1036,23 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             if (bi.storage && shader_reads_no_image && covers_extent) {
                 const SeedCoverageKey proof_key{item.code_addr, bi.binding,
                                                 r->width, r->height, r->depth};
-                bool proven_full = false, known = false;
+                bool proven_full = false, known = false, reprove_due = false;
                 {
                     std::lock_guard<std::mutex> lk(seed_coverage_mu);
                     auto it = seed_coverage_proof.find(proof_key);
                     if (it != seed_coverage_proof.end()) {
                         known = true;
-                        proven_full = it->second == SeedCoverage::Full;
+                        proven_full = it->second.cov == SeedCoverage::Full;
+                        // #1127: periodically re-prove a Full verdict so a data-dependent store that
+                        // later under-covers is caught (re-cached Partial, then always seeds). The
+                        // helper resets the counter, so concurrent dispatches on this key don't all
+                        // re-prove at once.
+                        if (proven_full && seed_reprove_due(it->second.skips, kSeedReproveInterval))
+                            reprove_due = true;
                     }
                 }
-                if (force_verify) {
-                    bi.poison_verify = true;    // always re-prove; the writeback caches the verdict
+                if (force_verify || reprove_due) {
+                    bi.poison_verify = true;    // (re-)prove; the writeback caches the verdict
                 } else if (proven_full) {
                     bi.seed_skip = true;        // proven: every texel is written, the seed is unobserved
                     if (trace)
@@ -2040,8 +2059,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     const SeedCoverageKey proof_key{item.code_addr, bi.binding,
                                                     r->width, r->height, r->depth};
                     std::lock_guard<std::mutex> lk(seed_coverage_mu);
+                    // Re-cache the freshly-proven verdict; skips=0 restarts the #1127 re-prove interval.
                     seed_coverage_proof[proof_key] =
-                        survived ? SeedCoverage::Partial : SeedCoverage::Full;
+                        SeedVerdict{ survived ? SeedCoverage::Partial : SeedCoverage::Full, 0 };
                 }
                 std::fprintf(stderr,
                              "[seed-skip-verify] code=0x%llx binding=%u texels=%zu poison_survived=%zu %s\n",

--- a/prosper/frontends/shared/seed_reprove.hpp
+++ b/prosper/frontends/shared/seed_reprove.hpp
@@ -1,0 +1,37 @@
+#pragma once
+#include <cstdint>
+#include <cstdlib>
+
+namespace prosper::frontend {
+
+// #1127: the #1122 seed-skip caches a "this write-only shader covers every texel" verdict per
+// (shader, binding, extent) and trusts it forever. That is unsound for a DATA-DEPENDENT store (full
+// on the proving frame, partial on a later frame with different input): the untouched texels then pack
+// undefined device memory to the guest. Bound the exposure by periodically re-proving a Full verdict.
+//
+// Advance the per-key fast-skip counter and report whether this dispatch is due to re-prove. `skips`
+// counts fast-skips taken since the last (re-)proof; on the interval-th one it fires (true) and resets
+// to 0, so the next re-prove is `interval` fast-skips later. `interval == 0` disables re-proving
+// (the old prove-once behavior). Pure and lock-free — the caller holds the verdict-map mutex.
+inline bool seed_reprove_due(uint32_t& skips, uint32_t interval) {
+    if (interval == 0) return false;
+    if (++skips >= interval) { skips = 0; return true; }
+    return false;
+}
+
+// Parse the PROSPER_SEED_REPROVE re-prove interval, failing SAFE. `env` is the raw getenv() result
+// (nullptr when unset). Only a fully-parsed, non-negative, in-uint32-range integer overrides `dflt`;
+// unset, empty, non-numeric ("foo"), trailing junk ("256x"), negative, or overflow ("4294967296")
+// all keep `dflt` -- so a typo in the safety knob can never silently DISABLE the safety (which an
+// atol-style parse would, by returning 0). An explicit, exact "0" is honored: it intentionally
+// disables re-proving (restores the old prove-once behavior). Uses strtoll so the range check is
+// correct on both LP64 (Linux) and LLP64 (MinGW, where long is 32-bit).
+inline uint32_t seed_reprove_interval_from_env(const char* env, uint32_t dflt) {
+    if (!env || !*env) return dflt;
+    char* end = nullptr;
+    long long v = std::strtoll(env, &end, 10);
+    if (end == env || *end != '\0' || v < 0 || v > (long long)UINT32_MAX) return dflt;
+    return (uint32_t)v;
+}
+
+}  // namespace prosper::frontend

--- a/prosper/tests/test_game_compute.cpp
+++ b/prosper/tests/test_game_compute.cpp
@@ -3,6 +3,7 @@
 #include "../src/gpu/shader_resources.hpp"
 #include "../src/gpu/tile.hpp"
 #include "live_compute.hpp"
+#include "seed_reprove.hpp"
 
 #include <algorithm>
 #include <array>
@@ -20,6 +21,37 @@ static int fails = 0;
 #define CHECK(c, msg) do { if (!(c)) { std::printf("FAIL: %s\n", msg); fails++; } } while (0)
 
 int main() {
+    // #1127: the seed-skip re-prove counter (seed_reprove.hpp). interval 0 disables (old prove-once);
+    // interval N fires on the Nth fast-skip and resets, so a Full-cached data-dependent shader is
+    // re-proven within N fast-skips instead of trusting a stale "covers every texel" verdict forever.
+    {
+        using prosper::frontend::seed_reprove_due;
+        uint32_t s = 0;
+        CHECK(!seed_reprove_due(s, 0) && !seed_reprove_due(s, 0) && s == 0,
+              "interval 0 never re-proves and leaves the counter untouched (prove-once)");
+        s = 0;
+        bool a = seed_reprove_due(s, 3), b = seed_reprove_due(s, 3), c = seed_reprove_due(s, 3);
+        CHECK(!a && !b && c && s == 0, "interval 3 fires on the 3rd fast-skip and resets the counter");
+        CHECK(!seed_reprove_due(s, 3) && !seed_reprove_due(s, 3) && seed_reprove_due(s, 3),
+              "the re-prove cycle repeats after a reset");
+        s = 0;
+        CHECK(seed_reprove_due(s, 1) && seed_reprove_due(s, 1),
+              "interval 1 re-proves every fast-skip (maximum soundness)");
+
+        // #1127: the interval env-parse must fail SAFE -- garbage/overflow keeps the default rather
+        // than silently disabling the safety (which an atol-style parse would, returning 0 = off).
+        using prosper::frontend::seed_reprove_interval_from_env;
+        CHECK(seed_reprove_interval_from_env(nullptr, 256) == 256, "unset env -> default");
+        CHECK(seed_reprove_interval_from_env("", 256) == 256, "empty env -> default");
+        CHECK(seed_reprove_interval_from_env("foo", 256) == 256, "non-numeric env -> default (fail-safe, not 0)");
+        CHECK(seed_reprove_interval_from_env("256x", 256) == 256, "trailing junk -> default");
+        CHECK(seed_reprove_interval_from_env("-4", 256) == 256, "negative -> default");
+        CHECK(seed_reprove_interval_from_env("4294967296", 256) == 256, "overflow (2^32) -> default, not truncated to 0");
+        CHECK(seed_reprove_interval_from_env("0", 256) == 0, "explicit 0 honored (intentionally disables re-proving)");
+        CHECK(seed_reprove_interval_from_env("64", 256) == 64, "exact in-range value overrides default");
+        CHECK(seed_reprove_interval_from_env("4294967295", 256) == 4294967295u, "max uint32 accepted");
+    }
+
     // MinGW's lround dominates full-HD storage-image writeback. Prove the bounded integer path is
     // identical to the previous conversion across all half-float values, every UNORM threshold and
     // adjacent float, plus a deterministic million-value float32 sample.


### PR DESCRIPTION
## Issue

Fixes #1127. The #1122 seed-skip optimization (`live_compute.cpp`) caches a *"this write-only compute shader covers every output texel"* verdict per `(shader code_addr, output binding, width, height, depth)` and then trusts it **forever**, fast-skipping the CPU seed on every future dispatch.

## Failure scenario

The verdict is proven once by a poison-verify frame (fill the target with a poison sentinel, dispatch, check no sentinel survives). That is sound only for a **data-independent** writer. For a **data-dependent** store — `if (buf[gid] > k) imageStore(dst, gid, ...)` — the shader can cover every texel on the frame it is first proven, then **under-cover** on a later frame with different guest input. The untouched texels present **undefined device memory** to the guest, and because the stale `Full` verdict is trusted forever, the gap is never re-detected. Unbounded corruption window.

No *currently-exercised* title shader triggers this (the exercised full-screen composites are genuinely data-independent), so this is a latent-correctness / defense-in-depth fix, not a visible-regression fix.

## Approach

Bound the trust window instead of trusting forever (reviewer option 2 from #1127):

- Re-prove a `Full` verdict every **`PROSPER_SEED_REPROVE`** fast-skips (default **256**; **0** restores the old prove-once behavior).
- On a re-prove the poison-verify path runs again. A shader that now under-covers is re-cached `Partial` and **always seeds** thereafter → exposure shrinks from *unbounded* to *≤ interval fast-skips*.
- A genuinely data-independent full-writer re-proves to `Full` every time → **rendered output unchanged**, cost is ~1 extra poison frame per interval (negligible).

The per-key counter advance is a pure, lock-free helper (`seed_reprove_due`, `frontends/shared/seed_reprove.hpp`) called under the existing verdict-map mutex.

## Invariants

- **Correctness can only improve, never regress:** for a real full-writer, re-proving reaches the identical `Full` verdict, so pixels are unchanged; the only observable effect is the re-prove cadence (perf), which the default (256) keeps negligible.
- **Concurrency:** `seed_reprove_due` runs under `seed_coverage_mu`, so exactly one dispatch per interval flips to re-prove; a concurrent dispatch fast-skipping on the still-`Full` verdict is at most `interval` stale — precisely the intended bound.
- `Partial` verdicts are unaffected (they always seed already).

## Affected / unaffected

- **Affected:** the seed-skip decision in `execute_item` (`live_compute.cpp`) — a `Full` verdict now expires after `interval` fast-skips.
- **Unaffected:** the poison-proof mechanism itself, `Partial` handling, the `force_verify` path, and every non-compute path. Default behavior over any window shorter than 256 fast-skips is byte-identical to before.

## Risk

Low. Worst case of a bad interval is purely performance (more/less frequent poison frames). `PROSPER_SEED_REPROVE=0` is an exact escape hatch back to prior behavior.

## Verification (Linux)

- `ctest` **138/138**. Adds a discriminating `seed_reprove_due` unit test in `test_game_compute`; an injected off-by-one (`>=` → `>`) in the helper **fails** it (verified).
- `test_game_compute` also exercises the live seed-skip path end-to-end: the full-coverage shader proves `Full` (skip), the partial shader stays `Partial` (always seed).
- `python3 tools/snapshot/snapshot.py check blasphemous2-gameplay`: **OK** in DEFAULT mode **and** with `PROSPER_SEED_REPROVE=1` (re-prove *every* frame) — both render gameplay correctly (2251 vs 2265 colors, 99/99 qualifying frames). This proves re-proving is behavior-preserving for the exercised full-writer and the periodic path does not regress the default.

Commands:
```
cmake --build prosper/build-linux -j8 && (cd prosper/build-linux && ctest)
python3 prosper/tools/snapshot/snapshot.py check blasphemous2-gameplay
PROSPER_SEED_REPROVE=1 python3 prosper/tools/snapshot/snapshot.py check blasphemous2-gameplay
```