### PR TITLE
hle: implement AGC shader-half fusion

### DIFF
--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -68,6 +68,7 @@ constexpr uint32_t R_DRAW_INDEX = 0x03, R_DRAW_INDEX_AUTO = 0x04, R_DRAW_RESET =
                    R_JUMP = 0x1e, R_SET_PRED = 0x1f;
 constexpr uint32_t R_NUM = 0x40;
 constexpr uint64_t kAgcErrInvalidArg = 0x8a6c000aull;
+constexpr uint64_t kAgcErrInvalidShaderHalves = 0x8a6c0008ull;
 inline uint32_t PM4(uint32_t len, uint32_t op, uint32_t r) {
     return 0xC0000000u | (((len - 2u) & 0x3fffu) << 16u) | ((op & 0xffu) << 8u) | ((r & (R_NUM - 1u)) << 2u);
 }
@@ -934,7 +935,118 @@ struct AgcShaderSpecialRegs {        // guest-visible (Kyty Shader.h:947); point
 };
 static_assert(offsetof(AgcShaderSpecialRegs, vgt_gs_out_prim_type) == 0x20, "specials layout");
 
+struct AgcSizeAlign {
+    uint64_t size;
+    uint64_t align;
+};
+
+constexpr uint8_t kAgcShaderGs = 2;
+constexpr uint8_t kAgcShaderHs = 3;
+constexpr uint8_t kAgcShaderGsFront = 4;
+constexpr uint8_t kAgcShaderHsFront = 5;
+constexpr uint8_t kAgcShaderGsBack = 6;
+constexpr uint8_t kAgcShaderHsBack = 7;
+
+bool agc_shader_halves_match(const AgcShader* front, const AgcShader* back) {
+    return front && back &&
+           ((front->type == kAgcShaderGsFront && back->type == kAgcShaderGsBack) ||
+            (front->type == kAgcShaderHsFront && back->type == kAgcShaderHsBack));
+}
+
+AgcShaderRegister* agc_find_shader_register(AgcShaderRegister* regs, uint32_t count,
+                                             uint32_t offset, uint32_t occurrence = 0) {
+    if (!regs) return nullptr;
+    for (uint32_t i = 0; i < count; ++i) {
+        if (regs[i].offset != offset) continue;
+        if (occurrence == 0) return &regs[i];
+        --occurrence;
+    }
+    return nullptr;
+}
+
+const AgcShaderRegister* agc_find_shader_register(const AgcShaderRegister* regs, uint32_t count,
+                                                   uint32_t offset, uint32_t occurrence = 0) {
+    if (!regs) return nullptr;
+    for (uint32_t i = 0; i < count; ++i) {
+        if (regs[i].offset != offset) continue;
+        if (occurrence == 0) return &regs[i];
+        --occurrence;
+    }
+    return nullptr;
+}
+
+void agc_patch_shader_address(AgcShaderRegister* regs, uint32_t count,
+                              uint32_t lo_offset, uint64_t address) {
+    AgcShaderRegister* lo = agc_find_shader_register(regs, count, lo_offset);
+    if (!lo || lo + 1 >= regs + count || (lo + 1)->offset != lo_offset + 1u) return;
+    lo->value = (uint32_t)((address >> 8u) & 0xffffffffu);
+    (lo + 1)->value = ((lo + 1)->value & 0xffffff00u) | (uint32_t)((address >> 40u) & 0xffu);
+}
+
 }  // namespace
