### PR TITLE
feat(gpu): implement CB_COLOR_CONTROL.MODE=3 (MSAA resolve) as a single-sample color0→color1 copy

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -2337,11 +2337,18 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     const VkFormat format0 = active_format(items[pass_i], false);
                     const VkFormat format1 = base1
                         ? active_format(items[pass_i], true) : VK_FORMAT_UNDEFINED;
+                    // A MODE=RESOLVE draw shares color0_base with the scene it resolves and reports
+                    // active_color1()==0 (it exports nothing), so without keying the group on cb_resolve
+                    // it could merge with the scene draws; the resolve-copy `continue` below would then
+                    // silently drop any ordinary draws grouped after it. Key on it so a resolve is always
+                    // its own pass.
+                    const bool resolve0 = items[pass_i].ps.cb_resolve;
                     std::vector<const prosper::gpu::DrawItem*> pass;
                     while (pass_i < items.size() && items[pass_i].color0_base == base &&
                            active_color1(items[pass_i]) == base1 &&
                            active_format(items[pass_i], false) == format0 &&
-                           (!base1 || active_format(items[pass_i], true) == format1)) {
+                           (!base1 || active_format(items[pass_i], true) == format1) &&
+                           items[pass_i].ps.cb_resolve == resolve0) {
                         pass.push_back(&items[pass_i]); ++pass_i;
                     }
 
