### PR TITLE
fix(host): report guest divide faults

### DIFF
--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -72,7 +72,7 @@ namespace {
     sigjmp_buf g_jb;
     volatile long g_armed_tid = 0;               // kernel tid that armed g_jb, 0 = none
     inline long cur_tid() { return (long)prosper_gettid(); }
-    volatile sig_atomic_t g_trap_kind = 0;   // 0 none, 2 SEGV/BUS, 3 ILL
+    volatile sig_atomic_t g_trap_kind = 0;   // 0 none, 2 fatal fault, 3 ILL
     volatile int          g_trap_sig = 0;
     void*    g_fault_addr = nullptr;
     uint64_t g_fault_rip = 0;
@@ -2244,7 +2244,9 @@ namespace {
 
     std::string trap_detail() {
         char buf[256];
-        const char* sn = g_trap_sig == SIGILL ? "SIGILL" : g_trap_sig == SIGBUS ? "SIGBUS" : "SIGSEGV";
+        const char* sn = g_trap_sig == SIGILL ? "SIGILL"
+                       : g_trap_sig == SIGBUS ? "SIGBUS"
+                       : g_trap_sig == SIGFPE ? "SIGFPE" : "SIGSEGV";
         uint64_t off = (g_base && g_fault_rip >= g_base) ? g_fault_rip - g_base : 0;
         snprintf(buf, sizeof buf, "%s at addr=%p  rip=0x%llx (image+0x%llx)",
                  sn, g_fault_addr, (unsigned long long)g_fault_rip, (unsigned long long)off);
@@ -2570,6 +2572,7 @@ void install_trap_handler() {
     sigaction(SIGSEGV, &sa, nullptr);
     sigaction(SIGBUS,  &sa, nullptr);
     sigaction(SIGILL,  &sa, nullptr);
+    sigaction(SIGFPE,  &sa, nullptr);
     if (g_watch_companion || g_bp_on || g_hwbp_on
         || getenv("PROSPER_WATCH_LABEL")
         || getenv("PROSPER_WATCH_ABS")

--- a/prosper/tests/test_initfault_dump.cpp
+++ b/prosper/tests/test_initfault_dump.cpp
@@ -1,4 +1,7 @@
-// test_initfault_dump — the init-fault REPORT must never fault itself (#128). run_guest_inits
+// test_initfault_dump — guest init faults must be recovered and their reports must not fault (#128).
+// This also drives a real integer #DE/SIGFPE through the installed handler (#1160); without the
+// SIGFPE registration the test process is killed before run_guest_inits can recover.
+// run_guest_inits
 // tolerates a faulting init fn (sigsetjmp recovery) and then prints a diagnostic that includes
 // the bytes around the faulting rip and the entry. With a WILD or NULL init-fn pointer — the
 // exact failure this diagnostic exists for — the faulting rip is unmapped; the old report
@@ -8,12 +11,23 @@
 #include "../src/host/exec_image.hpp"
 #include <cstdio>
 
+#ifndef _WIN32
+__attribute__((noinline)) static void divide_by_zero(uint64_t, uint64_t) {
+    __asm__ volatile("mov $1, %%eax; xor %%edx, %%edx; xor %%ecx, %%ecx; idiv %%ecx"
+                     : : : "rax", "rcx", "rdx", "cc");
+}
+#endif
+
 int main() {
     printf("== test_initfault_dump ==\n");
     prosper::install_trap_handler();
     // A canonical-but-unmapped target (wild jump: rip = target, rip-8 also unmapped) and a null
     // call. Both must be tolerated AND survive the byte-dump diagnostic that follows.
-    size_t ok = prosper::run_guest_inits({ 0xdead0000ull, 0ull });
+    std::vector<uint64_t> faulting = { 0xdead0000ull, 0ull };
+#ifndef _WIN32
+    faulting.push_back((uint64_t)(uintptr_t)&divide_by_zero);
+#endif
+    size_t ok = prosper::run_guest_inits(faulting);
     if (ok != 0) {
         printf("  [FAIL] wild init fns were counted as succeeded (ok=%zu)\n", ok);
         return 1;
@@ -27,7 +41,11 @@ int main() {
     }
     printf("  [ok]   recovery thunk provided aligned MS-x64 shadow-space call frame\n");
 #endif
-    printf("  [ok]   wild + null init fns tolerated; the fault report did not kill the process\n");
+#ifdef _WIN32
+    printf("  [ok]   wild and null faults were reported and recovered\n");
+#else
+    printf("  [ok]   wild, null, and integer-divide faults were reported and recovered\n");
+#endif
     printf("== PASS ==\n");
     return 0;
 }


### PR DESCRIPTION
Addresses the SIGFPE diagnostic gap noted in #1160.

## What changed
- install the existing POSIX guest fault handler for `SIGFPE`
- identify recovered divide faults as `SIGFPE` in `trap_detail()`
- extend the real init-fault recovery test with an x86 `idiv`-by-zero instruction

## Why
Guest integer divide errors previously bypassed Prosper's handler and produced an uninformative host core dump. They now capture RIP/register state and follow the same recovery/report path as other guest faults.

## Validation
- focused init-fault test reports and recovers a real integer divide fault
- full suite: 143/143 passed
- `git diff --check` clean