### PR TITLE
fix(gpu): lower cube shadow comparisons

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -6307,8 +6307,10 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 // (y-1)) / 6 at base LOD (mips aren't uploaded; a >0 LOD clamps to the one level).
                 // The in-face clamp stops bilinear bleed across face seams. CONFIDENCE: MED — the
                 // coordinate convention is Mesa-verified; face memory layout is validated visually.
-                if (!is_sample && !is_sample_l && !is_sample_lz && !is_sample_b) { ok = false; return true; }
-                const uint32_t ci = is_sample_b ? 1u : 0u;              // _b: bias occupies vaddr0
+                if (!is_sample && !is_sample_l && !is_sample_lz && !is_sample_b &&
+                    !is_sample_c_lz) { ok = false; return true; }
+                // Modifier-first order: _b carries bias in vaddr0; _c_lz carries DREF there.
+                const uint32_t ci = (is_sample_b || is_sample_c_lz) ? 1u : 0u;
                 uint32_t x = vread(cvg(ci)), y = vread(cvg(ci + 1)), fid = vread(cvg(ci + 2));
                 const uint32_t one = b.uconst(fbits(1.0f)), zero = b.uconst(fbits(0.0f));
                 uint32_t uf = b.fbin(Op_FSub, x, one);
@@ -6316,8 +6318,21 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 uint32_t layer = b.fext1(Glsl_RoundEven,
                                      b.fext2(Glsl_FMax, b.fext2(Glsl_FMin, fid, b.uconst(fbits(5.0f))), zero));
                 uint32_t v6 = b.fbin(Op_FMul, b.fbin(Op_FAdd, layer, vf), b.uconst(fbits(1.0f / 6.0f)));
