### PR TITLE
hle(videoout): --hdr flag — advertise HDR display capability on request; SDR stays the default

### DIFF
--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -633,7 +633,9 @@ int main(int argc, char** argv) {
         else if (a == "--hdr") {
             // Advertise an HDR-capable display to the guest (sceVideoOut capability + output
             // status). Default is SDR — the mode most users' displays and captures expect, and
-            // the path where titles apply their own tonemapping.
+            // the path where titles apply their own tonemapping. Presentation itself is
+            // unchanged (SDR swapchain): a title that commits to PQ output will look wrong —
+            // this is an A/B knob, not an HDR presentation path.
             if (!set_environment("PROSPER_HDR", "1")) {
                 fprintf(stderr, "prosper-app: failed to set PROSPER_HDR\n");
                 return 2;

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -630,6 +630,15 @@ int main(int argc, char** argv) {
                 return 2;
             }
         }
+        else if (a == "--hdr") {
+            // Advertise an HDR-capable display to the guest (sceVideoOut capability + output
+            // status). Default is SDR — the mode most users' displays and captures expect, and
+            // the path where titles apply their own tonemapping.
+            if (!set_environment("PROSPER_HDR", "1")) {
+                fprintf(stderr, "prosper-app: failed to set PROSPER_HDR\n");
+                return 2;
+            }
+        }
         else if (a[0] != '-' && dump.empty()) dump = a;                          // positional dump path
     }
 

--- a/prosper/src/hle/hle_graphics.cpp
+++ b/prosper/src/hle/hle_graphics.cpp
@@ -719,10 +719,11 @@ HLE(g_vo_configure_output) {
 // (0x8100070400000000) — i.e. status+0x04 is the output's dynamic-range/colorimetry mode with
 // 2 = HDR. Previously we returned success with the struct UNWRITTEN, so the caller consumed
 // uninitialized stack (usually != 2 -> SDR by luck — the classic success+garbage-out hazard).
-// Write a defined 8-byte {u32 state=0, u32 mode=0} prefix: mode 0 selects the SDR path
-// deterministically, matching prosper's advertised SDR-only display. 8 bytes cannot overrun any
-// plausible real struct (the DOLL caller reserves 0x50 stack bytes for it). CONFIDENCE: MED on
-// field semantics (single consumer, unambiguous read), HIGH that a defined write beats garbage.
+// Write a defined 8-byte {u32 state=0, u32 mode} prefix: mode 0 by default (the SDR path,
+// matching prosper's default SDR-only display) and mode 2 under PROSPER_HDR (the --hdr opt-in).
+// 8 bytes cannot overrun any plausible real struct (the DOLL caller reserves 0x50 stack bytes
+// for it). CONFIDENCE: MED on field semantics (single consumer, unambiguous read), HIGH that a
+// defined write beats garbage.
 HLE(g_vo_get_output_status) {
     vo_argtrace("GetOutputStatus", a0,a1,a2,a3,a4,a5);
     if (!a1)

--- a/prosper/src/hle/hle_graphics.cpp
+++ b/prosper/src/hle/hle_graphics.cpp
@@ -478,14 +478,23 @@ HLE(g_vo_vblankstatus) {
     *(uint64_t*)(s + 0x10) = ns;                         // tsc (monotonic ns; matches ReadTsc's unit)
     return 0;
 }
+// PROSPER_HDR (the frontends' --hdr flag): advertise an HDR-capable display. Default is SDR —
+// the common case for prosper users, and the mode whose output path titles tonemap themselves.
+// Deliberately uncached: capability queries are boot-time-rare, and tests exercise both modes in
+// one process.
+static bool prosper_hdr_output() { return getenv("PROSPER_HDR") != nullptr; }
+
 // sceVideoOutGetDeviceCapabilityInfo (SceVideoOutDeviceCapabilityInfo: single u64 capability).
-// Advertise a plain SDR display (no HDR/BT2020) — capability 0.
+// Default: a plain SDR display (no HDR/BT2020) — capability 0. With PROSPER_HDR, set the
+// BT2020/PQ capability bit (0x2 — the Orbis-era SCE_VIDEO_OUT_DEVICE_CAPABILITY_BT2020_PQ value;
+// secondary-implementation agreement only, no Gen5 title has been observed reading a different
+// bit yet). CONFIDENCE: MED on the exact bit; HIGH that 0 == SDR-only.
 HLE(g_vo_devcap) {
     if (!a1)
         return (uint64_t)(int64_t)(int32_t)0x80290002;  // SCE_VIDEO_OUT_ERROR_INVALID_ADDRESS
     VideoOutHandleGuard handle(a0);
     if (!handle.valid()) return kVoErrorInvalidHandle;
-    *(uint64_t*)(uintptr_t)a1 = 0;
+    *(uint64_t*)(uintptr_t)a1 = prosper_hdr_output() ? 0x2ull : 0ull;
     return 0;
 }
 
@@ -722,7 +731,8 @@ HLE(g_vo_get_output_status) {
     if (!handle.valid()) return kVoErrorInvalidHandle;
     if (a1 > 0xffffull) {
         *(uint32_t*)(uintptr_t)a1       = 0;   // +0x00: output state (0 = the boring/default state)
-        *(uint32_t*)(uintptr_t)(a1 + 4) = 0;   // +0x04: dynamic-range mode (2 = HDR; 0 = SDR)
+        // +0x04: dynamic-range mode (2 = HDR; 0 = SDR — the DOLL-RE'd field, issue #82).
+        *(uint32_t*)(uintptr_t)(a1 + 4) = prosper_hdr_output() ? 2u : 0u;
     }
     return 0;
 }

--- a/prosper/tests/test_videoout.cpp
+++ b/prosper/tests/test_videoout.cpp
@@ -84,6 +84,34 @@ int main() {
     CHECK((uint32_t)outstat(handle, 0, 0, 0, 0, 0) == kInvalidAddress,
           "GetOutputStatus rejects a null output pointer");
 
+    // PROSPER_HDR (the --hdr flag): default advertises SDR (capability 0, output mode 0); with the
+    // env set, the BT2020/PQ capability bit and dynamic-range mode 2 — the DOLL-RE'd HDR branch
+    // trigger (issue #82).
+    {
+        auto set_hdr = [](const char* value) {
+#ifdef _WIN32
+            _putenv_s("PROSPER_HDR", value ? value : "");
+#else
+            if (value) setenv("PROSPER_HDR", value, 1);
+            else unsetenv("PROSPER_HDR");
+#endif
+        };
+        uint64_t capability = 0xEEEEEEEEEEEEEEEEull;
+        uint32_t status[2] = {0xEEEEEEEEu, 0xEEEEEEEEu};
+        set_hdr(nullptr);
+        CHECK(cap(handle, (uint64_t)(uintptr_t)&capability, 0, 0, 0, 0) == 0 && capability == 0,
+              "default device capability advertises SDR (0)");
+        CHECK(outstat(handle, (uint64_t)(uintptr_t)status, 0, 0, 0, 0) == 0 && status[1] == 0,
+              "default output status advertises dynamic-range mode 0 (SDR)");
+        set_hdr("1");
+        capability = 0xEEEEEEEEEEEEEEEEull; status[1] = 0xEEEEEEEEu;
+        CHECK(cap(handle, (uint64_t)(uintptr_t)&capability, 0, 0, 0, 0) == 0 && capability == 0x2,
+              "PROSPER_HDR advertises the BT2020/PQ capability bit");
+        CHECK(outstat(handle, (uint64_t)(uintptr_t)status, 0, 0, 0, 0) == 0 && status[1] == 2,
+              "PROSPER_HDR advertises dynamic-range mode 2 (HDR)");
+        set_hdr(nullptr);
+    }
+
     // #394 F10 (handle scope): every handle-taking entrypoint must reject an unknown handle before
     // it mutates output, flip/present state, event registrations, or the display-buffer registry.
     constexpr uint32_t kInvalidHandle = 0x8029000bu;

--- a/prosper/tests/test_videoout.cpp
+++ b/prosper/tests/test_videoout.cpp
@@ -6,6 +6,7 @@
 #include "../src/gpu/videoout_present.hpp"
 #include <cstdio>
 #include <cstdint>
+#include <cstdlib>   // setenv/_putenv_s (PROSPER_HDR both-modes test)
 #include <cstring>
 #include <chrono>
 #include <thread>


### PR DESCRIPTION
Refs #1287 (the display-pipeline half of the Blue Prince investigation).

**Contract**: prosper has always advertised a plain SDR display. That stays the default — it is what most users' displays and captures expect, and the mode where titles apply their own tonemapping. `prosper-app --hdr` (env `PROSPER_HDR=1` for the other frontends) opts in: `sceVideoOutGetDeviceCapabilityInfo` reports the BT2020/PQ capability bit (0x2) and `sceVideoOutGetOutputStatus` reports dynamic-range mode 2 — the DOLL-RE'd HDR-branch trigger (#82).

**Evidence basis**: mode-2-at-status+0x04 is prosper's own gdb-RE of the one in-the-wild consumer (DOLL, #82) — HIGH. The capability bit value 0x2 has secondary-implementation agreement only (Orbis-era `SCE_VIDEO_OUT_DEVICE_CAPABILITY_BT2020_PQ`); no Gen5 title has been observed reading a different bit yet — CONFIDENCE: MED, documented in-code. The helper is deliberately uncached so tests exercise both modes in one process (queries are boot-rare).

**Unaffected**: default behavior is byte-identical (capability 0 / mode 0); the existing SDR assertions in `test_videoout` still pass untouched.

**Verification**: build clean; **ctest 147/147**; new `test_videoout` section proves both modes: default → capability 0 + mode 0; `PROSPER_HDR` → capability 0x2 + mode 2 (fails without the fix — the env had no effect before).