### PR TITLE
fix(tool): scan xrefs through segment tails

### DIFF
--- a/prosper/tools/re/test_xref.py
+++ b/prosper/tools/re/test_xref.py
@@ -50,6 +50,12 @@ def main():
     code += b"\x80\x3d" + rel32(site, 7, slot) + b"\x01"                  # cmp BYTE [rip+d],1  cmpb
     raw[0x100:0x100 + len(code)] = code
 
+    # #1314: a seven-byte reference ending exactly at the executable PT_LOAD boundary must be
+    # inspected. The old range(n - 7) stopped one byte before this instruction's start.
+    tail_site = 0x10f9
+    tail_slot = 0x1300
+    raw[0x1f9:0x200] = b"\xc6\x05" + rel32(tail_site, 7, tail_slot) + b"\x01"
+
     path = ""
     try:
         with tempfile.NamedTemporaryFile(delete=False) as f:
@@ -69,6 +75,7 @@ def main():
         actual = set(module.code_xref[slot])
         assert actual == expected, (actual, expected)
         assert module.code_xref[direct_target] == [(0x1000, "call")]
+        assert module.code_xref[tail_slot] == [(tail_site, "storeb")]
     finally:
         if path:
             os.unlink(path)

--- a/prosper/tools/re/xref.py
+++ b/prosper/tools/re/xref.py
@@ -98,24 +98,28 @@ class Module:
                 continue
             d = raw[o:o + fs]
             n = len(d)
-            for i in range(n - 7):
+            # Examine every possible instruction start. Each decoder below owns its exact bounds
+            # check; a shared `range(n - 7)` dropped seven-byte store/cmp instructions that ended
+            # exactly at the PT_LOAD boundary (#1314), as well as shorter tail calls.
+            for i in range(n):
                 b = d[i]
-                if b in (0x48, 0x4c) and d[i + 1] in (0x8d, 0x8b, 0x89) and d[i + 2] in MODRM_RIP:
+                if (i + 7 <= n and b in (0x48, 0x4c) and
+                        d[i + 1] in (0x8d, 0x8b, 0x89) and d[i + 2] in MODRM_RIP):
                     disp = struct.unpack_from('<i', d, i + 3)[0]
                     site = v + i
                     kind = {0x8d: 'lea', 0x8b: 'load', 0x89: 'store'}[d[i + 1]]
                     self.code_xref[site + 7 + disp].append((site, kind))
-                elif b == 0xff and i + 5 < n and (d[i + 1] & 0xc7) == 0x05:
+                elif i + 6 <= n and b == 0xff and (d[i + 1] & 0xc7) == 0x05:
                     reg = (d[i + 1] >> 3) & 7
                     if reg in (2, 4):
                         disp = struct.unpack_from('<i', d, i + 2)[0]
                         site = v + i
                         self.code_xref[site + 6 + disp].append((site, 'call*' if reg == 2 else 'jmp*'))
-                elif b == 0xe8:
+                elif i + 5 <= n and b == 0xe8:
                     disp = struct.unpack_from('<i', d, i + 1)[0]
                     site = v + i
                     self.code_xref[site + 5 + disp].append((site, 'call'))
-                elif b == 0xc6 and d[i + 1] == 0x05:
+                elif i + 7 <= n and b == 0xc6 and d[i + 1] == 0x05:
                     # mov BYTE PTR [rip+disp], imm8  (c6 /0) -- 7 bytes. This is the byte-store form
                     # that sets a guest 1-byte flag; objdump/readelf and the loads/stores above all
                     # miss it, so it is how the *writer* of a flag byte is found (e.g. the Bendy Agc
@@ -123,13 +127,12 @@ class Module:
                     disp = struct.unpack_from('<i', d, i + 2)[0]
                     site = v + i
                     self.code_xref[site + 7 + disp].append((site, 'storeb'))
-                elif b == 0xc7 and d[i + 1] == 0x05:
+                elif i + 10 <= n and b == 0xc7 and d[i + 1] == 0x05:
                     # mov DWORD PTR [rip+disp], imm32  (c7 /0) -- 10 bytes; the dword store-immediate.
-                    if i + 10 <= n:
-                        disp = struct.unpack_from('<i', d, i + 2)[0]
-                        site = v + i
-                        self.code_xref[site + 10 + disp].append((site, 'stored'))
-                elif b == 0x80 and d[i + 1] == 0x3d:
+                    disp = struct.unpack_from('<i', d, i + 2)[0]
+                    site = v + i
+                    self.code_xref[site + 10 + disp].append((site, 'stored'))
+                elif i + 7 <= n and b == 0x80 and d[i + 1] == 0x3d:
                     # cmp BYTE PTR [rip+disp], imm8  (80 /7) -- 7 bytes; the paired flag-*read* form
                     # (a spin-loop testing a 1-byte flag, e.g. the Bendy suspend-point watchdog).
                     disp = struct.unpack_from('<i', d, i + 2)[0]


### PR DESCRIPTION
## What changed

- scan every possible instruction start in executable PT_LOAD data
- apply exact size checks for each supported x86-64 reference form before reading operands
- add a synthetic ELF regression whose seven-byte RIP-relative store ends exactly at the segment boundary

## Root cause

The scanner used `range(n - 7)` for every instruction form. That excludes the start offset exactly seven bytes before the segment end, so the newly supported seven-byte `storeb`/`cmpb` forms were silently missed at PT_LOAD tails; shorter calls near the tail were also skipped.

## Impact

References are decoded through the complete executable file span without out-of-bounds reads. Existing supported forms are unchanged.

## Validation

- `python3 prosper/tools/re/test_xref.py`
- `python3 -m compileall -q prosper/tools`
- all Python tests under `prosper/tools`
- `git diff --check`

Fixes #1314