### PR TITLE
perf(render): demand-driven RTT readbacks — defer non-VO passes, materialize CPU pixels at real consumers

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -289,6 +289,28 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 return true;
             });
     }
+    // Deferred RTT readback (#1284) can leave a persistent Vulkan image as the ONLY copy of a
+    // target's pixels. When the backend evicts such an image it reads the pixels back first and
+    // hands them here, so the CPU cache regains the authoritative copy the eager path used to keep.
+    prosper::test::persistent_color_target_evict_sink() =
+        [](uint64_t id, uint32_t width, uint32_t height, VkFormat format,
+           std::vector<uint8_t>&& pixels) {
+            auto it = g_rtt.find(id);
+            if (it == g_rtt.end()) return;
+            RttSurf& surface = it->second;
+            if (surface.w != width || surface.h != height ||
+                prosper::test::backend_color_format(surface.format) !=
+                    prosper::test::backend_color_format(format))
+                return;
+            const size_t expected = static_cast<size_t>(width) * height *
+                prosper::test::backend_color_bytes_per_pixel(
+                    prosper::test::backend_color_format(format));
+            if (pixels.size() != expected) return;
+            if (!surface.rgba || surface.rgba->size() != expected)
+                surface.rgba =
+                    std::make_shared<const std::vector<uint8_t>>(std::move(pixels));
+            surface.gpu_valid = false;   // the image is being destroyed
+        };
     // The compute backend must not sample a surface whose CURRENT pixels live in this renderer's
     // RTT cache (raw guest memory is then empty/stale — the Dead Cells 642x362 lesson): publish the
     // exact-match identity and immutable CPU snapshot used by live compute (#590).
@@ -897,6 +919,48 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             r.compression_enabled ? r.dcc_metadata_host_data_size : 0u,
                         };
                         auto live_rtt = rtt_on ? g_rtt.find(r.gpu_addr) : g_rtt.end();
+                        // Deferred RTT readback (#1284): a GPU-resident target consumed in a way the
+                        // direct GPU bind below cannot serve (extent mismatch, feedback into its own
+                        // pass, storage image) materializes its CPU copy here on demand. The producer
+                        // ran in an earlier batch — same-batch CPU consumers force the eager readback
+                        // at defer time — so the queue-ordered copy reads current pixels.
+                        if (live_rtt != g_rtt.end() && live_gpu_targets && r.img_dim == 1u &&
+                            live_rtt->second.gpu_valid) {
+                            RttSurf& surface = live_rtt->second;
+                            const bool direct_serves = !fr.is_storage_image &&
+                                surface.w == tw && surface.h == th &&
+                                r.gpu_addr != draw.color0_base &&
+                                prosper::test::find_persistent_color_target(
+                                    r.gpu_addr, tw, th, surface.format) != nullptr;
+                            const VkFormat surface_format =
+                                prosper::test::backend_color_format(surface.format);
+                            const uint32_t surface_bpp =
+                                prosper::test::backend_color_bytes_per_pixel(surface_format);
+                            const uint64_t surface_texels =
+                                static_cast<uint64_t>(surface.w) * surface.h;
+                            if (!direct_serves && surface.w && surface.h && surface_bpp &&
+                                surface_texels <= UINT64_MAX / surface_bpp &&
+                                (!surface.rgba ||
+                                 surface.rgba->size() != surface_texels * surface_bpp)) {
+                                std::vector<uint8_t> materialized;
+                                std::string error;
+                                if (prosper::test::readback_persistent_color_target(
+                                        r.gpu_addr, surface.w, surface.h, surface_format,
+                                        materialized, error) &&
+                                    materialized.size() == surface_texels * surface_bpp) {
+                                    surface.rgba = std::make_shared<const std::vector<uint8_t>>(
+                                        std::move(materialized));
+                                } else {
+                                    static std::atomic<int> warned{0};
+                                    if (warned.fetch_add(1) < 24)
+                                        fprintf(stderr,
+                                                "[rtt] lazy sampled target readback failed: "
+                                                "base=0x%llx extent=%ux%u error=%s\n",
+                                                (unsigned long long)r.gpu_addr, surface.w,
+                                                surface.h, error.c_str());
+                                }
+                            }
+                        }
                         const bool has_cpu_live_rtt = r.img_dim == 1u && live_rtt != g_rtt.end() &&
                             live_rtt->second.w && live_rtt->second.h && live_rtt->second.rgba &&
                             !live_rtt->second.rgba->empty();
@@ -2535,6 +2599,14 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         } }
                     bool sampled_exact_later = false;
                     bool feedback_later = false;
