### PR TITLE
fix(render): preserve depth writer recency

### DIFF
--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -1450,6 +1450,12 @@ inline uint64_t& persistent_ds_write_generation() {
     return generation;
 }
 
+constexpr bool persistent_ds_pass_may_write_depth(bool clear_enabled, bool test_enabled,
+                                                  bool write_enabled, uint32_t compare_op) {
+    return clear_enabled ||
+        (test_enabled && write_enabled && compare_op != VK_COMPARE_OP_NEVER);
+}
+
 inline std::unordered_map<PersistentDsKey, PersistentDsImage, PersistentDsKeyHash>&
 persistent_ds_cache() {
     static std::unordered_map<PersistentDsKey, PersistentDsImage, PersistentDsKeyHash> cache;
@@ -2079,11 +2085,15 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     bool ds_layout_initialized = false;
     bool depth_was_valid = false, stencil_was_valid = false;
     bool depth_used_meaningfully = false;
+    bool depth_may_be_written = false;
     for (const auto& d : draws) {
         if (!d.ps) continue;
         depth_used_meaningfully |= d.ps->depth_clear_enable || d.ps->depth_write_enable ||
             (d.ps->depth_test_enable && d.ps->depth_compare_op != VK_COMPARE_OP_ALWAYS &&
                                         d.ps->depth_compare_op != VK_COMPARE_OP_NEVER);
+        depth_may_be_written |= persistent_ds_pass_may_write_depth(
+            d.ps->depth_clear_enable, d.ps->depth_test_enable, d.ps->depth_write_enable,
+            d.ps->depth_compare_op);
     }
     PersistentDsImage* cached_ds = nullptr;
     PersistentDsKey ds_key{};
@@ -4256,7 +4266,8 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         // Sampled depth bridge (#1275): recency for find_persistent_ds_sampled — two valid
         // entries can share a plane address (a surface re-keyed D32 -> D32S8 keeps its old
         // entry), and the most recently written one is the live truth.
-        if (use_depth) cached_ds->last_depth_write = ++persistent_ds_write_generation();
+        if (use_depth && depth_may_be_written)
+            cached_ds->last_depth_write = ++persistent_ds_write_generation();
     }
     if (cached_color) {
         active_submission.add_failure_cleanup([cached_color]() {

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -1456,6 +1456,12 @@ constexpr bool persistent_ds_pass_may_write_depth(bool clear_enabled, bool test_
         (test_enabled && write_enabled && compare_op != VK_COMPARE_OP_NEVER);
 }
 
+inline void note_persistent_ds_depth_write(PersistentDsImage& image, bool use_depth,
+                                           bool depth_may_be_written) {
+    if (use_depth && depth_may_be_written)
+        image.last_depth_write = ++persistent_ds_write_generation();
+}
+
 inline std::unordered_map<PersistentDsKey, PersistentDsImage, PersistentDsKeyHash>&
 persistent_ds_cache() {
     static std::unordered_map<PersistentDsKey, PersistentDsImage, PersistentDsKeyHash> cache;
@@ -4266,8 +4272,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         // Sampled depth bridge (#1275): recency for find_persistent_ds_sampled — two valid
         // entries can share a plane address (a surface re-keyed D32 -> D32S8 keeps its old
         // entry), and the most recently written one is the live truth.
-        if (use_depth && depth_may_be_written)
-            cached_ds->last_depth_write = ++persistent_ds_write_generation();
+        note_persistent_ds_depth_write(*cached_ds, use_depth, depth_may_be_written);
     }
     if (cached_color) {
         active_submission.add_failure_cleanup([cached_color]() {

--- a/prosper/tests/test_shadow_compare_render.cpp
+++ b/prosper/tests/test_shadow_compare_render.cpp
@@ -84,6 +84,20 @@ int main() {
     CHECK(right_total && right_fail == right_total,
           "dref 0.5 GREATER fails (0.0) where stored depth is ~0.9");
 
+    // #1308: sampled-depth bridge recency tracks writers, not mere depth attachment users.
+    CHECK(!prosper::test::persistent_ds_pass_may_write_depth(
+              false, true, false, VK_COMPARE_OP_ALWAYS),
+          "read-only depth use does not claim writer recency");
+    CHECK(prosper::test::persistent_ds_pass_may_write_depth(
+              true, false, false, VK_COMPARE_OP_NEVER),
+          "a depth clear claims writer recency");
+    CHECK(prosper::test::persistent_ds_pass_may_write_depth(
+              false, true, true, VK_COMPARE_OP_ALWAYS),
+          "depth writes claim writer recency");
+    CHECK(!prosper::test::persistent_ds_pass_may_write_depth(
+              false, true, true, VK_COMPARE_OP_NEVER),
+          "a depth write masked by NEVER does not claim writer recency");
+
     // ---- Persistent-DS sampled bridge (#1275) ----
     // A depth-only producer renders a fullscreen triangle at z=0.25 into a guest-identified
     // persistent DS surface. prosper never writes that depth back to guest memory, so a consumer

--- a/prosper/tests/test_shadow_compare_render.cpp
+++ b/prosper/tests/test_shadow_compare_render.cpp
@@ -98,6 +98,41 @@ int main() {
               false, true, true, VK_COMPARE_OP_NEVER),
           "a depth write masked by NEVER does not claim writer recency");
 
+    // Exercise the actual D32/D32S8 sibling selector, not just the predicate above. A read-only
+    // touch of the older format must not steal recency from the surface that was really written.
+    {
+        constexpr uint64_t kRecencyBase = 0x20d5feed00ull;
+        constexpr uint32_t kRecencyW = 17, kRecencyH = 19;
+        prosper::test::PersistentDsKey d32_key{
+            kRecencyBase, kRecencyBase, 0, 0, 0, kRecencyW, kRecencyH,
+            static_cast<uint32_t>(VK_FORMAT_D32_SFLOAT)};
+        prosper::test::PersistentDsKey d32s8_key{
+            kRecencyBase, kRecencyBase, 0, 0, 0, kRecencyW, kRecencyH,
+            static_cast<uint32_t>(VK_FORMAT_D32_SFLOAT_S8_UINT)};
+        auto& cache = prosper::test::persistent_ds_cache();
+        auto& older = cache[d32_key];
+        auto& newer = cache[d32s8_key];
+        older.image = (VkImage)(uintptr_t)1; older.layout_initialized = true; older.depth_valid = true;
+        newer.image = (VkImage)(uintptr_t)2; newer.layout_initialized = true; newer.depth_valid = true;
+        prosper::test::note_persistent_ds_depth_write(older, true, true);
+        prosper::test::note_persistent_ds_depth_write(newer, true, true);
+        CHECK(prosper::test::find_persistent_ds_sampled(
+                  kRecencyBase, kRecencyW, kRecencyH).image == &newer,
+              "newer D32S8 writer wins over stale D32 sibling");
+
+        prosper::test::note_persistent_ds_depth_write(older, true, false);
+        CHECK(prosper::test::find_persistent_ds_sampled(
+                  kRecencyBase, kRecencyW, kRecencyH).image == &newer,
+              "read-only D32 touch preserves D32S8 writer ordering");
+
+        prosper::test::note_persistent_ds_depth_write(older, true, true);
+        CHECK(prosper::test::find_persistent_ds_sampled(
+                  kRecencyBase, kRecencyW, kRecencyH).image == &older,
+              "a later real D32 write updates sibling ordering");
+        cache.erase(d32_key);
+        cache.erase(d32s8_key);
+    }
+
     // ---- Persistent-DS sampled bridge (#1275) ----
     // A depth-only producer renders a fullscreen triangle at z=0.25 into a guest-identified
     // persistent DS surface. prosper never writes that depth back to guest memory, so a consumer


### PR DESCRIPTION
## What changed

- advance sampled-depth bridge recency only when a pass may actually modify depth
- leave writer ordering unchanged for read-only depth tests and writes masked by `NEVER`
- add focused policy coverage to the existing end-to-end shadow bridge regression

## Root cause

PR #1305 updated `last_depth_write` whenever a pass merely used a depth attachment. After a D32/D32S8 re-key, touching a stale sibling with a read-only pass could therefore make it appear newer than the surface that actually received the latest depth writes.

## Impact

Sampled shadow/depth lookups retain the real writer ordering and cannot be redirected to stale depth by read-only attachment use.

## Validation

- `cmake --build build-audit --target test_shadow_compare_render prosper_live_renderer -j8`
- `ctest --test-dir build-audit -R "^shadow_compare_render$" --output-on-failure`
- `git diff --check`

Fixes #1308