### PR TITLE
fix(host): use raw writes in Linux fault diagnostics

### DIFF
--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -377,8 +377,8 @@ namespace {
                     char h = *p; int nib; if (h>='0'&&h<='9') nib=h-'0'; else if (h>='a'&&h<='f') nib=h-'a'+10;
                     else { ok=false; return; } v=(v<<4)|nib; d++; } out=v; if(!d) ok=false; };
                 hx(s); if (*p=='-') { p++; hx(e); }
-                if (ok && addr >= s && addr < e) { syscall(SYS_write, 2,pend, pn); syscall(SYS_write, 2,line, (size_t)li);
-                    syscall(SYS_write, 2,"\n", 1); close(fd); return; }
+                if (ok && addr >= s && addr < e) { raw_write(2,pend, pn); raw_write(2,line, (size_t)li);
+                    raw_write(2,"\n", 1); close(fd); return; }
                 li = 0;
             }
         }
@@ -393,7 +393,7 @@ namespace {
         int total = g_hwbp_ring_pos < HWBP_RING ? g_hwbp_ring_pos : HWBP_RING;
         int start = g_hwbp_ring_pos < HWBP_RING ? 0 : (g_hwbp_ring_pos % HWBP_RING);
         char hdr[96]; int hn = snprintf(hdr, sizeof hdr, "[hwbp-ring] dump (%s): last %d hits:\n", why, total);
-        syscall(SYS_write, 2,hdr, hn);
+        raw_write(2,hdr, hn);
         unsigned long long prev_cur = 0;
         for (int i = 0; i < total; ++i) {
             const HwbpRingEnt& e = g_hwbp_ring[(start + i) % HWBP_RING];
@@ -404,7 +404,7 @@ namespace {
                 i, e.rip_off, e.cur, e.rax, e.r8, e.f8, e.f10, e.r14,
                 (e.cur == e.r8 || e.cur == e.f8) ? "<<< MATCH (skip fetch)" : "");
             (void)dcur;
-            syscall(SYS_write, 2,lb, ln);
+            raw_write(2,lb, ln);
             prev_cur = e.cur;
         }
     }
@@ -416,7 +416,7 @@ namespace {
         char hdr[128]; int hn = snprintf(hdr, sizeof hdr,
             "[stepwin] dump (%s) after %ld steps: %d cursor advances, base=0x%llx:\n",
             why, g_stepwin_steps, total, (unsigned long long)g_stepwin_base);
-        syscall(SYS_write, 2,hdr, hn);
+        raw_write(2,hdr, hn);
         unsigned long long prev = 0;
         for (int i = 0; i < total; ++i) {
             const StepEnt& e = g_stepwin_ring[(start + i) % STEPWIN_RING];
@@ -424,7 +424,7 @@ namespace {
             char lb[160];
             int ln = snprintf(lb, sizeof lb, "  [%3d] rip=eboot+0x%llx cur=0x%llx (off 0x%llx) delta=%+lld\n",
                 i, e.rip_off, e.cur, (unsigned long long)(e.cur - g_stepwin_base), d);
-            syscall(SYS_write, 2,lb, ln);
+            raw_write(2,lb, ln);
             prev = e.cur;
         }
     }
@@ -432,7 +432,7 @@ namespace {
         long fd = perf_bp_open(addr, HW_BREAKPOINT_W);
         char b[160];
         if (fd < 0) { int n = snprintf(b, sizeof b, "[hwwatch] perf W-watch FAILED addr=0x%llx errno=%d\n",
-                          (unsigned long long)addr, errno); syscall(SYS_write, 2, b, (size_t)n);   /* raw: glibc write() reads the TCB via %fs (guest-fs unsafe in this handler) */ return; }
+                          (unsigned long long)addr, errno); raw_write(2, b, (size_t)n);   /* raw syscall: no libc TLS access */ return; }
         g_hwwatch_fd = (int)fd; g_hwwatch_addr = addr;
         fcntl(g_hwwatch_fd, F_SETFL, O_ASYNC);
         fcntl(g_hwwatch_fd, F_SETSIG, SIGTRAP);
@@ -440,7 +440,7 @@ namespace {
         fcntl(g_hwwatch_fd, F_SETOWN_EX, &ow);
         ioctl(g_hwwatch_fd, PERF_EVENT_IOC_ENABLE, 0);
         int n = snprintf(b, sizeof b, "[hwwatch] armed W-watch at 0x%llx (fd=%d)\n",
-                         (unsigned long long)addr, g_hwwatch_fd); syscall(SYS_write, 2, b, (size_t)n);   /* raw: glibc write() reads the TCB via %fs (guest-fs unsafe in this handler) */
+                         (unsigned long long)addr, g_hwwatch_fd); raw_write(2, b, (size_t)n);   /* raw syscall: no libc TLS access */
     }
     // ---- #312 per-thread MallocBinned3 pool-descriptor HEAD watch (PROSPER_MB3WATCH) -----------
     // The per-run corruptor stomps poolArray[idx].head (struct +0x20, size-class idx=1) of the MB3
@@ -480,7 +480,7 @@ namespace {
             if (fd < 0) { char b[128]; int k = snprintf(b, sizeof b,
                 "[mb3watch] arm FAILED addr=0x%llx tid=%ld errno=%d\n",
                 (unsigned long long)addr, cur_tid(), errno);
-                syscall(SYS_write, 2, b, (size_t)k); continue; }
+                raw_write(2, b, (size_t)k); continue; }
             fcntl((int)fd, F_SETFL, O_ASYNC);
             fcntl((int)fd, F_SETSIG, SIGTRAP);
             struct f_owner_ex ow; ow.type = F_OWNER_TID; ow.pid = (pid_t)prosper_gettid();
@@ -492,7 +492,7 @@ namespace {
                 "[mb3watch] ARMED head watch @0x%llx (base=0x%llx off=0x%x) fd=%ld tid=%ld slot=%d\n",
                 (unsigned long long)addr, (unsigned long long)base, g_mb3w_off,
                 fd, cur_tid(), slot);
-            syscall(SYS_write, 2, b, (size_t)k);
+            raw_write(2, b, (size_t)k);
         }
     }
     // PROSPER_PEEK dumps offsets off registers at fault time. Supports N specs separated by ';',
@@ -511,7 +511,7 @@ namespace {
     // pipe can never fill (probes are single small reads, well under PIPE_BUF).
     bool probe_readable(uint64_t a) {
         if (a < 0x1000 || g_probe_pipe[1] < 0) return false;
-        long w = syscall(SYS_write, g_probe_pipe[1], (const void*)a, 8);
+        long w = raw_write(g_probe_pipe[1], (const void*)a, 8);
         if (w > 0) { char b[8]; syscall(SYS_read, g_probe_pipe[0], b, (size_t)w); }
         return w == 8;
     }
@@ -614,7 +614,7 @@ namespace {
             on += snprintf(out+on, sizeof out-on, " %.*s=%s", slen, start, vb);
         }
         out[on] = '\n';
-        syscall(SYS_write, 2, out, (size_t)on + 1);   /* raw: glibc write() reads the TCB via %fs (guest-fs unsafe in this handler) */
+        raw_write(2, out, (size_t)on + 1);   /* raw syscall: no libc TLS access */
     }
     // PROSPER_KSCAN one-shot enumerator: scan the guest GC-heap mappings (from /proc/self/maps, in the
     // [0x20_00000000,0x28_00000000) object band) for every 8-aligned qword equal to g_kscan_klass — i.e. every
