### PR TITLE
fix(recompiler): accept IMAGE_SAMPLE_C_LZ on 2D non-array depth textures (#1274)

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -870,6 +870,20 @@ struct SpirvCompute {
         const uint32_t bits = bcu(result);
         out[0] = out[1] = out[2] = out[3] = bits;
     }
+    // IMAGE_SAMPLE_C_LZ on a plain 2D (non-array) depth texture (#1274 — Bendy's world shadow pass,
+    // dim=1). Identical to the 2D-array form but the coordinate is (u,v) with no layer; the scalar
+    // depth-comparison result is broadcast to the requested dmask component like the array path.
+    void image_sample_dref_lz_2d(uint32_t binding, uint32_t u_bits, uint32_t v_bits,
+                                 uint32_t dref_bits, uint32_t out[4]) {
+        uint32_t si = id(); put(code, Op_Load, {tex_binding_simg[binding], si, tex_var[binding]});
+        uint32_t coord = id();
+        put(code, Op_CompositeConstruct, {t_v2f(), coord, bcf(u_bits), bcf(v_bits)});
+        uint32_t result = id();
+        put(code, Op_ImageSampleDrefExplicitLod,
+            {t_f32, result, si, coord, bcf(dref_bits), ImgOp_Lod, fconstf(0.0f)});
+        const uint32_t bits = bcu(result);
+        out[0] = out[1] = out[2] = out[3] = bits;
+    }
     // image_sample_b 2D: implicit-LOD sample with an LOD BIAS (bias_bits float). Bias only means
     // anything with implicit LOD (fragment derivatives); outside the fragment stage the op resolves
     // like the other samples there — explicit LOD 0 (bias dropped, matching image_sample_2d's rule).
@@ -6098,14 +6112,22 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 // four consecutive address VGPRs, dref at slot 0 per 8.2.5) and LLVM's own
                 // llvm.amdgcn.image.sample.c.lz lowering (dref before coords). CONFIDENCE: MED —
                 // the #825 lane must re-validate against a real rendered shadow once it lights up.
-                // Integer views and non-array dimensions are not legal for this lowering; reject
-                // rather than silently turning a comparison sample into an ordinary color read.
-                if (in.mimg_dim != 5u || uint_texture || !res->depth_compare) {
+                // Integer views are never legal for a comparison sample, and the descriptor must be a
+                // depth-compare sampler; reject rather than silently turning a comparison into an
+                // ordinary color read. Both 2D (dim=1, vaddr [dref,u,v]) and 2D_ARRAY (dim=5, vaddr
+                // [dref,u,v,slice]) are handled — same modifier-first order, the array form adds the
+                // trailing slice coordinate (#1274 adds the non-array 2D case for Bendy's shadow pass).
+                if ((in.mimg_dim != 1u && in.mimg_dim != 5u) || uint_texture || !res->depth_compare) {
                     ok = false; return true;
                 }
-                b.declare_texture(res->binding, Dim_2D, false, true, true);
-                b.image_sample_dref_lz_2d_array(
-                    res->binding, vread(cvg(1)), vread(cvg(2)), vread(cvg(3)), vread(cvg(0)), out);
+                const bool c_lz_arrayed = (in.mimg_dim == 5u);
+                b.declare_texture(res->binding, Dim_2D, false, c_lz_arrayed, true);
+                if (c_lz_arrayed)
+                    b.image_sample_dref_lz_2d_array(
+                        res->binding, vread(cvg(1)), vread(cvg(2)), vread(cvg(3)), vread(cvg(0)), out);
+                else
+                    b.image_sample_dref_lz_2d(
+                        res->binding, vread(cvg(1)), vread(cvg(2)), vread(cvg(0)), out);
             } else if (is_gather_lz || is_gather_lz_o) {
                 // gather4 dmask selects ONE channel (must be a single bit); the result is always the
                 // four texels of that channel -> 4 consecutive VDATA VGPRs, gather order preserved.

--- a/prosper/tests/test_recompiled_fragment.cpp
+++ b/prosper/tests/test_recompiled_fragment.cpp
@@ -177,6 +177,43 @@ int main() {
               "GDS consume subtracts one covered-fragment allocation across all waves");
     }
 
+    // #1274 — IMAGE_SAMPLE_C_LZ on a plain 2D (non-array) depth texture. Bendy and the Ink Machine's
+    // world shadow pass issues op 0x2f with mimg_dim=1 (2D; vaddr [dref,u,v]). The recompiler previously
+    // accepted only the 2D_ARRAY (dim=5) comparison form and rejected the non-array case, dropping every
+    // shadowed draw. Recompile a minimal fragment that samples a depth-compare 2D texture and assert it
+    // lowers to a valid SPIR-V module. Without the fix the reject path returns an empty vector.
+    //   image_sample_c_lz v[0:3], v[0:2], s[8:15], s[16:19]  (op 0x2f, dim=1, SRSRC=s[8:15]).
+    const uint32_t clz2d_ps[] = {
+        0x7E0002FFu, 0x3E800000u,   // v_mov_b32 v0, 0.25  (dref)
+        0x7E0202FFu, 0x3E800000u,   // v_mov_b32 v1, 0.25  (u)
+        0x7E0402FFu, 0x3E800000u,   // v_mov_b32 v2, 0.25  (v)
+        0xF0BC0F08u, 0x00820000u,   // image_sample_c_lz v[0:3], v[0:2], s[8:15], s[16:19]
+        0xF800180Fu, 0x00000000u,   // exp mrt0 v0,v0,v0,v0  (keep sampled v0 live through export)
+        0xBF810000u,                // s_endpgm
+    };
+    ShaderResourceTable clz2d_rt;
+    ShaderResource clz2d_tex{};
+    clz2d_tex.cls = ResourceClass::Texture;
+    clz2d_tex.binding = 5; clz2d_tex.img_dim = 1;
+    clz2d_tex.width = 4; clz2d_tex.height = 4;
+    clz2d_tex.sgpr_base = 8;
+    clz2d_tex.depth_compare = true;    // shadow/PCF comparison sampler
+    clz2d_rt.resources.push_back(clz2d_tex);
+    std::vector<uint32_t> clz2d_frag = recompile_fragment(clz2d_ps, std::size(clz2d_ps), &clz2d_rt);
+    CHECK(!clz2d_frag.empty() && clz2d_frag[0] == 0x07230203u,
+          "#1274: IMAGE_SAMPLE_C_LZ on a 2D (non-array) depth texture recompiles to SPIR-V");
+
+    // The reject fence stays intact: the same instruction against a non-depth-compare descriptor must
+    // still fail-visible rather than silently turn a comparison sample into an ordinary color read.
+    ShaderResourceTable clz2d_nodc_rt;
+    ShaderResource clz2d_nodc_tex = clz2d_tex;
+    clz2d_nodc_tex.depth_compare = false;
+    clz2d_nodc_rt.resources.push_back(clz2d_nodc_tex);
+    std::vector<uint32_t> clz2d_nodc_frag =
+        recompile_fragment(clz2d_ps, std::size(clz2d_ps), &clz2d_nodc_rt);
+    CHECK(clz2d_nodc_frag.empty(),
+          "#1274: IMAGE_SAMPLE_C_LZ on a non-depth-compare 2D texture still rejects fail-visible");
+
     // Astro Bot's early foreground pass exports only R/G (EN=0x3). AMD's EXP contract preserves
     // disabled destination components; the live executor therefore intersects EN with the Vulkan
     // pipeline write mask. Prove both the exact rejected shader now recompiles and a partial draw


### PR DESCRIPTION
## Issue
Fixes #1274.

## Failure scenario
The RDNA2→SPIR-V recompiler's depth-compare LZ sample lowering (`IMAGE_SAMPLE_C_LZ`, MIMG op `0x2f`) only accepted `mimg_dim == 5` (2D_ARRAY). For `mimg_dim == 1` (plain 2D, no array layer) it hit the reject guard and set `ok = false`, so `recompile_fragment` returned an empty module and **the entire fragment shader failed to recompile** — every draw using it was dropped.

*Bendy and the Ink Machine* (PPSA27616) issues its world shadow-map sample as op `0x2f` with `dim = 1` (vaddr `[dref, u, v]`, no slice). A live boot logs **8** `[recompile-reject] … op=0x2f` lines; with this change they go to **0** and no new `spirv-val` failures appear.

## Behavioral contract
`IMAGE_SAMPLE_C_LZ` is a depth-comparison sample at LOD 0 (shadow maps / PCF). Both the 2D and 2D_ARRAY forms share the same modifier-first vaddr order — dref at slot 0, then coordinates; the array form adds a trailing slice coordinate. The lowering emits `OpImageSampleDrefExplicitLod` at LOD 0 and broadcasts the scalar comparison result to the requested components.

## Approach
- Add `image_sample_dref_lz_2d` — identical to the existing `image_sample_dref_lz_2d_array` helper but building a `vec2(u,v)` coordinate with no layer.
- Widen the guard from `mimg_dim != 5` to `mimg_dim != 1 && mimg_dim != 5`, and route `dim=1` to the new helper, `dim=5` to the array helper. The declared image view is non-arrayed for `dim=1`, arrayed for `dim=5`.
- The guard still rejects integer views and non-`depth_compare` descriptors, so an ordinary color read can never be silently lowered as a comparison sample (fail-visible backstop preserved).

## Affected / unaffected behavior
- **Affected:** shaders that sample a 2D (non-array) depth-compare texture with `IMAGE_SAMPLE_C_LZ` now recompile instead of being dropped.
- **Unaffected:** the 2D_ARRAY (`dim=5`) path is byte-for-byte unchanged (same helper, same declared arrayed view). Non-depth-compare and integer-view descriptors still reject.

## Tests
Round-trip unit test added to `test_recompiled_fragment`:
- A minimal fragment sampling a `depth_compare` 2D texture (`op 0x2f, dim=1, SRSRC=s[8:15]`) now recompiles to a valid SPIR-V module (magic `0x07230203`). **Would-fail-without-fix confirmed**: reverting the guard to `dim==5`-only makes this assertion fail and the test binary exit non-zero.
- The same instruction against a non-`depth_compare` descriptor still rejects (empty module), proving the fail-visible fence stays intact.

## Risk
Low. Additive dim case on an isolated lowering; the array path is untouched. The pre-existing `CONFIDENCE: MED` note on this lowering (visual re-validation of a real rendered shadow still pending) applies equally to the 2D extension — this PR removes the recompile-drop, not the eventual shadow-appearance validation.

## Verification
- `cmake --build prosper/build-linux -j` — clean.
- `ctest` — **140/140 passed** (worktree `.claude/worktrees/gpu-gaps`, host RADV STRIX_HALO).
- Would-fail-without-fix proven by reverting the guard (test exits 1).
- 5-title snapshot regression guard (`snapshot.py check`) — running; results appended to the PR before merge.
- Live: Bendy boot `op=0x2f` recompile-rejects 8 → 0, no new spirv-val failures.