### PR TITLE
fix(tool): classify active hang-probe samples

### DIFF
--- a/prosper/tools/guest_bt/guest_bt_gdb.py
+++ b/prosper/tools/guest_bt/guest_bt_gdb.py
@@ -102,6 +102,16 @@ def _pick_thread(arg):
             return t
     raise gdb.GdbError('no thread matching %r' % arg)
 
+def _print_native_frame():
+    """Emit the selected thread's native stop frame after any requested thread switch."""
+    try:
+        frame = gdb.newest_frame()
+        pc = int(frame.pc())
+        name = frame.name() or '??'
+        print('guest-bt-native: 0x%x in %s' % (pc, name))
+    except (gdb.error, ValueError) as e:
+        print('guest-bt-native: unavailable (%s)' % e)
+
 class GuestBt(gdb.Command):
     """guest-bt [thread] — symbolicated backtrace of a prosper guest thread across the HLE stub."""
     def __init__(self):
@@ -110,6 +120,7 @@ class GuestBt(gdb.Command):
     def invoke(self, arg, from_tty):
         t = _pick_thread(arg)
         t.switch()
+        _print_native_frame()
         print('=== guest-bt thread %s "%s" (LWP %s) ===' %
               (t.num, t.name or '?', t.ptid[1]))
         gdb.execute('bt')
@@ -122,6 +133,7 @@ class GuestBtAll(gdb.Command):
     def invoke(self, arg, from_tty):
         for t in gdb.selected_inferior().threads():
             t.switch()
+            _print_native_frame()
             print('\n=== thread %s "%s" (LWP %s) ===' % (t.num, t.name or '?', t.ptid[1]))
             try:
                 gdb.execute('bt')

--- a/prosper/tools/hang_probe/README.md
+++ b/prosper/tools/hang_probe/README.md
@@ -21,6 +21,8 @@ For each run it launches the title headless via `boot_trace` (with the gated `PR
   `run_command_buffer` / `present` / `SubmitDcb`), or a non-blocking selected native frame. The
   latter matters because a healthy main thread may be executing in Prosper, libc, the Vulkan driver,
   or guest code while re-sectioning leaves native `boot_trace` frames unnamed in the backtrace.
+  `guest_bt` emits this frame only after switching to the requested thread; the unrelated frame gdb
+  prints when it first attaches is deliberately ignored.
 - **UNKNOWN** — `guest_bt` timed out/failed, or returned no recognized running/wait frame; the run
   produced no trustworthy hang verdict. When available, the selected native stop frame is printed
   as evidence for refining the classifier.

--- a/prosper/tools/hang_probe/README.md
+++ b/prosper/tools/hang_probe/README.md
@@ -18,9 +18,12 @@ For each run it launches the title headless via `boot_trace` (with the gated `PR
 - **BLOCKED** — the top HLE frame is a kernel wait (`k_sema_wait` / `k_eq_wait` / `k_cond_wait` /
   `k_ef_wait` / `k_usleep`). On a BLOCKED run it prints Thread 1's stack as evidence.
 - **RUNNING** — an active render/submit frame (`execute_ordered` / `agc_driver_submit` /
-  `run_command_buffer` / `present` / `SubmitDcb`).
+  `run_command_buffer` / `present` / `SubmitDcb`), or a non-blocking selected native frame. The
+  latter matters because a healthy main thread may be executing in Prosper, libc, the Vulkan driver,
+  or guest code while re-sectioning leaves native `boot_trace` frames unnamed in the backtrace.
 - **UNKNOWN** — `guest_bt` timed out/failed, or returned no recognized running/wait frame; the run
-  produced no trustworthy hang verdict.
+  produced no trustworthy hang verdict. When available, the selected native stop frame is printed
+  as evidence for refining the classifier.
 - **DEAD** — `boot_trace` exited before the configured sample time, so no live thread could be
   classified.
 

--- a/prosper/tools/hang_probe/hang_probe.py
+++ b/prosper/tools/hang_probe/hang_probe.py
@@ -25,17 +25,32 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 WAIT_FRAMES = ("k_sema_wait", "k_eq_wait", "k_cond_wait", "k_ef_wait", "k_usleep")
 RUN_FRAMES  = ("execute_ordered", "execute_submit", "agc_driver_submit", "run_command_buffer",
                "present", "SubmitDcb", "run_command")
