### PR TITLE
fix(gpu): render Cobra material loops and retain Float32 textures

### DIFF
--- a/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
+++ b/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
@@ -53,13 +53,39 @@ resolution. Its key includes a copy of the decoded shader bytes, so same-address
 detected. It is bounded to 64 MiB by default and can be disabled with
 `PROSPER_NO_SHADER_DECODE_CACHE=1`.
 
-The persistent texture cache now covers guest-backed linear/tiled 2D sampled `Unorm8` textures with
-1-4 components and BC1-BC7 textures. It excludes render targets, storage images, cube/volume and DCC
-surfaces, captured host backing, and unsupported formats. Every hit validates the complete native,
-padded-tiled, or compressed-block source range, so address reuse and in-place mutation invalidate the
-entry. Its default 1 GiB budget covers Evergate's measured 835 MiB decoded working set. Disable it with
-`PROSPER_NO_TEXTURE_DECODE_CACHE=1`; the budget is controlled by
+The persistent texture cache now covers guest-backed linear/tiled 2D sampled `Unorm8`, `Float16`, and
+`Float32` textures with supported component counts, plus BC1-BC7 textures. It excludes render targets,
+storage images, cube/volume and DCC surfaces, captured host backing, and unsupported formats. Every hit
+validates the complete native, padded-tiled, or compressed-block source range, so address reuse and
+in-place mutation invalidate the entry. Its default 1 GiB budget covers Evergate's measured 835 MiB
+decoded working set. Disable it with `PROSPER_NO_TEXTURE_DECODE_CACHE=1`; the budget is controlled by
 `PROSPER_TEXTURE_DECODE_CACHE_MB`.
+
+## Cobra Float32 sampled-texture retention (2026-07-25)
+
+Cobra's title and cinematic repeatedly sample large guest-backed Float32 post-process inputs. The live
+renderer narrowed each one to RGBA16F on every callback even when its exact source bytes were unchanged;
+these were the largest frontend CPU cost and also forced a fresh backend image upload. Float32 2D inputs
+now use the existing exact-content cache. The key retains the complete descriptor shape, validation counts
+the 4-byte source components, and a cache hit restores the native RGBA16F backend format. Existing guest
+CPU/GPU write tracking and exact-byte fallback still invalidate changed versions.
+
+One Linux/Radeon 8060S binary, the same scripted route, native 1920x1080 output, audio enabled, and rolling
+25-submit windows produced:
+
+| Measurement | Float32 uncached | Float32 retained |
+|---|---:|---:|
+| Title frames reached at 45 seconds | 744 (16.5 FPS) | 1,178 (26.2 FPS) |
+| Matched cinematic draws / submit | 28.7 | 30.7 |
+| Cinematic whole submit | 142.8 ms | 46.5 ms |
+| Cinematic resource construction | 63.5 ms | 4.5 ms |
+| Matched dense draws / submit | 374.8 | 380.8 |
+| Dense whole submit | 418.2 ms | 279.1 ms |
+| Dense resource construction | 133.1 ms | 82.8 ms |
+
+The dense route retained 141 decoded versions / 910.8 MiB, below the existing 1 GiB bound. Backend draw
+setup and synchronous color-target readbacks remain the largest gameplay costs; this tranche does not
+claim a playable frame budget.
 
 ## Evergate native-render transition (2026-07-18)
 

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -1017,6 +1017,14 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         const bool persistent_fp16_texture =
                             r.format == prosper::gpu::DataFormat::Float16 &&
                             (r.num_components == 1 || r.num_components == 2 || r.num_components == 4);
+                        // Float32 sampled textures narrow to RGBA16F below. Like the existing fp16 path,
+                        // the decoded result is fully determined by the exact source bytes and descriptor
+                        // shape, so immutable versions can use the same validated cross-submit cache.
+                        // This matters for titles that repeatedly bind large Float32 post-process inputs:
+                        // otherwise every callback re-detiles and scalar-narrows the complete surface.
+                        const bool persistent_fp32_texture =
+                            r.format == prosper::gpu::DataFormat::Float32 &&
+                            (r.num_components == 1 || r.num_components == 2 || r.num_components == 4);
                         // Real source bytes per texel. It also determines the pitch of a guest-backed
                         // linear sampled image: GFX10 aligns those rows to 256 bytes independently of
                         // component count (e.g. a 1920-wide R8 video chroma plane has a 2048-byte row).
