### PR TITLE
test(render): guard full buffer uploads end to end

### DIFF
--- a/prosper/tests/test_gpu_capture_render.cpp
+++ b/prosper/tests/test_gpu_capture_render.cpp
@@ -50,6 +50,9 @@ static void unset_env(const char* name) {
 }
 
 int main() {
+    // buffer_upload_bytes caches this override on first use. Reset it before the renderer can build
+    // any buffer resource so the test always exercises the production default ceiling.
+    unset_env("PROSPER_MAX_BUFFER_UPLOAD_MB");
     std::printf("== test_gpu_capture_render ==\n");
     constexpr uint32_t W = 64, H = 64;
 
@@ -803,6 +806,74 @@ int main() {
               "missing sampled image receives a full-surface nonblack poison texture instead of zero");
     }
 
+    // #1435: prove the live renderer uploads buffer bytes beyond the old 1 MiB clamp. The fragment
+    // shader reads a raw dword through a direct V# at a scalar SOFFSET, then exports those float bits
+    // as red. A below-clamp sentinel is the positive control; the 1.5 MiB sentinel turns robust-OOB
+    // zero under the old truncated upload, so the framebuffer observes the defect end to end without
+    // involving vertex fetch or geometry.
+    {
+        constexpr uint32_t low_offset = 0x80000u;
+        constexpr uint32_t high_offset = 0x180000u;
+        std::vector<uint32_t> buffer_words(high_offset / sizeof(uint32_t) + 1u, 0u);
+        buffer_words[low_offset / sizeof(uint32_t)] = 0x3e800000u;   // 0.25f
+        buffer_words[high_offset / sizeof(uint32_t)] = 0x3f400000u; // 0.75f
+
+        ShaderResourceTable buffer_table;
+        ShaderResource buffer{};
+        buffer.cls = ResourceClass::ConstantBuffer;
+        buffer.format = DataFormat::Float32;
+        buffer.num_components = 1;
+        buffer.binding = 32;
+        buffer.sgpr_base = 0;
+        buffer.gpu_addr = 0x10000000u;
+        buffer.size = static_cast<uint32_t>(buffer_words.size() * sizeof(uint32_t));
+        buffer.host_data = reinterpret_cast<uint8_t*>(buffer_words.data());
+        buffer.host_data_size = buffer.size;
+        buffer_table.resources.push_back(buffer);
+
+        auto render_sentinel = [&](uint32_t byte_offset, uint64_t target_base) {
+            const uint32_t buffer_ps[] = {
+                0xbe8403ffu, byte_offset, // s_mov_b32 s4, byte_offset
+                0xe0300000u, 0x04000000u, // buffer_load_dword v0, off, s[0:3], s4
+                0x7e020280u,              // v_mov_b32 v1, 0
+                0x7e040280u,              // v_mov_b32 v2, 0
+                0x7e0602f2u,              // v_mov_b32 v3, 1.0
+                0xf800000fu, 0x03020100u, // exp mrt0 v0, v1, v2, v3
+                0xbf810000u,
+            };
+            DrawItem draw = replay.items[0];
+            draw.fs = recompile_fragment(buffer_ps, std::size(buffer_ps), &buffer_table);
+            draw.fs_shared.reset();
+            draw.fs_identity = 0;
+            draw.prt = std::make_shared<ShaderResourceTable>(buffer_table);
+            draw.color0_base = target_base;
+            if (draw.fs.empty()) return std::vector<uint8_t>{};
+            return render_submit_items({draw}, W, H);
+        };
+
+        const std::vector<uint8_t> low_pixels = render_sentinel(low_offset, 0xd00000u);
+        bool low_sentinel_visible = low_pixels.size() == static_cast<size_t>(W) * H * 4u;
+        if (low_sentinel_visible) {
+            const uint8_t* center =
+                &low_pixels[(static_cast<size_t>(H / 2) * W + W / 2) * 4u];
+            low_sentinel_visible = center[0] >= 56 && center[0] <= 72 &&
+                                   center[1] < 8 && center[2] < 8;
+        }
+        CHECK(low_sentinel_visible,
+              "fragment buffer read below 1 MiB exposes its distinct pixel sentinel");
+
+        const std::vector<uint8_t> high_pixels = render_sentinel(high_offset, 0xd10000u);
+        bool high_sentinel_visible = high_pixels.size() == static_cast<size_t>(W) * H * 4u;
+        if (high_sentinel_visible) {
+            const uint8_t* center =
+                &high_pixels[(static_cast<size_t>(H / 2) * W + W / 2) * 4u];
+            high_sentinel_visible = center[0] >= 184 && center[0] <= 200 &&
+                                    center[1] < 8 && center[2] < 8;
+        }
+        CHECK(high_sentinel_visible,
+              "fragment buffer read at 1.5 MiB survives the former upload clamp (#1435)");
+    }
+
     // VideoOut's registered dimensions are authoritative even when CB_COLOR0_ATTRIB2 describes a
     // larger backing allocation. Treating this 256x256 declaration as the visible extent scales the
     // pass to 128x128 and prevents the final 64x64 scanout lookup from publishing the rendered frame.
