### PR TITLE
diag(gpu,hle,host): per-submit POOLSHIFT window probe + pool-candidate fault check

### DIFF
--- a/prosper/src/gpu/mb3_freelist.cpp
+++ b/prosper/src/gpu/mb3_freelist.cpp
@@ -260,6 +260,32 @@ int mb3_poolshift_window_scan(char* out, unsigned cap) {
             found++;
         }
     }
+    // #1252-review B1: the eight global recycler slots hold bundle HEAD values directly, so a
+    // poisoned bundle parked there (not in any TLS bin) carries the same byteshift shape. Scan them
+    // too, else a parked poison scores found=0 for its whole residence. Chain INTERIORS remain a
+    // structural blind spot (the poison buried below a healthy head is invisible to a head-only
+    // scan) — see the header comment; the watchpoint path is what actually closes that.
+    uint64_t recycler = g_global_recycler_bin.load(std::memory_order_acquire);
+    if (!recycler) recycler = discover_global_recycler_bin();
+    if (recycler >= 0x10000 && !(recycler & 7ull)) {
+        for (uint8_t slot = 0; slot < 8; ++slot) {
+            uint64_t head = 0;
+            if (!safe_read(recycler + (uint64_t)slot * 8, &head, sizeof head)) break;
+            if (head >> 32 || head < 0x100000) continue;
+            uint64_t real = head << 8;
+            if (real < 0x2000000000ull || real >= 0x4000000000ull) continue;
+            uint64_t probe;
+            if (!safe_read(real, &probe, sizeof probe)) continue;
+            if (out && off + 96 < cap) {
+                int m = snprintf(out + off, cap - off,
+                                 "[poolshift-window] recycler=0x%llx slot=%u head=0x%llx (<<8=0x%llx)\n",
+                                 (unsigned long long)recycler, slot, (unsigned long long)head,
+                                 (unsigned long long)real);
+                if (m > 0) off += (unsigned)m;
+            }
+            found++;
+        }
+    }
     if (out && off < cap) out[off] = 0;
     return found;
 }

--- a/prosper/src/gpu/mb3_freelist.cpp
+++ b/prosper/src/gpu/mb3_freelist.cpp
@@ -228,6 +228,53 @@ bool mb3_freelist_contains_stable(uint64_t block, Mb3FreelistMatch* match) {
     return true;
 }
 
