### PR TITLE
fix(gpu): stencil initial value only from an explicit clear; #1361 test hygiene

### DIFF
--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -2105,7 +2105,12 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
             stencil_clear_effective(d.ps->stencil_clear_enable, d.ps->stencil_enable,
                                     d.ps->stencil_write_mask[0], d.ps->stencil_write_mask[1])) {
             use_stencil = true;
-            if (!got_stencil_clear) {
+            // Mirror the depth contract (#371/#508 via #1361): DB_STENCIL_CLEAR is consumed as a
+            // fresh image's initial contents only when the guest explicitly requests a clear.
+            // Latching it from every stencil-using draw let a STALE register word poison a new
+            // plane (the stencil analog of #371's Astro Bot depth case); without a clear the
+            // unknown guest contents are approximated as 0.
+            if (!got_stencil_clear && d.ps->stencil_clear_enable) {
                 stencil_clear = d.ps->stencil_clear_value; got_stencil_clear = true;
             } }
     }

--- a/prosper/tests/test_multidraw_render.cpp
+++ b/prosper/tests/test_multidraw_render.cpp
@@ -473,6 +473,12 @@ int main() {
         off_target_clear.color_write_mask = 0;
         off_target_clear.stencil_clear_enable = true;
         off_target_clear.stencil_clear_value = 0;
+        // #1361: keep this an EFFECTIVE clear shape (enable + write mask). With the #1355
+        // write-path gate, a bare clear bit is inert and this check would pass vacuously without
+        // exercising the off-target scissor clamp it was written for (#531).
+        off_target_clear.stencil_enable = true;
+        off_target_clear.stencil_compare_op[0] = off_target_clear.stencil_compare_op[1] = 7;
+        off_target_clear.stencil_write_mask[0] = off_target_clear.stencil_write_mask[1] = 0xff;
         off_target_clear.has_scissor = true;
         off_target_clear.scissor_left = 100; off_target_clear.scissor_top = 100;
         off_target_clear.scissor_right = 120; off_target_clear.scissor_bottom = 120;
@@ -772,6 +778,25 @@ int main() {
         const uint8_t* pc = center(preserved);
         CHECK(pc && pc[1] > 0xC0 && pc[0] < 0x40,
               "EQUAL reader still sees the written stencil after an inert clear rect (#1355)");
+
+        // #1361: an inert clear against a NEVER-written identity must not phantom-initialize the
+        // plane to its clear value. A partial gate (clear-site only) would let the forced stencil
+        // pass create the image, seed it from the latched clear value, and mark it valid — a later
+        // EQUAL-7 reader would then wrongly pass. With the full gate the reader's fresh plane
+        // defaults to 0 and EQUAL-7 rejects everywhere.
+        ResolvedPipelineState inert_fresh = inert_sclear;
+        inert_fresh.stencil_read_base = inert_fresh.stencil_write_base = 0x88780000;
+        ResolvedPipelineState seven_reader = sreader;
+        seven_reader.stencil_ref[0] = seven_reader.stencil_ref[1] = 7;
+        seven_reader.stencil_read_base = seven_reader.stencil_write_base = 0x88780000;
+        prosper::test::BackendDraw fcl; fcl.vs = vs; fcl.fs = red; fcl.ps = &inert_fresh; fcl.vcount = 3;
+        prosper::test::BackendDraw fr7; fr7.vs = vs; fr7.fs = green; fr7.ps = &seven_reader; fr7.vcount = 3;
+        (void)prosper::test::render_draws_rgba({fcl}, W, H, nullptr, nullptr, true);
+        std::vector<uint8_t> untouched =
+            prosper::test::render_draws_rgba({fr7}, W, H, nullptr, nullptr, true);
+        const uint8_t* uc7 = center(untouched);
+        CHECK(uc7 && uc7[1] < 0x80,
+              "an inert clear cannot phantom-initialize a never-written plane (#1361)");
     }
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }


### PR DESCRIPTION
Fixes #1361 (the three follow-ups recorded from the #1359 review).

1. **Stencil fresh-image initial value now requires an explicit clear** (`render_runner.h`), mirroring the depth #371/#508 contract: only `STENCIL_CLEAR_ENABLE` lets `DB_STENCIL_CLEAR` seed a newly-created plane; otherwise the unknown guest contents are approximated as 0. Previously ANY stencil-using draw latched the register word, so a stale value could poison a fresh plane (the stencil analog of #371's Astro Bot case). Behavior in practice is unchanged for all exercised shapes: non-clear draws carry `stencil_clear_value == 0` (the decode default), which equals the new fallback — only the stale-word poison case changes, fail-visibly toward 0.
2. **New regression**: an inert clear against a never-written identity must not phantom-initialize the plane (later EQUAL-`<clear value>` reader stays rejected). A simulated forcing-only partial fix confirmed the identity-selection gate independently blocks the phantom path — the test plus the per-site predicate checks cover the fully-ungated variant.
3. **#531 power restoration**: `off_target_clear` now programs an effective clear shape (enable+ALWAYS+full mask) so the off-target scissor-clamp check exercises the clamp again instead of passing vacuously through the #1355 gate.

Verification: full ctest **148/148** (Linux distrobox) including all stencil anchors (#919, #518, #531, the #1355 block). Item 1 is behavioral only for the stale-poison shape no known title exercises; snapshot gate will run at this head and be posted before merge (Messenger stencil family again the key route).