### PR TITLE
docs: surface the F9 frame grab in CLAUDE.md so every agent finds it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -300,6 +300,16 @@ Messenger depth, vertex-fetch, geometry, palette, or tiling hypotheses without c
   `HWWATCH`/`PEEK`/`FAULTMEM`, `tools/il2cpp/prx_to_elf.py` + Il2CppDumper, `tools/re/xref.py`, the snapshot
   guard) — the RE toolbox is the force multiplier, so grow it deliberately, verify it on a known answer,
   and land it so the next agent (and the next game) inherits it.
+  - **For a graphical bug or an FPS drop, the fastest loop is the F9 frame grab.** While a title runs in
+    `prosper-app`, pressing **F9** captures the current frame — the game's real GPU commands, shaders, and
+    resources, plus the renderer-owned RTTs it samples (seeded) — into a replayable `.prgbundle` + a `.bmp`
+    screenshot (`PROSPER_CAPTURE_DIR`, default cwd). Then `tools/gpu_replay --bundle <file>` reproduces
+    that exact frame **offline and deterministically**, and `--inspect-only` / `--draw-steps` /
+    `--dump-resource` (via `--bundle-extract-submit`) dissect it draw-by-draw. This answers "which draw
+    wrote this pixel / why does this frame look wrong / why is it slow" without re-booting and re-routing
+    to catch the moment live — the human presses F9 once, then the fix is iterated on the frozen frame.
+    It captures *rendered-frame* bugs (not CPU/logic/audio). See `tools/AGENTS.md` (interactive frame grab)
+    and `tools/gpu_replay/README.md`.
 - **Reaching the running frame loop** needs two gated switches (off by default, so the default boot stays
   stable): `PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct`. Add `PROSPER_RENDER=1` to run the
   live renderer, `PROSPER_GFXLOG=1` for graphics diagnostics.

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -1,5 +1,11 @@
 # GPU replay
 
+**Getting a capture:** either the env-driven `PROSPER_GPU_CAPTURE`/timeline flows below, or — the fastest
+for a graphical bug or FPS drop you can *see* — press **F9** while a title runs in `prosper-app` to grab
+the current frame into a replayable `.prgbundle` + screenshot (`PROSPER_CAPTURE_DIR`, default cwd; it seeds
+the renderer-owned RTTs the frame samples, so deferred titles replay for real). Replay it with
+`--bundle <file>`; see `tools/AGENTS.md` (interactive frame grab).
+
 `gpu_replay` inspects, validates, graphs, and renders a local `.prgcap` without booting the guest.
 Capsules contain title-derived shaders, resource bytes, addresses, ordered DMA endpoints, optional rendered RTT
 pixels, and optional exact persistent Vulkan depth/stencil checkpoint planes.


### PR DESCRIPTION
The F9 interactive frame grab (#1289 / #1291) was documented only in `tools/AGENTS.md` and the `gpu_replay` README — which agents read only once they're already working in `tools/`. This adds it to the place **every session loads**: the CLAUDE.md **Build tools** section's reuse-first toolbox list, framed as the fastest loop for a *visible* graphical bug or FPS drop (press F9 in `prosper-app` → replayable `.prgbundle` → `gpu_replay` offline, dissect draw-by-draw, iterate on the frozen frame). Plus a capture-source pointer at the top of the `gpu_replay` README.

Docs-only; no code change. `git diff --check` clean.