### PR TITLE
tool(gpu_replay): --recompile-raw offline A/B; PROSPER_MIPLOG/BUFLOG provenance logs

### DIFF
--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -3445,6 +3445,19 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                     // restricted to plain-2D RGBA8 sampled guest textures. Cube/volume stacks,
                     // storage images, RTT-backed bindings, and other formats keep one level.
                     uint32_t tex_mip_levels = 1;
+                    // PROSPER_MIPLOG=1: report every texture binding's mip-eligibility inputs —
+                    // which gate leg starves a declared chain down to one level (#1287 moiré).
+                    static const bool miplog_enabled = getenv("PROSPER_MIPLOG") != nullptr;
+                    if (miplog_enabled && r.tw >= 64 && !r.is_storage_image)
+                        fprintf(stderr,
+                                "[miplog] %ux%ux%u dim=%u declared_mips=%u fmt=%d rtt=%llu ds=%llu "
+                                "rgba=%d min_lod=%.1f max_lod=%.1f mag=%u min=%u mip=%u\n",
+                                r.tw, r.th, r.td, r.img_dim, r.declared_mip_levels,
+                                (int)r.texture_format,
+                                (unsigned long long)r.persistent_render_target_id,
+                                (unsigned long long)r.persistent_depth_target_id,
+                                r.tex_rgba != nullptr, r.min_lod, r.max_lod,
+                                r.mag_filter, r.min_filter, r.mip_filter);
                     if (!r.is_storage_image && r.img_dim == 1 && r.td == 1 &&
                         !r.persistent_render_target_id && r.tex_rgba &&
                         // Widening this format gate requires BLIT_SRC/BLIT_DST +
@@ -3818,6 +3831,22 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                     if (!words || !word_count) {
                         words = &zero_buffer_word;
                         word_count = 1;
+                    }
+                    // PROSPER_BUFLOG=1: per-binding upload provenance — set/binding, word count,
+                    // and the first dwords as floats. Ground truth for "which bytes did the shader
+                    // see" when a fetch-offset defect is suspected (the #1287 palette-UV audit).
+                    static const bool buflog_enabled = getenv("PROSPER_BUFLOG") != nullptr;
+                    if (buflog_enabled) {
+                        static int buflog_count = 0;
+                        if (buflog_count++ < 400) {
+                            const float* fp = reinterpret_cast<const float*>(words);
+                            fprintf(stderr,
+                                    "[buflog] set=%u binding=%u words=%zu id=%llx f0=%g f1=%g f2=%g\n",
+                                    r.set, r.binding, word_count,
+                                    (unsigned long long)r.buffer_identity,
+                                    word_count > 0 ? fp[0] : 0.f, word_count > 1 ? fp[1] : 0.f,
+                                    word_count > 2 ? fp[2] : 0.f);
+                        }
                     }
                     ++resource_reuse_stats.buffer_references;
                     ++backend_hash_stats_totals().references;

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -274,6 +274,31 @@ tap); inert and byte-identical when the env var is unset. The re-recompile drops
 value derived from `gl_FragCoord`/sample position reads 0 (visualise fetch/sample/colour intermediates, not
 FragCoord-dependent terms).
 
