### PR TITLE
fix(gpu): advance Astro Bot world map rendering

### DIFF
--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -51,6 +51,17 @@ uint8_t storage_pack_unorm8(uint32_t float_bits) {
     return static_cast<uint8_t>(whole + (scaled - static_cast<float>(whole) >= 0.5f));
 }
 
+uint16_t storage_pack_unorm16(uint32_t float_bits) {
+    float value;
+    std::memcpy(&value, &float_bits, sizeof(value));
+    if (!(value > 0.0f)) return 0; // Includes negative values and NaN.
+    if (value >= 1.0f) return 65535;
+    const float scaled = value * 65535.0f;
+    const uint32_t whole = static_cast<uint32_t>(scaled);
+    return static_cast<uint16_t>(whole +
+        (scaled - static_cast<float>(whole) >= 0.5f));
+}
+
 uint32_t storage_unpack_float16_bits(uint16_t half_bits) {
     // Full binary16 lookup: the source domain is only 64 Ki entries, while Astro Bot expands more
     // than 33 million FP16 channels for one 4K storage image. Keeping the already-converted float
@@ -1378,7 +1389,7 @@ struct BoundImage {
 // The recompiler moves image texels as RAW 32-bit VGPR channel values (uvec4 per texel; the VkImage is
 // R32G32B32A32_UINT with format-free reads/writes). Real hardware format-converts per the T#, so the
 // guest surface's bytes must be UNPACKED to channel dwords on upload and PACKED back on writeback:
-//   Unorm8  -> float(b/255) bits         <- clamp(bitcast float,0,1)*255 rounded
+//   Unorm8/16 -> float(channel/max) bits <- clamp(bitcast float,0,1)*max rounded
 //   Float16 -> half->float bits          <- round-to-nearest-even float->half
 //   Float32/Uint32/Sint32 -> raw 4-byte move both ways.
 //   Uint8/Sint8/Uint16/Sint16 -> integer channel widen (sign-extend for Sint) <- truncate to width.
@@ -1394,14 +1405,15 @@ struct BoundImage {
 // skips the dispatch loudly (never a silent wrong-layout write — correctness-first).
 bool storage_unpack_supported(prosper::gpu::DataFormat f) {
     using DF = prosper::gpu::DataFormat;
-    return f == DF::Unorm8 || f == DF::Float16 || f == DF::Float32 || f == DF::Uint32 ||
+    return f == DF::Unorm8 || f == DF::Unorm16 || f == DF::Float16 ||
+           f == DF::Float32 || f == DF::Uint32 ||
            f == DF::Sint32 || f == DF::Float10_11_11 ||
            f == DF::Uint8 || f == DF::Sint8 || f == DF::Uint16 || f == DF::Sint16 ||
            f == DF::Unorm2_10_10_10;
 }
 bool storage_pack_supported(prosper::gpu::DataFormat f) {
     using DF = prosper::gpu::DataFormat;
-    return f == DF::Unorm8 || f == DF::Float16 || f == DF::Float32 ||
+    return f == DF::Unorm8 || f == DF::Unorm16 || f == DF::Float16 || f == DF::Float32 ||
            f == DF::Uint32 || f == DF::Sint32 || f == DF::Float10_11_11 ||
            f == DF::Uint8 || f == DF::Sint8 || f == DF::Uint16 || f == DF::Sint16 ||
            f == DF::Unorm2_10_10_10;
@@ -1434,6 +1446,12 @@ void storage_unpack_texel(const uint8_t* src, prosper::gpu::DataFormat f, uint32
     for (uint32_t c = 0; c < ncomp && c < 4; c++) {
         switch (f) {
             case DF::Unorm8: { float v = src[c] / 255.0f; std::memcpy(&out[c], &v, 4); break; }
+            case DF::Unorm16: {
+                const uint16_t raw = static_cast<uint16_t>(src[c * 2] | (src[c * 2 + 1] << 8));
+                const float v = raw / 65535.0f;
+                std::memcpy(&out[c], &v, 4);
+                break;
+            }
             case DF::Float16:
                 out[c] = storage_unpack_float16_bits(
                     static_cast<uint16_t>(src[c * 2] | (src[c * 2 + 1] << 8)));
@@ -1475,6 +1493,16 @@ void storage_unpack_range(const uint8_t* src, size_t src_stride, prosper::gpu::D
             for (size_t t = 0; t < count; ++t) {
                 const uint8_t* p = src + t * src_stride; uint32_t* o = out + t * 4; defaults(o);
                 for (uint32_t c = 0; c < n; ++c) { float v = p[c] / 255.0f; std::memcpy(&o[c], &v, 4); }
+            }
+            return;
+        case DF::Unorm16:
+            for (size_t t = 0; t < count; ++t) {
+                const uint8_t* p = src + t * src_stride; uint32_t* o = out + t * 4; defaults(o);
+                for (uint32_t c = 0; c < n; ++c) {
+                    const uint16_t raw = static_cast<uint16_t>(p[c * 2] | (p[c * 2 + 1] << 8));
+                    const float v = raw / 65535.0f;
+                    std::memcpy(&o[c], &v, 4);
+                }
             }
             return;
         case DF::Float16:
@@ -1584,6 +1612,16 @@ void storage_pack_range(const uint32_t* channels, prosper::gpu::DataFormat f, ui
                 for (uint32_t c = 0; c < n; ++c) p[c] = static_cast<uint8_t>(in[c]);
             }
             return;
+        case DF::Unorm16:
+            for (size_t t = 0; t < count; ++t) {
+                const uint32_t* in = channels + t * 4; uint8_t* p = dst + t * dst_stride;
+                for (uint32_t c = 0; c < n; ++c) {
+                    const uint16_t value = storage_pack_unorm16(in[c]);
+                    p[c * 2] = static_cast<uint8_t>(value);
+                    p[c * 2 + 1] = static_cast<uint8_t>(value >> 8);
+                }
+            }
+            return;
         case DF::Uint16: case DF::Sint16:
             for (size_t t = 0; t < count; ++t) {
                 const uint32_t* in = channels + t * 4; uint8_t* p = dst + t * dst_stride;
@@ -1632,6 +1670,12 @@ void storage_pack_texel(const uint32_t in[4], prosper::gpu::DataFormat f, uint32
     for (uint32_t c = 0; c < ncomp && c < 4; c++) {
         switch (f) {
             case DF::Unorm8: dst[c] = storage_pack_unorm8(in[c]); break;
+            case DF::Unorm16: {
+                const uint16_t value = storage_pack_unorm16(in[c]);
+                dst[c * 2] = static_cast<uint8_t>(value);
+                dst[c * 2 + 1] = static_cast<uint8_t>(value >> 8);
+                break;
+            }
             case DF::Float16: { float v; std::memcpy(&v, &in[c], 4);
                                 const uint16_t h = prosper::gpu::float_to_half(v);
                                 dst[c * 2] = static_cast<uint8_t>(h);

--- a/prosper/frontends/shared/live_compute.hpp
+++ b/prosper/frontends/shared/live_compute.hpp
@@ -10,6 +10,7 @@ namespace prosper::frontend {
 // Pack one raw float32 channel to UNORM8 using the storage-image conversion contract. Kept public
 // so the optimized scalar conversion can be checked directly against the previous lround path.
 uint8_t storage_pack_unorm8(uint32_t float_bits);
+uint16_t storage_pack_unorm16(uint32_t float_bits);
 void storage_pack_unorm8_range(const uint32_t* channels, uint32_t components,
                                size_t texels, uint8_t* packed);
 

--- a/prosper/src/gpu/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc_shader_layout.cpp
@@ -540,19 +540,18 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
         }
     }
 
-    // Read-only buffer entries share sharp[0] with textures. A 4-dword V# carries the sharp size bit,
-    // but that bit is only a hint: live UE4 T# entries can carry it too. Source 258's size=1 direct
-    // entry at offset_dw=8 decodes as base=0x10c109ac60, stride=16, records=7 (112 bytes) and is
-    // consumed by s_buffer_load_dwordx8/x4. Treating every sharp[0] entry as a T# fabricated a tiny
-    // texture and left those scalar loads on the unrelated binding-2 fallback, which then failed the
-    // descriptor contract (required 48, available 32). EUD-resident size=1 entries use the same SRT
+    // Read-only buffer entries share sharp[0] with textures. A 4-dword V# usually carries the sharp
+    // size bit, but it is only a hint in both directions: live UE4 T# entries can carry it, while Astro
+    // Bot publishes valid V# entries without it. Classify every entry by the conservative V# shape
+    // below. A T# reinterpreted as V# normally loses its <<8 address scale and fails the guest-VA floor;
+    // the size/stride bounds reject the remaining false positives. EUD entries use the same SRT
     // provenance as the writable/category-1 and constant/category-3 buffers.
     const AgcShaderSharp* readonly_resources = ud->sharp_resource_offset[0];
     std::vector<bool> readonly_buffer_slots(ud->sharp_resource_count[0], false);
     if (arr_ok(readonly_resources, ud->sharp_resource_count[0], sizeof(AgcShaderSharp))) {
         for (uint16_t slot = 0; slot < ud->sharp_resource_count[0]; slot++) {
             const AgcShaderSharp& s = readonly_resources[slot];
-            if (s.empty() || !s.size()) continue;
+            if (s.empty()) continue;
             const uint32_t off = s.offset_dw();
             uint32_t vv[4];
             const uint32_t srt = load_sharp(off, 4, vv);
@@ -601,6 +600,7 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
             const bool tex_in_eud = (uint64_t)off + 8 > num_user_sgprs;
             DecodedImageDescriptor d = decode_image_descriptor(tv);
             if (d.base == 0 || d.width == 0 || d.height == 0 || d.depth == 0 ||
+                !valid_image_type(d.type) ||
                 d.base_array != 0 ||
                 d.width > 16384 || d.height > 16384) continue;  // skip a garbage/degenerate T#
             // PROSPER_DUMP_TILERAW (issue #282 derivation): dump the raw guest texel bytes of a tiled

--- a/prosper/src/gpu/agc_shader_layout.hpp
+++ b/prosper/src/gpu/agc_shader_layout.hpp
@@ -156,6 +156,11 @@ DecodedImageDescriptor decode_image_descriptor(const uint32_t t[8]);
 // long-standing 2D fallback.
 uint32_t image_type_to_dim(uint8_t type);
 
+// GFX10 image descriptors use only SQ_RSRC_IMG TYPE values 8..15. Buffer V# tables are frequently
+// eight-dword aligned too, so this discriminator is part of validating a candidate T# rather than a
+// cosmetic decode detail.
+inline bool valid_image_type(uint8_t type) { return type >= 8 && type <= 15; }
+
 // A Gen5/GFX10 T# IMG_FMT (the 9-bit combined format field) decoded to sizing + conversion info.
 // bytes_per_block is the byte size of one block_width x block_height texel block — for uncompressed
 // formats block dims are 1x1 and it equals bytes-per-texel; for BCn blocks are 4x4.

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -1532,6 +1532,15 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
     if (trc && !g_dyntrace_force)
         if (const char* fa = getenv("PROSPER_DYNTRACE_ADDR"))
             trc = strtoull(fa, nullptr, 16) == (uint64_t)(uintptr_t)code;
+    // A full scalar-fold trace is intentionally verbose. Live shaders can rebuild their stage table
+    // thousands of times per scene, so permit a targeted diagnostic run to capture the first matching
+    // fold without turning every subsequent frame into gigabytes of duplicate logging.
+    if (trc && !g_dyntrace_force && getenv("PROSPER_DYNTRACE_ONCE")) {
+        static std::mutex once_mx;
+        static std::set<const uint32_t*> traced;
+        std::lock_guard<std::mutex> lk(once_mx);
+        trc = traced.insert(code).second;
+    }
     // Scalar operands encode at most 128 SGPRs. Fixed register files avoid hundreds of tiny hash/tree
     // allocations per submit while retaining exactly the same known/unknown state model.
     constexpr size_t kFoldSgprs = 128;
@@ -1963,11 +1972,22 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                               descr_key_known.set((size_t)sdst);
                 }
                 if (n == 16) {
-                    // NGG back halves commonly fetch a compact stage-data block containing four
-                    // consecutive V# descriptors with one s_load_dwordx16. Each aligned group can
-                    // subsequently be consumed by MUBUF. The load's one byte-offset key cannot
-                    // distinguish those four resources, so retain key-less descriptor provenance;
-                    // the consumer is then resolved by its exact instruction pc.
+                    // NGG back halves commonly fetch a compact stage-data block containing a mix of
+                    // one 8-dword T# and 4-dword V# descriptors with one s_load_dwordx16. SGPR loads
+                    // are typeless, so retain both aligned interpretations and let the eventual MIMG
+                    // or MUBUF consumer select the appropriate one. The load's one byte-offset key
+                    // cannot distinguish the resources inside the block, so retain key-less
+                    // descriptor provenance; each consumer is resolved by its exact instruction pc.
+                    for (uint32_t first = 0; first < n; first += 8) {
+                        const int base_reg = sdst + static_cast<int>(first);
+                        if (!valid_reg(base_reg) || !valid_reg(base_reg + 7)) continue;
+                        descr8[(size_t)base_reg] = {
+                            mem[first], mem[first + 1], mem[first + 2], mem[first + 3],
+                            mem[first + 4], mem[first + 5], mem[first + 6], mem[first + 7] };
+                        descr8_known.set((size_t)base_reg);
+                        descr8_key[(size_t)base_reg] = 0xFFFFFFFFu;
+                        descr8_key_known.set((size_t)base_reg);
+                    }
                     for (uint32_t first = 0; first < n; first += 4) {
                         const int base_reg = sdst + static_cast<int>(first);
                         if (!valid_reg(base_reg) || !valid_reg(base_reg + 3)) continue;
@@ -2070,24 +2090,14 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                         current_known &= known(srsrc + k, current[(size_t)k]);
                     const bool loaded_provenance = valid_reg(srsrc) &&
                                                    descr_known.test((size_t)srsrc);
-                    bool moved_direct_provenance = valid_reg(srsrc) && valid_reg(srsrc + 3);
-                    uint32_t first_origin = 0;
-                    for (int k = 0; k < 4 && moved_direct_provenance; ++k) {
-                        const size_t reg = (size_t)(srsrc + k);
-                        if (!val_seed_origin_known.test(reg)) {
-                            moved_direct_provenance = false;
-                        } else if (k == 0) {
-                            first_origin = val_seed_origin[reg];
-                        } else if (val_seed_origin[reg] != first_origin + (uint32_t)k) {
-                            moved_direct_provenance = false;
-                        }
-                    }
-                    const bool direct_provenance = unchanged_seed_range(srsrc, 4) ||
-                                                   moved_direct_provenance;
-                    if (current_known && (loaded_provenance || direct_provenance)) {
-                        // Publish the four values LIVE at the consumer. A modeled scalar patch is
-                        // exact; an unmodeled/incompatible write becomes unknown and fails closed
-                        // instead of resurrecting the load-time descriptor snapshot.
+                    if (current_known) {
+                        // MUBUF/MTBUF itself is definitive that its four SRSRC words are a V#. Publish
+                        // the values LIVE at the consumer whenever the scalar fold knows all of them.
+                        // This also covers a direct descriptor whose NUM_RECORDS/stride is patched by
+                        // modeled scalar ALU: such a patch intentionally breaks entry-seed provenance,
+                        // but does not make the now-concrete V# any less valid. An unmodeled write makes
+                        // a word unknown and still fails closed; the shape/range checks below reject
+                        // malformed concrete values before any resource is emitted.
                         SrtUse u; u.kind = 1; u.v4 = current; u.key = 0xFFFFFFFFu; u.use_pc = in.pc;
                         if (is_mtbuf) u.instruction_format = in.mtbuf_format;
                         if (loaded_provenance) {
@@ -2919,6 +2929,7 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
                                 u.use_pc, u.key, (unsigned long long)d.base, d.width, d.height,
                                 d.format, d.tile_mode);
                     if (d.base == 0 || d.width == 0 || d.height == 0 || d.depth == 0 ||
+                        !valid_image_type(d.type) ||
                         d.base_array != 0 ||
                         d.width > 16384 || d.height > 16384) continue;       // garbage/degenerate T#
                     // A previous use already produced a resource for this SAME selected view (address +
@@ -3278,6 +3289,7 @@ std::vector<ComputeItem> realize_compute_dispatches(
                 {                                         // T# — storage image (store) or sampled texture
                     DecodedImageDescriptor d = decode_image_descriptor(u.t8.data());
                     if (d.base == 0 || d.width == 0 || d.height == 0 || d.depth == 0 ||
+                        !valid_image_type(d.type) ||
                         d.base_array != 0 ||
                         d.width > 16384 || d.height > 16384) continue;   // garbage/degenerate T#
                     Gen5ImageFormatInfo fi;

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -2012,25 +2012,45 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                     const int samp_base = in.src[2].value;
                     const bool have_t8 = valid_reg(tbase) && descr8_known.test((size_t)tbase);
                     const bool have_key = valid_reg(tbase) && descr8_key_known.test((size_t)tbase);
-                    const std::array<uint32_t, 8>* t8 = have_t8
-                        ? &descr8[(size_t)tbase] : nullptr;
-                    std::array<uint32_t, 8> seed_t8{};
-                    const uint32_t tkey = have_key
-                        ? descr8_key[(size_t)tbase] : 0xFFFFFFFFu;
-                    bool from_seed = false;
-                    if (!t8 && untouched_seed_range(tbase, 8)) {
-                        for (int k = 0; k < 8; k++)
-                            seed_t8[k] = user_sgprs[tbase - (int)user_sgpr_base + k];
-                        DecodedImageDescriptor d = decode_image_descriptor(seed_t8.data());
-                        // A direct T# has no s_load provenance key, so it is resolved by this MIMG's
-                        // exact pc. Reject obviously non-image user data before creating that mapping.
-                        if (d.base > 0x10000 && d.width && d.height &&
+                    // MIMG itself proves that its eight SRSRC words are a T#. A table snapshot or
+                    // direct user-data range establishes provenance, but the RESOURCE MUST use the
+                    // words live at this instruction: modeled scalar patches are architectural, and
+                    // an unmodeled write makes one word unknown and therefore rejects. Falling back
+                    // to descr8's load-time bytes after either case would bind a stale texture.
+                    std::array<uint32_t, 8> live_t8{};
+                    bool live_t8_known = true;
+                    for (int k = 0; k < 8; ++k)
+                        live_t8_known &= known(tbase + k, live_t8[(size_t)k]);
+                    const bool seed_provenance = !have_t8 && untouched_seed_range(tbase, 8);
+                    bool plausible_seed = true;
+                    if (seed_provenance && live_t8_known) {
+                        const DecodedImageDescriptor d = decode_image_descriptor(live_t8.data());
+                        plausible_seed = d.base > 0x10000 && d.width && d.height &&
                             d.width <= 16384 && d.height <= 16384 &&
-                            d.type >= 8 && d.type <= 15) {
-                            t8 = &seed_t8;
-                            from_seed = true;
-                        }
+                            d.type >= 8 && d.type <= 15;
                     }
+                    const std::array<uint32_t, 8>* t8 =
+                        live_t8_known && (have_t8 || (seed_provenance && plausible_seed))
+                            ? &live_t8 : nullptr;
+                    uint32_t tkey = 0xFFFFFFFFu;
+                    if (t8 && have_key) {
+                        uint32_t common_key = 0;
+                        bool common_key_known = true;
+                        for (int k = 0; k < 8; ++k) {
+                            const size_t reg = (size_t)(tbase + k);
+                            if (!valid_reg(tbase + k) || !val_srt_key_known.test(reg)) {
+                                common_key_known = false;
+                                break;
+                            }
+                            if (k == 0) common_key = val_srt_key[reg];
+                            else if (val_srt_key[reg] != common_key) {
+                                common_key_known = false;
+                                break;
+                            }
+                        }
+                        if (common_key_known) tkey = common_key;
+                    }
+                    const bool from_seed = t8 && seed_provenance;
                     if (trc) {
                         fprintf(stderr, "[dyntrace] MIMG pc=%u op=0x%x srsrc=s%d ssamp=s%d "
                                         "have_t8=%d seed_t8=%d key=0x%x t8=",
@@ -2055,15 +2075,15 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                         u.is_depth_compare = (in.opcode >= 0x28 && in.opcode <= 0x2f) ||
                                              (in.opcode >= 0x38 && in.opcode <= 0x3f) ||
                                              (in.opcode >= 0x58 && in.opcode <= 0x5f);
-                        if (valid_reg(samp_base) && descr_known.test((size_t)samp_base)) {
-                            u.has_samp = true;
-                            u.s4 = descr[(size_t)samp_base];
-                        } else if (untouched_seed_range(samp_base, 4)) {
-                            // Direct S# paired with the direct/table T#. Samplers have no address or
-                            // extent field to validate; block membership plus reload invalidation is
-                            // the conservative provenance check.
-                            for (int k = 0; k < 4; k++)
-                                u.s4[k] = user_sgprs[samp_base - (int)user_sgpr_base + k];
+                        const bool have_s4 = valid_reg(samp_base) &&
+                                             descr_known.test((size_t)samp_base);
+                        const bool seed_s4 = !have_s4 && untouched_seed_range(samp_base, 4);
+                        bool live_s4_known = true;
+                        for (int k = 0; k < 4; ++k)
+                            live_s4_known &= known(samp_base + k, u.s4[(size_t)k]);
+                        if (live_s4_known && (have_s4 || seed_s4)) {
+                            // Like the T#, sampler words are read live. This avoids retaining a stale
+                            // x16 load snapshot if scalar code patches or invalidates the paired S#.
                             u.has_samp = true;
                         }
                         srt_uses->push_back(u);

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -3669,6 +3669,33 @@ void for_each_scalar_write(const Rdna2Inst& in, Visitor&& visit) {
         visit(in.sdst.value, 2);
 }
 
+// True when this explicit scalar destination is written in the per-lane B64 mask domain.  Keep
+// this classification independent of the post-emission SSA maps: folded/data writers such as
+// s_getpc_b64 intentionally leave no scalar value behind, so absence from `sreg` cannot identify a
+// mask write.  VOP3B's SDST is a mask/carry pair even though the instruction's primary VDST is data.
+bool scalar_write_is_b64_mask(const Rdna2Inst& in, int base) {
+    if (in.fmt == Rdna2Format::SOP1 && in.dst.value == base) {
+        switch (in.opcode) {
+            case 0x04: case 0x08: case 0x0a: case 0x24: case 0x25: case 0x37:
+                return true;
+            default: break;
+        }
+    }
+    if (in.fmt == Rdna2Format::SOP2 && in.dst.value == base) {
+        switch (in.opcode) {
+            case 0x0b: case 0x0f: case 0x11: case 0x13: case 0x15:
+            case 0x17: case 0x19: case 0x1b: case 0x1d: case 0x25:
+                return true;
+            default: break;
+        }
+    }
+    if (in.fmt == Rdna2Format::VOPC && !vopc_is_cmpx(in.opcode) &&
+        in.dst.kind == OperandKind::SGPR && in.dst.value == base && base <= 105)
+        return true;
+    return in.fmt == Rdna2Format::VOP3 && in.sdst.kind == OperandKind::SGPR &&
+           in.sdst.value == base;
+}
+
 void record_scalar_write(RegState& rs, const Rdna2Inst& in) {
     // VOPC/VOP3 mask destinations live in sreg_bool, but they still overwrite the physical SGPR
     // pair. Drop any scalar-data value or SRT descriptor tag left by that pair's earlier lifetime;
@@ -3686,30 +3713,27 @@ void record_scalar_write(RegState& rs, const Rdna2Inst& in) {
         invalidate_mask_pair(in.sdst.value);
 
     for_each_scalar_write(in, [&](int base, uint32_t width) {
-        // emit_alu has already materialized the new lifetime. A scalar-data destination is present
-        // in sreg; a mask-only destination is not. End every overlapping one-word Wave32 mask
-        // lifetime on data writes, including SOP2, SOPK, SMEM, readfirstlane/readlane, and future
-        // scalar writers covered by scalar_write_width(). A pair-mask write replaces the B32 marker
-        // but retains its newly-emitted bool-domain value.
-        bool data_write = false;
-        for (uint32_t word = 0; word < width; ++word)
-            data_write |= rs.sreg.contains(base + static_cast<int>(word));
-        const bool preserves_b32_mask = width == 1 && in.fmt == Rdna2Format::SOP1 &&
+        // emit_alu has already materialized the new lifetime. Classify mask writers from the
+        // instruction itself rather than inferring them from `sreg`: s_getpc_b64's folded form
+        // deliberately erases both data SSA words, but hardware still overwrites the pair. End every
+        // overlapping one-word Wave32 alias on all non-mask writes. A B64 mask replacement retains
+        // its newly-emitted bool-domain value while dropping the obsolete B32 width marker.
+        const bool writes_b32_mask = width == 1 && in.fmt == Rdna2Format::SOP1 &&
             (in.opcode == 0x03 || in.opcode == 0x09) &&
-            rs.sreg_bool_b32.contains(base) && !data_write;
+            rs.sreg_bool_b32.contains(base);
+        const bool writes_b64_mask = width == 2 && scalar_write_is_b64_mask(in, base);
         for (uint32_t word = 0; word < width; ++word) {
             const int reg = base + static_cast<int>(word);
-            if (!rs.sreg_bool_b32.contains(reg) || (preserves_b32_mask && reg == base))
+            if (!rs.sreg_bool_b32.contains(reg) || (writes_b32_mask && reg == base))
                 continue;
             rs.sreg_bool_b32.erase(reg);
-            if (data_write || reg != base || !rs.sreg_bool.contains(base)) {
+            if (!writes_b64_mask || reg != base) {
                 rs.sreg_bool.erase(reg);
                 rs.sreg_bool_narrowed.erase(reg);
                 if (reg == 106) rs.vcc = 0;
             }
         }
-        if (!data_write && !preserves_b32_mask)
-            rs.sreg_bool_b32.erase(base);
+        if (!writes_b32_mask) rs.sreg_bool_b32.erase(base);
         for (uint32_t word = 0; word < width; ++word) {
             const int reg = base + static_cast<int>(word);
             rs.sreg_written.insert(reg);
@@ -3738,6 +3762,37 @@ void invalidate_loop_descriptor_provenance(RegState& rs, const std::set<int>& sr
         rs.sreg_input.erase(reg);
         rs.sreg_srt.erase(reg);
     }
+}
+
+// Complex CFG dispatch and the narrow loop structurizers persist B64 mask values, but not the
+// separate one-word-validity state required by Wave32 aliases. Conservatively find any B32 mask
+// copy that the region could create. The source set is deliberately path-insensitive: a pair made a
+// mask on any path may reach a later copy on another dispatcher edge, and rejecting an impossible
+// ordering is safer than silently restoring a stale Boolean.
+bool has_unpersisted_b32_mask_lifetime(const std::vector<Rdna2Inst>& ins,
+                                      uint32_t lo, uint32_t hi,
+                                      const RegState& entry) {
+    std::set<int> possible_mask_sources{106, 126}; // VCC_LO and EXEC_LO
+    for (const auto& kv : entry.sreg_bool) possible_mask_sources.insert(kv.first);
+    for (int reg : entry.sreg_bool_b32) possible_mask_sources.insert(reg);
+    for (const auto& in : ins) {
+        if (in.is_end || in.pc < lo || in.pc >= hi) continue;
+        for_each_scalar_write(in, [&](int base, uint32_t) {
+            if (scalar_write_is_b64_mask(in, base)) possible_mask_sources.insert(base);
+        });
+    }
+    for (const auto& in : ins) {
+        if (in.is_end || in.pc < lo || in.pc >= hi || in.fmt != Rdna2Format::SOP1)
+            continue;
+        if (in.opcode == 0x09) return true; // s_wqm_b32 creates/consumes the same width state
+        if (in.opcode != 0x03) continue;
+        const bool register_source = in.src[0].kind == OperandKind::SGPR ||
+                                     in.src[0].kind == OperandKind::Special;
+        if ((register_source && possible_mask_sources.contains(in.src[0].value)) ||
+            in.dst.value == 126)
+            return true;
+    }
+    return false;
 }
 
 } // namespace
@@ -7584,18 +7639,10 @@ bool emit_compute_cfg_state_machine(
     // per-edge validity value in addition to the bool itself. Until that state is represented, keep
     // complex-CFG Wave32 mask programs on the fail-visible path; straight-line/structured shaders
     // still use the exact lifetime tracking in RegState.
-    if (b.allow_b32_masks) {
-        if (!initial.sreg_bool_b32.empty()) return false;
-        for (const auto& in : ins) {
-            if (in.is_end) break;
-            if (in.fmt != Rdna2Format::SOP1) continue;
-            if (in.opcode == 0x09 ||
-                (in.opcode == 0x03 &&
-                 (in.src[0].value == 106 || in.src[0].value == 126 ||
-                  in.dst.value == 126)))
-                return false;
-        }
-    }
+    if (b.allow_b32_masks &&
+        (!initial.sreg_bool_b32.empty() ||
+         has_unpersisted_b32_mask_lifetime(ins, 0, UINT32_MAX, initial)))
+        return false;
     const uint32_t wave_count = (b.local_count + b.wave_size - 1) / b.wave_size;
     const uint32_t padded_lanes = wave_count * b.wave_size;
     const uint32_t wave_result_base = padded_lanes;
@@ -7610,22 +7657,10 @@ bool emit_compute_cfg_state_machine(
     for (const auto& kv : initial.sreg_bool) static_mask_keys.insert(kv.first);
     for (const auto& in : ins) {
         if (in.is_end) break;
-        if (in.fmt == Rdna2Format::SOP1 &&
-            (in.opcode == 0x04 || in.opcode == 0x08 || in.opcode == 0x0a ||
-             in.opcode == 0x24 || in.opcode == 0x25 || in.opcode == 0x37) &&
-            in.dst.value != 126 && in.dst.value != 127)
-            static_mask_keys.insert(in.dst.value);
-        if (in.fmt == Rdna2Format::SOP2 &&
-            (in.opcode == 0x0b || in.opcode == 0x0f || in.opcode == 0x11 ||
-             in.opcode == 0x13 || in.opcode == 0x15 || in.opcode == 0x17 ||
-             in.opcode == 0x19 || in.opcode == 0x1b || in.opcode == 0x1d ||
-             in.opcode == 0x25) &&
-            in.dst.value != 106 && in.dst.value != 107 &&
-            in.dst.value != 126 && in.dst.value != 127)
-            static_mask_keys.insert(in.dst.value);
-        if (in.fmt == Rdna2Format::VOPC && in.dst.kind == OperandKind::SGPR &&
-            in.dst.value <= 105)
-            static_mask_keys.insert(in.dst.value);
+        for_each_scalar_write(in, [&](int base, uint32_t) {
+            if (base <= 105 && scalar_write_is_b64_mask(in, base))
+                static_mask_keys.insert(base);
+        });
     }
     auto mask_zero_compare_source = [&](const Rdna2Inst& in) -> int {
         if (in.fmt != Rdna2Format::SOPC || (in.opcode != 0x12 && in.opcode != 0x13))
@@ -8831,17 +8866,10 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
         loop_scalar_may_writes(ins, L.header_pc, L.backedge_pc, scalar_may_writes);
         for (int reg : rs.sreg_bool_b32)
             if (scalar_may_writes.contains(reg)) return false;
-        if (b.allow_b32_masks)
-            for (const auto& candidate : ins) {
-                if (candidate.pc < L.header_pc || candidate.pc >= L.backedge_pc ||
-                    candidate.fmt != Rdna2Format::SOP1) continue;
-                if (candidate.opcode == 0x09 ||
-                    (candidate.opcode == 0x03 &&
-                     (candidate.src[0].value == 106 || candidate.src[0].value == 126 ||
-                      candidate.dst.value == 126 ||
-                      rs.sreg_bool_b32.contains(candidate.src[0].value))))
-                    return false;
-            }
+        if (b.allow_b32_masks &&
+            has_unpersisted_b32_mask_lifetime(
+                ins, L.header_pc, L.backedge_pc, rs))
+            return false;
         const uint32_t preheader = b.cur_block;
         const uint32_t hdr = b.id(), check = b.id(), body = b.id(), cont = b.id(), merge = b.id();
         b.emit_branch(hdr); b.emit_label(hdr);
@@ -9120,17 +9148,10 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
             loop_scalar_may_writes(ins, L.header_pc, L.backedge_pc, scalar_may_writes);
             for (int reg : rs.sreg_bool_b32)
                 if (scalar_may_writes.contains(reg)) return false;
-            if (b.allow_b32_masks)
-                for (const auto& candidate : ins) {
-                    if (candidate.pc < L.header_pc || candidate.pc >= L.backedge_pc ||
-                        candidate.fmt != Rdna2Format::SOP1) continue;
-                    if (candidate.opcode == 0x09 ||
-                        (candidate.opcode == 0x03 &&
-                         (candidate.src[0].value == 106 || candidate.src[0].value == 126 ||
-                          candidate.dst.value == 126 ||
-                          rs.sreg_bool_b32.contains(candidate.src[0].value))))
-                        return false;
-                }
+            if (b.allow_b32_masks &&
+                has_unpersisted_b32_mask_lifetime(
+                    ins, L.header_pc, L.backedge_pc, rs))
+                return false;
             const uint32_t preheader = b.cur_block;
             const uint32_t hdr = b.id(), chk = b.id(), body = b.id(), cont = b.id(), merge = b.id();
             b.emit_branch(hdr); b.emit_label(hdr);

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -9289,6 +9289,7 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                     uint32_t pre_scc = rs.scc, pre_vcc = rs.vcc, pre_exec = rs.exec;
                     const bool pre_narrowed = rs.exec_narrowed;
                     const std::unordered_map<int,uint32_t> pre_bool = rs.sreg_bool;   // mask-domain snapshot
+                    const auto pre_bool_b32 = rs.sreg_bool_b32;
                     uint32_t thenL = b.id(), mergeL = b.id();
                     b.emit_selmerge(mergeL); b.emit_condbranch(exec_cond, thenL, mergeL);
                     b.emit_label(thenL);
@@ -9299,6 +9300,11 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                     for (int r : ifs) then_s[r] = sget(r);
                     uint32_t then_scc = rs.scc, then_vcc = rs.vcc, then_exec = rs.exec;
                     const bool then_narrowed = rs.exec_narrowed;
+                    // The skipped edge retains the entry-time physical-word lifetime. A B32 mask
+                    // created or invalidated only in the taken arm therefore needs a validity phi,
+                    // which this narrow merge does not represent. Reject rather than attach the
+                    // taken arm's marker to the synthesized bool value on both paths.
+                    if (rs.sreg_bool_b32 != pre_bool_b32) return false;
                     b.emit_branch(mergeL); b.emit_label(mergeL);
                     for (int r : ifv) rs.vreg[r] = b.emit_phi_2way(b.t_u32,  pre_v[r], preblock, then_v[r], thenEnd);
                     for (int r : ifs) rs.sreg[r] = b.emit_phi_2way(b.t_u32,  pre_s[r], preblock, then_s[r], thenEnd);

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -219,6 +219,7 @@ struct SpirvCompute {
     std::map<uint32_t, uint32_t> cbuf_var;          // binding -> storage-buffer var (N-buffer model; 2/3 map to v_cbuf/v_cbuf1)
     bool     is_fragment=0;                          // true in the fragment shell (gates VINTRP interp)
     bool     is_vertex=0;                            // true in every vertex shell
+    bool     allow_b32_masks=0;                      // proven Wave32 or byte-exact graphics exception
     bool     ngg_one_lane=0;                         // exact GS_ALLOC_REQ wrapper: one guest lane/invocation
     bool     ngg_private_lds=0;                      // exact captured wrapper whose LDS projection is known
     uint32_t ngg_vertex_index_read_pc = UINT32_MAX;   // NGG wave/LDS prologue handoff -> host VertexIndex
@@ -2350,6 +2351,9 @@ struct RegState {
     std::unordered_set<int> sreg_written;
     std::unordered_map<int, uint32_t> sreg_bool;   // SGPR (pairs) holding a saved per-lane mask (bool id)
     std::unordered_map<int, bool> sreg_bool_narrowed;  // was EXEC narrowed when this mask was saved? (restores it)
+    // Wave32 saves occupy exactly one physical SGPR. Track those lifetimes separately so a later
+    // scalar-data write can invalidate the bool without also clobbering an unrelated neighbor.
+    std::unordered_set<int> sreg_bool_b32;
     std::unordered_map<int, uint32_t> sreg_srt;    // SGPR holding a descriptor -> its user_data/SRT byte offset
                                                    // (descriptor provenance: s_load_dwordx4 tags, s_buffer_load resolves)
     uint32_t vcc = 0;
@@ -3682,6 +3686,30 @@ void record_scalar_write(RegState& rs, const Rdna2Inst& in) {
         invalidate_mask_pair(in.sdst.value);
 
     for_each_scalar_write(in, [&](int base, uint32_t width) {
+        // emit_alu has already materialized the new lifetime. A scalar-data destination is present
+        // in sreg; a mask-only destination is not. End every overlapping one-word Wave32 mask
+        // lifetime on data writes, including SOP2, SOPK, SMEM, readfirstlane/readlane, and future
+        // scalar writers covered by scalar_write_width(). A pair-mask write replaces the B32 marker
+        // but retains its newly-emitted bool-domain value.
+        bool data_write = false;
+        for (uint32_t word = 0; word < width; ++word)
+            data_write |= rs.sreg.contains(base + static_cast<int>(word));
+        const bool preserves_b32_mask = width == 1 && in.fmt == Rdna2Format::SOP1 &&
+            (in.opcode == 0x03 || in.opcode == 0x09) &&
+            rs.sreg_bool_b32.contains(base) && !data_write;
+        for (uint32_t word = 0; word < width; ++word) {
+            const int reg = base + static_cast<int>(word);
+            if (!rs.sreg_bool_b32.contains(reg) || (preserves_b32_mask && reg == base))
+                continue;
+            rs.sreg_bool_b32.erase(reg);
+            if (data_write || reg != base || !rs.sreg_bool.contains(base)) {
+                rs.sreg_bool.erase(reg);
+                rs.sreg_bool_narrowed.erase(reg);
+                if (reg == 106) rs.vcc = 0;
+            }
+        }
+        if (!data_write && !preserves_b32_mask)
+            rs.sreg_bool_b32.erase(base);
         for (uint32_t word = 0; word < width; ++word) {
             const int reg = base + static_cast<int>(word);
             rs.sreg_written.insert(reg);
@@ -3862,7 +3890,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // ordinary scalar scratch when its source is ordinary data, matching the data path
             // below.  High-half moves remain unsupported: without the guest wave mode they may name
             // another lane rather than this invocation's bit.
-            if (in.opcode == 0x03) {                         // s_mov_b32
+            if (b.allow_b32_masks && in.opcode == 0x03) {   // s_mov_b32 (mask-domain form)
                 const auto data_value_present = [&](int reg) {
                     return rs.sreg.contains(reg) || rs.sreg_input.contains(reg);
                 };
@@ -3908,9 +3936,11 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                         rs.vcc = mask;
                         rs.sreg_bool[106] = mask;
                         rs.sreg_bool_narrowed[106] = narrowed;
+                        rs.sreg_bool_b32.insert(106);
                     } else {
                         rs.sreg_bool[in.dst.value] = mask;
                         rs.sreg_bool_narrowed[in.dst.value] = narrowed;
+                        rs.sreg_bool_b32.insert(in.dst.value);
                     }
                     // A B32 move overwrites only the addressed physical word.  Remove stale scalar
                     // data/descriptor provenance for that word while leaving its neighbor intact.
@@ -3919,7 +3949,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     return true;
                 }
             }
-            if (in.opcode == 0x09) {                         // s_wqm_b32
+            if (b.allow_b32_masks && in.opcode == 0x09) {   // s_wqm_b32
                 // Wave32 uses the low half of EXEC for the same whole-quad-mode idiom as
                 // s_wqm_b64.  In the per-invocation fragment model helper lanes are implicit, so
                 // widening is an identity on the tracked bool.  Keep this in the mask domain and
@@ -3964,9 +3994,11 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     rs.vcc = mask;
                     rs.sreg_bool[106] = mask;
                     rs.sreg_bool_narrowed[106] = true;
+                    rs.sreg_bool_b32.insert(106);
                 } else {
                     rs.sreg_bool[in.dst.value] = mask;
                     rs.sreg_bool_narrowed[in.dst.value] = true;
+                    rs.sreg_bool_b32.insert(in.dst.value);
                 }
                 rs.sreg.erase(in.dst.value);
                 rs.sreg_srt.erase(in.dst.value);
@@ -4172,6 +4204,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // let an earlier Wave32 mask save alias that new value in later mask-domain moves.
             rs.sreg_bool.erase(in.dst.value);
             rs.sreg_bool_narrowed.erase(in.dst.value);
+            rs.sreg_bool_b32.erase(in.dst.value);
             switch (in.opcode) {
                 case 0x03: {                                // s_mov_b32
                     d = a;
@@ -7546,6 +7579,23 @@ bool emit_compute_cfg_state_machine(
     if (end_pc == UINT32_MAX) return false;
     if ((b.wave_size != 32 && b.wave_size != 64) || !b.local_count || b.local_count > 1024)
         return false;
+    // The dispatcher persists a statically-shaped register file between cases. A B32 saved-mask
+    // alias can end when an ordinary scalar write reuses that word, which would require a separate
+    // per-edge validity value in addition to the bool itself. Until that state is represented, keep
+    // complex-CFG Wave32 mask programs on the fail-visible path; straight-line/structured shaders
+    // still use the exact lifetime tracking in RegState.
+    if (b.allow_b32_masks) {
+        if (!initial.sreg_bool_b32.empty()) return false;
+        for (const auto& in : ins) {
+            if (in.is_end) break;
+            if (in.fmt != Rdna2Format::SOP1) continue;
+            if (in.opcode == 0x09 ||
+                (in.opcode == 0x03 &&
+                 (in.src[0].value == 106 || in.src[0].value == 126 ||
+                  in.dst.value == 126)))
+                return false;
+        }
+    }
     const uint32_t wave_count = (b.local_count + b.wave_size - 1) / b.wave_size;
     const uint32_t padded_lanes = wave_count * b.wave_size;
     const uint32_t wave_result_base = padded_lanes;
@@ -7560,13 +7610,6 @@ bool emit_compute_cfg_state_machine(
     for (const auto& kv : initial.sreg_bool) static_mask_keys.insert(kv.first);
     for (const auto& in : ins) {
         if (in.is_end) break;
-        if (in.fmt == Rdna2Format::SOP1 &&
-            (in.opcode == 0x03 || in.opcode == 0x09) &&
-            in.dst.value <= 105 &&
-            (in.src[0].value == 126 ||
-             (in.src[0].kind == OperandKind::SGPR &&
-              static_mask_keys.count(in.src[0].value))))
-            static_mask_keys.insert(in.dst.value); // Wave32 s_mov_b32 save/copy of EXEC_LO
         if (in.fmt == Rdna2Format::SOP1 &&
             (in.opcode == 0x04 || in.opcode == 0x08 || in.opcode == 0x0a ||
              in.opcode == 0x24 || in.opcode == 0x25 || in.opcode == 0x37) &&
@@ -8725,6 +8768,7 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
             const uint32_t then_scc = rs.scc, then_vcc = rs.vcc, then_exec = rs.exec;
             const bool then_narrowed = rs.exec_narrowed;
             const auto then_bool = rs.sreg_bool;
+            const auto then_bool_b32 = rs.sreg_bool_b32;
             const auto then_written = rs.sreg_written;
             b.emit_branch(merge_label);
 
@@ -8759,7 +8803,7 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
             rs.exec_narrowed = then_narrowed || rs.exec_narrowed;
             rs.sreg_written.insert(then_written.begin(), then_written.end());
             for (int reg : then_written) rs.sreg_input.erase(reg);
-            if (then_bool != rs.sreg_bool) {
+            if (then_bool != rs.sreg_bool || then_bool_b32 != rs.sreg_bool_b32) {
                 if (getenv("PROSPER_DBG"))
                     fprintf(stderr, "[recompile-reject] counted-loop prelude changes mask domain\n");
                 return false; // no mask-domain PHIs in this narrow composition
@@ -8785,6 +8829,19 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
         loop_written_regs(ins, L.header_pc, L.backedge_pc, cv, cs);
         loop_written_regs(ins, L.header_pc, L.exit_branch_pc, condv, conds);
         loop_scalar_may_writes(ins, L.header_pc, L.backedge_pc, scalar_may_writes);
+        for (int reg : rs.sreg_bool_b32)
+            if (scalar_may_writes.contains(reg)) return false;
+        if (b.allow_b32_masks)
+            for (const auto& candidate : ins) {
+                if (candidate.pc < L.header_pc || candidate.pc >= L.backedge_pc ||
+                    candidate.fmt != Rdna2Format::SOP1) continue;
+                if (candidate.opcode == 0x09 ||
+                    (candidate.opcode == 0x03 &&
+                     (candidate.src[0].value == 106 || candidate.src[0].value == 126 ||
+                      candidate.dst.value == 126 ||
+                      rs.sreg_bool_b32.contains(candidate.src[0].value))))
+                    return false;
+            }
         const uint32_t preheader = b.cur_block;
         const uint32_t hdr = b.id(), check = b.id(), body = b.id(), cont = b.id(), merge = b.id();
         b.emit_branch(hdr); b.emit_label(hdr);
@@ -9061,6 +9118,19 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
             loop_written_regs(ins, L.header_pc, L.backedge_pc, cv, cs);
             loop_written_regs(ins, L.header_pc, L.exit_branch_pc, condv, conds);
             loop_scalar_may_writes(ins, L.header_pc, L.backedge_pc, scalar_may_writes);
+            for (int reg : rs.sreg_bool_b32)
+                if (scalar_may_writes.contains(reg)) return false;
+            if (b.allow_b32_masks)
+                for (const auto& candidate : ins) {
+                    if (candidate.pc < L.header_pc || candidate.pc >= L.backedge_pc ||
+                        candidate.fmt != Rdna2Format::SOP1) continue;
+                    if (candidate.opcode == 0x09 ||
+                        (candidate.opcode == 0x03 &&
+                         (candidate.src[0].value == 106 || candidate.src[0].value == 126 ||
+                          candidate.dst.value == 126 ||
+                          rs.sreg_bool_b32.contains(candidate.src[0].value))))
+                        return false;
+                }
             const uint32_t preheader = b.cur_block;
             const uint32_t hdr = b.id(), chk = b.id(), body = b.id(), cont = b.id(), merge = b.id();
             b.emit_branch(hdr); b.emit_label(hdr);
@@ -9147,6 +9217,7 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
             for (auto it = rs.sreg_bool.begin(); it != rs.sreg_bool.end();) {
                 if (!std::binary_search(mask_keys.begin(), mask_keys.end(), it->first)) {
                     rs.sreg_bool_narrowed.erase(it->first);
+                    rs.sreg_bool_b32.erase(it->first);
                     it = rs.sreg_bool.erase(it);
                 } else ++it;
             }
@@ -9255,6 +9326,7 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                     uint32_t then_scc = rs.scc, then_vcc = rs.vcc, then_exec = rs.exec;
                     const bool then_narrowed = rs.exec_narrowed;
                     const std::unordered_map<int,uint32_t> then_bool = rs.sreg_bool;
+                    const auto then_bool_b32 = rs.sreg_bool_b32;
                     const auto then_written = rs.sreg_written;
                     b.emit_branch(mergeL);
                     rs = pre;                               // else-arm starts from the pre-branch state
@@ -9274,6 +9346,7 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                     rs.exec_narrowed = then_narrowed || rs.exec_narrowed;
                     rs.sreg_written.insert(then_written.begin(), then_written.end());
                     for (int reg : then_written) rs.sreg_input.erase(reg);
+                    if (then_bool_b32 != rs.sreg_bool_b32) return false;
                     // Merge the UNION of mask keys. A mask created in only one arm is false in the
                     // other arm; leaving that arm-local SSA id live after the merge is invalid SPIR-V.
                     std::set<int> bool_keys;
@@ -9355,6 +9428,7 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
     b.native_storage_format_support = config.native_storage_format_support;
     b.begin(1, rt, local_x, local_y, local_z, wave_size,
             static_cast<uint32_t>(config.user_sgprs.size()));
+    b.allow_b32_masks = wave_size == 32;
     b.declare_guest_scratch(scratch);
     const bool has_partial_workgroup = config.threads_x % local_x != 0 ||
                                        config.threads_y % local_y != 0 ||
@@ -9588,6 +9662,16 @@ RecompileCoverage recompile_coverage(const uint32_t* code, size_t dwords) {
     return cov;
 }
 
+static uint64_t shader_program_hash(const uint32_t* code, size_t dwords) {
+    uint64_t hash = 1469598103934665603ull;
+    const auto* bytes = reinterpret_cast<const uint8_t*>(code);
+    for (size_t i = 0; i < dwords * sizeof(uint32_t); ++i) {
+        hash ^= bytes[i];
+        hash *= 1099511628211ull;
+    }
+    return hash;
+}
+
 uint32_t fragment_color_export_mask(const uint32_t* code, size_t dwords) {
     std::vector<Rdna2Inst> ins;
     rdna2_walk(code, dwords, ins);
@@ -9604,13 +9688,15 @@ uint32_t fragment_color_export_mask(const uint32_t* code, size_t dwords) {
     return packed;
 }
 
-std::vector<uint32_t> recompile_fragment(const uint32_t* code, size_t dwords,
-                                         const ShaderResourceTable* rt,
-                                         const PixelSystemInputMapping* system_inputs,
-                                         uint32_t pcrel_dispatch_target,
-                                         const FragmentInterpolationLayout* interpolation) {
+static std::vector<uint32_t> recompile_fragment_impl(
+        const uint32_t* code, size_t dwords,
+        const ShaderResourceTable* rt,
+        const PixelSystemInputMapping* system_inputs,
+        uint32_t pcrel_dispatch_target,
+        const FragmentInterpolationLayout* interpolation,
+        bool allow_test_wave32) {
     std::vector<Rdna2Inst> ins;
-    rdna2_walk(code, dwords, ins);
+    const size_t program_dwords = rdna2_walk(code, dwords, ins);
     if (pcrel_dispatch_target != UINT32_MAX) {
         const PcrelDispatchInfo dispatch = rdna2_pcrel_dispatch_info(code, dwords);
         if (!specialize_pcrel_dispatch(ins, dispatch, pcrel_dispatch_target)) {
@@ -9661,6 +9747,12 @@ std::vector<uint32_t> recompile_fragment(const uint32_t* code, size_t dwords,
     }
     SpirvCompute b;
     b.begin_fragment(rt, color_mask);
+    // Graphics wave mode is not yet plumbed from the stage registers. Keep low-half EXEC/VCC mask
+    // semantics restricted to the complete captured Astro material shader that demonstrated the
+    // Wave32 idiom. Arbitrary graphics shaders retain the previous fail-visible rejection.
+    b.allow_b32_masks = allow_test_wave32 ||
+        (program_dwords == 3142 &&
+         shader_program_hash(code, program_dwords) == 0x616dd4c0b241fbb1ull);
     // Fragment I/O value tap (PROSPER_FS_TAP=draw:pc): redirect the MRT0 colour export to the intermediate
     // VGPR produced at that PC so the rendered frame visualises the value. The `draw:` prefix is consumed by
     // gpu_replay (which re-recompiles only that draw's FS). Parse the same complete selector here so an
@@ -9787,6 +9879,20 @@ std::vector<uint32_t> recompile_fragment(const uint32_t* code, size_t dwords,
     return b.finish();
 }
 
+std::vector<uint32_t> recompile_fragment(const uint32_t* code, size_t dwords,
+                                         const ShaderResourceTable* rt,
+                                         const PixelSystemInputMapping* system_inputs,
+                                         uint32_t pcrel_dispatch_target,
+                                         const FragmentInterpolationLayout* interpolation) {
+    return recompile_fragment_impl(code, dwords, rt, system_inputs,
+                                   pcrel_dispatch_target, interpolation, false);
+}
+
+std::vector<uint32_t> recompile_fragment_wave32_for_test(
+        const uint32_t* code, size_t dwords) {
+    return recompile_fragment_impl(code, dwords, nullptr, nullptr, UINT32_MAX, nullptr, true);
+}
+
 uint32_t fragment_spirv_required_subgroup_size(const std::vector<uint32_t>& spirv) {
     if (spirv.size() < 5 || spirv[0] != 0x07230203u) return 0;
     for (size_t offset = 5; offset < spirv.size();) {
@@ -9839,12 +9945,7 @@ static bool is_astro_bot_ngg_one_lane_wrapper(const uint32_t* code, size_t dword
     if (program_dwords != 54 && program_dwords != 734 && program_dwords != 3124 &&
         program_dwords != 3435 && program_dwords != 3917)
         return false;
-    uint64_t hash = 1469598103934665603ull;
-    const auto* bytes = reinterpret_cast<const uint8_t*>(code);
-    for (size_t i = 0; i < program_dwords * sizeof(uint32_t); ++i) {
-        hash ^= bytes[i];
-        hash *= 1099511628211ull;
-    }
+    const uint64_t hash = shader_program_hash(code, program_dwords);
     return (program_dwords == 54 && hash == 0x9e9d8e37bcc70607ull) ||
            (program_dwords == 734 && hash == 0x79eb2b954b07dc8eull) ||
            (program_dwords == 3124 && hash == 0x41e6ac616c18d295ull) ||
@@ -9887,6 +9988,7 @@ static std::vector<uint32_t> recompile_vertex_impl(const uint32_t* code, size_t 
     // property of the GS_ALLOC_REQ opcode. Other NGG programs retain only the ordinary merged-stage
     // ABI setup below and fail closed if they reach a lane-sensitive operation.
     b.ngg_one_lane = b.ngg_private_lds || (ngg && allow_test_ngg_one_lane);
+    b.allow_b32_masks = b.ngg_one_lane;
     uint32_t ngg_output_gate_begin = UINT32_MAX;
     uint32_t ngg_output_gate_end = 0;
     if (ngg) {

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -3855,6 +3855,123 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
     if (in.has_modifier) { ok = false; return true; }
     switch (in.fmt) {
         case Rdna2Format::SOP1: {
+            // Wave32 shaders use the low 32-bit halves of EXEC/VCC for the same save/copy/restore
+            // idioms that wave64 shaders express with s_mov_b64.  A wave mask is one bool in this
+            // per-invocation model, so preserve that bool domain when either source is an
+            // unambiguous low-half mask or EXEC_LO is the destination.  VCC_LO remains available as
+            // ordinary scalar scratch when its source is ordinary data, matching the data path
+            // below.  High-half moves remain unsupported: without the guest wave mode they may name
+            // another lane rather than this invocation's bit.
+            if (in.opcode == 0x03) {                         // s_mov_b32
+                const auto data_value_present = [&](int reg) {
+                    return rs.sreg.contains(reg) || rs.sreg_input.contains(reg);
+                };
+                const bool src_exec_lo = in.src[0].value == 126;
+                const bool src_vcc_lo = in.src[0].value == 106 &&
+                    !data_value_present(106);
+                const auto saved = in.src[0].kind == OperandKind::SGPR
+                    ? rs.sreg_bool.find(in.src[0].value) : rs.sreg_bool.end();
+                const bool src_saved_mask = saved != rs.sreg_bool.end() &&
+                    !data_value_present(in.src[0].value);
+                const bool dst_exec_lo = in.dst.value == 126;
+                const bool mask_move = src_exec_lo || src_vcc_lo || src_saved_mask ||
+                    (dst_exec_lo && in.src[0].kind == OperandKind::InlineInt);
+                if (mask_move) {
+                    uint32_t mask = 0;
+                    bool narrowed = true;
+                    if (src_exec_lo) {
+                        mask = rs.exec;
+                        narrowed = rs.exec_narrowed;
+                    } else if (src_vcc_lo) {
+                        mask = rs.vcc;
+                        auto state = rs.sreg_bool_narrowed.find(106);
+                        narrowed = state == rs.sreg_bool_narrowed.end() || state->second;
+                    } else if (src_saved_mask) {
+                        mask = saved->second;
+                        auto state = rs.sreg_bool_narrowed.find(in.src[0].value);
+                        narrowed = state == rs.sreg_bool_narrowed.end() || state->second;
+                    } else if (in.src[0].value == -1) {
+                        mask = b.btrue();
+                        narrowed = false;
+                    } else if (in.src[0].value == 0) {
+                        mask = b.bfalse();
+                    }
+                    if (!mask || in.dst.value == 127 || in.dst.value == 107) {
+                        ok = false;
+                        return true;
+                    }
+
+                    if (dst_exec_lo) {
+                        rs.exec = mask;
+                        rs.exec_narrowed = narrowed;
+                    } else if (in.dst.value == 106) {
+                        rs.vcc = mask;
+                        rs.sreg_bool[106] = mask;
+                        rs.sreg_bool_narrowed[106] = narrowed;
+                    } else {
+                        rs.sreg_bool[in.dst.value] = mask;
+                        rs.sreg_bool_narrowed[in.dst.value] = narrowed;
+                    }
+                    // A B32 move overwrites only the addressed physical word.  Remove stale scalar
+                    // data/descriptor provenance for that word while leaving its neighbor intact.
+                    rs.sreg.erase(in.dst.value);
+                    rs.sreg_srt.erase(in.dst.value);
+                    return true;
+                }
+            }
+            if (in.opcode == 0x09) {                         // s_wqm_b32
+                // Wave32 uses the low half of EXEC for the same whole-quad-mode idiom as
+                // s_wqm_b64.  In the per-invocation fragment model helper lanes are implicit, so
+                // widening is an identity on the tracked bool.  Keep this in the mask domain and
+                // reject either high half; treating EXEC_LO as scalar data drops Astro's material
+                // fragments before their first sample.
+                const auto data_value_present = [&](int reg) {
+                    return rs.sreg.contains(reg) || rs.sreg_input.contains(reg);
+                };
+                const bool src_exec_lo = in.src[0].value == 126;
+                const bool src_vcc_lo = in.src[0].value == 106 &&
+                    !data_value_present(106);
+                const auto saved = in.src[0].kind == OperandKind::SGPR
+                    ? rs.sreg_bool.find(in.src[0].value) : rs.sreg_bool.end();
+                const bool src_saved_mask = saved != rs.sreg_bool.end() &&
+                    !data_value_present(in.src[0].value);
+                uint32_t mask = 0;
+                if (src_exec_lo) mask = rs.exec;
+                else if (src_vcc_lo) mask = rs.vcc;
+                else if (src_saved_mask) mask = saved->second;
+                else if (in.src[0].kind == OperandKind::InlineInt && in.src[0].value == -1)
+                    mask = b.btrue();
+                else if (in.src[0].kind == OperandKind::InlineInt && in.src[0].value == 0)
+                    mask = b.bfalse();
+                if (!mask || in.dst.value == 127 || in.dst.value == 107) {
+                    ok = false;
+                    return true;
+                }
+
+                // ISA SCC is a reduction over the whole resulting wave mask.  That value cannot be
+                // recovered from one invocation, so poison it exactly like s_wqm_b64 does.
+                rs.scc = 0;
+                if (in.dst.value == 126) {
+                    if (src_exec_lo) { /* exec <- wqm(exec): tracked identity */ }
+                    else if (in.src[0].kind == OperandKind::InlineInt && in.src[0].value == -1) {
+                        rs.exec = b.btrue();
+                        rs.exec_narrowed = false;
+                    } else {
+                        rs.exec = mask;
+                        rs.exec_narrowed = true;
+                    }
+                } else if (in.dst.value == 106) {
+                    rs.vcc = mask;
+                    rs.sreg_bool[106] = mask;
+                    rs.sreg_bool_narrowed[106] = true;
+                } else {
+                    rs.sreg_bool[in.dst.value] = mask;
+                    rs.sreg_bool_narrowed[in.dst.value] = true;
+                }
+                rs.sreg.erase(in.dst.value);
+                rs.sreg_srt.erase(in.dst.value);
+                return true;
+            }
             // 64-bit per-lane MASK ops (EXEC / VCC / saved masks). In our per-invocation model a wave
             // mask is a single bool for this lane. EXEC=SGPR 126/127, VCC=106/107; a saved mask lives
             // in sreg_bool. These implement divergent control flow (if/endif via saveexec + restore).
@@ -4026,6 +4143,24 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 rs.sreg_srt.erase(in.dst.value);
                 return true;
             }
+            if (in.opcode == 0x14 && b.ngg_one_lane) { // s_ff1_i32_b64
+                // RDNA2 returns the bit index of the first set bit, or -1 for an empty mask.
+                // The exact Astro NGG projection represents guest lane zero only, so a tracked
+                // mask has either that bit set (result 0) or no bits set (result 0xffffffff).
+                uint32_t mask = 0;
+                if (in.src[0].value == 106 || in.src[0].value == 107) mask = rs.vcc;
+                else if (in.src[0].value == 126 || in.src[0].value == 127) mask = rs.exec;
+                else if (in.src[0].kind == OperandKind::SGPR) {
+                    auto it = rs.sreg_bool.find(in.src[0].value);
+                    if (it != rs.sreg_bool.end()) mask = it->second;
+                }
+                if (!mask) { ok = false; return true; }
+                rs.sreg[in.dst.value] = b.sel(mask, b.uconst(0), b.uconst(0xffffffffu));
+                rs.sreg_srt.erase(in.dst.value);
+                rs.sreg_bool.erase(in.dst.value);
+                rs.sreg_bool_narrowed.erase(in.dst.value);
+                return true;
+            }
             // A 32-bit scalar DATA write into an EXEC half would leave the live per-lane mask
             // (rs.exec) stale — hardware updates EXEC (and EXECZ) immediately. No exercised title
             // writes EXEC halves via b32 scalar ops (wave64 compilers use the b64 forms), so
@@ -4033,6 +4168,10 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // documented data-scratch round-trip (NGG preamble s_bfe_u32 vcc_lo, DOLL M0 moves).
             if (in.dst.value == 126 || in.dst.value == 127) { ok = false; return true; }
             uint32_t a = val(in.src[0]); uint32_t& d = rs.sreg[in.dst.value];
+            // An ordinary scalar-data write starts a new lifetime for this physical word.  Do not
+            // let an earlier Wave32 mask save alias that new value in later mask-domain moves.
+            rs.sreg_bool.erase(in.dst.value);
+            rs.sreg_bool_narrowed.erase(in.dst.value);
             switch (in.opcode) {
                 case 0x03: {                                // s_mov_b32
                     d = a;
@@ -4056,6 +4195,15 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     rs.scc = b.ucmp(Op_INotEqual, d, b.uconst(0)); break;
                 case 0x0b:                                  // s_brev_b32
                     d = b.iun(Op_BitReverse, a); rs.sreg_srt.erase(in.dst.value); break;
+                case 0x34: {                                // s_abs_i32
+                    // Two's-complement absolute value.  OpISub deliberately preserves the ISA's
+                    // INT_MIN -> INT_MIN wraparound; SCC is set iff the resulting bits are nonzero.
+                    const uint32_t negative = b.scmp(Op_SLessThan, a, b.uconst(0));
+                    d = b.sel(negative, b.ibin(Op_ISub, b.uconst(0), a), a);
+                    rs.scc = b.ucmp(Op_INotEqual, d, b.uconst(0));
+                    rs.sreg_srt.erase(in.dst.value);
+                    break;
+                }
                 default: ok = false;
             }
             return true;
@@ -5485,7 +5633,23 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             } else if (in.opcode == 0x101) {                          // v_cndmask_b32_e64: src2_mask ? src1 : src0
                 const Operand& s2 = in.src[2]; uint32_t m = 0;        // src2 is an SGPR-pair (or VCC) wave mask
                 if (s2.value == 106 || s2.value == 107) m = rs.vcc;
-                else if (s2.kind == OperandKind::SGPR) { auto it = rs.sreg_bool.find(s2.value); if (it != rs.sreg_bool.end()) m = it->second; }
+                else if (s2.kind == OperandKind::SGPR) {
+                    auto it = rs.sreg_bool.find(s2.value);
+                    if (it != rs.sreg_bool.end()) {
+                        m = it->second;
+                    } else if (b.ngg_one_lane) {
+                        // The exact Astro NGG projection represents guest lane zero. Some wrappers
+                        // construct a literal/dynamic B64 lane mask in ordinary scalar DATA registers
+                        // rather than through a mask-domain instruction (7f5f: s4:s5=0xaaaaaaaa...
+                        // before pc3870). For lane zero, consuming that pair as a wave mask is exactly
+                        // its low dword's bit zero. Keep arbitrary vertex shaders fail-closed.
+                        auto data = rs.sreg.find(s2.value);
+                        if (data != rs.sreg.end())
+                            m = b.ucmp(Op_INotEqual,
+                                b.ibin(Op_BitwiseAnd, data->second, b.uconst(1)),
+                                b.uconst(0));
+                    }
+                }
                 // fv (not val): cndmask is float-modifier-capable and compilers emit it with -v/|v|
                 // sources (sign-select idioms). Raw val() silently dropped neg/abs — the shader
                 // recompiled "successfully" and computed the un-negated value. fv == val when no
@@ -5519,6 +5683,8 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 case 0x10:   // s_sendmsg        (NGG GS_ALLOC_REQ etc. — no wave/primitive allocation in
                              //                   our per-invocation model; only meaningful for NGG/GS,
                              //                   which we lower per-invocation, so it's a safe no-op)
+                case 0x17:   // s_cbranch_cdbgsys (Prosper exposes no attached GPU system debugger, so
+                             //                    COND_DBG_SYS is permanently clear and the branch falls through)
                 case 0x20:   // s_inst_prefetch  (I-cache hint)
                 case 0x21:   // s_clause         (memory-clause scheduling hint)
                 case 0x22:   // s_wait_idle
@@ -5542,6 +5708,13 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     ok = false;
                     break;
                 case 0x06: case 0x07:                              // s_cbranch_vccz / vccnz
+                    // A byte-exact Astro NGG terminal suffix may skip only trailing PARAM exports
+                    // after POS has already been exported. In the one-lane projection emitting those
+                    // otherwise-unused values is harmless; the gate proof records only that bounded
+                    // branch in safe_execz. General VCC branches remain unsupported below.
+                    if (safe_execz && safe_execz->count(in.pc)) break;
+                    ok = false;
+                    break;
                 case 0x09:                                         // s_cbranch_execnz
                     ok = false;
                     break;
@@ -6087,16 +6260,13 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                             in.pc, (unsigned)fmt, comp_bytes, stride, n);
                 ok = false; return true;
             }
-            // Packed (sub-dword) components are extracted at STATIC byte offsets relative to a
-            // DWORD-ALIGNED element base — the low 2 bits of the address (addr&3) are dropped by the
-            // addr>>2 dword index and never folded into the bit extraction (#150). That is only correct
-            // when the element base is provably 4-byte aligned; otherwise a component (a half2 UV after
-            // a snorm16x3 normal, an unorm8 at a byte offset) decodes the wrong bits. A fully general
-            // fix needs a runtime bit position that can straddle dwords; until then, prove alignment
-            // from the address terms and REJECT the packed load/store when it can't be proven (surfacing
-            // the gap) rather than silently mis-decode. Aligned iff: inst offset %4==0; stride %4==0
-            // when idxen; no offen (a runtime per-lane byte offset is unprovable); SOFFSET is NULL/0.
-            bool dyn_half = false;   // 16-bit element at a runtime dword half (stride-2 buffers, #273)
+            // Most packed (sub-dword) components below use static fields relative to a DWORD-ALIGNED
+            // element base. Float16 LOADS have a general runtime-address path: each component is read
+            // from addr+k*2, joining adjacent dwords if the 16-bit field starts at byte 3. Other packed
+            // formats still require a proven aligned base; reject them instead of silently dropping the
+            // low address bits. Aligned iff: inst offset %4==0; stride %4==0 when idxen; no offen; and
+            // SOFFSET is NULL/0. Stores retain their existing stricter paths.
+            bool dyn_half = false;   // Float16 components at an arbitrary runtime byte address
             bool dyn_int = false;    // integer sub-dword FORMAT component at a runtime (unaligned) byte addr
             bool dyn_int_store = false;  // integer sub-dword FORMAT store via race-free atomic clear+set
             if (packed && !raw_subword) {
@@ -6117,16 +6287,13 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                                    (!idxen || (stride & 3u) == 0) && soff_zero;
                 }
                 if (!base_aligned) {
-                    // HALFWORD-ALIGNED single-component 16-bit load (#273 — DOLL's title post PSes
-                    // fetch from a STRIDE-2 uint16 table: `buffer_load_format_x v, vIDX, V#` with
-                    // stride 2). The element sits at a RUNTIME dword half — bit offset (addr&2)*8 —
-                    // which never straddles a dword, so extract it dynamically instead of rejecting.
-                    // Provable iff every address term is 2-aligned and there is no per-lane byte
-                    // offset (offen). Loads only (the packed store path still rejects sub-dword ints).
+                    // Float16 format loads use the complete runtime byte address for every requested
+                    // component. This covers both the stride-2 single-half path (#273) and Astro's
+                    // Float16x4 vertex record with a register SOFFSET. Loads only: packed half stores
+                    // remain fail-visible until their race-free sub-dword write contract is modeled.
                     bool soff_zero = (in.src[2].kind == OperandKind::Special && in.src[2].value == 125) ||
                                      (in.src[2].kind == OperandKind::InlineInt && in.src[2].value == 0);
-                    dyn_half = !packed_word && !is_store && n == 1 && comp_bytes == 2 && !offen && !dyn_vfetch &&
-                               (offset & 1u) == 0 && (!idxen || (stride & 1u) == 0) && soff_zero;
+                    dyn_half = !packed_word && !is_store && is_half;
                     // An integer sub-dword FORMAT load extracts each component at its runtime byte
                     // address (join the straddled dwords, then bfe), so it needs no static alignment.
                     // Only LOADS: the packed store path still rejects sub-dword ints (they don't pack).
@@ -6313,15 +6480,21 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                         value = b.unpack_norm(dw, boff, bits, is_snorm, field_norm);
                     }
                 } else if (dyn_half) {
-                    // Runtime dword half (n==1, 16-bit element, 2-aligned address): shift the loaded
-                    // dword right by (addr&2)*8 and decode the 16-bit field at bit 0.
-                    uint32_t dw   = b.cbuf_load(idx, binding);
-                    uint32_t boff = b.ibin(Op_ShiftLeftLogical, b.ibin(Op_BitwiseAnd, addr, b.uconst(2)), b.uconst(3));
-                    uint32_t dws  = b.ibin(Op_ShiftRightLogical, dw, boff);
-                    value = is_half ? b.unpack_half(dws, 0)
-                          : is_uint ? b.bfe_u(dws, b.uconst(0), b.uconst(16))
-                          : is_sint ? b.bfe_s(dws, b.uconst(0), b.uconst(16))
-                                    : b.unpack_norm(dws, 0, 16, is_snorm, norm);
+                    // Float16 component k at byte address addr+k*2. Join the following dword when
+                    // the field begins at byte 3; masking the inverse shift avoids SPIR-V's undefined
+                    // shift-by-32 case, and the select discards that word when shift==0.
+                    const uint32_t caddr = k ? b.ibin(Op_IAdd, addr, b.uconst(k * 2)) : addr;
+                    const uint32_t cidx  = b.ibin(Op_ShiftRightLogical, caddr, b.uconst(2));
+                    const uint32_t shift = b.ibin(Op_ShiftLeftLogical,
+                                                  b.ibin(Op_BitwiseAnd, caddr, b.uconst(3)), b.uconst(3));
+                    uint32_t joined = b.ibin(Op_ShiftRightLogical, b.cbuf_load(cidx, binding), shift);
+                    const uint32_t dw1 = b.cbuf_load(b.ibin(Op_IAdd, cidx, b.uconst(1)), binding);
+                    const uint32_t inv_shift = b.ibin(Op_BitwiseAnd,
+                        b.ibin(Op_ISub, b.uconst(32), shift), b.uconst(31));
+                    const uint32_t upper = b.ibin(Op_ShiftLeftLogical, dw1, inv_shift);
+                    joined = b.ibin(Op_BitwiseOr, joined,
+                                    b.sel(b.ucmp(Op_IEqual, shift, b.uconst(0)), b.uconst(0), upper));
+                    value = b.unpack_half(joined, 0);
                 } else if (dyn_int) {
                     // Integer sub-dword FORMAT component k at a runtime byte address (addr + k*comp_bytes):
                     // shift the loaded dword right by (byteaddr&3)*8, join the next dword when a 16-bit
@@ -7387,6 +7560,13 @@ bool emit_compute_cfg_state_machine(
     for (const auto& kv : initial.sreg_bool) static_mask_keys.insert(kv.first);
     for (const auto& in : ins) {
         if (in.is_end) break;
+        if (in.fmt == Rdna2Format::SOP1 &&
+            (in.opcode == 0x03 || in.opcode == 0x09) &&
+            in.dst.value <= 105 &&
+            (in.src[0].value == 126 ||
+             (in.src[0].kind == OperandKind::SGPR &&
+              static_mask_keys.count(in.src[0].value))))
+            static_mask_keys.insert(in.dst.value); // Wave32 s_mov_b32 save/copy of EXEC_LO
         if (in.fmt == Rdna2Format::SOP1 &&
             (in.opcode == 0x04 || in.opcode == 0x08 || in.opcode == 0x0a ||
              in.opcode == 0x24 || in.opcode == 0x25 || in.opcode == 0x37) &&
@@ -9645,27 +9825,39 @@ bool fragment_spirv_uses_internal_gds(const std::vector<uint32_t>& spirv) {
     return false;
 }
 
-// Astro Bot's fused 2,936-byte NGG body uses real wave-shared LDS for culling and compaction. The
-// current Vulkan vertex shell intentionally projects that one observed wrapper to one private guest
-// lane; applying the projection to an arbitrary NGG program would silently miscompile peer-lane LDS.
-// Keep the exception byte-exact and fail closed for every other vertex DS shape. The hash is FNV-1a
-// over the complete little-endian shader bytes, matching the raw hash in successful-shader dumps.
-static bool is_astro_bot_ngg_private_lds_wrapper(const uint32_t* code, size_t dwords) {
-    if (!code || dwords != 734) return false;
+// Astro Bot's observed NGG wrappers use wave-shared plumbing for vertex allocation/compaction. The
+// current Vulkan vertex shell intentionally projects those complete wrappers to one private guest
+// lane; applying the projection to arbitrary NGG programs would silently miscompile peer-lane state.
+// Keep each exception byte-exact and fail closed for every other wrapper. The hashes are FNV-1a over
+// the little-endian instruction bytes through S_ENDPGM, matching the raw hashes in capture
+// diagnostics. A proven PC-relative constant-table tail is deliberately excluded from the wrapper
+// identity while remaining available to the recompiler.
+static bool is_astro_bot_ngg_one_lane_wrapper(const uint32_t* code, size_t dwords) {
+    if (!code) return false;
+    std::vector<Rdna2Inst> instructions;
+    const size_t program_dwords = rdna2_walk(code, dwords, instructions);
+    if (program_dwords != 54 && program_dwords != 734 && program_dwords != 3124 &&
+        program_dwords != 3435 && program_dwords != 3917)
+        return false;
     uint64_t hash = 1469598103934665603ull;
     const auto* bytes = reinterpret_cast<const uint8_t*>(code);
-    for (size_t i = 0; i < dwords * sizeof(uint32_t); ++i) {
+    for (size_t i = 0; i < program_dwords * sizeof(uint32_t); ++i) {
         hash ^= bytes[i];
         hash *= 1099511628211ull;
     }
-    return hash == 0x79eb2b954b07dc8eull;
+    return (program_dwords == 54 && hash == 0x9e9d8e37bcc70607ull) ||
+           (program_dwords == 734 && hash == 0x79eb2b954b07dc8eull) ||
+           (program_dwords == 3124 && hash == 0x41e6ac616c18d295ull) ||
+           (program_dwords == 3435 && hash == 0xfad7a9f486523cfcull) ||
+           (program_dwords == 3917 && hash == 0x7f5f2349e2816f5eull);
 }
 
 static std::vector<uint32_t> recompile_vertex_impl(const uint32_t* code, size_t dwords,
                                                   const ShaderResourceTable* rt,
                                                   const PixelInputMapping* pixel_inputs,
                                                   bool capture_position,
-                                                  bool allow_test_ngg_output_gate) {
+                                                  bool allow_test_ngg_output_gate,
+                                                  bool allow_test_ngg_one_lane) {
     const uint32_t passthrough_mask =
         pixel_inputs ? pixel_inputs->effective_passthrough_mask() : 0u;
     std::vector<Rdna2Inst> ins;
@@ -9689,11 +9881,12 @@ static std::vector<uint32_t> recompile_vertex_impl(const uint32_t* code, size_t 
     for (const auto& in : ins) { if (in.is_end) break;
         if (in.fmt == Rdna2Format::SOPP && in.opcode == 0x10 &&
             in.words[0] == 0xBF900009u) { ngg = true; break; } }
-    b.ngg_private_lds = ngg && is_astro_bot_ngg_private_lds_wrapper(code, dwords);
+    b.ngg_private_lds = ngg && (is_astro_bot_ngg_one_lane_wrapper(code, dwords) ||
+                                allow_test_ngg_output_gate);
     // Every wave/peer approximation is an exception for the one captured Astro wrapper, not a
     // property of the GS_ALLOC_REQ opcode. Other NGG programs retain only the ordinary merged-stage
     // ABI setup below and fail closed if they reach a lane-sensitive operation.
-    b.ngg_one_lane = b.ngg_private_lds;
+    b.ngg_one_lane = b.ngg_private_lds || (ngg && allow_test_ngg_one_lane);
     uint32_t ngg_output_gate_begin = UINT32_MAX;
     uint32_t ngg_output_gate_end = 0;
     if (ngg) {
@@ -9723,24 +9916,50 @@ static std::vector<uint32_t> recompile_vertex_impl(const uint32_t* code, size_t 
                 continue;
             bool has_position = false;
             bool output_only = true;
+            std::vector<uint32_t> trailing_vcc_branches;
             for (size_t j = i + 1; j < ins.size() && ins[j].pc < end_pc; ++j) {
                 const Rdna2Inst& candidate = ins[j];
                 if (candidate.fmt == Rdna2Format::EXP) {
                     has_position |= candidate.exp_target == 12;
                     continue;
                 }
+                // Astro's compacted-output suffix reconstructs the surviving vertex from private
+                // LDS immediately before exporting it (VOP address setup + DS reads). These remain
+                // inside the same CMPX/EXECZ-to-ENDPGM gate and their register writes are already
+                // EXEC-predicated by emit_alu. Admit them only for the byte-exact wrapper (or the
+                // explicit test hook); ordinary NGG shaders never reach this exception.
+                const bool output_rebuild = b.ngg_private_lds || allow_test_ngg_output_gate;
+                if (output_rebuild &&
+                    (candidate.fmt == Rdna2Format::VOP1 ||
+                     candidate.fmt == Rdna2Format::VOP2 ||
+                     candidate.fmt == Rdna2Format::VOP3 ||
+                     candidate.fmt == Rdna2Format::VOP3P ||
+                     (candidate.fmt == Rdna2Format::VOPC &&
+                      !vopc_is_cmpx(candidate.opcode)) ||
+                     candidate.fmt == Rdna2Format::DS))
+                    continue;
                 if (candidate.fmt == Rdna2Format::SOPC) continue;
                 if (sopp_is_noop(candidate)) continue;
                 if (candidate.fmt == Rdna2Format::SOPP &&
                     (candidate.opcode == 0x04 || candidate.opcode == 0x05) &&
                     candidate.simm16 > 0 && branch_target(candidate) == end_pc)
                     continue;
+                // The 7f5f wrapper exports POS, compares a per-vertex flag into VCC, then conditionally
+                // skips only its trailing PARAM exports. Those exports cannot affect position/topology;
+                // linearizing the branch merely supplies otherwise-undefined varyings for that path.
+                if (has_position && candidate.fmt == Rdna2Format::SOPP &&
+                    (candidate.opcode == 0x06 || candidate.opcode == 0x07) &&
+                    candidate.simm16 > 0 && branch_target(candidate) == end_pc) {
+                    trailing_vcc_branches.push_back(candidate.pc);
+                    continue;
+                }
                 output_only = false;
                 break;
             }
             if (has_position && output_only) {
                 ngg_output_gate_begin = branch.pc;
                 ngg_output_gate_end = end_pc;
+                safe_branches.insert(trailing_vcc_branches.begin(), trailing_vcc_branches.end());
                 break;
             }
         }
@@ -9986,12 +10205,17 @@ std::vector<uint32_t> recompile_vertex(const uint32_t* code, size_t dwords,
                                        const ShaderResourceTable* rt,
                                        const PixelInputMapping* pixel_inputs,
                                        bool capture_position) {
-    return recompile_vertex_impl(code, dwords, rt, pixel_inputs, capture_position, false);
+    return recompile_vertex_impl(code, dwords, rt, pixel_inputs, capture_position, false, false);
 }
 
 std::vector<uint32_t> recompile_vertex_terminal_ngg_gate_for_test(
     const uint32_t* code, size_t dwords) {
-    return recompile_vertex_impl(code, dwords, nullptr, nullptr, false, true);
+    return recompile_vertex_impl(code, dwords, nullptr, nullptr, false, true, false);
+}
+
+std::vector<uint32_t> recompile_vertex_ngg_one_lane_for_test(
+    const uint32_t* code, size_t dwords) {
+    return recompile_vertex_impl(code, dwords, nullptr, nullptr, false, false, true);
 }
 
 } // namespace prosper::gpu

--- a/prosper/src/gpu/rdna2_to_spirv.hpp
+++ b/prosper/src/gpu/rdna2_to_spirv.hpp
@@ -220,6 +220,11 @@ std::vector<uint32_t> recompile_fragment(const uint32_t* code, size_t dwords,
                                          uint32_t pcrel_dispatch_target = UINT32_MAX,
                                          const FragmentInterpolationLayout* interpolation = nullptr);
 
+// Test hook for the low-half EXEC/VCC mask path. Production graphics compilation enables it only
+// for byte-exact observed Wave32 shaders until the graphics wave-mode register is carried here.
+std::vector<uint32_t> recompile_fragment_wave32_for_test(
+    const uint32_t* code, size_t dwords);
+
 // Recompiled fragment wave operations use native Vulkan subgroup instructions and therefore require
 // an exact 64-lane subgroup. Returns zero for ordinary modules and 64 for that explicit contract.
 uint32_t fragment_spirv_required_subgroup_size(const std::vector<uint32_t>& spirv);

--- a/prosper/src/gpu/rdna2_to_spirv.hpp
+++ b/prosper/src/gpu/rdna2_to_spirv.hpp
@@ -247,6 +247,11 @@ std::vector<uint32_t> recompile_vertex(const uint32_t* code, size_t dwords,
 std::vector<uint32_t> recompile_vertex_terminal_ngg_gate_for_test(
     const uint32_t* code, size_t dwords);
 
+// Test hook: exercise operations whose semantics depend on the exact Astro one-lane NGG projection.
+// Production recompile_vertex only enables that projection for byte-exact observed wrappers.
+std::vector<uint32_t> recompile_vertex_ngg_one_lane_for_test(
+    const uint32_t* code, size_t dwords);
+
 // How much of a shader the recompiler currently covers (per-instruction), without requiring the
 // stream to be a complete vertex/fragment. `alu` = instructions emit_alu handles (VALU/scalar/
 // control-flow); `exports` = EXP (handled by the stage recompilers); `unsupported` = not yet handled

--- a/prosper/tests/test_build_shader_resources.cpp
+++ b/prosper/tests/test_build_shader_resources.cpp
@@ -628,6 +628,49 @@ int main() {
         CHECK(tt.by_sgpr_base(24) == nullptr, "unmapped IMG_FMT T# skipped (no silent RGBA8)");
     }
 
+    // Two adjacent V# buffer descriptors are also eight dwords. Astro's sharp metadata does not set the
+    // usual size hint for these entries, and their low address/format bits accidentally decode to
+    // plausible image dimensions. Shape-classify the first V# even without the hint instead of uploading
+    // two adjacent vertex buffers as one texture (the world-map checkerboarding path).
+    {
+        uint32_t vpair[32]; memset(vpair, 0, sizeof vpair);
+        make_vsharp(&vpair[0], 0x5000B441F68ull, 16, 3, 77);
+        make_vsharp(&vpair[4], 0x5000B442630ull, 16, 4, 77);
+        AgcShaderSharp fake_texture;
+        fake_texture.bits = 0; // offset_dw=0, size=0: previously sent directly to the T# path
+        AgcShaderUserData vud; memset(&vud, 0, sizeof vud);
+        vud.sharp_resource_offset[0] = &fake_texture;
+        vud.sharp_resource_count[0] = 1;
+        AgcShaderHeader vsh; memset(&vsh, 0, sizeof vsh);
+        vsh.file_header = 0x34333231u; vsh.version = 0x18; vsh.type = 2; vsh.user_data = &vud;
+
+        const DecodedImageDescriptor false_t = decode_image_descriptor(vpair);
+        CHECK(false_t.type == 0 && false_t.base != 0 && false_t.width != 0 && false_t.height != 0,
+              "adjacent Astro-shaped V#s reproduce a superficially plausible TYPE=0 T#");
+        const ShaderResourceTable vt = build_shader_resources(vsh, vpair, 32);
+        const ShaderResource* vr = vt.by_sgpr_base(0);
+        CHECK(vt.resources.size() == 1 && vr && vr->cls == ResourceClass::ConstantBuffer &&
+                  vr->gpu_addr == 0x5000B441F68ull && vr->size == 48,
+              "size-unhinted Astro V# is emitted as a buffer, not a texture");
+    }
+
+    // An invalid TYPE that does not have a valid V# shape must still be rejected outright. Keeping
+    // image validation independent of the V# classifier prevents arbitrary non-image tables from
+    // reaching either the metadata or dynamic texture paths.
+    {
+        uint32_t invalid_t[32]; memset(invalid_t, 0, sizeof invalid_t);
+        make_tsharp(invalid_t, 0xD1000000ull, 64, 64, /*fmt*/56, /*tile*/0, /*invalid type*/0);
+        AgcShaderSharp invalid_sharp;
+        invalid_sharp.bits = 0;
+        AgcShaderUserData iud; memset(&iud, 0, sizeof iud);
+        iud.sharp_resource_offset[0] = &invalid_sharp;
+        iud.sharp_resource_count[0] = 1;
+        AgcShaderHeader ish; memset(&ish, 0, sizeof ish);
+        ish.file_header = 0x34333231u; ish.version = 0x18; ish.type = 2; ish.user_data = &iud;
+        CHECK(build_shader_resources(ish, invalid_t, 32).resources.empty(),
+              "non-image SQ_RSRC TYPE is rejected instead of binding arbitrary bytes as a texture");
+    }
+
     // #382: an EUD-resident texture (T# spilled beyond the user-SGPR block) must be emitted, mirroring
     // the cbuf EUD path — the old hard `continue` dropped it, so the sampling draw rendered untextured.
     // Provenance is INDIRECT (srt_offset = the s_load immediate); sgpr_base is invalid so a stray

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -471,6 +471,40 @@ int main() {
               decode_buffer_descriptor(ngg_wide_uses[0].v4.data()).base == ngg_vertex_base,
           "fused NGG x16 stage-data load publishes its raw-buffer V# by consuming pc");
 
+    // Astro Bot's world-map NGG block begins with an 8-dword T# and also carries V#s later in the
+    // same x16 load. SGPR memory is typeless: preserving only the four V# interpretations makes the
+    // image_sample's s[8:15] permanently unknown and drops the main world-map draw at pc205.
+    alignas(16) static uint32_t ngg_mixed_stage_data[16] = {
+        0x01234000u, 0x00000005u, 0x00000000u, 0x00100000u,
+        0x00000000u, 0x00000000u, 0x00000000u, 0x00000008u,
+        0x89abcdefu, 0x01234567u, 0x76543210u, 0xfedcba98u,
+        0x11111111u, 0x22222222u, 0x33333333u, 0x44444444u,
+    };
+    const uint32_t ngg_mixed_system_sgprs[2] = {
+        static_cast<uint32_t>(reinterpret_cast<uint64_t>(ngg_mixed_stage_data)),
+        static_cast<uint32_t>(reinterpret_cast<uint64_t>(ngg_mixed_stage_data) >> 32),
+    };
+    const uint32_t ngg_loaded_wide_texture[] = {
+        0xF4100200u, 0xFA000000u,   // s_load_dwordx16 s[8:23], s[0:1], 0
+        0xF0800F08u, 0x00A20000u,   // image_sample v[0:3], v[0:1], s[8:15], s[20:23]
+        0xBF810000u,
+    };
+    std::vector<SrtUse> ngg_wide_texture_uses;
+    resolve_dynamic_fetch(
+        ngg_loaded_wide_texture, std::size(ngg_loaded_wide_texture), nullptr, 0, 8,
+        &ngg_wide_texture_uses, UINT32_MAX, nullptr, ngg_mixed_system_sgprs,
+        std::size(ngg_mixed_system_sgprs));
+    CHECK(ngg_wide_texture_uses.size() == 1 &&
+              ngg_wide_texture_uses[0].kind == 0 &&
+              ngg_wide_texture_uses[0].use_pc == 2 &&
+              ngg_wide_texture_uses[0].key == 0xFFFFFFFFu &&
+              std::equal(ngg_wide_texture_uses[0].t8.begin(),
+                         ngg_wide_texture_uses[0].t8.end(),
+                         std::begin(ngg_mixed_stage_data)) &&
+              ngg_wide_texture_uses[0].has_samp &&
+              ngg_wide_texture_uses[0].s4[0] == ngg_mixed_stage_data[12],
+          "fused NGG x16 mixed stage-data load publishes its T# and paired S# by consuming pc");
+
     // Kernel 5n: an s_buffer_load_dwordx8 result is typeless SGPR data. A later scalar buffer load
     // may consume its first four words as a nested V#, as DOLL's post-process shader does. Since the
     // V# came through another buffer descriptor it has no immediate key; preserve it by consumer pc.
@@ -715,6 +749,34 @@ int main() {
     CHECK(direct_v_uses.size() == 1 && direct_v_uses[0].v4[0] == seed5v[0] &&
           direct_v_uses[0].v4[1] == seed5v[1] && direct_v_uses[0].v4[2] == seed5v[2],
           "direct raw-MUBUF V# preserves base/stride/record dwords");
+
+    // Astro Bot's 7f5f world-map NGG shader patches only NUM_RECORDS in its direct s[16:19] V#
+    // (`s_mov_b32 s18, 1`) before a raw buffer_load_dwordx4 at pc2761. The consumer is itself the
+    // architectural descriptor proof; requiring the four words to retain pristine entry-seed
+    // provenance dropped this fully-known live descriptor and therefore the whole draw.
+    alignas(16) static uint32_t patched_raw_payload[4]{};
+    const uint64_t patched_raw_base = reinterpret_cast<uint64_t>(patched_raw_payload);
+    uint32_t patched_raw_seed[12]{};
+    patched_raw_seed[8]  = static_cast<uint32_t>(patched_raw_base); // shader s16, user block +8
+    patched_raw_seed[9]  = (static_cast<uint32_t>(patched_raw_base >> 32) & 0xffffu) |
+                           (16u << 16);
+    patched_raw_seed[10] = 64u;
+    patched_raw_seed[11] = 0u;
+    const uint32_t patched_direct_raw[] = {
+        0xBE920381u,                // s_mov_b32 s18, 1 (live NUM_RECORDS patch)
+        0xE03C2020u, 0x8004074Cu,   // exact Astro raw buffer_load_dwordx4 ..., s[16:19]
+        0xBF810000u,
+    };
+    std::vector<SrtUse> patched_raw_uses;
+    resolve_dynamic_fetch(patched_direct_raw, std::size(patched_direct_raw),
+                          patched_raw_seed, std::size(patched_raw_seed), 8,
+                          &patched_raw_uses);
+    CHECK(patched_raw_uses.size() == 1 && patched_raw_uses[0].kind == 1 &&
+              patched_raw_uses[0].use_pc == 1 &&
+              patched_raw_uses[0].key == 0xFFFFFFFFu &&
+              decode_buffer_descriptor(patched_raw_uses[0].v4.data()).base == patched_raw_base &&
+              decode_buffer_descriptor(patched_raw_uses[0].v4.data()).num_records == 1,
+          "Astro patched direct raw-MUBUF V# resolves by its exact consuming pc");
 
     // #636: Dead Cells' format-copy compute places its declared source V# at s0 and its otherwise
     // undeclared destination V# at s4. Resource discovery must follow the two actual MUBUF uses:

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -505,6 +505,29 @@ int main() {
               ngg_wide_texture_uses[0].s4[0] == ngg_mixed_stage_data[12],
           "fused NGG x16 mixed stage-data load publishes its T# and paired S# by consuming pc");
 
+    // The x16 snapshot is only provenance. A modeled scalar patch changes the physical T# word
+    // consumed by MIMG, so the emitted use must carry the live descriptor rather than stale load-time
+    // bytes. (An unmodeled write makes that word unknown and suppresses the use instead.)
+    const uint32_t ngg_patched_wide_texture[] = {
+        0xF4100200u, 0xFA000000u,   // s_load_dwordx16 s[8:23], s[0:1], 0
+        0xBE8A0381u,                // s_mov_b32 s10, 1 (patch T#.word2)
+        0xF0800F08u, 0x00A20000u,   // image_sample v[0:3], v[0:1], s[8:15], s[20:23]
+        0xBF810000u,
+    };
+    std::vector<SrtUse> ngg_patched_texture_uses;
+    resolve_dynamic_fetch(
+        ngg_patched_wide_texture, std::size(ngg_patched_wide_texture), nullptr, 0, 8,
+        &ngg_patched_texture_uses, UINT32_MAX, nullptr, ngg_mixed_system_sgprs,
+        std::size(ngg_mixed_system_sgprs));
+    CHECK(ngg_patched_texture_uses.size() == 1 &&
+              ngg_patched_texture_uses[0].kind == 0 &&
+              ngg_patched_texture_uses[0].use_pc == 3 &&
+              ngg_patched_texture_uses[0].key == 0xFFFFFFFFu &&
+              ngg_patched_texture_uses[0].t8[0] == ngg_mixed_stage_data[0] &&
+              ngg_patched_texture_uses[0].t8[2] == 1u &&
+              ngg_patched_texture_uses[0].t8[3] == ngg_mixed_stage_data[3],
+          "patched x16 T# publishes its live eight words at the MIMG consumer");
+
     // Kernel 5n: an s_buffer_load_dwordx8 result is typeless SGPR data. A later scalar buffer load
     // may consume its first four words as a nested V#, as DOLL's post-process shader does. Since the
     // V# came through another buffer descriptor it has no immediate key; preserve it by consumer pc.

--- a/prosper/tests/test_game_compute.cpp
+++ b/prosper/tests/test_game_compute.cpp
@@ -222,6 +222,32 @@ int main() {
     }
     CHECK(unorm8_matches, "fast UNORM8 pack is equivalent to the lround reference");
 
+    auto reference_unorm16 = [](uint32_t bits) {
+        float value;
+        std::memcpy(&value, &bits, sizeof(value));
+        if (std::isnan(value)) value = 0.0f;
+        value = value < 0.0f ? 0.0f : (value > 1.0f ? 1.0f : value);
+        return static_cast<uint16_t>(std::lround(value * 65535.0f));
+    };
+    bool unorm16_matches = true;
+    for (uint32_t raw = 0; raw <= 0xffffu; ++raw) {
+        const float value = raw / 65535.0f;
+        uint32_t bits = 0;
+        std::memcpy(&bits, &value, sizeof(bits));
+        if (prosper::frontend::storage_pack_unorm16(bits) != raw) {
+            unorm16_matches = false;
+            break;
+        }
+    }
+    for (uint32_t bits : pack_channels) {
+        if (prosper::frontend::storage_pack_unorm16(bits) != reference_unorm16(bits)) {
+            unorm16_matches = false;
+            break;
+        }
+    }
+    CHECK(unorm16_matches,
+          "UNORM16 pack preserves all quantized channels and matches lround for float inputs");
+
     bool storage_unorm8_range_matches = true;
     constexpr size_t unorm_texels = pack_channels_count / 4;
     for (uint32_t components : {1u, 2u, 3u, 4u}) {
@@ -591,6 +617,16 @@ int main() {
         for (uint32_t i = 0; i < s.size(); i++) s[i] = (uint8_t)(i * 71 + 11);
         CHECK(run_format_copy(DataFormat::Unorm8, 2, 2, s) == s,
               "Unorm8x2 storage copy round-trips native RG8 texels bit-exact (#590)");
+    }
+    {   // Astro Bot's title composite writes a tiled 256x64 RGBA16-UNORM surface.
+        std::vector<uint8_t> s(W * 8);
+        for (uint32_t t = 0; t < W * 4; ++t) {
+            const uint16_t value = static_cast<uint16_t>(t * 251u + 17u);
+            s[t * 2] = static_cast<uint8_t>(value);
+            s[t * 2 + 1] = static_cast<uint8_t>(value >> 8);
+        }
+        CHECK(run_format_copy(DataFormat::Unorm16, 4, 8, s) == s,
+              "Unorm16x4 storage copy round-trips guest channels bit-exact (#590)");
     }
     {   // Uint16 x1 (fmt=7): 16-bit integer widen on load, low-16-bit truncate on store
         std::vector<uint8_t> s(W * 2);

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -3,6 +3,7 @@
 #include "../src/gpu/shader_resources.hpp"
 #include <cstdint>
 #include <cstdio>
+#include <iterator>
 #include <unordered_map>
 #include <vector>
 
@@ -342,6 +343,44 @@ int main() {
         return 1;
     }
     printf("  [ok]   scalar reuse invalidates saved Wave32 mask aliases\n");
+
+    // A folded s_getpc_b64 has no runtime scalar SSA result, but it still overwrites both physical
+    // SGPR words. Keep an independent valid embedded-table chain in the shader so the first getpc is
+    // accepted, then prove that it kills the old B32 mask rather than letting v_cndmask see it.
+    const uint32_t wave32_mask_then_folded_getpc[] = {
+        0xbe80037eu,                         // pc0: s_mov_b32 s0, exec_lo
+        0xbe801f00u,                         // pc1: s_getpc_b64 s[0:1] (overwrites saved mask)
+        0xb0060010u,                         // pc2: s_movk_i32 s6, 16-byte table
+        0xbe8703ffu, 0x10005004u,            // pc3: s_mov_b32 s7, V# config
+        0xbe841f00u,                         // pc5: s_getpc_b64 s[4:5] (next byte 24)
+        0x800404b4u,                         // pc6: s_add_u32 s4, 52, s4 (table byte 76)
+        0x82050580u,                         // pc7: s_addc_u32 s5, 0, s5
+        0x7e020280u,                         // pc8: v_mov_b32 v1, 0 (table byte offset)
+        0xe0301000u, 0x80010101u,            // pc9: buffer_load_dword v1,v1,s[4:7]
+        0xbf8c3f70u,                         // pc11: s_waitcnt vmcnt(0)
+        0xd5010003u, 0x0001e8f2u,            // pc12: v_cndmask v3,1.0,2.0,s[0:1]
+        0x7e000280u, 0x7e040280u,
+        0xf800000fu, 0x03020100u,
+        0xbf810000u,
+        7u, 11u, 13u, 17u,
+    };
+    std::vector<uint32_t> wave32_folded_getpc_control(
+        std::begin(wave32_mask_then_folded_getpc),
+        std::end(wave32_mask_then_folded_getpc));
+    wave32_folded_getpc_control[13] = 0x01a9e8f2u; // consume live VCC, not overwritten s[0:1]
+    if (recompile_fragment_wave32_for_test(
+            wave32_folded_getpc_control.data(),
+            wave32_folded_getpc_control.size()).empty()) {
+        printf("  [FAIL] folded s_getpc_b64 control shader did not recompile\n");
+        return 1;
+    }
+    if (!recompile_fragment_wave32_for_test(
+            wave32_mask_then_folded_getpc,
+            std::size(wave32_mask_then_folded_getpc)).empty()) {
+        printf("  [FAIL] folded s_getpc_b64 retained a stale Wave32 mask alias\n");
+        return 1;
+    }
+    printf("  [ok]   folded s_getpc_b64 invalidates saved Wave32 mask aliases\n");
 
     const uint32_t scalar_abs_compute[] = {
         0xb000ffffu,                         // s_movk_i32 s0, -1

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -217,6 +217,110 @@ int main() {
     }
     printf("  [ok]   fragment private spill/fill emits structurally valid Function storage\n");
 
+    // Astro Bot's Wave32 graphics shaders save/copy/restore active-lane masks through the low
+    // halves of EXEC and VCC.  These are the B32 equivalents of the B64 mask moves already modeled
+    // below, not scalar-data transfers: treating EXEC_LO as ordinary data rejected the entire draw.
+    const uint32_t wave32_fragment_masks[] = {
+        0xbe80037eu,                         // s_mov_b32 s0, exec_lo
+        0xbeea037eu,                         // s_mov_b32 vcc_lo, exec_lo
+        0xbefe0300u,                         // s_mov_b32 exec_lo, s0
+        0x7e000280u, 0x7e020280u, 0x7e040280u, 0x7e0602f2u,
+        0xf800000fu, 0x03020100u,            // exp mrt0 v0,v1,v2,v3
+        0xbf810000u,
+    };
+    const auto wave32_fragment_spv = recompile_fragment(
+        wave32_fragment_masks, std::size(wave32_fragment_masks));
+    uint32_t wave32_fragment_bad_op = 0;
+    if (wave32_fragment_spv.empty() ||
+        !type_result_ids_are_nonzero(wave32_fragment_spv, &wave32_fragment_bad_op) ||
+        !phi_ids_are_nonzero(wave32_fragment_spv)) {
+        printf("  [FAIL] Wave32 fragment EXEC_LO/VCC_LO mask moves emitted invalid SPIR-V (op=%u)\n",
+               wave32_fragment_bad_op);
+        return 1;
+    }
+    printf("  [ok]   Wave32 fragment EXEC_LO/VCC_LO mask moves emit valid SPIR-V\n");
+
+    const uint32_t wave32_fragment_wqm[] = {
+        0xbe80037eu,                         // s_mov_b32 s0, exec_lo
+        0xbefe0900u,                         // s_wqm_b32 exec_lo, s0
+        0xbefe097eu,                         // s_wqm_b32 exec_lo, exec_lo
+        0x7e000280u, 0x7e020280u, 0x7e040280u, 0x7e0602f2u,
+        0xf800000fu, 0x03020100u,            // exp mrt0 v0,v1,v2,v3
+        0xbf810000u,
+    };
+    const auto wave32_fragment_wqm_spv = recompile_fragment(
+        wave32_fragment_wqm, std::size(wave32_fragment_wqm));
+    if (wave32_fragment_wqm_spv.empty() ||
+        !type_result_ids_are_nonzero(wave32_fragment_wqm_spv, nullptr) ||
+        !phi_ids_are_nonzero(wave32_fragment_wqm_spv)) {
+        printf("  [FAIL] Wave32 fragment s_wqm_b32 mask path did not recompile cleanly\n");
+        return 1;
+    }
+    printf("  [ok]   Wave32 fragment s_wqm_b32 mask path emits valid SPIR-V\n");
+
+    const uint32_t wave32_vertex_exec[] = {
+        0xbefe03c1u,                         // s_mov_b32 exec_lo, -1
+        0x7e000280u, 0x7e020280u, 0x7e040280u, 0x7e0602f2u,
+        0xf80008cfu, 0x03020100u,            // exp pos0 v0,v1,v2,v3
+        0xbf810000u,
+    };
+    const auto wave32_vertex_spv = recompile_vertex(
+        wave32_vertex_exec, std::size(wave32_vertex_exec));
+    if (wave32_vertex_spv.empty() || !phi_ids_are_nonzero(wave32_vertex_spv)) {
+        printf("  [FAIL] Wave32 vertex EXEC_LO all-lanes restore did not recompile\n");
+        return 1;
+    }
+    printf("  [ok]   Wave32 vertex EXEC_LO all-lanes restore recompiles\n");
+
+    const uint32_t scalar_abs_compute[] = {
+        0xb000ffffu,                         // s_movk_i32 s0, -1
+        0xbe813400u,                         // s_abs_i32 s1, s0
+        0xbf850001u,                         // s_cbranch_scc1 +1
+        0xbf800000u,                         // s_nop 0
+        0xbf810000u,
+    };
+    ComputeShaderConfig scalar_abs_config;
+    const auto scalar_abs_spv = recompile_compute(
+        scalar_abs_compute, std::size(scalar_abs_compute), nullptr, scalar_abs_config);
+    if (scalar_abs_spv.empty() || !type_result_ids_are_nonzero(scalar_abs_spv, nullptr) ||
+        !phi_ids_are_nonzero(scalar_abs_spv)) {
+        printf("  [FAIL] scalar s_abs_i32/SCC path did not recompile cleanly\n");
+        return 1;
+    }
+    printf("  [ok]   scalar s_abs_i32 writes its result and SCC in valid SPIR-V\n");
+
+    // Prosper does not expose an attached GPU system debugger to guest shaders, so COND_DBG_SYS is
+    // permanently clear and s_cbranch_cdbgsys falls through. Astro's world-map NGG wrapper uses this
+    // around its position export; rejecting it drops the complete draw despite ordinary hardware also
+    // taking the fallthrough path outside a shader-debugging session.
+    const uint32_t no_system_debugger_vertex[] = {
+        0x7e000280u, 0x7e020280u, 0x7e040280u, 0x7e0602f2u,
+        0xbf970001u,                         // s_cbranch_cdbgsys +1 (not taken)
+        0xf80008cfu, 0x03020100u,            // exp pos0 v0,v1,v2,v3
+        0xbf810000u,
+    };
+    const auto no_system_debugger_spv = recompile_vertex(
+        no_system_debugger_vertex, std::size(no_system_debugger_vertex));
+    if (no_system_debugger_spv.empty() ||
+        !type_result_ids_are_nonzero(no_system_debugger_spv, nullptr) ||
+        !phi_ids_are_nonzero(no_system_debugger_spv)) {
+        printf("  [FAIL] s_cbranch_cdbgsys did not take the no-debugger fallthrough path\n");
+        return 1;
+    }
+    printf("  [ok]   s_cbranch_cdbgsys falls through when no GPU debugger is exposed\n");
+
+    const uint32_t unsupported_exec_hi[] = {
+        0xbeff03c1u,                         // s_mov_b32 exec_hi, -1
+        0x7e000280u, 0x7e020280u, 0x7e040280u, 0x7e0602f2u,
+        0xf80008cfu, 0x03020100u,
+        0xbf810000u,
+    };
+    if (!recompile_vertex(unsupported_exec_hi, std::size(unsupported_exec_hi)).empty()) {
+        printf("  [FAIL] unsupported EXEC_HI B32 write was accepted\n");
+        return 1;
+    }
+    printf("  [ok]   EXEC_HI B32 writes remain fail-closed\n");
+
     const uint32_t scratch_vertex[] = {
         0xdc704010u, 0x00000000u, // scratch_store_dword off, v0, s0 offset:16
         0x7e000280u,              // v_mov_b32 v0, 0
@@ -278,6 +382,49 @@ int main() {
     }
     printf("  [ok]   unproven NGG rejects one-lane mask population count\n");
 
+    // In Astro's byte-exact one-lane NGG projection, find-first-one on a wave mask is exact:
+    // the represented lane is bit zero, so an active mask returns 0 and an empty mask returns -1.
+    // The test-only entry point exercises that lowering without broadening production acceptance.
+    const uint32_t ngg_mask_ff1[] = {
+        0xBF900009u,                         // s_sendmsg GS_ALLOC_REQ (marks NGG)
+        0xBEEA04C1u,                         // s_mov_b64 vcc, -1
+        0xBE80146Au,                         // s_ff1_i32_b64 s0, vcc
+        0x7E000C00u,                         // v_cvt_f32_u32 v0, s0
+        0x7E020280u, 0x7E040280u, 0x7E0602F2u,
+        0xF80008CFu, 0x03020100u,            // exp pos0 v0,v1,v2,v3
+        0xBF810000u,
+    };
+    const auto ngg_mask_ff1_spv = recompile_vertex_ngg_one_lane_for_test(
+        ngg_mask_ff1, std::size(ngg_mask_ff1));
+    if (ngg_mask_ff1_spv.empty() || !type_result_ids_are_nonzero(ngg_mask_ff1_spv, nullptr)) {
+        printf("  [FAIL] one-lane NGG s_ff1_i32_b64 did not emit valid SPIR-V\n");
+        return 1;
+    }
+    printf("  [ok]   one-lane NGG s_ff1_i32_b64 emits valid SPIR-V\n");
+
+    // Astro's 7f5f world-map wrapper constructs a B64 wave mask in ordinary scalar DATA registers
+    // and consumes it through v_cndmask_b32_e64. The one-lane projection represents lane zero, so
+    // the condition is exactly bit zero of the pair's low dword. Other vertex shaders still reject
+    // this wave-dependent form because they have no proven lane identity.
+    const uint32_t ngg_scalar_data_mask[] = {
+        0xBF900009u,                         // s_sendmsg GS_ALLOC_REQ (marks NGG)
+        0xBE8403FFu, 0xAAAAAAAAu,            // s_mov_b32 s4, 0xaaaaaaaa
+        0xBE850304u,                         // s_mov_b32 s5, s4
+        0xD5010005u, 0x00120AFFu, 0x00100800u, // exact v_cndmask_b32_e64 v5, lit, v5, s[4:5]
+        0x7E000305u,                         // v_mov_b32 v0, v5
+        0x7E020280u, 0x7E040280u, 0x7E0602F2u,
+        0xF80008CFu, 0x03020100u,            // exp pos0 v0,v1,v2,v3
+        0xBF810000u,
+    };
+    const auto ngg_scalar_data_mask_spv = recompile_vertex_ngg_one_lane_for_test(
+        ngg_scalar_data_mask, std::size(ngg_scalar_data_mask));
+    if (ngg_scalar_data_mask_spv.empty() ||
+        !type_result_ids_are_nonzero(ngg_scalar_data_mask_spv, nullptr)) {
+        printf("  [FAIL] one-lane NGG scalar-data mask cndmask did not emit valid SPIR-V\n");
+        return 1;
+    }
+    printf("  [ok]   one-lane NGG scalar-data mask cndmask emits valid SPIR-V\n");
+
     // Exercise the output-selection emitter through its explicit test hook. The production entry
     // point restricts every terminal NGG gate to the byte-exact Astro wrapper, as checked below.
     const uint32_t ngg_output_gate[] = {
@@ -294,6 +441,48 @@ int main() {
         return 1;
     }
     printf("  [ok]   terminal NGG compacted-vertex output gate produces valid SPIR-V\n");
+
+    // The real Astro wrapper does not export directly after its terminal CMPX gate: it computes an
+    // LDS address and reloads the compacted vertex first. Those predicated register-only operations
+    // are part of the same bounded gate and must not make its position export look unsafe.
+    const uint32_t ngg_output_rebuild_gate[] = {
+        0xBF900009u,                         // s_sendmsg GS_ALLOC_REQ (marks NGG)
+        0x7C3E0300u,                         // v_cmpx_tru_f32
+        0xBF880005u,                         // s_cbranch_execz -> s_endpgm
+        0x7E000280u,                         // v_mov_b32 v0, 0 (address/value setup)
+        0xD8D80000u, 0x00000000u,            // ds_read_b32 v0, v0
+        0xF80008CFu, 0x03020100u,            // exp pos0 v0,v1,v2,v3
+        0xBF810000u,
+    };
+    const auto ngg_output_rebuild_spv = recompile_vertex_terminal_ngg_gate_for_test(
+        ngg_output_rebuild_gate, std::size(ngg_output_rebuild_gate));
+    if (ngg_output_rebuild_spv.empty() || !phi_ids_are_nonzero(ngg_output_rebuild_spv)) {
+        printf("  [FAIL] terminal NGG LDS output-rebuild gate did not produce valid SPIR-V\n");
+        return 1;
+    }
+    printf("  [ok]   terminal NGG LDS output-rebuild gate produces valid SPIR-V\n");
+
+    // Astro's second world-map wrapper exports POS for a surviving compacted vertex, then a regular
+    // VCC compare conditionally skips only the trailing PARAM exports. Supplying those otherwise-
+    // undefined varyings in the one-lane projection is safe and must not drop the complete draw.
+    const uint32_t ngg_output_vcc_tail[] = {
+        0xBF900009u,                         // s_sendmsg GS_ALLOC_REQ (marks NGG)
+        0x7C3E0300u,                         // v_cmpx_tru_f32
+        0xBF880006u,                         // s_cbranch_execz -> s_endpgm
+        0xF80008CFu, 0x03020100u,            // exp pos0 v0,v1,v2,v3
+        0x7D8A5880u,                         // v_cmp_ne_u32 vcc, 0, v44
+        0xBF860002u,                         // s_cbranch_vccnz -> s_endpgm
+        0xF800020Fu, 0x03020100u,            // exp param0 v0,v1,v2,v3
+        0xBF810000u,
+    };
+    const auto ngg_output_vcc_tail_spv = recompile_vertex_terminal_ngg_gate_for_test(
+        ngg_output_vcc_tail, std::size(ngg_output_vcc_tail));
+    if (ngg_output_vcc_tail_spv.empty() || !phi_ids_are_nonzero(ngg_output_vcc_tail_spv)) {
+        printf("  [FAIL] terminal NGG VCC-gated PARAM tail did not produce valid SPIR-V\n");
+        return 1;
+    }
+    printf("  [ok]   terminal NGG VCC-gated PARAM tail produces valid SPIR-V\n");
+
     if (!recompile_vertex(ngg_output_gate, std::size(ngg_output_gate)).empty()) {
         printf("  [FAIL] production accepted an unproven constant NGG output gate\n");
         return 1;
@@ -458,6 +647,34 @@ int main() {
         return 1;
     }
     printf("  [ok]   vertex fetch recompiles to valid SPIR-V with a resource table (binding 3)\n");
+
+    // Astro's NGG vertex shader fetches Float16x4 records with an SGPR SOFFSET.  Even when the
+    // descriptor stride is dword-aligned, that runtime offset can select either half of a dword;
+    // all four components must be extracted relative to the complete byte address.  This exact
+    // MUBUF shape previously hit [mubuf-unaligned] and dropped the draw.
+    const uint32_t vs_fetch_half4_soffset[] = {
+        0xb0050002u,                         // s_movk_i32 s5, 2
+        0xe00c2000u, 0x05000100u,           // buffer_load_format_xyzw v[1:4], v0, s[0:3], s5 idxen
+        0xf80008cfu, 0x04030201u,            // exp pos0 v1,v2,v3,v4
+        0xbf810000u,
+    };
+    ShaderResourceTable rt_half4;
+    ShaderResource vb_half4{};
+    vb_half4.cls = ResourceClass::VertexBuffer;
+    vb_half4.format = DataFormat::Float16;
+    vb_half4.num_components = 4;
+    vb_half4.binding = 5;
+    vb_half4.stride = 36;
+    vb_half4.fetch_pc = 1;
+    vb_half4.fetch_index_mode = VertexFetchIndexMode::Shader;
+    rt_half4.resources.push_back(vb_half4);
+    const auto half4_spv = recompile_vertex(
+        vs_fetch_half4_soffset, std::size(vs_fetch_half4_soffset), &rt_half4);
+    if (half4_spv.empty() || half4_spv[0] != 0x07230203u) {
+        printf("  [FAIL] Float16x4 vertex fetch with runtime SOFFSET did not recompile\n");
+        return 1;
+    }
+    printf("  [ok]   Float16x4 vertex fetch handles a runtime SOFFSET\n");
 
     // image_sample LOD mode per execution model (#151): OpImageSampleImplicitLod is only legal in
     // the Fragment execution model — the compute and vertex shells have no derivatives, so an

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -228,7 +228,12 @@ int main() {
         0xf800000fu, 0x03020100u,            // exp mrt0 v0,v1,v2,v3
         0xbf810000u,
     };
-    const auto wave32_fragment_spv = recompile_fragment(
+    if (!recompile_fragment(wave32_fragment_masks,
+                            std::size(wave32_fragment_masks)).empty()) {
+        printf("  [FAIL] ungated graphics shader accepted Wave32 EXEC_LO/VCC_LO mask moves\n");
+        return 1;
+    }
+    const auto wave32_fragment_spv = recompile_fragment_wave32_for_test(
         wave32_fragment_masks, std::size(wave32_fragment_masks));
     uint32_t wave32_fragment_bad_op = 0;
     if (wave32_fragment_spv.empty() ||
@@ -240,6 +245,27 @@ int main() {
     }
     printf("  [ok]   Wave32 fragment EXEC_LO/VCC_LO mask moves emit valid SPIR-V\n");
 
+    const uint32_t wave32_compute_masks[] = {
+        0xbe80037eu,                         // s_mov_b32 s0, exec_lo
+        0xbeea037eu,                         // s_mov_b32 vcc_lo, exec_lo
+        0xbefe0300u,                         // s_mov_b32 exec_lo, s0
+        0xbf810000u,
+    };
+    ComputeShaderConfig wave32_compute_config;
+    wave32_compute_config.wave_size = 32;
+    if (recompile_compute(wave32_compute_masks, std::size(wave32_compute_masks), nullptr,
+                          wave32_compute_config).empty()) {
+        printf("  [FAIL] proven Wave32 compute mask moves did not recompile\n");
+        return 1;
+    }
+    wave32_compute_config.wave_size = 64;
+    if (!recompile_compute(wave32_compute_masks, std::size(wave32_compute_masks), nullptr,
+                           wave32_compute_config).empty()) {
+        printf("  [FAIL] Wave64 compute accepted Wave32 low-half mask semantics\n");
+        return 1;
+    }
+    printf("  [ok]   compute low-half mask semantics require proven Wave32 launch state\n");
+
     const uint32_t wave32_fragment_wqm[] = {
         0xbe80037eu,                         // s_mov_b32 s0, exec_lo
         0xbefe0900u,                         // s_wqm_b32 exec_lo, s0
@@ -248,7 +274,7 @@ int main() {
         0xf800000fu, 0x03020100u,            // exp mrt0 v0,v1,v2,v3
         0xbf810000u,
     };
-    const auto wave32_fragment_wqm_spv = recompile_fragment(
+    const auto wave32_fragment_wqm_spv = recompile_fragment_wave32_for_test(
         wave32_fragment_wqm, std::size(wave32_fragment_wqm));
     if (wave32_fragment_wqm_spv.empty() ||
         !type_result_ids_are_nonzero(wave32_fragment_wqm_spv, nullptr) ||
@@ -266,11 +292,56 @@ int main() {
     };
     const auto wave32_vertex_spv = recompile_vertex(
         wave32_vertex_exec, std::size(wave32_vertex_exec));
-    if (wave32_vertex_spv.empty() || !phi_ids_are_nonzero(wave32_vertex_spv)) {
-        printf("  [FAIL] Wave32 vertex EXEC_LO all-lanes restore did not recompile\n");
+    if (!wave32_vertex_spv.empty()) {
+        printf("  [FAIL] ungated vertex shader accepted Wave32 EXEC_LO restore\n");
         return 1;
     }
-    printf("  [ok]   Wave32 vertex EXEC_LO all-lanes restore recompiles\n");
+    printf("  [ok]   unproven graphics Wave32 mask operations remain fail-visible\n");
+
+    // A one-word Wave32 saved-mask alias ends when that physical SGPR is reused as scalar data.
+    // v_cndmask must not prefer the old bool after either an SOPK or SOP2 writer; without a numeric
+    // B64 mask representation these deliberately reject instead of silently selecting the stale arm.
+    const uint32_t wave32_mask_then_sopk[] = {
+        0xbe80037eu,                         // s_mov_b32 s0, exec_lo
+        0xb0000000u,                         // s_movk_i32 s0, 0
+        0xb0010000u,                         // s_movk_i32 s1, 0
+        0xd5010003u, 0x0001e8f2u,            // v_cndmask_b32_e64 v3, 1.0, 2.0, s[0:1]
+        0x7e000280u, 0x7e020280u, 0x7e040280u,
+        0xf800000fu, 0x03020100u,
+        0xbf810000u,
+    };
+    if (!recompile_fragment_wave32_for_test(
+            wave32_mask_then_sopk, std::size(wave32_mask_then_sopk)).empty()) {
+        printf("  [FAIL] SOPK scalar reuse retained a stale Wave32 mask alias\n");
+        return 1;
+    }
+    const uint32_t wave32_mask_then_sop2[] = {
+        0xbe80037eu,                         // s_mov_b32 s0, exec_lo
+        0x87008080u,                         // s_and_b32 s0, 0, 0
+        0xb0010000u,                         // s_movk_i32 s1, 0
+        0xd5010003u, 0x0001e8f2u,            // v_cndmask_b32_e64 v3, 1.0, 2.0, s[0:1]
+        0x7e000280u, 0x7e020280u, 0x7e040280u,
+        0xf800000fu, 0x03020100u,
+        0xbf810000u,
+    };
+    if (!recompile_fragment_wave32_for_test(
+            wave32_mask_then_sop2, std::size(wave32_mask_then_sop2)).empty()) {
+        printf("  [FAIL] SOP2 scalar reuse retained a stale Wave32 mask alias\n");
+        return 1;
+    }
+    const uint32_t wave32_sop2_reuse_control[] = {
+        0xbe80037eu,                         // s_mov_b32 s0, exec_lo
+        0x87008080u,                         // s_and_b32 s0, 0, 0
+        0x7e000280u, 0x7e020280u, 0x7e040280u, 0x7e0602f2u,
+        0xf800000fu, 0x03020100u,
+        0xbf810000u,
+    };
+    if (recompile_fragment_wave32_for_test(
+            wave32_sop2_reuse_control, std::size(wave32_sop2_reuse_control)).empty()) {
+        printf("  [FAIL] SOP2 scalar-reuse control shader did not recompile\n");
+        return 1;
+    }
+    printf("  [ok]   scalar reuse invalidates saved Wave32 mask aliases\n");
 
     const uint32_t scalar_abs_compute[] = {
         0xb000ffffu,                         // s_movk_i32 s0, -1

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -382,6 +382,27 @@ int main() {
     }
     printf("  [ok]   folded s_getpc_b64 invalidates saved Wave32 mask aliases\n");
 
+    // A no-else forward arm has a skipped predecessor at its merge. If only the taken arm creates a
+    // B32 saved mask, the physical-word validity differs between predecessors and cannot be modeled
+    // by a bool-value phi alone. Keep the post-merge mask consumer fail-visible.
+    const uint32_t wave32_conditional_mask_save[] = {
+        0xbe800380u,                         // pc0: s_mov_b32 s0, 0
+        0xbf060000u,                         // pc1: s_cmp_eq_u32 s0, s0
+        0xbf840001u,                         // pc2: s_cbranch_scc0 -> pc4
+        0xbe82037eu,                         // pc3: s_mov_b32 s2, exec_lo (taken arm only)
+        0xd5010003u, 0x0009e8f2u,            // pc4: v_cndmask v3,1.0,2.0,s[2:3]
+        0x7e000280u, 0x7e020280u, 0x7e040280u,
+        0xf800000fu, 0x03020100u,
+        0xbf810000u,
+    };
+    if (!recompile_fragment_wave32_for_test(
+            wave32_conditional_mask_save,
+            std::size(wave32_conditional_mask_save)).empty()) {
+        printf("  [FAIL] forward-if leaked a path-dependent Wave32 mask lifetime\n");
+        return 1;
+    }
+    printf("  [ok]   forward-if rejects path-dependent Wave32 mask lifetimes\n");
+
     const uint32_t scalar_abs_compute[] = {
         0xb000ffffu,                         // s_movk_i32 s0, -1
         0xbe813400u,                         // s_abs_i32 s1, s0

--- a/prosper/tests/test_recompile_coverage.cpp
+++ b/prosper/tests/test_recompile_coverage.cpp
@@ -302,6 +302,22 @@ int main() {
                           sizeof(compute_cfg_dispatch)/sizeof(compute_cfg_dispatch[0]), 0, 0,
                           &dispatch_rt).empty(),
           "a nested varying-VCC compute CFG preserves spilled EXEC and lowers through the dispatcher");
+    ComputeShaderConfig wave32_dispatch_config;
+    wave32_dispatch_config.wave_size = 32;
+    CHECK(!recompile_compute(compute_cfg_dispatch, std::size(compute_cfg_dispatch),
+                             &dispatch_rt, wave32_dispatch_config).empty(),
+          "the complex compute CFG dispatcher supports Wave32 without B32 mask aliases");
+    std::vector<uint32_t> compute_cfg_dispatch_created_b32 = {
+        0x7D8802F9u, 0x06068000u, // v_cmp_lt_f32_sdwa s[0:1], v0, v0
+        0xBE820300u,              // s_mov_b32 s2, s0 (new one-word mask alias)
+    };
+    compute_cfg_dispatch_created_b32.insert(
+        compute_cfg_dispatch_created_b32.end(), compute_cfg_dispatch,
+        compute_cfg_dispatch + std::size(compute_cfg_dispatch));
+    CHECK(recompile_compute(compute_cfg_dispatch_created_b32.data(),
+                            compute_cfg_dispatch_created_b32.size(), &dispatch_rt,
+                            wave32_dispatch_config).empty(),
+          "a dispatcher rejects B32 aliases of mask pairs produced inside its CFG");
     // The dispatcher includes branch-target/fallthrough blocks even when no entry path can reach
     // them. This dead block overwrites half of direct V# s[8:11] and then targets the live entry;
     // provenance at the reachable fetch must not include a write hardware can never execute.
@@ -416,6 +432,21 @@ int main() {
     CHECK(recompile_valu(compute_vcc_loop_barrier,
                          sizeof(compute_vcc_loop_barrier)/sizeof(compute_vcc_loop_barrier[0]), 0, 0).empty(),
           "a uniform VCCZ-exit loop containing s_barrier still rejects in the compute shell");
+
+    // The narrow loop structurizers likewise do not carry the validity bit for a one-word Wave32
+    // mask alias. This loop creates an SGPR-pair mask with VOPC and copies its low word before the
+    // back-edge; reject until that extra loop state has an explicit phi.
+    const uint32_t compute_vcc_loop_created_b32[] = {
+        0xBE800380u, 0x7E000280u, 0x7E020284u, 0x7D020200u, 0xBF860007u,
+        0x060000FFu, 0x3E800000u, 0x81008100u,
+        0x7D8802F9u, 0x06068200u, // v_cmp_lt_f32_sdwa s[2:3], v0, v0
+        0xBE840302u,              // s_mov_b32 s4, s2
+        0xBF82FFF7u, 0xBF810000u,
+    };
+    CHECK(recompile_compute(compute_vcc_loop_created_b32,
+                            std::size(compute_vcc_loop_created_b32), nullptr,
+                            wave32_dispatch_config).empty(),
+          "a structured loop rejects B32 aliases of mask pairs produced in-loop");
 
     // A FORWARD vccz if with the same proven-uniform compare also structurizes in compute (#590 —
     // DOLL's blocked lighting/fill kernels are forward vccz if/else trees, not loops). Same shape as


### PR DESCRIPTION
## What changed

- add missing Wave32 EXEC/VCC moves, `s_wqm_b32`, `s_abs_i32`, and byte-exact one-lane NGG operations used by Astro Bot
- support arbitrary-address Float16 vertex loads and UNORM16 storage-image conversion
- distinguish adjacent V# buffer descriptors from T# image descriptors using the GFX10 image TYPE field
- preserve mixed T#/V# tables loaded by `s_load_dwordx16` and accept fully known live V# descriptors after modeled scalar patches
- complete the terminal output paths of the observed Astro Bot NGG wrappers, including debugger-only and trailing parameter-export branches

## Why

Astro Bot reached the title sequence, but major world-map draws were discarded by shader recompilation and some adjacent vertex-buffer descriptors were being uploaded as images. These changes address the concrete failures observed in live runs while keeping one-lane NGG approximations restricted to byte-exact captured wrappers.

## Impact

The title sequence renders without the earlier coarse descriptor corruption, the game reaches `worldmap`, and both dominant 3435- and 3917-dword world-map vertex shaders now compile. The world map is still visually black/grid-like, so this is an incremental compatibility checkpoint rather than completion of #962.

## Validation

- `ctest --test-dir prosper/build-astrobot-fmv --output-on-failure -R '^(rdna2_spirv_struct|dynfetch_fold|build_shader_resources|game_compute_exec)$'`
- live Astro Bot run with rendering, realtime audio, scripted normal input, and immediate presentation through `LevelDocument Loaded: worldmap [worldmap]`
- live log confirms the previous `pc=205` MIMG, `pc=2761` raw-MUBUF, `pc=3374` narrowed export, `pc=3870` VOP3, and `pc=3887` terminal export failures are absent

Snapshot tests were intentionally not run: this is a development PR, not a release.