### PR TITLE
diag(gpu,host,hle): POOLSHIFT hunt instrumentation — widened tripwire, fault-time byte dumps, APR-destination provenance

### DIFF
--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -339,20 +339,24 @@ static bool ptr_like(uint64_t v) {
            (v >= 0x2000000000ull && v < 0x2100000000ull);
 }
 // #312 POOLSHIFT tripwire: the dominant residual crash reads a BYTE-SHIFTED pool-info pointer
-// (`0x20015f00` == `0x20015f0000 >> 8`) at eboot+0x2316c91. A qword is "byte-shifted pool ptr" when
-// its top 32 bits are 0 and (v<<8) lands in the FPoolInfo metadata region [0x2000000000,0x2100000000)
-// — i.e. an 8-byte pool pointer written one byte too LOW (aligned read drops the low byte). This
+// (historically `0x20015f00` == `0x20015f0000 >> 8` at eboot+0x2316c91). A qword is "byte-shifted
+// pool ptr" when its top 32 bits are 0 and (v<<8) lands in the allocator-metadata region — i.e. an
+// 8-byte pool pointer stored one byte too LOW (an aligned read then drops the low byte). This
 // catches ANY GPU-path write that CREATES that shape in the act, with the packet builder callsite.
+// #1226: the window is [0x2000000000, 0x4000000000) — the old DOLL-era [0x20..0x21) window went
+// stale when prosper's dmem layout moved: post-#1249 faults on BOTH DOLL and ArcRunner dereference
+// `0x30015f00` (<<8 = 0x30015f0000, the same FPoolInfo +0x15f0000 arena offset), which the old
+// window could not see (a silent false-negative for the exact hunt this tripwire exists for).
 static inline bool is_byteshift_poolptr(uint64_t v) {
     if (v >> 32) return false;                 // must fit in low 32 bits (top byte(s) were dropped)
     if (v < 0x100000) return false;            // ignore tiny ints
     uint64_t s = v << 8;
-    return s >= 0x2000000000ull && s < 0x2100000000ull;
+    return s >= 0x2000000000ull && s < 0x4000000000ull;
 }
 // A full (unshifted) pool-info pointer as a WRITE PAYLOAD is itself anomalous for a GPU fence/label
-// write (fence values are small ints / timestamps), so flag that too.
+// write (fence values are small ints / timestamps), so flag that too. (#1226: same widened window.)
 static inline bool is_poolinfo_ptr(uint64_t v) {
-    return v >= 0x2000000000ull && v < 0x2100000000ull;
+    return v >= 0x2000000000ull && v < 0x4000000000ull;
 }
 // Scan the just-written span [dst-8, dst+bytes+8) for a byte-shifted pool pointer and log the GPU
 // writer (kind + dst + packet builder addr) if found. Bounded; small writes only (the label/pointer
