### PR TITLE
fix(gpu): manually compare 2D-array shadows

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -869,21 +869,6 @@ struct SpirvCompute {
         uint32_t res   = id(); put(code, Op_ImageSampleExplicitLod, {texture_vec4(binding), res, si, coord, ImgOp_Lod, bcf(lod_bits)});
         unpack_texture_result(binding, res, out);
     }
-    // IMAGE_SAMPLE_C_LZ on a 2D array: compare the sampled depth against DREF at
-    // explicit LOD zero. Array coordinates are (u,v,layer); the comparison result is
-    // scalar and RDNA writes that value for the requested dmask component.
-    void image_sample_dref_lz_2d_array(uint32_t binding, uint32_t u_bits, uint32_t v_bits,
-                                       uint32_t layer_bits, uint32_t dref_bits, uint32_t out[4]) {
-        uint32_t si = id(); put(code, Op_Load, {tex_binding_simg[binding], si, tex_var[binding]});
-        uint32_t coord = id();
-        put(code, Op_CompositeConstruct,
-            {t_v3f(), coord, bcf(u_bits), bcf(v_bits), bcf(layer_bits)});
-        uint32_t result = id();
-        put(code, Op_ImageSampleDrefExplicitLod,
-            {t_f32, result, si, coord, bcf(dref_bits), ImgOp_Lod, fconstf(0.0f)});
-        const uint32_t bits = bcu(result);
-        out[0] = out[1] = out[2] = out[3] = bits;
-    }
     // Compare one sampled/fetched depth value against DREF and return raw float bits containing 0/1.
     uint32_t image_dref_compare_bits(uint32_t depth, uint32_t dref_bits, uint32_t compare_func) {
         if (compare_func == 0u) return bcu(fconstf(0.0f));   // NEVER
@@ -902,7 +887,8 @@ struct SpirvCompute {
         put(code, Op_Select, {t_f32, result, cmp, fconstf(1.0f), fconstf(0.0f)});
         return bcu(result);
     }
-    // IMAGE_SAMPLE_C_LZ on a plain 2D texture, lowered as a MANUAL depth compare. The hardware path
+    // IMAGE_SAMPLE_C_LZ on a plain 2D texture (or the backend's base-slice 2D_ARRAY fallback),
+    // lowered as a MANUAL depth compare. The hardware path
     // (compareEnable sampler over a depth-format view) needs backend machinery the color-texture path
     // lacks (see the render-runner S# note). NEAREST retains the exact single sampled tap. LINEAR uses
     // four level-0 fetches, compares each independently, then bilinearly weights the booleans — the
@@ -6361,9 +6347,17 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 // an ordinary color read.
                 if (uint_texture || !res->depth_compare) { ok = false; return true; }
                 if (in.mimg_dim == 5u) {
-                    b.declare_texture(res->binding, Dim_2D, false, true, true);
-                    b.image_sample_dref_lz_2d_array(
-                        res->binding, vread(cvg(1)), vread(cvg(2)), vread(cvg(3)), vread(cvg(0)), out);
+                    // The shared graphics backend currently exposes 2D_ARRAY textures as its
+                    // documented base-slice 2D view (#325). Match every other sampled DIM=5 path:
+                    // drop the slice coordinate and use the ordinary sampler plus an in-shader
+                    // compare. The old arrayed-depth declaration emitted OpImageSampleDref* against
+                    // a non-compare 2D sampler/view — invalid Vulkan usage and undefined output
+                    // (#1169). Multi-layer selection remains the pre-existing #325 limitation.
+                    b.declare_texture(res->binding, Dim_2D, false);
+                    b.image_sample_dref_manual_2d(res->binding, vread(cvg(1)), vread(cvg(2)),
+                                                  vread(cvg(0)), res->depth_compare_func,
+                                                  res->mag_filter != 0u, res->addr_uvw[0],
+                                                  res->addr_uvw[1], res->border_color_type, out);
                 } else if (in.mimg_dim == 1u) {
                     // Plain 2D form (Blue Prince's lit-material PSes, #1271: 436 rejects/run, all
                     // op 0x2f dim 1 dmask 0x1 — the entire shadowed lighting pass dropped and the

--- a/prosper/tests/test_shadow_compare_render.cpp
+++ b/prosper/tests/test_shadow_compare_render.cpp
@@ -21,6 +21,16 @@ static int fails = 0;
 #define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
                          else       { printf("  [ok]   %s\n", m); } } while (0)
 
+static bool has_spirv_opcode(const std::vector<uint32_t>& words, uint16_t opcode) {
+    for (size_t i = 5; i < words.size();) {
+        const uint16_t word_count = static_cast<uint16_t>(words[i] >> 16);
+        if (!word_count || i + word_count > words.size()) return false;
+        if (static_cast<uint16_t>(words[i]) == opcode) return true;
+        i += word_count;
+    }
+    return false;
+}
+
 int main() {
     printf("== test_shadow_compare_render ==\n");
     const uint32_t W = 128, H = 128;
@@ -91,6 +101,44 @@ int main() {
           "dref 0.5 GREATER passes (1.0) where stored depth is 0.0");
     CHECK(right_total && right_fail == right_total,
           "dref 0.5 GREATER fails (0.0) where stored depth is ~0.9");
+
+    // #1169: the remaining DIM=5 form used an arrayed depth SPIR-V image and
+    // OpImageSampleDrefExplicitLod, but the graphics backend binds an ordinary non-compare 2D
+    // sampler/view. Use the canonical NSA operand shape [dref,u,v,slice], deliberately select
+    // slice 3, and assert the established #325 base-slice fallback executes the same manual compare
+    // as DIM=1 without any Dref opcode in the module.
+    const uint32_t ps_array[] = {
+        0x7e1402f0u,                                          // v10 = 0.5 DREF
+        0x7e1602ffu, 0x3e800000u,                             // v11 = 0.25 u
+        0x7e1802f0u,                                          // v12 = 0.5 v
+        0x7e1a02ffu, 0x40400000u,                             // v13 = 3.0 slice (dropped by #325)
+        0xf0bc012au, 0x0082050au, 0x000d0c0bu,                // c_lz v5, [v10..v13], dim:2D_ARRAY
+        0xf800080fu, 0x08070605u,                             // exp mrt0 v5..v8
+        0xbf810000u,
+    };
+    ShaderResourceTable array_rt = rt;
+    array_rt.resources[0].img_dim = 5;
+    std::vector<uint32_t> array_frag = recompile_fragment(
+        ps_array, sizeof(ps_array) / sizeof(ps_array[0]), &array_rt);
+    CHECK(!array_frag.empty() && array_frag[0] == 0x07230203u,
+          "recompiled IMAGE_SAMPLE_C_LZ dim:2D_ARRAY through the base-slice fallback");
+    CHECK(!has_spirv_opcode(array_frag, 90 /* OpImageSampleDrefExplicitLod */),
+          "2D_ARRAY shadow shader contains no compare-sampler Dref instruction (#1169)");
+    if (!array_frag.empty()) {
+        prosper::test::FrameResource array_tex = nearest_tex;
+        array_tex.img_dim = 5;
+        std::vector<prosper::test::FrameResource> array_resources{array_tex};
+        std::vector<uint8_t> array_px = prosper::test::render_triangle_rgba(
+            vert, array_frag, W, H, nullptr, nullptr, nullptr, nullptr, &array_resources);
+        CHECK(array_px.size() == (size_t)W * H * 4,
+              "2D_ARRAY base-slice shadow-compare pipeline rendered a frame");
+        if (array_px.size() == (size_t)W * H * 4) {
+            const uint8_t r = array_px[(((size_t)H / 2 * W + W / 2) * 4)];
+            printf("  2D_ARRAY base-slice center R=%u (want 255)\n", r);
+            CHECK(r > 250,
+                  "2D_ARRAY base slice manually compares dref 0.5 against stored depth 0.0");
+        }
+    }
 
     // Fix #1394: hardware LINEAR comparison sampling compares all four footprint texels first and
     // only then bilinearly weights their boolean results. Pin u=v=0.5 so the 8x8 footprint straddles


### PR DESCRIPTION
Fixes #1169.

## Failure and root cause

The remaining `IMAGE_SAMPLE_C_LZ` DIM=5 path declared an arrayed depth image and emitted `OpImageSampleDrefExplicitLod`. The shared graphics backend supplies an ordinary non-compare 2D sampler/view, making that SPIR-V/Vulkan combination invalid and its shadow result undefined.

## Fix

- Route DIM=5 through the established manual depth-compare/PCF lowering used by DIM=1.
- Match the renderer's existing #325 2D-array fallback by sampling the base-slice 2D view and dropping the unsupported layer coordinate.
- Remove the obsolete arrayed-Dref emitter.
- Add an end-to-end canonical NSA DIM=5 shader test that asserts no Dref opcode is emitted, renders through the backend on RADV, and checks the expected compare result (`R=255`).

Multi-layer selection remains the documented #325 limitation; this PR makes the currently exposed base slice well-defined.

## Validation

- `git diff --check`
- `shadow_compare_render` and `recompile_coverage`: 2/2 passed
- Direct RADV execution: DIM=5 shader recompiled, contained no opcode 90, rendered a frame, and produced center `R=255`
- Full native build succeeded
- Full local CTest: 150/151 passed; only `module_loads_eboot` failed because the local Bendy dump has 611 imports/34 libraries while the fixture expects 612/35 (unrelated to this GPU-only diff)
- Full real-game snapshot matrix pending a quiet host; current load was 16 with unrelated ad-hoc game/debug boots, so the contaminated sweep was stopped before collecting evidence.