### PR TITLE
perf(gpu): bind retained compute images directly in graphics

### DIFF
--- a/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
+++ b/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
@@ -1355,6 +1355,14 @@ progression difference is supporting evidence rather than a standalone FPS claim
 this temporal residency boundary because replay resources intentionally own `host_data`; the production tests,
 live disable switch, and the unchanged replay fallback divide that verification responsibility explicitly.
 
+After merging current master, a fresh 140-second exact-head A/B repeated the result with identical build,
+route, full-resolution, audio, input, and timing settings. The enabled run logged 250 direct decisions,
+including a 3840x2160 RGBA16F result at 0.09 ms, and reached 2,220 presents; the single-switch disabled run
+logged no direct decisions and reached 2,040. Their final 25-submit texture-resource windows were 6.45 ms and
+10.62 ms respectively. Both native 3840x2160 checkpoints were visually clean. They armed at the same guest
+present (1,058) but asynchronous readback completed on different later presents and captured different menu
+states, so they remain independent correctness/progression evidence rather than a pixel-equality oracle.
+
 ## Next renderer step
 
 Capture a fresh v38 rolling temporal window on current code around the Plucky title/gameplay transition. It

--- a/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
+++ b/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
@@ -1319,6 +1319,42 @@ skips already avoid guest-write notification, so they are deliberately unaffecte
 trace instead keeps the disabled texture-watch and incomplete guest-range cases below as the active Plucky
 bottleneck.
 
+## Plucky direct compute-image sampling prototype (issue #1477)
+
+The remaining large sampled-texture spikes had an exact GPU authority that the renderer did not consume.
+A successful typed-storage compute dispatch already retained its native Vulkan image on the graphics
+device, then mirrored the same result into tiled guest memory. A later graphics span nevertheless validated,
+detiled, and uploaded those guest bytes again. The observed full-resolution outputs are 33,423,360-byte
+R11G11B10 and 66,846,720-byte RGBA16F surfaces; cold or invalidated fallback references have taken roughly
+64-90 ms to materialize.
+
+The issue #1477 prototype publishes only successful native typed-storage results created with sampled usage.
+The graphics import reconstructs the complete compute-cache identity and borrows the image only while the
+current-submit GPU-write journal or a clean cross-submit page watch proves that no later architectural writer
+overlapped its guest mirror. Every attempted storage dispatch revokes the previous authority before command
+recording, and only complete dispatch/writeback/layout success republishes it. A shared lease pins the cache
+entry until the graphics fence cleanup; graphics transitions the borrowed image from `GENERAL` to shader-read
+and restores `GENERAL` without destroying the image. Raw-uvec4 interchange images, replay `host_data`, depth,
+sRGB, mip-tail/array/volume views, and DCC surfaces without an exact all-`0xff` uncompressed proof remain on
+the existing path. `PROSPER_NO_DIRECT_COMPUTE_IMAGE_BIND=1` is the control switch.
+
+Focused production-backend coverage proves cross-submit watch authorization, rejects an import after an
+architectural GPU/DMA write dirties the watched guest range, and holds the lease through submission cleanup.
+The renderer execution test compares borrowed native FP16 and R11G11B10 images against the existing CPU
+readback/upload route byte for byte, then samples the owner again to prove its layout and lifetime were
+restored. Restoring the fallback importer or omitting either native-format bridge makes those tests fail.
+
+A 135-second full-resolution, normal-cadence Plucky route exercised the bridge on the real 4K outputs. The
+explicit detail log reached its 250-line cap with direct hits; individual frontend resource decisions took
+approximately 0.00-0.11 ms and copied or validated zero guest bytes. At submit 1,100, cumulative texture
+resource construction was 8.22 ms per submit with the bridge and 9.20 ms in the sequential disabled control;
+cumulative frontend time was 34.49 versus 35.04 ms. The enabled run produced a clean native 3840x2160 Play
+Style screenshot and completed 1,508 presents, versus 1,367 in the control. The scheduled control screenshot
+landed ten guest presents earlier during the menu's black fade, so it is not a pixel oracle and the route
+progression difference is supporting evidence rather than a standalone FPS claim. GPU replay cannot exercise
+this temporal residency boundary because replay resources intentionally own `host_data`; the production tests,
+live disable switch, and the unchanged replay fallback divide that verification responsibility explicitly.
+
 ## Next renderer step
 
 Capture a fresh v38 rolling temporal window on current code around the Plucky title/gameplay transition. It

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -5452,7 +5452,8 @@ bool import_live_compute_storage_image(const prosper::gpu::ShaderResource& sampl
         sampled_resource.cls != prosper::gpu::ResourceClass::Texture ||
         sampled_resource.host_data || !guest_bytes || guest_bytes > UINT32_MAX ||
         sampled_resource.img_dim != 1 || sampled_resource.depth != 1 ||
-        sampled_resource.in_mip_tail || sampled_resource.srgb ||
+        sampled_resource.declared_mip_levels != 1 || sampled_resource.in_mip_tail ||
+        sampled_resource.srgb ||
         sampled_resource.depth_compare)
         return false;
     const uint32_t components = sampled_resource.num_components

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -185,10 +185,11 @@ VkFormat native_storage_vk_format(prosper::gpu::DataFormat format, uint32_t comp
 }
 
 bool native_storage_image_create_supported(VkPhysicalDevice physical, VkFormat format,
-                                           uint32_t width, uint32_t height) {
+                                           uint32_t width, uint32_t height,
+                                           VkImageUsageFlags extra_usage = 0) {
     if (!physical || format == VK_FORMAT_UNDEFINED || !width || !height) return false;
-    constexpr VkImageUsageFlags usage = VK_IMAGE_USAGE_STORAGE_BIT |
-        VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+    const VkImageUsageFlags usage = VK_IMAGE_USAGE_STORAGE_BIT |
+        VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | extra_usage;
     VkImageFormatProperties properties{};
     return vkGetPhysicalDeviceImageFormatProperties(
                physical, format, VK_IMAGE_TYPE_2D, VK_IMAGE_TILING_OPTIMAL,
@@ -629,6 +630,22 @@ struct ComputeImageCacheKeyHash {
     }
 };
 
+ComputeImageCacheKey storage_image_cache_key(const prosper::gpu::ShaderResource& resource,
+                                              uint32_t guest_bytes,
+                                              VkFormat native_format) {
+    return {
+        resource.gpu_addr, guest_bytes, resource.size,
+        resource.width, resource.height, resource.depth,
+        static_cast<uint32_t>(resource.format),
+        resource.num_components ? resource.num_components : 1u,
+        resource.tile_mode, resource.img_dim, resource.linear_row_pitch_bytes,
+        resource.layer_stride_bytes, resource.layer_mip_offset_bytes,
+        resource.mip_tail_offset, resource.mip_tail_bytes,
+        resource.mip_tail_x, resource.mip_tail_y,
+        static_cast<uint32_t>(native_format), true, resource.in_mip_tail,
+        resource.srgb, resource.depth_compare};
+}
+
 struct CachedComputeImage {
     VkImage image = VK_NULL_HANDLE;
     VkDeviceMemory memory = VK_NULL_HANDLE;
@@ -644,6 +661,12 @@ struct CachedComputeImage {
     prosper::host::GuestWriteWatch write_watch;
     uint32_t write_watch_stable_validations = 0;
     prosper::gpu::GuestGpuWriteSnapshot validation_snapshot;
+    // A successful typed-storage dispatch leaves `image` in GENERAL with the exact result. Graphics
+    // may borrow it only while a current-submit journal or this watch proves that no later guest
+    // write changed the architectural backing. This is separate from source validation: a failed
+    // dispatch can leave the old guest mirror valid while making the Vulkan result unknowable.
+    prosper::gpu::GuestGpuWriteSnapshot graphics_export_snapshot;
+    bool graphics_export_valid = false;
     std::vector<uint8_t> source_snapshot;
     // Exact row-major bytes produced by the last storage dispatch. Full-overwrite post-processes
     // commonly reproduce the same large target on successive frames. Retaining the result lets a
@@ -1471,7 +1494,40 @@ struct VulkanComputeContext {
             // Do not trust the new mirror until the corresponding transfer completes. A failed
             // submit leaves this false, so the next use refreshes instead of skipping stale pixels.
             cached.content_valid = false;
+            cached.graphics_export_valid = false;
         }
+        return true;
+    }
+
+    void invalidate_cached_image_export(const ComputeImageCacheKey& key) {
+        const auto found = image_cache.find(key);
+        if (found != image_cache.end()) found->second.graphics_export_valid = false;
+    }
+
+    void authorize_cached_image_export(const ComputeImageCacheKey& key) {
+        const auto found = image_cache.find(key);
+        if (found == image_cache.end() || !found->second.content_valid || !found->second.image)
+            return;
+        found->second.graphics_export_snapshot = prosper::gpu::guest_gpu_write_snapshot();
+        found->second.graphics_export_valid = true;
+    }
+
+    bool borrow_cached_image_for_graphics(const ComputeImageCacheKey& key,
+                                          VkImage& image) {
+        const auto found = image_cache.find(key);
+        if (found == image_cache.end()) return false;
+        CachedComputeImage& cached = found->second;
+        if (!cached.graphics_export_valid || !cached.content_valid || !cached.image) return false;
+        const bool submit_unchanged =
+            prosper::gpu::guest_gpu_writes_since(cached.graphics_export_snapshot,
+                                                  key.gpu_addr, key.guest_bytes) ==
+            prosper::gpu::GuestGpuWriteQuery::Unchanged;
+        const bool watch_unchanged = !submit_unchanged && cached.write_watch &&
+            cached.write_watch.query() == prosper::host::GuestWriteWatchQuery::Unchanged;
+        if (!submit_unchanged && !watch_unchanged) return false;
+        cached.last_use = ++image_cache_clock;
+        ++cached.pins;
+        image = cached.image;
         return true;
     }
 
@@ -1757,6 +1813,16 @@ struct VulkanComputeContext {
 
 };
 
+VulkanComputeContext* g_live_compute_context = nullptr;
+
+struct BorrowedComputeImageLease {
+    VulkanComputeContext* context = nullptr;
+    ComputeImageCacheKey key{};
+    ~BorrowedComputeImageLease() {
+        if (context) context->release_cached_image(key);
+    }
+};
+
 struct BoundBuffer {
     const prosper::gpu::ShaderResource* resource = nullptr;
     VkBuffer buffer = VK_NULL_HANDLE;
@@ -1805,6 +1871,7 @@ struct BoundImage {
     uint32_t binding = 0;
     bool storage = false;               // storage image: read back + pack to guest after the dispatch
     bool native_float_storage = false;  // Vulkan performs exact UNORM/float conversion at native width
+    bool graphics_sampled_usage = false;// native image was created with SAMPLED usage for export
     uint32_t texel_depth = 1;           // logical Z/layer count represented in the staging buffer
     uint32_t array_layers = 1;           // Vulkan array-layer count (3D depth remains one layer)
     bool arrayed_2d = false;            // SPIR-V requires a real 2D-array view (not base-slice fallback)
@@ -2663,6 +2730,10 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             // if this replay device supports the optional typed format, while a live module is only
             // emitted as float after the frontend's physical-device feature query.
             bi.native_float_storage = spirv_native_storage;
+            bi.graphics_sampled_usage = bi.native_float_storage &&
+                native_storage_image_create_supported(
+                    ctx.physical, native_storage_format, r->width, r->height,
+                    VK_IMAGE_USAGE_SAMPLED_BIT);
             if (trace)
                 std::fprintf(stderr,
                              "[compute]   image binding=%u class=%s addr=0x%llx "
@@ -3532,16 +3603,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     !bi.poison_verify && (bi.native_float_storage || bi.seed_skip) &&
                     persistent_compute_image_enabled(sbytes, ComputeImageCacheClass::storage);
                 if (bi.cache_candidate) {
-                    bi.cache_key = {
-                        r->gpu_addr, static_cast<uint32_t>(guest_bytes), r->size,
-                        r->width, r->height, r->depth,
-                        static_cast<uint32_t>(r->format), sampled_components,
-                        r->tile_mode, r->img_dim, r->linear_row_pitch_bytes,
-                        r->layer_stride_bytes, r->layer_mip_offset_bytes,
-                        r->mip_tail_offset, r->mip_tail_bytes,
-                        r->mip_tail_x, r->mip_tail_y,
-                        static_cast<uint32_t>(image_format), bi.storage, r->in_mip_tail,
-                        r->srgb, r->depth_compare};
+                    bi.cache_key = storage_image_cache_key(
+                        *r, static_cast<uint32_t>(guest_bytes), image_format);
                     bi.persistent = ctx.acquire_cached_image(
                         bi.cache_key, resource_bytes_for(r, guest_bytes), image_validation_epoch,
                         bi.image, bi.memory, bi.upload_skipped);
@@ -4036,7 +4099,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             ici.samples = VK_SAMPLE_COUNT_1_BIT;
             ici.tiling = VK_IMAGE_TILING_OPTIMAL;
             ici.usage = (bi.storage ? (VK_IMAGE_USAGE_STORAGE_BIT |
-                                       VK_IMAGE_USAGE_TRANSFER_SRC_BIT)
+                                       VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
+                                       (bi.graphics_sampled_usage
+                                            ? VK_IMAGE_USAGE_SAMPLED_BIT : 0u))
                                     : VK_IMAGE_USAGE_SAMPLED_BIT) |
                         VK_IMAGE_USAGE_TRANSFER_DST_BIT;
             ici.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
@@ -4381,6 +4446,14 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         VkCommandBufferBeginInfo begin{VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO};
         begin.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
         if (!vk_ok(vkBeginCommandBuffer(command, &begin), "command-begin")) break;
+        // From this point a submitted storage dispatch can replace a retained image even if a
+        // later fence/readback step fails. Revoke its graphics authority up front; only the complete
+        // success path below republishes it.
+        for (const BoundImage& image : images) {
+            if (image.storage && image.alias_of == SIZE_MAX && image.cache_candidate &&
+                image.persistent)
+                ctx.invalidate_cached_image_export(image.cache_key);
+        }
         // Exactly one binding emits the layout transitions for each borrowed renderer image. The
         // hazard is per-VkImage, so ownership is keyed on the handle, and it is derived over the
         // bindings that actually REACH these loops (non-aliased ones) rather than decided at import
@@ -5252,6 +5325,15 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             }
         }
         if (!readback_ok) break;
+        // Every storage image is back in GENERAL, all exact guest writebacks/notifications have
+        // completed, and a failed dispatch cannot reach here. Publish only retained native results;
+        // raw interchange images are never descriptor-compatible with a graphics sampled view.
+        for (const BoundImage& image : images) {
+            if (image.storage && image.native_float_storage && image.graphics_sampled_usage &&
+                image.alias_of == SIZE_MAX &&
+                image.cache_candidate && image.persistent)
+                ctx.authorize_cached_image_export(image.cache_key);
+        }
         ok = true;
         phase_writeback = ComputeClock::now();
     } while (false);
@@ -5331,6 +5413,47 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
 }
 
 } // namespace
