### PR TITLE
perf(gpu): keep mirrored compute RTTs device-resident

### DIFF
--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -1,5 +1,6 @@
 #include "live_compute.hpp"
 #include "rtt_scale.hpp"
+#include "rtt_authority.hpp"
 #include "seed_reprove.hpp"
 #include "vulkan_device_select.hpp"
 
@@ -1375,6 +1376,9 @@ struct BoundImage {
     bool imported = false;
     bool imported_depth = false;        // borrowed persistent DS depth plane, not a color RTT
     VkFormat imported_format = VK_FORMAT_UNDEFINED;
+    prosper::gpu::LiveTargetPixelFormat imported_pixel_format =
+        prosper::gpu::LiveTargetPixelFormat::Rgba8Unorm;
+    bool imported_transfer_dst = false;
     bool persistent = false;            // guest-backed sampled image retained across dispatches
     bool cache_candidate = false;
     bool upload_skipped = false;         // write watch proved the cached source unchanged
@@ -1384,6 +1388,7 @@ struct BoundImage {
     bool seed_skip = false;             // #1122: write-only full-coverage storage image; no seed needed
     bool poison_verify = false;         // #1122: proving frame -- seed poison, prove full coverage
     size_t seed_from_imported = SIZE_MAX; // renderer image copied on-device into this partial-write target
+    bool mirror_result_to_imported = false;
     std::vector<uint8_t> seed_linear;   // #1122: detiled guest seed, kept on a proving frame so any
                                         // texel the write leaves untouched is restored (not corrupted)
     uint64_t imported_addr = 0;
@@ -2188,6 +2193,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         bi.imported = true;
                         bi.imported_depth = depth_import;
                         bi.imported_format = depth_import ? depth_format : VK_FORMAT_UNDEFINED;
+                        bi.imported_pixel_format = import.format;
+                        bi.imported_transfer_dst = import.transfer_dst;
                         bi.imported_addr = r->gpu_addr;
                         bi.imported_width = import.width;
                         bi.imported_height = import.height;
@@ -2285,6 +2292,10 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                             source.imported_width, source.imported_height))
                         continue;
                     bi.seed_from_imported = j;
+                    bi.mirror_result_to_imported =
+                        prosper::frontend::live_rtt_compute_mirror_eligible(
+                            true, source.imported_transfer_dst,
+                            std::getenv("PROSPER_NO_COMPUTE_RTT_MIRROR") != nullptr);
                     if (trace)
                         std::fprintf(stderr,
                                      "[compute]   GPU-seeded writable renderer RTT binding=%u "
@@ -3529,32 +3540,11 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                static_cast<uint32_t>(item.user_sgprs.size() * sizeof(uint32_t)),
                                item.user_sgprs.data());
         vkCmdDispatch(command, item.launch.groups_x, item.launch.groups_y, item.launch.groups_z);
