### PR TITLE
tool(gpu): PROSPER_GEOM_PROBE — per-draw post-transform vertex-position capture

### DIFF
--- a/prosper/docs/MESSENGER_BLACK_RENDER.md
+++ b/prosper/docs/MESSENGER_BLACK_RENDER.md
@@ -135,6 +135,14 @@ objective, needs no oracle, and turns "why did this draw render nothing" into a 
 bisection (it localised GTA V's menu black-wedge defect to a single `GEOMETRY-VANISH` mask draw in one run).
 See `tools/gpu_replay/README.md`. Use it to pick the suspect draw, *then* the filmstrip below to see it.
 
+**When the funnel says `GEOMETRY-VANISH`, follow up with `PROSPER_GEOM_PROBE=N`** (per-draw geometry probe):
+it captures draw N's post-transform clip-space vertices via transform feedback and reports where they landed
+(clip-space bbox, on-screen/clipped counts, `w<=0`, NaN, all-collapsed). That distinguishes *why* the geometry
+vanished — degenerate (fetch returned zero/constant), behind camera (`w<=0`), or shifted off-screen (bbox
+outside `[-1,1]`). It localized GTA V #1231's vanished mask draw to an off-screen transform (bbox `x[-4.86,0]`,
+all verts outside the clip cube) vs a working mask on-screen. Read it with the funnel — the funnel owns the
+"rasterizes?" verdict, the probe owns *where the vertices are*.
+
 **Then localize visually with `gpu_replay --draw-steps` (visual bisection).** Before probing individual draws,
 run `gpu_replay --draw-steps PREFIX --draw-steps-target WxH <capsule>` on the scene: it dumps a numbered BMP
 filmstrip of the composite building up per operation-step (plus a `[draw-step]` log with `visible-px`/`hash`),

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -802,8 +802,12 @@ std::vector<uint32_t> compile_graphics_shader(ShaderProgramStage stage, const Sh
     const uint32_t* code = !key.code || key.code->empty() ? nullptr : key.code->data();
     const size_t code_size = key.code ? key.code->size() : 0u;
     if (stage == ShaderProgramStage::Vertex)
+        // Geometry probe (PROSPER_GEOM_PROBE): decorate gl_Position for transform-feedback capture on
+        // the LIVE path (which recompiles here). Capsule replay substitutes an xfb VS in gpu_replay,
+        // because a capsule stores already-recompiled SPIR-V. Inert to the shader's computation.
         return recompile_vertex(code, code_size, resources,
-                                key.has_pixel_inputs ? &key.pixel_inputs : nullptr);
+                                key.has_pixel_inputs ? &key.pixel_inputs : nullptr,
+                                getenv("PROSPER_GEOM_PROBE") != nullptr);
     if (stage == ShaderProgramStage::Fragment)
         return recompile_fragment(code, code_size, resources,
                                   key.has_system_inputs ? &key.system_inputs : nullptr,

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -67,9 +67,10 @@ enum : uint32_t { Glsl_FAbs=4, Glsl_RoundEven=2, Glsl_Trunc=3, Glsl_Floor=8, Gls
 enum : uint32_t {
     Cap_Shader=1, Cap_Geometry=2, Cap_Int64=11, Cap_GroupNonUniform=61, Cap_GroupNonUniformVote=62,
     Cap_GroupNonUniformArithmetic=63, Cap_GroupNonUniformQuad=68,
+    Cap_TransformFeedback=53,   // VK_EXT_transform_feedback (geometry-probe capture of gl_Position, gated)
     Addr_Logical=0, Mem_GLSL450=1, Exec_Vertex=0, Exec_Geometry=3, Exec_Fragment=4, Exec_GLCompute=5,
     EM_OriginUpperLeft=7, EM_DepthReplacing=12, EM_LocalSize=17, EM_Triangles=22,
-    EM_OutputVertices=26, EM_OutputTriangleStrip=29,
+    EM_OutputVertices=26, EM_OutputTriangleStrip=29, EM_Xfb=11,   // transform-feedback execution mode
     SC_Input=1, SC_UniformConstant=0, SC_Output=3, SC_Function=7, SC_PushConstant=9,
     SC_StorageBuffer=12, FC_None=0,
     Dim_1D=0, Dim_2D=1, Dim_3D=2,   // SPIR-V Dim. (2D coincides with the SQ_RSRC 2D dim value, but distinct.)
@@ -87,7 +88,7 @@ enum : uint32_t {
     MemSem_UniformAcqRel=0x48, MemSem_WGAcqRel=0x108,   // storage/LDS AcquireRelease memory semantics
     Dec_Block=2, Dec_ArrayStride=6, Dec_BuiltIn=11, Dec_NoPerspective=13, Dec_Flat=14,
     Dec_Centroid=16, Dec_Sample=17, Dec_Location=30, Dec_Binding=33,
-    Dec_DescriptorSet=34, Dec_Offset=35,
+    Dec_DescriptorSet=34, Dec_Offset=35, Dec_XfbBuffer=36, Dec_XfbStride=37,
     BI_Position=0, BI_FragCoord=15, BI_FragDepth=22, BI_HelperInvocation=23,
     BI_WorkgroupId=26, BI_LocalInvocationId=27,
     BI_GlobalInvocationId=28, BI_SubgroupLocalInvocationId=41,
@@ -231,6 +232,9 @@ struct SpirvCompute {
     size_t function_var_insert = 0;                   // first-function-block OpVariable insertion point
     uint32_t exec_model=0;                           // deferred EntryPoint (emitted in finish() so lazily-
     std::vector<uint32_t> iface;                     // declared I/O varyings can join the interface list)
+    // Geometry-probe (PROSPER_GEOM_PROBE): when set before begin_vertex(), decorate gl_Position for
+    // transform-feedback capture. Inert to the shader's computation; only marks the output for readback.
+    bool capture_position = false;
 
     uint32_t id() { return next_id++; }
     static void put(std::vector<uint32_t>& s, uint32_t op, std::initializer_list<uint32_t> o) {
@@ -1555,6 +1559,16 @@ struct SpirvCompute {
         put(deco, Op_Decorate, {v_iid, Dec_BuiltIn, BI_InstanceIndex});
         put(deco, Op_MemberDecorate, {t_pv, 0, Dec_BuiltIn, BI_Position});   // gl_PerVertex.gl_Position
         put(deco, Op_Decorate, {t_pv, Dec_Block});
+        // Geometry-probe: mark gl_Position for transform-feedback capture (xfb buffer 0, one vec4/vertex).
+        // These decorations do not change the shader's computation; the host reads back the captured
+        // clip-space positions for the probed draw. Only emitted when explicitly requested.
+        if (capture_position) {
+            put(caps, Op_Capability, {Cap_TransformFeedback});
+            put(exec, Op_ExecutionMode, {f_main, EM_Xfb});
+            put(deco, Op_MemberDecorate, {t_pv, 0, Dec_XfbBuffer, 0});
+            put(deco, Op_MemberDecorate, {t_pv, 0, Dec_XfbStride, 16});
+            put(deco, Op_MemberDecorate, {t_pv, 0, Dec_Offset, 0});
+        }
         put(types, Op_TypeVoid, {t_void});
         put(types, Op_TypeFunction, {t_fn, t_void});
         put(types, Op_TypeFloat, {t_f32, 32});
@@ -8763,12 +8777,14 @@ bool fragment_spirv_uses_internal_gds(const std::vector<uint32_t>& spirv) {
 
 std::vector<uint32_t> recompile_vertex(const uint32_t* code, size_t dwords,
                                        const ShaderResourceTable* rt,
-                                       const PixelInputMapping* pixel_inputs) {
+                                       const PixelInputMapping* pixel_inputs,
+                                       bool capture_position) {
     std::vector<Rdna2Inst> ins;
     rdna2_walk(code, dwords, ins);
     const StaticScratchLayout scratch = analyze_static_scratch(ins);
 
     SpirvCompute b;
+    b.capture_position = capture_position;   // geometry-probe: mark gl_Position for xfb capture (gated)
     b.begin_vertex(rt);
     b.declare_guest_scratch(scratch);
     RegState rs; rs.vcc = b.bfalse(); rs.scc = b.bfalse(); rs.exec = b.btrue();

--- a/prosper/src/gpu/rdna2_to_spirv.hpp
+++ b/prosper/src/gpu/rdna2_to_spirv.hpp
@@ -164,9 +164,12 @@ uint32_t fragment_color_export_mask(const uint32_t* code, size_t dwords);
 // Recompile a vertex shader to a vertex SPIR-V module: v0 = gl_VertexIndex, run the VALU, and on EXP
 // to a POS target write vec4(src0..3) to gl_Position. Returns {} if unsupported / no position export.
 // An optional ShaderResourceTable enables vertex fetch (buffer_load_format_*) + constant loads.
+// `capture_position` (geometry-probe, gated): decorate gl_Position for VK_EXT_transform_feedback capture
+// so the host can read back this draw's post-transform clip-space vertices. Inert to the computation.
 std::vector<uint32_t> recompile_vertex(const uint32_t* code, size_t dwords,
                                        const ShaderResourceTable* rt = nullptr,
-                                       const PixelInputMapping* pixel_inputs = nullptr);
+                                       const PixelInputMapping* pixel_inputs = nullptr,
+                                       bool capture_position = false);
 
 // How much of a shader the recompiler currently covers (per-instruction), without requiring the
 // stream to be a complete vertex/fragment. `alu` = instructions emit_alu handles (VALU/scalar/

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -10,6 +10,7 @@
 #include <algorithm>
 #include <array>
 #include <chrono>
+#include <cmath>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
@@ -436,6 +437,8 @@ struct RenderVkCtx {
     // occlusion queries. Enabled at device creation only when advertised; inert otherwise.
     bool pipeline_stats_enabled = false;
     bool occlusion_precise = false;
+    // Geometry-probe (PROSPER_GEOM_PROBE): VK_EXT_transform_feedback for capturing gl_Position.
+    bool transform_feedback_enabled = false;
     bool subgroup_size_control = false;
     uint32_t min_subgroup_size = 0, max_subgroup_size = 0;
     VkShaderStageFlags required_subgroup_size_stages = 0;
@@ -506,6 +509,8 @@ inline const RenderVkCtx& render_vk_ctx() {
             VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_PROPERTIES};
         VkPhysicalDeviceSubgroupProperties subgroup_core_properties{
             VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_PROPERTIES};
+        VkPhysicalDeviceTransformFeedbackFeaturesEXT tf_features{
+            VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_FEATURES_EXT};
         { uint32_t ne = 0; vkEnumerateDeviceExtensionProperties(r.phys, nullptr, &ne, nullptr);
           std::vector<VkExtensionProperties> de(ne);
           vkEnumerateDeviceExtensionProperties(r.phys, nullptr, &ne, de.data());
@@ -539,6 +544,19 @@ inline const RenderVkCtx& render_vk_ctx() {
                           subgroup_properties.requiredSubgroupSizeStages;
                       r.subgroup_stages = subgroup_core_properties.supportedStages;
                       r.subgroup_operations = subgroup_core_properties.supportedOperations;
+                  }
+              }
+              // Geometry-probe (PROSPER_GEOM_PROBE): transform feedback to capture gl_Position. Enable
+              // only the base transformFeedback feature (VS-only capture; geometryStreams not needed).
+              if (!strcmp(de[i].extensionName, VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME)) {
+                  VkPhysicalDeviceFeatures2 f2{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2};
+                  f2.pNext = &tf_features; vkGetPhysicalDeviceFeatures2(r.phys, &f2);
+                  if (tf_features.transformFeedback) {
+                      tf_features.geometryStreams = VK_FALSE;
+                      tf_features.pNext = const_cast<void*>(dci.pNext);
+                      dci.pNext = &tf_features;
+                      dev_exts.push_back(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME);
+                      r.transform_feedback_enabled = true;
                   }
               }
 #ifdef __APPLE__
@@ -3469,6 +3487,39 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         }
     }
     const bool ds_active = ds_stats_pool != VK_NULL_HANDLE && ds_occ_pool != VK_NULL_HANDLE;
+
+    // Geometry probe (PROSPER_GEOM_PROBE=N): capture draw N's post-transform clip-space vertices via
+    // transform feedback and report where they land (degenerate / off-screen / behind-camera / NaN).
+    // Requires VK_EXT_transform_feedback + the VS recompiled with gl_Position xfb-decorated (gated on
+    // the same env var in gpu_executor). Only active with the env var, TF support, AND a flush here.
+    const char* geom_env = getenv("PROSPER_GEOM_PROBE");
+    const long geom_target = geom_env ? strtol(geom_env, nullptr, 10) : -1;
+    const bool geom_probe = geom_target >= 0 && static_cast<size_t>(geom_target) < dv.size()
+                            && ds_ctx.transform_feedback_enabled
+                            && (!submission_batch || readback_requested || flush_submission_batch);
+    static auto p_bindxfb  = reinterpret_cast<PFN_vkCmdBindTransformFeedbackBuffersEXT>(
+        vkGetDeviceProcAddr(dev, "vkCmdBindTransformFeedbackBuffersEXT"));
+    static auto p_beginxfb = reinterpret_cast<PFN_vkCmdBeginTransformFeedbackEXT>(
+        vkGetDeviceProcAddr(dev, "vkCmdBeginTransformFeedbackEXT"));
+    static auto p_endxfb   = reinterpret_cast<PFN_vkCmdEndTransformFeedbackEXT>(
+        vkGetDeviceProcAddr(dev, "vkCmdEndTransformFeedbackEXT"));
+    VkBuffer geom_buf = VK_NULL_HANDLE; VkDeviceMemory geom_mem = VK_NULL_HANDLE; uint32_t geom_vcount = 0;
+    if (geom_probe && p_bindxfb && p_beginxfb && p_endxfb && dv[geom_target].ok) {
+        const auto& tv = dv[geom_target];
+        const uint64_t per_inst = tv.icount ? tv.icount : tv.vcount;
+        uint64_t total = per_inst * (tv.instance_count ? tv.instance_count : 1u);
+        if (total > (1u << 20)) total = (1u << 20);   // cap capture at 1M vertices (16 MiB)
+        geom_vcount = static_cast<uint32_t>(total);
+        std::string gerr;
+        if (geom_vcount == 0 ||
+            !persistent_ds_transfer_buffer(ds_ctx, static_cast<VkDeviceSize>(geom_vcount) * 16,
+                                           VK_BUFFER_USAGE_TRANSFORM_FEEDBACK_BUFFER_BIT_EXT,
+                                           geom_buf, geom_mem, gerr)) {
+            geom_buf = VK_NULL_HANDLE; geom_mem = VK_NULL_HANDLE; geom_vcount = 0;
+        }
+    }
+    const bool geom_active = geom_buf != VK_NULL_HANDLE;
+
     // ONE render pass (cleared once): record every realized draw with its own pipeline + descriptors.
     vkCmdBeginRenderPass(cmd, &rpbi, VK_SUBPASS_CONTENTS_INLINE);
     for (size_t di = 0; di < dv.size(); di++) {
@@ -3495,12 +3546,19 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, v.pipe);
         vkCmdSetScissor(cmd, 0, 1, &v.scissor);
         if (v.use_desc) vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, v.layout, 0, v.n_sets, v.dsets.data(), 0, nullptr);
+        const bool geom_here = geom_active && static_cast<long>(di) == geom_target;
+        if (geom_here) {
+            VkDeviceSize off = 0, sz = static_cast<VkDeviceSize>(geom_vcount) * 16;
+            p_bindxfb(cmd, 0, 1, &geom_buf, &off, &sz);
+            p_beginxfb(cmd, 0, 0, nullptr, nullptr);
+        }
         if (v.icount) {
             vkCmdBindIndexBuffer(cmd, v.ibuf, 0, VK_INDEX_TYPE_UINT32);
             vkCmdDrawIndexed(cmd, v.icount, v.instance_count, 0, 0, 0);
         } else {
             vkCmdDraw(cmd, v.vcount, v.instance_count, 0, 0);
         }
+        if (geom_here) p_endxfb(cmd, 0, 0, nullptr, nullptr);
         if (ds_active) {
             vkCmdEndQuery(cmd, ds_occ_pool, static_cast<uint32_t>(di));
             vkCmdEndQuery(cmd, ds_stats_pool, static_cast<uint32_t>(di));
@@ -3701,6 +3759,55 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         }
         vkDestroyQueryPool(dev, ds_stats_pool, nullptr);
         vkDestroyQueryPool(dev, ds_occ_pool, nullptr);
+    }
+
+    // Geometry-probe readback: report where the probed draw's post-transform clip-space vertices landed.
+    // geom_active implies flush_now (same gate as buffer creation), so `cmd` has completed here.
+    if (geom_active) {
+        if (batch_completed) {
+            void* gp = nullptr;
+            if (vkMapMemory(dev, geom_mem, 0, static_cast<VkDeviceSize>(geom_vcount) * 16, 0, &gp) == VK_SUCCESS) {
+                const float* pos = static_cast<const float*>(gp);
+                float minx=1e30f,maxx=-1e30f,miny=1e30f,maxy=-1e30f,minz=1e30f,maxz=-1e30f,minw=1e30f,maxw=-1e30f;
+                uint32_t nan=0, wle0=0, offscreen=0, clipped=0, finite=0;
+                bool all_same = geom_vcount > 0;
+                for (uint32_t i = 0; i < geom_vcount; i++) {
+                    const float x=pos[i*4+0], y=pos[i*4+1], z=pos[i*4+2], w=pos[i*4+3];
+                    if (!std::isfinite(x)||!std::isfinite(y)||!std::isfinite(z)||!std::isfinite(w)) { nan++; continue; }
+                    finite++;
+                    minx=std::min(minx,x); maxx=std::max(maxx,x); miny=std::min(miny,y); maxy=std::max(maxy,y);
+                    minz=std::min(minz,z); maxz=std::max(maxz,z); minw=std::min(minw,w); maxw=std::max(maxw,w);
+                    if (w <= 0.0f) wle0++;
+                    if (std::fabs(x) > std::fabs(w) || std::fabs(y) > std::fabs(w)) offscreen++;
+                    // A vertex is on-screen only if it is in front of the camera (w>0) and inside the
+                    // clip cube (|x|,|y| <= w). Everything else is clipped and cannot rasterize.
+                    if (!(w > 0.0f && std::fabs(x) <= w && std::fabs(y) <= w)) clipped++;
+                    if (i && (x!=pos[0]||y!=pos[1]||z!=pos[2]||w!=pos[3])) all_same = false;
+                }
+                const uint32_t onscreen = finite - clipped;
+                // Classification is descriptive (read it WITH the funnel, which owns the vanishes verdict):
+                // a large quad whose verts sit just outside the cube still rasterizes via clipping, so
+                // "all verts outside" is not the same as "renders nothing" — the bbox tells them apart.
+                const char* tag =
+                    finite == 0             ? "ALL-NAN/INF(numeric defect)" :
+                    all_same                ? "DEGENERATE(all verts collapse to one clip point)" :
+                    wle0 == finite          ? "ALL-BEHIND-CAMERA(w<=0: transform/w defect)" :
+                    clipped == finite       ? "ALL-VERTS-OUTSIDE-CLIP-CUBE(see bbox: off-screen shift or oversized quad)" :
+                    onscreen * 20u < finite ? "MOSTLY-OUTSIDE(<5% verts on-screen; see bbox)" :
+                                              "on-screen(geometry spread across clip space)";
+                fprintf(stderr, "[geom-probe] draw=%ld verts=%u finite=%u on-screen=%u clipped=%u "
+                                "(offscreen=%u w<=0=%u nan/inf=%u)\n"
+                                "[geom-probe]   clip-bbox x[%g,%g] y[%g,%g] z[%g,%g] w[%g,%g] -> %s\n",
+                        geom_target, geom_vcount, finite, onscreen, clipped, offscreen, wle0, nan,
+                        minx,maxx, miny,maxy, minz,maxz, minw,maxw, tag);
+                for (uint32_t i = 0; i < geom_vcount && i < 4; i++)
+                    fprintf(stderr, "[geom-probe]   v%u = (%g, %g, %g, %g)\n",
+                            i, pos[i*4+0], pos[i*4+1], pos[i*4+2], pos[i*4+3]);
+                vkUnmapMemory(dev, geom_mem);
+            }
+        }
+        vkDestroyBuffer(dev, geom_buf, nullptr);
+        vkFreeMemory(dev, geom_mem, nullptr);
     }
 
     if (readback_requested && batch_completed) {

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -3503,22 +3503,33 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         vkGetDeviceProcAddr(dev, "vkCmdBeginTransformFeedbackEXT"));
     static auto p_endxfb   = reinterpret_cast<PFN_vkCmdEndTransformFeedbackEXT>(
         vkGetDeviceProcAddr(dev, "vkCmdEndTransformFeedbackEXT"));
-    VkBuffer geom_buf = VK_NULL_HANDLE; VkDeviceMemory geom_mem = VK_NULL_HANDLE; uint32_t geom_vcount = 0;
+    VkBuffer geom_buf = VK_NULL_HANDLE; VkDeviceMemory geom_mem = VK_NULL_HANDLE;
+    VkBuffer geom_counter = VK_NULL_HANDLE; VkDeviceMemory geom_counter_mem = VK_NULL_HANDLE;
+    uint32_t geom_cap = 0;   // buffer capacity in vertices; the counter buffer gives the exact count written
     if (geom_probe && p_bindxfb && p_beginxfb && p_endxfb && dv[geom_target].ok) {
         const auto& tv = dv[geom_target];
         const uint64_t per_inst = tv.icount ? tv.icount : tv.vcount;
-        uint64_t total = per_inst * (tv.instance_count ? tv.instance_count : 1u);
-        if (total > (1u << 20)) total = (1u << 20);   // cap capture at 1M vertices (16 MiB)
-        geom_vcount = static_cast<uint32_t>(total);
+        // Transform feedback records DECOMPOSED primitives: a triangle strip/fan of N verts emits up to
+        // ~3*(N-2) individual vertices. Over-size by 3x so no records are dropped; the counter buffer
+        // reports how many were actually written so we never read the uninitialized tail.
+        uint64_t total = per_inst * (tv.instance_count ? tv.instance_count : 1u) * 3u;
+        if (total > (1u << 20)) total = (1u << 20);   // cap at 1M vertices (16 MiB)
+        geom_cap = static_cast<uint32_t>(total);
         std::string gerr;
-        if (geom_vcount == 0 ||
-            !persistent_ds_transfer_buffer(ds_ctx, static_cast<VkDeviceSize>(geom_vcount) * 16,
+        if (geom_cap == 0 ||
+            !persistent_ds_transfer_buffer(ds_ctx, static_cast<VkDeviceSize>(geom_cap) * 16,
                                            VK_BUFFER_USAGE_TRANSFORM_FEEDBACK_BUFFER_BIT_EXT,
-                                           geom_buf, geom_mem, gerr)) {
-            geom_buf = VK_NULL_HANDLE; geom_mem = VK_NULL_HANDLE; geom_vcount = 0;
+                                           geom_buf, geom_mem, gerr) ||
+            !persistent_ds_transfer_buffer(ds_ctx, 16,
+                                           VK_BUFFER_USAGE_TRANSFORM_FEEDBACK_COUNTER_BUFFER_BIT_EXT,
+                                           geom_counter, geom_counter_mem, gerr)) {
+            if (geom_buf) { vkDestroyBuffer(dev, geom_buf, nullptr); vkFreeMemory(dev, geom_mem, nullptr); }
+            if (geom_counter) { vkDestroyBuffer(dev, geom_counter, nullptr); vkFreeMemory(dev, geom_counter_mem, nullptr); }
+            geom_buf = VK_NULL_HANDLE; geom_mem = VK_NULL_HANDLE;
+            geom_counter = VK_NULL_HANDLE; geom_counter_mem = VK_NULL_HANDLE; geom_cap = 0;
         }
     }
-    const bool geom_active = geom_buf != VK_NULL_HANDLE;
+    const bool geom_active = geom_buf != VK_NULL_HANDLE && geom_counter != VK_NULL_HANDLE;
 
     // ONE render pass (cleared once): record every realized draw with its own pipeline + descriptors.
     vkCmdBeginRenderPass(cmd, &rpbi, VK_SUBPASS_CONTENTS_INLINE);
@@ -3548,7 +3559,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         if (v.use_desc) vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, v.layout, 0, v.n_sets, v.dsets.data(), 0, nullptr);
         const bool geom_here = geom_active && static_cast<long>(di) == geom_target;
         if (geom_here) {
-            VkDeviceSize off = 0, sz = static_cast<VkDeviceSize>(geom_vcount) * 16;
+            VkDeviceSize off = 0, sz = static_cast<VkDeviceSize>(geom_cap) * 16;
             p_bindxfb(cmd, 0, 1, &geom_buf, &off, &sz);
             p_beginxfb(cmd, 0, 0, nullptr, nullptr);
         }
@@ -3558,7 +3569,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         } else {
             vkCmdDraw(cmd, v.vcount, v.instance_count, 0, 0);
         }
-        if (geom_here) p_endxfb(cmd, 0, 0, nullptr, nullptr);
+        if (geom_here) { VkDeviceSize coff = 0; p_endxfb(cmd, 0, 1, &geom_counter, &coff); }
         if (ds_active) {
             vkCmdEndQuery(cmd, ds_occ_pool, static_cast<uint32_t>(di));
             vkCmdEndQuery(cmd, ds_stats_pool, static_cast<uint32_t>(di));
@@ -3765,13 +3776,22 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     // geom_active implies flush_now (same gate as buffer creation), so `cmd` has completed here.
     if (geom_active) {
         if (batch_completed) {
+            // The counter buffer holds the byte count transform feedback actually wrote; read only that
+            // many vertices so the uninitialized tail of the (3x-oversized) buffer never pollutes stats.
+            uint32_t written = 0;
+            void* cp = nullptr;
+            if (vkMapMemory(dev, geom_counter_mem, 0, 16, 0, &cp) == VK_SUCCESS) {
+                uint32_t bytes = 0; std::memcpy(&bytes, cp, sizeof bytes);
+                written = std::min(bytes / 16u, geom_cap);
+                vkUnmapMemory(dev, geom_counter_mem);
+            }
             void* gp = nullptr;
-            if (vkMapMemory(dev, geom_mem, 0, static_cast<VkDeviceSize>(geom_vcount) * 16, 0, &gp) == VK_SUCCESS) {
+            if (written && vkMapMemory(dev, geom_mem, 0, static_cast<VkDeviceSize>(written) * 16, 0, &gp) == VK_SUCCESS) {
                 const float* pos = static_cast<const float*>(gp);
                 float minx=1e30f,maxx=-1e30f,miny=1e30f,maxy=-1e30f,minz=1e30f,maxz=-1e30f,minw=1e30f,maxw=-1e30f;
                 uint32_t nan=0, wle0=0, offscreen=0, clipped=0, finite=0;
-                bool all_same = geom_vcount > 0;
-                for (uint32_t i = 0; i < geom_vcount; i++) {
+                bool all_same = written > 0;
+                for (uint32_t i = 0; i < written; i++) {
                     const float x=pos[i*4+0], y=pos[i*4+1], z=pos[i*4+2], w=pos[i*4+3];
                     if (!std::isfinite(x)||!std::isfinite(y)||!std::isfinite(z)||!std::isfinite(w)) { nan++; continue; }
                     finite++;
@@ -3795,19 +3815,22 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                     clipped == finite       ? "ALL-VERTS-OUTSIDE-CLIP-CUBE(see bbox: off-screen shift or oversized quad)" :
                     onscreen * 20u < finite ? "MOSTLY-OUTSIDE(<5% verts on-screen; see bbox)" :
                                               "on-screen(geometry spread across clip space)";
-                fprintf(stderr, "[geom-probe] draw=%ld verts=%u finite=%u on-screen=%u clipped=%u "
+                fprintf(stderr, "[geom-probe] draw=%ld verts-written=%u finite=%u on-screen=%u clipped=%u "
                                 "(offscreen=%u w<=0=%u nan/inf=%u)\n"
                                 "[geom-probe]   clip-bbox x[%g,%g] y[%g,%g] z[%g,%g] w[%g,%g] -> %s\n",
-                        geom_target, geom_vcount, finite, onscreen, clipped, offscreen, wle0, nan,
+                        geom_target, written, finite, onscreen, clipped, offscreen, wle0, nan,
                         minx,maxx, miny,maxy, minz,maxz, minw,maxw, tag);
-                for (uint32_t i = 0; i < geom_vcount && i < 4; i++)
+                for (uint32_t i = 0; i < written && i < 4; i++)
                     fprintf(stderr, "[geom-probe]   v%u = (%g, %g, %g, %g)\n",
                             i, pos[i*4+0], pos[i*4+1], pos[i*4+2], pos[i*4+3]);
                 vkUnmapMemory(dev, geom_mem);
+            } else if (!written) {
+                fprintf(stderr, "[geom-probe] draw=%ld: transform feedback wrote 0 vertices "
+                                "(draw produced no primitives)\n", geom_target);
             }
         }
-        vkDestroyBuffer(dev, geom_buf, nullptr);
-        vkFreeMemory(dev, geom_mem, nullptr);
+        vkDestroyBuffer(dev, geom_buf, nullptr); vkFreeMemory(dev, geom_mem, nullptr);
+        vkDestroyBuffer(dev, geom_counter, nullptr); vkFreeMemory(dev, geom_counter_mem, nullptr);
     }
 
     if (readback_requested && batch_completed) {

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -112,6 +112,36 @@ counting clip whose first mask draw came back `GEOMETRY-VANISH`) in one run. Req
 `pipelineStatisticsQuery`; inert (no output, no cost, byte-identical rendering) when the env var is unset.
 Works on both `gpu_replay` and the live app because it lives in the shared render path.
 
+## Per-draw geometry probe — `PROSPER_GEOM_PROBE=N` (where did draw N's vertices actually land?)
+
+```bash
+PROSPER_GEOM_PROBE=4 ./build-linux/gpu_replay /tmp/submit.prgcap /tmp/out.bmp
+# [geom-probe] draw 4 VS re-recompiled with xfb capture (1700 words)
+# [geom-probe] draw=4 verts=1024 finite=1024 on-screen=0 clipped=1024 (offscreen=1023 w<=0=1 nan/inf=0)
+# [geom-probe]   clip-bbox x[-4.86,0] y[-1.14,3.81] z[0,0] w[0,1] -> ALL-VERTS-OUTSIDE-CLIP-CUBE(...)
+# [geom-probe]   v0 = (-2.9, -0.771, 0, 1) ...
+```
+
+The natural follow-up when the fragment funnel reports **GEOMETRY-VANISH**: capture draw N's **post-transform
+clip-space vertex positions** via `VK_EXT_transform_feedback` and report where they landed — clip-space
+bounding box, on-screen vs clipped counts, `w<=0` (behind-camera), NaN/inf, degenerate (all-collapsed), plus
+the first few raw `vec4`s. This distinguishes the ways a `GEOMETRY-VANISH` can happen:
+
+- all verts at one point → **DEGENERATE** (the vertex fetch returned constant/zero data);
+- `w<=0` for all → **behind camera** (transform / w defect);
+- spread but the bbox sits outside `[-1,1]` → **off-screen** (a transform/matrix defect shifting it away);
+- NaN/inf → a numeric defect.
+
+Read it **with** the funnel: the funnel owns the "does it rasterize" verdict (`after_clip`), the geom probe
+owns *where the geometry is* — a large full-screen quad can have every vertex just outside the cube yet still
+rasterize, so "all verts clipped" is not "renders nothing"; the bbox tells them apart.
+
+Mechanics: on a capsule (stored SPIR-V) gpu_replay re-recompiles draw N's raw RDNA2 VS with `gl_Position`
+xfb-decorated (requires a v19+ capsule that retained the raw VS stream) and swaps it in for that one draw; the
+live app recompiles fresh. Requires the device to advertise `VK_EXT_transform_feedback` (RADV, lavapipe). The
+probed draw's rendered pixels may be inexact (the re-recompile drops pixel-input remapping), but the captured
+`gl_Position` values are faithful; inert and byte-identical when the env var is unset.
+
 `--dump-shader DRAW:vs|fs PATH` writes the recompiled SPIR-V. Capture v19 adds
 `--dump-realized-shader DRAW:vs|fs PATH` for the exact bounded raw RDNA2 stream that produced that realized
 draw stage, suitable for `shader_inspect`. The VS/FS streams use the same content-addressed 64 KiB-per-stage,

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -1315,6 +1315,31 @@ int main(int argc, char** argv) {
     if (!prosper::gpu::materialize_gpu_replay(capture, replay, error)) {
         std::fprintf(stderr, "gpu_replay: cannot materialize: %s\n", error.c_str()); return 2;
     }
+    // Geometry probe (PROSPER_GEOM_PROBE=N): a capsule stores already-recompiled SPIR-V, so to capture
+    // draw N's gl_Position via transform feedback we re-recompile its raw RDNA2 VS with xfb decorations
+    // and swap it in here; render_runner then binds a TF buffer around that draw and reports where its
+    // post-transform vertices land. Requires a v19+ capsule that retained the raw VS stream.
+    if (const char* g = std::getenv("PROSPER_GEOM_PROBE")) {
+        const long n = std::strtol(g, nullptr, 10);
+        if (n >= 0 && static_cast<size_t>(n) < replay.items.size()) {
+            auto& it = replay.items[static_cast<size_t>(n)];
+            if (it.vs_raw_shader_index < replay.raw_shader_versions.size()) {
+                const auto& raw = replay.raw_shader_versions[it.vs_raw_shader_index];
+                auto xfb = prosper::gpu::recompile_vertex(raw.words.data(), raw.words.size(),
+                                                          it.vrt.get(), nullptr, true);
+                if (!xfb.empty()) {
+                    it.vs = std::move(xfb); it.vs_shared.reset(); it.vs_identity = 0;
+                    std::fprintf(stderr, "[geom-probe] draw %ld VS re-recompiled with xfb capture (%zu words)\n",
+                                 n, it.vs.size());
+                } else {
+                    std::fprintf(stderr, "[geom-probe] draw %ld: xfb re-recompile produced no VS "
+                                         "(no raw stream / unsupported)\n", n);
+                }
+            } else {
+                std::fprintf(stderr, "[geom-probe] draw %ld: no captured raw VS stream (capsule predates v19)\n", n);
+            }
+        }
+    }
     prosper::gpu::GpuCaptureFile prepend_capture;
     prosper::gpu::GpuReplayFrame prepend;
     if (!prepend_path.empty() &&

--- a/prosper/tools/spv_validate/spv_validate.cpp
+++ b/prosper/tools/spv_validate/spv_validate.cpp
@@ -79,7 +79,10 @@ int main(int argc, char** argv) {
     // Vertex: fullscreen triangle from gl_VertexIndex (EXP POS0).
     { const uint32_t c[] = {0x36020081u,0x2C040081u,0x7E020D01u,0x7E040D02u,0x7E0A02F6u,0x7E0C02F2u,0x10020B01u,
                             0x08020D01u,0x10040B02u,0x08040D02u,0x7E060280u,0x7E0802F2u,0xF80008CFu,0x04030201u,0xBF810000u};
-      dump(dir, "vertex_fullscreen", recompile_vertex(c, sizeof(c)/4)); }
+      dump(dir, "vertex_fullscreen", recompile_vertex(c, sizeof(c)/4));
+      // Geometry-probe capture variant: gl_Position decorated for transform-feedback readback. Must
+      // still pass spirv-val (Xfb capability + execution mode + member Offset/XfbBuffer/XfbStride).
+      dump(dir, "vertex_xfb_capture", recompile_vertex(c, sizeof(c)/4, nullptr, nullptr, true)); }
     // Vertex private spill/fill (Function-storage declaration in the graphics shell).
     { const uint32_t c[] = {0xdc704010u,0x00000000u,0x7e000280u,0xdc304010u,0x00000000u,
                             0xf80008cfu,0x00000000u,0xBF810000u};


### PR DESCRIPTION
## Summary
Adds `PROSPER_GEOM_PROBE=N` — the geometry probe (issue #1242), third tool in the per-draw GPU debug suite after `--draw-steps` (#1228) and `PROSPER_DRAW_STATS` (#1241). It captures draw N's **post-transform clip-space vertex positions** via `VK_EXT_transform_feedback` and reports where they landed:

```
[geom-probe] draw=4 verts=1024 finite=1024 on-screen=0 clipped=1024 (offscreen=1023 w<=0=1 nan/inf=0)
[geom-probe]   clip-bbox x[-4.86,0] y[-1.14,3.81] z[0,0] w[0,1] -> ALL-VERTS-OUTSIDE-CLIP-CUBE(...)
[geom-probe]   v0 = (-2.9, -0.771, 0, 1) ...
```

## Why
When the fragment funnel reports `GEOMETRY-VANISH`, the next question is *where the vertices actually landed* — degenerate (fetch returned zero/constant), behind camera (`w<=0`), off-screen (bbox outside `[-1,1]`), or NaN. This answered the open GTA V #1231 question in one run: the vanished mask draw is transformed **off-screen** (bbox `x[-4.86,0]`, all verts outside the clip cube), while a working mask lands on-screen (`x[-2.73,0.90]`).

## Implementation
- **recompiler** (`rdna2_to_spirv`): `recompile_vertex(capture_position)` adds gated `Xfb` decorations on `gl_Position` (`TransformFeedback` capability + `Xfb` execution mode + `XfbBuffer`/`XfbStride`/`Offset`). Inert to the computation. `spv_validate` gains a `vertex_xfb_capture` variant so **CI spirv-vals it**.
- **device** (`render_runner`): enable `VK_EXT_transform_feedback` (base `transformFeedback` feature) only when advertised, guarded like the other optional features.
- **render** (`render_runner`): for the probed draw, bind a TF buffer + `vkCmdBeginTransformFeedbackEXT`/End around the draw, read back `vec4` positions, classify, report. Gated on the env var + TF support + a flush in this call (results ready; no use-after-free — same gating discipline as the #1241 funnel).
- **gpu_replay**: a capsule stores already-recompiled SPIR-V, so for capsule replay it re-recompiles the probed draw's raw RDNA2 VS (v19+ capsules retain it) with xfb and swaps it in for that one draw; the live app recompiles fresh via gpu_executor.

## Behavioral contract
- **No behavioral change** with the env var unset: the render is byte-identical (verified GTA V menu submit hash `670576577254c2e8` unchanged) and emits no output. The only always-on change is enabling the TF device feature when advertised (permits the extension; can't alter rendering).
- Read it **with** the funnel: the funnel owns the "rasterizes?" verdict (`after_clip`); the geom probe owns *where the vertices are*. A large quad can have all verts just outside the cube yet still rasterize, so the bbox — not the clipped count — is the discriminator (the tag is descriptive, not prescriptive).
- Known limitation (documented): the capsule re-recompile drops pixel-input remapping, so the **probed draw's rendered pixels may be inexact** in a probe run — but the captured `gl_Position` values are faithful (pixel-inputs don't affect position).

## Verification
- **ctest 138/140** — the 2 failures (`module_loads_eboot`, `boot_reaches_first_syscall`) are dump-dependent boot/loader tests unrelated to the GPU path; all GPU render + `spv_validate` tests pass.
- Default-path render **byte-identical**, zero `[geom-probe]` output when unset.
- Probe validated on the GTA V menu capsule: draw 4 (funnel GEOMETRY-VANISH) → all verts off-screen `x[-4.86,0]`; draw 12 (works) → on-screen `x[-2.73,0.90]`.
- spirv-val isn't in this container, but `spv_validate`'s new `vertex_xfb_capture` case exercises the xfb SPIR-V under CI's spirv-val gate; the probe also functionally validated on RADV (real captures).

## Risk
Moderate — touches the recompiler, but the xfb path is gated/inert and the normal recompile is unchanged. Worth a reviewer's eye: the xfb SPIR-V decorations, the TF buffer lifetime/flush gating, and the capsule re-recompile substitution.

Fixes #1242.
