### PR TITLE
feat(gpu): honor PA_SU_POLY_OFFSET depth bias (capture v29)

### DIFF
--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -60,7 +60,7 @@ constexpr char kMagic[8] = {'P','R','G','P','C','A','P','\0'};
 // video chroma planes.
 // Older captures planned tight spans, so their materializer intentionally binds the legacy span while
 // still deriving the guest pitch for best-effort rendering of the rows that were retained.
-constexpr uint32_t kVersion = 28;
+constexpr uint32_t kVersion = 29;
 constexpr uint32_t kEndian = 0x01020304u;
 constexpr uint64_t kMaxFileBytes = 4ull << 30;
 constexpr uint64_t kMaxBlobBytes = 1ull << 30;
@@ -1643,6 +1643,24 @@ bool serialize_gpu_capture(const GpuCaptureFile& c, std::vector<uint8_t>& bytes,
         }
         for (const auto& compute : c.computes) write_linear_layout(compute.resources);
     }
+    // v29 (#1349) appends the resolved depth-bias state per realized/failed pipeline. Shadow-map
+    // passes program PA_SU_POLY_OFFSET_*; replaying without it re-introduces the acne the live
+    // renderer now avoids.
+    w.u32(static_cast<uint32_t>(c.draws.size()));
+    for (const auto& draw : c.draws) {
+        w.u8(draw.ps.depth_bias_enable ? 1u : 0u);
+        w.u32(std::bit_cast<uint32_t>(draw.ps.depth_bias_constant));
+        w.u32(std::bit_cast<uint32_t>(draw.ps.depth_bias_slope));
+        w.u32(std::bit_cast<uint32_t>(draw.ps.depth_bias_clamp));
+    }
+    w.u32(static_cast<uint32_t>(c.failure_diagnostics.size()));
+    for (const auto& diagnostic : c.failure_diagnostics) if (diagnostic.pipeline_present) {
+        w.u8(diagnostic.pipeline.depth_bias_enable ? 1u : 0u);
+        w.u32(std::bit_cast<uint32_t>(diagnostic.pipeline.depth_bias_constant));
+        w.u32(std::bit_cast<uint32_t>(diagnostic.pipeline.depth_bias_slope));
+        w.u32(std::bit_cast<uint32_t>(diagnostic.pipeline.depth_bias_clamp));
+    }
+
     if (w.data.size() > kMaxFileBytes) { error = "capture file exceeds 4 GiB"; return false; }
     bytes = std::move(w.data);
     return true;
@@ -2280,6 +2298,30 @@ bool deserialize_gpu_capture(const std::vector<uint8_t>& bytes, GpuCaptureFile& 
             if (!read_linear_layout(draw.vrt) || !read_linear_layout(draw.prt)) return false;
         for (auto& compute : c.computes)
             if (!read_linear_layout(compute.resources)) return false;
+    }
+    if (version >= 29) {   // #1349: resolved depth-bias state for realized and failed pipelines
+        uint32_t draw_count = 0;
+        if (!r.u32(draw_count) || draw_count != c.draws.size()) {
+            error = "invalid depth-bias draw-state count"; return false;
+        }
+        auto read_bias = [&](ResolvedPipelineState& pipeline) {
+            uint8_t enabled = 0;
+            uint32_t constant = 0, slope = 0, clamp = 0;
+            if (!r.u8(enabled) || enabled > 1 || !r.u32(constant) || !r.u32(slope) ||
+                !r.u32(clamp)) return false;
+            pipeline.depth_bias_enable   = enabled;
+            pipeline.depth_bias_constant = std::bit_cast<float>(constant);
+            pipeline.depth_bias_slope    = std::bit_cast<float>(slope);
+            pipeline.depth_bias_clamp    = std::bit_cast<float>(clamp);
+            return true;
+        };
+        for (auto& draw : c.draws) if (!read_bias(draw.ps)) return false;
+        uint32_t failure_count = 0;
+        if (!r.u32(failure_count) || failure_count != c.failure_diagnostics.size()) {
+            error = "invalid depth-bias failure-state count"; return false;
+        }
+        for (auto& diagnostic : c.failure_diagnostics) if (diagnostic.pipeline_present)
+            if (!read_bias(diagnostic.pipeline)) return false;
     }
     if (version >= 7 && !validate_failure_diagnostics(c, error)) return false;
     if (r.left) { error = "capture has trailing data"; return false; }

