### PR TITLE
fix(hle): complete PS5 3.20 APR event aliases

### DIFF
--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -1384,6 +1384,10 @@ HLE(k_ampr_measure_write_equeue) { // sSAUCCU1dv4 = sceAmprMeasureCommandSizeWri
     if (a0) prosper_eq_add_apr(a0, (int64_t)a1);
     return 20;
 }
+// The unversioned PS5 3.20 entry point is a pure command-size query and reserves a 0x20-byte
+// kernel-event record. Keep it separate from the older `_04_00` compatibility path above: DOLL
+// passes a live queue to that legacy sizing NID and depends on its historical 20-byte result.
+HLE(k_ampr_measure_write_equeue_on_completion) { return 0x20; }
 HLE(k_apr_cb_set_equeue) {       // H896Pt-yB4I (cb, eq, id, tag, 0, flags)
     ampr_arglog("H896Pt-yB4I(CbSetEqueue)", a0, a1, a2, a3, a4, a5);
     if (a1) prosper_eq_add_apr(a1, (int64_t)a2);
@@ -1732,7 +1736,11 @@ void register_kernel_mem_hle() {
     // registered in hle_file.cpp next to the other APR read path.
     Hle::register_fn("sSAUCCU1dv4", (HleFn)k_ampr_measure_write_equeue,
                      "sceAmprMeasureCommandSizeWriteKernelEventQueue_04_00");
+    Hle::register_fn("Zi3dBUjgyXI", (HleFn)k_ampr_measure_write_equeue_on_completion,
+                     "sceAmprMeasureCommandSizeWriteKernelEventQueueOnCompletion");
     Hle::register_fn("H896Pt-yB4I", (HleFn)k_apr_cb_set_equeue, "AprCbSetEventQueue?");
+    Hle::register_fn("o67gODLFpls", (HleFn)k_apr_cb_set_equeue,
+                     "sceAmprCommandBufferWriteKernelEventQueueOnCompletion");
     Hle::register_fn("ASoW5WE-UPo", (HleFn)k_apr_submit,        "AprSubmitCommandBuffer?");
     Hle::register_fn("GnxKOHEawhk", (HleFn)k_ampr_get_current_offset,
                      "sceAmprCommandBufferGetCurrentOffset");
@@ -4250,6 +4258,7 @@ HLE(k_query_memory_protection) {
 // Windows yet. Pure size/offset queries below keep their platform-independent return contracts.
 HLE(k_ampr_ok) { return 0; }
 HLE(k_ampr_measure_write_equeue) { return 20; }
+HLE(k_ampr_measure_write_equeue_on_completion) { return 0x20; }
 HLE(k_ampr_get_current_offset) { return 0; }
 HLE(k_ampr_measure_write_address) { return 32; }
 
@@ -4424,7 +4433,11 @@ void register_kernel_mem_hle() {
     Hle::register_fn("GuchCTefuZw", (HleFn)k_ampr_ok, "sceAmprCommandBufferDestructor");
     Hle::register_fn("sSAUCCU1dv4", (HleFn)k_ampr_measure_write_equeue,
                      "sceAmprMeasureCommandSizeWriteKernelEventQueue_04_00");
+    Hle::register_fn("Zi3dBUjgyXI", (HleFn)k_ampr_measure_write_equeue_on_completion,
+                     "sceAmprMeasureCommandSizeWriteKernelEventQueueOnCompletion");
     Hle::register_fn("H896Pt-yB4I", (HleFn)k_ampr_ok, "AprCbSetEventQueue?");
+    Hle::register_fn("o67gODLFpls", (HleFn)k_ampr_ok,
+                     "sceAmprCommandBufferWriteKernelEventQueueOnCompletion");
     Hle::register_fn("ASoW5WE-UPo", (HleFn)k_ampr_ok, "AprSubmitCommandBuffer?");
     Hle::register_fn("GnxKOHEawhk", (HleFn)k_ampr_get_current_offset,
                      "sceAmprCommandBufferGetCurrentOffset");

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -1040,6 +1040,12 @@ void prosper_eq_add_apr(uint64_t eq, int64_t id) {
         if (r.eq == eq && r.id == id) return;   // idempotent
     g_apr_eq_regs.push_back({ eq, id });
 }
+HLE(k_add_ampr_event) {   // sceKernelAddAmprEvent(eq, id, udata)
+    if (a0) prosper_eq_add_apr(a0, (int64_t)a1);
+    if (evlog()) fprintf(stderr, "[ev] AddAmprEvent eq=0x%llx id=%lld udata=0x%llx\n",
+        (unsigned long long)a0, (long long)a1, (unsigned long long)a2);
+    return 0;
+}
 
 // --- SceKernelEvent field accessors (Kyty EventQueue.cpp:318-378: plain field reads). The APR
 // listener consumes its events EXCLUSIVELY through sceKernelGetEventData; unimplemented-0 here made
@@ -1241,6 +1247,7 @@ void register_kernel_time_hle() {
     R("sceKernelGetEventFilter", k_get_event_filter); R("sceKernelGetEventFflags", k_get_event_fflags);
     R("sceKernelGetEventUserData", k_get_event_udata);R("sceKernelGetEventError", k_get_event_error);
     R("sceKernelAddHRTimerEvent", k_add_hrtimer_event); R("sceKernelAddUserEvent", k_add_user_event);
+    R("sceKernelAddAmprEvent", k_add_ampr_event);
     R("sceKernelAddUserEventEdge", k_add_user_event);   R("sceKernelTriggerUserEvent", k_trigger_user_event);
     R("sceKernelDeleteUserEvent", k_del_user_event);   R("sceKernelDeleteHRTimerEvent", k_del_timer_event);
     R("sceKernelDeleteTimerEvent", k_del_timer_event); R("sceKernelAddTimerEvent", k_add_timer_event);

--- a/prosper/tests/test_ampr_measure.cpp
+++ b/prosper/tests/test_ampr_measure.cpp
@@ -1,6 +1,7 @@
-// Regression guard for the libSceAmpr command-size NIDs used by Sonic Origins. These functions
-// return byte counts, not status codes. A sizing-only call must remain pure, while DOLL's older SDK
-// wrapper passes a registered APR id and relies on the same entry point to fill its destination.
+// Regression guard for the libSceAmpr command-size and completion NIDs used by Sonic Origins and
+// Pathless. Size queries return byte counts, not status codes. A sizing-only call must remain pure,
+// while DOLL's older SDK wrapper passes a registered APR id and relies on its legacy entry point to
+// fill the destination.
 #include "../src/hle/dispatch.hpp"
 #include <array>
 #include <cstdint>
@@ -24,8 +25,19 @@ int main() {
 
     HleFn write_address = Hle::lookup("4fgtGfXDrFc");
     HleFn write_equeue  = Hle::lookup("sSAUCCU1dv4");
+    HleFn write_equeue_320 = Hle::lookup("Zi3dBUjgyXI");
+    HleFn append_equeue = Hle::lookup("H896Pt-yB4I");
+    HleFn append_equeue_320 = Hle::lookup("o67gODLFpls");
+    HleFn add_ampr_event = Hle::lookup("bBfz7kMF2Ho");
     HleFn read_file     = Hle::lookup("vWU-odnS+fU");
-    CHECK(write_address && write_equeue && read_file, "AMPR measure NIDs registered");
+    CHECK(write_address && write_equeue && write_equeue_320 && append_equeue && append_equeue_320 &&
+              add_ampr_event && read_file,
+          "AMPR measure and completion-event NIDs registered");
+    CHECK(append_equeue_320 == append_equeue,
+          "PS5 3.20 kernel-equeue writer aliases the modeled completion path");
+    if (add_ampr_event)
+        CHECK(add_ampr_event(0, 0, 0, 0, 0, 0) == 0,
+              "AMPR event registration accepts a null queue as a no-op");
 
     if (write_address) {
         CHECK(write_address(8, 0, 0, 0, 0, 0) == 32,
@@ -36,6 +48,9 @@ int main() {
     if (write_equeue)
         CHECK(write_equeue(0, 0, 0, 0, 0, 0) == 20,
               "kernel-equeue command measures 20 bytes");
+    if (write_equeue_320)
+        CHECK(write_equeue_320(0, 0, 0, 0, 0, 0) == 0x20,
+              "PS5 3.20 kernel-equeue command measures a 0x20-byte record");
     if (read_file) {
         CHECK(read_file(0, 0, UINT32_MAX, 0xffffffffffull, 0, 0) == 24,
               "wide-offset read command measures 24 bytes (never EINVAL)");


### PR DESCRIPTION
Advances #1213.

## Failure and root cause

Pathless imports the PS5 3.20 AMPR completion functions under the unversioned NIDs `Zi3dBUjgyXI` and `o67gODLFpls`, and registers its listener through `sceKernelAddAmprEvent` (`bBfz7kMF2Ho`). Prosper only registered the older `_04_00`/unknown-NID spellings of the same completion path.

The generic zero-return stubs therefore let command construction continue but never bound the command buffer to the listener queue. `ASoW5WE-UPo` treated the read as unbound, posted no completion event, and Unreal waited forever after `GlobalShaderCache-SF_PS5.bin`.

## Behavioral contract

- The 3.20 measure entry point returns the firmware record size, `0x20` bytes.
- The 3.20 event writer uses the existing modeled completion binding, preserving the exact guest-chosen token and queue/id.
- `sceKernelAddAmprEvent(eq, id, udata)` registers the queue/id with Prosper's APR registry.
- DOLL's older `sSAUCCU1dv4` compatibility behavior remains deliberately unchanged at 20 bytes with its legacy registration side effect.
- Windows retains its existing no-op command-writer behavior; this PR only adds its missing name and pure size-query parity there.

This is intentionally limited to the missing aliases. The later Pathless allocator-canary failure exposed after streaming begins is a separate frontier on #1213.

## Verification

Exact base: `8f4306974d0558887b116c7d71b138e0a8adde33`

```text
cmake --build prosper/build-audit -j 12
ctest --test-dir prosper/build-audit --output-on-failure -j 12
```

Result: build passed; 146/146 tests passed.

Focused regression:

```text
ctest --test-dir prosper/build-audit -R '^ampr_measure$' --output-on-failure
```

Result: passed, including the 3.20 size contract, writer alias, and event-registration lookup.

Live Linux A/B on `PPSA01826-app0`, AMD Radeon 8060S / RADV:

- Base: zero presents after 180 seconds; last progress was `PreLoadFile ../../../Engine/GlobalShaderCache-SF_PS5.bin wasn't ready...`.
- Patched diagnostic run: six AMPR ids registered, exact completion tokens starting at the guest's seeded counter were delivered, and asset streaming continued through hundreds of reads before the later allocator-canary failure.

The run still produced no composited frame, so no black/diagnostic screenshot is attached or claimed as visible progression evidence.
