### PR TITLE
fix(gpu): preserve AvPlayer NV12 layout

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -8,6 +8,7 @@
 #include "gpu/gpu_execute.hpp"          // DrawItem, set_submit_renderer
 #include "gpu/writer_provenance.hpp"
 #include "gpu/gpu_capture.hpp"          // temporal RTT capture/replay seeds
+#include "gpu/guest_texture_layout.hpp" // exact pitch for HLE-produced guest textures
 #include "gpu/tile.hpp"                 // detile_surface / tiled_surface_bytes / detile_elements
 #include "gpu/bc_decode.hpp"            // BC1/2/3 block decompression -> RGBA8 (#121)
 #include "gpu/shader_resources.hpp"     // ShaderResourceTable / ResourceClass
@@ -203,6 +204,7 @@ struct TextureDecodeKey {
     uint64_t metadata_addr = 0;
     uint64_t metadata_host_data = 0;
     uint64_t metadata_host_data_size = 0;
+    bool preserve_narrow_channels = false;
     bool operator==(const TextureDecodeKey&) const = default;
 };
 
@@ -221,6 +223,7 @@ struct TextureDecodeKeyHash {
         mix(key.max_uncompressed_block_size);
         mix(key.max_compressed_block_size); mix(key.dcc_flags); mix(key.metadata_addr);
         mix(key.metadata_host_data); mix(key.metadata_host_data_size);
+        mix(key.preserve_narrow_channels);
         return hash;
     }
 };
@@ -919,6 +922,40 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     };
                     if (r.cls == RC::Texture || r.cls == RC::StorageImage) {
                         uint32_t tw = r.width ? r.width : 4, th = r.height ? r.height : 4;
+                        // AvPlayer exposes NV12 as a tight R8 luma plane followed by an RG8 UV plane.
+                        // Live resources carry exact HLE allocation provenance. Capture replay has no
+                        // process-local registry, so recognize the same two-plane contract from the
+                        // captured table: matching tight pitches, 2:1 extents, and adjacent guest VAs.
+                        // Keep this deliberately narrower than all RG8 resources; several established
+                        // game paths still rely on the historical narrow-texture coverage broadcast.
+                        const bool avplayer_chroma_layout = [&] {
+                            if (r.cls != RC::Texture || r.format != prosper::gpu::DataFormat::Unorm8 ||
+                                r.num_components != 2 || r.img_dim != 1u || r.tile_mode != 0u ||
+                                r.compression_enabled || r.swizzle[0] != 4 || r.swizzle[1] != 5 ||
+                                r.swizzle[2] != 0 || r.swizzle[3] != 1 || tw > UINT32_MAX / 2u)
+                                return false;
+                            const uint32_t row_bytes = tw * 2u;
+                            if (prosper::gpu::guest_linear_texture_row_pitch(r.gpu_addr, row_bytes) ==
+                                row_bytes)
+                                return true;
+                            if (!r.host_data || r.linear_row_pitch_bytes != row_bytes) return false;
+                            for (const auto& luma : t->resources) {
+                                if (luma.cls != RC::Texture ||
+                                    luma.format != prosper::gpu::DataFormat::Unorm8 ||
+                                    luma.num_components != 1 || luma.img_dim != 1u ||
+                                    luma.tile_mode != 0u || luma.compression_enabled ||
+                                    luma.width != row_bytes ||
+                                    (static_cast<uint64_t>(luma.height) + 1u) / 2u != th ||
+                                    luma.linear_row_pitch_bytes != row_bytes)
+                                    continue;
+                                const uint64_t luma_bytes =
+                                    static_cast<uint64_t>(row_bytes) * luma.height;
+                                if (luma.gpu_addr <= UINT64_MAX - luma_bytes &&
+                                    luma.gpu_addr + luma_bytes == r.gpu_addr)
+                                    return true;
+                            }
+                            return false;
+                        }();
                         const TextureDecodeKey decode_key{
                             r.gpu_addr, static_cast<uint64_t>(reinterpret_cast<uintptr_t>(r.host_data)),
                             r.host_data_size, r.size, static_cast<uint32_t>(r.cls),
@@ -938,6 +975,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                       r.dcc_metadata_host_data))
                                 : 0u,
                             r.compression_enabled ? r.dcc_metadata_host_data_size : 0u,
+                            avplayer_chroma_layout,
                         };
                         auto live_rtt = rtt_on ? g_rtt.find(r.gpu_addr) : g_rtt.end();
                         // Deferred RTT readback (#1284): a GPU-resident target consumed in a way the
@@ -1025,9 +1063,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         const bool persistent_fp32_texture =
                             r.format == prosper::gpu::DataFormat::Float32 &&
                             (r.num_components == 1 || r.num_components == 2 || r.num_components == 4);
-                        // Real source bytes per texel. It also determines the pitch of a guest-backed
-                        // linear sampled image: GFX10 aligns those rows to 256 bytes independently of
-                        // component count (e.g. a 1920-wide R8 video chroma plane has a 2048-byte row).
+                        // Real source bytes per texel. It also determines the visible row size used to
+                        // resolve a guest-backed linear image's pitch below: ordinary sampled images use
+                        // GFX10's 256-byte alignment, while exact HLE-producer provenance may stay tight.
                         uint32_t sampled_source_bpt =
                             prosper::gpu::data_format_bytes(r.format) *
                             (r.num_components ? r.num_components : 1u);
@@ -1059,15 +1097,22 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // texels). Guards keep
                         // this narrow and regression-safe: 2D only (volume/cube layouts untouched); tile_mode
                         // == 0 exactly, so unrecognized/actually-tiled modes are NOT strided (they fall to the
