### PR TITLE
fix(gpu): honor fragment Wave32 mode

### DIFF
--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -343,13 +343,15 @@ std::vector<uint32_t> recompile_graphics_shader_cached(ShaderProgramStage stage,
                                                        const ShaderResourceTable* resources = nullptr,
                                                        const PixelInputMapping* pixel_inputs = nullptr,
                                                        const PixelSystemInputMapping* system_inputs = nullptr,
-                                                       uint64_t* cache_identity = nullptr);
+                                                       uint64_t* cache_identity = nullptr,
+                                                       bool fragment_wave32 = false);
 SharedShaderWords recompile_graphics_shader_cached_shared(
     ShaderProgramStage stage, const uint32_t* code, size_t dwords,
     const ShaderResourceTable* resources = nullptr,
     const PixelInputMapping* pixel_inputs = nullptr,
     const PixelSystemInputMapping* system_inputs = nullptr,
-    uint64_t* cache_identity = nullptr);
+    uint64_t* cache_identity = nullptr,
+    bool fragment_wave32 = false);
 // Compute uses the same bounded content-addressed cache as graphics. Launch geometry that changes
 // generated SPIR-V participates in the key; per-dispatch push-constant values deliberately do not.
 std::vector<uint32_t> recompile_compute_shader_cached(
@@ -812,14 +814,16 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
             max_shader_dwords, vrt.get(), pixel_input_ptr, nullptr, &vs_identity);
         fs_shared = recompile_graphics_shader_cached_shared(
             ShaderProgramStage::Fragment, (const uint32_t*)(uintptr_t)rs.ps_addr,
-            max_shader_dwords, prt.get(), nullptr, system_input_ptr, &fs_identity);
+            max_shader_dwords, prt.get(), nullptr, system_input_ptr, &fs_identity,
+            rs.ps_wave32);
     } else {
         vs = recompile_graphics_shader_cached(
             ShaderProgramStage::Vertex, (const uint32_t*)(uintptr_t)vs_program_addr,
             max_shader_dwords, vrt.get(), pixel_input_ptr, nullptr, &vs_identity);
         fs = recompile_graphics_shader_cached(
             ShaderProgramStage::Fragment, (const uint32_t*)(uintptr_t)rs.ps_addr,
-            max_shader_dwords, prt.get(), nullptr, system_input_ptr, &fs_identity);
+            max_shader_dwords, prt.get(), nullptr, system_input_ptr, &fs_identity,
+            rs.ps_wave32);
     }
     // CB_COLOR_CONTROL.DCC_DECOMPRESS interprets the bound AGC metadata helper, rather than its
     // ordinary fragment-color export. The operation bits can remain folded into a later graphics

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -160,6 +160,7 @@ struct ShaderCompileKey {
     PixelInputMapping pixel_inputs{};
     bool has_system_inputs = false;
     PixelSystemInputMapping system_inputs{};
+    bool fragment_wave32 = false;
     bool has_pcrel_dispatch = false;
     uint32_t pcrel_dispatch_target = UINT32_MAX;
     // Compute modules also depend on launch ABI shape. User SGPR VALUES are push constants and stay
@@ -194,6 +195,7 @@ struct ShaderCompileKey {
                pixel_inputs == other.pixel_inputs &&
                has_system_inputs == other.has_system_inputs &&
                system_inputs == other.system_inputs &&
+               fragment_wave32 == other.fragment_wave32 &&
                has_pcrel_dispatch == other.has_pcrel_dispatch &&
                pcrel_dispatch_target == other.pcrel_dispatch_target &&
                has_compute_config == other.has_compute_config &&
@@ -252,6 +254,7 @@ struct ShaderCompileKeyHash {
             hash = hash_mix(hash, key.system_inputs.ena);
             hash = hash_mix(hash, key.system_inputs.addr);
         }
+        hash = hash_mix(hash, key.fragment_wave32);
         hash = hash_mix(hash, key.has_pcrel_dispatch);
         if (key.has_pcrel_dispatch) hash = hash_mix(hash, key.pcrel_dispatch_target);
         hash = hash_mix(hash, key.has_compute_config);
@@ -827,7 +830,8 @@ ShaderCompileKey make_shader_compile_key(ShaderProgramStage stage, const uint32_
                                          const ShaderResourceTable* resources,
                                          const PixelInputMapping* pixel_inputs,
                                          const PixelSystemInputMapping* system_inputs,
-                                         const ComputeShaderConfig* compute_config = nullptr) {
+                                         const ComputeShaderConfig* compute_config = nullptr,
+                                         bool fragment_wave32 = false) {
     ShaderCompileKey key;
     key.stage = stage;
     key.has_resource_table = resources != nullptr;
@@ -836,6 +840,7 @@ ShaderCompileKey make_shader_compile_key(ShaderProgramStage stage, const uint32_
     if (key.has_pixel_inputs) key.pixel_inputs = *pixel_inputs;
     key.has_system_inputs = stage == ShaderProgramStage::Fragment && system_inputs != nullptr;
     if (key.has_system_inputs) key.system_inputs = *system_inputs;
+    key.fragment_wave32 = stage == ShaderProgramStage::Fragment && fragment_wave32;
     key.has_compute_config = stage == ShaderProgramStage::Compute && compute_config;
     if (key.has_compute_config) {
         key.compute_user_sgpr_count = static_cast<uint32_t>(compute_config->user_sgprs.size());
@@ -939,7 +944,8 @@ std::vector<uint32_t> compile_graphics_shader(ShaderProgramStage stage, const Sh
     if (stage == ShaderProgramStage::Fragment)
         return recompile_fragment(code, code_size, resources,
                                   key.has_system_inputs ? &key.system_inputs : nullptr,
-                                  key.has_pcrel_dispatch ? key.pcrel_dispatch_target : UINT32_MAX);
+                                  key.has_pcrel_dispatch ? key.pcrel_dispatch_target : UINT32_MAX,
+                                  nullptr, key.fragment_wave32);
     return {};
 }
 
@@ -1067,10 +1073,11 @@ FragmentInterpolationLayout fragment_interpolation_layout_cached(
 SharedShaderWords recompile_graphics_shader_cached_shared(
         ShaderProgramStage stage, const uint32_t* code, size_t dwords,
         const ShaderResourceTable* resources, const PixelInputMapping* pixel_inputs,
-        const PixelSystemInputMapping* system_inputs, uint64_t* cache_identity) {
+        const PixelSystemInputMapping* system_inputs, uint64_t* cache_identity,
+        bool fragment_wave32) {
     if (cache_identity) *cache_identity = 0;
     ShaderCompileKey key = make_shader_compile_key(stage, code, dwords, resources, pixel_inputs,
-                                                   system_inputs);
+                                                   system_inputs, nullptr, fragment_wave32);
     if (getenv("PROSPER_NO_SHADER_CACHE")) {
         auto& cache = shader_cache();
         {
@@ -1131,9 +1138,11 @@ SharedShaderWords recompile_graphics_shader_cached_shared(
 std::vector<uint32_t> recompile_graphics_shader_cached(
         ShaderProgramStage stage, const uint32_t* code, size_t dwords,
         const ShaderResourceTable* resources, const PixelInputMapping* pixel_inputs,
-        const PixelSystemInputMapping* system_inputs, uint64_t* cache_identity) {
+        const PixelSystemInputMapping* system_inputs, uint64_t* cache_identity,
+        bool fragment_wave32) {
     SharedShaderWords words = recompile_graphics_shader_cached_shared(
-        stage, code, dwords, resources, pixel_inputs, system_inputs, cache_identity);
+        stage, code, dwords, resources, pixel_inputs, system_inputs, cache_identity,
+        fragment_wave32);
     return words ? *words : std::vector<uint32_t>{};
 }
 

--- a/prosper/src/gpu/pm4_registers.hpp
+++ b/prosper/src/gpu/pm4_registers.hpp
@@ -319,6 +319,10 @@ constexpr uint32_t SPI_PS_INPUT_ENA       = 0x1B3;
 constexpr uint32_t SPI_PS_INPUT_ADDR      = 0x1B4;
 constexpr uint32_t SPI_INTERP_CONTROL_0   = 0x1B5;
 constexpr uint32_t SPI_PS_IN_CONTROL      = 0x1B6;
+// GFX10/RDNA: PS_W32_EN selects Wave32 fragment execution. Clear selects Wave64. This is the
+// authoritative mode for low-half EXEC/VCC mask instructions (AMD/LLVM S_0286D8_PS_W32_EN).
+constexpr uint32_t SPI_PS_IN_CONTROL_PS_W32_EN_SHIFT = 15;
+constexpr uint32_t SPI_PS_IN_CONTROL_PS_W32_EN_MASK  = 0x1;
 constexpr uint32_t SPI_BARYC_CNTL         = 0x1B8;
 constexpr uint32_t SPI_TMPRING_SIZE       = 0x1BA;
 constexpr uint32_t SPI_SHADER_IDX_FORMAT  = 0x1C2;

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -9889,7 +9889,7 @@ static std::vector<uint32_t> recompile_fragment_impl(
         const PixelSystemInputMapping* system_inputs,
         uint32_t pcrel_dispatch_target,
         const FragmentInterpolationLayout* interpolation,
-        bool allow_test_wave32) {
+        bool wave32) {
     std::vector<Rdna2Inst> ins;
     const size_t program_dwords = rdna2_walk(code, dwords, ins);
     if (pcrel_dispatch_target != UINT32_MAX) {
@@ -9942,10 +9942,10 @@ static std::vector<uint32_t> recompile_fragment_impl(
     }
     SpirvCompute b;
     b.begin_fragment(rt, color_mask);
-    // Graphics wave mode is not yet plumbed from the stage registers. Keep low-half EXEC/VCC mask
-    // semantics restricted to the complete captured Astro material shader that demonstrated the
-    // Wave32 idiom. Arbitrary graphics shaders retain the previous fail-visible rejection.
-    b.allow_b32_masks = allow_test_wave32 ||
+    // SPI_PS_IN_CONTROL.PS_W32_EN proves that EXEC_HI/VCC_HI are unused and the low-half mask
+    // operations below represent the complete wave. Keep the older byte-exact captured exception
+    // until every replay/capture producer carries the stage register into this entry point.
+    b.allow_b32_masks = wave32 ||
         (program_dwords == 3142 &&
          shader_program_hash(code, program_dwords) == 0x616dd4c0b241fbb1ull);
     // Fragment I/O value tap (PROSPER_FS_TAP=draw:pc): redirect the MRT0 colour export to the intermediate
@@ -10082,9 +10082,10 @@ std::vector<uint32_t> recompile_fragment(const uint32_t* code, size_t dwords,
                                          const ShaderResourceTable* rt,
                                          const PixelSystemInputMapping* system_inputs,
                                          uint32_t pcrel_dispatch_target,
-                                         const FragmentInterpolationLayout* interpolation) {
+                                         const FragmentInterpolationLayout* interpolation,
+                                         bool wave32) {
     return recompile_fragment_impl(code, dwords, rt, system_inputs,
-                                   pcrel_dispatch_target, interpolation, false);
+                                   pcrel_dispatch_target, interpolation, wave32);
 }
 
 std::vector<uint32_t> recompile_fragment_wave32_for_test(

--- a/prosper/src/gpu/rdna2_to_spirv.hpp
+++ b/prosper/src/gpu/rdna2_to_spirv.hpp
@@ -218,10 +218,11 @@ std::vector<uint32_t> recompile_fragment(const uint32_t* code, size_t dwords,
                                          const ShaderResourceTable* rt = nullptr,
                                          const PixelSystemInputMapping* system_inputs = nullptr,
                                          uint32_t pcrel_dispatch_target = UINT32_MAX,
-                                         const FragmentInterpolationLayout* interpolation = nullptr);
+                                         const FragmentInterpolationLayout* interpolation = nullptr,
+                                         bool wave32 = false);
 
-// Test hook for the low-half EXEC/VCC mask path. Production graphics compilation enables it only
-// for byte-exact observed Wave32 shaders until the graphics wave-mode register is carried here.
+// Test hook for the low-half EXEC/VCC mask path. Production fragment compilation supplies the same
+// mode from SPI_PS_IN_CONTROL.PS_W32_EN.
 std::vector<uint32_t> recompile_fragment_wave32_for_test(
     const uint32_t* code, size_t dwords);
 

--- a/prosper/src/gpu/render_state.cpp
+++ b/prosper/src/gpu/render_state.cpp
@@ -112,6 +112,8 @@ RenderState extract_render_state(const GpuState& st) {
     }
     rs.ps_input_ena = rd(st.cx, P::SPI_PS_INPUT_ENA);
     rs.ps_input_addr = rd(st.cx, P::SPI_PS_INPUT_ADDR);
+    rs.ps_wave32 = PM4_FIELD(rd(st.cx, P::SPI_PS_IN_CONTROL),
+                             SPI_PS_IN_CONTROL, PS_W32_EN) != 0;
 
     // Color MRT 0 (context register file).
     rs.color0_base            = addr_of(rd(st.cx, P::CB_COLOR0_BASE), rd(st.cx, P::CB_COLOR0_BASE_EXT));

--- a/prosper/src/gpu/render_state.hpp
+++ b/prosper/src/gpu/render_state.hpp
@@ -33,6 +33,7 @@ struct RenderState {
     // are retained for the fragment recompiler.
     uint32_t ps_input_ena = 0;
     uint32_t ps_input_addr = 0;
+    bool ps_wave32 = false; // SPI_PS_IN_CONTROL.PS_W32_EN
 
     // Color MRT 0. format/number_type/comp_swap together select the VkFormat (see vk_translate).
     uint64_t color0_base        = 0;   // byte address (CB_COLOR0_BASE + BASE_EXT)

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -288,11 +288,12 @@ int main() {
     };
     if (!recompile_fragment(wave32_fragment_masks,
                             std::size(wave32_fragment_masks)).empty()) {
-        printf("  [FAIL] ungated graphics shader accepted Wave32 EXEC_LO/VCC_LO mask moves\n");
+        printf("  [FAIL] Wave64/default graphics shader accepted Wave32 EXEC_LO/VCC_LO masks\n");
         return 1;
     }
-    const auto wave32_fragment_spv = recompile_fragment_wave32_for_test(
-        wave32_fragment_masks, std::size(wave32_fragment_masks));
+    const auto wave32_fragment_spv = recompile_fragment(
+        wave32_fragment_masks, std::size(wave32_fragment_masks), nullptr, nullptr,
+        UINT32_MAX, nullptr, true);
     uint32_t wave32_fragment_bad_op = 0;
     if (wave32_fragment_spv.empty() ||
         !type_result_ids_are_nonzero(wave32_fragment_spv, &wave32_fragment_bad_op) ||
@@ -301,7 +302,7 @@ int main() {
                wave32_fragment_bad_op);
         return 1;
     }
-    printf("  [ok]   Wave32 fragment EXEC_LO/VCC_LO mask moves emit valid SPIR-V\n");
+    printf("  [ok]   registered Wave32 fragment EXEC_LO/VCC_LO mask moves emit valid SPIR-V\n");
 
     const uint32_t wave32_compute_masks[] = {
         0xbe80037eu,                         // s_mov_b32 s0, exec_lo

--- a/prosper/tests/test_render_state.cpp
+++ b/prosper/tests/test_render_state.cpp
@@ -137,6 +137,7 @@ int main() {
         { P::SPI_PS_INPUT_CNTL_0, 0x00000401u }, // PS input 0 <- PARAM1, flat
         { P::SPI_PS_INPUT_CNTL_0 + 1u, 0x00000320u }, // PS input 1 <- DEFAULT_VAL 1111
         { P::SPI_PS_INPUT_ENA, 0x00000303u }, // perspective sample/center + float position X/Y
+        { P::SPI_PS_IN_CONTROL, 1u << P::SPI_PS_IN_CONTROL_PS_W32_EN_SHIFT },
         { P::SPI_PS_INPUT_ADDR, 0x000003CFu }, // reserve disabled centroid/pull-model slots
         // #531: effective scissor is the intersection of screen/window/generic/viewport. Window and
         // viewport apply (-10,+5); generic disables the offset. Right/bottom are exclusive.
@@ -182,6 +183,7 @@ int main() {
           "programmed SPI_PS_INPUT_CNTL words and presence mask are retained");
     CHECK(rs.ps_input_ena == 0x00000303u && rs.ps_input_addr == 0x000003CFu,
           "SPI_PS_INPUT_ENA/ADDR system-value VGPR controls are retained");
+    CHECK(rs.ps_wave32, "SPI_PS_IN_CONTROL.PS_W32_EN is retained as fragment wave mode");
     CHECK(rs.spi_shader_col_format == 4u && rs.sx_ps_downconvert == 5u &&
           resolve_pipeline_state(rs).spi_shader_col_format == 4u &&
           resolve_pipeline_state(rs).sx_ps_downconvert == 5u,

--- a/prosper/tests/test_shader_recompile_cache.cpp
+++ b/prosper/tests/test_shader_recompile_cache.cpp
@@ -344,6 +344,27 @@ int main() {
               stats.misses == system_misses + 2,
           "pixel-system ENA/ADDR mappings participate in the fragment shader cache key");
 
+    // SPI_PS_IN_CONTROL.PS_W32_EN changes low-half EXEC/VCC semantics, so the same program and
+    // descriptor interface must not reuse a Wave64/default module under Wave32 (or vice versa).
+    const uint64_t wave_mode_hits = stats.hits;
+    const uint64_t wave_mode_misses = stats.misses;
+    uint64_t wave64_identity = 0, wave32_identity = 0, repeated_wave32_identity = 0;
+    const auto wave64_ps = recompile_graphics_shader_cached(
+        ShaderProgramStage::Fragment, kPs, std::size(kPs), nullptr, nullptr, nullptr,
+        &wave64_identity, false);
+    const auto wave32_ps = recompile_graphics_shader_cached(
+        ShaderProgramStage::Fragment, kPs, std::size(kPs), nullptr, nullptr, nullptr,
+        &wave32_identity, true);
+    const auto repeated_wave32_ps = recompile_graphics_shader_cached(
+        ShaderProgramStage::Fragment, kPs, std::size(kPs), nullptr, nullptr, nullptr,
+        &repeated_wave32_identity, true);
+    stats = shader_recompile_cache_stats();
+    CHECK(!wave64_ps.empty() && wave32_ps == wave64_ps && repeated_wave32_ps == wave32_ps &&
+              wave64_identity != 0 && wave32_identity != 0 &&
+              wave32_identity != wave64_identity && repeated_wave32_identity == wave32_identity &&
+              stats.hits == wave_mode_hits + 2 && stats.misses == wave_mode_misses + 1,
+          "fragment Wave32 mode participates in the shader cache key");
+
     const uint64_t identity_before_clear = first_identity;
     clear_shader_recompile_cache();
     stats = shader_recompile_cache_stats();


### PR DESCRIPTION
Closes #1455

## Failure scenario

Astro Bot reaches `worldmap`, but fragment shader `0x500696600` was rejected at PC 16 when it saved `EXEC_LO` into `s60`. The shader is a Wave32 program and later restores the saved low-half mask before exporting color. Treating it as the default Wave64 form dropped the fragment stage.

## Approach

- Decode the authoritative GFX10/RDNA `SPI_PS_IN_CONTROL.PS_W32_EN` register bit into render state.
- Carry fragment wave mode through live graphics realization and the content-addressed shader cache.
- Enable existing low-half EXEC/VCC mask semantics only when Wave32 is proven.
- Keep default/Wave64 shaders fail-visible, and keep the legacy byte-exact capture exception until older captures carry this register state.
- Cover register extraction, cache isolation, explicit Wave32 compilation, and default-path rejection.

Vertex and compute wave-mode behavior is deliberately unchanged.

## Live result

Linux host frontend, scripted Astro Bot route `scripts/astrobot/reach-first-level.pad`, native render settings:

- Reached `LevelDocument Loaded: worldmap [worldmap]`.
- The exact affected fragment stage now compiles: `ps=0x500696600 ... fs=6089`.
- The paired vertex stage is now the independent blocker: `vertex export under narrowed exec pc=48 target=12`, so the draw remains withheld and the world map remains black.
- No screenshot is attached because this checkpoint is still black/diagnostic-only rather than visible progression.

## Verification

Built in distrobox `ps5ys`:

```
cmake --build /var/home/mattias800/repos/ps5ys-codex-astrobot-fmv/prosper/build-astrobot-fmv -j8 --target test_gpu_execute test_rdna2_decode test_rdna2_spirv_struct test_rdna2_to_spirv test_recompile_coverage test_render_state test_shader_recompile_cache spv_validate
```

Focused tests on the host:

```
ctest --test-dir prosper/build-astrobot-fmv --output-on-failure -R '^(render_state_extract|recompile_coverage|shader_recompile_cache|rdna2_decode_walk|rdna2_spirv_struct|spv_validate|rdna2_to_spirv_exec|gpu_execute)$'
```

Result: 8/8 passed.

`git diff --check`: clean.

Snapshots were not run; they are optional during normal development and required before releases.