### PR TITLE
fix(gpu): preserve live fence generations on suppression

### DIFF
--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -827,7 +827,10 @@ static void honor_eop_write(const Pm4Command& c) {
                           // consumed-marker population so plain fence labels (Messenger) are never
                           // affected. CONFIDENCE: HIGH (mechanism captured live, sessions 2-5).
                           if (rel1_stomp_guard() && label_is_consumed_marker(c.rel_addr)) {
-                              label_hist_rel_exec(c.rel_addr, pre, c.queue_origin);   // ring visibility; write skipped
+                              // Keep the event visible without consuming an init generation. A
+                              // skipped fence did not signal anything; advancing rel_exec_n here
+                              // makes the next real init/fence pair look stale and suppresses it.
+                              label_hist_event(c.rel_addr, LE_REL_EXEC, pre, c.queue_origin);
                               return;
                           }
                       }
@@ -901,7 +904,9 @@ static void honor_eop_write(const Pm4Command& c) {
                   if (rel1_stomp_guard() && ptr_like(pre) && (uint32_t)pre != 0 &&
                       pre != c.rel_value && label_is_consumed_marker(c.rel_addr)) {
                       report_suspect_write("REL2-LIVE", c.rel_addr, c.rel_value, pre, pkt_addr(c));
-                      label_hist_rel_exec(c.rel_addr, pre, c.queue_origin);   // ring visibility; write skipped
+                      // A suppressed write belongs in the diagnostic ring, but it must not advance
+                      // the completed-fence counter (same protocol rule as REL1-LIVE above).
+                      label_hist_event(c.rel_addr, LE_REL_EXEC, pre, c.queue_origin);
                       return;
                   }
                   uint64_t v = c.rel_value;           memcpy(dst, &v, sizeof v);

--- a/prosper/tests/test_eop_write.cpp
+++ b/prosper/tests/test_eop_write.cpp
@@ -517,6 +517,40 @@ int main() {
         CHECK((uint32_t)live_label.next == 1,
               "live consumed-marker labels still execute DmaData(0) then ReleaseMem(1)");
     }
+
+    // A suppressed LIVE fence must not count as a completed generation. If an earlier generation's
+    // init never executes, its pointer-valued REL1/REL2 is suppressed; the next generation's real
+    // DmaData(0)+ReleaseMem(1) must still see an outstanding init and signal the label. Counting the
+    // suppressed fence makes dma_exec_n == rel_exec_n and the forge guard suppresses this real fence.
+    for (uint32_t stale_sel : {1u, 2u}) {
+        struct alignas(0x20) Label { uint64_t value; uint64_t pad[3]; } label{};
+        const uint64_t addr = (uint64_t)(uintptr_t)&label;
+        GpuState st;
+
+        prosper_label_hist_dma_built(addr, 0x5000 + stale_sel, 0, 1);
+        label.value = 0x1000000008ull; // freed/relinked pointer: missing init for generation 1
+        uint32_t stale_rel[7] = {};
+        stale_rel[0] = PM4(7, IT_NOP, R_RELEASE_MEM);
+        stale_rel[1] = (uint32_t)addr; stale_rel[2] = (uint32_t)(addr >> 32);
+        stale_rel[3] = stale_sel; stale_rel[4] = 1; stale_rel[6] = 4;
+        run_cb(stale_rel, 7, st);
+        CHECK(label.value == 0x1000000008ull,
+              stale_sel == 1 ? "REL1-LIVE stale fence is suppressed"
+                             : "REL2-LIVE stale fence is suppressed");
+
+        prosper_label_hist_dma_built(addr, 0x6000 + stale_sel, 0, 1);
+        uint32_t live_pair[14] = {};
+        live_pair[0] = PM4(7, IT_NOP, R_DMA_DATA);
+        live_pair[1] = (uint32_t)addr; live_pair[2] = (uint32_t)(addr >> 32);
+        live_pair[3] = 0; live_pair[4] = 0; live_pair[5] = 4; live_pair[6] = 0x303;
+        live_pair[7] = PM4(7, IT_NOP, R_RELEASE_MEM);
+        live_pair[8] = (uint32_t)addr; live_pair[9] = (uint32_t)(addr >> 32);
+        live_pair[10] = 1; live_pair[11] = 1; live_pair[13] = 4;
+        run_cb(live_pair, 14, st);
+        CHECK((uint32_t)label.value == 1,
+              stale_sel == 1 ? "REL1-LIVE suppression does not consume the next generation"
+                             : "REL2-LIVE suppression does not consume the next generation");
+    }
     mb3_reset_pool_candidates_for_test();
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }


### PR DESCRIPTION
Closes #1246.

## Summary

- record suppressed REL1-LIVE and REL2-LIVE fences in the diagnostic ring without advancing `rel_exec_n`
- keep the next real DMA-init/fence generation visible as live
- add a two-generation regression test for both suppression paths

## Validation

- negative control with the old counter updates: both new assertions fail
- `ctest --test-dir prosper/build-audit --output-on-failure -j2` (143/143 passed)
- `git diff --check`

Game snapshots are not required: this changes completion-label protocol bookkeeping and is covered by a deterministic command-processor regression test; no renderer output path changes.
