### PR TITLE
Optimize multi-wave compute subgroup lowering

### DIFF
--- a/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
+++ b/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
@@ -1222,17 +1222,38 @@ created and ran both exact pipeline contracts. The standalone startup capsule st
 operations and no temporal RTT seeds, so its final pixel oracle and live compute result do not match.
 It is valid evidence for module/pipeline analysis, not for a full-frame correctness claim.
 
-A matched live switch test separated the two remaining kernels. Native lowering reduced
+A matched live switch test first separated the two remaining kernels. Native lowering reduced
 `0x30180d0000` from a 5.65 ms to 3.22 ms median GPU dispatch, but the four-wave, LDS/barrier-heavy
-`0x3015770000` kernel moved from 5.21 ms to 5.62 ms. Every other eligible Plucky dispatch in the route
-used exactly one 64-lane guest wave; those were neutral or faster, including a repeated mip kernel at
-0.44 ms native versus 0.86 ms portable. Native lowering therefore defaults to exact single-wave
-workgroups. `PROSPER_NATIVE_COMPUTE_MULTIWAVE=1` retains the exact, captureable multi-wave experiment;
-`PROSPER_NO_NATIVE_COMPUTE_SUBGROUP=1` remains the full portable control. These are sequential
-dispatch-local runs; 441 versus 418 presented frames is supporting route progression, not a standalone
-whole-app claim. A clean combined-policy confirmation kept `0x30180d0000` native at 3.08 ms and
-`0x3015770000` portable at 5.27 ms over 378+ samples, with 425 frames presented and no dispatch skip,
-renderer failure, or shutdown error.
+`0x3015770000` kernel moved from 5.21 ms to 5.62 ms. The reason was structural rather than an inherent
+multi-wave cost: its exact-subgroup module still contained the portable structured-control-flow wave
+votes, including 20 synthetic workgroup barriers in addition to the program's three real barriers.
+Every other eligible Plucky dispatch in that route used exactly one 64-lane guest wave; those were
+neutral or faster, including a repeated mip kernel at 0.44 ms native versus 0.86 ms portable. The
+interim policy therefore defaulted to exact single-wave workgroups and retained
+`PROSPER_NATIVE_COMPUTE_MULTIWAVE=1` as an experiment.
+
+The follow-up on 2026-07-30 made the exact-subgroup contract consistent across all translator paths.
+Straight-line MBCNT now uses subgroup exclusive scans, as the CFG dispatcher already did, and the
+structured compute path uses subgroup-any instead of the portable workgroup vote. The captured
+`0x3015770000` module fell from 32,076 to 8,026 SPIR-V words and now contains ten subgroup votes plus
+only the three guest barriers. A matched 55-second full-resolution live A/B measured steady submits
+after submit 100:
+
+| program | portable median | native median | samples (portable/native) |
+|---|---:|---:|---:|
+| `0x30180d0000` | 6.230 ms | 3.615 ms | 726 / 800 |
+| `0x3015770000` | 5.880 ms | 1.630 ms | 724 / 799 |
+
+The default remains conservative and title-independent: multi-wave workgroups are admitted
+automatically only when the decoded shader contains the canonical MBCNT low/high pair or at least four
+VCC/EXEC scalar branches alongside a guest workgroup barrier, where repeated scratch-emulated
+scans/votes justify the exact subgroup shell.
+Other multi-wave shapes still require `PROSPER_NATIVE_COMPUTE_MULTIWAVE=1`, and
+`PROSPER_NO_NATIVE_COMPUTE_SUBGROUP=1` remains the complete portable control. A default-policy run
+selected subgroup64 for both heavy programs, presented 265 frames, and produced no renderer or dispatch
+failure. A fresh four-present bundle replayed all 12 submits and 56/56 operations in the heavy submit;
+its 3840x2160 output was pixel-identical to the independently scheduled live screenshot (infinite PSNR).
+Frame counts remain supporting route progression rather than a standalone FPS claim.
 
 ## Plucky split no-GS NGG producer coverage
 

--- a/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
+++ b/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
@@ -1246,8 +1246,9 @@ after submit 100:
 
 The default remains conservative and title-independent: multi-wave workgroups are admitted
 automatically only when the decoded shader contains the canonical MBCNT low/high pair or at least four
