### PR TITLE
fix(gpu): upload T#-declared mip chains via a GPU blit cascade (#1272)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -944,6 +944,11 @@ if(TARGET prosper_core)
       target_link_libraries(test_shadow_compare_render PRIVATE prosper_core Vulkan::Vulkan)
       add_test(NAME shadow_compare_render COMMAND test_shadow_compare_render)
 
+      # Generated mip chains bounded by the T#'s declared levels (#1272), end-to-end.
+      add_executable(test_texture_mip_render tests/test_texture_mip_render.cpp)
+      target_link_libraries(test_texture_mip_render PRIVATE prosper_core Vulkan::Vulkan)
+      add_test(NAME texture_mip_render COMMAND test_texture_mip_render)
+
       # Pipeline realization: build a VkPipeline whose fixed-function state comes from
       # resolve_pipeline_state(RenderState) and prove the resolved state drives rendering.
       add_executable(test_pipeline_render tests/test_pipeline_render.cpp)

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -1150,6 +1150,11 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             fr.th = decoded_reuse->output_height;
                             fr.td = is_volume ? r.depth : 1u;
                             fr.img_dim = r.img_dim;
+                            // #1272: plain 2D guest textures only — cube outputs stack 6 faces into
+                            // one 2D image (fr.th != th), and volumes keep their own path; generated
+                            // mips across face/slice boundaries would bleed.
+                            if (!is_volume && fr.th == th)
+                                fr.declared_mip_levels = r.declared_mip_levels;
                             narrow_done = decoded_reuse->narrow;
                             fr.persistent_texture_id = decoded_reuse->persistent_id;
                             decoded_textures.emplace(
@@ -1845,6 +1850,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         fr.tex_rgba = texture_pixels.data(); fr.tw = tw; fr.th = cube_done ? th * 6u : th;
                         fr.td = is_volume ? r.depth : 1u;
                         fr.img_dim = r.img_dim;
+                        // #1272: see the reuse path — plain 2D guest textures only.
+                        if (!is_volume && !cube_done)
+                            fr.declared_mip_levels = r.declared_mip_levels;
                         if (persistent_cache_eligible) {
                             size_t source_prefix_size = linear_source_prefix_size;
                             if (!persistent_source_matches_pixels) {

--- a/prosper/src/gpu/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc_shader_layout.cpp
@@ -694,6 +694,8 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
             r.width         = view.width;
             r.height        = view.height;
             r.depth         = d.depth;
+            r.declared_mip_levels =
+                d.last_level >= d.base_level ? (uint32_t)(d.last_level - d.base_level) + 1u : 1u;
             r.tile_mode     = d.tile_mode;          // so the renderer can auto-detile a GPU-tiled surface
             r.in_mip_tail   = view.in_mip_tail;
             r.mip_tail_offset = view.in_mip_tail

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -2534,6 +2534,8 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
                     r.cls = ResourceClass::Texture;
                     r.format = fi.format; r.num_components = fi.num_components;
                     r.gpu_addr = view.base; r.width = view.width; r.height = view.height; r.depth = d.depth;
+                    r.declared_mip_levels =
+                        d.last_level >= d.base_level ? (uint32_t)(d.last_level - d.base_level) + 1u : 1u;
                     r.tile_mode = d.tile_mode; r.srgb = fi.srgb;
                     r.in_mip_tail = view.in_mip_tail;
                     r.mip_tail_offset = view.in_mip_tail
@@ -2882,6 +2884,8 @@ std::vector<ComputeItem> realize_compute_dispatches(
                     }
                     r.gpu_addr = view.base; r.width = view.width; r.height = view.height; r.depth = d.depth;
                     r.tile_mode = d.tile_mode;
+                    r.declared_mip_levels =
+                        d.last_level >= d.base_level ? (uint32_t)(d.last_level - d.base_level) + 1u : 1u;
                     r.in_mip_tail = view.in_mip_tail;
                     r.mip_tail_offset = view.in_mip_tail
                         ? static_cast<uint32_t>(view.mip_offset) : 0;

--- a/prosper/src/gpu/shader_resources.hpp
+++ b/prosper/src/gpu/shader_resources.hpp
@@ -144,6 +144,10 @@ struct ShaderResource {
     uint32_t      tile_mode         = 0;                  // T# GFX10 TileMode; drives auto-detile of a sampled surface
     // A packed mip-tail view shares the allocation's first 4/64 KiB block. gpu_addr remains the
     // shared block base; the backend applies mip_tail_offset and preserves sibling levels on writes.
+    // T#-declared mip-chain length relative to the selected base level (last_level - base_level + 1,
+    // WORD3 [19:16]/[15:12]). 1 = single level (the historical behavior). The backend uses this to
+    // bound generated-mip uploads (#1272) — it never invents levels a T# does not declare.
+    uint32_t      declared_mip_levels = 1;
     bool          in_mip_tail       = false;
     uint32_t      mip_tail_offset   = 0;
     uint32_t      mip_tail_bytes    = 0;

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -96,6 +96,10 @@ struct FrameResource {
     bool is_internal_gds = false;
     const uint8_t* tex_rgba = nullptr;   // non-null => a texture; then tw/th are its dimensions
     uint32_t tw = 0, th = 0, td = 1;
+    // T#-declared mip-chain length (#1272). 1 (default) = single-level upload, the historical
+    // behavior. >1 lets the backend generate a box-filtered chain — bounded by this declared count —
+    // for plain-2D RGBA8 sampled textures, so minification stops point-sampling through dense art.
+    uint32_t declared_mip_levels = 1;
     uint32_t img_dim = 1;             // ShaderResource/MIMG dim (1=2D, 2=3D); depth-1 3D stays 3D
     // Renderer-owned RTTs keep their native format between producer and consumer. Guest-backed
     // textures still arrive through the existing RGBA8 decoder unless explicitly tagged otherwise.
@@ -2129,13 +2133,14 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         uint64_t render_target_id = 0;
         uint32_t width = 0, height = 0, depth = 1;
         uint32_t img_dim = 1;
+        uint32_t mip_levels = 1;   // effective uploaded chain length (#1272)
         VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
         bool storage_image = false;
         bool operator==(const TextureUploadKey& other) const {
             return pixels == other.pixels && render_target_id == other.render_target_id &&
                    width == other.width && height == other.height && depth == other.depth &&
-                   img_dim == other.img_dim && format == other.format &&
-                   storage_image == other.storage_image;
+                   img_dim == other.img_dim && mip_levels == other.mip_levels &&
+                   format == other.format && storage_image == other.storage_image;
         }
     };
     struct TextureUploadKeyHash {
@@ -2146,6 +2151,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
             h ^= static_cast<size_t>(key.height) + 0x9e3779b9u + (h << 6) + (h >> 2);
             h ^= static_cast<size_t>(key.depth) + 0x9e3779b9u + (h << 6) + (h >> 2);
             h ^= static_cast<size_t>(key.img_dim) + 0x9e3779b9u + (h << 6) + (h >> 2);
+            h ^= static_cast<size_t>(key.mip_levels) + 0x9e3779b9u + (h << 6) + (h >> 2);
             h ^= static_cast<size_t>(key.format) + 0x9e3779b9u + (h << 6) + (h >> 2);
             h ^= static_cast<size_t>(key.storage_image) + 0x9e3779b9u + (h << 6) + (h >> 2);
             return h;
@@ -2166,6 +2172,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     struct PersistentTextureKey {
         uint64_t id = 0;
         uint32_t width = 0, height = 0, depth = 1, img_dim = 1;
+        uint32_t mip_levels = 1;   // a cached image must match the requested chain length (#1272)
         VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
         bool operator==(const PersistentTextureKey&) const = default;
     };
@@ -2176,6 +2183,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                 h ^= static_cast<size_t>(value) + 0x9e3779b9u + (h << 6) + (h >> 2);
             };
             mix(key.width); mix(key.height); mix(key.depth); mix(key.img_dim);
+            mix(key.mip_levels);
             mix(static_cast<uint32_t>(key.format));
             return h;
         }
@@ -2728,9 +2736,27 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                         ? (VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT)
                         : VK_SHADER_STAGE_FRAGMENT_BIT;
                     texture_references++;
+                    // #1272: effective generated-mip chain — bounded by the chain the T# itself
+                    // declares (declared_mip_levels; 1 = historical single-level behavior), and
+                    // restricted to plain-2D RGBA8 sampled guest textures. Cube/volume stacks,
+                    // storage images, RTT-backed bindings, and other formats keep one level.
+                    uint32_t tex_mip_levels = 1;
+                    if (!r.is_storage_image && r.img_dim == 1 && r.td == 1 &&
+                        !r.persistent_render_target_id && r.tex_rgba &&
+                        // Widening this format gate requires BLIT_SRC/BLIT_DST +
+                        // SAMPLED_IMAGE_FILTER_LINEAR on the new format (the blit cascade below).
+                        backend_color_format(r.texture_format) == VK_FORMAT_R8G8B8A8_UNORM &&
+                        r.declared_mip_levels > 1 && (r.tw > 1 || r.th > 1)) {
+                        uint32_t full = 1;
+                        for (uint32_t m = r.tw > r.th ? r.tw : r.th; m > 1; m >>= 1) full++;
+                        tex_mip_levels = r.declared_mip_levels < full ? r.declared_mip_levels : full;
+                        // Symmetry with the 16-region copy cap below; unreachable from guest data
+                        // (T# extents are rejected above 16384 -> <= 15 levels).
+                        if (tex_mip_levels > 16u) tex_mip_levels = 16u;
+                    }
                     const TextureUploadKey texture_key{
                         r.tex_rgba, r.persistent_render_target_id, r.tw, r.th, r.td, r.img_dim,
-                        backend_color_format(r.texture_format), r.is_storage_image};
+                        tex_mip_levels, backend_color_format(r.texture_format), r.is_storage_image};
                     size_t upload_index = SIZE_MAX;
                     if (share_texture_uploads) {
                         auto found = texture_upload_indices.find(texture_key);
@@ -2760,7 +2786,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                         upload.persistent_id = r.is_storage_image ? 0 : r.persistent_texture_id;
                         const PersistentTextureKey persistent_key{
                             r.persistent_texture_id, r.tw, r.th, r.td, r.img_dim,
-                            backend_color_format(r.texture_format)};
+                            texture_key.mip_levels, backend_color_format(r.texture_format)};
                         if (!r.is_storage_image && !upload.borrowed_target && persistent_textures_enabled &&
                             r.persistent_texture_id) {
                             auto cached = persistent_texture_images.find(persistent_key);
@@ -2781,11 +2807,13 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                             tci.imageType = texture_3d ? VK_IMAGE_TYPE_3D : VK_IMAGE_TYPE_2D;
                             tci.format = backend_color_format(r.texture_format);
                             tci.extent = {r.tw, r.th, r.td};
-                            tci.mipLevels = 1; tci.arrayLayers = 1;
+                            tci.mipLevels = upload.key.mip_levels; tci.arrayLayers = 1;
                             tci.samples = VK_SAMPLE_COUNT_1_BIT; tci.tiling = VK_IMAGE_TILING_OPTIMAL;
                             tci.usage = (r.is_storage_image ? VK_IMAGE_USAGE_STORAGE_BIT
                                                           : VK_IMAGE_USAGE_SAMPLED_BIT) |
-                                        VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+                                        VK_IMAGE_USAGE_TRANSFER_DST_BIT |
+                                        (upload.key.mip_levels > 1 ? VK_IMAGE_USAGE_TRANSFER_SRC_BIT
+                                                                   : 0u);   // blit-cascade source (#1272)
                             vkCreateImage(dev, &tci, nullptr, &upload.image);
                             VkMemoryRequirements tr;
                             vkGetImageMemoryRequirements(dev, upload.image, &tr);
@@ -2805,6 +2833,11 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                             }
                             vkBindImageMemory(dev, upload.image, upload.memory, 0);
 
+                            // #1272: staging carries level 0 only; levels 1..N-1 are produced on the
+                            // GPU by a linear-filtered vkCmdBlitImage cascade at upload time (see the
+                            // copy site). A CPU box filter here was the first implementation and
+                            // collapsed titles that re-upload large mip-eligible textures per frame
+                            // (Evergate's title froze the publish rate — snapshot-gate catch).
                             const VkDeviceSize tbytes =
                                 static_cast<VkDeviceSize>(r.tw) * r.th * r.td *
                                 backend_color_bytes_per_pixel(r.texture_format);
@@ -2858,7 +2891,8 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                     // Vulkan component mappings do not apply to storage-image accesses.
                     if (!r.is_storage_image && !getenv("PROSPER_NO_SWIZZLE"))
                         tvci.components = {vkswz(r.swizzle[0]), vkswz(r.swizzle[1]), vkswz(r.swizzle[2]), vkswz(r.swizzle[3])};
-                    tvci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+                    tvci.subresourceRange =
+                        {VK_IMAGE_ASPECT_COLOR_BIT, 0, upload.key.mip_levels, 0, 1};
                     VkSamplerCreateInfo sci{VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO};
                     // Honor the game's decoded S# (r.mag/min/mip_filter, r.addr_uvw) instead of a fixed
                     // LINEAR/clamp sampler — point-sampled art (pixel-art titles) no longer gets a blurred
@@ -2942,7 +2976,8 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                             upload.persistent_id && !r.is_storage_image) {
                             persistent_image = persistent_texture_images.find(
                                 {upload.persistent_id, upload.key.width, upload.key.height,
-                                 upload.key.depth, upload.key.img_dim, upload.key.format});
+                                 upload.key.depth, upload.key.img_dim,
+                                 upload.key.mip_levels, upload.key.format});
                         }
                         if (persistent_image != persistent_texture_images.end()) {
                             auto cached_binding = persistent_image->second.bindings.find(binding_key);
@@ -3528,18 +3563,60 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         if (!upload.staging) continue;  // exact-validated persistent image already has shader-read layout
         VkImageMemoryBarrier b0{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
         b0.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED; b0.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
-        b0.image = upload.image; b0.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+        b0.image = upload.image;
+        b0.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, upload.key.mip_levels, 0, 1};
         b0.srcAccessMask = 0; b0.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
         vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr, 1, &b0);
         VkBufferImageCopy tc{}; tc.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
         tc.imageExtent = {upload.key.width, upload.key.height, upload.key.depth};
         vkCmdCopyBufferToImage(cmd, upload.staging, upload.image,
                                VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &tc);
