### PR TITLE
fix(gpu): retire the generation and MB3-freelist fence suppressions by default

### DIFF
--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -456,14 +456,16 @@ static void waf_report(const char* kind, uint64_t addr, uint64_t pre, uint64_t v
 // #312 close: direct, non-trapping membership in the guest allocator's Malloc(0x20) freelists.
 // Unlike content/counter inference, this remains truthful before our DmaData init has overwritten a
 // freed node's NextFreeBlock with 0.
-// #1226: default OFF; PROSPER_MB3_FREELIST_GUARD=1 re-arms for investigation. Membership is not
-// proof of staleness either: a label the guest freed and IMMEDIATELY re-malloc'd sits at the same
-// address, and this walk races the allocator's own updates — observed on ArcRunner as 64
-// suppressed live-protocol writes per run. Partial suppression is the worst state (generation off
-// + this on faulted 3/3 EARLY: inits landed while their paired fences were membership-suppressed);
-// with the whole family off, ArcRunner ran 3/3 zero-fault and DOLL 2/2 zero-fatal (see
-// generation_guard above for the full A/B). The #241 stale-ring source is closed by exact submit
-// counts. CONFIDENCE: MED-HIGH.
+// #1226: default OFF; PROSPER_MB3_FREELIST_GUARD=1 re-arms for investigation (and is also
+// required, together with PROSPER_GENERATION_GUARD=1, to re-arm the DMA-init generation check —
+// see generation_guard below). Membership is not proof of staleness: a label the guest freed and
+// IMMEDIATELY re-malloc'd sits at the same address, and this walk races the allocator's own
+// updates — observed on ArcRunner as 64 suppressed live-protocol writes per run. Partial
+// suppression is the worst state (generation off + this on faulted 3/3 EARLY: inits landed while
+// their paired fences were membership-suppressed); with the whole family off, pooled figures are
+// ArcRunner 2/7 faulting vs 4/7 on, all survivors the pre-existing POOLSHIFT class, and DOLL 0
+// fence fatals in 4/4 (full A/B at generation_guard below). The #241 stale-ring source is closed
+// by exact submit counts. CONFIDENCE: MED-HIGH.
 static bool mb3_freelist_guard() {
     static const bool v = [] { const char* e = getenv("PROSPER_MB3_FREELIST_GUARD");
                                return e && strtol(e, nullptr, 0) != 0; }();   // default OFF (#1226)
@@ -487,18 +489,25 @@ static void stale_dma_change_report(uint64_t addr, uint64_t build_pre, uint64_t 
                 (unsigned long long)pre, (unsigned long long)pkt,
                 (unsigned long long)now_ms());
 }
-// #1226: gate for BOTH build-pre generation checks (the DMA-init form at honor_dma_data and the
-// REL form below). Default OFF; PROSPER_GENERATION_GUARD=1 re-arms for investigation. The
-// content-stability premise ("an owned label's residue cannot change between build and exec, so a
-// change means the packet is stale") is FALSE for titles that build command buffers ahead of
-// submit over a churning label pool: ArcRunner's deferred/late-flushed inits routinely observe
-// drifted content, the suppressed init creates dma-free debt that also kills the paired fence,
-// and every consumer wait on that label then times out (a 1 Hz cascade under PROSPER_WAIT_DEFER).
-// Live A/B evidence (2026-07-23, both titles on the #1245 build): ArcRunner 3/3 zero-fault 120 s
-// runs with this and the MB3 membership guard off vs 4/7 faulting with them on; DOLL 2/2 zero
-// free-unrecognized fatals off vs fatals recurring on (257 generation suppressions in the fatal
-// run). The stale-ring re-execution these checks guarded against (#241) is closed at the source
-// by exact submit dword counts on every entry point. CONFIDENCE: MED-HIGH.
+// #1226: gate for the build-pre generation checks. Default OFF. Re-arm contract: this env alone
+// re-arms only the REL form (stale_release_generation below); the DMA-init form at honor_dma_data
+// lives INSIDE the MB3-gated block and additionally requires PROSPER_MB3_FREELIST_GUARD=1 —
+// deliberately, because a generation-suppressed init creates dma-free debt that only the MB3
+// release leg consumes, and re-arming it alone would recreate the partial-suppression state
+// (init suppressed, paired fence lands) that measured WORST in the A/B. The content-stability
+// premise ("an owned label's residue cannot change between build and exec, so a change means the
+// packet is stale") is FALSE for titles that build command buffers ahead of submit over a
+// churning label pool: ArcRunner's deferred/late-flushed inits routinely observe drifted content,
+// the suppressed init's debt also kills the paired fence, and every consumer wait on that label
+// then times out (a 1 Hz cascade under PROSPER_WAIT_DEFER).
+// Live A/B evidence (2026-07-23, both titles on the #1245 build, pooled): ArcRunner 120 s worker
+// faults 2/7 with this and the MB3 membership guard off vs 4/7 with them on — and EVERY surviving
+// fault in both titles is the pre-existing POOLSHIFT byte-shifted-pool-pointer class, so an
+// observed POOLSHIFT fault is NOT a regression of this flip. Partial removal (generation off,
+// membership on) faulted 3/3 early. DOLL: 0 free-unrecognized fatals in 4/4 runs off vs fatals
+// recurring on (257 generation suppressions in the fatal run). The stale-ring re-execution these
+// checks guarded against (#241) is closed at the source by exact submit dword counts on every
+// entry point. CONFIDENCE: MED-HIGH.
 static bool generation_guard() {
     static const bool v = [] { const char* e = getenv("PROSPER_GENERATION_GUARD");
                                return e && strtol(e, nullptr, 0) != 0; }();   // default OFF (#1226)

--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -455,10 +455,18 @@ static void waf_report(const char* kind, uint64_t addr, uint64_t pre, uint64_t v
 }
 // #312 close: direct, non-trapping membership in the guest allocator's Malloc(0x20) freelists.
 // Unlike content/counter inference, this remains truthful before our DmaData init has overwritten a
-// freed node's NextFreeBlock with 0. Default ON; PROSPER_MB3_FREELIST_GUARD=0 is the live A/B escape.
+// freed node's NextFreeBlock with 0.
+// #1226: default OFF; PROSPER_MB3_FREELIST_GUARD=1 re-arms for investigation. Membership is not
+// proof of staleness either: a label the guest freed and IMMEDIATELY re-malloc'd sits at the same
+// address, and this walk races the allocator's own updates — observed on ArcRunner as 64
+// suppressed live-protocol writes per run. Partial suppression is the worst state (generation off
+// + this on faulted 3/3 EARLY: inits landed while their paired fences were membership-suppressed);
+// with the whole family off, ArcRunner ran 3/3 zero-fault and DOLL 2/2 zero-fatal (see
+// generation_guard above for the full A/B). The #241 stale-ring source is closed by exact submit
+// counts. CONFIDENCE: MED-HIGH.
 static bool mb3_freelist_guard() {
     static const bool v = [] { const char* e = getenv("PROSPER_MB3_FREELIST_GUARD");
-                               return !e || strtol(e, nullptr, 0) != 0; }();
+                               return e && strtol(e, nullptr, 0) != 0; }();   // default OFF (#1226)
     return v;
 }
 // A consumed-marker label is intentionally uninitialized when its DmaData packet is built. The
@@ -479,7 +487,25 @@ static void stale_dma_change_report(uint64_t addr, uint64_t build_pre, uint64_t 
                 (unsigned long long)pre, (unsigned long long)pkt,
                 (unsigned long long)now_ms());
 }
