### PR TITLE
fix(gpu): seed F9 bundles with persistent DS state

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -487,12 +487,13 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
             }
             return prosper::gpu::LiveTargetByteReadResult::NotFound;
         });
-    if (getenv("PROSPER_GPU_CAPTURE") || getenv("PROSPER_GPU_TIMELINE_CAPTURE") ||
-        getenv("PROSPER_GPU_REPLAY_EXPORT_DS"))
-        prosper::gpu::set_gpu_capture_ds_seed_snapshot_reader(
-            [](std::vector<prosper::gpu::GpuCaptureDsSeed>& seeds, std::string& error) {
-                return prosper::test::snapshot_persistent_ds_images(seeds, error);
-            });
+    // Register unconditionally, as for RTT seeds above: the interactive F9 bundle has no capture
+    // environment variable and snapshots persistent depth/stencil state only after it is armed.
+    // Normal rendering pays nothing because the callback is otherwise never invoked (#1307).
+    prosper::gpu::set_gpu_capture_ds_seed_snapshot_reader(
+        [](std::vector<prosper::gpu::GpuCaptureDsSeed>& seeds, std::string& error) {
+            return prosper::test::snapshot_persistent_ds_images(seeds, error);
+        });
     if (getenv("PROSPER_GPU_REPLAY_RTT_SEEDS"))
         prosper::gpu::set_gpu_replay_rtt_seed_writer([](const prosper::gpu::GpuCaptureRttSeed& seed, std::string& error) {
             const VkFormat format = replay_color_format(seed.format);

--- a/prosper/src/gpu/gpu_timeline.cpp
+++ b/prosper/src/gpu/gpu_timeline.cpp
@@ -1386,6 +1386,7 @@ struct InteractiveFrameBundle {
                                  // animation over several frames; each extra frame is a full heavy capture.
     uint32_t frames_seen = 0;    // presents observed while capturing
     uint64_t submits = 0;
+    std::vector<GpuCaptureDsSeed> initial_ds_seeds; // persistent DS state at the capture boundary
     GpuCaptureBundle bundle;
 };
 InteractiveFrameBundle& interactive_frame_bundle() { static InteractiveFrameBundle b; return b; }
@@ -1430,8 +1431,17 @@ void interactive_frame_bundle_on_submit(const GpuState& state, uint64_t submit_n
     GpuCaptureFile capture;
     const GpuCaptureMetadata meta = runtime_capture_metadata(submit_no);
     std::string error;
-    if (!capture_gpustate_submit(state, submit_no, meta.width, meta.height, meta, capture, error) ||
-        !append_capture_to_frame_bundle(b.bundle, capture, b.max_unique_bytes, error)) {
+    if (!capture_gpustate_submit(state, submit_no, meta.width, meta.height, meta, capture, error)) {
+        b.failed = true;
+        std::fprintf(stderr, "[grab] frame-bundle: submit %llu failed (%s); grab aborted\n",
+                     static_cast<unsigned long long>(submit_no), error.c_str());
+        return;
+    }
+    // A persistent shadow atlas may have been produced before the captured frame. Seed that
+    // boundary state on the first submit only; later submits observe the replay cache updated by
+    // their predecessors instead of resetting it to the live pre-frame snapshot (#1307).
+    if (!b.submits) capture.ds_seeds = std::move(b.initial_ds_seeds);
+    if (!append_capture_to_frame_bundle(b.bundle, capture, b.max_unique_bytes, error)) {
         b.failed = true;
         std::fprintf(stderr, "[grab] frame-bundle: submit %llu failed (%s); grab aborted\n",
                      static_cast<unsigned long long>(submit_no), error.c_str());
@@ -1457,12 +1467,21 @@ void interactive_frame_bundle_on_present() {
                 else
                     std::fprintf(stderr, "[grab] frame-bundle: window had no submits; press F9 again\n");
                 b.capturing = false; b.current_path.clear(); b.bundle = GpuCaptureBundle{};
+                b.initial_ds_seeds.clear();
                 b.submits = 0; b.frames_seen = 0; b.failed = false;
                 if (b.armed_path.empty()) g_interactive_frame_active.store(false, std::memory_order_release);
             }
         } else if (!b.armed_path.empty()) {
             b.capturing = true; b.current_path = std::move(b.armed_path); b.armed_path.clear();
             b.bundle = GpuCaptureBundle{}; b.submits = 0; b.frames_seen = 0; b.failed = false;
+            b.initial_ds_seeds.clear();
+            std::string error;
+            if (gpu_capture_ds_seed_snapshot_available() &&
+                !read_all_gpu_capture_ds_seeds(b.initial_ds_seeds, error)) {
+                b.failed = true;
+                std::fprintf(stderr, "[grab] frame-bundle: initial DS snapshot failed (%s); "
+                                     "grab aborted\n", error.c_str());
+            }
             std::fprintf(stderr, "[grab] frame-bundle: capturing %u frames -> %s\n",
                          b.frames_wanted, b.current_path.c_str());
         }

--- a/prosper/src/gpu/gpu_timeline.cpp
+++ b/prosper/src/gpu/gpu_timeline.cpp
@@ -1386,7 +1386,6 @@ struct InteractiveFrameBundle {
                                  // animation over several frames; each extra frame is a full heavy capture.
     uint32_t frames_seen = 0;    // presents observed while capturing
     uint64_t submits = 0;
-    std::vector<GpuCaptureDsSeed> initial_ds_seeds; // persistent DS state at the capture boundary
     GpuCaptureBundle bundle;
 };
 InteractiveFrameBundle& interactive_frame_bundle() { static InteractiveFrameBundle b; return b; }
@@ -1439,8 +1438,16 @@ void interactive_frame_bundle_on_submit(const GpuState& state, uint64_t submit_n
     }
     // A persistent shadow atlas may have been produced before the captured frame. Seed that
     // boundary state on the first submit only; later submits observe the replay cache updated by
-    // their predecessors instead of resetting it to the live pre-frame snapshot (#1307).
-    if (!b.submits) capture.ds_seeds = std::move(b.initial_ds_seeds);
+    // their predecessors instead of resetting it to the live pre-frame snapshot (#1307). This hook
+    // runs under hle_agc's submit mutex, before renderer sampling, so the Vulkan DS cache cannot be
+    // mutated concurrently as it could from the independent present/flip thread.
+    if (!b.submits && gpu_capture_ds_seed_snapshot_available() &&
+        !read_all_gpu_capture_ds_seeds(capture.ds_seeds, error)) {
+        b.failed = true;
+        std::fprintf(stderr, "[grab] frame-bundle: initial DS snapshot failed (%s); grab aborted\n",
+                     error.c_str());
+        return;
+    }
     if (!append_capture_to_frame_bundle(b.bundle, capture, b.max_unique_bytes, error)) {
         b.failed = true;
         std::fprintf(stderr, "[grab] frame-bundle: submit %llu failed (%s); grab aborted\n",
@@ -1467,21 +1474,12 @@ void interactive_frame_bundle_on_present() {
                 else
                     std::fprintf(stderr, "[grab] frame-bundle: window had no submits; press F9 again\n");
                 b.capturing = false; b.current_path.clear(); b.bundle = GpuCaptureBundle{};
-                b.initial_ds_seeds.clear();
                 b.submits = 0; b.frames_seen = 0; b.failed = false;
                 if (b.armed_path.empty()) g_interactive_frame_active.store(false, std::memory_order_release);
             }
         } else if (!b.armed_path.empty()) {
             b.capturing = true; b.current_path = std::move(b.armed_path); b.armed_path.clear();
             b.bundle = GpuCaptureBundle{}; b.submits = 0; b.frames_seen = 0; b.failed = false;
-            b.initial_ds_seeds.clear();
-            std::string error;
-            if (gpu_capture_ds_seed_snapshot_available() &&
-                !read_all_gpu_capture_ds_seeds(b.initial_ds_seeds, error)) {
-                b.failed = true;
-                std::fprintf(stderr, "[grab] frame-bundle: initial DS snapshot failed (%s); "
-                                     "grab aborted\n", error.c_str());
-            }
             std::fprintf(stderr, "[grab] frame-bundle: capturing %u frames -> %s\n",
                          b.frames_wanted, b.current_path.c_str());
         }

--- a/prosper/tests/test_gpu_capture_bundle.cpp
+++ b/prosper/tests/test_gpu_capture_bundle.cpp
@@ -251,6 +251,31 @@ int main() {
     record_gpu_timeline_present(5, 0, 0, 1920, 1080);
     CHECK(!interactive_capture_bundle_active(), "the re-armed grab completes and disarms");
 
+    // Persistent depth/stencil images can predate the captured frame (for example a shadow-atlas
+    // cascade retained from the previous frame). F9 must snapshot them at the capture boundary and
+    // attach them to the first submit so bundle replay does not start those planes at zero (#1307).
+    const auto ds_bundle_path = std::filesystem::temp_directory_path() /
+        ("prosper-f9-ds-seed-" + std::to_string(nonce) + ".prgbundle");
+    unsigned ds_snapshots = 0;
+    set_gpu_capture_ds_seed_snapshot_reader(
+        [&](std::vector<GpuCaptureDsSeed>& seeds, std::string&) {
+            ++ds_snapshots; seeds = {ds_seed}; return true;
+        });
+    request_interactive_capture_bundle(ds_bundle_path.string());
+    record_gpu_timeline_present(6, 0, 0, 1920, 1080);
+    GpuState empty_submit;
+    record_gpu_timeline_submit(empty_submit, 77);
+    record_gpu_timeline_present(7, 0, 0, 1920, 1080);
+    GpuCaptureBundle ds_bundle;
+    GpuCaptureFile ds_first;
+    CHECK(ds_snapshots == 1 && read_gpu_capture_bundle(ds_bundle_path.string(), ds_bundle, error) &&
+          ds_bundle.submits.size() == 1 &&
+          materialize_gpu_capture_bundle_submit(ds_bundle, 0, ds_first, error) &&
+          ds_first.ds_seeds.size() == 1 && ds_first.ds_seeds[0].depth == ds_seed.depth,
+          "F9 bundle seeds its first submit with capture-boundary depth/stencil state");
+    set_gpu_capture_ds_seed_snapshot_reader({});
+    std::filesystem::remove(ds_bundle_path, ec);
+
     if (fails) { std::printf("== FAIL: %d ==\n", fails); return 1; }
     std::printf("== PASS ==\n"); return 0;
 }

--- a/prosper/tests/test_gpu_capture_bundle.cpp
+++ b/prosper/tests/test_gpu_capture_bundle.cpp
@@ -265,14 +265,17 @@ int main() {
     record_gpu_timeline_present(6, 0, 0, 1920, 1080);
     GpuState empty_submit;
     record_gpu_timeline_submit(empty_submit, 77);
+    record_gpu_timeline_submit(empty_submit, 78);
     record_gpu_timeline_present(7, 0, 0, 1920, 1080);
     GpuCaptureBundle ds_bundle;
-    GpuCaptureFile ds_first;
+    GpuCaptureFile ds_first, ds_second;
     CHECK(ds_snapshots == 1 && read_gpu_capture_bundle(ds_bundle_path.string(), ds_bundle, error) &&
-          ds_bundle.submits.size() == 1 &&
+          ds_bundle.submits.size() == 2 &&
           materialize_gpu_capture_bundle_submit(ds_bundle, 0, ds_first, error) &&
-          ds_first.ds_seeds.size() == 1 && ds_first.ds_seeds[0].depth == ds_seed.depth,
-          "F9 bundle seeds its first submit with capture-boundary depth/stencil state");
+          materialize_gpu_capture_bundle_submit(ds_bundle, 1, ds_second, error) &&
+          ds_first.ds_seeds.size() == 1 && ds_first.ds_seeds[0].depth == ds_seed.depth &&
+          ds_second.ds_seeds.empty(),
+          "F9 bundle seeds only its first submit with capture-boundary depth/stencil state");
     set_gpu_capture_ds_seed_snapshot_reader({});
     std::filesystem::remove(ds_bundle_path, ec);
 


### PR DESCRIPTION
Closes #1307.

## What changed

- register the persistent depth/stencil snapshot reader for interactive captures as well as environment-driven captures
- snapshot persistent DS planes at the F9 frame boundary
- attach that boundary snapshot only to the first bundle submit, so later submits retain replay mutations instead of resetting the atlas
- add a deterministic F9 state-machine regression that materializes the written bundle and verifies the exact DS seed bytes

## Root cause

F9 bundles seeded renderer-owned color targets but the DS snapshot callback was registered only when capture environment variables were present. Interactive F9 has no such variable, so shadow atlases produced in earlier frames began replay as zero-filled planes.

## Validation

- full build (`cmake --build build-audit -j2`)
- full test suite: 143/143 passed
- focused `test_gpu_capture_bundle` regression passed