### PR TITLE
fix(gpu): sample read-only attached depth

### DIFF
--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -2440,6 +2440,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     bool depth_was_valid = false, stencil_was_valid = false;
     bool depth_used_meaningfully = false;
     bool depth_may_be_written = false;
+    bool stencil_may_be_written = false;
     for (const auto& d : draws) {
         if (!d.ps) continue;
         depth_used_meaningfully |= effective_depth_clear(d.ps) || d.ps->depth_write_enable ||
@@ -2448,6 +2449,14 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         depth_may_be_written |= persistent_ds_pass_may_write_depth(
             d.ps->depth_clear_enable, d.ps->depth_test_enable, d.ps->depth_write_enable,
             d.ps->depth_compare_op);
+        stencil_may_be_written |= stencil_clear_effective(
+            d.ps->stencil_clear_enable, d.ps->stencil_enable,
+            d.ps->stencil_write_mask[0], d.ps->stencil_write_mask[1]);
+        // Keep the layout decision conservative: Vulkan validates attachment writability from
+        // pipeline state, and a nonzero guest write mask leaves the aspect writable even when this
+        // draw happens to program KEEP for every outcome.
+        stencil_may_be_written |= d.ps->stencil_enable &&
+            (d.ps->stencil_write_mask[0] != 0u || d.ps->stencil_write_mask[1] != 0u);
     }
     PersistentDsImage* cached_ds = nullptr;
     PersistentDsKey ds_key{};
@@ -2468,6 +2477,31 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         depth_was_valid = cached_ds->depth_valid;
         stencil_was_valid = cached_ds->stencil_valid;
     }
+    // A guest may sample the depth plane while that SAME surface remains attached for depth/stencil
+    // tests. Bendy's deferred-lighting and glow passes use read-only depth plus writable stencil in
+    // exactly this shape (#1186). The sampled-depth bridge used to reject it as feedback and upload
+    // zeros. Vulkan supports the hardware contract directly: keep depth read-only for both the
+    // attachment and shader view, while the stencil aspect may remain writable. Never enable the
+    // path when any draw in this render pass can write depth.
+    bool self_sampled_depth = false;
+    if (cached_ds && depth_was_valid && !depth_may_be_written) {
+        for (const auto& draw : draws) {
+            for (const auto& resource : draw.R) {
+                if (!resource.persistent_depth_target_id || resource.img_dim != 1u ||
+                    resource.tw != W || resource.th != H)
+                    continue;
+                if (find_persistent_ds_sampled(resource.persistent_depth_target_id,
+                                               resource.tw, resource.th).image == cached_ds) {
+                    self_sampled_depth = true;
+                    break;
+                }
+            }
+            if (self_sampled_depth) break;
+        }
+    }
+    const VkImageLayout self_depth_layout = format_has_stencil && stencil_may_be_written
+        ? VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL
+        : VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL;
     if (getenv("PROSPER_DSLOG")) {
         static uint64_t call_id = 0;
         const uint64_t id = ++call_id;
@@ -2700,14 +2734,19 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         : VK_ATTACHMENT_LOAD_OP_DONT_CARE;
     att[ds_attachment].stencilStoreOp = (persistent_ds && format_has_stencil)
         ? VK_ATTACHMENT_STORE_OP_STORE : VK_ATTACHMENT_STORE_OP_DONT_CARE;
-    att[ds_attachment].initialLayout = ds_layout_initialized
-        ? VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL : VK_IMAGE_LAYOUT_UNDEFINED;
+    att[ds_attachment].initialLayout = self_sampled_depth
+        ? self_depth_layout
+        : (ds_layout_initialized ? VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL
+                                 : VK_IMAGE_LAYOUT_UNDEFINED);
     att[ds_attachment].finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
     VkAttachmentReference ar[2] = {
         {0, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL},
         {1, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL},
     };
-    VkAttachmentReference dar{ds_attachment, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL};
+    VkAttachmentReference dar{
+        ds_attachment,
+        self_sampled_depth ? self_depth_layout
+                           : VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL};
     VkSubpassDescription sub{}; sub.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
     sub.colorAttachmentCount = color_count; sub.pColorAttachments = ar;
     if (use_ds) sub.pDepthStencilAttachment = &dar;
@@ -2782,6 +2821,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         // the DEPTH aspect of ds_format, and the call transitions the image DS-attachment ->
         // shader-read around its passes.
         bool borrowed_ds = false;
+        bool borrowed_ds_feedback = false; // same image is this pass's read-only depth attachment
         VkFormat ds_format = VK_FORMAT_UNDEFINED;
         bool direct_memory = false;
     };