+// #1226: gate for BOTH build-pre generation checks (the DMA-init form at honor_dma_data and the
+// REL form below). Default OFF; PROSPER_GENERATION_GUARD=1 re-arms for investigation. The
+// content-stability premise ("an owned label's residue cannot change between build and exec, so a
+// change means the packet is stale") is FALSE for titles that build command buffers ahead of
+// submit over a churning label pool: ArcRunner's deferred/late-flushed inits routinely observe
+// drifted content, the suppressed init creates dma-free debt that also kills the paired fence,
+// and every consumer wait on that label then times out (a 1 Hz cascade under PROSPER_WAIT_DEFER).
+// Live A/B evidence (2026-07-23, both titles on the #1245 build): ArcRunner 3/3 zero-fault 120 s
+// runs with this and the MB3 membership guard off vs 4/7 faulting with them on; DOLL 2/2 zero
+// free-unrecognized fatals off vs fatals recurring on (257 generation suppressions in the fatal
+// run). The stale-ring re-execution these checks guarded against (#241) is closed at the source
+// by exact submit dword counts on every entry point. CONFIDENCE: MED-HIGH.
+static bool generation_guard() {
+    static const bool v = [] { const char* e = getenv("PROSPER_GENERATION_GUARD");
+                               return e && strtol(e, nullptr, 0) != 0; }();   // default OFF (#1226)
+    return v;
+}
 static bool stale_release_generation(const Pm4Command& c, uint64_t pre) {
+    if (!generation_guard()) return false;
     if (!c.rel_build_pre_valid || c.rel_data_sel != 1 || c.rel_value != 1 ||
         !label_is_consumed_marker(c.rel_addr)) return false;
     uint64_t initialized = c.rel_build_pre & 0xffffffff00000000ull;
@@ -976,7 +1002,7 @@ static void honor_dma_data(const Pm4Command& c, uint64_t retained_packet_addr = 
         if (mb3_freelist_guard() && c.dd_bytes == 4 && v32 == 0 &&
             label_is_consumed_marker(c.dd_dst)) {
             uint64_t build_pre = 0;
-            bool generation_changed = dma_build_pre_changed(c, pre_dma, &build_pre);
+            bool generation_changed = generation_guard() && dma_build_pre_changed(c, pre_dma, &build_pre);
             if (generation_changed) {
                 label_hist_dma_free(c.dd_dst, 0);
                 stale_dma_change_report(c.dd_dst, build_pre, pre_dma, packet_addr);

--- a/prosper/tests/test_eop_write.cpp
+++ b/prosper/tests/test_eop_write.cpp
@@ -45,6 +45,17 @@ static size_t run_cb(const uint32_t* buf, size_t dwords, GpuState& st) {
 
 int main() {
     printf("== test_eop_write ==\n");
+    // #1226: the generation and MB3-freelist suppression families are OFF by default (their
+    // content/membership premises misfire on live protocols — see generation_guard() /
+    // mb3_freelist_guard() in command_processor.cpp). This test verifies the suppression
+    // MECHANISMS, so arm them explicitly; the env is read once before any fold below.
+#ifdef _WIN32
+    _putenv_s("PROSPER_GENERATION_GUARD", "1");
+    _putenv_s("PROSPER_MB3_FREELIST_GUARD", "1");
+#else
+    setenv("PROSPER_GENERATION_GUARD", "1", 1);
+    setenv("PROSPER_MB3_FREELIST_GUARD", "1", 1);
+#endif
 
     // A RELEASE_MEM writing a 64-bit fence value (data_sel==2) to a label, exactly as agc_cb_release_mem
     // lays it out: [0]=hdr [1..2]=addr [3]=data_sel [4..5]=value lo/hi [6]=action.

--- a/prosper/tests/test_eop_write.cpp
+++ b/prosper/tests/test_eop_write.cpp
@@ -10,6 +10,7 @@
 #include "../src/gpu/pm4_decode.hpp"
 #include <cstdio>
 #include <cstdint>
+#include <cstdlib>   // setenv/_putenv_s: arm the #1226-retired suppression guards for this test
 #include <cstring>
 #ifdef _WIN32
 #include <windows.h>


### PR DESCRIPTION
Progresses #1226 — the second act of #1245, same method (protocol truth over content heuristics), same outcome across both UE4 titles. High-risk area (#312 guard family): full A/B matrix and cross-title verification below.

## Failure scenario

Two more default-ON #312 content heuristics were suppressing **live guest protocol writes**:

- **Build-pre generation checks** (DMA-init + REL forms): premise 'an owned label's content cannot change between packet build and exec' — false for titles that build command buffers ahead of submit over a churning label pool. A suppressed init creates dma-free debt that also kills the paired fence, so the label's whole generation dies and every consumer wait times out (measured 1 Hz timeout cascade under `PROSPER_WAIT_DEFER`, correlated line-for-line with `DMA-GENERATION-CHANGED` suppressions).
- **MB3-freelist membership**: membership is not staleness — a label freed and immediately re-malloc'd sits at the same address, and the walk races the allocator's own updates (64 suppressed live-protocol writes per ArcRunner run).

## A/B matrix (native Linux, RADV, all on the #1245 build)

| config | ArcRunner 120 s faults | DOLL 150 s fence fatals |
|---|---|---|
| guards ON (master) | 4/7 | 2 free-unrecognized in 1 of 2 runs (257 gen suppressions) |
| generation OFF, MB3 ON | **3/3 — worst** (inits land, fences membership-suppressed) | — |
| both OFF (this PR's default) | 2/7 | **0 in 4/4** |

Honesty note: an initial 3/3-clean ArcRunner sample was luck; the pooled 7-run guards-OFF figure is 2/7 (vs 4/7 ON). **Every surviving fault in both titles is now the single POOLSHIFT byte-shifted-pool-pointer class** (`0x30015f00` Arc / `0x20015f00` DOLL at the documented sites) — no fence-protocol suppression appears in any observed failure. ArcRunner's violated waits reduce to ~40 early-boot transients that stop entirely.

## Behavioral contract

Real hardware performs DmaData/ReleaseMem writes unconditionally at pipe time. The #241 stale-ring re-execution these heuristics guarded against is closed at the source by exact submit dword counts on every entry point. Both families remain fully implemented. Re-arm contract: `PROSPER_GENERATION_GUARD=1` alone re-arms the REL generation form; the DMA-init form additionally requires `PROSPER_MB3_FREELIST_GUARD=1` (its suppression debt is consumed only by the MB3 release leg — re-arming it alone would recreate the measured-worst partial-suppression state); `test_eop_write` arms them explicitly and continues to verify the mechanisms (all its suppression checks pass when armed).

## Deliberately unaffected

- Non-UE4 titles: these guards fire only for consumed-marker labels (DmaData-init history); Messenger/Dead Cells/Blasphemous 2/Evergate/Terminator never qualify — confirmed by the snapshot suite.
- The #1245 forge guard (protocol-state-gated) is untouched and remains default ON for the no-outstanding-init case.

## Risks

- A genuine stale packet reaching exec (only possible via an unknown-length fold, now rare) would land where it was suppressed — re-armable via env for investigation, and the debt/membership machinery is retained intact.
- The DOLL POOLSHIFT residual (1 worker fault/run) is pre-existing and unchanged in every config; it is the isolated next target on #1226.

## Verification (head af8d409; 457ad12 is a comment-only + test-include review follow-up, ctest rerun 139/139 on it)

- `ctest` **139/139** (after arming `test_eop_write`).
- `snapshot.py check` **all 5 guards OK** (messenger-scene, evergate-title, dead-cells-gameplay, blasphemous2-gameplay, terminator-boot).
- ArcRunner 4 confirmation runs on the default-flipped build behave identically to the env-forced config (gen=0, mb3=0 suppressions; faults 2/4 = the POOLSHIFT class only); DOLL 2 confirmation runs: 0 fatals.

