### PR TITLE
tool(gpu_replay): publish non-RGBA8 prefix passes under PROSPER_PREFIX_INSPECT

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -173,6 +173,15 @@ std::vector<uint8_t> inspection_rgba8(const std::vector<uint8_t>& pixels,
     return rgba;
 }
 
+// #1330: gpu_replay sets PROSPER_PREFIX_INSPECT for its ordered-prefix modes (--draw N:M,
+// --draw-steps, --through-operation) before the first render, so a prefix ending on a non-RGBA8
+// color pass publishes that surface (inspection-converted) instead of a stale earlier RGBA8 pass.
+// Never set outside those diagnostic replays; cached once — the flag is process-lifetime.
+bool prefix_inspect_publish() {
+    static const bool enabled = getenv("PROSPER_PREFIX_INSPECT") != nullptr;
+    return enabled;
+}
+
 // Pixel decoding is a pure function of these fields for guest-backed textures. Keep this cache local
 // to one renderer callback: graphics spans are split at compute operations, so guest texture bytes
 // cannot change within its lifetime. Live RTT inputs are excluded separately because an earlier pass
@@ -3153,6 +3162,17 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         if (base && base == front_va) px_front = pass_pixels;  // the flipped buffer
                         if (is_vo)                    px_vo = pass_pixels;     // any registered scanout
                         px_last = pass_pixels;                                  // last non-empty (fallback)
+                    } else if (!rendered_pixels.empty() && prefix_inspect_publish()) {
+                        // #1330: under gpu_replay's ordered-prefix inspection (--draw/--draw-steps/
+                        // --through-operation set PROSPER_PREFIX_INSPECT), a prefix ending on a
+                        // non-RGBA8 pass (an FP16 HDR scene target) must return THAT surface, not
+                        // whatever stale RGBA8 pass ran earlier. Publish an inspection-converted copy
+                        // as the weakest fallback: any RGBA8 pass afterwards still overwrites it, and
+                        // with the env unset (every live/normal replay run) behavior is byte-identical.
+                        std::vector<uint8_t> converted =
+                            inspection_rgba8(rendered_pixels, gw, gh, pass_format);
+                        if (!converted.empty())
+                            px_last = std::make_shared<const std::vector<uint8_t>>(std::move(converted));
                     }
                     // PROSPER_PASS_LOG=<min-submit>: per-pass publish provenance for 3 submits —
                     // which pass produced pixels, its target identity, and the defer decision.

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -1340,6 +1340,13 @@ int main(int argc, char** argv) {
         usage(argv[0]); return 2;
     }
     if (draw_with_compute_prefix && draw_first < 0) { usage(argv[0]); return 2; }
+    // #1330: ordered-prefix inspection modes must see the pass a prefix actually ends on, even when
+    // that pass renders a non-RGBA8 target (an FP16 HDR scene). The shared live renderer publishes an
+    // inspection-converted fallback only under this env, so full replays and live runs are unchanged.
+    if ((draw_first >= 0 || through_operation >= 0 || !draw_steps_prefix.empty()) &&
+        !set_environment("PROSPER_PREFIX_INSPECT", "1")) {
+        std::fprintf(stderr, "gpu_replay: cannot set PROSPER_PREFIX_INSPECT\n"); return 2;
+    }
     prosper::gpu::GpuCaptureFile capture; std::string error;
     if (!prosper::gpu::read_gpu_capture(positional[0], capture, error)) {
         std::fprintf(stderr, "gpu_replay: %s: %s\n", positional[0], error.c_str()); return 2;


### PR DESCRIPTION
Fixes #1330.

## Failure scenario
An ordered-prefix replay (`--draw N:M`, `--draw-steps`, `--through-operation`) ending on a non-RGBA8 color pass returned the bytes of whatever stale RGBA8 pass came earlier, because the shared live renderer's per-pass publish gate (`px_front`/`px_vo`/`px_last`) only accepts `VK_FORMAT_R8G8B8A8_UNORM`. On Blue Prince (PPSA25009) every visually interesting pass — the 923-draw FP16 HDR scene pass, the FP16 reflection probe — was invisible to the visual-bisection primitive: `--draw 0:N` failed with `cannot write` (byte-count mismatch: 2048x2048x4 stale shadow atlas returned for a 1920x1080 prefix), and `--draw-steps --draw-steps-target 1920x1080` silently skipped every color-pass step.

## Contract / approach
- `gpu_replay` sets `PROSPER_PREFIX_INSPECT` before replaying when (and only when) a prefix mode is requested.
- Under that env, the shared renderer publishes an `inspection_rgba8`-converted copy of a non-RGBA8 pass into `px_last` only — the weakest fallback. Any RGBA8 pass afterwards still overwrites it; `px_front`/`px_vo` (the real present drivers, always RGBA8 VO surfaces) are untouched.
- With the env unset — every live run, snapshot route, and plain full replay — the publish gate is **byte-identical** to before (the new branch is behind `prefix_inspect_publish()`, a process-lifetime env check).

## Affected / deliberately unaffected
- Affected: gpu_replay prefix diagnostics only.
- Unaffected: live present selection, full-capsule replay hashes, bundle replay, snapshot guards. Verified: full replay of the Blue Prince Day One capsule is hash-identical before/after (`f35a47e5230645e1`).

## Evidence
- Before: `--draw 0:1512 <capsule> out.bmp` → `gpu_replay: cannot write` (readback 16777216 bytes = stale 2048² atlas). After: writes the real 1920x1080 FP16 scene content (clamped-RGBA8 inspection view) — the mid-pass Day One garden/character composition, previously unreachable offline.
- After: `--draw-steps --draw-steps-target 1920x1080` now dumps 22 steps across the FP16 color pass (previously 12, all outside it) — this immediately localized the #1287 present-vs-scene divergence (scene pass renders a different, correctly-shaded camera than the stale presented frame).
- `ctest`: 148/148 on the exact head. Snapshot check not run: the default-path publish gate is untouched with the env unset (no reachable rendered-output change); CI exercises the full matrix.

## Risks
- The env is process-lifetime-cached; a hypothetical embedder toggling it mid-process would see the first value. gpu_replay sets it before the first render, and nothing else sets it.
- `inspection_rgba8` supports RGBA8/RGBA16_UNORM/RGBA16F; other exotic pass formats still publish nothing (unchanged behavior), which is fail-visible in the step log.