### PR TITLE
fix(gpu): support R32 image atomic swap

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -1115,7 +1115,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 }
                             }
                         }
-                        const bool has_cpu_live_rtt = r.img_dim == 1u && live_rtt != g_rtt.end() &&
+                        const bool has_cpu_live_rtt = !fr.is_storage_image && r.img_dim == 1u &&
+                            live_rtt != g_rtt.end() &&
                             live_rtt->second.w && live_rtt->second.h && live_rtt->second.rgba &&
                             !live_rtt->second.rgba->empty();
                         // A retained render target was created for color-attachment + sampled usage,
@@ -1227,6 +1228,13 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             r.format == prosper::gpu::DataFormat::Unorm8 &&
                             r.num_components == 1 && r.tile_mode == 0u &&
                             !r.compression_enabled && !linear_padded_read;
+                        // Storage-image atomics require a typed integer Vulkan view. Keep R32_UINT
+                        // texels byte-exact through the existing 4-B read/detile path instead of
+                        // silently normalizing the view to RGBA8_UNORM.
+                        const bool native_r32ui_storage =
+                            r.cls == RC::StorageImage && r.img_dim == 1u &&
+                            r.format == prosper::gpu::DataFormat::Uint32 &&
+                            r.num_components == 1 && !r.compression_enabled;
                         const bool persistent_source_matches_pixels =
                             native_r8_sampled ||
                             (persistent_unorm8_texture && r.num_components == 4 &&
@@ -1609,9 +1617,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         const size_t volume_texels = (size_t)tw * th * (is_volume ? r.depth : 1u);
                         const VkFormat live_rtt_format = has_cpu_live_rtt
                             ? live_rtt->second.format
-                            : (native_r8_sampled ? VK_FORMAT_R8_UNORM
+                            : (native_r32ui_storage ? VK_FORMAT_R32_UINT
+                               : (native_r8_sampled ? VK_FORMAT_R8_UNORM
                                : (sampled_source_f32 ? VK_FORMAT_R16G16B16A16_SFLOAT
-                                                     : VK_FORMAT_R8G8B8A8_UNORM));
+                                                     : VK_FORMAT_R8G8B8A8_UNORM)));
                         fr.texture_format = live_rtt_format;
                         const uint32_t output_bpp =
                             prosper::test::backend_color_bytes_per_pixel(live_rtt_format);
@@ -1673,7 +1682,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // RTT (#167): if this texture's base is a color target we rendered into, inject those
                         // pixels (nearest-scaled to tw x th) instead of reading empty guest memory.
                         bool rtt_hit = false;
