### PR TITLE
gpu: clear Astro Bot linked world-map NGG failures

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -10710,9 +10710,10 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
             if (branch.pc < L.header_pc && target >= L.exit_pc) guarded_narrow_entry = true;
         }
         // 1. Pre-loop body. A compiler may place one ordinary uniform if/else before the canonical
-        // counted loop (Evergate selects one of two constant blocks this way). Structure that choice
-        // with the same two-arm PHIs as the general forward-if path, then enter the existing counted
-        // loop lowering. Anything nested/more complex stays unsupported and rejects visibly.
+        // counted loop (Evergate selects one of two constant blocks this way; Astro's NGG culling
+        // prelude also has a one-arm conditional). Structure that choice with the same two-arm PHIs
+        // as the general forward-if path, then enter the existing counted-loop lowering. Anything
+        // nested/more complex stays unsupported and rejects visibly.
         std::vector<Rdna2Inst> preloop;
         for (const auto& in : ins) {
             if (in.pc >= L.header_pc) break;
@@ -10732,9 +10733,10 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
         const std::vector<ForwardIf> preloop_ifs = detect_forward_ifs(
             preloop, /*allow_vcc*/!b.is_compute, code, dwords, &effective_safe, nullptr,
             &preloop_rejected, /*compute_wave_branches*/b.is_compute);
-        if (preloop_rejected || preloop_ifs.size() > 1 ||
-            (!preloop_ifs.empty() && (!preloop_ifs[0].has_else ||
-                                      preloop_ifs[0].merge_pc > L.header_pc))) {
+        const bool preloop_if_escapes = !preloop_ifs.empty() &&
+            (preloop_ifs[0].has_else ? preloop_ifs[0].merge_pc : preloop_ifs[0].target_pc) >
+                L.header_pc;
+        if (preloop_rejected || preloop_ifs.size() > 1 || preloop_if_escapes) {
             if (getenv("PROSPER_DBG"))
                 fprintf(stderr,
                         "[recompile-reject] counted-loop prelude cfg rejected=%u ifs=%zu header=%u\n",
@@ -10758,16 +10760,21 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
             condition = F.on_scc0 ? condition : b.logical_not(condition);
             const RegState before = rs;
             std::set<int> written_v, written_s;
-            loop_written_regs(ins, F.branch_pc + 1, F.sb_pc, written_v, written_s);
-            loop_written_regs(ins, F.target_pc, F.merge_pc, written_v, written_s);
+            const uint32_t then_end = F.has_else ? F.sb_pc : F.target_pc;
+            const uint32_t merge_pc = F.has_else ? F.merge_pc : F.target_pc;
+            loop_written_regs(ins, F.branch_pc + 1, then_end, written_v, written_s);
+            if (F.has_else)
+                loop_written_regs(ins, F.target_pc, merge_pc, written_v, written_s);
             const uint32_t then_label = b.id(), else_label = b.id(), merge_label = b.id();
             b.emit_selmerge(merge_label);
             b.emit_condbranch(condition, then_label, else_label);
 
             b.emit_label(then_label);
-            if (!emit_range(F.branch_pc + 1, F.sb_pc)) return false;
-            if (idx >= ins.size() || ins[idx].pc != F.sb_pc) return false;
-            ++idx; // consume the then arm's jump to the merge
+            if (!emit_range(F.branch_pc + 1, then_end)) return false;
+            if (F.has_else) {
+                if (idx >= ins.size() || ins[idx].pc != F.sb_pc) return false;
+                ++idx; // consume the then arm's jump to the merge
+            }
             const uint32_t then_block = b.cur_block;
             std::unordered_map<int, uint32_t> then_v, then_s;
             for (int reg : written_v) then_v[reg] = vget(reg);
@@ -10781,7 +10788,7 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
 
             rs = before;
             b.emit_label(else_label);
-            if (!emit_range(F.target_pc, F.merge_pc)) return false;
+            if (F.has_else && !emit_range(F.target_pc, merge_pc)) return false;
             const uint32_t else_block = b.cur_block;
             b.emit_branch(merge_label);
             b.emit_label(merge_label);
@@ -10815,7 +10822,7 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                     fprintf(stderr, "[recompile-reject] counted-loop prelude changes mask domain\n");
                 return false; // no mask-domain PHIs in this narrow composition
             }
-            if (!emit_range(F.merge_pc, L.header_pc)) return false;
+            if (!emit_range(merge_pc, L.header_pc)) return false;
         }
         // Ordinary counted loops require full EXEC at entry. An NGG vertex is already represented by
         // one independent Vulkan invocation, however, so its EXEC bit is an ordinary per-invocation
@@ -12099,14 +12106,20 @@ static bool is_astro_bot_ngg_one_lane_wrapper(const uint32_t* code, size_t dword
     if (!code) return false;
     std::vector<Rdna2Inst> instructions;
     const size_t program_dwords = rdna2_walk(code, dwords, instructions);
-    if (program_dwords != 54 && program_dwords != 734 && program_dwords != 3124 &&
-        program_dwords != 3435 && program_dwords != 3917)
+    if (program_dwords != 54 && program_dwords != 734 && program_dwords != 749 &&
+        program_dwords != 3124 && program_dwords != 3435 && program_dwords != 3455 &&
+        program_dwords != 3917)
         return false;
     const uint64_t hash = shader_program_hash(code, program_dwords);
     return (program_dwords == 54 && hash == 0x9e9d8e37bcc70607ull) ||
            (program_dwords == 734 && hash == 0x79eb2b954b07dc8eull) ||
+           // The same 734-word culling wrapper is live-linked after its exact 15-word fetch prolog.
+           (program_dwords == 749 && hash == 0xb440349937df751eull) ||
            (program_dwords == 3124 && hash == 0x41e6ac616c18d295ull) ||
            (program_dwords == 3435 && hash == 0xfad7a9f486523cfcull) ||
+           // The same 3435-word wrapper is live-linked after its exact 20-word fetch prolog.
+           // Hashing the complete concatenated program keeps the one-lane projection byte-exact.
+           (program_dwords == 3455 && hash == 0x562ce5ad01c4c6e3ull) ||
            (program_dwords == 3917 && hash == 0x7f5f2349e2816f5eull);
 }
 

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -10733,10 +10733,14 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
         const std::vector<ForwardIf> preloop_ifs = detect_forward_ifs(
             preloop, /*allow_vcc*/!b.is_compute, code, dwords, &effective_safe, nullptr,
             &preloop_rejected, /*compute_wave_branches*/b.is_compute);
-        const bool preloop_if_escapes = !preloop_ifs.empty() &&
-            (preloop_ifs[0].has_else ? preloop_ifs[0].merge_pc : preloop_ifs[0].target_pc) >
-                L.header_pc;
-        if (preloop_rejected || preloop_ifs.size() > 1 || preloop_if_escapes) {
+        // detect_forward_ifs clamps a branch to an immediate s_endpgm at its artificial end marker
+        // and records it as early_out. In this truncated prelude that can be a real branch over the
+        // entire counted loop, so it cannot be structured as an ordinary one-arm conditional.
+        const bool preloop_if_unsupported = !preloop_ifs.empty() &&
+            (preloop_ifs[0].early_out ||
+             (preloop_ifs[0].has_else ? preloop_ifs[0].merge_pc : preloop_ifs[0].target_pc) >
+                 L.header_pc);
+        if (preloop_rejected || preloop_ifs.size() > 1 || preloop_if_unsupported) {
             if (getenv("PROSPER_DBG"))
                 fprintf(stderr,
                         "[recompile-reject] counted-loop prelude cfg rejected=%u ifs=%zu header=%u\n",

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -2388,6 +2388,34 @@ int main() {
     printf("  kernel43 mismatches=%u (out[5]=%g expect=10)\n", bad43, got43.size()==N?got43[5]:-1);
     CHECK(got43.size()==N && bad43==0, "recompiled kernel 43 (counted loop sum 0..4) computes 10");
 
+    // Kernel 43a: one ordinary uniform if immediately before a counted loop. Astro Bot's NGG culling
+    // shader uses this composition in its setup; the two constructs were individually supported, but
+    // the counted-loop prelude previously admitted only if/else. Exercise both PHI inputs by changing
+    // the constant comparison: the taken form seeds sum=7, while the skipped form retains sum=0.
+    const uint32_t code43a_taken[] = {
+        0xBE800383u, 0xBE810385u, 0xBF0A0100u, 0x7E020280u, 0xBF840001u, 0x7E020287u,
+        0xB0020005u, 0xBE800380u, 0xBF0A0200u, 0xBF840003u, 0x4A020200u, 0x81008100u,
+        0xBF82FFFBu, 0x7E000D01u, 0xBF810000u,
+    };
+    const uint32_t code43a_skipped[] = {
+        0xBE800385u, 0xBE810383u, 0xBF0A0100u, 0x7E020280u, 0xBF840001u, 0x7E020287u,
+        0xB0020005u, 0xBE800380u, 0xBF0A0200u, 0xBF840003u, 0x4A020200u, 0x81008100u,
+        0xBF82FFFBu, 0x7E000D01u, 0xBF810000u,
+    };
+    const auto spv43a_taken = recompile_valu(
+        code43a_taken, std::size(code43a_taken), 0, 0);
+    const auto spv43a_skipped = recompile_valu(
+        code43a_skipped, std::size(code43a_skipped), 0, 0);
+    CHECK(!spv43a_taken.empty() && !spv43a_skipped.empty(),
+          "recompiled kernel 43a (one-arm pre-loop if + counted loop) -> SPIR-V");
+    const auto got43a_taken = prosper::test::run_compute(spv43a_taken, in43, N, N);
+    const auto got43a_skipped = prosper::test::run_compute(spv43a_skipped, in43, N, N);
+    uint32_t bad43a = 0;
+    for (uint32_t i = 0; i < N && got43a_taken.size() == N && got43a_skipped.size() == N; ++i)
+        if (got43a_taken[i] != 17.0f || got43a_skipped[i] != 10.0f) ++bad43a;
+    CHECK(got43a_taken.size() == N && got43a_skipped.size() == N && bad43a == 0,
+          "kernel 43a merges taken/skipped pre-loop values into the counted loop exactly");
+
     // Kernel 44: a value advanced in the CONDITION region and read after the loop. s0 is incremented by
     //   10 at the header (which runs on the exiting iteration too), so hardware yields 40, not the phi's
     //   back-edge value 30. Regression guard for the condition-region-vs-body merge-value distinction.

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -2416,6 +2416,18 @@ int main() {
     CHECK(got43a_taken.size() == N && got43a_skipped.size() == N && bad43a == 0,
           "kernel 43a merges taken/skipped pre-loop values into the counted loop exactly");
 
+    // Kernel 43b: a pre-loop conditional that jumps over the complete counted loop to s_endpgm.
+    // The prelude CFG scan uses the loop header as an artificial end marker, so it must preserve the
+    // early-out classification and reject rather than silently execute the loop on both outcomes.
+    const uint32_t code43b[] = {
+        0xBE800385u, 0xBE810383u, 0xBF0A0100u, 0xBF840009u, 0xB0020005u,
+        0xBE800380u, 0x7E020280u, 0xBF0A0200u, 0xBF840003u, 0x4A020200u,
+        0x81008100u, 0xBF82FFFBu, 0x7E000D01u, 0xBF810000u,
+    };
+    const auto spv43b = recompile_valu(code43b, std::size(code43b), 0, 0);
+    CHECK(spv43b.empty(),
+          "kernel 43b rejects a pre-loop early-out that skips the counted loop");
+
     // Kernel 44: a value advanced in the CONDITION region and read after the loop. s0 is incremented by
     //   10 at the header (which runs on the exiting iteration too), so hardware yields 40, not the phi's
     //   back-edge value 30. Regression guard for the condition-region-vs-body merge-value distinction.

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -162,6 +162,10 @@ and extract one with `--dump-failed-shader FAILURE:STAGE PATH`. Selection is
 intentionally bounded to the consumer and an optional
 immediate predecessor. Explicit-depth `.prgbundle` capture provides bounded recursive cross-submit closure;
 automatic present-to-producer selection remains #595.
+After a translator change, use `gpu_replay --retry-failed-stage FAILURE:STAGE` for one retained shader or
+`--retry-failed-chain FAILURE` for a captured split vertex prolog/main pair. These offline paths reuse the exact
+captured resource table and report whether the current production recompiler now produces SPIR-V, without a
+guest boot or Vulkan replay.
 Timeline version 6 retains the version-5 sliding graphics-target window plus full-run aggregate lifetime metadata
 when a detailed capture is requested. `PROSPER_GPU_TIMELINE_HISTORY=N` raises the window to at most 65536.
 Producer records identify the latest overlapping prior submit/draw/PM4 order, earliest observed graphics

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -338,6 +338,13 @@ stage is fault-safely read once, content-deduplicated, capped at 64 KiB, and sto
 outnumber semantic operations, and every reference/hash is validated while reading. Captures v1-v6 remain
 readable and print `failure-diagnostics: unavailable (capture predates v7)` rather than inventing evidence.
 
+`--retry-failed-stage FAILURE:STAGE` reruns one retained stage through the current recompiler with its exact
+captured resource table. For split vertex programs, `--retry-failed-chain FAILURE` instead reconstructs the
+first two retained vertex stages as one prolog/main chain and calls the production chain recompiler. Both modes
+exit successfully only when SPIR-V is produced and avoid Vulkan rendering, so they are the fast feedback path
+after a translator change. Chain retry requires the exact resource metadata added in capture v35 and rejects
+older or incomplete diagnostics explicitly.
+
 Capture v8 adds persistent depth/stencil checkpoints. Each seed stores the renderer's complete guest cache
 identity (depth/stencil read/write bases, HTILE base, extent, and D32/D32S8 format), independent depth/stencil
 validity, and raw valid-plane bytes. Counts, extents, formats, duplicate identities, per-plane lengths, and a

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -64,6 +64,7 @@ void usage(const char* argv0) {
                          "[--dump-realized-shader DRAW:vs|vs-main|fs PATH] "
                          "[--override-compute-spv N PATH] "
                          "[--dump-failed-shader FAILURE:STAGE PATH] "
+                         "[--retry-failed-chain FAILURE] "
                          "[--retry-failed-stage FAILURE:STAGE] "
                          "[--dump-compute-resource N:BINDING PATH] "
                          "[--legacy-htile-before-stencil] "
@@ -1376,7 +1377,7 @@ int main(int argc, char** argv) {
     std::string compute_override_spec, compute_override_path;
     std::string compute_resource_spec, compute_resource_path;
     std::string failed_shader_spec, failed_shader_path;
-    std::string retry_failed_stage_spec;
+    std::string retry_failed_chain_spec, retry_failed_stage_spec;
     std::string realized_shader_spec, realized_shader_path;
     std::string rtt_seed_path;
     std::string graph_json_path, prepend_path;
@@ -1507,6 +1508,8 @@ int main(int argc, char** argv) {
         else if (std::string(argv[i]) == "--dump-failed-shader" && i + 2 < argc) {
             failed_shader_spec = argv[++i]; failed_shader_path = argv[++i];
         }
+        else if (std::string(argv[i]) == "--retry-failed-chain" && i + 1 < argc)
+            retry_failed_chain_spec = argv[++i];
         else if (std::string(argv[i]) == "--retry-failed-stage" && i + 1 < argc)
             retry_failed_stage_spec = argv[++i];
         else positional.push_back(argv[i]);
@@ -1523,6 +1526,7 @@ int main(int argc, char** argv) {
             !realized_shader_spec.empty() ||
             !compute_override_spec.empty() ||
             !compute_resource_spec.empty() || !failed_shader_spec.empty() ||
+            !retry_failed_chain_spec.empty() ||
             !prepend_path.empty() || !draw_steps_prefix.empty()) {
             usage(argv[0]); return 2;
         }
@@ -1972,6 +1976,59 @@ int main(int argc, char** argv) {
         std::fprintf(stderr, "[gpureplay] dumped failed shader %s (%zu bytes) to %s\n",
                      failed_shader_spec.c_str(), bytes, failed_shader_path.c_str());
         if (positional.size() == 1 && !inspect) return 0;
+    }
+    if (!retry_failed_chain_spec.empty()) {
+        char* failure_end = nullptr;
+        const long failure_index = std::strtol(
+            retry_failed_chain_spec.c_str(), &failure_end, 0);
+        if (!failure_end || *failure_end || failure_index < 0 ||
+            static_cast<size_t>(failure_index) >= replay.failure_diagnostics.size()) {
+            std::fprintf(stderr, "gpu_replay: invalid failed-chain selector %s\n",
+                         retry_failed_chain_spec.c_str());
+            return 2;
+        }
+        const auto& failure = replay.failure_diagnostics[static_cast<size_t>(failure_index)];
+        if (failure.stages.size() < 2 ||
+            failure.stages[0].stage != prosper::gpu::ShaderProgramStage::Vertex ||
+            failure.stages[1].stage != prosper::gpu::ShaderProgramStage::Vertex) {
+            std::fprintf(stderr,
+                         "gpu_replay: failure %s does not retain a split vertex chain\n",
+                         retry_failed_chain_spec.c_str());
+            return 2;
+        }
+        const auto& prolog_stage = failure.stages[0];
+        const auto& main_stage = failure.stages[1];
+        if (prolog_stage.raw_shader_index >= replay.raw_shader_versions.size() ||
+            main_stage.raw_shader_index >= replay.raw_shader_versions.size()) {
+            std::fprintf(stderr,
+                         "gpu_replay: failed chain %s has no captured raw streams\n",
+                         retry_failed_chain_spec.c_str());
+            return 2;
+        }
+        if (prolog_stage.resource_table_present != prolog_stage.resource_table.present ||
+            prolog_stage.resource_count != prolog_stage.resource_table.resources.size()) {
+            std::fprintf(stderr,
+                         "gpu_replay: failed chain %s lacks exact resource metadata "
+                         "(capture predates v35)\n", retry_failed_chain_spec.c_str());
+            return 2;
+        }
+        prosper::gpu::ShaderResourceTable table;
+        table.resources.reserve(prolog_stage.resource_table.resources.size());
+        for (const auto& captured : prolog_stage.resource_table.resources)
+            table.resources.push_back(captured.resource);
+        const auto& prolog = replay.raw_shader_versions[prolog_stage.raw_shader_index];
+        const auto& main = replay.raw_shader_versions[main_stage.raw_shader_index];
+        const prosper::gpu::ShaderResourceTable* resources =
+            prolog_stage.resource_table.present ? &table : nullptr;
+        const std::vector<uint32_t> spirv = prosper::gpu::recompile_vertex_chain(
+            prolog.words.data(), prolog.words.size(), main.words.data(), main.words.size(),
+            resources);
+        std::fprintf(stderr,
+                     "[retry-failed-chain] %s %s resources=%zu spirv-dwords=%zu\n",
+                     retry_failed_chain_spec.c_str(),
+                     spirv.empty() ? "rejected" : "recompiled", table.resources.size(),
+                     spirv.size());
+        if (positional.size() == 1 && !inspect) return spirv.empty() ? 1 : 0;
     }
     if (!retry_failed_stage_spec.empty()) {
         const size_t colon = retry_failed_stage_spec.find(':');


### PR DESCRIPTION
## What changed

- recompile Astro Bot's two captured linked NGG world-map culling chains with byte-exact one-lane projection gates
- compose a proven one-arm uniform conditional with the existing counted-loop structurizer
- add taken/skipped execution coverage for values merged into a counted loop
- add `gpu_replay --retry-failed-chain FAILURE` to rerun captured split vertex programs offline with their exact resource table
- document the new offline retry workflow

## Root cause

The main NGG wrappers were already byte-exact approved, but live rendering links them after separate fetch prologs. The complete concatenated programs therefore missed the exact wrapper identity and fell back to fail-closed cross-lane rejection. The second wrapper also contains a normal one-arm conditional before its counted loop; those constructs worked independently, while the counted-loop prelude accepted only `if/else`.

## Impact

A fresh scripted `prosper-app` run reaches `worldmap`. In a new complete-frame capture, both linked vertex pipelines recompile live and the previous depth-writing shader failure is gone. Only two failures remain, both for the same fragment shader on passes with no color or depth write.

The map is still dark/black with a fine texture, so this is a progress checkpoint for #1459 rather than a complete fix. No PR screenshot is attached because the current world-map output is not meaningfully more than black.

Observed performance in this shared-GPU run was roughly 14–18 FPS during the late title route and 11–16 FPS on the world map; treat those as ballpark only.

## Validation

- `test_rdna2_to_spirv` — PASS, including both new pre-loop paths
- `test_recompiled_shaders` — PASS, including fail-closed NGG checks
- `test_gpu_replay_shader_dump` — PASS
- offline retry of former failure 65 — recompiled, 14,326 SPIR-V dwords
- fresh real frontend run with scripted input reached `worldmap`
- fresh F9 frame bundle at guest present 1016 / submit 7635 contains no relevant shader-recompile failure
- `git diff --check` — PASS

Snapshot tests were not run: they are optional for day-to-day/PR development and required before releases.