### PR TITLE
fix(gpu): recover lone-zero DB read/write base halves (#1353 stale arena slots)

### DIFF
--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -1704,13 +1704,14 @@ void GpuState::apply(const Pm4Command& c) {
                     continue;
                 }
                 file[regs[i].offset] = regs[i].value;
-                // PROSPER_DBBASETRACE (#1353): log every cx write into the DB base/info block
-                // (0x10..0x1F) with its source path, to attribute which packet family programs
-                // (or fails to program) DB_Z_WRITE_BASE for the shadow-caster passes.
+                // PROSPER_DBBASETRACE (#1353): log every cx write to the DB Z/STENCIL base
+                // registers (LO 0x12..0x15, HI 0x1A..0x1D) with its source path, to attribute
+                // which packet family programs (or clobbers) a base half — this trace found the
+                // stale arena slot writing (DB_Z_WRITE_BASE, 0) after the real pair write.
                 static const bool dbbase_trace = getenv("PROSPER_DBBASETRACE") != nullptr;
                 if (dbbase_trace && c.reg_class == RegClass::Cx &&
-                    (regs[i].offset == 0x12u || regs[i].offset == 0x14u ||
-                     regs[i].offset == 0x1Au || regs[i].offset == 0x1Cu)) {
+                    ((regs[i].offset >= 0x12u && regs[i].offset <= 0x15u) ||
+                     (regs[i].offset >= 0x1Au && regs[i].offset <= 0x1Du))) {
                     static std::atomic<int> n{0};
                     if (n.fetch_add(1) < 400000)
                         fprintf(stderr, "[dbbase] indirect off=0x%x val=0x%x order=%llu\n",
@@ -1796,7 +1797,7 @@ void GpuState::apply(const Pm4Command& c) {
             // PROSPER_DBBASETRACE (#1353): direct-span sibling of the indirect-path trace above.
             {
                 static const bool dbbase_trace = getenv("PROSPER_DBBASETRACE") != nullptr;
-                if (dbbase_trace && c.reg_class == RegClass::Cx && c.reg_offset <= 0x14u &&
+                if (dbbase_trace && c.reg_class == RegClass::Cx && c.reg_offset <= 0x1Du &&
                     c.reg_offset + c.reg_count > 0x12u) {
                     static std::atomic<int> n{0};
                     if (n.fetch_add(1) < 400000) {

--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -1704,6 +1704,19 @@ void GpuState::apply(const Pm4Command& c) {
                     continue;
                 }
                 file[regs[i].offset] = regs[i].value;
+                // PROSPER_DBBASETRACE (#1353): log every cx write into the DB base/info block
+                // (0x10..0x1F) with its source path, to attribute which packet family programs
+                // (or fails to program) DB_Z_WRITE_BASE for the shadow-caster passes.
+                static const bool dbbase_trace = getenv("PROSPER_DBBASETRACE") != nullptr;
+                if (dbbase_trace && c.reg_class == RegClass::Cx &&
+                    (regs[i].offset == 0x12u || regs[i].offset == 0x14u ||
+                     regs[i].offset == 0x1Au || regs[i].offset == 0x1Cu)) {
+                    static std::atomic<int> n{0};
+                    if (n.fetch_add(1) < 400000)
+                        fprintf(stderr, "[dbbase] indirect off=0x%x val=0x%x order=%llu\n",
+                                regs[i].offset, regs[i].value,
+                                (unsigned long long)command_order);
+                }
                 if (c.reg_class == RegClass::Cx &&
                     regs[i].offset == prosper::agc::Pm4::DB_RENDER_CONTROL &&
                     (regs[i].value & 0x3u) &&
@@ -1780,6 +1793,21 @@ void GpuState::apply(const Pm4Command& c) {
             }
             for (uint32_t k = 0; k < c.reg_count && c.reg_offset + k < kRegOffsetLimit; k++)
                 file[c.reg_offset + k] = c.reg_data[k];
+            // PROSPER_DBBASETRACE (#1353): direct-span sibling of the indirect-path trace above.
+            {
+                static const bool dbbase_trace = getenv("PROSPER_DBBASETRACE") != nullptr;
+                if (dbbase_trace && c.reg_class == RegClass::Cx && c.reg_offset <= 0x14u &&
+                    c.reg_offset + c.reg_count > 0x12u) {
+                    static std::atomic<int> n{0};
+                    if (n.fetch_add(1) < 400000) {
+                        fprintf(stderr, "[dbbase] direct off=0x%x count=%u order=%llu vals:",
+                                c.reg_offset, c.reg_count, (unsigned long long)command_order);
+                        for (uint32_t k = 0; k < c.reg_count && k < 16; k++)
+                            fprintf(stderr, " 0x%x", c.reg_data[k]);
+                        fprintf(stderr, "\n");
+                    }
+                }
+            }
             state_dirty_ = true;
             break;
         }

--- a/prosper/src/gpu/render_state.cpp
+++ b/prosper/src/gpu/render_state.cpp
@@ -201,6 +201,27 @@ RenderState extract_render_state(const GpuState& st) {
     rs.depth_write_base = addr_of(rd(st.cx, P::DB_Z_WRITE_BASE), rd(st.cx, P::DB_Z_WRITE_BASE_HI));
     rs.stencil_read_base = addr_of(rd(st.cx, P::DB_STENCIL_READ_BASE), rd(st.cx, P::DB_STENCIL_READ_BASE_HI));
     rs.stencil_write_base = addr_of(rd(st.cx, P::DB_STENCIL_WRITE_BASE), rd(st.cx, P::DB_STENCIL_WRITE_BASE_HI));
+    // #1353: on GFX10 the READ and WRITE base registers describe ONE surface — drivers program
+    // both from a single address (the split is a pre-GFX10 TC-compat remnant), so a lone zero on
+    // either side is never a coherent state. Blue Prince's Gen5 indirect register arenas carry
+    // stale slots that parse as (DB_Z_WRITE_BASE, 0) AFTER the real pair write in the SAME array
+    // (PROSPER_DBBASETRACE capture on the issue; the #1335 screen-scissor fold is the same
+    // family), leaving every shadow-caster pass with (read=P, write=0) and splitting the
+    // persistent-DS identity. Recover the clobbered half from its partner and log fail-visibly;
+    // a genuine unbind writes both halves 0 and is untouched. Divergent NONZERO pairs are kept
+    // as-is (not observed; hardware would not produce them either).
+    const auto recover_pair = [](uint64_t& a, uint64_t& b, const char* which) {
+        if (a == b || (a && b)) return;
+        static std::atomic<int> logged{0};
+        if (logged.fetch_add(1) < 8)
+            fprintf(stderr,
+                    "[render_state] lone-zero DB %s base recovered from partner "
+                    "(read=0x%llx write=0x%llx, #1353 stale arena slot)\n",
+                    which, (unsigned long long)a, (unsigned long long)b);
+        if (!a) a = b; else b = a;
+    };
+    recover_pair(rs.depth_read_base, rs.depth_write_base, "Z");
+    recover_pair(rs.stencil_read_base, rs.stencil_write_base, "STENCIL");
     rs.db_depth_view = rd(st.cx, P::DB_DEPTH_VIEW);
     rs.db_render_override = rd(st.cx, P::DB_RENDER_OVERRIDE);
     rs.db_render_override2 = rd(st.cx, P::DB_RENDER_OVERRIDE2);

--- a/prosper/tests/test_render_state.cpp
+++ b/prosper/tests/test_render_state.cpp
@@ -435,6 +435,31 @@ int main() {
           rs.db_stencil_info == 0x66u && rs.db_htile_surface == 0x99u,
           "depth view, HTILE, format, and extent programming is retained");
 
+    // #1353: GFX10 read/write DB bases describe one surface; a LONE zero half is a stale
+    // Gen5 indirect-arena slot (observed live as (DB_Z_WRITE_BASE, 0) folded AFTER the real
+    // pair write in the same array) and recovers from its partner. Pair-zero (a genuine
+    // unbind) and divergent nonzero pairs (asserted verbatim above) are untouched.
+    {
+        GpuState lone;
+        lone.cx[P::DB_Z_READ_BASE] = 0x21135e00u;
+        lone.cx[P::DB_Z_WRITE_BASE] = 0u;
+        lone.cx[P::DB_STENCIL_WRITE_BASE] = 0x21136000u;
+        const RenderState rec = extract_render_state(lone);
+        CHECK(rec.depth_write_base == rec.depth_read_base &&
+              rec.depth_read_base == rdna2_addr(0x21135e00u, 0u),
+              "a lone-zero DB_Z_WRITE_BASE recovers from the read base (#1353)");
+        CHECK(rec.stencil_read_base == rec.stencil_write_base &&
+              rec.stencil_write_base == rdna2_addr(0x21136000u, 0u),
+              "a lone-zero DB_STENCIL_READ_BASE recovers from the write base");
+
+        GpuState unbound;
+        unbound.cx[P::DB_DEPTH_CONTROL] = 0x46u;
+        const RenderState none = extract_render_state(unbound);
+        CHECK(none.depth_read_base == 0 && none.depth_write_base == 0 &&
+              none.stencil_read_base == 0 && none.stencil_write_base == 0,
+              "pair-zero (unbound) DB bases stay zero — no invented identity");
+    }
+
     // #371: depth clear value. The sample stream programs no DB_DEPTH_CLEAR, so resolve defaults it by
     // the compare op — 0.0 for GREATER (this stream), 1.0 for LESS — never a fixed 0.5. A programmed
     // DB_DEPTH_CLEAR is used verbatim.


### PR DESCRIPTION
Fixes #1353.

## Failure scenario

Blue Prince's per-light shadow-caster passes decoded `(DB_Z_READ_BASE=P, DB_Z_WRITE_BASE=0)` with Z writes enabled — impossible on hardware: GFX10's read/write base registers describe **one** surface (radv/PAL program both from a single address; the split is a pre-GFX10 TC-compat remnant). The split identity keyed the persistent-DS cache `(P,0)` for casters vs `(P,P)` for other passes on the same plane — the latent aliasing hazard documented on the issue.

## Root cause (attributed live)

A new targeted diagnostic (`PROSPER_DBBASETRACE=1` — logs every cx write to the DB Z-base offsets with fold path + command order) captured the mechanism on a live Day One route: the guest's Gen5 indirect register arena programs the pair correctly, then **a stale slot later in the same array parses as `(DB_Z_WRITE_BASE, 0)`** and clobbers the write half:

```
[dbbase] indirect off=0x12 val=0x21135e00 order=9297669   ← real pair write (read)
[dbbase] indirect off=0x14 val=0x21135e00 order=9297669   ← real pair write (write)
[dbbase] indirect off=0x1a val=0x0        order=9297669
[dbbase] indirect off=0x1c val=0x0        order=9297669
[dbbase] indirect off=0x14 val=0x0        order=9297669   ← stale slot, same array
```

Across the trace: 724 zero-writes to 0x14 vs 116 to 0x12 — the same arena family as #1335's `(PA_SC_SCREEN_SCISSOR_BR, 0)` fold. The deep fix (arena section contract from guest-builder disassembly) remains tracked on #1335's follow-up; this PR lands the same class of principled downstream recovery #1344 established.

## Change (`render_state.cpp` extract + `command_processor.cpp` diagnostic)

A **lone** zero on either half of the Z or STENCIL base pair recovers from the nonzero partner, with a capped fail-visible log. A genuine unbind writes both halves 0 and is untouched; divergent nonzero pairs are kept verbatim (not observed; the existing extract test asserts them verbatim). Basis: the GFX10 equal-bases contract. Stencil is included by the same contract (CONFIDENCE noted; a lone-zero stencil half was also observed live).

## Verification

- `test_render_state`: lone-zero Z-write recovers from read; lone-zero stencil-read recovers from write; pair-zero stays zero (no invented identity). Fails without the fix (extract returns the raw 0).
- Full ctest **148/148** (Linux distrobox); the pre-existing divergent-nonzero extraction check passes unchanged.
- **Live A/B (Linux screenshot frontend, Day One route)**: with the fix, every per-light 2048×2048 shadow plane keys `(P,P)` in the persistent-DS cache (`PROSPER_DSLOG` evidence) — zero `(P,0)` splits remain; the recovery log fires 8× (capped).
- Snapshot gate will run at this head and be posted before merge; independent review requested (reverse-engineered contract + persistent-identity change).

## Risks

- Persistent-DS cache keys change for previously-split identities (unification is the point); within-run keying stays deterministic. Cross-title effect bounded by the snapshot suite.
- A hypothetical guest intentionally programming a lone-zero half (no known hardware meaning) would be overridden — fail-visible via the capped log.