### PR TITLE
Fix Astro Bot custom pixel interpolation

### DIFF
--- a/prosper/src/gpu/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc_shader_layout.cpp
@@ -30,8 +30,11 @@ AgcPixelInputControls derive_agc_pixel_input_controls(const AgcShaderHeader* pro
             const AgcShaderSemantic& semantic = producer->output_semantics[i];
             const uint32_t slot = semantic.hardware_mapping() < 32u
                 ? semantic.hardware_mapping() : i;
-            out.controls[i] = slot | (semantic.is_flat_shaded() ? 0x400u : 0u);
+            const bool passthrough = semantic.is_custom();
+            out.controls[i] = slot | (passthrough ? 0x420u : 0u) |
+                              (semantic.is_flat_shaded() ? 0x400u : 0u);
             out.valid_mask |= 1u << i;
+            if (passthrough) out.passthrough_mask |= 1u << i;
         }
         return out;
     }
@@ -44,6 +47,13 @@ AgcPixelInputControls derive_agc_pixel_input_controls(const AgcShaderHeader* pro
             const AgcShaderSemantic& output = producer->output_semantics[j];
             if (output.semantic() == input.semantic() && output.hardware_mapping() < 32u) {
                 control = output.hardware_mapping();
+                if (input.is_custom()) {
+                    // GFX10 explicit interpolation selects the producer PARAM through OFFSET while
+                    // parameter-cache pass-through (OFFSET bit 5) and FLAT_SHADE expose each
+                    // triangle vertex to v_interp_mov instead of fixed-function coefficients.
+                    control |= 0x420u;
+                    out.passthrough_mask |= 1u << i;
+                }
                 break;
             }
         }

--- a/prosper/src/gpu/agc_shader_layout.hpp
+++ b/prosper/src/gpu/agc_shader_layout.hpp
@@ -55,6 +55,7 @@ struct AgcShaderSemantic {
     uint32_t semantic()         const { return  bits        & 0xffu; }
     uint32_t hardware_mapping() const { return (bits >>  8) & 0xffu; }
     bool     is_flat_shaded()   const { return ((bits >> 22) & 1u) != 0; }
+    bool     is_custom()        const { return ((bits >> 24) & 1u) != 0; }
     uint32_t default_value()    const { return (bits >> 28) & 0x3u; }
     uint32_t default_value_hi() const { return (bits >> 30) & 0x3u; }
 };
@@ -90,10 +91,12 @@ static_assert(offsetof(AgcShaderHeader, input_semantics) == 0x30 &&
 
 // Hardware SPI_PS_INPUT_CNTL values derived from an ES/GS producer and a PS consumer's semantic
 // metadata. Each valid control maps one logical PS input either to the matching producer PARAM slot
-// or to OFFSET=0x20 + DEFAULT_VAL when the producer does not export that semantic.
+// or to OFFSET=0x20 + DEFAULT_VAL when the producer does not export that semantic. Custom inputs also
+// set the explicit parameter-cache pass-through mask used by the portable interpolation fallback.
 struct AgcPixelInputControls {
     std::array<uint32_t, 32> controls{};
     uint32_t valid_mask = 0;
+    uint32_t passthrough_mask = 0;
 };
 AgcPixelInputControls derive_agc_pixel_input_controls(const AgcShaderHeader* producer,
                                                       const AgcShaderHeader* pixel);

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -361,7 +361,8 @@ void clear_shader_recompile_cache();
 
 FragmentInterpolationLayout fragment_interpolation_layout_cached(
     const uint32_t* code, size_t dwords,
-    const PixelSystemInputMapping* system_inputs = nullptr);
+    const PixelSystemInputMapping* system_inputs = nullptr,
+    const PixelInputMapping* pixel_inputs = nullptr);
 
 struct DrawRealizationPhaseStats {
     uint64_t draws = 0;
@@ -781,6 +782,7 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
         if (derived.valid_mask) {
             pixel_inputs.controls = derived.controls;
             pixel_inputs.valid_mask = derived.valid_mask;
+            pixel_inputs.passthrough_mask = derived.passthrough_mask;
             interpolants_from_metadata = true;
         }
     }
