### PR TITLE
tool(gpu): PROSPER_DRAW_STATS — per-draw fragment funnel (pipeline stats + occlusion)

### DIFF
--- a/prosper/docs/MESSENGER_BLACK_RENDER.md
+++ b/prosper/docs/MESSENGER_BLACK_RENDER.md
@@ -126,7 +126,16 @@ On a replayed draw, expose vertex position/color/UV, raw texture samples, consta
 pre-blend fragment output, and final attachment output in a standard report. Existing switches such as
 `PROSPER_RENDER_TESTPS`, `PROSPER_TESTTEX`, `PROSPER_CBUFLOG`, and draw isolation are useful primitives.
 
-**Start localization with `gpu_replay --draw-steps` (visual bisection).** Before probing individual draws,
+**First triage: `PROSPER_DRAW_STATS=1` (the per-draw "fragment funnel").** Before even the visual filmstrip,
+run `PROSPER_DRAW_STATS=1 gpu_replay <capsule> out.bmp`: it wraps every draw in pipeline-statistics + occlusion
+queries and prints one line per draw classifying **where its pixels vanished** — `GEOMETRY-VANISH` (all
+primitives clipped/degenerate/off-screen → a vertex/fetch/transform bug), `NO-RASTER` (cull/scissor/zero-area),
+`TEST-KILLED` (depth/stencil rejected every sample), or `passed-samples` (colour/stencil written). This is
+objective, needs no oracle, and turns "why did this draw render nothing" into a glance instead of a manual
+bisection (it localised GTA V's menu black-wedge defect to a single `GEOMETRY-VANISH` mask draw in one run).
+See `tools/gpu_replay/README.md`. Use it to pick the suspect draw, *then* the filmstrip below to see it.
+
+**Then localize visually with `gpu_replay --draw-steps` (visual bisection).** Before probing individual draws,
 run `gpu_replay --draw-steps PREFIX --draw-steps-target WxH <capsule>` on the scene: it dumps a numbered BMP
 filmstrip of the composite building up per operation-step (plus a `[draw-step]` log with `visible-px`/`hash`),
 so the exact step where the black/wrong composition first appears is found by scrubbing — no oracle needed.

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -432,6 +432,10 @@ struct RenderVkCtx {
     bool aniso_enabled = false; float max_aniso_limit = 1.0f;
     bool logic_op_enabled = false; bool ok = false;
     bool fragment_stores_atomics = false;
+    // Per-draw "fragment funnel" diagnostic (PROSPER_DRAW_STATS): pipeline-statistics + precise
+    // occlusion queries. Enabled at device creation only when advertised; inert otherwise.
+    bool pipeline_stats_enabled = false;
+    bool occlusion_precise = false;
     bool subgroup_size_control = false;
     uint32_t min_subgroup_size = 0, max_subgroup_size = 0;
     VkShaderStageFlags required_subgroup_size_stages = 0;
@@ -486,6 +490,11 @@ inline const RenderVkCtx& render_vk_ctx() {
         feats.vertexPipelineStoresAndAtomics = supported.vertexPipelineStoresAndAtomics;
         feats.fragmentStoresAndAtomics = supported.fragmentStoresAndAtomics;
         r.fragment_stores_atomics = supported.fragmentStoresAndAtomics;
+        // Per-draw fragment-funnel diagnostic (PROSPER_DRAW_STATS): pipeline statistics + precise
+        // occlusion. Enable only when advertised; costs nothing unless the diagnostic is used.
+        feats.pipelineStatisticsQuery = supported.pipelineStatisticsQuery;
+        r.pipeline_stats_enabled = supported.pipelineStatisticsQuery;
+        if (supported.occlusionQueryPrecise) { feats.occlusionQueryPrecise = VK_TRUE; r.occlusion_precise = true; }
         // robustImageAccess (VK_EXT_image_robustness): OpImageRead OOB must return zero (#131). Guarded.
         // Device extensions accumulate into a vector so the (optional) image-robustness and (macOS)
         // portability-subset extensions coexist.
@@ -3429,6 +3438,37 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         for (auto& v : dv) fprintf(stderr, " %s%u", v.ok ? "" : "SKIP", v.icount ? v.icount : v.vcount);
         fprintf(stderr, "\n");
     }
+    // Per-draw "fragment funnel" (PROSPER_DRAW_STATS): wrap each recorded draw in pipeline-statistics
+    // + occlusion queries to show WHERE its pixels vanish (geometry clipped away, never rasterized,
+    // depth/stencil-rejected, or survived) — objective per-draw truth, no oracle needed. Read-only, and
+    // only active with the env var AND a real flush in THIS call (so the results are ready to read back;
+    // the flush condition below is identical to `flush_now` computed after the pass). Query-pool RESET
+    // must be recorded outside a render pass, so it happens here.
+    const RenderVkCtx& ds_ctx = render_vk_ctx();
+    const bool draw_stats = getenv("PROSPER_DRAW_STATS") && ds_ctx.pipeline_stats_enabled && !dv.empty()
+                            && (!submission_batch || readback_requested || flush_submission_batch);
+    VkQueryPool ds_stats_pool = VK_NULL_HANDLE, ds_occ_pool = VK_NULL_HANDLE;
+    if (draw_stats) {
+        const uint32_t nq = static_cast<uint32_t>(dv.size());
+        VkQueryPoolCreateInfo sp{VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO};
+        sp.queryType = VK_QUERY_TYPE_PIPELINE_STATISTICS; sp.queryCount = nq;
+        sp.pipelineStatistics =
+            VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_VERTICES_BIT |
+            VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_PRIMITIVES_BIT |
+            VK_QUERY_PIPELINE_STATISTIC_CLIPPING_PRIMITIVES_BIT |
+            VK_QUERY_PIPELINE_STATISTIC_FRAGMENT_SHADER_INVOCATIONS_BIT;
+        VkQueryPoolCreateInfo op{VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO};
+        op.queryType = VK_QUERY_TYPE_OCCLUSION; op.queryCount = nq;
+        if (vkCreateQueryPool(dev, &sp, nullptr, &ds_stats_pool) == VK_SUCCESS &&
+            vkCreateQueryPool(dev, &op, nullptr, &ds_occ_pool) == VK_SUCCESS) {
+            vkCmdResetQueryPool(cmd, ds_stats_pool, 0, nq);
+            vkCmdResetQueryPool(cmd, ds_occ_pool, 0, nq);
+        } else {
+            if (ds_stats_pool) { vkDestroyQueryPool(dev, ds_stats_pool, nullptr); ds_stats_pool = VK_NULL_HANDLE; }
+            if (ds_occ_pool)   { vkDestroyQueryPool(dev, ds_occ_pool,   nullptr); ds_occ_pool   = VK_NULL_HANDLE; }
+        }
+    }
+    const bool ds_active = ds_stats_pool != VK_NULL_HANDLE && ds_occ_pool != VK_NULL_HANDLE;
     // ONE render pass (cleared once): record every realized draw with its own pipeline + descriptors.
     vkCmdBeginRenderPass(cmd, &rpbi, VK_SUBPASS_CONTENTS_INLINE);
     for (size_t di = 0; di < dv.size(); di++) {
@@ -3447,6 +3487,11 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                 vkCmdClearAttachments(cmd, 1, &dsc, 1, &rect);
         }
         if (!v.ok) continue;
+        if (ds_active) {
+            vkCmdBeginQuery(cmd, ds_stats_pool, static_cast<uint32_t>(di), 0);
+            vkCmdBeginQuery(cmd, ds_occ_pool, static_cast<uint32_t>(di),
+                            ds_ctx.occlusion_precise ? VK_QUERY_CONTROL_PRECISE_BIT : 0);
+        }
         vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, v.pipe);
         vkCmdSetScissor(cmd, 0, 1, &v.scissor);
         if (v.use_desc) vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, v.layout, 0, v.n_sets, v.dsets.data(), 0, nullptr);