--- a/prosper/src/gpu/render_state.cpp
+++ b/prosper/src/gpu/render_state.cpp
@@ -249,6 +249,11 @@ RenderState extract_render_state(const GpuState& st) {
     rs.db_depth_control  = dc;
     // Rasterizer cull/front-face/polygon mode (#456). Absent -> 0 -> CULL_NONE/CCW/FILL (prior default).
     rs.pa_su_sc_mode_cntl = rd(st.cx, P::PA_SU_SC_MODE_CNTL);
+    rs.pa_su_poly_offset_front_scale  = rd(st.cx, P::PA_SU_POLY_OFFSET_FRONT_SCALE);
+    rs.pa_su_poly_offset_front_offset = rd(st.cx, P::PA_SU_POLY_OFFSET_FRONT_OFFSET);
+    rs.pa_su_poly_offset_back_scale   = rd(st.cx, P::PA_SU_POLY_OFFSET_BACK_SCALE);
+    rs.pa_su_poly_offset_back_offset  = rd(st.cx, P::PA_SU_POLY_OFFSET_BACK_OFFSET);
+    rs.pa_su_poly_offset_clamp        = rd(st.cx, P::PA_SU_POLY_OFFSET_CLAMP);
     // Stencil op + ref/mask registers (absent -> 0; stencil_enable already gates whether they apply).
     rs.db_stencil_control   = st.cx.count(P::DB_STENCIL_CONTROL)   ? rd(st.cx, P::DB_STENCIL_CONTROL)   : 0u;
     rs.db_stencilrefmask    = st.cx.count(P::DB_STENCILREFMASK)    ? rd(st.cx, P::DB_STENCILREFMASK)    : 0u;
@@ -688,6 +693,34 @@ ResolvedPipelineState resolve_pipeline_state(const RenderState& rs) {
     ps.cull_mode  = (PM4_FIELD(su, PA_SU_SC_MODE_CNTL, CULL_FRONT) ? 1u : 0u)
                   | (PM4_FIELD(su, PA_SU_SC_MODE_CNTL, CULL_BACK)  ? 2u : 0u);
     ps.front_face = PM4_FIELD(su, PA_SU_SC_MODE_CNTL, FACE);
+    // Depth bias (#1349): PA_SU_POLY_OFFSET_* hold float BIT PATTERNS; Vulkan's mapping is the
+    // radv inverse (radv programs FRONT_OFFSET = fui(constantFactor), FRONT_SCALE =
+    // fui(slopeFactor * 16), CLAMP = fui(clamp)). Blue Prince programs the D32F configuration
+    // (DB_FMT_CNTL NEG_NUM_DB_BITS=-23 + FLOAT_FMT) during its shadow passes; without the bias
+    // those maps self-shadow into broad acne bands. Vulkan has a single bias for both faces —
+    // prefer the FRONT block when FRONT_ENABLE is set, else the BACK block. CONFIDENCE: MED for
+    // titles that program asymmetric front/back offsets (none observed).
+    const bool bias_front = PM4_FIELD(su, PA_SU_SC_MODE_CNTL, POLY_OFFSET_FRONT_ENABLE) != 0u;
+    const bool bias_back  = PM4_FIELD(su, PA_SU_SC_MODE_CNTL, POLY_OFFSET_BACK_ENABLE) != 0u;
+    ps.depth_bias_enable = (bias_front || bias_back) ? 1u : 0u;
+    if (ps.depth_bias_enable) {
+        const auto as_float = [](uint32_t bits) {
+            float value; std::memcpy(&value, &bits, sizeof value); return value;
+        };
+        const uint32_t scale  = bias_front ? rs.pa_su_poly_offset_front_scale
+                                           : rs.pa_su_poly_offset_back_scale;
+        const uint32_t offset = bias_front ? rs.pa_su_poly_offset_front_offset
+                                           : rs.pa_su_poly_offset_back_offset;
+        ps.depth_bias_constant = as_float(offset);
+        ps.depth_bias_slope    = as_float(scale) / 16.0f;
+        ps.depth_bias_clamp    = as_float(rs.pa_su_poly_offset_clamp);
+        // A non-finite register value would poison the pipeline; treat it as no bias.
+        if (!std::isfinite(ps.depth_bias_constant) || !std::isfinite(ps.depth_bias_slope) ||
+            !std::isfinite(ps.depth_bias_clamp)) {
+            ps.depth_bias_enable = 0u;
+            ps.depth_bias_constant = ps.depth_bias_slope = ps.depth_bias_clamp = 0.0f;
+        }
+    }
     if (PM4_FIELD(su, PA_SU_SC_MODE_CNTL, POLY_MODE) == 0u) {
         ps.polygon_mode = 0u;   // FILL
     } else {

--- a/prosper/src/gpu/render_state.hpp
+++ b/prosper/src/gpu/render_state.hpp
@@ -144,6 +144,14 @@ struct RenderState {
     // decodes to CULL_NONE + CCW-front + FILL — exactly the prior hardcoded default, so nothing changes
     // for a guest that never programs it. Decoded in resolve to Vk enums (#456).
     uint32_t pa_su_sc_mode_cntl = 0;
+    // Polygon-offset (depth bias) raw registers (#1349). Float bit patterns, the radv convention:
+    // Vulkan depthBiasConstantFactor = asfloat(OFFSET), SlopeFactor = asfloat(SCALE)/16,
+    // Clamp = asfloat(CLAMP). Absent registers stay 0 (bias disabled resolves harmlessly).
+    uint32_t pa_su_poly_offset_front_scale  = 0;
+    uint32_t pa_su_poly_offset_front_offset = 0;
+    uint32_t pa_su_poly_offset_back_scale   = 0;
+    uint32_t pa_su_poly_offset_back_offset  = 0;
+    uint32_t pa_su_poly_offset_clamp        = 0;
 
     // Viewport 0 transform (PA_CL_VPORT_{X,Y,Z}{SCALE,OFFSET} — IEEE-754 floats stored in the context
     // registers; 0 when the guest never set them). Hardware applies screen = offset + scale * ndc, with
@@ -251,6 +259,13 @@ struct ResolvedPipelineState {
     uint32_t cull_mode    = 0;   // VK_CULL_MODE_NONE
     uint32_t front_face   = 0;   // VK_FRONT_FACE_COUNTER_CLOCKWISE / guest FACE=0
     uint32_t polygon_mode = 0;   // VK_POLYGON_MODE_FILL
+    // Depth bias from PA_SU_POLY_OFFSET_* (#1349): shadow-map passes rely on it against acne.
+    // Values are ready for VkPipelineRasterizationStateCreateInfo; enable is FRONT|BACK from
+    // PA_SU_SC_MODE_CNTL (Vulkan has one bias for both faces; titles program them identically).
+    uint32_t depth_bias_enable   = 0;
+    float    depth_bias_constant = 0.0f;
+    float    depth_bias_slope    = 0.0f;
+    float    depth_bias_clamp    = 0.0f;
 
     // Optional second color attachment. These fields are appended so capture versions through v9
     // retain their exact serialized prefix and materialize with MRT1 disabled.

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -487,6 +487,7 @@ struct RenderVkCtx {
     VkDevice dev = VK_NULL_HANDLE; VkQueue queue = VK_NULL_HANDLE; uint32_t qfi = UINT32_MAX;
     VkDeviceSize storage_buffer_alignment = 1;
     bool aniso_enabled = false; float max_aniso_limit = 1.0f;
+    bool depth_bias_clamp_enabled = false;   // VkPhysicalDeviceFeatures::depthBiasClamp (#1349)
     bool logic_op_enabled = false; bool ok = false;
     bool fragment_stores_atomics = false;
     // Per-draw "fragment funnel" diagnostic (PROSPER_DRAW_STATS): pipeline-statistics + precise
@@ -609,6 +610,8 @@ inline const RenderVkCtx& render_vk_ctx() {
         r.storage_buffer_alignment = std::max<VkDeviceSize>(
             1, phys_props.limits.minStorageBufferOffsetAlignment);
         r.aniso_enabled = supported.samplerAnisotropy;
+        r.depth_bias_clamp_enabled = supported.depthBiasClamp;
+        if (r.depth_bias_clamp_enabled) feats.depthBiasClamp = VK_TRUE;
         r.logic_op_enabled = supported.logicOp;
         r.max_aniso_limit = phys_props.limits.maxSamplerAnisotropy;
         if (r.aniso_enabled) feats.samplerAnisotropy = VK_TRUE;
@@ -2851,6 +2854,16 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                                                                   : VK_FRONT_FACE_CLOCKWISE)
                       : (VkFrontFace)ps->front_face;
                   rs.polygonMode = (VkPolygonMode)ps->polygon_mode; }
+        // Depth bias (#1349): the guest's PA_SU_POLY_OFFSET_* — shadow-map passes need it against
+        // acne. Clamp requires the depthBiasClamp device feature; without it a non-zero clamp is
+        // dropped to 0 (bias still applies, unclamped — the safe direction). PROSPER_NO_DEPTH_BIAS
+        // is the A/B diagnostic, symmetric with PROSPER_NO_CULL above.
+        if (ps && ps->depth_bias_enable && !getenv("PROSPER_NO_DEPTH_BIAS")) {
+            rs.depthBiasEnable         = VK_TRUE;
+            rs.depthBiasConstantFactor = ps->depth_bias_constant;
+            rs.depthBiasSlopeFactor    = ps->depth_bias_slope;
+            rs.depthBiasClamp = render_vk_ctx().depth_bias_clamp_enabled ? ps->depth_bias_clamp : 0.0f;
+        }
         VkPipelineMultisampleStateCreateInfo ms{VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO};
         ms.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
         VkPipelineColorBlendAttachmentState cba[2]{};
@@ -3594,7 +3607,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                 memcpy(&word, &value, sizeof word);
                 append(word);
             };
-            append(7); // key schema version (fragment required subgroup size)
+            append(8); // key schema version (depth bias in rasterization state, #1349)
             append(W); append(H); append(color_count); append(static_cast<uint32_t>(FMT));
             append(static_cast<uint32_t>(FMT1)); append(use_ds); append(static_cast<uint32_t>(DFMT));
             const bool exact_shader_identities = bd.vs_identity && bd.fs_identity;
@@ -3641,6 +3654,8 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
             append_float(vp.x); append_float(vp.y); append_float(vp.width); append_float(vp.height);
             append_float(vp.minDepth); append_float(vp.maxDepth);
             append(rs.polygonMode); append(rs.cullMode); append(rs.frontFace); append_float(rs.lineWidth);
+            append(rs.depthBiasEnable); append_float(rs.depthBiasConstantFactor);
+            append_float(rs.depthBiasSlopeFactor); append_float(rs.depthBiasClamp);
             append(cb.logicOpEnable); append(cb.logicOp);
             for (uint32_t attachment = 0; attachment < color_count; ++attachment) {
                 append(cba[attachment].blendEnable); append(cba[attachment].srcColorBlendFactor);

--- a/prosper/tests/test_gpu_capture.cpp
+++ b/prosper/tests/test_gpu_capture.cpp
@@ -105,6 +105,10 @@ int main() {
     draw.ps.src_alpha_blend_factor1 = 1; draw.ps.dst_alpha_blend_factor1 = 7;
     draw.ps.alpha_blend_op1 = 0; draw.ps.color1_write_mask = 0xf;
     draw.ps.cb_resolve = true;
+    draw.ps.depth_bias_enable = 1;            // #1349: v29 depth-bias tail
+    draw.ps.depth_bias_constant = 4.0f;
+    draw.ps.depth_bias_slope = 2.0f;
+    draw.ps.depth_bias_clamp = 0.5f;
     draw.ps.spi_shader_col_format = 4;
     draw.ps.sx_ps_downconvert = 5;
     draw.ps.has_scissor = true; draw.ps.scissor_left = 12; draw.ps.scissor_top = 19;
@@ -207,6 +211,14 @@ int main() {
               scalar_capture.computes[0].resources.resources.empty(),
           "#636: capture ignores unconsumed descriptor-looking scalar arguments");
 
+    // v29 (#1349): byte length of the depth-bias tail (u8 enable + three u32 per pipeline).
+    auto v29_tail = [](const GpuCaptureFile& f) -> size_t {
+        size_t present_failures = 0;
+        for (const auto& diagnostic : f.failure_diagnostics)
+            if (diagnostic.pipeline_present) ++present_failures;
+        return 4 + 13 * f.draws.size() + 4 + 13 * present_failures;
+    };
+
     // v27: byte length of the trailing draw-modifier/vertex-offset block.
     auto v27_tail = [](const GpuCaptureFile& f) -> size_t {
         return 4 + 12 * f.draws.size();
@@ -258,6 +270,7 @@ int main() {
               v16_scissor_bytes.size() >= 25,
           "v17 capture serializes effective guest scissor state");
     if (v16_scissor_bytes.size() >= 25) {
+        v16_scissor_bytes.resize(v16_scissor_bytes.size() - v29_tail(v16_scissor_source));
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - v28_tail(v16_scissor_source));
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - v27_tail(v16_scissor_source));
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - v26_tail(v16_scissor_source));
@@ -356,7 +369,7 @@ int main() {
     };
     GpuCaptureFile video_capture;
     CHECK(capture_draw_items({video_draw}, meta, video_reader, video_capture, error) &&
-              video_capture.format_version == 28 && video_capture.blobs.size() == 1 &&
+              video_capture.format_version == 29 && video_capture.blobs.size() == 1 &&
               video_capture.blobs[0].bytes.size() == video_memory.size() &&
               video_capture.draws[0].prt.resources[0].captured_size == video_memory.size() &&
               video_capture.draws[0].prt.resources[0].resource.linear_row_pitch_bytes == 2048,
@@ -366,7 +379,7 @@ int main() {
     GpuReplayFrame video_replay;
     CHECK(serialize_gpu_capture(video_capture, video_capture_bytes, error) &&
               deserialize_gpu_capture(video_capture_bytes, video_loaded, error) &&
-              video_loaded.format_version == 28 &&
+              video_loaded.format_version == 29 &&
               video_loaded.draws[0].prt.resources[0].captured_size == video_memory.size() &&
               video_loaded.draws[0].prt.resources[0].resource.linear_row_pitch_bytes == 2048 &&
               materialize_gpu_replay(video_loaded, video_replay, error) &&
@@ -389,7 +402,7 @@ int main() {
     GpuReplayFrame upgraded_video_replay;
     CHECK(serialize_gpu_capture(legacy_video, upgraded_video_bytes, error) &&
               deserialize_gpu_capture(upgraded_video_bytes, upgraded_video, error) &&
-              upgraded_video.format_version == 28 &&
+              upgraded_video.format_version == 29 &&
               upgraded_video.draws[0].prt.resources[0].captured_size == video_chroma.size &&
               upgraded_video.draws[0].prt.resources[0].resource.linear_row_pitch_bytes == 2048 &&
               materialize_gpu_replay(upgraded_video, upgraded_video_replay, error) &&
@@ -487,6 +500,7 @@ int main() {
           "writer rejects an out-of-bounds DCC metadata reference");
     CHECK(serialize_gpu_capture(volume_capture, volume_bytes, error),
           "recreated valid v12 DCC bytes after malformed-reference check");
+    volume_bytes.resize(volume_bytes.size() - v29_tail(volume_capture));
     volume_bytes.resize(volume_bytes.size() - v28_tail(volume_capture));
     volume_bytes.resize(volume_bytes.size() - v27_tail(volume_capture));
     volume_bytes.resize(volume_bytes.size() - v26_tail(volume_capture));
@@ -562,6 +576,7 @@ int main() {
     CHECK(serialize_gpu_capture(captured, v20_bytes, error) && v20_bytes.size() >= 21,
           "v21 capture serializes the logic-op extension");
     if (v20_bytes.size() >= 21) {
+        v20_bytes.resize(v20_bytes.size() - v29_tail(captured));
         v20_bytes.resize(v20_bytes.size() - v28_tail(captured));
         v20_bytes.resize(v20_bytes.size() - v27_tail(captured));
         v20_bytes.resize(v20_bytes.size() - v26_tail(captured));
@@ -598,6 +613,11 @@ int main() {
           "v21 framebuffer logic op round-trips explicitly");
     CHECK(loaded.draws[0].ps.cb_resolve,
           "v25 MODE=3 resolve intent round-trips explicitly for gpu_replay");
+    CHECK(loaded.draws[0].ps.depth_bias_enable == 1 &&
+              loaded.draws[0].ps.depth_bias_constant == 4.0f &&
+              loaded.draws[0].ps.depth_bias_slope == 2.0f &&
+              loaded.draws[0].ps.depth_bias_clamp == 0.5f,
+          "v29 depth-bias state round-trips explicitly (#1349)");
     CHECK(loaded.draws[0].ps.spi_shader_col_format == 4 &&
           loaded.draws[0].ps.sx_ps_downconvert == 5,
           "v26 color export/downconversion state round-trips explicitly");
@@ -610,6 +630,7 @@ int main() {
           v24_resolve_bytes.size() >= v27_tail(captured) + v26_tail(captured) + v25_tail(captured),
           "v25 capture exposes a removable trailing resolve-state block");
     if (v24_resolve_bytes.size() >= v27_tail(captured) + v26_tail(captured) + v25_tail(captured)) {
+        v24_resolve_bytes.resize(v24_resolve_bytes.size() - v29_tail(captured));
         v24_resolve_bytes.resize(v24_resolve_bytes.size() - v28_tail(captured));
         v24_resolve_bytes.resize(v24_resolve_bytes.size() - v27_tail(captured));
         v24_resolve_bytes.resize(v24_resolve_bytes.size() - v26_tail(captured));
@@ -994,6 +1015,7 @@ int main() {
     if (v13_bytes.size() >= 32) {
         const size_t legacy_resource_count = legacy_source.draws[0].vrt.resources.size() +
                                              legacy_source.draws[0].prt.resources.size();
+        v13_bytes.resize(v13_bytes.size() - v29_tail(legacy_source));
         v13_bytes.resize(v13_bytes.size() - v28_tail(legacy_source));
         v13_bytes.resize(v13_bytes.size() - v27_tail(legacy_source));
         v13_bytes.resize(v13_bytes.size() - v26_tail(legacy_source));
@@ -1022,6 +1044,7 @@ int main() {
     if (legacy_bytes.size() >= 32) {
         const size_t legacy_resource_count = legacy_source.draws[0].vrt.resources.size() +
                                              legacy_source.draws[0].prt.resources.size();
+        legacy_bytes.resize(legacy_bytes.size() - v29_tail(legacy_source));
         legacy_bytes.resize(legacy_bytes.size() - v28_tail(legacy_source));
         legacy_bytes.resize(legacy_bytes.size() - v27_tail(legacy_source));
         legacy_bytes.resize(legacy_bytes.size() - v26_tail(legacy_source));
@@ -1076,9 +1099,9 @@ int main() {
     CHECK(deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
           !legacy_loaded.failure_diagnostics_available && legacy_loaded.failure_diagnostics.empty(),
           "v6 capture reopens with failed-operation diagnostics reported unavailable");
-    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 29;   // kVersion (28) + 1: a not-yet-defined future version
+    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 30;   // kVersion (29) + 1: a not-yet-defined future version
     CHECK(!deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
-          error == "unsupported capture version 29",
+          error == "unsupported capture version 30",
           "future capture versions fail with a concrete version error");
 
     GpuCaptureFile bad_hash = mixed;

--- a/prosper/tests/test_render_state.cpp
+++ b/prosper/tests/test_render_state.cpp
@@ -240,6 +240,30 @@ int main() {
                still_closed.scissor_bottom <= still_closed.scissor_top),
               "a genuine VPORT close stays closed — the screen recovery must not unmask it");
 
+        // #1349: PA_SU_POLY_OFFSET_* -> Vulkan depth bias (radv inverse: constant=asfloat(OFFSET),
+        // slope=asfloat(SCALE)/16, clamp=asfloat(CLAMP)); enable from PA_SU_SC_MODE_CNTL bit 11/12.
+        GpuState biased = st;
+        biased.cx[P::PA_SU_SC_MODE_CNTL] = st.cx.count(P::PA_SU_SC_MODE_CNTL)
+            ? st.cx[P::PA_SU_SC_MODE_CNTL] | (1u << 11) : (1u << 11);
+        auto fbits = [](float value) { uint32_t bits; memcpy(&bits, &value, sizeof bits); return bits; };
+        biased.cx[P::PA_SU_POLY_OFFSET_FRONT_SCALE]  = fbits(32.0f);   // slope 32/16 = 2.0
+        biased.cx[P::PA_SU_POLY_OFFSET_FRONT_OFFSET] = fbits(4.0f);
+        biased.cx[P::PA_SU_POLY_OFFSET_CLAMP]        = fbits(0.5f);
+        const ResolvedPipelineState with_bias =
+            resolve_pipeline_state(extract_render_state(biased));
+        CHECK(with_bias.depth_bias_enable == 1u && with_bias.depth_bias_constant == 4.0f &&
+              with_bias.depth_bias_slope == 2.0f && with_bias.depth_bias_clamp == 0.5f,
+              "POLY_OFFSET front block resolves to Vulkan depth bias (constant/slope/16/clamp)");
+        const ResolvedPipelineState no_bias = resolve_pipeline_state(extract_render_state(st));
+        CHECK(no_bias.depth_bias_enable == 0u && no_bias.depth_bias_constant == 0.0f,
+              "no POLY_OFFSET enable bit resolves to bias disabled");
+        GpuState poisoned = biased;
+        poisoned.cx[P::PA_SU_POLY_OFFSET_FRONT_SCALE] = 0x7fc00000u;   // NaN bit pattern
+        const ResolvedPipelineState nan_bias =
+            resolve_pipeline_state(extract_render_state(poisoned));
+        CHECK(nan_bias.depth_bias_enable == 0u,
+              "a non-finite POLY_OFFSET register disables the bias instead of poisoning it");
+
         RenderState empty{}; empty.has_scissor = true;
         empty.scissor_left = 10; empty.scissor_top = 20;
         empty.scissor_right = 5; empty.scissor_bottom = 15;


### PR DESCRIPTION
Fixes #1349.

## What / why
Games program the `PA_SU_POLY_OFFSET_*` block during shadow-map passes (depth bias against self-shadowing); prosper decoded none of it — the constants existed since the #917 audit with zero consumers, so every shadow map rendered without its bias. Blue Prince programs the D32F configuration live (`DB_FMT_CNTL` NEG_NUM_DB_BITS=-23 + FLOAT_FMT) with constant=-4 / slope=-1 (reverse-Z), verified firing through the new path on a live route.

## Contract
- Decode: the registers hold float bit patterns; the mapping is the radv inverse (radv programs `FRONT_OFFSET = fui(constantFactor)`, `FRONT_SCALE = fui(slopeFactor*16)`, `CLAMP = fui(clamp)`), enable from `PA_SU_SC_MODE_CNTL` POLY_OFFSET_FRONT|BACK (bits 11/12). Vulkan has a single bias — the FRONT block wins when both are enabled (no title observed programming them differently). Non-finite register values disable the bias instead of poisoning the pipeline (unit-tested).
- Backend: static rasterization-state bias; pipeline-cache key schema bumped to 8 with the four fields; `depthBiasClamp` gated on the device feature (clamp drops to 0 without it — the safe direction); `PROSPER_NO_DEPTH_BIAS` is the A/B diagnostic, symmetric with `PROSPER_NO_CULL`.
- Capture v29: count-prefixed trailing tail (u8 enable + three u32 per realized/failed pipeline), following the v25 pattern; v1-v28 prefixes stay byte-exact (all truncation sims extended; future-version probe now 30).

## Verification (exact head)
- ctest 148/148.
- New unit tests: register block → resolved Vulkan values; no-enable → disabled; NaN register → disabled. v29 roundtrip assert + version sims in test_gpu_capture.
- Live probe: bias fires with the game's real values (constant=-4, slope=-1, clamp=0) on the Blue Prince route.
- Snapshot gate running at this head; result posted before merge.

## Honest scope note
The Blue Prince interior banding that motivated the investigation is **unchanged** by this bias (live A/B, before/after visually identical) — that banding has a different mechanism (compare/sampling side; the investigation continues under #1287/#1349's record). This PR lands as real register semantics the titles exercise, per the "unsupported GPU operation is a fatal gap" charter rule, not as the banding fix.

## Risks
- Titles that already looked correct WITHOUT the game's programmed bias could theoretically shift shadow boundaries by the bias amount (that is hardware-faithful behavior); snapshot routes guard the known titles.
- The FRONT-over-BACK choice for asymmetric programming is CONFIDENCE: MED (unobserved).