### PR TITLE
fix(hle): resolve sceAvPlayer file:// URLs and case-mismatched guest paths

### DIFF
--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -8,6 +8,7 @@
 #include "nid.hpp"
 #include "heap_mutex.hpp"   // #707: keep the APR mutex off macOS __DATA
 #include "../host/guest_write_watch.hpp"   // #1144 B5: disarm texture watches before reading into guest mem
+#include "../host/boot_program.hpp"        // #1226: resolve_host_path_case (PS5 FS namespace is case-insensitive)
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -490,6 +491,28 @@ namespace {
         for (const auto& c : stack) { out += '/'; out += c; }
         return out;
     }
+    // Clamp-normalize a RELATIVE guest path (#1226): same lexical walk as sandbox_normalize_subpath,
+    // but a ".." with nothing left to pop is dropped (the POSIX "/.." == "/" rule at the virtual
+    // root) instead of failing. Only for rootless relative spellings — an ABSOLUTE guest path that
+    // climbs above its mount stays a denied sandbox escape (#1205). Returns the normalized path
+    // with no leading separator ("a/../../b/c" -> "b/c").
+    std::string clamp_normalize_relative(const std::string& sub) {
+        std::vector<std::string> stack;
+        size_t i = 0;
+        auto is_sep = [](char c) { return c == '/' || c == '\\'; };
+        while (i < sub.size()) {
+            while (i < sub.size() && is_sep(sub[i])) i++;
+            size_t j = i; while (j < sub.size() && !is_sep(sub[j])) j++;
+            std::string comp = sub.substr(i, j - i);
+            i = j;
+            if (comp.empty() || comp == ".") continue;
+            if (comp == "..") { if (!stack.empty()) stack.pop_back(); continue; }
+            stack.push_back(std::move(comp));
+        }
+        std::string out;
+        for (const auto& c : stack) { if (!out.empty()) out += '/'; out += c; }
+        return out;
+    }
     std::string translate(const char* guest) {
         if (!guest) return {};
         std::string p = guest;
@@ -524,6 +547,22 @@ namespace {
             sub = *norm;
         }
         std::string h = root + sub;
+        // The PS5's filesystem namespace is case-insensitive (runtime basename compare in
+        // hle_kernel.cpp; preload correction in boot_program.cpp, #1006), so a guest open whose
+        // casing differs from the dump's on-disk entry succeeds on real hardware — and silently
+        // "worked" here too on the case-insensitive dev hosts (NTFS / WSL DrvFs / default APFS).
+        // On a case-sensitive host filesystem, fall back to the real entry component by component
+        // (#1226: ArcRunner requests "Content/Movies/..."; its dump ships "content/movies/...").
+        // resolve_host_path_case returns `h` unchanged when it already exists (one stat) or when
+        // nothing matches, so a genuinely absent file still fails with ENOENT exactly as before.
+        if (!root.empty() && !sub.empty()) {
+            std::string fixed = resolve_host_path_case(h);
+            if (fixed != h) {
+                if (filelog()) fprintf(stderr, "[file] case-corrected '%s' -> '%s'\n",
+                                       h.c_str(), fixed.c_str());
+                h = std::move(fixed);
+            }
+        }
         if (filelog()) fprintf(stderr, "[file] open '%s' -> '%s'\n", guest, h.c_str());
         return h;
     }
