### PR TITLE
fix(hle): restore DOLL AMPR measure compatibility

### DIFF
--- a/prosper/docs/UE4_APR_IOSTORE_BRINGUP.md
+++ b/prosper/docs/UE4_APR_IOSTORE_BRINGUP.md
@@ -1217,3 +1217,27 @@ split to (a) **#288 — 64KB tile-mode detiling** (the noise) and (b) **#273 —
 draws). New diagnostic landed: `PROSPER_DUMP_TILERAW` (reusable for the #288 derivation). Messenger
 unaffected (mode 5 only; the diagnostic is gated + additive). CONFIDENCE: HIGH on the reframing (live
 frame + tile-mode histogram + descriptor dumps); the detiler itself is deliberately NOT shipped.
+
+### SOLVED (2026-07-26): cross-SDK AMPR measure compatibility after #1368
+
+The #1368 review changed `sSAUCCU1dv4` from the exact 20-byte
+`sceAmprMeasureCommandSizeWriteKernelEventQueue_04_00` result to a guessed 32-byte upper bound and
+made both AMPR measure calls pure. DOLL then stopped before its first present: the 32-byte return
+changed its command-buffer offsets, and its older SDK wrapper still consumes the two measure calls as
+eager compatibility operations while prosper does not execute the encoded commands.
+
+The shared contract is now explicit:
+
+- `sSAUCCU1dv4` always returns the exact 20-byte command size. A null queue is a pure Sonic sizing
+  query; DOLL's non-null queue/id pair also registers the APR completion source.
+- `vWU-odnS+fU` always returns 20 or 24 according to the file-offset width. An unregistered id is a
+  pure Sonic sizing query; a valid registered APR file id also performs DOLL's range-checked eager
+  read on both Linux and Windows.
+- `4fgtGfXDrFc` retains the independent 32-byte conservative size used by Sonic; A/B testing proved
+  it is not part of DOLL's regression.
+
+Live validation on current master plus the fix: first present at 2 seconds, Square Enix/Unreal/CRIWARE
+logos render, PCM is produced at 48 kHz stereo, the corrected title appears, and scripted Cross input
+advances into the new-game name entry. The same binary with the 32-byte equeue size remains at frame 0
+for at least 20 seconds. Focused tests cover the exact sizes, the pure unregistered query, and the
+registered eager-read discriminator.

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -2667,12 +2667,72 @@ extern "C" uint64_t f_apr_read_submit(uint64_t a0, uint64_t a1, uint64_t a2,
 }
 
 // libSceAmpr vWU-odnS+fU — sceAmprMeasureCommandSizeReadFile. The exact firmware contract returns
-// 20 bytes, or 24 when the file offset needs its high 32 bits. This is a pure sizing API on every
-// host: performing the older Linux-only compatibility read here made an allocation query mutate
-// guest memory and gave Windows different title-visible behavior. Encoded reads execute through
-// sceAmprAprCommandBufferReadFile instead.
+// 20 bytes, or 24 when the file offset needs its high 32 bits. DOLL's older SDK wrapper also relies
+// on this call to execute the described read immediately: it passes a valid APR file id and consumes
+// the destination before any encoded command buffer is submitted. Keep sizing-only calls pure by
+// requiring a registered id, while preserving that proven compatibility read on every host. The
+// return value is always the command size; an I/O failure must never become an allocation size.
 HLE(f_apr_measure_read_file) {
-    return (a3 >> 32) ? 24 : 20;
+    const uint64_t measured = (a3 >> 32) ? 24 : 20;
+    const std::string host = prosper_apr_path_for_id((uint32_t)a0);
+    if (host.empty() || a1 <= 0xffff || a2 == 0) {
+        if (filelog())
+            fprintf(stderr, "[apr] measure-read id=%llu -> %llu bytes (no compatibility read)\n",
+                    (unsigned long long)a0, (unsigned long long)measured);
+        return measured;
+    }
+
+    uint64_t file_size = 0;
+#ifndef _WIN32
+    struct stat st {};
+    if (::stat(host.c_str(), &st) == 0) file_size = (uint64_t)st.st_size;
+#else
+    struct _stat64 st {};
+    if (::_stat64(host.c_str(), &st) == 0) file_size = (uint64_t)st.st_size;
+#endif
+    if (a3 > file_size || a2 > file_size - a3 || a2 > (uint64_t)SIZE_MAX - 0xfff) {
+        if (filelog())
+            fprintf(stderr, "[apr] measure-read id=%llu range off=0x%llx size=%llu invalid\n",
+                    (unsigned long long)a0, (unsigned long long)a3,
+                    (unsigned long long)a2);
+        return measured;
+    }
+
+    bool copied = false;
+#ifndef _WIN32
+    const uint64_t rounded = (a2 + 0xfff) & ~0xfffull;
+    void* staging = mmap(nullptr, rounded, PROT_READ | PROT_WRITE,
+                         MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (staging != MAP_FAILED) {
+        const int fd = apr_cached_fd(host);
+        const ssize_t got = fd >= 0 ? ::pread(fd, staging, (size_t)a2, (off_t)a3) : -1;
+        copied = got == (ssize_t)a2 && apr_write_guest_dst(a1, staging, a2);
+        munmap(staging, rounded);
+    }
+#else
+    void* staging = ::malloc((size_t)a2);
+    if (staging) {
+        FILE* file = ::fopen(host.c_str(), "rb");
+        size_t got = 0;
+        if (file) {
+            if (_fseeki64(file, (__int64)a3, SEEK_SET) == 0)
+                got = ::fread(staging, 1, (size_t)a2, file);
+            ::fclose(file);
+        }
+        if (got == (size_t)a2 && windows_prepare_guest_write(a1, a2)) {
+            memcpy((void*)(uintptr_t)a1, staging, (size_t)a2);
+            copied = true;
+        }
+        ::free(staging);
+    }
+#endif
+    if (filelog())
+        fprintf(stderr, "[apr] measure-read compatibility id=%llu %s -> dst=0x%llx "
+                        "off=0x%llx size=%llu %s; measured=%llu\n",
+                (unsigned long long)a0, host.c_str(), (unsigned long long)a1,
+                (unsigned long long)a3, (unsigned long long)a2,
+                copied ? "OK" : "FAIL", (unsigned long long)measured);
+    return measured;
 }
 
 void register_file_hle() {

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -1378,12 +1378,11 @@ namespace {
 }
 HLE(k_ampr_measure_write_equeue) { // sSAUCCU1dv4 = sceAmprMeasureCommandSizeWriteKernelEventQueue_04_00
     ampr_arglog("sSAUCCU1dv4(MeasureWriteEqueue)", a0, a1, a2, a3, a4, a5);
-    // The guest uses this only to reserve its command buffer. A 32-byte record is the conservative
-    // firmware-compatible size; returning 20 risks under-allocation before the real builder runs.
-    // Registration belongs to sceAmprAprCommandBufferWriteKernelEventQueue below; keeping it here
-    // would make another pure size query title-visible and platform-dependent.
-    // CONFIDENCE: MED (Sonic allocation flow plus an independent implementation; no hardware trace).
-    return 32;
+    // DOLL's older SDK wrapper passes the live event queue and APR id here while constructing its
+    // listener. Until prosper executes the encoded command itself, preserve that registration as
+    // a compatibility side effect. Sonic's sizing call passes a null queue and remains pure.
+    if (a0) prosper_eq_add_apr(a0, (int64_t)a1);
+    return 20;
 }
 HLE(k_apr_cb_set_equeue) {       // H896Pt-yB4I (cb, eq, id, tag, 0, flags)
     ampr_arglog("H896Pt-yB4I(CbSetEqueue)", a0, a1, a2, a3, a4, a5);
@@ -1439,9 +1438,7 @@ HLE(k_ampr_get_current_offset) {
     return 0;
 }
 // Sonic Origins sums this result with the ReadFile and equeue sizes to reserve each AMPR command
-// buffer. Use the conservative 32-byte firmware-compatible record size; the earlier guessed
-// 8/12/16 encoding could under-allocate. CONFIDENCE: MED (guest allocation flow plus an independent
-// implementation; no hardware trace).
+// buffer. Use the conservative 32-byte firmware-compatible record size.
 HLE(k_ampr_measure_write_address) {
     ampr_arglog("4fgtGfXDrFc(MeasureWriteAddress)", a0, a1, a2, a3, a4, a5);
     return 32;
@@ -4252,7 +4249,7 @@ HLE(k_query_memory_protection) {
 // (PPSA17942, area:ue4) allocator pages remain no-op stubs because that title does not boot on
 // Windows yet. Pure size/offset queries below keep their platform-independent return contracts.
 HLE(k_ampr_ok) { return 0; }
-HLE(k_ampr_measure_write_equeue) { return 32; }
+HLE(k_ampr_measure_write_equeue) { return 20; }
 HLE(k_ampr_get_current_offset) { return 0; }
 HLE(k_ampr_measure_write_address) { return 32; }
 

--- a/prosper/tests/test_ampr_measure.cpp
+++ b/prosper/tests/test_ampr_measure.cpp
@@ -1,6 +1,6 @@
 // Regression guard for the libSceAmpr command-size NIDs used by Sonic Origins. These functions
-// return byte counts, not status codes: treating MeasureReadFile as a real read returned EINVAL for
-// a sizing-only call, and the guest used 0x80020016 as an allocation size.
+// return byte counts, not status codes. A sizing-only call must remain pure, while DOLL's older SDK
+// wrapper passes a registered APR id and relies on the same entry point to fill its destination.
 #include "../src/hle/dispatch.hpp"
 #include <array>
 #include <cstdint>
@@ -34,8 +34,8 @@ int main() {
               "write-address size does not under-allocate for a wide value");
     }
     if (write_equeue)
-        CHECK(write_equeue(0, 0, 0, 0, 0, 0) == 32,
-              "kernel-equeue command reserves the conservative 32-byte record");
+        CHECK(write_equeue(0, 0, 0, 0, 0, 0) == 20,
+              "kernel-equeue command measures 20 bytes");
     if (read_file) {
         CHECK(read_file(0, 0, UINT32_MAX, 0xffffffffffull, 0, 0) == 24,
               "wide-offset read command measures 24 bytes (never EINVAL)");
@@ -51,14 +51,18 @@ int main() {
             fixture_written = written == fixture.size() && closed;
         }
         prosper_apr_reset_for_test();
-        const uint32_t id = prosper_apr_register(fixture_path, fixture.size());
         std::array<uint8_t, 4> destination = {0xA1, 0xB2, 0xC3, 0xD4};
         const auto before = destination;
+        CHECK(read_file(0, (uint64_t)(uintptr_t)destination.data(), destination.size(),
+                        0, 0, 0) == 20 &&
+                  destination == before,
+              "unregistered read-file measurement is a pure query");
+        const uint32_t id = prosper_apr_register(fixture_path, fixture.size());
         CHECK(fixture_written &&
                   read_file(id, (uint64_t)(uintptr_t)destination.data(), destination.size(),
                             0, 0, 0) == 20 &&
-                  destination == before,
-              "read-file measurement is a pure query and never writes guest memory");
+                  destination == fixture,
+              "registered read-file measurement preserves the DOLL compatibility read");
         prosper_apr_reset_for_test();
         std::remove(fixture_path);
     }


### PR DESCRIPTION
## Summary
- restore the exact 20-byte AMPR equeue command-size contract and DOLL event registration side effect
- preserve DOLL eager APR reads only for registered file ids while keeping Sonic sizing queries pure
- add cross-title regression coverage and update the DOLL bring-up notes

## Validation
- full distrobox build
- ctest: 153/153 passed
- DOLL live run: first present at 2s, title reached, new-game name entry reached
- stereo float32 PCM produced at 48 kHz throughout the run
- A/B: 32-byte equeue result stalls at frame 0; exact 20-byte result advances past title

## Scope
The 32-byte write-address measurement remains unchanged; A/B testing exonerated it.