@@ -1038,6 +1046,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             !has_live_rtt && !r.host_data && r.img_dim == 1u &&
                             r.cls == RC::Texture &&
                             (persistent_unorm8_texture || persistent_fp16_texture ||
+                             persistent_fp32_texture ||
                              persistent_bc_block_bytes != 0);
                         const bool persistent_source_is_tiled =
                             persistent_sampled_texture && !getenv("PROSPER_NODETILE") &&
@@ -1080,9 +1089,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                           bw, bh, persistent_bc_block_bytes, r.tile_mode)
                                     : static_cast<size_t>(bw) * bh * persistent_bc_block_bytes;
                             }
-                            // fp16 source is 2 B/component; unorm8 is 1 B/component.
-                            const uint32_t source_bpt =
-                                r.num_components * (persistent_fp16_texture ? 2u : 1u);
+                            // fp32/fp16 sources are 4/2 B per component; unorm8 is 1 B/component.
+                            const uint32_t source_component_bytes = persistent_fp32_texture ? 4u
+                                : (persistent_fp16_texture ? 2u : 1u);
+                            const uint32_t source_bpt = r.num_components * source_component_bytes;
                             if (persistent_source_is_tiled)
                                 return prosper::gpu::tiled_surface_bytes(
                                     tw, th, r.tile_mode, persistent_pitch, source_bpt);
@@ -1314,6 +1324,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             fr.th = decoded_reuse->output_height;
                             fr.td = is_volume ? r.depth : 1u;
                             fr.img_dim = r.img_dim;
