### PR TITLE
feat(app): add flip-boundary pause and audio freeze

### DIFF
--- a/prosper/docs/FRONTEND_APP.md
+++ b/prosper/docs/FRONTEND_APP.md
@@ -120,6 +120,7 @@ init:  SDL_Init(VIDEO|AUDIO|GAMECONTROLLER); create window;
        start the guest run-loop on its own thread.
 
 frame: SDL_PollEvent → on SDL_QUIT / window-close: prosper_request_stop(); break;
+       Pause / F10 toggles a guest flip-boundary wait and the SDL audio device;
        F11 / Alt+Enter toggles borderless desktop fullscreen;
        pixel-size change → recreate the Vulkan swapchain before the next present;
        if present_count() advanced since last shown:
@@ -448,10 +449,11 @@ duplicate. Until then the app is fully functional via `--test-pattern` (and any 
   shows the composited game (verified `--dump … --frames 3`).
 - **P1 — audio** ✅ **done**: `prosper-app` installs the SDL3 `AudioSink` (`sceAudioOut` → host).
 - **P2 — controllers** ✅ **done**: installs the SDL3 `PadBackend` (host gamepad → `libScePad`).
-- **P3 — polish** (in progress): resize/fullscreen, present-mode selection, and non-modal SaveData
+- **P3 — polish** (in progress): resize/fullscreen, present-mode selection, pause/resume at a guest
+  flip boundary with coherent audio, and non-modal SaveData
   percentage progress presentation and SaveData virtual-slot LIST selection are implemented. The LIST
   boundary retains only guest virtual directory names and never exposes a host file picker;
-  pause/quit UX remains.
+  quit UX remains.
   Native Windows build/run packaging is done via `scripts/run-windows.ps1`. Cooperative guest-stop
   at a flip boundary is a follow-up (today the
   guest thread is detached at window-close and reclaimed by process exit).

--- a/prosper/docs/WINDOWS_RELEASE.md
+++ b/prosper/docs/WINDOWS_RELEASE.md
@@ -67,10 +67,12 @@ SDL3 automatically uses a connected controller as pad 0. Keyboard input is compo
 | U / O | L1 / R1 |
 | Y / H | L2 / R2 |
 | Enter | Options |
+| Pause or F10 | Pause/resume the guest and audio at a flip boundary |
 | F11 or Alt+Enter | Toggle host-window fullscreen |
 | Escape | Exit |
 
-Alt+Enter is consumed by the host window and is not forwarded as the guest Options button. Closing
+Pause/F10 is host-owned and is not forwarded to guest keyboard input. Alt+Enter is consumed by the
+host window and is not forwarded as the guest Options button. Closing
 the window also exits. Shutdown currently terminates the process after flushing logs because
 cooperative guest-thread teardown is not implemented yet.
 

--- a/prosper/frontends/audio_sdl3/audio_sdl3.hpp
+++ b/prosper/frontends/audio_sdl3/audio_sdl3.hpp
@@ -12,6 +12,11 @@ namespace prosper {
 // could not be initialised. Safe to call once at startup after register_builtin_hle().
 bool install_sdl3_audio_sink();
 
+// Pause/resume every active stream without discarding its queued samples. The guest output side
+// also waits on the shared lifecycle gate, so no additional audio accumulates during a host pause.
+// No-op when the SDL3 sink is not installed.
+void set_sdl3_audio_paused(bool paused);
+
 // Uninstall the SDL3 sink (restores the default), closing any open streams and SDL audio.
 void shutdown_sdl3_audio_sink();
 

--- a/prosper/frontends/audio_sdl3/audio_sink_sdl3.cpp
+++ b/prosper/frontends/audio_sdl3/audio_sink_sdl3.cpp
@@ -6,6 +6,7 @@
 // sceAudioOutOutput has on real hardware (it blocks until the audio ring has room).
 #include "audio_sdl3.hpp"
 #include "../../src/hle/audio.hpp"
+#include "../../src/host/lifecycle.hpp"
 
 #include <SDL3/SDL.h>
 
@@ -27,6 +28,7 @@ SDL_AudioFormat to_sdl_format(AudioFmt f) { return f == AudioFmt::F32 ? SDL_AUDI
 class Sdl3AudioSink : public AudioSink {
 public:
     bool init() {
+        paused_ = false;
         if (!SDL_InitSubSystem(SDL_INIT_AUDIO)) {
             SDL_Log("prosper-audio: SDL_InitSubSystem(AUDIO) failed: %s", SDL_GetError());
             return false;
@@ -56,8 +58,11 @@ public:
         s.freq = info.freq;
         s.put_failed = false;
         s.next = {};   // (re)start the per-grain pacing clock on the first output()
-        if (!SDL_ResumeAudioStreamDevice(s.stream)) {
-            SDL_Log("prosper-audio: ResumeAudioStreamDevice failed: %s", SDL_GetError());
+        const bool stream_ready = paused_ ? SDL_PauseAudioStreamDevice(s.stream)
+                                          : SDL_ResumeAudioStreamDevice(s.stream);
+        if (!stream_ready) {
+            SDL_Log("prosper-audio: %sAudioStreamDevice failed: %s",
+                    paused_ ? "Pause" : "Resume", SDL_GetError());
             SDL_DestroyAudioStream(s.stream);
             s.stream = nullptr;
             return false;
@@ -72,6 +77,9 @@ public:
 
     void output(int port, const void* pcm, int frames) override {
         if (port < 1 || port > kMaxPorts) return;
+        // Block before touching the SDL queue. Pausing the device preserves samples that were
+        // already accepted; this gate prevents guest audio threads from filling it while paused.
+        if (!prosper_wait_while_paused()) return;
         int freq = 0;
         std::chrono::steady_clock::time_point target{};
         {
@@ -123,6 +131,25 @@ public:
         s.frame_bytes = s.grain_bytes = 0;
     }
 
+    void set_paused(bool paused) {
+        std::lock_guard<std::mutex> lk(mx_);
+        if (paused_ == paused) return;
+        paused_ = paused;
+        int active_streams = 0;
+        for (Slot& s : slots_) {
+            if (!s.stream) continue;
+            ++active_streams;
+            const bool ok = paused ? SDL_PauseAudioStreamDevice(s.stream)
+                                   : SDL_ResumeAudioStreamDevice(s.stream);
+            if (!ok)
+                SDL_Log("prosper-audio: %sAudioStreamDevice failed: %s",
+                        paused ? "Pause" : "Resume", SDL_GetError());
+            if (!paused) s.next = {};   // resume pacing from now; never catch up in a burst
+        }
+        SDL_Log("prosper-audio: %s %d active stream%s", paused ? "paused" : "resumed",
+                active_streams, active_streams == 1 ? "" : "s");
+    }
+
 private:
     struct Slot { SDL_AudioStream* stream = nullptr; int frame_bytes = 0; int grain_bytes = 0;
                   bool put_failed = false;
@@ -130,6 +157,7 @@ private:
                   std::chrono::steady_clock::time_point next{}; };  // per-grain pacing deadline
     std::mutex mx_;
     std::array<Slot, kMaxPorts> slots_{};
+    bool paused_ = false;
 };
 
 Sdl3AudioSink g_sink;
@@ -144,6 +172,10 @@ bool install_sdl3_audio_sink() {
     g_installed = true;
     SDL_Log("prosper-audio: SDL3 audio backend installed");
     return true;
+}
+
+void set_sdl3_audio_paused(bool paused) {
+    if (g_installed) g_sink.set_paused(paused);
 }
 
 void shutdown_sdl3_audio_sink() {

--- a/prosper/frontends/audio_sdl3/test_audio_sdl3.cpp
+++ b/prosper/frontends/audio_sdl3/test_audio_sdl3.cpp
@@ -5,7 +5,9 @@
 #include "../../src/hle/dispatch.hpp"
 #include "../../src/hle/nid.hpp"
 #include "../../src/hle/audio.hpp"
+#include "../../src/host/lifecycle.hpp"
 #include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
@@ -53,6 +55,31 @@ int main() {
         CHECK(call("sceAudioOutSetVolume", (uint64_t)h, 0x3, PTR(vols)) == 0);
         CHECK(call("sceAudioOutClose", (uint64_t)h) == 0);
 
+        // A host pause freezes the device and blocks producers before they can fill its queue.
+        // Resume re-opens both gates and lets the exact pending grain complete.
+        AudioPortInfo pause_info;
+        pause_info.grain = 1;
+        AudioSink* pause_sink = audio_sink();
+        CHECK(pause_sink->open(1, pause_info));
+        int16_t pause_pcm[2] = {321, -321};
+        std::atomic<bool> pause_output_started{false};
+        std::atomic<bool> pause_output_done{false};
+        prosper_set_paused(true);
+        set_sdl3_audio_paused(true);
+        std::thread paused_output([&] {
+            pause_output_started.store(true, std::memory_order_release);
+            pause_sink->output(1, pause_pcm, 1);
+            pause_output_done.store(true, std::memory_order_release);
+        });
+        while (!pause_output_started.load(std::memory_order_acquire)) std::this_thread::yield();
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+        CHECK(!pause_output_done.load(std::memory_order_acquire));
+        set_sdl3_audio_paused(false);
+        prosper_set_paused(false);
+        paused_output.join();
+        CHECK(pause_output_done.load(std::memory_order_acquire));
+        pause_sink->close(1);
+
         // Output and lifecycle calls can arrive from different guest audio threads. Exercise the
         // exact #855 boundary repeatedly: close/reopen must not destroy an SDL_AudioStream while
         // output() is queueing into it. Completion without a host fault is the lifetime contract;
@@ -86,6 +113,8 @@ int main() {
         shutdown_sdl3_audio_sink();
         CHECK(audio_sink() != nullptr);   // default silent sink restored
     }
+
+    prosper_reset_stop();
 
     if (fails) { printf("== FAIL: %d check(s) failed ==\n", fails); return 1; }
     printf("== PASS: SDL3 audio frontend end-to-end (dummy driver) ==\n");

--- a/prosper/frontends/prosper-app/README.md
+++ b/prosper/frontends/prosper-app/README.md
@@ -55,7 +55,8 @@ PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct \
 ./build-app/prosper-app --test-pattern
 ```
 
-F11 or Alt+Enter toggles borderless desktop fullscreen. Esc or closing the window quits.
+Pause or F10 pauses/resumes at a guest flip boundary and freezes the audio stream. F11 or Alt+Enter
+toggles borderless desktop fullscreen. Esc or closing the window quits.
 
 ## Options
 

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -18,7 +18,7 @@
 #include "gpu/gpu_capture.hpp"         // request_interactive_gpu_capture (F9 frame grab)
 #include "gpu/gpu_timeline.hpp"        // request_interactive_capture_bundle (F9 whole-frame grab)
 #include "present_blit.hpp"           // GPU scanout handoff: acquire/release the renderer's front image
-#include "host/lifecycle.hpp"          // prosper_request_stop / prosper_stop_requested
+#include "host/lifecycle.hpp"          // frontend-owned stop/pause gates
 #include "host/boot_program.hpp"       // boot_program (shared guest-boot path, also used by boot_trace)
 #include "host/exec_image.hpp"         // run_entry
 #include "loader/linker.hpp"           // Program
@@ -801,7 +801,7 @@ int main(int argc, char** argv) {
     prosper::input::pad_set_backend(&g_keyboard_pad);
     fprintf(stderr, "[app] keyboard: WASD/Arrows=move  J/Space=Cross(jump)  K=Square(attack)  L=Circle  "
                     "I=Triangle  U/O=L1/R1  Y/H=L2/R2  Enter=Options  "
-                    "F11/Alt+Enter=fullscreen  Esc=quit\n");
+                    "Pause/F10=pause  F11/Alt+Enter=fullscreen  Esc=quit\n");
     fprintf(stderr, "[app] F9 = grab the current frame: writes a replayable .prgbundle + a .bmp "
                     "screenshot (to PROSPER_CAPTURE_DIR, default cwd) for gpu_replay debugging "
                     "(brief hitch on press; PROSPER_CAPTURE_FRAMES>1 grabs an animation).\n");
@@ -838,6 +838,7 @@ int main(int argc, char** argv) {
     };
     bool timedDumpPending = timedDumpMs > 0;
     bool running = true;
+    bool paused = false;
     bool swapchainDirty = false;
     const SDL_WindowID appWindowId = SDL_GetWindowID(win);
     prosper::frontend::AppWindowControls windowControls;
@@ -859,6 +860,7 @@ int main(int argc, char** argv) {
                 key.pressed = ev.key.down;
                 key.repeat = ev.key.repeat;
                 key.escape = ev.key.key == SDLK_ESCAPE;
+                key.pause = ev.key.key == SDLK_PAUSE || ev.key.key == SDLK_F10;
                 key.f11 = ev.key.key == SDLK_F11;
                 key.enter = ev.key.key == SDLK_RETURN || ev.key.key == SDLK_KP_ENTER;
                 key.alt = (ev.key.mod & SDL_KMOD_ALT) != 0;
@@ -883,11 +885,31 @@ int main(int argc, char** argv) {
                 // PPSA02664 read input through sceImeUpdate, not libScePad. SDL3 scancodes ARE USB
                 // HID usage ids for the keyboard page — exactly the keycode the guest event wants.
                 // Deliver clean press/release edges (skip auto-repeat).
-                if (key.app_window && !ev.key.repeat)
+                if (key.app_window && !ev.key.repeat && !key.pause)
                     prosper::ime_push_key((uint16_t)ev.key.scancode, ev.key.down);
                 switch (windowControls.handle_key(key)) {
                 case prosper::frontend::AppWindowCommand::quit:
                     running = false;
+                    break;
+                case prosper::frontend::AppWindowCommand::toggle_pause:
+                    paused = !paused;
+                    if (paused) {
+                        // Close the producer gate before freezing queued device audio.
+                        prosper_set_paused(true);
+#ifdef PROSPER_AUDIO_SDL3
+                        prosper::set_sdl3_audio_paused(true);
+#endif
+                    } else {
+                        // Start the device before releasing producers so the first resumed grain
+                        // cannot queue behind a device that is still paused.
+#ifdef PROSPER_AUDIO_SDL3
+                        prosper::set_sdl3_audio_paused(false);
+#endif
+                        prosper_set_paused(false);
+                    }
+                    SDL_SetWindowTitle(win, paused ? (title + " — paused").c_str() : title.c_str());
+                    fprintf(stderr, "[app] %s at guest flip boundary\n",
+                            paused ? "pause requested" : "resumed");
                     break;
                 case prosper::frontend::AppWindowCommand::toggle_fullscreen: {
                     // SDL may apply fullscreen requests asynchronously. Toggle the last accepted
@@ -981,7 +1003,7 @@ int main(int argc, char** argv) {
         }
 
         static const uint32_t kPatW = 1920, kPatH = 1080;
-        if (testPattern) feed_test_pattern(kPatW, kPatH, patFrame++);
+        if (testPattern && !paused) feed_test_pattern(kPatW, kPatH, patFrame++);
 
         // Present the latest finished frame from the core's present layer.
         // The frame dimensions: from the guest's registered VideoOut display in normal use; in

--- a/prosper/frontends/prosper-app/test_window_controls.cpp
+++ b/prosper/frontends/prosper-app/test_window_controls.cpp
@@ -28,6 +28,20 @@ int main() {
     key = {};
     key.app_window = true;
     key.pressed = true;
+    key.pause = true;
+    CHECK(controls.handle_key(key) == AppWindowCommand::toggle_pause,
+          "Pause/F10 toggles guest pause");
+    key.repeat = true;
+    CHECK(controls.handle_key(key) == AppWindowCommand::none,
+          "held Pause/F10 does not toggle repeatedly");
+    key.repeat = false;
+    key.app_window = false;
+    CHECK(controls.handle_key(key) == AppWindowCommand::none,
+          "another SDL window cannot pause the game window");
+
+    key = {};
+    key.app_window = true;
+    key.pressed = true;
     key.enter = true;
     key.alt = true;
     CHECK(controls.handle_key(key) == AppWindowCommand::toggle_fullscreen,

--- a/prosper/frontends/prosper-app/window_controls.hpp
+++ b/prosper/frontends/prosper-app/window_controls.hpp
@@ -5,6 +5,7 @@ namespace prosper::frontend {
 enum class AppWindowCommand {
     none,
     quit,
+    toggle_pause,
     toggle_fullscreen,
 };
 
@@ -13,6 +14,7 @@ struct AppWindowKey {
     bool pressed = false;
     bool repeat = false;
     bool escape = false;
+    bool pause = false;
     bool f11 = false;
     bool enter = false;
     bool alt = false;
@@ -30,6 +32,7 @@ public:
         }
         if (!key.pressed || key.repeat) return AppWindowCommand::none;
         if (key.escape) return AppWindowCommand::quit;
+        if (key.pause) return AppWindowCommand::toggle_pause;
         if (key.f11 || (key.enter && key.alt)) return AppWindowCommand::toggle_fullscreen;
         return AppWindowCommand::none;
     }

--- a/prosper/src/gpu/videoout_present.cpp
+++ b/prosper/src/gpu/videoout_present.cpp
@@ -1,6 +1,7 @@
 // videoout_present.cpp — see videoout_present.hpp.
 #include "videoout_present.hpp"
 #include "gpu_timeline.hpp"
+#include "host/lifecycle.hpp"
 #include <atomic>
 #include <cstring>
 #include <cstdio>
@@ -76,6 +77,11 @@ void present_flip(int buffer_index, int64_t flip_arg) {
             }
         }
     }
+
+    // The desktop app requests pause from its UI thread. Wait only after the completed flip is
+    // fully published and all local locks are gone: the app can keep presenting that last frame
+    // and pumping SDL events, while the guest resumes from an exact display boundary.
+    prosper_wait_while_paused();
 }
 
 int      present_front_index() { return videoout_front_index(); }

--- a/prosper/src/host/lifecycle.cpp
+++ b/prosper/src/host/lifecycle.cpp
@@ -1,13 +1,60 @@
 // lifecycle.cpp — see lifecycle.hpp.
 #include "lifecycle.hpp"
 #include <atomic>
+#include <condition_variable>
+#include <mutex>
 
 namespace prosper {
 
-namespace { std::atomic<bool> g_stop{false}; }
+namespace {
+std::atomic<bool> g_stop{false};
+std::atomic<bool> g_paused{false};
+std::mutex g_lifecycle_mx;
+std::condition_variable g_lifecycle_cv;
+}
 
-void prosper_request_stop()   { g_stop.store(true, std::memory_order_relaxed); }
-bool prosper_stop_requested() { return g_stop.load(std::memory_order_relaxed); }
-void prosper_reset_stop()     { g_stop.store(false, std::memory_order_relaxed); }
+void prosper_request_stop() {
+    {
+        // Use the waiter's mutex for the transition so a waiter cannot miss the notification
+        // between checking the predicate and sleeping.
+        std::lock_guard<std::mutex> lk(g_lifecycle_mx);
+        g_stop.store(true, std::memory_order_release);
+    }
+    g_lifecycle_cv.notify_all();
+}
+
+bool prosper_stop_requested() { return g_stop.load(std::memory_order_acquire); }
+
+void prosper_set_paused(bool paused) {
+    {
+        std::lock_guard<std::mutex> lk(g_lifecycle_mx);
+        g_paused.store(paused, std::memory_order_release);
+    }
+    if (!paused) g_lifecycle_cv.notify_all();
+}
+
+bool prosper_paused() { return g_paused.load(std::memory_order_acquire); }
+
+bool prosper_wait_while_paused() {
+    // This runs once per flip/audio grain. Keep the normal (never paused) path lock-free; a pause
+    // racing this check is observed at the next cooperative boundary.
+    if (!g_paused.load(std::memory_order_acquire))
+        return !g_stop.load(std::memory_order_acquire);
+    std::unique_lock<std::mutex> lk(g_lifecycle_mx);
+    g_lifecycle_cv.wait(lk, [] {
+        return !g_paused.load(std::memory_order_acquire) ||
+               g_stop.load(std::memory_order_acquire);
+    });
+    return !g_stop.load(std::memory_order_acquire);
+}
+
+void prosper_reset_stop() {
+    {
+        std::lock_guard<std::mutex> lk(g_lifecycle_mx);
+        g_stop.store(false, std::memory_order_release);
+        g_paused.store(false, std::memory_order_release);
+    }
+    g_lifecycle_cv.notify_all();
+}
 
 } // namespace prosper

--- a/prosper/src/host/lifecycle.hpp
+++ b/prosper/src/host/lifecycle.hpp
@@ -1,13 +1,13 @@
-// lifecycle.hpp — cooperative stop signal for a long-running guest session.
+// lifecycle.hpp — cooperative stop/pause signals for a long-running guest session.
 //
 // The headless harness (boot_trace) drives the guest to a fixed frame budget. A frontend app that
 // keeps the guest running as long as its window is open needs a way to ask the guest run-loop to
-// wind down (e.g. on window-close). This is that signal — a single process-wide flag the run-loop
-// polls at its own boundary; it does NOT interrupt guest code mid-instruction.
+// wind down (e.g. on window-close), or to wait at a safe boundary while the window keeps pumping
+// events. These are process-wide signals; they do NOT interrupt guest code mid-instruction.
 //
 // It is deliberately tiny and dependency-free so it lives in prosper_core without pulling in any
-// OS/windowing code. boot_trace is unaffected (it never sets the flag); only an opt-in run-loop
-// that checks prosper_stop_requested() responds to it.
+// OS/windowing code. boot_trace is unaffected (it never sets either signal); only opt-in boundaries
+// that check them respond.
 #pragma once
 
 namespace prosper {
@@ -18,7 +18,17 @@ void prosper_request_stop();
 // True once a stop has been requested. Polled by the run-loop; thread-safe.
 bool prosper_stop_requested();
 
-// Clear the flag (tests / restarting a session in-process).
+// Pause or resume boundary-aware guest work. Idempotent; thread-safe (any thread).
+void prosper_set_paused(bool paused);
+
+// True while the frontend has requested a pause. Thread-safe.
+bool prosper_paused();
+
+// Wait until pause is cleared or stop is requested. Returns false when released by stop, true when
+// work may continue. Calling this while not paused returns immediately.
+bool prosper_wait_while_paused();
+
+// Clear both signals (tests / restarting a session in-process), releasing paused waiters.
 void prosper_reset_stop();
 
 } // namespace prosper

--- a/prosper/tests/test_lifecycle.cpp
+++ b/prosper/tests/test_lifecycle.cpp
@@ -4,6 +4,8 @@
 #include <cstdio>
 #include <thread>
 #include <atomic>
+#include <chrono>
+#include <future>
 
 using namespace prosper;
 
@@ -33,6 +35,30 @@ int main() {
     CHECK(prosper_stop_requested(), "stop set from another thread is visible");
 
     prosper_reset_stop();
+    CHECK(!prosper_paused(), "not paused after reset");
+
+    prosper_set_paused(true);
+    CHECK(prosper_paused(), "pause is visible after request");
+    auto resume_waiter = std::async(std::launch::async, [] { return prosper_wait_while_paused(); });
+    CHECK(resume_waiter.wait_for(std::chrono::milliseconds(20)) == std::future_status::timeout,
+          "pause blocks boundary-aware work");
+    prosper_set_paused(false);
+    CHECK(resume_waiter.wait_for(std::chrono::seconds(1)) == std::future_status::ready &&
+              resume_waiter.get(),
+          "resume releases paused work");
+
+    prosper_set_paused(true);
+    auto stop_waiter = std::async(std::launch::async, [] { return prosper_wait_while_paused(); });
+    CHECK(stop_waiter.wait_for(std::chrono::milliseconds(20)) == std::future_status::timeout,
+          "second waiter reaches paused state");
+    prosper_request_stop();
+    CHECK(stop_waiter.wait_for(std::chrono::seconds(1)) == std::future_status::ready &&
+              !stop_waiter.get(),
+          "stop releases paused work without resuming it");
+
+    prosper_reset_stop();
+    CHECK(!prosper_stop_requested() && !prosper_paused(),
+          "reset clears stop and pause together");
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;

--- a/prosper/tests/test_present.cpp
+++ b/prosper/tests/test_present.cpp
@@ -5,10 +5,14 @@
 // plumbing end-to-end headlessly — the surface the renderer will present real frames to.
 #include "../src/hle/dispatch.hpp"
 #include "../src/gpu/videoout_present.hpp"
+#include "../src/host/lifecycle.hpp"
+#include <chrono>
 #include <cstdio>
 #include <cstdint>
 #include <cstring>
+#include <future>
 #include <memory>
+#include <thread>
 #include <vector>
 
 using namespace prosper;
@@ -133,6 +137,29 @@ int main() {
     CHECK(gpu::present_width() == W && gpu::present_height() == H &&
           got == FB_BYTES && out.front() == 0x22 && out.back() == 0x22,
           "set 0 flip restores its 16x8 buffer with matching geometry");
+
+    // The host pause gate lives after flip publication: the UI can keep showing the new front
+    // buffer while the guest caller waits, then resume it without interrupting mid-frame.
+    prosper_reset_stop();
+    prosper_set_paused(true);
+    const uint64_t paused_count = gpu::present_count();
+    auto paused_flip = std::async(std::launch::async, [&] {
+        flip(handle, 1, 0, 0xCAFE, 0, 0);
+        return true;
+    });
+    const auto publish_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(1);
+    while (gpu::present_count() == paused_count &&
+           std::chrono::steady_clock::now() < publish_deadline)
+        std::this_thread::yield();
+    CHECK(gpu::present_count() == paused_count + 1 && gpu::present_front_index() == 1,
+          "paused flip publishes its completed boundary");
+    CHECK(paused_flip.wait_for(std::chrono::milliseconds(20)) == std::future_status::timeout,
+          "paused flip holds the guest caller after publication");
+    prosper_set_paused(false);
+    CHECK(paused_flip.wait_for(std::chrono::seconds(1)) == std::future_status::ready &&
+              paused_flip.get(),
+          "resume releases the guest flip caller");
+    prosper_reset_stop();
 
     // Out-of-range flip index leaves the front buffer unchanged.
     flip(handle, 99, 0, 0, 0, 0);


### PR DESCRIPTION
## Summary

- add host-owned Pause/F10 controls with repeat debouncing, guest-IME suppression, paused title state, and frozen test-pattern behavior
- extend the host lifecycle seam with a lock-free fast path and a stop-aware pause wait at the completed guest flip boundary, leaving the SDL event loop responsive
- pause every active SDL audio device stream and block audio producers so queued audio is preserved without accumulating more samples; reset pacing on resume
- document the controls and cover lifecycle wakeups, flip publication/hold/resume, frontend command routing, and SDL dummy-device audio pause/resume

Part of #352. Cooperative guest shutdown remains a separate slice.

## Validation

- `distrobox enter ps5ys -- cmake --build prosper/build-linux -j8`
- `distrobox enter ps5ys -- ctest --test-dir prosper/build-linux --output-on-failure -j1` — 153/153 passed
- focused lifecycle/window/videoout/audio tests — 4/4 passed
- live Wayland `--test-pattern` smoke: injected F10 pause/resume and Esc; window remained responsive
- live title smoke with The Messenger and PipeWire: two 48 kHz stereo streams opened; F10 stopped guest/frame progress, resume restored progress, Esc exited cleanly

A parallel full-suite run exposed the pre-existing timing-sensitive snapshot-lock log assertion once; it passed immediately in isolation and in the clean serial 153-test run.