+        // #1272: generate levels 1..N-1 with a linear-filtered blit cascade (GPU-side, once per
+        // upload — a CPU box filter here collapsed titles that re-upload large textures per frame).
+        // Each source level transitions DST->SRC before feeding the next; the final barrier below
+        // then flips the whole chain to shader-read. RGBA8 linear-blit support is mandatory Vulkan.
+        for (uint32_t l = 1; l < upload.key.mip_levels; l++) {
+            VkImageMemoryBarrier bs{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
+            bs.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+            bs.newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+            bs.image = upload.image;
+            bs.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, l - 1, 1, 0, 1};
+            bs.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+            bs.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+            vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                                 0, 0, nullptr, 0, nullptr, 1, &bs);
+            const int32_t sw = (int32_t)(upload.key.width >> (l - 1) ? upload.key.width >> (l - 1) : 1u);
+            const int32_t sh = (int32_t)(upload.key.height >> (l - 1) ? upload.key.height >> (l - 1) : 1u);
+            const int32_t dw = (int32_t)(upload.key.width >> l ? upload.key.width >> l : 1u);
+            const int32_t dh = (int32_t)(upload.key.height >> l ? upload.key.height >> l : 1u);
+            VkImageBlit blit{};
+            blit.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, l - 1, 0, 1};
+            blit.srcOffsets[1] = {sw, sh, 1};
+            blit.dstSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, l, 0, 1};
+            blit.dstOffsets[1] = {dw, dh, 1};
+            vkCmdBlitImage(cmd, upload.image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                           upload.image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &blit,
+                           VK_FILTER_LINEAR);
+        }
+        if (upload.key.mip_levels > 1) {
+            // Levels 0..N-2 sit in TRANSFER_SRC after feeding the cascade; return them to
+            // TRANSFER_DST so the single final-layout barrier below covers the whole chain.
+            VkImageMemoryBarrier br{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
+            br.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+            br.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+            br.image = upload.image;
+            br.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, upload.key.mip_levels - 1, 0, 1};
+            br.srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+            br.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+            vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                                 0, 0, nullptr, 0, nullptr, 1, &br);
+        }
         VkImageMemoryBarrier b1{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
         b1.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
         b1.newLayout = upload.key.storage_image
             ? VK_IMAGE_LAYOUT_GENERAL : VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-        b1.image = upload.image; b1.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+        b1.image = upload.image;
+        b1.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, upload.key.mip_levels, 0, 1};
         b1.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
         b1.dstAccessMask = VK_ACCESS_SHADER_READ_BIT |
             (upload.key.storage_image ? VK_ACCESS_SHADER_WRITE_BIT : 0);
