### PR TITLE
fix(loader): reject unallocatable image extents

### DIFF
--- a/prosper/src/loader/linker.cpp
+++ b/prosper/src/loader/linker.cpp
@@ -19,7 +19,9 @@ bool link_program(const std::vector<LinkInput>& inputs, uint64_t stub_base,
         auto mo = Module::load(in.path, &e);
         if (!mo) return fail("load " + in.path + ": " + e);
         auto mod = std::make_unique<Module>(std::move(*mo));
-        LoadedImage img = build_image(*mod, in.base);
+        LoadedImage img;
+        if (!build_image(*mod, in.base, img, &e))
+            return fail("load " + in.path + ": " + e);
         out.mods.push_back(std::move(mod));
         out.imgs.push_back(std::move(img));
     }

--- a/prosper/src/self/module.cpp
+++ b/prosper/src/self/module.cpp
@@ -261,6 +261,10 @@ bool build_image(const Module& m, uint64_t base, LoadedImage& out, std::string* 
     img.max_vaddr = align_up(hi, 0x4000);
     if (img.max_vaddr < img.min_vaddr) img.max_vaddr = img.min_vaddr;  // degenerate (align_up wrap) -> empty
     const uint64_t image_size = img.max_vaddr - img.min_vaddr;
+    if (image_size > kMaxLoadedImageBytes) {
+        if (err) *err = "PT_LOAD image extent exceeds prosper's 1 GiB loader limit";
+        return false;
+    }
     if (image_size > img.mem.max_size()) {
         if (err) *err = "PT_LOAD image extent exceeds the host vector limit";
         return false;

--- a/prosper/src/self/module.cpp
+++ b/prosper/src/self/module.cpp
@@ -1,6 +1,7 @@
 #include "module.hpp"
 #include <cstdio>
 #include <cstring>
+#include <stdexcept>
 #include <unordered_map>
 #include <algorithm>
 
@@ -244,7 +245,7 @@ uint8_t* LoadedImage::at(uint64_t va) {
 }
 const uint8_t* LoadedImage::at(uint64_t va) const { return const_cast<LoadedImage*>(this)->at(va); }
 
-LoadedImage build_image(const Module& m, uint64_t base) {
+bool build_image(const Module& m, uint64_t base, LoadedImage& out, std::string* err) {
     LoadedImage img; img.base = base;
     uint64_t lo = UINT64_MAX, hi = 0;
     for (auto& s : m.segments)
@@ -259,7 +260,20 @@ LoadedImage build_image(const Module& m, uint64_t base) {
     img.min_vaddr = align_dn(lo, 0x4000);
     img.max_vaddr = align_up(hi, 0x4000);
     if (img.max_vaddr < img.min_vaddr) img.max_vaddr = img.min_vaddr;  // degenerate (align_up wrap) -> empty
-    img.mem.assign(img.max_vaddr - img.min_vaddr, 0);
+    const uint64_t image_size = img.max_vaddr - img.min_vaddr;
+    if (image_size > img.mem.max_size()) {
+        if (err) *err = "PT_LOAD image extent exceeds the host vector limit";
+        return false;
+    }
+    try {
+        img.mem.assign(static_cast<size_t>(image_size), 0);
+    } catch (const std::bad_alloc&) {
+        if (err) *err = "PT_LOAD image extent cannot be allocated";
+        return false;
+    } catch (const std::length_error&) {
+        if (err) *err = "PT_LOAD image extent exceeds the host vector limit";
+        return false;
+    }
     for (auto& s : m.segments) {
         if (s.type != PT_LOAD || s.vaddr < img.min_vaddr) continue;   // outside the mapped window
         uint64_t dst = s.vaddr - img.min_vaddr;
@@ -270,7 +284,8 @@ LoadedImage build_image(const Module& m, uint64_t base) {
         img.prot.push_back({ s.vaddr, s.memsz, (s.flags & 4) != 0, (s.flags & 2) != 0, (s.flags & 1) != 0 });
     }
     img.entry = base + m.e_entry;
-    return img;
+    out = std::move(img);
+    return true;
 }
 
 void bind_imports_to_stubs(const Module& m, LoadedImage& img, uint64_t stub_base, uint64_t stub_size) {

--- a/prosper/src/self/module.hpp
+++ b/prosper/src/self/module.hpp
@@ -145,7 +145,9 @@ struct LoadedImage {
 };
 
 // Build a flat image from a parsed module at guest base `base`.
-LoadedImage build_image(const Module& m, uint64_t base);
+// Build a module image without allowing a malformed PT_LOAD extent to terminate the process through
+// an uncaught vector allocation failure. Returns false and describes the load error on failure.
+bool build_image(const Module& m, uint64_t base, LoadedImage& out, std::string* err = nullptr);
 
 // The phdr-index key a SELF data segment maps to: bits [31:20] of its flags, masked to 12 bits (the
 // SCE self-segment id). Higher flag bits must be masked off or the data-segment map is keyed wrong.

--- a/prosper/src/self/module.hpp
+++ b/prosper/src/self/module.hpp
@@ -144,6 +144,13 @@ struct LoadedImage {
     const uint8_t* at(uint64_t va) const;
 };
 
+// prosper materializes each ELF module as one contiguous, eagerly zero-filled host vector. Bound
+// guest-declared PT_LOAD spans before allocation so malformed multi-terabyte extents cannot exploit
+// virtual-memory overcommit and OOM-kill the process during zero fill. The current title corpus peaks
+// at about 251 MiB (PPSA21564); 1 GiB retains substantial headroom without pretending this contiguous
+// representation can safely model an arbitrary 64-bit ELF address span.
+inline constexpr uint64_t kMaxLoadedImageBytes = 1ull << 30;
+
 // Build a flat image from a parsed module at guest base `base`.
 // Build a module image without allowing a malformed PT_LOAD extent to terminate the process through
 // an uncaught vector allocation failure. Returns false and describes the load error on failure.

--- a/prosper/tests/test_module.cpp
+++ b/prosper/tests/test_module.cpp
@@ -56,7 +56,8 @@ int main(int argc, char** argv) {
 
     // --- build image ---
     const uint64_t BASE = 0x400000;
-    LoadedImage img = build_image(m, BASE);
+    LoadedImage img;
+    CHECK(build_image(m, BASE, img), "build image");
     CHECK(img.mem.size() >= 0x2000000, "image size=0x%zx smaller than expected", img.mem.size());
     CHECK(img.entry == BASE + m.e_entry, "entry mismatch");
 

--- a/prosper/tests/test_self_bounds.cpp
+++ b/prosper/tests/test_self_bounds.cpp
@@ -129,13 +129,17 @@ static void test_build_image_bounds() {
         CHECK(build_image(m, 0x100000000ull, img), "align-up-wrapped extent returns an empty image");
         CHECK(img.mem.size() == 0, "align_up-wrapped extent clamped to empty (no giant allocation)");
     }
-    {   // A huge but non-wrapping extent passes the arithmetic guards above. Before #1299 it reached
-        // vector::assign and threw an uncaught length_error/bad_alloc, terminating link_program.
+    {   // A huge but non-wrapping extent passes the arithmetic guards above and is still far below a
+        // 64-bit vector::max_size(). Before #1299 it reached vector::assign; Linux overcommit could
+        // accept the virtual allocation, then OOM-kill the process while assign zero-filled it.
         Module m;
-        Segment s; s.type = PT_LOAD; s.vaddr = 0x4000; s.memsz = 1ull << 63; s.flags = 4;
+        Segment s; s.type = PT_LOAD; s.vaddr = 0x4000;
+        s.memsz = kMaxLoadedImageBytes + 0x4000; s.flags = 4;
         m.segments.push_back(s);
         LoadedImage img;
         std::string err;
+        CHECK(s.memsz < img.mem.max_size(),
+              "regression extent is below vector::max_size (exercises loader policy, not STL limit)");
         CHECK(!build_image(m, 0x100000000ull, img, &err),
               "huge non-wrapping PT_LOAD extent is rejected without throwing");
         CHECK(!err.empty(), "rejected huge PT_LOAD reports a load error");

--- a/prosper/tests/test_self_bounds.cpp
+++ b/prosper/tests/test_self_bounds.cpp
@@ -11,6 +11,8 @@
 //      valid pointer for the LAST byte, which +8 overruns) is guarded by test_at_last_byte_needs_guard().
 //   C) str_at() could return a pointer with no NUL before EOF -> a consumer's strlen/std::string
 //      reads past the buffer. Now requires an in-range NUL. Guarded by test_str_at().
+//   D) build_image() allowed a huge non-wrapping PT_LOAD span to reach vector::assign; the uncaught
+//      length_error/bad_alloc terminated linking. Image construction is now fallible and reports it.
 // No game dump needed: pure in-memory construction.
 #include "../src/self/module.hpp"
 #include <cstdio>
@@ -99,7 +101,8 @@ static void test_build_image_bounds() {
         m.file = {1,2,3,4,5,6,7,8};
         Segment s; s.type = PT_LOAD; s.vaddr = 0x4000; s.filesz = 8; s.memsz = 0x4000; s.file_off = 0; s.flags = 4;
         m.segments.push_back(s);
-        LoadedImage img = build_image(m, 0x100000000ull);
+        LoadedImage img;
+        CHECK(build_image(m, 0x100000000ull, img), "valid PT_LOAD image builds");
         const uint8_t* p = img.at(0x100000000ull + 0x4000);
         CHECK(p && p[0] == 1 && p[7] == 8, "valid PT_LOAD maps its filesz bytes");
     }
@@ -111,7 +114,8 @@ static void test_build_image_bounds() {
         m.file.assign(64, 0xAB);
         Segment bad; bad.type = PT_LOAD; bad.vaddr = 0x4001; bad.filesz = UINT64_MAX; bad.memsz = 0x4000; bad.file_off = 1; bad.flags = 4;
         m.segments.push_back(bad);
-        LoadedImage img = build_image(m, 0x100000000ull);   // reaching here at all means no OOB memcpy
+        LoadedImage img;
+        CHECK(build_image(m, 0x100000000ull, img), "wrapping filesz image still builds safely");
         CHECK(img.mem.size() > 0, "wrapping huge filesz skipped, no OOB memcpy (image still sized)");
     }
     {   // malformed huge memsz: vaddr+memsz does not overflow (passes the extent-skip guard) but
@@ -121,8 +125,20 @@ static void test_build_image_bounds() {
         m.file = {1,2,3,4};
         Segment s; s.type = PT_LOAD; s.vaddr = 0x8000; s.filesz = 4; s.memsz = UINT64_MAX - 0x8000; s.file_off = 0; s.flags = 4;
         m.segments.push_back(s);
-        LoadedImage img = build_image(m, 0x100000000ull);   // must not attempt a ~2^64 mem.assign
+        LoadedImage img;
+        CHECK(build_image(m, 0x100000000ull, img), "align-up-wrapped extent returns an empty image");
         CHECK(img.mem.size() == 0, "align_up-wrapped extent clamped to empty (no giant allocation)");
+    }
+    {   // A huge but non-wrapping extent passes the arithmetic guards above. Before #1299 it reached
+        // vector::assign and threw an uncaught length_error/bad_alloc, terminating link_program.
+        Module m;
+        Segment s; s.type = PT_LOAD; s.vaddr = 0x4000; s.memsz = 1ull << 63; s.flags = 4;
+        m.segments.push_back(s);
+        LoadedImage img;
+        std::string err;
+        CHECK(!build_image(m, 0x100000000ull, img, &err),
+              "huge non-wrapping PT_LOAD extent is rejected without throwing");
+        CHECK(!err.empty(), "rejected huge PT_LOAD reports a load error");
     }
 }
 

--- a/prosper/tools/imgdump/imgdump.cpp
+++ b/prosper/tools/imgdump/imgdump.cpp
@@ -9,7 +9,11 @@ int main(int argc, char** argv) {
     std::string err;
     auto m = prosper::Module::load(argv[1], &err);
     if (!m) { fprintf(stderr, "load failed: %s\n", err.c_str()); return 1; }
-    auto img = prosper::build_image(*m, 0);
+    prosper::LoadedImage img;
+    if (!prosper::build_image(*m, 0, img, &err)) {
+        fprintf(stderr, "build image failed: %s\n", err.c_str());
+        return 1;
+    }
     FILE* f = fopen(argv[2], "wb");
     if (!f) { perror("fopen"); return 1; }
     fwrite(img.mem.data(), 1, img.mem.size(), f);


### PR DESCRIPTION
## Summary

- make SELF/ELF image construction fallible
- reject extents beyond the host vector limit and convert allocation exceptions into loader errors
- propagate image-construction failures through `link_program` instead of terminating
- add a huge, non-wrapping PT_LOAD regression case

## Why

The post-#1119 review found that commit `cf2aafac` protected wrapping PT_LOAD arithmetic but still allowed enormous non-wrapping extents to reach `vector::assign`. An uncaught `std::length_error` or `std::bad_alloc` then terminated the emulator instead of rejecting the malformed dump.

Fixes #1299

## Verification

- `git diff --check`
- `cmake --build prosper/build-audit --target test_self_bounds test_module -j8`
- `ctest --test-dir prosper/build-audit -R self_bounds --output-on-failure`
- `prosper/build-audit/test_self_bounds` — 36 passed, 0 failed