### PR TITLE
gpu(render): sampled depth-plane bridge + true shadow-atlas extents

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -1239,7 +1239,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // surface prosper rendered into a persistent Vulkan DS image. Guest memory
                         // never receives that depth, so the guest-byte decode below would sample
                         // zeros (every shadow compare passes -> unshadowed, overbright scenes).
-                        // Bind the retained depth image directly instead.
+                        // Bind the retained depth image directly instead. Under
+                        // PROSPER_RENDER_SCALE>1 the DS extent is scaled while the T# stays native,
+                        // so the exact-extent match misses and scaled captures render unshadowed —
+                        // a documented limitation of the deliberate sampling accelerations.
                         const bool has_ds_live = !has_live_rtt && !fr.is_storage_image &&
                             r.img_dim == 1u && r.cls == RC::Texture &&
                             prosper::test::find_persistent_ds_sampled(r.gpu_addr, tw, th).image !=
@@ -2604,32 +2607,6 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                draw->ps.depth_clear_enable || draw->ps.stencil_enable ||
                                draw->ps.stencil_clear_enable;
                     });
-                    // DB_DEPTH_SIZE_XY is the depth surface's own allocation extent (X_MAX/Y_MAX+1)
-                    // — authoritative for a depth-only pass, unlike viewport coordinates (#1275).
-                    // Blue Prince renders 512x512 cascade viewports into a 2048x2048 shadow atlas:
-                    // viewport recovery under-sizes the surface and the presentation cap rejects the
-                    // atlas outright, leaving a 1x1 DS image whose depth every shadow tap then
-                    // misses. The register extent also exceeds the presentation surface by design,
-                    // so it bypasses that cap; a 16384 bound keeps corrupt state fail-visible.
-                    if (color_disabled && uses_ds) {
-                        uint32_t depth_reg_w = 0, depth_reg_h = 0;
-                        for (const auto* draw : pass) {
-                            const uint32_t size_xy = draw->ps.db_depth_size_xy;
-                            if (!size_xy) continue;
-                            const uint32_t reg_w = (size_xy & 0x3FFFu) + 1u;
-                            const uint32_t reg_h = ((size_xy >> 16) & 0x3FFFu) + 1u;
-                            depth_reg_w = std::max(depth_reg_w, reg_w);
-                            depth_reg_h = std::max(depth_reg_h, reg_h);
-                        }
-                        if (depth_reg_w > 1 && depth_reg_h > 1 && depth_reg_w <= 16384u &&
-                            depth_reg_h <= 16384u) {
-                            native_w = std::max(native_w, depth_reg_w);
-                            native_h = std::max(native_h, depth_reg_h);
-                            if (getenv("PROSPER_DSLOG"))
-                                fprintf(stderr, "[ds] register-derived extent %ux%u\n",
-                                        depth_reg_w, depth_reg_h);
-                        }
-                    }
                     if (color_disabled && uses_ds && w && h) {
                         float viewport_x = 0.0f, viewport_y = 0.0f;
                         for (const auto* draw : pass) {
@@ -2653,13 +2630,12 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // Prince's directional-shadow cascades render translated 512x512/1024x1024
                         // viewports into 2048x2048 and 4096x4096 atlases (#1275). Capping at the
                         // presentation surface collapsed those atlases to 1x1, erasing every shadow.
-                        // 4096 keeps the Dead Cells pathology (translated viewports inferring
+                        // The per-axis bound (each axis against its own presentation axis, or 4096)
+                        // keeps the Dead Cells pathology (translated viewports inferring
                         // 16384x16384, the reason this cap exists) rejected and fail-visible.
-                        const uint64_t ds_extent_limit =
-                            std::max<uint64_t>(4096u, std::max(max_native_w, max_native_h));
                         const bool viewport_extent_valid = viewport_native_w && viewport_native_h &&
-                            viewport_native_w <= ds_extent_limit &&
-                            viewport_native_h <= ds_extent_limit;
+                            viewport_native_w <= std::max<uint64_t>(4096u, max_native_w) &&
+                            viewport_native_h <= std::max<uint64_t>(4096u, max_native_h);
                         if (getenv("PROSPER_DSLOG") && (viewport_native_w || viewport_native_h)) {
                             fprintf(stderr,
                                     "[ds] viewport-derived extent %llux%llu (presentation %ux%u) -> %s\n",
@@ -2681,12 +2657,14 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         } else if (present_w && present_h) {
                             gw = std::max(1u, (uint32_t)(((uint64_t)native_w * w + present_w / 2) / present_w));
                             gh = std::max(1u, (uint32_t)(((uint64_t)native_h * h + present_h / 2) / present_h));
-                        } else {
-                            // No presentation extent (offline replay): render scale is 1, so the
-                            // surface's own native extent is exact. Falling back to the global w/h
-                            // here silently truncated over-presentation surfaces — Blue Prince's
-                            // 2048x2048 shadow atlas became a 1920x1080 DS image whose sampled
-                            // taps then missed the bridge (#1275).
+                        } else if (color_disabled && uses_ds) {
+                            // No presentation extent (offline replay): render scale is 1, so a
+                            // depth-only surface's viewport-derived extent is exact. Falling back
+                            // to the global w/h here silently truncated over-presentation atlases —
+                            // Blue Prince's 2048x2048 shadow atlas became a 1920x1080 DS image
+                            // whose sampled taps then missed the bridge (#1275). Color passes keep
+                            // the historical capture-extent truncation (their over-allocated
+                            // CB_COLOR0_ATTRIB2 backings are a different, hash-pinned contract).
                             gw = native_w; gh = native_h;
                         }
                     }

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -1235,11 +1235,38 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                         live_rtt != g_rtt.end() ? (int)(bool)live_rtt->second.rgba
                                                                 : -1);
                         }
