### PR TITLE
tools: probe final geometry-stage positions

### DIFF
--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -378,7 +378,8 @@ std::vector<uint32_t> recompile_graphics_shader_cached(ShaderProgramStage stage,
                                                        const PixelSystemInputMapping* system_inputs = nullptr,
                                                        uint64_t* cache_identity = nullptr,
                                                        bool fragment_wave32 = false,
-                                                       uint32_t vertex_lds_dwords = 0);
+                                                       uint32_t vertex_lds_dwords = 0,
+                                                       bool vertex_capture_position = false);
 SharedShaderWords recompile_graphics_shader_cached_shared(
     ShaderProgramStage stage, const uint32_t* code, size_t dwords,
     const ShaderResourceTable* resources = nullptr,
@@ -386,7 +387,8 @@ SharedShaderWords recompile_graphics_shader_cached_shared(
     const PixelSystemInputMapping* system_inputs = nullptr,
     uint64_t* cache_identity = nullptr,
     bool fragment_wave32 = false,
-    uint32_t vertex_lds_dwords = 0);
+    uint32_t vertex_lds_dwords = 0,
+    bool vertex_capture_position = false);
 // Compute uses the same bounded content-addressed cache as graphics. Launch geometry that changes
 // generated SPIR-V participates in the key; per-dispatch push-constant values deliberately do not.
 std::vector<uint32_t> recompile_compute_shader_cached(
@@ -398,7 +400,8 @@ SharedShaderWords recompile_vertex_chain_cached_shared(
     const ShaderResourceTable* resources = nullptr,
     const PixelInputMapping* pixel_inputs = nullptr,
     uint64_t* cache_identity = nullptr,
-    uint32_t vertex_lds_dwords = 0);
+    uint32_t vertex_lds_dwords = 0,
+    bool capture_position = false);
 ShaderRecompileCacheStats shader_recompile_cache_stats();
 void clear_shader_recompile_cache();
 
@@ -941,6 +944,8 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
     const FragmentInterpolationLayout interpolation = fragment_interpolation_layout_cached(
         reinterpret_cast<const uint32_t*>(static_cast<uintptr_t>(rs.ps_addr)),
         max_shader_dwords, system_input_ptr, pixel_input_ptr);
+    const bool capture_vertex_position = getenv("PROSPER_GEOM_PROBE") != nullptr &&
+                                         !interpolation.requires_geometry;
     uint64_t vs_identity = 0, fs_identity = 0;
     SharedShaderWords vs_shared, fs_shared;
     std::vector<uint32_t> vs, fs;