-VCC/EXEC scalar branches alongside a guest workgroup barrier, where repeated scratch-emulated
-scans/votes justify the exact subgroup shell.
+VCC/EXEC branches accepted as top-level regions by the structured compute emitter alongside top-level
+guest workgroup barriers. That structural proof guarantees portable lowering really emits the repeated
+scratch-emulated votes which justify the exact subgroup shell; raw branch opcodes alone do not qualify.
 Other multi-wave shapes still require `PROSPER_NATIVE_COMPUTE_MULTIWAVE=1`, and
 `PROSPER_NO_NATIVE_COMPUTE_SUBGROUP=1` remains the complete portable control. A default-policy run
 selected subgroup64 for both heavy programs, presented 265 frames, and produced no renderer or dispatch

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -634,8 +634,9 @@ struct SharedVulkanContext {
 };
 // Select the exact native subgroup contract only when the renderer device can actually be adopted
 // by compute and every required-subgroup workgroup bound is satisfied. Single-wave workgroups are
-// the default proven fast path; `allow_multiwave` is the explicit experimental opt-in and `disabled`
-// is the diagnostic/compatibility opt-out.
+// the default proven fast path; the caller may allow a multi-wave program based on a structural
+// shader proof or the explicit experimental opt-in. `disabled` is the diagnostic/compatibility
+// opt-out.
 uint32_t select_native_compute_subgroup_size(const SharedVulkanContext& context,
                                              const ComputeShaderConfig& config,
                                              bool allow_multiwave, bool disabled);

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -3742,10 +3742,12 @@ std::vector<ComputeItem> realize_compute_dispatches(
             }
         }
         assign_convention_bindings(*table, 2);