+NATIVE_STOP_FRAME = re.compile(r"^0x[0-9a-f]+ in .+$", re.MULTILINE)
+NATIVE_BLOCK_FRAME = re.compile(
+    r"\b(?:__syscall_cancel_arch|(?:__)?futex\w*|pthread_(?:cond|mutex|rwlock)\w*|sem_wait\w*|"
+    r"clock_nanosleep|nanosleep|poll|ppoll|select|epoll_wait|kevent)\b")
 
 
 def classify(gbt_text: str):
     """Return ('BLOCKED'|'RUNNING'|'UNKNOWN', top_frame_str) for the main thread's stack."""
-    if any(f in gbt_text for f in RUN_FRAMES):
-        m = next((l for l in gbt_text.splitlines() if any(f in l for f in RUN_FRAMES)), "")
-        return "RUNNING", m.strip()
+    # A guest kernel wait is decisive even when a lower frame happens to contain a render symbol.
+    # The EOP deadlock this probe targets has exactly that shape: the main thread is in k_sema_wait.
     if any(f in gbt_text for f in WAIT_FRAMES):
         m = next((l for l in gbt_text.splitlines() if any(f in l for f in WAIT_FRAMES)), "")
         return "BLOCKED", m.strip()
-    return "UNKNOWN", ""
+    if any(f in gbt_text for f in RUN_FRAMES):
+        m = next((l for l in gbt_text.splitlines() if any(f in l for f in RUN_FRAMES)), "")
+        return "RUNNING", m.strip()
+    # Re-sectioning guest modules leaves native boot_trace frames unnamed in the backtrace, but gdb
+    # prints the selected thread's current frame immediately before it. A non-blocking current frame
+    # means Thread 1 is executing: observed healthy Evergate samples include Prosper render helpers,
+    # libc allocation/string work, the Vulkan driver, and unsymbolicated guest PCs. Known host waits
+    # remain inconclusive unless guest_bt also found the decisive guest kernel-wait frame above.
+    m = NATIVE_STOP_FRAME.search(gbt_text)
+    frame = m.group(0).strip() if m else ""
+    if frame and not NATIVE_BLOCK_FRAME.search(frame):
+        return "RUNNING", frame
+    return "UNKNOWN", frame
 
 
 def run_guest_bt(cmd, timeout):

--- a/prosper/tools/hang_probe/hang_probe.py
+++ b/prosper/tools/hang_probe/hang_probe.py
@@ -41,19 +41,22 @@ def native_function(frame: str):
 
 def classify(gbt_text: str):
     """Return ('BLOCKED'|'RUNNING'|'UNKNOWN', top_frame_str) for the main thread's stack."""
+    native_match = NATIVE_STOP_FRAME.search(gbt_text)
+    # gdb prints the thread it happened to stop on before the guest-bt command switches threads.
+    # Once the selected-thread marker exists, no frame before it is classification evidence.
+    selected_text = gbt_text[native_match.start():] if native_match else gbt_text
     # A guest kernel wait is decisive even when a lower frame happens to contain a render symbol.
     # The EOP deadlock this probe targets has exactly that shape: the main thread is in k_sema_wait.
-    if any(f in gbt_text for f in WAIT_FRAMES):
-        m = next((l for l in gbt_text.splitlines() if any(f in l for f in WAIT_FRAMES)), "")
+    if any(f in selected_text for f in WAIT_FRAMES):
+        m = next((l for l in selected_text.splitlines() if any(f in l for f in WAIT_FRAMES)), "")
         return "BLOCKED", m.strip()
-    m = NATIVE_STOP_FRAME.search(gbt_text)
-    frame = m.group(1).strip() if m else ""
+    frame = native_match.group(1).strip() if native_match else ""
     # A selected thread stopped in a known host wait is inconclusive even if a lower caller happens
     # to carry an active-render name. Accepting that lower frame would turn a parked thread green.
     if frame and NATIVE_BLOCK_FUNCTION.fullmatch(native_function(frame)):
         return "UNKNOWN", frame
-    if any(f in gbt_text for f in RUN_FRAMES):
-        m = next((l for l in gbt_text.splitlines() if any(f in l for f in RUN_FRAMES)), "")
+    if any(f in selected_text for f in RUN_FRAMES):
+        m = next((l for l in selected_text.splitlines() if any(f in l for f in RUN_FRAMES)), "")
         return "RUNNING", m.strip()
     # Re-sectioning guest modules leaves native boot_trace frames unnamed in the backtrace, but gdb
     # prints the selected thread's current frame immediately before it. A non-blocking current frame

