### PR TITLE
Support Astro Bot world-map compute shaders

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -3914,6 +3914,13 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
             // PROSPER_DUMP_CONTENT=<min-nonzero-bytes>: dump ONLY frames whose framebuffer has at least
             // that many nonzero bytes — catches the intermittent content submits the periodic dump misses.
             size_t content_thr = 0; if (const char* c = getenv("PROSPER_DUMP_CONTENT")) content_thr = (size_t)atol(c);
+            // Sparse long-route captures can override the default first-60/every-10 cadence. This is
+            // particularly useful for 4K titles, where capturing itself would otherwise add gigabytes
+            // of readback I/O before the scene under investigation is reached. Zero disables a phase.
+            static const int dump_first = [] { const char* e = getenv("PROSPER_FRAME_DUMP_FIRST");
+                                                return e ? (int)atol(e) : 60; }();
+            static const int dump_every = [] { const char* e = getenv("PROSPER_FRAME_DUMP_EVERY");
+                                                return e ? (int)atol(e) : 10; }();
             // PROSPER_PRESENT_NZLOG=N: log the presented frame's nonzero-byte count every N frames WITHOUT
             // writing any image. A memory-safe content proxy for long progression runs — dumping BMPs to a
             // tmpfs frame dir exhausts RAM, this does not. 0/unset disables.
@@ -3923,7 +3930,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
             if (dump_bmps || nzlog_every) for (uint8_t b : px) px_nz += (b != 0);
             if (px.empty() && !published_gpu) {
                 fprintf(stderr, "[render] frame %d: Vulkan render FAILED (%ux%u)\n", n, w, h);
-            } else if (dump_bmps && ((content_thr && px_nz >= content_thr) || (!content_thr && (n < 60 || n % 10 == 0)))) {
+            } else if (dump_bmps && ((content_thr && px_nz >= content_thr) ||
+                       (!content_thr && ((dump_first > 0 && n < dump_first) ||
+                                         (dump_every > 0 && n % dump_every == 0))))) {
                 char fn[512]; snprintf(fn, sizeof fn, "%s/frame_%04d.bmp", frame_dir.c_str(), n);
                 prosper::test::dump_bmp(fn, px, w, h);
                 fprintf(stderr, "[render] frame %d rendered (%ux%u) nz=%zu -> %s\n", n, w, h, px_nz, fn);

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -1766,6 +1766,20 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                             val_seed_origin_known.set((size_t)in.dst.value);
                         }
                     } else forget(in.dst.value);