+                    // A later pass in THIS batch that reads the target's CPU bytes cannot be served
+                    // lazily: the producing commands are still unsubmitted when it binds, so a
+                    // mid-batch readback would return stale pixels. Only the direct GPU bind (2D
+                    // texture, exact extent, not feedback, not storage) is batch-ordered; every
+                    // other same-batch consumer forces the eager readback. img_dim != 1 consumers
+                    // read guest memory on both paths and never block. Cross-batch consumers
+                    // materialize on demand at bind/seed/compute/DMA time (#1284).
+                    bool cpu_needed_same_batch = false;
                     if (live_gpu_targets && base) {
                         for (size_t later = pass_i; later < items.size(); ++later) {
                             auto inspect = [&](const prosper::gpu::ShaderResourceTable* table) {
@@ -2550,12 +2622,22 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                         sampled_exact_later = true;
                                         feedback_later |= items[later].color0_base == base;
                                     }
+                                    const bool direct_bindable =
+                                        resource.cls == RC::Texture && rw == gw && rh == gh &&
+                                        items[later].color0_base != base;
+                                    if (later > pass_i && !direct_bindable)
+                                        cpu_needed_same_batch = true;
                                 }
                             };
                             inspect(items[later].vrt.get());
                             inspect(items[later].prt.get());
                         }
                     }
+                    static const bool defer_rtt_readback =
+                        !getenv("PROSPER_NO_RTT_READBACK_DEFER");
+                    const bool rtt_defer_ok = defer_rtt_readback
+                        ? !cpu_needed_same_batch
+                        : (sampled_exact_later && !feedback_later);
                     // Keep intermediate scanout spans GPU-resident too: they cannot publish until the
                     // final callback, where the cache is materialized on demand if no later scanout
                     // pass already requested CPU pixels. A same-submit DMA asks its producer span for
@@ -2564,7 +2646,47 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         !phase.authoritative_readback &&
                         ((is_vo && phase.allows_deferred_scanout_readback() &&
                           defer_intermediate_scanout) ||
-                         (!is_vo && base != front_va && sampled_exact_later && !feedback_later));
+                         (!is_vo && base != front_va && rtt_defer_ok));
+                    // PROSPER_READBACK_WHY (#1284): classify WHY each non-deferred pass takes the
+                    // synchronous CPU readback (75-79 ms/window on Blue Prince's Day One frame).
+                    // The dominant reason selects the next optimization; behavior unchanged.
+                    if (!defer_readback) {
+                        static const bool why = getenv("PROSPER_READBACK_WHY") != nullptr;
+                        if (why) {
+                            // Counts identify the failing defer condition; bytes weight each bucket
+                            // by the actual copy size, since readback time scales with bytes.
+                            enum { kNoLive, kNoVo, kNoBase, kAuth, kVoFinal, kFront,
+                                   kNotSampledExact, kFeedback, kBuckets };
+                            static std::atomic<uint64_t> counts[kBuckets], bytes[kBuckets];
+                            static std::atomic<uint64_t> c_total{0};
+                            int bucket = kNotSampledExact;
+                            if (!live_gpu_targets) bucket = kNoLive;
+                            else if (vo_n <= 0) bucket = kNoVo;
+                            else if (!base) bucket = kNoBase;
+                            else if (phase.authoritative_readback) bucket = kAuth;
+                            else if (is_vo) bucket = kVoFinal;
+                            else if (base == front_va) bucket = kFront;
+                            else if (sampled_exact_later && feedback_later) bucket = kFeedback;
+                            ++counts[bucket];
+                            bytes[bucket] += static_cast<uint64_t>(gw) * gh *
+                                prosper::test::backend_color_bytes_per_pixel(pass_format);
+                            static std::atomic<uint64_t> last_report{0};
+                            const uint64_t t = ++c_total;
+                            if (t >= last_report.load(std::memory_order_relaxed) + 200) {
+                                last_report.store(t, std::memory_order_relaxed);
+                                static const char* names[kBuckets] = {
+                                    "no_live", "no_vo", "no_base", "auth", "vo_final",
+                                    "front", "not_sampled_exact", "feedback"};
+                                fprintf(stderr, "[readback-why] total=%llu",
+                                        (unsigned long long)t);
+                                for (int i = 0; i < kBuckets; ++i)
+                                    fprintf(stderr, " %s=%llu/%lluMB", names[i],
+                                            (unsigned long long)counts[i].load(),
+                                            (unsigned long long)(bytes[i].load() >> 20));
+                                fprintf(stderr, "\n");
+                            }
+                        }
+                    }
                     prosper::test::BackendColorTarget backend_target{
                         base, seed_rtt, !defer_readback, pass_format};
                     const bool color1_extent_matches = base1 && !render_pass.empty() &&

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -246,6 +246,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
     // compute-only use (tests/test_game_compute.cpp) still creates its own device.
     (void)prosper::test::render_vk_ctx();
     static RttCache g_rtt;   // render-to-texture cache (#167)
+    // Shared final-callback ordinal for PROSPER_PASS_LOG (increments where dp_submit does).
+    static std::atomic<uint64_t> g_pass_log_submit{0};
     // Match boot_trace's progression-diagnostic contract: callers may register the graphics
     // renderer while deliberately leaving compute unregistered. This keeps semantic dispatches
     // visible without letting screenshot/prosper-app registration silently undo the A/B.
@@ -924,10 +926,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // pass, storage image) materializes its CPU copy here on demand. The producer
                         // ran in an earlier batch — same-batch CPU consumers force the eager readback
                         // at defer time — so the queue-ordered copy reads current pixels.