@@ -624,7 +624,7 @@ namespace {
     void il2cpp_kscan(void* uctx) {
         static char maps[256 * 1024];
         long fd = syscall(SYS_open, "/proc/self/maps", O_RDONLY, 0);
-        if (fd < 0) { const char* e = "[kscan] open /proc/self/maps failed\n"; syscall(SYS_write, 2, e, 36); return; }
+        if (fd < 0) { const char* e = "[kscan] open /proc/self/maps failed\n"; raw_write(2, e, 36); return; }
         long total = 0, r;
         while (total < (long)sizeof(maps) - 1 &&
                (r = syscall(SYS_read, fd, maps + total, sizeof(maps) - 1 - (size_t)total)) > 0) total += r;
@@ -632,7 +632,7 @@ namespace {
         maps[total < 0 ? 0 : total] = 0;
         char hdr[96]; int hn = snprintf(hdr, sizeof hdr, "[kscan] klass=0x%llx max=%d\n",
                                         (unsigned long long)g_kscan_klass, g_kscan_max);
-        syscall(SYS_write, 2, hdr, (size_t)hn);
+        raw_write(2, hdr, (size_t)hn);
         auto rdhex = [](const char** pp) -> uint64_t { uint64_t v = 0; const char* p = *pp;
             for (;; ++p) { char c=*p; uint64_t d; if(c>='0'&&c<='9')d=c-'0'; else if(c>='a'&&c<='f')d=c-'a'+10;
                 else if(c>='A'&&c<='F')d=c-'A'+10; else break; v=v*16+d; } *pp=p; return v; };
@@ -671,7 +671,7 @@ namespace {
         }
         char sum[96]; int sn = snprintf(sum, sizeof sum, "[kscan] done: %d instance(s), %llu MiB scanned\n",
                                         found, (unsigned long long)(scanned >> 20));
-        syscall(SYS_write, 2, sum, (size_t)sn);
+        raw_write(2, sum, (size_t)sn);
     }
     // PROSPER_DUMPAT="0xADDR[,0xADDR...]" — dump 0x40 bytes at each ABSOLUTE guest address at fault
     // time (up to 6). Complements the register-relative FAULTMEM/PEEK when the address of interest
@@ -682,14 +682,14 @@ namespace {
         for (int i = 0; i < g_dumpat_n; i++) {
             uint64_t a = g_dumpat[i];
             int n = snprintf(b, sizeof b, "[prosper] DUMPAT 0x%llx:\n", (unsigned long long)a);
-            syscall(SYS_write, 2, b, (size_t)n);
+            raw_write(2, b, (size_t)n);
             for (int r = 0; r < 8; r++) {
                 uint64_t addr = a + (uint64_t)r * 8;
                 if (probe_readable(addr))
                     n = snprintf(b, sizeof b, "  +0x%02x = 0x%016llx\n", r * 8, (unsigned long long)*(const uint64_t*)addr);
                 else
                     n = snprintf(b, sizeof b, "  +0x%02x = <unmapped>\n", r * 8);
-                syscall(SYS_write, 2, b, (size_t)n);
+                raw_write(2, b, (size_t)n);
             }
         }
     }
@@ -704,12 +704,12 @@ namespace {
         };
         char b[256];
         int n = snprintf(b, sizeof b, "[prosper] FAULTMEM dump (regs -> guest memory):\n");
-        syscall(SYS_write, 2, b, (size_t)n);   /* raw: glibc write() reads the TCB via %fs (guest-fs unsafe in this handler) */
+        raw_write(2, b, (size_t)n);   /* raw syscall: no libc TLS access */
         for (auto& r : regs) {
             if (!probe_readable(r.v)) {
                 n = snprintf(b, sizeof b, "  %s=0x%llx  (unmapped/immediate)\n",
                              r.n, (unsigned long long)r.v);
-                syscall(SYS_write, 2, b, (size_t)n);   /* raw: glibc write() reads the TCB via %fs (guest-fs unsafe in this handler) */
+                raw_write(2, b, (size_t)n);   /* raw syscall: no libc TLS access */
                 continue;
             }
             uint64_t q[4] = {0, 0, 0, 0};
@@ -722,7 +722,7 @@ namespace {
             }
             n = snprintf(b, sizeof b, "  %s=0x%llx -> [0]=%s [8]=%s [10]=%s [18]=%s\n",
                          r.n, (unsigned long long)r.v, part[0], part[1], part[2], part[3]);
-            syscall(SYS_write, 2, b, (size_t)n);   /* raw: glibc write() reads the TCB via %fs (guest-fs unsafe in this handler) */
+            raw_write(2, b, (size_t)n);   /* raw syscall: no libc TLS access */
         }
         // Deep field peek (PROSPER_PEEK, parsed once at arm time — getenv is not signal-safe): read
         // specific offsets off one or more registers to classify a large object beyond the 0x20-byte
@@ -732,7 +732,7 @@ namespace {
             uint64_t base = 0;
             for (auto& r : regs) { bool m = true; for (int i=0;i<3;i++) if (r.n[i]!=ps.reg[i]&&!(r.n[i]==' '&&ps.reg[i]==0)) { m=false; break; } if (m) { base=r.v; break; } }
             n = snprintf(b, sizeof b, "  PEEK %s=0x%llx:\n", ps.reg, (unsigned long long)base);
-            syscall(SYS_write, 2, b, (size_t)n);   /* raw: glibc write() reads the TCB via %fs (guest-fs unsafe in this handler) */
+            raw_write(2, b, (size_t)n);   /* raw syscall: no libc TLS access */
             for (int k = 0; k < ps.n; k++) {
                 uint64_t obj = base;
                 if (ps.deref[k]) {   // chase one pointer level: obj = [base + pre]
@@ -749,7 +749,7 @@ namespace {
                 else
                     n = snprintf(b, sizeof b, "    %s[+0x%llx]@+0x%llx = <unmapped>\n", pfx,
                                  (unsigned long long)ps.pre[k], (unsigned long long)ps.off[k]);
-                syscall(SYS_write, 2, b, (size_t)n);   /* raw: glibc write() reads the TCB via %fs (guest-fs unsafe in this handler) */
+                raw_write(2, b, (size_t)n);   /* raw syscall: no libc TLS access */
             }
         }
     }
@@ -787,7 +787,7 @@ namespace {
             n = snprintf(b, sizeof b, "[nullpage]   insn @rip:"
                          " %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x\n",
                          p[0],p[1],p[2],p[3],p[4],p[5],p[6],p[7],p[8],p[9],p[10],p[11],p[12],p[13],p[14],p[15]);
-            syscall(SYS_write, 2, b, (size_t)n);
+            raw_write(2, b, (size_t)n);
         }
         auto g = PROSPER_GREGS(uc);
         const struct { const char* nm; uint64_t v; } regs[] = {
@@ -804,7 +804,7 @@ namespace {
         for (int i = 0; i < 16; i++) {
             n += snprintf(b + n, sizeof b - (size_t)n, "%s%s=0x%llx", (i % 4) ? " " : "[nullpage]   ",
                           regs[i].nm, (unsigned long long)regs[i].v);
-            if (i % 4 == 3) { b[n++] = '\n'; syscall(SYS_write, 2, b, (size_t)n); n = 0; }
+            if (i % 4 == 3) { b[n++] = '\n'; raw_write(2, b, (size_t)n); n = 0; }
         }
         for (int i = 0; i < 16; i++) {
             uint64_t v = regs[i].v;
@@ -825,7 +825,7 @@ namespace {
                     n += snprintf(b + n, sizeof b - (size_t)n, " ????????????????");
             }
             n += snprintf(b + n, sizeof b - (size_t)n, "\n");
-            syscall(SYS_write, 2, b, (size_t)n);
+            raw_write(2, b, (size_t)n);
             // Corrupted-header hunt: the canary walk faulted following a NextFreeBlock == 0x1, so
             // the stomped FFreeBlock header is a qword equal to 0x1 somewhere in the current slab
             // (a 64 KiB-aligned guest-heap register, r13 in the observed walk). Scan the slab for
@@ -837,7 +837,7 @@ namespace {
                 if (prosper_gpu_write_ring_scan) {
                     static char slab_out[16384];
                     if (prosper_gpu_write_ring_scan(v, v + 0x10000, slab_out, sizeof slab_out) > 0)
-                        syscall(SYS_write, 2, slab_out, strlen(slab_out));
+                        raw_write(2, slab_out, strlen(slab_out));
                 }
                 int hits = 0;
                 for (uint64_t o = 0; o < 0x10000 && hits < 24; o += 8) {
@@ -851,11 +851,11 @@ namespace {
                                  (unsigned long long)o, (unsigned long long)addr,
                                  (unsigned long long)q[0], (unsigned long long)q[1],
                                  (unsigned long long)q[2], (unsigned long long)q[3]);
-                    syscall(SYS_write, 2, b, (size_t)n);
+                    raw_write(2, b, (size_t)n);
                     if (prosper_gpu_write_ring_scan) {
                         static char hit_out[1024];
                         if (prosper_gpu_write_ring_scan(addr - 8, addr + 16, hit_out, sizeof hit_out) > 0)
-                            syscall(SYS_write, 2, hit_out, strlen(hit_out));
+                            raw_write(2, hit_out, strlen(hit_out));
                     }
                 }
             } else if (prosper_gpu_write_ring_scan) {
@@ -863,7 +863,7 @@ namespace {
                 // tools that link exec_image without the gpu lib simply skip this)
                 static char ring_out[4096];
                 if (prosper_gpu_write_ring_scan(v - 0x100, v + 0x100, ring_out, sizeof ring_out) > 0)
-                    syscall(SYS_write, 2, ring_out, strlen(ring_out));
+                    raw_write(2, ring_out, strlen(ring_out));
             }
         }
     }
@@ -1001,7 +1001,7 @@ namespace {
         // timed run reveals whether the SIGILL round-trip is the throughput wall. Diagnostic only.
         if (g_sse4a_stat && (g_sse4a_emulated & 0xFFFFF) == 0) {
             char b[64]; int n = snprintf(b, sizeof b, "[sse4a] %lu emulated\n", g_sse4a_emulated);
-            if (n > 0) { ssize_t w = syscall(SYS_write, 2,b, (size_t)n); (void)w; }
+            if (n > 0) { ssize_t w = raw_write(2,b, (size_t)n); (void)w; }
         }
         return true;
     }
@@ -1039,7 +1039,7 @@ namespace {
             char b[96]; int n = snprintf(b, sizeof b, "[sigill] rip=0x%llx bytes:", (unsigned long long)rip);
             for (int k = 0; k < 16 && n < (int)sizeof b - 4; k++) n += snprintf(b + n, sizeof b - n, " %02x", p[k]);
             if (n < (int)sizeof b - 1) b[n++] = '\n';
-            ssize_t w = syscall(SYS_write, 2, b, (size_t)n); (void)w;
+            ssize_t w = raw_write(2, b, (size_t)n); (void)w;
         }
         // #312 per-thread MB3 head watch: a hardware WRITE-watch on a poolArray head slot fired.
         // Write-watchpoints trap AFTER the store, so RIP already points past it — just log the
@@ -1069,7 +1069,7 @@ namespace {
                     (unsigned long long)addr, v, in_eboot ? "eboot+" : "host:",
                     (unsigned long long)(in_eboot ? wr - 0x400000000ull : wr), cur_tid(),
                     shifted ? "  <<<<< POOLSHIFT CORRUPTOR" : "");
-                syscall(SYS_write, 2, b, (size_t)n);
+                raw_write(2, b, (size_t)n);
                 if (!in_eboot) classify_addr(wr);
                 if (shifted) {
                     char rb[420]; int rn = snprintf(rb, sizeof rb,
@@ -1081,7 +1081,7 @@ namespace {
                         (unsigned long long)gr2[REG_R8],  (unsigned long long)gr2[REG_R9],
                         (unsigned long long)gr2[REG_R10], (unsigned long long)gr2[REG_R11],
                         (unsigned long long)gr2[REG_RBP], (unsigned long long)gr2[REG_RSP]);
-                    syscall(SYS_write, 2, rb, (size_t)rn);
+                    raw_write(2, rb, (size_t)rn);
                     // Guest call stack: scan [rsp, rsp+0x200) for eboot-range return addresses.
                     uint64_t rsp = (uint64_t)gr2[REG_RSP];
                     char sb[320]; int sn = snprintf(sb, sizeof sb, "[mb3watch]   guest-stack:");
@@ -1096,7 +1096,7 @@ namespace {
                         }
                     }
                     sn += snprintf(sb + sn, sizeof sb - sn, "\n");
-                    syscall(SYS_write, 2, sb, (size_t)sn);
+                    raw_write(2, sb, (size_t)sn);
                 }
                 return;
             }
@@ -1167,7 +1167,7 @@ namespace {
                     int n = snprintf(b, sizeof b, "[hwwatch] #%d WRITE [0x%llx]=0x%llx by rip=%s0x%llx tid=%ld\n",
                         (int)g_hwwatch_count, (unsigned long long)g_hwwatch_addr, v,
                         in_eboot ? "eboot+" : "", (unsigned long long)(in_eboot ? wr - 0x400000000ull : wr), cur_tid());
-                    syscall(SYS_write, 2, b, (size_t)n);   /* raw: glibc write() reads the TCB via %fs (guest-fs unsafe in this handler) */
+                    raw_write(2, b, (size_t)n);   /* raw syscall: no libc TLS access */
                     if (!in_eboot) classify_addr(wr);
                 }
                 return;
@@ -1223,10 +1223,10 @@ namespace {
                         s[k] = c;
                     }
                     s[k] = 0;
-                    if (k >= 2) { char b[128]; int n = snprintf(b, sizeof b, "[hwbp-str] %s=0x%llx -> \"%s\"\n", rn, (unsigned long long)p, s); syscall(SYS_write, 2, b, (size_t)n);   /* raw: glibc write() reads the TCB via %fs (guest-fs unsafe in this handler) */ }
+                    if (k >= 2) { char b[128]; int n = snprintf(b, sizeof b, "[hwbp-str] %s=0x%llx -> \"%s\"\n", rn, (unsigned long long)p, s); raw_write(2, b, (size_t)n);   /* raw syscall: no libc TLS access */ }
                 };
                 char hdr[64]; int hn = snprintf(hdr, sizeof hdr, "[hwbp-str] hit @eboot+0x%llx:\n",
-                    (unsigned long long)((uint64_t)gr[REG_RIP] - 0x400000000ull)); syscall(SYS_write, 2,hdr, hn);
+                    (unsigned long long)((uint64_t)gr[REG_RIP] - 0x400000000ull)); raw_write(2,hdr, hn);
                 pstr("rdi", (uint64_t)gr[REG_RDI]); pstr("rsi", (uint64_t)gr[REG_RSI]);
                 pstr("rdx", (uint64_t)gr[REG_RDX]); pstr("rcx", (uint64_t)gr[REG_RCX]);
                 pstr("r8",  (uint64_t)gr[REG_R8]);  pstr("r9",  (uint64_t)gr[REG_R9]);
@@ -1245,7 +1245,7 @@ namespace {
                     if (k >= 2) { char b[160]; int n = snprintf(b, sizeof b,
                         "[hwbp-klass] %s obj=0x%llx klass=0x%llx name=\"%s\" [obj+0x40]=0x%llx\n",
                         rn, (unsigned long long)obj, (unsigned long long)klass, s,
-                        (unsigned long long)(probe_readable(obj+0x40)?*(const uint64_t*)(obj+0x40):0)); syscall(SYS_write, 2, b, (size_t)n);   /* raw: glibc write() reads the TCB via %fs (guest-fs unsafe in this handler) */ }
+                        (unsigned long long)(probe_readable(obj+0x40)?*(const uint64_t*)(obj+0x40):0)); raw_write(2, b, (size_t)n);   /* raw syscall: no libc TLS access */ }
                 };
                 // PROSPER_HWBP_FIELDS=1: dump rbx's object fields [0x10..0x60] + the class name of any
                 // field that is itself an object — to tell "whole object uninitialized (all null)" from
