### PR TITLE
wip(astrobot): unblock world-map shaders and accelerate compute

### DIFF
--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -3310,6 +3310,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             if (item.required_subgroup_size) {
                 required_subgroup.requiredSubgroupSize = item.required_subgroup_size;
                 cpci.stage.pNext = &required_subgroup;
+                cpci.stage.flags |=
+                    VK_PIPELINE_SHADER_STAGE_CREATE_REQUIRE_FULL_SUBGROUPS_BIT;
             }
             cpci.layout = pipeline_layout;
             if (trace) std::fprintf(stderr, "[compute]   creating compute pipeline\n");

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -1371,6 +1371,7 @@ struct BoundImage {
     std::vector<uint8_t> cache_source_snapshot; // first-use source captured before the transfer
     bool seed_skip = false;             // #1122: write-only full-coverage storage image; no seed needed
     bool poison_verify = false;         // #1122: proving frame -- seed poison, prove full coverage
+    size_t seed_from_imported = SIZE_MAX; // renderer image copied on-device into this partial-write target
     std::vector<uint8_t> seed_linear;   // #1122: detiled guest seed, kept on a proving frame so any
                                         // texel the write leaves untouched is restored (not corrupted)
     uint64_t imported_addr = 0;
@@ -2238,7 +2239,34 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 }
                 // Proven Partial: fall through, seed normally every frame.
             }