@@ -3429,10 +3469,14 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                             r.persistent_depth_target_id && r.img_dim == 1) {
                             const PersistentDsSampled sampled_ds = find_persistent_ds_sampled(
                                 r.persistent_depth_target_id, r.tw, r.th);
+                            const bool same_pass_feedback = self_sampled_depth && cached_ds &&
+                                sampled_ds.image == cached_ds;
                             if (sampled_ds.image &&
-                                (!cached_ds || sampled_ds.image->image != cached_ds->image)) {
+                                (same_pass_feedback || !cached_ds ||
+                                 sampled_ds.image->image != cached_ds->image)) {
                                 upload.image = sampled_ds.image->image;
                                 upload.borrowed_ds = true;
+                                upload.borrowed_ds_feedback = same_pass_feedback;
                                 upload.ds_format = sampled_ds.format;
                             }
                         }
@@ -3717,8 +3761,12 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                         shared_texture_binding_indices.emplace(binding_key, binding_index);
                         ++resource_reuse_stats.unique_texture_bindings;
                     }
+                    const SharedTextureUpload& descriptor_upload = texture_uploads[upload_index];
                     const VkImageLayout image_layout = r.is_storage_image
-                        ? VK_IMAGE_LAYOUT_GENERAL : VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+                        ? VK_IMAGE_LAYOUT_GENERAL
+                        : descriptor_upload.borrowed_ds_feedback
+                            ? self_depth_layout
+                            : VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
                     dii[i] = {shared_texture_bindings[binding_index].sampler,
                               shared_texture_bindings[binding_index].view, image_layout};
                     wr[i] = {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET}; wr[i].dstBinding = r.binding; wr[i].descriptorCount = 1;
@@ -4319,13 +4367,38 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                              VK_PIPELINE_STAGE_VERTEX_SHADER_BIT | VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
                              0, 0, nullptr, 0, nullptr, 1, &b1);
     }