@@ -1258,7 +1258,7 @@ namespace {
                             uint64_t v = *(const uint64_t*)(o + off);
                             n += snprintf(b+n, sizeof b-n, " +0x%llx=0x%llx", (unsigned long long)off, (unsigned long long)v);
                         }
-                        n += snprintf(b+n, sizeof b-n, "\n"); syscall(SYS_write, 2, b, (size_t)n);   /* raw: glibc write() reads the TCB via %fs (guest-fs unsafe in this handler) */
+                        n += snprintf(b+n, sizeof b-n, "\n"); raw_write(2, b, (size_t)n);   /* raw syscall: no libc TLS access */
                         // Resolve the class name of each object-typed field (its [obj]->klass->[+0x10]=name).
                         for (uint64_t off = 0x10; off <= 0x88; off += 8) {
                             if (!probe_readable(o + off + 7)) continue;
@@ -1273,7 +1273,7 @@ namespace {
                                 if (c == 0) break; if (c < 0x20 || c > 0x7e) { k = 0; break; } s[k] = c; }
                             s[k] = 0;
                             if (k >= 2) { char fb[128]; int fn = snprintf(fb, sizeof fb,
-                                "[hwbp-field] +0x%llx -> %s\n", (unsigned long long)off, s); syscall(SYS_write, 2,fb, fn); }
+                                "[hwbp-field] +0x%llx -> %s\n", (unsigned long long)off, s); raw_write(2,fb, fn); }
                         }
                     }
                 }
