### PR TITLE
fix(gpu): honor GE_INDX_OFFSET in draws

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -2377,6 +2377,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     bd.fs_identity = fs_ov ? 0 : it.fs_identity;
                     bd.vcount = refvs ? 3u : it.vertex_count;
                     bd.instance_count = it.instance_count;
+                    bd.vertex_offset = refvs ? 0 : it.vertex_offset;
                     bd.ps     = nops ? nullptr : &it.ps;
                     bd.R      = build_R(it, it.vrt.get(), it.prt.get());
                     if (!prosper::gpu::validate_runtime_descriptor_contract(

--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -1849,12 +1849,12 @@ void GpuState::apply(const Pm4Command& c) {
             d.index_count = c.index_count;
             d.instance_count = num_instances;
             d.state = last_snapshot_;
+            d.modifier = c.di_modifier;
             if (c.kind == K::DrawIndex) {
                 // Mark as indexed only when the packet was fully decoded — a short packet's addr/
                 // modifier would be fabricated zeros, and `indexed` promises index_addr is real.
                 d.indexed = c.di_valid;
                 d.index_addr = c.di_index_addr;
-                d.modifier = c.di_modifier;
             }
             draws.push_back(std::move(d));
             draws.back().command_order = command_order;

--- a/prosper/src/gpu/command_processor.hpp
+++ b/prosper/src/gpu/command_processor.hpp
@@ -39,9 +39,10 @@ struct GpuState {
     // folded state, so this field is inert until that executor lands. (Snapshot infra ported from #31.)
     // Indexed draws (sceAgcDcbDrawIndex): `indexed` is set only when the packet carried the full
     // operand set; `index_addr` is the guest address of the index buffer (1:1-mapped, so directly
-    // readable) and `modifier` the raw 64-bit draw-modifier bits. The index ELEMENT SIZE lives in the
-    // draw's register snapshot (`state->index_type`, from the preceding SetIndexType; 0 = 16-bit,
-    // 1 = 32-bit). The executor fetches the index data and renders with vkCmdDrawIndexed (#64).
+    // readable). Both DrawIndex and DrawIndexAuto retain their raw 64-bit `modifier`. The index
+    // ELEMENT SIZE lives in the draw's register snapshot (`state->index_type`, from the preceding
+    // SetIndexType; 0 = 16-bit, 1 = 32-bit). The executor fetches indexed data and renders with
+    // vkCmdDrawIndexed (#64).
     struct Draw {
         uint32_t index_count;
         uint32_t instance_count = 1;

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -51,7 +51,11 @@ constexpr char kMagic[8] = {'P','R','G','P','C','A','P','\0'};
 // mip-declaring title replayed single-level.
 // v25 (#1240): each realized/failed draw pipeline retains CB_COLOR_CONTROL.MODE=3 resolve intent in
 // another version-gated tail, keeping every v1-v24 record prefix byte-exact.
-constexpr uint32_t kVersion = 25;
+// v26: retain SPI shader export and SX render-target downconversion formats per draw.
+// v27: retain each draw's raw ShaderDrawModifier and signed GE_INDX_OFFSET. The latter is a draw
+// parameter (Vulkan firstVertex/vertexOffset), not pipeline state; omitting it collapsed distinct
+// ranges of a shared vertex pool onto vertex zero in both live rendering and replay.
+constexpr uint32_t kVersion = 27;
 constexpr uint32_t kEndian = 0x01020304u;
 constexpr uint64_t kMaxFileBytes = 4ull << 30;
 constexpr uint64_t kMaxBlobBytes = 1ull << 30;
@@ -975,6 +979,8 @@ bool capture_submit_items(const std::vector<DrawItem>& draws,
         c.ps = d.ps; c.vertex_count = d.vertex_count;
         c.instance_count = d.instance_count;
         c.raw_draw_count = d.raw_draw_count; c.raw_indexed = d.raw_indexed;   // #1256
+        c.raw_draw_modifier = d.raw_draw_modifier;
+        c.vertex_offset = d.vertex_offset;
         c.indices = d.indices; c.color0_base = d.color0_base;
         c.color0_width = d.color0_width; c.color0_height = d.color0_height;
         c.color1_base = d.color1_base;
@@ -1538,6 +1544,23 @@ bool serialize_gpu_capture(const GpuCaptureFile& c, std::vector<uint8_t>& bytes,
     w.u32(static_cast<uint32_t>(c.failure_diagnostics.size()));
     for (const auto& diagnostic : c.failure_diagnostics)
         if (diagnostic.pipeline_present) w.u8(diagnostic.pipeline.cb_resolve ? 1u : 0u);
+    w.u32(static_cast<uint32_t>(c.draws.size()));
+    for (const auto& draw : c.draws) {
+        w.u32(draw.ps.spi_shader_col_format);
+        w.u32(draw.ps.sx_ps_downconvert);
+    }
+    w.u32(static_cast<uint32_t>(c.failure_diagnostics.size()));
+    for (const auto& diagnostic : c.failure_diagnostics) if (diagnostic.pipeline_present) {
+        w.u32(diagnostic.pipeline.spi_shader_col_format);
+        w.u32(diagnostic.pipeline.sx_ps_downconvert);
+    }
+    // v27: raw draw modifier plus GE_INDX_OFFSET-derived Vulkan draw parameter. Keep this in a
+    // trailing block so v1-v26 prefixes remain byte-exact and older captures default both to zero.
+    w.u32(static_cast<uint32_t>(c.draws.size()));
+    for (const auto& draw : c.draws) {
+        w.u64(draw.raw_draw_modifier);
+        w.u32(static_cast<uint32_t>(draw.vertex_offset));
+    }
     if (w.data.size() > kMaxFileBytes) { error = "capture file exceeds 4 GiB"; return false; }
     bytes = std::move(w.data);
     return true;
@@ -2127,6 +2150,32 @@ bool deserialize_gpu_capture(const std::vector<uint8_t>& bytes, GpuCaptureFile& 
             diagnostic.pipeline.cb_resolve = enabled != 0;
         }
     }
+    if (version >= 26) {
+        uint32_t draw_count = 0;
+        if (!r.u32(draw_count) || draw_count != c.draws.size()) {
+            error = "invalid color-export draw-state count"; return false;
+        }
+        for (auto& draw : c.draws)
+            if (!r.u32(draw.ps.spi_shader_col_format) || !r.u32(draw.ps.sx_ps_downconvert)) return false;
+        uint32_t failure_count = 0;
+        if (!r.u32(failure_count) || failure_count != c.failure_diagnostics.size()) {
+            error = "invalid color-export failure-state count"; return false;
+        }
+        for (auto& diagnostic : c.failure_diagnostics) if (diagnostic.pipeline_present)
+            if (!r.u32(diagnostic.pipeline.spi_shader_col_format) ||
+                !r.u32(diagnostic.pipeline.sx_ps_downconvert)) return false;
+    }
+    if (version >= 27) {
+        uint32_t draw_count = 0;
+        if (!r.u32(draw_count) || draw_count != c.draws.size()) {
+            error = "invalid draw-parameter state count"; return false;
+        }
+        for (auto& draw : c.draws) {
+            uint32_t vertex_offset = 0;
+            if (!r.u64(draw.raw_draw_modifier) || !r.u32(vertex_offset)) return false;
+            draw.vertex_offset = static_cast<int32_t>(vertex_offset);
+        }
+    }
     if (version >= 7 && !validate_failure_diagnostics(c, error)) return false;
     if (r.left) { error = "capture has trailing data"; return false; }
     return true;
@@ -2214,6 +2263,8 @@ bool materialize_gpu_replay(const GpuCaptureFile& c, GpuReplayFrame& out, std::s
         d.ps = x.ps; d.vertex_count = x.vertex_count;
         d.instance_count = x.instance_count;
         d.raw_draw_count = x.raw_draw_count; d.raw_indexed = x.raw_indexed;   // #1256
+        d.raw_draw_modifier = x.raw_draw_modifier;
+        d.vertex_offset = x.vertex_offset;
         d.indices = x.indices; d.color0_base = x.color0_base;
         d.color0_width = x.color0_width; d.color0_height = x.color0_height;
         d.color1_base = x.color1_base;

--- a/prosper/src/gpu/gpu_capture.hpp
+++ b/prosper/src/gpu/gpu_capture.hpp
@@ -75,6 +75,8 @@ struct GpuCapturedDraw {
     // equal raw_draw_count; a divergence is a decode/realization bug (--inspect-only flags it). 0 = unknown.
     uint32_t raw_draw_count = 0;
     bool raw_indexed = false;
+    uint64_t raw_draw_modifier = 0;
+    int32_t vertex_offset = 0;
     std::vector<uint32_t> indices;
     uint64_t color0_base = 0;
     uint32_t color0_width = 0, color0_height = 0;

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -71,6 +71,10 @@ struct DrawItem {
     // persists these so gpu_replay --inspect-only can flag a decode/realization divergence offline.
     uint32_t raw_draw_count = 0;
     bool raw_indexed = false;
+    uint64_t raw_draw_modifier = 0;
+    // GE_INDX_OFFSET at this draw. Vulkan consumes it as firstVertex for non-indexed draws and as
+    // vertexOffset for indexed draws, preserving the hardware gl_VertexIndex contract.
+    int32_t vertex_offset = 0;
     // Indexed draw (sceAgcDcbDrawIndex): the guest index buffer, fetched from 1:1-mapped memory and
     // widened to 32-bit. Non-empty -> the backend must render with vkCmdDrawIndexed (gl_VertexIndex
     // then IS the fetched index, which the recompiled VS uses for its storage-buffer vertex fetch);
@@ -1049,7 +1053,13 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
             // and cap the grown size to the same 256 MB plausibility ceiling the V# decode uses — a VB this
             // large is never real, and an unbounded r.size drives a multi-GB upload (#461). Vertices past
             // the real backing degrade safely (safe_copy stops at the mapping edge -> robust-0).
-            uint64_t need = (uint64_t)vertex_count * r.stride;
+            // A positive GE_INDX_OFFSET selects a later range in the same shared vertex pool. The
+            // capture/backend buffer must include that prefix because gl_VertexIndex includes the
+            // Vulkan firstVertex/vertexOffset value before the translated shader fetches the V#.
+            uint64_t addressed_vertices = vertex_count;
+            const int32_t vertex_offset = static_cast<int32_t>(rs.ge_indx_offset);
+            if (vertex_offset > 0) addressed_vertices += static_cast<uint32_t>(vertex_offset);
+            uint64_t need = addressed_vertices * r.stride;
             if (need > 0x10000000ull) need = 0x10000000ull;   // 256 MB cap
             if ((uint64_t)r.size < need) r.size = (uint32_t)need;
         }
@@ -1139,6 +1149,8 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
     // #1256: record the raw draw-packet state (pre-realization) so a capture can be checked offline for
     // realization divergence. vcount_hint is the DrawIndexAuto/DrawIndex index_count decoded from the guest.
     out.raw_draw_count = vcount_hint; out.raw_indexed = (draw && draw->indexed);
+    out.raw_draw_modifier = draw ? draw->modifier : 0;
+    out.vertex_offset = static_cast<int32_t>(rs.ge_indx_offset);
     // The draw record is authoritative even in folded mode: register state may change after the
     // last draw, while IT_NUM_INSTANCES belongs to the draw at the moment it executes.
     out.instance_count = draw ? draw->instance_count : ds.num_instances;

--- a/prosper/src/gpu/pm4_decode.cpp
+++ b/prosper/src/gpu/pm4_decode.cpp
@@ -135,6 +135,9 @@ size_t decode_pm4(const uint32_t* buf, size_t dwords, std::vector<Pm4Command>& o
                 case R_DRAW_INDEX_AUTO:
                     c.kind = K::DrawIndexAuto;
                     if (npl >= 1) c.index_count = pl[0];
+                    // Custom HLE payload: [0]=count, [1..2]=64-bit ShaderDrawModifier. Legacy
+                    // three-dword hardware/test packets have only count+initiator and retain 0.
+                    if (npl >= 3) c.di_modifier = lo_hi(pl + 1);
                     break;
                 case R_DISPATCH_DIRECT:
                     c.kind = K::DispatchDirect;

--- a/prosper/src/gpu/pm4_decode.hpp
+++ b/prosper/src/gpu/pm4_decode.hpp
@@ -84,9 +84,11 @@ struct Pm4Command {
     uint32_t threads_x = 0, threads_y = 0, threads_z = 0;
     uint64_t dispatch_modifier = 0;          // DispatchDirect modifier bits
 
-    // DrawIndex (sceAgcDcbDrawIndex -> R_DRAW_INDEX, laid out by hle_agc.cpp agc_dcb_draw_index).
-    // Packet payload: [0]=index_count, [1..2]=index-buffer guest address (lo/hi), [3..4]=64-bit draw
-    // modifier (lo/hi). Field roles cross-checked against Kyty: GraphicsDrawIndex (Graphics.cpp:313)
+    // DrawIndex/DrawIndexAuto modifier. Both custom HLE packets retain the shader's trailing
+    // 64-bit ShaderDrawModifier; DrawIndex additionally carries an index-buffer address.
+    // DrawIndex payload: [0]=index_count, [1..2]=index-buffer guest address (lo/hi), [3..4]=64-bit
+    // modifier (lo/hi). DrawIndexAuto payload: [0]=index_count, [1..2]=64-bit modifier (lo/hi).
+    // Field roles cross-checked against Kyty: GraphicsDrawIndex (Graphics.cpp:313)
     // emits exactly cmd[1]=index_count, cmd[2..3]=index_addr lo/hi under R_DRAW_INDEX, and its consumer
     // cp_op_draw_index (GraphicsRun.cpp:2757) reads buffer[0]=index_count, buffer[1..2]=index_addr —
     // CONFIDENCE: HIGH for count/address. [3..4] follows the Gen5 Dcb convention of a trailing 64-bit
@@ -95,7 +97,7 @@ struct Pm4Command {
     // The index ELEMENT SIZE is not in this packet: it comes from the preceding SetIndexType
     // (GpuState::index_type), which the per-draw snapshot already captures.
     uint64_t di_index_addr = 0;          // DrawIndex: guest address of the index buffer
-    uint64_t di_modifier = 0;            // DrawIndex: raw 64-bit draw-modifier bits
+    uint64_t di_modifier = 0;            // DrawIndex/DrawIndexAuto: raw 64-bit draw-modifier bits
     bool     di_valid = false;           // DrawIndex: payload was long enough to carry addr+modifier
 
     // Gen5 indexed-draw state (issue #232). SetIndexBase: [0..1]=index buffer addr lo/hi.

--- a/prosper/src/gpu/pm4_registers.hpp
+++ b/prosper/src/gpu/pm4_registers.hpp
@@ -325,6 +325,7 @@ constexpr uint32_t SPI_SHADER_IDX_FORMAT  = 0x1C2;
 constexpr uint32_t SPI_SHADER_POS_FORMAT  = 0x1C3;
 constexpr uint32_t SPI_SHADER_Z_FORMAT    = 0x1C4;
 constexpr uint32_t SPI_SHADER_COL_FORMAT  = 0x1C5;
+constexpr uint32_t SX_PS_DOWNCONVERT      = 0x1D5;
 constexpr uint32_t CB_BLEND0_CONTROL                            = 0x1E0;
 constexpr uint32_t CB_BLEND1_CONTROL                            = 0x1E1;
 constexpr uint32_t CB_BLEND0_CONTROL_COLOR_SRCBLEND_SHIFT       = 0;

--- a/prosper/src/gpu/render_state.cpp
+++ b/prosper/src/gpu/render_state.cpp
@@ -177,6 +177,7 @@ RenderState extract_render_state(const GpuState& st) {
     // a Uc-class SetRegsIndirect / CreatePrimState's uc[2]), NOT a context register — read it from st.uc.
     // (Reading st.cx left it 0 -> the default PointList topology, so triangles rasterized as ~3 points.)
     rs.prim_type = PM4_FIELD(rd(st.uc, P::VGT_PRIMITIVE_TYPE), VGT_PRIMITIVE_TYPE, PRIM_TYPE);
+    rs.ge_indx_offset = rd(st.uc, P::GE_INDX_OFFSET);
 
     // Depth/stencil test state (decoded fields of DB_DEPTH_CONTROL).
     const uint32_t dc = rd(st.cx, P::DB_DEPTH_CONTROL);
@@ -282,6 +283,10 @@ RenderState extract_render_state(const GpuState& st) {
     // resolved Vulkan write mask intersects both registers so channels the shader does not export
     // preserve their existing attachment contents (AMD RDNA2 EXP EN semantics, Table 56).
     rs.cb_shader_mask    = st.cx.count(P::CB_SHADER_MASK) ? rd(st.cx, P::CB_SHADER_MASK) : 0xFFFFFFFFu;
+    rs.spi_shader_col_format = st.cx.count(P::SPI_SHADER_COL_FORMAT)
+        ? rd(st.cx, P::SPI_SHADER_COL_FORMAT) : 0u;
+    rs.sx_ps_downconvert = st.cx.count(P::SX_PS_DOWNCONVERT)
+        ? rd(st.cx, P::SX_PS_DOWNCONVERT) : 0u;
 
     // Viewport 0 transform (guest floats; all-zero when never programmed).
     rs.vport_xscale  = flt(rd(st.cx, P::PA_CL_VPORT_XSCALE));
@@ -423,6 +428,8 @@ ResolvedPipelineState resolve_pipeline_state(const RenderState& rs) {
         vk_color_format(rs.color0_format, rs.color0_number_type, rs.color0_comp_swap));
     ps.color1_format = rs.color1_format ? static_cast<uint32_t>(
         vk_color_format(rs.color1_format, rs.color1_number_type, rs.color1_comp_swap)) : 0u;
+    ps.spi_shader_col_format = rs.spi_shader_col_format;
+    ps.sx_ps_downconvert = rs.sx_ps_downconvert;
 
     // Fast-clear color: decode the CB_COLOR0_CLEAR_WORD when the game programmed one (#309). A
     // decode miss (no fast-clear, or an unmapped format) leaves has_clear_color false and the

--- a/prosper/src/gpu/render_state.hpp
+++ b/prosper/src/gpu/render_state.hpp
@@ -64,6 +64,9 @@ struct RenderState {
 
     // Primitive topology (VGT_PRIMITIVE_TYPE.PRIM_TYPE).
     uint32_t prim_type = 0;
+    // Signed base vertex/start vertex supplied through the UCONFIG GE_INDX_OFFSET register.
+    // Non-indexed draws pass it as firstVertex; indexed draws pass it as vertexOffset.
+    uint32_t ge_indx_offset = 0;
 
     // Depth/stencil test state, decoded from DB_DEPTH_CONTROL (field shifts/masks from pm4_registers.hpp,
     // matching Kyty hw_ctx_set_depth_control).
@@ -135,6 +138,8 @@ struct RenderState {
     // hardware/command-stream absent-register fallback so adding CB_SHADER_MASK cannot silently
     // turn those otherwise-valid color writes off.
     uint32_t cb_shader_mask    = 0xFFFFFFFFu; // CB_SHADER_MASK (components exported by the pixel shader)
+    uint32_t spi_shader_col_format = 0; // SPI_SHADER_COL_FORMAT (4-bit export format per MRT)
+    uint32_t sx_ps_downconvert = 0;      // SX_PS_DOWNCONVERT (4-bit target conversion per MRT)
     // Rasterizer cull/front-face/polygon mode (PA_SU_SC_MODE_CNTL). An ABSENT register reads 0, which
     // decodes to CULL_NONE + CCW-front + FILL — exactly the prior hardcoded default, so nothing changes
     // for a guest that never programs it. Decoded in resolve to Vk enums (#456).
@@ -166,6 +171,8 @@ RenderState extract_render_state(const GpuState& st);
 struct ResolvedPipelineState {
     uint32_t topology         = 0;   // == VkPrimitiveTopology
     uint32_t color0_format    = 0;   // == VkFormat (0 = VK_FORMAT_UNDEFINED)
+    uint32_t spi_shader_col_format = 0;
+    uint32_t sx_ps_downconvert = 0;
 
     // CB_COLOR_CONTROL.MODE == RESOLVE (3): this draw is a hardware MSAA resolve of the color0 (MSAA)
     // surface into the color1 destination, not an ordinary draw. prosper renders single-sample, so the

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -214,6 +214,7 @@ struct BackendDraw {
     std::vector<FrameResource> R;                              // set-tagged resources (empty -> no descriptors)
     uint32_t vcount = 3;
     uint32_t instance_count = 1;
+    int32_t vertex_offset = 0;
     // Indexed draw: 32-bit index data (the executor widens guest 16-bit indices). Non-empty -> the draw
     // is recorded as vkCmdBindIndexBuffer + vkCmdDrawIndexed(indices.size()), so gl_VertexIndex is the
     // fetched index — exactly what the recompiled VS's storage-buffer vertex fetch expects. Empty ->
@@ -2368,6 +2369,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         VkBuffer ibuf = VK_NULL_HANDLE; VkDeviceMemory ibmem = VK_NULL_HANDLE;   // index buffer (indexed draws)
         VkRect2D scissor{};
         uint32_t n_sets = 1, vcount = 3, icount = 0, instance_count = 1;
+        int32_t vertex_offset = 0;
         bool use_desc = false, ok = false, pipeline_cached = false;
     };
     struct TextureUploadKey {
@@ -2765,6 +2767,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         const prosper::gpu::ResolvedPipelineState* ps = bd.ps;
         v.vcount = bd.vcount;
         v.instance_count = bd.instance_count;
+        v.vertex_offset = bd.vertex_offset;
         v.scissor = {{0, 0}, {W, H}};
         // PROSPER_IGNORE_EMPTY_SCISSOR (#1287 bring-up diagnostic): render draws whose resolved
         // scissor is empty with a full-target scissor instead, to A/B whether they carry the
@@ -4094,9 +4097,10 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         }
         if (v.icount) {
             vkCmdBindIndexBuffer(cmd, v.ibuf, 0, VK_INDEX_TYPE_UINT32);
-            vkCmdDrawIndexed(cmd, v.icount, v.instance_count, 0, 0, 0);
+            vkCmdDrawIndexed(cmd, v.icount, v.instance_count, 0, v.vertex_offset, 0);
         } else {
-            vkCmdDraw(cmd, v.vcount, v.instance_count, 0, 0);
+            vkCmdDraw(cmd, v.vcount, v.instance_count,
+                      static_cast<uint32_t>(v.vertex_offset), 0);
         }
         if (geom_here) { VkDeviceSize coff = 0; p_endxfb(cmd, 0, 1, &geom_counter, &coff); }
         if (ds_active) {
@@ -4552,8 +4556,8 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                 for (size_t di = 0; di < dv.size(); di++) { auto& v = dv[di]; if (!v.ok) continue; if ((int)di == kk) continue;
                     vkCmdBindPipeline(c2, VK_PIPELINE_BIND_POINT_GRAPHICS, v.pipe);
                     if (v.use_desc) vkCmdBindDescriptorSets(c2, VK_PIPELINE_BIND_POINT_GRAPHICS, v.layout, 0, v.n_sets, v.dsets.data(), 0, nullptr);
-                    if (v.icount) { vkCmdBindIndexBuffer(c2, v.ibuf, 0, VK_INDEX_TYPE_UINT32); vkCmdDrawIndexed(c2, v.icount, v.instance_count, 0, 0, 0); }
-                    else vkCmdDraw(c2, v.vcount, v.instance_count, 0, 0);
+                    if (v.icount) { vkCmdBindIndexBuffer(c2, v.ibuf, 0, VK_INDEX_TYPE_UINT32); vkCmdDrawIndexed(c2, v.icount, v.instance_count, 0, v.vertex_offset, 0); }
+                    else vkCmdDraw(c2, v.vcount, v.instance_count, static_cast<uint32_t>(v.vertex_offset), 0);
                 }
                 vkCmdEndRenderPass(c2);
                 vkCmdCopyImageToBuffer(c2, img, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, rb, 1, &cp2);

--- a/prosper/tests/test_command_processor.cpp
+++ b/prosper/tests/test_command_processor.cpp
@@ -73,7 +73,7 @@ int main() {
     setsh_direct(D, pack_reg(0x2C0Du, 0xDDDDDDDDu), 0, 0, 0, 0);
     setuc_direct(D, pack_reg(0x0123u, 0xEEEEEEEEu), 0, 0, 0, 0);
     instances(D, 3, 0, 0, 0, 0);
-    draw(D, 0x0300, 0, 0, 0, 0);
+    draw(D, 0x0300, 0x1122334455667788ull, 0, 0, 0);
     instances(D, 0, 0, 0, 0, 0);
     draw(D, 0x0006, 0, 0, 0, 0);
 
@@ -99,6 +99,8 @@ int main() {
     CHECK(st.index_type == 2, "index_type = 2 (from SetIndexSize)");
 
     CHECK(st.draws.size() == 2, "2 draws recorded");
+    CHECK(st.draws.size() == 2 && st.draws[0].modifier == 0x1122334455667788ull,
+          "DrawIndexAuto retains its ShaderDrawModifier");
     CHECK(st.draws.size() == 2 && st.draws[0].index_count == 0x0300, "draw0 index_count = 0x300");
     CHECK(st.draws.size() == 2 && st.draws[1].index_count == 0x0006, "draw1 index_count = 0x6");
     CHECK(st.draws.size() == 2 && st.draws[0].instance_count == 3 && st.draws[0].state &&

--- a/prosper/tests/test_gpu_capture.cpp
+++ b/prosper/tests/test_gpu_capture.cpp
@@ -81,6 +81,8 @@ int main() {
     draw.fs_guest_addr = reinterpret_cast<uint64_t>(kDiagnosticBadPs);
     draw.vertex_count = 6; draw.instance_count = 3;
     draw.raw_draw_count = 6; draw.raw_indexed = false;   // #1256: raw draw-packet state (v23)
+    draw.raw_draw_modifier = 0x1122334455667788ull;
+    draw.vertex_offset = -37;
     draw.indices = {0, 1, 2, 2, 3, 0}; draw.color0_base = 0x2000;
     draw.color0_width = 1024; draw.color0_height = 32;
     draw.color1_base = 0x3000; draw.color1_width = 1024; draw.color1_height = 32;
@@ -103,6 +105,8 @@ int main() {
     draw.ps.src_alpha_blend_factor1 = 1; draw.ps.dst_alpha_blend_factor1 = 7;
     draw.ps.alpha_blend_op1 = 0; draw.ps.color1_write_mask = 0xf;
     draw.ps.cb_resolve = true;
+    draw.ps.spi_shader_col_format = 4;
+    draw.ps.sx_ps_downconvert = 5;
     draw.ps.has_scissor = true; draw.ps.scissor_left = 12; draw.ps.scissor_top = 19;
     draw.ps.scissor_right = 70; draw.ps.scissor_bottom = 75;
     draw.ps.logic_op_enable = true; draw.ps.logic_op = 6;
@@ -139,6 +143,9 @@ int main() {
           "capture retains the realized draw instance count");
     CHECK(captured.draws[0].raw_draw_count == 6 && !captured.draws[0].raw_indexed,
           "capture retains the raw draw-packet count and indexed flag (#1256)");
+    CHECK(captured.draws[0].raw_draw_modifier == 0x1122334455667788ull &&
+          captured.draws[0].vertex_offset == -37,
+          "capture retains the draw modifier and GE_INDX_OFFSET draw parameter");
     CHECK(captured.raw_shader_versions.size() == 2 &&
           captured.draws[0].vs_raw_shader_index < captured.raw_shader_versions.size() &&
           captured.draws[0].fs_raw_shader_index < captured.raw_shader_versions.size() &&
@@ -200,8 +207,20 @@ int main() {
               scalar_capture.computes[0].resources.resources.empty(),
           "#636: capture ignores unconsumed descriptor-looking scalar arguments");
 
-    // v25 (#1240): byte length of the trailing resolve-state block. Peeled first in each
-    // version-relabel backward-compat chain below (it is the outermost trailing tail).
+    // v27: byte length of the trailing draw-modifier/vertex-offset block.
+    auto v27_tail = [](const GpuCaptureFile& f) -> size_t {
+        return 4 + 12 * f.draws.size();
+    };
+
+    // v26: byte length of the trailing color-export/downconversion block.
+    auto v26_tail = [](const GpuCaptureFile& f) -> size_t {
+        size_t present_failures = 0;
+        for (const auto& diagnostic : f.failure_diagnostics)
+            if (diagnostic.pipeline_present) ++present_failures;
+        return 4 + 8 * f.draws.size() + 4 + 8 * present_failures;
+    };
+
+    // v25 (#1240): byte length of the trailing resolve-state block.
     auto v25_tail = [](const GpuCaptureFile& f) -> size_t {
         size_t present_failures = 0;
         for (const auto& diagnostic : f.failure_diagnostics)
@@ -231,6 +250,8 @@ int main() {
               v16_scissor_bytes.size() >= 25,
           "v17 capture serializes effective guest scissor state");
     if (v16_scissor_bytes.size() >= 25) {
+        v16_scissor_bytes.resize(v16_scissor_bytes.size() - v27_tail(v16_scissor_source));
+        v16_scissor_bytes.resize(v16_scissor_bytes.size() - v26_tail(v16_scissor_source));
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - v25_tail(v16_scissor_source)); // v25 resolve tail
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - v24_tail(v16_scissor_source)); // v24 declared-mip tail
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - 12); // v23 count + one raw-draw-state
@@ -383,6 +404,8 @@ int main() {
           "writer rejects an out-of-bounds DCC metadata reference");
     CHECK(serialize_gpu_capture(volume_capture, volume_bytes, error),
           "recreated valid v12 DCC bytes after malformed-reference check");
+    volume_bytes.resize(volume_bytes.size() - v27_tail(volume_capture));
+    volume_bytes.resize(volume_bytes.size() - v26_tail(volume_capture));
     volume_bytes.resize(volume_bytes.size() - v25_tail(volume_capture)); // v25 resolve tail
     volume_bytes.resize(volume_bytes.size() - v24_tail(volume_capture)); // v24 declared-mip tail
     volume_bytes.resize(volume_bytes.size() - 12); // v23 count + one raw-draw-state
@@ -455,6 +478,8 @@ int main() {
     CHECK(serialize_gpu_capture(captured, v20_bytes, error) && v20_bytes.size() >= 21,
           "v21 capture serializes the logic-op extension");
     if (v20_bytes.size() >= 21) {
+        v20_bytes.resize(v20_bytes.size() - v27_tail(captured));
+        v20_bytes.resize(v20_bytes.size() - v26_tail(captured));
         v20_bytes.resize(v20_bytes.size() - v25_tail(captured)); // v25 resolve tail
         v20_bytes.resize(v20_bytes.size() - v24_tail(captured)); // v24 declared-mip tail
         v20_bytes.resize(v20_bytes.size() - 12); // v23 count + one raw-draw-state
@@ -488,12 +513,20 @@ int main() {
           "v21 framebuffer logic op round-trips explicitly");
     CHECK(loaded.draws[0].ps.cb_resolve,
           "v25 MODE=3 resolve intent round-trips explicitly for gpu_replay");
+    CHECK(loaded.draws[0].ps.spi_shader_col_format == 4 &&
+          loaded.draws[0].ps.sx_ps_downconvert == 5,
+          "v26 color export/downconversion state round-trips explicitly");
+    CHECK(loaded.draws[0].raw_draw_modifier == 0x1122334455667788ull &&
+          loaded.draws[0].vertex_offset == -37,
+          "v27 draw modifier and vertex offset round-trip explicitly");
     std::vector<uint8_t> v24_resolve_bytes;
     GpuCaptureFile v24_resolve_loaded;
     CHECK(serialize_gpu_capture(captured, v24_resolve_bytes, error) &&
-          v24_resolve_bytes.size() >= v25_tail(captured),
+          v24_resolve_bytes.size() >= v27_tail(captured) + v26_tail(captured) + v25_tail(captured),
           "v25 capture exposes a removable trailing resolve-state block");
-    if (v24_resolve_bytes.size() >= v25_tail(captured)) {
+    if (v24_resolve_bytes.size() >= v27_tail(captured) + v26_tail(captured) + v25_tail(captured)) {
+        v24_resolve_bytes.resize(v24_resolve_bytes.size() - v27_tail(captured));
+        v24_resolve_bytes.resize(v24_resolve_bytes.size() - v26_tail(captured));
         v24_resolve_bytes.resize(v24_resolve_bytes.size() - v25_tail(captured));
         v24_resolve_bytes[8] = 24;
         v24_resolve_bytes[9] = v24_resolve_bytes[10] = v24_resolve_bytes[11] = 0;
@@ -584,6 +617,9 @@ int main() {
           "materialized draw retains its source operation identity");
     CHECK(replay.items[0].instance_count == 3,
           "materialized replay retains the draw instance count");
+    CHECK(replay.items[0].raw_draw_modifier == 0x1122334455667788ull &&
+          replay.items[0].vertex_offset == -37,
+          "materialized replay retains its draw modifier and Vulkan vertex offset");
     CHECK(replay.items[0].vs_raw_shader_index == loaded.draws[0].vs_raw_shader_index &&
           replay.items[0].fs_raw_shader_index == loaded.draws[0].fs_raw_shader_index,
           "materialized replay exposes both realized raw-stage identities");
@@ -872,6 +908,8 @@ int main() {
     if (v13_bytes.size() >= 32) {
         const size_t legacy_resource_count = legacy_source.draws[0].vrt.resources.size() +
                                              legacy_source.draws[0].prt.resources.size();
+        v13_bytes.resize(v13_bytes.size() - v27_tail(legacy_source));
+        v13_bytes.resize(v13_bytes.size() - v26_tail(legacy_source));
         v13_bytes.resize(v13_bytes.size() - v25_tail(legacy_source)); // v25 resolve tail
         v13_bytes.resize(v13_bytes.size() - v24_tail(legacy_source)); // v24 declared-mip tail
         v13_bytes.resize(v13_bytes.size() - 12); // v23 count + one raw-draw-state
@@ -897,6 +935,8 @@ int main() {
     if (legacy_bytes.size() >= 32) {
         const size_t legacy_resource_count = legacy_source.draws[0].vrt.resources.size() +
                                              legacy_source.draws[0].prt.resources.size();
+        legacy_bytes.resize(legacy_bytes.size() - v27_tail(legacy_source));
+        legacy_bytes.resize(legacy_bytes.size() - v26_tail(legacy_source));
         legacy_bytes.resize(legacy_bytes.size() - v25_tail(legacy_source)); // v25 resolve tail
         legacy_bytes.resize(legacy_bytes.size() - v24_tail(legacy_source)); // v24 declared-mip tail
         legacy_bytes.resize(legacy_bytes.size() - 12); // v23 count + one raw-draw-state
@@ -948,9 +988,9 @@ int main() {
     CHECK(deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
           !legacy_loaded.failure_diagnostics_available && legacy_loaded.failure_diagnostics.empty(),
           "v6 capture reopens with failed-operation diagnostics reported unavailable");
-    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 26;   // kVersion (25) + 1: a not-yet-defined future version
+    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 28;   // kVersion (27) + 1: a not-yet-defined future version
     CHECK(!deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
-          error == "unsupported capture version 26",
+          error == "unsupported capture version 28",
           "future capture versions fail with a concrete version error");
 
     GpuCaptureFile bad_hash = mixed;

--- a/prosper/tests/test_gpu_execute.cpp
+++ b/prosper/tests/test_gpu_execute.cpp
@@ -96,6 +96,18 @@ int main() {
     CHECK(green == total, "GpuState -> executor -> GREEN frame (full recompile+resolve+render spine)");
     CHECK(realized_draw.instance_count == 4,
           "draw realization retains the folded hardware instance count");
+    {
+        GpuState offset_state = st;
+        offset_state.uc[P::GE_INDX_OFFSET] = 37;
+        offset_state.draws[0].modifier = 0x1122334455667788ull;
+        DrawItem offset_item;
+        const bool made_offset = realize_draw_item(
+            offset_state, &offset_state.draws[0], offset_state.draws[0].index_count,
+            0x10000u, false, offset_item);
+        CHECK(made_offset && offset_item.vertex_offset == 37 &&
+              offset_item.raw_draw_modifier == 0x1122334455667788ull,
+              "draw realization retains GE_INDX_OFFSET and the raw ShaderDrawModifier");
+    }
 
     // DCC_DECOMPRESS binds a graphics helper whose color export is interpreted by the hardware as a
     // metadata operation. Prosper stores only materialized Vulkan color, so realization substitutes
@@ -432,6 +444,7 @@ int main() {
         prosper::test::BackendDraw d;
         d.vs = items[0].vs_words(); d.fs = items[0].fs_words(); d.ps = &items[0].ps;
         d.vcount = items[0].vertex_count; d.indices = items[0].indices;
+        d.vertex_offset = items[0].vertex_offset;
         return prosper::test::render_draws_rgba({std::move(d)}, W, H);
     };
     static const uint16_t kIdx012[3] = {0, 1, 2};

--- a/prosper/tests/test_indexed_render.cpp
+++ b/prosper/tests/test_indexed_render.cpp
@@ -57,9 +57,10 @@ int main() {
         return g == 9u;
     };
     auto draw_of = [&](const std::vector<uint32_t>& vbuf, const ResolvedPipelineState* st,
-                       uint32_t vcount, std::vector<uint32_t> idx) {
+                       uint32_t vcount, std::vector<uint32_t> idx, int32_t vertex_offset = 0) {
         prosper::test::BackendDraw d;
         d.vs = vert; d.fs = frag; d.ps = st; d.vcount = vcount; d.indices = std::move(idx);
+        d.vertex_offset = vertex_offset;
         prosper::test::FrameResource r; r.binding = 3; r.set = 0; r.dwords = vbuf;
         d.R.push_back(std::move(r));
         return d;
@@ -95,6 +96,17 @@ int main() {
         { draw_of(vbufB, &list_ps, 3, {}) }, W, H);
     CHECK(px_noidx.size() == (size_t)W*H*4 && px_noidx != px_tri,
           "dropping the indices changes the picture (indices are really applied)");
+
+    // --- Case C: GE_INDX_OFFSET reaches both Vulkan draw variants. The same shared pool can select
+    // records 1..3 either with non-indexed firstVertex=1 or indexed vertexOffset=1.
+    std::vector<uint8_t> px_first_vertex = prosper::test::render_draws_rgba(
+        { draw_of(vbufB, &list_ps, 3, {}, 1) }, W, H);
+    CHECK(px_first_vertex.size() == (size_t)W*H*4 && greenAt9(px_first_vertex),
+          "non-indexed firstVertex selects records 1..3 from a shared vertex pool");
+    std::vector<uint8_t> px_vertex_offset = prosper::test::render_draws_rgba(
+        { draw_of(vbufB, &list_ps, 3, {0,1,2}, 1) }, W, H);
+    CHECK(px_vertex_offset.size() == (size_t)W*H*4 && greenAt9(px_vertex_offset),
+          "indexed vertexOffset selects records 1..3 from a shared vertex pool");
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");

--- a/prosper/tests/test_pm4_decode.cpp
+++ b/prosper/tests/test_pm4_decode.cpp
@@ -70,7 +70,7 @@ int main() {
     setsh_direct(D, pack_reg(0x200, 0x22222222), 0, 0, 0, 0);
     setuc_direct(D, pack_reg(0x300, 0x33333333), 0, 0, 0, 0);
     instances(D, 7, 0, 0, 0, 0);
-    draw(D, /*index_count*/ 0x1234, 0, 0, 0, 0);
+    draw(D, /*index_count*/ 0x1234, /*modifier*/ 0x1122334455667788ull, 0, 0, 0);
     drawi(D, /*index_count*/ 0x0600, /*indices*/ 0xDEAD0000BEEF0040ull, /*modifier*/ 0x40000000ull, 0, 0);
     evt(D, /*event_type*/ 0x42, /*address*/ 0x1400ABCD00ull, 0, 0, 0);
     pop(D, 0, 0, 0, 0, 0);
@@ -113,6 +113,8 @@ int main() {
     CHECK(ops[7].kind == K::SetNumInstances && ops[7].instance_count == 7,
           "op7 = SetNumInstances(7)");
     CHECK(ops[8].kind == K::DrawIndexAuto && ops[8].index_count == 0x1234, "op8 = DrawIndexAuto(0x1234)");
+    CHECK(ops[8].di_modifier == 0x1122334455667788ull,
+          "op8 DrawIndexAuto modifier round-trips");
 
     // DrawIndex round-trip (issue #63): the builder wrote [1]=count, [2..3]=index addr, [4..5]=modifier;
     // the decoder must hand every field back (indexed draws were previously dropped as unknown NOPs).

--- a/prosper/tests/test_render_state.cpp
+++ b/prosper/tests/test_render_state.cpp
@@ -126,6 +126,8 @@ int main() {
         { P::CB_BLEND1_CONTROL,  (1u << 30) | (1u << 0) | (5u << 8) | (0u << 5) },
         { P::CB_TARGET_MASK,     0x000000FFu },
         { P::CB_SHADER_MASK,     0x000000F3u },
+        { P::SPI_SHADER_COL_FORMAT, 0x00000004u },
+        { P::SX_PS_DOWNCONVERT,     0x00000005u },
         // CB fast-clear (#309): CLEAR_WORD0 holds one texel in the surface's 8_8_8_8 format.
         { P::CB_COLOR0_CLEAR_WORD0, 0x11223344u },
         { P::CB_COLOR0_CLEAR_WORD1, 0x00000000u },
@@ -158,7 +160,10 @@ int main() {
     uint32_t buffer[256]; memset(buffer, 0, sizeof buffer);
     Dcb dcb{}; dcb.bottom = buffer; dcb.top = buffer + 256; dcb.cursor_up = buffer; dcb.cursor_down = buffer + 256;
     auto D = (uint64_t)(uintptr_t)&dcb;
-    ShaderReg uc_regs[] = { { P::VGT_PRIMITIVE_TYPE, 0x00000004u } };   // PRIM_TYPE = 4 (uconfig register)
+    ShaderReg uc_regs[] = {
+        { P::VGT_PRIMITIVE_TYPE, 0x00000004u }, // PRIM_TYPE = 4 (uconfig register)
+        { P::GE_INDX_OFFSET, 0xFFFFFFF9u },      // signed vertex offset = -7
+    };
     setcx(D, (uint64_t)(uintptr_t)cx_regs, sizeof(cx_regs)/sizeof(cx_regs[0]), 0, 0, 0);
     setsh(D, (uint64_t)(uintptr_t)sh_regs, sizeof(sh_regs)/sizeof(sh_regs[0]), 0, 0, 0);
     setuc(D, (uint64_t)(uintptr_t)uc_regs, sizeof(uc_regs)/sizeof(uc_regs[0]), 0, 0, 0);
@@ -170,11 +175,17 @@ int main() {
     CHECK(rs.ps_addr == rdna2_addr(0x00ABCDEFu, 0x12u), "PS shader addr = (LO<<8)|(HI<<40)");
     CHECK(rs.es_addr == rdna2_addr(0x00111111u, 0x34u), "ES shader addr = (LO<<8)|(HI<<40)");
     CHECK(rs.gs_addr == 0 && rs.hs_addr == 0, "unset GS/HS shader addrs are 0");
+    CHECK(static_cast<int32_t>(rs.ge_indx_offset) == -7,
+          "signed GE_INDX_OFFSET survives render-state extraction");
     CHECK(rs.ps_input_cntl_valid_mask == 0x3u &&
           rs.ps_input_cntl[0] == 0x00000401u && rs.ps_input_cntl[1] == 0x00000320u,
           "programmed SPI_PS_INPUT_CNTL words and presence mask are retained");
     CHECK(rs.ps_input_ena == 0x00000303u && rs.ps_input_addr == 0x000003CFu,
           "SPI_PS_INPUT_ENA/ADDR system-value VGPR controls are retained");
+    CHECK(rs.spi_shader_col_format == 4u && rs.sx_ps_downconvert == 5u &&
+          resolve_pipeline_state(rs).spi_shader_col_format == 4u &&
+          resolve_pipeline_state(rs).sx_ps_downconvert == 5u,
+          "pixel export and render-target downconversion formats survive resolution");
     CHECK(rs.has_scissor && rs.scissor_left == 12 && rs.scissor_top == 19 &&
           rs.scissor_right == 70 && rs.scissor_bottom == 75,
           "screen/window/generic/enabled-viewport scissors intersect with per-rectangle offsets");

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -49,8 +49,9 @@ Create a capsule with the native-speed workflow in
 
 ## Raw-vs-realized draw check — `raw=` on each `--inspect-only` draw line (#1256)
 
-Each `draw[i] … vcount=N indices=M topo=T raw=…` line reports the **raw draw-packet state** the guest
-submitted, decoded BEFORE realization (capture v23+):
+Each `draw[i] … vcount=N indices=M voffset=V modifier=D topo=T raw=…` line reports the **raw
+draw-packet state** the guest submitted, decoded BEFORE realization. `raw=` is available in capture
+v23+, while `voffset=` and `modifier=` are available in capture v27+:
 
 ```
 draw[12] … vcount=6 indices=0 topo=3 raw=6              # healthy: realized == guest's DrawIndexAuto count
@@ -63,6 +64,9 @@ draw[12] … vcount=1024 indices=0 topo=3 raw=6 [INFLATED] # realized swept more
 - **indexed**: `raw=N(idx)`; the fetched index count (`indices=`) must equal `N`, else `[INDEX-COUNT-MISMATCH]`
   (also fires when an indexed draw fell back to non-indexed on an unreadable index buffer — a real signal).
 - `raw=?` = a pre-v23 capture (the raw count was not retained). No flag is possible for those.
+- `voffset=V` is the signed `GE_INDX_OFFSET` applied as Vulkan `firstVertex` for non-indexed draws or
+  `vertexOffset` for indexed draws. Pre-v27 captures report zero because they did not retain it.
+- `modifier=D` is the raw 64-bit `ShaderDrawModifier`, retained for offline decode diagnostics in v27+.
 
 This makes a whole class of decode/realization-divergence bug — where prosper renders geometry the guest did
 not ask for — visible **offline** from a capsule, without a live boot. It was added because #1163 (the black

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -337,21 +337,23 @@ void inspect_frame(const prosper::gpu::GpuReplayFrame& replay) {
                           : d.vertex_count < d.raw_draw_count   ? " [DIVERGENT]" : "");
         }
         std::printf("draw[%zu] source=%llu target=%016llx extent=%ux%u fmt=%u cwm=%x "
-                    "target1=%016llx extent1=%ux%u fmt1=%u cwm1=%x vcount=%u indices=%zu topo=%u%s "
+                    "target1=%016llx extent1=%ux%u fmt1=%u cwm1=%x vcount=%u indices=%zu voffset=%d modifier=%016llx topo=%u%s "
                     "depth=%d/%d/%u stencil=%d blend=%d raster=%u/%u/%u viewport=%d %.1f,%.1f %.1fx%.1f "
-                    "scissor=%d [%d,%d)-[%d,%d) "
+                    "scissor=%d [%d,%d)-[%d,%d) export=%08x downconvert=%08x "
                     "vs=%zu/%016llx fs=%zu/%016llx\n",
                     i, static_cast<unsigned long long>(d.draw_index),
                     static_cast<unsigned long long>(d.color0_base), d.color0_width, d.color0_height,
                     d.ps.color0_format, d.ps.color_write_mask,
                     static_cast<unsigned long long>(d.color1_base), d.color1_width, d.color1_height,
                     d.ps.color1_format, d.ps.color1_write_mask, d.vertex_count, d.indices.size(),
+                    d.vertex_offset, static_cast<unsigned long long>(d.raw_draw_modifier),
                     d.ps.topology, rawtag, d.ps.depth_test_enable,
                     d.ps.depth_write_enable, d.ps.depth_compare_op, d.ps.stencil_enable, d.ps.blend_enable,
                     d.ps.cull_mode, d.ps.front_face, d.ps.polygon_mode,
                     d.ps.has_viewport, d.ps.viewport_x, d.ps.viewport_y, d.ps.viewport_w, d.ps.viewport_h,
                     d.ps.has_scissor, d.ps.scissor_left, d.ps.scissor_top,
                     d.ps.scissor_right, d.ps.scissor_bottom,
+                    d.ps.spi_shader_col_format, d.ps.sx_ps_downconvert,
                     d.vs.size(), static_cast<unsigned long long>(prosper::gpu::gpu_capture_hash(
                         reinterpret_cast<const uint8_t*>(d.vs.data()), d.vs.size() * 4)),
                     d.fs.size(), static_cast<unsigned long long>(prosper::gpu::gpu_capture_hash(
@@ -359,9 +361,10 @@ void inspect_frame(const prosper::gpu::GpuReplayFrame& replay) {
         // Blend detail: UI compositing correctness hangs on the exact color AND alpha factor
         // programming (a separate-alpha UI backdrop writes a different alpha than its color
         // factors imply — #320's dialogue overlay), so make the full equation inspectable.
-        std::printf("  blend color=%u,%u op=%u alpha=%u,%u aop=%u\n",
+        std::printf("  blend color=%u,%u op=%u alpha=%u,%u aop=%u logic=%d/%u\n",
                     d.ps.src_color_blend_factor, d.ps.dst_color_blend_factor, d.ps.color_blend_op,
-                    d.ps.src_alpha_blend_factor, d.ps.dst_alpha_blend_factor, d.ps.alpha_blend_op);
+                    d.ps.src_alpha_blend_factor, d.ps.dst_alpha_blend_factor, d.ps.alpha_blend_op,
+                    d.ps.logic_op_enable, d.ps.logic_op);
         std::printf("  stencil clear=%u cmp=%u/%u fail=%u/%u pass=%u/%u zfail=%u/%u "
                     "ref=%u/%u opval=%u/%u cmask=%02x/%02x wmask=%02x/%02x\n",
                     d.ps.stencil_clear_value, d.ps.stencil_compare_op[0], d.ps.stencil_compare_op[1],


### PR DESCRIPTION
## What changed

- Decode and retain `ShaderDrawModifier` for `DrawIndexAuto` packets.
- Extract `GE_INDX_OFFSET` per draw and pass it to Vulkan as `firstVertex` or indexed `vertexOffset`.
- Expand captured vertex-buffer ranges to include positive base-vertex prefixes.
- Bump GPU capture to v27 so replay retains the raw draw modifier and signed vertex offset; expose both through `--inspect-only`.
- Retain color-export/downconversion state needed while diagnosing captures.
- Add PM4, command processor, render-state, capture compatibility, executor, and real Vulkan draw tests.

## Root cause

GTA V changes `GE_INDX_OFFSET` while drawing from shared vertex pools. Prosper discarded the register and submitted every Vulkan draw with a zero vertex offset, so unrelated UI passes fetched the same vertex records and collapsed onto each other. Older captures also omitted the value, preventing faithful offline replay.

## Validation

- User visually confirmed the live GTA V title and menu rendering is corrected.
- Ordinary v27 bundle replay: 46/46 operations, hash `ab7fe6d6f769b3ba`, 3840×2160 output.
- `test_pm4_decode`, `test_command_processor`, `test_render_state`, `test_gpu_capture`, `test_gpu_execute`, and `test_indexed_render` pass.
- Full snapshot gate passes: Messenger, Evergate title/gameplay, Dead Cells gameplay, Blasphemous 2 gameplay, and Terminator boot.
- `git diff --check` passes.