### PR TITLE
diag(hle): PROSPER_MUTEX_WAITLOG (guest-mutex holder probe) + per-submit EOP pulse log

### DIFF
--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -1518,6 +1518,13 @@ bool deferred_pending()   { return !g_deferred.empty(); }
 // drain (vs per-stream) is the right granularity — it only errs later, the safe direction.
 namespace { uint64_t g_owed_pulses = 0; }
 void submit_completion_pulse(bool submit_rejected) {
+    if (getenv("PROSPER_EOPLOG")) {
+        static uint64_t call = 0;
+        fprintf(stderr, "[eop-pulse] #%llu rejected=%d deferred_empty=%d owed=%llu -> %s\n",
+                (unsigned long long)++call, submit_rejected ? 1 : 0, g_deferred.empty() ? 1 : 0,
+                (unsigned long long)g_owed_pulses,
+                submit_rejected ? "SKIP(rejected)" : (g_deferred.empty() ? "FIRE" : "OWE"));
+    }
     if (submit_rejected) return;
     if (!g_deferred.empty()) { g_owed_pulses++; return; }
     prosper_eq_trigger_eop();

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -470,10 +470,18 @@ namespace {
     std::mutex g_mtx_waitlog_mx;
     std::unordered_map<pthread_mutex_t*, MtxOwner> g_mtx_waitlog_owner;
     inline bool mtx_waitlog() { static const bool on = getenv("PROSPER_MUTEX_WAITLOG") != nullptr; return on; }
+    // winpthreads has no pthread_getname_np — fall back to the tid there (this is a POSIX debug tool).
+    inline void mtx_waitlog_self_name(char* buf, size_t len) {
+#ifdef _WIN32
+        snprintf(buf, len, "tid%ld", (long)prosper_gettid());
+#else
+        pthread_getname_np(pthread_self(), buf, len);
+#endif
+    }
     void mtx_waitlog_record(pthread_mutex_t* m) {
         if (!mtx_waitlog()) return;
         MtxOwner o; o.tid = (long)prosper_gettid();
-        pthread_getname_np(pthread_self(), o.name, sizeof o.name);
+        mtx_waitlog_self_name(o.name, sizeof o.name);
         std::lock_guard<std::mutex> lk(g_mtx_waitlog_mx); g_mtx_waitlog_owner[m] = o;
     }
     void mtx_waitlog_clear(pthread_mutex_t* m) {
@@ -486,7 +494,7 @@ namespace {
         MtxOwner o{}; bool have = false;
         { std::lock_guard<std::mutex> lk(g_mtx_waitlog_mx);
           auto it = g_mtx_waitlog_owner.find(m); if (it != g_mtx_waitlog_owner.end()) { o = it->second; have = true; } }
-        char self[16] = {0}; pthread_getname_np(pthread_self(), self, sizeof self);
+        char self[16] = {0}; mtx_waitlog_self_name(self, sizeof self);
         static std::atomic<int> n{0};
         if (n.fetch_add(1) < 256)
             fprintf(stderr, "[mtx-wait] '%s'(tid=%ld) BLOCKING on guest mutex slot=0x%llx held by %s\n",

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -463,25 +463,19 @@ namespace {
     }
 }
 // PROSPER_MUTEX_WAITLOG: name the HOLDER of a contended guest mutex when a thread is about to block on
-// it — a deadlock/lock-contention probe (POSIX ownership tracking above is Windows-only for perf). Fully
-// gated: the owner map is only touched when the env var is set, so there is zero cost by default.
+// it — a deadlock/lock-contention probe. POSIX-only (Linux/macOS): Windows already has the guest-mutex
+// ownership map above, and winpthreads lacks pthread_getname_np. Fully gated: the owner map is only
+// touched when the env var is set, so there is zero cost by default.
+#ifndef _WIN32
 namespace {
     struct MtxOwner { long tid = 0; char name[16] = {0}; };
     std::mutex g_mtx_waitlog_mx;
     std::unordered_map<pthread_mutex_t*, MtxOwner> g_mtx_waitlog_owner;
     inline bool mtx_waitlog() { static const bool on = getenv("PROSPER_MUTEX_WAITLOG") != nullptr; return on; }
-    // winpthreads has no pthread_getname_np — fall back to the tid there (this is a POSIX debug tool).
-    inline void mtx_waitlog_self_name(char* buf, size_t len) {
-#ifdef _WIN32
-        snprintf(buf, len, "tid%ld", (long)prosper_gettid());
-#else
-        pthread_getname_np(pthread_self(), buf, len);
-#endif
-    }
     void mtx_waitlog_record(pthread_mutex_t* m) {
         if (!mtx_waitlog()) return;
         MtxOwner o; o.tid = (long)prosper_gettid();
-        mtx_waitlog_self_name(o.name, sizeof o.name);
+        pthread_getname_np(pthread_self(), o.name, sizeof o.name);
         std::lock_guard<std::mutex> lk(g_mtx_waitlog_mx); g_mtx_waitlog_owner[m] = o;
     }
     void mtx_waitlog_clear(pthread_mutex_t* m) {
@@ -494,7 +488,7 @@ namespace {
         MtxOwner o{}; bool have = false;
         { std::lock_guard<std::mutex> lk(g_mtx_waitlog_mx);
           auto it = g_mtx_waitlog_owner.find(m); if (it != g_mtx_waitlog_owner.end()) { o = it->second; have = true; } }
-        char self[16] = {0}; mtx_waitlog_self_name(self, sizeof self);
+        char self[16] = {0}; pthread_getname_np(pthread_self(), self, sizeof self);
         static std::atomic<int> n{0};
         if (n.fetch_add(1) < 256)
             fprintf(stderr, "[mtx-wait] '%s'(tid=%ld) BLOCKING on guest mutex slot=0x%llx held by %s\n",
@@ -503,6 +497,13 @@ namespace {
                          : "<owner unknown / acquired via cond_wait>");
     }
 }
+#else
+namespace {
+    inline void mtx_waitlog_record(pthread_mutex_t*) {}
+    inline void mtx_waitlog_clear(pthread_mutex_t*) {}
+    inline void mtx_waitlog_report_block(pthread_mutex_t*, uint64_t) {}
+}
+#endif
 HLE(k_mutex_lock)    {
     auto* m = ensure_mutex(a0); if (!m) return 0x16;
     if (guest_mutex_self_deadlock(m)) return mtx_report("lock", a0, m, EDEADLK);

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -462,23 +462,57 @@ namespace {
         return fbsd_errno(host);
     }
 }
+// PROSPER_MUTEX_WAITLOG: name the HOLDER of a contended guest mutex when a thread is about to block on
+// it — a deadlock/lock-contention probe (POSIX ownership tracking above is Windows-only for perf). Fully
+// gated: the owner map is only touched when the env var is set, so there is zero cost by default.
+namespace {
+    struct MtxOwner { long tid = 0; char name[16] = {0}; };
+    std::mutex g_mtx_waitlog_mx;
+    std::unordered_map<pthread_mutex_t*, MtxOwner> g_mtx_waitlog_owner;
+    inline bool mtx_waitlog() { static const bool on = getenv("PROSPER_MUTEX_WAITLOG") != nullptr; return on; }
+    void mtx_waitlog_record(pthread_mutex_t* m) {
+        if (!mtx_waitlog()) return;
+        MtxOwner o; o.tid = (long)prosper_gettid();
+        pthread_getname_np(pthread_self(), o.name, sizeof o.name);
+        std::lock_guard<std::mutex> lk(g_mtx_waitlog_mx); g_mtx_waitlog_owner[m] = o;
+    }
+    void mtx_waitlog_clear(pthread_mutex_t* m) {
+        if (!mtx_waitlog()) return;
+        std::lock_guard<std::mutex> lk(g_mtx_waitlog_mx); g_mtx_waitlog_owner.erase(m);
+    }
+    void mtx_waitlog_report_block(pthread_mutex_t* m, uint64_t slot) {
+        if (!mtx_waitlog()) return;
+        if (pthread_mutex_trylock(m) == 0) { pthread_mutex_unlock(m); return; } // uncontended
+        MtxOwner o{}; bool have = false;
+        { std::lock_guard<std::mutex> lk(g_mtx_waitlog_mx);
+          auto it = g_mtx_waitlog_owner.find(m); if (it != g_mtx_waitlog_owner.end()) { o = it->second; have = true; } }
+        char self[16] = {0}; pthread_getname_np(pthread_self(), self, sizeof self);
+        static std::atomic<int> n{0};
+        if (n.fetch_add(1) < 256)
+            fprintf(stderr, "[mtx-wait] '%s'(tid=%ld) BLOCKING on guest mutex slot=0x%llx held by %s\n",
+                    self, (long)prosper_gettid(), (unsigned long long)slot,
+                    have ? ([&]{ static char b[48]; snprintf(b, sizeof b, "'%s'(tid=%ld)", o.name, o.tid); return b; }())
+                         : "<owner unknown / acquired via cond_wait>");
+    }
+}
 HLE(k_mutex_lock)    {
     auto* m = ensure_mutex(a0); if (!m) return 0x16;
     if (guest_mutex_self_deadlock(m)) return mtx_report("lock", a0, m, EDEADLK);
+    mtx_waitlog_report_block(m, a0);
     const int result = interruptible_mutex_lock(m);
-    if (result == 0) guest_mutex_acquired(m);
+    if (result == 0) { guest_mutex_acquired(m); mtx_waitlog_record(m); }
     return mtx_report("lock", a0, m, result);
 }
 HLE(k_mutex_trylock) {
     auto* m = ensure_mutex(a0); if (!m) return 0x16;
     const int result = pthread_mutex_trylock(m);
-    if (result == 0) guest_mutex_acquired(m);
+    if (result == 0) { guest_mutex_acquired(m); mtx_waitlog_record(m); }
     return mtx_report("trylock", a0, m, result);
 }
 HLE(k_mutex_unlock)  {
     auto* m = ensure_mutex(a0); if (!m) return 0x16;
     const int result = pthread_mutex_unlock(m);
-    if (result == 0) guest_mutex_released(m);
+    if (result == 0) { guest_mutex_released(m); mtx_waitlog_clear(m); }
     return mtx_report("unlock", a0, m, result);
 }
 


### PR DESCRIPTION
## Goal
Two gated, off-by-default diagnostics built while investigating Blue Prince's (PPSA25009) first-room load
stall — and specifically to **separate it from the EOP-delivery frontier (#1113/#1195)**. They're reusable
for any lock-contention / EOP investigation, so I'm landing them for the frontier agents (`session_011GRJS7`
on #1195, the overnight-session on #1113).

## 1. `PROSPER_MUTEX_WAITLOG` — guest-mutex holder probe (`hle_kernel.cpp`)
When a guest thread is about to block on a contended guest mutex, logs the **holder's thread name + tid**:
```
[mtx-wait] 'Loading.Preload'(tid=…) BLOCKING on guest mutex slot=0x… held by 'screenshot'(tid=…)
```
POSIX had no guest-mutex ownership tracking (`g_guest_mutex_states` is Windows-only for perf), so this adds a
**fully-gated** owner map (recorded on lock/trylock success, cleared on unlock, reported via a pre-block
`trylock`). Falls back to `<owner unknown / acquired via cond_wait>` when the lock was taken through
`pthread_cond_wait`'s internal re-acquire. Capped at 256 lines. This is what showed Blue Prince's stall is
main-thread ↔ `Loading.Preload` lock **thrashing** around the suspend-point safe-flag (a livelock), not a
hard deadlock.

## 2. Per-submit EOP pulse log (`command_processor.cpp`, gated on existing `PROSPER_EOPLOG`)
One line per `submit_completion_pulse`:
```
[eop-pulse] #N rejected=0 deferred_empty=1 owed=0 -> FIRE   (or OWE / SKIP(rejected))
```
Turns "is the EOP pulse fired, owed, or skipped?" into a grep. Proved Blue Prince fires **every** pulse
(1982/1982 `FIRE`) — i.e. its stall is **not** the #1113 EOP-delivery bug (see #1195 for the full analysis).

## Affected / unaffected
- **Diagnostic-only.** No behavior change with the env vars unset; the mutex owner-map is only touched when
  `PROSPER_MUTEX_WAITLOG` is set, so there's no synchronization-throughput cost by default (the reason the
  existing ownership map is Windows-gated).

## Verification
- `ctest`: **142/142**.
- Both used live on Blue Prince to produce the analysis posted on #1195.

Low-risk, off-by-default; supports the #1113/#1195 EOP/suspend-point frontier and future deadlock work.