### PR TITLE
fix(render): materialize same-batch scanout consumers

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -356,6 +356,10 @@ if(TARGET prosper_core)
   target_include_directories(test_rtt_injection PRIVATE frontends/shared)
   add_test(NAME rtt_injection COMMAND test_rtt_injection)
 
+  add_executable(test_readback_policy frontends/shared/test_readback_policy.cpp)
+  target_include_directories(test_readback_policy PRIVATE frontends/shared)
+  add_test(NAME readback_policy COMMAND test_readback_policy)
+
   # Bounded-acquire present classification (#1182). Needs Vulkan HEADERS only (VkResult enum), no loader
   # call — link Vulkan::Vulkan purely for its include dirs. Guarded so a headers-less host skips it
   # gracefully; every platform that builds prosper-app has Vulkan available.

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -2,6 +2,7 @@
 // (behavior-preserving); Vulkan-backed, so this unit links Vulkan::Vulkan.
 #include "live_renderer.hpp"
 #include "rtt_injection.hpp"
+#include "readback_policy.hpp"
 #include "live_compute.hpp"
 
 #include "gpu/gpu_execute.hpp"          // DrawItem, set_submit_renderer
@@ -2711,8 +2712,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     // authoritative readback, and compute consumers use the lazy target reader above.
                     const bool defer_readback = live_gpu_targets && vo_n > 0 && base &&
                         !phase.authoritative_readback &&
-                        ((is_vo && phase.allows_deferred_scanout_readback() &&
-                          defer_intermediate_scanout) ||
+                        ((is_vo && can_defer_intermediate_scanout_readback(
+                                       phase.allows_deferred_scanout_readback(),
+                                       defer_intermediate_scanout, cpu_needed_same_batch)) ||
                          (!is_vo && base != front_va && rtt_defer_ok));
                     // PROSPER_READBACK_WHY (#1284): classify WHY each non-deferred pass takes the
                     // synchronous CPU readback (75-79 ms/window on Blue Prince's Day One frame).

--- a/prosper/frontends/shared/readback_policy.hpp
+++ b/prosper/frontends/shared/readback_policy.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+namespace prosper::frontend {
+
+// An intermediate scanout normally stays GPU-resident until the final presentation callback.
+// A later non-direct consumer in the same submit is different: it needs authoritative CPU bytes
+// before the batch is submitted, so deferring here would make it observe the previous submit.
+constexpr bool can_defer_intermediate_scanout_readback(bool phase_allows_defer,
+                                                        bool defer_intermediate_scanout,
+                                                        bool cpu_needed_same_batch) {
+    return phase_allows_defer && defer_intermediate_scanout && !cpu_needed_same_batch;
+}
+
+} // namespace prosper::frontend

--- a/prosper/frontends/shared/test_readback_policy.cpp
+++ b/prosper/frontends/shared/test_readback_policy.cpp
@@ -1,0 +1,22 @@
+#include "readback_policy.hpp"
+
+#include <cstdio>
+
+using prosper::frontend::can_defer_intermediate_scanout_readback;
+
+static int failures = 0;
+#define CHECK(cond) do { if (!(cond)) { \
+    std::fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond); ++failures; } } while (0)
+
+int main() {
+    CHECK(can_defer_intermediate_scanout_readback(true, true, false));
+
+    // #1295: a same-submit 1D/cube/storage consumer cannot use the direct GPU target binding.
+    // Deferring its producer's readback makes that consumer decode stale guest bytes.
+    CHECK(!can_defer_intermediate_scanout_readback(true, true, true));
+    CHECK(!can_defer_intermediate_scanout_readback(false, true, false));
+    CHECK(!can_defer_intermediate_scanout_readback(true, false, false));
+
+    if (!failures) std::printf("readback_policy: OK\n");
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## What changed

- prevent intermediate scanout readback deferral when a later same-submit consumer needs CPU pixels
- extract the decision into a small renderer policy helper
- add a focused regression covering the stale-pixel case

## Root cause

The intermediate-video-output branch bypassed `cpu_needed_same_batch`. A later 1D, cube, storage, feedback, or color-seed consumer could therefore decode guest memory before its producing GPU commands had been submitted, observing pixels from the previous submit.

## Impact

Same-batch non-direct consumers now force authoritative readback while ordinary intermediate scanouts remain GPU-resident.

## Validation

- `cmake --build build-audit --target test_readback_policy prosper_live_renderer -j8`
- `ctest --test-dir build-audit -R "^readback_policy$" --output-on-failure`
- `git diff --check`

Fixes #1295