### PR TITLE
tool(gpu): dbbase-clobber full-array dump for the #1364 arena-format hunt

### DIFF
--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -1690,6 +1690,13 @@ void GpuState::apply(const Pm4Command& c) {
             // register window, with the packet's provenance, so the corrupt producer is identifiable.
             static const bool regbloat = getenv("PROSPER_REGBLOAT") != nullptr;
             uint32_t bad = 0, first_bad = 0;
+            // #1364: within-array clobber detector — a DB base offset written nonzero and then
+            // ZERO by a LATER slot of the SAME array is the stale-slot signature (#1353's
+            // (DB_Z_WRITE_BASE, 0)). Dump the whole array for the first few occurrences so the
+            // arena's real record format is decodable offline. Bits 0..3 = LO 0x12..0x15,
+            // bits 4..7 = HI 0x1A..0x1D. Gated with the trace.
+            uint32_t dbbase_nonzero_mask = 0;
+            bool dbbase_clobbered = false;
             for (uint32_t i = 0; i < c.num_regs; i++) {
                 // Hardware drops writes to nonexistent register offsets; mirror that instead of
                 // folding placeholder/stale array slots into the register file (see kRegOffsetLimit).
@@ -1717,6 +1724,10 @@ void GpuState::apply(const Pm4Command& c) {
                         fprintf(stderr, "[dbbase] indirect off=0x%x val=0x%x order=%llu\n",
                                 regs[i].offset, regs[i].value,
                                 (unsigned long long)command_order);
+                    const uint32_t bit = regs[i].offset <= 0x15u
+                        ? (regs[i].offset - 0x12u) : (4u + regs[i].offset - 0x1Au);
+                    if (regs[i].value != 0u) dbbase_nonzero_mask |= 1u << bit;
+                    else if (dbbase_nonzero_mask & (1u << bit)) dbbase_clobbered = true;
                 }
                 if (c.reg_class == RegClass::Cx &&
                     regs[i].offset == prosper::agc::Pm4::DB_RENDER_CONTROL &&
@@ -1726,6 +1737,19 @@ void GpuState::apply(const Pm4Command& c) {
                             "[ds-clear-reg] order=%llu value=%08x depth=%u stencil=%u\n",
                             (unsigned long long)command_order, regs[i].value,
                             regs[i].value & 1u, (regs[i].value >> 1) & 1u);
+            }
+            if (dbbase_clobbered) {
+                static std::atomic<int> dumps{0};
+                const int seq = dumps.fetch_add(1);
+                if (seq < 6) {
+                    fprintf(stderr,
+                            "[dbbase-clobber] seq=%d order=%llu vaddr=0x%llx num=%u full array:",
+                            seq, (unsigned long long)command_order,
+                            (unsigned long long)c.regs_vaddr, c.num_regs);
+                    for (uint32_t k = 0; k < c.num_regs && k < 512; k++)
+                        fprintf(stderr, " %x:%x", regs[k].offset, regs[k].value);
+                    fprintf(stderr, "\n");
+                }
             }
             if (regbloat) {
                 if (bad) {


### PR DESCRIPTION
Refs #1364 (instrumentation only — the fold-level fix needs the guest builder's record framing, which this tool now captures).

Extends `PROSPER_DBBASETRACE`: when an indirect cx register array writes a DB Z/STENCIL base offset nonzero and a **later slot of the same array** writes it zero (the #1353 stale-slot signature), the entire array is dumped (`[dbbase-clobber]`, capped 6) so the arena's record framing can be decoded offline. A first live capture already produced the anatomy posted on #1364: coherent register spans + repeating structured non-register records (pointer/size pairs in guest-module space) whose low dwords land in the register-file range — the source of the in-range stale slots the #1344/#1363 recoveries guard against.

Env-gated with the existing trace flag; zero behavior when unset (cached-bool short-circuit; the detector's two locals cost nothing measurable per array). Verification: full ctest **148/148**; the dump is print-only. No snapshot run: no default-path render behavior can change (same class as the merged #1358 logging PR). Independent review skipped per the routine/mechanical carve-out — diagnostic-print addition following the established DBBASETRACE/REGBLOAT patterns.