### PR TITLE
perf(render): accelerate live image compute

### DIFF
--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -11,8 +11,9 @@
 // a real guest frame takes. P0b wires the actual guest boot in front of this (the same present
 // path, no changes here).
 //
-// Two Vulkan contexts by design (docs/FRONTEND_APP.md): the core keeps its headless render device;
-// THIS is a separate presentation device, and frames cross as shared immutable CPU pixels.
+// Real game boots normally adopt the renderer's Vulkan device and pass its front image directly to
+// the swapchain. Test-pattern boots, an explicit override, or failed adoption retain the original
+// two-device path, where frames cross as shared immutable CPU pixels.
 #include "gpu/videoout_present.hpp"   // present_acquire_rendered_frame / present_write_frame
 #include "gpu/gpu_execute.hpp"         // shared_vulkan_context / gpu-present activation (#1270)
 #include "gpu/gpu_capture.hpp"         // request_interactive_gpu_capture (F9 frame grab)
@@ -771,10 +772,11 @@ int main(int argc, char** argv) {
     if (!win) { fprintf(stderr, "[app] SDL_CreateWindow: %s\n", SDL_GetError()); return 1; }
 
     Vk vk;
-    // Present unification (#1270, opt-in): prefer presenting on the renderer's shared device so we can
-    // GPU-blit its front-buffer image. Only for a real boot (the renderer produces front buffers); the
-    // test pattern and any adoption failure fall back to a private device + CPU pixels (unchanged path).
-    const bool wantGpuPresent = getenv("PROSPER_APP_GPU_PRESENT") != nullptr && !testPattern && !dump.empty();
+    // Present unification (#1270): prefer the renderer's shared device for real game boots so we can
+    // GPU-blit its front-buffer image. The test pattern, PROSPER_APP_GPU_PRESENT=0, and any adoption
+    // failure fall back to a private device + CPU pixels.
+    const bool wantGpuPresent = prosper::frontend::request_gpu_present(
+        getenv("PROSPER_APP_GPU_PRESENT"), testPattern, !dump.empty());
     if (!wantGpuPresent || !try_adopt_shared_present(vk, win)) {
         if (!create_instance(vk, win) || !pick_device(vk)) return 1;
     }

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -255,7 +255,9 @@ bool ensure_stage(Vk& vk, uint32_t w, uint32_t h) {
     vk.stageW = w; vk.stageH = h; vk.stageCap = (VkDeviceSize)w * h * 4;
 
     VkBufferCreateInfo bi{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
-    bi.size = vk.stageCap; bi.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT; bi.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+    bi.size = vk.stageCap;
+    bi.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+    bi.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     VKCHECK(vkCreateBuffer(vk.device, &bi, nullptr, &vk.stageBuf), "stage buffer");
     VkMemoryRequirements mr; vkGetBufferMemoryRequirements(vk.device, vk.stageBuf, &mr);
     VkMemoryAllocateInfo ai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO};
@@ -287,6 +289,41 @@ void barrier(VkCommandBuffer c, VkImage img, VkImageLayout from, VkImageLayout t
     b.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
     b.srcQueueFamilyIndex = b.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
     vkCmdPipelineBarrier(c, srcS, dstS, 0, 0, nullptr, 0, nullptr, 1, &b);
+}
+
+// A failed queue submit leaves inFlight unsignaled and the acquired-image semaphore unusable for a
+// second acquire. Replace the whole sync trio before asking the main loop to rebuild the swapchain;
+// otherwise the next frame would wait forever on a fence that no submit can signal. The abandoned
+// handles are deliberately retained until process teardown: the acquire signal operation may still
+// be pending, so destroying them here would itself violate Vulkan lifetime rules. This path is rare
+// and bounded by a fatal device/driver error.
+bool replace_present_sync(Vk& vk) {
+    VkSemaphore acquire = VK_NULL_HANDLE;
+    VkSemaphore present = VK_NULL_HANDLE;
+    VkFence fence = VK_NULL_HANDLE;
+    VkSemaphoreCreateInfo semi{VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO};
+    VkFenceCreateInfo fci{VK_STRUCTURE_TYPE_FENCE_CREATE_INFO};
+    fci.flags = VK_FENCE_CREATE_SIGNALED_BIT;
+    if (vkCreateSemaphore(vk.device, &semi, nullptr, &acquire) != VK_SUCCESS ||
+        vkCreateSemaphore(vk.device, &semi, nullptr, &present) != VK_SUCCESS ||
+        vkCreateFence(vk.device, &fci, nullptr, &fence) != VK_SUCCESS) {
+        if (fence) vkDestroyFence(vk.device, fence, nullptr);
+        if (present) vkDestroySemaphore(vk.device, present, nullptr);
+        if (acquire) vkDestroySemaphore(vk.device, acquire, nullptr);
+        return false;
+    }
+    vk.acquireSem = acquire;
+    vk.presentSem = present;
+    vk.inFlight = fence;
+    return true;
+}
+
+prosper::frontend::PresentAttempt recover_submit_failure(Vk& vk, VkResult result) {
+    fprintf(stderr, "[app] vkQueueSubmit failed (%d); replacing present synchronization\n",
+            static_cast<int>(result));
+    if (replace_present_sync(vk)) return prosper::frontend::PresentAttempt::out_of_date;
+    fprintf(stderr, "[app] could not replace present synchronization; stopping\n");
+    return prosper::frontend::PresentAttempt::failed;
 }
 
 // Interactive frame grab (F9): write a small BGR bottom-up BMP of a presented RGBA frame next to the
@@ -376,15 +413,17 @@ prosper::frontend::PresentAttempt present_frame(Vk& vk, const uint8_t* rgba, uin
     VkPresentInfoKHR pi{VK_STRUCTURE_TYPE_PRESENT_INFO_KHR};
     pi.waitSemaphoreCount = 1; pi.pWaitSemaphores = &vk.presentSem;
     pi.swapchainCount = 1; pi.pSwapchains = &vk.swapchain; pi.pImageIndices = &imgIndex;
-    VkResult pr;
+    VkResult submitResult;
+    VkResult pr = VK_SUCCESS;
     {
         // #1270: when this CPU present runs on the renderer's shared queue (the GPU-present miss fallback),
         // serialize the submit + present CALLS against the renderer's submits. No-op on a private device.
         std::unique_lock<std::mutex> lk(gpu::shared_present_submit_mutex(), std::defer_lock);
         if (gpu::shared_present_active()) lk.lock();
-        vkQueueSubmit(vk.queue, 1, &su, vk.inFlight);
-        pr = vkQueuePresentKHR(vk.queue, &pi);
+        submitResult = vkQueueSubmit(vk.queue, 1, &su, vk.inFlight);
+        if (submitResult == VK_SUCCESS) pr = vkQueuePresentKHR(vk.queue, &pi);
     }
+    if (submitResult != VK_SUCCESS) return recover_submit_failure(vk, submitResult);
     return prosper::frontend::classify_present(pr);
 }
 
@@ -434,9 +473,16 @@ bool try_adopt_shared_present(Vk& vk, SDL_Window* win) {
 // GPU read is complete once inFlight signals below, so it is released then. Updates prevSlot to the slot
 // now in flight and returns the acquire/present outcome.
 prosper::frontend::PresentAttempt present_frame_gpu(Vk& vk, const prosper::frontend::GpuScanoutFrame& gf,
-                                                    int& prevSlot) {
+                                                    int& prevSlot, bool requestReadback,
+                                                    bool& readbackReady) {
+    readbackReady = false;
     vkWaitForFences(vk.device, 1, &vk.inFlight, VK_TRUE, UINT64_MAX);   // previous present's read complete
     if (prevSlot >= 0) { prosper::frontend::present_blit_release(prevSlot); prevSlot = -1; }
+    if (requestReadback && !ensure_stage(vk, gf.width, gf.height)) {
+        prosper::frontend::present_blit_release(gf.slot);
+        fprintf(stderr, "[grab] could not allocate the gpu-present readback buffer\n");
+        return prosper::frontend::PresentAttempt::failed;
+    }
 
     uint32_t imgIndex = 0;
     constexpr uint64_t kAcquireTimeoutNs = 100ull * 1000 * 1000;
@@ -465,6 +511,24 @@ prosper::frontend::PresentAttempt present_frame_gpu(Vk& vk, const prosper::front
     blit.dstOffsets[1] = {(int32_t)vk.scExtent.width, (int32_t)vk.scExtent.height, 1};
     vkCmdBlitImage(vk.cmd, gf.image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
                    vk.scImages[imgIndex], VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &blit, VK_FILTER_LINEAR);
+    if (requestReadback) {
+        VkBufferImageCopy copy{};
+        copy.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+        copy.imageExtent = {gf.width, gf.height, 1};
+        vkCmdCopyImageToBuffer(vk.cmd, gf.image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                               vk.stageBuf, 1, &copy);
+        VkBufferMemoryBarrier hostBarrier{VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER};
+        hostBarrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+        hostBarrier.dstAccessMask = VK_ACCESS_HOST_READ_BIT;
+        hostBarrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        hostBarrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        hostBarrier.buffer = vk.stageBuf;
+        hostBarrier.offset = 0;
+        hostBarrier.size = vk.stageCap;
+        vkCmdPipelineBarrier(vk.cmd, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                             VK_PIPELINE_STAGE_HOST_BIT, 0, 0, nullptr, 1, &hostBarrier,
+                             0, nullptr);
+    }
     barrier(vk.cmd, vk.scImages[imgIndex], VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
             VK_IMAGE_LAYOUT_PRESENT_SRC_KHR, VK_ACCESS_TRANSFER_WRITE_BIT, 0,
             VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT);
@@ -478,15 +542,31 @@ prosper::frontend::PresentAttempt present_frame_gpu(Vk& vk, const prosper::front
     VkPresentInfoKHR pi{VK_STRUCTURE_TYPE_PRESENT_INFO_KHR};
     pi.waitSemaphoreCount = 1; pi.pWaitSemaphores = &vk.presentSem;
     pi.swapchainCount = 1; pi.pSwapchains = &vk.swapchain; pi.pImageIndices = &imgIndex;
-    VkResult pr;
+    VkResult submitResult;
+    VkResult pr = VK_SUCCESS;
     {
         // Serialize the present submit + present CALL against the renderer's submits on a shared queue.
         std::unique_lock<std::mutex> lk(gpu::shared_present_submit_mutex(), std::defer_lock);
         if (vk.queue_shared) lk.lock();
-        vkQueueSubmit(vk.queue, 1, &su, vk.inFlight);
-        pr = vkQueuePresentKHR(vk.queue, &pi);
+        submitResult = vkQueueSubmit(vk.queue, 1, &su, vk.inFlight);
+        if (submitResult == VK_SUCCESS) pr = vkQueuePresentKHR(vk.queue, &pi);
+    }
+    if (submitResult != VK_SUCCESS) {
+        prosper::frontend::present_blit_release(gf.slot);
+        return recover_submit_failure(vk, submitResult);
     }
     prevSlot = gf.slot;
+    if (requestReadback) {
+        const VkResult waitResult = vkWaitForFences(vk.device, 1, &vk.inFlight, VK_TRUE, UINT64_MAX);
+        if (waitResult != VK_SUCCESS) {
+            fprintf(stderr, "[grab] gpu-present readback wait failed (%d)\n",
+                    static_cast<int>(waitResult));
+            return prosper::frontend::PresentAttempt::failed;
+        }
+        prosper::frontend::present_blit_release(prevSlot);
+        prevSlot = -1;
+        readbackReady = true;
+    }
     return prosper::frontend::classify_present(pr);
 }
 
@@ -790,11 +870,10 @@ int main(int argc, char** argv) {
     VkCommandBufferAllocateInfo cai{VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO};
     cai.commandPool = vk.cmdPool; cai.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY; cai.commandBufferCount = 1;
     vkAllocateCommandBuffers(vk.device, &cai, &vk.cmd);
-    VkSemaphoreCreateInfo semi{VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO};
-    vkCreateSemaphore(vk.device, &semi, nullptr, &vk.acquireSem);
-    vkCreateSemaphore(vk.device, &semi, nullptr, &vk.presentSem);
-    VkFenceCreateInfo fci{VK_STRUCTURE_TYPE_FENCE_CREATE_INFO}; fci.flags = VK_FENCE_CREATE_SIGNALED_BIT;
-    vkCreateFence(vk.device, &fci, nullptr, &vk.inFlight);
+    if (!replace_present_sync(vk)) {
+        fprintf(stderr, "[app] could not create present synchronization\n");
+        return 1;
+    }
 
     fprintf(stderr, "[app] window up (%s). Close the window or press Esc to quit.\n",
             testPattern ? "test-pattern" : "waiting for guest frames");
@@ -1019,20 +1098,20 @@ int main(int argc, char** argv) {
             // GPU present (#1270): blit the renderer's front-buffer image straight to the swapchain.
             prosper::frontend::GpuScanoutFrame gf;
             if (prosper::frontend::present_blit_acquire(gf)) {
-                PresentAttempt attempt = present_frame_gpu(vk, gf, gpuPrevSlot);
+                bool grabReady = false;
+                PresentAttempt attempt = present_frame_gpu(
+                    vk, gf, gpuPrevSlot, !pendingGrabScreenshot.empty(), grabReady);
+                if (grabReady)
+                    flushGrabScreenshot(static_cast<const uint8_t*>(vk.stageMapped),
+                                        gf.width, gf.height);
                 if (attempt == PresentAttempt::out_of_date) {
                     swapchainDirty = true;
                 } else if (attempt == PresentAttempt::skipped) {
                     std::this_thread::sleep_for(std::chrono::milliseconds(4));
+                } else if (attempt == PresentAttempt::failed) {
+                    running = false;
                 } else {
                     shown++; lastFrameProgress = std::chrono::steady_clock::now();
-                    // GPU-present mode has no CPU pixels here for the F9 screenshot; drop the pending
-                    // request rather than letting it leak into a later CPU-present-miss frame (the
-                    // .prgbundle oracle is the authoritative image anyway).
-                    if (!pendingGrabScreenshot.empty()) {
-                        std::fprintf(stderr, "[grab] screenshot skipped (gpu-present); use the .prgbundle\n");
-                        pendingGrabScreenshot.clear();
-                    }
                     static auto t0 = std::chrono::steady_clock::now(); static uint64_t mark = 0;
                     if (shown - mark >= 60) {
                         auto now = std::chrono::steady_clock::now();
@@ -1055,6 +1134,7 @@ int main(int argc, char** argv) {
                     if (gpuPrevSlot >= 0) { prosper::frontend::present_blit_release(gpuPrevSlot); gpuPrevSlot = -1; }
                     if (a == PresentAttempt::out_of_date) swapchainDirty = true;
                     else if (a == PresentAttempt::skipped) std::this_thread::sleep_for(std::chrono::milliseconds(4));
+                    else if (a == PresentAttempt::failed) running = false;
                     else { lastFrameSeq = cf.frame_seq; shown++; lastFrameProgress = std::chrono::steady_clock::now();
                            flushGrabScreenshot(cf.rgba->data(), cf.width, cf.height); }
                 } else {
@@ -1080,6 +1160,8 @@ int main(int argc, char** argv) {
                     // Leave lastFrameSeq unchanged so we present the freshest frame once the window is
                     // visible again, and do not mark the swapchain dirty. The guest keeps running.
                     std::this_thread::sleep_for(std::chrono::milliseconds(4));
+                } else if (attempt == PresentAttempt::failed) {
+                    running = false;
                 } else {
                     lastFrameSeq = frame.frame_seq; shown++;
                     lastFrameProgress = std::chrono::steady_clock::now();

--- a/prosper/frontends/prosper-app/present_policy.hpp
+++ b/prosper/frontends/prosper-app/present_policy.hpp
@@ -2,18 +2,23 @@
 
 #include <vulkan/vulkan_core.h>
 
-// Present policy for prosper-app (#1182). The app owns its OWN Vulkan device/queue, separate from the
-// core live renderer's headless device (main.cpp: "two Vulkan contexts by design"). The guest↔app frame
-// handoff is a lock-free CPU shared_ptr copy (present_acquire_rendered_frame), so the guest is NOT
-// back-pressured by the app present at the Vulkan level. The one place the app can hurt the guest — and
-// itself — is a BLOCKING swapchain acquire: `vkAcquireNextImageKHR(..., UINT64_MAX, ...)` blocks the app
-// main thread indefinitely when the compositor releases no image (window occluded/minimized). That
-// freezes visible output, stops SDL event/close handling, and (on the shared physical GPU) can stall the
-// guest. The fix is to bound the acquire and treat a timeout as a benign SKIP, not an error: the main
-// loop stays responsive and the guest keeps running. This header holds the pure result-classification so
-// it is unit-testable without a device (Vulkan headers only, no loader).
+// Present policy for prosper-app (#1182). Real game boots normally share the renderer's Vulkan device;
+// the private-device fallback hands frames across as a lock-free CPU shared_ptr copy. Neither path
+// should let a BLOCKING swapchain acquire (`vkAcquireNextImageKHR(..., UINT64_MAX, ...)`) freeze event
+// handling and stall the guest when the compositor releases no image (for example, while occluded or
+// minimized). Bound the acquire and treat a timeout as a benign SKIP, not an error. This header holds
+// the pure result classification so it is unit-testable without a device (Vulkan headers only).
 
 namespace prosper::frontend {
+
+// Real game boots prefer the renderer's shared-device scanout path: it avoids a full-frame GPU->CPU
+// readback followed by a CPU->GPU upload. Adoption still validates all Vulkan prerequisites and falls
+// back to the private-device path on failure. `PROSPER_APP_GPU_PRESENT=0` is the explicit recovery/A-B
+// switch; test-pattern and no-game runs have no renderer-owned scanout to adopt.
+constexpr bool request_gpu_present(const char* setting, bool test_pattern, bool has_game) {
+    const bool explicitly_disabled = setting && setting[0] == '0' && setting[1] == '\0';
+    return has_game && !test_pattern && !explicitly_disabled;
+}
 
 // Outcome of one present_frame attempt.
 enum class PresentAttempt {

--- a/prosper/frontends/prosper-app/present_policy.hpp
+++ b/prosper/frontends/prosper-app/present_policy.hpp
@@ -25,6 +25,7 @@ enum class PresentAttempt {
     presented,    // the rendered frame reached the swapchain
     skipped,      // no swapchain image available within the bounded acquire (occluded/minimized) — retry
     out_of_date,  // swapchain is stale/lost/unusable — recreate it before the next present
+    failed,       // device/synchronization recovery failed — stop instead of waiting forever
 };
 
 // What present_frame should do after a BOUNDED vkAcquireNextImageKHR.

--- a/prosper/frontends/prosper-app/test_present_policy.cpp
+++ b/prosper/frontends/prosper-app/test_present_policy.cpp
@@ -22,6 +22,14 @@ static int failures = 0;
     } while (0)
 
 int main() {
+    // GPU presentation is the normal game policy because adoption has a safe CPU fallback. Keep the
+    // explicit zero override for driver diagnosis and never request it without a renderer-owned game.
+    CHECK(request_gpu_present(nullptr, false, true));
+    CHECK(request_gpu_present("1", false, true));
+    CHECK(!request_gpu_present("0", false, true));
+    CHECK(!request_gpu_present(nullptr, true, true));
+    CHECK(!request_gpu_present(nullptr, false, false));
+
     // Acquire: a usable image (SUCCESS or SUBOPTIMAL) → proceed to blit+present.
     CHECK(classify_acquire(VK_SUCCESS) == AcquireAction::proceed);
     CHECK(classify_acquire(VK_SUBOPTIMAL_KHR) == AcquireAction::proceed);

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -13,6 +13,7 @@
 #include <vulkan/vulkan.h>
 
 #include <algorithm>
+#include <array>
 #include <chrono>
 #include <cmath>
 #include <cstdlib>
@@ -20,11 +21,19 @@
 #include <cstring>
 #include <functional>
 #include <map>
+#include <memory>
 #include <mutex>
 #include <string>
+#include <thread>
 #include <tuple>
 #include <unordered_map>
 #include <vector>
+
+#if (defined(__x86_64__) || defined(__i386__)) && \
+    (defined(__GNUC__) || defined(__clang__))
+#include <immintrin.h>
+#define PROSPER_HAVE_TARGET_F16C 1
+#endif
 
 namespace prosper::frontend {
 
@@ -38,10 +47,274 @@ uint8_t storage_pack_unorm8(uint32_t float_bits) {
     return static_cast<uint8_t>(whole + (scaled - static_cast<float>(whole) >= 0.5f));
 }
 
+uint32_t storage_unpack_float16_bits(uint16_t half_bits) {
+    // Full binary16 lookup: the source domain is only 64 Ki entries, while Astro Bot expands more
+    // than 33 million FP16 channels for one 4K storage image. Keeping the already-converted float
+    // bits in a 256 KiB table removes the branchy scalar decoder from that inner loop without
+    // changing a single NaN payload, signed zero, subnormal, or infinity bit.
+    static const std::array<uint32_t, 65536> table = [] {
+        std::array<uint32_t, 65536> result{};
+        for (uint32_t bits = 0; bits < result.size(); ++bits) {
+            const float value = prosper::gpu::half_to_float(static_cast<uint16_t>(bits));
+            std::memcpy(&result[bits], &value, sizeof(value));
+        }
+        return result;
+    }();
+    return table[half_bits];
+}
+
+namespace {
+
+const std::array<uint8_t, 65536>& sampled_float16_unorm8_table() {
+    static const std::array<uint8_t, 65536> table = [] {
+        std::array<uint8_t, 65536> result{};
+        for (uint32_t bits = 0; bits < result.size(); ++bits) {
+            float value = prosper::gpu::half_to_float(static_cast<uint16_t>(bits));
+            if (std::isnan(value)) value = 0.0f;
+            value = value < 0.0f ? 0.0f : (value > 1.0f ? 1.0f : value);
+            result[bits] = static_cast<uint8_t>(std::lround(value * 255.0f));
+        }
+        return result;
+    }();
+    return table;
+}
+
+} // namespace
+
+uint8_t sampled_float16_to_unorm8(uint16_t half_bits) {
+    // The guest-backed sampled fallback maps NaN/negative to zero and positive infinity to one,
+    // matching its historical scalar clamp exactly. Cache every possible input so it avoids
+    // half_to_float + lround for every channel. Direct-bound renderer targets bypass this entirely.
+    return sampled_float16_unorm8_table()[half_bits];
+}
+
+bool direct_sampled_rtt_compatible(prosper::gpu::DataFormat format, uint32_t components,
+                                   prosper::gpu::LiveTargetPixelFormat target_format) {
+    using prosper::gpu::DataFormat;
+    using prosper::gpu::LiveTargetPixelFormat;
+    return components == 4 &&
+           ((format == DataFormat::Unorm8 &&
+             target_format == LiveTargetPixelFormat::Rgba8Unorm) ||
+            (format == DataFormat::Float16 &&
+             target_format == LiveTargetPixelFormat::Rgba16Float));
+}
+
 namespace {
 
 constexpr VkDeviceSize kMaxComputeImageBytes = 256ull << 20;
 constexpr size_t kMaxCachedComputePipelines = 4096;
+
+// Large storage-image format conversions are independent per texel. Astro Bot's 4K FP16 target is
+// 8.3 million texels, so leaving its lookup/pack walk on one core made a ~5 ms GPU dispatch wait on
+// hundreds of milliseconds of host work. Keep small surfaces scalar and cap large conversions at
+// sixteen workers because both the detiler and these loops eventually become memory-bandwidth-bound.
+// Astro Bot's 4K path is still measurably faster at 16 on a 16-core Strix Halo; 32 regresses.
+template <class Body>
+void parallel_compute_texels(size_t count, size_t work_bytes, Body&& body) {
+    if (!count) return;
+    static const unsigned configured = [] {
+        const char* value = std::getenv("PROSPER_COMPUTE_CONVERSION_THREADS");
+        if (!value || !*value) return 0u;
+        const unsigned long parsed = std::strtoul(value, nullptr, 10);
+        return static_cast<unsigned>(std::min(parsed, 32ul));
+    }();
+    const unsigned hardware = std::thread::hardware_concurrency();
+    const unsigned wanted = configured ? configured : std::min(hardware ? hardware : 4u, 16u);
+    const unsigned by_work = static_cast<unsigned>(std::min<size_t>(
+        count, std::max<size_t>(1, work_bytes / (512u * 1024u))));
+    const unsigned threads = std::max(1u, std::min(wanted ? wanted : 1u, by_work));
+    if (threads <= 1) {
+        body(size_t{0}, count);
+        return;
+    }
+    const size_t chunk = (count + threads - 1) / threads;
+    std::vector<std::thread> workers;
+    workers.reserve(threads - 1);
+    for (unsigned worker = 1; worker < threads; ++worker) {
+        const size_t begin = static_cast<size_t>(worker) * chunk;
+        const size_t end = std::min(count, begin + chunk);
+        if (begin >= end) break;
+        workers.emplace_back([&body, begin, end] { body(begin, end); });
+    }
+    body(size_t{0}, std::min(count, chunk));
+    for (auto& worker : workers) worker.join();
+}
+
+#if defined(PROSPER_HAVE_TARGET_F16C)
+__attribute__((target("avx2")))
+__m128i storage_pack_unorm8x8_avx2(__m256 values) {
+    const __m256 zero = _mm256_setzero_ps();
+    const __m256 one = _mm256_set1_ps(1.0f);
+    const __m256 scale = _mm256_set1_ps(255.0f);
+    const __m256 half = _mm256_set1_ps(0.5f);
+    // Reproduce storage_pack_unorm8 exactly: unordered/negative/zero -> 0, >=1 -> 255,
+    // otherwise multiply in float32 and round a .5 tie upward. Clamp before CVTTPS2DQ so NaN
+    // and infinities never raise an invalid-conversion exception.
+    const __m256 positive = _mm256_cmp_ps(values, zero, _CMP_GT_OQ);
+    const __m256 upper = _mm256_cmp_ps(values, one, _CMP_GE_OQ);
+    __m256 bounded = _mm256_blendv_ps(zero, values, positive);
+    bounded = _mm256_blendv_ps(bounded, one, upper);
+    const __m256 scaled = _mm256_mul_ps(bounded, scale);
+    const __m256i whole = _mm256_cvttps_epi32(scaled);
+    const __m256 fraction = _mm256_sub_ps(scaled, _mm256_cvtepi32_ps(whole));
+    const __m256i increment = _mm256_castps_si256(
+        _mm256_cmp_ps(fraction, half, _CMP_GE_OQ));
+    const __m256i rounded = _mm256_sub_epi32(whole, increment); // true mask is -1
+    const __m128i words = _mm_packus_epi32(
+        _mm256_castsi256_si128(rounded), _mm256_extracti128_si256(rounded, 1));
+    return _mm_packus_epi16(words, _mm_setzero_si128());
+}
+
+__attribute__((target("avx2")))
+void storage_pack_unorm8_avx2(const uint32_t* channels, uint32_t components,
+                              size_t begin, size_t end, uint8_t* packed) {
+    size_t texel = begin;
+    size_t step = 0;
+    if (components == 2) {
+        step = 4;
+    } else if (components == 4) {
+        step = 2;
+    }
+    for (; step && texel + step <= end; texel += step) {
+        __m256i bits;
+        if (components == 4) {
+            bits = _mm256_loadu_si256(
+                reinterpret_cast<const __m256i*>(channels + texel * 4));
+        } else {
+            const uint32_t* source = channels + texel * 4;
+            const __m128i texels01 = _mm_unpacklo_epi64(
+                _mm_loadl_epi64(reinterpret_cast<const __m128i*>(source)),
+                _mm_loadl_epi64(reinterpret_cast<const __m128i*>(source + 4)));
+            const __m128i texels23 = _mm_unpacklo_epi64(
+                _mm_loadl_epi64(reinterpret_cast<const __m128i*>(source + 8)),
+                _mm_loadl_epi64(reinterpret_cast<const __m128i*>(source + 12)));
+            bits = _mm256_inserti128_si256(_mm256_castsi128_si256(texels01), texels23, 1);
+        }
+        const __m256 values = _mm256_castsi256_ps(bits);
+        const __m128i bytes = storage_pack_unorm8x8_avx2(values);
+        _mm_storel_epi64(
+            reinterpret_cast<__m128i*>(packed + texel * components), bytes);
+    }
+    for (; texel < end; ++texel)
+        for (uint32_t channel = 0; channel < components; ++channel)
+            packed[texel * components + channel] =
+                storage_pack_unorm8(channels[texel * 4 + channel]);
+}
+
+__attribute__((target("avx2,f16c")))
+void sampled_float16x4_to_unorm8_f16c(const uint8_t* source, size_t begin, size_t end,
+                                      uint8_t* rgba,
+                                      const std::array<uint8_t, 65536>& fallback_table) {
+    size_t channel = begin * 4;
+    const size_t channel_end = end * 4;
+    const __m256 zero = _mm256_setzero_ps();
+    const __m256 one = _mm256_set1_ps(1.0f);
+    const __m256 scale = _mm256_set1_ps(255.0f);
+    const __m256 rounding = _mm256_set1_ps(0.5f);
+    for (; channel + 8 <= channel_end; channel += 8) {
+        const __m128i half = _mm_loadu_si128(
+            reinterpret_cast<const __m128i*>(source + channel * sizeof(uint16_t)));
+        __m256 value = _mm256_cvtph_ps(half);
+        // Match the scalar contract exactly: NaN/negative -> 0, +infinity/>1 -> 1, then
+        // round non-negative value*255 halfway away from zero (floor(x + 0.5)).
+        value = _mm256_and_ps(value, _mm256_cmp_ps(value, value, _CMP_ORD_Q));
+        value = _mm256_min_ps(_mm256_max_ps(value, zero), one);
+        const __m256i integers = _mm256_cvttps_epi32(
+            _mm256_add_ps(_mm256_mul_ps(value, scale), rounding));
+        const __m128i words = _mm_packus_epi32(
+            _mm256_castsi256_si128(integers), _mm256_extracti128_si256(integers, 1));
+        const __m128i bytes = _mm_packus_epi16(words, _mm_setzero_si128());
+        _mm_storel_epi64(reinterpret_cast<__m128i*>(rgba + channel), bytes);
+    }
+    for (; channel < channel_end; ++channel) {
+        uint16_t half = 0;
+        std::memcpy(&half, source + channel * sizeof(half), sizeof(half));
+        rgba[channel] = fallback_table[half];
+    }
+}
+
+__attribute__((target("avx2,f16c")))
+void storage_pack_float16x4_f16c(const uint32_t* channels, size_t begin, size_t end,
+                                 uint8_t* rgba16f) {
+    size_t texel = begin;
+    for (; texel + 2 <= end; texel += 2) {
+        const __m256 values = _mm256_castsi256_ps(_mm256_loadu_si256(
+            reinterpret_cast<const __m256i*>(channels + texel * 4)));
+        const __m128i half = _mm256_cvtps_ph(
+            values, _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+        _mm_storeu_si128(reinterpret_cast<__m128i*>(rgba16f + texel * 8), half);
+
+        // CVTPS2PH quiets signaling NaNs, while the established scalar contract preserves the top
+        // payload bits verbatim. That scalar also historically keeps an odd half exponent unchanged
+        // when mantissa rounding carries into bit 10 (rather than incrementing it). Preserve both
+        // observable behaviors by repairing only those rare lanes after the vector conversion.
+        for (unsigned lane = 0; lane < 8; ++lane) {
+            const uint32_t bits = channels[texel * 4 + lane];
+            const uint32_t exponent = (bits >> 23) & 0xffu;
+            const uint32_t mantissa = bits & 0x7fffffu;
+            bool scalar_lane = exponent == 0xffu && mantissa != 0;
+            const int32_t half_exponent = static_cast<int32_t>(exponent) - 127 + 15;
+            if (!scalar_lane && half_exponent > 0 && half_exponent < 31 &&
+                (half_exponent & 1) && (mantissa >> 13) == 0x3ffu) {
+                const uint32_t remainder = mantissa & 0x1fffu;
+                scalar_lane = remainder >= 0x1000u; // tie rounds up: 0x3ff is odd
+            }
+            if (!scalar_lane) continue;
+            float value;
+            std::memcpy(&value, &bits, sizeof(value));
+            const uint16_t scalar = prosper::gpu::float_to_half(value);
+            std::memcpy(rgba16f + texel * 8 + lane * sizeof(scalar), &scalar, sizeof(scalar));
+        }
+    }
+    for (; texel < end; ++texel) {
+        for (uint32_t channel = 0; channel < 4; ++channel) {
+            float value;
+            std::memcpy(&value, channels + texel * 4 + channel, sizeof(value));
+            const uint16_t half = prosper::gpu::float_to_half(value);
+            std::memcpy(rgba16f + texel * 8 + channel * sizeof(half), &half, sizeof(half));
+        }
+    }
+}
+
+__attribute__((target("avx2,f16c")))
+void storage_unpack_float16x4_f16c(const uint8_t* rgba16f, size_t begin, size_t end,
+                                   uint32_t* channels) {
+    size_t texel = begin;
+    const __m128i exponent_mask = _mm_set1_epi16(0x7c00);
+    const __m128i mantissa_mask = _mm_set1_epi16(0x03ff);
+    for (; texel + 2 <= end; texel += 2) {
+        const __m128i half = _mm_loadu_si128(
+            reinterpret_cast<const __m128i*>(rgba16f + texel * 8));
+        const __m256 values = _mm256_cvtph_ps(half);
+        _mm256_storeu_si256(reinterpret_cast<__m256i*>(channels + texel * 4),
+                            _mm256_castps_si256(values));
+
+        // CVTPH2PS quiets signaling NaNs; half_to_float intentionally preserves their payload bits.
+        // Detect the uncommon NaN lanes as packed 16-bit values and repair only those through the
+        // exhaustive table. Normal numbers, subnormals, infinities and quiet NaNs are already exact.
+        const __m128i exponent = _mm_and_si128(half, exponent_mask);
+        const __m128i mantissa = _mm_and_si128(half, mantissa_mask);
+        const __m128i exponent_all_ones = _mm_cmpeq_epi16(exponent, exponent_mask);
+        const __m128i mantissa_zero = _mm_cmpeq_epi16(mantissa, _mm_setzero_si128());
+        const __m128i nan_lanes = _mm_andnot_si128(mantissa_zero, exponent_all_ones);
+        if (_mm_movemask_epi8(nan_lanes)) {
+            for (unsigned lane = 0; lane < 8; ++lane) {
+                uint16_t bits = 0;
+                std::memcpy(&bits, rgba16f + texel * 8 + lane * sizeof(bits), sizeof(bits));
+                if ((bits & 0x7c00u) == 0x7c00u && (bits & 0x03ffu) != 0)
+                    channels[texel * 4 + lane] = storage_unpack_float16_bits(bits);
+            }
+        }
+    }
+    for (; texel < end; ++texel) {
+        for (uint32_t channel = 0; channel < 4; ++channel) {
+            uint16_t bits = 0;
+            std::memcpy(&bits, rgba16f + texel * 8 + channel * sizeof(bits), sizeof(bits));
+            channels[texel * 4 + channel] = storage_unpack_float16_bits(bits);
+        }
+    }
+}
+#endif
 
 struct ComputeMemoryKey {
     VkDeviceSize bytes = 0;
@@ -62,6 +335,7 @@ struct ComputeMemoryPool {
     std::mutex mutex;
     std::unordered_map<ComputeMemoryKey, std::vector<VkDeviceMemory>, ComputeMemoryKeyHash> available;
     std::unordered_map<VkDeviceMemory, ComputeMemoryKey> active;
+    std::unordered_map<VkDeviceMemory, void*> persistent_mappings;
     VkDeviceSize cached_bytes = 0;
     size_t cached_allocations = 0;
     uint64_t hits = 0;
@@ -92,7 +366,11 @@ bool compute_memory_pool_enabled() {
 VkDeviceSize compute_memory_pool_limit() {
     static const VkDeviceSize limit = []() -> VkDeviceSize {
         const char* value = std::getenv("PROSPER_COMPUTE_MEMORY_POOL_MB");
-        const uint64_t mib = value ? std::strtoull(value, nullptr, 10) : 256ull;
+        // Astro Bot's first 120 frames stabilize at about 614 MiB of differently-sized image and
+        // staging allocations. A 256 MiB cache discarded about 200 allocations and repeatedly paid
+        // AMD BO page initialization; 640 MiB holds that measured working set with zero discards,
+        // while remaining a bounded fraction of the renderer's persistent-target budget.
+        const uint64_t mib = value ? std::strtoull(value, nullptr, 10) : 640ull;
         if (mib > UINT64_MAX / (1024ull * 1024ull)) return VkDeviceSize{UINT64_MAX};
         return static_cast<VkDeviceSize>(mib) * 1024ull * 1024ull;
     }();
@@ -105,6 +383,10 @@ struct VulkanComputeContext {
     VkDevice device = VK_NULL_HANDLE;
     VkQueue queue = VK_NULL_HANDLE;
     VkPipelineCache pipeline_cache = VK_NULL_HANDLE;
+    VkDescriptorPool descriptor_pool = VK_NULL_HANDLE;
+    uint32_t descriptor_buffer_capacity = 0;
+    uint32_t descriptor_sampled_capacity = 0;
+    uint32_t descriptor_storage_capacity = 0;
     std::unordered_map<std::string, CachedComputePipeline> pipelines;
     uint32_t queue_family = UINT32_MAX;
     VkPhysicalDeviceMemoryProperties memory{};
@@ -120,6 +402,7 @@ struct VulkanComputeContext {
 
     ~VulkanComputeContext() {
         release_cached_memory();
+        if (descriptor_pool) vkDestroyDescriptorPool(device, descriptor_pool, nullptr);
         for (const auto& [key, cached] : pipelines) {
             (void)key;
             if (cached.pipeline) vkDestroyPipeline(device, cached.pipeline, nullptr);
@@ -135,20 +418,97 @@ struct VulkanComputeContext {
         if (instance) vkDestroyInstance(instance, nullptr);
     }
 
-    VkDeviceMemory allocate_memory(VkDeviceSize bytes, uint32_t memory_type) {
+    static bool descriptor_pool_reuse_enabled() {
+        static const bool enabled = std::getenv("PROSPER_NO_DESCRIPTOR_POOL_REUSE") == nullptr;
+        return enabled;
+    }
+
+    VkDescriptorPool prepare_descriptor_pool(uint32_t buffers, uint32_t sampled,
+                                             uint32_t storage) {
+        if (!descriptor_pool_reuse_enabled()) return VK_NULL_HANDLE;
+        if (descriptor_pool && buffers <= descriptor_buffer_capacity &&
+            sampled <= descriptor_sampled_capacity && storage <= descriptor_storage_capacity) {
+            if (vkResetDescriptorPool(device, descriptor_pool, 0) == VK_SUCCESS)
+                return descriptor_pool;
+            vkDestroyDescriptorPool(device, descriptor_pool, nullptr);
+            descriptor_pool = VK_NULL_HANDLE;
+        } else if (descriptor_pool) {
+            vkDestroyDescriptorPool(device, descriptor_pool, nullptr);
+            descriptor_pool = VK_NULL_HANDLE;
+        }
+        descriptor_buffer_capacity = std::max(buffers, descriptor_buffer_capacity);
+        descriptor_sampled_capacity = std::max(sampled, descriptor_sampled_capacity);
+        descriptor_storage_capacity = std::max(storage, descriptor_storage_capacity);
+        VkDescriptorPoolSize sizes[3];
+        uint32_t count = 0;
+        if (descriptor_buffer_capacity)
+            sizes[count++] = {VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, descriptor_buffer_capacity};
+        if (descriptor_sampled_capacity)
+            sizes[count++] = {VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+                              descriptor_sampled_capacity};
+        if (descriptor_storage_capacity)
+            sizes[count++] = {VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, descriptor_storage_capacity};
+        VkDescriptorPoolCreateInfo info{VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO};
+        info.maxSets = 1;
+        info.poolSizeCount = count;
+        info.pPoolSizes = sizes;
+        if (!count || vkCreateDescriptorPool(device, &info, nullptr, &descriptor_pool) != VK_SUCCESS)
+            descriptor_pool = VK_NULL_HANDLE;
+        return descriptor_pool;
+    }
+
+    static bool persistent_mapping_enabled() {
+        static const bool enabled =
+            std::getenv("PROSPER_NO_PERSISTENT_COMPUTE_MAP") == nullptr;
+        return enabled;
+    }
+
+    VkDeviceMemory allocate_memory(VkDeviceSize bytes, uint32_t memory_type,
+                                   bool persistently_map = false) {
         if (memory_type == UINT32_MAX) return VK_NULL_HANDLE;
         const ComputeMemoryKey key{bytes, memory_type};
+        static const bool best_fit_reuse =
+            std::getenv("PROSPER_COMPUTE_MEMORY_POOL_EXACT") == nullptr;
         if (compute_memory_pool_enabled()) {
             std::lock_guard<std::mutex> lock(memory_pool.mutex);
             auto found = memory_pool.available.find(key);
+            // Vulkan permits binding an allocation larger than the resource's memory requirement.
+            // Exact-size-only reuse fragmented Astro Bot's 256 MiB pool across many nearly-identical
+            // image/staging sizes, forcing hundreds of fresh AMD BO allocations and kernel page-zero
+            // passes. On an exact miss, reuse the smallest available allocation of the same memory
+            // type that is large enough. Keep its REAL size in active so release/accounting remain
+            // exact and a large allocation is never accidentally treated as a smaller one.
+            if ((found == memory_pool.available.end() || found->second.empty()) &&
+                best_fit_reuse) {
+                auto best = memory_pool.available.end();
+                for (auto candidate = memory_pool.available.begin();
+                     candidate != memory_pool.available.end(); ++candidate) {
+                    if (candidate->second.empty() || candidate->first.memory_type != memory_type ||
+                        candidate->first.bytes < bytes)
+                        continue;
+                    if (best == memory_pool.available.end() ||
+                        candidate->first.bytes < best->first.bytes)
+                        best = candidate;
+                }
+                found = best;
+            }
             if (found != memory_pool.available.end() && !found->second.empty()) {
+                const ComputeMemoryKey allocation_key = found->first;
                 const VkDeviceMemory allocation = found->second.back();
                 found->second.pop_back();
                 if (found->second.empty()) memory_pool.available.erase(found);
-                memory_pool.cached_bytes -= bytes;
+                memory_pool.cached_bytes -= allocation_key.bytes;
                 --memory_pool.cached_allocations;
                 ++memory_pool.hits;
-                memory_pool.active.emplace(allocation, key);
+                memory_pool.active.emplace(allocation, allocation_key);
+                if (persistently_map && persistent_mapping_enabled() &&
+                    memory_pool.persistent_mappings.find(allocation) ==
+                        memory_pool.persistent_mappings.end()) {
+                    void* mapping = nullptr;
+                    if (vkMapMemory(device, allocation, 0, allocation_key.bytes, 0, &mapping) ==
+                        VK_SUCCESS)
+                        memory_pool.persistent_mappings.emplace(allocation, mapping);
+                }
                 return allocation;
             }
             ++memory_pool.misses;
@@ -163,8 +523,36 @@ struct VulkanComputeContext {
         if (compute_memory_pool_enabled()) {
             std::lock_guard<std::mutex> lock(memory_pool.mutex);
             memory_pool.active.emplace(result, key);
+            if (persistently_map && persistent_mapping_enabled()) {
+                void* mapping = nullptr;
+                if (vkMapMemory(device, result, 0, bytes, 0, &mapping) == VK_SUCCESS)
+                    memory_pool.persistent_mappings.emplace(result, mapping);
+            }
         }
         return result;
+    }
+
+    VkResult map_memory(VkDeviceMemory allocation, VkDeviceSize offset, VkDeviceSize bytes,
+                        void** mapping) {
+        if (compute_memory_pool_enabled() && persistent_mapping_enabled()) {
+            std::lock_guard<std::mutex> lock(memory_pool.mutex);
+            const auto found = memory_pool.persistent_mappings.find(allocation);
+            if (found != memory_pool.persistent_mappings.end()) {
+                *mapping = static_cast<uint8_t*>(found->second) + offset;
+                return VK_SUCCESS;
+            }
+        }
+        return vkMapMemory(device, allocation, offset, bytes, 0, mapping);
+    }
+
+    void unmap_memory(VkDeviceMemory allocation) {
+        if (compute_memory_pool_enabled() && persistent_mapping_enabled()) {
+            std::lock_guard<std::mutex> lock(memory_pool.mutex);
+            if (memory_pool.persistent_mappings.find(allocation) !=
+                memory_pool.persistent_mappings.end())
+                return;
+        }
+        vkUnmapMemory(device, allocation);
     }
 
     void release_memory(VkDeviceMemory allocation) {
@@ -176,6 +564,8 @@ struct VulkanComputeContext {
         std::lock_guard<std::mutex> lock(memory_pool.mutex);
         auto found = memory_pool.active.find(allocation);
         if (found == memory_pool.active.end()) {
+            if (memory_pool.persistent_mappings.erase(allocation))
+                vkUnmapMemory(device, allocation);
             vkFreeMemory(device, allocation, nullptr);
             return;
         }
@@ -187,6 +577,8 @@ struct VulkanComputeContext {
             ? limit - memory_pool.cached_bytes : 0;
         if (memory_pool.cached_allocations >= max_cached_allocations || key.bytes > remaining) {
             ++memory_pool.discarded;
+            if (memory_pool.persistent_mappings.erase(allocation))
+                vkUnmapMemory(device, allocation);
             vkFreeMemory(device, allocation, nullptr);
             return;
         }
@@ -206,15 +598,21 @@ struct VulkanComputeContext {
         std::lock_guard<std::mutex> lock(memory_pool.mutex);
         for (const auto& [key, allocations] : memory_pool.available) {
             (void)key;
-            for (VkDeviceMemory allocation : allocations)
+            for (VkDeviceMemory allocation : allocations) {
+                if (memory_pool.persistent_mappings.erase(allocation))
+                    vkUnmapMemory(device, allocation);
                 vkFreeMemory(device, allocation, nullptr);
+            }
         }
         for (const auto& [allocation, key] : memory_pool.active) {
             (void)key;
+            if (memory_pool.persistent_mappings.erase(allocation))
+                vkUnmapMemory(device, allocation);
             vkFreeMemory(device, allocation, nullptr);
         }
         memory_pool.available.clear();
         memory_pool.active.clear();
+        memory_pool.persistent_mappings.clear();
         memory_pool.cached_bytes = 0;
         memory_pool.cached_allocations = 0;
     }
@@ -353,6 +751,25 @@ struct BoundBuffer {
     uint64_t changed_bytes = 0;
 };
 
+// Image conversion writes straight into the host-visible Vulkan staging allocation. Keep the map
+// scoped so every validation/error exit unmaps it before cleanup releases the pooled memory.
+struct ScopedMappedMemory {
+    explicit ScopedMappedMemory(VulkanComputeContext& c) : context(c) {}
+    ~ScopedMappedMemory() { unmap(); }
+    ScopedMappedMemory(const ScopedMappedMemory&) = delete;
+    ScopedMappedMemory& operator=(const ScopedMappedMemory&) = delete;
+
+    void unmap() {
+        if (!data) return;
+        context.unmap_memory(memory);
+        data = nullptr;
+    }
+
+    VulkanComputeContext& context;
+    VkDeviceMemory memory = VK_NULL_HANDLE;
+    void* data = nullptr;
+};
+
 // One image binding (#590): a sampled texture (usually RGBA8, with native UINT8x4 and R11G11B10F
 // views where shader-visible numeric semantics require them) or a storage image (R32G32B32A32_UINT
 // texels — the recompiler's format-free contract, exec-diff proven by tests/image_compute_runner.h).
@@ -449,9 +866,10 @@ void storage_unpack_texel(const uint8_t* src, prosper::gpu::DataFormat f, uint32
     for (uint32_t c = 0; c < ncomp && c < 4; c++) {
         switch (f) {
             case DF::Unorm8: { float v = src[c] / 255.0f; std::memcpy(&out[c], &v, 4); break; }
-            case DF::Float16: { float v = prosper::gpu::half_to_float(
-                                    (uint16_t)(src[c * 2] | (src[c * 2 + 1] << 8)));
-                                std::memcpy(&out[c], &v, 4); break; }
+            case DF::Float16:
+                out[c] = storage_unpack_float16_bits(
+                    static_cast<uint16_t>(src[c * 2] | (src[c * 2 + 1] << 8)));
+                break;
             // Integer formats carry the raw channel value; a UINT/SINT image_load reads the stored
             // integer directly (zero-extend for Uint, sign-extend for Sint). No normalization.
             case DF::Uint8:  out[c] = src[c]; break;
@@ -492,14 +910,21 @@ void storage_unpack_range(const uint8_t* src, size_t src_stride, prosper::gpu::D
             }
             return;
         case DF::Float16:
-            for (size_t t = 0; t < count; ++t) {
-                const uint8_t* p = src + t * src_stride; uint32_t* o = out + t * 4; defaults(o);
-                for (uint32_t c = 0; c < n; ++c) {
-                    float v = prosper::gpu::half_to_float(
-                        static_cast<uint16_t>(p[c * 2] | (p[c * 2 + 1] << 8)));
-                    std::memcpy(&o[c], &v, 4);
-                }
+            if (n == 4 && src_stride == 8) {
+                storage_unpack_float16x4_range(src, count, out);
+                return;
             }
+            parallel_compute_texels(count, count * (src_stride + sizeof(uint32_t) * 4),
+                [&](size_t begin, size_t end) {
+                    for (size_t t = begin; t < end; ++t) {
+                        const uint8_t* p = src + t * src_stride;
+                        uint32_t* o = out + t * 4;
+                        defaults(o);
+                        for (uint32_t c = 0; c < n; ++c)
+                            o[c] = storage_unpack_float16_bits(
+                                static_cast<uint16_t>(p[c * 2] | (p[c * 2 + 1] << 8)));
+                    }
+                });
             return;
         case DF::Uint8:
             for (size_t t = 0; t < count; ++t) {
@@ -552,21 +977,38 @@ void storage_pack_range(const uint32_t* channels, prosper::gpu::DataFormat f, ui
     const uint32_t n = ncomp < 4u ? ncomp : 4u;
     switch (f) {
         case DF::Unorm8:
-            for (size_t t = 0; t < count; ++t) {
-                const uint32_t* in = channels + t * 4; uint8_t* p = dst + t * dst_stride;
-                for (uint32_t c = 0; c < n; ++c) p[c] = storage_pack_unorm8(in[c]);
+            if (dst_stride == n && n >= 1 && n <= 4) {
+                storage_pack_unorm8_range(channels, n, count, dst);
+                return;
             }
+            parallel_compute_texels(count, count * (sizeof(uint32_t) * 4 + dst_stride),
+                [&](size_t begin, size_t end) {
+                    for (size_t t = begin; t < end; ++t) {
+                        const uint32_t* in = channels + t * 4;
+                        uint8_t* p = dst + t * dst_stride;
+                        for (uint32_t c = 0; c < n; ++c)
+                            p[c] = storage_pack_unorm8(in[c]);
+                    }
+                });
             return;
         case DF::Float16:
-            for (size_t t = 0; t < count; ++t) {
-                const uint32_t* in = channels + t * 4; uint8_t* p = dst + t * dst_stride;
-                for (uint32_t c = 0; c < n; ++c) {
-                    float v; std::memcpy(&v, &in[c], 4);
-                    const uint16_t h = prosper::gpu::float_to_half(v);
-                    p[c * 2] = static_cast<uint8_t>(h);
-                    p[c * 2 + 1] = static_cast<uint8_t>(h >> 8);
-                }
+            if (n == 4 && dst_stride == 8) {
+                storage_pack_float16x4_range(channels, count, dst);
+                return;
             }
+            parallel_compute_texels(count, count * (sizeof(uint32_t) * 4 + dst_stride),
+                [&](size_t begin, size_t end) {
+                    for (size_t t = begin; t < end; ++t) {
+                        const uint32_t* in = channels + t * 4;
+                        uint8_t* p = dst + t * dst_stride;
+                        for (uint32_t c = 0; c < n; ++c) {
+                            float v; std::memcpy(&v, &in[c], 4);
+                            const uint16_t h = prosper::gpu::float_to_half(v);
+                            p[c * 2] = static_cast<uint8_t>(h);
+                            p[c * 2 + 1] = static_cast<uint8_t>(h >> 8);
+                        }
+                    }
+                });
             return;
         case DF::Uint8: case DF::Sint8:
             for (size_t t = 0; t < count; ++t) {
@@ -786,6 +1228,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
     std::vector<VkDeviceSize> staging_bytes(image_descriptors.size(), 0);
     VkDescriptorSetLayout descriptor_layout = VK_NULL_HANDLE;
     VkDescriptorPool descriptor_pool = VK_NULL_HANDLE;
+    bool descriptor_pool_reused = false;
     VkDescriptorSet descriptor_set = VK_NULL_HANDLE;
     VkShaderModule shader = VK_NULL_HANDLE;
     VkPipelineLayout pipeline_layout = VK_NULL_HANDLE;
@@ -817,7 +1260,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             if (descriptor_layout)
                 vkDestroyDescriptorSetLayout(ctx.device, descriptor_layout, nullptr);
         }
-        if (descriptor_pool) vkDestroyDescriptorPool(ctx.device, descriptor_pool, nullptr);
+        if (descriptor_pool && !descriptor_pool_reused)
+            vkDestroyDescriptorPool(ctx.device, descriptor_pool, nullptr);
         for (auto& buffer : buffers) {
             if (buffer.alias_of != SIZE_MAX) continue;
             if (buffer.buffer) vkDestroyBuffer(ctx.device, buffer.buffer, nullptr);
@@ -879,11 +1323,12 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 vkGetBufferMemoryRequirements(ctx.device, buffers[i].buffer, &requirements);
                 const uint32_t memory_type = ctx.host_memory_type(requirements.memoryTypeBits);
                 if (memory_type == UINT32_MAX) break;
-                buffers[i].memory = ctx.allocate_memory(requirements.size, memory_type);
+                buffers[i].memory = ctx.allocate_memory(requirements.size, memory_type, true);
                 if (!buffers[i].memory) break;
                 if (vkBindBufferMemory(ctx.device, buffers[i].buffer, buffers[i].memory, 0) != VK_SUCCESS) break;
                 void* mapped = nullptr;
-                if (vkMapMemory(ctx.device, buffers[i].memory, 0, resource->size, 0, &mapped) != VK_SUCCESS) break;
+                if (ctx.map_memory(buffers[i].memory, 0, resource->size, &mapped) != VK_SUCCESS)
+                    break;
                 const uint8_t* source = resource_bytes(resource);
                 if (trace) buffers[i].before_hash = fnv1a(source, resource->size);
                 // Pooled host-visible allocations retain their previous contents. Compare them with
@@ -892,7 +1337,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 // still takes the ordinary full-copy path.
                 if (std::memcmp(mapped, source, resource->size) != 0)
                     std::memcpy(mapped, source, resource->size);
-                vkUnmapMemory(ctx.device, buffers[i].memory);
+                ctx.unmap_memory(buffers[i].memory);
             }
 
             layout_bindings[i].binding = descriptors[i].binding;
@@ -992,17 +1437,19 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             LiveTargetSnapshot live_target;
             bool renderer_owned = !r->in_mip_tail && is_live_render_target(r->gpu_addr);
             // Bind the renderer's own image when it is the authoritative copy and this binding
-            // matches it EXACTLY (#1095, phase 2 of #1091). Restricted to a sampled Unorm8x4 view of
-            // an rgba8 target because that is the one shape whose host path is a plain memcpy into a
-            // VK_FORMAT_R8G8B8A8_UNORM image -- the direct bind is then byte-identical, and it skips
-            // a full readback plus a re-upload of those same pixels to the same device. Every other
-            // shape (notably rgba16f, which the host path converts down to UNORM8) keeps that path.
+            // matches it EXACTLY (#1095, phase 2 of #1091). RGBA8 and RGBA16F targets both have a
+            // byte-identical sampled Vulkan view, so neither needs to round-trip through a CPU
+            // snapshot. The FP16 case is especially important for full-resolution post processing:
+            // converting a 4K target down to UNORM8 cost more than the compute dispatch itself and
+            // also discarded HDR values. Aliases and numerically converted views keep the snapshot
+            // path below.
             if (renderer_owned && !bi.storage && !dim_1d && !dim_3d && !dim_2d_array &&
-                r->depth == 1 && !r->depth_compare && r->format == DataFormat::Unorm8 &&
-                (r->num_components ? r->num_components : 1) == 4) {
+                r->depth == 1 && !r->depth_compare) {
                 LiveTargetImageImport import;
                 if (import_live_render_target_image(r->gpu_addr, import)) {
-                    if (import.format == LiveTargetPixelFormat::Rgba8Unorm &&
+                    if (direct_sampled_rtt_compatible(
+                            r->format, r->num_components ? r->num_components : 1,
+                            import.format) &&
                         import.width == r->width && import.height == r->height &&
                         import.device == static_cast<void*>(ctx.device)) {
                         bi.imported = true;
@@ -1015,9 +1462,11 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         if (trace)
                             std::fprintf(stderr,
                                          "[compute]   bound renderer RTT in place binding=%u "
-                                         "addr=0x%llx extent=%ux%u format=rgba8\n",
+                                         "addr=0x%llx extent=%ux%u format=%s\n",
                                          bi.binding, (unsigned long long)r->gpu_addr,
-                                         r->width, r->height);
+                                         r->width, r->height,
+                                         import.format == LiveTargetPixelFormat::Rgba16Float
+                                             ? "rgba16f" : "rgba8");
                     } else {
                         // Not our exact contract (a different device or a stale aliased view).
                         release_live_render_target_image(r->gpu_addr);
@@ -1256,6 +1705,12 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             const bool sampled_float32 = !bi.storage && !sampled_depth &&
                                          r->format == DataFormat::Float32 &&
                                          sampled_components >= 1 && sampled_components <= 4;
+            // Imported renderer-owned RGBA16F is already the exact native sampled representation.
+            // Guest-backed FP16 retains the historical RGBA8 conversion until its independent
+            // upload-format contract is changed.
+            const bool sampled_float16_native = !bi.storage && bi.imported &&
+                                                r->format == DataFormat::Float16 &&
+                                                sampled_components == 4;
             const bool sampled_unorm8x2 = !bi.storage && r->format == DataFormat::Unorm8 &&
                                           sampled_components == 2;
             const bool sampled_unorm16_native = !bi.storage && r->format == DataFormat::Unorm16 &&
@@ -1272,6 +1727,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                                 sampled_components == 4);
             const uint32_t texel_bytes = bi.storage || sampled_float32 ? 16u
                                          : sampled_depth ? data_format_bytes(r->format)
+                                         : sampled_float16_native ? 8u
                                          : sampled_uint32_native ? sampled_components * 4u
                                          : sampled_uint16_native ? sampled_components * 2u
                                          : sampled_unorm16_native ? sampled_components * 2u
@@ -1285,8 +1741,34 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             }
             staging_bytes[i] = sbytes;
 
-            // Fill the upload staging bytes.
-            std::vector<uint8_t> upload((bi.imported || bi.seed_skip) ? size_t{0} : (size_t)sbytes, 0);
+            // Allocate the host-visible staging buffer before conversion and write into its mapping
+            // directly. The old path first built a heap upload and then memcpy'd the complete result
+            // here -- an extra 132 MiB CPU pass for Astro Bot's 4K RGBA32 storage representation.
+            ScopedMappedMemory upload_mapping(ctx);
+            const size_t upload_size = (bi.imported || bi.seed_skip) ? size_t{0} : (size_t)sbytes;
+            if (!bi.imported) {
+                VkBufferCreateInfo sci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
+                sci.size = sbytes;
+                sci.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+                if (!vk_ok(vkCreateBuffer(ctx.device, &sci, nullptr, &staging[i]),
+                           "image-staging-buffer")) { images_ready = false; break; }
+                VkMemoryRequirements sreq{};
+                vkGetBufferMemoryRequirements(ctx.device, staging[i], &sreq);
+                const uint32_t staging_memory_type = ctx.host_memory_type(sreq.memoryTypeBits);
+                staging_memory[i] = ctx.allocate_memory(sreq.size, staging_memory_type, true);
+                if (!vk_handle_ok(staging_memory[i], "image-staging-memory") ||
+                    !vk_ok(vkBindBufferMemory(ctx.device, staging[i], staging_memory[i], 0),
+                           "image-staging-bind")) {
+                    images_ready = false; break;
+                }
+                upload_mapping.memory = staging_memory[i];
+                if (!bi.seed_skip &&
+                    !vk_ok(ctx.map_memory(staging_memory[i], 0, sbytes,
+                                          &upload_mapping.data), "image-staging-map")) {
+                    images_ready = false; break;
+                }
+            }
+            auto* upload = static_cast<uint8_t*>(upload_mapping.data);
             if (bi.imported) {
                 // The renderer's image is the source: there is nothing to convert or stage.
                 bi.guest_bytes = 0;
@@ -1328,15 +1810,19 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                       (r->host_data && r->host_data_size >= guest_bytes) ||
                                       guest_readable(r->gpu_addr, static_cast<uint32_t>(guest_bytes));
                 if (!readable) { skip_image(r, "storage backing unreadable"); break; }
-                std::vector<uint8_t> linear(bi.seed_skip ? size_t{0}
-                                            : (size_t)linear_guest_bytes, 0);
+                const size_t linear_size = bi.seed_skip
+                    ? size_t{0} : static_cast<size_t>(linear_guest_bytes);
+                std::unique_ptr<uint8_t[]> linear;
+                if (linear_size && !renderer_owned && r->tile_mode)
+                    linear = std::make_unique_for_overwrite<uint8_t[]>(linear_size);
+                const uint8_t* unpack_source = nullptr;
                 if (bi.seed_skip) {
                     // #1122: write-only full-coverage target -- the shader overwrites every texel, so
                     // the image is created but never seeded, uploaded, or read. Nothing to fill.
                 } else if (renderer_owned) {
-                    std::memcpy(linear.data(), live_target.pixels->data(), linear.size());
+                    unpack_source = live_target.pixels->data();
                     if (trace) {
-                        bi.before_hash = fnv1a(linear.data(), linear.size());
+                        bi.before_hash = fnv1a(unpack_source, linear_size);
                         std::fprintf(stderr,
                                      "[compute]   imported writable renderer RTT binding=%u "
                                      "addr=0x%llx extent=%ux%u format=%s\n",
@@ -1347,33 +1833,38 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     }
                 } else if (r->tile_mode && r->depth > 1) {
                     if (trace) bi.before_hash = fnv1a(src, guest_bytes);
-                    if (!detile_volume(linear.data(), src, guest_bytes, r->width, r->height,
+                    if (!detile_volume(linear.get(), src, guest_bytes, r->width, r->height,
                                        r->depth, r->tile_mode, static_cast<uint32_t>(guest_texel))) {
                         skip_image(r, "storage volume detile failed"); break;
                     }
+                    unpack_source = linear.get();
                 } else if (r->tile_mode && r->in_mip_tail) {
                     if (trace) bi.before_hash = fnv1a(src, guest_bytes);
-                    detile_surface_level(linear.data(), src, guest_bytes,
+                    detile_surface_level(linear.get(), src, guest_bytes,
                                          r->width, r->height, r->tile_mode,
                                          static_cast<uint32_t>(guest_texel),
                                          r->mip_tail_x, r->mip_tail_y);
+                    unpack_source = linear.get();
                 } else if (r->tile_mode) {
                     if (trace) bi.before_hash = fnv1a(src, guest_bytes);
-                    detile_surface(linear.data(), src, r->width, r->height, r->tile_mode, 0,
+                    detile_surface(linear.get(), src, r->width, r->height, r->tile_mode, 0,
                                    static_cast<uint32_t>(guest_texel));
+                    unpack_source = linear.get();
                 } else {
                     if (trace) bi.before_hash = fnv1a(src, guest_bytes);
-                    std::memcpy(linear.data(), src, linear.size());
+                    // Linear guest storage is already in the row-major layout consumed by unpack.
+                    // Decode it in place instead of copying the complete surface to a temporary first.
+                    unpack_source = src;
                 }
                 if (!bi.seed_skip)
-                    storage_unpack_range(linear.data(), guest_texel, r->format, nc, texels,
-                                         reinterpret_cast<uint32_t*>(upload.data()));
+                    storage_unpack_range(unpack_source, guest_texel, r->format, nc, texels,
+                                         reinterpret_cast<uint32_t*>(upload));
                 if (bi.poison_verify) {   // #1122 coverage proof: poison every uvec4 channel
                     // Keep the clean detiled guest seed: on a partial-coverage proving frame the
                     // writeback restores every un-stored (still-poison) texel from it, so proving
                     // never corrupts the guest -- only the GPU `upload` is poisoned, `linear` is not.
-                    bi.seed_linear = linear;
-                    uint32_t* pp = reinterpret_cast<uint32_t*>(upload.data());
+                    bi.seed_linear.assign(unpack_source, unpack_source + linear_size);
+                    uint32_t* pp = reinterpret_cast<uint32_t*>(upload);
                     for (size_t t = 0; t < texels * 4; ++t) pp[t] = 0xDEADBEEFu;
                 }
                 static const bool verify_unpack =
@@ -1384,10 +1875,11 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     // and identifies the binding, and logs the clean case too so a verified run is
                     // self-proving rather than merely silent.
                     uint32_t expect[4];
-                    const uint32_t* got = reinterpret_cast<const uint32_t*>(upload.data());
+                    const uint32_t* got = reinterpret_cast<const uint32_t*>(upload);
                     size_t bad = 0, first_bad = 0;
                     for (size_t t = 0; t < texels; ++t) {
-                        storage_unpack_texel(linear.data() + t * guest_texel, r->format, nc, expect);
+                        storage_unpack_texel(unpack_source + t * guest_texel,
+                                             r->format, nc, expect);
                         if (std::memcmp(expect, got + t * 4, sizeof expect) != 0) {
                             if (!bad) first_bad = t;
                             ++bad;
@@ -1423,7 +1915,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         // byte-identical to the UINT view.  Sonic aliases an RGBA16F render target
                         // as RGBA16_UINT for a compute resolve: those eight bytes must be
                         // reinterpreted, not numerically converted through float or UNORM.
-                        std::memcpy(upload.data(), pixels.data(), upload.size());
+                        std::memcpy(upload, pixels.data(), upload_size);
                     } else if (sampled_uint8_native) {
                         const size_t texels = static_cast<size_t>(volume_texels);
                         for (size_t t = 0; t < texels; ++t) {
@@ -1473,30 +1965,34 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                     else if (f >= 1.0f) f = 1.0f;
                                     value = static_cast<uint16_t>(std::lround(f * 65535.0f));
                                 }
-                                std::memcpy(upload.data() +
+                                std::memcpy(upload +
                                                 (t * sampled_components + c) * sizeof(value),
                                             &value, sizeof(value));
                             }
                         }
                     } else if (f32) {
                         const size_t texels = static_cast<size_t>(volume_texels);
-                        for (size_t t = 0; t < texels; ++t) {
-                            for (uint32_t c = 0; c < 4; ++c) {
-                                float value = 0.0f;
-                                if (live_target.format == LiveTargetPixelFormat::Rgba8Unorm) {
-                                    value = pixels[t * 4 + c] / 255.0f;
-                                } else {
-                                    uint16_t half = 0;
-                                    std::memcpy(&half, pixels.data() + t * 8 + c * 2, sizeof(half));
-                                    value = half_to_float(half);
-                                    if (std::isnan(value)) value = 0.0f;
+                        parallel_compute_texels(texels, texels * (16u + 8u),
+                            [&](size_t begin, size_t end) {
+                                for (size_t t = begin; t < end; ++t) {
+                                    for (uint32_t c = 0; c < 4; ++c) {
+                                        float value = 0.0f;
+                                        if (live_target.format == LiveTargetPixelFormat::Rgba8Unorm) {
+                                            value = pixels[t * 4 + c] / 255.0f;
+                                        } else {
+                                            uint16_t half = 0;
+                                            std::memcpy(&half, pixels.data() + t * 8 + c * 2,
+                                                        sizeof(half));
+                                            value = half_to_float(half);
+                                            if (std::isnan(value)) value = 0.0f;
+                                        }
+                                        std::memcpy(upload + (t * 4 + c) * sizeof(float),
+                                                    &value, sizeof(value));
+                                    }
                                 }
-                                std::memcpy(upload.data() + (t * 4 + c) * sizeof(float),
-                                            &value, sizeof(value));
-                            }
-                        }
+                            });
                     } else if (live_target.format == LiveTargetPixelFormat::Rgba8Unorm) {
-                        std::memcpy(upload.data(), pixels.data(), upload.size());
+                        std::memcpy(upload, pixels.data(), upload_size);
                     } else {
                         const size_t texels = static_cast<size_t>(volume_texels);
                         for (size_t t = 0; t < texels; ++t) {
@@ -1565,23 +2061,33 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         if (dim_2d_array) {
                             skip_image(r, "block-compressed sampled arrays deferred"); break;
                         }
-                        std::vector<uint8_t> lin((size_t)bw * bh * bpb, 0);
+                        std::unique_ptr<uint8_t[]> linear;
+                        const uint8_t* decode_source = src;
+                        if (r->tile_mode) {
+                            linear = std::make_unique_for_overwrite<uint8_t[]>((size_t)bw * bh * bpb);
+                            decode_source = linear.get();
+                        }
                         if (r->tile_mode && r->in_mip_tail)
-                            detile_elements_level(lin.data(), src, need, bw, bh, bpb,
+                            detile_elements_level(linear.get(), src, need, bw, bh, bpb,
                                                   r->tile_mode, r->mip_tail_x,
                                                   r->mip_tail_y);
                         else if (r->tile_mode)
-                            detile_elements(lin.data(), src, need, bw, bh, bpb, r->tile_mode);
-                        else
-                            std::memcpy(lin.data(), src, lin.size());
-                        if (!bc_decode_surface(upload.data(), lin.data(), lin.size(),
+                            detile_elements(linear.get(), src, need, bw, bh, bpb, r->tile_mode);
+                        if (!bc_decode_surface(upload, decode_source, (size_t)bw * bh * bpb,
                                                r->width, r->height, r->format)) {
                             skip_image(r, "BC decode unsupported"); break; }
                     } else {
                         const uint32_t bpt = r11g11b10 ? 4u : cb * nc;
-                        std::vector<uint8_t> lin((size_t)volume_texels * bpt, 0);
+                        const size_t linear_bytes = static_cast<size_t>(volume_texels) * bpt;
+                        std::unique_ptr<uint8_t[]> linear;
+                        const uint8_t* sampled_source = src;
+                        if (r->tile_mode) {
+                            linear = std::make_unique_for_overwrite<uint8_t[]>(linear_bytes);
+                            sampled_source = linear.get();
+                        }
                         if (r->tile_mode && dim_3d && r->depth > 1) {
-                            if (!detile_volume(lin.data(), src, need, r->width, r->height, r->depth,
+                            if (!detile_volume(linear.get(), src, need,
+                                               r->width, r->height, r->depth,
                                                r->tile_mode, bpt)) {
                                 skip_image(r, "sampled volume detile failed"); break;
                             }
@@ -1590,84 +2096,59 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                 r->width, r->height, r->tile_mode, 0, bpt);
                             const size_t linear_slice = static_cast<size_t>(r->width) * r->height * bpt;
                             for (uint32_t layer = 0; layer < r->depth; ++layer)
-                                detile_surface(lin.data() + linear_slice * layer,
+                                detile_surface(linear.get() + linear_slice * layer,
                                                src + tiled_slice * layer,
                                                r->width, r->height, r->tile_mode, 0, bpt);
                         } else if (r->tile_mode && r->in_mip_tail) {
-                            detile_surface_level(lin.data(), src, need, r->width, r->height,
+                            detile_surface_level(linear.get(), src, need, r->width, r->height,
                                                  r->tile_mode, bpt, r->mip_tail_x,
                                                  r->mip_tail_y);
                         } else if (r->tile_mode) {
-                            detile_surface(lin.data(), src, r->width, r->height, r->tile_mode, 0, bpt);
-                        } else {
-                            std::memcpy(lin.data(), src, lin.size());
+                            detile_surface(linear.get(), src, r->width, r->height,
+                                           r->tile_mode, 0, bpt);
                         }
                         const size_t texels = (size_t)volume_texels;
                         if (rgba8 || uint8 || r11g11b10 ||
                             sampled_unorm8x2 || sampled_unorm16_native ||
                             sampled_uint8_native || sampled_uint16_native ||
                             sampled_uint32_native || sampled_depth) {   // Native sampled texels
-                            std::memcpy(upload.data(), lin.data(), lin.size());
+                            std::memcpy(upload, sampled_source, linear_bytes);
                         } else if (f32) {                           // Native float channels + default fill
-                            for (size_t t = 0; t < texels; ++t) {
-                                for (uint32_t c = 0; c < 4; ++c) {
-                                    float value = c == 3 ? 1.0f : 0.0f;
-                                    if (c < nc)
-                                        std::memcpy(&value, lin.data() + (t * nc + c) * sizeof(float),
+                            parallel_compute_texels(texels, linear_bytes + texels * 16u,
+                                [&](size_t begin, size_t end) {
+                                    for (size_t t = begin; t < end; ++t) {
+                                        for (uint32_t c = 0; c < 4; ++c) {
+                                            float value = c == 3 ? 1.0f : 0.0f;
+                                            if (c < nc)
+                                                std::memcpy(
+                                                    &value,
+                                                    sampled_source + (t * nc + c) * sizeof(float),
                                                     sizeof(value));
-                                    std::memcpy(upload.data() + (t * 4 + c) * sizeof(float),
+                                            std::memcpy(
+                                                upload + (t * 4 + c) * sizeof(float),
                                                 &value, sizeof(value));
-                                }
-                            }
-                        } else if (r8) {                            // R8: broadcast coverage to RGBA
-                            for (size_t t = 0; t < texels; t++) {
-                                const uint8_t v = lin[t];
-                                upload[t * 4 + 0] = v; upload[t * 4 + 1] = v;
-                                upload[t * 4 + 2] = v; upload[t * 4 + 3] = v;
-                            }
-                        } else {                                    // Float16: half -> UNORM8 + default fill
-                            const uint16_t* hp = reinterpret_cast<const uint16_t*>(lin.data());
-                            for (size_t t = 0; t < texels; t++) {
-                                for (uint32_t c = 0; c < 4; c++) {
-                                    if (c >= nc) {
-                                        upload[t * 4 + c] = c == 3 ? 255 : 0;
-                                        continue;
+                                        }
                                     }
-                                    float v = half_to_float(hp[t * nc + c]);
-                                    if (std::isnan(v)) v = 0.f;
-                                    v = v < 0.f ? 0.f : (v > 1.f ? 1.f : v);
-                                    upload[t * 4 + c] = (uint8_t)std::lround(v * 255.0f);
-                                }
-                            }
+                                });
+                        } else if (r8) {                            // R8: broadcast coverage to RGBA
+                            parallel_compute_texels(texels, linear_bytes + texels * 4u,
+                                [&](size_t begin, size_t end) {
+                                    for (size_t t = begin; t < end; ++t) {
+                                        const uint8_t v = sampled_source[t];
+                                        upload[t * 4 + 0] = v; upload[t * 4 + 1] = v;
+                                        upload[t * 4 + 2] = v; upload[t * 4 + 3] = v;
+                                    }
+                                });
+                        } else {                                    // Float16: half -> UNORM8 + default fill
+                            sampled_float16_to_unorm8_range(
+                                sampled_source, nc, texels, upload);
                         }
                     }
                 }
             }
 
-            // Staging buffer (host-visible) holding the upload bytes; reused for storage
-            // readback. An imported renderer image supplies its own pixels, so it needs none.
-            if (!bi.imported) {
-                VkBufferCreateInfo sci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
-                sci.size = sbytes;
-                sci.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
-                if (!vk_ok(vkCreateBuffer(ctx.device, &sci, nullptr, &staging[i]),
-                           "image-staging-buffer")) { images_ready = false; break; }
-                VkMemoryRequirements sreq{};
-                vkGetBufferMemoryRequirements(ctx.device, staging[i], &sreq);
-                const uint32_t staging_memory_type = ctx.host_memory_type(sreq.memoryTypeBits);
-                staging_memory[i] = ctx.allocate_memory(sreq.size, staging_memory_type);
-                if (!vk_handle_ok(staging_memory[i], "image-staging-memory") ||
-                    !vk_ok(vkBindBufferMemory(ctx.device, staging[i], staging_memory[i], 0),
-                           "image-staging-bind")) {
-                    images_ready = false; break; }
-                if (!bi.seed_skip) {   // seed-skip (#1122): image is never uploaded, staging stays for writeback
-                  void* mapped = nullptr;
-                  if (!vk_ok(vkMapMemory(ctx.device, staging_memory[i], 0, sbytes, 0, &mapped),
-                             "image-staging-map")) {
-                      images_ready = false; break; }
-                  std::memcpy(mapped, upload.data(), (size_t)sbytes);
-                  vkUnmapMemory(ctx.device, staging_memory[i]); }
-            }
+            // Host writes are complete before this allocation is consumed by vkCmdCopyBufferToImage.
+            upload_mapping.unmap();
 
             // Device-local image.
             VkImageCreateInfo ici{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
@@ -1679,6 +2160,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                     : (sampled_depth
                                            ? (r->format == DataFormat::Float32
                                                   ? VK_FORMAT_D32_SFLOAT : VK_FORMAT_D16_UNORM)
+                                       : sampled_float16_native
+                                           ? VK_FORMAT_R16G16B16A16_SFLOAT
                                        : sampled_uint8_native
                                            ? (sampled_components == 1 ? VK_FORMAT_R8_UINT
                                               : sampled_components == 2 ? VK_FORMAT_R8G8_UINT
@@ -1834,12 +2317,19 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             pool_sizes[pool_size_count++] = {VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, sampled_count};
         if (storage_image_count)
             pool_sizes[pool_size_count++] = {VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, storage_image_count};
-        VkDescriptorPoolCreateInfo dpci{VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO};
-        dpci.maxSets = 1;
-        dpci.poolSizeCount = pool_size_count;
-        dpci.pPoolSizes = pool_sizes;
-        if (!vk_ok(vkCreateDescriptorPool(ctx.device, &dpci, nullptr, &descriptor_pool),
-                   "descriptor-pool")) break;
+        if (VulkanComputeContext::descriptor_pool_reuse_enabled()) {
+            descriptor_pool = ctx.prepare_descriptor_pool(
+                static_cast<uint32_t>(buffers.size()), sampled_count, storage_image_count);
+            descriptor_pool_reused = descriptor_pool != VK_NULL_HANDLE;
+            if (!vk_handle_ok(descriptor_pool, "descriptor-pool-reuse")) break;
+        } else {
+            VkDescriptorPoolCreateInfo dpci{VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO};
+            dpci.maxSets = 1;
+            dpci.poolSizeCount = pool_size_count;
+            dpci.pPoolSizes = pool_sizes;
+            if (!vk_ok(vkCreateDescriptorPool(ctx.device, &dpci, nullptr, &descriptor_pool),
+                       "descriptor-pool")) break;
+        }
         VkDescriptorSetAllocateInfo dsai{VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO};
         dsai.descriptorPool = descriptor_pool;
         dsai.descriptorSetCount = 1;
@@ -2091,7 +2581,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         for (auto& buffer : buffers) {
             if (buffer.alias_of != SIZE_MAX) continue;
             void* mapped = nullptr;
-            if (vkMapMemory(ctx.device, buffer.memory, 0, buffer.resource->size, 0, &mapped) != VK_SUCCESS) {
+            if (ctx.map_memory(buffer.memory, 0, buffer.resource->size, &mapped) != VK_SUCCESS) {
                 readback_ok = false;
                 break;
             }
@@ -2111,7 +2601,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             // RAM even when consecutive compute readbacks contain identical bytes.
             if (changed)
                 std::memcpy(destination, result, buffer.resource->size);
-            vkUnmapMemory(ctx.device, buffer.memory);
+            ctx.unmap_memory(buffer.memory);
             if (buffer.resource->gpu_addr)
                 notify_guest_gpu_write(buffer.resource->gpu_addr, buffer.resource->size);
             if (!buffer.resource->host_data && writer_provenance_enabled())
@@ -2129,7 +2619,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             if (!bi.storage || bi.alias_of != SIZE_MAX) continue;
             const ShaderResource* r = bi.resource;
             void* mapped = nullptr;
-            if (vkMapMemory(ctx.device, staging_memory[i], 0, staging_bytes[i], 0, &mapped) != VK_SUCCESS) {
+            if (ctx.map_memory(staging_memory[i], 0, staging_bytes[i], &mapped) != VK_SUCCESS) {
                 readback_ok = false;
                 break;
             }
@@ -2139,7 +2629,14 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                         r->format == DataFormat::Unorm2_10_10_10)
                 ? 4u : (size_t)cb * nc;
             const size_t texels = (size_t)r->width * r->height * r->depth;
-            std::vector<uint8_t> linear(texels * guest_texel, 0);
+            const size_t linear_bytes = texels * guest_texel;
+            uint8_t* destination = resource_bytes_for(r, bi.guest_bytes);
+            std::unique_ptr<uint8_t[]> linear;
+            uint8_t* packed = destination;
+            if (r->tile_mode) {
+                linear = std::make_unique_for_overwrite<uint8_t[]>(linear_bytes);
+                packed = linear.get();
+            }
             const uint32_t* channels = static_cast<const uint32_t*>(mapped);
             // #1122 proving-frame poison scan: a texel still fully poison was NOT stored by the write.
             // Zero survivors == the shader covers every texel (safe to fast-skip its seed henceforth);
@@ -2175,21 +2672,21 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             const auto pack_start = ComputeClock::now();
             static const bool pack_range_enabled = !std::getenv("PROSPER_NO_PACK_RANGE");
             if (pack_range_enabled) {
-                storage_pack_range(channels, r->format, nc, texels, linear.data(), guest_texel);
+                storage_pack_range(channels, r->format, nc, texels, packed, guest_texel);
             } else {
                 for (size_t t = 0; t < texels; t++)
                     storage_pack_texel(channels + t * 4, r->format, nc,
-                                       linear.data() + t * guest_texel);
+                                       packed + t * guest_texel);
             }
             // #1122: a proving frame that turned out partial-coverage packed poison garbage into the
             // un-stored texels. Restore each from the clean seed so the guest keeps its real prior
             // content (exactly a partial write's contract). Full-coverage proving frames have no
             // survivors, so this is a no-op there. bi.seed_linear shares this row-major texel layout.
             if (bi.poison_verify && !poison_texel.empty() &&
-                bi.seed_linear.size() == linear.size()) {
+                bi.seed_linear.size() == linear_bytes) {
                 for (size_t t = 0; t < texels; ++t) {
                     if (poison_texel[t])
-                        std::memcpy(linear.data() + t * guest_texel,
+                        std::memcpy(packed + t * guest_texel,
                                     bi.seed_linear.data() + t * guest_texel, guest_texel);
                 }
             }
@@ -2204,7 +2701,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 for (size_t t = 0; t < texels; ++t) {
                     std::memset(expect.data(), 0, expect.size());
                     storage_pack_texel(channels + t * 4, r->format, nc, expect.data());
-                    if (std::memcmp(expect.data(), linear.data() + t * guest_texel,
+                    if (std::memcmp(expect.data(), packed + t * guest_texel,
                                     guest_texel) != 0) {
                         if (!bad) first_bad = t;
                         ++bad;
@@ -2219,24 +2716,21 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     std::fprintf(stderr, "[compute] pack-verify first mismatch texel=%zu\n",
                                  first_bad);
             }
-            uint8_t* destination = resource_bytes_for(r, bi.guest_bytes);
             if (r->tile_mode && r->depth > 1) {
-                if (!tile_volume(destination, bi.guest_bytes, linear.data(), r->width, r->height,
+                if (!tile_volume(destination, bi.guest_bytes, packed, r->width, r->height,
                                  r->depth, r->tile_mode, static_cast<uint32_t>(guest_texel))) {
                     readback_ok = false;
-                    vkUnmapMemory(ctx.device, staging_memory[i]);
+                    ctx.unmap_memory(staging_memory[i]);
                     break;
                 }
             } else if (r->tile_mode && r->in_mip_tail) {
-                tile_surface_level(destination, bi.guest_bytes, linear.data(),
+                tile_surface_level(destination, bi.guest_bytes, packed,
                                    r->width, r->height, r->tile_mode,
                                    static_cast<uint32_t>(guest_texel),
                                    r->mip_tail_x, r->mip_tail_y);
             } else if (r->tile_mode) {
-                tile_surface(destination, linear.data(), r->width, r->height, r->tile_mode, 0,
+                tile_surface(destination, packed, r->width, r->height, r->tile_mode, 0,
                              static_cast<uint32_t>(guest_texel));
-            } else {
-                std::memcpy(destination, linear.data(), linear.size());
             }
             const auto layout_done = ComputeClock::now();
             pack_ms += std::chrono::duration<double, std::milli>(pack_done - pack_start).count();
@@ -2262,7 +2756,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                  bi.binding, (unsigned long long)r->metadata_addr,
                                  bi.dcc_metadata_bytes);
             }
-            vkUnmapMemory(ctx.device, staging_memory[i]);
+            ctx.unmap_memory(staging_memory[i]);
         }
         if (!readback_ok) break;
         ok = true;
@@ -2341,6 +2835,115 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
 }
 
 } // namespace
+
+void storage_pack_unorm8_range(const uint32_t* channels, uint32_t components,
+                               size_t texels, uint8_t* packed) {
+    if (!channels || !packed || !texels || !components || components > 4) return;
+#if defined(PROSPER_HAVE_TARGET_F16C)
+    static const bool use_avx2 = std::getenv("PROSPER_NO_AVX2_UNORM8_PACK") == nullptr &&
+                                  __builtin_cpu_supports("avx2");
+#endif
+    parallel_compute_texels(texels, texels * (sizeof(uint32_t) * 4u + components),
+        [&](size_t begin, size_t end) {
+#if defined(PROSPER_HAVE_TARGET_F16C)
+            if (use_avx2) {
+                storage_pack_unorm8_avx2(channels, components, begin, end, packed);
+                return;
+            }
+#endif
+            for (size_t texel = begin; texel < end; ++texel)
+                for (uint32_t channel = 0; channel < components; ++channel)
+                    packed[texel * components + channel] =
+                        storage_pack_unorm8(channels[texel * 4 + channel]);
+        });
+}
+
+void storage_unpack_float16x4_range(const uint8_t* rgba16f, size_t texels, uint32_t* channels) {
+    if (!rgba16f || !channels || !texels) return;
+#if defined(PROSPER_HAVE_TARGET_F16C)
+    static const bool use_f16c = std::getenv("PROSPER_NO_F16C_STORAGE_UNPACK") == nullptr &&
+                                 __builtin_cpu_supports("avx2") &&
+                                 __builtin_cpu_supports("f16c");
+#endif
+    parallel_compute_texels(texels, texels * (sizeof(uint16_t) * 4u + sizeof(uint32_t) * 4u),
+        [&](size_t begin, size_t end) {
+#if defined(PROSPER_HAVE_TARGET_F16C)
+            if (use_f16c) {
+                storage_unpack_float16x4_f16c(rgba16f, begin, end, channels);
+                return;
+            }
+#endif
+            for (size_t texel = begin; texel < end; ++texel)
+                for (uint32_t channel = 0; channel < 4; ++channel) {
+                    uint16_t bits = 0;
+                    std::memcpy(&bits,
+                                rgba16f + texel * 8 + channel * sizeof(bits), sizeof(bits));
+                    channels[texel * 4 + channel] = storage_unpack_float16_bits(bits);
+                }
+        });
+}
+
+void storage_pack_float16x4_range(const uint32_t* channels, size_t texels, uint8_t* rgba16f) {
+    if (!channels || !rgba16f || !texels) return;
+#if defined(PROSPER_HAVE_TARGET_F16C)
+    static const bool use_f16c = std::getenv("PROSPER_NO_F16C_STORAGE_PACK") == nullptr &&
+                                 __builtin_cpu_supports("avx2") &&
+                                 __builtin_cpu_supports("f16c");
+#endif
+    parallel_compute_texels(texels, texels * (sizeof(uint32_t) * 4u + sizeof(uint16_t) * 4u),
+        [&](size_t begin, size_t end) {
+#if defined(PROSPER_HAVE_TARGET_F16C)
+            if (use_f16c) {
+                storage_pack_float16x4_f16c(channels, begin, end, rgba16f);
+                return;
+            }
+#endif
+            for (size_t texel = begin; texel < end; ++texel) {
+                for (uint32_t channel = 0; channel < 4; ++channel) {
+                    float value;
+                    std::memcpy(&value, channels + texel * 4 + channel, sizeof(value));
+                    const uint16_t half = prosper::gpu::float_to_half(value);
+                    std::memcpy(rgba16f + texel * 8 + channel * sizeof(half),
+                                &half, sizeof(half));
+                }
+            }
+        });
+}
+
+void sampled_float16_to_unorm8_range(const uint8_t* source, uint32_t components,
+                                     size_t texels, uint8_t* rgba) {
+    if (!source || !rgba || !components || components > 4) return;
+    const auto& table = sampled_float16_unorm8_table();
+#if defined(PROSPER_HAVE_TARGET_F16C)
+    static const bool use_f16c = std::getenv("PROSPER_NO_F16C_SAMPLED") == nullptr &&
+                                 __builtin_cpu_supports("avx2") &&
+                                 __builtin_cpu_supports("f16c");
+#else
+    constexpr bool use_f16c = false;
+#endif
+    parallel_compute_texels(texels, texels * (components * 2u + 4u),
+        [&](size_t begin, size_t end) {
+#if defined(PROSPER_HAVE_TARGET_F16C)
+            if (components == 4 && use_f16c) {
+                sampled_float16x4_to_unorm8_f16c(source, begin, end, rgba, table);
+                return;
+            }
+#endif
+            for (size_t texel = begin; texel < end; ++texel) {
+                for (uint32_t channel = 0; channel < 4; ++channel) {
+                    if (channel >= components) {
+                        rgba[texel * 4 + channel] = channel == 3 ? 255 : 0;
+                        continue;
+                    }
+                    uint16_t half = 0;
+                    std::memcpy(&half,
+                                source + (texel * components + channel) * sizeof(half),
+                                sizeof(half));
+                    rgba[texel * 4 + channel] = table[half];
+                }
+            }
+        });
+}
 
 bool execute_live_compute_items(const std::vector<prosper::gpu::ComputeItem>& items) {
     // Keep the Vulkan device alive across dispatch spans. Constructing an instance, device, and queue for

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -24,6 +24,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <system_error>
 #include <thread>
 #include <tuple>
 #include <unordered_map>
@@ -128,16 +129,29 @@ void parallel_compute_texels(size_t count, size_t work_bytes, Body&& body) {
         return;
     }
     const size_t chunk = (count + threads - 1) / threads;
-    std::vector<std::thread> workers;
+    // jthread makes a partially-created set exception-safe: if the next OS thread cannot be
+    // created, already-started workers are still joined. Finish the unspawned ranges on this
+    // thread so transient resource pressure degrades to less parallelism instead of aborting.
+    std::vector<std::jthread> workers;
     workers.reserve(threads - 1);
-    for (unsigned worker = 1; worker < threads; ++worker) {
-        const size_t begin = static_cast<size_t>(worker) * chunk;
-        const size_t end = std::min(count, begin + chunk);
-        if (begin >= end) break;
-        workers.emplace_back([&body, begin, end] { body(begin, end); });
+    unsigned next_worker = 1;
+    try {
+        for (; next_worker < threads; ++next_worker) {
+            const size_t begin = static_cast<size_t>(next_worker) * chunk;
+            const size_t end = std::min(count, begin + chunk);
+            if (begin >= end) break;
+            workers.emplace_back([&body, begin, end] { body(begin, end); });
+        }
+    } catch (const std::system_error&) {
+        // Fall through: ranges that did not get a worker run synchronously below.
     }
     body(size_t{0}, std::min(count, chunk));
-    for (auto& worker : workers) worker.join();
+    for (; next_worker < threads; ++next_worker) {
+        const size_t begin = static_cast<size_t>(next_worker) * chunk;
+        const size_t end = std::min(count, begin + chunk);
+        if (begin >= end) break;
+        body(begin, end);
+    }
 }
 
 #if defined(PROSPER_HAVE_TARGET_F16C)
@@ -463,6 +477,26 @@ struct VulkanComputeContext {
         return enabled;
     }
 
+    size_t release_available_memory() {
+        if (!device) return 0;
+        std::lock_guard<std::mutex> lock(memory_pool.mutex);
+        size_t released = 0;
+        for (const auto& [key, allocations] : memory_pool.available) {
+            (void)key;
+            for (VkDeviceMemory allocation : allocations) {
+                if (memory_pool.persistent_mappings.erase(allocation))
+                    vkUnmapMemory(device, allocation);
+                vkFreeMemory(device, allocation, nullptr);
+                ++released;
+            }
+        }
+        memory_pool.available.clear();
+        memory_pool.cached_bytes = 0;
+        memory_pool.cached_allocations = 0;
+        memory_pool.discarded += released;
+        return released;
+    }
+
     VkDeviceMemory allocate_memory(VkDeviceSize bytes, uint32_t memory_type,
                                    bool persistently_map = false) {
         if (memory_type == UINT32_MAX) return VK_NULL_HANDLE;
@@ -518,8 +552,19 @@ struct VulkanComputeContext {
         allocation.allocationSize = bytes;
         allocation.memoryTypeIndex = memory_type;
         VkDeviceMemory result = VK_NULL_HANDLE;
-        if (vkAllocateMemory(device, &allocation, nullptr, &result) != VK_SUCCESS)
-            return VK_NULL_HANDLE;
+        VkResult allocation_result = vkAllocateMemory(device, &allocation, nullptr, &result);
+        if (allocation_result != VK_SUCCESS && compute_memory_pool_enabled()) {
+            // Cached allocations are expendable. Under real heap pressure, release them before
+            // propagating OOM so an enlarged reuse cache can never strand memory needed now.
+            const size_t released = release_available_memory();
+            if (released) {
+                fprintf(stderr,
+                        "[compute] allocation failed (%d); evicted %zu cached allocation(s) and retrying\n",
+                        static_cast<int>(allocation_result), released);
+                allocation_result = vkAllocateMemory(device, &allocation, nullptr, &result);
+            }
+        }
+        if (allocation_result != VK_SUCCESS) return VK_NULL_HANDLE;
         if (compute_memory_pool_enabled()) {
             std::lock_guard<std::mutex> lock(memory_pool.mutex);
             memory_pool.active.emplace(result, key);

--- a/prosper/frontends/shared/live_compute.hpp
+++ b/prosper/frontends/shared/live_compute.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "gpu/gpu_execute.hpp"
 
+#include <cstddef>
 #include <cstdint>
 #include <vector>
 
@@ -9,6 +10,27 @@ namespace prosper::frontend {
 // Pack one raw float32 channel to UNORM8 using the storage-image conversion contract. Kept public
 // so the optimized scalar conversion can be checked directly against the previous lround path.
 uint8_t storage_pack_unorm8(uint32_t float_bits);
+void storage_pack_unorm8_range(const uint32_t* channels, uint32_t components,
+                               size_t texels, uint8_t* packed);
+
+// Hot storage/sampled-image conversions. These retain the scalar reference semantics while using
+// exhaustive binary16 lookup tables or exact runtime-dispatched vector paths in production loops.
+uint32_t storage_unpack_float16_bits(uint16_t half_bits);
+// Expand tightly-strided RGBA16F to RGBA32F channel bits. The F16C path repairs signaling-NaN
+// payloads so every output bit remains identical to half_to_float.
+void storage_unpack_float16x4_range(const uint8_t* rgba16f, size_t texels, uint32_t* channels);
+uint8_t sampled_float16_to_unorm8(uint16_t half_bits);
+void sampled_float16_to_unorm8_range(const uint8_t* source, uint32_t components,
+                                     size_t texels, uint8_t* rgba);
+// Pack tightly-strided RGBA32F channel bits to RGBA16F. Uses a runtime-dispatched F16C path where
+// available and preserves float_to_half's exact NaN payload/rounding contract.
+void storage_pack_float16x4_range(const uint32_t* channels, size_t texels, uint8_t* rgba16f);
+
+// Whether a sampled guest view can bind a renderer-owned target without a CPU readback/conversion.
+// The formats must describe the same Vulkan texels exactly; aliases or numeric conversions fall back
+// to the snapshot upload path.
+bool direct_sampled_rtt_compatible(prosper::gpu::DataFormat format, uint32_t components,
+                                   prosper::gpu::LiveTargetPixelFormat target_format);
 
 // Execute already-realized compute items synchronously. Exposed for the production-backend test.
 bool execute_live_compute_items(const std::vector<prosper::gpu::ComputeItem>& items);

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -1817,17 +1817,11 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             } else {
                                 copy_resource(hlin.data(), r.gpu_addr, hlin.size());
                             }
-                            for (size_t t = 0; t < volume_texels; t++) {
-                                uint8_t* p = &texture_pixels[t * 4];
-                                for (uint32_t c = 0; c < 4; c++) {
-                                    if (c < nc) {
-                                        uint16_t hv; std::memcpy(&hv, &hlin[t * bpt + c * 2], 2);
-                                        float f = prosper::gpu::half_to_float(hv);
-                                        p[c] = (f != f || f <= 0.f) ? 0                     // NaN/neg -> 0
-                                             : (f >= 1.f ? 255 : (uint8_t)(f * 255.f + 0.5f));
-                                    } else p[c] = (c == 3) ? 255 : 0;       // absent: (.,0,0,1)
-                                }
-                            }
+                            // Same NaN/negative/positive-infinity clamp and absent-channel defaults
+                            // as the historical scalar loop, exhaustively checked over all binary16
+                            // inputs by test_game_compute. Large dynamic textures convert in parallel.
+                            sampled_float16_to_unorm8_range(
+                                hlin.data(), nc, volume_texels, texture_pixels.data());
                             f16_done = true;   // read+detiled at the real element size already
                         } else if (bpt < 4) {
                             // Narrow (single/dual-channel) surface: read at the REAL element size and detile
@@ -2649,6 +2643,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 return g.empty() ? nullptr : g.front()->ps.clear_color;
             };
             std::shared_ptr<const std::vector<uint8_t>> selected_pixels;
+            bool published_gpu = false;
             if (pertarget) {
                 // PER-TARGET RTT: a real frame is a sequence of passes, each rendering into a specific
                 // color target (CB_COLOR0_BASE), and a final composite pass SAMPLES the earlier targets.
@@ -3596,7 +3591,6 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 // through to the CPU readback below, which still publishes a CPU frame; prosper-app
                 // presents that CPU frame when no GPU frame was published (main.cpp), so a miss degrades to
                 // the CPU present path rather than freezing the window.
-                bool published_gpu = false;
                 if (front >= 0 && prosper::gpu::gpu_present_active()) {
                     const uint64_t front_va = prosper_vo_buffer_addr(front);
                     auto rit = g_rtt.find(front_va);
@@ -3674,7 +3668,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                                 return e ? (int)atol(e) : 0; }();
             size_t px_nz = 0;
             if (dump_bmps || nzlog_every) for (uint8_t b : px) px_nz += (b != 0);
-            if (px.empty()) {
+            if (px.empty() && !published_gpu) {
                 fprintf(stderr, "[render] frame %d: Vulkan render FAILED (%ux%u)\n", n, w, h);
             } else if (dump_bmps && ((content_thr && px_nz >= content_thr) || (!content_thr && (n < 60 || n % 10 == 0)))) {
                 char fn[512]; snprintf(fn, sizeof fn, "%s/frame_%04d.bmp", frame_dir.c_str(), n);

--- a/prosper/src/gpu/tile.cpp
+++ b/prosper/src/gpu/tile.cpp
@@ -11,6 +11,12 @@
 #include <thread>
 #include <vector>
 
+#if (defined(__x86_64__) || defined(__i386__)) && \
+    (defined(__GNUC__) || defined(__clang__))
+#include <immintrin.h>
+#define PROSPER_HAVE_TARGET_AVX2 1
+#endif
+
 namespace prosper::gpu {
 
 size_t linear_sampled_row_pitch(uint32_t width, uint32_t bytes_per_texel) {
@@ -398,7 +404,8 @@ size_t sw64kb_tiled_bytes(uint32_t ew, uint32_t eh, uint32_t pitch, uint32_t bpe
 // threads is race-free. Uses per-call std::thread (not a pool): this gates on large surfaces where the
 // spawn cost is amortized by the 4K detile work, and it avoids any pool-reuse synchronization hazard.
 // Small surfaces and PROSPER_DETILE_SINGLE_THREADED / PROSPER_DETILE_THREADS=1 stay single-threaded;
-// detiling is memory-bandwidth-bound, so the auto thread count is capped low (~8).
+// detiling is memory-bandwidth-bound, so the auto thread count is capped at 16. Astro Bot's 4K
+// surfaces improve from 8 to 16 workers on a 16-core Strix Halo, while 32 regresses.
 inline unsigned detile_row_threads(size_t work_bytes, uint32_t eh) {
     static const int env = [] {
         const char* s = getenv("PROSPER_DETILE_THREADS");
@@ -409,7 +416,7 @@ inline unsigned detile_row_threads(size_t work_bytes, uint32_t eh) {
     if (work_bytes < (size_t)512 * 1024) return 1u;            // small surface: spawn not worth it
     const unsigned hw = std::thread::hardware_concurrency();
     const unsigned want = env > 1 ? std::min((unsigned)env, 32u)   // clamp an over-large override
-                                  : std::min(hw ? hw : 4u, 8u);    // memory-bound -> cap ~8
+                                  : std::min(hw ? hw : 4u, 16u);   // memory-bound -> cap at 16
     const unsigned by_rows = eh / 32u;                             // keep >= 32 rows per thread
     return std::max(1u, std::min(want, by_rows));
 }
@@ -420,16 +427,105 @@ template <class Body>
 inline void parallel_rows(uint32_t eh, unsigned nthreads, Body&& body) {
     if (nthreads <= 1 || eh == 0) { if (eh) body(0u, eh); return; }
     const uint32_t chunk = (eh + nthreads - 1) / nthreads;
-    std::vector<std::thread> ts;
-    ts.reserve(nthreads - 1);
-    for (unsigned i = 1; i < nthreads; i++) {
-        const uint32_t b = i * chunk, e = std::min(eh, b + chunk);
-        if (b >= e) break;
-        ts.emplace_back([&body, b, e] { body(b, e); });
+    std::vector<std::thread> workers;
+    workers.reserve(nthreads - 1);
+    for (unsigned worker = 1; worker < nthreads; ++worker) {
+        const uint32_t begin = worker * chunk;
+        const uint32_t end = std::min(eh, begin + chunk);
+        if (begin >= end) break;
+        workers.emplace_back([&body, begin, end] { body(begin, end); });
     }
-    body(0u, std::min(eh, chunk));   // the calling thread runs chunk 0
-    for (auto& t : ts) t.join();
+    body(0u, std::min(eh, chunk));
+    for (auto& worker : workers) worker.join();
 }
+
+inline void copy_swizzled_element(uint8_t* dst, const uint8_t* src, uint32_t bpe) {
+    switch (bpe) {
+        case 1: *dst = *src; break;
+        case 2: std::memcpy(dst, src, 2); break;
+        case 4: std::memcpy(dst, src, 4); break;
+        case 8: std::memcpy(dst, src, 8); break;
+        case 16: std::memcpy(dst, src, 16); break;
+        default: std::memcpy(dst, src, bpe); break;
+    }
+}
+
+inline void zero_swizzled_element(uint8_t* dst, uint32_t bpe) {
+    switch (bpe) {
+        case 1: *dst = 0; break;
+        case 2: std::memset(dst, 0, 2); break;
+        case 4: std::memset(dst, 0, 4); break;
+        case 8: std::memset(dst, 0, 8); break;
+        case 16: std::memset(dst, 0, 16); break;
+        default: std::memset(dst, 0, bpe); break;
+    }
+}
+
+#if defined(PROSPER_HAVE_TARGET_AVX2)
+// A complete 64KB block has no per-element bounds failures. For the dominant element sizes, gather
+// precomputed swizzle offsets and write one contiguous linear span at a time. The low x bit maps to
+// the first address bit above elemLog2 in every supported pattern, so aligned 2/4-byte texel pairs
+// are adjacent in tiled memory and can share one 4/8-byte gather lane. Astro Bot moves about 3.7 GiB
+// of 8-byte, 2.5 GiB of 4-byte, and 580 MiB of 2-byte elements through this path in 120 frames.
+__attribute__((target("avx2")))
+void detile_full_block_row_avx2(uint8_t* dst, const uint8_t* tiled_block,
+                                const uint16_t* x_offsets, uint16_t y_offset,
+                                uint32_t columns, uint32_t bpe) {
+    uint32_t x = 0;
+    const __m128i y = _mm_set1_epi16(static_cast<int16_t>(y_offset));
+    static const bool paired_gathers =
+        std::getenv("PROSPER_NO_PAIRED_AVX2_DETILE") == nullptr;
+    const __m128i even_offsets = _mm_setr_epi8(
+        0, 1, 4, 5, 8, 9, 12, 13, -1, -1, -1, -1, -1, -1, -1, -1);
+    if (bpe == 2 && paired_gathers) {
+        for (; x + 8 <= columns; x += 8) {
+            const __m128i offsets16 = _mm_xor_si128(
+                _mm_loadu_si128(reinterpret_cast<const __m128i*>(x_offsets + x)), y);
+            const __m128i pair_offsets16 = _mm_shuffle_epi8(offsets16, even_offsets);
+            const __m128i pair_offsets32 = _mm_cvtepu16_epi32(pair_offsets16);
+            const __m128i values = _mm_i32gather_epi32(
+                reinterpret_cast<const int*>(tiled_block), pair_offsets32, 1);
+            _mm_storeu_si128(reinterpret_cast<__m128i*>(dst + static_cast<size_t>(x) * 2),
+                             values);
+        }
+    } else if (bpe == 4 && paired_gathers) {
+        for (; x + 8 <= columns; x += 8) {
+            const __m128i offsets16 = _mm_xor_si128(
+                _mm_loadu_si128(reinterpret_cast<const __m128i*>(x_offsets + x)), y);
+            const __m128i pair_offsets16 = _mm_shuffle_epi8(offsets16, even_offsets);
+            const __m256i pair_offsets64 = _mm256_cvtepu16_epi64(pair_offsets16);
+            const __m256i values = _mm256_i64gather_epi64(
+                reinterpret_cast<const long long*>(tiled_block), pair_offsets64, 1);
+            _mm256_storeu_si256(reinterpret_cast<__m256i*>(dst + static_cast<size_t>(x) * 4),
+                                values);
+        }
+    } else if (bpe == 4) {
+        for (; x + 8 <= columns; x += 8) {
+            const __m128i offsets16 = _mm_xor_si128(
+                _mm_loadu_si128(reinterpret_cast<const __m128i*>(x_offsets + x)), y);
+            const __m256i offsets32 = _mm256_cvtepu16_epi32(offsets16);
+            const __m256i values = _mm256_i32gather_epi32(
+                reinterpret_cast<const int*>(tiled_block), offsets32, 1);
+            _mm256_storeu_si256(reinterpret_cast<__m256i*>(dst + static_cast<size_t>(x) * 4),
+                                values);
+        }
+    } else if (bpe == 8) {
+        for (; x + 4 <= columns; x += 4) {
+            const __m128i offsets16 = _mm_xor_si128(
+                _mm_loadl_epi64(reinterpret_cast<const __m128i*>(x_offsets + x)), y);
+            const __m256i offsets64 = _mm256_cvtepu16_epi64(offsets16);
+            const __m256i values = _mm256_i64gather_epi64(
+                reinterpret_cast<const long long*>(tiled_block), offsets64, 1);
+            _mm256_storeu_si256(reinterpret_cast<__m256i*>(dst + static_cast<size_t>(x) * 8),
+                                values);
+        }
+    }
+    for (; x < columns; ++x)
+        copy_swizzled_element(dst + static_cast<size_t>(x) * bpe,
+                              tiled_block + (x_offsets[x] ^ y_offset), bpe);
+}
+
+#endif
 
 // The 64KB tiled<->linear walk. The pattern offset is XOR-separable in x and y (each offset bit is
 // parity(x&xm)^parity(y&ym)), so precompute fx[] / fy[] per coordinate and each element's in-block
@@ -441,10 +537,9 @@ void sw64kb_copy(uint8_t* dst, const uint8_t* src, uint32_t ew, uint32_t eh, uin
                  uint32_t bpe, size_t tiled_bytes, uint32_t tile_mode,
                  size_t tiled_origin = 0) {
     uint32_t el = sw64kb_elem_log2(bpe);
-    if (el == UINT32_MAX) {                                    // unsupported bpe -> straight copy
-        size_t n = (size_t)ew * eh * bpe;
-        if (ToTiled) std::memcpy(dst, src, std::min(n, tiled_bytes));
-        else         std::memcpy(dst, src, std::min(n, tiled_bytes));
+    if (el == UINT32_MAX) {
+        const size_t n = (size_t)ew * eh * bpe;
+        std::memcpy(dst, src, std::min(n, tiled_bytes));
         return;
     }
     uint32_t bw = 0, bh = 0; sw64kb_dims(el, bw, bh);
@@ -462,6 +557,89 @@ void sw64kb_copy(uint8_t* dst, const uint8_t* src, uint32_t ew, uint32_t eh, uin
         for (uint32_t i = el; i < 16; i++) v |= (uint32_t)(__builtin_popcount(y & pat[i].y) & 1) << i;
         fy[y] = (uint16_t)v;
     }
+    // Detiling in linear row order revisits every 64KB source block once per output row. A 4K
+    // RGBA16F surface has thirty-four block columns, so that walk cycles through more than 2 MiB
+    // before returning to the next few bytes of any block. Finish one 64KB block at a time instead:
+    // source reads then remain cache-local while each output row still receives a contiguous span.
+    // Split on whole block rows so workers write disjoint output rows and cannot false-share. The
+    // same order also lowers the CPU cost of guest writeback; either direction can be restored to
+    // the older row-major walk independently for diagnosis.
+    static const bool row_major_detile = std::getenv("PROSPER_DETILE_ROW_MAJOR") != nullptr;
+    static const bool row_major_tile = std::getenv("PROSPER_TILE_ROW_MAJOR") != nullptr;
+    if ((!ToTiled && !row_major_detile) || (ToTiled && !row_major_tile)) {
+#if defined(PROSPER_HAVE_TARGET_AVX2)
+        static const bool use_avx2_gather =
+            std::getenv("PROSPER_NO_AVX2_DETILE") == nullptr &&
+            __builtin_cpu_supports("avx2");
+#endif
+            const uint32_t surface_block_rows = (eh + bh - 1) / bh;
+            const uint32_t surface_block_cols = (ew + bw - 1) / bw;
+            static const bool paired_copy =
+                std::getenv("PROSPER_NO_PAIRED_TILE_COPY") == nullptr;
+            auto process_block_rows = [&](uint32_t block_row0, uint32_t block_row1) {
+                for (uint32_t block_y = block_row0; block_y < block_row1; ++block_y) {
+                    const uint32_t y0 = block_y * bh;
+                    const uint32_t rows = std::min(bh, eh - y0);
+                    for (uint32_t block_x = 0; block_x < surface_block_cols; ++block_x) {
+                        const uint32_t x0 = block_x * bw;
+                        const uint32_t columns = std::min(bw, ew - x0);
+                        const uint64_t block =
+                            static_cast<uint64_t>(block_y) * blocks_per_row + block_x;
+                        const uint64_t block_base = tiled_origin + (block << 16);
+                        const bool full_block = block_base <= tiled_bytes &&
+                            tiled_bytes - static_cast<size_t>(block_base) >= 65536u;
+                        for (uint32_t iy = 0; iy < rows; ++iy) {
+                            const uint32_t y = y0 + iy;
+                            const uint16_t y_offset = fy[y];
+                            uint8_t* linear = nullptr;
+                            if constexpr (!ToTiled)
+                                linear = dst + (static_cast<size_t>(y) * ew + x0) * bpe;
+#if defined(PROSPER_HAVE_TARGET_AVX2)
+                            if constexpr (!ToTiled) {
+                                if (full_block && (bpe == 2 || bpe == 4 || bpe == 8)) {
+                                    if (use_avx2_gather) {
+                                        detile_full_block_row_avx2(linear, src + block_base,
+                                                                  fx.data() + x0, y_offset,
+                                                                  columns, bpe);
+                                        continue;
+                                    }
+                                }
+                            }
+#endif
+                            for (uint32_t ix = 0; ix < columns;) {
+                                const uint64_t tiled = block_base + (fx[x0 + ix] ^ y_offset);
+                                // Up through 8-byte elements, x0 is the first swizzle bit above the
+                                // byte-within-element bits. Since block x origins and ix are even,
+                                // the next texel immediately follows this one in both layouts.
+                                const uint32_t run = paired_copy && bpe <= 8 && ix + 1 < columns
+                                    ? 2u : 1u;
+                                const uint32_t bytes = run * bpe;
+                                if constexpr (ToTiled) {
+                                    if (full_block || tiled + bytes <= tiled_bytes)
+                                        copy_swizzled_element(dst + tiled,
+                                                              src + (static_cast<size_t>(y) * ew +
+                                                                     x0 + ix) * bpe,
+                                                              bytes);
+                                } else {
+                                    if (full_block || tiled + bytes <= tiled_bytes)
+                                        copy_swizzled_element(
+                                            linear + static_cast<size_t>(ix) * bpe,
+                                            src + tiled, bytes);
+                                    else
+                                        zero_swizzled_element(
+                                            linear + static_cast<size_t>(ix) * bpe, bytes);
+                                }
+                                ix += run;
+                            }
+                        }
+                    }
+                }
+            };
+            const unsigned threads = std::min(
+                detile_row_threads((size_t)ew * eh * bpe, eh), surface_block_rows);
+            parallel_rows(surface_block_rows, threads, process_block_rows);
+            return;
+    }
     auto process_rows = [&](uint32_t y0, uint32_t y1) {
         for (uint32_t y = y0; y < y1; y++) {
             uint64_t brow = (uint64_t)(y / bh) * blocks_per_row;
@@ -469,9 +647,15 @@ void sw64kb_copy(uint8_t* dst, const uint8_t* src, uint32_t ew, uint32_t eh, uin
                 uint64_t t = tiled_origin +
                              (((brow + x / bw) << 16) | (uint32_t)(fx[x] ^ fy[y]));
                 size_t   l = ((size_t)y * ew + x) * bpe;
-                if (ToTiled) { if (t + bpe <= tiled_bytes) std::memcpy(dst + t, src + l, bpe); }
-                else         { if (t + bpe <= tiled_bytes) std::memcpy(dst + l, src + t, bpe);
-                               else                        std::memset(dst + l, 0, bpe); }
+                if (ToTiled) {
+                    if (t + bpe <= tiled_bytes)
+                        copy_swizzled_element(dst + t, src + l, bpe);
+                } else {
+                    if (t + bpe <= tiled_bytes)
+                        copy_swizzled_element(dst + l, src + t, bpe);
+                    else
+                        zero_swizzled_element(dst + l, bpe);
+                }
             }
         }
     };

--- a/prosper/src/gpu/tile.cpp
+++ b/prosper/src/gpu/tile.cpp
@@ -9,6 +9,7 @@
 #include <mutex>
 #include <set>
 #include <thread>
+#include <system_error>
 #include <vector>
 
 #if (defined(__x86_64__) || defined(__i386__)) && \
@@ -427,16 +428,28 @@ template <class Body>
 inline void parallel_rows(uint32_t eh, unsigned nthreads, Body&& body) {
     if (nthreads <= 1 || eh == 0) { if (eh) body(0u, eh); return; }
     const uint32_t chunk = (eh + nthreads - 1) / nthreads;
-    std::vector<std::thread> workers;
+    // Auto-joining workers keep a partially-created set safe when the OS refuses another thread.
+    // Any ranges that could not get a worker are completed synchronously below.
+    std::vector<std::jthread> workers;
     workers.reserve(nthreads - 1);
-    for (unsigned worker = 1; worker < nthreads; ++worker) {
-        const uint32_t begin = worker * chunk;
-        const uint32_t end = std::min(eh, begin + chunk);
-        if (begin >= end) break;
-        workers.emplace_back([&body, begin, end] { body(begin, end); });
+    unsigned next_worker = 1;
+    try {
+        for (; next_worker < nthreads; ++next_worker) {
+            const uint32_t begin = next_worker * chunk;
+            const uint32_t end = std::min(eh, begin + chunk);
+            if (begin >= end) break;
+            workers.emplace_back([&body, begin, end] { body(begin, end); });
+        }
+    } catch (const std::system_error&) {
+        // Fall through: ranges that did not get a worker run synchronously below.
     }
     body(0u, std::min(eh, chunk));
-    for (auto& worker : workers) worker.join();
+    for (; next_worker < nthreads; ++next_worker) {
+        const uint32_t begin = next_worker * chunk;
+        const uint32_t end = std::min(eh, begin + chunk);
+        if (begin >= end) break;
+        body(begin, end);
+    }
 }
 
 inline void copy_swizzled_element(uint8_t* dst, const uint8_t* src, uint32_t bpe) {
@@ -611,17 +624,27 @@ void sw64kb_copy(uint8_t* dst, const uint8_t* src, uint32_t ew, uint32_t eh, uin
                                 // Up through 8-byte elements, x0 is the first swizzle bit above the
                                 // byte-within-element bits. Since block x origins and ix are even,
                                 // the next texel immediately follows this one in both layouts.
-                                const uint32_t run = paired_copy && bpe <= 8 && ix + 1 < columns
+                                uint32_t run = paired_copy && bpe <= 8 && ix + 1 < columns
                                     ? 2u : 1u;
-                                const uint32_t bytes = run * bpe;
+                                uint32_t bytes = run * bpe;
+                                // A bounded source can end between otherwise-adjacent texels. Keep
+                                // the first valid element instead of rejecting/zeroing the whole pair;
+                                // the next loop iteration handles the truncated neighbor separately.
+                                if (!full_block && run == 2 &&
+                                    (tiled > tiled_bytes || bytes > tiled_bytes - tiled)) {
+                                    run = 1;
+                                    bytes = bpe;
+                                }
                                 if constexpr (ToTiled) {
-                                    if (full_block || tiled + bytes <= tiled_bytes)
+                                    if (full_block ||
+                                        (tiled <= tiled_bytes && bytes <= tiled_bytes - tiled))
                                         copy_swizzled_element(dst + tiled,
                                                               src + (static_cast<size_t>(y) * ew +
                                                                      x0 + ix) * bpe,
                                                               bytes);
                                 } else {
-                                    if (full_block || tiled + bytes <= tiled_bytes)
+                                    if (full_block ||
+                                        (tiled <= tiled_bytes && bytes <= tiled_bytes - tiled))
                                         copy_swizzled_element(
                                             linear + static_cast<size_t>(ix) * bpe,
                                             src + tiled, bytes);

--- a/prosper/tests/test_game_compute.cpp
+++ b/prosper/tests/test_game_compute.cpp
@@ -21,6 +21,124 @@ static int fails = 0;
 #define CHECK(c, msg) do { if (!(c)) { std::printf("FAIL: %s\n", msg); fails++; } } while (0)
 
 int main() {
+    bool half_luts_match = true;
+    for (uint32_t bits = 0; bits <= 0xffffu; ++bits) {
+        const uint16_t half = static_cast<uint16_t>(bits);
+        const float value = half_to_float(half);
+        uint32_t float_bits = 0;
+        std::memcpy(&float_bits, &value, sizeof(float_bits));
+        half_luts_match &= prosper::frontend::storage_unpack_float16_bits(half) == float_bits;
+
+        float normalized = value;
+        if (std::isnan(normalized)) normalized = 0.0f;
+        normalized = normalized < 0.0f ? 0.0f : (normalized > 1.0f ? 1.0f : normalized);
+        const uint8_t reference = static_cast<uint8_t>(std::lround(normalized * 255.0f));
+        half_luts_match &= prosper::frontend::sampled_float16_to_unorm8(half) == reference;
+    }
+    CHECK(half_luts_match,
+          "binary16 lookup conversions are exhaustive bit-exact matches for storage and sampling");
+
+    std::vector<uint8_t> half_source(65536u * sizeof(uint16_t));
+    std::vector<uint8_t> half_rgba(65536u * 4u);
+    for (uint32_t bits = 0; bits <= 0xffffu; ++bits) {
+        const uint16_t half = static_cast<uint16_t>(bits);
+        std::memcpy(half_source.data() + bits * sizeof(half), &half, sizeof(half));
+    }
+    prosper::frontend::sampled_float16_to_unorm8_range(
+        half_source.data(), 1, 65536u, half_rgba.data());
+    bool half_range_matches = true;
+    for (uint32_t bits = 0; bits <= 0xffffu; ++bits) {
+        half_range_matches &=
+            half_rgba[bits * 4] == prosper::frontend::sampled_float16_to_unorm8(
+                                       static_cast<uint16_t>(bits)) &&
+            half_rgba[bits * 4 + 1] == 0 && half_rgba[bits * 4 + 2] == 0 &&
+            half_rgba[bits * 4 + 3] == 255;
+    }
+    CHECK(half_range_matches,
+          "parallel binary16 sampled range matches every scalar value and fills (R,0,0,1)");
+
+    // Exercise the packed RGBA fast path with every binary16 bit pattern. On x86 this runtime-
+    // dispatches through F16C/AVX2 when available; elsewhere it proves the identical scalar fallback.
+    std::vector<uint8_t> half_source_x4(65536u * sizeof(uint16_t));
+    std::vector<uint8_t> half_rgba_x4(65536u);
+    for (uint32_t bits = 0; bits <= 0xffffu; ++bits) {
+        const uint16_t half = static_cast<uint16_t>(bits);
+        std::memcpy(half_source_x4.data() + bits * sizeof(half), &half, sizeof(half));
+    }
+    prosper::frontend::sampled_float16_to_unorm8_range(
+        half_source_x4.data(), 4, 65536u / 4u, half_rgba_x4.data());
+    bool half_range_x4_matches = true;
+    for (uint32_t bits = 0; bits <= 0xffffu; ++bits)
+        half_range_x4_matches &= half_rgba_x4[bits] ==
+            prosper::frontend::sampled_float16_to_unorm8(static_cast<uint16_t>(bits));
+    CHECK(half_range_x4_matches,
+          "packed RGBA binary16 sampled range matches every scalar lookup value");
+
+    std::vector<uint32_t> half_storage_x4(65536u);
+    prosper::frontend::storage_unpack_float16x4_range(
+        half_source_x4.data(), 65536u / 4u, half_storage_x4.data());
+    bool half_storage_x4_matches = true;
+    for (uint32_t bits = 0; bits <= 0xffffu; ++bits)
+        half_storage_x4_matches &= half_storage_x4[bits] ==
+            prosper::frontend::storage_unpack_float16_bits(static_cast<uint16_t>(bits));
+    CHECK(half_storage_x4_matches,
+          "packed RGBA16F storage range preserves every scalar float bit pattern");
+
+    // The storage writeback fast path converts two RGBA32F texels per F16C instruction. Compare a
+    // million deterministic float bit patterns, including explicit overflow/subnormal/NaN payload
+    // edges, against the established scalar round-to-nearest-even converter.
+    constexpr size_t pack_channels_count = 1u << 20;
+    std::vector<uint32_t> pack_channels(pack_channels_count);
+    const uint32_t pack_edges[] = {
+        0x00000000u, 0x80000000u, 0x00000001u, 0x80000001u,
+        0x33000000u, 0x33000001u, 0x387fc000u, 0x38800000u,
+        0x477fe000u, 0x477ff000u, 0x47800000u, 0xc7800000u,
+        0x7f800000u, 0xff800000u, 0x7fc00000u, 0x7f800001u,
+        0x7fffffffu, 0xff800001u, 0x3f800000u, 0xbf800000u,
+    };
+    size_t pack_at = 0;
+    for (uint32_t bits : pack_edges) pack_channels[pack_at++] = bits;
+    uint32_t pack_random = 0x91e10da5u;
+    while (pack_at < pack_channels.size()) {
+        pack_random ^= pack_random << 13;
+        pack_random ^= pack_random >> 17;
+        pack_random ^= pack_random << 5;
+        pack_channels[pack_at++] = pack_random;
+    }
+    std::vector<uint8_t> packed_half(pack_channels_count * sizeof(uint16_t));
+    prosper::frontend::storage_pack_float16x4_range(
+        pack_channels.data(), pack_channels_count / 4, packed_half.data());
+    bool storage_half_range_matches = true;
+    for (size_t i = 0; i < pack_channels.size(); ++i) {
+        float value;
+        std::memcpy(&value, &pack_channels[i], sizeof(value));
+        const uint16_t expected = prosper::gpu::float_to_half(value);
+        uint16_t actual = 0;
+        std::memcpy(&actual, packed_half.data() + i * sizeof(actual), sizeof(actual));
+        if (actual != expected) {
+            std::printf("Float16 pack mismatch index=%zu f32=%08x expected=%04x actual=%04x\n",
+                        i, pack_channels[i], expected, actual);
+            storage_half_range_matches = false;
+            break;
+        }
+    }
+    CHECK(storage_half_range_matches,
+          "packed RGBA32F storage range matches scalar Float16 rounding and NaN payloads");
+
+    using prosper::frontend::direct_sampled_rtt_compatible;
+    CHECK(direct_sampled_rtt_compatible(DataFormat::Unorm8, 4,
+                                        LiveTargetPixelFormat::Rgba8Unorm) &&
+          direct_sampled_rtt_compatible(DataFormat::Float16, 4,
+                                        LiveTargetPixelFormat::Rgba16Float),
+          "renderer RTT direct bind accepts exact RGBA8 and RGBA16F sampled views");
+    CHECK(!direct_sampled_rtt_compatible(DataFormat::Float16, 4,
+                                         LiveTargetPixelFormat::Rgba8Unorm) &&
+          !direct_sampled_rtt_compatible(DataFormat::Unorm8, 4,
+                                         LiveTargetPixelFormat::Rgba16Float) &&
+          !direct_sampled_rtt_compatible(DataFormat::Float16, 2,
+                                         LiveTargetPixelFormat::Rgba16Float),
+          "renderer RTT direct bind rejects format conversion and component aliases");
+
     // #1127: the seed-skip re-prove counter (seed_reprove.hpp). interval 0 disables (old prove-once);
     // interval N fires on the Nth fast-skip and resets, so a Full-cached data-dependent shader is
     // re-proven within N fast-skips instead of trusting a stale "covers every texel" verdict forever.
@@ -96,6 +214,32 @@ int main() {
         }
     }
     CHECK(unorm8_matches, "fast UNORM8 pack is equivalent to the lround reference");
+
+    bool storage_unorm8_range_matches = true;
+    constexpr size_t unorm_texels = pack_channels_count / 4;
+    for (uint32_t components : {1u, 2u, 3u, 4u}) {
+        std::vector<uint8_t> packed_unorm8(unorm_texels * components);
+        prosper::frontend::storage_pack_unorm8_range(
+            pack_channels.data(), components, unorm_texels, packed_unorm8.data());
+        for (size_t texel = 0; texel < unorm_texels; ++texel) {
+            for (uint32_t channel = 0; channel < components; ++channel) {
+                const size_t source = texel * 4 + channel;
+                const uint8_t expected =
+                    prosper::frontend::storage_pack_unorm8(pack_channels[source]);
+                const uint8_t actual = packed_unorm8[texel * components + channel];
+                if (actual == expected) continue;
+                std::printf("UNORM8 pack mismatch n=%u texel=%zu channel=%u f32=%08x "
+                            "expected=%02x actual=%02x\n",
+                            components, texel, channel, pack_channels[source], expected, actual);
+                storage_unorm8_range_matches = false;
+                break;
+            }
+            if (!storage_unorm8_range_matches) break;
+        }
+        if (!storage_unorm8_range_matches) break;
+    }
+    CHECK(storage_unorm8_range_matches,
+          "packed one-, two-, three-, and four-channel UNORM8 ranges match scalar clamp and rounding");
 
     // Dead Cells' bound startup fill kernel, copied verbatim from eboot.elf at runtime address
     // 0x401aec200. It stores s4-s7 to record `(TGID_X << 6) + local_id_x` through the V# in s0-s3.

--- a/prosper/tests/test_tile.cpp
+++ b/prosper/tests/test_tile.cpp
@@ -487,6 +487,32 @@ int main() {
         CHECK(rt64(S, 3840, 2160, 4), "SW_64KB_S round-trip 3840x2160 @ 4 B (row-parallel, native 4K)");
     }
 
+    // Bounded SW_64KB reads may end between a pair of adjacent texels. The paired fast path must
+    // preserve the first complete texel and zero only the truncated neighbor, exactly like the
+    // original per-element walk. A cutoff after texel (0,0) exercises this edge for every paired
+    // element size.
+    {
+        const uint32_t M = (uint32_t)TileMode::Sw64KbS;
+        bool split_pair_matches = true;
+        for (uint32_t bpe : {1u, 2u, 4u, 8u}) {
+            const uint32_t ew = 128, eh = 64;
+            std::vector<uint8_t> linear((size_t)ew * eh * bpe);
+            for (size_t i = 0; i < linear.size(); ++i)
+                linear[i] = static_cast<uint8_t>(0x31u + i * 17u);
+            std::vector<uint8_t> tiled(tiled_elements_bytes(ew, eh, bpe, M), 0);
+            tile_surface(tiled.data(), linear.data(), ew, eh, M, 0, bpe);
+
+            std::vector<uint8_t> actual(linear.size(), 0xcc);
+            detile_elements(actual.data(), tiled.data(), bpe, ew, eh, bpe, M);
+            split_pair_matches &=
+                std::memcmp(actual.data(), linear.data(), bpe) == 0 &&
+                std::all_of(actual.begin() + bpe, actual.end(),
+                            [](uint8_t value) { return value == 0; });
+        }
+        CHECK(split_pair_matches,
+              "64KB bounded detile preserves a complete texel when its paired neighbor is truncated");
+    }
+
     // AMD AddrLib GFX10_SW_64K_Z_X_1xaa golden, 16 pipes, 4 bpe. The selected pattern is
     // nibble01[10] + nibble2[74] + nibble3[31]: low Morton pairs, four pipe-XOR bits, then
     // y3/x4/y6/x6. These independent positions pin both the Z order and the pipe rotation used


### PR DESCRIPTION
## Goal

Reduce the host-side image and presentation cost exposed by Astro Bot's opening sequence. This is a throughput increment, not a compatibility-complete claim: the title screen is reached, but the FMV still advances at roughly 2 distinct frames/s on this machine and the visible checkerboard/flashing defect remains.

## What changed

- Prefer the renderer's shared Vulkan device for real-game presentation, retaining the private-device CPU fallback and an explicit `PROSPER_APP_GPU_PRESENT=0` recovery switch.
- Bind exact renderer-owned RGBA8 and RGBA16F sampled targets in place instead of GPU-to-CPU conversion followed by CPU-to-GPU upload.
- Write storage/sampled conversions directly into persistently mapped Vulkan staging allocations.
- Add exact runtime-dispatched AVX2/F16C conversion paths with exhaustive binary16 and deterministic float32/UNORM8 equivalence coverage.
- Process large conversions and 64 KiB tiled surfaces in bounded parallel chunks.
- Use block-major tiled copies, AVX2 gathers for the dominant 2/4/8-byte texels, and paired adjacent copies where the swizzle contract permits them.
- Reuse descriptor pools and best-fit Vulkan memory allocations. The default compute cache is bounded at 640 MiB (the measured Astro Bot opening working set); existing environment switches retain scalar, row-major, exact-size, nonpersistent, and CPU-present diagnostic fallbacks.
- Avoid redundant linear copies and avoid reporting a GPU-published frame as an empty CPU-render failure.

## Review hardening

Exact corrected head: `8a7eaf5f429370fa1273a9cb76e060536a0e77b0`

- Check GPU and CPU present queue submissions; never present after a failed submit, release the acquired scanout slot, and replace unusable present synchronization before retrying or stop safely if replacement fails.
- Preserve the promised F9 BMP in default GPU-present mode with a one-frame, fence-synchronized scanout readback.
- Fall back to a one-texel copy when a bounded 64 KiB source ends between an otherwise adjacent pair, with regression coverage for 1/2/4/8-byte texels.
- Make partial worker creation exception-safe and finish unspawned ranges synchronously.
- Evict available cached Vulkan memory and retry once after an allocation failure.

## Behavioral contract and risk

The optimized conversion and layout paths must remain bit-identical to their scalar predecessors. Renderer-owned target imports are accepted only for exact format/component/extent/device matches. Larger Vulkan allocations are reused only with the same memory type, while accounting retains the allocation's real size. The main risks are synchronization/lifetime errors around shared images and persistent mappings, incorrect swizzle adjacency assumptions, cross-platform intrinsic dispatch, and the larger bounded cache footprint.

## Local verification (exact corrected head `8a7eaf5f`)

- `distrobox enter ps5ys -- ninja -C prosper/build-astrobot-app` — passed (complete build).
- `distrobox enter ps5ys -- ctest --test-dir prosper/build-astrobot-app --output-on-failure --timeout 600` — 148/148 passed.
- Focused present-policy, compute, and tile tests — 4/4 passed.
- Tile fallbacks `PROSPER_NO_AVX2_DETILE=1`, `PROSPER_NO_PAIRED_TILE_COPY=1`, and `PROSPER_DETILE_ROW_MAJOR=1` — all passed.
- `git diff --check` — passed.
- Full snapshot matrix — messenger-scene, evergate-title, dead-cells-gameplay, blasphemous2-gameplay, and blue-prince-title passed.
- Three wall-clock evidence guards missed on this saturated host without output corruption: evergate-gameplay reached 5/6 structural matches twice; blue-prince-hall was still in the opening sequence during its hall window; terminator-boot reached 12/16 structural matches. Exact untouched `origin/master` (`e73d3811`) controls under the same load also missed each tested guard: Evergate 5/6, Blue Prince still in opening credits, and Terminator 8/16. Thresholds and baselines were not changed.
- Interactive `prosper-app` run used the real game, PipeWire audio, SDL input, and immediate GPU presentation. Astro Bot reached the title controller. Presented cadence improved substantially over the old CPU-present path, but effective FMV progress remains roughly 2 distinct frames/s and the checkerboard/flashing output is unresolved.

## Deliberately unaffected

No guest timing, shader semantics, snapshot baseline, save data, game assets, or diagnostic capture artifact is changed or committed. Test-pattern/no-game presentation and failed shared-device adoption retain the private-device CPU path.
