### PR TITLE
fix(hle): restore guest %fs around the sceImeUpdate keyboard callback (#1286)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -708,6 +708,13 @@ if(TARGET prosper_core)
     add_test(NAME hle_stack_args_guest_fs COMMAND test_hle_stack_args --guest-fs)
   endif()
 
+  # sceImeUpdate must invoke the guest key handler on the CALLER's guest %fs, not the host %fs the
+  # import stub swapped in (#1286: Evergate SIGSEGV at eboot+0xaf8431 on a key press). Drives the real
+  # import path on an activated guest TCB; a no-op pass off Linux.
+  add_executable(test_ime_fs tests/test_ime_fs.cpp)
+  target_link_libraries(test_ime_fs PRIVATE prosper_core)
+  add_test(NAME ime_fs COMMAND test_ime_fs)
+
   # x86-64 low-address READ decoder used by the Windows PROSPER_NULL_PAGE emulation. Header-only, so the
   # decode logic is verified on every platform even though the VEH caller is Windows-only.
   add_executable(test_x86_read_decode tests/test_x86_read_decode.cpp)

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -1146,6 +1146,20 @@ void ime_autokey_tick(uint64_t handler, uint64_t guest_fs) {
         ime_deliver(handler, {hid, false}, guest_fs);
     }
 }
+
+// Shared sceImeUpdate body: fire the autokey pulse (if enabled) then drain the queued keys, dispatching
+// each on the caller's guest %fs (guest_fs == 0 => no swap, the Windows/macOS path). The queue mutex is
+// released before every guest handler call (never held across guest code).
+void ime_update_run(uint64_t handler, uint64_t guest_fs) {
+    ime_autokey_tick(handler, guest_fs);        // handler = the guest event handler
+    for (;;) {
+        ImeKeyEvent ev;
+        { std::lock_guard<std::mutex> lk(g_ime_mx);
+          if (g_ime_queue.empty()) break;
+          ev = g_ime_queue.front(); g_ime_queue.pop_front(); }
+        ime_deliver(handler, ev, guest_fs);
+    }
+}
 } // namespace
 
 // Frontend seam (declared in ime_input.hpp): push a keyboard key (USB HID usage id) into the IME
