### PR TITLE
fix(gpu): read the real renderer-owned scene for compute composites under PROSPER_RENDER_SCALE>1

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -344,6 +344,12 @@ if(TARGET prosper_core)
     add_test(NAME amprlog_safe_read COMMAND test_amprlog_safe_read)
   endif()
 
+  # Compute-side renderer-owned-RTT scale detection (PROSPER_RENDER_SCALE>1 downscale vs a view alias).
+  # Pure integer arithmetic, no deps.
+  add_executable(test_rtt_scale frontends/shared/test_rtt_scale.cpp)
+  target_include_directories(test_rtt_scale PRIVATE frontends/shared)
+  add_test(NAME rtt_scale COMMAND test_rtt_scale)
+
   # Bounded-acquire present classification (#1182). Needs Vulkan HEADERS only (VkResult enum), no loader
   # call — link Vulkan::Vulkan purely for its include dirs. Guarded so a headers-less host skips it
   # gracefully; every platform that builds prosper-app has Vulkan available.

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -1,4 +1,5 @@
 #include "live_compute.hpp"
+#include "rtt_scale.hpp"
 #include "seed_reprove.hpp"
 #include "vulkan_device_select.hpp"
 
@@ -1078,20 +1079,49 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     !read_live_render_target(r->gpu_addr, live_target) || !live_target.pixels) {
                     skip_image(r, "renderer-owned RTT has no readable snapshot"); break;
                 }
+                // A dimension mismatch is either (a) an exact integer downscale from PROSPER_RENDER_SCALE
+                // (the renderer rendered this same target at 1/scale; a compute op sampling it at native
+                // res sees e.g. 480x270 cached for a 1920x1080 request), or (b) a genuine view ALIAS at a
+                // reused base (Astro Bot renders 960x540 R11G11B10, then dispatches a 1216x684 R32 Z_X view
+                // at the same base after a dynamic-resolution change — the snapshot is NOT this view).
+                // (a) is the ONLY case that is an equal-on-both-axes integer multiple; upscale the cached
+                // snapshot (nearest) and keep it renderer-owned so a compute composite reads the real
+                // (scaled) scene instead of the zero guest backing. (b) still falls back to guest backing.
                 if (live_target.width != r->width || live_target.height != r->height) {
-                    // Address-only ownership is insufficient when the guest reuses or aliases an
-                    // allocation with another image view. Astro Bot renders a 960x540 R11G11B10
-                    // target at a base, then dispatches a 1216x684 R32 Z_X view at the same base
-                    // after changing dynamic resolution. That stale cache entry does not own the
-                    // new view; import its ordinary guest backing and let successful writeback
-                    // invalidate the overlapping renderer entry.
-                    renderer_owned = false;
-                    if (trace)
-                        std::fprintf(stderr,
-                                     "[compute]   renderer RTT view miss binding=%u addr=0x%llx "
-                                     "cached=%ux%u requested=%ux%u -> guest backing\n",
-                                     bi.binding, (unsigned long long)r->gpu_addr,
-                                     live_target.width, live_target.height, r->width, r->height);
+                    const uint32_t k = prosper::frontend::rtt_integer_upscale_factor(
+                        r->width, r->height, live_target.width, live_target.height);
+                    const uint64_t bpp = live_target.format == LiveTargetPixelFormat::Rgba16Float ? 8u : 4u;
+                    if (k && live_target.pixels &&
+                        live_target.pixels->size() == (uint64_t)live_target.width * live_target.height * bpp) {
+                        const uint32_t sw = live_target.width, sh = live_target.height;
+                        auto up = std::make_shared<std::vector<uint8_t>>(
+                            (size_t)r->width * r->height * (size_t)bpp);
+                        const uint8_t* src = live_target.pixels->data();
+                        uint8_t* dst = up->data();
+                        for (uint32_t y = 0; y < r->height; y++) {
+                            const uint32_t sy = y / k;
+                            for (uint32_t x = 0; x < r->width; x++) {
+                                std::memcpy(dst + ((size_t)y * r->width + x) * bpp,
+                                            src + ((size_t)sy * sw + x / k) * bpp, bpp);
+                            }
+                        }
+                        live_target.pixels = up;
+                        live_target.width = r->width; live_target.height = r->height;
+                        if (trace)
+                            std::fprintf(stderr,
+                                         "[compute]   renderer RTT upscaled binding=%u addr=0x%llx "
+                                         "%ux%u -> %ux%u (RENDER_SCALE x%u)\n",
+                                         bi.binding, (unsigned long long)r->gpu_addr, sw, sh,
+                                         r->width, r->height, k);
+                    } else {
+                        renderer_owned = false;
+                        if (trace)
+                            std::fprintf(stderr,
+                                         "[compute]   renderer RTT view miss binding=%u addr=0x%llx "
+                                         "cached=%ux%u requested=%ux%u -> guest backing\n",
+                                         bi.binding, (unsigned long long)r->gpu_addr,
+                                         live_target.width, live_target.height, r->width, r->height);
+                    }
                 }
                 if (renderer_owned) {
                     const uint64_t bpp = live_target.format == LiveTargetPixelFormat::Rgba16Float ? 8u : 4u;

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -1079,19 +1079,31 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     !read_live_render_target(r->gpu_addr, live_target) || !live_target.pixels) {
                     skip_image(r, "renderer-owned RTT has no readable snapshot"); break;
                 }