@@ -3796,7 +3873,8 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     for (auto& upload : texture_uploads) {
         if (!upload.direct_memory || !upload.persistent_id || upload.persistent_hit) continue;
         const PersistentTextureKey key{upload.persistent_id, upload.key.width, upload.key.height,
-                                       upload.key.depth, upload.key.img_dim, upload.key.format};
+                                       upload.key.depth, upload.key.img_dim,
+                                       upload.key.mip_levels, upload.key.format};
         while (!avoid_cache_eviction &&
                (persistent_texture_images.size() >= persistent_texture_max_entries ||
                 (upload.image_bytes <= persistent_texture_limit &&

--- a/prosper/tests/test_texture_mip_render.cpp
+++ b/prosper/tests/test_texture_mip_render.cpp
@@ -1,0 +1,98 @@
+// test_texture_mip_render — generated mip chains bounded by the T#'s declared levels (#1272): a
+// pixel shader samples at an explicit LOD (image_sample_l), and a 4x4 texture whose columns
+// alternate red/blue is uploaded with declared_mip_levels=3. The box-filtered level 2 must sample
+// as purple (the red/blue average) — impossible from any level-0 texel — while the default
+// declared_mip_levels=1 keeps the historical single-level behavior (LOD clamps to 0) and level 0
+// stays byte-intact through the chain upload. Fails without the mip-chain generation.
+#include "../src/gpu/rdna2_to_spirv.hpp"
+#include "../src/gpu/shader_resources.hpp"
+#include "render_runner.h"
+#include <cstdio>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+using namespace prosper::gpu;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+int main() {
+    printf("== test_texture_mip_render ==\n");
+    const uint32_t W = 64, H = 64;
+
+    // Fullscreen-triangle VS (same words as test_texture_sample_render).
+    const uint32_t vs[] = {
+        0x36020081u, 0x2C040081u, 0x7E020D01u, 0x7E040D02u, 0x7E0A02F6u, 0x7E0C02F2u, 0x10020B01u,
+        0x08020D01u, 0x10040B02u, 0x08040D02u, 0x7E060280u, 0x7E0802F2u, 0xF80008CFu, 0x04030201u, 0xBF810000u,
+    };
+    std::vector<uint32_t> vert = recompile_vertex(vs, sizeof(vs)/sizeof(vs[0]));
+    CHECK(!vert.empty() && vert[0] == 0x07230203u, "recompiled fullscreen-triangle VS -> SPIR-V");
+
+    // PS: v0 = literal u, v1 = literal v, v2 = literal LOD; image_sample_l v[4:7], v[0:2],
+    // s[8:15], s[16:19] dim:2D dmask:0xf (word0 0xf0900f08 = the sample template's word with op
+    // 0x24); exp mrt0 v4..v7. Literal dwords at indices 1 (u), 3 (v), 5 (lod) are patched per draw.
+    const uint32_t ps_template[] = {
+        0x7e0002ffu, 0x3e000000u,   // v_mov_b32 v0, <u>
+        0x7e0202ffu, 0x3e000000u,   // v_mov_b32 v1, <v>
+        0x7e0402ffu, 0x40000000u,   // v_mov_b32 v2, <lod>
+        0xf0900f08u, 0x00820400u,   // image_sample_l v[4:7], v[0:2], s8, s16
+        0xf800000fu, 0x07060504u,   // exp mrt0 v4..v7
+        0xbf810000u,
+    };
+    ShaderResourceTable rt;
+    { ShaderResource t{}; t.cls = ResourceClass::Texture; t.binding = 4; t.img_dim = 1;
+      t.width = 4; t.height = 4; t.sgpr_base = 8; rt.resources.push_back(t); }
+
+    // 4x4 RGBA8: columns alternate red/blue -> box-filtered level 1 (2x2) and level 2 (1x1) are
+    // purple (128, 0, 128) — a value no level-0 texel contains.
+    uint8_t texels[4 * 4 * 4];
+    for (uint32_t y = 0; y < 4; y++) for (uint32_t x = 0; x < 4; x++) {
+        uint8_t* t = &texels[(y * 4 + x) * 4];
+        t[0] = (x & 1) ? 0 : 255; t[1] = 0; t[2] = (x & 1) ? 255 : 0; t[3] = 255;
+    }
+
+    auto render_at = [&](uint32_t u_bits, uint32_t v_bits, uint32_t lod_bits,
+                         uint32_t declared_levels, uint8_t out_rgb[3]) -> bool {
+        std::vector<uint32_t> ps(ps_template, ps_template + sizeof(ps_template)/sizeof(ps_template[0]));
+        ps[1] = u_bits; ps[3] = v_bits; ps[5] = lod_bits;
+        std::vector<uint32_t> frag = recompile_fragment(ps.data(), ps.size(), &rt);
+        if (frag.empty() || frag[0] != 0x07230203u) return false;
+        prosper::test::FrameResource resource;
+        resource.binding = 4; resource.set = 1;
+        resource.tex_rgba = texels; resource.tw = 4; resource.th = 4;
+        resource.declared_mip_levels = declared_levels;
+        resource.mip_filter = 0;      // NEAREST mip select: LOD 2.0 reads exactly level 2
+        resource.max_lod = 8.0f;      // S# LOD clamp above the chain; the image level count clamps
+        prosper::test::BackendDraw draw;
+        draw.vs = vert; draw.fs = frag; draw.R = {resource}; draw.vcount = 3;
+        std::vector<uint8_t> px = prosper::test::render_draws_rgba({draw}, W, H);
+        if (px.size() != (size_t)W * H * 4) return false;
+        const uint8_t* c = &px[((size_t)(H / 2) * W + W / 2) * 4];
+        out_rgb[0] = c[0]; out_rgb[1] = c[1]; out_rgb[2] = c[2];
+        return true;
+    };
+
+    const uint32_t U = 0x3e000000u /*0.125f -> texel column 0*/, LOD0 = 0x00000000u, LOD2 = 0x40000000u;
+    uint8_t rgb[3];
+
+    bool ok = render_at(U, U, LOD2, 3, rgb);
+    printf("  lod2 declared=3 center=(%u,%u,%u)\n", ok?rgb[0]:0, ok?rgb[1]:0, ok?rgb[2]:0);
+    CHECK(ok && rgb[0] > 0x60 && rgb[0] < 0xA0 && rgb[1] < 0x20 && rgb[2] > 0x60 && rgb[2] < 0xA0,
+          "LOD 2 with a declared 3-level chain samples the box-filtered purple (fails without #1272)");
+
+    ok = render_at(U, U, LOD0, 3, rgb);
+    printf("  lod0 declared=3 center=(%u,%u,%u)\n", ok?rgb[0]:0, ok?rgb[1]:0, ok?rgb[2]:0);
+    CHECK(ok && rgb[0] > 0xC0 && rgb[2] < 0x40,
+          "LOD 0 still reads the untouched base level (red) through the chain upload");
+
+    ok = render_at(U, U, LOD2, 1, rgb);
+    printf("  lod2 declared=1 center=(%u,%u,%u)\n", ok?rgb[0]:0, ok?rgb[1]:0, ok?rgb[2]:0);
+    CHECK(ok && rgb[0] > 0xC0 && rgb[2] < 0x40,
+          "declared_mip_levels=1 (the default) keeps the historical single-level clamp-to-0 behavior");
+
+    if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
+    printf("== PASS ==\n");
+    return 0;
+}


### PR DESCRIPTION
Fixes #1272. Layer 2 of the Blue Prince visual-quality work (#1216 context); capture-side follow-up tracked in #1280.

## Failure scenario

Every texture uploaded exactly one mip level, so any minified sampling point-sampled through dense art — most visibly Blue Prince's flower beds rendering as saturated pixel confetti at gameplay distance. Every title pays this on minified textures.

## Change

The T# already decodes `base_level`/`last_level`; prosper simply ignored the chain. Now:

- `declared_mip_levels` (= last_level − base_level + 1) flows from all three T#-decode sites (static table, dynamic draw, compute) through the live frontend's FrameResource marshaling (plain-2D guest textures only — cube stacks and volumes explicitly excluded at both marshaling sites plus the backend `img_dim==1` gate).
- The backend creates the image with the declared chain (clamped to the full pyramid and to the 16-region cap; unreachable-from-guest bound since T# extents are rejected above 16384) and generates levels 1..N−1 with a **GPU `vkCmdBlitImage` linear cascade** at upload: level-0 buffer copy (staging byte-identical to before), per-level DST→SRC feed barriers, one SRC→DST bulk return, then the pre-existing chain-wide shader-read barrier. RGBA8-UNORM linear blit is mandatory Vulkan.
- Cache identity: `TextureUploadKey` and `PersistentTextureKey` carry `mip_levels` (all four construction sites), so a cached image can never mismatch its view's `levelCount`.
- Single-level T#s (`declared==1`, and every excluded class) record the byte-identical pre-change Vulkan sequence.

Generated mips approximate the artist chain prosper does not yet decode from tiled guest memory — the faithful follow-up is documented at the site. CONFIDENCE: MED.

## Process note — the snapshot gate caught the first implementation

The first cut generated the chain with a **CPU box filter at upload time**. ctest was green, but the snapshot gate failed `evergate-title` reproducibly (structural 4/8, pixel changes 4/5, publish rate collapsed): Evergate's title re-uploads a large mip-eligible texture per frame, and the per-upload CPU filter froze the renderer. The blit cascade removes that cost class structurally (GPU-side, per-level blits). With it, evergate-title passes 9/9 twice and the failure images (which showed a correctly rendered but static title) are explained.

## Verification (head 33d1afd8; comment-only delta from the reviewed af2cc61b)

- ctest **143/143**, including new `test_texture_mip_render`: LOD 2 over a declared 3-level red/blue-column texture samples the exact box-average purple (128,0,128) — impossible from any level-0 texel; LOD 0 reads the byte-intact base; declared=1 keeps the historical clamp-to-0 behavior. Each leg fails without its half of the change.
- Snapshot gate **5/5 routes OK** (evergate-title ×2, messenger, dead-cells, blasphemous2, terminator).
- Blue Prince A/B (#1264 route, RADV): flower beds resolve into coherent red/white clusters instead of confetti speckle.
- Capsule replays (`regress.py list` on the local Bendy corpus) execute unchanged — captures don't yet carry the field (#1280), so `.prgcap` replay behavior is pre-change by construction.
- Independent review: initial **APPROVE (conditional on snapshot evidence)** whose condition then caught the evergate regression; after the blit-cascade rework, **re-APPROVE at af2cc61b** — verified the per-level layout/access chain, blit extents/LINEAR semantics vs the exact test expectation, the TRANSFER_SRC flag reachability proof (no path can blit an unflagged image), and the mandatory-format claim. Reviewer one-liners (compute-site wire-up, 16-clamp, format-gate cross-reference) all applied; #1280 filed per its finding.
