### PR TITLE
fix(gpu): resolve Gen5 virtual interpolant registers

### DIFF
--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -1860,9 +1860,23 @@ void GpuState::apply(const Pm4Command& c) {
             uint32_t dbbase_nonzero_mask = 0;
             bool dbbase_clobbered = false;
             for (uint32_t i = 0; i < c.num_regs; i++) {
+                // Gen5's BuildInterpolantMapping helper returns a reserved virtual Cx-register
+                // bank instead of raw hardware offsets. The Dcb consumes those pairs unchanged;
+                // the real driver resolves 0x10000000+n to SPI_PS_INPUT_CNTL_n while building the
+                // command stream. Our HLE packet deliberately retains the guest array until fold
+                // time (it may be patched after packet creation), so perform that one documented
+                // resolution here before applying the ordinary bounded-register-file guard.
+                uint32_t offset = regs[i].offset;
+                constexpr uint32_t kVirtualPsInputCntl0 = 0x10000000u;
+                if (c.reg_class == RegClass::Cx &&
+                    offset >= kVirtualPsInputCntl0 &&
+                    offset < kVirtualPsInputCntl0 + 32u) {
+                    offset = prosper::agc::Pm4::SPI_PS_INPUT_CNTL_0 +
+                             (offset - kVirtualPsInputCntl0);
+                }
                 // Hardware drops writes to nonexistent register offsets; mirror that instead of
                 // folding placeholder/stale array slots into the register file (see kRegOffsetLimit).
-                if (regs[i].offset >= kRegOffsetLimit) {
+                if (offset >= kRegOffsetLimit) {
                     if (bad++ == 0) first_bad = i;
                     static std::atomic<int> dropped_note{0};
                     if (dropped_note.fetch_add(1) < 4)
@@ -1872,27 +1886,27 @@ void GpuState::apply(const Pm4Command& c) {
                                 (int)c.reg_class, regs[i].offset, regs[i].value);
                     continue;
                 }
-                file[regs[i].offset] = regs[i].value;
+                file[offset] = regs[i].value;
                 // PROSPER_DBBASETRACE (#1353): log every cx write to the DB Z/STENCIL base
                 // registers (LO 0x12..0x15, HI 0x1A..0x1D) with its source path, to attribute
                 // which packet family programs (or clobbers) a base half — this trace found the
                 // stale arena slot writing (DB_Z_WRITE_BASE, 0) after the real pair write.
                 static const bool dbbase_trace = getenv("PROSPER_DBBASETRACE") != nullptr;
                 if (dbbase_trace && c.reg_class == RegClass::Cx &&
-                    ((regs[i].offset >= 0x12u && regs[i].offset <= 0x15u) ||
-                     (regs[i].offset >= 0x1Au && regs[i].offset <= 0x1Du))) {
+                    ((offset >= 0x12u && offset <= 0x15u) ||
+                     (offset >= 0x1Au && offset <= 0x1Du))) {
                     static std::atomic<int> n{0};
                     if (n.fetch_add(1) < 400000)
                         fprintf(stderr, "[dbbase] indirect off=0x%x val=0x%x order=%llu\n",
                                 regs[i].offset, regs[i].value,
                                 (unsigned long long)command_order);
-                    const uint32_t bit = regs[i].offset <= 0x15u
-                        ? (regs[i].offset - 0x12u) : (4u + regs[i].offset - 0x1Au);
+                    const uint32_t bit = offset <= 0x15u
+                        ? (offset - 0x12u) : (4u + offset - 0x1Au);
                     if (regs[i].value != 0u) dbbase_nonzero_mask |= 1u << bit;
                     else if (dbbase_nonzero_mask & (1u << bit)) dbbase_clobbered = true;
                 }
                 if (c.reg_class == RegClass::Cx &&
-                    regs[i].offset == prosper::agc::Pm4::DB_RENDER_CONTROL &&
+                    offset == prosper::agc::Pm4::DB_RENDER_CONTROL &&
                     (regs[i].value & 0x3u) &&
                     getenv("PROSPER_DS_CLEARLOG"))
                     fprintf(stderr,

--- a/prosper/src/gpu/command_processor.hpp
+++ b/prosper/src/gpu/command_processor.hpp
@@ -152,7 +152,9 @@ struct GpuState {
     // TEXTURE_GRADIENT_CONTROL default write, not stale data. That is safe today (nothing reads
     // them; CONFIDENCE: MED for the virtual-register encoding itself) — but if FSR / texture-
     // gradient consumption is ever implemented, ingest for those named offsets must be re-enabled
-    // deliberately. Kept generous (64K dwords) versus the few-hundred range real packets use.
+    // deliberately. The separate 0x10000000..0x1000001f Gen5 interpolant bank is allow-listed and
+    // resolved to SPI_PS_INPUT_CNTL_0..31 before this bound. Kept generous (64K dwords) versus the
+    // few-hundred range real packets use.
     static constexpr uint32_t kRegOffsetLimit = 0x10000;
 
     // Fold one decoded command into the state. Reads register arrays via their (1:1-mapped) vaddr.

--- a/prosper/tests/test_command_processor.cpp
+++ b/prosper/tests/test_command_processor.cpp
@@ -145,6 +145,35 @@ int main() {
         CHECK(zero_scissor.cx.count(prosper::agc::Pm4::PA_SC_WINDOW_SCISSOR_BR) &&
                   zero_scissor.cx[prosper::agc::Pm4::PA_SC_WINDOW_SCISSOR_BR] == 0x00000FACu,
               "unrelated bad offset does not suppress an empty window-scissor write");
+
+        // sceAgcBuildInterpolantMapping uses a compact virtual register bank. These entries are
+        // intentional Cx writes, not the arbitrary/stale out-of-range offsets rejected above.
+        ShaderReg virtual_interpolants[] = {
+            {0x10000000u, 0x00000003u},
+            {0x10000001u, 0x00000320u},
+            {0x1000001fu, 0x00000407u},
+            {0x10000020u, 0xDEADBEEFu},
+        };
+        uint32_t virtual_cb[8]{};
+        Dcb virtual_dcb{};
+        virtual_dcb.bottom = virtual_cb;
+        virtual_dcb.top = virtual_cb + 8;
+        virtual_dcb.cursor_up = virtual_cb;
+        virtual_dcb.cursor_down = virtual_cb + 8;
+        setcx((uint64_t)(uintptr_t)&virtual_dcb,
+              (uint64_t)(uintptr_t)virtual_interpolants,
+              sizeof(virtual_interpolants) / sizeof(virtual_interpolants[0]), 0, 0, 0);
+        GpuState resolved_interpolants;
+        run_cb(virtual_cb, 4, resolved_interpolants);
+        CHECK(resolved_interpolants.cx.count(prosper::agc::Pm4::SPI_PS_INPUT_CNTL_0) &&
+                  resolved_interpolants.cx[prosper::agc::Pm4::SPI_PS_INPUT_CNTL_0] == 0x00000003u &&
+                  resolved_interpolants.cx.count(prosper::agc::Pm4::SPI_PS_INPUT_CNTL_31) &&
+                  resolved_interpolants.cx[prosper::agc::Pm4::SPI_PS_INPUT_CNTL_31] == 0x00000407u,
+              "Gen5 virtual interpolant bank resolves to SPI_PS_INPUT_CNTL_0..31");
+        CHECK(resolved_interpolants.cx.count(prosper::agc::Pm4::SPI_PS_INPUT_CNTL_0 + 1u) &&
+                  resolved_interpolants.cx[prosper::agc::Pm4::SPI_PS_INPUT_CNTL_0 + 1u] == 0x00000320u &&
+                  resolved_interpolants.cx.count(0x10000020u) == 0,
+              "virtual interpolant values survive resolution and the adjacent offset stays rejected");
     }
 
     CHECK(st.draws.size() == 2, "2 draws recorded");


### PR DESCRIPTION
Closes #1373

## What changed
- Resolve Gen5's virtual interpolant Cx register bank to `SPI_PS_INPUT_CNTL_0..31` while folding indirect command writes.
- Keep the adjacent out-of-range virtual bank rejected.
- Add focused command-processor coverage for the first, second, and last mapped offsets.

## Root cause
`sceAgcBuildInterpolantMapping` emits `0x10000000+n` virtual offsets. Prosper applied its ordinary register-offset guard before resolving that bank, discarded all pixel-shader input controls, and left Dragon Quest VII's UI/logo pixel-shader inputs unwired.

## Validation
- Full CTest suite: 153/153 passed.
- Live Dragon Quest VII title route with audio: 15 consecutive full-resolution frames show the ocean, complete logo, “Venture Forth”, and copyright.
- Targeted GPU/render tests: `command_processor_apply`, `gpu_capture_render_replay`, `texture_sample_render`, `multidraw_render`, `interp_render`, and `textured_interp_render`.