### PR TITLE
snapshot: blue-prince-hall gameplay content guard (#1287 rung 6)

### DIFF
--- a/prosper/tools/snapshot/snapshots.json
+++ b/prosper/tools/snapshot/snapshots.json
@@ -518,6 +518,40 @@
       "min_nonblack_ratio": 0.288418
     },
     {
+      "name": "blue-prince-hall",
+      "dump": "PPSA25009-app0",
+      "scale": 1,
+      "timeout": 480,
+      "sample_seconds": 3,
+      "capture_after_seconds": 345,
+      "capture_before_seconds": 388,
+      "pad_script": null,
+      "savedata_policy": "fresh",
+      "env": {
+        "PROSPER_IME_AUTOKEY": "1"
+      },
+      "min_colors": 40000,
+      "min_qualifying_frames": 6,
+      "min_pixel_changes": 5,
+      "min_structural_similarity": 0.85,
+      "min_structural_matches": 6,
+      "min_content_match_ratio": 0.7,
+      "dims": [
+        1920,
+        1080
+      ],
+      "review": "Approved 16 composited images from two independent runs on 2026-07-25; intended scene, layers, and progression visually confirmed.",
+      "_note": "Display-chain guard for Blue Prince's Day One entrance hall (#1334/#1382/#1287): a fresh-save IME-autokey route walks through the front door into Mount Holly by ~350s; the evidence window covers the vestibule/hall interior. Runs at scale 1 deliberately - scaled runs break the DS-bridge exact-extent match and could mask the resolve->tonemap chain this guard exists to protect (the pre-#1382 failure mode was a BLOWN overbright frame, not black, so the structural luma references are the discriminating check; the color floor only catches collapse).",
+      "structural_references": [
+        {
+          "luma16x9": "0807000000010102020100000000000300000000040100010100000500020105000000000205232a271c0b01033c0911030209250e022047451d02040d6918190a0826360d031612080501020e6a1f1d0f1334511d09160e0e100b0e0f651d1e1b2e453825211b140d121d2313692e2f3e37432c170b0a0602020a151f36211d63570f0201020101010101020406091e",
+          "average_hash": "81c7e7caca580000",
+          "difference_hash": "078e8ebeb6b01411"
+        }
+      ],
+      "min_nonblack_ratio": 0.359395
+    },
+    {
       "name": "terminator-boot",
       "dump": "PPSA25872-app0",
       "scale": 4,


### PR DESCRIPTION
## Goal

Refs #1383 (item 3), #1287. Adds the automatic snapshot route that takes Blue Prince (PPSA25009) to bring-up rung 6: a deterministic routed capture of the Day One entrance hall with a reviewed content guard. This locks in the #1382 display-chain fix — any regression back to the blown-overbright/black hall fails the guard.

## Route & guard

- Fresh save, `PROSPER_IME_AUTOKEY=1`, capture window 345–388 s, 3 s sampling, 1920×1080, scale 1.
- `min_colors=40000` against an observed richest of 56 642–56 666 distinct colors (harness counting; comfortable margin above transition frames while far below any full-res PIL count — the two metrics differ by design).
- `min_structural_similarity=0.85` with reviewed structural luma references, `min_structural_matches=6`, `min_qualifying_frames=6`, `min_pixel_changes=5`.
- **Why structural references matter here:** the pre-#1382 failure mode was a *blown overbright* frame — not black — so a colors-only guard could pass on the broken output. The luma-signature match is the discriminating check.
- Scale 1 deliberately: scaled runs break the DS-bridge exact-extent match and would exercise a different code path than the defended one.

## Evidence (exact head)

- `snapshot.py verify blue-prince-hall`: **CONTENT-STABLE** (richest=56642/56666, qualifying=15/15, changes=14/14, dims=1920x1080 both runs).
- All 16 retained images from both independent runs inspected: every frame is the correct tonemapped entrance hall (footstep HUD, chandelier, quilted walls, colored carpet, coat rack, lamp, benches, busts). The known #1287 light-accumulation banding is present and expected — it is the separately tracked residual defect, not a guard failure.
- `snapshot.py update blue-prince-hall --reviewed`: approved 1 structural reference set; factual review note recorded in the route.
- `snapshot.py check blue-prince-hall`: **OK** (frames=15, qualifying=15, richest=56642 colors, pixel_changes=14, structural_matches=15, nonblack_matches=15).

## Affected / unaffected

Config-only: one route object appended to `tools/snapshot/snapshots.json`. No emulator code, no other routes touched. The guard is local-only (like all snapshot routes); CI compiles/tests as usual.

## Risks

- The route depends on #1382 (merged as `6479cd5f`) — running the guard on a pre-#1382 build fails by design.
- Animation states vary between valid runs; thresholds were calibrated from two independent runs (56.6 k colors observed vs 40 k floor) per the Dead Cells precedent of content bands over exact hashes.