@@ -3455,6 +3500,10 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
             vkCmdDrawIndexed(cmd, v.icount, v.instance_count, 0, 0, 0);
         } else {
             vkCmdDraw(cmd, v.vcount, v.instance_count, 0, 0);
+        }
+        if (ds_active) {
+            vkCmdEndQuery(cmd, ds_occ_pool, static_cast<uint32_t>(di));
+            vkCmdEndQuery(cmd, ds_stats_pool, static_cast<uint32_t>(di));
         }
     }
     vkCmdEndRenderPass(cmd);
@@ -3614,6 +3663,45 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     const auto timing_gpu_done = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
     const bool batch_completed = !flush_now ||
         (batch_result.submit_result == VK_SUCCESS && batch_result.wait_result == VK_SUCCESS);
+
+    // Fragment-funnel readback (PROSPER_DRAW_STATS): one line per realized draw showing where its
+    // pixels vanished. ds_active implies flush_now (the pool-creation gate above uses the same flush
+    // condition), so `cmd` has completed and the results are ready. Pools are destroyed unconditionally.
+    if (ds_active) {
+        const uint32_t nq = static_cast<uint32_t>(dv.size());
+        if (batch_completed) {
+            std::vector<uint64_t> sres(static_cast<size_t>(nq) * 5, 0);  // 4 statistics + availability
+            std::vector<uint64_t> ores(static_cast<size_t>(nq) * 2, 0);  // occlusion samples + availability
+            vkGetQueryPoolResults(dev, ds_stats_pool, 0, nq, sres.size() * sizeof(uint64_t), sres.data(),
+                                  5 * sizeof(uint64_t),
+                                  VK_QUERY_RESULT_64_BIT | VK_QUERY_RESULT_WITH_AVAILABILITY_BIT);
+            vkGetQueryPoolResults(dev, ds_occ_pool, 0, nq, ores.size() * sizeof(uint64_t), ores.data(),
+                                  2 * sizeof(uint64_t),
+                                  VK_QUERY_RESULT_64_BIT | VK_QUERY_RESULT_WITH_AVAILABILITY_BIT);
+            for (uint32_t i = 0; i < nq; i++) {
+                if (!sres[i * 5 + 4]) continue;  // unavailable -> draw was skipped (v.ok == false)
+                const uint64_t verts = sres[i * 5 + 0], prims = sres[i * 5 + 1],
+                               clip = sres[i * 5 + 2], fs = sres[i * 5 + 3];
+                const uint64_t samp = ores[i * 2 + 1] ? ores[i * 2 + 0] : 0;
+                // Funnel classification, checked in pipeline order. `samples` (occlusion) is the ground
+                // truth for "survived the depth+stencil test" — it is counted even when the fragment
+                // shader is optimised out for a colour-write-disabled (stencil-only) draw, so it must be
+                // tested before fs_inv or such draws look falsely dead.
+                const char* tag =
+                    (prims == 0) ? "NO-GEOMETRY(no primitives)" :
+                    (clip  == 0) ? "GEOMETRY-VANISH(clipped/degenerate/offscreen)" :
+                    (samp  >  0) ? "passed-samples(colour/stencil written)" :
+                    (fs    >  0) ? "TEST-KILLED(depth/stencil rejected all)" :
+                                   "NO-RASTER(cull/scissor/zero-area)";
+                fprintf(stderr,
+                        "[draw-stats] draw=%u verts=%llu prims=%llu after_clip=%llu fs_inv=%llu samples=%llu %s\n",
+                        i, (unsigned long long)verts, (unsigned long long)prims,
+                        (unsigned long long)clip, (unsigned long long)fs, (unsigned long long)samp, tag);
+            }
+        }
+        vkDestroyQueryPool(dev, ds_stats_pool, nullptr);
+        vkDestroyQueryPool(dev, ds_occ_pool, nullptr);
+    }
 
     if (readback_requested && batch_completed) {
         void* mp = nullptr; vkMapMemory(dev, bmem, 0, readback_bytes, 0, &mp);

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -84,6 +84,34 @@ expected hash. `--allow-mismatch` is for an intentional differential such as `--
 ./build-linux/gpu_replay --dump-failed-shader 0:1 /tmp/failed-fragment.bin /tmp/submit.prgcap
 ```
 
+## Per-draw "fragment funnel" — `PROSPER_DRAW_STATS` (first thing to run on a missing/wrong draw)
+
+```bash
+PROSPER_DRAW_STATS=1 ./build-linux/gpu_replay /tmp/submit.prgcap /tmp/out.bmp
+# [draw-stats] draw=4 verts=1024 prims=341 after_clip=0   fs_inv=0      samples=0        GEOMETRY-VANISH(...)
+# [draw-stats] draw=5 verts=1024 prims=341 after_clip=68  fs_inv=0      samples=12102811 passed-samples(...)
+```
+
+Wraps every realized draw in Vulkan pipeline-statistics + occlusion queries and prints one line per draw
+showing **where its pixels vanished** — objective per-draw truth, no oracle needed. A GPU draw can only
+disappear in four places, and this pinpoints which:
+
+- `prims>0, after_clip=0` → **GEOMETRY-VANISH**: every primitive was clipped/degenerate/off-screen (a
+  vertex-shader / vertex-fetch / transform problem — the geometry never reached the rasteriser).
+- `after_clip>0, samples=0, fs_inv=0` → **NO-RASTER**: rasteriser produced no fragments (backface cull,
+  empty scissor, zero-area).
+- `after_clip>0, samples=0, fs_inv>0` → **TEST-KILLED**: fragments ran but the depth/stencil test rejected
+  every sample.
+- `samples>0` → **passed-samples**: colour and/or stencil was written (for a colour-write-disabled
+  stencil-only draw `fs_inv` is 0 because the fragment shader is optimised out, but `samples` still counts —
+  which is why `samples` is the ground truth for "survived", checked before `fs_inv`).
+
+This is the fastest first-order triage for "why did this draw render nothing/wrong": it replaces manual
+`--through-operation` bisection with a single glance. Localised GTA V's menu black-wedge defect (a stencil-
+counting clip whose first mask draw came back `GEOMETRY-VANISH`) in one run. Requires the device to advertise
+`pipelineStatisticsQuery`; inert (no output, no cost, byte-identical rendering) when the env var is unset.
+Works on both `gpu_replay` and the live app because it lives in the shared render path.
+
 `--dump-shader DRAW:vs|fs PATH` writes the recompiled SPIR-V. Capture v19 adds
 `--dump-realized-shader DRAW:vs|fs PATH` for the exact bounded raw RDNA2 stream that produced that realized
 draw stage, suitable for `shader_inspect`. The VS/FS streams use the same content-addressed 64 KiB-per-stage,


