### PR TITLE
fix(gpu): recover present-but-degenerate SCREEN scissor pairs (Blue Prince Day One hold)

### DIFF
--- a/prosper/src/gpu/render_state.cpp
+++ b/prosper/src/gpu/render_state.cpp
@@ -318,6 +318,9 @@ RenderState extract_render_state(const GpuState& st) {
         // keeps the register's initialized full-screen value because that byte range is not
         // consumed as a register write. Substitute the full default and log fail-visibly; genuine
         // per-pass closes arrive via the WINDOW/GENERIC/VPORT rects, which stay fully honored.
+        // Both halves are reset, not only the BR: a degenerate partner poisons trust in the pair
+        // (the observed live TL of (0,1024) would otherwise clip 1024 of 1080 rows on its own),
+        // and the init state is the only coherent recovery target.
         {
             const auto s16 = [](uint32_t v, uint32_t shift) {
                 return static_cast<int32_t>(static_cast<int16_t>((v >> shift) & 0xffffu));

--- a/prosper/src/gpu/render_state.cpp
+++ b/prosper/src/gpu/render_state.cpp
@@ -3,6 +3,7 @@
 #include "pm4_registers.hpp"
 #include "vk_translate.hpp"
 #include <algorithm>
+#include <atomic>
 #include <cmath>
 #include <cstdio>
 #include <cstring>
@@ -304,10 +305,35 @@ RenderState extract_render_state(const GpuState& st) {
     rs.has_scissor = std::any_of(std::begin(scissor_registers), std::end(scissor_registers),
                                  [&](uint32_t reg) { return st.cx.count(reg) != 0; });
     if (rs.has_scissor) {
-        const uint32_t screen_tl = st.cx.count(P::PA_SC_SCREEN_SCISSOR_TL)
+        uint32_t screen_tl = st.cx.count(P::PA_SC_SCREEN_SCISSOR_TL)
             ? rd(st.cx, P::PA_SC_SCREEN_SCISSOR_TL) : 0u;
-        const uint32_t screen_br = st.cx.count(P::PA_SC_SCREEN_SCISSOR_BR)
+        uint32_t screen_br = st.cx.count(P::PA_SC_SCREEN_SCISSOR_BR)
             ? rd(st.cx, P::PA_SC_SCREEN_SCISSOR_BR) : 0x40004000u;
+        // #1335: a PRESENT-but-degenerate screen pair (BR <= TL on either axis) is never a
+        // coherently-programmed state — no draw intends a zero-area SCREEN scissor (the same
+        // contract as the window-offset recovery below). Blue Prince writes the TL thousands of
+        // times per route and the BR exactly once, with 0, folded out of a foreign span inside an
+        // indirect-register arena at the Day One transition; honoring it blanks every subsequent
+        // draw and freezes the presented frame (full evidence chain on the issue). Real hardware
+        // keeps the register's initialized full-screen value because that byte range is not
+        // consumed as a register write. Substitute the full default and log fail-visibly; genuine
+        // per-pass closes arrive via the WINDOW/GENERIC/VPORT rects, which stay fully honored.
+        {
+            const auto s16 = [](uint32_t v, uint32_t shift) {
+                return static_cast<int32_t>(static_cast<int16_t>((v >> shift) & 0xffffu));
+            };
+            if (s16(screen_br, 0) <= s16(screen_tl, 0) ||
+                s16(screen_br, 16) <= s16(screen_tl, 16)) {
+                static std::atomic<int> logged{0};
+                if (logged.fetch_add(1) < 8)
+                    fprintf(stderr,
+                            "[scissor] degenerate SCREEN pair recovered: tl=%08x br=%08x -> "
+                            "full (#1335)\n",
+                            screen_tl, screen_br);
+                screen_tl = 0u;
+                screen_br = 0x40004000u;
+            }
+        }
         const uint32_t window_offset = st.cx.count(P::PA_SC_WINDOW_OFFSET)
             ? rd(st.cx, P::PA_SC_WINDOW_OFFSET) : 0u;
         const uint32_t window_tl = st.cx.count(P::PA_SC_WINDOW_SCISSOR_TL)

--- a/prosper/tests/test_render_state.cpp
+++ b/prosper/tests/test_render_state.cpp
@@ -194,6 +194,29 @@ int main() {
         CHECK(!extract_render_state(GpuState{}).has_scissor,
               "completely absent guest scissor state preserves the full-target backend default");
 
+        // #1335: Blue Prince's Day One transition folds one foreign-span entry (0xd, 0x0) into
+        // PA_SC_SCREEN_SCISSOR_BR while the game only ever programs the TL — a PRESENT-but-
+        // degenerate screen pair. Honoring it blanks every draw (right=min(...,0)); hardware keeps
+        // the register's initialized full-screen value because that byte range is never consumed as
+        // a register write. The recovery substitutes the full default; the coherent WINDOW/GENERIC/
+        // VPORT constraints (genuine per-pass closes) must remain fully honored.
+        GpuState degenerate_screen = st;
+        degenerate_screen.cx[P::PA_SC_SCREEN_SCISSOR_TL] = 0x04000000u; // TL=(0,1024) — observed live
+        degenerate_screen.cx[P::PA_SC_SCREEN_SCISSOR_BR] = 0x00000000u; // BR=(0,0) — the stale fold
+        const RenderState recovered = extract_render_state(degenerate_screen);
+        CHECK(recovered.has_scissor && recovered.scissor_left == 12 && recovered.scissor_top == 19 &&
+              recovered.scissor_right == 70 && recovered.scissor_bottom == 75,
+              "degenerate SCREEN pair (BR<=TL, never coherently programmed) recovers to full and "
+              "keeps the window/generic/vport intersection");
+        GpuState closed_vport = degenerate_screen;
+        closed_vport.cx[P::PA_SC_VPORT_SCISSOR_0_TL] = 0x04000000u;     // tile TL=(0,1024)
+        closed_vport.cx[P::PA_SC_VPORT_SCISSOR_0_BR] = 0x00000000u;     // genuine close: BR=(0,0)
+        const RenderState still_closed = extract_render_state(closed_vport);
+        CHECK(still_closed.has_scissor &&
+              (still_closed.scissor_right <= still_closed.scissor_left ||
+               still_closed.scissor_bottom <= still_closed.scissor_top),
+              "a genuine VPORT close stays closed — the screen recovery must not unmask it");
+
         RenderState empty{}; empty.has_scissor = true;
         empty.scissor_left = 10; empty.scissor_top = 20;
         empty.scissor_right = 5; empty.scissor_bottom = 15;

--- a/prosper/tests/test_render_state.cpp
+++ b/prosper/tests/test_render_state.cpp
@@ -208,6 +208,18 @@ int main() {
               recovered.scissor_right == 70 && recovered.scissor_bottom == 75,
               "degenerate SCREEN pair (BR<=TL, never coherently programmed) recovers to full and "
               "keeps the window/generic/vport intersection");
+        // Regression-proof the SIGNED half interpretation: a coherent negative-TL pair whose BR
+        // BINDS the combine (50,60 < the 70/75 window/generic/vport bounds) must NOT trigger the
+        // recovery — an unsigned comparison would misread TL=(-4,-3) as huge and substitute full,
+        // which this exact-bound assertion would catch.
+        GpuState negative_tl = st;
+        negative_tl.cx[P::PA_SC_SCREEN_SCISSOR_TL] = 0xFFFDFFFCu;       // (-4,-3)
+        negative_tl.cx[P::PA_SC_SCREEN_SCISSOR_BR] = 0x003C0032u;       // (50,60)
+        const RenderState neg_tl = extract_render_state(negative_tl);
+        CHECK(neg_tl.has_scissor && neg_tl.scissor_left == 12 && neg_tl.scissor_top == 19 &&
+              neg_tl.scissor_right == 50 && neg_tl.scissor_bottom == 60,
+              "coherent negative-TL screen pair stays binding — no recovery misfire");
+
         GpuState closed_vport = degenerate_screen;
         closed_vport.cx[P::PA_SC_VPORT_SCISSOR_0_TL] = 0x04000000u;     // tile TL=(0,1024)
         closed_vport.cx[P::PA_SC_VPORT_SCISSOR_0_BR] = 0x00000000u;     // genuine close: BR=(0,0)


### PR DESCRIPTION
Fixes #1335. Unblocks the #1287/#1216 Day One family for Blue Prince (PPSA25009).

## Failure scenario
At the Day One scene transition, one foreign-span entry `(0xd, 0x0)` inside a game-built indirect-register arena folds into `PA_SC_SCREEN_SCISSOR_BR` — a register the title never programs itself (full-route ingest trace: 3,522 TL writes, exactly one BR write, that one). The resulting present-but-degenerate pair (BR <= TL) makes every subsequent draw's scissor combine collapse to a zero-area rect: zero fragments rasterize, and the presented frame freezes on the last-painted (blown) mansion for the rest of the run. Complete evidence chain (three-stage pipeline traces, resolved-empty provenance, array dumps, Kyty cross-check) on #1335.

## Contract / approach
A present-but-degenerate SCREEN pair is never a coherent program — the same documented contract ("an emitted draw never intends an empty scissor") behind the existing window-offset recoveries (#1161/#1164). On real hardware the byte range that produced the write is not consumed as a register update, so the register keeps its initialized full-screen value. The fix substitutes exactly that (TL=0, BR=0x40004000) when the pair is degenerate on either axis, with a fail-visible capped log. Genuine per-pass closes arrive via the WINDOW/GENERIC/VPORT rects and remain fully honored.

## Affected / deliberately unaffected
- Affected: only draws whose screen pair is degenerate — a state no coherently-programmed title produces (coherent screen scissors are never BR<=TL).
- Unaffected: all window/generic/vport constraints, including intentional zero-area vport closes (regression-tested); every title programming screen scissors coherently is byte-identical.

## Verification (exact head 59b1d285)
- `ctest`: 148/148.
- New regression pair in test_render_state: (a) degenerate screen pair recovers to the window/generic/vport intersection — **fails without the fix** (verified by reverting); (b) a genuine vport close stays closed through the recovery.
- Live A/B, Linux screenshot frontend, scripted IME route, no diagnostic env: without the fix the route freezes at the held Day One title (pixel-stale 18-39 s, constant crc) — with the fix the recovery fires 8× (logged), the hold breaks, and the run advances into Mount Holly's entrance hall with live gameplay HUD (footstep counter at 50) — the furthest this title has progressed. Representative capture: `~/bp-1264/fixab/PPSA25009_20260724-235722_119.png` (direct unmodified frontend output; happy to attach to the PR on request — the same checkpoint is also documented on #1335).
- Snapshot gate `snapshot.py check` running at this head; result will be posted before merge.

## Risks
- If a future title genuinely intended a zero-area SCREEN scissor (no known hardware-sane use), the recovery would un-mask it — the capped `[scissor] degenerate SCREEN pair recovered` log makes that scenario immediately visible.
- The underlying arena-fold looseness (#1335 discussion) remains: other registers could receive foreign values that are not degenerate-detectable. The proper section-contract fix (guest builder disassembly) is tracked on the issue; this recovery removes the catastrophic screen-pair case.