### PR TITLE
feat(input): add scripted headless IME keys

### DIFF
--- a/prosper/docs/INPUT_REPLAY.md
+++ b/prosper/docs/INPUT_REPLAY.md
@@ -63,6 +63,23 @@ We already have the seed: **`PROSPER_PAD_SCRIPT` (#202)** — a scripted `PadBac
 The remaining work is deeper route calibration and semantic checkpoint validation that does not
 depend on presentation speed.
 
+## IME-keyboard scripts
+
+Titles that consume keyboard input through `sceImeUpdate` instead of `scePadRead` can use
+`PROSPER_IME_SCRIPT`. Its entries are `fN:HID` or inclusive `fA-B:HID` windows, where HID is a
+decimal or `0x`-prefixed USB usage id (`0x28` Enter, `0x2c` Space). The frame axis counts non-null
+`sceImeUpdate` handler pumps from zero; in the observed IME titles this is one pump per game frame.
+A point holds for two pumps. Semicolon-separated inline routes and newline-separated `@file` routes
+with `#` comments are accepted:
+
+```bash
+PROSPER_IME_SCRIPT='f30:0x28;f120-124:0x2c' boot_trace <app0>
+PROSPER_IME_SCRIPT=@scripts/title/reach-menu.ime screenshot <app0>
+```
+
+The route emits one KEY_DOWN at the start of a window and one KEY_UP after it, without repeating the
+key while held. It is separate from `PROSPER_PAD_SCRIPT` because an IME-only title never polls the pad.
+
 ## Design
 
 ### 1. Frame/pad-read-anchored, file-loadable scripts (core) - implemented

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -7,6 +7,7 @@
 #include "hle_json2.hpp"
 #include "nid.hpp"
 #include "callback_fs.hpp"
+#include "ime_input.hpp"
 #include "platform_ui.hpp"
 #include "video_backend.hpp"   // sceAvPlayer -> host hardware-decode backend (#705)
 #include "../host/posix_shim.hpp"   // Darwin process_vm_readv shim + asm portability
@@ -16,6 +17,7 @@
 #include <cstring>
 #include <cstdio>
 #include <cstdlib>
+#include <cerrno>
 #include <atomic>
 #include <algorithm>
 #include <deque>
@@ -1152,8 +1154,6 @@ void ime_autokey_tick(uint64_t handler, uint64_t guest_fs) {
 // newlines; HID accepts decimal or 0x-prefixed USB usage ids. A point entry is held for two update
 // ticks. Prefix the value with '@' to load the same text from a route file. Unlike AUTOKEY this is a
 // finite route: transitions are emitted only when a key enters/leaves an active window.
-struct ImeScriptEntry { uint64_t first = 0, last = 0; uint16_t hid = 0; };
-
 std::string ime_script_text(const char* source, std::string& error) {
     if (!source || !*source) return {};
     if (*source != '@') return source;
@@ -1167,8 +1167,21 @@ std::string ime_script_text(const char* source, std::string& error) {
     return text;
 }
 
-std::vector<ImeScriptEntry> parse_ime_script(const std::string& text, std::string& error) {
-    std::vector<ImeScriptEntry> out;
+bool ime_script_u64(const char* p, char** tail, uint64_t& value) {
+    if (!p || !((*p >= '0' && *p <= '9'))) { if (tail) *tail = (char*)p; return false; }
+    errno = 0;
+    char* end = nullptr;
+    const int base = p[0] == '0' && (p[1] == 'x' || p[1] == 'X') ? 16 : 10;
+    const unsigned long long parsed = strtoull(p, &end, base);
+    if (end == p || errno == ERANGE || parsed > UINT64_MAX) { if (tail) *tail = end; return false; }
+    if (tail) *tail = end;
+    value = (uint64_t)parsed;
+    return true;
+}
+
+bool parse_ime_script_impl(const std::string& text, std::vector<ImeScriptWindow>& out,
+                           std::string& error) {
+    out.clear();
     size_t pos = 0;
     while (pos < text.size()) {
         size_t end = text.find_first_of(";\n\r", pos);
@@ -1181,28 +1194,31 @@ std::vector<ImeScriptEntry> parse_ime_script(const std::string& text, std::strin
         size_t last_nonspace = item.find_last_not_of(" \t");
         item = item.substr(first_nonspace, last_nonspace - first_nonspace + 1);
         if (item.empty()) continue;
-        if (item[0] != 'f') { error = "entry must start with f: " + item; return {}; }
+        if (item[0] != 'f') { error = "entry must start with f: " + item; return false; }
         const char* p = item.c_str() + 1;
         char* tail = nullptr;
-        unsigned long long first = strtoull(p, &tail, 0);
-        if (tail == p) { error = "invalid frame anchor: " + item; return {}; }
-        unsigned long long last = first == UINT64_MAX ? first : first + 1;
+        uint64_t first = 0;
+        if (!ime_script_u64(p, &tail, first)) { error = "invalid frame anchor: " + item; return false; }
+        uint64_t last = first == UINT64_MAX ? first : first + 1;
         // Point entries hold down for two update ticks (or one at the representational maximum).
         if (*tail == '-') {
             p = tail + 1;
-            last = strtoull(p, &tail, 0);
-            if (tail == p || last < first) { error = "invalid frame range: " + item; return {}; }
+            if (!ime_script_u64(p, &tail, last) || last < first) {
+                error = "invalid frame range: " + item; return false;
+            }
         }
-        if (*tail != ':') { error = "missing HID separator: " + item; return {}; }
+        if (*tail != ':') { error = "missing HID separator: " + item; return false; }
         p = tail + 1;
-        unsigned long hid = strtoul(p, &tail, 0);
+        uint64_t hid = 0;
+        if (!ime_script_u64(p, &tail, hid)) { error = "invalid HID usage: " + item; return false; }
         while (*tail == ' ' || *tail == '\t') ++tail;
-        if (tail == p || *tail || hid == 0 || hid > UINT16_MAX) {
-            error = "invalid HID usage: " + item; return {};
+        if (*tail || hid == 0 || hid > UINT16_MAX) {
+            error = "invalid HID usage: " + item; return false;
         }
-        out.push_back({(uint64_t)first, (uint64_t)last, (uint16_t)hid});
+        out.push_back({first, last, (uint16_t)hid});
     }
-    return out;
+    error.clear();
+    return true;
 }
 
 class ImeScriptRuntime {
@@ -1212,13 +1228,13 @@ public:
         if (!source || !*source) return;
         std::string error;
         const std::string text = ime_script_text(source, error);
-        if (error.empty()) entries_ = parse_ime_script(text, error);
+        if (error.empty()) parse_ime_script_impl(text, entries_, error);
         if (!error.empty()) fprintf(stderr, "[ime] PROSPER_IME_SCRIPT: %s\n", error.c_str());
     }
 
     void tick(uint64_t handler, uint64_t guest_fs) {
         if (!handler || entries_.empty()) return;
-        std::vector<ImeKeyEvent> transitions;
+        bool become_dispatcher = false;
         {
             std::lock_guard<std::mutex> lock(mutex_);
             std::vector<uint16_t> next;
@@ -1227,21 +1243,36 @@ public:
                     std::find(next.begin(), next.end(), e.hid) == next.end()) next.push_back(e.hid);
             for (uint16_t hid : active_)
                 if (std::find(next.begin(), next.end(), hid) == next.end())
-                    transitions.push_back({hid, false});
+                    pending_.push_back({handler, guest_fs, {hid, false}});
             for (uint16_t hid : next)
                 if (std::find(active_.begin(), active_.end(), hid) == active_.end())
-                    transitions.push_back({hid, true});
+                    pending_.push_back({handler, guest_fs, {hid, true}});
             active_ = std::move(next);
             ++tick_;
+            if (!dispatching_ && !pending_.empty()) { dispatching_ = true; become_dispatcher = true; }
         }
-        // Never retain the runtime mutex across a call into guest code.
-        for (const auto& ev : transitions) ime_deliver(handler, ev, guest_fs);
+        if (!become_dispatcher) return;
+        for (;;) {
+            Pending transition;
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+                if (pending_.empty()) { dispatching_ = false; return; }
+                transition = pending_.front();
+                pending_.pop_front();
+            }
+            // Never retain the runtime mutex across a call into guest code. A reentrant tick queues
+            // behind transitions already published by this tick; this outer dispatcher drains it.
+            ime_deliver(transition.handler, transition.ev, transition.guest_fs);
+        }
     }
 
 private:
-    std::vector<ImeScriptEntry> entries_;
+    struct Pending { uint64_t handler = 0, guest_fs = 0; ImeKeyEvent ev{}; };
+    std::vector<ImeScriptWindow> entries_;
     std::vector<uint16_t> active_;
+    std::deque<Pending> pending_;
     uint64_t tick_ = 0;
+    bool dispatching_ = false;
     std::mutex mutex_;
 };
 
@@ -1265,6 +1296,14 @@ void ime_update_run(uint64_t handler, uint64_t guest_fs) {
     }
 }
 } // namespace
+
+bool parse_ime_script_route(const std::string& text, std::vector<ImeScriptWindow>& out,
+                            std::string* error) {
+    std::string local_error;
+    const bool ok = parse_ime_script_impl(text, out, local_error);
+    if (error) *error = local_error;
+    return ok;
+}
 
 // Frontend seam (declared in ime_input.hpp): push a keyboard key (USB HID usage id) into the IME
 // queue; drained on the next sceImeUpdate. Thread-safe (called from the frontend's input thread).

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -1147,11 +1147,115 @@ void ime_autokey_tick(uint64_t handler, uint64_t guest_fs) {
     }
 }
 
