### PR TITLE
docs: make snapshots a release gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -268,12 +268,16 @@ Messenger depth, vertex-fetch, geometry, palette, or tiling hypotheses without c
   ```
 - **Verification is agentic-first / programmatic** (`docs/VERIFICATION.md`): ctest exit code is truth;
   shaders are `spirv-val`-gated; rendered frames are asserted by pixels, hashes, or routed content
-  metrics. Snapshot coverage is **mandatory before every release**: run the full local-only matrix with
-  `python3 tools/snapshot/snapshot.py check` against the release candidate. It is not a blanket gate for
-  opening a PR. For PRs, the author decides whether affected-title guards or the full matrix are
-  appropriate for the change and iteration stage, unless the task explicitly requires them. Changes
-  that can affect rendered output (recompiler, AGC decode, render state, detile, executor/present)
-  should consider snapshot coverage as a strong relevant check and record any runs in the PR. Gameplay
+  metrics. Snapshots are a **release-time regression inventory**, not a day-to-day development or merge
+  gate. Before every release, run the full local-only matrix with
+  `python3 tools/snapshot/snapshot.py check` against the release candidate and review every result.
+  During normal development, including long stretches of render work, authors may skip snapshots
+  entirely or run only useful focused guards; the PR author decides, unless the task explicitly requires
+  a run. Snapshot results do not define whether master or an individual PR is acceptable: either may
+  regress a guarded title, and a correct fix may even require an intentional cross-title tradeoff. The
+  release process is where detected regressions are
+  fixed or explicitly accepted and documented before publishing artifacts. Record any snapshots that
+  were run in the PR, but do not delay routine iteration merely to keep the whole matrix green. Gameplay
   guards inspect multiple frames in route-specific windows and use SSIM over compact luminance
   signatures from several reviewed states, looking for major collapse without rejecting subtle pixel improvements.
   Every new or materially changed baseline requires `snapshot.py verify`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -268,8 +268,12 @@ Messenger depth, vertex-fetch, geometry, palette, or tiling hypotheses without c
   ```
 - **Verification is agentic-first / programmatic** (`docs/VERIFICATION.md`): ctest exit code is truth;
   shaders are `spirv-val`-gated; rendered frames are asserted by pixels, hashes, or routed content
-  metrics. **After any change that can affect rendered output** (recompiler, AGC decode, render state,
-  detile, executor/present), run `python3 tools/snapshot/snapshot.py check` (local-only). Gameplay
+  metrics. Snapshot coverage is **mandatory before every release**: run the full local-only matrix with
+  `python3 tools/snapshot/snapshot.py check` against the release candidate. It is not a blanket gate for
+  opening a PR. For PRs, the author decides whether affected-title guards or the full matrix are
+  appropriate for the change and iteration stage, unless the task explicitly requires them. Changes
+  that can affect rendered output (recompiler, AGC decode, render state, detile, executor/present)
+  should consider snapshot coverage as a strong relevant check and record any runs in the PR. Gameplay
   guards inspect multiple frames in route-specific windows and use SSIM over compact luminance
   signatures from several reviewed states, looking for major collapse without rejecting subtle pixel improvements.
   Every new or materially changed baseline requires `snapshot.py verify`,

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -11,13 +11,15 @@ the shipped runtime. Build them from `build-linux/` like everything else.
   but do not rerun it; see the mandatory merge policy in the root `CLAUDE.md`. Run
   `powershell -File tools/test-verify-pr.ps1` after changing the orchestrator; it probes exact-base
   pinning, WSL selection, rejected skip attempts, and untracked-source contamination.
-- **`snapshot/`** - routed, multi-frame **rendering regression guard**. The full
-  `python3 tools/snapshot/snapshot.py check` matrix is mandatory before every
-  release. It is not required merely to open a PR: the PR author decides whether
-  affected-title guards or the full matrix are appropriate for a render-affecting
-  change, unless the task explicitly requires them. It catches major scene collapse
-  without treating subtle pixel changes as regressions. New or changed baselines
-  require two-run image inspection; see `snapshot/AGENTS.md`.
+- **`snapshot/`** - routed, multi-frame **rendering regression inventory**. Run
+  and review the full `python3 tools/snapshot/snapshot.py check` matrix before
+  every release. It is not a day-to-day development or merge gate: PR authors may
+  skip snapshots entirely during long iterations or run only useful focused guards,
+  unless the task explicitly requires a run. Snapshot results do not define whether
+  master or a PR is acceptable; either may contain a detected regression, including
+  an intentional cross-title tradeoff. Release review
+  decides whether to fix or explicitly accept and document it. New or changed
+  baselines require two-run image inspection; see `snapshot/AGENTS.md`.
 - **`boot_trace/`** — boots a SELF/ELF game image through the loader + HLE and
   runs it, with the fault handler, GPU executor, and (under `PROSPER_RENDER`) the
   live Vulkan renderer. The main harness for exercising a real title headlessly.

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -11,12 +11,13 @@ the shipped runtime. Build them from `build-linux/` like everything else.
   but do not rerun it; see the mandatory merge policy in the root `CLAUDE.md`. Run
   `powershell -File tools/test-verify-pr.ps1` after changing the orchestrator; it probes exact-base
   pinning, WSL selection, rejected skip attempts, and untracked-source contamination.