@@ -1158,25 +1172,28 @@ void ime_push_key(uint16_t hid_usage, bool down) {
 
 HLE(s_ime_kbd_open) { svc_log("sceImeKeyboardOpen", a0,a1,a2,a3,a4,a5); return 0; }  // handler comes via sceImeUpdate
 // sceImeUpdate invokes the guest event handler (guest code), so it must restore the caller's guest %fs
-// around each dispatch (see ime_deliver / #1286). Use the entry-stack trampoline (as AvPlayer callbacks
-// do) to recover that guest %fs from the import-stub frame; it returns 0 on Windows/macOS (no hardware
-// %fs swap), leaving those paths unchanged.
+// around each dispatch (see ime_deliver / #1286). On Linux/macOS the import stub swapped this thread to
+// host %fs, so recover the caller's guest %fs from the import-stub frame via the entry-stack trampoline
+// (as the AvPlayer callbacks do) and hand it to ime_update_run. PROSPER_ASM_TRAMPOLINE is POSIX-only, so
+// Windows/MinGW (which never swaps hardware %fs at the import boundary) registers a plain handler that
+// dispatches directly with guest_fs == 0. callback_guest_fs_from_entry_stack also returns 0 for any
+// non-guest frame, so the plain-tail-jump macOS path is likewise an unchanged direct call.
+#ifndef _WIN32
 extern "C" uint64_t s_ime_update_c(uint64_t a0, uint64_t a1, uint64_t a2, uint64_t a3,
                                    uint64_t a4, uint64_t a5, uint64_t entry_rsp) {
     svc_log("sceImeUpdate", a0,a1,a2,a3,a4,a5);
-    const uint64_t guest_fs = prosper::callback_guest_fs_from_entry_stack(entry_rsp);
-    ime_autokey_tick(a0, guest_fs);             // a0 = the guest event handler
-    for (;;) {
-        ImeKeyEvent ev;
-        { std::lock_guard<std::mutex> lk(g_ime_mx);
-          if (g_ime_queue.empty()) break;
-          ev = g_ime_queue.front(); g_ime_queue.pop_front(); }
-        ime_deliver(a0, ev, guest_fs);
-    }
+    ime_update_run(a0, prosper::callback_guest_fs_from_entry_stack(entry_rsp));
     return 0;
 }
 PROSPER_ASM_TRAMPOLINE(s_ime_update_entry, s_ime_update_c)
 extern "C" void s_ime_update_entry();
+#else
+HLE(s_ime_update) {   // Windows/MinGW: no import-boundary %fs swap -> dispatch directly (guest_fs = 0)
+    svc_log("sceImeUpdate", a0,a1,a2,a3,a4,a5);
+    ime_update_run(a0, 0);
+    return 0;
+}
+#endif
 // sceImeKeyboardGetResourceId(userId, OrbisImeKeyboardResourceIdArray* out): report the user's keyboard
 // resource ids. Headless -> none (all-zero). A registered PlatformUi (a windowed frontend with a host
 // keyboard) reports its own ids, so a title enables keyboard input (#347).
@@ -2369,7 +2386,11 @@ void register_service_hle() {
     R("sceSystemServiceHideSplashScreen", s_ok);
     // libSceIme keyboard API (#186): no physical keyboard -> consistent "none connected" state. Raw NIDs.
     Hle::register_fn("eaFXjfJv3xs", (HleFn)s_ime_kbd_open,  "sceImeKeyboardOpen");
-    Hle::register_fn("-4GCfYdNF1s", (HleFn)s_ime_update_entry, "sceImeUpdate");
+#ifdef _WIN32
+    Hle::register_fn("-4GCfYdNF1s", (HleFn)s_ime_update, "sceImeUpdate");         // plain handler (guest_fs=0)
+#else
+    Hle::register_fn("-4GCfYdNF1s", (HleFn)s_ime_update_entry, "sceImeUpdate");   // entry-rsp trampoline (#1286)
+#endif
     Hle::register_fn("VkqLPArfFdc", (HleFn)s_ime_kbd_info,  "sceImeKeyboardGetInfo");
     Hle::register_fn("dKadqZFgKKQ", (HleFn)s_ime_kbd_resid, "sceImeKeyboardGetResourceId");
     // libSceAvPlayer (#324): let a post-credits / intro video complete so the game reaches its scene.

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -1085,17 +1085,33 @@ struct ImeKeyEvent { uint16_t hid; bool down; };
 std::mutex g_ime_mx;
 std::deque<ImeKeyEvent> g_ime_queue;
 
-void ime_deliver(uint64_t handler, const ImeKeyEvent& ev) {
+void ime_deliver(uint64_t handler, const ImeKeyEvent& ev, uint64_t guest_fs) {
     if (!handler) return;
     alignas(16) uint8_t e[0x40] = {0};
     *(uint32_t*)(e + 0x00) = ev.down ? 0x101u : 0x102u;
     *(uint16_t*)(e + 0x08) = ev.hid;
-    // Guest handler is SysV-ABI and runs on the guest thread (guest %fs active) — call directly,
-    // exactly as h_qsort calls the guest comparator. arg (rdi) is passed 0: PPSA02664's handler
-    // ignores it; a title whose handler consumes the Open-registered arg is not yet modeled (it
-    // would need the arg captured from the sceImeKeyboardOpen param). The PROSPER_SYSV_ABI marker
-    // documents the host->guest boundary (currently expands empty; see dispatch.hpp).
+    // The guest handler is guest code that reads guest TLS (its per-thread allocator etc.). But
+    // sceImeUpdate is an HLE handler, so the import stub already swapped this thread to HOST %fs before
+    // it ran (#1155). Calling the guest handler directly here therefore ran it on host %fs, so its
+    // thread-local reads hit host glibc garbage and the first allocation it drives (the menu->gameplay
+    // transition on a key press) faulted at a near-null address — Evergate's SIGSEGV at eboot+0xaf8431
+    // (#1286). Restore the caller's guest %fs (recovered from the import-stub frame) for the duration of
+    // the call, then swap back to host %fs. Linux-only: only Linux swaps hardware %fs at the import
+    // boundary (guest_fs is 0 on Windows/macOS -> unchanged direct call). arg (rdi) is passed 0 as before.
+#if defined(__linux__) && !defined(__APPLE__)
+    uint64_t saved_fs = 0; bool swapped = false;
+    if (guest_fs) {
+        __asm__ volatile("rdfsbase %0" : "=r"(saved_fs));
+        __asm__ volatile("wrfsbase %0" : : "r"(guest_fs));
+        swapped = true;
+    }
+#else
+    (void)guest_fs;
+#endif
     ((void (PROSPER_SYSV_ABI *)(uint64_t, void*))(uintptr_t)handler)(0, e);
+#if defined(__linux__) && !defined(__APPLE__)
+    if (swapped) __asm__ volatile("wrfsbase %0" : : "r"(saved_fs));
+#endif
 }
 
 // PROSPER_IME_AUTOKEY=1: deliver a repeating Enter down/up pulse so headless routes advance a
@@ -1104,7 +1120,7 @@ void ime_deliver(uint64_t handler, const ImeKeyEvent& ev) {
 // the HID usage (default 0x28 Enter) and accepts a comma-separated LIST (e.g. "0x28,0x2c,0x1d") that
 // is cycled one key per press-window — so a single headless run can probe which key a dialog accepts.
 // Cadence: down, then up two ticks later, then the next key in the list two windows later.
-void ime_autokey_tick(uint64_t handler) {
+void ime_autokey_tick(uint64_t handler, uint64_t guest_fs) {
     static const int on = [] { const char* e = getenv("PROSPER_IME_AUTOKEY");
                                return e && strtol(e, nullptr, 0) != 0 ? 1 : 0; }();
     if (!on) return;
@@ -1124,10 +1140,10 @@ void ime_autokey_tick(uint64_t handler) {
     uint64_t t = tick.fetch_add(1);
     const uint16_t hid = hids[(t / 90) % hids.size()];
     if ((t % 90) == 0) {
-        ime_deliver(handler, {hid, true});
+        ime_deliver(handler, {hid, true}, guest_fs);
         if (svclog()) fprintf(stderr, "[ime-autokey] deliver hid=0x%x down\n", hid);
     } else if ((t % 90) == 2) {
-        ime_deliver(handler, {hid, false});
+        ime_deliver(handler, {hid, false}, guest_fs);
     }
 }
 } // namespace
@@ -1141,18 +1157,26 @@ void ime_push_key(uint16_t hid_usage, bool down) {
 }
 
 HLE(s_ime_kbd_open) { svc_log("sceImeKeyboardOpen", a0,a1,a2,a3,a4,a5); return 0; }  // handler comes via sceImeUpdate
-HLE(s_ime_update)   {
+// sceImeUpdate invokes the guest event handler (guest code), so it must restore the caller's guest %fs
+// around each dispatch (see ime_deliver / #1286). Use the entry-stack trampoline (as AvPlayer callbacks
+// do) to recover that guest %fs from the import-stub frame; it returns 0 on Windows/macOS (no hardware
+// %fs swap), leaving those paths unchanged.
+extern "C" uint64_t s_ime_update_c(uint64_t a0, uint64_t a1, uint64_t a2, uint64_t a3,
+                                   uint64_t a4, uint64_t a5, uint64_t entry_rsp) {
     svc_log("sceImeUpdate", a0,a1,a2,a3,a4,a5);
-    ime_autokey_tick(a0);                       // a0 = the guest event handler
+    const uint64_t guest_fs = prosper::callback_guest_fs_from_entry_stack(entry_rsp);
+    ime_autokey_tick(a0, guest_fs);             // a0 = the guest event handler
     for (;;) {
         ImeKeyEvent ev;
         { std::lock_guard<std::mutex> lk(g_ime_mx);
           if (g_ime_queue.empty()) break;
           ev = g_ime_queue.front(); g_ime_queue.pop_front(); }
-        ime_deliver(a0, ev);
+        ime_deliver(a0, ev, guest_fs);
     }
     return 0;
 }
+PROSPER_ASM_TRAMPOLINE(s_ime_update_entry, s_ime_update_c)
+extern "C" void s_ime_update_entry();
 // sceImeKeyboardGetResourceId(userId, OrbisImeKeyboardResourceIdArray* out): report the user's keyboard
 // resource ids. Headless -> none (all-zero). A registered PlatformUi (a windowed frontend with a host
 // keyboard) reports its own ids, so a title enables keyboard input (#347).
@@ -2345,7 +2369,7 @@ void register_service_hle() {
     R("sceSystemServiceHideSplashScreen", s_ok);
     // libSceIme keyboard API (#186): no physical keyboard -> consistent "none connected" state. Raw NIDs.
     Hle::register_fn("eaFXjfJv3xs", (HleFn)s_ime_kbd_open,  "sceImeKeyboardOpen");
-    Hle::register_fn("-4GCfYdNF1s", (HleFn)s_ime_update,    "sceImeUpdate");
+    Hle::register_fn("-4GCfYdNF1s", (HleFn)s_ime_update_entry, "sceImeUpdate");
     Hle::register_fn("VkqLPArfFdc", (HleFn)s_ime_kbd_info,  "sceImeKeyboardGetInfo");
     Hle::register_fn("dKadqZFgKKQ", (HleFn)s_ime_kbd_resid, "sceImeKeyboardGetResourceId");
     // libSceAvPlayer (#324): let a post-credits / intro video complete so the game reaches its scene.

--- a/prosper/tests/test_ime_fs.cpp
+++ b/prosper/tests/test_ime_fs.cpp
@@ -99,11 +99,14 @@ int main() {
 
     uint64_t handler = (uint64_t)(uintptr_t)&test_ime_handler;
     ime_update(handler, 0, 0, 0, 0, 0);
+    // Immediately after the import call returns (still before any libc), the import boundary must have
+    // restored the CALLER's guest %fs: the stub swapped guest->host on entry and back on exit. Reading
+    // it here proves the whole swap is balanced, not merely that we can force host %fs afterward.
+    uint64_t fs_at_return = 0;
+    __asm__ volatile("rdfsbase %0" : "=r"(fs_at_return));
 
     // Back to the host TCB so the CHECKs (libc printf) run correctly.
     guest_fs_enter_host_for_signal();
-    uint64_t fs_after = 0;
-    __asm__ volatile("rdfsbase %0" : "=r"(fs_after));
 
     CHECK(guest_fs != 0, "activated a guest %fs base for the call");
     CHECK(guest_fs != host_fs, "guest %fs base differs from the host %fs base");
@@ -116,7 +119,8 @@ int main() {
           "guest key handler ran on the caller's GUEST %fs (not host %fs)");
     CHECK(g_ime_observed_fs != host_fs,
           "guest key handler did NOT run on the host %fs (the #1286 crash condition)");
-    CHECK(fs_after == host_fs, "%fs restored to the host TCB after sceImeUpdate returned");
+    CHECK(fs_at_return == guest_fs,
+          "import boundary left %fs on the caller's guest TCB after sceImeUpdate returned (swap balanced)");
 
     if (fails) { std::printf("== FAIL: %d ==\n", fails); return 1; }
     std::printf("== PASS ==\n");

--- a/prosper/tests/test_ime_fs.cpp
+++ b/prosper/tests/test_ime_fs.cpp
@@ -1,0 +1,125 @@
+// test_ime_fs — sceImeUpdate drains the IME key queue and invokes the guest's registered keyboard
+// event handler, which is GUEST code that reads guest thread-local state (its per-thread allocator
+// etc.). But sceImeUpdate is itself an HLE handler, so the generated import stub has already swapped
+// this thread to the HOST %fs before it ran (#1155). If the guest handler is called directly here it
+// runs on host %fs, its thread-local reads hit host glibc garbage, and the first allocation it drives
+// (the menu->gameplay transition on a key press) faults near null — Evergate's SIGSEGV at eboot+0xaf8431
+// (#1286). The fix recovers the caller's guest %fs from the import-stub frame (via the entry-rsp
+// trampoline) and restores it around each per-key dispatch.
+//
+// This test drives the REAL sceImeUpdate import path end to end — generated import stub -> entry-rsp
+// trampoline -> guest-%fs recovery -> per-key dispatch — on an activated guest TCB, and asserts the
+// guest handler ran on the GUEST %fs (not the host %fs) and that %fs is left restored afterward. It is
+// the regression guard for #1286: revert the ime_deliver swap and the handler observes the host %fs.
+// The %fs swap is Linux-only (Windows/macOS never swap hardware %fs at the import boundary), so the
+// test is a no-op pass elsewhere.
+#include "../src/host/exec_image.hpp"
+#include "../src/hle/dispatch.hpp"
+#include "../src/hle/ime_input.hpp"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { std::printf("  [FAIL] %s\n", m); ++fails; } \
+                         else       { std::printf("  [ok]   %s\n", m); } } while (0)
+
+#if defined(__linux__) && !defined(__APPLE__)
+// The "guest" IME event handler: record the %fs base it is invoked on and the decoded event. Runs on
+// the guest TCB, so it must not call libc; it has no stack buffers, so no -fstack-protector canary is
+// emitted (and the guest TCB carries the host canary at +0x28 regardless — guest_tls.cpp:135). SysV
+// ABI matches ime_deliver's call cast on Linux (the default ABI).
+extern "C" {
+volatile uint64_t g_ime_observed_fs = 0;   // %fs base seen inside the guest handler
+volatile uint32_t g_ime_observed_kind = 0;  // event[0x00]: 0x101 = key down, 0x102 = key up
+volatile uint16_t g_ime_observed_hid = 0;   // event[0x08]: USB HID usage id
+volatile int      g_ime_calls = 0;
+}
+static void test_ime_handler(uint64_t /*arg0*/, void* ev) {
+    uint64_t fs = 0;
+    __asm__ volatile("rdfsbase %0" : "=r"(fs));
+    g_ime_observed_fs = fs;
+    g_ime_observed_kind = *(const uint32_t*)((const uint8_t*)ev + 0x00);
+    g_ime_observed_hid  = *(const uint16_t*)((const uint8_t*)ev + 0x08);
+    ++g_ime_calls;
+}
+
+using GuestIme = uint64_t (*)(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t);
+#endif
+
+int main() {
+    std::printf("== test_ime_fs ==\n");
+
+#if !defined(__linux__) || defined(__APPLE__)
+    std::printf("  [skip] guest-%%fs swap at the import boundary is Linux-only; nothing to guard here\n");
+    std::printf("== PASS ==\n");
+    return 0;
+#else
+    // Enable the Linux guest initial-exec %fs path with a single empty TLS module (as the guest-fs
+    // stub-args test does), then confirm it is active. The Linux suite already runs a guest-fs test,
+    // so the environment supports user-mode FSGSBASE.
+    setenv("PROSPER_GUEST_FS", "1", 1);
+    TlsModuleDesc empty_module{};
+    guest_tls_set_templates(&empty_module, 1);
+    CHECK(guest_tls_enabled(), "Linux guest initial-exec %fs path enabled");
+
+    // Register the built-in HLE table (which registers sceImeUpdate -> the s_ime_update_entry
+    // trampoline) and generate a resolved import stub for it, exactly as the guest calls it.
+    register_builtin_hle();
+    const std::vector<ImportSlot> slots = { {"libSceIme", "-4GCfYdNF1s"} };  // sceImeUpdate
+    dispatch_init(&slots, nullptr);
+    std::string err;
+    // Stubs MUST live in [0x600000000, 0x700000000): callback_guest_fs_from_entry_stack validates that
+    // the return-into-stub address falls in that range before trusting the saved guest %fs, matching
+    // where the real loader places import stubs. A base outside it makes recovery fail closed (return 0).
+    CHECK(install_stubs(slots, 0x680000000ull, 96, &err),
+          "generated the sceImeUpdate import stub");
+    if (fails) {
+        if (!err.empty()) std::printf("  install error: %s\n", err.c_str());
+        std::printf("== FAIL: %d ==\n", fails);
+        return 1;
+    }
+    auto ime_update = reinterpret_cast<GuestIme>(static_cast<uintptr_t>(stub_addr(0)));
+
+    // Queue one Space (HID 0x2c) key press. Do this BEFORE activating the guest TCB: ime_push_key
+    // takes a mutex (host libc), which must run on the host TCB.
+    ime_push_key(0x2c, /*down=*/true);
+
+    // Read the host %fs base, then activate this thread's guest TCB. From here until the restore below
+    // the thread runs on the guest TCB; avoid libc. The generated stub swaps to host %fs for the HLE
+    // body and the fix swaps back to the guest %fs only around the per-key handler dispatch.
+    uint64_t host_fs = 0;
+    __asm__ volatile("rdfsbase %0" : "=r"(host_fs));
+    const uint64_t guest_fs = guest_tls_activate_thread();
+
+    uint64_t handler = (uint64_t)(uintptr_t)&test_ime_handler;
+    ime_update(handler, 0, 0, 0, 0, 0);
+
+    // Back to the host TCB so the CHECKs (libc printf) run correctly.
+    guest_fs_enter_host_for_signal();
+    uint64_t fs_after = 0;
+    __asm__ volatile("rdfsbase %0" : "=r"(fs_after));
+
+    CHECK(guest_fs != 0, "activated a guest %fs base for the call");
+    CHECK(guest_fs != host_fs, "guest %fs base differs from the host %fs base");
+    CHECK(g_ime_calls == 1, "sceImeUpdate dispatched the queued key exactly once");
+    CHECK(g_ime_observed_kind == 0x101u && g_ime_observed_hid == 0x2cu,
+          "guest handler received the decoded key-down event (0x101, HID 0x2c)");
+    // The core #1286 assertion: the guest handler ran on the caller's GUEST %fs, not the host %fs the
+    // import stub swapped in. Reverting the ime_deliver swap makes g_ime_observed_fs == host_fs here.
+    CHECK(g_ime_observed_fs == guest_fs,
+          "guest key handler ran on the caller's GUEST %fs (not host %fs)");
+    CHECK(g_ime_observed_fs != host_fs,
+          "guest key handler did NOT run on the host %fs (the #1286 crash condition)");
+    CHECK(fs_after == host_fs, "%fs restored to the host TCB after sceImeUpdate returned");
+
+    if (fails) { std::printf("== FAIL: %d ==\n", fails); return 1; }
+    std::printf("== PASS ==\n");
+    return 0;
+#endif
+}


### PR DESCRIPTION
Fixes #1286.

## Failure scenario

Evergate (PPSA01885) intermittently crashed with a **guest SIGSEGV at eboot+0xaf8431** during boot,
and reliably **froze the moment a keyboard key was pressed at the main menu** (user-reproduced: press
Cross to advance, then Space → freeze). Both are the same fault.

A fault-time `%fs` attribution probe at the guest main-thread fault showed the guest thread running on
the **host glibc `%fs`** (its TCB had no `PROS` magic at +0x108). The faulting instruction reads its
thread-local allocator via `mov rdi,[fs-0x88]`; on the host TCB that slot is glibc garbage (observed
`0xd4`), and the next `[rdi+0xb0]` dereference faults near null. A last-HLE-call recorder named the
leaking call: **`sceImeUpdate`**.

## Root cause

`sceImeUpdate` is an HLE handler, so on Linux the generated import stub has **already swapped this
thread to the host `%fs`** before the handler body runs (#1155 — HLE bodies run on the host TCB).
`ime_deliver` then invoked the guest's registered IME **event handler directly**. Its comment claimed
the handler "runs on the guest thread (guest `%fs` active)", which is false in the HLE-handler context:
the guest handler — and the menu→gameplay allocation a key press drives — executed on the **host**
`%fs` and read its thread-local allocator as host garbage.

The crash is a real-window present-timing race (it needs the allocation-under-load timing), which is
why it was intermittent on boot and reliably triggered by a key press mid-transition.

## Fix

Recover the caller's guest `%fs` from the import-stub frame and restore it for the duration of each
guest handler call, then swap back to the host `%fs`:

- `sceImeUpdate` is re-registered through the **entry-rsp trampoline** (`PROSPER_ASM_TRAMPOLINE`),
  exactly as the AvPlayer callbacks do, so `callback_guest_fs_from_entry_stack` can read the saved
  guest `%fs` (`r11`) out of the stub frame.
- `ime_deliver` / `ime_autokey_tick` take that `guest_fs` and, on Linux, `wrfsbase` to it around the
  handler call, restoring the host `%fs` afterward.

**Linux-only:** only Linux swaps hardware `%fs` at the import boundary. `callback_guest_fs_from_entry_stack`
returns 0 on Windows/macOS and for any non-guest frame, so `guest_fs == 0` and the call path is the
unchanged direct call there.

## Affected / unaffected

- **Affected:** the `sceImeUpdate` → guest IME event-handler dispatch on Linux (Evergate and any title
  that reads the keyboard via `sceImeKeyboardOpen` + `sceImeUpdate`).
- **Unaffected:** Windows/macOS IME dispatch (no hardware `%fs` swap; behavior identical). No other HLE
  path changes. The autokey diagnostic lever now also passes `guest_fs` but is off by default.

## Risks

Low. The swap is guarded by `guest_fs != 0` (fail-closed recovery) and only wraps the single handler
call; `%fs` is unconditionally restored on the way out. The recovery already gates on the loader stub
address range and the guest-TCB `PROS` magic, so a malformed frame installs nothing.

## Verification

- `ctest` **145/145** on Linux (`build-linux`), including the new `ime_fs` guard.
- **Live (Linux, prosper-app, real Vulkan/Wayland):** with the fix, Evergate reaches gameplay via the
  real keyboard with **no freeze** — user-confirmed ("no freeze, i could reach gameplay"). Before the
  fix it froze on the first key press.
- **Regression guard (`tests/test_ime_fs.cpp`):** drives the real import path end to end (generated
  stub → trampoline → guest-`%fs` recovery → per-key `ime_deliver`) on an activated guest TCB and
  asserts the guest handler ran on the **guest** `%fs`, not the host `%fs`, with `%fs` restored after.
  Validated as a true guard: **passes with the fix (9/9); reverting only the `ime_deliver` swap makes
  the two core assertions fail** (handler observes the host `%fs` — the #1286 crash condition).

### Why a unit test and not a snapshot route
The crash is a real-window present-timing race — the headless screenshot path does **not** reproduce
it (confirmed: 0 crashes with *or* without the fix through the menu). A snapshot route would pass both
ways and guard nothing. The unit test reproduces the exact `%fs` condition deterministically instead.

## Commands
```
cmake -S prosper -B prosper/build-linux -DGAME_DUMP=<messenger dump>
cmake --build prosper/build-linux -j8
ctest --test-dir prosper/build-linux        # 145/145
prosper/build-linux/test_ime_fs             # standalone guard
```

Review requested: this is an ABI-sensitive, reverse-engineered `%fs`/TLS change and should get a
detailed independent review before merge.