@@ -1290,7 +1290,7 @@ namespace {
                         if (c == 0) break; if (c < 0x20 || c > 0x7e) { if (k < 2) return; break; } s[k] = c; }
                     s[k] = 0;
                     if (k >= 2) { char b[128]; int n = snprintf(b, sizeof b, "[hwbp-cname] %s klass=0x%llx name=\"%s\"\n",
-                        rn, (unsigned long long)klass, s); syscall(SYS_write, 2, b, (size_t)n);   /* raw: glibc write() reads the TCB via %fs (guest-fs unsafe in this handler) */ }
+                        rn, (unsigned long long)klass, s); raw_write(2, b, (size_t)n);   /* raw syscall: no libc TLS access */ }
                 };
                 pcname("rdi(class)", (uint64_t)gr[REG_RDI]);
                 // PROSPER_HWBP_GLOBAL=0xADDR: also resolve the class name stored at a fixed guest global
@@ -1318,7 +1318,7 @@ namespace {
                     (unsigned long long)gr[REG_RCX],
                     (unsigned long long)gr[REG_R8], (unsigned long long)gr[REG_R9],
                     (unsigned long long)(probe_readable((uint64_t)gr[REG_RSP]) ? (*(const uint64_t*)(uint64_t)gr[REG_RSP] - 0x400000000ull) : 0));
-                syscall(SYS_write, 2, b, (size_t)n);
+                raw_write(2, b, (size_t)n);
             }
             // PROSPER_HWBP_OBJ=1: treat rdi as an il2cpp object (at a method-entry bp); print its class
             // name ([[rdi]+0x10]) and fields [rdi+0x00..+0x60], plus [rdi+0x40] chased as an object too.
@@ -1337,7 +1337,7 @@ namespace {
                     (unsigned long long)rd(rdi+8),(unsigned long long)rd(rdi+0x10),(unsigned long long)rd(rdi+0x18),
                     (unsigned long long)rd(rdi+0x20),(unsigned long long)rd(rdi+0x28),(unsigned long long)rd(rdi+0x30),
                     (unsigned long long)rd(rdi+0x38),(unsigned long long)rd(rdi+0x48));
-                syscall(SYS_write, 2,b, n);
+                raw_write(2,b, n);
             }
             if (cond_ok && g_hwbp_r15_on) {
                 // The matching read: dump the window around rax (the source pointer) + classify its mapping,
@@ -1350,7 +1350,7 @@ namespace {
                     "[hwbp] MATCH r15=0x%llx rax(src)=0x%llx rbx=0x%llx | [rax-16..+24]= %llx %llx %llx %llx %llx %llx\n",
                     (unsigned long long)r15, (unsigned long long)rax, (unsigned long long)rbx,
                     rd(rax-16), rd(rax-8), rd(rax), rd(rax+8), rd(rax+16), rd(rax+24));
-                syscall(SYS_write, 2,b2, n2);
+                raw_write(2,b2, n2);
                 classify_addr(rax);
             }
             if (cond_ok && g_hwbp_count < g_hwbp_max) {
@@ -1374,7 +1374,7 @@ namespace {
                     (unsigned long long)rax, rax_u32, (unsigned long long)r14, (unsigned long long)rbx,
                     rd(rbx+0x38), rd(rbx+0x40), rd(rbx+0x48), off(rd(rsp)), off(rd(rbp + 8)), cur_tid());
                 (void)r15; (void)rdi; (void)rsi;
-                syscall(SYS_write, 2, b, (size_t)n);   /* raw: glibc write() reads the TCB via %fs (guest-fs unsafe in this handler) */
+                raw_write(2, b, (size_t)n);   /* raw syscall: no libc TLS access */
                 // PROSPER_HWBP_DIVCAP: log the typetree-vector transfer's elemSize/byteSize/count from the
                 // caller frame (rbp-relative), for the ~6 `call *0x88` array reads.
                 if (g_hwbp_divcap) {
@@ -1389,9 +1389,9 @@ namespace {
                         uint64_t lo = node - 0x6000, hi = node + 0x6000;
                         if (probe_readable(lo) && probe_readable(hi - 1)) {
                             int fd = open("/tmp/prosper_ttnodes.bin", O_WRONLY | O_CREAT | O_TRUNC, 0644);
-                            if (fd >= 0) { (void)!syscall(SYS_write, fd, (const void*)lo, (size_t)(hi - lo)); close(fd);
+                            if (fd >= 0) { (void)!raw_write(fd, (const void*)lo, (size_t)(hi - lo)); close(fd);
                                 char m2[96]; int mn = snprintf(m2, sizeof m2, "[ttnodes] dumped [0x%llx..0x%llx] base=0x%llx\n",
-                                    (unsigned long long)lo, (unsigned long long)hi, (unsigned long long)node); syscall(SYS_write, 2,m2, mn); }
+                                    (unsigned long long)lo, (unsigned long long)hi, (unsigned long long)node); raw_write(2,m2, mn); }
                         }
                     }
                     char db[300];
@@ -1400,7 +1400,7 @@ namespace {
                         (int)g_hwbp_count, rd(crbp - 0xf0), rd(crbp - 0xe8), rd(crbp - 0xf8),
                         node, rd(node), rd(node + 8), rd(node + 0x10), rd(node + 0x18), rd(node + 0x20),
                         rd((uint64_t)gr[REG_RBX] + 0x38));
-                    syscall(SYS_write, 2,db, dn);
+                    raw_write(2,db, dn);
                 }
                 // PROSPER_HWBP_BUFDUMP: write the reader window [base..end] to a per-hit file.
                 if (g_hwbp_bufdump) {
@@ -1408,9 +1408,9 @@ namespace {
                     if (end > base && end - base < 0x400000 && probe_readable(base) && probe_readable(end - 1)) {
                         char fn[64]; snprintf(fn, sizeof fn, "/tmp/prosper_buf_%d.bin", (int)g_hwbp_count);
                         int fd = open(fn, O_WRONLY | O_CREAT | O_TRUNC, 0644);
-                        if (fd >= 0) { (void)!syscall(SYS_write, fd, (const void*)base, (size_t)(end - base)); close(fd);
+                        if (fd >= 0) { (void)!raw_write(fd, (const void*)base, (size_t)(end - base)); close(fd);
                             char m2[96]; int mn = snprintf(m2, sizeof m2, "[hwbp] bufdump #%d -> %s (%llu bytes)\n",
-                                (int)g_hwbp_count, fn, (unsigned long long)(end - base)); syscall(SYS_write, 2,m2, mn); }
+                                (int)g_hwbp_count, fn, (unsigned long long)(end - base)); raw_write(2,m2, mn); }
                     }
                 }
             }
