### PR TITLE
Support Astro Bot fused NGG vertex shaders

### DIFF
--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -28,6 +28,7 @@
 #include <set>
 
 extern "C" const void* prosper_agc_shader_header_for_code(uint64_t code_addr);
+extern "C" const void* prosper_agc_fused_back_header_for_front(uint64_t front_code_addr);
 
 namespace prosper::gpu {
 
@@ -207,7 +208,9 @@ std::vector<DynFetch> resolve_dynamic_fetch(const uint32_t* code, size_t dwords,
                                             uint32_t user_sgpr_base,
                                             std::vector<SrtUse>* srt_uses = nullptr,
                                             uint32_t pcrel_dispatch_target = UINT32_MAX,
-                                            const PcrelDispatchInfo* pcrel_dispatch = nullptr);
+                                            const PcrelDispatchInfo* pcrel_dispatch = nullptr,
+                                            const uint32_t* system_sgprs = nullptr,
+                                            uint32_t nsystem_sgprs = 0);
 
 // Add instruction-provenance compute buffer resources to a metadata-built table. This is the exact
 // buffer-discovery path used by realize_compute_dispatches; it is exposed so tests can assert the
@@ -737,10 +740,15 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
                          (unsigned long long)rs.es_addr, (unsigned long long)rs.ps_addr);
         return false;
     }
+    const auto* fused_back = static_cast<const AgcShaderHeader*>(
+        prosper_agc_fused_back_header_for_front(rs.es_addr));
+    const uint64_t vs_program_addr = fused_back && fused_back->type == 6 && fused_back->code
+        ? static_cast<uint64_t>(reinterpret_cast<uintptr_t>(fused_back->code))
+        : rs.es_addr;
     const bool phase_timing = getenv("PROSPER_RENDER_TIMING") != nullptr;
     const auto table_start = phase_timing
         ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point{};
-    std::shared_ptr<ShaderResourceTable> vrt = build_stage_table(ds, rs.es_addr, false, vcount_hint);
+    std::shared_ptr<ShaderResourceTable> vrt = build_stage_table(ds, vs_program_addr, false, vcount_hint);
     std::shared_ptr<ShaderResourceTable> prt = build_stage_table(ds, rs.ps_addr, true, vcount_hint);
     const auto table_done = phase_timing
         ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point{};
@@ -766,7 +774,7 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
     bool interpolants_from_metadata = false;
     if (!pixel_inputs.valid_mask) {
         const auto* producer = static_cast<const AgcShaderHeader*>(
-            prosper_agc_shader_header_for_code(rs.es_addr));
+            prosper_agc_shader_header_for_code(vs_program_addr));
         const auto* pixel = static_cast<const AgcShaderHeader*>(
             prosper_agc_shader_header_for_code(rs.ps_addr));
         const AgcPixelInputControls derived = derive_agc_pixel_input_controls(producer, pixel);
@@ -799,14 +807,14 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
     std::vector<uint32_t> vs, fs;
     if (retain_shared_shader_words) {
         vs_shared = recompile_graphics_shader_cached_shared(
-            ShaderProgramStage::Vertex, (const uint32_t*)(uintptr_t)rs.es_addr,
+            ShaderProgramStage::Vertex, (const uint32_t*)(uintptr_t)vs_program_addr,
             max_shader_dwords, vrt.get(), pixel_input_ptr, nullptr, &vs_identity);
         fs_shared = recompile_graphics_shader_cached_shared(
             ShaderProgramStage::Fragment, (const uint32_t*)(uintptr_t)rs.ps_addr,
             max_shader_dwords, prt.get(), nullptr, system_input_ptr, &fs_identity);
     } else {
         vs = recompile_graphics_shader_cached(
-            ShaderProgramStage::Vertex, (const uint32_t*)(uintptr_t)rs.es_addr,
+            ShaderProgramStage::Vertex, (const uint32_t*)(uintptr_t)vs_program_addr,
             max_shader_dwords, vrt.get(), pixel_input_ptr, nullptr, &vs_identity);
         fs = recompile_graphics_shader_cached(
             ShaderProgramStage::Fragment, (const uint32_t*)(uintptr_t)rs.ps_addr,
@@ -856,16 +864,16 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
             std::chrono::duration<double, std::milli>(table_done - table_start).count(),
             std::chrono::duration<double, std::milli>(shader_done - table_done).count());
     }
