### PR TITLE
fix(tool): fail inconclusive hang probes

### DIFF
--- a/prosper/tools/guest_bt/guest_bt.py
+++ b/prosper/tools/guest_bt/guest_bt.py
@@ -35,6 +35,12 @@ def parse_initlog(path):
         sys.exit('guest_bt: no [initlog] lines in %s (run the title with PROSPER_INITLOG=1)' % path)
     return mods
 
+def run_gdb(gdb, pid, plugin, command, env):
+    """Run the debugger and preserve its status for callers such as hang_probe."""
+    return subprocess.run([gdb, '-p', str(pid), '-batch',
+                           '-ex', 'set debuginfod enabled off', '-ex', 'set pagination off',
+                           '-ex', 'source %s' % plugin, '-ex', command], env=env).returncode
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument('--pid', type=int, required=True)
@@ -85,9 +91,7 @@ def main():
     cmd = args.thread or ''
     gdb_cmd = 'guest-bt-all' if (args.all or not cmd) else ('guest-bt %s' % cmd)
     env = dict(os.environ, PROSPER_GBT_CONFIG=cfg_path)
-    subprocess.run([args.gdb, '-p', str(args.pid), '-batch',
-                    '-ex', 'set debuginfod enabled off', '-ex', 'set pagination off',
-                    '-ex', 'source %s' % PLUGIN, '-ex', gdb_cmd], env=env)
+    return run_gdb(args.gdb, args.pid, PLUGIN, gdb_cmd, env)
 
 if __name__ == '__main__':
-    main()
+    sys.exit(main())

--- a/prosper/tools/guest_bt/test_guest_bt.py
+++ b/prosper/tools/guest_bt/test_guest_bt.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+import importlib.util
+import os
+import subprocess
+import unittest
+from unittest import mock
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SPEC = importlib.util.spec_from_file_location("prosper_guest_bt", os.path.join(HERE, "guest_bt.py"))
+GUEST_BT = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(GUEST_BT)
+
+
+class GdbStatusTests(unittest.TestCase):
+    @mock.patch.object(GUEST_BT.subprocess, "run")
+    def test_propagates_gdb_failure_status(self, run):
+        run.return_value = subprocess.CompletedProcess(["gdb"], 7)
+        self.assertEqual(GUEST_BT.run_gdb("gdb", 123, "plugin.py", "guest-bt 1", {}), 7)
+
+    @mock.patch.object(GUEST_BT.subprocess, "run")
+    def test_success_returns_zero(self, run):
+        run.return_value = subprocess.CompletedProcess(["gdb"], 0)
+        self.assertEqual(GUEST_BT.run_gdb("gdb", 123, "plugin.py", "guest-bt 1", {}), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/prosper/tools/hang_probe/README.md
+++ b/prosper/tools/hang_probe/README.md
@@ -23,8 +23,9 @@ For each run it launches the title headless via `boot_trace` (with the gated `PR
 Plain `gdb` **cannot** unwind the guest main thread through prosper's HLE stub boundary (its backtrace
 is all `??? `), so `guest_bt` (which re-sections the flattened module ELFs) is required.
 
-Exit status is `1` if any run was BLOCKED, `0` otherwise — so it doubles as a bisect/gate predicate
-(e.g. "does commit X still hang evergate at boot?").
+Exit status is `1` if any run was BLOCKED, `2` if any run was UNKNOWN/DEAD and no hang was observed,
+and `0` only when every run was classified RUNNING. This makes debugger/attach failures inconclusive
+instead of false-green while preserving the hang/no-hang bisect predicate.
 
 ## Requirements
 

--- a/prosper/tools/hang_probe/README.md
+++ b/prosper/tools/hang_probe/README.md
@@ -19,6 +19,10 @@ For each run it launches the title headless via `boot_trace` (with the gated `PR
   `k_ef_wait` / `k_usleep`). On a BLOCKED run it prints Thread 1's stack as evidence.
 - **RUNNING** — an active render/submit frame (`execute_ordered` / `agc_driver_submit` /
   `run_command_buffer` / `present` / `SubmitDcb`).
+- **UNKNOWN** — `guest_bt` timed out/failed, or returned no recognized running/wait frame; the run
+  produced no trustworthy hang verdict.
+- **DEAD** — `boot_trace` exited before the configured sample time, so no live thread could be
+  classified.
 
 Plain `gdb` **cannot** unwind the guest main thread through prosper's HLE stub boundary (its backtrace
 is all `??? `), so `guest_bt` (which re-sections the flattened module ELFs) is required.

--- a/prosper/tools/hang_probe/hang_probe.py
+++ b/prosper/tools/hang_probe/hang_probe.py
@@ -38,6 +38,29 @@ def classify(gbt_text: str):
     return "UNKNOWN", ""
 
 
+def run_guest_bt(cmd, timeout):
+    """Return (state, evidence, stdout), preserving debugger/tool failures as UNKNOWN evidence."""
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        return "UNKNOWN", "(guest_bt timed out)", ""
+    if result.returncode != 0:
+        detail = next((line.strip() for line in reversed(result.stderr.splitlines()) if line.strip()), "")
+        suffix = f": {detail}" if detail else ""
+        return "UNKNOWN", f"(guest_bt failed, exit {result.returncode}{suffix})", result.stdout
+    state, frame = classify(result.stdout)
+    return state, frame, result.stdout
+
+
+def result_exit_code(counts):
+    """1 means a reproduced hang; 2 means the experiment was inconclusive; 0 is a clean result."""
+    if counts["BLOCKED"]:
+        return 1
+    if counts["UNKNOWN"] or counts["DEAD"]:
+        return 2
+    return 0
+
+
 def one_run(args, i):
     save = tempfile.mkdtemp(prefix=f"hangprobe_save{i}_")
     log = tempfile.NamedTemporaryFile(prefix=f"hangprobe_run{i}_", suffix=".log", delete=False).name
