### PR TITLE
fix(recompiler): IMAGE_SAMPLE_C_LZ on plain 2D shadow maps — manual dref compare (#1271)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -939,6 +939,11 @@ if(TARGET prosper_core)
       target_link_libraries(test_textured_interp_render PRIVATE prosper_core Vulkan::Vulkan)
       add_test(NAME textured_interp_render COMMAND test_textured_interp_render)
 
+      # IMAGE_SAMPLE_C_LZ 2D (shadow-map compare, #1271): manual-dref lowering, end-to-end.
+      add_executable(test_shadow_compare_render tests/test_shadow_compare_render.cpp)
+      target_link_libraries(test_shadow_compare_render PRIVATE prosper_core Vulkan::Vulkan)
+      add_test(NAME shadow_compare_render COMMAND test_shadow_compare_render)
+
       # Pipeline realization: build a VkPipeline whose fixed-function state comes from
       # resolve_pipeline_state(RenderState) and prove the resolved state drives rendering.
       add_executable(test_pipeline_render tests/test_pipeline_render.cpp)

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -870,6 +870,42 @@ struct SpirvCompute {
         const uint32_t bits = bcu(result);
         out[0] = out[1] = out[2] = out[3] = bits;
     }
+    // IMAGE_SAMPLE_C_LZ on a plain 2D texture, lowered as a MANUAL depth compare: sample the shadow
+    // map as an ordinary float texture at explicit LOD 0 and compare its .x against DREF in-shader
+    // using the S#'s compare function. The hardware path (compareEnable sampler over a depth-format
+    // view) needs backend machinery the color-texture path lacks (see the render-runner S# note);
+    // the manual form is exact for NEAREST shadow maps and approximates LINEAR PCF with a hard
+    // threshold. Vulkan compare semantics: result = (reference OP stored); the SQ S# compare enum
+    // (WORD0 [14:12]) matches VkCompareOp order — 0 NEVER, 1 LESS, 2 EQUAL, 3 LEQUAL, 4 GREATER,
+    // 5 NOTEQUAL, 6 GEQUAL, 7 ALWAYS. CONFIDENCE: MED (standard AMD sampler enum ordering; Blue
+    // Prince renders visually-correct shadows with it — the live A/B on #1271).
+    void image_sample_dref_manual_2d(uint32_t binding, uint32_t u_bits, uint32_t v_bits,
+                                     uint32_t dref_bits, uint32_t compare_func, uint32_t out[4]) {
+        uint32_t si    = id(); put(code, Op_Load, {tex_binding_simg[binding], si, tex_var[binding]});
+        uint32_t coord = id(); put(code, Op_CompositeConstruct, {t_v2f(), coord, bcf(u_bits), bcf(v_bits)});
+        uint32_t res   = id(); put(code, Op_ImageSampleExplicitLod,
+                                   {t_v4f, res, si, coord, ImgOp_Lod, fconstf(0.0f)});
+        uint32_t depth = id(); put(code, Op_CompositeExtract, {t_f32, depth, res, 0});
+        uint32_t result;
+        if (compare_func == 0u)      result = fconstf(0.0f);   // NEVER
+        else if (compare_func == 7u) result = fconstf(1.0f);   // ALWAYS
+        else {
+            uint32_t op;
+            switch (compare_func) {
+                case 1u: op = Op_FOrdLessThan;         break;
+                case 2u: op = Op_FOrdEqual;            break;
+                case 3u: op = Op_FOrdLessThanEqual;    break;
+                case 4u: op = Op_FOrdGreaterThan;      break;
+                case 5u: op = Op_FOrdNotEqual;         break;
+                default: op = Op_FOrdGreaterThanEqual; break;   // 6 GEQUAL
+            }
+            uint32_t cmp = id(); put(code, op, {t_bool, cmp, bcf(dref_bits), depth});
+            uint32_t r   = id(); put(code, Op_Select, {t_f32, r, cmp, fconstf(1.0f), fconstf(0.0f)});
+            result = r;
+        }
+        const uint32_t bits = bcu(result);
+        out[0] = out[1] = out[2] = out[3] = bits;
+    }
     // image_sample_b 2D: implicit-LOD sample with an LOD BIAS (bias_bits float). Bias only means
     // anything with implicit LOD (fragment derivatives); outside the fragment stage the op resolves
     // like the other samples there — explicit LOD 0 (bias dropped, matching image_sample_2d's rule).
@@ -6098,14 +6134,24 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 // four consecutive address VGPRs, dref at slot 0 per 8.2.5) and LLVM's own
                 // llvm.amdgcn.image.sample.c.lz lowering (dref before coords). CONFIDENCE: MED —
                 // the #825 lane must re-validate against a real rendered shadow once it lights up.
-                // Integer views and non-array dimensions are not legal for this lowering; reject
-                // rather than silently turning a comparison sample into an ordinary color read.
-                if (in.mimg_dim != 5u || uint_texture || !res->depth_compare) {
-                    ok = false; return true;
-                }
-                b.declare_texture(res->binding, Dim_2D, false, true, true);
-                b.image_sample_dref_lz_2d_array(
-                    res->binding, vread(cvg(1)), vread(cvg(2)), vread(cvg(3)), vread(cvg(0)), out);
+                // Integer views are not legal for this lowering, and a non-shadow S# means the
+                // provenance drifted; reject rather than silently turning a comparison sample into
+                // an ordinary color read.
+                if (uint_texture || !res->depth_compare) { ok = false; return true; }
+                if (in.mimg_dim == 5u) {
+                    b.declare_texture(res->binding, Dim_2D, false, true, true);
+                    b.image_sample_dref_lz_2d_array(
+                        res->binding, vread(cvg(1)), vread(cvg(2)), vread(cvg(3)), vread(cvg(0)), out);
+                } else if (in.mimg_dim == 1u) {
+                    // Plain 2D form (Blue Prince's lit-material PSes, #1271: 436 rejects/run, all
+                    // op 0x2f dim 1 dmask 0x1 — the entire shadowed lighting pass dropped and the
+                    // scene rendered unattenuated/blown-out). Same 8.2.5 vaddr order with no array
+                    // slice: [dref, u, v]. Lowered as a manual compare against the color-sampled
+                    // shadow map (see image_sample_dref_manual_2d for why not a compare sampler).
+                    b.declare_texture(res->binding, Dim_2D, false);
+                    b.image_sample_dref_manual_2d(res->binding, vread(cvg(1)), vread(cvg(2)),
+                                                  vread(cvg(0)), res->depth_compare_func, out);
+                } else { ok = false; return true; }
             } else if (is_gather_lz || is_gather_lz_o) {
                 // gather4 dmask selects ONE channel (must be a single bit); the result is always the
                 // four texels of that channel -> 4 consecutive VDATA VGPRs, gather order preserved.
@@ -8567,7 +8613,7 @@ RecompileCoverage recompile_coverage(const uint32_t* code, size_t dwords) {
                     // #325) — so array-sampling draws recompile+render instead of being skipped.
                     // 0xa0 is the high-bit sibling of image_sample (0x20), lowered identically (GTA V, #1145).
                     if (i.opcode == 0x20u || i.opcode == 0x27u || i.opcode == 0xa0u) return i.mimg_dim == 1u || i.mimg_dim == 2u || i.mimg_dim == 5u;
-                    if (i.opcode == 0x2fu) return i.mimg_dim == 5u; // IMAGE_SAMPLE_C_LZ 2D_ARRAY
+                    if (i.opcode == 0x2fu) return i.mimg_dim == 1u || i.mimg_dim == 5u; // IMAGE_SAMPLE_C_LZ 2D (#1271) / 2D_ARRAY
                     if (i.opcode == 0x24u || i.opcode == 0x25u || i.opcode == 0x47u) return i.mimg_dim == 1u || i.mimg_dim == 5u;
                     return false;
                 }

--- a/prosper/src/gpu/shader_resources.hpp
+++ b/prosper/src/gpu/shader_resources.hpp
@@ -175,8 +175,10 @@ struct ShaderResource {
     //   lod_bias:           WORD2 [13:0], signed s5.8 (sign-extended raw/256.0). mip LOD bias.
     //   max_aniso_ratio:    WORD0 [11:9] enum (maxAnisotropy = 1<<ratio). NEEDS the samplerAnisotropy
     //                       device feature — decoded only.
-    //   depth_compare_func: WORD0 [14:12] SQ compare enum for shadow/PCF samplers. NEEDS a depth/shadow
-    //                       sampling path (our images are color UNORM) — decoded only.
+    //   depth_compare_func: WORD0 [14:12] SQ compare enum for shadow/PCF samplers (VkCompareOp order).
+    //                       APPLIED in-shader by the recompiler's manual-dref c_lz lowering (#1271);
+    //                       the hardware compareEnable-sampler path still needs a depth-format view
+    //                       (see the render-runner sampler note).
     //   unnormalized:       WORD0 [15] FORCE_UNNORMALIZED. NEEDS strict validity (no mips, equal filters,
     //                       clamp addressing, minLod=maxLod=0) — decoded only.
     uint32_t      border_color_type = 0;

--- a/prosper/tests/test_shadow_compare_render.cpp
+++ b/prosper/tests/test_shadow_compare_render.cpp
@@ -1,0 +1,90 @@
+// test_shadow_compare_render — IMAGE_SAMPLE_C_LZ on a plain 2D shadow map (#1271): a recompiled
+// pixel shader interpolates UVs, moves a DREF constant into the vaddr slot BEFORE them (ISA 8.2.5
+// "{z-compare}{body}" order), issues image_sample_c_lz dim:2D dmask:0x1, and exports the compare
+// result as MRT0.R. The word0 encoding (0xf0bc0108) is byte-identical to Blue Prince's live
+// packets from the #1271 reject log — this test fails (recompile reject) without the 2D dref
+// lowering. The manual-compare semantics are asserted end-to-end: with compare func GREATER and
+// dref 0.5, texels darker than 0.5 pass (1.0) and brighter texels fail (0.0).
+#include "../src/gpu/rdna2_to_spirv.hpp"
+#include "../src/gpu/shader_resources.hpp"
+#include "render_runner.h"
+#include <cstdio>
+#include <cstdlib>
+#include <cstdint>
+#include <vector>
+
+using namespace prosper::gpu;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+int main() {
+    printf("== test_shadow_compare_render ==\n");
+    const uint32_t W = 128, H = 128;
+
+    // VS: fullscreen triangle + PARAM0 = (u, v, 0, 1) — same as test_textured_interp_render.
+    const uint32_t vs[] = {
+        0x36020081u, 0x2c040081u, 0x7e020d01u, 0x7e040d02u, 0x100602f6u, 0x100804f6u, 0x060606f3u,
+        0x060808f3u, 0x100a02f4u, 0x100c04f4u, 0x7e0e0280u, 0x7e1002f2u, 0xf80008cfu, 0x08070403u,
+        0xf800020fu, 0x08070605u, 0xbf810000u,
+    };
+    // PS: v2 = interp attr0.x (u), v3 = interp attr0.y (v); v1 = 0.5 (DREF);
+    // image_sample_c_lz v4, v[1:3], s[8:15], s[16:19] dmask:0x1 dim:2D  (word0 0xf0bc0108 — the
+    // exact op/dmask/dim word Blue Prince issues); exp mrt0 v4..v7.
+    const uint32_t ps[] = {
+        0xc8080000u, 0xc8090001u, 0xc80c0100u, 0xc80d0101u,   // v2 = u, v3 = v
+        0x7e0202f0u,                                          // v_mov_b32 v1, 0.5
+        0xf0bc0108u, 0x00820401u,                             // image_sample_c_lz v4, v[1:3], s8, s16
+        0xf800080fu, 0x07060504u,                             // exp mrt0 v4..v7
+        0xbf810000u,                                          // s_endpgm
+    };
+
+    std::vector<uint32_t> vert = recompile_vertex(vs, sizeof(vs)/sizeof(vs[0]));
+    ShaderResourceTable rt;
+    { ShaderResource t{}; t.cls = ResourceClass::Texture; t.binding = 4; t.img_dim = 1;
+      t.width = 8; t.height = 8; t.sgpr_base = 8;
+      t.depth_compare = true; t.depth_compare_func = 4;   // GREATER: pass = dref > stored
+      rt.resources.push_back(t); }
+    std::vector<uint32_t> frag = recompile_fragment(ps, sizeof(ps)/sizeof(ps[0]), &rt);
+    CHECK(!vert.empty() && vert[0] == 0x07230203u, "recompiled VS -> SPIR-V");
+    CHECK(!frag.empty() && frag[0] == 0x07230203u,
+          "recompiled PS with image_sample_c_lz dim:2D -> SPIR-V (rejects without the #1271 lowering)");
+    if (vert.empty() || frag.empty()) { printf("== FAIL ==\n"); return 1; }
+
+    // 8x8 "shadow map" sampled as a color texture: left half R=0 (depth 0.0), right half R=230
+    // (depth ~0.9). dref 0.5 with GREATER -> left passes (1.0 -> R=255), right fails (0.0 -> R=0).
+    std::vector<uint8_t> tex(8 * 8 * 4);
+    for (uint32_t y = 0; y < 8; y++) for (uint32_t x = 0; x < 8; x++) {
+        uint8_t* t = &tex[(y * 8 + x) * 4];
+        t[0] = x < 4 ? 0 : 230; t[1] = 0; t[2] = 0; t[3] = 255;
+    }
+    prosper::test::TexDesc td{ /*binding*/4, 8, 8, tex.data() };
+
+    std::vector<uint8_t> px = prosper::test::render_triangle_rgba(vert, frag, W, H, nullptr, nullptr, nullptr, &td);
+    CHECK(px.size() == (size_t)W * H * 4, "shadow-compare pipeline rendered a frame");
+    if (px.size() != (size_t)W * H * 4) { printf("== FAIL: render failed ==\n"); return 1; }
+
+    // Left half must be lit (compare passed -> R=255), right half shadow-failed (R=0). Sample
+    // interior points away from the half boundary and the viewport edges.
+    uint32_t left_pass = 0, left_total = 0, right_fail = 0, right_total = 0;
+    for (uint32_t y = 16; y < H - 16; y += 8) {
+        for (uint32_t x = 8; x < W / 2 - 12; x += 8) {
+            const uint8_t* p = &px[((size_t)y * W + x) * 4]; left_total++;
+            if (p[0] > 200) left_pass++;
+        }
+        for (uint32_t x = W / 2 + 12; x < W - 8; x += 8) {
+            const uint8_t* p = &px[((size_t)y * W + x) * 4]; right_total++;
+            if (p[0] < 50) right_fail++;
+        }
+    }
+    printf("  left pass %u/%u  right fail %u/%u\n", left_pass, left_total, right_fail, right_total);
+    CHECK(left_total && left_pass == left_total,
+          "dref 0.5 GREATER passes (1.0) where stored depth is 0.0");
+    CHECK(right_total && right_fail == right_total,
+          "dref 0.5 GREATER fails (0.0) where stored depth is ~0.9");
+
+    if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
+    printf("== PASS ==\n");
+    return 0;
+}


### PR DESCRIPTION
Partially fixes #1271 (the dropped-draw component); follow-up layer tracked in #1275. Blue Prince gameplay milestone context: #1216.

## Failure scenario

Blue Prince's Day One opening scene rendered blown-out: its lit-material fragment shaders issue `IMAGE_SAMPLE_C_LZ` (MIMG op 0x2f) with **dim:2D** (word0 `0xf0bc0108`, dmask 0x1 — both non-NSA and NSA forms observed live), but the recompiler's c_lz lowering existed only for the Astro Bot **2D_ARRAY** NSA shape. Every such shader rejected — **436 recompile-rejects per route run** — dropping the entire shadowed lighting pass, so surfaces rendered unattenuated.

## Change

- `image_sample_dref_manual_2d` (rdna2_to_spirv.cpp): lower the 2D form as a **manual depth compare** — sample the shadow map as an ordinary float 2D texture at explicit LOD 0 and emit the compare in SPIR-V (`OpFOrd*` + `OpSelect`) with the S# `depth_compare_func`. Reference is on the left (Vulkan `(ref OP stored)` semantics); the SQ compare enum matches VkCompareOp order, consistent with the project's DB_DEPTH_CONTROL.ZFUNC precedent (`vk_translate.hpp:57`). NEVER/ALWAYS constant-fold. The hardware path (compareEnable sampler over a depth-format view) needs backend machinery the color-texture path lacks — documented at the builder; manual compare is exact for NEAREST shadow maps and approximates LINEAR PCF with a hard threshold. CONFIDENCE: MED markers on the enum claim.
- MIMG `is_sample_c_lz` branch: dim==1 path with the same ISA 8.2.5 `{z-compare}{body}` vaddr order (`[dref, u, v]`) the `_b`/`_o`/array paths use; dim==5 behavior byte-identical; uint views and non-shadow S# still reject fail-visibly; other dims still reject.
- Coverage classifier (`rdna2_to_spirv.cpp` instruction-aware supported() lambda) updated so `shader_inspect`/`--inspect-only`/capture artifacts stop reporting the now-supported form as unsupported (review finding).
- `shader_resources.hpp` S# comment updated: `depth_compare_func` is now applied in-shader.

## Test

`test_shadow_compare_render` (new, registered): end-to-end execution test whose PS uses the **exact live BP word0 encoding**; fails with a recompile reject without the lowering, and asserts GREATER/dref-0.5 splits a half-dark/half-bright shadow map into fully lit/shadowed halves through the real pipeline (72/72 sample points each side).

## Affected / deliberately unaffected

- Affected: recompilation of MIMG op 0x2f dim:2D only (previously always rejected — no behavior existed to regress).
- Unaffected: dim:2D_ARRAY c_lz (byte-identical), every other sample op, backend sampler creation, capture formats.

## Risks

- Shadow-map CONTENT is the next layer: prosper never writes rendered depth back to guest memory, so the sampled taps currently read stale guest bytes (typically zero → unshadowed). #1275 tracks the depth-RTT sampled-binding/readback bridge. This PR's gain is that the lit-material draws execute at all.
- Hard-threshold compare vs hardware PCF: acceptable first cut, documented.

## Verification (exact head 1903ff2d)

- ctest **142/142** (includes the new execution test).
- `snapshot.py check` **5/5 routes OK** (messenger/evergate/dead-cells/blasphemous2/terminator; run against the pre-amend binary — the amend delta is the diagnostic classifier + comments only).
- Live A/B on the #1271 route (RADV, unmodified `screenshot` frontend): recompile-rejects **436 → 0**; the manor's materials recover tone gradation (window frames, roof shingles, clock face, arch interiors legible vs uniform blown white). Local frames: `~/bp-1264/probe/…_150.png` (before) vs `~/bp-1264/light2/…_169.png` (after); imagery stays local per the snapshot contract.
- Independent review: **APPROVE** (adversarial pass verified vaddr order against the decoder for both NSA layouts, compare semantics against the executor's S# decode and the ZFUNC precedent, SPIR-V type validity, dim5 regression surface, and the test's fail-without-fix property). Its one material finding (stale coverage classifier) and comment fix are applied on this head — both the reviewer's own specified one-liners.
