### PR TITLE
Terminalize ATRAC9 after result publication failure

### DIFF
--- a/prosper/src/hle/hle_audio.cpp
+++ b/prosper/src/hle/hle_audio.cpp
@@ -1828,9 +1828,10 @@ void ajm2_decode_batch(std::vector<AjmDecJob>& jobs) {
                 if (!err) ajm2_dump_decode(inst_id,
                     std::span<const uint8_t>(input.data(), consumed), pcm.data(), produced);
                 if (!err && produced) instance.decoded_samples += produced / frame_bytes;
-                if (!ajm2_write_result(job.result_addr, err, consumed, produced,
-                                       instance.decoded_samples,
-                                       err ? 0 : decoded.decoded_frames)) {
+                const bool result_published = ajm2_write_result(
+                    job.result_addr, err, consumed, produced, instance.decoded_samples,
+                    err ? 0 : decoded.decoded_frames);
+                if (!result_published) {
                     // The codec and guest PCM may already have advanced, but the guest did not
                     // receive the progress sideband. Preserve the same terminal invariant as every
                     // other unpublishable result before another queued job reaches the decoder.
@@ -1842,7 +1843,7 @@ void ajm2_decode_batch(std::vector<AjmDecJob>& jobs) {
                             (unsigned long long)ajm2_log_ms(), inst_id, instance.codec,
                             got, job.in_size, job.out_size, consumed, produced, decoded.channels,
                             decoded.sample_rate, (unsigned long long)instance.decoded_samples,
-                            err ? " ERR" : "");
+                            !result_published ? " RESULT_STORE_ERR" : (err ? " ERR" : ""));
             }
             ji = je;
             continue;
@@ -1858,7 +1859,16 @@ void ajm2_decode_batch(std::vector<AjmDecJob>& jobs) {
         }
         Atrac9Decoder* dec = (it != g_ajm2_inst.end() && it->second.at9_dec && it->second.at9_dec->valid())
                              ? it->second.at9_dec.get() : nullptr;
-        if (!dec) { for (size_t k = ji; k < je; ++k) ajm2_write_result(jobs[k].result_addr, kAjm2ErrDecode, 0, 0); ji = je; continue; }
+        if (!dec) {
+            const uint64_t total = it != g_ajm2_inst.end()
+                ? (it->second.total_samples ? it->second.gapless_delivered
+                                            : it->second.decoded_samples)
+                : 0;
+            for (size_t k = ji; k < je; ++k)
+                ajm2_write_result(jobs[k].result_addr, kAjm2ErrDecode, 0, 0, total);
+            ji = je;
+            continue;
+        }
         const int ch = dec->channels();
         const int sfb = dec->superframe_bytes();
         const int sfs = dec->superframe_samples();
@@ -1874,6 +1884,14 @@ void ajm2_decode_batch(std::vector<AjmDecJob>& jobs) {
         for (size_t k = ji; k < je; ++k) {
             AjmDecJob& job = jobs[k];
             AjmDecodeInst& I = it->second;
+            // A prior job may have advanced ATRAC9 state and then failed to publish its result.
+            // Such an instance is terminal: later jobs must report zero progress instead of
+            // decoding against state the guest could not observe.
+            if (!dec) {
+                ajm2_write_result(job.result_addr, kAjm2ErrDecode, 0, 0,
+                                  I.total_samples ? I.gapless_delivered : I.decoded_samples);
+                continue;
+            }
             // A programmed gapless decode (#1097): drop `skip` priming frames at the program start,
             // deliver EXACTLY `total` trimmed frames, then pin the reported total there with no
             // further PCM. FMOD's channel-end and codec-slot recycling key off that exact landing;
@@ -1952,14 +1970,23 @@ void ajm2_decode_batch(std::vector<AjmDecJob>& jobs) {
                     carry.insert(carry.end(), spill, spill + (size_t)spill_frames * ch);
             }
             I.decoded_samples += produced / frame_bytes;
-            ajm2_write_result(job.result_addr, err, in_cur, produced,
-                              prog ? I.gapless_delivered : I.decoded_samples,
-                              decoded_codec_frames);
+            const bool result_published = ajm2_write_result(
+                job.result_addr, err, in_cur, produced,
+                prog ? I.gapless_delivered : I.decoded_samples, decoded_codec_frames);
+            if (!result_published) {
+                // Decoder/trim/carry state and guest PCM may already have advanced, but the guest
+                // did not receive the progress sideband. Keep cumulative totals for diagnostics
+                // and terminal error sidebands, while preventing any retry from advancing further.
+                I.at9_dec.reset();
+                I.carry.clear();
+                dec = nullptr;
+            }
             if (log)
                 fprintf(stderr, "[ajm2] t=%llums decode inst=%u in=%zu/%u out=%u -> %u consumed, %u PCM, total=%llu carry=%zu%s\n",
                         (unsigned long long)ajm2_log_ms(), inst_id, got, job.in_size, job.out_size,
                         in_cur, produced, (unsigned long long)it->second.decoded_samples,
-                        carry.size() * sizeof(int16_t), err ? " ERR" : "");
+                        carry.size() * sizeof(int16_t),
+                        !result_published ? " RESULT_STORE_ERR" : (err ? " ERR" : ""));
         }
         ji = je;
     }