-- **`snapshot/`** - routed, multi-frame **rendering regression guard**. Run
-  `python3 tools/snapshot/snapshot.py check` after any change that can affect
-  rendered output (recompiler, AGC decode, render state, detile, present). It
-  catches major scene collapse without treating subtle pixel changes as
-  regressions. New or changed baselines require two-run image inspection; see
-  `snapshot/AGENTS.md`. **Run this after touching the render path.**
+- **`snapshot/`** - routed, multi-frame **rendering regression guard**. The full
+  `python3 tools/snapshot/snapshot.py check` matrix is mandatory before every
+  release. It is not required merely to open a PR: the PR author decides whether
+  affected-title guards or the full matrix are appropriate for a render-affecting
+  change, unless the task explicitly requires them. It catches major scene collapse
+  without treating subtle pixel changes as regressions. New or changed baselines
+  require two-run image inspection; see `snapshot/AGENTS.md`.
 - **`boot_trace/`** — boots a SELF/ELF game image through the loader + HLE and
   runs it, with the fault handler, GPU executor, and (under `PROSPER_RENDER`) the
   live Vulkan renderer. The main harness for exercising a real title headlessly.

--- a/prosper/tools/snapshot/AGENTS.md
+++ b/prosper/tools/snapshot/AGENTS.md
@@ -1,9 +1,12 @@
 # AGENTS.md - rendering snapshot tests
 
-This is the required local real-game rendering gate. Run the affected title
-guards after any change that can affect output: RDNA2-to-SPIR-V recompilation,
-AGC/PM4 decoding, render state, texture decode/detiling, executor behavior, or
-presentation.
+This is the local real-game rendering gate. The full matrix is required before
+every release. It is not a blanket prerequisite for opening a PR: the PR author
+decides whether affected-title guards or the full matrix are appropriate for the
+change and iteration stage, unless the task explicitly requires them. Changes
+that can affect output should consider snapshot coverage as a strong relevant
+check: RDNA2-to-SPIR-V recompilation, AGC/PM4 decoding, render state, texture
+decode/detiling, executor behavior, or presentation.
 
 ```bash
 # From prosper/, with build-linux/boot_trace built from the change.

--- a/prosper/tools/snapshot/AGENTS.md
+++ b/prosper/tools/snapshot/AGENTS.md
@@ -1,12 +1,13 @@
 # AGENTS.md - rendering snapshot tests
 
-This is the local real-game rendering gate. The full matrix is required before
-every release. It is not a blanket prerequisite for opening a PR: the PR author
-decides whether affected-title guards or the full matrix are appropriate for the
-change and iteration stage, unless the task explicitly requires them. Changes
-that can affect output should consider snapshot coverage as a strong relevant
-check: RDNA2-to-SPIR-V recompilation, AGC/PM4 decoding, render state, texture
-decode/detiling, executor behavior, or presentation.
+This is the local real-game rendering regression inventory. Run and review the
+full matrix before every release. It is not a day-to-day development or merge
+gate: a PR author may skip snapshots entirely during long iterations or run only
+useful focused guards, unless the task explicitly requires a run. Snapshot results
+do not define whether master or a PR is acceptable; either may contain a detected
+regression, including an intentional cross-title
+tradeoff from an otherwise correct fix. Release review decides whether to fix the
+regression or explicitly accept and document it before publishing artifacts.
 
 ```bash
 # From prosper/, with build-linux/boot_trace built from the change.


### PR DESCRIPTION
## Summary

- Define the real-game snapshot matrix as a release-time regression inventory, not a day-to-day development or merge gate.
- Require the full matrix to be run and reviewed before every release.
- Let PR authors skip snapshots during long development iterations or run only useful focused guards, unless a task explicitly requires them.
- Make clear that snapshot results do not define whether master or a PR is acceptable: regressions and intentional cross-title tradeoffs can be part of active development.
- Require release review to fix detected regressions or explicitly accept and document them before publishing artifacts.

## Validation

- `git diff --check`
- Documentation-only change; runtime tests were not run.