### PR TITLE
fix(host): honor the 0x66 operand-size prefix in fs_emu movzx/movsx (#1326)

### DIFF
--- a/prosper/src/host/fs_emu.hpp
+++ b/prosper/src/host/fs_emu.hpp
@@ -103,10 +103,15 @@ inline FsEmuResult fs_emulate_access(const uint8_t* p, volatile uint8_t* mem, ui
         }
     } else {
         switch (op) {
-            case 0xB6: wr_reg(reg, rd_mem(1), w?8:4); handled = true; break;          // movzx r, m8
-            case 0xB7: wr_reg(reg, rd_mem(2), w?8:4); handled = true; break;          // movzx r, m16
-            case 0xBE: wr_reg(reg, (uint64_t)(int64_t)(int8_t)rd_mem(1), w?8:4);  handled = true; break;  // movsx m8
-            case 0xBF: wr_reg(reg, (uint64_t)(int64_t)(int16_t)rd_mem(2), w?8:4); handled = true; break;  // movsx m16
+            // Destination width is the effective operand size `sz` (= 8 under REX.W, 2 under a 0x66
+            // operand-size prefix, else 4). The source width is fixed by the opcode (m8/m16). Using a
+            // bare w?8:4 here ignored 0x66 and wrote a 32-bit result into a 16-bit destination, clobbering
+            // all of bits 63:16 (zeroing 63:32 and overwriting 31:16) instead of merging into the low 16
+            // and preserving 63:16 (#1326).
+            case 0xB6: wr_reg(reg, rd_mem(1), sz); handled = true; break;          // movzx r, m8
+            case 0xB7: wr_reg(reg, rd_mem(2), sz); handled = true; break;          // movzx r, m16
+            case 0xBE: wr_reg(reg, (uint64_t)(int64_t)(int8_t)rd_mem(1), sz);  handled = true; break;  // movsx r, m8
+            case 0xBF: wr_reg(reg, (uint64_t)(int64_t)(int16_t)rd_mem(2), sz); handled = true; break;  // movsx r, m16
             default: break;
         }
     }

--- a/prosper/tests/test_fs_emu.cpp
+++ b/prosper/tests/test_fs_emu.cpp
@@ -104,6 +104,19 @@ int main() {
         r = fs_emulate_access(sx, c.mem, c.regs);
         CHECK(r.status == FsEmuStatus::Handled && c.regs[RAX] == 0xFFFFFFFFFFFFFF80ull, "movsx m8 sign-extends");
     }
+    // --- #1326: 0x66-prefixed movzx/movsx have a 16-bit destination — must MERGE into the low 16 bits
+    //     and preserve register bits 63:16 (the bug wrote a 32-bit result, zeroing 31:16 and 63:32). ---
+    {
+        Ctx c; c.mem[0] = 0x80;   // RAX starts at 0x1111111111111111
+        const uint8_t zx16[] = { 0x64, 0x66, 0x0f, 0xb6, 0x04, 0x25, 0x00, 0x00, 0x00, 0x00 };
+        auto r = fs_emulate_access(zx16, c.mem, c.regs);
+        CHECK(r.status == FsEmuStatus::Handled && r.insn_len == 10, "movzx16 handled+len");
+        CHECK(c.regs[RAX] == 0x1111111111110080ull, "movzx ax zero-extends into 16-bit dest, preserving bits 63:16");
+        const uint8_t sx16[] = { 0x64, 0x66, 0x0f, 0xbe, 0x04, 0x25, 0x00, 0x00, 0x00, 0x00 };
+        r = fs_emulate_access(sx16, c.mem, c.regs);
+        CHECK(r.status == FsEmuStatus::Handled && c.regs[RAX] == 0x111111111111FF80ull,
+              "movsx ax sign-extends into 16-bit dest, preserving bits 63:16");
+    }
     // --- disp8 form length: mov eax, fs:[rax+0x10] is mod=1 rm=0 (64 8b 40 10) ---
     {
         Ctx c; c.mem[0] = 0x42;


### PR DESCRIPTION
Fixes #1326. Found via systematic bug-hunt.

## Failure scenario
The four `movzx`/`movsx` cases in `src/host/fs_emu.hpp` (the `%fs` trap-emulation instruction decoder)
hard-coded the destination width as `w?8:4`, ignoring the `0x66` operand-size prefix. The `sz` variable
(`sz = w ? 8 : (opsz16 ? 2 : 4)`) already computes the correct effective operand size but wasn't used
here.

So a `0x66`-prefixed 16-bit-destination `movzx/movsx ax, fs:[m]` wrote a **32-bit** result into a 16-bit
destination — clobbering register bits 31:16 and clearing 63:32, instead of merging into the low 16 bits
and preserving bits 63:16 (x86 semantics for a 16-bit destination).

Concrete (RAX = 0x1111111111111111, `fs:[m8]` = 0x80):
| insn | correct | buggy |
| --- | --- | --- |
| `movzx ax, fs:[m8]` (`64 66 0F B6 …`) | `0x1111111111110080` | `0x0000000000000080` |
| `movsx ax, fs:[m8]` (`64 66 0F BE …`) | `0x111111111111FF80` | `0x00000000FFFFFF80` |

A guest 16-bit `movzx/movsx` from a `%fs:`-relative TLS slot (macOS/Rosetta TRAP-mode `%fs` emulation, and
the Windows `PROSPER_NULL_PAGE` low-address decoder) would silently corrupt the upper bits of the
destination register.

## Fix
Use `sz` (the correct effective destination width) instead of `w?8:4` in the 0xB6/0xB7/0xBE/0xBF cases.
The source width stays fixed by the opcode (m8/m16). One-line-per-case change.

## Affected / unaffected
- **Affected:** 16-bit-destination (`0x66`-prefixed) `movzx`/`movsx` from an emulated `%fs` slot — now
  merges into the low 16 bits and preserves bits 63:16.
- **Unaffected:** 32-bit and 64-bit destinations — `sz == w?8:4` when `0x66` is absent, so those are
  byte-identical. All pre-existing `test_fs_emu` golden vectors pass unchanged.

## Risk
LOW. A single decode-width correction that reuses the already-computed `sz`; no new state, no change to
the 32/64-bit paths. This code runs only in the `%fs`-emulation SIGSEGV/SIGBUS handler path (macOS TRAP
mode + Windows null-page emulation), not on the default Linux hardware-`%fs` path.

## Verification
Two `0x66`-prefixed vectors added to `tests/test_fs_emu.cpp` assert the 16-bit-destination merge/preserve
behavior. Both **fail on master** (0x80 / 0xFFFFFF80) and **pass after the fix**. Full `ctest` green on
Linux (148/148).