--- a/prosper/tests/test_ajm2_gapless.cpp
+++ b/prosper/tests/test_ajm2_gapless.cpp
@@ -194,6 +194,49 @@ int main() {
     CHECK(sb4.uiTotalDecodedSamples == raw_frames,
           "no-gapless instance keeps the cumulative raw-frame counter");
 
+    // Result publication is the commit point for a persistent ATRAC9 decode. If the result pointer
+    // is inaccessible after PCM and codec state advance, the instance must become terminal before
+    // either a later job in the same batch or a later batch can decode against hidden state.
+    const uint32_t inst5 = 11;
+    Sideband terminal_same_batch{};
+    std::vector<int16_t> terminal_first((size_t)sfs * ch, (int16_t)0x5555);
+    std::vector<int16_t> terminal_second((size_t)sfs * ch, (int16_t)0x6666);
+    job_init(batch, inst5, addr(kAt9Config), 8, 0, 0, 0, 0, 0, 0);
+    constexpr uint64_t inaccessible_result = 0x0000deadbeef0000ull;
+    CHECK(job_dec(batch, inst5, addr(kAt9Data), (uint32_t)sfb,
+                  addr(terminal_first.data()), (uint32_t)(terminal_first.size() * sizeof(int16_t)),
+                  inaccessible_result, 0, 0, 0) == 0 &&
+          job_dec(batch, inst5, addr(kAt9Data + sfb), (uint32_t)sfb,
+                  addr(terminal_second.data()), (uint32_t)(terminal_second.size() * sizeof(int16_t)),
+                  addr(&terminal_same_batch), 0, 0, 0) == 0,
+          "ATRAC9 publication fixture queues two jobs on one persistent instance");
+    batch_go(0, batch, 0, 0, 0, 0, 0, 0, 0, 0);
+    CHECK(std::memcmp(terminal_first.data(), reference.data(),
+                      (size_t)sfs * frame_bytes) == 0,
+          "failed result publication occurs after the first ATRAC9 decode reaches PCM output");
+    CHECK(terminal_same_batch.iResult != 0 &&
+          terminal_same_batch.iSizeConsumed == 0 &&
+          terminal_same_batch.iSizeProduced == 0 &&
+          terminal_same_batch.uiTotalDecodedSamples == (uint64_t)sfs &&
+          terminal_same_batch.numFrames == 0 &&
+          terminal_second.front() == (int16_t)0x6666,
+          "failed result publication terminalizes before the same-batch job");
+
+    Sideband terminal_later_batch{};
+    std::vector<int16_t> terminal_third((size_t)sfs * ch, (int16_t)0x7777);
+    CHECK(job_dec(batch, inst5, addr(kAt9Data + 2 * sfb), (uint32_t)sfb,
+                  addr(terminal_third.data()), (uint32_t)(terminal_third.size() * sizeof(int16_t)),
+                  addr(&terminal_later_batch), 0, 0, 0) == 0,
+          "terminal ATRAC9 instance accepts a later job for an error sideband");
+    batch_go(0, batch, 0, 0, 0, 0, 0, 0, 0, 0);
+    CHECK(terminal_later_batch.iResult != 0 &&
+          terminal_later_batch.iSizeConsumed == 0 &&
+          terminal_later_batch.iSizeProduced == 0 &&
+          terminal_later_batch.uiTotalDecodedSamples == (uint64_t)sfs &&
+          terminal_later_batch.numFrames == 0 &&
+          terminal_third.front() == (int16_t)0x7777,
+          "terminal ATRAC9 state persists across batches with a stable cumulative total");
+
     printf(fails ? "test_ajm2_gapless: %d FAILURE(S)\n" : "test_ajm2_gapless: all ok\n", fails);
     return fails ? 1 : 0;
 }


### PR DESCRIPTION
Closes #1376.

## Summary
- make a failed non-null ATRAC9 result-sideband store terminal before another queued job can advance the persistent decoder
- preserve the last cumulative decoded/gapless total in zero-progress error sidebands across the same and later batches
- distinguish `RESULT_STORE_ERR` from codec failures in both ATRAC9 and host-codec diagnostics
- add a real LibAtrac9 regression proving the failed publication occurs after PCM output, then blocks same-batch and later-batch advancement

## Correctness boundary
The guest-visible result sideband is the commit point for stateful decode progress. Once PCM/MDCT/trim/carry state advances but that sideband cannot be published, retrying compressed input is unsafe; the instance remains terminal until normal instance/config lifecycle replacement. Null result pointers remain valid and successful decoding is unchanged.

## Validation
- `cmake --build build-linux -j8 --target test_ajm2_gapless test_ajm_mp3`
- `ctest --test-dir build-linux --output-on-failure -R '^(ajm2_gapless|ajm_mp3_decode)$'` (2/2)\n- `cmake --build build-linux -j8 && ctest --test-dir build-linux --output-on-failure` (144/144)\n- `git diff --check`\n\nExact authored head: `fd9b201d` (subject to synchronization if `master` advances before merge).