--- a/prosper/tools/hang_probe/hang_probe.py
+++ b/prosper/tools/hang_probe/hang_probe.py
@@ -27,8 +27,11 @@ RUN_FRAMES  = ("execute_ordered", "execute_submit", "agc_driver_submit", "run_co
                "present", "SubmitDcb", "run_command")
 NATIVE_STOP_FRAME = re.compile(r"^guest-bt-native: (0x[0-9a-f]+ in .+)$", re.MULTILINE)
 NATIVE_BLOCK_FUNCTION = re.compile(
-    r"^(?:syscall_cancel_arch|futex\w*|pthread_(?:cond|mutex|rwlock)\w*|sem_wait\w*|"
-    r"clock_nanosleep(?:_time64)?|nanosleep|poll|ppoll|select(?:64)?|epoll_wait|kevent)$")
+    r"^(?:syscall_cancel_arch|futex_(?:(?:abstimed_)?wait(?:_(?:common|cancelable))?(?:64)?|wait_simple)|"
+    r"pthread_cond_(?:wait|timedwait|clockwait)|pthread_mutex_(?:lock|timedlock|clocklock)(?:_full)?|"
+    r"pthread_rwlock_(?:rdlock|wrlock|timedrdlock|timedwrlock|clockrdlock|clockwrlock)|"
+    r"sem_(?:wait|timedwait|clockwait)|clock_nanosleep(?:_time64)?|nanosleep|poll|ppoll|"
+    r"select(?:64)?|epoll_(?:wait|pwait|pwait2)|kevent(?:64)?)$")
 
 
 def native_function(frame: str):

--- a/prosper/tools/hang_probe/hang_probe.py
+++ b/prosper/tools/hang_probe/hang_probe.py
@@ -9,7 +9,7 @@ automates the run -> wait -> gdb/guest_bt classify -> repeat loop that is otherw
 For each run it launches the title headless through boot_trace, waits, then attaches guest_bt to the
 main thread (Thread 1) and classifies it:
   * BLOCKED (hung) - the top HLE frame is a kernel wait (k_sema_wait / k_eq_wait / k_cond_wait / k_ef_wait)
-  * RUNNING        - an active render/submit frame (execute_ordered / present / agc_driver_submit / run_command)
+  * RUNNING        - an active render/submit frame or a non-blocking selected native frame
 Plain gdb cannot unwind the guest main thread through the HLE stub boundary, so guest_bt is required (it
 re-sections the flattened module ELFs). On a BLOCKED run the tool prints Thread 1's stack as evidence.
 
@@ -25,7 +25,7 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 WAIT_FRAMES = ("k_sema_wait", "k_eq_wait", "k_cond_wait", "k_ef_wait", "k_usleep")
 RUN_FRAMES  = ("execute_ordered", "execute_submit", "agc_driver_submit", "run_command_buffer",
                "present", "SubmitDcb", "run_command")
-NATIVE_STOP_FRAME = re.compile(r"^0x[0-9a-f]+ in .+$", re.MULTILINE)
+NATIVE_STOP_FRAME = re.compile(r"^guest-bt-native: (0x[0-9a-f]+ in .+)$", re.MULTILINE)
 NATIVE_BLOCK_FRAME = re.compile(
     r"\b(?:__syscall_cancel_arch|(?:__)?futex\w*|pthread_(?:cond|mutex|rwlock)\w*|sem_wait\w*|"
     r"clock_nanosleep|nanosleep|poll|ppoll|select|epoll_wait|kevent)\b")
@@ -47,7 +47,7 @@ def classify(gbt_text: str):
     # libc allocation/string work, the Vulkan driver, and unsymbolicated guest PCs. Known host waits
     # remain inconclusive unless guest_bt also found the decisive guest kernel-wait frame above.
     m = NATIVE_STOP_FRAME.search(gbt_text)
-    frame = m.group(0).strip() if m else ""
+    frame = m.group(1).strip() if m else ""
     if frame and not NATIVE_BLOCK_FRAME.search(frame):
         return "RUNNING", frame
     return "UNKNOWN", frame

