### PR TITLE
fix(tool): resolve replay probes by semantic draw ID

### DIFF
--- a/prosper/docs/BLUE_PRINCE_STATUS.md
+++ b/prosper/docs/BLUE_PRINCE_STATUS.md
@@ -80,7 +80,8 @@ The `blue-prince-title` snapshot route guards the title screen.
   `[render_state] lone-zero DB … recovered` fire on the two landed arena recoveries.
 - `PROSPER_DSLOG=1` / `PROSPER_DSBRIDGE_LOG=1` — persistent-DS call keys and sampled-bridge
   HIT/miss (how #1352 was found).
-- `PROSPER_FS_TAP=DRAW:PC` on a v19+ capsule — visualize a light-FS intermediate offline.
+- `PROSPER_FS_TAP=DRAW:PC` on a v19+ capsule — visualize a light-FS intermediate offline; `DRAW`
+  is the semantic `draw[ID]` printed by `gpu_replay --inspect-only`, not its compact `item=` offset.
 - The #1352-era scissor three-stage traces are parked on branch
   `fix/issue-1335-regindirect-tags`.
 

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -2462,6 +2462,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     }
                     bd.vs_identity = refvs ? 0 : it.vs_identity;
                     bd.fs_identity = fs_ov ? 0 : it.fs_identity;
+                    bd.draw_index = it.draw_index;
                     bd.vcount = refvs ? 3u : it.vertex_count;
                     bd.instance_count = it.instance_count;
                     bd.vertex_offset = refvs ? 0 : it.vertex_offset;

--- a/prosper/src/gpu/diagnostic_selectors.hpp
+++ b/prosper/src/gpu/diagnostic_selectors.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <cstdint>
+#include <limits>
+#include <string_view>
+
+namespace prosper::gpu {
+
+// Diagnostic draw selectors are semantic capture IDs.  Keep their spelling and range rules shared
+// between the replay front-end and the render backend so a selector cannot recompile one draw while
+// probing another.  Match the command-line tools' base-0 convention without strtoull's permissive
+// whitespace/sign handling.
+inline bool parse_diagnostic_draw_id(std::string_view text, uint64_t& value) {
+    if (text.empty() || text.front() == '+' || text.front() == '-') return false;
+
+    unsigned base = 10;
+    size_t offset = 0;
+    if (text.size() > 2 && text[0] == '0' && (text[1] == 'x' || text[1] == 'X')) {
+        base = 16;
+        offset = 2;
+    } else if (text.size() > 1 && text[0] == '0') {
+        base = 8;
+        offset = 1;
+    }
+    if (offset == text.size()) return false;
+
+    uint64_t parsed = 0;
+    for (; offset < text.size(); ++offset) {
+        const char c = text[offset];
+        unsigned digit = 0;
+        if (c >= '0' && c <= '9') digit = static_cast<unsigned>(c - '0');
+        else if (c >= 'a' && c <= 'f') digit = static_cast<unsigned>(c - 'a') + 10;
+        else if (c >= 'A' && c <= 'F') digit = static_cast<unsigned>(c - 'A') + 10;
+        else return false;
+        if (digit >= base || parsed > (std::numeric_limits<uint64_t>::max() - digit) / base)
+            return false;
+        parsed = parsed * base + digit;
+    }
+    value = parsed;
+    return true;
+}
+
+} // namespace prosper::gpu

--- a/prosper/src/gpu/diagnostic_selectors.hpp
+++ b/prosper/src/gpu/diagnostic_selectors.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <limits>
 #include <string_view>
