### PR TITLE
capture(v24): serialize the MODE=3 MSAA resolve flag

### DIFF
--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -44,6 +44,9 @@ constexpr char kMagic[8] = {'P','R','G','P','C','A','P','\0'};
 // --inspect-only surface raw-vs-realized offline and flag a decode/realization divergence (e.g. GTA
 // #1163's non-indexed vertex-count inflation) without a live boot. Older captures read fine (the fields
 // default to 0/false = "unknown").
+// v24 (#1240): a trailing per-draw/per-failure CB_COLOR_CONTROL.MODE=3 resolve flag, so offline
+// replays run the resolve copy the live renderer performs (pre-v24 captures default to false and
+// silently skip it — a Blue Prince replay presented black while live showed content).
 constexpr uint32_t kVersion = 24;
 constexpr uint32_t kEndian = 0x01020304u;
 constexpr uint64_t kMaxFileBytes = 4ull << 30;

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -44,7 +44,7 @@ constexpr char kMagic[8] = {'P','R','G','P','C','A','P','\0'};
 // --inspect-only surface raw-vs-realized offline and flag a decode/realization divergence (e.g. GTA
 // #1163's non-indexed vertex-count inflation) without a live boot. Older captures read fine (the fields
 // default to 0/false = "unknown").
-constexpr uint32_t kVersion = 23;
+constexpr uint32_t kVersion = 24;
 constexpr uint32_t kEndian = 0x01020304u;
 constexpr uint64_t kMaxFileBytes = 4ull << 30;
 constexpr uint64_t kMaxBlobBytes = 1ull << 30;
@@ -1507,6 +1507,15 @@ bool serialize_gpu_capture(const GpuCaptureFile& c, std::vector<uint8_t>& bytes,
     // ("unknown"). Kept as a trailing block so every v1-v22 record prefix stays byte-exact.
     w.u32(static_cast<uint32_t>(c.draws.size()));
     for (const auto& draw : c.draws) { w.u32(draw.raw_draw_count); w.u32(draw.raw_indexed ? 1u : 0u); }
+    // v24 (#1240) appends CB_COLOR_CONTROL.MODE=3 (MSAA resolve) per draw + failure pipeline.
+    // Without it a replay silently skips the resolve copy (the display source never fills), so the
+    // offline oracle is blind to #1238's behavior. Trailing block: every v1-v23 prefix stays
+    // byte-exact and pre-v24 captures default to false.
+    w.u32(static_cast<uint32_t>(c.draws.size()));
+    for (const auto& draw : c.draws) w.u8(draw.ps.cb_resolve ? 1u : 0u);
+    w.u32(static_cast<uint32_t>(c.failure_diagnostics.size()));
+    for (const auto& diagnostic : c.failure_diagnostics)
+        if (diagnostic.pipeline_present) w.u8(diagnostic.pipeline.cb_resolve ? 1u : 0u);
     if (w.data.size() > kMaxFileBytes) { error = "capture file exceeds 4 GiB"; return false; }
     bytes = std::move(w.data);
     return true;
@@ -2059,6 +2068,25 @@ bool deserialize_gpu_capture(const std::vector<uint8_t>& bytes, GpuCaptureFile& 
             if (!r.u32(draw.raw_draw_count) || !r.u32(ri)) return false;
             draw.raw_indexed = ri != 0;
         }
+    }
+    if (version >= 24) {   // #1240: MODE=3 resolve flag per draw + failure pipeline
+        uint32_t nd = 0;
+        if (!r.u32(nd) || nd != c.draws.size()) { error = "invalid resolve draw-state count"; return false; }
+        for (auto& draw : c.draws) {
+            uint8_t b = 0;
+            if (!r.u8(b)) return false;
+            draw.ps.cb_resolve = b != 0;
+        }
+        uint32_t nf = 0;
+        if (!r.u32(nf) || nf != c.failure_diagnostics.size()) {
+            error = "invalid resolve failure-state count"; return false;
+        }
+        for (auto& diagnostic : c.failure_diagnostics)
+            if (diagnostic.pipeline_present) {
+                uint8_t b = 0;
+                if (!r.u8(b)) return false;
+                diagnostic.pipeline.cb_resolve = b != 0;
+            }
     }
     if (version >= 7 && !validate_failure_diagnostics(c, error)) return false;
     if (r.left) { error = "capture has trailing data"; return false; }

