### PR TITLE
fix(gpu/exec): trust the DrawIndexAuto count for non-indexed draws (GTA V #1163)

### DIFF
--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -556,6 +556,24 @@ inline bool index_buffer_is_unannounced_32bit(const uint16_t* p16, const uint32_
     return has_odd && odd_zero && all_small && any_nonzero;
 }
 
+// #1163: choose a NON-INDEXED draw's vertex count. A DrawIndexAuto packet's count (draw_count) is the
+// AUTHORITATIVE hardware vertex count — the GPU draws exactly that many vertices with auto indices
+// 0..draw_count-1. The bound vertex buffer's record count (vb_records = size/stride) is ONLY a fallback for
+// a draw that supplied no count at all; it must NEVER override a real count. Historically (#60) the executor
+// folded a whole submit into one item and applied the FIRST draw's index_count to it, so a multi-draw mesh
+// rendered only that first (small) count -> a degenerate sliver; substituting the larger VB record count
+// recovered the geometry. The per-draw executor now gives every draw its OWN decoded count (R_DRAW_INDEX_-
+// AUTO -> index_count), so that workaround is obsolete, and substituting the VB record count is actively WRONG when
+// a title binds a SHARED vertex POOL: GTA V's Scaleform UI submits per-draw counts of 3/6/30 against one
+// fixed ~4096-byte pool, so vb_records = pool/stride is 146/1024/512 — sweeping the whole pool rasterizes
+// hundreds of spurious triangles from stale/zero pool data. That inflated the stencil masks' coverage past
+// their EQUAL==2 clip (GTA #1163's black menu wedges) and painted the same phantom vertex tail that earlier
+// read as an "alpha-0 compositing" artifact. Zero-count non-indexed draws are already skipped as no-ops
+// (#400) before this runs, so draw_count is non-zero in practice and the vb_records fallback is a guard.
+inline uint32_t resolve_nonindexed_vertex_count(uint32_t draw_count, uint32_t vb_records) {
+    return draw_count ? draw_count : vb_records;
+}
+
 // Realize ONE draw of `ds` (a register snapshot or the folded state) into a DrawItem: recompile the
 // VS+PS, resolve fixed-function state, and — for an indexed draw — fetch the guest index buffer.
 // `draw` is the PM4 draw record (index count + indexed/index_addr); null means "no record" (hand-built
@@ -960,17 +978,17 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
     }
     // A genuinely empty draw (vcount_hint == 0 — engines emit 0-vertex DrawIndexAuto/DrawIndexOffset as
     // no-ops) that resolved NO indices above must render nothing, exactly as it does on hardware. Do NOT
-    // fall through: `vertex_count = vcount_hint ? vcount_hint : 3` already fabricated 3, and the
-    // vb_entries override below would then sweep the ENTIRE residual vertex pool (0..vb_entries-1) of
-    // whatever geometry the last-bound VB still holds — turning a no-op into a phantom triangle or a
-    // full-VB draw of stale geometry composited into the frame (#400). The vb_entries "truer count"
-    // override exists to correct a LOW/stale count, never to synthesize one for a zero-count draw.
+    // fall through: `vertex_count = vcount_hint ? vcount_hint : 3` already fabricated 3, and the vb_records
+    // fallback in resolve_nonindexed_vertex_count() below would then sweep the ENTIRE residual vertex pool
+    // (0..vb_records-1) of whatever geometry the last-bound VB still holds — turning a no-op into a phantom
+    // triangle or a full-VB draw of stale geometry composited into the frame (#400). Skipping here keeps
+    // that fallback a pure zero-count guard; a non-zero DrawIndexAuto count is authoritative (see #1163).
     if (vcount_hint == 0 && out.indices.empty()) {
         if (failure) failure->reason = RealizationFailureReason::ZeroVertices;
         if (log) fprintf(stderr, "[exec] skip draw: zero vertex count (no-op draw)\n");
         return false;
     }