--- a/prosper/tools/hang_probe/hang_probe.py
+++ b/prosper/tools/hang_probe/hang_probe.py
@@ -26,9 +26,17 @@ WAIT_FRAMES = ("k_sema_wait", "k_eq_wait", "k_cond_wait", "k_ef_wait", "k_usleep
 RUN_FRAMES  = ("execute_ordered", "execute_submit", "agc_driver_submit", "run_command_buffer",
                "present", "SubmitDcb", "run_command")
 NATIVE_STOP_FRAME = re.compile(r"^guest-bt-native: (0x[0-9a-f]+ in .+)$", re.MULTILINE)
-NATIVE_BLOCK_FRAME = re.compile(
-    r"\b(?:__syscall_cancel_arch|(?:__)?futex\w*|pthread_(?:cond|mutex|rwlock)\w*|sem_wait\w*|"
-    r"clock_nanosleep|nanosleep|poll|ppoll|select|epoll_wait|kevent)\b")
+NATIVE_BLOCK_FUNCTION = re.compile(
+    r"^(?:syscall_cancel_arch|futex\w*|pthread_(?:cond|mutex|rwlock)\w*|sem_wait\w*|"
+    r"clock_nanosleep(?:_time64)?|nanosleep|poll|ppoll|select(?:64)?|epoll_wait|kevent)$")
+
+
+def native_function(frame: str):
+    """Return a normalized function name from a guest-bt-native evidence line."""
+    name = frame.partition(" in ")[2].split("(", 1)[0].split("@", 1)[0].strip()
+    if name.startswith("__GI_"):
+        name = name[len("__GI_"):]
+    return name.lstrip("_")
 
 
 def classify(gbt_text: str):
@@ -42,7 +50,7 @@ def classify(gbt_text: str):
     frame = m.group(1).strip() if m else ""
     # A selected thread stopped in a known host wait is inconclusive even if a lower caller happens
     # to carry an active-render name. Accepting that lower frame would turn a parked thread green.
-    if frame and NATIVE_BLOCK_FRAME.search(frame):
+    if frame and NATIVE_BLOCK_FUNCTION.fullmatch(native_function(frame)):
         return "UNKNOWN", frame
     if any(f in gbt_text for f in RUN_FRAMES):
         m = next((l for l in gbt_text.splitlines() if any(f in l for f in RUN_FRAMES)), "")

--- a/prosper/tools/hang_probe/hang_probe.py
+++ b/prosper/tools/hang_probe/hang_probe.py
@@ -38,6 +38,12 @@ def classify(gbt_text: str):
     if any(f in gbt_text for f in WAIT_FRAMES):
         m = next((l for l in gbt_text.splitlines() if any(f in l for f in WAIT_FRAMES)), "")
         return "BLOCKED", m.strip()
+    m = NATIVE_STOP_FRAME.search(gbt_text)
+    frame = m.group(1).strip() if m else ""
+    # A selected thread stopped in a known host wait is inconclusive even if a lower caller happens
+    # to carry an active-render name. Accepting that lower frame would turn a parked thread green.
+    if frame and NATIVE_BLOCK_FRAME.search(frame):
+        return "UNKNOWN", frame
     if any(f in gbt_text for f in RUN_FRAMES):
         m = next((l for l in gbt_text.splitlines() if any(f in l for f in RUN_FRAMES)), "")
         return "RUNNING", m.strip()
@@ -46,9 +52,7 @@ def classify(gbt_text: str):
     # means Thread 1 is executing: observed healthy Evergate samples include Prosper render helpers,
     # libc allocation/string work, the Vulkan driver, and unsymbolicated guest PCs. Known host waits
     # remain inconclusive unless guest_bt also found the decisive guest kernel-wait frame above.
-    m = NATIVE_STOP_FRAME.search(gbt_text)
-    frame = m.group(1).strip() if m else ""
-    if frame and not NATIVE_BLOCK_FRAME.search(frame):
+    if frame:
         return "RUNNING", frame
     return "UNKNOWN", frame
 

--- a/prosper/tools/hang_probe/test_hang_probe.py
+++ b/prosper/tools/hang_probe/test_hang_probe.py
@@ -11,6 +11,42 @@ HANG_PROBE = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(HANG_PROBE)
 
 
+class ClassificationTests(unittest.TestCase):
+    def test_active_gpu_native_frame_is_running(self):
+        text = ("0x0000000000442f85 in prosper::gpu::build_stage_table(prosper::gpu::GpuState const&) ()\n"
+                "guest-bt: loaded\n#0 0x442f85 in ??? ()\n")
+        self.assertEqual(HANG_PROBE.classify(text),
+                         ("RUNNING", text.splitlines()[0]))
+
+    def test_active_live_frontend_native_frame_is_running(self):
+        text = ("0x0000000000652319 in prosper::frontend::register_live_renderer()::{lambda()#1}::operator()() const ()\n"
+                "guest-bt: loaded\n#0 0x652319 in ??? ()\n")
+        self.assertEqual(HANG_PROBE.classify(text),
+                         ("RUNNING", text.splitlines()[0]))
+
+    def test_active_libc_native_frame_is_running(self):
+        text = "0x00007f00 in _int_free_chunk () from /lib64/libc.so.6\n#0 0x7f00 in ??? ()\n"
+        self.assertEqual(HANG_PROBE.classify(text),
+                         ("RUNNING", text.splitlines()[0]))
+
+    def test_active_unsymbolicated_guest_frame_is_running(self):
+        text = "0x0000000410f4bb02 in ?? ()\n#0 0x410f4bb02 in ??? ()\n"
+        self.assertEqual(HANG_PROBE.classify(text),
+                         ("RUNNING", text.splitlines()[0]))
+
+    def test_native_blocking_frame_remains_unknown(self):
+        text = "0x00007f00 in pthread_cond_wait@@GLIBC_2.3.2 ()\n#0 0x7f00 in ??? ()\n"
+        self.assertEqual(HANG_PROBE.classify(text),
+                         ("UNKNOWN", text.splitlines()[0]))
+
+    def test_guest_wait_takes_precedence_over_lower_running_frame(self):
+        text = "#0 k_sema_wait\n#1 prosper::gpu::execute_ordered\n"
+        self.assertEqual(HANG_PROBE.classify(text), ("BLOCKED", "#0 k_sema_wait"))
+
+    def test_unknown_without_native_frame_has_empty_evidence(self):
+        self.assertEqual(HANG_PROBE.classify("#0 0x7f00 in ??? ()\n"), ("UNKNOWN", ""))
+
+
 class GuestBtResultTests(unittest.TestCase):
     @mock.patch.object(HANG_PROBE.subprocess, "run")
     def test_failed_guest_bt_is_unknown_with_stderr(self, run):

--- a/prosper/tools/hang_probe/test_hang_probe.py
+++ b/prosper/tools/hang_probe/test_hang_probe.py
@@ -47,10 +47,24 @@ class ClassificationTests(unittest.TestCase):
                 text = f"guest-bt-native: {frame}\n#1 prosper::gpu::execute_ordered\n"
                 self.assertEqual(HANG_PROBE.classify(text), ("UNKNOWN", frame))
 
-    def test_non_wait_name_with_select_prefix_is_running(self):
-        frame = "0x0000000000442f85 in prosper::gpu::select_shader"
-        self.assertEqual(HANG_PROBE.classify(f"guest-bt-native: {frame}\n"),
-                         ("RUNNING", frame))
+    def test_native_blocking_operations_remain_unknown(self):
+        names = ("__futex_abstimed_wait_common64", "pthread_cond_timedwait",
+                 "pthread_mutex_lock", "pthread_rwlock_rdlock", "sem_clockwait")
+        for name in names:
+            with self.subTest(name=name):
+                frame = f"0x00007f00 in {name}"
+                self.assertEqual(HANG_PROBE.classify(f"guest-bt-native: {frame}\n"),
+                                 ("UNKNOWN", frame))
+
+    def test_active_native_operations_are_running(self):
+        names = ("futex_wake", "pthread_cond_signal", "pthread_mutex_unlock",
+                 "pthread_mutex_trylock", "pthread_rwlock_unlock",
+                 "prosper::gpu::select_shader")
+        for name in names:
+            with self.subTest(name=name):
+                frame = f"0x0000000000442f85 in {name}"
+                self.assertEqual(HANG_PROBE.classify(f"guest-bt-native: {frame}\n"),
+                                 ("RUNNING", frame))
 
     def test_attach_frame_before_thread_switch_is_ignored(self):
         text = ("0x00007f00 in prosper::k_sema_wait()\n#1 prosper::gpu::present\n"

--- a/prosper/tools/hang_probe/test_hang_probe.py
+++ b/prosper/tools/hang_probe/test_hang_probe.py
@@ -13,31 +13,37 @@ SPEC.loader.exec_module(HANG_PROBE)
 
 class ClassificationTests(unittest.TestCase):
     def test_active_gpu_native_frame_is_running(self):
-        text = ("0x0000000000442f85 in prosper::gpu::build_stage_table(prosper::gpu::GpuState const&) ()\n"
+        text = ("guest-bt-native: 0x0000000000442f85 in prosper::gpu::build_stage_table\n"
                 "guest-bt: loaded\n#0 0x442f85 in ??? ()\n")
         self.assertEqual(HANG_PROBE.classify(text),
-                         ("RUNNING", text.splitlines()[0]))
+                         ("RUNNING", "0x0000000000442f85 in prosper::gpu::build_stage_table"))
 
     def test_active_live_frontend_native_frame_is_running(self):
-        text = ("0x0000000000652319 in prosper::frontend::register_live_renderer()::{lambda()#1}::operator()() const ()\n"
+        text = ("guest-bt-native: 0x0000000000652319 in prosper::frontend::register_live_renderer()::{lambda()#1}::operator()() const\n"
                 "guest-bt: loaded\n#0 0x652319 in ??? ()\n")
         self.assertEqual(HANG_PROBE.classify(text),
-                         ("RUNNING", text.splitlines()[0]))
+                         ("RUNNING", text.splitlines()[0].removeprefix("guest-bt-native: ")))
 
     def test_active_libc_native_frame_is_running(self):
-        text = "0x00007f00 in _int_free_chunk () from /lib64/libc.so.6\n#0 0x7f00 in ??? ()\n"
+        text = "guest-bt-native: 0x00007f00 in _int_free_chunk\n#0 0x7f00 in ??? ()\n"
         self.assertEqual(HANG_PROBE.classify(text),
-                         ("RUNNING", text.splitlines()[0]))
+                         ("RUNNING", "0x00007f00 in _int_free_chunk"))
 
     def test_active_unsymbolicated_guest_frame_is_running(self):
-        text = "0x0000000410f4bb02 in ?? ()\n#0 0x410f4bb02 in ??? ()\n"
+        text = "guest-bt-native: 0x0000000410f4bb02 in ??\n#0 0x410f4bb02 in ??? ()\n"
         self.assertEqual(HANG_PROBE.classify(text),
-                         ("RUNNING", text.splitlines()[0]))
+                         ("RUNNING", "0x0000000410f4bb02 in ??"))
 
     def test_native_blocking_frame_remains_unknown(self):
