### PR TITLE
fix(tool): reject failed replay hashes

### DIFF
--- a/prosper/tools/gpu_replay/regress.py
+++ b/prosper/tools/gpu_replay/regress.py
@@ -62,6 +62,11 @@ def replay_hash(replay_bin: str, capsule: Path, timeout: int) -> str:
     proc = subprocess.run([replay_bin, str(capsule)], capture_output=True, text=True,
                           timeout=timeout, env=child_env)
     out_hash = parse_output_hash(proc.stdout + proc.stderr)
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"gpu_replay failed for {capsule.name} (exit {proc.returncode})"
+            + (f" after reporting hash {out_hash}" if out_hash is not None else "")
+            + "\n--- stderr tail ---\n" + "\n".join(proc.stderr.splitlines()[-8:]))
     if out_hash is None:
         raise RuntimeError(
             f"no output hash from gpu_replay for {capsule.name} (exit {proc.returncode})\n"

--- a/prosper/tools/gpu_replay/test_regress.py
+++ b/prosper/tools/gpu_replay/test_regress.py
@@ -6,6 +6,9 @@ import importlib.util
 import os
 import sys
 import unittest
+from pathlib import Path
+from subprocess import CompletedProcess
+from unittest import mock
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 SPEC = importlib.util.spec_from_file_location("prosper_regress", os.path.join(HERE, "regress.py"))
@@ -33,6 +36,27 @@ class ParseOutputHashTests(unittest.TestCase):
     def test_lowercased(self):
         self.assertEqual(REGRESS.parse_output_hash("output=1x1 hash=ABCDEF0123456789"),
                          "abcdef0123456789")
+
+
+class ReplayHashTests(unittest.TestCase):
+    @mock.patch.object(REGRESS.subprocess, "run")
+    def test_rejects_hash_when_replay_exits_nonzero(self, run):
+        run.return_value = CompletedProcess(
+            ["gpu_replay", "scene.prgcap"], 1,
+            stdout="[gpureplay] output=8x8 hash=1234567890abcdef\n",
+            stderr="gpu_replay: output mismatch\n")
+
+        with self.assertRaisesRegex(RuntimeError, r"exit 1.*hash 1234567890abcdef"):
+            REGRESS.replay_hash("gpu_replay", Path("scene.prgcap"), 10)
+
+    @mock.patch.object(REGRESS.subprocess, "run")
+    def test_accepts_hash_only_on_successful_exit(self, run):
+        run.return_value = CompletedProcess(
+            ["gpu_replay", "scene.prgcap"], 0,
+            stdout="[gpureplay] output=8x8 hash=1234567890ABCDEF\n", stderr="")
+
+        self.assertEqual(REGRESS.replay_hash("gpu_replay", Path("scene.prgcap"), 10),
+                         "1234567890abcdef")
 
 
 class ClassifyCheckTests(unittest.TestCase):


### PR DESCRIPTION
## What changed

- reject every nonzero `gpu_replay` exit even when its diagnostics contain a parseable output hash
- include the reported hash and stderr tail in the replay error
- add subprocess-level coverage for failing and successful replay exits

## Root cause

`gpu_replay` prints its output hash before checking the capture expected output. `regress.py` accepted that hash without checking the process return code, so an explicit `output mismatch` exit could be treated as a successful regression result or recorded into a new baseline.

## Impact

The capsule regression gate now fails closed when replay itself reports an error. Successful replay hash behavior is unchanged.

## Validation

- `python3 prosper/tools/gpu_replay/test_regress.py` (10 tests)
- `python3 -m compileall -q prosper/tools`
- all Python tests under `prosper/tools`
- `git diff --check`

Fixes #1310