-                        if (live_rtt != g_rtt.end() && live_gpu_targets && r.img_dim == 1u &&
+                        if (live_rtt != g_rtt.end() && live_gpu_targets && r.img_dim != 2u &&
                             live_rtt->second.gpu_valid) {
                             RttSurf& surface = live_rtt->second;
-                            const bool direct_serves = !fr.is_storage_image &&
+                            const bool direct_serves = !fr.is_storage_image && r.img_dim == 1u &&
                                 surface.w == tw && surface.h == th &&
                                 r.gpu_addr != draw.color0_base &&
                                 prosper::test::find_persistent_color_target(
@@ -967,6 +969,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // A retained render target was created for color-attachment + sampled usage,
                         // not storage usage. Storage images therefore take the decoded/upload path.
                         const bool has_gpu_live_rtt = !fr.is_storage_image && live_gpu_targets &&
+                            !getenv("PROSPER_RTT_MATERIALIZE_ALL") &&
                             r.img_dim == 1u &&
                             live_rtt != g_rtt.end() && live_rtt->second.gpu_valid &&
                             live_rtt->second.w == tw && live_rtt->second.h == th &&
@@ -1203,6 +1206,29 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                     pending_timing.persistent_misses++;
                                 }
                             }
+                        }
+                        // PROSPER_BIND_LOG=<min-cb>: log every sampled-resource binding decision for
+                        // 3 final callbacks (same ordinal as PROSPER_PASS_LOG) — which path serves
+                        // each guest address, so a black consumer input can be attributed.
+                        if (const char* bl = getenv("PROSPER_BIND_LOG")) {
+                            const uint64_t at = g_pass_log_submit.load(std::memory_order_relaxed);
+                            const uint64_t bl_min = std::strtoull(bl, nullptr, 0);
+                            if (at >= bl_min && at < bl_min + 3u)
+                                fprintf(stderr,
+                                        "[bind] cb=%llu addr=0x%llx %ux%u dim=%u fmt=%u path=%s "
+                                        "rtt(w=%u h=%u gpu=%d rgba=%d)\n",
+                                        (unsigned long long)at, (unsigned long long)r.gpu_addr,
+                                        tw, th, r.img_dim, (unsigned)r.format,
+                                        has_gpu_live_rtt          ? "gpu-bind"
+                                        : has_cpu_live_rtt        ? "cpu-rtt"
+                                        : decoded_reuse           ? "decode-cache"
+                                                                  : "decode",
+                                        live_rtt != g_rtt.end() ? live_rtt->second.w : 0,
+                                        live_rtt != g_rtt.end() ? live_rtt->second.h : 0,
+                                        live_rtt != g_rtt.end() ? (int)live_rtt->second.gpu_valid
+                                                                : -1,
+                                        live_rtt != g_rtt.end() ? (int)(bool)live_rtt->second.rgba
+                                                                : -1);
                         }
                         if (has_gpu_live_rtt) {
                             fr.persistent_render_target_id = r.gpu_addr;
@@ -2450,6 +2476,47 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         const uint64_t rsrc = pass.front()->color0_base;
                         const uint64_t rdst = pass.front()->color1_base;
                         auto src_it = rsrc ? g_rtt.find(rsrc) : g_rtt.end();
+                        // Deferred RTT readback (#1284): the resolve is a CPU copy of the source's
+                        // pixels, and the source pass usually rendered EARLIER IN THIS BATCH with its
+                        // readback deferred. The consumer scan cannot see a resolve (it consumes via
+                        // cb_resolve, not a sampled resource), so materialize here: flush the pending
+                        // batch first — a mid-batch readback would otherwise return stale pixels —
+                        // then read the persistent image back once.
+                        if (src_it != g_rtt.end() && src_it->second.gpu_valid &&
+                            src_it->second.w && src_it->second.h && rdst) {
+                            RttSurf& src_surface = src_it->second;
+                            const VkFormat src_format =
+                                prosper::test::backend_color_format(src_surface.format);
+                            const uint32_t src_bpp =
+                                prosper::test::backend_color_bytes_per_pixel(src_format);
+                            const size_t src_bytes = static_cast<size_t>(src_surface.w) *
+                                src_surface.h * src_bpp;
+                            if (src_bpp &&
+                                (!src_surface.rgba || src_surface.rgba->size() != src_bytes)) {
+                                const prosper::test::RenderVkCtx& ctx =
+                                    prosper::test::render_vk_ctx();
+                                if (ctx.ok && backend_submission.pending())
+                                    backend_submission.submit_and_wait(ctx.dev, ctx.queue, false);
+                                std::vector<uint8_t> materialized;
+                                std::string error;
+                                if (prosper::test::readback_persistent_color_target(
+                                        rsrc, src_surface.w, src_surface.h, src_format,
+                                        materialized, error) &&
+                                    materialized.size() == src_bytes) {
+                                    src_surface.rgba =
+                                        std::make_shared<const std::vector<uint8_t>>(
+                                            std::move(materialized));
+                                } else {
+                                    static std::atomic<int> warned{0};
+                                    if (warned.fetch_add(1) < 24)
+                                        fprintf(stderr,
+                                                "[rtt] resolve source readback failed: "
+                                                "base=0x%llx extent=%ux%u error=%s\n",
+                                                (unsigned long long)rsrc, src_surface.w,
+                                                src_surface.h, error.c_str());
+                                }
+                            }
+                        }
                         if (rsrc && rdst && src_it != g_rtt.end() && src_it->second.rgba) {
                             // Copy the source RttSurf out before the g_rtt[rdst] insert: operator[] may
                             // rehash and invalidate src_it before the assignment reads it.
@@ -2614,16 +2681,17 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 for (const auto& resource : table->resources) {
                                     if ((resource.cls != RC::Texture &&
                                          resource.cls != RC::StorageImage) ||
-                                        resource.gpu_addr != base || resource.img_dim != 1u)
+                                        resource.gpu_addr != base || resource.img_dim == 2u)
                                         continue;
                                     const uint32_t rw = resource.width ? resource.width : 4u;
                                     const uint32_t rh = resource.height ? resource.height : 4u;
-                                    if (rw == gw && rh == gh) {
+                                    if (resource.img_dim == 1u && rw == gw && rh == gh) {
                                         sampled_exact_later = true;
                                         feedback_later |= items[later].color0_base == base;
                                     }
                                     const bool direct_bindable =
-                                        resource.cls == RC::Texture && rw == gw && rh == gh &&
+                                        resource.cls == RC::Texture && resource.img_dim == 1u &&
+                                        rw == gw && rh == gh &&
                                         items[later].color0_base != base;
                                     if (later > pass_i && !direct_bindable)
                                         cpu_needed_same_batch = true;
@@ -3003,10 +3071,40 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         if (is_vo)                    px_vo = pass_pixels;     // any registered scanout
                         px_last = pass_pixels;                                  // last non-empty (fallback)
                     }
+                    // PROSPER_PASS_LOG=<min-submit>: per-pass publish provenance for 3 submits —
+                    // which pass produced pixels, its target identity, and the defer decision.
+                    if (const char* pl = getenv("PROSPER_PASS_LOG")) {
+                        const uint64_t at = g_pass_log_submit.load(std::memory_order_relaxed);
+                        const uint64_t pl_min = std::strtoull(pl, nullptr, 0);
+                        size_t nz = 0;
+                        for (size_t p = 0; p + 3 < rendered_pixels.size(); p += 4)
+                            if (rendered_pixels[p] || rendered_pixels[p + 1] ||
+                                rendered_pixels[p + 2]) nz++;
+                        // In-window: every pass. Out of window: only content-bearing (or deferred)
+                        // passes, so the publish source can be found without knowing the callback.
+                        if ((at >= pl_min && at < pl_min + 3u) || nz > 100 || defer_readback)
+                            fprintf(stderr,
+                                    "[pass] cb=%llu pass=%zu/%zu base=0x%llx %ux%u fmt=%d vo=%d "
+                                    "seed=%d defer=%d writes=%llu px_nonblack=%zu\n",
+                                    (unsigned long long)at, pass_i, items.size(),
+                                    (unsigned long long)base, gw, gh, (int)pass_format,
+                                    (int)is_vo, (int)seed_rtt, (int)defer_readback,
+                                    (unsigned long long)color_target_call.writes, nz);
+                    }
                 }
                 // Present priority: the flipped front buffer > any registered scanout target > the
                 // legacy "last group" fallback (unchanged behavior when no group targets a VO buffer).
                 selected_pixels = px_front ? px_front : (px_vo ? px_vo : px_last);
+                {
+                    const uint64_t at = g_pass_log_submit.fetch_add(1);
+                    if (const char* pl = getenv("PROSPER_PASS_LOG")) {
+                        const uint64_t pl_min = std::strtoull(pl, nullptr, 0);
+                        if (at >= pl_min && at < pl_min + 3u)
+                            fprintf(stderr, "[pass] cb=%llu selected=%s\n", (unsigned long long)at,
+                                    px_front ? "px_front"
+                                             : (px_vo ? "px_vo" : (px_last ? "px_last" : "none")));
+                    }
+                }
                 // PROSPER_DUMP_PERSISTENT=<min-submit>: read back and dump EVERY persistent color
                 // target after this submit's passes render. Unlike PROSPER_RTT*/DUMP_*, this flag is
                 // NOT in the live_gpu_targets disable list (:480-487), so it observes the NORMAL

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -927,7 +927,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // ran in an earlier batch — same-batch CPU consumers force the eager readback
                         // at defer time — so the queue-ordered copy reads current pixels.
                         if (live_rtt != g_rtt.end() && live_gpu_targets && r.img_dim != 2u &&
-                            live_rtt->second.gpu_valid) {
+                            !r.in_mip_tail && live_rtt->second.gpu_valid) {
                             RttSurf& surface = live_rtt->second;
                             const bool direct_serves = !fr.is_storage_image && r.img_dim == 1u &&
                                 surface.w == tw && surface.h == th &&
@@ -969,7 +969,6 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // A retained render target was created for color-attachment + sampled usage,
                         // not storage usage. Storage images therefore take the decoded/upload path.
                         const bool has_gpu_live_rtt = !fr.is_storage_image && live_gpu_targets &&
-                            !getenv("PROSPER_RTT_MATERIALIZE_ALL") &&
                             r.img_dim == 1u &&
                             live_rtt != g_rtt.end() && live_rtt->second.gpu_valid &&
                             live_rtt->second.w == tw && live_rtt->second.h == th &&
@@ -1210,9 +1209,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // PROSPER_BIND_LOG=<min-cb>: log every sampled-resource binding decision for
                         // 3 final callbacks (same ordinal as PROSPER_PASS_LOG) — which path serves
                         // each guest address, so a black consumer input can be attributed.
-                        if (const char* bl = getenv("PROSPER_BIND_LOG")) {
+                        static const char* const bind_log = getenv("PROSPER_BIND_LOG");
+                        if (bind_log) {
                             const uint64_t at = g_pass_log_submit.load(std::memory_order_relaxed);
-                            const uint64_t bl_min = std::strtoull(bl, nullptr, 0);
+                            const uint64_t bl_min = std::strtoull(bind_log, nullptr, 0);
                             if (at >= bl_min && at < bl_min + 3u)
                                 fprintf(stderr,
                                         "[bind] cb=%llu addr=0x%llx %ux%u dim=%u fmt=%u path=%s "
@@ -2670,9 +2670,13 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     // lazily: the producing commands are still unsubmitted when it binds, so a
                     // mid-batch readback would return stale pixels. Only the direct GPU bind (2D
                     // texture, exact extent, not feedback, not storage) is batch-ordered; every
-                    // other same-batch consumer forces the eager readback. img_dim != 1 consumers
-                    // read guest memory on both paths and never block. Cross-batch consumers
-                    // materialize on demand at bind/seed/compute/DMA time (#1284).
+                    // other same-batch consumer forces the eager readback — including cube/1D
+                    // samplers (they consume rgba via the RTT injection path) and passes that
+                    // re-bind this target as their color1 seed. Volume (img_dim==2) consumers read
+                    // guest memory on both paths and never block. pass_i has already advanced past
+                    // the current pass, so every scanned item is a genuine later consumer.
+                    // Cross-batch consumers materialize on demand at bind/seed/compute/DMA time
+                    // (#1284).
                     bool cpu_needed_same_batch = false;
                     if (live_gpu_targets && base) {
                         for (size_t later = pass_i; later < items.size(); ++later) {
@@ -2693,12 +2697,13 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                         resource.cls == RC::Texture && resource.img_dim == 1u &&
                                         rw == gw && rh == gh &&
                                         items[later].color0_base != base;
-                                    if (later > pass_i && !direct_bindable)
-                                        cpu_needed_same_batch = true;
+                                    if (!direct_bindable) cpu_needed_same_batch = true;
                                 }
                             };
                             inspect(items[later].vrt.get());
                             inspect(items[later].prt.get());
+                            if (active_color1(items[later]) == base)
+                                cpu_needed_same_batch = true;
                         }
                     }
                     static const bool defer_rtt_readback =
@@ -2724,7 +2729,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             // Counts identify the failing defer condition; bytes weight each bucket
                             // by the actual copy size, since readback time scales with bytes.
                             enum { kNoLive, kNoVo, kNoBase, kAuth, kVoFinal, kFront,
-                                   kNotSampledExact, kFeedback, kBuckets };
+                                   kSameBatchCpu, kNotSampledExact, kFeedback, kBuckets };
                             static std::atomic<uint64_t> counts[kBuckets], bytes[kBuckets];
                             static std::atomic<uint64_t> c_total{0};
                             int bucket = kNotSampledExact;
@@ -2734,6 +2739,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             else if (phase.authoritative_readback) bucket = kAuth;
                             else if (is_vo) bucket = kVoFinal;
                             else if (base == front_va) bucket = kFront;
+                            else if (cpu_needed_same_batch) bucket = kSameBatchCpu;
                             else if (sampled_exact_later && feedback_later) bucket = kFeedback;
                             ++counts[bucket];
                             bytes[bucket] += static_cast<uint64_t>(gw) * gh *
@@ -2744,7 +2750,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 last_report.store(t, std::memory_order_relaxed);
                                 static const char* names[kBuckets] = {
                                     "no_live", "no_vo", "no_base", "auth", "vo_final",
-                                    "front", "not_sampled_exact", "feedback"};
+                                    "front", "same_batch_cpu", "not_sampled_exact", "feedback"};
                                 fprintf(stderr, "[readback-why] total=%llu",
                                         (unsigned long long)t);
                                 for (int i = 0; i < kBuckets; ++i)
@@ -2767,6 +2773,40 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     const VkFormat pass_format1 = use_color1 ? format1 : VK_FORMAT_UNDEFINED;
                     const uint8_t* seed1 = nullptr;
                     if (seed_rtt && use_color1) { auto sit = g_rtt.find(base1);
+                        // Deferred RTT readback (#1284): color1 has no GPU-side load path, so a
+                        // deferred target re-bound as the color1 seed materializes its CPU pixels
+                        // here. Same-batch producers were forced eager by the consumer scan
+                        // (active_color1 == base), so this readback only ever sees prior,
+                        // already-submitted batches.
+                        if (sit != g_rtt.end() && sit->second.gpu_valid &&
+                            sit->second.w == gw && sit->second.h == gh &&
+                            sit->second.format == pass_format1) {
+                            RttSurf& seed1_surface = sit->second;
+                            const size_t seed1_bytes = static_cast<size_t>(gw) * gh *
+                                prosper::test::backend_color_bytes_per_pixel(pass_format1);
+                            if (seed1_bytes &&
+                                (!seed1_surface.rgba ||
+                                 seed1_surface.rgba->size() != seed1_bytes)) {
+                                std::vector<uint8_t> materialized;
+                                std::string error;
+                                if (prosper::test::readback_persistent_color_target(
+                                        base1, gw, gh,
+                                        prosper::test::backend_color_format(pass_format1),
+                                        materialized, error) &&
+                                    materialized.size() == seed1_bytes) {
+                                    seed1_surface.rgba =
+                                        std::make_shared<const std::vector<uint8_t>>(
+                                            std::move(materialized));
+                                } else {
+                                    static std::atomic<int> warned{0};
+                                    if (warned.fetch_add(1) < 24)
+                                        fprintf(stderr,
+                                                "[rtt] color1 seed readback failed: base=0x%llx "
+                                                "extent=%ux%u error=%s\n",
+                                                (unsigned long long)base1, gw, gh, error.c_str());
+                                }
+                            }
+                        }
                         if (sit != g_rtt.end() && sit->second.w == gw && sit->second.h == gh &&
                             sit->second.format == pass_format1 && sit->second.rgba &&
                             sit->second.rgba->size() == static_cast<size_t>(gw) * gh *

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -2160,6 +2160,14 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         ++color_target_stats.writes;
         color_target_stats.write_hits = load_cached_color ? 1 : 0;
     }
+    if (color_target && color_target->persistent_id && getenv("PROSPER_BACKEND_LOAD_LOG"))
+        fprintf(stderr,
+                "[backend-load] id=0x%llx %ux%u fmt=%d cached=%d valid=%d load_existing=%d "
+                "seed=%d readback=%d -> load=%d\n",
+                (unsigned long long)color_target->persistent_id, W, H, (int)FMT,
+                cached_color != nullptr, cached_color ? (int)cached_color->valid : -1,
+                (int)color_target->load_existing, seed_rgba != nullptr,
+                (int)color_target->readback, (int)load_cached_color);
 
     VkImage img1 = VK_NULL_HANDLE; VkDeviceMemory imem1 = VK_NULL_HANDLE;
     VkImageView view1 = VK_NULL_HANDLE;

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -1051,6 +1051,21 @@ inline void destroy_persistent_color_target(const RenderVkCtx& ctx,
     target = {};
 }
 
+inline bool readback_persistent_color_target(uint64_t id, uint32_t width, uint32_t height,
+                                             VkFormat format, std::vector<uint8_t>& output,
+                                             std::string& error);
+
+// With deferred RTT readback (#1284) a valid persistent target can hold the ONLY copy of its
+// rendered pixels. Eviction must hand those pixels back to the frontend's CPU cache before the
+// image is destroyed, or the content is silently lost. Without a registered sink, eviction keeps
+// the historical destroy-only behavior (every pass then still has an authoritative CPU copy).
+inline std::function<void(uint64_t, uint32_t, uint32_t, VkFormat, std::vector<uint8_t>&&)>&
+persistent_color_target_evict_sink() {
+    static std::function<void(uint64_t, uint32_t, uint32_t, VkFormat, std::vector<uint8_t>&&)>
+        sink;
+    return sink;
+}
+
 inline bool evict_persistent_color_target(const RenderVkCtx& ctx, uint64_t current_generation) {
     auto& cache = persistent_color_target_cache();
     auto victim = cache.end();
@@ -1060,6 +1075,18 @@ inline bool evict_persistent_color_target(const RenderVkCtx& ctx, uint64_t curre
             victim = it;
     }
     if (victim == cache.end()) return false;
+    if (victim->second.valid) {
+        auto& sink = persistent_color_target_evict_sink();
+        if (sink) {
+            std::vector<uint8_t> pixels;
+            std::string error;
+            if (readback_persistent_color_target(victim->first.id, victim->first.width,
+                                                 victim->first.height, victim->first.format,
+                                                 pixels, error))
+                sink(victim->first.id, victim->first.width, victim->first.height,
+                     victim->first.format, std::move(pixels));
+        }
+    }
     persistent_color_target_bytes() -= victim->second.bytes;
     destroy_persistent_color_target(ctx, victim->second);
     cache.erase(victim);

--- a/prosper/tests/test_texture_sample_render.cpp
+++ b/prosper/tests/test_texture_sample_render.cpp
@@ -380,6 +380,42 @@ int main() {
         CHECK(fallback_stats.sampled_hits == 0 &&
                   invalidated_fallback == cpu_accumulated_sample,
               "invalidated GPU target uses the supplied CPU fallback instead of stale pixels");
+
+        // #1284: with deferred RTT readback the persistent image can hold a target's ONLY pixels.
+        // Evicting an unpinned valid target must hand those exact pixels to the registered sink
+        // before the image is destroyed; without the sink the content would be silently lost.
+        constexpr uint64_t sink_target_id = 0x6210000000000001ull;
+        prosper::test::BackendColorTarget sink_target{sink_target_id, false, false};
+        const std::vector<uint8_t> sink_producer_output = prosper::test::render_draws_rgba(
+            {producer}, W, H, nullptr, nullptr, false, &sink_target);
+        struct SinkCapture {
+            uint32_t w = 0, h = 0;
+            VkFormat format = VK_FORMAT_UNDEFINED;
+            std::vector<uint8_t> pixels;
+            int hits = 0;
+        } sink_capture;
+        prosper::test::persistent_color_target_evict_sink() =
+            [&sink_capture](uint64_t id, uint32_t w, uint32_t h, VkFormat format,
+                            std::vector<uint8_t>&& pixels) {
+                if (id != sink_target_id) return;
+                ++sink_capture.hits;
+                sink_capture.w = w; sink_capture.h = h; sink_capture.format = format;
+                sink_capture.pixels = std::move(pixels);
+            };
+        const uint64_t sink_pressure_count =
+            prosper::test::persistent_color_target_count_limit() + 40;
+        for (uint64_t pressure = 0; pressure < sink_pressure_count; ++pressure) {
+            prosper::test::BackendColorTarget sink_pressure_target{
+                sink_target_id + 0x2000 + pressure, false, false};
+            prosper::test::render_draws_rgba(
+                {producer}, W, H, nullptr, nullptr, false, &sink_pressure_target);
+        }
+        prosper::test::persistent_color_target_evict_sink() = nullptr;
+        CHECK(sink_producer_output.empty() && sink_capture.hits == 1 &&
+                  sink_capture.w == W && sink_capture.h == H &&
+                  sink_capture.format == VK_FORMAT_R8G8B8A8_UNORM &&
+                  sink_capture.pixels == first,
+              "evicting a GPU-only color target hands its exact pixels to the registered sink");
     }
 
     // Renderer-owned FP16 targets must retain HDR values through both CPU RTT readback/upload and


### PR DESCRIPTION
Refs #1284 (Blue Prince 3D-scene frame budget decomposition).

## Failure scenario / motivation

Blue Prince's Day One 3D frame spends 70–89 ms per submit on synchronous per-pass GPU→CPU readbacks. A byte-weighted census (new `PROSPER_READBACK_WHY` diagnostic) over the full intro→3D route shows 85.6% of all readback bytes (355.6 of 415 GB logical) come from non-VO RTT passes whose target is not sampled at exact extent later in the same batch — while the buckets that actually *demand* CPU bytes synchronously (`auth`, `front`, `feedback`) were zero across the entire route. The eager readbacks also force per-pass batch flushes and CPU→GPU re-uploads of sampled RTT content.

## Behavioral contract

- A non-VO RTT pass keeps its pixels GPU-resident unless a **same-batch** consumer needs CPU bytes mid-batch. Only the direct GPU bind (2D texture, exact extent, not feedback, not storage image) is batch-ordered; every other same-batch consumer forces the eager readback exactly as before.
- **Cross-batch** consumers the direct bind cannot serve materialize the CPU copy on demand via `readback_persistent_color_target` — prior batches are queue-ordered and fence-waited, so the copy reads current pixels. Covered consumers: mismatched-extent sampling, feedback binds, storage images, cube-sampled RTTs, compute readers (pre-existing lazy reader), DMA byte reads (pre-existing), final scanout publish (pre-existing), and **CB MODE=RESOLVE sources** (new — see below).
- Evicting a valid persistent target hands its exact pixels to a registered sink before the image is destroyed, so eviction cannot destroy the only copy of deferred pixels. Mid-batch eviction staleness cannot occur: every in-render evict site is gated by `avoid_cache_eviction = active_submission.pending()`.
- `PROSPER_NO_RTT_READBACK_DEFER=1` restores the legacy exact-sample defer scan unchanged.

## The resolve bug found during bring-up (fixed in this PR)

The first full-route run froze at black: Blue Prince resolves its 4×-MSAA scene with a CB MODE=RESOLVE pass that copies the source's **CPU pixels** from color0 into the color1 surface the display samples — and the consumer scan structurally cannot see a resolve (it consumes via `cb_resolve`, not a sampled resource). With a deferred source the copy silently skipped and the presented chain never received the scene. The resolve now flushes the pending submission batch (a mid-batch readback would return stale pixels) and materializes the source once. Localized via format-bisect (only RGBA16F deferral broke), a shadow experiment (readbacks executed on the GPU but bytes discarded → still broke, proving a frontend byte-dependency), and new per-resource bind logging (the consumer's input had no RTT cache entry at all).

The stricter same-batch scan also closes two latent holes where a deferred target's mixed-extent or storage-image same-batch consumer fell through to stale guest memory.

## Diagnostics added (kept)

- `PROSPER_READBACK_WHY` — per-bucket count/byte census of why each non-deferred readback happened.
- `PROSPER_PASS_LOG=<cb>` — per-pass publish provenance (target, extent, format, VO, seed, defer, content).
- `PROSPER_BIND_LOG=<cb>` — per-resource binding decision (gpu-bind / cpu-rtt / decode-cache / decode).
- `PROSPER_BACKEND_LOAD_LOG` — backend load-vs-clear provenance per persistent pass.

## Measured effect (Blue Prince PPSA25009, Linux/RADV, identical envs, 170×3 s route, tail = Day One 3D scene, ~1,525 draws/window)

| metric (per submit) | eager baseline | this PR |
|---|---|---|
| measured total | 341–374 ms | **154–178 ms (~2.2×)** |
| readback | 73–89 ms | 3.8–4.1 ms |
| draw_setup | 193–246 ms | 116–141 ms |
| record_upload | 29–30 ms | 8.2–8.6 ms |
| gpu_wait | 24.7–25 ms | 15.4–15.6 ms |
| fence waits / window | 61 | 41 |

Residual readbacks are only `no_base` (passes with no color0 address; 42 GB) and `vo_final` (CPU-present publish, harness-only; 24 GB) — both tracked as follow-ups on #1284. `not_sampled_exact` is 0 across the whole route with zero materialization failures.

## Affected / unaffected

- Affected: live-renderer per-pass readback policy, RTT cache CPU-copy lifecycle, resolve source materialization, persistent-target eviction.
- Unaffected: capture/diagnostic paths (any capture env disables `live_gpu_targets` and with it the whole defer path), VO scanout defer policy (unchanged), MRT1 passes (still always read back), replay/capsule semantics (byte-identical, see below), Windows/macOS frontends (shared code but same gates).

## Risks

- A CPU-byte consumer not covered by the audit would read stale guest memory. Mitigations: the route-level bring-up found exactly one (the resolve) and fixed it; consumers all funnel through the audited sites (bind path, seed path, compute reader/importer, DMA byte reader, resolve, final publish, evict sink); `PROSPER_NO_RTT_READBACK_DEFER=1` is a one-switch recovery.
- Eviction sink correctness under pressure is covered by a new regression test.

## Verification

- `cmake --build prosper/build-linux -j24` — clean; `ctest` — **144/144 passed**.
- New test: evicting an unpinned GPU-only target hands its exact pixels to the registered sink (fails without the sink implementation, which did not previously exist).
- Byte-oracle: `gpu_replay dayone.prgcap` (2,869 draws / 34 computes, full Day One 3D frame) → hash `ada58952a9cde383`, **identical to master**.
- Live route: intro/logos/menu animate (previously frozen with the unfixed deferral); Day One 3D scene renders the known-good composition (estate, character, flower beds; the over-brightness is pre-existing #1287/#1271).
- Snapshot gate (`snapshot.py check`, all routes): running — result will be posted as a comment before merge.

## Review corrections (commit c4c2b23b)

Independent review found one blocking defect and two should-fixes, all addressed:

- **Scan off-by-one (blocking)**: `pass_i` has already advanced past the current pass when the consumer scan runs, so a `later > pass_i` guard exempted the next pass's first draw — a genuine same-batch consumer whose non-direct-bindable use would have triggered a mid-batch lazy readback of unsubmitted commands. Guard dropped.
- **color1 seeds**: color1 has no GPU-side load path, so a deferred target re-bound as a color1 seed lost prior content. The scan now blocks deferral when a later same-batch pass binds the target as color1, and the seed1 site materializes cross-batch sources on demand.
- **Half-wired experiment switch removed**; mip-tail consumers no longer trigger a wasted materialization; the census gained a `same_batch_cpu` bucket; BIND_LOG's getenv cached out of the per-resource loop.
- The pre-existing 1D-of-FP16 RTT injection stride overrun the review surfaced is tracked as #1293.

Two review notes recorded here rather than in code: (1) the mid-callback resolve flush's submit/fence is not counted in `pending_timing`, so window fence/submit counts slightly undercount on resolve-heavy titles; (2) `PROSPER_NO_RTT_READBACK_DEFER=1` restores the legacy *defer decision* byte-for-byte, but the consumer-side materializations (bind-time, the color1 seed site) and evict sink stay active — they only fire for legacy-deferred targets' mismatched consumers, where they strictly improve on master's latent stale-guest-memory hole.

Verification on the corrected head: build clean, **ctest 144/144**, capsule replay hash `ada58952a9cde383` unchanged, live intro route animates with zero materialization failures.



A pre-existing equal-in-kind hole the re-review noted — the `is_vo` intermediate-scanout defer arm bypassing the same-batch consumer scan — is tracked as #1295 (not a regression of this PR).
