### PR TITLE
tool: edis — disassemble a flattened PS5 module ELF at a guest address

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -87,6 +87,8 @@ find_package(Python3 COMPONENTS Interpreter QUIET)
 if(Python3_Interpreter_FOUND)
   add_test(NAME re_xref_decoder
            COMMAND "${Python3_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tools/re/test_xref.py")
+  add_test(NAME re_edis_mapping
+           COMMAND "${Python3_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tools/re/test_edis.py")
   add_test(NAME snapshot_guard_logic
            COMMAND "${Python3_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tools/snapshot/test_snapshot.py")
 endif()

--- a/prosper/tools/re/README.md
+++ b/prosper/tools/re/README.md
@@ -37,3 +37,26 @@ call* at eboot+0x1473a6f  # invokes the populated slot
 
 This slot is zero in the flat image and has no ELF relocation. Treating every indirect RIP-relative call
 as a static GOT import would send the investigation to the wrong layer.
+
+## Disassemble guest code at an address
+
+Once `xref.py` (or a live trace) points at an interesting address, read the instructions there with
+`edis.py`. The flattened module ELFs have no section header table, so `objdump -d`/`readelf` reject them
+outright; `edis.py` resolves the byte at a guest VADDR through the module's PT_LOAD program headers and
+disassembles it in Intel syntax with the real guest addresses:
+
+```bash
+python3 tools/il2cpp/prx_to_elf.py /path/to/eboot.bin /tmp/eboot.elf
+python3 tools/re/edis.py /tmp/eboot.elf 0x109a680 0x70
+```
+
+```text
+ 109a6e4:  c6 05 ba f1 fc 00 01   mov  BYTE PTR [rip+0xfcf1ba],0x1   # 0x20698a5
+ 109a6eb:  89 05 af f1 fc 00      mov  DWORD PTR [rip+0xfcf1af],eax  # 0x20698a0
+```
+
+objdump computes the RIP-relative targets (the `# 0x…` comments), which is how the writer of a guest data
+slot is identified — the byte-store forms (`c6 05 …`, `80 3d …`) that `xref.py` does not decode. Unlike
+`tools/dbg/dis.sh`, which disassembles a pre-extracted `/tmp/text.bin` for one title, `edis.py` takes any
+flattened module ELF directly, so the same command works for every title. Requires `objdump` (binutils) on
+PATH.