-                        if (rtt_on && !is_volume && !r.in_mip_tail) { auto rit = g_rtt.find(r.gpu_addr);
+                        if (!fr.is_storage_image && rtt_on && !is_volume && !r.in_mip_tail) {
+                            auto rit = g_rtt.find(r.gpu_addr);
                             if (rit != g_rtt.end() && rit->second.w && rit->second.h && rit->second.rgba &&
                                 !rit->second.rgba->empty()) {
                                 const RttSurf& s = rit->second;

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -964,6 +964,11 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             prosper::gpu::SpirvDescriptorKind::CombinedImageSampler &&
                         reflected_binding->normalized_sampling &&
                         !reflected_binding->texel_access;
+                    const bool writable_storage_image =
+                        reflected_binding != reflected.descriptors.end() &&
+                        reflected_binding->kind ==
+                            prosper::gpu::SpirvDescriptorKind::StorageImage &&
+                        reflected_binding->writable;
                     // Captured replays preserve the logical guest address for RT identity but provide
                     // owned bytes here. Production resources leave host_data null and use guest memory.
                     auto copy_resource = [&](uint8_t* dst, uint64_t addr, size_t n) -> size_t {
@@ -2292,6 +2297,62 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         fr.tex_rgba = texture_pixels.data(); fr.tw = tw; fr.th = cube_done ? th * 6u : th;
                         fr.td = is_volume ? r.depth : 1u;
                         fr.img_dim = r.img_dim;
+                        if (native_r32ui_storage && writable_storage_image) {
+                            const uint32_t writeback_pitch = getenv("PROSPER_PITCH")
+                                ? static_cast<uint32_t>(atoi(getenv("PROSPER_PITCH"))) : 0u;
+                            const size_t linear_bytes = static_cast<size_t>(tw) * th * 4u;
+                            const bool tiled = prosper::gpu::tile_mode_is_tiled(r.tile_mode);
+                            const size_t guest_bytes = r.in_mip_tail
+                                ? r.mip_tail_bytes
+                                : (tiled
+                                       ? prosper::gpu::tiled_surface_bytes(
+                                             tw, th, r.tile_mode, writeback_pitch, 4u)
+                                       : linear_bytes);
+                            // The exact Astro atomic surface is a base-level 2D R32_UINT image. Keep
+                            // the callback fail-closed for malformed/short replay backing; losing a
+                            // write is preferable to overrunning an unrelated guest allocation.
+                            const bool backing_fits = guest_bytes &&
+                                (!r.host_data || guest_bytes <= r.host_data_size);
+                            if (backing_fits) {
+                                const uint64_t guest_addr = r.gpu_addr;
+                                uint8_t* const replay_data = r.host_data;
+                                const uint32_t tile_mode = r.tile_mode;
+                                const bool in_mip_tail = r.in_mip_tail;
+                                const uint32_t mip_tail_x = r.mip_tail_x;
+                                const uint32_t mip_tail_y = r.mip_tail_y;
+                                fr.storage_image_writeback =
+                                    [guest_addr, replay_data, guest_bytes, linear_bytes,
+                                     tw, th, tile_mode, writeback_pitch, in_mip_tail,
+                                     mip_tail_x, mip_tail_y](const uint8_t* pixels,
+                                                            size_t bytes) {
+                                        if (!pixels || bytes != linear_bytes) return;
+                                        uint8_t* destination = replay_data;
+                                        if (!destination) {
+                                            if (guest_bytes > UINT32_MAX ||
+                                                !prosper::gpu::guest_writable(
+                                                    guest_addr,
+                                                    static_cast<uint32_t>(guest_bytes)))
+                                                return;
+                                            prosper::host::guest_write_watch_notify_host_write(
+                                                guest_addr, guest_bytes);
+                                            destination = reinterpret_cast<uint8_t*>(
+                                                static_cast<uintptr_t>(guest_addr));
+                                        }
+                                        if (in_mip_tail) {
+                                            prosper::gpu::tile_surface_level(
+                                                destination, guest_bytes, pixels, tw, th,
+                                                tile_mode, 4u, mip_tail_x, mip_tail_y);
+                                        } else {
+                                            prosper::gpu::tile_surface(
+                                                destination, pixels, tw, th, tile_mode,
+                                                writeback_pitch, 4u);
+                                        }
+                                        if (guest_addr)
+                                            prosper::gpu::notify_guest_gpu_write(
+                                                guest_addr, guest_bytes);
+                                    };
+                            }
+                        }
                         // #1272: see the reuse path — plain 2D guest textures only.
                         if (!is_volume && !cube_done)
                             fr.declared_mip_levels = r.declared_mip_levels;

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -205,9 +205,10 @@ bool prefix_inspect_publish() {
 }
 
 // Pixel decoding is a pure function of these fields for guest-backed textures. Keep this cache local
-// to one renderer callback: graphics spans are split at compute operations, so guest texture bytes
-// cannot change within its lifetime. Live RTT inputs are excluded separately because an earlier pass
-// in the same callback can replace their pixels.
+// to one renderer callback: graphics spans are split at compute operations, so ordinary guest texture
+// bytes cannot change within its lifetime. Writable storage-image callbacks explicitly invalidate every
+// overlapping entry after publishing their results. Live RTT inputs are excluded separately because an
+// earlier pass in the same callback can replace their pixels.
 struct TextureDecodeKey {
     uint64_t gpu_addr = 0;
     uint64_t host_data = 0;

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -2297,62 +2297,6 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         fr.tex_rgba = texture_pixels.data(); fr.tw = tw; fr.th = cube_done ? th * 6u : th;
                         fr.td = is_volume ? r.depth : 1u;
                         fr.img_dim = r.img_dim;
-                        if (native_r32ui_storage && writable_storage_image) {
-                            const uint32_t writeback_pitch = getenv("PROSPER_PITCH")
-                                ? static_cast<uint32_t>(atoi(getenv("PROSPER_PITCH"))) : 0u;
-                            const size_t linear_bytes = static_cast<size_t>(tw) * th * 4u;
-                            const bool tiled = prosper::gpu::tile_mode_is_tiled(r.tile_mode);
-                            const size_t guest_bytes = r.in_mip_tail
-                                ? r.mip_tail_bytes
-                                : (tiled
-                                       ? prosper::gpu::tiled_surface_bytes(
-                                             tw, th, r.tile_mode, writeback_pitch, 4u)
-                                       : linear_bytes);
-                            // The exact Astro atomic surface is a base-level 2D R32_UINT image. Keep
-                            // the callback fail-closed for malformed/short replay backing; losing a
-                            // write is preferable to overrunning an unrelated guest allocation.
-                            const bool backing_fits = guest_bytes &&
-                                (!r.host_data || guest_bytes <= r.host_data_size);
-                            if (backing_fits) {
-                                const uint64_t guest_addr = r.gpu_addr;
-                                uint8_t* const replay_data = r.host_data;
-                                const uint32_t tile_mode = r.tile_mode;
-                                const bool in_mip_tail = r.in_mip_tail;
-                                const uint32_t mip_tail_x = r.mip_tail_x;
-                                const uint32_t mip_tail_y = r.mip_tail_y;
-                                fr.storage_image_writeback =
-                                    [guest_addr, replay_data, guest_bytes, linear_bytes,
-                                     tw, th, tile_mode, writeback_pitch, in_mip_tail,
-                                     mip_tail_x, mip_tail_y](const uint8_t* pixels,
-                                                            size_t bytes) {
-                                        if (!pixels || bytes != linear_bytes) return;
-                                        uint8_t* destination = replay_data;
-                                        if (!destination) {
-                                            if (guest_bytes > UINT32_MAX ||
-                                                !prosper::gpu::guest_writable(
-                                                    guest_addr,
-                                                    static_cast<uint32_t>(guest_bytes)))
-                                                return;
-                                            prosper::host::guest_write_watch_notify_host_write(
-                                                guest_addr, guest_bytes);
-                                            destination = reinterpret_cast<uint8_t*>(
-                                                static_cast<uintptr_t>(guest_addr));
-                                        }
-                                        if (in_mip_tail) {
-                                            prosper::gpu::tile_surface_level(
-                                                destination, guest_bytes, pixels, tw, th,
-                                                tile_mode, 4u, mip_tail_x, mip_tail_y);
-                                        } else {
-                                            prosper::gpu::tile_surface(
-                                                destination, pixels, tw, th, tile_mode,
-                                                writeback_pitch, 4u);
-                                        }
-                                        if (guest_addr)
-                                            prosper::gpu::notify_guest_gpu_write(
-                                                guest_addr, guest_bytes);
-                                    };
-                            }
-                        }
                         // #1272: see the reuse path — plain 2D guest textures only.
                         if (!is_volume && !cube_done)
                             fr.declared_mip_levels = r.declared_mip_levels;
@@ -2437,6 +2381,81 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             decoded_textures.emplace(
                                 decode_key, DecodedTexture{fr.tex_rgba, fr.th, narrow_done,
                                                           fr.persistent_texture_id});
+                        }
+                        if (native_r32ui_storage && writable_storage_image) {
+                            const uint32_t writeback_pitch = getenv("PROSPER_PITCH")
+                                ? static_cast<uint32_t>(atoi(getenv("PROSPER_PITCH"))) : 0u;
+                            const size_t linear_bytes = static_cast<size_t>(tw) * th * 4u;
+                            const bool tiled = prosper::gpu::tile_mode_is_tiled(r.tile_mode);
+                            const size_t guest_bytes = r.in_mip_tail
+                                ? r.mip_tail_bytes
+                                : (tiled
+                                       ? prosper::gpu::tiled_surface_bytes(
+                                             tw, th, r.tile_mode, writeback_pitch, 4u)
+                                       : linear_bytes);
+                            // The exact Astro atomic surface is a base-level 2D R32_UINT image. Keep
+                            // the callback fail-closed for malformed/short replay backing; losing a
+                            // write is preferable to overrunning an unrelated guest allocation.
+                            const bool backing_fits = guest_bytes &&
+                                (!r.host_data || guest_bytes <= r.host_data_size);
+                            if (backing_fits) {
+                                const uint64_t guest_addr = r.gpu_addr;
+                                uint8_t* const replay_data = r.host_data;
+                                const uint32_t tile_mode = r.tile_mode;
+                                const bool in_mip_tail = r.in_mip_tail;
+                                const uint32_t mip_tail_x = r.mip_tail_x;
+                                const uint32_t mip_tail_y = r.mip_tail_y;
+                                fr.storage_image_writeback =
+                                    [guest_addr, replay_data, guest_bytes, linear_bytes,
+                                     tw, th, tile_mode,
+                                     writeback_pitch, in_mip_tail, mip_tail_x,
+                                     mip_tail_y, &decoded_textures](const uint8_t* pixels,
+                                                                  size_t bytes) {
+                                        if (!pixels || bytes != linear_bytes) return;
+                                        uint8_t* destination = replay_data;
+                                        if (!destination) {
+                                            if (guest_bytes > UINT32_MAX ||
+                                                !prosper::gpu::guest_writable(
+                                                    guest_addr,
+                                                    static_cast<uint32_t>(guest_bytes)))
+                                                return;
+                                            prosper::host::guest_write_watch_notify_host_write(
+                                                guest_addr, guest_bytes);
+                                            destination = reinterpret_cast<uint8_t*>(
+                                                static_cast<uintptr_t>(guest_addr));
+                                        }
+                                        if (in_mip_tail) {
+                                            prosper::gpu::tile_surface_level(
+                                                destination, guest_bytes, pixels, tw, th,
+                                                tile_mode, 4u, mip_tail_x, mip_tail_y);
+                                        } else {
+                                            prosper::gpu::tile_surface(
+                                                destination, pixels, tw, th, tile_mode,
+                                                writeback_pitch, 4u);
+                                        }
+                                        if (guest_addr)
+                                            prosper::gpu::notify_guest_gpu_write(
+                                                guest_addr, guest_bytes);
+                                        // The same guest range can already have a sampled-image decode
+                                        // under a different cache key/class. Its pixel representation
+                                        // cannot be patched byte-for-byte from R32_UINT, so discard every
+                                        // overlapping submit-local decode and let the next pass rebuild it
+                                        // from the now-current guest bytes.
+                                        if (guest_addr) {
+                                            for (auto it = decoded_textures.begin();
+                                                 it != decoded_textures.end();) {
+                                                const uint64_t cached_addr = it->first.gpu_addr;
+                                                const uint64_t cached_bytes =
+                                                    std::max<uint64_t>(it->first.size, 1u);
+                                                const bool overlaps = cached_addr <= guest_addr
+                                                    ? guest_addr - cached_addr < cached_bytes
+                                                    : cached_addr - guest_addr < guest_bytes;
+                                                if (overlaps) it = decoded_textures.erase(it);
+                                                else ++it;
+                                            }
+                                        }
+                                    };
+                            }
                         }
                         // Carry the decoded S# sampler state (filter/wrap/mip) so the pipeline samples the
                         // way the game asked instead of a fixed LINEAR/clamp sampler (#<sampler-fix>).

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -195,10 +195,9 @@ struct SrtUse {
     // has no usable key; keying the TEXTURE use by its exact instruction (ShaderResource::fetch_pc,
     // the same per-instruction provenance the vertex fetches use) is unambiguous.
     uint32_t use_pc = 0xFFFFFFFFu;   // exact consuming pc for key-less texture/buffer uses
-    // The consuming image op WRITES the image (image_store — MIMG op 0x8): the resource must be a
-    // STORAGE image, not a sampled texture (#590 — the recompiler's storage path requires
-    // ResourceClass::StorageImage). Only meaningful for kind 0.
-    bool is_store = false;
+    // The consuming image op requires a STORAGE image (image_store 0x08 or an image atomic such as
+    // IMAGE_ATOMIC_SWAP 0x0f), not a sampled texture. Only meaningful for kind 0.
+    bool is_storage_image = false;
     // The consuming MIMG opcode is a comparison/depth sample (IMAGE_SAMPLE_C*). This is a
     // property of the use, not merely the S# compare function: NEVER is a valid compare op.
     bool is_depth_compare = false;

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -2071,7 +2071,7 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                         SrtUse u; u.kind = 0; u.t8 = *t8;
                         u.key = tkey;
                         u.use_pc = in.pc;
-                        u.is_store = in.opcode == 0x08;   // image_store: a STORAGE-image use (#590)
+                        u.is_storage_image = in.opcode == 0x08 || in.opcode == 0x0f;
                         u.is_depth_compare = (in.opcode >= 0x28 && in.opcode <= 0x2f) ||
                                              (in.opcode >= 0x38 && in.opcode <= 0x3f) ||
                                              (in.opcode >= 0x58 && in.opcode <= 0x5f);
@@ -2942,7 +2942,7 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
                     if (log) fprintf(stderr, "[srt] %s cbuf key=0x%x pc=%u base=0x%llx size=%u\n", is_ps ? "PS" : "VS",
                                      u.key, u.use_pc, (unsigned long long)d.base, resource_size);
                     t.resources.push_back(r);
-                } else {                                  // texture (T# [+ paired S#])
+                } else {                                  // sampled texture or storage image (T# [+ paired S#])
                     DecodedImageDescriptor d = decode_image_descriptor(u.t8.data());
                     if (g_dyntrace_force)
                         fprintf(stderr, "[dynfail] tex use pc=%u key=0x%x base=0x%llx %ux%u fmt=%u tile=%u\n",
@@ -2957,8 +2957,11 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
                     // if it has none yet (#273). If it already carries a DIFFERENT use's pc, fall
                     // through and create a second resource for this pc (fetch_pc holds one pc; a
                     // sample whose pc has no mapping would stay unresolved).
+                    const ResourceClass wanted = u.is_storage_image
+                        ? ResourceClass::StorageImage : ResourceClass::Texture;
                     Gen5ImageFormatInfo fi;
                     if (!gen5_image_format(d.format, &fi)) {
+                        if (wanted == ResourceClass::StorageImage) continue;
                         // Same policy as build_shader_resources: the normal per-target renderer can
                         // bind this as RGBA8 for RTT injection; legacy single-target mode skips it.
                         static const bool rtt_bind = getenv("PROSPER_RTT") != nullptr ||
@@ -2978,7 +2981,7 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
                     {
                         bool mapped = false;
                         for (auto& r0 : t.resources)
-                            if (r0.cls == ResourceClass::Texture && r0.gpu_addr == view.base &&
+                            if (r0.cls == wanted && r0.gpu_addr == view.base &&
                                 r0.width == view.width && r0.height == view.height &&
                                 r0.depth == d.depth && r0.format == fi.format && r0.img_dim == img_dim &&
                                 r0.depth_compare == u.is_depth_compare &&
@@ -2992,7 +2995,7 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
                         if (mapped) continue;
                     }
                     ShaderResource r;
-                    r.cls = ResourceClass::Texture;
+                    r.cls = wanted;
                     r.format = fi.format; r.num_components = fi.num_components;
                     r.gpu_addr = view.base; r.width = view.width; r.height = view.height; r.depth = d.depth;
                     r.declared_mip_levels =
@@ -3026,7 +3029,9 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
                     r.size = static_cast<uint32_t>(backing_bytes);
                     r.srt_offset = clash ? 0xFFFFFFFFu : u.key;   // ambiguous/absent key: pc-only provenance
                     r.fetch_pc   = u.use_pc;                       // per-instruction provenance (#273)
-                    if (u.has_samp) {                     // paired S# (same SQ_IMG_SAMP decode as the sharp path)
+                    if (wanted == ResourceClass::Texture && u.has_samp) {
+                        // Paired S# (same SQ_IMG_SAMP decode as the sharp path). Storage operations do
+                        // not consume a sampler even when their SSAMP bits alias known user SGPRs.
                         const uint32_t* sm = u.s4.data();
                         r.mag_filter  = ((sm[2] >> 20) & 0x3u) ? 1u : 0u;
                         r.min_filter  = ((sm[2] >> 22) & 0x3u) ? 1u : 0u;
@@ -3044,9 +3049,12 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
                         r.lod_bias           = (float)bias14 / 256.0f;
                         r.border_color_type  = (sm[3] >> 30) & 0x3u;
                     }
-                    if (log) fprintf(stderr, "[srt] %s tex key=0x%x %ux%u fmt=%u base=0x%llx tile=%u samp=%d\n",
-                                     is_ps ? "PS" : "VS", u.key, d.width, d.height, d.format,
-                                     (unsigned long long)d.base, d.tile_mode, (int)u.has_samp);
+                    if (log) fprintf(stderr, "[srt] %s %s key=0x%x %ux%u fmt=%u base=0x%llx tile=%u samp=%d\n",
+                                     is_ps ? "PS" : "VS",
+                                     wanted == ResourceClass::StorageImage ? "storage-image" : "tex",
+                                     u.key, d.width, d.height, d.format,
+                                     (unsigned long long)d.base, d.tile_mode,
+                                     (int)(wanted == ResourceClass::Texture && u.has_samp));
                     t.resources.push_back(r);
                 }
             }
@@ -3317,7 +3325,7 @@ std::vector<ComputeItem> realize_compute_dispatches(
                     // Unknown sampled formats cannot be decoded. Unknown storage formats may still
                     // recompile (format-free SPIR-V), but remain explicitly Unknown so the live backend
                     // rejects them instead of silently treating arbitrary bytes as RGBA8.
-                    if (!mapped_fmt && !u.is_store) continue;
+                    if (!mapped_fmt && !u.is_storage_image) continue;
                     if (mapped_fmt && fi.block_width > 1 && fi.snorm) continue;   // signed BCn: not wired
                     const DecodedImageView view = mapped_fmt
                         ? image_base_level_view(d, fi)
@@ -3327,8 +3335,8 @@ std::vector<ComputeItem> realize_compute_dispatches(
                         warn_unsupported_image_view(d);
                         continue;
                     }
-                    const ResourceClass wanted = u.is_store ? ResourceClass::StorageImage
-                                                           : ResourceClass::Texture;
+                    const ResourceClass wanted = u.is_storage_image ? ResourceClass::StorageImage
+                                                                   : ResourceClass::Texture;
                     const DataFormat view_format = mapped_fmt ? fi.format : DataFormat::Unknown;
                     const uint32_t img_dim = image_type_to_dim(d.type);
                     {

--- a/prosper/src/gpu/rdna2_decode.cpp
+++ b/prosper/src/gpu/rdna2_decode.cpp
@@ -461,13 +461,14 @@ void decode_operands(Rdna2Inst& i) {
             // Image op. opcode is 8 bits: MSB in dword0 bit 0, low 7 bits in [24:18] (Table 100:
             // "combine bits zero and 18-24" — dropping bit 0 aliased IMAGE_MSAA_LOAD (128) onto
             // IMAGE_LOAD (0) and the _G16/BVH families onto wrong identities); dmask[11:8];
-            // unorm[12]; dim[5:3]. dword1: VADDR base[7:0]; VDATA base[15:8]; SRSRC (T# base
+            // unorm[12]; GLC[13]; dim[5:3]. dword1: VADDR base[7:0]; VDATA base[15:8]; SRSRC (T# base
             // SGPR, ×4)[20:16]; SSAMP (S# base SGPR, ×4)[25:21].
             // image_sample = opcode 0x20, image_load = 0x00. (Bit layout verified via llvm-mc gfx1030.)
             const uint32_t d1 = i.words[1];
             i.opcode     = ((w & 1u) << 7) | ((w >> 18) & 0x7Fu);
             i.mimg_dmask = (w >> 8)  & 0xFu;
             i.mimg_unorm = (w >> 12) & 0x1u;
+            i.mimg_glc   = (w >> 13) & 0x1u;
             i.mimg_dim   = (w >> 3)  & 0x7u;
             i.dst    = vgpr(d1 >> 8);                         // VDATA (dest base)
             i.src[0] = vgpr(d1 & 0xFFu);                      // VADDR (coord base VGPR)

--- a/prosper/src/gpu/rdna2_decode.hpp
+++ b/prosper/src/gpu/rdna2_decode.hpp
@@ -126,11 +126,13 @@ struct Rdna2Inst {
     // OP). Bit 16 is likewise captured so an unknown flag rejects rather than silently running
     // against workgroup LDS with device-global (GDS) semantics expected.
     bool     ds_gds = false;
-    // 2D=1, 3D=2, Cube=3, 1D_ARRAY=4, 2D_ARRAY=5, ...), and the unnormalized-coordinate flag. VDATA is
-    // in `dst`, VADDR in src[0], SRSRC (T# base SGPR) in src[1], SSAMP (S# base SGPR) in src[2].
+    // 2D=1, 3D=2, Cube=3, 1D_ARRAY=4, 2D_ARRAY=5, ...), the unnormalized-coordinate flag, and GLC
+    // (bit 13). For image atomics, GLC means return the pre-operation value to VDATA. VDATA is in
+    // `dst`, VADDR in src[0], SRSRC (T# base SGPR) in src[1], SSAMP (S# base SGPR) in src[2].
     uint32_t mimg_dmask = 0;
     uint32_t mimg_dim   = 0;
     bool     mimg_unorm = false;
+    bool     mimg_glc   = false;
 
     // VINTRP-only: the interpolated attribute (parameter location) and its component channel (0..3).
     // opcode = p1(0)/p2(1)/mov(2); dst = vdst; src[0] = vsrc (the i/j barycentric VGPR).

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -42,7 +42,7 @@ enum : uint32_t {
     Op_ShiftRightLogical=194, Op_ShiftRightArithmetic=195, Op_ShiftLeftLogical=196, Op_BitwiseOr=197,
     Op_BitwiseXor=198, Op_BitwiseAnd=199, Op_Not=200, Op_BitFieldSExtract=202, Op_BitFieldUExtract=203,
     Op_BitReverse=204, Op_BitCount=205, Op_UConvert=113,
-    Op_TypeImage=25, Op_TypeSampledImage=27, Op_SampledImage=86,
+    Op_TypeImage=25, Op_TypeSampledImage=27, Op_ImageTexelPointer=60, Op_SampledImage=86,
     Op_ImageSampleImplicitLod=87, Op_ImageSampleExplicitLod=88,
     Op_ImageSampleDrefImplicitLod=89, Op_ImageSampleDrefExplicitLod=90,
     Op_ImageFetch=95, Op_ImageGather=96, Op_Image=100,
@@ -73,7 +73,7 @@ enum : uint32_t {
     EM_OriginUpperLeft=7, EM_DepthReplacing=12, EM_LocalSize=17, EM_Triangles=22,
     EM_OutputVertices=26, EM_OutputTriangleStrip=29, EM_Xfb=11,   // transform-feedback execution mode
     SC_Input=1, SC_UniformConstant=0, SC_Output=3, SC_Function=7, SC_PushConstant=9,
-    SC_StorageBuffer=12, FC_None=0,
+    SC_Image=11, SC_StorageBuffer=12, FC_None=0,
     Dim_1D=0, Dim_2D=1, Dim_3D=2,   // SPIR-V Dim. (2D coincides with the SQ_RSRC 2D dim value, but distinct.)
     Cap_Sampled1D=43, Cap_Image1D=44,   // Dim=1D needs Sampled1D; a 1D STORAGE image (read/write) also needs Image1D
     Cap_StorageImageMultisample=27,      // MS=1 storage image (read/write a multisampled image)
@@ -84,9 +84,11 @@ enum : uint32_t {
     ImgOp_Offset=0x10,                   // ImageOperands bit: dynamic texel offset (needs ImageGatherExtended)
     Img_Sampled_Storage=2,   // OpTypeImage "Sampled" operand: 2 = used WITHOUT a sampler (read/write storage image)
     ImgFmt_Unknown=0,        // OpTypeImage "Image Format": Unknown (runtime view format; needs the caps above)
+    ImgFmt_R32ui=33,         // exact uint32 storage image format required by image atomics
     ImgOp_Bias=1, ImgOp_Lod=2, ImgOp_Grad=4, ImgOp_Sample=0x40,   // ImageOperands bits.
     SC_Workgroup=4, Scope_Device=1, Scope_Workgroup=2, Scope_Subgroup=3,
-    MemSem_UniformAcqRel=0x48, MemSem_WGAcqRel=0x108,   // storage/LDS AcquireRelease memory semantics
+    MemSem_UniformAcqRel=0x48, MemSem_WGAcqRel=0x108,   // storage-buffer/LDS AcquireRelease semantics
+    MemSem_ImageAcqRel=0x808,                            // AcquireRelease | ImageMemory
     Dec_Block=2, Dec_ArrayStride=6, Dec_BuiltIn=11, Dec_NoPerspective=13, Dec_Flat=14,
     Dec_Centroid=16, Dec_Sample=17, Dec_Location=30, Dec_Binding=33,
     Dec_DescriptorSet=34, Dec_Offset=35, Dec_XfbBuffer=36, Dec_XfbStride=37,
@@ -213,6 +215,7 @@ struct SpirvCompute {
     uint32_t v_push_constants = 0, t_ptr_push_u32 = 0;
     uint32_t linear_localid = 0, local_count = 64, wave_size = 64;
     uint32_t v_cbuf=0, v_cbuf1=0, t_ptr_sb_u32=0;   // scalar-memory constant buffers (bindings 2 and 3)
+    uint32_t t_ptr_img_u32=0;                       // OpImageTexelPointer result for R32_UINT atomics
     uint32_t guest_scratch=0, t_ptr_guest_scratch_u32=0;
     int32_t guest_scratch_min_byte=0, guest_scratch_saddr=-1;
     uint32_t guest_scratch_dwords=0;
@@ -1164,18 +1167,22 @@ struct SpirvCompute {
     uint32_t t_v4u_cache = 0;
     uint32_t t_v4u() { if (!t_v4u_cache) { t_v4u_cache = id(); put(types, Op_TypeVector, {t_v4u_cache, t_u32, 4}); } return t_v4u_cache; }
     uint32_t t_v3u_c = 0;   // integer coordinate vector type (uvec3); 2D reuses the shared t_v2u()
-    std::unordered_map<uint32_t, uint32_t> stg_img_type;   // (dim | arrayed<<8 | ms<<9 | float<<10) -> type
+    std::unordered_map<uint32_t, uint32_t> stg_img_type;   // dimension/type/format key -> OpTypeImage
+    std::unordered_map<uint32_t, uint32_t> stg_img_binding_type; // binding -> declared OpTypeImage
     std::unordered_map<uint32_t, uint32_t> stg_img_var;    // binding -> storage-image OpVariable id
     std::unordered_map<uint32_t, bool> stg_img_float;      // binding -> float (rather than uint) texels
+    std::unordered_map<uint32_t, uint32_t> stg_img_format; // binding -> SPIR-V Image Format
     bool declared_read_wo_fmt = false, declared_write_wo_fmt = false, declared_sampled1d = false, declared_ms = false, declared_msarray = false;
-    static uint32_t stg_key(uint32_t dim, bool arrayed, bool ms, bool float_texel) {
+    static uint32_t stg_key(uint32_t dim, bool arrayed, bool ms, bool float_texel,
+                            uint32_t image_format) {
         return dim | (arrayed ? 0x100u : 0u) | (ms ? 0x200u : 0u) |
-               (float_texel ? 0x400u : 0u);
+               (float_texel ? 0x400u : 0u) | (image_format << 11);
     }
     // Declare (idempotently) a storage image of SPIR-V `dim` (arrayed = layer in the coord; ms =
     // multisampled) at set 0, `binding`. Float and uint sampled types are keyed separately.
     void declare_storage_image(uint32_t binding, uint32_t dim, bool arrayed = false,
-                               bool ms = false, bool float_texel = false) {
+                               bool ms = false, bool float_texel = false,
+                               uint32_t image_format = ImgFmt_Unknown) {
         if (dim == Dim_1D && !declared_sampled1d) {   // SPIR-V: Dim=1D needs Sampled1D; storage 1D also needs Image1D
             put(caps, Op_Capability, {Cap_Sampled1D});
             put(caps, Op_Capability, {Cap_Image1D});
@@ -1183,12 +1190,12 @@ struct SpirvCompute {
         }
         if (ms && !declared_ms) { put(caps, Op_Capability, {Cap_StorageImageMultisample}); declared_ms = true; }
         if (ms && arrayed && !declared_msarray) { put(caps, Op_Capability, {Cap_ImageMSArray}); declared_msarray = true; }
-        uint32_t key = stg_key(dim, arrayed, ms, float_texel);
+        uint32_t key = stg_key(dim, arrayed, ms, float_texel, image_format);
         if (!stg_img_type.count(key)) {
             uint32_t ti = id();
             put(types, Op_TypeImage, {ti, float_texel ? t_f32 : t_u32, dim, 0,
                                       arrayed ? 1u : 0u, ms ? 1u : 0u,
-                                      Img_Sampled_Storage, ImgFmt_Unknown});
+                                      Img_Sampled_Storage, image_format});
             stg_img_type[key] = ti;
         }
         if (stg_img_var.count(binding)) return;
@@ -1196,11 +1203,10 @@ struct SpirvCompute {
         uint32_t v = id();     put(types, Op_Variable,    {t_ptr, v, SC_UniformConstant});
         put(deco, Op_Decorate, {v, Dec_DescriptorSet, desc_set});
         put(deco, Op_Decorate, {v, Dec_Binding, binding});
+        stg_img_binding_type[binding] = stg_img_type[key];
         stg_img_var[binding] = v;
         stg_img_float[binding] = float_texel;
-    }
-    uint32_t stg_img_id(uint32_t dim, bool arrayed, bool ms, bool float_texel) {
-        return stg_img_type[stg_key(dim, arrayed, ms, float_texel)];
+        stg_img_format[binding] = image_format;
     }
     // Build the integer coordinate operand from `n` raw-bit VGPR coords (u32 texel indices, incl. the
     // array layer as the last component for arrayed images). n=1 -> scalar u32; 2 -> uvec2; 3 -> uvec3.
@@ -1228,11 +1234,14 @@ struct SpirvCompute {
     // (the test harness does). The store side is instead EXEC-predicated (no robust "harmless" OOB write).
     void image_read(uint32_t binding, uint32_t dim, bool arrayed, uint32_t ncoord, const uint32_t* coords,
                     uint32_t out[4], bool ms = false, uint32_t sample = 0) {
-        if (!declared_read_wo_fmt) { put(caps, Op_Capability, {Cap_StorageImageReadWithoutFormat}); declared_read_wo_fmt = true; }
+        if (stg_img_format[binding] == ImgFmt_Unknown && !declared_read_wo_fmt) {
+            put(caps, Op_Capability, {Cap_StorageImageReadWithoutFormat});
+            declared_read_wo_fmt = true;
+        }
         const bool float_texel = stg_img_float[binding];
         const uint32_t vector_type = float_texel ? t_v4f : t_v4u();
         uint32_t img   = id(); put(code, Op_Load,
-                                   {stg_img_id(dim, arrayed, ms, float_texel), img,
+                                   {stg_img_binding_type[binding], img,
                                     stg_img_var[binding]});
         uint32_t coord = stg_coord(ncoord, coords);
         uint32_t res   = id();
@@ -1251,10 +1260,13 @@ struct SpirvCompute {
     // e.g. a grid-tail bounds check.)
     void image_write(uint32_t binding, uint32_t dim, bool arrayed, uint32_t ncoord, const uint32_t* coords,
                      const uint32_t vals[4], bool predicated = false, uint32_t pred = 0) {
-        if (!declared_write_wo_fmt) { put(caps, Op_Capability, {Cap_StorageImageWriteWithoutFormat}); declared_write_wo_fmt = true; }
+        if (stg_img_format[binding] == ImgFmt_Unknown && !declared_write_wo_fmt) {
+            put(caps, Op_Capability, {Cap_StorageImageWriteWithoutFormat});
+            declared_write_wo_fmt = true;
+        }
         const bool float_texel = stg_img_float[binding];
         uint32_t img   = id(); put(code, Op_Load,
-                                   {stg_img_id(dim, arrayed, false, float_texel), img,
+                                   {stg_img_binding_type[binding], img,
                                     stg_img_var[binding]});
         uint32_t coord = stg_coord(ncoord, coords);
         uint32_t texel = id();
@@ -1272,6 +1284,40 @@ struct SpirvCompute {
         put(code, Op_ImageWrite, {img, coord, texel});
         put(code, Op_Branch, {merge});
         put(code, Op_Label, {merge}); cur_block = merge;
+    }
+
+    // IMAGE_ATOMIC_SWAP on an R32_UINT storage image. OpImageTexelPointer consumes the descriptor
+    // variable directly (not a loaded image object) and yields an Image-storage pointer suitable for
+    // the SPIR-V atomic. Inactive EXEC lanes neither touch the image nor clobber VDATA.
+    uint32_t image_atomic_swap(uint32_t binding, uint32_t ncoord, const uint32_t* coords,
+                               uint32_t value, bool predicated, uint32_t pred,
+                               uint32_t fallback) {
+        if (!t_ptr_img_u32) {
+            t_ptr_img_u32 = id();
+            put(types, Op_TypePointer, {t_ptr_img_u32, SC_Image, t_u32});
+        }
+        auto emit = [&]() {
+            const uint32_t coord = stg_coord(ncoord, coords);
+            const uint32_t pointer = id();
+            put(code, Op_ImageTexelPointer,
+                {t_ptr_img_u32, pointer, stg_img_var[binding], coord, uconst(0)});
+            const uint32_t result = id();
+            put(code, Op_AtomicExchange,
+                {t_u32, result, pointer, uconst(Scope_Device),
+                 uconst(MemSem_ImageAcqRel), value});
+            return result;
+        };
+        if (!predicated) return emit();
+        const uint32_t entry = cur_block;
+        const uint32_t then = id(), merge = id();
+        put(code, Op_SelectionMerge, {merge, 0});
+        put(code, Op_BranchConditional, {pred, then, merge});
+        put(code, Op_Label, {then}); cur_block = then;
+        const uint32_t result = emit();
+        const uint32_t then_end = cur_block;
+        put(code, Op_Branch, {merge});
+        put(code, Op_Label, {merge}); cur_block = merge;
+        return emit_phi_2way(t_u32, result, then_end, fallback, entry);
     }
 
     // buffer element pointer: base[ gid.x*stride + k ]
@@ -6639,8 +6685,9 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             }
             // Exact per-use provenance wins over table keys. A sample and store may consume the same
             // T# through a colliding offset but require different Vulkan descriptor classes.
-            if ((in.opcode == 0x08 && res && res->cls != ResourceClass::StorageImage) ||
-                (in.opcode != 0x00 && in.opcode != 0x08 && in.opcode != 0x0e &&
+            const bool storage_only_op = in.opcode == 0x08 || in.opcode == 0x0f;
+            if ((storage_only_op && res && res->cls != ResourceClass::StorageImage) ||
+                (in.opcode != 0x00 && !storage_only_op && in.opcode != 0x0e &&
                  res && res->cls != ResourceClass::Texture))
                 res = nullptr;
             if ((!res || (res->cls != ResourceClass::Texture && res->cls != ResourceClass::StorageImage))
@@ -6662,10 +6709,13 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                                       res->format == DataFormat::Uint16 ||
                                       res->format == DataFormat::Uint32;
 
-            // --- Storage-image path: image_load (0x00) / image_store (0x08), no sampler, any dim ---
+            // --- Storage-image path: image_load (0x00), image_store (0x08), and R32_UINT
+            // image_atomic_swap (0x0f), without a sampler. ---
             if (res->cls == ResourceClass::StorageImage) {
-                const bool is_ld = (in.opcode == 0x00), is_st = (in.opcode == 0x08);
-                if (!is_ld && !is_st) { ok = false; return true; }
+                const bool is_ld = in.opcode == 0x00;
+                const bool is_st = in.opcode == 0x08;
+                const bool is_atomic_swap = in.opcode == 0x0f;
+                if (!is_ld && !is_st && !is_atomic_swap) { ok = false; return true; }
                 uint32_t dim, ncoord; bool arrayed = false, ms = false;
                 switch (in.mimg_dim) {   // SQ_RSRC dim -> SPIR-V Dim + coord count (+ array layer / MSAA sample)
                     case 0: dim = Dim_1D; ncoord = 1; break;                       // 1D
@@ -6677,15 +6727,31 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     case 7: dim = Dim_2D; ncoord = 3; arrayed = true; ms = true; break;  // 2D_MSAA_ARRAY (x,y,layer)+sample
                     default: ok = false; return true;   // cube storage images deferred
                 }
-                if (ms && is_st) { ok = false; return true; }   // per-sample MSAA store not modeled (resolve shaders read)
+                if (ms && (is_st || is_atomic_swap)) { ok = false; return true; }
                 const uint32_t components = res->num_components ? res->num_components : 1;
+                // The live Astro Bot visibility image is an ordinary 2D R32_UINT surface. Keep the
+                // first atomic implementation exact and fail-visible for every other image shape;
+                // atomics require a typed integer image in Vulkan/SPIR-V rather than Format=Unknown.
+                if (is_atomic_swap &&
+                    (in.mimg_dim != SQ_DIM_2D || arrayed || ms || in.len_dwords != 2 ||
+                     in.mimg_unorm || in.mimg_dmask != 1u ||
+                     res->img_dim != 1u || res->depth != 1u || res->depth_compare ||
+                     res->format != DataFormat::Uint32 || components != 1u)) {
+                    ok = false;
+                    return true;
+                }
                 const bool ordinary_2d = res->img_dim == 1 && res->depth == 1 &&
                                          !res->depth_compare;
                 const bool native_float = ordinary_2d && native_float_storage_image_supported(
                     res->format, components, res->srgb,
                     (b.native_storage_format_support &
                      native_storage_format_support_bit(res->format, components)) != 0);
-                b.declare_storage_image(res->binding, dim, arrayed, ms, native_float);
+                // Existing load/store-only uint images retain the raw uvec4/Format=Unknown contract
+                // used by the compute backend. The atomic's exact R32_UINT gate above is the only path
+                // that opts into a typed R32ui image.
+                const bool native_r32ui = is_atomic_swap;
+                b.declare_storage_image(res->binding, dim, arrayed, ms, native_float,
+                                        native_r32ui ? ImgFmt_R32ui : ImgFmt_Unknown);
                 // Coordinate VGPR per axis. Non-NSA (len==2): consecutive from VADDR (src[0]). NSA (len>2):
                 // split across the extra address dwords — coord0 = VADDR, coord k>=1 = byte (k-1) of
                 // words[2..3] (dword2 = addr1..4, dword3 = addr5..8). Layout verified via llvm-mc gfx1010.
@@ -6706,7 +6772,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                         uint32_t old = vreg_old(b, rs, vd + w); rs.vreg[vd + w] = out[c];
                         predicate_write(b, rs, vd + w, old); w++;
                     }
-                } else {
+                } else if (is_st) {
                     // image_store: gather the VDATA VGPRs selected by dmask into an RGBA texel (channels
                     // absent from dmask store as 0). Under a narrowed EXEC (e.g. a grid-tail bounds check),
                     // the write is EXEC-predicated so inactive lanes don't write out-of-range texels.
@@ -6714,6 +6780,16 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     int vd = in.dst.value, w = 0;
                     for (uint32_t c = 0; c < 4; c++) if (in.mimg_dmask & (1u << c)) { vals[c] = vread(vd + w); w++; }
                     b.image_write(res->binding, dim, arrayed, ncoord, coords, vals, rs.exec_narrowed, rs.exec);
+                } else {
+                    // IMAGE_ATOMIC_SWAP reads its exchange operand from VDATA. GLC=1 overwrites that
+                    // VGPR with the pre-operation texel; GLC=0 leaves VDATA unchanged. The helper's
+                    // phi preserves the old register value for EXEC-inactive lanes.
+                    const int vd = in.dst.value;
+                    const uint32_t old = vreg_old(b, rs, vd);
+                    const uint32_t result = b.image_atomic_swap(
+                        res->binding, ncoord, coords, vread(vd),
+                        rs.exec_narrowed, rs.exec, old);
+                    if (in.mimg_glc) rs.vreg[vd] = result;
                 }
                 return true;
             }
@@ -8720,13 +8796,13 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                 if (getenv("PROSPER_DBG"))
                     fprintf(stderr, "[recompile-reject] pc=%u words=%08x,%08x fmt=%d op=0x%x "
                                     "dst=%d(kind%d) src=%d(k%d),%d(k%d),%d(k%d) dmask=0x%x "
-                                    "dim=%u len=%u modifier=%d dpp=%d sdwa=%u/%u/%u/%u\n",
+                                    "dim=%u glc=%d len=%u modifier=%d dpp=%d sdwa=%u/%u/%u/%u\n",
                         in.pc, in.words[0], in.words[1], (int)in.fmt, in.opcode,
                         in.dst.value, (int)in.dst.kind,
                         in.src[0].value, (int)in.src[0].kind,
                         in.src[1].value, (int)in.src[1].kind,
                         in.src[2].value, (int)in.src[2].kind,
-                        in.mimg_dmask, in.mimg_dim, in.len_dwords, (int)in.has_modifier,
+                        in.mimg_dmask, in.mimg_dim, (int)in.mimg_glc, in.len_dwords, (int)in.has_modifier,
                         (int)in.has_dpp, in.sdwa_dst_sel, in.sdwa_dst_unused,
                         in.sdwa_src0_sel, in.sdwa_src1_sel);
                 return false;
@@ -9741,6 +9817,9 @@ RecompileCoverage recompile_coverage(const uint32_t* code, size_t dwords) {
                     const bool st_dim = i.mimg_dim <= 2u || i.mimg_dim == 4u || i.mimg_dim == 5u;
                     if (i.opcode == 0x00u) return st_dim || i.mimg_dim == 6u || i.mimg_dim == 7u;   // image_load (+ 2D_MSAA[_ARRAY])
                     if (i.opcode == 0x08u) return st_dim;                       // image_store (no per-sample MSAA store)
+                    if (i.opcode == 0x0fu)                                     // image_atomic_swap R32_UINT 2D
+                        return i.mimg_dim == 1u && i.mimg_dmask == 1u &&
+                               !i.mimg_unorm && i.len_dwords == 2u;
                     if (i.opcode == 0x0eu) return i.mimg_dim <= 2u;             // image_get_resinfo 1D/2D/3D
                     // sample*: 2D (NSA ok); plus implicit-LOD image_sample (0x20) / LOD-0 image_sample_lz
                     // (0x27) from a 3D texture; sample_b (0x25) and gather4_lz (0x47) are 2D. 2D_ARRAY (dim 5)

--- a/prosper/src/gpu/shader_resources.cpp
+++ b/prosper/src/gpu/shader_resources.cpp
@@ -213,6 +213,7 @@ enum : uint32_t {
     OpTypePointer = 32,
     OpConstant = 43,
     OpVariable = 59,
+    OpImageTexelPointer = 60,
     OpLoad = 61,
     OpStore = 62,
     OpAccessChain = 65,
@@ -233,6 +234,7 @@ enum : uint32_t {
 };
 enum : uint32_t {
     StorageUniformConstant = 0,
+    StorageImage = 11,
     StorageBuffer = 12,
     DecorationArrayStride = 6,
     DecorationBinding = 33,
@@ -605,7 +607,27 @@ DescriptorValidationReport validate_spirv_descriptor_interface(
     };
     for (const Instruction& in : insts) {
         const uint32_t n = in.words - 1u;
-        if (in.opcode == OpLoad && n >= 3) {
+        if (in.opcode == OpImageTexelPointer && n >= 5) {
+            // Unlike OpImageRead/Write, this instruction consumes the storage-image descriptor
+            // variable directly and returns a pointer in the Image storage class. Preserve that
+            // provenance so the following OpAtomic* marks the image readable+writable.
+            const uint32_t result_type = word(in, 0);
+            const uint32_t result = word(in, 1);
+            const uint32_t image_var = word(in, 2);
+            const auto descriptor = descriptor_vars.find(image_var);
+            const auto pointer_type = types.find(result_type);
+            if (descriptor != descriptor_vars.end() &&
+                descriptor->second == SpirvDescriptorKind::StorageImage &&
+                pointer_type != types.end() &&
+                pointer_type->second.kind == TypeKind::Pointer &&
+                pointer_type->second.storage == StorageImage) {
+                PointerAccess access;
+                access.variable = image_var;
+                access.pointee_type = pointer_type->second.element;
+                accesses[result] = access;
+                texel_access_vars.insert(image_var);
+            }
+        } else if (in.opcode == OpLoad && n >= 3) {
             const uint32_t root = pointer_root(word(in, 2));
             const auto descriptor = descriptor_vars.find(root);
             const bool image_descriptor = descriptor != descriptor_vars.end() &&

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -176,6 +176,8 @@ inline VkFormat backend_color_format(VkFormat format) {
         return VK_FORMAT_R16G16B16A16_SFLOAT;
     if (format == VK_FORMAT_R8_UNORM)
         return VK_FORMAT_R8_UNORM;
+    if (format == VK_FORMAT_R32_UINT)
+        return VK_FORMAT_R32_UINT;
     return VK_FORMAT_R8G8B8A8_UNORM;
 }
 

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -112,6 +112,12 @@ struct FrameResource {
     // layout. Keep the flag independent of tex_rgba because both sampled and storage images upload
     // decoded pixels through that pointer.
     bool is_storage_image = false;
+    // Writable graphics storage images must publish their final linear texels before this backend call
+    // returns. The live frontend uses this to restore the guest's linear/tiled layout and notify the
+    // normal guest-write invalidation path, so later graphics, sampled aliases, compute, DMA, and CPU
+    // consumers all observe the image side effect. An empty callback keeps read-only/test fixtures on
+    // the ordinary asynchronous upload path.
+    std::function<void(const uint8_t*, size_t)> storage_image_writeback;
     // Sampler state (Texture only). Defaults = LINEAR + clamp-to-edge — the harness's prior fixed
     // sampler — so render tests that build FrameResources directly stay byte-identical. The live path
     // fills these from the decoded S# (shader_resources.hpp). filter: 0=nearest, 1=linear; addr = Gen5
@@ -3105,6 +3111,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         bool borrowed_ds_feedback = false; // same image is this pass's read-only depth attachment
         VkFormat ds_format = VK_FORMAT_UNDEFINED;
         bool direct_memory = false;
+        std::vector<std::function<void(const uint8_t*, size_t)>> storage_writebacks;
     };
     struct PersistentTextureKey {
         uint64_t id = 0;
@@ -3810,6 +3817,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                             tci.usage = (r.is_storage_image ? VK_IMAGE_USAGE_STORAGE_BIT
                                                           : VK_IMAGE_USAGE_SAMPLED_BIT) |
                                         VK_IMAGE_USAGE_TRANSFER_DST_BIT |
+                                        (r.is_storage_image
+                                             ? VK_IMAGE_USAGE_TRANSFER_SRC_BIT : 0u) |
                                         (upload.key.mip_levels > 1 ? VK_IMAGE_USAGE_TRANSFER_SRC_BIT
                                                                    : 0u);   // blit-cascade source (#1272)
                             vkCreateImage(dev, &tci, nullptr, &upload.image);
@@ -3840,7 +3849,10 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                                 static_cast<VkDeviceSize>(r.tw) * r.th * r.td *
                                 backend_color_bytes_per_pixel(r.texture_format);
                             VkBufferCreateInfo stci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
-                            stci.size = tbytes; stci.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+                            stci.size = tbytes;
+                            stci.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT |
+                                (r.is_storage_image
+                                     ? VK_BUFFER_USAGE_TRANSFER_DST_BIT : 0u);
                             vkCreateBuffer(dev, &stci, nullptr, &upload.staging);
                             VkMemoryRequirements sr;
                             vkGetBufferMemoryRequirements(dev, upload.staging, &sr);
@@ -3875,6 +3887,10 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                             vkUnmapMemory(dev, upload.staging_memory);
                         }
                     }
+                    if (r.is_storage_image && r.storage_image_writeback &&
+                        texture_uploads[upload_index].storage_writebacks.empty())
+                        texture_uploads[upload_index].storage_writebacks.push_back(
+                            r.storage_image_writeback);
                     const SharedTextureUpload& upload = texture_uploads[upload_index];
                     VkImageViewCreateInfo tvci{VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO};
                     // NOTE(#263): r.srgb carries whether the T# is a gamma-encoded (sRGB) surface, but we
@@ -4516,6 +4532,13 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     const bool readback_color1 = use_color1 &&
         (!persistent_color1 || color_target->readback1);
     const bool readback_requested = readback_color0 || readback_color1;
+    const bool storage_writeback_requested = std::any_of(
+        texture_uploads.begin(), texture_uploads.end(),
+        [](const SharedTextureUpload& upload) {
+            return !upload.storage_writebacks.empty();
+        });
+    const bool synchronous_results_requested =
+        readback_requested || storage_writeback_requested;
     const VkDeviceSize readback_color1_offset = readback_color0 ? bytes : 0;
     const VkDeviceSize readback_bytes = (readback_color0 ? bytes : 0) +
                                         (readback_color1 ? bytes1 : 0);
@@ -4801,7 +4824,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     // must be recorded outside a render pass, so it happens here.
     const RenderVkCtx& ds_ctx = render_vk_ctx();
     const bool draw_stats = getenv("PROSPER_DRAW_STATS") && ds_ctx.pipeline_stats_enabled && !dv.empty()
-                            && (!submission_batch || readback_requested || flush_submission_batch);
+                            && (!submission_batch || synchronous_results_requested ||
+                                flush_submission_batch);
     VkQueryPool ds_stats_pool = VK_NULL_HANDLE, ds_occ_pool = VK_NULL_HANDLE;
     if (draw_stats) {
         const uint32_t nq = static_cast<uint32_t>(dv.size());
@@ -4850,7 +4874,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     }
     const bool geom_probe = geom_item != SIZE_MAX
                             && ds_ctx.transform_feedback_enabled
-                            && (!submission_batch || readback_requested || flush_submission_batch);
+                            && (!submission_batch || synchronous_results_requested ||
+                                flush_submission_batch);
     static auto p_bindxfb  = reinterpret_cast<PFN_vkCmdBindTransformFeedbackBuffersEXT>(
         vkGetDeviceProcAddr(dev, "vkCmdBindTransformFeedbackBuffersEXT"));
     static auto p_beginxfb = reinterpret_cast<PFN_vkCmdBeginTransformFeedbackEXT>(
@@ -4999,6 +5024,43 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                                  VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT,
                              0, 0, nullptr, 0, nullptr, 1, &to_ds);
     }
+    // A writable graphics storage image is architecturally guest memory, not a callback-local
+    // texture. Copy its final texels back through the upload's coherent staging allocation before
+    // releasing the image. The callback below restores the guest surface layout and publishes the
+    // ordinary guest-write invalidation event. This deliberately forces one synchronization boundary
+    // for storage-image calls; retaining GPU images without alias/import/write invalidation would be
+    // faster but would still lose visibility at graphics->compute/DMA/CPU boundaries.
+    for (SharedTextureUpload& upload : texture_uploads) {
+        if (upload.storage_writebacks.empty() || !upload.image || !upload.staging) continue;
+        VkImageMemoryBarrier to_readback{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
+        to_readback.oldLayout = VK_IMAGE_LAYOUT_GENERAL;
+        to_readback.newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+        to_readback.image = upload.image;
+        to_readback.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+        to_readback.srcAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT;
+        to_readback.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+        vkCmdPipelineBarrier(cmd,
+                             VK_PIPELINE_STAGE_VERTEX_SHADER_BIT |
+                                 VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+                             VK_PIPELINE_STAGE_TRANSFER_BIT,
+                             0, 0, nullptr, 0, nullptr, 1, &to_readback);
+        VkBufferImageCopy copy{};
+        copy.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+        copy.imageExtent = {upload.key.width, upload.key.height, upload.key.depth};
+        vkCmdCopyImageToBuffer(cmd, upload.image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                               upload.staging, 1, &copy);
+        VkImageMemoryBarrier to_general{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
+        to_general.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+        to_general.newLayout = VK_IMAGE_LAYOUT_GENERAL;
+        to_general.image = upload.image;
+        to_general.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+        to_general.srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+        to_general.dstAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT;
+        vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                             VK_PIPELINE_STAGE_VERTEX_SHADER_BIT |
+                                 VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+                             0, 0, nullptr, 0, nullptr, 1, &to_general);
+    }
     if (readback_requested) {
         auto transition_color_to_readback = [&](bool persistent, bool readback, VkImage image) {
             if (!persistent || !readback) return;
@@ -5130,7 +5192,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         cached_color1->valid = true;
         cached_color1->layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
     }
-    const bool flush_now = !submission_batch || readback_requested || flush_submission_batch;
+    const bool flush_now = !submission_batch || synchronous_results_requested ||
+                           flush_submission_batch;
     BackendSubmissionBatchResult batch_result;
     if (flush_now)
         batch_result = active_submission.submit_and_wait(dev, queue, backend_trace);
@@ -5336,6 +5399,26 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         }
     }
 
+    if (storage_writeback_requested && batch_completed) {
+        for (SharedTextureUpload& upload : texture_uploads) {
+            if (upload.storage_writebacks.empty() || !upload.staging ||
+                !upload.staging_memory)
+                continue;
+            const size_t storage_bytes = static_cast<size_t>(upload.key.width) *
+                upload.key.height * upload.key.depth *
+                backend_color_bytes_per_pixel(upload.key.format);
+            void* mapped = nullptr;
+            if (!storage_bytes ||
+                vkMapMemory(dev, upload.staging_memory, 0, storage_bytes, 0,
+                            &mapped) != VK_SUCCESS ||
+                !mapped)
+                continue;
+            const auto* pixels = static_cast<const uint8_t*>(mapped);
+            for (const auto& writeback : upload.storage_writebacks)
+                writeback(pixels, storage_bytes);
+            vkUnmapMemory(dev, upload.staging_memory);
+        }
+    }
     if (readback_requested && batch_completed) {
         void* mp = nullptr; vkMapMemory(dev, bmem, 0, readback_bytes, 0, &mp);
         const auto* readback = static_cast<const uint8_t*>(mp);

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -627,6 +627,31 @@ int main() {
           direct_uses[0].s4[0] == seed5d[8] && direct_uses[0].s4[3] == seed5d[11],
           "direct user-SGPR T#/S# dwords are preserved");
 
+    // Astro Bot's live visibility packet consumes a direct R32_UINT T# in s[0:7]. Opcode 0x0f is
+    // IMAGE_ATOMIC_SWAP, so its instruction-scoped resource must be materialized as a storage image
+    // even though the packet's unused SSAMP field aliases s0.
+    const uint32_t image_atomic_swap[] = {
+        0xf03c2108u, 0x00000900u,
+        0xbf810000u,
+    };
+    const uint32_t atomic_image_seed[8] = {
+        0x055c0100u, 0xc1400000u, 0x001fc01fu, 0x91b00204u,
+        0x00000000u, 0x00700000u, 0x00000000u, 0x00000000u,
+    };
+    std::vector<SrtUse> atomic_image_uses;
+    resolve_dynamic_fetch(image_atomic_swap, std::size(image_atomic_swap),
+                          atomic_image_seed, std::size(atomic_image_seed), 0,
+                          &atomic_image_uses);
+    const std::array<uint32_t, 8> expected_atomic_t8 = {
+        0x055c0100u, 0xc1400000u, 0x001fc01fu, 0x91b00204u,
+        0x00000000u, 0x00700000u, 0x00000000u, 0x00000000u,
+    };
+    CHECK(atomic_image_uses.size() == 1 && atomic_image_uses[0].kind == 0 &&
+              atomic_image_uses[0].use_pc == 0 &&
+              atomic_image_uses[0].is_storage_image &&
+              atomic_image_uses[0].t8 == expected_atomic_t8,
+          "image_atomic_swap publishes the live direct T# as a storage-image use");
+
     // Astro's title PS consumes a V# placed directly in s[24:27] with a scalar offset computed in
     // VCC_LO. No s_load gives that descriptor an SRT key, and AGC metadata need not publish a sharp
     // for it. The fold nevertheless knows all four entry dwords and the exact offset, so retain the

--- a/prosper/tests/test_rdna2_decode.cpp
+++ b/prosper/tests/test_rdna2_decode.cpp
@@ -258,6 +258,14 @@ int main() {
     CHECK(n3.fmt == Rdna2Format::MIMG && n3.opcode == 0x00u && n3.len_dwords == 3 && n3.mimg_dim == 2u &&
           (n3.words[1] & 0xFFu) == 0u && (n3.words[2] & 0xFFu) == 7u && ((n3.words[2] >> 8) & 0xFFu) == 3u,
           "NSA MIMG 3D captures the extra address dword; coords decode to v0,v7,v3");
+    // Astro Bot's live image_atomic_swap packet. Bit 13 is GLC: atomically exchange v9 with the
+    // R32_UINT texel at (v0,v1), returning the pre-operation value to v9.
+    const uint32_t mimg_atomic_swap[] = { 0xf03c2108u, 0x00000900u };
+    Rdna2Inst atomic_swap = rdna2_decode_one(mimg_atomic_swap, 2);
+    CHECK(atomic_swap.fmt == Rdna2Format::MIMG && atomic_swap.opcode == 0x0fu &&
+          atomic_swap.mimg_dim == 1u && atomic_swap.mimg_dmask == 1u && atomic_swap.mimg_glc &&
+          atomic_swap.dst.value == 9 && atomic_swap.src[0].value == 0 && atomic_swap.src[1].value == 0,
+          "Astro image_atomic_swap decodes 2D/R32 data and the return-pre-op GLC flag");
 
     // inline-constant field decode: SGPR106 special, field 129 -> +1, 193 -> -1, 242 -> 1.0f
     CHECK(decode_src_field(0).kind == OperandKind::SGPR && decode_src_field(0).value == 0, "field 0 -> SGPR0");

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -971,6 +971,29 @@ int main() {
     }
     printf("  [ok]   image_get_resinfo 3D lowers to size/level image queries\n");
 
+    // Astro Bot's exact visibility-image packet: exchange v9 with R32_UINT texel (v0,v1), GLC=1.
+    // Both SPIR-V operations are essential: accepting the MIMG without a real texel pointer/atomic
+    // would merely hide the rejection while dropping the image side effect.
+    const uint32_t ps_image_atomic[] = {
+        0x7e000280u, 0x7e020280u, 0x7e120280u,
+        0xf03c2108u, 0x00000900u,
+        0x7e000280u, 0x7e020309u, 0x7e040280u, 0x7e0602f2u,
+        0xf800000fu, 0x03020100u, 0xbf810000u,
+    };
+    ShaderResourceTable rt_atomic_image;
+    { ShaderResource image{}; image.cls = ResourceClass::StorageImage;
+      image.format = DataFormat::Uint32; image.num_components = 1;
+      image.binding = 4; image.img_dim = 1; image.width = 1; image.height = 1;
+      image.depth = 1; image.sgpr_base = 0; rt_atomic_image.resources.push_back(image); }
+    const std::vector<uint32_t> atomic_image_spv = recompile_fragment(
+        ps_image_atomic, std::size(ps_image_atomic), &rt_atomic_image);
+    if (atomic_image_spv.empty() || !has_opcode(atomic_image_spv, 60u) ||
+        !has_opcode(atomic_image_spv, 229u)) {
+        printf("  [FAIL] image_atomic_swap did not lower through OpImageTexelPointer/OpAtomicExchange\n");
+        return 1;
+    }
+    printf("  [ok]   image_atomic_swap lowers to a typed R32_UINT SPIR-V image atomic\n");
+
     // LDS array is sized from the shader's real allocation (#130), not a hardcoded 16 KB. A compute
     // kernel that uses ds_write/ds_read declares a Workgroup array; its length must be 4096 dwords
     // (16 KB) by default and rise to the requested size (clamped to the RDNA2 64 KB / 16384-dword max)

--- a/prosper/tests/test_shader_resources.cpp
+++ b/prosper/tests/test_shader_resources.cpp
@@ -106,6 +106,25 @@ static std::vector<uint32_t> storage_image_access_test_spirv(bool float_sampled_
     return s;
 }
 
+static std::vector<uint32_t> storage_image_atomic_test_spirv() {
+    // R32_UINT storage image -> OpImageTexelPointer -> OpAtomicExchange. The image variable is an
+    // operand of OpImageTexelPointer directly, so reflection must carry that provenance through the
+    // returned Image-storage pointer to the atomic read/write.
+    std::vector<uint32_t> s = {0x07230203u, 0x00010000u, 0, 24, 0};
+    emit(s, 15, {4, 20, 0x6e69616d, 0});                    // OpEntryPoint Fragment %20 "main"
+    emit(s, 21, {1, 32, 0});                               // %1 = u32
+    emit(s, 23, {2, 1, 2});                                // %2 = uvec2
+    emit(s, 25, {3, 1, 1, 0, 0, 0, 2, 33});               // %3 = storage 2D R32ui image
+    emit(s, 32, {4, 0, 3});                                // %4 = UniformConstant pointer to image
+    emit(s, 32, {5, 11, 1});                               // %5 = Image pointer to u32
+    emit(s, 59, {4, 6, 0});                                // %6 = image variable
+    emit(s, 71, {6, 34, 1}); emit(s, 71, {6, 33, 7});      // set 1 binding 7
+    emit(s, 43, {1, 7, 0});                                // %7 = 0 (sample/value)
+    emit(s, 60, {5, 8, 6, 9, 7});                          // %8 = OpImageTexelPointer %6
+    emit(s, 229, {1, 10, 8, 7, 7, 7});                     // %10 = atomicExchange %8
+    return s;
+}
+
 static bool has_issue(const DescriptorValidationReport& r, DescriptorIssueCode code) {
     for (const auto& issue : r.issues) if (issue.code == code) return true;
     return false;
@@ -382,6 +401,22 @@ int main() {
               float_storage_report.descriptors[0].storage_float &&
               float_storage_report.descriptors[1].storage_float,
           "storage-image reflection preserves the SPIR-V float sampled-type contract");
+    ShaderResource atomic_image = storage_src;
+    atomic_image.binding = 7;
+    atomic_image.format = DataFormat::Uint32;
+    atomic_image.num_components = 1;
+    ShaderResourceTable atomic_image_table;
+    atomic_image_table.resources = {atomic_image};
+    const auto atomic_image_report = validate_spirv_descriptor_interface(
+        storage_image_atomic_test_spirv(), &atomic_image_table, 1,
+        SpirvShaderStage::Fragment);
+    CHECK(atomic_image_report.ok() && atomic_image_report.descriptors.size() == 1 &&
+              atomic_image_report.descriptors[0].kind == SpirvDescriptorKind::StorageImage &&
+              atomic_image_report.descriptors[0].readable &&
+              atomic_image_report.descriptors[0].writable &&
+              atomic_image_report.descriptors[0].texel_access &&
+              !atomic_image_report.descriptors[0].storage_float,
+          "image-texel-pointer atomic reflects an exact readable+writable integer storage image");
     image_table.resources[0].size = 0;
     auto izr = validate_spirv_descriptor_interface(
         image_spv, &image_table, 1, SpirvShaderStage::Fragment);

--- a/prosper/tests/test_texture_sample_render.cpp
+++ b/prosper/tests/test_texture_sample_render.cpp
@@ -666,9 +666,10 @@ int main() {
         }
     }
 
-    // Astro Bot's exact IMAGE_ATOMIC_SWAP form. Every fragment exchanges the R32_UINT word with the
-    // same 1.0f bit pattern, so GLC's returned pre-operation value remains 1.0f and exports GREEN.
-    // This executes the translated OpImageTexelPointer/OpAtomicExchange against a real Vulkan image.
+    // Astro Bot's exact IMAGE_ATOMIC_SWAP form. Use a one-pixel target so exactly one fragment
+    // exchanges the R32_UINT word. The callback is the graphics->guest synchronization boundary:
+    // call one returns 0.5 and writes 1.0 to guest-visible storage; call two must then return that 1.0.
+    // This proves both real Vulkan execution and visibility across separate backend calls/CPU memory.
     {
         const uint32_t atomic_ps[] = {
             0x7e000280u,                         // v0 = x = 0
@@ -689,23 +690,43 @@ int main() {
         CHECK(!atomic_frag.empty() && atomic_frag[0] == 0x07230203u,
               "recompiled Astro image_atomic_swap fragment shader");
         if (!atomic_frag.empty()) {
-            const uint32_t initial_word = 0x3f800000u;
+            uint32_t storage_word = 0x3f000000u;   // initial 0.5f bits
             prosper::test::FrameResource resource;
             resource.binding = 4; resource.set = 1;
-            resource.tex_rgba = reinterpret_cast<const uint8_t*>(&initial_word);
+            resource.tex_rgba = reinterpret_cast<const uint8_t*>(&storage_word);
             resource.tw = 1; resource.th = 1;
             resource.texture_format = VK_FORMAT_R32_UINT;
             resource.is_storage_image = true;
+            resource.storage_image_writeback =
+                [&](const uint8_t* pixels, size_t bytes) {
+                    if (bytes == sizeof(storage_word))
+                        std::memcpy(&storage_word, pixels, sizeof(storage_word));
+                };
             prosper::test::BackendDraw draw;
             draw.vs = vert; draw.fs = atomic_frag; draw.R = {resource}; draw.vcount = 3;
-            const std::vector<uint8_t> pixels =
-                prosper::test::render_draws_rgba({draw}, W, H);
-            const uint8_t* center = pixels.size() == static_cast<size_t>(W) * H * 4
-                ? &pixels[(static_cast<size_t>(H / 2) * W + W / 2) * 4] : nullptr;
-            printf("  image_atomic_swap center=(%u,%u,%u)\n",
-                   center ? center[0] : 0, center ? center[1] : 0, center ? center[2] : 0);
-            CHECK(center && center[1] > 0x80 && center[0] < 0x40 && center[2] < 0x40,
-                  "R32_UINT image atomic executes and returns the pre-operation value to VDATA");
+            prosper::test::BackendSubmissionBatch storage_batch;
+            const std::vector<uint8_t> first =
+                prosper::test::render_draws_rgba(
+                    {draw}, 1, 1, nullptr, nullptr, false, nullptr,
+                    nullptr, nullptr, nullptr, &storage_batch, false);
+            const uint8_t* first_pixel = first.size() == 4 ? first.data() : nullptr;
+            printf("  image_atomic_swap first=(%u,%u,%u) guest=%08x\n",
+                   first_pixel ? first_pixel[0] : 0, first_pixel ? first_pixel[1] : 0,
+                   first_pixel ? first_pixel[2] : 0, storage_word);
+            CHECK(first_pixel && first_pixel[1] > 0x60 && first_pixel[1] < 0xa0 &&
+                      first_pixel[0] < 0x40 && first_pixel[2] < 0x40,
+                  "R32_UINT image atomic returns the pre-operation 0.5 value to VDATA");
+            CHECK(storage_word == 0x3f800000u,
+                  "graphics storage-image atomic writes back exact texels to CPU/guest memory");
+            CHECK(!storage_batch.pending(),
+                  "storage-image writeback flushes an otherwise deferred live-render batch");
+            draw.R[0].tex_rgba = reinterpret_cast<const uint8_t*>(&storage_word);
+            const std::vector<uint8_t> second =
+                prosper::test::render_draws_rgba({draw}, 1, 1);
+            const uint8_t* second_pixel = second.size() == 4 ? second.data() : nullptr;
+            CHECK(second_pixel && second_pixel[1] > 0xc0 &&
+                      second_pixel[0] < 0x40 && second_pixel[2] < 0x40,
+                  "a later graphics call observes the prior storage-image writeback");
         }
     }
 

--- a/prosper/tests/test_texture_sample_render.cpp
+++ b/prosper/tests/test_texture_sample_render.cpp
@@ -123,6 +123,9 @@ int main() {
               "native R8 sampled upload broadcasts its channel without RGBA expansion");
         CHECK(prosper::test::backend_color_bytes_per_pixel(VK_FORMAT_R8_UNORM) == 1,
               "native R8 upload accounts one byte per texel");
+        CHECK(prosper::test::backend_color_format(VK_FORMAT_R32_UINT) == VK_FORMAT_R32_UINT &&
+                  prosper::test::backend_color_bytes_per_pixel(VK_FORMAT_R32_UINT) == 4,
+              "R32_UINT storage images retain their typed four-byte Vulkan format");
     }
 
     // The live renderer commonly submits hundreds of draws that reference the same few decoded
@@ -660,6 +663,49 @@ int main() {
             const auto storage_stats = prosper::test::backend_texture_upload_stats();
             CHECK(storage_stats.references == 2 && storage_stats.unique_uploads == 2,
                   "sampled and storage descriptors never share an incompatible image upload");
+        }
+    }
+
+    // Astro Bot's exact IMAGE_ATOMIC_SWAP form. Every fragment exchanges the R32_UINT word with the
+    // same 1.0f bit pattern, so GLC's returned pre-operation value remains 1.0f and exports GREEN.
+    // This executes the translated OpImageTexelPointer/OpAtomicExchange against a real Vulkan image.
+    {
+        const uint32_t atomic_ps[] = {
+            0x7e000280u,                         // v0 = x = 0
+            0x7e020280u,                         // v1 = y = 0
+            0x7e1202ffu, 0x3f800000u,           // v9 = exchange value (1.0f bits)
+            0xf03c2108u, 0x00000900u,           // image_atomic_swap v9,[v0,v1],s[0:7] glc dmask:x 2D
+            0x7e000280u, 0x7e020309u,           // R=0, G=returned v9
+            0x7e040280u, 0x7e0602f2u,           // B=0, A=1
+            0xf800000fu, 0x03020100u, 0xbf810000u,
+        };
+        ShaderResourceTable atomic_rt;
+        { ShaderResource image{}; image.cls = ResourceClass::StorageImage;
+          image.format = DataFormat::Uint32; image.num_components = 1;
+          image.binding = 4; image.img_dim = 1; image.width = 1; image.height = 1;
+          image.depth = 1; image.sgpr_base = 0; atomic_rt.resources.push_back(image); }
+        const std::vector<uint32_t> atomic_frag = recompile_fragment(
+            atomic_ps, std::size(atomic_ps), &atomic_rt);
+        CHECK(!atomic_frag.empty() && atomic_frag[0] == 0x07230203u,
+              "recompiled Astro image_atomic_swap fragment shader");
+        if (!atomic_frag.empty()) {
+            const uint32_t initial_word = 0x3f800000u;
+            prosper::test::FrameResource resource;
+            resource.binding = 4; resource.set = 1;
+            resource.tex_rgba = reinterpret_cast<const uint8_t*>(&initial_word);
+            resource.tw = 1; resource.th = 1;
+            resource.texture_format = VK_FORMAT_R32_UINT;
+            resource.is_storage_image = true;
+            prosper::test::BackendDraw draw;
+            draw.vs = vert; draw.fs = atomic_frag; draw.R = {resource}; draw.vcount = 3;
+            const std::vector<uint8_t> pixels =
+                prosper::test::render_draws_rgba({draw}, W, H);
+            const uint8_t* center = pixels.size() == static_cast<size_t>(W) * H * 4
+                ? &pixels[(static_cast<size_t>(H / 2) * W + W / 2) * 4] : nullptr;
+            printf("  image_atomic_swap center=(%u,%u,%u)\n",
+                   center ? center[0] : 0, center ? center[1] : 0, center ? center[2] : 0);
+            CHECK(center && center[1] > 0x80 && center[0] < 0x40 && center[2] < 0x40,
+                  "R32_UINT image atomic executes and returns the pre-operation value to VDATA");
         }
     }
 

--- a/prosper/tests/test_texture_sample_render.cpp
+++ b/prosper/tests/test_texture_sample_render.cpp
@@ -690,37 +690,52 @@ int main() {
         CHECK(!atomic_frag.empty() && atomic_frag[0] == 0x07230203u,
               "recompiled Astro image_atomic_swap fragment shader");
         if (!atomic_frag.empty()) {
-            uint32_t storage_word = 0x3f000000u;   // initial 0.5f bits
+            uint32_t return_word = 0x3f000000u;   // initial 0.5f bits
             prosper::test::FrameResource resource;
             resource.binding = 4; resource.set = 1;
-            resource.tex_rgba = reinterpret_cast<const uint8_t*>(&storage_word);
+            resource.tex_rgba = reinterpret_cast<const uint8_t*>(&return_word);
             resource.tw = 1; resource.th = 1;
             resource.texture_format = VK_FORMAT_R32_UINT;
             resource.is_storage_image = true;
-            resource.storage_image_writeback =
-                [&](const uint8_t* pixels, size_t bytes) {
-                    if (bytes == sizeof(storage_word))
-                        std::memcpy(&storage_word, pixels, sizeof(storage_word));
-                };
             prosper::test::BackendDraw draw;
             draw.vs = vert; draw.fs = atomic_frag; draw.R = {resource}; draw.vcount = 3;
-            prosper::test::BackendSubmissionBatch storage_batch;
-            const std::vector<uint8_t> first =
-                prosper::test::render_draws_rgba(
-                    {draw}, 1, 1, nullptr, nullptr, false, nullptr,
-                    nullptr, nullptr, nullptr, &storage_batch, false);
-            const uint8_t* first_pixel = first.size() == 4 ? first.data() : nullptr;
-            printf("  image_atomic_swap first=(%u,%u,%u) guest=%08x\n",
-                   first_pixel ? first_pixel[0] : 0, first_pixel ? first_pixel[1] : 0,
-                   first_pixel ? first_pixel[2] : 0, storage_word);
-            CHECK(first_pixel && first_pixel[1] > 0x60 && first_pixel[1] < 0xa0 &&
-                      first_pixel[0] < 0x40 && first_pixel[2] < 0x40,
+            const std::vector<uint8_t> returned =
+                prosper::test::render_draws_rgba({draw}, 1, 1);
+            const uint8_t* returned_pixel = returned.size() == 4 ? returned.data() : nullptr;
+            CHECK(returned_pixel && returned_pixel[1] > 0x60 &&
+                      returned_pixel[1] < 0xa0 && returned_pixel[0] < 0x40 &&
+                      returned_pixel[2] < 0x40,
                   "R32_UINT image atomic returns the pre-operation 0.5 value to VDATA");
-            CHECK(storage_word == 0x3f800000u,
+
+            // Keep the upload source distinct from the callback destination. This prevents the test
+            // from passing merely because a mutable source variable was updated in place.
+            const uint32_t upload_word = 0x3f000000u;
+            uint32_t guest_word = upload_word;
+            resource.tex_rgba = reinterpret_cast<const uint8_t*>(&upload_word);
+            resource.storage_image_writeback =
+                [&](const uint8_t* pixels, size_t bytes) {
+                    if (bytes == sizeof(guest_word))
+                        std::memcpy(&guest_word, pixels, sizeof(guest_word));
+                };
+            draw.vs = vert; draw.fs = atomic_frag; draw.R = {resource}; draw.vcount = 3;
+            constexpr uint64_t storage_target_id = 0x41544f4d49430001ull;
+            prosper::test::BackendColorTarget storage_target{
+                storage_target_id, false, false};
+            prosper::test::BackendSubmissionBatch storage_batch;
+            const std::vector<uint8_t> storage_only =
+                prosper::test::render_draws_rgba(
+                    {draw}, 1, 1, nullptr, nullptr, false, &storage_target,
+                    nullptr, nullptr, nullptr, &storage_batch, false);
+            const auto storage_stats = prosper::test::backend_color_target_stats();
+            printf("  image_atomic_swap storage-only guest=%08x source=%08x\n",
+                   guest_word, upload_word);
+            CHECK(storage_only.empty() && storage_stats.readbacks == 0,
+                  "storage-image synchronization does not rely on a color readback");
+            CHECK(upload_word == 0x3f000000u && guest_word == 0x3f800000u,
                   "graphics storage-image atomic writes back exact texels to CPU/guest memory");
             CHECK(!storage_batch.pending(),
                   "storage-image writeback flushes an otherwise deferred live-render batch");
-            draw.R[0].tex_rgba = reinterpret_cast<const uint8_t*>(&storage_word);
+            draw.R[0].tex_rgba = reinterpret_cast<const uint8_t*>(&guest_word);
             const std::vector<uint8_t> second =
                 prosper::test::render_draws_rgba({draw}, 1, 1);
             const uint8_t* second_pixel = second.size() == 4 ? second.data() : nullptr;

--- a/prosper/tools/spv_validate/spv_validate.cpp
+++ b/prosper/tools/spv_validate/spv_validate.cpp
@@ -97,6 +97,15 @@ int main(int argc, char** argv) {
       ShaderResourceTable rt; ShaderResource t{}; t.cls=ResourceClass::Texture; t.format=DataFormat::Float32;
       t.num_components=4; t.binding=4; t.img_dim=1; t.width=2; t.height=2; t.sgpr_base=8; rt.resources.push_back(t);
       dump(dir, "fragment_texture", recompile_fragment(c, sizeof(c)/4, &rt)); }
+    // Fragment: Astro Bot R32_UINT image_atomic_swap with GLC return.
+    { const uint32_t c[] = {0x7e000280u,0x7e020280u,0x7e1202ffu,0x3f800000u,
+                            0xf03c2108u,0x00000900u,0x7e000280u,0x7e020309u,
+                            0x7e040280u,0x7e0602f2u,0xf800000fu,0x03020100u,0xbf810000u};
+      ShaderResourceTable rt; ShaderResource image{}; image.cls=ResourceClass::StorageImage;
+      image.format=DataFormat::Uint32; image.num_components=1; image.binding=4;
+      image.img_dim=1; image.width=1; image.height=1; image.depth=1; image.sgpr_base=0;
+      rt.resources.push_back(image);
+      dump(dir, "fragment_image_atomic", recompile_fragment(c, sizeof(c)/4, &rt)); }
     // Fragment: image_sample a 3D texture (3 coords) -> mrt0. (shader_028 pattern)
     { const uint32_t c[] = {0x7E0002FFu,0x3E800000u,0x7E0202FFu,0x3E800000u,0x7E0402FFu,0x3E800000u,
                             0xF0800F10u,0x00400000u,0xF800180Fu,0x03020100u,0xBF810000u};


### PR DESCRIPTION
## What changed

- decode the MIMG GLC bit and classify `IMAGE_ATOMIC_SWAP` uses as storage images
- lower Astro Bot's exact 2D R32_UINT atomic-swap form to typed SPIR-V `OpImageTexelPointer` + `OpAtomicExchange`
- reflect atomic image access as readable/writable and bind byte-exact `VK_FORMAT_R32_UINT` storage views
- copy writable graphics storage-image results back through coherent staging, restore the guest surface layout, and publish the normal guest-write invalidation event
- invalidate overlapping submit-local storage and sampled decode aliases after writeback so stale pixels cannot be re-uploaded
- keep storage images out of sampled render-target injection paths that can silently change their format
- add decode, resource discovery, reflection, SPIR-V structure/validation, real Vulkan execution, and cross-call visibility coverage

## Why

Astro Bot's world-map path uses MIMG opcode `0x0f`, which is `IMAGE_ATOMIC_SWAP` (the provisional investigation had misidentified it as `image_get_lod`). The recompiler rejected the instruction and dropped the complete draw. The implementation is deliberately gated to the observed non-NSA 2D R32_UINT form so unsupported atomic variants remain fail-visible.

Writable graphics storage images are guest memory. The backend therefore synchronizes and writes the final texels back before returning, so later graphics/sampled aliases, compute, DMA, and CPU consumers observe the side effect and subsequent guest writes follow the established invalidation path.

With this change, the shader advances past the former atomic rejection. The live run reaches `LevelDocument Loaded: worldmap`; its next rejection is a distinct instruction at PC 109, giving the follow-up investigation a clean boundary. The intro remains visually correct with no checkerboard artifact.

Closes #962

## Validation

- built `prosper-app` in distrobox
- `test_rdna2_decode`
- `test_dynfetch_fold`
- `test_rdna2_spirv_struct`
- `test_shader_resources`
- `test_texture_sample_render` on RADV, including exact pre-operation return, storage-only synchronization with color readback disabled, distinct upload/writeback backing, and visibility to a later graphics call
- `spv_validate` / `spirv-val` for all generated fixtures, including `fragment_image_atomic`
- live Astro Bot run through title and world-map load; the previous instance remained stable past 12,800 rendered frames

Snapshot tests were intentionally not run: repository policy makes them optional for day-to-day PRs and mandatory before releases.