### PR TITLE
fix(render): handle buffer upload failures safely

### DIFF
--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -255,6 +255,7 @@ inline BackendTextureUploadStats backend_texture_upload_stats() {
 struct BackendResourceReuseStats {
     size_t buffer_references = 0;
     size_t unique_buffers = 0;
+    size_t buffer_upload_fallbacks = 0;
     size_t texture_binding_references = 0;
     size_t unique_texture_bindings = 0;
     size_t descriptor_set_layout_references = 0;
@@ -1462,6 +1463,103 @@ inline void release_render_host_buffer(VkDevice device, RenderHostBuffer buffer)
     }
     for (RenderHostBuffer& old : evicted) destroy_render_host_buffer(device, old);
     if (buffer.buffer) destroy_render_host_buffer(device, buffer);
+}
+
+// Deterministic one-shot injection for the fresh storage-buffer upload regression checks. The
+// production path never arms this state; keeping it programmatic (rather than environment-driven)
+// prevents an accidental live-run setting from manufacturing allocation failures.
+enum class RenderBufferUploadFailureStep {
+    None,
+    CreateBuffer,
+    AllocateMemory,
+    BindMemory,
+    MapMemory,
+};
+
+inline RenderBufferUploadFailureStep& render_buffer_upload_failure_once_storage() {
+    static thread_local RenderBufferUploadFailureStep step =
+        RenderBufferUploadFailureStep::None;
+    return step;
+}
+
+inline void inject_render_buffer_upload_failure_once(RenderBufferUploadFailureStep step) {
+    render_buffer_upload_failure_once_storage() = step;
+}
+
+inline bool consume_render_buffer_upload_failure(RenderBufferUploadFailureStep step) {
+    RenderBufferUploadFailureStep& armed = render_buffer_upload_failure_once_storage();
+    if (armed != step) return false;
+    armed = RenderBufferUploadFailureStep::None;
+    return true;
+}
+
+inline const char* render_buffer_upload_failure_name(RenderBufferUploadFailureStep step) {
+    switch (step) {
+        case RenderBufferUploadFailureStep::CreateBuffer: return "vkCreateBuffer";
+        case RenderBufferUploadFailureStep::AllocateMemory: return "vkAllocateMemory";
+        case RenderBufferUploadFailureStep::BindMemory: return "vkBindBufferMemory";
+        case RenderBufferUploadFailureStep::MapMemory: return "vkMapMemory";
+        default: return "none";
+    }
+}
+
+// Create, populate, and unmap one transient storage buffer. Every partial failure tears down in
+// Vulkan lifetime order (buffer before any bound memory) and leaves both outputs null. Returning the
+// exact failed step lets the caller report the binding before substituting a safe zero-word buffer.
+inline RenderBufferUploadFailureStep create_transient_storage_buffer_upload(
+        const RenderVkCtx& ctx, const void* source, VkDeviceSize bytes,
+        VkBuffer& buffer, VkDeviceMemory& memory) {
+    buffer = VK_NULL_HANDLE;
+    memory = VK_NULL_HANDLE;
+    auto fail = [&](RenderBufferUploadFailureStep step) {
+        if (buffer) vkDestroyBuffer(ctx.dev, buffer, nullptr);
+        if (memory) release_transient_render_memory(ctx.dev, memory);
+        buffer = VK_NULL_HANDLE;
+        memory = VK_NULL_HANDLE;
+        return step;
+    };
+
+    VkBufferCreateInfo info{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
+    info.size = bytes;
+    info.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
+    const VkResult create_result =
+        consume_render_buffer_upload_failure(RenderBufferUploadFailureStep::CreateBuffer)
+            ? VK_ERROR_OUT_OF_DEVICE_MEMORY
+            : vkCreateBuffer(ctx.dev, &info, nullptr, &buffer);
+    if (create_result != VK_SUCCESS) {
+        // A failed create has no live object; the output value is not a destroyable handle.
+        buffer = VK_NULL_HANDLE;
+        return RenderBufferUploadFailureStep::CreateBuffer;
+    }
+    if (!buffer) return fail(RenderBufferUploadFailureStep::CreateBuffer);
+
+    VkMemoryRequirements requirements{};
+    vkGetBufferMemoryRequirements(ctx.dev, buffer, &requirements);
+    const uint32_t memory_type = render_memory_type(
+        ctx.phys, requirements.memoryTypeBits,
+        VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+    const bool inject_allocation_failure =
+        consume_render_buffer_upload_failure(RenderBufferUploadFailureStep::AllocateMemory);
+    if (memory_type != UINT32_MAX && !inject_allocation_failure)
+        memory = allocate_transient_render_memory(ctx.dev, requirements.size, memory_type);
+    if (!memory) return fail(RenderBufferUploadFailureStep::AllocateMemory);
+
+    const VkResult bind_result =
+        consume_render_buffer_upload_failure(RenderBufferUploadFailureStep::BindMemory)
+            ? VK_ERROR_OUT_OF_DEVICE_MEMORY
+            : vkBindBufferMemory(ctx.dev, buffer, memory, 0);
+    if (bind_result != VK_SUCCESS) return fail(RenderBufferUploadFailureStep::BindMemory);
+
+    void* mapped = nullptr;
+    const VkResult map_result =
+        consume_render_buffer_upload_failure(RenderBufferUploadFailureStep::MapMemory)
+            ? VK_ERROR_MEMORY_MAP_FAILED
+            : vkMapMemory(ctx.dev, memory, 0, bytes, 0, &mapped);
+    if (map_result != VK_SUCCESS || !mapped)
+        return fail(RenderBufferUploadFailureStep::MapMemory);
+    std::memcpy(mapped, source, static_cast<size_t>(bytes));
+    vkUnmapMemory(ctx.dev, memory);
+    return RenderBufferUploadFailureStep::None;
 }
 
 inline const RenderHostBuffer& render_internal_gds_buffer() {
@@ -2943,6 +3041,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         VkDeviceMemory memory = VK_NULL_HANDLE;
         void* mapped = nullptr;
         VkDeviceSize offset = 0;
+        VkDeviceSize range = 0;
         VkDeviceSize bytes = 0;
         VkDeviceSize allocation_bytes = 0;
         bool pooled = false;
@@ -3424,6 +3523,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
             std::vector<VkDescriptorBufferInfo> dbi(R.size());
             std::vector<VkDescriptorImageInfo> dii(R.size());
             std::vector<VkWriteDescriptorSet> wr(R.size());
+            bool buffer_resources_ready = true;
             for (size_t i = 0; i < R.size(); i++) {
                 const FrameResource& r = R[i];
                 lb[i] = {}; lb[i].binding = r.binding; lb[i].descriptorCount = 1;
@@ -3917,26 +4017,42 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                             upload.pooled = upload.buffer && upload.memory && upload.mapped;
                         }
                         if (!upload.arena && !upload.pooled) {
-                            VkBufferCreateInfo buffer_info{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
-                            buffer_info.size = bytes;
-                            buffer_info.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
-                            vkCreateBuffer(dev, &buffer_info, nullptr, &upload.buffer);
-                            VkMemoryRequirements requirements;
-                            vkGetBufferMemoryRequirements(dev, upload.buffer, &requirements);
-                            const uint32_t memory_type = pick(
-                                requirements.memoryTypeBits,
-                                VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
-                                    VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-                            upload.memory = allocate_transient_render_memory(
-                                dev, requirements.size, memory_type);
-                            vkBindBufferMemory(dev, upload.buffer, upload.memory, 0);
-                            void* mapped = nullptr;
-                            vkMapMemory(dev, upload.memory, 0, bytes, 0, &mapped);
-                            std::memcpy(mapped, words, static_cast<size_t>(bytes));
-                            vkUnmapMemory(dev, upload.memory);
+                            RenderBufferUploadFailureStep failure =
+                                create_transient_storage_buffer_upload(
+                                    ctx, words, bytes, upload.buffer, upload.memory);
+                            if (failure != RenderBufferUploadFailureStep::None) {
+                                static std::atomic<uint32_t> failure_logs{0};
+                                if (failure_logs.fetch_add(1, std::memory_order_relaxed) < 32)
+                                    std::fprintf(
+                                        stderr,
+                                        "[buffer-upload-failed] set=%u binding=%u requested=%llu "
+                                        "step=%s — substituting one zero word\n",
+                                        r.set, r.binding, (unsigned long long)bytes,
+                                        render_buffer_upload_failure_name(failure));
+                                upload = {};
+                                failure = create_transient_storage_buffer_upload(
+                                    ctx, &zero_buffer_word, sizeof(zero_buffer_word),
+                                    upload.buffer, upload.memory);
+                                if (failure != RenderBufferUploadFailureStep::None) {
+                                    if (failure_logs.fetch_add(1, std::memory_order_relaxed) < 32)
+                                        std::fprintf(
+                                            stderr,
+                                            "[buffer-upload-failed] set=%u binding=%u zero-word "
+                                            "fallback step=%s — skipping draw\n",
+                                            r.set, r.binding,
+                                            render_buffer_upload_failure_name(failure));
+                                    buffer_resources_ready = false;
+                                    break;
+                                }
+                                upload.range = sizeof(zero_buffer_word);
+                                ++resource_reuse_stats.buffer_upload_fallbacks;
+                            } else {
+                                upload.range = bytes;
+                            }
                         } else {
                             std::memcpy(static_cast<uint8_t*>(upload.mapped) + upload.offset,
                                         words, static_cast<size_t>(bytes));
+                            upload.range = bytes;
                         }
                         shared_buffers.push_back(upload);
                         shared_buffer_indices.emplace(buffer_key, buffer_index);
@@ -3947,11 +4063,12 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                     }
                     dbi[i] = {shared_buffers[buffer_index].buffer,
                               shared_buffers[buffer_index].offset,
-                              static_cast<VkDeviceSize>(word_count) * sizeof(uint32_t)};
+                              shared_buffers[buffer_index].range};
                     wr[i] = {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET}; wr[i].dstBinding = r.binding; wr[i].descriptorCount = 1;
                     wr[i].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER; wr[i].pBufferInfo = &dbi[i];
                 }
             }
+            if (!buffer_resources_ready) continue;
             for (uint32_t s = 0; s < v.n_sets; s++) {
                 std::vector<VkDescriptorSetLayoutBinding> slb;
                 for (size_t i = 0; i < R.size(); i++) if (R[i].set == s) slb.push_back(lb[i]);

--- a/prosper/tests/test_multidraw_render.cpp
+++ b/prosper/tests/test_multidraw_render.cpp
@@ -345,6 +345,33 @@ int main() {
         CHECK(pool_bypassed == shared,
               "pooled and forced-transient storage buffers render byte-identically");
 
+        // #1432: every failure in the fresh Vulkan upload path must tear down any partial objects,
+        // avoid copying through a null mapping, and bind one zero word instead. A buffer-reading VS
+        // makes that fallback observable: the valid payload covers the target red, while zeros
+        // collapse all three vertices to one point and preserve the blue clear.
+        prosper::test::BackendDraw failure_draw = d0;
+        failure_draw.R = {buffer};
+        set_env("PROSPER_NO_BACKEND_BUFFER_POOL", "1");
+        const prosper::test::RenderBufferUploadFailureStep failure_steps[] = {
+            prosper::test::RenderBufferUploadFailureStep::CreateBuffer,
+            prosper::test::RenderBufferUploadFailureStep::AllocateMemory,
+            prosper::test::RenderBufferUploadFailureStep::BindMemory,
+            prosper::test::RenderBufferUploadFailureStep::MapMemory,
+        };
+        for (const auto step : failure_steps) {
+            prosper::test::inject_render_buffer_upload_failure_once(step);
+            const std::vector<uint8_t> fallback =
+                prosper::test::render_draws_rgba({failure_draw}, W, H);
+            const uint8_t* fallback_center = center(fallback);
+            const auto fallback_stats = prosper::test::backend_resource_reuse_stats();
+            CHECK(fallback_center && fallback_center[0] < 0x40 &&
+                      fallback_center[1] < 0x40 && fallback_center[2] > 0xC0 &&
+                      fallback_stats.buffer_upload_fallbacks == 1 &&
+                      fallback_stats.unique_buffers == 1,
+                  "fresh buffer-upload failure binds a one-word zero fallback without crashing");
+        }
+        set_env("PROSPER_NO_BACKEND_BUFFER_POOL", nullptr);
+
         // #1268: buffers above the 4 KiB hash-dedup bound skip content hashing entirely (live Blue
         // Prince data: zero dedup hits across 556K hashed references at ~1.8 GiB/s of hashing).
         // Repeat references still resolve through the per-call memo, and rendering is unchanged.


### PR DESCRIPTION
Closes #1432.

## Failure scenario

The fresh `SharedBufferUpload` path ignored `vkCreateBuffer`, transient allocation, `vkBindBufferMemory`, and `vkMapMemory` failures, then copied guest words through the returned mapping unconditionally. A large or corrupt descriptor that exhausted host-visible memory could therefore turn an ordinary Vulkan allocation failure into a host null-pointer crash.

## Behavioral contract

- Centralize fresh storage-buffer creation/upload in a checked helper.
- Tear down partial objects in Vulkan lifetime order and leave both handles null after every failure.
- Emit a capped `[buffer-upload-failed]` diagnostic naming set, binding, requested bytes, and failed Vulkan step.
- Retry the binding with one zero word. Its descriptor range is reduced to exactly four bytes, so robust-buffer reads beyond it return zero rather than exposing adjacent memory.
- Skip the draw fail-visibly only if the four-byte fallback also cannot be created.
- Add deterministic one-shot injection for create/allocation/bind/map and exercise each boundary through the real multi-draw Vulkan renderer. The buffer-reading vertex shader makes the fallback observable: the normal payload covers the target, while the zero fallback collapses the triangle and preserves the clear.

The arena and persistent host-buffer pool success paths are unchanged. Successful fresh uploads retain the same bytes and descriptor range; only failure behavior changes.

## Risk

The intended degradation is missing geometry for the affected binding instead of a renderer crash. The fallback depends on Vulkan robust buffer access, which this renderer explicitly enables. If even a four-byte allocation fails, the draw is skipped rather than building a null descriptor.

## Exact-head verification

Head: `dff4a1af742951975af54bea1e0620129d616978`

- `git diff --check origin/master...HEAD` — pass
- `distrobox enter ps5ys -- bash -lc 'cmake --build prosper/build-linux -j8'` — pass
- `distrobox enter ps5ys -- bash -lc 'ctest --test-dir prosper/build-linux --output-on-failure'` — 151/151 pass
- `distrobox enter ps5ys -- bash -lc 'cd prosper && PROSPER_GAME_ROOT=/var/home/mattias800/repos/ps5ys PROSPER_BOOT_TRACE=/var/home/mattias800/repos/ps5ys-issue-1432/prosper/build-linux/boot_trace PROSPER_SCREENSHOT=/var/home/mattias800/repos/ps5ys-issue-1432/prosper/build-linux/screenshot python3 tools/snapshot/snapshot.py check messenger-scene'` — pass (`29/29` qualifying frames, 28 pixel changes, 29 structural/nonblack matches)