@@ -829,9 +900,6 @@ int main() {
     // that scene run 1.4-3.0 MiB, and the draw that straddled the clamp lost precisely the vertices
     // whose offset exceeded it, so these sizes are the measured contract, not round numbers.
     {
-        // buffer_upload_bytes caches the override in a function-local static, so an exported
-        // PROSPER_MAX_BUFFER_UPLOAD_MB (the A/B shell) would otherwise fail these checks.
-        unset_env("PROSPER_MAX_BUFFER_UPLOAD_MB");
         using prosper::frontend::buffer_upload_bytes;
         CHECK(buffer_upload_bytes(454024u) == 454024u,
               "a sub-megabyte vertex stream uploads whole (unchanged behavior)");


### PR DESCRIPTION
## Failure scenario

The #1427/#1429 fix removed the silent 1 MiB buffer-upload clamp, but ctest only pinned the size helper. A renderer regression could still upload a truncated descriptor, make a fragment read past 1 MiB robustly return zero, and pass every existing end-to-end assertion.

Refs #1435 (ctest guard only; the remaining 27 Blue Prince hall draws deliberately stay out of scope).

## Behavioral contract

- Reset `PROSPER_MAX_BUFFER_UPLOAD_MB` before any renderer/resource setup because `buffer_upload_bytes` caches its first environment read.
- Bind one 1.5 MiB constant buffer to a fragment shader over the existing fullscreen triangle.
- Read a distinct 0.25 sentinel at 512 KiB as a positive harness control.
- Read a 0.75 sentinel at 1.5 MiB and assert the resulting framebuffer pixel.
- Clear `fs_shared` and the shader identity when replacing the cloned replay fragment shader, so shared-shader precedence cannot make the test green through the old texture shader.

This is test-only. It does not change upload policy, shader lowering, resource binding, or the separate investigation of the 27 remaining hall draws.

## Exact-head verification

Head: `2f0cdea27a33b4581b0f2f0cc42a80ffabc22f20`
Base: `ffbb7d74e4c16cb4652c7efaa837bddd8f0cc895`

- `git diff --check origin/master...HEAD` — pass.
- `cmake --build prosper/build-arcrunner --target test_gpu_capture_render -j2` — pass.
- `ctest --test-dir prosper/build-arcrunner -R ^gpu_capture_render_replay$ --output-on-failure` — 1/1 pass on AMD Radeon 8060S / RADV.
- Counterfactual: temporarily restored the old 1 MiB production ceiling, rebuilt, and ran the same executable. The 512 KiB control passed, `[buffer-truncated]` reported the 1.5 MiB resource, and the high-offset pixel assertion failed. The temporary source change was then removed and the exact-head focused test passed again.
- CI-equivalent clean configuration: `cmake -S prosper -B prosper/build-codex-ci -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_DISABLE_FIND_PACKAGE_Vulkan=TRUE`; build passed; ctest 121/121 passed.
- Full GPU-enabled local ctest: 150/153 passed. The only failures are unrelated dump-contract checks because `build-arcrunner` points at ArcRunner instead of the default test dump: `module_loads_eboot`, `boot_reaches_first_syscall`, and `real_shader_render`. All 27 Vulkan execution tests, including this regression, passed.

`pwsh`/PowerShell and a Windows toolchain are unavailable in this Linux devcontainer, so the repository verification wrapper and local Windows leg could not be run; required CI remains authoritative for those legs.

## Risk

Low and test-only. The shader uses existing decoded gfx1030 encodings and tolerant UNORM8 pixel ranges; its below-clamp control distinguishes shader/resource/harness failure from the upload-boundary regression.