@@ -1445,7 +1445,7 @@ namespace {
                     "[stepwin] ENTER at driver hit #%d: base=0x%llx cur=0x%llx (off 0x%llx)\n",
                     (int)g_hwbp_count, (unsigned long long)g_stepwin_base, (unsigned long long)g_stepwin_prevcur,
                     (unsigned long long)(g_stepwin_prevcur - g_stepwin_base));
-                syscall(SYS_write, 2,sb, sn);
+                raw_write(2,sb, sn);
                 PROSPER_GREGS(uc)[REG_EFL] |= 0x100ll;   // start single-stepping
                 guest_fs_restore_scoped(saved_fs);
                 return;
@@ -1516,7 +1516,7 @@ namespace {
                         }
                     }
                     if (n < (int)sizeof b - 1) b[n++] = '\n';
-                    syscall(SYS_write, 2, b, (size_t)n);   /* raw: glibc write() reads the TCB via %fs (guest-fs unsafe in this handler) */
+                    raw_write(2, b, (size_t)n);   /* raw syscall: no libc TLS access */
                     // PROSPER_BP_PROBE: evaluate the configured pointer/field chains at this hit (first,
                     // so it is never skipped by a KLASS-candidate issue below).
                     if (g_bp_probe) bp_eval_probes(g_bp_probe, uc, 0, "[bp-probe]");
@@ -1537,7 +1537,7 @@ namespace {
                             if (bp_il2cpp_cname(c.v, nm, sizeof nm)) {
                                 char kb[176]; int kn = snprintf(kb, sizeof kb, "[bp-klass] %s=0x%llx %s\n",
                                     c.rn, (unsigned long long)c.v, nm);
-                                syscall(SYS_write, 2, kb, (size_t)kn);
+                                raw_write(2, kb, (size_t)kn);
                             }
                         }
                     }
@@ -1572,7 +1572,7 @@ namespace {
                         n += snprintf(b + n, sizeof b - (size_t)n, " s:%llx",
                                       (unsigned long long)(g_lwatch_stk[i] - 0x400000000ull));
                     if (n < (int)sizeof b - 1) b[n++] = '\n';
-                    syscall(SYS_write, 2, b, (size_t)n);
+                    raw_write(2, b, (size_t)n);
                     if (g_lwatch_hits >= g_lwatch_max) {   // caught enough — disarm, leave page RW
                         mprotect((void*)g_lwatch_page, 0x1000, PROT_READ | PROT_WRITE);
                         g_lwatch_armed = 0; g_lwatch_stepping = false; g_lwatch_step_rip = 0;
@@ -1589,7 +1589,7 @@ namespace {
                 int n = snprintf(b, sizeof b, "[lwatch]   -> slot now [0]=0x%llx [8]=0x%llx\n",
                                  (unsigned long long)*(const uint64_t*)g_lwatch_slot,
                                  (unsigned long long)*(const uint64_t*)(g_lwatch_slot + 8));
-                syscall(SYS_write, 2, b, (size_t)n);
+                raw_write(2, b, (size_t)n);
                 g_lwatch_step_rip = 0;
             }
             if (g_lwatch_armed) mprotect((void*)g_lwatch_page, 0x1000, PROT_READ);
@@ -1649,7 +1649,7 @@ namespace {
                         }
                     }
                     if (n < (int)sizeof b - 1) b[n++] = '\n';
-                    syscall(SYS_write, 2, b, (size_t)n);
+                    raw_write(2, b, (size_t)n);
                     g_lwatch_step_rip = rip;
                     if (g_lwatch_hits >= g_lwatch_max) {   // bounded: disarm after enough evidence
                         mprotect((void*)g_lwatch_page, 0x1000, PROT_READ | PROT_WRITE);
@@ -1674,7 +1674,7 @@ namespace {
             unsigned long long tag  = *(const uint64_t*)(g_watch_addr - 0x140);
             char b[128];
             int n = snprintf(b, sizeof b, "[watch]   -> slot now=0x%llx  obj[+0]=0x%llx\n", slot, tag);
-            syscall(SYS_write, 2, b, (size_t)n);   /* raw: glibc write() reads the TCB via %fs (guest-fs unsafe in this handler) */
+            raw_write(2, b, (size_t)n);   /* raw syscall: no libc TLS access */
             mprotect((void*)g_watch_page, 0x1000, PROT_READ);
             g_watch_stepping = false;
             return;
@@ -1691,7 +1691,7 @@ namespace {
                     char b[128];
                     int n = snprintf(b, sizeof b, "[watch] armed on companion slot 0x%llx (obj r15=0x%llx) reader-tid=%ld\n",
                                      (unsigned long long)g_watch_addr, (unsigned long long)r15, cur_tid());
-                    syscall(SYS_write, 2, b, (size_t)n);   /* raw: glibc write() reads the TCB via %fs (guest-fs unsafe in this handler) */
+                    raw_write(2, b, (size_t)n);   /* raw syscall: no libc TLS access */
                 }
                 // Skip this (null) read so the boot proceeds; the slot's page is now watched.
                 PROSPER_GREGS(uc)[REG_RIP] = (greg_t)g_skip_target;
@@ -1711,7 +1711,7 @@ namespace {
                                      (unsigned long long)fa,
                                      (unsigned long long)PROSPER_GREGS(uc)[REG_RIP], cur_tid(),
                                      (int)g_watch_hits);
-                    syscall(SYS_write, 2, b, (size_t)n);   /* raw: glibc write() reads the TCB via %fs (guest-fs unsafe in this handler) */
+                    raw_write(2, b, (size_t)n);   /* raw syscall: no libc TLS access */
                 }
                 mprotect((void*)g_watch_page, 0x1000, PROT_READ | PROT_WRITE);
                 PROSPER_GREGS(uc)[REG_EFL] |= 0x100ll;   // set TF -> single-step the write
@@ -1775,7 +1775,7 @@ namespace {
                     int n = snprintf(b, sizeof b, "[fault] GPU-VA %s addr=0x%llx rip=0x%llx\n",
                                      ok ? "mapped" : "MMAP-FAILED", (unsigned long long)a,
                                      (unsigned long long)rip);
-                    syscall(SYS_write, 2, b, (size_t)n);   /* raw: glibc write() reads the TCB via %fs (guest-fs unsafe in this handler) */
+                    raw_write(2, b, (size_t)n);   /* raw syscall: no libc TLS access */
                 }
                 if (ok) { g_lazy_pages = g_lazy_pages + 1; return; }  // re-execute against the now-mapped page
             }
@@ -1840,7 +1840,7 @@ namespace {
                     "[+0x1a0]=0x%llx -> skip to 0x%llx\n",
                     (int)g_skip_count, (unsigned long long)r15, rd(r15+0xc0), rd(r15+0xe0),
                     rd(r15+0x138), rd(r15+0x140), rd(r15+0x1a0), (unsigned long long)g_skip_target);
-                syscall(SYS_write, 2, b, (size_t)n);   /* raw: glibc write() reads the TCB via %fs (guest-fs unsafe in this handler) */
+                raw_write(2, b, (size_t)n);   /* raw syscall: no libc TLS access */
                 PROSPER_GREGS(uc)[REG_RIP] = (greg_t)g_skip_target;
                 return;   // re-execute from the reader's skip label
             }
