### PR TITLE
fix(gpu): honor linear texture row pitch

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -196,6 +196,7 @@ struct TextureDecodeKey {
     uint32_t num_components = 0;
     uint32_t width = 0, height = 0, depth = 1;
     uint32_t tile_mode = 0;
+    uint32_t linear_row_pitch_bytes = 0;
     uint32_t img_dim = 0;
     uint32_t max_uncompressed_block_size = 0, max_compressed_block_size = 0;
     uint32_t dcc_flags = 0;
@@ -216,7 +217,8 @@ struct TextureDecodeKeyHash {
         };
         mix(key.gpu_addr); mix(key.host_data); mix(key.host_data_size); mix(key.size);
         mix(key.cls); mix(key.format); mix(key.num_components); mix(key.width); mix(key.height); mix(key.depth);
-        mix(key.tile_mode); mix(key.img_dim); mix(key.max_uncompressed_block_size);
+        mix(key.tile_mode); mix(key.linear_row_pitch_bytes); mix(key.img_dim);
+        mix(key.max_uncompressed_block_size);
         mix(key.max_compressed_block_size); mix(key.dcc_flags); mix(key.metadata_addr);
         mix(key.metadata_host_data); mix(key.metadata_host_data_size);
         return hash;
@@ -921,7 +923,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             r.gpu_addr, static_cast<uint64_t>(reinterpret_cast<uintptr_t>(r.host_data)),
                             r.host_data_size, r.size, static_cast<uint32_t>(r.cls),
                             static_cast<uint32_t>(r.format), r.num_components, tw, th, r.depth,
-                            r.tile_mode, r.img_dim,
+                            r.tile_mode, r.linear_row_pitch_bytes, r.img_dim,
                             r.compression_enabled ? r.max_uncompressed_block_size : 0u,
                             r.compression_enabled ? r.max_compressed_block_size : 0u,
                             r.compression_enabled
@@ -1015,6 +1017,17 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         const bool persistent_fp16_texture =
                             r.format == prosper::gpu::DataFormat::Float16 &&
                             (r.num_components == 1 || r.num_components == 2 || r.num_components == 4);
+                        // Real source bytes per texel. It also determines the pitch of a guest-backed
+                        // linear sampled image: GFX10 aligns those rows to 256 bytes independently of
+                        // component count (e.g. a 1920-wide R8 video chroma plane has a 2048-byte row).
+                        uint32_t sampled_source_bpt =
+                            prosper::gpu::data_format_bytes(r.format) *
+                            (r.num_components ? r.num_components : 1u);
+                        const bool sampled_source_f16 =
+                            r.format == prosper::gpu::DataFormat::Float16 &&
+                            (sampled_source_bpt == 2 || sampled_source_bpt == 4 || sampled_source_bpt == 8);
+                        if (sampled_source_bpt == 0 ||
+                            (sampled_source_bpt > 4 && !sampled_source_f16)) sampled_source_bpt = 4;
                         const bool persistent_sampled_texture =
                             !has_live_rtt && !r.host_data && r.img_dim == 1u &&
                             r.cls == RC::Texture &&
@@ -1023,23 +1036,29 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         const bool persistent_source_is_tiled =
                             persistent_sampled_texture && !getenv("PROSPER_NODETILE") &&
                             prosper::gpu::tile_mode_is_tiled(r.tile_mode);
-                        // A sampled LINEAR (tile_mode 0) 2D surface whose tight row (tw*4) is not 256-aligned
+                        // A sampled LINEAR (tile_mode 0) 2D surface whose tight row is not 256-aligned
                         // is pitch-padded: RDNA2 requires a sampled linear texture's row pitch to be aligned
-                        // (256 B here), so its real pitch is align(tw*4,256). The RGBA8 decode below must read
-                        // it row-by-row at that pitch (else every row drifts -> horizontal scramble, e.g.
-                        // Dead Cells' 348-wide Motion Twin splash whose real pitch is 384 texels). Guards keep
+                        // (256 B here), so its real pitch is align(tw*bytes_per_texel,256). The decode
+                        // below must read it row-by-row at that pitch (else every row drifts -> horizontal
+                        // scramble, e.g. Dead Cells' 348-wide Motion Twin splash whose real pitch is 384
+                        // texels). Guards keep
                         // this narrow and regression-safe: 2D only (volume/cube layouts untouched); tile_mode
                         // == 0 exactly, so unrecognized/actually-tiled modes are NOT strided (they fall to the
                         // contiguous read + auto-detile pass); !host_data, so CPU-uploaded tightly-packed
-                        // pixels (test fixtures, staged uploads) are read contiguously. The tightly-packed
+                        // pixels (test fixtures, staged uploads) are read contiguously unless capture replay
+                        // supplies an explicit guest-layout pitch. The tightly-packed
                         // LINEAR_GENERAL layout is a buffer/copy layout, not a sampled-texture layout, so it
                         // does not reach here. r.size is the TIGHT extent (tw*th*bpp), so it cannot gate this.
-                        const size_t linear_dst_row = (size_t)tw * 4;
-                        size_t linear_src_row = (linear_dst_row + 255) & ~size_t(255);
+                        const size_t linear_dst_row = (size_t)tw * sampled_source_bpt;
+                        size_t linear_src_row = r.linear_row_pitch_bytes
+                            ? r.linear_row_pitch_bytes
+                            : prosper::gpu::linear_sampled_row_pitch(tw, sampled_source_bpt);
                         if (const char* lp = getenv("PROSPER_LINPITCH"))
-                            linear_src_row = (size_t)strtoull(lp, nullptr, 0) * 4;
+                            linear_src_row = (size_t)strtoull(lp, nullptr, 0) * sampled_source_bpt;
                         const bool linear_padded_read =
-                            r.cls == RC::Texture && r.img_dim == 1u && r.tile_mode == 0 && !r.host_data &&
+                            r.cls == RC::Texture && r.img_dim == 1u && r.tile_mode == 0 &&
+                            (!r.host_data || r.linear_row_pitch_bytes != 0) &&
+                            !r.compression_enabled && persistent_bc_block_bytes == 0 &&
                             linear_dst_row != 0 && linear_src_row > linear_dst_row;
                         const bool persistent_source_matches_pixels =
                             persistent_unorm8_texture && r.num_components == 4 && !linear_padded_read &&
@@ -1067,6 +1086,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             // always reads exactly tw*th*source_bpt and must NOT be excluded.
                             if (persistent_unorm8_texture && source_bpt == 4 &&
                                 !persistent_source_matches_pixels) return size_t{0};
+                            if (linear_padded_read) return linear_src_row * th;
                             return static_cast<size_t>(tw) * th * source_bpt;
                         }();
                         const bool persistent_cache_eligible = !fr.is_storage_image &&