+        bool native_multiwave_wave_work = false;
         {
             std::vector<Rdna2Inst> decoded;
             rdna2_walk(reinterpret_cast<const uint32_t*>(static_cast<uintptr_t>(code_addr)),
                        shader_dwords, decoded);
+            native_multiwave_wave_work = compute_shader_prefers_native_multiwave(decoded);
             const bool uses_gds = std::any_of(decoded.begin(), decoded.end(), [](const auto& in) {
                 return in.fmt == Rdna2Format::DS && in.ds_gds && in.opcode == 0x0d;
             });
@@ -3797,9 +3799,14 @@ std::vector<ComputeItem> realize_compute_dispatches(
         // Vulkan's implementation-defined LocalInvocationIndex order and subgroup lane order while
         // still making each native subgroup exactly one RDNA wave. Capture v37 records this exact
         // module's required-subgroup/full-subgroups pipeline contract for faithful replay.
+        // Repeated scratch-emulated wave scans/votes are a structural exception to the conservative
+        // multi-wave default: the exact subgroup shell removes their workgroup barriers while
+        // preserving one native subgroup per guest wave. Keep the environment switch as an explicit
+        // experiment for every other multi-wave shape; this automatic path is shader-address/title
+        // independent and remains subject to all device and workgroup bounds below.
         config.native_subgroup_size = select_native_compute_subgroup_size(
             shared_vulkan, config,
-            getenv("PROSPER_NATIVE_COMPUTE_MULTIWAVE") != nullptr,
+            native_multiwave_wave_work || getenv("PROSPER_NATIVE_COMPUTE_MULTIWAVE") != nullptr,
             getenv("PROSPER_NO_NATIVE_COMPUTE_SUBGROUP") != nullptr);
         config.tgid_x_en = tgid_x_en;
         config.tgid_y_en = tgid_y_en;

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -3754,7 +3754,9 @@ std::vector<ComputeItem> realize_compute_dispatches(
             std::vector<Rdna2Inst> decoded;
             rdna2_walk(reinterpret_cast<const uint32_t*>(static_cast<uintptr_t>(code_addr)),
                        shader_dwords, decoded);
-            native_multiwave_wave_work = compute_shader_prefers_native_multiwave(decoded);
+            native_multiwave_wave_work = compute_shader_prefers_native_multiwave(
+                decoded, reinterpret_cast<const uint32_t*>(static_cast<uintptr_t>(code_addr)),
+                shader_dwords);
             const bool uses_gds = std::any_of(decoded.begin(), decoded.end(), [](const auto& in) {
                 return in.fmt == Rdna2Format::DS && in.ds_gds && in.opcode == 0x0d;
             });

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -7038,13 +7038,19 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 // (126/127) -> this lane's exec bool; inline -1 (all-ones) -> always set (mbcnt = lane
                 // index, the common "get my lane id" idiom, e.g. shader 037); inline 0 -> never; an SGPR
                 // pair -> that saved mask's bool. A general computed 32-bit mask VALUE isn't representable
-                // per-lane, so reject that. Compute uses LDS+barriers at barrier-uniform sites;
-                // fragment uses a native exclusive subgroup sum with an enforced wave64 pipeline.
+                // per-lane, so reject that. Portable compute uses LDS+barriers at barrier-uniform sites;
+                // exact-size compute subgroups and fragments use a native exclusive subgroup sum.
                 const uint32_t active = mbcnt_source_bit(
                     b, rs, in.src[0], in.opcode == 0x366);
-                if (active) vreg[in.dst.value] = b.is_fragment
-                    ? b.fragment_mbcnt(active, val(in.src[1]), in.opcode == 0x365)
-                    : b.mbcnt(active, val(in.src[1]), in.opcode == 0x365);
+                if (active) {
+                    const uint32_t acc = val(in.src[1]);
+                    const uint32_t lo = in.opcode == 0x365 ? b.btrue() : b.bfalse();
+                    vreg[in.dst.value] = b.is_fragment
+                        ? b.fragment_mbcnt(active, acc, in.opcode == 0x365)
+                        : (b.native_subgroup_size
+                            ? b.native_compute_mbcnt(active, acc, lo)
+                            : b.mbcnt(active, acc, in.opcode == 0x365));
+                }
                 else ok = false;
             } else if (in.opcode == 0x12F) {                          // v_cvt_pkrtz_f16_f32 = pack(s0->lo, s1->hi)
                 vreg[in.dst.value] = b.pack_half2x16_rtz(fv(0), fv(1)); // v_cvt_pkrtz VOP3: RTZ clamp (#452)
@@ -11279,7 +11285,9 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                     return false;
                 uint32_t cond_reg = F.on_exec ? rs.exec : (F.on_vcc ? rs.vcc : rs.scc);
                 if (b.is_compute && (F.on_exec || F.on_vcc))
-                    cond_reg = b.guest_wave_any(cond_reg);
+                    cond_reg = b.native_subgroup_size
+                        ? b.native_wave_any(cond_reg)
+                        : b.guest_wave_any(cond_reg);
                 else if (b.is_fragment && (F.on_exec || F.on_vcc))
                     cond_reg = b.fragment_wave_any(cond_reg);
                 uint32_t exec_cond = F.on_scc0 ? cond_reg : b.bsel(cond_reg, b.bfalse(), b.btrue());
@@ -11527,6 +11535,35 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
     // a module that could deadlock or observe undefined workgroup-memory behavior.
     if (has_partial_workgroup && b.uses_barrier) return {};
     return b.finish();
+}
+
+bool compute_shader_prefers_native_multiwave(const std::vector<Rdna2Inst>& ins) {
+    bool low = false;
+    bool high = false;
+    bool guest_barrier = false;
+    uint32_t wave_branches = 0;
+    for (const Rdna2Inst& in : ins) {
+        if (in.is_end) break;
+        if (in.fmt == Rdna2Format::VOP3) {
+            low |= in.opcode == 0x365;
+            high |= in.opcode == 0x366;
+        }
+        if (in.fmt == Rdna2Format::SOPP && in.opcode >= 0x06 && in.opcode <= 0x09)
+            ++wave_branches;
+        guest_barrier |= in.fmt == Rdna2Format::SOPP && in.opcode == 0x0a;
+        if (low && high) return true;
+    }
+    // Four raw wave branches plus a real workgroup barrier are intentionally required: simple
+    // if/loop shapes may be lowered per invocation without scratch, while barrier-separated,
+    // branch-dense structured shaders repeatedly pay for exact guest-wave votes. This keeps the
+    // default narrower than the all-multi-wave experiment.
+    return guest_barrier && wave_branches >= 4;
+}
+
+bool compute_shader_prefers_native_multiwave(const uint32_t* code, size_t dwords) {
+    std::vector<Rdna2Inst> ins;
+    rdna2_walk(code, dwords, ins);
+    return compute_shader_prefers_native_multiwave(ins);
 }
 
 // See FlatLoadInfo / analyze_flat_loads in the header (#1171). A `base + offset` flat address VGPR pair

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -11559,33 +11559,65 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
     return b.finish();
 }
 
-bool compute_shader_prefers_native_multiwave(const std::vector<Rdna2Inst>& ins) {
+bool compute_shader_prefers_native_multiwave(const std::vector<Rdna2Inst>& ins,
+                                             const uint32_t* code, size_t dwords) {
     bool low = false;
     bool high = false;
     bool guest_barrier = false;
-    uint32_t wave_branches = 0;
     for (const Rdna2Inst& in : ins) {
         if (in.is_end) break;
         if (in.fmt == Rdna2Format::VOP3) {
             low |= in.opcode == 0x365;
             high |= in.opcode == 0x366;
         }
-        if (in.fmt == Rdna2Format::SOPP && in.opcode >= 0x06 && in.opcode <= 0x09)
-            ++wave_branches;
         guest_barrier |= in.fmt == Rdna2Format::SOPP && in.opcode == 0x0a;
         if (low && high) return true;
     }
-    // Four raw wave branches plus a real workgroup barrier are intentionally required: simple
-    // if/loop shapes may be lowered per invocation without scratch, while barrier-separated,
-    // branch-dense structured shaders repeatedly pay for exact guest-wave votes. This keeps the
-    // default narrower than the all-multi-wave experiment.
-    return guest_barrier && wave_branches >= 4;
+    if (!guest_barrier || !code) return false;
+
+    // Mirror the conservative, acyclic subset of emit_body's structured-compute admission. Counting
+    // raw VCC/EXEC opcodes is insufficient: kill-mask branches may be safely linearized, loop exits
+    // are owned by another emitter, and rejected CFGs never reach guest_wave_any. Requiring the same
+    // accepted ForwardIf regions proves that portable lowering really emits two scratch barriers per
+    // counted vote and that exact-subgroup lowering removes them. Loops deliberately stay behind the
+    // explicit experiment until their additional compute guards are shared with this analysis.
+    auto safe = safe_execz_branches(ins);
+    for (uint32_t pc : waterfall_branches(ins)) safe.insert(pc);
+    const std::vector<DivLoop> loops = detect_divergent_loops(ins, safe, /*fragment*/false);
+    if (!loops.empty()) return false;
+
+    bool rejected = false;
+    const std::vector<ForwardIf> branches = detect_forward_ifs(
+        ins, /*allow_vcc*/false, code, dwords, &safe, nullptr, &rejected,
+        /*compute_wave_branches*/true);
+    if (rejected) return false;
+
+    auto top_level_pc = [&](uint32_t pc) {
+        for (const ForwardIf& parent : branches) {
+            const uint32_t parent_end = parent.has_else ? parent.merge_pc : parent.target_pc;
+            if (parent.branch_pc < pc && pc < parent_end) return false;
+        }
+        return true;
+    };
+    const bool barriers_are_top_level = std::all_of(ins.begin(), ins.end(), [&](const Rdna2Inst& in) {
+        return in.fmt != Rdna2Format::SOPP || in.opcode != 0x0a || top_level_pc(in.pc);
+    });
+    if (!barriers_are_top_level) return false;
+
+    size_t structured_wave_votes = 0;
+    for (const ForwardIf& branch : branches) {
+        if (!branch.on_exec && !branch.on_vcc) continue;
+        if (!top_level_pc(branch.branch_pc)) return false;
+        ++structured_wave_votes;
+    }
+    // Four proven scratch-emulated votes keep the default narrower than the all-multi-wave experiment.
+    return structured_wave_votes >= 4;
 }
 
 bool compute_shader_prefers_native_multiwave(const uint32_t* code, size_t dwords) {
     std::vector<Rdna2Inst> ins;
     rdna2_walk(code, dwords, ins);
-    return compute_shader_prefers_native_multiwave(ins);
+    return compute_shader_prefers_native_multiwave(ins, code, dwords);
 }
 
 // See FlatLoadInfo / analyze_flat_loads in the header (#1171). A `base + offset` flat address VGPR pair

--- a/prosper/src/gpu/rdna2_to_spirv.hpp
+++ b/prosper/src/gpu/rdna2_to_spirv.hpp
@@ -225,13 +225,14 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
                                         const ShaderResourceTable* rt,
                                         const ComputeShaderConfig& config);
 
-// True when the program contains enough wave work to justify an exact multi-wave subgroup shell:
-// either the canonical low/high MBCNT pair, or at least four VCC/EXEC scalar branches in a shader
-// containing a guest workgroup barrier. Portable compute lowers these through synchronized workgroup
-// scratch; native compute uses subgroup scans/votes. This deliberately conservative structural signal
-// is independent of title and shader address.
+// True when the program contains enough proven wave work to justify an exact multi-wave subgroup
+// shell: either the canonical low/high MBCNT pair, or at least four VCC/EXEC branches accepted by the
+// structured compute emitter in a shader containing only top-level guest workgroup barriers. Portable
+// compute lowers those operations through synchronized workgroup scratch; native compute uses subgroup
+// scans/votes. This deliberately conservative structural signal is independent of title and address.
 bool compute_shader_prefers_native_multiwave(const uint32_t* code, size_t dwords);
-bool compute_shader_prefers_native_multiwave(const std::vector<Rdna2Inst>& instructions);
+bool compute_shader_prefers_native_multiwave(const std::vector<Rdna2Inst>& instructions,
+                                             const uint32_t* code, size_t dwords);
 
 // DPP/permlane operations are native subgroup shuffles: quad permutations need four contiguous
 // lanes, row operations need 16, and PERMLANEX16 needs a paired 32-lane row. The backend rejects

--- a/prosper/src/gpu/rdna2_to_spirv.hpp
+++ b/prosper/src/gpu/rdna2_to_spirv.hpp
@@ -224,6 +224,14 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
                                         const ShaderResourceTable* rt,
                                         const ComputeShaderConfig& config);
 
