### PR TITLE
tool(gpu_replay): PROSPER_STENCIL_DUMP — read back & visualize the stencil plane

### DIFF
--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -1723,6 +1723,41 @@ int main(int argc, char** argv) {
         ? static_cast<size_t>(through_operation) + 1 : selected_operation_limit;
     const bool selected_draws_only = draw_first >= 0 && !draw_with_compute_prefix;
     std::vector<uint8_t> pixels = execute_frame(replay, selected_draws_only, operation_limit);
+    // Diagnostic: after rendering, read back every persistent depth/stencil surface's STENCIL plane and
+    // write it as a grayscale image (value*80) plus a value histogram. This shows exactly where a
+    // stencil-counting clip mask reached each count — e.g. GTA V's menu artwork is gated on stencil==2
+    // and renders as black wedges wherever the count never reaches 2 (#1231).
+    if (const char* sdump = getenv("PROSPER_STENCIL_DUMP")) {
+        std::vector<prosper::gpu::GpuCaptureDsSeed> seeds;
+        std::string derr;
+        if (prosper::test::snapshot_persistent_ds_images(seeds, derr)) {
+            for (size_t si = 0; si < seeds.size(); ++si) {
+                const auto& s = seeds[si];
+                if (!s.stencil_valid || s.stencil.empty()) continue;
+                const size_t n = static_cast<size_t>(s.width) * s.height;
+                std::vector<uint8_t> rgba(n * 4, 255);
+                uint64_t histo[8] = {0};
+                for (size_t p = 0; p < n && p < s.stencil.size(); ++p) {
+                    const uint8_t sv = s.stencil[p];
+                    const uint8_t v = static_cast<uint8_t>(sv > 3 ? 255 : sv * 80);
+                    rgba[p * 4 + 0] = v; rgba[p * 4 + 1] = v; rgba[p * 4 + 2] = v; rgba[p * 4 + 3] = 255;
+                    histo[sv < 8 ? sv : 7]++;
+                }
+                char path[600];
+                std::snprintf(path, sizeof path, "%s_ds%zu_%ux%u.bmp", sdump, si, s.width, s.height);
+                prosper::test::dump_bmp(path, rgba, s.width, s.height);
+                std::fprintf(stderr, "[stencil-dump] ds%zu %ux%u -> %s histo[0..7+]="
+                             " %llu %llu %llu %llu %llu %llu %llu %llu\n",
+                             si, s.width, s.height, path,
+                             (unsigned long long)histo[0], (unsigned long long)histo[1],
+                             (unsigned long long)histo[2], (unsigned long long)histo[3],
+                             (unsigned long long)histo[4], (unsigned long long)histo[5],
+                             (unsigned long long)histo[6], (unsigned long long)histo[7]);
+            }
+        } else {
+            std::fprintf(stderr, "[stencil-dump] snapshot failed: %s\n", derr.c_str());
+        }
+    }
     const auto extent_mode = selected_draws_only
         ? prosper::gpu::replay_tool::OutputExtentMode::SelectedDraws
         : (through_operation >= 0 || (draw_first >= 0 && draw_with_compute_prefix))


### PR DESCRIPTION
## Summary
Adds a read-only diagnostic to `gpu_replay`: `PROSPER_STENCIL_DUMP=<prefix>`. After rendering a capsule, it reads back every persistent depth/stencil surface's **stencil plane** (reusing the existing `snapshot_persistent_ds_images` path) and writes each as a grayscale image (`value*80`, clamped) plus a per-value histogram to stderr. Combined with `--through-operation N` it shows exactly how a stencil count builds up across draws.

## Why
Oracle-screenshot comparison can't localize a stencil-masked composition bug. This tool made the GTA V main-menu "black triangles" defect (#1231) fully diagnosable **offline**: the menu is a per-panel stencil-counting clip (`REPLACE→0` clear, `INCR`, `INCR`, then fill where `stencil==2`). Dumping the stencil at successive `--through-operation` cut points proved the **first INCR mask draw per panel renders 0 pixels**, so the count reaches only 1 and the `EQUAL 2` artwork fill passes only in the second INCR's self-overlap wedges. That's the black-wedge pattern.

## Behavioral contract
- No behavioral change. The diagnostic runs only when `PROSPER_STENCIL_DUMP` is set; otherwise the code path is skipped entirely.
- `gpu_replay`-only (a tool); no change to the emulator, renderer, recompiler, or capture format.
- Reuses `prosper::test::snapshot_persistent_ds_images` + `dump_bmp` (both already in `render_runner.h`).

## Affected / unaffected
- Affected: `prosper/tools/gpu_replay/gpu_replay.cpp` (+35 lines, one gated block after `execute_frame`).
- Unaffected: all rendering/capture behavior; every existing gpu_replay invocation is byte-identical.

## Test / verify
- Builds clean against current master (`cmake --build . --target gpu_replay`).
- Verified on a captured GTA V menu submit: emits `[stencil-dump] ds0 3840x2160 -> ... histo[0..7+]= ...` and a readable grayscale BMP; matches the `PROSPER_STENCILLOG` op sequence.
- No ctest impact (tool-only, gated on an env var).

Docs/usage tracked on #1231.
