### PR TITLE
Correct the fragment overlapping-loop guard and make it CI-visible

### DIFF
--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -879,6 +879,67 @@ int main() {
     }
     printf("  [ok]   complex fragment CFG exports active state from both alternate sites\n");
 
+    // #1474: partially-overlapping LOOPS in the fragment shell. Two back-edges whose ranges cross
+    // without nesting (B's header lies inside A's body, B's back-edge outside it) are what the narrow
+    // pattern structurizer calls unstructured and rejects. Since the graphics CFG dispatcher above
+    // exists, that rejection is no longer the end of the road: the per-invocation dispatcher executes
+    // the exact block graph, so the region lowers instead of dropping the draw. Both directions are
+    // pinned here, in the DEVICE-FREE test, because the Vulkan-execution tests are not built where no
+    // Vulkan device is available — a guard that only runs on a developer GPU is not a guard.
+    const uint32_t overlapping_loops[] = {
+        0xbe800380u,               //  0: s_mov_b32 s0, 0
+        0x7e020284u,               //  1: v_mov_b32 v1, 4
+        0x7da20200u,               //  2: A_HDR: v_cmpx_lt_u32 s0, v1
+        0xbf880006u,               //  3: s_cbranch_execz +6 -> 10 (export)
+        0x7da20200u,               //  4: B_HDR: v_cmpx_lt_u32 s0, v1
+        0xbf880006u,               //  5: s_cbranch_execz +6 -> 12 (endpgm)
+        0x81008100u,               //  6: s0++
+        0xbf82fffau,               //  7: s_branch -6 -> 2  (A back-edge; A = [2,7])
+        0x81008100u,               //  8: s0++
+        0xbf82fffau,               //  9: s_branch -6 -> 4  (B back-edge; B = [4,9] crosses A)
+        0xf800180fu, 0x05020302u,  // 10: exp mrt0
+        0xbf810000u,               // 12: s_endpgm
+    };
+    const auto overlapping_spv =
+        recompile_fragment(overlapping_loops, std::size(overlapping_loops));
+    if (overlapping_spv.empty() || !has_opcode(overlapping_spv, 251) ||
+        !type_result_ids_are_nonzero(overlapping_spv, nullptr) ||
+        !phi_ids_are_nonzero(overlapping_spv)) {
+        printf("  [FAIL] #1474: partially-overlapping fragment loops did not lower through a valid "
+               "OpSwitch dispatcher\n");
+        return 1;
+    }
+    printf("  [ok]   #1474: partially-overlapping fragment loops lower through the CFG dispatcher\n");
+
+    // The fail-visible backstop still has to work. A cross-lane MBCNT inside the same region
+    // disqualifies the per-invocation dispatcher — one guest lane cannot answer for the whole wave —
+    // and with the narrow structurizer already rejecting, the only remaining outcome is a loud
+    // reject. This mirrors how the compute-side #590 case keeps an s_barrier in its region for
+    // exactly the same reason (test_rdna2_to_spirv.cpp). Branch offsets are re-based for the MBCNT's
+    // two dwords; dropping the MBCNT makes this region lower, which is what makes the guard real.
+    const uint32_t overlapping_loops_cross_lane[] = {
+        0xbe800380u,               //  0: s_mov_b32 s0, 0
+        0x7e020284u,               //  1: v_mov_b32 v1, 4
+        0x7da20200u,               //  2: A_HDR: v_cmpx_lt_u32 s0, v1
+        0xbf880008u,               //  3: s_cbranch_execz +8 -> 12 (export)
+        0x7da20200u,               //  4: B_HDR: v_cmpx_lt_u32 s0, v1
+        0xbf880008u,               //  5: s_cbranch_execz +8 -> 14 (endpgm)
+        0xd7650004u, 0x000100c1u,  //  6: v_mbcnt_lo_u32_b32 v4, -1, 0  (cross-lane)
+        0x81008100u,               //  8: s0++
+        0xbf82fff8u,               //  9: s_branch -8 -> 2  (A back-edge; A = [2,9])
+        0x81008100u,               // 10: s0++
+        0xbf82fff8u,               // 11: s_branch -8 -> 4  (B back-edge; B = [4,11] crosses A)
+        0xf800180fu, 0x05020302u,  // 12: exp mrt0
+        0xbf810000u,               // 14: s_endpgm
+    };
+    if (!recompile_fragment(overlapping_loops_cross_lane,
+                            std::size(overlapping_loops_cross_lane)).empty()) {
+        printf("  [FAIL] #1474: cross-lane MBCNT inside an unstructured fragment region must "
+               "REJECT, not lower through the per-invocation dispatcher\n");
+        return 1;
+    }
+    printf("  [ok]   #1474: cross-lane op in an unstructured fragment region still rejects loudly\n");
+
     // The graphics CFG dispatcher must retain the fragment shell's already-proven alpha-test
     // linearization.  This reduced Astro Bot shape prefixes the crossing-region CFG above with a
     // survivor-mask SCC early-out.  The SCC from s_andn2_b64 is a whole-wave reduction, not an SSA

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -883,9 +883,20 @@ int main() {
     // without nesting (B's header lies inside A's body, B's back-edge outside it) are what the narrow
     // pattern structurizer calls unstructured and rejects. Since the graphics CFG dispatcher above
     // exists, that rejection is no longer the end of the road: the per-invocation dispatcher executes
-    // the exact block graph, so the region lowers instead of dropping the draw. Both directions are
-    // pinned here, in the DEVICE-FREE test, because the Vulkan-execution tests are not built where no
-    // Vulkan device is available — a guard that only runs on a developer GPU is not a guard.
+    // the exact block graph, so the region lowers instead of dropping the draw.
+    //
+    // Two properties of this stream are worth stating, because both are easy to misread:
+    //   * The crossing pair is SYNTACTIC only — pc7 is an unconditional s_branch, so pc8/pc9 (B's
+    //     back-edge) are unreachable. detect_divergent_loops collects back-edges without a
+    //     reachability filter, so the pair check still sees the overlap and rejects. If that pass
+    //     ever gains reachability pruning, the accept assertion below fails for a GOOD reason.
+    //   * The rejection is OVER-DETERMINED: pc3's execz targets 10, past A's exit at 8, so pass 2's
+    //     "conditional jump past the loop" rule would reject this stream even with the overlap check
+    //     deleted. Neither this assertion nor the pre-#1474 one isolates overlap as the sole cause.
+    //
+    // Both directions are pinned here, in the DEVICE-FREE test, rather than only in the
+    // Vulkan-execution tests: those are gated on find_package(Vulkan) succeeding, and CI disables
+    // Vulkan discovery outright, so a guard living only there never runs in CI at all.
     const uint32_t overlapping_loops[] = {
         0xbe800380u,               //  0: s_mov_b32 s0, 0
         0x7e020284u,               //  1: v_mov_b32 v1, 4
@@ -909,14 +920,29 @@ int main() {
                "OpSwitch dispatcher\n");
         return 1;
     }
+    // Lowering is not enough: a dispatcher that emitted the block graph but dropped the export would
+    // satisfy every check above, and the device-side test only asserts the readback's size — that is
+    // exactly the "silent skip drops real rendered content" failure the charter warns about. This
+    // stream has one export site, so it must produce exactly one output store.
+    if (output_store_stats(overlapping_spv).stores != 1) {
+        printf("  [FAIL] #1474: dispatcher-lowered overlapping loops dropped the export (stores=%u)\n",
+               output_store_stats(overlapping_spv).stores);
+        return 1;
+    }
     printf("  [ok]   #1474: partially-overlapping fragment loops lower through the CFG dispatcher\n");
 
     // The fail-visible backstop still has to work. A cross-lane MBCNT inside the same region
-    // disqualifies the per-invocation dispatcher — one guest lane cannot answer for the whole wave —
-    // and with the narrow structurizer already rejecting, the only remaining outcome is a loud
-    // reject. This mirrors how the compute-side #590 case keeps an s_barrier in its region for
-    // exactly the same reason (test_rdna2_to_spirv.cpp). Branch offsets are re-based for the MBCNT's
-    // two dwords; dropping the MBCNT makes this region lower, which is what makes the guard real.
+    // disqualifies the per-invocation dispatcher — inside a dispatcher case the lanes of one subgroup
+    // sit at different guest blocks, so MBCNT's subgroup exclusive scan would be answering for a wave
+    // that is not there. See the `reason=mbcnt-cross-lane` reject in rdna2_to_spirv.cpp; if graphics
+    // ever gains a synchronized common phase that closes the gap, this assertion fails LOUDLY rather
+    // than silently losing the reject coverage. With the narrow structurizer already rejecting, a
+    // loud reject is the only remaining outcome. The compute-side #590 case keeps an s_barrier in its
+    // region for the same purpose (test_rdna2_to_spirv.cpp).
+    //
+    // Branch offsets are re-based for the MBCNT's two dwords, and the MBCNT sits on the REACHABLE
+    // path (pc5's fallthrough), not in the dead region above. Dropping it makes this stream lower,
+    // which is what makes the guard real rather than decorative.
     const uint32_t overlapping_loops_cross_lane[] = {
         0xbe800380u,               //  0: s_mov_b32 s0, 0
         0x7e020284u,               //  1: v_mov_b32 v1, 4

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -890,13 +890,15 @@ int main() {
     //     back-edge) are unreachable. detect_divergent_loops collects back-edges without a
     //     reachability filter, so the pair check still sees the overlap and rejects. If that pass
     //     ever gains reachability pruning, the accept assertion below fails for a GOOD reason.
-    //   * The rejection is OVER-DETERMINED: pc3's execz targets 10, past A's exit at 8, so pass 2's
-    //     "conditional jump past the loop" rule would reject this stream even with the overlap check
-    //     deleted. Neither this assertion nor the pre-#1474 one isolates overlap as the sole cause.
+    //   * The rejection is OVER-DETERMINED: pc3's execz targets 10, past A's exit_pc of 8 (the dword
+    //     after A's back-edge, not A's exit target), so pass 2's "conditional jump past the loop" rule
+    //     would reject this stream even with the overlap check deleted. Neither this assertion nor the
+    //     pre-#1474 one isolates overlap as the sole cause of rejection.
     //
     // Both directions are pinned here, in the DEVICE-FREE test, rather than only in the
-    // Vulkan-execution tests: those are gated on find_package(Vulkan) succeeding, and CI disables
-    // Vulkan discovery outright, so a guard living only there never runs in CI at all.
+    // Vulkan-execution tests: those are gated on find_package(Vulkan) succeeding, and every CI job
+    // that runs ctest either disables Vulkan discovery (Linux, Windows MinGW, macOS) or runs a
+    // three-test seam subset (Windows App), so a guard living only there never runs in CI at all.
     const uint32_t overlapping_loops[] = {
         0xbe800380u,               //  0: s_mov_b32 s0, 0
         0x7e020284u,               //  1: v_mov_b32 v1, 4
@@ -923,13 +925,17 @@ int main() {
     // Lowering is not enough: a dispatcher that emitted the block graph but dropped the export would
     // satisfy every check above, and the device-side test only asserts the readback's size — that is
     // exactly the "silent skip drops real rendered content" failure the charter warns about. This
-    // stream has one export site, so it must produce exactly one output store.
-    if (output_store_stats(overlapping_spv).stores != 1) {
-        printf("  [FAIL] #1474: dispatcher-lowered overlapping loops dropped the export (stores=%u)\n",
-               output_store_stats(overlapping_spv).stores);
+    // stream has one EXP site, so it must produce exactly one output store. The count is exact rather
+    // than >= 1 so a DOUBLED export (which would write MRT0 twice) fails too; the neighbouring
+    // two-site test asserting stores == 2 is the cross-check that this counts sites, not components.
+    const OutputStoreStats overlapping_outputs = output_store_stats(overlapping_spv);
+    if (overlapping_outputs.stores != 1) {
+        printf("  [FAIL] #1474: dispatcher-lowered overlapping loops did not export exactly once "
+               "(stores=%u)\n", overlapping_outputs.stores);
         return 1;
     }
-    printf("  [ok]   #1474: partially-overlapping fragment loops lower through the CFG dispatcher\n");
+    printf("  [ok]   #1474: partially-overlapping fragment loops lower through the CFG dispatcher, "
+           "exporting exactly once\n");
 
     // The fail-visible backstop still has to work. A cross-lane MBCNT inside the same region
     // disqualifies the per-invocation dispatcher — inside a dispatcher case the lanes of one subgroup

--- a/prosper/tests/test_recompiled_fragment.cpp
+++ b/prosper/tests/test_recompiled_fragment.cpp
@@ -553,8 +553,13 @@ int main() {
             }
         }
 
-        // Partially-overlapping loops (a back-edge into another loop's body without proper nesting)
-        // remain rejected in the fragment shell (no dispatcher fallback exists there).
+        // Partially-overlapping loops (a back-edge into another loop's body without proper nesting).
+        // The narrow pattern structurizer still calls this unstructured and rejects it, but the
+        // graphics CFG dispatcher added for Astro Bot's materials then executes the exact block graph
+        // per invocation, so the region lowers rather than dropping the draw (#1474). This test owns
+        // the half that needs a device: a real driver has to accept the module. The accept/reject
+        // contract itself is pinned device-free in test_rdna2_spirv_struct, because these
+        // Vulkan-execution tests are not built where no Vulkan device is available.
         const uint32_t overlap_ps[] = {
             0xBE800380u, 0x7E020284u,
             0x7DA20200u,               //  2: A_HDR: v_cmpx_lt_u32 s0, v1
@@ -568,8 +573,18 @@ int main() {
             0xF800180Fu, 0x05020302u,  // 10: export
             0xBF810000u,               // 12: s_endpgm
         };
-        CHECK(recompile_fragment(overlap_ps, sizeof(overlap_ps)/sizeof(overlap_ps[0])).empty(),
-              "#590: partially-overlapping loops remain REJECTED (fragment)");
+        std::vector<uint32_t> overlap_frag =
+            recompile_fragment(overlap_ps, sizeof(overlap_ps)/sizeof(overlap_ps[0]));
+        CHECK(!overlap_frag.empty() && overlap_frag[0] == 0x07230203u,
+              "#1474: partially-overlapping fragment loops lower to a SPIR-V module");
+        if (!overlap_frag.empty()) {
+            // Pipeline creation is the assertion: the driver validates the dispatcher's output, so a
+            // structurally invalid lowering fails here rather than silently producing a module.
+            std::vector<uint8_t> overlap_px =
+                prosper::test::render_triangle_rgba(vert, overlap_frag, W, H);
+            CHECK(overlap_px.size() == (size_t)W * H * 4,
+                  "#1474: a real driver accepts the dispatcher-lowered overlapping-loop shader");
+        }
     }
 
     // SCALAR-SPILL lane slots (#273): v_writelane_b32 packs two scalars into v10's lanes 3/7 and

--- a/prosper/tests/test_recompiled_fragment.cpp
+++ b/prosper/tests/test_recompiled_fragment.cpp
@@ -558,8 +558,10 @@ int main() {
         // graphics CFG dispatcher added for Astro Bot's materials then executes the exact block graph
         // per invocation, so the region lowers rather than dropping the draw (#1474). This test owns
         // the half that needs a device: a real driver has to accept the module. The accept/reject
-        // contract itself is pinned device-free in test_rdna2_spirv_struct, because these
-        // Vulkan-execution tests are not built where no Vulkan device is available.
+        // contract itself — including that the export survives the lowering — is pinned device-free in
+        // test_rdna2_spirv_struct, because these Vulkan-execution tests are gated on
+        // find_package(Vulkan) succeeding and CI disables Vulkan discovery outright, so nothing here
+        // runs in CI.
         const uint32_t overlap_ps[] = {
             0xBE800380u, 0x7E020284u,
             0x7DA20200u,               //  2: A_HDR: v_cmpx_lt_u32 s0, v1

--- a/prosper/tests/test_recompiled_fragment.cpp
+++ b/prosper/tests/test_recompiled_fragment.cpp
@@ -560,8 +560,9 @@ int main() {
         // the half that needs a device: a real driver has to accept the module. The accept/reject
         // contract itself — including that the export survives the lowering — is pinned device-free in
         // test_rdna2_spirv_struct, because these Vulkan-execution tests are gated on
-        // find_package(Vulkan) succeeding and CI disables Vulkan discovery outright, so nothing here
-        // runs in CI.
+        // find_package(Vulkan) succeeding and every CI job that runs ctest either disables Vulkan
+        // discovery (Linux, Windows MinGW, macOS) or runs a three-test seam subset (Windows App), so
+        // nothing here runs in CI.
         const uint32_t overlap_ps[] = {
             0xBE800380u, 0x7E020284u,
             0x7DA20200u,               //  2: A_HDR: v_cmpx_lt_u32 s0, v1


### PR DESCRIPTION
Fixes #1474.

> **Correction (2026-07-30).** An earlier revision of this description claimed that `16af6924` also
> updated the compute-side twin of this guard. **That was wrong** — `16af6924` touches only
> `rdna2_to_spirv.cpp` and `test_rdna2_spirv_struct.cpp`. The provenance below is the verified version,
> and it supports the same conclusion more strongly. Thanks to review for catching it.

## What was failing

`test_recompiled_fragment` has been failing on any machine where `find_package(Vulkan)` succeeds:

```
[FAIL] #590: partially-overlapping loops remain REJECTED (fragment)
```

## Root cause — a guard whose premise was removed under it

Bisected (437 commits, automated) to **`16af6924` "fix(gpu): lower complex graphics control flow"**.

The actual history, verified:

- **`134342c7`** ("structurize nested divergent EXEC/VCC-exit loops (#590)") created *both* the compute
  and fragment guards. At that point compute already had the CFG state-machine dispatcher, and its
  guard says so in as many words (`test_rdna2_to_spirv.cpp:4263-4266`): *"In compute they may
  **legitimately** fall to the CFG state-machine dispatcher (faithful wave emulation) — so this stream
  carries a mid-region `s_barrier`, which disqualifies the dispatcher too."* Fragment had no dispatcher,
  so its guard was written as a plain strict reject, and its comment stated the premise: *"no dispatcher
  fallback exists there"*.
- **`16af6924`** then gave the fragment/vertex path exactly such a dispatcher (`complex_graphics_cfg &&
  cf_rejected`). That removed the fragment guard's premise. Nobody updated the guard.

So the guard's own author already regarded dispatcher fallback as *legitimate* for this shape and
disqualified it deliberately where it applied. Fragment strictness was contingent, and the contingency
is gone.

**Corroborating, not authoritative:** PR #1461 (an unmerged, unreviewed draft in another workstream)
rewrites this same block to `"partially-overlapping fragment loops use the explicit CFG dispatcher"`,
and its author separately characterized the mechanism in their own words — *"the graphics CFG dispatcher
represents the irreducible guest PC graph explicitly and must still produce structurally valid
SPIR-V."* That second independent reading of the same code is the part worth citing; the agreement
itself is **correlated, not independent**, since both changes were provoked by the same failing
assertion on the same master. It ranks below `134342c7`'s comment and the structural argument above,
and is not evidence of correctness on its own. Note also that #1461's replacement assertion is weaker
than this one (no `OpSwitch` check, no export-survival check), so this PR supersedes rather than
duplicates it.

## Why acceptance is correct

Worth being precise, because the obvious argument is *not* sufficient: "valid SPIR-V + a driver builds
a pipeline" would not settle it — a mis-structurized loop nest can be perfectly valid SPIR-V and still
emit wrong pixels.

The sufficient argument is structural: `emit_cfg_state_machine` **does not structurize at all**. It
splits at every branch target and fallthrough, emits one `OpSwitch` case per guest block, persists the
register file in `Function` variables, and lowers a back-edge as nothing more than a store to `pc_var`;
graphics conditions branch on *this invocation's own* VCC/EXEC bool with no wave vote. The exact hazard
the old guard existed to prevent — a crossing pair mis-nested into an incorrect `OpLoopMerge` tree that
silently emits wrong pixels — is structurally impossible on the accepted path.

Supporting evidence: the region lowers to a 791-dword module, `spirv-val --target-env vulkan1.2` is
clean, and a real driver builds a pipeline from it. Rejecting it instead would drop the draw, which is
what `CLAUDE.md`'s *"an unsupported shader/GPU operation is a FATAL gap, not an acceptable skip"* exists
to prevent.

## The other half of the bug: the guard never ran in CI

CI's Linux job runs **122** tests; a local build runs **147**. The Vulkan-execution tests are inside
`if(Vulkan_FOUND)`, and **every CI job that runs full ctest — Linux, Windows MinGW, macOS — passes
`-DCMAKE_DISABLE_FIND_PACKAGE_Vulkan=TRUE`**, so they are never built in those jobs. Of the rest,
Windows App keeps Vulkan but runs only a three-test seam subset, and Linux App / macOS App build
`prosper-app` and run no tests at all. **Neither #590 loop guard has ever run in CI** — which is
precisely how a behaviour change could land with its guard failing while master stayed green.

Note this is a *dev-files* gate, not a device gate: on a headless machine with `libvulkan-dev` present
they do build and run.

A guard that only runs where Vulkan headers happen to be installed is not a guard, so the
accept/reject contract now lives in the **device-free** test:

| Test | In CI | Now asserts |
|---|---|---|
| `test_rdna2_spirv_struct` | **yes** (#87) | the region lowers through a valid `OpSwitch` dispatcher, **exports exactly once** (`stores == 1`, exact so a doubled export fails too), **and** the same region carrying a cross-lane `MBCNT` still rejects loudly |
| `test_recompiled_fragment` | no | only the half needing a driver: a real driver accepts the dispatcher-lowered module |

The reject case uses a cross-lane `MBCNT` as its disqualifier: inside a dispatcher case the lanes of one
subgroup sit at different guest blocks, so MBCNT's subgroup scan would be answering for a wave that is
not there. That is a design-level gap, not an unimplemented opcode, so if graphics ever gains a
synchronized common phase this assertion fails *loudly* rather than silently losing reject coverage.

## Two properties of the test stream, now recorded in-file

Both are easy to misread, and a future reader deserves them:

- **The crossing pair is syntactic only.** pc7 is an unconditional `s_branch`, so pc8/pc9 (B's
  back-edge) are unreachable. `detect_divergent_loops` collects back-edges with no reachability filter,
  which is why the pair check still sees the overlap. If that pass ever gains reachability pruning, the
  accept assertion will fail for a *good* reason.
- **The rejection is over-determined.** pc3's `execz` targets 10, past A's `exit_pc` of 8 (the dword after A's back-edge, not A's exit target), which pass 2
  rejects independently of the overlap check. Neither this assertion nor the pre-#1474 one isolates
  overlap as the sole cause of rejection. (Both inherited from `134342c7`.)

## Verification

```
full build + ctest  ->  100% tests passed, 147/147
  #87  rdna2_spirv_struct ......... Passed
  #130 recompiled_fragment_render . Passed   (was FAILING before this change)
git diff --check    ->  clean
```

**Mutation-tested, so no new assertion is vacuous:**

| Mutation | Result |
|---|---|
| force `complex_graphics_cfg = false` (disable the graphics dispatcher) | dispatcher assertions **fail** |
| drop the cross-lane `MBCNT` from the reject case | that region **lowers** → reject assertion **fails** |
| expect the wrong export count | fails and reports `stores=1`, so the check reads a real value |

The accept assertion's dependence on the dispatcher is independently established by the bisect: at
`134342c7` the identical shader was rejected.

## Deliberately unaffected

No production code changes — `prosper/src/` is untouched. The compute-side `#590` guard, the existing
`fragment_cfg_dispatch` positive test, and every other assertion in both files are unchanged.

## Risks and known gaps

- This **ratifies `16af6924`'s intent** rather than restoring the old rejection. If the original author
  intended fragment to stay strict regardless, this is the place to say so.
- The assertions pin *structure* (dispatcher lowering, export survival, driver acceptance), not guest
  execution semantics. The stream is synthetic and its second loop is dead, so asserting numeric output
  would pin an arbitrary interpretation rather than real behaviour.
- **Pre-existing gap, now tracked:** nothing anywhere *executes* the graphics dispatcher over a
  reachable crossing CFG and checks values. The Astro Bot dispatcher tests are structural, and the only
  executed numeric dispatcher coverage is compute-side (#825 kernels 17d/17e/17f) which also does not
  run in CI. Filed separately rather than expanded into this PR.
- **#1461** (draft) touches both `rdna2_to_spirv.cpp` (`detect_divergent_loops`) and the same hunk of
  `test_recompiled_fragment.cpp`. Whichever lands second reconciles by hand; this PR is tests-only to
  keep that trivial. Happy to rebase behind #1461 if its author prefers.
