### PR TITLE
fix(gpu): support three-dword raw buffer stores

### DIFF
--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -2099,7 +2099,7 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                 // live at the instruction and resolves by exact pc, avoiding a duplicate stale SRT use.
                 const bool raw_buffer_use = !is_mtbuf &&
                     ((in.opcode >= 0x08 && in.opcode <= 0x0F) ||
-                     (in.opcode >= 0x1C && in.opcode <= 0x1E));
+                     (in.opcode >= 0x1C && in.opcode <= 0x1F));
                 const bool format_store_use = in.opcode >= 0x04 && in.opcode <= 0x07;
                 const bool atomic_buffer_use = in.opcode == 0x38; // buffer_atomic_umax
                 if (srt_uses && (format_store_use || raw_buffer_use || atomic_buffer_use)) {

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -6142,6 +6142,8 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 case 0x1C: n = 1; is_store = true; break;   // buffer_store_dword
                 case 0x1D: n = 2; is_store = true; break;   // buffer_store_dwordx2
                 case 0x1E: n = 4; is_store = true; break;   // buffer_store_dwordx4
+                case 0x1F: n = 3; is_store = true; break;   // buffer_store_dwordx3 (like loads,
+                                                            // x3 sorts after x4 in this ISA)
                 case 0x4: n = 1; is_format = true; is_store = true; break;   // buffer_store_format_x
                 case 0x5: n = 2; is_format = true; is_store = true; break;   // buffer_store_format_xy
                 case 0x6: n = 3; is_format = true; is_store = true; break;   // buffer_store_format_xyz

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -826,6 +826,23 @@ int main() {
               decode_buffer_descriptor(patched_raw_uses[0].v4.data()).num_records == 1,
           "Astro patched direct raw-MUBUF V# resolves by its exact consuming pc");
 
+    // Astro Bot world-map PS consumes its direct s[16:19] V# with the raw x3 store at pc109.
+    // Discovery must publish the binding before the recompiler can emit the otherwise-supported store.
+    const uint32_t astro_store_x3[] = {
+        0xE07C2000u, 0x8004030Au,   // buffer_store_dwordx3 v[3:5], v10, s[16:19], 0 idxen
+        0xBF810000u,
+    };
+    std::vector<SrtUse> astro_store_x3_uses;
+    resolve_dynamic_fetch(astro_store_x3, std::size(astro_store_x3),
+                          patched_raw_seed, std::size(patched_raw_seed), 8,
+                          &astro_store_x3_uses);
+    CHECK(astro_store_x3_uses.size() == 1 && astro_store_x3_uses[0].kind == 1 &&
+              astro_store_x3_uses[0].use_pc == 0 &&
+              astro_store_x3_uses[0].key == 0xFFFFFFFFu &&
+              astro_store_x3_uses[0].v4[0] == patched_raw_seed[8] &&
+              astro_store_x3_uses[0].v4[1] == patched_raw_seed[9],
+          "Astro buffer_store_dwordx3 publishes its direct V# by exact consumer pc");
+
     // #636: Dead Cells' format-copy compute places its declared source V# at s0 and its otherwise
     // undeclared destination V# at s4. Resource discovery must follow the two actual MUBUF uses:
     // the load arrives through DynFetch and the store through a pc-keyed SrtUse. No all-SGPR scan is

--- a/prosper/tests/test_rdna2_decode.cpp
+++ b/prosper/tests/test_rdna2_decode.cpp
@@ -103,6 +103,14 @@ int main() {
           isS(mb.src[1], 8) && ((mb.literal >> 12) & 1u), "buffer_load_dwordx4 MUBUF op/VDATA/VADDR/SRSRC/offen");
     CHECK(mb.src[2].kind == OperandKind::InlineInt && mb.src[2].value == 0,
           "MUBUF SOFFSET 0x80 decodes as inline 0, not SGPR s0");
+    // Astro Bot world-map PS, exact final packet: buffer_store_dwordx3
+    // v[3:5], v10, s[16:19], 0 idxen. Raw x3 stores use opcode 0x1f, after x4.
+    const uint32_t astro_store_x3[] = { 0xe07c2000u, 0x8004030au };
+    Rdna2Inst store_x3 = rdna2_decode_one(astro_store_x3, 2);
+    CHECK(store_x3.fmt == Rdna2Format::MUBUF && store_x3.opcode == 0x1fu &&
+              isV(store_x3.dst, 3) && isV(store_x3.src[0], 10) &&
+              isS(store_x3.src[1], 16) && ((store_x3.literal >> 13) & 1u),
+          "Astro buffer_store_dwordx3 decodes VDATA/VADDR/SRSRC and IDXEN exactly");
     // gfx1030 llvm-mc: tbuffer_load_format_xy v[4:5], v2, s[8:11], s12
     // format:[BUF_FMT_16_16_FLOAT] offen offset:52. MTBUF uses the Gen5 combined format 29,
     // not the old split DFMT=13/NFMT=1 interpretation of those same seven bits.

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -1309,6 +1309,32 @@ int main() {
       printf("  kernel29 mismatches=%u (buf[5]=%g expect=10)\n", bad29, f5); }
     CHECK(stored_out.size() == N && bad29 == 0, "recompiled kernel 29 (MUBUF store writes buffer[gid]=2*gid) correct");
 
+    // Astro Bot world-map PS exact final MUBUF packet. Every lane writes three consecutive raw
+    // dwords to one 12-byte record, proving both the unusual x3 component count and IDXEN stride.
+    const uint32_t code29x3[] = {
+        0x7e140f00u,                         // v10 = (uint)v0 = invocation index
+        0x7e060281u, 0x7e080282u, 0x7e0a0283u, // v3/v4/v5 = 1/2/3
+        0xe07c2000u, 0x8004030au,           // exact Astro buffer_store_dwordx3 packet
+        0xbf810000u,
+    };
+    ShaderResourceTable rt29x3;
+    { ShaderResource dst{}; dst.cls = ResourceClass::ConstantBuffer;
+      dst.format = DataFormat::Uint32; dst.num_components = 1;
+      dst.binding = 3; dst.stride = 12; dst.sgpr_base = 16;
+      rt29x3.resources.push_back(dst); }
+    std::vector<uint32_t> spv29x3 = recompile_valu(
+        code29x3, std::size(code29x3), 1, 0, &rt29x3);
+    CHECK(!spv29x3.empty(),
+          "recompiled exact Astro buffer_store_dwordx3 packet -> SPIR-V");
+    std::vector<uint32_t> stored29x3(N * 3, 0u), stored29x3_out;
+    prosper::test::run_compute(spv29x3, in29, N, N, {}, stored29x3, &stored29x3_out);
+    uint32_t bad29x3 = 0;
+    for (uint32_t lane = 0; lane < N && stored29x3_out.size() == N * 3; ++lane)
+        for (uint32_t component = 0; component < 3; ++component)
+            bad29x3 += stored29x3_out[lane * 3 + component] != component + 1;
+    CHECK(stored29x3_out.size() == N * 3 && bad29x3 == 0,
+          "buffer_store_dwordx3 writes all three dwords of every indexed record");
+
     const uint32_t code29mt[] = {
         0x7e040f00u, 0x06060100u, 0xe8b42000u, 0x80020302u, 0xbf810000u,
     };

--- a/prosper/tests/test_recompile_coverage.cpp
+++ b/prosper/tests/test_recompile_coverage.cpp
@@ -175,6 +175,19 @@ int main() {
           mtbuf_tfe.unsupported == 1 && mtbuf_tfe.first_bad_op == 0u,
           "MTBUF TFE remains explicit unsupported coverage until its status write is modeled");
 
+    // Astro Bot world-map PS ends with this exact raw x3 store. The table-less coverage shell uses
+    // its conventional binding 2, so accepting the instruction must classify it as handled ALU/memory
+    // rather than the shader's sole unsupported opcode.
+    const uint32_t astro_store_x3[] = {
+        0xE07C2000u, 0x8004030Au, 0xBF810000u,
+    };
+    RecompileCoverage x3_store = recompile_coverage(
+        astro_store_x3, std::size(astro_store_x3));
+    CHECK(x3_store.total == 1 && x3_store.alu == 1 &&
+              x3_store.table_dependent == 0 && x3_store.unsupported == 0 &&
+              x3_store.first_bad_fmt < 0,
+          "Astro buffer_store_dwordx3 is covered as a supported raw memory operation");
+
     // The common compiler spill/fill form uses a fixed byte offset and one unmodified scalar base.
     // The host shader maps that private storage to one per-invocation Function array.
     const uint32_t scratch_static[] = {

--- a/prosper/tools/spv_validate/spv_validate.cpp
+++ b/prosper/tools/spv_validate/spv_validate.cpp
@@ -131,6 +131,13 @@ int main(int argc, char** argv) {
       ShaderResourceTable rt; ShaderResource vb{}; vb.cls=ResourceClass::VertexBuffer; vb.format=DataFormat::Float32;
       vb.num_components=1; vb.binding=3; vb.stride=4; vb.sgpr_base=8; rt.resources.push_back(vb);
       dump(dir, "compute_store", recompile_valu(c, sizeof(c)/4, 1, 0, &rt)); }
+    // Astro Bot exact raw buffer_store_dwordx3 packet.
+    { const uint32_t c[] = {0x7e140f00u,0x7e060281u,0x7e080282u,0x7e0a0283u,
+                            0xe07c2000u,0x8004030au,0xbf810000u};
+      ShaderResourceTable rt; ShaderResource dst{}; dst.cls=ResourceClass::ConstantBuffer;
+      dst.format=DataFormat::Uint32; dst.num_components=1; dst.binding=3;
+      dst.stride=12; dst.sgpr_base=16; rt.resources.push_back(dst);
+      dump(dir, "compute_store_x3", recompile_valu(c, sizeof(c)/4, 1, 0, &rt)); }
     // Compute EXEC-predicated store (v_cmpx + guard execz + store).
     { const uint32_t c[] = {0x7e040f00u,0x06060100u,0x7e0a0284u,0x7da20b02u,0xbf880002u,0xe0102000u,0x80020302u,0xbf810000u};
       ShaderResourceTable rt; ShaderResource vb{}; vb.cls=ResourceClass::VertexBuffer; vb.format=DataFormat::Float32;


### PR DESCRIPTION
Closes #1453

## Failure scenario

Astro Bot reaches `worldmap`, then compute program `0x50054b600` consumes the exact packet `e07c2000 8004030a` (`buffer_store_dwordx3 v[3:5], v10, s[16:19], 0 idxen`). The decoder recognized the MUBUF packet, but the recompiler did not classify opcode `0x1f` as a raw store and dynamic resource discovery did not publish its live V# descriptor. The program therefore failed visibly at pc 109 instead of executing.

## What changed

- lower raw MUBUF opcode `0x1f` as a three-component storage-buffer write
- include the opcode in exact-PC dynamic V# resource discovery
- add the captured Astro packet to decode, discovery, coverage, SPIR-V validation, and real Vulkan execution tests
- verify the Vulkan path writes all three dwords of every indexed 12-byte record

## Behavioral contract and risk

This extends the existing raw dword/x2/x4 store path with the ISA's x3 component count; addressing, bounds checks, EXEC predication, writeback, and descriptor resolution stay on the established path. Other MUBUF opcodes and typed MTBUF stores are unaffected. The main risk is an incorrect component count or resource binding, covered by exact-packet decode/discovery checks and GPU execution over 128 indexed records.

## Validation

Built in the `ps5ys` distrobox:

- `cmake --build prosper/build-astrobot-fmv --target test_rdna2_decode test_dynfetch_fold test_recompile_coverage test_rdna2_to_spirv spv_validate prosper-app`
- `prosper/build-astrobot-fmv/test_rdna2_decode`
- `prosper/build-astrobot-fmv/test_dynfetch_fold`
- `prosper/build-astrobot-fmv/test_recompile_coverage`
- `prosper/build-astrobot-fmv/test_rdna2_to_spirv`
- `prosper/build-astrobot-fmv/spv_validate prosper/build-astrobot-fmv`
- live Linux/Vulkan `prosper-app` run with realtime audio and `scripts/astrobot/reach-first-level.pad`: reached `LevelDocument Loaded: worldmap [worldmap]`; the former exact pc-109 `buffer_store_dwordx3` rejection was absent and later independent shader gaps remained fail-visible
- `git diff --check`

The world map remains visually black/dark, so this PR does not claim new visible progression and has no representative screenshot. Snapshot tests were intentionally not run: this is day-to-day development, not a release.