### PR TITLE
fix(gpu): bounded resolve-copy fence wait; check bind/view results in target creation

### DIFF
--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -1835,7 +1835,12 @@ inline bool readback_persistent_color_target(uint64_t id, uint32_t width, uint32
         vkWaitForFences(ctx.dev, 1, &fence, VK_TRUE, 5ull * 1000 * 1000 * 1000) == VK_SUCCESS;
     if (submitted && !finished) finished = render_locked_queue_wait_idle(ctx.queue) == VK_SUCCESS;
     if (!finished) {
-        cleanup(); error = "persistent color target readback did not complete"; return false;
+        // Submitted-but-unfinished: the command buffer (and the readback buffer it references)
+        // may still be pending on a wedged queue, so destroying the pool, fence, or buffer is
+        // invalid use. Deliberately leak the one-shot objects — the device is effectively lost
+        // (#1383). The never-submitted failure modes still clean up normally.
+        if (!submitted) cleanup();
+        error = "persistent color target readback did not complete"; return false;
     }
     void* mapped = nullptr;
     if (vkMapMemory(ctx.dev, memory, 0, bytes, 0, &mapped) != VK_SUCCESS || !mapped) {
@@ -1909,12 +1914,24 @@ inline bool copy_persistent_color_target(uint64_t src_id, uint64_t dst_id, uint3
             error = "resolve destination exceeds the persistent target budget";
             return false;
         }
-        vkBindImageMemory(ctx.dev, img, imem, 0);
+        if (vkBindImageMemory(ctx.dev, img, imem, 0) != VK_SUCCESS) {
+            vkDestroyImage(ctx.dev, img, nullptr);
+            vkFreeMemory(ctx.dev, imem, nullptr);
+            persistent_color_target_cache().erase(dst_key);
+            error = "cannot bind resolve destination memory";
+            return false;
+        }
         VkImageViewCreateInfo ivci{VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO};
         ivci.image = img; ivci.viewType = VK_IMAGE_VIEW_TYPE_2D; ivci.format = format;
         ivci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
         VkImageView view = VK_NULL_HANDLE;
-        vkCreateImageView(ctx.dev, &ivci, nullptr, &view);
+        if (vkCreateImageView(ctx.dev, &ivci, nullptr, &view) != VK_SUCCESS || !view) {
+            vkDestroyImage(ctx.dev, img, nullptr);
+            vkFreeMemory(ctx.dev, imem, nullptr);
+            persistent_color_target_cache().erase(dst_key);
+            error = "cannot create resolve destination view";
+            return false;
+        }
         // Element pointers survive unordered_map rehash; this re-fetch is belt-and-braces only.
         dst = &persistent_color_target_cache()[dst_key];
         dst->image = img; dst->memory = imem; dst->view = view;
@@ -1998,9 +2015,16 @@ inline bool copy_persistent_color_target(uint64_t src_id, uint64_t dst_id, uint3
     }
     VkSubmitInfo submit{VK_STRUCTURE_TYPE_SUBMIT_INFO};
     submit.commandBufferCount = 1; submit.pCommandBuffers = &command;
-    if (render_locked_queue_submit(ctx.queue, 1, &submit, fence) != VK_SUCCESS ||
-        vkWaitForFences(ctx.dev, 1, &fence, VK_TRUE, UINT64_MAX) != VK_SUCCESS) {
-        cleanup(); return fail("resolve copy submission failed");
+    const bool submitted = render_locked_queue_submit(ctx.queue, 1, &submit, fence) == VK_SUCCESS;
+    bool finished = submitted &&
+        vkWaitForFences(ctx.dev, 1, &fence, VK_TRUE, 5ull * 1000 * 1000 * 1000) == VK_SUCCESS;
+    if (submitted && !finished) finished = render_locked_queue_wait_idle(ctx.queue) == VK_SUCCESS;
+    if (!finished) {
+        // Submitted-but-unfinished means the command buffer may still be pending on a wedged
+        // queue; destroying its pool or fence then is invalid use. Deliberately leak the
+        // one-shot objects instead — the device is effectively lost (#1383).
+        if (!submitted) cleanup();
+        return fail("resolve copy did not complete");
     }
     cleanup();
     dst->layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
@@ -2403,6 +2427,10 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                       (persistent_color ? VK_IMAGE_USAGE_SAMPLED_BIT : 0u) |
                       ((seed_rgba || persistent_color) ? VK_IMAGE_USAGE_TRANSFER_DST_BIT : 0u);
         vkCreateImage(dev, &imgci, nullptr, &img);
+        if (!img) {
+            if (cached_color) persistent_color_target_cache().erase(color_key);
+            return out;
+        }
         VkMemoryRequirements ir{}; vkGetImageMemoryRequirements(dev, img, &ir);
         VkMemoryAllocateInfo iai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO};
         iai.allocationSize = ir.size; iai.memoryTypeIndex = pick(ir.memoryTypeBits, 0);
@@ -2430,17 +2458,33 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                 imgci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
                               (seed_rgba ? VK_IMAGE_USAGE_TRANSFER_DST_BIT : 0u);
                 vkCreateImage(dev, &imgci, nullptr, &img);
+                if (!img) return out;
                 vkGetImageMemoryRequirements(dev, img, &ir);
                 iai.allocationSize = ir.size; iai.memoryTypeIndex = pick(ir.memoryTypeBits, 0);
             }
         }
         if (!imem)
             imem = allocate_transient_render_memory(dev, iai.allocationSize, iai.memoryTypeIndex);
