### PR TITLE
fix(gpu-replay): honor shared shader storage

### DIFF
--- a/prosper/tests/test_gpu_replay_shader_dump.cpp
+++ b/prosper/tests/test_gpu_replay_shader_dump.cpp
@@ -94,6 +94,31 @@ int main() {
               error.find("capture predates v19 or source was unreadable") != std::string::npos,
           "missing legacy raw source is explicit instead of selecting unrelated bytes");
 
+    gpu::GpuReplayFrame shared_replay;
+    gpu::DrawItem shared_draw;
+    shared_draw.draw_index = 19;
+    shared_draw.vs = {0xaaaaaaaa};
+    shared_draw.fs = {0xbbbbbbbb};
+    shared_draw.vs_shared =
+        std::make_shared<const std::vector<uint32_t>>(std::vector<uint32_t>{0x07230203, 0x11});
+    shared_draw.fs_shared =
+        std::make_shared<const std::vector<uint32_t>>(std::vector<uint32_t>{0x07230203, 0x22, 0x33});
+    shared_replay.items.push_back(shared_draw);
+    bool shared = false;
+    const auto* stored_vs = tools::select_recompiled_shader(shared_replay, "19:vs", shared, error);
+    CHECK(stored_vs == shared_draw.vs_shared.get() && shared,
+          "recompiled VS selection reads the shared words that rendering consumes");
+    const auto* stored_fs = tools::select_recompiled_shader(shared_replay, "19:fs", shared, error);
+    CHECK(stored_fs == shared_draw.fs_shared.get() && shared,
+          "recompiled FS selection reads the shared words that rendering consumes");
+    shared_replay.items[0].vs_shared.reset();
+    const auto* owned_vs = tools::select_recompiled_shader(shared_replay, "19:vs", shared, error);
+    CHECK(owned_vs == &shared_replay.items[0].vs && !shared,
+          "recompiled shader selection retains the ordinary owned-vector path");
+    CHECK(!tools::select_recompiled_shader(shared_replay, "20:vs", shared, error) &&
+              error.find("realized draw 20 not found") != std::string::npos,
+          "recompiled shader selection rejects an absent semantic draw");
+
     std::printf("%s\n", fails ? "FAIL" : "PASS");
     return fails ? 1 : 0;
 }

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -20,6 +20,8 @@ Inspection reports each descriptor's declared size, capture-planned footprint, a
 count separately, so a thin capsule can still expose a pathological range. Capture v28+ retains the exact
 planned span and reports the resolved `row-pitch` for linear sampled images; older captures derive the
 guest pitch while retaining their historical tight byte span.