-                        // contiguous read + auto-detile pass); !host_data, so CPU-uploaded tightly-packed
-                        // pixels (test fixtures, staged uploads) are read contiguously unless capture replay
-                        // supplies an explicit guest-layout pitch. The tightly-packed
+                        // contiguous read + auto-detile pass); exact HLE-producer provenance can select a
+                        // tight guest layout (AvPlayer NV12); !host_data keeps ordinary CPU-uploaded test
+                        // fixtures contiguous unless capture replay supplies an explicit guest-layout pitch.
+                        // The tightly-packed
                         // LINEAR_GENERAL layout is a buffer/copy layout, not a sampled-texture layout, so it
                         // does not reach here. r.size is the TIGHT extent (tw*th*bpp), so it cannot gate this.
                         const size_t linear_dst_row = (size_t)tw * sampled_source_bpt;
+                        const uint32_t registered_linear_pitch = linear_dst_row <= UINT32_MAX
+                            ? prosper::gpu::guest_linear_texture_row_pitch(
+                                  r.gpu_addr, static_cast<uint32_t>(linear_dst_row))
+                            : 0;
                         size_t linear_src_row = r.linear_row_pitch_bytes
                             ? r.linear_row_pitch_bytes
-                            : prosper::gpu::linear_sampled_row_pitch(tw, sampled_source_bpt);
+                            : (registered_linear_pitch
+                                   ? registered_linear_pitch
+                                   : prosper::gpu::linear_sampled_row_pitch(tw, sampled_source_bpt));
                         if (const char* lp = getenv("PROSPER_LINPITCH"))
                             linear_src_row = (size_t)strtoull(lp, nullptr, 0) * sampled_source_bpt;
                         const bool linear_padded_read =