+    // Same-pass depth feedback (#1186): make prior attachment writes visible to the shader and
+    // enter the layout declared by both the sampled descriptor and this render pass. The render
+    // pass returns the image to DEPTH_STENCIL_ATTACHMENT_OPTIMAL at the end, preserving the cache
+    // contract for every later call. Include both aspects in the transition for D32S8; the mixed
+    // layout keeps depth read-only while allowing the stencil writes detected above.
+    if (self_sampled_depth) {
+        VkImageMemoryBarrier to_feedback{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
+        to_feedback.oldLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+        to_feedback.newLayout = self_depth_layout;
+        to_feedback.image = dimg;
+        to_feedback.subresourceRange = {DASPECT, 0, 1, 0, 1};
+        to_feedback.srcAccessMask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+        to_feedback.dstAccessMask = VK_ACCESS_SHADER_READ_BIT |
+                                    VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT |
+                                    (stencil_may_be_written
+                                         ? VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT : 0u);
+        vkCmdPipelineBarrier(cmd,
+                             VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT |
+                                 VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT,
+                             VK_PIPELINE_STAGE_VERTEX_SHADER_BIT |
+                                 VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT |
+                                 VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT |
+                                 VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT,
+                             0, 0, nullptr, 0, nullptr, 1, &to_feedback);
+    }
     // Sampled depth bridge (#1275): borrowed DS images live in DEPTH_STENCIL_ATTACHMENT_OPTIMAL
     // between passes. Transition each (once) to SHADER_READ_ONLY for this pass's sampling; the
     // matching post-pass barrier below returns it so the next depth pass LOADs it unchanged.
     // Both aspects of a combined image must transition together.
     std::vector<std::pair<VkImage, VkFormat>> borrowed_ds_images;
     for (const SharedTextureUpload& upload : texture_uploads) {
-        if (!upload.borrowed_ds || !upload.image) continue;
+        if (!upload.borrowed_ds || upload.borrowed_ds_feedback || !upload.image) continue;
         if (std::any_of(borrowed_ds_images.begin(), borrowed_ds_images.end(),
                         [&](const auto& entry) { return entry.first == upload.image; }))
             continue;

--- a/prosper/tests/test_shadow_compare_render.cpp
+++ b/prosper/tests/test_shadow_compare_render.cpp
@@ -316,6 +316,56 @@ int main() {
               "bridged consumer reads the produced depth (~0.25) from the persistent DS image");
         CHECK(center0[0] == 0, "control without the bridge samples zeros");
 
+        // #1186: Bendy samples its full-resolution scene depth while the same D32S8 surface is
+        // attached for read-only depth testing and writable stencil masking. The original bridge
+        // rejected that same-pass identity as feedback and silently substituted zeros, removing
+        // the deferred-lighting / lens-flare occlusion input. Exercise the harder mixed-layout
+        // case (depth sampled + read-only, stencil writable) end to end.
+        constexpr uint64_t kFeedbackDepth = 0x20d5800000ull;
+        constexpr uint64_t kFeedbackStencil = 0x20d5900000ull;
+        ResolvedPipelineState feedback_producer = producer;
+        feedback_producer.depth_read_base = kFeedbackDepth;
+        feedback_producer.depth_write_base = kFeedbackDepth;
+        feedback_producer.stencil_read_base = kFeedbackStencil;
+        feedback_producer.stencil_write_base = kFeedbackStencil;
+        feedback_producer.stencil_enable = true;
+        feedback_producer.stencil_compare_op[0] = feedback_producer.stencil_compare_op[1] = 7;
+        prosper::test::BackendDraw feedback_pw = pw;
+        feedback_pw.ps = &feedback_producer;
+        std::vector<uint8_t> feedback_produced = prosper::test::render_draws_rgba(
+            {feedback_pw}, W, H, nullptr, nullptr, /*persist_depth_stencil=*/true);
+        CHECK(!feedback_produced.empty(),
+              "depth producer rendered a persistent D32S8 feedback surface");
+
+        ResolvedPipelineState feedback_state{};
+        feedback_state.topology = 3; feedback_state.color_write_mask = 0xF;
+        feedback_state.depth_test_enable = true; feedback_state.depth_write_enable = false;
+        feedback_state.depth_compare_op = 7;   // read-only ALWAYS
+        feedback_state.depth_read_base = kFeedbackDepth;
+        feedback_state.depth_write_base = kFeedbackDepth;
+        feedback_state.stencil_read_base = kFeedbackStencil;
+        feedback_state.stencil_write_base = kFeedbackStencil;
+        feedback_state.stencil_enable = true;
+        feedback_state.stencil_compare_op[0] = feedback_state.stencil_compare_op[1] = 7;
+        feedback_state.stencil_pass_op[0] = feedback_state.stencil_pass_op[1] = 1; // ZERO
+        feedback_state.stencil_write_mask[0] = feedback_state.stencil_write_mask[1] = 0xff;
+        prosper::test::FrameResource feedback_resource = bridged;
+        feedback_resource.persistent_depth_target_id = kFeedbackDepth;
+        prosper::test::BackendDraw feedback_consumer = consumer;
+        feedback_consumer.ps = &feedback_state;
+        feedback_consumer.R = {feedback_resource};
+        std::vector<uint8_t> via_feedback = prosper::test::render_draws_rgba(
+            {feedback_consumer}, W, H, nullptr, nullptr, /*persist_depth_stencil=*/true);
+        CHECK(via_feedback.size() == (size_t)W * H * 4,
+              "same-pass depth-feedback consumer rendered");
+        if (via_feedback.size() == (size_t)W * H * 4) {
+            const uint8_t* feedback_center =
+                &via_feedback[(((size_t)H / 2) * W + W / 2) * 4];
+            printf("  same-pass feedback center R=%u (want ~64)\n", feedback_center[0]);
+            CHECK(feedback_center[0] > 56 && feedback_center[0] < 72,
+                  "same-pass consumer samples attached depth while stencil remains writable (#1186)");
+        }
+
         // ---- #1287: an ineffective clear draw must not shadow the rendered plane ----
         // Blue Prince's light loop: shadow casters render depth into plane P (identity dr=P, dw=0),
         // then a fullscreen rect with DB_RENDER_CONTROL.DEPTH_CLEAR_ENABLE set but DB_DEPTH_CONTROL


### PR DESCRIPTION
## Summary

- preserve a cached depth/stencil surface when a draw samples its depth plane while keeping that same surface attached
- use Vulkan's read-only-depth / writable-stencil mixed layout when the guest may update stencil
- retain the existing fail-visible zero fallback whenever any draw in the pass may write depth
- add an end-to-end D32S8 regression test covering depth sampling with writable stencil

## Why

Bendy uses its scene depth as both a sampled input and a read-only depth attachment during deferred-lighting and glow work. The sampled-depth bridge treated that identity as unsupported feedback and substituted a zero texture, which removed most of the lit scene. Vulkan can represent this contract directly as long as depth is not writable.

This restores the rendered world in the Bendy capture and live route. A separate screen-centered concentric-ring artifact remains, so this PR intentionally does **not** close #1186.

Refs #1164
Refs #1186

## Behavioral contract and risk

The new path is gated to cached depth surfaces that already contain valid depth and only when no draw in the render pass can write depth. For D32S8, depth is shader-readable while stencil remains attachment-writable when guest state can update it. Writable-depth feedback remains rejected. Non-feedback sampled-depth transitions are unchanged.

## Exact-head validation

Pushed head: `5aa91b82f9e2077c7476704453d9f7f9c6d2c97f` on master `c48b4a013f94fe814238b657ccbe76b444ea510a`.

- full local Release build — passed (152 steps/targets)
- `ctest --test-dir build-audit --output-on-failure -j2` — 146/146 passed
- `ctest --test-dir build-audit --output-on-failure -R shadow_compare_render` — passed; feedback sample R=64 (expected ~64)
- Khronos validation-layer focused run — passed with no VUID, validation error, or synchronization hazard
- Bendy capture replay — output hash changes from `a46d9a1d6ce0606c` to `efac4b6599cdd0c9`, restoring the lit hallway
- Bendy direct screenshot-frontend scripted route — 18 captures over 540 seconds, 17 pixel-distinct, status=ok; lit world restored and residual centered ring confirmed
- required CI — Linux, Linux App, Windows MinGW, Windows App, macOS, and macOS App all passed

### Snapshot matrix investigation

The full eight-scenario matrix completed: Messenger, Evergate title, Dead Cells gameplay, Blasphemous 2 gameplay, and Blue Prince title passed. Three current guards missed their thresholds and were investigated rather than treated as passing:

- Evergate gameplay: correct gameplay frames, 4/6 structural matches; isolated rerun reached 5/6. Diagnostic runs recorded **zero** sampled-depth bridge hits/declines, so this PR's changed path never activates.
- Terminator boot: correct intro/title progression, 8/16 structural matches; isolated reruns reached 10/16 and 8/16. Diagnostic runs recorded **zero** sampled-depth bridge hits/declines, so this PR's changed path never activates.
- Blue Prince hall: both exact PR head and a separate clean-worktree `master` control at `c48b4a01` produced the same opening-film state instead of the hall (0 qualifying/structural matches, eight capped bridge hits in each). The identical base failure proves this is a current-master route failure, not a #1408 regression.

No baselines or thresholds were changed.

## Review

Independent exact-head review approved `5aa91b82f9e2077c7476704453d9f7f9c6d2c97f`: https://github.com/mattias800/ps5ys/pull/1408#pullrequestreview-4780444821
