### PR TITLE
feat(gpu/capture): retain raw draw-packet state so --inspect-only flags realization divergence (#1256)

### DIFF
--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -38,7 +38,12 @@ namespace prosper::gpu {
 namespace {
 
 constexpr char kMagic[8] = {'P','R','G','P','C','A','P','\0'};
-constexpr uint32_t kVersion = 22;
+// v23 (#1256): each realized draw also retains its RAW draw-packet state — the DrawIndexAuto/DrawIndex
+// index_count and indexed flag as decoded from the guest, BEFORE realization. This lets gpu_replay
+// --inspect-only surface raw-vs-realized offline and flag a decode/realization divergence (e.g. GTA
+// #1163's non-indexed vertex-count inflation) without a live boot. Older captures read fine (the fields
+// default to 0/false = "unknown").
+constexpr uint32_t kVersion = 23;
 constexpr uint32_t kEndian = 0x01020304u;
 constexpr uint64_t kMaxFileBytes = 4ull << 30;
 constexpr uint64_t kMaxBlobBytes = 1ull << 30;
@@ -961,6 +966,7 @@ bool capture_submit_items(const std::vector<DrawItem>& draws,
         GpuCapturedDraw c; c.vs = d.vs_words(); c.gs = d.gs_words(); c.fs = d.fs_words();
         c.ps = d.ps; c.vertex_count = d.vertex_count;
         c.instance_count = d.instance_count;
+        c.raw_draw_count = d.raw_draw_count; c.raw_indexed = d.raw_indexed;   // #1256
         c.indices = d.indices; c.color0_base = d.color0_base;
         c.color0_width = d.color0_width; c.color0_height = d.color0_height;
         c.color1_base = d.color1_base;
@@ -1495,6 +1501,11 @@ bool serialize_gpu_capture(const GpuCaptureFile& c, std::vector<uint8_t>& bytes,
         if (!write_internal_state(draw.vrt) || !write_internal_state(draw.prt)) return false;
     for (const auto& compute : c.computes)
         if (!write_internal_state(compute.resources)) return false;
+    // v23 (#1256) appends the raw draw-packet state (DrawIndexAuto/DrawIndex index_count + indexed flag)
+    // per realized draw, decoded from the guest BEFORE realization. Older captures default to 0/false
+    // ("unknown"). Kept as a trailing block so every v1-v22 record prefix stays byte-exact.
+    w.u32(static_cast<uint32_t>(c.draws.size()));
+    for (const auto& draw : c.draws) { w.u32(draw.raw_draw_count); w.u32(draw.raw_indexed ? 1u : 0u); }
     if (w.data.size() > kMaxFileBytes) { error = "capture file exceeds 4 GiB"; return false; }
     bytes = std::move(w.data);
     return true;
@@ -2039,6 +2050,15 @@ bool deserialize_gpu_capture(const std::vector<uint8_t>& bytes, GpuCaptureFile& 
         for (auto& compute : c.computes)
             if (!read_internal_state(compute.resources)) return false;
     }
+    if (version >= 23) {   // #1256: raw draw-packet state per realized draw
+        uint32_t nd = 0;
+        if (!r.u32(nd) || nd != c.draws.size()) { error = "invalid raw-draw-state count"; return false; }
+        for (auto& draw : c.draws) {
+            uint32_t ri = 0;
+            if (!r.u32(draw.raw_draw_count) || !r.u32(ri)) return false;
+            draw.raw_indexed = ri != 0;
+        }
+    }
     if (version >= 7 && !validate_failure_diagnostics(c, error)) return false;
     if (r.left) { error = "capture has trailing data"; return false; }
     return true;
@@ -2125,6 +2145,7 @@ bool materialize_gpu_replay(const GpuCaptureFile& c, GpuReplayFrame& out, std::s
         DrawItem d; d.vs = x.vs; d.gs = x.gs; d.fs = x.fs;
         d.ps = x.ps; d.vertex_count = x.vertex_count;
         d.instance_count = x.instance_count;
+        d.raw_draw_count = x.raw_draw_count; d.raw_indexed = x.raw_indexed;   // #1256
         d.indices = x.indices; d.color0_base = x.color0_base;
         d.color0_width = x.color0_width; d.color0_height = x.color0_height;
         d.color1_base = x.color1_base;

--- a/prosper/src/gpu/gpu_capture.hpp
+++ b/prosper/src/gpu/gpu_capture.hpp
@@ -70,6 +70,11 @@ struct GpuCapturedDraw {
     GpuCapturedTable prt;
     uint32_t vertex_count = 3;
     uint32_t instance_count = 1;
+    // #1256 (v23): the RAW draw-packet count (DrawIndexAuto/DrawIndex index_count) and indexed flag as
+    // decoded from the guest, BEFORE realization. For a non-indexed draw the realized vertex_count must
+    // equal raw_draw_count; a divergence is a decode/realization bug (--inspect-only flags it). 0 = unknown.
+    uint32_t raw_draw_count = 0;
+    bool raw_indexed = false;
     std::vector<uint32_t> indices;
     uint64_t color0_base = 0;
     uint32_t color0_width = 0, color0_height = 0;

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -64,6 +64,12 @@ struct DrawItem {
     std::shared_ptr<ShaderResourceTable> vrt, prt;    // may be null
     uint32_t vertex_count = 3;
     uint32_t instance_count = 1;
+    // #1256: the RAW draw-packet state recorded BEFORE realization — the DrawIndexAuto/DrawIndex
+    // index_count (vcount_hint) and whether the draw was indexed. For a non-indexed draw the realized
+    // vertex_count must equal raw_draw_count (see resolve_nonindexed_vertex_count / #1163); the capture
+    // persists these so gpu_replay --inspect-only can flag a decode/realization divergence offline.
+    uint32_t raw_draw_count = 0;
+    bool raw_indexed = false;
     // Indexed draw (sceAgcDcbDrawIndex): the guest index buffer, fetched from 1:1-mapped memory and
     // widened to 32-bit. Non-empty -> the backend must render with vkCmdDrawIndexed (gl_VertexIndex
     // then IS the fetched index, which the recompiled VS uses for its storage-buffer vertex fetch);
@@ -1099,6 +1105,9 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
     out.vs_guest_addr = rs.es_addr; out.fs_guest_addr = rs.ps_addr;
     out.vs_identity = vs_identity; out.fs_identity = fs_identity; out.ps = ps;
     out.vrt = std::move(vrt); out.prt = std::move(prt); out.vertex_count = vertex_count;
+    // #1256: record the raw draw-packet state (pre-realization) so a capture can be checked offline for
+    // realization divergence. vcount_hint is the DrawIndexAuto/DrawIndex index_count decoded from the guest.
+    out.raw_draw_count = vcount_hint; out.raw_indexed = (draw && draw->indexed);
     // The draw record is authoritative even in folded mode: register state may change after the
     // last draw, while IT_NUM_INSTANCES belongs to the draw at the moment it executes.
     out.instance_count = draw ? draw->instance_count : ds.num_instances;

--- a/prosper/tests/test_gpu_capture.cpp
+++ b/prosper/tests/test_gpu_capture.cpp
@@ -80,6 +80,7 @@ int main() {
     draw.vs_guest_addr = reinterpret_cast<uint64_t>(kDiagnosticVs);
     draw.fs_guest_addr = reinterpret_cast<uint64_t>(kDiagnosticBadPs);
     draw.vertex_count = 6; draw.instance_count = 3;
+    draw.raw_draw_count = 6; draw.raw_indexed = false;   // #1256: raw draw-packet state (v23)
     draw.indices = {0, 1, 2, 2, 3, 0}; draw.color0_base = 0x2000;
     draw.color0_width = 1024; draw.color0_height = 32;
     draw.color1_base = 0x3000; draw.color1_width = 1024; draw.color1_height = 32;
@@ -135,6 +136,8 @@ int main() {
           "capture indexes unique shaders and retains operation provenance");
     CHECK(captured.draws.size() == 1 && captured.draws[0].instance_count == 3,
           "capture retains the realized draw instance count");
+    CHECK(captured.draws[0].raw_draw_count == 6 && !captured.draws[0].raw_indexed,
+          "capture retains the raw draw-packet count and indexed flag (#1256)");
     CHECK(captured.raw_shader_versions.size() == 2 &&
           captured.draws[0].vs_raw_shader_index < captured.raw_shader_versions.size() &&
           captured.draws[0].fs_raw_shader_index < captured.raw_shader_versions.size() &&
@@ -210,6 +213,7 @@ int main() {
               v16_scissor_bytes.size() >= 25,
           "v17 capture serializes effective guest scissor state");
     if (v16_scissor_bytes.size() >= 25) {
+        v16_scissor_bytes.resize(v16_scissor_bytes.size() - 12); // v23 count + one raw-draw-state
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - 28); // v22 count + three empty vectors
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - 13); // v21 one draw + zero failures
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - 8); // v20 draw count + instance count
@@ -356,6 +360,7 @@ int main() {
           "writer rejects an out-of-bounds DCC metadata reference");
     CHECK(serialize_gpu_capture(volume_capture, volume_bytes, error),
           "recreated valid v12 DCC bytes after malformed-reference check");
+    volume_bytes.resize(volume_bytes.size() - 12); // v23 count + one raw-draw-state
     volume_bytes.resize(volume_bytes.size() - 12); // v22 count + one empty vector
     volume_bytes.resize(volume_bytes.size() - 13); // v21 one logic-op draw + zero failures
     volume_bytes.resize(volume_bytes.size() - 8); // v20 draw count + instance count
@@ -425,6 +430,7 @@ int main() {
     CHECK(serialize_gpu_capture(captured, v20_bytes, error) && v20_bytes.size() >= 21,
           "v21 capture serializes the logic-op extension");
     if (v20_bytes.size() >= 21) {
+        v20_bytes.resize(v20_bytes.size() - 12); // v23 count + one raw-draw-state
         v20_bytes.resize(v20_bytes.size() - 28); // v22 count + three empty vectors
         v20_bytes.resize(v20_bytes.size() - 13); // v21 one logic-op draw + zero failures
         v20_bytes[8] = 20; v20_bytes[9] = v20_bytes[10] = v20_bytes[11] = 0;
@@ -476,6 +482,8 @@ int main() {
           "content versions and draw operation identity round-trip");
     CHECK(loaded.draws[0].instance_count == 3,
           "v20 realized draw instance count round-trips");
+    CHECK(loaded.draws[0].raw_draw_count == 6 && !loaded.draws[0].raw_indexed,
+          "v23 raw draw-packet state round-trips through write/read (#1256)");
     CHECK(loaded.raw_shader_versions.size() == 2 &&
           loaded.draws[0].vs_raw_shader_index < loaded.raw_shader_versions.size() &&
           loaded.draws[0].fs_raw_shader_index < loaded.raw_shader_versions.size(),
@@ -818,6 +826,7 @@ int main() {
     if (v13_bytes.size() >= 32) {
         const size_t legacy_resource_count = legacy_source.draws[0].vrt.resources.size() +
                                              legacy_source.draws[0].prt.resources.size();
+        v13_bytes.resize(v13_bytes.size() - 12); // v23 count + one raw-draw-state
         v13_bytes.resize(v13_bytes.size() - (4 + 8 * legacy_resource_count)); // v22
         v13_bytes.resize(v13_bytes.size() - 13); // v21 one logic-op draw + zero failures
         v13_bytes.resize(v13_bytes.size() - 8); // v20 draw count + instance count
@@ -840,6 +849,7 @@ int main() {
     if (legacy_bytes.size() >= 32) {
         const size_t legacy_resource_count = legacy_source.draws[0].vrt.resources.size() +
                                              legacy_source.draws[0].prt.resources.size();
+        legacy_bytes.resize(legacy_bytes.size() - 12); // v23 count + one raw-draw-state
         legacy_bytes.resize(legacy_bytes.size() - (4 + 8 * legacy_resource_count)); // v22
         legacy_bytes.resize(legacy_bytes.size() - 13); // v21 one logic-op draw + zero failures
         legacy_bytes.resize(legacy_bytes.size() - 8); // v20 draw count + instance count
@@ -888,9 +898,9 @@ int main() {
     CHECK(deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
           !legacy_loaded.failure_diagnostics_available && legacy_loaded.failure_diagnostics.empty(),
           "v6 capture reopens with failed-operation diagnostics reported unavailable");
-    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 23;
+    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 24;
     CHECK(!deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
-          error == "unsupported capture version 23",
+          error == "unsupported capture version 24",
           "future capture versions fail with a concrete version error");
 
     GpuCaptureFile bad_hash = mixed;

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -41,6 +41,28 @@ Create a capsule with the native-speed workflow in
 ./build-linux/gpu_replay --bundle /tmp/window.prgbundle --bundle-zero-boundary /tmp/zero-ab.bmp
 ```
 
+## Raw-vs-realized draw check — `raw=` on each `--inspect-only` draw line (#1256)
+
+Each `draw[i] … vcount=N indices=M topo=T raw=…` line reports the **raw draw-packet state** the guest
+submitted, decoded BEFORE realization (capture v23+):
+
+```
+draw[12] … vcount=6 indices=0 topo=3 raw=6              # healthy: realized == guest's DrawIndexAuto count
+draw[12] … vcount=1024 indices=0 topo=3 raw=6 [INFLATED] # realized swept more than the guest asked for
+```
+
+- **non-indexed** (`indices=0`): the realized `vcount` MUST equal `raw` (the DrawIndexAuto count). `[INFLATED]`
+  = realized > raw+1 (the GTA #1163 shared-vertex-pool signature); `[DIVERGENT]` = realized < raw. A realized
+  `raw+1` is NOT flagged — a PS5 RectList draw legitimately synthesizes one extra procedural corner (3 -> 4).
+- **indexed**: `raw=N(idx)`; the fetched index count (`indices=`) must equal `N`, else `[INDEX-COUNT-MISMATCH]`
+  (also fires when an indexed draw fell back to non-indexed on an unreadable index buffer — a real signal).
+- `raw=?` = a pre-v23 capture (the raw count was not retained). No flag is possible for those.
+
+This makes a whole class of decode/realization-divergence bug — where prosper renders geometry the guest did
+not ask for — visible **offline** from a capsule, without a live boot. It was added because #1163 (the black
+menu wedges) could only be diagnosed by booting the game repeatedly with `PROSPER_DRAWLOG`; the capsule stored
+only the realized `vcount=1024`, hiding that the guest's real count was 6.
+
 ## Reading graph output
 
 - `edge producer=P consumer=C` means operation `C` reads a range last written by earlier operation `P`.

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -316,8 +316,28 @@ void inspect_frame(const prosper::gpu::GpuReplayFrame& replay) {
     }
     for (size_t i = 0; i < replay.items.size(); ++i) {
         const auto& d = replay.items[i];
+        // #1256: raw-vs-realized draw-count check. The capture retains the raw DrawIndexAuto/DrawIndex
+        // index_count (raw_draw_count) decoded from the guest; for a non-indexed draw the realized
+        // vertex_count MUST equal it, and for an indexed draw the fetched index count must equal it.
+        // A divergence is a decode/realization bug (e.g. GTA #1163's shared-pool vertex-count inflation),
+        // visible here offline without a live boot. raw_draw_count==0 && !raw_indexed = pre-v23 capture.
+        char rawtag[80];
+        if (d.raw_draw_count == 0 && !d.raw_indexed) {
+            std::snprintf(rawtag, sizeof rawtag, " raw=?");
+        } else if (d.raw_indexed) {
+            std::snprintf(rawtag, sizeof rawtag, " raw=%u(idx)%s", d.raw_draw_count,
+                          d.indices.size() == d.raw_draw_count ? "" : " [INDEX-COUNT-MISMATCH]");
+        } else {
+            // A PS5 RectList draw legitimately realizes ONE extra procedural vertex (3 -> 4, the
+            // rectangle's synthesized fourth corner; see realize_draw_item's rect_list expansion), so
+            // vertex_count == raw+1 is benign and must not flag. After #1163 that +1 is the only correct
+            // realized>raw case; any larger excess is a real over-draw (the #1163 pool inflation was ~170x).
+            std::snprintf(rawtag, sizeof rawtag, " raw=%u%s", d.raw_draw_count,
+                          d.vertex_count > d.raw_draw_count + 1 ? " [INFLATED]"
+                          : d.vertex_count < d.raw_draw_count   ? " [DIVERGENT]" : "");
+        }
         std::printf("draw[%zu] source=%llu target=%016llx extent=%ux%u fmt=%u cwm=%x "
-                    "target1=%016llx extent1=%ux%u fmt1=%u cwm1=%x vcount=%u indices=%zu topo=%u "
+                    "target1=%016llx extent1=%ux%u fmt1=%u cwm1=%x vcount=%u indices=%zu topo=%u%s "
                     "depth=%d/%d/%u stencil=%d blend=%d raster=%u/%u/%u viewport=%d %.1f,%.1f %.1fx%.1f "
                     "scissor=%d [%d,%d)-[%d,%d) "
                     "vs=%zu/%016llx fs=%zu/%016llx\n",
@@ -326,7 +346,7 @@ void inspect_frame(const prosper::gpu::GpuReplayFrame& replay) {
                     d.ps.color0_format, d.ps.color_write_mask,
                     static_cast<unsigned long long>(d.color1_base), d.color1_width, d.color1_height,
                     d.ps.color1_format, d.ps.color1_write_mask, d.vertex_count, d.indices.size(),
-                    d.ps.topology, d.ps.depth_test_enable,
+                    d.ps.topology, rawtag, d.ps.depth_test_enable,
                     d.ps.depth_write_enable, d.ps.depth_compare_op, d.ps.stencil_enable, d.ps.blend_enable,
                     d.ps.cull_mode, d.ps.front_face, d.ps.polygon_mode,
                     d.ps.has_viewport, d.ps.viewport_x, d.ps.viewport_y, d.ps.viewport_w, d.ps.viewport_h,


### PR DESCRIPTION
Fixes #1256

## Why
Capsules stored only the **realized** draw state (final `vertex_count`), so a decode/realization-divergence bug was invisible offline. That's exactly why GTA #1163 (the black menu wedges) could only be found by booting the game repeatedly with `PROSPER_DRAWLOG`: the capsule showed `vcount=1024`, hiding that the guest's raw DrawIndexAuto count was `6`.

## What
Capture **v23** retains, per realized draw, the **raw draw-packet state** decoded from the guest *before* realization: the DrawIndexAuto/DrawIndex `index_count` and the `indexed` flag (recorded in `realize_draw_item` as `vcount_hint` / `draw->indexed`). `gpu_replay --inspect-only` prints `raw=N` per draw and flags divergence:

```
draw[12] … vcount=6 indices=0 topo=3 raw=6               # healthy
draw[12] … vcount=1024 indices=0 topo=3 raw=6 [INFLATED]  # realized swept more than the guest asked for (#1163)
```
- **non-indexed**: realized `vcount` must equal `raw` → `[INFLATED]` (realized > raw) or `[DIVERGENT]` (realized < raw)
- **indexed**: `raw=N(idx)`; fetched index count must equal N, else `[INDEX-COUNT-MISMATCH]`
- `raw=?` = pre-v23 capture (not retained)

## Format / compatibility
The raw state is a **trailing v23 block** (draw count + per-draw count/indexed), so every v1–v22 record prefix stays **byte-exact** and older captures read unchanged (fields default to `0/false` = unknown). `kVersion` 22 → 23. The down-version reopen fixtures in `test_gpu_capture` strip the new trailing block; the unsupported-version probe moves to 24.

## Verification
- **Round-trip unit tests**: raw count/indexed survive capture, and a full write→read (`test_gpu_capture`, green).
- **Fresh v23 GTA capsule**: inspects with `raw` matching realized on every draw — **no false positives** (since #1163 is fixed on master).
- **Backward-compat**: an old pre-v23 capsule reads fine and shows `raw=?` (still showing the inflated `vcount=1024`).
- **Flag fires**: a capsule with a hand-injected divergence (`raw=1`, `vcount=3`) prints `raw=1 [INFLATED]`.
- ctest capture/execute/render suites green. The 2 boot/module ctest failures are the pre-existing GTA-dump-vs-Messenger config mismatch, unrelated to this change.

## Risk
Shared **persistent capture format** change (new version + serialize/deserialize + a struct field on `DrawItem`/`GpuCapturedDraw`). Mitigated by: trailing-block placement keeping all prior prefixes byte-exact, version-gated read, round-trip + down-version fixtures, and the field being diagnostic-only (no effect on replay/render). Requests review of the serialization + version-fixture correctness.