@@ -1862,7 +1862,7 @@ namespace {
             int n = snprintf(b, sizeof b, "[fault] sig=%d addr=%p rip=0x%llx armed=%d tid=%ld\n",
                              sig, si->si_addr, (unsigned long long)PROSPER_GREGS(uc)[REG_RIP],
                              (int)(g_armed_tid && cur_tid() == g_armed_tid), cur_tid());
-            syscall(SYS_write, 2, b, (size_t)n);   /* raw: glibc write() reads the TCB via %fs (guest-fs unsafe in this handler) */
+            raw_write(2, b, (size_t)n);   /* raw syscall: no libc TLS access */
         }
         g_fault_addr = si->si_addr;
         auto* uc = (ucontext_t*)uctx;
@@ -1898,7 +1898,7 @@ namespace {
                     int n = snprintf(b, sizeof b,
                         "[int41] guest int $0x41 (debugbreak) at eboot+0x%llx -> skipped\n",
                         (unsigned long long)(g_fault_rip - g_base));
-                    syscall(SYS_write, 2, b, (size_t)n);
+                    raw_write(2, b, (size_t)n);
                 }
                 g[REG_RIP] = g_fault_rip + 2;   // advance past the 2-byte int instruction
                 guest_fs_restore_scoped(saved_guest_fs);   // resume guest on its guest %fs, not host (#1155)
@@ -1931,7 +1931,7 @@ namespace {
                              sig, g_fault_addr, (unsigned long long)g_fault_rip,
                              (unsigned long long)(g_base && g_fault_rip >= g_base ? g_fault_rip - g_base : g_fault_rip),
                              (unsigned long long)g_rbp);
-            syscall(SYS_write, 2, b, (size_t)n);   /* raw: glibc write() reads the TCB via %fs (guest-fs unsafe in this handler) */
+            raw_write(2, b, (size_t)n);   /* raw syscall: no libc TLS access */
             // Classify the fault rip + fault-addr regions (which mapping / module) and dump the instruction
             // bytes at rip — turns the ASLR-relocated "rip=0x...48b" into an identifiable location.
             classify_addr(g_fault_rip);
@@ -1942,7 +1942,7 @@ namespace {
                 rdb(g_fault_rip), rdb(g_fault_rip+1), rdb(g_fault_rip+2), rdb(g_fault_rip+3),
                 rdb(g_fault_rip+4), rdb(g_fault_rip+5), rdb(g_fault_rip+6), rdb(g_fault_rip+7),
                 (unsigned long long)(probe_readable(g_rsp) ? *(const uint64_t*)g_rsp : 0));
-            syscall(SYS_write, 2,ib, m);
+            raw_write(2,ib, m);
             // Guest-%fs attribution (#1155): is the faulting thread running guest code on OUR guest TCB
             // or leaked onto the host glibc TCB? The guest loads its TCB self-pointer with `mov %fs:0x0`;
             // at a fault right after, that value is still in rax (the common landing reg) and equals the
@@ -1956,7 +1956,7 @@ namespace {
                 char tb[160];
                 int t = snprintf(tb, sizeof tb, "[fault] thread='%s' fs(rax)=0x%llx on-guest-TCB=%s\n",
                                  nm, (unsigned long long)g_rax, on_guest_tcb ? "yes" : "NO(host-%fs leak?)");
-                syscall(SYS_write, 2, tb, (size_t)t);
+                raw_write(2, tb, (size_t)t);
             }
             // PROSPER_FAULTOBJ (#1226): dump the leading 0xC0 bytes of the objects in rax/r15/rbx via a
             // fault-safe self-read (process_vm_readv, EFAULT-safe on unmapped guest VAs). For ArcRunner's
@@ -1982,7 +1982,7 @@ namespace {
                         on += snprintf(ob + on, sizeof ob - (size_t)on, " +%02x=%016llx",
                                        w * 8, (unsigned long long)buf[w]);
                     on += snprintf(ob + on, sizeof ob - (size_t)on, "\n");
-                    syscall(SYS_write, 2, ob, (size_t)on);
+                    raw_write(2, ob, (size_t)on);
                 }
                 // Corruption-source probe: dump rcx/rdx and scan the GPU-write ring around rdx (the
                 // free-list head slot for a `mov [rdx]`-style pop) and rax. If a prosper ReleaseMem/fence
@@ -1991,7 +1991,7 @@ namespace {
                     char cb[160];
                     int cn = snprintf(cb, sizeof cb, "[faultobj] rcx=0x%llx rdx=0x%llx\n",
                                       (unsigned long long)g_rcx, (unsigned long long)g_rdx);
-                    syscall(SYS_write, 2, cb, (size_t)cn);
+                    raw_write(2, cb, (size_t)cn);
                     if (prosper_gpu_write_ring_scan) {
                         static char ring[8192];
                         const uint64_t probes[2] = { g_rdx, g_rax };
@@ -2003,8 +2003,8 @@ namespace {
                                 char hb[96]; int hn = snprintf(hb, sizeof hb,
                                     "[faultobj] GPU-write-ring hits in page 0x%llx:\n",
                                     (unsigned long long)pg);
-                                syscall(SYS_write, 2, hb, (size_t)hn);
-                                syscall(SYS_write, 2, ring, strlen(ring));
+                                raw_write(2, hb, (size_t)hn);
+                                raw_write(2, ring, strlen(ring));
                             }
                         }
                     }