+                            if (sampled_source_f32)
+                                fr.texture_format = VK_FORMAT_R16G16B16A16_SFLOAT;
                             // #1272: plain 2D guest textures only — cube outputs stack 6 faces into
                             // one 2D image (fr.th != th), and volumes keep their own path; generated
                             // mips across face/slice boundaries would bleed.

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -2958,8 +2958,10 @@ bool instruction_may_change_exec(const Rdna2Inst& in) {
 // branch as per-invocation structured control flow is exact only when the VCC producer is provably
 // uniform across the wave. Dead Cells' light loops use the narrow compiler shape
 //   v_cvt_i32_f32 vBOUND, sBOUND; ...; v_cmp_* vcc, sCOUNTER, vBOUND; s_cbranch_vccz EXIT
-// so every active lane makes the same comparison. Keep the proof deliberately local and reject a
-// varying/unresolved VGPR bound rather than silently changing wave semantics.
+// so every active lane makes the same comparison. Unity also derives the bound through a short
+// lane-local VALU chain fed only by scalar sources. Trace that chain backwards: uniform inputs stay
+// uniform through ordinary VOP1/VOP2 arithmetic, while lane permutations, VCC-dependent selects,
+// carry chains, interpolants, and unresolved VGPR inputs remain rejected.
 // True when `in` provably cannot overwrite VCC — used by vcc_exit_is_wave_uniform's compare-finding
 // walk (#590) to look past instructions scheduled between the VOPC and its consuming branch (real
 // UE4 compute kernels hoist ~15 unrelated ALU ops in between). Anything not provably safe stops the
@@ -3022,37 +3024,43 @@ bool vcc_exit_is_wave_uniform(const std::vector<Rdna2Inst>& ins, uint32_t branch
     }
     if (!compare || compare->fmt != Rdna2Format::VOPC || vopc_is_cmpx(compare->opcode)) return false;
 
-    auto uniform_operand = [&](const Operand& operand) -> bool {
-        if (operand.kind == OperandKind::SGPR || operand.kind == OperandKind::InlineInt ||
-            operand.kind == OperandKind::InlineFloat || operand.kind == OperandKind::Literal)
-            return true;
+    std::function<bool(const Operand&, uint32_t)> uniform_operand_at;
+    uniform_operand_at = [&](const Operand& operand, uint32_t use_pc) -> bool {
+        if (operand.kind == OperandKind::SGPR || operand.kind == OperandKind::Special ||
+            operand.kind == OperandKind::InlineInt || operand.kind == OperandKind::InlineFloat ||
+            operand.kind == OperandKind::Literal)
+            return true; // scalar-register sources (including VCC halves) broadcast one wave value
         if (operand.kind != OperandKind::VGPR) return false;
         for (auto it = ins.rbegin(); it != ins.rend(); ++it) {
-            if (it->pc >= compare->pc) continue;
+            if (it->pc >= use_pc) continue;
             const uint32_t writes = vgpr_write_count(*it);
             if (!writes || operand.value < it->dst.value ||
                 operand.value >= it->dst.value + (int32_t)writes) continue;
-            const bool uniform_unary = it->fmt == Rdna2Format::VOP1 &&
-                (it->opcode == 0x01 || (it->opcode >= 0x05 && it->opcode <= 0x08));
-            const bool uniform_definition = it->dst.value == operand.value && uniform_unary &&
-                !it->has_modifier && !it->has_dpp && it->sdwa_dst_sel == 6 &&
-                it->sdwa_src0_sel == 6 && it->n_src == 1 &&
-                (it->src[0].kind == OperandKind::SGPR ||
-                 it->src[0].kind == OperandKind::InlineInt ||
-                 it->src[0].kind == OperandKind::InlineFloat ||
-                 it->src[0].kind == OperandKind::Literal);
-            if (!uniform_definition) return false;
-            // The write makes every currently active lane uniform. It remains so only while EXEC is
-            // unchanged; a later widen could reactivate lanes that retained an older varying value.
+            if (it->dst.value != operand.value || it->has_dpp) return false;
+            // The write makes every currently active lane uniform. Keep the original conservative
+            // EXEC rule: any later mask change could expose a lane that retained an older value.
             for (const auto& between : ins)
                 if (between.pc > it->pc && between.pc < compare->pc &&
                     instruction_may_change_exec(between)) return false;
+
+            bool pure_lane_alu = false;
+            if (it->fmt == Rdna2Format::VOP1) {
+                pure_lane_alu = it->n_src == 1;
+            } else if (it->fmt == Rdna2Format::VOP2) {
+                // v_cndmask consumes VCC; the carry family consumes/produces VCC. Neither preserves
+                // scalar-source uniformity as a simple lane-local expression.
+                pure_lane_alu = it->n_src == 2 && it->opcode != 0x01 &&
+                    (it->opcode < 0x28 || it->opcode > 0x2a);
+            }
+            if (!pure_lane_alu) return false;
+            for (uint32_t i = 0; i < it->n_src; ++i)
+                if (!uniform_operand_at(it->src[i], it->pc)) return false;
             return true;
         }
         return false;
     };
     for (uint32_t i = 0; i < compare->n_src; ++i)
-        if (!uniform_operand(compare->src[i])) return false;
+        if (!uniform_operand_at(compare->src[i], compare->pc)) return false;
     return compare->n_src != 0;
 }
 

--- a/prosper/tests/test_gpu_capture_render.cpp
+++ b/prosper/tests/test_gpu_capture_render.cpp
@@ -336,6 +336,50 @@ int main() {
             CHECK(!changed_bc.empty() && changed_bc != reused_bc,
                   "guest BC mutation publishes newly decoded pixels instead of stale cache data");
 #endif
+
+            // Cobra repeatedly binds guest-backed Float32 post-process inputs. They narrow to
+            // RGBA16F, but an unchanged version should retain both that conversion and its backend
+            // image just like BC/fp16 textures do.
+            float* float_source = reinterpret_cast<float*>(source_va + 0x1000);
+            const float float_values[16] = {
+                0.5f, 0.25f, 0.125f, 1.0f, 0.5f, 0.25f, 0.125f, 1.0f,
+                0.5f, 0.25f, 0.125f, 1.0f, 0.5f, 0.25f, 0.125f, 1.0f,
+            };
+            std::memcpy(float_source, float_values, sizeof(float_values));
+            DrawItem cached_float_draw = replay.items[0];
+            cached_float_draw.color0_base = 0xd80000;
+            auto cached_float_table =
+                std::make_shared<ShaderResourceTable>(*cached_float_draw.prt);
+            ShaderResource& cached_float_resource = cached_float_table->resources[0];
+            cached_float_resource.gpu_addr = reinterpret_cast<uint64_t>(float_source);
+            cached_float_resource.host_data = nullptr;
+            cached_float_resource.host_data_size = 0;
+            cached_float_resource.size = sizeof(float_values);
+            cached_float_resource.width = cached_float_resource.height = 2;
+            cached_float_resource.depth = 1;
+            cached_float_resource.img_dim = 1;
+            cached_float_resource.tile_mode = 0;
+            cached_float_resource.linear_row_pitch_bytes = 2u * 4u * sizeof(float);
+            cached_float_resource.format = DataFormat::Float32;
+            cached_float_resource.num_components = 4;
+            cached_float_resource.compression_enabled = false;
+            cached_float_draw.prt = std::move(cached_float_table);
+
+            const std::vector<uint8_t> first_float =
+                render_submit_items({cached_float_draw}, W, H);
+            const auto first_float_stats = prosper::test::backend_texture_upload_stats();
+            const std::vector<uint8_t> reused_float =
+                render_submit_items({cached_float_draw}, W, H);
+            const auto reused_float_stats = prosper::test::backend_texture_upload_stats();
+            CHECK(first_float_stats.persistent_misses == 1 &&
+                      first_float_stats.unique_uploads == 1,
+                  "first guest-backed Float32 version enters the persistent texture cache");
+            CHECK(reused_float_stats.persistent_hits == 1 &&
+                      reused_float_stats.unique_uploads == 0 &&
+                      reused_float_stats.upload_bytes == 0,
+                  "unchanged Float32 texture skips its next narrow/decode/upload callback");
+            CHECK(!first_float.empty() && first_float == reused_float,
+                  "persistent Float32 reuse preserves the native RGBA16F sampling result");
             CHECK(unmap(source_va, source_mapping_size, 0, 0, 0, 0) == 0,
                   "persistent BC test unmaps its guest source");
         }

--- a/prosper/tests/test_recompile_coverage.cpp
+++ b/prosper/tests/test_recompile_coverage.cpp
@@ -271,11 +271,11 @@ int main() {
     };
     CHECK(!recompile_valu(compute_vcc_loop, sizeof(compute_vcc_loop)/sizeof(compute_vcc_loop[0]), 0, 0).empty(),
           "a proven-uniform VCCZ-exit loop structurizes in the compute shell (#590)");
-    // The SAME loop with v1 defined from a VGPR (`v_mov_b32 v1, v0`) fails the uniform-VOP1-from-
-    // scalar proof clause: the compare can no longer be proven wave-uniform, so compute still
-    // rejects it loudly (a varying trip count needs a real wave reduction).
+    // The SAME loop with v1 defined from an unresolved VGPR (`v_mov_b32 v1, v2`) cannot prove the
+    // compare wave-uniform, so compute still rejects it loudly (a varying trip count needs a real
+    // wave reduction). Do not use v0 here: the preceding `v_mov_b32 v0, 0` makes that chain uniform.
     const uint32_t compute_vcc_loop_varying[] = {
-        0xBE800380u, 0x7E000280u, 0x7E020300u, 0x7D020200u, 0xBF860004u,
+        0xBE800380u, 0x7E000280u, 0x7E020302u, 0x7D020200u, 0xBF860004u,
         0x060000FFu, 0x3E800000u, 0x81008100u, 0xBF82FFFAu, 0xBF810000u,
     };
     CHECK(recompile_valu(compute_vcc_loop_varying,

--- a/prosper/tests/test_recompiled_fragment.cpp
+++ b/prosper/tests/test_recompiled_fragment.cpp
@@ -462,6 +462,11 @@ int main() {
         };
         CHECK(!recompile_fragment(scalar_chain_ps, std::size(scalar_chain_ps)).empty(),
               "a scalar-fed VOP chain is accepted as a uniform VCC-loop bound");
+        uint32_t varying_chain_ps[std::size(scalar_chain_ps)];
+        std::copy(std::begin(scalar_chain_ps), std::end(scalar_chain_ps), varying_chain_ps);
+        varying_chain_ps[1] = 0x7E020302u;  // v1 = unresolved lane-varying v2 before the same chain
+        CHECK(recompile_fragment(varying_chain_ps, std::size(varying_chain_ps)).empty(),
+              "a lane-varying input remains rejected through the VOP chain");
 
         uint32_t varying_ps[sizeof(ps)/sizeof(ps[0])];
         std::copy(std::begin(ps), std::end(ps), varying_ps);

--- a/prosper/tests/test_recompiled_fragment.cpp
+++ b/prosper/tests/test_recompiled_fragment.cpp
@@ -450,6 +450,19 @@ int main() {
             }
         }
 
+        // Cobra's Unity material PS derives its loop bound through scalar-fed VOP2 + VOP1 before
+        // comparing it with the scalar counter. The resulting VGPR is still wave-uniform.
+        const uint32_t scalar_chain_ps[] = {
+            0xBE800380u, 0x7E020284u,            // s0 = 0; v1 = scalar constant 4
+            0x4A020281u,                         // lane-local VOP2 v1 = v1 + 1
+            0x7E021101u,                         // lane-local VOP1 v1 = f32(v1)
+            0x7D020200u, 0xBF860002u,           // v_cmp_* vcc,s0,v1; vccz -> exit
+            0x81008100u, 0xBF82FFFCu,           // ++s0; back to compare
+            0x7E0002F2u, 0xF800180Fu, 0x00000000u, 0xBF810000u,
+        };
+        CHECK(!recompile_fragment(scalar_chain_ps, std::size(scalar_chain_ps)).empty(),
+              "a scalar-fed VOP chain is accepted as a uniform VCC-loop bound");
+
         uint32_t varying_ps[sizeof(ps)/sizeof(ps[0])];
         std::copy(std::begin(ps), std::end(ps), varying_ps);
         varying_ps[2] = 0x7E020302u;  // v_mov_b32 v1,v2: a lane-varying/unproven loop bound


### PR DESCRIPTION
## What changed

- prove scalar-fed VOP1/VOP2 chains wave-uniform when structuring VCCZ material loops
- retain exact-validated guest Float32 sampled textures as RGBA16F across callbacks
- add positive and negative shader-structure coverage plus a Vulkan cache/reuse regression
- document the matched Cobra performance profile

## Root cause

Cobra's Unity material fragment shaders derive a light-loop bound through a short lane-local VALU chain fed only by scalar sources. The structurizer only recognized a direct scalar-to-VGPR unary definition, rejected the otherwise uniform loop, and dropped the affected material draws. The resulting frame contained corrupted-looking partial geometry.

Once those draws rendered, large guest Float32 post-process inputs were narrowed and uploaded again on every callback even when their exact source bytes were unchanged.

## Impact

Cobra now renders coherent title/cinematic/gameplay scenes with clean audio. On the measured Linux/Radeon 8060S route:

- title progression at 45 seconds: 744 -> 1,178 frames (16.5 -> 26.2 FPS)
- matched cinematic submit: 142.8 -> 46.5 ms
- matched dense submit: 418.2 -> 279.1 ms

Dense gameplay remains backend-limited and is not yet a playable frame budget.

## Validation

- full CTest suite: 153/153 passed
- focused shader/replay tests passed
- 405-second native 1920x1080 Cobra route completed with 27 distinct checkpoints
- gameplay visuals remained coherent through effects, dialogue, and combat
- 60-second tail audio analysis: CLEAN, 0.0% duplicate grains