--- a/prosper/tools/re/edis.py
+++ b/prosper/tools/re/edis.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""edis — disassemble a FLATTENED PS5 module ELF at an eboot-relative offset.
+
+The flattened module ELFs that `tools/il2cpp/prx_to_elf.py` produces (for Il2CppDumper) have
+NO section header table — they target readers that only parse program headers. `objdump -d`
+and `readelf` reject them outright ("file format not recognized" / "too large section header
+offset"), so the usual way to look at guest code is a fiddly
+`dd skip=<off> | objdump -D -b binary -m i386:x86-64 --adjust-vma=<off>` incantation that also
+has to know the segment's file-offset↔vaddr mapping. This wraps that into a one-liner.
+
+Unlike `tools/dbg/dis.sh` (which disassembles a pre-extracted `/tmp/text.bin` of ONE title), this
+takes any flattened module ELF directly and resolves the byte at an eboot/guest VADDR through the
+module's own PT_LOAD program headers, so the same command works for every title.
+
+Usage:
+    tools/re/edis.py <flattened.elf> <vaddr_or_offset> [length_bytes]
+
+    <vaddr_or_offset>  eboot-relative address to disassemble (hex 0x… or decimal). For a flattened
+                       ELF the guest VADDR equals the file offset, but this also handles a normal
+                       PT_LOAD mapping by resolving through the containing segment.
+    [length_bytes]     how many bytes to decode (default 176; hex or decimal).
+
+Example (locate the safe-flag setter in Bendy's flattened eboot):
+    tools/re/edis.py bendy_eboot.elf 0x109a680 0x70
+
+Output is AT&T-free Intel syntax with the real guest addresses, e.g.:
+     109a6e4:  c6 05 ba f1 fc 00 01   mov  BYTE PTR [rip+0xfcf1ba],0x1   # 0x20698a5
+"""
+import struct
+import subprocess
+import sys
+import tempfile
+import os
+
+
+def load_segments(raw):
+    """Return the PT_LOAD segments of an ELF64 as (p_offset, p_vaddr, p_filesz) tuples."""
+    if raw[:4] != b"\x7fELF":
+        raise ValueError("not an ELF (bad magic) — pass a flattened module ELF from prx_to_elf.py")
+    if raw[4] != 2:
+        raise ValueError("not ELF64")
+    e_phoff = struct.unpack_from("<Q", raw, 0x20)[0]
+    e_phentsize = struct.unpack_from("<H", raw, 0x36)[0]
+    e_phnum = struct.unpack_from("<H", raw, 0x38)[0]
+    segs = []
+    for i in range(e_phnum):
+        base = e_phoff + i * e_phentsize
+        if base + 56 > len(raw):
+            break
+        p_type = struct.unpack_from("<I", raw, base)[0]
+        if p_type != 1:  # PT_LOAD
+            continue
+        p_offset = struct.unpack_from("<Q", raw, base + 0x08)[0]
+        p_vaddr = struct.unpack_from("<Q", raw, base + 0x10)[0]
+        p_filesz = struct.unpack_from("<Q", raw, base + 0x20)[0]
+        segs.append((p_offset, p_vaddr, p_filesz))
+    return segs
+
+
+def vaddr_to_file_off(segs, vaddr):
+    """Map a guest VADDR to a file offset via the containing PT_LOAD segment (None if unmapped)."""
+    for p_offset, p_vaddr, p_filesz in segs:
+        if p_vaddr <= vaddr < p_vaddr + p_filesz:
+            return p_offset + (vaddr - p_vaddr)
+    return None
+
+
+def main(argv):
+    if len(argv) < 3:
+        print(__doc__)
+        return 1
+    path = argv[1]
+    vaddr = int(argv[2], 0)
+    length = int(argv[3], 0) if len(argv) > 3 else 176
+    if length <= 0:
+        print("edis: length must be positive", file=sys.stderr)
+        return 2
+
+    with open(path, "rb") as f:
+        raw = f.read()
+
+    segs = load_segments(raw)
+    if not segs:
+        print("edis: no PT_LOAD segments — not a mappable module image", file=sys.stderr)
+        return 2
+    file_off = vaddr_to_file_off(segs, vaddr)
+    if file_off is None:
+        lo = min(v for _, v, _ in segs)
+        hi = max(v + s for _, v, s in segs)
+        print(f"edis: 0x{vaddr:x} is not in any PT_LOAD segment "
+              f"(mapped range 0x{lo:x}..0x{hi:x})", file=sys.stderr)
+        return 2
+
+    avail = len(raw) - file_off
+    if avail <= 0:
+        print(f"edis: file offset 0x{file_off:x} past end of file (0x{len(raw):x})", file=sys.stderr)
+        return 2
+    if length > avail:
+        length = avail  # clamp to what the file actually holds; still disassemble the rest
+
+    chunk = raw[file_off:file_off + length]
+    tmp = tempfile.NamedTemporaryFile(prefix="edis-", suffix=".bin", delete=False)
+    try:
+        tmp.write(chunk)
+        tmp.close()
+        try:
+            out = subprocess.run(
+                ["objdump", "-D", "-b", "binary", "-m", "i386:x86-64", "-M", "intel",
+                 f"--adjust-vma=0x{vaddr:x}", tmp.name],
+                capture_output=True, text=True, check=True).stdout
+        except FileNotFoundError:
+            print("edis: objdump not found on PATH", file=sys.stderr)
+            return 3
+        except subprocess.CalledProcessError as e:
+            sys.stderr.write(e.stderr)
+            return e.returncode or 3
+    finally:
+        os.unlink(tmp.name)
+
+    # Keep only the instruction lines (objdump prints a file-format banner + a ".data" section header).
+    for line in out.splitlines():
+        stripped = line.lstrip()
+        if stripped[:1].isalnum() and ":\t" in line:
+            print(line)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/prosper/tools/re/test_edis.py
+++ b/prosper/tools/re/test_edis.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Regression for edis.py's ELF program-header parsing + VADDR→file-offset mapping.
+
+The pure mapping logic (load_segments / vaddr_to_file_off) is tested against a synthetic ELF with
+no objdump dependency, so it runs on every platform. The end-to-end objdump path is exercised only
+where objdump is on PATH (Linux dev/CI); elsewhere it is skipped, never failed."""
+
+import importlib.util
+import os
+import shutil
+import struct
+import subprocess
+import sys
+
+sys.dont_write_bytecode = True
+HERE = os.path.dirname(os.path.abspath(__file__))
+SPEC = importlib.util.spec_from_file_location("prosper_edis", os.path.join(HERE, "edis.py"))
+EDIS = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(EDIS)
+
+fails = 0
+
+
+def check(cond, msg):
+    global fails
+    if not cond:
+        print(f"FAIL: {msg}")
+        fails += 1
+    else:
+        print(f"ok: {msg}")
+
+
+def gnu_objdump():
+    """Path to GNU binutils objdump, or None. edis's -b binary / -M intel / --adjust-vma flags are
+    GNU-specific, so a different implementation on PATH (e.g. LLVM objdump on macOS) must be treated
+    as 'unavailable' — skipped, not failed."""
+    exe = shutil.which("objdump")
+    if not exe:
+        return None
+    try:
+        ver = subprocess.run([exe, "--version"], capture_output=True, text=True, timeout=10).stdout
+    except Exception:
+        return None
+    return exe if "GNU objdump" in ver else None
+
+
+def build_elf(code, p_offset, p_vaddr):
+    """A minimal ELF64 with one PT_LOAD, `code` placed at file offset p_offset."""
+    size = max(0x200, p_offset + len(code) + 0x10)
+    raw = bytearray(size)
+    raw[:4] = b"\x7fELF"
+    raw[4] = 2                                        # ELFCLASS64
+    struct.pack_into("<Q", raw, 0x20, 0x40)          # e_phoff
+    struct.pack_into("<HH", raw, 0x36, 56, 1)        # e_phentsize, e_phnum
+    struct.pack_into("<IIQQQQQQ", raw, 0x40,
+                     1,          # p_type = PT_LOAD
+                     5,          # p_flags = R+X
+                     p_offset, p_vaddr, 0,
+                     len(code),  # p_filesz
+                     len(code),  # p_memsz
+                     0x1000)     # p_align
+    raw[p_offset:p_offset + len(code)] = code
+    return bytes(raw)
+
+
+def main():
+    # --- Case A: FLATTENED image (p_offset == p_vaddr), as prx_to_elf.py emits. ---
+    flat = build_elf(b"\x90\x90\xc3", p_offset=0x2000, p_vaddr=0x2000)
+    segs = EDIS.load_segments(flat)
+    check(segs == [(0x2000, 0x2000, 3)], "load_segments reads the single PT_LOAD (flattened)")
+    check(EDIS.vaddr_to_file_off(segs, 0x2000) == 0x2000, "flattened: vaddr maps to equal file offset")
+    check(EDIS.vaddr_to_file_off(segs, 0x2002) == 0x2002, "flattened: mid-segment vaddr maps correctly")
+
+    # --- Case B: NORMAL mapping (p_offset != p_vaddr) — the general formula must still hold. ---
+    norm = build_elf(b"\x90\x90\xc3", p_offset=0x100, p_vaddr=0x400000)
+    nsegs = EDIS.load_segments(norm)
+    check(EDIS.vaddr_to_file_off(nsegs, 0x400000) == 0x100,
+          "non-flattened: vaddr resolves through p_offset+(vaddr-p_vaddr)")
+    check(EDIS.vaddr_to_file_off(nsegs, 0x400002) == 0x102, "non-flattened: mid-segment offset correct")
+
+    # --- Bounds: an address outside every segment is unmapped (None), not a wild offset. ---
+    check(EDIS.vaddr_to_file_off(segs, 0x1FFF) is None, "vaddr just below the segment is unmapped")
+    check(EDIS.vaddr_to_file_off(segs, 0x2003) is None, "vaddr just past the segment end is unmapped")
+
+    # --- Rejects a non-ELF blob rather than mis-parsing it. ---
+    try:
+        EDIS.load_segments(b"not an elf" + b"\x00" * 0x100)
+        check(False, "load_segments rejects a non-ELF blob")
+    except ValueError:
+        check(True, "load_segments rejects a non-ELF blob")
+
+    # --- End-to-end objdump path. Runs only with GNU binutils objdump (edis's -b binary / -M intel /
+    # --adjust-vma flags are GNU-specific); skipped — never failed — where objdump is absent or is a
+    # different implementation (e.g. LLVM objdump on macOS CI). ---
+    if gnu_objdump():
+        # `c6 05 <disp32> 01` = mov BYTE PTR [rip+disp],0x1 — the shape of Bendy's SAFE-flag setter.
+        setter = build_elf(b"\xc6\x05\x00\x00\x00\x00\x01\xc3", p_offset=0x3000, p_vaddr=0x3000)
+        import tempfile
+        with tempfile.NamedTemporaryFile(suffix=".elf", delete=False) as tf:
+            tf.write(setter)
+            elf_path = tf.name
+        try:
+            out = subprocess.run(
+                [sys.executable, os.path.join(HERE, "edis.py"), elf_path, "0x3000", "0x8"],
+                capture_output=True, text=True)
+            body = out.stdout
+            check("mov" in body and "BYTE PTR" in body,
+                  "end-to-end: decodes the mov-byte instruction")
+            check("3000:" in body, "end-to-end: prints the real guest VADDR, not a 0-based offset")
+        finally:
+            os.unlink(elf_path)
+    else:
+        print("skip: GNU objdump not available — end-to-end disassembly path not exercised")
+
+    if fails:
+        print(f"\n{fails} FAILED")
+        return 1
+    print("\n== PASS ==")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Goal

Add a small RE tool that disassembles guest code at an address in a **flattened** PS5 module ELF — the kind `tools/il2cpp/prx_to_elf.py` produces.

## Problem

Those flattened ELFs have **no section header table** (they target Il2CppDumper, which only reads program headers), so `objdump -d` and `readelf` reject them (`file format not recognized` / `too large section header offset`). Reading code at a guest address meant a hand-rolled `dd skip=<off> | objdump -D -b binary -m i386:x86-64 --adjust-vma=<off>` that also had to know the PT_LOAD file-offset↔vaddr mapping. This session hit exactly that while locating Bendy's Agc suspend-point SAFE flag (#1195).

## What this adds

`tools/re/edis.py <flattened.elf> <vaddr> [len]` — resolves the byte at a guest VADDR through the module's own PT_LOAD program headers (works whether or not `p_offset==p_vaddr`) and disassembles it in Intel syntax with the real guest addresses. objdump computes the RIP-relative targets (`# 0x…`), so it names the **writer** of a guest data slot via the byte-store forms (`c6 05 …` / `80 3d …`) that `xref.py` does **not** decode.

```text
 109a6e4:  c6 05 ba f1 fc 00 01   mov  BYTE PTR [rip+0xfcf1ba],0x1   # 0x20698a5
```

Complements the existing tools: `xref.py` finds *who references* an address; `edis.py` shows *what the code there does*. Unlike `tools/dbg/dis.sh` (DOLL-specific, pre-extracted `/tmp/text.bin`), it takes any flattened module ELF directly.

## Tests

`tools/re/test_edis.py` (registered as the `re_edis_mapping` ctest, matching `re_xref_decoder`):
- Synthetic-ELF regression for the program-header parse + VADDR→file-offset mapping: **flattened** (`p_offset==p_vaddr`) and **non-flattened** cases, out-of-segment → `None`, mid-segment offset, non-ELF blob rejected. No objdump dependency, so it runs on every platform.
- objdump-gated end-to-end decode (checks it decodes `mov BYTE PTR` and prints the real VADDR), **skipped** (never failed) where objdump is absent (non-Linux CI).

Verified:
- `re_edis_mapping` passes via ctest.
- The mapping test **fails** when the `(vaddr - p_vaddr)` delta is dropped (discriminating).
- edis reproduces the hand-derived Bendy watchdog (`0x1530320`) + SAFE-setter (`0x109a680`) disassembly byte-for-byte.

## Risk

Dev-only RE tooling; **no emulator behavior change**. Requires `objdump` (binutils) on PATH for the disassembly path; the tool and its portable test degrade/skip cleanly without it.