@@ -2024,8 +2024,8 @@ namespace {
                             char hb[112]; int hn = snprintf(hb, sizeof hb,
                                 "[faultobj] clock-fence targets in page 0x%llx: %d\n",
                                 (unsigned long long)pg, fn2);
-                            syscall(SYS_write, 2, hb, (size_t)hn);
-                            if (fn2 > 0) syscall(SYS_write, 2, cfb, strlen(cfb));
+                            raw_write(2, hb, (size_t)hn);
+                            if (fn2 > 0) raw_write(2, cfb, strlen(cfb));
                         }
                     }
                     // #1226 reverse lookup: the corrupted value's shape is {orig_low32, clock_low32}
@@ -2053,8 +2053,8 @@ namespace {
                             char hb[128]; int hn = snprintf(hb, sizeof hb,
                                 "[faultobj] clock-fence low32 matches for value 0x%llx (hi32=0x%x): %d\n",
                                 (unsigned long long)v, hi32, fn3);
-                            syscall(SYS_write, 2, hb, (size_t)hn);
-                            if (fn3 > 0) syscall(SYS_write, 2, fb, strlen(fb));
+                            raw_write(2, hb, (size_t)hn);
+                            if (fn3 > 0) raw_write(2, fb, strlen(fb));
                         }
                     }
                     // #1226 POOLSHIFT probe. Both residual fault classes dereference a value whose
@@ -2095,7 +2095,7 @@ namespace {
                                 bn += snprintf(bb + bn, sizeof bb - (size_t)bn, "%s%02x",
                                                (k % 8 == 0) ? " " : "", bytes[k]);
                             bn += snprintf(bb + bn, sizeof bb - (size_t)bn, "\n");
-                            syscall(SYS_write, 2, bb, (size_t)bn);
+                            raw_write(2, bb, (size_t)bn);
                         };
                         byte_dump("rdx", g_rdx);
                         byte_dump("r8", g_r8);
@@ -2106,7 +2106,7 @@ namespace {
                                 char cb2[96]; int cn2 = snprintf(cb2, sizeof cb2,
                                     "[faultobj] pool 0x%llx candidate=%d\n",
                                     (unsigned long long)pb, prosper_mb3_is_pool_candidate(pb));
-                                syscall(SYS_write, 2, cb2, (size_t)cn2);
+                                raw_write(2, cb2, (size_t)cn2);
                             }
                         }
                         // #1226: cross-reference the slot pages against APR write destinations —
@@ -2121,8 +2121,8 @@ namespace {
                                 char h4[112]; int h4n = snprintf(h4, sizeof h4,
                                     "[faultobj] APR dests overlapping page 0x%llx: %d\n",
                                     (unsigned long long)pg, an);
-                                syscall(SYS_write, 2, h4, (size_t)h4n);
-                                syscall(SYS_write, 2, ab, strlen(ab));   // unconditional: the stores/evictions header IS the zero-case confidence signal
+                                raw_write(2, h4, (size_t)h4n);
+                                raw_write(2, ab, strlen(ab));   // unconditional: the stores/evictions header IS the zero-case confidence signal
                             }
                         }
                         const uint64_t cands[3] = { g_rax, g_rcx, rdx_val2 };
