### PR TITLE
fix(render): fail closed on present fence errors

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -371,6 +371,11 @@ if(TARGET prosper_core)
     target_include_directories(test_prosper_app_present_policy PRIVATE frontends/prosper-app)
     target_link_libraries(test_prosper_app_present_policy PRIVATE Vulkan::Vulkan)
     add_test(NAME prosper_app_present_policy COMMAND test_prosper_app_present_policy)
+
+    add_executable(test_present_blit_policy frontends/shared/test_present_blit_policy.cpp)
+    target_include_directories(test_present_blit_policy PRIVATE frontends/shared)
+    target_link_libraries(test_present_blit_policy PRIVATE Vulkan::Vulkan)
+    add_test(NAME present_blit_policy COMMAND test_present_blit_policy)
   endif()
 
   add_executable(test_sync_on_address tests/test_sync_on_address.cpp)

--- a/prosper/frontends/shared/present_blit.cpp
+++ b/prosper/frontends/shared/present_blit.cpp
@@ -1,5 +1,6 @@
 // present_blit.cpp — see present_blit.hpp (#1270).
 #include "present_blit.hpp"
+#include "present_blit_policy.hpp"
 #include "render_runner.h"            // render_vk_ctx()
 #include "gpu/gpu_execute.hpp"        // shared_present_submit_mutex / shared_present_active
 #include <mutex>
@@ -203,7 +204,17 @@ bool present_blit_publish(VkImage src, VkImageLayout src_layout, VkFormat src_fo
     // acquired -- this is what lets the consumer read it with no cross-thread semaphore, and is strictly
     // cheaper than the GPU->CPU readback + CPU->GPU re-upload it replaces. Does not touch the queue, so it
     // is outside the submit mutex.
-    vkWaitForFences(s.dev, 1, &s.blit_fence, VK_TRUE, 5ull * 1000 * 1000 * 1000);
+    const VkResult wait_result =
+        vkWaitForFences(s.dev, 1, &s.blit_fence, VK_TRUE, 5ull * 1000 * 1000 * 1000);
+    if (!present_blit_wait_completed(wait_result)) {
+        // The command buffer and destination slot may still be in flight. Fail the GPU-present path
+        // closed for this session so neither can be published or reused; present_blit_reset() retains
+        // the resources until its device-idle barrier and callers fall back to CPU presentation.
+        std::fprintf(stderr, "[present-blit] fence wait failed (%d); disabling GPU present\n",
+                     static_cast<int>(wait_result));
+        s.ok = false;
+        return false;
+    }
 
     sl.frame_seq = frame_seq;
     sl.state = SlotState::Published;

--- a/prosper/frontends/shared/present_blit_policy.hpp
+++ b/prosper/frontends/shared/present_blit_policy.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <vulkan/vulkan.h>
+
+namespace prosper::frontend {
+
+// A scanout slot is publishable only after its copy fence is known to be signaled. Timeouts and
+// device errors leave the submitted command buffer potentially in flight.
+constexpr bool present_blit_wait_completed(VkResult result) {
+    return result == VK_SUCCESS;
+}
+
+} // namespace prosper::frontend

--- a/prosper/frontends/shared/test_present_blit_policy.cpp
+++ b/prosper/frontends/shared/test_present_blit_policy.cpp
@@ -1,0 +1,20 @@
+#include "present_blit_policy.hpp"
+
+#include <cstdio>
+
+using prosper::frontend::present_blit_wait_completed;
+
+static int failures = 0;
+#define CHECK(cond) do { if (!(cond)) { \
+    std::fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond); ++failures; } } while (0)
+
+int main() {
+    CHECK(present_blit_wait_completed(VK_SUCCESS));
+
+    // #1303: a timeout or device error must not publish a slot whose blit may still be in flight.
+    CHECK(!present_blit_wait_completed(VK_TIMEOUT));
+    CHECK(!present_blit_wait_completed(VK_ERROR_DEVICE_LOST));
+
+    if (!failures) std::printf("present_blit_policy: OK\n");
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## What changed

- require the GPU-present blit fence wait to complete successfully before publishing its scanout slot
- disable GPU present for the remainder of the session after a timeout or device error
- retain potentially in-flight resources until the existing device-idle reset cleanup
- add a focused wait-result policy regression

## Root cause

`present_blit_publish()` ignored the result of its five-second `vkWaitForFences()` call and unconditionally published the slot. A timeout or device error could therefore expose an incomplete image and allow the submitted command buffer to be reset and reused.

## Impact

Fence failures now fail closed. The caller uses its existing CPU-present fallback, while successful GPU presentation is unchanged.

## Validation

- `cmake --build build-audit --target test_present_blit_policy prosper_live_renderer test_present_blit -j8`
- `ctest --test-dir build-audit -R "^(present_blit_policy|present_blit)$" --output-on-failure`
- `git diff --check`

Fixes #1303