+                        // Sampled depth bridge (#1275): the T# addresses the depth plane of a
+                        // surface prosper rendered into a persistent Vulkan DS image. Guest memory
+                        // never receives that depth, so the guest-byte decode below would sample
+                        // zeros (every shadow compare passes -> unshadowed, overbright scenes).
+                        // Bind the retained depth image directly instead.
+                        const bool has_ds_live = !has_live_rtt && !fr.is_storage_image &&
+                            r.img_dim == 1u && r.cls == RC::Texture &&
+                            prosper::test::find_persistent_ds_sampled(r.gpu_addr, tw, th).image !=
+                                nullptr;
                         if (has_gpu_live_rtt) {
                             fr.persistent_render_target_id = r.gpu_addr;
                             fr.tw = tw; fr.th = th; fr.td = 1; fr.img_dim = r.img_dim;
                             fr.texture_format = live_rtt->second.format;
                             resource_rtt_hit = true;
+                        } else if (has_ds_live) {
+                            fr.persistent_depth_target_id = r.gpu_addr;
+                            fr.tw = tw; fr.th = th; fr.td = 1; fr.img_dim = r.img_dim;
+                            resource_rtt_hit = true;
+                            if (getenv("PROSPER_DSBRIDGE_LOG")) {
+                                static int consumer_logged = 0;
+                                if (consumer_logged++ < 24)
+                                    fprintf(stderr,
+                                            "[dsbridge] consumer draw target=0x%llx samples "
+                                            "0x%llx %ux%u cwm=%x scissor=[%d,%d)-[%d,%d) "
+                                            "dcmp=%d func=%u\n",
+                                            (unsigned long long)draw.color0_base,
+                                            (unsigned long long)r.gpu_addr, tw, th,
+                                            draw.ps.color_write_mask, draw.ps.scissor_left,
+                                            draw.ps.scissor_top, draw.ps.scissor_right,
+                                            draw.ps.scissor_bottom, (int)r.depth_compare,
+                                            r.depth_compare_func);
+                            }
                         } else if (decoded_reuse) {
                             fr.tex_rgba = decoded_reuse->pixels;
                             fr.tw = tw;
@@ -2577,6 +2604,32 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                draw->ps.depth_clear_enable || draw->ps.stencil_enable ||
                                draw->ps.stencil_clear_enable;
                     });
