### PR TITLE
gpu: restore an Astro Bot world-map shader pipeline

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -3125,37 +3125,135 @@ uint32_t scalar_write_width(const Rdna2Inst& in);
 std::unordered_set<uint32_t> mask_test_branches(const std::vector<Rdna2Inst>& ins,
                                                 bool allow_b32_masks = false) {
     std::unordered_set<uint32_t> out;
-    std::unordered_set<int> b32_masks;
     std::unordered_set<uint32_t> b32_mask_writer_pcs;
     std::unordered_set<uint32_t> block_entries;
-    if (allow_b32_masks) {
-        for (const auto& candidate : ins) {
-            if (candidate.is_end) break;
-            if (candidate.fmt != Rdna2Format::SOPP ||
-                (candidate.opcode != 0x02 &&
-                 (candidate.opcode < 0x04 || candidate.opcode > 0x09)))
-                continue;
-            const int64_t target = static_cast<int64_t>(candidate.pc) +
-                candidate.len_dwords + candidate.simm16;
-            if (target >= 0 && target <= UINT32_MAX)
-                block_entries.insert(static_cast<uint32_t>(target));
+    size_t active_count = 0;
+    while (active_count < ins.size() && !ins[active_count].is_end) ++active_count;
+    std::unordered_map<uint32_t, size_t> index_by_pc;
+    for (size_t i = 0; i < active_count; ++i) index_by_pc.emplace(ins[i].pc, i);
+    auto is_scalar_branch = [](const Rdna2Inst& candidate) {
+        return candidate.fmt == Rdna2Format::SOPP &&
+            (candidate.opcode == 0x02 ||
+             (candidate.opcode >= 0x04 && candidate.opcode <= 0x09));
+    };
+    auto branch_target_pc = [](const Rdna2Inst& candidate) -> int64_t {
+        return static_cast<int64_t>(candidate.pc) + candidate.len_dwords + candidate.simm16;
+    };
+    for (size_t i = 0; i < active_count; ++i) {
+        if (!is_scalar_branch(ins[i])) continue;
+        const int64_t target = branch_target_pc(ins[i]);
+        if (target >= 0 && target <= UINT32_MAX)
+            block_entries.insert(static_cast<uint32_t>(target));
+    }
+
+    // Transfer one instruction's one-word Wave32-mask provenance. The domain is a MUST fact: an
+    // SGPR is present only when every path reaching this instruction proves that it contains a
+    // complete Wave32 lane mask. This preserves masks through a conditional fall-through (the live
+    // Astro alpha-test preamble) while intersecting away a compare performed on only one predecessor.
+    auto transfer_b32_masks = [&](const Rdna2Inst& in,
+                                  const std::unordered_set<int>& incoming,
+                                  bool* mask_writer) {
+        std::unordered_set<int> masks = incoming;
+        auto tracked_mask_source = [&](const Operand& source) {
+            return source.value == 126 ||
+                   ((source.kind == OperandKind::SGPR ||
+                     source.kind == OperandKind::Special) &&
+                    incoming.contains(source.value));
+        };
+        bool writes_b32_mask = false;
+        int mask_dst = -1;
+        if (in.fmt == Rdna2Format::VOPC && !vopc_is_cmpx(in.opcode)) {
+            mask_dst = in.dst.kind == OperandKind::SGPR ? in.dst.value : 106;
+            writes_b32_mask = true;
+        } else if (in.fmt == Rdna2Format::SOP1 &&
+                   (in.opcode == 0x03 || in.opcode == 0x09 ||
+                    in.opcode == 0x3c || in.opcode == 0x40 || in.opcode == 0x44)) {
+            writes_b32_mask = tracked_mask_source(in.src[0]) && in.dst.value != 127;
+            mask_dst = in.dst.value;
+        } else if (in.fmt == Rdna2Format::SOP2 &&
+                   (in.opcode == 0x0a ||
+                    (in.opcode >= 0x0e && in.opcode <= 0x1c &&
+                     (in.opcode & 1u) == 0))) {
+            const bool real_mask_source = tracked_mask_source(in.src[0]) ||
+                                          tracked_mask_source(in.src[1]);
+            auto representable = [&](const Operand& source) {
+                return tracked_mask_source(source) || source.kind == OperandKind::InlineInt;
+            };
+            writes_b32_mask = real_mask_source && representable(in.src[0]) &&
+                              representable(in.src[1]) && in.dst.value != 127;
+            mask_dst = in.dst.value;
+        } else if (in.fmt == Rdna2Format::VOP3 &&
+                   in.opcode >= 0x128 && in.opcode <= 0x12a &&
+                   in.sdst.kind == OperandKind::SGPR) {
+            writes_b32_mask = tracked_mask_source(in.src[2]);
+            mask_dst = in.sdst.value;
+        }
+
+        auto erase_written_words = [&](int base, uint32_t width) {
+            for (uint32_t word = 0; word < width; ++word)
+                masks.erase(base + static_cast<int>(word));
+        };
+        const uint32_t dst_width = scalar_write_width(in);
+        if (dst_width) erase_written_words(in.dst.value, dst_width);
+        if (in.fmt == Rdna2Format::VOPC && !vopc_is_cmpx(in.opcode) &&
+            in.dst.kind == OperandKind::SGPR && in.dst.value <= 105)
+            erase_written_words(in.dst.value, 1);
+        if (in.fmt == Rdna2Format::VOP3 && in.sdst.kind == OperandKind::SGPR)
+            erase_written_words(in.sdst.value,
+                in.opcode >= 0x128 && in.opcode <= 0x12a ? 1u : 2u);
+        if (writes_b32_mask && mask_dst >= 0 && mask_dst != 126)
+            masks.insert(mask_dst);
+        if (mask_writer) *mask_writer = writes_b32_mask && mask_dst >= 0 && mask_dst != 126;
+        return masks;
+    };
+
+    if (allow_b32_masks && active_count) {
+        std::vector<std::unordered_set<int>> incoming(active_count);
+        std::vector<bool> reachable(active_count, false);
+        std::vector<size_t> worklist{0};
+        reachable[0] = true;
+        auto merge_into = [&](size_t successor, const std::unordered_set<int>& masks) {
+            if (!reachable[successor]) {
+                incoming[successor] = masks;
+                reachable[successor] = true;
+                worklist.push_back(successor);
+                return;
+            }
+            std::unordered_set<int> intersection;
+            for (int reg : incoming[successor])
+                if (masks.contains(reg)) intersection.insert(reg);
+            if (intersection != incoming[successor]) {
+                incoming[successor] = std::move(intersection);
+                worklist.push_back(successor);
+            }
+        };
+        for (size_t cursor = 0; cursor < worklist.size(); ++cursor) {
+            const size_t i = worklist[cursor];
+            const auto outgoing = transfer_b32_masks(ins[i], incoming[i], nullptr);
+            auto merge_pc = [&](int64_t pc) {
+                if (pc < 0 || pc > UINT32_MAX) return;
+                const auto found = index_by_pc.find(static_cast<uint32_t>(pc));
+                if (found != index_by_pc.end()) merge_into(found->second, outgoing);
+            };
+            if (is_scalar_branch(ins[i])) {
+                merge_pc(branch_target_pc(ins[i]));
+                if (ins[i].opcode != 0x02 && i + 1 < active_count)
+                    merge_into(i + 1, outgoing);
+            } else if (i + 1 < active_count) {
+                merge_into(i + 1, outgoing);
+            }
+        }
+        for (size_t i = 0; i < active_count; ++i) {
+            if (!reachable[i]) continue;
+            bool writes_mask = false;
+            (void)transfer_b32_masks(ins[i], incoming[i], &writes_mask);
+            if (writes_mask) b32_mask_writer_pcs.insert(ins[i].pc);
         }
     }
-    auto tracked_mask_source = [&](const Operand& source) {
-        return source.value == 126 ||
-               ((source.kind == OperandKind::SGPR ||
-                 source.kind == OperandKind::Special) &&
-                b32_masks.contains(source.value));
-    };
+
     const Rdna2Inst* prev = nullptr;
     for (const auto& in : ins) {
-        // B32 mask provenance is intentionally basic-block local. A linear scan cannot prove which
-        // predecessor supplied an SGPR at a join, so carrying one arm's compare into the merge can
-        // make an ordinary scalar SCC branch look like a disposable whole-wave vote.
-        if (allow_b32_masks && block_entries.contains(in.pc)) {
-            b32_masks.clear();
-            prev = nullptr;
-        }
+        if (block_entries.contains(in.pc)) prev = nullptr;
         if (in.is_end) break;
         if (sopp_is_noop(in)) continue;                         // hints don't break the mask->branch pairing
         if (in.fmt == Rdna2Format::SOPP && (in.opcode == 0x04 || in.opcode == 0x05) && in.simm16 > 0) {
@@ -3188,65 +3286,7 @@ std::unordered_set<uint32_t> mask_test_branches(const std::vector<Rdna2Inst>& in
             }
         }
 
-        if (allow_b32_masks) {
-            bool writes_b32_mask = false;
-            int mask_dst = -1;
-            if (in.fmt == Rdna2Format::VOPC && !vopc_is_cmpx(in.opcode)) {
-                mask_dst = in.dst.kind == OperandKind::SGPR ? in.dst.value : 106;
-                writes_b32_mask = true;
-            } else if (in.fmt == Rdna2Format::SOP1 &&
-                       (in.opcode == 0x03 || in.opcode == 0x09 ||
-                        in.opcode == 0x3c || in.opcode == 0x40 || in.opcode == 0x44)) {
-                writes_b32_mask = tracked_mask_source(in.src[0]) && in.dst.value != 127;
-                mask_dst = in.dst.value;
-            } else if (in.fmt == Rdna2Format::SOP2 &&
-                       (in.opcode == 0x0a ||
-                        (in.opcode >= 0x0e && in.opcode <= 0x1c &&
-                         (in.opcode & 1u) == 0))) {
-                const bool real_mask_source = tracked_mask_source(in.src[0]) ||
-                                              tracked_mask_source(in.src[1]);
-                auto representable = [&](const Operand& source) {
-                    return tracked_mask_source(source) || source.kind == OperandKind::InlineInt;
-                };
-                writes_b32_mask = real_mask_source && representable(in.src[0]) &&
-                                  representable(in.src[1]) && in.dst.value != 127;
-                mask_dst = in.dst.value;
-            } else if (in.fmt == Rdna2Format::VOP3 &&
-                       in.opcode >= 0x128 && in.opcode <= 0x12a &&
-                       in.sdst.kind == OperandKind::SGPR) {
-                writes_b32_mask = tracked_mask_source(in.src[2]);
-                mask_dst = in.sdst.value;
-            }
-
-            // End every overwritten word's prior lifetime before publishing a newly-proven mask
-            // result. In particular, a B64 write must invalidate an independently tracked Wave32
-            // mask in its high word; otherwise a later ordinary B32 ALU op can inherit stale mask
-            // provenance and make us drop a real SCC branch.
-            auto erase_written_words = [&](int base, uint32_t width) {
-                for (uint32_t word = 0; word < width; ++word)
-                    b32_masks.erase(base + static_cast<int>(word));
-            };
-            const uint32_t dst_width = scalar_write_width(in);
-            if (dst_width) erase_written_words(in.dst.value, dst_width);
-            if (in.fmt == Rdna2Format::VOPC && !vopc_is_cmpx(in.opcode) &&
-                in.dst.kind == OperandKind::SGPR && in.dst.value <= 105)
-                erase_written_words(in.dst.value, 1);
-            if (in.fmt == Rdna2Format::VOP3 && in.sdst.kind == OperandKind::SGPR)
-                erase_written_words(in.sdst.value,
-                    in.opcode >= 0x128 && in.opcode <= 0x12a ? 1u : 2u);
-            if (writes_b32_mask && mask_dst >= 0 && mask_dst != 126) {
-                b32_masks.insert(mask_dst);
-                b32_mask_writer_pcs.insert(in.pc);
-            }
-        }
-        const bool ends_block = in.fmt == Rdna2Format::SOPP &&
-            (in.opcode == 0x02 || (in.opcode >= 0x04 && in.opcode <= 0x09));
-        if (allow_b32_masks && ends_block) {
-            b32_masks.clear();
-            prev = nullptr;
-        } else {
-            prev = &in;
-        }
+        prev = is_scalar_branch(in) ? nullptr : &in;
     }
     return out;
 }

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -7727,6 +7727,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // SOFFSET is NULL/0. Stores retain their existing stricter paths.
             bool dyn_half = false;   // Float16 components at an arbitrary runtime byte address
             bool dyn_int = false;    // integer sub-dword FORMAT component at a runtime (unaligned) byte addr
+            bool dyn_norm = false;   // normalized sub-dword FORMAT component at an arbitrary byte addr
             bool dyn_int_store = false;  // integer sub-dword FORMAT store via race-free atomic clear+set
             if (packed && !raw_subword) {
                 bool base_aligned;
@@ -7757,6 +7758,12 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     // address (join the straddled dwords, then bfe), so it needs no static alignment.
                     // Only LOADS: the packed store path still rejects sub-dword ints (they don't pack).
                     if (!dyn_half) dyn_int = int_subword && !is_store;
+                    // UNORM/SNORM 8/16 loads use the same runtime extraction, followed by the format's
+                    // normalization. Astro's world-map VS fetches SNORM16x3 with a shader-computed
+                    // SOFFSET; treating it as statically packed rejected the complete map draw.
+                    if (!dyn_half && !dyn_int)
+                        dyn_norm = !packed_word && !is_store && norm != 0.0f &&
+                                   (comp_bytes == 1 || comp_bytes == 2);
                     // An integer sub-dword FORMAT STORE writes ONE lane's disjoint bit field of the
                     // containing dword. A plain masked read-modify-write would race (adjacent lanes' fields
                     // share a dword), but atomicAnd(clear field)+atomicOr(set field) COMMUTE across lanes
@@ -7766,7 +7773,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     if (!dyn_half && !dyn_int && is_store && int_subword && !offen && !dyn_vfetch &&
                         (offset % comp_bytes) == 0 && (!idxen || (stride % comp_bytes) == 0) && soff_zero)
                         dyn_int_store = true;
-                    if (!dyn_half && !dyn_int && !dyn_int_store) {
+                    if (!dyn_half && !dyn_int && !dyn_norm && !dyn_int_store) {
                         if (getenv("PROSPER_DBG"))
                             fprintf(stderr, "[mubuf-unaligned] pc=%u fmt=%u off=%u offen=%d idxen=%d stride=%u\n",
                                     in.pc, (unsigned)fmt, offset, (int)offen, (int)idxen, stride);
@@ -7954,11 +7961,12 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     joined = b.ibin(Op_BitwiseOr, joined,
                                     b.sel(b.ucmp(Op_IEqual, shift, b.uconst(0)), b.uconst(0), upper));
                     value = b.unpack_half(joined, 0);
-                } else if (dyn_int) {
-                    // Integer sub-dword FORMAT component k at a runtime byte address (addr + k*comp_bytes):
+                } else if (dyn_int || dyn_norm) {
+                    // Integer/normalized sub-dword FORMAT component k at a runtime byte address
+                    // (addr + k*comp_bytes):
                     // shift the loaded dword right by (byteaddr&3)*8, join the next dword when a 16-bit
-                    // field straddles the boundary, then zero-/sign-extend the comp_bytes*8-bit field.
-                    // Mirrors the raw_subword path but per packed component (stride-1 Uint8, unaligned u16).
+                    // field straddles the boundary, then extend or normalize the low field. Mirrors the
+                    // raw_subword path but per packed component (stride-1 Uint8, unaligned u16/SNORM16).
                     const uint32_t caddr = k ? b.ibin(Op_IAdd, addr, b.uconst(k * comp_bytes)) : addr;
                     const uint32_t cidx  = b.ibin(Op_ShiftRightLogical, caddr, b.uconst(2));
                     const uint32_t shift = b.ibin(Op_ShiftLeftLogical,
@@ -7972,8 +7980,10 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                         joined = b.ibin(Op_BitwiseOr, joined,
                                         b.sel(b.ucmp(Op_IEqual, shift, b.uconst(0)), b.uconst(0), upper));
                     }
-                    value = is_sint ? b.bfe_s(joined, b.uconst(0), b.uconst(comp_bytes * 8))
-                                    : b.bfe_u(joined, b.uconst(0), b.uconst(comp_bytes * 8));
+                    value = dyn_norm
+                        ? b.unpack_norm(joined, 0, comp_bytes * 8, is_snorm, norm)
+                        : is_sint ? b.bfe_s(joined, b.uconst(0), b.uconst(comp_bytes * 8))
+                                  : b.bfe_u(joined, b.uconst(0), b.uconst(comp_bytes * 8));
                 } else {
                     // Component k lives at byte k*comp_bytes within the element: pick its dword + field.
                     uint32_t byte_off = k * comp_bytes;

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -538,6 +538,29 @@ int main() {
     }
     printf("  [ok]   Wave32 mask-branch proof does not cross control-flow joins\n");
 
+    // Reduced Astro world-map PS PC9..33 preamble: s64 is a saved mask before a real EXECZ
+    // conditional. The fall-through arm refines it with an explicit VOPC mask and immediately votes
+    // through SCC. Provenance on that arm is valid even though the EXECZ target bypasses the block.
+    const uint32_t wave32_mask_through_execz_fallthrough[] = {
+        0xbec0037eu,                         // pc0: s_mov_b32 s64, exec_lo
+        0x7c220b31u,                         // pc1: v_cmpx_lt_f32 vcc, v49, v5
+        0xbf880004u,                         // pc2: s_cbranch_execz -> merge at PC7
+        0x7c0862f9u, 0x0686eb25u,            // pc3: v_cmp_lt_f32_sdwa vcc_hi, s37, v49
+        0x8a406b40u,                         // pc5: s_andn2_b32 s64, s64, vcc_hi
+        0xbf840001u,                         // pc6: s_cbranch_scc0 -> terminal tail
+        0xbf810000u,                         // pc7: merge
+    };
+    bool found_fallthrough_vote = false;
+    for (uint32_t pc : mask_test_branches_for_test(
+             wave32_mask_through_execz_fallthrough,
+             std::size(wave32_mask_through_execz_fallthrough), true))
+        if (pc == 6) found_fallthrough_vote = true;
+    if (!found_fallthrough_vote) {
+        printf("  [FAIL] valid fall-through Wave32 mask provenance was lost at EXECZ\n");
+        return 1;
+    }
+    printf("  [ok]   Wave32 mask proof preserves valid conditional fall-through provenance\n");
+
     // The same live shader selects EXEC_LO or an empty mask into VCC_HI from an ordinary scalar
     // comparison. This is s_cselect_b32's mask-domain form, not a scalar integer selection.
     const uint32_t wave32_fragment_b32_cselect[] = {

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -1647,6 +1647,34 @@ int main() {
     }
     printf("  [ok]   Float16x4 vertex fetch handles a runtime SOFFSET\n");
 
+    // Astro's world-map VS uses the same arbitrary byte-address shape for a three-component SNORM16
+    // attribute. Its stride is dword-aligned, but the shader-computed SOFFSET can select either half
+    // of a dword, and a component beginning at byte three must join the following dword.
+    const uint32_t vs_fetch_snorm16x3_soffset[] = {
+        0xb0040002u,                         // s_movk_i32 s4, 2
+        0xe0082000u, 0x04000405u,            // buffer_load_format_xyz v[4:6], v5, s[0:3], s4 idxen
+        0x7e0e02f2u,                         // v_mov_b32 v7, 1.0
+        0xf80008cfu, 0x07060504u,            // exp pos0 v4,v5,v6,v7
+        0xbf810000u,
+    };
+    ShaderResourceTable rt_snorm16x3;
+    ShaderResource vb_snorm16x3{};
+    vb_snorm16x3.cls = ResourceClass::VertexBuffer;
+    vb_snorm16x3.format = DataFormat::Snorm16;
+    vb_snorm16x3.num_components = 3;
+    vb_snorm16x3.binding = 6;
+    vb_snorm16x3.stride = 28;
+    vb_snorm16x3.fetch_pc = 1;
+    vb_snorm16x3.fetch_index_mode = VertexFetchIndexMode::Shader;
+    rt_snorm16x3.resources.push_back(vb_snorm16x3);
+    const auto snorm16x3_spv = recompile_vertex(
+        vs_fetch_snorm16x3_soffset, std::size(vs_fetch_snorm16x3_soffset), &rt_snorm16x3);
+    if (snorm16x3_spv.empty() || snorm16x3_spv[0] != 0x07230203u) {
+        printf("  [FAIL] SNORM16x3 vertex fetch with runtime SOFFSET did not recompile\n");
+        return 1;
+    }
+    printf("  [ok]   SNORM16x3 vertex fetch handles a runtime SOFFSET\n");
+
     // image_sample LOD mode per execution model (#151): OpImageSampleImplicitLod is only legal in
     // the Fragment execution model — the compute and vertex shells have no derivatives, so an
     // image_sample there must lower to OpImageSampleExplicitLod (LOD 0) or spirv-val rejects the

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -1196,13 +1196,23 @@ int main() {
     CHECK(!spv_store16.empty() && store16_out.size() == N / 2 && bad_store16 == 0,
           "#590: stride-2 Uint16 buffer_store_format_x lands disjoint fields race-free (dword k = 2k|(2k+1)<<16)");
 
-    // Kernel 24b (#150): the SAME unorm8x4 fetch but with a NON-dword-aligned inst offset (offset:2).
-    // The packed unpack extracts components at static byte offsets from a dword-aligned base and drops
-    // addr&3, so a non-aligned element base would decode the wrong bits — it must be REJECTED (the
-    // alignment can't be proven) rather than silently mis-decoded. Kernel 24 (offset 0) still succeeds.
+    // Kernel 24b: the SAME unorm8x4 fetch at a NON-dword-aligned inst offset (offset:2). The runtime
+    // normalized-component path must begin at byte 2 of each record and join the following dword for
+    // the later components. Reading v1 back proves the first component is B rather than the old R.
     const uint32_t code24b[] = { 0x7e000f00u, 0xe00c2002u, 0x80020100u, 0xbf810000u };
-    CHECK(recompile_valu(code24b, sizeof(code24b)/sizeof(code24b[0]), 1, /*out_vgpr*/1, &rt24).empty(),
-          "kernel 24b (packed unorm8x4 at a non-dword-aligned offset:2) is REJECTED (not mis-decoded)");
+    std::vector<uint32_t> spv24b = recompile_valu(
+        code24b, std::size(code24b), 1, /*out_vgpr*/1, &rt24);
+    std::vector<uint32_t> vbuf24b = vbuf24;
+    vbuf24b.push_back(0u); // final XYZW fetch straddles one dword past the last record
+    const std::vector<float> got24b = prosper::test::run_compute(
+        spv24b, in24, N, N, {}, vbuf24b);
+    uint32_t bad24b = 0;
+    for (uint32_t i = 0; i < N && got24b.size() == N; ++i) {
+        const float blue = static_cast<float>((vbuf24[i] >> 16) & 0xffu) / 255.0f;
+        if (std::fabs(got24b[i] - blue) > 1e-5f) ++bad24b;
+    }
+    CHECK(!spv24b.empty() && got24b.size() == N && bad24b == 0,
+          "kernel 24b extracts normalized components from a non-dword-aligned runtime address");
 
     // Kernel 25: SNORM16x2 vertex fetch — signed 16-bit fields, normalized /32767 and clamped to -1.0
     // (the SNORM rule: -32768 maps to -1.0, not -1.00003). out = v1 + 10*v2. y is fixed at -32768 to


### PR DESCRIPTION
## Context

Progress on #1459. Astro Bot reaches and loads `worldmap`, but the current frontend output is still black/dark and this PR does **not** claim the issue is finished.

Two stages of one repeated world-map pipeline were being rejected:

- The vertex shader fetches an SNORM16x3 attribute at a runtime byte address using a register SOFFSET. The normalized packed-fetch path required static dword alignment and rejected it.
- The fragment shader saves a Wave32 mask, narrows EXEC, takes an `s_cbranch_execz`, then refines the saved mask on the fall-through arm before an immediate SCC branch. Basic-block-local provenance discarded the still-valid saved mask at the conditional branch, so the real Wave32 vote was not recognized and the graphics CFG rejected the shader.

## Change

- Carry one-word Wave32-mask provenance through the shader CFG as a must-dataflow fact. Conditional branches propagate to both successors and joins retain only facts proven on every reachable predecessor. Immediate mask-writer/branch pairing remains block-local.
- Add runtime-address extraction for UNORM/SNORM 8- and 16-bit format loads, including fields that straddle two dwords, then apply the existing normalization rules.
- Add focused guards for the exact Astro conditional-fallthrough shape and SNORM16x3/SOFFSET fetch, plus an end-to-end Vulkan value test for a non-dword-aligned UNORM8x4 fetch.

## Live evidence

- Linux SDL frontend, normal realtime render/audio/input route: `scripts/astrobot/reach-first-level.pad`.
- Reached `LevelDocument Loaded: worldmap [worldmap]`.
- Semantic metadata capture at submit 25268: 3840x2160, 27 draws, 26 dispatches.
- The exact repeated pipeline hashes now report both stages recompiled:
  - VS `7f5f2349e2816f5e` (3917 dwords)
  - FS `6717346b580f8084` (3180 dwords)
- The world map remains black/dark because other world-map shader gaps remain. Per the project evidence rules, there is no screenshot attached for black/diagnostic-only output.

## Verification

Exact head `7642a0319271d3c73ccb7b5187a3828b6f440e7e`:

```text
ctest --test-dir build-astrobot-fmv --output-on-failure -j1 \
  -R '^(recompile_coverage|rdna2_decode_walk|rdna2_spirv_struct|dynfetch_fold|rdna2_to_spirv_exec|recompiled_fragment_render|interp_render)$'

100% tests passed, 0 tests failed out of 7
```

`git diff --check` passes. Snapshot inventory was not run; this is a day-to-day renderer checkpoint rather than a release candidate.

## Risk

The CFG analysis is deliberately conservative at joins and invalidates every overwritten SGPR word before publishing a new mask fact. The normalized load expansion is load-only; packed stores keep their existing stricter behavior.
