### PR TITLE
fix(gpu): only suppress a forge-shaped fence write when no executed init is outstanding

### DIFF
--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -157,6 +157,7 @@ enum : uint8_t { LE_DMA_BUILT = 1, LE_REL_BUILT, LE_WAIT_BUILT, LE_DMA_EXEC, LE_
                  LE_DMA_FREE, LE_REL_FREE };
 struct LabelEvent {
     uint8_t  type;
+    uint8_t  origin;      // #1226: exec events — queue_origin of the folding submit (0=?, 1=Dcb, 2=Acb, 3=Final)
     uint32_t fold;        // g_fold_seq at event time (exec events; builds carry it too for context)
     uint64_t t_ms;
     uint64_t aux;         // builds: packet addr; execs: pre-content qword at the label
@@ -181,12 +182,12 @@ inline LabelHist& label_hist_slot(uint64_t addr) {
     }
     return h;
 }
-void label_hist_event(uint64_t addr, uint8_t type, uint64_t aux) {
+void label_hist_event(uint64_t addr, uint8_t type, uint64_t aux, uint8_t origin = 0) {
     if (!addr) return;
     LabelHist& h = label_hist_slot(addr);
     uint32_t i = h.n.fetch_add(1, std::memory_order_relaxed);
     LabelEvent& e = h.ev[i & 15];
-    e.type = type; e.t_ms = now_ms(); e.aux = aux;
+    e.type = type; e.origin = origin; e.t_ms = now_ms(); e.aux = aux;
     e.fold = g_fold_seq.load(std::memory_order_relaxed);
 }
 }
@@ -211,14 +212,14 @@ uint64_t peek_qword(uint64_t addr) {
     if (addr >= 0x10000 && !(addr & 3)) memcpy(&v, (const void*)(uintptr_t)addr, sizeof v);
     return v;
 }