-            if (renderer_owned && !bi.imported && !bi.seed_skip) {
+            // A partial storage write needs the old target contents, but an exact sampled binding
+            // earlier in this dispatch may already have borrowed those pixels directly from the
+            // renderer. Seed the private writable image from that Vulkan image below instead of
+            // materializing the complete RTT on the CPU and immediately uploading it again. Keep
+            // proving frames on the CPU poison path: their coverage verdict depends on the seed.
+            if (renderer_owned && bi.storage && bi.native_float_storage &&
+                !bi.seed_skip && !bi.poison_verify) {
+                for (size_t j = 0; j < i; ++j) {
+                    const BoundImage& source = images[j];
+                    const ShaderResource* p = source.resource;
+                    if (!source.imported || source.imported_depth || source.storage || !p)
+                        continue;
+                    if (p->gpu_addr != r->gpu_addr || p->width != r->width ||
+                        p->height != r->height || p->depth != r->depth ||
+                        p->format != r->format || p->num_components != r->num_components)
+                        continue;
+                    bi.seed_from_imported = j;
+                    if (trace)
+                        std::fprintf(stderr,
+                                     "[compute]   GPU-seeded writable renderer RTT binding=%u "
+                                     "from binding=%u addr=0x%llx extent=%ux%u\n",
+                                     bi.binding, source.binding,
+                                     (unsigned long long)r->gpu_addr, r->width, r->height);
+                    break;
+                }
+            }
+            if (renderer_owned && !bi.imported && !bi.seed_skip &&
+                bi.seed_from_imported == SIZE_MAX) {
                 if (dim_3d || r->depth != 1 ||
                     !read_live_render_target(r->gpu_addr, live_target) || !live_target.pixels) {
                     skip_image(r, "renderer-owned RTT has no readable snapshot"); break;
@@ -2622,7 +2650,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             // directly. The old path first built a heap upload and then memcpy'd the complete result
             // here -- an extra 132 MiB CPU pass for Astro Bot's 4K RGBA32 storage representation.
             ScopedMappedMemory upload_mapping(ctx);
-            const size_t upload_size = (bi.imported || bi.seed_skip)
+            const size_t upload_size = (bi.imported || bi.seed_skip ||
+                                        bi.seed_from_imported != SIZE_MAX)
                 ? size_t{0} : (size_t)sbytes;
             if (!bi.imported && !(bi.persistent && bi.upload_skipped)) {
                 VkBufferCreateInfo sci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
@@ -2640,7 +2669,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     images_ready = false; break;
                 }
                 upload_mapping.memory = staging_memory[i];
-                if (!bi.seed_skip &&
+                if (!bi.seed_skip && bi.seed_from_imported == SIZE_MAX &&
                     !vk_ok(ctx.map_memory(staging_memory[i], 0, sbytes,
                                           &upload_mapping.data), "image-staging-map")) {
                     images_ready = false; break;
@@ -2721,7 +2750,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                      guest_bytes, bi.upload_skipped ? 1u : 0u);
                 }
                 if (!(bi.persistent && bi.upload_skipped)) {
-                const size_t linear_size = bi.seed_skip
+                const size_t linear_size = (bi.seed_skip || bi.seed_from_imported != SIZE_MAX)
                     ? size_t{0} : static_cast<size_t>(linear_guest_bytes);
                 std::unique_ptr<uint8_t[]> linear;
                 if (linear_size && !renderer_owned && r->tile_mode)
@@ -2730,6 +2759,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 if (bi.seed_skip) {
                     // #1122: write-only full-coverage target -- the shader overwrites every texel, so
                     // the image is created but never seeded, uploaded, or read. Nothing to fill.
+                } else if (bi.seed_from_imported != SIZE_MAX) {
+                    // The command buffer copies the renderer's exact native image into this target.
+                    // Staging remains allocated because the result still has to be read back below.
                 } else if (renderer_owned) {
                     unpack_source = live_target.pixels->data();
                     if (trace) {
@@ -2767,7 +2799,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     // Decode it in place instead of copying the complete surface to a temporary first.
                     unpack_source = src;
                 }
-                if (!bi.seed_skip) {
+                if (!bi.seed_skip && bi.seed_from_imported == SIZE_MAX) {
                     if (bi.native_float_storage) {
                         parallel_compute_texels(texels, static_cast<size_t>(linear_guest_bytes) * 2,
                             [&](size_t begin, size_t end) {
@@ -3373,6 +3405,58 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 vkCmdPipelineBarrier(command, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
                                      VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, 0, 0, nullptr, 0, nullptr,
                                      1, &to_general);
+                continue;
+            }
+            if (bi.seed_from_imported != SIZE_MAX) {
+                const BoundImage& source = images[bi.seed_from_imported];
+                VkImageMemoryBarrier source_to_copy{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
+                source_to_copy.srcAccessMask = VK_ACCESS_SHADER_READ_BIT;
+                source_to_copy.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+                source_to_copy.oldLayout = VK_IMAGE_LAYOUT_GENERAL;
+                source_to_copy.newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+                source_to_copy.srcQueueFamilyIndex = source_to_copy.dstQueueFamilyIndex =
+                    VK_QUEUE_FAMILY_IGNORED;
+                source_to_copy.image = source.image;
+                source_to_copy.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+                vkCmdPipelineBarrier(command, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                                     VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr,
+                                     1, &source_to_copy);
+
+                VkImageMemoryBarrier target_to_copy{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
+                target_to_copy.srcAccessMask = 0;
+                target_to_copy.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+                target_to_copy.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+                target_to_copy.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+                target_to_copy.srcQueueFamilyIndex = target_to_copy.dstQueueFamilyIndex =
+                    VK_QUEUE_FAMILY_IGNORED;
+                target_to_copy.image = bi.image;
+                target_to_copy.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+                vkCmdPipelineBarrier(command, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                                     VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr,
+                                     1, &target_to_copy);
+
+                VkImageCopy copy{};
+                copy.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+                copy.dstSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+                copy.extent = {r->width, r->height, r->depth};
+                vkCmdCopyImage(command, source.image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                               bi.image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copy);
+
+                VkImageMemoryBarrier ready[2]{};
+                ready[0] = source_to_copy;
+                ready[0].srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+                ready[0].dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+                ready[0].oldLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+                ready[0].newLayout = VK_IMAGE_LAYOUT_GENERAL;
+                ready[1] = target_to_copy;
+                ready[1].srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+                ready[1].dstAccessMask = VK_ACCESS_SHADER_READ_BIT |
+                                         VK_ACCESS_SHADER_WRITE_BIT;
+                ready[1].oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+                ready[1].newLayout = VK_IMAGE_LAYOUT_GENERAL;
+                vkCmdPipelineBarrier(command, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                                     VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, 0, 0, nullptr, 0,
+                                     nullptr, 2, ready);
                 continue;
             }
             VkImageMemoryBarrier to_dst{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -639,6 +639,11 @@ struct VulkanComputeContext {
     // tests/image_compute_runner.h, the exec-diff harness for that contract). When the device lacks
     // the features, image-binding dispatches are skipped loudly instead of creating an invalid device.
     bool image_support = false;
+    // Exact-subgroup pipelines are valid only on an adopted renderer device that enabled the
+    // published size-control/full-subgroup contract. Private fallback devices deliberately do not
+    // enable that optional extension.
+    bool native_subgroup_contract = false;
+    uint32_t min_native_subgroup_size = 0, max_native_subgroup_size = 0;
     // True when instance/device/queue were ADOPTED from the live renderer (#1091). A borrowed
     // context is owned by the renderer: destroy our own pipelines/pools/memory, never its device.
     bool borrowed = false;
@@ -1212,6 +1217,11 @@ struct VulkanComputeContext {
             queue_family = shared.queue_family;
             borrowed = true;
             image_support = true;
+            native_subgroup_contract = shared.compute_subgroup_size_control &&
+                shared.compute_full_subgroups && shared.compute_subgroup_vote &&
+                shared.compute_subgroup_arithmetic;
+            min_native_subgroup_size = shared.min_compute_subgroup_size;
+            max_native_subgroup_size = shared.max_compute_subgroup_size;
             VkPipelineCacheCreateInfo pcci{VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO};
             if (vkCreatePipelineCache(device, &pcci, nullptr, &pipeline_cache) == VK_SUCCESS) {
                 vkGetPhysicalDeviceMemoryProperties(physical, &memory);
@@ -1226,6 +1236,8 @@ struct VulkanComputeContext {
             instance = VK_NULL_HANDLE; physical = VK_NULL_HANDLE;
             device = VK_NULL_HANDLE; queue = VK_NULL_HANDLE;
             queue_family = UINT32_MAX; borrowed = false; image_support = false;
+            native_subgroup_contract = false;
+            min_native_subgroup_size = max_native_subgroup_size = 0;
             pipeline_cache = VK_NULL_HANDLE;
         }
         VkApplicationInfo app{VK_STRUCTURE_TYPE_APPLICATION_INFO};
@@ -1375,6 +1387,7 @@ struct BoundImage {
     std::vector<uint8_t> seed_linear;   // #1122: detiled guest seed, kept on a proving frame so any
                                         // texel the write leaves untouched is restored (not corrupted)
     uint64_t imported_addr = 0;
+    uint32_t imported_width = 0, imported_height = 0; // actual renderer VkImage extent
     uint32_t imported_saved_layout = 0;      // VkImageLayout the renderer left the image in
     // Several bindings can borrow the SAME renderer image without being folded together, because
     // the import contract is looser than the alias contract (it ignores sampler state, T# size and
@@ -1737,6 +1750,16 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
     double layout_ms = 0.0;
     const std::vector<uint32_t>& spirv = item.spirv;
     const bool trace = trace_compute_item(item);
+    if (item.required_subgroup_size &&
+        (!ctx.borrowed || !ctx.native_subgroup_contract ||
+         item.required_subgroup_size < ctx.min_native_subgroup_size ||
+         item.required_subgroup_size > ctx.max_native_subgroup_size)) {
+        std::fprintf(stderr,
+                     "[compute] program 0x%llx requires subgroup=%u on a context without "
+                     "that enabled contract -> dispatch skipped\n",
+                     (unsigned long long)item.code_addr, item.required_subgroup_size);
+        return false;
+    }
     const uint64_t image_validation_epoch = ++ctx.image_validation_clock;
     // #1122 review B1: enough invocations for all texels is NECESSARY but NOT SUFFICIENT
     // for skipping the seed. A write-only shader can store a subset of its grid (a masked composite:
@@ -2166,6 +2189,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         bi.imported_depth = depth_import;
                         bi.imported_format = depth_import ? depth_format : VK_FORMAT_UNDEFINED;
                         bi.imported_addr = r->gpu_addr;
+                        bi.imported_width = import.width;
+                        bi.imported_height = import.height;
                         bi.imported_saved_layout = import.layout;
                         bi.image = static_cast<VkImage>(import.image);
                         live_target.width = import.width;
@@ -2254,6 +2279,10 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     if (p->gpu_addr != r->gpu_addr || p->width != r->width ||
                         p->height != r->height || p->depth != r->depth ||
                         p->format != r->format || p->num_components != r->num_components)
+                        continue;
+                    if (!prosper::frontend::rtt_gpu_seed_import_extent_compatible(
+                            r->width, r->height,
+                            source.imported_width, source.imported_height))
                         continue;
                     bi.seed_from_imported = j;
                     if (trace)

--- a/prosper/frontends/shared/rtt_scale.hpp
+++ b/prosper/frontends/shared/rtt_scale.hpp
@@ -70,4 +70,12 @@ constexpr bool rtt_direct_import_compatible(bool storage_image,
         requested_w, requested_h, cached_w, cached_h, render_scale, normalized_sampling);
 }
 
+// On-device image copies do not scale. A normalized sampled descriptor may legally borrow a
+// renderer image reduced by PROSPER_RENDER_SCALE, but that image cannot seed a native-resolution
+// writable storage image with vkCmdCopyImage unless the actual Vulkan extents match exactly.
+constexpr bool rtt_gpu_seed_import_extent_compatible(uint32_t storage_w, uint32_t storage_h,
+                                                      uint32_t imported_w, uint32_t imported_h) {
+    return storage_w && storage_h && storage_w == imported_w && storage_h == imported_h;
+}
+
 } // namespace prosper::frontend

--- a/prosper/frontends/shared/test_rtt_scale.cpp
+++ b/prosper/frontends/shared/test_rtt_scale.cpp
@@ -11,6 +11,7 @@
 
 using prosper::frontend::rtt_integer_upscale_factor;
 using prosper::frontend::rtt_direct_import_compatible;
+using prosper::frontend::rtt_gpu_seed_import_extent_compatible;
 using prosper::frontend::rtt_sampled_extent_compatible;
 using prosper::frontend::rtt_scaled_axis;
 using prosper::frontend::rtt_scaled_extent_compatible;
@@ -55,6 +56,9 @@ int main() {
     CHECK(rtt_direct_import_compatible(false, 1920, 1080, 960, 540, 2, true));
     CHECK(!rtt_direct_import_compatible(false, 1920, 1080, 960, 540, 2, false));
     CHECK(!rtt_direct_import_compatible(true, 1920, 1080, 1920, 1080, 1, true));
+    CHECK(rtt_gpu_seed_import_extent_compatible(1920, 1080, 1920, 1080));
+    CHECK(!rtt_gpu_seed_import_extent_compatible(1920, 1080, 960, 540));
+    CHECK(!rtt_gpu_seed_import_extent_compatible(0, 1080, 0, 1080));
 
     // Pass-local targets use nearest-integer division, so non-divisible native dimensions are still
     // valid renderer-owned images. This is common in Astro Bot's dynamic-resolution post chain.

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -548,8 +548,10 @@ struct SharedVulkanContext {
     bool storage_image_write_without_format = false;
     // Exact compute-wave acceleration. These describe features ENABLED on the borrowed device, not
     // merely physical support. The recompiler opts in only when the requested guest wave is inside
-    // this range and both vote and arithmetic subgroup operations are available.
+    // this range, full compute subgroups can be required, and both vote and arithmetic subgroup
+    // operations are available.
     bool compute_subgroup_size_control = false;
+    bool compute_full_subgroups = false;
     bool compute_subgroup_vote = false;
     bool compute_subgroup_arithmetic = false;
     uint32_t min_compute_subgroup_size = 0;

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -556,6 +556,9 @@ struct SharedVulkanContext {
     bool compute_subgroup_arithmetic = false;
     uint32_t min_compute_subgroup_size = 0;
     uint32_t max_compute_subgroup_size = 0;
+    uint32_t max_compute_workgroup_subgroups = 0;
+    uint32_t max_compute_workgroup_size_x = 0;
+    uint32_t max_compute_workgroup_invocations = 0;
     // Vulkan-independent mask from native_storage_format_support_bit(). The renderer queries
     // optimal-tiling STORAGE_IMAGE support before publishing its physical device.
     uint32_t native_storage_format_support = 0;
@@ -571,6 +574,12 @@ struct SharedVulkanContext {
     bool present_queue_shared = false;
     bool valid() const { return instance && physical && device && queue && queue_family != UINT32_MAX; }
 };
+// Select the exact native subgroup contract only when the renderer device can actually be adopted
+// by compute and every required-subgroup workgroup bound is satisfied. `capture_bound` keeps saved
+// artifacts device-portable; `disabled` is the explicit diagnostic/compatibility opt-out.
+uint32_t select_native_compute_subgroup_size(const SharedVulkanContext& context,
+                                             const ComputeShaderConfig& config,
+                                             bool capture_bound, bool disabled);
 void set_shared_vulkan_context(const SharedVulkanContext& context);
 SharedVulkanContext shared_vulkan_context();
 

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -3547,16 +3547,9 @@ std::vector<ComputeItem> realize_compute_dispatches(
         // Vulkan's implementation-defined LocalInvocationIndex order and subgroup lane order while
         // still making each native subgroup exactly one RDNA wave. Captures remain portable until
         // their schema records the required-subgroup/full-subgroup pipeline contract.
-        const uint64_t local_invocations = static_cast<uint64_t>(config.local_x) *
-            config.local_y * config.local_z;
-        if (!capture_bound && !getenv("PROSPER_NO_NATIVE_COMPUTE_SUBGROUP") &&
-            shared_vulkan.compute_subgroup_size_control &&
-            shared_vulkan.compute_full_subgroups &&
-            shared_vulkan.compute_subgroup_vote && shared_vulkan.compute_subgroup_arithmetic &&
-            local_invocations && local_invocations % config.wave_size == 0 &&
-            config.wave_size >= shared_vulkan.min_compute_subgroup_size &&
-            config.wave_size <= shared_vulkan.max_compute_subgroup_size)
-            config.native_subgroup_size = config.wave_size;
+        config.native_subgroup_size = select_native_compute_subgroup_size(
+            shared_vulkan, config, capture_bound,
+            getenv("PROSPER_NO_NATIVE_COMPUTE_SUBGROUP") != nullptr);
         config.tgid_x_en = tgid_x_en;
         config.tgid_y_en = tgid_y_en;
         config.tgid_z_en = tgid_z_en;
@@ -4727,6 +4720,40 @@ void notify_live_render_target_image_written(uint64_t gpu_addr) {
 static SharedVulkanContext g_shared_vulkan;
 void set_shared_vulkan_context(const SharedVulkanContext& context) { g_shared_vulkan = context; }
 SharedVulkanContext shared_vulkan_context() { return g_shared_vulkan; }
+
+uint32_t select_native_compute_subgroup_size(const SharedVulkanContext& context,
+                                             const ComputeShaderConfig& config,
+                                             bool capture_bound, bool disabled) {
+    const bool adoptable = context.valid() && context.compute_queue_supported &&
+        context.storage_image_read_without_format &&
+        context.storage_image_write_without_format;
+    if (capture_bound || disabled || !adoptable ||
+        !context.compute_subgroup_size_control || !context.compute_full_subgroups ||
+        !context.compute_subgroup_vote || !context.compute_subgroup_arithmetic ||
+        !context.max_compute_workgroup_subgroups || !context.max_compute_workgroup_size_x ||
+        !context.max_compute_workgroup_invocations || !config.local_x || !config.local_y ||
+        !config.local_z || (config.wave_size != 32u && config.wave_size != 64u) ||
+        config.wave_size < context.min_compute_subgroup_size ||
+        config.wave_size > context.max_compute_subgroup_size)
+        return 0;
+
+    // The native shader declares a flattened LocalSize=(guest X*Y*Z,1,1), then reconstructs the
+    // guest 3D local/global IDs from SubgroupId/SubgroupLocalInvocationId. Besides avoiding any
+    // implementation-defined lane ordering, this makes Vulkan's REQUIRE_FULL_SUBGROUPS X-dimension
+    // rule explicit. Keep the multiplication and maxComputeWorkgroupSubgroups bound overflow-safe.
+    const uint64_t xy = static_cast<uint64_t>(config.local_x) * config.local_y;
+    if (xy > UINT64_MAX / config.local_z) return 0;
+    const uint64_t local_invocations = xy * config.local_z;
+    const uint64_t subgroup_capacity = static_cast<uint64_t>(config.wave_size) *
+        context.max_compute_workgroup_subgroups;
+    if (local_invocations % config.wave_size != 0 ||
+        local_invocations > subgroup_capacity ||
+        local_invocations > context.max_compute_workgroup_size_x ||
+        local_invocations > context.max_compute_workgroup_invocations ||
+        local_invocations > UINT32_MAX)
+        return 0;
+    return config.wave_size;
+}
 
 // Present unification (#1270): see gpu_execute.hpp. The atomic gates the lock so the common (headless /
 // non-shared / app-not-yet-adopted) path pays only a single acquire load and takes no lock. Set true

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -3537,20 +3537,23 @@ std::vector<ComputeItem> realize_compute_dispatches(
         // Realized captures store SPIR-V but not enough raw compute launch state to recompile a
         // device-specific typed-storage module on replay. Compile capture-bound dispatches through
         // the portable raw-uvec4 path so optional format support never becomes an artifact ABI.
-        if (std::getenv("PROSPER_GPU_CAPTURE") ||
+        const bool capture_bound = std::getenv("PROSPER_GPU_CAPTURE") ||
             std::getenv("PROSPER_GPU_TIMELINE_CAPTURE") ||
-            interactive_gpu_capture_armed() || interactive_capture_bundle_active())
+            interactive_gpu_capture_armed() || interactive_capture_bundle_active();
+        if (capture_bound)
             config.native_storage_format_support = 0;
-        // RequiredSubgroupSize fixes only the subgroup WIDTH. Vulkan deliberately does not promise
-        // that SubgroupLocalInvocationId is LocalInvocationIndex modulo that width, so using native
-        // lane IDs for RDNA MBCNT/EXEC/VCC would silently change guest wave membership on a
-        // conforming implementation. Keep the portable emulation by default. This opt-in exists for
-        // driver experiments whose contiguous mapping has been validated externally; it is not a
-        // portable correctness contract.
-        if (getenv("PROSPER_ASSUME_CONTIGUOUS_COMPUTE_SUBGROUPS") &&
-            !getenv("PROSPER_NO_NATIVE_COMPUTE_SUBGROUP") &&
+        // Full exact-size subgroups let the translator assign guest local coordinates in
+        // SubgroupId/SubgroupLocalInvocationId order. That avoids assuming any relationship between
+        // Vulkan's implementation-defined LocalInvocationIndex order and subgroup lane order while
+        // still making each native subgroup exactly one RDNA wave. Captures remain portable until
+        // their schema records the required-subgroup/full-subgroup pipeline contract.
+        const uint64_t local_invocations = static_cast<uint64_t>(config.local_x) *
+            config.local_y * config.local_z;
+        if (!capture_bound && !getenv("PROSPER_NO_NATIVE_COMPUTE_SUBGROUP") &&
             shared_vulkan.compute_subgroup_size_control &&
+            shared_vulkan.compute_full_subgroups &&
             shared_vulkan.compute_subgroup_vote && shared_vulkan.compute_subgroup_arithmetic &&
+            local_invocations && local_invocations % config.wave_size == 0 &&
             config.wave_size >= shared_vulkan.min_compute_subgroup_size &&
             config.wave_size <= shared_vulkan.max_compute_subgroup_size)
             config.native_subgroup_size = config.wave_size;

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -5578,6 +5578,14 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                                          b.lor(b.fcmp(Op_FUnordNotEqual, s1, s1),
                                                b.fcmp(Op_FUnordNotEqual, s2, s2)));
                 vreg[in.dst.value] = fresult(b.sel(nan_any, min3, med));
+            } else if (in.opcode == 0x159) {                          // v_med3_u32
+                // Unsigned median of three values: max(min(a,b), min(max(a,b),c)).
+                // Astro Bot uses this to clamp a material index into [0,31] before its world-map
+                // depth prepass. VERIFIED(llvm-mc gfx1030: VOP3 0x159 = v_med3_u32).
+                const uint32_t s0 = val(in.src[0]), s1 = val(in.src[1]), s2 = val(in.src[2]);
+                const uint32_t mn = b.uext2(Glsl_UMin, s0, s1);
+                const uint32_t mx = b.uext2(Glsl_UMax, s0, s1);
+                vreg[in.dst.value] = b.uext2(Glsl_UMax, mn, b.uext2(Glsl_UMin, mx, s2));
             } else if (in.opcode == 0x151 || in.opcode == 0x154) {    // v_min3_f32 / v_max3_f32
                 // min/max of three floats (DOLL's AA-clamp PS). VERIFIED(round-trip llvm-mc gfx1010:
                 // VOP3 0x151 = v_min3_f32, 0x154 = v_max3_f32 — 0xd551…/0xd554…). NaN-aware NMin/
@@ -7710,6 +7718,16 @@ bool emit_cfg_state_machine(
     const uint32_t* code, size_t dwords) {
     const bool graphics = b.is_fragment || b.is_vertex;
     if ((!b.is_compute && !graphics) || ins.empty()) return false;
+    // `safe` branches have already been proven equivalent to straight-line predication by the
+    // stage-specific analysis (fragment alpha-test wave early-outs, safe EXECZ regions, and the
+    // bounded NGG terminal export gate).  The compact SSA emitter feeds them to emit_alu, which
+    // deliberately no-ops the scalar branch while retaining the per-invocation EXEC effect.  Do the
+    // same in the CFG fallback: treating one as a basic-block terminator makes a kill-mask SCC look
+    // like an ordinary scalar boolean, even though the mask lowering intentionally poisons that
+    // cross-lane SCC.  Astro Bot's complex material PS combines both shapes and was rejected there.
+    auto linearized_branch = [&](const Rdna2Inst& in) {
+        return graphics && in.fmt == Rdna2Format::SOPP && safe.contains(in.pc);
+    };
 
     uint32_t end_pc = UINT32_MAX;
     for (const auto& in : ins) if (in.is_end) { end_pc = in.pc; break; }
@@ -7802,7 +7820,8 @@ bool emit_cfg_state_machine(
             if (i + 1 < ins.size() && ins[i + 1].pc <= end_pc)
                 start_set.insert(ins[i + 1].pc);
         }
-        if (in.fmt != Rdna2Format::SOPP || in.opcode < 0x02 || in.opcode > 0x09 ||
+        if (linearized_branch(in) || in.fmt != Rdna2Format::SOPP ||
+            in.opcode < 0x02 || in.opcode > 0x09 ||
             in.opcode == 0x03) continue;
         const uint32_t target = branch_target(in);
         if (target <= end_pc) start_set.insert(target);
@@ -7897,8 +7916,9 @@ bool emit_cfg_state_machine(
         const Rdna2Inst* terminator = nullptr;
         for (const auto& in : ins) {
             if (in.pc < lo || in.pc >= hi) continue;
-            if (in.is_end || (in.fmt == Rdna2Format::SOPP && in.opcode >= 0x02 &&
-                              in.opcode <= 0x09 && in.opcode != 0x03)) {
+            if (in.is_end || (!linearized_branch(in) && in.fmt == Rdna2Format::SOPP &&
+                              in.opcode >= 0x02 && in.opcode <= 0x09 &&
+                              in.opcode != 0x03)) {
                 terminator = &in;
                 break;
             }
@@ -7967,8 +7987,8 @@ bool emit_cfg_state_machine(
                 mbcnt_event_for_pc.contains(in.pc) || append_event_for_pc.contains(in.pc) ||
                 mask_zero_compare_source(in) >= 0;
             conditional_block[block] = conditional_block[block] ||
-                (in.fmt == Rdna2Format::SOPP && in.opcode >= 0x04 && in.opcode <= 0x09 &&
-                 in.opcode != 0x03);
+                (!linearized_branch(in) && in.fmt == Rdna2Format::SOPP &&
+                 in.opcode >= 0x04 && in.opcode <= 0x09 && in.opcode != 0x03);
         }
     }
     for (uint32_t first = 0; first < starts.size(); ++first) {
@@ -8257,8 +8277,9 @@ bool emit_cfg_state_machine(
             const Rdna2Inst* block_mask_compare = nullptr;
             for (const auto& in : ins) {
                 if (in.pc < lo || in.pc >= hi) continue;
-                if (in.is_end || (in.fmt == Rdna2Format::SOPP && in.opcode >= 0x02 &&
-                                  in.opcode <= 0x09 && in.opcode != 0x03)) {
+                if (in.is_end || (!linearized_branch(in) && in.fmt == Rdna2Format::SOPP &&
+                                  in.opcode >= 0x02 && in.opcode <= 0x09 &&
+                                  in.opcode != 0x03)) {
                     block_terminator = &in;
                     break;
                 }

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -1752,7 +1752,15 @@ struct SpirvCompute {
         put(mem, Op_MemoryModel, {Addr_Logical, Mem_GLSL450});
         is_compute = true;
         exec_model = Exec_GLCompute; iface = {v_gid, v_groupid, v_localid};   // EntryPoint deferred to finish()
-        put(exec, Op_ExecutionMode, {f_main, EM_LocalSize, local_x, local_y, local_z});
+        // REQUIRE_FULL_SUBGROUPS constrains LocalSize X, not merely the total workgroup size. The
+        // native shell never consumes Vulkan's LocalInvocationId: it reconstructs the original guest
+        // x/y/z coordinates below from the exact subgroup lane order. Declare the equivalent Vulkan
+        // workgroup flattened on X so 8x8 and other multidimensional guest waves satisfy that rule.
+        const uint32_t vulkan_local_x = native_subgroup_size ? local_count : local_x;
+        const uint32_t vulkan_local_y = native_subgroup_size ? 1u : local_y;
+        const uint32_t vulkan_local_z = native_subgroup_size ? 1u : local_z;
+        put(exec, Op_ExecutionMode,
+            {f_main, EM_LocalSize, vulkan_local_x, vulkan_local_y, vulkan_local_z});
         put(deco, Op_Decorate, {v_gid, Dec_BuiltIn, BI_GlobalInvocationId});
         put(deco, Op_Decorate, {v_groupid, Dec_BuiltIn, BI_WorkgroupId});
         put(deco, Op_Decorate, {v_localid, Dec_BuiltIn, BI_LocalInvocationId});   // wave lane index (.x)
@@ -9679,7 +9687,9 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
     const uint32_t local_y = std::max(1u, config.local_y);
     const uint32_t local_z = std::max(1u, config.local_z);
     const uint32_t wave_size = config.wave_size == 32 ? 32u : 64u;
-    b.native_subgroup_size = config.native_subgroup_size == wave_size ? wave_size : 0u;
+    const uint64_t local_count = static_cast<uint64_t>(local_x) * local_y * local_z;
+    b.native_subgroup_size = config.native_subgroup_size == wave_size &&
+        local_count <= UINT32_MAX && local_count % wave_size == 0 ? wave_size : 0u;
     b.native_storage_format_support = config.native_storage_format_support;
     b.begin(1, rt, local_x, local_y, local_z, wave_size,
             static_cast<uint32_t>(config.user_sgprs.size()));

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -35,6 +35,7 @@ enum : uint32_t {
     Op_Load=61, Op_Store=62, Op_AccessChain=65, Op_Decorate=71, Op_MemberDecorate=72,
     Op_ConvertFToU=109, Op_ConvertFToS=110, Op_ConvertSToF=111, Op_ConvertUToF=112, Op_Bitcast=124,
     Op_CompositeConstruct=80, Op_CompositeExtract=81, Op_IAdd=128, Op_FAdd=129, Op_ISub=130, Op_FSub=131, Op_IMul=132, Op_FMul=133,
+    Op_UDiv=134, Op_UMod=137,
     Op_UMulExtended=151, Op_SMulExtended=152,   // {lo,hi} struct results (for mul_hi)
     Op_FDiv=136, Op_SMod=139, Op_IEqual=170, Op_INotEqual=171, Op_UGreaterThan=172, Op_SGreaterThan=173,
     Op_UGreaterThanEqual=174, Op_SGreaterThanEqual=175, Op_ULessThan=176, Op_SLessThan=177,
@@ -94,7 +95,7 @@ enum : uint32_t {
     Dec_DescriptorSet=34, Dec_Offset=35, Dec_XfbBuffer=36, Dec_XfbStride=37,
     BI_Position=0, BI_FragCoord=15, BI_FragDepth=22, BI_HelperInvocation=23,
     BI_WorkgroupId=26, BI_LocalInvocationId=27,
-    BI_GlobalInvocationId=28, BI_SubgroupLocalInvocationId=41,
+    BI_GlobalInvocationId=28, BI_SubgroupId=40, BI_SubgroupLocalInvocationId=41,
     BI_VertexIndex=42, BI_InstanceIndex=43,
     GroupOp_Reduce=0, GroupOp_ExclusiveScan=2,
 };
@@ -234,7 +235,7 @@ struct SpirvCompute {
     // subgroup size equal to the PS5 wave. Native votes/scans are then architecture-exact.
     uint32_t native_subgroup_size=0;
     uint32_t native_storage_format_support=0;
-    uint32_t v_subgroup_localid=0, t_ptr_in_u32=0;
+    uint32_t v_subgroupid=0, v_subgroup_localid=0, t_ptr_in_u32=0;
     uint32_t v_helper_invocation=0, t_ptr_in_bool=0;
     uint32_t v_internal_gds=0, t_ptr_gds_u32=0;
     // Descriptor set for this stage's resources. VS and PS share ONE Vulkan pipeline, so they must NOT
@@ -462,8 +463,10 @@ struct SpirvCompute {
             declared_subgroup = true;
         }
         if (!v_subgroup_localid) {
-            t_ptr_in_u32 = id();
-            put(types, Op_TypePointer, {t_ptr_in_u32, SC_Input, t_u32});
+            if (!t_ptr_in_u32) {
+                t_ptr_in_u32 = id();
+                put(types, Op_TypePointer, {t_ptr_in_u32, SC_Input, t_u32});
+            }
             v_subgroup_localid = id();
             put(types, Op_Variable, {t_ptr_in_u32, v_subgroup_localid, SC_Input});
             put(deco, Op_Decorate,
@@ -481,6 +484,26 @@ struct SpirvCompute {
         uint32_t lane = id();
         put(code, Op_Load, {t_u32, lane, v_subgroup_localid});
         return lane;
+    }
+    uint32_t subgroup_id() {
+        if (!declared_subgroup) {
+            put(caps, Op_Capability, {Cap_GroupNonUniform});
+            declared_subgroup = true;
+        }
+        if (!v_subgroupid) {
+            if (!t_ptr_in_u32) {
+                t_ptr_in_u32 = id();
+                put(types, Op_TypePointer, {t_ptr_in_u32, SC_Input, t_u32});
+            }
+            v_subgroupid = id();
+            put(types, Op_Variable, {t_ptr_in_u32, v_subgroupid, SC_Input});
+            put(deco, Op_Decorate, {v_subgroupid, Dec_BuiltIn, BI_SubgroupId});
+            put(deco, Op_Decorate, {v_subgroupid, Dec_Flat});
+            iface.push_back(v_subgroupid);
+        }
+        uint32_t subgroup = id();
+        put(code, Op_Load, {t_u32, subgroup, v_subgroupid});
+        return subgroup;
     }
     uint32_t fragment_mbcnt(uint32_t mask_bit, uint32_t acc_bits, bool lo) {
         if (!is_fragment) return 0;
@@ -1777,28 +1800,47 @@ struct SpirvCompute {
         put(code, Op_Function, {t_void, f_main, FC_None, t_fn});
         put(code, Op_Label, {lbl}); cur_block = lbl;
         function_var_insert = code.size();
-        uint32_t ld = id(); put(code, Op_Load, {t_v3u, ld, v_gid});
-        for (uint32_t c = 0; c < 3; c++) {
-            globalid_comp[c] = id();
-            put(code, Op_CompositeExtract, {t_u32, globalid_comp[c], ld, c});
-        }
-        gidx = globalid_comp[0];
-        uint32_t ldl = id(); put(code, Op_Load, {t_v3u, ldl, v_localid});
-        for (uint32_t c = 0; c < 3; c++) {
-            localid_comp[c] = id();
-            put(code, Op_CompositeExtract, {t_u32, localid_comp[c], ldl, c});
-        }
-        localid = localid_comp[0];   // wave lane index
-        // Vulkan and RDNA both linearize X fastest, then Y, then Z. Keep the legacy X-only lane id
-        // for the older 64x1 wave helpers, but retain the exact linear id for 2D/3D dispatcher waves.
-        uint32_t yz = ibin(Op_IMul, localid_comp[2], uconst(local_y));
-        yz = ibin(Op_IAdd, yz, localid_comp[1]);
-        linear_localid = ibin(Op_IAdd, ibin(Op_IMul, yz, uconst(local_x)), localid_comp[0]);
         uint32_t ldg = id(); put(code, Op_Load, {t_v3u, ldg, v_groupid});
         for (uint32_t c = 0; c < 3; c++) {
             groupid[c] = id();
             put(code, Op_CompositeExtract, {t_u32, groupid[c], ldg, c});
         }
+        if (native_subgroup_size) {
+            // Vulkan does not promise that LocalInvocationIndex follows subgroup lane order.  A
+            // full, exact-size subgroup does promise that SubgroupId/SubgroupLocalInvocationId
+            // identify every workgroup invocation once, so assign guest coordinates in that order.
+            // This makes one Vulkan subgroup exactly one consecutive RDNA wave without depending on
+            // the implementation's otherwise-unspecified local-invocation mapping.
+            linear_localid = ibin(Op_IAdd,
+                ibin(Op_IMul, subgroup_id(), uconst(native_subgroup_size)),
+                subgroup_local_id());
+            localid_comp[0] = ibin(Op_UMod, linear_localid, uconst(local_x));
+            const uint32_t linear_yz = ibin(Op_UDiv, linear_localid, uconst(local_x));
+            localid_comp[1] = ibin(Op_UMod, linear_yz, uconst(local_y));
+            localid_comp[2] = ibin(Op_UDiv, linear_yz, uconst(local_y));
+            const uint32_t local_size[3] = {local_x, local_y, local_z};
+            for (uint32_t c = 0; c < 3; ++c)
+                globalid_comp[c] = ibin(Op_IAdd,
+                    ibin(Op_IMul, groupid[c], uconst(local_size[c])), localid_comp[c]);
+        } else {
+            uint32_t ld = id(); put(code, Op_Load, {t_v3u, ld, v_gid});
+            for (uint32_t c = 0; c < 3; c++) {
+                globalid_comp[c] = id();
+                put(code, Op_CompositeExtract, {t_u32, globalid_comp[c], ld, c});
+            }
+            uint32_t ldl = id(); put(code, Op_Load, {t_v3u, ldl, v_localid});
+            for (uint32_t c = 0; c < 3; c++) {
+                localid_comp[c] = id();
+                put(code, Op_CompositeExtract, {t_u32, localid_comp[c], ldl, c});
+            }
+            // Vulkan and RDNA both linearize X fastest, then Y, then Z.
+            uint32_t yz = ibin(Op_IMul, localid_comp[2], uconst(local_y));
+            yz = ibin(Op_IAdd, yz, localid_comp[1]);
+            linear_localid = ibin(
+                Op_IAdd, ibin(Op_IMul, yz, uconst(local_x)), localid_comp[0]);
+        }
+        gidx = globalid_comp[0];
+        localid = localid_comp[0];
     }
     // AGC thread-dimension mode can request a non-multiple of the shader's local size. Vulkan still
     // launches the final complete workgroup, so make its excess invocations branch directly to the

--- a/prosper/src/gpu/rdna2_to_spirv.hpp
+++ b/prosper/src/gpu/rdna2_to_spirv.hpp
@@ -194,9 +194,10 @@ struct ComputeShaderConfig {
     bool tgid_x_en = false, tgid_y_en = false, tgid_z_en = false;
     bool tg_size_en = false;
     uint32_t lds_bytes = 0;
-    // Non-zero only when the live backend can REQUIRE this exact Vulkan subgroup size. Complex
-    // guest-wave CFGs may then replace their portable workgroup-scratch vote/scan emulation with
-    // native subgroup operations without changing the PS5 wave domain.
+    // Non-zero only when the live backend can REQUIRE this exact Vulkan subgroup size and full
+    // compute subgroups. The shell remaps guest local coordinates into subgroup lane order, so
+    // complex guest-wave CFGs may replace portable workgroup-scratch vote/scan emulation with native
+    // subgroup operations without assuming Vulkan's LocalInvocationIndex ordering.
     uint32_t native_subgroup_size = 0;
     // Per-format VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT support published by the device-owning
     // frontend. Offline callers default to the portable raw path; live execution supplies the exact

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -535,6 +535,7 @@ struct RenderVkCtx {
     // Geometry-probe (PROSPER_GEOM_PROBE): VK_EXT_transform_feedback for capturing gl_Position.
     bool transform_feedback_enabled = false;
     bool subgroup_size_control = false;
+    bool compute_full_subgroups = false;
     uint32_t min_subgroup_size = 0, max_subgroup_size = 0;
     VkShaderStageFlags required_subgroup_size_stages = 0;
     VkShaderStageFlags subgroup_stages = 0;
@@ -711,6 +712,7 @@ inline const RenderVkCtx& render_vk_ctx() {
                       dci.pNext = &subgroup_features;
                       dev_exts.push_back(VK_EXT_SUBGROUP_SIZE_CONTROL_EXTENSION_NAME);
                       r.subgroup_size_control = true;
+                      r.compute_full_subgroups = subgroup_features.computeFullSubgroups;
                       r.min_subgroup_size = subgroup_properties.minSubgroupSize;
                       r.max_subgroup_size = subgroup_properties.maxSubgroupSize;
                       r.required_subgroup_size_stages =
@@ -786,6 +788,7 @@ inline const RenderVkCtx& render_vk_ctx() {
             shared.compute_subgroup_size_control = r.subgroup_size_control &&
                 (r.required_subgroup_size_stages & VK_SHADER_STAGE_COMPUTE_BIT) &&
                 (r.subgroup_stages & VK_SHADER_STAGE_COMPUTE_BIT);
+            shared.compute_full_subgroups = r.compute_full_subgroups;
             shared.compute_subgroup_vote =
                 (r.subgroup_operations & VK_SUBGROUP_FEATURE_VOTE_BIT) != 0;
             shared.compute_subgroup_arithmetic =

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -537,6 +537,9 @@ struct RenderVkCtx {
     bool subgroup_size_control = false;
     bool compute_full_subgroups = false;
     uint32_t min_subgroup_size = 0, max_subgroup_size = 0;
+    uint32_t max_compute_workgroup_subgroups = 0;
+    uint32_t max_compute_workgroup_size_x = 0;
+    uint32_t max_compute_workgroup_invocations = 0;
     VkShaderStageFlags required_subgroup_size_stages = 0;
     VkShaderStageFlags subgroup_stages = 0;
     VkSubgroupFeatureFlags subgroup_operations = 0;
@@ -646,6 +649,8 @@ inline const RenderVkCtx& render_vk_ctx() {
         // samplerAnisotropy (#275): enable only if advertised; maxSamplerAnisotropy is the clamp ceiling.
         VkPhysicalDeviceFeatures supported{}; vkGetPhysicalDeviceFeatures(r.phys, &supported);
         VkPhysicalDeviceProperties phys_props{}; vkGetPhysicalDeviceProperties(r.phys, &phys_props);
+        r.max_compute_workgroup_size_x = phys_props.limits.maxComputeWorkGroupSize[0];
+        r.max_compute_workgroup_invocations = phys_props.limits.maxComputeWorkGroupInvocations;
         r.storage_buffer_alignment = std::max<VkDeviceSize>(
             1, phys_props.limits.minStorageBufferOffsetAlignment);
         r.aniso_enabled = supported.samplerAnisotropy;
@@ -715,6 +720,8 @@ inline const RenderVkCtx& render_vk_ctx() {
                       r.compute_full_subgroups = subgroup_features.computeFullSubgroups;
                       r.min_subgroup_size = subgroup_properties.minSubgroupSize;
                       r.max_subgroup_size = subgroup_properties.maxSubgroupSize;
+                      r.max_compute_workgroup_subgroups =
+                          subgroup_properties.maxComputeWorkgroupSubgroups;
                       r.required_subgroup_size_stages =
                           subgroup_properties.requiredSubgroupSizeStages;
                       r.subgroup_stages = subgroup_core_properties.supportedStages;
@@ -795,6 +802,10 @@ inline const RenderVkCtx& render_vk_ctx() {
                 (r.subgroup_operations & VK_SUBGROUP_FEATURE_ARITHMETIC_BIT) != 0;
             shared.min_compute_subgroup_size = r.min_subgroup_size;
             shared.max_compute_subgroup_size = r.max_subgroup_size;
+            shared.max_compute_workgroup_subgroups = r.max_compute_workgroup_subgroups;
+            shared.max_compute_workgroup_size_x = r.max_compute_workgroup_size_x;
+            shared.max_compute_workgroup_invocations =
+                r.max_compute_workgroup_invocations;
             uint32_t queue_family_count = 0;
             vkGetPhysicalDeviceQueueFamilyProperties(r.phys, &queue_family_count, nullptr);
             std::vector<VkQueueFamilyProperties> queue_families(queue_family_count);

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -849,6 +849,47 @@ int main() {
     }
     printf("  [ok]   complex fragment CFG exports active state from both alternate sites\n");
 
+    // The graphics CFG dispatcher must retain the fragment shell's already-proven alpha-test
+    // linearization.  This reduced Astro Bot shape prefixes the crossing-region CFG above with a
+    // survivor-mask SCC early-out.  The SCC from s_andn2_b64 is a whole-wave reduction, not an SSA
+    // scalar boolean; the per-invocation translation drops that optimization, narrows EXEC, and
+    // OpKills failed lanes at either export.  Treating the safe branch as a dispatcher terminator
+    // instead poisoned SCC and rejected the otherwise-supported material shader.
+    const uint32_t fragment_cfg_kill_dispatch[] = {
+        0xbe82047eu,                         // pc0:  s_mov_b64 s[2:3], exec
+        0x7c020300u,                         // pc1:  v_cmp_lt_f32 vcc, v0, v1
+        0x8a826a02u,                         // pc2:  s_andn2_b64 s[2:3], s[2:3], vcc
+        0xbf840012u,                         // pc3:  s_cbranch_scc0 -> pc22 (wave early-out)
+        0xbefe0a02u,                         // pc4:  s_wqm_b64 exec, s[2:3]
+        0x7e040280u,                         // pc5:  v_mov_b32 v2, 0
+        0x7e060280u,                         // pc6:  v_mov_b32 v3, 0
+        0x7e080280u,                         // pc7:  v_mov_b32 v4, 0
+        0x7e0a0280u,                         // pc8:  v_mov_b32 v5, 0
+        0x7c020300u,                         // pc9:  v_cmp_lt_f32 vcc, v0, v1
+        0xbf860003u,                         // pc10: s_cbranch_vccz -> pc14
+        0x7c020300u,                         // pc11: v_cmp_lt_f32 vcc, v0, v1
+        0xbf860002u,                         // pc12: s_cbranch_vccz -> pc15 (crossing region)
+        0x7e040281u,                         // pc13: v_mov_b32 v2, 1
+        0x7e060281u,                         // pc14: v_mov_b32 v3, 1
+        0x7c020300u,                         // pc15: v_cmp_lt_f32 vcc, v0, v1
+        0xbf860003u,                         // pc16: s_cbranch_vccz -> alternate export at pc20
+        0xf800180fu, 0x05040302u,            // pc17: exp mrt0 v2, v3, v4, v5 done vm
+        0xbf820003u,                         // pc19: s_branch -> verified tail exit at pc23
+        0xf800180fu, 0x05040302u,            // pc20: alternate exp mrt0 v2, v3, v4, v5 done vm
+        0xbf810000u,                         // pc22: s_endpgm
+        0xbf810000u,                         // pc23: branch-target s_endpgm
+    };
+    const auto fragment_cfg_kill_spv = recompile_fragment(
+        fragment_cfg_kill_dispatch, std::size(fragment_cfg_kill_dispatch));
+    if (fragment_cfg_kill_spv.empty() || !has_opcode(fragment_cfg_kill_spv, 251) ||
+        !has_opcode(fragment_cfg_kill_spv, 252) ||
+        !type_result_ids_are_nonzero(fragment_cfg_kill_spv, nullptr) ||
+        !phi_ids_are_nonzero(fragment_cfg_kill_spv)) {
+        printf("  [FAIL] complex fragment CFG lost its proven alpha-test branch linearization\n");
+        return 1;
+    }
+    printf("  [ok]   complex fragment CFG retains alpha-test discard linearization\n");
+
     // Alpha-test discard via the SCALAR-BRANCH form (not v_cmpx): compare a sampled/interpolated value,
     // ANDN2 the survivor mask into a saved EXEC copy (SCC = "any lane survives"), and s_cbranch_scc0 skips
     // the shading if NO lane survives; the block then narrows EXEC (s_wqm exec, survivors) and shades. This

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -49,6 +49,19 @@ static size_t count_spirv_opcode(const std::vector<uint32_t>& spv, uint16_t opco
     }
     return matches;
 }
+static bool has_spirv_builtin(const std::vector<uint32_t>& spv, uint32_t builtin) {
+    constexpr uint16_t OpDecorate = 71;
+    constexpr uint32_t DecorationBuiltIn = 11;
+    for (size_t word = 5; word < spv.size();) {
+        const uint32_t count = spv[word] >> 16;
+        if (!count || word + count > spv.size()) return false;
+        if ((spv[word] & 0xFFFFu) == OpDecorate && count >= 4 &&
+            spv[word + 2] == DecorationBuiltIn && spv[word + 3] == builtin)
+            return true;
+        word += count;
+    }
+    return false;
+}
 
 int main() {
     printf("== test_rdna2_to_spirv ==\n");
@@ -519,6 +532,11 @@ int main() {
           "exact-wave CFG dispatcher lowers votes and liveness to native subgroup-any");
     CHECK(count_spirv_opcode(native_spv17d, 224) == 0,
           "exact-wave CFG dispatcher emits no workgroup control barrier");
+    CHECK(has_spirv_builtin(native_spv17d, 40) &&
+              has_spirv_builtin(native_spv17d, 41) &&
+              count_spirv_opcode(native_spv17d, 134) >= 2 &&
+              count_spirv_opcode(native_spv17d, 137) >= 2,
+          "exact-wave compute remaps local coordinates in full-subgroup lane order");
 
     // Kernel 17d2: Astro's mask-priority sequence compares a VOPC-produced SGPR pair against zero,
     // then uses that wave-uniform SCC in s_cselect_b64.  Keep the irreducible prefix so this exercises

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -133,6 +133,31 @@ int main() {
     printf("  kernel4 mismatches=%u (out[60]=%g expect=%g)\n", bad4, got4.size()==N?got4[60]:-1, exp4[60]);
     CHECK(got4.size()==N && bad4==0, "recompiled kernel 4 computes ceil(median(a0,a1,a2)) correctly");
 
+    // Kernel 4b: unsigned median-of-three. Convert the float harness inputs to u32, find the
+    // median, and convert it back so all six input orderings are checked by real Vulkan execution.
+    const uint32_t code4b[] = {
+        0x7E000F00u, 0x7E020F01u, 0x7E040F02u, 0xD5590003u, 0x040A0300u,
+        0x7E000D03u, 0xBF810000u,
+    };
+    std::vector<uint32_t> spv4b = recompile_valu(code4b, std::size(code4b), 3, 0);
+    CHECK(!spv4b.empty(), "recompiled kernel 4b (v_med3_u32) -> SPIR-V");
+    std::vector<float> in4b(N * 3), exp4b(N);
+    for (uint32_t i = 0; i < N; i++) {
+        const uint32_t u0 = (i * 37u) % 211u;
+        const uint32_t u1 = (i * 83u + 17u) % 211u;
+        const uint32_t u2 = (i * 19u + 101u) % 211u;
+        in4b[i*3+0] = (float)u0; in4b[i*3+1] = (float)u1; in4b[i*3+2] = (float)u2;
+        const uint32_t mn = std::min(u0, u1), mx = std::max(u0, u1);
+        exp4b[i] = (float)std::max(mn, std::min(mx, u2));
+    }
+    std::vector<float> got4b = prosper::test::run_compute(spv4b, in4b, N, N);
+    uint32_t bad4b = 0;
+    for (uint32_t i = 0; i < N && got4b.size() == N; i++)
+        if (got4b[i] != exp4b[i]) bad4b++;
+    printf("  kernel4b mismatches=%u (out[60]=%g expect=%g)\n",
+           bad4b, got4b.size()==N ? got4b[60] : -1, exp4b[60]);
+    CHECK(got4b.size()==N && bad4b==0, "recompiled kernel 4b computes unsigned median correctly");
+
     // Kernel 5: unsigned min/max/sub/not/and. u=(uint)a; d=(max-min) & ~u0. out=(float)d.
     const uint32_t code5[] = {
         0x7E000F00u, 0x7E020F01u, 0x26040300u, 0x28060300u, 0x4C040503u, 0x7E066F00u, 0x36040702u, 0x7E000D02u, 0xBF810000u,

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -62,6 +62,21 @@ static bool has_spirv_builtin(const std::vector<uint32_t>& spv, uint32_t builtin
     }
     return false;
 }
+static bool has_spirv_local_size(const std::vector<uint32_t>& spv,
+                                 uint32_t x, uint32_t y, uint32_t z) {
+    constexpr uint16_t OpExecutionMode = 16;
+    constexpr uint32_t ExecutionModeLocalSize = 17;
+    for (size_t word = 5; word < spv.size();) {
+        const uint32_t count = spv[word] >> 16;
+        if (!count || word + count > spv.size()) return false;
+        if ((spv[word] & 0xFFFFu) == OpExecutionMode && count == 6 &&
+            spv[word + 2] == ExecutionModeLocalSize && spv[word + 3] == x &&
+            spv[word + 4] == y && spv[word + 5] == z)
+            return true;
+        word += count;
+    }
+    return false;
+}
 
 int main() {
     printf("== test_rdna2_to_spirv ==\n");
@@ -523,7 +538,8 @@ int main() {
     CHECK(got17d.size()==N && bad17d==0,
           "CFG dispatcher emulates a 64-lane wave across narrower Vulkan subgroups");
     ComputeShaderConfig native_cfg17d;
-    native_cfg17d.local_x = 64;
+    native_cfg17d.local_x = 8;
+    native_cfg17d.local_y = 8;
     native_cfg17d.wave_size = 64;
     native_cfg17d.native_subgroup_size = 64;
     const std::vector<uint32_t> native_spv17d = recompile_compute(
@@ -537,6 +553,8 @@ int main() {
               count_spirv_opcode(native_spv17d, 134) >= 2 &&
               count_spirv_opcode(native_spv17d, 137) >= 2,
           "exact-wave compute remaps local coordinates in full-subgroup lane order");
+    CHECK(has_spirv_local_size(native_spv17d, 64, 1, 1),
+          "multidimensional guest wave flattens Vulkan LocalSize X for full subgroups");
 
     // Kernel 17d2: Astro's mask-priority sequence compares a VOPC-produced SGPR pair against zero,
     // then uses that wave-uniform SCC in s_cselect_b64.  Keep the irreducible prefix so this exercises

--- a/prosper/tests/test_shared_vulkan_device.cpp
+++ b/prosper/tests/test_shared_vulkan_device.cpp
@@ -16,6 +16,66 @@ static int fails = 0;
                               else         { printf("  [ok]   %s\n", msg); } } while (0)
 
 int main() {
+    // Device-contract selection is pure and must reject capability bits that cannot belong to the
+    // context compute will actually execute on. A multidimensional 8x8 guest group remains eligible:
+    // the native shader flattens its Vulkan LocalSize to 64x1x1 before requiring full subgroups.
+    prosper::gpu::SharedVulkanContext eligible;
+    eligible.instance = eligible.physical = eligible.device = eligible.queue =
+        reinterpret_cast<void*>(1);
+    eligible.queue_family = 0;
+    eligible.storage_image_read_without_format = true;
+    eligible.storage_image_write_without_format = true;
+    eligible.compute_queue_supported = true;
+    eligible.compute_subgroup_size_control = true;
+    eligible.compute_full_subgroups = true;
+    eligible.compute_subgroup_vote = true;
+    eligible.compute_subgroup_arithmetic = true;
+    eligible.min_compute_subgroup_size = 32;
+    eligible.max_compute_subgroup_size = 64;
+    eligible.max_compute_workgroup_subgroups = 4;
+    eligible.max_compute_workgroup_size_x = 256;
+    eligible.max_compute_workgroup_invocations = 256;
+    prosper::gpu::ComputeShaderConfig multidimensional;
+    multidimensional.local_x = 8;
+    multidimensional.local_y = 8;
+    multidimensional.local_z = 1;
+    multidimensional.wave_size = 64;
+    CHECK(prosper::gpu::select_native_compute_subgroup_size(
+              eligible, multidimensional, false, false) == 64,
+          "8x8 guest wave selects a flattened full-subgroup compute shell");
+    auto no_compute_queue = eligible;
+    no_compute_queue.compute_queue_supported = false;
+    CHECK(prosper::gpu::select_native_compute_subgroup_size(
+              no_compute_queue, multidimensional, false, false) == 0,
+          "native subgroup path rejects a renderer context compute cannot adopt");
+    auto one_subgroup = eligible;
+    one_subgroup.max_compute_workgroup_subgroups = 1;
+    auto two_waves = multidimensional;
+    two_waves.local_y = 16;
+    CHECK(prosper::gpu::select_native_compute_subgroup_size(
+              one_subgroup, multidimensional, false, false) == 64 &&
+          prosper::gpu::select_native_compute_subgroup_size(
+              one_subgroup, two_waves, false, false) == 0,
+          "native subgroup selection enforces maxComputeWorkgroupSubgroups boundary");
+    auto narrow_flattened_x = eligible;
+    narrow_flattened_x.max_compute_workgroup_size_x = 128;
+    auto guest_16x16 = multidimensional;
+    guest_16x16.local_x = 16;
+    guest_16x16.local_y = 16;
+    CHECK(prosper::gpu::select_native_compute_subgroup_size(
+              narrow_flattened_x, guest_16x16, false, false) == 0,
+          "native subgroup selection rejects flattened X beyond the device limit");
+    auto low_invocation_limit = eligible;
+    low_invocation_limit.max_compute_workgroup_invocations = 64;
+    CHECK(prosper::gpu::select_native_compute_subgroup_size(
+              low_invocation_limit, two_waves, false, false) == 0,
+          "native subgroup selection enforces the core workgroup invocation limit");
+    CHECK(prosper::gpu::select_native_compute_subgroup_size(
+              eligible, multidimensional, true, false) == 0 &&
+          prosper::gpu::select_native_compute_subgroup_size(
+              eligible, multidimensional, false, true) == 0,
+          "captures and explicit opt-out retain the portable compute shell");
+
     // Nothing published before the renderer initializes: headless compute-only use must keep
     // creating its own device (tests/test_game_compute.cpp depends on this).
     CHECK(!prosper::gpu::shared_vulkan_context().valid(),
@@ -57,6 +117,12 @@ int main() {
           "published storage-image WRITE flag reflects the device");
     CHECK(shared.compute_full_subgroups == ctx.compute_full_subgroups,
           "published full-compute-subgroup flag reflects the enabled device feature");
+    CHECK(shared.max_compute_workgroup_subgroups == ctx.max_compute_workgroup_subgroups,
+          "published full-subgroup workgroup bound reflects the physical-device property");
+    CHECK(shared.max_compute_workgroup_size_x == ctx.max_compute_workgroup_size_x &&
+              shared.max_compute_workgroup_invocations ==
+                  ctx.max_compute_workgroup_invocations,
+          "published flattened-workgroup limits reflect the physical-device properties");
 
     // Adopting a queue family without COMPUTE would make every dispatch invalid usage.
     uint32_t count = 0;

--- a/prosper/tests/test_shared_vulkan_device.cpp
+++ b/prosper/tests/test_shared_vulkan_device.cpp
@@ -55,6 +55,8 @@ int main() {
     CHECK(shared.storage_image_write_without_format ==
               (supported.shaderStorageImageWriteWithoutFormat == VK_TRUE),
           "published storage-image WRITE flag reflects the device");
+    CHECK(shared.compute_full_subgroups == ctx.compute_full_subgroups,
+          "published full-compute-subgroup flag reflects the enabled device feature");
 
     // Adopting a queue family without COMPUTE would make every dispatch invalid usage.
     uint32_t count = 0;


### PR DESCRIPTION
## Summary

This is the active handoff PR for Astro Bot world-map recovery. It now contains two shader/compiler unblocks and two measured compute-path performance improvements that make continued live investigation substantially more practical.

The game still reaches the title flow and loads `title_controller_ship`. A prior no-compute diagnostic reaches `worldmap`; full-compute execution is now much faster, but this PR still does not claim a correct visible world map.

## Shader progress

The first commit removes two concrete blockers from a critical world-map fragment path:

- safely linearizes a proven fragment `s_cbranch_scc0` alpha-test/WQM path instead of rejecting it as an unsupported CFG terminator;
- lowers `v_med3_u32` with unsigned min/max composition;
- adds structural CFG coverage and Vulkan execution coverage for the new lowering.

Offline recompilation of the final world-map capture now substitutes all 9 realized vertex and fragment programs (`vs=9 fs=9`, no stored fallback). Capture analysis indicates the recovered fragment program at `0x5008f1400` covers 34 consecutive world-map scene draws. The replay image is not a pixel oracle because this capture lacks the earlier temporal state.

## Renderer-target seed performance

Astro repeatedly runs a partial-write compute pass over the 4K RGBA16F renderer target. The source already existed as a renderer-owned Vulkan image, but the compute backend previously read the entire 66 MB target back to the CPU, copied it into staging, and uploaded it to a private storage image before dispatch.

The second commit seeds that private writable target with an on-device `vkCmdCopyImage` from the exact imported renderer image. Coverage-proving frames retain the poison/CPU path, and the optimization is gated to exact native-format, extent, and resource matches.

On back-to-back 35-second title samples with rendering and compute enabled:

- average rendered-submit time: **37.4 ms -> 28.7 ms** (about **23% lower**);
- hot `0x500657d00` pass: **7.0 ms -> 2.9 ms** (about **58% lower**);
- completed submits in the same wall time: **550 -> 650**.

## Native full-subgroup compute performance

Astro's next dominant compute program (`0x5006e8500`) has complex guest-wave control flow. The portable translator correctly emulates wave votes/scans with workgroup scratch and barriers, but actual GPU execution dominates its cost.

The latest commit makes the existing native subgroup lowering safe and automatic on capable devices:

- requires the exact guest wave size and full compute subgroups at pipeline creation;
- remaps guest local/global coordinates into `SubgroupId` + `SubgroupLocalInvocationId` order, avoiding any assumption about Vulkan's otherwise-unspecified `LocalInvocationIndex` mapping;
- enables the path only when full subgroups, size control, vote, arithmetic, wave range, and workgroup divisibility are all satisfied;
- retains `PROSPER_NO_NATIVE_COMPUTE_SUBGROUP=1` as a diagnostic fallback;
- forces all realized/timeline/interactive captures to keep compiling the portable shader until the capture schema stores the subgroup contract.

On comparable steady title-workload samples:

- average compute-dispatch cost: **2.04 ms -> 1.41 ms** (about **31% lower**);
- hot `0x5006e8500` dispatch: **12.16 ms -> 6.13 ms** across the later/full-resolution workload (about **50% lower**);
- average renderer submit: **28.66 ms -> 26.83 ms**, approximately **37 FPS** of backend work.

These are ballpark measurements because another game test workload was sharing the machine, but the phase-level change is large and repeatable.

## Correctness evidence

- Frozen Astro compute capture: the native full-subgroup shader changes the same 32,640 words and produces the byte-identical writable output hash `c1f83aa716364903`; all other writable bindings also match.
- The newly emitted Astro shader passes `spirv-val --target-env vulkan1.1`.
- A 14-second Astro boot executed 356 required-full-subgroup dispatches under `VK_LAYER_KHRONOS_validation` with no VUID or validation errors.
- Capture-mode boot reports `subgroup=0` for all dispatches and writes a portable metadata capsule successfully.
- Focused CTest set passes: `rdna2_spirv_struct`, `game_compute_exec`, `rdna2_to_spirv_exec`, and `shared_vulkan_device` (4/4).
- `boot_trace`, `gpu_replay`, and the relevant test targets build successfully in the distrobox.
- Snapshot suite was not run; repository policy leaves it optional for development PRs and requires it before a release.

## Current visual/runtime status

- Intro FMV is visually clean; the earlier checkerboard artifact is fixed on the current base.
- The static “Sony … presents” segment has previously shown rhythmic black flashing/edge oversaturation; that remains a separate target.
- Full-compute boot reaches the title flow much more quickly, but has not yet produced a correct visible world-map capture on this branch.
- No new screenshot is attached for these performance-only commits because they do not introduce a new visual milestone.

## Next investigation

- Use the faster full-compute path to drive and recapture `worldmap`.
- Inspect the later unresolved capture programs: fragment `0x500126600` and compute `0x500525200` / `0x500529400`.
- Continue reducing synchronous compute setup/writeback and renderer costs; the backend is now near 30 FPS but still short of the 60 FPS end goal.

Primary issue: https://github.com/mattias800/prosper/issues/1459


## Review corrections at `9cc50189`

The independent review identified four Vulkan portability/correctness gaps in the first native-subgroup implementation. The corrected head:

- flattens the Vulkan compute workgroup to X while reconstructing the original guest 3D IDs, satisfying full-subgroup X-dimension rules;
- selects the native contract only for an adoptable shared compute device/queue and validates that contract again at execution;
- gates the device-side RTT seed on the actual imported Vulkan extent, including render-scaled targets;
- enforces `maxComputeWorkgroupSubgroups`, flattened-X, and total-invocation device limits with overflow-safe arithmetic.

Post-correction evidence:

- focused CTest set passes: `rtt_scale`, `rdna2_spirv_struct`, `game_compute_exec`, `rdna2_to_spirv_exec`, and `shared_vulkan_device` (5/5);
- a 16-second validation-layer Astro boot completed 543 compute dispatches with no VUID or Vulkan validation error;
- the corrected hot Astro shader passes `spirv-val --target-env vulkan1.1` and declares `LocalSize 64 1 1`;
- the single failure seen in the broader local test pass, `#590 partially-overlapping loops remain REJECTED`, reproduces unchanged on exact base `3e879875` and is not introduced by this branch.
