### PR TITLE
fix(hle): accept PS5 AJM initialization config

### DIFF
--- a/prosper/src/hle/hle_audio.cpp
+++ b/prosper/src/hle/hle_audio.cpp
@@ -1447,6 +1447,7 @@ namespace {
     constexpr uint64_t AJM_ERR_INVALID_INSTANCE  = (uint64_t)(int64_t)(int32_t)0x80930003u;
     constexpr uint64_t AJM_ERR_INVALID_BATCH     = (uint64_t)(int64_t)(int32_t)0x80930004u;
     constexpr uint64_t AJM_ERR_INVALID_PARAMETER = (uint64_t)(int64_t)(int32_t)0x80930005u;
+    constexpr uint64_t AJM_INITIALIZE_PS5_CONFIG = 0x200000000ull;
 
     // The four pointer-returning builder exports serialize a batch from 8/16-byte chunks. These
     // layout values are shared by Sony's PS4-inherited AJM ABI and the PS5 3.20 export surface.
@@ -1583,9 +1584,10 @@ std::map<uint32_t, AjmDecodeInst> g_ajm2_inst;             // instance id -> cod
 std::map<uint64_t, std::vector<AjmDecJob>> g_ajm2_jobs;   // batchInfo -> queued decode jobs
 } // namespace
 
-// sceAjmInitialize(s64 reserved, u32* out_context): create a context. Filling out_context is the point.
+// sceAjmInitialize(u64 config, u32* out_context): create a context. PS4-style callers pass zero,
+// while PS5 titles also use the observed 0x200000000 configuration value.
 HLE(ajm_initialize) {
-    if (a0 != 0 || !a1) return AJM_ERR_INVALID_PARAMETER;
+    if ((a0 != 0 && a0 != AJM_INITIALIZE_PS5_CONFIG) || !a1) return AJM_ERR_INVALID_PARAMETER;
     if (!a2_store_u32(a1, g_ajm_next.fetch_add(1))) return AJM_ERR_INVALID_PARAMETER;
     return 0;
 }

--- a/prosper/tests/test_ajm.cpp
+++ b/prosper/tests/test_ajm.cpp
@@ -83,9 +83,14 @@ int main() {
     CHECK(init(0, 0, 0, 0, 0, 0) == kInvalidParameter, "Initialize(NULL out) -> INVALID_PARAMETER");
     CHECK(init(0, 1, 0, 0, 0, 0) == kInvalidParameter,
           "Initialize(inaccessible out) -> INVALID_PARAMETER without host fault");
+    uint32_t ps5_ctx = 0xBEEF;
+    CHECK(init(0x200000000ull, (uint64_t)(uintptr_t)&ps5_ctx, 0, 0, 0, 0) == 0,
+          "Initialize(PS5 config) -> OK");
+    CHECK(ps5_ctx != 0 && ps5_ctx != 0xBEEF,
+          "Initialize(PS5 config) writes a valid non-zero context");
     uint32_t rejected_ctx = 0xCAFE;
     CHECK(init(1, (uint64_t)(uintptr_t)&rejected_ctx, 0, 0, 0, 0) == kInvalidParameter,
-          "Initialize(nonzero reserved) -> INVALID_PARAMETER");
+          "Initialize(unknown config) -> INVALID_PARAMETER");
     CHECK(rejected_ctx == 0xCAFE, "invalid Initialize leaves the context output untouched");
 
     // ModuleRegister needs a context.


### PR DESCRIPTION
## Summary

- accept the PS5 AJM initialization configuration value observed in Pathless
- retain invalid-parameter handling for unknown configuration values and bad output pointers
- cover the PS5 path with a focused AJM regression test

## Root cause

Pathless calls `sceAjmInitialize(0x200000000, &context)`. Prosper rejected every nonzero first argument with `SCE_AJM_ERROR_INVALID_PARAMETER`, which made the title unwind audio initialization. That unwind exposed the misleading MallocBinned2 corruption-canary failure seen in #1213.

## Behavioral contract

AJM initialization accepts the existing zero configuration and the exact PS5 value `0x200000000`. Other nonzero values remain invalid, invalid output pointers retain fault-safe error handling, and all other AJM lifecycle and decode behavior is deliberately unchanged.

## Impact

Pathless now completes AJM context and codec registration and continues into later startup GPU work instead of aborting during audio initialization. This is diagnostic startup progression, not a claim of a new visible rendering checkpoint.

## Risk

The PS5 value is inferred from the live title call site and runtime behavior rather than public SDK documentation. Whitelisting only the observed value limits the compatibility change and preserves the previous validation for unknown values.

## Validation at exact head `0876cfe470488357305deece60aaa98fed8ee1e3`

- `cmake --build prosper/build-audit --target test_ajm test_ajm_mp3 boot_trace -j2` — passed
- `prosper/build-audit/test_ajm` — passed
- `prosper/build-audit/test_ajm_mp3` — passed
- 45-second Pathless `boot_trace` — AJM codecs 1 and 24 registered, audio batch initialized, and process remained alive until the deliberate timeout
- `git diff --check` — passed
- repository core verification wrapper — unavailable because this devcontainer has neither `powershell` nor `pwsh`
- GitHub CI — all six required platform jobs passed

Progresses #1213