@@ -610,14 +649,30 @@ namespace {
 void set_app0_root(const std::string& root) { g_app0 = root; }
 std::string resolve_guest_path(const char* guest_path) {
     if (!guest_path || !*guest_path) return {};
+    std::string p = guest_path;
+    // sceAvPlayer sources are URIs, and UE4 hands over the local-file scheme spelled out
+    // (#1226, ArcRunner: "file://../../../arcrunner/Content/Movies/..."). Only the file scheme
+    // names sandbox content; strip it and treat the remainder as the guest path ("file:///app0/x"
+    // is the absolute spelling, "file://<relative>" the BaseDir-relative one).
+    if (p.rfind("file://", 0) == 0) p = p.substr(7);
+    if (p.empty()) return {};
     // Sony media APIs accept content paths relative to the title's application root. Unlike the
     // guest libc, a native host backend has no guest current-working-directory state, so root the
     // relative spelling explicitly before applying the shared mount translation.
-    if (guest_path[0] != '/') {
-        const std::string app_path = std::string("/app0/") + guest_path;
+    if (p[0] != '/') {
+        // A relative URL may carry leading ".." components: UE4 media paths are BaseDir-relative
+        // ("../../../<project>/Content/..." climbs from Engine/Binaries/<Platform>/ up to the
+        // package root), but prosper models no BaseDir/CWD and ArcRunner's dump has no such
+        // directories — the only mount a rootless relative path can name is /app0 itself. Clamp
+        // ".." at that root (POSIX "/.." == "/") instead of letting translate() deny the composed
+        // path as an absolute sandbox escape (#1205 stays intact for absolute guest paths).
+        // CONFIDENCE: MED — correct for the observed UE4 shape, where the ".." count equals the
+        // real base-dir depth; the resolved host path is visible under PROSPER_FILELOG/[avp] logs.
+        if (p.find("..") != std::string::npos) p = clamp_normalize_relative(p);
+        const std::string app_path = std::string("/app0/") + p;
         return translate(app_path.c_str());
     }
-    return translate(guest_path);
+    return translate(p.c_str());
 }
 
 // Mount / unmount the guest "/savedata0" area onto a host dir named by the save's dirName

--- a/prosper/src/host/boot_program.cpp
+++ b/prosper/src/host/boot_program.cpp
@@ -19,14 +19,14 @@ namespace prosper {
 // hle_kernel.cpp), so correct each missing component against the real directory entry instead.
 // Pure std::filesystem; never throws (error_code overloads), and an unreadable/missing parent just
 // yields `want` unchanged so the caller's existing absence handling applies.
-std::string resolve_module_path_case(const std::string& want) {
+std::string resolve_host_path_case(const std::string& want) {
     namespace fs = std::filesystem;
     std::error_code ec;
     if (want.empty() || fs::exists(fs::path(want), ec)) return want;   // exact case (or case-insensitive FS)
     const fs::path p(want);
     const std::string parent = p.parent_path().string();
     if (parent.empty() || parent == want) return want;                 // no ancestor left to correct
-    const std::string dir = resolve_module_path_case(parent);          // fix ancestor casing first
+    const std::string dir = resolve_host_path_case(parent);          // fix ancestor casing first
     const std::string base = p.filename().string();
     auto ieq = [](const std::string& a, const std::string& b) {
         if (a.size() != b.size()) return false;
@@ -93,7 +93,7 @@ bool boot_program(const std::string& d, Program& p, std::string* err,
     // the real on-disk entry first so a case-only mismatch (#1006) doesn't drop a present module on a
     // case-sensitive host filesystem.
     for (size_t i = in.size(); i-- > 1; ) {
-        std::string resolved = resolve_module_path_case(in[i].path);
+        std::string resolved = resolve_host_path_case(in[i].path);
         if (resolved != in[i].path) {
             printf("module path case-corrected: %s -> %s\n", in[i].path.c_str(), resolved.c_str());
             in[i].path = std::move(resolved);

--- a/prosper/src/host/boot_program.hpp
+++ b/prosper/src/host/boot_program.hpp
@@ -45,12 +45,14 @@ bool boot_program(const std::string& dump_root, Program& out, std::string* err,
                   const std::function<void()>& after_hle_registered = {});
 
 // Resolve `want` to the real on-disk entry, correcting case-only mismatches component by component
-// (#1006). The boot preload list hard-codes one casing per module path, but titles disagree (The
-// Messenger ships "Il2cppUserAssemblies.prx"; Blasphemous 2 / Evergate ship
-// "Il2CppUserAssemblies.prx"), and PS5 module paths are effectively case-insensitive — so a
-// case-sensitive host filesystem must not decide module presence by exact-case probe. Returns the
-// corrected path, or `want` unchanged when the path already exists or no entry matches (the caller's
-// absence handling then applies as before). Exposed for boot_program's preload loop and its unit test.
-std::string resolve_module_path_case(const std::string& want);
+// (#1006). The PS5's filesystem namespace is case-insensitive (see the runtime basename compare in
+// hle_kernel.cpp), so neither module presence (the boot preload list hard-codes one casing per module
+// path, but titles disagree: The Messenger ships "Il2cppUserAssemblies.prx"; Blasphemous 2 / Evergate
+// ship "Il2CppUserAssemblies.prx") nor a guest file open (ArcRunner requests "Content/Movies/..."
+// where the dump ships "content/movies/...", #1226) may be decided by exact-case probe on a
+// case-sensitive host filesystem. Returns the corrected path, or `want` unchanged when the path
+// already exists or no entry matches (the caller's absence handling then applies as before).
+// Consumers: boot_program's preload loop, hle_file's translate(), and the unit test.
+std::string resolve_host_path_case(const std::string& want);
 
 } // namespace prosper

--- a/prosper/tests/test_module_path_case.cpp
+++ b/prosper/tests/test_module_path_case.cpp
@@ -1,4 +1,4 @@
-// test_module_path_case — guards resolve_module_path_case (#1006): the boot preloader must find a
+// test_module_path_case — guards resolve_host_path_case (#1006): the boot preloader must find a
 // module whose on-disk casing differs from the hard-coded preload path. The Messenger ships
 // "Il2cppUserAssemblies.prx" while Blasphemous 2 / Evergate ship "Il2CppUserAssemblies.prx"; on a
 // case-sensitive host filesystem the old exact-case fopen probe silently dropped the present module,
@@ -13,7 +13,7 @@
 #include <string>
 
 namespace fs = std::filesystem;
-using prosper::resolve_module_path_case;
+using prosper::resolve_host_path_case;
 
 static int fails = 0;
 #define CHECK(cond, msg) do { if (!(cond)) { printf("  [FAIL] %s\n", msg); fails++; } \
@@ -30,37 +30,37 @@ int main() {
 
     // Exact-case path: exists, returned unchanged.
     const std::string exact = base + "/Media/Modules/Il2CppUserAssemblies.prx";
-    CHECK(resolve_module_path_case(exact) == exact, "exact-case path returned unchanged");
+    CHECK(resolve_host_path_case(exact) == exact, "exact-case path returned unchanged");
 
     // The #1006 scenario: preload list says lowercase "Il2cpp", disk has uppercase "Il2Cpp".
     // On a case-sensitive FS the result is the corrected real name; on a case-insensitive FS the
     // wrong-case path already opens, so it comes back unchanged. Either way it must reference the
     // real file (fs::exists true) — that is the property boot_program's absence check relies on.
     const std::string wrongBase = base + "/Media/Modules/Il2cppUserAssemblies.prx";
-    const std::string r1 = resolve_module_path_case(wrongBase);
+    const std::string r1 = resolve_host_path_case(wrongBase);
     CHECK(fs::exists(fs::path(r1)), "wrong-case basename resolves to a present file");
     CHECK(fs::path(r1).parent_path() == fs::path(wrongBase).parent_path(),
           "resolution stays inside the requested directory");
 
     // Case mismatch in an intermediate DIRECTORY component as well ("media/modules/...").
     const std::string wrongDirs = base + "/media/modules/IL2CPPUSERASSEMBLIES.PRX";
-    const std::string r2 = resolve_module_path_case(wrongDirs);
+    const std::string r2 = resolve_host_path_case(wrongDirs);
     CHECK(fs::exists(fs::path(r2)), "wrong-case directory components resolve to the present file");
 
     // Genuinely absent file: input returned unchanged so the caller's skip path still triggers.
     const std::string missing = base + "/Media/Modules/DoesNotExist.prx";
-    CHECK(resolve_module_path_case(missing) == missing, "absent file returned unchanged");
+    CHECK(resolve_host_path_case(missing) == missing, "absent file returned unchanged");
 
     // Whole directory chain absent: unchanged, no throw.
     const std::string noDir = base + "/NoSuchDir/Nested/Nope.prx";
-    CHECK(resolve_module_path_case(noDir) == noDir, "absent directory chain returned unchanged");
+    CHECK(resolve_host_path_case(noDir) == noDir, "absent directory chain returned unchanged");
 
     // Name that differs by more than case must NOT match ("Il2cppUserAssemblies2.prx").
     const std::string lenDiff = base + "/Media/Modules/Il2cppUserAssemblies2.prx";
-    CHECK(resolve_module_path_case(lenDiff) == lenDiff, "length-differing name is not case-matched");
+    CHECK(resolve_host_path_case(lenDiff) == lenDiff, "length-differing name is not case-matched");
 
     // Empty input: unchanged, no throw.
-    CHECK(resolve_module_path_case("").empty(), "empty path returned unchanged");
+    CHECK(resolve_host_path_case("").empty(), "empty path returned unchanged");
 
     fs::remove_all(root, ec);
     printf(fails ? "test_module_path_case: %d FAILURE(S)\n" : "test_module_path_case: all ok\n", fails);

--- a/prosper/tests/test_translate_sandbox.cpp
+++ b/prosper/tests/test_translate_sandbox.cpp
@@ -1,13 +1,25 @@
-// test_translate_sandbox — #1205: the guest-path -> host-path mapping (translate(), exercised via the
-// public resolve_guest_path) must not let a guest path climb OUT of its virtual root (/app0, /temp0,
-// /savedata0). A sub-path containing ".." is lexically normalized; one that escapes above the root is
-// denied. Normal paths and benign in-sandbox ".." are byte-for-byte unaffected (a benign ".." resolves
-// to the same host file it always would). No real filesystem access is needed — translate() is pure.
+// test_translate_sandbox — the guest-path -> host-path mapping (translate(), exercised via the
+// public resolve_guest_path):
+//  - #1205: a guest path must not climb OUT of its virtual root (/app0, /temp0, /savedata0). A
+//    sub-path containing ".." is lexically normalized; an ABSOLUTE path that escapes above the root
+//    is denied. Normal paths and benign in-sandbox ".." are byte-for-byte unaffected.
+//  - #1226: sceAvPlayer sources arrive as file:// URLs (UE4:
+//    "file://../../../<project>/Content/Movies/x.mp4"). The scheme is stripped; a RELATIVE path's
+//    leading ".." clamps at the /app0 root (prosper models no UE4 BaseDir/CWD) instead of being
+//    denied as an escape.
+//  - #1226: the PS5 filesystem namespace is case-insensitive, so a guest spelling whose case
+//    differs from the on-disk dump entry must resolve to the real file on a case-sensitive host
+//    (ArcRunner asks for "Content/Movies/...", its dump ships "content/movies/...").
+// The app0 root is a real temp tree: translate() probes the host FS for the case-corrected
+// fallback. It returns composed paths unchanged whenever the exact-case entry exists (or nothing
+// matches), which keeps the byte-exact checks below valid on case-insensitive filesystems too.
 #include "../src/hle/dispatch.hpp"
 #include <cstdio>
-#include <cstdlib>
+#include <filesystem>
+#include <fstream>
 #include <string>
 
+namespace fs = std::filesystem;
 using namespace prosper;
 
 static int fails = 0;
@@ -17,37 +29,90 @@ static int fails = 0;
 static bool denied(const std::string& r) { return r.rfind("/prosper-denied", 0) == 0; }
 
 int main() {
-    // g_app0 is cached on first use, so set the root before any translate() call.
-    // setenv is POSIX-only (MinGW-w64 lacks it); use _putenv_s on Windows.
-#ifdef _WIN32
-    _putenv_s("PROSPER_APP0", "/hostroot/app0");
-#else
-    setenv("PROSPER_APP0", "/hostroot/app0", 1);
-#endif
     std::printf("== test_translate_sandbox ==\n");
+    std::error_code ec;
+    const fs::path root = fs::temp_directory_path() / "prosper_test_translate_sandbox";
+    fs::remove_all(root, ec);                       // stale run debris
+    fs::create_directories(root / "data");
+    fs::create_directories(root / "arcrunner" / "content" / "movies");   // dump-style lowercase
+    { std::ofstream(root / "data" / "config.bin") << "x"; }
+    { std::ofstream(root / "arcrunner" / "content" / "movies" / "intro_ps5.mp4") << "x"; }
+    const std::string base = root.string();
+    set_app0_root(base);
+
+    // ---- #1205: sandbox containment (unchanged behavior) ----
 
     // Normal path: composed directly under the host root (identical to pre-#1205 behavior).
-    CHECK(resolve_guest_path("/app0/foo/bar") == "/hostroot/app0/foo/bar",
+    CHECK(resolve_guest_path("/app0/data/config.bin") == base + "/data/config.bin",
           "normal /app0 path maps directly under the root");
 
     // Benign in-sandbox '..': normalizes to the same host file the OS would have resolved anyway.
-    CHECK(resolve_guest_path("/app0/data/../config") == "/hostroot/app0/config",
-          "in-sandbox '..' normalizes to <root>/config");
+    CHECK(resolve_guest_path("/app0/data/../data/config.bin") == base + "/data/config.bin",
+          "in-sandbox '..' normalizes to the same host file");
 
     // A filename that merely CONTAINS '..' as a substring is a normal component, not traversal.
-    CHECK(resolve_guest_path("/app0/foo..bar") == "/hostroot/app0/foo..bar",
+    CHECK(resolve_guest_path("/app0/foo..bar") == base + "/foo..bar",
           "'foo..bar' is a normal filename, not a traversal");
 
     // Escaping traversal: denied, and never composes the escaping host path.
     {
         std::string r = resolve_guest_path("/app0/../escape");
         CHECK(denied(r), "'/app0/../escape' escaping the root is denied");
-        CHECK(r.find("/hostroot/app0/../") == std::string::npos,
+        CHECK(r.find(base + "/../") == std::string::npos,
               "denied result does not compose the escaping host path");
     }
     CHECK(denied(resolve_guest_path("/app0/../../etc/passwd")), "double-'..' escape denied");
     CHECK(denied(resolve_guest_path("/app0/a/../../b")),        "'..' popping past the root denied");
 
+    // A genuinely absent file keeps its composed exact-case path (ENOENT downstream, as before).
+    CHECK(resolve_guest_path("/app0/nope/missing.bin") == base + "/nope/missing.bin",
+          "absent file composes unchanged (still fails with ENOENT)");
+
+    // ---- #1226: file:// scheme stripping ----
+
+    // Absolute file:// URL: scheme stripped, then the ordinary /app0 mount translation.
+    CHECK(resolve_guest_path("file:///app0/data/config.bin") == base + "/data/config.bin",
+          "'file:///app0/...' strips the scheme and maps under the root");
+
+    // The sandbox guard applies to the stripped ABSOLUTE path exactly as without the scheme.
+    CHECK(denied(resolve_guest_path("file:///app0/../escape")),
+          "'file:///app0/../escape' is still a denied escape");
+
+    // ---- #1226: relative media URLs root at /app0 with leading-'..' clamping ----
+
+    // Plain relative path (pre-existing contract): rooted at /app0.
+    CHECK(resolve_guest_path("data/config.bin") == base + "/data/config.bin",
+          "bare relative path roots at /app0");
+
+    // The observed UE4 shape: BaseDir-relative '../../..' clamps at the /app0 root instead of
+    // being denied (prosper has no BaseDir/CWD model; the ".." count matches the base-dir depth).
+    CHECK(resolve_guest_path("file://../../../arcrunner/content/movies/intro_ps5.mp4")
+              == base + "/arcrunner/content/movies/intro_ps5.mp4",
+          "UE4 'file://../../../<project>/...' clamps to the /app0 package root");
+
+    // Interior '..' still pops normally before clamping applies.
+    CHECK(resolve_guest_path("file://a/../../../data/config.bin") == base + "/data/config.bin",
+          "interior '..' pops, leading overflow clamps");
+
+    // ---- #1226: case-insensitive fallback against the real on-disk entries ----
+
+    // The ArcRunner scenario end-to-end: mixed-case request, lowercase dump. On a case-sensitive
+    // host the result is the corrected real path; on a case-insensitive host the composed spelling
+    // already opens the same file — the cross-platform contract is that the result exists.
+    {
+        std::string r = resolve_guest_path("file://../../../ArcRunner/Content/Movies/INTRO_PS5.MP4");
+        CHECK(fs::exists(fs::path(r)), "mixed-case UE4 movie URL resolves to the on-disk file");
+    }
+    {
+        std::string r = resolve_guest_path("/app0/Data/Config.BIN");
+        CHECK(fs::exists(fs::path(r)), "mixed-case absolute /app0 path resolves to the on-disk file");
+    }
+
+    // Case correction must not invent matches: absent names stay the composed exact-case path.
+    CHECK(resolve_guest_path("/app0/Data/Config2.BIN") == base + "/Data/Config2.BIN",
+          "no case-insensitive match leaves the composed path unchanged");
+
+    fs::remove_all(root, ec);
     std::printf(fails ? "FAILED (%d)\n" : "PASSED\n", fails);
     return fails ? 1 : 0;
 }


### PR DESCRIPTION
Progresses #1226 (ArcRunner bring-up — the intro-movie path item; the free-list corruption track remains separate).

## Failure scenario

ArcRunner (PPSA21406, UE4 4.27) hands `sceAvPlayerAddSource` the URL
`file://../../../arcrunner/Content/Movies/ArcRunner_Intro_A_1080p_PS5_30fps.mp4`.
`resolve_guest_path` rooted that spelling at `/app0` verbatim, so the `file:` component plus the leading `..`s read as a #1205 sandbox escape and the source resolved to `/prosper-denied/...` — the intro movie can never open. Even with the URL resolved, the exact-case host path misses on a case-sensitive filesystem: the guest asks for `arcrunner/Content/Movies/ArcRunner_Intro_A_1080p_PS5_30fps.mp4`, the dump ships `arcrunner/content/movies/arcrunner_intro_a_1080p_ps5_30fps.mp4`.

## Behavioral contract

- `file://` is stripped from sceAvPlayer source URIs; only the local-file scheme names sandbox content (`file:///app0/x` = absolute, `file://<relative>` = BaseDir-relative).
- A **relative** path's leading `..` clamps at the `/app0` root (POSIX `/..` == `/`): UE4 media URLs are BaseDir-relative (`../../../<project>/Content/...` climbs from `Engine/Binaries/<Platform>/`), but prosper models no BaseDir/CWD and the dump ships no such directories. **Absolute** guest paths keep the full #1205 escape denial, unchanged. `CONFIDENCE: MED`, correction visible under `PROSPER_FILELOG`.
- `translate()` falls back to the real on-disk entry component by component when the exact-case host path does not exist — the PS5 filesystem namespace is case-insensitive (project evidence: runtime basename compare in `hle_kernel.cpp`, preload correction #1006). The helper (renamed `resolve_module_path_case` → `resolve_host_path_case`, now two consumers) returns the path unchanged when it already exists or nothing matches.

## Deliberately unaffected

- Exact-case titles and case-insensitive dev hosts (NTFS / WSL DrvFs / default APFS): the fallback's first probe is `fs::exists`, which succeeds there, so translation is byte-for-byte identical (one added stat per mount-translated open).
- Genuinely absent files still compose the exact-case path → ENOENT, so probe-storm boot flows see the same *results* (each miss now costs up-tree existence probes plus one directory scan per missing component — see Risks).
- #1205 sandbox containment for absolute paths (the original test cases are retained and green).
- Shape-level note from review: `file:///<absolute-non-mount>` (e.g. `file:///etc/x`) now reaches `translate()`'s pre-existing, documented unmounted-absolute passthrough instead of being accidentally mangled under `/app0`. No new capability — the guest could always pass `/etc/x` directly and the passthrough is pinned by `test_savedata_ime.cpp`.

## Risks

- The clamp is derived from the one observed UE4 shape (`..` count == real base-dir depth). A relative URL whose `..` count differs would resolve to a different app0 subpath — fail-visible in `[file]`/`[avp]` logs, and previously it was a hard DENIED anyway.
- The case fallback scans one directory per missing component on miss; bounded, dcache-served, and only on the mount-translated branch.

## Verification (native Linux host, btrfs = case-sensitive, gcc 16)

- `cmake --build prosper/build-linux && ctest` → **117/117 passed** headless; after adding Vulkan headers (`-DVulkan_INCLUDE_DIR=<Vulkan-Headers> -DVulkan_LIBRARY=/usr/lib64/libvulkan.so.1`, RADV STRIX_HALO) the offscreen graphics harness builds too → **139/139 passed** including the Vulkan execution tests.
- `test_translate_sandbox` (rewritten against a real temp tree): #1205 containment retained; new checks for scheme stripping, denied absolute escape via `file://`, relative clamping, interior-`..` popping, mixed-case end-to-end resolution, and no-invented-match.
- Live headless ArcRunner boot (`boot_trace` + `PROSPER_AVPLOG=1 PROSPER_FILELOG=1`):
  ```
  [avp] add source request handle=0x1 guest='file://../../../arcrunner/Content/Movies/ArcRunner_Intro_A_1080p_PS5_30fps.mp4'
  [file] case-corrected '<dump>/arcrunner/Content/Movies/ArcRunner_Intro_A_1080p_PS5_30fps.mp4' -> '<dump>/arcrunner/content/movies/arcrunner_intro_a_1080p_ps5_30fps.mp4'
  [avp] opening source host='<dump>/arcrunner/content/movies/arcrunner_intro_a_1080p_ps5_30fps.mp4' backend=0
  ```
  This host build has no ffmpeg dev packages, so the #1105 graceful skip then fires; on a full build the same path feeds the real vaapi backend. Movie **playback** (and the separate RHIThread free-list corruption, reproduced again this run at `eboot+0x117811f`) are outside this PR's scope — no progression-rung claim is made here.
- Not run: `snapshot.py check` (routes not established on this box). Rationale for safety: on the canonical snapshot hosts the filesystem is case-insensitive, where this change is a translation no-op.