-        text = "0x00007f00 in pthread_cond_wait@@GLIBC_2.3.2 ()\n#0 0x7f00 in ??? ()\n"
+        text = "guest-bt-native: 0x00007f00 in pthread_cond_wait@@GLIBC_2.3.2\n#0 0x7f00 in ??? ()\n"
         self.assertEqual(HANG_PROBE.classify(text),
-                         ("UNKNOWN", text.splitlines()[0]))
+                         ("UNKNOWN", "0x00007f00 in pthread_cond_wait@@GLIBC_2.3.2"))
+
+    def test_attach_frame_before_thread_switch_is_ignored(self):
+        text = ("0x00007f00 in pthread_cond_wait@@GLIBC_2.3.2 ()\n"
+                "guest-bt-native: 0x0000000410f4bb02 in ??\n#0 0x410f4bb02 in ??? ()\n")
+        self.assertEqual(HANG_PROBE.classify(text),
+                         ("RUNNING", "0x0000000410f4bb02 in ??"))
 
     def test_guest_wait_takes_precedence_over_lower_running_frame(self):
         text = "#0 k_sema_wait\n#1 prosper::gpu::execute_ordered\n"

--- a/prosper/tools/hang_probe/test_hang_probe.py
+++ b/prosper/tools/hang_probe/test_hang_probe.py
@@ -35,7 +35,8 @@ class ClassificationTests(unittest.TestCase):
                          ("RUNNING", "0x0000000410f4bb02 in ??"))
 
     def test_native_blocking_frame_remains_unknown(self):