-        // Hand every borrowed renderer image back in the layout its owner left it in (#1095), so the
-        // renderer's own layout tracking stays true whether or not a dispatch consumed the target.
-        for (size_t i = 0; i < images.size(); i++) {
-            const BoundImage& bi = images[i];
-            if (!bi.imported || bi.alias_of != SIZE_MAX || !imported_barrier_owner(i)) continue;
-            VkImageMemoryBarrier restore{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
-            restore.srcAccessMask = VK_ACCESS_SHADER_READ_BIT |
-                (imported_image_is_writable(bi.image) ? VK_ACCESS_SHADER_WRITE_BIT : 0u);
-            // The renderer's next use of a persistent target is frequently vkCmdCopyImageToBuffer
-            // or a scanout blit, so make the transition visible to transfer access as well.
-            restore.dstAccessMask = bi.imported_depth
-                ? VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT |
-                      VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT
-                : VK_ACCESS_COLOR_ATTACHMENT_READ_BIT |
-                      VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT | VK_ACCESS_SHADER_READ_BIT |
-                      VK_ACCESS_TRANSFER_READ_BIT | VK_ACCESS_TRANSFER_WRITE_BIT;
-            restore.oldLayout = VK_IMAGE_LAYOUT_GENERAL;
-            restore.newLayout = static_cast<VkImageLayout>(bi.imported_saved_layout);
-            restore.srcQueueFamilyIndex = restore.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-            restore.image = bi.image;
-            restore.subresourceRange = {imported_aspects(bi), 0, 1, 0, 1};
-            vkCmdPipelineBarrier(command, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
-                                 VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0, nullptr, 0, nullptr,
-                                 1, &restore);
-        }
         // Storage images: copy the written texels back into the staging buffer for guest writeback.
+        // When this private image was seeded from an exact borrowed renderer target, copy the final
+        // result back to that same image as well. The CPU writeback below remains mandatory for
+        // overlapping guest aliases; this second device-local copy prevents graphics from having to
+        // detile those identical bytes again on the next pass.
         for (size_t i = 0; i < images.size(); i++) {
             const BoundImage& bi = images[i];
             if (!bi.storage || bi.alias_of != SIZE_MAX || bi.imported) continue;
@@ -3574,6 +3564,36 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             region.imageExtent = {r->width, r->height, r->depth};
             vkCmdCopyImageToBuffer(command, bi.image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
                                    staging[i], 1, &region);
+            if (bi.mirror_result_to_imported) {
+                const BoundImage& mirror = images[bi.seed_from_imported];
+                VkImageMemoryBarrier mirror_to_dst{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
+                mirror_to_dst.srcAccessMask = VK_ACCESS_SHADER_READ_BIT;
+                mirror_to_dst.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+                mirror_to_dst.oldLayout = VK_IMAGE_LAYOUT_GENERAL;
+                mirror_to_dst.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+                mirror_to_dst.srcQueueFamilyIndex = mirror_to_dst.dstQueueFamilyIndex =
+                    VK_QUEUE_FAMILY_IGNORED;
+                mirror_to_dst.image = mirror.image;
+                mirror_to_dst.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+                vkCmdPipelineBarrier(command, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                                     VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr,
+                                     1, &mirror_to_dst);
+                VkImageCopy mirror_copy{};
+                mirror_copy.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+                mirror_copy.dstSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+                mirror_copy.extent = {r->width, r->height, r->depth};
+                vkCmdCopyImage(command, bi.image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                               mirror.image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                               1, &mirror_copy);
+                VkImageMemoryBarrier mirror_to_general = mirror_to_dst;
+                mirror_to_general.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+                mirror_to_general.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+                mirror_to_general.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+                mirror_to_general.newLayout = VK_IMAGE_LAYOUT_GENERAL;
+                vkCmdPipelineBarrier(command, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                                     VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, 0, 0, nullptr, 0,
+                                     nullptr, 1, &mirror_to_general);
+            }
             if (bi.cache_candidate || bi.persistent) {
                 VkImageMemoryBarrier to_general = to_src;
                 to_general.srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
@@ -3585,6 +3605,34 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                      VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, 0, 0, nullptr,
                                      0, nullptr, 1, &to_general);
             }
+        }
+        // Hand every borrowed renderer image back in the layout its owner left it in (#1095), so the
+        // renderer's own layout tracking stays true whether the dispatch only sampled it or the
+        // device-local mirror above replaced its pixels. Include transfer writes in the source scope.
+        for (size_t i = 0; i < images.size(); i++) {
+            const BoundImage& bi = images[i];
+            if (!bi.imported || bi.alias_of != SIZE_MAX || !imported_barrier_owner(i)) continue;
+            VkImageMemoryBarrier restore{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
+            restore.srcAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_TRANSFER_WRITE_BIT |
+                (imported_image_is_writable(bi.image) ? VK_ACCESS_SHADER_WRITE_BIT : 0u);
+            // The renderer's next use of a persistent target is frequently vkCmdCopyImageToBuffer
+            // or a scanout blit, so make the transition visible to transfer access as well.
+            restore.dstAccessMask = bi.imported_depth
+                ? VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT |
+                      VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT
+                : VK_ACCESS_COLOR_ATTACHMENT_READ_BIT |
+                      VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT | VK_ACCESS_SHADER_READ_BIT |
+                      VK_ACCESS_TRANSFER_READ_BIT | VK_ACCESS_TRANSFER_WRITE_BIT;
+            restore.oldLayout = VK_IMAGE_LAYOUT_GENERAL;
+            restore.newLayout = static_cast<VkImageLayout>(bi.imported_saved_layout);
+            restore.srcQueueFamilyIndex = restore.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+            restore.image = bi.image;
+            restore.subresourceRange = {imported_aspects(bi), 0, 1, 0, 1};
+            vkCmdPipelineBarrier(command,
+                                 VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT |
+                                     VK_PIPELINE_STAGE_TRANSFER_BIT,
+                                 VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0, nullptr, 0, nullptr,
+                                 1, &restore);
         }
         if (!vk_ok(vkEndCommandBuffer(command), "command-end")) break;
         VkSubmitInfo submit{VK_STRUCTURE_TYPE_SUBMIT_INFO};
@@ -3866,6 +3914,18 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                  "[compute]   DCC uncompressed binding=%u meta=0x%llx bytes=%zu code=0xff\n",
                                  bi.binding, (unsigned long long)r->metadata_addr,
                                  bi.dcc_metadata_bytes);
+            }
+            if (bi.mirror_result_to_imported) {
+                const BoundImage& mirror = images[bi.seed_from_imported];
+                notify_live_render_target_image_written({
+                    r->gpu_addr, mirror.imported_width, mirror.imported_height,
+                    mirror.imported_pixel_format});
+                if (trace)
+                    std::fprintf(stderr,
+                                 "[compute]   mirrored storage result into renderer RTT "
+                                 "binding=%u addr=0x%llx extent=%ux%u\n",
+                                 bi.binding, (unsigned long long)r->gpu_addr,
+                                 mirror.imported_width, mirror.imported_height);
             }
             if (bi.cache_candidate) {
                 if (bi.persistent) {

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -509,6 +509,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
             import.image = target->image;
             import.device = ctx.dev;
             import.layout = static_cast<uint32_t>(target->layout);
+            import.transfer_dst = true;
             return true;
         },
         [](uint64_t addr) {
@@ -518,14 +519,36 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
             prosper::test::unpin_persistent_color_target(addr, pin.width, pin.height, pin.format);
             if (--pin.count == 0) pinned_imports.erase(pinned);
         });
