### PR TITLE
fix(hle): fail APR resolution for missing paths

### DIFF
--- a/prosper/docs/UE4_APR_IOSTORE_BRINGUP.md
+++ b/prosper/docs/UE4_APR_IOSTORE_BRINGUP.md
@@ -53,8 +53,8 @@ Not on the draw path (frame DCBs carry no draws). Full disasm + repro in #222.
   memfd physical aliasing, the `libSceAmpr` init/begin/setBuffer trio, `sceKernelGetdents`, RTC
   calendar, `pthread_create_name_np`, etc. (PR #47, #49.)
 - **`sceKernelAprResolveFilepathsToIdsAndFileSizes`** (commit 3d51097): the APR entry point.
-  ABI (live-captured): `(const char** paths, int count, uint32_t* outIds, uint64_t* outSizes,
-  uint32_t* outFlags, int)`. Called once per pak container with `/app0`-translated paths
+  ABI: `(const char** paths, int count, uint32_t* outIds, uint64_t* outSizes,
+  uint32_t* errorIndex)`. Called once per pak container with `/app0`-translated paths
   (`global.utoc/.ucas`, `pakchunkN-ps5.{pak,utoc,ucas}`). Implemented in `hle_file.cpp`
   (`f_apr_resolve`): stat the host file, assign a 1-based id, record `id -> host path`, exposed as
   `std::string prosper_apr_path_for_id(uint32_t id)`. This eliminated the entire MallocBinned

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -2014,13 +2014,13 @@ HLE(k_rename){ uint64_t r = f_rename(a0, a1, a2, a3, a4, a5); int e = errno; ret
 
 // --- APR (Async Page Read) file resolution -----------------------------------------------------
 // sceKernelAprResolveFilepathsToIdsAndFileSizes(const char** paths, int count, uint32_t* outIds,
-//   uint64_t* outSizes, uint32_t* outFlags, int reserved) — the entry point of UE4's IoStore/APR
+//   uint64_t* outSizes, uint32_t* errorIndex) — the entry point of UE4's IoStore/APR
 // pipeline. Live capture (PPSA17942): called once per pak container with a /app0-translated path
 // (global.utoc/.ucas, pakchunkN-ps5.pak/.utoc/.ucas). Stubbing it to EINVAL made APR proceed on
 // garbage ids/sizes and wild-write over the allocator (the "MallocBinned unrecognized block" /
 // canary corruption). Resolve each path for real: stat the host file, assign a stable id, record
-// id->host-path so the read path can pread by id. CONFIDENCE: MED (arg roles from live capture;
-// outFlags semantics unknown -> 0).
+// id->host-path so the read path can pread by id. CONFIDENCE: HIGH (argument roles and missing-path
+// error behavior agree between live ArcRunner capture and the reference implementation).
 namespace {
     PROSPER_HEAP_MUTEX(g_apr_mx);   // #707: heap-backed on macOS (APR registry mutex near the corrupted __DATA cluster)
     struct AprFile { std::string path; uint64_t size; };
@@ -2063,11 +2063,13 @@ int prosper_apr_match_by_size(uint64_t size, std::string* out_path) {
 // WithPrefix variant, DOLL (PPSA17942, UE4) the non-prefix one. Each resolved container is stat'd
 // and assigned a stable 1-based id recorded in the APR registry so the read/stat paths can find
 // its host file. Returning without populating the id/size outputs (the old EINVAL/success stub)
-// makes APR proceed on garbage ids and wild-write over the allocator, so every entry writes all
-// three outputs.
+// makes APR proceed on garbage ids and wild-write over the allocator, so every successful entry
+// writes its id and size. `error_index` is one scalar, not an output array; a missing path records
+// its index and fails the batch so callers do not construct a zero-length reader (#1226).
 static uint64_t apr_resolve_impl(const char* prefix, const char** paths, int count,
-                                 uint32_t* out_ids, uint64_t* out_sizes, uint32_t* out_flags) {
+                                 uint32_t* out_ids, uint64_t* out_sizes, uint32_t* error_index) {
     if (!paths || count <= 0) return 0x80020016ull;   // EINVAL
+    if (error_index) *error_index = 0;
     for (int i = 0; i < count; i++) {
         const char* gp = paths[i];
         std::string guest = gp ? std::string(gp) : std::string();
@@ -2104,8 +2106,14 @@ static uint64_t apr_resolve_impl(const char* prefix, const char** paths, int cou
             }
         }
         if (found) size = (uint64_t)st.st_size;
-        else { if (out_ids) out_ids[i] = 0; if (out_sizes) out_sizes[i] = 0; if (out_flags) out_flags[i] = 0;
-               if (filelog()) fprintf(stderr, "[apr] resolve MISS %s\n", guest.empty() ? "(null)" : guest.c_str()); continue; }
+        else {
+            if (out_ids) out_ids[i] = 0xffffffffu;
+            if (out_sizes) out_sizes[i] = 0;
+            if (error_index) *error_index = (uint32_t)i;
+            if (filelog()) fprintf(stderr, "[apr] resolve MISS %s\n",
+                                   guest.empty() ? "(null)" : guest.c_str());
+            return 0x80020002ull;   // ENOENT
+        }
         // Warn loudly (unconditionally) when a DIFFERENT container shares this size: the read
         // path is size-keyed (see f_apr_read_submit) and will refuse such reads as ambiguous.
         std::string clash; int same_size = prosper_apr_match_by_size(size, &clash);
@@ -2116,7 +2124,6 @@ static uint64_t apr_resolve_impl(const char* prefix, const char** paths, int cou
                     host.c_str(), clash.c_str(), (unsigned long long)size);
         if (out_ids)   out_ids[i]   = id;
         if (out_sizes) out_sizes[i] = size;
-        if (out_flags) out_flags[i] = 0;
         if (filelog()) fprintf(stderr, "[apr] resolve %s -> id=%u size=%llu\n", guest.c_str(), id, (unsigned long long)size);
     }
     return 0;
@@ -2126,25 +2133,22 @@ HLE(f_apr_resolve) {
                             (uint32_t*)P(a2), (uint64_t*)P(a3), (uint32_t*)P(a4));
 }
 // sceKernelAprResolveFilepathsToIds(pathList, count, ids, errorIndex): Sonic/CRI's smaller APR
-// resolver.  It is the same path registry operation as the size-returning variant, but its fourth
-// argument is ONE failure index rather than an array.  Do not pass it to apr_resolve_impl as flags:
-// doing so would overwrite past the scalar when count > 1.  The current tolerant resolver records
-// missing entries as id 0 and completes the batch, so a successful batch leaves errorIndex at zero.
+// resolver. It is the same path registry operation as the size-returning variant, and its fourth
+// argument is likewise one failure index rather than an array.
 HLE(f_apr_resolve_ids) {
     uint32_t* error_index = (uint32_t*)P(a3);
-    if (error_index) *error_index = 0;
     return apr_resolve_impl(nullptr, (const char**)P(a0), (int)(int64_t)a1,
-                            (uint32_t*)P(a2), nullptr, nullptr);
+                            (uint32_t*)P(a2), nullptr, error_index);
 }
 // APR builders/read commands execute eagerly in prosper.  A later WaitCommandBuffer therefore has
 // no outstanding host work and succeeds synchronously, matching the completion observed by the
 // caller without inventing an asynchronous submission object.
 HLE(f_apr_wait_command_buffer) { return 0; }
 // sceKernelAprResolveFilepathsWithPrefixToIdsAndFileSizes(const char* prefix, const char** paths,
-//   int count, uint32_t* outIds, uint64_t* outSizes, uint32_t* outFlags) — GTA V's RAGE resource
+//   int count, uint32_t* outIds, uint64_t* outSizes, uint32_t* errorIndex) — GTA V's RAGE resource
 // loader entry. ABI recovered from live guest disassembly (PPSA04263, [RAGE] Main Thr): rdi=prefix
-// (empty ""), rsi=paths (paths[0]="/app0/ps5/audio/sfx/ANIMALS.rpf"), rdx=count(1), then the three
-// output arrays. Same contract as the non-prefix twin with one leading prefix arg.
+// (empty ""), rsi=paths (paths[0]="/app0/ps5/audio/sfx/ANIMALS.rpf"), rdx=count(1), then the two
+// output arrays and scalar error index. Same contract as the non-prefix twin with one leading arg.
 HLE(f_apr_resolve_with_prefix) {
     return apr_resolve_impl((const char*)P(a0), (const char**)P(a1), (int)(int64_t)a2,
                             (uint32_t*)P(a3), (uint64_t*)P(a4), (uint32_t*)P(a5));

--- a/prosper/tests/test_apr_registry.cpp
+++ b/prosper/tests/test_apr_registry.cpp
@@ -161,7 +161,7 @@ int main() {
 
     // sceKernelAprResolveFilepathsWithPrefixToIdsAndFileSizes (GTA V / PPSA04263, RAGE, issue #1130):
     // the prefix-taking twin of the plain resolve. It must prepend `prefix` to each guest path,
-    // stat the resolved container, and WRITE all three output arrays (id/size/flags). Stubbing it to
+    // stat the resolved container, and write its id/size outputs. Stubbing it to
     // success without populating the outputs makes RAGE proceed on a garbage file id (0xffffffff was
     // observed live at the next GetFileStat) and wild-write over its allocator. translate() passes a
     // non-mount path through unchanged, so a relative fixture path exercises the real handler.
@@ -185,13 +185,15 @@ int main() {
     if (resolve_prefix && resolve_plain) {
         // The prefix path is prepended: prefix="prosper-test-apr-", paths[0]="prefix.tmp".
         const char* paths[1] = { wp_tail };
-        uint32_t ids[1] = { 0xdeadbeef }; uint64_t sizes[1] = { 0xdead }; uint32_t flags[1] = { 0xdead };
+        uint32_t ids[1] = { 0xdeadbeef }; uint64_t sizes[1] = { 0xdead }; uint32_t error_index = 0xdead;
         uint64_t r = resolve_prefix((uint64_t)(uintptr_t)wp_prefix, (uint64_t)(uintptr_t)paths, 1,
-                                    (uint64_t)(uintptr_t)ids, (uint64_t)(uintptr_t)sizes, (uint64_t)(uintptr_t)flags);
+                                    (uint64_t)(uintptr_t)ids, (uint64_t)(uintptr_t)sizes,
+                                    (uint64_t)(uintptr_t)&error_index);
         CHECK(r == 0, "WithPrefix resolve returns success");
         CHECK(sizes[0] == wp_bytes.size(),
               "WithPrefix resolve prepends the prefix and stats the combined path");
-        CHECK(ids[0] >= 1 && flags[0] == 0, "WithPrefix resolve populates id and flags");
+        CHECK(ids[0] >= 1 && error_index == 0,
+              "WithPrefix resolve populates the id and clears the scalar error index");
         CHECK(prosper_apr_path_for_id(ids[0]) == wp_full,
               "WithPrefix registers the combined host path under the returned id");
 
@@ -249,24 +251,39 @@ int main() {
         // An empty prefix must behave exactly like the plain (non-prefix) resolve.
         prosper_apr_reset_for_test();
         const char* full_paths[1] = { wp_full };
-        uint32_t id_wp = 0, id_plain = 0; uint64_t sz_wp = 0, sz_plain = 0; uint32_t fl_wp = 1, fl_plain = 1;
+        uint32_t id_wp = 0, id_plain = 0; uint64_t sz_wp = 0, sz_plain = 0;
+        uint32_t err_wp = 1, err_plain = 1;
         resolve_prefix((uint64_t)(uintptr_t)"", (uint64_t)(uintptr_t)full_paths, 1,
-                       (uint64_t)(uintptr_t)&id_wp, (uint64_t)(uintptr_t)&sz_wp, (uint64_t)(uintptr_t)&fl_wp);
+                       (uint64_t)(uintptr_t)&id_wp, (uint64_t)(uintptr_t)&sz_wp,
+                       (uint64_t)(uintptr_t)&err_wp);
         prosper_apr_reset_for_test();
         resolve_plain((uint64_t)(uintptr_t)full_paths, 1,
-                      (uint64_t)(uintptr_t)&id_plain, (uint64_t)(uintptr_t)&sz_plain, (uint64_t)(uintptr_t)&fl_plain, 0);
-        CHECK(id_wp == id_plain && sz_wp == sz_plain && sz_wp == wp_bytes.size() && fl_wp == 0,
+                      (uint64_t)(uintptr_t)&id_plain, (uint64_t)(uintptr_t)&sz_plain,
+                      (uint64_t)(uintptr_t)&err_plain, 0);
+        CHECK(id_wp == id_plain && sz_wp == sz_plain && sz_wp == wp_bytes.size() &&
+                  err_wp == 0 && err_plain == 0,
               "empty prefix matches the plain resolve");
 
-        // A missing container zeroes its outputs (no garbage id) rather than failing the batch.
+        // ArcRunner asks for a loose Game.locres that lives only inside its pak. Returning success
+        // with id/size zero makes UE parse an errored reader and use stale stack data as a count,
+        // trapping startup in a multi-billion-iteration loop. Resolve the preceding valid entry,
+        // then fail at the missing entry with its scalar index and without writing past that scalar.
         prosper_apr_reset_for_test();
-        const char* miss_paths[1] = { "prosper-test-apr-does-not-exist.tmp" };
-        uint32_t miss_id = 0x55; uint64_t miss_sz = 0x55; uint32_t miss_fl = 0x55;
-        uint64_t rm = resolve_prefix((uint64_t)(uintptr_t)"", (uint64_t)(uintptr_t)miss_paths, 1,
-                                     (uint64_t)(uintptr_t)&miss_id, (uint64_t)(uintptr_t)&miss_sz,
-                                     (uint64_t)(uintptr_t)&miss_fl);
-        CHECK(rm == 0 && miss_id == 0 && miss_sz == 0 && miss_fl == 0,
-              "unresolvable container zeroes its outputs");
+        const char* miss_paths[2] = { wp_full, "prosper-test-apr-does-not-exist.tmp" };
+        uint32_t miss_ids[2] = { 0x55, 0x55 }; uint64_t miss_sizes[2] = { 0x55, 0x55 };
+        uint32_t miss_error_guard[3] = { 0x11111111u, 0xDEADBEEFu, 0x22222222u };
+        uint64_t rm = resolve_plain((uint64_t)(uintptr_t)miss_paths, 2,
+                                    (uint64_t)(uintptr_t)miss_ids,
+                                    (uint64_t)(uintptr_t)miss_sizes,
+                                    (uint64_t)(uintptr_t)&miss_error_guard[1], 0);
+        CHECK((uint32_t)rm == 0x80020002u,
+              "missing APR path returns SCE_KERNEL_ERROR_ENOENT");
+        CHECK(miss_ids[0] >= 1 && miss_sizes[0] == wp_bytes.size() &&
+                  miss_ids[1] == 0xffffffffu && miss_sizes[1] == 0,
+              "APR resolver stops with deterministic outputs at the missing entry");
+        CHECK(miss_error_guard[0] == 0x11111111u && miss_error_guard[1] == 1 &&
+                  miss_error_guard[2] == 0x22222222u,
+              "APR resolver reports the scalar failure index without an array overrun");
 
         // A null paths pointer / non-positive count is rejected without touching memory.
         CHECK((uint32_t)resolve_prefix((uint64_t)(uintptr_t)"", 0, 1, 0, 0, 0) == 0x80020016u,


### PR DESCRIPTION
Progresses #1226.

## Failure scenario

ArcRunner asks `sceKernelAprResolveFilepathsToIdsAndFileSizes` for the loose resource `../../../arcrunner/Content/Localization/Game/en-US/Game.locres`. The resource exists only inside `arcrunner-ps5.pak`, so neither its ordinary `/app0` translation nor the existing `/app0/raw` fallback exists as a host file.

Prosper zeroed the output id and size but returned success. UE consequently cached a zero-length file, constructed an errored archive reader, and parsed stale stack data as a serialized array count. Live GDB inspection caught `inner_count=0xe125cc00`, trapping the main guest thread in a multi-billion-iteration loop before the second GPU submit.

## Behavioral contract

APR's fifth output is one scalar `errorIndex`, not a flags array. A missing path now:

- writes the failing index to that scalar without touching adjacent memory
- leaves deterministic invalid-id/zero-size outputs for the failed entry
- returns `SCE_KERNEL_ERROR_ENOENT` immediately

Successful path registration, stable ids/sizes, `/app0/raw` content fallback, and APR reads are unchanged. The shared behavior also applies to the id-only and WithPrefix resolver variants. This matches the independently implemented APR contract and, critically, ArcRunner's live caller behavior: UE rejects the missing loose file and continues loading it from the pak.

## Regression coverage

`test_apr_registry` now resolves a valid entry followed by a missing one and asserts:

- the first entry still receives its real id and size
- the second receives the invalid-id/zero-size sentinel
- the result is `SCE_KERNEL_ERROR_ENOENT`
- `errorIndex == 1`
- canaries around the scalar remain intact, preventing the old flags-array interpretation from returning

## Exact-head verification

Head: `b3b9e0887e968339d5f48784a228a51cbde3dd26`

- `cmake --build prosper/build-audit -j2` — PASS
- `ctest --test-dir prosper/build-audit --output-on-failure -j2` — 146/146 PASS, including hardware Vulkan execution tests on AMD Radeon 8060S / RADV STRIX_HALO
- `git diff --check origin/master...HEAD` — PASS
- ArcRunner baseline on current master, 35 seconds — pak resolves and reads, loose `Game.locres` misses, process remains before submit #2 in the stale-count loop
- ArcRunner fixed live run, 45 seconds — passes localization, initializes network/audio/compute, and renders 40+ 3840x2160 frames; the first nonzero frame is a solid-yellow render target, so this restores the rendering frontier but does not claim correct scene composition
- DOLL/PPSA17942 compatibility run, 40 seconds — remains alive through pak mount and 426+ frame folds with no APR regression or allocator fatal

The ArcRunner-configured CTest build additionally ran 150/153 tests successfully; its three dump-backed fixture tests correctly rejected ArcRunner because they encode the canonical dump's import/module/shader shape. The clean no-dump build above is the applicable full suite.

`prosper/tools/verify-pr.ps1 core` could not be run because neither `pwsh` nor `powershell` is installed in this Linux devcontainer.

## Risk

Callers that relied on fake success for a genuinely absent APR path now receive the platform error instead. That is intentional and bounded: existing files and the Sonic `/app0/raw` fallback resolve before the error path, and the DOLL live check exercises the other sensitive UE/APR boot path.