+
+bool import_live_compute_storage_image(const prosper::gpu::ShaderResource& sampled_resource,
+                                       uint64_t guest_bytes,
+                                       LiveComputeImageImport& import) {
+    import = {};
+    VulkanComputeContext* context = g_live_compute_context;
+    if (!context || !context->device || !sampled_resource.gpu_addr ||
+        sampled_resource.cls != prosper::gpu::ResourceClass::Texture ||
+        sampled_resource.host_data || !guest_bytes || guest_bytes > UINT32_MAX ||
+        sampled_resource.img_dim != 1 || sampled_resource.depth != 1 ||
+        sampled_resource.in_mip_tail || sampled_resource.srgb ||
+        sampled_resource.depth_compare)
+        return false;
+    const uint32_t components = sampled_resource.num_components
+        ? sampled_resource.num_components : 1u;
+    const VkFormat native_format =
+        native_storage_vk_format(sampled_resource.format, components);
+    if (native_format == VK_FORMAT_UNDEFINED) return false;
+    const ComputeImageCacheKey key = storage_image_cache_key(
+        sampled_resource, static_cast<uint32_t>(guest_bytes), native_format);
+    VkImage image = VK_NULL_HANDLE;
+    if (!context->borrow_cached_image_for_graphics(key, image)) return false;
+    try {
+        auto lease = std::make_shared<BorrowedComputeImageLease>();
+        lease->context = context;
+        lease->key = key;
+        import.width = sampled_resource.width;
+        import.height = sampled_resource.height;
+        import.depth = sampled_resource.depth;
+        import.native_format = static_cast<uint32_t>(native_format);
+        import.layout = static_cast<uint32_t>(VK_IMAGE_LAYOUT_GENERAL);
+        import.image = static_cast<void*>(image);
+        import.device = static_cast<void*>(context->device);
+        import.lease = std::move(lease);
+    } catch (...) {
+        context->release_cached_image(key);
+        import = {};
+        return false;
+    }
+    return import.valid();
+}
 
 uint64_t live_compute_buffer_gpu_result_skips() {
     return g_buffer_gpu_result_skips.load(std::memory_order_relaxed);
@@ -5455,6 +5578,7 @@ bool execute_live_compute_items(const std::vector<prosper::gpu::ComputeItem>& it
         std::fprintf(stderr, "[compute] Vulkan initialization failed\n");
         return false;
     }
+    g_live_compute_context = &context;
     const bool timing_enabled = std::getenv("PROSPER_RENDER_TIMING") != nullptr;
     const auto timing_start = timing_enabled
         ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point{};

--- a/prosper/frontends/shared/live_compute.hpp
+++ b/prosper/frontends/shared/live_compute.hpp
@@ -3,6 +3,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <vector>
 
 namespace prosper::frontend {
@@ -70,6 +71,28 @@ bool pack_live_target_r11g11b10(const prosper::gpu::LiveTargetSnapshot& snapshot
 
 // Execute already-realized compute items synchronously. Exposed for the production-backend test.
 bool execute_live_compute_items(const std::vector<prosper::gpu::ComputeItem>& items);
+
+// Borrow an exact native storage result for a later sampled graphics binding. The import is
+// deliberately narrower than the compute image cache: only a successful typed-storage dispatch can
+// publish one, the complete descriptor identity must match, and either the current submit journal or
+// the cache's page watch must prove that no later guest write overlapped the result. The lease pins
+// the Vulkan image until the graphics submission has completed. Handles remain opaque here so this
+// shared interface does not expose Vulkan types.
+struct LiveComputeImageImport {
+    uint32_t width = 0, height = 0, depth = 0;
+    uint32_t native_format = 0; // opaque VkFormat
+    uint32_t layout = 0;        // opaque VkImageLayout; currently GENERAL
+    void* image = nullptr;      // borrowed VkImage
+    void* device = nullptr;     // VkDevice that owns image
+    std::shared_ptr<void> lease;
+
+    bool valid() const {
+        return width && height && depth && native_format && image && device && lease;
+    }
+};
+bool import_live_compute_storage_image(const prosper::gpu::ShaderResource& sampled_resource,
+                                       uint64_t guest_bytes,
+                                       LiveComputeImageImport& import);
 
 // Monotonic diagnostic count of writable-buffer results whose exact GPU comparison avoided a host
 // mapping/scan. Exposed so the production-backend test can prove that optimization path executes.

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -1268,6 +1268,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     const auto resource_timing_start = timing_enabled
                         ? RenderClock::now() : RenderClock::time_point{};
                     bool resource_rtt_hit = false;
+                    bool resource_compute_image_hit = false;
                     bool resource_local_reuse = false;
                     bool resource_persistent_hit = false;
                     bool resource_persistent_submit_reuse = false;
@@ -1684,12 +1685,50 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         const size_t persistent_source_size = persistent_dcc_fast_clear
                             ? sampled_dcc_metadata.size() : persistent_base_source_size;
                         resource_texture_source_bytes = persistent_source_size;
+                        // A successful typed-storage compute dispatch may still own this exact
+                        // sampled image on the shared Vulkan device. Prefer that image only for the
+                        // two native formats the graphics backend preserves today. The compute cache
+                        // independently requires the complete descriptor key plus a current-submit
+                        // journal or page-watch proof; a miss falls through to the existing exact
+                        // guest-byte decode/cache path.
+                        prosper::frontend::LiveComputeImageImport compute_image_import;
+                        VkFormat compute_image_format = VK_FORMAT_UNDEFINED;
+                        if (r.format == prosper::gpu::DataFormat::Float16 &&
+                            r.num_components == 4)
+                            compute_image_format = VK_FORMAT_R16G16B16A16_SFLOAT;
+                        else if (r.format == prosper::gpu::DataFormat::Float10_11_11 &&
+                                 r.num_components == 3)
+                            compute_image_format = VK_FORMAT_B10G11R11_UFLOAT_PACK32;
+                        const bool compute_image_candidate =
+                            !getenv("PROSPER_NO_DIRECT_COMPUTE_IMAGE_BIND") &&
+                            !has_live_rtt && !has_ds_live && r.cls == RC::Texture &&
+                            r.img_dim == 1u && r.depth == 1u && !r.in_mip_tail &&
+                            !r.srgb && !r.depth_compare && !r.host_data &&
+                            persistent_source_size &&
+                            (!r.compression_enabled || persistent_dcc_uncompressed) &&
+                            compute_image_format != VK_FORMAT_UNDEFINED;
+                        if (compute_image_candidate &&
+                            prosper::frontend::import_live_compute_storage_image(
+                                r, persistent_source_size, compute_image_import)) {
+                            const prosper::test::RenderVkCtx& render_context =
+                                prosper::test::render_vk_ctx();
+                            resource_compute_image_hit = compute_image_import.valid() &&
+                                compute_image_import.native_format ==
+                                    static_cast<uint32_t>(compute_image_format) &&
+                                compute_image_import.width == tw &&
+                                compute_image_import.height == th &&
+                                compute_image_import.depth == 1u && render_context.ok &&
+                                compute_image_import.device ==
+                                    static_cast<void*>(render_context.dev);
+                            if (!resource_compute_image_hit) compute_image_import = {};
+                        }
                         auto copy_persistent_source = [&](uint8_t* dst, size_t bytes) {
                             return persistent_dcc_fast_clear
                                 ? copy_dcc_metadata(dst, bytes)
                                 : copy_resource(dst, r.gpu_addr, bytes);
                         };
-                        const bool persistent_cache_eligible = !fr.is_storage_image &&
+                        const bool persistent_cache_eligible = !resource_compute_image_hit &&
+                            !fr.is_storage_image &&
                             !getenv("PROSPER_NO_TEXTURE_DECODE_CACHE") &&
                             (!r.compression_enabled || persistent_dcc_uncompressed ||
                              persistent_dcc_fast_clear) &&
@@ -1729,8 +1768,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // to (R,0,0,1) and must retain the real descriptor swizzle, so the two facts differ.
                         bool narrow_done = false;
                         bool narrow_decode_done = false;
-                        auto reused = has_live_rtt ? decoded_textures.end()
-                                                   : decoded_textures.find(decode_key);
+                        auto reused = (has_live_rtt || resource_compute_image_hit)
+                            ? decoded_textures.end() : decoded_textures.find(decode_key);
                         DecodedTexture persistent_reuse;
                         const DecodedTexture* decoded_reuse = reused != decoded_textures.end()
                             ? &reused->second : nullptr;
@@ -1959,6 +1998,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                         tw, th, r.img_dim, (unsigned)r.format,
                                         has_gpu_live_rtt          ? "gpu-bind"
                                         : has_cpu_live_rtt        ? "cpu-rtt"
+                                        : resource_compute_image_hit ? "compute-bind"
                                         : decoded_reuse           ? "decode-cache"
                                                                   : "decode",
                                         live_rtt != g_rtt.end() ? live_rtt->second.w : 0,
@@ -1984,6 +2024,17 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             fr.td = 1; fr.img_dim = r.img_dim;
                             fr.texture_format = live_rtt->second.format;
                             resource_rtt_hit = true;
+                        } else if (resource_compute_image_hit) {
+                            fr.borrowed_compute_image = compute_image_import.image;
+                            fr.borrowed_compute_device = compute_image_import.device;
+                            fr.borrowed_compute_image_layout = compute_image_import.layout;
+                            fr.borrowed_compute_image_lease =
+                                std::move(compute_image_import.lease);
+                            fr.tw = compute_image_import.width;
+                            fr.th = compute_image_import.height;
+                            fr.td = compute_image_import.depth;
+                            fr.img_dim = r.img_dim;
+                            fr.texture_format = compute_image_format;
                         } else if (has_ds_live) {
                             fr.persistent_depth_target_id = r.gpu_addr;
                             fr.tw = sampled_ds.width;
@@ -3003,7 +3054,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 }
                             }
                         }
