### PR TITLE
Unified-device GPU present: blit the renderer's front-buffer image to the swapchain (#1270)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -737,7 +737,8 @@ if(TARGET prosper_core)
       target_link_libraries(boot_trace PRIVATE Vulkan::Vulkan)
       target_compile_definitions(boot_trace PRIVATE PROSPER_HAVE_VULKAN=1)
       add_library(prosper_live_renderer STATIC frontends/shared/live_renderer.cpp
-                                               frontends/shared/live_compute.cpp)
+                                               frontends/shared/live_compute.cpp
+                                               frontends/shared/present_blit.cpp)
       target_include_directories(prosper_live_renderer PRIVATE src tests tools/boot_trace)
       target_link_libraries(prosper_live_renderer PUBLIC prosper_core Vulkan::Vulkan)
       target_include_directories(prosper_live_renderer PUBLIC frontends/shared)
@@ -840,7 +841,8 @@ if(TARGET prosper_core)
       # boot_trace so BOTH boot_trace and prosper-app register the SAME renderer instead of
       # duplicating it. Needs render_runner.h (tests/) and refvs.inc (tools/boot_trace/).
       add_library(prosper_live_renderer STATIC frontends/shared/live_renderer.cpp
-                                               frontends/shared/live_compute.cpp)
+                                               frontends/shared/live_compute.cpp
+                                               frontends/shared/present_blit.cpp)
       target_include_directories(prosper_live_renderer PRIVATE src tests tools/boot_trace)
       target_link_libraries(prosper_live_renderer PUBLIC prosper_core Vulkan::Vulkan)
       target_include_directories(prosper_live_renderer PUBLIC frontends/shared)
@@ -1257,4 +1259,11 @@ if(TARGET prosper_live_renderer AND TARGET prosper_core)
   add_executable(test_shared_vulkan_device tests/test_shared_vulkan_device.cpp)
   target_link_libraries(test_shared_vulkan_device PRIVATE prosper_live_renderer prosper_core)
   add_test(NAME shared_vulkan_device COMMAND test_shared_vulkan_device)
+
+  # GPU scanout handoff (#1270): the front-buffer image blits into a scanout slot byte-exactly, and the
+  # producer/consumer slot handoff never tears or reuses an image in flight. Headless (no surface).
+  add_executable(test_present_blit tests/test_present_blit.cpp)
+  target_include_directories(test_present_blit PRIVATE src tests)
+  target_link_libraries(test_present_blit PRIVATE prosper_live_renderer prosper_core Vulkan::Vulkan)
+  add_test(NAME present_blit COMMAND test_present_blit)
 endif()

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -14,6 +14,8 @@
 // Two Vulkan contexts by design (docs/FRONTEND_APP.md): the core keeps its headless render device;
 // THIS is a separate presentation device, and frames cross as shared immutable CPU pixels.
 #include "gpu/videoout_present.hpp"   // present_acquire_rendered_frame / present_write_frame
+#include "gpu/gpu_execute.hpp"         // shared_vulkan_context / gpu-present activation (#1270)
+#include "present_blit.hpp"           // GPU scanout handoff: acquire/release the renderer's front image
 #include "host/lifecycle.hpp"          // prosper_request_stop / prosper_stop_requested
 #include "host/boot_program.hpp"       // boot_program (shared guest-boot path, also used by boot_trace)
 #include "host/exec_image.hpp"         // run_entry
@@ -57,6 +59,7 @@
 #include <cmath>
 #include <chrono>
 #include <thread>
+#include <mutex>
 
 using namespace prosper;
 