@@ -2357,11 +2364,14 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         const uint64_t rdst = pass.front()->color1_base;
                         auto src_it = rsrc ? g_rtt.find(rsrc) : g_rtt.end();
                         if (rsrc && rdst && src_it != g_rtt.end() && src_it->second.rgba) {
-                            g_rtt[rdst] = src_it->second;   // shares pixels; dest inherits src content
+                            // Copy the source RttSurf out before the g_rtt[rdst] insert: operator[] may
+                            // rehash and invalidate src_it before the assignment reads it.
+                            RttSurf resolved = src_it->second;   // shares pixels (shared_ptr), no deep copy
+                            const uint32_t rw = resolved.w, rh = resolved.h;
+                            g_rtt[rdst] = std::move(resolved);    // dest inherits src content/extent/format
                             if (getenv("PROSPER_MSAA_LOG"))
                                 fprintf(stderr, "[msaa] resolve copy 0x%llx -> 0x%llx (%ux%u)\n",
-                                        (unsigned long long)rsrc, (unsigned long long)rdst,
-                                        src_it->second.w, src_it->second.h);
+                                        (unsigned long long)rsrc, (unsigned long long)rdst, rw, rh);
                         } else if (getenv("PROSPER_MSAA_LOG")) {
                             fprintf(stderr, "[msaa] resolve SKIP src=0x%llx dst=0x%llx (%s)\n",
                                     (unsigned long long)rsrc, (unsigned long long)rdst,

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -2345,6 +2345,31 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         pass.push_back(&items[pass_i]); ++pass_i;
                     }
 
+                    // CB_COLOR_CONTROL.MODE=RESOLVE(3): the guest resolves an MSAA color0 surface into a
+                    // single-sample color1 destination (Blue Prince PPSA25009 resolves its 4x-MSAA scene
+                    // this way). prosper renders single-sample, so the resolve is a straight copy of the
+                    // already-rendered color0 surface into color1. Use the RAW color1_base, not
+                    // active_color1(): a fixed-function resolve exports nothing, so its color1_write_mask
+                    // is 0 and active_color1 would report no destination. Without this the resolved surface
+                    // the display later samples never receives the scene and the frame is a uniform fill.
+                    if (!pass.empty() && pass.front()->ps.cb_resolve) {
+                        const uint64_t rsrc = pass.front()->color0_base;
+                        const uint64_t rdst = pass.front()->color1_base;
+                        auto src_it = rsrc ? g_rtt.find(rsrc) : g_rtt.end();
+                        if (rsrc && rdst && src_it != g_rtt.end() && src_it->second.rgba) {
+                            g_rtt[rdst] = src_it->second;   // shares pixels; dest inherits src content
+                            if (getenv("PROSPER_MSAA_LOG"))
+                                fprintf(stderr, "[msaa] resolve copy 0x%llx -> 0x%llx (%ux%u)\n",
+                                        (unsigned long long)rsrc, (unsigned long long)rdst,
+                                        src_it->second.w, src_it->second.h);
+                        } else if (getenv("PROSPER_MSAA_LOG")) {
+                            fprintf(stderr, "[msaa] resolve SKIP src=0x%llx dst=0x%llx (%s)\n",
+                                    (unsigned long long)rsrc, (unsigned long long)rdst,
+                                    !rsrc || !rdst ? "missing base" : "source has no rendered surface");
+                        }
+                        continue;   // resolve is a copy, not an ordinary-draw render
+                    }
+
                     // Gen5 render-target extent (#526). Large scene/scanout surfaces retain the
                     // configured VideoOut render scale; small offscreen targets render at native
                     // resolution so lookup textures (Messenger's 1024x32 grading LUT) preserve every

--- a/prosper/src/gpu/pm4_registers.hpp
+++ b/prosper/src/gpu/pm4_registers.hpp
@@ -404,6 +404,7 @@ constexpr uint32_t CB_COLOR_CONTROL_MODE_SHIFT = 4;
 constexpr uint32_t CB_COLOR_CONTROL_MODE_MASK  = 0x7;
 constexpr uint32_t CB_COLOR_CONTROL_MODE_DISABLE = 0;
 constexpr uint32_t CB_COLOR_CONTROL_MODE_NORMAL = 1;
+constexpr uint32_t CB_COLOR_CONTROL_MODE_RESOLVE = 3;   // hardware MSAA resolve (color0 MSAA -> color1)
 constexpr uint32_t CB_COLOR_CONTROL_MODE_DCC_DECOMPRESS = 6;
 constexpr uint32_t CB_COLOR_CONTROL_ROP3_SHIFT = 16;
 constexpr uint32_t CB_COLOR_CONTROL_ROP3_MASK  = 0xFF;

--- a/prosper/src/gpu/render_state.cpp
+++ b/prosper/src/gpu/render_state.cpp
@@ -126,6 +126,27 @@ RenderState extract_render_state(const GpuState& st) {
         rs.color0_height = PM4_FIELD(color_attrib2->second, CB_COLOR0_ATTRIB2, MIP0_HEIGHT) + 1u;
     }
 
+    // Diagnostic (PROSPER_MSAA_LOG): report MSAA sample/fragment programming and the CB color mode so we
+    // can tell whether a title uses MSAA + hardware resolve (CB_COLOR_CONTROL.MODE=3), which prosper renders
+    // single-sample and does not yet resolve. Gated; no default behavior change.
+    if (getenv("PROSPER_MSAA_LOG")) {
+        const uint32_t cattr    = st.cx.count(P::CB_COLOR0_ATTRIB)   ? rd(st.cx, P::CB_COLOR0_ATTRIB)   : 0u;
+        const uint32_t aacfg    = st.cx.count(P::PA_SC_AA_CONFIG)    ? rd(st.cx, P::PA_SC_AA_CONFIG)    : 0u;
+        const uint32_t modecntl = st.cx.count(P::PA_SC_MODE_CNTL_0)  ? rd(st.cx, P::PA_SC_MODE_CNTL_0)  : 0u;
+        const uint32_t ctrl     = st.cx.count(P::CB_COLOR_CONTROL)   ? rd(st.cx, P::CB_COLOR_CONTROL)   : 0u;
+        const uint32_t nsamp  = PM4_FIELD(cattr, CB_COLOR0_ATTRIB, NUM_SAMPLES);
+        const uint32_t aa_ns  = PM4_FIELD(aacfg, PA_SC_AA_CONFIG, MSAA_NUM_SAMPLES);
+        const uint32_t msaaen = PM4_FIELD(modecntl, PA_SC_MODE_CNTL_0, MSAA_ENABLE);
+        const uint32_t cbmode = PM4_FIELD(ctrl, CB_COLOR_CONTROL, MODE);
+        const uint64_t c1base  = addr_of(rd(st.cx, P::CB_COLOR1_BASE), rd(st.cx, P::CB_COLOR1_BASE_EXT));
+        const uint32_t tmask   = st.cx.count(P::CB_TARGET_MASK) ? rd(st.cx, P::CB_TARGET_MASK) : 0xffffffffu;
+        fprintf(stderr, "[msaa] color0=0x%llx fmt=%u %ux%u ATTRIB.NUM_SAMPLES=%u(=%ux) "
+                        "AA.NUM_SAMPLES=%u(=%ux) MSAA_ENABLE=%u CB_MODE=%u color1=0x%llx tgtmask=0x%x\n",
+                (unsigned long long)rs.color0_base, rs.color0_format, rs.color0_width, rs.color0_height,
+                nsamp, 1u << nsamp, aa_ns, 1u << aa_ns, msaaen, cbmode,
+                (unsigned long long)c1base, tmask);
+    }
+
     // CB fast-clear color (CB_COLOR0_CLEAR_WORD0/1). Present only when the game programs a fast-clear
     // for MRT 0; the words carry the clear value in the target's pixel format (decoded in resolve).
     rs.color0_has_clear   = st.cx.count(P::CB_COLOR0_CLEAR_WORD0) || st.cx.count(P::CB_COLOR0_CLEAR_WORD1);

--- a/prosper/src/gpu/render_state.cpp
+++ b/prosper/src/gpu/render_state.cpp
@@ -549,6 +549,10 @@ ResolvedPipelineState resolve_pipeline_state(const RenderState& rs) {
         if (cb_mode == P::CB_COLOR_CONTROL_MODE_DISABLE) {
             ps.color_write_mask = 0;
             ps.color1_write_mask = 0;
+        } else if (cb_mode == P::CB_COLOR_CONTROL_MODE_RESOLVE) {
+            // MSAA resolve: color0 (MSAA source) -> color1 (single-sample dest). The live backend copies
+            // the already-rendered color0 surface into color1 instead of running these as ordinary draws.
+            ps.cb_resolve = true;
         } else if (cb_mode != P::CB_COLOR_CONTROL_MODE_NORMAL &&
                    cb_mode != P::CB_COLOR_CONTROL_MODE_DCC_DECOMPRESS) {
             warn_unsupported_cb_color_mode(cb_mode);

--- a/prosper/src/gpu/render_state.hpp
+++ b/prosper/src/gpu/render_state.hpp
@@ -167,6 +167,11 @@ struct ResolvedPipelineState {
     uint32_t topology         = 0;   // == VkPrimitiveTopology
     uint32_t color0_format    = 0;   // == VkFormat (0 = VK_FORMAT_UNDEFINED)
 
+    // CB_COLOR_CONTROL.MODE == RESOLVE (3): this draw is a hardware MSAA resolve of the color0 (MSAA)
+    // surface into the color1 destination, not an ordinary draw. prosper renders single-sample, so the
+    // live backend implements it as a straight copy of the already-rendered color0 surface into color1.
+    bool     cb_resolve       = false;
+
     // Color-target clear value, decoded from CB_COLOR0_CLEAR_WORD0/1 per the surface format (#309).
     // has_clear_color == the game programmed a fast-clear that we decoded; clear_color is RGBA in
     // Vulkan order (float32[0]=R). When has_clear_color is false the backend clears to opaque black —

--- a/prosper/tests/test_render_state.cpp
+++ b/prosper/tests/test_render_state.cpp
@@ -512,17 +512,31 @@ int main() {
 
         RenderState unsupported2 = absent;
         unsupported2.has_cb_color_control = true;
-        unsupported2.cb_color_control = 2u << P::CB_COLOR_CONTROL_MODE_SHIFT;
-        RenderState unsupported3 = unsupported2;
-        unsupported3.cb_color_control = 3u << P::CB_COLOR_CONTROL_MODE_SHIFT;
+        unsupported2.cb_color_control = 2u << P::CB_COLOR_CONTROL_MODE_SHIFT;  // ELIMINATE_FAST_CLEAR
+        RenderState unsupported5 = unsupported2;
+        unsupported5.cb_color_control = 5u << P::CB_COLOR_CONTROL_MODE_SHIFT;  // still unmodeled
         const std::string mode_diagnostics = capture_stderr([&] {
             (void)resolve_pipeline_state(unsupported2);
             (void)resolve_pipeline_state(unsupported2);
-            (void)resolve_pipeline_state(unsupported3);
+            (void)resolve_pipeline_state(unsupported5);
         });
         CHECK(occurrence_count(mode_diagnostics, "MODE=2 ") == 1u &&
-                  occurrence_count(mode_diagnostics, "MODE=3 ") == 1u,
+                  occurrence_count(mode_diagnostics, "MODE=5 ") == 1u,
               "unmodeled CB modes log once per distinct value while retaining fallback behavior");
+
+        // MODE=RESOLVE(3) is a modeled hardware MSAA resolve: resolve_pipeline_state flags cb_resolve so
+        // the live backend copies color0->color1, and it is NOT warned as unmodeled. Would fail before the
+        // resolve implementation (cb_resolve=false + a "MODE=3 " unmodeled warning).
+        RenderState resolve_mode = absent;
+        resolve_mode.has_cb_color_control = true;
+        resolve_mode.cb_color_control =
+            P::CB_COLOR_CONTROL_MODE_RESOLVE << P::CB_COLOR_CONTROL_MODE_SHIFT;
+        const std::string resolve_diag = capture_stderr([&] {
+            (void)resolve_pipeline_state(resolve_mode);
+        });
+        CHECK(resolve_pipeline_state(resolve_mode).cb_resolve &&
+                  occurrence_count(resolve_diag, "MODE=3 ") == 0u,
+              "CB_COLOR_CONTROL.MODE=RESOLVE flags cb_resolve and is not warned as unmodeled");
     }
 
     // #309: CB fast-clear word extraction + format-aware decode in resolve_pipeline_state.


### PR DESCRIPTION
## Goal / context
Found while investigating Blue Prince (PPSA25009, #1216), which renders a uniform-fill frame. This PR
closes a confirmed GPU-op gap: prosper had **no handling for the RDNA2 hardware MSAA resolve**
(`CB_COLOR_CONTROL.MODE=3`) and is entirely MSAA-agnostic.

## Failure scenario
`resolve_pipeline_state` warned on MODE=3 and treated it as an ordinary draw. A title that renders an MSAA
scene then resolves it never populated the resolved destination the display later samples. New diagnostic
`PROSPER_MSAA_LOG` proved Blue Prince renders its 1920×1080 scene at **4× MSAA**
(`NUM_SAMPLES=4x MSAA_ENABLE=1 CB_MODE=1`, ~17k draws/frame) then issues **MODE=3 RESOLVE** draws
(`MSAA_ENABLE=0 CB_MODE=3`) resolving **color0 (MSAA source) → color1 (single-sample dest)**
(e.g. `0x2026dd0000 → 0x202add0000`, tgtmask=0xf).

## Approach / contract
Since prosper already renders single-sample, the correct emulation of a resolve is a straight copy of the
already-rendered color0 surface into color1:
- **render_state**: new `CB_COLOR_CONTROL_MODE_RESOLVE=3` constant; `resolve_pipeline_state` flags
  `ps.cb_resolve` instead of warning as unmodeled.
- **live_renderer**: on a resolve pass, copy `g_rtt[color0_base] → g_rtt[color1_base]` (shared-ptr pixel
  handle, no deep copy) and skip the ordinary draw.

## Key invariant
The copy uses the **raw `color1_base`**, NOT `active_color1()`: a fixed-function resolve exports nothing, so
its `color1_write_mask` is 0 and `active_color1()` reports no destination (my first attempt was a silent
no-op for exactly this reason — captured in the commit history).

## Affected / unaffected
- **Affected:** only MODE=3 draws, which were previously an unmodeled no-op — no title that renders
  correctly today depends on the old fallback.
- **Unaffected:** all other CB modes; single-sample rendering everywhere else is unchanged.

## Verification (Linux, RADV STRIX_HALO)
- `ctest`: **142/142** including a new `test_render_state` case (MODE=RESOLVE flags `cb_resolve` + is not
  warned; **fails without this change**).
- Live: `[msaa] resolve copy 0x2026dd0000 → 0x202add0000 (1920x1080)` fires under `PROSPER_MSAA_LOG`.
- **Snapshot regression — all 5 titles OK** (no change): terminator-boot, messenger-scene,
  evergate-title (52939 colors), dead-cells-gameplay (10352, 44/44), blasphemous2-gameplay (2259, 98/98).

## Honest scope note
This does **not** by itself fix Blue Prince's uniform frame. With the resolve firing, its display is still
uniform because the resolve **source** (`g_rtt[color0]`, the scene MSAA target) is itself uniform upstream
(a full-screen constant-white fill overwrites the scene / the game is parked on a uniform loading/transition
it never advances past). That upstream issue is tracked in #1216. This PR is a correct, low-risk GPU-op gap
closure and a prerequisite for Blue Prince — not progression evidence.

CONFIDENCE: HIGH on correctness/safety; MED on sufficiency for any single title.