@@ -378,6 +382,15 @@ static void poolshift_check(const char* kind, uint64_t dst, uint64_t bytes, uint
     for (uint64_t a = lo; a < hi; a += 8) {
         uint64_t q = peek_qword(a);
         if (is_byteshift_poolptr(q)) {
+            // #1226 precision: the widened window admits any dword in [0x20000000,0x3fffffff]
+            // (floats, sizes) — a REAL shifted pool pointer's <<8 must at least be MAPPED guest
+            // memory (0x3d787f0000-style unmapped values are guest data, not pointers). Also
+            // dedup consecutive repeats: one stale value next to a hot per-frame label otherwise
+            // saturates the report cap in seconds (measured: 128/128 on one address).
+            if (!guest_readable(q << 8, 8)) continue;
+            static uint64_t last_a = 0, last_q = 0;
+            if (a == last_a && q == last_q) continue;
+            last_a = a; last_q = q;
             bool inspan = (a + 7 >= dst) && (a < dst + bytes);   // did THIS write touch these bytes?
             if (n.fetch_add(1) < 128)
                 fprintf(stderr, "[agc] POOLSHIFT-STOMP kind=%s @0x%llx=0x%llx (<<8=0x%llx) dst=0x%llx bytes=%llu inspan=%d payload=0x%llx pkt=eboot+0x%llx t=%llums\n",

--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -368,14 +368,23 @@ static void poolshift_check(const char* kind, uint64_t dst, uint64_t bytes, uint
     // 0x20015f00 pool pointer — so it stays as diagnostic-only instrumentation for the next session.
     static const bool on = getenv("PROSPER_POOLSHIFT") != nullptr;
     if (!on) return;
-    static std::atomic<int> n{0};
-    if (n.load(std::memory_order_relaxed) >= 128) return;
-    if (is_byteshift_poolptr(payload) || is_poolinfo_ptr(payload)) {
-        if (n.fetch_add(1) < 128)
+    // #1252 review: PAYLOAD and STOMP get SEPARATE caps — with the widened windows, a shared cap
+    // let ordinary address-source DMA payloads (full arena VAs now match is_poolinfo_ptr) burn the
+    // budget and silence the stomp scan, the exact silent-false-negative this tripwire hunts.
+    // The payload flag also requires the same mapped-target proof as the scan (byteshift form) and
+    // skips DMA (whose `payload` is a SOURCE ADDRESS, legitimately arena-valued, not written data).
+    static std::atomic<int> n_payload{0};
+    static std::atomic<int> n{0};   // STOMP-scan reports only
+    const bool payload_suspicious =
+        (is_byteshift_poolptr(payload) && guest_readable(payload << 8, 8)) ||
+        (is_poolinfo_ptr(payload) && kind[0] != 'D');
+    if (payload_suspicious) {
+        if (n_payload.fetch_add(1) < 128)
             fprintf(stderr, "[agc] POOLSHIFT-PAYLOAD kind=%s dst=0x%llx bytes=%llu payload=0x%llx pkt=eboot+0x%llx t=%llums\n",
                     kind, (unsigned long long)dst, (unsigned long long)bytes,
                     (unsigned long long)payload, (unsigned long long)pkt, (unsigned long long)now_ms());
     }
+    if (n.load(std::memory_order_relaxed) >= 128) return;
     if (bytes > 256) return;                    // cap the scan (label/pointer writes are small)
     uint64_t lo = (dst >= 8 ? dst - 8 : dst) & ~7ull;
     uint64_t hi = dst + bytes + 8;
@@ -388,9 +397,9 @@ static void poolshift_check(const char* kind, uint64_t dst, uint64_t bytes, uint
             // dedup consecutive repeats: one stale value next to a hot per-frame label otherwise
             // saturates the report cap in seconds (measured: 128/128 on one address).
             if (!guest_readable(q << 8, 8)) continue;
-            static uint64_t last_a = 0, last_q = 0;
-            if (a == last_a && q == last_q) continue;
-            last_a = a; last_q = q;
+            static std::atomic<uint64_t> last_a{0}, last_q{0};
+            if (a == last_a.load(std::memory_order_relaxed) && q == last_q.load(std::memory_order_relaxed)) continue;
+            last_a.store(a, std::memory_order_relaxed); last_q.store(q, std::memory_order_relaxed);
             bool inspan = (a + 7 >= dst) && (a < dst + bytes);   // did THIS write touch these bytes?
             if (n.fetch_add(1) < 128)
                 fprintf(stderr, "[agc] POOLSHIFT-STOMP kind=%s @0x%llx=0x%llx (<<8=0x%llx) dst=0x%llx bytes=%llu inspan=%d payload=0x%llx pkt=eboot+0x%llx t=%llums\n",

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -32,6 +32,7 @@
 #include <sys/mman.h>    // PROSPER_APR_ALTDEST: prosper-owned guest read buffer
 #include <pthread.h>
 #include <thread>        // PROSPER_APR_DEFER: async (real-hardware-timing) APR fill
+#include <chrono>        // #1226: APR-destination provenance timestamps
 #else
 #include <direct.h>
 #include <io.h>
@@ -2150,8 +2151,47 @@ static int apr_cached_fd(const std::string& host) {
 // face). Commit the pages exactly like the fault handler and retry once. CONFIDENCE: HIGH (same
 // policy as the lazy-commit path in exec_image_linux.cpp). Shared by the record-based
 // sceAmprAprCommandBufferReadFile path and the direct vWU-odnS+fU read (issue #115).
+// #1226 APR-destination provenance: APR is the one prosper subsystem that bulk-writes guest memory
+// OUTSIDE the GPU write ring / clock-fence provenance (async file reads via process_vm_writev
+// below), and APR-vs-allocator collisions have prior form (#88's second face was exactly the
+// "free an unrecognized block" fatal). Persistent, never-aging, direct-mapped record of the last
+// write per destination, so the PROSPER_FAULTOBJ worker-fault dump can answer "was the corrupted
+// slot (or the buffer a poisoned value points into) ever an APR destination?" Always-on: one
+// hashed store per APR write. Async-signal-safe reader; diagnostic-grade races acceptable.
+namespace {
+struct AprDestRec { uint64_t dst, size, t_ms; uint32_t count; };
+constexpr uint32_t kAprDestSlots = 8192;               // power of two
+AprDestRec g_apr_dests[kAprDestSlots];
+uint64_t apr_now_ms() {
+    static const auto t0 = std::chrono::steady_clock::now();
+    return (uint64_t)std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - t0).count();
+}
+void apr_dest_record(uint64_t dst, uint64_t size) {
+    AprDestRec& rec = g_apr_dests[(uint32_t)(((dst >> 4) * 0x9E3779B97F4A7C15ull) >> 51)
+                                  & (kAprDestSlots - 1)];
+    if (rec.dst != dst) { rec.dst = dst; rec.count = 0; }
+    rec.size = size; rec.t_ms = apr_now_ms(); rec.count++;
+}
+}
+extern "C" int prosper_apr_dest_scan(uint64_t lo, uint64_t hi, char* out, size_t cap) {
+    size_t off = 0; int found = 0;
+    for (uint32_t i = 0; i < kAprDestSlots && off + 120 < cap; i++) {
+        const AprDestRec& rec = g_apr_dests[i];
+        if (!rec.dst || rec.dst + rec.size <= lo || rec.dst >= hi) continue;
+        int m = snprintf(out + off, cap - off,
+                         "[aprdest] dst=0x%llx size=%llu count=%u t=%llums\n",
+                         (unsigned long long)rec.dst, (unsigned long long)rec.size,
+                         rec.count, (unsigned long long)rec.t_ms);
+        if (m > 0) off += (size_t)m;
+        found++;
+    }
+    if (off < cap) out[off] = 0;
+    return found;
+}
 static bool apr_write_guest_dst(uint64_t dst, void* buf, uint64_t size) {
     if (!size) return true;
+    apr_dest_record(dst, size);
     struct iovec l { buf, (size_t)size }, r { (void*)(uintptr_t)dst, (size_t)size };
     if (process_vm_writev(getpid(), &l, 1, &r, 1, 0) == (ssize_t)size) return true;
     bool committed = false;

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -2157,11 +2157,18 @@ static int apr_cached_fd(const std::string& host) {
 // "free an unrecognized block" fatal). Persistent, never-aging, direct-mapped record of the last
 // write per destination, so the PROSPER_FAULTOBJ worker-fault dump can answer "was the corrupted
 // slot (or the buffer a poisoned value points into) ever an APR destination?" Always-on: one
-// hashed store per APR write. Async-signal-safe reader; diagnostic-grade races acceptable.
+// hashed store per ATTEMPTED APR write (failed writes are recorded too — conservative in the
+// exonerating direction). Async-signal-safe reader; diagnostic-grade races acceptable. Answers
+// coverage for both the corrupted slot pages and the reconstructed (candidate<<8) page (the
+// FAULTOBJ dump scans both).
 namespace {
 struct AprDestRec { uint64_t dst, size, t_ms; uint32_t count; };
 constexpr uint32_t kAprDestSlots = 8192;               // power of two
 AprDestRec g_apr_dests[kAprDestSlots];
+// Direct-mapped with eviction, so a zero-hit scan means "no SURVIVING record", not "never a
+// destination" (#1252 review). The store/evict totals are printed in the scan header so a zero
+// result carries its own confidence: sparse evictions = strong, heavy churn = weak.
+std::atomic<uint64_t> g_apr_dest_stores{0}, g_apr_dest_evicts{0};
 uint64_t apr_now_ms() {
     static const auto t0 = std::chrono::steady_clock::now();
     return (uint64_t)std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -2170,15 +2177,26 @@ uint64_t apr_now_ms() {
 void apr_dest_record(uint64_t dst, uint64_t size) {
     AprDestRec& rec = g_apr_dests[(uint32_t)(((dst >> 4) * 0x9E3779B97F4A7C15ull) >> 51)
                                   & (kAprDestSlots - 1)];
-    if (rec.dst != dst) { rec.dst = dst; rec.count = 0; }
+    g_apr_dest_stores.fetch_add(1, std::memory_order_relaxed);
+    if (rec.dst != dst) {
+        if (rec.dst) g_apr_dest_evicts.fetch_add(1, std::memory_order_relaxed);
+        rec.dst = dst; rec.count = 0;
+    }
     rec.size = size; rec.t_ms = apr_now_ms(); rec.count++;
 }
 }
 extern "C" int prosper_apr_dest_scan(uint64_t lo, uint64_t hi, char* out, size_t cap) {
     size_t off = 0; int found = 0;
+    int hdr = snprintf(out, cap, "[aprdest] table: stores=%llu evictions=%llu\n",
+                       (unsigned long long)g_apr_dest_stores.load(std::memory_order_relaxed),
+                       (unsigned long long)g_apr_dest_evicts.load(std::memory_order_relaxed));
+    if (hdr > 0 && (size_t)hdr < cap) off = (size_t)hdr;
     for (uint32_t i = 0; i < kAprDestSlots && off + 120 < cap; i++) {
         const AprDestRec& rec = g_apr_dests[i];
-        if (!rec.dst || rec.dst + rec.size <= lo || rec.dst >= hi) continue;
+        if (!rec.dst) continue;
+        uint64_t rec_end = rec.dst + rec.size;
+        if (rec_end < rec.dst) rec_end = ~0ull;        // saturate a corrupt/huge size (#1252 review)
+        if (rec_end <= lo || rec.dst >= hi) continue;
         int m = snprintf(out + off, cap - off,
                          "[aprdest] dst=0x%llx size=%llu count=%u t=%llums\n",
                          (unsigned long long)rec.dst, (unsigned long long)rec.size,

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -2073,6 +2073,9 @@ namespace {
                         // image+0x127e751) or r8 (DOLL, image+0x2316acf); dump around both when
                         // guest-pointer-shaped. Mixed 4-byte compressed entries vs full 8-byte
                         // heads in the NEIGHBORING bins are visible directly in the byte stream.
+                        // #1252 review: print the ABSOLUTE base address of the dump, never a
+                        // relative label — byte-exact forensics must not require the reader to
+                        // reconstruct the base from call-site arithmetic.
                         auto byte_dump = [&](const char* nm, uint64_t center) {
                             if (center < 0x10000) return;
                             uint8_t bytes[0x60];
@@ -2080,8 +2083,9 @@ namespace {
                             struct iovec rb; rb.iov_base = (void*)(uintptr_t)(center - 0x20); rb.iov_len = sizeof bytes;
                             ssize_t got = syscall(SYS_process_vm_readv, getpid(), &lb, 1UL, &rb, 1UL, 0UL);
                             if (got <= 0) return;
-                            char bb[600];
-                            int bn = snprintf(bb, sizeof bb, "[faultobj] bytes @%s-0x20:", nm);
+                            char bb[640];
+                            int bn = snprintf(bb, sizeof bb, "[faultobj] bytes (%s) @0x%llx:", nm,
+                                              (unsigned long long)(center - 0x20));
                             for (ssize_t k = 0; k < got && bn < (int)sizeof bb - 4; k++)
                                 bn += snprintf(bb + bn, sizeof bb - (size_t)bn, "%s%02x",
                                                (k % 8 == 0) ? " " : "", bytes[k]);
@@ -2118,7 +2122,18 @@ namespace {
                             // What actually lives at the reconstructed pointer? A live free block
                             // (next-pointer residue), a pool-info record, or unrelated data —
                             // discriminates "compressed pointer misread" from coincidence.
-                            byte_dump("real", real + 0x20);
+                            byte_dump("real ptr", real + 0x20);
+                            // Was the reconstructed buffer itself ever an APR destination?
+                            if (prosper_apr_dest_scan) {
+                                static char ar[4096];
+                                uint64_t rp = real & ~0xfffull;
+                                int arn = prosper_apr_dest_scan(rp, rp + 0x1000, ar, sizeof ar);
+                                char h5[112]; int h5n = snprintf(h5, sizeof h5,
+                                    "[faultobj] APR dests overlapping real-ptr page 0x%llx: %d\n",
+                                    (unsigned long long)rp, arn);
+                                syscall(SYS_write, 2, h5, (size_t)h5n);
+                                if (arn > 0) syscall(SYS_write, 2, ar, strlen(ar));
+                            }
                             uint64_t pg = real & ~0xfffull;
                             if (prosper_gpu_write_ring_scan) {
                                 static char rs[4096];

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -763,6 +763,9 @@ namespace {
     // value's high dword (the {orig_low32, clock_low32} A-4 read-back signature; see gpu TU).
     extern "C" int prosper_gpu_clockfence_find_low32(uint32_t low32, char* out, size_t cap)
         __attribute__((weak));
+    // #1226: APR-destination provenance (hle_file.cpp) — the bulk guest-writer no ring tracks.
+    extern "C" int prosper_apr_dest_scan(uint64_t lo, uint64_t hi, char* out, size_t cap)
+        __attribute__((weak));
 
     // Issue-#312 heap-corruption attribution dump, fired on the first PROSPER_NULL_PAGE hit (the
     // deterministic precursor of DOLL's MallocBinned3 "Canary was 0x3" fatal: a read of address
@@ -2047,6 +2050,94 @@ namespace {
                                 (unsigned long long)v, hi32, fn3);
                             syscall(SYS_write, 2, hb, (size_t)hn);
                             if (fn3 > 0) syscall(SYS_write, 2, fb, strlen(fb));
+                        }
+                    }
+                    // #1226 POOLSHIFT probe. Both residual fault classes dereference a value whose
+                    // <<8 lands in the allocator-metadata region (0x30015f00 -> pool table
+                    // 0x30015f0000 on current dmem layouts, both UE4 titles). Two questions a
+                    // fault can answer directly:
+                    // (1) mechanism discriminator — a BYTE dump around the source slot [rdx]: if
+                    //     the UNSHIFTED pointer sits at rdx-1 (bytes align one low), the pointer
+                    //     was STORED at an odd address; if the slot holds exactly the shifted
+                    //     value with clean zero high bytes, it was COPIED/computed already-shifted.
+                    // (2) writer cross-reference — scan the GPU-write ring and clock-fence table
+                    //     around (v<<8), the REAL pool table, not just the corrupted slot.
+                    {
+                        uint64_t rdx_val2 = 0;
+                        struct iovec l2; l2.iov_base = &rdx_val2; l2.iov_len = 8;
+                        struct iovec r2; r2.iov_base = (void*)(uintptr_t)g_rdx; r2.iov_len = 8;
+                        if (syscall(SYS_process_vm_readv, getpid(), &l2, 1UL, &r2, 1UL, 0UL) != 8)
+                            rdx_val2 = 0;
+                        // Byte dump around the free-list SLOT — the mechanism discriminator. The
+                        // two observed pop compilations keep the slot pointer in rdx (ArcRunner,
+                        // image+0x127e751) or r8 (DOLL, image+0x2316acf); dump around both when
+                        // guest-pointer-shaped. Mixed 4-byte compressed entries vs full 8-byte
+                        // heads in the NEIGHBORING bins are visible directly in the byte stream.
+                        auto byte_dump = [&](const char* nm, uint64_t center) {
+                            if (center < 0x10000) return;
+                            uint8_t bytes[0x60];
+                            struct iovec lb; lb.iov_base = bytes; lb.iov_len = sizeof bytes;
+                            struct iovec rb; rb.iov_base = (void*)(uintptr_t)(center - 0x20); rb.iov_len = sizeof bytes;
+                            ssize_t got = syscall(SYS_process_vm_readv, getpid(), &lb, 1UL, &rb, 1UL, 0UL);
+                            if (got <= 0) return;
+                            char bb[600];
+                            int bn = snprintf(bb, sizeof bb, "[faultobj] bytes @%s-0x20:", nm);
+                            for (ssize_t k = 0; k < got && bn < (int)sizeof bb - 4; k++)
+                                bn += snprintf(bb + bn, sizeof bb - (size_t)bn, "%s%02x",
+                                               (k % 8 == 0) ? " " : "", bytes[k]);
+                            bn += snprintf(bb + bn, sizeof bb - (size_t)bn, "\n");
+                            syscall(SYS_write, 2, bb, (size_t)bn);
+                        };
+                        byte_dump("rdx", g_rdx);
+                        byte_dump("r8", g_r8);
+                        // #1226: cross-reference the slot pages against APR write destinations —
+                        // the bulk guest-writer outside every GPU provenance ring (#88 precedent).
+                        if (prosper_apr_dest_scan) {
+                            static char ab[4096];
+                            const uint64_t aprobes[2] = { g_rdx, g_r8 };
+                            for (uint64_t probe : aprobes) {
+                                uint64_t pg = probe & ~0xfffull;
+                                if (pg < 0x1000) continue;
+                                int an = prosper_apr_dest_scan(pg, pg + 0x1000, ab, sizeof ab);
+                                char h4[112]; int h4n = snprintf(h4, sizeof h4,
+                                    "[faultobj] APR dests overlapping page 0x%llx: %d\n",
+                                    (unsigned long long)pg, an);
+                                syscall(SYS_write, 2, h4, (size_t)h4n);
+                                if (an > 0) syscall(SYS_write, 2, ab, strlen(ab));
+                            }
+                        }
+                        const uint64_t cands[3] = { g_rax, g_rcx, rdx_val2 };
+                        for (uint64_t v : cands) {
+                            if (v >> 32 || v < 0x100000) continue;           // must look byte-shifted
+                            uint64_t real = v << 8;
+                            if (real < 0x2000000000ull || real >= 0x4000000000ull) continue;
+                            char pb[128]; int pn = snprintf(pb, sizeof pb,
+                                "[faultobj] POOLSHIFT candidate 0x%llx -> real ptr 0x%llx\n",
+                                (unsigned long long)v, (unsigned long long)real);
+                            syscall(SYS_write, 2, pb, (size_t)pn);
+                            // What actually lives at the reconstructed pointer? A live free block
+                            // (next-pointer residue), a pool-info record, or unrelated data —
+                            // discriminates "compressed pointer misread" from coincidence.
+                            byte_dump("real", real + 0x20);
+                            uint64_t pg = real & ~0xfffull;
+                            if (prosper_gpu_write_ring_scan) {
+                                static char rs[4096];
+                                int rn2 = prosper_gpu_write_ring_scan(pg, pg + 0x1000, rs, sizeof rs);
+                                char h2[112]; int h2n = snprintf(h2, sizeof h2,
+                                    "[faultobj] GPU-write-ring hits at real-ptr page 0x%llx: %d\n",
+                                    (unsigned long long)pg, rn2);
+                                syscall(SYS_write, 2, h2, (size_t)h2n);
+                                if (rn2 > 0) syscall(SYS_write, 2, rs, strlen(rs));
+                            }
+                            if (prosper_gpu_clockfence_scan) {
+                                static char cs[4096];
+                                int cn2 = prosper_gpu_clockfence_scan(pg, pg + 0x1000, cs, sizeof cs);
+                                char h3[112]; int h3n = snprintf(h3, sizeof h3,
+                                    "[faultobj] clock-fence targets at real-ptr page 0x%llx: %d\n",
+                                    (unsigned long long)pg, cn2);
+                                syscall(SYS_write, 2, h3, (size_t)h3n);
+                                if (cn2 > 0) syscall(SYS_write, 2, cs, strlen(cs));
+                            }
                         }
                     }
                 }

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -2107,7 +2107,7 @@ namespace {
                                     "[faultobj] APR dests overlapping page 0x%llx: %d\n",
                                     (unsigned long long)pg, an);
                                 syscall(SYS_write, 2, h4, (size_t)h4n);
-                                if (an > 0) syscall(SYS_write, 2, ab, strlen(ab));
+                                syscall(SYS_write, 2, ab, strlen(ab));   // unconditional: the stores/evictions header IS the zero-case confidence signal
                             }
                         }
                         const uint64_t cands[3] = { g_rax, g_rcx, rdx_val2 };
@@ -2132,7 +2132,7 @@ namespace {
                                     "[faultobj] APR dests overlapping real-ptr page 0x%llx: %d\n",
                                     (unsigned long long)rp, arn);
                                 syscall(SYS_write, 2, h5, (size_t)h5n);
-                                if (arn > 0) syscall(SYS_write, 2, ar, strlen(ar));
+                                syscall(SYS_write, 2, ar, strlen(ar));   // unconditional (see above)
                             }
                             uint64_t pg = real & ~0xfffull;
                             if (prosper_gpu_write_ring_scan) {


### PR DESCRIPTION
Progresses #1226 (the POOLSHIFT leg). Diagnostics only — no behavioral change on any write or guard path.

## What this adds and what it already proved

1. **Widened + tightened POOLSHIFT tripwire**: the byte-shift windows were DOLL-era `[0x2000000000,0x2100000000)` and physically could not see the current faults' `0x30015f00` artifact (prosper's dmem layout moved since July 10 — a silent false-negative in the exact tool built for this hunt). Widened to `[0x20..0x40)`, with a mapped-pointer requirement on the reconstructed address plus consecutive-dup dedup (the raw widening admitted any `0x20000000..0x3fffffff` dword — one stale float saturated the 128-report cap). **Result: a full faulting DOLL run produces ZERO in-the-act or adjacent hits — the PM4-write-path exoneration now rests on a window that can actually see the artifact.**
2. **`PROSPER_FAULTOBJ` byte-level dumps** around the free-list slot (both observed pop compilations: `rdx` ArcRunner, `r8` DOLL) and around the reconstructed `(candidate<<8)` target. **Result: the poisoned TLS pool bin reads `{head=0x30015f00, count=3/8}` between HEALTHY `{raw 8-byte 0x20xx-arena pointer, count}` neighbors — raw encoding throughout, one foreign value pushed via the normal path; and `0x30015f0000` is a buffer filled wall-to-wall with dword `0x00024001`** — the same constant as the first corruption class and the eboot's static `{0x24001|size}` template records.
3. **APR-destination provenance**: persistent per-destination record of every `apr_write_guest_dst` (the bulk guest-writer outside all GPU provenance rings; #88 is precedent for APR-vs-allocator fatals), cross-referenced at fault. **Result: zero APR writes overlapping the poisoned pool-array page.**

## Where the evidence points (recorded on #1226)

The guest itself calls `free(0x30015f00)` — a GPU-encoded (`addr>>8`, the AGC PGM/descriptor convention) address of the `0x24001` buffer; `count=8` shows it entered the bin through the ordinary push path. Real hardware runs the same code clean, so the leading suspect is a prosper HLE output carrying a `>>8`-encoded value where the real API returns a raw pointer. The next decisive instrument is a hardware watchpoint on the learned TLS pool bins (catches the push with a guest backtrace) — gated on `kernel.perf_event_paranoid=1` on the dev host.

## Risks / unaffected

All additions are gated diagnostics (`PROSPER_POOLSHIFT`, `PROSPER_FAULTOBJ`) or always-on bounded recording (APR table: 8192 fixed slots, one hashed store per APR write; async-signal-safe reader following the clock-fence-table precedent). No guard, write, or ordering change anywhere.

## Verification

- Full build + `ctest` **139/139** on the exact head (an earlier in-session ctest ran against an unbuilt worktree and reported spurious failures; re-verified green after a full build — noting for transparency).
- Live evidence runs on both titles exercising every new path (byte dumps, APR scan, tightened tripwire, candidate reconstruction) — outputs quoted above and on #1226.