-        text = "guest-bt-native: 0x00007f00 in pthread_cond_wait@@GLIBC_2.3.2\n#0 0x7f00 in ??? ()\n"
+        text = ("guest-bt-native: 0x00007f00 in pthread_cond_wait@@GLIBC_2.3.2\n"
+                "#0 0x7f00 in ??? ()\n#1 prosper::gpu::present\n")
         self.assertEqual(HANG_PROBE.classify(text),
                          ("UNKNOWN", "0x00007f00 in pthread_cond_wait@@GLIBC_2.3.2"))
 

--- a/prosper/tools/hang_probe/test_hang_probe.py
+++ b/prosper/tools/hang_probe/test_hang_probe.py
@@ -53,7 +53,7 @@ class ClassificationTests(unittest.TestCase):
                          ("RUNNING", frame))
 
     def test_attach_frame_before_thread_switch_is_ignored(self):
-        text = ("0x00007f00 in pthread_cond_wait@@GLIBC_2.3.2 ()\n"
+        text = ("0x00007f00 in prosper::k_sema_wait()\n#1 prosper::gpu::present\n"
                 "guest-bt-native: 0x0000000410f4bb02 in ??\n#0 0x410f4bb02 in ??? ()\n")
         self.assertEqual(HANG_PROBE.classify(text),
                          ("RUNNING", "0x0000000410f4bb02 in ??"))

--- a/prosper/tools/hang_probe/test_hang_probe.py
+++ b/prosper/tools/hang_probe/test_hang_probe.py
@@ -40,6 +40,18 @@ class ClassificationTests(unittest.TestCase):
         self.assertEqual(HANG_PROBE.classify(text),
                          ("UNKNOWN", "0x00007f00 in pthread_cond_wait@@GLIBC_2.3.2"))
 
+    def test_decorated_glibc_waits_remain_unknown(self):
+        for name in ("__GI___clock_nanosleep", "__GI___poll", "__GI___select"):
+            with self.subTest(name=name):
+                frame = f"0x00007f00 in {name}"
+                text = f"guest-bt-native: {frame}\n#1 prosper::gpu::execute_ordered\n"
+                self.assertEqual(HANG_PROBE.classify(text), ("UNKNOWN", frame))
+
+    def test_non_wait_name_with_select_prefix_is_running(self):
+        frame = "0x0000000000442f85 in prosper::gpu::select_shader"
+        self.assertEqual(HANG_PROBE.classify(f"guest-bt-native: {frame}\n"),
+                         ("RUNNING", frame))
+
     def test_attach_frame_before_thread_switch_is_ignored(self):
         text = ("0x00007f00 in pthread_cond_wait@@GLIBC_2.3.2 ()\n"
                 "guest-bt-native: 0x0000000410f4bb02 in ??\n#0 0x410f4bb02 in ??? ()\n")


### PR DESCRIPTION
Refs #1214

## Failure scenario and contract

`hang_probe` classified healthy Evergate boots as `UNKNOWN` whenever Thread 1 was actively executing outside its small render-symbol allowlist. Live samples stopped in Prosper renderer helpers, libc allocation/string routines, RADV, and guest code, so the tool could not produce a usable hang-rate experiment.

A guest kernel wait remains decisive and must win over lower render frames. All evidence is scoped to the requested thread. A selected native frame is active work unless it is an actual host blocking operation, and active wake/signal/unlock/trylock operations remain running.

## Approach

- make `guest_bt` emit the native stop frame after switching to the requested thread
- ignore every attach-time frame before that selected-thread marker
- give guest `k_*_wait` and known native waits precedence over lower active-render symbols
- normalize decorated glibc names before exact blocking-operation matching
- retain the selected native frame as evidence for inconclusive results
- cover live Evergate frames, wrong-thread preambles, decorated waits, wait precedence, and active pthread operations

## Deliberately unaffected

- `BLOCKED`, `DEAD`, and `UNKNOWN` exit-code semantics are unchanged
- title execution, synchronization, rendering, and EOP delivery are untouched

## Risk

A CPU spin or renderer-driver call in a non-blocking frame is considered running, consistent with this tool's scope of detecting parked kernel-wait hangs. Recognized guest and native blocking operations take precedence to avoid masking the EOP deadlock family.

## Verification

Exact published head `99370e28c279480a28a6dbdd48e04baef9072905`:

- `python3 -m unittest tools.hang_probe.test_hang_probe tools.guest_bt.test_guest_bt -v` — 18/18 passed
- `python3 tools/hang_probe/hang_probe.py --dump /home/mattias800/repos/ps5ys/PPSA01885-app0 --boot-trace build-audit/boot_trace --runs 4 --wait 35` — BLOCKED=0, RUNNING=4, DEAD=0, UNKNOWN=0; exit 0
- live `guest_bt --thread 1` emitted `guest-bt-native` after selecting Thread 1
- `git diff --check origin/master...HEAD` — clean
