### PR TITLE
renderer: split attached-depth feedback phases

### DIFF
--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -2342,6 +2342,11 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         : 0;
     const uint32_t color_count = use_color1 ? 2u : 1u;
     const uint32_t ds_attachment = color_count;
+    // A feedback split is a physical Vulkan detail, not a guest draw-pass boundary. Attachment
+    // identity/format and fresh-image fallback values therefore come from the original logical
+    // span. Segment-local use/write/layout decisions and explicit clears remain local below.
+    const std::span<const BackendDraw> logical_draws = logical_ds_draws.empty()
+        ? draws : logical_ds_draws;
     // Depth attachment is created if ANY draw enables the depth test (the shared render pass has one
     // fixed attachment set); each draw's pipeline sets its own depthTest/Write/CompareOp. A frame with
     // no depth-using draw takes the color-only path unchanged.
@@ -2362,7 +2367,15 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     };
     for (const auto& d : draws) {
         if (!d.ps) continue;
-        if (d.ps->depth_test_enable || effective_depth_clear(d.ps)) { use_depth = true;
+        if (d.ps->depth_test_enable || effective_depth_clear(d.ps)) use_depth = true;
+        if (d.ps->stencil_enable ||
+            stencil_clear_effective(d.ps->stencil_clear_enable, d.ps->stencil_enable,
+                                    d.ps->stencil_write_mask[0], d.ps->stencil_write_mask[1]))
+            use_stencil = true;
+    }
+    for (const auto& d : logical_draws) {
+        if (!d.ps) continue;
+        if (d.ps->depth_test_enable || effective_depth_clear(d.ps)) {
             // DB_DEPTH_CLEAR is only consumed when DB_RENDER_CONTROL requests an actual clear. Merely
             // programming the register does not initialize a newly-created host depth image: it is
             // commonly stale state, and Astro Bot even leaves the packed 1920x1080 max coordinates
@@ -2388,7 +2401,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                                d.ps->depth_compare_op == VK_COMPARE_OP_GREATER_OR_EQUAL)
                     ? 0.0f : 1.0f;
                 got_depth_clear = true;
-            } }
+            }
+        }
         // #1355: like the depth gate above, a STENCIL_CLEAR_ENABLE bit with the stencil write
         // path disabled is inert and must not force a stencil attachment or clear in-pass. The
         // initial-value latch stays reachable through stencil_enable only, mirroring the depth
@@ -2396,7 +2410,6 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         if (d.ps->stencil_enable ||
             stencil_clear_effective(d.ps->stencil_clear_enable, d.ps->stencil_enable,
                                     d.ps->stencil_write_mask[0], d.ps->stencil_write_mask[1])) {
-            use_stencil = true;
             // Mirror the depth contract (#371/#508 via #1361): DB_STENCIL_CLEAR is consumed as a
             // fresh image's initial contents only when the guest explicitly requests a clear.
             // Latching it from every stencil-using draw let a STALE register word poison a new
@@ -2404,7 +2417,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
             // unknown guest contents are approximated as 0.
             if (!got_stencil_clear && d.ps->stencil_clear_enable) {
                 stencil_clear = d.ps->stencil_clear_value; got_stencil_clear = true;
-            } }
+            }
+        }
     }
     if (const char* v = getenv("PROSPER_STENCIL_CLEAR"))
         stencil_clear = static_cast<uint32_t>(strtoul(v, nullptr, 0)) & 0xFFu;
@@ -2425,11 +2439,9 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     // or partly stale DB bases (for example dr=0,dw=P followed by dr=P,dw=P); re-keying at the pass
     // boundary would bind a newly-cleared attachment even though sampled-depth lookup still finds
     // the producer image. The logical span is supplied only by the split wrapper below.
-    const std::span<const BackendDraw> identity_draws = logical_ds_draws.empty()
-        ? draws : logical_ds_draws;
     const prosper::gpu::ResolvedPipelineState* identity = nullptr;
     bool logical_use_stencil = false;
