### PR TITLE
perf(render): stop re-hashing full buffer contents per draw-reference (#1268)

### DIFF
--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -252,6 +252,16 @@ struct BackendResourceReuseStats {
     size_t persistent_texture_binding_misses = 0;
     size_t persistent_texture_binding_entries = 0;
     size_t persistent_texture_binding_evictions = 0;
+    // Buffer content-hash economics (#1268): the shared-buffer dedup key embeds a full content
+    // hash, which profiled as the dominant CPU term on Blue Prince's ~4,000-draw submits. These
+    // count, per call like the rest of this struct, how much hashing actually ran and how much
+    // was avoided (repeat references resolved by the per-call memo; unique-tag keys that cannot
+    // match anything skip hashing entirely).
+    uint64_t buffer_hash_calls = 0;
+    uint64_t buffer_hash_dwords = 0;
+    uint64_t buffer_hash_skipped_unique = 0;
+    uint64_t buffer_hash_skipped_large = 0;
+    uint64_t buffer_ref_memo_hits = 0;
 };
 
 inline BackendResourceReuseStats& backend_resource_reuse_stats_storage() {
@@ -261,6 +271,39 @@ inline BackendResourceReuseStats& backend_resource_reuse_stats_storage() {
 
 inline BackendResourceReuseStats backend_resource_reuse_stats() {
     return backend_resource_reuse_stats_storage();
+}
+
+// Cumulative across calls (the per-call struct above is reset at every render_draws_rgba entry, which
+// tests rely on). PROSPER_HASH_STATS=1 prints these every few seconds from the render path so a live
+// route shows the hashing economics without a debugger (#1268).
+struct BackendHashStatsTotals {
+    uint64_t references = 0;
+    uint64_t memo_hits = 0;
+    uint64_t hash_calls = 0;
+    uint64_t hash_dwords = 0;
+    uint64_t skipped_unique = 0;
+    uint64_t skipped_large = 0;
+    uint64_t unique_buffers = 0;
+};
+inline BackendHashStatsTotals& backend_hash_stats_totals() {
+    static thread_local BackendHashStatsTotals totals;
+    return totals;
+}
+inline void maybe_report_hash_stats() {
+    static const bool on = getenv("PROSPER_HASH_STATS") != nullptr;
+    if (!on) return;
+    static thread_local auto last = std::chrono::steady_clock::now();
+    const auto now = std::chrono::steady_clock::now();
+    if (now - last < std::chrono::seconds(5)) return;
+    last = now;
+    const BackendHashStatsTotals& t = backend_hash_stats_totals();
+    fprintf(stderr,
+            "[hash-stats] refs=%llu memo_hits=%llu hash_calls=%llu hashed_MiB=%.1f "
+            "skipped_unique=%llu skipped_large=%llu unique_buffers=%llu\n",
+            (unsigned long long)t.references, (unsigned long long)t.memo_hits,
+            (unsigned long long)t.hash_calls, (double)t.hash_dwords * 4.0 / (1024.0 * 1024.0),
+            (unsigned long long)t.skipped_unique, (unsigned long long)t.skipped_large,
+            (unsigned long long)t.unique_buffers);
 }
 
 struct BackendPipelineCacheStats {
@@ -1700,6 +1743,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     color_target_stats = {};
     BackendResourceReuseStats& resource_reuse_stats = backend_resource_reuse_stats_storage();
     resource_reuse_stats = {};
+    maybe_report_hash_stats();   // gated cumulative hashing economics (#1268)
     std::vector<uint8_t> out;
     if (out_rgba1) out_rgba1->clear();
     if (draws.empty()) return out;
@@ -2225,6 +2269,28 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     std::vector<SharedBufferUpload> shared_buffers;
     std::vector<SharedBufferArena> shared_buffer_arenas;
     std::unordered_map<SharedBufferKey, size_t, SharedBufferKeyHash> shared_buffer_indices;
+    // Per-call repeat-reference memo (#1268): draws in one pass batch overwhelmingly re-reference
+    // the same guest ranges (same VB/UB across hundreds of draws), and the SharedBufferKey lookup
+    // pays a FULL content hash per reference because the hash is part of the key. Within one call
+    // the referenced guest memory is stable modulo cross-thread racing writes — which are equally
+    // nondeterministic on real hardware (the GPU samples the buffer once per draw at execution),
+    // so resolving a repeated (words, count, identity) reference to the first upload is within the
+    // same latitude the hardware has. First reference still hashes + memcmps as before.
+    struct BufferRefMemoKey {
+        const uint32_t* words = nullptr;
+        size_t count = 0;
+        uint64_t identity = 0;
+        bool operator==(const BufferRefMemoKey& other) const {
+            return words == other.words && count == other.count && identity == other.identity;
+        }
+    };
+    struct BufferRefMemoKeyHash {
+        size_t operator()(const BufferRefMemoKey& key) const {
+            return static_cast<size_t>((reinterpret_cast<uintptr_t>(key.words) >> 2) ^
+                (key.count * 0x9e3779b97f4a7c15ull) ^ key.identity);
+        }
+    };
+    std::unordered_map<BufferRefMemoKey, size_t, BufferRefMemoKeyHash> buffer_ref_memo;
     std::vector<SharedTextureBinding> shared_texture_bindings;
     std::unordered_map<TextureBindingKey, size_t, TextureBindingKeyHash>
         shared_texture_binding_indices;
@@ -2951,12 +3017,56 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                         words = &zero_buffer_word;
                         word_count = 1;
                     }
-                    const uint64_t content_hash = hash_buffer_words(words, word_count);
+                    ++resource_reuse_stats.buffer_references;
+                    ++backend_hash_stats_totals().references;
+                    const bool shareable = share_backend_resources && r.buffer_identity != 0;
+                    size_t buffer_index = SIZE_MAX;
+                    const BufferRefMemoKey memo_key{words, word_count, r.buffer_identity};
+                    if (shareable) {
+                        auto memo_found = buffer_ref_memo.find(memo_key);
+                        if (memo_found != buffer_ref_memo.end()) {
+                            buffer_index = memo_found->second;
+                            ++resource_reuse_stats.buffer_ref_memo_hits;
+                            ++backend_hash_stats_totals().memo_hits;
+                        }
+                    }
+                    if (buffer_index != SIZE_MAX) {
+                        // repeat reference within this call — resolved without hashing (#1268)
+                    } else {
+                    // A unique-tag key can never match an existing entry (the tag differs from every
+                    // other key and operator== checks all scalars before the memcmp), so its content
+                    // hash contributes nothing to the lookup — skip it (#1268).
+                    //
+                    // Large buffers also take a unique tag: cross-pointer content dedup is kept for
+                    // SMALL buffers only (<= kSharedBufferHashDedupMaxDwords). Measured live on Blue
+                    // Prince's loading submits, the content-hash lookup had ZERO dedup hits across
+                    // 556K hashed references while costing ~1.8 GiB/s of FNV over ~97 KiB average
+                    // payloads — pure waste at exactly the draw volume where it hurts. Repeat
+                    // references to a large range still resolve through the per-call memo above;
+                    // what a large buffer loses is only the merge of two DIFFERENT-pointer,
+                    // identical-content references within one call, which the live data shows never
+                    // happens. Small buffers (per-draw UBO-sized, the tests' contract) keep the full
+                    // hash + memcmp dedup exactly as before.
+                    constexpr size_t kSharedBufferHashDedupMaxDwords = 1024;   // 4 KiB
+                    const bool hash_dedup =
+                        shareable && word_count <= kSharedBufferHashDedupMaxDwords;
+                    uint64_t content_hash = 0;
+                    if (hash_dedup) {
+                        content_hash = hash_buffer_words(words, word_count);
+                        ++resource_reuse_stats.buffer_hash_calls;
+                        resource_reuse_stats.buffer_hash_dwords += word_count;
+                        ++backend_hash_stats_totals().hash_calls;
+                        backend_hash_stats_totals().hash_dwords += word_count;
+                    } else if (shareable) {
+                        ++resource_reuse_stats.buffer_hash_skipped_large;
+                        ++backend_hash_stats_totals().skipped_large;
+                    } else {
+                        ++resource_reuse_stats.buffer_hash_skipped_unique;
+                        ++backend_hash_stats_totals().skipped_unique;
+                    }
                     SharedBufferKey buffer_key{
                         words, word_count, r.buffer_identity, content_hash,
-                        share_backend_resources && r.buffer_identity ? 0 : ++resource_unique_tag};
-                    ++resource_reuse_stats.buffer_references;
-                    size_t buffer_index = SIZE_MAX;
+                        hash_dedup ? 0 : ++resource_unique_tag};
                     auto buffer_found = shared_buffer_indices.find(buffer_key);
                     if (buffer_found != shared_buffer_indices.end()) {
                         buffer_index = buffer_found->second;
@@ -3000,6 +3110,9 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                         shared_buffers.push_back(upload);
                         shared_buffer_indices.emplace(buffer_key, buffer_index);
                         ++resource_reuse_stats.unique_buffers;
+                        ++backend_hash_stats_totals().unique_buffers;
+                    }
+                    if (shareable) buffer_ref_memo.emplace(memo_key, buffer_index);
                     }
                     dbi[i] = {shared_buffers[buffer_index].buffer,
                               shared_buffers[buffer_index].offset,

--- a/prosper/tests/test_multidraw_render.cpp
+++ b/prosper/tests/test_multidraw_render.cpp
@@ -295,6 +295,18 @@ int main() {
         CHECK(shared_contents_stats.buffer_references == 4 &&
                   shared_contents_stats.unique_buffers == 2,
               "immutable buffer views retain exact backend upload reuse");
+        // #1268: the second draw's references carry the SAME view pointer + identity, so the
+        // per-call memo must resolve them without re-hashing; only the first draw's two
+        // references pay a content hash. (The owned-vector block above copies the dwords into
+        // each BackendDraw, so its four references have distinct pointers and all hash —
+        // asserted below — which is exactly the hash+memcmp dedup path the memo falls back to.)
+        CHECK(shared_contents_stats.buffer_ref_memo_hits == 2 &&
+                  shared_contents_stats.buffer_hash_calls == 2 &&
+                  shared_contents_stats.buffer_hash_skipped_unique == 0,
+              "repeat view references resolve via the per-call memo without re-hashing");
+        CHECK(shared_stats.buffer_ref_memo_hits == 0 &&
+                  shared_stats.buffer_hash_calls == 4,
+              "owned-vector references (distinct pointers) keep full hash+memcmp dedup");
 
         prosper::test::BackendDraw capacity_peer0 = d0;
         prosper::test::BackendDraw capacity_peer1 = d1;
@@ -332,6 +344,58 @@ int main() {
               "buffer-pool disable switch restores transient Vulkan uploads");
         CHECK(pool_bypassed == shared,
               "pooled and forced-transient storage buffers render byte-identically");
+
+        // #1268: buffers above the 4 KiB hash-dedup bound skip content hashing entirely (live Blue
+        // Prince data: zero dedup hits across 556K hashed references at ~1.8 GiB/s of hashing).
+        // Repeat references still resolve through the per-call memo, and rendering is unchanged.
+        // (Placed after the pool-delta assertions above: the 8 KiB upload adds its own pool miss.)
+        {
+            prosper::test::FrameResource large = buffer;
+            large.dwords.assign(2048, 0u);
+            std::copy(std::begin(fullscreen_triangle), std::end(fullscreen_triangle),
+                      large.dwords.begin());
+            large.buffer_identity = 0x7020000000000004ull;
+            prosper::test::BackendDraw large0 = d0;
+            prosper::test::BackendDraw large1 = d1;
+            for (prosper::test::BackendDraw* draw : {&large0, &large1}) {
+                draw->R[1].dwords.clear();
+                draw->R[1].dwords_view = large.dwords.data();
+                draw->R[1].dwords_view_count = large.dwords.size();
+                draw->R[1].buffer_identity = large.buffer_identity;
+            }
+            const std::vector<uint8_t> large_frame =
+                prosper::test::render_draws_rgba({large0, large1}, W, H);
+            const auto large_stats = prosper::test::backend_resource_reuse_stats();
+            CHECK(large_frame == shared,
+                  "large-buffer views render byte-identically (hash-dedup bound is inert visually)");
+            CHECK(large_stats.buffer_hash_skipped_large == 1 &&
+                      large_stats.buffer_ref_memo_hits == 1 &&
+                      large_stats.buffer_hash_calls == 2 &&
+                      large_stats.unique_buffers == 2,
+              "large buffer skips content hashing; its repeat reference resolves via the memo "
+              "(the two owned filler copies keep small-buffer hash dedup)");
+        }
+
+        // #1268 review follow-up: the memo key includes buffer_identity — the SAME view pointer
+        // under two DIFFERENT identities must not memo-merge (equal bytes at distinct identities
+        // remain distinct uploads, as the identity-keyed SharedBufferKey already guarantees).
+        {
+            prosper::test::BackendDraw ident0 = d0;
+            prosper::test::BackendDraw ident1 = d1;
+            for (prosper::test::BackendDraw* draw : {&ident0, &ident1}) {
+                draw->R[1].dwords.clear();
+                draw->R[1].dwords_view = buffer.dwords.data();
+                draw->R[1].dwords_view_count = buffer.dwords.size();
+            }
+            ident1.R[1].buffer_identity++;
+            const std::vector<uint8_t> ident_frame =
+                prosper::test::render_draws_rgba({ident0, ident1}, W, H);
+            const auto ident_stats = prosper::test::backend_resource_reuse_stats();
+            CHECK(ident_frame == shared,
+                  "distinct-identity views render byte-identically");
+            CHECK(ident_stats.buffer_ref_memo_hits == 0 && ident_stats.unique_buffers == 3,
+                  "the memo keys on identity: one view pointer under two identities stays distinct");
+        }
 
         prosper::test::BackendDraw distinct = d1;
         distinct.R[1].buffer_identity++;


### PR DESCRIPTION
Fixes #1268. Term 2 of the Blue Prince loading crawl (#1264/#1266 fixed term 1; #1177 is the family issue; #1216 is gated on this path).

## Failure scenario

Post-#1266, Blue Prince's intro/loading runs at ~1.9 fps with one core pegged inside `render_draws_rgba`; 4 of 5 gdb samples sit in `hash_buffer_words`. The shared-buffer dedup embeds a full content hash in its lookup key (`SharedBufferKey`), so **every storage-buffer reference of every draw hashes its full contents** — and pass batches of hundreds of draws re-reference the same ranges. Live measurement on the #1264 route (new `PROSPER_HASH_STATS=1`): during the crawl prosper hashed **~1.8 GiB/s** (52.9 GiB in one 150 s run, ~97 KiB average per hashed reference) — while across **556K hashed lookups the content-hash dedup scored exactly zero hits**. The hashing was 100% waste at exactly the draw volume where it hurts.

## Change

Two independent cuts, both leaving the small-buffer dedup contract intact:

1. **Per-call repeat-reference memo**: draws in one pass batch overwhelmingly re-reference the same guest ranges; a `(words-ptr, word_count, buffer_identity)` memo resolves repeats to the first upload without hashing or re-uploading. Within one call the referenced guest memory is stable modulo cross-thread racing writes, which are equally nondeterministic on real hardware (the GPU samples a buffer once per draw at execution), so first-reference-wins is within the same latitude the hardware has. Measured live: the memo resolves **78% of references** (1.95M of 2.5M in one run).
2. **Hash-dedup size bound (`kSharedBufferHashDedupMaxDwords` = 1024, i.e. 4 KiB)**: larger buffers take a unique tag instead of a content hash — their repeats still resolve via the memo; what they lose is only the merge of different-pointer identical-content references within one call, which the live data shows never happens (0 of 556K). Small per-draw-UBO-sized buffers keep the exact hash + memcmp dedup as before. A unique-tag key also skips hashing outright since it can never match any other key.

Also: `PROSPER_HASH_STATS=1` — gated 5-second cumulative report of the hashing economics (`refs / memo_hits / hash_calls / hashed_MiB / skipped_unique / skipped_large / unique_buffers`), and per-call fields on `BackendResourceReuseStats` asserted by tests.

## Affected / deliberately unaffected

- Affected: the storage-buffer resource path of `render_draws_rgba` only (hash economics + upload count for large repeat references).
- Unaffected: rendering output (uploads carry identical bytes; the large-buffer test asserts byte-identical frames), texture bindings, pipeline/layout caches, capture formats, small-buffer dedup and its arena accounting (pool-delta tests unchanged).

## Risks

- Scope note (from review): the "zero cross-pointer merge hits" measurement is Blue Prince-only. A capture/bundle replay with duplicated large buffers at distinct host pointers would upload once per pointer per call instead of merging — bounded, transient, and correctness-neutral (the bundle store is content-deduplicated into shared chunks, so the common replay case memo-hits anyway).

- A workload that genuinely repeats identical content at *different* pointers in buffers > 4 KiB within one call would now upload per pointer instead of merging. Live BP data shows this never occurs; the cost would be extra arena bytes, not wrong rendering.
- The memo intentionally makes first-reference-wins explicit for racing guest writes mid-submit (hardware-equivalent nondeterminism, documented in the code).

## Verification (exact head)

- ctest: **141/141** (includes new `test_multidraw_render` assertions: memo resolves repeat view references without re-hashing; owned-vector copies keep full hash+memcmp dedup; the 4 KiB bound is visually inert and skips hashing — each fails without its half of the change).
- `PROSPER_GAME_ROOT=… python3 tools/snapshot/snapshot.py check` — **all five routes OK, exit 0** (messenger-scene 29/29 qualifying, evergate-title 9/9, dead-cells-gameplay 44/44, blasphemous2-gameplay 98/98, terminator-boot 19 qualifying / 24 nonblack — all structural matches green).
- Blue Prince A/B on the #1264 route (RADV, 3 s shots), same route three ways:
  - post-#1266 baseline (run6): crawl phase ~1.9 fps
  - memo only (hs1): ~2.6 fps, hashed 52.9 GiB/150 s (~1.8 GiB/s), memo_hits 78%
  - memo + size bound (hs2): hashed volume **52.9 GiB → 0.56 GiB (95x)**; references processed in the same 150 s window **2.5M → 14.0M (5.6x draw throughput)**; memo resolves 81% of references, 1.36M large references skip hashing; screenshot staleness **3.1 s max → 0.0 s** with 49/49 source-distinct shots; the intro cinematic (will-reading scene with subtitle text) renders continuously instead of the former slideshow. (Frame-counter absolutes vary between runs per the #1178 boot intermittency; the throughput/staleness metrics are the stable comparison.)