+// True when the program contains enough wave work to justify an exact multi-wave subgroup shell:
+// either the canonical low/high MBCNT pair, or at least four VCC/EXEC scalar branches in a shader
+// containing a guest workgroup barrier. Portable compute lowers these through synchronized workgroup
+// scratch; native compute uses subgroup scans/votes. This deliberately conservative structural signal
+// is independent of title and shader address.
+bool compute_shader_prefers_native_multiwave(const uint32_t* code, size_t dwords);
+bool compute_shader_prefers_native_multiwave(const std::vector<Rdna2Inst>& instructions);
+
 // DPP/permlane operations are native subgroup shuffles: quad permutations need four contiguous
 // lanes, row operations need 16, and PERMLANEX16 needs a paired 32-lane row. The backend rejects
 // (rather than miscompiles) a module on a narrower host.

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -2872,6 +2872,31 @@ int main() {
            got63.size()==N?got63[5]:-1, exp63[5], got63.size()==N?got63[70]:-1, exp63[70]);
     CHECK(got63.size()==N && bad63==0, "recompiled kernel 63 (v_mbcnt full-exec = localid) correct");
 
+    ComputeShaderConfig native_cfg63;
+    native_cfg63.local_x = 8;
+    native_cfg63.local_y = 8;
+    native_cfg63.wave_size = 64;
+    native_cfg63.native_subgroup_size = 64;
+    const std::vector<uint32_t> native_spv63 = recompile_compute(
+        code63, std::size(code63), nullptr, native_cfg63);
+    const uint32_t vote_heavy_policy_code[] = {
+        0xbf880000u, 0xbf860000u, 0xbf890000u, 0xbf870000u, 0xbf8a0000u, 0xbf810000u,
+    };
+    const uint32_t vote_light_policy_code[] = {
+        0xbf880000u, 0xbf860000u, 0xbf890000u, 0xbf8a0000u, 0xbf810000u,
+    };
+    CHECK(compute_shader_prefers_native_multiwave(code63, std::size(code63)) &&
+              compute_shader_prefers_native_multiwave(
+                  vote_heavy_policy_code, std::size(vote_heavy_policy_code)) &&
+              !compute_shader_prefers_native_multiwave(
+                  vote_light_policy_code, std::size(vote_light_policy_code)) &&
+              !compute_shader_prefers_native_multiwave(code62, std::size(code62)),
+          "multi-wave policy recognizes scan/vote-heavy shaders without title-specific identity");
+    CHECK(!native_spv63.empty() && count_spirv_opcode(native_spv63, 349) == 2,
+          "straight-line exact-wave MBCNT lowers both halves to subgroup scans");
+    CHECK(count_spirv_opcode(native_spv63, 224) == 0,
+          "straight-line exact-wave MBCNT emits no workgroup control barrier");
+
     // Kernel 64: v_mbcnt with DIVERGENT exec — the real compaction use. v_cmpx narrows exec to (a>thr);
     // then mbcnt gives each active lane its index among active lanes. Even lanes active (a=1>0.5), odd
     // inactive (a=0): active lane L -> L/2 (count of active lanes below); inactive lanes keep 0 (the