-    for (const auto& d : identity_draws) {
+    for (const auto& d : logical_draws) {
         if (d.ps && (d.ps->stencil_enable ||
                      stencil_clear_effective(d.ps->stencil_clear_enable,
                                              d.ps->stencil_enable,

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -19,6 +19,7 @@
 #include <cstring>
 #include <functional>
 #include <mutex>
+#include <span>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -204,10 +205,9 @@ inline BackendColorTargetStats backend_color_target_stats() {
 // When `tex` is non-null, its RGBA8 texels are uploaded to a sampled VkImage and bound as a combined
 // image sampler at tex->binding — how a recompiled pixel shader's image_sample reaches a real texture.
 // One draw for the multi-draw backend: recompiled VS+PS SPIR-V, its resolved fixed-function state, its
-// set-tagged resources, vertex count, and instance count. render_draws_rgba records ALL of a submit's
-// draws into ONE
-// render pass (clear once, then per-draw pipeline+descriptors+draw) so a multi-draw frame composites
-// correctly. render_triangle_rgba is a thin single-draw wrapper (below).
+// set-tagged resources, vertex count, and instance count. render_draws_rgba preserves every draw in
+// order, normally in one render pass; an attached-depth write/sample transition is the narrow case
+// that requires an ordered pass boundary. render_triangle_rgba is a thin single-draw wrapper (below).
 struct BackendDraw {
     std::vector<uint32_t> vs, gs, fs;
     prosper::gpu::SharedShaderWords vs_shared, fs_shared;
@@ -2275,16 +2275,17 @@ inline bool restore_persistent_ds_image(const prosper::gpu::GpuCaptureDsSeed& se
 // readback may return after recording; `flush_submission_batch` submits every accumulated command
 // buffer in order, waits once, and releases all retained resources. Omitting the batch preserves the
 // synchronous test/replay contract.
-inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& draws, uint32_t W, uint32_t H,
-                                              const uint8_t* seed_rgba = nullptr,
-                                              const float* clear_rgba = nullptr,
-                                              bool persist_depth_stencil = false,
-                                              const BackendColorTarget* color_target = nullptr,
-                                              const uint8_t* seed_rgba1 = nullptr,
-                                              const float* clear_rgba1 = nullptr,
-                                              std::vector<uint8_t>* out_rgba1 = nullptr,
-                                              BackendSubmissionBatch* submission_batch = nullptr,
-                                              bool flush_submission_batch = true) {
+inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> draws,
+                                                  uint32_t W, uint32_t H,
+                                                  const uint8_t* seed_rgba = nullptr,
+                                                  const float* clear_rgba = nullptr,
+                                                  bool persist_depth_stencil = false,
+                                                  const BackendColorTarget* color_target = nullptr,
+                                                  const uint8_t* seed_rgba1 = nullptr,
+                                                  const float* clear_rgba1 = nullptr,
+                                                  std::vector<uint8_t>* out_rgba1 = nullptr,
+                                                  BackendSubmissionBatch* submission_batch = nullptr,
+                                                  bool flush_submission_batch = true) {
     using TimingClock = std::chrono::steady_clock;
     const bool timing_enabled = getenv("PROSPER_RENDER_TIMING") != nullptr;
     const auto timing_start = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
@@ -5387,6 +5388,202 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     }
     // NB: dev/instance are the persistent RenderVkCtx — do NOT destroy them here (reused across calls).
     return out;
+}
+
+// A Vulkan render pass has one depth layout for every draw. If an earlier draw writes a persistent
+// guest depth plane and a later draw samples that same plane, keeping both in one pass makes the
+// attachment writable and the sampled-depth bridge must reject the alias. Split exactly at those
+// write/sample transitions (in either direction): queue order plus the persistent color/DS caches
+// preserve guest draw order, while each resulting pass has a legal, unambiguous depth layout.
+inline size_t depth_feedback_split_index(std::span<const BackendDraw> draws,
+                                         uint32_t W, uint32_t H) {
+    std::unordered_set<uint64_t> sampled_depth;
+    std::unordered_set<uint64_t> written_depth;
+    for (size_t i = 0; i < draws.size(); ++i) {
+        const BackendDraw& draw = draws[i];
+        const bool samples_prior_write = std::any_of(
+            draw.R.begin(), draw.R.end(), [&](const FrameResource& resource) {
+                return resource.persistent_depth_target_id && resource.img_dim == 1u &&
+                    resource.tw == W && resource.th == H &&
+                    written_depth.contains(resource.persistent_depth_target_id);
+            });
+        const bool writes_depth = draw.ps && persistent_ds_pass_may_write_depth(
+            draw.ps->depth_clear_enable, draw.ps->depth_test_enable,
+            draw.ps->depth_write_enable, draw.ps->depth_compare_op);
+        const bool writes_prior_sample = writes_depth &&
+            ((draw.ps->depth_read_base && sampled_depth.contains(draw.ps->depth_read_base)) ||
+             (draw.ps->depth_write_base && sampled_depth.contains(draw.ps->depth_write_base)));
+        if (i && (samples_prior_write || writes_prior_sample)) return i;
+
+        for (const FrameResource& resource : draw.R)
+            if (resource.persistent_depth_target_id && resource.img_dim == 1u &&
+                resource.tw == W && resource.th == H)
+                sampled_depth.insert(resource.persistent_depth_target_id);
+        if (writes_depth) {
+            if (draw.ps->depth_read_base) written_depth.insert(draw.ps->depth_read_base);
+            if (draw.ps->depth_write_base) written_depth.insert(draw.ps->depth_write_base);
+        }
+    }
+    return draws.size();
+}
+
+// Logical multi-draw entry. Most calls remain one Vulkan render pass. A depth feedback transition
+// becomes multiple ordered passes without copying the (often large) BackendDraw shader/resource
+// payloads. Intermediate color is retained on the GPU when possible and carried through CPU pixels
+// only on the established non-persistent/MRT path.
+inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& draws,
+                                              uint32_t W, uint32_t H,
+                                              const uint8_t* seed_rgba = nullptr,
+                                              const float* clear_rgba = nullptr,
+                                              bool persist_depth_stencil = false,
+                                              const BackendColorTarget* color_target = nullptr,
+                                              const uint8_t* seed_rgba1 = nullptr,
+                                              const float* clear_rgba1 = nullptr,
+                                              std::vector<uint8_t>* out_rgba1 = nullptr,
+                                              BackendSubmissionBatch* submission_batch = nullptr,
+                                              bool flush_submission_batch = true) {
+    const std::span<const BackendDraw> all(draws);
+    if (!persist_depth_stencil ||
+        depth_feedback_split_index(all, W, H) == all.size())
+        return render_draw_pass_rgba(all, W, H, seed_rgba, clear_rgba,
+                                     persist_depth_stencil, color_target, seed_rgba1,
+                                     clear_rgba1, out_rgba1, submission_batch,
+                                     flush_submission_batch);
+
+    BackendColorTargetStats aggregate_color{};
+    BackendTextureUploadStats aggregate_textures{};
+    BackendResourceReuseStats aggregate_resources{};
+    BackendPipelineCacheStats aggregate_pipelines{};
+    BackendRenderTimingStats aggregate_timing{};
+    std::vector<uint8_t> carried_color0;
+    std::vector<uint8_t> carried_color1;
+    const uint8_t* next_seed0 = seed_rgba;
+    const uint8_t* next_seed1 = seed_rgba1;
+
+    auto add_stats = [&] {
+        const BackendColorTargetStats color = backend_color_target_stats();
+        aggregate_color.writes += color.writes;
+        aggregate_color.write_hits += color.write_hits;
+        aggregate_color.sampled_hits += color.sampled_hits;
+        aggregate_color.readbacks += color.readbacks;
+        aggregate_color.cached_bytes = color.cached_bytes;
+        aggregate_color.cached_entries = color.cached_entries;
+
+        const BackendTextureUploadStats textures = backend_texture_upload_stats();
+        aggregate_textures.references += textures.references;
+        aggregate_textures.unique_uploads += textures.unique_uploads;
+        aggregate_textures.upload_bytes += textures.upload_bytes;
+        aggregate_textures.persistent_hits += textures.persistent_hits;
+        aggregate_textures.persistent_misses += textures.persistent_misses;
+        aggregate_textures.persistent_cached_bytes = textures.persistent_cached_bytes;
+
+        const BackendResourceReuseStats resources = backend_resource_reuse_stats();
+#define PROSPER_SUM_RESOURCE_STAT(field) aggregate_resources.field += resources.field
+        PROSPER_SUM_RESOURCE_STAT(buffer_references);
+        PROSPER_SUM_RESOURCE_STAT(unique_buffers);
+        PROSPER_SUM_RESOURCE_STAT(texture_binding_references);
+        PROSPER_SUM_RESOURCE_STAT(unique_texture_bindings);
+        PROSPER_SUM_RESOURCE_STAT(descriptor_set_layout_references);
+        PROSPER_SUM_RESOURCE_STAT(unique_descriptor_set_layouts);
+        PROSPER_SUM_RESOURCE_STAT(pipeline_layout_references);
+        PROSPER_SUM_RESOURCE_STAT(unique_pipeline_layouts);
+        PROSPER_SUM_RESOURCE_STAT(descriptor_pools);
+        PROSPER_SUM_RESOURCE_STAT(persistent_pipeline_layout_hits);
+        PROSPER_SUM_RESOURCE_STAT(persistent_pipeline_layout_misses);
+        PROSPER_SUM_RESOURCE_STAT(persistent_pipeline_layout_evictions);
+        PROSPER_SUM_RESOURCE_STAT(persistent_texture_binding_hits);
+        PROSPER_SUM_RESOURCE_STAT(persistent_texture_binding_misses);
+        PROSPER_SUM_RESOURCE_STAT(persistent_texture_binding_evictions);
+        PROSPER_SUM_RESOURCE_STAT(buffer_hash_calls);
+        PROSPER_SUM_RESOURCE_STAT(buffer_hash_dwords);
+        PROSPER_SUM_RESOURCE_STAT(buffer_hash_skipped_unique);
+        PROSPER_SUM_RESOURCE_STAT(buffer_hash_skipped_large);
+        PROSPER_SUM_RESOURCE_STAT(buffer_ref_memo_hits);
+#undef PROSPER_SUM_RESOURCE_STAT
+        aggregate_resources.persistent_pipeline_layout_entries =
+            resources.persistent_pipeline_layout_entries;
+        aggregate_resources.persistent_texture_binding_entries =
+            resources.persistent_texture_binding_entries;
+
+        const BackendPipelineCacheStats pipelines = backend_pipeline_cache_stats();
+        aggregate_pipelines.references += pipelines.references;
+        aggregate_pipelines.hits += pipelines.hits;
+        aggregate_pipelines.misses += pipelines.misses;
+        aggregate_pipelines.bypasses += pipelines.bypasses;
+        aggregate_pipelines.entries = pipelines.entries;
+        aggregate_pipelines.evictions += pipelines.evictions;
+
+        if (getenv("PROSPER_RENDER_TIMING")) {
+            const BackendRenderTimingStats timing = backend_render_timing_stats();
+#define PROSPER_SUM_TIMING_STAT(field) aggregate_timing.field += timing.field
+            PROSPER_SUM_TIMING_STAT(calls);
+            PROSPER_SUM_TIMING_STAT(draws);
+            PROSPER_SUM_TIMING_STAT(command_buffers);
+            PROSPER_SUM_TIMING_STAT(queue_submits);
+            PROSPER_SUM_TIMING_STAT(fence_waits);
+            PROSPER_SUM_TIMING_STAT(target_ms);
+            PROSPER_SUM_TIMING_STAT(draw_setup_ms);
+            PROSPER_SUM_TIMING_STAT(record_upload_ms);
+            PROSPER_SUM_TIMING_STAT(gpu_wait_ms);
+            PROSPER_SUM_TIMING_STAT(readback_ms);
+            PROSPER_SUM_TIMING_STAT(cleanup_ms);
+            PROSPER_SUM_TIMING_STAT(setup_shader_ms);
+            PROSPER_SUM_TIMING_STAT(setup_fixed_ms);
+            PROSPER_SUM_TIMING_STAT(setup_resources_ms);
+            PROSPER_SUM_TIMING_STAT(setup_pipeline_ms);
+#undef PROSPER_SUM_TIMING_STAT
+        }
+    };
+
+    size_t begin = 0;
+    while (begin < all.size()) {
+        const std::span<const BackendDraw> remaining = all.subspan(begin);
+        const size_t relative_end = depth_feedback_split_index(remaining, W, H);
+        const size_t end = begin + relative_end;
+        const bool final = end == all.size();
+
+        BackendColorTarget segment_target{};
+        const BackendColorTarget* segment_target_ptr = nullptr;
+        if (color_target) {
+            segment_target = *color_target;
+            if (begin) segment_target.load_existing = true;
+            if (!final) segment_target.readback = false;
+            segment_target_ptr = &segment_target;
+        }
+        std::vector<uint8_t> intermediate_color1;
+        std::vector<uint8_t>* segment_out1 = out_rgba1
+            ? (final ? out_rgba1 : &intermediate_color1) : nullptr;
+        std::vector<uint8_t> rendered = render_draw_pass_rgba(
+            all.subspan(begin, end - begin), W, H, next_seed0,
+            begin ? nullptr : clear_rgba, true, segment_target_ptr, next_seed1,
+            begin ? nullptr : clear_rgba1, segment_out1, submission_batch,
+            final ? flush_submission_batch : false);
+        add_stats();
+
+        if (final) {
+            backend_color_target_stats_storage() = aggregate_color;
+            backend_texture_upload_stats_storage() = aggregate_textures;
+            backend_resource_reuse_stats_storage() = aggregate_resources;
+            backend_pipeline_cache_stats_storage() = aggregate_pipelines;
+            if (getenv("PROSPER_RENDER_TIMING"))
+                backend_render_timing_stats_storage() = aggregate_timing;
+            return rendered;
+        }
+
+        // A persistent color target intentionally returns no pixels here; the next pass LOADs its
+        // queued image. Transient and MRT paths read back and carry their exact output as a seed.
+        if (!rendered.empty()) carried_color0 = std::move(rendered);
+        else carried_color0.clear();
+        next_seed0 = carried_color0.empty() ? nullptr : carried_color0.data();
+        if (out_rgba1) {
+            carried_color1 = std::move(intermediate_color1);
+            next_seed1 = carried_color1.empty() ? nullptr : carried_color1.data();
+        } else {
+            next_seed1 = nullptr;
+        }
+        begin = end;
+    }
+    return {};
 }
 
 // Single-draw entry — a thin wrapper over render_draws_rgba, preserving the exact signature/behavior the

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -2285,7 +2285,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                                                   const float* clear_rgba1 = nullptr,
                                                   std::vector<uint8_t>* out_rgba1 = nullptr,
                                                   BackendSubmissionBatch* submission_batch = nullptr,
-                                                  bool flush_submission_batch = true) {
+                                                  bool flush_submission_batch = true,
+                                                  std::span<const BackendDraw> logical_ds_draws = {}) {
     using TimingClock = std::chrono::steady_clock;
     const bool timing_enabled = getenv("PROSPER_RENDER_TIMING") != nullptr;
     const auto timing_start = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
@@ -2419,19 +2420,36 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     // Use a stencil-capable depth format ONLY when a draw actually uses stencil (a UI mask). The
     // depth-only path keeps the original D32 depth-only format + aspect, so existing render tests are
     // byte-identical (#264).
+    // Physical passes created for one logical draw batch must retain the exact DS attachment that
+    // the original unsplit pass would have selected. Segment-local first states can carry aliased
+    // or partly stale DB bases (for example dr=0,dw=P followed by dr=P,dw=P); re-keying at the pass
+    // boundary would bind a newly-cleared attachment even though sampled-depth lookup still finds
+    // the producer image. The logical span is supplied only by the split wrapper below.
+    const std::span<const BackendDraw> identity_draws = logical_ds_draws.empty()
+        ? draws : logical_ds_draws;
     const prosper::gpu::ResolvedPipelineState* identity = nullptr;
-    for (const auto& d : draws)
+    bool logical_use_stencil = false;
+    for (const auto& d : identity_draws) {
+        if (d.ps && (d.ps->stencil_enable ||
+                     stencil_clear_effective(d.ps->stencil_clear_enable,
+                                             d.ps->stencil_enable,
+                                             d.ps->stencil_write_mask[0],
+                                             d.ps->stencil_write_mask[1])))
+            logical_use_stencil = true;
         if (d.ps && (d.ps->depth_test_enable || d.ps->stencil_enable ||
                      effective_depth_clear(d.ps) ||
                      stencil_clear_effective(d.ps->stencil_clear_enable, d.ps->stencil_enable,
                                              d.ps->stencil_write_mask[0],
-                                             d.ps->stencil_write_mask[1]))) { identity = d.ps; break; }
+                                             d.ps->stencil_write_mask[1])) && !identity)
+            identity = d.ps;
+    }
+    if (getenv("PROSPER_NO_STENCIL")) logical_use_stencil = false;
     const bool has_ds_identity = identity && (identity->depth_read_base || identity->depth_write_base ||
                                                identity->stencil_read_base || identity->stencil_write_base);
     const bool persistent_ds = persist_depth_stencil && use_ds && has_ds_identity;
     // A persistent attachment must keep a stable format even across a depth-only call between stencil
     // users. Nonzero stencil identity means this guest surface owns a stencil plane.
-    const bool format_has_stencil = use_stencil || (persistent_ds &&
+    const bool format_has_stencil = logical_use_stencil || (persistent_ds &&
         (identity->stencil_read_base || identity->stencil_write_base));
     const VkFormat DFMT = format_has_stencil ? VK_FORMAT_D32_SFLOAT_S8_UINT : VK_FORMAT_D32_SFLOAT;
     const VkImageAspectFlags DASPECT = VK_IMAGE_ASPECT_DEPTH_BIT |
@@ -5557,7 +5575,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
             all.subspan(begin, end - begin), W, H, next_seed0,
             begin ? nullptr : clear_rgba, true, segment_target_ptr, next_seed1,
             begin ? nullptr : clear_rgba1, segment_out1, submission_batch,
-            final ? flush_submission_batch : false);
+            final ? flush_submission_batch : false, all);
         add_stats();
 
         if (final) {

--- a/prosper/tests/test_shadow_compare_render.cpp
+++ b/prosper/tests/test_shadow_compare_render.cpp
@@ -366,6 +366,48 @@ int main() {
                   "same-pass consumer samples attached depth while stencil remains writable (#1186)");
         }
 