@@ -1766,11 +1811,12 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         } else if (bpt < 4) {
                             // Narrow (single/dual-channel) surface: read at the REAL element size and detile
                             // with the matching bpe geometry (1 B -> 64x64, 2 B -> 64x32 micro-tiles, #119),
-                            // then expand the first component to RGBA8. Legacy 8-bit coverage resources keep
-                            // the grayscale broadcast so shaders can read either .r or .a. A UNORM16 resource
-                            // instead receives the format-defined missing channels (R,0,0,1), after which the
-                            // real T# DST_SEL is applied below. Its R component must be normalized from both
-                            // bytes; selecting byte zero turns a smooth ramp into a repeating sawtooth (#1186).
+                            // then expand to RGBA8. Legacy 8-bit coverage resources keep the grayscale
+                            // broadcast so shaders can read either .r or .a, while the exact AvPlayer NV12
+                            // contract preserves both bytes of its RG8 interleaved U/V plane. A UNORM16
+                            // resource instead receives the format-defined missing channels (R,0,0,1), after
+                            // which the real T# DST_SEL is applied below. Its R component must be normalized
+                            // from both bytes; selecting byte zero makes a smooth ramp a sawtooth (#1186).
                             std::vector<uint8_t> nlin(volume_texels * bpt, 0);
                             bool tiled = prosper::gpu::tile_mode_is_tiled(r.tile_mode) && !getenv("PROSPER_NODETILE");
                             if (tiled) {
@@ -1806,17 +1852,23 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             }
                             const bool unorm16 = r.format == prosper::gpu::DataFormat::Unorm16;
                             for (size_t t = 0; t < volume_texels; t++) {
-                                uint8_t v = nlin[t * bpt];   // first (coverage) channel
-                                if (unorm16) {
-                                    uint16_t raw;
-                                    std::memcpy(&raw, &nlin[t * bpt], sizeof(raw));
-                                    v = prosper::gpu::unorm16_to_unorm8(raw);
-                                }
                                 uint8_t* p = &texture_pixels[t * 4];
-                                if (unorm16) {
-                                    p[0] = v; p[1] = p[2] = 0; p[3] = 255;
+                                if (avplayer_chroma_layout) {
+                                    const uint8_t* source = &nlin[t * bpt];
+                                    p[0] = source[0];
+                                    p[1] = source[1];
+                                    p[2] = r.num_components > 2 ? source[2] : 0;
+                                    p[3] = 255;
                                 } else {
-                                    p[0] = p[1] = p[2] = p[3] = v;
+                                    uint8_t v = nlin[t * bpt]; // first (coverage) channel
+                                    if (unorm16) {
+                                        uint16_t raw;
+                                        std::memcpy(&raw, &nlin[t * bpt], sizeof(raw));
+                                        v = prosper::gpu::unorm16_to_unorm8(raw);
+                                        p[0] = v; p[1] = p[2] = 0; p[3] = 255;
+                                    } else {
+                                        p[0] = p[1] = p[2] = p[3] = v;
+                                    }
                                 }
                             }
                             narrow_decode_done = true;   // skip the generic 32-bpp detiler below
@@ -2207,10 +2259,12 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // (isotropic) so this is a no-op for it; carries correct behavior for titles that
                         // request anisotropic filtering.
                         fr.max_aniso_ratio = r.max_aniso_ratio;
-                        // T# DST_SEL channel remap (#261): apply only to REAL-RGBA texels. The narrow
-                        // R->RGBA replication path (narrow_done) already broadcasts coverage to every
-                        // channel — keep it identity so the font/mask path (#102/#256) is untouched.
-                        if (narrow_done) { fr.swizzle[0]=4; fr.swizzle[1]=5; fr.swizzle[2]=6; fr.swizzle[3]=7; }
+                        // T# DST_SEL channel remap (#261): narrow coverage paths already broadcast to
+                        // every channel, so keep them identity. AvPlayer RG8 preserved U/V above and
+                        // still needs its T# mapping (R,G,0,1).
+                        if (narrow_done && !avplayer_chroma_layout) {
+                            fr.swizzle[0]=4; fr.swizzle[1]=5; fr.swizzle[2]=6; fr.swizzle[3]=7;
+                        }
                         else { for (int k=0;k<4;k++) fr.swizzle[k] = r.swizzle[k]; }
                         // PROSPER_ALPHA1: force the sampled alpha to constant 1 (opaque). Diagnostic for a
                         // black scene whose textures decode to real RGB but composite to nothing — if the

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -8,6 +8,7 @@
 
 #include <mutex>
 #include "bc_decode.hpp"
+#include "guest_texture_layout.hpp"
 #include "rdna2_decode.hpp"
 #include "rdna2_to_spirv.hpp"
 #include "tile.hpp"
@@ -350,6 +351,9 @@ uint32_t resolved_linear_row_pitch(const ShaderResource& r, uint32_t width, uint
     const uint64_t tight = checked_mul(width, bpt);
     if (tight > UINT32_MAX) return UINT32_MAX;
     if (r.host_data) return static_cast<uint32_t>(tight);
+    if (const uint32_t registered = guest_linear_texture_row_pitch(
+            r.gpu_addr, static_cast<uint32_t>(tight)))
+        return registered;
     const size_t aligned = linear_sampled_row_pitch(width, bpt);
     return aligned > UINT32_MAX ? UINT32_MAX : static_cast<uint32_t>(aligned);
 }
@@ -374,8 +378,9 @@ uint64_t resource_footprint_impl(const ShaderResource& r, bool legacy_linear_tig
         } else if (r.tile_mode == static_cast<uint32_t>(TileMode::Linear) &&
                    r.cls == ResourceClass::Texture && r.img_dim == 1u &&
                    !r.compression_enabled && !legacy_linear_tight) {
-            // Guest-backed linear sampled images use GFX10's 256-byte row alignment. Capturing only
-            // width*height*bpt made narrow video planes replay with row drift and omitted their tail.
+            // Guest-backed linear sampled images default to GFX10's 256-byte row alignment. Exact
+            // HLE-producer provenance may override it (AvPlayer's CPU-staged NV12 is tight). Capturing
+            // only width*height*bpt made genuinely padded video planes drift and omitted their tail.
             decoded = checked_mul(resolved_linear_row_pitch(r, w, bpt), h);
         } else {
             decoded = checked_mul(checked_mul(w, h), bpt);

--- a/prosper/src/gpu/guest_texture_layout.cpp
+++ b/prosper/src/gpu/guest_texture_layout.cpp
@@ -1,0 +1,43 @@
+// guest_texture_layout.cpp — see guest_texture_layout.hpp.
+#include "guest_texture_layout.hpp"
+
+#include <map>
+#include <mutex>
+
+namespace prosper::gpu {
+namespace {
+
+struct LinearTextureLayout {
+    uint64_t end = 0;
+    uint32_t row_pitch_bytes = 0;
+};
+
+std::mutex g_linear_texture_layout_mx;
+std::map<uint64_t, LinearTextureLayout> g_linear_texture_layouts;
+
+} // namespace
+
+void register_guest_linear_texture_layout(uint64_t base, size_t bytes,
+                                          uint32_t row_pitch_bytes) {
+    if (!base || !bytes || !row_pitch_bytes || bytes > UINT64_MAX - base) return;
+    std::lock_guard<std::mutex> lock(g_linear_texture_layout_mx);
+    g_linear_texture_layouts[base] = {base + bytes, row_pitch_bytes};
+}
+
+void unregister_guest_linear_texture_layout(uint64_t base) {
+    if (!base) return;
+    std::lock_guard<std::mutex> lock(g_linear_texture_layout_mx);
+    g_linear_texture_layouts.erase(base);
+}
+
+uint32_t guest_linear_texture_row_pitch(uint64_t address, uint32_t visible_row_bytes) {
+    if (!address || !visible_row_bytes) return 0;
+    std::lock_guard<std::mutex> lock(g_linear_texture_layout_mx);
+    auto it = g_linear_texture_layouts.upper_bound(address);
+    if (it == g_linear_texture_layouts.begin()) return 0;
+    --it;
+    return address < it->second.end && visible_row_bytes == it->second.row_pitch_bytes
+        ? it->second.row_pitch_bytes : 0;
+}
+
+} // namespace prosper::gpu

--- a/prosper/src/gpu/guest_texture_layout.hpp
+++ b/prosper/src/gpu/guest_texture_layout.hpp
@@ -1,0 +1,20 @@
+// guest_texture_layout.hpp — exact host-produced layouts for guest-visible sampled textures.
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace prosper::gpu {
+
+// Register a guest-visible allocation whose sampled-linear rows are intentionally tightly packed.
+// The ordinary GFX10 fallback remains 256-byte aligned; this provenance is for HLE producers such as
+// AvPlayer that return CPU-staged pixels and an explicit row pitch to the title.
+void register_guest_linear_texture_layout(uint64_t base, size_t bytes,
+                                          uint32_t row_pitch_bytes);
+void unregister_guest_linear_texture_layout(uint64_t base);
+
+// Return the registered pitch only when `address` belongs to a registered allocation and the
+// descriptor's visible row consumes exactly that many bytes. Zero means no exact host provenance.
+uint32_t guest_linear_texture_row_pitch(uint64_t address, uint32_t visible_row_bytes);
+
+} // namespace prosper::gpu

--- a/prosper/src/gpu/shader_resources.hpp
+++ b/prosper/src/gpu/shader_resources.hpp
@@ -160,8 +160,9 @@ struct ShaderResource {
     uint32_t      depth             = 1;
     uint32_t      tile_mode         = 0;                  // T# GFX10 TileMode; drives auto-detile of a sampled surface
     // Byte distance between rows of a linear sampled image. Zero means derive it from the live
-    // descriptor/backing: guest images use the GFX10 sampled-image alignment while ordinary host
-    // fixtures are tight. Captures persist the resolved value so replay keeps both layouts exact.
+    // descriptor/backing: exact HLE-producer provenance wins, other guest images use the GFX10
+    // sampled-image alignment, and ordinary host fixtures are tight. Captures persist the resolved
+    // value so replay keeps every layout exact.
     uint32_t      linear_row_pitch_bytes = 0;
     // A packed mip-tail view shares the allocation's first 4/64 KiB block. gpu_addr remains the
     // shared block base; the backend applies mip_tail_offset and preserves sibling levels on writes.

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -10,6 +10,7 @@
 #include "ime_input.hpp"
 #include "platform_ui.hpp"
 #include "video_backend.hpp"   // sceAvPlayer -> host hardware-decode backend (#705)
+#include "../gpu/guest_texture_layout.hpp" // exact HLE-produced sampled-linear layouts
 #include "../host/posix_shim.hpp"   // Darwin process_vm_readv shim + asm portability
 #include <cinttypes>
 #include <cstddef>
@@ -500,6 +501,28 @@ bool avp_nv12_bytes(uint32_t width, uint32_t height, size_t& bytes) {
     return true;
 }
 
+void avp_register_frame_layout(uint8_t* base, size_t bytes, uint32_t pitch) {
+    gpu::register_guest_linear_texture_layout(
+        static_cast<uint64_t>(reinterpret_cast<uintptr_t>(base)), bytes, pitch);
+}
+
+void avp_release_frame_storage(AvpPlayer& player) {
+    if (!player.frame.empty())
+        gpu::unregister_guest_linear_texture_layout(
+            static_cast<uint64_t>(reinterpret_cast<uintptr_t>(player.frame.data())));
+    player.frame.clear();
+}
+
+uint8_t* avp_frame_storage(AvpPlayer& player, size_t bytes, uint32_t pitch) {
+    if (player.frame.size() != bytes) {
+        avp_release_frame_storage(player);
+        player.frame.resize(bytes);
+    }
+    if (player.frame.empty()) return nullptr;
+    avp_register_frame_layout(player.frame.data(), player.frame.size(), pitch);
+    return player.frame.data();
+}
+
 // Native decoders own their dequeue storage and may move or recycle it on the next pull. Copy the
 // visible NV12 rows into a guest texture buffer when one exists.  The host-vector fallback preserves
 // the old lifetime guarantee for native tests and titles that omit the replacement callbacks.
@@ -510,33 +533,25 @@ bool avp_stage_video(AvpPlayer& player, const prosper::video::VideoFrame& frame,
     const size_t uv_stride = frame.uv_stride ? frame.uv_stride : frame.width;
     if (y_stride < frame.width || uv_stride < frame.width) return false;
     const size_t uv_rows = (static_cast<size_t>(frame.height) + 1) / 2;
-    if (!player.texture_frames.empty()) {
-        size_t bytes = 0;
-        if (!avp_nv12_bytes(frame.width, frame.height, bytes) ||
-            bytes > player.texture_frame_bytes) return false;
-        uint8_t* dst = player.texture_frames[player.next_texture_frame++ %
-                                              player.texture_frames.size()];
-        if (!dst) return false;
-        for (uint32_t row = 0; row < frame.height; ++row)
-            memcpy(dst + static_cast<size_t>(row) * frame.width,
-                   frame.y + static_cast<size_t>(row) * y_stride, frame.width);
-        uint8_t* dst_uv = dst + static_cast<size_t>(frame.width) * frame.height;
-        for (size_t row = 0; row < uv_rows; ++row)
-            memcpy(dst_uv + row * frame.width, frame.uv + row * uv_stride, frame.width);
-        data = dst;
-        pitch = frame.width;
-        return true;
-    }
     if (y_stride > SIZE_MAX / frame.height || uv_stride > SIZE_MAX / uv_rows) return false;
-    const size_t y_bytes = y_stride * frame.height;
-    const size_t uv_bytes = uv_stride * uv_rows;
-    if (uv_bytes > SIZE_MAX - y_bytes) return false;
-    const size_t bytes = y_bytes + uv_bytes;
-    if (player.frame.size() != bytes) player.frame.resize(bytes);
-    memcpy(player.frame.data(), frame.y, y_bytes);
-    memcpy(player.frame.data() + y_bytes, frame.uv, uv_bytes);
-    data = player.frame.data();
-    pitch = static_cast<uint32_t>(y_stride);
+    size_t bytes = 0;
+    if (!avp_nv12_bytes(frame.width, frame.height, bytes)) return false;
+    uint8_t* dst = nullptr;
+    if (!player.texture_frames.empty()) {
+        if (bytes > player.texture_frame_bytes) return false;
+        dst = player.texture_frames[player.next_texture_frame++ % player.texture_frames.size()];
+    } else {
+        dst = avp_frame_storage(player, bytes, frame.width);
+    }
+    if (!dst) return false;
+    for (uint32_t row = 0; row < frame.height; ++row)
+        memcpy(dst + static_cast<size_t>(row) * frame.width,
+               frame.y + static_cast<size_t>(row) * y_stride, frame.width);
+    uint8_t* dst_uv = dst + static_cast<size_t>(frame.width) * frame.height;
+    for (size_t row = 0; row < uv_rows; ++row)
+        memcpy(dst_uv + row * frame.width, frame.uv + row * uv_stride, frame.width);
+    data = dst;
+    pitch = frame.width;
     return true;
 }
 
@@ -547,11 +562,11 @@ bool avp_stage_synthetic(AvpPlayer& player, uint8_t*& data) {
         if (need > player.texture_frame_bytes) return false;
         data = player.texture_frames[player.next_texture_frame++ % player.texture_frames.size()];
         if (!data) return false;
-        memset(data, 0, need);
-        return true;
+    } else {
+        data = avp_frame_storage(player, need, player.width);
+        if (!data) return false;
     }
-    if (player.frame.size() != need) player.frame.assign(need, 0);
-    data = player.frame.data();
+    memset(data, 0, need);
     return true;
 }
 
@@ -624,7 +639,11 @@ void avp_deallocate_texture(const AvpMemAllocator& memory, void* allocation) {
 
 void avp_release_textures(const AvpMemAllocator& memory,
                           const std::vector<uint8_t*>& textures) {
-    for (auto* texture : textures) avp_deallocate_texture(memory, texture);
+    for (auto* texture : textures) {
+        gpu::unregister_guest_linear_texture_layout(
+            static_cast<uint64_t>(reinterpret_cast<uintptr_t>(texture)));
+        avp_deallocate_texture(memory, texture);
+    }
 }
 
 bool avp_build_textures(const AvpMemAllocator& memory, int32_t requested,
@@ -651,7 +670,9 @@ bool avp_build_textures(const AvpMemAllocator& memory, int32_t requested,
             texture_bytes = 0;
             return false;
         }
-        textures.push_back(static_cast<uint8_t*>(allocation));
+        auto* texture = static_cast<uint8_t*>(allocation);
+        textures.push_back(texture);
+        avp_register_frame_layout(texture, texture_bytes, width);
     }
     if (avp_log()) {
         fprintf(stderr,
@@ -815,6 +836,7 @@ static uint64_t avp_add_source(uint64_t handle, const char* guest_path) {
         memory = p.memory;
         requested_textures = p.num_fb;
         old_textures = std::move(p.texture_frames);
+        avp_release_frame_storage(p);
         p.texture_frame_bytes = 0;
         p.next_texture_frame = 0;
         p.have_source = false; p.synthetic = false; p.playing = false; p.paused = false;
@@ -1148,6 +1170,7 @@ HLE(s_avp_stop) {   // s32 sceAvPlayerStop(handle)
         backend = p.backend; backend_id = p.backend_id;
         memory = p.memory;
         textures = std::move(p.texture_frames);
+        avp_release_frame_storage(p);
         p.texture_frame_bytes = 0; p.next_texture_frame = 0;
         p.backend = nullptr; p.backend_id = -1; p.have_source = false; p.synthetic = false;
         if (p.playing && !p.stop_fired) {
@@ -1172,6 +1195,7 @@ HLE(s_avp_close) {   // s32 sceAvPlayerClose(handle)
             backend = it->second.backend; backend_id = it->second.backend_id;
             memory = it->second.memory;
             textures = std::move(it->second.texture_frames);
+            avp_release_frame_storage(it->second);
             g_avp.erase(it);
         }
     }

--- a/prosper/tests/test_avplayer.cpp
+++ b/prosper/tests/test_avplayer.cpp
@@ -9,6 +9,7 @@
 #include "../src/hle/dispatch.hpp"
 #include "../src/hle/nid.hpp"
 #include "../src/hle/video_backend.hpp"
+#include "../src/gpu/guest_texture_layout.hpp"
 #include <cstdio>
 #include <algorithm>
 #include <cstdint>
@@ -41,13 +42,19 @@ static_assert(offsetof(AvpFrameInfoEx, details) == 24, "AvPlayerFrameInfoEx ABI"
 
 class FakeVideoBackend final : public video::VideoBackend {
 public:
+    static constexpr uint32_t kWidth = 640;
+    static constexpr uint32_t kHeight = 360;
     bool fail_open = false;
     bool delivered = false;
     bool audio_delivered = false;
     int close_count = 0;
     std::string opened_path;
-    std::vector<uint8_t> nv12 = std::vector<uint8_t>(640 * 360 * 3 / 2, 0x40);
+    std::vector<uint8_t> nv12 = std::vector<uint8_t>(kWidth * kHeight * 3 / 2, 0x40);
     std::vector<int16_t> pcm = std::vector<int16_t>(2 * 128, 0x20);
+
+    FakeVideoBackend() {
+        std::fill(nv12.begin() + kWidth * kHeight, nv12.end(), 0x80);
+    }
 
     int open(const std::string& host_path) override {
         opened_path = host_path; delivered = false; audio_delivered = false;
@@ -55,15 +62,15 @@ public:
     }
     bool info(int id, video::StreamInfo& out) override {
         if (id != 17) return false;
-        out.width = 640; out.height = 360; out.fps = 60.0f;
+        out.width = kWidth; out.height = kHeight; out.fps = 60.0f;
         out.has_audio = true; out.audio_channels = 2; out.audio_rate = 48'000;
         out.duration_us = 2'000'000;
         return true;
     }
     bool next_video(int id, video::VideoFrame& out) override {
         if (id != 17 || delivered) return false;
-        out.y = nv12.data(); out.uv = nv12.data() + 640 * 360;
-        out.width = 640; out.height = 360; out.y_stride = 640; out.uv_stride = 640;
+        out.y = nv12.data(); out.uv = nv12.data() + kWidth * kHeight;
+        out.width = kWidth; out.height = kHeight; out.y_stride = kWidth; out.uv_stride = kWidth;
         out.pts_us = 16'667; delivered = true;
         return true;
     }
@@ -265,15 +272,19 @@ int main() {
           "native source opens through the registered backend");
     CHECK(texture_alloc_count == 3 && texture_last_align == 0x100 &&
               texture_last_size == fake.nv12.size(),
-          "native source allocates the requested guest NV12 texture ring");
+          "native source allocates the requested tight guest NV12 texture ring");
     CHECK(fake.opened_path == "C:/prosper-test-app0/movie.mp4",
           "native backend receives the resolved host path, not the raw relative guest path");
     CHECK(streams(native_handle, 0, 0, 0, 0, 0) == 2,
           "native audio-bearing source enumerates video and audio streams");
     AvpStreamInfoEx native_info{}; native_info.size = sizeof(native_info);
+    uint32_t native_info_pitch = 0;
     CHECK(infoex(native_handle, 0, (uint64_t)(uintptr_t)&native_info, 0, 0, 0) == 0 &&
               native_info.type == 1 && native_info.duration == 2000,
           "native stream metadata and duration come from the backend");
+    memcpy(&native_info_pitch, native_info.details + 36, sizeof(native_info_pitch));
+    CHECK(native_info_pitch == FakeVideoBackend::kWidth,
+          "native stream metadata reports the AvPlayer tight row pitch");
     native_info = {}; native_info.size = sizeof(native_info);
     CHECK(infoex(native_handle, 1, (uint64_t)(uintptr_t)&native_info, 0, 0, 0) == 0 &&
               native_info.type == 2,
@@ -289,15 +300,25 @@ int main() {
               native_frame.timestamp == 16 &&
               memcmp(native_frame.data, fake.nv12.data(), fake.nv12.size()) == 0,
           "native decoded NV12 frame is copied into caller-owned guest texture staging");
+    const auto* staged = static_cast<const uint8_t*>(native_frame.data);
+    const uint64_t staged_address = static_cast<uint64_t>(reinterpret_cast<uintptr_t>(staged));
+    CHECK(gpu::guest_linear_texture_row_pitch(staged_address, FakeVideoBackend::kWidth) ==
+              FakeVideoBackend::kWidth &&
+          gpu::guest_linear_texture_row_pitch(
+              staged_address + FakeVideoBackend::kWidth * FakeVideoBackend::kHeight,
+              FakeVideoBackend::kWidth) == FakeVideoBackend::kWidth,
+          "native luma and chroma addresses retain exact tight-layout provenance for GPU sampling");
     fake.nv12[0] = 0x7f;
     CHECK(static_cast<const uint8_t*>(native_frame.data)[0] == 0x40,
           "guest frame storage remains independent when the backend recycles its packet");
-    uint32_t native_width = 0, native_height = 0; double native_fps = 0.0;
+    uint32_t native_width = 0, native_height = 0, native_pitch = 0; double native_fps = 0.0;
     memcpy(&native_width, native_frame.details + 0, sizeof(native_width));
     memcpy(&native_height, native_frame.details + 4, sizeof(native_height));
+    memcpy(&native_pitch, native_frame.details + 36, sizeof(native_pitch));
     memcpy(&native_fps, native_frame.details + 48, sizeof(native_fps));
-    CHECK(native_width == 640 && native_height == 360 && native_fps == 60.0,
-          "native frame details preserve backend dimensions and frame rate");
+    CHECK(native_width == FakeVideoBackend::kWidth && native_height == FakeVideoBackend::kHeight &&
+              native_pitch == FakeVideoBackend::kWidth && native_fps == 60.0,
+          "native frame details preserve dimensions, tight row pitch, and frame rate");
     CHECK(video(native_handle, (uint64_t)(uintptr_t)&native_frame, 0, 0, 0, 0) == 0 &&
               event_count == 3 && events[2] == 1 && !fake.audio_delivered,
           "video-only consumption of an audio-bearing source reaches EOF and fires one STOP");
@@ -308,6 +329,8 @@ int main() {
     close(native_handle, 0, 0, 0, 0, 0);
     CHECK(fake.close_count == 1 && texture_free_count == 3,
           "Close releases the native decode session and every guest texture");
+    CHECK(gpu::guest_linear_texture_row_pitch(staged_address, FakeVideoBackend::kWidth) == 0,
+          "Close removes the released AvPlayer texture layout provenance");
     prosper::video::set_backend(nullptr);
 
     // One delivered synthetic frame, then EOF on the next pull. Astro Bot follows this path and does
@@ -335,6 +358,8 @@ int main() {
           "synthetic audio pull returns stable silent PCM");
     CHECK(video(h2, (uint64_t)(uintptr_t)&frame, 0, 0, 0, 0) == 1, "first synthetic video pull returns a frame");
     CHECK(frame.data != nullptr, "synthetic frame has stable storage");
+    const uint64_t synthetic_frame_address =
+        static_cast<uint64_t>(reinterpret_cast<uintptr_t>(frame.data));
     uint32_t width = 0, height = 0, pitch = 0; double fps = 0.0;
     memcpy(&width, frame.details + 0, sizeof(width));
     memcpy(&height, frame.details + 4, sizeof(height));
@@ -342,6 +367,8 @@ int main() {
     memcpy(&fps, frame.details + 48, sizeof(fps));
     CHECK(width == 1920 && height == 1080 && pitch == 1920 && fps == 30.0,
           "AvPlayerVideoEx uses the published 80-byte layout");
+    CHECK(gpu::guest_linear_texture_row_pitch(synthetic_frame_address, pitch) == pitch,
+          "fallback AvPlayer storage also publishes its exact tight layout");
     CHECK(pause(h2, 0, 0, 0, 0, 0) == 0 && event_count == 3 && events[2] == 4,
           "Pause reports success and fires PAUSE without deadlocking the callback");
     CHECK(video(h2, (uint64_t)(uintptr_t)&frame, 0, 0, 0, 0) == 0 && event_count == 3,
@@ -352,6 +379,9 @@ int main() {
     CHECK(event_count == 5 && events[4] == 1, "EOF fires one STOP callback");
     CHECK(video(h2, (uint64_t)(uintptr_t)&frame, 0, 0, 0, 0) == 0 && event_count == 5,
           "EOF remains stopped without duplicate callbacks");
+    close(h2, 0, 0, 0, 0, 0);
+    CHECK(gpu::guest_linear_texture_row_pitch(synthetic_frame_address, pitch) == 0,
+          "Close removes fallback AvPlayer layout provenance");
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");

--- a/prosper/tests/test_gpu_capture.cpp
+++ b/prosper/tests/test_gpu_capture.cpp
@@ -1,5 +1,6 @@
 #include "../src/gpu/gpu_capture.hpp"
 #include "../src/gpu/agc_shader_layout.hpp"
+#include "../src/gpu/guest_texture_layout.hpp"
 #include "../src/gpu/pm4_registers.hpp"
 #include "../src/gpu/tile.hpp"
 
@@ -418,6 +419,18 @@ int main() {
               materialize_gpu_replay(upgraded_video, upgraded_video_replay, error) &&
               upgraded_video_replay.items[0].prt->resources[0].host_data_size == video_chroma.size,
           "rewriting a v27 capture preserves its short span and best-effort derived pitch in v28");
+    register_guest_linear_texture_layout(video_chroma.gpu_addr, video_chroma.size, 1920);
+    GpuCaptureFile tight_video_capture;
+    CHECK(gpu_capture_resource_footprint(video_chroma) == video_chroma.size &&
+              capture_draw_items({video_draw}, meta, video_reader, tight_video_capture, error) &&
+              tight_video_capture.blobs.size() == 1 &&
+              tight_video_capture.blobs[0].bytes.size() == video_chroma.size &&
+              tight_video_capture.draws[0].prt.resources[0].captured_size == video_chroma.size &&
+              tight_video_capture.draws[0].prt.resources[0].resource.linear_row_pitch_bytes == 1920,
+          "capture preserves an exact registered tight pitch for an HLE-produced guest texture");
+    unregister_guest_linear_texture_layout(video_chroma.gpu_addr);
+    CHECK(gpu_capture_resource_footprint(video_chroma) == 2048u * 2u,
+          "unregistered guest textures return to the GFX10 aligned-pitch fallback");
     large_table->resources = {large_resource};
     DrawItem large_draw = draw;
     large_draw.vrt = large_table;

--- a/prosper/tests/test_gpu_capture_render.cpp
+++ b/prosper/tests/test_gpu_capture_render.cpp
@@ -141,6 +141,92 @@ int main() {
               "replay samples captured red texel from owned backing");
     }
 
+    // NV12 chroma arrives as an RG8 sampled texture. The narrow upload path used to broadcast only
+    // its first byte, turning (U,V) into (U,U) and giving every decoded movie a green/purple cast.
+    {
+        uint8_t rg_texels[8] = {32, 224, 32, 224, 32, 224, 32, 224};
+        DrawItem rg_draw = replay.items[0];
+        rg_draw.color0_base = 0x210000;
+        auto rg_table = std::make_shared<ShaderResourceTable>(*rg_draw.prt);
+        ShaderResource& rg = rg_table->resources[0];
+        rg.gpu_addr = 0x110000;
+        rg.format = DataFormat::Unorm8;
+        rg.num_components = 2;
+        rg.width = rg.height = 2;
+        rg.size = sizeof(rg_texels);
+        rg.linear_row_pitch_bytes = 4;
+        rg.host_data = rg_texels;
+        rg.host_data_size = sizeof(rg_texels);
+        rg.swizzle[0] = 4; rg.swizzle[1] = 5; rg.swizzle[2] = 0; rg.swizzle[3] = 1;
+        rg_draw.prt = rg_table;
+        const std::vector<uint8_t> generic_rg_pixels =
+            render_submit_items({rg_draw}, W, H);
+        bool generic_rg_broadcast =
+            generic_rg_pixels.size() == static_cast<size_t>(W) * H * 4;
+        if (generic_rg_broadcast) {
+            const uint8_t* center =
+                &generic_rg_pixels[(static_cast<size_t>(H / 2) * W + W / 2) * 4];
+            for (uint32_t channel = 0; channel < 4; ++channel)
+                generic_rg_broadcast &= center[channel] >= 24 && center[channel] <= 40;
+        }
+        CHECK(generic_rg_broadcast,
+              "ordinary narrow RG8 uploads retain the established coverage broadcast");
+
+        uint8_t luma_texels[16] = {};
+        ShaderResource luma = rg;
+        luma.binding = 5;
+        luma.gpu_addr = rg.gpu_addr - sizeof(luma_texels);
+        luma.num_components = 1;
+        luma.width = luma.height = 4;
+        luma.size = sizeof(luma_texels);
+        luma.linear_row_pitch_bytes = 4;
+        luma.host_data = luma_texels;
+        luma.host_data_size = sizeof(luma_texels);
+        rg_table->resources.push_back(luma);
+        rg_draw.prt = std::move(rg_table);
+        const std::vector<uint8_t> rg_pixels = render_submit_items({rg_draw}, W, H);
+        bool rg_preserved = rg_pixels.size() == static_cast<size_t>(W) * H * 4;
+        if (rg_preserved) {
+            const uint8_t* center =
+                &rg_pixels[(static_cast<size_t>(H / 2) * W + W / 2) * 4];
+            rg_preserved = center[0] >= 24 && center[0] <= 40 &&
+                           center[1] >= 216 && center[1] <= 232 &&
+                           center[2] < 8 && center[3] > 248;
+        }
+        CHECK(rg_preserved,
+              "narrow RG8 uploads preserve both channels and apply the descriptor swizzle");
+    }
+
+    // R8 masks historically broadcast coverage to every channel and deliberately ignore a T#
+    // remap. Keep that independent behavior while the exact AvPlayer RG8 contract preserves U/V.
+    {
+        uint8_t r_texels[4] = {96, 96, 96, 96};
+        DrawItem r_draw = replay.items[0];
+        r_draw.color0_base = 0x220000;
+        auto r_table = std::make_shared<ShaderResourceTable>(*r_draw.prt);
+        ShaderResource& r = r_table->resources[0];
+        r.gpu_addr = 0x120000;
+        r.format = DataFormat::Unorm8;
+        r.num_components = 1;
+        r.width = r.height = 2;
+        r.size = sizeof(r_texels);
+        r.linear_row_pitch_bytes = 2;
+        r.host_data = r_texels;
+        r.host_data_size = sizeof(r_texels);
+        r.swizzle[0] = 0; r.swizzle[1] = 1; r.swizzle[2] = 0; r.swizzle[3] = 1;
+        r_draw.prt = std::move(r_table);
+        const std::vector<uint8_t> r_pixels = render_submit_items({r_draw}, W, H);
+        bool r_broadcast = r_pixels.size() == static_cast<size_t>(W) * H * 4;
+        if (r_broadcast) {
+            const uint8_t* center =
+                &r_pixels[(static_cast<size_t>(H / 2) * W + W / 2) * 4];
+            for (uint32_t channel = 0; channel < 4; ++channel)
+                r_broadcast &= center[channel] >= 88 && center[channel] <= 104;
+        }
+        CHECK(r_broadcast,
+              "narrow R8 uploads retain coverage broadcast independently of descriptor swizzle");
+    }
+
     {
         const auto nonce = std::chrono::steady_clock::now().time_since_epoch().count();
         const std::filesystem::path dump_dir = std::filesystem::temp_directory_path() /


### PR DESCRIPTION
Fixes #1393.

## Failure

GRIS's opening AvPlayer FMV rendered as dense horizontal stripes and a magenta band. Gameplay rendered normally after the movie.

The movie is a tight NV12 allocation:
- 1920x1080 R8 luma
- 960x540 RG8 chroma at `luma + 1920 * 1080`
- 1920 bytes per row for both planes

The renderer instead applied the generic 256-byte sampled-texture fallback (2048 bytes at this width), and its historical narrow coverage upload broadcast U into both RG channels.

## Root cause and approach

- Add a thread-safe exact guest-linear layout registry for HLE-produced allocations.
- Register and unregister AvPlayer callback/fallback frame storage across allocation, release, source replacement, stop, and close.
- Keep defensive source-stride overflow validation before staging rows.
- Use exact pitch only when the descriptor's visible row matches registered provenance; ordinary guest textures retain the generic aligned fallback.
- Persist the exact pitch and span in F9 capture metadata.
- Preserve RG chroma channels only for exact live AvPlayer provenance. Capture replay recognizes the same contract through a strict adjacent R8/RG8 NV12 pair (tight matching pitches, 2:1 extents, expected swizzle, exact guest-VA adjacency).
- Keep ordinary narrow R8/RG8 coverage broadcast unchanged.
- Include the semantic bit in the decoded-texture cache key so coverage and NV12 interpretations cannot alias.

Padding AvPlayer to 2048 was tested and rejected: GRIS uses the published pitch as descriptor width, which exposed the padded tail as a right-edge strip.

## Validation

Exact final head: `15ccc5e01083f868d5760e4185ae064b6cbf2d1c`

- Distrobox `ps5ys`: Release configure/build succeeded at the exact final head.
- `ctest --test-dir prosper/build-app-linux --output-on-failure -j8`: 153/153 passed at the exact final head (6.22s).
- Native GRIS route at the exact final head: 48/48 screenshots, 48 source-distinct and 43 pixel-distinct, status OK; the full sampled FMV is clean with correct color and no stripe/right-edge corruption.
- Fresh F9 capture from the equivalent pre-rebase production patch:
  - luma R8 1920x1080, row pitch 1920, 2,073,600 bytes
  - chroma RG8 960x540, row pitch 1920, 1,036,800 bytes
  - isolated conversion draw replayed cleanly
  - game-derived capture remains local and is not committed
- The final rebase resolved master's overlapping Float32-cache/UNORM16 narrow-decode changes by preserving both those semantics and the exact AvPlayer RG8 path.
- Snapshot gate during investigation: Messenger scene, Evergate title/gameplay, Dead Cells gameplay, and Blasphemous 2 gameplay passed. Blue Prince title/hall and Terminator boot hit timing/route mismatches while unrelated long-running GPU jobs shared the host; the final implementation was narrowed to exact AvPlayer provenance and regression-tests ordinary narrow texture behavior.

## Review

Independent review initially found the removed source-stride overflow guards. They were restored and the reviewer approved pre-rebase head `17b7734c` with no remaining blockers. Fresh independent re-review approved exact rebased head `15ccc5e0`: the conflict resolution preserves master’s Float32/UNORM16 paths, AvPlayer RG8 U/V, ordinary UNORM8 coverage, and the prior stride bounds. No blockers.