### PR DESCRIPTION
## Summary
Adds `PROSPER_DRAW_STATS` — a per-draw **"fragment funnel"** diagnostic in the shared render path. It wraps every realized draw in Vulkan pipeline-statistics + occlusion queries and prints one line per draw classifying **where its pixels vanished**:

```
[draw-stats] draw=4 verts=1024 prims=341 after_clip=0   fs_inv=0      samples=0        GEOMETRY-VANISH(...)
[draw-stats] draw=5 verts=1024 prims=341 after_clip=68  fs_inv=0      samples=12102811 passed-samples(...)
```

## Why
A GPU draw can only disappear in four places, and oracle screenshots can't distinguish them. Pipeline-statistics + occlusion queries can — objectively, no oracle. The tag:
- `prims>0, after_clip=0` → **GEOMETRY-VANISH** (clipped/degenerate/off-screen → vertex/fetch/transform bug)
- `after_clip>0, samples=0, fs_inv=0` → **NO-RASTER** (cull/scissor/zero-area)
- `after_clip>0, samples=0, fs_inv>0` → **TEST-KILLED** (depth/stencil rejected all)
- `samples>0` → **passed-samples** (colour/stencil written)

`samples` (occlusion) is the ground truth for "survived" and is checked before `fs_inv`, because a colour-write-disabled stencil-only draw has its FS optimised out (`fs_inv=0`) yet still rasterises and passes.