@@ -801,7 +803,7 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
     const ResolvedPipelineState resolved_pipeline = resolve_pipeline_state(rs);
     const FragmentInterpolationLayout interpolation = fragment_interpolation_layout_cached(
         reinterpret_cast<const uint32_t*>(static_cast<uintptr_t>(rs.ps_addr)),
-        max_shader_dwords, system_input_ptr);
+        max_shader_dwords, system_input_ptr, pixel_input_ptr);
     uint64_t vs_identity = 0, fs_identity = 0;
     SharedShaderWords vs_shared, fs_shared;
     std::vector<uint32_t> vs, fs;

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -773,18 +773,18 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
     pixel_inputs.controls = rs.ps_input_cntl;
     pixel_inputs.valid_mask = rs.ps_input_cntl_valid_mask;
     bool interpolants_from_metadata = false;
-    if (!pixel_inputs.valid_mask) {
+    if (!pixel_inputs.valid_mask || pixel_inputs.ambiguous_passthrough_mask()) {
         const auto* producer = static_cast<const AgcShaderHeader*>(
             prosper_agc_shader_header_for_code(vs_program_addr));
         const auto* pixel = static_cast<const AgcShaderHeader*>(
             prosper_agc_shader_header_for_code(rs.ps_addr));
         const AgcPixelInputControls derived = derive_agc_pixel_input_controls(producer, pixel);
-        if (derived.valid_mask) {
-            pixel_inputs.controls = derived.controls;
-            pixel_inputs.valid_mask = derived.valid_mask;
-            pixel_inputs.passthrough_mask = derived.passthrough_mask;
-            interpolants_from_metadata = true;
-        }
+        PixelInputMapping metadata_inputs;
+        metadata_inputs.controls = derived.controls;
+        metadata_inputs.valid_mask = derived.valid_mask;
+        metadata_inputs.passthrough_mask = derived.passthrough_mask;
+        pixel_inputs = resolve_pixel_input_mapping(
+            pixel_inputs, metadata_inputs, &interpolants_from_metadata);
     }
     if (getenv("PROSPER_INTERPLOG")) {
         fprintf(stderr, "[interp] es=0x%llx ps=0x%llx source=%s valid=%08x ena=%08x addr=%08x",

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -243,6 +243,7 @@ struct ShaderCompileKeyHash {
         hash = hash_mix(hash, key.has_pixel_inputs);
         if (key.has_pixel_inputs) {
             hash = hash_mix(hash, key.pixel_inputs.valid_mask);
+            hash = hash_mix(hash, key.pixel_inputs.passthrough_mask);
             for (uint32_t control : key.pixel_inputs.controls)
                 hash = hash_mix(hash, control);
         }
@@ -367,6 +368,7 @@ struct InterpolationCacheKey {
     uint64_t analysis_identity = 0;
     PixelSystemInputMapping system_inputs{};
     bool has_system_inputs = false;
+    uint32_t passthrough_mask = 0;
 
     bool operator==(const InterpolationCacheKey&) const = default;
 };
@@ -380,6 +382,7 @@ struct InterpolationCacheKeyHash {
             hash = hash_mix(hash, key.system_inputs.ena);
             hash = hash_mix(hash, key.system_inputs.addr);
         }
+        hash = hash_mix(hash, key.passthrough_mask);
         return static_cast<size_t>(hash);
     }
 };
@@ -1028,10 +1031,11 @@ void clear_shader_analysis_cache() {
 
 FragmentInterpolationLayout fragment_interpolation_layout_cached(
         const uint32_t* code, size_t dwords,
-        const PixelSystemInputMapping* system_inputs) {
+        const PixelSystemInputMapping* system_inputs,
+        const PixelInputMapping* pixel_inputs) {
     const auto analysis = analyze_shader_code_cached(code, dwords);
     if (!analysis || getenv("PROSPER_NO_SHADER_ANALYSIS_CACHE"))
-        return fragment_interpolation_layout(code, dwords, system_inputs);
+        return fragment_interpolation_layout(code, dwords, system_inputs, pixel_inputs);
 
     InterpolationCacheKey key;
     // Use the immutable analysis version, without retaining its shader-byte allocation beyond the
@@ -1039,6 +1043,7 @@ FragmentInterpolationLayout fragment_interpolation_layout_cached(
     key.analysis_identity = analysis->identity;
     key.has_system_inputs = system_inputs != nullptr;
     if (system_inputs) key.system_inputs = *system_inputs;
+    key.passthrough_mask = pixel_inputs ? pixel_inputs->effective_passthrough_mask() : 0u;
     auto& cache = interpolation_cache();
     std::lock_guard lock(cache.mutex);
     auto found = cache.entries.find(key);
@@ -1047,7 +1052,7 @@ FragmentInterpolationLayout fragment_interpolation_layout_cached(
         return found->second.layout;
     }
     const FragmentInterpolationLayout layout =
-        fragment_interpolation_layout(code, dwords, system_inputs);
+        fragment_interpolation_layout(code, dwords, system_inputs, pixel_inputs);
     constexpr size_t max_entries = 4096;
     while (cache.entries.size() >= max_entries && !cache.entries.empty()) {
         auto oldest = cache.entries.begin();

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -2143,12 +2143,17 @@ struct SpirvCompute {
         for (uint32_t attr = 0; attr < 32; ++attr) {
             if (!attribute_inputs[attr]) continue;
             parameters[attr][2] = attribute_values[attr][0];
-            parameters[attr][0] = id();
-            put(code, Op_FSub, {t_v4f, parameters[attr][0],
-                                attribute_values[attr][1], attribute_values[attr][0]});
-            parameters[attr][1] = id();
-            put(code, Op_FSub, {t_v4f, parameters[attr][1],
-                                attribute_values[attr][2], attribute_values[attr][0]});
+            if (layout.passthrough_mask & (1u << attr)) {
+                parameters[attr][0] = attribute_values[attr][1];
+                parameters[attr][1] = attribute_values[attr][2];
+            } else {
+                parameters[attr][0] = id();
+                put(code, Op_FSub, {t_v4f, parameters[attr][0],
+                                    attribute_values[attr][1], attribute_values[attr][0]});
+                parameters[attr][1] = id();
+                put(code, Op_FSub, {t_v4f, parameters[attr][1],
+                                    attribute_values[attr][2], attribute_values[attr][0]});
+            }
         }
 
         for (uint32_t vertex = 0; vertex < 3; ++vertex) {
@@ -2271,7 +2276,8 @@ static bool extend_terminating_if_else(const uint32_t* code, size_t dwords,
 
 FragmentInterpolationLayout fragment_interpolation_layout(
         const uint32_t* code, size_t dwords,
-        const PixelSystemInputMapping* system_inputs) {
+        const PixelSystemInputMapping* system_inputs,
+        const PixelInputMapping* pixel_inputs) {
     FragmentInterpolationLayout layout;
     std::vector<Rdna2Inst> instructions;
     rdna2_walk(code, dwords, instructions);
@@ -2290,6 +2296,9 @@ FragmentInterpolationLayout fragment_interpolation_layout(
         else if (instruction.opcode == 2 && instruction.src[0].value < 3)
             selectors[attr] |= static_cast<uint8_t>(1u << instruction.src[0].value);
     }
+    if (pixel_inputs)
+        layout.passthrough_mask =
+            pixel_inputs->effective_passthrough_mask() & layout.attribute_mask;
 
     // P10/P20 have no ordinary Vulkan varying equivalent. P0 can retain the cheap Flat-input path
     // when it is the attribute's only interpolation mode; mixed P0+smooth needs the geometry copy too.
@@ -9657,6 +9666,8 @@ static std::vector<uint32_t> recompile_vertex_impl(const uint32_t* code, size_t 
                                                   const PixelInputMapping* pixel_inputs,
                                                   bool capture_position,
                                                   bool allow_test_ngg_output_gate) {
+    const uint32_t passthrough_mask =
+        pixel_inputs ? pixel_inputs->effective_passthrough_mask() : 0u;
     std::vector<Rdna2Inst> ins;
     rdna2_walk(code, dwords, ins);
     const StaticScratchLayout scratch = analyze_static_scratch(ins);
@@ -9931,7 +9942,9 @@ static std::vector<uint32_t> recompile_vertex_impl(const uint32_t* code, size_t 
             if (pixel_inputs) {
                 for (uint32_t ps_input = 0; ps_input < pixel_inputs->controls.size(); ++ps_input) {
                     if (!(pixel_inputs->valid_mask & (1u << ps_input))) continue;
-                    const uint32_t offset = pixel_inputs->controls[ps_input] & 0x3Fu;
+                    const uint32_t raw_offset = pixel_inputs->controls[ps_input] & 0x3Fu;
+                    const uint32_t offset = (passthrough_mask & (1u << ps_input))
+                        ? (raw_offset & 0x1fu) : raw_offset;
                     if (offset == source) b.export_param(ps_input, x, y, z, w);
                 }
             }
@@ -9956,7 +9969,8 @@ static std::vector<uint32_t> recompile_vertex_impl(const uint32_t* code, size_t 
         for (uint32_t ps_input = 0; ps_input < pixel_inputs->controls.size(); ++ps_input) {
             if (!(pixel_inputs->valid_mask & (1u << ps_input))) continue;
             const uint32_t control = pixel_inputs->controls[ps_input];
-            if ((control & 0x3Fu) != 0x20u) continue;
+            if ((passthrough_mask & (1u << ps_input)) ||
+                (control & 0x3Fu) != 0x20u) continue;
             const uint32_t one = b.uconst(0x3F800000u), zero = b.uconst(0u);
             const uint32_t default_val = (control >> 8) & 0x3u;
             const bool xyz_one = (default_val & 0x2u) != 0;

--- a/prosper/src/gpu/rdna2_to_spirv.hpp
+++ b/prosper/src/gpu/rdna2_to_spirv.hpp
@@ -57,10 +57,26 @@ size_t rdna2_recompile_code_span(const uint32_t* code, size_t dwords);
 // Fixed-function PS interpolant wiring captured from SPI_PS_INPUT_CNTL_0..31. A valid entry's
 // OFFSET selects the vertex PARAM export feeding that logical PS input; OFFSET=0x20 selects the
 // four hardware default vectors encoded by DEFAULT_VAL instead. Keeping this separate from
-// RenderState makes the recompiler independently unit-testable.
+// RenderState makes the recompiler independently unit-testable. `passthrough_mask` disambiguates the
+// custom PARAM0 encoding; other custom PARAM slots can also be recovered from their register control.
 struct PixelInputMapping {
     std::array<uint32_t, 32> controls{};
     uint32_t valid_mask = 0;
+    uint32_t passthrough_mask = 0;
+
+    uint32_t effective_passthrough_mask() const {
+        uint32_t mask = passthrough_mask;
+        for (uint32_t input = 0; input < controls.size(); ++input) {
+            if (!(valid_mask & (1u << input))) continue;
+            const uint32_t control = controls[input];
+            // OFFSET bit 5 + FLAT_SHADE is the register form emitted for explicit parameter-cache
+            // pass-through. A nonzero low OFFSET distinguishes it from the constant-default form;
+            // metadata's explicit mask covers the otherwise ambiguous PARAM0 encoding.
+            if ((control & 0x420u) == 0x420u && (control & 0x1fu) != 0u)
+                mask |= 1u << input;
+        }
+        return mask & valid_mask;
+    }
 
     bool operator==(const PixelInputMapping&) const = default;
 };
@@ -82,14 +98,17 @@ struct PixelSystemInputMapping {
 // subset of devices. When `requires_geometry` is true, the renderer inserts the generated geometry
 // stage returned by recompile_interpolation_geometry(). It passes ordinary smooth attributes through
 // and publishes P0, P10=(P1-P0), P20=(P2-P0), plus any requested barycentric system inputs, as a
-// packed interface understood by recompile_fragment(). Locations are capped at Vulkan's portable
-// 128-component fragment-input minimum (32 vec4 locations); `valid == false` keeps overflow visible.
+// packed interface understood by recompile_fragment(). Custom/pass-through attributes instead expose
+// the three raw vertex values that the guest shader explicitly interpolates. Locations are capped at
+// Vulkan's portable 128-component fragment-input minimum (32 vec4 locations); `valid == false` keeps
+// overflow visible.
 struct FragmentInterpolationLayout {
     static constexpr uint32_t kUnusedLocation = UINT32_MAX;
     std::array<std::array<uint32_t, 3>, 32> parameter_locations{}; // [attr][0=P10,1=P20,2=P0]
     std::array<uint32_t, 7> system_locations{};                    // PS system fields 0..6
     uint32_t attribute_mask = 0;                                  // attributes consumed by VINTRP
     uint32_t smooth_mask = 0;                                     // attributes consumed by P1/P2
+    uint32_t passthrough_mask = 0;                                // explicit inputs exposing raw vertex values
     bool requires_geometry = false;
     bool valid = true;
 
@@ -98,7 +117,8 @@ struct FragmentInterpolationLayout {
 
 FragmentInterpolationLayout fragment_interpolation_layout(
     const uint32_t* code, size_t dwords,
-    const PixelSystemInputMapping* system_inputs = nullptr);
+    const PixelSystemInputMapping* system_inputs = nullptr,
+    const PixelInputMapping* pixel_inputs = nullptr);
 
 // Generate the descriptor-free triangle geometry stage described above. Returns {} when no fallback
 // is required or the packed interface is invalid. Triangle lists, strips, fans, and the RectList

--- a/prosper/src/gpu/rdna2_to_spirv.hpp
+++ b/prosper/src/gpu/rdna2_to_spirv.hpp
@@ -78,8 +78,50 @@ struct PixelInputMapping {
         return mask & valid_mask;
     }
 
+    uint32_t ambiguous_passthrough_mask() const {
+        uint32_t mask = 0;
+        for (uint32_t input = 0; input < controls.size(); ++input) {
+            if (!(valid_mask & (1u << input))) continue;
+            const uint32_t control = controls[input];
+            if ((control & 0x420u) == 0x420u && (control & 0x1fu) == 0u)
+                mask |= 1u << input;
+        }
+        return mask;
+    }
+
+    void merge_compatible_passthrough(
+            const std::array<uint32_t, 32>& metadata_controls,
+            uint32_t metadata_valid_mask, uint32_t metadata_passthrough_mask) {
+        uint32_t candidates = valid_mask & metadata_valid_mask & metadata_passthrough_mask;
+        for (uint32_t input = 0; input < controls.size(); ++input) {
+            const uint32_t bit = 1u << input;
+            if (!(candidates & bit)) continue;
+            // OFFSET and FLAT_SHADE must describe the same producer PARAM. Ignore unrelated control
+            // fields so metadata can disambiguate custom PARAM0 without overriding register wiring.
+            if ((controls[input] & 0x43fu) == (metadata_controls[input] & 0x43fu))
+                passthrough_mask |= bit;
+        }
+    }
+
     bool operator==(const PixelInputMapping&) const = default;
 };
+
+// Reconcile the register-backed linkage used by a live draw with richer AGC shader metadata. The
+// registers remain authoritative whenever present; metadata only supplies the custom PARAM0 bit that
+// SPI_PS_INPUT_CNTL cannot distinguish from a flat default input.
+inline PixelInputMapping resolve_pixel_input_mapping(
+        PixelInputMapping registered, const PixelInputMapping& metadata,
+        bool* resolved_from_metadata = nullptr) {
+    const bool use_metadata = !registered.valid_mask && metadata.valid_mask;
+    if (use_metadata) {
+        registered = metadata;
+    } else if (metadata.passthrough_mask) {
+        registered.merge_compatible_passthrough(
+            metadata.controls, metadata.valid_mask, metadata.passthrough_mask);
+    }
+    if (resolved_from_metadata) *resolved_from_metadata = use_metadata;
+    return registered;
+}
 
 // Fixed-function per-pixel VGPR loads selected by SPI_PS_INPUT_ENA / SPI_PS_INPUT_ADDR. ENA says
 // which values hardware computes and loads; ADDR also reserves VGPR slots for disabled values, so it

--- a/prosper/tests/test_build_shader_resources.cpp
+++ b/prosper/tests/test_build_shader_resources.cpp
@@ -244,25 +244,26 @@ int main() {
             {0x0000000fu}, {0x00000110u}, {0x00000211u}, {0x00000312u},
         };
         AgcShaderSemantic pixel_in[] = {
-            {0x0000000fu}, {0x00000012u}, {0x01000012u},
+            {0x0000000fu}, {0x00000012u}, {0x01000012u}, {0x0100000fu},
         };
         AgcShaderHeader producer{};
         producer.output_semantics = producer_out;
         producer.num_output_semantics = 4;
         AgcShaderHeader pixel{};
         pixel.input_semantics = pixel_in;
-        pixel.num_input_semantics = 3;
+        pixel.num_input_semantics = 4;
         AgcPixelInputControls mapping = derive_agc_pixel_input_controls(&producer, &pixel);
-        CHECK(mapping.valid_mask == 0x7u && mapping.controls[0] == 0u &&
+        CHECK(mapping.valid_mask == 0xfu && mapping.controls[0] == 0u &&
                   mapping.controls[1] == 3u && mapping.controls[2] == 0x423u &&
-                  mapping.passthrough_mask == 0x4u,
-              "semantic wiring distinguishes ordinary and custom PARAM3 inputs");
+                  mapping.controls[3] == 0x420u && mapping.passthrough_mask == 0xcu,
+              "semantic wiring distinguishes ordinary and custom PARAM3/PARAM0 inputs");
 
         producer.output_semantics = nullptr;
         producer.num_output_semantics = 0;
         mapping = derive_agc_pixel_input_controls(&producer, &pixel);
-        CHECK(mapping.valid_mask == 0x7u && mapping.controls[0] == 0x20u &&
+        CHECK(mapping.valid_mask == 0xfu && mapping.controls[0] == 0x20u &&
                   mapping.controls[1] == 0x20u && mapping.controls[2] == 0x20u &&
+                  mapping.controls[3] == 0x20u &&
                   mapping.passthrough_mask == 0u,
               "procedural producer with no PARAM exports materializes PS input defaults");
 

--- a/prosper/tests/test_build_shader_resources.cpp
+++ b/prosper/tests/test_build_shader_resources.cpp
@@ -243,21 +243,27 @@ int main() {
         AgcShaderSemantic producer_out[] = {
             {0x0000000fu}, {0x00000110u}, {0x00000211u}, {0x00000312u},
         };
-        AgcShaderSemantic pixel_in[] = {{0x0000000fu}, {0x00000012u}};
+        AgcShaderSemantic pixel_in[] = {
+            {0x0000000fu}, {0x00000012u}, {0x01000012u},
+        };
         AgcShaderHeader producer{};
         producer.output_semantics = producer_out;
         producer.num_output_semantics = 4;
         AgcShaderHeader pixel{};
         pixel.input_semantics = pixel_in;
-        pixel.num_input_semantics = 2;
+        pixel.num_input_semantics = 3;
         AgcPixelInputControls mapping = derive_agc_pixel_input_controls(&producer, &pixel);
-        CHECK(mapping.valid_mask == 0x3u && mapping.controls[0] == 0u && mapping.controls[1] == 3u,
-              "DOLL semantics map PS inputs {15,18} to producer PARAM slots {0,3}");
+        CHECK(mapping.valid_mask == 0x7u && mapping.controls[0] == 0u &&
+                  mapping.controls[1] == 3u && mapping.controls[2] == 0x423u &&
+                  mapping.passthrough_mask == 0x4u,
+              "semantic wiring distinguishes ordinary and custom PARAM3 inputs");
 
         producer.output_semantics = nullptr;
         producer.num_output_semantics = 0;
         mapping = derive_agc_pixel_input_controls(&producer, &pixel);
-        CHECK(mapping.valid_mask == 0x3u && mapping.controls[0] == 0x20u && mapping.controls[1] == 0x20u,
+        CHECK(mapping.valid_mask == 0x7u && mapping.controls[0] == 0x20u &&
+                  mapping.controls[1] == 0x20u && mapping.controls[2] == 0x20u &&
+                  mapping.passthrough_mask == 0u,
               "procedural producer with no PARAM exports materializes PS input defaults");
 
         AgcShaderSemantic default_flat[] = {{0x30400055u}}; // DEFAULT_VAL=3 + flat, no matching output

--- a/prosper/tests/test_interp_render.cpp
+++ b/prosper/tests/test_interp_render.cpp
@@ -106,6 +106,28 @@ int main() {
               "P0 + P10*I + P20*J reconstructs the original smooth red gradient");
     }
 
+    PixelInputMapping custom_input;
+    custom_input.valid_mask = 1u;
+    custom_input.passthrough_mask = 1u;
+    const FragmentInterpolationLayout custom_layout = fragment_interpolation_layout(
+        explicit_ps, std::size(explicit_ps), &perspective_center, &custom_input);
+    const std::vector<uint32_t> custom_geom = recompile_interpolation_geometry(custom_layout);
+    auto count_spirv_opcode = [](const std::vector<uint32_t>& words, uint32_t opcode) {
+        size_t count = 0;
+        for (size_t i = 5; i < words.size();) {
+            const uint32_t word_count = words[i] >> 16;
+            if (!word_count) break;
+            if ((words[i] & 0xffffu) == opcode) ++count;
+            i += word_count;
+        }
+        return count;
+    };
+    CHECK(custom_layout.passthrough_mask == 1u && !custom_geom.empty(),
+          "custom pixel input requests raw triangle-vertex parameters from the geometry stage");
+    CHECK(count_spirv_opcode(explicit_geom, 131u) ==
+              count_spirv_opcode(custom_geom, 131u) + 2u, // OpFSub
+          "custom geometry exports two raw vertices instead of fixed-function deltas");
+
     // DOLL's live linkage shape is non-identity: PS input 1 consumes producer PARAM3. Exercise the
     // generic form here by moving this fixture's export from PARAM0 to PARAM3, then remapping logical
     // PS input 0 back to source slot 3. The unchanged attr0 PS must still receive the gradient.
@@ -129,6 +151,20 @@ int main() {
         CHECK(remapped_max - remapped_min > 40,
               "remapped PARAM3 preserves the interpolated gradient at PS input 0");
     }
+
+    PixelInputMapping custom_remap;
+    custom_remap.valid_mask = 1u;
+    custom_remap.controls[0] = 0x423u; // PARAM3 + parameter-cache pass-through + flat
+    CHECK(custom_remap.effective_passthrough_mask() == 1u,
+          "register-form custom PARAM3 recovers its pass-through mode");
+    std::vector<uint32_t> custom_remapped_vert = recompile_vertex(
+        param3_vs.data(), param3_vs.size(), nullptr, &custom_remap);
+    std::vector<uint8_t> custom_remapped_px = prosper::test::render_triangle_rgba(
+        custom_remapped_vert, frag, W, H);
+    CHECK(custom_remapped_px.size() == (size_t)W * H * 4,
+          "custom OFFSET bit does not hide the underlying PARAM3 vertex export");
+    CHECK(custom_remapped_px == remapped_px,
+          "custom register linkage preserves the exact PARAM3 varying values");
 
     // GFX10 fixed-function interpolation can replace a missing PARAM export with one of four
     // DEFAULT_VAL vectors. Vulkan has no matching pipeline state, so the vertex recompiler emits

--- a/prosper/tests/test_interp_render.cpp
+++ b/prosper/tests/test_interp_render.cpp
@@ -166,6 +166,36 @@ int main() {
     CHECK(custom_remapped_px == remapped_px,
           "custom register linkage preserves the exact PARAM3 varying values");
 
+    PixelInputMapping custom_param0;
+    custom_param0.valid_mask = 1u;
+    custom_param0.controls[0] = 0x420u; // ambiguous: custom PARAM0 or flat default
+    CHECK(custom_param0.effective_passthrough_mask() == 0u &&
+              custom_param0.ambiguous_passthrough_mask() == 1u,
+          "register-form PARAM0 waits for metadata to disambiguate pass-through from default");
+    PixelInputMapping custom_param0_metadata;
+    custom_param0_metadata.valid_mask = 1u;
+    custom_param0_metadata.passthrough_mask = 1u;
+    custom_param0_metadata.controls[0] = 0x420u;
+    bool custom_param0_from_metadata = true;
+    custom_param0 = resolve_pixel_input_mapping(
+        custom_param0, custom_param0_metadata, &custom_param0_from_metadata);
+    const FragmentInterpolationLayout custom_param0_layout = fragment_interpolation_layout(
+        explicit_ps, std::size(explicit_ps), &perspective_center, &custom_param0);
+    CHECK(custom_param0.effective_passthrough_mask() == 1u &&
+              custom_param0_layout.passthrough_mask == 1u && !custom_param0_from_metadata,
+          "compatible AGC metadata preserves custom PARAM0 through register-backed realization");
+    PixelInputMapping incompatible_param0;
+    incompatible_param0.valid_mask = 1u;
+    incompatible_param0.controls[0] = 0x420u;
+    custom_param0_metadata.controls[0] = 0x421u;
+    incompatible_param0 = resolve_pixel_input_mapping(incompatible_param0, custom_param0_metadata);
+    CHECK(incompatible_param0.effective_passthrough_mask() == 0u,
+          "metadata cannot override incompatible register PARAM wiring");
+
+    PixelInputMapping metadata_only = resolve_pixel_input_mapping({}, custom_input);
+    CHECK(metadata_only.valid_mask == 1u && metadata_only.effective_passthrough_mask() == 1u,
+          "metadata remains the complete fallback when no input-control registers were captured");
+
     // GFX10 fixed-function interpolation can replace a missing PARAM export with one of four
     // DEFAULT_VAL vectors. Vulkan has no matching pipeline state, so the vertex recompiler emits
     // the selected constant at the logical PS input location. DEFAULT_VAL=3 is (1,1,1,1): the same


### PR DESCRIPTION
## Summary

- decode AGC's custom pixel-input semantic and preserve its parameter-cache pass-through mode
- keep custom PARAM linkage distinct from fixed-function interpolation/default values in shader and interpolation caches
- emit raw per-vertex values from the portable geometry fallback for guest shaders that perform interpolation themselves

This removes Astro Bot's flashing checkerboard/triangle corruption in the intro compositor and keeps the existing ordinary `P0/P10/P20` path unchanged. Continues #962.

## Validation

- `test_build_shader_resources`
- `test_interp_render`
- `test_shader_recompile_cache`
- `test_gpu_capture`
- full `prosper-app` build
- live Astro Bot boot with audio/input: clean intro frames, approximately 45–60 FPS through the heavy FMV and 65–80 FPS after entering the title/world-map game state under concurrent emulator test load
- deterministic captured-frame A/B: the same draw changes from checkerboard corruption to clean video when custom pass-through semantics are applied

Snapshot suite not run; per project policy it is optional for development PRs and required before a release.