### PR TITLE
hle(file): match PROSPER_DENY_SUBSTR case-insensitively

### DIFF
--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -9,6 +9,7 @@
 #include "heap_mutex.hpp"   // #707: keep the APR mutex off macOS __DATA
 #include "../host/guest_write_watch.hpp"   // #1144 B5: disarm texture watches before reading into guest mem
 #include "../host/boot_program.hpp"        // #1226: resolve_host_path_case (PS5 FS namespace is case-insensitive)
+#include <cctype>        // #1237: case-insensitive PROSPER_DENY_SUBSTR matching
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -450,6 +451,10 @@ namespace {
     // redirected to a guaranteed-missing host path, so open/stat fail with ENOENT.
     // Diagnostic knob (off by default) — used to A/B whether the title's boot flow gates on a
     // file class we can't service yet (e.g. .usm movies through the stubbed CRI/AJM decoders).
+    // Matching is CASE-INSENSITIVE (#1237): translate() resolves guest paths case-insensitively
+    // against the dump (the PS5 namespace is effectively case-insensitive, #1233), so a guest
+    // spelling `Intro.USM` must not slip past a `.usm` deny — a casing variant defeating the knob
+    // makes the A/B experiment lie.
     bool deny_path(const std::string& guest) {
         static std::vector<std::string> subs = [] {
             std::vector<std::string> v;
@@ -462,11 +467,16 @@ namespace {
                     pos = c + 1;
                 }
             }
+            for (auto& sub : v)
+                for (char& ch : sub)
+                    ch = static_cast<char>(std::tolower(static_cast<unsigned char>(ch)));
             return v;
         }();
         if (subs.empty()) return false;
+        std::string lower = guest;
+        for (char& ch : lower) ch = static_cast<char>(std::tolower(static_cast<unsigned char>(ch)));
         for (const auto& sub : subs)
-            if (guest.find(sub) != std::string::npos) return true;
+            if (lower.find(sub) != std::string::npos) return true;
         return false;
     }
     // Lexically normalize a virtual sub-path (the part AFTER a /app0|/temp0|/savedata0 root),

--- a/prosper/tests/test_file_binary.cpp
+++ b/prosper/tests/test_file_binary.cpp
@@ -48,6 +48,16 @@ static_assert(sizeof(GuestTimeval) == 0x10, "SceKernelTimeval ABI");
 
 int main() {
     std::printf("== test_file_binary ==\n");
+    // PROSPER_DENY_SUBSTR (#1237): armed for the whole process BEFORE any guest file op (the
+    // substring list is cached on first use). The unique marker cannot collide with any other
+    // path this test opens; the case-variant open below proves matching is case-insensitive
+    // (the guest namespace resolves case-insensitively since #1233, so a casing variant must
+    // not defeat the deny knob).
+#ifdef _WIN32
+    _putenv_s("PROSPER_DENY_SUBSTR", ".tmpdeny");
+#else
+    setenv("PROSPER_DENY_SUBSTR", ".tmpdeny", 1);
+#endif
     const char* path = "prosper-test-file-binary.tmp";
     std::array<uint8_t, 512> expected{};
     for (size_t i = 0; i < expected.size(); ++i) expected[i] = (uint8_t)(i * 37u + 11u);
@@ -500,6 +510,20 @@ int main() {
           "libc open retains the -1 plus errno contract");
     CHECK((uint32_t)kernel_missing == 0x80020002u,
           "sceKernelOpen returns SCE_KERNEL_ERROR_ENOENT directly");
+
+    // PROSPER_DENY_SUBSTR case-insensitivity (#1237): the fixture EXISTS on disk, but its name
+    // contains a CASE VARIANT of the armed ".tmpdeny" substring — the deny must still fire.
+    {
+        const char* deny_fixture = "prosper-deny-fixture.TmpDeny";
+        FILE* deny_out = std::fopen(deny_fixture, "wb");
+        CHECK(deny_out != nullptr, "create deny fixture");
+        if (deny_out) { std::fputs("x", deny_out); std::fclose(deny_out); }
+        const uint64_t denied = open_fn
+            ? open_fn((uint64_t)(uintptr_t)deny_fixture, 0, 0, 0, 0, 0) : 0;
+        CHECK((uint32_t)denied == 0x80020002u,
+              "PROSPER_DENY_SUBSTR denies a case-variant spelling (ENOENT despite the file existing)");
+        std::remove(deny_fixture);
+    }
     const std::string unreachable_file = std::string("/app0/") + missing_path;
     std::string overlong_path(256, 'a');
     CHECK(kernel_reachability_fn &&

--- a/prosper/tests/test_file_binary.cpp
+++ b/prosper/tests/test_file_binary.cpp
@@ -6,6 +6,7 @@
 #include <cerrno>
 #include <cstdint>
 #include <cstdio>
+#include <cstdlib>   // setenv/_putenv_s (PROSPER_DENY_SUBSTR arming)
 #include <cstring>
 #include <filesystem>
 #include <map>
@@ -54,9 +55,9 @@ int main() {
     // (the guest namespace resolves case-insensitively since #1233, so a casing variant must
     // not defeat the deny knob).
 #ifdef _WIN32
-    _putenv_s("PROSPER_DENY_SUBSTR", ".tmpdeny");
+    _putenv_s("PROSPER_DENY_SUBSTR", ".TMPDENY");
 #else
-    setenv("PROSPER_DENY_SUBSTR", ".tmpdeny", 1);
+    setenv("PROSPER_DENY_SUBSTR", ".TMPDENY", 1);
 #endif
     const char* path = "prosper-test-file-binary.tmp";
     std::array<uint8_t, 512> expected{};


### PR DESCRIPTION
Fixes #1237 (independent-review follow-up from #1233).

**Failure scenario**: since #1233, `translate()` resolves guest paths case-insensitively against the dump (the PS5 namespace is effectively case-insensitive), so a guest spelling `Intro.USM` bypasses a `.usm` deny substring AND opens the real file — the casing miss that previously ENOENT'd by accident no longer protects the A/B experiment. A diagnostic knob whose sole purpose is 'make this file class unavailable' silently lying defeats its point.

**Approach**: fold the substrings to lowercase once at parse, fold the guest path per query, match on the folded forms. Behavior for same-case matches is unchanged; the knob remains off by default.

**Verification**: build clean; **ctest full suite green**; new regression in `test_file_binary` arms `.tmpdeny` before any guest file op and proves a case-variant fixture (`.TmpDeny`) still denies with `SCE_KERNEL_ERROR_ENOENT` even though the file exists on disk — fails without the fix (the variant would open successfully).

**Risk**: none beyond the diagnostic knob itself; matching got strictly broader (case variants now deny), which is the documented intent.