### PR TITLE
fix(gpu): bound the register-file ingest domain — Blue Prince loading-crawl term 1 (#1264)

### DIFF
--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -1678,7 +1678,26 @@ void GpuState::apply(const Pm4Command& c) {
                     fprintf(stderr, " (off=0x%x val=0x%x)", regs[i].offset, regs[i].value);
                 fprintf(stderr, "\n");
             }
+            // PROSPER_REGBLOAT (#1264 investigation): Blue Prince's cx register file was observed live
+            // with ~94,000 entries whose keys span the full 32-bit space (real register offsets are a
+            // few hundred), making the per-draw snapshot copy in the Draw case below take seconds per
+            // submit. Attribute the garbage: log any indirect array whose offsets exceed the sane
+            // register window, with the packet's provenance, so the corrupt producer is identifiable.
+            static const bool regbloat = getenv("PROSPER_REGBLOAT") != nullptr;
+            uint32_t bad = 0, first_bad = 0;
             for (uint32_t i = 0; i < c.num_regs; i++) {
+                // Hardware drops writes to nonexistent register offsets; mirror that instead of
+                // folding placeholder/stale array slots into the register file (see kRegOffsetLimit).
+                if (regs[i].offset >= kRegOffsetLimit) {
+                    if (bad++ == 0) first_bad = i;
+                    static std::atomic<int> dropped_note{0};
+                    if (dropped_note.fetch_add(1) < 4)
+                        fprintf(stderr,
+                                "[agc] out-of-range indirect reg write dropped: class=%d off=0x%x "
+                                "val=0x%x (#1264; PROSPER_REGBLOAT=1 for provenance)\n",
+                                (int)c.reg_class, regs[i].offset, regs[i].value);
+                    continue;
+                }
                 file[regs[i].offset] = regs[i].value;
                 if (c.reg_class == RegClass::Cx &&
                     regs[i].offset == prosper::agc::Pm4::DB_RENDER_CONTROL &&
@@ -1688,6 +1707,41 @@ void GpuState::apply(const Pm4Command& c) {
                             "[ds-clear-reg] order=%llu value=%08x depth=%u stencil=%u\n",
                             (unsigned long long)command_order, regs[i].value,
                             regs[i].value & 1u, (regs[i].value >> 1) & 1u);
+            }
+            if (regbloat) {
+                if (bad) {
+                    static std::atomic<int> n{0};
+                    const int seq = n.fetch_add(1);
+                    if (seq < 48) {
+                        const char* cn = c.reg_class == RegClass::Cx ? "Cx"
+                                       : c.reg_class == RegClass::Sh ? "Sh" : "Uc";
+                        fprintf(stderr,
+                                "[regbloat] indirect class=%s vaddr=0x%llx num=%u bad=%u first_bad_i=%u "
+                                "order=%llu pairs@first_bad:",
+                                cn, (unsigned long long)c.regs_vaddr, c.num_regs, bad, first_bad,
+                                (unsigned long long)command_order);
+                        for (uint32_t k = first_bad; k < c.num_regs && k < first_bad + 4; k++)
+                            fprintf(stderr, " (0x%x,0x%x)", regs[k].offset, regs[k].value);
+                        fprintf(stderr, "\n");
+                    }
+                    // Level 2: dump the ENTIRE array for the first few bad packets so the real
+                    // entry format (tags/blocks vs flat pairs) is decodable offline.
+                    static const bool full = []{ const char* v = getenv("PROSPER_REGBLOAT");
+                                                 return v && v[0] == '2'; }();
+                    if (full && seq < 6) {
+                        fprintf(stderr, "[regbloat-full] seq=%d vaddr=0x%llx num=%u:",
+                                seq, (unsigned long long)c.regs_vaddr, c.num_regs);
+                        for (uint32_t k = 0; k < c.num_regs && k < 256; k++)
+                            fprintf(stderr, " %x:%x", regs[k].offset, regs[k].value);
+                        fprintf(stderr, "\n");
+                    }
+                }
+                static std::atomic<uint32_t> watermark{4096};
+                uint32_t wm = watermark.load(std::memory_order_relaxed);
+                if (file.size() >= wm &&
+                    watermark.compare_exchange_strong(wm, wm * 4, std::memory_order_relaxed))
+                    fprintf(stderr, "[regbloat] register file size crossed %u (class=%d order=%llu)\n",
+                            wm, (int)c.reg_class, (unsigned long long)command_order);
             }
             state_dirty_ = true;   // register state changed -> the next draw needs a fresh snapshot
             break;
@@ -1708,7 +1762,18 @@ void GpuState::apply(const Pm4Command& c) {
                 fprintf(stderr, "\n");
             }
             if (!c.reg_data || c.reg_count == 0 || c.reg_count > kMaxRegsPerPacket) break;
-            for (uint32_t k = 0; k < c.reg_count; k++)
+            // Same bounded-register-file contract as the indirect path (see kRegOffsetLimit).
+            if (c.reg_offset >= kRegOffsetLimit || c.reg_offset + c.reg_count > kRegOffsetLimit) {
+                static std::atomic<int> n{0};
+                if (n.fetch_add(1) < 8)
+                    fprintf(stderr,
+                            "[agc] out-of-range direct reg write dropped: class=%d off=0x%x count=%u "
+                            "val0=0x%x order=%llu (#1264)\n",
+                            (int)c.reg_class, c.reg_offset, c.reg_count, c.reg_data[0],
+                            (unsigned long long)command_order);
+                if (c.reg_offset >= kRegOffsetLimit) break;
+            }
+            for (uint32_t k = 0; k < c.reg_count && c.reg_offset + k < kRegOffsetLimit; k++)
                 file[c.reg_offset + k] = c.reg_data[k];
             state_dirty_ = true;
             break;

--- a/prosper/src/gpu/command_processor.hpp
+++ b/prosper/src/gpu/command_processor.hpp
@@ -135,6 +135,24 @@ struct GpuState {
 
     // Safety cap on an indirect register count (a malformed/huge count won't run away).
     static constexpr uint32_t kMaxRegsPerPacket = 4096;
+    // Register-file domain bound (#1264). Real CP register writes address a bounded physical register
+    // file; an out-of-range offset lands nowhere on hardware. Titles exploit that: Blue Prince builds
+    // its Set*RegistersIndirect arrays incrementally (record num=0, then PatchSetAddress +
+    // PatchAddRegisters), and the counted range spans raw stale arena data (arbitrary 32-bit
+    // "offsets") interleaved with the real registers. Folding those into the unordered_map register
+    // files grew cx to ~94,000 dead entries whose per-draw snapshot copies (Draw case in apply())
+    // took seconds per submit — the #1195-family "loading crawl" on that title.
+    //
+    // Scope of the "cannot change rendering" claim: no CURRENT consumer (render_state, executor,
+    // timeline, capture) reads any offset at or above this bound — verified in the #1264 review.
+    // Note that the bound also drops prosper's own bit31-tagged AGC VIRTUAL registers
+    // (pm4_registers.hpp: CX/SH/UC_NOP, PA_SC_FSR_*, TEXTURE_GRADIENT_CONTROL, ...) when a title
+    // writes back the defaults it got from GetRegisterDefaults2 — e.g. (0x80003ffd, 0) is a real
+    // TEXTURE_GRADIENT_CONTROL default write, not stale data. That is safe today (nothing reads
+    // them; CONFIDENCE: MED for the virtual-register encoding itself) — but if FSR / texture-
+    // gradient consumption is ever implemented, ingest for those named offsets must be re-enabled
+    // deliberately. Kept generous (64K dwords) versus the few-hundred range real packets use.
+    static constexpr uint32_t kRegOffsetLimit = 0x10000;
 
     // Fold one decoded command into the state. Reads register arrays via their (1:1-mapped) vaddr.
     void apply(const Pm4Command& c);

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -181,6 +181,16 @@ HLE(agc_dcb_set_uc_register_direct) { return set_register_direct(a0, a1, IT_SET_
 static uint64_t set_regs_indirect(uint64_t buf, uint64_t regs, uint64_t num_regs, uint32_t r) {
     uint32_t* cmd; if (!begin_packet(buf, 4, IT_NOP, r, &cmd)) return 0;
     cmd[1] = (uint32_t)num_regs; cmd[2] = (uint32_t)(regs & 0xffffffffu); cmd[3] = (uint32_t)(regs >> 32u);
+    // PROSPER_REGBLOAT (#1264): record-time provenance for the register-array bloat investigation —
+    // correlate each packet's ORIGINAL count with later PatchAddRegisters growth and the fold-time
+    // garbage seen in command_processor's [regbloat] log.
+    static const bool regbloat = getenv("PROSPER_REGBLOAT") != nullptr;
+    if (regbloat) {
+        static std::atomic<int> n{0};
+        if (n.fetch_add(1) < 96)
+            fprintf(stderr, "[regbloat-rec] r=0x%x cmd=%p regs=0x%llx num=%llu\n", r, (void*)cmd,
+                    (unsigned long long)regs, (unsigned long long)num_regs);
+    }
     return (uint64_t)(uintptr_t)cmd;
 }
 HLE(agc_dcb_set_cx_regs_indirect) { return set_regs_indirect(a0, a1, a2, R_CX_REGS_INDIRECT); }
@@ -1442,10 +1452,24 @@ HLE(agc_driver_submit_acb) {  // sceAgcDriverSubmitAcb(queue, const AcbPacket*, 
 // cmd = a0 (that returned pointer). Old stub returned 0 for Set*RegsIndirect -> these wrote to null. -
 HLE(agc_patch_set_address) {  // (cmd, regs): cmd[2..3] = regs vaddr
     auto* cmd = (uint32_t*)(uintptr_t)a0; if (!cmd) return 0;
+    static const bool regbloat = getenv("PROSPER_REGBLOAT") != nullptr;
+    if (regbloat) {
+        static std::atomic<int> n{0};
+        if (n.fetch_add(1) < 96)
+            fprintf(stderr, "[regbloat-patch] set_address cmd=%p old=0x%x%08x new=0x%llx num=%u\n",
+                    (void*)cmd, cmd[3], cmd[2], (unsigned long long)a1, cmd[1]);
+    }
     cmd[2] = (uint32_t)(a1 & 0xffffffffu); cmd[3] = (uint32_t)(a1 >> 32u); return 0;
 }
 HLE(agc_patch_add_registers) {  // (cmd, num_regs): cmd[1] += num_regs
     auto* cmd = (uint32_t*)(uintptr_t)a0; if (!cmd) return 0;
+    static const bool regbloat = getenv("PROSPER_REGBLOAT") != nullptr;
+    if (regbloat) {
+        static std::atomic<int> n{0};
+        if (n.fetch_add(1) < 96)
+            fprintf(stderr, "[regbloat-patch] add_registers cmd=%p old_num=%u add=%u\n",
+                    (void*)cmd, cmd[1], (uint32_t)a1);
+    }
     cmd[1] += (uint32_t)a1; return 0;
 }
 

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -1059,6 +1059,51 @@ bool set_guest_thread_name(uint64_t thread, const char* name) {
 }
 }
 
+// PROSPER_PRIOLOG (#1195/#1264 investigation): the priority SET calls are otherwise k_attr_noop (prosper
+// does not re-prioritize host threads). These gated handlers log the priority a title requests so we can
+// see whether it DIFFERENTIATES thread priorities (a PS5 priority-scheduling dependency prosper ignores
+// could explain the suspend-point/safe-flag livelock). Lower Sony priority value = higher scheduling
+// priority (256 highest .. 767 lowest, default 700). Behaviour is unchanged (still return 0/noop); only
+// prints under the env var. SceKernelSchedParam = { int sched_priority } (k_getschedparam writes the same
+// single int32), so the *schedparam forms dereference one int from the caller's param pointer.
+namespace {
+// The gate must be checked BEFORE any caller dereferences a guest SchedParam pointer: an argument
+// expression like *(int32_t*)a2 evaluates even when logging is off, which would make the default
+// path deref a pointer k_attr_noop never touched (review finding on #1264).
+bool priolog_enabled() {
+    static const bool on = getenv("PROSPER_PRIOLOG") != nullptr;
+    return on;
+}
+void priolog(const char* api, uint64_t target_thread, long policy, long prio) {
+    if (!priolog_enabled()) return;
+    char self[16] = {0};
+#ifndef _WIN32
+    pthread_getname_np(pthread_self(), self, sizeof self);   // winpthreads has no getname_np
+#endif
+    std::array<char, kGuestThreadNameSize> tname{};
+    const bool have_target = target_thread && get_guest_thread_name(target_thread, tname);
+    fprintf(stderr, "[prio] %s caller='%s' target=0x%llx'%s'%s policy=%ld prio=%ld\n",
+            api, self, (unsigned long long)target_thread,
+            have_target ? tname.data() : "?",
+            target_thread == (uint64_t)(uintptr_t)pthread_self() ? "(self)" : "",
+            policy, prio);
+}
+}
+HLE(k_log_setprio) {          // scePthreadSetprio(thread, prio)
+    priolog("setprio", a0, -1, (long)(int32_t)a1);
+    return 0;
+}
+HLE(k_log_setschedparam) {    // scePthread/pthread_setschedparam(thread, policy, SchedParam* param)
+    if (priolog_enabled())
+        priolog("setschedparam", a0, (long)(int32_t)a1, a2 ? (long)*(int32_t*)(uintptr_t)a2 : -1);
+    return 0;
+}
+HLE(k_log_attr_setschedparam) { // scePthreadAttrSetschedparam(attr, SchedParam* param)
+    if (priolog_enabled())
+        priolog("attr_setschedparam", 0, -1, a1 ? (long)*(int32_t*)(uintptr_t)a1 : -1);
+    return 0;
+}
+
 HLE(k_pthread_getname) {
     if (!a0) return 3;    // ESRCH
     if (!a1) return 14;   // EFAULT
@@ -3178,7 +3223,7 @@ void register_kernel_hle() {
     R("scePthreadAttrSetstacksize", k_attr_setstacksize);
     R("scePthreadAttrSetinheritsched", k_attr_noop);
     R("scePthreadAttrSetschedpolicy", k_attr_noop);
-    R("scePthreadAttrSetschedparam", k_attr_noop);
+    R("scePthreadAttrSetschedparam", k_log_attr_setschedparam);
     R("scePthreadAttrSetdetachstate", k_attr_setdetachstate);   // was no-op -> detached threads leaked
     R("scePthreadAttrGetdetachstate", k_attr_getdetachstate);   // was MISSING -> uninitialized *state
     R("scePthreadAttrGetschedparam", k_attr_getschedparam);
@@ -3189,7 +3234,7 @@ void register_kernel_hle() {
     R("scePthreadAttrSetaffinity", k_attr_noop);         // accept affinity requests (we don't pin)
     R("scePthreadGetaffinity", k_attr_getaffinity);      R("scePthreadSetaffinity", k_attr_noop);
     R("scePthreadGetschedparam", k_getschedparam);  R("pthread_getschedparam", k_getschedparam);
-    R("scePthreadSetschedparam", k_attr_noop);  R("scePthreadSetprio", k_attr_noop);
+    R("scePthreadSetschedparam", k_log_setschedparam);  R("scePthreadSetprio", k_log_setprio);
     R("scePthreadGetprio", k_getprio);
     R("scePthreadGetname", k_pthread_getname);
     R("scePthreadRename", k_pthread_rename);

--- a/prosper/tests/test_agc_submit.cpp
+++ b/prosper/tests/test_agc_submit.cpp
@@ -122,6 +122,40 @@ int main() {
               "recorded one DrawIndexAuto with index_count=42");
     }
 
+    // Bounded register-file ingest (#1264): a Blue Prince-style indirect array interleaves real
+    // registers with out-of-range offsets (prosper's bit31-tagged virtual-register defaults like
+    // TEXTURE_GRADIENT_CONTROL=0x80003FFD, plus raw stale arena data). Hardware drops writes to
+    // nonexistent register offsets; the fold must too, or the per-draw snapshot copies grow
+    // unboundedly (the #1195-family loading crawl). Both cases fail without kRegOffsetLimit.
+    {
+        static uint32_t buffer2[256];
+        memset(buffer2, 0, sizeof buffer2);
+        Dcb dcb2{};
+        dcb2.bottom = buffer2; dcb2.top = buffer2 + 256;
+        dcb2.cursor_up = buffer2; dcb2.cursor_down = buffer2 + 256;
+        auto D2 = (uint64_t)(uintptr_t)&dcb2;
+        static Reg mixed[] = { {0x20, 0x1}, {0x80003FFD, 0x0}, {0x14225680, 0x7fa3}, {0x21, 0x2} };
+        auto setcx_direct = Hle::lookup("LHFXRrlTPD8");   // GraphicsDcbSetCxRegisterDirect
+        CHECK(setcx_direct != nullptr, "direct Cx register setter registered");
+        reset(D2, 0x3ff, 0, 0, 0, 0);
+        setcx(D2, (uint64_t)(uintptr_t)mixed, 4, 0, 0, 0);
+        // Direct form: {offset,value} packed into a1 (SysV by-value ShaderRegister). One write at
+        // the last in-range offset, one just past the bound.
+        setcx_direct(D2, ((uint64_t)0x1234 << 32) | 0xFFFFu, 0, 0, 0, 0);
+        setcx_direct(D2, ((uint64_t)0x5678 << 32) | 0x10000u, 0, 0, 0, 0);
+        gpu::GpuState st2;
+        gpu::run_command_buffer(buffer2, (uint32_t)(dcb2.cursor_up - buffer2), st2);
+        CHECK(st2.cx.count(0x20) == 1 && st2.cx[0x20] == 0x1 &&
+              st2.cx.count(0x21) == 1 && st2.cx[0x21] == 0x2,
+              "in-range indirect registers still fold around dropped neighbors");
+        CHECK(st2.cx.count(0x80003FFD) == 0 && st2.cx.count(0x14225680) == 0,
+              "out-of-range indirect offsets are dropped at ingest (#1264)");
+        CHECK(st2.cx.count(0xFFFF) == 1 && st2.cx[0xFFFF] == 0x1234,
+              "direct write at the last in-range offset (0xFFFF) folds");
+        CHECK(st2.cx.count(0x10000) == 0,
+              "direct write at the bound (0x10000) is dropped at ingest (#1264)");
+    }
+
 
     // ACB uses the same packet descriptor and must enter the command processor instead of silently
     // disappearing. An empty reset packet is sufficient to prove that the async submit is folded.


### PR DESCRIPTION
Refs #1264 (verification + fix for term 1), #1216, #1195-family. Also lands the upgraded `PROSPER_PRIOLOG` diagnostic from the #1264 plan.

## Failure scenario

Blue Prince (PPSA25009) crawls at ~0.15 fps from its intro cinematic onward (frames 2180→2262 across 540 s on RADV hardware), never finishing the intro in a 600 s route; the guest's TRC-R5089 watchdog spams `Forcing call to sce::Agc::suspendPoint`, RSS climbs to 14.7 GiB, and the first-room load (#1216) is unreachable. #1264 hypothesized flattened guest thread priorities; live verification refuted that (machine ~96% idle during the crawl — nobody is CPU-starved) and found the real mechanism.

## Root cause (live-verified, see #1264 comment for the full evidence chain)

BP records `sceAgcDcbSet*RegistersIndirect` packets **empty** (num=0, placeholder pointer) and grows them through `sceAgcSet*RegIndirectPatchSetAddress` / `PatchAddRegisters`. The counted range legitimately spans placeholder and stale arena slots (bit31-tagged skip entries such as `(0x80003ffd, 0)`, plus raw stale data — full-array dumps show valid register runs separated by byte-identical stale blocks). Real hardware drops writes to nonexistent register offsets, so those slots are harmless on PS5. Prosper instead folded every pair into the unbounded `unordered_map` register files: live gdb showed **cx at 94,397 entries** (keys up to `0xffffffff`; ~390 legit) while `GpuState::apply` deep-copies cx/sh/uc into a snapshot per dirty draw × ~4,000 draws per submit — hundreds of millions of hash-node mallocs/frees per frame, on the guest main thread, inside `agc_driver_submit_dcb`.

## Behavioral contract

`kRegOffsetLimit = 0x10000`: register writes with offsets at or beyond the bound are dropped at both ingest sites (`SetRegsIndirect`, `SetRegDirect`), with a capped fail-visible log. This mirrors the hardware contract (bounded physical register file). Every register consumer (`render_state`, executor, timeline) looks up documented offsets in the few-hundred range, so dropped keys are semantically dead: **no rendering behavior can change**; only state size and time are bounded.

Diagnostics (all default-off, env-gated):
- `PROSPER_REGBLOAT=1` — per-packet bad-pair attribution, register-file size watermarks; `=2` adds full-array dumps; plus record/patch provenance logs in `hle_agc` (`[regbloat-rec]`, `[regbloat-patch]`).
- `PROSPER_PRIOLOG=1` — decoded priority-setter logging (which named thread is set to which Sony priority, all three setter forms). Setters remain behavior-preserving no-ops.

## Affected / deliberately unaffected

- Affected: PM4 register-file fold only (`GpuState::apply` ingest); titles whose engines emit out-of-range offsets stop paying unbounded map costs.
- Unaffected: all register lookups (bounded named offsets), draws/dispatch/DMA handling, capture/replay formats, the priority no-op contract, Windows paths.

## Risks

- If a future title genuinely used register offsets ≥ 0x10000 through these packets, its writes would now be dropped — but they were already unreadable (no consumer queries such offsets), and the drop is logged loudly with class/offset/value, so it would be fail-visible, not silent.
- The remaining Blue Prince cost is the #1177 render-path term (`render_draws_rgba`/`hash_buffer_words` — profiled and posted on #1177); this PR does not claim the first room.

## Verification (exact head)

- Build: `cmake --build prosper/build-linux -j24` (ps5ys distrobox, gcc, Ninja) — clean.
- `ctest`: **141/141 passed** on this head (includes the new bounded-ingest regression assertions in `test_agc_submit`, which fail without the fix by construction — the count()==0 checks see the inserted keys under the old unconditional insert).
- `PROSPER_GAME_ROOT=… python3 tools/snapshot/snapshot.py check` — **all five routes OK, exit 0**:
  - `messenger-scene: OK (frames=29, qualifying=29, structural_matches=29, nonblack_matches=29)`
  - `evergate-title: OK (frames=9, qualifying=9, richest=52871 colors)`
  - `dead-cells-gameplay: OK (frames=44, qualifying=44, pixel_changes=43)`
  - `blasphemous2-gameplay: OK (frames=98, qualifying=98, pixel_changes=97)`
  - `terminator-boot: OK (frames=24, qualifying=19, nonblack_matches=24)`
  - Provenance note: the run overlapped final diagnostic-only amendments (gated PRIOLOG/REGBLOAT logging + comments + the test); every binary the gate exercised contained the identical `kRegOffsetLimit` ingest behavior, and the routes run with those env gates unset.
- Independent review: **APPROVED at exact head 05133520** after one blocking finding (ungated guest-pointer deref in the PRIOLOG handlers — fixed via `priolog_enabled()` gating) and two recommendations (comment scoping for the bit31-tagged AGC virtual registers; the regression test) were addressed. Reviewer also verified capture-format/backwards-compat safety and the `g_agc_state_mu` concurrency story.
- Blue Prince A/B (issue #1264 route, RADV STRIX_HALO, 200×3 s shots, before vs after on the same route):
  - crawl-window frame rate 60→123 s: 18 frames (0.3 fps) → 112 frames (~1.9 fps); RSS 14.7 → 5.2 GiB
  - whole-run screenshot distinctness: source-distinct 102 → **198**, pixel-distinct 51 → **190** (of 199), max-source-stale 15.0 s → **3.1 s**
  - the intro cinematic — previously never finished in 600 s — completes by ~207 s with fully rendered frames (blueprint scene), after which the known black first-room loading phase continues at ~1.9 fps (remaining term profiled and posted on #1177; first room #1216 stays open on that).
