### PR TITLE
fix(hle): require mount path component boundaries

### DIFF
--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -514,6 +514,11 @@ namespace {
         for (const auto& c : stack) { if (!out.empty()) out += '/'; out += c; }
         return out;
     }
+    bool mount_path_matches(const std::string& path, const char* mount) {
+        const size_t len = std::strlen(mount);
+        return path.compare(0, len, mount) == 0 &&
+               (path.size() == len || path[len] == '/' || path[len] == '\\');
+    }
     std::string translate(const char* guest) {
         if (!guest) return {};
         std::string p = guest;
@@ -529,10 +534,10 @@ namespace {
         // sub-path and reject an escape (#1205); normal paths are byte-identical to before, and a benign
         // in-sandbox ".." resolves to the same host file it would have anyway.
         std::string save0;
-        if (p.rfind("/savedata0", 0) == 0) { std::lock_guard<std::mutex> lk(g_save0_mx); save0 = g_save0; }
+        if (mount_path_matches(p, "/savedata0")) { std::lock_guard<std::mutex> lk(g_save0_mx); save0 = g_save0; }
         std::string root; size_t vlen = 0;
-        if      (p.rfind("/app0", 0) == 0)  { root = g_app0;       vlen = 5;  }
-        else if (p.rfind("/temp0", 0) == 0) { root = temp0_root(); vlen = 6;  }
+        if      (mount_path_matches(p, "/app0"))  { root = g_app0;       vlen = 5;  }
+        else if (mount_path_matches(p, "/temp0")) { root = temp0_root(); vlen = 6;  }
         else if (!save0.empty())            { root = save0;        vlen = 10; }
         else {
             if (filelog()) fprintf(stderr, "[file] open '%s' -> '%s'\n", guest, p.c_str());

--- a/prosper/tests/test_translate_sandbox.cpp
+++ b/prosper/tests/test_translate_sandbox.cpp
@@ -15,6 +15,7 @@
 // matches), which keeps the byte-exact checks below valid on case-insensitive filesystems too.
 #include "../src/hle/dispatch.hpp"
 #include <cstdio>
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <string>
@@ -39,12 +40,30 @@ int main() {
     { std::ofstream(root / "arcrunner" / "content" / "movies" / "intro_ps5.mp4") << "x"; }
     const std::string base = root.string();
     set_app0_root(base);
+#ifdef _WIN32
+    _putenv_s("PROSPER_SAVE0", (root / "saves").string().c_str());
+#else
+    setenv("PROSPER_SAVE0", (root / "saves").string().c_str(), 1);
+#endif
 
     // ---- #1205: sandbox containment (unchanged behavior) ----
 
     // Normal path: composed directly under the host root (identical to pre-#1205 behavior).
     CHECK(resolve_guest_path("/app0/data/config.bin") == base + "/data/config.bin",
           "normal /app0 path maps directly under the root");
+
+    // A mount name must end at a component boundary. Raw prefix matching aliases unrelated guest
+    // namespaces into a mount (for example, /app0evil/file -> <app0-root>/evil/file).
+    CHECK(resolve_guest_path("/app0evil/file") == "/app0evil/file",
+          "sibling prefix '/app0evil' is not mapped into /app0");
+    CHECK(resolve_guest_path("/temp00/file") == "/temp00/file",
+          "sibling prefix '/temp00' is not mapped into /temp0");
+    fs::create_directories(root / "saves");
+    CHECK(savedata0_mount("slot", SaveDataMountPolicy::OpenOrCreate) == SaveDataMountOutcome::Created,
+          "test save directory mounts");
+    CHECK(resolve_guest_path("/savedata00/file") == "/savedata00/file",
+          "sibling prefix '/savedata00' is not mapped into /savedata0");
+    CHECK(savedata0_umount(), "test save directory unmounts");
 
     // Benign in-sandbox '..': normalizes to the same host file the OS would have resolved anyway.
     CHECK(resolve_guest_path("/app0/data/../data/config.bin") == base + "/data/config.bin",


### PR DESCRIPTION
## Summary

- require `/app0`, `/temp0`, and `/savedata0` mount matches to end at a path-component boundary
- preserve `/` and `\` as accepted guest separators
- cover sibling-prefix paths for all three mounts, including an active save-data mount

## Why

The post-#1119 HLE audit found that raw prefix matching redirected unrelated guest paths such as `/app0evil/file` and `/savedata00/file` into mounted host directories. This produced incorrect namespace resolution, though it did not escape the selected host sandbox.

Fixes #1297

## Verification

- `git diff --check`
- `cmake --build prosper/build-audit --target test_translate_sandbox -j8`
- `ctest --test-dir prosper/build-audit -R translate_sandbox_guard --output-on-failure` (1/1 passed)