+// See mb3_freelist.hpp. Bin region: the first 0x400 bytes of each learned pool array cover 32
+// size classes of {head, count32, secondaryHead, secondaryCount32} at 0x20 stride; heads sit at
+// +0x00 and +0x10 of each class (observed live: the #1226 poisoned bin at base+0x20 between
+// healthy raw-pointer bins). A legitimate head is 0 or a full 0x20xx/0x30xx pointer (nonzero top
+// dword), so the byte-shifted test (top32==0, <<8 lands in mapped [0x20..0x40) guest memory) has
+// no overlap with healthy state; safe_read doubles as the fault-safe mappedness probe.
+int mb3_poolshift_window_scan(char* out, unsigned cap) {
+    unsigned off = 0; int found = 0;
+    uint32_t count = g_pool_candidate_count.load(std::memory_order_acquire);
+    if (count > kMaxPoolCandidates) count = kMaxPoolCandidates;
+    for (uint32_t i = 0; i < count; i++) {
+        uint64_t base = g_pool_candidates[i].load(std::memory_order_acquire);
+        if (!base) continue;
+        uint8_t bins[0x400];
+        if (!safe_read(base, bins, sizeof bins)) continue;
+        for (uint32_t o = 0; o + 8 <= sizeof bins; o += 0x10) {
+            uint64_t q; memcpy(&q, bins + o, sizeof q);
+            if (q >> 32 || q < 0x100000) continue;
+            uint64_t real = q << 8;
+            if (real < 0x2000000000ull || real >= 0x4000000000ull) continue;
+            uint64_t probe;
+            if (!safe_read(real, &probe, sizeof probe)) continue;
+            if (out && off + 96 < cap) {
+                int m = snprintf(out + off, cap - off,
+                                 "[poolshift-window] pool=0x%llx +0x%x head=0x%llx (<<8=0x%llx)\n",
+                                 (unsigned long long)base, o, (unsigned long long)q,
+                                 (unsigned long long)real);
+                if (m > 0) off += (unsigned)m;
+            }
+            found++;
+        }
+    }
+    if (out && off < cap) out[off] = 0;
+    return found;
+}
+
+// #1226: is `base` a learned TLS pool array? Async-signal-safe (atomic loads only) — the
+// PROSPER_FAULTOBJ dump uses it to report whether the faulting pool was even visible to the
+// window probe (an unregistered pool explains a probe miss without implicating scan timing).
+extern "C" int prosper_mb3_is_pool_candidate(uint64_t base) {
+    uint32_t count = g_pool_candidate_count.load(std::memory_order_acquire);
+    if (count > kMaxPoolCandidates) count = kMaxPoolCandidates;
+    for (uint32_t i = 0; i < count; i++)
+        if (g_pool_candidates[i].load(std::memory_order_acquire) == base) return 1;
+    return 0;
+}
+
 void mb3_reset_pool_candidates_for_test() {
     for (auto& base : g_pool_candidates) base.store(0, std::memory_order_relaxed);
     g_pool_candidate_count.store(0, std::memory_order_release);

--- a/prosper/src/gpu/mb3_freelist.cpp
+++ b/prosper/src/gpu/mb3_freelist.cpp
@@ -260,7 +260,7 @@ int mb3_poolshift_window_scan(char* out, unsigned cap) {
             found++;
         }
     }
-    // #1252-review B1: the eight global recycler slots hold bundle HEAD values directly, so a
+    // #1254-review B1: the eight global recycler slots hold bundle HEAD values directly, so a
     // poisoned bundle parked there (not in any TLS bin) carries the same byteshift shape. Scan them
     // too, else a parked poison scores found=0 for its whole residence. Chain INTERIORS remain a
     // structural blind spot (the poison buried below a healthy head is invisible to a head-only

--- a/prosper/src/gpu/mb3_freelist.hpp
+++ b/prosper/src/gpu/mb3_freelist.hpp
@@ -28,6 +28,13 @@ void mb3_note_global_recycler_bin(uint64_t base);
 // observed twice so a concurrent allocator pop cannot turn a stale first read into a false verdict.
 bool mb3_freelist_contains_stable(uint64_t block, Mb3FreelistMatch* match = nullptr);
 
+// #1226 POOLSHIFT window scan: walk every learned TLS pool array's bin region (both bundle heads
+// per 0x20-stride size class) and report heads whose value is a byte-shifted (>>8-encoded) pointer
+// to MAPPED guest memory — the poisoned-bin signature. Called per submit (env-gated by the caller)
+// so a state CHANGE bounds the poisoning free() to one submit window. Fault-safe; returns the hit
+// count and formats up to `cap` bytes into `out` (NUL-terminated) when out is non-null.
+int mb3_poolshift_window_scan(char* out, unsigned cap);
+
 // Test isolation for the process-global candidate registry.
 void mb3_reset_pool_candidates_for_test();
 

--- a/prosper/src/gpu/mb3_freelist.hpp
+++ b/prosper/src/gpu/mb3_freelist.hpp
@@ -28,11 +28,17 @@ void mb3_note_global_recycler_bin(uint64_t base);
 // observed twice so a concurrent allocator pop cannot turn a stale first read into a false verdict.
 bool mb3_freelist_contains_stable(uint64_t block, Mb3FreelistMatch* match = nullptr);
 