-    add_stage_diagnostic(ShaderProgramStage::Vertex, rs.es_addr, vrt, vs_words);
+    add_stage_diagnostic(ShaderProgramStage::Vertex, vs_program_addr, vrt, vs_words);
     add_stage_diagnostic(ShaderProgramStage::Fragment, rs.ps_addr, prt, fs_words);
     if (const char* dd = getenv("PROSPER_VS_DUMP")) {   // diag: dump successful VS SPIR-V + raw RDNA2 for inspection
         static int nd = 0;
         if (nd < 3 && !vs_words.empty()) {
             char fn[512];
-            snprintf(fn, sizeof fn, "%s/vs_%d_%llx.spv", dd, nd, (unsigned long long)rs.es_addr);
+            snprintf(fn, sizeof fn, "%s/vs_%d_%llx.spv", dd, nd, (unsigned long long)vs_program_addr);
             if (FILE* f = fopen(fn, "wb")) { fwrite(vs_words.data(), 4, vs_words.size(), f); fclose(f); }
-            snprintf(fn, sizeof fn, "%s/vs_%d_%llx.bin", dd, nd, (unsigned long long)rs.es_addr);
-            if (FILE* f = fopen(fn, "wb")) { fwrite((const void*)(uintptr_t)rs.es_addr, 1, 4096, f); fclose(f); }
+            snprintf(fn, sizeof fn, "%s/vs_%d_%llx.bin", dd, nd, (unsigned long long)vs_program_addr);
+            if (FILE* f = fopen(fn, "wb")) { fwrite((const void*)(uintptr_t)vs_program_addr, 1, 4096, f); fclose(f); }
             // Also dump the paired PS raw RDNA2 (the recompile-guard fixture needs both stages, #228).
             snprintf(fn, sizeof fn, "%s/ps_%d_%llx.bin", dd, nd, (unsigned long long)rs.ps_addr);
             if (FILE* f = fopen(fn, "wb")) { fwrite((const void*)(uintptr_t)rs.ps_addr, 1, 4096, f); fclose(f); }
@@ -879,11 +887,11 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
         // failing draw's exact seeding/s_load chain is captured without knowing its address up front.
         if (vs_words.empty() && getenv("PROSPER_DYNTRACE_FAIL")) {
             static std::set<uint64_t> traced;
-            if (traced.insert(rs.es_addr).second) {
+            if (traced.insert(vs_program_addr).second) {
                 fprintf(stderr, "[dynfail] replaying VS 0x%llx resource build with trace:\n",
-                        (unsigned long long)rs.es_addr);
+                        (unsigned long long)vs_program_addr);
                 g_dyntrace_force = true;
-                (void)build_stage_table(ds, rs.es_addr, false, vcount_hint);
+                (void)build_stage_table(ds, vs_program_addr, false, vcount_hint);
                 g_dyntrace_force = false;
             }
         }
@@ -903,15 +911,16 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
             should_log_recompile_reject(rs.es_addr, rs.ps_addr,
                                         vs_words.size(), gs.size(), fs_words.size(),
                                         &reject_occurrence))
-            fprintf(stderr, "[exec-recompile-reject] es=0x%llx ps=0x%llx vs=%zu gs=%zu fs=%zu "
+            fprintf(stderr, "[exec-recompile-reject] es=0x%llx gs-pgm=0x%llx hs-pgm=0x%llx ps=0x%llx vs=%zu gs=%zu fs=%zu "
                             "prim=%u topo=%u ena=%08x addr=%08x order=%llu occurrence=%llu\n",
-                    (unsigned long long)rs.es_addr, (unsigned long long)rs.ps_addr,
+                    (unsigned long long)rs.es_addr, (unsigned long long)rs.gs_addr,
+                    (unsigned long long)rs.hs_addr, (unsigned long long)rs.ps_addr,
                     vs_words.size(), gs.size(), fs_words.size(), rs.prim_type, resolved_pipeline.topology,
                     rs.ps_input_ena, rs.ps_input_addr,
                     (unsigned long long)(draw ? draw->command_order : 0),
                     (unsigned long long)reject_occurrence);
         if (const char* dd = getenv("PROSPER_SHADER_DUMP")) {
-            for (auto [tag, addr] : {std::pair{"vs", rs.es_addr}, std::pair{"ps", rs.ps_addr}}) {
+            for (auto [tag, addr] : {std::pair{"vs", vs_program_addr}, std::pair{"ps", rs.ps_addr}}) {
                 if (!addr || !guest_readable(addr, sizeof(uint32_t))) continue;
                 const size_t dump_dwords = rdna2_recompile_code_span(
                     reinterpret_cast<const uint32_t*>(static_cast<uintptr_t>(addr)),
@@ -943,7 +952,7 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
                     (int)rs.stencil_enable, (int)rs.stencil_clear_enable, rs.stencil_clear_value,
                     (unsigned long long)rs.stencil_read_base,
                     (unsigned long long)rs.stencil_write_base);
-            for (auto [tag, addr] : {std::pair{"vs", rs.es_addr}, std::pair{"ps", rs.ps_addr}}) {
+            for (auto [tag, addr] : {std::pair{"vs", vs_program_addr}, std::pair{"ps", rs.ps_addr}}) {
                 RecompileCoverage c = recompile_coverage((const uint32_t*)(uintptr_t)addr, max_shader_dwords);
                 fprintf(stderr, "[exec]   %s coverage: total=%u alu=%u exp=%u tabledep=%u unsupported=%u "
                                 "first_bad fmt=%d op=0x%x\n", tag, c.total, c.alu, c.exports,
@@ -1208,7 +1217,7 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
     }
     out.vs = std::move(vs); out.gs = std::move(gs); out.fs = std::move(fs);
     out.vs_shared = std::move(vs_shared); out.fs_shared = std::move(fs_shared);
-    out.vs_guest_addr = rs.es_addr; out.fs_guest_addr = rs.ps_addr;
+    out.vs_guest_addr = vs_program_addr; out.fs_guest_addr = rs.ps_addr;
     out.vs_identity = vs_identity; out.fs_identity = fs_identity; out.ps = ps;
     out.vrt = std::move(vrt); out.prt = std::move(prt); out.vertex_count = vertex_count;
     // #1256: record the raw draw-packet state (pre-realization) so a capture can be checked offline for

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -1482,7 +1482,8 @@ std::vector<DynFetch>
 resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_sgprs, uint32_t nsgpr,
                       uint32_t user_sgpr_base, std::vector<SrtUse>* srt_uses,
                       uint32_t pcrel_dispatch_target,
-                      const PcrelDispatchInfo* pcrel_dispatch) {
+                      const PcrelDispatchInfo* pcrel_dispatch,
+                      const uint32_t* system_sgprs, uint32_t nsystem_sgprs) {
     using FoldClock = std::chrono::steady_clock;
     static const bool profile_fold = std::getenv("PROSPER_STAGE_FOLD_PROFILE") != nullptr;
     const auto fold_start = profile_fold ? FoldClock::now() : FoldClock::time_point{};
@@ -1588,6 +1589,8 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
             mask_state[(size_t)r] = FoldMask::Unknown;
         }
     };
+    for (uint32_t i = 0; system_sgprs && i < nsystem_sgprs && i < kFoldSgprs; ++i)
+        set_value(static_cast<int>(i), system_sgprs[i]);
     for (uint32_t i = 0; i < nsgpr; i++) {
         const int reg = (int)(user_sgpr_base + i);
         set_value(reg, user_sgprs[i]);
@@ -1953,6 +1956,22 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                               descr_known.set((size_t)sdst);
                               descr_key[(size_t)sdst] = descr8_key[(size_t)sdst];
                               descr_key_known.set((size_t)sdst);
+                }
+                if (n == 16) {
+                    // NGG back halves commonly fetch a compact stage-data block containing four
+                    // consecutive V# descriptors with one s_load_dwordx16. Each aligned group can
+                    // subsequently be consumed by MUBUF. The load's one byte-offset key cannot
+                    // distinguish those four resources, so retain key-less descriptor provenance;
+                    // the consumer is then resolved by its exact instruction pc.
+                    for (uint32_t first = 0; first < n; first += 4) {
+                        const int base_reg = sdst + static_cast<int>(first);
+                        if (!valid_reg(base_reg) || !valid_reg(base_reg + 3)) continue;
+                        descr[(size_t)base_reg] = {
+                            mem[first], mem[first + 1], mem[first + 2], mem[first + 3] };
+                        descr_known.set((size_t)base_reg);
+                        descr_key[(size_t)base_reg] = 0xFFFFFFFFu;
+                        descr_key_known.set((size_t)base_reg);
+                    }
                 }
                 break;
             }
@@ -2664,8 +2683,20 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
     } else {
         // NGG merged VS/GS: s0..s7 are system SGPRs, user data starts at s8 (confirmed by matching the
         // shader's s[8:11]/s[24:25] descriptor pointers to the register file at GS_0+offset).
+        uint32_t system_sgprs[2] = {};
+        uint32_t system_count = 0;
+        if (hdr->type == 6) { // fused GS back: s[0:1] points at the driver stage-data table
+            const auto sh_value = [&](uint32_t reg) {
+                const auto found = st.sh.find(reg);
+                return found == st.sh.end() ? 0u : found->second;
+            };
+            system_sgprs[0] = sh_value(P::SPI_SHADER_USER_DATA_ADDR_LO_GS);
+            system_sgprs[1] = sh_value(P::SPI_SHADER_USER_DATA_ADDR_HI_GS);
+            system_count = (system_sgprs[0] || system_sgprs[1]) ? 2u : 0u;
+        }
         dyn_vb = resolve_dynamic_fetch((const uint32_t*)(uintptr_t)code_addr, shader_dwords,
-                                       primary_sgprs, kUserSgprs, 8, &srt_uses);
+                                       primary_sgprs, kUserSgprs, 8, &srt_uses,
+                                       UINT32_MAX, nullptr, system_sgprs, system_count);
         if (getenv("PROSPER_GFXLOG") || getenv("PROSPER_RESDUMP")) {
             fprintf(stderr, "[dynvb] VS resolved %zu dynamic vertex-fetch descriptor(s):\n", dyn_vb.size());
             for (auto& kv : dyn_vb) {

--- a/prosper/src/gpu/rdna2_decode.cpp
+++ b/prosper/src/gpu/rdna2_decode.cpp
@@ -211,6 +211,21 @@ void decode_operands(Rdna2Inst& i) {
                         i.has_modifier = false;
                     }
                 }
+                // NGG culling extracts three packed byte indices and converts them to LDS byte
+                // addresses with `v_lshlrev_b32_sdwa ..., 2, vN src1_sel:BYTE_k`. Admit the exact
+                // zero-extending form: full-dword destination/shift amount, one byte from src1, and
+                // no sign/float/output modifiers.
+                else if (((w >> 25) & 0x3Fu) == 0x1Au) {
+                    const uint32_t dsel = (sd >> 8) & 7u, dun = (sd >> 11) & 3u;
+                    const uint32_t s0sel = (sd >> 16) & 7u, s1sel = (sd >> 24) & 7u;
+                    if (dsel == 6u && dun == 0u && s0sel == 6u && s1sel <= 5u &&
+                        !((sd >> 19) & 0xFu) && !((sd >> 27) & 0xFu) &&
+                        !i.clamp && !i.omod) {
+                        i.sdwa_src0_sel = static_cast<uint8_t>(s0sel);
+                        i.sdwa_src1_sel = static_cast<uint8_t>(s1sel);
+                        i.has_modifier = false;
+                    }
+                }
             } else if (i.has_dpp) {   // DPP16: real SRC0 in dw1[7:0]; SRC1 stays the dword0 VGPR field
                 i.src[0] = vgpr(i.words[1]); i.src[1] = vgpr(w >> 9); i.n_src = 2;
             } else { i.src[0] = decode_src_field(w & 0x1FFu); i.src[1] = vgpr(w >> 9); i.n_src = 2; }
@@ -540,6 +555,16 @@ Rdna2Inst rdna2_decode_one(const uint32_t* code, size_t max_dwords) {
                 const uint32_t ctrl = (d1 >> 8) & 0x1FFu;
                 if (ctrl < 0x100u && ((d1 >> 28) & 0xFu) == 0xFu && ((d1 >> 24) & 0xFu) == 0xFu &&
                     ((d1 >> 20) & 0xFu) == 0u && ((d1 >> 18) & 1u) == 0u) {
+                    i.has_modifier = false; i.has_dpp = true; i.dpp_ctrl = (uint16_t)ctrl;
+                }
+                // Astro Bot's NGG primitive packer performs two bounded row-right shifts before
+                // v_add_nc_u32. The one-lane vertex model lowers the absent neighbor to zero; admit
+                // only that exact integer-add form with full row/bank masks and BOUND_CTRL=1.
+                else if (vf == Rdna2Format::VOP2 && ((w >> 25) & 0x3Fu) == 0x25u &&
+                         ctrl >= 0x111u && ctrl <= 0x11Fu &&
+                         ((d1 >> 28) & 0xFu) == 0xFu && ((d1 >> 24) & 0xFu) == 0xFu &&
+                         ((d1 >> 20) & 0xFu) == 0u && ((d1 >> 19) & 1u) == 1u &&
+                         ((d1 >> 18) & 1u) == 0u) {
                     i.has_modifier = false; i.has_dpp = true; i.dpp_ctrl = (uint16_t)ctrl;
                 }
             }

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -9652,10 +9652,11 @@ static bool is_astro_bot_ngg_private_lds_wrapper(const uint32_t* code, size_t dw
     return hash == 0x79eb2b954b07dc8eull;
 }
 
-std::vector<uint32_t> recompile_vertex(const uint32_t* code, size_t dwords,
-                                       const ShaderResourceTable* rt,
-                                       const PixelInputMapping* pixel_inputs,
-                                       bool capture_position) {
+static std::vector<uint32_t> recompile_vertex_impl(const uint32_t* code, size_t dwords,
+                                                  const ShaderResourceTable* rt,
+                                                  const PixelInputMapping* pixel_inputs,
+                                                  bool capture_position,
+                                                  bool allow_test_ngg_output_gate) {
     std::vector<Rdna2Inst> ins;
     rdna2_walk(code, dwords, ins);
     const StaticScratchLayout scratch = analyze_static_scratch(ins);
@@ -9704,20 +9705,10 @@ std::vector<uint32_t> recompile_vertex(const uint32_t* code, size_t dwords,
             if (ins[previous].fmt != Rdna2Format::VOPC ||
                 !vopc_is_cmpx(ins[previous].opcode))
                 continue;
-            // The observed Astro wrapper is byte-exact. For any other NGG program, accept this
-            // vertex-suppression projection only for CMPX_F/CMPX_TRU with EXEC never narrowed
-            // beforehand: every host invocation then takes the same active/inactive path, so no
-            // mixed primitive can be fabricated regardless of topology. These constant forms also
-            // provide small executable regression fixtures without widening production semantics.
-            bool exec_full_before_compare = true;
-            for (size_t j = 0; j < previous; ++j)
-                if (instruction_may_change_exec(ins[j])) {
-                    exec_full_before_compare = false;
-                    break;
-                }
-            const bool constant_whole_draw_gate = exec_full_before_compare &&
-                (ins[previous].opcode == 0x10u || ins[previous].opcode == 0x1fu);
-            if (!b.ngg_private_lds && !constant_whole_draw_gate)
+            // Production accepts data-dependent vertex suppression only for the byte-exact Astro
+            // wrapper. The explicit test hook below exercises active/inactive export selection with
+            // a tiny shader without turning that shader shape into a runtime allow-list exception.
+            if (!b.ngg_private_lds && !allow_test_ngg_output_gate)
                 continue;
             bool has_position = false;
             bool output_only = true;
@@ -9975,6 +9966,18 @@ std::vector<uint32_t> recompile_vertex(const uint32_t* code, size_t dwords,
         }
     }
     return b.finish();
+}
+
+std::vector<uint32_t> recompile_vertex(const uint32_t* code, size_t dwords,
+                                       const ShaderResourceTable* rt,
+                                       const PixelInputMapping* pixel_inputs,
+                                       bool capture_position) {
+    return recompile_vertex_impl(code, dwords, rt, pixel_inputs, capture_position, false);
+}
+
+std::vector<uint32_t> recompile_vertex_terminal_ngg_gate_for_test(
+    const uint32_t* code, size_t dwords) {
+    return recompile_vertex_impl(code, dwords, nullptr, nullptr, false, true);
 }
 
 } // namespace prosper::gpu

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -218,7 +218,9 @@ struct SpirvCompute {
     uint32_t guest_scratch_dwords=0;
     std::map<uint32_t, uint32_t> cbuf_var;          // binding -> storage-buffer var (N-buffer model; 2/3 map to v_cbuf/v_cbuf1)
     bool     is_fragment=0;                          // true in the fragment shell (gates VINTRP interp)
-    bool     is_vertex=0;                            // true in the vertex shell (NGG single-invocation model)
+    bool     is_vertex=0;                            // true in every vertex shell
+    bool     ngg_one_lane=0;                         // exact GS_ALLOC_REQ wrapper: one guest lane/invocation
+    bool     ngg_private_lds=0;                      // exact captured wrapper whose LDS projection is known
     uint32_t ngg_vertex_index_read_pc = UINT32_MAX;   // NGG wave/LDS prologue handoff -> host VertexIndex
     uint32_t ngg_vertex_index_value = 0;
     bool     is_compute=0;                            // true in the compute shell (gates LDS / s_barrier)
@@ -1358,6 +1360,8 @@ struct SpirvCompute {
         uint32_t len = uconst(lds_dwords);
         uint32_t t_arr = id();        put(types, Op_TypeArray, {t_arr, t_u32, len});
         if (is_vertex) {
+            // Vertex-stage LDS is only legal for the exact NGG wrapper selected by recompile_vertex.
+            // All other vertex DS shapes reject before reaching this declaration.
             uint32_t t_ptr_fn_arr = 0;
             lds_var = function_var(t_arr, t_ptr_fn_arr);
             t_ptr_wg_u32 = id();
@@ -1429,7 +1433,7 @@ struct SpirvCompute {
     }
     // s_barrier: workgroup execution + memory barrier (OpControlBarrier).
     void barrier() {
-        if (is_vertex) return; // one modeled NGG lane has no peer whose LDS access must be synchronized
+        if (ngg_private_lds) return; // exact one-lane wrapper has no peer requiring synchronization
         uses_barrier = true;
         put(code, Op_ControlBarrier, {uconst(Scope_Workgroup), uconst(Scope_Workgroup), uconst(MemSem_WGAcqRel)});
     }
@@ -2408,8 +2412,9 @@ uint32_t inline_int_mask_bit(SpirvCompute& b, int value) {
     // A Vulkan vertex invocation is the single guest lane retained by the NGG approximation. It is
     // lane zero, so an inline B64 mask contributes exactly its low bit; vertex modules do not declare
     // LocalInvocationIndex, and trying to use that compute-only ID emitted invalid SPIR-V ID zero.
-    if (b.is_vertex)
+    if (b.ngg_one_lane)
         return (static_cast<uint32_t>(value) & 1u) ? b.btrue() : b.bfalse();
+    if (b.is_vertex) return 0; // an ordinary VS has no proven lane identity for a partial wave mask
     const uint32_t lane_id = b.is_fragment ? b.subgroup_local_id() : b.linear_localid;
     const uint32_t lane = b.ibin(Op_BitwiseAnd, lane_id,
                                   b.uconst(b.wave_size - 1));
@@ -2427,7 +2432,8 @@ uint32_t inline_int_mask_bit(SpirvCompute& b, int value) {
 // operand. Lanes < 32 never contribute to the HI window, so their bit is 0.
 uint32_t inline_int_mask_bit_hi(SpirvCompute& b, int value) {
     if (value == 0) return b.bfalse();
-    if (b.is_vertex) return b.bfalse(); // the modeled NGG lane is lane zero, never in the HI window
+    if (b.ngg_one_lane) return b.bfalse(); // the modeled NGG lane is lane zero, never in the HI window
+    if (b.is_vertex) return 0;
     const uint32_t lane_id = b.is_fragment ? b.subgroup_local_id() : b.linear_localid;
     const uint32_t lane = b.ibin(Op_BitwiseAnd, lane_id, b.uconst(b.wave_size - 1));
     const uint32_t high = b.ucmp(Op_UGreaterThanEqual, lane, b.uconst(32));
@@ -3994,7 +4000,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 }
                 return true;
             }
-            if (in.opcode == 0x10 && b.is_vertex) { // s_bcnt1_i32_b64
+            if (in.opcode == 0x10 && b.ngg_one_lane) { // s_bcnt1_i32_b64
                 // NGG's final primitive packing counts active bits in a saved wave mask. A Vulkan
                 // vertex invocation models one guest lane, so the population count of that lane's
                 // Boolean mask is exactly 0 or 1. Keep the result in the ordinary scalar-data domain
@@ -4047,6 +4053,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
         }
         case Rdna2Format::SOP2: {
             if (in.opcode == 0x25) {   // s_bfm_b64: D=((1ULL<<(S0&63))-1)<<(S1&63)
+                if (b.is_vertex && !b.ngg_one_lane) { ok = false; return true; }
                 // Wave masks are represented as one bool per SPIR-V invocation.  Constructing the
                 // architectural 64-bit integer and then splitting it would lose that domain, so test
                 // the current lane directly: bits [offset, offset+width) are set, truncated at bit 63.
@@ -4055,7 +4062,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 const uint32_t offset = b.ibin(Op_BitwiseAnd, val(in.src[1]), b.uconst(63));
                 // Vertex NGG is the same one-lane approximation as the inline-mask helpers: its
                 // represented guest lane is lane zero and it has no compute LocalInvocationIndex.
-                const uint32_t lane = b.is_vertex ? b.uconst(0) :
+                const uint32_t lane = b.ngg_one_lane ? b.uconst(0) :
                     b.ibin(Op_BitwiseAnd, b.linear_localid, b.uconst(b.wave_size - 1));
                 const uint32_t at_or_after = b.ucmp(Op_UGreaterThanEqual, lane, offset);
                 const uint32_t within_width = b.ucmp(
@@ -4699,7 +4706,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 const bool fop = in.opcode == 0x03 || in.opcode == 0x04 || in.opcode == 0x05 ||
                                  in.opcode == 0x08 || in.opcode == 0x0F || in.opcode == 0x10 ||
                                  in.opcode == 0x1F || in.opcode == 0x2B;
-                const bool ngg_row_shift = b.is_vertex && in.opcode == 0x25 &&
+                const bool ngg_row_shift = b.ngg_one_lane && in.opcode == 0x25 &&
                                            in.dpp_ctrl >= 0x111u && in.dpp_ctrl <= 0x11Fu;
                 if (!fop && !ngg_row_shift) { ok = false; return true; }
                 if (ngg_row_shift) {
@@ -5065,7 +5072,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             if (in.opcode == 0x360) {                                 // v_readlane_b32 sDST, vSRC, lane
                 const bool static_lane = in.src[1].kind == OperandKind::InlineInt &&
                                          in.src[1].value >= 0 && in.src[1].value <= 63;
-                const bool dynamic_absent_ngg_peer = b.is_vertex &&
+                const bool dynamic_absent_ngg_peer = b.ngg_one_lane &&
                     in.src[1].kind == OperandKind::Special &&
                     in.src[1].value >= 106 && in.src[1].value <= 124;
                 if (!static_lane && !dynamic_absent_ngg_peer) {
@@ -5099,7 +5106,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     // from an ordinary VGPR. A Vulkan vertex invocation models guest lane zero: a
                     // lane-zero read returns this invocation's source, while every absent peer reads
                     // zero. The dynamic form remains exact by selecting on its scalar lane index.
-                    if (!b.is_vertex) { ok = false; return true; }
+                    if (!b.ngg_one_lane) { ok = false; return true; }
                     const uint32_t source = val(in.src[0]);
                     uint32_t reads_self = 0;
                     if (static_lane) {
@@ -5424,7 +5431,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     if (in.sdst.value == 106 || in.sdst.value == 107) rs.vcc = cout_masked;
                     else if (in.sdst.kind == OperandKind::SGPR) rs.sreg_bool[in.sdst.value] = cout_masked;
                 }
-            } else if ((in.opcode == 0x365 || in.opcode == 0x366) && b.is_vertex) {
+            } else if ((in.opcode == 0x365 || in.opcode == 0x366) && b.ngg_one_lane) {
                 // NGG is deliberately lowered as one guest lane per Vulkan vertex invocation. No
                 // lane precedes that invocation, so either half of MBCNT contributes zero and leaves
                 // its accumulator unchanged. This is the scalar counterpart of recompile_vertex's
@@ -5512,7 +5519,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     else if (rs.exec_narrowed && (!safe_execz || !safe_execz->count(in.pc))) ok = false;
                     break;                                          // forward = no-op (predication covers it)
                 case 0x0a:                                          // s_barrier
-                    if (b.is_compute || b.is_vertex) b.barrier();   // NGG vertex = one modeled lane
+                    if (b.is_compute || b.ngg_private_lds) b.barrier();
                     else ok = false;                                // barrier only meaningful in compute
                     break;
                 case 0x04: case 0x05:                              // s_cbranch_scc0 / scc1
@@ -6728,7 +6735,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // offset; the backing store is dword-indexed. gfx10 ds_write2_b64 carries two independent
             // 8-bit offsets in units of 64-bit elements, while ds_write_b64 uses the ordinary 16-bit
             // byte offset. GDS and the remaining widths/atomics are deferred.
-            if ((!b.is_compute && !b.is_vertex) || (in.opcode != 0x00 && in.opcode != 0x07 &&
+            if ((!b.is_compute && !b.ngg_private_lds) || (in.opcode != 0x00 && in.opcode != 0x07 &&
                                   in.opcode != 0x08 && in.opcode != 0x20 &&
                                   in.opcode != 0x2d &&
                                   in.opcode != 0x0d && in.opcode != 0x36 && in.opcode != 0x37 &&
@@ -6783,7 +6790,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 }
                 return true;
             }
-            if (b.is_vertex && in.opcode == 0x36 &&
+            if (b.ngg_private_lds && in.opcode == 0x36 &&
                 in.pc == b.ngg_vertex_index_read_pc && b.ngg_vertex_index_value) {
                 // The merged NGG prologue distributes hardware vertex ids between wave lanes through
                 // LDS, then the ES consumes that value as its first MUBUF index. In the one-invocation
@@ -6803,8 +6810,8 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 b.compute_gds_store(idx, vread(in.src[1].value), rs.exec_narrowed, rs.exec);
                 return true;
             }
-            if (b.is_vertex && (in.opcode == 0x00 || in.opcode == 0x07 || in.opcode == 0x08 ||
-                                in.opcode == 0x20 || in.opcode == 0x2d)) {
+            if (b.ngg_private_lds && (in.opcode == 0x00 || in.opcode == 0x07 || in.opcode == 0x08 ||
+                                     in.opcode == 0x20 || in.opcode == 0x2d)) {
                 // Cross-lane/atomic NGG LDS effects do not have a proven single-lane reduction yet.
                 ok = false; return true;
             }
@@ -8574,7 +8581,7 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
         // one independent Vulkan invocation, however, so its EXEC bit is an ordinary per-invocation
         // Boolean. Carry that bit through the loop just like SCC/VCC instead of rejecting Astro Bot's
         // fixed-trip culling loop merely because some guest lanes were masked before its header.
-        const bool carry_vertex_exec = b.is_vertex && rs.exec_narrowed;
+        const bool carry_vertex_exec = b.ngg_one_lane && rs.exec_narrowed;
         if (rs.exec_narrowed && !guarded_narrow_entry && !carry_vertex_exec) {
             if (getenv("PROSPER_DBG"))
                 fprintf(stderr, "[recompile-reject] counted-loop enters with narrowed EXEC\n");
@@ -9629,6 +9636,22 @@ bool fragment_spirv_uses_internal_gds(const std::vector<uint32_t>& spirv) {
     return false;
 }
 
+// Astro Bot's fused 2,936-byte NGG body uses real wave-shared LDS for culling and compaction. The
+// current Vulkan vertex shell intentionally projects that one observed wrapper to one private guest
+// lane; applying the projection to an arbitrary NGG program would silently miscompile peer-lane LDS.
+// Keep the exception byte-exact and fail closed for every other vertex DS shape. The hash is FNV-1a
+// over the complete little-endian shader bytes, matching the raw hash in successful-shader dumps.
+static bool is_astro_bot_ngg_private_lds_wrapper(const uint32_t* code, size_t dwords) {
+    if (!code || dwords != 734) return false;
+    uint64_t hash = 1469598103934665603ull;
+    const auto* bytes = reinterpret_cast<const uint8_t*>(code);
+    for (size_t i = 0; i < dwords * sizeof(uint32_t); ++i) {
+        hash ^= bytes[i];
+        hash *= 1099511628211ull;
+    }
+    return hash == 0x79eb2b954b07dc8eull;
+}
+
 std::vector<uint32_t> recompile_vertex(const uint32_t* code, size_t dwords,
                                        const ShaderResourceTable* rt,
                                        const PixelInputMapping* pixel_inputs,
@@ -9647,12 +9670,15 @@ std::vector<uint32_t> recompile_vertex(const uint32_t* code, size_t dwords,
     RegState rs; rs.vcc = b.bfalse(); rs.scc = b.bfalse(); rs.exec = b.btrue();
     auto safe_branches = safe_execz_branches(ins);
     for (uint32_t wpc : waterfall_branches(ins)) safe_branches.insert(wpc);   // readfirstlane waterfalls (#273)
-    // NGG vertex shaders (s_sendmsg GS_ALLOC_REQ present) carry the vertex index in v5, not v0, and wrap
+    // NGG vertex shaders (the exact GS_ALLOC_REQ message present) carry the vertex index in v5, not v0, and wrap
     // the body in wave-packing plumbing (s_sendmsg / exp prim / s_lshr_b64 exec) that lowers to no-ops in
     // our per-invocation model. Detect NGG and bind the index to v5 as well.
     bool ngg = false;
     for (const auto& in : ins) { if (in.is_end) break;
-        if (in.fmt == Rdna2Format::SOPP && in.opcode == 0x10) { ngg = true; break; } }
+        if (in.fmt == Rdna2Format::SOPP && in.opcode == 0x10 &&
+            in.words[0] == 0xBF900009u) { ngg = true; break; } }
+    b.ngg_one_lane = ngg;
+    b.ngg_private_lds = ngg && is_astro_bot_ngg_private_lds_wrapper(code, dwords);
     uint32_t ngg_output_gate_begin = UINT32_MAX;
     uint32_t ngg_output_gate_end = 0;
     if (ngg) {
@@ -9860,18 +9886,37 @@ std::vector<uint32_t> recompile_vertex(const uint32_t* code, size_t dwords,
                             in.pc, in.exp_en);
                 return false;
             }
-            b.export_position(operand_bits(b, rs, in, in.src[0], &eok), operand_bits(b, rs, in, in.src[1], &eok),
-                              operand_bits(b, rs, in, in.src[2], &eok), operand_bits(b, rs, in, in.src[3], &eok));
+            uint32_t x = operand_bits(b, rs, in, in.src[0], &eok);
+            uint32_t y = operand_bits(b, rs, in, in.src[1], &eok);
+            uint32_t z = operand_bits(b, rs, in, in.src[2], &eok);
+            uint32_t w = operand_bits(b, rs, in, in.src[3], &eok);
+            if (terminal_ngg_output && rs.exec_narrowed) {
+                // The exact compacted-output wrapper emits a contiguous prefix of complete
+                // primitives. Map every inactive suffix invocation to one identical clip point;
+                // primitives assembled solely from that suffix are therefore degenerate instead of
+                // accidentally reusing the last active vertex. Keep the real values on the true path.
+                const uint32_t zero = b.uconst(0);
+                x = b.sel(rs.exec, x, zero);
+                y = b.sel(rs.exec, y, zero);
+                z = b.sel(rs.exec, z, zero);
+                w = b.sel(rs.exec, w, b.uconst(fbits(1.0f)));
+            }
+            b.export_position(x, y, z, w);
             exported = true;
         } else if (in.exp_target >= 32) {                    // PARAM0.. -> remapped PS input varying
             const uint32_t source = in.exp_target - 32;
             // EN gates which channels the export sends (vec2/vec3 varyings use EN=0x3/0x7):
             // hardware leaves disabled channels unwritten (undefined for the PS). Substitute a
             // deterministic 0.0 for them instead of exporting stale VGPR data.
-            const uint32_t x = (in.exp_en & 1u) ? operand_bits(b, rs, in, in.src[0], &eok) : b.uconst(0);
-            const uint32_t y = (in.exp_en & 2u) ? operand_bits(b, rs, in, in.src[1], &eok) : b.uconst(0);
-            const uint32_t z = (in.exp_en & 4u) ? operand_bits(b, rs, in, in.src[2], &eok) : b.uconst(0);
-            const uint32_t w = (in.exp_en & 8u) ? operand_bits(b, rs, in, in.src[3], &eok) : b.uconst(0);
+            uint32_t x = (in.exp_en & 1u) ? operand_bits(b, rs, in, in.src[0], &eok) : b.uconst(0);
+            uint32_t y = (in.exp_en & 2u) ? operand_bits(b, rs, in, in.src[1], &eok) : b.uconst(0);
+            uint32_t z = (in.exp_en & 4u) ? operand_bits(b, rs, in, in.src[2], &eok) : b.uconst(0);
+            uint32_t w = (in.exp_en & 8u) ? operand_bits(b, rs, in, in.src[3], &eok) : b.uconst(0);
+            if (terminal_ngg_output && rs.exec_narrowed) {
+                const uint32_t zero = b.uconst(0);
+                x = b.sel(rs.exec, x, zero); y = b.sel(rs.exec, y, zero);
+                z = b.sel(rs.exec, z, zero); w = b.sel(rs.exec, w, zero);
+            }
             if (!pixel_inputs || source >= 32 || !(pixel_inputs->valid_mask & (1u << source)))
                 b.export_param(source, x, y, z, w);           // absent control retains identity wiring
             if (pixel_inputs) {

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -9677,8 +9677,11 @@ std::vector<uint32_t> recompile_vertex(const uint32_t* code, size_t dwords,
     for (const auto& in : ins) { if (in.is_end) break;
         if (in.fmt == Rdna2Format::SOPP && in.opcode == 0x10 &&
             in.words[0] == 0xBF900009u) { ngg = true; break; } }
-    b.ngg_one_lane = ngg;
     b.ngg_private_lds = ngg && is_astro_bot_ngg_private_lds_wrapper(code, dwords);
+    // Every wave/peer approximation is an exception for the one captured Astro wrapper, not a
+    // property of the GS_ALLOC_REQ opcode. Other NGG programs retain only the ordinary merged-stage
+    // ABI setup below and fail closed if they reach a lane-sensitive operation.
+    b.ngg_one_lane = b.ngg_private_lds;
     uint32_t ngg_output_gate_begin = UINT32_MAX;
     uint32_t ngg_output_gate_end = 0;
     if (ngg) {
@@ -9700,6 +9703,21 @@ std::vector<uint32_t> recompile_vertex(const uint32_t* code, size_t dwords,
             do { --previous; } while (previous > 0 && sopp_is_noop(ins[previous]));
             if (ins[previous].fmt != Rdna2Format::VOPC ||
                 !vopc_is_cmpx(ins[previous].opcode))
+                continue;
+            // The observed Astro wrapper is byte-exact. For any other NGG program, accept this
+            // vertex-suppression projection only for CMPX_F/CMPX_TRU with EXEC never narrowed
+            // beforehand: every host invocation then takes the same active/inactive path, so no
+            // mixed primitive can be fabricated regardless of topology. These constant forms also
+            // provide small executable regression fixtures without widening production semantics.
+            bool exec_full_before_compare = true;
+            for (size_t j = 0; j < previous; ++j)
+                if (instruction_may_change_exec(ins[j])) {
+                    exec_full_before_compare = false;
+                    break;
+                }
+            const bool constant_whole_draw_gate = exec_full_before_compare &&
+                (ins[previous].opcode == 0x10u || ins[previous].opcode == 0x1fu);
+            if (!b.ngg_private_lds && !constant_whole_draw_gate)
                 continue;
             bool has_position = false;
             bool output_only = true;

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -218,6 +218,9 @@ struct SpirvCompute {
     uint32_t guest_scratch_dwords=0;
     std::map<uint32_t, uint32_t> cbuf_var;          // binding -> storage-buffer var (N-buffer model; 2/3 map to v_cbuf/v_cbuf1)
     bool     is_fragment=0;                          // true in the fragment shell (gates VINTRP interp)
+    bool     is_vertex=0;                            // true in the vertex shell (NGG single-invocation model)
+    uint32_t ngg_vertex_index_read_pc = UINT32_MAX;   // NGG wave/LDS prologue handoff -> host VertexIndex
+    uint32_t ngg_vertex_index_value = 0;
     bool     is_compute=0;                            // true in the compute shell (gates LDS / s_barrier)
     bool     uses_barrier=0;                          // guest or synthesized workgroup barrier emitted
     bool     declared_subgroup=0, declared_subgroup_vote=0, declared_subgroup_arithmetic=0;
@@ -1337,8 +1340,11 @@ struct SpirvCompute {
         put(code, Op_Label, {merge}); cur_block = merge;
         return emit_phi_2way(t_u32, result, then_end, fallback, entry);
     }
-    // LDS (Local Data Share) — a workgroup-shared u32 array for compute ds_read/ds_write. Declared on
-    // first use, sized to `lds_dwords`. RDNA2's per-workgroup LDS MAX is 64 KB (16384 dwords); the real
+    // LDS (Local Data Share) — a workgroup-shared u32 array for compute ds_read/ds_write. NGG shaders
+    // are lowered as one independent Vulkan vertex invocation, so their LDS becomes Function-private:
+    // the single modeled guest lane can observe its own writes, with no cross-invocation races or an
+    // illegal Workgroup variable in the Vertex execution model. Declared on first use and sized to
+    // `lds_dwords`. RDNA2's per-workgroup LDS MAX is 64 KB (16384 dwords); the real
     // per-shader allocation is COMPUTE_PGM_RSRC2.LDS_SIZE. `lds_dwords` defaults to 4096 (16 KB) — a
     // shader whose real allocation exceeds that would ds_read/write past the array (OOB Workgroup
     // access, UB — NOT covered by robustBufferAccess), so recompile_valu raises it from the plumbed
@@ -1351,9 +1357,16 @@ struct SpirvCompute {
         if (lds_var) return;
         uint32_t len = uconst(lds_dwords);
         uint32_t t_arr = id();        put(types, Op_TypeArray, {t_arr, t_u32, len});
-        uint32_t t_ptr_wg_arr = id(); put(types, Op_TypePointer, {t_ptr_wg_arr, SC_Workgroup, t_arr});
-        lds_var = id();               put(types, Op_Variable, {t_ptr_wg_arr, lds_var, SC_Workgroup});
-        t_ptr_wg_u32 = id();          put(types, Op_TypePointer, {t_ptr_wg_u32, SC_Workgroup, t_u32});
+        if (is_vertex) {
+            uint32_t t_ptr_fn_arr = 0;
+            lds_var = function_var(t_arr, t_ptr_fn_arr);
+            t_ptr_wg_u32 = id();
+            put(types, Op_TypePointer, {t_ptr_wg_u32, SC_Function, t_u32});
+        } else {
+            uint32_t t_ptr_wg_arr = id(); put(types, Op_TypePointer, {t_ptr_wg_arr, SC_Workgroup, t_arr});
+            lds_var = id();               put(types, Op_Variable, {t_ptr_wg_arr, lds_var, SC_Workgroup});
+            t_ptr_wg_u32 = id();          put(types, Op_TypePointer, {t_ptr_wg_u32, SC_Workgroup, t_u32});
+        }
     }
     uint32_t lds_load(uint32_t idx) {
         uint32_t p = id(); putv(code, Op_AccessChain, {t_ptr_wg_u32, p, lds_var, idx});
@@ -1416,6 +1429,7 @@ struct SpirvCompute {
     }
     // s_barrier: workgroup execution + memory barrier (OpControlBarrier).
     void barrier() {
+        if (is_vertex) return; // one modeled NGG lane has no peer whose LDS access must be synchronized
         uses_barrier = true;
         put(code, Op_ControlBarrier, {uconst(Scope_Workgroup), uconst(Scope_Workgroup), uconst(MemSem_WGAcqRel)});
     }
@@ -1820,6 +1834,7 @@ struct SpirvCompute {
         put(caps, Op_Capability, {Cap_Shader});
         { std::vector<uint32_t> o{glsl}; pstr(o, "GLSL.std.450"); putv(extimp, Op_ExtInstImport, o); }
         put(mem, Op_MemoryModel, {Addr_Logical, Mem_GLSL450});
+        is_vertex = true;
         exec_model = Exec_Vertex; iface = {v_vid, v_iid, v_pos};   // EntryPoint deferred to finish()
         put(deco, Op_Decorate, {v_vid, Dec_BuiltIn, BI_VertexIndex});
         put(deco, Op_Decorate, {v_iid, Dec_BuiltIn, BI_InstanceIndex});
@@ -2390,6 +2405,11 @@ inline bool sreg_srt_range_tag(const RegState& rs, int base, uint32_t words, uin
 uint32_t inline_int_mask_bit(SpirvCompute& b, int value) {
     if (value == -1) return b.btrue();
     if (value == 0) return b.bfalse();
+    // A Vulkan vertex invocation is the single guest lane retained by the NGG approximation. It is
+    // lane zero, so an inline B64 mask contributes exactly its low bit; vertex modules do not declare
+    // LocalInvocationIndex, and trying to use that compute-only ID emitted invalid SPIR-V ID zero.
+    if (b.is_vertex)
+        return (static_cast<uint32_t>(value) & 1u) ? b.btrue() : b.bfalse();
     const uint32_t lane_id = b.is_fragment ? b.subgroup_local_id() : b.linear_localid;
     const uint32_t lane = b.ibin(Op_BitwiseAnd, lane_id,
                                   b.uconst(b.wave_size - 1));
@@ -2407,6 +2427,7 @@ uint32_t inline_int_mask_bit(SpirvCompute& b, int value) {
 // operand. Lanes < 32 never contribute to the HI window, so their bit is 0.
 uint32_t inline_int_mask_bit_hi(SpirvCompute& b, int value) {
     if (value == 0) return b.bfalse();
+    if (b.is_vertex) return b.bfalse(); // the modeled NGG lane is lane zero, never in the HI window
     const uint32_t lane_id = b.is_fragment ? b.subgroup_local_id() : b.linear_localid;
     const uint32_t lane = b.ibin(Op_BitwiseAnd, lane_id, b.uconst(b.wave_size - 1));
     const uint32_t high = b.ucmp(Op_UGreaterThanEqual, lane, b.uconst(32));
@@ -3597,7 +3618,8 @@ uint32_t scalar_write_width(const Rdna2Inst& in) {
                     return 2; // B64 data/mask writes
                 default: return 1;
             }
-        case Rdna2Format::SOPK: return 1;
+        // SOPK compare opcodes use the encoded SDST field as a source and write only SCC.
+        case Rdna2Format::SOPK: return in.opcode >= 0x03 && in.opcode <= 0x0e ? 0u : 1u;
         case Rdna2Format::SMEM:
             switch (in.opcode) {
                 case 0x0: case 0x8: return 1;
@@ -3724,8 +3746,11 @@ void loop_written_regs(const std::vector<Rdna2Inst>& ins, uint32_t lo, uint32_t 
                 for (uint32_t k = 0; k < vgpr_write_count(in); ++k)
                     vregs.insert(in.dst.value + (int)k);
                 break;
-            case Rdna2Format::SOP1: case Rdna2Format::SOPK:
+            case Rdna2Format::SOP1:
                 sregs.insert(in.dst.value); break;
+            case Rdna2Format::SOPK:
+                if (in.opcode < 0x03 || in.opcode > 0x0e) sregs.insert(in.dst.value);
+                break;
             case Rdna2Format::SOP2:
                 // s_lshr_b64 -> EXEC is modeled only in the per-lane mask domain. It does not
                 // produce scalar SGPR data, so carrying a scalar value through a loop/if merge is
@@ -3969,6 +3994,23 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 }
                 return true;
             }
+            if (in.opcode == 0x10 && b.is_vertex) { // s_bcnt1_i32_b64
+                // NGG's final primitive packing counts active bits in a saved wave mask. A Vulkan
+                // vertex invocation models one guest lane, so the population count of that lane's
+                // Boolean mask is exactly 0 or 1. Keep the result in the ordinary scalar-data domain
+                // for the following integer packing arithmetic.
+                uint32_t mask = 0;
+                if (in.src[0].value == 106 || in.src[0].value == 107) mask = rs.vcc;
+                else if (in.src[0].value == 126 || in.src[0].value == 127) mask = rs.exec;
+                else if (in.src[0].kind == OperandKind::SGPR) {
+                    auto it = rs.sreg_bool.find(in.src[0].value);
+                    if (it != rs.sreg_bool.end()) mask = it->second;
+                }
+                if (!mask) { ok = false; return true; }
+                rs.sreg[in.dst.value] = b.sel(mask, b.uconst(1), b.uconst(0));
+                rs.sreg_srt.erase(in.dst.value);
+                return true;
+            }
             // A 32-bit scalar DATA write into an EXEC half would leave the live per-lane mask
             // (rs.exec) stale — hardware updates EXEC (and EXECZ) immediately. No exercised title
             // writes EXEC halves via b32 scalar ops (wave64 compilers use the b64 forms), so
@@ -4011,8 +4053,10 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 // This is also exact for width==0 (the ISA expression produces an empty mask).
                 const uint32_t width = b.ibin(Op_BitwiseAnd, val(in.src[0]), b.uconst(63));
                 const uint32_t offset = b.ibin(Op_BitwiseAnd, val(in.src[1]), b.uconst(63));
-                const uint32_t lane = b.ibin(Op_BitwiseAnd, b.linear_localid,
-                                              b.uconst(b.wave_size - 1));
+                // Vertex NGG is the same one-lane approximation as the inline-mask helpers: its
+                // represented guest lane is lane zero and it has no compute LocalInvocationIndex.
+                const uint32_t lane = b.is_vertex ? b.uconst(0) :
+                    b.ibin(Op_BitwiseAnd, b.linear_localid, b.uconst(b.wave_size - 1));
                 const uint32_t at_or_after = b.ucmp(Op_UGreaterThanEqual, lane, offset);
                 const uint32_t within_width = b.ucmp(
                     Op_ULessThan, b.ibin(Op_ISub, lane, offset), width);
@@ -4171,6 +4215,13 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                         b.ibin(Op_ShiftRightLogical, a, b.uconst(28)), b.uconst(0));
                     uint32_t wrapped = b.ucmp(Op_ULessThan, d, c);
                     rs.scc = b.bsel(shifted_out, b.btrue(), wrapped); break;
+                }
+                case 0x32: { // s_pack_ll_b32_b16: D={S1[15:0],S0[15:0]}
+                    const uint32_t lo = b.ibin(Op_BitwiseAnd, a, b.uconst(0xFFFFu));
+                    const uint32_t hi = b.ibin(Op_ShiftLeftLogical,
+                        b.ibin(Op_BitwiseAnd, c, b.uconst(0xFFFFu)), b.uconst(16));
+                    d = b.ibin(Op_BitwiseOr, lo, hi);
+                    break;
                 }
                 case 0x35: d = b.umul_hi(a, c); break;               // s_mul_hi_u32 (high 32 bits; no SCC)
                 case 0x36: d = b.smul_hi(a, c); break;               // s_mul_hi_i32 (high 32 bits; no SCC).
@@ -4348,13 +4399,42 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             return true;
         }
         case Rdna2Format::SOPK: {
-            // 16-bit-immediate scalar ops. s_movk_i32 (0x00): dst = sign-extend(simm16). The decoder
-            // already sign-extended simm16 to 32 bits. (s_cmovk/s_cmpk/s_addk/s_mulk deferred.)
+            // 16-bit-immediate scalar ops. The decoder sign-extends simm16 for signed operations;
+            // unsigned comparisons use the original 16-bit bit pattern. SOPK comparisons name their
+            // scalar source in the encoded SDST field and write only SCC.
             switch (in.opcode) {
                 case 0x00:                                  // s_movk_i32
                     rs.sreg[in.dst.value] = b.uconst((uint32_t)in.simm16);
                     rs.sreg_srt.erase(in.dst.value);
                     break;
+                case 0x03: case 0x04: case 0x05: case 0x06:
+                case 0x07: case 0x08: {                      // s_cmpk_{eq,lg,gt,ge,lt,le}_i32
+                    const uint32_t a = val(in.dst);
+                    const uint32_t c = b.uconst((uint32_t)in.simm16);
+                    switch (in.opcode) {
+                        case 0x03: rs.scc = b.ucmp(Op_IEqual, a, c); break;
+                        case 0x04: rs.scc = b.ucmp(Op_INotEqual, a, c); break;
+                        case 0x05: rs.scc = b.scmp(Op_SGreaterThan, a, c); break;
+                        case 0x06: rs.scc = b.scmp(Op_SGreaterThanEqual, a, c); break;
+                        case 0x07: rs.scc = b.scmp(Op_SLessThan, a, c); break;
+                        case 0x08: rs.scc = b.scmp(Op_SLessThanEqual, a, c); break;
+                    }
+                    break;
+                }
+                case 0x09: case 0x0A: case 0x0B:
+                case 0x0C: case 0x0D: case 0x0E: {           // s_cmpk_{eq,lg,gt,ge,lt,le}_u32
+                    const uint32_t a = val(in.dst);
+                    const uint32_t c = b.uconst((uint32_t)(uint16_t)in.simm16);
+                    switch (in.opcode) {
+                        case 0x09: rs.scc = b.ucmp(Op_IEqual, a, c); break;
+                        case 0x0A: rs.scc = b.ucmp(Op_INotEqual, a, c); break;
+                        case 0x0B: rs.scc = b.ucmp(Op_UGreaterThan, a, c); break;
+                        case 0x0C: rs.scc = b.ucmp(Op_UGreaterThanEqual, a, c); break;
+                        case 0x0D: rs.scc = b.ucmp(Op_ULessThan, a, c); break;
+                        case 0x0E: rs.scc = b.ucmp(Op_ULessThanEqual, a, c); break;
+                    }
+                    break;
+                }
                 // s_waitcnt_vscnt/vmcnt/expcnt/lgkmcnt: wait-for-counter — benign no-ops in our
                 // synchronous model (like SOPP s_waitcnt). These are SOPK on gfx10, NOT SOPP 0x7d
                 // as previously claimed (that case was unreachable dead code, and a real
@@ -4607,14 +4687,26 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
         }
         case Rdna2Format::VOP2: {
             uint32_t a = val(in.src[0]), c = val(in.src[1]); uint32_t old_d = vreg_old(b, rs, in.dst.value);
+            if (in.opcode == 0x1A && in.sdwa_src1_sel <= 5u) {
+                const uint32_t bits = in.sdwa_src1_sel <= 3u ? 8u : 16u;
+                const uint32_t offset = in.sdwa_src1_sel <= 3u
+                    ? 8u * in.sdwa_src1_sel : 16u * (in.sdwa_src1_sel - 4u);
+                c = b.bfe_u(c, b.uconst(offset), b.uconst(bits));
+            }
             // DPP16 quad_perm on src0 (#273): fragment-only, FLOAT ops only (add/sub/subrev/mul/min/
             // max/mac — the manual-derivative idiom's carriers); anything else stays rejected.
             if (in.has_dpp) {
                 const bool fop = in.opcode == 0x03 || in.opcode == 0x04 || in.opcode == 0x05 ||
                                  in.opcode == 0x08 || in.opcode == 0x0F || in.opcode == 0x10 ||
                                  in.opcode == 0x1F || in.opcode == 0x2B;
-                if (!fop) { ok = false; return true; }
-                if (b.is_fragment) {
+                const bool ngg_row_shift = b.is_vertex && in.opcode == 0x25 &&
+                                           in.dpp_ctrl >= 0x111u && in.dpp_ctrl <= 0x11Fu;
+                if (!fop && !ngg_row_shift) { ok = false; return true; }
+                if (ngg_row_shift) {
+                    // One modeled NGG lane has no preceding row neighbor. BOUND_CTRL=1 on the only
+                    // admitted packets makes the shifted source zero, so add_nc retains src1.
+                    a = b.uconst(0);
+                } else if (b.is_fragment) {
                     a = b.dpp_quad(a, in.dpp_ctrl);
                 } else if (b.is_compute) {
                     // Astro's title blur/reduction kernels use the same three XOR quad permutations
@@ -4971,13 +5063,19 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 return true;
             }
             if (in.opcode == 0x360) {                                 // v_readlane_b32 sDST, vSRC, lane
-                if (in.src[1].kind != OperandKind::InlineInt || in.src[1].value < 0 || in.src[1].value > 63) {
+                const bool static_lane = in.src[1].kind == OperandKind::InlineInt &&
+                                         in.src[1].value >= 0 && in.src[1].value <= 63;
+                const bool dynamic_absent_ngg_peer = b.is_vertex &&
+                    in.src[1].kind == OperandKind::Special &&
+                    in.src[1].value >= 106 && in.src[1].value <= 124;
+                if (!static_lane && !dynamic_absent_ngg_peer) {
                     ok = false; return true;
                 }
+                const int lane = static_lane ? in.src[1].value : -1;
                 auto vit = rs.vgpr_lane_slots.find(in.src[0].value);
                 auto mit = rs.vgpr_lane_mask_slots.find(in.src[0].value);
                 if (mit != rs.vgpr_lane_mask_slots.end()) {
-                    auto sit = mit->second.find(in.src[1].value);
+                    auto sit = mit->second.find(lane);
                     if (sit != mit->second.end()) {
                         rs.sreg_bool[in.dst.value] = sit->second;
                         rs.sreg_bool_narrowed[in.dst.value] = true;
@@ -4986,7 +5084,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                         // views after a block join; keep both destination domains when present so
                         // the statically typed consumer selects the representation it needs.
                         if (vit != rs.vgpr_lane_slots.end()) {
-                            auto data = vit->second.find(in.src[1].value);
+                            auto data = vit->second.find(lane);
                             if (data != vit->second.end()) rs.sreg[in.dst.value] = data->second;
                             else rs.sreg.erase(in.dst.value);
                         } else {
@@ -4996,8 +5094,28 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                         return true;
                     }
                 }
-                if (vit == rs.vgpr_lane_slots.end()) { ok = false; return true; }   // not a spill array
-                auto sit = vit->second.find(in.src[1].value);
+                if (vit == rs.vgpr_lane_slots.end()) {
+                    // NGG's final wave-packing tail reads peer lanes (Astro Bot uses lanes 63 and 3)
+                    // from an ordinary VGPR. A Vulkan vertex invocation models guest lane zero: a
+                    // lane-zero read returns this invocation's source, while every absent peer reads
+                    // zero. The dynamic form remains exact by selecting on its scalar lane index.
+                    if (!b.is_vertex) { ok = false; return true; }
+                    const uint32_t source = val(in.src[0]);
+                    uint32_t reads_self = 0;
+                    if (static_lane) {
+                        reads_self = lane == 0 ? b.btrue() : b.bfalse();
+                    } else {
+                        auto lane_value = rs.sreg.find(in.src[1].value);
+                        if (lane_value == rs.sreg.end()) { ok = false; return true; }
+                        reads_self = b.ucmp(Op_IEqual, lane_value->second, b.uconst(0));
+                    }
+                    rs.sreg[in.dst.value] = b.sel(reads_self, source, b.uconst(0));
+                    rs.sreg_bool.erase(in.dst.value);
+                    rs.sreg_bool_narrowed.erase(in.dst.value);
+                    rs.sreg_srt.erase(in.dst.value);
+                    return true;
+                }
+                auto sit = vit->second.find(lane);
                 if (sit == vit->second.end()) { ok = false; return true; }          // slot never written
                 rs.sreg[in.dst.value] = sit->second;   // dst field is the SGPR number (like readfirstlane)
                 rs.sreg_bool.erase(in.dst.value);
@@ -5306,6 +5424,12 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     if (in.sdst.value == 106 || in.sdst.value == 107) rs.vcc = cout_masked;
                     else if (in.sdst.kind == OperandKind::SGPR) rs.sreg_bool[in.sdst.value] = cout_masked;
                 }
+            } else if ((in.opcode == 0x365 || in.opcode == 0x366) && b.is_vertex) {
+                // NGG is deliberately lowered as one guest lane per Vulkan vertex invocation. No
+                // lane precedes that invocation, so either half of MBCNT contributes zero and leaves
+                // its accumulator unchanged. This is the scalar counterpart of recompile_vertex's
+                // existing s3=1 (one ES vertex, no GS primitive) ABI model.
+                vreg[in.dst.value] = val(in.src[1]);
             } else if ((in.opcode == 0x365 || in.opcode == 0x366) && allow_wave &&
                        (b.is_compute || b.is_fragment)) {
                 // v_mbcnt_lo/hi_u32_b32 (cross-lane): dst = src1 + count of lanes below this one whose mask
@@ -5388,7 +5512,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     else if (rs.exec_narrowed && (!safe_execz || !safe_execz->count(in.pc))) ok = false;
                     break;                                          // forward = no-op (predication covers it)
                 case 0x0a:                                          // s_barrier
-                    if (b.is_compute) b.barrier();                  // workgroup exec+memory barrier (LDS sync)
+                    if (b.is_compute || b.is_vertex) b.barrier();   // NGG vertex = one modeled lane
                     else ok = false;                                // barrier only meaningful in compute
                     break;
                 case 0x04: case 0x05:                              // s_cbranch_scc0 / scc1
@@ -6604,7 +6728,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // offset; the backing store is dword-indexed. gfx10 ds_write2_b64 carries two independent
             // 8-bit offsets in units of 64-bit elements, while ds_write_b64 uses the ordinary 16-bit
             // byte offset. GDS and the remaining widths/atomics are deferred.
-            if (!b.is_compute || (in.opcode != 0x00 && in.opcode != 0x07 &&
+            if ((!b.is_compute && !b.is_vertex) || (in.opcode != 0x00 && in.opcode != 0x07 &&
                                   in.opcode != 0x08 && in.opcode != 0x20 &&
                                   in.opcode != 0x2d &&
                                   in.opcode != 0x0d && in.opcode != 0x36 && in.opcode != 0x37 &&
@@ -6659,6 +6783,18 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 }
                 return true;
             }
+            if (b.is_vertex && in.opcode == 0x36 &&
+                in.pc == b.ngg_vertex_index_read_pc && b.ngg_vertex_index_value) {
+                // The merged NGG prologue distributes hardware vertex ids between wave lanes through
+                // LDS, then the ES consumes that value as its first MUBUF index. In the one-invocation
+                // Vulkan shell there is no peer-lane LDS routing: the equivalent value is precisely
+                // BuiltIn VertexIndex. This handoff is identified in recompile_vertex from the first
+                // MUBUF's vaddr reaching back to this DS read; all other vertex LDS reads remain real.
+                const uint32_t old = vreg_old(b, rs, in.dst.value);
+                rs.vreg[in.dst.value] = b.ngg_vertex_index_value;
+                predicate_write(b, rs, in.dst.value, old);
+                return true;
+            }
             uint32_t addr = b.ibin(Op_IAdd, vread(in.src[0].value), b.uconst(in.literal));
             if (in.ds_gds)
                 addr = b.ibin(Op_BitwiseAnd, addr, b.uconst(0xFFFFu));
@@ -6666,6 +6802,11 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             if (in.ds_gds && in.opcode == 0x0d) {
                 b.compute_gds_store(idx, vread(in.src[1].value), rs.exec_narrowed, rs.exec);
                 return true;
+            }
+            if (b.is_vertex && (in.opcode == 0x00 || in.opcode == 0x07 || in.opcode == 0x08 ||
+                                in.opcode == 0x20 || in.opcode == 0x2d)) {
+                // Cross-lane/atomic NGG LDS effects do not have a proven single-lane reduction yet.
+                ok = false; return true;
             }
             if (in.opcode == 0x00) {                     // ds_add_u32: LDS += DATA0, no VGPR return
                 b.lds_atomic(Op_AtomicIAdd, idx, vread(in.src[1].value),
@@ -8429,8 +8570,12 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
             }
             if (!emit_range(F.merge_pc, L.header_pc)) return false;
         }
-        // Loops require full EXEC at entry (per-lane loop semantics); bail if narrowed.
-        if (rs.exec_narrowed && !guarded_narrow_entry) {
+        // Ordinary counted loops require full EXEC at entry. An NGG vertex is already represented by
+        // one independent Vulkan invocation, however, so its EXEC bit is an ordinary per-invocation
+        // Boolean. Carry that bit through the loop just like SCC/VCC instead of rejecting Astro Bot's
+        // fixed-trip culling loop merely because some guest lanes were masked before its header.
+        const bool carry_vertex_exec = b.is_vertex && rs.exec_narrowed;
+        if (rs.exec_narrowed && !guarded_narrow_entry && !carry_vertex_exec) {
             if (getenv("PROSPER_DBG"))
                 fprintf(stderr, "[recompile-reject] counted-loop enters with narrowed EXEC\n");
             return false;
@@ -8447,7 +8592,7 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
         const uint32_t preheader = b.cur_block;
         const uint32_t hdr = b.id(), check = b.id(), body = b.id(), cont = b.id(), merge = b.id();
         b.emit_branch(hdr); b.emit_label(hdr);
-        struct PhiRec { int reg; int dom; uint32_t phi; size_t patch; };   // dom: 0=vreg,1=sreg,2=scc,3=vcc
+        struct PhiRec { int reg; int dom; uint32_t phi; size_t patch; };   // dom: 0=vreg,1=sreg,2=scc,3=vcc,4=exec
         std::vector<PhiRec> phis;
         for (int r : cv) { size_t p; uint32_t ph = b.emit_phi2(b.t_u32, vget(r), preheader, p); rs.vreg[r] = ph; phis.push_back({r, 0, ph, p}); }
         for (int r : cs) { size_t p; uint32_t ph = b.emit_phi2(b.t_u32, sget(r), preheader, p); rs.sreg[r] = ph; phis.push_back({r, 1, ph, p}); }
@@ -8455,6 +8600,12 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
         // in-loop s_cmp before any read, so the phi seed is dead in practice; 0 would be invalid SSA.
         { size_t p; uint32_t ph = b.emit_phi2(b.t_bool, rs.scc ? rs.scc : b.bfalse(), preheader, p); rs.scc = ph; phis.push_back({0, 2, ph, p}); }
         { size_t p; uint32_t ph = b.emit_phi2(b.t_bool, rs.vcc, preheader, p); rs.vcc = ph; phis.push_back({0, 3, ph, p}); }
+        if (carry_vertex_exec) {
+            size_t p;
+            uint32_t ph = b.emit_phi2(b.t_bool, rs.exec, preheader, p);
+            rs.exec = ph;
+            phis.push_back({0, 4, ph, p});
+        }
         // The header executes again after the back-edge. A direct/SRT descriptor overwritten
         // anywhere in the loop is therefore not an invariant entry descriptor at header compile
         // time. An exact descriptor load in the header may establish fresh provenance afterward.
@@ -8467,6 +8618,8 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
         std::unordered_map<int,uint32_t> condv_val, conds_val;
         for (int r : condv) condv_val[r] = vget(r);
         for (int r : conds) conds_val[r] = sget(r);
+        const uint32_t cond_exec = rs.exec;
+        const bool cond_exec_narrowed = rs.exec_narrowed;
         // s_cbranch_scc0 exits when SCC==0 (so the loop CONTINUES when SCC!=0); scc1 is the inverse.
         uint32_t loop_cond = L.exit_on_scc0 ? rs.scc : b.bsel(rs.scc, b.bfalse(), b.btrue());
         b.emit_condbranch(loop_cond, body, merge);
@@ -8475,7 +8628,7 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
         b.emit_label(body);
         // 4. Body [after exit_branch, back-edge). Must restore EXEC before looping (bail if left narrowed).
         if (!emit_range(L.exit_branch_pc + 1, L.backedge_pc)) return false;
-        if (rs.exec_narrowed && !guarded_narrow_entry) {
+        if (rs.exec_narrowed && !guarded_narrow_entry && !carry_vertex_exec) {
             if (getenv("PROSPER_DBG"))
                 fprintf(stderr, "[recompile-reject] counted-loop body leaves EXEC narrowed\n");
             return false;
@@ -8484,7 +8637,10 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
         // 5. Continue block branches back to the header; patch each phi's back-edge (value = current, cont).
         b.emit_branch(cont); b.emit_label(cont);
         for (auto& pr : phis) {
-            uint32_t nv = pr.dom == 0 ? vget(pr.reg) : pr.dom == 1 ? sget(pr.reg) : pr.dom == 2 ? rs.scc : rs.vcc;
+            uint32_t nv = pr.dom == 0 ? vget(pr.reg)
+                        : pr.dom == 1 ? sget(pr.reg)
+                        : pr.dom == 2 ? rs.scc
+                        : pr.dom == 3 ? rs.vcc : rs.exec;
             if (!nv && pr.dom == 2) nv = b.bfalse();   // poisoned SCC back-edge value: bfalse (dead in practice)
             b.patch_phi(pr.patch, nv, cont);
         }
@@ -8499,8 +8655,10 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
             // not a real codegen pattern (flags are transient, consumed by their branch), so the A-class
             // exit-iteration refinement is intentionally omitted for them.
             else if (pr.dom == 2) rs.scc = pr.phi;
-            else                  rs.vcc = pr.phi;
+            else if (pr.dom == 3) rs.vcc = pr.phi;
+            else                  rs.exec = cond_exec;
         }
+        if (carry_vertex_exec) rs.exec_narrowed = cond_exec_narrowed;
         // 7. Post-loop body. Feed the suffix back through the ordinary body selector: with this
         // counted back-edge removed it can use the established nested forward-if/divergent-loop
         // structurizer. This composes a counted loop with a non-trivial shared postlude without
@@ -9495,11 +9653,78 @@ std::vector<uint32_t> recompile_vertex(const uint32_t* code, size_t dwords,
     bool ngg = false;
     for (const auto& in : ins) { if (in.is_end) break;
         if (in.fmt == Rdna2Format::SOPP && in.opcode == 0x10) { ngg = true; break; } }
+    uint32_t ngg_output_gate_begin = UINT32_MAX;
+    uint32_t ngg_output_gate_end = 0;
+    if (ngg) {
+        uint32_t end_pc = UINT32_MAX;
+        for (const auto& in : ins)
+            if (in.is_end) { end_pc = in.pc; break; }
+        // An NGG primitive shader finishes by compacting surviving vertices, CMPX-testing whether
+        // this lane owns one of those vertices, then exporting POS/PARAM values before S_ENDPGM.
+        // Vulkan's vertex shell already represents one surviving guest vertex per invocation, but
+        // retaining the condition is still useful when the compacted count is zero. Permit exports
+        // under narrowed EXEC only for this mechanically bounded terminal output gate; ordinary
+        // vertex CMPX/export programs remain rejected below.
+        for (size_t i = 1; i < ins.size(); ++i) {
+            const Rdna2Inst& branch = ins[i];
+            if (branch.fmt != Rdna2Format::SOPP || branch.opcode != 0x08 ||
+                branch.simm16 <= 0 || branch_target(branch) != end_pc)
+                continue;
+            size_t previous = i;
+            do { --previous; } while (previous > 0 && sopp_is_noop(ins[previous]));
+            if (ins[previous].fmt != Rdna2Format::VOPC ||
+                !vopc_is_cmpx(ins[previous].opcode))
+                continue;
+            bool has_position = false;
+            bool output_only = true;
+            for (size_t j = i + 1; j < ins.size() && ins[j].pc < end_pc; ++j) {
+                const Rdna2Inst& candidate = ins[j];
+                if (candidate.fmt == Rdna2Format::EXP) {
+                    has_position |= candidate.exp_target == 12;
+                    continue;
+                }
+                if (candidate.fmt == Rdna2Format::SOPC) continue;
+                if (sopp_is_noop(candidate)) continue;
+                if (candidate.fmt == Rdna2Format::SOPP &&
+                    (candidate.opcode == 0x04 || candidate.opcode == 0x05) &&
+                    candidate.simm16 > 0 && branch_target(candidate) == end_pc)
+                    continue;
+                output_only = false;
+                break;
+            }
+            if (has_position && output_only) {
+                ngg_output_gate_begin = branch.pc;
+                ngg_output_gate_end = end_pc;
+                break;
+            }
+        }
+    }
     uint32_t vidx = b.load_vertex_index();
     uint32_t iidx = b.load_instance_index();
     rs.vreg[0] = vidx;                       // Legacy VS ABI: v0 = vertex index
     rs.vreg[3] = iidx;                       // Legacy VS ABI: v3 = instance index
     if (ngg) {
+        // Locate the NGG prologue's LDS-to-ES vertex-index handoff without hard-coding a register or
+        // program counter: the first MUBUF vaddr must be most recently defined by a scalar DS read.
+        // The one-lane backend substitutes BuiltIn VertexIndex at that exact read (see DS lowering).
+        for (size_t use = 0; use < ins.size(); ++use) {
+            if (ins[use].is_end) break;
+            if ((ins[use].fmt != Rdna2Format::MUBUF && ins[use].fmt != Rdna2Format::MTBUF) ||
+                ins[use].src[0].kind != OperandKind::VGPR)
+                continue;
+            const int index_reg = ins[use].src[0].value;
+            for (size_t def = use; def-- > 0;) {
+                const Rdna2Inst& candidate = ins[def];
+                if (candidate.dst.kind != OperandKind::VGPR || candidate.dst.value != index_reg)
+                    continue;
+                if (candidate.fmt == Rdna2Format::DS && candidate.opcode == 0x36) {
+                    b.ngg_vertex_index_read_pc = candidate.pc;
+                    b.ngg_vertex_index_value = vidx;
+                }
+                break;
+            }
+            break;
+        }
         // GFX10's merged GS/ES ABI enters the ES prolog with vertex/instance indices in v5/v8 and
         // merged-wave counts in s3 ([7:0] ES vertices, [15:8] GS primitives). SPIR-V invokes one
         // vertex at a time, so model one active ES vertex and no GS primitive. Leaving s3 at the
@@ -9507,6 +9732,90 @@ std::vector<uint32_t> recompile_vertex(const uint32_t* code, size_t dwords,
         rs.vreg[5] = vidx;
         rs.vreg[8] = iidx;
         rs.sreg[3] = b.uconst(1);
+
+        // The merged NGG wrapper guards its whole counted ES loop with EXECZ. In the single-lane
+        // model above that one ES lane is active by construction, so the wave-empty shortcut cannot
+        // be taken. Let the ordinary counted-loop lowering consume the loop instead of rejecting the
+        // redundant outer guard merely because the original hardware mask was vector-shaped.
+        const CountedLoop loop = detect_counted_loop(ins);
+        if (loop.found) {
+            // NGG culling unrolls several EXEC-predicated LDS blocks inside its counted loop. A
+            // larger block may contain a smaller already-safe EXECZ block plus CMPX comparisons,
+            // and ends by restoring a VCC-saved mask to EXEC. The generic safe-execz pass deliberately
+            // rejects CMPX writes. Here they are exact: the branch immediately follows a CMPX that
+            // narrowed EXEC, all effects in the skipped block are EXEC-predicated (further CMPX can
+            // only narrow it again), and the common target performs the same EXEC=VCC restore on both
+            // paths. Scan inside-out so nested blocks are proven before their parents.
+            for (size_t branch_index = ins.size(); branch_index-- > 0;) {
+                const Rdna2Inst& branch = ins[branch_index];
+                if (branch.pc < loop.header_pc || branch.pc > loop.backedge_pc ||
+                    branch.fmt != Rdna2Format::SOPP || branch.opcode != 0x08 ||
+                    branch.simm16 <= 0)
+                    continue;
+                size_t previous = branch_index;
+                while (previous > 0) {
+                    --previous;
+                    if (!sopp_is_noop(ins[previous])) break;
+                }
+                if (previous >= branch_index || ins[previous].fmt != Rdna2Format::VOPC ||
+                    !vopc_is_cmpx(ins[previous].opcode))
+                    continue;
+                const uint32_t target_pc = branch_target(branch);
+                size_t target_index = ins.size();
+                for (size_t i = 0; i < ins.size(); ++i)
+                    if (ins[i].pc == target_pc) { target_index = i; break; }
+                bool restores_saved_exec = false;
+                for (size_t i = target_index; i < ins.size() && i < target_index + 3; ++i) {
+                    const Rdna2Inst& candidate = ins[i];
+                    if (candidate.fmt == Rdna2Format::SOP1 && candidate.opcode == 0x04 &&
+                        candidate.dst.value >= 126 &&
+                        (candidate.src[0].value == 106 || candidate.src[0].value == 107)) {
+                        restores_saved_exec = true;
+                        break;
+                    }
+                    bool clobbers_saved_mask = instruction_may_change_exec(candidate) ||
+                        candidate.fmt == Rdna2Format::VOPC;
+                    for_each_scalar_write(candidate, [&](int base, uint32_t width) {
+                        clobbers_saved_mask |= base < 108 && 106 < base + static_cast<int>(width);
+                    });
+                    if (clobbers_saved_mask ||
+                        (candidate.fmt == Rdna2Format::SOPP && candidate.opcode >= 0x02 &&
+                         candidate.opcode <= 0x09 && candidate.opcode != 0x03))
+                        break;
+                }
+                if (!restores_saved_exec)
+                    continue;
+                bool safe_block = true;
+                for (const auto& candidate : ins) {
+                    if (candidate.pc <= branch.pc || candidate.pc >= target_pc) continue;
+                    const bool predicated_or_masked =
+                        candidate.fmt == Rdna2Format::VOP1 ||
+                        candidate.fmt == Rdna2Format::VOP2 ||
+                        candidate.fmt == Rdna2Format::VOP3 ||
+                        candidate.fmt == Rdna2Format::VOP3P ||
+                        (candidate.fmt == Rdna2Format::VOPC &&
+                         vopc_is_cmpx(candidate.opcode)) ||
+                        candidate.fmt == Rdna2Format::MIMG ||
+                        candidate.fmt == Rdna2Format::MUBUF ||
+                        candidate.fmt == Rdna2Format::MTBUF ||
+                        candidate.fmt == Rdna2Format::DS ||
+                        candidate.fmt == Rdna2Format::FLAT;
+                    const bool nested_safe = candidate.fmt == Rdna2Format::SOPP &&
+                        candidate.opcode == 0x08 && safe_branches.count(candidate.pc);
+                    if (!predicated_or_masked && !nested_safe && !sopp_is_noop(candidate)) {
+                        safe_block = false;
+                        break;
+                    }
+                }
+                if (safe_block) safe_branches.insert(branch.pc);
+            }
+            for (const auto& in : ins) {
+                if (in.pc >= loop.header_pc) break;
+                if (in.fmt == Rdna2Format::SOPP && in.opcode == 0x08 &&
+                    branch_target(in) == loop.exit_pc)
+                    safe_branches.insert(in.pc);
+            }
+        }
     }
     bool exported = false;
     auto exp_fn = [&](const Rdna2Inst& in) -> bool {         // EXP POS0..3 -> gl_Position; PARAM -> varyings
@@ -9515,14 +9824,27 @@ std::vector<uint32_t> recompile_vertex(const uint32_t* code, size_t dwords,
         // VSRCs as full floats would pass packed-half bit patterns as x/y and stale registers as
         // z/w. Never observed in a vertex stage (compilers export positions/params at 32 bits);
         // reject fail-visibly until a live title exercises one.
-        if (in.exp_compr) return false;
+        if (in.exp_compr) {
+            if (getenv("PROSPER_DBG"))
+                fprintf(stderr, "[recompile-reject] vertex compressed export pc=%u target=%u\n",
+                        in.pc, in.exp_target);
+            return false;
+        }
         // v_cmpx is now allowed in the vertex shell (allow_exec_update=true below): a divergent block
         // (v_cmpx … s_mov_b64 exec, saved — DOLL's per-vertex lighting/fog attenuation) predicates its
         // VGPR writes like compute. A vertex MUST still export from full EXEC — the compiled shape
         // always restores EXEC before its pos/param exports; if one ever arrives narrowed, reject
         // (fail-visibly) rather than export possibly-inactive-lane values.
-        if (rs.exec_narrowed && (in.exp_target >= 32 ||
-            (in.exp_target >= 12 && in.exp_target <= 16))) return false;
+        const bool terminal_ngg_output = ngg_output_gate_begin != UINT32_MAX &&
+            in.pc > ngg_output_gate_begin && in.pc < ngg_output_gate_end;
+        if (rs.exec_narrowed && !terminal_ngg_output && (in.exp_target >= 32 ||
+            (in.exp_target >= 12 && in.exp_target <= 16))) {
+            if (getenv("PROSPER_DBG"))
+                fprintf(stderr,
+                        "[recompile-reject] vertex export under narrowed exec pc=%u target=%u\n",
+                        in.pc, in.exp_target);
+            return false;
+        }
         if (in.exp_target == 12 && !exported) {
             // POS0 is the mandatory x/y/z/w position vector. POS1..POS4 carry ancillary position
             // data (clip/cull distances, point size, viewport/layer selection according to the
@@ -9531,7 +9853,13 @@ std::vector<uint32_t> recompile_vertex(const uint32_t* code, size_t dwords,
             // existing deliberate behavior of ignoring them.
             // A position export must supply all four components (EN=0xF); a partial POS0 is not
             // meaningfully completable in the current model, so reject rather than invent components.
-            if (in.exp_en != 0xFu) return false;
+            if (in.exp_en != 0xFu) {
+                if (getenv("PROSPER_DBG"))
+                    fprintf(stderr,
+                            "[recompile-reject] partial vertex position export pc=%u en=0x%x\n",
+                            in.pc, in.exp_en);
+                return false;
+            }
             b.export_position(operand_bits(b, rs, in, in.src[0], &eok), operand_bits(b, rs, in, in.src[1], &eok),
                               operand_bits(b, rs, in, in.src[2], &eok), operand_bits(b, rs, in, in.src[3], &eok));
             exported = true;
@@ -9556,8 +9884,17 @@ std::vector<uint32_t> recompile_vertex(const uint32_t* code, size_t dwords,
         }
         return eok;
     };
-    if (!emit_body(b, rs, ins, safe_branches, rt, /*allow_exec_update*/true, /*allow_smem*/rt != nullptr, exp_fn, code, dwords)) return {};
-    if (!exported) return {};
+    if (!emit_body(b, rs, ins, safe_branches, rt, /*allow_exec_update*/true,
+                   /*allow_smem*/rt != nullptr, exp_fn, code, dwords)) {
+        if (getenv("PROSPER_DBG"))
+            fprintf(stderr, "[recompile-reject] vertex body failed\n");
+        return {};
+    }
+    if (!exported) {
+        if (getenv("PROSPER_DBG"))
+            fprintf(stderr, "[recompile-reject] vertex emitted no position\n");
+        return {};
+    }
     // OFFSET=0x20 asks the interpolator to synthesize a constant instead of consuming a PARAM
     // export. GFX10 DEFAULT_VAL encodes 0000, 0001, 1110, and 1111. Materialize those outputs in
     // the Vulkan vertex stage, whose fixed-function interface has no equivalent default source.

--- a/prosper/src/gpu/rdna2_to_spirv.hpp
+++ b/prosper/src/gpu/rdna2_to_spirv.hpp
@@ -179,6 +179,12 @@ std::vector<uint32_t> recompile_vertex(const uint32_t* code, size_t dwords,
                                        const PixelInputMapping* pixel_inputs = nullptr,
                                        bool capture_position = false);
 
+// Test hook: allow a tiny synthetic NGG shader to reach the terminal EXEC-gated export lowering so
+// Vulkan tests can execute both active and inactive outcomes. Production recompile_vertex keeps that
+// exception restricted to the byte-exact observed Astro wrapper.
+std::vector<uint32_t> recompile_vertex_terminal_ngg_gate_for_test(
+    const uint32_t* code, size_t dwords);
+
 // How much of a shader the recompiler currently covers (per-instruction), without requiring the
 // stream to be a complete vertex/fragment. `alu` = instructions emit_alu handles (VALU/scalar/
 // control-flow); `exports` = EXP (handled by the stage recompilers); `unsupported` = not yet handled

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -744,6 +744,14 @@ static_assert(offsetof(AgcShader, user_data) == 0x08 && offsetof(AgcShader, code
 // store mid-iteration — a use-after-free read, not the "benign stale read" it was assumed to be.
 std::mutex&                      agc_shaders_mx() { static std::mutex m; return m; }
 std::vector<const AgcShader*>&   agc_shaders()   { static std::vector<const AgcShader*> v; return v; }
+struct AgcFusedShaderPair {
+    uint64_t front_code = 0;
+    const AgcShader* back = nullptr;
+};
+std::vector<AgcFusedShaderPair>& agc_fused_shader_pairs() {
+    static std::vector<AgcFusedShaderPair> v;
+    return v;
+}
 
 // Relocate one self-relative pointer field in place. SDK shader blobs use small forward offsets from
 // the pointer field; linked guest pointers live above 4 GiB. Inspect the field representation rather
@@ -777,6 +785,21 @@ extern "C" const void* prosper_agc_shader_header_for_code(uint64_t code_addr) {
     for (const AgcShader* h : agc_shaders())
         if (h && (uint64_t)(uintptr_t)h->code == code_addr) return h;
     return nullptr;
+}
+
+// A fused GS/HS programs the front-half address into the stage register while retaining the actual
+// shader body in the back-half header. Preserve that association for the Vulkan executor, which sees
+// only the bound front address after PM4 decoding.
+extern "C" const void* prosper_agc_fused_back_header_for_front(uint64_t front_code_addr) {
+    if (!front_code_addr) return nullptr;
+    std::lock_guard<std::mutex> lk(agc_shaders_mx());
+    const AgcShader* match = nullptr;
+    for (const auto& pair : agc_fused_shader_pairs()) {
+        if (pair.front_code != front_code_addr) continue;
+        if (match && match->code != pair.back->code) return nullptr; // ambiguous reuse: fail closed
+        match = pair.back;
+    }
+    return match;
 }
 
 // Bounded RE probe (PROSPER_PIPETRACE): log the raw pointer args of the shader/pipeline construction
@@ -1045,6 +1068,16 @@ HLE(agc_fuse_shader_halves) {  // (Shader* dst, const Shader* front, const Shade
                                  SPI_SHADER_PGM_LO_LS, (uint64_t)(uintptr_t)front->code);
     }
     dst->user_data = nullptr;
+    {
+        std::lock_guard<std::mutex> lk(agc_shaders_mx());
+        const uint64_t front_code = (uint64_t)(uintptr_t)front->code;
+        auto& pairs = agc_fused_shader_pairs();
+        auto found = std::find_if(pairs.begin(), pairs.end(), [front_code, back](const auto& pair) {
+            return pair.front_code == front_code && pair.back->code == back->code;
+        });
+        if (found == pairs.end()) pairs.push_back({front_code, back});
+        else found->back = back;
+    }
     return 0;
 }
 

--- a/prosper/tests/test_agc_shader.cpp
+++ b/prosper/tests/test_agc_shader.cpp
@@ -69,6 +69,7 @@ int fails = 0;
 } // namespace
 
 extern "C" size_t prosper_agc_shader_count();
+extern "C" const void* prosper_agc_fused_back_header_for_front(uint64_t front_code_addr);
 
 int main() {
     printf("== test_agc_shader ==\n");
@@ -142,6 +143,9 @@ int main() {
               "GS fusion replaces both checksums without disturbing other back registers");
         CHECK(back_regs[0].value == 0 && back_regs[2].value == 0xaaaaaaaau,
               "GS fusion leaves the source back-half register array unchanged");
+        CHECK(prosper_agc_fused_back_header_for_front(
+                  reinterpret_cast<uint64_t>(front.code)) == &back,
+              "GS fusion publishes the back-half body for the bound front address");
 
         ShaderRegister hs_regs[] = {
             {SPI_SHADER_PGM_LO_LS, 0},

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -419,6 +419,58 @@ int main() {
     CHECK(have_cbuf, "kernel 5 s_buffer_load reports a ConstantBuffer table-use keyed by the V# load imm");
     CHECK(cbuf_ok,   "kernel 5 V# dwords match the table as loaded");
 
+    // A fused NGG back shader receives a driver stage-data pointer in system s[0:1], before user
+    // data begins at s8. Its prologue loads the live V# from that table into s[8:11]. Preserve those
+    // system seeds so the exact consuming MUBUF can be resolved like any other loaded descriptor.
+    static uint32_t ngg_stage_data[4];
+    static uint32_t ngg_vertices[16];
+    const uint64_t ngg_vertex_base = reinterpret_cast<uint64_t>(ngg_vertices);
+    ngg_stage_data[0] = static_cast<uint32_t>(ngg_vertex_base);
+    ngg_stage_data[1] = static_cast<uint32_t>(ngg_vertex_base >> 32);
+    ngg_stage_data[2] = 16;
+    ngg_stage_data[3] = 0;
+    const uint32_t ngg_system_sgprs[2] = {
+        static_cast<uint32_t>(reinterpret_cast<uint64_t>(ngg_stage_data)),
+        static_cast<uint32_t>(reinterpret_cast<uint64_t>(ngg_stage_data) >> 32),
+    };
+    const uint32_t ngg_loaded_vsharp[] = {
+        0xF4080200u, 0xFA000000u,   // s_load_dwordx4 s[8:11], s[0:1], 0
+        0xE0002000u, 0x80020100u,   // buffer_load_format_x v1, v0, s[8:11], 0 idxen
+        0xBF810000u,
+    };
+    const auto ngg_fetches = resolve_dynamic_fetch(
+        ngg_loaded_vsharp, std::size(ngg_loaded_vsharp), nullptr, 0, 8, nullptr,
+        UINT32_MAX, nullptr, ngg_system_sgprs, std::size(ngg_system_sgprs));
+    CHECK(ngg_fetches.size() == 1 && ngg_fetches[0].fetch_pc == 2 &&
+              ngg_fetches[0].desc.base == ngg_vertex_base,
+          "fused NGG system stage-data pointer resolves its loaded vertex descriptor");
+
+    // Astro Bot loads four consecutive V# descriptors from the same stage-data pointer in one
+    // s_load_dwordx16, then consumes the first with an untyped MUBUF operation. The wide load is
+    // still descriptor provenance, but must resolve by consuming pc because its one immediate
+    // offset cannot identify which of the four V#s was selected.
+    alignas(16) static uint32_t ngg_wide_stage_data[16]{};
+    std::copy(std::begin(ngg_stage_data), std::end(ngg_stage_data),
+              std::begin(ngg_wide_stage_data));
+    const uint32_t ngg_wide_system_sgprs[2] = {
+        static_cast<uint32_t>(reinterpret_cast<uint64_t>(ngg_wide_stage_data)),
+        static_cast<uint32_t>(reinterpret_cast<uint64_t>(ngg_wide_stage_data) >> 32),
+    };
+    const uint32_t ngg_loaded_wide_vsharp[] = {
+        0xF4100200u, 0xFA000000u,   // s_load_dwordx16 s[8:23], s[0:1], 0
+        0xE0382020u, 0x80020509u,   // buffer_load_dwordx4 v[5:8], v9, s[8:11], s2 offen
+        0xBF810000u,
+    };
+    std::vector<SrtUse> ngg_wide_uses;
+    resolve_dynamic_fetch(
+        ngg_loaded_wide_vsharp, std::size(ngg_loaded_wide_vsharp), nullptr, 0, 8,
+        &ngg_wide_uses, UINT32_MAX, nullptr, ngg_wide_system_sgprs,
+        std::size(ngg_wide_system_sgprs));
+    CHECK(ngg_wide_uses.size() == 1 && ngg_wide_uses[0].use_pc == 2 &&
+              ngg_wide_uses[0].key == 0xFFFFFFFFu &&
+              decode_buffer_descriptor(ngg_wide_uses[0].v4.data()).base == ngg_vertex_base,
+          "fused NGG x16 stage-data load publishes its raw-buffer V# by consuming pc");
+
     // Kernel 5n: an s_buffer_load_dwordx8 result is typeless SGPR data. A later scalar buffer load
     // may consume its first four words as a nested V#, as DOLL's post-process shader does. Since the
     // V# came through another buffer descriptor it has no immediate key; preserve it by consumer pc.

--- a/prosper/tests/test_rdna2_decode.cpp
+++ b/prosper/tests/test_rdna2_decode.cpp
@@ -187,6 +187,17 @@ int main() {
     Rdna2Inst sd = rdna2_decode_one(sdwa, 2);
     CHECK(sd.fmt == Rdna2Format::VOP2 && sd.len_dwords == 2 && sd.has_modifier,
           "VOP2 SDWA form is 2 dwords and flagged has_modifier");
+    const uint32_t ngg_byte_shift[] = { 0x340018f9u, 0x02860682u };
+    Rdna2Inst nbs = rdna2_decode_one(ngg_byte_shift, 2);
+    CHECK(nbs.fmt == Rdna2Format::VOP2 && nbs.opcode == 0x1Au && !nbs.has_modifier &&
+          isV(nbs.dst, 0) && nbs.src[0].kind == OperandKind::InlineInt &&
+          nbs.src[0].value == 2 && isV(nbs.src[1], 12) && nbs.sdwa_src1_sel == 2u,
+          "Astro NGG byte-select v_lshlrev SDWA packet is admitted exactly");
+    const uint32_t ngg_word_shift[] = { 0x34001ef9u, 0x05860682u };
+    Rdna2Inst nws = rdna2_decode_one(ngg_word_shift, 2);
+    CHECK(nws.fmt == Rdna2Format::VOP2 && nws.opcode == 0x1Au && !nws.has_modifier &&
+          isV(nws.src[1], 15) && nws.sdwa_src1_sel == 5u,
+          "Astro NGG word-select v_lshlrev SDWA packet is admitted exactly");
     const uint32_t f16cmp[] = { 0x7db900f9u, 0x86050007u };
     Rdna2Inst fc = rdna2_decode_one(f16cmp, 2);
     CHECK(fc.fmt == Rdna2Format::VOPC && fc.opcode == 0xDCu && !fc.has_modifier &&
@@ -206,6 +217,11 @@ int main() {
     Rdna2Inst dp = rdna2_decode_one(dpp16, 2);
     CHECK(dp.fmt == Rdna2Format::VOP2 && dp.len_dwords == 2 && dp.has_modifier,
           "VOP2 DPP16 form is 2 dwords and flagged has_modifier");
+    const uint32_t ngg_row_shift[] = { 0x4a1e1efau, 0xff09110fu };
+    Rdna2Inst nrs = rdna2_decode_one(ngg_row_shift, 2);
+    CHECK(nrs.fmt == Rdna2Format::VOP2 && nrs.opcode == 0x25u && !nrs.has_modifier &&
+          nrs.has_dpp && nrs.dpp_ctrl == 0x111u && isV(nrs.src[0], 15) && isV(nrs.src[1], 15),
+          "Astro NGG bounded DPP row-right add is admitted exactly");
     const uint32_t dpp8[] = { 0x4a0e0ce9u, 0xfac68806u };    // v_add_nc_u32_dpp v7, v6, v6 dpp8:[...]
     Rdna2Inst d8 = rdna2_decode_one(dpp8, 2);
     CHECK(d8.fmt == Rdna2Format::VOP2 && d8.len_dwords == 2 && d8.has_modifier,

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -260,8 +260,8 @@ int main() {
     }
     printf("  [ok]   NGG EXEC wave-pack control flow emits only valid nonzero OpPhi ids\n");
 
-    // In a one-lane NGG vertex invocation, s_bcnt1_i32_b64 of a wave mask is the integer value of
-    // that lane's Boolean bit (0/1). Astro Bot uses this in its final primitive packing arithmetic.
+    // A GS_ALLOC_REQ marker alone does not prove the one-lane model. An unrelated NGG shader that
+    // reaches a wave population count must remain fail-closed rather than silently counting lane 0.
     const uint32_t ngg_mask_count[] = {
         0xBF900009u,                         // s_sendmsg GS_ALLOC_REQ (marks NGG)
         0xBEEA04C1u,                         // s_mov_b64 vcc, -1
@@ -271,20 +271,19 @@ int main() {
         0xF80008CFu, 0x03020100u,            // exp pos0 v0,v1,v2,v3
         0xBF810000u,
     };
-    const auto ngg_mask_count_spv = recompile_vertex(
-        ngg_mask_count, sizeof(ngg_mask_count) / sizeof(ngg_mask_count[0]));
-    if (ngg_mask_count_spv.empty() || !phi_ids_are_nonzero(ngg_mask_count_spv)) {
-        printf("  [FAIL] NGG one-lane mask population count did not produce valid SPIR-V\n");
+    if (!recompile_vertex(ngg_mask_count,
+                          sizeof(ngg_mask_count) / sizeof(ngg_mask_count[0])).empty()) {
+        printf("  [FAIL] unproven NGG accepted one-lane mask population count\n");
         return 1;
     }
-    printf("  [ok]   NGG one-lane mask population count produces valid SPIR-V\n");
+    printf("  [ok]   unproven NGG rejects one-lane mask population count\n");
 
-    // The terminal NGG output gate is a compacted-vertex ownership test. Unlike a general vertex
-    // CMPX/export (tested below), this exact output-only branch may retain the narrowed EXEC while
-    // exporting from the one-lane Vulkan representation.
+    // A constant terminal NGG output gate cannot mix active and inactive host vertices, so it is a
+    // topology-independent fixture for the output selection. Data-dependent gates remain restricted
+    // to the byte-exact Astro wrapper and are rejected immediately below.
     const uint32_t ngg_output_gate[] = {
         0xBF900009u,                         // s_sendmsg GS_ALLOC_REQ (marks NGG)
-        0x7DA80300u,                         // v_cmpx_* (narrows EXEC)
+        0x7C3E0300u,                         // v_cmpx_tru_f32 (uniformly narrows no lanes)
         0xBF880002u,                         // s_cbranch_execz -> s_endpgm
         0xF80008CFu, 0x03020100u,            // exp pos0 v0,v1,v2,v3
         0xBF810000u,
@@ -297,9 +296,24 @@ int main() {
     }
     printf("  [ok]   terminal NGG compacted-vertex output gate produces valid SPIR-V\n");
 
-    // NGG uses small inline B64 masks (1/3/15) while packing its final partial wave. Vertex SPIR-V
-    // has no LocalInvocationIndex; the one-lane model must read bit zero directly rather than emit an
-    // integer operation with the compute-only built-in's absent (zero) ID.
+    // A per-vertex CMPX under the same superficial terminal shape can create mixed active/inactive
+    // primitives. Without the byte-exact Astro wrapper/topology proof it must remain rejected.
+    const uint32_t unproven_ngg_output_gate[] = {
+        0xBF900009u,
+        0x7DA80300u,                         // data-dependent v_cmpx_*
+        0xBF880002u,
+        0xF80008CFu, 0x03020100u,
+        0xBF810000u,
+    };
+    if (!recompile_vertex(unproven_ngg_output_gate,
+                          std::size(unproven_ngg_output_gate)).empty()) {
+        printf("  [FAIL] unproven NGG accepted a mixed terminal output gate\n");
+        return 1;
+    }
+    printf("  [ok]   unproven NGG mixed terminal output gate remains fail-closed\n");
+
+    // Small inline B64 masks are also lane-sensitive. Merely resembling an NGG wrapper cannot opt a
+    // shader into the captured Astro program's lane-zero projection.
     const uint32_t ngg_inline_mask[] = {
         0xBF900009u,                         // s_sendmsg GS_ALLOC_REQ (marks NGG)
         0x92EA8081u,                         // s_bfm_b64 vcc, 1, 0 (lane-zero mask)
@@ -308,15 +322,12 @@ int main() {
         0xF80008CFu, 0x03020100u,            // exp pos0 v0,v1,v2,v3
         0xBF810000u,
     };
-    const auto ngg_inline_mask_spv = recompile_vertex(
-        ngg_inline_mask, sizeof(ngg_inline_mask) / sizeof(ngg_inline_mask[0]));
-    constexpr uint32_t OpBitwiseAnd = 199;
-    if (ngg_inline_mask_spv.empty() ||
-        !binary_id_operands_are_nonzero(ngg_inline_mask_spv, OpBitwiseAnd)) {
-        printf("  [FAIL] NGG inline mask referenced an absent vertex local-invocation id\n");
+    if (!recompile_vertex(ngg_inline_mask,
+                          sizeof(ngg_inline_mask) / sizeof(ngg_inline_mask[0])).empty()) {
+        printf("  [FAIL] unproven NGG accepted lane-zero inline-mask semantics\n");
         return 1;
     }
-    printf("  [ok]   NGG inline mask uses the modeled lane-zero bit without invalid ids\n");
+    printf("  [ok]   unproven NGG rejects lane-zero inline-mask semantics\n");
 
     // The same wave shortcut is not valid for an ordinary vertex shader: without the exact NGG
     // allocation message there is no proof that a Vulkan invocation represents guest lane zero.

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -278,9 +278,8 @@ int main() {
     }
     printf("  [ok]   unproven NGG rejects one-lane mask population count\n");
 
-    // A constant terminal NGG output gate cannot mix active and inactive host vertices, so it is a
-    // topology-independent fixture for the output selection. Data-dependent gates remain restricted
-    // to the byte-exact Astro wrapper and are rejected immediately below.
+    // Exercise the output-selection emitter through its explicit test hook. The production entry
+    // point restricts every terminal NGG gate to the byte-exact Astro wrapper, as checked below.
     const uint32_t ngg_output_gate[] = {
         0xBF900009u,                         // s_sendmsg GS_ALLOC_REQ (marks NGG)
         0x7C3E0300u,                         // v_cmpx_tru_f32 (uniformly narrows no lanes)
@@ -288,13 +287,18 @@ int main() {
         0xF80008CFu, 0x03020100u,            // exp pos0 v0,v1,v2,v3
         0xBF810000u,
     };
-    const auto ngg_output_gate_spv = recompile_vertex(
+    const auto ngg_output_gate_spv = recompile_vertex_terminal_ngg_gate_for_test(
         ngg_output_gate, sizeof(ngg_output_gate) / sizeof(ngg_output_gate[0]));
     if (ngg_output_gate_spv.empty() || !phi_ids_are_nonzero(ngg_output_gate_spv)) {
         printf("  [FAIL] terminal NGG compacted-vertex output gate did not produce valid SPIR-V\n");
         return 1;
     }
     printf("  [ok]   terminal NGG compacted-vertex output gate produces valid SPIR-V\n");
+    if (!recompile_vertex(ngg_output_gate, std::size(ngg_output_gate)).empty()) {
+        printf("  [FAIL] production accepted an unproven constant NGG output gate\n");
+        return 1;
+    }
+    printf("  [ok]   production rejects unproven constant NGG output gates (including points)\n");
 
     // A per-vertex CMPX under the same superficial terminal shape can create mixed active/inactive
     // primitives. Without the byte-exact Astro wrapper/topology proof it must remain rejected.

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -318,6 +318,42 @@ int main() {
     }
     printf("  [ok]   NGG inline mask uses the modeled lane-zero bit without invalid ids\n");
 
+    // The same wave shortcut is not valid for an ordinary vertex shader: without the exact NGG
+    // allocation message there is no proof that a Vulkan invocation represents guest lane zero.
+    const uint32_t ordinary_vertex_mask_count[] = {
+        0xBEEA04C1u,                         // s_mov_b64 vcc, -1
+        0xBE80106Au,                         // s_bcnt1_i32_b64 s0, vcc
+        0x7E000C00u,                         // v_cvt_f32_u32 v0, s0
+        0x7E020280u, 0x7E040280u, 0x7E0602F2u,
+        0xF80008CFu, 0x03020100u,
+        0xBF810000u,
+    };
+    if (!recompile_vertex(ordinary_vertex_mask_count,
+                          std::size(ordinary_vertex_mask_count)).empty()) {
+        printf("  [FAIL] ordinary vertex shader accepted NGG lane-zero mask semantics\n");
+        return 1;
+    }
+    printf("  [ok]   ordinary vertex shader rejects NGG-only lane-zero mask semantics\n");
+
+    // Even an exact GS_ALLOC_REQ marker does not make arbitrary LDS lane-local. A peer-addressed
+    // write/barrier/read shape must stay fail-closed unless the complete observed Astro wrapper is
+    // selected by its byte-exact fingerprint.
+    const uint32_t unproven_ngg_peer_lds[] = {
+        0xBF900009u,                         // s_sendmsg GS_ALLOC_REQ
+        0x7E000280u, 0x7E020281u,            // v0=0 byte address, v1=1 data
+        0xD8340000u, 0x00000100u,            // ds_write_b32 v0, v1
+        0xBF8A0000u,                         // s_barrier
+        0xD8D80000u, 0x02000000u,            // ds_read_b32 v2, v0
+        0x7E060280u, 0x7E0802F2u,
+        0xF80008CFu, 0x04030302u,
+        0xBF810000u,
+    };
+    if (!recompile_vertex(unproven_ngg_peer_lds, std::size(unproven_ngg_peer_lds)).empty()) {
+        printf("  [FAIL] unproven NGG peer-LDS shader accepted private one-lane LDS semantics\n");
+        return 1;
+    }
+    printf("  [ok]   unproven NGG peer-LDS shader remains fail-closed\n");
+
     // v_cmpx_* narrows EXEC. A FRAGMENT export under a narrowed EXEC is a discard (alpha test / kill): it
     // now lowers to a per-invocation OpKill of the inactive lanes followed by an export from the survivors,
     // so fragment recompilation ACCEPTS it and emits valid SPIR-V. (A VERTEX shader cannot discard — OpKill

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -85,6 +85,21 @@ bool has_opcode(const std::vector<uint32_t>& spv, uint32_t opcode) {
     return false;
 }
 
+bool binary_id_operands_are_nonzero(const std::vector<uint32_t>& spv, uint32_t opcode) {
+    if (spv.size() < 5) return false;
+    for (size_t i = 5; i < spv.size();) {
+        const uint32_t word = spv[i];
+        const uint32_t op = word & 0xffffu, wc = word >> 16u;
+        if (wc == 0 || i + wc > spv.size()) return false;
+        // Integer binary operations are {result type, result id, operand 1 id, operand 2 id}.
+        if (op == opcode && (wc != 5 || !spv[i + 1] || !spv[i + 2] ||
+                             !spv[i + 3] || !spv[i + 4]))
+            return false;
+        i += wc;
+    }
+    return true;
+}
+
 bool phi_ids_are_nonzero(const std::vector<uint32_t>& spv) {
     constexpr uint32_t OpPhi = 245;
     if (spv.size() < 5) return false;
@@ -244,6 +259,64 @@ int main() {
         return 1;
     }
     printf("  [ok]   NGG EXEC wave-pack control flow emits only valid nonzero OpPhi ids\n");
+
+    // In a one-lane NGG vertex invocation, s_bcnt1_i32_b64 of a wave mask is the integer value of
+    // that lane's Boolean bit (0/1). Astro Bot uses this in its final primitive packing arithmetic.
+    const uint32_t ngg_mask_count[] = {
+        0xBF900009u,                         // s_sendmsg GS_ALLOC_REQ (marks NGG)
+        0xBEEA04C1u,                         // s_mov_b64 vcc, -1
+        0xBE80106Au,                         // s_bcnt1_i32_b64 s0, vcc
+        0x7E000C00u,                         // v_cvt_f32_u32 v0, s0
+        0x7E020280u, 0x7E040280u, 0x7E0602F2u,
+        0xF80008CFu, 0x03020100u,            // exp pos0 v0,v1,v2,v3
+        0xBF810000u,
+    };
+    const auto ngg_mask_count_spv = recompile_vertex(
+        ngg_mask_count, sizeof(ngg_mask_count) / sizeof(ngg_mask_count[0]));
+    if (ngg_mask_count_spv.empty() || !phi_ids_are_nonzero(ngg_mask_count_spv)) {
+        printf("  [FAIL] NGG one-lane mask population count did not produce valid SPIR-V\n");
+        return 1;
+    }
+    printf("  [ok]   NGG one-lane mask population count produces valid SPIR-V\n");
+
+    // The terminal NGG output gate is a compacted-vertex ownership test. Unlike a general vertex
+    // CMPX/export (tested below), this exact output-only branch may retain the narrowed EXEC while
+    // exporting from the one-lane Vulkan representation.
+    const uint32_t ngg_output_gate[] = {
+        0xBF900009u,                         // s_sendmsg GS_ALLOC_REQ (marks NGG)
+        0x7DA80300u,                         // v_cmpx_* (narrows EXEC)
+        0xBF880002u,                         // s_cbranch_execz -> s_endpgm
+        0xF80008CFu, 0x03020100u,            // exp pos0 v0,v1,v2,v3
+        0xBF810000u,
+    };
+    const auto ngg_output_gate_spv = recompile_vertex(
+        ngg_output_gate, sizeof(ngg_output_gate) / sizeof(ngg_output_gate[0]));
+    if (ngg_output_gate_spv.empty() || !phi_ids_are_nonzero(ngg_output_gate_spv)) {
+        printf("  [FAIL] terminal NGG compacted-vertex output gate did not produce valid SPIR-V\n");
+        return 1;
+    }
+    printf("  [ok]   terminal NGG compacted-vertex output gate produces valid SPIR-V\n");
+
+    // NGG uses small inline B64 masks (1/3/15) while packing its final partial wave. Vertex SPIR-V
+    // has no LocalInvocationIndex; the one-lane model must read bit zero directly rather than emit an
+    // integer operation with the compute-only built-in's absent (zero) ID.
+    const uint32_t ngg_inline_mask[] = {
+        0xBF900009u,                         // s_sendmsg GS_ALLOC_REQ (marks NGG)
+        0x92EA8081u,                         // s_bfm_b64 vcc, 1, 0 (lane-zero mask)
+        0xBEFE0481u,                         // s_mov_b64 exec, 1
+        0xBEFE04C1u,                         // s_mov_b64 exec, -1 (restore before export)
+        0xF80008CFu, 0x03020100u,            // exp pos0 v0,v1,v2,v3
+        0xBF810000u,
+    };
+    const auto ngg_inline_mask_spv = recompile_vertex(
+        ngg_inline_mask, sizeof(ngg_inline_mask) / sizeof(ngg_inline_mask[0]));
+    constexpr uint32_t OpBitwiseAnd = 199;
+    if (ngg_inline_mask_spv.empty() ||
+        !binary_id_operands_are_nonzero(ngg_inline_mask_spv, OpBitwiseAnd)) {
+        printf("  [FAIL] NGG inline mask referenced an absent vertex local-invocation id\n");
+        return 1;
+    }
+    printf("  [ok]   NGG inline mask uses the modeled lane-zero bit without invalid ids\n");
 
     // v_cmpx_* narrows EXEC. A FRAGMENT export under a narrowed EXEC is a discard (alpha test / kill): it
     // now lowers to a per-invocation OpKill of the inactive lanes followed by an export from the survivors,

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -1909,6 +1909,31 @@ int main() {
     printf("  kernel37 mismatches=%u (out[5]=%g expect=%g)\n", bad37, got37.size()==N?got37[5]:-1, exp37[5]);
     CHECK(got37.size()==N && bad37==0, "recompiled kernel 37 (s_movk_i32 -100) computes a0-100");
 
+    // Kernel 37a: s_cmpk_le_u32 compares the SGPR named by SOPK's SDST field against the raw
+    // unsigned 16-bit immediate and writes SCC without changing that SGPR. Cover both sides of the
+    // 0xffff boundary used by Astro Bot's NGG primitive-count setup.
+    const uint32_t code37a_true[] = {
+        0xB000007Bu, 0xB700FFFFu, 0x850287AAu, 0x7E000C02u, 0xBF810000u,
+    };
+    const uint32_t code37a_false[] = {
+        0xB000FFFFu, 0xB700FFFFu, 0x850287AAu, 0x7E000C02u, 0xBF810000u,
+    };
+    std::vector<uint32_t> spv37a_true = recompile_valu(
+        code37a_true, std::size(code37a_true), 1, 0);
+    std::vector<uint32_t> spv37a_false = recompile_valu(
+        code37a_false, std::size(code37a_false), 1, 0);
+    CHECK(!spv37a_true.empty() && !spv37a_false.empty(),
+          "recompiled kernel 37a (s_cmpk_le_u32, both SCC paths) -> SPIR-V");
+    std::vector<float> got37a_true = prosper::test::run_compute(spv37a_true, in37, N, N);
+    std::vector<float> got37a_false = prosper::test::run_compute(spv37a_false, in37, N, N);
+    uint32_t bad37a = 0;
+    for (uint32_t i=0;i<N&&got37a_true.size()==N;i++)
+        if (got37a_true[i] != 42.0f) bad37a++;
+    for (uint32_t i=0;i<N&&got37a_false.size()==N;i++)
+        if (got37a_false[i] != 7.0f) bad37a++;
+    CHECK(got37a_true.size()==N && got37a_false.size()==N && bad37a==0,
+          "kernel 37a: s_cmpk_le_u32 treats 0xffff as unsigned and drives s_cselect");
+
     // Astro Bot's loading composite starts with s_brev_b32 s16,1 to construct 0x80000000.
     // AMD ISA 70648 also specifies that S_BREV does not set SCC. Seed SCC=true, reverse bit 0,
     // then select the reversed value through SCC so the test covers both contracts.
@@ -1994,6 +2019,21 @@ int main() {
     uint32_t bad42 = 0; for (uint32_t i=0;i<N&&got42.size()==N;i++) if (std::fabs(got42[i]-268435456.0f)>16.0f) bad42++;
     printf("  kernel42 mismatches=%u (out[5]=%g expect=268435456)\n", bad42, got42.size()==N?got42[5]:-1);
     CHECK(got42.size()==N && bad42==0, "recompiled kernel 42 (s_mul_hi_u32) computes hi(2^60)=2^28");
+
+    // Astro Bot's NGG primitive packer combines two 16-bit population counts with
+    // s_pack_ll_b32_b16. Pack 1 and 2 -> 0x00020001, then convert to an exactly representable f32.
+    const uint32_t code42b[] = {
+        0xB0000001u, 0xB0010002u, 0x99020100u, 0x7E000C02u, 0xBF810000u,
+    };
+    std::vector<uint32_t> spv42b = recompile_valu(
+        code42b, sizeof(code42b) / sizeof(code42b[0]), 0, 0);
+    CHECK(!spv42b.empty(), "recompiled kernel 42b (s_pack_ll_b32_b16) -> SPIR-V");
+    std::vector<float> got42b = prosper::test::run_compute(spv42b, in42, N, N);
+    uint32_t bad42b = 0;
+    for (uint32_t i = 0; i < N && got42b.size() == N; ++i)
+        if (got42b[i] != 131073.0f) ++bad42b;
+    CHECK(got42b.size() == N && bad42b == 0,
+          "s_pack_ll_b32_b16 packs {S1.low16,S0.low16}");
 
     // Kernel 43: a real COUNTED LOOP reconstructed as structured SPIR-V (OpLoopMerge + OpPhi for the
     //   loop-carried s0 and v1). sum=0; for (i=0; i<5; i++) sum+=i;  =>  sum = 0+1+2+3+4 = 10.

--- a/prosper/tests/test_recompiled_shaders.cpp
+++ b/prosper/tests/test_recompiled_shaders.cpp
@@ -8,6 +8,7 @@
 #include "render_runner.h"
 #include <cstdio>
 #include <cstdint>
+#include <iterator>
 #include <vector>
 
 using namespace prosper::gpu;
@@ -72,6 +73,57 @@ int main() {
         printf("  NGG: inside(16,16)green=%d outside(60,60)notgreen=%d\n", inside_green, outside_not);
         CHECK(npx.size()==(size_t)W*H*4, "pipeline accepted the recompiled NGG VS + rendered");
         CHECK(inside_green && outside_not, "NGG VS geometry correct (v5->lower-left-half triangle)");
+    }
+
+    // Terminal NGG compaction gates its POS/PARAM exports with CMPX + EXECZ. The vertex shell cannot
+    // suppress a Vulkan invocation, so inactive suffix vertices must be mapped to one degenerate clip
+    // point while active vertices retain their real positions. Exercise both Boolean outcomes through
+    // the real rasterizer: active renders the same lower-left triangle; inactive renders no fragments.
+    const uint32_t ngg_gate_active[] = {
+        0xBF900009u,                         // s_sendmsg GS_ALLOC_REQ
+        0x34040A81u, 0x36060AC2u,           // v2/v3 from NGG v5 vertex index
+        0x7E000280u, 0x7E0202F2u,
+        0x36040482u, 0x4A0606C1u, 0x4A0404C1u,
+        0x7E060B03u, 0x7E040B02u,           // triangle position in v2,v3,v0,v1
+        0x7E280281u, 0x7E2A0280u,           // v20=1, v21=0
+        0x7DA82B14u,                         // v_cmpx_gt_u32 v20, v21 -> true
+        0xBF880002u,                         // s_cbranch_execz -> end
+        0xF80008CFu, 0x01000302u,
+        0xBF810000u,
+    };
+    const uint32_t ngg_gate_inactive[] = {
+        0xBF900009u,
+        0x34040A81u, 0x36060AC2u,
+        0x7E000280u, 0x7E0202F2u,
+        0x36040482u, 0x4A0606C1u, 0x4A0404C1u,
+        0x7E060B03u, 0x7E040B02u,
+        0x7E280280u, 0x7E2A0280u,           // v20=0, v21=0
+        0x7DA82B14u,                         // v_cmpx_gt_u32 v20, v21 -> false
+        0xBF880002u,
+        0xF80008CFu, 0x01000302u,
+        0xBF810000u,
+    };
+    const auto active_gate_spv = recompile_vertex(
+        ngg_gate_active, std::size(ngg_gate_active));
+    const auto inactive_gate_spv = recompile_vertex(
+        ngg_gate_inactive, std::size(ngg_gate_inactive));
+    CHECK(!active_gate_spv.empty() && !inactive_gate_spv.empty(),
+          "terminal NGG output gate recompiles for active and inactive paths");
+    if (!active_gate_spv.empty() && !inactive_gate_spv.empty()) {
+        const auto active_px = prosper::test::render_triangle_rgba(active_gate_spv, frag, W, H);
+        const auto inactive_px = prosper::test::render_triangle_rgba(inactive_gate_spv, frag, W, H);
+        auto green_pixels = [&](const std::vector<uint8_t>& pixels) {
+            size_t count = 0;
+            for (size_t i = 0; i + 3 < pixels.size(); i += 4)
+                count += pixels[i + 1] > 0x80 && pixels[i] < 0x40 && pixels[i + 2] < 0x40;
+            return count;
+        };
+        const size_t active_green = green_pixels(active_px);
+        const size_t inactive_green = green_pixels(inactive_px);
+        printf("  NGG gate: active-green=%zu inactive-green=%zu\n",
+               active_green, inactive_green);
+        CHECK(active_green > 0, "active terminal NGG output path retains real geometry");
+        CHECK(inactive_green == 0, "inactive terminal NGG output path degenerates the vertex tail");
     }
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }

--- a/prosper/tests/test_recompiled_shaders.cpp
+++ b/prosper/tests/test_recompiled_shaders.cpp
@@ -85,8 +85,8 @@ int main() {
         0x7E000280u, 0x7E0202F2u,
         0x36040482u, 0x4A0606C1u, 0x4A0404C1u,
         0x7E060B03u, 0x7E040B02u,           // triangle position in v2,v3,v0,v1
-        0x7E280281u, 0x7E2A0280u,           // v20=1, v21=0
-        0x7DA82B14u,                         // v_cmpx_gt_u32 v20, v21 -> true
+        0x7E280281u, 0x7E2A0280u,
+        0x7C3E2B14u,                         // v_cmpx_tru_f32 -> every invocation active
         0xBF880002u,                         // s_cbranch_execz -> end
         0xF80008CFu, 0x01000302u,
         0xBF810000u,
@@ -98,7 +98,7 @@ int main() {
         0x36040482u, 0x4A0606C1u, 0x4A0404C1u,
         0x7E060B03u, 0x7E040B02u,
         0x7E280280u, 0x7E2A0280u,           // v20=0, v21=0
-        0x7DA82B14u,                         // v_cmpx_gt_u32 v20, v21 -> false
+        0x7C202B14u,                         // v_cmpx_f_f32 -> every invocation inactive
         0xBF880002u,
         0xF80008CFu, 0x01000302u,
         0xBF810000u,

--- a/prosper/tests/test_recompiled_shaders.cpp
+++ b/prosper/tests/test_recompiled_shaders.cpp
@@ -103,9 +103,9 @@ int main() {
         0xF80008CFu, 0x01000302u,
         0xBF810000u,
     };
-    const auto active_gate_spv = recompile_vertex(
+    const auto active_gate_spv = recompile_vertex_terminal_ngg_gate_for_test(
         ngg_gate_active, std::size(ngg_gate_active));
-    const auto inactive_gate_spv = recompile_vertex(
+    const auto inactive_gate_spv = recompile_vertex_terminal_ngg_gate_for_test(
         ngg_gate_inactive, std::size(ngg_gate_inactive));
     CHECK(!active_gate_spv.empty() && !inactive_gate_spv.empty(),
           "terminal NGG output gate recompiles for active and inactive paths");


### PR DESCRIPTION
## What changed

- preserve the AGC front/back association created by fused GS shader halves and compile the real NGG back body when its front half is bound
- seed fused-stage system SGPRs and retain all four descriptors loaded by the NGG stage-data prologue
- add a deliberately bounded one-guest-lane vertex lowering for the exact NGG mask, LDS, loop, compacted-output, SDWA, and DPP forms used by Astro Bot
- add focused decoder, shader-structure, descriptor-folding, AGC fusion, and Vulkan execution coverage

## Why

Astro Bot binds the front half of a fused GS program, while Prosper previously forgot the fusion association and compiled only that tiny front program. Once the real back half was selected, several NGG wave/LDS forms still rejected or produced invalid vertex SPIR-V. This patch preserves the association and implements only the mechanically bounded semantics exercised by that shader, leaving unsupported general vertex divergence fail-closed.

## Impact

The intro now produces clean, changing Sony Interactive Entertainment frames without the checkerboard seen previously, and the game remains stable instead of losing the renderer. Warm live runs reached roughly 30 FPS under a contended development machine. The intro still advances much too slowly and the title screen has not been reached; issue #962 remains open for continued work.

## Validation

- `test_agc_shader`
- `test_dynfetch_fold`
- `test_rdna2_decode`
- `test_rdna2_spirv_struct`
- `test_rdna2_to_spirv`
- 20-second Astro Bot live smoke test with continuous presentation and no driver crash
- all 58 generated SPIR-V modules validated with `spirv-val --target-env vulkan1.2`, including the 2,936-byte fused NGG shader

The full snapshot suite was not run: this is a day-to-day development PR, not a release, and repository policy leaves snapshots to the PR author's judgment while requiring them before releases.