@@ -4875,6 +4900,20 @@ int main() {
                    gotStructuredWave[64], gotStructuredWave[127]);
         CHECK(gotStructuredWave.size() == 128 && badStructuredWave == 0,
               "#1373: structured branch performs one exact 64-lane guest-wave vote");
+
+        ComputeShaderConfig nativeStructuredWaveConfig;
+        nativeStructuredWaveConfig.local_x = 8;
+        nativeStructuredWaveConfig.local_y = 8;
+        nativeStructuredWaveConfig.wave_size = 64;
+        nativeStructuredWaveConfig.native_subgroup_size = 64;
+        const std::vector<uint32_t> nativeStructuredWaveSpv = recompile_compute(
+            structured_wave_cs, std::size(structured_wave_cs), nullptr,
+            nativeStructuredWaveConfig);
+        CHECK(!nativeStructuredWaveSpv.empty() &&
+                  count_spirv_opcode(nativeStructuredWaveSpv, 335) >= 1,
+              "structured exact-wave branch lowers its vote to subgroup-any");
+        CHECK(count_spirv_opcode(nativeStructuredWaveSpv, 224) == 1,
+              "structured exact-wave branch retains only its guest workgroup barrier");
 
         // UE4 reduction kernels also use sequential top-level EXEC tests separated by workgroup
         // barriers, with no loop in the shader. A scalar write in each arm makes the result visible

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -2919,19 +2919,9 @@ int main() {
     native_cfg63.native_subgroup_size = 64;
     const std::vector<uint32_t> native_spv63 = recompile_compute(
         code63, std::size(code63), nullptr, native_cfg63);
-    const uint32_t vote_heavy_policy_code[] = {
-        0xbf880000u, 0xbf860000u, 0xbf890000u, 0xbf870000u, 0xbf8a0000u, 0xbf810000u,
-    };
-    const uint32_t vote_light_policy_code[] = {
-        0xbf880000u, 0xbf860000u, 0xbf890000u, 0xbf8a0000u, 0xbf810000u,
-    };
     CHECK(compute_shader_prefers_native_multiwave(code63, std::size(code63)) &&
-              compute_shader_prefers_native_multiwave(
-                  vote_heavy_policy_code, std::size(vote_heavy_policy_code)) &&
-              !compute_shader_prefers_native_multiwave(
-                  vote_light_policy_code, std::size(vote_light_policy_code)) &&
               !compute_shader_prefers_native_multiwave(code62, std::size(code62)),
-          "multi-wave policy recognizes scan/vote-heavy shaders without title-specific identity");
+          "multi-wave policy recognizes scan-heavy shaders without title-specific identity");
     CHECK(!native_spv63.empty() && count_spirv_opcode(native_spv63, 349) == 2,
           "straight-line exact-wave MBCNT lowers both halves to subgroup scans");
     CHECK(count_spirv_opcode(native_spv63, 224) == 0,
@@ -4994,6 +4984,80 @@ int main() {
             if (gotBarrierReduction[i] != expBarrierReduction[i]) ++badBarrierReduction;
         CHECK(gotBarrierReduction.size() == 128 && badBarrierReduction == 0,
               "barrier-separated reductions perform independent exact 64-lane guest-wave votes");
+
+        // The automatic multi-wave policy must follow translated structure, not raw opcode counts.
+        // Four valid sequential top-level wave votes each cost two synchronized scratch barriers in
+        // portable lowering and none in exact-subgroup lowering. The two-vote kernel above remains
+        // below the conservative threshold.
+        const uint32_t vote_heavy_policy_cs[] = {
+            0xBE800380u,               //  0: s_mov_b32 s0, 0
+            0xBE810380u,               //  1: s_mov_b32 s1, 0
+            0x7DA20200u,               //  2: v_cmpx_lt_u32 exec, s0, v1
+            0xBF880001u,               //  3: s_cbranch_execz +1 -> 5
+            0xBE800381u,               //  4: s_mov_b32 s0, 1
+            0xBEFE04C1u,               //  5: s_mov_b64 exec, -1
+            0xBF8A0000u,               //  6: s_barrier
+            0x7DA20600u,               //  7: v_cmpx_lt_u32 exec, s0, v3
+            0xBF880001u,               //  8: s_cbranch_execz +1 -> 10
+            0xBE810382u,               //  9: s_mov_b32 s1, 2
+            0xBEFE04C1u,               // 10: s_mov_b64 exec, -1
+            0xBF8A0000u,               // 11: s_barrier
+            0x7DA20200u,               // 12: v_cmpx_lt_u32 exec, s0, v1
+            0xBF880001u,               // 13: s_cbranch_execz +1 -> 15
+            0xBE800383u,               // 14: s_mov_b32 s0, 3
+            0xBEFE04C1u,               // 15: s_mov_b64 exec, -1
+            0xBF8A0000u,               // 16: s_barrier
+            0x7DA20600u,               // 17: v_cmpx_lt_u32 exec, s0, v3
+            0xBF880001u,               // 18: s_cbranch_execz +1 -> 20
+            0xBE810384u,               // 19: s_mov_b32 s1, 4
+            0xBEFE04C1u,               // 20: s_mov_b64 exec, -1
+            0xBF8A0000u,               // 21: s_barrier
+            0x80020100u,               // 22: s_add_u32 s2, s0, s1
+            0x7E040C02u,               // 23: v_cvt_f32_u32 v2, s2
+            0xBF810000u,               // 24: s_endpgm
+        };
+        ComputeShaderConfig portableVotePolicyConfig;
+        portableVotePolicyConfig.local_x = 8;
+        portableVotePolicyConfig.local_y = 8;
+        portableVotePolicyConfig.wave_size = 64;
+        ComputeShaderConfig nativeVotePolicyConfig = portableVotePolicyConfig;
+        nativeVotePolicyConfig.native_subgroup_size = 64;
+        const std::vector<uint32_t> portableVotePolicySpv = recompile_compute(
+            vote_heavy_policy_cs, std::size(vote_heavy_policy_cs), nullptr,
+            portableVotePolicyConfig);
+        const std::vector<uint32_t> nativeVotePolicySpv = recompile_compute(
+            vote_heavy_policy_cs, std::size(vote_heavy_policy_cs), nullptr,
+            nativeVotePolicyConfig);
+        const uint32_t linearized_vote_policy_cs[] = {
+            0xBF8A0000u,               //  0: s_barrier (uniform, before all guarded work)
+            0x7DA20200u,               //  1: v_cmpx_lt_u32 exec, s0, v1
+            0xBF880007u,               //  2: s_cbranch_execz +7 -> 10 (safe guard to end)
+            0x7DA20200u,               //  3: v_cmpx_lt_u32 exec, s0, v1
+            0xBF880005u,               //  4: s_cbranch_execz +5 -> 10 (safe guard to end)
+            0x7DA20200u,               //  5: v_cmpx_lt_u32 exec, s0, v1
+            0xBF880003u,               //  6: s_cbranch_execz +3 -> 10 (safe guard to end)
+            0x7DA20200u,               //  7: v_cmpx_lt_u32 exec, s0, v1
+            0xBF880001u,               //  8: s_cbranch_execz +1 -> 10 (safe guard to end)
+            0x7E040C00u,               //  9: v_cvt_f32_u32 v2, s0
+            0xBF810000u,               // 10: s_endpgm
+        };
+        const std::vector<uint32_t> linearizedVotePolicySpv = recompile_compute(
+            linearized_vote_policy_cs, std::size(linearized_vote_policy_cs), nullptr,
+            portableVotePolicyConfig);
+        CHECK(compute_shader_prefers_native_multiwave(
+                  vote_heavy_policy_cs, std::size(vote_heavy_policy_cs)) &&
+                  !compute_shader_prefers_native_multiwave(
+                      barrier_reduction_cs, std::size(barrier_reduction_cs)) &&
+                  !compute_shader_prefers_native_multiwave(
+                      linearized_vote_policy_cs, std::size(linearized_vote_policy_cs)),
+              "multi-wave vote policy counts accepted structured wave branches");
+        CHECK(!portableVotePolicySpv.empty() && !nativeVotePolicySpv.empty() &&
+                  count_spirv_opcode(portableVotePolicySpv, 224) ==
+                      count_spirv_opcode(nativeVotePolicySpv, 224) + 8,
+              "multi-wave vote policy proves exact lowering removes eight scratch barriers");
+        CHECK(!linearizedVotePolicySpv.empty() &&
+                  count_spirv_opcode(linearizedVotePolicySpv, 224) == 1,
+              "raw branch density alone does not opt a linearized shader into multi-wave mode");
 
         std::vector<uint32_t> divergentBarrierStructuredWave(
             std::begin(structured_wave_cs), std::end(structured_wave_cs));

--- a/prosper/tests/test_shared_vulkan_device.cpp
+++ b/prosper/tests/test_shared_vulkan_device.cpp
@@ -91,7 +91,7 @@ int main() {
               eligible, two_waves, false, false) == 0 &&
           prosper::gpu::select_native_compute_subgroup_size(
               eligible, two_waves, true, false) == 64,
-          "multi-wave native compute requires an explicit experimental opt-in");
+          "multi-wave native compute remains gated by the caller's structural or experimental proof");
     auto narrow_flattened_x = eligible;
     narrow_flattened_x.max_compute_workgroup_size_x = 128;
     auto guest_16x16 = multidimensional;