@@ -2133,7 +2133,7 @@ namespace {
                             char pb[128]; int pn = snprintf(pb, sizeof pb,
                                 "[faultobj] POOLSHIFT candidate 0x%llx -> real ptr 0x%llx\n",
                                 (unsigned long long)v, (unsigned long long)real);
-                            syscall(SYS_write, 2, pb, (size_t)pn);
+                            raw_write(2, pb, (size_t)pn);
                             // What actually lives at the reconstructed pointer? A live free block
                             // (next-pointer residue), a pool-info record, or unrelated data —
                             // discriminates "compressed pointer misread" from coincidence.
@@ -2146,8 +2146,8 @@ namespace {
                                 char h5[112]; int h5n = snprintf(h5, sizeof h5,
                                     "[faultobj] APR dests overlapping real-ptr page 0x%llx: %d\n",
                                     (unsigned long long)rp, arn);
-                                syscall(SYS_write, 2, h5, (size_t)h5n);
-                                syscall(SYS_write, 2, ar, strlen(ar));   // unconditional (see above)
+                                raw_write(2, h5, (size_t)h5n);
+                                raw_write(2, ar, strlen(ar));   // unconditional (see above)
                             }
                             uint64_t pg = real & ~0xfffull;
                             if (prosper_gpu_write_ring_scan) {
@@ -2156,8 +2156,8 @@ namespace {
                                 char h2[112]; int h2n = snprintf(h2, sizeof h2,
                                     "[faultobj] GPU-write-ring hits at real-ptr page 0x%llx: %d\n",
                                     (unsigned long long)pg, rn2);
-                                syscall(SYS_write, 2, h2, (size_t)h2n);
-                                if (rn2 > 0) syscall(SYS_write, 2, rs, strlen(rs));
+                                raw_write(2, h2, (size_t)h2n);
+                                if (rn2 > 0) raw_write(2, rs, strlen(rs));
                             }
                             if (prosper_gpu_clockfence_scan) {
                                 static char cs[4096];
@@ -2165,8 +2165,8 @@ namespace {
                                 char h3[112]; int h3n = snprintf(h3, sizeof h3,
                                     "[faultobj] clock-fence targets at real-ptr page 0x%llx: %d\n",
                                     (unsigned long long)pg, cn2);
-                                syscall(SYS_write, 2, h3, (size_t)h3n);
-                                if (cn2 > 0) syscall(SYS_write, 2, cs, strlen(cs));
+                                raw_write(2, h3, (size_t)h3n);
+                                if (cn2 > 0) raw_write(2, cs, strlen(cs));
                             }
                         }
                     }
@@ -2183,7 +2183,7 @@ namespace {
             {
                 char lb[160]; int ln;
                 ln = snprintf(lb, sizeof lb, "[prosper]   guest fp-chain (rbp=0x%llx):\n", (unsigned long long)g_rbp);
-                if (ln > 0) syscall(SYS_write, 2, lb, (size_t)ln);
+                if (ln > 0) raw_write(2, lb, (size_t)ln);
                 uint64_t fp = g_rbp;
                 for (int depth = 0; depth < 16; depth++) {
                     if (!probe_readable(fp) || !probe_readable(fp + 8)) break;
@@ -2194,13 +2194,13 @@ namespace {
                                       depth, (unsigned long long)ra, (unsigned long long)(ra - g_base));
                     else
                         ln = snprintf(lb, sizeof lb, "[prosper]     #%d ra=0x%llx\n", depth, (unsigned long long)ra);
-                    if (ln > 0) syscall(SYS_write, 2, lb, (size_t)ln);
+                    if (ln > 0) raw_write(2, lb, (size_t)ln);
                     if (nfp <= fp || nfp - fp > 0x200000ull) break;   // non-increasing / implausible frame: stop
                     fp = nfp;
                 }
                 ln = snprintf(lb, sizeof lb, "[prosper]   guest ret-addr scan (rsp=0x%llx, 64 qwords):\n",
                               (unsigned long long)g_rsp);
-                if (ln > 0) syscall(SYS_write, 2, lb, (size_t)ln);
+                if (ln > 0) raw_write(2, lb, (size_t)ln);
                 for (int i = 0, shown = 0; i < 64 && shown < 16; i++) {
                     uint64_t sa = g_rsp + (uint64_t)i * 8;
                     if (!probe_readable(sa)) continue;
@@ -2208,7 +2208,7 @@ namespace {
                     if (g_base && q >= g_base && q < g_base + 0x100000000ull) {
                         ln = snprintf(lb, sizeof lb, "[prosper]     rsp+0x%03x = 0x%llx (eboot+0x%llx)\n",
                                       i * 8, (unsigned long long)q, (unsigned long long)(q - g_base));
-                        if (ln > 0) syscall(SYS_write, 2, lb, (size_t)ln);
+                        if (ln > 0) raw_write(2, lb, (size_t)ln);
                         shown++;
                     }
                 }
@@ -2224,7 +2224,7 @@ namespace {
                     if (g_base && r.v >= g_base && r.v < g_base + 0x100000000ull) {
                         ln = snprintf(lb, sizeof lb, "[prosper]     %-3s = 0x%llx (eboot+0x%llx)\n",
                                       r.nm, (unsigned long long)r.v, (unsigned long long)(r.v - g_base));
-                        if (ln > 0) syscall(SYS_write, 2, lb, (size_t)ln);
+                        if (ln > 0) raw_write(2, lb, (size_t)ln);
                     }
                 }
             }
@@ -2585,7 +2585,7 @@ void arm_bp() {
     char b[96];
     int n = snprintf(b, sizeof b, "[bp] armed int3 at eboot+0x%llx (orig=0x%02x)\n",
                      (unsigned long long)(g_bp_addr - g_base), g_bp_orig);
-    syscall(SYS_write, 2, b, (size_t)n);   /* raw: glibc write() reads the TCB via %fs (guest-fs unsafe in this handler) */
+    raw_write(2, b, (size_t)n);   /* raw syscall: no libc TLS access */
 }
 
 // Open + enable the PROSPER_HWBP hardware breakpoint (must run on the main/guest thread — the perf
@@ -2597,7 +2597,7 @@ void arm_hwbp() {
     if (fd < 0) {
         int n = snprintf(b, sizeof b, "[hwbp] perf_event_open FAILED for eboot+0x%llx (errno=%d) — HW bp disabled\n",
                          (unsigned long long)(g_hwbp_addr - g_base), errno);
-        syscall(SYS_write, 2, b, (size_t)n);   /* raw: glibc write() reads the TCB via %fs (guest-fs unsafe in this handler) */ g_hwbp_on = false; return;
+        raw_write(2, b, (size_t)n);   /* raw syscall: no libc TLS access */ g_hwbp_on = false; return;
     }
     g_hwbp_fd = (int)fd;
     fcntl(g_hwbp_fd, F_SETFL, O_ASYNC);
@@ -2607,14 +2607,14 @@ void arm_hwbp() {
     if (!hwbp_register_thread(ow.pid, g_hwbp_fd)) {
         int n = snprintf(b, sizeof b, "[hwbp] thread-state table full for tid=%ld - HW bp disabled\n",
                          (long)ow.pid);
-        syscall(SYS_write, 2, b, (size_t)n);
+        raw_write(2, b, (size_t)n);
         close(g_hwbp_fd); g_hwbp_fd = -1; g_hwbp_on = false; return;
     }
     ioctl(g_hwbp_fd, PERF_EVENT_IOC_ENABLE, 0);
     t_hwbp_fd = g_hwbp_fd;   // main thread uses the same fd for its per-thread stepping state
     int n = snprintf(b, sizeof b, "[hwbp] armed HW execute bp at eboot+0x%llx (fd=%d tid=%ld)\n",
                      (unsigned long long)(g_hwbp_addr - g_base), g_hwbp_fd, (long)prosper_gettid());
-    syscall(SYS_write, 2, b, (size_t)n);   /* raw: glibc write() reads the TCB via %fs (guest-fs unsafe in this handler) */
+    raw_write(2, b, (size_t)n);   /* raw syscall: no libc TLS access */
 }
 
 // Arm the same execute bp on the CURRENT (worker) thread, gated by PROSPER_HWBP_ALLTHREADS. Each thread
@@ -2622,11 +2622,11 @@ void arm_hwbp() {
 void arm_hwbp_this_thread() {
     if (getenv("PROSPER_HWBP_ARMLOG")) { char b[128]; int n = snprintf(b, sizeof b,
         "[hwbp] arm_this_thread tid=%ld on=%d all=%d addr=0x%llx tfd=%d\n", (long)prosper_gettid(),
-        g_hwbp_on, g_hwbp_allthreads, (unsigned long long)g_hwbp_addr, t_hwbp_fd); syscall(SYS_write, 2,b, n); }
+        g_hwbp_on, g_hwbp_allthreads, (unsigned long long)g_hwbp_addr, t_hwbp_fd); raw_write(2,b, n); }
     if (!g_hwbp_on || !g_hwbp_allthreads || !g_hwbp_addr || t_hwbp_fd >= 0) return;
     long fd = perf_bp_open(g_hwbp_addr, HW_BREAKPOINT_X);
     if (fd < 0) { char b[96]; int n = snprintf(b, sizeof b, "[hwbp] worker-arm FAILED tid=%ld errno=%d\n",
-        (long)prosper_gettid(), errno); syscall(SYS_write, 2,b, n); return; }
+        (long)prosper_gettid(), errno); raw_write(2,b, n); return; }
     t_hwbp_fd = (int)fd;
     fcntl(t_hwbp_fd, F_SETFL, O_ASYNC);
     fcntl(t_hwbp_fd, F_SETSIG, SIGTRAP);
@@ -2635,13 +2635,13 @@ void arm_hwbp_this_thread() {
     if (!hwbp_register_thread(ow.pid, t_hwbp_fd)) {
         char b[112]; int n = snprintf(b, sizeof b,
             "[hwbp] thread-state table full for worker tid=%ld - not armed\n", (long)ow.pid);
-        syscall(SYS_write, 2, b, n);
+        raw_write(2, b, n);
         close(t_hwbp_fd); t_hwbp_fd = -1; return;
     }
     ioctl(t_hwbp_fd, PERF_EVENT_IOC_ENABLE, 0);
     char b[128]; int n = snprintf(b, sizeof b, "[hwbp] armed on worker tid=%ld (fd=%d) for eboot+0x%llx\n",
         (long)prosper_gettid(), t_hwbp_fd, (unsigned long long)(g_hwbp_addr - 0x400000000ull));
-    syscall(SYS_write, 2,b, n);
+    raw_write(2,b, n);
 }
 
 uint64_t stub_addr(uint64_t idx) { return g_stub_base + idx * g_stub_size; }


### PR DESCRIPTION
Closes #1075.

## What changed
- replace every remaining glibc `syscall(SYS_write, ...)` use in Linux fault/debug diagnostics with `raw_write`
- cover default fault reports, HWBP/HWWATCH/KSCAN dump helpers, probe pipe writes, and breakpoint-arm diagnostics
- preserve all destinations, byte counts, and ignored/checked return-value behavior

## Root cause
glibc's syscall wrapper stores errno through `%fs` on failure. Guest threads can enter these diagnostics with `%fs` pointing at guest TLS, so a failed diagnostic write can fault recursively inside the signal handler. `raw_write` issues the syscall directly and returns `-errno` in-register without touching TLS.

## Validation
- `raw_syscall` errno-preservation test passed
- full suite: 143/143 passed
- no `syscall(SYS_write` call remains in `exec_image_linux.cpp`