### PR TITLE
tool(xref): decode rip-relative immediate byte/dword stores + byte compares

### DIFF
--- a/prosper/tools/re/.gitignore
+++ b/prosper/tools/re/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/prosper/tools/re/README.md
+++ b/prosper/tools/re/README.md
@@ -25,8 +25,20 @@ python3 tools/re/xref.py /tmp/eboot.elf to 0x2031d10
 ```
 
 The `to` query reports Sony relative-relocation data pointers, direct calls, RIP-relative loads/stores,
-and indirect calls/jumps through the requested slot. `from ADDRESS` lists references made by the function
-window containing that address; `reloc ADDRESS` restricts output to relative data relocations.
+indirect calls/jumps, and the RIP-relative **immediate byte/dword stores and byte compares**
+(`storeb` = `c6 05` mov-byte-imm, `stored` = `c7 05` mov-dword-imm, `cmpb` = `80 3d` cmp-byte-imm)
+through the requested slot. The immediate forms are how the *writer* of a 1-byte state flag is found —
+it is not a register store, so `objdump`/`readelf` cannot name it. For example, the Bendy Agc
+suspend-point SAFE flag (`#1195`) is set by three `storeb` sites that a plain reg-store scan misses:
+
+```text
+python3 tools/re/xref.py /tmp/eboot.elf to 0x20698a5
+   storeb at 0x109a6e4  (in func 0x109a680)   # mov BYTE [rip+..],1
+   cmpb   at 0x1530385  (in func 0x1530320)   # the watchdog's flag test
+```
+
+`from ADDRESS` lists references made by the function window containing that address; `reloc ADDRESS`
+restricts output to relative data relocations.
 
 For The Messenger, the example above identifies both sides of Unity's runtime IL2CPP API table:
 
@@ -55,8 +67,9 @@ python3 tools/re/edis.py /tmp/eboot.elf 0x109a680 0x70
  109a6eb:  89 05 af f1 fc 00      mov  DWORD PTR [rip+0xfcf1af],eax  # 0x20698a0
 ```
 
-objdump computes the RIP-relative targets (the `# 0x…` comments), which is how the writer of a guest data
-slot is identified — the byte-store forms (`c6 05 …`, `80 3d …`) that `xref.py` does not decode. Unlike
-`tools/dbg/dis.sh`, which disassembles a pre-extracted `/tmp/text.bin` for one title, `edis.py` takes any
-flattened module ELF directly, so the same command works for every title. Requires `objdump` (binutils) on
-PATH.
+objdump computes the RIP-relative targets (the `# 0x…` comments), so `edis.py` shows exactly what the
+code at a site does. It complements `xref.py to <slot>`, which lists the *sites* that reference a slot
+(including the `storeb`/`stored`/`cmpb` immediate byte/dword store + compare forms): find the writers with
+`xref.py`, then read each one with `edis.py`. Unlike `tools/dbg/dis.sh`, which disassembles a pre-extracted
+`/tmp/text.bin` for one title, `edis.py` takes any flattened module ELF directly, so the same command works
+for every title. Requires `objdump` (binutils) on PATH.

--- a/prosper/tools/re/test_xref.py
+++ b/prosper/tools/re/test_xref.py
@@ -42,6 +42,12 @@ def main():
     code += b"\xff\x15" + rel32(site, 6, slot)
     site += 6
     code += b"\xff\x25" + rel32(site, 6, slot)
+    site += 6
+    code += b"\xc6\x05" + rel32(site, 7, slot) + b"\x01"                  # mov BYTE [rip+d],1  storeb
+    site += 7
+    code += b"\xc7\x05" + rel32(site, 10, slot) + b"\x00\x00\x00\x00"    # mov DWORD [rip+d],0 stored
+    site += 10
+    code += b"\x80\x3d" + rel32(site, 7, slot) + b"\x01"                  # cmp BYTE [rip+d],1  cmpb
     raw[0x100:0x100 + len(code)] = code
 
     path = ""
@@ -56,6 +62,9 @@ def main():
             (0x1013, "store"),
             (0x101a, "call*"),
             (0x1020, "jmp*"),
+            (0x1026, "storeb"),
+            (0x102d, "stored"),
+            (0x1037, "cmpb"),
         }
         actual = set(module.code_xref[slot])
         assert actual == expected, (actual, expected)

--- a/prosper/tools/re/xref.py
+++ b/prosper/tools/re/xref.py
@@ -5,8 +5,13 @@
 #   - direct calls          e8 <rel32>
 #   - rip-relative load/store REX.W/REX.WR 8d|8b|89 modrm(rip) <disp32>
 #   - indirect call/jump     ff /2|/4 modrm(rip) <disp32>
+#   - byte/dword store-imm   c6 05 <disp32> <imm8>  /  c7 05 <disp32> <imm32>   (storeb/stored)
+#   - byte compare-imm       80 3d <disp32> <imm8>                              (cmpb)
 #   - data pointers          absolute pointers stored in data, emitted as
 #                            R_X86_64_RELATIVE relocations (DT_RELA / DT_SCE_RELA)
