### PR TITLE
fix(gpu): STENCIL_CLEAR_ENABLE acts only through the enabled stencil write path

### DIFF
--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -1473,6 +1473,18 @@ constexpr bool persistent_ds_pass_may_write_depth(bool clear_enabled, bool test_
     return test_enabled && write_enabled && compare_op != VK_COMPARE_OP_NEVER;
 }
 
+// STENCIL_CLEAR_ENABLE is the stencil twin of the rule above (#1355): the bit substitutes the
+// VALUE of stencil writes and only acts through the enabled stencil write path — STENCIL_ENABLE
+// plus a nonzero write mask (driver stencil-clear draws program enable+ALWAYS+REPLACE+full mask).
+// Op-level analysis (a KEEP-everywhere draw writes nothing) is deliberately omitted: requiring
+// only enable+mask errs toward honoring clears, the safe direction for real guest clear shapes.
+// CONFIDENCE: MED (write-path gating by analogy with the #1352 title evidence; no title observed
+// exercising the writes-disabled stencil shape).
+constexpr bool stencil_clear_effective(bool clear_enabled, bool stencil_enabled,
+                                       uint32_t write_mask_front, uint32_t write_mask_back) {
+    return clear_enabled && stencil_enabled && ((write_mask_front | write_mask_back) != 0u);
+}
+
 inline void note_persistent_ds_depth_write(PersistentDsImage& image, bool use_depth,
                                            bool depth_may_be_written) {
     if (use_depth && depth_may_be_written)
@@ -2085,7 +2097,14 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                     ? 0.0f : 1.0f;
                 got_depth_clear = true;
             } }
-        if (d.ps->stencil_enable || d.ps->stencil_clear_enable) { use_stencil = true;
+        // #1355: like the depth gate above, a STENCIL_CLEAR_ENABLE bit with the stencil write
+        // path disabled is inert and must not force a stencil attachment or clear in-pass. The
+        // initial-value latch stays reachable through stencil_enable only, mirroring the depth
+        // fresh-image approximation.
+        if (d.ps->stencil_enable ||
+            stencil_clear_effective(d.ps->stencil_clear_enable, d.ps->stencil_enable,
+                                    d.ps->stencil_write_mask[0], d.ps->stencil_write_mask[1])) {
+            use_stencil = true;
             if (!got_stencil_clear) {
                 stencil_clear = d.ps->stencil_clear_value; got_stencil_clear = true;
             } }
@@ -2107,7 +2126,10 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     const prosper::gpu::ResolvedPipelineState* identity = nullptr;
     for (const auto& d : draws)
         if (d.ps && (d.ps->depth_test_enable || d.ps->stencil_enable ||
-                     effective_depth_clear(d.ps) || d.ps->stencil_clear_enable)) { identity = d.ps; break; }
+                     effective_depth_clear(d.ps) ||
+                     stencil_clear_effective(d.ps->stencil_clear_enable, d.ps->stencil_enable,
+                                             d.ps->stencil_write_mask[0],
+                                             d.ps->stencil_write_mask[1]))) { identity = d.ps; break; }
     const bool has_ds_identity = identity && (identity->depth_read_base || identity->depth_write_base ||
                                                identity->stencil_read_base || identity->stencil_write_base);
     const bool persistent_ds = persist_depth_stencil && use_ds && has_ds_identity;