-    if (out.indices.empty() && vb_entries > vertex_count) vertex_count = vb_entries;
+    if (out.indices.empty()) vertex_count = resolve_nonindexed_vertex_count(vcount_hint, vb_entries);
     // PS5 RectList (primitive 7; standard AMD RectList is 17) consumes three procedural vertices but
     // covers the rectangle's synthesized fourth corner. Vulkan has no rectangle-list topology. The
     // Blasphemous 2 clear shader explicitly computes all four clip-space corners from VertexIndex, has

--- a/prosper/src/gpu/render_state.cpp
+++ b/prosper/src/gpu/render_state.cpp
@@ -255,13 +255,15 @@ RenderState extract_render_state(const GpuState& st) {
     // stencil-enabled draw — ground truth for compare/op decode questions (the translated fields
     // above can be audited against exactly what the title programmed). Dedup on change.
     if (rs.stencil_enable && getenv("PROSPER_STENCILLOG")) {
-        static thread_local uint32_t last_dc, last_sc, last_rm, last_rmb;
+        static thread_local uint32_t last_dc, last_sc, last_rm, last_rmb, last_prim = 0xFFFFFFFFu;
         if (dc != last_dc || rs.db_stencil_control != last_sc ||
-            rs.db_stencilrefmask != last_rm || rs.db_stencilrefmask_bf != last_rmb) {
+            rs.db_stencilrefmask != last_rm || rs.db_stencilrefmask_bf != last_rmb ||
+            rs.prim_type != last_prim) {
             last_dc = dc; last_sc = rs.db_stencil_control;
-            last_rm = rs.db_stencilrefmask; last_rmb = rs.db_stencilrefmask_bf;
-            fprintf(stderr, "[stencil-raw] dc=%08x sc=%08x rm=%08x rmb=%08x\n",
-                    dc, rs.db_stencil_control, rs.db_stencilrefmask, rs.db_stencilrefmask_bf);
+            last_rm = rs.db_stencilrefmask; last_rmb = rs.db_stencilrefmask_bf; last_prim = rs.prim_type;
+            fprintf(stderr, "[stencil-raw] dc=%08x sc=%08x rm=%08x rmb=%08x prim=%u backface_en=%u\n",
+                    dc, rs.db_stencil_control, rs.db_stencilrefmask, rs.db_stencilrefmask_bf,
+                    rs.prim_type, PM4_FIELD(dc, DB_DEPTH_CONTROL, BACKFACE_ENABLE));
         }
     }
     rs.has_cb_color_control = st.cx.count(P::CB_COLOR_CONTROL) != 0;

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -2625,9 +2625,12 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
             };
             dss.front = mkop(0); dss.back = mkop(1);
             if (getenv("PROSPER_STENCILLOG"))
-                fprintf(stderr, "[stencil] front{cmp=%u ref=%u opval=%u cmask=0x%x wmask=0x%x fail=%u pass=%u zfail=%u} vkref=%u depth_test=%d\n",
+                fprintf(stderr, "[stencil] front{cmp=%u ref=%u opval=%u cmask=0x%x wmask=0x%x fail=%u pass=%u zfail=%u} back{cmp=%u ref=%u fail=%u pass=%u zfail=%u} vkref=%u/%u cull=%u depth_test=%d\n",
                         ps->stencil_compare_op[0], ps->stencil_ref[0], ps->stencil_op_val[0], ps->stencil_compare_mask[0], ps->stencil_write_mask[0],
-                        ps->stencil_fail_op[0], ps->stencil_pass_op[0], ps->stencil_depth_fail_op[0], dss.front.reference, (int)ps->depth_test_enable);
+                        ps->stencil_fail_op[0], ps->stencil_pass_op[0], ps->stencil_depth_fail_op[0],
+                        ps->stencil_compare_op[1], ps->stencil_ref[1],
+                        ps->stencil_fail_op[1], ps->stencil_pass_op[1], ps->stencil_depth_fail_op[1],
+                        dss.front.reference, dss.back.reference, (unsigned)ps->cull_mode, (int)ps->depth_test_enable);
         }
         // Descriptor resources for this draw (two-set: VS=set0, PS=set1 — same layout as the single path).
         const auto setup_fixed_ready = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