@@ -61,11 +84,7 @@ def one_run(args, i):
                "--initlog", log, "--thread", str(args.thread)]
         if args.dump:
             cmd += ["--dump", args.dump]
-        try:
-            out = subprocess.run(cmd, capture_output=True, text=True, timeout=args.gbt_timeout).stdout
-        except subprocess.TimeoutExpired:
-            return "UNKNOWN", "(guest_bt timed out)", log
-        state, frame = classify(out)
+        state, frame, out = run_guest_bt(cmd, args.gbt_timeout)
         if state == "BLOCKED" and args.show_stack:
             sys.stdout.write("    --- Thread 1 stack ---\n")
             for l in out.splitlines():
@@ -122,8 +141,9 @@ def main():
     print(f"== BLOCKED={counts['BLOCKED']} RUNNING={counts['RUNNING']} "
           f"DEAD={counts['DEAD']} UNKNOWN={counts['UNKNOWN']} (of {args.runs}) "
           f"=> hang rate ~{rate:.0f}% of classified ==")
-    # exit 1 if any hang was observed, so it's usable as a gate/bisect predicate
-    sys.exit(1 if counts["BLOCKED"] else 0)
+    # A gate must not report a clean result when no usable backtrace was obtained. Keep reproduced
+    # hangs as exit 1 for bisect predicates and use exit 2 for inconclusive/tool-failure runs.
+    sys.exit(result_exit_code(counts))
 
 
 if __name__ == "__main__":

--- a/prosper/tools/hang_probe/test_hang_probe.py
+++ b/prosper/tools/hang_probe/test_hang_probe.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+import importlib.util
+import os
+import subprocess
+import unittest
+from unittest import mock
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SPEC = importlib.util.spec_from_file_location("prosper_hang_probe", os.path.join(HERE, "hang_probe.py"))
+HANG_PROBE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(HANG_PROBE)
+
+
+class GuestBtResultTests(unittest.TestCase):
+    @mock.patch.object(HANG_PROBE.subprocess, "run")
+    def test_failed_guest_bt_is_unknown_with_stderr(self, run):
+        run.return_value = subprocess.CompletedProcess(
+            ["guest_bt"], 1, stdout="", stderr="ptrace: Operation not permitted\n")
+        self.assertEqual(HANG_PROBE.run_guest_bt(["guest_bt"], 5),
+                         ("UNKNOWN", "(guest_bt failed, exit 1: ptrace: Operation not permitted)", ""))
+
+    @mock.patch.object(HANG_PROBE.subprocess, "run")
+    def test_successful_guest_bt_is_classified(self, run):
+        run.return_value = subprocess.CompletedProcess(
+            ["guest_bt"], 0, stdout="#0 k_sema_wait\n", stderr="")
+        self.assertEqual(HANG_PROBE.run_guest_bt(["guest_bt"], 5),
+                         ("BLOCKED", "#0 k_sema_wait", "#0 k_sema_wait\n"))
+
+
+class ExitCodeTests(unittest.TestCase):
+    def counts(self, **updates):
+        counts = {"BLOCKED": 0, "RUNNING": 0, "DEAD": 0, "UNKNOWN": 0}
+        counts.update(updates)
+        return counts
+
+    def test_clean_classified_runs_succeed(self):
+        self.assertEqual(HANG_PROBE.result_exit_code(self.counts(RUNNING=3)), 0)
+
+    def test_reproduced_hang_is_bisect_failure(self):
+        self.assertEqual(HANG_PROBE.result_exit_code(self.counts(BLOCKED=1)), 1)
+
+    def test_unknown_or_dead_runs_are_inconclusive(self):
+        self.assertEqual(HANG_PROBE.result_exit_code(self.counts(UNKNOWN=1)), 2)
+        self.assertEqual(HANG_PROBE.result_exit_code(self.counts(DEAD=1)), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- propagate gdb’s exit status through `guest_bt.py`
- preserve guest_bt failures and stderr as explicit UNKNOWN evidence in `hang_probe`
- exit 2 for inconclusive UNKNOWN/DEAD run sets instead of reporting a clean result
- perform exactly one debugger attach per sample, retaining stdout for optional stack printing
- document the three exit outcomes and add focused mocked subprocess tests

## Root cause

`guest_bt.py` discarded gdb’s return code. `hang_probe.py` then ignored the child status and stderr, classified an attach failure as UNKNOWN, and exited zero whenever no run happened to be BLOCKED. A completely failed experiment could therefore pass a gate or bisect predicate.

## Impact

Only fully classified RUNNING experiments succeed. Reproduced hangs remain exit 1; tool/attach failures and premature process exits are distinguishable as exit 2.

## Validation

- `python3 prosper/tools/guest_bt/test_guest_bt.py`
- `python3 prosper/tools/hang_probe/test_hang_probe.py`
- `python3 -m compileall -q prosper/tools`
- all Python tests under `prosper/tools`
- `git diff --check`

Fixes #1312