+The `vs=` and `fs=` summaries identify whether each recompiled shader is retained as `owned` or
+`shared`; their size and hash always describe the accessor-selected words the renderer consumes.
 
 Build from `prosper/`, using the worktree-local Linux build:
 

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -321,6 +321,8 @@ void inspect_frame(const prosper::gpu::GpuReplayFrame& replay) {
     }
     for (size_t i = 0; i < replay.items.size(); ++i) {
         const auto& d = replay.items[i];
+        const auto vs = prosper::tools::recompiled_shader_view(d, true);
+        const auto fs = prosper::tools::recompiled_shader_view(d, false);
         // #1256: raw-vs-realized draw-count check. The capture retains the raw DrawIndexAuto/DrawIndex
         // index_count (raw_draw_count) decoded from the guest; for a non-indexed draw the realized
         // vertex_count MUST equal it, and for an indexed draw the fetched index count must equal it.
@@ -346,7 +348,7 @@ void inspect_frame(const prosper::gpu::GpuReplayFrame& replay) {
                     "depth=%d/%d/%u stencil=%d blend=%d raster=%u/%u/%u bias=%u/%g/%g/%g "
                     "viewport=%d %.1f,%.1f %.1fx%.1f "
                     "scissor=%d [%d,%d)-[%d,%d) export=%08x downconvert=%08x "
-                    "vs=%zu/%016llx fs=%zu/%016llx\n",
+                    "vs=%zu/%016llx/%s fs=%zu/%016llx/%s\n",
                     static_cast<unsigned long long>(d.draw_index), i,
                     static_cast<unsigned long long>(d.color0_base), d.color0_width, d.color0_height,
                     d.ps.color0_format, d.ps.color_write_mask,
@@ -362,10 +364,12 @@ void inspect_frame(const prosper::gpu::GpuReplayFrame& replay) {
                     d.ps.has_scissor, d.ps.scissor_left, d.ps.scissor_top,
                     d.ps.scissor_right, d.ps.scissor_bottom,
                     d.ps.spi_shader_col_format, d.ps.sx_ps_downconvert,
-                    d.vs.size(), static_cast<unsigned long long>(prosper::gpu::gpu_capture_hash(
-                        reinterpret_cast<const uint8_t*>(d.vs.data()), d.vs.size() * 4)),
-                    d.fs.size(), static_cast<unsigned long long>(prosper::gpu::gpu_capture_hash(
-                        reinterpret_cast<const uint8_t*>(d.fs.data()), d.fs.size() * 4)));
+                    vs.words->size(), static_cast<unsigned long long>(prosper::gpu::gpu_capture_hash(
+                        reinterpret_cast<const uint8_t*>(vs.words->data()), vs.words->size() * 4)),
+                    vs.shared ? "shared" : "owned",
+                    fs.words->size(), static_cast<unsigned long long>(prosper::gpu::gpu_capture_hash(
+                        reinterpret_cast<const uint8_t*>(fs.words->data()), fs.words->size() * 4)),
+                    fs.shared ? "shared" : "owned");
         // Blend detail: UI compositing correctness hangs on the exact color AND alpha factor
         // programming (a separate-alpha UI backdrop writes a different alpha than its color
         // factors imply — #320's dialogue overlay), so make the full equation inspectable.
@@ -528,6 +532,8 @@ bool validate_frame(const prosper::gpu::GpuReplayFrame& replay) {
     bool valid = true;
     for (size_t i = 0; i < replay.items.size(); ++i) {
         const auto& d = replay.items[i];
+        const auto vs = prosper::tools::recompiled_shader_view(d, true);
+        const auto fs = prosper::tools::recompiled_shader_view(d, false);
         struct StageInput {
             const char* name;
             const std::vector<uint32_t>* spirv;
@@ -535,8 +541,8 @@ bool validate_frame(const prosper::gpu::GpuReplayFrame& replay) {
             uint32_t set;
             prosper::gpu::SpirvShaderStage stage;
         } stages[] = {
-            {"VS", &d.vs, d.vrt.get(), 0, prosper::gpu::SpirvShaderStage::Vertex},
-            {"PS", &d.fs, d.prt.get(), 1, prosper::gpu::SpirvShaderStage::Fragment},
+            {"VS", vs.words, d.vrt.get(), 0, prosper::gpu::SpirvShaderStage::Vertex},
+            {"PS", fs.words, d.prt.get(), 1, prosper::gpu::SpirvShaderStage::Fragment},
         };
         for (const auto& s : stages) {
             auto report = prosper::gpu::validate_spirv_descriptor_interface(
@@ -1623,26 +1629,19 @@ int main(int argc, char** argv) {
                      static_cast<unsigned long long>(found->host_data_size), dump_path.c_str());
     }
     if (!shader_spec.empty()) {
-        size_t colon = shader_spec.find(':');
-        char* draw_end = nullptr;
-        const unsigned long long draw_index = std::strtoull(shader_spec.c_str(), &draw_end, 0);
-        const size_t di = colon != std::string::npos && shader_spec[0] != '-' &&
-                                  draw_end == shader_spec.c_str() + colon
-            ? prosper::tools::replay_item_index_for_draw(replay, draw_index) : SIZE_MAX;
-        std::string stage =
-            colon == std::string::npos ? std::string{} : shader_spec.substr(colon + 1);
-        if (colon == std::string::npos || di == SIZE_MAX ||
-            (stage != "vs" && stage != "fs")) {
-            std::fprintf(stderr, "gpu_replay: invalid shader selector %s\n", shader_spec.c_str()); return 2;
+        bool shared = false;
+        const auto* words = prosper::tools::select_recompiled_shader(
+            replay, shader_spec, shared, error);
+        if (!words) {
+            std::fprintf(stderr, "gpu_replay: %s\n", error.c_str()); return 2;
         }
-        const auto& words = stage == "vs" ? replay.items[di].vs : replay.items[di].fs;
-        FILE* f = std::fopen(shader_path.c_str(), "wb"); size_t bytes = words.size() * sizeof(uint32_t);
-        if (!f || std::fwrite(words.data(), 1, bytes, f) != bytes) {
+        FILE* f = std::fopen(shader_path.c_str(), "wb"); size_t bytes = words->size() * sizeof(uint32_t);
+        if (!f || std::fwrite(words->data(), 1, bytes, f) != bytes) {
             if (f) std::fclose(f); std::fprintf(stderr, "gpu_replay: cannot write %s\n", shader_path.c_str()); return 2;
         }
         std::fclose(f);
-        std::fprintf(stderr, "[gpureplay] dumped %s (%zu bytes) to %s\n", shader_spec.c_str(), bytes,
-                     shader_path.c_str());
+        std::fprintf(stderr, "[gpureplay] dumped %s (%zu bytes, %s) to %s\n", shader_spec.c_str(),
+                     bytes, shared ? "shared" : "owned", shader_path.c_str());
     }
     if (!realized_shader_spec.empty()) {
         const auto* raw = prosper::tools::select_realized_raw_shader(

--- a/prosper/tools/gpu_replay/realized_shader_dump.hpp
+++ b/prosper/tools/gpu_replay/realized_shader_dump.hpp
@@ -14,6 +14,17 @@ struct RealizedShaderSelector {
     bool vertex = false;
 };
 
+struct RecompiledShaderView {
+    const std::vector<uint32_t>* words = nullptr;
+    bool shared = false;
+};
+
+inline RecompiledShaderView recompiled_shader_view(const gpu::DrawItem& draw,
+                                                    bool vertex) {
+    return vertex ? RecompiledShaderView{&draw.vs_words(), static_cast<bool>(draw.vs_shared)}
+                  : RecompiledShaderView{&draw.fs_words(), static_cast<bool>(draw.fs_shared)};
+}
+
 inline size_t replay_item_index_for_draw(const gpu::GpuReplayFrame& replay,
                                          uint64_t draw_index) {
     for (size_t item_index = 0; item_index < replay.items.size(); ++item_index)
@@ -49,6 +60,25 @@ inline bool parse_realized_shader_selector(const std::string& spec,
     selector.draw_index = static_cast<uint64_t>(draw);
     selector.vertex = stage == "vs";
     return true;
+}
+
+inline const std::vector<uint32_t>* select_recompiled_shader(
+    const gpu::GpuReplayFrame& replay, const std::string& spec, bool& shared,
+    std::string& error) {
+    RealizedShaderSelector selector;
+    if (!parse_realized_shader_selector(spec, selector)) {
+        error = "invalid shader selector " + spec;
+        return nullptr;
+    }
+    const size_t item_index = replay_item_index_for_draw(replay, selector.draw_index);
+    if (item_index == SIZE_MAX) {
+        error = "realized draw " + std::to_string(selector.draw_index) + " not found";
+        return nullptr;
+    }
+    const auto selection = recompiled_shader_view(replay.items[item_index], selector.vertex);
+    shared = selection.shared;
+    error.clear();
+    return selection.words;
 }
 
 inline const gpu::GpuCaptureRawShaderVersion* select_realized_raw_shader(


### PR DESCRIPTION
Fixes #1442.

## Failure scenario

`DrawItem` can retain recompiled VS/FS SPIR-V through shared ownership. The renderer consumes those values through `vs_words()` / `fs_words()`, but gpu_replay inspection, descriptor validation, and `--dump-shader` read the owned vectors directly. A shared-backed replay item would therefore report/hash/validate/dump an empty or stale vector even though rendering used different words.

## Change

- Route all three replay read paths through one accessor-backed recompiled-shader view.
- Keep semantic draw selection exact for `--dump-shader`.
- Report `owned` versus `shared` alongside inspect hashes and dump diagnostics.
- Add focused coverage with deliberately different owned and shared words, plus the ordinary owned path.
- Document the inspect storage tag.

This does not alter capture serialization, shader recompilation, substitution, or rendering. Existing replay capsules materialize owned words and retain their behavior; the change hardens future/shared-backed replay paths and makes ownership visible.

## Risk

Low and tooling-only. The main compatibility risk is accidental selector or diagnostic-format drift; the focused selector test, real capsule inspect/dump/validate checks, and complete suite cover those paths. No renderer output path changed, so no snapshot baseline applies.

## Exact-head verification

Head: `bd1e4a21e0c7b9463303602b64ab440fa40ddebd`

```text
distrobox enter ps5ys -- bash -lc 'cmake -S prosper -B prosper/build-linux -DGAME_DUMP=/var/home/mattias800/repos/ps5ys/PPSA24651-app0 -DCMAKE_BUILD_TYPE=RelWithDebInfo'
distrobox enter ps5ys -- bash -lc 'cmake --build prosper/build-linux -j8'
distrobox enter ps5ys -- bash -lc 'ctest --test-dir prosper/build-linux --output-on-failure'
# 151/151 passed

distrobox enter ps5ys -- bash -lc './prosper/build-linux/gpu_replay --inspect-only /tmp/cobra-pass-22230.prgcap'
# draw 18: vs=4794/e01f7101d5a5659e/owned fs=5903/872f8e0fd29150db/owned

distrobox enter ps5ys -- bash -lc './prosper/build-linux/gpu_replay --dump-shader 18:vs /tmp/ps5ys-1442.l0Eo1m/draw18-vs.spv /tmp/cobra-pass-22230.prgcap'
# dumped 19,176 bytes as owned; replay completed on RADV

distrobox enter ps5ys -- bash -lc './prosper/build-linux/gpu_replay --validate /tmp/cobra-pass-22230.prgcap'
# VS and PS descriptor interfaces accepted

git diff --check origin/master...HEAD
# clean
```
