### PR TITLE
test(audio): allow elapsed queue drain

### DIFF
--- a/prosper/src/hle/audio.hpp
+++ b/prosper/src/hle/audio.hpp
@@ -35,6 +35,10 @@ void audio_decode_format(uint32_t param, int& channels, AudioFmt& fmt);
 void audio_apply_channel_volumes(int dst[8], uint32_t mask, const int* vols);
 int audio_peak_channel_volume(uint32_t mask, const int* vols);
 
+// Reserve one AudioOut2 device-queue slot. Kept as a pure transition so queue accounting can be
+// verified independently of the wall-clock drain performed by sceAudioOut2ContextGetQueueLevel.
+bool audio2_reserve_queue_slot(uint32_t& queued, uint32_t queue_depth);
+
 // Pluggable audio backend. All calls arrive on the guest's audio thread; output() MAY block to
 // pace it (as real hardware does — sceAudioOutOutput blocks until the ring has room).
 struct AudioSink {

--- a/prosper/src/hle/hle_audio.cpp
+++ b/prosper/src/hle/hle_audio.cpp
@@ -153,6 +153,12 @@ int audio_peak_channel_volume(uint32_t mask, const int* vols) {
     return peak;
 }
 
+bool audio2_reserve_queue_slot(uint32_t& queued, uint32_t queue_depth) {
+    if (queued >= queue_depth) return false;
+    ++queued;
+    return true;
+}
+
 void audio_reset() {
     AudioSink* s = audio_sink();
     {
@@ -1007,9 +1013,9 @@ HLE(audio2_ctx_push) {
             if (!context) return kA2ErrInvalidParam;
             const auto now = std::chrono::steady_clock::now();
             audio2_update_queue_locked(*context, now);
-            if (context->queued < context->queue_depth) {
-                if (!context->queued) context->last_queue_update = now;
-                ++context->queued;
+            const bool was_empty = !context->queued;
+            if (audio2_reserve_queue_slot(context->queued, context->queue_depth)) {
+                if (was_empty) context->last_queue_update = now;
                 grain = context->grain;
                 break;
             }

--- a/prosper/tests/test_audio.cpp
+++ b/prosper/tests/test_audio.cpp
@@ -138,6 +138,15 @@ int main() {
     CHECK((int32_t)call("sceAudioOut2ContextResetParam", 1) == (int32_t)0x80268001);
     CHECK((int32_t)call("sceAudioOut2ContextQueryMemory", 0, 1) == (int32_t)0x80268001);
 
+    // Queue-level queries advance a wall clock and can observe a just-pushed grain before or after
+    // it drains. Cover the positive accounting transition itself without that timing dependency.
+    uint32_t reserved_grains = 0;
+    CHECK(audio2_reserve_queue_slot(reserved_grains, 4));
+    CHECK(reserved_grains == 1);
+    reserved_grains = 4;
+    CHECK(!audio2_reserve_queue_slot(reserved_grains, 4));
+    CHECK(reserved_grains == 4);
+
     // --- 2. open -> handle + backend.open with decoded params --------------------------------
     audio_reset();
     CapturingSink sink; audio_set_sink(&sink);

--- a/prosper/tests/test_audio.cpp
+++ b/prosper/tests/test_audio.cpp
@@ -399,7 +399,12 @@ int main() {
     a2_queued = a2_available = 0xCCCCCCCCu;
     CHECK(call("sceAudioOut2ContextGetQueueLevel", a2_context,
                PTR(&a2_queued), PTR(&a2_available)) == 0);
-    CHECK(a2_queued == 1 && a2_available == 3);            // submitted grain is observable
+    // GetQueueLevel advances the emulated 48 kHz device clock. The 64-frame grain lasts only
+    // 1.33 ms, so a slow/suspended runner may legitimately drain it during Push's synchronous
+    // sink copy. The sink assertions below prove submission; here assert the point-in-time queue
+    // contract without assuming the host schedules this query before the first drain boundary.
+    CHECK(a2_queued <= 1);
+    CHECK(a2_queued + a2_available == 4);
     CHECK(sink.opens.size() == 1);
     CHECK(sink.outs.size() == 1);
     if (!sink.outs.empty()) {


### PR DESCRIPTION
Fixes #1389.

## Failure scenario
The AudioOut2 test pushes a 64-frame grain and immediately queries sceAudioOut2ContextGetQueueLevel. That grain lasts only 1.33 ms at 48 kHz. On a slow or descheduled Rosetta runner, the emulated device clock can legitimately drain it during the synchronous sink copy, so the old exact queued=1, available=3 assertion was timing-dependent.

## What changed
- retain the point-in-time queue invariants: at most the one submitted grain may remain, and queued + available must equal the four-slot depth
- extract the queue-slot reservation into a pure production helper and test its positive/full transitions deterministically, so relaxing the timed observation cannot mask broken queue accounting
- continue proving actual submission through the existing exact sink event, frame count, PCM size, and byte-for-byte PCM checks
- leave AudioOut2 runtime behavior unchanged

## Validation
- test_audio: 200 consecutive passes
- full build succeeded
- full suite: 146/146 passed
- git diff --check clean