### PR TITLE
Fix guest timing across synchronous GPU stalls

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -253,6 +253,12 @@ if(TARGET prosper_core)
   target_link_libraries(test_det_clock PRIVATE prosper_core)
   add_test(NAME det_clock COMMAND test_det_clock)
 
+  # Synchronous host-GPU work must not become a giant guest frame delta. The clock retains one
+  # caller-supplied frame budget, stays monotonic under concurrent reads, and leaves realtime alone.
+  add_executable(test_gpu_time_compensation tests/test_gpu_time_compensation.cpp)
+  target_link_libraries(test_gpu_time_compensation PRIVATE prosper_core)
+  add_test(NAME gpu_time_compensation COMMAND test_gpu_time_compensation)
+
   # UserService/libkernel startup stubs (HLE audit): getters write deterministic defaults; the
   # libkernel registration/hook calls resolve to benign OK no-ops.
   add_executable(test_service_getters tests/test_service_getters.cpp)

--- a/prosper/docs/FRONTEND_APP.md
+++ b/prosper/docs/FRONTEND_APP.md
@@ -167,6 +167,18 @@ For native Windows, configure MinGW with `-DPROSPER_APP=ON -DPROSPER_AUDIO_SDL3=
 
 The complete manual PowerShell recipe is in `WINDOWS_PORT_HANDOFF.md`.
 
+### Guest time during synchronous GPU work
+
+Prosper currently realizes and executes an AGC submit synchronously on the guest submitter. The
+guest monotonic clock discounts host GPU time beyond the refresh interval represented by that
+submit's completed VideoOut flips. This keeps shader compilation, resource conversion, execution,
+and readback stalls from becoming multi-second frame deltas that skip time-based guest states. Wall
+clock/RTC surfaces remain tied to host time, and monotonic time continues normally outside the
+backend scope, including while media or wait loops prepare the next frame. This is intentionally
+narrower than the opt-in `PROSPER_DET_CLOCK`, which holds monotonic time between every pair of flips.
+
+Set `PROSPER_NO_GPU_TIME_COMPENSATION=1` only for a diagnostic A/B against the old behavior.
+
 ### Live renderer performance diagnostics
 
 Set `PROSPER_RENDER_TIMING=1` before launching to print aggregate timings every 25 operations:

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -9,6 +9,7 @@
 // reverse-engineered the real libSceAgc ABI. A later CommandProcessor will decode this PM4 stream to
 // Vulkan (see docs/AGC_IMPL_PLAN.md). Registered by raw NID (AGC lib is undocumented).
 #include "dispatch.hpp"
+#include "hle_kernel_time.hpp"
 #include "gpu/pm4_registers.hpp"
 #include "gpu/command_processor.hpp"
 #include "gpu/pm4_decode.hpp"
@@ -1109,6 +1110,7 @@ void prosper_eq_trigger_eop();
 
 // Total flips so far (hle_graphics.cpp) — part of the PROSPER_PROGRESS heartbeat below.
 extern "C" uint64_t prosper_vo_flip_count();
+extern "C" int prosper_vo_flip_rate();
 
 namespace {
 // PROSPER_PROGRESS=<secs>: emit a one-line timestamped forward-progress heartbeat at most every
@@ -1176,6 +1178,19 @@ static bool execute_submit_work(gpu::GpuState& st, uint64_t submit_no, unsigned&
     // Native-speed semantic capture happens before renderer sampling. PROSPER_RENDER_EVERY and
     // warmup may skip Vulkan work, but must not erase submit/present history from the timeline.
     gpu::record_gpu_timeline_submit(st, submit_no);
+    // Account at most one requested refresh interval per flip while the host performs synchronous
+    // GPU work. A real console returns from submission without charging shader compilation,
+    // resource conversion, execution, or readback latency to the guest's next frame delta.
+    static uint64_t accounted_flips = 0;
+    const uint64_t flips = prosper_vo_flip_count();
+    const uint64_t flip_delta = flips >= accounted_flips ? flips - accounted_flips : flips;
+    accounted_flips = flips;
+    const int flip_rate = prosper_vo_flip_rate();
+    const uint64_t refresh_divisor = flip_rate >= 0 && flip_rate <= 2
+        ? (uint64_t)flip_rate + 1 : 1;
+    const uint64_t period_ns = (1000000000ull * refresh_divisor) / 60ull;
+    const uint64_t clock_budget_ns = flip_delta > UINT64_MAX / period_ns
+        ? UINT64_MAX : flip_delta * period_ns;
     // A bounded sparse phase accelerates long intros, then cadence=1 rebuilds any temporal render
     // targets before a visual checkpoint. Screenshot exposes these as --render-every/--render-every-for-seconds.
     static const unsigned render_every = [] {
@@ -1202,10 +1217,12 @@ static bool execute_submit_work(gpu::GpuState& st, uint64_t submit_no, unsigned&
         render = ordered_dma_requires_render || cadence_render;
     }
     if (!render) {
-        if ((!st.dispatches.empty() || !st.dma_copies.empty()) &&
-            !gpu::execute_nonrender_submit_work(st, submit_no) && getenv("PROSPER_COMPUTELOG"))
-            fprintf(stderr, "[compute] submit #%llu produced no executable work\n",
-                    (unsigned long long)submit_no);
+        if (!st.dispatches.empty() || !st.dma_copies.empty()) {
+            HostGpuClockScope host_gpu_clock(clock_budget_ns);
+            if (!gpu::execute_nonrender_submit_work(st, submit_no) && getenv("PROSPER_COMPUTELOG"))
+                fprintf(stderr, "[compute] submit #%llu produced no executable work\n",
+                        (unsigned long long)submit_no);
+        }
         return false;
     }
 
@@ -1225,6 +1242,7 @@ static bool execute_submit_work(gpu::GpuState& st, uint64_t submit_no, unsigned&
     // but leave fence/label completions on their post-submit FIFO: exposing a ReleaseMem fence before
     // this call returns lets another guest thread recycle its label while the submitter is still
     // updating the corresponding allocation lists (#312).
+    HostGpuClockScope host_gpu_clock(clock_budget_ns);
     gpu::flush_deferred_streams();
     prosper_gpu_drain_renderer_writes();
     // PROSPER_PRESENT_EVERY=N suppresses publication only. Unlike PROSPER_RENDER_EVERY, every

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -2,6 +2,7 @@
 // libkernel stubs the engine needs during init. Cross-platform (chrono + pthread).
 #include "dispatch.hpp"
 #include "nid.hpp"
+#include "hle_kernel_time.hpp"
 #include "heap_mutex.hpp"   // #707: keep hot equeue/APR mutexes off macOS __DATA
 #include "sync_futex.hpp"
 #include <pthread.h>
@@ -44,6 +45,67 @@ namespace {
         return (uint64_t)std::chrono::duration_cast<std::chrono::nanoseconds>(clk::now() - g_start).count();
     }
 
+    // The live GPU backend is synchronous today: the guest submitter performs shader realization,
+    // Vulkan execution, and readback before its HLE call returns. On hardware that work runs on the
+    // GPU after a cheap CPU submission. Without compensation, a one-off host pipeline/resource
+    // warmup is incorrectly exposed as a giant guest frame delta and can skip entire animations.
+    //
+    // During a host-GPU scope, monotonic time advances only through the caller-supplied display
+    // budget, then holds. At scope exit the excess is permanently removed from process-time/TSC.
+    // Ordinary guest execution and all realtime/RTC surfaces keep advancing from the host clocks.
+    // This is deliberately narrower than PROSPER_DET_CLOCK: time-gated media and wait loops can
+    // continue between flips, so a title cannot deadlock waiting to produce its next frame.
+    struct HostGpuClockState {
+        std::mutex writer_mutex;
+        std::atomic<uint64_t> sequence{0};
+        std::atomic<uint64_t> total_excess_ns{0};
+        std::atomic<uint64_t> active_start_ns{0};
+        std::atomic<uint64_t> active_budget_ns{0};
+        std::atomic<uint64_t> active_token{0};
+        uint64_t next_token = 1;
+        std::atomic<uint64_t> last_ns{0};
+    };
+    HostGpuClockState g_host_gpu_clock;
+
+    bool host_gpu_clock_enabled() {
+        static const bool enabled = getenv("PROSPER_NO_GPU_TIME_COMPENSATION") == nullptr;
+        return enabled;
+    }
+
+    uint64_t host_gpu_compensated_ns(uint64_t mono) {
+        // Process-time reads are hot and may come from many guest threads. Writers publish their
+        // handful of atomic fields under a seqlock, giving readers one consistent snapshot without
+        // serializing every clock query on the scope-management mutex.
+        uint64_t total_excess;
+        uint64_t active_start;
+        uint64_t active_budget;
+        uint64_t active_token;
+        for (;;) {
+            const uint64_t before = g_host_gpu_clock.sequence.load(std::memory_order_acquire);
+            if (before & 1) continue;
+            total_excess = g_host_gpu_clock.total_excess_ns.load(std::memory_order_relaxed);
+            active_start = g_host_gpu_clock.active_start_ns.load(std::memory_order_relaxed);
+            active_budget = g_host_gpu_clock.active_budget_ns.load(std::memory_order_relaxed);
+            active_token = g_host_gpu_clock.active_token.load(std::memory_order_relaxed);
+            const uint64_t after = g_host_gpu_clock.sequence.load(std::memory_order_acquire);
+            if (before == after) break;
+        }
+
+        uint64_t excess = total_excess;
+        if (active_token && mono > active_start) {
+            const uint64_t elapsed = mono - active_start;
+            if (elapsed > active_budget) {
+                const uint64_t active_excess = elapsed - active_budget;
+                excess = active_excess > UINT64_MAX - excess ? UINT64_MAX : excess + active_excess;
+            }
+        }
+        const uint64_t current = mono >= excess ? mono - excess : 0;
+        uint64_t last = g_host_gpu_clock.last_ns.load(std::memory_order_relaxed);
+        while (last < current && !g_host_gpu_clock.last_ns.compare_exchange_weak(
+                   last, current, std::memory_order_relaxed, std::memory_order_relaxed)) {}
+        return std::max(last, current);
+    }
+
     // PROSPER_DET_CLOCK: derive the guest MONOTONIC clock from the flip count instead of host elapsed
     // time, so per-frame deltaTime is fixed regardless of host render cost. Wall-clock/RTC surfaces keep
     // using real_ns(): deterministic gameplay time must not freeze the calendar clock between flips.
@@ -73,7 +135,7 @@ namespace {
     uint64_t ns_now() {
         static const bool det = getenv("PROSPER_DET_CLOCK") != nullptr;
         uint64_t mono = real_ns();
-        if (!det) return mono;
+        if (!det) return host_gpu_compensated_ns(mono);
         uint64_t flip = prosper_vo_flip_count();
         std::lock_guard<std::mutex> lock(g_det_clock.mutex);
         if (!g_det_clock.anchored) {
@@ -113,6 +175,48 @@ namespace {
     // RTC epoch: SceRtcTick counts microseconds since 0001-01-01 00:00:00 UTC; the unix epoch is
     // 62135596800 s after it (the documented Orbis RTC convention, also shadPS4 UNIX_EPOCH_TICKS).
     constexpr uint64_t kRtcUnixEpochOffsetUs = 62135596800ull * 1000000ull;
+}
+
+uint64_t guest_clock_host_gpu_begin(uint64_t budget_ns) {
+    if (!host_gpu_clock_enabled()) return 0;
+    std::lock_guard<std::mutex> lock(g_host_gpu_clock.writer_mutex);
+    // AGC submissions are serialized, so overlap indicates a future caller violated the scope
+    // contract. Fail open rather than letting an inner end truncate or double-count the outer wait.
+    if (g_host_gpu_clock.active_token.load(std::memory_order_relaxed)) return 0;
+    // Make the snapshot unavailable before sampling: if this writer is preempted, readers must not
+    // advance against the old state and then have that already-observed interval discounted.
+    g_host_gpu_clock.sequence.fetch_add(1, std::memory_order_acq_rel);
+    const uint64_t mono = real_ns();
+    uint64_t token = g_host_gpu_clock.next_token++;
+    if (!token) token = g_host_gpu_clock.next_token++;
+    g_host_gpu_clock.active_start_ns.store(mono, std::memory_order_relaxed);
+    g_host_gpu_clock.active_budget_ns.store(budget_ns, std::memory_order_relaxed);
+    g_host_gpu_clock.active_token.store(token, std::memory_order_relaxed);
+    g_host_gpu_clock.sequence.fetch_add(1, std::memory_order_release);
+    return token;
+}
+
+void guest_clock_host_gpu_end(uint64_t token) {
+    if (!token) return;
+    std::lock_guard<std::mutex> lock(g_host_gpu_clock.writer_mutex);
+    if (g_host_gpu_clock.active_token.load(std::memory_order_relaxed) != token) return;
+    // Block reader snapshots across the active-to-inactive boundary, then sample as late as possible
+    // so a writer preemption cannot expose a stale end time as a completed transition.
+    g_host_gpu_clock.sequence.fetch_add(1, std::memory_order_acq_rel);
+    const uint64_t active_start = g_host_gpu_clock.active_start_ns.load(std::memory_order_relaxed);
+    const uint64_t active_budget = g_host_gpu_clock.active_budget_ns.load(std::memory_order_relaxed);
+    uint64_t total_excess = g_host_gpu_clock.total_excess_ns.load(std::memory_order_relaxed);
+    const uint64_t mono = real_ns();
+    const uint64_t elapsed = mono > active_start ? mono - active_start : 0;
+    if (elapsed > active_budget) {
+        const uint64_t excess = elapsed - active_budget;
+        total_excess = excess > UINT64_MAX - total_excess ? UINT64_MAX : total_excess + excess;
+    }
+    g_host_gpu_clock.total_excess_ns.store(total_excess, std::memory_order_relaxed);
+    g_host_gpu_clock.active_start_ns.store(0, std::memory_order_relaxed);
+    g_host_gpu_clock.active_budget_ns.store(0, std::memory_order_relaxed);
+    g_host_gpu_clock.active_token.store(0, std::memory_order_relaxed);
+    g_host_gpu_clock.sequence.fetch_add(1, std::memory_order_release);
 }
 
 // --- time / clock (return real, advancing time so wait-for-time loops progress) ---

--- a/prosper/src/hle/hle_kernel_time.hpp
+++ b/prosper/src/hle/hle_kernel_time.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <cstdint>
+
+namespace prosper {
+
+// Exclude excess time spent in Prosper's synchronous host GPU backend from the guest monotonic
+// clock. Real hardware submits this work asynchronously; charging a multi-second host translation
+// or pipeline warmup to the next guest frame makes time-based state machines skip visible states.
+// `budget_ns` is the amount of that interval that may legitimately belong to completed display
+// flips. A zero token means the scope was not installed (disabled or another scope is active).
+uint64_t guest_clock_host_gpu_begin(uint64_t budget_ns);
+void guest_clock_host_gpu_end(uint64_t token);
+
+class HostGpuClockScope {
+public:
+    explicit HostGpuClockScope(uint64_t budget_ns)
+        : token_(guest_clock_host_gpu_begin(budget_ns)) {}
+    ~HostGpuClockScope() { guest_clock_host_gpu_end(token_); }
+
+    HostGpuClockScope(const HostGpuClockScope&) = delete;
+    HostGpuClockScope& operator=(const HostGpuClockScope&) = delete;
+
+private:
+    uint64_t token_ = 0;
+};
+
+} // namespace prosper

--- a/prosper/tests/test_gpu_time_compensation.cpp
+++ b/prosper/tests/test_gpu_time_compensation.cpp
@@ -1,0 +1,112 @@
+// test_gpu_time_compensation - discount synchronous host-GPU overhead from guest monotonic time.
+#include "../src/hle/dispatch.hpp"
+#include "../src/hle/hle_kernel_time.hpp"
+#include "../src/hle/nid.hpp"
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <thread>
+#include <vector>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { std::printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { std::printf("  [ok]   %s\n", m); } } while (0)
+
+int main() {
+    std::printf("== test_gpu_time_compensation ==\n");
+    register_builtin_hle();
+    auto ptc = Hle::lookup(nid_hash("sceKernelGetProcessTimeCounter"));
+    auto clock_gettime_fn = Hle::lookup(nid_hash("sceKernelClockGettime"));
+    CHECK(ptc && clock_gettime_fn, "monotonic and realtime entry points registered");
+    if (fails) return 1;
+
+    constexpr uint64_t kBudgetNs = 8'000'000;
+    uint64_t before = ptc(0, 0, 0, 0, 0, 0);
+    int64_t rt0[2] = {};
+    clock_gettime_fn(0, (uint64_t)(uintptr_t)rt0, 0, 0, 0, 0);
+    {
+        HostGpuClockScope scope(kBudgetNs);
+        std::this_thread::sleep_for(std::chrono::milliseconds(35));
+        uint64_t held0 = ptc(0, 0, 0, 0, 0, 0);
+        std::this_thread::sleep_for(std::chrono::milliseconds(15));
+        uint64_t held1 = ptc(0, 0, 0, 0, 0, 0);
+        CHECK(held0 >= before + 4'000'000 && held0 <= before + 25'000'000,
+              "host-GPU interval retains its bounded guest frame budget");
+        CHECK(held1 == held0, "guest monotonic time holds after the GPU budget is exhausted");
+
+        std::vector<uint64_t> concurrent(8);
+        std::vector<std::thread> readers;
+        for (size_t i = 0; i < concurrent.size(); ++i)
+            readers.emplace_back([&, i] { concurrent[i] = ptc(0, 0, 0, 0, 0, 0); });
+        for (auto& reader : readers) reader.join();
+        CHECK(*std::min_element(concurrent.begin(), concurrent.end()) == held0 &&
+                  *std::max_element(concurrent.begin(), concurrent.end()) == held0,
+              "concurrent readers share one held monotonic value");
+    }
+    uint64_t after_scope = ptc(0, 0, 0, 0, 0, 0);
+    CHECK(after_scope - before <= 25'000'000,
+          "scope exit permanently removes excess synchronous GPU time");
+
+    int64_t rt1[2] = {};
+    clock_gettime_fn(0, (uint64_t)(uintptr_t)rt1, 0, 0, 0, 0);
+    int64_t wall_delta = (rt1[0] - rt0[0]) * 1'000'000'000ll + (rt1[1] - rt0[1]);
+    CHECK(wall_delta >= 35'000'000,
+          "CLOCK_REALTIME continues through a compensated host-GPU interval");
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(15));
+    uint64_t resumed = ptc(0, 0, 0, 0, 0, 0);
+    CHECK(resumed >= after_scope + 8'000'000,
+          "guest monotonic time resumes after the host-GPU scope");
+
+    // A rejected overlapping begin returns zero, and ending that token must not truncate the
+    // active outer scope. This pins the fail-open behavior used if serialization ever regresses.
+    uint64_t outer = guest_clock_host_gpu_begin(2'000'000);
+    uint64_t inner = guest_clock_host_gpu_begin(2'000'000);
+    CHECK(outer != 0 && inner == 0, "overlapping host-GPU scopes fail open without nesting");
+    guest_clock_host_gpu_end(inner);
+    guest_clock_host_gpu_end(outer + 1);
+    std::this_thread::sleep_for(std::chrono::milliseconds(8));
+    uint64_t overlap_held = ptc(0, 0, 0, 0, 0, 0);
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    CHECK(ptc(0, 0, 0, 0, 0, 0) == overlap_held,
+          "rejected and mismatched ends cannot release the outer clock hold");
+    guest_clock_host_gpu_end(outer);
+
+    // Exercise the lock-free reader snapshot across rapid begin/end publications. Every reader
+    // must retain its local monotonic ordering, and the one writer must never lose its scope token.
+    std::atomic<bool> stop_readers{false};
+    std::atomic<bool> readers_monotonic{true};
+    std::vector<std::thread> racing_readers;
+    for (unsigned i = 0; i < 4; ++i) {
+        racing_readers.emplace_back([&] {
+            uint64_t previous = ptc(0, 0, 0, 0, 0, 0);
+            while (!stop_readers.load(std::memory_order_relaxed)) {
+                const uint64_t current = ptc(0, 0, 0, 0, 0, 0);
+                if (current < previous)
+                    readers_monotonic.store(false, std::memory_order_relaxed);
+                previous = current;
+            }
+        });
+    }
+    bool writer_tokens_valid = true;
+    for (unsigned i = 0; i < 2000; ++i) {
+        const uint64_t token = guest_clock_host_gpu_begin(0);
+        writer_tokens_valid &= token != 0;
+        guest_clock_host_gpu_end(token);
+    }
+    stop_readers.store(true, std::memory_order_relaxed);
+    for (auto& reader : racing_readers) reader.join();
+    CHECK(writer_tokens_valid && readers_monotonic.load(std::memory_order_relaxed),
+          "lock-free readers stay monotonic across scope publication races");
+    const uint64_t stress_end = ptc(0, 0, 0, 0, 0, 0);
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    CHECK(ptc(0, 0, 0, 0, 0, 0) >= stress_end + 2'000'000,
+          "guest monotonic time resumes after rapid scope transitions");
+
+    if (fails) std::printf("== FAIL (%d) ==\n", fails);
+    else       std::printf("== PASS ==\n");
+    return fails ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

- discount excess time spent in Prosper's synchronous AGC/Vulkan backend from the guest monotonic process clock
- retain the refresh budget represented by completed VideoOut flips while leaving realtime/RTC and ordinary guest execution untouched
- publish clock-scope transitions through lock-free, consistent reader snapshots so hot process-time reads do not serialize on a mutex
- add scoped token validation, concurrency/failure-path coverage, documentation, and a diagnostic opt-out
- fix GTA V's skipped second disclaimer and abrupt transition without title-specific behavior

## Root cause

A renderer warm-up submit blocked the guest submitter for about 10.56 seconds. Prosper exposed that host-only shader/resource/render latency as one guest frame delta, so GTA V's time-based startup state machine advanced from the first disclaimer directly to the title. `PROSPER_DET_CLOCK=1` is not suitable here because holding time between all flips deadlocks time-gated video production.

## Validation

Exact head: `9a4170315e505464d7b1c0559b2f77945a1e5100`

- full RelWithDebInfo app/screenshot build: passed
- `ctest --test-dir prosper/build-gta-cadence --output-on-failure`: 146/146 passed
- `gpu_time_compensation`: passed 50 consecutive runs after the final concurrent transition stress was added
- exact-head GPU replay/capture: 95 full-resolution 3840x2160 PNGs at 0.5-second cadence
  - first disclaimer visible at 27.7s and fades out through 32.2s
  - distinct second disclaimer fades in at 36.7s and remains animated through 44.7s
  - title appears at 46.2s with the existing corrected X icon
- baseline capture showed the first disclaimer followed directly by the title

## Author failure-path review

- scopes are installed only around actual synchronous backend execution
- disabled or overlapping scopes fail open
- zero, rejected, and mismatched end tokens cannot terminate an active scope
- writer transitions become unavailable before timestamping, preventing stale boundaries after preemption
- atomic seqlock snapshots keep concurrent readers consistent and nondecreasing without a hot global mutex
- accumulation and flip-budget multiplication saturate on overflow
- CLOCK_REALTIME/RTC are not compensated
- process-global guest monotonic time is intentional: the host-only backend interval does not exist on the virtual console timeline, so all guest threads must observe one coherent clock

Fixes #1348