### PR TITLE
tool(gpu): PROSPER_FS_TAP — fragment-shader value tap (fixes #1250)

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -1534,7 +1534,11 @@ struct SpirvCompute {
     // Write a vec4(r,g,b,a) (bit-operands) to the matching fragment color output.
     void export_color(uint32_t mrt, uint32_t r, uint32_t g, uint32_t bl, uint32_t a) {
         if (mrt >= v_color.size() || !v_color[mrt]) return;
-        uint32_t v = id(); putv(code, Op_CompositeConstruct, {t_v4f, v, bcf(r), bcf(g), bcf(bl), bcf(a)});
+        // Fragment I/O tap (PROSPER_FS_TAP): if an intermediate was snapshotted at the tapped PC, store THAT
+        // as the MRT0 colour instead of the shader's real colour, so the rendered frame visualises the value.
+        uint32_t v;
+        if (tap_vec && mrt == 0) { v = tap_vec; }
+        else { v = id(); putv(code, Op_CompositeConstruct, {t_v4f, v, bcf(r), bcf(g), bcf(bl), bcf(a)}); }
         put(code, Op_Store, {v_color[mrt], v});
     }
     // Fragment depth export (EXP target 8 = MRTZ) — a lazily declared BuiltIn FragDepth output.
@@ -8647,6 +8651,14 @@ std::vector<uint32_t> recompile_fragment(const uint32_t* code, size_t dwords,
     if (!derived_interpolation.valid) return {};
     SpirvCompute b;
     b.begin_fragment(rt, color_mask);
+    // Fragment I/O value tap (PROSPER_FS_TAP=draw:pc): redirect the MRT0 colour export to the intermediate
+    // VGPR produced at that PC so the rendered frame visualises the value. The `draw:` prefix is consumed by
+    // gpu_replay (which re-recompiles only that draw's FS); here we take the PC after the ':' (or the whole
+    // value if there is no ':').
+    if (const char* tap = getenv("PROSPER_FS_TAP")) {
+        const char* pc = strchr(tap, ':');
+        b.tap_pc = static_cast<uint32_t>(strtoul(pc ? pc + 1 : tap, nullptr, 0));
+    }
     b.declare_guest_scratch(scratch);
     b.fragment_interpolation = &derived_interpolation;
     // P0-only attributes retain the cheap Flat varying path. Mixed smooth/explicit-parameter reads

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -165,6 +165,28 @@ and byte-identical when the env var is unset. Tap a PC in the shader's **straigh
 vertex-fetch/transform prologue) — a PC inside a loop or if-body defines the value in a block that doesn't
 dominate the position export, so the shader fails to compile (fail-visible: the draw drops, no output line).
 
+## Fragment I/O value tap — `PROSPER_FS_TAP=DRAW:PC` (what did the fragment shader compute at PC?)
+
+```bash
+PROSPER_FS_TAP=6:27 ./build-linux/gpu_replay /tmp/submit.prgcap /tmp/out.bmp
+# [fs-tap] draw 6 FS re-recompiled with colour tap (1740 words)
+# -> draw 6's pixels in out.bmp now show its sampled texel (the value at pc=27), not its real colour
+```
+
+The fragment-stage sibling of `PROSPER_SHADER_TAP`, for "why is this **pixel** the wrong colour?" — capture a
+fragment shader's intermediate at instruction `PC` (the same PC `shader_inspect` prints) and **redirect the
+MRT0 colour export to it**, so draw `DRAW`'s pixels in the rendered frame *are* the value visualised. Unlike the
+VS tap it needs no separate capture — the output BMP is the readout. Point `--dump-realized-shader DRAW:fs` +
+`shader_inspect` at the FS to find the PC (an `image_sample`/MIMG result, a UV, a pre-blend colour), then
+`PROSPER_FS_TAP=DRAW:PC`. gpu_replay re-recompiles only that draw's FS (needs a v19+ capsule with the raw FS
+stream); the rest of the frame renders normally, so read the tapped draw's region.
+
+Precision: the value goes through the colour attachment, so it inherits that target's format — values in [0,1]
+(UVs, colours, factors, alpha) show directly; larger values clamp (8-bit targets) — read them as colour, not
+exact floats. It confirmed GTA V #1163 draw 6 samples the correct artwork texture (so the colour path is fine;
+the defect is the stencil masks). Fragment stage only; tap a straight-line PC (same loop/if caveat as the VS
+tap); inert and byte-identical when the env var is unset.
+
 `--dump-shader DRAW:vs|fs PATH` writes the recompiled SPIR-V. Capture v19 adds
 `--dump-realized-shader DRAW:vs|fs PATH` for the exact bounded raw RDNA2 stream that produced that realized
 draw stage, suitable for `shader_inspect`. The VS/FS streams use the same content-addressed 64 KiB-per-stage,

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -185,7 +185,9 @@ Precision: the value goes through the colour attachment, so it inherits that tar
 (UVs, colours, factors, alpha) show directly; larger values clamp (8-bit targets) — read them as colour, not
 exact floats. It confirmed GTA V #1163 draw 6 samples the correct artwork texture (so the colour path is fine;
 the defect is the stencil masks). Fragment stage only; tap a straight-line PC (same loop/if caveat as the VS
-tap); inert and byte-identical when the env var is unset.
+tap); inert and byte-identical when the env var is unset. The re-recompile drops system inputs, so a tapped
+value derived from `gl_FragCoord`/sample position reads 0 (visualise fetch/sample/colour intermediates, not
+FragCoord-dependent terms).
 
 `--dump-shader DRAW:vs|fs PATH` writes the recompiled SPIR-V. Capture v19 adds
 `--dump-realized-shader DRAW:vs|fs PATH` for the exact bounded raw RDNA2 stream that produced that realized

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -1340,6 +1340,30 @@ int main(int argc, char** argv) {
             }
         }
     }