+                    // DB_DEPTH_SIZE_XY is the depth surface's own allocation extent (X_MAX/Y_MAX+1)
+                    // — authoritative for a depth-only pass, unlike viewport coordinates (#1275).
+                    // Blue Prince renders 512x512 cascade viewports into a 2048x2048 shadow atlas:
+                    // viewport recovery under-sizes the surface and the presentation cap rejects the
+                    // atlas outright, leaving a 1x1 DS image whose depth every shadow tap then
+                    // misses. The register extent also exceeds the presentation surface by design,
+                    // so it bypasses that cap; a 16384 bound keeps corrupt state fail-visible.
+                    if (color_disabled && uses_ds) {
+                        uint32_t depth_reg_w = 0, depth_reg_h = 0;
+                        for (const auto* draw : pass) {
+                            const uint32_t size_xy = draw->ps.db_depth_size_xy;
+                            if (!size_xy) continue;
+                            const uint32_t reg_w = (size_xy & 0x3FFFu) + 1u;
+                            const uint32_t reg_h = ((size_xy >> 16) & 0x3FFFu) + 1u;
+                            depth_reg_w = std::max(depth_reg_w, reg_w);
+                            depth_reg_h = std::max(depth_reg_h, reg_h);
+                        }
+                        if (depth_reg_w > 1 && depth_reg_h > 1 && depth_reg_w <= 16384u &&
+                            depth_reg_h <= 16384u) {
+                            native_w = std::max(native_w, depth_reg_w);
+                            native_h = std::max(native_h, depth_reg_h);
+                            if (getenv("PROSPER_DSLOG"))
+                                fprintf(stderr, "[ds] register-derived extent %ux%u\n",
+                                        depth_reg_w, depth_reg_h);
+                        }
+                    }
                     if (color_disabled && uses_ds && w && h) {
                         float viewport_x = 0.0f, viewport_y = 0.0f;
                         for (const auto* draw : pass) {
@@ -2596,8 +2649,17 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             std::ceil(viewport_x * static_cast<float>(max_native_w) / w));
                         const uint64_t viewport_native_h = static_cast<uint64_t>(
                             std::ceil(viewport_y * static_cast<float>(max_native_h) / h));
+                        // Depth-only surfaces legitimately exceed the presentation extent: Blue
+                        // Prince's directional-shadow cascades render translated 512x512/1024x1024
+                        // viewports into 2048x2048 and 4096x4096 atlases (#1275). Capping at the
+                        // presentation surface collapsed those atlases to 1x1, erasing every shadow.
+                        // 4096 keeps the Dead Cells pathology (translated viewports inferring
+                        // 16384x16384, the reason this cap exists) rejected and fail-visible.
+                        const uint64_t ds_extent_limit =
+                            std::max<uint64_t>(4096u, std::max(max_native_w, max_native_h));
                         const bool viewport_extent_valid = viewport_native_w && viewport_native_h &&
-                            viewport_native_w <= max_native_w && viewport_native_h <= max_native_h;
+                            viewport_native_w <= ds_extent_limit &&
+                            viewport_native_h <= ds_extent_limit;
                         if (getenv("PROSPER_DSLOG") && (viewport_native_w || viewport_native_h)) {
                             fprintf(stderr,
                                     "[ds] viewport-derived extent %llux%llu (presentation %ux%u) -> %s\n",
@@ -2619,6 +2681,13 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         } else if (present_w && present_h) {
                             gw = std::max(1u, (uint32_t)(((uint64_t)native_w * w + present_w / 2) / present_w));
                             gh = std::max(1u, (uint32_t)(((uint64_t)native_h * h + present_h / 2) / present_h));
+                        } else {
+                            // No presentation extent (offline replay): render scale is 1, so the
+                            // surface's own native extent is exact. Falling back to the global w/h
+                            // here silently truncated over-presentation surfaces — Blue Prince's
+                            // 2048x2048 shadow atlas became a 1920x1080 DS image whose sampled
+                            // taps then missed the bridge (#1275).
+                            gw = native_w; gh = native_h;
                         }
                     }
                     std::vector<prosper::gpu::DrawItem> adjusted;

--- a/prosper/src/gpu/render_state.cpp
+++ b/prosper/src/gpu/render_state.cpp
@@ -395,6 +395,20 @@ RenderState extract_render_state(const GpuState& st) {
         // mechanism verified against the live capture; the un-offset recovery matches hardware.
         if (!combine(/*apply_offset=*/true) && (offset_x != 0 || offset_y != 0))
             combine(/*apply_offset=*/false);
+        // PROSPER_SCISSORLOG (#1287 bring-up): print the raw scissor registers whenever the combined
+        // rectangle is empty — Blue Prince resolves 699 of ~2,400 Day One draws to [0,0)x[0,0).
+        if (right <= left || bottom <= top) {
+            static const bool scissor_log = getenv("PROSPER_SCISSORLOG") != nullptr;
+            static int logged = 0;
+            if (scissor_log && logged < 24) {
+                ++logged;
+                fprintf(stderr,
+                        "[scissor] EMPTY combined=[%d,%d)-[%d,%d) screen=%08x/%08x window=%08x/%08x "
+                        "generic=%08x/%08x vport=%08x/%08x offset=%08x mode=%08x\n",
+                        left, top, right, bottom, screen_tl, screen_br, window_tl, window_br,
+                        generic_tl, generic_br, viewport_tl, viewport_br, window_offset, mode);
+            }
+        }
         rs.scissor_left = left; rs.scissor_top = top;
         rs.scissor_right = right; rs.scissor_bottom = bottom;
     }

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -132,6 +132,11 @@ struct FrameResource {
     // target is available, bind its GPU image directly instead of uploading `tex_rgba` again.
     // `tex_rgba` remains an optional conservative fallback for an invalidated/missing target.
     uint64_t persistent_render_target_id = 0;
+    // Non-zero identifies a persistent depth/stencil surface whose DEPTH plane this resource
+    // samples (a shadow map / depth pyramid tap, #1275). The backend binds the retained Vulkan
+    // depth image directly — prosper never writes rendered depth back to guest memory, so there
+    // is no CPU fallback; an invalidated/missing surface falls through to the guest-byte decode.
+    uint64_t persistent_depth_target_id = 0;
     const uint32_t* buffer_words_data() const {
         return dwords_view && dwords_view_count
             ? dwords_view : (dwords.empty() ? nullptr : dwords.data());
@@ -139,7 +144,10 @@ struct FrameResource {
     size_t buffer_word_count() const {
         return dwords_view && dwords_view_count ? dwords_view_count : dwords.size();
     }
-    bool is_texture() const { return tex_rgba != nullptr || persistent_render_target_id != 0; }
+    bool is_texture() const {
+        return tex_rgba != nullptr || persistent_render_target_id != 0 ||
+               persistent_depth_target_id != 0;
+    }
 };
 
 // Optional color-target contract for the live backend. A non-zero ID gives the target a stable
@@ -1442,6 +1450,45 @@ persistent_ds_cache() {
     return cache;
 }
 
+// Sampled depth-plane lookup (#1275): a shadow-map / depth-pyramid T# addresses the DEPTH plane of
+// a surface prosper rendered into a persistent Vulkan DS image and never wrote back to guest
+// memory. Resolve that address (read or write base — the guest aliases both at the same plane) to
+// the retained image so the consumer can bind it directly. Extent must match the T# exactly; only
+// a valid, initialized depth plane may be sampled.
+struct PersistentDsSampled {
+    PersistentDsImage* image = nullptr;
+    VkFormat format = VK_FORMAT_UNDEFINED;
+};
+inline PersistentDsSampled find_persistent_ds_sampled(uint64_t addr, uint32_t width,
+                                                      uint32_t height) {
+    if (!addr) return {};
+    static const bool bridge_log = getenv("PROSPER_DSBRIDGE_LOG") != nullptr;
+    for (auto& [key, image] : persistent_ds_cache()) {
+        if (key.w != width || key.h != height) continue;
+        if (key.dr != addr && key.dw != addr) continue;
+        if (!image.depth_valid || !image.layout_initialized || !image.image) continue;
+        if (bridge_log) {
+            static int hits = 0;
+            if (hits++ < 8)
+                fprintf(stderr, "[dsbridge] HIT addr=0x%llx %ux%u fmt=%u\n",
+                        (unsigned long long)addr, width, height, key.fmt);
+        }
+        return {&image, static_cast<VkFormat>(key.fmt)};
+    }
+    if (bridge_log) {
+        static int misses = 0;
+        if (misses++ < 8) {
+            fprintf(stderr, "[dsbridge] miss addr=0x%llx %ux%u; cache:\n",
+                    (unsigned long long)addr, width, height);
+            for (const auto& [key, image] : persistent_ds_cache())
+                fprintf(stderr, "[dsbridge]   dr=0x%llx dw=0x%llx %ux%u fmt=%u dvalid=%d init=%d\n",
+                        (unsigned long long)key.dr, (unsigned long long)key.dw, key.w, key.h,
+                        key.fmt, (int)image.depth_valid, (int)image.layout_initialized);
+        }
+    }
+    return {};
+}
+
 inline bool guest_ranges_overlap(uint64_t a, uint64_t a_size, uint64_t b, uint64_t b_size) {
     if (!a || !a_size || !b || !b_size) return false;
     return a < b + b_size && b < a + a_size;
@@ -1829,7 +1876,8 @@ inline bool restore_persistent_ds_image(const prosper::gpu::GpuCaptureDsSeed& se
         info.mipLevels = 1; info.arrayLayers = 1; info.samples = VK_SAMPLE_COUNT_1_BIT;
         info.tiling = VK_IMAGE_TILING_OPTIMAL;
         info.usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT |
-                     VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+                     VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT |
+                     VK_IMAGE_USAGE_SAMPLED_BIT;   // sampled depth bridge (#1275)
         if (vkCreateImage(ctx.dev, &info, nullptr, &image.image) != VK_SUCCESS) {
             error = "cannot create restored persistent DS image"; return false;
         }
@@ -2200,7 +2248,8 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         dci.mipLevels = 1; dci.arrayLayers = 1; dci.samples = VK_SAMPLE_COUNT_1_BIT;
         dci.tiling = VK_IMAGE_TILING_OPTIMAL;
         dci.usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT |
-                    VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+                    VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT |
+                    VK_IMAGE_USAGE_SAMPLED_BIT;   // sampled depth bridge (#1275)
         vkCreateImage(dev, &dci, nullptr, &dimg);
         VkMemoryRequirements dr; vkGetImageMemoryRequirements(dev, dimg, &dr);
         VkMemoryAllocateInfo dai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO};
@@ -2328,6 +2377,11 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         VkDeviceSize image_bytes = 0;
         bool persistent_hit = false;
         bool borrowed_target = false;
+        // Sampled depth bridge (#1275): image borrowed from the persistent DS cache. The view uses
+        // the DEPTH aspect of ds_format, and the call transitions the image DS-attachment ->
+        // shader-read around its passes.
+        bool borrowed_ds = false;
+        VkFormat ds_format = VK_FORMAT_UNDEFINED;
         bool direct_memory = false;
     };
     struct PersistentTextureKey {
@@ -2921,8 +2975,13 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                         // (T# extents are rejected above 16384 -> <= 15 levels).
                         if (tex_mip_levels > 16u) tex_mip_levels = 16u;
                     }
+                    // A DS-bridged resource shares the id slot: both are guest plane addresses, and
+                    // pixels stays null for either direct bind, so distinct surfaces cannot collide.
                     const TextureUploadKey texture_key{
-                        r.tex_rgba, r.persistent_render_target_id, r.tw, r.th, r.td, r.img_dim,
+                        r.tex_rgba,
+                        r.persistent_render_target_id ? r.persistent_render_target_id
+                                                      : r.persistent_depth_target_id,
+                        r.tw, r.th, r.td, r.img_dim,
                         tex_mip_levels, backend_color_format(r.texture_format), r.is_storage_image};
                     size_t upload_index = SIZE_MAX;
                     if (share_texture_uploads) {
@@ -2950,11 +3009,28 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                                 ++color_target_stats.sampled_hits;
                             }
                         }
-                        upload.persistent_id = r.is_storage_image ? 0 : r.persistent_texture_id;
+                        // Sampled depth bridge (#1275): the T# addresses a depth plane rendered
+                        // into a persistent DS image (never written back to guest memory). Bind
+                        // that image's depth aspect directly. The pass's own DS attachment must
+                        // not be borrowed as a sampled input (feedback) — cached_ds identifies it.
+                        if (!upload.image && !upload.borrowed_target && !r.is_storage_image &&
+                            r.persistent_depth_target_id && r.img_dim == 1) {
+                            const PersistentDsSampled sampled_ds = find_persistent_ds_sampled(
+                                r.persistent_depth_target_id, r.tw, r.th);
+                            if (sampled_ds.image &&
+                                (!cached_ds || sampled_ds.image->image != cached_ds->image)) {
+                                upload.image = sampled_ds.image->image;
+                                upload.borrowed_ds = true;
+                                upload.ds_format = sampled_ds.format;
+                            }
+                        }
+                        upload.persistent_id =
+                            r.is_storage_image || upload.borrowed_ds ? 0 : r.persistent_texture_id;
                         const PersistentTextureKey persistent_key{
                             r.persistent_texture_id, r.tw, r.th, r.td, r.img_dim,
                             texture_key.mip_levels, backend_color_format(r.texture_format)};
-                        if (!r.is_storage_image && !upload.borrowed_target && persistent_textures_enabled &&
+                        if (!r.is_storage_image && !upload.borrowed_target && !upload.borrowed_ds &&
+                            persistent_textures_enabled &&
                             r.persistent_texture_id) {
                             auto cached = persistent_texture_images.find(persistent_key);
                             if (cached != persistent_texture_images.end()) {
@@ -2968,7 +3044,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                             }
                         }
 
-                        if (!upload.persistent_hit && !upload.borrowed_target) {
+                        if (!upload.persistent_hit && !upload.borrowed_target && !upload.borrowed_ds) {
                             VkImageCreateInfo tci{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
                             const bool texture_3d = r.img_dim == 2;
                             tci.imageType = texture_3d ? VK_IMAGE_TYPE_3D : VK_IMAGE_TYPE_2D;
@@ -3060,6 +3136,13 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                         tvci.components = {vkswz(r.swizzle[0]), vkswz(r.swizzle[1]), vkswz(r.swizzle[2]), vkswz(r.swizzle[3])};
                     tvci.subresourceRange =
                         {VK_IMAGE_ASPECT_COLOR_BIT, 0, upload.key.mip_levels, 0, 1};
+                    // Sampled depth bridge (#1275): a borrowed DS image is viewed through its own
+                    // depth format's DEPTH aspect (one level — DS surfaces have no mip chains here);
+                    // the sampled value arrives in R. The T# swizzle above still applies.
+                    if (upload.borrowed_ds) {
+                        tvci.format = upload.ds_format;
+                        tvci.subresourceRange = {VK_IMAGE_ASPECT_DEPTH_BIT, 0, 1, 0, 1};
+                    }
                     VkSamplerCreateInfo sci{VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO};
                     // Honor the game's decoded S# (r.mag/min/mip_filter, r.addr_uvw) instead of a fixed
                     // LINEAR/clamp sampler — point-sampled art (pixel-art titles) no longer gets a blurred
@@ -3796,6 +3879,34 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                              VK_PIPELINE_STAGE_VERTEX_SHADER_BIT | VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
                              0, 0, nullptr, 0, nullptr, 1, &b1);
     }
+    // Sampled depth bridge (#1275): borrowed DS images live in DEPTH_STENCIL_ATTACHMENT_OPTIMAL
+    // between passes. Transition each (once) to SHADER_READ_ONLY for this pass's sampling; the
+    // matching post-pass barrier below returns it so the next depth pass LOADs it unchanged.
+    // Both aspects of a combined image must transition together.
+    std::vector<VkImage> borrowed_ds_images;
+    for (const SharedTextureUpload& upload : texture_uploads) {
+        if (!upload.borrowed_ds || !upload.image) continue;
+        if (std::find(borrowed_ds_images.begin(), borrowed_ds_images.end(), upload.image) !=
+            borrowed_ds_images.end())
+            continue;
+        borrowed_ds_images.push_back(upload.image);
+        const bool ds_has_stencil = upload.ds_format == VK_FORMAT_D32_SFLOAT_S8_UINT;
+        VkImageMemoryBarrier to_sampled{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
+        to_sampled.oldLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+        to_sampled.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+        to_sampled.image = upload.image;
+        to_sampled.subresourceRange = {
+            VK_IMAGE_ASPECT_DEPTH_BIT |
+                (ds_has_stencil ? VK_IMAGE_ASPECT_STENCIL_BIT : 0u), 0, 1, 0, 1};
+        to_sampled.srcAccessMask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+        to_sampled.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+        vkCmdPipelineBarrier(cmd,
+                             VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT |
+                                 VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT,
+                             VK_PIPELINE_STAGE_VERTEX_SHADER_BIT |
+                                 VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+                             0, 0, nullptr, 0, nullptr, 1, &to_sampled);
+    }
     // Clear color: the caller's clear_rgba (game fast-clear / black on the live path), else the
     // legacy diagnostic blue. PROSPER_CLEAR_DEBUG forces blue back on even when a color is passed.
     float cc[4] = {0.0f, 0.0f, 1.0f, 1.0f};   // diagnostic blue
@@ -3973,6 +4084,34 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                              VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT |
                                  VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT,
                              0, 0, nullptr, 0, nullptr, 1, &ds_ready);
+    }
+    // Sampled depth bridge (#1275): return each borrowed DS image to the layout every depth pass
+    // expects, so the bridge is invisible to the existing persistent-DS contract.
+    for (VkImage borrowed : borrowed_ds_images) {
+        VkFormat borrowed_format = VK_FORMAT_UNDEFINED;
+        for (const SharedTextureUpload& upload : texture_uploads)
+            if (upload.borrowed_ds && upload.image == borrowed) {
+                borrowed_format = upload.ds_format;
+                break;
+            }
+        VkImageMemoryBarrier to_ds{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
+        to_ds.oldLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+        to_ds.newLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+        to_ds.image = borrowed;
+        to_ds.subresourceRange = {
+            VK_IMAGE_ASPECT_DEPTH_BIT |
+                (borrowed_format == VK_FORMAT_D32_SFLOAT_S8_UINT ? VK_IMAGE_ASPECT_STENCIL_BIT
+                                                                 : 0u),
+            0, 1, 0, 1};
+        to_ds.srcAccessMask = VK_ACCESS_SHADER_READ_BIT;
+        to_ds.dstAccessMask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT |
+                              VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+        vkCmdPipelineBarrier(cmd,
+                             VK_PIPELINE_STAGE_VERTEX_SHADER_BIT |
+                                 VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+                             VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT |
+                                 VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT,
+                             0, 0, nullptr, 0, nullptr, 1, &to_ds);
     }
     if (readback_requested) {
         if (persistent_color) {
@@ -4445,7 +4584,8 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
             for (SharedBufferArena& arena : shared_buffer_arenas)
                 release_render_host_buffer(dev, arena.buffer);
             for (auto& upload : texture_uploads) {
-                if (upload.image && !upload.persistent_hit && !upload.borrowed_target)
+                if (upload.image && !upload.persistent_hit && !upload.borrowed_target &&
+                    !upload.borrowed_ds)
                     vkDestroyImage(dev, upload.image, nullptr);
                 if (upload.memory) {
                     if (upload.direct_memory) vkFreeMemory(dev, upload.memory, nullptr);

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -2680,7 +2680,13 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         v.vcount = bd.vcount;
         v.instance_count = bd.instance_count;
         v.scissor = {{0, 0}, {W, H}};
-        if (ps && ps->has_scissor) {
+        // PROSPER_IGNORE_EMPTY_SCISSOR (#1287 bring-up diagnostic): render draws whose resolved
+        // scissor is empty with a full-target scissor instead, to A/B whether they carry the
+        // missing post/shadow content. Off by default; not a fix.
+        static const bool ignore_empty_scissor = getenv("PROSPER_IGNORE_EMPTY_SCISSOR") != nullptr;
+        const bool scissor_empty = ps && ps->has_scissor &&
+            (ps->scissor_right <= ps->scissor_left || ps->scissor_bottom <= ps->scissor_top);
+        if (ps && ps->has_scissor && !(ignore_empty_scissor && scissor_empty)) {
             const int64_t left = std::clamp<int64_t>(ps->scissor_left, 0, W);
             const int64_t top = std::clamp<int64_t>(ps->scissor_top, 0, H);
             const int64_t right = std::clamp<int64_t>(ps->scissor_right, left, W);

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -1442,7 +1442,13 @@ struct PersistentDsImage {
     bool layout_initialized = false;
     bool depth_valid = false;
     bool stencil_valid = false;
+    uint64_t last_depth_write = 0;   // sampled-bridge recency (#1275)
 };
+
+inline uint64_t& persistent_ds_write_generation() {
+    static uint64_t generation = 0;
+    return generation;
+}
 
 inline std::unordered_map<PersistentDsKey, PersistentDsImage, PersistentDsKeyHash>&
 persistent_ds_cache() {
@@ -1463,17 +1469,27 @@ inline PersistentDsSampled find_persistent_ds_sampled(uint64_t addr, uint32_t wi
                                                       uint32_t height) {
     if (!addr) return {};
     static const bool bridge_log = getenv("PROSPER_DSBRIDGE_LOG") != nullptr;
+    // Prefer the most recently DEPTH-WRITTEN match: a surface re-keyed (D32 -> D32S8) keeps its
+    // stale sibling entry, and unordered_map iteration order must not pick the winner.
+    PersistentDsSampled best{};
+    uint64_t best_write = 0;
     for (auto& [key, image] : persistent_ds_cache()) {
         if (key.w != width || key.h != height) continue;
         if (key.dr != addr && key.dw != addr) continue;
         if (!image.depth_valid || !image.layout_initialized || !image.image) continue;
+        if (!best.image || image.last_depth_write > best_write) {
+            best = {&image, static_cast<VkFormat>(key.fmt)};
+            best_write = image.last_depth_write;
+        }
+    }
+    if (best.image) {
         if (bridge_log) {
             static int hits = 0;
             if (hits++ < 8)
                 fprintf(stderr, "[dsbridge] HIT addr=0x%llx %ux%u fmt=%u\n",
-                        (unsigned long long)addr, width, height, key.fmt);
+                        (unsigned long long)addr, width, height, (unsigned)best.format);
         }
-        return {&image, static_cast<VkFormat>(key.fmt)};
+        return best;
     }
     if (bridge_log) {
         static int misses = 0;
@@ -3099,7 +3115,24 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                             vkBindBufferMemory(dev, upload.staging, upload.staging_memory, 0);
                             void* sp = nullptr;
                             vkMapMemory(dev, upload.staging_memory, 0, tbytes, 0, &sp);
-                            std::memcpy(sp, r.tex_rgba, static_cast<size_t>(tbytes));
+                            if (r.tex_rgba) {
+                                std::memcpy(sp, r.tex_rgba, static_cast<size_t>(tbytes));
+                            } else {
+                                // Only a declined/missed depth-plane borrow reaches the creation
+                                // path with no CPU pixels (#1275: the bridge deliberately carries
+                                // none — e.g. the consumer samples its own bound DS attachment, or
+                                // the plane was invalidated between the frontend gate and this
+                                // lookup). Bind well-defined zeros — the value the guest-byte
+                                // decode of an unwritten depth address produced — and say so.
+                                std::memset(sp, 0, static_cast<size_t>(tbytes));
+                                static int declined_logged = 0;
+                                if (declined_logged++ < 16)
+                                    fprintf(stderr,
+                                            "[dsbridge] borrow declined/missed for 0x%llx %ux%u -> "
+                                            "zero texture\n",
+                                            (unsigned long long)r.persistent_depth_target_id,
+                                            r.tw, r.th);
+                            }
                             vkUnmapMemory(dev, upload.staging_memory);
                         }
                     }
@@ -3158,6 +3191,15 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                     };
                     sci.magFilter = vkflt(r.mag_filter); sci.minFilter = vkflt(r.min_filter);
                     sci.mipmapMode = r.mip_filter ? VK_SAMPLER_MIPMAP_MODE_LINEAR : VK_SAMPLER_MIPMAP_MODE_NEAREST;
+                    // Sampled depth bridge (#1275): LINEAR filtering of depth formats is an OPTIONAL
+                    // Vulkan format feature, and the manual-compare lowering takes single taps
+                    // anyway (filter-then-compare would differ from hardware's compare-then-filter
+                    // PCF regardless). Force NEAREST for borrowed depth views.
+                    if (upload.borrowed_ds) {
+                        sci.magFilter = VK_FILTER_NEAREST;
+                        sci.minFilter = VK_FILTER_NEAREST;
+                        sci.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
+                    }
                     sci.addressModeU = vkaddr(r.addr_uvw[0]);
                     sci.addressModeV = vkaddr(r.addr_uvw[1]);
                     sci.addressModeW = vkaddr(r.addr_uvw[2]);
@@ -3883,13 +3925,13 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     // between passes. Transition each (once) to SHADER_READ_ONLY for this pass's sampling; the
     // matching post-pass barrier below returns it so the next depth pass LOADs it unchanged.
     // Both aspects of a combined image must transition together.
-    std::vector<VkImage> borrowed_ds_images;
+    std::vector<std::pair<VkImage, VkFormat>> borrowed_ds_images;
     for (const SharedTextureUpload& upload : texture_uploads) {
         if (!upload.borrowed_ds || !upload.image) continue;
-        if (std::find(borrowed_ds_images.begin(), borrowed_ds_images.end(), upload.image) !=
-            borrowed_ds_images.end())
+        if (std::any_of(borrowed_ds_images.begin(), borrowed_ds_images.end(),
+                        [&](const auto& entry) { return entry.first == upload.image; }))
             continue;
-        borrowed_ds_images.push_back(upload.image);
+        borrowed_ds_images.push_back({upload.image, upload.ds_format});
         const bool ds_has_stencil = upload.ds_format == VK_FORMAT_D32_SFLOAT_S8_UINT;
         VkImageMemoryBarrier to_sampled{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
         to_sampled.oldLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
@@ -4087,13 +4129,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     }
     // Sampled depth bridge (#1275): return each borrowed DS image to the layout every depth pass
     // expects, so the bridge is invisible to the existing persistent-DS contract.
-    for (VkImage borrowed : borrowed_ds_images) {
-        VkFormat borrowed_format = VK_FORMAT_UNDEFINED;
-        for (const SharedTextureUpload& upload : texture_uploads)
-            if (upload.borrowed_ds && upload.image == borrowed) {
-                borrowed_format = upload.ds_format;
-                break;
-            }
+    for (const auto& [borrowed, borrowed_format] : borrowed_ds_images) {
         VkImageMemoryBarrier to_ds{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
         to_ds.oldLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
         to_ds.newLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
@@ -4217,6 +4253,10 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         cached_ds->layout_initialized = true;
         cached_ds->depth_valid |= use_depth && depth_used_meaningfully;
         cached_ds->stencil_valid |= use_stencil;
+        // Sampled depth bridge (#1275): recency for find_persistent_ds_sampled — two valid
+        // entries can share a plane address (a surface re-keyed D32 -> D32S8 keeps its old
+        // entry), and the most recently written one is the live truth.
+        if (use_depth) cached_ds->last_depth_write = ++persistent_ds_write_generation();
     }
     if (cached_color) {
         active_submission.add_failure_cleanup([cached_color]() {

--- a/prosper/tests/test_shadow_compare_render.cpp
+++ b/prosper/tests/test_shadow_compare_render.cpp
@@ -84,6 +84,78 @@ int main() {
     CHECK(right_total && right_fail == right_total,
           "dref 0.5 GREATER fails (0.0) where stored depth is ~0.9");
 
+    // ---- Persistent-DS sampled bridge (#1275) ----
+    // A depth-only producer renders a fullscreen triangle at z=0.25 into a guest-identified
+    // persistent DS surface. prosper never writes that depth back to guest memory, so a consumer
+    // sampling the depth-plane address as a 2D texture must be served by the retained Vulkan depth
+    // image (the bridge); without it the consumer reads zeros. The consumer samples at (0.25,0.25)
+    // and exports R = stored depth: bridge -> ~0.25 (R~64), no bridge -> 0.
+    {
+        const uint32_t vs_z[] = {
+            0x36020081u, 0x2c040081u, 0x7e020d01u, 0x7e040d02u, 0x100602f6u, 0x100804f6u,
+            0x060606f3u, 0x060808f3u, 0x100a02f4u, 0x100c04f4u, 0x7e0e02ffu, 0x3e800000u,
+            0x7e1002f2u, 0xf80008cfu, 0x08070403u, 0xf800020fu, 0x08070605u, 0xbf810000u,
+        };
+        const uint32_t ps_red[] = {
+            0x7e0002f2u, 0x7e020280u, 0x7e040280u, 0x7e0602f2u,
+            0xf800180fu, 0x03020100u, 0xbf810000u,
+        };
+        std::vector<uint32_t> vert_z = recompile_vertex(vs_z, sizeof(vs_z) / sizeof(vs_z[0]));
+        std::vector<uint32_t> red = recompile_fragment(ps_red, sizeof(ps_red) / sizeof(ps_red[0]),
+                                                       nullptr);
+        CHECK(!vert_z.empty() && !red.empty(), "recompiled z=0.25 producer shaders");
+
+        constexpr uint64_t kDepthBase = 0x20d5000000ull;
+        ResolvedPipelineState producer{};
+        producer.topology = 3; producer.color_write_mask = 0xF;
+        producer.depth_test_enable = true; producer.depth_write_enable = true;
+        producer.depth_compare_op = 7;   // ALWAYS
+        producer.depth_read_base = kDepthBase; producer.depth_write_base = kDepthBase;
+        prosper::test::BackendDraw pw;
+        pw.vs = vert_z; pw.fs = red; pw.ps = &producer; pw.vcount = 3;
+        std::vector<uint8_t> produced = prosper::test::render_draws_rgba(
+            {pw}, W, H, nullptr, nullptr, /*persist_depth_stencil=*/true);
+        CHECK(!produced.empty(), "depth-writing producer rendered with a persistent DS identity");
+
+        const uint32_t ps_sample[] = {
+            0x7e0002ffu, 0x3e800000u, 0x7e0202ffu, 0x3e800000u, 0xf0800f08u, 0x00820000u,
+            0xf800000fu, 0x03020100u, 0xbf810000u,
+        };
+        ShaderResourceTable sample_rt;
+        { ShaderResource t{}; t.cls = ResourceClass::Texture; t.binding = 4; t.img_dim = 1;
+          t.width = W; t.height = H; t.sgpr_base = 8; sample_rt.resources.push_back(t); }
+        std::vector<uint32_t> sample_fs = recompile_fragment(
+            ps_sample, sizeof(ps_sample) / sizeof(ps_sample[0]), &sample_rt);
+        CHECK(!sample_fs.empty(), "recompiled depth-plane sampling consumer");
+
+        ResolvedPipelineState opaque{};
+        opaque.topology = 3; opaque.color_write_mask = 0xF;
+        prosper::test::FrameResource bridged;
+        bridged.binding = 4; bridged.set = 1;
+        bridged.persistent_depth_target_id = kDepthBase;
+        bridged.tw = W; bridged.th = H;
+        prosper::test::BackendDraw consumer;
+        consumer.vs = vert; consumer.fs = sample_fs; consumer.ps = &opaque;
+        consumer.R = {bridged}; consumer.vcount = 3;
+        std::vector<uint8_t> via_bridge = prosper::test::render_draws_rgba({consumer}, W, H);
+        CHECK(via_bridge.size() == (size_t)W * H * 4, "bridged consumer rendered");
+
+        std::vector<uint8_t> zeros((size_t)W * H * 4, 0);
+        prosper::test::FrameResource unbridged = bridged;
+        unbridged.persistent_depth_target_id = 0;
+        unbridged.tex_rgba = zeros.data();
+        prosper::test::BackendDraw control = consumer;
+        control.R = {unbridged};
+        std::vector<uint8_t> via_zeros = prosper::test::render_draws_rgba({control}, W, H);
+
+        const uint8_t* center = &via_bridge[(((size_t)H / 2) * W + W / 2) * 4];
+        const uint8_t* center0 = &via_zeros[(((size_t)H / 2) * W + W / 2) * 4];
+        printf("  bridged center R=%u control R=%u\n", center[0], center0[0]);
+        CHECK(center[0] > 56 && center[0] < 72,
+              "bridged consumer reads the produced depth (~0.25) from the persistent DS image");
+        CHECK(center0[0] == 0, "control without the bridge samples zeros");
+    }
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -458,7 +458,8 @@ void inspect_frame(const prosper::gpu::GpuReplayFrame& replay) {
                 // A no-effect verdict hinges on the exact per-face stencil program — print it so a
                 // wrongly-skipped stencil writer is visible from the summary alone.
                 if (failure.pipeline.stencil_enable)
-                    std::printf(" sops=%u/%u/%u|%u/%u/%u swm=%02x/%02x scmp=%u/%u sref=%u/%u",
+                    std::printf(" sops=%u/%u/%u|%u/%u/%u swm=%02x/%02x scmp=%u/%u sref=%u/%u"
+                                " sopval=%u/%u",
                                 failure.pipeline.stencil_fail_op[0],
                                 failure.pipeline.stencil_pass_op[0],
                                 failure.pipeline.stencil_depth_fail_op[0],
@@ -470,7 +471,9 @@ void inspect_frame(const prosper::gpu::GpuReplayFrame& replay) {
                                 failure.pipeline.stencil_compare_op[0],
                                 failure.pipeline.stencil_compare_op[1],
                                 failure.pipeline.stencil_ref[0],
-                                failure.pipeline.stencil_ref[1]);
+                                failure.pipeline.stencil_ref[1],
+                                failure.pipeline.stencil_op_val[0],
+                                failure.pipeline.stencil_op_val[1]);
             }
             std::printf("\n");
         } else {

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -449,12 +449,29 @@ void inspect_frame(const prosper::gpu::GpuReplayFrame& replay) {
                         static_cast<unsigned long long>(failure.color0_base),
                         failure.color0_width, failure.color0_height, failure.vertex_count,
                         failure.pipeline_present ? "yes" : "no");
-            if (failure.pipeline_present)
+            if (failure.pipeline_present) {
                 std::printf(" fmt=%u cwm=%x depth=%d/%d/%u stencil=%d blend=%d",
                             failure.pipeline.color0_format, failure.pipeline.color_write_mask,
                             failure.pipeline.depth_test_enable, failure.pipeline.depth_write_enable,
                             failure.pipeline.depth_compare_op, failure.pipeline.stencil_enable,
                             failure.pipeline.blend_enable);
+                // A no-effect verdict hinges on the exact per-face stencil program — print it so a
+                // wrongly-skipped stencil writer is visible from the summary alone.
+                if (failure.pipeline.stencil_enable)
+                    std::printf(" sops=%u/%u/%u|%u/%u/%u swm=%02x/%02x scmp=%u/%u sref=%u/%u",
+                                failure.pipeline.stencil_fail_op[0],
+                                failure.pipeline.stencil_pass_op[0],
+                                failure.pipeline.stencil_depth_fail_op[0],
+                                failure.pipeline.stencil_fail_op[1],
+                                failure.pipeline.stencil_pass_op[1],
+                                failure.pipeline.stencil_depth_fail_op[1],
+                                failure.pipeline.stencil_write_mask[0],
+                                failure.pipeline.stencil_write_mask[1],
+                                failure.pipeline.stencil_compare_op[0],
+                                failure.pipeline.stencil_compare_op[1],
+                                failure.pipeline.stencil_ref[0],
+                                failure.pipeline.stencil_ref[1]);
+            }
             std::printf("\n");
         } else {
             const auto& launch = failure.compute_launch;

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -1844,6 +1844,42 @@ int main(int argc, char** argv) {
             std::fprintf(stderr, "[stencil-dump] snapshot failed: %s\n", derr.c_str());
         }
     }
+    // Sibling depth-plane dump (#1275): grayscale each persistent DEPTH plane + numeric stats, so a
+    // shadow atlas whose casters rasterize nothing is distinguishable from a populated one.
+    if (const char* ddump = getenv("PROSPER_DEPTH_DUMP")) {
+        std::vector<prosper::gpu::GpuCaptureDsSeed> seeds;
+        std::string derr;
+        if (prosper::test::snapshot_persistent_ds_images(seeds, derr)) {
+            for (size_t si = 0; si < seeds.size(); ++si) {
+                const auto& s = seeds[si];
+                if (!s.depth_valid || s.depth.empty()) continue;
+                const size_t n = static_cast<size_t>(s.width) * s.height;
+                const float* dz = reinterpret_cast<const float*>(s.depth.data());
+                const size_t nz = std::min(n, s.depth.size() / 4);
+                float dmin = 1e30f, dmax = -1e30f;
+                size_t nonzero = 0;
+                std::vector<uint8_t> rgba(n * 4, 255);
+                for (size_t p = 0; p < nz; ++p) {
+                    const float v = dz[p];
+                    dmin = std::min(dmin, v); dmax = std::max(dmax, v);
+                    if (v != 0.0f) ++nonzero;
+                    const uint8_t g = static_cast<uint8_t>(
+                        std::clamp(v, 0.0f, 1.0f) * 255.0f);
+                    rgba[p * 4 + 0] = g; rgba[p * 4 + 1] = g; rgba[p * 4 + 2] = g;
+                    rgba[p * 4 + 3] = 255;
+                }
+                char path[600];
+                std::snprintf(path, sizeof path, "%s_depth%zu_%ux%u.bmp", ddump, si,
+                              s.width, s.height);
+                prosper::test::dump_bmp(path, rgba, s.width, s.height);
+                std::fprintf(stderr,
+                             "[depth-dump] ds%zu %ux%u min=%g max=%g nonzero=%zu/%zu -> %s\n",
+                             si, s.width, s.height, dmin, dmax, nonzero, nz, path);
+            }
+        } else {
+            std::fprintf(stderr, "[depth-dump] snapshot failed: %s\n", derr.c_str());
+        }
+    }
     const auto extent_mode = selected_draws_only
         ? prosper::gpu::replay_tool::OutputExtentMode::SelectedDraws
         : (through_operation >= 0 || (draw_first >= 0 && draw_with_compute_prefix))


### PR DESCRIPTION
Fixes #1275. Refs #1287.

## Failure scenario

Blue Prince renders directional-shadow cascades into 2048×2048/4096×4096 depth atlases, then samples them in a 512×512 screen-space shadow-mask pass (`IMAGE_SAMPLE_C_LZ`, manual-compare lowering from #1276). Two independent defects erased every shadow:

1. **Depth-only passes created their DS surface at 1×1.** With no color target, the pass extent came from the absent color attachment; the viewport-derived recovery computed the true atlas extents (2048/4096) but the presentation-surface cap — added for Dead Cells' pathological 16384×16384 inferences — rejected anything above 1920×1080. The entire shadow atlas rendered into one pixel (verified: pre-fix depth dump shows a 1×1 plane; post-fix the 2048² atlas holds ~950k real depth texels, max 0.707).
2. **Rendered depth has no path to consumers.** prosper never writes depth back to guest memory and had no sampled-texture bridge (the color path has both), so shadow taps decoded guest zeros and every compare passed → unshadowed, overbright scenes.

## Approach

- **Extent**: depth-only passes may infer viewport-derived extents up to 4096×4096 (`ds_extent_limit`); the Dead Cells pathology stays rejected and fail-visible. The offline-replay path (no presentation extent) now uses the native extent instead of silently truncating to the capture extent.
- **Bridge**: a sampled 2D T# whose address matches a valid persistent DS depth plane (read or write base, exact extent) binds the retained Vulkan depth image directly: DEPTH-aspect view in the DS's own format, `DS_ATTACHMENT → SHADER_READ_ONLY` transition before the consuming pass and back after (both aspects together for D32S8), excluded from the persistent-texture cache/creation/cleanup paths, and feedback onto the pass's own DS attachment declined. No CPU fallback exists by design — a missing/invalid surface falls through to the guest-byte decode exactly as before.
- **Diagnostics kept**: `PROSPER_DEPTH_DUMP` (grayscale + min/max/nonzero per persistent depth plane), `PROSPER_DSBRIDGE_LOG` (bridge hit/miss with cache keys + consumer identity).

## Invariants / unaffected

- Passes without a DS-plane address match are byte-identical (the bridge only adds a lookup).
- The DS image lifecycle (validity, invalidation on guest writes #611, layout contract between depth passes) is unchanged — the bridge transitions layouts around the consuming pass and restores `DEPTH_STENCIL_ATTACHMENT_OPTIMAL`.
- Capture/diagnostic env combinations behave as before (the bridge does not depend on `live_gpu_targets`).

## Deliberately not fixed here

The #1287 blowout persists: the offline capsule cannot carry cross-frame cascade state (DS-seeds=0 — earlier-frame atlases sample as zeros offline), and the live A/B shows recovered ground texture and character detail but the overbright term remains. The residual investigation continues on #1287 with this infrastructure in place. F9 bundle DS seeding is a follow-up.

## Verification

- Build clean; **ctest 145/145** (new test included).
- **New end-to-end regression test** (`test_shadow_compare_render`): a depth-only producer writes z=0.25 into a persistent DS identity; a consumer sampling that plane through the bridge reads R=64 (~0.25) and the no-bridge control reads 0. Fails without the bridge (the control IS the without case).
- Capsule evidence: post-fix `PROSPER_DEPTH_DUMP` shows real cascade content in all rendered atlases (2048²: 950k nonzero texels; 4096²: full coverage; multiple 1024² cascades with real ranges).
- Snapshot gate: running — result posted before merge (the extent change touches every depth-only pass, so this gate is the cross-title guard).