### PR TITLE
tool(snapshot): serialize capture sweeps across worktrees

### DIFF
--- a/prosper/tools/snapshot/README.md
+++ b/prosper/tools/snapshot/README.md
@@ -28,6 +28,12 @@ render state, texture decode/detiling, executor behavior, or presentation.
 representative presented PNGs, the boot log, and structured per-frame evidence
 in `tools/snapshot/failures/`.
 
+`check` and `verify` hold a cooperative lock in the clone's Git common directory,
+so snapshot runs from sibling worktrees wait instead of contending for the GPU
+and shifting long-boot capture windows. The waiter prints the owning PID and
+command. Set `PROSPER_SNAPSHOT_LOCK` to share a lock across separate clones, or
+set `PROSPER_SNAPSHOT_NO_LOCK=1` only when concurrent captures are intentional.
+
 Snapshot rendering uses the shared renderer's hardware-first Vulkan selection: discrete, integrated,
 and virtual GPUs are preferred over CPU devices, with llvmpipe used only when no usable GPU is exposed.
 The selected device is printed in each retained run log.
@@ -134,3 +140,5 @@ inspection unless they fail.
 - `PROSPER_BOOT_TRACE`: `boot_trace` path; defaults to `build-linux/boot_trace`.
 - `PROSPER_SCREENSHOT`: presented-capture frontend; defaults to
   `build-linux/screenshot`.
+- `PROSPER_SNAPSHOT_LOCK`: lockfile override, useful for coordinating separate clones.
+- `PROSPER_SNAPSHOT_NO_LOCK=1`: opt out of capture serialization explicitly.

--- a/prosper/tools/snapshot/snapshot.py
+++ b/prosper/tools/snapshot/snapshot.py
@@ -100,6 +100,9 @@ def _unlock_snapshot_file(lock_file):
 def _snapshot_lock_owner(lock_path):
     try:
         with open(lock_path, encoding="utf-8") as owner_file:
+            # Byte zero is the Windows lock range and cannot be read by a
+            # contender. Owner metadata intentionally starts after it.
+            owner_file.seek(1)
             owner = json.load(owner_file)
         return f"pid {owner['pid']} ({owner['command']})"
     except (OSError, ValueError, KeyError, TypeError):
@@ -118,9 +121,11 @@ def snapshot_run_lock(command, names=(), lock_path=None):
     lock_fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
     with os.fdopen(lock_fd, "r+", encoding="utf-8") as lock_file:
         # Windows byte-range locks require the byte to exist before it is locked.
+        # Reserve byte zero exclusively for the lock so contenders can still
+        # read the owner metadata which follows it.
         lock_file.seek(0, os.SEEK_END)
         if lock_file.tell() == 0:
-            lock_file.write("\n")
+            lock_file.write(" ")
             lock_file.flush()
 
         if not _try_snapshot_file_lock(lock_file):
@@ -138,7 +143,7 @@ def snapshot_run_lock(command, names=(), lock_path=None):
             "started": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
             "cwd": os.getcwd(),
         }
-        lock_file.seek(0)
+        lock_file.seek(1)
         json.dump(owner, lock_file)
         lock_file.write("\n")
         lock_file.truncate()

--- a/prosper/tools/snapshot/snapshot.py
+++ b/prosper/tools/snapshot/snapshot.py
@@ -21,6 +21,8 @@ Env overrides:
   PROSPER_GAME_ROOT   dir holding the <dump> subdirs   (default: /mnt/c/Users/matti/repos/ps5ys)
   PROSPER_BOOT_TRACE  path to the boot_trace binary    (default: <prosper>/build-linux/boot_trace)
   PROSPER_SCREENSHOT  path to the screenshot binary    (default: <prosper>/build-linux/screenshot)
+  PROSPER_SNAPSHOT_LOCK path for the cross-worktree capture lock
+  PROSPER_SNAPSHOT_NO_LOCK=1 to allow an intentional concurrent capture
 
 Exact mode targets a frame with RENDER_EVERY=1 plus `frame`=F, so frame_<F>.bmp
 is the F-th draw submit's render. Pick F in a stable-content window and use