-void label_hist_dma_exec(uint64_t addr, uint64_t pre) {
+void label_hist_dma_exec(uint64_t addr, uint64_t pre, uint8_t origin = 0) {
     label_hist_slot(addr).dma_exec_n.fetch_add(1, std::memory_order_relaxed);
-    label_hist_event(addr, LE_DMA_EXEC, pre);
+    label_hist_event(addr, LE_DMA_EXEC, pre, origin);
 }
 void label_hist_dma_skip(uint64_t addr)               { label_hist_event(addr, LE_DMA_SKIP, 0); }
-void label_hist_rel_exec(uint64_t addr, uint64_t pre) {
+void label_hist_rel_exec(uint64_t addr, uint64_t pre, uint8_t origin = 0) {
     label_hist_slot(addr).rel_exec_n.fetch_add(1, std::memory_order_relaxed);
-    label_hist_event(addr, LE_REL_EXEC, pre);
+    label_hist_event(addr, LE_REL_EXEC, pre, origin);
 }
 void label_hist_dma_free(uint64_t addr, uint64_t pool_base) {
     label_hist_slot(addr).mb3_dma_suppressed_n.fetch_add(1, std::memory_order_relaxed);
@@ -314,11 +315,14 @@ void label_hist_report(uint64_t addr, char* out, size_t cap) {
     uint32_t n = h.n.load(std::memory_order_relaxed);
     uint32_t first = n > 16 ? n - 16 : 0;
     size_t off = (size_t)snprintf(out, cap, "events(total=%u):", n);
-    for (uint32_t i = first; i < n && off + 48 < cap; i++) {
+    // Exec events carry the folding submit entry point (#1226): D=SubmitDcb A=SubmitAcb
+    // F=SubmitDcbFinal, absent when unknown/build-side — the cross-queue discriminator.
+    static const char* qn[] = {"", "(D)", "(A)", "(F)"};
+    for (uint32_t i = first; i < n && off + 52 < cap; i++) {
         const LabelEvent& e = h.ev[i & 15];
-        int m = snprintf(out + off, cap - off, " %s@%llu/f%u:0x%llx",
-                         e.type <= 8 ? nm[e.type] : "?", (unsigned long long)e.t_ms, e.fold,
-                         (unsigned long long)e.aux);
+        int m = snprintf(out + off, cap - off, " %s%s@%llu/f%u:0x%llx",
+                         e.type <= 8 ? nm[e.type] : "?", e.origin <= 3 ? qn[e.origin] : "",
+                         (unsigned long long)e.t_ms, e.fold, (unsigned long long)e.aux);
         if (m > 0) off += (size_t)m;
     }
 }
@@ -766,26 +770,44 @@ static void honor_eop_write(const Pm4Command& c) {
                           // consumed-marker population so plain fence labels (Messenger) are never
                           // affected. CONFIDENCE: HIGH (mechanism captured live, sessions 2-5).
                           if (rel1_stomp_guard() && label_is_consumed_marker(c.rel_addr)) {
-                              label_hist_rel_exec(c.rel_addr, pre);   // ring visibility; write skipped
+                              label_hist_rel_exec(c.rel_addr, pre, c.queue_origin);   // ring visibility; write skipped
                               return;
                           }
                       }
                       else if (pre_low == 1 && (pre >> 32))
                           report_suspect_write("REL1-NOINIT", c.rel_addr, c.rel_value, pre, pkt_addr(c));
                   }
-                  // #312 ROOT (session-10): the missed case — pre is a freelist next-pointer with a
-                  // ZERO low dword (0x1000000000-shaped). The pre_low!=0 branch above never sees it,
-                  // so the value-1 write below would forge pre|1 (0x1000000001) and seed the crash.
+                  // #312 ROOT (session-10): pre is a freelist next-pointer with a ZERO low dword
+                  // (0x1000000000-shaped). The pre_low!=0 branch above never sees it, so the value-1
+                  // write below would forge pre|1 (0x1000000001) and seed the crash.
+                  //
+                  // #1226 CORRECTION to session-10's "this is always a write-after-free" claim: it is
+                  // NOT. The guest's DmaData init writes only 4 BYTES, so a LIVE, correctly init'd
+                  // label whose 0x20-byte malloc residue had nonzero HIGH bits reads exactly
+                  // {stale_high, low=0} — byte-identical to the freed-block shape. Observed live on
+                  // ArcRunner (PPSA21406): residue 0x2020e31680, 4-byte init -> qword 0x2000000000,
+                  // and this guard then suppressed the guest's own paired fence, leaving every
+                  // consumer WaitRegMem dependency-violated (thousands/min) and desynchronizing the
+                  // fence-gated free protocol — the very corruption the guard exists to prevent.
+                  // Content cannot discriminate the two; PROTOCOL STATE can (same model as
+                  // label_freed_marker_kind Case B): an EXECUTED init not yet consumed by a fence
+                  // (dma_exec_n > rel_exec_n) means this rel is the paired fence of a live
+                  // generation — real hardware performs the 32-bit write (the consumer polls only
+                  // the low dword; the stale high half is invisible to it). Suppress only when no
+                  // executed init is outstanding (the true stale/WAF fence). CONFIDENCE: MED-HIGH
+                  // (live ArcRunner protocol trace + the WAF model's documented lifecycle).
                   else if (forges_freelist_ptr(pre, 4, c.rel_value)) {
                       forge_trip("REL1", c.rel_addr, pre, c.rel_value, 4, pkt_addr(c));
-                      // No consumed-marker gate here (unlike REL1-LIVE): pre == a 0x1000000000-shaped
-                      // freelist next-pointer only ever occurs on a FREED/recycled MB3 block — a live
-                      // fence label (Messenger or DOLL) holds 0 / a small fence value there, never a
-                      // 64 KiB-aligned heap pointer. So this is always a write-after-free; suppressing
-                      // it can never re-block a live WaitRegMem==1 consumer. CONFIDENCE: HIGH.
-                      if (forge_guard()) {
+                      LabelHist& fh = label_hist_slot(c.rel_addr);
+                      const bool live_pair =
+                          fh.dma_exec_n.load(std::memory_order_relaxed) >
+                          fh.rel_exec_n.load(std::memory_order_relaxed);
+                      if (forge_guard() && !live_pair) {
                           report_suspect_write("REL1-FORGE", c.rel_addr, c.rel_value, pre, pkt_addr(c));
-                          label_hist_rel_exec(c.rel_addr, pre);   // ring visibility; write skipped
+                          // Ring visibility WITHOUT the rel_exec_n bump: a suppressed fence must not
+                          // advance the consumed-count, or the NEXT generation's live check above
+                          // would read dma_exec_n == rel_exec_n and wrongly suppress a real fence.
+                          label_hist_event(c.rel_addr, LE_REL_EXEC, pre, c.queue_origin);
                           return;
                       }
                   }
@@ -804,7 +826,7 @@ static void honor_eop_write(const Pm4Command& c) {
                   uint32_t v = (uint32_t)c.rel_value; memcpy(dst, &v, sizeof v);
                   ring_record(c.rel_addr, v, 4, 1, pkt_addr(c));
                   poolshift_check("REL1", c.rel_addr, 4, c.rel_value, pkt_addr(c));
-                  label_hist_rel_exec(c.rel_addr, pre); break; }
+                  label_hist_rel_exec(c.rel_addr, pre, c.queue_origin); break; }
         case 2: { if (!c.rel_value_valid) return;
                   if (mb3_suppress_release(c.rel_addr, c.rel_value, "REL2")) return;
                   // #312: the same freelist-stomp guard as the 32-bit path. An 8-byte value-1 fence
@@ -822,7 +844,7 @@ static void honor_eop_write(const Pm4Command& c) {
                   if (rel1_stomp_guard() && ptr_like(pre) && (uint32_t)pre != 0 &&
                       pre != c.rel_value && label_is_consumed_marker(c.rel_addr)) {
                       report_suspect_write("REL2-LIVE", c.rel_addr, c.rel_value, pre, pkt_addr(c));
-                      label_hist_rel_exec(c.rel_addr, pre);   // ring visibility; write skipped
+                      label_hist_rel_exec(c.rel_addr, pre, c.queue_origin);   // ring visibility; write skipped
                       return;
                   }
                   uint64_t v = c.rel_value;           memcpy(dst, &v, sizeof v);
@@ -976,7 +998,7 @@ static void honor_dma_data(const Pm4Command& c, uint64_t retained_packet_addr = 
             if (i < c.dd_bytes) memcpy(dst + i, &v32, c.dd_bytes - i);
         }
         poolshift_check("DMA", c.dd_dst, c.dd_bytes, c.dd_src, packet_addr);
-        if (c.dd_bytes <= 8) label_hist_dma_exec(c.dd_dst, pre_dma);
+        if (c.dd_bytes <= 8) label_hist_dma_exec(c.dd_dst, pre_dma, c.queue_origin);
         if (getenv("PROSPER_GFXLOG"))
             fprintf(stderr, "[agc]   DmaData fill [0x%llx] := 0x%x (%u bytes)\n",
                     (unsigned long long)c.dd_dst, v32, c.dd_bytes);
@@ -1824,8 +1846,10 @@ void GpuState::apply(const Pm4Command& c) {
                         uint64_t baddr = 0, bpre = 0, bt = 0;
                         int have = prosper_fence_journal_lookup(pkt_addr(c), &baddr, &bpre, &bt);
                         char hist[512]; label_hist_report(c.wm_addr, hist, sizeof hist);
-                        fprintf(stderr, "[agc] WaitRegMem #%d NOT satisfied at fold time: [0x%llx]&0x%llx = 0x%llx, func=%u ref=0x%llx — %s | built@%llums(age=%lldms)%s pre@build=0x%llx%s%s | %s\n",
-                                ln, (unsigned long long)c.wm_addr, (unsigned long long)c.wm_mask,
+                        static const char* qn2[] = {"?", "D", "A", "F"};
+                        fprintf(stderr, "[agc] WaitRegMem #%d q=%s NOT satisfied at fold time: [0x%llx]&0x%llx = 0x%llx, func=%u ref=0x%llx — %s | built@%llums(age=%lldms)%s pre@build=0x%llx%s%s | %s\n",
+                                ln, c.queue_origin <= 3 ? qn2[c.queue_origin] : "?",
+                                (unsigned long long)c.wm_addr, (unsigned long long)c.wm_mask,
                                 (unsigned long long)(mem & c.wm_mask), c.wm_func, (unsigned long long)c.wm_ref,
                                 defer_enabled() ? "pausing queue (deferred effects)" : "dependency violated",
                                 (unsigned long long)bt, have ? (long long)(now_ms() - bt) : -1,
@@ -1933,6 +1957,12 @@ void GpuState::apply(const Pm4Command& c) {
     }
 }
 
+// #1226: the submit entry point currently folding (1=SubmitDcb, 2=SubmitAcb, 3=SubmitDcbFinal).
+// Set by hle_agc under g_agc_state_mu (all folds are serialized), stamped onto every decoded
+// command so deferred/pended effects retain their queue of origin. Diagnostic only.
+namespace { uint8_t g_fold_origin = 0; }
+extern "C" void prosper_gpu_set_fold_origin(uint8_t origin) { g_fold_origin = origin; }
+
 size_t run_command_buffer(const uint32_t* buf, size_t dwords, GpuState& st) {
     // Each TOP-LEVEL stream starts a fresh fold state (#312: the pause flag and the lazily-opened
     // deferred stream are per-fold). A Jump recursion must NOT reset them: the jump target
@@ -1950,6 +1980,7 @@ size_t run_command_buffer(const uint32_t* buf, size_t dwords, GpuState& st) {
     decode_pm4(buf, dwords, ops);
     for (auto& c : ops) {
         c.stream_order = st.command_order + 1;
+        c.queue_origin = g_fold_origin;   // #1226: retained by deferred/pended effects
         st.apply(c);
     }
     return ops.size();

--- a/prosper/src/gpu/pm4_decode.hpp
+++ b/prosper/src/gpu/pm4_decode.hpp
@@ -56,6 +56,11 @@ struct Pm4Command {
     } kind = Kind::Unknown;
 
     uint64_t stream_order = 0;          // assigned before apply and retained by deferred effects
+    // #1226 diagnostic: which driver submit entry point folded this command (0=unknown, 1=SubmitDcb,
+    // 2=SubmitAcb, 3=SubmitDcbFinal). Stamped by run_command_buffer from the fold origin and retained
+    // by deferred/pended effects, so fence-protocol history can show cross-queue producer/consumer
+    // pairs (ArcRunner submits real async-compute ACBs; prosper folds both queues into one stream).
+    uint8_t queue_origin = 0;
     uint32_t        header = 0;
     uint32_t        op = 0, r = 0, len = 0;   // op, sub-op, total dwords (incl. header)
     const uint32_t* payload = nullptr;        // points at header+1 (len-1 dwords)

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -1186,11 +1186,16 @@ static bool execute_submit_work(gpu::GpuState& st, uint64_t submit_no, unsigned&
 // submit path (sceAgcDriverSubmitDcb) and the DOLL warmup-submit variant (w1KFAHVqpaU) below.
 // `dw_num == 0` means "length unknown" — decode_pm4 self-terminates at the first non-type-3 dword, and
 // we cap the walk at kUnknownCap dwords as a runaway guard (a bounded ring can't legitimately exceed it).
+extern "C" void prosper_gpu_set_fold_origin(uint8_t origin);   // #1226 queue-origin diagnostic
 static uint64_t submit_dcb_stream(const uint32_t* addr, uint32_t dw_num, const char* who) {
     if (!addr) return 0;
     constexpr uint32_t kUnknownCap = 0x80000;   // 512 KiB of dwords — well past any real Dcb
     uint32_t walk = dw_num ? dw_num : kUnknownCap;
     std::lock_guard<std::mutex> lk(g_agc_state_mu);   // serialize with the other submit entry (#278)
+    // #1226: stamp this fold's submit entry point so fence-protocol history can distinguish the
+    // graphics Dcb stream from ArcRunner's async-compute Acb stream (folded into the same state).
+    prosper_gpu_set_fold_origin(strcmp(who, "SubmitAcb") == 0      ? 2
+                                : strcmp(who, "SubmitDcbFinal") == 0 ? 3 : 1);
     // #312: flush any earlier stream paused on a WAIT_REG_MEM — this submit may be its producer.
     gpu::flush_deferred_streams();
     agc_gpu_state().draws.clear();
@@ -1281,6 +1286,7 @@ HLE(agc_driver_submit_dcb) {  // (const Packet* packet)
     const auto* p = (const Packet*)(uintptr_t)a0;
     if (!p || !p->addr || !p->dw_num) return kAgcErrInvalidArg;
     std::lock_guard<std::mutex> lk(g_agc_state_mu);   // serialize with submit_dcb_stream/w1KFAHVqpaU (#278)
+    prosper_gpu_set_fold_origin(1);   // #1226: this direct entry is the graphics SubmitDcb path
     // Reset the per-submit draw list BEFORE folding this Dcb. The folded GpuState is process-lifetime and
     // its register files (cx/sh/uc) persist across submits (as on real hardware), but its `draws` vector
     // must NOT accumulate — otherwise it grows unbounded and every later frame re-renders stale geometry.


### PR DESCRIPTION
Progresses #1226 (ArcRunner corruption track) and materially advances DOLL/DQ7 (PPSA17942). Touches the delicate #312 EOP/ReleaseMem guard family — evidence and cross-title verification below.

## Failure scenario

The #312 forge guard (session-10, default ON) suppresses a 4-byte `ReleaseMem(value)` whose target qword reads `{heap-pointer high bits, low dword 0}`, on the claim that this shape 'only ever occurs on a FREED/recycled MB3 block'. The claim is wrong: the guest's DmaData label init writes only **4 bytes**, so a **live, correctly initialized label** whose 0x20-byte malloc residue had nonzero high bits reads exactly `{stale_high, 0}` — byte-identical. The WAF model's own doc already records this ('the high dword of a live 4-byte-fence label is malloc residue').

Consequences, observed live:
- **ArcRunner**: label residue `0x2020e31680` → 4-byte init → qword `0x2000000000` → the guard suppressed the guest's own paired fence → **23,552+ dependency-violated waits in 76 s** → fence-gated free protocol desyncs → the #1226 free-list corruption faults (both variants).
- **DOLL master**: 192 false suppressions in 8 s ending in `FMallocBinned3 Attempt to free an unrecognized block 2000000000` — the fatal **names the artifact** — and the boot dies at ~8 s.

## Behavioral contract

Content cannot discriminate a live init'd label from a freed block; **protocol state can** (the existing `label_freed_marker_kind` Case-B model): an executed init not yet consumed by a fence (`dma_exec_n > rel_exec_n`) marks the paired fence of a live generation → perform the 32-bit write, as real hardware does (the consumer polls only the low dword). Suppression remains for the true stale/WAF fence (no outstanding executed init). The suppressed path now records ring visibility **without** bumping `rel_exec_n` — a suppressed fence must not advance the consumed-count, or the next generation's live check would wrongly suppress a real fence.

Also included: the **queue-origin provenance** that found this — `Pm4Command.queue_origin` stamped at fold time from the submit entry point (SubmitDcb / SubmitAcb / SubmitDcbFinal), retained by deferred/pended effects, shown per exec event in label history (`relX(A)@…`) and on the violation line (`q=D`). Diagnostic only.

## Verification (native Linux host, RADV STRIX_HALO)

- `ctest` on the rebased head: **139/139**.
- **ArcRunner** 7×120 s: violated waits **23,552+/76 s → ~1k/118 s** (20-30×); fences land; `PROSPER_WAIT_DEFER=1` no longer wedges at flip 12 (flips reach 1256 — the wedge was the suppressed-fence trickle); worker faults 4/7 vs ~2/3 baseline, **1/3 under fix+WAIT_DEFER**. The survivor is the documented POOLSHIFT byte-shifted-pool-pointer class (`0x30015f00`), shared with DOLL's known residual at `eboot+0x2316c91` — the next frontier, tracked on #1226.
- **DOLL A/B** 150 s: baseline 192 suppressions, 2 free-unrecognized fatals, dead at ~8 s; fixed build **1 suppression (the true WAF), 0 fatals, alive at 78 s+**.
- **`snapshot.py check`: all 5 guards OK** (messenger-scene, evergate-title, dead-cells-gameplay, blasphemous2-gameplay, terminator-boot) — Messenger's plain-fence path is additionally structurally unaffected (`forges_freelist_ptr` requires ptr-like pre-content its labels never hold).

## Risks

- The re-enabled write class: a label whose init landed but whose block the guest freed via a timeout path before the fence would now be stomped where it was suppressed — bounded by the guest needing to free WITHOUT observing the fence value (the poll can't pass), and empirically invisible in 7 ArcRunner + 1 DOLL + 5 snapshot runs.
- Counter fidelity: `dma_exec_n`/`rel_exec_n` reset on label-hist hash collision (pre-existing, diagnostic-grade); a collision reset reads as no-outstanding-init → suppress → old behavior, i.e. fails toward the previous state, not toward a new stomp.