@@ -101,6 +104,12 @@ struct Vk {
     VkCommandBuffer cmd     = VK_NULL_HANDLE;
     VkSemaphore     acquireSem = VK_NULL_HANDLE, presentSem = VK_NULL_HANDLE;
     VkFence         inFlight   = VK_NULL_HANDLE;
+
+    // Present unification (#1270): set when the app adopted the renderer's shared device and presents by
+    // GPU-blitting its front-buffer image (no CPU round-trip). queue_shared means the present queue aliases
+    // the render queue, so present submits serialize through gpu::shared_present_submit_mutex().
+    bool            gpu_present = false;
+    bool            queue_shared = false;
 };
 
 uint32_t find_mem(VkPhysicalDevice p, uint32_t typeBits, VkMemoryPropertyFlags props) {
@@ -338,6 +347,108 @@ prosper::frontend::PresentAttempt present_frame(Vk& vk, const uint8_t* rgba, uin
     pi.waitSemaphoreCount = 1; pi.pWaitSemaphores = &vk.presentSem;
     pi.swapchainCount = 1; pi.pSwapchains = &vk.swapchain; pi.pImageIndices = &imgIndex;
     VkResult pr = vkQueuePresentKHR(vk.queue, &pi);
+    return prosper::frontend::classify_present(pr);
+}
+
+// Present unification (#1270): try to present on the RENDERER's Vulkan device instead of a private one,
+// so the app can GPU-blit the renderer's front-buffer image straight to the swapchain (no 4K CPU
+// round-trip). Returns false at any unmet precondition, leaving the caller to create its own device (the
+// unchanged CPU path). Called only when PROSPER_APP_GPU_PRESENT is set and a game is booting.
+bool try_adopt_shared_present(Vk& vk, SDL_Window* win) {
+    const gpu::SharedVulkanContext ctx = gpu::shared_vulkan_context();
+    if (!ctx.valid() || !ctx.present_capable || !ctx.present_queue) {
+        fprintf(stderr, "[app] GPU present: shared device is not present-capable; using own device\n");
+        return false;
+    }
+    VkInstance inst = (VkInstance)ctx.instance;
+    VkSurfaceKHR surface = VK_NULL_HANDLE;
+    if (!SDL_Vulkan_CreateSurface(win, inst, nullptr, &surface)) {
+        // The shared instance was created before SDL_Init and enabled every AVAILABLE platform surface
+        // extension blind; if SDL needs one we did not get, fall back to a private device.
+        fprintf(stderr, "[app] GPU present: surface on shared instance failed (%s); using own device\n",
+                SDL_GetError());
+        return false;
+    }
+    VkPhysicalDevice phys = (VkPhysicalDevice)ctx.physical;
+    VkBool32 present = VK_FALSE;
+    vkGetPhysicalDeviceSurfaceSupportKHR(phys, ctx.queue_family, surface, &present);
+    if (!present) {
+        fprintf(stderr, "[app] GPU present: shared queue family cannot present here; using own device\n");
+        vkDestroySurfaceKHR(inst, surface, nullptr);
+        return false;
+    }
+    vk.instance = inst; vk.surface = surface; vk.phys = phys;
+    vk.device = (VkDevice)ctx.device; vk.qfamily = ctx.queue_family;
+    vk.queue = (VkQueue)ctx.present_queue;
+    vk.gpu_present = true;
+    vk.queue_shared = ctx.present_queue_shared;
+    // The renderer must now publish the front-buffer image (and skip the CPU readback); if the present
+    // queue aliases the render queue, both threads must serialize their submits.
+    gpu::set_gpu_present_active(true);
+    if (ctx.present_queue_shared) gpu::set_shared_present_active(true);
+    fprintf(stderr, "[app] GPU present: adopted the renderer's device (%s present queue)\n",
+            ctx.present_queue_shared ? "shared" : "dedicated");
+    return true;
+}
+
+// Present one GPU scanout frame (the renderer's front-buffer image, already in TRANSFER_SRC_OPTIMAL) by
+// blitting it straight to the swapchain -- no CPU pixels. `prevSlot` is the slot presented last frame; its
+// GPU read is complete once inFlight signals below, so it is released then. Updates prevSlot to the slot
+// now in flight and returns the acquire/present outcome.
+prosper::frontend::PresentAttempt present_frame_gpu(Vk& vk, const prosper::frontend::GpuScanoutFrame& gf,
+                                                    int& prevSlot) {
+    vkWaitForFences(vk.device, 1, &vk.inFlight, VK_TRUE, UINT64_MAX);   // previous present's read complete
+    if (prevSlot >= 0) { prosper::frontend::present_blit_release(prevSlot); prevSlot = -1; }
+
+    uint32_t imgIndex = 0;
+    constexpr uint64_t kAcquireTimeoutNs = 100ull * 1000 * 1000;
+    VkResult acq = vkAcquireNextImageKHR(vk.device, vk.swapchain, kAcquireTimeoutNs, vk.acquireSem,
+                                         VK_NULL_HANDLE, &imgIndex);
+    switch (prosper::frontend::classify_acquire(acq)) {
+    case prosper::frontend::AcquireAction::skip:
+        prosper::frontend::present_blit_release(gf.slot); return prosper::frontend::PresentAttempt::skipped;
+    case prosper::frontend::AcquireAction::recreate:
+        prosper::frontend::present_blit_release(gf.slot); return prosper::frontend::PresentAttempt::out_of_date;
+    case prosper::frontend::AcquireAction::proceed: break;
+    }
+    vkResetFences(vk.device, 1, &vk.inFlight);
+    vkResetCommandBuffer(vk.cmd, 0);
+    VkCommandBufferBeginInfo bi{VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO};
+    bi.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+    vkBeginCommandBuffer(vk.cmd, &bi);
+    // gf.image is already TRANSFER_SRC_OPTIMAL (left there by present_blit); swapchain image
+    // UNDEFINED -> TRANSFER_DST -> (scaled blit) -> PRESENT_SRC.
+    barrier(vk.cmd, vk.scImages[imgIndex], VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+            0, VK_ACCESS_TRANSFER_WRITE_BIT, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT);
+    VkImageBlit blit{};
+    blit.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    blit.srcOffsets[1] = {(int32_t)gf.width, (int32_t)gf.height, 1};
+    blit.dstSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    blit.dstOffsets[1] = {(int32_t)vk.scExtent.width, (int32_t)vk.scExtent.height, 1};
+    vkCmdBlitImage(vk.cmd, gf.image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                   vk.scImages[imgIndex], VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &blit, VK_FILTER_LINEAR);
+    barrier(vk.cmd, vk.scImages[imgIndex], VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+            VK_IMAGE_LAYOUT_PRESENT_SRC_KHR, VK_ACCESS_TRANSFER_WRITE_BIT, 0,
+            VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT);
+    vkEndCommandBuffer(vk.cmd);
+
+    VkPipelineStageFlags waitStage = VK_PIPELINE_STAGE_TRANSFER_BIT;
+    VkSubmitInfo su{VK_STRUCTURE_TYPE_SUBMIT_INFO};
+    su.waitSemaphoreCount = 1; su.pWaitSemaphores = &vk.acquireSem; su.pWaitDstStageMask = &waitStage;
+    su.commandBufferCount = 1; su.pCommandBuffers = &vk.cmd;
+    su.signalSemaphoreCount = 1; su.pSignalSemaphores = &vk.presentSem;
+    VkPresentInfoKHR pi{VK_STRUCTURE_TYPE_PRESENT_INFO_KHR};
+    pi.waitSemaphoreCount = 1; pi.pWaitSemaphores = &vk.presentSem;
+    pi.swapchainCount = 1; pi.pSwapchains = &vk.swapchain; pi.pImageIndices = &imgIndex;
+    VkResult pr;
+    {
+        // Serialize the present submit + present CALL against the renderer's submits on a shared queue.
+        std::unique_lock<std::mutex> lk(gpu::shared_present_submit_mutex(), std::defer_lock);
+        if (vk.queue_shared) lk.lock();
+        vkQueueSubmit(vk.queue, 1, &su, vk.inFlight);
+        pr = vkQueuePresentKHR(vk.queue, &pi);
+    }
+    prevSlot = gf.slot;
     return prosper::frontend::classify_present(pr);
 }
 
@@ -606,7 +717,13 @@ int main(int argc, char** argv) {
     if (!win) { fprintf(stderr, "[app] SDL_CreateWindow: %s\n", SDL_GetError()); return 1; }
 
     Vk vk;
-    if (!create_instance(vk, win) || !pick_device(vk)) return 1;
+    // Present unification (#1270, opt-in): prefer presenting on the renderer's shared device so we can
+    // GPU-blit its front-buffer image. Only for a real boot (the renderer produces front buffers); the
+    // test pattern and any adoption failure fall back to a private device + CPU pixels (unchanged path).
+    const bool wantGpuPresent = getenv("PROSPER_APP_GPU_PRESENT") != nullptr && !testPattern && !dump.empty();
+    if (!wantGpuPresent || !try_adopt_shared_present(vk, win)) {
+        if (!create_instance(vk, win) || !pick_device(vk)) return 1;
+    }
     // Initial swapchain sized to the window; recreated on resize / out-of-date.
     { int dw = 0, dh = 0; SDL_GetWindowSizeInPixels(win, &dw, &dh);
       if (!create_swapchain(vk, (uint32_t)dw, (uint32_t)dh, requestedPresentMode)) return 1; }
@@ -648,6 +765,7 @@ int main(int argc, char** argv) {
     auto lastFrameProgress = loopStarted;
     auto nextTimedDump = loopStarted + std::chrono::milliseconds(timedDumpMs);
     uint64_t shown = 0, lastFrameSeq = ~0ull, patFrame = 0;
+    int gpuPrevSlot = -1;   // #1270: the GPU scanout slot presented last frame (released after its read)
     unsigned timedDumpCount = 0;
     bool timedDumpPending = timedDumpMs > 0;
     bool running = true;
@@ -740,7 +858,17 @@ int main(int argc, char** argv) {
                 std::this_thread::sleep_for(std::chrono::milliseconds(2));
                 continue;   // minimized or between fullscreen modes; retry after the next event
             }
-            vkDeviceWaitIdle(vk.device);
+            {
+                // #1270: on a shared present queue, hold the submit mutex across the device drain so no
+                // guest submit races vkDeviceWaitIdle (which waits on all queues). Only the wait needs it;
+                // the swapchain destroy/create below do not touch the render queue.
+                std::unique_lock<std::mutex> lk(gpu::shared_present_submit_mutex(), std::defer_lock);
+                if (vk.gpu_present && vk.queue_shared) lk.lock();
+                vkDeviceWaitIdle(vk.device);
+            }
+            if (vk.gpu_present && gpuPrevSlot >= 0) {
+                prosper::frontend::present_blit_release(gpuPrevSlot); gpuPrevSlot = -1;
+            }
             if (vk.swapchain) vkDestroySwapchainKHR(vk.device, vk.swapchain, nullptr);
             vk.swapchain = VK_NULL_HANDLE;
             if (!create_swapchain(vk, static_cast<uint32_t>(dw), static_cast<uint32_t>(dh),
@@ -777,6 +905,31 @@ int main(int argc, char** argv) {
         // Render completion and guest flips are separate clocks: the command stream can flip before
         // the renderer publishes its CPU frame. Key this loop to the completed-frame sequence so a
         // late renderer publication is not missed or marked handled while only the previous frame exists.
+        if (vk.gpu_present) {
+            // GPU present (#1270): blit the renderer's front-buffer image straight to the swapchain.
+            prosper::frontend::GpuScanoutFrame gf;
+            if (prosper::frontend::present_blit_acquire(gf)) {
+                PresentAttempt attempt = present_frame_gpu(vk, gf, gpuPrevSlot);
+                if (attempt == PresentAttempt::out_of_date) {
+                    swapchainDirty = true;
+                } else if (attempt == PresentAttempt::skipped) {
+                    std::this_thread::sleep_for(std::chrono::milliseconds(4));
+                } else {
+                    shown++; lastFrameProgress = std::chrono::steady_clock::now();
+                    static auto t0 = std::chrono::steady_clock::now(); static uint64_t mark = 0;
+                    if (shown - mark >= 60) {
+                        auto now = std::chrono::steady_clock::now();
+                        double s = std::chrono::duration<double>(now - t0).count();
+                        fprintf(stderr, "[app] %.1f fps (%llu frames, gpu-present)\n",
+                                (shown - mark) / (s > 0 ? s : 1), (unsigned long long)shown);
+                        t0 = now; mark = shown;
+                    }
+                    if (exitAfter && (int)shown >= exitAfter) running = false;
+                }
+            } else {
+                std::this_thread::sleep_for(std::chrono::milliseconds(2));   // no new GPU frame yet
+            }
+        } else {
         bool newFrame = testPattern || (gpu::present_frame_seq() != lastFrameSeq);
         gpu::PresentFrameLease frame;
         if (newFrame && gpu::present_acquire_rendered_frame(frame)) {
@@ -829,6 +982,7 @@ int main(int argc, char** argv) {
         } else {
             std::this_thread::sleep_for(std::chrono::milliseconds(2));   // no new frame — don't spin
         }
+        }   // end CPU-present branch (#1270)
         if (stallDumpMs > 0 &&
             std::chrono::steady_clock::now() - lastFrameProgress >=
                 std::chrono::milliseconds(stallDumpMs)) {

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -341,12 +341,19 @@ prosper::frontend::PresentAttempt present_frame(Vk& vk, const uint8_t* rgba, uin
     su.waitSemaphoreCount = 1; su.pWaitSemaphores = &vk.acquireSem; su.pWaitDstStageMask = &waitStage;
     su.commandBufferCount = 1; su.pCommandBuffers = &vk.cmd;
     su.signalSemaphoreCount = 1; su.pSignalSemaphores = &vk.presentSem;
-    vkQueueSubmit(vk.queue, 1, &su, vk.inFlight);
 
     VkPresentInfoKHR pi{VK_STRUCTURE_TYPE_PRESENT_INFO_KHR};
     pi.waitSemaphoreCount = 1; pi.pWaitSemaphores = &vk.presentSem;
     pi.swapchainCount = 1; pi.pSwapchains = &vk.swapchain; pi.pImageIndices = &imgIndex;
-    VkResult pr = vkQueuePresentKHR(vk.queue, &pi);
+    VkResult pr;
+    {
+        // #1270: when this CPU present runs on the renderer's shared queue (the GPU-present miss fallback),
+        // serialize the submit + present CALLS against the renderer's submits. No-op on a private device.
+        std::unique_lock<std::mutex> lk(gpu::shared_present_submit_mutex(), std::defer_lock);
+        if (gpu::shared_present_active()) lk.lock();
+        vkQueueSubmit(vk.queue, 1, &su, vk.inFlight);
+        pr = vkQueuePresentKHR(vk.queue, &pi);
+    }
     return prosper::frontend::classify_present(pr);
 }
 
@@ -926,8 +933,24 @@ int main(int argc, char** argv) {
                     }
                     if (exitAfter && (int)shown >= exitAfter) running = false;
                 }
+            } else if (gpu::present_frame_seq() != lastFrameSeq) {
+                // #1270 Finding 2: no GPU frame was published this iteration. On a publish MISS (front
+                // target evicted/invalidated, or no free slot) the renderer still did the CPU readback, so
+                // present that CPU frame rather than stranding the window on a stale/black image. Also
+                // covers startup before the first publish. present_frame serializes on the shared queue.
+                gpu::PresentFrameLease cf;
+                if (gpu::present_acquire_rendered_frame(cf) && cf.width && cf.height && cf.rgba &&
+                    cf.rgba->size() == (size_t)cf.width * cf.height * 4) {
+                    PresentAttempt a = present_frame(vk, cf.rgba->data(), cf.width, cf.height);
+                    if (gpuPrevSlot >= 0) { prosper::frontend::present_blit_release(gpuPrevSlot); gpuPrevSlot = -1; }
+                    if (a == PresentAttempt::out_of_date) swapchainDirty = true;
+                    else if (a == PresentAttempt::skipped) std::this_thread::sleep_for(std::chrono::milliseconds(4));
+                    else { lastFrameSeq = cf.frame_seq; shown++; lastFrameProgress = std::chrono::steady_clock::now(); }
+                } else {
+                    std::this_thread::sleep_for(std::chrono::milliseconds(2));
+                }
             } else {
-                std::this_thread::sleep_for(std::chrono::milliseconds(2));   // no new GPU frame yet
+                std::this_thread::sleep_for(std::chrono::milliseconds(2));   // no new GPU or CPU frame yet
             }
         } else {
         bool newFrame = testPattern || (gpu::present_frame_seq() != lastFrameSeq);

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -2013,7 +2013,15 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         submit.commandBufferCount = 1;
         submit.pCommandBuffers = &command;
         if (trace) std::fprintf(stderr, "[compute]   submitting dispatch\n");
-        if (!vk_ok(vkQueueSubmit(ctx.queue, 1, &submit, fence), "queue-submit")) break;
+        // #1270: when prosper-app presents on this same (shared) queue, serialize the submit CALL against
+        // its present submits. No-op relaxed atomic load until the app adopts the shared queue.
+        VkResult compute_submit_rc;
+        {
+            std::unique_lock<std::mutex> lk(prosper::gpu::shared_present_submit_mutex(), std::defer_lock);
+            if (prosper::gpu::shared_present_active()) lk.lock();
+            compute_submit_rc = vkQueueSubmit(ctx.queue, 1, &submit, fence);
+        }
+        if (!vk_ok(compute_submit_rc, "queue-submit")) break;
         if (trace) std::fprintf(stderr, "[compute]   waiting for dispatch\n");
         if (!vk_ok(vkWaitForFences(ctx.device, 1, &fence, VK_TRUE,
                                    30ull * 1000 * 1000 * 1000), "queue-wait")) {
@@ -2023,6 +2031,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             // readback_persistent_color_target uses the same drain but PROMOTES a successful drain
             // to success; this item stays failed either way, which is the conservative choice for a
             // dispatch whose results we can no longer trust.
+            std::unique_lock<std::mutex> qlk(prosper::gpu::shared_present_submit_mutex(), std::defer_lock);
+            if (prosper::gpu::shared_present_active()) qlk.lock();
             if (vkQueueWaitIdle(ctx.queue) != VK_SUCCESS && trace)
                 std::fprintf(stderr, "[compute]   queue drain after fence timeout failed\n");
             break;

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -3013,8 +3013,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 // front-buffer image directly, blit it into a scanout slot on the GPU and SKIP the CPU
                 // readback+reupload entirely. gpu_present_active() is false in every headless/test/
                 // screenshot process, so this whole branch is inert there and the CPU path below is
-                // byte-for-byte unchanged. A miss (image not resident this frame) falls through to the CPU
-                // path, so it can never cause a black present.
+                // byte-for-byte unchanged. On a MISS (image not resident/valid this frame) this falls
+                // through to the CPU readback below, which still publishes a CPU frame; prosper-app
+                // presents that CPU frame when no GPU frame was published (main.cpp), so a miss degrades to
+                // the CPU present path rather than freezing the window.
                 bool published_gpu = false;
                 if (front >= 0 && prosper::gpu::gpu_present_active()) {
                     const uint64_t front_va = prosper_vo_buffer_addr(front);

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -11,6 +11,7 @@
 #include "gpu/shader_resources.hpp"     // ShaderResourceTable / ResourceClass
 #include "gpu/rdna2_to_spirv.hpp"       // recompile_fragment (diagnostic solid-color PS)
 #include "gpu/videoout_present.hpp"     // present_front_index (flip-anchored present selection)
+#include "present_blit.hpp"             // GPU scanout handoff (#1270 unified-device present)
 #include "host/guest_write_watch.hpp"
 #include "render_runner.h"              // offscreen Vulkan backend (render_draws_rgba) + dump_bmp
 
@@ -3008,9 +3009,32 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     return surface.rgba && surface.rgba->size() == expected ? &surface : nullptr;
                 };
                 const int front = prosper::gpu::present_front_index();
-                const RttSurf* scanout = front >= 0
+                // GPU present (#1270): when prosper-app has adopted this device and is consuming the
+                // front-buffer image directly, blit it into a scanout slot on the GPU and SKIP the CPU
+                // readback+reupload entirely. gpu_present_active() is false in every headless/test/
+                // screenshot process, so this whole branch is inert there and the CPU path below is
+                // byte-for-byte unchanged. A miss (image not resident this frame) falls through to the CPU
+                // path, so it can never cause a black present.
+                bool published_gpu = false;
+                if (front >= 0 && prosper::gpu::gpu_present_active()) {
+                    const uint64_t front_va = prosper_vo_buffer_addr(front);
+                    auto rit = g_rtt.find(front_va);
+                    if (rit != g_rtt.end() && rit->second.gpu_valid && rit->second.w && rit->second.h) {
+                        const VkFormat fmt = prosper::test::backend_color_format(rit->second.format);
+                        prosper::test::PersistentColorTargetImage* tgt =
+                            prosper::test::find_persistent_color_target(
+                                front_va, rit->second.w, rit->second.h, fmt);
+                        if (tgt && tgt->image && tgt->layout != VK_IMAGE_LAYOUT_UNDEFINED) {
+                            static std::atomic<uint64_t> gpu_present_seq{0};
+                            published_gpu = prosper::frontend::present_blit_publish(
+                                tgt->image, tgt->layout, fmt, rit->second.w, rit->second.h,
+                                gpu_present_seq.fetch_add(1) + 1);
+                        }
+                    }
+                }
+                const RttSurf* scanout = (!published_gpu && front >= 0)
                     ? cached_scanout(prosper_vo_buffer_addr(front)) : nullptr;
-                if (!scanout) {
+                if (!published_gpu && !scanout) {
                     for (int i = 0; i < prosper_vo_buffer_count(); ++i)
                         if ((scanout = cached_scanout(prosper_vo_buffer_addr(i)))) break;
                 }
@@ -3025,8 +3049,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 // warned, frame_no — all assume the one serialized present path). It must not be read or
                 // assigned from another thread; a concurrent present would race the object assignment.
                 static std::shared_ptr<const std::vector<uint8_t>> last_scanout_present;
-                if (selected_pixels && !selected_pixels->empty()) last_scanout_present = selected_pixels;
-                else if (last_scanout_present) selected_pixels = last_scanout_present;
+                if (!published_gpu) {
+                    if (selected_pixels && !selected_pixels->empty()) last_scanout_present = selected_pixels;
+                    else if (last_scanout_present) selected_pixels = last_scanout_present;
+                }
                 if (getenv("PROSPER_DUMP_PERSISTENT")) {
                     size_t nb = 0;
                     if (selected_pixels)

--- a/prosper/frontends/shared/present_blit.cpp
+++ b/prosper/frontends/shared/present_blit.cpp
@@ -10,6 +10,7 @@ namespace prosper::frontend {
 namespace {
 
 constexpr int kSlots = 3;   // 1 in-flight (consumer) + 1 published (untaken) + >=1 free
+constexpr VkFormat kScanoutFormat = VK_FORMAT_R8G8B8A8_UNORM;
 
 enum class SlotState { Free, Published, InFlight };
 
@@ -18,6 +19,7 @@ struct Slot {
     VkDeviceMemory memory = VK_NULL_HANDLE;
     VkCommandBuffer cmd = VK_NULL_HANDLE;
     SlotState      state = SlotState::Free;
+    uint32_t       w = 0, h = 0;            // the size of THIS slot's current image (per-slot, #1270)
     uint64_t       frame_seq = 0;
 };
 
@@ -31,7 +33,6 @@ struct PresentBlitState {
     uint32_t        qfi = UINT32_MAX;
     VkCommandPool   pool = VK_NULL_HANDLE;
     VkFence         blit_fence = VK_NULL_HANDLE;   // publish waits its own blit on this (single producer)
-    uint32_t        img_w = 0, img_h = 0;   // current allocation size of the slot images (0 = none)
     Slot            slots[kSlots];
     int             latest = -1;            // slot index of the newest published frame
     bool            latest_taken = false;   // has the consumer acquired `latest`
@@ -47,6 +48,19 @@ uint32_t find_mem_type(VkPhysicalDevice phys, uint32_t bits, VkMemoryPropertyFla
     return UINT32_MAX;
 }
 
+// #1270: an optimal-tiling image can only be blit source/dest if the driver advertises the feature for
+// that format. On any conformant driver RGBA8/RGBA16F/BGRA8 all support BLIT_SRC/BLIT_DST, so this is
+// belt-and-suspenders: an unsupported combination declines to the CPU present path instead of producing a
+// validation error / garbage. vkGetPhysicalDeviceFormatProperties is a cheap driver-table lookup.
+bool blit_supported(VkPhysicalDevice phys, VkFormat src_format) {
+    auto has = [&](VkFormat f, VkFormatFeatureFlags bit) {
+        VkFormatProperties fp{}; vkGetPhysicalDeviceFormatProperties(phys, f, &fp);
+        return (fp.optimalTilingFeatures & bit) == bit;
+    };
+    return has(src_format, VK_FORMAT_FEATURE_BLIT_SRC_BIT) &&
+           has(kScanoutFormat, VK_FORMAT_FEATURE_BLIT_DST_BIT);
+}
+
 void image_barrier(VkCommandBuffer cb, VkImage img, VkImageLayout from, VkImageLayout to,
                    VkAccessFlags src_access, VkAccessFlags dst_access,
                    VkPipelineStageFlags src_stage, VkPipelineStageFlags dst_stage) {
@@ -59,40 +73,38 @@ void image_barrier(VkCommandBuffer cb, VkImage img, VkImageLayout from, VkImageL
     vkCmdPipelineBarrier(cb, src_stage, dst_stage, 0, 0, nullptr, 0, nullptr, 1, &b);
 }
 
-// Destroy the per-slot images (caller holds mx and has made the device idle).
-void destroy_slot_images(PresentBlitState& s) {
-    for (auto& sl : s.slots) {
-        if (sl.image)  vkDestroyImage(s.dev, sl.image, nullptr);
-        if (sl.memory) vkFreeMemory(s.dev, sl.memory, nullptr);
-        sl.image = VK_NULL_HANDLE; sl.memory = VK_NULL_HANDLE;
-        sl.state = SlotState::Free;
-    }
-    s.img_w = s.img_h = 0; s.latest = -1; s.latest_taken = false;
+void destroy_slot_image(PresentBlitState& s, Slot& sl) {
+    if (sl.image)  vkDestroyImage(s.dev, sl.image, nullptr);
+    if (sl.memory) vkFreeMemory(s.dev, sl.memory, nullptr);
+    sl.image = VK_NULL_HANDLE; sl.memory = VK_NULL_HANDLE; sl.w = sl.h = 0;
 }
 
-bool create_slot_images(PresentBlitState& s, uint32_t w, uint32_t h) {
-    for (auto& sl : s.slots) {
-        VkImageCreateInfo ici{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
-        ici.imageType = VK_IMAGE_TYPE_2D;
-        ici.format = VK_FORMAT_R8G8B8A8_UNORM;
-        ici.extent = {w, h, 1};
-        ici.mipLevels = 1; ici.arrayLayers = 1;
-        ici.samples = VK_SAMPLE_COUNT_1_BIT;
-        ici.tiling = VK_IMAGE_TILING_OPTIMAL;
-        ici.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
-        ici.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-        ici.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-        if (vkCreateImage(s.dev, &ici, nullptr, &sl.image) != VK_SUCCESS) return false;
-        VkMemoryRequirements req{}; vkGetImageMemoryRequirements(s.dev, sl.image, &req);
-        uint32_t mt = find_mem_type(s.phys, req.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
-        if (mt == UINT32_MAX) return false;
-        VkMemoryAllocateInfo mai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO};
-        mai.allocationSize = req.size; mai.memoryTypeIndex = mt;
-        if (vkAllocateMemory(s.dev, &mai, nullptr, &sl.memory) != VK_SUCCESS) return false;
-        if (vkBindImageMemory(s.dev, sl.image, sl.memory, 0) != VK_SUCCESS) return false;
-        sl.state = SlotState::Free;
-    }
-    s.img_w = w; s.img_h = h; s.latest = -1; s.latest_taken = false;
+// Ensure THIS slot owns an image of exactly (w,h). Caller holds mx AND the slot is Free -- a Free slot's
+// last GPU use (its publish blit, fence-waited; or the consumer's read, released only after its present
+// fence) is provably complete, so destroying/recreating its image needs no device wait and can never
+// touch an image the consumer still references (#1270 Finding 1). Returns false on allocation failure.
+bool ensure_slot_image(PresentBlitState& s, Slot& sl, uint32_t w, uint32_t h) {
+    if (sl.image && sl.w == w && sl.h == h) return true;
+    destroy_slot_image(s, sl);
+    VkImageCreateInfo ici{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
+    ici.imageType = VK_IMAGE_TYPE_2D;
+    ici.format = kScanoutFormat;
+    ici.extent = {w, h, 1};
+    ici.mipLevels = 1; ici.arrayLayers = 1;
+    ici.samples = VK_SAMPLE_COUNT_1_BIT;
+    ici.tiling = VK_IMAGE_TILING_OPTIMAL;
+    ici.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+    ici.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+    ici.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    if (vkCreateImage(s.dev, &ici, nullptr, &sl.image) != VK_SUCCESS) { sl.image = VK_NULL_HANDLE; return false; }
+    VkMemoryRequirements req{}; vkGetImageMemoryRequirements(s.dev, sl.image, &req);
+    uint32_t mt = find_mem_type(s.phys, req.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+    if (mt == UINT32_MAX) { destroy_slot_image(s, sl); return false; }
+    VkMemoryAllocateInfo mai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO};
+    mai.allocationSize = req.size; mai.memoryTypeIndex = mt;
+    if (vkAllocateMemory(s.dev, &mai, nullptr, &sl.memory) != VK_SUCCESS) { destroy_slot_image(s, sl); return false; }
+    if (vkBindImageMemory(s.dev, sl.image, sl.memory, 0) != VK_SUCCESS) { destroy_slot_image(s, sl); return false; }
+    sl.w = w; sl.h = h;
     return true;
 }
 
@@ -128,24 +140,21 @@ int pick_free_slot(PresentBlitState& s) {
 
 } // namespace
 
-bool present_blit_publish(VkImage src, VkImageLayout src_layout, VkFormat /*src_format*/,
+bool present_blit_publish(VkImage src, VkImageLayout src_layout, VkFormat src_format,
                           uint32_t w, uint32_t h, uint64_t frame_seq) {
     if (!src || !w || !h) return false;
     PresentBlitState& s = S();
     std::lock_guard<std::mutex> lk(s.mx);
     if (!ensure_init(s)) return false;
-
-    // (Re)allocate the slot images if this is the first frame or the display size changed. A size change
-    // is rare (window resize); make the device idle first so no in-flight consumer read is dropped.
-    if (s.img_w != w || s.img_h != h) {
-        vkDeviceWaitIdle(s.dev);
-        if (s.img_w) destroy_slot_images(s);
-        if (!create_slot_images(s, w, h)) return false;
-    }
+    if (!blit_supported(s.phys, src_format)) return false;   // decline -> caller keeps CPU present path
 
     const int slot = pick_free_slot(s);
     if (slot < 0) return false;   // consumer is behind; drop this frame's publish (it keeps the last one)
     Slot& sl = s.slots[slot];
+    // Size the (Free) slot's image to this frame. A display-size change (or dynamic resolution) recreates
+    // ONLY this Free slot's image -- never an in-flight one -- so it cannot free an image the consumer
+    // still holds, and needs no device-wide wait (#1270 Finding 1).
+    if (!ensure_slot_image(s, sl, w, h)) return false;
 
     VkCommandBuffer cb = sl.cmd;
     vkResetCommandBuffer(cb, 0);
@@ -217,7 +226,7 @@ bool present_blit_acquire(GpuScanoutFrame& out) {
     sl.state = SlotState::InFlight;
     s.latest_taken = true;
     out.image = sl.image;
-    out.width = s.img_w; out.height = s.img_h;
+    out.width = sl.w; out.height = sl.h;
     out.frame_seq = sl.frame_seq;
     out.slot = s.latest;
     return true;
@@ -235,9 +244,9 @@ void present_blit_reset() {
     PresentBlitState& s = S();
     std::lock_guard<std::mutex> lk(s.mx);
     if (s.dev) vkDeviceWaitIdle(s.dev);
-    if (s.img_w && s.dev) destroy_slot_images(s);
+    if (s.dev)
+        for (auto& sl : s.slots) { destroy_slot_image(s, sl); sl.state = SlotState::Free; sl.cmd = VK_NULL_HANDLE; }
     if (s.dev) {
-        for (auto& sl : s.slots) sl.cmd = VK_NULL_HANDLE;   // freed with the pool
         if (s.blit_fence) { vkDestroyFence(s.dev, s.blit_fence, nullptr); s.blit_fence = VK_NULL_HANDLE; }
         if (s.pool) { vkDestroyCommandPool(s.dev, s.pool, nullptr); s.pool = VK_NULL_HANDLE; }
     }
@@ -246,6 +255,10 @@ void present_blit_reset() {
     s.latest = -1; s.latest_taken = false;
 }
 
-bool present_blit_ready() { return S().ok; }
+bool present_blit_ready() {
+    PresentBlitState& s = S();
+    std::lock_guard<std::mutex> lk(s.mx);
+    return s.ok;
+}
 
 } // namespace prosper::frontend

--- a/prosper/frontends/shared/present_blit.cpp
+++ b/prosper/frontends/shared/present_blit.cpp
@@ -1,0 +1,251 @@
+// present_blit.cpp — see present_blit.hpp (#1270).
+#include "present_blit.hpp"
+#include "render_runner.h"            // render_vk_ctx()
+#include "gpu/gpu_execute.hpp"        // shared_present_submit_mutex / shared_present_active
+#include <mutex>
+#include <cstdio>
+#include <cstring>
+
+namespace prosper::frontend {
+namespace {
+
+constexpr int kSlots = 3;   // 1 in-flight (consumer) + 1 published (untaken) + >=1 free
+
+enum class SlotState { Free, Published, InFlight };
+
+struct Slot {
+    VkImage        image = VK_NULL_HANDLE;
+    VkDeviceMemory memory = VK_NULL_HANDLE;
+    VkCommandBuffer cmd = VK_NULL_HANDLE;
+    SlotState      state = SlotState::Free;
+    uint64_t       frame_seq = 0;
+};
+
+struct PresentBlitState {
+    std::mutex      mx;                     // guards the slot bookkeeping below
+    bool            init_tried = false;
+    bool            ok = false;             // device + pool + fence created
+    VkDevice        dev = VK_NULL_HANDLE;
+    VkPhysicalDevice phys = VK_NULL_HANDLE;
+    VkQueue         queue = VK_NULL_HANDLE;
+    uint32_t        qfi = UINT32_MAX;
+    VkCommandPool   pool = VK_NULL_HANDLE;
+    VkFence         blit_fence = VK_NULL_HANDLE;   // publish waits its own blit on this (single producer)
+    uint32_t        img_w = 0, img_h = 0;   // current allocation size of the slot images (0 = none)
+    Slot            slots[kSlots];
+    int             latest = -1;            // slot index of the newest published frame
+    bool            latest_taken = false;   // has the consumer acquired `latest`
+};
+
+PresentBlitState& S() { static PresentBlitState s; return s; }
+
+uint32_t find_mem_type(VkPhysicalDevice phys, uint32_t bits, VkMemoryPropertyFlags want) {
+    VkPhysicalDeviceMemoryProperties mp{};
+    vkGetPhysicalDeviceMemoryProperties(phys, &mp);
+    for (uint32_t i = 0; i < mp.memoryTypeCount; i++)
+        if ((bits & (1u << i)) && (mp.memoryTypes[i].propertyFlags & want) == want) return i;
+    return UINT32_MAX;
+}
+
+void image_barrier(VkCommandBuffer cb, VkImage img, VkImageLayout from, VkImageLayout to,
+                   VkAccessFlags src_access, VkAccessFlags dst_access,
+                   VkPipelineStageFlags src_stage, VkPipelineStageFlags dst_stage) {
+    VkImageMemoryBarrier b{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
+    b.oldLayout = from; b.newLayout = to;
+    b.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED; b.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    b.image = img;
+    b.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+    b.srcAccessMask = src_access; b.dstAccessMask = dst_access;
+    vkCmdPipelineBarrier(cb, src_stage, dst_stage, 0, 0, nullptr, 0, nullptr, 1, &b);
+}
+
+// Destroy the per-slot images (caller holds mx and has made the device idle).
+void destroy_slot_images(PresentBlitState& s) {
+    for (auto& sl : s.slots) {
+        if (sl.image)  vkDestroyImage(s.dev, sl.image, nullptr);
+        if (sl.memory) vkFreeMemory(s.dev, sl.memory, nullptr);
+        sl.image = VK_NULL_HANDLE; sl.memory = VK_NULL_HANDLE;
+        sl.state = SlotState::Free;
+    }
+    s.img_w = s.img_h = 0; s.latest = -1; s.latest_taken = false;
+}
+
+bool create_slot_images(PresentBlitState& s, uint32_t w, uint32_t h) {
+    for (auto& sl : s.slots) {
+        VkImageCreateInfo ici{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
+        ici.imageType = VK_IMAGE_TYPE_2D;
+        ici.format = VK_FORMAT_R8G8B8A8_UNORM;
+        ici.extent = {w, h, 1};
+        ici.mipLevels = 1; ici.arrayLayers = 1;
+        ici.samples = VK_SAMPLE_COUNT_1_BIT;
+        ici.tiling = VK_IMAGE_TILING_OPTIMAL;
+        ici.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+        ici.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+        ici.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        if (vkCreateImage(s.dev, &ici, nullptr, &sl.image) != VK_SUCCESS) return false;
+        VkMemoryRequirements req{}; vkGetImageMemoryRequirements(s.dev, sl.image, &req);
+        uint32_t mt = find_mem_type(s.phys, req.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+        if (mt == UINT32_MAX) return false;
+        VkMemoryAllocateInfo mai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO};
+        mai.allocationSize = req.size; mai.memoryTypeIndex = mt;
+        if (vkAllocateMemory(s.dev, &mai, nullptr, &sl.memory) != VK_SUCCESS) return false;
+        if (vkBindImageMemory(s.dev, sl.image, sl.memory, 0) != VK_SUCCESS) return false;
+        sl.state = SlotState::Free;
+    }
+    s.img_w = w; s.img_h = h; s.latest = -1; s.latest_taken = false;
+    return true;
+}
+
+// One-time device/pool/fence/command-buffer setup. Caller holds mx.
+bool ensure_init(PresentBlitState& s) {
+    if (s.init_tried) return s.ok;
+    s.init_tried = true;
+    const prosper::test::RenderVkCtx& ctx = prosper::test::render_vk_ctx();
+    if (!ctx.ok) return false;   // no render device -> GPU present declines -> caller keeps CPU path
+    s.dev = ctx.dev; s.phys = ctx.phys; s.queue = ctx.queue; s.qfi = ctx.qfi;
+
+    VkCommandPoolCreateInfo pci{VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO};
+    pci.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+    pci.queueFamilyIndex = s.qfi;
+    if (vkCreateCommandPool(s.dev, &pci, nullptr, &s.pool) != VK_SUCCESS) return false;
+
+    VkFenceCreateInfo fci{VK_STRUCTURE_TYPE_FENCE_CREATE_INFO};
+    if (vkCreateFence(s.dev, &fci, nullptr, &s.blit_fence) != VK_SUCCESS) return false;
+
+    for (auto& sl : s.slots) {
+        VkCommandBufferAllocateInfo ai{VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO};
+        ai.commandPool = s.pool; ai.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY; ai.commandBufferCount = 1;
+        if (vkAllocateCommandBuffers(s.dev, &ai, &sl.cmd) != VK_SUCCESS) return false;
+    }
+    s.ok = true;
+    return true;
+}
+
+int pick_free_slot(PresentBlitState& s) {
+    for (int i = 0; i < kSlots; i++) if (s.slots[i].state == SlotState::Free) return i;
+    return -1;
+}
+
+} // namespace
+
+bool present_blit_publish(VkImage src, VkImageLayout src_layout, VkFormat /*src_format*/,
+                          uint32_t w, uint32_t h, uint64_t frame_seq) {
+    if (!src || !w || !h) return false;
+    PresentBlitState& s = S();
+    std::lock_guard<std::mutex> lk(s.mx);
+    if (!ensure_init(s)) return false;
+
+    // (Re)allocate the slot images if this is the first frame or the display size changed. A size change
+    // is rare (window resize); make the device idle first so no in-flight consumer read is dropped.
+    if (s.img_w != w || s.img_h != h) {
+        vkDeviceWaitIdle(s.dev);
+        if (s.img_w) destroy_slot_images(s);
+        if (!create_slot_images(s, w, h)) return false;
+    }
+
+    const int slot = pick_free_slot(s);
+    if (slot < 0) return false;   // consumer is behind; drop this frame's publish (it keeps the last one)
+    Slot& sl = s.slots[slot];
+
+    VkCommandBuffer cb = sl.cmd;
+    vkResetCommandBuffer(cb, 0);
+    VkCommandBufferBeginInfo bi{VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO};
+    bi.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+    if (vkBeginCommandBuffer(cb, &bi) != VK_SUCCESS) return false;
+
+    // src (front-buffer image) -> TRANSFER_SRC; scanout slot -> TRANSFER_DST (contents discarded).
+    image_barrier(cb, src, src_layout, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                  VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT, VK_ACCESS_TRANSFER_READ_BIT,
+                  VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT);
+    image_barrier(cb, sl.image, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                  0, VK_ACCESS_TRANSFER_WRITE_BIT,
+                  VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT);
+
+    VkImageBlit blit{};
+    blit.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    blit.srcOffsets[1] = {(int32_t)w, (int32_t)h, 1};
+    blit.dstSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    blit.dstOffsets[1] = {(int32_t)w, (int32_t)h, 1};
+    vkCmdBlitImage(cb, src, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                   sl.image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &blit, VK_FILTER_NEAREST);
+
+    // scanout slot -> TRANSFER_SRC (consumer reads it); restore src to its original layout.
+    image_barrier(cb, sl.image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                  VK_ACCESS_TRANSFER_WRITE_BIT, VK_ACCESS_TRANSFER_READ_BIT,
+                  VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT);
+    image_barrier(cb, src, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, src_layout,
+                  VK_ACCESS_TRANSFER_READ_BIT, VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+                  VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
+    if (vkEndCommandBuffer(cb) != VK_SUCCESS) return false;
+
+    VkSubmitInfo si{VK_STRUCTURE_TYPE_SUBMIT_INFO};
+    si.commandBufferCount = 1; si.pCommandBuffers = &cb;
+
+    vkResetFences(s.dev, 1, &s.blit_fence);
+    VkResult sr;
+    {
+        // Serialize the host submit CALL against prosper-app's present submits on the shared queue.
+        std::unique_lock<std::mutex> qlk(prosper::gpu::shared_present_submit_mutex(), std::defer_lock);
+        if (prosper::gpu::shared_present_active()) qlk.lock();
+        sr = vkQueueSubmit(s.queue, 1, &si, s.blit_fence);
+    }
+    if (sr != VK_SUCCESS) return false;
+    // Wait the blit's completion here (a fast GPU->GPU copy) so the slot is fully written before it can be
+    // acquired -- this is what lets the consumer read it with no cross-thread semaphore, and is strictly
+    // cheaper than the GPU->CPU readback + CPU->GPU re-upload it replaces. Does not touch the queue, so it
+    // is outside the submit mutex.
+    vkWaitForFences(s.dev, 1, &s.blit_fence, VK_TRUE, 5ull * 1000 * 1000 * 1000);
+
+    sl.frame_seq = frame_seq;
+    sl.state = SlotState::Published;
+
+    // A previously published-but-untaken frame is now stale; free its slot for reuse.
+    if (s.latest >= 0 && s.latest != slot && !s.latest_taken &&
+        s.slots[s.latest].state == SlotState::Published)
+        s.slots[s.latest].state = SlotState::Free;
+    s.latest = slot;
+    s.latest_taken = false;
+    return true;
+}
+
+bool present_blit_acquire(GpuScanoutFrame& out) {
+    PresentBlitState& s = S();
+    std::lock_guard<std::mutex> lk(s.mx);
+    if (!s.ok || s.latest < 0 || s.latest_taken) return false;
+    Slot& sl = s.slots[s.latest];
+    if (sl.state != SlotState::Published) return false;
+    sl.state = SlotState::InFlight;
+    s.latest_taken = true;
+    out.image = sl.image;
+    out.width = s.img_w; out.height = s.img_h;
+    out.frame_seq = sl.frame_seq;
+    out.slot = s.latest;
+    return true;
+}
+
+void present_blit_release(int slot) {
+    if (slot < 0 || slot >= kSlots) return;
+    PresentBlitState& s = S();
+    std::lock_guard<std::mutex> lk(s.mx);
+    Slot& sl = s.slots[slot];
+    if (sl.state == SlotState::InFlight) sl.state = SlotState::Free;
+}
+
+void present_blit_reset() {
+    PresentBlitState& s = S();
+    std::lock_guard<std::mutex> lk(s.mx);
+    if (s.dev) vkDeviceWaitIdle(s.dev);
+    if (s.img_w && s.dev) destroy_slot_images(s);
+    if (s.dev) {
+        for (auto& sl : s.slots) sl.cmd = VK_NULL_HANDLE;   // freed with the pool
+        if (s.blit_fence) { vkDestroyFence(s.dev, s.blit_fence, nullptr); s.blit_fence = VK_NULL_HANDLE; }
+        if (s.pool) { vkDestroyCommandPool(s.dev, s.pool, nullptr); s.pool = VK_NULL_HANDLE; }
+    }
+    s.init_tried = false; s.ok = false;
+    s.dev = VK_NULL_HANDLE; s.phys = VK_NULL_HANDLE; s.queue = VK_NULL_HANDLE; s.qfi = UINT32_MAX;
+    s.latest = -1; s.latest_taken = false;
+}
+
+bool present_blit_ready() { return S().ok; }
+
+} // namespace prosper::frontend

--- a/prosper/frontends/shared/present_blit.hpp
+++ b/prosper/frontends/shared/present_blit.hpp
@@ -1,0 +1,67 @@
+// present_blit.hpp — GPU-side scanout handoff for the unified-device present path (#1270).
+//
+// Today prosper reads the rendered front-buffer image back to CPU every present and the frontend
+// re-uploads it (a 4K GPU->CPU->GPU round-trip). Once prosper-app presents on the SAME VkDevice as the
+// renderer (see render_vk_ctx present-capability, #1270), this module removes the round-trip: on the
+// render device the renderer blits the front-buffer image into a small pool of renderer-owned "scanout"
+// images, and the app blits the chosen scanout image straight to its swapchain.
+//
+// Ownership / lifetime model (a tiny triple-buffered producer->consumer):
+//   - The renderer (guest thread) calls present_blit_publish(front image): it takes a FREE slot, records a
+//     blit front->scanout[slot] on the render queue (serialized by the shared present mutex), submits it
+//     with a fence and WAITS that fence, then marks the slot PUBLISHED as the newest frame. A previously
+//     published-but-untaken slot returns to FREE.
+//   - The consumer (app main thread) calls present_blit_acquire(): it takes the PUBLISHED slot (-> IN_FLIGHT)
+//     and blits it straight to its swapchain. After its present fence signals (its GPU read of the slot is
+//     complete) it calls present_blit_release(slot), returning it to FREE for reuse.
+//
+// Synchronization needs no semaphore between the two threads. A slot only becomes acquirable AFTER its
+// front->scanout blit has fully completed (publish fence-waits it), so the consumer never reads a
+// half-written image. A slot is only reused by the producer AFTER the consumer released it, i.e. after the
+// consumer's present fence proved its GPU read finished. The per-side fences plus the slot state machine
+// therefore fully order producer-write vs consumer-read; concurrent host CALLS to the shared VkQueue are
+// serialized by shared_present_submit_mutex(). Everything is on ONE VkDevice (render_vk_ctx) -- no
+// queue-family ownership transfers, no external memory. The blit fence-wait is a fast GPU->GPU sync that
+// replaces (and is strictly cheaper than) today's GPU->CPU readback + CPU->GPU re-upload.
+//
+// All functions are no-ops that return false / do nothing when GPU present is unavailable (no render
+// device, allocation failure), so the caller always retains the CPU present path as a fallback and the
+// headless test/screenshot path is never affected.
+#pragma once
+#include <vulkan/vulkan.h>
+#include <cstdint>
+
+namespace prosper::frontend {
+
+// A published GPU scanout frame handed to the consumer. The image is fully written and stable (in
+// TRANSFER_SRC_OPTIMAL) until the consumer releases the slot.
+struct GpuScanoutFrame {
+    VkImage     image = VK_NULL_HANDLE;      // RGBA8_UNORM, in TRANSFER_SRC_OPTIMAL, ready to read
+    uint32_t    width = 0, height = 0;
+    uint64_t    frame_seq = 0;               // renderer frame identity that produced this image
+    int         slot = -1;                   // opaque handle to pass back to present_blit_release
+    bool valid() const { return image && width && height && slot >= 0; }
+};
+
+// Renderer side (guest thread). Blit `src` (the front-buffer image; it is transitioned to TRANSFER_SRC and
+// restored to `src_layout` afterward) into a free scanout slot sized w*h and publish it. Returns false and
+// changes nothing if GPU present cannot run this frame (uninitialized device, no free slot, Vulkan error) --
+// the caller keeps the CPU present path. `frame_seq` is echoed back in the published frame for identity.
+bool present_blit_publish(VkImage src, VkImageLayout src_layout, VkFormat src_format,
+                          uint32_t w, uint32_t h, uint64_t frame_seq);
+
+// Consumer side. Fetch the newest published frame not already taken; false if nothing new is available.
+// The caller owns the returned slot until it calls present_blit_release(out.slot).
+bool present_blit_acquire(GpuScanoutFrame& out);
+
+// Consumer side. Return a slot after the consumer's GPU read of it has completed (its present fence
+// signaled). Safe to call with a stale/-1 slot (ignored).
+void present_blit_release(int slot);
+
+// Destroy all owned Vulkan resources. The render device must be idle. Used by tests and teardown.
+void present_blit_reset();
+
+// True once at least one publish has initialized the pool on a present-capable render device.
+bool present_blit_ready();
+
+} // namespace prosper::frontend

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -484,6 +484,15 @@ struct SharedVulkanContext {
     // Features the compute backend requires; when false it must decline the shared device.
     bool storage_image_read_without_format = false;
     bool storage_image_write_without_format = false;
+    // Present unification (#1270): when present_capable, prosper-app may create its window surface on
+    // `instance`, its swapchain on `device`, and present on `present_queue` -- then blit the renderer's
+    // front-buffer image straight to the swapchain with no CPU round-trip. present_queue_shared means the
+    // present queue aliases the render queue, so both threads must serialize submits through
+    // shared_render_submit_mutex(). false/nullptr on a headless build (prosper-app then uses its own
+    // separate present device + CPU pixels, exactly as before).
+    bool present_capable = false;
+    void* present_queue = nullptr;
+    bool present_queue_shared = false;
     bool valid() const { return instance && physical && device && queue && queue_family != UINT32_MAX; }
 };
 void set_shared_vulkan_context(const SharedVulkanContext& context);

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -22,6 +22,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <functional>
+#include <mutex>
 #include <memory>
 #include <vector>
 #include <set>
@@ -497,6 +498,18 @@ struct SharedVulkanContext {
 };
 void set_shared_vulkan_context(const SharedVulkanContext& context);
 SharedVulkanContext shared_vulkan_context();
+
+// Present unification (#1270): when prosper-app presents on the SAME VkQueue the renderer/compute submit
+// on (present_queue_shared), the renderer's guest thread and the app's present thread would call
+// vkQueueSubmit/vkQueueWaitIdle/vkQueuePresentKHR on one queue concurrently -- undefined without external
+// synchronization. This mutex serializes those host CALLS (not GPU waits, which don't touch the queue).
+// It is a no-op until the app adopts the shared queue and calls set_shared_present_active(true): every
+// renderer/compute submit site takes it only when shared_present_active() is true, so the headless
+// test/screenshot path pays a single relaxed atomic load and no lock. GPU-side render->present ordering
+// is handled by a semaphore, independently of this mutex.
+std::mutex& shared_present_submit_mutex();
+void set_shared_present_active(bool active);
+bool shared_present_active();
 
 // Ordered memory producers need the same authoritative storage version as live compute. A source
 // may begin inside a target, so the renderer validates the complete requested byte range instead of

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -511,6 +511,15 @@ std::mutex& shared_present_submit_mutex();
 void set_shared_present_active(bool active);
 bool shared_present_active();
 
+// Present unification (#1270): true once prosper-app has adopted the render device and is consuming the
+// renderer's front-buffer image directly (present_blit). While true the renderer publishes the front image
+// via present_blit_publish and SKIPS the CPU readback+reupload of the scanout buffer. Distinct from
+// shared_present_active: GPU present can run on a dedicated present queue (no shared-queue mutex needed).
+// Stays false in every headless/test/screenshot process, so their CPU present path is byte-for-byte
+// unchanged. Set once by prosper-app after a successful adoption; never cleared mid-run.
+void set_gpu_present_active(bool active);
+bool gpu_present_active();
+
 // Ordered memory producers need the same authoritative storage version as live compute. A source
 // may begin inside a target, so the renderer validates the complete requested byte range instead of
 // exposing an unbounded pointer into its cache.

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -4195,9 +4195,10 @@ void set_shared_vulkan_context(const SharedVulkanContext& context) { g_shared_vu
 SharedVulkanContext shared_vulkan_context() { return g_shared_vulkan; }
 
 // Present unification (#1270): see gpu_execute.hpp. The atomic gates the lock so the common (headless /
-// non-shared / app-not-yet-adopted) path pays only a relaxed load. Set true exactly once, by prosper-app,
-// after it has adopted the shared queue for present and before its first present submit; never cleared
-// mid-run (the app owns the shared device for the process lifetime once adopted).
+// non-shared / app-not-yet-adopted) path pays only a single acquire load and takes no lock. Set true
+// exactly once, by prosper-app, after it has adopted the shared queue for present and before its first
+// present submit; never cleared mid-run (the app owns the shared device for the process lifetime once
+// adopted). acquire/release ordering publishes the adoption's writes to the guest thread.
 static std::atomic<bool> g_shared_present_active{false};
 std::mutex& shared_present_submit_mutex() {
     static std::mutex m;

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -4209,6 +4209,13 @@ void set_shared_present_active(bool active) {
 bool shared_present_active() {
     return g_shared_present_active.load(std::memory_order_acquire);
 }
+static std::atomic<bool> g_gpu_present_active{false};
+void set_gpu_present_active(bool active) {
+    g_gpu_present_active.store(active, std::memory_order_release);
+}
+bool gpu_present_active() {
+    return g_gpu_present_active.load(std::memory_order_acquire);
+}
 bool read_live_render_target(uint64_t gpu_addr, LiveTargetSnapshot& snapshot) {
     snapshot = {};
     return g_live_target_reader && g_live_target_reader(gpu_addr, snapshot);

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -4193,6 +4193,22 @@ void release_live_render_target_image(uint64_t gpu_addr) {
 static SharedVulkanContext g_shared_vulkan;
 void set_shared_vulkan_context(const SharedVulkanContext& context) { g_shared_vulkan = context; }
 SharedVulkanContext shared_vulkan_context() { return g_shared_vulkan; }
+
+// Present unification (#1270): see gpu_execute.hpp. The atomic gates the lock so the common (headless /
+// non-shared / app-not-yet-adopted) path pays only a relaxed load. Set true exactly once, by prosper-app,
+// after it has adopted the shared queue for present and before its first present submit; never cleared
+// mid-run (the app owns the shared device for the process lifetime once adopted).
+static std::atomic<bool> g_shared_present_active{false};
+std::mutex& shared_present_submit_mutex() {
+    static std::mutex m;
+    return m;
+}
+void set_shared_present_active(bool active) {
+    g_shared_present_active.store(active, std::memory_order_release);
+}
+bool shared_present_active() {
+    return g_shared_present_active.load(std::memory_order_acquire);
+}
 bool read_live_render_target(uint64_t gpu_addr, LiveTargetSnapshot& snapshot) {
     snapshot = {};
     return g_live_target_reader && g_live_target_reader(gpu_addr, snapshot);

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -491,6 +491,15 @@ struct RenderVkCtx {
     VkShaderStageFlags required_subgroup_size_stages = 0;
     VkShaderStageFlags subgroup_stages = 0;
     VkSubgroupFeatureFlags subgroup_operations = 0;
+    // Present unification (#1270): so prosper-app can adopt THIS device for its swapchain and blit the
+    // renderer's front-buffer image straight to the screen (no 4K CPU round-trip). All additive and
+    // only when advertised, so the headless test/screenshot path is byte-for-byte unchanged: on a
+    // display-less target the surface instance-extensions and VK_KHR_swapchain are simply absent, these
+    // stay false, and prosper-app falls back to its own separate present device + CPU pixels.
+    bool present_surface_capable = false;   // instance enabled VK_KHR_surface (+ a platform surface ext)
+    bool present_swapchain_capable = false; // device enabled VK_KHR_swapchain
+    VkQueue present_queue = VK_NULL_HANDLE; // dedicated 2nd queue when the family has >=2, else == queue
+    bool present_queue_shared = false;      // present_queue aliases the render queue -> submits need a mutex
 };
 inline const RenderVkCtx& render_vk_ctx() {
     static RenderVkCtx c = [] {
@@ -499,7 +508,59 @@ inline const RenderVkCtx& render_vk_ctx() {
         VkInstanceCreateInfo ici{VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO}; ici.pApplicationInfo = &app;
         // macOS: MoltenVK is linked directly, so VK_KHR_portability_enumeration is neither needed nor
         // accepted here (see prosper-app main.cpp). Only the device-level portability_subset matters.
-        if (vkCreateInstance(&ici, nullptr, &r.inst) != VK_SUCCESS || !r.inst) return r;
+        //
+        // Present unification (#1270): enable the WSI surface instance-extensions when the loader
+        // advertises them, so prosper-app can create its window surface on THIS instance and present on
+        // this device (see present_surface_capable). "Add-if-available" only: a headless target (llvmpipe
+        // CI, no display) advertises none, so the enabled list stays empty and instance creation is
+        // exactly as before. This is created before SDL_Init in the app, so we can't consult
+        // SDL_Vulkan_GetInstanceExtensions; instead enable every platform surface extension present and
+        // let the app fall back to its own device if SDL still needs one we didn't get (#1270 R4).
+        std::vector<const char*> inst_exts;
+        {
+            static const char* const kWsiExts[] = {
+                "VK_KHR_surface",
+#if defined(_WIN32)
+                "VK_KHR_win32_surface",
+#elif defined(__APPLE__)
+                "VK_EXT_metal_surface", "VK_MVK_macos_surface",
+#else
+                "VK_KHR_xlib_surface", "VK_KHR_xcb_surface", "VK_KHR_wayland_surface",
+#endif
+            };
+            uint32_t nie = 0; vkEnumerateInstanceExtensionProperties(nullptr, &nie, nullptr);
+            std::vector<VkExtensionProperties> avail(nie);
+            if (nie) vkEnumerateInstanceExtensionProperties(nullptr, &nie, avail.data());
+            auto has = [&](const char* name) {
+                for (const auto& e : avail) if (!strcmp(e.extensionName, name)) return true;
+                return false;
+            };
+            bool have_surface = has("VK_KHR_surface");
+            if (have_surface) {
+                bool have_platform = false;
+                for (const char* e : kWsiExts) {
+                    if (has(e)) { inst_exts.push_back(e); if (strcmp(e, "VK_KHR_surface")) have_platform = true; }
+                }
+                // A bare VK_KHR_surface with no platform surface is useless for a window; require both.
+                r.present_surface_capable = have_platform;
+                if (!have_platform) inst_exts.clear();
+            }
+            if (!inst_exts.empty()) {
+                ici.enabledExtensionCount = (uint32_t)inst_exts.size();
+                ici.ppEnabledExtensionNames = inst_exts.data();
+            }
+        }
+        // If the driver rejects the surface set (should not happen since each was advertised), retry with
+        // no instance extensions so the headless render path never regresses on an unexpected loader.
+        if (vkCreateInstance(&ici, nullptr, &r.inst) != VK_SUCCESS || !r.inst) {
+            if (!inst_exts.empty()) {
+                r.present_surface_capable = false;
+                VkInstanceCreateInfo bare{VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO}; bare.pApplicationInfo = &app;
+                if (vkCreateInstance(&bare, nullptr, &r.inst) != VK_SUCCESS || !r.inst) return r;
+            } else {
+                return r;
+            }
+        }
         uint32_t nd = 0; vkEnumeratePhysicalDevices(r.inst, &nd, nullptr);
         if (!nd) return r;
         std::vector<VkPhysicalDevice> devs(nd); vkEnumeratePhysicalDevices(r.inst, &nd, devs.data());
@@ -510,9 +571,24 @@ inline const RenderVkCtx& render_vk_ctx() {
         std::fprintf(stderr, "[render] Vulkan device: %s (%s)\n",
                      selection.properties.deviceName,
                      prosper::frontend::vulkan_device_type_name(selection.properties.deviceType));
-        float prio = 1.0f;
+        // Present unification (#1270): if the graphics family exposes a second queue, dedicate index 1
+        // to prosper-app's present so the app's blit/present submits never contend the render queue's
+        // external-synchronization. On a single-queue family (RADV STRIX_HALO is queueCount==1) the app
+        // instead shares queue index 0 under a submit mutex. Requesting queueCount is harmless to the
+        // headless path: the extra queue is simply never fetched by tests/screenshot.
+        uint32_t family_queue_count = 1;
+        {
+            uint32_t nq = 0; vkGetPhysicalDeviceQueueFamilyProperties(r.phys, &nq, nullptr);
+            if (nq) {
+                std::vector<VkQueueFamilyProperties> qfp(nq);
+                vkGetPhysicalDeviceQueueFamilyProperties(r.phys, &nq, qfp.data());
+                if (r.qfi < nq) family_queue_count = qfp[r.qfi].queueCount;
+            }
+        }
+        float prio[2] = {1.0f, 1.0f};
+        const uint32_t want_queues = family_queue_count >= 2 ? 2u : 1u;
         VkDeviceQueueCreateInfo qci{VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO};
-        qci.queueFamilyIndex = r.qfi; qci.queueCount = 1; qci.pQueuePriorities = &prio;
+        qci.queueFamilyIndex = r.qfi; qci.queueCount = want_queues; qci.pQueuePriorities = prio;
         VkDeviceCreateInfo dci{VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO};
         dci.queueCreateInfoCount = 1; dci.pQueueCreateInfos = &qci;
         // robustBufferAccess: OOB storage-buffer accesses are well-defined (predicated ops on
@@ -606,6 +682,16 @@ inline const RenderVkCtx& render_vk_ctx() {
                       r.transform_feedback_enabled = true;
                   }
               }
+              // Present unification (#1270): the swapchain device-extension, only when the instance is
+              // surface-capable. Enabling it on the headless render device is harmless (no swapchain is
+              // ever created there by tests/screenshot); prosper-app needs it to create its swapchain on
+              // this shared device. Gated on present_surface_capable so a display-less build never
+              // requests it.
+              if (r.present_surface_capable &&
+                  !strcmp(de[i].extensionName, VK_KHR_SWAPCHAIN_EXTENSION_NAME)) {
+                  dev_exts.push_back(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
+                  r.present_swapchain_capable = true;
+              }
 #ifdef __APPLE__
               // Spec-mandated: must be enabled when advertised (MoltenVK always advertises it).
               if (!strcmp(de[i].extensionName, "VK_KHR_portability_subset")) dev_exts.push_back("VK_KHR_portability_subset");
@@ -615,6 +701,19 @@ inline const RenderVkCtx& render_vk_ctx() {
         dci.ppEnabledExtensionNames = dev_exts.empty() ? nullptr : dev_exts.data();
         if (vkCreateDevice(r.phys, &dci, nullptr, &r.dev) != VK_SUCCESS || !r.dev) return r;
         vkGetDeviceQueue(r.dev, r.qfi, 0, &r.queue);
+        // Present unification (#1270): resolve the queue prosper-app will use to present. A dedicated
+        // second queue (when the family has >=2) avoids contending the render queue; otherwise the app
+        // shares queue 0 under a submit mutex (present_queue_shared). present capability requires the
+        // swapchain extension to have been enabled above.
+        if (r.present_swapchain_capable) {
+            if (want_queues >= 2) {
+                vkGetDeviceQueue(r.dev, r.qfi, 1, &r.present_queue);
+                r.present_queue_shared = false;
+            } else {
+                r.present_queue = r.queue;
+                r.present_queue_shared = true;
+            }
+        }
         r.ok = true;
         // Publish this device so the compute backend can adopt it instead of creating a second one
         // (#1091). Only the features compute needs are advertised; it declines the shared context if
@@ -634,6 +733,12 @@ inline const RenderVkCtx& render_vk_ctx() {
             // declaring a capability the device never enabled.
             shared.storage_image_read_without_format = feats.shaderStorageImageReadWithoutFormat;
             shared.storage_image_write_without_format = feats.shaderStorageImageWriteWithoutFormat;
+            // Present unification (#1270): advertise present adoption only when the instance is
+            // surface-capable AND the device enabled VK_KHR_swapchain AND a present queue was resolved.
+            shared.present_capable = r.present_surface_capable && r.present_swapchain_capable &&
+                                     r.present_queue != VK_NULL_HANDLE;
+            shared.present_queue = r.present_queue;
+            shared.present_queue_shared = r.present_queue_shared;
             prosper::gpu::set_shared_vulkan_context(shared);
         }
         return r;

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -746,6 +746,25 @@ inline const RenderVkCtx& render_vk_ctx() {
     return c;
 }
 
+// Present unification (#1270): serialize a single queue CALL against prosper-app's present submits when
+// they share one VkQueue. Locks ONLY around the host call (never a GPU wait), and only once the app has
+// adopted the shared queue (shared_present_active()); otherwise it is a plain call after a relaxed atomic
+// load, so the headless/test/screenshot path and every non-shared device are unaffected.
+inline VkResult render_locked_queue_submit(VkQueue q, uint32_t n, const VkSubmitInfo* s, VkFence f) {
+    if (prosper::gpu::shared_present_active()) {
+        std::lock_guard<std::mutex> lk(prosper::gpu::shared_present_submit_mutex());
+        return vkQueueSubmit(q, n, s, f);
+    }
+    return vkQueueSubmit(q, n, s, f);
+}
+inline VkResult render_locked_queue_wait_idle(VkQueue q) {
+    if (prosper::gpu::shared_present_active()) {
+        std::lock_guard<std::mutex> lk(prosper::gpu::shared_present_submit_mutex());
+        return vkQueueWaitIdle(q);
+    }
+    return vkQueueWaitIdle(q);
+}
+
 struct BackendSubmissionBatchResult {
     VkResult submit_result = VK_SUCCESS;
     VkResult wait_result = VK_SUCCESS;
@@ -816,7 +835,7 @@ public:
                          commands_.size());
             std::fflush(stderr);
         }
-        result.submit_result = vkQueueSubmit(queue, 1, &submit, fence);
+        result.submit_result = render_locked_queue_submit(queue, 1, &submit, fence);
         result.queue_submits = 1;
         if (backend_trace) {
             std::fprintf(stderr,
@@ -830,7 +849,7 @@ public:
             result.fence_waits = 1;
             // Preserve lifetime safety even if the bounded diagnostic wait expires.
             if (result.wait_result != VK_SUCCESS)
-                result.wait_result = vkQueueWaitIdle(queue);
+                result.wait_result = render_locked_queue_wait_idle(queue);
         }
         if (backend_trace) {
             std::fprintf(stderr, "[backend-trace] fence-wait end result=%d\n",
@@ -1577,10 +1596,10 @@ inline bool submit_persistent_ds_transfer(const RenderVkCtx& ctx, VkImage image,
         vkCreateFence(ctx.dev, &fence_info, nullptr, &fence) == VK_SUCCESS;
     VkSubmitInfo submit{VK_STRUCTURE_TYPE_SUBMIT_INFO};
     submit.commandBufferCount = 1; submit.pCommandBuffers = &command;
-    const bool submitted = fenced && vkQueueSubmit(ctx.queue, 1, &submit, fence) == VK_SUCCESS;
+    const bool submitted = fenced && render_locked_queue_submit(ctx.queue, 1, &submit, fence) == VK_SUCCESS;
     bool finished = submitted &&
         vkWaitForFences(ctx.dev, 1, &fence, VK_TRUE, 5ull * 1000 * 1000 * 1000) == VK_SUCCESS;
-    if (submitted && !finished) finished = vkQueueWaitIdle(ctx.queue) == VK_SUCCESS;
+    if (submitted && !finished) finished = render_locked_queue_wait_idle(ctx.queue) == VK_SUCCESS;
     if (fence) vkDestroyFence(ctx.dev, fence, nullptr);
     vkDestroyCommandPool(ctx.dev, pool, nullptr);
     if (!finished) { error = "persistent DS transfer did not complete"; return false; }
@@ -1678,10 +1697,10 @@ inline bool readback_persistent_color_target(uint64_t id, uint32_t width, uint32
         vkCreateFence(ctx.dev, &fence_info, nullptr, &fence) == VK_SUCCESS;
     VkSubmitInfo submit{VK_STRUCTURE_TYPE_SUBMIT_INFO};
     submit.commandBufferCount = 1; submit.pCommandBuffers = &command;
-    const bool submitted = fenced && vkQueueSubmit(ctx.queue, 1, &submit, fence) == VK_SUCCESS;
+    const bool submitted = fenced && render_locked_queue_submit(ctx.queue, 1, &submit, fence) == VK_SUCCESS;
     bool finished = submitted &&
         vkWaitForFences(ctx.dev, 1, &fence, VK_TRUE, 5ull * 1000 * 1000 * 1000) == VK_SUCCESS;
-    if (submitted && !finished) finished = vkQueueWaitIdle(ctx.queue) == VK_SUCCESS;
+    if (submitted && !finished) finished = render_locked_queue_wait_idle(ctx.queue) == VK_SUCCESS;
     if (!finished) {
         cleanup(); error = "persistent color target readback did not complete"; return false;
     }
@@ -4302,7 +4321,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                 vkCmdCopyImageToBuffer(c2, img, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, rb, 1, &cp2);
                 vkEndCommandBuffer(c2); vkResetFences(dev, 1, &iso_fence);
                 VkSubmitInfo si2{VK_STRUCTURE_TYPE_SUBMIT_INFO}; si2.commandBufferCount = 1; si2.pCommandBuffers = &c2;
-                vkQueueSubmit(queue, 1, &si2, iso_fence); vkWaitForFences(dev, 1, &iso_fence, VK_TRUE, 5ull * 1000 * 1000 * 1000);
+                render_locked_queue_submit(queue, 1, &si2, iso_fence); vkWaitForFences(dev, 1, &iso_fence, VK_TRUE, 5ull * 1000 * 1000 * 1000);
                 std::vector<uint8_t> px(bytes); void* m2 = nullptr; vkMapMemory(dev, bmem, 0, bytes, 0, &m2);
                 for (VkDeviceSize i = 0; i < bytes; i++) px[i] = ((const uint8_t*)m2)[i]; vkUnmapMemory(dev, bmem);
                 const uint8_t* tp = &px[((size_t)ty * W + tx) * 4];

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -747,9 +747,11 @@ inline const RenderVkCtx& render_vk_ctx() {
 }
 
 // Present unification (#1270): serialize a single queue CALL against prosper-app's present submits when
-// they share one VkQueue. Locks ONLY around the host call (never a GPU wait), and only once the app has
-// adopted the shared queue (shared_present_active()); otherwise it is a plain call after a relaxed atomic
-// load, so the headless/test/screenshot path and every non-shared device are unaffected.
+// they share one VkQueue, and only once the app has adopted the shared queue (shared_present_active());
+// otherwise it is a plain call after an acquire atomic load, so the headless/test/screenshot path and
+// every non-shared device are unaffected. vkQueueSubmit returns without waiting for GPU work; the
+// wait-idle wrapper (used only on the batch fence-timeout and compute-drain ERROR paths) does drain the
+// queue under the lock, which briefly blocks the peer thread's submits -- acceptable on those rare paths.
 inline VkResult render_locked_queue_submit(VkQueue q, uint32_t n, const VkSubmitInfo* s, VkFence f) {
     if (prosper::gpu::shared_present_active()) {
         std::lock_guard<std::mutex> lk(prosper::gpu::shared_present_submit_mutex());

--- a/prosper/tests/test_present_blit.cpp
+++ b/prosper/tests/test_present_blit.cpp
@@ -218,6 +218,77 @@ int main() {
            (unsigned long long)published.load(), (unsigned long long)consumed.load(),
            mismatches.load());
 
+    // #1270 Finding 3: the real front buffer can be R16G16B16A16_SFLOAT; present_blit converts it to the
+    // RGBA8 scanout format. Verify that conversion (including the HDR >1.0 clamp) with exactly-representable
+    // half values, single-threaded (the concurrent test above already covers the handoff mechanics).
+    {
+        const uint32_t rw = 32, rh = 16;
+        const size_t rsrcBytes = (size_t)rw * rh * 8, rdstBytes = (size_t)rw * rh * 4;
+        VkImage r16 = VK_NULL_HANDLE; VkDeviceMemory r16Mem = VK_NULL_HANDLE;
+        VkImageCreateInfo ici{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
+        ici.imageType = VK_IMAGE_TYPE_2D; ici.format = VK_FORMAT_R16G16B16A16_SFLOAT;
+        ici.extent = {rw, rh, 1}; ici.mipLevels = 1; ici.arrayLayers = 1;
+        ici.samples = VK_SAMPLE_COUNT_1_BIT; ici.tiling = VK_IMAGE_TILING_OPTIMAL;
+        ici.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+        ici.sharingMode = VK_SHARING_MODE_EXCLUSIVE; ici.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        vkCreateImage(ctx.dev, &ici, nullptr, &r16);
+        VkMemoryRequirements rq{}; vkGetImageMemoryRequirements(ctx.dev, r16, &rq);
+        VkMemoryAllocateInfo rmai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO}; rmai.allocationSize = rq.size;
+        rmai.memoryTypeIndex = mem_type(ctx.phys, rq.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+        vkAllocateMemory(ctx.dev, &rmai, nullptr, &r16Mem); vkBindImageMemory(ctx.dev, r16, r16Mem, 0);
+        auto hbuf = [&](VkDeviceSize sz, VkBufferUsageFlags u, VkBuffer& b, VkDeviceMemory& m, void** mp) {
+            VkBufferCreateInfo bci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
+            bci.size = sz; bci.usage = u; bci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+            vkCreateBuffer(ctx.dev, &bci, nullptr, &b);
+            VkMemoryRequirements q{}; vkGetBufferMemoryRequirements(ctx.dev, b, &q);
+            VkMemoryAllocateInfo a{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO}; a.allocationSize = q.size;
+            a.memoryTypeIndex = mem_type(ctx.phys, q.memoryTypeBits,
+                VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+            vkAllocateMemory(ctx.dev, &a, nullptr, &m); vkBindBufferMemory(ctx.dev, b, m, 0);
+            if (mp) vkMapMemory(ctx.dev, m, 0, sz, 0, mp);
+        };
+        VkBuffer rstage, rrb; VkDeviceMemory rstageMem, rrbMem; void* rstageMap = nullptr; void* rrbMap = nullptr;
+        hbuf(rsrcBytes, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, rstage, rstageMem, &rstageMap);
+        hbuf(rdstBytes, VK_BUFFER_USAGE_TRANSFER_DST_BIT, rrb, rrbMem, &rrbMap);
+        struct HCase { uint16_t half; uint8_t expect; };
+        const HCase cases[] = {{0x0000, 0}, {0x3C00, 255}, {0x4000, 255}};   // 0.0->0, 1.0->255, 2.0->255(clamp)
+        int r16_mismatches = 0; uint64_t seq = 1000;
+        for (const HCase& c : cases) {
+            uint16_t* pmap = (uint16_t*)rstageMap;
+            for (size_t i = 0; i < (size_t)rw * rh * 4; i++) pmap[i] = c.half;
+            VkCommandBufferBeginInfo bi{VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO};
+            bi.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+            vkResetCommandBuffer(prodCb, 0); vkBeginCommandBuffer(prodCb, &bi);
+            barrier(prodCb, r16, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                    0, VK_ACCESS_TRANSFER_WRITE_BIT, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT);
+            VkBufferImageCopy cp{}; cp.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1}; cp.imageExtent = {rw, rh, 1};
+            vkCmdCopyBufferToImage(prodCb, rstage, r16, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &cp);
+            barrier(prodCb, r16, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+                    VK_ACCESS_TRANSFER_WRITE_BIT, VK_ACCESS_SHADER_READ_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
+            vkEndCommandBuffer(prodCb); locked_submit_wait(ctx, prodCb, prodFence);
+            CHECK(frontend::present_blit_publish(r16, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+                    VK_FORMAT_R16G16B16A16_SFLOAT, rw, rh, seq++), "R16F publish succeeded");
+            frontend::GpuScanoutFrame gf; bool acq = false;
+            for (int t = 0; t < 1000 && !acq; t++) { acq = frontend::present_blit_acquire(gf); if (!acq) std::this_thread::yield(); }
+            CHECK(acq, "R16F acquire succeeded");
+            if (acq) {
+                vkResetCommandBuffer(prodCb, 0); vkBeginCommandBuffer(prodCb, &bi);
+                VkBufferImageCopy cp2{}; cp2.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1}; cp2.imageExtent = {rw, rh, 1};
+                vkCmdCopyImageToBuffer(prodCb, gf.image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, rrb, 1, &cp2);
+                vkEndCommandBuffer(prodCb); locked_submit_wait(ctx, prodCb, prodFence);
+                const uint8_t* out = (const uint8_t*)rrbMap;
+                for (size_t i = 0; i < rdstBytes; i++) if (out[i] != c.expect) { r16_mismatches++; break; }
+                frontend::present_blit_release(gf.slot);
+            }
+        }
+        CHECK(r16_mismatches == 0, "R16G16B16A16_SFLOAT source converts + clamps to the expected RGBA8");
+        printf("test_present_blit: r16f_conversion mismatches=%d\n", r16_mismatches);
+        vkDeviceWaitIdle(ctx.dev);
+        vkDestroyBuffer(ctx.dev, rstage, nullptr); vkFreeMemory(ctx.dev, rstageMem, nullptr);
+        vkDestroyBuffer(ctx.dev, rrb, nullptr); vkFreeMemory(ctx.dev, rrbMem, nullptr);
+        vkDestroyImage(ctx.dev, r16, nullptr); vkFreeMemory(ctx.dev, r16Mem, nullptr);
+    }
+
     vkDeviceWaitIdle(ctx.dev);
     frontend::present_blit_reset();
     gpu::set_shared_present_active(false);

--- a/prosper/tests/test_present_blit.cpp
+++ b/prosper/tests/test_present_blit.cpp
@@ -289,6 +289,82 @@ int main() {
         vkDestroyImage(ctx.dev, r16, nullptr); vkFreeMemory(ctx.dev, r16Mem, nullptr);
     }
 
+    // #1270 Finding 1 (direct guard): an ACQUIRED (in-flight) slot's image must survive a different-size
+    // publish. The resize UAF this replaces would free the held image here. Publish+acquire frame A at
+    // WxH; publish several frames at a DIFFERENT size (which recreate OTHER free slots); the held image
+    // must still be valid and still contain A's pixels.
+    {
+        const uint32_t w2 = 48, h2 = 27;
+        const size_t bytes2 = (size_t)w2 * h2 * 4;
+        VkImage src2 = VK_NULL_HANDLE; VkDeviceMemory src2Mem = VK_NULL_HANDLE;
+        { VkImageCreateInfo ici{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
+          ici.imageType = VK_IMAGE_TYPE_2D; ici.format = VK_FORMAT_R8G8B8A8_UNORM; ici.extent = {w2, h2, 1};
+          ici.mipLevels = 1; ici.arrayLayers = 1; ici.samples = VK_SAMPLE_COUNT_1_BIT;
+          ici.tiling = VK_IMAGE_TILING_OPTIMAL;
+          ici.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+          ici.sharingMode = VK_SHARING_MODE_EXCLUSIVE; ici.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+          vkCreateImage(ctx.dev, &ici, nullptr, &src2);
+          VkMemoryRequirements q{}; vkGetImageMemoryRequirements(ctx.dev, src2, &q);
+          VkMemoryAllocateInfo a{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO}; a.allocationSize = q.size;
+          a.memoryTypeIndex = mem_type(ctx.phys, q.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+          vkAllocateMemory(ctx.dev, &a, nullptr, &src2Mem); vkBindImageMemory(ctx.dev, src2, src2Mem, 0); }
+        VkBuffer st2, rbA; VkDeviceMemory st2Mem, rbAMem; void* st2Map = nullptr; void* rbAMap = nullptr;
+        auto hbuf2 = [&](VkDeviceSize sz, VkBufferUsageFlags u, VkBuffer& b, VkDeviceMemory& m, void** mp) {
+            VkBufferCreateInfo bci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
+            bci.size = sz; bci.usage = u; bci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+            vkCreateBuffer(ctx.dev, &bci, nullptr, &b);
+            VkMemoryRequirements q{}; vkGetBufferMemoryRequirements(ctx.dev, b, &q);
+            VkMemoryAllocateInfo a{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO}; a.allocationSize = q.size;
+            a.memoryTypeIndex = mem_type(ctx.phys, q.memoryTypeBits,
+                VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+            vkAllocateMemory(ctx.dev, &a, nullptr, &m); vkBindBufferMemory(ctx.dev, b, m, 0);
+            if (mp) vkMapMemory(ctx.dev, m, 0, sz, 0, mp);
+        };
+        hbuf2(bytes2, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, st2, st2Mem, &st2Map);
+        hbuf2((size_t)W * H * 4, VK_BUFFER_USAGE_TRANSFER_DST_BIT, rbA, rbAMem, &rbAMap);
+        auto upload_and_publish = [&](VkImage img, VkBuffer stg, void* stgMap, uint32_t iw, uint32_t ih,
+                                      uint64_t seq) -> bool {
+            fill_pattern((uint8_t*)stgMap, iw, ih, seq);
+            VkCommandBufferBeginInfo bi{VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO};
+            bi.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+            vkResetCommandBuffer(prodCb, 0); vkBeginCommandBuffer(prodCb, &bi);
+            barrier(prodCb, img, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                    0, VK_ACCESS_TRANSFER_WRITE_BIT, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT);
+            VkBufferImageCopy cp{}; cp.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1}; cp.imageExtent = {iw, ih, 1};
+            vkCmdCopyBufferToImage(prodCb, stg, img, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &cp);
+            barrier(prodCb, img, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+                    VK_ACCESS_TRANSFER_WRITE_BIT, VK_ACCESS_SHADER_READ_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
+            vkEndCommandBuffer(prodCb); locked_submit_wait(ctx, prodCb, prodFence);
+            return frontend::present_blit_publish(img, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+                    VK_FORMAT_R8G8B8A8_UNORM, iw, ih, seq);
+        };
+        // Frame A at WxH; hold it.
+        CHECK(upload_and_publish(src, stage, stageMap, W, H, 777), "held-slot: publish A (WxH)");
+        frontend::GpuScanoutFrame gfA; bool gotA = false;
+        for (int t = 0; t < 1000 && !gotA; t++) { gotA = frontend::present_blit_acquire(gfA); if (!gotA) std::this_thread::yield(); }
+        CHECK(gotA && gfA.width == W && gfA.height == H, "held-slot: acquire A");
+        // Publish several DIFFERENT-size frames; these recreate other free slots, never the held one.
+        for (uint64_t k = 0; k < 4; k++) upload_and_publish(src2, st2, st2Map, w2, h2, 800 + k);
+        // The held image must still be valid AND still contain A's pixels.
+        int held_mismatch = 1;
+        if (gotA) {
+            VkCommandBufferBeginInfo bi{VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO};
+            bi.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+            vkResetCommandBuffer(consCb, 0); vkBeginCommandBuffer(consCb, &bi);
+            VkBufferImageCopy cp{}; cp.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1}; cp.imageExtent = {W, H, 1};
+            vkCmdCopyImageToBuffer(consCb, gfA.image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, rbA, 1, &cp);
+            vkEndCommandBuffer(consCb); locked_submit_wait(ctx, consCb, consFence);
+            std::vector<uint8_t> expA((size_t)W * H * 4); fill_pattern(expA.data(), W, H, 777);
+            held_mismatch = memcmp(rbAMap, expA.data(), expA.size()) != 0 ? 1 : 0;
+            frontend::present_blit_release(gfA.slot);
+        }
+        CHECK(held_mismatch == 0, "held-slot: acquired image survives a different-size publish, content intact");
+        vkDeviceWaitIdle(ctx.dev);
+        vkDestroyBuffer(ctx.dev, st2, nullptr); vkFreeMemory(ctx.dev, st2Mem, nullptr);
+        vkDestroyBuffer(ctx.dev, rbA, nullptr); vkFreeMemory(ctx.dev, rbAMem, nullptr);
+        vkDestroyImage(ctx.dev, src2, nullptr); vkFreeMemory(ctx.dev, src2Mem, nullptr);
+    }
+
     vkDeviceWaitIdle(ctx.dev);
     frontend::present_blit_reset();
     gpu::set_shared_present_active(false);

--- a/prosper/tests/test_present_blit.cpp
+++ b/prosper/tests/test_present_blit.cpp
@@ -1,0 +1,231 @@
+// test_present_blit — the GPU scanout handoff (#1270) must reproduce the source front-buffer pixels
+// EXACTLY, under a concurrent producer/consumer on the shared render queue.
+//
+// A producer thread fills a source image with a per-frame, spatially-varied pattern and calls
+// present_blit_publish (the renderer's role: front image -> scanout slot). A consumer thread acquires the
+// published scanout image and copies it to a host-visible buffer (standing in for the app's swapchain
+// blit), then asserts every pixel equals the pattern for that frame. This validates: (a) blit fidelity --
+// the scanout image is a byte-exact copy of the front buffer, so GPU-present == the CPU readback path; and
+// (b) the slot handoff -- with fence-gated publish and release, the consumer never reads a half-written or
+// reused image even while the producer runs ahead. Run it under VK_LAYER_KHRONOS_validation in CI to catch
+// sync/layout hazards. No window/surface is needed, so it runs headlessly.
+#include "render_runner.h"
+#include "../frontends/shared/live_renderer.hpp"
+#include "../frontends/shared/present_blit.hpp"
+#include "../src/gpu/gpu_execute.hpp"
+#include <atomic>
+#include <cstdint>
+#include <cstdio>
+#include <thread>
+#include <vector>
+
+using namespace prosper;
+
+namespace {
+constexpr uint32_t W = 96, H = 54;
+constexpr uint64_t FRAMES = 48;
+
+int fails = 0;
+#define CHECK(cond, msg) do { if (!(cond)) { printf("  [FAIL] %s\n", msg); fails++; } } while (0)
+
+// The per-frame source pattern (spatially varied + frame-varied so a torn/stale/reused frame is visible).
+inline void fill_pattern(uint8_t* p, uint32_t w, uint32_t h, uint64_t seq) {
+    for (uint32_t y = 0; y < h; y++)
+        for (uint32_t x = 0; x < w; x++) {
+            uint8_t* px = p + ((size_t)y * w + x) * 4;
+            px[0] = (uint8_t)((x + seq) & 0xFF);
+            px[1] = (uint8_t)((y * 3 + seq) & 0xFF);
+            px[2] = (uint8_t)((seq * 5) & 0xFF);
+            px[3] = 255;
+        }
+}
+
+uint32_t mem_type(VkPhysicalDevice phys, uint32_t bits, VkMemoryPropertyFlags want) {
+    VkPhysicalDeviceMemoryProperties mp{}; vkGetPhysicalDeviceMemoryProperties(phys, &mp);
+    for (uint32_t i = 0; i < mp.memoryTypeCount; i++)
+        if ((bits & (1u << i)) && (mp.memoryTypes[i].propertyFlags & want) == want) return i;
+    return UINT32_MAX;
+}
+
+// Submit one command buffer on the shared render queue and wait its fence, holding the shared present
+// submit mutex around the CALL exactly as the real renderer/app do.
+VkResult locked_submit_wait(const test::RenderVkCtx& ctx, VkCommandBuffer cb, VkFence fence) {
+    VkSubmitInfo si{VK_STRUCTURE_TYPE_SUBMIT_INFO};
+    si.commandBufferCount = 1; si.pCommandBuffers = &cb;
+    vkResetFences(ctx.dev, 1, &fence);
+    VkResult sr;
+    {
+        std::unique_lock<std::mutex> lk(gpu::shared_present_submit_mutex(), std::defer_lock);
+        if (gpu::shared_present_active()) lk.lock();
+        sr = vkQueueSubmit(ctx.queue, 1, &si, fence);
+    }
+    if (sr != VK_SUCCESS) return sr;
+    return vkWaitForFences(ctx.dev, 1, &fence, VK_TRUE, 5ull * 1000 * 1000 * 1000);
+}
+
+void barrier(VkCommandBuffer cb, VkImage img, VkImageLayout from, VkImageLayout to,
+             VkAccessFlags sa, VkAccessFlags da, VkPipelineStageFlags ss, VkPipelineStageFlags ds) {
+    VkImageMemoryBarrier b{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
+    b.oldLayout = from; b.newLayout = to;
+    b.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED; b.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    b.image = img; b.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+    b.srcAccessMask = sa; b.dstAccessMask = da;
+    vkCmdPipelineBarrier(cb, ss, ds, 0, 0, nullptr, 0, nullptr, 1, &b);
+}
+} // namespace
+
+int main() {
+    frontend::register_live_renderer(std::string(), false);
+    const test::RenderVkCtx& ctx = test::render_vk_ctx();
+    if (!ctx.ok) { printf("test_present_blit: no Vulkan device, skipping\n"); return 0; }
+
+    gpu::set_shared_present_active(true);   // exercise the shared-queue submit-mutex path
+
+    const size_t bytes = (size_t)W * H * 4;
+
+    // Producer resources: a source image (front-buffer stand-in) + a host-visible staging buffer to fill it.
+    VkImage src = VK_NULL_HANDLE; VkDeviceMemory srcMem = VK_NULL_HANDLE;
+    {
+        VkImageCreateInfo ici{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
+        ici.imageType = VK_IMAGE_TYPE_2D; ici.format = VK_FORMAT_R8G8B8A8_UNORM;
+        ici.extent = {W, H, 1}; ici.mipLevels = 1; ici.arrayLayers = 1;
+        ici.samples = VK_SAMPLE_COUNT_1_BIT; ici.tiling = VK_IMAGE_TILING_OPTIMAL;
+        ici.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+        ici.sharingMode = VK_SHARING_MODE_EXCLUSIVE; ici.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        CHECK(vkCreateImage(ctx.dev, &ici, nullptr, &src) == VK_SUCCESS, "create source image");
+        VkMemoryRequirements req{}; vkGetImageMemoryRequirements(ctx.dev, src, &req);
+        VkMemoryAllocateInfo mai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO};
+        mai.allocationSize = req.size;
+        mai.memoryTypeIndex = mem_type(ctx.phys, req.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+        CHECK(vkAllocateMemory(ctx.dev, &mai, nullptr, &srcMem) == VK_SUCCESS, "alloc source image");
+        vkBindImageMemory(ctx.dev, src, srcMem, 0);
+    }
+    auto make_host_buffer = [&](VkBufferUsageFlags usage, VkBuffer& buf, VkDeviceMemory& mem, void** map) {
+        VkBufferCreateInfo bci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
+        bci.size = bytes; bci.usage = usage; bci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+        vkCreateBuffer(ctx.dev, &bci, nullptr, &buf);
+        VkMemoryRequirements req{}; vkGetBufferMemoryRequirements(ctx.dev, buf, &req);
+        VkMemoryAllocateInfo mai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO};
+        mai.allocationSize = req.size;
+        mai.memoryTypeIndex = mem_type(ctx.phys, req.memoryTypeBits,
+            VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+        vkAllocateMemory(ctx.dev, &mai, nullptr, &mem);
+        vkBindBufferMemory(ctx.dev, buf, mem, 0);
+        if (map) vkMapMemory(ctx.dev, mem, 0, bytes, 0, map);
+    };
+    VkBuffer stage = VK_NULL_HANDLE; VkDeviceMemory stageMem = VK_NULL_HANDLE; void* stageMap = nullptr;
+    make_host_buffer(VK_BUFFER_USAGE_TRANSFER_SRC_BIT, stage, stageMem, &stageMap);
+
+    // Per-thread command pools (pools are externally synchronized -> one per submitting thread).
+    auto make_pool = [&](VkCommandPool& pool, VkCommandBuffer& cb) {
+        VkCommandPoolCreateInfo pci{VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO};
+        pci.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT; pci.queueFamilyIndex = ctx.qfi;
+        vkCreateCommandPool(ctx.dev, &pci, nullptr, &pool);
+        VkCommandBufferAllocateInfo ai{VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO};
+        ai.commandPool = pool; ai.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY; ai.commandBufferCount = 1;
+        vkAllocateCommandBuffers(ctx.dev, &ai, &cb);
+    };
+    VkCommandPool prodPool, consPool; VkCommandBuffer prodCb, consCb;
+    make_pool(prodPool, prodCb); make_pool(consPool, consCb);
+    VkFence prodFence, consFence;
+    { VkFenceCreateInfo fci{VK_STRUCTURE_TYPE_FENCE_CREATE_INFO};
+      vkCreateFence(ctx.dev, &fci, nullptr, &prodFence);
+      vkCreateFence(ctx.dev, &fci, nullptr, &consFence); }
+
+    std::atomic<bool> producer_done{false};
+    std::atomic<uint64_t> published{0};
+    std::atomic<uint64_t> consumed{0};
+    std::atomic<int> mismatches{0};
+    std::atomic<uint64_t> last_frame_seq{~0ull};
+
+    // Producer (renderer role): fill src with pattern(seq), transition it to SHADER_READ_ONLY (front-buffer
+    // layout), then publish. present_blit_publish fence-waits its blit, so src is free to refill afterward.
+    std::thread producer([&] {
+        for (uint64_t seq = 0; seq < FRAMES; seq++) {
+            fill_pattern((uint8_t*)stageMap, W, H, seq);
+            vkResetCommandBuffer(prodCb, 0);
+            VkCommandBufferBeginInfo bi{VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO};
+            bi.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+            vkBeginCommandBuffer(prodCb, &bi);
+            barrier(prodCb, src, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                    0, VK_ACCESS_TRANSFER_WRITE_BIT,
+                    VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT);
+            VkBufferImageCopy cp{}; cp.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+            cp.imageExtent = {W, H, 1};
+            vkCmdCopyBufferToImage(prodCb, stage, src, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &cp);
+            barrier(prodCb, src, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                    VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+                    VK_ACCESS_TRANSFER_WRITE_BIT, VK_ACCESS_SHADER_READ_BIT,
+                    VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
+            vkEndCommandBuffer(prodCb);
+            locked_submit_wait(ctx, prodCb, prodFence);
+
+            // Retry publish a few times if the consumer is momentarily behind (no free slot).
+            bool ok = false;
+            for (int tries = 0; tries < 1000 && !ok; tries++) {
+                ok = frontend::present_blit_publish(src, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+                                                    VK_FORMAT_R8G8B8A8_UNORM, W, H, seq);
+                if (!ok) std::this_thread::yield();
+            }
+            if (ok) published.fetch_add(1);
+        }
+        producer_done.store(true);
+    });
+
+    // Consumer (app role): acquire the latest scanout image, copy it to a host buffer, verify the pixels
+    // equal the pattern for that frame_seq, then release the slot.
+    std::thread consumer([&] {
+        VkBuffer rb = VK_NULL_HANDLE; VkDeviceMemory rbMem = VK_NULL_HANDLE; void* rbMap = nullptr;
+        make_host_buffer(VK_BUFFER_USAGE_TRANSFER_DST_BIT, rb, rbMem, &rbMap);
+        std::vector<uint8_t> expected(bytes);
+        // Drain until the producer is done AND no newer frame is available. The consumer legitimately
+        // SKIPS superseded frames (the renderer runs ahead), so it must not wait for consumed==published.
+        while (true) {
+            frontend::GpuScanoutFrame f;
+            if (!frontend::present_blit_acquire(f)) {
+                if (producer_done.load()) break;
+                std::this_thread::yield();
+                continue;
+            }
+            if (last_frame_seq.load() == f.frame_seq) { frontend::present_blit_release(f.slot); continue; }
+            last_frame_seq.store(f.frame_seq);
+
+            vkResetCommandBuffer(consCb, 0);
+            VkCommandBufferBeginInfo bi{VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO};
+            bi.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+            vkBeginCommandBuffer(consCb, &bi);
+            VkBufferImageCopy cp{}; cp.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+            cp.imageExtent = {W, H, 1};
+            vkCmdCopyImageToBuffer(consCb, f.image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, rb, 1, &cp);
+            vkEndCommandBuffer(consCb);
+            locked_submit_wait(ctx, consCb, consFence);
+
+            fill_pattern(expected.data(), W, H, f.frame_seq);
+            if (memcmp(rbMap, expected.data(), bytes) != 0) mismatches.fetch_add(1);
+            consumed.fetch_add(1);
+            frontend::present_blit_release(f.slot);
+        }
+        vkDestroyBuffer(ctx.dev, rb, nullptr); vkFreeMemory(ctx.dev, rbMem, nullptr);
+    });
+
+    producer.join();
+    consumer.join();
+
+    CHECK(published.load() == FRAMES, "producer published every frame");
+    CHECK(consumed.load() >= 1, "consumer observed at least one frame");
+    CHECK(mismatches.load() == 0, "every consumed scanout image is a byte-exact copy of its source");
+    printf("test_present_blit: published=%llu consumed=%llu mismatches=%d\n",
+           (unsigned long long)published.load(), (unsigned long long)consumed.load(),
+           mismatches.load());
+
+    vkDeviceWaitIdle(ctx.dev);
+    frontend::present_blit_reset();
+    gpu::set_shared_present_active(false);
+    vkDestroyFence(ctx.dev, prodFence, nullptr); vkDestroyFence(ctx.dev, consFence, nullptr);
+    vkDestroyCommandPool(ctx.dev, prodPool, nullptr); vkDestroyCommandPool(ctx.dev, consPool, nullptr);
+    vkDestroyBuffer(ctx.dev, stage, nullptr); vkFreeMemory(ctx.dev, stageMem, nullptr);
+    vkDestroyImage(ctx.dev, src, nullptr); vkFreeMemory(ctx.dev, srcMem, nullptr);
+
+    printf(fails ? "test_present_blit: %d FAILURE(S)\n" : "test_present_blit: all ok\n", fails);
+    return fails ? 1 : 0;
+}

--- a/prosper/tests/test_shared_vulkan_device.cpp
+++ b/prosper/tests/test_shared_vulkan_device.cpp
@@ -65,6 +65,34 @@ int main() {
           (props[shared.queue_family].queueFlags & VK_QUEUE_COMPUTE_BIT) != 0,
           "published queue family supports COMPUTE (dispatches are legal on it)");
 
+    // Present unification (#1270): the published present-capability must exactly mirror what the device
+    // was actually created with. present_capable requires BOTH a surface-capable instance AND the
+    // swapchain device-extension AND a resolved present queue. On a headless target (no display, no
+    // platform surface extension advertised) all three are false and prosper-app falls back to its own
+    // separate present device -- so this assertion also proves the headless path is preserved.
+    CHECK(shared.present_capable ==
+              (ctx.present_surface_capable && ctx.present_swapchain_capable &&
+               ctx.present_queue != VK_NULL_HANDLE),
+          "published present_capable mirrors the surface+swapchain+queue the device was created with");
+    CHECK(!ctx.present_swapchain_capable || ctx.present_surface_capable,
+          "swapchain is never enabled without a surface-capable instance");
+    // The present queue is a dedicated 2nd queue when the family exposes >=2, else it shares queue 0
+    // (RADV STRIX_HALO is queueCount==1). Either way it must be a queue of the SAME family (no ownership
+    // transfers on the front-buffer blit), and the shared flag must agree with the queue identity.
+    if (shared.present_capable) {
+        CHECK(shared.present_queue != nullptr, "present-capable context publishes a non-null present queue");
+        const bool one_queue = props[shared.queue_family].queueCount < 2;
+        CHECK(shared.present_queue_shared == one_queue,
+              "present_queue_shared iff the graphics family has a single queue");
+        CHECK(!shared.present_queue_shared || shared.present_queue == shared.queue,
+              "a shared present queue aliases the render queue (submits will serialize via a mutex)");
+        CHECK(shared.present_queue_shared || shared.present_queue != shared.queue,
+              "a dedicated present queue is distinct from the render queue");
+    } else {
+        CHECK(shared.present_queue == nullptr && !shared.present_queue_shared,
+              "a non-present-capable context publishes no present queue (headless fallback path)");
+    }
+
     printf(fails ? "test_shared_vulkan_device: %d FAILURE(S)\n"
                  : "test_shared_vulkan_device: all ok\n", fails);
     return fails ? 1 : 0;


### PR DESCRIPTION
## Summary

Fixes #1270. Lets **prosper-app present the renderer's front-buffer image via a GPU→swapchain blit** instead of reading it back to CPU and re-uploading it — eliminating a **4K CPU round-trip on every present**. Opt-in behind `PROSPER_APP_GPU_PRESENT` (default OFF); the default and every headless/test/screenshot path is byte-for-byte unchanged.

## Failure scenario / motivation (see #1265)

Profiling GTA V's 4K present cost showed the shared `live_renderer` reads the front-buffer GPU image back to CPU (`present_write_frame`) and both frontends re-upload it (`prosper-app` → staging → swapchain blit). At 4K that's ~3 ms readback + ~2 ms re-upload **per present**, and it scales with resolution — dead weight on heavier 3D frames. The obstruction: the app's swapchain device and the renderer's persistent-image device were **separate `VkDevice`s by design**. This PR unifies them so a direct `vkCmdBlitImage(front image → swapchain)` is possible.

## Approach (staged; one commit per stage)

1. **`54035f1d` — present-capable render device.** `render_vk_ctx()` enables the WSI surface instance-extensions + `VK_KHR_swapchain` + a dedicated-or-shared present queue *when advertised* (add-if-available), and publishes `present_capable`/`present_queue`/`present_queue_shared` in `SharedVulkanContext`.
2. **`a5f4bb79` — shared-queue submit mutex.** RADV exposes one graphics queue, so the app shares queue 0 with the renderer. `shared_present_submit_mutex()` serializes every guest-thread shared-queue submit CALL (backend batch, both readback/direct paths, the per-draw isolation diagnostic, and the compute dispatch submit/drain) against the app's present submits. Locks only the host call, never a GPU wait.
3. **`51acfa61` — `present_blit` scanout handoff.** A triple-buffered producer/consumer: `present_blit_publish()` blits the front image into a free slot and fence-waits it; `present_blit_acquire()/release()` hand it to the app and reclaim it after the app's read fence. **No cross-thread semaphore** — a slot is acquirable only after its blit completed, and reusable only after the consumer released it.
4. **`ca4b079b` — renderer publish + readback skip.** When `gpu_present_active()`, the present path publishes the front image and skips the CPU readback; a miss falls through to the CPU path (never a black present).
5. **`3e2dbaf0` — app consumer.** `try_adopt_shared_present()` adopts the shared device (or falls back to a private device at any unmet precondition); `present_frame_gpu()` blits the acquired scanout image to the swapchain.

## Key invariants

- **OFF-path is dead code.** `gpu_present_active()`/`shared_present_active()` are process-global atomics set only by `prosper-app` after a successful adoption. No test/screenshot process sets them, so the renderer's CPU present path, the submit sites, and device creation are unchanged there.
- Everything is on **one `VkDevice`** — no external memory, no queue-family ownership transfers.
- A booted guest exits via `std::_Exit`, so the app never destroys the shared device.

## Affected / deliberately unaffected

- **Affected (ON only):** `prosper-app` present path when `PROSPER_APP_GPU_PRESENT=1` on a real boot with a display.
- **Unaffected:** default `prosper-app` boot, `screenshot`, all ctests, snapshot routes, headless/llvmpipe CI (no surface extensions → `present_capable=false` → CPU path), the compute shared-device adoption.

## Risks

- The **ON path cannot be validated in a headless container** (no display) — it needs an interactive `PROSPER_APP_GPU_PRESENT=1` run on a display host, and a Vulkan-validation-layer pass (the layer is absent here).
- Cross-thread queue sharing on a single-queue GPU; resize drains the shared device. See the in-code comments and the review thread.

## Verification (exact commands + results, RADV STRIX_HALO)

- `cmake --build build-linux -j8` — clean.
- `ctest` — **144/144 green** (includes the new `present_blit` concurrency test).
- `test_present_blit` — concurrent producer/consumer, **48 published / 43 consumed / 0 mismatches** (scanout image byte-exact vs source; validates the handoff has no tearing/reuse hazard, headlessly).
- `python3 tools/snapshot/snapshot.py check` — **5/5 OK** (messenger, evergate, dead-cells, blasphemous2, terminator) → OFF-path render output byte-identical.

**Not progression evidence:** this is an infra present-path change; the OFF path renders identically and the ON path's visible output needs interactive validation on a display host (attach captures there).

## Merge gating

Do **not** merge until: (a) the detailed independent review is clean, (b) an interactive `PROSPER_APP_GPU_PRESENT=1` run on a display host confirms correct output + the readback removal, and (c) a Vulkan-validation-layer pass is clean.