+// PROSPER_IME_SCRIPT: deterministic headless keyboard input, anchored to the first sceImeUpdate
+// call carrying a non-null handler. Entries are `fN:HID` or `fA-B:HID`, separated by semicolons or
+// newlines; HID accepts decimal or 0x-prefixed USB usage ids. A point entry is held for two update
+// ticks. Prefix the value with '@' to load the same text from a route file. Unlike AUTOKEY this is a
+// finite route: transitions are emitted only when a key enters/leaves an active window.
+struct ImeScriptEntry { uint64_t first = 0, last = 0; uint16_t hid = 0; };
+
+std::string ime_script_text(const char* source, std::string& error) {
+    if (!source || !*source) return {};
+    if (*source != '@') return source;
+    FILE* f = fopen(source + 1, "rb");
+    if (!f) { error = std::string("cannot open route file: ") + (source + 1); return {}; }
+    std::string text;
+    char buf[4096];
+    while (size_t n = fread(buf, 1, sizeof buf, f)) text.append(buf, n);
+    if (ferror(f)) error = std::string("cannot read route file: ") + (source + 1);
+    fclose(f);
+    return text;
+}
+
+std::vector<ImeScriptEntry> parse_ime_script(const std::string& text, std::string& error) {
+    std::vector<ImeScriptEntry> out;
+    size_t pos = 0;
+    while (pos < text.size()) {
+        size_t end = text.find_first_of(";\n\r", pos);
+        if (end == std::string::npos) end = text.size();
+        std::string item = text.substr(pos, end - pos);
+        pos = end + 1;
+        if (size_t hash = item.find('#'); hash != std::string::npos) item.resize(hash);
+        size_t first_nonspace = item.find_first_not_of(" \t");
+        if (first_nonspace == std::string::npos) continue;
+        size_t last_nonspace = item.find_last_not_of(" \t");
+        item = item.substr(first_nonspace, last_nonspace - first_nonspace + 1);
+        if (item.empty()) continue;
+        if (item[0] != 'f') { error = "entry must start with f: " + item; return {}; }
+        const char* p = item.c_str() + 1;
+        char* tail = nullptr;
+        unsigned long long first = strtoull(p, &tail, 0);
+        if (tail == p) { error = "invalid frame anchor: " + item; return {}; }
+        unsigned long long last = first == UINT64_MAX ? first : first + 1;
+        // Point entries hold down for two update ticks (or one at the representational maximum).
+        if (*tail == '-') {
+            p = tail + 1;
+            last = strtoull(p, &tail, 0);
+            if (tail == p || last < first) { error = "invalid frame range: " + item; return {}; }
+        }
+        if (*tail != ':') { error = "missing HID separator: " + item; return {}; }
+        p = tail + 1;
+        unsigned long hid = strtoul(p, &tail, 0);
+        while (*tail == ' ' || *tail == '\t') ++tail;
+        if (tail == p || *tail || hid == 0 || hid > UINT16_MAX) {
+            error = "invalid HID usage: " + item; return {};
+        }
+        out.push_back({(uint64_t)first, (uint64_t)last, (uint16_t)hid});
+    }
+    return out;
+}
+
+class ImeScriptRuntime {
+public:
+    ImeScriptRuntime() {
+        const char* source = getenv("PROSPER_IME_SCRIPT");
+        if (!source || !*source) return;
+        std::string error;
+        const std::string text = ime_script_text(source, error);
+        if (error.empty()) entries_ = parse_ime_script(text, error);
+        if (!error.empty()) fprintf(stderr, "[ime] PROSPER_IME_SCRIPT: %s\n", error.c_str());
+    }
+
+    void tick(uint64_t handler, uint64_t guest_fs) {
+        if (!handler || entries_.empty()) return;
+        std::vector<ImeKeyEvent> transitions;
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            std::vector<uint16_t> next;
+            for (const auto& e : entries_)
+                if (tick_ >= e.first && tick_ <= e.last &&
+                    std::find(next.begin(), next.end(), e.hid) == next.end()) next.push_back(e.hid);
+            for (uint16_t hid : active_)
+                if (std::find(next.begin(), next.end(), hid) == next.end())
+                    transitions.push_back({hid, false});
+            for (uint16_t hid : next)
+                if (std::find(active_.begin(), active_.end(), hid) == active_.end())
+                    transitions.push_back({hid, true});
+            active_ = std::move(next);
+            ++tick_;
+        }
+        // Never retain the runtime mutex across a call into guest code.
+        for (const auto& ev : transitions) ime_deliver(handler, ev, guest_fs);
+    }
+
+private:
+    std::vector<ImeScriptEntry> entries_;
+    std::vector<uint16_t> active_;
+    uint64_t tick_ = 0;
+    std::mutex mutex_;
+};
+
+void ime_script_tick(uint64_t handler, uint64_t guest_fs) {
+    static ImeScriptRuntime runtime;
+    runtime.tick(handler, guest_fs);
+}
+
 // Shared sceImeUpdate body: fire the autokey pulse (if enabled) then drain the queued keys, dispatching
 // each on the caller's guest %fs (guest_fs == 0 => no swap, the Windows/macOS path). The queue mutex is
 // released before every guest handler call (never held across guest code).
 void ime_update_run(uint64_t handler, uint64_t guest_fs) {
     ime_autokey_tick(handler, guest_fs);        // handler = the guest event handler
+    ime_script_tick(handler, guest_fs);
     for (;;) {
         ImeKeyEvent ev;
         { std::lock_guard<std::mutex> lk(g_ime_mx);

--- a/prosper/src/hle/ime_input.hpp
+++ b/prosper/src/hle/ime_input.hpp
@@ -7,8 +7,20 @@
 //   Enter=0x28  Space=0x2c  Escape=0x29  A..Z=0x04..0x1d  Right=0x4f Left=0x50 Down=0x51 Up=0x52
 #pragma once
 #include <cstdint>
+#include <string>
+#include <vector>
 
 namespace prosper {
+struct ImeScriptWindow {
+    uint64_t first = 0, last = 0;
+    uint16_t hid = 0;
+};
+
+// Pure route parser shared with regression tests. Frame spellings are unsigned decimal/0x counts;
+// ranges are inclusive. Returns false and describes the first malformed entry in `error`.
+bool parse_ime_script_route(const std::string& text, std::vector<ImeScriptWindow>& out,
+                            std::string* error = nullptr);
+
 // Push one keyboard key transition (USB HID usage id) into the IME event queue. Thread-safe;
 // drained on the next sceImeUpdate on the guest thread. `down` = key press, else release.
 void ime_push_key(uint16_t hid_usage, bool down);

--- a/prosper/tests/test_ime_input.cpp
+++ b/prosper/tests/test_ime_input.cpp
@@ -9,6 +9,10 @@
 #include "../src/hle/ime_input.hpp"
 #include <cstdio>
 #include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <string>
 #include <vector>
 
 using namespace prosper;
@@ -27,6 +31,15 @@ static void fake_handler(uint64_t /*arg*/, void* ev) {
 
 int main() {
     printf("== test_ime_input ==\n");
+    const std::filesystem::path script_path =
+        std::filesystem::temp_directory_path() / "prosper_test_ime_input.route";
+    { std::ofstream route(script_path); route << "# headless keyboard route\nf5-6:0x2c\n"; }
+    const std::string script_source = "@" + script_path.string();
+#ifdef _WIN32
+    _putenv_s("PROSPER_IME_SCRIPT", script_source.c_str());
+#else
+    setenv("PROSPER_IME_SCRIPT", script_source.c_str(), 1);
+#endif
     register_builtin_hle();
     auto update = reinterpret_cast<uint64_t (*)(uint64_t,uint64_t,uint64_t,uint64_t,uint64_t,uint64_t,uint64_t)>(
         Hle::lookup(nid_hash("sceImeUpdate")));
@@ -66,6 +79,23 @@ int main() {
     update(0, 0, 0, 0, 0, 0, 0);
     CHECK(true, "null handler tolerated");
 
+    // PROSPER_IME_SCRIPT is anchored to non-null sceImeUpdate calls (the null pump above does not
+    // consume a frame). The f5-6 range emits one down transition, remains held, then emits one up.
+    g_rec.clear();
+    update(H, 0, 0, 0, 0, 0, 0); // f4
+    CHECK(g_rec.empty(), "IME script stays idle before its frame window");
+    update(H, 0, 0, 0, 0, 0, 0); // f5
+    CHECK(g_rec.size() == 1 && g_rec[0].id == 0x101 && g_rec[0].keycode == 0x2c,
+          "IME script emits key down at the range start");
+    g_rec.clear();
+    update(H, 0, 0, 0, 0, 0, 0); // f6
+    CHECK(g_rec.empty(), "IME script holds a key without repeating it inside the range");
+    update(H, 0, 0, 0, 0, 0, 0); // f7
+    CHECK(g_rec.size() == 1 && g_rec[0].id == 0x102 && g_rec[0].keycode == 0x2c,
+          "IME script emits key up after the range ends");
+
+    std::error_code remove_error;
+    std::filesystem::remove(script_path, remove_error);
     printf("fails=%d\n", fails);
     return fails ? 1 : 0;
 }

--- a/prosper/tests/test_ime_input.cpp
+++ b/prosper/tests/test_ime_input.cpp
@@ -24,16 +24,25 @@ static int fails = 0;
 // Fake guest handler: records each delivered event's id + keycode.
 struct Rec { uint32_t id; uint16_t keycode; };
 static std::vector<Rec> g_rec;
+using UpdateFn = uint64_t (*)(uint64_t,uint64_t,uint64_t,uint64_t,uint64_t,uint64_t,uint64_t);
+static UpdateFn g_update = nullptr;
+static uint64_t g_handler_addr = 0;
+static bool g_reenter_on_space_up = false;
 static void fake_handler(uint64_t /*arg*/, void* ev) {
     auto* e = (uint8_t*)ev;
-    g_rec.push_back({*(uint32_t*)(e + 0x00), *(uint16_t*)(e + 0x08)});
+    const Rec rec{*(uint32_t*)(e + 0x00), *(uint16_t*)(e + 0x08)};
+    g_rec.push_back(rec);
+    if (g_reenter_on_space_up && rec.id == 0x102 && rec.keycode == 0x2c) {
+        g_reenter_on_space_up = false;
+        g_update(g_handler_addr, 0, 0, 0, 0, 0, 0);
+    }
 }
 
 int main() {
     printf("== test_ime_input ==\n");
     const std::filesystem::path script_path =
         std::filesystem::temp_directory_path() / "prosper_test_ime_input.route";
-    { std::ofstream route(script_path); route << "# headless keyboard route\nf5-6:0x2c\n"; }
+    { std::ofstream route(script_path); route << "# headless keyboard route\nf5-6:0x2c\nf7-7:0x28\n"; }
     const std::string script_source = "@" + script_path.string();
 #ifdef _WIN32
     _putenv_s("PROSPER_IME_SCRIPT", script_source.c_str());
@@ -41,11 +50,21 @@ int main() {
     setenv("PROSPER_IME_SCRIPT", script_source.c_str(), 1);
 #endif
     register_builtin_hle();
-    auto update = reinterpret_cast<uint64_t (*)(uint64_t,uint64_t,uint64_t,uint64_t,uint64_t,uint64_t,uint64_t)>(
-        Hle::lookup(nid_hash("sceImeUpdate")));
+    auto update = reinterpret_cast<UpdateFn>(Hle::lookup(nid_hash("sceImeUpdate")));
     CHECK(update != nullptr, "sceImeUpdate registered");
     if (!update) { printf("fails=%d\n", fails); return 1; }
     const uint64_t H = (uint64_t)(uintptr_t)&fake_handler;
+    g_update = update;
+    g_handler_addr = H;
+
+    std::vector<ImeScriptWindow> parsed;
+    std::string parse_error;
+    CHECK(!parse_ime_script_route("f-1:0x28", parsed, &parse_error),
+          "IME script rejects a negative frame anchor");
+    CHECK(!parse_ime_script_route("f18446744073709551616:0x28", parsed, &parse_error),
+          "IME script rejects an overflowing frame anchor");
+    CHECK(!parse_ime_script_route("f1-18446744073709551616:0x28", parsed, &parse_error),
+          "IME script rejects an overflowing range endpoint");
 
     // No queued events -> handler is never called (a title with no input this frame).
     g_rec.clear();
@@ -90,9 +109,13 @@ int main() {
     g_rec.clear();
     update(H, 0, 0, 0, 0, 0, 0); // f6
     CHECK(g_rec.empty(), "IME script holds a key without repeating it inside the range");
-    update(H, 0, 0, 0, 0, 0, 0); // f7
-    CHECK(g_rec.size() == 1 && g_rec[0].id == 0x102 && g_rec[0].keycode == 0x2c,
-          "IME script emits key up after the range ends");
+    g_reenter_on_space_up = true;
+    update(H, 0, 0, 0, 0, 0, 0); // f7; callback re-enters at f8
+    CHECK(g_rec.size() == 3 &&
+              g_rec[0].id == 0x102 && g_rec[0].keycode == 0x2c &&
+              g_rec[1].id == 0x101 && g_rec[1].keycode == 0x28 &&
+              g_rec[2].id == 0x102 && g_rec[2].keycode == 0x28,
+          "reentrant IME update preserves release/press/release transition order");
 
     std::error_code remove_error;
     std::filesystem::remove(script_path, remove_error);


### PR DESCRIPTION
Addresses the scripted-input slice of #1100. The handler-argument and additional-event-id follow-ups remain open because their ABI layouts still need title evidence.

## Summary

- add `PROSPER_IME_SCRIPT` with `fN:HID` and inclusive `fA-B:HID` windows
- support inline semicolon routes and newline/comment-friendly `@file` routes
- anchor at the first non-null `sceImeUpdate` handler pump and emit transition-only KEY_DOWN/KEY_UP events
- serialize runtime state without holding a mutex across guest callback execution
- document the route format alongside controller input replay

## Validation

- `ctest --test-dir prosper/build-audit --output-on-failure -R '^(ime_input|ime_fs)$'`
- `ctest --test-dir prosper/build-audit --output-on-failure -j2` (143/143 passed)
- `git diff --check`

The regression loads an actual `@file` route and verifies idle, down, held-without-repeat, and up behavior through the registered `sceImeUpdate` HLE. No game snapshots are required: this is a deterministic input-delivery route with no renderer changes.