+
+// sceAgcGetFusedShaderSize / sceAgcFuseShaderHalves. UE builds geometry and hull shaders from
+// separately compiled front/back halves. The size query reserves scratch space for a private copy
+// of the back half's SH-register array; fusion then patches that copy with the front program address
+// (and GS checksums), producing an ordinary type-2 GS or type-3 HS shader. Returning success without
+// these writes left UE's stack-local fused Shader uninitialized, so a later TaskGraph worker treated
+// stack bytes as num_cx_registers and called memcpy from its null cx_registers pointer (#1213).
+HLE(agc_get_fused_shader_size) {  // (SizeAlign* dst, const Shader* front, const Shader* back)
+    auto* dst = (AgcSizeAlign*)(uintptr_t)a0;
+    auto* front = (const AgcShader*)(uintptr_t)a1;
+    auto* back = (const AgcShader*)(uintptr_t)a2;
+    if (!dst || !front || !back) return kAgcErrInvalidArg;
+    if (!agc_shader_halves_match(front, back)) return kAgcErrInvalidShaderHalves;
+    dst->size = (uint64_t)back->num_sh_registers * sizeof(AgcShaderRegister);
+    dst->align = alignof(uint32_t);
+    return 0;
+}
+
+HLE(agc_fuse_shader_halves) {  // (Shader* dst, const Shader* front, const Shader* back, void* scratch)
+    auto* dst = (AgcShader*)(uintptr_t)a0;
+    auto* front = (const AgcShader*)(uintptr_t)a1;
+    auto* back = (const AgcShader*)(uintptr_t)a2;
+    void* scratch = (void*)(uintptr_t)a3;
+    if (!dst || !front || !back) return kAgcErrInvalidArg;
+    if (!agc_shader_halves_match(front, back)) return kAgcErrInvalidShaderHalves;
+
+    *dst = *back;
+    dst->type = front->type == kAgcShaderGsFront ? kAgcShaderGs : kAgcShaderHs;
+
+    auto* front_specials = (const AgcShaderSpecialRegs*)front->specials;
+    auto* back_specials = (const AgcShaderSpecialRegs*)back->specials;
+    if (front_specials && back_specials) {
+        const uint32_t mismatch_bit = front->type == kAgcShaderGsFront ? (1u << 22u) : (1u << 21u);
+        if (((front_specials->vgt_shader_stages_en.value ^
+              back_specials->vgt_shader_stages_en.value) & mismatch_bit) != 0)
+            return kAgcErrInvalidShaderHalves;
+    }
+
+    if (scratch && back->sh_registers && back->num_sh_registers) {
+        auto* copied = (AgcShaderRegister*)scratch;
+        memcpy(copied, back->sh_registers,
+               (size_t)back->num_sh_registers * sizeof(AgcShaderRegister));
+        dst->sh_registers = copied;
+    }
+
+    using namespace prosper::agc::Pm4;
+    if (front->type == kAgcShaderGsFront) {
+        for (uint32_t occurrence = 0; occurrence < 2; ++occurrence) {
+            AgcShaderRegister* out = agc_find_shader_register(
+                dst->sh_registers, dst->num_sh_registers, SPI_SHADER_PGM_CHKSUM_GS, occurrence);
+            const AgcShaderRegister* in = agc_find_shader_register(
+                front->sh_registers, front->num_sh_registers, SPI_SHADER_PGM_CHKSUM_GS, occurrence);
+            if (out && in) out->value = in->value;
+        }
+        agc_patch_shader_address(dst->sh_registers, dst->num_sh_registers,
+                                 SPI_SHADER_PGM_LO_ES, (uint64_t)(uintptr_t)front->code);
+    } else {
+        agc_patch_shader_address(dst->sh_registers, dst->num_sh_registers,
+                                 SPI_SHADER_PGM_LO_LS, (uint64_t)(uintptr_t)front->code);
+    }
+    dst->user_data = nullptr;
+    return 0;
+}
 
 // sceAgcGetDataPacketPayloadAddress (V++UgBtQhn0) — called from INSIDE eboot's static AGC code
 // (register-bank prepare, eboot+0x3af040 path, callsite +0x3af170): resolve a data packet built in