-// #1226 POOLSHIFT window scan: walk every learned TLS pool array's bin region (both bundle heads
-// per 0x20-stride size class) and report heads whose value is a byte-shifted (>>8-encoded) pointer
-// to MAPPED guest memory — the poisoned-bin signature. Called per submit (env-gated by the caller)
-// so a state CHANGE bounds the poisoning free() to one submit window. Fault-safe; returns the hit
-// count and formats up to `cap` bytes into `out` (NUL-terminated) when out is non-null.
+// #1226 POOLSHIFT window scan: walk every learned TLS pool array's bin heads (both bundle heads
+// per 0x20-stride size class) AND the eight global recycler slots, reporting any head whose value
+// is a byte-shifted (>>8-encoded) pointer to MAPPED guest memory — the poisoned-bin signature.
+// Called per submit (env-gated by the caller). LIMITS (do NOT read a found=0 as "no poison in this
+// window"): it samples head RESIDENCE only — a poison buried in a free-chain INTERIOR (below a
+// healthy head) is invisible, and a head that only surfaces in a microsecond sliver on the
+// allocator hot path can fall between two per-submit samples. So a state change gives a WEAK bound
+// (the poison was at a scanned head between these submits), never the free()-to-fault lifetime; the
+// mapped-target requirement additionally drops a poisoned head whose <<8 target was unmapped by
+// scan time. The watchpoint path (PROSPER_MB3WATCH) is what actually traps the store. Fault-safe;
+// returns the hit count and formats up to `cap` bytes into `out` (NUL-terminated) when out non-null.
 int mb3_poolshift_window_scan(char* out, unsigned cap);
 
 // Test isolation for the process-global candidate registry.

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -1190,9 +1190,11 @@ static bool execute_submit_work(gpu::GpuState& st, uint64_t submit_no, unsigned&
 extern "C" void prosper_gpu_set_fold_origin(uint8_t origin);   // #1226 queue-origin diagnostic
 extern "C" uint64_t prosper_guest_tsc_ns();                    // shared guest clock (hle_kernel_time)
 // #1226 POOLSHIFT window probe (PROSPER_POOLSHIFT_WINDOW=1): after each submit, scan the learned
-// TLS pool bins for the byte-shifted-head poison signature and log on STATE CHANGE — the poisoning
-// guest free() is thereby bounded to one inter-submit window for log correlation (the software
-// fallback while hardware watchpoints are unavailable on the dev host). Serialized by the callers'
+// TLS pool bins + global recycler slots for the byte-shifted-head poison signature and log on STATE
+// CHANGE. A change gives only a WEAK bound — the poison was at a scanned head between these two
+// submits — NOT the free()-to-fault lifetime: the scan samples head residence, and a poison buried
+// in a chain interior or surfacing in a sub-submit sliver is missed (see mb3_poolshift_window_scan).
+// The decisive instrument is PROSPER_MB3WATCH (traps the store). Serialized by the callers'
 // g_agc_state_mu, so the plain statics are single-threaded.
 static void poolshift_window_probe(uint64_t submit_no) {
     static const bool on = getenv("PROSPER_POOLSHIFT_WINDOW") != nullptr;

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -15,6 +15,7 @@
 #include "gpu/gpu_execute.hpp"
 #include "gpu/gpu_timeline.hpp"
 #include "gpu/videoout_present.hpp"
+#include "gpu/mb3_freelist.hpp"   // #1226: per-submit POOLSHIFT window probe
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
@@ -1187,6 +1188,25 @@ static bool execute_submit_work(gpu::GpuState& st, uint64_t submit_no, unsigned&
 // `dw_num == 0` means "length unknown" — decode_pm4 self-terminates at the first non-type-3 dword, and
 // we cap the walk at kUnknownCap dwords as a runaway guard (a bounded ring can't legitimately exceed it).
 extern "C" void prosper_gpu_set_fold_origin(uint8_t origin);   // #1226 queue-origin diagnostic
+extern "C" uint64_t prosper_guest_tsc_ns();                    // shared guest clock (hle_kernel_time)
+// #1226 POOLSHIFT window probe (PROSPER_POOLSHIFT_WINDOW=1): after each submit, scan the learned
+// TLS pool bins for the byte-shifted-head poison signature and log on STATE CHANGE — the poisoning
+// guest free() is thereby bounded to one inter-submit window for log correlation (the software
+// fallback while hardware watchpoints are unavailable on the dev host). Serialized by the callers'
+// g_agc_state_mu, so the plain statics are single-threaded.
+static void poolshift_window_probe(uint64_t submit_no) {
+    static const bool on = getenv("PROSPER_POOLSHIFT_WINDOW") != nullptr;
+    if (!on) return;
+    static char buf[2048];
+    static int last_found = -1;
+    int found = gpu::mb3_poolshift_window_scan(buf, sizeof buf);
+    if (found != last_found) {
+        fprintf(stderr, "[agc] POOLSHIFT-WINDOW submit=%llu found=%d (was %d) t=%llums\n%s",
+                (unsigned long long)submit_no, found, last_found,
+                (unsigned long long)prosper_guest_tsc_ns() / 1000000ull, found ? buf : "");
+        last_found = found;
+    }
+}
 static uint64_t submit_dcb_stream(const uint32_t* addr, uint32_t dw_num, const char* who) {
     if (!addr) return 0;
     constexpr uint32_t kUnknownCap = 0x80000;   // 512 KiB of dwords — well past any real Dcb
@@ -1221,6 +1241,7 @@ static uint64_t submit_dcb_stream(const uint32_t* addr, uint32_t dw_num, const c
     // Watchdog keys off PENDING streams, not just this fold: streams can outlive their fold (and
     // the Jump-recursion flag reset once hid a deferring fold entirely — the wedge class).
     if (gpu::deferred_pending()) start_defer_watchdog();
+    poolshift_window_probe(g_submit_count);
     if (getenv("PROSPER_GFXLOG"))
         fprintf(stderr, "[agc] %s #%llu: %u dwords (walk=%u) -> %zu packets applied (draws: %zu, dispatches: %llu)\n",
                 who, (unsigned long long)g_submit_count, dw_num, walk, applied,
@@ -1313,6 +1334,7 @@ HLE(agc_driver_submit_dcb) {  // (const Packet* packet)
     gpu::flush_deferred_streams();
     gpu::submit_completion_pulse(agc_gpu_state().dma_execution_rejected);
     if (gpu::deferred_pending()) start_defer_watchdog();
+    poolshift_window_probe(g_submit_count);
     if (getenv("PROSPER_GFXLOG")) {
         fprintf(stderr, "[agc] SubmitDcb #%llu: %u dwords -> %zu packets applied (draws so far: %zu, dispatches total: %llu)\n",
                 (unsigned long long)g_submit_count, p->dw_num, applied, agc_gpu_state().draws.size(),

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -766,6 +766,8 @@ namespace {
     // #1226: APR-destination provenance (hle_file.cpp) — the bulk guest-writer no ring tracks.
     extern "C" int prosper_apr_dest_scan(uint64_t lo, uint64_t hi, char* out, size_t cap)
         __attribute__((weak));
+    // #1226: pool-candidate membership (mb3_freelist.cpp) — async-signal-safe atomic reads.
+    extern "C" int prosper_mb3_is_pool_candidate(uint64_t base) __attribute__((weak));
 
     // Issue-#312 heap-corruption attribution dump, fired on the first PROSPER_NULL_PAGE hit (the
     // deterministic precursor of DOLL's MallocBinned3 "Canary was 0x3" fatal: a read of address
@@ -2094,6 +2096,16 @@ namespace {
                         };
                         byte_dump("rdx", g_rdx);
                         byte_dump("r8", g_r8);
+                        // #1226: was the faulting pool array even visible to the window probe?
+                        if (prosper_mb3_is_pool_candidate) {
+                            for (uint64_t pb : { g_rdx & ~0xffffull, g_r8 & ~0xffffull }) {
+                                if (pb < 0x10000) continue;
+                                char cb2[96]; int cn2 = snprintf(cb2, sizeof cb2,
+                                    "[faultobj] pool 0x%llx candidate=%d\n",
+                                    (unsigned long long)pb, prosper_mb3_is_pool_candidate(pb));
+                                syscall(SYS_write, 2, cb2, (size_t)cn2);
+                            }
+                        }
                         // #1226: cross-reference the slot pages against APR write destinations —
                         // the bulk guest-writer outside every GPU provenance ring (#88 precedent).
                         if (prosper_apr_dest_scan) {

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -157,7 +157,10 @@ namespace {
     uint64_t g_lwatch_stk[8] = {0};          // guest-RA call stack captured on SIGSEGV
     int      g_lwatch_stkn = 0;
     static inline bool lwatch_is_pool_shift(uint64_t v) {
-        return (v >> 32) == 0 && ((v << 8) >= 0x2000000000ull && (v << 8) < 0x2100000000ull);
+        // #1226: widened from the DOLL-era [0x20..0x21) to [0x20..0x40) — the current faults on both
+        // DOLL and ArcRunner store 0x30015f00 (<<8 = 0x30015f0000), which the old window could not
+        // see (dmem layout moved). Matches is_byteshift_poolptr in command_processor.cpp.
+        return (v >> 32) == 0 && ((v << 8) >= 0x2000000000ull && (v << 8) < 0x4000000000ull);
     }
     bool g_bp_shift = false;   // PROSPER_BP_SHIFT=1: only log a BP hit when rsi is a pool-shifted ptr
     // PROSPER_BP=0xOFFSET (guest image offset): int3 code-breakpoint that LOGS registers at each hit,


### PR DESCRIPTION
Progresses #1226 (POOLSHIFT leg). Diagnostics only; includes the probe's own documented negative result, which redirects the hunt.

## What this adds

- **`PROSPER_POOLSHIFT_WINDOW=1`**: after each submit (both entry points, serialized under the submit mutex), scan every learned TLS pool array's bin region — both bundle heads per 0x20-stride size class, fault-safe reads, byteshift-shape + mapped-target test — and log on state change, bounding a poisoned-bin appearance to one inter-submit window. `mb3_poolshift_window_scan` exported from the MB3 model (which already documents the exact bin layout this reads).
- **`PROSPER_FAULTOBJ` pool-candidate check**: at a worker fault, report whether the faulting pool array is in the learned candidate registry (async-signal-safe atomic reads).

## The result that matters

Two faulting DOLL runs: **`candidate=1` — the faulting pool was in the learned registry at fault time — yet `found=0` throughout the run.** Corrected per review (B1): this is a **weak** bound — the scan samples head *residence* only. The poison can live buried in a free-chain interior (below a healthy head) or parked in a global recycler slot for many windows, surfacing at a scanned head only in a sub-submit sliver, so `found=0` does **not** establish that the free()-to-fault lifetime is under one window. What it does establish: per-submit head sampling cannot reliably catch this writer at any practical rate. The decisive instrument must trap the store itself:
1. **Hardware watchpoints** on the learned bins (preferred; blocked on `kernel.perf_event_paranoid=1` on the dev host), or
2. a value-filtering extension of the protection-based `guest_write_watch` (delicate fault-path work, tracked on #1226).

The probe now also scans the eight global recycler slots and stays as a cheap standing tripwire (a poison resident at any scanned head across a submit boundary is caught; chain interiors remain a head-only-scan blind spot), and the candidate check removes registration coverage as an alternative explanation for any future probe miss.

## Risks / unaffected

Env-gated scan (≤256 registered pools (observed ~21) × 1 KiB fault-safe reads per submit, only when armed); an always-callable atomic membership query; no behavioral path touched. Windows/macOS compile via the existing `safe_read` portability layers; the FAULTOBJ wiring stays in the Linux-only block behind a weak symbol.

## Verification

Full build + `ctest` **139/139** on the exact head. Live DOLL runs exercising probe arming, state-change logging (submit=1 baseline line), and the candidate check at a real fault (outputs quoted above and on #1226).

