### PR TITLE
fix(recompiler): honor IMAGE_SAMPLE_D gradients; LINEAR-S# dref becomes real 2x2 PCF

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -6320,9 +6320,12 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     // shadow map (see image_sample_dref_manual_2d for why not a compare sampler);
                     // an S# requesting LINEAR gets the software 2x2 PCF form (#1287/#781 banding).
                     b.declare_texture(res->binding, Dim_2D, false);
+                    // PROSPER_NO_DREF_PCF restores the historical hard-threshold single tap for
+                    // A/B bisection (PROSPER_NO_DEPTH_BIAS convention).
+                    static const bool no_pcf = getenv("PROSPER_NO_DREF_PCF") != nullptr;
                     b.image_sample_dref_manual_2d(res->binding, vread(cvg(1)), vread(cvg(2)),
                                                   vread(cvg(0)), res->depth_compare_func,
-                                                  res->mag_filter != 0, out);
+                                                  !no_pcf && res->mag_filter != 0, out);
                 } else { ok = false; return true; }
             } else if (is_gather_lz || is_gather_lz_o) {
                 // gather4 dmask selects ONE channel (must be a single bit); the result is always the
@@ -6353,10 +6356,16 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     // dropped them for an implicit-LOD sample; that is wrong exactly where guests
                     // use _d — projected/wrapped coordinates whose quad derivatives spike at wrap
                     // seams, which painted deep-mip bands as concentric light-pattern rings
-                    // (#1287/#781). See image_sample_grad_2d.
-                    b.image_sample_grad_2d(res->binding, vread(cvg(4)), vread(cvg(5)),
-                                           vread(cvg(0)), vread(cvg(1)),
-                                           vread(cvg(2)), vread(cvg(3)), out);
+                    // (#1287/#781). See image_sample_grad_2d. PROSPER_NO_SAMPLE_D_GRAD restores
+                    // the historical implicit-LOD form for A/B bisection (PROSPER_NO_DEPTH_BIAS
+                    // convention).
+                    static const bool no_grad = getenv("PROSPER_NO_SAMPLE_D_GRAD") != nullptr;
+                    if (no_grad)
+                        b.image_sample_2d(res->binding, vread(cvg(4)), vread(cvg(5)), out);
+                    else
+                        b.image_sample_grad_2d(res->binding, vread(cvg(4)), vread(cvg(5)),
+                                               vread(cvg(0)), vread(cvg(1)),
+                                               vread(cvg(2)), vread(cvg(3)), out);
                 } else {
                     uint32_t cu = vread(cvg(0)), cv = vread(cvg(1));
                     if (is_sample)         b.image_sample_2d(res->binding, cu, cv, out);

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -83,7 +83,7 @@ enum : uint32_t {
     ImgOp_Offset=0x10,                   // ImageOperands bit: dynamic texel offset (needs ImageGatherExtended)
     Img_Sampled_Storage=2,   // OpTypeImage "Sampled" operand: 2 = used WITHOUT a sampler (read/write storage image)
     ImgFmt_Unknown=0,        // OpTypeImage "Image Format": Unknown (runtime view format; needs the caps above)
-    ImgOp_Bias=1, ImgOp_Lod=2, ImgOp_Sample=0x40,   // ImageOperands bits: LOD bias / explicit LOD / MSAA Sample index.
+    ImgOp_Bias=1, ImgOp_Lod=2, ImgOp_Grad=4, ImgOp_Sample=0x40,   // ImageOperands bits: LOD bias / explicit LOD / explicit gradients / MSAA Sample index.
     SC_Workgroup=4, Scope_Device=1, Scope_Workgroup=2, Scope_Subgroup=3,
     MemSem_UniformAcqRel=0x48, MemSem_WGAcqRel=0x108,   // storage/LDS AcquireRelease memory semantics
     Dec_Block=2, Dec_ArrayStride=6, Dec_BuiltIn=11, Dec_NoPerspective=13, Dec_Flat=14,
@@ -865,40 +865,87 @@ struct SpirvCompute {
         const uint32_t bits = bcu(result);
         out[0] = out[1] = out[2] = out[3] = bits;
     }
-    // IMAGE_SAMPLE_C_LZ on a plain 2D texture, lowered as a MANUAL depth compare: sample the shadow
-    // map as an ordinary float texture at explicit LOD 0 and compare its .x against DREF in-shader
-    // using the S#'s compare function. The hardware path (compareEnable sampler over a depth-format
-    // view) needs backend machinery the color-texture path lacks (see the render-runner S# note);
-    // the manual form is exact for NEAREST shadow maps and approximates LINEAR PCF with a hard
-    // threshold. Vulkan compare semantics: result = (reference OP stored); the SQ S# compare enum
-    // (WORD0 [14:12]) matches VkCompareOp order — 0 NEVER, 1 LESS, 2 EQUAL, 3 LEQUAL, 4 GREATER,
-    // 5 NOTEQUAL, 6 GEQUAL, 7 ALWAYS. CONFIDENCE: MED (standard AMD sampler enum ordering; Blue
-    // Prince renders visually-correct shadows with it — the live A/B on #1271).
-    void image_sample_dref_manual_2d(uint32_t binding, uint32_t u_bits, uint32_t v_bits,
-                                     uint32_t dref_bits, uint32_t compare_func, uint32_t out[4]) {
-        uint32_t si    = id(); put(code, Op_Load, {tex_binding_simg[binding], si, tex_var[binding]});
-        uint32_t coord = id(); put(code, Op_CompositeConstruct, {t_v2f(), coord, bcf(u_bits), bcf(v_bits)});
-        uint32_t res   = id(); put(code, Op_ImageSampleExplicitLod,
-                                   {t_v4f, res, si, coord, ImgOp_Lod, fconstf(0.0f)});
-        uint32_t depth = id(); put(code, Op_CompositeExtract, {t_f32, depth, res, 0});
-        uint32_t result;
-        if (compare_func == 0u)      result = fconstf(0.0f);   // NEVER
-        else if (compare_func == 7u) result = fconstf(1.0f);   // ALWAYS
-        else {
-            uint32_t op;
-            switch (compare_func) {
-                case 1u: op = Op_FOrdLessThan;         break;
-                case 2u: op = Op_FOrdEqual;            break;
-                case 3u: op = Op_FOrdLessThanEqual;    break;
-                case 4u: op = Op_FOrdGreaterThan;      break;
-                case 5u: op = Op_FOrdNotEqual;         break;
-                default: op = Op_FOrdGreaterThanEqual; break;   // 6 GEQUAL
-            }
-            uint32_t cmp = id(); put(code, op, {t_bool, cmp, bcf(dref_bits), depth});
-            uint32_t r   = id(); put(code, Op_Select, {t_f32, r, cmp, fconstf(1.0f), fconstf(0.0f)});
-            result = r;
+    // The S# comparison (VkCompareOp order) of DREF against one depth value; both operands and the
+    // f32 0/1 result are raw bits. Vulkan compare semantics: result = (reference OP stored); the SQ
+    // S# compare enum (WORD0 [14:12]) matches VkCompareOp order — 0 NEVER, 1 LESS, 2 EQUAL,
+    // 3 LEQUAL, 4 GREATER, 5 NOTEQUAL, 6 GEQUAL, 7 ALWAYS. CONFIDENCE: MED (standard AMD sampler
+    // enum ordering; Blue Prince renders visually-correct shadows with it — the live A/B on #1271).
+    uint32_t dref_compare_result(uint32_t dref_bits, uint32_t depth_bits, uint32_t compare_func) {
+        if (compare_func == 0u) return bcu(fconstf(0.0f));   // NEVER
+        if (compare_func == 7u) return bcu(fconstf(1.0f));   // ALWAYS
+        uint32_t op;
+        switch (compare_func) {
+            case 1u: op = Op_FOrdLessThan;         break;
+            case 2u: op = Op_FOrdEqual;            break;
+            case 3u: op = Op_FOrdLessThanEqual;    break;
+            case 4u: op = Op_FOrdGreaterThan;      break;
+            case 5u: op = Op_FOrdNotEqual;         break;
+            default: op = Op_FOrdGreaterThanEqual; break;   // 6 GEQUAL
         }
-        const uint32_t bits = bcu(result);
+        uint32_t cmp = id(); put(code, op, {t_bool, cmp, bcf(dref_bits), bcf(depth_bits)});
+        uint32_t r   = id(); put(code, Op_Select, {t_f32, r, cmp, fconstf(1.0f), fconstf(0.0f)});
+        return bcu(r);
+    }
+    // IMAGE_SAMPLE_C_LZ on a plain 2D texture, lowered as a MANUAL depth compare. The hardware path
+    // (compareEnable sampler over a depth-format view) needs backend machinery the color-texture
+    // path lacks (see the render-runner S# note), so the comparison is emitted in-shader using the
+    // S#'s compare function. Two forms by the S#'s XY filter:
+    //  - NEAREST: sample the shadow map as an ordinary float texture at explicit LOD 0 and compare
+    //    its .x against DREF (exact for point sampling).
+    //  - LINEAR (linear_pcf): software 2x2 PCF with hardware compare-THEN-filter semantics — fetch
+    //    the four footprint texels, compare EACH against DREF, and bilinearly weight the four 0/1
+    //    results by the sample position's fractional texel weights. A compare sampler filters
+    //    comparison results, never depth values, so this matches hardware PCF. The previous
+    //    hard-threshold single tap quantized every filtered penumbra to 0/1, which surfaced as the
+    //    #1287/#781 light-attenuation banding (concentric rings / wall striping) once per-light
+    //    contributions were amplified. Texel coordinates clamp to the level-0 edge (CLAMP_TO_EDGE —
+    //    the observed shadow S# address mode; border modes would need the border value here).
+    void image_sample_dref_manual_2d(uint32_t binding, uint32_t u_bits, uint32_t v_bits,
+                                     uint32_t dref_bits, uint32_t compare_func, bool linear_pcf,
+                                     uint32_t out[4]) {
+        if (!linear_pcf) {
+            uint32_t si    = id(); put(code, Op_Load, {tex_binding_simg[binding], si, tex_var[binding]});
+            uint32_t coord = id(); put(code, Op_CompositeConstruct, {t_v2f(), coord, bcf(u_bits), bcf(v_bits)});
+            uint32_t res   = id(); put(code, Op_ImageSampleExplicitLod,
+                                       {t_v4f, res, si, coord, ImgOp_Lod, fconstf(0.0f)});
+            uint32_t depth = id(); put(code, Op_CompositeExtract, {t_f32, depth, res, 0});
+            const uint32_t bits = dref_compare_result(dref_bits, bcu(depth), compare_func);
+            out[0] = out[1] = out[2] = out[3] = bits;
+            return;
+        }
+        if (!declared_image_query) { put(caps, Op_Capability, {Cap_ImageQuery}); declared_image_query = true; }
+        uint32_t si   = id(); put(code, Op_Load,  {tex_binding_simg[binding], si, tex_var[binding]});
+        uint32_t img  = id(); put(code, Op_Image, {tex_binding_img[binding], img, si});
+        uint32_t size = id(); put(code, Op_ImageQuerySizeLod, {t_v2i(), size, img, uconst(0)});
+        uint32_t w_i  = id(); put(code, Op_CompositeExtract, {t_i32, w_i, size, 0});
+        uint32_t h_i  = id(); put(code, Op_CompositeExtract, {t_i32, h_i, size, 1});
+        // Unnormalized sample position t = coord*size - 0.5; base texel floor(t), weights fract(t).
+        const uint32_t half = uconst(0x3f000000u);   // 0.5f
+        uint32_t tx = fbin(Op_FSub, fbin(Op_FMul, u_bits, cvt_i2f(i2u(w_i))), half);
+        uint32_t ty = fbin(Op_FSub, fbin(Op_FMul, v_bits, cvt_i2f(i2u(h_i))), half);
+        uint32_t fx = fext1(Glsl_Fract, tx), fy = fext1(Glsl_Fract, ty);
+        uint32_t x0 = cvt_f2i(fext1(Glsl_Floor, tx));
+        uint32_t y0 = cvt_f2i(fext1(Glsl_Floor, ty));
+        uint32_t wm1 = sbin(Op_ISub, i2u(w_i), uconst(1u));
+        uint32_t hm1 = sbin(Op_ISub, i2u(h_i), uconst(1u));
+        auto edge_clamp = [&](uint32_t value, uint32_t max_bits) {
+            return sext2(Glsl_SMin, sext2(Glsl_SMax, value, uconst(0u)), max_bits);
+        };
+        uint32_t x0c = edge_clamp(x0, wm1), x1c = edge_clamp(sbin(Op_IAdd, x0, uconst(1u)), wm1);
+        uint32_t y0c = edge_clamp(y0, hm1), y1c = edge_clamp(sbin(Op_IAdd, y0, uconst(1u)), hm1);
+        auto tap = [&](uint32_t xb, uint32_t yb) {
+            uint32_t coord = id(); put(code, Op_CompositeConstruct, {t_v2u(), coord, xb, yb});
+            uint32_t texel = id(); put(code, Op_ImageFetch,
+                                       {texture_vec4(binding), texel, img, coord, ImgOp_Lod, uconst(0)});
+            uint32_t depth = id(); put(code, Op_CompositeExtract, {t_f32, depth, texel, 0});
+            return dref_compare_result(dref_bits, bcu(depth), compare_func);
+        };
+        uint32_t r00 = tap(x0c, y0c), r10 = tap(x1c, y0c);
+        uint32_t r01 = tap(x0c, y1c), r11 = tap(x1c, y1c);
+        auto lerp = [&](uint32_t a, uint32_t b_, uint32_t f) {
+            return fbin(Op_FAdd, a, fbin(Op_FMul, fbin(Op_FSub, b_, a), f));
+        };
+        const uint32_t bits = lerp(lerp(r00, r10, fx), lerp(r01, r11, fx), fy);
         out[0] = out[1] = out[2] = out[3] = bits;
     }
     // image_sample_b 2D: implicit-LOD sample with an LOD BIAS (bias_bits float). Bias only means
@@ -910,6 +957,22 @@ struct SpirvCompute {
         uint32_t res   = id();
         if (is_fragment) put(code, Op_ImageSampleImplicitLod, {texture_vec4(binding), res, si, coord, ImgOp_Bias, bcf(bias_bits)});
         else             put(code, Op_ImageSampleExplicitLod, {texture_vec4(binding), res, si, coord, ImgOp_Lod, fconstf(0.0f)});
+        unpack_texture_result(binding, res, out);
+    }
+    // image_sample_d 2D: explicit-gradient sample (OpImageSampleExplicitLod + Grad). The guest
+    // supplies analytic d(s,t)/dx and d(s,t)/dy precisely because its coordinates are NOT plain
+    // interpolants (projected/wrapped light patterns, polar mappings): screen-quad derivatives
+    // spike at every wrap seam, and an implicit-LOD fallback sampled the deepest mip in a band
+    // around each seam — the #1287/#781 concentric light-pattern rings. Honor the gradients.
+    void image_sample_grad_2d(uint32_t binding, uint32_t u_bits, uint32_t v_bits,
+                              uint32_t dsdx_bits, uint32_t dtdx_bits,
+                              uint32_t dsdy_bits, uint32_t dtdy_bits, uint32_t out[4]) {
+        uint32_t si    = id(); put(code, Op_Load, {tex_binding_simg[binding], si, tex_var[binding]});
+        uint32_t coord = id(); put(code, Op_CompositeConstruct, {t_v2f(), coord, bcf(u_bits), bcf(v_bits)});
+        uint32_t dx    = id(); put(code, Op_CompositeConstruct, {t_v2f(), dx, bcf(dsdx_bits), bcf(dtdx_bits)});
+        uint32_t dy    = id(); put(code, Op_CompositeConstruct, {t_v2f(), dy, bcf(dsdy_bits), bcf(dtdy_bits)});
+        uint32_t res   = id(); put(code, Op_ImageSampleExplicitLod,
+                                   {texture_vec4(binding), res, si, coord, ImgOp_Grad, dx, dy});
         unpack_texture_result(binding, res, out);
     }
     // image_gather4_lz 2D: OpImageGather of component `comp` (0..3) — the 2x2 footprint's four texels
@@ -6254,10 +6317,12 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     // op 0x2f dim 1 dmask 0x1 — the entire shadowed lighting pass dropped and the
                     // scene rendered unattenuated/blown-out). Same 8.2.5 vaddr order with no array
                     // slice: [dref, u, v]. Lowered as a manual compare against the color-sampled
-                    // shadow map (see image_sample_dref_manual_2d for why not a compare sampler).
+                    // shadow map (see image_sample_dref_manual_2d for why not a compare sampler);
+                    // an S# requesting LINEAR gets the software 2x2 PCF form (#1287/#781 banding).
                     b.declare_texture(res->binding, Dim_2D, false);
                     b.image_sample_dref_manual_2d(res->binding, vread(cvg(1)), vread(cvg(2)),
-                                                  vread(cvg(0)), res->depth_compare_func, out);
+                                                  vread(cvg(0)), res->depth_compare_func,
+                                                  res->mag_filter != 0, out);
                 } else { ok = false; return true; }
             } else if (is_gather_lz || is_gather_lz_o) {
                 // gather4 dmask selects ONE channel (must be a single bit); the result is always the
@@ -6284,9 +6349,14 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 } else if (is_sample_lz_o) {   // vaddr order for _o: [packed offset, u, v]
                     b.image_sample_lz_offset_2d(res->binding, vread(cvg(1)), vread(cvg(2)), vread(cvg(0)), out);
                 } else if (is_sample_d) {   // vaddr order for _d: [Ds/Dx, Dt/Dx, Ds/Dy, Dt/Dy, u, v]
-                    // Drop the four explicit gradients; the (u,v) coords follow them. Implicit-LOD sample
-                    // (fragment quad derivatives ~ the explicit gradients for ordinary UVs).
-                    b.image_sample_2d(res->binding, vread(cvg(4)), vread(cvg(5)), out);
+                    // Honor the explicit gradients (SPIR-V Grad operands). The previous lowering
+                    // dropped them for an implicit-LOD sample; that is wrong exactly where guests
+                    // use _d — projected/wrapped coordinates whose quad derivatives spike at wrap
+                    // seams, which painted deep-mip bands as concentric light-pattern rings
+                    // (#1287/#781). See image_sample_grad_2d.
+                    b.image_sample_grad_2d(res->binding, vread(cvg(4)), vread(cvg(5)),
+                                           vread(cvg(0)), vread(cvg(1)),
+                                           vread(cvg(2)), vread(cvg(3)), out);
                 } else {
                     uint32_t cu = vread(cvg(0)), cv = vread(cvg(1));
                     if (is_sample)         b.image_sample_2d(res->binding, cu, cv, out);

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -3370,6 +3370,19 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                     // restricted to plain-2D RGBA8 sampled guest textures. Cube/volume stacks,
                     // storage images, RTT-backed bindings, and other formats keep one level.
                     uint32_t tex_mip_levels = 1;
+                    // PROSPER_MIPLOG=1: report every texture binding's mip-eligibility decision —
+                    // which gate leg starves a declared chain down to one level (#1287 moiré).
+                    static const bool miplog_enabled = getenv("PROSPER_MIPLOG") != nullptr;
+                    if (miplog_enabled && r.tw >= 64 && !r.is_storage_image)
+                        fprintf(stderr,
+                                "[miplog] %ux%ux%u dim=%u declared_mips=%u fmt=%d rtt=%llu ds=%llu "
+                                "rgba=%d min_lod=%.1f max_lod=%.1f mag=%u min=%u mip=%u\n",
+                                r.tw, r.th, r.td, r.img_dim, r.declared_mip_levels,
+                                (int)r.texture_format,
+                                (unsigned long long)r.persistent_render_target_id,
+                                (unsigned long long)r.persistent_depth_target_id,
+                                r.tex_rgba != nullptr, r.min_lod, r.max_lod,
+                                r.mag_filter, r.min_filter, r.mip_filter);
                     if (!r.is_storage_image && r.img_dim == 1 && r.td == 1 &&
                         !r.persistent_render_target_id && r.tex_rgba &&
                         // Widening this format gate requires BLIT_SRC/BLIT_DST +
@@ -3735,6 +3748,22 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                     if (!words || !word_count) {
                         words = &zero_buffer_word;
                         word_count = 1;
+                    }
+                    // PROSPER_BUFLOG=1: per-binding upload provenance — set/binding, byte count, and
+                    // the first dwords as floats. Ground truth for "which bytes did the shader see"
+                    // when a fetch-offset defect is suspected (#1287).
+                    static const bool buflog_enabled = getenv("PROSPER_BUFLOG") != nullptr;
+                    if (buflog_enabled) {
+                        static int buflog_count = 0;
+                        if (buflog_count++ < 400) {
+                            const float* fp = reinterpret_cast<const float*>(words);
+                            fprintf(stderr,
+                                    "[buflog] set=%u binding=%u words=%zu id=%llx f0=%g f1=%g f2=%g\n",
+                                    r.set, r.binding, word_count,
+                                    (unsigned long long)r.buffer_identity,
+                                    word_count > 0 ? fp[0] : 0.f, word_count > 1 ? fp[1] : 0.f,
+                                    word_count > 2 ? fp[2] : 0.f);
+                        }
                     }
                     ++resource_reuse_stats.buffer_references;
                     ++backend_hash_stats_totals().references;

--- a/prosper/tests/test_shadow_compare_render.cpp
+++ b/prosper/tests/test_shadow_compare_render.cpp
@@ -257,6 +257,58 @@ int main() {
         }
     }
 
+    // LINEAR-filter dref = software 2x2 PCF with hardware compare-THEN-filter semantics
+    // (#1287/#781): a 2x2 depth texture with a pass/fail diagonal — texel (0,0)=0.0 and
+    // (1,1)=0.0 pass dref 0.5 GREATER, (1,0)=(0,1)~0.9 fail — sampled at the shared texel
+    // corner (u=v~0.5) must bilinearly weight the four 0/1 COMPARE RESULTS to ~0.5 (gray).
+    // The previous hard-threshold single tap produced only 0 or 1 there. A NEAREST S# keeps
+    // the exact single-tap behavior (1.0: the nearest texel passes).
+    {
+        std::vector<uint8_t> diag(2 * 2 * 4, 0);
+        auto texel = [&](uint32_t x, uint32_t y, uint8_t depth) {
+            uint8_t* t = &diag[(y * 2 + x) * 4]; t[0] = depth; t[3] = 255;
+        };
+        texel(0, 0, 0); texel(1, 0, 230); texel(0, 1, 230); texel(1, 1, 0);
+        prosper::test::TexDesc diag_td{4, 2, 2, diag.data()};
+
+        ShaderResourceTable pcf_rt;
+        { ShaderResource t{}; t.cls = ResourceClass::Texture; t.binding = 4; t.img_dim = 1;
+          t.width = 2; t.height = 2; t.sgpr_base = 8;
+          t.depth_compare = true; t.depth_compare_func = 4;   // GREATER
+          t.mag_filter = 1;                                   // LINEAR -> the PCF lowering
+          pcf_rt.resources.push_back(t); }
+        std::vector<uint32_t> pcf_frag = recompile_fragment(ps, sizeof(ps)/sizeof(ps[0]), &pcf_rt);
+        CHECK(!pcf_frag.empty(), "recompiled LINEAR-S# dref PS -> SPIR-V");
+        if (!pcf_frag.empty()) {
+            std::vector<uint8_t> px = prosper::test::render_triangle_rgba(
+                vert, pcf_frag, W, H, nullptr, nullptr, nullptr, &diag_td);
+            const uint8_t* c = px.size() == (size_t)W * H * 4
+                ? &px[((size_t)(H / 2) * W + W / 2) * 4] : nullptr;
+            printf("  PCF diagonal center R=%d (want ~128)\n", c ? c[0] : -1);
+            CHECK(c && c[0] > 90 && c[0] < 165,
+                  "LINEAR dref at the texel corner bilinearly weights the four compare "
+                  "results (~0.5) — hard-threshold gives 0/255");
+        }
+
+        ShaderResourceTable point_rt;
+        { ShaderResource t{}; t.cls = ResourceClass::Texture; t.binding = 4; t.img_dim = 1;
+          t.width = 2; t.height = 2; t.sgpr_base = 8;
+          t.depth_compare = true; t.depth_compare_func = 4;
+          t.mag_filter = 0; t.min_filter = 0;                 // NEAREST -> exact single tap
+          point_rt.resources.push_back(t); }
+        std::vector<uint32_t> point_frag = recompile_fragment(ps, sizeof(ps)/sizeof(ps[0]), &point_rt);
+        CHECK(!point_frag.empty(), "recompiled NEAREST-S# dref PS -> SPIR-V");
+        if (!point_frag.empty()) {
+            std::vector<uint8_t> px = prosper::test::render_triangle_rgba(
+                vert, point_frag, W, H, nullptr, nullptr, nullptr, &diag_td);
+            const uint8_t* c = px.size() == (size_t)W * H * 4
+                ? &px[((size_t)(H / 2) * W + W / 2) * 4] : nullptr;
+            printf("  NEAREST diagonal center R=%d (want 255)\n", c ? c[0] : -1);
+            CHECK(c && c[0] > 200,
+                  "NEAREST dref keeps the single-tap compare (the near texel passes)");
+        }
+    }
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;

--- a/prosper/tests/test_texture_mip_render.cpp
+++ b/prosper/tests/test_texture_mip_render.cpp
@@ -92,6 +92,47 @@ int main() {
     CHECK(ok && rgb[0] > 0xC0 && rgb[2] < 0x40,
           "declared_mip_levels=1 (the default) keeps the historical single-level clamp-to-0 behavior");
 
+    // IMAGE_SAMPLE_D honors the guest's explicit gradients (#1287/#781): du/dx = 1.0 across a
+    // 4-texel-wide base level is a 4-texel footprint -> LOD 2 -> the box-filtered purple. The
+    // previous lowering DROPPED the gradients for an implicit-LOD sample; the coordinates here
+    // are literals (zero quad derivatives), so it read level 0 (red) and this check fails.
+    {
+        const uint32_t ps_d[] = {
+            0x7e0002ffu, 0x3f800000u,   // v_mov_b32 v0, 1.0  (Ds/Dx)
+            0x7e0202ffu, 0x00000000u,   // v_mov_b32 v1, 0.0  (Dt/Dx)
+            0x7e0402ffu, 0x00000000u,   // v_mov_b32 v2, 0.0  (Ds/Dy)
+            0x7e0602ffu, 0x3f800000u,   // v_mov_b32 v3, 1.0  (Dt/Dy)
+            0x7e0802ffu, 0x3e000000u,   // v_mov_b32 v4, 0.125 (u)
+            0x7e0a02ffu, 0x3e000000u,   // v_mov_b32 v5, 0.125 (v)
+            0xf0880f08u, 0x00820600u,   // image_sample_d v[6:9], v[0:5], s8, s16 dim:2D dmask:0xf
+            0xf800000fu, 0x09080706u,   // exp mrt0 v6..v9
+            0xbf810000u,
+        };
+        std::vector<uint32_t> frag = recompile_fragment(ps_d, sizeof(ps_d)/sizeof(ps_d[0]), &rt);
+        CHECK(!frag.empty() && frag[0] == 0x07230203u, "recompiled PS with image_sample_d -> SPIR-V");
+        if (!frag.empty()) {
+            prosper::test::FrameResource resource;
+            resource.binding = 4; resource.set = 1;
+            resource.tex_rgba = texels; resource.tw = 4; resource.th = 4;
+            resource.declared_mip_levels = 3;
+            resource.mip_filter = 0;
+            resource.max_lod = 8.0f;
+            prosper::test::BackendDraw draw;
+            draw.vs = vert; draw.fs = frag; draw.R = {resource}; draw.vcount = 3;
+            std::vector<uint8_t> px = prosper::test::render_draws_rgba({draw}, W, H);
+            bool rendered = px.size() == (size_t)W * H * 4;
+            uint8_t r = 0, g = 0, b = 0;
+            if (rendered) {
+                const uint8_t* c = &px[((size_t)(H / 2) * W + W / 2) * 4];
+                r = c[0]; g = c[1]; b = c[2];
+            }
+            printf("  sample_d grad=1.0 center=(%u,%u,%u)\n", r, g, b);
+            CHECK(rendered && r > 0x60 && r < 0xA0 && g < 0x20 && b > 0x60 && b < 0xA0,
+                  "image_sample_d with unit gradients reads the LOD-2 purple "
+                  "(red = gradients dropped for implicit LOD)");
+        }
+    }
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -53,6 +53,7 @@ void usage(const char* argv0) {
                          "[--bundle-find-ds ADDR] "
                          "[--bundle-zero-boundary] "
                          "[--draw-steps PREFIX [--draw-steps-every N] [--draw-steps-target WxH]] "
+                         "[--recompile-raw] "
                          "[--prepend producer.prgcap] "
                          "[--dump-resource DRAW:vs|ps:BINDING PATH] [--allow-mismatch] "
                          "[--dump-rtt-seed ADDR PATH] "
@@ -1180,6 +1181,7 @@ int main(int argc, char** argv) {
     bool inspect = false, inspect_only = false, validate_only = false, allow_mismatch = false;
     bool graph_only = false, bundle_zero_boundary = false, bundle_ds_summary = false;
     bool legacy_htile_before_stencil = false, draw_with_compute_prefix = false;
+    bool recompile_raw = false;
     size_t bundle_tail = 0;
     uint32_t bundle_intermediate_target_width = 0, bundle_intermediate_target_height = 0;
     int draw_first = -1, draw_last = -1;
@@ -1213,6 +1215,7 @@ int main(int argc, char** argv) {
             graph_only = true; graph_json_path = argv[++i];
         }
         else if (std::string(argv[i]) == "--allow-mismatch") allow_mismatch = true;
+        else if (std::string(argv[i]) == "--recompile-raw") recompile_raw = true;
         else if (std::string(argv[i]) == "--legacy-htile-before-stencil")
             legacy_htile_before_stencil = true;
         else if (std::string(argv[i]) == "--bundle" && i + 1 < argc) bundle_path = argv[++i];
@@ -1374,6 +1377,60 @@ int main(int argc, char** argv) {
     prosper::gpu::GpuReplayFrame replay;
     if (!prosper::gpu::materialize_gpu_replay(capture, replay, error)) {
         std::fprintf(stderr, "gpu_replay: cannot materialize: %s\n", error.c_str()); return 2;
+    }
+    // --recompile-raw: a capsule stores already-recompiled SPIR-V, so recompiler changes are
+    // invisible to a default replay. This mode re-recompiles EVERY retained raw VS/FS with the
+    // CURRENT recompiler and substitutes the result, turning any v19+ capsule into a deterministic
+    // offline A/B vehicle for recompiler work (stored vs current output diff via the replay hash).
+    // Items without a retained raw stream, or whose re-recompile fails, keep their stored SPIR-V —
+    // counted and reported, never silent. Interface hints (pixel/system inputs) are not retained by
+    // captures; nullptr matches the FS-tap/geom-probe precedent and the VS/FS interface itself is
+    // derived from the raw streams on both sides.
+    if (recompile_raw) {
+        // PROSPER_FS_TAP=draw:pc composes with --recompile-raw: recompile_fragment reads the pc
+        // from the env for EVERY compile, so without scoping, one tap request would tap every
+        // shader that happens to have an instruction at that pc. Scope it: keep the env set only
+        // while recompiling the named item's FS.
+        long tap_item = -1;
+        std::string tap_env;
+        if (const char* f = std::getenv("PROSPER_FS_TAP")) { tap_env = f; tap_item = std::strtol(f, nullptr, 10); }
+        size_t vs_swapped = 0, fs_swapped = 0, vs_kept = 0, fs_kept = 0, item_index = 0;
+        for (auto& it : replay.items) {
+            if (it.vs_raw_shader_index < replay.raw_shader_versions.size()) {
+                const auto& raw = replay.raw_shader_versions[it.vs_raw_shader_index];
+                auto vs = prosper::gpu::recompile_vertex(raw.words.data(), raw.words.size(),
+                                                         it.vrt.get(), nullptr, false);
+                if (!vs.empty()) { it.vs = std::move(vs); it.vs_shared.reset(); it.vs_identity = 0; ++vs_swapped; }
+                else ++vs_kept;
+            } else ++vs_kept;
+            if (it.fs_raw_shader_index < replay.raw_shader_versions.size()) {
+                if (!tap_env.empty()) {
+                    if (static_cast<long>(item_index) == tap_item) setenv("PROSPER_FS_TAP", tap_env.c_str(), 1);
+                    else unsetenv("PROSPER_FS_TAP");
+                }
+                const auto& raw = replay.raw_shader_versions[it.fs_raw_shader_index];
+                auto fs = prosper::gpu::recompile_fragment(raw.words.data(), raw.words.size(),
+                                                           it.prt.get(), nullptr, UINT32_MAX, nullptr);
+                // Tap probe (tap_item == -2, i.e. PROSPER_FS_TAP="-2:pc"): report every item whose
+                // FS actually contains the tapped pc — recompile once more with the tap enabled and
+                // log when the words differ. Finds where a value lives without knowing the item map.
+                if (tap_item == -2 && !fs.empty()) {
+                    setenv("PROSPER_FS_TAP", tap_env.c_str(), 1);
+                    auto tapped = prosper::gpu::recompile_fragment(raw.words.data(), raw.words.size(),
+                                                                   it.prt.get(), nullptr, UINT32_MAX, nullptr);
+                    unsetenv("PROSPER_FS_TAP");
+                    if (tapped != fs)
+                        std::fprintf(stderr, "[tap-probe] item=%zu raw-index=%u tap bites\n",
+                                     item_index, it.fs_raw_shader_index);
+                }
+                if (!fs.empty()) { it.fs = std::move(fs); it.fs_shared.reset(); it.fs_identity = 0; ++fs_swapped; }
+                else ++fs_kept;
+            } else ++fs_kept;
+            ++item_index;
+        }
+        if (!tap_env.empty()) setenv("PROSPER_FS_TAP", tap_env.c_str(), 1);
+        std::fprintf(stderr, "[recompile-raw] substituted vs=%zu fs=%zu kept-stored vs=%zu fs=%zu of %zu draws\n",
+                     vs_swapped, fs_swapped, vs_kept, fs_kept, replay.items.size());
     }
     // Geometry probe (PROSPER_GEOM_PROBE=N): a capsule stores already-recompiled SPIR-V, so to capture
     // draw N's gl_Position via transform feedback we re-recompile its raw RDNA2 VS with xfb decorations


### PR DESCRIPTION
Fixes #1394. Both gaps were found localizing the #1287/#781 light-pattern banding on Blue Prince's Day One hall capsule (full evidence chain: https://github.com/mattias800/ps5ys/issues/1287#issuecomment-5080228014).

## Failure scenarios & contracts

1. **`IMAGE_SAMPLE_D` (op 0x22, 2D) dropped the guest's explicit gradients**, lowering to an implicit-LOD sample on the assumption that quad derivatives approximate them. That is wrong precisely where guests use `_d`: projected/wrapped/atlas coordinates whose screen-space derivatives spike at wrap seams (painting deep-mip bands around every seam — a visible component of the ring artifact family), and literal/uniform coordinates whose quad derivatives are zero. Now lowered as `OpImageSampleExplicitLod` + `Grad` (vaddr `[Ds/Dx, Dt/Dx, Ds/Dy, Dt/Dy, u, v]`, ISA 8.2.5 modifier-first). CONFIDENCE: HIGH (ISA operand order; LLVM's `image.sample.d` lowering agrees; execution-tested).
2. **`IMAGE_SAMPLE_C_LZ` (plain 2D) hard-thresholded every dref to a single tap** — self-described in the old comment as "approximates LINEAR PCF with a hard threshold". An S# requesting LINEAR means hardware 2×2 compare-THEN-filter PCF (comparison *results* are filtered, never depth values). The lowering now keys on the S# XY filter: LINEAR fetches the 2×2 footprint (`OpImageFetch`, sampler-independent — deliberately compatible with the DS-bridge's forced-NEAREST samplers), compares each texel, and bilinearly weights the four 0/1 results with level-0 edge clamping; NEAREST keeps the exact single-tap form. The compare emission is shared (`dref_compare_result`). Blue Prince's live shadow taps request LINEAR (`filt=1/1/1` in the capture), so every filtered penumbra was previously quantized to binary.

## Verification (exact head, posted below when the gate lands)

- New execution tests assert values **impossible under the old lowerings**:
  - `test_texture_mip_render`: `image_sample_d` with unit gradients and literal coordinates reads the LOD-2 box-filtered purple `(128,0,128)`; the old implicit-LOD lowering reads level-0 red (zero quad derivatives).
  - `test_shadow_compare_render`: a pass/fail texel-corner PCF sample lands at exactly `R=128` (old: 0/255); a NEAREST-S# variant pins the single-tap behavior at 255.
- `ctest` at head: running (results below).
- Full `snapshot.py check`: pending a quiet window — this box currently carries four concurrent agents' capture runs (load ≈ 12) and the two 1080p-route failures in the last sweep reproduce **without** this change class: an interleaved same-binary A/B (stored shaders vs `--recompile-raw` with the new lowerings, 3 rounds) times 4.7 s vs 4.8 s on the 1594-operation hall frame, within noise, so the change adds no measurable render cost. Gate results will be posted before merge.

## Tools (inert by default, same investigation)

- `gpu_replay --recompile-raw`: re-recompiles every retained raw VS/FS with the **current** recompiler and substitutes them — any v19+ capsule becomes a deterministic offline A/B vehicle for recompiler changes (stored vs current via replay hash). `PROSPER_FS_TAP=draw:pc` composes scoped to the named item; `PROSPER_FS_TAP=-2:pc` probes which items contain the pc. (The pre-existing inert per-draw FS_TAP substitution is tracked separately as #1395.)
- `PROSPER_MIPLOG`, `PROSPER_BUFLOG` (render_runner): per-binding mip-eligibility and buffer-upload provenance logs, both behind cached env gates.

## Affected / unaffected

Affected: every title's `IMAGE_SAMPLE_D` 2D samples (now honor gradients) and LINEAR-S# 2D dref samples (now fractional PCF). Unaffected: NEAREST-S# drefs (byte-identical single-tap lowering), the 2D-array dref path, all other sample forms, and every default-off diagnostic. Dead Cells' #781 window-light pass is the suspected cross-title beneficiary — to be re-examined after merge.

## Risks

- The PCF footprint/weights derive from `floor(coord·size − 0.5)`, the standard definition; a half-texel disagreement with hardware footprint selection at exact texel boundaries would show as one-texel shadow-edge shifts. The execution test pins the corner case exactly.
- Grad on single-level textures degenerates to LOD 0 (unchanged behavior).