### PR TITLE
fix(hle): retain every non-coalesced completion

### DIFF
--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -508,7 +508,14 @@ namespace {
     // condvar a waiter is blocked on (the old raw-pointer scheme was a use-after-free: delete freed
     // the state while k_eq_wait sat in cv.wait on it). Delete marks `deleted` and wakes waiters; the
     // object dies when the last reference drops.
-    struct EqState { std::mutex m; std::condition_variable cv; std::deque<SceKEvent> ready; bool deleted = false; };
+    struct PendingEvent { SceKEvent event; bool coalescible; };
+    struct EqState {
+        std::mutex m;
+        std::condition_variable cv;
+        std::deque<PendingEvent> ready;
+        size_t coalescible_ready = 0;
+        bool deleted = false;
+    };
     PROSPER_HEAP_MUTEX(g_eq_mx);   // #707: heap-backed on macOS (std::mutex would land in the corrupted __DATA cluster)
     std::unordered_map<uint64_t, std::shared_ptr<EqState>> g_eqs;   // guest eq handle -> state
     struct FlipReg { uint64_t eq; int64_t ident; uint64_t udata; };
@@ -554,20 +561,29 @@ namespace {
         // EVERY completion delivered — two in-flight completions share (ident, filter) but carry
         // different request tags in data, and replacing one loses a completion forever.
         if (coalesce)
-            for (auto& q : s->ready)
-                if (q.ident == e.ident && q.filter == e.filter) {
+            for (auto& pending : s->ready) {
+                auto& q = pending.event;
+                if (pending.coalescible && q.ident == e.ident && q.filter == e.filter) {
                     // Timer / HR-timer (filter -7 / -15): ACCUMULATE expirations across coalesced fires so
                     // the delivered event carries expirations-since-last-read (kqueue EVFILT_TIMER). Other
                     // filters keep replace-in-place (vblank/flip: the newest event wins).
                     int64_t data = (e.filter == -7 || e.filter == -15) ? q.data + e.data : e.data;
                     q = e; q.data = data; s->cv.notify_all(); return;
                 }
+            }
         // Distinct coalesced (ident, filter) pairs are few; cap that level-style queue as a leak
-        // guard and shed the oldest event if it ever fires. coalesce=false is deliberately exempt:
-        // EOP and APR completions are count-sensitive, so dropping any occurrence loses guest work
-        // and can strand a semaphore consumer even though the producer fired every completion.
-        if (coalesce && s->ready.size() >= 64) s->ready.pop_front();
-        s->ready.push_back(e);
+        // guard and shed the oldest COALESCIBLE event if it ever fires. Count-sensitive EOP/APR
+        // entries may share this deque and must never be selected as overflow victims.
+        if (coalesce && s->coalescible_ready >= 64) {
+            auto oldest = std::find_if(s->ready.begin(), s->ready.end(),
+                                       [](const PendingEvent& p) { return p.coalescible; });
+            if (oldest != s->ready.end()) {
+                s->ready.erase(oldest);
+                s->coalescible_ready--;
+            }
+        }
+        s->ready.push_back({ e, coalesce });
+        s->coalescible_ready += coalesce;
         s->cv.notify_all();
     }
     void vblank_pump() {
@@ -848,7 +864,12 @@ HLE(k_eq_wait)   {   // (eq, SceKernelEvent* ev, int num, int* out, SceKernelUse
     }
     if (s->deleted && s->ready.empty()) { if (a3) *(int32_t*)P(a3) = 0; return 0x80020009ull; }  // deleted under us
     int n = 0; auto* ev = (SceKEvent*)P(a1);
-    while (n < num && !s->ready.empty()) { if (ev) ev[n] = s->ready.front(); s->ready.pop_front(); n++; }
+    while (n < num && !s->ready.empty()) {
+        if (ev) ev[n] = s->ready.front().event;
+        s->coalescible_ready -= s->ready.front().coalescible;
+        s->ready.pop_front();
+        n++;
+    }
     if (a3) *(int32_t*)P(a3) = n;
     if (evlog() && n > 0) fprintf(stderr, "[ev]   -> delivered %d ev(s) eq=0x%llx ra=eboot+0x%llx (ident=%lld filter=%d)\n",
         n, (unsigned long long)a0, (unsigned long long)((uint64_t)__builtin_return_address(0) - 0x400000000ull),

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -562,9 +562,11 @@ namespace {
                     int64_t data = (e.filter == -7 || e.filter == -15) ? q.data + e.data : e.data;
                     q = e; q.data = data; s->cv.notify_all(); return;
                 }
-        // Distinct (ident, filter) pairs are few; the cap is a leak guard only. If it ever fires,
-        // shed the OLDEST event — never the just-posted one.
-        if (s->ready.size() >= 64) s->ready.pop_front();
+        // Distinct coalesced (ident, filter) pairs are few; cap that level-style queue as a leak
+        // guard and shed the oldest event if it ever fires. coalesce=false is deliberately exempt:
+        // EOP and APR completions are count-sensitive, so dropping any occurrence loses guest work
+        // and can strand a semaphore consumer even though the producer fired every completion.
+        if (coalesce && s->ready.size() >= 64) s->ready.pop_front();
         s->ready.push_back(e);
         s->cv.notify_all();
     }

--- a/prosper/tests/test_equeue_events.cpp
+++ b/prosper/tests/test_equeue_events.cpp
@@ -112,15 +112,25 @@ int main() {
         CHECK(getcount(eq, 0, 0, 0, 0, 0) == kBurst,
               "non-coalesced EOP burst retains every completion beyond the generic queue cap");
 
-        std::vector<KEvent> burst(kBurst); int32_t bout = -1; uint32_t bcap = 50000;
+        // A later level-style event shares the deque but may evict only another coalescible entry,
+        // never one of the count-sensitive completions already beyond the generic cap.
+        trigger(eq, (uint64_t)kId, 0x5151, 0, 0, 0);
+        CHECK(getcount(eq, 0, 0, 0, 0, 0) == kBurst + 1,
+              "coalesced post after a completion burst does not evict a completion");
+
+        std::vector<KEvent> burst(kBurst + 1); int32_t bout = -1; uint32_t bcap = 50000;
         wait(eq, (uint64_t)(uintptr_t)burst.data(), burst.size(), (uint64_t)(uintptr_t)&bout,
              (uint64_t)(uintptr_t)&bcap, 0);
-        CHECK(bout == kBurst, "WaitEqueue returns every retained EOP completion");
+        CHECK(bout == kBurst + 1, "WaitEqueue returns every retained EOP completion plus user event");
         bool burst_shape = true;
-        for (const auto& bev : burst)
+        for (int i = 0; i < kBurst; i++) {
+            const auto& bev = burst[i];
             burst_shape &= bev.ident == kEop && bev.filter == -14 && bev.data == kEop &&
                            bev.udata == kEopUdata;
+        }
         CHECK(burst_shape, "every retained EOP completion preserves its event payload");
+        CHECK(burst.back().ident == kId && burst.back().filter == -11 && burst.back().udata == 0x5151,
+              "coalesced user event retains its payload after the completion burst");
     }
 
     // VideoOut flip event accessor (#394 F5): the producer stores the submitted flipArg raw in

--- a/prosper/tests/test_equeue_events.cpp
+++ b/prosper/tests/test_equeue_events.cpp
@@ -12,6 +12,7 @@
 #include <cstring>
 #include <chrono>
 #include <thread>
+#include <vector>
 
 using namespace prosper;
 
@@ -101,6 +102,25 @@ int main() {
         CHECK(gev.filter == -14, "EOP event filter == GraphicsCore (-14)");
         CHECK(gev.data == kEop, "EOP event data == id (sceGnmGetEqEventType semantics)");
         CHECK(gev.udata == kEopUdata, "EOP event echoed the registered udata");
+
+        // Count-sensitive completion sources use coalesce=false: every trigger must survive until
+        // the guest consumes it. A generic queue leak cap must not silently discard older EOPs.
+        constexpr int kBurst = 80;
+        for (int i = 0; i < kBurst; i++) prosper_eq_trigger_eop();
+        for (int i = 0; i < 50 && getcount(eq, 0, 0, 0, 0, 0) != kBurst; i++)
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        CHECK(getcount(eq, 0, 0, 0, 0, 0) == kBurst,
+              "non-coalesced EOP burst retains every completion beyond the generic queue cap");
+
+        std::vector<KEvent> burst(kBurst); int32_t bout = -1; uint32_t bcap = 50000;
+        wait(eq, (uint64_t)(uintptr_t)burst.data(), burst.size(), (uint64_t)(uintptr_t)&bout,
+             (uint64_t)(uintptr_t)&bcap, 0);
+        CHECK(bout == kBurst, "WaitEqueue returns every retained EOP completion");
+        bool burst_shape = true;
+        for (const auto& bev : burst)
+            burst_shape &= bev.ident == kEop && bev.filter == -14 && bev.data == kEop &&
+                           bev.udata == kEopUdata;
+        CHECK(burst_shape, "every retained EOP completion preserves its event payload");
     }
 
     // VideoOut flip event accessor (#394 F5): the producer stores the submitted flipArg raw in


### PR DESCRIPTION
Refs #1214
Refs #1113

## Failure scenario and contract

`eq_post(..., coalesce=false)` represents count-sensitive EOP and APR completions: every post must remain available until the guest consumes it. The shared equeue nevertheless applied its generic 64-entry leak cap and dropped the oldest event on overflow. An 80-pulse EOP regression on current master retained exactly 64 events, so a burst can lose a completion and strand the guest semaphore consumer even though every producer pulse fired.

The queue mixes source types. A later coalesced user/timer event must not evict an older completion merely because the total deque length exceeds the coalesced-source cap.

## Approach

Track whether each pending entry is coalescible and separately count that subset. The 64-entry leak cap applies only to coalescible entries and evicts the oldest member of that subset; count-sensitive entries remain ordered and lossless. The regression queues 80 EOPs followed by one user event and verifies all 81 entries and payloads.

## Deliberately unaffected

- coalescing by `(ident, filter)` is unchanged
- the generic cap still bounds coalescible distinct-source entries
- EOP scheduling, ordering, registration, and payload shape are unchanged
- no renderer or title-specific behavior is introduced

## Risk

A guest that produces count-sensitive completions without ever consuming them can grow that subset beyond 64 entries. Dropping those entries is not a safe pressure policy because each one retires distinct guest work; the existing consumers require exact cardinality. Each queued event now carries one coalescibility flag and `EqState` carries its subset count.

## Verification

Exact published head `32e2248f6e5428d4086dc91e79efb20c6ef44c3f` against live master `62cb8e0ba69043ae0cae7cdaf47eb12abe8869a8`:

- pre-fix regression on master: 80-pulse EOP burst retained exactly 64 events; three assertions failed; exit 1
- corrected mixed-source regression: 80 EOP + 1 user event returned all 81 entries with intact payloads
- `ctest --test-dir build-audit --output-on-failure -j2` — 146/146 passed
- rebuilt live Evergate `hang_probe.py ... --runs 8 --wait 35` — BLOCKED=0, RUNNING=8, DEAD=0, UNKNOWN=0; exit 0
- remote branch equals verified local head
- `git diff --check origin/master...HEAD` — clean