-                b.declare_texture(res->binding, Dim_2D, uint_texture);
-                b.image_sample_lod_2d(res->binding, uf, v6, b.uconst(0), out);
+                if (is_sample_c_lz) {
+                    // Point-light shadow maps use the same cube-processed coordinates as ordinary
+                    // samples, with DREF prepended: [dref, x, y, face]. The renderer uploads cube
+                    // faces as one vertical 2D stack, so compare the transformed face coordinate
+                    // manually through its ordinary non-compare sampler (#1167/#1169).
+                    if (uint_texture || !res->depth_compare) { ok = false; return true; }
+                    b.declare_texture(res->binding, Dim_2D, false);
+                    b.image_sample_dref_manual_2d(res->binding, uf, v6, vread(cvg(0)),
+                                                  res->depth_compare_func,
+                                                  res->mag_filter != 0u, res->addr_uvw[0],
+                                                  res->addr_uvw[1], res->border_color_type, out);
+                } else {
+                    b.declare_texture(res->binding, Dim_2D, uint_texture);
+                    b.image_sample_lod_2d(res->binding, uf, v6, b.uconst(0), out);
+                }
             } else if (dim3d) {
                 // 3D: implicit-LOD / LOD-0 sample, or an integer texel FETCH (image_load — DOLL's
                 // color-grade 3D LUT, #273).
@@ -8903,7 +8918,8 @@ RecompileCoverage recompile_coverage(const uint32_t* code, size_t dwords) {
                     if (i.opcode == 0x20u || i.opcode == 0x27u || i.opcode == 0xa0u)
                         return i.mimg_dim == 1u || i.mimg_dim == 2u || i.mimg_dim == 5u;
                     if (i.opcode == 0x22u) return i.mimg_dim == 1u || i.mimg_dim == 5u;
-                    if (i.opcode == 0x2fu) return i.mimg_dim == 1u || i.mimg_dim == 5u; // IMAGE_SAMPLE_C_LZ 2D (#1271) / 2D_ARRAY
+                    if (i.opcode == 0x2fu)
+                        return i.mimg_dim == 1u || i.mimg_dim == 3u || i.mimg_dim == 5u;
                     if (i.opcode == 0x24u || i.opcode == 0x25u || i.opcode == 0x47u) return i.mimg_dim == 1u || i.mimg_dim == 5u;
                     return false;
                 }

--- a/prosper/tests/test_shadow_compare_render.cpp
+++ b/prosper/tests/test_shadow_compare_render.cpp
@@ -1,4 +1,5 @@
-// test_shadow_compare_render — IMAGE_SAMPLE_C_LZ on a plain 2D shadow map (#1271): a recompiled
+// test_shadow_compare_render — IMAGE_SAMPLE_C_LZ on 2D/2D_ARRAY/CUBE shadow maps (#1167/#1169/#1271):
+// a recompiled
 // pixel shader interpolates UVs, moves a DREF constant into the vaddr slot BEFORE them (ISA 8.2.5
 // "{z-compare}{body}" order), issues image_sample_c_lz dim:2D dmask:0x1, and exports the compare
 // result as MRT0.R. The word0 encoding (0xf0bc0108) is byte-identical to Blue Prince's live
@@ -137,6 +138,50 @@ int main() {
             printf("  2D_ARRAY base-slice center R=%u (want 255)\n", r);
             CHECK(r > 250,
                   "2D_ARRAY base slice manually compares dref 0.5 against stored depth 0.0");
+        }
+    }
+
+    // #1167: CUBE coords are the AMD cube-processed [x,y,face] form, with DREF prepended for
+    // SAMPLE_C_LZ. The backend stores six faces vertically in one 2D image. Select the center of
+    // face 3; only that face contains passing depth, so an incorrect operand order or face transform
+    // produces black instead of the asserted white compare result.
+    const uint32_t ps_cube[] = {
+        0x7e1402f0u,                                          // v10 = 0.5 DREF
+        0x7e1602ffu, 0x3fc00000u,                             // v11 = 1.5 cube x -> u 0.5
+        0x7e1802ffu, 0x3fc00000u,                             // v12 = 1.5 cube y -> v 0.5
+        0x7e1a02ffu, 0x40400000u,                             // v13 = face 3.0
+        0xf0bc0118u, 0x0082050au,                             // c_lz v5, v[10:13], dim:CUBE
+        0xf800080fu, 0x08070605u,                             // exp mrt0 v5..v8
+        0xbf810000u,
+    };
+    ShaderResourceTable cube_rt = rt;
+    cube_rt.resources[0].img_dim = 3;
+    std::vector<uint32_t> cube_frag = recompile_fragment(
+        ps_cube, sizeof(ps_cube) / sizeof(ps_cube[0]), &cube_rt);
+    CHECK(!cube_frag.empty() && cube_frag[0] == 0x07230203u,
+          "recompiled IMAGE_SAMPLE_C_LZ dim:CUBE through the stacked-face lowering (#1167)");
+    CHECK(!has_spirv_opcode(cube_frag, 90 /* OpImageSampleDrefExplicitLod */),
+          "CUBE shadow shader contains no compare-sampler Dref instruction");
+    if (!cube_frag.empty()) {
+        std::vector<uint8_t> cube(8 * 8 * 6 * 4);
+        for (uint32_t face = 0; face < 6; face++) {
+            for (uint32_t y = 0; y < 8; y++) for (uint32_t x = 0; x < 8; x++) {
+                uint8_t* t = &cube[((face * 8 + y) * 8 + x) * 4];
+                t[0] = face == 3 ? 0 : 230; t[1] = t[2] = 0; t[3] = 255;
+            }
+        }
+        prosper::test::FrameResource cube_tex = nearest_tex;
+        cube_tex.tex_rgba = cube.data(); cube_tex.tw = 8; cube_tex.th = 8 * 6;
+        cube_tex.img_dim = 3;
+        std::vector<prosper::test::FrameResource> cube_resources{cube_tex};
+        std::vector<uint8_t> cube_px = prosper::test::render_triangle_rgba(
+            vert, cube_frag, W, H, nullptr, nullptr, nullptr, nullptr, &cube_resources);
+        CHECK(cube_px.size() == (size_t)W * H * 4,
+              "stacked CUBE shadow-compare pipeline rendered a frame");
+        if (cube_px.size() == (size_t)W * H * 4) {
+            const uint8_t r = cube_px[(((size_t)H / 2 * W + W / 2) * 4)];
+            printf("  CUBE face-3 center R=%u (want 255)\n", r);
+            CHECK(r > 250, "CUBE face 3 manually compares its selected stored depth (#1167)");
         }
     }
 


### PR DESCRIPTION
## Summary

- lower `IMAGE_SAMPLE_C_LZ dim:CUBE` through the existing six-face vertical-stack coordinate transform
- preserve the ISA's modifier-first `[dref, x, y, face]` operand order and perform the depth comparison through the ordinary sampler
- add a real Vulkan execution regression that selects face 3 and verifies the generated SPIR-V contains no unsupported Dref opcode

## Testing

- `ctest --test-dir prosper/build-linux -R "recompile_coverage|shadow_compare_render" --output-on-failure` — 2/2 passed
- direct RADV execution in `shadow_compare_render` — stacked CUBE pipeline rendered; face-3 center R=255
- `ctest --test-dir prosper/build-linux -E "^module_loads_eboot$" --output-on-failure` — 150/150 passed
- full snapshot matrix was not used as evidence because the host is carrying unrelated, long-running game/debug processes; those user processes were preserved

Fixes #1167