### PR TITLE
tool(gpu_replay): reject --draw-steps under --bundle and orphan filmstrip sub-flags

### DIFF
--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -1316,7 +1316,7 @@ int main(int argc, char** argv) {
             !realized_shader_spec.empty() ||
             !compute_override_spec.empty() ||
             !compute_resource_spec.empty() || !failed_shader_spec.empty() ||
-            !prepend_path.empty()) {
+            !prepend_path.empty() || !draw_steps_prefix.empty()) {
             usage(argv[0]); return 2;
         }
         return replay_bundle(bundle_path, positional.empty() ? nullptr : positional[0],
@@ -1340,6 +1340,10 @@ int main(int argc, char** argv) {
         usage(argv[0]); return 2;
     }
     if (draw_with_compute_prefix && draw_first < 0) { usage(argv[0]); return 2; }
+    // #1332: the filmstrip sub-flags configure --draw-steps; alone they would be silently unused.
+    if ((draw_steps_every > 0 || draw_steps_target_w) && draw_steps_prefix.empty()) {
+        usage(argv[0]); return 2;
+    }
     // #1330: ordered-prefix inspection modes must see the pass a prefix actually ends on, even when
     // that pass renders a non-RGBA8 target (an FP16 HDR scene). The shared live renderer publishes an
     // inspection-converted fallback only under this env, so full replays and live runs are unchanged.


### PR DESCRIPTION
Fixes #1332 (found during the #1331 independent review; pre-existing on master).

## Failure scenario
- `gpu_replay --bundle X --draw-steps P` ran a plain bundle replay and silently produced no filmstrip (`replay_bundle` has no draw-steps path), reading as "covered" when it was not.
- `--draw-steps-every N` / `--draw-steps-target WxH` without `--draw-steps` were accepted and silently unused.

## Approach
Pure CLI validation, two lines: add `!draw_steps_prefix.empty()` to the existing bundle-mode rejection list, and reject the two sub-flags when `draw_steps_prefix` is empty. No replay-semantics change; every previously-working invocation is unchanged (a valid `--draw-steps ... --draw-steps-every ...` capsule run still proceeds to file loading).

## Verification
- Build clean; ctest 148/148 on the exact head.
- Manual: all three invalid forms now exit 2 with usage; the valid combined form proceeds past argument validation (fails later only on the deliberately nonexistent input file).

## Review note
Skipping independent review per the mechanical-change carve-out: this is a two-line argument-validation addition to an existing rejection pattern, with no behavioral surface beyond usage errors. Shout if that judgment seems wrong.