@@ -1409,6 +1429,17 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         if (texstore_used == texstore.size()) texstore.emplace_back();
                         std::vector<uint8_t>& texture_pixels = texstore[texstore_used++];
                         texture_pixels.resize(nb);
+                        auto copy_linear_padded_rows = [&](uint8_t* dst, size_t dst_row) {
+                            size_t total = 0;
+                            for (uint32_t y = 0; y < th; ++y) {
+                                uint8_t* drow = dst + (size_t)y * dst_row;
+                                const size_t got = copy_resource(
+                                    drow, r.gpu_addr + (uint64_t)y * linear_src_row, dst_row);
+                                total += got;
+                                if (got < dst_row) std::fill(drow + got, drow + dst_row, 0);
+                            }
+                            return total;
+                        };
                         // PROSPER_TEXCOMMIT: log, once per texture base, how much of the sampled surface is
                         // COMMITTED guest memory (the same reserved_range_state safe_copy stops at). If the
                         // level's backgrounds read ~0% committed, they're GPU-DMA'd pages the CPU never
@@ -1441,13 +1472,11 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // them as RGBA8 packs adjacent texels into one pixel and over-reads the allocation,
                         // which is why glyph text rendered as solid white/black BLOCKS (#102). bpt drives a
                         // narrow read+expand path below. StorageImage / unknown formats keep 4 B (bpt=0->4).
-                        uint32_t bpt = prosper::gpu::data_format_bytes(r.format) * (r.num_components ? r.num_components : 1);
+                        uint32_t bpt = sampled_source_bpt;
                         // fp16 surfaces (fmt 71 Float16x4 = 8 B/texel, 29 = 4 B, 13 = 2 B) get a real
                         // half->UNORM8 conversion path below for guest-backed textures. Renderer-owned
                         // Float16x4 RTTs bypass it and retain native bytes. Other unknown formats keep RGBA8.
-                        const bool f16 = r.format == prosper::gpu::DataFormat::Float16 &&
-                                         (bpt == 2 || bpt == 4 || bpt == 8);
-                        if (bpt == 0 || (bpt > 4 && !f16)) bpt = 4;
+                        const bool f16 = sampled_source_f16;
                         bool f16_done = false;
                         // RTT (#167): if this texture's base is a color target we rendered into, inject those
                         // pixels (nearest-scaled to tw x th) instead of reading empty guest memory.
@@ -1640,6 +1669,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                     r.mip_tail_x, r.mip_tail_y);
                                 else prosper::gpu::detile_surface(
                                     hlin.data(), traw.data(), tw, th, r.tile_mode, 0, bpt);
+                            } else if (linear_padded_read) {
+                                copy_linear_padded_rows(hlin.data(), (size_t)tw * bpt);
                             } else {
                                 copy_resource(hlin.data(), r.gpu_addr, hlin.size());
                             }
@@ -1688,6 +1719,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                     r.mip_tail_x, r.mip_tail_y);
                                 else prosper::gpu::detile_surface(
                                     nlin.data(), traw.data(), tw, th, r.tile_mode, 0, bpt);
+                            } else if (linear_padded_read) {
+                                copy_linear_padded_rows(nlin.data(), (size_t)tw * bpt);
                             } else {
                                 copy_resource(nlin.data(), r.gpu_addr, nlin.size());
                             }