### PR DESCRIPTION
Advances #1390.

## Problem

Plucky Squire's remaining frame cost is dominated by two full-resolution compute programs. Exact native wave64 lowering already accelerated `0x30180d0000`, but the 16x16 / four-wave `0x3015770000` program regressed under the multi-wave experiment.

The root cause was not multi-wave execution itself. The straight/structured translator paths still used portable workgroup-scratch emulation for MBCNT and exact VCC/EXEC wave votes even when the pipeline required one exact host subgroup per guest wave. For `0x3015770000`, that left 20 synthetic barriers around ten wave votes in addition to the shader's three real guest barriers.

## Change

- Lower straight-line compute MBCNT to native subgroup exclusive scans when an exact subgroup contract is present, matching the already-proven CFG path.
- Lower structured exact-wave compute votes to subgroup-any while preserving real guest workgroup barriers.
- Keep default multi-wave selection conservative and title-independent:
  - automatically admit a canonical MBCNT low/high pair; or
  - admit only an acyclic shader with at least four VCC/EXEC branches accepted as top-level regions by the same structurizer used for translation, alongside top-level guest barriers.
- Reuse the resource builder's existing decoded instruction stream, so policy selection adds no second shader decode per dispatch.
- Retain `PROSPER_NATIVE_COMPUTE_MULTIWAVE=1` for other experimental shapes and `PROSPER_NO_NATIVE_COMPUTE_SUBGROUP=1` as the full portable control.
- Add structural/execution regression coverage, including a four-raw-branch shader whose branches are safely linearized and therefore must not qualify.
- Merge current master, including the reviewed Astro Bot shader/replay changes.

