### PR TITLE
fix(gpu): give DrawItem a shader setter so substitutions cannot be silently shadowed

### DIFF
--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -97,7 +97,9 @@ struct DrawItem {
     // reads as "my substitution changed nothing" rather than as an error (#1434; it cost real time in
     // the #1427 investigation, and #1396 fixed the same class of confusion for the replay probes).
     // Substitute through set_vs()/set_fs(), which drop the shared value and the cache identity so
-    // persistent backend caches compare the new words instead of hitting the old entry.
+    // persistent backend caches compare the new words instead of hitting the old entry. `gs` has no
+    // shared form today; if one is ever added it needs the same accessor/setter pair, or this bug
+    // returns through the geometry stage.
     const std::vector<uint32_t>& vs_words() const { return vs_shared ? *vs_shared : vs; }
     const std::vector<uint32_t>& gs_words() const { return gs; }
     const std::vector<uint32_t>& fs_words() const { return fs_shared ? *fs_shared : fs; }

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -92,9 +92,27 @@ struct DrawItem {
     uint64_t draw_index = 0;
     uint64_t command_order = 0;
 
+    // A shared value WINS over the owned vector. Assigning `vs`/`fs` on an item that already carries
+    // a shared value therefore has NO effect — the original shader keeps rendering, and the mistake
+    // reads as "my substitution changed nothing" rather than as an error (#1434; it cost real time in
+    // the #1427 investigation, and #1396 fixed the same class of confusion for the replay probes).
+    // Substitute through set_vs()/set_fs(), which drop the shared value and the cache identity so
+    // persistent backend caches compare the new words instead of hitting the old entry.
     const std::vector<uint32_t>& vs_words() const { return vs_shared ? *vs_shared : vs; }
     const std::vector<uint32_t>& gs_words() const { return gs; }
     const std::vector<uint32_t>& fs_words() const { return fs_shared ? *fs_shared : fs; }
+
+    void set_vs(std::vector<uint32_t> words) {
+        vs = std::move(words); vs_shared.reset(); vs_identity = 0;
+    }
+    void set_fs(std::vector<uint32_t> words) {
+        fs = std::move(words); fs_shared.reset(); fs_identity = 0;
+    }
+    // True when an owned vector was assigned while a shared value still shadows it — the silent
+    // failure above. Diagnostics assert on this rather than rendering the wrong shader quietly.
+    bool has_shadowed_shader() const {
+        return (vs_shared && !vs.empty()) || (fs_shared && !fs.empty());
+    }
 };
 
 // The pluggable Vulkan backend: render the submit's draw items into one image and return W*H*4 RGBA8

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -226,9 +226,21 @@ struct BackendDraw {
     // plain vkCmdDraw(vcount). Both paths preserve instance_count.
     std::vector<uint32_t> indices;
 
+    // Same precedence — and same trap — as DrawItem (#1434): a shared value WINS, so assigning
+    // `vs`/`fs` on a draw that already carries one silently keeps the ORIGINAL shader. Substitute
+    // through set_vs()/set_fs(), which also clear the cache identity so the persistent pipeline
+    // cache compares the new words instead of hitting the stale entry. `gs` has no shared form; if
+    // one is ever added it needs the same accessor/setter pair.
     const std::vector<uint32_t>& vs_words() const { return vs_shared ? *vs_shared : vs; }
     const std::vector<uint32_t>& gs_words() const { return gs; }
     const std::vector<uint32_t>& fs_words() const { return fs_shared ? *fs_shared : fs; }
+
+    void set_vs(std::vector<uint32_t> words) {
+        vs = std::move(words); vs_shared.reset(); vs_identity = 0;
+    }
+    void set_fs(std::vector<uint32_t> words) {
+        fs = std::move(words); fs_shared.reset(); fs_identity = 0;
+    }
 };
 
 struct BackendTextureUploadStats {

--- a/prosper/tests/test_gpu_execute.cpp
+++ b/prosper/tests/test_gpu_execute.cpp
@@ -689,6 +689,20 @@ int main() {
         CHECK(owned.vs_words() == std::vector<uint32_t>({0x07230203u, 7u}) &&
                   !owned.has_shadowed_shader(),
               "set_vs on an item without a shared value behaves like a plain assignment");
+
+        // BackendDraw carries the identical accessor precedence (the line #1434 originally cited),
+        // so it gets the same setters. This is the struct the frontend hands the Vulkan backend.
+        prosper::test::BackendDraw backend;
+        backend.vs_shared = std::make_shared<const std::vector<uint32_t>>(
+            std::vector<uint32_t>{0x07230203u, 111u});
+        backend.vs_identity = 0xCCCC;
+        backend.vs = {0x07230203u, 999u};
+        CHECK(backend.vs_words() == std::vector<uint32_t>({0x07230203u, 111u}),
+              "BackendDraw shows the same shadowing before substitution (#1434)");
+        backend.set_vs({0x07230203u, 999u});
+        CHECK(backend.vs_words() == std::vector<uint32_t>({0x07230203u, 999u}) &&
+                  !backend.vs_shared && backend.vs_identity == 0,
+              "BackendDraw::set_vs substitutes and clears the shared value and identity");
     }
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }

--- a/prosper/tests/test_gpu_execute.cpp
+++ b/prosper/tests/test_gpu_execute.cpp
@@ -650,6 +650,47 @@ int main() {
     CHECK(!execute_and_present(empty, W, H), "execute_and_present skips a draw-less submit even with a renderer");
     set_submit_renderer({});  // restore inert default
 
+    // #1434: a shared shader value WINS over the owned vector, so assigning `vs`/`fs` on an item
+    // that already carries one silently keeps rendering the ORIGINAL shader. That reads as "my
+    // substitution changed nothing" rather than as an error, and it cost real time during the
+    // #1427 investigation. set_vs()/set_fs() are the safe form: they drop the shared value and the
+    // cache identity, so persistent backend caches compare the new words instead of hitting the
+    // stale entry.
+    {
+        DrawItem shadowed;
+        shadowed.vs_shared = std::make_shared<const std::vector<uint32_t>>(
+            std::vector<uint32_t>{0x07230203u, 111u});
+        shadowed.fs_shared = std::make_shared<const std::vector<uint32_t>>(
+            std::vector<uint32_t>{0x07230203u, 222u});
+        shadowed.vs_identity = 0xAAAA; shadowed.fs_identity = 0xBBBB;
+
+        shadowed.vs = {0x07230203u, 999u};          // the trap: direct assignment
+        CHECK(shadowed.vs_words() == std::vector<uint32_t>({0x07230203u, 111u}),
+              "a direct vs assignment is shadowed by vs_shared (the #1434 trap)");
+        CHECK(shadowed.has_shadowed_shader(),
+              "has_shadowed_shader() reports the shadowed assignment");
+
+        shadowed.set_vs({0x07230203u, 999u});
+        CHECK(shadowed.vs_words() == std::vector<uint32_t>({0x07230203u, 999u}) &&
+                  !shadowed.vs_shared && shadowed.vs_identity == 0,
+              "set_vs substitutes the words and clears the shared value and cache identity");
+        CHECK(shadowed.fs_words() == std::vector<uint32_t>({0x07230203u, 222u}) &&
+                  shadowed.fs_identity == 0xBBBB,
+              "set_vs leaves the fragment stage untouched");
+
+        shadowed.set_fs({0x07230203u, 888u});
+        CHECK(shadowed.fs_words() == std::vector<uint32_t>({0x07230203u, 888u}) &&
+                  !shadowed.fs_shared && shadowed.fs_identity == 0 &&
+                  !shadowed.has_shadowed_shader(),
+              "set_fs substitutes the fragment stage and clears the shadow");
+
+        DrawItem owned;                              // no shared value: unchanged behavior
+        owned.set_vs({0x07230203u, 7u});
+        CHECK(owned.vs_words() == std::vector<uint32_t>({0x07230203u, 7u}) &&
+                  !owned.has_shadowed_shader(),
+              "set_vs on an item without a shared value behaves like a plain assignment");
+    }
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -1402,14 +1402,14 @@ int main(int argc, char** argv) {
                 const auto& raw = replay.raw_shader_versions[it.vs_raw_shader_index];
                 auto vs = prosper::gpu::recompile_vertex(raw.words.data(), raw.words.size(),
                                                          it.vrt.get(), nullptr, false);
-                if (!vs.empty()) { it.vs = std::move(vs); it.vs_shared.reset(); it.vs_identity = 0; ++vs_swapped; }
+                if (!vs.empty()) { it.set_vs(std::move(vs)); ++vs_swapped; }
                 else ++vs_kept;
             } else ++vs_kept;
             if (it.fs_raw_shader_index < replay.raw_shader_versions.size()) {
                 const auto& raw = replay.raw_shader_versions[it.fs_raw_shader_index];
                 auto fs = prosper::gpu::recompile_fragment(raw.words.data(), raw.words.size(),
                                                            it.prt.get(), nullptr, UINT32_MAX, nullptr);
-                if (!fs.empty()) { it.fs = std::move(fs); it.fs_shared.reset(); it.fs_identity = 0; ++fs_swapped; }
+                if (!fs.empty()) { it.set_fs(std::move(fs)); ++fs_swapped; }
                 else ++fs_kept;
             } else ++fs_kept;
         }
@@ -1440,7 +1440,7 @@ int main(int argc, char** argv) {
                 auto xfb = prosper::gpu::recompile_vertex(raw.words.data(), raw.words.size(),
                                                           it.vrt.get(), nullptr, true);
                 if (!xfb.empty()) {
-                    it.vs = std::move(xfb); it.vs_shared.reset(); it.vs_identity = 0;
+                    it.set_vs(std::move(xfb));
                     std::fprintf(stderr,
                                  "[geom-probe] draw=%llu item=%zu operation=%lld VS re-recompiled "
                                  "with xfb capture (%zu words)\n",
@@ -1481,7 +1481,7 @@ int main(int argc, char** argv) {
                 auto fs = prosper::gpu::recompile_fragment(raw.words.data(), raw.words.size(),
                                                            it.prt.get(), nullptr, UINT32_MAX, nullptr);
                 if (!fs.empty()) {
-                    it.fs = std::move(fs); it.fs_shared.reset(); it.fs_identity = 0;
+                    it.set_fs(std::move(fs));
                     std::fprintf(stderr,
                                  "[fs-tap] draw=%llu item=%zu operation=%lld FS re-recompiled "
                                  "at pc=%u with colour tap (%zu words)\n",


### PR DESCRIPTION
Fixes #1434.

## Failure scenario

`DrawItem::vs_words()`/`fs_words()` return the **shared** value whenever one is set. Assigning `vs`/`fs` on an item that carries one therefore has no effect — the original shader keeps rendering:

```cpp
DrawItem d = replay.items[0];
d.vs = recompile_vertex(my_vs, n, my_table);   // ignored: d.vs_shared still set
```

The frame renders normally with the *wrong* shader, so the mistake reads as "my substitution changed nothing" rather than as an error. It cost real time during the #1427 investigation — a test that appeared to exercise a substituted shader was in fact rendering the original — and #1396 fixed the same class of ownership confusion for the replay probes.

## Contract

- **`set_vs()` / `set_fs()`** assign the words and drop both the shared value and the cache identity, so persistent backend caches compare the new words instead of hitting the stale entry. This is exactly the hand-written triple the correct call sites already performed.
- **`has_shadowed_shader()`** reports the ambiguous state (owned vector assigned while a shared value still shadows it) so a diagnostic can assert instead of quietly rendering the wrong shader.
- The accessor now documents the precedence at the point where a reader forms the wrong assumption, rather than only in the field comment above it.
- The four substitution sites in `gpu_replay` (`--recompile-raw`'s mass loop, the geometry probe, the fragment tap) go through the setters.

## Affected / unaffected

Behavior is unchanged everywhere: the setters do what the correct sites already did, and an item with no shared value behaves like a plain assignment. No renderer path, format, or ordering semantics change — hence no snapshot gate.

## Verification (exact head `ea6ba0a8`)

- `ctest`: **152/152**.
- The new checks pin the precedence itself: the first asserts that a direct assignment **is** shadowed (so the test documents the trap and fails if the precedence ever silently flips), then that `set_vs`/`set_fs` substitute and clear, that each leaves the other stage untouched, and that an item without a shared value is unaffected.
- Behavioral smoke on the converted paths: `gpu_replay --recompile-raw` still substitutes 1563/1563 draws on the Blue Prince hall capsule, and `PROSPER_FS_TAP=1153:399` still reports `draw=1153 item=1149 operation=1172`.

## Risk

`has_shadowed_shader()` has no callers yet — it is the hook for a future debug assert; adding one now would risk tripping on a legitimate transient state I have not surveyed. Noted rather than hidden.