### PR TITLE
fix(fs): jail bare root path spellings

### DIFF
--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -755,10 +755,14 @@ std::string resolve_guest_path(const char* guest_path) {
     // is the absolute spelling, "file://<relative>" the BaseDir-relative one).
     if (p.rfind("file://", 0) == 0) p = p.substr(7);
     if (p.empty()) return {};
+    // A separator-only spelling names the guest root. Send it directly to translate() so a bare
+    // backslash reaches the virtual-root case without making every leading-backslash path host-
+    // absolute on Windows ("\\foo" and UNC-like spellings must remain rooted under /app0).
+    if (p.find_first_not_of("/\\") == std::string::npos) return translate(p.c_str());
     // Sony media APIs accept content paths relative to the title's application root. Unlike the
     // guest libc, a native host backend has no guest current-working-directory state, so root the
     // relative spelling explicitly before applying the shared mount translation.
-    if (p[0] != '/' && p[0] != '\\') {
+    if (p[0] != '/') {
         // A relative URL may carry leading ".." components: UE4 media paths are BaseDir-relative
         // ("../../../<project>/Content/..." climbs from Engine/Binaries/<Platform>/ up to the
         // package root), but prosper models no BaseDir/CWD and ArcRunner's dump has no such

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -566,6 +566,17 @@ namespace {
             if (filelog()) fprintf(stderr, "[file] DENIED (PROSPER_DENY_SUBSTR) '%s'\n", guest);
             return "/prosper-denied" + p;
         }
+        // #1323: separator-only spellings name the jailed title's root, not the host root.
+        // Keep this consistent with the traversal spelling "/app0/.." handled below. Accept
+        // both guest separators (and repeated separators) so no equivalent root spelling can
+        // fall through to the host-passthrough return.
+        if (!p.empty() && p.find_first_not_of("/\\") == std::string::npos) {
+            const std::string vroot = virtual_root_dir();
+            if (filelog())
+                fprintf(stderr, "[file] open '%s' -> virtual root '%s'\n", guest,
+                        vroot.c_str());
+            return vroot;
+        }
         // Map /app0[/...] -> <root>[/...], /temp0[/...] -> scratch dir, /savedata0[/...] -> the mounted
         // save dir; other paths as-is. Guest paths are the game's own and normally contain no ".." —
         // but a path that climbs above its virtual root (e.g. "/savedata0/../x") would otherwise compose
@@ -747,7 +758,7 @@ std::string resolve_guest_path(const char* guest_path) {
     // Sony media APIs accept content paths relative to the title's application root. Unlike the
     // guest libc, a native host backend has no guest current-working-directory state, so root the
     // relative spelling explicitly before applying the shared mount translation.
-    if (p[0] != '/') {
+    if (p[0] != '/' && p[0] != '\\') {
         // A relative URL may carry leading ".." components: UE4 media paths are BaseDir-relative
         // ("../../../<project>/Content/..." climbs from Engine/Binaries/<Platform>/ up to the
         // package root), but prosper models no BaseDir/CWD and ArcRunner's dump has no such

--- a/prosper/tests/test_translate_sandbox.cpp
+++ b/prosper/tests/test_translate_sandbox.cpp
@@ -75,6 +75,12 @@ int main() {
     CHECK(resolve_guest_path("//") == virtual_root,
           "repeated root separators cannot fall through to the host root");
     CHECK(virtual_root != "/", "virtual root is not the real host root");
+    CHECK(resolve_guest_path("\\foo") == base + "/\\foo",
+          "non-root leading backslash remains rooted under /app0");
+    CHECK(resolve_guest_path("\\\\server\\share") == base + "/\\\\server\\share",
+          "UNC-like guest spelling remains rooted under /app0");
+    CHECK(resolve_guest_path("file://\\foo") == base + "/\\foo",
+          "file URL with non-root backslash remains rooted under /app0");
 
     // Benign in-sandbox '..': normalizes to the same host file the OS would have resolved anyway.
     CHECK(resolve_guest_path("/app0/data/../data/config.bin") == base + "/data/config.bin",

--- a/prosper/tests/test_translate_sandbox.cpp
+++ b/prosper/tests/test_translate_sandbox.cpp
@@ -65,6 +65,17 @@ int main() {
           "sibling prefix '/savedata00' is not mapped into /savedata0");
     CHECK(savedata0_umount(), "test save directory unmounts");
 
+    // Every separator-only spelling names the jailed title's virtual root. In particular, bare
+    // "/" must not pass through to the real host root while "/app0/.." maps to the vroot (#1323).
+    const std::string virtual_root = resolve_guest_path("/app0/..");
+    CHECK(resolve_guest_path("/") == virtual_root,
+          "bare '/' maps to the same virtual root as '/app0/..'");
+    CHECK(resolve_guest_path("\\") == virtual_root,
+          "bare backslash maps to the virtual root");
+    CHECK(resolve_guest_path("//") == virtual_root,
+          "repeated root separators cannot fall through to the host root");
+    CHECK(virtual_root != "/", "virtual root is not the real host root");
+
     // Benign in-sandbox '..': normalizes to the same host file the OS would have resolved anyway.
     CHECK(resolve_guest_path("/app0/data/../data/config.bin") == base + "/data/config.bin",
           "in-sandbox '..' normalizes to the same host file");


### PR DESCRIPTION
Closes #1323.

## What changed
- map bare `/` to the jailed title's prepared virtual root instead of the real host root
- treat backslash and repeated separator-only spellings as the same virtual root
- preserve app0-rooting for non-root backslash and UNC-like guest paths
- add regression coverage proving root spellings match `/app0/..` without exposing Windows host paths

## Validation
- `test_translate_sandbox` passed
- full suite: 143/143 passed
- `git diff --check` clean