### PR TITLE
fix(loader): preload Unity CommonDialog plugin

### DIFF
--- a/prosper/src/host/boot_program.cpp
+++ b/prosper/src/host/boot_program.cpp
@@ -83,6 +83,12 @@ bool boot_program(const std::string& d, Program& p, std::string* err,
         // in the list => its init runs first (it's PSNCore's dependency). Absent-file titles skip these.
         { d + "/Media/Plugins/PSNCore.prx", BOOT_PSNCORE },
         { d + "/Media/Plugins/PSNCommon.prx", BOOT_PSNCOMMON },
+        // Unity's PS5 platform layer calls CommonDialog::PrxCommonDialogUpdate before it services
+        // deferred save/load work. Titles such as Space Adventure Cobra reach that P/Invoke only
+        // after accepting input on the title screen; leaving the PRX to the unsupported runtime
+        // loader therefore stalls the main thread with the save request still queued. Preload the
+        // optional plugin just like PSN/SaveData so its export is available to il2cpp immediately.
+        { d + "/Media/Plugins/CommonDialog.prx", BOOT_COMMONDIALOG },
         // FMOD's C# integration resolves these through P/Invoke only when its RuntimeManager is first
         // constructed. Until prosper has true runtime PRX loading (#639), link the optional pair up
         // front so LoadStartModule returns a real module handle. Studio precedes core in this list

--- a/prosper/src/host/boot_program.hpp
+++ b/prosper/src/host/boot_program.hpp
@@ -21,6 +21,7 @@ inline constexpr uint64_t BOOT_IL2CPP   = 0x440000000ull;
 inline constexpr uint64_t BOOT_PS5UTIL  = 0x4c0000000ull;
 inline constexpr uint64_t BOOT_PSNCORE  = 0x480000000ull;   // PPSA02664's Unity PSN native plugin
 inline constexpr uint64_t BOOT_PSNCOMMON = 0x4a0000000ull;  //   (PSNCore.prx + PSNCommon.prx)
+inline constexpr uint64_t BOOT_COMMONDIALOG = 0x4b0000000ull; // Unity CommonDialog native plugin
 inline constexpr uint64_t BOOT_PSN      = 0x4e0000000ull;
 inline constexpr uint64_t BOOT_NPCPPWEBAPI = 0x4d0000000ull; // optional bundled PSN C++ support PRX
 inline constexpr uint64_t BOOT_SAVEDATA = 0x4f0000000ull;


### PR DESCRIPTION
## Summary

- preload the optional Unity `CommonDialog.prx` alongside the existing PSN, save-data, FMOD, and Wwise plugins
- assign it a non-overlapping fixed guest module base
- make its exports available to IL2CPP before title-screen input can trigger the P/Invoke

## Root cause

Space Adventure Cobra queues its initial save/load request after Cross is pressed on the title screen. `PlatformPS5.Update` calls `CommonDialog::PrxCommonDialogUpdate` before servicing that deferred request. The plugin ships in the dump, but it was not part of the preload set, so IL2CPP fell into prosper’s unsupported runtime PRX-loading path and stalled the main thread while the save request remained queued.

Preloading the optional plugin lets the P/Invoke resolve immediately and leaves titles that do not ship it unchanged through the existing absent-module filter.

## Validation

Exact head: `8613f785e69f40d008be90e7288bdea4c16ccdc9`

- current-master distrobox full app build with SDL3 video/audio/pad and FFmpeg/VA-API support
- `ctest --test-dir prosper/build-linux --output-on-failure -j 16`: **153/153 passed**
- native 1920x1080 Cobra route: title -> main menu -> new-game setup -> opening movies -> dialogue -> player-controlled tutorial
- gameplay proof includes live HUD, readable tutorial prompt, projectiles/impact effects, and distinct frames after scripted movement
- exact-head normal `prosper-app` route consumed gameplay movement at 190-194 seconds; SDL opened both 48 kHz stereo ports on PipeWire and output remained non-silent during gameplay (about 0.105 one-second peak, with earlier peaks up to 0.339)

Visual rendering artifacts remain a separate GPU-translation concern; this PR fixes the progression stall.

Progresses #1356.