@@ -10,7 +11,7 @@ namespace prosper::gpu {
 // between the replay front-end and the render backend so a selector cannot recompile one draw while
 // probing another.  Match the command-line tools' base-0 convention without strtoull's permissive
 // whitespace/sign handling.
-inline bool parse_diagnostic_draw_id(std::string_view text, uint64_t& value) {
+inline bool parse_diagnostic_uint64(std::string_view text, uint64_t& value) {
     if (text.empty() || text.front() == '+' || text.front() == '-') return false;
 
     unsigned base = 10;
@@ -37,6 +38,39 @@ inline bool parse_diagnostic_draw_id(std::string_view text, uint64_t& value) {
         parsed = parsed * base + digit;
     }
     value = parsed;
+    return true;
+}
+
+inline bool parse_diagnostic_draw_id(std::string_view text, uint64_t& value) {
+    return parse_diagnostic_uint64(text, value);
+}
+
+inline bool parse_diagnostic_draw_range(std::string_view text,
+                                        uint64_t& first, uint64_t& last) {
+    const size_t colon = text.find(':');
+    if (colon == std::string_view::npos) {
+        if (!parse_diagnostic_draw_id(text, first)) return false;
+        last = first;
+        return true;
+    }
+    if (text.find(':', colon + 1) != std::string_view::npos ||
+        !parse_diagnostic_draw_id(text.substr(0, colon), first) ||
+        !parse_diagnostic_draw_id(text.substr(colon + 1), last))
+        return false;
+    return true;
+}
+
+inline bool parse_fragment_tap_selector(std::string_view text,
+                                        uint64_t& draw, uint32_t& pc) {
+    const size_t colon = text.find(':');
+    uint64_t parsed_pc = 0;
+    if (colon == std::string_view::npos ||
+        text.find(':', colon + 1) != std::string_view::npos ||
+        !parse_diagnostic_draw_id(text.substr(0, colon), draw) ||
+        !parse_diagnostic_uint64(text.substr(colon + 1), parsed_pc) ||
+        parsed_pc > std::numeric_limits<uint32_t>::max())
+        return false;
+    pc = static_cast<uint32_t>(parsed_pc);
     return true;
 }
 

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -1,5 +1,6 @@
 // rdna2_to_spirv.cpp — see rdna2_to_spirv.hpp. Internal SpirvCompute builder + the VALU translator.
 #include "rdna2_to_spirv.hpp"
+#include "diagnostic_selectors.hpp"
 #include "rdna2_decode.hpp"
 #include "shader_resources.hpp"
 #include <algorithm>
@@ -8890,11 +8891,12 @@ std::vector<uint32_t> recompile_fragment(const uint32_t* code, size_t dwords,
     b.begin_fragment(rt, color_mask);
     // Fragment I/O value tap (PROSPER_FS_TAP=draw:pc): redirect the MRT0 colour export to the intermediate
     // VGPR produced at that PC so the rendered frame visualises the value. The `draw:` prefix is consumed by
-    // gpu_replay (which re-recompiles only that draw's FS); here we take the PC after the ':' (or the whole
-    // value if there is no ':').
+    // gpu_replay (which re-recompiles only that draw's FS). Parse the same complete selector here so an
+    // invalid or overflowing PC cannot silently become PC zero or truncate to 32 bits.
     if (const char* tap = getenv("PROSPER_FS_TAP")) {
-        const char* pc = strchr(tap, ':');
-        b.tap_pc = static_cast<uint32_t>(strtoul(pc ? pc + 1 : tap, nullptr, 0));
+        uint64_t draw = 0;
+        uint32_t pc = 0;
+        if (parse_fragment_tap_selector(tap, draw, pc)) b.tap_pc = pc;
     }
     b.declare_guest_scratch(scratch);
     b.fragment_interpolation = &derived_interpolation;

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -211,6 +211,9 @@ struct BackendDraw {
     std::vector<uint32_t> vs, gs, fs;
     prosper::gpu::SharedShaderWords vs_shared, fs_shared;
     uint64_t vs_identity = 0, fs_identity = 0;
+    // Stable semantic draw ID from DrawItem::draw_index. Diagnostics must not use this backend
+    // vector's pass-local offset: target/compute splitting can make that offset differ per pass.
+    uint64_t draw_index = UINT64_MAX;
     const prosper::gpu::ResolvedPipelineState* ps = nullptr;   // null -> triangle-list, write RGBA, no depth
     std::vector<FrameResource> R;                              // set-tagged resources (empty -> no descriptors)
     uint32_t vcount = 3;
@@ -4401,7 +4404,22 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     // the same env var in gpu_executor). Only active with the env var, TF support, AND a flush here.
     const char* geom_env = getenv("PROSPER_GEOM_PROBE");
     const long geom_target = geom_env ? strtol(geom_env, nullptr, 10) : -1;
-    const bool geom_probe = geom_target >= 0 && static_cast<size_t>(geom_target) < dv.size()
+    size_t geom_item = SIZE_MAX;
+    if (geom_target >= 0) {
+        for (size_t i = 0; i < draws.size(); ++i)
+            if (draws[i].draw_index == static_cast<uint64_t>(geom_target)) {
+                geom_item = i;
+                break;
+            }
+        // Direct backend tests and the single-draw wrapper have no semantic DrawItem. Preserve their
+        // positional diagnostic behavior only when the caller supplied no semantic IDs at all.
+        if (geom_item == SIZE_MAX &&
+            std::none_of(draws.begin(), draws.end(), [](const BackendDraw& draw) {
+                return draw.draw_index != UINT64_MAX;
+            }) && static_cast<size_t>(geom_target) < draws.size())
+            geom_item = static_cast<size_t>(geom_target);
+    }
+    const bool geom_probe = geom_item != SIZE_MAX
                             && ds_ctx.transform_feedback_enabled
                             && (!submission_batch || readback_requested || flush_submission_batch);
     static auto p_bindxfb  = reinterpret_cast<PFN_vkCmdBindTransformFeedbackBuffersEXT>(
@@ -4413,8 +4431,8 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     VkBuffer geom_buf = VK_NULL_HANDLE; VkDeviceMemory geom_mem = VK_NULL_HANDLE;
     VkBuffer geom_counter = VK_NULL_HANDLE; VkDeviceMemory geom_counter_mem = VK_NULL_HANDLE;
     uint32_t geom_cap = 0;   // buffer capacity in vertices; the counter buffer gives the exact count written
-    if (geom_probe && p_bindxfb && p_beginxfb && p_endxfb && dv[geom_target].ok) {
-        const auto& tv = dv[geom_target];
+    if (geom_probe && p_bindxfb && p_beginxfb && p_endxfb && dv[geom_item].ok) {
+        const auto& tv = dv[geom_item];
         const uint64_t per_inst = tv.icount ? tv.icount : tv.vcount;
         // Transform feedback records DECOMPOSED primitives: a triangle strip/fan of N verts emits up to
         // ~3*(N-2) individual vertices. Over-size by 3x so no records are dropped; the counter buffer
@@ -4469,7 +4487,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, v.pipe);
         vkCmdSetScissor(cmd, 0, 1, &v.scissor);
         if (v.use_desc) vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, v.layout, 0, v.n_sets, v.dsets.data(), 0, nullptr);
-        const bool geom_here = geom_active && static_cast<long>(di) == geom_target;
+        const bool geom_here = geom_active && di == geom_item;
         if (geom_here) {
             VkDeviceSize off = 0, sz = static_cast<VkDeviceSize>(geom_cap) * 16;
             p_bindxfb(cmd, 0, 1, &geom_buf, &off, &sz);
@@ -4702,9 +4720,12 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                     (samp  >  0) ? "passed-samples(colour/stencil written)" :
                     (fs    >  0) ? "TEST-KILLED(depth/stencil rejected all)" :
                                    "NO-RASTER(cull/scissor/zero-area)";
+                const uint64_t draw_index = draws[i].draw_index != UINT64_MAX
+                    ? draws[i].draw_index : i;
                 fprintf(stderr,
-                        "[draw-stats] draw=%u verts=%llu prims=%llu after_clip=%llu fs_inv=%llu samples=%llu %s\n",
-                        i, (unsigned long long)verts, (unsigned long long)prims,
+                        "[draw-stats] draw=%llu verts=%llu prims=%llu after_clip=%llu fs_inv=%llu samples=%llu %s\n",
+                        (unsigned long long)draw_index,
+                        (unsigned long long)verts, (unsigned long long)prims,
                         (unsigned long long)clip, (unsigned long long)fs, (unsigned long long)samp, tag);
             }
         }

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -4406,6 +4406,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     const char* geom_env = getenv("PROSPER_GEOM_PROBE");
     uint64_t geom_target = 0;
     const bool geom_target_valid = geom_env && gpu::parse_diagnostic_draw_id(geom_env, geom_target);
+    const auto geom_target_label = static_cast<unsigned long long>(geom_target);
     size_t geom_item = SIZE_MAX;
     if (geom_target_valid) {
         for (size_t i = 0; i < draws.size(); ++i)
@@ -4781,13 +4782,14 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                 // integers/bitfields, not clip floats) and skip the meaningless clip classification.
                 const bool is_tap = getenv("PROSPER_SHADER_TAP") != nullptr;
                 if (is_tap)
-                    fprintf(stderr, "[geom-probe] draw=%ld SHADER-TAP: values below are the tapped VGPR "
-                                    "(dst+3) at that PC, not clip positions (bbox/tags meaningless)\n", geom_target);
+                    fprintf(stderr, "[geom-probe] draw=%llu SHADER-TAP: values below are the tapped VGPR "
+                                    "(dst+3) at that PC, not clip positions (bbox/tags meaningless)\n",
+                            geom_target_label);
                 else
-                    fprintf(stderr, "[geom-probe] draw=%ld verts-written=%u finite=%u on-screen=%u clipped=%u "
+                    fprintf(stderr, "[geom-probe] draw=%llu verts-written=%u finite=%u on-screen=%u clipped=%u "
                                     "(offscreen=%u w<=0=%u nan/inf=%u)\n"
                                     "[geom-probe]   clip-bbox x[%g,%g] y[%g,%g] z[%g,%g] w[%g,%g] -> %s\n",
-                            geom_target, written, finite, onscreen, clipped, offscreen, wle0, nan,
+                            geom_target_label, written, finite, onscreen, clipped, offscreen, wle0, nan,
                             minx,maxx, miny,maxy, minz,maxz, minw,maxw, tag);
                 for (uint32_t i = 0; i < written && i < (is_tap ? 8u : 4u); i++) {
                     if (is_tap) {
@@ -4863,9 +4865,9 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                         finite_tri && degenerate * 5u >= finite_tri*4u ? "DEGENERATE-HEAVY(>=80% zero-area - strip-stitching read as list, or wrong count/stride)" :
                         dup_tri && dup_tri * 4u >= real_tri            ? "DUPLICATE-TRIANGLES(exact repeats = pure overdraw - likely over-count/wrong vertex range)" :
                                                                          "ok(check PROSPER_DRAW_STATS for overdraw: samples>pixels)";
-                    fprintf(stderr, "[geom-health] draw=%ld verts=%u unique-pos=%u (max-mult=%u) "
+                    fprintf(stderr, "[geom-health] draw=%llu verts=%u unique-pos=%u (max-mult=%u) "
                                     "triangles=%u degenerate=%u(%.0f%%) real=%u duplicate-tri=%u -> %s\n",
-                            geom_target, (unsigned)verts.size(), unique_pos, max_mult, finite_tri, degenerate,
+                            geom_target_label, (unsigned)verts.size(), unique_pos, max_mult, finite_tri, degenerate,
                             finite_tri ? 100.0 * degenerate / finite_tri : 0.0, real_tri, dup_tri, health);
                 }
                 // PROSPER_GEOM_PROBE_DUMP=path (gated, off by default): write EVERY post-transform vertex
@@ -4884,8 +4886,8 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                 }
                 vkUnmapMemory(dev, geom_mem);
             } else if (!written) {
-                fprintf(stderr, "[geom-probe] draw=%ld: transform feedback wrote 0 vertices "
-                                "(draw produced no primitives)\n", geom_target);
+                fprintf(stderr, "[geom-probe] draw=%llu: transform feedback wrote 0 vertices "
+                                "(draw produced no primitives)\n", geom_target_label);
             }
         }
     }

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -5,6 +5,7 @@
 #pragma once
 #include <vulkan/vulkan.h>
 #include "../src/gpu/gpu_capture.hpp"
+#include "../src/gpu/diagnostic_selectors.hpp"
 #include "../src/gpu/render_state.hpp"
 #include "../frontends/shared/vulkan_device_select.hpp"
 #include <algorithm>
@@ -4403,11 +4404,12 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     // Requires VK_EXT_transform_feedback + the VS recompiled with gl_Position xfb-decorated (gated on
     // the same env var in gpu_executor). Only active with the env var, TF support, AND a flush here.
     const char* geom_env = getenv("PROSPER_GEOM_PROBE");
-    const long geom_target = geom_env ? strtol(geom_env, nullptr, 10) : -1;
+    uint64_t geom_target = 0;
+    const bool geom_target_valid = geom_env && gpu::parse_diagnostic_draw_id(geom_env, geom_target);
     size_t geom_item = SIZE_MAX;
-    if (geom_target >= 0) {
+    if (geom_target_valid) {
         for (size_t i = 0; i < draws.size(); ++i)
-            if (draws[i].draw_index == static_cast<uint64_t>(geom_target)) {
+            if (draws[i].draw_index == geom_target) {
                 geom_item = i;
                 break;
             }
@@ -4416,7 +4418,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         if (geom_item == SIZE_MAX &&
             std::none_of(draws.begin(), draws.end(), [](const BackendDraw& draw) {
                 return draw.draw_index != UINT64_MAX;
-            }) && static_cast<size_t>(geom_target) < draws.size())
+            }) && geom_target < draws.size())
             geom_item = static_cast<size_t>(geom_target);
     }
     const bool geom_probe = geom_item != SIZE_MAX

--- a/prosper/tests/test_gpu_replay_shader_dump.cpp
+++ b/prosper/tests/test_gpu_replay_shader_dump.cpp
@@ -30,20 +30,36 @@ int main() {
         {22, true, {0x22222222u, 0xbf810000u}},
     };
     gpu::DrawItem draw;
+    draw.draw_index = 7;
     draw.vs_raw_shader_index = 1;
     draw.fs_raw_shader_index = 0;
     replay.items.push_back(draw);
 
+    gpu::DrawItem later = draw;
+    later.draw_index = 11;
+    later.vs_raw_shader_index = 0;
+    later.fs_raw_shader_index = 1;
+    replay.items.push_back(later);
+    replay.operations = {
+        {gpu::SubmitOperationKind::Draw, 7, 100, true},
+        {gpu::SubmitOperationKind::Dispatch, 3, 101, true},
+        {gpu::SubmitOperationKind::Draw, 11, 102, true},
+    };
+
     std::string error;
-    const auto* vs = tools::select_realized_raw_shader(replay, "0:vs", error);
-    const auto* fs = tools::select_realized_raw_shader(replay, "0:fs", error);
+    const auto* vs = tools::select_realized_raw_shader(replay, "7:vs", error);
+    const auto* fs = tools::select_realized_raw_shader(replay, "7:fs", error);
     CHECK(vs == &replay.raw_shader_versions[1] && fs == &replay.raw_shader_versions[0],
-          "selector resolves the realized draw's exact raw stage identities");
+          "selector resolves a semantic draw ID instead of a compact item offset");
+    CHECK(tools::replay_item_index_for_draw(replay, 11) == 1 &&
+              tools::replay_operation_index_for_draw(replay, 11) == 2 &&
+              tools::replay_item_index_for_draw(replay, 1) == SIZE_MAX,
+          "draw IDs map across compact-item holes and mixed operation indices");
     CHECK(!tools::select_realized_raw_shader(replay, "2:vs", error) &&
-              error.find("invalid realized-shader selector") != std::string::npos,
-          "out-of-range realized draw reports a selector error");
+              error.find("realized draw 2 not found") != std::string::npos,
+          "missing semantic draw reports a selector error");
     replay.items[0].fs_raw_shader_index = 0xFFFFFFFFu;
-    CHECK(!tools::select_realized_raw_shader(replay, "0:fs", error) &&
+    CHECK(!tools::select_realized_raw_shader(replay, "7:fs", error) &&
               error.find("capture predates v19 or source was unreadable") != std::string::npos,
           "missing legacy raw source is explicit instead of selecting unrelated bytes");
 

--- a/prosper/tests/test_gpu_replay_shader_dump.cpp
+++ b/prosper/tests/test_gpu_replay_shader_dump.cpp
@@ -1,4 +1,5 @@
 #include "../tools/gpu_replay/realized_shader_dump.hpp"
+#include "../src/gpu/diagnostic_selectors.hpp"
 
 #include <cstdio>
 
@@ -23,6 +24,14 @@ int main() {
               !tools::parse_realized_shader_selector("1:ps", selector) &&
               !tools::parse_realized_shader_selector("1:vs:extra", selector),
           "malformed realized-shader selectors are rejected without partial parsing");
+
+    uint64_t diagnostic_draw = 0;
+    CHECK(gpu::parse_diagnostic_draw_id("0x481", diagnostic_draw) && diagnostic_draw == 1153,
+          "geometry probe accepts the same explicit-base semantic ID in every layer");
+    CHECK(!gpu::parse_diagnostic_draw_id("1153junk", diagnostic_draw) &&
+              !gpu::parse_diagnostic_draw_id("-1", diagnostic_draw) &&
+              !gpu::parse_diagnostic_draw_id("18446744073709551616", diagnostic_draw),
+          "geometry probe rejects partial, signed, and overflowing draw IDs");
 
     gpu::GpuReplayFrame replay;
     replay.raw_shader_versions = {

--- a/prosper/tests/test_gpu_replay_shader_dump.cpp
+++ b/prosper/tests/test_gpu_replay_shader_dump.cpp
@@ -33,6 +33,28 @@ int main() {
               !gpu::parse_diagnostic_draw_id("18446744073709551616", diagnostic_draw),
           "geometry probe rejects partial, signed, and overflowing draw IDs");
 
+    uint64_t draw_first = 0, draw_last = 0;
+    CHECK(gpu::parse_diagnostic_draw_range("0x7:013", draw_first, draw_last) &&
+              draw_first == 7 && draw_last == 11 &&
+              gpu::parse_diagnostic_draw_range("1153", draw_first, draw_last) &&
+              draw_first == 1153 && draw_last == 1153,
+          "draw selection parses complete semantic IDs and explicit numeric bases");
+    CHECK(!gpu::parse_diagnostic_draw_range("7junk", draw_first, draw_last) &&
+              !gpu::parse_diagnostic_draw_range("7:", draw_first, draw_last) &&
+              !gpu::parse_diagnostic_draw_range(":11", draw_first, draw_last) &&
+              !gpu::parse_diagnostic_draw_range("7:11:12", draw_first, draw_last),
+          "draw selection rejects partial and incomplete ranges");
+
+    uint32_t tap_pc = 0;
+    CHECK(gpu::parse_fragment_tap_selector("0x481:0x18f", diagnostic_draw, tap_pc) &&
+              diagnostic_draw == 1153 && tap_pc == 399,
+          "fragment tap parses a complete semantic draw and 32-bit PC");
+    CHECK(!gpu::parse_fragment_tap_selector("1153", diagnostic_draw, tap_pc) &&
+              !gpu::parse_fragment_tap_selector("1153:399junk", diagnostic_draw, tap_pc) &&
+              !gpu::parse_fragment_tap_selector("1153:0x100000000", diagnostic_draw, tap_pc) &&
+              !gpu::parse_fragment_tap_selector("1153:399:1", diagnostic_draw, tap_pc),
+          "fragment tap rejects missing, partial, overflowing, and extra components");
+
     gpu::GpuReplayFrame replay;
     replay.raw_shader_versions = {
         {11, true, {0x11111111u, 0xbf810000u}},

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -51,7 +51,7 @@ Create a capsule with the native-speed workflow in
 
 ## Raw-vs-realized draw check — `raw=` on each `--inspect-only` draw line (#1256)
 
-Each `draw[i] … vcount=N indices=M voffset=V modifier=D topo=T raw=…` line reports the **raw
+Each `draw[ID] item=I … vcount=N indices=M voffset=V modifier=D topo=T raw=…` line reports the **raw
 draw-packet state** the guest submitted, decoded BEFORE realization. `raw=` is available in capture
 v23+, while `voffset=` and `modifier=` are available in capture v27+:
 
@@ -182,7 +182,7 @@ PROSPER_GEOM_PROBE=4 ./build-linux/gpu_replay /tmp/submit.prgcap /tmp/out.bmp
 # [geom-probe]   v0 = (-2.9, -0.771, 0, 1) ...
 ```
 
-The natural follow-up when the fragment funnel reports **GEOMETRY-VANISH**: capture draw N's **post-transform
+The natural follow-up when the fragment funnel reports **GEOMETRY-VANISH**: capture semantic draw N's **post-transform
 clip-space vertex positions** via `VK_EXT_transform_feedback` and report where they landed — clip-space
 bounding box, on-screen vs clipped counts, `w<=0` (behind-camera), NaN/inf, degenerate (all-collapsed), plus
 the first few raw `vec4`s. This distinguishes the ways a `GEOMETRY-VANISH` can happen:
@@ -196,7 +196,8 @@ Read it **with** the funnel: the funnel owns the "does it rasterize" verdict (`a
 owns *where the geometry is* — a large full-screen quad can have every vertex just outside the cube yet still
 rasterize, so "all verts clipped" is not "renders nothing"; the bbox tells them apart.
 
-Mechanics: on a capsule (stored SPIR-V) gpu_replay re-recompiles draw N's raw RDNA2 VS with `gl_Position`
+Mechanics: on a capsule (stored SPIR-V) gpu_replay resolves semantic draw N to its compact item, then
+re-recompiles that draw's raw RDNA2 VS with `gl_Position`
 xfb-decorated (requires a v19+ capsule that retained the raw VS stream) and swaps it in for that one draw; the
 live app recompiles fresh. Requires the device to advertise `VK_EXT_transform_feedback` (RADV, lavapipe). The
 probed draw's rendered pixels may be inexact (the re-recompile drops pixel-input remapping), but the captured
@@ -259,7 +260,7 @@ PROSPER_FS_TAP=6:27 ./build-linux/gpu_replay /tmp/submit.prgcap /tmp/out.bmp
 
 The fragment-stage sibling of `PROSPER_SHADER_TAP`, for "why is this **pixel** the wrong colour?" — capture a
 fragment shader's intermediate at instruction `PC` (the same PC `shader_inspect` prints) and **redirect the
-MRT0 colour export to it**, so draw `DRAW`'s pixels in the rendered frame *are* the value visualised. Unlike the
+MRT0 colour export to it**, so semantic draw `DRAW`'s pixels in the rendered frame *are* the value visualised. Unlike the
 VS tap it needs no separate capture — the output BMP is the readout. Point `--dump-realized-shader DRAW:fs` +
 `shader_inspect` at the FS to find the PC (an `image_sample`/MIMG result, a UV, a pre-blend colour), then
 `PROSPER_FS_TAP=DRAW:PC`. gpu_replay re-recompiles only that draw's FS (needs a v19+ capsule with the raw FS
@@ -273,7 +274,8 @@ tap); inert and byte-identical when the env var is unset. The re-recompile drops
 value derived from `gl_FragCoord`/sample position reads 0 (visualise fetch/sample/colour intermediates, not
 FragCoord-dependent terms).
 
-`--dump-shader DRAW:vs|fs PATH` writes the recompiled SPIR-V. Capture v19 adds
+`--dump-shader DRAW:vs|fs PATH` writes the recompiled SPIR-V. `DRAW` is the semantic ID printed by
+`--inspect-only`, as it is for the probes above. Capture v19 adds
 `--dump-realized-shader DRAW:vs|fs PATH` for the exact bounded raw RDNA2 stream that produced that realized
 draw stage, suitable for `shader_inspect`. The VS/FS streams use the same content-addressed 64 KiB-per-stage,
 64 MiB-total store as failed-shader diagnostics. Captures v1-v18 remain readable; because they did not retain
@@ -335,11 +337,14 @@ matches the optional address filter is written. A sampled-texture filter A/B use
 These environment variables are localization probes, not fixes, and their output must not replace an unmodified
 regression oracle.
 
-`--draw` uses realized draw indices, while graphs use mixed semantic operation indices. They are not
-interchangeable when dispatches or unrealized operations are present. Replay restores serialized render-target
-seeds before operation zero and uses owned resource memory; it must not dereference original guest mappings.
-Bundle operation sources are semantic draw IDs and may contain holes; tooling must resolve them through each
-realized item's `draw_index`, never treat them as offsets into the compact draw vector.
+Every user-facing `DRAW` selector (`--draw`, `--dump-resource`, `--dump-shader`,
+`--dump-realized-shader`, `PROSPER_GEOM_PROBE`, and `PROSPER_FS_TAP`) uses the stable semantic draw ID
+printed as `draw[ID]` by `--inspect-only`. The adjacent `item=I` is only the compact realized-vector offset;
+it can differ after an unrealized draw and is never a selector. Mixed `operation[N]` ordinals remain a separate,
+explicit namespace used by `--through-operation`. Replay restores serialized render-target seeds before
+operation zero and uses owned resource memory; it must not dereference original guest mappings. Bundle
+operation sources are semantic draw IDs and may contain holes; tooling resolves them through each realized
+item's `draw_index`, never as offsets into the compact draw vector.
 
 `--draw-with-compute-prefix` retains every compute operation before the selected draw while discarding the
 other graphics draws. This isolates geometry whose vertex/indirect buffers are produced earlier in the same

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -1,6 +1,7 @@
 #include "gpu/gpu_capture.hpp"
 #include "gpu/gpu_capture_bundle.hpp"
 #include "gpu/gpu_dependency_graph.hpp"
+#include "gpu/diagnostic_selectors.hpp"
 #include "gpu/gpu_execute.hpp"
 #include "gpu/shader_resources.hpp"
 #include "live_renderer.hpp"
@@ -1381,10 +1382,13 @@ int main(int argc, char** argv) {
     // and swap it in here; render_runner then binds a TF buffer around that draw and reports where its
     // post-transform vertices land. Requires a v19+ capsule that retained the raw VS stream.
     if (const char* g = std::getenv("PROSPER_GEOM_PROBE")) {
-        char* end = nullptr;
-        const unsigned long long n = std::strtoull(g, &end, 0);
-        const size_t item_index = g[0] != '-' && end != g && end && !*end
-            ? prosper::tools::replay_item_index_for_draw(replay, n) : SIZE_MAX;
+        uint64_t n = 0;
+        if (!prosper::gpu::parse_diagnostic_draw_id(g, n)) {
+            std::fprintf(stderr, "[geom-probe] invalid semantic draw selector '%s'\n", g);
+            return 2;
+        }
+        const auto draw_label = static_cast<unsigned long long>(n);
+        const size_t item_index = prosper::tools::replay_item_index_for_draw(replay, n);
         if (item_index != SIZE_MAX) {
             auto& it = replay.items[item_index];
             const size_t operation_index =
@@ -1400,17 +1404,18 @@ int main(int argc, char** argv) {
                     std::fprintf(stderr,
                                  "[geom-probe] draw=%llu item=%zu operation=%lld VS re-recompiled "
                                  "with xfb capture (%zu words)\n",
-                                 n, item_index, operation_label, it.vs.size());
+                                 draw_label, item_index, operation_label, it.vs.size());
                 } else {
                     std::fprintf(stderr, "[geom-probe] draw %llu: xfb re-recompile produced no VS "
-                                         "(no raw stream / unsupported)\n", n);
+                                         "(no raw stream / unsupported)\n", draw_label);
                 }
             } else {
                 std::fprintf(stderr, "[geom-probe] draw %llu: no captured raw VS stream "
-                                     "(capsule predates v19)\n", n);
+                                     "(capsule predates v19)\n", draw_label);
             }
         } else {
-            std::fprintf(stderr, "[geom-probe] invalid or unrealized semantic draw selector '%s'\n", g);
+            std::fprintf(stderr, "[geom-probe] unrealized semantic draw %llu\n", draw_label);
+            return 2;
         }
     }
     // Fragment I/O tap (PROSPER_FS_TAP=draw:pc): re-recompile draw N's raw FS (recompile_fragment reads the

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -1184,7 +1184,8 @@ int main(int argc, char** argv) {
     bool legacy_htile_before_stencil = false, draw_with_compute_prefix = false;
     size_t bundle_tail = 0;
     uint32_t bundle_intermediate_target_width = 0, bundle_intermediate_target_height = 0;
-    int draw_first = -1, draw_last = -1;
+    bool draw_selected = false;
+    uint64_t draw_first = 0, draw_last = 0;
     int through_operation = -1;
     int compute_only = -1;
     std::string draw_steps_prefix;     // --draw-steps PREFIX: filmstrip of the composite per operation-step
@@ -1250,9 +1251,9 @@ int main(int argc, char** argv) {
         }
         else if (std::string(argv[i]) == "--prepend" && i + 1 < argc) prepend_path = argv[++i];
         else if (std::string(argv[i]) == "--draw" && i + 1 < argc) {
-            std::string range = argv[++i]; size_t colon = range.find(':');
-            draw_first = std::atoi(range.c_str());
-            draw_last = colon == std::string::npos ? draw_first : std::atoi(range.c_str() + colon + 1);
+            draw_selected = prosper::gpu::parse_diagnostic_draw_range(
+                argv[++i], draw_first, draw_last);
+            if (!draw_selected) { usage(argv[0]); return 2; }
         }
         else if (std::string(argv[i]) == "--draw-with-compute-prefix")
             draw_with_compute_prefix = true;
@@ -1320,7 +1321,7 @@ int main(int argc, char** argv) {
     if (!bundle_path.empty()) {
         if (bundle_ds_summary && bundle_find_ds_addr) { usage(argv[0]); return 2; }
         if (positional.size() > 1 || inspect || inspect_only || validate_only || graph_only ||
-            draw_first >= 0 || draw_with_compute_prefix || through_operation >= 0 ||
+            draw_selected || draw_with_compute_prefix || through_operation >= 0 ||
             compute_only >= 0 ||
             warmup_repeats || !dump_spec.empty() || rtt_seed_addr ||
             !shader_spec.empty() || !compute_shader_spec.empty() ||
@@ -1346,11 +1347,11 @@ int main(int argc, char** argv) {
         usage(argv[0]); return 2;
     }
     if (positional.empty() || positional.size() > 2) { usage(argv[0]); return 2; }
-    if ((draw_first >= 0 && through_operation >= 0) ||
-        (compute_only >= 0 && (draw_first >= 0 || through_operation >= 0))) {
+    if ((draw_selected && through_operation >= 0) ||
+        (compute_only >= 0 && (draw_selected || through_operation >= 0))) {
         usage(argv[0]); return 2;
     }
-    if (draw_with_compute_prefix && draw_first < 0) { usage(argv[0]); return 2; }
+    if (draw_with_compute_prefix && !draw_selected) { usage(argv[0]); return 2; }
     // #1332: the filmstrip sub-flags configure --draw-steps; alone they would be silently unused.
     if ((draw_steps_every > 0 || draw_steps_target_w) && draw_steps_prefix.empty()) {
         usage(argv[0]); return 2;
@@ -1358,7 +1359,7 @@ int main(int argc, char** argv) {
     // #1330: ordered-prefix inspection modes must see the pass a prefix actually ends on, even when
     // that pass renders a non-RGBA8 target (an FP16 HDR scene). The shared live renderer publishes an
     // inspection-converted fallback only under this env, so full replays and live runs are unchanged.
-    if ((draw_first >= 0 || through_operation >= 0 || !draw_steps_prefix.empty()) &&
+    if ((draw_selected || through_operation >= 0 || !draw_steps_prefix.empty()) &&
         !set_environment("PROSPER_PREFIX_INSPECT", "1")) {
         std::fprintf(stderr, "gpu_replay: cannot set PROSPER_PREFIX_INSPECT\n"); return 2;
     }
@@ -1422,10 +1423,14 @@ int main(int argc, char** argv) {
     // pc after the ':' and redirects its MRT0 colour export to the intermediate value at that PC) and swap it
     // in, so that draw's rendered pixels visualise the tapped value. Requires a v19+ capsule with the raw FS.
     if (const char* f = std::getenv("PROSPER_FS_TAP")) {
-        char* end = nullptr;
-        const unsigned long long n = std::strtoull(f, &end, 0);
-        const size_t item_index = f[0] != '-' && end != f && end && *end == ':'
-            ? prosper::tools::replay_item_index_for_draw(replay, n) : SIZE_MAX;
+        uint64_t n = 0;
+        uint32_t tap_pc = 0;
+        if (!prosper::gpu::parse_fragment_tap_selector(f, n, tap_pc)) {
+            std::fprintf(stderr, "[fs-tap] invalid draw:pc selector '%s'\n", f);
+            return 2;
+        }
+        const auto draw_label = static_cast<unsigned long long>(n);
+        const size_t item_index = prosper::tools::replay_item_index_for_draw(replay, n);
         if (item_index != SIZE_MAX) {
             auto& it = replay.items[item_index];
             const size_t operation_index =
@@ -1440,18 +1445,19 @@ int main(int argc, char** argv) {
                     it.fs = std::move(fs); it.fs_shared.reset(); it.fs_identity = 0;
                     std::fprintf(stderr,
                                  "[fs-tap] draw=%llu item=%zu operation=%lld FS re-recompiled "
-                                 "with colour tap (%zu words)\n",
-                                 n, item_index, operation_label, it.fs.size());
+                                 "at pc=%u with colour tap (%zu words)\n",
+                                 draw_label, item_index, operation_label, tap_pc, it.fs.size());
                 } else {
                     std::fprintf(stderr, "[fs-tap] draw %llu: FS re-recompile produced no output "
-                                         "(no raw stream / unsupported)\n", n);
+                                         "(no raw stream / unsupported)\n", draw_label);
                 }
             } else {
                 std::fprintf(stderr, "[fs-tap] draw %llu: no captured raw FS stream "
-                                     "(capsule predates v19)\n", n);
+                                     "(capsule predates v19)\n", draw_label);
             }
         } else {
-            std::fprintf(stderr, "[fs-tap] invalid or unrealized semantic draw selector '%s'\n", f);
+            std::fprintf(stderr, "[fs-tap] unrealized semantic draw %llu\n", draw_label);
+            return 2;
         }
     }
     prosper::gpu::GpuCaptureFile prepend_capture;
@@ -1715,22 +1721,25 @@ int main(int argc, char** argv) {
                      compute_resource_path.c_str());
     }
     size_t selected_operation_limit = SIZE_MAX;
-    if (draw_first >= 0) {
+    if (draw_selected) {
         if (draw_last < draw_first) {
-            std::fprintf(stderr, "gpu_replay: draw range %d:%d is out of range\n", draw_first, draw_last); return 2;
+            std::fprintf(stderr, "gpu_replay: draw range %llu:%llu is out of range\n",
+                         static_cast<unsigned long long>(draw_first),
+                         static_cast<unsigned long long>(draw_last));
+            return 2;
         }
         std::vector<prosper::gpu::DrawItem> selected;
         std::unordered_set<uint64_t> selected_draw_indexes;
         for (auto& item : replay.items) {
-            if (item.draw_index < static_cast<uint64_t>(draw_first) ||
-                item.draw_index > static_cast<uint64_t>(draw_last))
+            if (item.draw_index < draw_first || item.draw_index > draw_last)
                 continue;
             selected_draw_indexes.insert(item.draw_index);
             selected.push_back(std::move(item));
         }
         if (selected.empty()) {
-            std::fprintf(stderr, "gpu_replay: semantic draw range %d:%d has no realized items\n",
-                         draw_first, draw_last);
+            std::fprintf(stderr, "gpu_replay: semantic draw range %llu:%llu has no realized items\n",
+                         static_cast<unsigned long long>(draw_first),
+                         static_cast<unsigned long long>(draw_last));
             return 2;
         }
         if (draw_with_compute_prefix) {
@@ -1747,8 +1756,9 @@ int main(int argc, char** argv) {
             }
         }
         replay.items = std::move(selected); allow_mismatch = true;
-        std::fprintf(stderr, "[gpureplay] selected semantic draws %d:%d (%zu realized)%s\n",
-                     draw_first, draw_last, replay.items.size(),
+        std::fprintf(stderr, "[gpureplay] selected semantic draws %llu:%llu (%zu realized)%s\n",
+                     static_cast<unsigned long long>(draw_first),
+                     static_cast<unsigned long long>(draw_last), replay.items.size(),
                      draw_with_compute_prefix ? " with compute prefix" : "");
     }
     if (through_operation >= 0) {
@@ -1878,7 +1888,7 @@ int main(int argc, char** argv) {
     }
     const size_t operation_limit = through_operation >= 0
         ? static_cast<size_t>(through_operation) + 1 : selected_operation_limit;
-    const bool selected_draws_only = draw_first >= 0 && !draw_with_compute_prefix;
+    const bool selected_draws_only = draw_selected && !draw_with_compute_prefix;
     std::vector<uint8_t> pixels = execute_frame(replay, selected_draws_only, operation_limit);
     // Diagnostic: after rendering, read back every persistent depth/stencil surface's STENCIL plane and
     // write it as a grayscale image (value*80) plus a value histogram. This shows exactly where a
@@ -1953,7 +1963,7 @@ int main(int argc, char** argv) {
     }
     const auto extent_mode = selected_draws_only
         ? prosper::gpu::replay_tool::OutputExtentMode::SelectedDraws
-        : (through_operation >= 0 || (draw_first >= 0 && draw_with_compute_prefix))
+        : (through_operation >= 0 || (draw_selected && draw_with_compute_prefix))
             ? prosper::gpu::replay_tool::OutputExtentMode::OrderedPrefix
             : prosper::gpu::replay_tool::OutputExtentMode::Capture;
     const auto output_extent = prosper::gpu::replay_tool::replay_output_extent(

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -339,13 +339,13 @@ void inspect_frame(const prosper::gpu::GpuReplayFrame& replay) {
                           d.vertex_count > d.raw_draw_count + 1 ? " [INFLATED]"
                           : d.vertex_count < d.raw_draw_count   ? " [DIVERGENT]" : "");
         }
-        std::printf("draw[%zu] source=%llu target=%016llx extent=%ux%u fmt=%u cwm=%x "
+        std::printf("draw[%llu] item=%zu target=%016llx extent=%ux%u fmt=%u cwm=%x "
                     "target1=%016llx extent1=%ux%u fmt1=%u cwm1=%x vcount=%u indices=%zu voffset=%d modifier=%016llx topo=%u%s "
                     "depth=%d/%d/%u stencil=%d blend=%d raster=%u/%u/%u bias=%u/%g/%g/%g "
                     "viewport=%d %.1f,%.1f %.1fx%.1f "
                     "scissor=%d [%d,%d)-[%d,%d) export=%08x downconvert=%08x "
                     "vs=%zu/%016llx fs=%zu/%016llx\n",
-                    i, static_cast<unsigned long long>(d.draw_index),
+                    static_cast<unsigned long long>(d.draw_index), i,
                     static_cast<unsigned long long>(d.color0_base), d.color0_width, d.color0_height,
                     d.ps.color0_format, d.ps.color_write_mask,
                     static_cast<unsigned long long>(d.color1_base), d.color1_width, d.color1_height,
@@ -539,7 +539,8 @@ bool validate_frame(const prosper::gpu::GpuReplayFrame& replay) {
         for (const auto& s : stages) {
             auto report = prosper::gpu::validate_spirv_descriptor_interface(
                 *s.spirv, s.table, s.set, s.stage, true);
-            std::printf("draw[%zu] %s descriptors=%zu runtime=%zu result=%s\n", i, s.name,
+            std::printf("draw[%llu] item=%zu %s descriptors=%zu runtime=%zu result=%s\n",
+                        static_cast<unsigned long long>(d.draw_index), i, s.name,
                         report.descriptors.size(), s.table ? s.table->resources.size() : 0,
                         report.ok() ? "accept" : "reject");
             for (const auto& binding : report.descriptors)
@@ -1380,48 +1381,72 @@ int main(int argc, char** argv) {
     // and swap it in here; render_runner then binds a TF buffer around that draw and reports where its
     // post-transform vertices land. Requires a v19+ capsule that retained the raw VS stream.
     if (const char* g = std::getenv("PROSPER_GEOM_PROBE")) {
-        const long n = std::strtol(g, nullptr, 10);
-        if (n >= 0 && static_cast<size_t>(n) < replay.items.size()) {
-            auto& it = replay.items[static_cast<size_t>(n)];
+        char* end = nullptr;
+        const unsigned long long n = std::strtoull(g, &end, 0);
+        const size_t item_index = g[0] != '-' && end != g && end && !*end
+            ? prosper::tools::replay_item_index_for_draw(replay, n) : SIZE_MAX;
+        if (item_index != SIZE_MAX) {
+            auto& it = replay.items[item_index];
+            const size_t operation_index =
+                prosper::tools::replay_operation_index_for_draw(replay, n);
+            const long long operation_label = operation_index == SIZE_MAX
+                ? -1 : static_cast<long long>(operation_index);
             if (it.vs_raw_shader_index < replay.raw_shader_versions.size()) {
                 const auto& raw = replay.raw_shader_versions[it.vs_raw_shader_index];
                 auto xfb = prosper::gpu::recompile_vertex(raw.words.data(), raw.words.size(),
                                                           it.vrt.get(), nullptr, true);
                 if (!xfb.empty()) {
                     it.vs = std::move(xfb); it.vs_shared.reset(); it.vs_identity = 0;
-                    std::fprintf(stderr, "[geom-probe] draw %ld VS re-recompiled with xfb capture (%zu words)\n",
-                                 n, it.vs.size());
+                    std::fprintf(stderr,
+                                 "[geom-probe] draw=%llu item=%zu operation=%lld VS re-recompiled "
+                                 "with xfb capture (%zu words)\n",
+                                 n, item_index, operation_label, it.vs.size());
                 } else {
-                    std::fprintf(stderr, "[geom-probe] draw %ld: xfb re-recompile produced no VS "
+                    std::fprintf(stderr, "[geom-probe] draw %llu: xfb re-recompile produced no VS "
                                          "(no raw stream / unsupported)\n", n);
                 }
             } else {
-                std::fprintf(stderr, "[geom-probe] draw %ld: no captured raw VS stream (capsule predates v19)\n", n);
+                std::fprintf(stderr, "[geom-probe] draw %llu: no captured raw VS stream "
+                                     "(capsule predates v19)\n", n);
             }
+        } else {
+            std::fprintf(stderr, "[geom-probe] invalid or unrealized semantic draw selector '%s'\n", g);
         }
     }
     // Fragment I/O tap (PROSPER_FS_TAP=draw:pc): re-recompile draw N's raw FS (recompile_fragment reads the
     // pc after the ':' and redirects its MRT0 colour export to the intermediate value at that PC) and swap it
     // in, so that draw's rendered pixels visualise the tapped value. Requires a v19+ capsule with the raw FS.
     if (const char* f = std::getenv("PROSPER_FS_TAP")) {
-        const long n = std::strtol(f, nullptr, 10);   // draw index (text before the ':')
-        if (n >= 0 && static_cast<size_t>(n) < replay.items.size()) {
-            auto& it = replay.items[static_cast<size_t>(n)];
+        char* end = nullptr;
+        const unsigned long long n = std::strtoull(f, &end, 0);
+        const size_t item_index = f[0] != '-' && end != f && end && *end == ':'
+            ? prosper::tools::replay_item_index_for_draw(replay, n) : SIZE_MAX;
+        if (item_index != SIZE_MAX) {
+            auto& it = replay.items[item_index];
+            const size_t operation_index =
+                prosper::tools::replay_operation_index_for_draw(replay, n);
+            const long long operation_label = operation_index == SIZE_MAX
+                ? -1 : static_cast<long long>(operation_index);
             if (it.fs_raw_shader_index < replay.raw_shader_versions.size()) {
                 const auto& raw = replay.raw_shader_versions[it.fs_raw_shader_index];
                 auto fs = prosper::gpu::recompile_fragment(raw.words.data(), raw.words.size(),
                                                            it.prt.get(), nullptr, UINT32_MAX, nullptr);
                 if (!fs.empty()) {
                     it.fs = std::move(fs); it.fs_shared.reset(); it.fs_identity = 0;
-                    std::fprintf(stderr, "[fs-tap] draw %ld FS re-recompiled with colour tap (%zu words)\n",
-                                 n, it.fs.size());
+                    std::fprintf(stderr,
+                                 "[fs-tap] draw=%llu item=%zu operation=%lld FS re-recompiled "
+                                 "with colour tap (%zu words)\n",
+                                 n, item_index, operation_label, it.fs.size());
                 } else {
-                    std::fprintf(stderr, "[fs-tap] draw %ld: FS re-recompile produced no output "
+                    std::fprintf(stderr, "[fs-tap] draw %llu: FS re-recompile produced no output "
                                          "(no raw stream / unsupported)\n", n);
                 }
             } else {
-                std::fprintf(stderr, "[fs-tap] draw %ld: no captured raw FS stream (capsule predates v19)\n", n);
+                std::fprintf(stderr, "[fs-tap] draw %llu: no captured raw FS stream "
+                                     "(capsule predates v19)\n", n);
             }
+        } else {
+            std::fprintf(stderr, "[fs-tap] invalid or unrealized semantic draw selector '%s'\n", f);
         }
     }
     prosper::gpu::GpuCaptureFile prepend_capture;
@@ -1523,9 +1548,13 @@ int main(int argc, char** argv) {
     if (!dump_spec.empty()) {
         size_t c1 = dump_spec.find(':'), c2 = c1 == std::string::npos ? c1 : dump_spec.find(':', c1 + 1);
         if (c1 == std::string::npos || c2 == std::string::npos) { usage(argv[0]); return 2; }
-        int di = std::atoi(dump_spec.c_str()); std::string stage = dump_spec.substr(c1 + 1, c2 - c1 - 1);
+        char* draw_end = nullptr;
+        const unsigned long long draw_index = std::strtoull(dump_spec.c_str(), &draw_end, 0);
+        const size_t di = dump_spec[0] != '-' && draw_end == dump_spec.c_str() + c1
+            ? prosper::tools::replay_item_index_for_draw(replay, draw_index) : SIZE_MAX;
+        std::string stage = dump_spec.substr(c1 + 1, c2 - c1 - 1);
         int binding = std::atoi(dump_spec.c_str() + c2 + 1);
-        if (di < 0 || static_cast<size_t>(di) >= replay.items.size() || (stage != "vs" && stage != "ps")) {
+        if (di == SIZE_MAX || (stage != "vs" && stage != "ps")) {
             std::fprintf(stderr, "gpu_replay: invalid resource selector %s\n", dump_spec.c_str()); return 2;
         }
         const auto* table = stage == "vs" ? replay.items[di].vrt.get() : replay.items[di].prt.get();
@@ -1545,9 +1574,14 @@ int main(int argc, char** argv) {
     }
     if (!shader_spec.empty()) {
         size_t colon = shader_spec.find(':');
-        int di = std::atoi(shader_spec.c_str()); std::string stage =
+        char* draw_end = nullptr;
+        const unsigned long long draw_index = std::strtoull(shader_spec.c_str(), &draw_end, 0);
+        const size_t di = colon != std::string::npos && shader_spec[0] != '-' &&
+                                  draw_end == shader_spec.c_str() + colon
+            ? prosper::tools::replay_item_index_for_draw(replay, draw_index) : SIZE_MAX;
+        std::string stage =
             colon == std::string::npos ? std::string{} : shader_spec.substr(colon + 1);
-        if (colon == std::string::npos || di < 0 || static_cast<size_t>(di) >= replay.items.size() ||
+        if (colon == std::string::npos || di == SIZE_MAX ||
             (stage != "vs" && stage != "fs")) {
             std::fprintf(stderr, "gpu_replay: invalid shader selector %s\n", shader_spec.c_str()); return 2;
         }
@@ -1677,14 +1711,22 @@ int main(int argc, char** argv) {
     }
     size_t selected_operation_limit = SIZE_MAX;
     if (draw_first >= 0) {
-        if (draw_last < draw_first || static_cast<size_t>(draw_last) >= replay.items.size()) {
+        if (draw_last < draw_first) {
             std::fprintf(stderr, "gpu_replay: draw range %d:%d is out of range\n", draw_first, draw_last); return 2;
         }
         std::vector<prosper::gpu::DrawItem> selected;
         std::unordered_set<uint64_t> selected_draw_indexes;
-        for (int i = draw_first; i <= draw_last; ++i) {
-            selected_draw_indexes.insert(replay.items[i].draw_index);
-            selected.push_back(std::move(replay.items[i]));
+        for (auto& item : replay.items) {
+            if (item.draw_index < static_cast<uint64_t>(draw_first) ||
+                item.draw_index > static_cast<uint64_t>(draw_last))
+                continue;
+            selected_draw_indexes.insert(item.draw_index);
+            selected.push_back(std::move(item));
+        }
+        if (selected.empty()) {
+            std::fprintf(stderr, "gpu_replay: semantic draw range %d:%d has no realized items\n",
+                         draw_first, draw_last);
+            return 2;
         }
         if (draw_with_compute_prefix) {
             for (size_t operation_index = 0; operation_index < replay.operations.size();
@@ -1700,8 +1742,9 @@ int main(int argc, char** argv) {
             }
         }
         replay.items = std::move(selected); allow_mismatch = true;
-        std::fprintf(stderr, "[gpureplay] selected original draws %d:%d%s\n", draw_first,
-                     draw_last, draw_with_compute_prefix ? " with compute prefix" : "");
+        std::fprintf(stderr, "[gpureplay] selected semantic draws %d:%d (%zu realized)%s\n",
+                     draw_first, draw_last, replay.items.size(),
+                     draw_with_compute_prefix ? " with compute prefix" : "");
     }
     if (through_operation >= 0) {
         if (static_cast<size_t>(through_operation) >= replay.operations.size()) {

--- a/prosper/tools/gpu_replay/realized_shader_dump.hpp
+++ b/prosper/tools/gpu_replay/realized_shader_dump.hpp
@@ -3,16 +3,35 @@
 #include "../../src/gpu/gpu_capture.hpp"
 
 #include <cerrno>
+#include <cstdint>
 #include <cstdlib>
-#include <limits>
 #include <string>
 
 namespace prosper::tools {
 
 struct RealizedShaderSelector {
-    size_t draw_index = 0;
+    uint64_t draw_index = 0;
     bool vertex = false;
 };
+
+inline size_t replay_item_index_for_draw(const gpu::GpuReplayFrame& replay,
+                                         uint64_t draw_index) {
+    for (size_t item_index = 0; item_index < replay.items.size(); ++item_index)
+        if (replay.items[item_index].draw_index == draw_index) return item_index;
+    return SIZE_MAX;
+}
+
+inline size_t replay_operation_index_for_draw(const gpu::GpuReplayFrame& replay,
+                                              uint64_t draw_index) {
+    for (size_t operation_index = 0; operation_index < replay.operations.size();
+         ++operation_index) {
+        const auto& operation = replay.operations[operation_index];
+        if (operation.kind == gpu::SubmitOperationKind::Draw && operation.realized &&
+            operation.source_index == draw_index)
+            return operation_index;
+    }
+    return SIZE_MAX;
+}
 
 inline bool parse_realized_shader_selector(const std::string& spec,
                                            RealizedShaderSelector& selector) {
@@ -23,12 +42,11 @@ inline bool parse_realized_shader_selector(const std::string& spec,
     errno = 0;
     char* end = nullptr;
     const unsigned long long draw = std::strtoull(spec.c_str(), &end, 0);
-    if (errno == ERANGE || end != spec.c_str() + colon ||
-        draw > std::numeric_limits<size_t>::max())
+    if (errno == ERANGE || end != spec.c_str() + colon)
         return false;
     const std::string stage = spec.substr(colon + 1);
     if (stage != "vs" && stage != "fs") return false;
-    selector.draw_index = static_cast<size_t>(draw);
+    selector.draw_index = static_cast<uint64_t>(draw);
     selector.vertex = stage == "vs";
     return true;
 }
@@ -36,12 +54,16 @@ inline bool parse_realized_shader_selector(const std::string& spec,
 inline const gpu::GpuCaptureRawShaderVersion* select_realized_raw_shader(
     const gpu::GpuReplayFrame& replay, const std::string& spec, std::string& error) {
     RealizedShaderSelector selector;
-    if (!parse_realized_shader_selector(spec, selector) ||
-        selector.draw_index >= replay.items.size()) {
+    if (!parse_realized_shader_selector(spec, selector)) {
         error = "invalid realized-shader selector " + spec;
         return nullptr;
     }
-    const auto& draw = replay.items[selector.draw_index];
+    const size_t item_index = replay_item_index_for_draw(replay, selector.draw_index);
+    if (item_index == SIZE_MAX) {
+        error = "realized draw " + std::to_string(selector.draw_index) + " not found";
+        return nullptr;
+    }
+    const auto& draw = replay.items[item_index];
     const uint32_t raw_index = selector.vertex
         ? draw.vs_raw_shader_index : draw.fs_raw_shader_index;
     if (raw_index >= replay.raw_shader_versions.size()) {


### PR DESCRIPTION
Fixes #1395.

## Failure scenario

Replay capsules store realized draws in a compact `items` vector, while mixed operations address stable semantic draw IDs. After any unrealized draw, those indices diverge. The per-draw fragment and geometry probes treated `DRAW` as a compact item offset, and the Vulkan geometry backend compared it again against a pass-local vector offset after target/compute splitting. A probe could therefore report successful recompilation while substituting or capturing a different draw.

In the Blue Prince `lit_frame.prgcap` reproducer, operation 1172 addresses semantic draw 1153, stored at item 1149. The old `PROSPER_FS_TAP=1153:399` mutated item 1153 (semantic draw 1157) and left the frame byte-identical.

## Behavioral contract

- every user-facing `DRAW` selector uses the semantic `DrawItem::draw_index`
- `--inspect-only` prints `draw[ID] item=I` so the stable selector and diagnostic-only compact offset cannot be confused
- `--draw`, shader/resource dumps, `PROSPER_FS_TAP`, and `PROSPER_GEOM_PROBE` resolve the same semantic ID
- draw IDs and fragment PCs use a shared, fully consuming, range-checked base-0 grammar
- malformed selectors fail visibly instead of selecting draw or PC zero
- mixed `operation[N]` remains an explicit separate namespace for `--through-operation`
- backend-only tests without semantic IDs retain their positional geometry-probe fallback
- with diagnostics unset, rendering and output bytes are unchanged

## Implementation

- centralize semantic draw-to-item and draw-to-operation lookup
- carry the semantic draw ID into `BackendDraw` and resolve geometry probes after pass splitting
- share selector parsing between replay, the Vulkan backend, and fragment recompilation
- label draw-stat output with the semantic ID
- add compact-vector-hole, mixed-operation, cross-layer hex selector, and malformed selector regressions
- document the selector contract in the replay and Blue Prince tooling docs

## Validation at exact head 9c6aa213

- `cmake --build prosper/build-audit -j8` — passed
- `ctest --test-dir prosper/build-audit --output-on-failure -j8` — 146/146 passed
- unmodified Blue Prince replay — unchanged hash `8fee88f6b5cabd39`
- `PROSPER_FS_TAP=0x481:0x18f` — maps `draw=1153 item=1149 operation=1172`, PC 399, and changes output to `a30c3bd6a29d8715`
- `PROSPER_GEOM_PROBE=0x481` — maps the same IDs and captures 23,202 vertices
- `--draw 0x481` — selects semantic draw 1153 and replays successfully
- malformed `--draw 1153junk` and overflowing `PROSPER_FS_TAP=1153:0x100000000` — rejected with exit code 2
- semantic shader/raw-shader/resource selectors — passed
- `git diff --check` — clean

The live Blue Prince snapshot was not runnable in this devcontainer because the configured game dump is not mounted. The exact frozen Blue Prince capsule is the issue reproducer and exercises both affected probes on the real RADV GPU.
