### PR TITLE
fix(gpu): admit bounded NGG output rebuilds

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -10192,6 +10192,33 @@ static std::vector<uint32_t> recompile_vertex_impl(const uint32_t* code, size_t 
     uint32_t ngg_output_gate_begin = UINT32_MAX;
     uint32_t ngg_output_gate_end = 0;
     if (ngg) {
+        // A terminal compacted-output suffix may reconstruct its values from a shader-embedded
+        // constant table. Detect those loads with the same bounded PC-relative proof used by the
+        // emitter; an arbitrary external load or any buffer write must not broaden this gate.
+        PcrelTables output_tables;
+        if (b.ngg_private_lds)
+            output_tables = detect_pcrel_tables(ins, code, dwords);
+        auto scalar_output_setup = [](const Rdna2Inst& candidate) {
+            if (candidate.fmt != Rdna2Format::SOP1 &&
+                candidate.fmt != Rdna2Format::SOP2 &&
+                candidate.fmt != Rdna2Format::SOPK)
+                return false;
+            bool wrote_data = false;
+            bool safe = !instruction_may_change_exec(candidate);
+            for_each_scalar_write(candidate, [&](int base, uint32_t width) {
+                wrote_data = true;
+                safe &= base >= 0 && base + static_cast<int>(width) <= 106;
+                safe &= !scalar_write_is_b64_mask(candidate, base);
+            });
+            return wrote_data && safe;
+        };
+        auto embedded_output_load = [&](const Rdna2Inst& candidate) {
+            if (candidate.fmt != Rdna2Format::MUBUF || candidate.mubuf_lds)
+                return false;
+            const bool read_only = candidate.opcode <= 0x03u ||
+                (candidate.opcode >= 0x0cu && candidate.opcode <= 0x0fu);
+            return read_only && output_tables.mubuf.contains(candidate.pc);
+        };
         uint32_t end_pc = UINT32_MAX;
         for (const auto& in : ins)
             if (in.is_end) { end_pc = in.pc; break; }
@@ -10226,10 +10253,11 @@ static std::vector<uint32_t> recompile_vertex_impl(const uint32_t* code, size_t 
                     continue;
                 }
                 // Astro's compacted-output suffix reconstructs the surviving vertex from private
-                // LDS immediately before exporting it (VOP address setup + DS reads). These remain
-                // inside the same CMPX/EXECZ-to-ENDPGM gate and their register writes are already
-                // EXEC-predicated by emit_alu. Admit them only for the byte-exact wrapper (or the
-                // explicit test hook); ordinary NGG shaders never reach this exception.
+                // LDS or a bounded shader-embedded table immediately before exporting it. Vector,
+                // DS, and table-load destination writes are EXEC-predicated by emit_alu; scalar ALU
+                // may only build ordinary data/descriptor registers. Admit them only for the
+                // byte-exact wrapper (or the explicit test hook); arbitrary NGG shaders never reach
+                // this exception, and buffer stores/external reads remain rejected.
                 const bool output_rebuild = b.ngg_private_lds || allow_test_ngg_output_gate;
                 if (output_rebuild &&
                     (candidate.fmt == Rdna2Format::VOP1 ||
@@ -10238,7 +10266,9 @@ static std::vector<uint32_t> recompile_vertex_impl(const uint32_t* code, size_t 
                      candidate.fmt == Rdna2Format::VOP3P ||
                      (candidate.fmt == Rdna2Format::VOPC &&
                       !vopc_is_cmpx(candidate.opcode)) ||
-                     candidate.fmt == Rdna2Format::DS))
+                     candidate.fmt == Rdna2Format::DS ||
+                     scalar_output_setup(candidate) ||
+                     embedded_output_load(candidate)))
                     continue;
                 if (candidate.fmt == Rdna2Format::SOPC) continue;
                 if (sopp_is_noop(candidate)) continue;

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -651,6 +651,49 @@ int main() {
     }
     printf("  [ok]   terminal NGG LDS output-rebuild gate produces valid SPIR-V\n");
 
+    // Astro Bot's first world-map wrapper rebuilds its surviving compacted output through a
+    // shader-embedded constant table rather than LDS. The terminal suffix is still side-effect
+    // free: scalar ALU constructs the PC-relative V#, MUBUF only reads the proven bounded table,
+    // and the results feed POS0/PARAM0 before S_ENDPGM. This is the exact captured 54-dword program
+    // plus the table tail required by those two loads.
+    const uint32_t astro_worldmap_pcrel_output_gate[] = {
+        0xbfa00003u, 0x93ebff03u, 0x00040018u, 0xbefe03c1u,
+        0x9380ff02u, 0x00090016u, 0x9381ff02u, 0x0009000cu,
+        0xbf8a0000u, 0xbf076b80u, 0xbf850004u, 0x8f6a8c00u,
+        0x887c6a01u, 0xbf800000u, 0xbf900009u, 0x8f6a856bu,
+        0xd7650001u, 0x0000d4c1u, 0x7da80200u, 0xbf880002u,
+        0xf8000941u, 0x00000000u, 0xbf8cff0fu, 0xbefe03c1u,
+        0x7da80201u, 0xbf88001bu, 0xd56a0000u, 0x00020affu,
+        0xaaaaaaabu, 0xbe8303ffu, 0x10005004u, 0xb0020048u,
+        0xbe801f00u, 0x800000ffu, 0x000000acu, 0x82010180u,
+        0x2c000081u, 0xd7460000u, 0x04010300u, 0x4c000105u,
+        0x34000083u, 0xd7460004u, 0x04010300u, 0xe0381000u,
+        0x80000004u, 0xe0341010u, 0x80000404u, 0xbf8c3f71u,
+        0xf80008cfu, 0x03020100u, 0xbf8c3f70u, 0xf8000203u,
+        0x00000504u, 0xbf810000u,
+        // Padding to byte offset 304, then the 72-byte constant table.
+        0xbf9f0000u, 0xbf9f0000u, 0xbf9f0000u, 0xbf9f0000u,
+        0xbf9f0000u, 0xbf9f0000u, 0xbf9f0000u, 0xbf9f0000u,
+        0xbf9f0000u, 0xbf9f0000u, 0xbf9f0000u, 0xbf9f0000u,
+        0xbf9f0000u, 0xbf9f0000u, 0xbf9f0000u, 0xbf9f0000u,
+        0xbf9f0000u, 0xbf9f0000u, 0xbf9f0000u, 0xbf9f0000u,
+        0xbf9f0000u,
+        0x00000000u, 0xbf800000u, 0xbf800000u, 0x3f800000u,
+        0x3f800000u, 0x00000000u, 0x3f800000u, 0x40400000u,
+        0xbf800000u, 0x3f800000u, 0x3f800000u, 0x40000000u,
+        0x3f800000u, 0xbf800000u, 0x40400000u, 0x3f800000u,
+        0x3f800000u, 0x00000000u, 0xbf800000u,
+    };
+    const auto astro_worldmap_pcrel_output_spv = recompile_vertex(
+        astro_worldmap_pcrel_output_gate, std::size(astro_worldmap_pcrel_output_gate));
+    if (astro_worldmap_pcrel_output_spv.empty() ||
+        !type_result_ids_are_nonzero(astro_worldmap_pcrel_output_spv, nullptr) ||
+        !phi_ids_are_nonzero(astro_worldmap_pcrel_output_spv)) {
+        printf("  [FAIL] captured Astro PC-relative NGG output gate did not emit valid SPIR-V\n");
+        return 1;
+    }
+    printf("  [ok]   captured Astro PC-relative NGG output gate emits valid SPIR-V\n");
+
     // Astro's second world-map wrapper exports POS for a surviving compacted vertex, then a regular
     // VCC compare conditionally skips only the trailing PARAM exports. Supplying those otherwise-
     // undefined varyings in the one-lane projection is safe and must not drop the complete draw.


### PR DESCRIPTION
Closes #1457

## Failure scenario

After #1456 enables Astro Bot's world-map fragment shader, its paired 54-dword NGG vertex wrapper still fails at PC 48:

```
[recompile-reject] vertex export under narrowed exec pc=48 target=12
```

The wrapper's terminal `v_cmpx` / `s_cbranch_execz -> s_endpgm` output gate is already byte-exactly recognized. Unlike previously supported variants, this one reconstructs POS0/PARAM0 through scalar setup of a PC-relative V# followed by two shader-embedded MUBUF reads. The safety scan admitted vector/DS reconstruction only, so it never marked the terminal export as bounded.

## Approach

- Run the existing PC-relative table proof for proven one-lane NGG wrappers.
- Admit ordinary scalar setup only when it writes data SGPRs below the special mask registers, does not modify EXEC, and is not a B64 mask operation.
- Admit MUBUF only when it is a read-only load and that exact PC was proven to access the bounded shader-embedded table.
- Retain fail-visible rejection for external loads, stores/atomics, special mask writes, arbitrary NGG shaders, and ordinary vertex CMPX/export.
- Add the exact captured 54-dword program plus its 72-byte table tail as a production-path regression.

## Live result

Linux host frontend, scripted Astro Bot route `scripts/astrobot/reach-first-level.pad`, native render settings:

- Reached `LevelDocument Loaded: worldmap [worldmap]`.
- The old PC 48 narrowed-EXEC rejection is absent.
- F9 capture inspection records both exact stages as retained: VS `0x500695d00 recompiled=yes`, PS `0x500696600 recompiled=yes`.
- The window now contains a very dark 14-level grayscale/checkerboard pattern. This is partial visible output, not a visually correct world map.
- The seven-submit F9 bundle is preserved locally; its offline replay has unresolved temporal inputs and is not treated as a pixel oracle.

![Astro Bot world map — dark partial output](https://gist.githubusercontent.com/mattias800/c7d08401778bd7546717b10e26ce2064/raw/90bd5280df8e3d03bf1862e87c22639f63ace88f/astrobot-worldmap-dark-output.png)

**Astro Bot (`PPSA21564`) — Linux/Vulkan (RADV), `prosper-app`, scripted `scripts/astrobot/reach-first-level.pad` route.** Direct, unmodified active-window frontend capture at the reached `worldmap` checkpoint. The faint patterned output is intentionally shown as-is.

## Verification

Built in distrobox `ps5ys`:

```
cmake --build /var/home/mattias800/repos/ps5ys-codex-astrobot-fmv/prosper/build-astrobot-fmv -j8 --target test_rdna2_spirv_struct test_rdna2_to_spirv test_recompile_coverage test_recompiled_shaders test_gpu_capture test_shader_recompile_cache spv_validate
```

Focused tests on the host:

```
ctest --test-dir prosper/build-astrobot-fmv --output-on-failure -R '^(recompile_coverage|shader_recompile_cache|rdna2_spirv_struct|spv_validate|gpu_capture_roundtrip|rdna2_to_spirv_exec|recompiled_shaders_render)$'
```

Result: 7/7 passed.

`git diff --check`: clean.

Snapshots were not run; they are optional during normal development and required before releases.