@@ -1700,17 +1733,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         } else if (linear_padded_read) {
                             // Pitch-padded linear surface (see linear_padded_read above): read row-by-row at
                             // the 256-byte-aligned source pitch into the tight destination, dropping the
-                            // per-row padding. The read stays within the backing (linear_src_row*th <= size,
-                            // checked when the flag was set) and copy_resource is fault-safe on a short row.
-                            size_t total = 0;
-                            for (uint32_t y = 0; y < th; ++y) {
-                                uint8_t* drow = texture_pixels.data() + (size_t)y * linear_dst_row;
-                                const size_t got = copy_resource(
-                                    drow, r.gpu_addr + (uint64_t)y * linear_src_row, linear_dst_row);
-                                total += got;
-                                if (got < linear_dst_row) std::fill(drow + got, drow + linear_dst_row, 0);
-                            }
-                            linear_source_prefix_size = total;
+                            // per-row padding. copy_resource is fault-safe when an old capture has a short
+                            // backing because its pre-v28 writer omitted the final padded rows.
+                            linear_source_prefix_size = copy_linear_padded_rows(
+                                texture_pixels.data(), linear_dst_row);
                         } else {
                             const size_t got = copy_resource(texture_pixels.data(), r.gpu_addr, nb);
                             linear_source_prefix_size = got;

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -55,7 +55,12 @@ constexpr char kMagic[8] = {'P','R','G','P','C','A','P','\0'};
 // v27: retain each draw's raw ShaderDrawModifier and signed GE_INDX_OFFSET. The latter is a draw
 // parameter (Vulkan firstVertex/vertexOffset), not pipeline state; omitting it collapsed distinct
 // ranges of a shared vertex pool onto vertex zero in both live rendering and replay.
-constexpr uint32_t kVersion = 27;
+// v28: retain the resolved byte row pitch and exact planned span of every resource. Guest-backed
+// GFX10 linear sampled images use 256-byte-aligned rows, which differs from width*bytes-per-texel for
+// video chroma planes.
+// Older captures planned tight spans, so their materializer intentionally binds the legacy span while
+// still deriving the guest pitch for best-effort rendering of the rows that were retained.
+constexpr uint32_t kVersion = 28;
 constexpr uint32_t kEndian = 0x01020304u;
 constexpr uint64_t kMaxFileBytes = 4ull << 30;
 constexpr uint64_t kMaxBlobBytes = 1ull << 30;
@@ -337,7 +342,16 @@ uint64_t checked_mul(uint64_t a, uint64_t b) {
     return a && b > std::numeric_limits<uint64_t>::max() / a ? std::numeric_limits<uint64_t>::max() : a * b;
 }
 
-uint64_t resource_footprint(const ShaderResource& r) {
+uint32_t resolved_linear_row_pitch(const ShaderResource& r, uint32_t width, uint32_t bpt) {
+    if (r.linear_row_pitch_bytes) return r.linear_row_pitch_bytes;
+    const uint64_t tight = checked_mul(width, bpt);
+    if (tight > UINT32_MAX) return UINT32_MAX;
+    if (r.host_data) return static_cast<uint32_t>(tight);
+    const size_t aligned = linear_sampled_row_pitch(width, bpt);
+    return aligned > UINT32_MAX ? UINT32_MAX : static_cast<uint32_t>(aligned);
+}
+
+uint64_t resource_footprint_impl(const ShaderResource& r, bool legacy_linear_tight) {
     uint64_t result = r.size;
     if (r.cls != ResourceClass::Texture && r.cls != ResourceClass::StorageImage) return result;
     const uint64_t layers = r.img_dim == 3u ? 6u : (r.img_dim == 2u ? std::max(r.depth, 1u) : 1u);
@@ -352,11 +366,28 @@ uint64_t resource_footprint(const ShaderResource& r) {
         uint32_t bpt = data_format_bytes(r.format) * (r.num_components ? r.num_components : 1);
         const bool f16 = r.format == DataFormat::Float16 && (bpt == 2 || bpt == 4 || bpt == 8);
         if (bpt == 0 || (bpt > 4 && !f16)) bpt = 4;
-        decoded = tile_mode_is_tiled(r.tile_mode) ? tiled_surface_bytes(w, h, r.tile_mode, 0, bpt)
-                                                  : checked_mul(checked_mul(w, h), bpt);
+        if (tile_mode_is_tiled(r.tile_mode)) {
+            decoded = tiled_surface_bytes(w, h, r.tile_mode, 0, bpt);
+        } else if (r.tile_mode == static_cast<uint32_t>(TileMode::Linear) &&
+                   r.cls == ResourceClass::Texture && r.img_dim == 1u &&
+                   !r.compression_enabled && !legacy_linear_tight) {
+            // Guest-backed linear sampled images use GFX10's 256-byte row alignment. Capturing only
+            // width*height*bpt made narrow video planes replay with row drift and omitted their tail.
+            decoded = checked_mul(resolved_linear_row_pitch(r, w, bpt), h);
+        } else {
+            decoded = checked_mul(checked_mul(w, h), bpt);
+        }
     }
     decoded = checked_mul(decoded, layers);
     return std::max(result, decoded);
+}
+
+uint64_t resource_footprint(const ShaderResource& r) {
+    return resource_footprint_impl(r, false);
+}
+
+uint64_t legacy_resource_footprint(const ShaderResource& r) {
+    return resource_footprint_impl(r, true);
 }
 
 uint64_t dcc_metadata_footprint(const ShaderResource& r) {
@@ -473,12 +504,26 @@ bool capture_table(const ShaderResourceTable* src, const std::vector<Interval>& 
     dst.present = src != nullptr;
     if (!src) return true;
     for (const auto& r : src->resources) {
-        GpuCapturedResource c; c.resource = r; c.resource.host_data = nullptr; c.resource.host_data_size = 0;
+        GpuCapturedResource c;
+        c.resource = r;
+        if (r.cls == ResourceClass::Texture && r.img_dim == 1u &&
+            r.tile_mode == static_cast<uint32_t>(TileMode::Linear) &&
+            !r.compression_enabled && !bc_block_bytes(r.format)) {
+            uint32_t bpt = data_format_bytes(r.format) *
+                           (r.num_components ? r.num_components : 1u);
+            const bool f16 = r.format == DataFormat::Float16 &&
+                             (bpt == 2 || bpt == 4 || bpt == 8);
+            if (bpt == 0 || (bpt > 4 && !f16)) bpt = 4;
+            c.resource.linear_row_pitch_bytes = resolved_linear_row_pitch(
+                r, r.width ? r.width : 4u, bpt);
+        }
+        c.resource.host_data = nullptr; c.resource.host_data_size = 0;
         c.resource.dcc_metadata_host_data = nullptr;
         c.resource.dcc_metadata_host_data_size = 0;
         c.metadata_size = dcc_metadata_footprint(r);
         c.resource.dcc_metadata_size = c.metadata_size;
         uint64_t n = resource_footprint(r);
+        c.captured_size = n;
         if (is_compute_internal_gds(r) && include_resource_data) {
             if (!r.host_data || r.host_data_size < n) {
                 error = "compute GDS resource has no complete host backing";
@@ -940,7 +985,7 @@ bool capture_submit_items(const std::vector<DrawItem>& draws,
                           std::string& error, const CaptureRttSeedReader& rtt_reader,
                           const std::vector<OperationRealizationFailure>& failures,
                           const std::vector<GpuState::DmaCopy>& dma_copies) {
-    error.clear(); out = {}; out.metadata = metadata;
+    error.clear(); out = {}; out.format_version = kVersion; out.metadata = metadata;
     out.failure_diagnostics_available = true;
     if (draws.size() > kMaxDraws || computes.size() > kMaxComputes ||
         operations.size() > kMaxOperations) {
@@ -1561,6 +1606,43 @@ bool serialize_gpu_capture(const GpuCaptureFile& c, std::vector<uint8_t>& bytes,
         w.u64(draw.raw_draw_modifier);
         w.u32(static_cast<uint32_t>(draw.vertex_offset));
     }
+    // v28: exact source row pitch and capture-planned byte span for each resource. A zero pitch remains
+    // meaningful for resources that are not linear sampled images; enumeration matches v16/v24.
+    {
+        size_t resource_count = 0;
+        for (const auto& draw : c.draws)
+            resource_count += draw.vrt.resources.size() + draw.prt.resources.size();
+        for (const auto& compute : c.computes)
+            resource_count += compute.resources.resources.size();
+        w.u32(static_cast<uint32_t>(resource_count));
+        auto write_linear_layout = [&](const GpuCapturedTable& table) {
+            for (const auto& captured : table.resources) {
+                ShaderResource resource = captured.resource;
+                if (c.format_version < 28 && !resource.linear_row_pitch_bytes &&
+                    resource.cls == ResourceClass::Texture && resource.img_dim == 1u &&
+                    resource.tile_mode == static_cast<uint32_t>(TileMode::Linear) &&
+                    !resource.compression_enabled && !bc_block_bytes(resource.format)) {
+                    uint32_t bpt = data_format_bytes(resource.format) *
+                                   (resource.num_components ? resource.num_components : 1u);
+                    const bool f16 = resource.format == DataFormat::Float16 &&
+                                     (bpt == 2 || bpt == 4 || bpt == 8);
+                    if (bpt == 0 || (bpt > 4 && !f16)) bpt = 4;
+                    resource.linear_row_pitch_bytes = resolved_linear_row_pitch(
+                        resource, resource.width ? resource.width : 4u, bpt);
+                }
+                w.u32(resource.linear_row_pitch_bytes);
+                w.u64(captured.captured_size ? captured.captured_size
+                                             : (c.format_version < 28
+                                                    ? legacy_resource_footprint(resource)
+                                                    : resource_footprint(resource)));
+            }
+        };
+        for (const auto& draw : c.draws) {
+            write_linear_layout(draw.vrt);
+            write_linear_layout(draw.prt);
+        }
+        for (const auto& compute : c.computes) write_linear_layout(compute.resources);
+    }
     if (w.data.size() > kMaxFileBytes) { error = "capture file exceeds 4 GiB"; return false; }
     bytes = std::move(w.data);
     return true;
@@ -1601,6 +1683,7 @@ bool deserialize_gpu_capture(const std::vector<uint8_t>& bytes, GpuCaptureFile& 
         error = "unsupported capture version " + std::to_string(version);
         return false;
     }
+    c.format_version = version;
     if (!r.u32(endian)) { error = "truncated capture byte-order marker"; return false; }
     if (endian != kEndian) { error = "unsupported capture byte order"; return false; }
     auto& m = c.metadata;
@@ -2176,6 +2259,28 @@ bool deserialize_gpu_capture(const std::vector<uint8_t>& bytes, GpuCaptureFile& 
             draw.vertex_offset = static_cast<int32_t>(vertex_offset);
         }
     }
+    if (version >= 28) {
+        size_t expected = 0;
+        for (auto& draw : c.draws)
+            expected += draw.vrt.resources.size() + draw.prt.resources.size();
+        for (auto& compute : c.computes)
+            expected += compute.resources.resources.size();
+        uint32_t count = 0;
+        if (!r.u32(count) || count != expected) {
+            error = "invalid linear-row-pitch count"; return false;
+        }
+        auto read_linear_layout = [&](GpuCapturedTable& table) {
+            for (auto& captured : table.resources) {
+                if (!r.u32(captured.resource.linear_row_pitch_bytes) ||
+                    !r.u64(captured.captured_size)) return false;
+            }
+            return true;
+        };
+        for (auto& draw : c.draws)
+            if (!read_linear_layout(draw.vrt) || !read_linear_layout(draw.prt)) return false;
+        for (auto& compute : c.computes)
+            if (!read_linear_layout(compute.resources)) return false;
+    }
     if (version >= 7 && !validate_failure_diagnostics(c, error)) return false;
     if (r.left) { error = "capture has trailing data"; return false; }
     return true;
@@ -2226,6 +2331,21 @@ bool materialize_gpu_replay(const GpuCaptureFile& c, GpuReplayFrame& out, std::s
         dst = std::make_shared<ShaderResourceTable>();
         for (const auto& x : src.resources) {
             ShaderResource r = x.resource; r.host_data = nullptr; r.host_data_size = 0;
+            const uint64_t captured_footprint = x.captured_size ? x.captured_size
+                : (c.format_version >= 28 ? resource_footprint(r) : legacy_resource_footprint(r));
+            // v1-v27 captured linear images tightly. Preserve that bounded backing so old files stay
+            // readable, but derive the real guest pitch for best-effort replay of every retained row.
+            if (c.format_version < 28 && r.cls == ResourceClass::Texture && r.img_dim == 1u &&
+                r.tile_mode == static_cast<uint32_t>(TileMode::Linear) &&
+                !r.compression_enabled && !bc_block_bytes(r.format)) {
+                uint32_t bpt = data_format_bytes(r.format) *
+                               (r.num_components ? r.num_components : 1u);
+                const bool f16 = r.format == DataFormat::Float16 &&
+                                 (bpt == 2 || bpt == 4 || bpt == 8);
+                if (bpt == 0 || (bpt > 4 && !f16)) bpt = 4;
+                r.linear_row_pitch_bytes = resolved_linear_row_pitch(
+                    r, r.width ? r.width : 4u, bpt);
+            }
             r.dcc_metadata_size = x.metadata_size;
             r.dcc_metadata_host_data = nullptr;
             r.dcc_metadata_host_data_size = 0;
@@ -2241,7 +2361,7 @@ bool materialize_gpu_replay(const GpuCaptureFile& c, GpuReplayFrame& out, std::s
                 }
                 r.host_data = instance.data();
                 r.host_data_size = instance.size();
-            } else if (!bind_range(x.blob_index, x.blob_offset, r.gpu_addr, resource_footprint(r),
+            } else if (!bind_range(x.blob_index, x.blob_offset, r.gpu_addr, captured_footprint,
                             r.host_data, r.host_data_size,
                             "resource references an invalid capture blob",
                             "resource footprint exceeds capture blob",

--- a/prosper/src/gpu/gpu_capture.hpp
+++ b/prosper/src/gpu/gpu_capture.hpp
@@ -46,6 +46,9 @@ struct GpuCaptureRawShaderVersion {
 
 struct GpuCapturedResource {
     ShaderResource resource;
+    // Exact base-resource byte span planned by the capture that produced this record. v1-v27 leave
+    // this zero and materialize with their historical footprint rules.
+    uint64_t captured_size = 0;
     uint32_t blob_index = 0xFFFFFFFFu;
     uint64_t blob_offset = 0;
     uint64_t metadata_size = 0;
@@ -188,6 +191,9 @@ struct GpuCaptureDsSeed {
 };
 
 struct GpuCaptureFile {
+    // In-memory provenance for version-dependent materialization. This is populated by capture/read;
+    // the on-disk header remains the single serialized version field.
+    uint32_t format_version = 0;
     GpuCaptureMetadata metadata;
     std::vector<GpuCaptureBlob> blobs;
     std::vector<GpuCaptureShaderVersion> shader_versions;

--- a/prosper/src/gpu/shader_resources.hpp
+++ b/prosper/src/gpu/shader_resources.hpp
@@ -142,6 +142,10 @@ struct ShaderResource {
     uint32_t      height            = 0;
     uint32_t      depth             = 1;
     uint32_t      tile_mode         = 0;                  // T# GFX10 TileMode; drives auto-detile of a sampled surface
+    // Byte distance between rows of a linear sampled image. Zero means derive it from the live
+    // descriptor/backing: guest images use the GFX10 sampled-image alignment while ordinary host
+    // fixtures are tight. Captures persist the resolved value so replay keeps both layouts exact.
+    uint32_t      linear_row_pitch_bytes = 0;
     // A packed mip-tail view shares the allocation's first 4/64 KiB block. gpu_addr remains the
     // shared block base; the backend applies mip_tail_offset and preserves sibling levels on writes.
     // T#-declared mip-chain length relative to the selected base level (last_level - base_level + 1,

--- a/prosper/src/gpu/tile.cpp
+++ b/prosper/src/gpu/tile.cpp
@@ -13,6 +13,19 @@
 
 namespace prosper::gpu {
 
+size_t linear_sampled_row_pitch(uint32_t width, uint32_t bytes_per_texel) {
+    if (!width || !bytes_per_texel) return 0;
+    const uint64_t tight = static_cast<uint64_t>(width) * bytes_per_texel;
+    const uint64_t aligned = (tight + 255u) & ~uint64_t{255u};
+    return aligned > std::numeric_limits<size_t>::max() ? 0 : static_cast<size_t>(aligned);
+}
+
+size_t linear_sampled_surface_bytes(uint32_t width, uint32_t height, uint32_t bytes_per_texel) {
+    const size_t pitch = linear_sampled_row_pitch(width, bytes_per_texel);
+    if (!pitch || !height || pitch > std::numeric_limits<size_t>::max() / height) return 0;
+    return pitch * height;
+}
+
 bool tile_mode_is_tiled(uint32_t tile_mode) {
     return tile_mode == (uint32_t)TileMode::Sw4KbS ||
            tile_mode == (uint32_t)TileMode::Sw64KbS ||

--- a/prosper/src/gpu/tile.hpp
+++ b/prosper/src/gpu/tile.hpp
@@ -8,6 +8,7 @@
 // the texels follow a Morton/Z order with the Y bit in the LOW position of each pair (y0,x0,y1,x1,...).
 // Empirically derived (raw-tiled-bytes dump + offline swizzle sweep) and pixel-verified against the game.
 #pragma once
+#include <cstddef>
 #include <cstdint>
 #include <vector>
 
@@ -25,6 +26,11 @@ enum class TileMode : uint32_t {
     Sw64KbZX = 24,
     Sw64KbRX = 27,
 };
+
+// GFX10 sampled images in linear mode use a 256-byte-aligned row pitch. Buffer/host-data uploads
+// remain tightly packed; callers apply this only to guest-backed sampled Texture resources.
+size_t linear_sampled_row_pitch(uint32_t width, uint32_t bytes_per_texel);
+size_t linear_sampled_surface_bytes(uint32_t width, uint32_t height, uint32_t bytes_per_texel);
 
 // True if `tile_mode` denotes a swizzled layout that detile_surface will de-swizzle.
 bool tile_mode_is_tiled(uint32_t tile_mode);

--- a/prosper/tests/test_gpu_capture.cpp
+++ b/prosper/tests/test_gpu_capture.cpp
@@ -212,6 +212,14 @@ int main() {
         return 4 + 12 * f.draws.size();
     };
 
+    // v28: byte length of the linear-layout tail (u32 count + u32 pitch/u64 span per resource).
+    auto v28_tail = [](const GpuCaptureFile& f) -> size_t {
+        size_t rc = 0;
+        for (const auto& d : f.draws) rc += d.vrt.resources.size() + d.prt.resources.size();
+        for (const auto& cm : f.computes) rc += cm.resources.resources.size();
+        return 4 + 12 * rc;
+    };
+
     // v26: byte length of the trailing color-export/downconversion block.
     auto v26_tail = [](const GpuCaptureFile& f) -> size_t {
         size_t present_failures = 0;
@@ -250,6 +258,7 @@ int main() {
               v16_scissor_bytes.size() >= 25,
           "v17 capture serializes effective guest scissor state");
     if (v16_scissor_bytes.size() >= 25) {
+        v16_scissor_bytes.resize(v16_scissor_bytes.size() - v28_tail(v16_scissor_source));
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - v27_tail(v16_scissor_source));
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - v26_tail(v16_scissor_source));
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - v25_tail(v16_scissor_source)); // v25 resolve tail
@@ -312,6 +321,80 @@ int main() {
     large_resource.size = 2u << 20;
     CHECK(gpu_capture_resource_footprint(large_resource) == (2u << 20),
           "public capture footprint reports the planner's declared buffer range");
+    ShaderResource video_chroma;
+    video_chroma.cls = ResourceClass::Texture;
+    video_chroma.format = DataFormat::Unorm8;
+    video_chroma.num_components = 1;
+    video_chroma.img_dim = 1;
+    video_chroma.width = 1920;
+    video_chroma.height = 1080;
+    video_chroma.tile_mode = static_cast<uint32_t>(TileMode::Linear);
+    video_chroma.size = 1920u * 1080u;
+    CHECK(gpu_capture_resource_footprint(video_chroma) == 2048u * 1080u,
+          "capture includes 256-byte row padding for a guest-backed linear R8 sampled image");
+    uint8_t host_video_texel = 0;
+    video_chroma.host_data = &host_video_texel;
+    CHECK(gpu_capture_resource_footprint(video_chroma) == 1920u * 1080u,
+          "capture keeps tightly-packed host texture fixtures unpadded");
+    video_chroma.host_data = nullptr;
+    video_chroma.gpu_addr = 0xa00000;
+    video_chroma.height = 2;
+    video_chroma.size = 1920u * 2u;
+    auto video_table = std::make_shared<ShaderResourceTable>();
+    video_table->resources = {video_chroma};
+    DrawItem video_draw = draw;
+    video_draw.vrt.reset();
+    video_draw.prt = video_table;
+    std::vector<uint8_t> video_memory(2048u * 2u, 0x80);
+    auto video_reader = [&](uint64_t addr, uint8_t* dst, size_t n) -> size_t {
+        if (addr < video_chroma.gpu_addr ||
+            addr >= video_chroma.gpu_addr + video_memory.size()) return 0;
+        const size_t offset = static_cast<size_t>(addr - video_chroma.gpu_addr);
+        const size_t take = std::min(n, video_memory.size() - offset);
+        std::memcpy(dst, video_memory.data() + offset, take);
+        return take;
+    };
+    GpuCaptureFile video_capture;
+    CHECK(capture_draw_items({video_draw}, meta, video_reader, video_capture, error) &&
+              video_capture.format_version == 28 && video_capture.blobs.size() == 1 &&
+              video_capture.blobs[0].bytes.size() == video_memory.size() &&
+              video_capture.draws[0].prt.resources[0].captured_size == video_memory.size() &&
+              video_capture.draws[0].prt.resources[0].resource.linear_row_pitch_bytes == 2048,
+          "v28 capture retains the complete padded rows and their resolved byte pitch");
+    std::vector<uint8_t> video_capture_bytes;
+    GpuCaptureFile video_loaded;
+    GpuReplayFrame video_replay;
+    CHECK(serialize_gpu_capture(video_capture, video_capture_bytes, error) &&
+              deserialize_gpu_capture(video_capture_bytes, video_loaded, error) &&
+              video_loaded.format_version == 28 &&
+              video_loaded.draws[0].prt.resources[0].captured_size == video_memory.size() &&
+              video_loaded.draws[0].prt.resources[0].resource.linear_row_pitch_bytes == 2048 &&
+              materialize_gpu_replay(video_loaded, video_replay, error) &&
+              video_replay.items[0].prt->resources[0].host_data_size == video_memory.size(),
+          "v28 replay round-trips and binds the complete pitch-padded source span");
+    GpuCaptureFile legacy_video = video_capture;
+    legacy_video.format_version = 27;
+    legacy_video.draws[0].prt.resources[0].captured_size = 0;
+    legacy_video.draws[0].prt.resources[0].resource.linear_row_pitch_bytes = 0;
+    legacy_video.blobs[0].bytes.resize(video_chroma.size);
+    legacy_video.blobs[0].bytes_read = legacy_video.blobs[0].bytes.size();
+    legacy_video.blobs[0].content_hash = gpu_capture_hash(legacy_video.blobs[0].bytes);
+    GpuReplayFrame legacy_video_replay;
+    CHECK(materialize_gpu_replay(legacy_video, legacy_video_replay, error) &&
+              legacy_video_replay.items[0].prt->resources[0].host_data_size == video_chroma.size &&
+              legacy_video_replay.items[0].prt->resources[0].linear_row_pitch_bytes == 2048,
+          "v27 replay keeps its tight captured span readable while deriving the guest row pitch");
+    std::vector<uint8_t> upgraded_video_bytes;
+    GpuCaptureFile upgraded_video;
+    GpuReplayFrame upgraded_video_replay;
+    CHECK(serialize_gpu_capture(legacy_video, upgraded_video_bytes, error) &&
+              deserialize_gpu_capture(upgraded_video_bytes, upgraded_video, error) &&
+              upgraded_video.format_version == 28 &&
+              upgraded_video.draws[0].prt.resources[0].captured_size == video_chroma.size &&
+              upgraded_video.draws[0].prt.resources[0].resource.linear_row_pitch_bytes == 2048 &&
+              materialize_gpu_replay(upgraded_video, upgraded_video_replay, error) &&
+              upgraded_video_replay.items[0].prt->resources[0].host_data_size == video_chroma.size,
+          "rewriting a v27 capture preserves its short span and best-effort derived pitch in v28");
     large_table->resources = {large_resource};
     DrawItem large_draw = draw;
     large_draw.vrt = large_table;
@@ -404,6 +487,7 @@ int main() {
           "writer rejects an out-of-bounds DCC metadata reference");
     CHECK(serialize_gpu_capture(volume_capture, volume_bytes, error),
           "recreated valid v12 DCC bytes after malformed-reference check");
+    volume_bytes.resize(volume_bytes.size() - v28_tail(volume_capture));
     volume_bytes.resize(volume_bytes.size() - v27_tail(volume_capture));
     volume_bytes.resize(volume_bytes.size() - v26_tail(volume_capture));
     volume_bytes.resize(volume_bytes.size() - v25_tail(volume_capture)); // v25 resolve tail
@@ -478,6 +562,7 @@ int main() {
     CHECK(serialize_gpu_capture(captured, v20_bytes, error) && v20_bytes.size() >= 21,
           "v21 capture serializes the logic-op extension");
     if (v20_bytes.size() >= 21) {
+        v20_bytes.resize(v20_bytes.size() - v28_tail(captured));
         v20_bytes.resize(v20_bytes.size() - v27_tail(captured));
         v20_bytes.resize(v20_bytes.size() - v26_tail(captured));
         v20_bytes.resize(v20_bytes.size() - v25_tail(captured)); // v25 resolve tail
@@ -525,6 +610,7 @@ int main() {
           v24_resolve_bytes.size() >= v27_tail(captured) + v26_tail(captured) + v25_tail(captured),
           "v25 capture exposes a removable trailing resolve-state block");
     if (v24_resolve_bytes.size() >= v27_tail(captured) + v26_tail(captured) + v25_tail(captured)) {
+        v24_resolve_bytes.resize(v24_resolve_bytes.size() - v28_tail(captured));
         v24_resolve_bytes.resize(v24_resolve_bytes.size() - v27_tail(captured));
         v24_resolve_bytes.resize(v24_resolve_bytes.size() - v26_tail(captured));
         v24_resolve_bytes.resize(v24_resolve_bytes.size() - v25_tail(captured));
@@ -908,6 +994,7 @@ int main() {
     if (v13_bytes.size() >= 32) {
         const size_t legacy_resource_count = legacy_source.draws[0].vrt.resources.size() +
                                              legacy_source.draws[0].prt.resources.size();
+        v13_bytes.resize(v13_bytes.size() - v28_tail(legacy_source));
         v13_bytes.resize(v13_bytes.size() - v27_tail(legacy_source));
         v13_bytes.resize(v13_bytes.size() - v26_tail(legacy_source));
         v13_bytes.resize(v13_bytes.size() - v25_tail(legacy_source)); // v25 resolve tail
@@ -935,6 +1022,7 @@ int main() {
     if (legacy_bytes.size() >= 32) {
         const size_t legacy_resource_count = legacy_source.draws[0].vrt.resources.size() +
                                              legacy_source.draws[0].prt.resources.size();
+        legacy_bytes.resize(legacy_bytes.size() - v28_tail(legacy_source));
         legacy_bytes.resize(legacy_bytes.size() - v27_tail(legacy_source));
         legacy_bytes.resize(legacy_bytes.size() - v26_tail(legacy_source));
         legacy_bytes.resize(legacy_bytes.size() - v25_tail(legacy_source)); // v25 resolve tail
@@ -988,9 +1076,9 @@ int main() {
     CHECK(deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
           !legacy_loaded.failure_diagnostics_available && legacy_loaded.failure_diagnostics.empty(),
           "v6 capture reopens with failed-operation diagnostics reported unavailable");
-    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 28;   // kVersion (27) + 1: a not-yet-defined future version
+    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 29;   // kVersion (28) + 1: a not-yet-defined future version
     CHECK(!deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
-          error == "unsupported capture version 28",
+          error == "unsupported capture version 29",
           "future capture versions fail with a concrete version error");
 
     GpuCaptureFile bad_hash = mixed;

--- a/prosper/tests/test_gpu_capture_render.cpp
+++ b/prosper/tests/test_gpu_capture_render.cpp
@@ -96,6 +96,7 @@ int main() {
     ShaderResourceTable compile_rt;
     ShaderResource tex{}; tex.cls = ResourceClass::Texture; tex.binding = 4; tex.img_dim = 1;
     tex.width = 2; tex.height = 2; tex.size = 16; tex.sgpr_base = 8; tex.gpu_addr = 0x100000;
+    tex.linear_row_pitch_bytes = 8;  // synthetic reader publishes tightly packed RGBA8 rows
     tex.mag_filter = tex.min_filter = 0; compile_rt.resources.push_back(tex);
     DrawItem item; item.vs = recompile_vertex(vs_rdna, std::size(vs_rdna));
     item.fs = recompile_fragment(ps_rdna, std::size(ps_rdna), &compile_rt);

--- a/prosper/tests/test_tile.cpp
+++ b/prosper/tests/test_tile.cpp
@@ -99,6 +99,12 @@ int main() {
 
     CHECK(tile_mode_is_tiled((uint32_t)TileMode::Sw4KbS), "tile_mode 5 (SW_4KB_S) is tiled");
     CHECK(!tile_mode_is_tiled((uint32_t)TileMode::Linear), "tile_mode 0 (linear) is not tiled");
+    CHECK(linear_sampled_row_pitch(1920, 1) == 2048 &&
+          linear_sampled_surface_bytes(1920, 1080, 1) == 2048u * 1080u,
+          "linear R8 sampled images align each row to 256 bytes");
+    CHECK(linear_sampled_row_pitch(3840, 1) == 3840 &&
+          linear_sampled_surface_bytes(3840, 2160, 1) == 3840u * 2160u,
+          "already-aligned linear sampled rows retain their tight pitch");
 
     // Linear mode: detile is a straight copy.
     {

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -17,7 +17,9 @@ need, `PROSPER_GPU_CAPTURE_METADATA_ONLY=1` writes a thin capsule with shaders, 
 state, and resource descriptors but no guest resource or RTT bytes. Thin capsules support
 `--inspect-only`, `--validate`, and `--graph`; rendering exits with a concrete error.
 Inspection reports each descriptor's declared size, capture-planned footprint, and captured byte
-count separately, so a thin capsule can still expose a pathological range.
+count separately, so a thin capsule can still expose a pathological range. Capture v28+ retains the exact
+planned span and reports the resolved `row-pitch` for linear sampled images; older captures derive the
+guest pitch while retaining their historical tight byte span.
 
 Build from `prosper/`, using the worktree-local Linux build:
 

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -232,7 +232,8 @@ void inspect_table(const char* stage, const prosper::gpu::ShaderResourceTable* t
         });
         std::printf("  %s %-7s b=%u addr=%016llx declared=%u footprint=%llu captured=%llu "
                     "nz=%zu hash=%016llx first=%08x "
-                    "fmt=%u nc=%u stride=%u %ux%ux%u tile=%u addr=%u%u%u swz=%u%u%u%u filt=%u/%u/%u "
+                    "fmt=%u nc=%u stride=%u %ux%ux%u tile=%u row-pitch=%u "
+                    "addr=%u%u%u swz=%u%u%u%u filt=%u/%u/%u "
                     "dcc=%u meta=%016llx meta-bytes=%llu/%llu meta-nz=%zu meta-unique=%zu "
                     "meta-first=%08x meta-hash=%016llx "
                     "blocks=%u/%u flags=%u%u%u%u "
@@ -243,7 +244,7 @@ void inspect_table(const char* stage, const prosper::gpu::ShaderResourceTable* t
                     static_cast<unsigned long long>(r.host_data_size), nz,
                     static_cast<unsigned long long>(hash), first,
                     static_cast<unsigned>(r.format), r.num_components, r.stride,
-                    r.width, r.height, r.depth, r.tile_mode,
+                    r.width, r.height, r.depth, r.tile_mode, r.linear_row_pitch_bytes,
                     r.addr_uvw[0], r.addr_uvw[1], r.addr_uvw[2],
                     r.swizzle[0], r.swizzle[1], r.swizzle[2], r.swizzle[3],
                     r.mag_filter, r.min_filter, r.mip_filter,


### PR DESCRIPTION
## Summary

- decode guest-backed linear sampled textures using the GFX10 256-byte-aligned row pitch for every texel width, including R8/RG8/FP16 sources
- extend GPU capture v28 with the resolved linear row pitch and exact captured span, while retaining best-effort compatibility with older tight captures
- expose row pitch in `gpu_replay --inspect-only` and add focused capture/replay regression coverage

## GTA V replay evidence

The original 3840×2160 Rockstar capture used 1920×1080 R8 chroma planes. Their real row pitch is 2048 bytes, but capture v27 retained only `1920 * 1080` bytes. With this change, replay renders the Rockstar mark in strong yellow and removes the horizontal line corruption. The old capture's uncaptured final 68 chroma rows remain visibly unavailable as a bottom strip; v28 captures retain the complete `2048 * 1080` span.

Replay output hash: `f53074778bd49344`.

## Verification

- `test_tile`
- `test_gpu_capture`
- `test_gpu_capture_bundle`
- `test_gpu_capture_render`
- `test_gpu_resources`
- `test_build_shader_resources`
- `test_texture_sample_render`
- built `gpu_replay` and `prosper-app`
- replayed the original GTA V capture to a full-resolution 3840×2160 PNG