### PR TITLE
fix(gpu): harden depth-bias decode — execution test, DB_FMT_CNTL check, magnitude bound

### DIFF
--- a/prosper/src/gpu/render_state.cpp
+++ b/prosper/src/gpu/render_state.cpp
@@ -254,6 +254,7 @@ RenderState extract_render_state(const GpuState& st) {
     rs.pa_su_poly_offset_back_scale   = rd(st.cx, P::PA_SU_POLY_OFFSET_BACK_SCALE);
     rs.pa_su_poly_offset_back_offset  = rd(st.cx, P::PA_SU_POLY_OFFSET_BACK_OFFSET);
     rs.pa_su_poly_offset_clamp        = rd(st.cx, P::PA_SU_POLY_OFFSET_CLAMP);
+    rs.pa_su_poly_offset_db_fmt_cntl  = rd(st.cx, P::PA_SU_POLY_OFFSET_DB_FMT_CNTL);
     // Stencil op + ref/mask registers (absent -> 0; stencil_enable already gates whether they apply).
     rs.db_stencil_control   = st.cx.count(P::DB_STENCIL_CONTROL)   ? rd(st.cx, P::DB_STENCIL_CONTROL)   : 0u;
     rs.db_stencilrefmask    = st.cx.count(P::DB_STENCILREFMASK)    ? rd(st.cx, P::DB_STENCILREFMASK)    : 0u;
@@ -714,9 +715,37 @@ ResolvedPipelineState resolve_pipeline_state(const RenderState& rs) {
         ps.depth_bias_constant = as_float(offset);
         ps.depth_bias_slope    = as_float(scale) / 16.0f;
         ps.depth_bias_clamp    = as_float(rs.pa_su_poly_offset_clamp);
-        // A non-finite register value would poison the pipeline; treat it as no bias.
-        if (!std::isfinite(ps.depth_bias_constant) || !std::isfinite(ps.depth_bias_slope) ||
-            !std::isfinite(ps.depth_bias_clamp)) {
+        // The unscaled-constant inverse above is exact only for the float depth configuration:
+        // prosper hosts depth exclusively as D32F, so the host driver always programs the float
+        // DB_FMT_CNTL, and the guest must agree (NEG_NUM_DB_BITS=-23 + FLOAT_FMT = 0x1E9 — the
+        // value Blue Prince programs). A UNORM-style guest config (D16/D24 units; constants
+        // conventionally in the hundreds) would silently misscale by orders of magnitude — warn
+        // once, fail-visibly, rather than guess a conversion (#1351).
+        if ((rs.pa_su_poly_offset_db_fmt_cntl & 0x1FFu) != 0x1E9u) {
+            static std::atomic<bool> warned_fmt{false};
+            if (!warned_fmt.exchange(true))
+                std::fprintf(stderr,
+                             "[render_state] depth bias enabled with non-float "
+                             "PA_SU_POLY_OFFSET_DB_FMT_CNTL=0x%08x (expected 0x1E9 config); "
+                             "constant may be misscaled\n",
+                             rs.pa_su_poly_offset_db_fmt_cntl);
+        }
+        // A non-finite register value would poison the pipeline; treat it as no bias. Huge-but-
+        // finite values are equally implausible as float-config bias factors and DO occur as
+        // float-decoded stale cx-arena garbage on this title family (#1264/#1335) — bound them
+        // out too. 2^24 passes every plausible legitimate value including unorm-convention
+        // constants while rejecting essentially all garbage bit patterns (#1351).
+        const auto bias_bad = [](float v) {
+            return !std::isfinite(v) || std::fabs(v) > 16777216.0f;
+        };
+        if (bias_bad(ps.depth_bias_constant) || bias_bad(ps.depth_bias_slope) ||
+            bias_bad(ps.depth_bias_clamp)) {
+            static std::atomic<bool> warned_mag{false};
+            if (!warned_mag.exchange(true))
+                std::fprintf(stderr,
+                             "[render_state] implausible depth-bias values "
+                             "(constant=%g slope=%g clamp=%g) — disabling bias for this draw\n",
+                             ps.depth_bias_constant, ps.depth_bias_slope, ps.depth_bias_clamp);
             ps.depth_bias_enable = 0u;
             ps.depth_bias_constant = ps.depth_bias_slope = ps.depth_bias_clamp = 0.0f;
         }

--- a/prosper/src/gpu/render_state.hpp
+++ b/prosper/src/gpu/render_state.hpp
@@ -152,6 +152,7 @@ struct RenderState {
     uint32_t pa_su_poly_offset_back_scale   = 0;
     uint32_t pa_su_poly_offset_back_offset  = 0;
     uint32_t pa_su_poly_offset_clamp        = 0;
+    uint32_t pa_su_poly_offset_db_fmt_cntl  = 0;
 
     // Viewport 0 transform (PA_CL_VPORT_{X,Y,Z}{SCALE,OFFSET} — IEEE-754 floats stored in the context
     // registers; 0 when the guest never set them). Hardware applies screen = offset + scale * ndc, with

--- a/prosper/tests/test_multidraw_render.cpp
+++ b/prosper/tests/test_multidraw_render.cpp
@@ -684,6 +684,48 @@ int main() {
         CHECK(sc && sc[1] < 0x80, "standard-Z EQUAL remains exact");
     }
 
+    // #1351: the backend must APPLY the resolved depth bias, not merely decode it. Precedent for
+    // requiring execution coverage: #456's cull/front-face landed decode-only and its reversed
+    // VkFrontFace survived until #534. Contract under test: a LESS draw at exactly the stored
+    // depth is rejected without bias, and a negative constant bias (Vulkan adds
+    // constant * 2^(e-23) on D32F) nudges its fragments nearer so the same draw passes.
+    {
+        std::vector<uint32_t> z_vs = ref_vs_with_depth(vs, 0x3f000000u); // 0.5f
+        CHECK(!z_vs.empty(), "bias test fullscreen VS at z=0.5 available");
+
+        ResolvedPipelineState bias_writer = opaque;
+        bias_writer.color_write_mask = 0;
+        bias_writer.depth_test_enable = true;
+        bias_writer.depth_write_enable = true;
+        bias_writer.depth_compare_op = 7; // ALWAYS
+        bias_writer.depth_read_base = bias_writer.depth_write_base = 0x77660000;
+
+        ResolvedPipelineState less_reader = opaque;
+        less_reader.depth_test_enable = true;
+        less_reader.depth_compare_op = 1; // LESS
+        less_reader.depth_read_base = less_reader.depth_write_base = 0x77660000;
+
+        prosper::test::BackendDraw bw; bw.vs = z_vs; bw.fs = red; bw.ps = &bias_writer; bw.vcount = 3;
+        prosper::test::BackendDraw br; br.vs = z_vs; br.fs = green; br.ps = &less_reader; br.vcount = 3;
+        (void)prosper::test::render_draws_rgba({bw}, W, H, nullptr, nullptr, true);
+        std::vector<uint8_t> unbiased =
+            prosper::test::render_draws_rgba({br}, W, H, nullptr, nullptr, true);
+        const uint8_t* uc = center(unbiased);
+        CHECK(uc && uc[1] < 0x80, "LESS at exactly the stored depth is rejected without bias");
+
+        ResolvedPipelineState biased_reader = less_reader;
+        biased_reader.depth_bias_enable = 1u;
+        biased_reader.depth_bias_constant = -64.0f;   // ~-3.8e-6 at e(0.5) on D32F — decisive, tiny
+        biased_reader.depth_bias_slope = 0.0f;
+        biased_reader.depth_bias_clamp = 0.0f;
+        prosper::test::BackendDraw bb = br; bb.ps = &biased_reader;
+        std::vector<uint8_t> biased =
+            prosper::test::render_draws_rgba({bb}, W, H, nullptr, nullptr, true);
+        const uint8_t* bc = center(biased);
+        CHECK(bc && bc[1] > 0xC0 && bc[0] < 0x40,
+              "a negative constant depth bias flips the same LESS draw to passing (#1351)");
+    }
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;

--- a/prosper/tests/test_render_state.cpp
+++ b/prosper/tests/test_render_state.cpp
@@ -263,6 +263,23 @@ int main() {
             resolve_pipeline_state(extract_render_state(poisoned));
         CHECK(nan_bias.depth_bias_enable == 0u,
               "a non-finite POLY_OFFSET register disables the bias instead of poisoning it");
+        // #1351: huge-but-finite float-decoded garbage (documented stale cx-arena phenomenon on
+        // this title family, #1264/#1335) must not become an absurd bias — bound at 2^24.
+        GpuState huge = biased;
+        huge.cx[P::PA_SU_POLY_OFFSET_FRONT_OFFSET] = fbits(1e30f);
+        const ResolvedPipelineState huge_bias =
+            resolve_pipeline_state(extract_render_state(huge));
+        CHECK(huge_bias.depth_bias_enable == 0u && huge_bias.depth_bias_constant == 0.0f,
+              "an implausibly large POLY_OFFSET value (>2^24) disables the bias");
+        // The float depth config (0x1E9) must keep the bias enabled — the DB_FMT_CNTL check is
+        // fail-visible logging only, never a behavior gate for the exercised configuration.
+        GpuState float_cfg = biased;
+        float_cfg.cx[P::PA_SU_POLY_OFFSET_DB_FMT_CNTL] = 0x1E9u;
+        const ResolvedPipelineState float_cfg_bias =
+            resolve_pipeline_state(extract_render_state(float_cfg));
+        CHECK(float_cfg_bias.depth_bias_enable == 1u &&
+              float_cfg_bias.depth_bias_constant == 4.0f,
+              "the float DB_FMT_CNTL configuration (0x1E9) keeps the decoded bias intact");
 
         RenderState empty{}; empty.has_scissor = true;
         empty.scissor_left = 10; empty.scissor_top = 20;

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -225,7 +225,8 @@ Version-4+ capsules also print and restore temporal RTT seeds: exact host-render
 captured submit whose producer ran in an earlier submit. This keeps replay from silently substituting stale
 guest-memory bytes for renderer-owned history; older capsules remain readable and report zero seeds.
 The draw header also reports raster state as `raster=cull/front-face/polygon-mode`, using Vulkan enum
-values. `PROSPER_NO_CULL=1` disables culling; `PROSPER_FLIP_FRONT_FACE=1` preserves the cull mode and
+values, and the resolved depth bias as `bias=enable/constant/slope/clamp` (all zero for pre-v29
+captures, which did not retain bias state). `PROSPER_NO_CULL=1` disables culling; `PROSPER_FLIP_FRONT_FACE=1` preserves the cull mode and
 toggles only the resolved winding convention. The latter is useful for isolating `PA_SU_SC_MODE_CNTL`
 translation without the overdraw introduced by disabling culling entirely.
 `PROSPER_EXECLOG=1` includes command order, target extent, depth/stencil identity, compare/write state, and clear

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -339,7 +339,8 @@ void inspect_frame(const prosper::gpu::GpuReplayFrame& replay) {
         }
         std::printf("draw[%zu] source=%llu target=%016llx extent=%ux%u fmt=%u cwm=%x "
                     "target1=%016llx extent1=%ux%u fmt1=%u cwm1=%x vcount=%u indices=%zu voffset=%d modifier=%016llx topo=%u%s "
-                    "depth=%d/%d/%u stencil=%d blend=%d raster=%u/%u/%u viewport=%d %.1f,%.1f %.1fx%.1f "
+                    "depth=%d/%d/%u stencil=%d blend=%d raster=%u/%u/%u bias=%u/%g/%g/%g "
+                    "viewport=%d %.1f,%.1f %.1fx%.1f "
                     "scissor=%d [%d,%d)-[%d,%d) export=%08x downconvert=%08x "
                     "vs=%zu/%016llx fs=%zu/%016llx\n",
                     i, static_cast<unsigned long long>(d.draw_index),
@@ -351,6 +352,8 @@ void inspect_frame(const prosper::gpu::GpuReplayFrame& replay) {
                     d.ps.topology, rawtag, d.ps.depth_test_enable,
                     d.ps.depth_write_enable, d.ps.depth_compare_op, d.ps.stencil_enable, d.ps.blend_enable,
                     d.ps.cull_mode, d.ps.front_face, d.ps.polygon_mode,
+                    d.ps.depth_bias_enable, d.ps.depth_bias_constant, d.ps.depth_bias_slope,
+                    d.ps.depth_bias_clamp,
                     d.ps.has_viewport, d.ps.viewport_x, d.ps.viewport_y, d.ps.viewport_w, d.ps.viewport_h,
                     d.ps.has_scissor, d.ps.scissor_left, d.ps.scissor_top,
                     d.ps.scissor_right, d.ps.scissor_bottom,


### PR DESCRIPTION
Fixes #1351 (the three non-blocking recommendations from the #1350 independent review, in priority order).

## Changes

1. **Execution-level bias-application test** (`prosper/tests/test_multidraw_render.cpp`). Decode was regression-tested in #1350 but nothing proved the backend *applies* the bias; the cited precedent is #456's cull/front-face landing decode-only with its reversed `VkFrontFace` surviving until #534. The new test writes a z=0.5 depth plane (ALWAYS+write), shows a LESS draw at exactly the stored depth is rejected unbiased, then that `depth_bias_enable=1, constant=-64` (≈ −3.8e-6 at e(0.5) on D32F) flips the same draw to passing. **Discriminance verified**: the final check fails under `PROSPER_NO_DEPTH_BIAS=1` (the backend-side kill switch), i.e. exactly when the backend fails to apply a decoded bias.
2. **`PA_SU_POLY_OFFSET_DB_FMT_CNTL` (0x2DE) decoded + fail-visible warn** (`render_state.{hpp,cpp}`). The unscaled-constant radv inverse is exact only for the float depth configuration (`0x1E9` = NEG_NUM_DB_BITS=-23 + FLOAT_FMT — what Blue Prince programs, and what the D32F-only host always uses); a UNORM-style guest config would silently misscale the constant by orders of magnitude. One-time warn when bias is enabled with any other configuration; logging only, no behavior change. Regression: the 0x1E9 config keeps the decoded bias intact.
3. **Magnitude bound alongside `isfinite`** (`render_state.cpp`). Huge-but-finite float-decoded garbage (documented stale cx-arena phenomenon on this title family: #1264's ~94k garbage offsets, #1335's stale fold) passed the isfinite guard. `|constant|/|slope|/|clamp| > 2^24` → disable bias + one-time warn. Regression: `fbits(1e30f)` in FRONT_OFFSET → bias disabled.

Also: `gpu_replay --inspect-only` now prints per-draw v29 bias state (`bias=enable/constant/slope/clamp`) so a capture shows directly whether a pass carries bias — being used right now in the #1287 ring investigation to check whether Blue Prince's shadow-caster passes retain their POLY_OFFSET enables.

## Behavior notes / risks

- No exercised title changes behavior: Blue Prince's live values (constant=-4, slope=-1, clamp=0, config 0x1E9) pass both gates; the magnitude bound only triggers on garbage-decoded registers, where applying the "bias" was never meaningful.
- The DB_FMT_CNTL warn also fires for config 0 (register never programmed while enable bits set) — deliberate: a guest enabling bias without programming the format is itself suspicious, and the message includes the raw value.

## Verification

- ctest **148/148** (Linux distrobox), including the three new `test_render_state` cases and the two new `test_multidraw_render` execution checks.
- Discriminance: `PROSPER_NO_DEPTH_BIAS=1 ./test_multidraw_render` → the #1351 execution check FAILS (and only it).
- Snapshot gate queued at this head (emulator currently occupied by a capture run); result will be posted before merge.