-                        if (!resource_rtt_hit && !has_live_rtt)
+                        if (!resource_rtt_hit && !resource_compute_image_hit && !has_live_rtt)
                             decoded_textures.emplace(
                                 decode_key, DecodedTexture{fr.tex_rgba, fr.th, narrow_done,
                                                           fr.persistent_texture_id});
@@ -3256,14 +3307,16 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 mode && strcmp(mode, "detail") == 0 &&
                                 static_cast<uint64_t>(g_this_submit) >= detail_min_submit) {
                                 static uint64_t detail_lines = 0;
-                                if ((elapsed >= 0.5 || resource_persistent_invalidation) &&
+                                if ((elapsed >= 0.5 || resource_persistent_invalidation ||
+                                     resource_compute_image_hit) &&
                                     detail_lines++ < 250) {
                                     const char* cache_state = resource_rtt_hit ? "rtt" :
+                                        (resource_compute_image_hit ? "compute-image" :
                                         (resource_local_reuse ? "local" :
                                         (resource_persistent_submit_reuse ? "persistent-submit" :
                                         (resource_persistent_hit ? "persistent-hit" :
                                         (resource_persistent_invalidation ? "persistent-invalid" :
-                                        (resource_persistent_miss ? "persistent-miss" : "uncached")))));
+                                        (resource_persistent_miss ? "persistent-miss" : "uncached"))))));
                                     auto submit_query_name = [](int query) {
                                         switch (query) {
                                             case static_cast<int>(

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -1703,7 +1703,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             !getenv("PROSPER_NO_DIRECT_COMPUTE_IMAGE_BIND") &&
                             !has_live_rtt && !has_ds_live && r.cls == RC::Texture &&
                             r.img_dim == 1u && r.depth == 1u && !r.in_mip_tail &&
-                            !r.srgb && !r.depth_compare && !r.host_data &&
+                            r.declared_mip_levels == 1u && !r.srgb &&
+                            !r.depth_compare && !r.host_data &&
                             persistent_source_size &&
                             (!r.compression_enabled || persistent_dcc_uncompressed) &&
                             compute_image_format != VK_FORMAT_UNDEFINED;

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -954,8 +954,14 @@ public:
     }
 
     void add_cleanup(std::function<void()> cleanup) {
-        if (!pending_resources_abandoned_)
+        if (!pending_resources_abandoned_) {
             cleanups_.push_back(std::move(cleanup));
+            return;
+        }
+        // Some resources are bundled only after submission diagnostics finish. If completion was
+        // already found indeterminate, destroying this late closure would release those resources
+        // (including borrowed-image leases) while the submitted command may still use them.
+        (void)new std::function<void()>(std::move(cleanup));
     }
 
     // Persistent attachment state is updated speculatively so later command buffers in the same

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -147,6 +147,14 @@ struct FrameResource {
     // depth image directly — prosper never writes rendered depth back to guest memory, so there
     // is no CPU fallback; an invalidated/missing surface falls through to the guest-byte decode.
     uint64_t persistent_depth_target_id = 0;
+    // Exact typed-storage result borrowed from the live compute cache. The image and device handles
+    // are opaque here only at the frontend boundary; this Vulkan backend verifies the device,
+    // transitions from `borrowed_image_layout` for sampling, restores that layout afterward, and
+    // retains the lease until the submission has completed.
+    void* borrowed_compute_image = nullptr;
+    void* borrowed_compute_device = nullptr;
+    uint32_t borrowed_compute_image_layout = 0;
+    std::shared_ptr<void> borrowed_compute_image_lease;
     const uint32_t* buffer_words_data() const {
         return dwords_view && dwords_view_count
             ? dwords_view : (dwords.empty() ? nullptr : dwords.data());
@@ -156,7 +164,7 @@ struct FrameResource {
     }
     bool is_texture() const {
         return tex_rgba != nullptr || persistent_render_target_id != 0 ||
-               persistent_depth_target_id != 0;
+               persistent_depth_target_id != 0 || borrowed_compute_image != nullptr;
     }
 };
 
@@ -3216,6 +3224,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     struct TextureUploadKey {
         const uint8_t* pixels = nullptr;
         uint64_t render_target_id = 0;
+        void* borrowed_compute_image = nullptr;
         uint32_t width = 0, height = 0, depth = 1;
         uint32_t img_dim = 1;
         uint32_t mip_levels = 1;   // effective uploaded chain length (#1272)
@@ -3223,6 +3232,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         bool storage_image = false;
         bool operator==(const TextureUploadKey& other) const {
             return pixels == other.pixels && render_target_id == other.render_target_id &&
+                   borrowed_compute_image == other.borrowed_compute_image &&
                    width == other.width && height == other.height && depth == other.depth &&
                    img_dim == other.img_dim && mip_levels == other.mip_levels &&
                    format == other.format && storage_image == other.storage_image;
@@ -3232,6 +3242,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         size_t operator()(const TextureUploadKey& key) const {
             size_t h = std::hash<const uint8_t*>{}(key.pixels);
             h ^= std::hash<uint64_t>{}(key.render_target_id) + 0x9e3779b9u + (h << 6) + (h >> 2);
+            h ^= std::hash<void*>{}(key.borrowed_compute_image) +
+                 0x9e3779b9u + (h << 6) + (h >> 2);
             h ^= static_cast<size_t>(key.width) + 0x9e3779b9u + (h << 6) + (h >> 2);
             h ^= static_cast<size_t>(key.height) + 0x9e3779b9u + (h << 6) + (h >> 2);
             h ^= static_cast<size_t>(key.depth) + 0x9e3779b9u + (h << 6) + (h >> 2);
@@ -3252,6 +3264,9 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         VkDeviceSize image_bytes = 0;
         bool persistent_hit = false;
         bool borrowed_target = false;
+        bool borrowed_compute = false;
+        VkImageLayout borrowed_compute_layout = VK_IMAGE_LAYOUT_UNDEFINED;
+        std::shared_ptr<void> borrowed_compute_lease;
         // Sampled depth bridge (#1275): image borrowed from the persistent DS cache. The view uses
         // the DEPTH aspect of ds_format, and the call transitions the image DS-attachment ->
         // shader-read around its passes.
@@ -3902,6 +3917,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                         r.tex_rgba,
                         r.persistent_render_target_id ? r.persistent_render_target_id
                                                       : r.persistent_depth_target_id,
+                        r.borrowed_compute_image,
                         r.tw, r.th, r.td, r.img_dim,
                         tex_mip_levels, backend_color_format(r.texture_format), r.is_storage_image};
                     size_t upload_index = SIZE_MAX;
@@ -3916,12 +3932,25 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                         upload.key = texture_key;
                         if (share_texture_uploads) texture_upload_indices.emplace(texture_key, upload_index);
 
+                        if (!r.is_storage_image && r.borrowed_compute_image &&
+                            r.borrowed_compute_device == static_cast<void*>(dev) &&
+                            r.borrowed_compute_image_layout !=
+                                static_cast<uint32_t>(VK_IMAGE_LAYOUT_UNDEFINED) &&
+                            r.borrowed_compute_image_lease) {
+                            upload.image = static_cast<VkImage>(r.borrowed_compute_image);
+                            upload.borrowed_compute = true;
+                            upload.borrowed_compute_layout = static_cast<VkImageLayout>(
+                                r.borrowed_compute_image_layout);
+                            upload.borrowed_compute_lease = r.borrowed_compute_image_lease;
+                        }
+
                         const bool target_feedback =
                             (persistent_color &&
                              r.persistent_render_target_id == color_target->persistent_id) ||
                             (persistent_color1 &&
                              r.persistent_render_target_id == color_target->persistent_id1);
-                        if (!r.is_storage_image && persistent_color_targets_enabled && !target_feedback &&
+                        if (!upload.borrowed_compute && !r.is_storage_image &&
+                            persistent_color_targets_enabled && !target_feedback &&
                             r.persistent_render_target_id && r.img_dim == 1) {
                             if (auto* target = find_persistent_color_target(
                                     r.persistent_render_target_id, r.tw, r.th,
@@ -3937,7 +3966,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                         // into a persistent DS image (never written back to guest memory). Bind
                         // that image's depth aspect directly. The pass's own DS attachment must
                         // not be borrowed as a sampled input (feedback) — cached_ds identifies it.
-                        if (!upload.image && !upload.borrowed_target && !r.is_storage_image &&
+                        if (!upload.image && !upload.borrowed_target && !upload.borrowed_compute &&
+                            !r.is_storage_image &&
                             r.persistent_depth_target_id && r.img_dim == 1) {
                             const PersistentDsSampled sampled_ds = find_persistent_ds_sampled(
                                 r.persistent_depth_target_id, r.tw, r.th);
@@ -3957,7 +3987,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                         const PersistentTextureKey persistent_key{
                             r.persistent_texture_id, r.tw, r.th, r.td, r.img_dim,
                             texture_key.mip_levels, backend_color_format(r.texture_format)};
-                        if (!r.is_storage_image && !upload.borrowed_target && !upload.borrowed_ds &&
+                        if (!r.is_storage_image && !upload.borrowed_target &&
+                            !upload.borrowed_compute && !upload.borrowed_ds &&
                             persistent_textures_enabled &&
                             r.persistent_texture_id) {
                             auto cached = persistent_texture_images.find(persistent_key);
@@ -3972,7 +4003,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                             }
                         }
 
-                        if (!upload.persistent_hit && !upload.borrowed_target && !upload.borrowed_ds) {
+                        if (!upload.persistent_hit && !upload.borrowed_target &&
+                            !upload.borrowed_compute && !upload.borrowed_ds) {
                             VkImageCreateInfo tci{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
                             const bool texture_3d = r.img_dim == 2;
                             tci.imageType = texture_3d ? VK_IMAGE_TYPE_3D : VK_IMAGE_TYPE_2D;
@@ -4913,6 +4945,33 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                              VK_PIPELINE_STAGE_VERTEX_SHADER_BIT | VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
                              0, 0, nullptr, 0, nullptr, 1, &b1);
     }
+    // Compute-owned typed storage results rest in GENERAL. Borrow each exact image once per call,
+    // make the completed compute/transfer writes visible to graphics sampling, and restore GENERAL
+    // after the pass so the compute cache's layout contract remains true.
+    std::vector<std::pair<VkImage, VkImageLayout>> borrowed_compute_images;
+    for (const SharedTextureUpload& upload : texture_uploads) {
+        if (!upload.borrowed_compute || !upload.image) continue;
+        if (std::any_of(borrowed_compute_images.begin(), borrowed_compute_images.end(),
+                        [&](const auto& entry) { return entry.first == upload.image; }))
+            continue;
+        borrowed_compute_images.push_back({upload.image, upload.borrowed_compute_layout});
+        VkImageMemoryBarrier to_sampled{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
+        to_sampled.oldLayout = upload.borrowed_compute_layout;
+        to_sampled.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+        to_sampled.srcAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT |
+                                   VK_ACCESS_TRANSFER_READ_BIT | VK_ACCESS_TRANSFER_WRITE_BIT;
+        to_sampled.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+        to_sampled.srcQueueFamilyIndex = to_sampled.dstQueueFamilyIndex =
+            VK_QUEUE_FAMILY_IGNORED;
+        to_sampled.image = upload.image;
+        to_sampled.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+        vkCmdPipelineBarrier(cmd,
+                             VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT |
+                                 VK_PIPELINE_STAGE_TRANSFER_BIT,
+                             VK_PIPELINE_STAGE_VERTEX_SHADER_BIT |
+                                 VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+                             0, 0, nullptr, 0, nullptr, 1, &to_sampled);
+    }
     // Same-pass depth feedback (#1186): make prior attachment writes visible to the shader and
     // enter the layout declared by both the sampled descriptor and this render pass. The render
     // pass returns the image to DEPTH_STENCIL_ATTACHMENT_OPTIMAL at the end, preserving the cache
@@ -5205,6 +5264,23 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                              VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT |
                                  VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT,
                              0, 0, nullptr, 0, nullptr, 1, &to_ds);
+    }
+    for (const auto& [borrowed, saved_layout] : borrowed_compute_images) {
+        VkImageMemoryBarrier restore{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
+        restore.oldLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+        restore.newLayout = saved_layout;
+        restore.srcAccessMask = VK_ACCESS_SHADER_READ_BIT;
+        restore.dstAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT |
+                                VK_ACCESS_TRANSFER_READ_BIT | VK_ACCESS_TRANSFER_WRITE_BIT;
+        restore.srcQueueFamilyIndex = restore.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        restore.image = borrowed;
+        restore.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+        vkCmdPipelineBarrier(cmd,
+                             VK_PIPELINE_STAGE_VERTEX_SHADER_BIT |
+                                 VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+                             VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT |
+                                 VK_PIPELINE_STAGE_TRANSFER_BIT,
+                             0, 0, nullptr, 0, nullptr, 1, &restore);
     }
     // A writable graphics storage image is architecturally guest memory, not a callback-local
     // texture. Copy its final texels back through the upload's coherent staging allocation before
@@ -5818,7 +5894,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                 release_render_host_buffer(dev, arena.buffer);
             for (auto& upload : texture_uploads) {
                 if (upload.image && !upload.persistent_hit && !upload.borrowed_target &&
-                    !upload.borrowed_ds)
+                    !upload.borrowed_compute && !upload.borrowed_ds)
                     vkDestroyImage(dev, upload.image, nullptr);
                 if (upload.memory) {
                     if (upload.direct_memory) vkFreeMemory(dev, upload.memory, nullptr);

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -972,14 +972,20 @@ public:
     }
 
     // Completion could not be proven after a successful submit. Invalidate speculative state, but
-    // never invoke cleanup callbacks for work Vulkan may still own. The sticky flag also rejects
-    // callbacks registered later in the current renderer call (registration follows diagnostics).
+    // never invoke or destroy cleanup callbacks for work Vulkan may still own. Besides Vulkan
+    // handles, their captures can contain ownership tokens for resources borrowed from another
+    // cache. Keep the complete closure set alive until process teardown; a normal static owner is
+    // unsuitable because its destructor could run while a lost device still owns the submission.
+    // The sticky flag also rejects callbacks registered later in the current renderer call
+    // (registration follows diagnostics).
     void abandon_pending_resources() {
         commands_.clear();
         finish_persistent_state(false);
         pending_resources_abandoned_ = true;
         backend_mark_unproven_submission();
-        cleanups_.clear();
+        if (!cleanups_.empty()) {
+            (void)new std::vector<std::function<void()>>(std::move(cleanups_));
+        }
     }
 
     BackendSubmissionBatchResult submit_and_wait(VkDevice dev, VkQueue queue,
@@ -1047,8 +1053,9 @@ public:
             finish_persistent_state(state == BackendSubmissionState::Complete);
         } else {
             // Neither wait proved completion, so every command buffer and object captured by its
-            // cleanup may still be in use. Drop the callbacks without invoking them; leaking these
-            // one-shot resources is the only valid last-resort action on an effectively lost device.
+            // cleanup may still be in use. Retain the callbacks without invoking or destroying
+            // them; leaking these one-shot resources and any borrowed ownership tokens they hold
+            // is the only valid last-resort action on an effectively lost device.
             abandon_pending_resources();
         }
         return result;

--- a/prosper/tests/test_game_compute.cpp
+++ b/prosper/tests/test_game_compute.cpp
@@ -1890,8 +1890,14 @@ int main() {
                 const bool rejected_srgb =
                     !prosper::frontend::import_live_compute_storage_image(
                         mismatched_fill, import_dst.size, rejected_import);
-                CHECK(rejected_extent && rejected_layout && rejected_replay && rejected_srgb,
-                      "compute-image import requires full identity and keeps replay/sRGB fallback");
+                mismatched_fill = sampled_fill;
+                mismatched_fill.declared_mip_levels = 2;
+                const bool rejected_mips =
+                    !prosper::frontend::import_live_compute_storage_image(
+                        mismatched_fill, import_dst.size, rejected_import);
+                CHECK(rejected_extent && rejected_layout && rejected_replay && rejected_srgb &&
+                          rejected_mips,
+                      "compute-image import requires full identity and keeps replay/mip/sRGB fallback");
                 compute_import = {};
                 // This binary does not install the emulator's SIGSEGV write-fault handler. Mark the
                 // same page dirty through the DMA/GPU side of the watch API; the importer must not

--- a/prosper/tests/test_game_compute.cpp
+++ b/prosper/tests/test_game_compute.cpp
@@ -1868,6 +1868,30 @@ int main() {
                           compute_import.height == 1 && compute_import.depth == 1 &&
                           compute_import.native_format && compute_import.layout,
                       "validated typed-storage result can be leased by an exact sampled descriptor");
+                prosper::frontend::LiveComputeImageImport rejected_import;
+                ShaderResource mismatched_fill = sampled_fill;
+                ++mismatched_fill.width;
+                const bool rejected_extent =
+                    !prosper::frontend::import_live_compute_storage_image(
+                        mismatched_fill, import_dst.size, rejected_import);
+                mismatched_fill = sampled_fill;
+                ++mismatched_fill.tile_mode;
+                const bool rejected_layout =
+                    !prosper::frontend::import_live_compute_storage_image(
+                        mismatched_fill, import_dst.size, rejected_import);
+                mismatched_fill = sampled_fill;
+                mismatched_fill.host_data = import_guest;
+                mismatched_fill.host_data_size = import_dst.size;
+                const bool rejected_replay =
+                    !prosper::frontend::import_live_compute_storage_image(
+                        mismatched_fill, import_dst.size, rejected_import);
+                mismatched_fill = sampled_fill;
+                mismatched_fill.srgb = true;
+                const bool rejected_srgb =
+                    !prosper::frontend::import_live_compute_storage_image(
+                        mismatched_fill, import_dst.size, rejected_import);
+                CHECK(rejected_extent && rejected_layout && rejected_replay && rejected_srgb,
+                      "compute-image import requires full identity and keeps replay/sRGB fallback");
                 compute_import = {};
                 // This binary does not install the emulator's SIGSEGV write-fault handler. Mark the
                 // same page dirty through the DMA/GPU side of the watch API; the importer must not

--- a/prosper/tests/test_game_compute.cpp
+++ b/prosper/tests/test_game_compute.cpp
@@ -1763,6 +1763,94 @@ int main() {
             CHECK(repeated_write_notifications == 0,
                   "identical retained output skips redundant guest writeback and invalidation");
 
+            // The live draw immediately following a compute producer is inside the same ordered
+            // guest submit. Its mutation journal is an exact authority even before a cross-submit
+            // page watch has accumulated enough stable validations to be promoted.
+            std::vector<uint8_t> journal_guest(W * 8, 0x51);
+            ShaderResourceTable journal_rt = fill_rt;
+            ShaderResource& journal_dst = journal_rt.resources.back();
+            journal_dst.gpu_addr = reinterpret_cast<uint64_t>(journal_guest.data());
+            ComputeItem journal_item = it;
+            journal_item.resources = std::make_shared<ShaderResourceTable>(journal_rt);
+            journal_item.dispatch_index = 31;
+            journal_item.command_order = 10;
+            DrawItem journal_consumer;
+            journal_consumer.draw_index = 47;
+            journal_consumer.command_order = 20;
+            bool journal_imported = false;
+            const OrderedSubmitResult journal_result = execute_ordered_items(
+                {{SubmitOperationKind::Dispatch, journal_item.dispatch_index,
+                  journal_item.command_order},
+                 {SubmitOperationKind::Draw, journal_consumer.draw_index,
+                  journal_consumer.command_order}},
+                {journal_consumer}, {journal_item},
+                [&](const std::vector<DrawItem>&, uint32_t, uint32_t) {
+                    ShaderResource sampled = journal_dst;
+                    sampled.cls = ResourceClass::Texture;
+                    prosper::frontend::LiveComputeImageImport compute_import;
+                    journal_imported = prosper::frontend::import_live_compute_storage_image(
+                        sampled, journal_dst.size, compute_import) && compute_import.valid();
+                    return RenderedFrame{};
+                },
+                [&](const std::vector<ComputeItem>& items) {
+                    return prosper::frontend::execute_live_compute_items(items);
+                },
+                1, 1);
+            CHECK(journal_result.compute_executed && journal_result.render_spans == 1 &&
+                      journal_imported,
+                  "same-submit journal authorizes the first retained compute-image consumer");
+
+#if defined(__linux__)
+            // Use a dedicated mapping so page protection cannot alias unrelated malloc metadata.
+            // Outside an ordered submit there is no submit-local journal, so a successful import
+            // here specifically proves the cross-submit write-watch authority path.
+            constexpr size_t import_mapping_bytes = 4096;
+            auto* import_guest = static_cast<uint8_t*>(mmap(
+                nullptr, import_mapping_bytes, PROT_READ | PROT_WRITE,
+                MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+            CHECK(import_guest != MAP_FAILED,
+                  "allocate dedicated typed-storage import mapping");
+            if (import_guest != MAP_FAILED) {
+                std::memset(import_guest, 0x37, import_mapping_bytes);
+                prosper::host::guest_write_watch_set_fault_onstack(true);
+                prosper::host::guest_write_watch_notify_direct_mapping_added(
+                    reinterpret_cast<uint64_t>(import_guest), import_mapping_bytes,
+                    0x7c0000, 0x3 /* SCE CPU_READ|CPU_WRITE */);
+                ShaderResourceTable import_rt = fill_rt;
+                ShaderResource& import_dst = import_rt.resources.back();
+                import_dst.gpu_addr = reinterpret_cast<uint64_t>(import_guest);
+                ComputeItem import_item = it;
+                import_item.resources = std::make_shared<ShaderResourceTable>(import_rt);
+                CHECK(prosper::frontend::execute_live_compute_items({import_item}) &&
+                          prosper::frontend::execute_live_compute_items({import_item}) &&
+                          prosper::frontend::execute_live_compute_items({import_item}) &&
+                          prosper::frontend::execute_live_compute_items({import_item}),
+                      "repeated typed-storage output promotes its exact source watch");
+                ShaderResource sampled_fill = import_dst;
+                sampled_fill.cls = ResourceClass::Texture;
+                prosper::frontend::LiveComputeImageImport compute_import;
+                CHECK(prosper::frontend::import_live_compute_storage_image(
+                          sampled_fill, import_dst.size, compute_import) &&
+                          compute_import.valid() && compute_import.width == W &&
+                          compute_import.height == 1 && compute_import.depth == 1 &&
+                          compute_import.native_format && compute_import.layout,
+                      "validated typed-storage result can be leased by an exact sampled descriptor");
+                compute_import = {};
+                // This binary does not install the emulator's SIGSEGV write-fault handler. Mark the
+                // same page dirty through the DMA/GPU side of the watch API; the importer must not
+                // trust the retained image after any architectural writer invalidates its bytes.
+                prosper::host::guest_write_watch_notify_gpu_write(
+                    reinterpret_cast<uint64_t>(import_guest), import_dst.size);
+                CHECK(!prosper::frontend::import_live_compute_storage_image(
+                          sampled_fill, import_dst.size, compute_import),
+                      "guest mutation revokes a cross-submit compute-image import");
+                prosper::host::guest_write_watch_notify_direct_mapping_removed(
+                    reinterpret_cast<uint64_t>(import_guest), import_mapping_bytes);
+                prosper::host::guest_write_watch_set_fault_onstack(false);
+                munmap(import_guest, import_mapping_bytes);
+            }
+#endif
+
             // Prove a second full writer of the same format/extent on a different target, then use
             // it on this still-valid guest mirror. The persistent image key intentionally does not
             // contain the shader: different post-processes may reuse one target. Its GPU comparison

--- a/prosper/tests/test_game_compute.cpp
+++ b/prosper/tests/test_game_compute.cpp
@@ -1848,7 +1848,7 @@ int main() {
                 prosper::host::guest_write_watch_set_fault_onstack(true);
                 prosper::host::guest_write_watch_notify_direct_mapping_added(
                     reinterpret_cast<uint64_t>(import_guest), import_mapping_bytes,
-                    0x7c0000, 0x3 /* SCE CPU_READ|CPU_WRITE */);
+                    0x7e0000, 0x3 /* SCE CPU_READ|CPU_WRITE */);
                 ShaderResourceTable import_rt = fill_rt;
                 ShaderResource& import_dst = import_rt.resources.back();
                 import_dst.gpu_addr = reinterpret_cast<uint64_t>(import_guest);

--- a/prosper/tests/test_texture_sample_render.cpp
+++ b/prosper/tests/test_texture_sample_render.cpp
@@ -936,6 +936,7 @@ int main() {
         bool prior_cleanup_ran = false;
         bool later_cleanup_ran = false;
         bool borrowed_lease_released = false;
+        bool late_borrowed_lease_released = false;
         auto borrowed_lease = std::shared_ptr<void>(
             new int(1),
             [&](void* ptr) {
@@ -944,22 +945,35 @@ int main() {
             });
         CHECK(!prosper::test::backend_has_unproven_submission(),
               "completed test submissions leave the global lifetime guard clear");
-        prosper::test::BackendSubmissionBatch abandoned_batch;
-        abandoned_batch.enqueue(VK_NULL_HANDLE);
-        abandoned_batch.add_failure_cleanup([&]() { speculative_state_valid = false; });
-        abandoned_batch.add_cleanup([&, lease = borrowed_lease]() {
-            (void)lease;
-            prior_cleanup_ran = true;
-        });
-        borrowed_lease.reset();
-        abandoned_batch.abandon_pending_resources();
-        abandoned_batch.add_cleanup([&]() { later_cleanup_ran = true; });
-        abandoned_batch.complete();
-        CHECK(!abandoned_batch.pending() && abandoned_batch.retains_pending_resources() &&
-                  prosper::test::backend_has_unproven_submission() &&
-                  !speculative_state_valid && !prior_cleanup_ran && !later_cleanup_ran &&
-                  !borrowed_lease_released,
-              "pending submission globally retains prior resources and borrowed leases");
+        {
+            prosper::test::BackendSubmissionBatch abandoned_batch;
+            abandoned_batch.enqueue(VK_NULL_HANDLE);
+            abandoned_batch.add_failure_cleanup([&]() { speculative_state_valid = false; });
+            abandoned_batch.add_cleanup([&, lease = borrowed_lease]() {
+                (void)lease;
+                prior_cleanup_ran = true;
+            });
+            borrowed_lease.reset();
+            abandoned_batch.abandon_pending_resources();
+            auto late_borrowed_lease = std::shared_ptr<void>(
+                new int(2),
+                [&](void* ptr) {
+                    late_borrowed_lease_released = true;
+                    delete static_cast<int*>(ptr);
+                });
+            abandoned_batch.add_cleanup([&, lease = late_borrowed_lease]() {
+                (void)lease;
+                later_cleanup_ran = true;
+            });
+            late_borrowed_lease.reset();
+            abandoned_batch.complete();
+            CHECK(!abandoned_batch.pending() && abandoned_batch.retains_pending_resources() &&
+                      prosper::test::backend_has_unproven_submission() &&
+                      !speculative_state_valid && !prior_cleanup_ran && !later_cleanup_ran,
+                  "pending submission globally retains prior and late resources");
+        }
+        CHECK(!borrowed_lease_released && !late_borrowed_lease_released,
+              "borrowed leases survive destruction of an abandoned submission batch");
         const std::vector<uint8_t> blocked = prosper::test::render_triangle_rgba(
             vert, lzf, W, H, nullptr, nullptr, nullptr, &td);
         CHECK(blocked.empty(),

--- a/prosper/tests/test_texture_sample_render.cpp
+++ b/prosper/tests/test_texture_sample_render.cpp
@@ -327,6 +327,32 @@ int main() {
                   sampled_stats.sampled_hits == 1,
               "GPU-resident target sampling matches CPU readback+upload byte-for-byte");
 
+        // Exercise the generic compute-image borrow carried by FrameResource. Reuse this exact
+        // backend-owned image as a convenient fixture, but address it only through the opaque
+        // borrowed-image fields: the backend must build a view/sampler, preserve the owner's layout,
+        // retain the lease through completion, and never destroy the borrowed VkImage.
+        auto* borrowed_fixture = prosper::test::find_persistent_color_target(
+            target_id, W, H, VK_FORMAT_R8G8B8A8_UNORM);
+        prosper::test::FrameResource borrowed_resource = cpu_resource;
+        borrowed_resource.tex_rgba = nullptr;
+        borrowed_resource.persistent_render_target_id = 0;
+        borrowed_resource.borrowed_compute_image =
+            borrowed_fixture ? static_cast<void*>(borrowed_fixture->image) : nullptr;
+        borrowed_resource.borrowed_compute_device =
+            static_cast<void*>(prosper::test::render_vk_ctx().dev);
+        borrowed_resource.borrowed_compute_image_layout = borrowed_fixture
+            ? static_cast<uint32_t>(borrowed_fixture->layout) : 0u;
+        borrowed_resource.borrowed_compute_image_lease = std::make_shared<int>(1);
+        prosper::test::BackendDraw borrowed_sample = cpu_sample;
+        borrowed_sample.R = {borrowed_resource};
+        std::vector<uint8_t> borrowed_resident = prosper::test::render_draws_rgba(
+            {borrowed_sample}, W, H);
+        std::vector<uint8_t> borrowed_followup = prosper::test::render_draws_rgba(
+            {gpu_sample}, W, H);
+        CHECK(borrowed_fixture && borrowed_resident == cpu_roundtrip &&
+                  borrowed_followup == cpu_roundtrip,
+              "borrowed compute-image sampling preserves pixels, owner layout, and image lifetime");
+
         // Multiple ordered target calls may record into one queue submission. The producer returns no
         // CPU pixels; the consumer samples that not-yet-submitted target, then its requested readback
         // flushes both command buffers behind one fence.
@@ -529,7 +555,78 @@ int main() {
             const auto gpu_sample_stats = prosper::test::backend_color_target_stats();
             CHECK(gpu_sample_stats.sampled_hits == 1 && gpu_sampled == cpu_sampled,
                   "GPU-resident FP16 target sampling matches native CPU RTT round-trip");
+
+            auto* borrowed_fp16_fixture = prosper::test::find_persistent_color_target(
+                fp16_target_id, W, H, VK_FORMAT_R16G16B16A16_SFLOAT);
+            prosper::test::FrameResource borrowed_fp16_resource = fp16_resource;
+            borrowed_fp16_resource.tex_rgba = nullptr;
+            borrowed_fp16_resource.borrowed_compute_image = borrowed_fp16_fixture
+                ? static_cast<void*>(borrowed_fp16_fixture->image) : nullptr;
+            borrowed_fp16_resource.borrowed_compute_device =
+                static_cast<void*>(prosper::test::render_vk_ctx().dev);
+            borrowed_fp16_resource.borrowed_compute_image_layout = borrowed_fp16_fixture
+                ? static_cast<uint32_t>(borrowed_fp16_fixture->layout) : 0u;
+            borrowed_fp16_resource.borrowed_compute_image_lease = std::make_shared<int>(1);
+            consumer.R = {borrowed_fp16_resource};
+            const std::vector<uint8_t> borrowed_fp16_sampled =
+                prosper::test::render_draws_rgba({consumer}, W, H);
+            consumer.R = {gpu_fp16_resource};
+            const std::vector<uint8_t> borrowed_fp16_followup =
+                prosper::test::render_draws_rgba({consumer}, W, H);
+            CHECK(borrowed_fp16_fixture && borrowed_fp16_sampled == cpu_sampled &&
+                      borrowed_fp16_followup == cpu_sampled,
+                  "borrowed native FP16 image preserves HDR sampling, layout, and lifetime");
             prosper::test::invalidate_persistent_color_target(fp16_target_id);
+
+            ResolvedPipelineState r11_state = fp16_state;
+            r11_state.color0_format = VK_FORMAT_B10G11R11_UFLOAT_PACK32;
+            producer.ps = &r11_state;
+            constexpr uint64_t r11_target_id = 0x7590000000000011ull;
+            prosper::test::BackendColorTarget r11_target{
+                r11_target_id, false, true, VK_FORMAT_B10G11R11_UFLOAT_PACK32};
+            const std::vector<uint8_t> r11_native = prosper::test::render_draws_rgba(
+                {producer}, W, H, nullptr, nullptr, false, &r11_target);
+            prosper::test::FrameResource r11_resource;
+            r11_resource.binding = 4; r11_resource.set = 1;
+            r11_resource.tex_rgba = r11_native.data();
+            r11_resource.tw = W; r11_resource.th = H;
+            r11_resource.texture_format = VK_FORMAT_B10G11R11_UFLOAT_PACK32;
+            consumer.R = {r11_resource};
+            const std::vector<uint8_t> r11_cpu_sampled =
+                prosper::test::render_draws_rgba({consumer}, W, H);
+
+            prosper::test::FrameResource gpu_r11_resource = r11_resource;
+            gpu_r11_resource.tex_rgba = nullptr;
+            gpu_r11_resource.persistent_render_target_id = r11_target_id;
+            consumer.R = {gpu_r11_resource};
+            const std::vector<uint8_t> r11_gpu_sampled =
+                prosper::test::render_draws_rgba({consumer}, W, H);
+
+            auto* borrowed_r11_fixture = prosper::test::find_persistent_color_target(
+                r11_target_id, W, H, VK_FORMAT_B10G11R11_UFLOAT_PACK32);
+            prosper::test::FrameResource borrowed_r11_resource = r11_resource;
+            borrowed_r11_resource.tex_rgba = nullptr;
+            borrowed_r11_resource.borrowed_compute_image = borrowed_r11_fixture
+                ? static_cast<void*>(borrowed_r11_fixture->image) : nullptr;
+            borrowed_r11_resource.borrowed_compute_device =
+                static_cast<void*>(prosper::test::render_vk_ctx().dev);
+            borrowed_r11_resource.borrowed_compute_image_layout = borrowed_r11_fixture
+                ? static_cast<uint32_t>(borrowed_r11_fixture->layout) : 0u;
+            borrowed_r11_resource.borrowed_compute_image_lease = std::make_shared<int>(1);
+            consumer.R = {borrowed_r11_resource};
+            const std::vector<uint8_t> r11_borrowed_sampled =
+                prosper::test::render_draws_rgba({consumer}, W, H);
+            consumer.R = {gpu_r11_resource};
+            const std::vector<uint8_t> r11_borrowed_followup =
+                prosper::test::render_draws_rgba({consumer}, W, H);
+            CHECK(r11_native.size() == static_cast<size_t>(W) * H * 4 &&
+                      center_red(r11_cpu_sampled) >= 126 &&
+                      center_red(r11_cpu_sampled) <= 129 &&
+                      r11_gpu_sampled == r11_cpu_sampled && borrowed_r11_fixture &&
+                      r11_borrowed_sampled == r11_cpu_sampled &&
+                      r11_borrowed_followup == r11_cpu_sampled,
+                  "borrowed native R11G11B10 image preserves HDR sampling, layout, and lifetime");
+            prosper::test::invalidate_persistent_color_target(r11_target_id);
         }
     }
 

--- a/prosper/tests/test_texture_sample_render.cpp
+++ b/prosper/tests/test_texture_sample_render.cpp
@@ -935,19 +935,31 @@ int main() {
         bool speculative_state_valid = true;
         bool prior_cleanup_ran = false;
         bool later_cleanup_ran = false;
+        bool borrowed_lease_released = false;
+        auto borrowed_lease = std::shared_ptr<void>(
+            new int(1),
+            [&](void* ptr) {
+                borrowed_lease_released = true;
+                delete static_cast<int*>(ptr);
+            });
         CHECK(!prosper::test::backend_has_unproven_submission(),
               "completed test submissions leave the global lifetime guard clear");
         prosper::test::BackendSubmissionBatch abandoned_batch;
         abandoned_batch.enqueue(VK_NULL_HANDLE);
         abandoned_batch.add_failure_cleanup([&]() { speculative_state_valid = false; });
-        abandoned_batch.add_cleanup([&]() { prior_cleanup_ran = true; });
+        abandoned_batch.add_cleanup([&, lease = borrowed_lease]() {
+            (void)lease;
+            prior_cleanup_ran = true;
+        });
+        borrowed_lease.reset();
         abandoned_batch.abandon_pending_resources();
         abandoned_batch.add_cleanup([&]() { later_cleanup_ran = true; });
         abandoned_batch.complete();
         CHECK(!abandoned_batch.pending() && abandoned_batch.retains_pending_resources() &&
                   prosper::test::backend_has_unproven_submission() &&
-                  !speculative_state_valid && !prior_cleanup_ran && !later_cleanup_ran,
-              "pending submission globally protects prior and later resources");
+                  !speculative_state_valid && !prior_cleanup_ran && !later_cleanup_ran &&
+                  !borrowed_lease_released,
+              "pending submission globally retains prior resources and borrowed leases");
         const std::vector<uint8_t> blocked = prosper::test::render_triangle_rgba(
             vert, lzf, W, H, nullptr, nullptr, nullptr, &td);
         CHECK(blocked.empty(),

--- a/prosper/tests/test_texture_sample_render.cpp
+++ b/prosper/tests/test_texture_sample_render.cpp
@@ -353,6 +353,39 @@ int main() {
                   borrowed_followup == cpu_roundtrip,
               "borrowed compute-image sampling preserves pixels, owner layout, and image lifetime");
 
+        // A live renderer span can retain resources while later target passes are still being
+        // recorded into the same queue batch. Drop every caller-owned lease reference before the
+        // fence: only the backend cleanup scope may keep the borrowed VkImage pinned at that point.
+        bool pending_lease_released = false;
+        prosper::test::FrameResource pending_borrow = borrowed_resource;
+        pending_borrow.borrowed_compute_image_lease = std::shared_ptr<void>(
+            new int(1), [&](void* allocation) {
+                pending_lease_released = true;
+                delete static_cast<int*>(allocation);
+            });
+        prosper::test::BackendDraw pending_sample = cpu_sample;
+        pending_sample.R = {pending_borrow};
+        constexpr uint64_t pending_target_id = 0x7590000000000002ull;
+        prosper::test::BackendColorTarget pending_target{
+            pending_target_id, false, false};
+        prosper::test::BackendSubmissionBatch pending_batch;
+        const std::vector<uint8_t> pending_result = prosper::test::render_draws_rgba(
+            {pending_sample}, W, H, nullptr, nullptr, false, &pending_target,
+            nullptr, nullptr, nullptr, &pending_batch, false);
+        pending_borrow.borrowed_compute_image_lease.reset();
+        pending_sample.R.clear();
+        CHECK(pending_result.empty() && pending_batch.pending() && !pending_lease_released,
+              "pending graphics submission retains the borrowed compute-image lease");
+        const prosper::test::BackendSubmissionBatchResult pending_submit =
+            pending_batch.submit_and_wait(
+                prosper::test::render_vk_ctx().dev,
+                prosper::test::render_vk_ctx().queue, false);
+        pending_batch.complete();
+        CHECK(pending_submit.submit_result == VK_SUCCESS &&
+                  pending_submit.wait_result == VK_SUCCESS && pending_lease_released,
+              "borrowed compute-image lease releases only after graphics completion");
+        prosper::test::invalidate_persistent_color_target(pending_target_id);
+
         // Multiple ordered target calls may record into one queue submission. The producer returns no
         // CPU pixels; the consumer samples that not-yet-submitted target, then its requested readback
         // flushes both command buffers behind one fence.


### PR DESCRIPTION
Closes #1477.

## Problem

Successful typed-storage compute dispatches already retain an exact native Vulkan image and mirror that result into guest memory. A later graphics texture binding ignored the native authority, revalidated/detiled the tiled guest mirror, and uploaded another image. Plucky repeatedly exercises this on 3840x2160 R11G11B10 (33.4 MiB) and RGBA16F (66.8 MiB) outputs; cold fallback materialization has taken roughly 64-90 ms.

## Change

- Publish only fully successful retained native typed-storage results that were created with sampled usage.
- Reconstruct the complete compute cache identity at graphics import and require either the current-submit guest-write journal or a clean cross-submit page watch.
- Revoke export authority before recording an attempted storage dispatch and republish only after dispatch, readback/writeback, notifications, and GENERAL-layout restoration all succeed.
- Pin the cached image through graphics fence cleanup. Graphics creates only its view/sampler, transitions GENERAL to shader-read for the pass, restores GENERAL, and never destroys the compute-owned image.
- Bind the two exact native graphics formats currently supported by this path: Float16x4 and packed Float10_11_11x3.
- Retain the existing fallback for raw-uvec4 interchange images, replay `host_data`, depth/compare and sRGB views, mip-tail/array/volume resources, non-uncompressed DCC state, unsupported formats, and any failed authority check.
- Add `PROSPER_NO_DIRECT_COMPUTE_IMAGE_BIND=1` as the single-switch control.

## Correctness contract and tests

The production-backend regressions prove:

- same-submit journal authorization;
- cross-submit write-watch promotion and rejection after an architectural GPU/DMA write;
- full descriptor identity and replay/sRGB fallback rejection;
- FP16 and R11G11B10 borrowed sampling against the established CPU readback/upload path;
- owner reuse after graphics, lease release after a proven graphics fence, and intentional lease
  retention when completion of submitted work cannot be proven;
- failure-injected storage readback revokes stale authority and forces a safe retry.

Exact head `d5c56a4a`:

```text
cmake --build prosper/build-verify-gta5 --target test_game_compute test_texture_sample_render test_rdna2_to_spirv test_rdna2_spirv_struct -j2
TMPDIR=/home/mattias800/.cache/prosper-1477-tmp ctest --test-dir prosper/build-verify-gta5 --output-on-failure -R '^(game_compute_exec|texture_sample_render|rdna2_to_spirv_exec|rdna2_spirv_struct)$' -j1
4/4 passed
```

A clean Release core/renderer build configured with the repository's Messenger fixture completed, then the serial full suite passed 150/153 tests. The three local failures are diagnostic stderr/timing capture tests outside this diff (`sync_delete`, `service_logging_unmapped_args`, and `render_state_extract`); every GPU, compute, replay, renderer, shared-device, and present test passed. `git diff --check origin/master...HEAD` is clean.

No Plucky snapshot baseline is registered and this change does not alter snapshot data. The snapshot guard unit test passed; live full-resolution checkpoints below provide the title-specific visual check.

## Live Plucky A/B

A fresh feature-head pair used the same 140-second full-resolution route, normal render cadence, audio, SDL input, and timing settings. Only the disable switch changed; the later commits tighten import eligibility and indeterminate-submit lifetime handling without changing the successful rendering path.

| | Enabled | Disabled control |
|---|---:|---:|
| Presented frames | 2,220 | 2,040 |
| Final 25-submit texture-resource window | 6.45 ms | 10.62 ms |
| Logged direct decisions | 250 (detail cap) | 0 |

The enabled trace included a 3840x2160 RGBA16F import at 0.09 ms with zero guest-byte validation/copy. Both native 3840x2160 checkpoints were visually clean. They armed at the same guest present (1,058), but asynchronous readback completed on different later presents and captured different menu states, so they are correctness/progression evidence rather than a pixel-equality oracle. GPU replay intentionally owns resources as `host_data`, so it exercises the unchanged fallback rather than this temporal live-residency boundary.

## Risk

This crosses compute/graphics image ownership and synchronization boundaries. The implementation keeps Vulkan handles opaque at the frontend boundary, verifies the shared device, pins cache entries through fence cleanup, performs explicit layout/access transitions, and fails closed to the existing CPU path whenever identity, authority, format, device, or lifetime requirements are not met. If submitted work reaches an indeterminate fence state, the renderer becomes sticky-unavailable and intentionally retains the complete cleanup closure, including borrowed ownership tokens, for process lifetime.