-        vkBindImageMemory(dev, img, imem, 0);
         VkImageViewCreateInfo ivci{VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO};
         ivci.image = img; ivci.viewType = VK_IMAGE_VIEW_TYPE_2D; ivci.format = FMT;
         ivci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
-        vkCreateImageView(dev, &ivci, nullptr, &view);
+        const bool target_ready = imem &&
+            vkBindImageMemory(dev, img, imem, 0) == VK_SUCCESS &&
+            vkCreateImageView(dev, &ivci, nullptr, &view) == VK_SUCCESS && view;
+        if (!target_ready) {
+            // Caching a half-created target (null view / unbound memory) would break every
+            // later LOAD of this identity (#1383): drop it fail-visibly instead.
+            if (view) vkDestroyImageView(dev, view, nullptr);
+            vkDestroyImage(dev, img, nullptr);
+            if (cached_color) {
+                if (cached_color->bytes) persistent_color_target_bytes() -= cached_color->bytes;
+                if (imem) vkFreeMemory(dev, imem, nullptr);
+                persistent_color_target_cache().erase(color_key);
+            } else if (imem) {
+                release_transient_render_memory(dev, imem);
+            }
+            return out;
+        }
         if (cached_color) {
             cached_color->image = img;
             cached_color->memory = imem;


### PR DESCRIPTION
Fixes #1383 (items 1–2; item 3 landed separately as PR #1385). These are the deferred non-blocking findings from the #1382 independent review, all in `prosper/tests/render_runner.h`.

## Failure scenarios & contract

1. **Unbounded fence wait** (`copy_persistent_color_target`): `vkWaitForFences(..., UINT64_MAX)` hangs the caller forever on device loss. Now uses the established readback model: 5 s fence timeout, then `render_locked_queue_wait_idle` fallback, then fail-visible error (destination marked invalid via the existing `fail()` path).
2. **Pool destruction with a pending command buffer** (copy + readback last-resort paths): when the submit succeeded but both waits failed, the one-shot command buffer may still be *pending* on a wedged queue — destroying its pool/fence (and, in the readback, the pending-referenced buffer) is invalid API use. Those paths now deliberately leak the one-shot objects with an explanatory comment; every never-submitted failure still cleans up exactly as before. `submit_persistent_ds_transfer` shares this pattern but its transfer buffer is **caller-owned**, so a local fix can't remove the invalid destruction — tracked separately as #1386.
3. **Ignored `vkBindImageMemory`/`vkCreateImageView` results**:
   - In the copy's destination-creation branch: both are now checked; failure destroys the image/memory, erases the cache entry, and returns an error — no half-created identity is ever cached. (Budget accounting still happens only after full success, so no subtraction is needed on these paths.)
   - In `render_draws_rgba`'s own target creation: both `vkCreateImage` sites are guarded before `vkGetImageMemoryRequirements` (calling it on `VK_NULL_HANDLE` was invalid), and bind/view are checked before storing into the persistent cache — a cached null view would break every later LOAD of that identity. The failure path releases the budget accounting it took (`cached_color->bytes`), frees dedicated vs transient memory through the correct API (`vkFreeMemory` vs `release_transient_render_memory`), erases the cache entry, and returns the function's established empty-output failure convention.

## Affected / unaffected

All changes are failure-path-only: every Vulkan success path executes byte-identically to master. No format, size, indexing, or ordering semantics change. The #1382 regression test (GPU-resident copy + missing-source decline) still covers the success/decline contract.

## Risks

- The deliberate leak on the pending path trades a bounded one-shot leak for removing UB on an effectively-lost device — the accepted convention from the #1382 review discussion.
- The new fail-visible early returns in `render_draws_rgba` occur before any other per-call allocation (verified: no `vkCreate*`/`vkAllocate*`/transient allocation exists between function entry and the target-creation block), so they leak nothing.
- No practical fault injection exists for these device-loss/bind-failure paths in ctest; verification is build + full suite + snapshot gate demonstrating unchanged success-path behavior.

## Verification (exact head `2b3b59c8`)

- Build: clean incremental Linux build.
- `ctest`: **151/151 pass**.
- `snapshot.py check` (full, all routes — includes the new `blue-prince-hall` guard if #1385 lands first): running, result to be posted below before merge.