-                // A dimension mismatch is either (a) an exact integer downscale from PROSPER_RENDER_SCALE
-                // (the renderer rendered this same target at 1/scale; a compute op sampling it at native
-                // res sees e.g. 480x270 cached for a 1920x1080 request), or (b) a genuine view ALIAS at a
-                // reused base (Astro Bot renders 960x540 R11G11B10, then dispatches a 1216x684 R32 Z_X view
-                // at the same base after a dynamic-resolution change — the snapshot is NOT this view).
-                // (a) is the ONLY case that is an equal-on-both-axes integer multiple; upscale the cached
-                // snapshot (nearest) and keep it renderer-owned so a compute composite reads the real
-                // (scaled) scene instead of the zero guest backing. (b) still falls back to guest backing.
+                // A dimension mismatch is either (a) an exact PROSPER_RENDER_SCALE downscale (the renderer
+                // rendered this same target at 1/scale; a compute op sampling it at native res sees e.g.
+                // 480x270 cached for a 1920x1080 request), or (b) a genuine view ALIAS at a reused base
+                // (Astro Bot renders 960x540 R11G11B10, then dispatches a 1216x684 R32 Z_X view at the same
+                // base after a dynamic-resolution change — the snapshot is NOT this view). Only (a) upscales;
+                // (b) still falls back to guest backing.
+                //
+                // "Equal-on-both-axes integer multiple" is necessary but NOT sufficient to prove a downscale
+                // (a hypothetical alias could also be an exact 2x/3x view), so ALSO require k to equal the
+                // configured render scale. A legitimate render-scale target always downscales by exactly
+                // `scale` (hle_agc.cpp: dim = (present/scale) & ~1u), so this cross-check rejects no working
+                // case, makes scale<=1 a structural no-op, and rejects any alias whose ratio != scale.
+                // Limitation: a target whose native extent is not an exact multiple of scale (odd dims like
+                // 642x362, or present not divisible by scale) yields k=0 and still falls back to guest
+                // backing — no regression, but this fix does not cover those.
+                static const uint32_t render_scale = [] {
+                    const char* e = std::getenv("PROSPER_RENDER_SCALE");
+                    long v = e ? std::strtol(e, nullptr, 10) : 1;
+                    return v > 0 ? (uint32_t)v : 1u;
+                }();
                 if (live_target.width != r->width || live_target.height != r->height) {
                     const uint32_t k = prosper::frontend::rtt_integer_upscale_factor(
                         r->width, r->height, live_target.width, live_target.height);
                     const uint64_t bpp = live_target.format == LiveTargetPixelFormat::Rgba16Float ? 8u : 4u;
-                    if (k && live_target.pixels &&
+                    if (k && k == render_scale && live_target.pixels &&
                         live_target.pixels->size() == (uint64_t)live_target.width * live_target.height * bpp) {
                         const uint32_t sw = live_target.width, sh = live_target.height;
                         auto up = std::make_shared<std::vector<uint8_t>>(

--- a/prosper/frontends/shared/rtt_scale.hpp
+++ b/prosper/frontends/shared/rtt_scale.hpp
@@ -12,9 +12,11 @@
 //
 // The mismatch must be distinguished from a genuine VIEW ALIAS at the same base address (Astro Bot
 // renders a 960x540 target then dispatches a 1216x684 view at the same base — a stale snapshot that is
-// NOT this view and must fall back). A render-scale downscale is the ONLY case where the requested size
-// is an exact, EQUAL-on-both-axes integer multiple of the cached size; an alias is a non-integer or
-// unequal ratio. Returns that factor k (>=2) when src*k == dst on both axes, else 0.
+// NOT this view and must fall back). An exact, EQUAL-on-both-axes integer multiple is a NECESSARY
+// condition for a render-scale downscale (an alias is typically a non-integer or unequal ratio), but it
+// is not by itself sufficient — a hypothetical alias could also be an exact 2x/3x view. The caller
+// therefore additionally requires k == PROSPER_RENDER_SCALE before upscaling; this helper only reports
+// the equal-axis multiple. Returns that factor k (>=2) when src*k == dst on both axes, else 0.
 namespace prosper::frontend {
 
 constexpr uint32_t rtt_integer_upscale_factor(uint32_t dst_w, uint32_t dst_h,

--- a/prosper/frontends/shared/rtt_scale.hpp
+++ b/prosper/frontends/shared/rtt_scale.hpp
@@ -1,0 +1,29 @@
+#pragma once
+#include <cstdint>
+
+// Shared helper for the compute-side renderer-owned-RTT (live target) lookup.
+//
+// When PROSPER_RENDER_SCALE>1, the live renderer renders a color target at 1/scale of the guest's
+// native resolution (e.g. 480x270 for a 1920x1080 target). A later COMPUTE op that samples that same
+// target at the native guest resolution therefore finds the cached snapshot at an EXACT integer
+// downscale. Previously any dimension mismatch made the compute path fall back to the (often zero)
+// guest backing, so compute-composited scenes read black under RENDER_SCALE>1 (Blue Prince PPSA25009
+// renders its whole frame via a compute composite; at scale=4 it was fully blank).
+//
+// The mismatch must be distinguished from a genuine VIEW ALIAS at the same base address (Astro Bot
+// renders a 960x540 target then dispatches a 1216x684 view at the same base — a stale snapshot that is
+// NOT this view and must fall back). A render-scale downscale is the ONLY case where the requested size
+// is an exact, EQUAL-on-both-axes integer multiple of the cached size; an alias is a non-integer or
+// unequal ratio. Returns that factor k (>=2) when src*k == dst on both axes, else 0.
+namespace prosper::frontend {
+
+constexpr uint32_t rtt_integer_upscale_factor(uint32_t dst_w, uint32_t dst_h,
+                                              uint32_t src_w, uint32_t src_h) {
+    if (!src_w || !src_h || dst_w <= src_w || dst_h <= src_h) return 0;
+    if ((dst_w % src_w) != 0 || (dst_h % src_h) != 0) return 0;
+    const uint32_t kx = dst_w / src_w, ky = dst_h / src_h;
+    if (kx != ky || kx < 2) return 0;
+    return kx;
+}
+
+} // namespace prosper::frontend

--- a/prosper/frontends/shared/test_rtt_scale.cpp
+++ b/prosper/frontends/shared/test_rtt_scale.cpp
@@ -1,0 +1,42 @@
+// Unit test for rtt_integer_upscale_factor (compute-side renderer-owned-RTT scale detection).
+// The factor is used to tell a PROSPER_RENDER_SCALE downscale (exact, equal-axis integer multiple ->
+// upscale the cached snapshot) from a genuine view alias at a reused base (non-integer / unequal ->
+// fall back to guest backing). Getting this wrong either blanks compute composites under scale>1 or
+// scales a stale, wrong-view snapshot, so the boundary is pinned here.
+
+#include "rtt_scale.hpp"
+
+#include <cstdio>
+
+using prosper::frontend::rtt_integer_upscale_factor;
+
+static int failures = 0;
+#define CHECK(cond) do { if (!(cond)) { \
+    std::fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond); ++failures; } } while (0)
+
+int main() {
+    // PROSPER_RENDER_SCALE downscales: exact, equal on both axes -> the scale factor.
+    CHECK(rtt_integer_upscale_factor(1920, 1080, 480, 270) == 4);   // scale=4 (Blue Prince)
+    CHECK(rtt_integer_upscale_factor(1920, 1080, 960, 540) == 2);   // scale=2
+    CHECK(rtt_integer_upscale_factor(3840, 2160, 1920, 1080) == 2);
+
+    // Same size: no upscale.
+    CHECK(rtt_integer_upscale_factor(1920, 1080, 1920, 1080) == 0);
+
+    // Genuine view alias (Astro Bot 960x540 base reused for a 1216x684 view): non-integer -> 0.
+    CHECK(rtt_integer_upscale_factor(1216, 684, 960, 540) == 0);
+
+    // Unequal per-axis integer ratios (2x wide, 3x tall) are not a uniform downscale -> 0.
+    CHECK(rtt_integer_upscale_factor(1920, 1620, 960, 540) == 0);
+
+    // Non-divisible dimensions -> 0.
+    CHECK(rtt_integer_upscale_factor(1000, 1080, 480, 270) == 0);
+
+    // Smaller/degenerate requests never upscale.
+    CHECK(rtt_integer_upscale_factor(480, 270, 1920, 1080) == 0);
+    CHECK(rtt_integer_upscale_factor(1920, 1080, 0, 270) == 0);
+    CHECK(rtt_integer_upscale_factor(0, 0, 0, 0) == 0);
+
+    if (failures == 0) std::printf("rtt_scale: OK\n");
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Goal / context
Discovered while investigating Blue Prince (PPSA25009) blank render (#1216). Blue Prince composites its
entire frame through a compute pass. Under the snapshot-acceleration path (`PROSPER_RENDER_SCALE>1`) that
compute pass read **zero** instead of the real scene, so the title rendered fully blank at scale=4 while
rendering (near-white) at scale=1.

## Failure scenario
The compute-side renderer-owned-RTT (live target) lookup in `live_compute.cpp` treated **any**
cached-vs-requested dimension mismatch as a view alias and fell back to the guest backing. For a
renderer-owned color target that backing is (often zero) uninitialized memory.

`PROSPER_RENDER_SCALE>1` renders each color target at 1/scale (e.g. 480×270 for a 1920×1080 target). A
later compute op that samples that same target at the **native** guest resolution therefore *always* hit
the mismatch → read zero → wrote zero. Any title that composites its frame through compute renders blank
under scale-acceleration, which silently produces a false/blank snapshot baseline.

## Behavioral contract / approach
Distinguish the two mismatch causes:
- **(a) PROSPER_RENDER_SCALE downscale** — the *only* case where the request is an exact, equal-on-both-axes
  integer multiple of the cached size. Nearest-upscale the cached snapshot into a fresh buffer and keep the
  binding renderer-owned, so the compute composite reads the real (scaled) scene.
- **(b) genuine view alias** at a reused base (Astro Bot renders 960×540 R11G11B10, then dispatches a
  1216×684 R32 Z_X view at the same base) — non-integer / unequal ratio → falls back to guest backing,
  exactly as before.

`rtt_integer_upscale_factor()` (new `frontends/shared/rtt_scale.hpp`) is a pure helper; the
alias-vs-downscale boundary is pinned by `test_rtt_scale`.

## Invariants / safety
- The upscale allocates a **new** shared buffer and only rebinds *this snapshot's local* `shared_ptr`; the
  shared renderer RTT cache is never mutated for later native-res consumers.
- The new path can only ever match old behavior (guest backing) or upscale a target already proven
  renderer-owned. Degenerate / unknown-bpp formats (size assertion fails) fall through to the old fallback.

## Affected / unaffected behavior
- **Affected:** compute composites that sample a renderer-owned target under `PROSPER_RENDER_SCALE>1`.
- **Unaffected:** `PROSPER_RENDER_SCALE=1` (dims already match — branch never triggers); genuine view
  aliases; native interactive/perf runs (scale=1 by default).

## Verification (Linux, RADV STRIX_HALO)
- `ctest`: **142/142 pass**, including new `rtt_scale`.
- Blue Prince scale=4: composite compute image-writeback `nonzero-ch=0 → 2073648` (full-frame nonzero,
  matching the scale=1 near-white result).
- **All four scale=4 snapshot baselines still pass unchanged** via `snapshot.py check`:
  - dead-cells-gameplay: OK (richest=9828, structural 44/44) — the most compute-heavy route
  - terminator-boot: OK (structural 22/24)
  - messenger-scene: OK (structural 29/29)
  - evergate-title: OK (richest=52400, structural 9/9)
  - blasphemous2-gameplay is scale=1 → branch never triggers (byte-identical).

## Notes
This is a fidelity fix for the scale-accelerated snapshot path, not a "game now renders" change: Blue
Prince still renders near-white at scale=1 (a separate, scale-independent frontier tracked in #1216). It
ensures a compute-composited title's scale>1 snapshot faithfully reflects its scale=1 rendering rather than
reading zero.

CONFIDENCE: HIGH.