+## Offline recompiler A/B — `--recompile-raw` (does a recompiler change fix/regress this frame?)
+
+```bash
+./build-linux/gpu_replay ~/cap/frame.prgcap /tmp/stored.bmp                    # stored (capture-time) shaders
+./build-linux/gpu_replay --recompile-raw ~/cap/frame.prgcap /tmp/current.bmp   # CURRENT recompiler
+# [recompile-raw] substituted vs=1563 fs=1563 kept-stored vs=0 fs=0 of 1563 draws
+```
+
+A capsule stores already-recompiled SPIR-V, so recompiler changes are invisible to a default replay.
+`--recompile-raw` re-recompiles **every** retained raw VS/FS with the current recompiler and substitutes the
+results — any v19+ capsule becomes a deterministic ~seconds-per-iteration A/B vehicle for recompiler work
+(compare the replay hashes / BMPs), instead of a multi-minute live route per experiment. This was the
+iteration loop that localized #1394 for #1287. Items without a retained raw stream, or whose re-recompile
+fails, keep their stored SPIR-V — the `[recompile-raw]` line counts them; a nonzero `kept-stored` means the
+A/B is partial, never silent. Composes with `PROSPER_FS_TAP` (masked during the mass loop so the per-draw tap
+block keeps exclusive ownership of its semantic draw). Interface hints are re-derived from the raw streams,
+the same contract as the probes above.
+
+Two render_runner provenance logs pair with it when a capsule replay disagrees with expectations
+(both inert by default): `PROSPER_MIPLOG=1` prints each texture binding's mip-eligibility inputs
+(extent, declared chain, format, RTT/DS identity, LOD clamps, filters — which #1272 gate leg starved a
+chain), and `PROSPER_BUFLOG=1` prints each buffer binding's upload provenance (set/binding/word count/
+identity/first floats, capped) — ground truth for "which bytes did the shader actually see" (the #1287
+palette-UV audit).
+
 `--dump-shader DRAW:vs|fs PATH` writes the recompiled SPIR-V. `DRAW` is the semantic ID printed by
 `--inspect-only`, as it is for the probes above. Capture v19 adds
 `--dump-realized-shader DRAW:vs|fs PATH` for the exact bounded raw RDNA2 stream that produced that realized

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -54,6 +54,7 @@ void usage(const char* argv0) {
                          "[--bundle-find-ds ADDR] "
                          "[--bundle-zero-boundary] "
                          "[--draw-steps PREFIX [--draw-steps-every N] [--draw-steps-target WxH]] "
+                         "[--recompile-raw] "
                          "[--prepend producer.prgcap] "
                          "[--dump-resource DRAW:vs|ps:BINDING PATH] [--allow-mismatch] "
                          "[--dump-rtt-seed ADDR PATH] "
@@ -1180,6 +1181,7 @@ int replay_bundle(const std::string& path, const char* output_path, bool zero_bo
 
 int main(int argc, char** argv) {
     bool inspect = false, inspect_only = false, validate_only = false, allow_mismatch = false;
+    bool recompile_raw = false;
     bool graph_only = false, bundle_zero_boundary = false, bundle_ds_summary = false;
     bool legacy_htile_before_stencil = false, draw_with_compute_prefix = false;
     size_t bundle_tail = 0;
@@ -1216,6 +1218,7 @@ int main(int argc, char** argv) {
             graph_only = true; graph_json_path = argv[++i];
         }
         else if (std::string(argv[i]) == "--allow-mismatch") allow_mismatch = true;
+        else if (std::string(argv[i]) == "--recompile-raw") recompile_raw = true;
         else if (std::string(argv[i]) == "--legacy-htile-before-stencil")
             legacy_htile_before_stencil = true;
         else if (std::string(argv[i]) == "--bundle" && i + 1 < argc) bundle_path = argv[++i];
@@ -1377,6 +1380,42 @@ int main(int argc, char** argv) {
     prosper::gpu::GpuReplayFrame replay;
     if (!prosper::gpu::materialize_gpu_replay(capture, replay, error)) {
         std::fprintf(stderr, "gpu_replay: cannot materialize: %s\n", error.c_str()); return 2;
+    }
+    // --recompile-raw: a capsule stores already-recompiled SPIR-V, so recompiler changes are
+    // invisible to a default replay. This mode re-recompiles EVERY retained raw VS/FS with the
+    // CURRENT recompiler and substitutes the result, turning any v19+ capsule into a deterministic
+    // offline A/B vehicle for recompiler work (stored vs current output diff via the replay hash —
+    // the #1394/#1287 localization loop). Items without a retained raw stream, or whose
+    // re-recompile fails, keep their stored SPIR-V — counted and reported, never silent.
+    // PROSPER_FS_TAP is masked during the mass loop (recompile_fragment reads it per compile, so an
+    // unmasked env would tap every shader containing that pc) and restored after, so the per-draw
+    // tap block below still applies to exactly its semantic draw. Interface hints (pixel/system
+    // inputs) are not retained by captures; nullptr matches the FS-tap/geom-probe precedent and the
+    // VS/FS interface itself is re-derived deterministically from the raw streams on both sides.
+    if (recompile_raw) {
+        const char* tap_env_raw = std::getenv("PROSPER_FS_TAP");
+        const std::string tap_env = tap_env_raw ? tap_env_raw : "";
+        if (tap_env_raw) unsetenv("PROSPER_FS_TAP");
+        size_t vs_swapped = 0, fs_swapped = 0, vs_kept = 0, fs_kept = 0;
+        for (auto& it : replay.items) {
+            if (it.vs_raw_shader_index < replay.raw_shader_versions.size()) {
+                const auto& raw = replay.raw_shader_versions[it.vs_raw_shader_index];
+                auto vs = prosper::gpu::recompile_vertex(raw.words.data(), raw.words.size(),
+                                                         it.vrt.get(), nullptr, false);
+                if (!vs.empty()) { it.vs = std::move(vs); it.vs_shared.reset(); it.vs_identity = 0; ++vs_swapped; }
+                else ++vs_kept;
+            } else ++vs_kept;
+            if (it.fs_raw_shader_index < replay.raw_shader_versions.size()) {
+                const auto& raw = replay.raw_shader_versions[it.fs_raw_shader_index];
+                auto fs = prosper::gpu::recompile_fragment(raw.words.data(), raw.words.size(),
+                                                           it.prt.get(), nullptr, UINT32_MAX, nullptr);
+                if (!fs.empty()) { it.fs = std::move(fs); it.fs_shared.reset(); it.fs_identity = 0; ++fs_swapped; }
+                else ++fs_kept;
+            } else ++fs_kept;
+        }
+        if (tap_env_raw) setenv("PROSPER_FS_TAP", tap_env.c_str(), 1);
+        std::fprintf(stderr, "[recompile-raw] substituted vs=%zu fs=%zu kept-stored vs=%zu fs=%zu of %zu draws\n",
+                     vs_swapped, fs_swapped, vs_kept, fs_kept, replay.items.size());
     }
     // Geometry probe (PROSPER_GEOM_PROBE=N): a capsule stores already-recompiled SPIR-V, so to capture
     // draw N's gl_Position via transform feedback we re-recompile its raw RDNA2 VS with xfb decorations


### PR DESCRIPTION
The surviving tooling from the #1394/#1287 localization session (the recompiler fixes themselves landed independently overnight via #1399/#1401/#1402/#1404; my equivalent PR #1397 is closed as superseded — see its thread for the snapshot-gate A/B dossier).

## What this adds (all inert by default)

- **`gpu_replay --recompile-raw`**: re-recompiles every retained raw VS/FS with the **current** recompiler and substitutes the results, making any v19+ capsule a deterministic offline A/B vehicle for recompiler work — stored vs current output via the replay hash, ~5 s per iteration on the 1594-op Blue Prince hall frame vs a ~8 min live route. This is the loop that localized #1394. Composes with the semantic-draw `PROSPER_FS_TAP` (#1396): the env is masked during the mass loop (recompile_fragment reads it per compile; unmasked it would tap every shader containing that pc) and restored for the per-draw tap block. Items with missing/failed raw streams keep stored SPIR-V, counted and reported.
- **`PROSPER_MIPLOG=1`** (render_runner): logs each texture binding's mip-eligibility inputs (extent, declared chain, format, RTT/DS identity, LOD clamps, filters) — the probe that exonerated the #1272 mip gate during the #1287 moiré hunt.
- **`PROSPER_BUFLOG=1`** (render_runner): logs each buffer binding's upload provenance (set/binding/word count/identity/first floats, capped at 400 lines) — the probe that proved the palette-UV vertex attribute reaches the backend byte-intact in the #1287 audit.

## Verification (exact head)

- `ctest`: **152/152**.
- `--recompile-raw` on `lit_frame.prgcap`: substitutes 1563/1563 draws; output hash differs from the stored-SPIR-V replay exactly as expected (master's recompiler now contains #1399/#1401, the capsule predates them).
- Composed tap: `PROSPER_FS_TAP=1153:399 gpu_replay --recompile-raw …` reports `draw=1153 item=1149 operation=1172` (the #1396 semantic mapping) and changes the replay hash — the tap bites exactly its draw through the mass substitution.
- Snapshot gate deliberately not run: the render_runner edits are env-gated log statements (cached `static const bool`, off by default) and the gpu_replay change is behind an explicit flag — no default rendering path changes by construction. (The suite also remains load-volatile on this shared box — see the #1397 dossier.)

## Affected / unaffected

Default behavior: byte-identical everywhere. With flags: only diagnostic output, except `--recompile-raw` which intentionally replaces replay shaders.