--- a/prosper/tests/test_gpu_capture.cpp
+++ b/prosper/tests/test_gpu_capture.cpp
@@ -105,6 +105,7 @@ int main() {
     draw.ps.has_scissor = true; draw.ps.scissor_left = 12; draw.ps.scissor_top = 19;
     draw.ps.scissor_right = 70; draw.ps.scissor_bottom = 75;
     draw.ps.logic_op_enable = true; draw.ps.logic_op = 6;
+    draw.ps.cb_resolve = true;   // #1240: MODE=3 MSAA resolve flag (v24)
 
     GpuCaptureMetadata meta; meta.width = 480; meta.height = 270; meta.submit_index = 42;
     meta.revision = "deadbeef"; meta.title_id = "PPSA24651"; meta.input_route = "@reach-level.pad";
@@ -213,6 +214,7 @@ int main() {
               v16_scissor_bytes.size() >= 25,
           "v17 capture serializes effective guest scissor state");
     if (v16_scissor_bytes.size() >= 25) {
+        v16_scissor_bytes.resize(v16_scissor_bytes.size() - 9); // v24 count + one resolve flag + zero-failure count
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - 12); // v23 count + one raw-draw-state
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - 28); // v22 count + three empty vectors
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - 13); // v21 one draw + zero failures
@@ -360,6 +362,7 @@ int main() {
           "writer rejects an out-of-bounds DCC metadata reference");
     CHECK(serialize_gpu_capture(volume_capture, volume_bytes, error),
           "recreated valid v12 DCC bytes after malformed-reference check");
+    volume_bytes.resize(volume_bytes.size() - 9); // v24 count + one resolve flag + zero-failure count
     volume_bytes.resize(volume_bytes.size() - 12); // v23 count + one raw-draw-state
     volume_bytes.resize(volume_bytes.size() - 12); // v22 count + one empty vector
     volume_bytes.resize(volume_bytes.size() - 13); // v21 one logic-op draw + zero failures