@@ -949,12 +954,13 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
             vs_shared = recompile_vertex_chain_cached_shared(
                 reinterpret_cast<const uint32_t*>(static_cast<uintptr_t>(rs.es_addr)), vertex_dwords,
                 reinterpret_cast<const uint32_t*>(static_cast<uintptr_t>(chain_addr)), chain_dwords,
-                vrt.get(), pixel_input_ptr, &vs_identity, vertex_lds_dwords);
+                vrt.get(), pixel_input_ptr, &vs_identity, vertex_lds_dwords,
+                capture_vertex_position);
         else
             vs_shared = recompile_graphics_shader_cached_shared(
                 ShaderProgramStage::Vertex, (const uint32_t*)(uintptr_t)vs_program_addr,
                 max_shader_dwords, vrt.get(), pixel_input_ptr, nullptr, &vs_identity,
-                false, vertex_lds_dwords);
+                false, vertex_lds_dwords, capture_vertex_position);
         fs_shared = recompile_graphics_shader_cached_shared(
             ShaderProgramStage::Fragment, (const uint32_t*)(uintptr_t)rs.ps_addr,
             max_shader_dwords, prt.get(), pixel_input_ptr, system_input_ptr, &fs_identity,
@@ -964,13 +970,14 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
             const SharedShaderWords linked = recompile_vertex_chain_cached_shared(
                 reinterpret_cast<const uint32_t*>(static_cast<uintptr_t>(rs.es_addr)), vertex_dwords,
                 reinterpret_cast<const uint32_t*>(static_cast<uintptr_t>(chain_addr)), chain_dwords,
-                vrt.get(), pixel_input_ptr, &vs_identity, vertex_lds_dwords);
+                vrt.get(), pixel_input_ptr, &vs_identity, vertex_lds_dwords,
+                capture_vertex_position);
             if (linked) vs = *linked;
         } else {
             vs = recompile_graphics_shader_cached(
                 ShaderProgramStage::Vertex, (const uint32_t*)(uintptr_t)vs_program_addr,
                 max_shader_dwords, vrt.get(), pixel_input_ptr, nullptr, &vs_identity,
-                false, vertex_lds_dwords);
+                false, vertex_lds_dwords, capture_vertex_position);
         }
         fs = recompile_graphics_shader_cached(
             ShaderProgramStage::Fragment, (const uint32_t*)(uintptr_t)rs.ps_addr,
@@ -1013,7 +1020,9 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
         // provide the three AMD vertex parameters and remain fail-visible.
         const bool triangle_topology = resolved_pipeline.topology >= 3u &&
                                        resolved_pipeline.topology <= 5u;
-        if (triangle_topology) gs = recompile_interpolation_geometry(interpolation);
+        if (triangle_topology)
+            gs = recompile_interpolation_geometry(
+                interpolation, getenv("PROSPER_GEOM_PROBE") != nullptr);
     }
     if (phase_timing) {
         const auto shader_done = std::chrono::steady_clock::now();

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -163,6 +163,7 @@ struct ShaderCompileKey {
     ShaderProgramStage stage = ShaderProgramStage::Vertex;
     bool has_resource_table = false;
     bool force_position_w = false;
+    bool capture_position = false;
     bool has_pixel_inputs = false;
     PixelInputMapping pixel_inputs{};
     bool has_system_inputs = false;
@@ -207,6 +208,7 @@ struct ShaderCompileKey {
         return stage == other.stage &&
                has_resource_table == other.has_resource_table &&
                force_position_w == other.force_position_w &&
+               capture_position == other.capture_position &&
                has_pixel_inputs == other.has_pixel_inputs &&
                pixel_inputs == other.pixel_inputs &&
                has_system_inputs == other.has_system_inputs &&
@@ -260,6 +262,7 @@ struct ShaderCompileKeyHash {
         hash = hash_mix(hash, static_cast<uint32_t>(key.stage));
         hash = hash_mix(hash, key.has_resource_table);
         hash = hash_mix(hash, key.force_position_w);
+        hash = hash_mix(hash, key.capture_position);
         hash = hash_mix(hash, key.has_pixel_inputs);
         if (key.has_pixel_inputs) {
             hash = hash_mix(hash, key.pixel_inputs.valid_mask);
@@ -863,7 +866,8 @@ ShaderCompileKey make_shader_compile_key(ShaderProgramStage stage, const uint32_
                                          size_t chain_dwords = 0,
                                          uint32_t vertex_lds_dwords = 0,
                                          const ComputeShaderConfig* compute_config = nullptr,
-                                         bool fragment_wave32 = false) {
+                                         bool fragment_wave32 = false,
+                                         bool capture_position = false) {
     ShaderCompileKey key;
     key.stage = stage;
     key.vertex_lds_dwords = stage == ShaderProgramStage::Vertex
@@ -872,6 +876,7 @@ ShaderCompileKey make_shader_compile_key(ShaderProgramStage stage, const uint32_
         ? resources->vertices_per_instance : 0u;
     key.has_resource_table = resources != nullptr;
     key.force_position_w = getenv("PROSPER_FORCE_W") != nullptr;
+    key.capture_position = stage == ShaderProgramStage::Vertex && capture_position;
     key.has_pixel_inputs = stage != ShaderProgramStage::Compute && pixel_inputs != nullptr;
     if (key.has_pixel_inputs) key.pixel_inputs = *pixel_inputs;
     key.has_system_inputs = stage == ShaderProgramStage::Fragment && system_inputs != nullptr;
@@ -994,18 +999,17 @@ std::vector<uint32_t> compile_graphics_shader(ShaderProgramStage stage, const Sh
     const uint32_t* code = !key.code || key.code->empty() ? nullptr : key.code->data();
     const size_t code_size = key.code ? key.code->size() : 0u;
     if (stage == ShaderProgramStage::Vertex)
-        // Geometry probe (PROSPER_GEOM_PROBE): decorate gl_Position for transform-feedback capture on
-        // the LIVE path (which recompiles here). Capsule replay substitutes an xfb VS in gpu_replay,
-        // because a capsule stores already-recompiled SPIR-V. Inert to the shader's computation.
+        // Geometry probe: decorate gl_Position only when the caller proved the VS is the last
+        // pre-rasterization stage. Generated interpolation geometry stages own XFB themselves.
         return key.chain_code
             ? recompile_vertex_chain(code, code_size, key.chain_code->data(),
                                      key.chain_code->size(), resources,
                                      key.has_pixel_inputs ? &key.pixel_inputs : nullptr,
-                                     getenv("PROSPER_GEOM_PROBE") != nullptr,
+                                     key.capture_position,
                                      key.vertex_lds_dwords)
             : recompile_vertex(code, code_size, resources,
                                key.has_pixel_inputs ? &key.pixel_inputs : nullptr,
-                               getenv("PROSPER_GEOM_PROBE") != nullptr,
+                               key.capture_position,
                                key.vertex_lds_dwords);
     if (stage == ShaderProgramStage::Fragment) {
         const FragmentInterpolationLayout interpolation = fragment_interpolation_layout(
@@ -1224,11 +1228,12 @@ SharedShaderWords recompile_graphics_shader_cached_shared(
         ShaderProgramStage stage, const uint32_t* code, size_t dwords,
         const ShaderResourceTable* resources, const PixelInputMapping* pixel_inputs,
         const PixelSystemInputMapping* system_inputs, uint64_t* cache_identity,
-        bool fragment_wave32, uint32_t vertex_lds_dwords) {
+        bool fragment_wave32, uint32_t vertex_lds_dwords,
+        bool vertex_capture_position) {
     ShaderCompileKey key = make_shader_compile_key(stage, code, dwords, resources, pixel_inputs,
                                                    system_inputs, nullptr, 0,
                                                    vertex_lds_dwords, nullptr,
-                                                   fragment_wave32);
+                                                   fragment_wave32, vertex_capture_position);
     return cache_compiled_graphics_shader(stage, std::move(key), resources, cache_identity);
 }
 
@@ -1236,10 +1241,11 @@ SharedShaderWords recompile_vertex_chain_cached_shared(
         const uint32_t* prolog, size_t prolog_dwords,
         const uint32_t* main, size_t main_dwords,
         const ShaderResourceTable* resources, const PixelInputMapping* pixel_inputs,
-        uint64_t* cache_identity, uint32_t vertex_lds_dwords) {
+        uint64_t* cache_identity, uint32_t vertex_lds_dwords,
+        bool capture_position) {
     ShaderCompileKey key = make_shader_compile_key(
         ShaderProgramStage::Vertex, prolog, prolog_dwords, resources, pixel_inputs, nullptr,
-        main, main_dwords, vertex_lds_dwords);
+        main, main_dwords, vertex_lds_dwords, nullptr, false, capture_position);
     if (!key.chain_code) {
         if (cache_identity) *cache_identity = 0;
         return {};
@@ -1252,10 +1258,11 @@ std::vector<uint32_t> recompile_graphics_shader_cached(
         ShaderProgramStage stage, const uint32_t* code, size_t dwords,
         const ShaderResourceTable* resources, const PixelInputMapping* pixel_inputs,
         const PixelSystemInputMapping* system_inputs, uint64_t* cache_identity,
-        bool fragment_wave32, uint32_t vertex_lds_dwords) {
+        bool fragment_wave32, uint32_t vertex_lds_dwords,
+        bool vertex_capture_position) {
     SharedShaderWords words = recompile_graphics_shader_cached_shared(
         stage, code, dwords, resources, pixel_inputs, system_inputs, cache_identity,
-        fragment_wave32, vertex_lds_dwords);
+        fragment_wave32, vertex_lds_dwords, vertex_capture_position);
     return words ? *words : std::vector<uint32_t>{};
 }
 

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -2374,12 +2374,13 @@ struct SpirvCompute {
     // Descriptor-free geometry pass-through used when a fragment program asks for AMD's explicit
     // P0/P10/P20 vertex parameters on a Vulkan device without a barycentric/vertex-parameter
     // extension. Input assembly has already decomposed lists/strips/fans into triangles here.
-    std::vector<uint32_t> build_interpolation_geometry(const FragmentInterpolationLayout& layout) {
+    std::vector<uint32_t> build_interpolation_geometry(
+            const FragmentInterpolationLayout& layout, bool capture_geometry_position) {
         if (!layout.requires_geometry || !layout.valid) return {};
 
         t_void = id(); t_fn = id(); t_f32 = id(); t_u32 = id(); t_i32 = id(); t_bool = id();
         t_v4f = id();
-        const uint32_t t_per_vertex = id();
+        const uint32_t t_input_per_vertex = id(), t_output_per_vertex = id();
         const uint32_t c_three = id();
         const uint32_t t_input_positions = id(), t_input_varyings = id();
         const uint32_t ptr_in_positions = id(), ptr_in_varyings = id();
@@ -2405,6 +2406,7 @@ struct SpirvCompute {
 
         put(caps, Op_Capability, {Cap_Shader});
         put(caps, Op_Capability, {Cap_Geometry});
+        if (capture_geometry_position) put(caps, Op_Capability, {Cap_TransformFeedback});
         { std::vector<uint32_t> operands{glsl}; pstr(operands, "GLSL.std.450");
           putv(extimp, Op_ExtInstImport, operands); }
         put(mem, Op_MemoryModel, {Addr_Logical, Mem_GLSL450});
@@ -2412,9 +2414,17 @@ struct SpirvCompute {
         put(exec, Op_ExecutionMode, {f_main, EM_Triangles});
         put(exec, Op_ExecutionMode, {f_main, EM_OutputTriangleStrip});
         put(exec, Op_ExecutionMode, {f_main, EM_OutputVertices, 3});
+        if (capture_geometry_position) put(exec, Op_ExecutionMode, {f_main, EM_Xfb});
 
-        put(deco, Op_MemberDecorate, {t_per_vertex, 0, Dec_BuiltIn, BI_Position});
-        put(deco, Op_Decorate, {t_per_vertex, Dec_Block});
+        put(deco, Op_MemberDecorate, {t_input_per_vertex, 0, Dec_BuiltIn, BI_Position});
+        put(deco, Op_Decorate, {t_input_per_vertex, Dec_Block});
+        put(deco, Op_MemberDecorate, {t_output_per_vertex, 0, Dec_BuiltIn, BI_Position});
+        put(deco, Op_Decorate, {t_output_per_vertex, Dec_Block});
+        if (capture_geometry_position) {
+            put(deco, Op_MemberDecorate, {t_output_per_vertex, 0, Dec_XfbBuffer, 0});
+            put(deco, Op_MemberDecorate, {t_output_per_vertex, 0, Dec_XfbStride, 16});
+            put(deco, Op_MemberDecorate, {t_output_per_vertex, 0, Dec_Offset, 0});
+        }
         for (uint32_t attr = 0; attr < 32; ++attr) {
             if (attribute_inputs[attr]) {
                 put(deco, Op_Decorate, {attribute_inputs[attr], Dec_Location, attr});
@@ -2451,14 +2461,15 @@ struct SpirvCompute {
         put(types, Op_TypeInt, {t_i32, 32, 1});
         put(types, Op_TypeBool, {t_bool});
         put(types, Op_TypeVector, {t_v4f, t_f32, 4});
-        put(types, Op_TypeStruct, {t_per_vertex, t_v4f});
+        put(types, Op_TypeStruct, {t_input_per_vertex, t_v4f});
+        put(types, Op_TypeStruct, {t_output_per_vertex, t_v4f});
         put(types, Op_Constant, {t_u32, c_three, 3});
-        put(types, Op_TypeArray, {t_input_positions, t_per_vertex, c_three});
+        put(types, Op_TypeArray, {t_input_positions, t_input_per_vertex, c_three});
         put(types, Op_TypeArray, {t_input_varyings, t_v4f, c_three});
         put(types, Op_TypePointer, {ptr_in_positions, SC_Input, t_input_positions});
         put(types, Op_TypePointer, {ptr_in_varyings, SC_Input, t_input_varyings});
         put(types, Op_TypePointer, {ptr_in_v4f, SC_Input, t_v4f});
-        put(types, Op_TypePointer, {ptr_out_position, SC_Output, t_per_vertex});
+        put(types, Op_TypePointer, {ptr_out_position, SC_Output, t_output_per_vertex});
         put(types, Op_TypePointer, {ptr_out_v4f, SC_Output, t_v4f});
         put(types, Op_Variable, {ptr_in_positions, input_position, SC_Input});
         put(types, Op_Variable, {ptr_out_position, output_position, SC_Output});
@@ -2693,9 +2704,9 @@ FragmentInterpolationLayout fragment_interpolation_layout(
 }
 
 std::vector<uint32_t> recompile_interpolation_geometry(
-        const FragmentInterpolationLayout& layout) {
+        const FragmentInterpolationLayout& layout, bool capture_position) {
     SpirvCompute builder;
-    return builder.build_interpolation_geometry(layout);
+    return builder.build_interpolation_geometry(layout, capture_position);
 }
 
 // Machine state during recompilation: the VGPR and SGPR files (VGPR/SGPR number -> current SSA bits

--- a/prosper/src/gpu/rdna2_to_spirv.hpp
+++ b/prosper/src/gpu/rdna2_to_spirv.hpp
@@ -177,9 +177,10 @@ FragmentInterpolationLayout fragment_interpolation_layout(
 
 // Generate the descriptor-free triangle geometry stage described above. Returns {} when no fallback
 // is required or the packed interface is invalid. Triangle lists, strips, fans, and the RectList
-// triangle-strip lowering all feed Vulkan's `Triangles` geometry input primitive.
+// triangle-strip lowering all feed Vulkan's `Triangles` geometry input primitive. The optional
+// capture flag decorates this final pre-rasterization stage for the geometry diagnostic only.
 std::vector<uint32_t> recompile_interpolation_geometry(
-    const FragmentInterpolationLayout& layout);
+    const FragmentInterpolationLayout& layout, bool capture_position = false);
 
 // Translate a straight-line float-VALU RDNA2 stream to a compute-shader SPIR-V module.
 // Returns {} if the stream contains an opcode/format this stage does not yet handle. An optional

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -553,7 +553,7 @@ struct RenderVkCtx {
     // occlusion queries. Enabled at device creation only when advertised; inert otherwise.
     bool pipeline_stats_enabled = false;
     bool occlusion_precise = false;
-    // Geometry-probe (PROSPER_GEOM_PROBE): VK_EXT_transform_feedback for capturing gl_Position.
+    // Geometry-probe (PROSPER_GEOM_PROBE): transform feedback for final clip-space positions.
     bool transform_feedback_enabled = false;
     bool subgroup_size_control = false;
     bool compute_full_subgroups = false;
@@ -749,8 +749,8 @@ inline const RenderVkCtx& render_vk_ctx() {
                       r.subgroup_operations = subgroup_core_properties.supportedOperations;
                   }
               }
-              // Geometry-probe (PROSPER_GEOM_PROBE): transform feedback to capture gl_Position. Enable
-              // only the base transformFeedback feature (VS-only capture; geometryStreams not needed).
+              // Geometry-probe (PROSPER_GEOM_PROBE): capture the last pre-rasterization stage. Enable
+              // only the base transformFeedback feature; separate geometry streams are not needed.
               if (!strcmp(de[i].extensionName, VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME)) {
                   VkPhysicalDeviceFeatures2 f2{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2};
                   f2.pNext = &tf_features; vkGetPhysicalDeviceFeatures2(r.phys, &f2);
@@ -5111,7 +5111,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
 
     // Geometry probe (PROSPER_GEOM_PROBE=N): capture draw N's post-transform clip-space vertices via
     // transform feedback and report where they land (degenerate / off-screen / behind-camera / NaN).
-    // Requires VK_EXT_transform_feedback + the VS recompiled with gl_Position xfb-decorated (gated on
+    // Requires VK_EXT_transform_feedback + the last pre-rasterization shader xfb-decorated (gated on
     // the same env var in gpu_executor). Only active with the env var, TF support, AND a flush here.
     const char* geom_env = getenv("PROSPER_GEOM_PROBE");
     uint64_t geom_target = 0;

--- a/prosper/tests/test_gpu_replay_shader_dump.cpp
+++ b/prosper/tests/test_gpu_replay_shader_dump.cpp
@@ -36,6 +36,18 @@ int main() {
               !gpu::parse_diagnostic_draw_id("18446744073709551616", diagnostic_draw),
           "geometry probe rejects partial, signed, and overflowing draw IDs");
 
+    CHECK(tools::select_geometry_probe_stage(true, true, false) ==
+              tools::GeometryProbeStage::GeneratedGeometry,
+          "rebuilt generated geometry owns probe capture without a raw VS");
+    CHECK(tools::select_geometry_probe_stage(false, false, true) ==
+              tools::GeometryProbeStage::Vertex,
+          "VS-only geometry probe instruments a captured raw vertex stream");
+    CHECK(tools::select_geometry_probe_stage(false, false, false) ==
+              tools::GeometryProbeStage::Unsupported &&
+              tools::select_geometry_probe_stage(false, true, true) ==
+                  tools::GeometryProbeStage::Unsupported,
+          "geometry probe rejects a missing raw VS and an unrebuildable existing GS");
+
     uint64_t draw_first = 0, draw_last = 0;
     CHECK(gpu::parse_diagnostic_draw_range("0x7:013", draw_first, draw_last) &&
               draw_first == 7 && draw_last == 11 &&

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -87,6 +87,23 @@ bool has_opcode(const std::vector<uint32_t>& spv, uint32_t opcode) {
     return false;
 }
 
+// Whether an instruction's zero-based operand has the requested literal value.
+bool has_instruction_operand(const std::vector<uint32_t>& spv, uint32_t opcode,
+                             uint32_t operand_index, uint32_t value) {
+    if (spv.size() < 5) return false;
+    for (size_t i = 5; i < spv.size();) {
+        const uint32_t word = spv[i];
+        const uint32_t op = word & 0xffffu;
+        const uint32_t wc = word >> 16u;
+        if (wc == 0 || i + wc > spv.size()) return false;
+        if (op == opcode && wc > operand_index + 1u &&
+            spv[i + 1u + operand_index] == value)
+            return true;
+        i += wc;
+    }
+    return false;
+}
+
 bool has_select_with_false_constant(const std::vector<uint32_t>& spv, uint32_t literal) {
     constexpr uint32_t OpConstant = 43, OpSelect = 169;
     std::unordered_set<uint32_t> matching_constants;
@@ -2072,6 +2089,24 @@ int main() {
         return 1;
     }
     printf("  [ok]   mixed P0+smooth interpolation generates coefficient pass-through SPIR-V\n");
+
+    // Transform feedback must decorate the final pre-rasterization stage. When interpolation needs
+    // the generated GS, decorating only the VS produces real pixels but writes zero probe vertices.
+    const std::vector<uint32_t> mixed_xfb_gs =
+        recompile_interpolation_geometry(mixed_layout, true);
+    constexpr uint32_t OpCapability = 17, OpExecutionMode = 16, OpMemberDecorate = 72;
+    constexpr uint32_t CapTransformFeedback = 53, ExecutionModeXfb = 11;
+    constexpr uint32_t DecOffset = 35, DecXfbBuffer = 36, DecXfbStride = 37;
+    if (mixed_xfb_gs.empty() ||
+        !has_instruction_operand(mixed_xfb_gs, OpCapability, 0, CapTransformFeedback) ||
+        !has_instruction_operand(mixed_xfb_gs, OpExecutionMode, 1, ExecutionModeXfb) ||
+        !has_instruction_operand(mixed_xfb_gs, OpMemberDecorate, 2, DecXfbBuffer) ||
+        !has_instruction_operand(mixed_xfb_gs, OpMemberDecorate, 2, DecXfbStride) ||
+        !has_instruction_operand(mixed_xfb_gs, OpMemberDecorate, 2, DecOffset)) {
+        printf("  [FAIL] generated interpolation geometry does not own transform-feedback output\n");
+        return 1;
+    }
+    printf("  [ok]   generated interpolation geometry can capture its final positions\n");
 
     // Explicit P10/P20/P0 values are the three AMD parameters used by Astro Bot's rejected title
     // composite PS. All three fragment inputs are Flat outputs of the generated geometry stage.

--- a/prosper/tests/test_shader_recompile_cache.cpp
+++ b/prosper/tests/test_shader_recompile_cache.cpp
@@ -712,6 +712,25 @@ int main() {
               stats.misses == chain_misses + 1,
           "changing only the chained main shader invalidates compiled cache identity");
 
+    clear_shader_recompile_cache();
+    uint64_t normal_identity = 0, capture_identity = 0, repeated_capture_identity = 0;
+    const auto normal_vertex = recompile_graphics_shader_cached(
+        ShaderProgramStage::Vertex, kVs, std::size(kVs), &table, nullptr, nullptr,
+        &normal_identity);
+    const auto capture_vertex = recompile_graphics_shader_cached(
+        ShaderProgramStage::Vertex, kVs, std::size(kVs), &table, nullptr, nullptr,
+        &capture_identity, false, 0, true);
+    const auto repeated_capture_vertex = recompile_graphics_shader_cached(
+        ShaderProgramStage::Vertex, kVs, std::size(kVs), &table, nullptr, nullptr,
+        &repeated_capture_identity, false, 0, true);
+    stats = shader_recompile_cache_stats();
+    CHECK(!normal_vertex.empty() && !capture_vertex.empty() &&
+              normal_vertex != capture_vertex && normal_identity != capture_identity &&
+              capture_vertex == repeated_capture_vertex &&
+              capture_identity == repeated_capture_identity &&
+              stats.misses == 2 && stats.hits == 1 && stats.entries == 2,
+          "geometry-probe vertex capture has a distinct, reusable cache identity");
+
     if (failures) {
         std::printf("== FAIL: %d ==\n", failures);
         return 1;

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -187,7 +187,7 @@ Works on both `gpu_replay` and the live app because it lives in the shared rende
 
 ```bash
 PROSPER_GEOM_PROBE=4 ./build-linux/gpu_replay /tmp/submit.prgcap /tmp/out.bmp
-# [geom-probe] draw=4 item=2 operation=19 VS re-recompiled with xfb in GS (1700 VS words, 676 GS words)
+# [geom-probe] draw=4 item=2 operation=19 reused stored VS with xfb in GS (1700 VS words, 676 GS words)
 # [geom-probe] draw=4 verts=1024 finite=1024 on-screen=0 clipped=1024 (offscreen=1023 w<=0=1 nan/inf=0)
 # [geom-probe]   clip-bbox x[-4.86,0] y[-1.14,3.81] z[0,0] w[0,1] -> ALL-VERTS-OUTSIDE-CLIP-CUBE(...)
 # [geom-probe]   v0 = (-2.9, -0.771, 0, 1) ...
@@ -208,9 +208,9 @@ owns *where the geometry is* — a large full-screen quad can have every vertex 
 rasterize, so "all verts clipped" is not "renders nothing"; the bbox tells them apart.
 
 Mechanics: on a capsule (stored SPIR-V) gpu_replay resolves semantic draw N to its compact item, then
-recompiles that draw's raw RDNA2 vertex program and decorates the **last pre-rasterization stage** for XFB.
-That is normally the VS. If explicit fragment interpolation inserted Prosper's generated GS, gpu_replay
-rebuilds that GS with XFB output instead; Vulkan sources transform feedback only from the final such stage.
+decorates the **last pre-rasterization stage** for XFB. That is normally a recompiled raw RDNA2 VS. If explicit
+fragment interpolation inserted Prosper's generated GS, gpu_replay rebuilds that GS with XFB output and
+reuses the stored VS instead; Vulkan sources transform feedback only from the final such stage.
 A v19+ capsule is sufficient for an ordinary vertex shader; v31+ additionally retains a separately-installed
 NGG main stage and its graphics-LDS allocation, allowing linked prolog+main programs to be probed faithfully.
 Existing guest geometry stages cannot yet be rebuilt and are rejected visibly. The live app follows the same

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -187,7 +187,7 @@ Works on both `gpu_replay` and the live app because it lives in the shared rende
 
 ```bash
 PROSPER_GEOM_PROBE=4 ./build-linux/gpu_replay /tmp/submit.prgcap /tmp/out.bmp
-# [geom-probe] draw 4 VS re-recompiled with xfb capture (1700 words)
+# [geom-probe] draw=4 item=2 operation=19 VS re-recompiled with xfb in GS (1700 VS words, 676 GS words)
 # [geom-probe] draw=4 verts=1024 finite=1024 on-screen=0 clipped=1024 (offscreen=1023 w<=0=1 nan/inf=0)
 # [geom-probe]   clip-bbox x[-4.86,0] y[-1.14,3.81] z[0,0] w[0,1] -> ALL-VERTS-OUTSIDE-CLIP-CUBE(...)
 # [geom-probe]   v0 = (-2.9, -0.771, 0, 1) ...
@@ -208,13 +208,14 @@ owns *where the geometry is* — a large full-screen quad can have every vertex 
 rasterize, so "all verts clipped" is not "renders nothing"; the bbox tells them apart.
 
 Mechanics: on a capsule (stored SPIR-V) gpu_replay resolves semantic draw N to its compact item, then
-re-recompiles that draw's raw RDNA2 VS with `gl_Position`
-xfb-decorated and swaps it in for that one draw. A v19+ capsule is sufficient for an ordinary vertex shader;
-v31+ additionally retains a separately-installed NGG main stage and its graphics-LDS allocation, allowing
-linked prolog+main programs to be probed faithfully. The live app recompiles fresh. Requires the device to
-advertise `VK_EXT_transform_feedback` (RADV, lavapipe). The
-probed draw's rendered pixels may be inexact (the re-recompile drops pixel-input remapping), but the captured
-`gl_Position` values are faithful; inert and byte-identical when the env var is unset.
+recompiles that draw's raw RDNA2 vertex program and decorates the **last pre-rasterization stage** for XFB.
+That is normally the VS. If explicit fragment interpolation inserted Prosper's generated GS, gpu_replay
+rebuilds that GS with XFB output instead; Vulkan sources transform feedback only from the final such stage.
+A v19+ capsule is sufficient for an ordinary vertex shader; v31+ additionally retains a separately-installed
+NGG main stage and its graphics-LDS allocation, allowing linked prolog+main programs to be probed faithfully.
+Existing guest geometry stages cannot yet be rebuilt and are rejected visibly. The live app follows the same
+stage selection while recompiling fresh. Requires `VK_EXT_transform_feedback` (RADV, lavapipe). The captured
+final `gl_Position` values are faithful; inert and byte-identical when the env var is unset.
 
 ### Geometry-health line (`[geom-health]`, printed alongside the probe)
 

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -1655,11 +1655,11 @@ int main(int argc, char** argv) {
         std::fprintf(stderr, "[recompile-raw] substituted vs=%zu fs=%zu kept-stored vs=%zu fs=%zu of %zu draws\n",
                      vs_swapped, fs_swapped, vs_kept, fs_kept, replay.items.size());
     }
-    // Geometry probe (PROSPER_GEOM_PROBE=N): a capsule stores already-recompiled SPIR-V, so to capture
-    // draw N's gl_Position via transform feedback we re-recompile its raw RDNA2 VS with xfb decorations
-    // and swap it in here; render_runner then binds a TF buffer around that draw and reports where its
-    // post-transform vertices land. v31+ capsules also retain separately-installed linked vertex mains
-    // and graphics LDS; earlier capsules can probe only single-stage vertex programs.
+    // Geometry probe (PROSPER_GEOM_PROBE=N): a capsule stores already-recompiled SPIR-V, so rebuild
+    // draw N from its raw RDNA2 and decorate the last pre-rasterization stage for transform feedback.
+    // That is normally the VS, but explicit interpolation inserts a generated GS which must own XFB.
+    // render_runner then binds a TF buffer around the draw and reports where the final clip vertices
+    // land. v31+ capsules retain separately-installed linked vertex mains and graphics LDS.
     if (const char* g = std::getenv("PROSPER_GEOM_PROBE")) {
         if (capture.format_version < 36) {
             std::fprintf(stderr,
@@ -1682,6 +1682,32 @@ int main(int argc, char** argv) {
                 ? -1 : static_cast<long long>(operation_index);
             if (it.vs_raw_shader_index < replay.raw_shader_versions.size()) {
                 const auto& raw = replay.raw_shader_versions[it.vs_raw_shader_index];
+                const auto* pixel_inputs = it.has_pixel_inputs ? &it.pixel_inputs : nullptr;
+                const auto* system_inputs = it.has_system_inputs ? &it.system_inputs : nullptr;
+                bool xfb_in_geometry = false;
+                if (it.fs_raw_shader_index < replay.raw_shader_versions.size()) {
+                    const auto& fragment = replay.raw_shader_versions[it.fs_raw_shader_index];
+                    const auto interpolation = prosper::gpu::fragment_interpolation_layout(
+                        fragment.words.data(), fragment.words.size(), system_inputs, pixel_inputs);
+                    if (interpolation.valid && interpolation.requires_geometry &&
+                        it.ps.topology >= 3u && it.ps.topology <= 5u) {
+                        auto geometry = prosper::gpu::recompile_interpolation_geometry(
+                            interpolation, true);
+                        if (!geometry.empty()) {
+                            it.gs = std::move(geometry);
+                            xfb_in_geometry = true;
+                        }
+                    }
+                }
+                // Transform feedback is sourced from the last pre-rasterization stage. A generated
+                // interpolation GS therefore has to carry the XFB decorations; decorating only the VS
+                // renders real primitives but leaves the counter at zero.
+                if (!xfb_in_geometry && !it.gs.empty()) {
+                    std::fprintf(stderr,
+                                 "[geom-probe] draw %llu: cannot rebuild its geometry stage for xfb\n",
+                                 draw_label);
+                    return 2;
+                }
                 std::vector<uint32_t> xfb;
                 const bool linked =
                     it.vs_chain_raw_shader_index < replay.raw_shader_versions.size();
@@ -1690,22 +1716,22 @@ int main(int argc, char** argv) {
                         replay.raw_shader_versions[it.vs_chain_raw_shader_index];
                     xfb = prosper::gpu::recompile_vertex_chain(
                         raw.words.data(), raw.words.size(), main.words.data(), main.words.size(),
-                        it.vrt.get(), it.has_pixel_inputs ? &it.pixel_inputs : nullptr, true,
+                        it.vrt.get(), pixel_inputs, !xfb_in_geometry,
                         it.vertex_lds_dwords);
                 } else {
                     xfb = prosper::gpu::recompile_vertex(raw.words.data(), raw.words.size(),
-                                                         it.vrt.get(),
-                                                         it.has_pixel_inputs ? &it.pixel_inputs : nullptr,
-                                                         true,
+                                                         it.vrt.get(), pixel_inputs,
+                                                         !xfb_in_geometry,
                                                          it.vertex_lds_dwords);
                 }
                 if (!xfb.empty()) {
                     it.set_vs(std::move(xfb));
                     std::fprintf(stderr,
                                  "[geom-probe] draw=%llu item=%zu operation=%lld VS%s re-recompiled "
-                                 "with xfb capture (%zu words, lds=%u dwords)\n",
+                                 "with xfb in %s (%zu VS words, %zu GS words, lds=%u dwords)\n",
                                  draw_label, item_index, operation_label,
-                                 linked ? "+main" : "", it.vs.size(), it.vertex_lds_dwords);
+                                 linked ? "+main" : "", xfb_in_geometry ? "GS" : "VS",
+                                 it.vs.size(), it.gs.size(), it.vertex_lds_dwords);
                 } else {
                     std::fprintf(stderr, "[geom-probe] draw %llu: xfb re-recompile produced no VS "
                                          "(no raw stream / unsupported)\n", draw_label);

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -1680,34 +1680,44 @@ int main(int argc, char** argv) {
                 prosper::tools::replay_operation_index_for_draw(replay, n);
             const long long operation_label = operation_index == SIZE_MAX
                 ? -1 : static_cast<long long>(operation_index);
-            if (it.vs_raw_shader_index < replay.raw_shader_versions.size()) {
-                const auto& raw = replay.raw_shader_versions[it.vs_raw_shader_index];
-                const auto* pixel_inputs = it.has_pixel_inputs ? &it.pixel_inputs : nullptr;
-                const auto* system_inputs = it.has_system_inputs ? &it.system_inputs : nullptr;
-                bool xfb_in_geometry = false;
-                if (it.fs_raw_shader_index < replay.raw_shader_versions.size()) {
-                    const auto& fragment = replay.raw_shader_versions[it.fs_raw_shader_index];
-                    const auto interpolation = prosper::gpu::fragment_interpolation_layout(
-                        fragment.words.data(), fragment.words.size(), system_inputs, pixel_inputs);
-                    if (interpolation.valid && interpolation.requires_geometry &&
-                        it.ps.topology >= 3u && it.ps.topology <= 5u) {
-                        auto geometry = prosper::gpu::recompile_interpolation_geometry(
-                            interpolation, true);
-                        if (!geometry.empty()) {
-                            it.gs = std::move(geometry);
-                            xfb_in_geometry = true;
-                        }
-                    }
+            const auto* pixel_inputs = it.has_pixel_inputs ? &it.pixel_inputs : nullptr;
+            const auto* system_inputs = it.has_system_inputs ? &it.system_inputs : nullptr;
+            std::vector<uint32_t> rebuilt_geometry;
+            if (it.fs_raw_shader_index < replay.raw_shader_versions.size()) {
+                const auto& fragment = replay.raw_shader_versions[it.fs_raw_shader_index];
+                const auto interpolation = prosper::gpu::fragment_interpolation_layout(
+                    fragment.words.data(), fragment.words.size(), system_inputs, pixel_inputs);
+                if (interpolation.valid && interpolation.requires_geometry &&
+                    it.ps.topology >= 3u && it.ps.topology <= 5u) {
+                    rebuilt_geometry = prosper::gpu::recompile_interpolation_geometry(
+                        interpolation, true);
                 }
-                // Transform feedback is sourced from the last pre-rasterization stage. A generated
-                // interpolation GS therefore has to carry the XFB decorations; decorating only the VS
-                // renders real primitives but leaves the counter at zero.
-                if (!xfb_in_geometry && !it.gs.empty()) {
+            }
+            const bool has_raw_vertex =
+                it.vs_raw_shader_index < replay.raw_shader_versions.size();
+            const auto probe_stage = prosper::tools::select_geometry_probe_stage(
+                !rebuilt_geometry.empty(), !it.gs.empty(), has_raw_vertex);
+            if (probe_stage == prosper::tools::GeometryProbeStage::Unsupported) {
+                if (!it.gs.empty()) {
                     std::fprintf(stderr,
                                  "[geom-probe] draw %llu: cannot rebuild its geometry stage for xfb\n",
                                  draw_label);
-                    return 2;
+                } else {
+                    std::fprintf(stderr, "[geom-probe] draw %llu: no captured raw VS stream "
+                                         "(capsule predates v19 or source was unreadable)\n",
+                                         draw_label);
                 }
+                return 2;
+            }
+            if (probe_stage == prosper::tools::GeometryProbeStage::GeneratedGeometry) {
+                it.gs = std::move(rebuilt_geometry);
+                std::fprintf(stderr,
+                             "[geom-probe] draw=%llu item=%zu operation=%lld reused stored VS "
+                             "with xfb in GS (%zu VS words, %zu GS words, lds=%u dwords)\n",
+                             draw_label, item_index, operation_label, it.vs_words().size(),
+                             it.gs.size(), it.vertex_lds_dwords);
+            } else {
+                const auto& raw = replay.raw_shader_versions[it.vs_raw_shader_index];
                 std::vector<uint32_t> xfb;
                 const bool linked =
                     it.vs_chain_raw_shader_index < replay.raw_shader_versions.size();
@@ -1716,29 +1726,24 @@ int main(int argc, char** argv) {
                         replay.raw_shader_versions[it.vs_chain_raw_shader_index];
                     xfb = prosper::gpu::recompile_vertex_chain(
                         raw.words.data(), raw.words.size(), main.words.data(), main.words.size(),
-                        it.vrt.get(), pixel_inputs, !xfb_in_geometry,
-                        it.vertex_lds_dwords);
+                        it.vrt.get(), pixel_inputs, true, it.vertex_lds_dwords);
                 } else {
                     xfb = prosper::gpu::recompile_vertex(raw.words.data(), raw.words.size(),
-                                                         it.vrt.get(), pixel_inputs,
-                                                         !xfb_in_geometry,
+                                                         it.vrt.get(), pixel_inputs, true,
                                                          it.vertex_lds_dwords);
                 }
-                if (!xfb.empty()) {
-                    it.set_vs(std::move(xfb));
-                    std::fprintf(stderr,
-                                 "[geom-probe] draw=%llu item=%zu operation=%lld VS%s re-recompiled "
-                                 "with xfb in %s (%zu VS words, %zu GS words, lds=%u dwords)\n",
-                                 draw_label, item_index, operation_label,
-                                 linked ? "+main" : "", xfb_in_geometry ? "GS" : "VS",
-                                 it.vs.size(), it.gs.size(), it.vertex_lds_dwords);
-                } else {
+                if (xfb.empty()) {
                     std::fprintf(stderr, "[geom-probe] draw %llu: xfb re-recompile produced no VS "
-                                         "(no raw stream / unsupported)\n", draw_label);
+                                         "(unsupported raw stream)\n", draw_label);
+                    return 2;
                 }
-            } else {
-                std::fprintf(stderr, "[geom-probe] draw %llu: no captured raw VS stream "
-                                     "(capsule predates v19)\n", draw_label);
+                it.set_vs(std::move(xfb));
+                std::fprintf(stderr,
+                             "[geom-probe] draw=%llu item=%zu operation=%lld VS%s re-recompiled "
+                             "with xfb in VS (%zu VS words, 0 GS words, lds=%u dwords)\n",
+                             draw_label, item_index, operation_label,
+                             linked ? "+main" : "", it.vs_words().size(),
+                             it.vertex_lds_dwords);
             }
         } else {
             std::fprintf(stderr, "[geom-probe] unrealized semantic draw %llu\n", draw_label);

--- a/prosper/tools/gpu_replay/realized_shader_dump.hpp
+++ b/prosper/tools/gpu_replay/realized_shader_dump.hpp
@@ -20,6 +20,23 @@ struct RecompiledShaderView {
     bool shared = false;
 };
 
+enum class GeometryProbeStage {
+    Unsupported,
+    Vertex,
+    GeneratedGeometry,
+};
+
+// Transform feedback must be owned by the final pre-rasterization stage. A successfully rebuilt
+// generated GS can reuse the stored VS; otherwise a VS-only draw needs a captured raw VS so replay
+// can instrument it. Existing geometry that replay cannot rebuild must remain fail-closed.
+inline GeometryProbeStage select_geometry_probe_stage(bool rebuilt_generated_geometry,
+                                                       bool has_existing_geometry,
+                                                       bool has_raw_vertex) {
+    if (rebuilt_generated_geometry) return GeometryProbeStage::GeneratedGeometry;
+    if (has_existing_geometry || !has_raw_vertex) return GeometryProbeStage::Unsupported;
+    return GeometryProbeStage::Vertex;
+}
+
 inline RecompiledShaderView recompiled_shader_view(const gpu::DrawItem& draw,
                                                     bool vertex) {
     return vertex ? RecompiledShaderView{&draw.vs_words(), static_cast<bool>(draw.vs_shared)}


### PR DESCRIPTION
## What changed

- make the geometry probe capture positions from the final pre-rasterization stage
- rebuild Prosper's generated interpolation geometry shader with transform-feedback decorations when present
- keep ordinary and linked vertex-only draws on the existing vertex-stage capture path
- include vertex capture mode in the shader cache key
- reject unsupported pre-existing geometry stages instead of returning a false zero-vertex result
- document the final-stage rule and add structural/cache regressions

## Why

Astro Bot's world-map draws use Prosper's generated interpolation geometry stage. Vulkan sources transform feedback from the last pre-rasterization stage, but the probe decorated only the vertex shader. The scene rendered real primitives while the transform-feedback counter stayed at zero, falsely implicating vertex generation.

With this fix, captured world-map draw 69 reports 17,208 finite, on-screen vertices and 5,611 non-degenerate triangles. Ordinary fullscreen draw 188 still reports the expected three vertices through the VS path. This rules out missing world-map geometry and lets #1459 move on to the later depth/compute/composite stages.

## Validation

- `test_rdna2_spirv_struct`
- `test_shader_recompile_cache`
- `test_interp_render`
- `test_gpu_replay_shader_dump`
- real Astro Bot replay: draw 69, generated GS/XFB, 17,208 healthy vertices
- real Astro Bot replay: draw 188, VS/XFB, expected fullscreen triangle
- `git diff --check`

## Visual evidence

No screenshot: this PR changes a diagnostic-only path and the world-map replay output remains dark. The meaningful evidence is the exact transform-feedback geometry report above.

Refs #1459