+# The store-imm/compare-imm forms write/test a guest FLAG in place; without them the *writer* of a
+# 1-byte state flag is invisible (it is not a reg-store) -- e.g. the Bendy Agc suspend-point SAFE
+# flag (#1195), whose three `c6 05 .. 01` setters this decodes but objdump/readelf cannot name.
 # so "grep for who references address X" is not a text search — it needs all three
 # decoded. Standard tools don't read the Sony (DT_SCE_*) relocation encoding, and
 # rip-relative refs never appear as literals at all. This tool builds a reverse
@@ -110,6 +115,26 @@ class Module:
                     disp = struct.unpack_from('<i', d, i + 1)[0]
                     site = v + i
                     self.code_xref[site + 5 + disp].append((site, 'call'))
+                elif b == 0xc6 and d[i + 1] == 0x05:
+                    # mov BYTE PTR [rip+disp], imm8  (c6 /0) -- 7 bytes. This is the byte-store form
+                    # that sets a guest 1-byte flag; objdump/readelf and the loads/stores above all
+                    # miss it, so it is how the *writer* of a flag byte is found (e.g. the Bendy Agc
+                    # suspend-point SAFE flag setter, #1195).
+                    disp = struct.unpack_from('<i', d, i + 2)[0]
+                    site = v + i
+                    self.code_xref[site + 7 + disp].append((site, 'storeb'))
+                elif b == 0xc7 and d[i + 1] == 0x05:
+                    # mov DWORD PTR [rip+disp], imm32  (c7 /0) -- 10 bytes; the dword store-immediate.
+                    if i + 10 <= n:
+                        disp = struct.unpack_from('<i', d, i + 2)[0]
+                        site = v + i
+                        self.code_xref[site + 10 + disp].append((site, 'stored'))
+                elif b == 0x80 and d[i + 1] == 0x3d:
+                    # cmp BYTE PTR [rip+disp], imm8  (80 /7) -- 7 bytes; the paired flag-*read* form
+                    # (a spin-loop testing a 1-byte flag, e.g. the Bendy suspend-point watchdog).
+                    disp = struct.unpack_from('<i', d, i + 2)[0]
+                    site = v + i
+                    self.code_xref[site + 7 + disp].append((site, 'cmpb'))
 
 
 def main():


### PR DESCRIPTION
## Goal

Teach `tools/re/xref.py` to find the **writer of a guest state flag** — the immediate store/compare forms it previously missed.

## Problem

`xref.py` decoded direct calls, REX.W rip-relative `lea`/`load`/`store`, indirect `call`/`jmp`, and Sony relocations — but not the RIP-relative **immediate** forms:
- `c6 05 <disp32> <imm8>` — `mov BYTE PTR [rip+d], imm8`
- `c7 05 <disp32> <imm32>` — `mov DWORD PTR [rip+d], imm32`
- `80 3d <disp32> <imm8>` — `cmp BYTE PTR [rip+d], imm8`

These write/test a flag *in place*, so the writer of a 1-byte state flag was invisible: it's not a register store, and `objdump`/`readelf` can't name a rip-relative target at all. This is the documented gap hit while locating the Bendy Agc suspend-point SAFE flag (#1195) — its three setters had to be found by a manual objdump scan.

## What this adds

Three new `code_xref` kinds — `storeb` (`c6 05`), `stored` (`c7 05`), `cmpb` (`80 3d`) — with the correct instruction lengths (7 / 10 / 7 bytes; target = `site + len + disp32`).

**Dogfooded** against the flattened Bendy eboot — `to 0x20698a5` (the SAFE flag) now reports the three setters a reg-store scan missed, and `to 0x20698a4` (the crawl gate) names its writers, instantly resolving #1195's last open question:
```
$ xref.py bendy_eboot.elf to 0x20698a5
   storeb at 0x109a6e4  (in func 0x109a680)
   storeb at 0x14ffaab  (in func 0x14fcd20)
   storeb at 0x150c367  (in func 0x150c300)
   cmpb   at 0x1530385  (in func 0x1530320)   # the watchdog's flag test
```

## Tests

`test_xref.py` (the existing `re_xref_decoder` ctest) extends the synthetic decode sequence with the three forms and asserts their exact sites/kinds. Verified it **fails** when any form's instruction length is wrong (e.g. `c6` len 7→6 shifts the `storeb` target). Magnitude sanity-checked on the full 34 MB Bendy eboot: the new kinds (storeb 2168, stored 12687, cmpb 3048) are the same order as the existing register `store` (9295) — genuine instruction density, not false-positive flooding.

## Affected / risk

Pure additive decode: existing kinds and all consumers are unchanged; the new kinds only add references that were previously missing. Also updates the `tools/re/README.md` (documents the new kinds and reconciles the edis section, which had said xref doesn't decode these forms) and adds a `tools/re/.gitignore` for `__pycache__`. Dev-only RE tooling; no emulator behavior change.