### PR TITLE
fix(render): size RTT injection by producer stride

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -352,6 +352,10 @@ if(TARGET prosper_core)
   target_include_directories(test_rtt_scale PRIVATE frontends/shared)
   add_test(NAME rtt_scale COMMAND test_rtt_scale)
 
+  add_executable(test_rtt_injection frontends/shared/test_rtt_injection.cpp)
+  target_include_directories(test_rtt_injection PRIVATE frontends/shared)
+  add_test(NAME rtt_injection COMMAND test_rtt_injection)
+
   # Bounded-acquire present classification (#1182). Needs Vulkan HEADERS only (VkResult enum), no loader
   # call — link Vulkan::Vulkan purely for its include dirs. Guarded so a headers-less host skips it
   # gracefully; every platform that builds prosper-app has Vulkan available.

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -1,6 +1,7 @@
 // live_renderer.cpp — see live_renderer.hpp. Extracted from boot_trace's PROSPER_RENDER lambda
 // (behavior-preserving); Vulkan-backed, so this unit links Vulkan::Vulkan.
 #include "live_renderer.hpp"
+#include "rtt_injection.hpp"
 #include "live_compute.hpp"
 
 #include "gpu/gpu_execute.hpp"          // DrawItem, set_submit_renderer
@@ -1415,19 +1416,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 !rit->second.rgba->empty()) {
                                 const RttSurf& s = rit->second;
                                 const uint32_t rtt_bpp = prosper::test::backend_color_bytes_per_pixel(s.format);
-                                const size_t expected = static_cast<size_t>(tw) * th * rtt_bpp;
-                                if (s.w == tw && s.h == th && s.rgba->size() == expected) {
-                                    std::memcpy(texture_pixels.data(), s.rgba->data(), expected);
-                                } else {
-                                    std::fill(texture_pixels.begin(), texture_pixels.end(), 0);
-                                    for (uint32_t y = 0; y < th; y++) for (uint32_t x = 0; x < tw; x++) {
-                                        uint32_t sx = (uint32_t)((uint64_t)x * s.w / tw), sy = (uint32_t)((uint64_t)y * s.h / th);
-                                        size_t si = ((size_t)sy * s.w + sx) * rtt_bpp;
-                                        if (si + rtt_bpp <= s.rgba->size())
-                                            std::memcpy(&texture_pixels[((size_t)y * tw + x) * rtt_bpp],
-                                                        &(*s.rgba)[si], rtt_bpp);
-                                    }
-                                }
+                                if (!prosper::frontend::inject_rtt_pixels(
+                                        texture_pixels, tw, th, *s.rgba, s.w, s.h, rtt_bpp))
+                                    continue;
                                 fr.texture_format = s.format;
                                 rtt_hit = true;
                                 resource_rtt_hit = true;

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -1416,35 +1416,33 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 !rit->second.rgba->empty()) {
                                 const RttSurf& s = rit->second;
                                 const uint32_t rtt_bpp = prosper::test::backend_color_bytes_per_pixel(s.format);
-                                if (!prosper::frontend::inject_rtt_pixels(
-                                        texture_pixels, tw, th, *s.rgba, s.w, s.h, rtt_bpp))
-                                    continue;
-                                fr.texture_format = s.format;
-                                rtt_hit = true;
-                                resource_rtt_hit = true;
-                                // PROSPER_DUMP_SAMPLED_RTT (#710/#320): dump the EXACT RTT-layer pixels a
-                                // draw samples, at sample time, so we can see whether an already-rendered
-                                // layer (e.g. the title's menu panel) arrives bright or dark — disambiguates
-                                // "layer rendered dark" from "composite/tint darkens a correct layer". One
-                                // BMP per (sampled addr) into PROSPER_FRAME_DIR.
-                                if (getenv("PROSPER_DUMP_SAMPLED_RTT")) {
-                                    static std::set<uint64_t> seen;
-                                    if (seen.insert(r.gpu_addr).second) {
-                                        const std::vector<uint8_t> inspected = inspection_rgba8(
-                                            texture_pixels, tw, th, s.format);
-                                        size_t nz = 0, rgbnz = 0;
-                                        for (size_t p = 0; p + 3 < inspected.size(); p += 4) {
-                                            if (inspected[p] || inspected[p+1] || inspected[p+2]) rgbnz++;
-                                            for (int k = 0; k < 4; k++) nz += (inspected[p+k] != 0);
+                                if (prosper::frontend::inject_rtt_pixels(
+                                        texture_pixels, tw, th, *s.rgba, s.w, s.h, rtt_bpp)) {
+                                    fr.texture_format = s.format;
+                                    rtt_hit = true;
+                                    resource_rtt_hit = true;
+                                    // PROSPER_DUMP_SAMPLED_RTT (#710/#320): dump the exact RTT-layer
+                                    // pixels a draw samples, disambiguating a dark layer from a later
+                                    // composite/tint that darkens otherwise-correct input.
+                                    if (getenv("PROSPER_DUMP_SAMPLED_RTT")) {
+                                        static std::set<uint64_t> seen;
+                                        if (seen.insert(r.gpu_addr).second) {
+                                            const std::vector<uint8_t> inspected = inspection_rgba8(
+                                                texture_pixels, tw, th, s.format);
+                                            size_t nz = 0, rgbnz = 0;
+                                            for (size_t p = 0; p + 3 < inspected.size(); p += 4) {
+                                                if (inspected[p] || inspected[p+1] || inspected[p+2]) rgbnz++;
+                                                for (int k = 0; k < 4; k++) nz += (inspected[p+k] != 0);
+                                            }
+                                            const char* dd = getenv("PROSPER_FRAME_DIR");
+                                            char fn[512]; snprintf(fn, sizeof fn, "%s/sampledrtt_%llx_%ux%u.bmp",
+                                                                   dd ? dd : ".", (unsigned long long)r.gpu_addr, tw, th);
+                                            prosper::test::dump_bmp(fn, inspected, tw, th);
+                                            fprintf(stderr, "[sampledrtt] addr=0x%llx %ux%u rgb_nonblack=%zu/%u -> %s\n",
+                                                    (unsigned long long)r.gpu_addr, tw, th, rgbnz, tw*th, fn);
                                         }
-                                        const char* dd = getenv("PROSPER_FRAME_DIR");
-                                        char fn[512]; snprintf(fn, sizeof fn, "%s/sampledrtt_%llx_%ux%u.bmp",
-                                                               dd ? dd : ".", (unsigned long long)r.gpu_addr, tw, th);
-                                        prosper::test::dump_bmp(fn, inspected, tw, th);
-                                        fprintf(stderr, "[sampledrtt] addr=0x%llx %ux%u rgb_nonblack=%zu/%u -> %s\n",
-                                                (unsigned long long)r.gpu_addr, tw, th, rgbnz, tw*th, fn);
                                     }
-                                }
+                                } // malformed/incomplete RTT bytes => miss; decode guest backing below
                             }
                             if (rtt_log)
                                 fprintf(stderr, "[rtt] sample tex addr=0x%llx %ux%u fmt=%u -> %s (cache_size=%zu)\n",

--- a/prosper/frontends/shared/rtt_injection.hpp
+++ b/prosper/frontends/shared/rtt_injection.hpp
@@ -23,11 +23,11 @@ inline bool inject_rtt_pixels(std::vector<uint8_t>& dst, uint32_t dst_w, uint32_
     const size_t dst_bytes = static_cast<size_t>(dst_texels) * bytes_per_pixel;
     const size_t src_bytes = static_cast<size_t>(src_texels) * bytes_per_pixel;
     if (src.size() != src_bytes) return false;
-    dst.assign(dst_bytes, 0);
     if (src_w == dst_w && src_h == dst_h) {
         dst = src;
         return true;
     }
+    dst.resize(dst_bytes);
     for (uint32_t y = 0; y < dst_h; ++y) {
         const uint32_t sy = static_cast<uint32_t>(static_cast<uint64_t>(y) * src_h / dst_h);
         for (uint32_t x = 0; x < dst_w; ++x) {

--- a/prosper/frontends/shared/rtt_injection.hpp
+++ b/prosper/frontends/shared/rtt_injection.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <vector>
+
+namespace prosper::frontend {
+
+// Copy a renderer-owned target into a sampled-resource buffer, nearest-scaling when the view extent
+// differs. The RTT format owns the byte stride: consumers such as 1D views may have been provisionally
+// sized as RGBA8 even when the cached producer is RGBA16F, so this helper resizes before every write.
+inline bool inject_rtt_pixels(std::vector<uint8_t>& dst, uint32_t dst_w, uint32_t dst_h,
+                              const std::vector<uint8_t>& src, uint32_t src_w, uint32_t src_h,
+                              uint32_t bytes_per_pixel) {
+    if (!dst_w || !dst_h || !src_w || !src_h || !bytes_per_pixel) return false;
+    const uint64_t dst_texels = static_cast<uint64_t>(dst_w) * dst_h;
+    const uint64_t src_texels = static_cast<uint64_t>(src_w) * src_h;
+    if (dst_texels > std::numeric_limits<size_t>::max() / bytes_per_pixel ||
+        src_texels > std::numeric_limits<size_t>::max() / bytes_per_pixel)
+        return false;
+    const size_t dst_bytes = static_cast<size_t>(dst_texels) * bytes_per_pixel;
+    const size_t src_bytes = static_cast<size_t>(src_texels) * bytes_per_pixel;
+    if (src.size() != src_bytes) return false;
+    dst.assign(dst_bytes, 0);
+    if (src_w == dst_w && src_h == dst_h) {
+        dst = src;
+        return true;
+    }
+    for (uint32_t y = 0; y < dst_h; ++y) {
+        const uint32_t sy = static_cast<uint32_t>(static_cast<uint64_t>(y) * src_h / dst_h);
+        for (uint32_t x = 0; x < dst_w; ++x) {
+            const uint32_t sx = static_cast<uint32_t>(static_cast<uint64_t>(x) * src_w / dst_w);
+            const size_t si = (static_cast<size_t>(sy) * src_w + sx) * bytes_per_pixel;
+            const size_t di = (static_cast<size_t>(y) * dst_w + x) * bytes_per_pixel;
+            std::memcpy(dst.data() + di, src.data() + si, bytes_per_pixel);
+        }
+    }
+    return true;
+}
+
+} // namespace prosper::frontend

--- a/prosper/frontends/shared/test_rtt_injection.cpp
+++ b/prosper/frontends/shared/test_rtt_injection.cpp
@@ -27,8 +27,10 @@ int main() {
     CHECK(std::equal(scaled.begin(), scaled.begin() + 8, fp16_source.begin()));
     CHECK(std::equal(scaled.begin() + 8, scaled.end(), fp16_source.begin() + 16));
 
-    std::vector<uint8_t> malformed(7);
+    std::vector<uint8_t> malformed(7), fallback_bytes = {0xaa, 0xbb, 0xcc, 0xdd};
+    consumer = fallback_bytes;
     CHECK(!inject_rtt_pixels(consumer, 1, 1, malformed, 1, 1, 8));
+    CHECK(consumer == fallback_bytes); // rejection preserves the caller's guest-decode fallback buffer
 
     if (!failures) std::printf("rtt_injection: OK\n");
     return failures ? 1 : 0;

--- a/prosper/frontends/shared/test_rtt_injection.cpp
+++ b/prosper/frontends/shared/test_rtt_injection.cpp
@@ -1,0 +1,35 @@
+#include "rtt_injection.hpp"
+
+#include <algorithm>
+#include <cstdio>
+#include <vector>
+
+using prosper::frontend::inject_rtt_pixels;
+
+static int failures = 0;
+#define CHECK(cond) do { if (!(cond)) { \
+    std::fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond); ++failures; } } while (0)
+
+int main() {
+    // #1293: a 1D consumer was provisionally allocated at RGBA8 (4 B/px), then an exact-size FP16
+    // RTT injection memcpy'd 8 B/px into it. The helper must resize from the producer's real stride.
+    std::vector<uint8_t> fp16_source(4 * 2 * 8);
+    for (size_t i = 0; i < fp16_source.size(); ++i) fp16_source[i] = static_cast<uint8_t>(i);
+    std::vector<uint8_t> consumer(4 * 2 * 4, 0xcc);
+    CHECK(inject_rtt_pixels(consumer, 4, 2, fp16_source, 4, 2, 8));
+    CHECK(consumer.size() == fp16_source.size());
+    CHECK(consumer == fp16_source);
+
+    // The mismatched-extent path must use the same 8-byte destination stride while nearest-scaling.
+    std::vector<uint8_t> scaled;
+    CHECK(inject_rtt_pixels(scaled, 2, 1, fp16_source, 4, 2, 8));
+    CHECK(scaled.size() == 2 * 1 * 8);
+    CHECK(std::equal(scaled.begin(), scaled.begin() + 8, fp16_source.begin()));
+    CHECK(std::equal(scaled.begin() + 8, scaled.end(), fp16_source.begin() + 16));
+
+    std::vector<uint8_t> malformed(7);
+    CHECK(!inject_rtt_pixels(consumer, 1, 1, malformed, 1, 1, 8));
+
+    if (!failures) std::printf("rtt_injection: OK\n");
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

- route renderer-owned RTT injection through a bounds-checked nearest-scale helper
- size sampled-resource storage from the producer RTT byte stride before copying
- add exact-size and scaled RGBA16F regression coverage

## Why

A 1D consumer was provisionally allocated as RGBA8 (4 bytes/texel), while the cached renderer-owned producer could be RGBA16F (8 bytes/texel). Both the exact memcpy and scaled copy then wrote at the producer stride into the smaller destination, causing a heap overrun.

Fixes #1293

## Verification

- `cmake --build prosper/build-audit --target test_rtt_injection prosper_live_renderer -j8`
- `ctest --test-dir prosper/build-audit -R rtt_injection --output-on-failure`
- `git diff --check`