### PR TITLE
fix(gpu): limit forge suppression to consumed markers

### DIFF
--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -862,7 +862,7 @@ static void honor_eop_write(const Pm4Command& c) {
                       const bool live_pair =
                           fh.dma_exec_n.load(std::memory_order_relaxed) >
                           fh.rel_exec_n.load(std::memory_order_relaxed);
-                      if (forge_guard() && !live_pair) {
+                      if (forge_guard() && label_is_consumed_marker(c.rel_addr) && !live_pair) {
                           report_suspect_write("REL1-FORGE", c.rel_addr, c.rel_value, pre, pkt_addr(c));
                           // Ring visibility WITHOUT the rel_exec_n bump: a suppressed fence must not
                           // advance the consumed-count, or the NEXT generation's live check above

--- a/prosper/tests/test_eop_write.cpp
+++ b/prosper/tests/test_eop_write.cpp
@@ -518,6 +518,22 @@ int main() {
               "live consumed-marker labels still execute DmaData(0) then ReleaseMem(1)");
     }
 
+    // Plain EOP labels have no DmaData-init lifecycle. Their untouched high dword may look like a
+    // heap pointer while the low dword is the legitimate fence payload; the consumed-marker forge
+    // guard must not permanently suppress that ordinary 32-bit completion write.
+    {
+        static struct alignas(0x20) PlainLabel { uint64_t value; uint64_t pad[3]; } label{};
+        label.value = 0x1000000000ull;
+        const uint64_t addr = (uint64_t)(uintptr_t)&label;
+        uint32_t rel[7] = {};
+        rel[0] = PM4(7, IT_NOP, R_RELEASE_MEM);
+        rel[1] = (uint32_t)addr; rel[2] = (uint32_t)(addr >> 32);
+        rel[3] = 1; rel[4] = 1; rel[6] = 4;
+        GpuState st; run_cb(rel, 7, st);
+        CHECK(label.value == 0x1000000001ull,
+              "plain pointer-shaped fence label is not treated as a consumed-marker forge");
+    }
+
     // A suppressed LIVE fence must not count as a completed generation. If an earlier generation's
     // init never executes, its pointer-valued REL1/REL2 is suppressed; the next generation's real
     // DmaData(0)+ReleaseMem(1) must still see an outstanding init and signal the label. Counting the


### PR DESCRIPTION
Closes #1247.

## Summary

- require consumed-marker DmaData history before suppressing a pointer-forging ReleaseMem
- leave ordinary 32-bit EOP labels outside the consumed-marker protocol untouched
- add a regression for a plain fence whose preserved high dword resembles allocator residue

## Validation

- negative control without the gate: the new plain-fence assertion fails
- `ctest --test-dir prosper/build-audit --output-on-failure -j2` (143/143 passed)
- `git diff --check`

Game snapshots are not required: this is completion-label protocol classification with a deterministic command-processor regression test; renderer output is unchanged.
