### PR TITLE
feat(gpu/tools): regress.py — fast cross-title capsule-hash regression gate (#1258)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -91,6 +91,8 @@ if(Python3_Interpreter_FOUND)
            COMMAND "${Python3_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tools/re/test_edis.py")
   add_test(NAME snapshot_guard_logic
            COMMAND "${Python3_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tools/snapshot/test_snapshot.py")
+  add_test(NAME gpu_replay_regress_logic
+           COMMAND "${Python3_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tools/gpu_replay/test_regress.py")
 endif()
 # Path to the (gitignored) local game dump; override with -DGAME_DUMP=...
 set(GAME_DUMP "${CMAKE_SOURCE_DIR}/../PPSA24651-app0" CACHE PATH "Local PS5 game dump root")

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -84,6 +84,32 @@ Renderer-invocation captures record an expected byte count/hash and replay exits
 Timeline-selected captures occur before Vulkan and report `oracle=no`; they render normally but do not invent an
 expected hash. `--allow-mismatch` is for an intentional differential such as `--draw N:M`.
 
+## Cross-title regression gate — `regress.py` (#1258)
+
+`tools/gpu_replay/regress.py` replays a whole **corpus** of `.prgcap` capsules and diffs each one's rendered
+output hash against a committed baseline. It runs in seconds (deterministic offline replay, no live game boot),
+so a shared GPU/executor/recompiler change can be checked against many scenes across many titles **before** the
+~18-minute live-boot snapshot suite — the fast pre-snapshot gate the GTA #1163 fix (#1255) lacked.
+
+```bash
+export PROSPER_GPU_REPLAY=build-linux/gpu_replay
+python3 tools/gpu_replay/regress.py update <corpus-dir>   # record baseline hashes after an INTENDED change
+python3 tools/gpu_replay/regress.py check  <corpus-dir>   # exit 1 if any capsule's hash CHANGED (a regression)
+python3 tools/gpu_replay/regress.py list   <corpus-dir>   # just print each capsule's current hash
+```
+
+The corpus (`.prgcap` files) is **local and gitignored** — capsules are large and carry game imagery, exactly
+like the game dumps. Only the small baseline (`regress-baseline.json`, basename → hash) is meant to be committed
+and shared. `check` fails on a changed hash or a capsule that failed to replay; `new`/`missing` capsules are
+reported informationally (pass `--strict` to also fail when a baselined capsule is missing from the corpus,
+so a locally-deleted capsule can't silently shrink coverage). The child gpu_replay runs with `PROSPER_*`
+scrubbed from its environment, so a diagnostic left in your shell can't perturb a hash into a false regression.
+
+**Scope (important):** a replay hash validates the **translation** path (recompiler, AGC/PM4 decode,
+render-state resolve, executor ordering, detile) — it is the right guard for changes to *that* code. It does
+**not** exercise live GPU residency; a change to `live_gpu_targets`/residency can be hash-identical yet wrong
+(the capture/replay blind spot, #1103). Use it to catch translation regressions fast, not as full coverage.
+
 ## Isolation and extraction
 
 ```bash

--- a/prosper/tools/gpu_replay/regress.py
+++ b/prosper/tools/gpu_replay/regress.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+# regress.py (#1258) — a fast, cross-title capsule-hash regression gate.
+#
+# Replays every .prgcap in a LOCAL corpus directory through gpu_replay and diffs each capsule's
+# rendered output hash against a committed baseline. Runs in seconds (deterministic offline replay,
+# no live game boot), so a shared GPU/executor/recompiler change can be checked against many scenes
+# before the ~18-minute live-boot snapshot suite.
+#
+#   regress.py update <corpus-dir> [--baseline FILE]   # (re)record baseline hashes after an INTENDED change
+#   regress.py check  <corpus-dir> [--baseline FILE]    # compare current hashes to the baseline; exit 1 on any diff
+#   regress.py list   <corpus-dir>                      # just print each capsule's current hash
+#
+# The corpus (.prgcap files) is LOCAL and gitignored — capsules are large and carry game imagery, exactly
+# like the game dumps. Only the small baseline (basename -> hash, JSON) is meant to be committed/shared.
+#
+# SCOPE (important): a replay hash validates the TRANSLATION path (recompiler, AGC/PM4 decode, render-state
+# resolve, executor ordering, detile) — it is the right guard for changes to THAT code. It does NOT exercise
+# live GPU residency; a change to live_gpu_targets/residency can be hash-identical yet wrong (see
+# docs blind-spot note / issue #1103). Use this to catch translation regressions fast, not as full coverage.
+
+import argparse, json, os, re, shutil, subprocess, sys
+from pathlib import Path
+
+HASH_RE = re.compile(r"\bhash=([0-9a-fA-F]{1,16})\b")
+DEFAULT_REPLAY = os.environ.get("PROSPER_GPU_REPLAY", "build-linux/gpu_replay")
+
+
+def parse_output_hash(text: str):
+    """Extract the rendered output hash from gpu_replay's log — the `hash=` on the render summary line
+    `[gpureplay] output=WxH ... hash=H`. Take the LAST such line so per-resource/-seed hashes earlier in
+    the log never shadow the final output hash. Returns the lowercase hex string, or None if absent."""
+    out_hash = None
+    for line in text.splitlines():
+        if "output=" in line and "hash=" in line:
+            m = HASH_RE.search(line)
+            if m:
+                out_hash = m.group(1).lower()
+    return out_hash
+
+
+def classify_check(current: dict, baseline: dict):
+    """Compare current capsule hashes to the baseline. Returns (regressions, errors, new, missing):
+    regressions = [(name, baseline_hash, current_hash)] a committed hash CHANGED (the real signal);
+    errors = capsules that failed to replay (current hash is None); new = present now but not baselined;
+    missing = in the baseline but absent from the corpus. Only regressions+errors fail the gate."""
+    regressions = [(n, baseline[n], current[n]) for n in current
+                   if current[n] is not None and n in baseline and baseline[n] != current[n]]
+    errors = [n for n in current if current[n] is None]
+    new = [n for n in current if current[n] is not None and n not in baseline]
+    missing = [n for n in baseline if n not in current]
+    return regressions, errors, new, missing
+
+
+def replay_hash(replay_bin: str, capsule: Path, timeout: int) -> str:
+    """Run gpu_replay on one capsule and return its rendered output hash. Raises on failure so a broken
+    capsule is loud, not silent."""
+    # Scrub PROSPER_* from the child env so a diagnostic left in the caller's shell (PROSPER_RENDER_SCALE,
+    # PROSPER_DETILE, ...) can't perturb the hash and produce a false regression — the gate must be
+    # reproducible regardless of the caller's environment. gpu_replay applies the capsule's own renderer_env
+    # from the capture metadata, so it needs no PROSPER_* from the parent.
+    child_env = {k: v for k, v in os.environ.items() if not k.startswith("PROSPER_")}
+    proc = subprocess.run([replay_bin, str(capsule)], capture_output=True, text=True,
+                          timeout=timeout, env=child_env)
+    out_hash = parse_output_hash(proc.stdout + proc.stderr)
+    if out_hash is None:
+        raise RuntimeError(
+            f"no output hash from gpu_replay for {capsule.name} (exit {proc.returncode})\n"
+            f"--- stderr tail ---\n" + "\n".join((proc.stderr).splitlines()[-8:]))
+    return out_hash
+
+
+def corpus_hashes(replay_bin: str, corpus: Path, timeout: int) -> dict:
+    capsules = sorted(corpus.glob("*.prgcap"))
+    if not capsules:
+        sys.exit(f"regress: no .prgcap files in {corpus}")
+    result = {}
+    for cap in capsules:
+        try:
+            result[cap.name] = replay_hash(replay_bin, cap, timeout)
+            print(f"  {cap.name:48} {result[cap.name]}")
+        except Exception as e:
+            print(f"  {cap.name:48} ERROR: {e}")
+            result[cap.name] = None
+    return result
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="capsule-hash regression gate (#1258)")
+    ap.add_argument("mode", choices=["check", "update", "list"])
+    ap.add_argument("corpus", type=Path, help="directory of .prgcap capsules (local, gitignored)")
+    ap.add_argument("--baseline", type=Path, default=None,
+                    help="baseline JSON (default: <corpus>/regress-baseline.json)")
+    ap.add_argument("--replay", default=DEFAULT_REPLAY, help="gpu_replay binary (or $PROSPER_GPU_REPLAY)")
+    ap.add_argument("--timeout", type=int, default=600, help="per-capsule replay timeout seconds")
+    ap.add_argument("--strict", action="store_true",
+                    help="check: also fail when a baselined capsule is MISSING from the corpus "
+                         "(so a locally-deleted capsule can't silently shrink coverage)")
+    args = ap.parse_args()
+
+    if not args.corpus.is_dir():
+        sys.exit(f"regress: corpus dir not found: {args.corpus}")
+    # One clear message if the replay binary is wrong, instead of N identical FileNotFoundErrors.
+    if shutil.which(args.replay) is None and not Path(args.replay).is_file():
+        sys.exit(f"regress: gpu_replay not found: {args.replay} "
+                 f"(set --replay or $PROSPER_GPU_REPLAY to the built binary)")
+    baseline_path = args.baseline or (args.corpus / "regress-baseline.json")
+
+    print(f"[regress] {args.mode} corpus={args.corpus} replay={args.replay}")
+    current = corpus_hashes(args.replay, args.corpus, args.timeout)
+
+    if args.mode == "list":
+        return 1 if any(v is None for v in current.values()) else 0
+
+    if args.mode == "update":
+        # Refuse to bake an ERROR (None) hash into the baseline — that would mask a broken capsule as "expected".
+        if any(v is None for v in current.values()):
+            print("[regress] FAILED: some capsules did not replay; baseline NOT written")
+            return 1
+        baseline_path.write_text(json.dumps(current, indent=2, sort_keys=True) + "\n")
+        print(f"[regress] wrote baseline for {len(current)} capsule(s) -> {baseline_path}")
+        return 0
+
+    # check
+    if not baseline_path.exists():
+        sys.exit(f"regress: no baseline at {baseline_path} (run `regress.py update {args.corpus}` first)")
+    try:
+        baseline = json.loads(baseline_path.read_text())
+    except json.JSONDecodeError as e:
+        sys.exit(f"regress: baseline {baseline_path} is corrupt JSON: {e}")
+    if not isinstance(baseline, dict):
+        sys.exit(f"regress: baseline {baseline_path} is not a name->hash object")
+    regressions, errors, new, missing = classify_check(current, baseline)
+
+    for name, exp, got in regressions:
+        print(f"[regress] CHANGED  {name}: baseline {exp} -> now {got}")
+    for name in errors:
+        print(f"[regress] ERROR    {name}: did not replay")
+    for name in new:
+        print(f"[regress] new      {name}: not in baseline (run update to record)")
+    for name in missing:
+        print(f"[regress] missing  {name}: in baseline but not in corpus"
+              + (" [FAIL under --strict]" if args.strict else ""))
+
+    strict_missing = missing if args.strict else []
+    if regressions or errors or strict_missing:
+        print(f"[regress] FAIL: {len(regressions)} changed, {len(errors)} errored"
+              + (f", {len(strict_missing)} missing (--strict)" if strict_missing else ""))
+        return 1
+    print(f"[regress] OK: {len(current)} capsule(s) match baseline"
+          + (f" ({len(new)} new, {len(missing)} missing — informational)" if (new or missing) else ""))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/prosper/tools/gpu_replay/test_regress.py
+++ b/prosper/tools/gpu_replay/test_regress.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+# test_regress.py (#1258) — unit tests for the pure logic of the capsule-hash regression gate
+# (regress.py): output-hash extraction from gpu_replay's log and the baseline-vs-current classifier.
+# gpu_replay itself is not invoked here (that path is exercised manually against a local corpus).
+import importlib.util
+import os
+import sys
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SPEC = importlib.util.spec_from_file_location("prosper_regress", os.path.join(HERE, "regress.py"))
+REGRESS = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(REGRESS)
+
+
+class ParseOutputHashTests(unittest.TestCase):
+    def test_takes_the_output_line_hash(self):
+        log = (
+            "[gpureplay] rev=abc submit=1000 3840x2160 draws=46 ... resource-data=present\n"
+            "  VS CB b=3 ... hash=cf3e4df9be3d0fd1 ...\n"       # a resource hash must NOT win
+            "[gpureplay] output=3840x2160 bytes=33177600 hash=670576577254c2e8 expected_hash=0\n"
+        )
+        self.assertEqual(REGRESS.parse_output_hash(log), "670576577254c2e8")
+
+    def test_last_output_line_wins(self):
+        log = ("[gpureplay] output=8x8 hash=1111111111111111\n"
+               "[gpureplay] output=8x8 hash=2222222222222222\n")
+        self.assertEqual(REGRESS.parse_output_hash(log), "2222222222222222")
+
+    def test_none_when_absent(self):
+        self.assertIsNone(REGRESS.parse_output_hash("[gpureplay] rev=abc inspect only, no render\n"))
+
+    def test_lowercased(self):
+        self.assertEqual(REGRESS.parse_output_hash("output=1x1 hash=ABCDEF0123456789"),
+                         "abcdef0123456789")
+
+
+class ClassifyCheckTests(unittest.TestCase):
+    def test_all_match(self):
+        cur = {"a.prgcap": "dead", "b.prgcap": "beef"}
+        reg, err, new, missing = REGRESS.classify_check(cur, dict(cur))
+        self.assertEqual((reg, err, new, missing), ([], [], [], []))
+
+    def test_regression_detected(self):
+        reg, err, new, missing = REGRESS.classify_check(
+            {"a.prgcap": "NEWHASH"}, {"a.prgcap": "oldhash"})
+        self.assertEqual(reg, [("a.prgcap", "oldhash", "NEWHASH")])
+        self.assertEqual((err, new, missing), ([], [], []))
+
+    def test_error_capsule_is_a_failure_not_silently_ok(self):
+        reg, err, new, missing = REGRESS.classify_check({"a.prgcap": None}, {"a.prgcap": "x"})
+        self.assertEqual(err, ["a.prgcap"])
+        self.assertEqual(reg, [])  # a None hash must not be miscompared as a regression
+
+    def test_new_and_missing_are_informational(self):
+        reg, err, new, missing = REGRESS.classify_check(
+            {"b.prgcap": "hb"}, {"a.prgcap": "ha"})
+        self.assertEqual(reg, [])
+        self.assertEqual(err, [])
+        self.assertEqual(new, ["b.prgcap"])       # present now, not baselined
+        self.assertEqual(missing, ["a.prgcap"])   # baselined, absent from corpus
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #1258

## What
`tools/gpu_replay/regress.py` replays a corpus of `.prgcap` capsules through gpu_replay and diffs each one's rendered output hash against a committed baseline — in **seconds**, no live game boot. It's the fast pre-snapshot gate the GTA #1163 fix (#1255) lacked (that change touched every non-indexed draw and had only the ~18-minute 5-title live-boot snapshot suite as a cross-title net).

```bash
export PROSPER_GPU_REPLAY=build-linux/gpu_replay
python3 tools/gpu_replay/regress.py update <corpus-dir>   # record baseline after an INTENDED change
python3 tools/gpu_replay/regress.py check  <corpus-dir>   # exit 1 if any capsule's hash CHANGED
python3 tools/gpu_replay/regress.py list   <corpus-dir>
```

- The corpus (`.prgcap`) is **local + gitignored** (large, carries game imagery — like the dumps). Only the small `regress-baseline.json` (basename → hash) is committed.
- Reuses gpu_replay's existing `[gpureplay] output=… hash=…` line (a plain replay renders + hashes with no output path) — **no change to the gpu_replay binary**.
- `check` fails on a changed hash or a capsule that failed to replay; `new`/`missing` are informational.

## Scope / limitation (documented in the tool + README)
A replay hash validates the **translation** path (recompiler, AGC/PM4 decode, render-state resolve, executor ordering, detile) — the right guard for changes to that code. It does **not** exercise live GPU residency; a residency change can be hash-identical yet wrong (the capture/replay blind spot, #1103). This is a fast translation-regression gate, not full coverage.

## Tests
- `test_regress.py` unit-tests the pure logic (output-hash extraction + baseline classifier), registered as the `gpu_replay_regress_logic` ctest (passes).
- Verified end-to-end against a local corpus: `update` records; `check` passes on match and **exits 1 on a tampered baseline**; and the replay hash is **deterministic** across runs (a stable gate).

## Risk
Standalone Python driver + a unit test + one `add_test` line + docs. No emulator/gpu_replay-binary code changes. Low risk; the only judgment is the log-parsing (guarded to the `output=` line so resource/seed hashes can't shadow it) and the classifier (unit-tested).