### PR TITLE
fix(gpu): SCISSORLOG atomic counter + effective-values label

### DIFF
--- a/prosper/src/gpu/render_state.cpp
+++ b/prosper/src/gpu/render_state.cpp
@@ -439,9 +439,12 @@ RenderState extract_render_state(const GpuState& st) {
         // rectangle is empty — Blue Prince resolves 699 of ~2,400 Day One draws to [0,0)x[0,0).
         if (right <= left || bottom <= top) {
             static const bool scissor_log = getenv("PROSPER_SCISSORLOG") != nullptr;
-            static int logged = 0;
-            if (scissor_log && logged < 24) {
-                ++logged;
+            // Atomic like the #1335 recovery log above: extract_render_state runs from
+            // DrawRealizationPool workers, so a plain int here was a formal data race (#1345).
+            static std::atomic<int> logged{0};
+            if (scissor_log && logged.fetch_add(1) < 24) {
+                // screen= is the EFFECTIVE pair — the #1335 degenerate-pair recovery above may
+                // have substituted the full default; the recovery's own log prints the raw pair.
                 fprintf(stderr,
                         "[scissor] EMPTY combined=[%d,%d)-[%d,%d) screen=%08x/%08x window=%08x/%08x "
                         "generic=%08x/%08x vport=%08x/%08x offset=%08x mode=%08x\n",


### PR DESCRIPTION
Fixes #1345 (both nits from the #1344 independent review).

1. The `PROSPER_SCISSORLOG` empty-scissor dump counter was a plain `static int` mutated from DrawRealizationPool workers — a formal data race. Now `static std::atomic<int>` with `fetch_add`, matching the #1335 recovery log's established pattern one block above.
2. The dump prints the screen pair AFTER the #1335 degenerate-pair recovery may have substituted the full default, while presenting itself as raw registers. A comment now states these are the effective values and points at the recovery's own log for the raw pair.

Env-gated logging only; no behavior change on any default path (the log requires `PROSPER_SCISSORLOG`; the counter's increment still only evaluates under the flag via short-circuit). Verification: full ctest **148/148** on Linux (distrobox) at this head, rebased on current master (post-#1357). No snapshot run: the change cannot affect rendered output (diagnostic printf path only). Independent review skipped per the routine/mechanical/low-risk carve-out — the change transplants an existing reviewed pattern.