+                } else if (in.opcode == 0x34) {                 // s_abs_i32
+                    // This is a 32-bit destination. Treating every unmodeled SOP1 as a possible
+                    // 64-bit pair write erased the untouched adjacent SGPR; Astro Bot keeps the
+                    // high half of a descriptor-table pointer there immediately before an x8 load.
+                    // Compute abs in unsigned arithmetic so INT_MIN remains 0x80000000 without C++
+                    // signed-overflow undefined behaviour. Arithmetic deliberately drops seed/SRT
+                    // provenance through set_value().
+                    uint32_t v = 0;
+                    const bool source_known = in.src[0].kind == OperandKind::Literal
+                        ? (v = in.literal, true) : srcval(in.src[0], v);
+                    if (source_known)
+                        set_value(in.dst.value, static_cast<int32_t>(v) < 0 ? 0u - v : v);
+                    else
+                        forget(in.dst.value);
                 } else if (in.opcode == 0x04 &&                 // s_mov_b64
                            in.dst.kind == OperandKind::SGPR &&
                            in.src[0].kind == OperandKind::SGPR) {

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -7268,11 +7268,14 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 auto m0 = rs.sreg.find(124);
                 if (m0 == rs.sreg.end()) { ok = false; return true; }
                 b.declare_lds();
+                // The instruction uses M0[15:0]; the upper half is ignored by hardware.
+                const uint32_t m0_low = b.ibin(
+                    Op_BitwiseAnd, m0->second, b.uconst(0xFFFFu));
                 const uint32_t lane = b.ibin(
                     Op_BitwiseAnd, b.linear_localid, b.uconst(b.wave_size - 1));
                 const uint32_t byte_addr = b.ibin(
                     Op_IAdd,
-                    b.ibin(Op_IAdd, m0->second, b.uconst(in.literal)),
+                    b.ibin(Op_IAdd, m0_low, b.uconst(in.literal)),
                     b.ibin(Op_ShiftLeftLogical, lane, b.uconst(2)));
                 const uint32_t idx = b.ibin(Op_ShiftRightLogical, byte_addr, b.uconst(2));
                 if (in.opcode == 0xb0) {
@@ -7360,7 +7363,9 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 const uint32_t idx0 = b.ibin(Op_IAdd, base, b.uconst(in.literal & 0xFFu));
                 const uint32_t idx1 = b.ibin(Op_IAdd, base, b.uconst((in.literal >> 8) & 0xFFu));
                 b.lds_store(idx0, vread(in.src[1].value), rs.exec_narrowed, rs.exec);
-                b.lds_store(idx1, vread(in.src[2].value), rs.exec_narrowed, rs.exec);
+                // Equal offsets encode one memory access and use DATA0; DATA1 is ignored.
+                if ((in.literal & 0xFFu) != ((in.literal >> 8) & 0xFFu))
+                    b.lds_store(idx1, vread(in.src[2].value), rs.exec_narrowed, rs.exec);
                 return true;
             }
             if (in.opcode == 0x4e) {                    // ds_write2_b64: two VGPR pairs at offset0/offset1

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -4816,6 +4816,16 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     rs.sreg[in.dst.value] = b.uconst((uint32_t)in.simm16);
                     rs.sreg_srt.erase(in.dst.value);
                     break;
+                case 0x10: {                                // s_mulk_i32 (read-modify-write)
+                    // D = low32(D * sign_extend(SIMM16)). Unlike s_addk_i32, MULK does not write
+                    // SCC. Astro Bot uses the exact `s_mulk_i32 vcc_lo, 276` word to turn a
+                    // scalar table index into a byte offset before s_buffer_load_dwordx4.
+                    const uint32_t a = val(in.dst);
+                    rs.sreg[in.dst.value] = b.ibin(
+                        Op_IMul, a, b.uconst(static_cast<uint32_t>(in.simm16)));
+                    rs.sreg_srt.erase(in.dst.value);
+                    break;
+                }
                 case 0x03: case 0x04: case 0x05: case 0x06:
                 case 0x07: case 0x08: {                      // s_cmpk_{eq,lg,gt,ge,lt,le}_i32
                     const uint32_t a = val(in.dst);
@@ -7250,7 +7260,34 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // device-global counter (exact for the exercised dispatch shapes). CONFIDENCE: MED.
             if (in.ds_gds && in.opcode != 0x3d && in.opcode != 0x3e &&
                 !(b.is_compute && in.opcode == 0x0d)) { ok = false; return true; }
-            // ds_write_addtid_b32 (0xb0) / ds_read_addtid_b32 (0xb1) in a GRAPHICS stage (#273):
+            // ds_write_addtid_b32 (0xb0) / ds_read_addtid_b32 (0xb1). In compute, ADDR is the
+            // wave lane's private dword at M0 + OFFSET + lane*4, backed by ordinary workgroup LDS.
+            // Astro Bot's world-map material kernel uses several such lane arrays before reducing
+            // them through explicit DS reads and barriers.
+            if (b.is_compute && (in.opcode == 0xb0 || in.opcode == 0xb1)) {
+                auto m0 = rs.sreg.find(124);
+                if (m0 == rs.sreg.end()) { ok = false; return true; }
+                b.declare_lds();
+                const uint32_t lane = b.ibin(
+                    Op_BitwiseAnd, b.linear_localid, b.uconst(b.wave_size - 1));
+                const uint32_t byte_addr = b.ibin(
+                    Op_IAdd,
+                    b.ibin(Op_IAdd, m0->second, b.uconst(in.literal)),
+                    b.ibin(Op_ShiftLeftLogical, lane, b.uconst(2)));
+                const uint32_t idx = b.ibin(Op_ShiftRightLogical, byte_addr, b.uconst(2));
+                if (in.opcode == 0xb0) {
+                    auto value = rs.vreg.find(in.src[1].value);
+                    b.lds_store(idx, value != rs.vreg.end() ? value->second : b.uconst(0),
+                                rs.exec_narrowed, rs.exec);
+                } else {
+                    const uint32_t old = vreg_old(b, rs, in.dst.value);
+                    rs.vreg[in.dst.value] = b.lds_load(idx);
+                    predicate_write(b, rs, in.dst.value, old);
+                }
+                return true;
+            }
+            // In a GRAPHICS stage (#273), ADDTID is a per-lane VGPR spill through LDS. The
+            // per-invocation graphics projection can track the matching slot directly:
             // a per-lane VGPR spill through LDS (addr = M0 + offset + tid*4) — DOLL's title post
             // PSes spill v15 before their accumulation loop and reload it after. Per-invocation the
             // slot is ONE value: track it in rs.lds_addtid keyed by (M0 SSA id, inst offset); the
@@ -7300,13 +7337,14 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 return true;
             }
             // LDS (workgroup shared memory), compute-only. Byte address = ADDR VGPR + instruction
-            // offset; the backing store is dword-indexed. gfx10 ds_write2_b64 carries two independent
-            // 8-bit offsets in units of 64-bit elements, while ds_write_b64 uses the ordinary 16-bit
-            // byte offset. GDS and the remaining widths/atomics are deferred.
+            // offset; the backing store is dword-indexed. gfx10 ds_write2_b32/b64 carry two independent
+            // 8-bit offsets in units of 32-/64-bit elements, while the single-address wide stores use
+            // the ordinary 16-bit byte offset. GDS and the remaining widths/atomics are deferred.
             if ((!b.is_compute && !b.ngg_private_lds) || (in.opcode != 0x00 && in.opcode != 0x07 &&
                                   in.opcode != 0x08 && in.opcode != 0x20 &&
                                   in.opcode != 0x2d &&
-                                  in.opcode != 0x0d && in.opcode != 0x36 && in.opcode != 0x37 &&
+                                  in.opcode != 0x0d && in.opcode != 0x0e &&
+                                  in.opcode != 0x36 && in.opcode != 0x37 &&
                                   in.opcode != 0x3d && in.opcode != 0x3e && in.opcode != 0x4d && in.opcode != 0x4e &&
                                   in.opcode != 0x76 && in.opcode != 0x77 &&
                                   in.opcode != 0xde && in.opcode != 0xdf &&
@@ -7315,6 +7353,16 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             }
             b.declare_lds();
             auto vread = [&](int r){ auto it = rs.vreg.find(r); return it == rs.vreg.end() ? b.uconst(0) : it->second; };
+            if (in.opcode == 0x0e) {                    // ds_write2_b32: two dwords at offset0/offset1
+                // AMD RDNA2 ISA 12.13: MEM[ADDR + OFFSET0/1 * 4] = DATA0/1. The packed offsets
+                // mirror ds_read2_b32 below; Astro Bot's world-map reduction uses both operations.
+                const uint32_t base = b.ibin(Op_ShiftRightLogical, vread(in.src[0].value), b.uconst(2));
+                const uint32_t idx0 = b.ibin(Op_IAdd, base, b.uconst(in.literal & 0xFFu));
+                const uint32_t idx1 = b.ibin(Op_IAdd, base, b.uconst((in.literal >> 8) & 0xFFu));
+                b.lds_store(idx0, vread(in.src[1].value), rs.exec_narrowed, rs.exec);
+                b.lds_store(idx1, vread(in.src[2].value), rs.exec_narrowed, rs.exec);
+                return true;
+            }
             if (in.opcode == 0x4e) {                    // ds_write2_b64: two VGPR pairs at offset0/offset1
                 const uint32_t base = b.ibin(Op_ShiftRightLogical, vread(in.src[0].value), b.uconst(2));
                 const uint32_t idx0 = b.ibin(Op_IAdd, base, b.uconst((in.literal & 0xFFu) * 2u));

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -702,6 +702,35 @@ int main() {
     CHECK(moved_gapped_image_uses.empty(),
           "gapped entry pairs do not fabricate moved image-descriptor provenance");
 
+    // Astro Bot's world-map compaction kernel keeps an x8 descriptor-table pointer in s[14:15],
+    // while s_abs_i32 writes the adjacent s13 immediately before the load. S_ABS has a 32-bit
+    // destination: the scalar fold must not erase s14 as though this were an unknown pair write,
+    // or the second image_store's exact descriptor disappears.
+    alignas(16) uint32_t abs_adjacent_image[8];
+    std::copy(std::begin(atomic_image_seed), std::end(atomic_image_seed),
+              std::begin(abs_adjacent_image));
+    const uint64_t abs_adjacent_image_addr =
+        reinterpret_cast<uint64_t>(abs_adjacent_image);
+    uint32_t abs_adjacent_seed[25]{};
+    abs_adjacent_seed[14] = static_cast<uint32_t>(abs_adjacent_image_addr);
+    abs_adjacent_seed[15] = static_cast<uint32_t>(abs_adjacent_image_addr >> 32);
+    abs_adjacent_seed[24] = 17u;
+    const uint32_t abs_adjacent_load[] = {
+        0xbe8d3418u,                // s_abs_i32 s13, s24 (must leave s14 untouched)
+        0xf40c0907u, 0xfa000000u,   // s_load_dwordx8 s[36:43], s[14:15], 0
+        0xf0200108u, 0x00090600u,   // image_store v6, v0, s[36:43] dmask:x 2D
+        0xbf810000u,
+    };
+    std::vector<SrtUse> abs_adjacent_uses;
+    resolve_dynamic_fetch(abs_adjacent_load, std::size(abs_adjacent_load),
+                          abs_adjacent_seed, std::size(abs_adjacent_seed), 0,
+                          &abs_adjacent_uses);
+    CHECK(abs_adjacent_uses.size() == 1 && abs_adjacent_uses[0].kind == 0 &&
+              abs_adjacent_uses[0].use_pc == 3 &&
+              abs_adjacent_uses[0].is_storage_image &&
+              abs_adjacent_uses[0].t8 == expected_atomic_t8,
+          "Astro s_abs_i32 preserves the adjacent x8 image-table pointer");
+
     // Astro's title PS consumes a V# placed directly in s[24:27] with a scalar offset computed in
     // VCC_LO. No s_load gives that descriptor an SRT key, and AGC metadata need not publish a sharp
     // for it. The fold nevertheless knows all four entry dwords and the exact offset, so retain the

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -1501,6 +1501,44 @@ int main() {
     CHECK(got32b2.size()==1 && std::fabs(got32b2[0]-10.0f)<1e-3f,
           "kernel 32b2 DS_READ2_B32 applies both packed dword offsets exactly");
 
+    // Kernel 32b2w: Astro Bot's world-map reduction pairs that read with DS_WRITE2_B32. Use its
+    // exact offset0/1=(0,1), DATA0=v2, DATA1=v1 instruction, read both slots back, and expose their
+    // sum. This also proves DATA0/DATA1 are not accidentally treated as one consecutive VGPR pair.
+    const uint32_t code32b2w[] = {
+        0x7e000280u, 0x7e020281u, 0x7e040282u,
+        0xd8380100u, 0x00010200u, 0xbf8a0000u,
+        0xd8dc0100u, 0x03000000u,
+        0x7e060d03u, 0x7e080d04u, 0x060a0903u, 0xbf810000u,
+    };
+    std::vector<uint32_t> spv32b2w = recompile_valu(
+        code32b2w, std::size(code32b2w), 0, 5);
+    CHECK(!spv32b2w.empty(), "recompiled kernel 32b2w (Astro DS_WRITE2_B32 word) -> SPIR-V");
+    std::vector<float> got32b2w = prosper::test::run_compute(
+        spv32b2w, std::vector<float>(1), 1, 1);
+    CHECK(got32b2w.size()==1 && std::fabs(got32b2w[0]-3.0f)<1e-3f,
+          "kernel 32b2w DS_WRITE2_B32 stores DATA0/1 at both packed dword offsets");
+
+    // Kernel 32b2a: Astro Bot's large world-map compute program spills each wave lane through
+    // DS_WRITE_ADDTID_B32 and reloads it with DS_READ_ADDTID_B32. Unique per-lane input values prove
+    // the translation uses lane*4 rather than racing every invocation through one LDS dword.
+    const uint32_t code32b2a[] = {
+        0xb07c0000u,                // s_movk_i32 m0, 0
+        0xdac00700u, 0x00000000u,   // ds_write_addtid_b32 v0 offset:0x700
+        0xbf8a0000u,                // s_barrier
+        0xdac40700u, 0x01000000u,   // ds_read_addtid_b32 v1 offset:0x700
+        0xbf810000u,
+    };
+    std::vector<uint32_t> spv32b2a = recompile_valu(
+        code32b2a, std::size(code32b2a), 1, 1);
+    CHECK(!spv32b2a.empty(),
+          "recompiled kernel 32b2a (Astro DS_WRITE/READ_ADDTID_B32 words) -> SPIR-V");
+    std::vector<float> in32b2a(64);
+    for (uint32_t i = 0; i < in32b2a.size(); ++i) in32b2a[i] = 1000.0f + (float)i;
+    std::vector<float> got32b2a = prosper::test::run_compute(
+        spv32b2a, in32b2a, (uint32_t)in32b2a.size(), (uint32_t)in32b2a.size());
+    CHECK(got32b2a == in32b2a,
+          "kernel 32b2a ADDTID round-trips every lane through its own LDS dword");
+
     // Kernel 32b3: three other exact words from Astro's loading compute shaders. V_MUL_U32_U24
     // must mask both operands to 24 bits, while V_CVT_FLR_I32_F32 must round negative values toward
     // -infinity (not toward zero). Add the converted results: (64 * 3) + floor(-2.25) = 189.
@@ -1995,6 +2033,22 @@ int main() {
     uint32_t bad37 = 0; for (uint32_t i=0;i<N&&got37.size()==N;i++) if (std::fabs(got37[i]-exp37[i])>1e-3f) bad37++;
     printf("  kernel37 mismatches=%u (out[5]=%g expect=%g)\n", bad37, got37.size()==N?got37[5]:-1, exp37[5]);
     CHECK(got37.size()==N && bad37==0, "recompiled kernel 37 (s_movk_i32 -100) computes a0-100");
+
+    // Astro Bot's world-map material kernel scales a scalar-table index with this exact SOPK word.
+    // VCC_LO is used as ordinary scalar data here; 3*276 must survive as the following VALU source.
+    const uint32_t code37m[] = {
+        0xbeea03ffu, 0x00000003u,   // s_mov_b32 vcc_lo, 3
+        0xb86a0114u,                // s_mulk_i32 vcc_lo, 276
+        0x7e000a6au,                // v_cvt_f32_u32 v0, vcc_lo
+        0xbf810000u,
+    };
+    std::vector<uint32_t> spv37m = recompile_valu(
+        code37m, std::size(code37m), 0, 0);
+    CHECK(!spv37m.empty(), "recompiled kernel 37m (Astro s_mulk_i32 word) -> SPIR-V");
+    std::vector<float> got37m = prosper::test::run_compute(
+        spv37m, std::vector<float>(1), 1, 1);
+    CHECK(got37m.size()==1 && got37m[0]==828.0f,
+          "kernel 37m multiplies scalar data by the signed SOPK immediate exactly");
 
     // Kernel 37a: s_cmpk_le_u32 compares the SGPR named by SOPK's SDST field against the raw
     // unsigned 16-bit immediate and writes SCC without changing that SGPR. Cover both sides of the

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -1502,21 +1502,37 @@ int main() {
           "kernel 32b2 DS_READ2_B32 applies both packed dword offsets exactly");
 
     // Kernel 32b2w: Astro Bot's world-map reduction pairs that read with DS_WRITE2_B32. Use its
-    // exact offset0/1=(0,1), DATA0=v2, DATA1=v1 instruction, read both slots back, and expose their
-    // sum. This also proves DATA0/DATA1 are not accidentally treated as one consecutive VGPR pair.
+    // exact offset0/1=(0,1), DATA0=v2, DATA1=v1 instruction, then expose OFFSET0 alone. A
+    // position-sensitive result proves DATA0/DATA1 are not swapped or treated as one VGPR pair.
     const uint32_t code32b2w[] = {
         0x7e000280u, 0x7e020281u, 0x7e040282u,
         0xd8380100u, 0x00010200u, 0xbf8a0000u,
         0xd8dc0100u, 0x03000000u,
-        0x7e060d03u, 0x7e080d04u, 0x060a0903u, 0xbf810000u,
+        0x7e0a0d03u, 0xbf810000u,
     };
     std::vector<uint32_t> spv32b2w = recompile_valu(
         code32b2w, std::size(code32b2w), 0, 5);
     CHECK(!spv32b2w.empty(), "recompiled kernel 32b2w (Astro DS_WRITE2_B32 word) -> SPIR-V");
     std::vector<float> got32b2w = prosper::test::run_compute(
         spv32b2w, std::vector<float>(1), 1, 1);
-    CHECK(got32b2w.size()==1 && std::fabs(got32b2w[0]-3.0f)<1e-3f,
-          "kernel 32b2w DS_WRITE2_B32 stores DATA0/1 at both packed dword offsets");
+    CHECK(got32b2w.size()==1 && std::fabs(got32b2w[0]-2.0f)<1e-3f,
+          "kernel 32b2w DS_WRITE2_B32 keeps DATA0 at packed OFFSET0");
+
+    // Equal offsets are one access, not two ordered writes: DATA0 wins and DATA1 is ignored.
+    const uint32_t code32b2weq[] = {
+        0x7e000280u, 0x7e020281u, 0x7e040282u,
+        0xd8380000u, 0x00010200u, 0xbf8a0000u,
+        0xd8d80000u, 0x03000000u,
+        0x7e0a0d03u, 0xbf810000u,
+    };
+    std::vector<uint32_t> spv32b2weq = recompile_valu(
+        code32b2weq, std::size(code32b2weq), 0, 5);
+    CHECK(!spv32b2weq.empty(),
+          "recompiled kernel 32b2weq (DS_WRITE2_B32 equal offsets) -> SPIR-V");
+    std::vector<float> got32b2weq = prosper::test::run_compute(
+        spv32b2weq, std::vector<float>(1), 1, 1);
+    CHECK(got32b2weq.size()==1 && std::fabs(got32b2weq[0]-2.0f)<1e-3f,
+          "kernel 32b2weq equal offsets perform one DATA0 access");
 
     // Kernel 32b2a: Astro Bot's large world-map compute program spills each wave lane through
     // DS_WRITE_ADDTID_B32 and reloads it with DS_READ_ADDTID_B32. Unique per-lane input values prove
@@ -1538,6 +1554,24 @@ int main() {
         spv32b2a, in32b2a, (uint32_t)in32b2a.size(), (uint32_t)in32b2a.size());
     CHECK(got32b2a == in32b2a,
           "kernel 32b2a ADDTID round-trips every lane through its own LDS dword");
+
+    // ADDTID addresses use only M0[15:0]. Cross-check the write against an ordinary DS read so the
+    // test cannot pass merely because ADDTID write and read share the same incorrect formula.
+    const uint32_t code32b2amw[] = {
+        0xbefc03ffu, 0x00010000u,   // s_mov_b32 m0, 0x10000 (low 16 bits are zero)
+        0xdac00700u, 0x00000000u,   // ds_write_addtid_b32 v0 offset:0x700
+        0xbf8a0000u,
+        0x7e0402ffu, 0x00000700u,   // v_mov_b32 v2, 0x700
+        0xd8d80000u, 0x01000002u,   // ds_read_b32 v1, v2
+        0xbf810000u,
+    };
+    std::vector<uint32_t> spv32b2amw = recompile_valu(
+        code32b2amw, std::size(code32b2amw), 1, 1);
+    CHECK(!spv32b2amw.empty(), "recompiled kernel 32b2amw (ADDTID write M0 mask) -> SPIR-V");
+    std::vector<float> got32b2amw = prosper::test::run_compute(
+        spv32b2amw, std::vector<float>{1234.0f}, 1, 1);
+    CHECK(got32b2amw == std::vector<float>{1234.0f},
+          "kernel 32b2amw masks M0 to 16 bits before ADDTID write");
 
     // Kernel 32b3: three other exact words from Astro's loading compute shaders. V_MUL_U32_U24
     // must mask both operands to 24 bits, while V_CVT_FLR_I32_F32 must round negative values toward

--- a/prosper/tools/boot_trace/boot_trace.cpp
+++ b/prosper/tools/boot_trace/boot_trace.cpp
@@ -261,7 +261,17 @@ int main(int argc, char** argv) {
     // PROSPER_NO_COMPUTE=1 is a progression diagnostic only: semantic timelines still retain the
     // dispatches, but neither graphics nor compute mutates guest GPU resources. This distinguishes
     // host compute throughput from guest/HLE progression; it is never a correctness mode.
-    if (!getenv("PROSPER_NO_COMPUTE")) prosper::frontend::register_live_compute();
+    if (getenv("PROSPER_COMPUTE_TRANSLATE_ONLY")) {
+        // Shared-machine shader diagnostics need the normal resource discovery/recompiler path but
+        // no Vulkan allocation or submission. A non-null callback makes the executor realize every
+        // dispatch (including PROSPER_SHADER_DUMP failures), then deliberately discards successful
+        // items. Guest GPU resources are not mutated; this is never a correctness/progression mode.
+        prosper::gpu::set_submit_compute(
+            [](const std::vector<prosper::gpu::ComputeItem>& items) { return !items.empty(); });
+        std::fprintf(stderr, "[compute] translate-only diagnostic backend registered\n");
+    } else if (!getenv("PROSPER_NO_COMPUTE")) {
+        prosper::frontend::register_live_compute();
+    }
     // PROSPER_RENDER=1: register the live Vulkan renderer (shared with prosper-app via
     // frontends/shared/live_renderer) so execute_and_present composites every submitted Dcb with
     // draws and hands the frame to the present path; periodic BMP screenshots go to PROSPER_FRAME_DIR


### PR DESCRIPTION
## What changed

- Model `S_ABS_I32` as a 32-bit scalar destination during dynamic descriptor folding, preserving Astro Bot's adjacent descriptor-table pointer.
- Translate the RDNA2 operations used by the remaining world-map compute programs:
  - `DS_WRITE2_B32`
  - `DS_WRITE_ADDTID_B32` / `DS_READ_ADDTID_B32`
  - `S_MULK_I32`
- Add executable regressions using the exact instruction words observed in Astro Bot.
- Add a compute-translation-only boot diagnostic so shaders can be discovered and validated without allocating/submitting Vulkan work on a shared GPU.
- Make periodic renderer captures configurable so long 4K routes can collect sparse evidence without gigabytes of readback I/O.

## Why

The scripted Astro Bot title-to-world-map route previously discovered three compute programs that the RDNA2 translator skipped. One failure was caused by losing an adjacent scalar descriptor pointer; the other failures were unsupported scalar/LDS instructions in the large world-map material and reduction kernels.

With this change, the same route reports **zero skipped compute programs**. A normal real-Vulkan graphics/compute run also reaches `LevelDocument Loaded: worldmap [worldmap]` and continues rendering for hundreds of frames.

The current world-map composition remains near-black, so this is a progression/translator checkpoint rather than a visual-completeness claim. Per the project convention, no near-black screenshot is included. The synthetic AVP intro shortcut was used only to shorten repeated route validation; it is not video correctness evidence.

Progress on #1459.

## Validation

- `cmake --build build-astrobot-fmv --target test_dynfetch_fold test_rdna2_to_spirv test_rdna2_spirv_struct test_rdna2_decode test_game_compute prosper-app boot_trace -j4`
- `ctest --test-dir build-astrobot-fmv --output-on-failure -R '^(rdna2_decode_walk|rdna2_spirv_struct|dynfetch_fold|game_compute_exec|rdna2_to_spirv_exec)$'` — 5/5 passed
- Translation-only scripted title-to-world-map route — zero skipped compute programs
- Real Vulkan scripted route — world map loaded; formerly skipped programs executed; no unsupported-program fallback or command-submission OOM

Snapshot tests were not run. They are optional for day-to-day PRs and required before releases.