### PR TITLE
ci: publish Windows artifacts only for release tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,7 @@ jobs:
           fi
 
       - name: Package Windows app
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         shell: pwsh
         run: |
           $stage = Join-Path $env:RUNNER_TEMP 'prosper-windows-x64'
@@ -165,6 +166,7 @@ jobs:
           "$hash  prosper-windows-x64.zip" | Set-Content "$zip.sha256" -Encoding ascii
 
       - name: Upload Windows app
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         uses: actions/upload-artifact@v4
         with:
           name: prosper-windows-x64


### PR DESCRIPTION
## Summary

Fixes #1462.

Ordinary pull requests currently build and test the Windows frontend, then also package and upload a 14-day release archive. That wastes storage and can hold an otherwise-green PR open when artifact upload stalls.

This change applies the existing release gate to both release-only Windows steps:

- package `prosper-windows-x64.zip` only for a `push` whose ref is `refs/tags/v*`;
- upload that archive only under the same condition.

The Windows app build, SDL audio/input seam tests, and portable-runtime import verification still run on every pull request. The existing `Publish Release` job remains gated to the same pushed `v*` tag and creates a new release with `gh release create --verify-tag`, so a GitHub release can only be created for a tag that exists in git.

## Verification

- `git diff --check` passes.
- The conditions exactly reuse the already-valid release-job expression.
- The PR workflow is expected to build/test normally while marking both package/upload steps skipped.
- No snapshots were run: this changes CI release policy only and cannot affect emulation or rendered output.
