### PR TITLE
fix(hle): advance PS5 3.20 AMPR command buffers

### DIFF
--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -2236,6 +2236,8 @@ extern uint64_t g_apr_last_cb, g_apr_last_cb_size;
 // Mark an APR request frame eventful (async streaming read -> equeue completion event) or sync;
 // consumed by the ASoW5WE-UPo submit handler (hle_kernel_mem.cpp, issue #180).
 void prosper_apr_mark_eventful(uint64_t req, bool eventful);
+// Account for the encoded ReadFile record in the command buffer's GetCurrentOffset state.
+void prosper_ampr_advance(uint64_t cb, uint64_t bytes);
 // Tracked-mapping state probe (hle_kernel_mem.cpp): 1 = addr is inside a guest-RESERVED range
 // whose pages lazy-commit on first touch. Used by the read path's dst-write to replicate the
 // fault handler's commit-on-write semantics for kernel-side (process_vm_writev) copies.
@@ -2621,6 +2623,7 @@ extern "C" uint64_t f_apr_read_submit(uint64_t a0, uint64_t a1, uint64_t a2,
     if (!ok || in_dst) {
         munmap(slot, rounded);   // failure: record stays -> guest reports it; success-into-dst: staging no longer needed
     }
+    if (ok) prosper_ampr_advance(a0, (offset >> 32) ? 24 : 20);
     if (filelog()) fprintf(stderr, "[apr] read-submit id=%llu %s -> dst=0x%llx(%s) off=0x%llx size=%llu got=%lld %s\n",
                    (unsigned long long)id, host.c_str(),
                    in_dst ? (unsigned long long)a4 : (unsigned long long)(uintptr_t)slot,
@@ -2656,6 +2659,7 @@ extern "C" uint64_t f_apr_read_submit(uint64_t a0, uint64_t a1, uint64_t a2,
             *(uint64_t*)(uintptr_t)(a2 + 0x10) = size;
     }
     if (in_dst) ::free(slot);
+    prosper_ampr_advance(a0, (offset >> 32) ? 24 : 20);
     if (filelog()) fprintf(stderr,
         "[apr] read-submit id=%llu %s -> dst=0x%llx(%s) off=0x%llx size=%llu got=%llu OK\n",
         (unsigned long long)id, host.c_str(),

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -1386,7 +1386,9 @@ HLE(k_ampr_write_address) {   // j0+3uJMxYJY (cb, address, value, flags)
 // + live tag-echo captures).
 uint64_t prosper_apr_next_token(unsigned ring);                          // hle_kernel_time.cpp
 void prosper_eq_add_apr(uint64_t eq, int64_t id);                        // "
-void prosper_eq_post_apr_token(uint64_t eq, int64_t id, uint64_t token); // " (tag echo, #208)
+uint64_t prosper_eq_identity(uint64_t eq);                               // " (lifetime guard)
+void prosper_eq_post_apr_token(uint64_t eq, uint64_t eq_identity,
+                               int64_t id, uint64_t token);              // " (tag echo, #208)
 namespace {
     // Command-buffer ctxs bound to the APR event queue via H896Pt-yB4I, with the binding's a3 TAG
     // and target equeue. The tag IS the guest-chosen completion token for that cb ((ring<<58)|n,
@@ -1399,7 +1401,7 @@ namespace {
     // the engine believed batch #1 was in flight forever and the whole async IO pipeline jammed
     // behind it (the CreateGlobalShaderMap precache stall).
     struct AprBoundCb {
-        uint64_t cb, tag, eq;
+        uint64_t cb, tag, eq, eq_identity;
         int64_t id;
         bool deduplicate_completion;
         bool completion_posted;
@@ -1441,7 +1443,8 @@ namespace {
                 ready.push_back(b);
             }
             lk.unlock();
-            for (const auto& b : ready) prosper_eq_post_apr_token(b.eq, b.id, b.tag);
+            for (const auto& b : ready)
+                prosper_eq_post_apr_token(b.eq, b.eq_identity, b.id, b.tag);
             lk.lock();
         }
     }
@@ -1461,6 +1464,16 @@ namespace {
                 return true;
             }
         return false;
+    }
+    void apr_cb_cancel_tail(uint64_t cb) {
+        AprBoundState& state = apr_bound_state();
+        std::lock_guard<std::mutex> lk(state.mx);
+        for (auto& b : state.cbs) {
+            if (b.cb != cb || !b.deduplicate_completion) continue;
+            b.fallback_pending = false;
+            b.completion_posted = true;
+            break;
+        }
     }
     // Per-request "eventful" marks for UNBOUND one-shot cbs (issue #180). The engine drives two
     // flavors of sceAmprAprCommandBufferReadFile through ONE wrapper (identical guest-RA chains):
@@ -1503,6 +1516,11 @@ HLE(k_ampr_measure_write_equeue) { // sSAUCCU1dv4 = sceAmprMeasureCommandSizeWri
     if (a0) prosper_eq_add_apr(a0, (int64_t)a1);
     return 20;
 }
+HLE(k_ampr_destruct_320) {
+    ampr_arglog("AmprCommandBufferDestructor", a0, a1, a2, a3, a4, a5);
+    apr_cb_cancel_tail(a0);
+    return 0;
+}
 // The unversioned PS5 3.20 entry point is a pure command-size query and reserves a 0x20-byte
 // kernel-event record. Keep it separate from the older `_04_00` compatibility path above: DOLL
 // passes a live queue to that legacy sizing NID and depends on its historical 20-byte result.
@@ -1520,6 +1538,7 @@ static uint64_t apr_cb_set_equeue(uint64_t command_size, bool eager_completion,
         for (auto& b : state.cbs)
             if (b.cb == a0) {
                 b.tag = a3; b.eq = a1; b.id = (int64_t)a2;
+                b.eq_identity = prosper_eq_identity(a1);
                 b.deduplicate_completion = eager_completion;
                 b.completion_posted = false;
                 b.fallback_pending = eager_completion && a1 && a3;
@@ -1529,7 +1548,8 @@ static uint64_t apr_cb_set_equeue(uint64_t command_size, bool eager_completion,
                 break;
             }
         if (!seen)
-            state.cbs.push_back({ a0, a3, a1, (int64_t)a2, eager_completion, false,
+            state.cbs.push_back({ a0, a3, a1, prosper_eq_identity(a1), (int64_t)a2,
+                                  eager_completion, false,
                                   eager_completion && a1 && a3,
                                   std::chrono::steady_clock::now() +
                                       std::chrono::milliseconds(10) });
@@ -1590,7 +1610,8 @@ HLE(k_apr_submit) {              // libkernel ASoW5WE-UPo (cb, ring_1based, out1
                            (unsigned long long)a0, (unsigned long long)a1,
                            (unsigned long long)a2, (unsigned long long)a3, (unsigned long long)token,
                            bound ? " (bound)" : "", apr_req_eventful(a0) ? " (arg8-async)" : "");
-    if (tag_echo && should_post) prosper_eq_post_apr_token(bc.eq, bc.id, bc.tag);
+    if (tag_echo && should_post)
+        prosper_eq_post_apr_token(bc.eq, bc.eq_identity, bc.id, bc.tag);
     // Submit consumes the encoded commands. Pathless reuses completed pool buffers without calling
     // the public Reset/ClearBuffer NIDs between batches, so the next append must observe a fresh
     // cursor even though the fixed capacity remains attached to the command-buffer object.
@@ -1892,8 +1913,10 @@ void register_kernel_mem_hle() {
     // libSceAmpr corpus (sceAmprCommandBuffer<Verb>): ClearBuffer and GetSize.
     Hle::register_fn("ULvXMDz56po", (HleFn)k_ampr_x2, "sceAmprCommandBufferClearBuffer");
     Hle::register_fn("tZDDEo2tE5k", (HleFn)k_ampr_getsize, "sceAmprCommandBufferGetSize");
-    Hle::register_fn("Qs1xtplKo0U", (HleFn)k_ampr_x3, "sceAmprAprCommandBufferDestructor");
-    Hle::register_fn("GuchCTefuZw", (HleFn)k_ampr_x4, "sceAmprCommandBufferDestructor");
+    Hle::register_fn("Qs1xtplKo0U", (HleFn)k_ampr_destruct_320,
+                     "sceAmprAprCommandBufferDestructor");
+    Hle::register_fn("GuchCTefuZw", (HleFn)k_ampr_destruct_320,
+                     "sceAmprCommandBufferDestructor");
     // APR completion-event plumbing (issue #115). vWU-odnS+fU (the direct async file read) is
     // registered in hle_file.cpp next to the other APR read path.
     Hle::register_fn("sSAUCCU1dv4", (HleFn)k_ampr_measure_write_equeue,

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -8,6 +8,11 @@
 #include "sync_futex.hpp"   // shared futex wake + waiter registration (also used by the GPU's label wake)
 #include "../host/guest_memory_map.hpp"
 #include "../host/guest_write_watch.hpp"
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+#include <unordered_map>
 
 namespace prosper {
 // #312/#946 huge-reserve redirect threshold, shared by the Linux and Windows reserve paths (one
@@ -15,6 +20,70 @@ namespace prosper {
 // (only UE's 512 GiB MallocBinned3 flex arena qualifies) is steered off its low hint into the
 // guest auto window. See k_reserve_vrange (POSIX) / win_reserve (Windows).
 inline constexpr uint64_t kHugeReserveLen = 0x2000000000ull;   // 128 GiB
+
+// libSceAmpr command-buffer accounting is host-platform independent. UE4 batches commands until
+// `GetSize(cb) - GetCurrentOffset(cb)` can no longer hold the next packet, then submits that cb.
+// Keep the fixed capacity and appended-byte cursor together so constructor and reset operations
+// cannot leave half-stale state when guest addresses are recycled.
+namespace {
+struct AmprCbState { uint64_t capacity = 0, offset = 0; bool tracks_offset = false; };
+std::mutex g_ampr_cb_state_mx;
+std::unordered_map<uint64_t, AmprCbState> g_ampr_cb_state;
+
+uint64_t ampr_cb_capacity_arg(uint64_t a1, uint64_t a2, uint64_t a5) {
+    // Observed constructor shapes place capacity in a1 (APR request), a2 (Pathless IoStore batch),
+    // or a5 (DOLL IoStore batch). Pointer-valued arguments are outside this conservative bound.
+    if (a1 && a1 <= 0x100000) return a1;
+    // DOLL uses a2=1 as a mode flag and carries capacity in a5. Pathless's PS5 3.20 shape instead
+    // supplies the actual command-buffer size in a2, so accept only a plausible packet capacity.
+    if (a2 >= 0x20 && a2 <= 0x100000) return a2;
+    if (a5 && a5 <= 0x100000) return a5;
+    return 0;
+}
+
+void ampr_cb_construct(uint64_t cb, uint64_t capacity, bool tracks_offset) {
+    if (!cb) return;
+    std::lock_guard<std::mutex> lock(g_ampr_cb_state_mx);
+    if (g_ampr_cb_state.size() >= 4096 && !g_ampr_cb_state.count(cb))
+        g_ampr_cb_state.erase(g_ampr_cb_state.begin());
+    auto& state = g_ampr_cb_state[cb];
+    // Several SDK flows refresh a live object through a constructor-shaped call whose size slots
+    // are all zero/pointers. The previous capacity map updated only when it decoded a nonzero size;
+    // preserve that contract instead of erasing a valid capacity on the refresh.
+    if (capacity) state.capacity = capacity;
+    state.offset = 0;
+    state.tracks_offset = tracks_offset;
+}
+
+void ampr_cb_reset(uint64_t cb) {
+    if (!cb) return;
+    std::lock_guard<std::mutex> lock(g_ampr_cb_state_mx);
+    auto it = g_ampr_cb_state.find(cb);
+    if (it != g_ampr_cb_state.end()) it->second.offset = 0;
+}
+
+uint64_t ampr_cb_capacity(uint64_t cb) {
+    std::lock_guard<std::mutex> lock(g_ampr_cb_state_mx);
+    auto it = g_ampr_cb_state.find(cb);
+    return it == g_ampr_cb_state.end() ? 0 : it->second.capacity;
+}
+
+uint64_t ampr_cb_offset(uint64_t cb) {
+    std::lock_guard<std::mutex> lock(g_ampr_cb_state_mx);
+    auto it = g_ampr_cb_state.find(cb);
+    return it == g_ampr_cb_state.end() ? 0 : it->second.offset;
+}
+}
+
+// The ReadFile builder lives in hle_file.cpp; expose the one state transition it shares with the
+// other AMPR builders without exposing the map itself.
+void prosper_ampr_advance(uint64_t cb, uint64_t bytes) {
+    if (!cb || !bytes) return;
+    std::lock_guard<std::mutex> lock(g_ampr_cb_state_mx);
+    auto it = g_ampr_cb_state.find(cb);
+    if (it != g_ampr_cb_state.end() && it->second.tracks_offset)
+        it->second.offset += bytes;
+}
 }
 
 #if defined(__linux__) || defined(__APPLE__)
@@ -1154,26 +1223,17 @@ namespace { bool amprlog() { static int v = getenv("PROSPER_AMPRLOG") ? 1 : 0; r
 // lives inside cbBuf (the "CB offset 40" of the guest's error message is a byte offset into it).
 // Exposed so the read-submit HLE can locate and decode the real command. CONFIDENCE: MED.
 uint64_t g_apr_last_cb = 0, g_apr_last_cb_size = 0;
-// Per-cb capacity, recorded at init (issue #208 follow-up). Two live-captured init flavors carry
-// the size in different args: the APR read flow inits (req, cbSize=a1, 0, cbBuf=a3, poolCtx, 3),
-// and the IoStore batch-append cb inits (cb=a0, 0, 0, 0, -1, size=a5 — observed a5=0x720). The
+// Per-cb capacity, recorded at init (issue #208 follow-up). Live-captured init flavors carry the
+// size in different args: the APR read flow uses a1; Pathless's IoStore batch uses a2=0x560; and
+// DOLL's IoStore batch uses a5=0x720. The
 // guest's append loop (eboot+0x227e2c0) polls GetSize(cb) - GetUsed(cb) and only appends the next
 // command when the difference exceeds 0xff — with the old global "last size" (0 for this cb) the
 // loop spun forever, parking the IoStore thread and stalling the whole post-shader-map load.
-namespace {
-    std::mutex g_ampr_cb_mx;
-    std::unordered_map<uint64_t, uint64_t> g_ampr_cb_size;   // cb ctx -> byte capacity
-}
 HLE(k_ampr_init) {
     if (a3 > 0xffff && a1 && a1 <= 0x10000) { g_apr_last_cb = a3; g_apr_last_cb_size = a1; }
-    if (a0 > 0xffff) {
-        uint64_t sz = (a1 && a1 <= 0x100000) ? a1 : (a5 && a5 <= 0x100000) ? a5 : 0;
-        if (sz) {
-            std::lock_guard<std::mutex> lk(g_ampr_cb_mx);
-            g_ampr_cb_size[a0] = sz;
-            if (g_ampr_cb_size.size() > 4096) g_ampr_cb_size.clear();   // bound (ctxs recycle)
-        }
-    }
+    if (a0 > 0xffff)
+        ampr_cb_construct(a0, ampr_cb_capacity_arg(a1, a2, a5),
+                          a2 >= 0x20 && a2 <= 0x100000); // Pathless 3.20 uses a2=0x560; DOLL uses 0/1
     if (amprlog()) {
         fprintf(stderr, "[amprlog] init  a0=0x%llx a1=0x%llx a2=0x%llx a3=0x%llx a4=0x%llx a5=0x%llx\n",
                 (unsigned long long)a0, (unsigned long long)a1, (unsigned long long)a2,
@@ -1211,8 +1271,16 @@ static uint64_t ampr_arglog(const char* tag, uint64_t a0, uint64_t a1, uint64_t 
     }
     return 0;
 }
-HLE(k_ampr_x1) { return ampr_arglog("baQO9ez2gL4", a0, a1, a2, a3, a4, a5); }
-HLE(k_ampr_x2) { return ampr_arglog("ULvXMDz56po", a0, a1, a2, a3, a4, a5); }
+HLE(k_ampr_x1) {
+    ampr_arglog("baQO9ez2gL4", a0, a1, a2, a3, a4, a5);
+    ampr_cb_reset(a0);
+    return 0;
+}
+HLE(k_ampr_x2) {
+    ampr_arglog("ULvXMDz56po", a0, a1, a2, a3, a4, a5);
+    ampr_cb_reset(a0);
+    return 0;
+}
 // sceAmprCommandBufferGetSize (NID tZDDEo2tE5k, recovered by brute-forcing nid_hash over a
 // generated libSceAmpr corpus). Returns the command buffer's byte CAPACITY. Live contract
 // (issue #208 follow-up, guest append loop eboot+0x227e2c0, wrapper 0x59b5dd0): the IoStore
@@ -1227,11 +1295,7 @@ HLE(k_ampr_x2) { return ampr_arglog("ULvXMDz56po", a0, a1, a2, a3, a4, a5); }
 HLE(k_ampr_getsize) {
     (void)a1; (void)a2; (void)a3; (void)a4; (void)a5;
     ampr_arglog("tZDDEo2tE5k(GetSize)", a0, a1, a2, a3, a4, a5);
-    {
-        std::lock_guard<std::mutex> lk(g_ampr_cb_mx);
-        auto it = g_ampr_cb_size.find(a0);
-        if (it != g_ampr_cb_size.end()) return it->second;
-    }
+    if (uint64_t capacity = ampr_cb_capacity(a0)) return capacity;
     return g_apr_last_cb_size ? g_apr_last_cb_size : 0x10000;
 }
 HLE(k_ampr_x3) { return ampr_arglog("Qs1xtplKo0U", a0, a1, a2, a3, a4, a5); }
@@ -1334,13 +1398,68 @@ namespace {
     // pre-#180 code posted an invented per-ring counter (seq 1,2,...) that could never match, so
     // the engine believed batch #1 was in flight forever and the whole async IO pipeline jammed
     // behind it (the CreateGlobalShaderMap precache stall).
-    struct AprBoundCb { uint64_t cb, tag, eq; int64_t id; };
-    std::mutex g_apr_bound_mx;
-    std::vector<AprBoundCb> g_apr_bound_cbs;
-    bool apr_cb_bound(uint64_t cb, AprBoundCb* out = nullptr) {
-        std::lock_guard<std::mutex> lk(g_apr_bound_mx);
-        for (auto& b : g_apr_bound_cbs)
-            if (b.cb == cb) { if (out) *out = b; return true; }
+    struct AprBoundCb {
+        uint64_t cb, tag, eq;
+        int64_t id;
+        bool deduplicate_completion;
+        bool completion_posted;
+        bool fallback_pending;
+        std::chrono::steady_clock::time_point fallback_due;
+    };
+    struct AprBoundState {
+        std::mutex mx;
+        std::condition_variable cv;
+        std::vector<AprBoundCb> cbs;
+        bool worker_started = false;
+    };
+    // The fallback worker is detached and outlives main, so its synchronization state must not run
+    // static destructors during process shutdown.
+    AprBoundState& apr_bound_state() {
+        static AprBoundState* state = new AprBoundState;
+        return *state;
+    }
+    void apr_tail_worker() {
+        AprBoundState& state = apr_bound_state();
+        std::unique_lock<std::mutex> lk(state.mx);
+        for (;;) {
+            auto next = std::chrono::steady_clock::time_point::max();
+            for (const auto& b : state.cbs)
+                if (b.fallback_pending && b.fallback_due < next) next = b.fallback_due;
+            if (next == std::chrono::steady_clock::time_point::max()) {
+                state.cv.wait(lk);
+                continue;
+            }
+            if (state.cv.wait_until(lk, next) != std::cv_status::timeout) continue;
+
+            const auto now = std::chrono::steady_clock::now();
+            std::vector<AprBoundCb> ready;
+            for (auto& b : state.cbs) {
+                if (!b.fallback_pending || b.fallback_due > now) continue;
+                b.fallback_pending = false;
+                if (!b.deduplicate_completion || b.completion_posted) continue;
+                b.completion_posted = true;
+                ready.push_back(b);
+            }
+            lk.unlock();
+            for (const auto& b : ready) prosper_eq_post_apr_token(b.eq, b.id, b.tag);
+            lk.lock();
+        }
+    }
+    bool apr_cb_submit_state(uint64_t cb, AprBoundCb* out, bool* should_post) {
+        AprBoundState& state = apr_bound_state();
+        std::lock_guard<std::mutex> lk(state.mx);
+        for (auto& b : state.cbs)
+            if (b.cb == cb) {
+                if (out) *out = b;
+                if (should_post) {
+                    *should_post = !b.deduplicate_completion || !b.completion_posted;
+                    if (b.deduplicate_completion) {
+                        b.completion_posted = true;
+                        b.fallback_pending = false;
+                    }
+                }
+                return true;
+            }
         return false;
     }
     // Per-request "eventful" marks for UNBOUND one-shot cbs (issue #180). The engine drives two
@@ -1388,17 +1507,55 @@ HLE(k_ampr_measure_write_equeue) { // sSAUCCU1dv4 = sceAmprMeasureCommandSizeWri
 // kernel-event record. Keep it separate from the older `_04_00` compatibility path above: DOLL
 // passes a live queue to that legacy sizing NID and depends on its historical 20-byte result.
 HLE(k_ampr_measure_write_equeue_on_completion) { return 0x20; }
-HLE(k_apr_cb_set_equeue) {       // H896Pt-yB4I (cb, eq, id, tag, 0, flags)
+static uint64_t apr_cb_set_equeue(uint64_t command_size, bool eager_completion,
+                                 uint64_t a0, uint64_t a1, uint64_t a2,
+                                 uint64_t a3, uint64_t a4, uint64_t a5) {
     ampr_arglog("H896Pt-yB4I(CbSetEqueue)", a0, a1, a2, a3, a4, a5);
     if (a1) prosper_eq_add_apr(a1, (int64_t)a2);
+    bool start_worker = false;
     if (a0) {
-        std::lock_guard<std::mutex> lk(g_apr_bound_mx);
+        AprBoundState& state = apr_bound_state();
+        std::lock_guard<std::mutex> lk(state.mx);
         bool seen = false;
-        for (auto& b : g_apr_bound_cbs)
-            if (b.cb == a0) { b.tag = a3; b.eq = a1; b.id = (int64_t)a2; seen = true; break; }
-        if (!seen) g_apr_bound_cbs.push_back({ a0, a3, a1, (int64_t)a2 });
+        for (auto& b : state.cbs)
+            if (b.cb == a0) {
+                b.tag = a3; b.eq = a1; b.id = (int64_t)a2;
+                b.deduplicate_completion = eager_completion;
+                b.completion_posted = false;
+                b.fallback_pending = eager_completion && a1 && a3;
+                b.fallback_due = std::chrono::steady_clock::now() +
+                                 std::chrono::milliseconds(10);
+                seen = true;
+                break;
+            }
+        if (!seen)
+            state.cbs.push_back({ a0, a3, a1, (int64_t)a2, eager_completion, false,
+                                  eager_completion && a1 && a3,
+                                  std::chrono::steady_clock::now() +
+                                      std::chrono::milliseconds(10) });
+        if (eager_completion && !state.worker_started) {
+            state.worker_started = true;
+            start_worker = true;
+        }
+    }
+    prosper_ampr_advance(a0, command_size);
+    // prosper executes ReadFile eagerly while this completion command is appended. Normally the
+    // guest submits immediately and k_apr_submit posts the event. Pathless can drain its work queue
+    // with one partial 3.20 batch left unsent, though: no later append rechecks the flush gate and
+    // every worker sleeps waiting for that already-complete read. After a grace period, complete
+    // only a binding that still has not been claimed by submit. Rebinding replaces the buffer's tag
+    // and deadline, while completion_posted deduplicates the submit and fallback paths.
+    if (start_worker) std::thread(apr_tail_worker).detach();
+    if (eager_completion) {
+        apr_bound_state().cv.notify_one();
     }
     return 0;
+}
+HLE(k_apr_cb_set_equeue) {       // H896Pt-yB4I: legacy eager path keeps zero used bytes
+    return apr_cb_set_equeue(0, false, a0, a1, a2, a3, a4, a5);
+}
+HLE(k_apr_cb_set_equeue_320) {   // o67gODLFpls: PS5 3.20 0x20-byte completion command
+    return apr_cb_set_equeue(0x20, true, a0, a1, a2, a3, a4, a5);
 }
 HLE(k_apr_submit) {              // libkernel ASoW5WE-UPo (cb, ring_1based, out1, out2)
     unsigned ring = a1 ? (unsigned)(a1 - 1) & 0x3f : 0;
@@ -1421,7 +1578,8 @@ HLE(k_apr_submit) {              // libkernel ASoW5WE-UPo (cb, ring_1based, out1
     //     unconditional last:=cnt store (+0x2274143), setting up the fatal +0x229df3e walk (the
     //     #180 residual fault). CONFIDENCE: HIGH (static disassembly + live tag-echo runs).
     AprBoundCb bc{};
-    const bool bound = apr_cb_bound(a0, &bc);
+    bool should_post = false;
+    const bool bound = apr_cb_submit_state(a0, &bc, &should_post);
     const bool tag_echo = bound && bc.tag && bc.eq;
     uint64_t token = tag_echo ? bc.tag : prosper_apr_next_token(ring);
     if (!bound) {
@@ -1432,14 +1590,18 @@ HLE(k_apr_submit) {              // libkernel ASoW5WE-UPo (cb, ring_1based, out1
                            (unsigned long long)a0, (unsigned long long)a1,
                            (unsigned long long)a2, (unsigned long long)a3, (unsigned long long)token,
                            bound ? " (bound)" : "", apr_req_eventful(a0) ? " (arg8-async)" : "");
-    if (tag_echo) prosper_eq_post_apr_token(bc.eq, bc.id, bc.tag);
+    if (tag_echo && should_post) prosper_eq_post_apr_token(bc.eq, bc.id, bc.tag);
+    // Submit consumes the encoded commands. Pathless reuses completed pool buffers without calling
+    // the public Reset/ClearBuffer NIDs between batches, so the next append must observe a fresh
+    // cursor even though the fixed capacity remains attached to the command-buffer object.
+    ampr_cb_reset(a0);
     return 0;
 }
-// sceAmprCommandBufferGetCurrentOffset. The current command-buffer model does not yet retain this
-// state, and callers observed so far query a freshly reset buffer, for which zero is exact.
+// sceAmprCommandBufferGetCurrentOffset: byte cursor after the commands appended since construction,
+// reset, or clear. Pathless uses this with GetSize to decide when an IoStore batch must be submitted.
 HLE(k_ampr_get_current_offset) {
     ampr_arglog("GnxKOHEawhk(GetCurrentOffset)", a0, a1, a2, a3, a4, a5);
-    return 0;
+    return ampr_cb_offset(a0);
 }
 // Sonic Origins sums this result with the ReadFile and equeue sizes to reserve each AMPR command
 // buffer. Use the conservative 32-byte firmware-compatible record size.
@@ -1739,7 +1901,7 @@ void register_kernel_mem_hle() {
     Hle::register_fn("Zi3dBUjgyXI", (HleFn)k_ampr_measure_write_equeue_on_completion,
                      "sceAmprMeasureCommandSizeWriteKernelEventQueueOnCompletion");
     Hle::register_fn("H896Pt-yB4I", (HleFn)k_apr_cb_set_equeue, "AprCbSetEventQueue?");
-    Hle::register_fn("o67gODLFpls", (HleFn)k_apr_cb_set_equeue,
+    Hle::register_fn("o67gODLFpls", (HleFn)k_apr_cb_set_equeue_320,
                      "sceAmprCommandBufferWriteKernelEventQueueOnCompletion");
     Hle::register_fn("ASoW5WE-UPo", (HleFn)k_apr_submit,        "AprSubmitCommandBuffer?");
     Hle::register_fn("GnxKOHEawhk", (HleFn)k_ampr_get_current_offset,
@@ -4257,9 +4419,22 @@ HLE(k_query_memory_protection) {
 // (PPSA17942, area:ue4) allocator pages remain no-op stubs because that title does not boot on
 // Windows yet. Pure size/offset queries below keep their platform-independent return contracts.
 HLE(k_ampr_ok) { return 0; }
+HLE(k_ampr_init) {
+    ampr_cb_construct(a0, ampr_cb_capacity_arg(a1, a2, a5),
+                      a2 >= 0x20 && a2 <= 0x100000); // match the POSIX 3.20 discriminator
+    return 0;
+}
+HLE(k_ampr_reset) { ampr_cb_reset(a0); return 0; }
+HLE(k_ampr_getsize) {
+    if (uint64_t capacity = ampr_cb_capacity(a0)) return capacity;
+    return 0x10000;
+}
 HLE(k_ampr_measure_write_equeue) { return 20; }
 HLE(k_ampr_measure_write_equeue_on_completion) { return 0x20; }
-HLE(k_ampr_get_current_offset) { return 0; }
+HLE(k_ampr_append_equeue_legacy) { return 0; }
+HLE(k_ampr_append_equeue_320) { prosper_ampr_advance(a0, 0x20); return 0; }
+HLE(k_ampr_submit) { ampr_cb_reset(a0); return 0; }
+HLE(k_ampr_get_current_offset) { return ampr_cb_offset(a0); }
 HLE(k_ampr_measure_write_address) { return 32; }
 
 // APR command-buffer WriteAddress (NID j0+3uJMxYJY) — the completion-notification write (#1149).
@@ -4423,22 +4598,22 @@ void register_kernel_mem_hle() {
     Hle::register_fn("Hc4CaR6JBL0", (HleFn)k_wait_on_address, "sceKernelWaitOnAddress?");
     Hle::register_fn("q2y-wDIVWZA", (HleFn)k_wake_by_address, "sceKernelWakeByAddress?");
     // libSceAmpr / APR command-buffer trio + teardown — no-op stubs on Windows (area:ue4).
-    Hle::register_fn("8aI7R7WaOlc", (HleFn)k_ampr_ok, "sceAmprCommandBufferConstructor");
+    Hle::register_fn("8aI7R7WaOlc", (HleFn)k_ampr_init, "sceAmprCommandBufferConstructor");
     Hle::register_fn("a8uLzYY--tM", (HleFn)k_ampr_ok, "sceAmprAprCommandBufferConstructor");
     Hle::register_fn("N-FSPA4S3nI", (HleFn)k_ampr_ok, "sceAmprCommandBufferSetBuffer");
-    Hle::register_fn("baQO9ez2gL4", (HleFn)k_ampr_ok, "sceAmprCommandBufferReset");
-    Hle::register_fn("ULvXMDz56po", (HleFn)k_ampr_ok, "sceAmprCommandBufferClearBuffer");
-    Hle::register_fn("tZDDEo2tE5k", (HleFn)k_ampr_ok, "sceAmprCommandBufferGetSize");
+    Hle::register_fn("baQO9ez2gL4", (HleFn)k_ampr_reset, "sceAmprCommandBufferReset");
+    Hle::register_fn("ULvXMDz56po", (HleFn)k_ampr_reset, "sceAmprCommandBufferClearBuffer");
+    Hle::register_fn("tZDDEo2tE5k", (HleFn)k_ampr_getsize, "sceAmprCommandBufferGetSize");
     Hle::register_fn("Qs1xtplKo0U", (HleFn)k_ampr_ok, "sceAmprAprCommandBufferDestructor");
     Hle::register_fn("GuchCTefuZw", (HleFn)k_ampr_ok, "sceAmprCommandBufferDestructor");
     Hle::register_fn("sSAUCCU1dv4", (HleFn)k_ampr_measure_write_equeue,
                      "sceAmprMeasureCommandSizeWriteKernelEventQueue_04_00");
     Hle::register_fn("Zi3dBUjgyXI", (HleFn)k_ampr_measure_write_equeue_on_completion,
                      "sceAmprMeasureCommandSizeWriteKernelEventQueueOnCompletion");
-    Hle::register_fn("H896Pt-yB4I", (HleFn)k_ampr_ok, "AprCbSetEventQueue?");
-    Hle::register_fn("o67gODLFpls", (HleFn)k_ampr_ok,
+    Hle::register_fn("H896Pt-yB4I", (HleFn)k_ampr_append_equeue_legacy, "AprCbSetEventQueue?");
+    Hle::register_fn("o67gODLFpls", (HleFn)k_ampr_append_equeue_320,
                      "sceAmprCommandBufferWriteKernelEventQueueOnCompletion");
-    Hle::register_fn("ASoW5WE-UPo", (HleFn)k_ampr_ok, "AprSubmitCommandBuffer?");
+    Hle::register_fn("ASoW5WE-UPo", (HleFn)k_ampr_submit, "AprSubmitCommandBuffer?");
     Hle::register_fn("GnxKOHEawhk", (HleFn)k_ampr_get_current_offset,
                      "sceAmprCommandBufferGetCurrentOffset");
     Hle::register_fn("4fgtGfXDrFc", (HleFn)k_ampr_measure_write_address,

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -62,6 +62,14 @@ void ampr_cb_reset(uint64_t cb) {
     if (it != g_ampr_cb_state.end()) it->second.offset = 0;
 }
 
+void ampr_cb_destroy_320(uint64_t cb) {
+    if (!cb) return;
+    std::lock_guard<std::mutex> lock(g_ampr_cb_state_mx);
+    auto it = g_ampr_cb_state.find(cb);
+    if (it != g_ampr_cb_state.end() && it->second.tracks_offset)
+        g_ampr_cb_state.erase(it);
+}
+
 uint64_t ampr_cb_capacity(uint64_t cb) {
     std::lock_guard<std::mutex> lock(g_ampr_cb_state_mx);
     auto it = g_ampr_cb_state.find(cb);
@@ -1465,15 +1473,13 @@ namespace {
             }
         return false;
     }
-    void apr_cb_cancel_tail(uint64_t cb) {
+    void apr_cb_destroy_320_binding(uint64_t cb) {
         AprBoundState& state = apr_bound_state();
         std::lock_guard<std::mutex> lk(state.mx);
-        for (auto& b : state.cbs) {
-            if (b.cb != cb || !b.deduplicate_completion) continue;
-            b.fallback_pending = false;
-            b.completion_posted = true;
-            break;
-        }
+        auto it = std::find_if(state.cbs.begin(), state.cbs.end(), [&](const AprBoundCb& b) {
+            return b.cb == cb && b.deduplicate_completion;
+        });
+        if (it != state.cbs.end()) state.cbs.erase(it);
     }
     // Per-request "eventful" marks for UNBOUND one-shot cbs (issue #180). The engine drives two
     // flavors of sceAmprAprCommandBufferReadFile through ONE wrapper (identical guest-RA chains):
@@ -1518,7 +1524,8 @@ HLE(k_ampr_measure_write_equeue) { // sSAUCCU1dv4 = sceAmprMeasureCommandSizeWri
 }
 HLE(k_ampr_destruct_320) {
     ampr_arglog("AmprCommandBufferDestructor", a0, a1, a2, a3, a4, a5);
-    apr_cb_cancel_tail(a0);
+    apr_cb_destroy_320_binding(a0);
+    ampr_cb_destroy_320(a0);
     return 0;
 }
 // The unversioned PS5 3.20 entry point is a pure command-size query and reserves a 0x20-byte
@@ -4448,6 +4455,7 @@ HLE(k_ampr_init) {
     return 0;
 }
 HLE(k_ampr_reset) { ampr_cb_reset(a0); return 0; }
+HLE(k_ampr_destruct) { ampr_cb_destroy_320(a0); return 0; }
 HLE(k_ampr_getsize) {
     if (uint64_t capacity = ampr_cb_capacity(a0)) return capacity;
     return 0x10000;
@@ -4627,8 +4635,10 @@ void register_kernel_mem_hle() {
     Hle::register_fn("baQO9ez2gL4", (HleFn)k_ampr_reset, "sceAmprCommandBufferReset");
     Hle::register_fn("ULvXMDz56po", (HleFn)k_ampr_reset, "sceAmprCommandBufferClearBuffer");
     Hle::register_fn("tZDDEo2tE5k", (HleFn)k_ampr_getsize, "sceAmprCommandBufferGetSize");
-    Hle::register_fn("Qs1xtplKo0U", (HleFn)k_ampr_ok, "sceAmprAprCommandBufferDestructor");
-    Hle::register_fn("GuchCTefuZw", (HleFn)k_ampr_ok, "sceAmprCommandBufferDestructor");
+    Hle::register_fn("Qs1xtplKo0U", (HleFn)k_ampr_destruct,
+                     "sceAmprAprCommandBufferDestructor");
+    Hle::register_fn("GuchCTefuZw", (HleFn)k_ampr_destruct,
+                     "sceAmprCommandBufferDestructor");
     Hle::register_fn("sSAUCCU1dv4", (HleFn)k_ampr_measure_write_equeue,
                      "sceAmprMeasureCommandSizeWriteKernelEventQueue_04_00");
     Hle::register_fn("Zi3dBUjgyXI", (HleFn)k_ampr_measure_write_equeue_on_completion,

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -514,10 +514,12 @@ namespace {
         std::condition_variable cv;
         std::deque<PendingEvent> ready;
         size_t coalescible_ready = 0;
+        uint64_t identity = 0;
         bool deleted = false;
     };
     PROSPER_HEAP_MUTEX(g_eq_mx);   // #707: heap-backed on macOS (std::mutex would land in the corrupted __DATA cluster)
     std::unordered_map<uint64_t, std::shared_ptr<EqState>> g_eqs;   // guest eq handle -> state
+    std::atomic<uint64_t> g_eq_next_identity{1};
     struct FlipReg { uint64_t eq; int64_t ident; uint64_t udata; };
     std::vector<FlipReg> g_flip_regs, g_vblank_regs;
     // GPU end-of-pipe (EOP) event sources registered via sceGnmAddEqEvent / GraphicsAddEqEvent
@@ -543,13 +545,17 @@ namespace {
     std::map<std::pair<uint64_t, int64_t>, TimerTok> g_timers;
     std::atomic<bool> g_pump_started{false};
 
-    std::shared_ptr<EqState> eq_find(uint64_t eq) {
+    std::shared_ptr<EqState> eq_find(uint64_t eq, uint64_t expected_identity = 0) {
         std::lock_guard lk(g_eq_mx);
         auto it = g_eqs.find(eq);
-        return it == g_eqs.end() ? nullptr : it->second;
+        if (it == g_eqs.end() ||
+            (expected_identity && it->second->identity != expected_identity))
+            return nullptr;
+        return it->second;
     }
-    void eq_post(uint64_t eq, const SceKEvent& e, bool coalesce = true) {
-        auto s = eq_find(eq); if (!s) return;
+    void eq_post(uint64_t eq, const SceKEvent& e, bool coalesce = true,
+                 uint64_t expected_identity = 0) {
+        auto s = eq_find(eq, expected_identity); if (!s) return;
         std::lock_guard<std::mutex> lk(s->m);
         if (s->deleted) return;
         // kqueue semantics: one knote per (ident, filter) — a re-trigger UPDATES the pending event
@@ -749,8 +755,16 @@ void prosper_eq_trigger_eop() {
     q.cv.notify_one();
 }
 
+// Stable identity for the current lifetime of an opaque equeue handle. Allocator address reuse can
+// give a later queue the same handle, so delayed producers must retain and validate this value.
+uint64_t prosper_eq_identity(uint64_t eq) {
+    auto s = eq_find(eq);
+    return s ? s->identity : 0;
+}
+
 HLE(k_eq_create) {
     auto s = std::make_shared<EqState>();
+    s->identity = g_eq_next_identity.fetch_add(1, std::memory_order_relaxed);
     if (a0) *(void**)P(a0) = (void*)s.get();   // the guest's opaque SceKernelEqueue handle IS our state ptr
     { std::lock_guard lk(g_eq_mx); g_eqs[(uint64_t)(uintptr_t)s.get()] = s; }
     if (evlog()) fprintf(stderr, "[ev] CreateEqueue -> eq=%p name=%s\n", (void*)s.get(), a1 ? (const char*)P(a1) : "");
@@ -932,10 +946,11 @@ namespace {
     std::vector<AprEqReg> g_apr_eq_regs;               // guarded by g_apr_mx (registration log)
     uint64_t g_apr_ring_seq[64] = {};                  // per-ring counters for prosper-issued tokens
     uint64_t g_apr_tag_hwm[64] = {};                   // per-ring highest tag counter posted (guarded)
-    void apr_post(const AprEqReg& r, unsigned ring, uint64_t token) {   // no APR lock held
-        SceKEvent e{}; e.ident = r.id + (int64_t)ring; e.filter = EVFILT_AMPR_MODELED;
+    void apr_post(uint64_t eq, uint64_t eq_identity, int64_t id,
+                  unsigned ring, uint64_t token) {   // no APR lock held
+        SceKEvent e{}; e.ident = id + (int64_t)ring; e.filter = EVFILT_AMPR_MODELED;
         e.data = (int64_t)token; e.udata = 0;
-        eq_post(r.eq, e);
+        eq_post(eq, e, /*coalesce=*/true, eq_identity);
     }
 }
 // Post an EXACT guest-chosen completion token (the H896Pt-yB4I binding tag) to the binding's own
@@ -945,7 +960,9 @@ namespace {
 // recorded at post time, not the captured token: two deferred posts can run out of order, and the
 // coalesced knote must never regress the "completed up to" counter (the listener walks
 // last+1..cnt, so the highest counter covers every pending batch on the ring).
-void prosper_eq_post_apr_token(uint64_t eq, int64_t id, uint64_t token) {
+void prosper_eq_post_apr_token(uint64_t eq, uint64_t eq_identity,
+                               int64_t id, uint64_t token) {
+    if (!eq_identity) return;
     // TWO tag dialects share the H896 binding call, discriminated by the binding's id (a2):
     //   id = 0x74fe+ring (the FAPREventQueueListener channel, #208): tag = (ring<<58)|counter with
     //     a ctor-seeded dense per-ring counter. The listener range-walks last+1..cnt, so the knote
@@ -979,7 +996,7 @@ void prosper_eq_post_apr_token(uint64_t eq, int64_t id, uint64_t token) {
         // no H896/ASoW after it, all delivered events balanced — matches exactly).
         if (evlog()) fprintf(stderr, "[ev] AprPtrTagComplete tag=0x%llx -> eq=0x%llx scheduled\n",
                              (unsigned long long)token, (unsigned long long)eq);
-        struct PtrPost { uint64_t eq; uint64_t token; };
+        struct PtrPost { uint64_t eq, eq_identity, token; };
         struct PtrQueue { std::mutex mx; std::condition_variable cv; std::deque<PtrPost> q; };
         static PtrQueue* pq = new PtrQueue;   // immortal: the worker is detached and outlives exit
         static std::atomic<bool> started{false};
@@ -994,12 +1011,12 @@ void prosper_eq_post_apr_token(uint64_t eq, int64_t id, uint64_t token) {
                 nanosleep(&ts, nullptr);
                 for (auto& p : batch) {
                     SceKEvent e{}; e.ident = 0; e.filter = EVFILT_AMPR_MODELED; e.data = (int64_t)p.token;
-                    eq_post(p.eq, e, /*coalesce=*/false);
+                    eq_post(p.eq, e, /*coalesce=*/false, p.eq_identity);
                 }
                 lk.lock();
             }
         }).detach();
-        { std::lock_guard<std::mutex> lk(pq->mx); pq->q.push_back({ eq, token }); }
+        { std::lock_guard<std::mutex> lk(pq->mx); pq->q.push_back({ eq, eq_identity, token }); }
         pq->cv.notify_one();
         return;
     }
@@ -1011,13 +1028,12 @@ void prosper_eq_post_apr_token(uint64_t eq, int64_t id, uint64_t token) {
     }
     if (evlog()) fprintf(stderr, "[ev] AprTagComplete token=0x%llx (ring=%u) -> eq=0x%llx scheduled\n",
                          (unsigned long long)token, ring, (unsigned long long)eq);
-    std::thread([eq, id, ring] {
+    std::thread([eq, eq_identity, id, ring] {
         struct timespec ts{ 0, 2000000 };   // 2 ms
         nanosleep(&ts, nullptr);
         uint64_t hwm;
         { std::lock_guard lk(g_apr_mx); hwm = g_apr_tag_hwm[ring]; }
-        AprEqReg r{ eq, id };
-        apr_post(r, ring, ((uint64_t)ring << 58) | hwm);
+        apr_post(eq, eq_identity, id, ring, ((uint64_t)ring << 58) | hwm);
     }).detach();
 }
 // Assign the next completion token for `ring` (0-based, 6 bits) — for UNBOUND submits only, whose

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -945,7 +945,10 @@ namespace {
     PROSPER_HEAP_MUTEX(g_apr_mx);   // #707: heap-backed on macOS (hot APR mutex in the corrupted __DATA cluster)
     std::vector<AprEqReg> g_apr_eq_regs;               // guarded by g_apr_mx (registration log)
     uint64_t g_apr_ring_seq[64] = {};                  // per-ring counters for prosper-issued tokens
-    uint64_t g_apr_tag_hwm[64] = {};                   // per-ring highest tag counter posted (guarded)
+    std::unordered_map<uint64_t, uint64_t> g_apr_tag_hwm; // (equeue identity, ring) -> highest counter
+    uint64_t apr_hwm_key(uint64_t eq_identity, unsigned ring) {
+        return (eq_identity << 6) | (ring & 0x3f);
+    }
     void apr_post(uint64_t eq, uint64_t eq_identity, int64_t id,
                   unsigned ring, uint64_t token) {   // no APR lock held
         SceKEvent e{}; e.ident = id + (int64_t)ring; e.filter = EVFILT_AMPR_MODELED;
@@ -962,7 +965,7 @@ namespace {
 // last+1..cnt, so the highest counter covers every pending batch on the ring).
 void prosper_eq_post_apr_token(uint64_t eq, uint64_t eq_identity,
                                int64_t id, uint64_t token) {
-    if (!eq_identity) return;
+    if (!eq_identity || prosper_eq_identity(eq) != eq_identity) return;
     // TWO tag dialects share the H896 binding call, discriminated by the binding's id (a2):
     //   id = 0x74fe+ring (the FAPREventQueueListener channel, #208): tag = (ring<<58)|counter with
     //     a ctor-seeded dense per-ring counter. The listener range-walks last+1..cnt, so the knote
@@ -1022,17 +1025,18 @@ void prosper_eq_post_apr_token(uint64_t eq, uint64_t eq_identity,
     }
     unsigned ring = (unsigned)(token >> 58) & 0x3f;
     uint64_t cnt = token & ((1ull << 58) - 1);
+    const uint64_t hwm_key = apr_hwm_key(eq_identity, ring);
     {
         std::lock_guard lk(g_apr_mx);
-        if (cnt > g_apr_tag_hwm[ring]) g_apr_tag_hwm[ring] = cnt;
+        if (cnt > g_apr_tag_hwm[hwm_key]) g_apr_tag_hwm[hwm_key] = cnt;
     }
     if (evlog()) fprintf(stderr, "[ev] AprTagComplete token=0x%llx (ring=%u) -> eq=0x%llx scheduled\n",
                          (unsigned long long)token, ring, (unsigned long long)eq);
-    std::thread([eq, eq_identity, id, ring] {
+    std::thread([eq, eq_identity, id, ring, hwm_key] {
         struct timespec ts{ 0, 2000000 };   // 2 ms
         nanosleep(&ts, nullptr);
         uint64_t hwm;
-        { std::lock_guard lk(g_apr_mx); hwm = g_apr_tag_hwm[ring]; }
+        { std::lock_guard lk(g_apr_mx); hwm = g_apr_tag_hwm[hwm_key]; }
         apr_post(eq, eq_identity, id, ring, ((uint64_t)ring << 58) | hwm);
     }).detach();
 }

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -942,10 +942,19 @@ namespace {
     constexpr int16_t EVFILT_AMPR_MODELED = -24;   // guest never reads filter; distinct on purpose
     struct AprEqReg { uint64_t eq; int64_t id; };
     // Own mutex (NOT g_eq_mx): the post path calls eq_post/eq_find, which lock g_eq_mx themselves.
-    PROSPER_HEAP_MUTEX(g_apr_mx);   // #707: heap-backed on macOS (hot APR mutex in the corrupted __DATA cluster)
-    std::vector<AprEqReg> g_apr_eq_regs;               // guarded by g_apr_mx (registration log)
-    uint64_t g_apr_ring_seq[64] = {};                  // per-ring counters for prosper-issued tokens
-    std::unordered_map<uint64_t, uint64_t> g_apr_tag_hwm; // (equeue identity, ring) -> highest counter
+    // Detached APR delivery threads can outlive main, so the mutex and every container they touch
+    // are one intentionally immortal heap object. Heap placement also keeps the hot mutex out of
+    // the macOS __DATA cluster affected by #707.
+    struct AprTokenState {
+        std::mutex mx;
+        std::vector<AprEqReg> eq_regs;
+        uint64_t ring_seq[64] = {};
+        std::unordered_map<uint64_t, uint64_t> tag_hwm;
+    };
+    AprTokenState& apr_token_state() {
+        static AprTokenState* state = new AprTokenState;
+        return *state;
+    }
     uint64_t apr_hwm_key(uint64_t eq_identity, unsigned ring) {
         return (eq_identity << 6) | (ring & 0x3f);
     }
@@ -1027,8 +1036,9 @@ void prosper_eq_post_apr_token(uint64_t eq, uint64_t eq_identity,
     uint64_t cnt = token & ((1ull << 58) - 1);
     const uint64_t hwm_key = apr_hwm_key(eq_identity, ring);
     {
-        std::lock_guard lk(g_apr_mx);
-        if (cnt > g_apr_tag_hwm[hwm_key]) g_apr_tag_hwm[hwm_key] = cnt;
+        AprTokenState& state = apr_token_state();
+        std::lock_guard lk(state.mx);
+        if (cnt > state.tag_hwm[hwm_key]) state.tag_hwm[hwm_key] = cnt;
     }
     if (evlog()) fprintf(stderr, "[ev] AprTagComplete token=0x%llx (ring=%u) -> eq=0x%llx scheduled\n",
                          (unsigned long long)token, ring, (unsigned long long)eq);
@@ -1036,7 +1046,11 @@ void prosper_eq_post_apr_token(uint64_t eq, uint64_t eq_identity,
         struct timespec ts{ 0, 2000000 };   // 2 ms
         nanosleep(&ts, nullptr);
         uint64_t hwm;
-        { std::lock_guard lk(g_apr_mx); hwm = g_apr_tag_hwm[hwm_key]; }
+        {
+            AprTokenState& state = apr_token_state();
+            std::lock_guard lk(state.mx);
+            hwm = state.tag_hwm[hwm_key];
+        }
         apr_post(eq, eq_identity, id, ring, ((uint64_t)ring << 58) | hwm);
     }).detach();
 }
@@ -1045,8 +1059,9 @@ void prosper_eq_post_apr_token(uint64_t eq, uint64_t eq_identity,
 // event is ever posted for these — see the block comment above).
 uint64_t prosper_apr_next_token(unsigned ring) {
     ring &= 0x3f;
-    std::lock_guard lk(g_apr_mx);
-    uint64_t seq = ++g_apr_ring_seq[ring];
+    AprTokenState& state = apr_token_state();
+    std::lock_guard lk(state.mx);
+    uint64_t seq = ++state.ring_seq[ring];
     return ((uint64_t)ring << 58) | (seq & ((1ull << 58) - 1));
 }
 // Record an APR completion registration (sSAUCCU1dv4 / H896Pt-yB4I target queue). Registration is
@@ -1055,10 +1070,11 @@ uint64_t prosper_apr_next_token(unsigned ring) {
 // ctor-seeded per-ring last-processed (see the block comment above; the pre-#208 replay was the
 // root cause of the #180 range-walk fault).
 void prosper_eq_add_apr(uint64_t eq, int64_t id) {
-    std::lock_guard lk(g_apr_mx);
-    for (auto& r : g_apr_eq_regs)
+    AprTokenState& state = apr_token_state();
+    std::lock_guard lk(state.mx);
+    for (auto& r : state.eq_regs)
         if (r.eq == eq && r.id == id) return;   // idempotent
-    g_apr_eq_regs.push_back({ eq, id });
+    state.eq_regs.push_back({ eq, id });
 }
 HLE(k_add_ampr_event) {   // sceKernelAddAmprEvent(eq, id, udata)
     if (a0) prosper_eq_add_apr(a0, (int64_t)a1);

--- a/prosper/tests/test_ampr_measure.cpp
+++ b/prosper/tests/test_ampr_measure.cpp
@@ -196,6 +196,12 @@ int main() {
         std::this_thread::sleep_for(std::chrono::milliseconds(25));
         CHECK(get_count(replacement_eq, 0, 0, 0, 0, 0) == 0,
               "destroying a PS5 3.20 command buffer cancels its pending tail");
+        construct(destroyed_cb, 0, 0, 0, 0, 0);
+        uint64_t unbound_out1 = 0, unbound_out2 = 0;
+        submit(destroyed_cb, 1, (uint64_t)(uintptr_t)&unbound_out1,
+               (uint64_t)(uintptr_t)&unbound_out2, 0, 0);
+        CHECK(unbound_out1 && unbound_out1 == unbound_out2,
+              "reconstructed command buffer is unbound after PS5 3.20 destruction");
         delete_eq(replacement_eq, 0, 0, 0, 0, 0);
     }
 #endif

--- a/prosper/tests/test_ampr_measure.cpp
+++ b/prosper/tests/test_ampr_measure.cpp
@@ -3,21 +3,35 @@
 // while DOLL's older SDK wrapper passes a registered APR id and relies on its legacy entry point to
 // fill the destination.
 #include "../src/hle/dispatch.hpp"
+#include "../src/hle/nid.hpp"
 #include <array>
+#include <chrono>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
+#include <thread>
 
 using namespace prosper;
 
 namespace prosper {
 uint32_t prosper_apr_register(const std::string& path, uint64_t size);
 void prosper_apr_reset_for_test();
+void prosper_ampr_advance(uint64_t cb, uint64_t bytes);
 }
 
 static int fails = 0;
 #define CHECK(c, m) do { if (!(c)) { std::printf("  [FAIL] %s\n", m); fails++; } \
                          else       { std::printf("  [ok]   %s\n", m); } } while (0)
+
+struct KEvent {
+    int64_t ident;
+    int16_t filter;
+    uint16_t flags;
+    uint32_t fflags;
+    int64_t data;
+    uint64_t udata;
+};
+static_assert(sizeof(KEvent) == 0x20);
 
 int main() {
     std::printf("== test_ampr_measure ==\n");
@@ -28,13 +42,18 @@ int main() {
     HleFn write_equeue_320 = Hle::lookup("Zi3dBUjgyXI");
     HleFn append_equeue = Hle::lookup("H896Pt-yB4I");
     HleFn append_equeue_320 = Hle::lookup("o67gODLFpls");
+    HleFn construct      = Hle::lookup("8aI7R7WaOlc");
+    HleFn reset          = Hle::lookup("baQO9ez2gL4");
+    HleFn clear          = Hle::lookup("ULvXMDz56po");
+    HleFn get_size       = Hle::lookup("tZDDEo2tE5k");
+    HleFn get_offset     = Hle::lookup("GnxKOHEawhk");
+    HleFn submit         = Hle::lookup("ASoW5WE-UPo");
     HleFn add_ampr_event = Hle::lookup("bBfz7kMF2Ho");
     HleFn read_file     = Hle::lookup("vWU-odnS+fU");
     CHECK(write_address && write_equeue && write_equeue_320 && append_equeue && append_equeue_320 &&
-              add_ampr_event && read_file,
+              construct && reset && clear && get_size && get_offset && submit && add_ampr_event &&
+              read_file,
           "AMPR measure and completion-event NIDs registered");
-    CHECK(append_equeue_320 == append_equeue,
-          "PS5 3.20 kernel-equeue writer aliases the modeled completion path");
     if (add_ampr_event)
         CHECK(add_ampr_event(0, 0, 0, 0, 0, 0) == 0,
               "AMPR event registration accepts a null queue as a no-op");
@@ -51,6 +70,88 @@ int main() {
     if (write_equeue_320)
         CHECK(write_equeue_320(0, 0, 0, 0, 0, 0) == 0x20,
               "PS5 3.20 kernel-equeue command measures a 0x20-byte record");
+    if (construct && reset && clear && get_size && get_offset && submit && append_equeue &&
+        append_equeue_320) {
+        std::array<uint64_t, 8> cb_storage{};
+        const uint64_t cb = (uint64_t)(uintptr_t)cb_storage.data();
+        CHECK(construct(cb, 0x200000000ull, 0x560, 0, 0, 0) == 0 &&
+                  get_size(cb, 0, 0, 0, 0, 0) == 0x560,
+              "Pathless constructor shape records capacity from a2");
+        CHECK(get_offset(cb, 0, 0, 0, 0, 0) == 0,
+              "new command buffer starts at offset zero");
+        prosper_ampr_advance(cb, 24);
+        CHECK(append_equeue_320(cb, 0, 0, 0, 0, 0) == 0 &&
+                  get_offset(cb, 0, 0, 0, 0, 0) == 56,
+              "ReadFile plus PS5 3.20 completion advances by measured bytes");
+        CHECK(submit(cb, 1, 0, 0, 0, 0) == 0 && get_offset(cb, 0, 0, 0, 0, 0) == 0 &&
+                  get_size(cb, 0, 0, 0, 0, 0) == 0x560,
+              "submit consumes commands while preserving buffer capacity");
+        CHECK(clear(cb, 0, 0, 0, 0, 0) == 0 && get_offset(cb, 0, 0, 0, 0, 0) == 0,
+              "clear resets the current offset");
+        CHECK(append_equeue(cb, 0, 0, 0, 0, 0) == 0 &&
+                  get_offset(cb, 0, 0, 0, 0, 0) == 0,
+              "legacy completion writer retains eager zero-used compatibility");
+        CHECK(reset(cb, 0, 0, 0, 0, 0) == 0 && get_offset(cb, 0, 0, 0, 0, 0) == 0,
+              "reset returns the current offset to zero");
+
+        std::array<uint64_t, 8> legacy_storage{};
+        const uint64_t legacy_cb = (uint64_t)(uintptr_t)legacy_storage.data();
+        construct(legacy_cb, 0, 0, 0, 0, 0x720);
+        prosper_ampr_advance(legacy_cb, 20);
+        CHECK(get_size(legacy_cb, 0, 0, 0, 0, 0) == 0x720 &&
+                  get_offset(legacy_cb, 0, 0, 0, 0, 0) == 0,
+              "legacy a5-capacity buffers retain eager zero-used compatibility");
+        construct(legacy_cb, 0x81, 1, 0, 0, 0x5a0);
+        prosper_ampr_advance(legacy_cb, 20);
+        CHECK(get_size(legacy_cb, 0, 0, 0, 0, 0) == 0x81 &&
+                  get_offset(legacy_cb, 0, 0, 0, 0, 0) == 0,
+              "DOLL a2=1 constructor shape keeps a1 capacity and zero-used compatibility");
+        construct(legacy_cb, 0, 1, 0, 0, 0x5a0);
+        CHECK(get_size(legacy_cb, 0, 0, 0, 0, 0) == 0x5a0,
+              "DOLL a2=1 mode flag does not shadow its a5 capacity");
+    }
+#ifndef _WIN32
+    // Prosper executes ReadFile at append time. If a PS5 3.20 partial batch remains unsent when the
+    // producer queue drains, the matching completion record must eventually release its waiter;
+    // an immediate explicit submit must still produce exactly one event.
+    auto create_eq = Hle::lookup(nid_hash("sceKernelCreateEqueue"));
+    auto delete_eq = Hle::lookup(nid_hash("sceKernelDeleteEqueue"));
+    auto wait_eq = Hle::lookup(nid_hash("sceKernelWaitEqueue"));
+    auto get_count = Hle::lookup(nid_hash("sceKernelGetEventCount"));
+    if (construct && append_equeue_320 && submit && create_eq && delete_eq && wait_eq && get_count) {
+        uint64_t eq = 0;
+        create_eq((uint64_t)(uintptr_t)&eq, 0, 0, 0, 0, 0);
+        std::array<uint64_t, 8> tail_storage{};
+        const uint64_t tail_cb = (uint64_t)(uintptr_t)tail_storage.data();
+        constexpr int64_t event_id = 0x74fe;
+        constexpr uint64_t tail_tag = 0x3e8;
+        construct(tail_cb, 0, 0x560, 0, 0, 0);
+        append_equeue_320(tail_cb, eq, (uint64_t)event_id, tail_tag, 0, 0);
+        KEvent tail_event{};
+        int32_t tail_out = -1;
+        uint32_t tail_timeout = 100000;
+        wait_eq(eq, (uint64_t)(uintptr_t)&tail_event, 1, (uint64_t)(uintptr_t)&tail_out,
+                (uint64_t)(uintptr_t)&tail_timeout, 0);
+        CHECK(tail_out == 1 && tail_event.ident == event_id && tail_event.filter == -24 &&
+                  (uint64_t)tail_event.data == tail_tag,
+              "unsent PS5 3.20 tail receives one deferred eager completion");
+
+        constexpr uint64_t submitted_tag = tail_tag + 1;
+        append_equeue_320(tail_cb, eq, (uint64_t)event_id, submitted_tag, 0, 0);
+        submit(tail_cb, 1, 0, 0, 0, 0);
+        KEvent submitted_event{};
+        int32_t submitted_out = -1;
+        uint32_t submitted_timeout = 100000;
+        wait_eq(eq, (uint64_t)(uintptr_t)&submitted_event, 1,
+                (uint64_t)(uintptr_t)&submitted_out,
+                (uint64_t)(uintptr_t)&submitted_timeout, 0);
+        std::this_thread::sleep_for(std::chrono::milliseconds(25));
+        CHECK(submitted_out == 1 && (uint64_t)submitted_event.data == submitted_tag &&
+                  get_count(eq, 0, 0, 0, 0, 0) == 0,
+              "explicit submit wins the fallback race without a duplicate completion");
+        delete_eq(eq, 0, 0, 0, 0, 0);
+    }
+#endif
     if (read_file) {
         CHECK(read_file(0, 0, UINT32_MAX, 0xffffffffffull, 0, 0) == 24,
               "wide-offset read command measures 24 bytes (never EINVAL)");

--- a/prosper/tests/test_ampr_measure.cpp
+++ b/prosper/tests/test_ampr_measure.cpp
@@ -17,6 +17,9 @@ namespace prosper {
 uint32_t prosper_apr_register(const std::string& path, uint64_t size);
 void prosper_apr_reset_for_test();
 void prosper_ampr_advance(uint64_t cb, uint64_t bytes);
+uint64_t prosper_eq_identity(uint64_t eq);
+void prosper_eq_post_apr_token(uint64_t eq, uint64_t eq_identity,
+                               int64_t id, uint64_t token);
 }
 
 static int fails = 0;
@@ -48,11 +51,12 @@ int main() {
     HleFn get_size       = Hle::lookup("tZDDEo2tE5k");
     HleFn get_offset     = Hle::lookup("GnxKOHEawhk");
     HleFn submit         = Hle::lookup("ASoW5WE-UPo");
+    HleFn destruct       = Hle::lookup("GuchCTefuZw");
     HleFn add_ampr_event = Hle::lookup("bBfz7kMF2Ho");
     HleFn read_file     = Hle::lookup("vWU-odnS+fU");
     CHECK(write_address && write_equeue && write_equeue_320 && append_equeue && append_equeue_320 &&
-              construct && reset && clear && get_size && get_offset && submit && add_ampr_event &&
-              read_file,
+              construct && reset && clear && get_size && get_offset && submit && destruct &&
+              add_ampr_event && read_file,
           "AMPR measure and completion-event NIDs registered");
     if (add_ampr_event)
         CHECK(add_ampr_event(0, 0, 0, 0, 0, 0) == 0,
@@ -118,7 +122,8 @@ int main() {
     auto delete_eq = Hle::lookup(nid_hash("sceKernelDeleteEqueue"));
     auto wait_eq = Hle::lookup(nid_hash("sceKernelWaitEqueue"));
     auto get_count = Hle::lookup(nid_hash("sceKernelGetEventCount"));
-    if (construct && append_equeue_320 && submit && create_eq && delete_eq && wait_eq && get_count) {
+    if (construct && append_equeue_320 && submit && destruct && create_eq && delete_eq && wait_eq &&
+        get_count) {
         uint64_t eq = 0;
         create_eq((uint64_t)(uintptr_t)&eq, 0, 0, 0, 0, 0);
         std::array<uint64_t, 8> tail_storage{};
@@ -150,6 +155,36 @@ int main() {
                   get_count(eq, 0, 0, 0, 0, 0) == 0,
               "explicit submit wins the fallback race without a duplicate completion");
         delete_eq(eq, 0, 0, 0, 0, 0);
+
+        uint64_t stale_eq = 0;
+        create_eq((uint64_t)(uintptr_t)&stale_eq, 0, 0, 0, 0, 0);
+        const uint64_t stale_identity = prosper_eq_identity(stale_eq);
+        std::array<uint64_t, 8> stale_storage{};
+        const uint64_t stale_cb = (uint64_t)(uintptr_t)stale_storage.data();
+        construct(stale_cb, 0, 0x560, 0, 0, 0);
+        append_equeue_320(stale_cb, stale_eq, (uint64_t)event_id, tail_tag + 2, 0, 0);
+        delete_eq(stale_eq, 0, 0, 0, 0, 0);
+        uint64_t replacement_eq = 0;
+        create_eq((uint64_t)(uintptr_t)&replacement_eq, 0, 0, 0, 0, 0);
+        const uint64_t replacement_identity = prosper_eq_identity(replacement_eq);
+        CHECK(stale_identity && replacement_identity && stale_identity != replacement_identity,
+              "replacement equeue receives a distinct lifetime identity");
+        prosper_eq_post_apr_token(replacement_eq, stale_identity,
+                                  event_id, tail_tag + 3);
+        std::this_thread::sleep_for(std::chrono::milliseconds(40));
+        CHECK(get_count(replacement_eq, 0, 0, 0, 0, 0) == 0,
+              "deleted AMPR queue cannot post into a replacement lifetime");
+
+        std::array<uint64_t, 8> destroyed_storage{};
+        const uint64_t destroyed_cb = (uint64_t)(uintptr_t)destroyed_storage.data();
+        construct(destroyed_cb, 0, 0x560, 0, 0, 0);
+        append_equeue_320(destroyed_cb, replacement_eq, (uint64_t)event_id,
+                          tail_tag + 4, 0, 0);
+        destruct(destroyed_cb, 0, 0, 0, 0, 0);
+        std::this_thread::sleep_for(std::chrono::milliseconds(25));
+        CHECK(get_count(replacement_eq, 0, 0, 0, 0, 0) == 0,
+              "destroying a PS5 3.20 command buffer cancels its pending tail");
+        delete_eq(replacement_eq, 0, 0, 0, 0, 0);
     }
 #endif
     if (read_file) {

--- a/prosper/tests/test_ampr_measure.cpp
+++ b/prosper/tests/test_ampr_measure.cpp
@@ -174,6 +174,18 @@ int main() {
         std::this_thread::sleep_for(std::chrono::milliseconds(40));
         CHECK(get_count(replacement_eq, 0, 0, 0, 0, 0) == 0,
               "deleted AMPR queue cannot post into a replacement lifetime");
+        constexpr uint64_t replacement_tag = tail_tag + 1;
+        prosper_eq_post_apr_token(replacement_eq, replacement_identity,
+                                  event_id, replacement_tag);
+        KEvent replacement_event{};
+        int32_t replacement_out = -1;
+        uint32_t replacement_timeout = 100000;
+        wait_eq(replacement_eq, (uint64_t)(uintptr_t)&replacement_event, 1,
+                (uint64_t)(uintptr_t)&replacement_out,
+                (uint64_t)(uintptr_t)&replacement_timeout, 0);
+        CHECK(replacement_out == 1 &&
+                  (uint64_t)replacement_event.data == replacement_tag,
+              "stale equeue lifetime cannot poison a replacement completion token");
 
         std::array<uint64_t, 8> destroyed_storage{};
         const uint64_t destroyed_cb = (uint64_t)(uintptr_t)destroyed_storage.data();


### PR DESCRIPTION
## Summary

- model per-command-buffer AMPR capacity and current offset for the PS5 3.20 IoStore path
- account for eager ReadFile and 0x20-byte completion records, resetting the cursor on submit/reset/clear
- release an already-completed idle burst tail after a 10 ms submit grace period using one ordered fallback worker
- bind deferred APR delivery and counter high-water state to a unique equeue lifetime
- retire pending tails, bindings, and tracked cursor state on PS5 3.20 command-buffer destruction
- preserve legacy DOLL capacity decoding, zero-used cursor behavior, repeated-submit completion behavior, and binding lifetime
- add focused coverage for Pathless, both observed DOLL constructor shapes, submit/fallback deduplication, queue address reuse, counter isolation, and command-buffer address reuse

## Why

Pathless computes available AMPR space as GetSize minus GetCurrentOffset. Prosper returned zero for the offset forever, so one command buffer accumulated 889 unsubmitted commands and the async loader stopped. Modeling the measured packet sizes restores normal submits.

Prosper executes the affected ReadFile work eagerly. When a producer burst goes idle, a partial 3.20 buffer can remain unsubmitted even though its read has already completed, leaving workers asleep. The 3.20-only fallback releases an idle completed burst after a grace period unless submit claims it first. This is an eager-HLE compatibility rule, not a claim that real hardware completes unsubmitted command buffers.

During compatibility validation, DOLL exposed an a2=1 mode flag that was initially mistaken for a one-byte capacity. The decoder now accepts a2 only when it is a plausible packet capacity and otherwise retains legacy a1/a5 precedence.

Independent review reproduced two lifetime bugs in the first candidate. Deleting an equeue with a pending fallback could deliver into a replacement allocated at the same address, and a rejected stale counter could still raise the global ring high-water mark. Each equeue lifetime now has a monotonic identity captured by the binding, validated at delivery, and used to scope high-water state. Destroying a 3.20 command buffer removes its pending tail, binding, and tracked cursor object so address reuse returns to the unbound submit contract; legacy DOLL bindings remain unchanged.

## Verification

- git diff --check
- test_ampr_measure: PASS, including cursor accounting, DOLL a2=1/a5=0x5a0 decoding, tail completion, submit deduplication, equeue delete/recreate isolation, replacement-token exactness, destructor cancellation, and reconstructed unbound submit
- ctest --test-dir prosper/build-audit --output-on-failure: 146/146 passed on latest master
- DOLL PPSA17942 AMD Vulkan final smoke: frames 138 and 192 captured at 3/6 seconds; source-distinct=2, pixel-distinct=2; status=ok
- Pathless PPSA01826 AMD Vulkan final smoke: frames 93, 272, 515, 1049, and 1594 captured through 15 seconds; source-distinct=5, pixel-distinct=2; status=ok

The repository PowerShell verifier could not be run because this devcontainer has neither powershell nor pwsh installed.

## Remaining work

This advances issue #1213 past the AMPR loader deadlock. Longer runs reach a later worker null-source fault around eboot+0x1b70cd0; that downstream blocker is intentionally left for the next focused change.

Progresses #1213