@@ -4110,10 +4132,15 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     for (size_t di = 0; di < dv.size(); di++) {
         auto& v = dv[di];
         const auto* ps = draws[di].ps;
-        if (use_ds && ps && (effective_depth_clear(ps) || ps->stencil_clear_enable)) {
+        if (use_ds && ps &&
+            (effective_depth_clear(ps) ||
+             stencil_clear_effective(ps->stencil_clear_enable, ps->stencil_enable,
+                                     ps->stencil_write_mask[0], ps->stencil_write_mask[1]))) {
             VkClearAttachment dsc{};
             if (effective_depth_clear(ps)) dsc.aspectMask |= VK_IMAGE_ASPECT_DEPTH_BIT;
-            if (ps->stencil_clear_enable && format_has_stencil)
+            if (stencil_clear_effective(ps->stencil_clear_enable, ps->stencil_enable,
+                                        ps->stencil_write_mask[0], ps->stencil_write_mask[1]) &&
+                format_has_stencil)
                 dsc.aspectMask |= VK_IMAGE_ASPECT_STENCIL_BIT;
             dsc.clearValue.depthStencil = {ps->depth_clear_value, ps->stencil_clear_value};
             VkClearRect rect{v.scissor, 0, 1};

--- a/prosper/tests/test_multidraw_render.cpp
+++ b/prosper/tests/test_multidraw_render.cpp
@@ -726,6 +726,54 @@ int main() {
               "a negative constant depth bias flips the same LESS draw to passing (#1351)");
     }
 
+    // #1355: STENCIL_CLEAR_ENABLE is the stencil twin of the #1352 depth rule — the bit
+    // substitutes the VALUE of stencil writes and only acts through the enabled stencil write
+    // path. A writes-disabled clear rect between a stencil writer and an EQUAL reader must not
+    // destroy the written plane.
+    {
+        CHECK(!prosper::test::stencil_clear_effective(true, false, 0xff, 0xff),
+              "a stencil clear with STENCIL_ENABLE off is inert (#1355)");
+        CHECK(!prosper::test::stencil_clear_effective(true, true, 0, 0),
+              "a stencil clear with a zero write mask is inert");
+        CHECK(prosper::test::stencil_clear_effective(true, true, 0xff, 0),
+              "a real stencil clear shape (enable + mask) stays effective");
+
+        ResolvedPipelineState swriter = opaque;
+        swriter.color_write_mask = 0;
+        swriter.stencil_enable = true;
+        swriter.stencil_compare_op[0] = swriter.stencil_compare_op[1] = 7; // ALWAYS
+        swriter.stencil_pass_op[0] = swriter.stencil_pass_op[1] = 2;       // REPLACE
+        swriter.stencil_op_val[0] = swriter.stencil_op_val[1] = 2;
+        swriter.stencil_write_mask[0] = swriter.stencil_write_mask[1] = 0xff;
+        swriter.stencil_read_base = swriter.stencil_write_base = 0x88770000;
+
+        ResolvedPipelineState inert_sclear{};
+        inert_sclear.topology = 3; inert_sclear.color_write_mask = 0;
+        inert_sclear.stencil_clear_enable = true;
+        inert_sclear.stencil_clear_value = 7;
+        inert_sclear.stencil_enable = false;   // write path fully disabled
+        inert_sclear.stencil_read_base = inert_sclear.stencil_write_base = 0x88770000;
+
+        ResolvedPipelineState sreader = opaque;
+        sreader.stencil_enable = true;
+        sreader.stencil_compare_op[0] = sreader.stencil_compare_op[1] = 2; // EQUAL
+        sreader.stencil_ref[0] = sreader.stencil_ref[1] = 2;
+        sreader.stencil_compare_mask[0] = sreader.stencil_compare_mask[1] = 0xff;
+        sreader.stencil_write_mask[0] = sreader.stencil_write_mask[1] = 0;
+        sreader.stencil_read_base = sreader.stencil_write_base = 0x88770000;
+
+        prosper::test::BackendDraw sw; sw.vs = vs; sw.fs = red; sw.ps = &swriter; sw.vcount = 3;
+        prosper::test::BackendDraw scl; scl.vs = vs; scl.fs = red; scl.ps = &inert_sclear; scl.vcount = 3;
+        prosper::test::BackendDraw sr; sr.vs = vs; sr.fs = green; sr.ps = &sreader; sr.vcount = 3;
+        (void)prosper::test::render_draws_rgba({sw}, W, H, nullptr, nullptr, true);
+        (void)prosper::test::render_draws_rgba({scl}, W, H, nullptr, nullptr, true);
+        std::vector<uint8_t> preserved =
+            prosper::test::render_draws_rgba({sr}, W, H, nullptr, nullptr, true);
+        const uint8_t* pc = center(preserved);
+        CHECK(pc && pc[1] > 0xC0 && pc[0] < 0x40,
+              "EQUAL reader still sees the written stencil after an inert clear rect (#1355)");
+    }
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;


### PR DESCRIPTION
Fixes #1355 (filed from the #1354 review as the stencil twin of the #1352 depth rule).

## Contract

`DB_RENDER_CONTROL.STENCIL_CLEAR_ENABLE` substitutes the VALUE of stencil writes; it does not create writes. The stencil write path requires `STENCIL_ENABLE` plus a nonzero write mask (driver stencil-clear draws program enable+ALWAYS+REPLACE+full mask — the same shape family as the #1352 depth evidence). prosper previously honored the bit unconditionally at the pass-effect sites, so a writes-disabled clear rect between a stencil writer and a reader destroyed the written plane. No title is currently known to exercise the inert shape — this is hardening by direct analogy so the #1352 bug class isn't rediscovered; CONFIDENCE: MED is marked in the code.

## Change (`prosper/tests/render_runner.h`, shared live + replay)

- New `stencil_clear_effective(clear, stencil_enable, wmask_front, wmask_back)` beside the depth predicate.
- Gated sites: `use_stencil` attachment forcing, DS-identity selection, in-pass `vkCmdClearAttachments` stencil aspect (and its enclosing entry condition).
- Deliberately NOT gated: the initial-value path (reachable via `stencil_enable`, mirroring the depth fresh-image approximation) and `stencil_valid |= use_stencil` (pre-existing coarser semantics — narrowing it is a separate question; the clear-only-draw gating already prevents the inert shape from marking validity since such a pass no longer uses stencil at all). Op-level analysis (a KEEP-everywhere draw writes nothing) omitted — enable+mask errs toward honoring clears, the safe direction.

## Verification

- New checks in `test_multidraw_render`: three predicate cases + a persistent-DS execution scenario (REPLACE writer stencil=2 → writes-disabled clear rect value 7 → EQUAL ref=2 reader must still pass).
- **Fails without the fix**: with old semantics temporarily restored, the inert rect clears the plane and 3 checks fail (including the execution scenario); with the gate, all pass.
- Full ctest **148/148** (Linux distrobox), including the #919 stencil-writer/reader anchor and the #534/#508/#371 depth blocks.
- Snapshot gate will run at this head and be posted before merge (Messenger #541 stencil family is the key route).
- Independent review requested (behavioral change in reverse-engineered semantics).

## Risks

A title performing a real stencil clear with a shape outside enable+mask (contradicting the derived contract) would regress fail-visibly toward preserved/loaded stencil. The #1352 depth precedent, the driver clear shapes, and the snapshot suite bound this risk.