+        // #1186 regression: Bendy records the depth-writing scene geometry and its later deferred
+        // light volumes in one same-target draw run. The light samples that attached scene depth.
+        // One Vulkan render pass cannot expose a writable attachment as a sampled image, so the
+        // logical draw batch must split at the write -> sample transition while retaining color,
+        // depth, and stencil between the two ordered backend passes.
+        constexpr uint64_t kBatchedDepth = 0x20d5a00000ull;
+        constexpr uint64_t kBatchedStencil = 0x20d5b00000ull;
+        ResolvedPipelineState batched_producer_state = feedback_producer;
+        batched_producer_state.depth_read_base = kBatchedDepth;
+        batched_producer_state.depth_write_base = kBatchedDepth;
+        batched_producer_state.stencil_read_base = kBatchedStencil;
+        batched_producer_state.stencil_write_base = kBatchedStencil;
+        prosper::test::BackendDraw batched_producer = feedback_pw;
+        batched_producer.ps = &batched_producer_state;
+
+        ResolvedPipelineState batched_consumer_state = feedback_state;
+        batched_consumer_state.depth_read_base = kBatchedDepth;
+        batched_consumer_state.depth_write_base = kBatchedDepth;
+        batched_consumer_state.stencil_read_base = kBatchedStencil;
+        batched_consumer_state.stencil_write_base = kBatchedStencil;
+        prosper::test::FrameResource batched_resource = feedback_resource;
+        batched_resource.persistent_depth_target_id = kBatchedDepth;
+        prosper::test::BackendDraw batched_consumer = feedback_consumer;
+        batched_consumer.ps = &batched_consumer_state;
+        batched_consumer.R = {batched_resource};
+        prosper::test::BackendColorTarget batched_color{
+            0x20d5c00000ull, true, true, VK_FORMAT_R8G8B8A8_UNORM};
+        prosper::test::BackendSubmissionBatch batched_submission;
+        std::vector<uint8_t> via_batched_feedback = prosper::test::render_draws_rgba(
+            {batched_producer, batched_consumer}, W, H, nullptr, nullptr,
+            /*persist_depth_stencil=*/true, &batched_color, nullptr, nullptr, nullptr,
+            &batched_submission, /*flush_submission_batch=*/true);
+        CHECK(via_batched_feedback.size() == (size_t)W * H * 4,
+              "depth producer and sampled-depth consumer rendered from one logical batch");
+        if (via_batched_feedback.size() == (size_t)W * H * 4) {
+            const uint8_t* batched_center =
+                &via_batched_feedback[(((size_t)H / 2) * W + W / 2) * 4];
+            printf("  batched feedback center R=%u (want ~64)\n", batched_center[0]);
+            CHECK(batched_center[0] > 56 && batched_center[0] < 72,
+                  "write/sample transition preserves produced depth instead of binding zeros (#1186)");
+        }
+
         // ---- #1287: an ineffective clear draw must not shadow the rendered plane ----
         // Blue Prince's light loop: shadow casters render depth into plane P (identity dr=P, dw=0),
         // then a fullscreen rect with DB_RENDER_CONTROL.DEPTH_CLEAR_ENABLE set but DB_DEPTH_CONTROL

