### PR TITLE
fix(agc): accept ArcRunner's async-compute submit ABI (#1226)

### DIFF
--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -1384,7 +1384,18 @@ HLE(agc_driver_submit_acb) {  // sceAgcDriverSubmitAcb(queue, const AcbPacket*, 
     uint64_t stream = 0, count64 = 0;
     memcpy(&stream, (const void*)(uintptr_t)a1, 8);
     memcpy(&count64, (const void*)(uintptr_t)(a1 + 8), 8);
-    if (!stream || count64 == 0 || count64 > 0x400000ull || (a3 && a3 != count64))
+    if (!stream || count64 == 0 || count64 > 0x400000ull)
+        return kAgcErrInvalidArg;
+    // word[1] of the record is the authoritative dword count (further validated below via stream
+    // readability + the PM4 header). A redundant count copy is ALSO passed in a register as a sanity
+    // cross-check, but WHICH register holds it varies by the AgcDriver::submitAsyncCompute ABI:
+    // Astro Bot puts the count in a3 (queue id in a0); ArcRunner (UE4 4.27) puts the count in a2 and
+    // mirrors the queue id in a3. Accept the count-mirror in EITHER register; only reject when BOTH
+    // register copies are present and BOTH disagree with word[1] -- a genuinely inconsistent submit.
+    // The previous `a3 == count64` check was Astro-Bot-specific and wrongly rejected ArcRunner's valid
+    // submissions (a3 == queue id 0x20 != count 0x7a) -> sceAgcDriverSubmitAcb returned kAgcErrInvalidArg
+    // and UE4 aborted with `Agc::submitAsyncCompute(...) failed 0x8a6c000a`. CONFIDENCE: HIGH.
+    if (a2 && a3 && a2 != count64 && a3 != count64)
         return kAgcErrInvalidArg;
     // The decoder consumes every advertised dword.  Checking only the header allowed a stream at
     // the end of a readable page to fault as soon as decode crossed into the following guard page.

--- a/prosper/tests/test_agc_submit.cpp
+++ b/prosper/tests/test_agc_submit.cpp
@@ -139,6 +139,19 @@ int main() {
               "SubmitAcb returns OK");
         uint64_t after = 0; prosper_agc_submit_stats(&after, &ignored);
         CHECK(after == before + 1, "SubmitAcb folds one async command stream");
+
+        // ArcRunner (UE4 4.27) async-compute ABI (#1226): the redundant dword-count copy is in a2,
+        // while a3 mirrors the QUEUE id (a0), NOT the count. The old `a3 == count` validation wrongly
+        // returned kAgcErrInvalidArg for this valid submission, so UE4 aborted with
+        // `Agc::submitAsyncCompute(...) failed 0x8a6c000a`. word[1] of the record is authoritative;
+        // the register mirror may be a2 or a3. This case fails against the old check (a3=0x20 != count).
+        uint64_t before2 = 0; prosper_agc_submit_stats(&before2, &ignored);
+        CHECK(submit_acb(0x20 /*queue*/, (uint64_t)(uintptr_t)&packet,
+                         packet.dw_num /*count mirrored in a2*/, 0x20 /*a3 = queue id, not count*/,
+                         0, 0) == 0,
+              "SubmitAcb accepts the ArcRunner ABI (count in a2, queue id mirrored in a3)");
+        uint64_t after2 = 0; prosper_agc_submit_stats(&after2, &ignored);
+        CHECK(after2 == before2 + 1, "ArcRunner-ABI SubmitAcb folds one async command stream");
     }
 
     // A valid header at the last dword of a readable page must not make the decoder walk into the


### PR DESCRIPTION
## Goal
First bring-up of **ArcRunner (PPSA21406, UE4 4.27-plus + EOS)**. It boots cleanly through UE4 init + `.pak` load into the RHI, then immediately fataled at the first GPU submit. Fixes that fatal (part of #1226).

## Failure
```
LowLevelFatalError [Line: 747]
Agc::submitAsyncCompute(...) failed with error code: 0x8a6c000a   (kAgcErrInvalidArg)
```
`agc_driver_submit_acb` (the driver entry UE4's `Agc::submitAsyncCompute` wraps) validated a redundant dword-count copy against register **`a3`** — the **Astro Bot** ABI (`a0`=queue, `a3`=count). ArcRunner (UE4 4.27) uses a different register convention:

```
SubmitAcb a0=0x20 a1=<record> a2=0x7a a3=0x20   record = {stream=0x30036c0000, count=0x7a, ...}
```
The count (`0x7a`) is mirrored in **`a2`**; **`a3`** mirrors the **queue id** (`0x20`). So `a3 != count` → prosper wrongly returned `kAgcErrInvalidArg` for a valid submission → UE4 abort.

## Fix
`word[1]` of the submission record is the authoritative dword count and is independently validated (stream readability + a valid PM4 header). The register mirror is only a defense-in-depth cross-check whose location varies by ABI, so accept the count in **either `a2` or `a3`**, and reject only when **both** register copies are present and **both** disagree with the record's count.

## Result
**ArcRunner now boots past the fatal into the UE4 frame loop and renders 4K frames** (process stable, no fatal on this path). Bring-up milestone: rung 1 (real frames from the live renderer). Remaining work to the title screen (UE4 worker-thread host-`%fs` fault; intro-movie `file://` path/case) is tracked in #1226 — this PR is the isolated, unblocking AGC fix.

## Affected / unaffected
- **Affected:** `agc_driver_submit_acb` accepts the count mirror in `a2` as well as `a3`.
- **Unaffected:** Astro Bot's `a3==count` path (still accepted); the strong record + stream + PM4-header validation is unchanged; genuinely inconsistent submits (both registers present and both wrong) still rejected.

## Tests
`test_agc_submit` adds an ArcRunner-ABI case (count in `a2`, queue mirrored in `a3`) that returns OK and folds the stream. Verified it **FAILS** against the old `a3==count` check. `ctest` **139/139** on the Messenger dump.

## Risk
Low — a strict relaxation of one ABI cross-check, guarded by the authoritative record + header validation. Reverse-engineered ABI semantics, so an independent review is welcome.