### PR TITLE
tool(gpu): PROSPER_SHADER_TAP — capture a shader intermediate value at a given PC

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -235,6 +235,16 @@ struct SpirvCompute {
     // Geometry-probe (PROSPER_GEOM_PROBE): when set before begin_vertex(), decorate gl_Position for
     // transform-feedback capture. Inert to the shader's computation; only marks the output for readback.
     bool capture_position = false;
+    // Shader I/O value tap (PROSPER_SHADER_TAP=pc): after the instruction at `tap_pc`, snapshot its
+    // destination VGPR (and the next 3) as a vec4; the vertex position export is then redirected to it,
+    // so the geometry-probe capture reports the intermediate value AT that PC (e.g. a MUBUF fetch result)
+    // instead of gl_Position. Inert unless the env var is set. Values are bitcast-as-float in the output.
+    uint32_t tap_pc = 0xFFFFFFFFu;
+    uint32_t tap_vec = 0;   // 0 = no tap captured; else the vec4 SPIR-V id export_position emits
+    void set_tap(uint32_t a, uint32_t bb, uint32_t c, uint32_t d) {
+        uint32_t v = id(); putv(code, Op_CompositeConstruct, {t_v4f, v, bcf(a), bcf(bb), bcf(c), bcf(d)});
+        tap_vec = v;
+    }
 
     uint32_t id() { return next_id++; }
     static void put(std::vector<uint32_t>& s, uint32_t op, std::initializer_list<uint32_t> o) {
@@ -1597,7 +1607,11 @@ struct SpirvCompute {
         // multiply leaves w at 0 under our (still-incomplete) descriptor decode, collapsing the
         // perspective divide; forcing w=1 reveals whether the x/y are otherwise on-screen.
         if (getenv("PROSPER_FORCE_W")) w = uconst(0x3f800000u);   // raw bits of 1.0f (bcf bitcasts to float)
-        uint32_t v = id(); putv(code, Op_CompositeConstruct, {t_v4f, v, bcf(x), bcf(y), bcf(z), bcf(w)});
+        // Shader I/O tap: if an intermediate was snapshotted at PROSPER_SHADER_TAP's PC, export THAT as
+        // gl_Position instead of the real clip position, so the geometry-probe capture reads it back.
+        uint32_t v;
+        if (tap_vec) { v = tap_vec; }
+        else { v = id(); putv(code, Op_CompositeConstruct, {t_v4f, v, bcf(x), bcf(y), bcf(z), bcf(w)}); }
         uint32_t p = id(); putv(code, Op_AccessChain, {t_ptr_out_v4f, p, v_pos, uconst(0)});
         put(code, Op_Store, {p, v});
     }
@@ -7637,6 +7651,11 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
             const bool handled = emit_alu(
                 b, rs, in, ok, allow_exec_update, &effective_safe, allow_smem, rt, wave_ok);
             if (handled && ok) record_scalar_write(rs, in);
+            // Shader I/O tap: snapshot this instruction's destination VGPR (+3) if it is the tapped PC.
+            if (handled && ok && in.pc == b.tap_pc && in.dst.kind == OperandKind::VGPR) {
+                auto tv = [&](int r) { auto it = rs.vreg.find(r); return it == rs.vreg.end() ? b.uconst(0) : it->second; };
+                b.set_tap(tv(in.dst.value), tv(in.dst.value + 1), tv(in.dst.value + 2), tv(in.dst.value + 3));
+            }
             if (!handled || !ok) {
                 // PROSPER_DBG (gated, off by default): report the instruction that fails recompilation —
                 // the first unsupported op / unresolved resource that makes a shader return empty.
@@ -8785,6 +8804,9 @@ std::vector<uint32_t> recompile_vertex(const uint32_t* code, size_t dwords,
 
     SpirvCompute b;
     b.capture_position = capture_position;   // geometry-probe: mark gl_Position for xfb capture (gated)
+    // Shader I/O value tap (PROSPER_SHADER_TAP=pc): redirect the position export to the intermediate VGPR
+    // produced at that PC. Applies to the vertex stage only; captured via the geometry probe.
+    if (const char* tap = getenv("PROSPER_SHADER_TAP")) b.tap_pc = static_cast<uint32_t>(strtoul(tap, nullptr, 0));
     b.begin_vertex(rt);
     b.declare_guest_scratch(scratch);
     RegState rs; rs.vcc = b.bfalse(); rs.scc = b.bfalse(); rs.exec = b.btrue();

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -3815,14 +3815,29 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                     clipped == finite       ? "ALL-VERTS-OUTSIDE-CLIP-CUBE(see bbox: off-screen shift or oversized quad)" :
                     onscreen * 20u < finite ? "MOSTLY-OUTSIDE(<5% verts on-screen; see bbox)" :
                                               "on-screen(geometry spread across clip space)";
-                fprintf(stderr, "[geom-probe] draw=%ld verts-written=%u finite=%u on-screen=%u clipped=%u "
-                                "(offscreen=%u w<=0=%u nan/inf=%u)\n"
-                                "[geom-probe]   clip-bbox x[%g,%g] y[%g,%g] z[%g,%g] w[%g,%g] -> %s\n",
-                        geom_target, written, finite, onscreen, clipped, offscreen, wle0, nan,
-                        minx,maxx, miny,maxy, minz,maxz, minw,maxw, tag);
-                for (uint32_t i = 0; i < written && i < 4; i++)
-                    fprintf(stderr, "[geom-probe]   v%u = (%g, %g, %g, %g)\n",
-                            i, pos[i*4+0], pos[i*4+1], pos[i*4+2], pos[i*4+3]);
+                // Shader I/O tap mode (PROSPER_SHADER_TAP): the captured "positions" are actually the tapped
+                // intermediate VGPR (dst..dst+3) at that PC, so print the raw hex too (values are often
+                // integers/bitfields, not clip floats) and skip the meaningless clip classification.
+                const bool is_tap = getenv("PROSPER_SHADER_TAP") != nullptr;
+                if (is_tap)
+                    fprintf(stderr, "[geom-probe] draw=%ld SHADER-TAP: values below are the tapped VGPR "
+                                    "(dst+3) at that PC, not clip positions (bbox/tags meaningless)\n", geom_target);
+                else
+                    fprintf(stderr, "[geom-probe] draw=%ld verts-written=%u finite=%u on-screen=%u clipped=%u "
+                                    "(offscreen=%u w<=0=%u nan/inf=%u)\n"
+                                    "[geom-probe]   clip-bbox x[%g,%g] y[%g,%g] z[%g,%g] w[%g,%g] -> %s\n",
+                            geom_target, written, finite, onscreen, clipped, offscreen, wle0, nan,
+                            minx,maxx, miny,maxy, minz,maxz, minw,maxw, tag);
+                for (uint32_t i = 0; i < written && i < (is_tap ? 8u : 4u); i++) {
+                    if (is_tap) {
+                        uint32_t h[4]; std::memcpy(h, &pos[i*4], 16);
+                        fprintf(stderr, "[geom-probe]   v%u = float(%g, %g, %g, %g) hex(%08x %08x %08x %08x)\n",
+                                i, pos[i*4+0], pos[i*4+1], pos[i*4+2], pos[i*4+3], h[0], h[1], h[2], h[3]);
+                    } else {
+                        fprintf(stderr, "[geom-probe]   v%u = (%g, %g, %g, %g)\n",
+                                i, pos[i*4+0], pos[i*4+1], pos[i*4+2], pos[i*4+3]);
+                    }
+                }
                 vkUnmapMemory(dev, geom_mem);
             } else if (!written) {
                 fprintf(stderr, "[geom-probe] draw=%ld: transform feedback wrote 0 vertices "

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -142,6 +142,27 @@ live app recompiles fresh. Requires the device to advertise `VK_EXT_transform_fe
 probed draw's rendered pixels may be inexact (the re-recompile drops pixel-input remapping), but the captured
 `gl_Position` values are faithful; inert and byte-identical when the env var is unset.
 
+## Shader I/O value tap — `PROSPER_SHADER_TAP=PC` (what did the shader compute at instruction PC?)
+
+```bash
+PROSPER_SHADER_TAP=60 PROSPER_GEOM_PROBE=4 ./build-linux/gpu_replay /tmp/submit.prgcap /tmp/out.bmp
+# [geom-probe] draw=4 SHADER-TAP: values below are the tapped VGPR (dst+3) at that PC, not clip positions
+# [geom-probe]   v0 = float(0, 2.04e-41, 0, 0) hex(00000000 000038bc 00000000 00000000)
+```
+
+The deepest probe: capture a **shader's intermediate value** — a `MUBUF` vertex-fetch result, a decoded
+constant, a pre-transform coordinate — at the instruction whose PC you name (the same PC `shader_inspect`
+prints). The recompiler snapshots that instruction's destination VGPR (and the next 3) as a vec4 and redirects
+the vertex-position export to it, so the geometry-probe capture reads the value back per vertex. Output shows
+both float and raw hex (intermediate values are frequently integers/bitfields — read the hex for those).
+
+Workflow: `shader_inspect` the draw's VS (`--dump-realized-shader N:vs`) to find the PC whose value you want,
+then `PROSPER_SHADER_TAP=<pc> PROSPER_GEOM_PROBE=N`. This answers "is prosper fetching the right vertex data /
+computing the right intermediate?" without an oracle — it revealed GTA V #1163's mask draws fetch plausible
+large-integer control coordinates (so the off-screen result is data-driven, not garbage). Vertex stage only; the
+tapped draw's render is garbage in a tap run (position is redirected) but the captured values are exact; inert
+and byte-identical when the env var is unset.
+
 `--dump-shader DRAW:vs|fs PATH` writes the recompiled SPIR-V. Capture v19 adds
 `--dump-realized-shader DRAW:vs|fs PATH` for the exact bounded raw RDNA2 stream that produced that realized
 draw stage, suitable for `shader_inspect`. The VS/FS streams use the same content-addressed 64 KiB-per-stage,

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -161,7 +161,9 @@ then `PROSPER_SHADER_TAP=<pc> PROSPER_GEOM_PROBE=N`. This answers "is prosper fe
 computing the right intermediate?" without an oracle — it revealed GTA V #1163's mask draws fetch plausible
 large-integer control coordinates (so the off-screen result is data-driven, not garbage). Vertex stage only; the
 tapped draw's render is garbage in a tap run (position is redirected) but the captured values are exact; inert
-and byte-identical when the env var is unset.
+and byte-identical when the env var is unset. Tap a PC in the shader's **straight-line region** (e.g. the
+vertex-fetch/transform prologue) — a PC inside a loop or if-body defines the value in a block that doesn't
+dominate the position export, so the shader fails to compile (fail-visible: the draw drops, no output line).
 
 `--dump-shader DRAW:vs|fs PATH` writes the recompiled SPIR-V. Capture v19 adds
 `--dump-realized-shader DRAW:vs|fs PATH` for the exact bounded raw RDNA2 stream that produced that realized


### PR DESCRIPTION
## Summary
Adds `PROSPER_SHADER_TAP=PC` — the **shader I/O value tap**, fourth tool in the per-draw GPU debug suite (after `--draw-steps` #1228, `PROSPER_DRAW_STATS` #1241, `PROSPER_GEOM_PROBE` #1244). It captures a vertex shader's **intermediate value** — a `MUBUF` vertex-fetch result, a decoded constant, a pre-transform coordinate — at the instruction whose PC you name:

```
PROSPER_SHADER_TAP=60 PROSPER_GEOM_PROBE=4 gpu_replay submit.prgcap out.bmp
[geom-probe] draw=4 SHADER-TAP: values below are the tapped VGPR (dst+3) at that PC, not clip positions
[geom-probe]   v0 = float(0, 2.04e-41, 0, 0) hex(00000000 000038bc 00000000 00000000)
```

## Why
Answers "is prosper fetching the right vertex data / computing the right intermediate?" without an oracle — the question the geometry probe raises but can't answer. It refined GTA V #1163: the vanished mask draws fetch **plausible large-integer control coordinates** (0x38bc=14524, 0x75c4=30148…), so the off-screen transform is data-driven, not a garbage fetch — pointing the investigation away from the fetch and toward the panels' second-mask tessellation.

## Implementation
- **recompiler** (`rdna2_to_spirv`): after `emit_alu` processes the instruction at `tap_pc`, `emit_body` snapshots its destination VGPR (+3) as a vec4 (`set_tap`); `export_position` then exports that vec4 instead of `gl_Position`. Reuses the geometry probe's transform-feedback capture to read it back per vertex. `tap_pc` is set from the env var in `recompile_vertex` (vertex stage only).
- **render** (`render_runner`): the geometry-probe report detects the tap and prints float **and raw hex** (tapped values are frequently integers/bitfields) and skips the meaningless clip classification.

## Behavioral contract
- **No behavioral change** with the env var unset: `tap_pc` stays `0xFFFFFFFF`, no VGPR is snapshotted, `tap_vec` stays 0, `export_position` emits the real position, and rendering is byte-identical (verified: GTA V menu submit hash `670576577254c2e8` unchanged, zero `[geom-probe]` output).
- The redirected position is a plain `OpCompositeConstruct` vec4 + store — no new capability/decoration, so it stays valid SPIR-V.
- In a tap run the tapped draw's own render is intentionally garbage (its position is redirected); the captured values are exact. Vertex stage only.

## Verification
- **ctest 138/140** — the 2 failures (`module_loads_eboot`, `boot_reaches_first_syscall`) are dump-dependent boot/loader tests unrelated to the GPU path; **all recompiler + GPU render + spv_validate tests pass**.
- Default-path render **byte-identical**; geometry probe unaffected without the tap.
- Validated on the GTA V menu capsule: `PROSPER_SHADER_TAP=60` reveals draw 4's fetched control integers; `=65` the converted coordinate.

## Risk
Low–moderate — touches the recompiler, but the tap is gated (only fires when the env var names a PC) and the substituted export is trivially valid SPIR-V; the normal recompile is unchanged. Worth a reviewer's eye: the `emit_range` capture placement and the `export_position` substitution.