-    prosper::gpu::set_live_target_image_written_notifier([](uint64_t addr) {
-        auto it = g_rtt.find(addr);
-        if (it == g_rtt.end()) return;
-        // The compute dispatch wrote the persistent image itself. Keep it authoritative and discard
-        // the now-older ordered readback mirror without publishing stale guest bytes over the image.
-        it->second.rgba.reset();
-        it->second.gpu_valid = true;
-    });
+    prosper::gpu::set_live_target_image_written_notifier(
+        [invalidate_ds](const prosper::gpu::LiveTargetImageWrite& write) {
+            auto it = g_rtt.find(write.gpu_addr);
+            if (it == g_rtt.end()) return;
+            const VkFormat format =
+                write.format == prosper::gpu::LiveTargetPixelFormat::Rgba16Float
+                    ? VK_FORMAT_R16G16B16A16_SFLOAT : VK_FORMAT_R8G8B8A8_UNORM;
+            if (!prosper::frontend::live_rtt_mirror_identity_matches(
+                    it->first, it->second.w, it->second.h,
+                    static_cast<uint32_t>(
+                        prosper::test::backend_color_format(it->second.format)),
+                    write.gpu_addr, write.width, write.height,
+                    static_cast<uint32_t>(format)))
+                return;
+
+            // The compute backend also wrote exact guest bytes. Process that ordinary notification
+            // first so every color/depth/view alias becomes stale, then restore only the persistent
+            // image that received the queue-ordered device copy. If the image disappeared, leave the
+            // invalidation in force and let the next graphics use rebuild from the correct guest bytes.
+            drain_guest_gpu_writes(g_rtt, invalidate_ds);
+            if (!prosper::test::restore_persistent_color_target_after_mirrored_write(
+                    write.gpu_addr, write.width, write.height, format))
+                return;
+            RttSurf& published = g_rtt[write.gpu_addr];
+            published.rgba.reset();
+            published.w = write.width;
+            published.h = write.height;
+            published.format = format;
+            published.gpu_valid = true;
+        });
     prosper::gpu::set_live_target_byte_range_reader(
         [invalidate_ds](uint64_t addr, uint32_t bytes, std::vector<uint8_t>& output) {
             drain_guest_gpu_writes(g_rtt, invalidate_ds);

--- a/prosper/frontends/shared/rtt_authority.hpp
+++ b/prosper/frontends/shared/rtt_authority.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 namespace prosper::frontend {
 
 // The live RTT cache has two independently useful representations. A CPU snapshot with no valid
@@ -18,6 +20,22 @@ constexpr LiveRttAuthority live_rtt_authority(bool gpu_valid, bool has_cpu_snaps
 constexpr bool live_rtt_gpu_importable(bool gpu_valid, bool has_cpu_snapshot) {
     const LiveRttAuthority authority = live_rtt_authority(gpu_valid, has_cpu_snapshot);
     return authority == LiveRttAuthority::gpu || authority == LiveRttAuthority::mirrored;
+}
+
+// A mirrored guest write may re-authorize only the exact renderer image that actually received the
+// same completed GPU result. Address overlap or an equal byte footprint is insufficient: reused
+// allocations can expose different shapes/formats at one base address.
+constexpr bool live_rtt_mirror_identity_matches(
+    uint64_t target_addr, uint32_t target_width, uint32_t target_height, uint32_t target_format,
+    uint64_t mirror_addr, uint32_t mirror_width, uint32_t mirror_height, uint32_t mirror_format) {
+    return target_addr && target_width && target_height &&
+        target_addr == mirror_addr && target_width == mirror_width &&
+        target_height == mirror_height && target_format == mirror_format;
+}
+
+constexpr bool live_rtt_compute_mirror_eligible(
+    bool exact_import_seed, bool imported_transfer_dst, bool disabled) {
+    return exact_import_seed && imported_transfer_dst && !disabled;
 }
 
 } // namespace prosper::frontend

--- a/prosper/frontends/shared/test_rtt_scale.cpp
+++ b/prosper/frontends/shared/test_rtt_scale.cpp
@@ -18,6 +18,8 @@ using prosper::frontend::rtt_scaled_extent_compatible;
 using prosper::frontend::LiveRttAuthority;
 using prosper::frontend::live_rtt_authority;
 using prosper::frontend::live_rtt_gpu_importable;
+using prosper::frontend::live_rtt_compute_mirror_eligible;
+using prosper::frontend::live_rtt_mirror_identity_matches;
 
 static int failures = 0;
 #define CHECK(cond) do { if (!(cond)) { \
@@ -82,6 +84,18 @@ int main() {
     CHECK(live_rtt_gpu_importable(true, true));
     CHECK(!live_rtt_gpu_importable(false, true));
     CHECK(!live_rtt_gpu_importable(false, false));
+    CHECK(live_rtt_mirror_identity_matches(
+        0x100000, 3840, 2160, 97, 0x100000, 3840, 2160, 97));
+    CHECK(!live_rtt_mirror_identity_matches(
+        0x100000, 3840, 2160, 97, 0x100000, 1920, 4320, 97));
+    CHECK(!live_rtt_mirror_identity_matches(
+        0x100000, 3840, 2160, 97, 0x100000, 3840, 2160, 37));
+    CHECK(!live_rtt_mirror_identity_matches(
+        0x100000, 3840, 2160, 97, 0x100800, 3840, 2160, 97));
+    CHECK(live_rtt_compute_mirror_eligible(true, true, false));
+    CHECK(!live_rtt_compute_mirror_eligible(false, true, false));
+    CHECK(!live_rtt_compute_mirror_eligible(true, false, false));
+    CHECK(!live_rtt_compute_mirror_eligible(true, true, true));
 
     if (failures == 0) std::printf("rtt_scale: OK\n");
     return failures == 0 ? 0 : 1;

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -504,6 +504,9 @@ struct LiveTargetImageImport {
     void* image = nullptr;    // VkImage owned by the live renderer
     void* device = nullptr;   // VkDevice it belongs to; the caller must be running on that device
     uint32_t layout = 0;      // VkImageLayout the renderer left it in -- restore it after the dispatch
+    // Explicit image-creation contract: a sampled import is not otherwise guaranteed to carry
+    // VK_IMAGE_USAGE_TRANSFER_DST_BIT, which the compute-result mirror requires.
+    bool transfer_dst = false;
     bool valid() const { return image && device && width && height; }
 };
 struct LiveTargetImageRequest {
@@ -517,16 +520,24 @@ struct LiveTargetImageRequest {
 using LiveTargetImageImportFn = std::function<bool(
     uint64_t gpu_addr, const LiveTargetImageRequest& request, LiveTargetImageImport& import)>;
 using LiveTargetImageReleaseFn = std::function<void(uint64_t gpu_addr)>;
-using LiveTargetImageWrittenFn = std::function<void(uint64_t gpu_addr)>;
+struct LiveTargetImageWrite {
+    uint64_t gpu_addr = 0;
+    uint32_t width = 0, height = 0;
+    LiveTargetPixelFormat format = LiveTargetPixelFormat::Rgba8Unorm;
+    bool valid() const { return gpu_addr && width && height; }
+};
+using LiveTargetImageWrittenFn = std::function<void(const LiveTargetImageWrite& write)>;
 void set_live_target_image_importer(LiveTargetImageImportFn import_fn,
                                     LiveTargetImageReleaseFn release_fn);
 void set_live_target_image_written_notifier(LiveTargetImageWrittenFn written_fn);
 bool import_live_render_target_image(uint64_t gpu_addr, const LiveTargetImageRequest& request,
                                      LiveTargetImageImport& import);
 void release_live_render_target_image(uint64_t gpu_addr);
-// Publish that a borrowed renderer image was modified in place. The renderer keeps the Vulkan image
-// authoritative and discards any older CPU readback mirror; guest bytes intentionally stay deferred.
-void notify_live_render_target_image_written(uint64_t gpu_addr);
+// Publish that a borrowed renderer image received the completed compute result. The caller may also
+// have written the exact guest bytes for alias correctness; the renderer processes that normal
+// invalidation first, then re-authorizes only this exact image identity and discards an older CPU
+// readback mirror.
+void notify_live_render_target_image_written(const LiveTargetImageWrite& write);
 // Shared Vulkan device (#1091 phase 1). live_compute historically created its own VkInstance/VkDevice,
 // so a renderer-owned image could never be bound to a dispatch and had to round-trip through host
 // memory. The live renderer publishes its already-created device here; the compute backend ADOPTS it

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -4714,8 +4714,8 @@ bool import_live_render_target_image(uint64_t gpu_addr, const LiveTargetImageReq
 void release_live_render_target_image(uint64_t gpu_addr) {
     if (g_live_target_image_release) g_live_target_image_release(gpu_addr);
 }
-void notify_live_render_target_image_written(uint64_t gpu_addr) {
-    if (g_live_target_image_written) g_live_target_image_written(gpu_addr);
+void notify_live_render_target_image_written(const LiveTargetImageWrite& write) {
+    if (g_live_target_image_written && write.valid()) g_live_target_image_written(write);
 }
 static SharedVulkanContext g_shared_vulkan;
 void set_shared_vulkan_context(const SharedVulkanContext& context) { g_shared_vulkan = context; }

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -1213,6 +1213,19 @@ inline void invalidate_persistent_color_target_guest_write(uint64_t addr, uint64
     }
 }
 
+// A compute dispatch can publish both exact guest bytes and an equivalent device-local result into
+// one borrowed renderer target. Normal guest-write invalidation runs first so every overlapping alias
+// becomes stale; only the image proven to have received that result may then regain authority.
+inline bool restore_persistent_color_target_after_mirrored_write(
+    uint64_t id, uint32_t width, uint32_t height, VkFormat format) {
+    PersistentColorTargetImage* target = find_persistent_color_target(
+        id, width, height, backend_color_format(format), false);
+    if (!target || !target->image || target->layout == VK_IMAGE_LAYOUT_UNDEFINED) return false;
+    target->valid = true;
+    target->last_use = ++persistent_color_target_generation();
+    return true;
+}
+
 inline void destroy_persistent_color_target(const RenderVkCtx& ctx,
                                             PersistentColorTargetImage& target) {
     if (target.view) vkDestroyImageView(ctx.dev, target.view, nullptr);

--- a/prosper/tests/test_shared_vulkan_device.cpp
+++ b/prosper/tests/test_shared_vulkan_device.cpp
@@ -16,6 +16,36 @@ static int fails = 0;
                               else         { printf("  [ok]   %s\n", msg); } } while (0)
 
 int main() {
+    // Mirrored compute publication invalidates every overlapping cached interpretation, then
+    // re-authorizes only the exact renderer image that received the device-local copy.
+    {
+        auto& cache = prosper::test::persistent_color_target_cache();
+        cache.clear();
+        constexpr uint64_t base = 0x500000;
+        const prosper::test::PersistentColorTargetKey exact{
+            base, 3840, 2160, VK_FORMAT_R16G16B16A16_SFLOAT};
+        const prosper::test::PersistentColorTargetKey overlapping_alias{
+            base + 0x1000, 1920, 1080, VK_FORMAT_R8G8B8A8_UNORM};
+        cache[exact].image = reinterpret_cast<VkImage>(uintptr_t{1});
+        cache[exact].layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+        cache[exact].valid = true;
+        cache[overlapping_alias].image = reinterpret_cast<VkImage>(uintptr_t{2});
+        cache[overlapping_alias].layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+        cache[overlapping_alias].valid = true;
+        auto& exact_target = cache.at(exact);
+        auto& alias_target = cache.at(overlapping_alias);
+        prosper::test::invalidate_persistent_color_target_guest_write(
+            base, static_cast<uint64_t>(3840) * 2160 * 8);
+        CHECK(!exact_target.valid && !alias_target.valid,
+              "guest write invalidates the exact target and every overlapping alias first");
+        CHECK(prosper::test::restore_persistent_color_target_after_mirrored_write(
+                  exact.id, exact.width, exact.height, exact.format),
+              "completed device-local mirror restores the exact renderer target");
+        CHECK(exact_target.valid && !alias_target.valid,
+              "mirrored publication does not resurrect an overlapping non-identical alias");
+        cache.clear();
+    }
+
     // Device-contract selection is pure and must reject capability bits that cannot belong to the
     // context compute will actually execute on. A multidimensional 8x8 guest group remains eligible:
     // the native shader flattens its Vulkan LocalSize to 64x1x1 before requiring full subgroups.


### PR DESCRIPTION
## Summary

Fixes #1464.

Astro Bot's partial-write compute pass over a 3840x2160 RGBA16F renderer target already seeded its private writable image from the renderer image on-device. After dispatch, however, the generic guest write notification invalidated that equivalent renderer image. The next graphics consumer therefore CPU-detiled the same 4K target again at roughly 35–46 ms per use.

This PR preserves both required representations:

- the compute result is still read back, packed/tiled, and written to guest memory so CPU and overlapping buffer aliases remain correct;
- when the writable image was seeded from an exact borrowed renderer image on the same device, the completed result is also copied back into that renderer image in the same queue-ordered Vulkan command;
- normal guest-write invalidation runs first, invalidating every overlapping color/depth/view alias;
- only the exact address + extent + format image that received the device copy is re-authorized as GPU-current, and its older CPU RTT snapshot is discarded.

## Safety and unaffected behavior

The mirror is gated on all of the existing exact GPU-seed checks plus an explicit importer declaration that the borrowed image was created with `VK_IMAGE_USAGE_TRANSFER_DST_BIT`. `PROSPER_NO_COMPUTE_RTT_MIRROR=1` keeps a focused recovery/A-B switch.

Scaled imports, depth images, format/extent aliases, private devices, CPU-only targets, coverage-proving dispatches, and importers without transfer-destination usage retain the existing guest-writeback/rebuild behavior. If exact renderer reauthorization fails after the command, correct guest bytes remain authoritative and graphics rebuilds from them.

## Astro Bot evidence

Native-scale PPSA21564 run with rendering, compute phase timing, detailed renderer timing, and `VK_LAYER_KHRONOS_validation`:

- normal path: 18 hot 4K GPU seeds, 18 result mirrors, only the one mandatory poison-proving CPU detile, zero validation errors;
- later renderer window: texture resource building averaged **0.88 ms/callback**, down from the prior roughly **14–18 ms/callback** windows;
- opt-out run: 2 hot GPU seeds, 0 mirrors, 3 repeated CPU detiles averaging **39.55 ms**, zero validation errors;
- the opt-out changes only this result mirror, proving the repeated detile removal is causal.

Timings are ballpark because another title workload was sharing the machine. The path choice and validation results are deterministic.

## Verification

Focused CTest set passes 11/11:

- `rtt_scale`
- `rtt_injection`
- `vulkan_offscreen_clear`
- `vulkan_triangle_render`
- `compute_exec_differential`
- `game_compute_exec`
- `texture_sample_render`
- `storage_image_copy`
- `textured_interp_render`
- `texture_mip_render`
- `shared_vulkan_device`

The focused authority test invalidates an exact target plus an overlapping non-identical alias, then proves only the exact device-mirrored target regains validity. `git diff --check` passes.

Snapshots were not run: repository policy leaves them optional for development PRs and requires them before a release. This performance/authority change does not claim a new visible progression milestone, so there is no new screenshot.