This replaces manual `--through-operation` bisection with a single glance. It localised the GTA V menu black-wedge defect (#1231) in one run — the first stencil-mask draw per panel came back `GEOMETRY-VANISH (after_clip=0)`, objectively proving the stencil count never reaches its target because that draw's geometry is entirely clipped away (previously ~15 commands of manual triage).

## Behavioral contract
- **No behavioral change.** With `PROSPER_DRAW_STATS` unset, `ds_active` is false, no queries are recorded, no output is emitted, and the render is byte-identical (verified: GTA V menu submit hash `670576577254c2e8` unchanged).
- Device creation now enables `pipelineStatisticsQuery` + `occlusionQueryPrecise` **only when the device advertises them** (guarded like the other optional features). Enabling a query feature does not change render output.
- Query pools are created/reset before the render pass and destroyed after readback, and only when the env var is set **AND** this call flushes+waits (same condition as `flush_now`), so results are always ready before readback and there is no use-after-free on the batched (non-flushing) path.
- Lives in the shared `render_runner.h` path → works for both `gpu_replay` and the live app.

## Affected / unaffected
- Affected: `prosper/tests/render_runner.h` (device features + gated query wrapping + readback), docs.
- Unaffected: all rendering/capture behavior with the env var unset; every existing render path is byte-identical.

## Verification
- Full build clean; **ctest 138/140** — the 2 failures (`module_loads_eboot`, `boot_reaches_first_syscall`) are dump-dependent boot/loader tests (`cannot open file` for eboot/IL2CPP modules) unrelated to the GPU render path; **all GPU render tests pass**.
- Default-path render **byte-identical** (hash `670576577254c2e8`), zero `[draw-stats]` output when unset.
- Demonstrated on the GTA V menu capsule: correctly classifies GEOMETRY-VANISH / passed-samples / NO-RASTER per draw.
- Snapshot guard not run: the change is provably non-behavioral on the default path (byte-identical hash) and this build is dump-configured for GTA V, not the snapshot titles; the byte-identical hash is the definitive evidence that rendered output is unaffected.

## Risk
Low — read-only, env-gated, guarded device-feature enable. The one thing worth a reviewer's eye is the query lifetime/flush gating (that `ds_active` implies a flush in this call).