@@ -1702,6 +1814,9 @@ void register_agc_hle() {
     RN("hL7C0IRpWZI", agc_cb_eop_action_get_size);   // sceAgcCbQueueEndOfPipeActionGetSize
     RN("t7PlZ9nt5Lc", agc_cb_nop_get_size);          // sceAgcCbNopGetSize
     RN("f3dg2CSgRKY", agc_create_shader);   // sceAgcCreateShader — populates the shader registry
+    RN("dolOmWH+huQ", agc_get_fused_shader_size); // sceAgcGetFusedShaderSize (Pathless SDK)
+    RN("nApJjpKNBl4", agc_fuse_shader_halves);    // sceAgcFuseShaderHalves (PS5 3.20)
+    RN("fd5Bp5tGTgo", agc_fuse_shader_halves);    // older observed SDK alias
     RN("AOLcoIkQDgM", agc_driver_query_resource_registration_user_memory_requirements);
     RN("uJziRsODk1c", agc_driver_get_resource_registration_max_name_length);
     RN("X-Nm5KLREeg", agc_driver_register_owner);

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -1815,6 +1815,7 @@ void register_agc_hle() {
     RN("t7PlZ9nt5Lc", agc_cb_nop_get_size);          // sceAgcCbNopGetSize
     RN("f3dg2CSgRKY", agc_create_shader);   // sceAgcCreateShader — populates the shader registry
     RN("dolOmWH+huQ", agc_get_fused_shader_size); // sceAgcGetFusedShaderSize (Pathless SDK)
+    RN("nQT5kYLv0cg", agc_get_fused_shader_size); // sceAgcGetFusedShaderSize (PS5 3.20)
     RN("nApJjpKNBl4", agc_fuse_shader_halves);    // sceAgcFuseShaderHalves (PS5 3.20)
     RN("fd5Bp5tGTgo", agc_fuse_shader_halves);    // older observed SDK alias
     RN("AOLcoIkQDgM", agc_driver_query_resource_registration_user_memory_requirements);

--- a/prosper/tests/test_agc_shader.cpp
+++ b/prosper/tests/test_agc_shader.cpp
@@ -76,12 +76,14 @@ int main() {
 
     HleFn create_shader = Hle::lookup("f3dg2CSgRKY");
     HleFn fused_size = Hle::lookup("dolOmWH+huQ");
+    HleFn fused_size_320 = Hle::lookup("nQT5kYLv0cg");
     HleFn fuse_halves = Hle::lookup("nApJjpKNBl4");
     HleFn fuse_halves_old = Hle::lookup("fd5Bp5tGTgo");
     HleFn create_interp = Hle::lookup("dbOlWdppb4o");
     HleFn create_interp_320 = Hle::lookup("pdEV7bI6COI");
     CHECK(create_shader != nullptr, "sceAgcCreateShader registered");
-    CHECK(fused_size != nullptr && fuse_halves != nullptr && fuse_halves_old != nullptr,
+    CHECK(fused_size != nullptr && fused_size_320 != nullptr &&
+          fuse_halves != nullptr && fuse_halves_old != nullptr,
           "fused-shader size query and SDK aliases registered");
     CHECK(create_interp != nullptr && create_interp_320 != nullptr,
           "CreateInterpolantMapping SDK aliases registered");
@@ -90,7 +92,7 @@ int main() {
     // Pathless builds GS/HS shaders from separately compiled front/back binaries. A success-only
     // stub left its stack-local fused Shader untouched, and the later register copier interpreted
     // unrelated stack bytes as a nonzero count paired with a null register pointer.
-    if (fused_size && fuse_halves && fuse_halves_old) {
+    if (fused_size && fused_size_320 && fuse_halves && fuse_halves_old) {
         using namespace prosper::agc::Pm4;
         ShaderRegister front_regs[] = {
             {SPI_SHADER_PGM_CHKSUM_GS, 0x11111111u},
@@ -119,9 +121,9 @@ int main() {
         back.specials = &back_specials;
 
         SizeAlign requirements{0xdeadbeefull, 0xdeadbeefull};
-        uint64_t fused_rc = fused_size((uint64_t)(uintptr_t)&requirements,
-                                       (uint64_t)(uintptr_t)&front,
-                                       (uint64_t)(uintptr_t)&back, 0, 0, 0);
+        uint64_t fused_rc = fused_size_320((uint64_t)(uintptr_t)&requirements,
+                                           (uint64_t)(uintptr_t)&front,
+                                           (uint64_t)(uintptr_t)&back, 0, 0, 0);
         CHECK(fused_rc == 0 && requirements.size == sizeof(back_regs) && requirements.align == 4,
               "fused-shader size query reserves one copied SH-register array");
 

--- a/prosper/tests/test_agc_shader.cpp
+++ b/prosper/tests/test_agc_shader.cpp
@@ -45,6 +45,19 @@ struct Shader {
     uint8_t num_sh_registers;
 };
 
+struct ShaderSpecialRegs {
+    ShaderRegister ge_cntl;
+    ShaderRegister vgt_shader_stages_en;
+    uint32_t dispatch_modifier;
+    uint16_t user_data_range_start;
+    uint16_t user_data_range_end;
+    uint64_t draw_modifier;
+    ShaderRegister vgt_gs_out_prim_type;
+    ShaderRegister ge_user_vgpr_en;
+};
+
+struct SizeAlign { uint64_t size, align; };
+
 static_assert(offsetof(Shader, user_data) == 0x08 && offsetof(Shader, code) == 0x10 &&
               offsetof(Shader, specials) == 0x28 && offsetof(Shader, type) == 0x5a &&
               offsetof(Shader, num_sh_registers) == 0x5c, "test Shader layout must mirror hle_agc");
@@ -62,12 +75,103 @@ int main() {
     register_builtin_hle();
 
     HleFn create_shader = Hle::lookup("f3dg2CSgRKY");
+    HleFn fused_size = Hle::lookup("dolOmWH+huQ");
+    HleFn fuse_halves = Hle::lookup("nApJjpKNBl4");
+    HleFn fuse_halves_old = Hle::lookup("fd5Bp5tGTgo");
     HleFn create_interp = Hle::lookup("dbOlWdppb4o");
     HleFn create_interp_320 = Hle::lookup("pdEV7bI6COI");
     CHECK(create_shader != nullptr, "sceAgcCreateShader registered");
+    CHECK(fused_size != nullptr && fuse_halves != nullptr && fuse_halves_old != nullptr,
+          "fused-shader size query and SDK aliases registered");
     CHECK(create_interp != nullptr && create_interp_320 != nullptr,
           "CreateInterpolantMapping SDK aliases registered");
     if (!create_shader) return 1;
+
+    // Pathless builds GS/HS shaders from separately compiled front/back binaries. A success-only
+    // stub left its stack-local fused Shader untouched, and the later register copier interpreted
+    // unrelated stack bytes as a nonzero count paired with a null register pointer.
+    if (fused_size && fuse_halves && fuse_halves_old) {
+        using namespace prosper::agc::Pm4;
+        ShaderRegister front_regs[] = {
+            {SPI_SHADER_PGM_CHKSUM_GS, 0x11111111u},
+            {SPI_SHADER_PGM_CHKSUM_GS, 0x22222222u},
+        };
+        ShaderRegister back_regs[] = {
+            {SPI_SHADER_PGM_LO_ES, 0},
+            {SPI_SHADER_PGM_LO_ES + 1u, 0xabcdef00u},
+            {SPI_SHADER_PGM_CHKSUM_GS, 0xaaaaaaaau},
+            {SPI_SHADER_PGM_CHKSUM_GS, 0xbbbbbbbbu},
+            {0x234u, 0xccccccccu},
+        };
+        ShaderSpecialRegs front_specials{}, back_specials{};
+        Shader front{};
+        front.type = 4; // GS front
+        front.code = reinterpret_cast<const void*>(0x123456789a00ull);
+        front.sh_registers = front_regs;
+        front.num_sh_registers = (uint8_t)(sizeof(front_regs) / sizeof(front_regs[0]));
+        front.specials = &front_specials;
+        Shader back{};
+        back.type = 6; // GS back
+        back.code = reinterpret_cast<const void*>(0x20c0000000ull);
+        back.sh_registers = back_regs;
+        back.num_sh_registers = (uint8_t)(sizeof(back_regs) / sizeof(back_regs[0]));
+        back.user_data = reinterpret_cast<ShaderUserData*>(0x12345678ull);
+        back.specials = &back_specials;
+
+        SizeAlign requirements{0xdeadbeefull, 0xdeadbeefull};
+        uint64_t fused_rc = fused_size((uint64_t)(uintptr_t)&requirements,
+                                       (uint64_t)(uintptr_t)&front,
+                                       (uint64_t)(uintptr_t)&back, 0, 0, 0);
+        CHECK(fused_rc == 0 && requirements.size == sizeof(back_regs) && requirements.align == 4,
+              "fused-shader size query reserves one copied SH-register array");
+
+        ShaderRegister scratch[sizeof(back_regs) / sizeof(back_regs[0])]{};
+        Shader fused{};
+        fused_rc = fuse_halves((uint64_t)(uintptr_t)&fused, (uint64_t)(uintptr_t)&front,
+                               (uint64_t)(uintptr_t)&back, (uint64_t)(uintptr_t)scratch, 0, 0);
+        CHECK(fused_rc == 0 && fused.type == 2 && fused.sh_registers == scratch,
+              "GS halves produce a fused GS backed by caller scratch");
+        CHECK(fused.user_data == nullptr && fused.code == back.code && fused.specials == back.specials,
+              "fused shader inherits the back half but clears user data");
+        CHECK(scratch[0].value == 0x3456789au && scratch[1].value == 0xabcdef12u,
+              "GS fusion patches the front program address into ES registers");
+        CHECK(scratch[2].value == 0x11111111u && scratch[3].value == 0x22222222u &&
+              scratch[4].value == 0xccccccccu,
+              "GS fusion replaces both checksums without disturbing other back registers");
+        CHECK(back_regs[0].value == 0 && back_regs[2].value == 0xaaaaaaaau,
+              "GS fusion leaves the source back-half register array unchanged");
+
+        ShaderRegister hs_regs[] = {
+            {SPI_SHADER_PGM_LO_LS, 0},
+            {SPI_SHADER_PGM_LO_LS + 1u, 0x11223300u},
+        };
+        Shader hs_front{};
+        hs_front.type = 5; // HS front
+        hs_front.code = reinterpret_cast<const void*>(0x445566778800ull);
+        Shader hs_back{};
+        hs_back.type = 7; // HS back
+        hs_back.sh_registers = hs_regs;
+        hs_back.num_sh_registers = 2;
+        Shader hs_fused{};
+        fused_rc = fuse_halves_old((uint64_t)(uintptr_t)&hs_fused,
+                                   (uint64_t)(uintptr_t)&hs_front,
+                                   (uint64_t)(uintptr_t)&hs_back, 0, 0, 0);
+        CHECK(fused_rc == 0 && hs_fused.type == 3 && hs_fused.sh_registers == hs_regs &&
+              hs_regs[0].value == 0x55667788u && hs_regs[1].value == 0x11223344u,
+              "older fusion alias supports HS halves and patches LS registers in place");
+
+        Shader wrong{};
+        wrong.type = 1;
+        requirements = {0xdeadbeefull, 0xdeadbeefull};
+        fused_rc = fused_size((uint64_t)(uintptr_t)&requirements,
+                              (uint64_t)(uintptr_t)&front,
+                              (uint64_t)(uintptr_t)&wrong, 0, 0, 0);
+        CHECK(fused_rc == 0x8a6c0008ull && requirements.size == 0xdeadbeefull,
+              "mismatched shader halves are rejected without writing requirements");
+        fused_rc = fuse_halves(0, (uint64_t)(uintptr_t)&front,
+                               (uint64_t)(uintptr_t)&back, 0, 0, 0);
+        CHECK(fused_rc == kAgcErrInvalidArg, "null fused-shader output is rejected");
+    }
 
     // Cobra's eboot wrapper allocates exactly 32 ShaderRegisters, calls dbOlWdppb4o with
     // (out, producer type 2, pixel type 1), then advertises all 32 to PatchAddRegisters. A success


### PR DESCRIPTION
Closes #1213

## Root cause

Pathless calls `dolOmWH+huQ` to size scratch storage and `nApJjpKNBl4` (`sceAgcFuseShaderHalves`) to combine separately compiled GS/HS shader halves. Both imports returned success without writing their output. UE then consumed an uninitialized stack-local `Shader`: unrelated stack bytes supplied a nonzero `num_cx_registers` while `cx_registers` was null, and multiple TaskGraph workers faulted in `libc.prx` while executing `memcpy(dst, nullptr, count * 8)`.

## Change

- implement fused-shader scratch sizing with GS/HS half-pair validation
- copy the back-half shader and SH-register array, then patch the front-half program address
- carry the two GS checksum registers, produce fused GS/HS types, and clear fused user data
- register the Pathless/PS5 3.20 NIDs plus the older observed fusion alias
- add focused coverage for GS and HS fusion, scratch ownership, address/checksum patching, validation, aliases, and source immutability

The behavior follows the AGC shader ABI already used by this file and the MIT-licensed Kyty reference implementation at commit `85876388cf7693eca30f3c9297c21b231e81c9af`.

## Validation

- `./prosper/build-audit/test_agc_shader` — PASS
- `ctest --test-dir prosper/build-audit --output-on-failure -j4` — 146/146 PASS
- Pathless live GPU run for 50 seconds — exit 0, five distinct source frames, no fusion calls reported as unimplemented, and no worker fault; it proceeds into new compute, volumetric-resource, and DCC fast-clear work beyond the old reproducible 18–20 second crash

The rendered output remains white and later reaches a GPU dependency wait; this PR fixes the worker crash/progression gate only.

`prosper/tools/verify-pr.ps1 core` could not be run because neither `pwsh` nor `powershell` is installed in this Linux devcontainer.