@@ -29,7 +31,8 @@ window of normal composited screenshots, requires multiple frames to meet `min_c
 require visible pixel changes. Its pass/fail contract uses SSIM and content coverage to catch major
 collapse without rejecting subtle pixel improvements.
 """
-import sys, os, json, time, hashlib, math, struct, subprocess, tempfile, shutil, signal, ctypes
+import sys, os, json, time, hashlib, math, struct, subprocess, tempfile, shutil, signal, ctypes, errno
+from contextlib import contextmanager
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 PROSPER_ROOT = os.path.normpath(os.path.join(HERE, "..", ".."))
@@ -40,6 +43,110 @@ GAME_ROOT = os.environ.get("PROSPER_GAME_ROOT", "/mnt/c/Users/matti/repos/ps5ys"
 
 _PR_SET_PDEATHSIG = 1
 _LIBC = ctypes.CDLL(None, use_errno=True) if sys.platform.startswith("linux") else None
+
+
+def _snapshot_lock_path():
+    override = os.environ.get("PROSPER_SNAPSHOT_LOCK")
+    if override:
+        return os.path.abspath(os.path.expanduser(override))
+
+    # All worktrees of one clone share this directory, unlike PROSPER_ROOT.
+    # Keeping the lock there makes independent agent worktrees cooperate without
+    # introducing a tracked file in any checkout.
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
+            cwd=PROSPER_ROOT, check=True, text=True, stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+        common_dir = result.stdout.strip()
+        if common_dir:
+            return os.path.join(common_dir, "prosper-snapshot.lock")
+    except (OSError, subprocess.CalledProcessError):
+        pass
+
+    # Source archives have no Git common directory. Still coordinate invocations
+    # from the same extracted tree without colliding with unrelated checkouts.
+    root_key = hashlib.sha256(os.path.realpath(PROSPER_ROOT).encode()).hexdigest()[:16]
+    return os.path.join(tempfile.gettempdir(), f"prosper-snapshot-{root_key}.lock")
+
+
+def _try_snapshot_file_lock(lock_file):
+    lock_file.seek(0)
+    try:
+        if os.name == "nt":
+            import msvcrt
+            msvcrt.locking(lock_file.fileno(), msvcrt.LK_NBLCK, 1)
+        else:
+            import fcntl
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return True
+    except OSError as error:
+        if error.errno in (errno.EACCES, errno.EAGAIN) or getattr(error, "winerror", None) in (33, 36):
+            return False
+        raise
+
+
+def _unlock_snapshot_file(lock_file):
+    lock_file.seek(0)
+    if os.name == "nt":
+        import msvcrt
+        msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
+    else:
+        import fcntl
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
+def _snapshot_lock_owner(lock_path):
+    try:
+        with open(lock_path, encoding="utf-8") as owner_file:
+            owner = json.load(owner_file)
+        return f"pid {owner['pid']} ({owner['command']})"
+    except (OSError, ValueError, KeyError, TypeError):
+        return "another snapshot process"
+
+
+@contextmanager
+def snapshot_run_lock(command, names=(), lock_path=None):
+    """Serialize resource-heavy capture commands across this clone's worktrees."""
+    if os.environ.get("PROSPER_SNAPSHOT_NO_LOCK") == "1":
+        yield
+        return
+
+    lock_path = lock_path or _snapshot_lock_path()
+    os.makedirs(os.path.dirname(os.path.abspath(lock_path)), exist_ok=True)
+    lock_fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
+    with os.fdopen(lock_fd, "r+", encoding="utf-8") as lock_file:
+        # Windows byte-range locks require the byte to exist before it is locked.
+        lock_file.seek(0, os.SEEK_END)
+        if lock_file.tell() == 0:
+            lock_file.write("\n")
+            lock_file.flush()
+
+        if not _try_snapshot_file_lock(lock_file):
+            started_waiting = time.monotonic()
+            print(f"[snapshot-lock] waiting for {_snapshot_lock_owner(lock_path)}; "
+                  f"lock={lock_path}", flush=True)
+            while not _try_snapshot_file_lock(lock_file):
+                time.sleep(0.25)
+            waited = time.monotonic() - started_waiting
+            print(f"[snapshot-lock] acquired after {waited:.1f}s", flush=True)
+
+        owner = {
+            "pid": os.getpid(),
+            "command": " ".join([command] + list(names)),
+            "started": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "cwd": os.getcwd(),
+        }
+        lock_file.seek(0)
+        json.dump(owner, lock_file)
+        lock_file.write("\n")
+        lock_file.truncate()
+        lock_file.flush()
+        try:
+            yield
+        finally:
+            _unlock_snapshot_file(lock_file)
 
 
 def _snapshot_child_setup(parent_pid):
@@ -865,7 +972,12 @@ def main():
         sys.exit(2)
     cmd, names = sys.argv[1], sys.argv[2:]
     m = load_manifest()
-    rc = {"check": cmd_check, "update": cmd_update, "verify": cmd_verify, "list": cmd_list}[cmd](m, names)
+    runner = {"check": cmd_check, "update": cmd_update, "verify": cmd_verify, "list": cmd_list}[cmd]
+    if cmd in ("check", "verify"):
+        with snapshot_run_lock(cmd, names):
+            rc = runner(m, names)
+    else:
+        rc = runner(m, names)
     sys.exit(rc or 0)
 
 

--- a/prosper/tools/snapshot/test_snapshot.py
+++ b/prosper/tools/snapshot/test_snapshot.py
@@ -17,6 +17,45 @@ SPEC.loader.exec_module(SNAPSHOT)
 
 
 class SnapshotContentTests(unittest.TestCase):
+    def test_snapshot_lock_serializes_independent_processes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            lock_path = os.path.join(tmp, "snapshot.lock")
+            child_script = """
+import importlib.util
+import json
+import os
+
+spec = importlib.util.spec_from_file_location("snapshot_child", {snapshot_path})
+snapshot = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(snapshot)
+print("attempting", flush=True)
+with snapshot.snapshot_run_lock("verify", ["child"], {lock_path}):
+    print("acquired", flush=True)
+""".format(
+                snapshot_path=json.dumps(os.path.join(HERE, "snapshot.py")),
+                lock_path=json.dumps(lock_path),
+            )
+            child = None
+            try:
+                with SNAPSHOT.snapshot_run_lock("check", ["parent"], lock_path):
+                    child = subprocess.Popen(
+                        [sys.executable, "-c", child_script],
+                        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
+                    )
+                    self.assertEqual("attempting", child.stdout.readline().strip())
+                    time.sleep(0.25)
+                    self.assertIsNone(child.poll(), "second snapshot process bypassed the lock")
+
+                output, _ = child.communicate(timeout=5)
+                self.assertEqual(0, child.returncode, output)
+                self.assertIn("[snapshot-lock] waiting for pid", output)
+                self.assertIn("[snapshot-lock] acquired after", output)
+                self.assertTrue(output.rstrip().endswith("acquired"), output)
+            finally:
+                if child is not None and child.poll() is None:
+                    child.kill()
+                    child.wait(timeout=5)
+
     @unittest.skipUnless(sys.platform.startswith("linux"), "PR_SET_PDEATHSIG is Linux-specific")
     def test_snapshot_child_dies_when_harness_is_killed(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
Fixes #1417.

## What changed

- `snapshot.py check` and `verify` now take an OS-backed cooperative lock in the clone's Git common directory, so sibling worktrees serialize resource-heavy game captures.
- A waiting invocation reports the current owner PID/command and acquires automatically when that process exits; OS lock ownership makes crashes safe.
- `PROSPER_SNAPSHOT_LOCK` coordinates separate clones, while `PROSPER_SNAPSHOT_NO_LOCK=1` explicitly permits intentional concurrency.
- Added a real cross-process regression test and documented the behavior.

## Why

Concurrent snapshot boots contend for the shared GPU/CPU and shift long wall-clock capture windows into earlier scenes, creating false rendering failures. Worktree-local conventions cannot prevent this because each agent runs from a different checkout; the Git common directory is shared by all worktrees of the clone.

## Validation

- `git diff --check`
- `python3 -m py_compile prosper/tools/snapshot/snapshot.py prosper/tools/snapshot/test_snapshot.py`
- `python3 -m unittest discover -s prosper/tools/snapshot -p 'test_*.py' -v` — 9/9 passed
- `python3 prosper/tools/snapshot/snapshot.py list`
- Verified the default lock resolves to the shared main-worktree Git directory from this sibling worktree.