### PR TITLE
fix(gpu): honor shadow PCF address modes

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -36,7 +36,7 @@ enum : uint32_t {
     Op_ConvertFToU=109, Op_ConvertFToS=110, Op_ConvertSToF=111, Op_ConvertUToF=112, Op_Bitcast=124,
     Op_CompositeConstruct=80, Op_CompositeExtract=81, Op_IAdd=128, Op_FAdd=129, Op_ISub=130, Op_FSub=131, Op_IMul=132, Op_FMul=133,
     Op_UMulExtended=151, Op_SMulExtended=152,   // {lo,hi} struct results (for mul_hi)
-    Op_FDiv=136, Op_IEqual=170, Op_INotEqual=171, Op_UGreaterThan=172, Op_SGreaterThan=173,
+    Op_FDiv=136, Op_SMod=139, Op_IEqual=170, Op_INotEqual=171, Op_UGreaterThan=172, Op_SGreaterThan=173,
     Op_UGreaterThanEqual=174, Op_SGreaterThanEqual=175, Op_ULessThan=176, Op_SLessThan=177,
     Op_ULessThanEqual=178, Op_SLessThanEqual=179,
     Op_ShiftRightLogical=194, Op_ShiftRightArithmetic=195, Op_ShiftLeftLogical=196, Op_BitwiseOr=197,
@@ -913,7 +913,8 @@ struct SpirvCompute {
     // Prince renders visually-correct shadows with it — the live A/B on #1271).
     void image_sample_dref_manual_2d(uint32_t binding, uint32_t u_bits, uint32_t v_bits,
                                      uint32_t dref_bits, uint32_t compare_func,
-                                     bool linear_filter, uint32_t out[4]) {
+                                     bool linear_filter, uint32_t addr_u, uint32_t addr_v,
+                                     uint32_t border_color_type, uint32_t out[4]) {
         uint32_t si    = id(); put(code, Op_Load, {tex_binding_simg[binding], si, tex_var[binding]});
         if (linear_filter) {
             if (!declared_image_query) {
@@ -927,24 +928,54 @@ struct SpirvCompute {
             const uint32_t w = i2u(w_i), h = i2u(h_i);
 
             // Normalized linear filtering addresses texel centers at n + 0.5. Convert to that
-            // footprint, then clamp both taps independently to reproduce clamp-to-edge.
+            // footprint, then address each tap with the decoded S#. Match the backend's current
+            // Gen5 contract (#1400): 0=repeat, 1=mirrored repeat, 2..5=clamp-to-edge, 6..7=border.
+            // The finer mirror-once/half-border distinctions in 3..5 remain deliberately folded by
+            // both paths until the shared sampler decoder grows them.
             const uint32_t half = bcu(fconstf(0.5f));
             const uint32_t x = fbin(Op_FSub, fbin(Op_FMul, u_bits, cvt_i2f(w)), half);
             const uint32_t y = fbin(Op_FSub, fbin(Op_FMul, v_bits, cvt_i2f(h)), half);
             const uint32_t fx = fext1(Glsl_Fract, x), fy = fext1(Glsl_Fract, y);
             const uint32_t bx = cvt_f2i(fext1(Glsl_Floor, x));
             const uint32_t by = cvt_f2i(fext1(Glsl_Floor, y));
-            const uint32_t max_x = sbin(Op_ISub, w, uconst(1));
-            const uint32_t max_y = sbin(Op_ISub, h, uconst(1));
-            auto clamp_coord = [&](uint32_t value, uint32_t maximum) {
+            auto address_coord = [&](uint32_t value, uint32_t extent, uint32_t mode,
+                                     uint32_t& outside_border) {
+                outside_border = bfalse();
+                if (mode == 0u) return sbin(Op_SMod, value, extent);
+                if (mode == 1u) {
+                    const uint32_t period = sbin(Op_IMul, extent, uconst(2));
+                    const uint32_t wrapped = sbin(Op_SMod, value, period);
+                    const uint32_t reflected = sbin(
+                        Op_ISub, sbin(Op_ISub, period, uconst(1)), wrapped);
+                    return sel(scmp(Op_SGreaterThanEqual, wrapped, extent), reflected, wrapped);
+                }
+                const uint32_t maximum = sbin(Op_ISub, extent, uconst(1));
+                if (mode >= 6u) {
+                    outside_border = lor(scmp(Op_SLessThan, value, uconst(0)),
+                                         scmp(Op_SGreaterThanEqual, value, extent));
+                }
                 return sext2(Glsl_SMin, sext2(Glsl_SMax, value, uconst(0)), maximum);
             };
-            const uint32_t x0 = clamp_coord(bx, max_x);
-            const uint32_t y0 = clamp_coord(by, max_y);
-            const uint32_t x1 = clamp_coord(sbin(Op_IAdd, bx, uconst(1)), max_x);
-            const uint32_t y1 = clamp_coord(sbin(Op_IAdd, by, uconst(1)), max_y);
+            uint32_t x0_border, x1_border, y0_border, y1_border;
+            const uint32_t x0 = address_coord(bx, w, addr_u, x0_border);
+            const uint32_t y0 = address_coord(by, h, addr_v, y0_border);
+            const uint32_t x1 = address_coord(
+                sbin(Op_IAdd, bx, uconst(1)), w, addr_u, x1_border);
+            const uint32_t y1 = address_coord(
+                sbin(Op_IAdd, by, uconst(1)), h, addr_v, y1_border);
 
-            auto compare_fetch = [&](uint32_t tx, uint32_t ty) {
+            const bool uses_border = addr_u >= 6u || addr_v >= 6u;
+            uint32_t border_compare = 0;
+            if (uses_border) {
+                // The sampled depth is R: transparent/opaque black and unsupported custom-register
+                // border colors all contribute 0, while opaque white contributes 1. This mirrors the
+                // backend sampler's custom-border fallback.
+                const float border_depth = border_color_type == 2u ? 1.0f : 0.0f;
+                border_compare = image_dref_compare_bits(
+                    fconstf(border_depth), dref_bits, compare_func);
+            }
+
+            auto compare_fetch = [&](uint32_t tx, uint32_t ty, uint32_t outside_border) {
                 uint32_t coord = id();
                 put(code, Op_CompositeConstruct, {t_v2u(), coord, tx, ty});
                 uint32_t texel = id();
@@ -952,12 +983,17 @@ struct SpirvCompute {
                     {t_v4f, texel, img, coord, ImgOp_Lod, uconst(0)});
                 uint32_t depth = id();
                 put(code, Op_CompositeExtract, {t_f32, depth, texel, 0});
-                return image_dref_compare_bits(depth, dref_bits, compare_func);
+                const uint32_t fetched = image_dref_compare_bits(
+                    depth, dref_bits, compare_func);
+                return uses_border ? sel(outside_border, border_compare, fetched) : fetched;
             };
-            const uint32_t c00 = compare_fetch(x0, y0);
-            const uint32_t c10 = compare_fetch(x1, y0);
-            const uint32_t c01 = compare_fetch(x0, y1);
-            const uint32_t c11 = compare_fetch(x1, y1);
+            auto tap_border = [&](uint32_t x_border, uint32_t y_border) {
+                return uses_border ? lor(x_border, y_border) : bfalse();
+            };
+            const uint32_t c00 = compare_fetch(x0, y0, tap_border(x0_border, y0_border));
+            const uint32_t c10 = compare_fetch(x1, y0, tap_border(x1_border, y0_border));
+            const uint32_t c01 = compare_fetch(x0, y1, tap_border(x0_border, y1_border));
+            const uint32_t c11 = compare_fetch(x1, y1, tap_border(x1_border, y1_border));
             auto lerp = [&](uint32_t a, uint32_t b, uint32_t t) {
                 return fbin(Op_FAdd, a, fbin(Op_FMul, fbin(Op_FSub, b, a), t));
             };
@@ -6329,7 +6365,8 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     b.declare_texture(res->binding, Dim_2D, false);
                     b.image_sample_dref_manual_2d(res->binding, vread(cvg(1)), vread(cvg(2)),
                                                   vread(cvg(0)), res->depth_compare_func,
-                                                  res->mag_filter != 0u, out);
+                                                  res->mag_filter != 0u, res->addr_uvw[0],
+                                                  res->addr_uvw[1], res->border_color_type, out);
                 } else { ok = false; return true; }
             } else if (is_gather_lz || is_gather_lz_o) {
                 // gather4 dmask selects ONE channel (must be a single bit); the result is always the

--- a/prosper/tests/test_shadow_compare_render.cpp
+++ b/prosper/tests/test_shadow_compare_render.cpp
@@ -125,6 +125,67 @@ int main() {
         }
     }
 
+    // #1400: the software PCF footprint must use the decoded S# address modes instead of silently
+    // clamping every tap. Keep literal coordinates so each mode has an unambiguous result that the
+    // old clamp-only lowering cannot produce.
+    std::vector<uint8_t> all_pass(8 * 8 * 4);
+    std::vector<uint8_t> vertical(8 * 8 * 4);
+    for (uint32_t y = 0; y < 8; y++) for (uint32_t x = 0; x < 8; x++) {
+        uint8_t* a = &all_pass[(y * 8 + x) * 4];
+        a[0] = a[1] = a[2] = 0; a[3] = 255;
+        uint8_t* v = &vertical[(y * 8 + x) * 4];
+        v[0] = y < 4 ? 0 : 230; v[1] = v[2] = 0; v[3] = 255;
+    }
+    const uint32_t ps_addressed_pcf[] = {
+        0x7e0202f0u,                                          // v1 = 0.5 DREF
+        0x7e0402ffu, 0x00000000u,                             // v2 = literal u (patched below)
+        0x7e0602ffu, 0x00000000u,                             // v3 = literal v (patched below)
+        0xf0bc0108u, 0x00820401u,                             // image_sample_c_lz v4, v[1:3], s8, s16
+        0xf800080fu, 0x07060504u,                             // exp mrt0 v4..v7
+        0xbf810000u,
+    };
+    auto addressed_pcf = [&](uint32_t u, uint32_t v, uint32_t addr_u, uint32_t addr_v,
+                              uint32_t border_type, const uint8_t* pixels) -> int {
+        std::vector<uint32_t> shader(
+            ps_addressed_pcf,
+            ps_addressed_pcf + sizeof(ps_addressed_pcf) / sizeof(ps_addressed_pcf[0]));
+        shader[2] = u; shader[4] = v;
+        ShaderResourceTable addressed_rt = linear_rt;
+        addressed_rt.resources[0].addr_uvw[0] = addr_u;
+        addressed_rt.resources[0].addr_uvw[1] = addr_v;
+        addressed_rt.resources[0].border_color_type = border_type;
+        std::vector<uint32_t> addressed_frag = recompile_fragment(
+            shader.data(), shader.size(), &addressed_rt);
+        if (addressed_frag.empty()) return -1;
+        prosper::test::FrameResource resource = nearest_tex;
+        resource.tex_rgba = pixels;
+        resource.mag_filter = resource.min_filter = 1;
+        resource.addr_uvw[0] = addr_u; resource.addr_uvw[1] = addr_v;
+        resource.border_color_type = border_type;
+        std::vector<prosper::test::FrameResource> resources{resource};
+        std::vector<uint8_t> result = prosper::test::render_triangle_rgba(
+            vert, addressed_frag, W, H, nullptr, nullptr, nullptr, nullptr, &resources);
+        if (result.size() != (size_t)W * H * 4) return -1;
+        return result[(((size_t)H / 2 * W + W / 2) * 4)];
+    };
+    constexpr uint32_t ZERO = 0x00000000u, HALF = 0x3f000000u;
+    const int clamp_u = addressed_pcf(ZERO, HALF, 2, 2, 0, tex.data());
+    const int repeat_u = addressed_pcf(ZERO, HALF, 0, 2, 0, tex.data());
+    const int mirror_u = addressed_pcf(0x3fe00000u /*1.75*/, HALF, 1, 2, 0, tex.data());
+    const int border_u = addressed_pcf(ZERO, HALF, 6, 2, 2, all_pass.data());
+    const int repeat_v = addressed_pcf(HALF, ZERO, 2, 0, 0, vertical.data());
+    printf("  PCF address modes clampU=%d repeatU=%d mirrorU=%d borderU=%d repeatV=%d\n",
+           clamp_u, repeat_u, mirror_u, border_u, repeat_v);
+    CHECK(clamp_u >= 254, "LINEAR PCF clamp-to-edge repeats the passing edge texel");
+    CHECK(repeat_u >= 127 && repeat_u <= 128,
+          "LINEAR PCF U repeat wraps one footprint tap to the failing edge (#1400)");
+    CHECK(mirror_u >= 254,
+          "LINEAR PCF U mirror reflects 1.75 onto the passing half (#1400)");
+    CHECK(border_u >= 127 && border_u <= 128,
+          "LINEAR PCF U border compares an opaque-white border tap independently (#1400)");
+    CHECK(repeat_v >= 127 && repeat_v <= 128,
+          "LINEAR PCF V repeat wraps one footprint tap to the failing edge (#1400)");
+
     // #1308: sampled-depth bridge recency tracks writers, not mere depth attachment users.
     CHECK(!prosper::test::persistent_ds_pass_may_write_depth(
               false, true, false, VK_COMPARE_OP_ALWAYS),


### PR DESCRIPTION
## Summary
- apply decoded S# U/V addressing to every software-PCF footprint tap
- support repeat, mirrored repeat, clamp-to-edge, and border comparison under the backend's existing Gen5 mode contract
- add RADV execution cases whose coverage differs from the old clamp-only lowering on both axes

## Semantics
The manual LINEAR `IMAGE_SAMPLE_C_LZ` path now maps integer footprint coordinates as follows, matching the current backend sampler decoder:

- `0`: repeat via signed modulo
- `1`: mirrored repeat over a `2 * extent` period
- `2..5`: clamp-to-edge (the backend's existing folded treatment of mirror-once/half-border modes)
- `6..7`: border; out-of-range taps compare against the decoded black/white border depth before bilinear weighting

Opaque-white border depth is 1.0; transparent/opaque black and the backend's unsupported-custom fallback are 0.0. Fetch coordinates remain clamped in the border case so no undefined out-of-range `OpImageFetch` is emitted.

## Verification
- `ctest --test-dir prosper/build-audit --output-on-failure -j8`: 146/146 passed
- focused `spv_validate`, `rdna2_to_spirv_exec`, and `shadow_compare_render` passed
- RADV address matrix: `clampU=255 repeatU=128 mirrorU=255 borderU=128 repeatV=128`
- injected old clamp-only dispatch: four new non-clamp assertions fail with `repeatU=255 mirrorU=0 borderU=255 repeatV=255`
- `git diff --check`

Refs #1400