+    // Fragment I/O tap (PROSPER_FS_TAP=draw:pc): re-recompile draw N's raw FS (recompile_fragment reads the
+    // pc after the ':' and redirects its MRT0 colour export to the intermediate value at that PC) and swap it
+    // in, so that draw's rendered pixels visualise the tapped value. Requires a v19+ capsule with the raw FS.
+    if (const char* f = std::getenv("PROSPER_FS_TAP")) {
+        const long n = std::strtol(f, nullptr, 10);   // draw index (text before the ':')
+        if (n >= 0 && static_cast<size_t>(n) < replay.items.size()) {
+            auto& it = replay.items[static_cast<size_t>(n)];
+            if (it.fs_raw_shader_index < replay.raw_shader_versions.size()) {
+                const auto& raw = replay.raw_shader_versions[it.fs_raw_shader_index];
+                auto fs = prosper::gpu::recompile_fragment(raw.words.data(), raw.words.size(),
+                                                           it.prt.get(), nullptr, UINT32_MAX, nullptr);
+                if (!fs.empty()) {
+                    it.fs = std::move(fs); it.fs_shared.reset(); it.fs_identity = 0;
+                    std::fprintf(stderr, "[fs-tap] draw %ld FS re-recompiled with colour tap (%zu words)\n",
+                                 n, it.fs.size());
+                } else {
+                    std::fprintf(stderr, "[fs-tap] draw %ld: FS re-recompile produced no output "
+                                         "(no raw stream / unsupported)\n", n);
+                }
+            } else {
+                std::fprintf(stderr, "[fs-tap] draw %ld: no captured raw FS stream (capsule predates v19)\n", n);
+            }
+        }
+    }
     prosper::gpu::GpuCaptureFile prepend_capture;
     prosper::gpu::GpuReplayFrame prepend;
     if (!prepend_path.empty() &&


### PR DESCRIPTION
## Summary
Implements #1250 — `PROSPER_FS_TAP=DRAW:PC`, the **fragment-shader value tap**, sixth per-draw GPU debug tool and fragment-stage sibling of the VS `PROSPER_SHADER_TAP` (#1248). For "why is this **pixel** the wrong colour?": capture a fragment shader's intermediate (an `image_sample` result, a UV, a pre-blend colour) at the named instruction PC and **redirect the MRT0 colour export to it**, so the probed draw's pixels in the rendered frame *are* the value visualised.

```
PROSPER_FS_TAP=6:27 gpu_replay submit.prgcap out.bmp
[fs-tap] draw 6 FS re-recompiled with colour tap (1740 words)
-> draw 6's pixels show its sampled texel (value at pc=27), not its real colour
```

## Why
The suite covered geometry/coverage; this fills the fragment stage. It immediately confirmed GTA V #1163 draw 6 samples the **correct** artwork texture — so the colour/texture path is fine and the defect is purely the stencil masks, corroborating the winding-fill conclusion on #1231.

## Implementation
- **recompiler** (`rdna2_to_spirv`): `recompile_fragment` reads the PC (text after `:`) from `PROSPER_FS_TAP` and sets `b.tap_pc`; `export_color` stores the snapshotted VGPR (`tap_vec`, built by the shared `set_tap` from #1248) to MRT0 instead of the real colour. Reuses the entire tap machinery from the VS tap.
- **gpu_replay**: parses the DRAW (before `:`) and re-recompiles only that draw's raw FS (v19+ capsule with the raw FS stream), swapping `items[DRAW].fs` — exactly how the geometry probe re-recompiles the VS. The colour attachment is the readout, so no separate capture is needed.

## Behavioral contract
- **No behavioral change** with `PROSPER_FS_TAP` unset: `tap_pc` stays `0xFFFFFFFF`, no VGPR is snapshotted, `tap_vec` stays 0, `export_color` emits the real colour, rendering is byte-identical (verified: hash `670576577254c2e8` unchanged).
- Fragment stage only; the redirected MRT0 store is a plain vec4 (no new capability/decoration) → valid SPIR-V.
- Precision: the value inherits the colour target's format — [0,1] values show directly, larger values clamp on 8-bit targets (read as colour, not exact floats). Same straight-line-PC (loop/if dominance) caveat as the VS tap.

## Verification
- **ctest 138/140** — the 2 failures (`module_loads_eboot`, `boot_reaches_first_syscall`) are dump-dependent boot/loader tests unrelated to the GPU path; **all recompiler + GPU render + spv_validate tests pass**.
- Default-path render **byte-identical**.
- Validated on the GTA V menu capsule: `PROSPER_FS_TAP=6:27` renders draw 6's region as its sampled texel (the artwork texture).

## Risk
Low–moderate — touches the recompiler (`export_color` + one env read), but the tap is gated and the redirected store is trivially valid SPIR-V; the normal FS recompile is unchanged.

Fixes #1250.
