### PR TITLE
fix(gpu): extend the scissor-offset recover to the off-target (extent-empty) case

### DIFF
--- a/prosper/src/gpu/render_state.cpp
+++ b/prosper/src/gpu/render_state.cpp
@@ -368,12 +368,13 @@ RenderState extract_render_state(const GpuState& st) {
                           PM4_FIELD(viewport_tl, PA_SC_VPORT_SCISSOR_0_TL,
                                     WINDOW_OFFSET_DISABLE) != 0);
             // #1164: a window offset can push the scissor ENTIRELY off the render target while
-            // leaving it non-empty in absolute coordinates (e.g. TL_Y offset 2560 on a 2160-tall
-            // target -> top=2560 > bottom -> zero area once clamped). Judge emptiness against the
-            // color0 extent so the recover below fires for the off-target case too, not only the
-            // absolute-degenerate case. Only when the extent is known (a color pass); a depth-only
-            // pass leaves color0_width/height 0 and keeps the pre-#1164 absolute test.
-            if (rs.color0_width && rs.color0_height) {
+            // leaving it non-empty in ABSOLUTE coordinates. E.g. a VPORT rect [0,2048) offset by
+            // +2560 becomes [2560,4608): right>left (absolutely non-empty), but its overlap with a
+            // 2048-wide target is [max(2560,0), min(4608,2048)) = [2560,2048) = empty. Judge
+            // emptiness against the color0 extent so the recover below fires for that off-target
+            // case too, not only the absolute-degenerate case #1161 handled. Only when the extent
+            // is known (a color pass); a depth-only pass has no extent and keeps the absolute test.
+            if (rs.color0_has_extent) {
                 const int32_t cw = static_cast<int32_t>(rs.color0_width);
                 const int32_t ch = static_cast<int32_t>(rs.color0_height);
                 return std::min(right, cw) > std::max(left, 0) &&

--- a/prosper/src/gpu/render_state.cpp
+++ b/prosper/src/gpu/render_state.cpp
@@ -367,6 +367,18 @@ RenderState extract_render_state(const GpuState& st) {
                           PM4_FIELD(viewport_br, PA_SC_VPORT_SCISSOR_0_BR, BR_Y),
                           PM4_FIELD(viewport_tl, PA_SC_VPORT_SCISSOR_0_TL,
                                     WINDOW_OFFSET_DISABLE) != 0);
+            // #1164: a window offset can push the scissor ENTIRELY off the render target while
+            // leaving it non-empty in absolute coordinates (e.g. TL_Y offset 2560 on a 2160-tall
+            // target -> top=2560 > bottom -> zero area once clamped). Judge emptiness against the
+            // color0 extent so the recover below fires for the off-target case too, not only the
+            // absolute-degenerate case. Only when the extent is known (a color pass); a depth-only
+            // pass leaves color0_width/height 0 and keeps the pre-#1164 absolute test.
+            if (rs.color0_width && rs.color0_height) {
+                const int32_t cw = static_cast<int32_t>(rs.color0_width);
+                const int32_t ch = static_cast<int32_t>(rs.color0_height);
+                return std::min(right, cw) > std::max(left, 0) &&
+                       std::min(bottom, ch) > std::max(top, 0);
+            }
             return right > left && bottom > top;
         };
 
@@ -376,8 +388,10 @@ RenderState extract_render_state(const GpuState& st) {
         // offset is the cause, recover by re-running the combine without it. Observed on Bendy and
         // the Ink Machine (PPSA27616), whose title/menu/gameplay draws leave the VPORT scissor
         // offset-enabled while PA_SC_WINDOW_OFFSET carries a large value; the un-offset scissor is
-        // the correct full-target region and the frame renders. CONFIDENCE: MED — mechanism verified
-        // against the live capture; the un-offset recovery matches on-hardware output.
+        // the correct full-target region and the frame renders. #1164 extends the empty test to
+        // "empty after clamping to the color0 extent" so in-game draws whose offset shifts the
+        // scissor off-target (non-empty in absolute coords) also recover. CONFIDENCE: MED —
+        // mechanism verified against the live capture; the un-offset recovery matches hardware.
         if (!combine(/*apply_offset=*/true) && (offset_x != 0 || offset_y != 0))
             combine(/*apply_offset=*/false);
         rs.scissor_left = left; rs.scissor_top = top;

--- a/prosper/tests/test_render_state.cpp
+++ b/prosper/tests/test_render_state.cpp
@@ -241,6 +241,43 @@ int main() {
               kept.scissor_right == 2064 && kept.scissor_bottom == 2064,
               "a window offset that keeps the VPORT scissor on-target is preserved, not dropped");
     }
+    {
+        // #1164: the OFF-TARGET recover — a window offset that leaves the scissor NON-EMPTY in
+        // absolute coordinates but shifts it entirely off the render target (empty only after
+        // clamping to the color0 extent). The #1161 recover above tests the absolute-empty case;
+        // this tests the absolute-non-empty-but-off-target case, which needs a known color extent.
+        // WOULD-FAIL-WITHOUT-FIX: without the extent-aware emptiness test, combine(true) reports the
+        // off-target rect as non-empty (screen scissor 16384 wide leaves [2560,4608) intact), no
+        // recover fires, and the final scissor is the off-target [2560,4608) — asserted against here.
+        GpuState off;
+        off.cx[P::PA_SC_SCREEN_SCISSOR_TL]  = 0x00000000u;    // (0,0)
+        off.cx[P::PA_SC_SCREEN_SCISSOR_BR]  = 0x40004000u;    // (16384,16384) AGC default
+        off.cx[P::PA_SC_WINDOW_SCISSOR_TL]  = 0x80000000u;    // offset disabled, full
+        off.cx[P::PA_SC_WINDOW_SCISSOR_BR]  = 0x40004000u;
+        off.cx[P::PA_SC_GENERIC_SCISSOR_TL] = 0x80000000u;    // offset disabled, full
+        off.cx[P::PA_SC_GENERIC_SCISSOR_BR] = 0x40004000u;
+        off.cx[P::PA_SC_VPORT_SCISSOR_0_TL] = 0x00000000u;    // (0,0), offset ENABLED (bit31 clear)
+        off.cx[P::PA_SC_VPORT_SCISSOR_0_BR] = 0x08000800u;    // (2048,2048)
+        off.cx[P::PA_SC_MODE_CNTL_0]        = 0x00000002u;    // VPORT_SCISSOR_ENABLE
+        off.cx[P::CB_COLOR0_ATTRIB2]        = ((2048u - 1u) << 14) | (2048u - 1u);   // 2048x2048 target
+        off.cx[P::PA_SC_WINDOW_OFFSET]      = 0x0A000A00u;    // (+2560,+2560): VPORT -> [2560,4608)^2
+        const RenderState recovered_off = extract_render_state(off);
+        CHECK(recovered_off.has_scissor && recovered_off.scissor_left == 0 &&
+              recovered_off.scissor_top == 0 && recovered_off.scissor_right == 2048 &&
+              recovered_off.scissor_bottom == 2048,
+              "a window offset that pushes an absolute-non-empty VPORT scissor off the color0 extent "
+              "is dropped, recovering the on-target rectangle (#1164)");
+
+        // Boundary: an offset that leaves the VPORT scissor PARTIALLY on-target (overlaps the extent)
+        // is genuine and preserved — the recover must not fire. VPORT [0,2048) offset +1900 ->
+        // [1900,3948): overlap with the 2048 extent is [1900,2048), non-empty -> kept as-is.
+        GpuState partial = off;
+        partial.cx[P::PA_SC_WINDOW_OFFSET] = 0x0000076Cu;     // (X=+1900, Y=0)
+        const RenderState kept_partial = extract_render_state(partial);
+        CHECK(kept_partial.scissor_left == 1900 && kept_partial.scissor_right == 3948 &&
+              kept_partial.scissor_top == 0 && kept_partial.scissor_bottom == 2048,
+              "a window offset leaving the VPORT scissor partially on-target is preserved, not dropped");
+    }
 
     CHECK(rs.color0_base == rdna2_addr(0x00100000u, 0x12u), "color0_base = (BASE<<8)|(EXT<<40)");
     CHECK(rs.color0_format == 0x0Au, "color0_format = 0x0A (FORMAT field)");


### PR DESCRIPTION
Progresses #1164 (Bendy in-game black). **Honest scope up front: this is a correctness fix that measurably but PARTIALLY improves Bendy — it is NOT a rendered-scene milestone; the scene is still mostly black due to a separate, unresolved second cause.** Posting for independent review because it touches the delicate scissor path (shared render-state code).

## Failure scenario
Bendy's in-game draws carry a large, **genuine** (proven in #1162: prosper decodes the guest's indirect register array faithfully) `PA_SC_WINDOW_OFFSET` that shifts the VPORT scissor **entirely off the render target** while leaving it non-empty in absolute coordinates (e.g. `TL_Y` offset 2560 on a 2160-tall target → `top=2560 > bottom`). The existing recover (`render_state.cpp`, from the merged #1161) only fires when the combined scissor is empty in **absolute** coords (`right<=left`), so the off-target case passed through, the draw's scissor landed off the framebuffer, the extent-clamp zeroed its area, and those draws wrote nothing.

## Fix
Judge scissor emptiness against the **color0 extent** (`rs.color0_width/height`) so an off-target-but-non-empty scissor also triggers the existing un-offset recover — the same class of recovery #1161 already does for degenerate-empty. Guarded to a known color extent; a depth-only pass (extent 0) keeps the pre-existing absolute test.

## Evidence (controlled A/B, same `reach-gameplay.pad` route, clean-master vs fix build)
Post-BEGIN late frames, distinct-color count as a content proxy:
- **master:** static loop 48 / 56 / 115 colors (near-black).
- **fix:** varied & richer — 1257, 656, 4338, …, 447, 387 interleaved. Visually recovers a wood-slatted structure (correct 3D perspective) + a framed picture, both absent in the black baseline.

So the fix demonstrably renders more of the scene — but ~90% stays black; the main HDR G-buffer/depth passes still don't render (a **second cause**, tracked in #1164). This reproduces the conclusion of the issue's earlier drafted extent-clamp.

## Deliberately unaffected / risk
- Depth-only passes (color extent 0) keep the exact prior behavior.
- On-target scissors (normal draws in every title) are non-empty after extent-clamp → recover does not fire → identical to before.
- Shared render-state code → the key gate is no regression on working titles.

## Verification (native Linux, RADV)
- `ctest` **140/140**.
- `snapshot.py check` **all 5 titles OK** — messenger-scene, evergate-title, dead-cells-gameplay, blasphemous2-gameplay, terminator-boot (no regression; this is the hard safety gate for a shared scissor change).
- Bendy A/B as above (partial improvement; not attached as progression evidence since the captures are still mostly black, per the charter).

**Reviewer question to weigh:** the project previously drafted-but-did-not-land an extent-clamp of this kind (per #1164). This version is clean, snapshot-safe, and A/B-verified to help — but is a correct-yet-insufficient generalization of #1161 worth landing as a stepping stone, or held until the second cause is also fixed? Your call on the merge bar.