@@ -3836,6 +3839,20 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                     } else {
                         fprintf(stderr, "[geom-probe]   v%u = (%g, %g, %g, %g)\n",
                                 i, pos[i*4+0], pos[i*4+1], pos[i*4+2], pos[i*4+3]);
+                    }
+                }
+                // PROSPER_GEOM_PROBE_DUMP=path (gated, off by default): write EVERY post-transform vertex
+                // (x,y,z,w in primitive-assembly order — for a triangle list, consecutive triples are the
+                // rasterized triangles) as CSV, so per-triangle overlap/degeneracy can be analyzed offline
+                // (e.g. GTA #1163's stencil over-count from self-overlapping mask triangles).
+                if (const char* dp = getenv("PROSPER_GEOM_PROBE_DUMP")) {
+                    if (FILE* f = fopen(dp, "w")) {
+                        fprintf(f, "i,x,y,z,w\n");
+                        for (uint32_t i = 0; i < written; i++)
+                            fprintf(f, "%u,%.7g,%.7g,%.7g,%.7g\n",
+                                    i, pos[i*4+0], pos[i*4+1], pos[i*4+2], pos[i*4+3]);
+                        fclose(f);
+                        fprintf(stderr, "[geom-probe]   wrote %u verts -> %s\n", written, dp);
                     }
                 }
                 vkUnmapMemory(dev, geom_mem);

--- a/prosper/tests/test_gpu_execute.cpp
+++ b/prosper/tests/test_gpu_execute.cpp
@@ -483,6 +483,23 @@ int main() {
               "PS5 procedural RectList expands three vertices to a four-corner Vulkan strip");
     }
 
+    // #1163: a non-indexed DrawIndexAuto count is the AUTHORITATIVE hardware vertex count. The bound VB's
+    // record count (vb_records = size/stride) must NOT override it — a title binding a SHARED vertex pool
+    // (GTA V's Scaleform UI: per-draw counts 3/6/30 against a fixed ~4096-byte pool -> vb_records
+    // 146/1024/512) would otherwise sweep the whole pool, rasterizing stale-data triangles that inflate the
+    // stencil masks past their EQUAL==2 clip (the black menu wedges). The VB record count is only a fallback
+    // when the draw supplied NO count (draw_count == 0, already skipped as a no-op upstream). WITHOUT the
+    // fix (old: `if (vb_records > count) count = vb_records`) every one of these would return the record
+    // count, so each real-count assertion below would fail.
+    CHECK(resolve_nonindexed_vertex_count(/*draw_count*/6u,  /*vb_records*/1024u) == 6u,
+          "#1163: GTA Scaleform mask draw (6 verts vs 1024-record shared pool) keeps its real count");
+    CHECK(resolve_nonindexed_vertex_count(/*draw_count*/3u,  /*vb_records*/146u)  == 3u,
+          "#1163: a 3-vertex non-indexed draw is not inflated to the VB record count");
+    CHECK(resolve_nonindexed_vertex_count(/*draw_count*/30u, /*vb_records*/512u)  == 30u,
+          "#1163: a 30-vertex non-indexed draw is not inflated to the VB record count");
+    CHECK(resolve_nonindexed_vertex_count(/*draw_count*/0u,  /*vb_records*/1024u) == 1024u,
+          "#1163: a draw with NO count falls back to the VB record count (zero-count guard)");
+
     // #461: an indexed draw whose fetched index buffer contains a garbage-large value (an announced
     // 32-bit index buffer, or a torn read of concurrently-freed guest memory) must NOT inflate
     // vertex_count / the VB upload unboundedly (OOM guard). realize_draw_item clamps vertex_count to the


### PR DESCRIPTION
Fixes #1163

## Problem / failure scenario
GTA V's menu art and loading collages rendered with large **black wedges / a black center** over the artwork (interactive 2D menus were fine). The prior investigation localized this to a suspected cross-submit **present/composite alpha** issue (an opaque black quad occluding the artwork; a `vcount=146` draw whose vertices were "63% alpha=0"). That direction was a red herring caused by the actual bug below.