@@ -427,9 +430,22 @@ int main() {
     CHECK(read_gpu_capture(path.string(), loaded, error), "versioned capture reads back");
     std::vector<uint8_t> v20_bytes;
     GpuCaptureFile v20_loaded;
+    // v23 simulation (#1240): strip ONLY the v24 resolve tail — the flag must default to false.
+    std::vector<uint8_t> v23_bytes;
+    GpuCaptureFile v23_loaded;
+    CHECK(serialize_gpu_capture(captured, v23_bytes, error) && v23_bytes.size() >= 21,
+          "v24 capture serializes the resolve extension");
+    if (v23_bytes.size() >= 21) {
+        v23_bytes.resize(v23_bytes.size() - 9); // v24 count + one resolve flag + zero-failure count
+        v23_bytes[8] = 23; v23_bytes[9] = v23_bytes[10] = v23_bytes[11] = 0;
+    }
+    CHECK(deserialize_gpu_capture(v23_bytes, v23_loaded, error) &&
+              !v23_loaded.draws[0].ps.cb_resolve,
+          "v23 capture reopens with the historical no-resolve default (#1240)");
     CHECK(serialize_gpu_capture(captured, v20_bytes, error) && v20_bytes.size() >= 21,
           "v21 capture serializes the logic-op extension");
     if (v20_bytes.size() >= 21) {
+        v20_bytes.resize(v20_bytes.size() - 9); // v24 count + one resolve flag + zero-failure count
         v20_bytes.resize(v20_bytes.size() - 12); // v23 count + one raw-draw-state
         v20_bytes.resize(v20_bytes.size() - 28); // v22 count + three empty vectors
         v20_bytes.resize(v20_bytes.size() - 13); // v21 one logic-op draw + zero failures
@@ -484,6 +500,8 @@ int main() {
           "v20 realized draw instance count round-trips");
     CHECK(loaded.draws[0].raw_draw_count == 6 && !loaded.draws[0].raw_indexed,
           "v23 raw draw-packet state round-trips through write/read (#1256)");
+    CHECK(loaded.draws[0].ps.cb_resolve,
+          "v24 MODE=3 resolve flag round-trips through write/read (#1240)");
     CHECK(loaded.raw_shader_versions.size() == 2 &&
           loaded.draws[0].vs_raw_shader_index < loaded.raw_shader_versions.size() &&
           loaded.draws[0].fs_raw_shader_index < loaded.raw_shader_versions.size(),
@@ -826,6 +844,7 @@ int main() {
     if (v13_bytes.size() >= 32) {
         const size_t legacy_resource_count = legacy_source.draws[0].vrt.resources.size() +
                                              legacy_source.draws[0].prt.resources.size();
+        v13_bytes.resize(v13_bytes.size() - 9); // v24 count + one resolve flag + zero-failure count
         v13_bytes.resize(v13_bytes.size() - 12); // v23 count + one raw-draw-state
         v13_bytes.resize(v13_bytes.size() - (4 + 8 * legacy_resource_count)); // v22
         v13_bytes.resize(v13_bytes.size() - 13); // v21 one logic-op draw + zero failures
@@ -849,6 +868,7 @@ int main() {
     if (legacy_bytes.size() >= 32) {
         const size_t legacy_resource_count = legacy_source.draws[0].vrt.resources.size() +
                                              legacy_source.draws[0].prt.resources.size();
+        legacy_bytes.resize(legacy_bytes.size() - 9); // v24 count + one resolve flag + zero-failure count
         legacy_bytes.resize(legacy_bytes.size() - 12); // v23 count + one raw-draw-state
         legacy_bytes.resize(legacy_bytes.size() - (4 + 8 * legacy_resource_count)); // v22
         legacy_bytes.resize(legacy_bytes.size() - 13); // v21 one logic-op draw + zero failures
@@ -898,9 +918,9 @@ int main() {
     CHECK(deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
           !legacy_loaded.failure_diagnostics_available && legacy_loaded.failure_diagnostics.empty(),
           "v6 capture reopens with failed-operation diagnostics reported unavailable");
-    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 24;
+    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 25;
     CHECK(!deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
-          error == "unsupported capture version 24",
+          error == "unsupported capture version 25",
           "future capture versions fail with a concrete version error");
 
     GpuCaptureFile bad_hash = mixed;

--- a/prosper/tests/test_gpu_capture.cpp
+++ b/prosper/tests/test_gpu_capture.cpp
@@ -796,6 +796,9 @@ int main() {
 
     const auto failed_path = std::filesystem::temp_directory_path() /
         "prosper_gpu_capture_failed_diagnostic_test.prgcap";
+    // #1240 (v24): a TRUE resolve flag on a failure pipeline must survive the present-only
+    // trailing payload (the realized-draw fixture covers the draw column).
+    failed_capture.failure_diagnostics[0].pipeline.cb_resolve = true;
     CHECK(write_gpu_capture(failed_path.string(), failed_capture, error),
           "failed-operation diagnostic capture writes");
     GpuCaptureFile failed_loaded;
@@ -806,7 +809,8 @@ int main() {
           failed_loaded.failure_diagnostics[0].pipeline.scissor_left == 9 &&
           failed_loaded.failure_diagnostics[0].pipeline.logic_op_enable &&
           failed_loaded.failure_diagnostics[0].pipeline.logic_op == 6 &&
-          failed_loaded.failure_diagnostics[0].stages[1].coverage.first_bad_pc == 1,
+          failed_loaded.failure_diagnostics[0].stages[1].coverage.first_bad_pc == 1 &&
+          failed_loaded.failure_diagnostics[0].pipeline.cb_resolve,
           "failed stage state, coverage, and raw shader versions round-trip offline");
 
     GpuCaptureFile stale_raw = failed_capture;


### PR DESCRIPTION
Fixes #1240 (follow-up from the #1238 review, finding C).

**Failure scenario**: `ResolvedPipelineState.cb_resolve` (#1238's resolve-copy gate) was never serialized; every `.prgcap` replayed with it defaulting false, so `gpu_replay` silently skipped the resolve copy. Concretely observed on Blue Prince this session: env-captures of the Day One pan replay a BLACK frame while live presents content — the resolve that fills the display source never fires offline, and the offline exact-hash oracle is blind to resolve behavior.

**Approach**: the v17-scissor evolution pattern — a **trailing columnar section** (count + one u8 per draw, count + one u8 per present failure pipeline) at capture version 24. Every v1..v23 record prefix stays byte-exact, pre-v24 captures read the historical no-resolve default, and the test suite's truncate-and-patch old-version simulations keep working (each pre-v24 chain strips the 9-byte v24 tail first — the issue's named blocker, handled). A mid-stream `write_pipeline` append was deliberately rejected: it breaks the truncation model and the byte-exact prefix contract.

**Verification**: build clean; **ctest 147/147** on the branch; new assertions: the roundtrip fixture marks its draw `cb_resolve` and it survives write/read; a v23 simulation strips only the v24 tail and reads the false default; the future-version probe moves to v25. A live v24 Blue Prince capture evidence run is in flight and its offline-resolve behavior will be posted before merge.

**Risk**: capture format evolution only; readers of older versions unchanged (guarded `version >= 24`). No live-renderer behavior change.