### PR TITLE
docs(blue-prince): close vanished-draw triage

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -173,8 +173,8 @@ earlier: unbounded register-file growth (#1266) and per-draw full-buffer content
 
 Open: a by-eye play-through confirmation is still outstanding, the snapshot guard for the hall
 predates the geometry fix (#1433), floating black rectangles remain at the wall-lamp positions
-(#1287), 27 draws still vanish at clip pending triage (#1435), and boot remains intermittent
-(#1178).
+(#1287), and boot remains intermittent (#1178). The 27 draws that still vanish at clip were
+individually probed and confirmed as legitimate frustum culls (#1435).
 
 ## Dragon Quest VII Reimagined — `PPSA17942`
 

--- a/prosper/docs/BLUE_PRINCE_STATUS.md
+++ b/prosper/docs/BLUE_PRINCE_STATUS.md
@@ -1,7 +1,8 @@
 # Blue Prince (PPSA25009, Unity/IL2CPP) — status & investigation map
 
-Last revised: 2026-07-26 (materials fixed — #1287 families 1-3 resolved; see below). Prior history: #1216 (closed —
-boot/blank-frame era), #1264 (Day One hold investigation), #1287 (visuals umbrella, open).
+Last revised: 2026-07-26 (materials fixed and residual vanished draws triaged; see below). Prior history:
+#1216 (closed — boot/blank-frame era), #1264 (Day One hold investigation), #1287 (visuals umbrella,
+open).
 
 ## Ladder position
 
@@ -56,8 +57,9 @@ The `blue-prince-title` snapshot route guards the title screen.
 ## Defect families (#1287) — families 1–3 and 5 RESOLVED 2026-07-26
 
 Families 1–3 and 5 below are **fixed on master**; they are retained as the resolution record so
-the evidence is not re-chased. Only family 4 remains open, plus the two #1427 remainders tracked
-in #1435 (a ctest-resident truncation guard, and triage of the 27 still-vanished hall draws).
+the evidence is not re-chased. Only family 4 remains open. Both #1427 remainders tracked in #1435
+are resolved: #1440 added the ctest-resident truncation guard, and the residual 27 vanished draws
+were confirmed as legitimate frustum culls.
 
 1. **RESOLVED — concentric ring/band moiré** radiating from lights. It was never
    light-accumulation math: the ring structure was the *palette/material atlas* sampled through
@@ -95,8 +97,12 @@ in #1435 (a ctest-resident truncation guard, and triage of the 27 still-vanished
    drops vanished draws to 27/248 and renders the hall at oracle parity
    (`docs/screenshots/issue-1427-oracle-before-after.png`). The old bisection range recorded here
    (operations 1100-1200) was a red herring produced by the isolated-draw depth trap — do not
-   resume it. Remaining: the 27 still-vanished draws, some plausibly legitimate off-screen culling
-   (triage tracked in #1435), and the bouquet's confetti-coloured flowers.
+   resume it. The residual 27/248 `GEOMETRY-VANISH` draws were each checked with
+   `PROSPER_GEOM_PROBE`: all wrote their expected finite vertex count, retained real positional
+   spread and healthy topology, and landed wholly outside the clip volume or behind the camera.
+   None had the pre-fix `unique-pos<=2` collapse signature; the repeated transparent-pass meshes
+   reproduced the same off-screen bounds as their opaque passes (#1435). The bouquet's
+   confetti-coloured flowers remain part of family 4.
 
 ## Capsule & artifact inventory (`~/bp-1264/`, all run-local addresses)
 


### PR DESCRIPTION
## Summary

- record that every one of the 27 residual entrance-hall `GEOMETRY-VANISH` draws has healthy post-transform geometry
- distinguish legitimate frustum culls from the pre-#1429 collapsed-fetch signature
- remove the stale compatibility item now that #1440 also supplies the end-to-end upload guard

## Evidence

On current `origin/master` (`50f0791da3ae701ef24084b10826b5150f507a86`), `PROSPER_DRAW_STATS=1` reports the same 27 residual draws in semantic range 896..1143. I isolated and probed all 27 with `PROSPER_GEOM_PROBE=<draw> gpu_replay --draw <draw> ...`:

- 27/27 wrote the full finite vertex count
- 27/27 reported `geom-health ... -> ok`
- none reported `COLLAPSED`, `DEGENERATE`, NaN/Inf output, or `unique-pos<=2`
- all clip-space bounds were wholly off-screen or behind the camera
- repeated transparent-pass meshes reproduced the opaque passes’ off-screen bounds exactly

That is the expected signature for real submitted meshes culled by the view, in contrast to the pre-#1429 defect (`unique-pos=1`, extreme multiplicity, 100% degenerate).

## Validation

- `git diff --check`
- rebuilt `gpu_replay` from current master
- full-capture `PROSPER_DRAW_STATS=1` reproduction: 27 vanished draws in the 248-draw hall range
- isolated `PROSPER_GEOM_PROBE` sweep of all 27 semantic draw IDs

Documentation-only change; PowerShell verification was unavailable in the Linux devcontainer.

Closes #1435