### PR TITLE
perf(render): keep live compute resources GPU-resident

### DIFF
--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -105,6 +105,46 @@ bool direct_sampled_rtt_compatible(prosper::gpu::DataFormat format, uint32_t com
 
 namespace {
 
+VkFormat native_storage_vk_format(prosper::gpu::DataFormat format, uint32_t components) {
+    using prosper::gpu::DataFormat;
+    switch (format) {
+    case DataFormat::Unorm8:
+        if (components == 1) return VK_FORMAT_R8_UNORM;
+        if (components == 2) return VK_FORMAT_R8G8_UNORM;
+        if (components == 4) return VK_FORMAT_R8G8B8A8_UNORM;
+        break;
+    case DataFormat::Float16:
+        if (components == 1) return VK_FORMAT_R16_SFLOAT;
+        if (components == 2) return VK_FORMAT_R16G16_SFLOAT;
+        if (components == 4) return VK_FORMAT_R16G16B16A16_SFLOAT;
+        break;
+    case DataFormat::Float32:
+        if (components == 1) return VK_FORMAT_R32_SFLOAT;
+        if (components == 2) return VK_FORMAT_R32G32_SFLOAT;
+        if (components == 4) return VK_FORMAT_R32G32B32A32_SFLOAT;
+        break;
+    case DataFormat::Float10_11_11:
+        if (components == 3) return VK_FORMAT_B10G11R11_UFLOAT_PACK32;
+        break;
+    default:
+        break;
+    }
+    return VK_FORMAT_UNDEFINED;
+}
+
+bool native_storage_image_create_supported(VkPhysicalDevice physical, VkFormat format,
+                                           uint32_t width, uint32_t height) {
+    if (!physical || format == VK_FORMAT_UNDEFINED || !width || !height) return false;
+    constexpr VkImageUsageFlags usage = VK_IMAGE_USAGE_STORAGE_BIT |
+        VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+    VkImageFormatProperties properties{};
+    return vkGetPhysicalDeviceImageFormatProperties(
+               physical, format, VK_IMAGE_TYPE_2D, VK_IMAGE_TILING_OPTIMAL,
+               usage, 0, &properties) == VK_SUCCESS &&
+           width <= properties.maxExtent.width && height <= properties.maxExtent.height &&
+           properties.maxExtent.depth >= 1 && properties.maxArrayLayers >= 1;
+}
+
 constexpr VkDeviceSize kMaxComputeImageBytes = 256ull << 20;
 constexpr size_t kMaxCachedComputePipelines = 4096;
 
@@ -453,6 +493,7 @@ struct ComputeImageCacheKey {
     uint32_t mip_tail_offset = 0, mip_tail_bytes = 0;
     uint32_t mip_tail_x = 0, mip_tail_y = 0;
     uint32_t vk_format = 0;
+    bool storage = false;
     bool in_mip_tail = false;
     bool srgb = false;
     bool depth_compare = false;
@@ -472,7 +513,7 @@ struct ComputeImageCacheKeyHash {
         mix(key.format); mix(key.components); mix(key.tile_mode); mix(key.img_dim);
         mix(key.linear_row_pitch); mix(key.mip_tail_offset); mix(key.mip_tail_bytes);
         mix(key.mip_tail_x); mix(key.mip_tail_y); mix(key.vk_format);
-        mix(key.in_mip_tail); mix(key.srgb); mix(key.depth_compare);
+        mix(key.storage); mix(key.in_mip_tail); mix(key.srgb); mix(key.depth_compare);
         return result;
     }
 };
@@ -1311,12 +1352,6 @@ struct BoundImage {
     bool imported = false;
     bool imported_depth = false;        // borrowed persistent DS depth plane, not a color RTT
     VkFormat imported_format = VK_FORMAT_UNDEFINED;
-    // A native-resolution storage image backed by a reduced-resolution renderer RTT. `image` is a
-    // temporary compute image; `bridge_image` is the pinned renderer image. Two GPU blits replace
-    // the old CPU snapshot upscale + guest writeback while preserving integer storage coordinates.
-    bool scaled_bridge = false;
-    VkImage bridge_image = VK_NULL_HANDLE;
-    uint32_t bridge_width = 0, bridge_height = 0;
     bool persistent = false;            // guest-backed sampled image retained across dispatches
     bool cache_candidate = false;
     bool upload_skipped = false;         // write watch proved the cached source unchanged
@@ -1794,7 +1829,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         for (size_t i = 0; i < images.size(); i++) {
             // A pin is taken per successful import, so it is released per import -- including for a
             // binding that a later alias check folded into an earlier one (#1095).
-            if (images[i].imported || images[i].scaled_bridge)
+            if (images[i].imported)
                 release_live_render_target_image(images[i].imported_addr);
             if (images[i].alias_of != SIZE_MAX) continue;
             if (images[i].sampler) vkDestroySampler(ctx.device, images[i].sampler, nullptr);
@@ -1944,8 +1979,26 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             bi.resource = r;
             bi.binding = image_descriptors[i].binding;
             bi.storage = image_descriptors[i].kind == SpirvDescriptorKind::StorageImage;
-            bi.native_float_storage = bi.storage && native_float_storage_image(
-                r->format, r->num_components ? r->num_components : 1, r->srgb);
+            const uint32_t descriptor_components =
+                r->num_components ? r->num_components : 1;
+            const VkFormat native_storage_format =
+                native_storage_vk_format(r->format, descriptor_components);
+            const bool spirv_native_storage =
+                bi.storage && image_descriptors[i].storage_float;
+            const bool ordinary_2d_storage = r->img_dim == 1 && r->depth == 1 &&
+                                             !r->depth_compare;
+            const bool native_storage_supported = native_float_storage_image_supported(
+                r->format, descriptor_components, r->srgb,
+                ordinary_2d_storage && native_storage_image_create_supported(
+                    ctx.physical, native_storage_format, r->width, r->height));
+            if (spirv_native_storage && !native_storage_supported) {
+                skip_image(r, "compiled typed storage format is unsupported by this device");
+                break;
+            }
+            // SPIR-V is authoritative here: a raw-uvec4 module must keep the conversion path even
+            // if this replay device supports the optional typed format, while a live module is only
+            // emitted as float after the frontend's physical-device feature query.
+            bi.native_float_storage = spirv_native_storage;
             if (trace)
                 std::fprintf(stderr,
                              "[compute]   image binding=%u class=%s addr=0x%llx "
@@ -1998,9 +2051,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     bi.dcc_metadata = reinterpret_cast<uint8_t*>(uintptr_t(r->metadata_addr));
                 }
             }
-            // A renderer-owned target's current pixels are not in raw guest memory. Import its
-            // immutable CPU snapshot for sampled and storage bindings; a successful storage
-            // writeback publishes ordinary guest bytes and invalidates the renderer-owned copy.
+            // A renderer-owned target's current pixels are not in raw guest memory. Sampled
+            // descriptors may borrow its Vulkan image directly; storage descriptors use the CPU
+            // snapshot path below so their guest writeback keeps overlapping aliases coherent.
             LiveTargetSnapshot live_target;
             bool renderer_owned = !r->in_mip_tail && is_live_render_target(r->gpu_addr);
             static const uint32_t render_scale = [] {
@@ -2019,13 +2072,19 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 !dim_2d_array && r->depth == 1 && r->img_dim == 1 &&
                 r->format == DataFormat::Float32 &&
                 (r->num_components ? r->num_components : 1u) == 1u;
-            if ((renderer_owned || depth_import_eligible) &&
-                (!bi.storage || bi.native_float_storage) &&
+            // Persistent renderer images do not carry VK_IMAGE_USAGE_STORAGE_BIT, and a writable
+            // storage import would also leave overlapping guest buffer aliases stale. Storage
+            // descriptors therefore retain the owned-image + guest-writeback path.
+            if (!bi.storage && (renderer_owned || depth_import_eligible) &&
                 !dim_1d && !dim_3d && !dim_2d_array &&
                 r->depth == 1 && !r->depth_compare) {
                 LiveTargetImageImport import;
+                const bool normalized_sampling =
+                    image_descriptors[i].normalized_sampling &&
+                    !image_descriptors[i].texel_access;
                 const LiveTargetImageRequest import_request{
-                    r->width, r->height, render_scale, depth_import_eligible};
+                    r->width, r->height, render_scale, depth_import_eligible,
+                    normalized_sampling};
                 const bool import_available = import_live_render_target_image(
                     r->gpu_addr, import_request, import);
                 if (trace)
@@ -2053,14 +2112,10 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                               import.format);
                     const bool compatible_device =
                         import.device == static_cast<void*>(ctx.device);
-                    const bool direct_extent = bi.storage
-                        ? import.width == r->width && import.height == r->height
-                        : prosper::frontend::rtt_sampled_extent_compatible(
-                              r->width, r->height, import.width, import.height, render_scale);
-                    const bool bridge_extent = bi.storage && bi.native_float_storage &&
-                        image_descriptors[i].writable &&
-                        prosper::frontend::rtt_storage_bridge_extent_compatible(
-                            r->width, r->height, import.width, import.height, render_scale);
+                    const bool direct_extent =
+                        prosper::frontend::rtt_direct_import_compatible(
+                            bi.storage, r->width, r->height, import.width, import.height,
+                            render_scale, normalized_sampling);
                     if (compatible_format && direct_extent && compatible_device) {
                         bi.imported = true;
                         bi.imported_depth = depth_import;
@@ -2081,19 +2136,6 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                          depth_import ? "depth"
                                              : import.format == LiveTargetPixelFormat::Rgba16Float
                                                    ? "rgba16f" : "rgba8");
-                    } else if (compatible_format && bridge_extent && compatible_device) {
-                        bi.scaled_bridge = true;
-                        bi.imported_addr = r->gpu_addr;
-                        bi.imported_saved_layout = import.layout;
-                        bi.bridge_image = static_cast<VkImage>(import.image);
-                        bi.bridge_width = import.width;
-                        bi.bridge_height = import.height;
-                        if (trace)
-                            std::fprintf(stderr,
-                                         "[compute]   GPU-scaled renderer RTT bridge binding=%u "
-                                         "addr=0x%llx %ux%u <-> %ux%u\n",
-                                         bi.binding, (unsigned long long)r->gpu_addr,
-                                         import.width, import.height, r->width, r->height);
                     } else {
                         // Not our exact contract (a different device or a stale aliased view).
                         release_live_render_target_image(r->gpu_addr);
@@ -2152,7 +2194,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 }
                 // Proven Partial: fall through, seed normally every frame.
             }
-            if (renderer_owned && !bi.imported && !bi.scaled_bridge && !bi.seed_skip) {
+            if (renderer_owned && !bi.imported && !bi.seed_skip) {
                 if (dim_3d || r->depth != 1 ||
                     !read_live_render_target(r->gpu_addr, live_target) || !live_target.pixels) {
                     skip_image(r, "renderer-owned RTT has no readable snapshot"); break;
@@ -2514,7 +2556,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         r->tile_mode, r->img_dim, r->linear_row_pitch_bytes,
                         r->mip_tail_offset, r->mip_tail_bytes,
                         r->mip_tail_x, r->mip_tail_y,
-                        static_cast<uint32_t>(image_format), r->in_mip_tail,
+                        static_cast<uint32_t>(image_format), bi.storage, r->in_mip_tail,
                         r->srgb, r->depth_compare};
                     bi.persistent = ctx.acquire_cached_image(
                         bi.cache_key, sampled_guest_source, image_validation_epoch,
@@ -2536,10 +2578,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             // directly. The old path first built a heap upload and then memcpy'd the complete result
             // here -- an extra 132 MiB CPU pass for Astro Bot's 4K RGBA32 storage representation.
             ScopedMappedMemory upload_mapping(ctx);
-            const size_t upload_size = (bi.imported || bi.scaled_bridge || bi.seed_skip)
+            const size_t upload_size = (bi.imported || bi.seed_skip)
                 ? size_t{0} : (size_t)sbytes;
-            if (!bi.imported && !bi.scaled_bridge &&
-                !(bi.persistent && bi.upload_skipped)) {
+            if (!bi.imported && !(bi.persistent && bi.upload_skipped)) {
                 VkBufferCreateInfo sci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
                 sci.size = sbytes;
                 sci.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
@@ -2562,9 +2603,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 }
             }
             auto* upload = static_cast<uint8_t*>(upload_mapping.data);
-            if (bi.imported || bi.scaled_bridge) {
-                // The renderer's image is the source: direct imports need no transfer; scaled
-                // storage bridges are populated by an image-to-image blit in the command buffer.
+            if (bi.imported) {
+                // The renderer's sampled image is the source, so direct imports need no transfer.
                 bi.guest_bytes = 0;
             } else if (bi.storage) {
                 if (r->tile_mode && !tile_mode_is_tiled(r->tile_mode)) {
@@ -2624,7 +2664,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         r->tile_mode, r->img_dim, r->linear_row_pitch_bytes,
                         r->mip_tail_offset, r->mip_tail_bytes,
                         r->mip_tail_x, r->mip_tail_y,
-                        static_cast<uint32_t>(image_format), r->in_mip_tail,
+                        static_cast<uint32_t>(image_format), bi.storage, r->in_mip_tail,
                         r->srgb, r->depth_compare};
                     bi.persistent = ctx.acquire_cached_image(
                         bi.cache_key, resource_bytes_for(r, guest_bytes), image_validation_epoch,
@@ -2979,13 +3019,10 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             ici.arrayLayers = dim_2d_array ? r->depth : 1;
             ici.samples = VK_SAMPLE_COUNT_1_BIT;
             ici.tiling = VK_IMAGE_TILING_OPTIMAL;
-            ici.usage = (bi.storage ? (VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_SAMPLED_BIT |
+            ici.usage = (bi.storage ? (VK_IMAGE_USAGE_STORAGE_BIT |
                                        VK_IMAGE_USAGE_TRANSFER_SRC_BIT)
                                     : VK_IMAGE_USAGE_SAMPLED_BIT) |
                         VK_IMAGE_USAGE_TRANSFER_DST_BIT;
-            if (!bi.storage && native_float_storage_image(
-                    r->format, sampled_components, r->srgb))
-                ici.usage |= VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
             ici.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
             // An imported binding already holds the renderer's image; only the view/sampler below
             // are ours to create. `ici` is still filled above so the view matches its format/layers.
@@ -3249,61 +3286,6 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             const BoundImage& bi = images[i];
             if (bi.alias_of != SIZE_MAX) continue;
             const ShaderResource* r = bi.resource;
-            if (bi.scaled_bridge) {
-                // Keep render-scale storage traffic on the GPU. The shader still sees its native
-                // extent and integer coordinates; only the renderer-owned backing is reduced.
-                VkImageMemoryBarrier barriers[2]{};
-                barriers[0] = {VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
-                barriers[0].srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT |
-                                            VK_ACCESS_TRANSFER_WRITE_BIT |
-                                            VK_ACCESS_SHADER_WRITE_BIT;
-                barriers[0].dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
-                barriers[0].oldLayout = static_cast<VkImageLayout>(bi.imported_saved_layout);
-                barriers[0].newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
-                barriers[0].srcQueueFamilyIndex = barriers[0].dstQueueFamilyIndex =
-                    VK_QUEUE_FAMILY_IGNORED;
-                barriers[0].image = bi.bridge_image;
-                barriers[0].subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
-                barriers[1] = {VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
-                barriers[1].srcAccessMask = 0;
-                barriers[1].dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
-                barriers[1].oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-                barriers[1].newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
-                barriers[1].srcQueueFamilyIndex = barriers[1].dstQueueFamilyIndex =
-                    VK_QUEUE_FAMILY_IGNORED;
-                barriers[1].image = bi.image;
-                barriers[1].subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
-                vkCmdPipelineBarrier(command, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
-                                     VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr,
-                                     2, barriers);
-                VkImageBlit blit{};
-                blit.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
-                blit.srcOffsets[1] = {static_cast<int32_t>(bi.bridge_width),
-                                      static_cast<int32_t>(bi.bridge_height), 1};
-                blit.dstSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
-                blit.dstOffsets[1] = {static_cast<int32_t>(r->width),
-                                      static_cast<int32_t>(r->height), 1};
-                vkCmdBlitImage(command, bi.bridge_image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-                               bi.image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &blit,
-                               VK_FILTER_NEAREST);
-                barriers[0].srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
-                barriers[0].dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT |
-                                            VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT |
-                                            VK_ACCESS_SHADER_READ_BIT |
-                                            VK_ACCESS_TRANSFER_READ_BIT |
-                                            VK_ACCESS_TRANSFER_WRITE_BIT;
-                barriers[0].oldLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
-                barriers[0].newLayout = static_cast<VkImageLayout>(bi.imported_saved_layout);
-                barriers[1].srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
-                barriers[1].dstAccessMask = VK_ACCESS_SHADER_READ_BIT |
-                                            VK_ACCESS_SHADER_WRITE_BIT;
-                barriers[1].oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
-                barriers[1].newLayout = VK_IMAGE_LAYOUT_GENERAL;
-                vkCmdPipelineBarrier(command, VK_PIPELINE_STAGE_TRANSFER_BIT,
-                                     VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0, nullptr, 0, nullptr,
-                                     2, barriers);
-                continue;
-            }
             if (bi.imported) {
                 if (!imported_barrier_owner(i)) continue;   // another binding transitions this image
                 // Borrowed renderer image: nothing to upload. Include shader-write access when an
@@ -3388,61 +3370,6 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                static_cast<uint32_t>(item.user_sgprs.size() * sizeof(uint32_t)),
                                item.user_sgprs.data());
         vkCmdDispatch(command, item.launch.groups_x, item.launch.groups_y, item.launch.groups_z);
-        // Downscale native compute output directly into its persistent render-scale target. The
-        // target is returned in exactly the layout recorded by the renderer's import contract.
-        for (const BoundImage& bi : images) {
-            if (!bi.scaled_bridge || bi.alias_of != SIZE_MAX) continue;
-            const ShaderResource* r = bi.resource;
-            VkImageMemoryBarrier barriers[2]{};
-            barriers[0] = {VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
-            barriers[0].srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
-            barriers[0].dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
-            barriers[0].oldLayout = VK_IMAGE_LAYOUT_GENERAL;
-            barriers[0].newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
-            barriers[0].srcQueueFamilyIndex = barriers[0].dstQueueFamilyIndex =
-                VK_QUEUE_FAMILY_IGNORED;
-            barriers[0].image = bi.image;
-            barriers[0].subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
-            barriers[1] = {VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
-            barriers[1].srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT |
-                                        VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT |
-                                        VK_ACCESS_SHADER_READ_BIT |
-                                        VK_ACCESS_TRANSFER_READ_BIT |
-                                        VK_ACCESS_TRANSFER_WRITE_BIT;
-            barriers[1].dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
-            barriers[1].oldLayout = static_cast<VkImageLayout>(bi.imported_saved_layout);
-            barriers[1].newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
-            barriers[1].srcQueueFamilyIndex = barriers[1].dstQueueFamilyIndex =
-                VK_QUEUE_FAMILY_IGNORED;
-            barriers[1].image = bi.bridge_image;
-            barriers[1].subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
-            vkCmdPipelineBarrier(command, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT |
-                                 VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
-                                 VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr,
-                                 2, barriers);
-            VkImageBlit blit{};
-            blit.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
-            blit.srcOffsets[1] = {static_cast<int32_t>(r->width),
-                                  static_cast<int32_t>(r->height), 1};
-            blit.dstSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
-            blit.dstOffsets[1] = {static_cast<int32_t>(bi.bridge_width),
-                                  static_cast<int32_t>(bi.bridge_height), 1};
-            vkCmdBlitImage(command, bi.image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-                           bi.bridge_image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &blit,
-                           VK_FILTER_LINEAR);
-            VkImageMemoryBarrier restore = barriers[1];
-            restore.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
-            restore.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT |
-                                    VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT |
-                                    VK_ACCESS_SHADER_READ_BIT |
-                                    VK_ACCESS_TRANSFER_READ_BIT |
-                                    VK_ACCESS_TRANSFER_WRITE_BIT;
-            restore.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
-            restore.newLayout = static_cast<VkImageLayout>(bi.imported_saved_layout);
-            vkCmdPipelineBarrier(command, VK_PIPELINE_STAGE_TRANSFER_BIT,
-                                 VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0, nullptr, 0, nullptr,
-                                 1, &restore);
-        }
         // Hand every borrowed renderer image back in the layout its owner left it in (#1095), so the
         // renderer's own layout tracking stays true whether or not a dispatch consumed the target.
         for (size_t i = 0; i < images.size(); i++) {
@@ -3471,7 +3398,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         // Storage images: copy the written texels back into the staging buffer for guest writeback.
         for (size_t i = 0; i < images.size(); i++) {
             const BoundImage& bi = images[i];
-            if (!bi.storage || bi.alias_of != SIZE_MAX || bi.imported || bi.scaled_bridge) continue;
+            if (!bi.storage || bi.alias_of != SIZE_MAX || bi.imported) continue;
             const ShaderResource* r = bi.resource;
             VkImageMemoryBarrier to_src{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
             to_src.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
@@ -3567,17 +3494,6 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             }
         }
 
-        // A native storage binding may have written a borrowed renderer image directly. Publish the
-        // new authority before releasing its pin; no guest write notification is sent because raw
-        // guest bytes are intentionally stale while the persistent image owns the current pixels.
-        std::unordered_set<uint64_t> published_imports;
-        for (const BoundImage& image : images) {
-            if ((image.imported || image.scaled_bridge) && image.storage &&
-                image.imported_addr &&
-                published_imports.insert(image.imported_addr).second)
-                notify_live_render_target_image_written(image.imported_addr);
-        }
-
         bool readback_ok = true;
         for (auto& buffer : buffers) {
             if (buffer.alias_of != SIZE_MAX || !buffer.writable) continue;
@@ -3624,7 +3540,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         // the render side exactly like the buffer path.
         for (size_t i = 0; i < images.size() && readback_ok; i++) {
             BoundImage& bi = images[i];
-            if (!bi.storage || bi.alias_of != SIZE_MAX || bi.imported || bi.scaled_bridge) continue;
+            if (!bi.storage || bi.alias_of != SIZE_MAX || bi.imported) continue;
             const ShaderResource* r = bi.resource;
             void* mapped = nullptr;
             if (ctx.map_memory(staging_memory[i], 0, staging_bytes[i], &mapped) != VK_SUCCESS) {

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -9,10 +9,12 @@
 #include "gpu/shader_resources.hpp"
 #include "gpu/tile.hpp"
 #include "gpu/writer_provenance.hpp"
+#include "host/guest_write_watch.hpp"
 
 #include <vulkan/vulkan.h>
 
 #include <algorithm>
+#include <atomic>
 #include <array>
 #include <chrono>
 #include <cmath>
@@ -28,6 +30,7 @@
 #include <thread>
 #include <tuple>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #if (defined(__x86_64__) || defined(__i386__)) && \
@@ -111,7 +114,8 @@ constexpr size_t kMaxCachedComputePipelines = 4096;
 // sixteen workers because both the detiler and these loops eventually become memory-bandwidth-bound.
 // Astro Bot's 4K path is still measurably faster at 16 on a 16-core Strix Halo; 32 regresses.
 template <class Body>
-void parallel_compute_texels(size_t count, size_t work_bytes, Body&& body) {
+void parallel_compute_texels(size_t count, size_t work_bytes, Body&& body,
+                             unsigned max_threads = 16u) {
     if (!count) return;
     static const unsigned configured = [] {
         const char* value = std::getenv("PROSPER_COMPUTE_CONVERSION_THREADS");
@@ -120,7 +124,8 @@ void parallel_compute_texels(size_t count, size_t work_bytes, Body&& body) {
         return static_cast<unsigned>(std::min(parsed, 32ul));
     }();
     const unsigned hardware = std::thread::hardware_concurrency();
-    const unsigned wanted = configured ? configured : std::min(hardware ? hardware : 4u, 16u);
+    const unsigned wanted = std::min(
+        configured ? configured : std::min(hardware ? hardware : 4u, 16u), max_threads);
     const unsigned by_work = static_cast<unsigned>(std::min<size_t>(
         count, std::max<size_t>(1, work_bytes / (512u * 1024u))));
     const unsigned threads = std::max(1u, std::min(wanted ? wanted : 1u, by_work));
@@ -152,6 +157,38 @@ void parallel_compute_texels(size_t count, size_t work_bytes, Body&& body) {
         if (begin >= end) break;
         body(begin, end);
     }
+}
+
+bool compute_buffers_equal(const void* lhs, const void* rhs, size_t bytes) {
+    // glibc's vectorized memcmp is excellent for ordinary bindings. A 32 MiB persistent SSBO still
+    // costs several milliseconds on one core, though, and the common maintenance-kernel result is
+    // unchanged. Eight independent ranges measured best on the target APU (more workers became
+    // memory-bandwidth/thread-start limited). This remains an exact comparison of every byte.
+    constexpr size_t kParallelThreshold = 8u << 20;
+    if (bytes < kParallelThreshold) return std::memcmp(lhs, rhs, bytes) == 0;
+    const auto* a = static_cast<const uint8_t*>(lhs);
+    const auto* b = static_cast<const uint8_t*>(rhs);
+    std::atomic<bool> equal{true};
+    parallel_compute_texels(bytes, bytes,
+        [&](size_t begin, size_t end) {
+            if (std::memcmp(a + begin, b + begin, end - begin) != 0)
+                equal.store(false, std::memory_order_relaxed);
+        }, 8u);
+    return equal.load(std::memory_order_relaxed);
+}
+
+void copy_compute_buffer(void* destination, const void* source, size_t bytes) {
+    constexpr size_t kParallelThreshold = 8u << 20;
+    if (bytes < kParallelThreshold) {
+        std::memcpy(destination, source, bytes);
+        return;
+    }
+    auto* dst = static_cast<uint8_t*>(destination);
+    const auto* src = static_cast<const uint8_t*>(source);
+    parallel_compute_texels(bytes, bytes,
+        [&](size_t begin, size_t end) {
+            std::memcpy(dst + begin, src + begin, end - begin);
+        }, 8u);
 }
 
 #if defined(PROSPER_HAVE_TARGET_F16C)
@@ -365,6 +402,134 @@ struct ComputeMemoryPoolStats {
     uint64_t discarded = 0;
 };
 
+struct ComputeBufferCacheKey {
+    uint64_t gpu_addr = 0;
+    uintptr_t host_data = 0;
+    uint32_t bytes = 0;
+    bool operator==(const ComputeBufferCacheKey& other) const {
+        return gpu_addr == other.gpu_addr && host_data == other.host_data && bytes == other.bytes;
+    }
+};
+
+struct ComputeBufferCacheKeyHash {
+    size_t operator()(const ComputeBufferCacheKey& key) const {
+        size_t result = std::hash<uint64_t>{}(key.gpu_addr);
+        result ^= std::hash<uintptr_t>{}(key.host_data) << 1;
+        result ^= std::hash<uint32_t>{}(key.bytes) << 2;
+        return result;
+    }
+};
+
+constexpr uint32_t kComputeBufferWriteWatchChunkBytes = 1u << 20;
+
+struct ComputeBufferWriteWatchChunk {
+    uint32_t offset = 0;
+    uint32_t bytes = 0;
+    prosper::host::GuestWriteWatch watch;
+};
+
+struct CachedComputeBuffer {
+    VkBuffer buffer = VK_NULL_HANDLE;
+    VkDeviceMemory memory = VK_NULL_HANDLE;
+    VkDeviceSize allocation_bytes = 0;
+    uint64_t last_use = 0;
+    uint32_t pins = 0;
+    // GuestWriteWatch is page-granular internally, but its public query historically collapsed a
+    // registration to one Dirty bit. A four-byte guest write could therefore make the persistent
+    // compute cache compare an entire 32 MiB buffer. Split large sources into moderately-sized
+    // registrations so an exact refresh only scans chunks containing a dirtied page. An unavailable
+    // chunk watch remains fail-closed: acquire_cached_buffer falls back to the full byte comparison.
+    std::vector<ComputeBufferWriteWatchChunk> write_watches;
+    prosper::gpu::GuestGpuWriteSnapshot validation_snapshot;
+};
+
+struct ComputeImageCacheKey {
+    uint64_t gpu_addr = 0;
+    uint32_t guest_bytes = 0;
+    uint32_t resource_bytes = 0;
+    uint32_t width = 0, height = 0, depth = 0;
+    uint32_t format = 0, components = 0, tile_mode = 0, img_dim = 0;
+    uint32_t linear_row_pitch = 0;
+    uint32_t mip_tail_offset = 0, mip_tail_bytes = 0;
+    uint32_t mip_tail_x = 0, mip_tail_y = 0;
+    uint32_t vk_format = 0;
+    bool in_mip_tail = false;
+    bool srgb = false;
+    bool depth_compare = false;
+
+    bool operator==(const ComputeImageCacheKey& other) const = default;
+};
+
+struct ComputeImageCacheKeyHash {
+    size_t operator()(const ComputeImageCacheKey& key) const {
+        size_t result = std::hash<uint64_t>{}(key.gpu_addr);
+        const auto mix = [&](uint64_t value) {
+            result ^= std::hash<uint64_t>{}(value) + 0x9e3779b97f4a7c15ull +
+                      (result << 6) + (result >> 2);
+        };
+        mix(key.guest_bytes); mix(key.resource_bytes);
+        mix(key.width); mix(key.height); mix(key.depth);
+        mix(key.format); mix(key.components); mix(key.tile_mode); mix(key.img_dim);
+        mix(key.linear_row_pitch); mix(key.mip_tail_offset); mix(key.mip_tail_bytes);
+        mix(key.mip_tail_x); mix(key.mip_tail_y); mix(key.vk_format);
+        mix(key.in_mip_tail); mix(key.srgb); mix(key.depth_compare);
+        return result;
+    }
+};
+
+struct CachedComputeImage {
+    VkImage image = VK_NULL_HANDLE;
+    VkDeviceMemory memory = VK_NULL_HANDLE;
+    VkDeviceSize allocation_bytes = 0;
+    uint64_t last_use = 0;
+    uint32_t pins = 0;
+    bool content_valid = true;
+    // Several descriptors in one dispatch can name the same image with different sampler state.
+    // They need distinct views/samplers but validate the same guest byte range. Remember the first
+    // exact result for that setup epoch so later bindings do not rescan the complete surface.
+    uint64_t validation_epoch = 0;
+    bool validation_result = false;
+    prosper::host::GuestWriteWatch write_watch;
+    prosper::gpu::GuestGpuWriteSnapshot validation_snapshot;
+    std::vector<uint8_t> source_snapshot;
+};
+
+bool persistent_compute_buffer_enabled(uint32_t bytes) {
+    static const bool enabled =
+        std::getenv("PROSPER_NO_PERSISTENT_COMPUTE_BUFFERS") == nullptr;
+    // Small bindings are cheap and numerous. Residency targets the multi-megabyte SSBOs whose
+    // create/bind/full-compare cycle is visible in every Astro Bot frame.
+    return enabled && bytes >= (1u << 20);
+}
+
+VkDeviceSize persistent_compute_buffer_limit() {
+    static const VkDeviceSize limit = []() -> VkDeviceSize {
+        const char* value = std::getenv("PROSPER_COMPUTE_BUFFER_CACHE_MB");
+        const uint64_t mib = value ? std::strtoull(value, nullptr, 10) : 256ull;
+        if (mib > UINT64_MAX / (1024ull * 1024ull)) return VkDeviceSize{UINT64_MAX};
+        return static_cast<VkDeviceSize>(mib) * 1024ull * 1024ull;
+    }();
+    return limit;
+}
+
+bool persistent_compute_image_enabled(VkDeviceSize bytes) {
+    static const bool enabled =
+        std::getenv("PROSPER_NO_PERSISTENT_COMPUTE_IMAGES") == nullptr;
+    // The cache exists to remove full-surface detile/conversion/upload work. Tiny textures are both
+    // cheap and numerous, so leave them on the pooled transient path.
+    return enabled && bytes >= (1u << 20);
+}
+
+VkDeviceSize persistent_compute_image_limit() {
+    static const VkDeviceSize limit = []() -> VkDeviceSize {
+        const char* value = std::getenv("PROSPER_COMPUTE_IMAGE_CACHE_MB");
+        const uint64_t mib = value ? std::strtoull(value, nullptr, 10) : 512ull;
+        if (mib > UINT64_MAX / (1024ull * 1024ull)) return VkDeviceSize{UINT64_MAX};
+        return static_cast<VkDeviceSize>(mib) * 1024ull * 1024ull;
+    }();
+    return limit;
+}
+
 struct CachedComputePipeline {
     VkDescriptorSetLayout descriptor_layout = VK_NULL_HANDLE;
     VkShaderModule shader = VK_NULL_HANDLE;
@@ -398,6 +563,9 @@ struct VulkanComputeContext {
     VkQueue queue = VK_NULL_HANDLE;
     VkPipelineCache pipeline_cache = VK_NULL_HANDLE;
     VkDescriptorPool descriptor_pool = VK_NULL_HANDLE;
+    VkCommandPool command_pool = VK_NULL_HANDLE;
+    VkCommandBuffer command_buffer = VK_NULL_HANDLE;
+    VkFence dispatch_fence = VK_NULL_HANDLE;
     uint32_t descriptor_buffer_capacity = 0;
     uint32_t descriptor_sampled_capacity = 0;
     uint32_t descriptor_storage_capacity = 0;
@@ -405,6 +573,15 @@ struct VulkanComputeContext {
     uint32_t queue_family = UINT32_MAX;
     VkPhysicalDeviceMemoryProperties memory{};
     ComputeMemoryPool memory_pool;
+    std::unordered_map<ComputeBufferCacheKey, CachedComputeBuffer,
+                       ComputeBufferCacheKeyHash> buffer_cache;
+    VkDeviceSize buffer_cache_bytes = 0;
+    uint64_t buffer_cache_clock = 0;
+    std::unordered_map<ComputeImageCacheKey, CachedComputeImage,
+                       ComputeImageCacheKeyHash> image_cache;
+    VkDeviceSize image_cache_bytes = 0;
+    uint64_t image_cache_clock = 0;
+    uint64_t image_validation_clock = 0;
     // Storage-image support (#590): the recompiler's storage path declares the
     // StorageImageRead/WriteWithoutFormat capabilities (raw uvec4 texel model — see
     // tests/image_compute_runner.h, the exec-diff harness for that contract). When the device lacks
@@ -415,7 +592,11 @@ struct VulkanComputeContext {
     bool borrowed = false;
 
     ~VulkanComputeContext() {
+        release_cached_buffers();
+        release_cached_images();
         release_cached_memory();
+        if (dispatch_fence) vkDestroyFence(device, dispatch_fence, nullptr);
+        if (command_pool) vkDestroyCommandPool(device, command_pool, nullptr);
         if (descriptor_pool) vkDestroyDescriptorPool(device, descriptor_pool, nullptr);
         for (const auto& [key, cached] : pipelines) {
             (void)key;
@@ -435,6 +616,32 @@ struct VulkanComputeContext {
     static bool descriptor_pool_reuse_enabled() {
         static const bool enabled = std::getenv("PROSPER_NO_DESCRIPTOR_POOL_REUSE") == nullptr;
         return enabled;
+    }
+
+    bool prepare_dispatch_commands() {
+        if (!command_pool) {
+            VkCommandPoolCreateInfo pool_info{VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO};
+            pool_info.flags = VK_COMMAND_POOL_CREATE_TRANSIENT_BIT;
+            pool_info.queueFamilyIndex = queue_family;
+            if (vkCreateCommandPool(device, &pool_info, nullptr, &command_pool) != VK_SUCCESS)
+                return false;
+            VkCommandBufferAllocateInfo allocate{VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO};
+            allocate.commandPool = command_pool;
+            allocate.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+            allocate.commandBufferCount = 1;
+            if (vkAllocateCommandBuffers(device, &allocate, &command_buffer) != VK_SUCCESS)
+                return false;
+        } else if (vkResetCommandPool(device, command_pool, 0) != VK_SUCCESS) {
+            return false;
+        }
+        if (!dispatch_fence) {
+            VkFenceCreateInfo fence_info{VK_STRUCTURE_TYPE_FENCE_CREATE_INFO};
+            if (vkCreateFence(device, &fence_info, nullptr, &dispatch_fence) != VK_SUCCESS)
+                return false;
+        } else if (vkResetFences(device, 1, &dispatch_fence) != VK_SUCCESS) {
+            return false;
+        }
+        return command_buffer != VK_NULL_HANDLE;
     }
 
     VkDescriptorPool prepare_descriptor_pool(uint32_t buffers, uint32_t sampled,
@@ -662,6 +869,265 @@ struct VulkanComputeContext {
         memory_pool.cached_allocations = 0;
     }
 
+    void release_cached_buffers() {
+        if (!device) return;
+        for (auto& [key, cached] : buffer_cache) {
+            (void)key;
+            cached.write_watches.clear();
+            if (cached.buffer) vkDestroyBuffer(device, cached.buffer, nullptr);
+            if (cached.memory) release_memory(cached.memory);
+        }
+        buffer_cache.clear();
+        buffer_cache_bytes = 0;
+    }
+
+    void release_cached_images() {
+        if (!device) return;
+        for (auto& [key, cached] : image_cache) {
+            (void)key;
+            cached.write_watch.reset();
+            if (cached.image) vkDestroyImage(device, cached.image, nullptr);
+            if (cached.memory) release_memory(cached.memory);
+        }
+        image_cache.clear();
+        image_cache_bytes = 0;
+    }
+
+    bool make_buffer_cache_room(VkDeviceSize bytes) {
+        const VkDeviceSize limit = persistent_compute_buffer_limit();
+        if (bytes > limit) return false;
+        while (buffer_cache_bytes > limit - bytes) {
+            auto victim = buffer_cache.end();
+            for (auto it = buffer_cache.begin(); it != buffer_cache.end(); ++it) {
+                if (it->second.pins) continue;
+                if (victim == buffer_cache.end() ||
+                    it->second.last_use < victim->second.last_use)
+                    victim = it;
+            }
+            if (victim == buffer_cache.end()) return false;
+            victim->second.write_watches.clear();
+            if (victim->second.buffer) vkDestroyBuffer(device, victim->second.buffer, nullptr);
+            if (victim->second.memory) release_memory(victim->second.memory);
+            buffer_cache_bytes -= victim->second.allocation_bytes;
+            buffer_cache.erase(victim);
+        }
+        return true;
+    }
+
+    bool acquire_cached_buffer(const ComputeBufferCacheKey& key, const uint8_t* source,
+                               VkBuffer& buffer, VkDeviceMemory& memory, bool& upload_skipped,
+                               uint32_t& dirty_watch_chunks, uint32_t& total_watch_chunks) {
+        auto found = buffer_cache.find(key);
+        if (found == buffer_cache.end()) return false;
+        CachedComputeBuffer& cached = found->second;
+        cached.last_use = ++buffer_cache_clock;
+        ++cached.pins;
+        buffer = cached.buffer;
+        memory = cached.memory;
+        const bool submit_unchanged = !key.host_data &&
+            prosper::gpu::guest_gpu_writes_since(cached.validation_snapshot,
+                                                  key.gpu_addr, key.bytes) ==
+                prosper::gpu::GuestGpuWriteQuery::Unchanged;
+        std::vector<size_t> dirty_chunks;
+        bool watches_complete = !cached.write_watches.empty();
+        if (!submit_unchanged) {
+            for (size_t i = 0; i < cached.write_watches.size(); ++i) {
+                ++total_watch_chunks;
+                const auto query = cached.write_watches[i].watch.query();
+                if (query == prosper::host::GuestWriteWatchQuery::Unknown) {
+                    watches_complete = false;
+                } else if (query == prosper::host::GuestWriteWatchQuery::Dirty) {
+                    dirty_chunks.push_back(i);
+                }
+            }
+        }
+        dirty_watch_chunks = static_cast<uint32_t>(dirty_chunks.size());
+        upload_skipped = submit_unchanged || (watches_complete && dirty_chunks.empty());
+        if (!upload_skipped) {
+            void* mapped = nullptr;
+            if (map_memory(cached.memory, 0, key.bytes, &mapped) != VK_SUCCESS) {
+                --cached.pins;
+                buffer = VK_NULL_HANDLE;
+                memory = VK_NULL_HANDLE;
+                return false;
+            }
+            if (watches_complete) {
+                bool changed = false;
+                auto* destination = static_cast<uint8_t*>(mapped);
+                for (size_t index : dirty_chunks) {
+                    const ComputeBufferWriteWatchChunk& chunk = cached.write_watches[index];
+                    if (std::memcmp(destination + chunk.offset, source + chunk.offset,
+                                    chunk.bytes) == 0)
+                        continue;
+                    std::memcpy(destination + chunk.offset, source + chunk.offset, chunk.bytes);
+                    changed = true;
+                }
+                upload_skipped = !changed;
+            } else {
+                const bool changed = !compute_buffers_equal(mapped, source, key.bytes);
+                if (changed) copy_compute_buffer(mapped, source, key.bytes);
+                upload_skipped = !changed;
+            }
+            unmap_memory(cached.memory);
+            if (!key.host_data) validate_cached_buffer_source(key);
+        }
+        return true;
+    }
+
+    bool retain_buffer(const ComputeBufferCacheKey& key, VkBuffer buffer, VkDeviceMemory memory,
+                       VkDeviceSize allocation_bytes) {
+        if (!make_buffer_cache_room(allocation_bytes)) return false;
+        CachedComputeBuffer cached;
+        cached.buffer = buffer;
+        cached.memory = memory;
+        cached.allocation_bytes = allocation_bytes;
+        cached.last_use = ++buffer_cache_clock;
+        cached.pins = 1;
+        if (!key.host_data) {
+            for (uint32_t offset = 0; offset < key.bytes;) {
+                const uint32_t bytes = std::min(kComputeBufferWriteWatchChunkBytes,
+                                                key.bytes - offset);
+                cached.write_watches.push_back({
+                    offset, bytes,
+                    prosper::host::GuestWriteWatch::create(key.gpu_addr + offset, bytes)});
+                offset += bytes;
+            }
+        }
+        if (!key.host_data)
+            cached.validation_snapshot = prosper::gpu::guest_gpu_write_snapshot();
+        auto [it, inserted] = buffer_cache.emplace(key, std::move(cached));
+        if (!inserted) return false;
+        buffer_cache_bytes += allocation_bytes;
+        return true;
+    }
+
+    void release_cached_buffer(const ComputeBufferCacheKey& key) {
+        auto found = buffer_cache.find(key);
+        if (found != buffer_cache.end() && found->second.pins) --found->second.pins;
+    }
+
+    void validate_cached_buffer_source(const ComputeBufferCacheKey& key) {
+        auto found = buffer_cache.find(key);
+        if (found == buffer_cache.end() || key.host_data) return;
+        CachedComputeBuffer& cached = found->second;
+        cached.validation_snapshot = prosper::gpu::guest_gpu_write_snapshot();
+        for (ComputeBufferWriteWatchChunk& chunk : cached.write_watches) {
+            if (chunk.watch && chunk.watch.rearm()) continue;
+            chunk.watch.reset();
+            chunk.watch = prosper::host::GuestWriteWatch::create(
+                key.gpu_addr + chunk.offset, chunk.bytes);
+        }
+    }
+
+    bool make_image_cache_room(VkDeviceSize bytes) {
+        const VkDeviceSize limit = persistent_compute_image_limit();
+        if (bytes > limit) return false;
+        while (image_cache_bytes > limit - bytes) {
+            auto victim = image_cache.end();
+            for (auto it = image_cache.begin(); it != image_cache.end(); ++it) {
+                if (it->second.pins) continue;
+                if (victim == image_cache.end() ||
+                    it->second.last_use < victim->second.last_use)
+                    victim = it;
+            }
+            if (victim == image_cache.end()) return false;
+            victim->second.write_watch.reset();
+            if (victim->second.image) vkDestroyImage(device, victim->second.image, nullptr);
+            if (victim->second.memory) release_memory(victim->second.memory);
+            image_cache_bytes -= victim->second.allocation_bytes;
+            image_cache.erase(victim);
+        }
+        return true;
+    }
+
+    bool acquire_cached_image(const ComputeImageCacheKey& key, const uint8_t* source,
+                              uint64_t validation_epoch, VkImage& image,
+                              VkDeviceMemory& memory, bool& upload_skipped) {
+        auto found = image_cache.find(key);
+        if (found == image_cache.end()) return false;
+        CachedComputeImage& cached = found->second;
+        cached.last_use = ++image_cache_clock;
+        ++cached.pins;
+        image = cached.image;
+        memory = cached.memory;
+        if (validation_epoch && cached.validation_epoch == validation_epoch) {
+            upload_skipped = cached.validation_result;
+            return true;
+        }
+        const bool submit_unchanged = cached.content_valid &&
+            prosper::gpu::guest_gpu_writes_since(cached.validation_snapshot,
+                                                  key.gpu_addr, key.guest_bytes) ==
+                prosper::gpu::GuestGpuWriteQuery::Unchanged;
+        const bool watch_unchanged = !submit_unchanged && cached.content_valid &&
+            cached.write_watch &&
+            cached.write_watch.query() == prosper::host::GuestWriteWatchQuery::Unchanged;
+        const bool exact_unchanged = cached.content_valid && !submit_unchanged &&
+            !watch_unchanged && source &&
+            cached.source_snapshot.size() == key.guest_bytes &&
+            std::memcmp(cached.source_snapshot.data(), source, key.guest_bytes) == 0;
+        upload_skipped = submit_unchanged || watch_unchanged || exact_unchanged;
+        cached.validation_epoch = validation_epoch;
+        cached.validation_result = upload_skipped;
+        if (exact_unchanged) {
+            cached.validation_snapshot = prosper::gpu::guest_gpu_write_snapshot();
+            if (!cached.write_watch || !cached.write_watch.rearm()) {
+                cached.write_watch.reset();
+                cached.write_watch = prosper::host::GuestWriteWatch::create(
+                    key.gpu_addr, key.guest_bytes);
+            }
+        } else if (!upload_skipped && source) {
+            cached.source_snapshot.assign(source, source + key.guest_bytes);
+            // Do not trust the new mirror until the corresponding transfer completes. A failed
+            // submit leaves this false, so the next use refreshes instead of skipping stale pixels.
+            cached.content_valid = false;
+        }
+        return true;
+    }
+
+    bool retain_image(const ComputeImageCacheKey& key, VkImage image, VkDeviceMemory memory,
+                      VkDeviceSize allocation_bytes, const uint8_t* source) {
+        if (!make_image_cache_room(allocation_bytes)) return false;
+        CachedComputeImage cached;
+        cached.image = image;
+        cached.memory = memory;
+        cached.allocation_bytes = allocation_bytes;
+        cached.last_use = ++image_cache_clock;
+        cached.pins = 1;
+        cached.write_watch = prosper::host::GuestWriteWatch::create(
+            key.gpu_addr, key.guest_bytes);
+        cached.validation_snapshot = prosper::gpu::guest_gpu_write_snapshot();
+        if (source)
+            cached.source_snapshot.assign(source, source + key.guest_bytes);
+        auto [it, inserted] = image_cache.emplace(key, std::move(cached));
+        if (!inserted) return false;
+        image_cache_bytes += allocation_bytes;
+        return true;
+    }
+
+    void release_cached_image(const ComputeImageCacheKey& key) {
+        auto found = image_cache.find(key);
+        if (found != image_cache.end() && found->second.pins) --found->second.pins;
+    }
+
+    void validate_cached_image_source(const ComputeImageCacheKey& key,
+                                      const uint8_t* current_source = nullptr) {
+        auto found = image_cache.find(key);
+        if (found == image_cache.end()) return;
+        CachedComputeImage& cached = found->second;
+        // A storage dispatch replaces both the image and its guest-memory mirror. Retain those
+        // result bytes as the exact comparison baseline; keeping the pre-dispatch input here could
+        // misclassify a later guest write that restores that old input as "unchanged".
+        if (current_source)
+            cached.source_snapshot.assign(current_source,
+                                          current_source + key.guest_bytes);
+        cached.content_valid = true;
+        cached.validation_snapshot = prosper::gpu::guest_gpu_write_snapshot();
+        if (cached.write_watch && cached.write_watch.rearm()) return;
+        cached.write_watch.reset();
+        cached.write_watch = prosper::host::GuestWriteWatch::create(
+            key.gpu_addr, key.guest_bytes);
+    }
+
     // A GRAPHICS queue family is not required by spec to also advertise COMPUTE, and the renderer
     // selects its family on GRAPHICS alone. Dispatching on a family without COMPUTE is invalid usage,
     // so verify before adopting rather than assuming the common family-0 layout.
@@ -785,6 +1251,7 @@ struct VulkanComputeContext {
                 return i;
         return UINT32_MAX;
     }
+
 };
 
 struct BoundBuffer {
@@ -792,6 +1259,12 @@ struct BoundBuffer {
     VkBuffer buffer = VK_NULL_HANDLE;
     VkDeviceMemory memory = VK_NULL_HANDLE;
     size_t alias_of = SIZE_MAX;         // exact guest range sharing an earlier storage buffer
+    bool writable = false;              // reflected OpStore/writing-atomic reachability
+    bool persistent = false;
+    bool upload_skipped = false;
+    uint32_t dirty_watch_chunks = 0;
+    uint32_t total_watch_chunks = 0;
+    ComputeBufferCacheKey cache_key{};
     uint64_t before_hash = 0, after_hash = 0;
     uint64_t changed_bytes = 0;
 };
@@ -822,6 +1295,7 @@ struct BoundImage {
     const prosper::gpu::ShaderResource* resource = nullptr;
     uint32_t binding = 0;
     bool storage = false;               // storage image: read back + pack to guest after the dispatch
+    bool native_float_storage = false;  // Vulkan performs exact UNORM/float conversion at native width
     VkImage image = VK_NULL_HANDLE;
     VkDeviceMemory memory = VK_NULL_HANDLE;
     VkImageView view = VK_NULL_HANDLE;
@@ -835,6 +1309,20 @@ struct BoundImage {
     // renderer: it must not be destroyed here, its layout must be restored, and the pin taken at
     // import time must be released.
     bool imported = false;
+    bool imported_depth = false;        // borrowed persistent DS depth plane, not a color RTT
+    VkFormat imported_format = VK_FORMAT_UNDEFINED;
+    // A native-resolution storage image backed by a reduced-resolution renderer RTT. `image` is a
+    // temporary compute image; `bridge_image` is the pinned renderer image. Two GPU blits replace
+    // the old CPU snapshot upscale + guest writeback while preserving integer storage coordinates.
+    bool scaled_bridge = false;
+    VkImage bridge_image = VK_NULL_HANDLE;
+    uint32_t bridge_width = 0, bridge_height = 0;
+    bool persistent = false;            // guest-backed sampled image retained across dispatches
+    bool cache_candidate = false;
+    bool upload_skipped = false;         // write watch proved the cached source unchanged
+    VkDeviceSize allocation_bytes = 0;
+    ComputeImageCacheKey cache_key{};
+    std::vector<uint8_t> cache_source_snapshot; // first-use source captured before the transfer
     bool seed_skip = false;             // #1122: write-only full-coverage storage image; no seed needed
     bool poison_verify = false;         // #1122: proving frame -- seed poison, prove full coverage
     std::vector<uint8_t> seed_linear;   // #1122: detiled guest seed, kept on a proving frame so any
@@ -1167,8 +1655,10 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
     auto phase_writeback = phase_start;
     double pack_ms = 0.0;
     double layout_ms = 0.0;
+    const std::vector<uint32_t>& spirv = item.spirv;
     const bool trace = trace_compute_item(item);
-    // #1122 review B1: covers_extent (dispatch grid >= image extent) is NECESSARY but NOT SUFFICIENT
+    const uint64_t image_validation_epoch = ++ctx.image_validation_clock;
+    // #1122 review B1: enough invocations for all texels is NECESSARY but NOT SUFFICIENT
     // for skipping the seed. A write-only shader can store a subset of its grid (a masked composite:
     // `if (mask) imageStore(...)`, or a scatter store), covering the grid yet leaving untouched texels
     // undefined. Skipping the seed there would pack reused-pool garbage to the guest -- silent
@@ -1202,25 +1692,14 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
     // disabling the safety (see seed_reprove_interval_from_env).
     static const uint32_t kSeedReproveInterval =
         seed_reprove_interval_from_env(std::getenv("PROSPER_SEED_REPROVE"), 256u);
-    // #1122: a compute post-process that only image_stores its output (no image_load) never reads the
-    // seed, so materializing the renderer RTT's prior pixels into it is wasted. Detect it cheaply: an
-    // OpImageRead-free SPIR-V reads no storage image at all. Combined with full dispatch coverage of
-    // the target, the seed (a GPU readback + rgba8->uvec4 expand + upload, ~20 ms/frame on Blasphemous
-    // 2's full-screen composite) can be skipped entirely. PROSPER_NO_SKIP_SEED forces the seed.
-    const bool shader_reads_no_image = [&] {
-        if (std::getenv("PROSPER_NO_SKIP_SEED")) return false;
-        const auto& w = item.spirv;
-        for (size_t k = 5; k < w.size();) {
-            const uint32_t wc = w[k] >> 16, op = w[k] & 0xffff;
-            if (!wc) break;
-            if (op == 98u /* OpImageRead */) return false;
-            k += wc;
-        }
-        return true;
-    }();
+    // #1122: a compute post-process that only image_stores an output never reads that output's seed.
+    // Reflection tracks image access per descriptor: a shader may read several input storage images
+    // while binding a distinct write-only output, so the old shader-wide OpImageRead test needlessly
+    // seeded the output (66 MiB/frame for Astro Bot's 4K FP16 post target).
+    const bool seed_skip_enabled = std::getenv("PROSPER_NO_SKIP_SEED") == nullptr;
     const auto setup_validate_start = ComputeClock::now();
     auto report = validate_spirv_descriptor_interface(
-        item.spirv, item.resources.get(), 0, SpirvShaderStage::Compute, false);
+        spirv, item.resources.get(), 0, SpirvShaderStage::Compute, false);
     if (!report.ok()) return false;
     double setup_validate_ms = std::chrono::duration<double, std::milli>(
         ComputeClock::now() - setup_validate_start).count();
@@ -1280,8 +1759,6 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
     VkPipeline pipeline = VK_NULL_HANDLE;
     bool pipeline_cached = false;
     std::string pipeline_key;
-    VkCommandPool command_pool = VK_NULL_HANDLE;
-    VkFence fence = VK_NULL_HANDLE;
     bool ok = false;
     auto vk_ok = [&](VkResult result, const char* stage) {
         if (result == VK_SUCCESS) return true;
@@ -1296,8 +1773,6 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
     };
 
     auto cleanup = [&] {
-        if (fence) vkDestroyFence(ctx.device, fence, nullptr);
-        if (command_pool) vkDestroyCommandPool(ctx.device, command_pool, nullptr);
         if (!pipeline_cached) {
             if (pipeline) vkDestroyPipeline(ctx.device, pipeline, nullptr);
             if (pipeline_layout) vkDestroyPipelineLayout(ctx.device, pipeline_layout, nullptr);
@@ -1309,20 +1784,29 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             vkDestroyDescriptorPool(ctx.device, descriptor_pool, nullptr);
         for (auto& buffer : buffers) {
             if (buffer.alias_of != SIZE_MAX) continue;
+            if (buffer.persistent) {
+                ctx.release_cached_buffer(buffer.cache_key);
+                continue;
+            }
             if (buffer.buffer) vkDestroyBuffer(ctx.device, buffer.buffer, nullptr);
             if (buffer.memory) ctx.release_memory(buffer.memory);
         }
         for (size_t i = 0; i < images.size(); i++) {
             // A pin is taken per successful import, so it is released per import -- including for a
             // binding that a later alias check folded into an earlier one (#1095).
-            if (images[i].imported) release_live_render_target_image(images[i].imported_addr);
+            if (images[i].imported || images[i].scaled_bridge)
+                release_live_render_target_image(images[i].imported_addr);
             if (images[i].alias_of != SIZE_MAX) continue;
             if (images[i].sampler) vkDestroySampler(ctx.device, images[i].sampler, nullptr);
             if (images[i].view) vkDestroyImageView(ctx.device, images[i].view, nullptr);
+            if (images[i].persistent) {
+                ctx.release_cached_image(images[i].cache_key);
+            } else {
             // An imported image belongs to the live renderer: release the pin, destroy nothing.
-            if (images[i].image && !images[i].imported)
-                vkDestroyImage(ctx.device, images[i].image, nullptr);
-            if (images[i].memory) ctx.release_memory(images[i].memory);
+                if (images[i].image && !images[i].imported)
+                    vkDestroyImage(ctx.device, images[i].image, nullptr);
+                if (images[i].memory) ctx.release_memory(images[i].memory);
+            }
             if (staging[i]) vkDestroyBuffer(ctx.device, staging[i], nullptr);
             if (staging_memory[i]) ctx.release_memory(staging_memory[i]);
         }
@@ -1346,6 +1830,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 ((!resource->host_data || resource->host_data_size < resource->size) &&
                  !guest_readable(resource->gpu_addr, resource->size))) break;
             buffers[i].resource = resource;
+            buffers[i].writable = descriptors[i].writable;
             for (size_t j = 0; j < i; ++j) {
                 const ShaderResource* prior = buffers[j].resource;
                 if (!prior || prior->gpu_addr != resource->gpu_addr ||
@@ -1357,32 +1842,57 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 const BoundBuffer& owner = buffers[buffers[i].alias_of];
                 buffers[i].buffer = owner.buffer;
                 buffers[i].memory = owner.memory;
+                buffers[buffers[i].alias_of].writable |= buffers[i].writable;
                 break;
             }
             if (buffers[i].alias_of == SIZE_MAX) {
-                VkBufferCreateInfo bci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
-                bci.size = resource->size;
-                bci.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
-                if (vkCreateBuffer(ctx.device, &bci, nullptr, &buffers[i].buffer) != VK_SUCCESS) break;
-                VkMemoryRequirements requirements{};
-                vkGetBufferMemoryRequirements(ctx.device, buffers[i].buffer, &requirements);
-                const uint32_t memory_type = ctx.host_memory_type(requirements.memoryTypeBits);
-                if (memory_type == UINT32_MAX) break;
-                buffers[i].memory = ctx.allocate_memory(requirements.size, memory_type, true);
-                if (!buffers[i].memory) break;
-                if (vkBindBufferMemory(ctx.device, buffers[i].buffer, buffers[i].memory, 0) != VK_SUCCESS) break;
-                void* mapped = nullptr;
-                if (ctx.map_memory(buffers[i].memory, 0, resource->size, &mapped) != VK_SUCCESS)
-                    break;
                 const uint8_t* source = resource_bytes(resource);
                 if (trace) buffers[i].before_hash = fnv1a(source, resource->size);
-                // Pooled host-visible allocations retain their previous contents. Compare them with
-                // current guest memory before uploading: an exact match is safe to reuse even when a
-                // different resource owned the allocation previously, while any guest CPU mutation
-                // still takes the ordinary full-copy path.
-                if (std::memcmp(mapped, source, resource->size) != 0)
-                    std::memcpy(mapped, source, resource->size);
-                ctx.unmap_memory(buffers[i].memory);
+                buffers[i].cache_key = {
+                    resource->gpu_addr, reinterpret_cast<uintptr_t>(resource->host_data),
+                    resource->size};
+                const bool cache_candidate = persistent_compute_buffer_enabled(resource->size);
+                if (cache_candidate && ctx.acquire_cached_buffer(
+                        buffers[i].cache_key, source, buffers[i].buffer, buffers[i].memory,
+                        buffers[i].upload_skipped, buffers[i].dirty_watch_chunks,
+                        buffers[i].total_watch_chunks)) {
+                    buffers[i].persistent = true;
+                } else {
+                    VkBufferCreateInfo bci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
+                    bci.size = resource->size;
+                    bci.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
+                    if (vkCreateBuffer(ctx.device, &bci, nullptr, &buffers[i].buffer) != VK_SUCCESS)
+                        break;
+                    VkMemoryRequirements requirements{};
+                    vkGetBufferMemoryRequirements(ctx.device, buffers[i].buffer, &requirements);
+                    const uint32_t memory_type = ctx.host_memory_type(requirements.memoryTypeBits);
+                    if (memory_type == UINT32_MAX) break;
+                    buffers[i].memory = ctx.allocate_memory(requirements.size, memory_type, true);
+                    if (!buffers[i].memory) break;
+                    if (vkBindBufferMemory(ctx.device, buffers[i].buffer, buffers[i].memory, 0) !=
+                        VK_SUCCESS)
+                        break;
+                    void* mapped = nullptr;
+                    if (ctx.map_memory(buffers[i].memory, 0, resource->size, &mapped) != VK_SUCCESS)
+                        break;
+                    // Pooled host-visible allocations retain their previous contents. Compare them
+                    // with current guest memory before uploading: any mutation takes the exact copy.
+                    if (!compute_buffers_equal(mapped, source, resource->size))
+                        copy_compute_buffer(mapped, source, resource->size);
+                    ctx.unmap_memory(buffers[i].memory);
+                    if (cache_candidate && ctx.retain_buffer(
+                            buffers[i].cache_key, buffers[i].buffer, buffers[i].memory,
+                            requirements.size))
+                        buffers[i].persistent = true;
+                }
+                if (trace && buffers[i].persistent)
+                    std::fprintf(stderr,
+                                 "[compute]   persistent buffer binding=%u addr=0x%llx size=%u "
+                                 "upload-skipped=%u dirty-watch-chunks=%u/%u\n",
+                                 resource->binding, (unsigned long long)resource->gpu_addr,
+                                 resource->size, buffers[i].upload_skipped ? 1u : 0u,
+                                 buffers[i].dirty_watch_chunks,
+                                 buffers[i].total_watch_chunks);
             }
 
             layout_bindings[i].binding = descriptors[i].binding;
@@ -1425,13 +1935,25 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             }
             images_ready = false;
         };
+        const bool image_timing = std::getenv("PROSPER_COMPUTE_IMAGE_TIMING") != nullptr;
         for (size_t i = 0; i < image_descriptors.size() && images_ready; i++) {
+            const auto image_start = ComputeClock::now();
             const ShaderResource* r = item.resources->by_binding(image_descriptors[i].binding);
             if (!r || !r->width || !r->height) { skip_image(r, "no/degenerate resource"); break; }
             BoundImage& bi = images[i];
             bi.resource = r;
             bi.binding = image_descriptors[i].binding;
             bi.storage = image_descriptors[i].kind == SpirvDescriptorKind::StorageImage;
+            bi.native_float_storage = bi.storage && native_float_storage_image(
+                r->format, r->num_components ? r->num_components : 1, r->srgb);
+            if (trace)
+                std::fprintf(stderr,
+                             "[compute]   image binding=%u class=%s addr=0x%llx "
+                             "extent=%ux%ux%u format=%u components=%u tile=%u native-storage=%u\n",
+                             bi.binding, bi.storage ? "storage" : "sampled",
+                             (unsigned long long)r->gpu_addr, r->width, r->height, r->depth,
+                             (unsigned)r->format, r->num_components, r->tile_mode,
+                             bi.native_float_storage ? 1u : 0u);
             // A surface whose CURRENT pixels live in the renderer's RTT cache must not be read from
             // raw guest memory (empty/stale — the Dead Cells 642x362 lesson).
             const bool dim_1d = r->img_dim == 0;
@@ -1481,6 +2003,11 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             // writeback publishes ordinary guest bytes and invalidates the renderer-owned copy.
             LiveTargetSnapshot live_target;
             bool renderer_owned = !r->in_mip_tail && is_live_render_target(r->gpu_addr);
+            static const uint32_t render_scale = [] {
+                const char* e = std::getenv("PROSPER_RENDER_SCALE");
+                const long v = e ? std::strtol(e, nullptr, 10) : 1;
+                return v > 0 ? static_cast<uint32_t>(v) : 1u;
+            }();
             // Bind the renderer's own image when it is the authoritative copy and this binding
             // matches it EXACTLY (#1095, phase 2 of #1091). RGBA8 and RGBA16F targets both have a
             // byte-identical sampled Vulkan view, so neither needs to round-trip through a CPU
@@ -1488,16 +2015,56 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             // converting a 4K target down to UNORM8 cost more than the compute dispatch itself and
             // also discarded HDR values. Aliases and numerically converted views keep the snapshot
             // path below.
-            if (renderer_owned && !bi.storage && !dim_1d && !dim_3d && !dim_2d_array &&
+            const bool depth_import_eligible = !bi.storage && !dim_1d && !dim_3d &&
+                !dim_2d_array && r->depth == 1 && r->img_dim == 1 &&
+                r->format == DataFormat::Float32 &&
+                (r->num_components ? r->num_components : 1u) == 1u;
+            if ((renderer_owned || depth_import_eligible) &&
+                (!bi.storage || bi.native_float_storage) &&
+                !dim_1d && !dim_3d && !dim_2d_array &&
                 r->depth == 1 && !r->depth_compare) {
                 LiveTargetImageImport import;
-                if (import_live_render_target_image(r->gpu_addr, import)) {
-                    if (direct_sampled_rtt_compatible(
-                            r->format, r->num_components ? r->num_components : 1,
-                            import.format) &&
-                        import.width == r->width && import.height == r->height &&
-                        import.device == static_cast<void*>(ctx.device)) {
+                const LiveTargetImageRequest import_request{
+                    r->width, r->height, render_scale, depth_import_eligible};
+                const bool import_available = import_live_render_target_image(
+                    r->gpu_addr, import_request, import);
+                if (trace)
+                    std::fprintf(stderr,
+                                 "[compute]   direct RTT candidate binding=%u addr=0x%llx "
+                                 "requested=f%u/c%u dim=%u extent=%ux%u available=%u "
+                                 "imported=%ux%u/%u kind=%s native=%u\n",
+                                 bi.binding, (unsigned long long)r->gpu_addr,
+                                 (unsigned)r->format, r->num_components, r->img_dim,
+                                 r->width, r->height, import_available ? 1u : 0u,
+                                 import.width, import.height, (unsigned)import.format,
+                                 import.kind == LiveTargetImageImport::Kind::Depth
+                                     ? "depth" : "color",
+                                 import.native_format);
+                if (import_available) {
+                    const bool depth_import =
+                        import.kind == LiveTargetImageImport::Kind::Depth;
+                    const VkFormat depth_format = static_cast<VkFormat>(import.native_format);
+                    const bool compatible_format = depth_import
+                        ? depth_import_eligible &&
+                              (depth_format == VK_FORMAT_D32_SFLOAT ||
+                               depth_format == VK_FORMAT_D32_SFLOAT_S8_UINT)
+                        : direct_sampled_rtt_compatible(
+                              r->format, r->num_components ? r->num_components : 1,
+                              import.format);
+                    const bool compatible_device =
+                        import.device == static_cast<void*>(ctx.device);
+                    const bool direct_extent = bi.storage
+                        ? import.width == r->width && import.height == r->height
+                        : prosper::frontend::rtt_sampled_extent_compatible(
+                              r->width, r->height, import.width, import.height, render_scale);
+                    const bool bridge_extent = bi.storage && bi.native_float_storage &&
+                        image_descriptors[i].writable &&
+                        prosper::frontend::rtt_storage_bridge_extent_compatible(
+                            r->width, r->height, import.width, import.height, render_scale);
+                    if (compatible_format && direct_extent && compatible_device) {
                         bi.imported = true;
+                        bi.imported_depth = depth_import;
+                        bi.imported_format = depth_import ? depth_format : VK_FORMAT_UNDEFINED;
                         bi.imported_addr = r->gpu_addr;
                         bi.imported_saved_layout = import.layout;
                         bi.image = static_cast<VkImage>(import.image);
@@ -1506,12 +2073,27 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         live_target.format = import.format;
                         if (trace)
                             std::fprintf(stderr,
-                                         "[compute]   bound renderer RTT in place binding=%u "
+                                         "[compute]   bound renderer RTT in place binding=%u class=%s "
                                          "addr=0x%llx extent=%ux%u format=%s\n",
+                                         bi.binding, bi.storage ? "storage" : "sampled",
+                                         (unsigned long long)r->gpu_addr,
+                                         import.width, import.height,
+                                         depth_import ? "depth"
+                                             : import.format == LiveTargetPixelFormat::Rgba16Float
+                                                   ? "rgba16f" : "rgba8");
+                    } else if (compatible_format && bridge_extent && compatible_device) {
+                        bi.scaled_bridge = true;
+                        bi.imported_addr = r->gpu_addr;
+                        bi.imported_saved_layout = import.layout;
+                        bi.bridge_image = static_cast<VkImage>(import.image);
+                        bi.bridge_width = import.width;
+                        bi.bridge_height = import.height;
+                        if (trace)
+                            std::fprintf(stderr,
+                                         "[compute]   GPU-scaled renderer RTT bridge binding=%u "
+                                         "addr=0x%llx %ux%u <-> %ux%u\n",
                                          bi.binding, (unsigned long long)r->gpu_addr,
-                                         r->width, r->height,
-                                         import.format == LiveTargetPixelFormat::Rgba16Float
-                                             ? "rgba16f" : "rgba8");
+                                         import.width, import.height, r->width, r->height);
                     } else {
                         // Not our exact contract (a different device or a stale aliased view).
                         release_live_render_target_image(r->gpu_addr);
@@ -1520,15 +2102,17 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             }
             // #1122: skip the seed entirely for a write-only storage image whose dispatch fully
             // covers the target -- BUT only after proving (once per shader) that the write actually
-            // stores every texel (see the SeedCoverage cache above). One thread per texel with global
-            // size >= extent is a NECESSARY condition (a partially-covered grid always seeds); the
-            // proving frame establishes it is also sufficient for this specific shader.
-            const bool covers_extent =
-                item.launch.threads_x >= r->width && item.launch.threads_y >= r->height &&
-                item.launch.threads_z >= r->depth;
+            // stores every texel (see the SeedCoverage cache above). Enough total invocations is a
+            // NECESSARY condition (a smaller grid always seeds), but the mapping need not be one
+            // invocation per same-axis texel: vectorized/swizzled kernels are common. The poison
+            // proving frame establishes actual full coverage for this shader/binding/extent.
+            const bool enough_threads = dispatch_has_enough_threads_for_texels(
+                item.launch.threads_x, item.launch.threads_y, item.launch.threads_z,
+                r->width, r->height, r->depth);
             // Diagnostic: force the proving (poison) path on every eligible dispatch, never fast-skip.
             static const bool force_verify = std::getenv("PROSPER_VERIFY_SEED_SKIP") != nullptr;
-            if (bi.storage && shader_reads_no_image && covers_extent) {
+            if (bi.storage && seed_skip_enabled && !image_descriptors[i].readable &&
+                image_descriptors[i].writable && enough_threads) {
                 const SeedCoverageKey proof_key{item.code_addr, bi.binding,
                                                 r->width, r->height, r->depth};
                 bool proven_full = false, known = false, reprove_due = false;
@@ -1568,7 +2152,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 }
                 // Proven Partial: fall through, seed normally every frame.
             }
-            if (renderer_owned && !bi.imported && !bi.seed_skip) {
+            if (renderer_owned && !bi.imported && !bi.scaled_bridge && !bi.seed_skip) {
                 if (dim_3d || r->depth != 1 ||
                     !read_live_render_target(r->gpu_addr, live_target) || !live_target.pixels) {
                     skip_image(r, "renderer-owned RTT has no readable snapshot"); break;
@@ -1580,24 +2164,15 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 // base after a dynamic-resolution change — the snapshot is NOT this view). Only (a) upscales;
                 // (b) still falls back to guest backing.
                 //
-                // "Equal-on-both-axes integer multiple" is necessary but NOT sufficient to prove a downscale
-                // (a hypothetical alias could also be an exact 2x/3x view), so ALSO require k to equal the
-                // configured render scale. A legitimate render-scale target always downscales by exactly
-                // `scale` (hle_agc.cpp: dim = (present/scale) & ~1u), so this cross-check rejects no working
-                // case, makes scale<=1 a structural no-op, and rejects any alias whose ratio != scale.
-                // Limitation: a target whose native extent is not an exact multiple of scale (odd dims like
-                // 642x362, or present not divisible by scale) yields k=0 and still falls back to guest
-                // backing — no regression, but this fix does not cover those.
-                static const uint32_t render_scale = [] {
-                    const char* e = std::getenv("PROSPER_RENDER_SCALE");
-                    long v = e ? std::strtol(e, nullptr, 10) : 1;
-                    return v > 0 ? (uint32_t)v : 1u;
-                }();
+                // The renderer rounds each native axis independently when it constructs a scaled target.
+                // Requiring an exact integer ratio rejects legitimate non-divisible extents (for example
+                // 1216x684 -> 405x228 at scale 3), so use the shared rounded-extent proof. A stale view alias
+                // still fails unless BOTH cached axes equal the configured-scale result.
                 if (live_target.width != r->width || live_target.height != r->height) {
-                    const uint32_t k = prosper::frontend::rtt_integer_upscale_factor(
-                        r->width, r->height, live_target.width, live_target.height);
+                    const bool scaled_extent = prosper::frontend::rtt_scaled_extent_compatible(
+                        r->width, r->height, live_target.width, live_target.height, render_scale);
                     const uint64_t bpp = live_target.format == LiveTargetPixelFormat::Rgba16Float ? 8u : 4u;
-                    if (k && k == render_scale && live_target.pixels &&
+                    if (scaled_extent && live_target.pixels &&
                         live_target.pixels->size() == (uint64_t)live_target.width * live_target.height * bpp) {
                         const uint32_t sw = live_target.width, sh = live_target.height;
                         auto up = std::make_shared<std::vector<uint8_t>>(
@@ -1605,10 +2180,15 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         const uint8_t* src = live_target.pixels->data();
                         uint8_t* dst = up->data();
                         for (uint32_t y = 0; y < r->height; y++) {
-                            const uint32_t sy = y / k;
+                            const uint32_t sy = std::min<uint32_t>(
+                                sh - 1u, static_cast<uint32_t>(
+                                    static_cast<uint64_t>(y) * sh / r->height));
                             for (uint32_t x = 0; x < r->width; x++) {
+                                const uint32_t sx = std::min<uint32_t>(
+                                    sw - 1u, static_cast<uint32_t>(
+                                        static_cast<uint64_t>(x) * sw / r->width));
                                 std::memcpy(dst + ((size_t)y * r->width + x) * bpp,
-                                            src + ((size_t)sy * sw + x / k) * bpp, bpp);
+                                            src + ((size_t)sy * sw + sx) * bpp, bpp);
                             }
                         }
                         live_target.pixels = up;
@@ -1618,7 +2198,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                          "[compute]   renderer RTT upscaled binding=%u addr=0x%llx "
                                          "%ux%u -> %ux%u (RENDER_SCALE x%u)\n",
                                          bi.binding, (unsigned long long)r->gpu_addr, sw, sh,
-                                         r->width, r->height, k);
+                                         r->width, r->height, render_scale);
                     } else {
                         renderer_owned = false;
                         if (trace)
@@ -1641,20 +2221,21 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     }
                 }
                 if (renderer_owned && !bi.storage &&
-                    (r->format == DataFormat::Uint16 || r->format == DataFormat::Uint32)) {
+                    (r->format == DataFormat::Float32 || r->format == DataFormat::Uint16 ||
+                     r->format == DataFormat::Uint32)) {
                     const uint64_t cached_bpp =
                         live_target.format == LiveTargetPixelFormat::Rgba16Float ? 8u : 4u;
                     const uint64_t requested_bpp =
                         static_cast<uint64_t>(data_format_bytes(r->format)) *
                         (r->num_components ? r->num_components : 1u);
                     if (cached_bpp != requested_bpp) {
-                        // A UINT view is a bit reinterpretation of the target allocation. When the
+                        // A typed view is a bit reinterpretation of the target allocation. When the
                         // cached and requested texel widths differ, the renderer snapshot is a
                         // different alias and cannot be expanded or numerically converted safely.
                         renderer_owned = false;
                         if (trace)
                             std::fprintf(stderr,
-                                         "[compute]   renderer RTT integer-view miss binding=%u "
+                                         "[compute]   renderer RTT typed-view miss binding=%u "
                                          "addr=0x%llx cached-bpp=%llu requested-bpp=%llu "
                                          "-> guest backing\n",
                                          bi.binding, (unsigned long long)r->gpu_addr,
@@ -1737,7 +2318,17 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                  bi.binding, owner.binding, (unsigned long long)r->gpu_addr);
                 break;
             }
-            if (bi.alias_of != SIZE_MAX) continue;
+            if (bi.alias_of != SIZE_MAX) {
+                if (image_timing)
+                    std::fprintf(stderr,
+                                 "[compute-image] code=0x%llx binding=%u class=%s alias=1 "
+                                 "extent=%ux%ux%u ms=%.3f\n",
+                                 (unsigned long long)item.code_addr, bi.binding,
+                                 bi.storage ? "storage" : "sampled", r->width, r->height, r->depth,
+                                 std::chrono::duration<double, std::milli>(
+                                     ComputeClock::now() - image_start).count());
+                continue;
+            }
             const VkDeviceSize volume_texels = static_cast<VkDeviceSize>(r->width) * r->height * r->depth;
             const uint32_t sampled_components = r->num_components ? r->num_components : 1;
             const bool sampled_depth = !bi.storage && r->depth_compare && dim_2d_array &&
@@ -1750,9 +2341,14 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             const bool sampled_float32 = !bi.storage && !sampled_depth &&
                                          r->format == DataFormat::Float32 &&
                                          sampled_components >= 1 && sampled_components <= 4;
+            // Vulkan supplies (0, 0, 1) for missing sampled-image channels, exactly matching the
+            // GCN texture result. Keep native one/two/four-channel widths instead of expanding an
+            // R32 image to RGBA32F every dispatch. Three-channel optimal images are not universally
+            // supported, so retain the portable four-channel expansion for that uncommon case.
+            const bool sampled_float32_native = sampled_float32 && sampled_components != 3;
             // Imported renderer-owned RGBA16F is already the exact native sampled representation.
-            // Guest-backed FP16 retains the historical RGBA8 conversion until its independent
-            // upload-format contract is changed.
+            // Guest-backed FP16 retains the historical RGBA8 conversion: native RG16F sampling is
+            // exact, but was measured 7x slower in Astro Bot's full-resolution composite on RADV.
             const bool sampled_float16_native = !bi.storage && bi.imported &&
                                                 r->format == DataFormat::Float16 &&
                                                 sampled_components == 4;
@@ -1770,7 +2366,14 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             const bool sampled_uint32_native = !bi.storage && r->format == DataFormat::Uint32 &&
                                                (sampled_components == 1 || sampled_components == 2 ||
                                                 sampled_components == 4);
-            const uint32_t texel_bytes = bi.storage || sampled_float32 ? 16u
+            const uint32_t native_storage_bytes = bi.native_float_storage
+                ? (r->format == DataFormat::Float10_11_11
+                       ? 4u : data_format_bytes(r->format) * sampled_components)
+                : 0u;
+            const uint32_t texel_bytes = bi.native_float_storage ? native_storage_bytes
+                                         : bi.storage ? 16u
+                                         : sampled_float32_native ? sampled_components * 4u
+                                         : sampled_float32 ? 16u
                                          : sampled_depth ? data_format_bytes(r->format)
                                          : sampled_float16_native ? 8u
                                          : sampled_uint32_native ? sampled_components * 4u
@@ -1778,6 +2381,52 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                          : sampled_unorm16_native ? sampled_components * 2u
                                          : sampled_uint8_native ? sampled_components
                                          : sampled_unorm8x2 ? 2u : 4u;
+            const bool sampled_r11g11b10 = !bi.storage &&
+                r->format == DataFormat::Float10_11_11 && sampled_components == 3;
+            const VkFormat image_format = bi.imported_depth ? bi.imported_format
+                : bi.native_float_storage
+                ? (r->format == DataFormat::Unorm8
+                       ? (sampled_components == 1 ? VK_FORMAT_R8_UNORM
+                          : sampled_components == 2 ? VK_FORMAT_R8G8_UNORM
+                                                     : VK_FORMAT_R8G8B8A8_UNORM)
+                   : r->format == DataFormat::Float16
+                       ? (sampled_components == 1 ? VK_FORMAT_R16_SFLOAT
+                          : sampled_components == 2 ? VK_FORMAT_R16G16_SFLOAT
+                                                     : VK_FORMAT_R16G16B16A16_SFLOAT)
+                   : r->format == DataFormat::Float10_11_11
+                       ? VK_FORMAT_B10G11R11_UFLOAT_PACK32
+                       : (sampled_components == 1 ? VK_FORMAT_R32_SFLOAT
+                          : sampled_components == 2 ? VK_FORMAT_R32G32_SFLOAT
+                                                     : VK_FORMAT_R32G32B32A32_SFLOAT))
+                : bi.storage ? VK_FORMAT_R32G32B32A32_UINT
+                : sampled_depth
+                    ? (r->format == DataFormat::Float32
+                           ? VK_FORMAT_D32_SFLOAT : VK_FORMAT_D16_UNORM)
+                : sampled_float16_native ? VK_FORMAT_R16G16B16A16_SFLOAT
+                : sampled_uint8_native
+                    ? (sampled_components == 1 ? VK_FORMAT_R8_UINT
+                       : sampled_components == 2 ? VK_FORMAT_R8G8_UINT
+                                                  : VK_FORMAT_R8G8B8A8_UINT)
+                : sampled_uint16_native
+                    ? (sampled_components == 1 ? VK_FORMAT_R16_UINT
+                       : sampled_components == 2 ? VK_FORMAT_R16G16_UINT
+                                                  : VK_FORMAT_R16G16B16A16_UINT)
+                : sampled_uint32_native
+                    ? (sampled_components == 1 ? VK_FORMAT_R32_UINT
+                       : sampled_components == 2 ? VK_FORMAT_R32G32_UINT
+                                                  : VK_FORMAT_R32G32B32A32_UINT)
+                : sampled_r11g11b10 ? VK_FORMAT_B10G11R11_UFLOAT_PACK32
+                : sampled_unorm8x2 ? VK_FORMAT_R8G8_UNORM
+                : sampled_unorm16_native
+                    ? (sampled_components == 1 ? VK_FORMAT_R16_UNORM
+                       : sampled_components == 2 ? VK_FORMAT_R16G16_UNORM
+                                                  : VK_FORMAT_R16G16B16A16_UNORM)
+                : sampled_float32_native
+                    ? (sampled_components == 1 ? VK_FORMAT_R32_SFLOAT
+                       : sampled_components == 2 ? VK_FORMAT_R32G32_SFLOAT
+                                                  : VK_FORMAT_R32G32B32A32_SFLOAT)
+                : sampled_float32 ? VK_FORMAT_R32G32B32A32_SFLOAT
+                                  : VK_FORMAT_R8G8B8A8_UNORM;
             // Storage images use raw uvec4 channels. Most sampled formats are normalized to RGBA8,
             // but Float32 stays native so exposure/HDR kernels do not lose sign or dynamic range.
             const VkDeviceSize sbytes = volume_texels * texel_bytes;
@@ -1786,12 +2435,111 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             }
             staging_bytes[i] = sbytes;
 
+            const uint32_t sampled_bpb = bc_block_bytes(r->format);
+            const uint32_t sampled_cb = data_format_bytes(r->format);
+            const uint32_t sampled_nc = sampled_components;
+            const bool sampled_rgba8 = r->format == DataFormat::Unorm8 && sampled_nc == 4;
+            const bool sampled_uint8 = r->format == DataFormat::Uint8 && sampled_nc == 4;
+            const bool sampled_r8 = r->format == DataFormat::Unorm8 && sampled_nc == 1;
+            const bool sampled_f16 = r->format == DataFormat::Float16 &&
+                                     sampled_nc >= 1 && sampled_nc <= 4;
+            const bool sampled_f32 = sampled_float32;
+            size_t sampled_guest_need = 0;
+            const uint8_t* sampled_guest_source = nullptr;
+            if (!bi.storage && !renderer_owned) {
+                // Resolve and validate the guest source before allocating staging. A proven cache
+                // hit can then avoid the staging buffer/map as well as conversion and GPU upload.
+                if (sampled_bpb && dim_3d) {
+                    skip_image(r, "block-compressed 3D texture deferred"); break;
+                } else if (sampled_bpb) {
+                    const uint32_t bw = (r->width + 3) / 4, bh = (r->height + 3) / 4;
+                    const size_t slice = r->tile_mode
+                        ? tiled_elements_bytes(bw, bh, sampled_bpb, r->tile_mode)
+                        : static_cast<size_t>(bw) * bh * sampled_bpb;
+                    sampled_guest_need = dim_2d_array ? slice * r->depth : slice;
+                } else if (sampled_rgba8 || sampled_uint8 || sampled_r8 || sampled_f16 ||
+                           sampled_f32 || sampled_r11g11b10 || sampled_unorm8x2 ||
+                           sampled_unorm16_native || sampled_uint8_native ||
+                           sampled_uint16_native || sampled_uint32_native || sampled_depth) {
+                    const uint32_t bpt = sampled_r11g11b10 ? 4u : sampled_cb * sampled_nc;
+                    if (r->tile_mode && dim_3d && r->depth > 1) {
+                        sampled_guest_need = tiled_volume_bytes(
+                            r->width, r->height, r->depth, r->tile_mode, bpt);
+                    } else if (r->tile_mode && dim_2d_array) {
+                        sampled_guest_need = tiled_surface_bytes(
+                            r->width, r->height, r->tile_mode, 0, bpt) * r->depth;
+                    } else {
+                        sampled_guest_need = r->tile_mode
+                            ? tiled_surface_bytes(r->width, r->height, r->tile_mode, 0, bpt)
+                            : static_cast<size_t>(volume_texels) * bpt;
+                    }
+                } else {
+                    skip_image(r, "sampled format not decodable yet"); break;
+                }
+                if (!sampled_guest_need || sampled_guest_need > kMaxComputeImageBytes ||
+                    sampled_guest_need > UINT32_MAX) {
+                    skip_image(r, "sampled backing exceeds the 256 MiB backend bound"); break;
+                }
+                if (sampled_bpb && dim_2d_array) {
+                    skip_image(r, "block-compressed sampled arrays deferred"); break;
+                }
+                bi.guest_bytes = sampled_guest_need;
+                sampled_guest_source = resource_bytes_for(r, sampled_guest_need);
+                const bool readable =
+                    (r->host_data && r->host_data_size >= sampled_guest_need) ||
+                    guest_readable(r->gpu_addr, static_cast<uint32_t>(sampled_guest_need));
+                if (!readable) { skip_image(r, "sampled surface unreadable"); break; }
+
+                bool dcc_cache_safe = !r->compression_enabled;
+                if (r->compression_enabled) {
+                    const uint64_t metadata_bytes = gpu_capture_dcc_metadata_footprint(*r);
+                    const uint8_t* metadata =
+                        r->dcc_metadata_host_data &&
+                                r->dcc_metadata_host_data_size >= metadata_bytes
+                            ? r->dcc_metadata_host_data : nullptr;
+                    if (!metadata && metadata_bytes && metadata_bytes <= UINT32_MAX &&
+                        guest_readable(r->metadata_addr, static_cast<uint32_t>(metadata_bytes)))
+                        metadata = reinterpret_cast<const uint8_t*>(uintptr_t(r->metadata_addr));
+                    dcc_cache_safe = metadata && metadata_bytes &&
+                        std::all_of(metadata, metadata + metadata_bytes,
+                                    [](uint8_t value) { return value == 0xff; });
+                }
+                bi.cache_candidate = !r->host_data && dcc_cache_safe &&
+                    persistent_compute_image_enabled(sbytes);
+                if (bi.cache_candidate) {
+                    bi.cache_key = {
+                        r->gpu_addr, static_cast<uint32_t>(sampled_guest_need), r->size,
+                        r->width, r->height, r->depth,
+                        static_cast<uint32_t>(r->format), sampled_components,
+                        r->tile_mode, r->img_dim, r->linear_row_pitch_bytes,
+                        r->mip_tail_offset, r->mip_tail_bytes,
+                        r->mip_tail_x, r->mip_tail_y,
+                        static_cast<uint32_t>(image_format), r->in_mip_tail,
+                        r->srgb, r->depth_compare};
+                    bi.persistent = ctx.acquire_cached_image(
+                        bi.cache_key, sampled_guest_source, image_validation_epoch,
+                        bi.image, bi.memory, bi.upload_skipped);
+                    if (trace && bi.persistent)
+                        std::fprintf(stderr,
+                                     "[compute]   persistent sampled image binding=%u "
+                                     "addr=0x%llx guest=%zu upload-skipped=%u\n",
+                                     bi.binding, (unsigned long long)r->gpu_addr,
+                                     sampled_guest_need, bi.upload_skipped ? 1u : 0u);
+                    if (!bi.persistent)
+                        bi.cache_source_snapshot.assign(
+                            sampled_guest_source,
+                            sampled_guest_source + sampled_guest_need);
+                }
+            }
+
             // Allocate the host-visible staging buffer before conversion and write into its mapping
             // directly. The old path first built a heap upload and then memcpy'd the complete result
             // here -- an extra 132 MiB CPU pass for Astro Bot's 4K RGBA32 storage representation.
             ScopedMappedMemory upload_mapping(ctx);
-            const size_t upload_size = (bi.imported || bi.seed_skip) ? size_t{0} : (size_t)sbytes;
-            if (!bi.imported) {
+            const size_t upload_size = (bi.imported || bi.scaled_bridge || bi.seed_skip)
+                ? size_t{0} : (size_t)sbytes;
+            if (!bi.imported && !bi.scaled_bridge &&
+                !(bi.persistent && bi.upload_skipped)) {
                 VkBufferCreateInfo sci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
                 sci.size = sbytes;
                 sci.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
@@ -1814,8 +2562,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 }
             }
             auto* upload = static_cast<uint8_t*>(upload_mapping.data);
-            if (bi.imported) {
-                // The renderer's image is the source: there is nothing to convert or stage.
+            if (bi.imported || bi.scaled_bridge) {
+                // The renderer's image is the source: direct imports need no transfer; scaled
+                // storage bridges are populated by an image-to-image blit in the command buffer.
                 bi.guest_bytes = 0;
             } else if (bi.storage) {
                 if (r->tile_mode && !tile_mode_is_tiled(r->tile_mode)) {
@@ -1855,6 +2604,39 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                       (r->host_data && r->host_data_size >= guest_bytes) ||
                                       guest_readable(r->gpu_addr, static_cast<uint32_t>(guest_bytes));
                 if (!readable) { skip_image(r, "storage backing unreadable"); break; }
+                // Native storage targets are byte-identical to their sampled view. Retain them after
+                // writeback so the next dispatch/frame can consume the GPU result directly instead
+                // of detiling and uploading the same multi-megabyte surface again. Poison proving
+                // deliberately stays transient: a partial proof repairs untouched texels on the CPU
+                // after readback, so its device image is not yet the repaired authoritative value.
+                const bool dcc_cache_safe = !r->compression_enabled ||
+                    (bi.dcc_metadata && bi.dcc_metadata_bytes &&
+                     std::all_of(bi.dcc_metadata, bi.dcc_metadata + bi.dcc_metadata_bytes,
+                                 [](uint8_t value) { return value == 0xff; }));
+                bi.cache_candidate = !renderer_owned && !r->host_data && dcc_cache_safe &&
+                    !bi.seed_skip && !bi.poison_verify &&
+                    bi.native_float_storage && persistent_compute_image_enabled(sbytes);
+                if (bi.cache_candidate) {
+                    bi.cache_key = {
+                        r->gpu_addr, static_cast<uint32_t>(guest_bytes), r->size,
+                        r->width, r->height, r->depth,
+                        static_cast<uint32_t>(r->format), sampled_components,
+                        r->tile_mode, r->img_dim, r->linear_row_pitch_bytes,
+                        r->mip_tail_offset, r->mip_tail_bytes,
+                        r->mip_tail_x, r->mip_tail_y,
+                        static_cast<uint32_t>(image_format), r->in_mip_tail,
+                        r->srgb, r->depth_compare};
+                    bi.persistent = ctx.acquire_cached_image(
+                        bi.cache_key, resource_bytes_for(r, guest_bytes), image_validation_epoch,
+                        bi.image, bi.memory, bi.upload_skipped);
+                    if (trace && bi.persistent)
+                        std::fprintf(stderr,
+                                     "[compute]   persistent storage image binding=%u "
+                                     "addr=0x%llx guest=%zu upload-skipped=%u\n",
+                                     bi.binding, (unsigned long long)r->gpu_addr,
+                                     guest_bytes, bi.upload_skipped ? 1u : 0u);
+                }
+                if (!(bi.persistent && bi.upload_skipped)) {
                 const size_t linear_size = bi.seed_skip
                     ? size_t{0} : static_cast<size_t>(linear_guest_bytes);
                 std::unique_ptr<uint8_t[]> linear;
@@ -1901,16 +2683,31 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     // Decode it in place instead of copying the complete surface to a temporary first.
                     unpack_source = src;
                 }
-                if (!bi.seed_skip)
-                    storage_unpack_range(unpack_source, guest_texel, r->format, nc, texels,
-                                         reinterpret_cast<uint32_t*>(upload));
+                if (!bi.seed_skip) {
+                    if (bi.native_float_storage) {
+                        parallel_compute_texels(texels, static_cast<size_t>(linear_guest_bytes) * 2,
+                            [&](size_t begin, size_t end) {
+                                std::memcpy(upload + begin * guest_texel,
+                                            unpack_source + begin * guest_texel,
+                                            (end - begin) * guest_texel);
+                            });
+                    } else
+                        storage_unpack_range(unpack_source, guest_texel, r->format, nc, texels,
+                                             reinterpret_cast<uint32_t*>(upload));
+                }
                 if (bi.poison_verify) {   // #1122 coverage proof: poison every uvec4 channel
                     // Keep the clean detiled guest seed: on a partial-coverage proving frame the
                     // writeback restores every un-stored (still-poison) texel from it, so proving
                     // never corrupts the guest -- only the GPU `upload` is poisoned, `linear` is not.
                     bi.seed_linear.assign(unpack_source, unpack_source + linear_size);
-                    uint32_t* pp = reinterpret_cast<uint32_t*>(upload);
-                    for (size_t t = 0; t < texels * 4; ++t) pp[t] = 0xDEADBEEFu;
+                    if (bi.native_float_storage) {
+                        // Transfers preserve this finite, non-special native texel pattern exactly.
+                        // A texel that remains all 0x5a after the dispatch was not stored.
+                        std::memset(upload, 0x5a, static_cast<size_t>(sbytes));
+                    } else {
+                        uint32_t* pp = reinterpret_cast<uint32_t*>(upload);
+                        for (size_t t = 0; t < texels * 4; ++t) pp[t] = 0xDEADBEEFu;
+                    }
                 }
                 static const bool verify_unpack =
                     std::getenv("PROSPER_VERIFY_UNPACK") != nullptr && !bi.seed_skip;
@@ -1939,23 +2736,25 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     if (bad)
                         std::fprintf(stderr, "[compute]   first mismatching texel=%zu\n", first_bad);
                 }
+                }
             } else {
-                const uint32_t bpb = bc_block_bytes(r->format);
-                const uint32_t cb = data_format_bytes(r->format);
-                const uint32_t nc = r->num_components ? r->num_components : 1;
-                const bool rgba8 = r->format == DataFormat::Unorm8 && nc == 4;
-                const bool uint8 = r->format == DataFormat::Uint8 && nc == 4;
-                const bool r8 = r->format == DataFormat::Unorm8 && nc == 1;
-                const bool f16 = r->format == DataFormat::Float16 && nc >= 1 && nc <= 4;
-                const bool f32 = sampled_float32;
-                const bool r11g11b10 = r->format == DataFormat::Float10_11_11 && nc == 3;
+                const uint32_t bpb = sampled_bpb;
+                const uint32_t cb = sampled_cb;
+                const uint32_t nc = sampled_nc;
+                const bool rgba8 = sampled_rgba8;
+                const bool uint8 = sampled_uint8;
+                const bool r8 = sampled_r8;
+                const bool f16 = sampled_f16;
+                const bool f32 = sampled_f32;
+                const bool r11g11b10 = sampled_r11g11b10;
                 if (renderer_owned) {
                     if (r11g11b10) {
                         skip_image(r, "renderer RTT cannot be reconstructed as packed R11G11B10");
                         break;
                     }
                     const std::vector<uint8_t>& pixels = *live_target.pixels;
-                    if (sampled_uint16_native || sampled_uint32_native) {
+                    if (sampled_float32_native || sampled_uint16_native ||
+                        sampled_uint32_native) {
                         // A renderer-owned target is authoritative only when its cached texel is
                         // byte-identical to the UINT view.  Sonic aliases an RGBA16F render target
                         // as RGBA16_UINT for a compute resolve: those eight bytes must be
@@ -2017,10 +2816,14 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         }
                     } else if (f32) {
                         const size_t texels = static_cast<size_t>(volume_texels);
-                        parallel_compute_texels(texels, texels * (16u + 8u),
+                        const uint32_t output_components =
+                            sampled_float32_native ? sampled_components : 4u;
+                        parallel_compute_texels(
+                            texels,
+                            texels * (output_components * sizeof(float) + 8u),
                             [&](size_t begin, size_t end) {
                                 for (size_t t = begin; t < end; ++t) {
-                                    for (uint32_t c = 0; c < 4; ++c) {
+                                    for (uint32_t c = 0; c < output_components; ++c) {
                                         float value = 0.0f;
                                         if (live_target.format == LiveTargetPixelFormat::Rgba8Unorm) {
                                             value = pixels[t * 4 + c] / 255.0f;
@@ -2031,7 +2834,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                             value = half_to_float(half);
                                             if (std::isnan(value)) value = 0.0f;
                                         }
-                                        std::memcpy(upload + (t * 4 + c) * sizeof(float),
+                                        std::memcpy(upload +
+                                                        (t * output_components + c) * sizeof(float),
                                                     &value, sizeof(value));
                                     }
                                 }
@@ -2068,40 +2872,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     }
                     bi.guest_bytes = 0;
                 } else {
-                    size_t need;                                   // guest bytes the decode reads
-                    if (bpb && dim_3d) {
-                        skip_image(r, "block-compressed 3D texture deferred"); break;
-                    } else if (bpb) {
-                        const uint32_t bw = (r->width + 3) / 4, bh = (r->height + 3) / 4;
-                        const size_t slice = r->tile_mode
-                            ? tiled_elements_bytes(bw, bh, bpb, r->tile_mode)
-                            : (size_t)bw * bh * bpb;
-                        need = dim_2d_array ? slice * r->depth : slice;
-                    } else if (rgba8 || uint8 || r8 || f16 || f32 || r11g11b10 ||
-                               sampled_unorm8x2 || sampled_unorm16_native || sampled_uint8_native ||
-                               sampled_uint16_native || sampled_uint32_native || sampled_depth) {
-                        const uint32_t bpt = r11g11b10 ? 4u : cb * nc;
-                        if (r->tile_mode && dim_3d && r->depth > 1) {
-                            need = tiled_volume_bytes(r->width, r->height, r->depth,
-                                                      r->tile_mode, bpt);
-                        } else if (r->tile_mode && dim_2d_array) {
-                            need = tiled_surface_bytes(r->width, r->height,
-                                                       r->tile_mode, 0, bpt) * r->depth;
-                        } else {
-                            need = r->tile_mode
-                                ? tiled_surface_bytes(r->width, r->height, r->tile_mode, 0, bpt)
-                                : (size_t)volume_texels * bpt;
-                        }
-                    } else { skip_image(r, "sampled format not decodable yet"); break; }
-                    if (!need || need > kMaxComputeImageBytes || need > UINT32_MAX) {
-                        skip_image(r, "sampled backing exceeds the 256 MiB backend bound"); break;
-                    }
-                    bi.guest_bytes = need;
-                    const uint8_t* src = resource_bytes_for(r, need);
-                    const bool readable = (r->host_data && r->host_data_size >= need) ||
-                                          guest_readable(r->gpu_addr, (uint32_t)need);
-                    if (!readable) { skip_image(r, "sampled surface unreadable"); break; }
-                    if (bpb) {                                      // BCn: (block-detile ->) decode
+                    const size_t need = sampled_guest_need;
+                    const uint8_t* src = sampled_guest_source;
+                    if (!bi.upload_skipped && bpb) {                 // BCn: (block-detile ->) decode
                         const uint32_t bw = (r->width + 3) / 4, bh = (r->height + 3) / 4;
                         if (dim_2d_array) {
                             skip_image(r, "block-compressed sampled arrays deferred"); break;
@@ -2121,7 +2894,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         if (!bc_decode_surface(upload, decode_source, (size_t)bw * bh * bpb,
                                                r->width, r->height, r->format)) {
                             skip_image(r, "BC decode unsupported"); break; }
-                    } else {
+                    } else if (!bi.upload_skipped) {
                         const uint32_t bpt = r11g11b10 ? 4u : cb * nc;
                         const size_t linear_bytes = static_cast<size_t>(volume_texels) * bpt;
                         std::unique_ptr<uint8_t[]> linear;
@@ -2156,7 +2929,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         if (rgba8 || uint8 || r11g11b10 ||
                             sampled_unorm8x2 || sampled_unorm16_native ||
                             sampled_uint8_native || sampled_uint16_native ||
-                            sampled_uint32_native || sampled_depth) {   // Native sampled texels
+                            sampled_uint32_native || sampled_float32_native ||
+                            sampled_depth) {                            // Native sampled texels
                             std::memcpy(upload, sampled_source, linear_bytes);
                         } else if (f32) {                           // Native float channels + default fill
                             parallel_compute_texels(texels, linear_bytes + texels * 16u,
@@ -2198,52 +2972,29 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             // Device-local image.
             VkImageCreateInfo ici{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
             ici.imageType = dim_1d ? VK_IMAGE_TYPE_1D : (dim_3d ? VK_IMAGE_TYPE_3D : VK_IMAGE_TYPE_2D);
-            const bool sampled_r11g11b10 = !bi.storage &&
-                r->format == DataFormat::Float10_11_11 &&
-                (r->num_components ? r->num_components : 1) == 3;
-            ici.format = bi.storage ? VK_FORMAT_R32G32B32A32_UINT
-                                    : (sampled_depth
-                                           ? (r->format == DataFormat::Float32
-                                                  ? VK_FORMAT_D32_SFLOAT : VK_FORMAT_D16_UNORM)
-                                       : sampled_float16_native
-                                           ? VK_FORMAT_R16G16B16A16_SFLOAT
-                                       : sampled_uint8_native
-                                           ? (sampled_components == 1 ? VK_FORMAT_R8_UINT
-                                              : sampled_components == 2 ? VK_FORMAT_R8G8_UINT
-                                                                         : VK_FORMAT_R8G8B8A8_UINT)
-                                       : sampled_uint16_native
-                                           ? (sampled_components == 1 ? VK_FORMAT_R16_UINT
-                                              : sampled_components == 2 ? VK_FORMAT_R16G16_UINT
-                                                                         : VK_FORMAT_R16G16B16A16_UINT)
-                                       : sampled_uint32_native
-                                           ? (sampled_components == 1 ? VK_FORMAT_R32_UINT
-                                              : sampled_components == 2 ? VK_FORMAT_R32G32_UINT
-                                                                         : VK_FORMAT_R32G32B32A32_UINT)
-                                       : sampled_r11g11b10 ? VK_FORMAT_B10G11R11_UFLOAT_PACK32
-                                         : sampled_unorm8x2 ? VK_FORMAT_R8G8_UNORM
-                                           : sampled_unorm16_native
-                                               ? (sampled_components == 1 ? VK_FORMAT_R16_UNORM
-                                                  : sampled_components == 2 ? VK_FORMAT_R16G16_UNORM
-                                                                            : VK_FORMAT_R16G16B16A16_UNORM)
-                                         : sampled_float32 ? VK_FORMAT_R32G32B32A32_SFLOAT
-                                                           : VK_FORMAT_R8G8B8A8_UNORM);
+            ici.format = image_format;
             ici.extent = {r->width, r->height, r->depth};
             ici.mipLevels = 1;
             if (dim_2d_array) ici.extent.depth = 1;
             ici.arrayLayers = dim_2d_array ? r->depth : 1;
             ici.samples = VK_SAMPLE_COUNT_1_BIT;
             ici.tiling = VK_IMAGE_TILING_OPTIMAL;
-            ici.usage = (bi.storage ? (VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT)
+            ici.usage = (bi.storage ? (VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_SAMPLED_BIT |
+                                       VK_IMAGE_USAGE_TRANSFER_SRC_BIT)
                                     : VK_IMAGE_USAGE_SAMPLED_BIT) |
                         VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+            if (!bi.storage && native_float_storage_image(
+                    r->format, sampled_components, r->srgb))
+                ici.usage |= VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
             ici.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
             // An imported binding already holds the renderer's image; only the view/sampler below
             // are ours to create. `ici` is still filled above so the view matches its format/layers.
-            if (!bi.imported) {
+            if (!bi.imported && !bi.image) {
                 if (!vk_ok(vkCreateImage(ctx.device, &ici, nullptr, &bi.image),
                            "image-create")) { images_ready = false; break; }
                 VkMemoryRequirements ireq{};
                 vkGetImageMemoryRequirements(ctx.device, bi.image, &ireq);
+                bi.allocation_bytes = ireq.size;
                 const uint32_t image_memory_type = device_memory_type(ireq.memoryTypeBits);
                 bi.memory = ctx.allocate_memory(ireq.size, image_memory_type);
                 if (!vk_handle_ok(bi.memory, "image-memory") ||
@@ -2274,7 +3025,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 vci.components = {sel(r->swizzle[0]), sel(r->swizzle[1]),
                                   sel(r->swizzle[2]), sel(r->swizzle[3])};
             }
-            const VkImageAspectFlags image_aspect = sampled_depth
+            const VkImageAspectFlags image_aspect = (sampled_depth || bi.imported_depth)
                 ? VK_IMAGE_ASPECT_DEPTH_BIT : VK_IMAGE_ASPECT_COLOR_BIT;
             vci.subresourceRange = {image_aspect, 0, 1, 0, ici.arrayLayers};
             if (!vk_ok(vkCreateImageView(ctx.device, &vci, nullptr, &bi.view),
@@ -2310,6 +3061,16 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 if (!vk_ok(vkCreateSampler(ctx.device, &smci, nullptr, &bi.sampler), "image-sampler")) {
                     images_ready = false; break; }
             }
+            if (image_timing)
+                std::fprintf(stderr,
+                             "[compute-image] code=0x%llx binding=%u class=%s imported=%u "
+                             "extent=%ux%ux%u guest=%zu staging=%llu ms=%.3f\n",
+                             (unsigned long long)item.code_addr, bi.binding,
+                             bi.storage ? "storage" : "sampled", bi.imported ? 1u : 0u,
+                             r->width, r->height, r->depth, bi.guest_bytes,
+                             (unsigned long long)sbytes,
+                             std::chrono::duration<double, std::milli>(
+                                 ComputeClock::now() - image_start).count());
         }
         if (!images_ready) break;
         phase_setup = ComputeClock::now();
@@ -2328,10 +3089,11 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         auto append_pipeline_key_u32 = [&](uint32_t value) {
             pipeline_key.append(reinterpret_cast<const char*>(&value), sizeof(value));
         };
-        append_pipeline_key_u32(static_cast<uint32_t>(item.spirv.size()));
-        pipeline_key.append(reinterpret_cast<const char*>(item.spirv.data()),
-                            item.spirv.size() * sizeof(uint32_t));
+        append_pipeline_key_u32(static_cast<uint32_t>(spirv.size()));
+        pipeline_key.append(reinterpret_cast<const char*>(spirv.data()),
+                            spirv.size() * sizeof(uint32_t));
         append_pipeline_key_u32(static_cast<uint32_t>(item.user_sgprs.size()));
+        append_pipeline_key_u32(item.required_subgroup_size);
         append_pipeline_key_u32(static_cast<uint32_t>(layout_bindings.size()));
         for (const auto& binding : layout_bindings) {
             append_pipeline_key_u32(binding.binding);
@@ -2409,8 +3171,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
 
         if (!pipeline_cached) {
             VkShaderModuleCreateInfo smci{VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO};
-            smci.codeSize = item.spirv.size() * sizeof(uint32_t);
-            smci.pCode = item.spirv.data();
+            smci.codeSize = spirv.size() * sizeof(uint32_t);
+            smci.pCode = spirv.data();
             if (!vk_ok(vkCreateShaderModule(ctx.device, &smci, nullptr, &shader), "shader-module"))
                 break;
             VkPipelineLayoutCreateInfo plci{VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO};
@@ -2430,6 +3192,12 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             cpci.stage.stage = VK_SHADER_STAGE_COMPUTE_BIT;
             cpci.stage.module = shader;
             cpci.stage.pName = "main";
+            VkPipelineShaderStageRequiredSubgroupSizeCreateInfo required_subgroup{
+                VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_REQUIRED_SUBGROUP_SIZE_CREATE_INFO};
+            if (item.required_subgroup_size) {
+                required_subgroup.requiredSubgroupSize = item.required_subgroup_size;
+                cpci.stage.pNext = &required_subgroup;
+            }
             cpci.layout = pipeline_layout;
             if (trace) std::fprintf(stderr, "[compute]   creating compute pipeline\n");
             if (!vk_ok(vkCreateComputePipelines(ctx.device, ctx.pipeline_cache, 1, &cpci, nullptr,
@@ -2443,15 +3211,11 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         }
         phase_pipeline = ComputeClock::now();
 
-        VkCommandPoolCreateInfo pci{VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO};
-        pci.queueFamilyIndex = ctx.queue_family;
-        if (!vk_ok(vkCreateCommandPool(ctx.device, &pci, nullptr, &command_pool), "command-pool")) break;
-        VkCommandBufferAllocateInfo cbai{VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO};
-        cbai.commandPool = command_pool;
-        cbai.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
-        cbai.commandBufferCount = 1;
-        VkCommandBuffer command = VK_NULL_HANDLE;
-        if (!vk_ok(vkAllocateCommandBuffers(ctx.device, &cbai, &command), "command-buffer")) break;
+        if (!ctx.prepare_dispatch_commands()) {
+            if (trace) std::fprintf(stderr, "[compute]   Vulkan failure stage=command-reuse\n");
+            break;
+        }
+        const VkCommandBuffer command = ctx.command_buffer;
         VkCommandBufferBeginInfo begin{VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO};
         begin.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
         if (!vk_ok(vkBeginCommandBuffer(command, &begin), "command-begin")) break;
@@ -2468,11 +3232,106 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     return false;
             return true;
         };
+        auto imported_image_is_writable = [&](VkImage image) {
+            return std::any_of(images.begin(), images.end(), [&](const BoundImage& candidate) {
+                return candidate.imported && candidate.alias_of == SIZE_MAX &&
+                       candidate.image == image && candidate.storage;
+            });
+        };
+        auto imported_aspects = [](const BoundImage& image) {
+            if (!image.imported_depth) return VkImageAspectFlags{VK_IMAGE_ASPECT_COLOR_BIT};
+            return VkImageAspectFlags{VK_IMAGE_ASPECT_DEPTH_BIT |
+                (image.imported_format == VK_FORMAT_D32_SFLOAT_S8_UINT
+                     ? VK_IMAGE_ASPECT_STENCIL_BIT : 0u)};
+        };
         // Upload every image: UNDEFINED -> TRANSFER_DST, copy the staged texels in, -> GENERAL.
         for (size_t i = 0; i < images.size(); i++) {
             const BoundImage& bi = images[i];
             if (bi.alias_of != SIZE_MAX) continue;
             const ShaderResource* r = bi.resource;
+            if (bi.scaled_bridge) {
+                // Keep render-scale storage traffic on the GPU. The shader still sees its native
+                // extent and integer coordinates; only the renderer-owned backing is reduced.
+                VkImageMemoryBarrier barriers[2]{};
+                barriers[0] = {VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
+                barriers[0].srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT |
+                                            VK_ACCESS_TRANSFER_WRITE_BIT |
+                                            VK_ACCESS_SHADER_WRITE_BIT;
+                barriers[0].dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+                barriers[0].oldLayout = static_cast<VkImageLayout>(bi.imported_saved_layout);
+                barriers[0].newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+                barriers[0].srcQueueFamilyIndex = barriers[0].dstQueueFamilyIndex =
+                    VK_QUEUE_FAMILY_IGNORED;
+                barriers[0].image = bi.bridge_image;
+                barriers[0].subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+                barriers[1] = {VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
+                barriers[1].srcAccessMask = 0;
+                barriers[1].dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+                barriers[1].oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+                barriers[1].newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+                barriers[1].srcQueueFamilyIndex = barriers[1].dstQueueFamilyIndex =
+                    VK_QUEUE_FAMILY_IGNORED;
+                barriers[1].image = bi.image;
+                barriers[1].subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+                vkCmdPipelineBarrier(command, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+                                     VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr,
+                                     2, barriers);
+                VkImageBlit blit{};
+                blit.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+                blit.srcOffsets[1] = {static_cast<int32_t>(bi.bridge_width),
+                                      static_cast<int32_t>(bi.bridge_height), 1};
+                blit.dstSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+                blit.dstOffsets[1] = {static_cast<int32_t>(r->width),
+                                      static_cast<int32_t>(r->height), 1};
+                vkCmdBlitImage(command, bi.bridge_image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                               bi.image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &blit,
+                               VK_FILTER_NEAREST);
+                barriers[0].srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+                barriers[0].dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT |
+                                            VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT |
+                                            VK_ACCESS_SHADER_READ_BIT |
+                                            VK_ACCESS_TRANSFER_READ_BIT |
+                                            VK_ACCESS_TRANSFER_WRITE_BIT;
+                barriers[0].oldLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+                barriers[0].newLayout = static_cast<VkImageLayout>(bi.imported_saved_layout);
+                barriers[1].srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+                barriers[1].dstAccessMask = VK_ACCESS_SHADER_READ_BIT |
+                                            VK_ACCESS_SHADER_WRITE_BIT;
+                barriers[1].oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+                barriers[1].newLayout = VK_IMAGE_LAYOUT_GENERAL;
+                vkCmdPipelineBarrier(command, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                                     VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0, nullptr, 0, nullptr,
+                                     2, barriers);
+                continue;
+            }
+            if (bi.imported) {
+                if (!imported_barrier_owner(i)) continue;   // another binding transitions this image
+                // Borrowed renderer image: nothing to upload. Include shader-write access when an
+                // exact native storage binding aliases the sampled view in this dispatch.
+                VkImageMemoryBarrier to_general{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
+                to_general.srcAccessMask = bi.imported_depth
+                    ? VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT
+                    : VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT |
+                          VK_ACCESS_TRANSFER_WRITE_BIT | VK_ACCESS_SHADER_WRITE_BIT;
+                to_general.dstAccessMask = VK_ACCESS_SHADER_READ_BIT |
+                    (imported_image_is_writable(bi.image) ? VK_ACCESS_SHADER_WRITE_BIT : 0u);
+                to_general.oldLayout = static_cast<VkImageLayout>(bi.imported_saved_layout);
+                to_general.newLayout = VK_IMAGE_LAYOUT_GENERAL;
+                to_general.srcQueueFamilyIndex = to_general.dstQueueFamilyIndex =
+                    VK_QUEUE_FAMILY_IGNORED;
+                to_general.image = bi.image;
+                to_general.subresourceRange = {imported_aspects(bi), 0, 1, 0, 1};
+                vkCmdPipelineBarrier(command, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+                                     VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, 0, 0, nullptr, 0, nullptr,
+                                     1, &to_general);
+                continue;
+            }
+            if (bi.persistent && bi.upload_skipped) {
+                // The previous synchronous dispatch left this read-only sampled image in GENERAL,
+                // and the write watch proved its complete guest source unchanged. No transfer or
+                // layout transition is needed.
+                continue;
+            }
             if (bi.seed_skip) {
                 // #1122: nothing uploaded -- take the never-seeded image straight to GENERAL for the
                 // write-only shader (which overwrites every texel). The result is read back below.
@@ -2490,30 +3349,11 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                      1, &to_general);
                 continue;
             }
-            if (bi.imported) {
-                if (!imported_barrier_owner(i)) continue;   // another binding transitions this image
-                // Borrowed renderer image (#1095): nothing to upload. Make the renderer's writes
-                // visible to this dispatch and move it into the GENERAL layout the descriptors
-                // declare. The matching barrier after the dispatch puts it back.
-                VkImageMemoryBarrier to_general{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
-                to_general.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT |
-                                           VK_ACCESS_TRANSFER_WRITE_BIT | VK_ACCESS_SHADER_WRITE_BIT;
-                to_general.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
-                to_general.oldLayout = static_cast<VkImageLayout>(bi.imported_saved_layout);
-                to_general.newLayout = VK_IMAGE_LAYOUT_GENERAL;
-                to_general.srcQueueFamilyIndex = to_general.dstQueueFamilyIndex =
-                    VK_QUEUE_FAMILY_IGNORED;
-                to_general.image = bi.image;
-                to_general.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
-                vkCmdPipelineBarrier(command, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
-                                     VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, 0, 0, nullptr, 0, nullptr,
-                                     1, &to_general);
-                continue;
-            }
             VkImageMemoryBarrier to_dst{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
-            to_dst.srcAccessMask = 0;
+            to_dst.srcAccessMask = bi.persistent ? VK_ACCESS_SHADER_READ_BIT : 0;
             to_dst.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
-            to_dst.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+            to_dst.oldLayout = bi.persistent ? VK_IMAGE_LAYOUT_GENERAL
+                                             : VK_IMAGE_LAYOUT_UNDEFINED;
             to_dst.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
             to_dst.srcQueueFamilyIndex = to_dst.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
             to_dst.image = bi.image;
@@ -2521,7 +3361,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             const VkImageAspectFlags aspect = r->depth_compare
                 ? VK_IMAGE_ASPECT_DEPTH_BIT : VK_IMAGE_ASPECT_COLOR_BIT;
             to_dst.subresourceRange = {aspect, 0, 1, 0, array_depth ? r->depth : 1u};
-            vkCmdPipelineBarrier(command, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+            vkCmdPipelineBarrier(command,
+                                 bi.persistent ? VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT
+                                               : VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
                                  VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr, 1, &to_dst);
             VkBufferImageCopy region{};
             region.imageSubresource = {aspect, 0, 0, array_depth ? r->depth : 1u};
@@ -2546,23 +3388,82 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                static_cast<uint32_t>(item.user_sgprs.size() * sizeof(uint32_t)),
                                item.user_sgprs.data());
         vkCmdDispatch(command, item.launch.groups_x, item.launch.groups_y, item.launch.groups_z);
+        // Downscale native compute output directly into its persistent render-scale target. The
+        // target is returned in exactly the layout recorded by the renderer's import contract.
+        for (const BoundImage& bi : images) {
+            if (!bi.scaled_bridge || bi.alias_of != SIZE_MAX) continue;
+            const ShaderResource* r = bi.resource;
+            VkImageMemoryBarrier barriers[2]{};
+            barriers[0] = {VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
+            barriers[0].srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
+            barriers[0].dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+            barriers[0].oldLayout = VK_IMAGE_LAYOUT_GENERAL;
+            barriers[0].newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+            barriers[0].srcQueueFamilyIndex = barriers[0].dstQueueFamilyIndex =
+                VK_QUEUE_FAMILY_IGNORED;
+            barriers[0].image = bi.image;
+            barriers[0].subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+            barriers[1] = {VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
+            barriers[1].srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT |
+                                        VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT |
+                                        VK_ACCESS_SHADER_READ_BIT |
+                                        VK_ACCESS_TRANSFER_READ_BIT |
+                                        VK_ACCESS_TRANSFER_WRITE_BIT;
+            barriers[1].dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+            barriers[1].oldLayout = static_cast<VkImageLayout>(bi.imported_saved_layout);
+            barriers[1].newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+            barriers[1].srcQueueFamilyIndex = barriers[1].dstQueueFamilyIndex =
+                VK_QUEUE_FAMILY_IGNORED;
+            barriers[1].image = bi.bridge_image;
+            barriers[1].subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+            vkCmdPipelineBarrier(command, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT |
+                                 VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+                                 VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr,
+                                 2, barriers);
+            VkImageBlit blit{};
+            blit.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+            blit.srcOffsets[1] = {static_cast<int32_t>(r->width),
+                                  static_cast<int32_t>(r->height), 1};
+            blit.dstSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+            blit.dstOffsets[1] = {static_cast<int32_t>(bi.bridge_width),
+                                  static_cast<int32_t>(bi.bridge_height), 1};
+            vkCmdBlitImage(command, bi.image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                           bi.bridge_image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &blit,
+                           VK_FILTER_LINEAR);
+            VkImageMemoryBarrier restore = barriers[1];
+            restore.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+            restore.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT |
+                                    VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT |
+                                    VK_ACCESS_SHADER_READ_BIT |
+                                    VK_ACCESS_TRANSFER_READ_BIT |
+                                    VK_ACCESS_TRANSFER_WRITE_BIT;
+            restore.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+            restore.newLayout = static_cast<VkImageLayout>(bi.imported_saved_layout);
+            vkCmdPipelineBarrier(command, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                                 VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0, nullptr, 0, nullptr,
+                                 1, &restore);
+        }
         // Hand every borrowed renderer image back in the layout its owner left it in (#1095), so the
         // renderer's own layout tracking stays true whether or not a dispatch consumed the target.
         for (size_t i = 0; i < images.size(); i++) {
             const BoundImage& bi = images[i];
             if (!bi.imported || bi.alias_of != SIZE_MAX || !imported_barrier_owner(i)) continue;
             VkImageMemoryBarrier restore{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
-            restore.srcAccessMask = VK_ACCESS_SHADER_READ_BIT;
+            restore.srcAccessMask = VK_ACCESS_SHADER_READ_BIT |
+                (imported_image_is_writable(bi.image) ? VK_ACCESS_SHADER_WRITE_BIT : 0u);
             // The renderer's next use of a persistent target is frequently vkCmdCopyImageToBuffer
             // or a scanout blit, so make the transition visible to transfer access as well.
-            restore.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT |
-                                    VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT | VK_ACCESS_SHADER_READ_BIT |
-                                    VK_ACCESS_TRANSFER_READ_BIT | VK_ACCESS_TRANSFER_WRITE_BIT;
+            restore.dstAccessMask = bi.imported_depth
+                ? VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT |
+                      VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT
+                : VK_ACCESS_COLOR_ATTACHMENT_READ_BIT |
+                      VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT | VK_ACCESS_SHADER_READ_BIT |
+                      VK_ACCESS_TRANSFER_READ_BIT | VK_ACCESS_TRANSFER_WRITE_BIT;
             restore.oldLayout = VK_IMAGE_LAYOUT_GENERAL;
             restore.newLayout = static_cast<VkImageLayout>(bi.imported_saved_layout);
             restore.srcQueueFamilyIndex = restore.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
             restore.image = bi.image;
-            restore.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+            restore.subresourceRange = {imported_aspects(bi), 0, 1, 0, 1};
             vkCmdPipelineBarrier(command, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
                                  VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0, nullptr, 0, nullptr,
                                  1, &restore);
@@ -2570,7 +3471,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         // Storage images: copy the written texels back into the staging buffer for guest writeback.
         for (size_t i = 0; i < images.size(); i++) {
             const BoundImage& bi = images[i];
-            if (!bi.storage || bi.alias_of != SIZE_MAX) continue;
+            if (!bi.storage || bi.alias_of != SIZE_MAX || bi.imported || bi.scaled_bridge) continue;
             const ShaderResource* r = bi.resource;
             VkImageMemoryBarrier to_src{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
             to_src.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
@@ -2587,10 +3488,19 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             region.imageExtent = {r->width, r->height, r->depth};
             vkCmdCopyImageToBuffer(command, bi.image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
                                    staging[i], 1, &region);
+            if (bi.cache_candidate || bi.persistent) {
+                VkImageMemoryBarrier to_general = to_src;
+                to_general.srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+                to_general.dstAccessMask = VK_ACCESS_SHADER_READ_BIT |
+                                           VK_ACCESS_SHADER_WRITE_BIT;
+                to_general.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+                to_general.newLayout = VK_IMAGE_LAYOUT_GENERAL;
+                vkCmdPipelineBarrier(command, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                                     VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, 0, 0, nullptr,
+                                     0, nullptr, 1, &to_general);
+            }
         }
         if (!vk_ok(vkEndCommandBuffer(command), "command-end")) break;
-        VkFenceCreateInfo fci{VK_STRUCTURE_TYPE_FENCE_CREATE_INFO};
-        if (!vk_ok(vkCreateFence(ctx.device, &fci, nullptr, &fence), "fence")) break;
         VkSubmitInfo submit{VK_STRUCTURE_TYPE_SUBMIT_INFO};
         submit.commandBufferCount = 1;
         submit.pCommandBuffers = &command;
@@ -2601,11 +3511,11 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         {
             std::unique_lock<std::mutex> lk(prosper::gpu::shared_present_submit_mutex(), std::defer_lock);
             if (prosper::gpu::shared_present_active()) lk.lock();
-            compute_submit_rc = vkQueueSubmit(ctx.queue, 1, &submit, fence);
+            compute_submit_rc = vkQueueSubmit(ctx.queue, 1, &submit, ctx.dispatch_fence);
         }
         if (!vk_ok(compute_submit_rc, "queue-submit")) break;
         if (trace) std::fprintf(stderr, "[compute]   waiting for dispatch\n");
-        if (!vk_ok(vkWaitForFences(ctx.device, 1, &fence, VK_TRUE,
+        if (!vk_ok(vkWaitForFences(ctx.device, 1, &ctx.dispatch_fence, VK_TRUE,
                                    30ull * 1000 * 1000 * 1000), "queue-wait")) {
             // cleanup() destroys the command buffer and releases the borrowed image's pin. With a
             // renderer-owned image bound, in-flight work still references it and its layout
@@ -2622,9 +3532,55 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         if (trace) std::fprintf(stderr, "[compute]   dispatch complete\n");
         phase_dispatch = ComputeClock::now();
 
+        // The fence proves every upload is complete and every sampled image is back in GENERAL.
+        // New entries become cache-owned only here, so an earlier Vulkan failure cannot retain an
+        // uninitialized image. A dirty hit rearms its source watch after the refreshed upload.
+        for (BoundImage& image : images) {
+            if (image.storage || image.imported || image.alias_of != SIZE_MAX ||
+                !image.cache_candidate)
+                continue;
+            // When this dispatch samples and writes the same guest view through distinct bindings,
+            // the post-dispatch storage image is the cache authority. Retaining the sampled seed here
+            // would occupy the identical key before storage writeback can retain the actual result.
+            const bool replaced_by_storage = std::any_of(
+                images.begin(), images.end(), [&](const BoundImage& candidate) {
+                    return candidate.storage && candidate.cache_candidate &&
+                           candidate.cache_key == image.cache_key;
+                });
+            if (replaced_by_storage) continue;
+            if (image.persistent) {
+                if (!image.upload_skipped)
+                    ctx.validate_cached_image_source(image.cache_key);
+            } else if (image.image && image.memory && image.allocation_bytes &&
+                       ctx.retain_image(image.cache_key, image.image, image.memory,
+                                        image.allocation_bytes,
+                                        image.cache_source_snapshot.empty()
+                                            ? nullptr : image.cache_source_snapshot.data())) {
+                image.persistent = true;
+                if (trace)
+                    std::fprintf(stderr,
+                                 "[compute]   retained sampled image binding=%u addr=0x%llx "
+                                 "allocation=%llu\n",
+                                 image.binding,
+                                 (unsigned long long)image.resource->gpu_addr,
+                                 (unsigned long long)image.allocation_bytes);
+            }
+        }
+
+        // A native storage binding may have written a borrowed renderer image directly. Publish the
+        // new authority before releasing its pin; no guest write notification is sent because raw
+        // guest bytes are intentionally stale while the persistent image owns the current pixels.
+        std::unordered_set<uint64_t> published_imports;
+        for (const BoundImage& image : images) {
+            if ((image.imported || image.scaled_bridge) && image.storage &&
+                image.imported_addr &&
+                published_imports.insert(image.imported_addr).second)
+                notify_live_render_target_image_written(image.imported_addr);
+        }
+
         bool readback_ok = true;
         for (auto& buffer : buffers) {
-            if (buffer.alias_of != SIZE_MAX) continue;
+            if (buffer.alias_of != SIZE_MAX || !buffer.writable) continue;
             void* mapped = nullptr;
             if (ctx.map_memory(buffer.memory, 0, buffer.resource->size, &mapped) != VK_SUCCESS) {
                 readback_ok = false;
@@ -2632,7 +3588,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             }
             uint8_t* destination = resource_bytes(buffer.resource);
             const auto* result = static_cast<const uint8_t*>(mapped);
-            const bool changed = std::memcmp(destination, result, buffer.resource->size) != 0;
+            const bool changed = !compute_buffers_equal(
+                destination, result, buffer.resource->size);
             if (trace) {
                 buffer.after_hash = fnv1a(result, buffer.resource->size);
                 for (uint32_t i = 0; i < buffer.resource->size; i++)
@@ -2644,11 +3601,17 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             // write removes one full pass over both source and destination. Cache invalidation and
             // writer provenance remain unconditional: renderer-resident state can differ from guest
             // RAM even when consecutive compute readbacks contain identical bytes.
-            if (changed)
-                std::memcpy(destination, result, buffer.resource->size);
+            if (changed) {
+                if (!buffer.resource->host_data && buffer.resource->gpu_addr)
+                    prosper::host::guest_write_watch_notify_host_write(
+                        buffer.resource->gpu_addr, buffer.resource->size);
+                copy_compute_buffer(destination, result, buffer.resource->size);
+            }
             ctx.unmap_memory(buffer.memory);
             if (buffer.resource->gpu_addr)
                 notify_guest_gpu_write(buffer.resource->gpu_addr, buffer.resource->size);
+            if (buffer.persistent)
+                ctx.validate_cached_buffer_source(buffer.cache_key);
             if (!buffer.resource->host_data && writer_provenance_enabled())
                 record_guest_write(GuestWriterKind::ComputeBuffer,
                                    buffer.resource->gpu_addr, buffer.resource->size,
@@ -2661,7 +3624,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         // the render side exactly like the buffer path.
         for (size_t i = 0; i < images.size() && readback_ok; i++) {
             BoundImage& bi = images[i];
-            if (!bi.storage || bi.alias_of != SIZE_MAX) continue;
+            if (!bi.storage || bi.alias_of != SIZE_MAX || bi.imported || bi.scaled_bridge) continue;
             const ShaderResource* r = bi.resource;
             void* mapped = nullptr;
             if (ctx.map_memory(staging_memory[i], 0, staging_bytes[i], &mapped) != VK_SUCCESS) {
@@ -2676,6 +3639,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             const size_t texels = (size_t)r->width * r->height * r->depth;
             const size_t linear_bytes = texels * guest_texel;
             uint8_t* destination = resource_bytes_for(r, bi.guest_bytes);
+            if (!r->host_data && r->gpu_addr)
+                prosper::host::guest_write_watch_notify_host_write(
+                    r->gpu_addr, bi.guest_bytes);
             std::unique_ptr<uint8_t[]> linear;
             uint8_t* packed = destination;
             if (r->tile_mode) {
@@ -2683,6 +3649,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 packed = linear.get();
             }
             const uint32_t* channels = static_cast<const uint32_t*>(mapped);
+            const uint8_t* native_texels = static_cast<const uint8_t*>(mapped);
             // #1122 proving-frame poison scan: a texel still fully poison was NOT stored by the write.
             // Zero survivors == the shader covers every texel (safe to fast-skip its seed henceforth);
             // any survivor == partial coverage (must always seed). Cache the verdict per (code,binding)
@@ -2693,7 +3660,14 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 poison_texel.assign(texels, 0);
                 for (size_t t = 0; t < texels; ++t) {
                     bool all = true;
-                    for (uint32_t c = 0; c < 4; ++c) if (channels[t * 4 + c] != 0xDEADBEEFu) all = false;
+                    if (bi.native_float_storage) {
+                        const uint8_t* texel = native_texels + t * guest_texel;
+                        for (size_t b = 0; b < guest_texel; ++b)
+                            if (texel[b] != 0x5a) all = false;
+                    } else {
+                        for (uint32_t c = 0; c < 4; ++c)
+                            if (channels[t * 4 + c] != 0xDEADBEEFu) all = false;
+                    }
                     if (all) { ++survived; poison_texel[t] = 1; }
                 }
                 {
@@ -2710,13 +3684,30 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                              survived ? "PARTIAL-COVERAGE (will always seed)" : "full-coverage (seed-skip proven)");
             }
             if (trace) {
-                for (size_t t = 0; t < texels; t++)
-                    for (uint32_t c = 0; c < 4; c++)
-                        bi.nonzero_channels += channels[t * 4 + c] != 0;
+                if (bi.native_float_storage) {
+                    for (size_t t = 0; t < texels; ++t) {
+                        const uint8_t* texel = native_texels + t * guest_texel;
+                        for (size_t b = 0; b < guest_texel; ++b)
+                            bi.nonzero_channels += texel[b] != 0;
+                    }
+                } else {
+                    for (size_t t = 0; t < texels; t++)
+                        for (uint32_t c = 0; c < 4; c++)
+                            bi.nonzero_channels += channels[t * 4 + c] != 0;
+                }
             }
             const auto pack_start = ComputeClock::now();
             static const bool pack_range_enabled = !std::getenv("PROSPER_NO_PACK_RANGE");
-            if (pack_range_enabled) {
+            if (bi.native_float_storage) {
+                // The typed Vulkan image has already applied the PS5 descriptor's UNORM/float
+                // conversion. Its transfer bytes are the guest's exact row-major texels.
+                parallel_compute_texels(texels, linear_bytes * 2,
+                    [&](size_t begin, size_t end) {
+                        std::memcpy(packed + begin * guest_texel,
+                                    native_texels + begin * guest_texel,
+                                    (end - begin) * guest_texel);
+                    });
+            } else if (pack_range_enabled) {
                 storage_pack_range(channels, r->format, nc, texels, packed, guest_texel);
             } else {
                 for (size_t t = 0; t < texels; t++)
@@ -2737,7 +3728,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             }
             const auto pack_done = ComputeClock::now();
             static const bool verify_pack = std::getenv("PROSPER_VERIFY_PACK") != nullptr;
-            if (verify_pack) {
+            if (verify_pack && !bi.native_float_storage) {
                 // Fail-visible A/B (mirrors PROSPER_VERIFY_UNPACK): the specialized range pack must
                 // be bit-identical to the per-texel path it replaces, verified against the real
                 // workload's texels. Logs the clean case too, so a verified run is self-proving.
@@ -2800,6 +3791,23 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                  "[compute]   DCC uncompressed binding=%u meta=0x%llx bytes=%zu code=0xff\n",
                                  bi.binding, (unsigned long long)r->metadata_addr,
                                  bi.dcc_metadata_bytes);
+            }
+            if (bi.cache_candidate) {
+                if (bi.persistent) {
+                    // Guest bytes now mirror the retained image again; discard the self-write
+                    // notification and arm the next external-write check from this exact state.
+                    ctx.validate_cached_image_source(bi.cache_key, destination);
+                } else if (bi.image && bi.memory && bi.allocation_bytes &&
+                           ctx.retain_image(bi.cache_key, bi.image, bi.memory,
+                                            bi.allocation_bytes, destination)) {
+                    bi.persistent = true;
+                    if (trace)
+                        std::fprintf(stderr,
+                                     "[compute]   retained storage image binding=%u "
+                                     "addr=0x%llx allocation=%llu\n",
+                                     bi.binding, (unsigned long long)r->gpu_addr,
+                                     (unsigned long long)bi.allocation_bytes);
+                }
             }
             ctx.unmap_memory(staging_memory[i]);
         }
@@ -2865,7 +3873,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                      "setup_ms=%.2f setup_validate_ms=%.2f setup_buffers_ms=%.2f "
                      "pipeline_ms=%.2f dispatch_ms=%.2f "
                      "writeback_ms=%.2f pack_ms=%.2f layout_ms=%.2f "
-                     "cleanup_ms=%.2f total_ms=%.2f\n",
+                     "cleanup_ms=%.2f total_ms=%.2f subgroup=%u\n",
                      (unsigned long long)item.submit_no, (unsigned long long)item.code_addr,
                      ok ? 1u : 0u, milliseconds(phase_start, phase_setup),
                      setup_validate_ms, setup_buffers_ms,
@@ -2874,7 +3882,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                      milliseconds(phase_dispatch, phase_writeback),
                      pack_ms, layout_ms,
                      milliseconds(phase_writeback, phase_cleanup),
-                     milliseconds(phase_start, phase_cleanup));
+                     milliseconds(phase_start, phase_cleanup), item.required_subgroup_size);
     }
     return ok;
 }

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -437,32 +437,32 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                      prosper::gpu::LiveTargetImageImport& import) {
             if (!direct_bind) return false;
             drain_guest_gpu_writes(g_rtt, invalidate_ds);
-            auto it = g_rtt.find(addr);
-            if (it == g_rtt.end()) {
-                // The color-target registry and persistent DS cache deliberately have separate
-                // authority rules. Compute still needs the same sampled-depth bridge as graphics:
-                // guest bytes are stale while the retained Vulkan depth image owns the current
-                // plane, and under PROSPER_RENDER_SCALE that image is also much smaller. Offer the
-                // synchronous compute consumer the exact image instead of detiling/uploading a 4K
-                // guest mirror. Persistent DS entries are not evicted, and compute runs in ordered
-                // submit execution, so unlike the bounded color cache this path needs no pin.
-                if (!request.allow_depth || !request.width || !request.height) return false;
+            // `allow_depth` is set only for a proven one-component Float32 2D descriptor. Prefer the
+            // matching DS plane before consulting the address-only color registry: guest allocations
+            // are reused, and a stale RttSurf at the same base must not hide the newer persistent
+            // depth image. Persistent DS entries are not evicted, and compute runs in ordered submit
+            // execution, so unlike the bounded color cache this path needs no pin.
+            if (request.allow_depth && request.width && request.height) {
                 const prosper::test::PersistentDsSampled sampled =
                     prosper::test::find_persistent_ds_sampled(
                         addr, request.width, request.height,
-                        request.render_scale ? request.render_scale : 1u);
+                        request.render_scale ? request.render_scale : 1u,
+                        request.normalized_sampling);
                 const prosper::test::RenderVkCtx& ctx = prosper::test::render_vk_ctx();
-                if (!sampled.image || !ctx.ok) return false;
-                import.width = sampled.width;
-                import.height = sampled.height;
-                import.kind = prosper::gpu::LiveTargetImageImport::Kind::Depth;
-                import.native_format = static_cast<uint32_t>(sampled.format);
-                import.image = sampled.image->image;
-                import.device = ctx.dev;
-                import.layout = static_cast<uint32_t>(
-                    VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
-                return true;
+                if (sampled.image && ctx.ok) {
+                    import.width = sampled.width;
+                    import.height = sampled.height;
+                    import.kind = prosper::gpu::LiveTargetImageImport::Kind::Depth;
+                    import.native_format = static_cast<uint32_t>(sampled.format);
+                    import.image = sampled.image->image;
+                    import.device = ctx.dev;
+                    import.layout = static_cast<uint32_t>(
+                        VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
+                    return true;
+                }
             }
+            auto it = g_rtt.find(addr);
+            if (it == g_rtt.end()) return false;
             RttSurf& surface = it->second;
             if (!surface.w || !surface.h) return false;
             const VkFormat format = prosper::test::backend_color_format(surface.format);
@@ -934,8 +934,13 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                const prosper::gpu::ShaderResourceTable* vrt,
                                const prosper::gpu::ShaderResourceTable* prt) {
               std::vector<prosper::test::FrameResource> R;
-              auto add = [&](const prosper::gpu::ShaderResourceTable* t, uint32_t set){
+              auto add = [&](const prosper::gpu::ShaderResourceTable* t, uint32_t set,
+                             const std::vector<uint32_t>& spirv,
+                             prosper::gpu::SpirvShaderStage stage){
                 if (!t) return;
+                const prosper::gpu::DescriptorValidationReport reflected =
+                    prosper::gpu::validate_spirv_descriptor_interface(
+                        spirv, t, set, stage, false);
                 for (auto& r : t->resources) {
                     const auto resource_timing_start = timing_enabled
                         ? RenderClock::now() : RenderClock::time_point{};
@@ -948,6 +953,17 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     bool resource_buffer_view = false;
                     prosper::test::FrameResource fr; fr.binding = r.binding; fr.set = set;
                     fr.is_storage_image = r.cls == RC::StorageImage;
+                    const auto reflected_binding = std::find_if(
+                        reflected.descriptors.begin(), reflected.descriptors.end(),
+                        [&](const auto& descriptor) {
+                            return descriptor.set == set && descriptor.binding == r.binding;
+                        });
+                    const bool normalized_sampling =
+                        reflected_binding != reflected.descriptors.end() &&
+                        reflected_binding->kind ==
+                            prosper::gpu::SpirvDescriptorKind::CombinedImageSampler &&
+                        reflected_binding->normalized_sampling &&
+                        !reflected_binding->texel_access;
                     // Captured replays preserve the logical guest address for RT identity but provide
                     // owned bytes here. Production resources leave host_data null and use guest memory.
                     auto copy_resource = [&](uint8_t* dst, uint64_t addr, size_t n) -> size_t {
@@ -1063,7 +1079,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             RttSurf& surface = live_rtt->second;
                             const bool sampled_extent_compatible =
                                 prosper::frontend::rtt_sampled_extent_compatible(
-                                    tw, th, surface.w, surface.h, render_scale);
+                                    tw, th, surface.w, surface.h, render_scale,
+                                    normalized_sampling);
                             const bool direct_serves = !fr.is_storage_image && r.img_dim == 1u &&
                                 sampled_extent_compatible &&
                                 r.gpu_addr != draw.color0_base &&
@@ -1107,7 +1124,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             r.img_dim == 1u &&
                             live_rtt != g_rtt.end() && live_rtt->second.gpu_valid &&
                             prosper::frontend::rtt_sampled_extent_compatible(
-                                tw, th, live_rtt->second.w, live_rtt->second.h, render_scale) &&
+                                tw, th, live_rtt->second.w, live_rtt->second.h, render_scale,
+                                normalized_sampling) &&
                             r.gpu_addr != draw.color0_base &&
                             prosper::test::find_persistent_color_target(
                                 r.gpu_addr, live_rtt->second.w, live_rtt->second.h,
@@ -1437,7 +1455,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             !has_live_rtt && !fr.is_storage_image && r.img_dim == 1u &&
                                     r.cls == RC::Texture
                                 ? prosper::test::find_persistent_ds_sampled(
-                                      r.gpu_addr, tw, th, render_scale)
+                                      r.gpu_addr, tw, th, render_scale, normalized_sampling)
                                 : prosper::test::PersistentDsSampled{};
                         const bool has_ds_live = sampled_ds.image != nullptr;
                         if (has_gpu_live_rtt) {
@@ -2504,7 +2522,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     R.push_back(std::move(fr));
                 }
               };
-              add(vrt, 0); add(prt, 1);   // VS resources -> descriptor set 0, PS -> set 1
+              add(vrt, 0, draw.vs_words(), prosper::gpu::SpirvShaderStage::Vertex);
+              add(prt, 1, draw.fs_words(), prosper::gpu::SpirvShaderStage::Fragment);
+              // VS resources -> descriptor set 0, PS -> set 1
               return R;
             };
             // Poison mode keeps the draw running while making invalid bindings visually/numerically
@@ -3119,7 +3139,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                         active_color1(items[later]) == target_base;
                                     const bool sampled_extent_compatible =
                                         prosper::frontend::rtt_sampled_extent_compatible(
-                                            rw, rh, gw, gh, render_scale);
+                                            rw, rh, gw, gh, render_scale, false);
                                     if (resource.img_dim == 1u && sampled_extent_compatible) {
                                         result.sampled_exact = true;
                                         result.feedback |= same_pass_target;

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -1,7 +1,9 @@
 // live_renderer.cpp — see live_renderer.hpp. Extracted from boot_trace's PROSPER_RENDER lambda
 // (behavior-preserving); Vulkan-backed, so this unit links Vulkan::Vulkan.
 #include "live_renderer.hpp"
+#include "rtt_authority.hpp"
 #include "rtt_injection.hpp"
+#include "rtt_scale.hpp"
 #include "readback_policy.hpp"
 #include "live_compute.hpp"
 
@@ -154,6 +156,17 @@ std::vector<uint8_t> inspection_rgba8(const std::vector<uint8_t>& pixels,
     const size_t texels = static_cast<size_t>(width) * height;
     if (format == VK_FORMAT_R8G8B8A8_UNORM && pixels.size() == texels * 4)
         return pixels;
+    if (format == VK_FORMAT_R8_UNORM && pixels.size() == texels) {
+        std::vector<uint8_t> rgba(texels * 4);
+        for (size_t texel = 0; texel < texels; ++texel) {
+            const uint8_t value = pixels[texel];
+            rgba[texel * 4 + 0] = value;
+            rgba[texel * 4 + 1] = value;
+            rgba[texel * 4 + 2] = value;
+            rgba[texel * 4 + 3] = value;
+        }
+        return rgba;
+    }
     // R16G16B16A16_UNORM: 16-bit fixed-point per channel -> 8-bit (high byte). Without this, a 64-bit
     // UNORM color target (a common non-float HDR/deep surface) inspected to black regardless of content,
     // which is misleading for RTT diagnostics.
@@ -405,10 +418,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
             return true;
         });
     // Phase 2 of #1091 (#1095): with one shared device the compute backend can sample the renderer's
-    // persistent image in place. Offer it ONLY while that image is the authoritative copy -- exactly
-    // the case the reader above would have had to materialize. Whenever a CPU snapshot exists it may
-    // be the newer truth (a guest GPU write drops the CPU copy and invalidates the GPU target
-    // independently, #780), so the caller must keep using the snapshot path there.
+    // persistent image in place. Offer it only while gpu_valid proves that image is current. A CPU
+    // snapshot may coexist as an ordered readback mirror; CPU-newer publications clear gpu_valid,
+    // while guest GPU writes erase the cache entry before this callback runs (#780).
     // One dispatch can bind the same target through several descriptors, so pins are counted: the
     // compute backend releases once per successful import and the entry drops at zero.
     struct PinnedImport { uint32_t width, height; VkFormat format; uint32_t count; };
@@ -420,13 +432,39 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
     pinned_imports.clear();
     const bool direct_bind = !getenv("PROSPER_NO_DIRECT_RTT_BIND");
     prosper::gpu::set_live_target_image_importer(
-        [invalidate_ds, direct_bind](uint64_t addr, prosper::gpu::LiveTargetImageImport& import) {
+        [invalidate_ds, direct_bind](uint64_t addr,
+                                     const prosper::gpu::LiveTargetImageRequest& request,
+                                     prosper::gpu::LiveTargetImageImport& import) {
             if (!direct_bind) return false;
             drain_guest_gpu_writes(g_rtt, invalidate_ds);
             auto it = g_rtt.find(addr);
-            if (it == g_rtt.end()) return false;
+            if (it == g_rtt.end()) {
+                // The color-target registry and persistent DS cache deliberately have separate
+                // authority rules. Compute still needs the same sampled-depth bridge as graphics:
+                // guest bytes are stale while the retained Vulkan depth image owns the current
+                // plane, and under PROSPER_RENDER_SCALE that image is also much smaller. Offer the
+                // synchronous compute consumer the exact image instead of detiling/uploading a 4K
+                // guest mirror. Persistent DS entries are not evicted, and compute runs in ordered
+                // submit execution, so unlike the bounded color cache this path needs no pin.
+                if (!request.allow_depth || !request.width || !request.height) return false;
+                const prosper::test::PersistentDsSampled sampled =
+                    prosper::test::find_persistent_ds_sampled(
+                        addr, request.width, request.height,
+                        request.render_scale ? request.render_scale : 1u);
+                const prosper::test::RenderVkCtx& ctx = prosper::test::render_vk_ctx();
+                if (!sampled.image || !ctx.ok) return false;
+                import.width = sampled.width;
+                import.height = sampled.height;
+                import.kind = prosper::gpu::LiveTargetImageImport::Kind::Depth;
+                import.native_format = static_cast<uint32_t>(sampled.format);
+                import.image = sampled.image->image;
+                import.device = ctx.dev;
+                import.layout = static_cast<uint32_t>(
+                    VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
+                return true;
+            }
             RttSurf& surface = it->second;
-            if (!surface.w || !surface.h || !surface.gpu_valid) return false;
+            if (!surface.w || !surface.h) return false;
             const VkFormat format = prosper::test::backend_color_format(surface.format);
             // Map the backend format explicitly and fail closed. A direct bind hands the consumer a
             // real VkImage, so an unrecognized format must decline rather than be reported as rgba8:
@@ -443,7 +481,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
             const uint64_t texels = static_cast<uint64_t>(surface.w) * surface.h;
             if (texels > UINT64_MAX / bytes_per_pixel) return false;
             const uint64_t expected = texels * bytes_per_pixel;
-            if (surface.rgba && surface.rgba->size() == expected) return false;  // CPU copy is truth
+            const bool has_cpu_snapshot = surface.rgba && surface.rgba->size() == expected;
+            if (!prosper::frontend::live_rtt_gpu_importable(surface.gpu_valid,
+                                                             has_cpu_snapshot))
+                return false;
             const prosper::test::RenderVkCtx& ctx = prosper::test::render_vk_ctx();
             if (!ctx.ok) return false;
             prosper::test::PersistentColorTargetImage* target =
@@ -476,6 +517,14 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
             prosper::test::unpin_persistent_color_target(addr, pin.width, pin.height, pin.format);
             if (--pin.count == 0) pinned_imports.erase(pinned);
         });
+    prosper::gpu::set_live_target_image_written_notifier([](uint64_t addr) {
+        auto it = g_rtt.find(addr);
+        if (it == g_rtt.end()) return;
+        // The compute dispatch wrote the persistent image itself. Keep it authoritative and discard
+        // the now-older ordered readback mirror without publishing stale guest bytes over the image.
+        it->second.rgba.reset();
+        it->second.gpu_valid = true;
+    });
     prosper::gpu::set_live_target_byte_range_reader(
         [invalidate_ds](uint64_t addr, uint32_t bytes, std::vector<uint8_t>& output) {
             drain_guest_gpu_writes(g_rtt, invalidate_ds);
@@ -999,6 +1048,11 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             avplayer_chroma_layout,
                         };
                         auto live_rtt = rtt_on ? g_rtt.find(r.gpu_addr) : g_rtt.end();
+                        static const uint32_t render_scale = [] {
+                            const char* e = std::getenv("PROSPER_RENDER_SCALE");
+                            const long v = e ? std::strtol(e, nullptr, 10) : 1;
+                            return v > 0 ? static_cast<uint32_t>(v) : 1u;
+                        }();
                         // Deferred RTT readback (#1284): a GPU-resident target consumed in a way the
                         // direct GPU bind below cannot serve (extent mismatch, feedback into its own
                         // pass, storage image) materializes its CPU copy here on demand. The producer
@@ -1007,11 +1061,14 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         if (live_rtt != g_rtt.end() && live_gpu_targets && r.img_dim != 2u &&
                             !r.in_mip_tail && live_rtt->second.gpu_valid) {
                             RttSurf& surface = live_rtt->second;
+                            const bool sampled_extent_compatible =
+                                prosper::frontend::rtt_sampled_extent_compatible(
+                                    tw, th, surface.w, surface.h, render_scale);
                             const bool direct_serves = !fr.is_storage_image && r.img_dim == 1u &&
-                                surface.w == tw && surface.h == th &&
+                                sampled_extent_compatible &&
                                 r.gpu_addr != draw.color0_base &&
                                 prosper::test::find_persistent_color_target(
-                                    r.gpu_addr, tw, th, surface.format) != nullptr;
+                                    r.gpu_addr, surface.w, surface.h, surface.format) != nullptr;
                             const VkFormat surface_format =
                                 prosper::test::backend_color_format(surface.format);
                             const uint32_t surface_bpp =
@@ -1049,10 +1106,12 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         const bool has_gpu_live_rtt = !fr.is_storage_image && live_gpu_targets &&
                             r.img_dim == 1u &&
                             live_rtt != g_rtt.end() && live_rtt->second.gpu_valid &&
-                            live_rtt->second.w == tw && live_rtt->second.h == th &&
+                            prosper::frontend::rtt_sampled_extent_compatible(
+                                tw, th, live_rtt->second.w, live_rtt->second.h, render_scale) &&
                             r.gpu_addr != draw.color0_base &&
                             prosper::test::find_persistent_color_target(
-                                r.gpu_addr, tw, th, live_rtt->second.format) != nullptr;
+                                r.gpu_addr, live_rtt->second.w, live_rtt->second.h,
+                                live_rtt->second.format) != nullptr;
                         const bool has_live_rtt = has_cpu_live_rtt || has_gpu_live_rtt;
                         const bool is_cube = r.img_dim == 3u;   // CUBE: six faces stacked vertically (#273)
                         const bool is_volume = r.img_dim == 2u;
@@ -1141,10 +1200,21 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             (!r.host_data || r.linear_row_pitch_bytes != 0) &&
                             !r.compression_enabled && persistent_bc_block_bytes == 0 &&
                             linear_dst_row != 0 && linear_src_row > linear_dst_row;
+                        // Dynamic single-channel video/coverage surfaces are already exactly what a
+                        // VK_FORMAT_R8_UNORM sampled image consumes. Expanding every byte to RGBA on the
+                        // CPU multiplied Astro Bot's 3840x3240 FMV traffic by four and cost 26-31 ms per
+                        // frame. Keep the historical grayscale broadcast through the image-view swizzle.
+                        const bool native_r8_sampled =
+                            r.cls == RC::Texture && r.img_dim == 1u &&
+                            r.format == prosper::gpu::DataFormat::Unorm8 &&
+                            r.num_components == 1 && r.tile_mode == 0u &&
+                            !r.compression_enabled && !linear_padded_read;
                         const bool persistent_source_matches_pixels =
-                            persistent_unorm8_texture && r.num_components == 4 && !linear_padded_read &&
-                            !prosper::gpu::tile_mode_is_tiled(r.tile_mode) &&
-                            (!getenv("PROSPER_DETILE") || atoi(getenv("PROSPER_DETILE")) == 0);
+                            native_r8_sampled ||
+                            (persistent_unorm8_texture && r.num_components == 4 &&
+                             !linear_padded_read &&
+                             !prosper::gpu::tile_mode_is_tiled(r.tile_mode) &&
+                             (!getenv("PROSPER_DETILE") || atoi(getenv("PROSPER_DETILE")) == 0));
                         const size_t persistent_source_size = [&] {
                             if (!persistent_sampled_texture) return size_t{0};
                             if (persistent_bc_block_bytes) {
@@ -1358,22 +1428,30 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // surface prosper rendered into a persistent Vulkan DS image. Guest memory
                         // never receives that depth, so the guest-byte decode below would sample
                         // zeros (every shadow compare passes -> unshadowed, overbright scenes).
-                        // Bind the retained depth image directly instead. Under
-                        // PROSPER_RENDER_SCALE>1 the DS extent is scaled while the T# stays native,
-                        // so the exact-extent match misses and scaled captures render unshadowed —
-                        // a documented limitation of the deliberate sampling accelerations.
-                        const bool has_ds_live = !has_live_rtt && !fr.is_storage_image &&
-                            r.img_dim == 1u && r.cls == RC::Texture &&
-                            prosper::test::find_persistent_ds_sampled(r.gpu_addr, tw, th).image !=
-                                nullptr;
+                        // Bind the retained depth image directly instead. The guest T# keeps its
+                        // native extent under PROSPER_RENDER_SCALE>1 while the renderer-owned image
+                        // is uniformly smaller; normalized depth sampling maps onto that image just
+                        // like the color-target bridge above. Keep the actual image extent in the
+                        // backend resource so its exact cache lookup remains unambiguous.
+                        const prosper::test::PersistentDsSampled sampled_ds =
+                            !has_live_rtt && !fr.is_storage_image && r.img_dim == 1u &&
+                                    r.cls == RC::Texture
+                                ? prosper::test::find_persistent_ds_sampled(
+                                      r.gpu_addr, tw, th, render_scale)
+                                : prosper::test::PersistentDsSampled{};
+                        const bool has_ds_live = sampled_ds.image != nullptr;
                         if (has_gpu_live_rtt) {
                             fr.persistent_render_target_id = r.gpu_addr;
-                            fr.tw = tw; fr.th = th; fr.td = 1; fr.img_dim = r.img_dim;
+                            fr.tw = live_rtt->second.w;
+                            fr.th = live_rtt->second.h;
+                            fr.td = 1; fr.img_dim = r.img_dim;
                             fr.texture_format = live_rtt->second.format;
                             resource_rtt_hit = true;
                         } else if (has_ds_live) {
                             fr.persistent_depth_target_id = r.gpu_addr;
-                            fr.tw = tw; fr.th = th; fr.td = 1; fr.img_dim = r.img_dim;
+                            fr.tw = sampled_ds.width;
+                            fr.th = sampled_ds.height;
+                            fr.td = 1; fr.img_dim = r.img_dim;
                             resource_rtt_hit = true;
                             if (getenv("PROSPER_DSBRIDGE_LOG")) {
                                 static int consumer_logged = 0;
@@ -1395,7 +1473,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             fr.th = decoded_reuse->output_height;
                             fr.td = is_volume ? r.depth : 1u;
                             fr.img_dim = r.img_dim;
-                            if (sampled_source_f32)
+                            if (native_r8_sampled)
+                                fr.texture_format = VK_FORMAT_R8_UNORM;
+                            else if (sampled_source_f32)
                                 fr.texture_format = VK_FORMAT_R16G16B16A16_SFLOAT;
                             // #1272: plain 2D guest textures only — cube outputs stack 6 faces into
                             // one 2D image (fr.th != th), and volumes keep their own path; generated
@@ -1511,8 +1591,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         const size_t volume_texels = (size_t)tw * th * (is_volume ? r.depth : 1u);
                         const VkFormat live_rtt_format = has_cpu_live_rtt
                             ? live_rtt->second.format
-                            : (sampled_source_f32 ? VK_FORMAT_R16G16B16A16_SFLOAT
-                                                  : VK_FORMAT_R8G8B8A8_UNORM);
+                            : (native_r8_sampled ? VK_FORMAT_R8_UNORM
+                               : (sampled_source_f32 ? VK_FORMAT_R16G16B16A16_SFLOAT
+                                                     : VK_FORMAT_R8G8B8A8_UNORM));
                         fr.texture_format = live_rtt_format;
                         const uint32_t output_bpp =
                             prosper::test::backend_color_bytes_per_pixel(live_rtt_format);
@@ -1823,6 +1904,17 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             sampled_float16_to_unorm8_range(
                                 hlin.data(), nc, volume_texels, texture_pixels.data());
                             f16_done = true;   // read+detiled at the real element size already
+                        } else if (native_r8_sampled) {
+                            // Tight linear R8 needs neither detiling nor per-texel expansion. One guarded
+                            // copy feeds the backend's 1-byte staging upload; the view swizzle below makes
+                            // every sampled component equal R, byte-for-byte matching the old RGBA result.
+                            linear_source_prefix_size = copy_resource(
+                                texture_pixels.data(), r.gpu_addr, texture_pixels.size());
+                            if (linear_source_prefix_size < texture_pixels.size())
+                                std::fill(texture_pixels.begin() + linear_source_prefix_size,
+                                          texture_pixels.end(), 0);
+                            narrow_decode_done = true;
+                            narrow_done = true;
                         } else if (bpt < 4) {
                             // Narrow (single/dual-channel) surface: read at the REAL element size and detile
                             // with the matching bpe geometry (1 B -> 64x64, 2 B -> 64x32 micro-tiles, #119),
@@ -2049,7 +2141,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // PROSPER_PALETTELOG: compact identity/provenance trace for Unity's 256x16
                         // palette textures. Unlike GFXLOG this is cheap enough for a focused render
                         // window and reveals both descriptor-address and decoded-content changes.
-                        if (getenv("PROSPER_PALETTELOG") && tw == 256 && th == 16) {
+                        if (getenv("PROSPER_PALETTELOG") && tw == 256 && th == 16 &&
+                            fr.texture_format == VK_FORMAT_R8G8B8A8_UNORM) {
                             uint64_t hash = 1469598103934665603ull;
                             size_t rgb_nonblack = 0;
                             for (size_t t = 0; t < (size_t)tw * th; ++t) {
@@ -2091,6 +2184,14 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                             p[2] = prosper::gpu::float_to_half(ck ? 0.8f : 0.16f);
                                             p[3] = prosper::gpu::float_to_half(1.0f);
                                         }
+                            } else if (fr.texture_format == VK_FORMAT_R8_UNORM) {
+                                for (uint32_t z = 0; z < slices; ++z)
+                                    for (uint32_t y = 0; y < th; ++y)
+                                        for (uint32_t x = 0; x < tw; ++x) {
+                                            const bool ck = ((x / 64) ^ (y / 64) ^ z) & 1;
+                                            texture_pixels[((size_t)z * th + y) * tw + x] =
+                                                ck ? 200 : 40;
+                                        }
                             } else {
                                 for (uint32_t z = 0; z < slices; ++z)
                                     for (uint32_t y = 0; y < th; ++y)
@@ -2109,7 +2210,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // The identity probe preserves source color through shaders using
                         // u=r/17+b*15/16, v=1-g, distinguishing lookup contents from a broken
                         // source/geometry/sample path (#522).
-                        if (getenv("PROSPER_TESTLUT") && tw == 256 && th == 16) {
+                        if (getenv("PROSPER_TESTLUT") && tw == 256 && th == 16 &&
+                            fr.texture_format == VK_FORMAT_R8G8B8A8_UNORM) {
                             for (uint32_t y = 0; y < th; y++) for (uint32_t x = 0; x < tw; x++) {
                                 uint8_t* p = &texture_pixels[((size_t)y * tw + x) * 4];
                                 p[0] = (uint8_t)((x % 16) * 255 / 15);
@@ -2121,7 +2223,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // Unity's post-processing stack flattens a 32^3 grading LUT into a 1024x32
                         // strip (32 red samples per blue slice). This isolates a missing LUT producer
                         // from the persistent post shader and its healthy scene input (#522).
-                        if (getenv("PROSPER_TESTLUT32") && tw == 1024 && th == 32) {
+                        if (getenv("PROSPER_TESTLUT32") && tw == 1024 && th == 32 &&
+                            fr.texture_format == VK_FORMAT_R8G8B8A8_UNORM) {
                             for (uint32_t y = 0; y < th; ++y) for (uint32_t x = 0; x < tw; ++x) {
                                 uint8_t* p = &texture_pixels[((size_t)y * tw + x) * 4];
                                 p[0] = (uint8_t)((x % 32) * 255 / 31);
@@ -2277,7 +2380,11 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // T# DST_SEL channel remap (#261): narrow coverage paths already broadcast to
                         // every channel, so keep them identity. AvPlayer RG8 preserved U/V above and
                         // still needs its T# mapping (R,G,0,1).
-                        if (narrow_done && !avplayer_chroma_layout) {
+                        if (native_r8_sampled) {
+                            fr.swizzle[0]=4; fr.swizzle[1]=4;
+                            fr.swizzle[2]=4; fr.swizzle[3]=4;
+                        }
+                        else if (narrow_done && !avplayer_chroma_layout) {
                             fr.swizzle[0]=4; fr.swizzle[1]=5; fr.swizzle[2]=6; fr.swizzle[3]=7;
                         }
                         else { for (int k=0;k<4;k++) fr.swizzle[k] = r.swizzle[k]; }
@@ -2936,6 +3043,14 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     const uint8_t* seed = nullptr;
                     bool gpu_seed_available = false;
                     const VkFormat pass_format = format0;
+                    const bool color1_extent_matches = base1 && !render_pass.empty() &&
+                        render_pass.front()->color1_width == native_w &&
+                        render_pass.front()->color1_height == native_h;
+                    // Keep an exact-capture diagnostic switch so MRT1 can be compared against the
+                    // previous single-target behavior without recapturing.
+                    const bool use_color1 = base1 && color1_extent_matches &&
+                                            getenv("PROSPER_NO_MRT1") == nullptr;
+                    const VkFormat pass_format1 = use_color1 ? format1 : VK_FORMAT_UNDEFINED;
                     const size_t pass_bytes = static_cast<size_t>(gw) * gh *
                         prosper::test::backend_color_bytes_per_pixel(pass_format);
                     if (seed_rtt && base) { auto sit = g_rtt.find(base);
@@ -2966,63 +3081,90 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                         sit->second.rgba ? sit->second.rgba->size() : (size_t)0,
                                         gw, gh, (int)pass_format, pass_bytes);
                         } }
-                    bool sampled_exact_later = false;
-                    bool feedback_later = false;
+                    struct LaterTargetConsumers {
+                        bool sampled_exact = false;
+                        bool feedback = false;
+                        bool cpu_needed = false;
+                    };
                     // A later pass in THIS batch that reads the target's CPU bytes cannot be served
                     // lazily: the producing commands are still unsubmitted when it binds, so a
                     // mid-batch readback would return stale pixels. Only the direct GPU bind (2D
                     // texture, exact extent, not feedback, not storage) is batch-ordered; every
-                    // other same-batch consumer forces the eager readback — including cube/1D
-                    // samplers (they consume rgba via the RTT injection path) and passes that
-                    // re-bind this target as their color1 seed. Volume (img_dim==2) consumers read
-                    // guest memory on both paths and never block. pass_i has already advanced past
-                    // the current pass, so every scanned item is a genuine later consumer.
+                    // other same-batch consumer forces the eager readback. A later color attachment
+                    // LOAD is now direct for both MRT attachments and needs no CPU copy. Volume
+                    // (img_dim==2) consumers read guest memory on both paths and never block. pass_i
+                    // has already advanced past the current pass, so every scanned item is genuine.
                     // Cross-batch consumers materialize on demand at bind/seed/compute/DMA time
                     // (#1284).
-                    bool cpu_needed_same_batch = false;
-                    if (live_gpu_targets && base) {
+                    const auto inspect_later_consumers = [&](uint64_t target_base) {
+                        LaterTargetConsumers result;
+                        if (!live_gpu_targets || !target_base) return result;
+                        static const uint32_t render_scale = [] {
+                            const char* e = std::getenv("PROSPER_RENDER_SCALE");
+                            const long v = e ? std::strtol(e, nullptr, 10) : 1;
+                            return v > 0 ? static_cast<uint32_t>(v) : 1u;
+                        }();
                         for (size_t later = pass_i; later < items.size(); ++later) {
                             auto inspect = [&](const prosper::gpu::ShaderResourceTable* table) {
                                 if (!table) return;
                                 for (const auto& resource : table->resources) {
                                     if ((resource.cls != RC::Texture &&
                                          resource.cls != RC::StorageImage) ||
-                                        resource.gpu_addr != base || resource.img_dim == 2u)
+                                        resource.gpu_addr != target_base || resource.img_dim == 2u)
                                         continue;
                                     const uint32_t rw = resource.width ? resource.width : 4u;
                                     const uint32_t rh = resource.height ? resource.height : 4u;
-                                    if (resource.img_dim == 1u && rw == gw && rh == gh) {
-                                        sampled_exact_later = true;
-                                        feedback_later |= items[later].color0_base == base;
+                                    const bool same_pass_target =
+                                        items[later].color0_base == target_base ||
+                                        active_color1(items[later]) == target_base;
+                                    const bool sampled_extent_compatible =
+                                        prosper::frontend::rtt_sampled_extent_compatible(
+                                            rw, rh, gw, gh, render_scale);
+                                    if (resource.img_dim == 1u && sampled_extent_compatible) {
+                                        result.sampled_exact = true;
+                                        result.feedback |= same_pass_target;
                                     }
                                     const bool direct_bindable =
                                         resource.cls == RC::Texture && resource.img_dim == 1u &&
-                                        rw == gw && rh == gh &&
-                                        items[later].color0_base != base;
-                                    if (!direct_bindable) cpu_needed_same_batch = true;
+                                        sampled_extent_compatible && !same_pass_target;
+                                    if (!direct_bindable) result.cpu_needed = true;
                                 }
                             };
                             inspect(items[later].vrt.get());
                             inspect(items[later].prt.get());
-                            if (active_color1(items[later]) == base)
-                                cpu_needed_same_batch = true;
                         }
-                    }
+                        return result;
+                    };
+                    const LaterTargetConsumers consumers0 = inspect_later_consumers(base);
+                    const LaterTargetConsumers consumers1 = use_color1
+                        ? inspect_later_consumers(base1) : LaterTargetConsumers{};
+                    const bool sampled_exact_later = consumers0.sampled_exact;
+                    const bool feedback_later = consumers0.feedback;
+                    const bool cpu_needed_same_batch = consumers0.cpu_needed;
                     static const bool defer_rtt_readback =
                         !getenv("PROSPER_NO_RTT_READBACK_DEFER");
                     const bool rtt_defer_ok = defer_rtt_readback
                         ? !cpu_needed_same_batch
                         : (sampled_exact_later && !feedback_later);
+                    const bool rtt_defer_ok1 = defer_rtt_readback
+                        ? !consumers1.cpu_needed
+                        : (consumers1.sampled_exact && !consumers1.feedback);
                     // Keep intermediate scanout spans GPU-resident too: they cannot publish until the
                     // final callback, where the cache is materialized on demand if no later scanout
                     // pass already requested CPU pixels. A same-submit DMA asks its producer span for
                     // authoritative readback, and compute consumers use the lazy target reader above.
+                    const bool final_gpu_present = phase.final_span &&
+                        !phase.authoritative_readback && prosper::gpu::gpu_present_active();
                     const bool defer_readback = live_gpu_targets && vo_n > 0 && base &&
                         !phase.authoritative_readback &&
-                        ((is_vo && can_defer_intermediate_scanout_readback(
+                        ((is_vo && can_defer_scanout_readback(
                                        phase.allows_deferred_scanout_readback(),
+                                       final_gpu_present,
                                        defer_intermediate_scanout, cpu_needed_same_batch)) ||
                          (!is_vo && base != front_va && rtt_defer_ok));
+                    const bool defer_readback1 = live_gpu_targets && vo_n > 0 && use_color1 &&
+                        base1 && base1 != base && !phase.authoritative_readback &&
+                        base1 != front_va && rtt_defer_ok1;
                     // PROSPER_READBACK_WHY (#1284): classify WHY each non-deferred pass takes the
                     // synchronous CPU readback (75-79 ms/window on Blue Prince's Day One frame).
                     // The dominant reason selects the next optimization; behavior unchanged.
@@ -3064,53 +3206,17 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             }
                         }
                     }
-                    prosper::test::BackendColorTarget backend_target{
-                        base, seed_rtt, !defer_readback, pass_format};
-                    const bool color1_extent_matches = base1 && !render_pass.empty() &&
-                        render_pass.front()->color1_width == native_w &&
-                        render_pass.front()->color1_height == native_h;
-                    // Keep an exact-capture diagnostic switch so MRT1 can be compared
-                    // against the previous single-target behavior without recapturing.
-                    const bool use_color1 = base1 && color1_extent_matches &&
-                                            getenv("PROSPER_NO_MRT1") == nullptr;
-                    const VkFormat pass_format1 = use_color1 ? format1 : VK_FORMAT_UNDEFINED;
                     const uint8_t* seed1 = nullptr;
+                    bool gpu_seed1_available = false;
                     if (seed_rtt && use_color1) { auto sit = g_rtt.find(base1);
-                        // Deferred RTT readback (#1284): color1 has no GPU-side load path, so a
-                        // deferred target re-bound as the color1 seed materializes its CPU pixels
-                        // here. Same-batch producers were forced eager by the consumer scan
-                        // (active_color1 == base), so this readback only ever sees prior,
-                        // already-submitted batches.
-                        if (sit != g_rtt.end() && sit->second.gpu_valid &&
+                        gpu_seed1_available = live_gpu_targets && sit != g_rtt.end() &&
+                            sit->second.gpu_valid &&
                             sit->second.w == gw && sit->second.h == gh &&
-                            sit->second.format == pass_format1) {
-                            RttSurf& seed1_surface = sit->second;
-                            const size_t seed1_bytes = static_cast<size_t>(gw) * gh *
-                                prosper::test::backend_color_bytes_per_pixel(pass_format1);
-                            if (seed1_bytes &&
-                                (!seed1_surface.rgba ||
-                                 seed1_surface.rgba->size() != seed1_bytes)) {
-                                std::vector<uint8_t> materialized;
-                                std::string error;
-                                if (prosper::test::readback_persistent_color_target(
-                                        base1, gw, gh,
-                                        prosper::test::backend_color_format(pass_format1),
-                                        materialized, error) &&
-                                    materialized.size() == seed1_bytes) {
-                                    seed1_surface.rgba =
-                                        std::make_shared<const std::vector<uint8_t>>(
-                                            std::move(materialized));
-                                } else {
-                                    static std::atomic<int> warned{0};
-                                    if (warned.fetch_add(1) < 24)
-                                        fprintf(stderr,
-                                                "[rtt] color1 seed readback failed: base=0x%llx "
-                                                "extent=%ux%u error=%s\n",
-                                                (unsigned long long)base1, gw, gh, error.c_str());
-                                }
-                            }
-                        }
-                        if (sit != g_rtt.end() && sit->second.w == gw && sit->second.h == gh &&
+                            sit->second.format == pass_format1 &&
+                            prosper::test::find_persistent_color_target(
+                                base1, gw, gh, pass_format1) != nullptr;
+                        if (!gpu_seed1_available && sit != g_rtt.end() &&
+                            sit->second.w == gw && sit->second.h == gh &&
                             sit->second.format == pass_format1 && sit->second.rgba &&
                             sit->second.rgba->size() == static_cast<size_t>(gw) * gh *
                                 prosper::test::backend_color_bytes_per_pixel(pass_format1))
@@ -3125,6 +3231,12 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     }
                     const auto build_start = timing_enabled
                         ? RenderClock::now() : RenderClock::time_point{};
+                    prosper::test::BackendColorTarget backend_target{
+                        base, seed_rtt, !defer_readback, pass_format};
+                    backend_target.persistent_id1 = use_color1 ? base1 : 0;
+                    backend_target.load_existing1 = seed_rtt;
+                    backend_target.readback1 = !defer_readback1;
+                    backend_target.format1 = pass_format1;
                     auto backend_draws = build_bds(render_pass);
                     const auto build_done = timing_enabled
                         ? RenderClock::now() : RenderClock::time_point{};
@@ -3202,8 +3314,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         surface.format = pass_format;
                         surface.gpu_valid = false;
                     }
-                    if (use_color1 && !gpx1.empty()) {
-                        if (rtt_log) {
+                    if (use_color1 && base1) {
+                        if (rtt_log && !gpx1.empty()) {
                             size_t nz = 0, rgb_nz = 0;
                             for (uint8_t byte : gpx1) nz += byte != 0;
                             if (pass_format1 == VK_FORMAT_R8G8B8A8_UNORM)
@@ -3216,9 +3328,16 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                     (unsigned long long)base1, gw, gh, pass.size(), nz, rgb_nz);
                         }
                         RttSurf& surface = g_rtt[base1];
-                        surface.rgba = std::make_shared<const std::vector<uint8_t>>(std::move(gpx1));
-                        surface.w = gw; surface.h = gh; surface.format = pass_format1;
-                        surface.gpu_valid = false;
+                        surface.w = gw;
+                        surface.h = gh;
+                        surface.format = pass_format1;
+                        surface.gpu_valid = prosper::test::find_persistent_color_target(
+                            base1, gw, gh, pass_format1) != nullptr;
+                        if (!gpx1.empty())
+                            surface.rgba = std::make_shared<const std::vector<uint8_t>>(
+                                std::move(gpx1));
+                        else if (surface.gpu_valid)
+                            surface.rgba.reset();
                     }
                     const std::vector<uint8_t>& rendered_pixels = *pass_pixels;
                     if (native_w == resource_hash_w && native_h == resource_hash_h &&

--- a/prosper/frontends/shared/readback_policy.hpp
+++ b/prosper/frontends/shared/readback_policy.hpp
@@ -2,13 +2,17 @@
 
 namespace prosper::frontend {
 
-// An intermediate scanout normally stays GPU-resident until the final presentation callback.
-// A later non-direct consumer in the same submit is different: it needs authoritative CPU bytes
-// before the batch is submitted, so deferring here would make it observe the previous submit.
-constexpr bool can_defer_intermediate_scanout_readback(bool phase_allows_defer,
-                                                        bool defer_intermediate_scanout,
-                                                        bool cpu_needed_same_batch) {
-    return phase_allows_defer && defer_intermediate_scanout && !cpu_needed_same_batch;
+// Intermediate scanouts normally stay GPU-resident until the final presentation callback. The final
+// scanout can do the same when the app consumes the renderer image directly; if that handoff fails,
+// the completed persistent target is still available for the existing on-demand CPU fallback.
+// A non-direct consumer later in the same submit is different: it needs authoritative bytes before
+// the batch is submitted, so deferring there would make it observe the previous submit.
+constexpr bool can_defer_scanout_readback(bool phase_allows_defer,
+                                           bool final_gpu_present,
+                                           bool defer_scanout,
+                                           bool cpu_needed_same_batch) {
+    return (phase_allows_defer || final_gpu_present) && defer_scanout &&
+           !cpu_needed_same_batch;
 }
 
 } // namespace prosper::frontend

--- a/prosper/frontends/shared/rtt_authority.hpp
+++ b/prosper/frontends/shared/rtt_authority.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+namespace prosper::frontend {
+
+// The live RTT cache has two independently useful representations. A CPU snapshot with no valid
+// persistent image is authoritative CPU data. When the persistent image is valid, any CPU snapshot
+// is a mirror produced by an ordered readback (or the matching CPU result of the same render pass),
+// so sampling the image remains safe. Guest writes erase the cache entry and CPU-only publications
+// explicitly clear gpu_valid before an importer can observe them.
+enum class LiveRttAuthority { none, cpu, gpu, mirrored };
+
+constexpr LiveRttAuthority live_rtt_authority(bool gpu_valid, bool has_cpu_snapshot) {
+    if (gpu_valid) return has_cpu_snapshot ? LiveRttAuthority::mirrored
+                                           : LiveRttAuthority::gpu;
+    return has_cpu_snapshot ? LiveRttAuthority::cpu : LiveRttAuthority::none;
+}
+
+constexpr bool live_rtt_gpu_importable(bool gpu_valid, bool has_cpu_snapshot) {
+    const LiveRttAuthority authority = live_rtt_authority(gpu_valid, has_cpu_snapshot);
+    return authority == LiveRttAuthority::gpu || authority == LiveRttAuthority::mirrored;
+}
+
+} // namespace prosper::frontend

--- a/prosper/frontends/shared/rtt_injection.hpp
+++ b/prosper/frontends/shared/rtt_injection.hpp
@@ -8,6 +8,57 @@
 
 namespace prosper::frontend {
 
+namespace detail {
+
+template <size_t BytesPerPixel>
+inline void inject_scaled_rtt_rows(uint8_t* dst, uint32_t dst_w, uint32_t dst_h,
+                                   const uint8_t* src, uint32_t src_w, uint32_t src_h) {
+    const size_t dst_row_bytes = static_cast<size_t>(dst_w) * BytesPerPixel;
+    uint32_t previous_sy = UINT32_MAX;
+
+    // Render scaling is normally an integer factor (Astro Bot is 3840x2160 over a 1920x1080
+    // retained target). Expand one source row and bulk-copy its vertical repetitions. This avoids
+    // millions of tiny variable-sized memcpy calls and integer divisions in the old per-texel loop.
+    const uint32_t integer_x_scale = dst_w >= src_w && dst_w % src_w == 0
+        ? dst_w / src_w : 0;
+    for (uint32_t y = 0; y < dst_h; ++y) {
+        const uint32_t sy = static_cast<uint32_t>(static_cast<uint64_t>(y) * src_h / dst_h);
+        uint8_t* dst_row = dst + static_cast<size_t>(y) * dst_row_bytes;
+        if (y && sy == previous_sy) {
+            std::memcpy(dst_row, dst_row - dst_row_bytes, dst_row_bytes);
+            continue;
+        }
+
+        const uint8_t* src_row = src + static_cast<size_t>(sy) * src_w * BytesPerPixel;
+        if (src_w == dst_w) {
+            std::memcpy(dst_row, src_row, dst_row_bytes);
+        } else if (integer_x_scale) {
+            for (uint32_t sx = 0; sx < src_w; ++sx) {
+                const uint8_t* pixel = src_row + static_cast<size_t>(sx) * BytesPerPixel;
+                for (uint32_t repeat = 0; repeat < integer_x_scale; ++repeat)
+                    std::memcpy(dst_row +
+                                    (static_cast<size_t>(sx) * integer_x_scale + repeat) *
+                                        BytesPerPixel,
+                                pixel, BytesPerPixel);
+            }
+        } else {
+            // Precomputing x offsets once would require a scratch allocation. The uncommon
+            // non-integer path instead uses a division per output texel, but still specializes the
+            // copy width so the compiler emits a scalar load/store rather than a libc call.
+            for (uint32_t x = 0; x < dst_w; ++x) {
+                const uint32_t sx = static_cast<uint32_t>(
+                    static_cast<uint64_t>(x) * src_w / dst_w);
+                std::memcpy(dst_row + static_cast<size_t>(x) * BytesPerPixel,
+                            src_row + static_cast<size_t>(sx) * BytesPerPixel,
+                            BytesPerPixel);
+            }
+        }
+        previous_sy = sy;
+    }
+}
+
+} // namespace detail
+
 // Copy a renderer-owned target into a sampled-resource buffer, nearest-scaling when the view extent
 // differs. The RTT format owns the byte stride: consumers such as 1D views may have been provisionally
 // sized as RGBA8 even when the cached producer is RGBA16F, so this helper resizes before every write.
@@ -28,14 +79,30 @@ inline bool inject_rtt_pixels(std::vector<uint8_t>& dst, uint32_t dst_w, uint32_
         return true;
     }
     dst.resize(dst_bytes);
-    for (uint32_t y = 0; y < dst_h; ++y) {
-        const uint32_t sy = static_cast<uint32_t>(static_cast<uint64_t>(y) * src_h / dst_h);
-        for (uint32_t x = 0; x < dst_w; ++x) {
-            const uint32_t sx = static_cast<uint32_t>(static_cast<uint64_t>(x) * src_w / dst_w);
-            const size_t si = (static_cast<size_t>(sy) * src_w + sx) * bytes_per_pixel;
-            const size_t di = (static_cast<size_t>(y) * dst_w + x) * bytes_per_pixel;
-            std::memcpy(dst.data() + di, src.data() + si, bytes_per_pixel);
-        }
+    switch (bytes_per_pixel) {
+        case 1: detail::inject_scaled_rtt_rows<1>(dst.data(), dst_w, dst_h,
+                                                  src.data(), src_w, src_h); break;
+        case 2: detail::inject_scaled_rtt_rows<2>(dst.data(), dst_w, dst_h,
+                                                  src.data(), src_w, src_h); break;
+        case 4: detail::inject_scaled_rtt_rows<4>(dst.data(), dst_w, dst_h,
+                                                  src.data(), src_w, src_h); break;
+        case 8: detail::inject_scaled_rtt_rows<8>(dst.data(), dst_w, dst_h,
+                                                  src.data(), src_w, src_h); break;
+        case 16: detail::inject_scaled_rtt_rows<16>(dst.data(), dst_w, dst_h,
+                                                    src.data(), src_w, src_h); break;
+        default:
+            for (uint32_t y = 0; y < dst_h; ++y) {
+                const uint32_t sy = static_cast<uint32_t>(
+                    static_cast<uint64_t>(y) * src_h / dst_h);
+                for (uint32_t x = 0; x < dst_w; ++x) {
+                    const uint32_t sx = static_cast<uint32_t>(
+                        static_cast<uint64_t>(x) * src_w / dst_w);
+                    const size_t si = (static_cast<size_t>(sy) * src_w + sx) * bytes_per_pixel;
+                    const size_t di = (static_cast<size_t>(y) * dst_w + x) * bytes_per_pixel;
+                    std::memcpy(dst.data() + di, src.data() + si, bytes_per_pixel);
+                }
+            }
+            break;
     }
     return true;
 }

--- a/prosper/frontends/shared/rtt_scale.hpp
+++ b/prosper/frontends/shared/rtt_scale.hpp
@@ -51,23 +51,23 @@ constexpr bool rtt_scaled_extent_compatible(uint32_t requested_w, uint32_t reque
 // unnormalized texel-fetch contracts must keep using exact extents at their call sites.
 constexpr bool rtt_sampled_extent_compatible(uint32_t requested_w, uint32_t requested_h,
                                              uint32_t cached_w, uint32_t cached_h,
-                                             uint32_t render_scale) {
+                                             uint32_t render_scale,
+                                             bool normalized_sampling) {
     if (requested_w == cached_w && requested_h == cached_h) return true;
-    return rtt_scaled_extent_compatible(
+    return normalized_sampling && rtt_scaled_extent_compatible(
         requested_w, requested_h, cached_w, cached_h, render_scale);
 }
 
-// A native-format storage image cannot be bound at a different extent because imageLoad/imageStore
-// use integer texel coordinates. It can, however, stay entirely on the GPU through a temporary
-// native-resolution image when the renderer owns an exact render-scale version: upscale before the
-// dispatch and downscale the result afterwards. This deliberately has the same strict geometry gate
-// as scaled sampled imports so an unrelated alias at the same guest address is never bridged.
-constexpr bool rtt_storage_bridge_extent_compatible(uint32_t requested_w, uint32_t requested_h,
-                                                    uint32_t cached_w, uint32_t cached_h,
-                                                    uint32_t render_scale) {
-    return (requested_w != cached_w || requested_h != cached_h) &&
-           rtt_scaled_extent_compatible(
-               requested_w, requested_h, cached_w, cached_h, render_scale);
+// Renderer-owned persistent color images are created for attachment/sampling/transfer use, not
+// storage descriptors. Only sampled descriptors may borrow them directly; storage bindings retain
+// an owned storage-capable image and the guest writeback path even at an exact extent.
+constexpr bool rtt_direct_import_compatible(bool storage_image,
+                                            uint32_t requested_w, uint32_t requested_h,
+                                            uint32_t cached_w, uint32_t cached_h,
+                                            uint32_t render_scale,
+                                            bool normalized_sampling) {
+    return !storage_image && rtt_sampled_extent_compatible(
+        requested_w, requested_h, cached_w, cached_h, render_scale, normalized_sampling);
 }
 
 } // namespace prosper::frontend

--- a/prosper/frontends/shared/rtt_scale.hpp
+++ b/prosper/frontends/shared/rtt_scale.hpp
@@ -12,11 +12,10 @@
 //
 // The mismatch must be distinguished from a genuine VIEW ALIAS at the same base address (Astro Bot
 // renders a 960x540 target then dispatches a 1216x684 view at the same base — a stale snapshot that is
-// NOT this view and must fall back). An exact, EQUAL-on-both-axes integer multiple is a NECESSARY
-// condition for a render-scale downscale (an alias is typically a non-integer or unequal ratio), but it
-// is not by itself sufficient — a hypothetical alias could also be an exact 2x/3x view. The caller
-// therefore additionally requires k == PROSPER_RENDER_SCALE before upscaling; this helper only reports
-// the equal-axis multiple. Returns that factor k (>=2) when src*k == dst on both axes, else 0.
+// NOT this view and must fall back). The configured render scale plus the renderer's nearest-integer
+// extent rule provide that proof: the cached axes must equal round(native/scale) independently. This
+// also covers legitimate targets whose dimensions are not divisible by the scale (1216/3 -> 405),
+// which an exact integer-ratio check incorrectly sent through CPU readback.
 namespace prosper::frontend {
 
 constexpr uint32_t rtt_integer_upscale_factor(uint32_t dst_w, uint32_t dst_h,
@@ -26,6 +25,49 @@ constexpr uint32_t rtt_integer_upscale_factor(uint32_t dst_w, uint32_t dst_h,
     const uint32_t kx = dst_w / src_w, ky = dst_h / src_h;
     if (kx != ky || kx < 2) return 0;
     return kx;
+}
+
+constexpr uint32_t rtt_scaled_axis(uint32_t native, uint32_t render_scale) {
+    if (!native || render_scale <= 1) return native;
+    // Match live_renderer.cpp's (native * scaled_present + present/2) / present when the
+    // presentation extent is reduced by exactly render_scale. The 64-bit addition avoids overflow
+    // for synthetic test extents even though real image dimensions are much smaller.
+    const uint32_t scaled = static_cast<uint32_t>(
+        (static_cast<uint64_t>(native) + render_scale / 2u) / render_scale);
+    return scaled ? scaled : 1u;
+}
+
+constexpr bool rtt_scaled_extent_compatible(uint32_t requested_w, uint32_t requested_h,
+                                            uint32_t cached_w, uint32_t cached_h,
+                                            uint32_t render_scale) {
+    return requested_w && requested_h && cached_w && cached_h && render_scale > 1 &&
+           rtt_scaled_axis(requested_w, render_scale) == cached_w &&
+           rtt_scaled_axis(requested_h, render_scale) == cached_h;
+}
+
+// A sampled descriptor can bind the renderer's reduced-resolution image directly: normalized
+// sampling naturally maps the guest view onto the smaller image. Exact extents are always valid;
+// a mismatch is valid only when it was produced by the configured render scale. Storage images and
+// unnormalized texel-fetch contracts must keep using exact extents at their call sites.
+constexpr bool rtt_sampled_extent_compatible(uint32_t requested_w, uint32_t requested_h,
+                                             uint32_t cached_w, uint32_t cached_h,
+                                             uint32_t render_scale) {
+    if (requested_w == cached_w && requested_h == cached_h) return true;
+    return rtt_scaled_extent_compatible(
+        requested_w, requested_h, cached_w, cached_h, render_scale);
+}
+
+// A native-format storage image cannot be bound at a different extent because imageLoad/imageStore
+// use integer texel coordinates. It can, however, stay entirely on the GPU through a temporary
+// native-resolution image when the renderer owns an exact render-scale version: upscale before the
+// dispatch and downscale the result afterwards. This deliberately has the same strict geometry gate
+// as scaled sampled imports so an unrelated alias at the same guest address is never bridged.
+constexpr bool rtt_storage_bridge_extent_compatible(uint32_t requested_w, uint32_t requested_h,
+                                                    uint32_t cached_w, uint32_t cached_h,
+                                                    uint32_t render_scale) {
+    return (requested_w != cached_w || requested_h != cached_h) &&
+           rtt_scaled_extent_compatible(
+               requested_w, requested_h, cached_w, cached_h, render_scale);
 }
 
 } // namespace prosper::frontend

--- a/prosper/frontends/shared/seed_reprove.hpp
+++ b/prosper/frontends/shared/seed_reprove.hpp
@@ -4,6 +4,18 @@
 
 namespace prosper::frontend {
 
+// A write-only shader can map invocations to texels in swizzled or vectorized ways (Astro Bot's
+// bloom chain launches width*8 by height/8). Per-axis comparison therefore rejects valid full-image
+// fills. The only shape-independent prerequisite is enough total invocations; the poison proving
+// pass below establishes actual coverage before any seed is skipped.
+constexpr bool dispatch_has_enough_threads_for_texels(uint32_t threads_x, uint32_t threads_y,
+                                                       uint32_t threads_z, uint32_t width,
+                                                       uint32_t height, uint32_t depth) {
+    if (!threads_x || !threads_y || !threads_z || !width || !height || !depth) return false;
+    return static_cast<uint64_t>(threads_x) * threads_y * threads_z >=
+           static_cast<uint64_t>(width) * height * depth;
+}
+
 // #1127: the #1122 seed-skip caches a "this write-only shader covers every texel" verdict per
 // (shader, binding, extent) and trusts it forever. That is unsound for a DATA-DEPENDENT store (full
 // on the proving frame, partial on a later frame with different input): the untouched texels then pack

--- a/prosper/frontends/shared/test_readback_policy.cpp
+++ b/prosper/frontends/shared/test_readback_policy.cpp
@@ -2,20 +2,21 @@
 
 #include <cstdio>
 
-using prosper::frontend::can_defer_intermediate_scanout_readback;
+using prosper::frontend::can_defer_scanout_readback;
 
 static int failures = 0;
 #define CHECK(cond) do { if (!(cond)) { \
     std::fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond); ++failures; } } while (0)
 
 int main() {
-    CHECK(can_defer_intermediate_scanout_readback(true, true, false));
+    CHECK(can_defer_scanout_readback(true, false, true, false));
+    CHECK(can_defer_scanout_readback(false, true, true, false));
 
     // #1295: a same-submit 1D/cube/storage consumer cannot use the direct GPU target binding.
     // Deferring its producer's readback makes that consumer decode stale guest bytes.
-    CHECK(!can_defer_intermediate_scanout_readback(true, true, true));
-    CHECK(!can_defer_intermediate_scanout_readback(false, true, false));
-    CHECK(!can_defer_intermediate_scanout_readback(true, false, false));
+    CHECK(!can_defer_scanout_readback(true, false, true, true));
+    CHECK(!can_defer_scanout_readback(false, false, true, false));
+    CHECK(!can_defer_scanout_readback(true, false, false, false));
 
     if (!failures) std::printf("readback_policy: OK\n");
     return failures ? 1 : 0;

--- a/prosper/frontends/shared/test_rtt_injection.cpp
+++ b/prosper/frontends/shared/test_rtt_injection.cpp
@@ -27,6 +27,32 @@ int main() {
     CHECK(std::equal(scaled.begin(), scaled.begin() + 8, fp16_source.begin()));
     CHECK(std::equal(scaled.begin() + 8, scaled.end(), fp16_source.begin() + 16));
 
+    // The integer render-scale fast path expands pixels and rows without changing nearest-neighbor
+    // selection. Distinct values in both axes catch accidental row/pixel replication mixups.
+    const std::vector<uint8_t> rgba_source = {
+        1, 2, 3, 4,  5, 6, 7, 8,
+        9,10,11,12, 13,14,15,16,
+    };
+    std::vector<uint8_t> rgba_scaled;
+    CHECK(inject_rtt_pixels(rgba_scaled, 4, 4, rgba_source, 2, 2, 4));
+    const std::vector<uint8_t> rgba_expected = {
+        1,2,3,4, 1,2,3,4, 5,6,7,8, 5,6,7,8,
+        1,2,3,4, 1,2,3,4, 5,6,7,8, 5,6,7,8,
+        9,10,11,12, 9,10,11,12, 13,14,15,16, 13,14,15,16,
+        9,10,11,12, 9,10,11,12, 13,14,15,16, 13,14,15,16,
+    };
+    CHECK(rgba_scaled == rgba_expected);
+
+    // Keep a non-integer scale covered as well; this takes the generic specialized-width loop.
+    std::vector<uint8_t> odd_scaled;
+    CHECK(inject_rtt_pixels(odd_scaled, 3, 3, rgba_source, 2, 2, 4));
+    const std::vector<uint8_t> odd_expected = {
+        1,2,3,4, 1,2,3,4, 5,6,7,8,
+        1,2,3,4, 1,2,3,4, 5,6,7,8,
+        9,10,11,12, 9,10,11,12, 13,14,15,16,
+    };
+    CHECK(odd_scaled == odd_expected);
+
     std::vector<uint8_t> malformed(7), fallback_bytes = {0xaa, 0xbb, 0xcc, 0xdd};
     consumer = fallback_bytes;
     CHECK(!inject_rtt_pixels(consumer, 1, 1, malformed, 1, 1, 8));

--- a/prosper/frontends/shared/test_rtt_scale.cpp
+++ b/prosper/frontends/shared/test_rtt_scale.cpp
@@ -5,10 +5,18 @@
 // scales a stale, wrong-view snapshot, so the boundary is pinned here.
 
 #include "rtt_scale.hpp"
+#include "rtt_authority.hpp"
 
 #include <cstdio>
 
 using prosper::frontend::rtt_integer_upscale_factor;
+using prosper::frontend::rtt_sampled_extent_compatible;
+using prosper::frontend::rtt_scaled_axis;
+using prosper::frontend::rtt_scaled_extent_compatible;
+using prosper::frontend::rtt_storage_bridge_extent_compatible;
+using prosper::frontend::LiveRttAuthority;
+using prosper::frontend::live_rtt_authority;
+using prosper::frontend::live_rtt_gpu_importable;
 
 static int failures = 0;
 #define CHECK(cond) do { if (!(cond)) { \
@@ -36,6 +44,40 @@ int main() {
     CHECK(rtt_integer_upscale_factor(480, 270, 1920, 1080) == 0);
     CHECK(rtt_integer_upscale_factor(1920, 1080, 0, 270) == 0);
     CHECK(rtt_integer_upscale_factor(0, 0, 0, 0) == 0);
+
+    CHECK(rtt_sampled_extent_compatible(1920, 1080, 1920, 1080, 1));
+    CHECK(rtt_sampled_extent_compatible(1920, 1080, 960, 540, 2));
+    CHECK(!rtt_sampled_extent_compatible(1920, 1080, 960, 540, 1));
+    CHECK(!rtt_sampled_extent_compatible(1216, 684, 960, 540, 2));
+    CHECK(!rtt_sampled_extent_compatible(1920, 1620, 960, 540, 2));
+
+    // Pass-local targets use nearest-integer division, so non-divisible native dimensions are still
+    // valid renderer-owned images. This is common in Astro Bot's dynamic-resolution post chain.
+    CHECK(rtt_scaled_axis(1216, 3) == 405);
+    CHECK(rtt_scaled_axis(684, 3) == 228);
+    CHECK(rtt_scaled_axis(1, 3) == 1);
+    CHECK(rtt_scaled_extent_compatible(1216, 684, 405, 228, 3));
+    CHECK(rtt_sampled_extent_compatible(1216, 684, 405, 228, 3));
+    CHECK(!rtt_sampled_extent_compatible(1216, 684, 406, 228, 3));
+    CHECK(!rtt_sampled_extent_compatible(1216, 684, 960, 540, 3));
+
+    CHECK(rtt_storage_bridge_extent_compatible(3840, 2160, 1920, 1080, 2));
+    CHECK(!rtt_storage_bridge_extent_compatible(1920, 1080, 1920, 1080, 2));
+    CHECK(!rtt_storage_bridge_extent_compatible(3840, 2160, 1920, 1080, 1));
+    CHECK(!rtt_storage_bridge_extent_compatible(1216, 684, 960, 540, 2));
+    CHECK(rtt_storage_bridge_extent_compatible(1216, 684, 405, 228, 3));
+
+    // A snapshot produced by an ordered readback mirrors a still-valid persistent GPU image; it
+    // must not force a full GPU->CPU->GPU round trip on the next compute consumer. Conversely, a
+    // CPU-only publication has gpu_valid=false and must never expose the stale image.
+    CHECK(live_rtt_authority(true, false) == LiveRttAuthority::gpu);
+    CHECK(live_rtt_authority(true, true) == LiveRttAuthority::mirrored);
+    CHECK(live_rtt_authority(false, true) == LiveRttAuthority::cpu);
+    CHECK(live_rtt_authority(false, false) == LiveRttAuthority::none);
+    CHECK(live_rtt_gpu_importable(true, false));
+    CHECK(live_rtt_gpu_importable(true, true));
+    CHECK(!live_rtt_gpu_importable(false, true));
+    CHECK(!live_rtt_gpu_importable(false, false));
 
     if (failures == 0) std::printf("rtt_scale: OK\n");
     return failures == 0 ? 0 : 1;

--- a/prosper/frontends/shared/test_rtt_scale.cpp
+++ b/prosper/frontends/shared/test_rtt_scale.cpp
@@ -10,10 +10,10 @@
 #include <cstdio>
 
 using prosper::frontend::rtt_integer_upscale_factor;
+using prosper::frontend::rtt_direct_import_compatible;
 using prosper::frontend::rtt_sampled_extent_compatible;
 using prosper::frontend::rtt_scaled_axis;
 using prosper::frontend::rtt_scaled_extent_compatible;
-using prosper::frontend::rtt_storage_bridge_extent_compatible;
 using prosper::frontend::LiveRttAuthority;
 using prosper::frontend::live_rtt_authority;
 using prosper::frontend::live_rtt_gpu_importable;
@@ -45,11 +45,16 @@ int main() {
     CHECK(rtt_integer_upscale_factor(1920, 1080, 0, 270) == 0);
     CHECK(rtt_integer_upscale_factor(0, 0, 0, 0) == 0);
 
-    CHECK(rtt_sampled_extent_compatible(1920, 1080, 1920, 1080, 1));
-    CHECK(rtt_sampled_extent_compatible(1920, 1080, 960, 540, 2));
-    CHECK(!rtt_sampled_extent_compatible(1920, 1080, 960, 540, 1));
-    CHECK(!rtt_sampled_extent_compatible(1216, 684, 960, 540, 2));
-    CHECK(!rtt_sampled_extent_compatible(1920, 1620, 960, 540, 2));
+    CHECK(rtt_sampled_extent_compatible(1920, 1080, 1920, 1080, 1, false));
+    CHECK(rtt_sampled_extent_compatible(1920, 1080, 960, 540, 2, true));
+    CHECK(!rtt_sampled_extent_compatible(1920, 1080, 960, 540, 2, false));
+    CHECK(!rtt_sampled_extent_compatible(1920, 1080, 960, 540, 1, true));
+    CHECK(!rtt_sampled_extent_compatible(1216, 684, 960, 540, 2, true));
+    CHECK(!rtt_sampled_extent_compatible(1920, 1620, 960, 540, 2, true));
+    CHECK(rtt_direct_import_compatible(false, 1920, 1080, 1920, 1080, 1, false));
+    CHECK(rtt_direct_import_compatible(false, 1920, 1080, 960, 540, 2, true));
+    CHECK(!rtt_direct_import_compatible(false, 1920, 1080, 960, 540, 2, false));
+    CHECK(!rtt_direct_import_compatible(true, 1920, 1080, 1920, 1080, 1, true));
 
     // Pass-local targets use nearest-integer division, so non-divisible native dimensions are still
     // valid renderer-owned images. This is common in Astro Bot's dynamic-resolution post chain.
@@ -57,15 +62,10 @@ int main() {
     CHECK(rtt_scaled_axis(684, 3) == 228);
     CHECK(rtt_scaled_axis(1, 3) == 1);
     CHECK(rtt_scaled_extent_compatible(1216, 684, 405, 228, 3));
-    CHECK(rtt_sampled_extent_compatible(1216, 684, 405, 228, 3));
-    CHECK(!rtt_sampled_extent_compatible(1216, 684, 406, 228, 3));
-    CHECK(!rtt_sampled_extent_compatible(1216, 684, 960, 540, 3));
-
-    CHECK(rtt_storage_bridge_extent_compatible(3840, 2160, 1920, 1080, 2));
-    CHECK(!rtt_storage_bridge_extent_compatible(1920, 1080, 1920, 1080, 2));
-    CHECK(!rtt_storage_bridge_extent_compatible(3840, 2160, 1920, 1080, 1));
-    CHECK(!rtt_storage_bridge_extent_compatible(1216, 684, 960, 540, 2));
-    CHECK(rtt_storage_bridge_extent_compatible(1216, 684, 405, 228, 3));
+    CHECK(rtt_sampled_extent_compatible(1216, 684, 405, 228, 3, true));
+    CHECK(!rtt_sampled_extent_compatible(1216, 684, 405, 228, 3, false));
+    CHECK(!rtt_sampled_extent_compatible(1216, 684, 406, 228, 3, true));
+    CHECK(!rtt_sampled_extent_compatible(1216, 684, 960, 540, 3, true));
 
     // A snapshot produced by an ordered readback mirrors a still-valid persistent GPU image; it
     // must not force a full GPU->CPU->GPU round trip on the next compute consumer. Conversely, a

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -505,6 +505,9 @@ struct LiveTargetImageRequest {
     uint32_t width = 0, height = 0;
     uint32_t render_scale = 1;
     bool allow_depth = false;
+    // True only when reflection proves this descriptor is read exclusively through normalized
+    // sample/gather operations. Integer image fetch/read must retain the exact declared extent.
+    bool normalized_sampling = false;
 };
 using LiveTargetImageImportFn = std::function<bool(
     uint64_t gpu_addr, const LiveTargetImageRequest& request, LiveTargetImageImport& import)>;
@@ -546,6 +549,10 @@ struct SharedVulkanContext {
     bool compute_subgroup_arithmetic = false;
     uint32_t min_compute_subgroup_size = 0;
     uint32_t max_compute_subgroup_size = 0;
+    // Vulkan-independent mask from native_storage_format_support_bit(). The renderer queries
+    // optimal-tiling STORAGE_IMAGE support before publishing its physical device.
+    uint32_t native_storage_format_support = 0;
+    bool compute_queue_supported = false;
     // Present unification (#1270): when present_capable, prosper-app may create its window surface on
     // `instance`, its swapchain on `device`, and present on `present_queue` -- then blit the renderer's
     // front-buffer image straight to the swapchain with no CPU round-trip. present_queue_shared means the

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -296,6 +296,7 @@ struct ComputeItem {
     uint64_t dispatch_index = 0;
     uint64_t submit_no = 0;
     uint64_t command_order = 0;
+    uint32_t required_subgroup_size = 0;
 };
 
 enum class SubmitOperationKind : uint8_t { Draw, Dispatch, DmaCopy };
@@ -347,6 +348,11 @@ SharedShaderWords recompile_graphics_shader_cached_shared(
     const PixelInputMapping* pixel_inputs = nullptr,
     const PixelSystemInputMapping* system_inputs = nullptr,
     uint64_t* cache_identity = nullptr);
+// Compute uses the same bounded content-addressed cache as graphics. Launch geometry that changes
+// generated SPIR-V participates in the key; per-dispatch push-constant values deliberately do not.
+std::vector<uint32_t> recompile_compute_shader_cached(
+    const uint32_t* code, size_t dwords, const ShaderResourceTable* resources,
+    const ComputeShaderConfig& config, uint64_t* cache_identity = nullptr);
 ShaderRecompileCacheStats shader_recompile_cache_stats();
 void clear_shader_recompile_cache();
 
@@ -474,29 +480,45 @@ bool read_live_render_target(uint64_t gpu_addr, LiveTargetSnapshot& snapshot);
 // renderer's persistent image in place instead of forcing a GPU->CPU readback and an immediate
 // re-upload of the very same pixels to the very same device.
 //
-// AUTHORITY RULE: the import is offered only while the persistent Vulkan image is the authoritative
-// copy of the surface -- exactly the case where read_live_render_target() would have had to
-// materialize it. Whenever a CPU RTT snapshot already exists it may be the NEWER truth (a guest GPU
-// write discards the CPU copy and invalidates the GPU target independently, #780), so the caller
-// must fall back to the snapshot path rather than assume the two agree.
+// AUTHORITY RULE: the import is offered only while the persistent Vulkan image is current. An
+// ordered GPU readback may leave an equivalent CPU snapshot beside it; that mirror does not make the
+// image stale. CPU-newer publications clear gpu_valid, and guest GPU writes invalidate the cache
+// entry before import (#780), so neither can expose an obsolete image through this contract.
 //
 // The image is BORROWED: the caller must not destroy it, must restore `layout` before returning, and
 // must call release_live_render_target_image() to drop the pin that keeps the renderer's cache from
 // evicting the entry mid-dispatch. Handles stay opaque so this layer keeps no Vulkan dependency.
 struct LiveTargetImageImport {
+    enum class Kind : uint8_t { Color, Depth };
     uint32_t width = 0, height = 0;
     LiveTargetPixelFormat format = LiveTargetPixelFormat::Rgba8Unorm;
+    Kind kind = Kind::Color;
+    // Opaque VkFormat for depth imports. Color imports keep using `format`, whose deliberately
+    // small enum is part of the renderer/compute numeric-compatibility contract.
+    uint32_t native_format = 0;
     void* image = nullptr;    // VkImage owned by the live renderer
     void* device = nullptr;   // VkDevice it belongs to; the caller must be running on that device
     uint32_t layout = 0;      // VkImageLayout the renderer left it in -- restore it after the dispatch
     bool valid() const { return image && device && width && height; }
 };
-using LiveTargetImageImportFn = std::function<bool(uint64_t gpu_addr, LiveTargetImageImport& import)>;
+struct LiveTargetImageRequest {
+    uint32_t width = 0, height = 0;
+    uint32_t render_scale = 1;
+    bool allow_depth = false;
+};
+using LiveTargetImageImportFn = std::function<bool(
+    uint64_t gpu_addr, const LiveTargetImageRequest& request, LiveTargetImageImport& import)>;
 using LiveTargetImageReleaseFn = std::function<void(uint64_t gpu_addr)>;
+using LiveTargetImageWrittenFn = std::function<void(uint64_t gpu_addr)>;
 void set_live_target_image_importer(LiveTargetImageImportFn import_fn,
                                     LiveTargetImageReleaseFn release_fn);
-bool import_live_render_target_image(uint64_t gpu_addr, LiveTargetImageImport& import);
+void set_live_target_image_written_notifier(LiveTargetImageWrittenFn written_fn);
+bool import_live_render_target_image(uint64_t gpu_addr, const LiveTargetImageRequest& request,
+                                     LiveTargetImageImport& import);
 void release_live_render_target_image(uint64_t gpu_addr);
+// Publish that a borrowed renderer image was modified in place. The renderer keeps the Vulkan image
+// authoritative and discards any older CPU readback mirror; guest bytes intentionally stay deferred.
+void notify_live_render_target_image_written(uint64_t gpu_addr);
 // Shared Vulkan device (#1091 phase 1). live_compute historically created its own VkInstance/VkDevice,
 // so a renderer-owned image could never be bound to a dispatch and had to round-trip through host
 // memory. The live renderer publishes its already-created device here; the compute backend ADOPTS it
@@ -516,6 +538,14 @@ struct SharedVulkanContext {
     // Features the compute backend requires; when false it must decline the shared device.
     bool storage_image_read_without_format = false;
     bool storage_image_write_without_format = false;
+    // Exact compute-wave acceleration. These describe features ENABLED on the borrowed device, not
+    // merely physical support. The recompiler opts in only when the requested guest wave is inside
+    // this range and both vote and arithmetic subgroup operations are available.
+    bool compute_subgroup_size_control = false;
+    bool compute_subgroup_vote = false;
+    bool compute_subgroup_arithmetic = false;
+    uint32_t min_compute_subgroup_size = 0;
+    uint32_t max_compute_subgroup_size = 0;
     // Present unification (#1270): when present_capable, prosper-app may create its window surface on
     // `instance`, its swapchain on `device`, and present on `present_queue` -- then blit the renderer's
     // front-buffer image straight to the swapchain with no CPU round-trip. present_queue_shared means the

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -6,6 +6,7 @@
 // binary at startup, or a test via render_runner.h), so prosper_core links this without Vulkan.
 #include "gpu_execute.hpp"
 #include "gpu_capture.hpp"
+#include "gpu_timeline.hpp"
 #include "videoout_present.hpp"   // present_write_frame
 #include "agc_shader_layout.hpp"  // AgcShaderHeader + build_shader_resources
 #include "pm4_registers.hpp"      // SPI_SHADER_USER_DATA_* offsets
@@ -139,6 +140,14 @@ struct ShaderResourceCompileKey {
     uint32_t sgpr_base = 0;
     uint32_t fetch_pc = 0;
     uint32_t fetch_index_mode = 0;
+    uint32_t flat_base_sgpr = 0;
+    bool srgb = false;
+    bool depth_compare = false;
+    uint32_t depth_compare_func = 0;
+    uint32_t mag_filter = 0;
+    uint32_t addr_u = 0;
+    uint32_t addr_v = 0;
+    uint32_t border_color_type = 0;
 
     bool operator==(const ShaderResourceCompileKey&) const = default;
 };
@@ -167,6 +176,7 @@ struct ShaderCompileKey {
     bool compute_tg_size_en = false;
     uint32_t compute_lds_bytes = 0;
     uint32_t compute_native_subgroup_size = 0;
+    uint32_t compute_native_storage_format_support = 0;
     // Aliases ShaderCodeAnalysis::code and keeps that immutable analysis alive. Warm lookups used to
     // copy and re-hash the complete raw program for every draw before reaching the shader cache.
     std::shared_ptr<const std::vector<uint32_t>> code;
@@ -203,6 +213,8 @@ struct ShaderCompileKey {
                compute_tg_size_en == other.compute_tg_size_en &&
                compute_lds_bytes == other.compute_lds_bytes &&
                compute_native_subgroup_size == other.compute_native_subgroup_size &&
+               compute_native_storage_format_support ==
+                   other.compute_native_storage_format_support &&
                resources == other.resources && same_code;
     }
 };
@@ -259,6 +271,7 @@ struct ShaderCompileKeyHash {
             hash = hash_mix(hash, key.compute_tg_size_en);
             hash = hash_mix(hash, key.compute_lds_bytes);
             hash = hash_mix(hash, key.compute_native_subgroup_size);
+            hash = hash_mix(hash, key.compute_native_storage_format_support);
         }
         hash = hash_mix(hash, key.code ? key.code->size() : 0u);
         hash = hash_mix(hash, key.code_hash);
@@ -272,6 +285,15 @@ struct ShaderCompileKeyHash {
             hash = hash_mix(hash, resource.srt_offset);
             hash = hash_mix(hash, resource.sgpr_base);
             hash = hash_mix(hash, resource.fetch_pc);
+            hash = hash_mix(hash, resource.fetch_index_mode);
+            hash = hash_mix(hash, resource.flat_base_sgpr);
+            hash = hash_mix(hash, resource.srgb);
+            hash = hash_mix(hash, resource.depth_compare);
+            hash = hash_mix(hash, resource.depth_compare_func);
+            hash = hash_mix(hash, resource.mag_filter);
+            hash = hash_mix(hash, resource.addr_u);
+            hash = hash_mix(hash, resource.addr_v);
+            hash = hash_mix(hash, resource.border_color_type);
         }
         return static_cast<size_t>(hash);
     }
@@ -829,6 +851,8 @@ ShaderCompileKey make_shader_compile_key(ShaderProgramStage stage, const uint32_
         key.compute_tg_size_en = compute_config->tg_size_en;
         key.compute_lds_bytes = compute_config->lds_bytes;
         key.compute_native_subgroup_size = compute_config->native_subgroup_size;
+        key.compute_native_storage_format_support =
+            compute_config->native_storage_format_support;
     }
     const std::shared_ptr<const ShaderCodeAnalysis> analysis =
         code && dwords ? analyze_shader_code_cached(code, dwords) : nullptr;
@@ -876,11 +900,21 @@ ShaderCompileKey make_shader_compile_key(ShaderProgramStage stage, const uint32_
     if (resources) {
         key.resources.reserve(resources->resources.size());
         for (const auto& resource : resources->resources) {
+            const bool texture = resource.cls == ResourceClass::Texture;
+            const bool storage_image = resource.cls == ResourceClass::StorageImage;
+            const bool manual_compare = texture && resource.depth_compare;
             key.resources.push_back({
                 static_cast<uint32_t>(resource.cls), static_cast<uint32_t>(resource.format),
                 resource.num_components, resource.binding, resource.stride,
                 resource.srt_offset, resource.sgpr_base, resource.fetch_pc,
                 static_cast<uint32_t>(resource.fetch_index_mode),
+                resource.flat_base_sgpr, storage_image && resource.srgb,
+                manual_compare,
+                manual_compare ? resource.depth_compare_func : 0u,
+                manual_compare ? resource.mag_filter : 0u,
+                manual_compare ? resource.addr_uvw[0] : 0u,
+                manual_compare ? resource.addr_uvw[1] : 0u,
+                manual_compare ? resource.border_color_type : 0u,
             });
         }
     }
@@ -3409,7 +3443,27 @@ std::vector<ComputeItem> realize_compute_dispatches(
             P::COMPUTE_DISPATCH_INITIATOR_CS_W32_EN_SHIFT) &
             P::COMPUTE_DISPATCH_INITIATOR_CS_W32_EN_MASK) ? 32u : 64u;
         const SharedVulkanContext shared_vulkan = shared_vulkan_context();
-        if (!getenv("PROSPER_NO_NATIVE_COMPUTE_SUBGROUP") &&
+        const bool shared_compute_adoptable = shared_vulkan.valid() &&
+            shared_vulkan.compute_queue_supported &&
+            shared_vulkan.storage_image_read_without_format &&
+            shared_vulkan.storage_image_write_without_format;
+        config.native_storage_format_support = shared_compute_adoptable
+            ? shared_vulkan.native_storage_format_support : 0;
+        // Realized captures store SPIR-V but not enough raw compute launch state to recompile a
+        // device-specific typed-storage module on replay. Compile capture-bound dispatches through
+        // the portable raw-uvec4 path so optional format support never becomes an artifact ABI.
+        if (std::getenv("PROSPER_GPU_CAPTURE") ||
+            std::getenv("PROSPER_GPU_TIMELINE_CAPTURE") ||
+            interactive_gpu_capture_armed() || interactive_capture_bundle_active())
+            config.native_storage_format_support = 0;
+        // RequiredSubgroupSize fixes only the subgroup WIDTH. Vulkan deliberately does not promise
+        // that SubgroupLocalInvocationId is LocalInvocationIndex modulo that width, so using native
+        // lane IDs for RDNA MBCNT/EXEC/VCC would silently change guest wave membership on a
+        // conforming implementation. Keep the portable emulation by default. This opt-in exists for
+        // driver experiments whose contiguous mapping has been validated externally; it is not a
+        // portable correctness contract.
+        if (getenv("PROSPER_ASSUME_CONTIGUOUS_COMPUTE_SUBGROUPS") &&
+            !getenv("PROSPER_NO_NATIVE_COMPUTE_SUBGROUP") &&
             shared_vulkan.compute_subgroup_size_control &&
             shared_vulkan.compute_subgroup_vote && shared_vulkan.compute_subgroup_arithmetic &&
             config.wave_size >= shared_vulkan.min_compute_subgroup_size &&

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -153,6 +153,20 @@ struct ShaderCompileKey {
     PixelSystemInputMapping system_inputs{};
     bool has_pcrel_dispatch = false;
     uint32_t pcrel_dispatch_target = UINT32_MAX;
+    // Compute modules also depend on launch ABI shape. User SGPR VALUES are push constants and stay
+    // runtime data; only their count changes declarations. Exact thread extents matter because a
+    // partial final workgroup emits a literal invocation guard into SPIR-V.
+    bool has_compute_config = false;
+    uint32_t compute_user_sgpr_count = 0;
+    uint32_t compute_local_x = 1, compute_local_y = 1, compute_local_z = 1;
+    bool compute_exact_thread_extent = false;
+    uint32_t compute_threads_x = 0, compute_threads_y = 0, compute_threads_z = 0;
+    uint32_t compute_wave_size = 64;
+    uint32_t compute_tidig_comp_cnt = 0;
+    bool compute_tgid_x_en = false, compute_tgid_y_en = false, compute_tgid_z_en = false;
+    bool compute_tg_size_en = false;
+    uint32_t compute_lds_bytes = 0;
+    uint32_t compute_native_subgroup_size = 0;
     // Aliases ShaderCodeAnalysis::code and keeps that immutable analysis alive. Warm lookups used to
     // copy and re-hash the complete raw program for every draw before reaching the shader cache.
     std::shared_ptr<const std::vector<uint32_t>> code;
@@ -172,6 +186,23 @@ struct ShaderCompileKey {
                system_inputs == other.system_inputs &&
                has_pcrel_dispatch == other.has_pcrel_dispatch &&
                pcrel_dispatch_target == other.pcrel_dispatch_target &&
+               has_compute_config == other.has_compute_config &&
+               compute_user_sgpr_count == other.compute_user_sgpr_count &&
+               compute_local_x == other.compute_local_x &&
+               compute_local_y == other.compute_local_y &&
+               compute_local_z == other.compute_local_z &&
+               compute_exact_thread_extent == other.compute_exact_thread_extent &&
+               compute_threads_x == other.compute_threads_x &&
+               compute_threads_y == other.compute_threads_y &&
+               compute_threads_z == other.compute_threads_z &&
+               compute_wave_size == other.compute_wave_size &&
+               compute_tidig_comp_cnt == other.compute_tidig_comp_cnt &&
+               compute_tgid_x_en == other.compute_tgid_x_en &&
+               compute_tgid_y_en == other.compute_tgid_y_en &&
+               compute_tgid_z_en == other.compute_tgid_z_en &&
+               compute_tg_size_en == other.compute_tg_size_en &&
+               compute_lds_bytes == other.compute_lds_bytes &&
+               compute_native_subgroup_size == other.compute_native_subgroup_size &&
                resources == other.resources && same_code;
     }
 };
@@ -210,6 +241,25 @@ struct ShaderCompileKeyHash {
         }
         hash = hash_mix(hash, key.has_pcrel_dispatch);
         if (key.has_pcrel_dispatch) hash = hash_mix(hash, key.pcrel_dispatch_target);
+        hash = hash_mix(hash, key.has_compute_config);
+        if (key.has_compute_config) {
+            hash = hash_mix(hash, key.compute_user_sgpr_count);
+            hash = hash_mix(hash, key.compute_local_x);
+            hash = hash_mix(hash, key.compute_local_y);
+            hash = hash_mix(hash, key.compute_local_z);
+            hash = hash_mix(hash, key.compute_exact_thread_extent);
+            hash = hash_mix(hash, key.compute_threads_x);
+            hash = hash_mix(hash, key.compute_threads_y);
+            hash = hash_mix(hash, key.compute_threads_z);
+            hash = hash_mix(hash, key.compute_wave_size);
+            hash = hash_mix(hash, key.compute_tidig_comp_cnt);
+            hash = hash_mix(hash, key.compute_tgid_x_en);
+            hash = hash_mix(hash, key.compute_tgid_y_en);
+            hash = hash_mix(hash, key.compute_tgid_z_en);
+            hash = hash_mix(hash, key.compute_tg_size_en);
+            hash = hash_mix(hash, key.compute_lds_bytes);
+            hash = hash_mix(hash, key.compute_native_subgroup_size);
+        }
         hash = hash_mix(hash, key.code ? key.code->size() : 0u);
         hash = hash_mix(hash, key.code_hash);
         hash = hash_mix(hash, key.resources.size());
@@ -751,7 +801,8 @@ PcrelDispatchSelection select_pcrel_dispatch(const uint32_t* code, size_t dwords
 ShaderCompileKey make_shader_compile_key(ShaderProgramStage stage, const uint32_t* code, size_t dwords,
                                          const ShaderResourceTable* resources,
                                          const PixelInputMapping* pixel_inputs,
-                                         const PixelSystemInputMapping* system_inputs) {
+                                         const PixelSystemInputMapping* system_inputs,
+                                         const ComputeShaderConfig* compute_config = nullptr) {
     ShaderCompileKey key;
     key.stage = stage;
     key.has_resource_table = resources != nullptr;
@@ -760,6 +811,25 @@ ShaderCompileKey make_shader_compile_key(ShaderProgramStage stage, const uint32_
     if (key.has_pixel_inputs) key.pixel_inputs = *pixel_inputs;
     key.has_system_inputs = stage == ShaderProgramStage::Fragment && system_inputs != nullptr;
     if (key.has_system_inputs) key.system_inputs = *system_inputs;
+    key.has_compute_config = stage == ShaderProgramStage::Compute && compute_config;
+    if (key.has_compute_config) {
+        key.compute_user_sgpr_count = static_cast<uint32_t>(compute_config->user_sgprs.size());
+        key.compute_local_x = compute_config->local_x;
+        key.compute_local_y = compute_config->local_y;
+        key.compute_local_z = compute_config->local_z;
+        key.compute_exact_thread_extent = compute_config->exact_thread_extent;
+        key.compute_threads_x = compute_config->threads_x;
+        key.compute_threads_y = compute_config->threads_y;
+        key.compute_threads_z = compute_config->threads_z;
+        key.compute_wave_size = compute_config->wave_size;
+        key.compute_tidig_comp_cnt = compute_config->tidig_comp_cnt;
+        key.compute_tgid_x_en = compute_config->tgid_x_en;
+        key.compute_tgid_y_en = compute_config->tgid_y_en;
+        key.compute_tgid_z_en = compute_config->tgid_z_en;
+        key.compute_tg_size_en = compute_config->tg_size_en;
+        key.compute_lds_bytes = compute_config->lds_bytes;
+        key.compute_native_subgroup_size = compute_config->native_subgroup_size;
+    }
     const std::shared_ptr<const ShaderCodeAnalysis> analysis =
         code && dwords ? analyze_shader_code_cached(code, dwords) : nullptr;
     if (stage == ShaderProgramStage::Fragment && code && dwords && resources) {
@@ -1026,6 +1096,72 @@ std::vector<uint32_t> recompile_graphics_shader_cached(
     SharedShaderWords words = recompile_graphics_shader_cached_shared(
         stage, code, dwords, resources, pixel_inputs, system_inputs, cache_identity);
     return words ? *words : std::vector<uint32_t>{};
+}
+
+std::vector<uint32_t> recompile_compute_shader_cached(
+        const uint32_t* code, size_t dwords, const ShaderResourceTable* resources,
+        const ComputeShaderConfig& config, uint64_t* cache_identity) {
+    if (cache_identity) *cache_identity = 0;
+    ShaderCompileKey key = make_shader_compile_key(
+        ShaderProgramStage::Compute, code, dwords, resources, nullptr, nullptr, &config);
+    auto compile = [&] {
+        const uint32_t* owned_code = !key.code || key.code->empty() ? nullptr : key.code->data();
+        const size_t owned_dwords = key.code ? key.code->size() : 0u;
+        return recompile_compute(owned_code, owned_dwords, resources, config);
+    };
+    if (getenv("PROSPER_NO_SHADER_CACHE")) {
+        auto& cache = shader_cache();
+        {
+            std::lock_guard lock(cache.mutex);
+            ++cache.stats.bypasses;
+        }
+        std::vector<uint32_t> spirv = compile();
+        maybe_dump_successful_shader(ShaderProgramStage::Compute, key, spirv);
+        return spirv;
+    }
+
+    auto& cache = shader_cache();
+    std::lock_guard lock(cache.mutex);
+    auto found = cache.entries.find(key);
+    if (found != cache.entries.end()) {
+        ++cache.stats.hits;
+        found->second.last_use = ++cache.use_counter;
+        if (cache_identity) *cache_identity = found->second.identity;
+        maybe_dump_successful_shader(ShaderProgramStage::Compute, key, *found->second.spirv);
+        return *found->second.spirv;
+    }
+
+    const auto start = std::chrono::steady_clock::now();
+    auto spirv = std::make_shared<const std::vector<uint32_t>>(compile());
+    maybe_dump_successful_shader(ShaderProgramStage::Compute, key, *spirv);
+    const auto end = std::chrono::steady_clock::now();
+    ++cache.stats.misses;
+    cache.stats.compile_ms += std::chrono::duration<double, std::milli>(end - start).count();
+
+    constexpr size_t max_entries = 4096;
+    const uint64_t bytes = shader_cache_entry_bytes(key, *spirv);
+    const uint64_t limit = shader_cache_limit_bytes();
+    while (!cache.entries.empty() &&
+           (cache.entries.size() >= max_entries || cache.stats.bytes + bytes > limit)) {
+        auto oldest = cache.entries.begin();
+        for (auto it = std::next(cache.entries.begin()); it != cache.entries.end(); ++it)
+            if (it->second.last_use < oldest->second.last_use) oldest = it;
+        cache.stats.bytes -= oldest->second.bytes;
+        cache.entries.erase(oldest);
+        ++cache.stats.evictions;
+    }
+    if (bytes <= limit && max_entries != 0) {
+        CachedShader value;
+        value.spirv = spirv;
+        value.identity = cache.next_identity++;
+        value.last_use = ++cache.use_counter;
+        value.bytes = bytes;
+        if (cache_identity) *cache_identity = value.identity;
+        cache.stats.bytes += bytes;
+        cache.entries.emplace(std::move(key), std::move(value));
+    }
+    cache.stats.entries = cache.entries.size();
+    return *spirv;
 }
 
 ShaderRecompileCacheStats shader_recompile_cache_stats() {
@@ -3272,6 +3408,13 @@ std::vector<ComputeItem> realize_compute_dispatches(
         config.wave_size = ((dispatch.modifier >>
             P::COMPUTE_DISPATCH_INITIATOR_CS_W32_EN_SHIFT) &
             P::COMPUTE_DISPATCH_INITIATOR_CS_W32_EN_MASK) ? 32u : 64u;
+        const SharedVulkanContext shared_vulkan = shared_vulkan_context();
+        if (!getenv("PROSPER_NO_NATIVE_COMPUTE_SUBGROUP") &&
+            shared_vulkan.compute_subgroup_size_control &&
+            shared_vulkan.compute_subgroup_vote && shared_vulkan.compute_subgroup_arithmetic &&
+            config.wave_size >= shared_vulkan.min_compute_subgroup_size &&
+            config.wave_size <= shared_vulkan.max_compute_subgroup_size)
+            config.native_subgroup_size = config.wave_size;
         config.tgid_x_en = tgid_x_en;
         config.tgid_y_en = tgid_y_en;
         config.tgid_z_en = tgid_z_en;
@@ -3283,16 +3426,10 @@ std::vector<ComputeItem> realize_compute_dispatches(
                                  P::COMPUTE_PGM_RSRC2_LDS_SIZE_MASK) * 512u;
 
         ComputeItem item;
-        item.spirv = recompile_compute((const uint32_t*)(uintptr_t)code_addr, 0x10000,
-                                       table.get(), config);
+        item.spirv = recompile_compute_shader_cached(
+            (const uint32_t*)(uintptr_t)code_addr, 0x10000, table.get(), config);
         item.user_sgprs = config.user_sgprs;
-        if (!item.spirv.empty() && getenv("PROSPER_SHADER_DUMP_SUCCESS")) {
-            const ShaderCompileKey dump_key = make_shader_compile_key(
-                ShaderProgramStage::Compute,
-                reinterpret_cast<const uint32_t*>(static_cast<uintptr_t>(code_addr)),
-                0x10000, table.get(), nullptr, nullptr);
-            maybe_dump_successful_shader(ShaderProgramStage::Compute, dump_key, item.spirv);
-        }
+        item.required_subgroup_size = config.native_subgroup_size;
         item.resources = std::move(table);
         item.launch = launch;
         item.code_addr = code_addr;
@@ -4413,15 +4550,23 @@ void set_live_target_reader(LiveTargetReaderFn fn) { g_live_target_reader = std:
 
 static LiveTargetImageImportFn g_live_target_image_import;
 static LiveTargetImageReleaseFn g_live_target_image_release;
+static LiveTargetImageWrittenFn g_live_target_image_written;
 void set_live_target_image_importer(LiveTargetImageImportFn import_fn,
                                     LiveTargetImageReleaseFn release_fn) {
     g_live_target_image_import = std::move(import_fn);
     g_live_target_image_release = std::move(release_fn);
 }
-bool import_live_render_target_image(uint64_t gpu_addr, LiveTargetImageImport& import) {
+void set_live_target_image_written_notifier(LiveTargetImageWrittenFn written_fn) {
+    g_live_target_image_written = std::move(written_fn);
+}
+bool import_live_render_target_image(uint64_t gpu_addr, const LiveTargetImageRequest& request,
+                                     LiveTargetImageImport& import) {
     import = LiveTargetImageImport{};
     if (!g_live_target_image_import) return false;
-    if (!g_live_target_image_import(gpu_addr, import)) { import = LiveTargetImageImport{}; return false; }
+    if (!g_live_target_image_import(gpu_addr, request, import)) {
+        import = LiveTargetImageImport{};
+        return false;
+    }
     if (!import.valid()) {
         // The importer pinned the entry before returning true; drop that pin rather than leaking a
         // permanently un-evictable cache entry if a future importer breaks the contract.
@@ -4433,6 +4578,9 @@ bool import_live_render_target_image(uint64_t gpu_addr, LiveTargetImageImport& i
 }
 void release_live_render_target_image(uint64_t gpu_addr) {
     if (g_live_target_image_release) g_live_target_image_release(gpu_addr);
+}
+void notify_live_render_target_image_written(uint64_t gpu_addr) {
+    if (g_live_target_image_written) g_live_target_image_written(gpu_addr);
 }
 static SharedVulkanContext g_shared_vulkan;
 void set_shared_vulkan_context(const SharedVulkanContext& context) { g_shared_vulkan = context; }

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -220,7 +220,10 @@ struct SpirvCompute {
     bool     is_fragment=0;                          // true in the fragment shell (gates VINTRP interp)
     bool     is_compute=0;                            // true in the compute shell (gates LDS / s_barrier)
     bool     uses_barrier=0;                          // guest or synthesized workgroup barrier emitted
-    bool     declared_subgroup=0, declared_subgroup_arithmetic=0;
+    bool     declared_subgroup=0, declared_subgroup_vote=0, declared_subgroup_arithmetic=0;
+    // When non-zero, the backend promises to create this compute pipeline with an exact required
+    // subgroup size equal to the PS5 wave. Native votes/scans are then architecture-exact.
+    uint32_t native_subgroup_size=0;
     uint32_t v_subgroup_localid=0, t_ptr_in_u32=0;
     uint32_t v_helper_invocation=0, t_ptr_in_bool=0;
     uint32_t v_internal_gds=0, t_ptr_gds_u32=0;
@@ -480,6 +483,37 @@ struct SpirvCompute {
         // with fragment GDS append/consume's non-helper population.
         const uint32_t guest_lane = land(mask_bit, logical_not(helper_invocation()));
         const uint32_t selected = sel(land(guest_lane, in_half), uconst(1), uconst(0));
+        uint32_t prefix = id();
+        put(code, Op_GroupNonUniformIAdd,
+            {t_u32, prefix, uconst(Scope_Subgroup), GroupOp_ExclusiveScan, selected});
+        return ibin(Op_IAdd, acc_bits, prefix);
+    }
+    uint32_t native_wave_any(uint32_t value) {
+        if (!native_subgroup_size) return 0;
+        if (!declared_subgroup) {
+            put(caps, Op_Capability, {Cap_GroupNonUniform});
+            declared_subgroup = true;
+        }
+        if (!declared_subgroup_vote) {
+            put(caps, Op_Capability, {Cap_GroupNonUniformVote});
+            declared_subgroup_vote = true;
+        }
+        uint32_t result = id();
+        put(code, Op_GroupNonUniformAny,
+            {t_bool, result, uconst(Scope_Subgroup), value});
+        return result;
+    }
+    uint32_t native_compute_mbcnt(uint32_t mask_bit, uint32_t acc_bits, uint32_t lo) {
+        if (!native_subgroup_size) return 0;
+        const uint32_t lane = subgroup_local_id();
+        if (!declared_subgroup_arithmetic) {
+            put(caps, Op_Capability, {Cap_GroupNonUniformArithmetic});
+            declared_subgroup_arithmetic = true;
+        }
+        const uint32_t in_half = bsel(
+            lo, ucmp(Op_ULessThan, lane, uconst(32)),
+            ucmp(Op_UGreaterThanEqual, lane, uconst(32)));
+        const uint32_t selected = sel(land(mask_bit, in_half), uconst(1), uconst(0));
         uint32_t prefix = id();
         put(code, Op_GroupNonUniformIAdd,
             {t_u32, prefix, uconst(Scope_Subgroup), GroupOp_ExclusiveScan, selected});
@@ -1114,19 +1148,27 @@ struct SpirvCompute {
     }
 
     // --- STORAGE images (MIMG image_load / image_store WITHOUT a sampler; compute copy/blit) ---
-    // Modeled with a UINT-sampled OpTypeImage, Format=Unknown, Sampled=2 (storage), so OpImageRead/Write
-    // move raw 32-bit texels — an exact fit for our untyped-VGPR model (any real format reinterpretation
-    // lives in the bound image view / T# descriptor). Requires the read/write-without-format caps.
+    // Integer/packed formats use a UINT-sampled OpTypeImage and the host converts between raw VGPR
+    // channels and guest texels. Four-channel UNORM8/FLOAT16/FLOAT32 use a FLOAT-sampled image instead:
+    // Vulkan then performs exactly the descriptor's normalized/float load-store conversion and the
+    // host can stage the guest texels at their native width. VGPRs remain raw u32 bits; float image
+    // components are bitcast at this boundary. Both paths use Format=Unknown and therefore require
+    // the read/write-without-format capabilities.
     uint32_t t_v4u_cache = 0;
     uint32_t t_v4u() { if (!t_v4u_cache) { t_v4u_cache = id(); put(types, Op_TypeVector, {t_v4u_cache, t_u32, 4}); } return t_v4u_cache; }
     uint32_t t_v3u_c = 0;   // integer coordinate vector type (uvec3); 2D reuses the shared t_v2u()
-    std::unordered_map<uint32_t, uint32_t> stg_img_type;   // (dim | arrayed<<8 | ms<<9) -> OpTypeImage id
+    std::unordered_map<uint32_t, uint32_t> stg_img_type;   // (dim | arrayed<<8 | ms<<9 | float<<10) -> type
     std::unordered_map<uint32_t, uint32_t> stg_img_var;    // binding -> storage-image OpVariable id
+    std::unordered_map<uint32_t, bool> stg_img_float;      // binding -> float (rather than uint) texels
     bool declared_read_wo_fmt = false, declared_write_wo_fmt = false, declared_sampled1d = false, declared_ms = false, declared_msarray = false;
-    static uint32_t stg_key(uint32_t dim, bool arrayed, bool ms) { return dim | (arrayed ? 0x100u : 0u) | (ms ? 0x200u : 0u); }
-    // Declare (idempotently) a uint storage image of SPIR-V `dim` (arrayed = layer in the coord; ms =
-    // multisampled) at set 0, `binding`. Each (dim,arrayed,ms) is a distinct OpTypeImage, keyed separately.
-    void declare_storage_image(uint32_t binding, uint32_t dim, bool arrayed = false, bool ms = false) {
+    static uint32_t stg_key(uint32_t dim, bool arrayed, bool ms, bool float_texel) {
+        return dim | (arrayed ? 0x100u : 0u) | (ms ? 0x200u : 0u) |
+               (float_texel ? 0x400u : 0u);
+    }
+    // Declare (idempotently) a storage image of SPIR-V `dim` (arrayed = layer in the coord; ms =
+    // multisampled) at set 0, `binding`. Float and uint sampled types are keyed separately.
+    void declare_storage_image(uint32_t binding, uint32_t dim, bool arrayed = false,
+                               bool ms = false, bool float_texel = false) {
         if (dim == Dim_1D && !declared_sampled1d) {   // SPIR-V: Dim=1D needs Sampled1D; storage 1D also needs Image1D
             put(caps, Op_Capability, {Cap_Sampled1D});
             put(caps, Op_Capability, {Cap_Image1D});
@@ -1134,10 +1176,12 @@ struct SpirvCompute {
         }
         if (ms && !declared_ms) { put(caps, Op_Capability, {Cap_StorageImageMultisample}); declared_ms = true; }
         if (ms && arrayed && !declared_msarray) { put(caps, Op_Capability, {Cap_ImageMSArray}); declared_msarray = true; }
-        uint32_t key = stg_key(dim, arrayed, ms);
+        uint32_t key = stg_key(dim, arrayed, ms, float_texel);
         if (!stg_img_type.count(key)) {
             uint32_t ti = id();
-            put(types, Op_TypeImage, {ti, t_u32, dim, 0, arrayed ? 1u : 0u, ms ? 1u : 0u, Img_Sampled_Storage, ImgFmt_Unknown});
+            put(types, Op_TypeImage, {ti, float_texel ? t_f32 : t_u32, dim, 0,
+                                      arrayed ? 1u : 0u, ms ? 1u : 0u,
+                                      Img_Sampled_Storage, ImgFmt_Unknown});
             stg_img_type[key] = ti;
         }
         if (stg_img_var.count(binding)) return;
@@ -1146,8 +1190,11 @@ struct SpirvCompute {
         put(deco, Op_Decorate, {v, Dec_DescriptorSet, desc_set});
         put(deco, Op_Decorate, {v, Dec_Binding, binding});
         stg_img_var[binding] = v;
+        stg_img_float[binding] = float_texel;
     }
-    uint32_t stg_img_id(uint32_t dim, bool arrayed, bool ms = false) { return stg_img_type[stg_key(dim, arrayed, ms)]; }
+    uint32_t stg_img_id(uint32_t dim, bool arrayed, bool ms, bool float_texel) {
+        return stg_img_type[stg_key(dim, arrayed, ms, float_texel)];
+    }
     // Build the integer coordinate operand from `n` raw-bit VGPR coords (u32 texel indices, incl. the
     // array layer as the last component for arrayed images). n=1 -> scalar u32; 2 -> uvec2; 3 -> uvec3.
     uint32_t stg_coord(uint32_t n, const uint32_t* c) {
@@ -1175,12 +1222,20 @@ struct SpirvCompute {
     void image_read(uint32_t binding, uint32_t dim, bool arrayed, uint32_t ncoord, const uint32_t* coords,
                     uint32_t out[4], bool ms = false, uint32_t sample = 0) {
         if (!declared_read_wo_fmt) { put(caps, Op_Capability, {Cap_StorageImageReadWithoutFormat}); declared_read_wo_fmt = true; }
-        uint32_t img   = id(); put(code, Op_Load,      {stg_img_id(dim, arrayed, ms), img, stg_img_var[binding]});
+        const bool float_texel = stg_img_float[binding];
+        const uint32_t vector_type = float_texel ? t_v4f : t_v4u();
+        uint32_t img   = id(); put(code, Op_Load,
+                                   {stg_img_id(dim, arrayed, ms, float_texel), img,
+                                    stg_img_var[binding]});
         uint32_t coord = stg_coord(ncoord, coords);
         uint32_t res   = id();
-        if (ms) put(code, Op_ImageRead, {t_v4u(), res, img, coord, ImgOp_Sample, sample});  // MSAA: read sample `sample`
-        else    put(code, Op_ImageRead, {t_v4u(), res, img, coord});
-        for (uint32_t c = 0; c < 4; c++) { uint32_t e = id(); put(code, Op_CompositeExtract, {t_u32, e, res, c}); out[c] = e; }
+        if (ms) put(code, Op_ImageRead, {vector_type, res, img, coord, ImgOp_Sample, sample});
+        else    put(code, Op_ImageRead, {vector_type, res, img, coord});
+        for (uint32_t c = 0; c < 4; c++) {
+            uint32_t e = id();
+            put(code, Op_CompositeExtract, {float_texel ? t_f32 : t_u32, e, res, c});
+            out[c] = float_texel ? bcu(e) : e;
+        }
     }
     // image_store: OpImageWrite raw-bit VGPR components vals[0..3] as a uvec4 texel to the storage image.
     // When `predicated` (narrowed EXEC), the write is wrapped in a selection merge on `pred` (the per-lane
@@ -1190,9 +1245,18 @@ struct SpirvCompute {
     void image_write(uint32_t binding, uint32_t dim, bool arrayed, uint32_t ncoord, const uint32_t* coords,
                      const uint32_t vals[4], bool predicated = false, uint32_t pred = 0) {
         if (!declared_write_wo_fmt) { put(caps, Op_Capability, {Cap_StorageImageWriteWithoutFormat}); declared_write_wo_fmt = true; }
-        uint32_t img   = id(); put(code, Op_Load, {stg_img_id(dim, arrayed), img, stg_img_var[binding]});
+        const bool float_texel = stg_img_float[binding];
+        uint32_t img   = id(); put(code, Op_Load,
+                                   {stg_img_id(dim, arrayed, false, float_texel), img,
+                                    stg_img_var[binding]});
         uint32_t coord = stg_coord(ncoord, coords);
-        uint32_t texel = id(); put(code, Op_CompositeConstruct, {t_v4u(), texel, vals[0], vals[1], vals[2], vals[3]});
+        uint32_t texel = id();
+        if (float_texel)
+            put(code, Op_CompositeConstruct,
+                {t_v4f, texel, bcf(vals[0]), bcf(vals[1]), bcf(vals[2]), bcf(vals[3])});
+        else
+            put(code, Op_CompositeConstruct,
+                {t_v4u(), texel, vals[0], vals[1], vals[2], vals[3]});
         if (!predicated) { put(code, Op_ImageWrite, {img, coord, texel}); return; }
         uint32_t then = id(), merge = id();
         put(code, Op_SelectionMerge, {merge, 0});
@@ -1486,6 +1550,39 @@ struct SpirvCompute {
         uint32_t result = id(); put(code, Op_Load, {t_u32, result, result_ptr});
         barrier();
         return result;
+    }
+    uint32_t native_wave_append(uint32_t lds_idx, uint32_t active_bool,
+                                uint32_t consume) {
+        if (!native_subgroup_size) return 0;
+        (void)subgroup_local_id();
+        if (!declared_subgroup_arithmetic) {
+            put(caps, Op_Capability, {Cap_GroupNonUniformArithmetic});
+            declared_subgroup_arithmetic = true;
+        }
+        const uint32_t contribution = sel(active_bool, uconst(1), uconst(0));
+        uint32_t count = id();
+        put(code, Op_GroupNonUniformIAdd,
+            {t_u32, count, uconst(Scope_Subgroup), GroupOp_Reduce, contribution});
+        uint32_t prefix = id();
+        put(code, Op_GroupNonUniformIAdd,
+            {t_u32, prefix, uconst(Scope_Subgroup), GroupOp_ExclusiveScan, contribution});
+        const uint32_t elected = land(active_bool, ucmp(Op_IEqual, prefix, uconst(0)));
+        const uint32_t entry = cur_block, leader = id(), merge = id();
+        emit_selmerge(merge);
+        emit_condbranch(elected, leader, merge);
+        emit_label(leader);
+        const uint32_t delta = sel(consume, ibin(Op_ISub, uconst(0), count), count);
+        const uint32_t leader_old = lds_atomic_rtn(
+            Op_AtomicIAdd, lds_idx, delta, false, btrue(), uconst(0));
+        const uint32_t leader_end = cur_block;
+        emit_branch(merge);
+        emit_label(merge);
+        const uint32_t local_old = emit_phi_2way(
+            t_u32, leader_old, leader_end, uconst(0), entry);
+        uint32_t old = id();
+        put(code, Op_GroupNonUniformIAdd,
+            {t_u32, old, uconst(Scope_Subgroup), GroupOp_Reduce, local_old});
+        return old;
     }
     uint32_t b_iadd(uint32_t a, uint32_t b_) { uint32_t r = id(); put(code, Op_IAdd, {t_u32, r, a, b_}); return r; }
     // Declare the two scalar-memory constant/vertex buffers (bindings 2 & 3) that SMEM / buffer_load_
@@ -6179,7 +6276,10 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     default: ok = false; return true;   // cube storage images deferred
                 }
                 if (ms && is_st) { ok = false; return true; }   // per-sample MSAA store not modeled (resolve shaders read)
-                b.declare_storage_image(res->binding, dim, arrayed, ms);
+                const uint32_t components = res->num_components ? res->num_components : 1;
+                const bool native_float = native_float_storage_image(
+                    res->format, components, res->srgb);
+                b.declare_storage_image(res->binding, dim, arrayed, ms, native_float);
                 // Coordinate VGPR per axis. Non-NSA (len==2): consecutive from VADDR (src[0]). NSA (len>2):
                 // split across the extra address dwords — coord0 = VADDR, coord k>=1 = byte (k-1) of
                 // words[2..3] (dword2 = addr1..4, dword3 = addr5..8). Layout verified via llvm-mc gfx1010.
@@ -7115,7 +7215,8 @@ bool emit_compute_cfg_state_machine(
     const uint32_t padded_lanes = wave_count * b.wave_size;
     const uint32_t wave_result_base = padded_lanes;
     const uint32_t group_active_slot = wave_result_base + wave_count;
-    b.declare_cfg_scratch(group_active_slot + 1);
+    if (!b.native_subgroup_size)
+        b.declare_cfg_scratch(group_active_slot + 1);
 
     // Discover every scalar pair that lives in the per-lane mask domain.  Besides defining the
     // dispatcher variables below, this identifies s_cmp_{eq,lg}_u64 mask,0: its SCC result is a
@@ -7240,12 +7341,37 @@ bool emit_compute_cfg_state_machine(
     // path. Entry-rooted reachability excludes writes in dead blocks, while backedges participate in
     // the fixed point and prevent stale fallback on later loop iterations.
     std::vector<std::unordered_set<int>> scalar_writes(starts.size());
+    std::vector<std::set<int>> vector_writes(starts.size());
+    std::vector<std::set<int>> vector_reads(starts.size());
     std::vector<std::vector<uint32_t>> successors(starts.size());
     for (uint32_t block = 0; block < starts.size(); ++block) {
         const uint32_t lo = starts[block];
         const uint32_t hi = block + 1 < starts.size() ? starts[block + 1] : UINT32_MAX;
+        std::set<int> ignored_scalar_writes;
+        loop_written_regs(ins, lo, hi, vector_writes[block], ignored_scalar_writes);
+        vector_reads[block] = vector_writes[block];
+        bool reads_dynamic_vector_range = false;
         for (const auto& in : ins) {
             if (in.pc < lo || in.pc >= hi) continue;
+            for (uint32_t source = 0; source < in.n_src; ++source) {
+                if (in.src[source].kind == OperandKind::VGPR) {
+                    // DS read/write2 and 64/96/128-bit transfers consume consecutive VGPRs that the
+                    // packet represents by their base register. Four is a safe architectural upper
+                    // bound for the forms accepted by emit_alu.
+                    const uint32_t words = in.fmt == Rdna2Format::DS ? 4u : 1u;
+                    for (uint32_t word = 0; word < words; ++word)
+                        vector_reads[block].insert(
+                            in.src[source].value + static_cast<int>(word));
+                }
+            }
+            // Buffer/image packets have format- and dmask-dependent implicit register ranges (and
+            // stores encode VDATA in the decoded destination field). Relative VGPR reads similarly
+            // select from a runtime range. Keep those uncommon blocks fully conservative; ordinary
+            // ALU/branch blocks can still avoid loading the rest of the vector register file.
+            reads_dynamic_vector_range |=
+                in.fmt == Rdna2Format::MUBUF || in.fmt == Rdna2Format::MTBUF ||
+                in.fmt == Rdna2Format::MIMG || in.fmt == Rdna2Format::FLAT ||
+                (in.fmt == Rdna2Format::VOP1 && in.opcode == 0x43);
             for_each_scalar_write(in, [&](int base, uint32_t width) {
                 for (uint32_t word = 0; word < width; ++word)
                     scalar_writes[block].insert(base + static_cast<int>(word));
@@ -7263,7 +7389,9 @@ bool emit_compute_cfg_state_machine(
         }
         auto add_successor = [&](uint32_t pc) {
             auto next = block_for_pc.find(pc);
-            if (pc <= end_pc && next != block_for_pc.end())
+            if (pc <= end_pc && next != block_for_pc.end() &&
+                std::find(successors[block].begin(), successors[block].end(), next->second) ==
+                    successors[block].end())
                 successors[block].push_back(next->second);
         };
         if (!terminator) {
@@ -7273,6 +7401,7 @@ bool emit_compute_cfg_state_machine(
             if (terminator->opcode != 0x02)
                 add_successor(terminator->pc + terminator->len_dwords);
         }
+        if (reads_dynamic_vector_range) vector_reads[block] = vregs;
     }
     std::vector<std::unordered_set<int>> scalar_may_write_in(starts.size());
     std::vector<bool> scalar_reachable(starts.size(), false);
@@ -7296,6 +7425,60 @@ bool emit_compute_cfg_state_machine(
                 scalar_may_write_in[successor].insert(out.begin(), out.end());
                 provenance_changed |= scalar_may_write_in[successor].size() != before;
             }
+        }
+    }
+
+    // The native exact-wave path does not need to return to a synchronized common phase after a
+    // plain unconditional edge.  Fuse maximal forward chains whose successor has no other
+    // predecessor; the successor cannot be entered from outside the chain, so keeping its register
+    // state in SSA is equivalent to a dispatcher save/reload without duplicating guest code.  Keep
+    // backward edges as dispatcher iterations (they form loops), and end a chain at every wave op
+    // that must execute as one uniform switch case.
+    std::vector<std::vector<uint32_t>> dispatch_blocks;
+    std::vector<uint32_t> dispatch_for_block(starts.size(), UINT32_MAX);
+    std::vector<uint32_t> predecessor_count(starts.size(), 0);
+    for (const auto& edges : successors)
+        for (uint32_t successor : edges)
+            if (successor < predecessor_count.size()) ++predecessor_count[successor];
+    std::vector<bool> synchronized_block(starts.size(), false);
+    for (uint32_t block = 0; block < starts.size(); ++block) {
+        const uint32_t lo = starts[block];
+        const uint32_t hi = block + 1 < starts.size() ? starts[block + 1] : UINT32_MAX;
+        for (const auto& in : ins) {
+            if (in.pc < lo || in.pc >= hi) continue;
+            synchronized_block[block] = synchronized_block[block] ||
+                mbcnt_event_for_pc.contains(in.pc) || append_event_for_pc.contains(in.pc) ||
+                mask_zero_compare_source(in) >= 0;
+        }
+    }
+    for (uint32_t first = 0; first < starts.size(); ++first) {
+        if (dispatch_for_block[first] != UINT32_MAX) continue;
+        const uint32_t dispatch = static_cast<uint32_t>(dispatch_blocks.size());
+        dispatch_blocks.push_back({});
+        uint32_t block = first;
+        while (true) {
+            dispatch_for_block[block] = dispatch;
+            dispatch_blocks.back().push_back(block);
+            if (!b.native_subgroup_size || synchronized_block[block] ||
+                successors[block].size() != 1) break;
+            const uint32_t successor = successors[block].front();
+            if (successor <= block || predecessor_count[successor] != 1 ||
+                dispatch_for_block[successor] != UINT32_MAX) break;
+            block = successor;
+        }
+    }
+
+    std::vector<std::set<int>> dispatch_vector_reads(dispatch_blocks.size());
+    std::vector<std::set<int>> dispatch_vector_writes(dispatch_blocks.size());
+    std::vector<std::unordered_set<int>> dispatch_scalar_writes(dispatch_blocks.size());
+    for (uint32_t dispatch = 0; dispatch < dispatch_blocks.size(); ++dispatch) {
+        for (uint32_t block : dispatch_blocks[dispatch]) {
+            dispatch_vector_reads[dispatch].insert(
+                vector_reads[block].begin(), vector_reads[block].end());
+            dispatch_vector_writes[dispatch].insert(
+                vector_writes[block].begin(), vector_writes[block].end());
+            dispatch_scalar_writes[dispatch].insert(
+                scalar_writes[block].begin(), scalar_writes[block].end());
         }
     }
 
@@ -7395,10 +7578,14 @@ bool emit_compute_cfg_state_machine(
     b.store_function(pc_var, b.uconst(0));
     b.store_function(active_var, yes);
 
-    auto load_state = [&]() {
+    auto load_state = [&](uint32_t dispatch = UINT32_MAX) {
         RegState state;
         state.sreg_input = initial.sreg_input;
-        for (const auto& kv : vv) state.vreg[kv.first] = b.load_function(b.t_u32, kv.second);
+        for (const auto& kv : vv) {
+            if (dispatch != UINT32_MAX &&
+                !dispatch_vector_reads[dispatch].contains(kv.first)) continue;
+            state.vreg[kv.first] = b.load_function(b.t_u32, kv.second);
+        }
         for (const auto& kv : sv) state.sreg[kv.first] = b.load_function(b.t_u32, kv.second);
         for (const auto& kv : mv) {
             state.sreg_bool[kv.first] = b.load_function(b.t_bool, kv.second);
@@ -7418,16 +7605,27 @@ bool emit_compute_cfg_state_machine(
         state.smem_pcrel_tables = initial.smem_pcrel_tables;
         return state;
     };
-    auto save_state = [&](const RegState& state) {
+    auto save_state = [&](const RegState& state, uint32_t dispatch) {
+        // A dispatcher case starts from the persistent register file, executes exactly one guest
+        // basic block, then returns to the common loop.  Only registers WRITTEN by that block need
+        // to be copied back.  Saving every tracked VGPR/SGPR at every edge generated thousands of
+        // redundant Function-memory stores for large kernels (Astro Bot's title compute shader has
+        // around one hundred tracked registers and dozens of cases), creating severe register
+        // pressure and scratch traffic in the host driver.  The conservative static writer sets
+        // include multi-register loads and secondary scalar destinations; unchanged variables keep
+        // the value loaded at the preceding dispatcher edge.
         for (const auto& kv : vv) {
+            if (!dispatch_vector_writes[dispatch].contains(kv.first)) continue;
             auto it = state.vreg.find(kv.first);
             b.store_function(kv.second, it == state.vreg.end() ? zero : it->second);
         }
         for (const auto& kv : sv) {
+            if (!dispatch_scalar_writes[dispatch].contains(kv.first)) continue;
             auto it = state.sreg.find(kv.first);
             b.store_function(kv.second, it == state.sreg.end() ? zero : it->second);
         }
         for (const auto& kv : mv) {
+            if (!dispatch_scalar_writes[dispatch].contains(kv.first)) continue;
             auto it = state.sreg_bool.find(kv.first);
             b.store_function(kv.second, it == state.sreg_bool.end() ? no : it->second);
         }
@@ -7458,9 +7656,9 @@ bool emit_compute_cfg_state_machine(
 
     const uint32_t loop_header = b.id(), switch_header = b.id(), switch_merge = b.id();
     const uint32_t loop_continue = b.id(), loop_merge = b.id(), fallback = b.id();
-    std::vector<uint32_t> labels(starts.size());
+    std::vector<uint32_t> labels(dispatch_blocks.size());
     std::vector<std::pair<uint32_t, uint32_t>> switch_cases;
-    for (uint32_t i = 0; i < starts.size(); ++i) {
+    for (uint32_t i = 0; i < dispatch_blocks.size(); ++i) {
         labels[i] = b.id();
         switch_cases.emplace_back(i, labels[i]);
     }
@@ -7468,25 +7666,32 @@ bool emit_compute_cfg_state_machine(
     b.emit_label(loop_header);
     // Every live hardware wave executes one guest basic block per dispatcher iteration. Inactive
     // invocations remain in the loop as synchronization participants until all waves finish.
-    b.store_function(vote_pending_var, no);
-    b.store_function(vote_value_var, no);
-    b.store_function(vote_invert_var, no);
-    b.store_function(vote_to_scc_var, no);
-    b.store_function(vote_taken_var, zero);
-    b.store_function(vote_next_var, zero);
-    b.store_function(mbcnt_pending_var, no);
-    b.store_function(mbcnt_mask_var, no);
-    b.store_function(mbcnt_low_var, no);
-    b.store_function(mbcnt_write_var, no);
-    b.store_function(mbcnt_event_var, zero);
-    b.store_function(mbcnt_acc_var, zero);
-    b.store_function(mbcnt_dst_var, zero);
-    b.store_function(append_pending_var, no);
-    b.store_function(append_active_var, no);
-    b.store_function(append_event_var, zero);
-    b.store_function(append_consume_var, no);
-    b.store_function(append_idx_var, zero);
-    b.store_function(append_dst_var, zero);
+    // With an exact native subgroup, one host subgroup is one guest wave and its scalar PC is
+    // uniform.  Cross-lane operations can therefore execute directly in their switch case.  The
+    // old publish/merge phase remains necessary only for the portable workgroup-scratch fallback;
+    // resetting all of its mailboxes on every native dispatcher iteration was a surprisingly large
+    // SALU/function-memory tax for branch-heavy kernels.
+    if (!b.native_subgroup_size) {
+        b.store_function(vote_pending_var, no);
+        b.store_function(vote_value_var, no);
+        b.store_function(vote_invert_var, no);
+        b.store_function(vote_to_scc_var, no);
+        b.store_function(vote_taken_var, zero);
+        b.store_function(vote_next_var, zero);
+        b.store_function(mbcnt_pending_var, no);
+        b.store_function(mbcnt_mask_var, no);
+        b.store_function(mbcnt_low_var, no);
+        b.store_function(mbcnt_write_var, no);
+        b.store_function(mbcnt_event_var, zero);
+        b.store_function(mbcnt_acc_var, zero);
+        b.store_function(mbcnt_dst_var, zero);
+        b.store_function(append_pending_var, no);
+        b.store_function(append_active_var, no);
+        b.store_function(append_event_var, zero);
+        b.store_function(append_consume_var, no);
+        b.store_function(append_idx_var, zero);
+        b.store_function(append_dst_var, zero);
+    }
     b.emit_loopmerge(loop_merge, loop_continue);
     b.emit_branch(switch_header);
     b.emit_label(switch_header);
@@ -7498,14 +7703,13 @@ bool emit_compute_cfg_state_machine(
     auto set_next = [&](uint32_t pc) {
         auto found = block_for_pc.find(pc);
         if (pc > end_pc || found == block_for_pc.end()) b.store_function(active_var, no);
-        else b.store_function(pc_var, b.uconst(found->second));
+        else b.store_function(pc_var, b.uconst(dispatch_for_block[found->second]));
     };
-    for (uint32_t block = 0; block < starts.size(); ++block) {
-        const uint32_t lo = starts[block];
-        const uint32_t hi = block + 1 < starts.size() ? starts[block + 1] : UINT32_MAX;
-        b.emit_label(labels[block]);
-        RegState state = load_state();
-        state.sreg_written = scalar_may_write_in[block];
+    for (uint32_t dispatch = 0; dispatch < dispatch_blocks.size(); ++dispatch) {
+        const uint32_t entry_block = dispatch_blocks[dispatch].front();
+        b.emit_label(labels[dispatch]);
+        RegState state = load_state(dispatch);
+        state.sreg_written = scalar_may_write_in[entry_block];
         for (int reg : state.sreg_written) state.sreg_input.erase(reg);
         if (!direct_descriptor_sregs.empty()) {
             for (int reg : direct_descriptor_sregs)
@@ -7515,40 +7719,64 @@ bool emit_compute_cfg_state_machine(
         const Rdna2Inst* mbcnt = nullptr;
         const Rdna2Inst* append = nullptr;
         const Rdna2Inst* mask_compare = nullptr;
-        for (const auto& in : ins) {
-            if (in.pc < lo || in.pc >= hi) continue;
-            if (in.is_end || (in.fmt == Rdna2Format::SOPP && in.opcode >= 0x02 &&
-                              in.opcode <= 0x09 && in.opcode != 0x03)) {
-                terminator = &in;
-                break;
+        const uint32_t final_block = dispatch_blocks[dispatch].back();
+        const uint32_t final_hi = final_block + 1 < starts.size()
+            ? starts[final_block + 1] : UINT32_MAX;
+        for (size_t member = 0; member < dispatch_blocks[dispatch].size(); ++member) {
+            const uint32_t block = dispatch_blocks[dispatch][member];
+            const uint32_t lo = starts[block];
+            const uint32_t hi = block + 1 < starts.size() ? starts[block + 1] : UINT32_MAX;
+            const Rdna2Inst* block_terminator = nullptr;
+            const Rdna2Inst* block_mbcnt = nullptr;
+            const Rdna2Inst* block_append = nullptr;
+            const Rdna2Inst* block_mask_compare = nullptr;
+            for (const auto& in : ins) {
+                if (in.pc < lo || in.pc >= hi) continue;
+                if (in.is_end || (in.fmt == Rdna2Format::SOPP && in.opcode >= 0x02 &&
+                                  in.opcode <= 0x09 && in.opcode != 0x03)) {
+                    block_terminator = &in;
+                    break;
+                }
+                if (in.fmt == Rdna2Format::VOP3 &&
+                    (in.opcode == 0x365 || in.opcode == 0x366)) {
+                    block_mbcnt = &in;
+                    break;
+                }
+                if (in.fmt == Rdna2Format::DS && (in.opcode == 0x3d || in.opcode == 0x3e)) {
+                    block_append = &in;
+                    break;
+                }
+                if (mask_zero_compare_source(in) >= 0) {
+                    block_mask_compare = &in;
+                    break;
+                }
+                if (in.fmt == Rdna2Format::EXP) {
+                    if (!exp_fn(in)) return false;
+                    continue;
+                }
+                bool ok = true;
+                const bool handled = emit_alu(b, state, in, ok, allow_exec_update, &safe,
+                                              allow_smem, rt, /*allow_wave*/false);
+                if (handled && ok) record_scalar_write(state, in);
+                if (!handled || !ok) {
+                    if (getenv("PROSPER_DBG"))
+                        std::fprintf(stderr, "[cfg-recompile-reject] pc=%u fmt=%d op=0x%x\n",
+                                     in.pc, static_cast<int>(in.fmt), in.opcode);
+                    return false;
+                }
             }
-            if (in.fmt == Rdna2Format::VOP3 &&
-                (in.opcode == 0x365 || in.opcode == 0x366)) {
-                mbcnt = &in;
-                break;
+            const bool last = member + 1 == dispatch_blocks[dispatch].size();
+            if (!last) {
+                // Group construction admits only one-successor plain blocks before the tail.
+                if (block_mbcnt || block_append || block_mask_compare ||
+                    (block_terminator && (block_terminator->is_end ||
+                                          block_terminator->opcode != 0x02))) return false;
+                continue; // consume an unconditional guest branch without a dispatcher round-trip
             }
-            if (in.fmt == Rdna2Format::DS && (in.opcode == 0x3d || in.opcode == 0x3e)) {
-                append = &in;
-                break;
-            }
-            if (mask_zero_compare_source(in) >= 0) {
-                mask_compare = &in;
-                break;
-            }
-            if (in.fmt == Rdna2Format::EXP) {
-                if (!exp_fn(in)) return false;
-                continue;
-            }
-            bool ok = true;
-            const bool handled = emit_alu(b, state, in, ok, allow_exec_update, &safe,
-                                          allow_smem, rt, /*allow_wave*/false);
-            if (handled && ok) record_scalar_write(state, in);
-            if (!handled || !ok) {
-                if (getenv("PROSPER_DBG"))
-                    std::fprintf(stderr, "[cfg-recompile-reject] pc=%u fmt=%d op=0x%x\n",
-                                 in.pc, static_cast<int>(in.fmt), in.opcode);
-                return false;
-            }
+            terminator = block_terminator;
+            mbcnt = block_mbcnt;
+            append = block_append;
+            mask_compare = block_mask_compare;
         }
         if (mbcnt) {
             bool operand_ok = true;
@@ -7557,15 +7785,32 @@ bool emit_compute_cfg_state_machine(
             const uint32_t acc = operand_bits(b, state, *mbcnt, mbcnt->src[1], &operand_ok);
             const auto event = mbcnt_event_for_pc.find(mbcnt->pc);
             if (!mask || !operand_ok || event == mbcnt_event_for_pc.end()) return false;
-            b.store_function(mbcnt_pending_var, yes);
-            b.store_function(mbcnt_mask_var, mask);
-            b.store_function(mbcnt_low_var, mbcnt->opcode == 0x365 ? yes : no);
-            // load_state conservatively marks EXEC narrowed. Writing under the current per-lane EXEC
-            // is equivalent for a known-full mask and preserves inactive VGPR lanes for divergent code.
-            b.store_function(mbcnt_write_var, state.exec);
-            b.store_function(mbcnt_event_var, b.uconst(event->second));
-            b.store_function(mbcnt_acc_var, acc);
-            b.store_function(mbcnt_dst_var, b.uconst(static_cast<uint32_t>(mbcnt->dst.value)));
+            if (b.native_subgroup_size) {
+                // The switch selector is scalar within this exact-size subgroup, so every guest
+                // lane reaches the same case.  Execute the wave prefix count here and retain masked-
+                // off lanes exactly as an RDNA VGPR write does, instead of dynamically selecting a
+                // destination across the entire persistent register file in the common phase.
+                const uint32_t result = b.native_compute_mbcnt(
+                    mask, acc, mbcnt->opcode == 0x365 ? yes : no);
+                const int dst = mbcnt->dst.value;
+                const auto old = state.vreg.find(dst);
+                state.vreg[dst] = b.sel(
+                    state.exec, result, old == state.vreg.end() ? zero : old->second);
+                for (auto& vg : state.vgpr_lane_slots)
+                    if (vg.first == dst) for (auto& slot : vg.second) slot.second = zero;
+                for (auto& vg : state.vgpr_lane_mask_slots)
+                    if (vg.first == dst) for (auto& slot : vg.second) slot.second = no;
+            } else {
+                b.store_function(mbcnt_pending_var, yes);
+                b.store_function(mbcnt_mask_var, mask);
+                b.store_function(mbcnt_low_var, mbcnt->opcode == 0x365 ? yes : no);
+                // load_state conservatively marks EXEC narrowed. Writing under the current per-lane EXEC
+                // is equivalent for a known-full mask and preserves inactive VGPR lanes for divergent code.
+                b.store_function(mbcnt_write_var, state.exec);
+                b.store_function(mbcnt_event_var, b.uconst(event->second));
+                b.store_function(mbcnt_acc_var, acc);
+                b.store_function(mbcnt_dst_var, b.uconst(static_cast<uint32_t>(mbcnt->dst.value)));
+            }
         }
         if (append) {
             const auto m0 = state.sreg.find(124);
@@ -7574,27 +7819,46 @@ bool emit_compute_cfg_state_machine(
             b.declare_lds();
             const uint32_t base = b.ibin(Op_BitwiseAnd, m0->second, b.uconst(0xffffu));
             const uint32_t byte_addr = b.ibin(Op_IAdd, base, b.uconst(append->literal));
-            b.store_function(append_pending_var, yes);
-            b.store_function(append_active_var, state.exec);
-            b.store_function(append_event_var, b.uconst(event->second));
-            b.store_function(append_consume_var, append->opcode == 0x3d ? yes : no);
-            b.store_function(append_idx_var,
-                b.ibin(Op_ShiftRightLogical, byte_addr, b.uconst(2)));
-            b.store_function(append_dst_var,
-                b.uconst(static_cast<uint32_t>(append->dst.value)));
+            const uint32_t idx = b.ibin(Op_ShiftRightLogical, byte_addr, b.uconst(2));
+            if (b.native_subgroup_size) {
+                const uint32_t result = b.native_wave_append(
+                    idx, state.exec, append->opcode == 0x3d ? yes : no);
+                const int dst = append->dst.value;
+                const auto old = state.vreg.find(dst);
+                state.vreg[dst] = b.sel(
+                    state.exec, result, old == state.vreg.end() ? zero : old->second);
+                for (auto& vg : state.vgpr_lane_slots)
+                    if (vg.first == dst) for (auto& slot : vg.second) slot.second = zero;
+                for (auto& vg : state.vgpr_lane_mask_slots)
+                    if (vg.first == dst) for (auto& slot : vg.second) slot.second = no;
+            } else {
+                b.store_function(append_pending_var, yes);
+                b.store_function(append_active_var, state.exec);
+                b.store_function(append_event_var, b.uconst(event->second));
+                b.store_function(append_consume_var, append->opcode == 0x3d ? yes : no);
+                b.store_function(append_idx_var, idx);
+                b.store_function(append_dst_var,
+                    b.uconst(static_cast<uint32_t>(append->dst.value)));
+            }
         }
         if (mask_compare) {
             const int source = mask_zero_compare_source(*mask_compare);
             const auto value = state.sreg_bool.find(source);
             if (value == state.sreg_bool.end()) return false;
-            b.store_function(vote_pending_var, yes);
-            b.store_function(vote_value_var, value->second);
-            // EQ mask,0 means !any(mask); LG mask,0 means any(mask).
-            b.store_function(vote_invert_var,
-                mask_compare->opcode == 0x12 ? yes : no);
-            b.store_function(vote_to_scc_var, yes);
+            if (b.native_subgroup_size) {
+                const uint32_t wave_any = b.native_wave_any(value->second);
+                // EQ mask,0 means !any(mask); LG mask,0 means any(mask).
+                state.scc = mask_compare->opcode == 0x12
+                    ? b.logical_not(wave_any) : wave_any;
+            } else {
+                b.store_function(vote_pending_var, yes);
+                b.store_function(vote_value_var, value->second);
+                b.store_function(vote_invert_var,
+                    mask_compare->opcode == 0x12 ? yes : no);
+                b.store_function(vote_to_scc_var, yes);
+            }
         }
-        save_state(state);
+        save_state(state, dispatch);
         if (mbcnt) {
             set_next(mbcnt->pc + mbcnt->len_dwords);
         } else if (append) {
@@ -7602,7 +7866,7 @@ bool emit_compute_cfg_state_machine(
         } else if (mask_compare) {
             set_next(mask_compare->pc + mask_compare->len_dwords);
         } else if (!terminator) {
-            set_next(hi);
+            set_next(final_hi);
         } else if (terminator->is_end) {
             b.store_function(active_var, no);
         } else if (terminator->opcode == 0x02) {
@@ -7624,17 +7888,27 @@ bool emit_compute_cfg_state_machine(
             const uint32_t fallthrough = terminator->pc + terminator->len_dwords;
             auto taken = block_for_pc.find(target), next = block_for_pc.find(fallthrough);
             if (taken == block_for_pc.end() || next == block_for_pc.end()) return false;
+            const uint32_t taken_dispatch = dispatch_for_block[taken->second];
+            const uint32_t next_dispatch = dispatch_for_block[next->second];
             if (terminator->opcode == 0x04 || terminator->opcode == 0x05) {
                 b.store_function(pc_var,
-                    b.sel(condition, b.uconst(taken->second), b.uconst(next->second)));
+                    b.sel(condition, b.uconst(taken_dispatch), b.uconst(next_dispatch)));
+            } else if (b.native_subgroup_size) {
+                const uint32_t wave_any = b.native_wave_any(
+                    terminator->opcode <= 0x07 ? state.vcc : state.exec);
+                const uint32_t wave_condition =
+                    terminator->opcode == 0x06 || terminator->opcode == 0x08
+                        ? b.logical_not(wave_any) : wave_any;
+                b.store_function(pc_var,
+                    b.sel(wave_condition, b.uconst(taken_dispatch), b.uconst(next_dispatch)));
             } else {
                 b.store_function(vote_pending_var, yes);
                 b.store_function(vote_value_var,
                     terminator->opcode <= 0x07 ? state.vcc : state.exec);
                 b.store_function(vote_invert_var,
                     terminator->opcode == 0x06 || terminator->opcode == 0x08 ? yes : no);
-                b.store_function(vote_taken_var, b.uconst(taken->second));
-                b.store_function(vote_next_var, b.uconst(next->second));
+                b.store_function(vote_taken_var, b.uconst(taken_dispatch));
+                b.store_function(vote_next_var, b.uconst(next_dispatch));
             }
         }
         b.emit_branch(switch_merge);
@@ -7646,6 +7920,14 @@ bool emit_compute_cfg_state_machine(
     b.emit_branch(loop_continue);
     b.emit_label(loop_continue);
 
+    if (b.native_subgroup_size) {
+        // Native wave operations and votes were already resolved in the selected case.  PC and
+        // ACTIVE are scalar guest-wave state, so every invocation in this exact-size subgroup has
+        // the same value; another subgroup in the workgroup may still leave independently because
+        // this path contains no workgroup barriers.
+        b.emit_condbranch(b.load_function(b.t_bool, active_var),
+                          loop_header, loop_merge);
+    } else {
     // MBCNT common phase. Cases publish an event-tagged mask bit and accumulator, but never emit a
     // barrier themselves. Every invocation—including ended waves and lanes currently at a different
     // guest block—therefore executes these two barriers in identical structured control flow. Event
@@ -7891,6 +8173,7 @@ bool emit_compute_cfg_state_machine(
     const uint32_t group_active = b.ucmp(
         Op_INotEqual, b.cfg_scratch_load(b.uconst(group_active_slot)), zero);
     b.emit_condbranch(group_active, loop_header, loop_merge);
+    }
     b.emit_label(loop_merge);
 
     // Expose the final emulated state to the caller (compute currently consumes no register output,
@@ -8709,6 +8992,7 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
     const uint32_t local_y = std::max(1u, config.local_y);
     const uint32_t local_z = std::max(1u, config.local_z);
     const uint32_t wave_size = config.wave_size == 32 ? 32u : 64u;
+    b.native_subgroup_size = config.native_subgroup_size == wave_size ? wave_size : 0u;
     b.begin(1, rt, local_x, local_y, local_z, wave_size,
             static_cast<uint32_t>(config.user_sgprs.size()));
     b.declare_guest_scratch(scratch);

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -224,6 +224,7 @@ struct SpirvCompute {
     // When non-zero, the backend promises to create this compute pipeline with an exact required
     // subgroup size equal to the PS5 wave. Native votes/scans are then architecture-exact.
     uint32_t native_subgroup_size=0;
+    uint32_t native_storage_format_support=0;
     uint32_t v_subgroup_localid=0, t_ptr_in_u32=0;
     uint32_t v_helper_invocation=0, t_ptr_in_bool=0;
     uint32_t v_internal_gds=0, t_ptr_gds_u32=0;
@@ -6277,8 +6278,12 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 }
                 if (ms && is_st) { ok = false; return true; }   // per-sample MSAA store not modeled (resolve shaders read)
                 const uint32_t components = res->num_components ? res->num_components : 1;
-                const bool native_float = native_float_storage_image(
-                    res->format, components, res->srgb);
+                const bool ordinary_2d = res->img_dim == 1 && res->depth == 1 &&
+                                         !res->depth_compare;
+                const bool native_float = ordinary_2d && native_float_storage_image_supported(
+                    res->format, components, res->srgb,
+                    (b.native_storage_format_support &
+                     native_storage_format_support_bit(res->format, components)) != 0);
                 b.declare_storage_image(res->binding, dim, arrayed, ms, native_float);
                 // Coordinate VGPR per axis. Non-NSA (len==2): consecutive from VADDR (src[0]). NSA (len>2):
                 // split across the extra address dwords — coord0 = VADDR, coord k>=1 = byte (k-1) of
@@ -8993,6 +8998,7 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
     const uint32_t local_z = std::max(1u, config.local_z);
     const uint32_t wave_size = config.wave_size == 32 ? 32u : 64u;
     b.native_subgroup_size = config.native_subgroup_size == wave_size ? wave_size : 0u;
+    b.native_storage_format_support = config.native_storage_format_support;
     b.begin(1, rt, local_x, local_y, local_z, wave_size,
             static_cast<uint32_t>(config.user_sgprs.size()));
     b.declare_guest_scratch(scratch);

--- a/prosper/src/gpu/rdna2_to_spirv.hpp
+++ b/prosper/src/gpu/rdna2_to_spirv.hpp
@@ -132,6 +132,10 @@ struct ComputeShaderConfig {
     bool tgid_x_en = false, tgid_y_en = false, tgid_z_en = false;
     bool tg_size_en = false;
     uint32_t lds_bytes = 0;
+    // Non-zero only when the live backend can REQUIRE this exact Vulkan subgroup size. Complex
+    // guest-wave CFGs may then replace their portable workgroup-scratch vote/scan emulation with
+    // native subgroup operations without changing the PS5 wave domain.
+    uint32_t native_subgroup_size = 0;
 };
 
 // Translate a game compute program without the synthetic binding-0 input / binding-1 output used by

--- a/prosper/src/gpu/rdna2_to_spirv.hpp
+++ b/prosper/src/gpu/rdna2_to_spirv.hpp
@@ -136,6 +136,10 @@ struct ComputeShaderConfig {
     // guest-wave CFGs may then replace their portable workgroup-scratch vote/scan emulation with
     // native subgroup operations without changing the PS5 wave domain.
     uint32_t native_subgroup_size = 0;
+    // Per-format VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT support published by the device-owning
+    // frontend. Offline callers default to the portable raw path; live execution supplies the exact
+    // physical-device mask so unsupported typed formats compile to the raw uvec4 fallback.
+    uint32_t native_storage_format_support = 0;
 };
 
 // Translate a game compute program without the synthetic binding-0 input / binding-1 output used by

--- a/prosper/src/gpu/shader_resources.cpp
+++ b/prosper/src/gpu/shader_resources.cpp
@@ -266,6 +266,7 @@ struct TypeInfo {
     uint32_t width = 0;
     uint32_t storage = 0;
     uint32_t image_sampled = 0;
+    bool scalar_float = false;
     std::vector<uint32_t> members;
 };
 
@@ -339,6 +340,26 @@ SpirvDescriptorKind descriptor_kind(const VariableInfo& var,
         return SpirvDescriptorKind::Unknown;
     }
     return SpirvDescriptorKind::Unknown;
+}
+
+bool descriptor_storage_float(const VariableInfo& var,
+                              const std::unordered_map<uint32_t, TypeInfo>& types) {
+    auto pi = types.find(var.pointer_type);
+    if (pi == types.end() || pi->second.kind != TypeKind::Pointer) return false;
+    uint32_t type = pi->second.element;
+    for (uint32_t depth = 0; depth < 8; ++depth) {
+        auto ti = types.find(type);
+        if (ti == types.end()) return false;
+        if (ti->second.kind == TypeKind::Array) {
+            type = ti->second.element;
+            continue;
+        }
+        if (ti->second.kind != TypeKind::Image || ti->second.image_sampled != 2) return false;
+        auto sampled_type = types.find(ti->second.element);
+        return sampled_type != types.end() && sampled_type->second.kind == TypeKind::Scalar &&
+               sampled_type->second.scalar_float;
+    }
+    return false;
 }
 
 SpirvDescriptorKind resource_kind(const ShaderResource& r) {
@@ -476,8 +497,11 @@ DescriptorValidationReport validate_spirv_descriptor_interface(
                 if (n >= 2 && stage == SpirvShaderStage::Unknown)
                     stage = static_cast<SpirvShaderStage>(word(in, 0));
                 break;
-            case OpTypeInt: case OpTypeFloat:
+            case OpTypeInt:
                 if (n >= 2) { TypeInfo t; t.kind = TypeKind::Scalar; t.width = word(in, 1); types[word(in, 0)] = t; }
+                break;
+            case OpTypeFloat:
+                if (n >= 2) { TypeInfo t; t.kind = TypeKind::Scalar; t.width = word(in, 1); t.scalar_float = true; types[word(in, 0)] = t; }
                 break;
             case OpTypeVector:
                 if (n >= 3) { TypeInfo t; t.kind = TypeKind::Vector; t.element = word(in, 1); t.count = word(in, 2); types[word(in, 0)] = t; }
@@ -529,14 +553,22 @@ DescriptorValidationReport validate_spirv_descriptor_interface(
     }
 
     std::unordered_map<uint32_t, SpirvDescriptorKind> descriptor_vars;
+    std::set<uint32_t> storage_float_vars;
     for (const auto& [id, var] : variables) {
         SpirvDescriptorKind kind = descriptor_kind(var, types);
-        if (kind != SpirvDescriptorKind::Unknown) descriptor_vars[id] = kind;
+        if (kind != SpirvDescriptorKind::Unknown) {
+            descriptor_vars[id] = kind;
+            if (kind == SpirvDescriptorKind::StorageImage &&
+                descriptor_storage_float(var, types))
+                storage_float_vars.insert(id);
+        }
     }
 
     std::set<uint32_t> used_vars;
     std::set<uint32_t> read_vars;
     std::set<uint32_t> written_vars;
+    std::set<uint32_t> normalized_sample_vars;
+    std::set<uint32_t> texel_access_vars;
     std::unordered_map<uint32_t, PointerAccess> accesses;
     // Result id of OpLoad/OpSampledImage -> descriptor variable. An image descriptor load accesses
     // the descriptor object, not its texels; only the later image opcode establishes read/write data
@@ -564,6 +596,12 @@ DescriptorValidationReport validate_spirv_descriptor_interface(
     auto mark_image = [&](uint32_t object, bool read, bool write) {
         auto origin = image_objects.find(object);
         if (origin != image_objects.end()) mark(origin->second, read, write);
+    };
+    auto mark_image_coordinate_contract = [&](uint32_t object, bool normalized) {
+        auto origin = image_objects.find(object);
+        if (origin == image_objects.end()) return;
+        if (normalized) normalized_sample_vars.insert(origin->second);
+        else texel_access_vars.insert(origin->second);
     };
     for (const Instruction& in : insts) {
         const uint32_t n = in.words - 1u;
@@ -593,11 +631,23 @@ DescriptorValidationReport validate_spirv_descriptor_interface(
             // All sampled/fetch/gather forms plus OpImageRead place their image object after result
             // type/result id. The descriptor itself was loaded earlier; this is the texel read.
             mark_image(word(in, 2), true, false);
+            // OpImageSample* (87..94) and Gather/DrefGather (96..97) consume normalized sampler
+            // coordinates. OpImageFetch (95) and OpImageRead (98) consume integer texel coordinates
+            // and therefore cannot observe a reduced render target as if it had the native extent.
+            mark_image_coordinate_contract(
+                word(in, 2), (in.opcode >= 87u && in.opcode <= 94u) ||
+                                 in.opcode == 96u || in.opcode == 97u);
         } else if (in.opcode == 99u /* OpImageWrite */ && n >= 1) {
             mark_image(word(in, 0), false, true);
         } else if (in.opcode == 100u /* OpImage */ && n >= 3) {
             auto origin = image_objects.find(word(in, 2));
             if (origin != image_objects.end()) image_objects[word(in, 1)] = origin->second;
+        } else if (in.opcode >= 101u && in.opcode <= 107u && n >= 3) {
+            // OpImageQueryFormat/Order/SizeLod/Size/Lod/Levels/Samples all place the image object
+            // after result type/result id. Query-only descriptors must remain in the reflected
+            // layout, and their reported dimensions/LOD contract requires the guest's exact extent.
+            mark_image(word(in, 2), true, false);
+            mark_image_coordinate_contract(word(in, 2), false);
         } else if ((in.opcode == OpAccessChain || in.opcode == OpInBoundsAccessChain) && n >= 3) {
             const uint32_t result = word(in, 1), base = word(in, 2);
             PointerAccess a;
@@ -650,7 +700,10 @@ DescriptorValidationReport validate_spirv_descriptor_interface(
         if (si == sets.end() || bi == bindings.end()) { add_malformed(report); continue; }
         report.descriptors.push_back({var, si->second, bi->second, descriptor_vars[var], stage,
                                       required[var], dynamic[var], read_vars.count(var) != 0,
-                                      written_vars.count(var) != 0});
+                                      written_vars.count(var) != 0,
+                                      normalized_sample_vars.count(var) != 0,
+                                      texel_access_vars.count(var) != 0,
+                                      storage_float_vars.count(var) != 0});
     }
     std::sort(report.descriptors.begin(), report.descriptors.end(), [](const auto& a, const auto& b) {
         return a.set != b.set ? a.set < b.set : a.binding < b.binding;

--- a/prosper/src/gpu/shader_resources.cpp
+++ b/prosper/src/gpu/shader_resources.cpp
@@ -3,8 +3,10 @@
 
 #include <algorithm>
 #include <cstring>
+#include <iterator>
 #include <limits>
 #include <map>
+#include <mutex>
 #include <set>
 #include <unordered_map>
 
@@ -353,6 +355,42 @@ void add_malformed(DescriptorValidationReport& report) {
     report.issues.push_back({DescriptorIssueCode::MalformedSpirv, true});
 }
 
+struct DescriptorReflectionCacheEntry {
+    std::vector<uint32_t> spirv;
+    DescriptorValidationReport reflection;
+    SpirvShaderStage stage = SpirvShaderStage::Unknown;
+    uint64_t last_use = 0;
+};
+
+struct DescriptorReflectionCache {
+    std::mutex mutex;
+    std::unordered_map<uint64_t, DescriptorReflectionCacheEntry> entries;
+    uint64_t use_clock = 0;
+    uint64_t bytes = 0;
+};
+
+DescriptorReflectionCache& descriptor_reflection_cache() {
+    static DescriptorReflectionCache cache;
+    return cache;
+}
+
+uint64_t spirv_reflection_hash(const std::vector<uint32_t>& spirv) {
+    uint64_t hash = 1469598103934665603ull;
+    for (uint32_t word : spirv) {
+        hash ^= word;
+        hash *= 1099511628211ull;
+    }
+    return hash;
+}
+
+uint64_t reflection_entry_bytes(const DescriptorReflectionCacheEntry& entry) {
+    return static_cast<uint64_t>(entry.spirv.size()) * sizeof(uint32_t) +
+           static_cast<uint64_t>(entry.reflection.descriptors.size()) *
+               sizeof(SpirvDescriptorBinding) +
+           static_cast<uint64_t>(entry.reflection.issues.size()) *
+               sizeof(DescriptorValidationIssue);
+}
+
 } // namespace
 
 bool DescriptorValidationReport::ok() const {
@@ -393,6 +431,24 @@ DescriptorValidationReport validate_spirv_descriptor_interface(
     SpirvShaderStage expected_stage,
     bool report_unused) {
     DescriptorValidationReport report;
+    SpirvShaderStage stage = SpirvShaderStage::Unknown;
+    const uint64_t reflection_hash = spirv_reflection_hash(spirv);
+    bool reflection_cached = false;
+    {
+        DescriptorReflectionCache& cache = descriptor_reflection_cache();
+        std::lock_guard lock(cache.mutex);
+        auto found = cache.entries.find(reflection_hash);
+        // Equality is authoritative; the hash only selects a candidate, so collisions cannot reuse
+        // another module's descriptor contract.
+        if (found != cache.entries.end() && found->second.spirv == spirv) {
+            found->second.last_use = ++cache.use_clock;
+            report = found->second.reflection;
+            stage = found->second.stage;
+            reflection_cached = true;
+        }
+    }
+
+    if (!reflection_cached) {
     if (spirv.size() < 5 || spirv[0] != kSpirvMagic) { add_malformed(report); return report; }
 
     std::vector<Instruction> insts;
@@ -412,8 +468,6 @@ DescriptorValidationReport validate_spirv_descriptor_interface(
     std::unordered_map<uint32_t, uint32_t> sets, bindings;
     std::unordered_map<uint32_t, uint64_t> array_strides;
     std::unordered_map<uint64_t, uint64_t> member_offsets;
-    SpirvShaderStage stage = SpirvShaderStage::Unknown;
-
     auto word = [&](const Instruction& in, uint32_t operand) { return spirv[in.offset + 1u + operand]; };
     for (const Instruction& in : insts) {
         const uint32_t n = in.words - 1u;
@@ -481,30 +535,69 @@ DescriptorValidationReport validate_spirv_descriptor_interface(
     }
 
     std::set<uint32_t> used_vars;
+    std::set<uint32_t> read_vars;
+    std::set<uint32_t> written_vars;
     std::unordered_map<uint32_t, PointerAccess> accesses;
+    // Result id of OpLoad/OpSampledImage -> descriptor variable. An image descriptor load accesses
+    // the descriptor object, not its texels; only the later image opcode establishes read/write data
+    // access. Keeping that distinction makes write-only storage outputs visible to the backend even
+    // when the same shader reads a different storage image.
+    std::unordered_map<uint32_t, uint32_t> image_objects;
     std::unordered_map<uint32_t, uint64_t> required;
     std::unordered_map<uint32_t, bool> dynamic;
 
-    auto mark = [&](uint32_t var) { if (descriptor_vars.count(var)) used_vars.insert(var); };
+    auto mark = [&](uint32_t var, bool read, bool write) {
+        if (!descriptor_vars.count(var)) return;
+        used_vars.insert(var);
+        if (read) read_vars.insert(var);
+        if (write) written_vars.insert(var);
+    };
+    auto pointer_root = [&](uint32_t pointer) -> uint32_t {
+        if (descriptor_vars.count(pointer)) return pointer;
+        auto access = accesses.find(pointer);
+        return access != accesses.end() ? access->second.variable : 0u;
+    };
+    auto mark_pointer = [&](uint32_t pointer, bool read, bool write) {
+        const uint32_t root = pointer_root(pointer);
+        if (root) mark(root, read, write);
+    };
+    auto mark_image = [&](uint32_t object, bool read, bool write) {
+        auto origin = image_objects.find(object);
+        if (origin != image_objects.end()) mark(origin->second, read, write);
+    };
     for (const Instruction& in : insts) {
         const uint32_t n = in.words - 1u;
         if (in.opcode == OpLoad && n >= 3) {
-            uint32_t ptr = word(in, 2); mark(ptr);
-            auto ai = accesses.find(ptr); if (ai != accesses.end()) mark(ai->second.variable);
+            const uint32_t root = pointer_root(word(in, 2));
+            const auto descriptor = descriptor_vars.find(root);
+            const bool image_descriptor = descriptor != descriptor_vars.end() &&
+                descriptor->second != SpirvDescriptorKind::StorageBuffer;
+            mark_pointer(word(in, 2), !image_descriptor, false);
+            if (image_descriptor) image_objects[word(in, 1)] = root;
         } else if (in.opcode == OpStore && n >= 1) {
-            uint32_t ptr = word(in, 0); mark(ptr);
-            auto ai = accesses.find(ptr); if (ai != accesses.end()) mark(ai->second.variable);
-        } else if (((in.opcode >= OpAtomicLoad && in.opcode <= OpAtomicIDecrement) ||
+            mark_pointer(word(in, 0), false, true);
+        } else if (in.opcode == OpAtomicLoad && n >= 3) {
+            mark_pointer(word(in, 2), true, false);
+        } else if (((in.opcode >= OpAtomicExchange && in.opcode <= OpAtomicIDecrement) ||
                     (in.opcode >= OpAtomicIAdd && in.opcode <= OpAtomicXor) ||
                     in.opcode == OpAtomicFlagTestAndSet) && n >= 3) {
             // Result-producing atomic instructions place their pointer after result type/result id.
-            // A write-only atomic buffer is still part of the live descriptor interface.
-            uint32_t ptr = word(in, 2); mark(ptr);
-            auto ai = accesses.find(ptr); if (ai != accesses.end()) mark(ai->second.variable);
+            mark_pointer(word(in, 2), true, true);
         } else if ((in.opcode == OpAtomicStore || in.opcode == OpAtomicFlagClear) && n >= 1) {
             // The two result-less atomic instructions place the pointer first, like OpStore.
-            uint32_t ptr = word(in, 0); mark(ptr);
-            auto ai = accesses.find(ptr); if (ai != accesses.end()) mark(ai->second.variable);
+            mark_pointer(word(in, 0), false, true);
+        } else if (in.opcode == 86u /* OpSampledImage */ && n >= 3) {
+            auto origin = image_objects.find(word(in, 2));
+            if (origin != image_objects.end()) image_objects[word(in, 1)] = origin->second;
+        } else if (in.opcode >= 87u && in.opcode <= 98u && n >= 3) {
+            // All sampled/fetch/gather forms plus OpImageRead place their image object after result
+            // type/result id. The descriptor itself was loaded earlier; this is the texel read.
+            mark_image(word(in, 2), true, false);
+        } else if (in.opcode == 99u /* OpImageWrite */ && n >= 1) {
+            mark_image(word(in, 0), false, true);
+        } else if (in.opcode == 100u /* OpImage */ && n >= 3) {
+            auto origin = image_objects.find(word(in, 2));
+            if (origin != image_objects.end()) image_objects[word(in, 1)] = origin->second;
         } else if ((in.opcode == OpAccessChain || in.opcode == OpInBoundsAccessChain) && n >= 3) {
             const uint32_t result = word(in, 1), base = word(in, 2);
             PointerAccess a;
@@ -556,11 +649,47 @@ DescriptorValidationReport validate_spirv_descriptor_interface(
         auto si = sets.find(var), bi = bindings.find(var);
         if (si == sets.end() || bi == bindings.end()) { add_malformed(report); continue; }
         report.descriptors.push_back({var, si->second, bi->second, descriptor_vars[var], stage,
-                                      required[var], dynamic[var]});
+                                      required[var], dynamic[var], read_vars.count(var) != 0,
+                                      written_vars.count(var) != 0});
     }
     std::sort(report.descriptors.begin(), report.descriptors.end(), [](const auto& a, const auto& b) {
         return a.set != b.set ? a.set < b.set : a.binding < b.binding;
     });
+
+    // Reflection depends only on immutable SPIR-V. Runtime addresses, sizes, metadata, and the
+    // expected stage/set are validated below on every call. Keeping those out of this cache lets a
+    // shader dispatched against different guest allocations reuse the expensive instruction/type
+    // walk without weakening any per-dispatch checks.
+    {
+        DescriptorReflectionCache& cache = descriptor_reflection_cache();
+        std::lock_guard lock(cache.mutex);
+        DescriptorReflectionCacheEntry entry;
+        entry.spirv = spirv;
+        entry.reflection = report;
+        entry.stage = stage;
+        entry.last_use = ++cache.use_clock;
+        constexpr uint64_t kCacheLimit = 64ull * 1024 * 1024;
+        constexpr size_t kMaxEntries = 4096;
+        const uint64_t entry_bytes = reflection_entry_bytes(entry);
+        auto collision = cache.entries.find(reflection_hash);
+        if (collision != cache.entries.end()) {
+            cache.bytes -= reflection_entry_bytes(collision->second);
+            cache.entries.erase(collision);
+        }
+        while (!cache.entries.empty() &&
+               (cache.entries.size() >= kMaxEntries || cache.bytes + entry_bytes > kCacheLimit)) {
+            auto oldest = cache.entries.begin();
+            for (auto it = std::next(cache.entries.begin()); it != cache.entries.end(); ++it)
+                if (it->second.last_use < oldest->second.last_use) oldest = it;
+            cache.bytes -= reflection_entry_bytes(oldest->second);
+            cache.entries.erase(oldest);
+        }
+        if (entry_bytes <= kCacheLimit) {
+            cache.bytes += entry_bytes;
+            cache.entries.emplace(reflection_hash, std::move(entry));
+        }
+    }
+    }
 
     if (stage != expected_stage)
         report.issues.push_back({DescriptorIssueCode::StageMismatch, true, expected_set, 0});

--- a/prosper/src/gpu/shader_resources.hpp
+++ b/prosper/src/gpu/shader_resources.hpp
@@ -84,6 +84,31 @@ constexpr bool native_float_storage_image(DataFormat format, uint32_t components
             (components == 3 && format == DataFormat::Float10_11_11));
 }
 
+// Native typed storage is only valid when the physical device advertises storage-image support
+// for the selected VkFormat. Keep the feature input abstract so the fallback policy can be tested
+// without requiring a particular Vulkan device or exposing Vulkan types in this shared header.
+constexpr bool native_float_storage_image_supported(DataFormat format, uint32_t components,
+                                                    bool srgb, bool storage_image_feature) {
+    return storage_image_feature && native_float_storage_image(format, components, srgb);
+}
+
+// Stable, Vulkan-independent bits used to carry per-format storage-image capabilities from the
+// device-owning frontend into the compute recompiler. Zero means the semantic format is not a native
+// typed-storage candidate; otherwise each exact VkFormat candidate has its own bit.
+constexpr uint32_t native_storage_format_support_bit(DataFormat format, uint32_t components) {
+    if (format == DataFormat::Unorm8)
+        return components == 1 ? 1u << 0 : components == 2 ? 1u << 1
+             : components == 4 ? 1u << 2 : 0u;
+    if (format == DataFormat::Float16)
+        return components == 1 ? 1u << 3 : components == 2 ? 1u << 4
+             : components == 4 ? 1u << 5 : 0u;
+    if (format == DataFormat::Float32)
+        return components == 1 ? 1u << 6 : components == 2 ? 1u << 7
+             : components == 4 ? 1u << 8 : 0u;
+    if (format == DataFormat::Float10_11_11 && components == 3) return 1u << 9;
+    return 0;
+}
+
 // IEEE-754 binary16 -> binary32 (handles subnormals, +/-inf, NaN). Used by the texture upload path to
 // convert a sampled Float16 surface to the RGBA8 the backend uploads (#290). Pure + testable.
 float half_to_float(uint16_t h);
@@ -316,6 +341,14 @@ struct SpirvDescriptorBinding {
     // the per-binding result to avoid seeding write-only outputs and reading back read-only inputs.
     bool readable = false;
     bool writable = false;
+    // Coordinate contract for sampled images. Normalized sampling (OpImageSample*/Gather) may bind a
+    // uniformly render-scaled image directly; texel-space access (OpImageFetch/Read) requires the
+    // descriptor's exact declared extent. A binding can use both, in which case exact extent wins.
+    bool normalized_sampling = false;
+    bool texel_access = false;
+    // Storage-image sampled type encoded by SPIR-V. This is the backend's authoritative choice
+    // between a native float VkFormat and the portable raw-uvec4 conversion path, including replay.
+    bool storage_float = false;
 };
 
 enum class DescriptorIssueCode : uint32_t {

--- a/prosper/src/gpu/shader_resources.hpp
+++ b/prosper/src/gpu/shader_resources.hpp
@@ -71,6 +71,19 @@ void rdna2_buffer_format(uint32_t fmt, DataFormat* out_fmt, uint32_t* out_compon
 // How many bytes one component of `format` occupies (0 for Unknown and block-compressed formats).
 uint32_t data_format_bytes(DataFormat f);
 
+// Formats whose storage-image conversion can be delegated exactly to a native Vulkan float image.
+// Loads return float32 components (with Vulkan's standard missing-channel defaults) and stores accept
+// float32 components, matching the PS5 image instruction's VGPR contract; the backing texels remain
+// at their native byte width. Three-channel optimal images are deliberately limited to packed
+// R11G11B10 because ordinary RGB8/RGB16/RGB32 storage support is not portable.
+constexpr bool native_float_storage_image(DataFormat format, uint32_t components, bool srgb) {
+    return !srgb &&
+           (((components == 1 || components == 2 || components == 4) &&
+             (format == DataFormat::Unorm8 || format == DataFormat::Float16 ||
+              format == DataFormat::Float32)) ||
+            (components == 3 && format == DataFormat::Float10_11_11));
+}
+
 // IEEE-754 binary16 -> binary32 (handles subnormals, +/-inf, NaN). Used by the texture upload path to
 // convert a sampled Float16 surface to the RGBA8 the backend uploads (#290). Pure + testable.
 float half_to_float(uint16_t h);
@@ -102,9 +115,9 @@ enum class ResourceClass : uint32_t {
     Texture,         // read by image_sample / image_load (sampled image + sampler)
     Sampler,         // paired with a Texture for image_sample
     StorageImage,    // read/written by image_load / image_store WITHOUT a sampler (compute copy/blit).
-                     // Bound as a Vulkan STORAGE_IMAGE; img_dim gives 1D/2D/3D. Our raw-32-bit-VGPR
-                     // model uses a uint-sampled storage image (Format=Unknown + read/write-without-
-                     // format), so texels move bit-exact (format reinterpretation lives in the descriptor).
+                     // Bound as a Vulkan STORAGE_IMAGE; img_dim gives 1D/2D/3D. Integer/packed formats
+                     // use uint texels plus host conversion; native four-channel float/UNORM formats
+                     // use float texels and Vulkan's descriptor conversion.
 };
 
 // One resource a shader accesses. FILLED BY THE FRONT-HALF from the game's real descriptors (the
@@ -298,6 +311,11 @@ struct SpirvDescriptorBinding {
     // runtime range may be addressed, so validation cannot derive an upper bound from SPIR-V alone.
     uint64_t required_bytes = 0;
     bool dynamic_access = false;
+    // Data access, distinct from merely loading the descriptor object. For buffers these follow
+    // pointer loads/stores; for images they follow OpImageRead/sample and OpImageWrite. Backends use
+    // the per-binding result to avoid seeding write-only outputs and reading back read-only inputs.
+    bool readable = false;
+    bool writable = false;
 };
 
 enum class DescriptorIssueCode : uint32_t {

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -784,6 +784,37 @@ inline const RenderVkCtx& render_vk_ctx() {
                 (r.subgroup_operations & VK_SUBGROUP_FEATURE_ARITHMETIC_BIT) != 0;
             shared.min_compute_subgroup_size = r.min_subgroup_size;
             shared.max_compute_subgroup_size = r.max_subgroup_size;
+            uint32_t queue_family_count = 0;
+            vkGetPhysicalDeviceQueueFamilyProperties(r.phys, &queue_family_count, nullptr);
+            std::vector<VkQueueFamilyProperties> queue_families(queue_family_count);
+            vkGetPhysicalDeviceQueueFamilyProperties(
+                r.phys, &queue_family_count, queue_families.data());
+            shared.compute_queue_supported = r.qfi < queue_families.size() &&
+                (queue_families[r.qfi].queueFlags & VK_QUEUE_COMPUTE_BIT) != 0;
+            const auto add_native_storage_format = [&](prosper::gpu::DataFormat format,
+                                                       uint32_t components,
+                                                       VkFormat vk_format) {
+                VkImageFormatProperties properties{};
+                constexpr VkImageUsageFlags usage = VK_IMAGE_USAGE_STORAGE_BIT |
+                    VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+                if (vkGetPhysicalDeviceImageFormatProperties(
+                        r.phys, vk_format, VK_IMAGE_TYPE_2D, VK_IMAGE_TILING_OPTIMAL,
+                        usage, 0, &properties) == VK_SUCCESS)
+                    shared.native_storage_format_support |=
+                        prosper::gpu::native_storage_format_support_bit(format, components);
+            };
+            add_native_storage_format(prosper::gpu::DataFormat::Unorm8, 1, VK_FORMAT_R8_UNORM);
+            add_native_storage_format(prosper::gpu::DataFormat::Unorm8, 2, VK_FORMAT_R8G8_UNORM);
+            add_native_storage_format(prosper::gpu::DataFormat::Unorm8, 4, VK_FORMAT_R8G8B8A8_UNORM);
+            add_native_storage_format(prosper::gpu::DataFormat::Float16, 1, VK_FORMAT_R16_SFLOAT);
+            add_native_storage_format(prosper::gpu::DataFormat::Float16, 2, VK_FORMAT_R16G16_SFLOAT);
+            add_native_storage_format(prosper::gpu::DataFormat::Float16, 4, VK_FORMAT_R16G16B16A16_SFLOAT);
+            add_native_storage_format(prosper::gpu::DataFormat::Float32, 1, VK_FORMAT_R32_SFLOAT);
+            add_native_storage_format(prosper::gpu::DataFormat::Float32, 2, VK_FORMAT_R32G32_SFLOAT);
+            add_native_storage_format(prosper::gpu::DataFormat::Float32, 4, VK_FORMAT_R32G32B32A32_SFLOAT);
+            add_native_storage_format(
+                prosper::gpu::DataFormat::Float10_11_11, 3,
+                VK_FORMAT_B10G11R11_UFLOAT_PACK32);
             // Present unification (#1270): advertise present adoption only when the instance is
             // surface-capable AND the device enabled VK_KHR_swapchain AND a present queue was resolved.
             shared.present_capable = r.present_surface_capable && r.present_swapchain_capable &&
@@ -1713,7 +1744,8 @@ struct PersistentDsSampled {
 };
 inline PersistentDsSampled find_persistent_ds_sampled(uint64_t addr, uint32_t width,
                                                       uint32_t height,
-                                                      uint32_t render_scale = 1) {
+                                                      uint32_t render_scale = 1,
+                                                      bool normalized_sampling = true) {
     if (!addr) return {};
     static const bool bridge_log = getenv("PROSPER_DSBRIDGE_LOG") != nullptr;
     // Prefer the most recently DEPTH-WRITTEN match: a surface re-keyed (D32 -> D32S8) keeps its
@@ -1722,7 +1754,7 @@ inline PersistentDsSampled find_persistent_ds_sampled(uint64_t addr, uint32_t wi
     uint64_t best_write = 0;
     for (auto& [key, image] : persistent_ds_cache()) {
         if (!prosper::frontend::rtt_sampled_extent_compatible(
-                width, height, key.w, key.h, render_scale))
+                width, height, key.w, key.h, render_scale, normalized_sampling))
             continue;
         if (key.dr != addr && key.dw != addr) continue;
         if (!image.depth_valid || !image.layout_initialized || !image.image) continue;

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -7,6 +7,7 @@
 #include "../src/gpu/gpu_capture.hpp"
 #include "../src/gpu/diagnostic_selectors.hpp"
 #include "../src/gpu/render_state.hpp"
+#include "../frontends/shared/rtt_scale.hpp"
 #include "../frontends/shared/vulkan_device_select.hpp"
 #include <algorithm>
 #include <array>
@@ -162,16 +163,27 @@ struct BackendColorTarget {
     bool load_existing = true;
     bool readback = true;
     VkFormat format = VK_FORMAT_UNDEFINED;
+    // MRT1 has an independent guest identity and lifetime. Keeping its contract beside color0 lets
+    // paired passes retain both attachments without changing the established single-target callers.
+    uint64_t persistent_id1 = 0;
+    bool load_existing1 = true;
+    bool readback1 = true;
+    VkFormat format1 = VK_FORMAT_UNDEFINED;
 };
 
 inline VkFormat backend_color_format(VkFormat format) {
-    return format == VK_FORMAT_R16G16B16A16_SFLOAT
-        ? VK_FORMAT_R16G16B16A16_SFLOAT
-        : VK_FORMAT_R8G8B8A8_UNORM;
+    if (format == VK_FORMAT_R16G16B16A16_SFLOAT)
+        return VK_FORMAT_R16G16B16A16_SFLOAT;
+    if (format == VK_FORMAT_R8_UNORM)
+        return VK_FORMAT_R8_UNORM;
+    return VK_FORMAT_R8G8B8A8_UNORM;
 }
 
 inline uint32_t backend_color_bytes_per_pixel(VkFormat format) {
-    return backend_color_format(format) == VK_FORMAT_R16G16B16A16_SFLOAT ? 8u : 4u;
+    format = backend_color_format(format);
+    if (format == VK_FORMAT_R16G16B16A16_SFLOAT) return 8u;
+    if (format == VK_FORMAT_R8_UNORM) return 1u;
+    return 4u;
 }
 
 struct BackendColorTargetStats {
@@ -763,6 +775,15 @@ inline const RenderVkCtx& render_vk_ctx() {
             // declaring a capability the device never enabled.
             shared.storage_image_read_without_format = feats.shaderStorageImageReadWithoutFormat;
             shared.storage_image_write_without_format = feats.shaderStorageImageWriteWithoutFormat;
+            shared.compute_subgroup_size_control = r.subgroup_size_control &&
+                (r.required_subgroup_size_stages & VK_SHADER_STAGE_COMPUTE_BIT) &&
+                (r.subgroup_stages & VK_SHADER_STAGE_COMPUTE_BIT);
+            shared.compute_subgroup_vote =
+                (r.subgroup_operations & VK_SUBGROUP_FEATURE_VOTE_BIT) != 0;
+            shared.compute_subgroup_arithmetic =
+                (r.subgroup_operations & VK_SUBGROUP_FEATURE_ARITHMETIC_BIT) != 0;
+            shared.min_compute_subgroup_size = r.min_subgroup_size;
+            shared.max_compute_subgroup_size = r.max_subgroup_size;
             // Present unification (#1270): advertise present adoption only when the instance is
             // surface-capable AND the device enabled VK_KHR_swapchain AND a present queue was resolved.
             shared.present_capable = r.present_surface_capable && r.present_swapchain_capable &&
@@ -1687,9 +1708,12 @@ persistent_ds_cache() {
 struct PersistentDsSampled {
     PersistentDsImage* image = nullptr;
     VkFormat format = VK_FORMAT_UNDEFINED;
+    uint32_t width = 0;
+    uint32_t height = 0;
 };
 inline PersistentDsSampled find_persistent_ds_sampled(uint64_t addr, uint32_t width,
-                                                      uint32_t height) {
+                                                      uint32_t height,
+                                                      uint32_t render_scale = 1) {
     if (!addr) return {};
     static const bool bridge_log = getenv("PROSPER_DSBRIDGE_LOG") != nullptr;
     // Prefer the most recently DEPTH-WRITTEN match: a surface re-keyed (D32 -> D32S8) keeps its
@@ -1697,11 +1721,13 @@ inline PersistentDsSampled find_persistent_ds_sampled(uint64_t addr, uint32_t wi
     PersistentDsSampled best{};
     uint64_t best_write = 0;
     for (auto& [key, image] : persistent_ds_cache()) {
-        if (key.w != width || key.h != height) continue;
+        if (!prosper::frontend::rtt_sampled_extent_compatible(
+                width, height, key.w, key.h, render_scale))
+            continue;
         if (key.dr != addr && key.dw != addr) continue;
         if (!image.depth_valid || !image.layout_initialized || !image.image) continue;
         if (!best.image || image.last_depth_write > best_write) {
-            best = {&image, static_cast<VkFormat>(key.fmt)};
+            best = {&image, static_cast<VkFormat>(key.fmt), key.w, key.h};
             best_write = image.last_depth_write;
         }
     }
@@ -1709,8 +1735,9 @@ inline PersistentDsSampled find_persistent_ds_sampled(uint64_t addr, uint32_t wi
         if (bridge_log) {
             static int hits = 0;
             if (hits++ < 8)
-                fprintf(stderr, "[dsbridge] HIT addr=0x%llx %ux%u fmt=%u\n",
-                        (unsigned long long)addr, width, height, (unsigned)best.format);
+                fprintf(stderr, "[dsbridge] HIT addr=0x%llx requested=%ux%u image=%ux%u fmt=%u\n",
+                        (unsigned long long)addr, width, height, best.width, best.height,
+                        (unsigned)best.format);
         }
         return best;
     }
@@ -2444,7 +2471,14 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     const VkFormat FMT = color_target && color_target->format != VK_FORMAT_UNDEFINED
         ? backend_color_format(color_target->format)
         : first_pipeline_format(false);
-    const VkFormat FMT1 = use_color1 ? first_pipeline_format(true) : VK_FORMAT_UNDEFINED;
+    const VkFormat FMT1 = use_color1
+        ? (color_target && color_target->format1 != VK_FORMAT_UNDEFINED
+               ? backend_color_format(color_target->format1)
+               : first_pipeline_format(true))
+        : VK_FORMAT_UNDEFINED;
+    const bool persistent_color1_enabled = persistent_color_targets_enabled && use_color1 &&
+                                           color_target && color_target->persistent_id1 &&
+                                           color_target->persistent_id1 != color_target->persistent_id;
     const VkDeviceSize bytes = static_cast<VkDeviceSize>(W) * H *
                                backend_color_bytes_per_pixel(FMT);
     const VkDeviceSize bytes1 = use_color1
@@ -2792,30 +2826,100 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                 (int)color_target->load_existing, seed_rgba != nullptr,
                 (int)color_target->readback, (int)load_cached_color);
 
-    VkImage img1 = VK_NULL_HANDLE; VkDeviceMemory imem1 = VK_NULL_HANDLE;
-    VkImageView view1 = VK_NULL_HANDLE;
-    if (use_color1) {
+    bool persistent_color1 = persistent_color1_enabled;
+    PersistentColorTargetKey color_key1{};
+    PersistentColorTargetImage* cached_color1 = nullptr;
+    if (persistent_color1) {
+        color_key1 = {color_target->persistent_id1, W, H, FMT1};
+        auto [found, inserted] = persistent_color_target_cache().try_emplace(color_key1);
+        cached_color1 = &found->second;
+        cached_color1->last_use = color_target_generation;
+    }
+
+    VkImage img1 = cached_color1 ? cached_color1->image : VK_NULL_HANDLE;
+    VkDeviceMemory imem1 = cached_color1 ? cached_color1->memory : VK_NULL_HANDLE;
+    VkImageView view1 = cached_color1 ? cached_color1->view : VK_NULL_HANDLE;
+    if (use_color1 && !img1) {
         VkImageCreateInfo color1_ci{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
         color1_ci.imageType = VK_IMAGE_TYPE_2D; color1_ci.format = FMT1;
         color1_ci.extent = {W, H, 1}; color1_ci.mipLevels = 1; color1_ci.arrayLayers = 1;
         color1_ci.samples = VK_SAMPLE_COUNT_1_BIT; color1_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
         color1_ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
-                          (seed_rgba1 ? VK_IMAGE_USAGE_TRANSFER_DST_BIT : 0u);
+                          (persistent_color1 ? VK_IMAGE_USAGE_SAMPLED_BIT : 0u) |
+                          ((seed_rgba1 || persistent_color1)
+                               ? VK_IMAGE_USAGE_TRANSFER_DST_BIT : 0u);
         vkCreateImage(dev, &color1_ci, nullptr, &img1);
+        if (!img1) {
+            if (cached_color1) persistent_color_target_cache().erase(color_key1);
+            return out;
+        }
         VkMemoryRequirements color1_requirements{};
         vkGetImageMemoryRequirements(dev, img1, &color1_requirements);
         VkMemoryAllocateInfo color1_allocation{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO};
         color1_allocation.allocationSize = color1_requirements.size;
         color1_allocation.memoryTypeIndex = pick(color1_requirements.memoryTypeBits, 0);
-        imem1 = allocate_transient_render_memory(
-            dev, color1_allocation.allocationSize, color1_allocation.memoryTypeIndex);
-        vkBindImageMemory(dev, img1, imem1, 0);
+        if (persistent_color1) {
+            const VkDeviceSize limit = persistent_color_target_limit();
+            while (!avoid_cache_eviction &&
+                   (persistent_color_target_cache().size() >
+                            persistent_color_target_count_limit() ||
+                    color1_requirements.size > limit ||
+                    persistent_color_target_bytes() > limit - color1_requirements.size) &&
+                   evict_persistent_color_target(ctx, color_target_generation)) {}
+            if (color1_requirements.size <= limit &&
+                persistent_color_target_cache().size() <=
+                    persistent_color_target_count_limit() &&
+                persistent_color_target_bytes() <= limit - color1_requirements.size &&
+                vkAllocateMemory(dev, &color1_allocation, nullptr, &imem1) == VK_SUCCESS) {
+                cached_color1->bytes = color1_requirements.size;
+                persistent_color_target_bytes() += color1_requirements.size;
+            } else {
+                vkDestroyImage(dev, img1, nullptr);
+                img1 = VK_NULL_HANDLE;
+                persistent_color_target_cache().erase(color_key1);
+                cached_color1 = nullptr;
+                persistent_color1 = false;
+                color1_ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT |
+                                  VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
+                                  (seed_rgba1 ? VK_IMAGE_USAGE_TRANSFER_DST_BIT : 0u);
+                vkCreateImage(dev, &color1_ci, nullptr, &img1);
+                if (!img1) return out;
+                vkGetImageMemoryRequirements(dev, img1, &color1_requirements);
+                color1_allocation.allocationSize = color1_requirements.size;
+                color1_allocation.memoryTypeIndex = pick(color1_requirements.memoryTypeBits, 0);
+            }
+        }
+        if (!imem1)
+            imem1 = allocate_transient_render_memory(
+                dev, color1_allocation.allocationSize, color1_allocation.memoryTypeIndex);
         VkImageViewCreateInfo color1_view_ci{VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO};
         color1_view_ci.image = img1; color1_view_ci.viewType = VK_IMAGE_VIEW_TYPE_2D;
         color1_view_ci.format = FMT1;
         color1_view_ci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
-        vkCreateImageView(dev, &color1_view_ci, nullptr, &view1);
+        const bool color1_ready = imem1 &&
+            vkBindImageMemory(dev, img1, imem1, 0) == VK_SUCCESS &&
+            vkCreateImageView(dev, &color1_view_ci, nullptr, &view1) == VK_SUCCESS && view1;
+        if (!color1_ready) {
+            if (view1) vkDestroyImageView(dev, view1, nullptr);
+            vkDestroyImage(dev, img1, nullptr);
+            if (cached_color1) {
+                if (cached_color1->bytes)
+                    persistent_color_target_bytes() -= cached_color1->bytes;
+                if (imem1) vkFreeMemory(dev, imem1, nullptr);
+                persistent_color_target_cache().erase(color_key1);
+            } else if (imem1) {
+                release_transient_render_memory(dev, imem1);
+            }
+            return out;
+        }
+        if (cached_color1) {
+            cached_color1->image = img1;
+            cached_color1->memory = imem1;
+            cached_color1->view = view1;
+        }
     }
+    const bool load_cached_color1 = cached_color1 && cached_color1->valid &&
+                                    color_target->load_existing1 && !seed_rgba1;
 
     if (use_ds && !dimg) {
         VkImageCreateInfo dci{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
@@ -2853,13 +2957,15 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                                           : VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
     if (use_color1) {
         att[1].format = FMT1; att[1].samples = VK_SAMPLE_COUNT_1_BIT;
-        att[1].loadOp = seed_rgba1 ? VK_ATTACHMENT_LOAD_OP_LOAD : VK_ATTACHMENT_LOAD_OP_CLEAR;
+        att[1].loadOp = (seed_rgba1 || load_cached_color1)
+            ? VK_ATTACHMENT_LOAD_OP_LOAD : VK_ATTACHMENT_LOAD_OP_CLEAR;
         att[1].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
         att[1].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
         att[1].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-        att[1].initialLayout = seed_rgba1 ? VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL
-                                          : VK_IMAGE_LAYOUT_UNDEFINED;
-        att[1].finalLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+        att[1].initialLayout = (seed_rgba1 || load_cached_color1)
+            ? VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL : VK_IMAGE_LAYOUT_UNDEFINED;
+        att[1].finalLayout = persistent_color1 ? VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL
+                                               : VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
     }
     att[ds_attachment].format = DFMT; att[ds_attachment].samples = VK_SAMPLE_COUNT_1_BIT;
     // A guest-identified DS surface survives calls. New attachments get a defined initial value;
@@ -3603,8 +3709,11 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                         upload.key = texture_key;
                         if (share_texture_uploads) texture_upload_indices.emplace(texture_key, upload_index);
 
-                        const bool target_feedback = persistent_color &&
-                            r.persistent_render_target_id == color_target->persistent_id;
+                        const bool target_feedback =
+                            (persistent_color &&
+                             r.persistent_render_target_id == color_target->persistent_id) ||
+                            (persistent_color1 &&
+                             r.persistent_render_target_id == color_target->persistent_id1);
                         if (!r.is_storage_image && persistent_color_targets_enabled && !target_feedback &&
                             r.persistent_render_target_id && r.img_dim == 1) {
                             if (auto* target = find_persistent_color_target(
@@ -4369,10 +4478,13 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     }
 
     const auto timing_draws_ready = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
-    const VkDeviceSize readback_bytes = bytes + bytes1;
-    // MRT1 is currently retained in the live renderer's CPU RTT cache, so a paired pass always
-    // reads both attachments back. Single-target passes keep the persistent no-readback fast path.
-    const bool readback_requested = use_color1 || !persistent_color || color_target->readback;
+    const bool readback_color0 = !persistent_color || color_target->readback;
+    const bool readback_color1 = use_color1 &&
+        (!persistent_color1 || color_target->readback1);
+    const bool readback_requested = readback_color0 || readback_color1;
+    const VkDeviceSize readback_color1_offset = readback_color0 ? bytes : 0;
+    const VkDeviceSize readback_bytes = (readback_color0 ? bytes : 0) +
+                                        (readback_color1 ? bytes1 : 0);
     VkBuffer rb = VK_NULL_HANDLE;
     VkDeviceMemory bmem = VK_NULL_HANDLE;
     if (readback_requested) {
@@ -4411,6 +4523,24 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         // A previous target pass may be an earlier command buffer in the same queue submission.
         // Command-buffer order does not itself make its attachment writes visible, so include the
         // producer access/stage as well as the layouts in which an already-flushed target can rest.
+        load.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT |
+                             VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_TRANSFER_READ_BIT;
+        load.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT |
+                             VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+        vkCmdPipelineBarrier(cmd,
+                             VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT |
+                                 VK_PIPELINE_STAGE_VERTEX_SHADER_BIT |
+                                 VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT |
+                                 VK_PIPELINE_STAGE_TRANSFER_BIT,
+                             VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+                             0, 0, nullptr, 0, nullptr, 1, &load);
+    }
+    if (load_cached_color1) {
+        VkImageMemoryBarrier load{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
+        load.oldLayout = cached_color1->layout;
+        load.newLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+        load.image = img1;
+        load.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
         load.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT |
                              VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_TRANSFER_READ_BIT;
         load.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT |
@@ -4778,11 +4908,12 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     // any later command buffer in the queue can sample or LOAD them without relying on driver-wide
     // serialization. The final render-pass layouts are already correct; these same-layout barriers
     // supply the missing availability/visibility dependency.
-    if (persistent_color && !readback_requested) {
+    auto publish_persistent_color = [&](bool persistent, bool readback, VkImage image) {
+        if (!persistent || readback) return;
         VkImageMemoryBarrier color_ready{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
         color_ready.oldLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
         color_ready.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-        color_ready.image = img;
+        color_ready.image = image;
         color_ready.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
         color_ready.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
         color_ready.dstAccessMask = VK_ACCESS_SHADER_READ_BIT |
@@ -4793,7 +4924,9 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                                  VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT |
                                  VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
                              0, 0, nullptr, 0, nullptr, 1, &color_ready);
-    }
+    };
+    publish_persistent_color(persistent_color, readback_color0, img);
+    publish_persistent_color(persistent_color1, readback_color1, img1);
     if (persistent_ds) {
         VkImageMemoryBarrier ds_ready{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
         ds_ready.oldLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
@@ -4833,32 +4966,38 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                              0, 0, nullptr, 0, nullptr, 1, &to_ds);
     }
     if (readback_requested) {
-        if (persistent_color) {
+        auto transition_color_to_readback = [&](bool persistent, bool readback, VkImage image) {
+            if (!persistent || !readback) return;
             VkImageMemoryBarrier to_readback{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
             to_readback.oldLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
             to_readback.newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
-            to_readback.image = img;
+            to_readback.image = image;
             to_readback.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
             to_readback.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
             to_readback.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
             vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
                                  VK_PIPELINE_STAGE_TRANSFER_BIT,
                                  0, 0, nullptr, 0, nullptr, 1, &to_readback);
-        }
+        };
+        transition_color_to_readback(persistent_color, readback_color0, img);
+        transition_color_to_readback(persistent_color1, readback_color1, img1);
         VkBufferImageCopy cp{};
         cp.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
         cp.imageExtent = {W, H, 1};
-        vkCmdCopyImageToBuffer(cmd, img, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, rb, 1, &cp);
-        if (use_color1) {
-            VkBufferImageCopy cp1 = cp; cp1.bufferOffset = bytes;
+        if (readback_color0)
+            vkCmdCopyImageToBuffer(
+                cmd, img, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, rb, 1, &cp);
+        if (readback_color1) {
+            VkBufferImageCopy cp1 = cp; cp1.bufferOffset = readback_color1_offset;
             vkCmdCopyImageToBuffer(
                 cmd, img1, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, rb, 1, &cp1);
         }
-        if (persistent_color) {
+        auto restore_persistent_color = [&](bool persistent, bool readback, VkImage image) {
+            if (!persistent || !readback) return;
             VkImageMemoryBarrier to_sample{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
             to_sample.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
             to_sample.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-            to_sample.image = img;
+            to_sample.image = image;
             to_sample.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
             to_sample.srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
             to_sample.dstAccessMask = VK_ACCESS_SHADER_READ_BIT |
@@ -4869,7 +5008,9 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                                      VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT |
                                      VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
                                  0, 0, nullptr, 0, nullptr, 1, &to_sample);
-        }
+        };
+        restore_persistent_color(persistent_color, readback_color0, img);
+        restore_persistent_color(persistent_color1, readback_color1, img1);
     }
     vkEndCommandBuffer(cmd);
 
@@ -4947,6 +5088,13 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         });
         cached_color->valid = true;
         cached_color->layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    }
+    if (cached_color1) {
+        active_submission.add_failure_cleanup([cached_color1]() {
+            cached_color1->valid = false;
+        });
+        cached_color1->valid = true;
+        cached_color1->layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
     }
     const bool flush_now = !submission_batch || readback_requested || flush_submission_batch;
     BackendSubmissionBatchResult batch_result;
@@ -5159,10 +5307,11 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         const auto* readback = static_cast<const uint8_t*>(mp);
         // A range assignment constructs directly from the mapped pixels. resize()+memcpy first zeroed the
         // entire 8.3 MiB 1080p vector even though every byte was immediately overwritten.
-        out.assign(readback, readback + static_cast<size_t>(bytes));
-        if (use_color1)
-            out_rgba1->assign(readback + static_cast<size_t>(bytes),
-                              readback + static_cast<size_t>(readback_bytes));
+        if (readback_color0)
+            out.assign(readback, readback + static_cast<size_t>(bytes));
+        if (readback_color1)
+            out_rgba1->assign(readback + static_cast<size_t>(readback_color1_offset),
+                              readback + static_cast<size_t>(readback_color1_offset + bytes1));
         vkUnmapMemory(dev, bmem);
         color_target_stats.readbacks = persistent_color ? 1 : 0;
     }
@@ -5297,6 +5446,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     resource_reuse_stats.persistent_pipeline_layout_entries =
         persistent_pipeline_layouts.size();
     const bool transient_color = cached_color == nullptr;
+    const bool transient_color1 = use_color1 && cached_color1 == nullptr;
     const bool transient_ds = use_ds && cached_ds == nullptr;
     const RenderVkCtx* ctx_ptr = &ctx;
     active_submission.add_cleanup(
@@ -5307,7 +5457,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
          shared_buffers = std::move(shared_buffers),
          shared_buffer_arenas = std::move(shared_buffer_arenas),
          texture_uploads = std::move(texture_uploads), seedbuf, seedmem, seedbuf1, seedmem1,
-         rb, bmem, fb, rp, transient_color, view, img, imem, use_color1, view1, img1,
+         rb, bmem, fb, rp, transient_color, view, img, imem, transient_color1, view1, img1,
          imem1, transient_ds, dview, dimg, dmem, ds_stats_pool, ds_occ_pool,
          geom_buf, geom_mem, geom_counter, geom_counter_mem, ctx_ptr,
          color_target_generation]() mutable {
@@ -5378,7 +5528,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                 vkDestroyImage(dev, img, nullptr);
                 release_transient_render_memory(dev, imem);
             }
-            if (use_color1) {
+            if (transient_color1) {
                 vkDestroyImageView(dev, view1, nullptr);
                 vkDestroyImage(dev, img1, nullptr);
                 release_transient_render_memory(dev, imem1);
@@ -5734,8 +5884,14 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         const BackendColorTarget* segment_target_ptr = nullptr;
         if (color_target) {
             segment_target = *color_target;
-            if (begin) segment_target.load_existing = true;
-            if (!final) segment_target.readback = false;
+            if (begin) {
+                segment_target.load_existing = true;
+                segment_target.load_existing1 = true;
+            }
+            if (!final) {
+                segment_target.readback = false;
+                segment_target.readback1 = false;
+            }
             segment_target_ptr = &segment_target;
         }
         std::vector<uint8_t> intermediate_color1;

--- a/prosper/tests/test_game_compute.cpp
+++ b/prosper/tests/test_game_compute.cpp
@@ -144,6 +144,13 @@ int main() {
     // re-proven within N fast-skips instead of trusting a stale "covers every texel" verdict forever.
     {
         using prosper::frontend::seed_reprove_due;
+        using prosper::frontend::dispatch_has_enough_threads_for_texels;
+        CHECK(dispatch_has_enough_threads_for_texels(15360, 135, 1, 1920, 1080, 1),
+              "vectorized/swizzled dispatch with one invocation per texel can prove coverage");
+        CHECK(!dispatch_has_enough_threads_for_texels(1919, 1080, 1, 1920, 1080, 1),
+              "dispatch with fewer total invocations than texels cannot prove coverage");
+        CHECK(!dispatch_has_enough_threads_for_texels(0, 1080, 1, 1920, 1080, 1),
+              "degenerate dispatch cannot prove coverage");
         uint32_t s = 0;
         CHECK(!seed_reprove_due(s, 0) && !seed_reprove_due(s, 0) && s == 0,
               "interval 0 never re-proves and leaves the counter untouched (prove-once)");
@@ -579,6 +586,12 @@ int main() {
         CHECK(run_format_copy(DataFormat::Uint8, 4, 4, s) == s,
               "Uint8x4 storage copy round-trips guest bytes bit-exact (#590)");
     }
+    {   // Unorm8 x2: native RG8 storage keeps its two-byte texel width and conversion contract
+        std::vector<uint8_t> s(W * 2);
+        for (uint32_t i = 0; i < s.size(); i++) s[i] = (uint8_t)(i * 71 + 11);
+        CHECK(run_format_copy(DataFormat::Unorm8, 2, 2, s) == s,
+              "Unorm8x2 storage copy round-trips native RG8 texels bit-exact (#590)");
+    }
     {   // Uint16 x1 (fmt=7): 16-bit integer widen on load, low-16-bit truncate on store
         std::vector<uint8_t> s(W * 2);
         for (uint32_t i = 0; i < s.size(); i++) s[i] = (uint8_t)(i * 29 + 3);
@@ -590,6 +603,20 @@ int main() {
         for (uint32_t t = 0; t < W; t++) { uint32_t p = t * 2654435761u; std::memcpy(&s[t * 4], &p, 4); }
         CHECK(run_format_copy(DataFormat::Unorm2_10_10_10, 4, 4, s) == s,
               "Unorm2_10_10_10 storage copy round-trips packed guest word bit-exact (#590)");
+    }
+    {   // R11G11B10 UFLOAT: native float storage conversion must preserve quantized finite texels
+        std::vector<uint8_t> s(W * 4);
+        for (uint32_t t = 0; t < W; ++t) {
+            const float r = static_cast<float>((t * 17u) % 97u) / 13.0f;
+            const float g = static_cast<float>((t * 29u) % 89u) / 11.0f;
+            const float b = static_cast<float>((t * 43u) % 83u) / 9.0f;
+            const uint32_t packed = static_cast<uint32_t>(float_to_f11(r)) |
+                                    (static_cast<uint32_t>(float_to_f11(g)) << 11) |
+                                    (static_cast<uint32_t>(float_to_f10(b)) << 22);
+            std::memcpy(&s[t * 4], &packed, sizeof(packed));
+        }
+        CHECK(run_format_copy(DataFormat::Float10_11_11, 3, 4, s) == s,
+              "R11G11B10 storage copy round-trips native packed texels bit-exact (#590)");
     }
 
     // The backend publishes ordinary tiled texels, not hardware-compressed blocks. Prove that a

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -484,6 +484,16 @@ int main() {
            got17d.size()==N?got17d[127]:-1);
     CHECK(got17d.size()==N && bad17d==0,
           "CFG dispatcher emulates a 64-lane wave across narrower Vulkan subgroups");
+    ComputeShaderConfig native_cfg17d;
+    native_cfg17d.local_x = 64;
+    native_cfg17d.wave_size = 64;
+    native_cfg17d.native_subgroup_size = 64;
+    const std::vector<uint32_t> native_spv17d = recompile_compute(
+        code17d, std::size(code17d), nullptr, native_cfg17d);
+    CHECK(!native_spv17d.empty() && count_spirv_opcode(native_spv17d, 335) >= 2,
+          "exact-wave CFG dispatcher lowers votes and liveness to native subgroup-any");
+    CHECK(count_spirv_opcode(native_spv17d, 224) == 0,
+          "exact-wave CFG dispatcher emits no workgroup control barrier");
 
     // Kernel 17d2: Astro's mask-priority sequence compares a VOPC-produced SGPR pair against zero,
     // then uses that wave-uniform SCC in s_cselect_b64.  Keep the irreducible prefix so this exercises
@@ -538,6 +548,11 @@ int main() {
         if (std::fabs(got17e[i] - static_cast<float>(i % 64)) > 1e-3f) ++bad17e;
     CHECK(got17e.size() == N && bad17e == 0,
           "#825: CFG dispatcher synchronizes MBCNT across each emulated wave64");
+    const std::vector<uint32_t> native_spv17e = recompile_compute(
+        code17e, std::size(code17e), nullptr, native_cfg17d);
+    CHECK(!native_spv17e.empty() && count_spirv_opcode(native_spv17e, 349) >= 1 &&
+              count_spirv_opcode(native_spv17e, 224) == 0,
+          "exact-wave CFG MBCNT uses subgroup scans without workgroup barriers");
 
     // Kernel 17f: DS_APPEND in the same generic dispatcher. The LDS initial value is intentionally
     // unspecified; this test verifies that the generated module executes to completion with the
@@ -555,6 +570,11 @@ int main() {
     std::vector<float> got17f = prosper::test::run_compute(spv17f, in17d, N, N);
     CHECK(got17f.size() == N,
           "#825: Vulkan executes dispatcher DS_APPEND with uniform barriers");
+    const std::vector<uint32_t> native_spv17f = recompile_compute(
+        code17f, std::size(code17f), nullptr, native_cfg17d);
+    CHECK(!native_spv17f.empty() && count_spirv_opcode(native_spv17f, 349) >= 3 &&
+              count_spirv_opcode(native_spv17f, 224) == 0,
+          "exact-wave CFG DS_APPEND uses subgroup reduction/broadcast without barriers");
 
     // Kernel 18: the REAL if-then idiom with a forward branch. v3=7; vcc=(u0>u1);
     // s_and_saveexec_b64 s[0:1],vcc (save exec, exec=vcc); s_cbranch_execz skip (forward -> no-op);

--- a/prosper/tests/test_shader_recompile_cache.cpp
+++ b/prosper/tests/test_shader_recompile_cache.cpp
@@ -434,6 +434,154 @@ int main() {
               changed_compute != direct_compute && stats.misses == 2 && stats.hits == 1,
           "compute cache reuses push-constant variants and separates launch-specialized modules");
 
+    // Resource descriptor fields that specialize SPIR-V must participate in the cache identity.
+    // Storage-image sRGB state changes whether the module declares a native float image or the raw
+    // uint-channel fallback, even when the guest code and every binding/provenance field are equal.
+    clear_shader_recompile_cache();
+    static const uint32_t kStorageCompute[] = {
+        0x7e080300u, 0xf0000f00u, 0x00000004u, 0xbf8c3f70u,
+        0xf0200f00u, 0x00020004u, 0xbf810000u,
+    };
+    ShaderResourceTable storage_table;
+    for (uint32_t i = 0; i < 2; ++i) {
+        ShaderResource image;
+        image.cls = ResourceClass::StorageImage;
+        image.format = DataFormat::Float32;
+        image.num_components = 4;
+        image.binding = 4 + i;
+        image.sgpr_base = i * 8;
+        storage_table.resources.push_back(image);
+    }
+    ComputeShaderConfig storage_config;
+    storage_config.user_sgprs.resize(16);
+    storage_config.local_x = 64;
+    storage_config.native_storage_format_support =
+        native_storage_format_support_bit(DataFormat::Float32, 4);
+    uint64_t native_storage_identity = 0;
+    const auto native_storage = recompile_compute_shader_cached(
+        kStorageCompute, std::size(kStorageCompute), &storage_table, storage_config,
+        &native_storage_identity);
+    storage_config.native_storage_format_support = 0;
+    uint64_t raw_storage_identity = 0;
+    const auto raw_storage = recompile_compute_shader_cached(
+        kStorageCompute, std::size(kStorageCompute), &storage_table, storage_config,
+        &raw_storage_identity);
+    storage_config.native_storage_format_support =
+        native_storage_format_support_bit(DataFormat::Float32, 4);
+    storage_table.resources[0].srgb = true;
+    uint64_t srgb_storage_identity = 0;
+    const auto srgb_storage = recompile_compute_shader_cached(
+        kStorageCompute, std::size(kStorageCompute), &storage_table, storage_config,
+        &srgb_storage_identity);
+    storage_table.resources[0].srgb = false;
+    uint64_t repeated_storage_identity = 0;
+    const auto repeated_storage = recompile_compute_shader_cached(
+        kStorageCompute, std::size(kStorageCompute), &storage_table, storage_config,
+        &repeated_storage_identity);
+    stats = shader_recompile_cache_stats();
+    const auto native_report = validate_spirv_descriptor_interface(
+        native_storage, &storage_table, 0, SpirvShaderStage::Compute, false);
+    const auto raw_report = validate_spirv_descriptor_interface(
+        raw_storage, &storage_table, 0, SpirvShaderStage::Compute, false);
+    CHECK(!native_storage.empty() && !raw_storage.empty() && !srgb_storage.empty() &&
+              native_storage != raw_storage && native_storage != srgb_storage &&
+              repeated_storage == native_storage &&
+              native_storage_identity != 0 && raw_storage_identity != 0 &&
+              srgb_storage_identity != 0 &&
+              native_storage_identity != srgb_storage_identity &&
+              native_storage_identity != raw_storage_identity &&
+              repeated_storage_identity == native_storage_identity &&
+              native_report.descriptors.size() == 2 &&
+              native_report.descriptors[0].storage_float &&
+              raw_report.descriptors.size() == 2 &&
+              !raw_report.descriptors[0].storage_float &&
+              stats.misses == 3 && stats.hits == 1 && stats.entries == 3,
+          "compute cache separates device-gated typed storage from the raw fallback and sRGB state");
+
+    // Manual shadow comparison bakes the enable, compare op, filter mode, address modes, and border
+    // color into SPIR-V. In particular depth_compare=false must not reuse a previously successful
+    // module: that descriptor contract is supposed to reject this comparison-sample shader.
+    clear_shader_recompile_cache();
+    static const uint32_t kShadowPs[] = {
+        0xc8080000u, 0xc8090001u, 0xc80c0100u, 0xc80d0101u,
+        0x7e0202f0u, 0xf0bc0108u, 0x00820401u,
+        0xf800080fu, 0x07060504u, 0xbf810000u,
+    };
+    ShaderResource shadow;
+    shadow.cls = ResourceClass::Texture;
+    shadow.format = DataFormat::Unorm8;
+    shadow.num_components = 4;
+    shadow.binding = 4;
+    shadow.sgpr_base = 8;
+    shadow.depth_compare = true;
+    shadow.depth_compare_func = 4;
+    shadow.mag_filter = 0;
+    ShaderResourceTable shadow_table;
+    shadow_table.resources.push_back(shadow);
+    uint64_t shadow_identity = 0, shadow_repeat_identity = 0, disabled_identity = 0;
+    uint64_t function_identity = 0, filter_identity = 0, address_identity = 0, border_identity = 0;
+    const auto shadow_spv = recompile_graphics_shader_cached(
+        ShaderProgramStage::Fragment, kShadowPs, std::size(kShadowPs), &shadow_table,
+        nullptr, nullptr, &shadow_identity);
+    const auto shadow_repeat = recompile_graphics_shader_cached(
+        ShaderProgramStage::Fragment, kShadowPs, std::size(kShadowPs), &shadow_table,
+        nullptr, nullptr, &shadow_repeat_identity);
+    shadow_table.resources[0].depth_compare = false;
+    const auto disabled_shadow = recompile_graphics_shader_cached(
+        ShaderProgramStage::Fragment, kShadowPs, std::size(kShadowPs), &shadow_table,
+        nullptr, nullptr, &disabled_identity);
+    shadow_table.resources[0].depth_compare = true;
+    shadow_table.resources[0].depth_compare_func = 1;
+    const auto function_shadow = recompile_graphics_shader_cached(
+        ShaderProgramStage::Fragment, kShadowPs, std::size(kShadowPs), &shadow_table,
+        nullptr, nullptr, &function_identity);
+    shadow_table.resources[0].mag_filter = 1;
+    const auto filter_shadow = recompile_graphics_shader_cached(
+        ShaderProgramStage::Fragment, kShadowPs, std::size(kShadowPs), &shadow_table,
+        nullptr, nullptr, &filter_identity);
+    shadow_table.resources[0].addr_uvw[0] = 6;
+    const auto address_shadow = recompile_graphics_shader_cached(
+        ShaderProgramStage::Fragment, kShadowPs, std::size(kShadowPs), &shadow_table,
+        nullptr, nullptr, &address_identity);
+    shadow_table.resources[0].border_color_type = 2;
+    const auto border_shadow = recompile_graphics_shader_cached(
+        ShaderProgramStage::Fragment, kShadowPs, std::size(kShadowPs), &shadow_table,
+        nullptr, nullptr, &border_identity);
+    stats = shader_recompile_cache_stats();
+    CHECK(!shadow_spv.empty() && shadow_repeat == shadow_spv && disabled_shadow.empty() &&
+              !function_shadow.empty() && !filter_shadow.empty() && !address_shadow.empty() &&
+              !border_shadow.empty() && shadow_identity == shadow_repeat_identity &&
+              shadow_identity != function_identity && function_identity != filter_identity &&
+              filter_identity != address_identity && address_identity != border_identity &&
+              stats.misses == 6 && stats.hits == 1 && stats.entries == 6,
+          "shader cache separates every manual shadow-comparison codegen field");
+
+    // A FLAT-window's base push-constant index is embedded in the module. Keep it in the key even
+    // though both variants use the same binding and exact fetch PC.
+    clear_shader_recompile_cache();
+    static const uint32_t kFlatCompute[] = {
+        0xd70f6a01u, 0x00020c0cu, 0x50041af9u, 0x86860680u,
+        0xdc200000u, 0x007d0001u, 0xbf810000u,
+    };
+    ComputeShaderConfig flat_config;
+    flat_config.user_sgprs.resize(16);
+    ShaderResource flat_window;
+    flat_window.cls = ResourceClass::ConstantBuffer;
+    flat_window.binding = 4;
+    flat_window.fetch_pc = 4;
+    flat_window.flat_base_sgpr = 12;
+    ShaderResourceTable flat_table;
+    flat_table.resources.push_back(flat_window);
+    const auto flat_s12 = recompile_compute_shader_cached(
+        kFlatCompute, std::size(kFlatCompute), &flat_table, flat_config);
+    flat_table.resources[0].flat_base_sgpr = 10;
+    const auto flat_s10 = recompile_compute_shader_cached(
+        kFlatCompute, std::size(kFlatCompute), &flat_table, flat_config);
+    stats = shader_recompile_cache_stats();
+    CHECK(!flat_s12.empty() && !flat_s10.empty() && flat_s12 != flat_s10 &&
+              stats.misses == 2 && stats.hits == 0,
+          "compute cache separates the FLAT-window push-constant base SGPR");
+
     if (failures) {
         std::printf("== FAIL: %d ==\n", failures);
         return 1;

--- a/prosper/tests/test_shader_recompile_cache.cpp
+++ b/prosper/tests/test_shader_recompile_cache.cpp
@@ -392,6 +392,48 @@ int main() {
     CHECK(shared_first && !shared_first->empty(),
           "shared shader words outlive cache reset while a realized draw retains them");
 
+    // Compute realization used to run the full RDNA2 walk/CFG/SPIR-V builder for every dispatch,
+    // even though SGPR values are supplied as push constants. Cache by code, descriptor interface,
+    // and the launch ABI fields that actually specialize the module.
+    static const uint32_t kCompute[] = {
+        0xd7460004, 0x04010c08, 0x7e000204, 0x7e020205, 0x7e040206,
+        0x7e060207, 0xe01c2000, 0x80000004, 0xbf810000,
+    };
+    ShaderResource compute_buffer;
+    compute_buffer.cls = ResourceClass::ConstantBuffer;
+    compute_buffer.format = DataFormat::Uint32;
+    compute_buffer.num_components = 4;
+    compute_buffer.binding = 2;
+    compute_buffer.stride = 16;
+    compute_buffer.sgpr_base = 0;
+    compute_buffer.size = 4096;
+    ShaderResourceTable compute_table;
+    compute_table.resources.push_back(compute_buffer);
+    ComputeShaderConfig compute_config;
+    compute_config.user_sgprs.resize(8);
+    compute_config.local_x = 64;
+    compute_config.exact_thread_extent = true;
+    compute_config.threads_x = 130;
+    compute_config.threads_y = compute_config.threads_z = 1;
+    compute_config.tgid_x_en = true;
+    const auto direct_compute = recompile_compute(
+        kCompute, std::size(kCompute), &compute_table, compute_config);
+    const auto cached_compute = recompile_compute_shader_cached(
+        kCompute, std::size(kCompute), &compute_table, compute_config);
+    ComputeShaderConfig new_push_constants = compute_config;
+    new_push_constants.user_sgprs[4] = 0x12345678;
+    const auto repeated_compute = recompile_compute_shader_cached(
+        kCompute, std::size(kCompute), &compute_table, new_push_constants);
+    ComputeShaderConfig changed_launch = compute_config;
+    changed_launch.local_x = 32;
+    const auto changed_compute = recompile_compute_shader_cached(
+        kCompute, std::size(kCompute), &compute_table, changed_launch);
+    stats = shader_recompile_cache_stats();
+    CHECK(!direct_compute.empty() && cached_compute == direct_compute &&
+              repeated_compute == direct_compute && !changed_compute.empty() &&
+              changed_compute != direct_compute && stats.misses == 2 && stats.hits == 1,
+          "compute cache reuses push-constant variants and separates launch-specialized modules");
+
     if (failures) {
         std::printf("== FAIL: %d ==\n", failures);
         return 1;

--- a/prosper/tests/test_shader_resources.cpp
+++ b/prosper/tests/test_shader_resources.cpp
@@ -59,16 +59,42 @@ static std::vector<uint32_t> image_test_spirv() {
     emit(s, 59, {4, 5, 0});                                // %5 = image variable
     emit(s, 71, {5, 34, 1}); emit(s, 71, {5, 33, 4});      // set 1 binding 4
     emit(s, 61, {3, 6, 5});                                // %6 = load %5
+    emit(s, 87, {1, 7, 6, 8});                             // %7 = OpImageSampleImplicitLod %6
     return s;
 }
 
-static std::vector<uint32_t> storage_image_access_test_spirv() {
+static std::vector<uint32_t> image_fetch_test_spirv() {
+    std::vector<uint32_t> s = image_test_spirv();
+    // Replace the terminal normalized sample with OpImageFetch. Reflection only needs the image
+    // object's provenance and opcode class; the fixture is not submitted to a SPIR-V implementation.
+    s[s.size() - 5] = (5u << 16) | 95u;
+    return s;
+}
+
+static std::vector<uint32_t> image_query_test_spirv() {
+    std::vector<uint32_t> s = {0x07230203u, 0x00010000u, 0, 16, 0};
+    emit(s, 15, {5, 12, 0x6e69616d, 0});                    // OpEntryPoint Compute %12 "main"
+    emit(s, 21, {1, 32, 0});                               // %1 = u32
+    emit(s, 25, {2, 1, 1, 0, 0, 0, 1, 0});                // %2 = sampled 2D image
+    emit(s, 27, {3, 2});                                   // %3 = sampled-image %2
+    emit(s, 32, {4, 0, 3});                                // %4 = UniformConstant pointer
+    emit(s, 59, {4, 5, 0});                                // %5 = image variable
+    emit(s, 71, {5, 34, 0}); emit(s, 71, {5, 33, 4});      // set 0 binding 4
+    emit(s, 61, {3, 6, 5});                                // %6 = load sampled image
+    emit(s, 100, {2, 7, 6});                               // %7 = OpImage %6
+    emit(s, 106, {1, 8, 7});                               // %8 = OpImageQueryLevels %7
+    emit(s, 103, {1, 9, 7, 10});                           // %9 = OpImageQuerySizeLod %7 %10
+    return s;
+}
+
+static std::vector<uint32_t> storage_image_access_test_spirv(bool float_sampled_type = false) {
     // Two storage-image descriptors: binding 5 is read, binding 6 is independently write-only.
     // This is the shape that permits the compute backend to skip seeding binding 6 even though the
     // shader has an OpImageRead for binding 5.
     std::vector<uint32_t> s = {0x07230203u, 0x00010000u, 0, 24, 0};
     emit(s, 15, {5, 20, 0x6e69616d, 0});                    // OpEntryPoint Compute %20 "main"
-    emit(s, 21, {1, 32, 0});                               // %1 = u32
+    if (float_sampled_type) emit(s, 22, {1, 32});           // %1 = f32
+    else emit(s, 21, {1, 32, 0});                          // %1 = u32
     emit(s, 25, {2, 1, 1, 0, 0, 0, 2, 0});                // %2 = storage 2D image
     emit(s, 32, {3, 0, 2});                                // %3 = UniformConstant pointer
     emit(s, 59, {3, 4, 0}); emit(s, 59, {3, 5, 0});        // %4 source, %5 destination
@@ -207,6 +233,30 @@ int main() {
           data_format_bytes(DataFormat::Sint2_10_10_10) == 0,
           "packed 2_10_10_10 vertex variants have no uniform per-component byte size");
 
+    CHECK(native_float_storage_image_supported(DataFormat::Unorm8, 1, false, true) &&
+              native_float_storage_image_supported(DataFormat::Unorm8, 2, false, true) &&
+              native_float_storage_image_supported(
+                  DataFormat::Float10_11_11, 3, false, true),
+          "native typed storage accepts supported R8, RG8, and packed R11G11B10 formats");
+    CHECK(!native_float_storage_image_supported(DataFormat::Unorm8, 1, false, false) &&
+              !native_float_storage_image_supported(DataFormat::Unorm8, 2, false, false) &&
+              !native_float_storage_image_supported(
+                  DataFormat::Float10_11_11, 3, false, false),
+          "missing Vulkan storage-image support forces optional typed formats to the raw fallback");
+    CHECK(!native_float_storage_image_supported(DataFormat::Unorm8, 4, true, true) &&
+              !native_float_storage_image_supported(DataFormat::Float16, 3, false, true),
+          "device support cannot override semantic native-storage exclusions");
+    const uint32_t r8_storage =
+        native_storage_format_support_bit(DataFormat::Unorm8, 1);
+    const uint32_t rg8_storage =
+        native_storage_format_support_bit(DataFormat::Unorm8, 2);
+    const uint32_t packed_storage =
+        native_storage_format_support_bit(DataFormat::Float10_11_11, 3);
+    CHECK(r8_storage && rg8_storage && packed_storage && r8_storage != rg8_storage &&
+              rg8_storage != packed_storage &&
+              native_storage_format_support_bit(DataFormat::Float16, 3) == 0,
+          "native storage capability bits distinguish exact typed VkFormat candidates");
+
     uint8_t rgba10[4] = {};
     unorm2_10_10_10_to_rgba8(0xFFFFFFFFu, rgba10);
     CHECK(rgba10[0] == 255 && rgba10[1] == 255 && rgba10[2] == 255 && rgba10[3] == 255,
@@ -288,10 +338,24 @@ int main() {
     auto ir = validate_spirv_descriptor_interface(
         image_spv, &image_table, 1, SpirvShaderStage::Fragment);
     CHECK(ir.ok() && ir.descriptors.size() == 1 &&
-          ir.descriptors[0].kind == SpirvDescriptorKind::CombinedImageSampler,
+          ir.descriptors[0].kind == SpirvDescriptorKind::CombinedImageSampler &&
+          ir.descriptors[0].normalized_sampling && !ir.descriptors[0].texel_access,
           "sampled-image reflection validates a concrete texture binding");
     CHECK(ir.descriptors.size() == 1 && !ir.descriptors[0].writable,
           "sampled descriptor is not mistaken for an image output");
+    const auto fetch_report = validate_spirv_descriptor_interface(
+        image_fetch_test_spirv(), &image_table, 1, SpirvShaderStage::Fragment);
+    CHECK(fetch_report.ok() && fetch_report.descriptors.size() == 1 &&
+              !fetch_report.descriptors[0].normalized_sampling &&
+              fetch_report.descriptors[0].texel_access,
+          "OpImageFetch reflection requires the descriptor's exact texel extent");
+    const auto query_report = validate_spirv_descriptor_interface(
+        image_query_test_spirv(), &image_table, 0, SpirvShaderStage::Compute);
+    CHECK(query_report.ok() && query_report.descriptors.size() == 1 &&
+              query_report.descriptors[0].readable &&
+              !query_report.descriptors[0].normalized_sampling &&
+              query_report.descriptors[0].texel_access,
+          "query-only sampled images stay reflected and require their exact guest extent");
 
     ShaderResource storage_src{};
     storage_src.cls = ResourceClass::StorageImage; storage_src.binding = 5;
@@ -307,8 +371,17 @@ int main() {
           "storage-image read/write fixture reflects both bindings");
     CHECK(storage_report.descriptors.size() == 2 && storage_report.descriptors[0].readable &&
               !storage_report.descriptors[0].writable &&
-              !storage_report.descriptors[1].readable && storage_report.descriptors[1].writable,
+              !storage_report.descriptors[1].readable && storage_report.descriptors[1].writable &&
+              storage_report.descriptors[0].texel_access &&
+              !storage_report.descriptors[0].normalized_sampling &&
+              !storage_report.descriptors[0].storage_float,
           "storage-image texel access is classified per binding");
+    const auto float_storage_report = validate_spirv_descriptor_interface(
+        storage_image_access_test_spirv(true), &storage_table, 0, SpirvShaderStage::Compute);
+    CHECK(float_storage_report.ok() && float_storage_report.descriptors.size() == 2 &&
+              float_storage_report.descriptors[0].storage_float &&
+              float_storage_report.descriptors[1].storage_float,
+          "storage-image reflection preserves the SPIR-V float sampled-type contract");
     image_table.resources[0].size = 0;
     auto izr = validate_spirv_descriptor_interface(
         image_spv, &image_table, 1, SpirvShaderStage::Fragment);

--- a/prosper/tests/test_shader_resources.cpp
+++ b/prosper/tests/test_shader_resources.cpp
@@ -62,6 +62,24 @@ static std::vector<uint32_t> image_test_spirv() {
     return s;
 }
 
+static std::vector<uint32_t> storage_image_access_test_spirv() {
+    // Two storage-image descriptors: binding 5 is read, binding 6 is independently write-only.
+    // This is the shape that permits the compute backend to skip seeding binding 6 even though the
+    // shader has an OpImageRead for binding 5.
+    std::vector<uint32_t> s = {0x07230203u, 0x00010000u, 0, 24, 0};
+    emit(s, 15, {5, 20, 0x6e69616d, 0});                    // OpEntryPoint Compute %20 "main"
+    emit(s, 21, {1, 32, 0});                               // %1 = u32
+    emit(s, 25, {2, 1, 1, 0, 0, 0, 2, 0});                // %2 = storage 2D image
+    emit(s, 32, {3, 0, 2});                                // %3 = UniformConstant pointer
+    emit(s, 59, {3, 4, 0}); emit(s, 59, {3, 5, 0});        // %4 source, %5 destination
+    emit(s, 71, {4, 34, 0}); emit(s, 71, {4, 33, 5});      // set 0 binding 5
+    emit(s, 71, {5, 34, 0}); emit(s, 71, {5, 33, 6});      // set 0 binding 6
+    emit(s, 61, {2, 6, 4}); emit(s, 61, {2, 7, 5});        // load image objects
+    emit(s, 98, {8, 9, 6, 10});                            // %9 = OpImageRead %6
+    emit(s, 99, {7, 10, 9});                               // OpImageWrite %7
+    return s;
+}
+
 static bool has_issue(const DescriptorValidationReport& r, DescriptorIssueCode code) {
     for (const auto& issue : r.issues) if (issue.code == code) return true;
     return false;
@@ -207,7 +225,8 @@ int main() {
           "reflection validates one statically-used descriptor and ignores inactive declarations");
     CHECK(vr.descriptors.size() == 1 && vr.descriptors[0].binding == 9 &&
           vr.descriptors[0].kind == SpirvDescriptorKind::StorageBuffer &&
-          vr.descriptors[0].required_bytes == 20 && !vr.descriptors[0].dynamic_access,
+          vr.descriptors[0].required_bytes == 20 && !vr.descriptors[0].dynamic_access &&
+          !vr.descriptors[0].writable,
           "constant access chain reflects storage-buffer binding 9 with a 20-byte minimum");
 
     ShaderResource atomic = good; atomic.binding = 10;
@@ -215,8 +234,9 @@ int main() {
     const DescriptorValidationReport atomic_report = validate_spirv_descriptor_interface(
         atomic_descriptor_test_spirv(), &atomic_table, 0, SpirvShaderStage::Vertex);
     CHECK(atomic_report.ok() && atomic_report.descriptors.size() == 2 &&
-              atomic_report.descriptors[1].binding == 10,
-          "write-only atomic access reflects its storage-buffer descriptor");
+              atomic_report.descriptors[1].binding == 10 &&
+              atomic_report.descriptors[1].writable,
+          "write-only atomic access reflects its writable storage-buffer descriptor");
 
     ShaderResourceTable missing;
     auto mr = validate_spirv_descriptor_interface(spv, &missing, 0, SpirvShaderStage::Vertex);
@@ -270,6 +290,25 @@ int main() {
     CHECK(ir.ok() && ir.descriptors.size() == 1 &&
           ir.descriptors[0].kind == SpirvDescriptorKind::CombinedImageSampler,
           "sampled-image reflection validates a concrete texture binding");
+    CHECK(ir.descriptors.size() == 1 && !ir.descriptors[0].writable,
+          "sampled descriptor is not mistaken for an image output");
+
+    ShaderResource storage_src{};
+    storage_src.cls = ResourceClass::StorageImage; storage_src.binding = 5;
+    storage_src.gpu_addr = 0x56790000; storage_src.size = 4;
+    storage_src.width = storage_src.height = 1;
+    storage_src.format = DataFormat::Unorm8; storage_src.num_components = 4;
+    ShaderResource storage_dst = storage_src;
+    storage_dst.binding = 6; storage_dst.gpu_addr += 0x10000;
+    ShaderResourceTable storage_table; storage_table.resources = {storage_src, storage_dst};
+    const auto storage_report = validate_spirv_descriptor_interface(
+        storage_image_access_test_spirv(), &storage_table, 0, SpirvShaderStage::Compute);
+    CHECK(storage_report.ok() && storage_report.descriptors.size() == 2,
+          "storage-image read/write fixture reflects both bindings");
+    CHECK(storage_report.descriptors.size() == 2 && storage_report.descriptors[0].readable &&
+              !storage_report.descriptors[0].writable &&
+              !storage_report.descriptors[1].readable && storage_report.descriptors[1].writable,
+          "storage-image texel access is classified per binding");
     image_table.resources[0].size = 0;
     auto izr = validate_spirv_descriptor_interface(
         image_spv, &image_table, 1, SpirvShaderStage::Fragment);

--- a/prosper/tests/test_shadow_compare_render.cpp
+++ b/prosper/tests/test_shadow_compare_render.cpp
@@ -334,6 +334,17 @@ int main() {
         CHECK(prosper::test::find_persistent_ds_sampled(
                   kRecencyBase, kRecencyW, kRecencyH).image == &older,
               "a later real D32 write updates sibling ordering");
+
+        const auto scaled = prosper::test::find_persistent_ds_sampled(
+            kRecencyBase, kRecencyW * 2, kRecencyH * 2, 2);
+        CHECK(scaled.image == &older && scaled.width == kRecencyW && scaled.height == kRecencyH,
+              "configured render scale resolves native depth view to the retained image extent");
+        CHECK(!prosper::test::find_persistent_ds_sampled(
+                   kRecencyBase, kRecencyW * 2, kRecencyH * 2).image,
+              "scaled depth lookup stays disabled without the configured render scale");
+        CHECK(!prosper::test::find_persistent_ds_sampled(
+                   kRecencyBase, kRecencyW * 3, kRecencyH * 2, 2).image,
+              "non-uniform depth aliases do not enter the scaled bridge");
         cache.erase(d32_key);
         cache.erase(d32s8_key);
     }
@@ -565,6 +576,40 @@ int main() {
             CHECK(mrt1_center[0] == 17 && mrt1_center[1] == 34 &&
                       mrt1_center[2] == 51 && mrt1_center[3] == 255,
                   "split MRT carry preserves an untouched secondary attachment exactly");
+        }
+
+        // Both color attachments can remain device-local across calls. Seed MRT1 once, perform a
+        // GPU-only paired render, then LOAD and read it back on the next call. The shader writes only
+        // MRT0, so every secondary pixel must survive exactly without the former paired CPU carry.
+        prosper::test::BackendColorTarget resident_mrt{
+            0x20d5c10000ull, false, false, VK_FORMAT_R8G8B8A8_UNORM};
+        resident_mrt.persistent_id1 = 0x20d5c20000ull;
+        resident_mrt.load_existing1 = false;
+        resident_mrt.readback1 = false;
+        resident_mrt.format1 = VK_FORMAT_R8G8B8A8_UNORM;
+        std::vector<uint8_t> pending_mrt1;
+        const std::vector<uint8_t> pending_mrt = prosper::test::render_draws_rgba(
+            {batched_producer}, W, H, nullptr, nullptr,
+            /*persist_depth_stencil=*/true, &resident_mrt, mrt1_seed.data(), nullptr,
+            &pending_mrt1);
+        resident_mrt.load_existing = true;
+        resident_mrt.readback = true;
+        resident_mrt.load_existing1 = true;
+        resident_mrt.readback1 = true;
+        std::vector<uint8_t> loaded_mrt1;
+        const std::vector<uint8_t> loaded_mrt = prosper::test::render_draws_rgba(
+            {batched_producer}, W, H, nullptr, nullptr,
+            /*persist_depth_stencil=*/true, &resident_mrt, nullptr, nullptr, &loaded_mrt1);
+        CHECK(pending_mrt.empty() && pending_mrt1.empty() &&
+                  loaded_mrt.size() == (size_t)W * H * 4 &&
+                  loaded_mrt1.size() == mrt1_seed.size(),
+              "persistent MRT keeps both attachments GPU-resident until explicitly read back");
+        if (loaded_mrt1.size() == mrt1_seed.size()) {
+            const uint8_t* resident_center =
+                &loaded_mrt1[(((size_t)H / 2) * W + W / 2) * 4];
+            CHECK(resident_center[0] == 17 && resident_center[1] == 34 &&
+                      resident_center[2] == 51 && resident_center[3] == 255,
+                  "persistent MRT1 LOAD preserves its GPU-only secondary attachment exactly");
         }
 
         // Fresh-image initialization is also a logical-pass contract. An ALWAYS producer does not

--- a/prosper/tests/test_texture_sample_render.cpp
+++ b/prosper/tests/test_texture_sample_render.cpp
@@ -98,6 +98,33 @@ int main() {
     printf("  (0.75,0.25) center=(%u,%u,%u)\n", ok1?rgb[0]:0, ok1?rgb[1]:0, ok1?rgb[2]:0);
     CHECK(ok1 && rgb[1] > 0x80 && rgb[0] < 0x40 && rgb[2] < 0x40, "sampling texel (1,0) yields GREEN (proves u routing)");
 
+    // Dynamic single-channel textures (notably Astro Bot's FMV planes) stay R8 through upload. The
+    // component mapping reproduces the live frontend's historical coverage broadcast without a 4x
+    // CPU expansion to RGBA8.
+    {
+        std::vector<uint32_t> ps(ps_template, ps_template + sizeof(ps_template)/sizeof(ps_template[0]));
+        ps[1] = C025; ps[3] = C025;
+        std::vector<uint32_t> frag = recompile_fragment(ps.data(), ps.size(), &rt);
+        const uint8_t r8_texels[4] = {32, 96, 160, 224};
+        prosper::test::FrameResource resource;
+        resource.binding = 4; resource.set = 1;
+        resource.tex_rgba = r8_texels; resource.tw = 2; resource.th = 2;
+        resource.texture_format = VK_FORMAT_R8_UNORM;
+        resource.swizzle[0] = resource.swizzle[1] =
+            resource.swizzle[2] = resource.swizzle[3] = 4;
+        prosper::test::BackendDraw draw;
+        draw.vs = vert; draw.fs = frag; draw.R = {resource}; draw.vcount = 3;
+        const std::vector<uint8_t> pixels =
+            prosper::test::render_draws_rgba({draw}, W, H);
+        const uint8_t* center = pixels.size() == static_cast<size_t>(W) * H * 4
+            ? &pixels[(static_cast<size_t>(H / 2) * W + W / 2) * 4] : nullptr;
+        CHECK(center && center[0] >= 31 && center[0] <= 33 &&
+                         center[1] == center[0] && center[2] == center[0],
+              "native R8 sampled upload broadcasts its channel without RGBA expansion");
+        CHECK(prosper::test::backend_color_bytes_per_pixel(VK_FORMAT_R8_UNORM) == 1,
+              "native R8 upload accounts one byte per texel");
+    }
+
     // The live renderer commonly submits hundreds of draws that reference the same few decoded
     // textures. The backend must upload identical pixels once per call while preserving the legacy
     // rendered bytes and separate per-descriptor views/samplers.


### PR DESCRIPTION
## Summary

This is the first shareable Astro Bot render-performance batch after #1445.

- Keep large live-compute buffers and guest-backed images resident across dispatches, with chunked guest-write validation and exact source snapshots before reuse.
- Reuse shader recompilation/reflection, descriptor pools, memory allocations, command objects, renderer targets, and direct presentation resources when their contracts are unchanged.
- Borrow renderer-owned color/depth images only when SPIR-V reflection proves the access is compatible: exact extents always work, while reduced-resolution direct binding requires normalized sampling.
- Keep writable storage images on the owned-image + guest-writeback path so overlapping guest buffer/image aliases remain coherent.
- Gate native typed 2D storage on the exact executing device's image-create support; compile portable raw storage for unsupported formats and captures.
- Keep the non-portable contiguous-lane subgroup acceleration as an explicit `PROSPER_ASSUME_CONTIGUOUS_COMPUTE_SUBGROUPS` experiment. Portable guest-wave emulation remains the default.
- Complete shader-cache identity for codegen-relevant resource state and reflect image query/normalized/texel/storage-numeric contracts.
- Add focused coverage for cache invalidation, shader resources and cache identity, scaled RTT injection, storage copies, shadow compare, and texture sampling.

## Astro Bot result

During the pre-review live iteration—with realtime rendering, FMV, audio, and input enabled—Astro Bot advanced through the Sony intro and logged both `title_controller_ship` and `worldmap` level control flow. With another game workload sharing the machine, observed throughput was approximately **24–32 FPS**, up from the initial approximately 2 FPS / multi-second frames.

That number is directional, not an exact-head benchmark: review hardening subsequently made portable wave emulation the default and removed writable direct/scaled storage imports. The current head retains the broad residency/caching work, but has not been rerouted through the full game under comparable load.

This is **not compatibility-complete**. After the Sony intro, the visible title/world-map output remains black with a faint checkerboard-like pattern. The title logic is reached, but the title screen is not visibly rendered and the game is not yet playable. Unsupported compute programs remain a likely correctness lead for follow-up work.

## Review hardening

Independent review found nine blocking correctness/portability risks. The corrected head:

- includes every codegen-relevant descriptor field in shader-cache identity
- distinguishes normalized sampling from integer texel access and image queries before scaled direct RTT binding
- rejects writable renderer-image imports and preserves guest writeback/alias invalidation
- removes the unsafe scaled-storage blit bridge
- reflects query-only image descriptors
- defaults to portable wave emulation
- device-gates typed storage compilation and keeps backend representation authoritative from SPIR-V
- prefers a proven persistent depth plane over a stale color-cache alias at the same guest address

## Validation

Exact rebased head `b45940fe`:

- Distrobox CMake build: passed
- CTest: **148/148 passed**
- `git diff --check`: passed
- Rebasing onto current `master` added only the snapshot-policy documentation from #1446

The full real-game snapshot matrix was run during this development batch before the final review corrections:

- Passed: Messenger scene, Evergate title/gameplay, Dead Cells gameplay, Blasphemous 2 gameplay, Blue Prince title
- Detected change: Blue Prince hall produced black frames
- Detected change: Terminator boot visibly progressed to its title screen, but only 10/16 samples met the route's structural SSIM threshold

Per the repository's snapshot policy, those findings are development evidence rather than a PR merge gate. They remain recorded for follow-up and release-time review.

## Review focus

This is a large, high-risk renderer change. Final exact-head review should focus on:

- persistent buffer/image lifetime and invalidation
- source-mirror coherency after writeback
- Vulkan image layout/ownership transitions and direct RTT compatibility
- portable guest-wave behavior and experimental native subgroup gating
- shader reflection, device-format gating, and descriptor/cache identities
- correctness under guest address aliasing