## Impact

The capture-compatible `0x3015770000` module drops from 32,076 to 8,026 SPIR-V words. It now contains ten subgroup votes and only the program's three real barriers.

Matched 55-second, full-resolution live runs after submit 100:

| program | portable median | native median | samples |
|---|---:|---:|---:|
| `0x30180d0000` | 6.230 ms | 3.615 ms | 726 / 800 |
| `0x3015770000` | 5.880 ms | 1.630 ms | 724 / 799 |

A fresh exact-head default-policy smoke after merging master and addressing review selected subgroup64 for both programs, presented 440 frames, and retained steady `0x3015770000` samples around 1.3–1.7 ms.

## Correctness evidence

- Fresh four-present bundle: 12/12 submits replayed.
- Heavy submit: 56/56 operations realized.
- Replayed 3840x2160 output is pixel-identical to the independently scheduled live screenshot (PSNR = infinity).
- Captured `0x3015770000` SPIR-V passes `spirv-val --target-env vulkan1.2`.
- Compute-only replay produced stable output hashes across 20 repeats:
  - binding 10: `c420c36630344ddf`
  - binding 11: `7bbaebfc39e50383`
- Exact-head live screenshot at 3840x2160 remains visually correct after integration.

Capture files remain local because they contain title-derived data.

## Validation

- `cmake --build prosper/build-linux -j8`
- `test_rdna2_to_spirv` — PASS, including native MBCNT, valid portable/native structured-vote translation, eight removed scratch barriers, and the safe-linearization negative
- `test_shared_vulkan_device` — PASS
- Full CTest: 154/157. The three failures are asset-fixture tests configured for GTA while this build tree points at the Plucky dump (expected import counts, missing GTA module, and embedded GTA shader fixture), not code failures.
- Full-resolution live portable/native A/B, final default-policy smoke, SPIR-V validation, bundle replay, compute-only replay, and pixel comparison as described above.

## Risk / boundaries

The native path still requires subgroup-size control, full compute subgroups, vote/arithmetic support, exact wave-size compatibility, and all existing workgroup/device bounds. Multi-wave programs outside the narrow translator-proven policy remain portable by default. Looped wave-vote shaders are deliberately excluded from automatic admission.