## Root cause
For **non-indexed** draws, `realize_draw_item` overrode the DrawIndexAuto vertex count with the bound vertex buffer's record count (`size/stride`) whenever that was larger — the `vb_entries` override from #60. That override dates from when the draw count was undecoded and defaulted to a "sliver"; the count is now decoded correctly from `R_DRAW_INDEX_AUTO`.

GTA V's Scaleform UI binds a **shared ~4096-byte vertex pool** and submits tiny per-draw counts. Confirmed live with `PROSPER_DRAWLOG`:

| raw DrawIndexAuto count | stride | inflated to (= 4096/stride) |
|---|---|---|
| 3 | 28 | 146 |
| **6** | 4 | **1024** |
| 30 | 8 | 512 |

So a 6-vertex (2-triangle) mask draw rendered as **1024 vertices**, sweeping the whole pool and rasterizing hundreds of spurious triangles from stale/zero pool data. For the menu's stencil masks (`clear → INCR → INCR → test EQUAL==2` per panel, `PROSPER_STENCILLOG`) that inflated the mask coverage to counts ≥3 across ~1.15M pixels (`PROSPER_STENCIL_DUMP`), which fail the `EQUAL==2` clip and render **black**. The earlier "146 verts, 63% alpha=0" observation was the same inflation (146 = 4096/28; real count 3; the alpha-0 tail is stale pool data).

Ruled out with evidence (not assumption): two-sided winding (`BACKFACE_ENABLE=0`, no DECR — capsule deduction + live raw regs), topology mis-decode (raw `prim=4`/TriangleList for both intro and menu), stencil-state decode, FP precision.

## Fix
Extract the decision into `resolve_nonindexed_vertex_count(draw_count, vb_records)`: trust the authoritative DrawIndexAuto count; fall back to the VB record count only when the draw supplied **no** count at all (zero-count non-indexed draws are already skipped as no-ops upstream, #400). **Indexed draws are unchanged** (their vertex range still comes from the index buffer, #257/#461).

Also included: three env-gated diagnostics that root-caused this (back-face stencil state in `PROSPER_STENCILLOG`, `prim_type`/`BACKFACE_ENABLE` in `[stencil-raw]`, `PROSPER_GEOM_PROBE_DUMP` full post-transform vertex CSV). All are logging/CSV only, byte-identical when unset.

## Affected / unaffected behavior
- **Affected:** non-indexed DrawIndexAuto draws no longer render more vertices than the packet asked for. Fixes GTA V's menu/loading composition.
- **Unaffected:** indexed draws (index buffer authoritative); zero-count no-op skip (#400); RectList expansion; the bindless per-glyph VB-grow (#257).

## Verification
- **Live (user-confirmed):** GTA V menu now renders the full Lester-at-desk artwork with no black wedges — "~95% correct, was ~10%". Mask draws use their real counts (3/6/30, was 146/1024/512).
- **Regression test:** new assertions in `test_gpu_execute.cpp` (`resolve_nonindexed_vertex_count`) fail against the old override.
- **ctest:** GPU suite green (`gpu_execute`, `real_shader_render`, `pipeline_render`, `gpustate_render`). The 2 failing boot/module tests are pre-existing config mismatches (build's `GAME_DUMP` is GTA, those tests expect the Messenger eboot) — unrelated to this change.
- **Snapshot (`snapshot.py check`, local, no game imagery committed):** `messenger-scene` **OK** (the #60 origin), `dead-cells-gameplay` **OK**. `blasphemous2-gameplay` / `evergate-title` / `terminator-boot` running — results to follow in a comment.

## Risk
Shared draw-executor change affecting all non-indexed draws. Mitigated by: the DrawIndexAuto count being authoritative hardware state, the zero-count fallback preserved, and the snapshot suite (esp. the #60 origin passing). Requests independent review of the executor semantics.