--- a/prosper/tests/test_shadow_compare_render.cpp
+++ b/prosper/tests/test_shadow_compare_render.cpp
@@ -370,26 +370,60 @@ int main() {
         // light volumes in one same-target draw run. The light samples that attached scene depth.
         // One Vulkan render pass cannot expose a writable attachment as a sampled image, so the
         // logical draw batch must split at the write -> sample transition while retaining color,
-        // depth, and stencil between the two ordered backend passes.
+        // depth, and stencil between the two ordered backend passes. The two states deliberately
+        // use different register aliases/HTILE values: selecting a segment-local persistent-DS key
+        // would give the consumer a newly-cleared attachment while its sampled descriptor still
+        // borrowed the producer image.
         constexpr uint64_t kBatchedDepth = 0x20d5a00000ull;
         constexpr uint64_t kBatchedStencil = 0x20d5b00000ull;
         ResolvedPipelineState batched_producer_state = feedback_producer;
-        batched_producer_state.depth_read_base = kBatchedDepth;
+        batched_producer_state.depth_read_base = 0;
         batched_producer_state.depth_write_base = kBatchedDepth;
-        batched_producer_state.stencil_read_base = kBatchedStencil;
+        batched_producer_state.stencil_read_base = 0;
         batched_producer_state.stencil_write_base = kBatchedStencil;
+        batched_producer_state.htile_data_base = 0x20d5900000ull;
+        batched_producer_state.stencil_pass_op[0] =
+            batched_producer_state.stencil_pass_op[1] = 2; // REPLACE
+        batched_producer_state.stencil_op_val[0] =
+            batched_producer_state.stencil_op_val[1] = 2;
+        batched_producer_state.stencil_write_mask[0] =
+            batched_producer_state.stencil_write_mask[1] = 0xff;
+        const uint32_t ps_green[] = {
+            0x7e000280u, 0x7e0202f2u, 0x7e040280u, 0x7e0602f2u,
+            0xf800180fu, 0x03020100u, 0xbf810000u,
+        };
+        std::vector<uint32_t> green = recompile_fragment(
+            ps_green, sizeof(ps_green) / sizeof(ps_green[0]), nullptr);
+        CHECK(!green.empty(), "recompiled batched producer color shader");
         prosper::test::BackendDraw batched_producer = feedback_pw;
         batched_producer.ps = &batched_producer_state;
+        batched_producer.fs = green;
 
         ResolvedPipelineState batched_consumer_state = feedback_state;
         batched_consumer_state.depth_read_base = kBatchedDepth;
         batched_consumer_state.depth_write_base = kBatchedDepth;
         batched_consumer_state.stencil_read_base = kBatchedStencil;
         batched_consumer_state.stencil_write_base = kBatchedStencil;
+        batched_consumer_state.htile_data_base = 0x0004dfac00ull;
+        batched_consumer_state.depth_compare_op = 2; // EQUAL: prove attachment depth survived
+        batched_consumer_state.stencil_compare_op[0] =
+            batched_consumer_state.stencil_compare_op[1] = 2; // EQUAL
+        batched_consumer_state.stencil_ref[0] = batched_consumer_state.stencil_ref[1] = 2;
+        batched_consumer_state.stencil_compare_mask[0] =
+            batched_consumer_state.stencil_compare_mask[1] = 0xff;
+        batched_consumer_state.stencil_pass_op[0] =
+            batched_consumer_state.stencil_pass_op[1] = 0; // KEEP
+        batched_consumer_state.stencil_write_mask[0] =
+            batched_consumer_state.stencil_write_mask[1] = 0;
+        batched_consumer_state.blend_enable = true;
+        batched_consumer_state.src_color_blend_factor = 1; // ONE
+        batched_consumer_state.dst_color_blend_factor = 1; // ONE
+        batched_consumer_state.color_blend_op = 0;          // ADD
         prosper::test::FrameResource batched_resource = feedback_resource;
         batched_resource.persistent_depth_target_id = kBatchedDepth;
         prosper::test::BackendDraw batched_consumer = feedback_consumer;
         batched_consumer.ps = &batched_consumer_state;
+        batched_consumer.vs = vert_z;
         batched_consumer.R = {batched_resource};
         prosper::test::BackendColorTarget batched_color{
             0x20d5c00000ull, true, true, VK_FORMAT_R8G8B8A8_UNORM};
@@ -403,9 +437,41 @@ int main() {
         if (via_batched_feedback.size() == (size_t)W * H * 4) {
             const uint8_t* batched_center =
                 &via_batched_feedback[(((size_t)H / 2) * W + W / 2) * 4];
-            printf("  batched feedback center R=%u (want ~64)\n", batched_center[0]);
-            CHECK(batched_center[0] > 56 && batched_center[0] < 72,
-                  "write/sample transition preserves produced depth instead of binding zeros (#1186)");
+            printf("  batched feedback center RG=%u/%u (want ~64/255)\n",
+                   batched_center[0], batched_center[1]);
+            CHECK(batched_center[0] > 56 && batched_center[0] < 72 &&
+                      batched_center[1] > 248,
+                  "split preserves sampled depth, tested DS planes, and persistent color LOAD (#1186)");
+        }
+
+        // The non-persistent color path carries intermediate MRT pixels through CPU seeds. Keep
+        // MRT1 untouched so its exact seed proves both readback/carry legs, while MRT0 proves that
+        // the producer's green survives and the consumer additively contributes sampled depth.
+        std::vector<uint8_t> mrt1_seed((size_t)W * H * 4);
+        for (size_t i = 0; i < mrt1_seed.size(); i += 4) {
+            mrt1_seed[i + 0] = 17; mrt1_seed[i + 1] = 34;
+            mrt1_seed[i + 2] = 51; mrt1_seed[i + 3] = 255;
+        }
+        std::vector<uint8_t> carried_mrt1;
+        std::vector<uint8_t> via_transient_feedback = prosper::test::render_draws_rgba(
+            {batched_producer, batched_consumer}, W, H, nullptr, nullptr,
+            /*persist_depth_stencil=*/true, nullptr, mrt1_seed.data(), nullptr,
+            &carried_mrt1);
+        CHECK(via_transient_feedback.size() == (size_t)W * H * 4 &&
+                  carried_mrt1.size() == mrt1_seed.size(),
+              "split transient/MRT path rendered both color attachments");
+        if (via_transient_feedback.size() == (size_t)W * H * 4 &&
+            carried_mrt1.size() == mrt1_seed.size()) {
+            const uint8_t* transient_center =
+                &via_transient_feedback[(((size_t)H / 2) * W + W / 2) * 4];
+            const uint8_t* mrt1_center =
+                &carried_mrt1[(((size_t)H / 2) * W + W / 2) * 4];
+            CHECK(transient_center[0] > 56 && transient_center[0] < 72 &&
+                      transient_center[1] > 248,
+                  "split transient color carry preserves producer and consumer composition");
+            CHECK(mrt1_center[0] == 17 && mrt1_center[1] == 34 &&
+                      mrt1_center[2] == 51 && mrt1_center[3] == 255,
+                  "split MRT carry preserves an untouched secondary attachment exactly");
         }
 
         // ---- #1287: an ineffective clear draw must not shadow the rendered plane ----

--- a/prosper/tests/test_shadow_compare_render.cpp
+++ b/prosper/tests/test_shadow_compare_render.cpp
@@ -474,6 +474,53 @@ int main() {
                   "split MRT carry preserves an untouched secondary attachment exactly");
         }
 
+        // Fresh-image initialization is also a logical-pass contract. An ALWAYS producer does not
+        // constrain the fallback value, so the later meaningful reverse-Z GEQUAL must choose 0.0
+        // even though the producer occupies the first physical pass. Restrict the producer to the
+        // left half: if that segment incorrectly clears fresh depth to its local default 1.0, the
+        // full-target consumer fails depth on the untouched right half and leaves the blue color.
+        constexpr uint64_t kPartialDepth = 0x20d5d00000ull;
+        ResolvedPipelineState partial_producer_state = producer;
+        partial_producer_state.color_write_mask = 0;
+        partial_producer_state.depth_read_base = kPartialDepth;
+        partial_producer_state.depth_write_base = kPartialDepth;
+        partial_producer_state.has_scissor = true;
+        partial_producer_state.scissor_left = 0;
+        partial_producer_state.scissor_top = 0;
+        partial_producer_state.scissor_right = W / 2;
+        partial_producer_state.scissor_bottom = H;
+        prosper::test::BackendDraw partial_producer = pw;
+        partial_producer.ps = &partial_producer_state;
+
+        ResolvedPipelineState reverse_consumer_state = opaque;
+        reverse_consumer_state.depth_test_enable = true;
+        reverse_consumer_state.depth_write_enable = false;
+        reverse_consumer_state.depth_compare_op = 6; // GREATER_OR_EQUAL
+        reverse_consumer_state.depth_read_base = kPartialDepth;
+        reverse_consumer_state.depth_write_base = kPartialDepth;
+        prosper::test::FrameResource partial_resource = bridged;
+        partial_resource.persistent_depth_target_id = kPartialDepth;
+        prosper::test::BackendDraw reverse_consumer = consumer;
+        reverse_consumer.vs = vert_z;
+        reverse_consumer.ps = &reverse_consumer_state;
+        reverse_consumer.R = {partial_resource};
+        prosper::test::BackendColorTarget partial_color{
+            0x20d5e00000ull, true, true, VK_FORMAT_R8G8B8A8_UNORM};
+        prosper::test::BackendSubmissionBatch partial_submission;
+        std::vector<uint8_t> partial = prosper::test::render_draws_rgba(
+            {partial_producer, reverse_consumer}, W, H, nullptr, nullptr,
+            /*persist_depth_stencil=*/true, &partial_color, nullptr, nullptr, nullptr,
+            &partial_submission, /*flush_submission_batch=*/true);
+        CHECK(partial.size() == (size_t)W * H * 4,
+              "partial depth producer and reverse-Z consumer rendered across a split");
+        if (partial.size() == (size_t)W * H * 4) {
+            const uint8_t* written = &partial[((size_t)(H / 2) * W + W / 4) * 4];
+            const uint8_t* untouched = &partial[((size_t)(H / 2) * W + 3 * W / 4) * 4];
+            CHECK(written[0] > 56 && written[0] < 72 &&
+                      untouched[0] > 56 && untouched[0] < 72 && untouched[2] < 8,
+                  "logical reverse-Z fallback lets the consumer pass on untouched depth pixels");
+        }
+
         // ---- #1287: an ineffective clear draw must not shadow the rendered plane ----
         // Blue Prince's light loop: shadow casters render depth into plane P (identity dr=P, dw=0),
         // then a fullscreen rect with DB_RENDER_CONTROL.DEPTH_CLEAR_ENABLE set but DB_DEPTH_CONTROL


### PR DESCRIPTION
Relates to #1186. This is a prerequisite correctness fix; it does not close the remaining Bendy ring artifact.

## Failure scenario

Bendy records depth-writing scene geometry and later deferred light volumes in one contiguous same-target draw run. Those light draws sample the same persistent depth plane. A Vulkan render pass has one depth layout across all draws, so the earlier writer made the attachment writable for the whole pass and the sampled-depth bridge had to reject the alias, substituting a zero texture.

Review exposed two split-only state edges that are also fixed here: physical segments must not independently re-key aliased DB states onto a newly-cleared attachment, and they must not independently choose fresh-image fallback values that differ from the original logical pass.

## Behavioral contract and approach

- Detect only exact full-extent persistent depth identities that transition between writes and sampling.
- Split the logical draw run at each write/sample or sample/write transition.
- Preserve draw order through the existing queue/submission batch.
- Select one canonical depth/stencil attachment identity, format, and fresh-image fallback from the original logical draw batch, then retain them across every physical segment.
- Keep segment-local attachment use/write/layout decisions and explicit in-order clears local.
- Preserve color through the persistent GPU target when available, with the established CPU seed fallback for transient/MRT paths.
- Allow read-only depth sampling while stencil remains independently writable.
- Aggregate per-call backend statistics across physical pass segments so diagnostics retain logical-call accounting.

Ordinary draw runs without an attached-depth conflict remain a single render pass. Same-draw writable feedback is deliberately not generalized or hidden.

## Verification

Verified on exact head `7f2da8301609b26d3324cd713462e7aa6f3fd424`, rebased on live master `537293c258605c413770591e188980e5e6036dde`:

- `cmake --build prosper/build-audit -j2` — pass.
- `prosper/build-audit/test_shadow_compare_render` — pass.
- `ctest --test-dir prosper/build-audit --output-on-failure -j4 -I 1,121` — 121/121 pass.
- `ctest --test-dir prosper/build-audit --output-on-failure -j1 -I 122,146` — 25/25 pass (146/146 total).
- The key/carry regression deliberately crosses `{dr=0,dw=P,sr=0,sw=S,htile=A}` to `{dr=P,dw=P,sr=S,sw=S,htile=B}`. The consumer samples produced depth R=64 (~0.25), passes meaningful EQUAL depth and EQUAL stencil tests, retains the producer's green through a persistent GPU color LOAD plus deferred submission, and preserves both transient color composition and untouched MRT1 bytes through the CPU carry path.
- The same test includes a partial-coverage `ALWAYS` depth producer followed by a full-target reverse-Z `GEQUAL` consumer. Untouched pixels pass only when the logical consumer selects fresh depth 0.0; the old segment-local default 1.0 leaves those pixels blue and fails the assertion.
- `PROSPER_DSBRIDGE_LOG=1 PROSPER_DSLOG=1 prosper/build-audit/gpu_replay --allow-mismatch /home/mattias800/bendy_ingame.prgcap /tmp/bendy-final.bmp` — pass; output hash `7ccbecfcebc5df6f` (prior implementation `09c0b35fb154ebb4`, pre-split master `efac4b6599cdd0c9`). Physical calls 61/62 use the same canonical key `20b4e90000/20b4e90000/20b6e90000/20b6e90000`, choose logical initial depth 0.0, enter the consumer segment with depth/stencil valid, report bridge HIT, and have zero declined borrows.
- Snapshot no-regression sweep: messenger scene, Evergate title/gameplay, Dead Cells gameplay, and Blasphemous 2 gameplay passed on the patch-equivalent pre-rebase head. The final source also passes `snapshot.py check blue-prince-title` (9 structural matches).
- Two existing snapshot-route failures were A/B checked with separately compiled, exact live-master binaries: `terminator-boot` reaches the correct menu late with 8/16 structural matches on both master and this PR; `blue-prince-hall` produces the same black retained window on master (0 qualifying / 0 structural) and the PR. A temporary diagnostic also confirmed no #1410 physical feedback split occurs before the Blue Prince black transition; no diagnostic code remains in the branch.
- Required CI: Linux, Linux App, Windows MinGW, Windows App, macOS, and macOS App are required; final-head results are recorded by GitHub below.
- Independent exact-head review: https://github.com/mattias800/ps5ys/pull/1410#pullrequestreview-4780663711

## Remaining issue / risk

The frozen Bendy replay still shows the reported wall bands even with real depth bound, so #1186 remains open. The next investigation starts from the now-valid depth signal and focuses on light-cookie projection/shader semantics. The main implementation risk is state carry across the new pass boundary; persistent and transient color, MRT, depth, stencil, key aliases, logical fallback values, partial coverage, and deferred submission now have focused coverage, and the full render suite is green.