### PR TITLE
gpu: keep R11G11B10 storage packed through compute

### DIFF
--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -1876,14 +1876,16 @@ struct ScopedMappedMemory {
 };
 
 // One image binding (#590): a sampled texture (usually RGBA8, with native UINT8x4 and R11G11B10F
-// views where shader-visible numeric semantics require them) or a storage image (R32G32B32A32_UINT
-// texels — the recompiler's format-free contract, exec-diff proven by tests/image_compute_runner.h).
+// views where shader-visible numeric semantics require them) or a storage image. Storage normally
+// uses R32G32B32A32_UINT format-free texels; packed R11G11B10 can instead use exact R32_UINT words.
 struct BoundImage {
     const prosper::gpu::ShaderResource* resource = nullptr;
     uint32_t binding = 0;
     bool storage = false;               // storage image: read back + pack to guest after the dispatch
     bool native_float_storage = false;  // Vulkan performs exact UNORM/float conversion at native width
+    bool packed_r11_storage = false;    // shader packs exact R11G11B10 words into typed R32_UINT
     bool graphics_sampled_usage = false;// native image was created with SAMPLED usage for export
+    bool exact_storage_bytes() const { return native_float_storage || packed_r11_storage; }
     uint32_t texel_depth = 1;           // logical Z/layer count represented in the staging buffer
     uint32_t array_layers = 1;           // Vulkan array-layer count (3D depth remains one layer)
     bool arrayed_2d = false;            // SPIR-V requires a real 2D-array view (not base-slice fallback)
@@ -1942,8 +1944,9 @@ struct BoundImage {
 };
 
 // --- Storage-image channel model (#590) -------------------------------------------------------------
-// The recompiler moves image texels as RAW 32-bit VGPR channel values (uvec4 per texel; the VkImage is
-// R32G32B32A32_UINT with format-free reads/writes). Real hardware format-converts per the T#, so the
+// The portable recompiler path moves image texels as RAW 32-bit VGPR channel values (uvec4 per texel;
+// the VkImage is R32G32B32A32_UINT with format-free reads/writes). Real hardware format-converts per
+// the T#, so the
 // guest surface's bytes must be UNPACKED to channel dwords on upload and PACKED back on writeback:
 //   Unorm8/16 -> float(u/max) bits        <- clamp(bitcast float,0,1)*max rounded
 //   Snorm8/16 -> max(float(s/max),-1) bits <- clamp(bitcast float,-1,1)*max rounded
@@ -2688,9 +2691,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             ComputeClock::now() - setup_validate_start).count() - setup_validate_ms;
 
         // --- Image bindings (#590): sampled textures use RGBA8 unless integer/packed-float semantics
-        // require a native view; storage images are R32G32B32A32_UINT raw-channel texels (the recompiler's
-        // format-free contract, exec-diff proven by tests/image_compute_runner.h) with per-format
-        // pack/unpack against the guest surface. Everything not provably correct skips LOUDLY. ---
+        // require a native view. Storage images normally use format-free R32G32B32A32_UINT channels;
+        // exact native-width paths are selected from reflected SPIR-V. Everything not provably correct
+        // skips LOUDLY. ---
         bool images_ready = !ctx.device ? false : true;
         auto device_memory_type = [&](uint32_t bits) -> uint32_t {
             for (uint32_t i = 0; i < ctx.memory.memoryTypeCount; i++)
@@ -2732,6 +2735,10 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 native_storage_vk_format(r->format, descriptor_components);
             const bool spirv_native_storage =
                 bi.storage && image_descriptors[i].storage_float;
+            bi.packed_r11_storage = bi.storage && !spirv_native_storage &&
+                !image_descriptors[i].atomic_access &&
+                image_descriptors[i].storage_image_format == kSpirvImageFormatR32ui &&
+                r->format == DataFormat::Float10_11_11 && descriptor_components == 3;
             const bool ordinary_2d_storage = r->img_dim == 1 && r->depth == 1 &&
                                              !r->depth_compare;
             const bool native_storage_supported = native_float_storage_image_supported(
@@ -2758,6 +2765,10 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                              (unsigned long long)r->gpu_addr, r->width, r->height, r->depth,
                              (unsigned)r->format, r->num_components, r->tile_mode,
                              bi.native_float_storage ? 1u : 0u);
+            if (trace && bi.packed_r11_storage)
+                std::fprintf(stderr,
+                             "[compute]   image binding=%u exact packed R11G11B10 storage via R32_UINT\n",
+                             bi.binding);
             // A surface whose CURRENT pixels live in the renderer's RTT cache must not be read from
             // raw guest memory (empty/stale — the Dead Cells 642x362 lesson).
             const bool dim_1d = r->img_dim == 0;
@@ -3143,7 +3154,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         (live_target.format == LiveTargetPixelFormat::Rgba8Unorm &&
                          r->format == DataFormat::Unorm8 && nc == 4) ||
                         (live_target.format == LiveTargetPixelFormat::Rgba16Float &&
-                         r->format == DataFormat::Float16 && nc == 4);
+                         r->format == DataFormat::Float16 && nc == 4) ||
+                        (live_target.format == LiveTargetPixelFormat::R11G11B10Float &&
+                         r->format == DataFormat::Float10_11_11 && nc == 3);
                     if (!compatible) {
                         // The same allocation can carry another target view before this compute
                         // operation (Astro Bot uses R8G8 and RGBA16F views at one base). A snapshot
@@ -3155,7 +3168,10 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                          "addr=0x%llx cached=%s requested=f%u/c%u -> guest backing\n",
                                          bi.binding, (unsigned long long)r->gpu_addr,
                                          live_target.format == LiveTargetPixelFormat::Rgba16Float
-                                             ? "rgba16f" : "rgba8",
+                                             ? "rgba16f"
+                                         : live_target.format ==
+                                               LiveTargetPixelFormat::R11G11B10Float
+                                             ? "r11g11b10" : "rgba8",
                                          (unsigned)r->format, nc);
                     }
                 }
@@ -3276,11 +3292,11 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             const bool sampled_uint32_native = !bi.storage && r->format == DataFormat::Uint32 &&
                                                (sampled_components == 1 || sampled_components == 2 ||
                                                 sampled_components == 4);
-            const uint32_t native_storage_bytes = bi.native_float_storage
+            const uint32_t native_storage_bytes = bi.exact_storage_bytes()
                 ? (r->format == DataFormat::Float10_11_11
                        ? 4u : data_format_bytes(r->format) * sampled_components)
                 : 0u;
-            const uint32_t texel_bytes = bi.native_float_storage ? native_storage_bytes
+            const uint32_t texel_bytes = bi.exact_storage_bytes() ? native_storage_bytes
                                          : bi.storage ? 16u
                                          : sampled_float32_native ? sampled_components * 4u
                                          : sampled_float32 ? 16u
@@ -3294,6 +3310,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             const bool sampled_r11g11b10 = !bi.storage &&
                 r->format == DataFormat::Float10_11_11 && sampled_components == 3;
             const VkFormat image_format = bi.imported_depth ? bi.imported_format
+                : bi.packed_r11_storage ? VK_FORMAT_R32_UINT
                 : bi.native_float_storage
                 ? (r->format == DataFormat::Unorm8
                        ? (sampled_components == 1 ? VK_FORMAT_R8_UNORM
@@ -3337,8 +3354,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                                   : VK_FORMAT_R32G32B32A32_SFLOAT)
                 : sampled_float32 ? VK_FORMAT_R32G32B32A32_SFLOAT
                                   : VK_FORMAT_R8G8B8A8_UNORM;
-            // Storage images use raw uvec4 channels. Most sampled formats are normalized to RGBA8,
-            // but Float32 stays native so exposure/HDR kernels do not lose sign or dynamic range.
+            // Most storage images use raw uvec4 channels; reflected exact paths keep native-width
+            // bytes. Most sampled formats normalize to RGBA8, while HDR/integer formats stay native.
             const VkDeviceSize sbytes = volume_texels * texel_bytes;
             if (!sbytes || sbytes > kMaxComputeImageBytes) {
                 skip_image(r, "expanded image exceeds the 512 MiB backend bound"); break;
@@ -3558,7 +3575,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     ? 4u : (size_t)cb * nc;
                 const size_t texels = (size_t)volume_texels;
                 const uint64_t linear_guest_bytes = static_cast<uint64_t>(texels) * guest_texel;
-                bi.exact_result_bytes = bi.native_float_storage
+                bi.exact_result_bytes = bi.exact_storage_bytes()
                     ? static_cast<VkDeviceSize>(linear_guest_bytes) : sbytes;
                 size_t guest_bytes = r->tile_mode
                     ? (dim_3d && r->depth > 1
@@ -3605,7 +3622,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                       (r->host_data && r->host_data_size >= guest_bytes) ||
                                       guest_readable(r->gpu_addr, static_cast<uint32_t>(guest_bytes));
                 if (!readable) { skip_image(r, "storage backing unreadable"); break; }
-                // Native storage targets are byte-identical to their sampled view. A raw-uvec4
+                // Exact-width storage targets are byte-identical to guest row-major bytes. A raw-uvec4
                 // target is also safe to retain when seed_skip proves the shader is a full, write-only
                 // producer: the previous raw values are then unobservable, while retaining them lets
                 // the exact GPU comparator recognize a repeated result before CPU pack/retile.
@@ -3616,7 +3633,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                      std::all_of(bi.dcc_metadata, bi.dcc_metadata + bi.dcc_metadata_bytes,
                                  [](uint8_t value) { return value == 0xff; }));
                 bi.cache_candidate = !renderer_owned && !r->host_data && dcc_cache_safe &&
-                    !bi.poison_verify && (bi.native_float_storage || bi.seed_skip) &&
+                    !bi.poison_verify && (bi.exact_storage_bytes() || bi.seed_skip) &&
                     persistent_compute_image_enabled(sbytes, ComputeImageCacheClass::storage);
                 if (bi.cache_candidate) {
                     bi.cache_key = storage_image_cache_key(
@@ -3658,7 +3675,10 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                      bi.binding, (unsigned long long)r->gpu_addr,
                                      r->width, r->height,
                                      live_target.format == LiveTargetPixelFormat::Rgba16Float
-                                         ? "rgba16f" : "rgba8");
+                                         ? "rgba16f"
+                                     : live_target.format ==
+                                           LiveTargetPixelFormat::R11G11B10Float
+                                         ? "r11g11b10" : "rgba8");
                     }
                 } else if (r->tile_mode && dim_3d && r->depth > 1) {
                     if (trace) bi.before_hash = fnv1a(src, guest_bytes);
@@ -3718,7 +3738,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     unpack_source = src;
                 }
                 if (!bi.seed_skip && bi.seed_from_imported == SIZE_MAX) {
-                    if (bi.native_float_storage) {
+                    if (bi.exact_storage_bytes()) {
                         parallel_compute_texels(texels, static_cast<size_t>(linear_guest_bytes) * 2,
                             [&](size_t begin, size_t end) {
                                 std::memcpy(upload + begin * guest_texel,
@@ -3734,7 +3754,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     // writeback restores every un-stored (still-poison) texel from it, so proving
                     // never corrupts the guest -- only the GPU `upload` is poisoned, `linear` is not.
                     bi.seed_linear.assign(unpack_source, unpack_source + linear_size);
-                    if (bi.native_float_storage) {
+                    if (bi.exact_storage_bytes()) {
                         // Transfers preserve this finite, non-special native texel pattern exactly.
                         // A texel that remains all 0x5a after the dispatch was not stored.
                         std::memset(upload, 0x5a, static_cast<size_t>(sbytes));
@@ -3744,7 +3764,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     }
                 }
                 static const bool verify_unpack =
-                    std::getenv("PROSPER_VERIFY_UNPACK") != nullptr && !bi.seed_skip;
+                    std::getenv("PROSPER_VERIFY_UNPACK") != nullptr && !bi.seed_skip &&
+                    !bi.exact_storage_bytes();
                 if (verify_unpack) {
                     // Fail-visible A/B: the specialized range unpack must be bit-identical to the
                     // per-texel path it replaces. Reports the whole divergence (count + first texel)
@@ -4349,9 +4370,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
 
         // Retained writable buffers and storage images can carry an exact prior-result buffer.
         // Compare the current result against it on the GPU, reducing millions of word equalities to
-        // one flag. Native image bytes are canonical; raw-uvec4 image bytes enter this path only for
-        // proven-full write-only targets. The optimization is deliberately limited to whole uvec4s;
-        // unaligned byte counts retain the collision-free CPU comparison below.
+        // one flag. Exact-width image bytes are canonical; raw-uvec4 image bytes enter this path
+        // only for proven-full write-only targets. The optimization is deliberately limited to
+        // whole uvec4s; unaligned byte counts retain the collision-free CPU comparison below.
         struct CompareTarget {
             VkBuffer current = VK_NULL_HANDLE;
             VkBuffer baseline = VK_NULL_HANDLE;
@@ -5035,9 +5056,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                    item.command_order, item.code_addr);
         }
         if (!readback_ok) break;
-        // Storage-image writeback (#590): pack the kernel's raw uvec4 channel texels back into the
-        // guest surface's real format, then restore its linear or 3D tiled address layout and notify
-        // the render side exactly like the buffer path.
+        // Storage-image writeback (#590): copy exact-width texels or pack raw uvec4 channels back
+        // into the guest format, then restore its linear or 3D tiled address layout and notify the
+        // render side exactly like the buffer path.
         for (size_t i = 0; i < images.size() && readback_ok; i++) {
             BoundImage& bi = images[i];
             if (!bi.storage || bi.alias_of != SIZE_MAX || bi.imported) continue;
@@ -5082,7 +5103,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             static const bool direct_tiled_writeback_disabled =
                 std::getenv("PROSPER_NO_DIRECT_TILED_WRITEBACK") != nullptr;
             const bool tile_mapped_bytes = storage_writeback_can_tile_mapped_bytes(
-                bi.native_float_storage, r->tile_mode, bi.poison_verify,
+                bi.exact_storage_bytes(), r->tile_mode, bi.poison_verify,
                 direct_tiled_writeback_disabled);
             std::unique_ptr<uint8_t[]> linear;
             uint8_t* packed = destination;
@@ -5098,7 +5119,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             // that guest memory still contains the prior result, and this dispatch reproduced the
             // same row-major bytes. If either comparison fails, take the ordinary writeback below.
             const bool repeated_output = bi.cache_candidate && bi.persistent &&
-                bi.upload_skipped && bi.native_float_storage &&
+                bi.upload_skipped && bi.exact_storage_bytes() &&
                 ctx.cached_image_result_matches(bi.cache_key, native_texels, linear_bytes);
             if (repeated_output) {
                 if (trace)
@@ -5128,7 +5149,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 poison_texel.assign(texels, 0);
                 for (size_t t = 0; t < texels; ++t) {
                     bool all = true;
-                    if (bi.native_float_storage) {
+                    if (bi.exact_storage_bytes()) {
                         const uint8_t* texel = native_texels + t * guest_texel;
                         for (size_t b = 0; b < guest_texel; ++b)
                             if (texel[b] != 0x5a) all = false;
@@ -5152,7 +5173,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                              survived ? "PARTIAL-COVERAGE (will always seed)" : "full-coverage (seed-skip proven)");
             }
             if (trace) {
-                if (bi.native_float_storage) {
+                if (bi.exact_storage_bytes()) {
                     for (size_t t = 0; t < texels; ++t) {
                         const uint8_t* texel = native_texels + t * guest_texel;
                         for (size_t b = 0; b < guest_texel; ++b)
@@ -5166,7 +5187,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             }
             const auto pack_start = ComputeClock::now();
             static const bool pack_range_enabled = !std::getenv("PROSPER_NO_PACK_RANGE");
-            if (bi.native_float_storage) {
+            if (bi.exact_storage_bytes()) {
                 // The typed Vulkan image has already applied the PS5 descriptor's UNORM/float
                 // conversion. Its transfer bytes are the guest's exact row-major texels. A tiled
                 // non-proving write can feed those bytes straight to the tiler, avoiding a second
@@ -5199,7 +5220,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             }
             const auto pack_done = ComputeClock::now();
             static const bool verify_pack = std::getenv("PROSPER_VERIFY_PACK") != nullptr;
-            if (verify_pack && !bi.native_float_storage) {
+            if (verify_pack && !bi.exact_storage_bytes()) {
                 // Fail-visible A/B (mirrors PROSPER_VERIFY_UNPACK): the specialized range pack must
                 // be bit-identical to the per-texel path it replaces, verified against the real
                 // workload's texels. Logs the clean case too, so a verified run is self-proving.

--- a/prosper/frontends/shared/live_compute.hpp
+++ b/prosper/frontends/shared/live_compute.hpp
@@ -49,11 +49,11 @@ void storage_pack_float16x4_range(const uint32_t* channels, size_t texels, uint8
 // A typed Vulkan storage image already exposes the guest format as exact row-major bytes. For a
 // tiled guest surface the tiler can therefore read the mapped staging image directly, unless a
 // poison-proving dispatch still needs a mutable linear copy to restore untouched texels.
-constexpr bool storage_writeback_can_tile_mapped_bytes(bool native_float_storage,
+constexpr bool storage_writeback_can_tile_mapped_bytes(bool exact_storage_bytes,
                                                        uint32_t tile_mode,
                                                        bool poison_verify,
                                                        bool disabled) {
-    return native_float_storage && tile_mode != 0 && !poison_verify && !disabled;
+    return exact_storage_bytes && tile_mode != 0 && !poison_verify && !disabled;
 }
 
 // Whether a sampled guest view can bind a renderer-owned target without a CPU readback/conversion.

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -186,6 +186,7 @@ struct ShaderCompileKey {
     uint32_t compute_lds_bytes = 0;
     uint32_t compute_native_subgroup_size = 0;
     uint32_t compute_native_storage_format_support = 0;
+    bool compute_packed_r11_storage = true;
     uint32_t vertex_lds_dwords = 0;
     uint32_t vertices_per_instance = 0;
     // Aliases ShaderCodeAnalysis::code and keeps that immutable analysis alive. Warm lookups used to
@@ -235,6 +236,7 @@ struct ShaderCompileKey {
                compute_native_subgroup_size == other.compute_native_subgroup_size &&
                compute_native_storage_format_support ==
                    other.compute_native_storage_format_support &&
+               compute_packed_r11_storage == other.compute_packed_r11_storage &&
                vertex_lds_dwords == other.vertex_lds_dwords &&
                vertices_per_instance == other.vertices_per_instance &&
                resources == other.resources && same_code && same_chain_code;
@@ -297,6 +299,7 @@ struct ShaderCompileKeyHash {
             hash = hash_mix(hash, key.compute_lds_bytes);
             hash = hash_mix(hash, key.compute_native_subgroup_size);
             hash = hash_mix(hash, key.compute_native_storage_format_support);
+            hash = hash_mix(hash, key.compute_packed_r11_storage);
         }
         hash = hash_mix(hash, key.vertex_lds_dwords);
         hash = hash_mix(hash, key.vertices_per_instance);
@@ -902,6 +905,7 @@ ShaderCompileKey make_shader_compile_key(ShaderProgramStage stage, const uint32_
         key.compute_native_subgroup_size = compute_config->native_subgroup_size;
         key.compute_native_storage_format_support =
             compute_config->native_storage_format_support;
+        key.compute_packed_r11_storage = compute_config->packed_r11_storage;
     }
     const std::shared_ptr<const ShaderCodeAnalysis> analysis =
         code && dwords ? analyze_shader_code_cached(code, dwords) : nullptr;
@@ -3795,9 +3799,12 @@ std::vector<ComputeItem> realize_compute_dispatches(
             shared_vulkan.storage_image_write_without_format;
         config.native_storage_format_support = shared_compute_adoptable
             ? shared_vulkan.native_storage_format_support : 0;
+        config.packed_r11_storage =
+            std::getenv("PROSPER_NO_PACKED_R11_STORAGE") == nullptr;
         // Realized captures store SPIR-V but not enough raw compute launch state to recompile a
         // device-specific typed-storage module on replay. Compile capture-bound dispatches through
-        // the portable raw-uvec4 path so optional format support never becomes an artifact ABI.
+        // device-independent storage paths (raw uvec4 or exact packed R32ui), so optional format
+        // support never becomes an artifact ABI.
         const bool capture_bound = std::getenv("PROSPER_GPU_CAPTURE") ||
             std::getenv("PROSPER_GPU_TIMELINE_CAPTURE") ||
             interactive_gpu_capture_armed() || interactive_capture_bundle_active();

--- a/prosper/src/gpu/gpu_timeline.cpp
+++ b/prosper/src/gpu/gpu_timeline.cpp
@@ -242,6 +242,8 @@ struct RuntimeDetailRequest {
     uint32_t bundle_target_height = 0;
     uint32_t bundle_start_target_width = 0;
     uint32_t bundle_start_target_height = 0;
+    uint32_t bundle_start_target_min_index = 0;
+    uint32_t bundle_start_target_max_index = UINT32_MAX;
     uint32_t bundle_checkpoint_interval = 0;
     uint32_t select_target_width = 0;
     uint32_t select_target_height = 0;
@@ -326,6 +328,21 @@ struct RuntimeDetailRequest {
                 } else {
                     bundle_start_target_width = width;
                     bundle_start_target_height = height;
+                }
+            }
+            if (const char* range = std::getenv(
+                    "PROSPER_GPU_TIMELINE_CAPTURE_START_TARGET_DRAW_INDEX")) {
+                unsigned first = 0, last = 0; char tail = 0;
+                if (!bundle_start_target_width ||
+                    std::sscanf(range, "%u:%u%c", &first, &last, &tail) != 2 ||
+                    first > last) {
+                    std::fprintf(stderr,
+                                 "[timeline] capture start target draw index requires "
+                                 "START_TARGET_DIM and a MIN:MAX range\n");
+                    bundle_path.clear(); bundle_depth = 0;
+                } else {
+                    bundle_start_target_min_index = first;
+                    bundle_start_target_max_index = last;
                 }
             }
             if (const char* interval = std::getenv(
@@ -715,9 +732,11 @@ bool hash_guest_backing(uint64_t addr, uint64_t size, uint64_t& hash) {
     return true;
 }
 
-bool runtime_submit_has_target(const GpuState& state, uint32_t width, uint32_t height) {
+bool runtime_submit_has_target(const GpuState& state, uint32_t width, uint32_t height,
+                               uint32_t min_draw = 0, uint32_t max_draw = UINT32_MAX) {
     if (!width || !height) return false;
     for (size_t i = 0; i < state.draws.size(); ++i) {
+        if (i < min_draw || i > max_draw) continue;
         const RenderState rs = extract_render_state(state.state_at_draw(i));
         if (rs.color0_width == width && rs.color0_height == height) return true;
     }
@@ -1756,11 +1775,16 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
     RuntimeProducerHistory& history = runtime_producer_history();
     if (request.valid && request.bundle_start_target_width && !request.bundle_start_reached &&
         runtime_submit_has_target(state, request.bundle_start_target_width,
-                                  request.bundle_start_target_height)) {
+                                  request.bundle_start_target_height,
+                                  request.bundle_start_target_min_index,
+                                  request.bundle_start_target_max_index)) {
         request.bundle_start_reached = true;
-        std::fprintf(stderr, "[timeline] capture bundle start reached submit=%llu target=%ux%u\n",
+        std::fprintf(stderr, "[timeline] capture bundle start reached submit=%llu "
+                     "target=%ux%u target-index=%u..%u\n",
                      static_cast<unsigned long long>(submit_no),
-                     request.bundle_start_target_width, request.bundle_start_target_height);
+                     request.bundle_start_target_width, request.bundle_start_target_height,
+                     request.bundle_start_target_min_index,
+                     request.bundle_start_target_max_index);
     }
     const bool capture_endpoint = request.valid &&
         runtime_capture_endpoint_matches(request, submit, state);

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -86,7 +86,7 @@ enum : uint32_t {
     ImgOp_Offset=0x10,                   // ImageOperands bit: dynamic texel offset (needs ImageGatherExtended)
     Img_Sampled_Storage=2,   // OpTypeImage "Sampled" operand: 2 = used WITHOUT a sampler (read/write storage image)
     ImgFmt_Unknown=0,        // OpTypeImage "Image Format": Unknown (runtime view format; needs the caps above)
-    ImgFmt_R32ui=33,         // exact uint32 storage image format required by image atomics
+    ImgFmt_R32ui=kSpirvImageFormatR32ui, // exact uint32 storage image format required by image atomics
     ImgOp_Bias=1, ImgOp_Lod=2, ImgOp_Grad=4, ImgOp_Sample=0x40,   // ImageOperands bits.
     SC_Workgroup=4, Scope_Device=1, Scope_Workgroup=2, Scope_Subgroup=3,
     MemSem_UniformAcqRel=0x48, MemSem_WGAcqRel=0x108,   // storage-buffer/LDS AcquireRelease semantics
@@ -238,6 +238,7 @@ struct SpirvCompute {
     // subgroup size equal to the PS5 wave. Native votes/scans are then architecture-exact.
     uint32_t native_subgroup_size=0;
     uint32_t native_storage_format_support=0;
+    bool packed_r11_storage=true;
     uint32_t compute_min_subgroup_size=0;             // non-semantic backend contract (4/16/32/64)
     uint32_t fragment_required_subgroup_size=0;       // exact guest-wave contract (32 or 64)
     uint32_t v_subgroupid=0, v_subgroup_localid=0, t_ptr_in_u32=0;
@@ -942,6 +943,77 @@ struct SpirvCompute {
         uint32_t half = ibin(Op_ShiftLeftLogical, raw, uconst(bits == 11 ? 4u : 5u));
         return unpack_half(half, 0);
     }
+    // Round a 24-bit significand right by a dynamic amount using round-to-nearest-even. SPIR-V
+    // shifts by the word width are undefined, so clamp the executed shift and select zero for the
+    // large-shift case (the significand is then strictly below halfway).
+    uint32_t round_shift_even_u32(uint32_t value, uint32_t shift) {
+        const uint32_t safe_shift = uext2(Glsl_UMin, shift, uconst(31));
+        const uint32_t nonzero_shift = uext2(Glsl_UMax, safe_shift, uconst(1));
+        const uint32_t rounded = ibin(Op_ShiftRightLogical, value, nonzero_shift);
+        const uint32_t one_shifted = ibin(Op_ShiftLeftLogical, uconst(1), nonzero_shift);
+        const uint32_t remainder = ibin(
+            Op_BitwiseAnd, value, ibin(Op_ISub, one_shifted, uconst(1)));
+        const uint32_t halfway_shift = ibin(Op_ISub, nonzero_shift, uconst(1));
+        const uint32_t halfway = ibin(Op_ShiftLeftLogical, uconst(1), halfway_shift);
+        const uint32_t above = ucmp(Op_UGreaterThan, remainder, halfway);
+        const uint32_t tie = land(
+            ucmp(Op_IEqual, remainder, halfway),
+            ucmp(Op_INotEqual, ibin(Op_BitwiseAnd, rounded, uconst(1)), uconst(0)));
+        const uint32_t incremented = ibin(Op_IAdd, rounded, sel(lor(above, tie), uconst(1), uconst(0)));
+        const uint32_t finite = sel(ucmp(Op_IEqual, shift, uconst(0)), value, incremented);
+        return sel(ucmp(Op_UGreaterThanEqual, shift, uconst(32)), uconst(0), finite);
+    }
+    // Exact inverse of unpack_ufloat for R11G11B10 stores. This mirrors float_to_f11/f10 without
+    // going through binary16, which would double-round values near the shortened-mantissa ties.
+    uint32_t pack_ufloat(uint32_t bits, uint32_t mantissa_bits) {
+        const uint32_t exponent = bfe_u(bits, uconst(23), uconst(8));
+        const uint32_t mantissa = ibin(Op_BitwiseAnd, bits, uconst(0x7fffff));
+        const uint32_t sign = ibin(Op_ShiftRightLogical, bits, uconst(31));
+        const uint32_t exponent_bits = uconst(0x1fu << mantissa_bits);
+        const uint32_t mantissa_mask = uconst((1u << mantissa_bits) - 1u);
+
+        const uint32_t payload_shifted = ibin(
+            Op_ShiftRightLogical, mantissa, uconst(23u - mantissa_bits));
+        const uint32_t payload = sel(
+            ucmp(Op_IEqual, payload_shifted, uconst(0)), uconst(1), payload_shifted);
+        const uint32_t special = sel(
+            ucmp(Op_IEqual, mantissa, uconst(0)), exponent_bits,
+            ibin(Op_BitwiseOr, exponent_bits, payload));
+
+        const uint32_t significand = ibin(Op_BitwiseOr, uconst(0x800000), mantissa);
+        const uint32_t sub_shift = ibin(
+            Op_ISub, uconst(136u - mantissa_bits), exponent);
+        const uint32_t sub_rounded = round_shift_even_u32(significand, sub_shift);
+        const uint32_t subnormal = sel(
+            ucmp(Op_UGreaterThanEqual, sub_rounded, uconst(1u << mantissa_bits)),
+            uconst(1u << mantissa_bits), sub_rounded);
+
+        const uint32_t normal_rounded = round_shift_even_u32(
+            significand, uconst(23u - mantissa_bits));
+        const uint32_t carry = ucmp(
+            Op_IEqual, normal_rounded, uconst(1u << (mantissa_bits + 1u)));
+        const uint32_t target_exponent = ibin(Op_ISub, exponent, uconst(112));
+        const uint32_t carried_exponent = ibin(
+            Op_IAdd, target_exponent, sel(carry, uconst(1), uconst(0)));
+        const uint32_t carried_mantissa = sel(
+            carry, uconst(0), ibin(Op_BitwiseAnd, normal_rounded, mantissa_mask));
+        const uint32_t normal_finite = ibin(
+            Op_BitwiseOr,
+            ibin(Op_ShiftLeftLogical, carried_exponent, uconst(mantissa_bits)),
+            carried_mantissa);
+        const uint32_t normal = sel(
+            ucmp(Op_UGreaterThanEqual, carried_exponent, uconst(31)),
+            exponent_bits, normal_finite);
+
+        const uint32_t finite = sel(
+            ucmp(Op_ULessThanEqual, exponent, uconst(112)), subnormal,
+            sel(ucmp(Op_UGreaterThanEqual, exponent, uconst(143)), exponent_bits, normal));
+        const uint32_t invalid = lor(
+            ucmp(Op_INotEqual, sign, uconst(0)), ucmp(Op_IEqual, exponent, uconst(0)));
+        const uint32_t ordinary = sel(invalid, uconst(0), finite);
+        // Infinity and NaN are handled before the sign clamp, matching the guest conversion.
+        return sel(ucmp(Op_IEqual, exponent, uconst(0xff)), special, ordinary);
+    }
     // Inverse of unpack_norm: pack a float VGPR (bits) into a `bits`-wide UNORM/SNORM integer field:
     // clamp to [0,1] (unsigned) or [-1,1] (signed), scale by `norm`, round-to-nearest-even, mask to width.
     uint32_t pack_norm(uint32_t fbits, uint32_t bits, bool is_signed, float norm) {
@@ -1341,8 +1413,9 @@ struct SpirvCompute {
     }
 
     // --- STORAGE images (MIMG image_load / image_store WITHOUT a sampler; compute copy/blit) ---
-    // Integer/packed formats use a UINT-sampled OpTypeImage and the host converts between raw VGPR
-    // channels and guest texels. Four-channel UNORM8/FLOAT16/FLOAT32 use a FLOAT-sampled image instead:
+    // Integer/packed formats use a UINT-sampled OpTypeImage. The portable host path converts between
+    // raw VGPR channels and guest texels; the exact R11G11B10 fallback instead packs one R32ui word
+    // in the shader. Four-channel UNORM8/FLOAT16/FLOAT32 use a FLOAT-sampled image instead:
     // Vulkan then performs exactly the descriptor's normalized/float load-store conversion and the
     // host can stage the guest texels at their native width. VGPRs remain raw u32 bits; float image
     // components are bitcast at this boundary. Both paths use Format=Unknown and therefore require
@@ -1355,6 +1428,7 @@ struct SpirvCompute {
     std::unordered_map<uint32_t, uint32_t> stg_img_var;    // binding -> storage-image OpVariable id
     std::unordered_map<uint32_t, bool> stg_img_float;      // binding -> float (rather than uint) texels
     std::unordered_map<uint32_t, uint32_t> stg_img_format; // binding -> SPIR-V Image Format
+    std::unordered_map<uint32_t, bool> stg_img_packed_r11; // binding -> R11G11B10 packed in R32ui
     bool declared_read_wo_fmt = false, declared_write_wo_fmt = false, declared_sampled1d = false, declared_ms = false, declared_msarray = false;
     static uint32_t stg_key(uint32_t dim, bool arrayed, bool ms, bool float_texel,
                             uint32_t image_format) {
@@ -1365,7 +1439,8 @@ struct SpirvCompute {
     // multisampled) at set 0, `binding`. Float and uint sampled types are keyed separately.
     void declare_storage_image(uint32_t binding, uint32_t dim, bool arrayed = false,
                                bool ms = false, bool float_texel = false,
-                               uint32_t image_format = ImgFmt_Unknown) {
+                               uint32_t image_format = ImgFmt_Unknown,
+                               bool packed_r11 = false) {
         if (dim == Dim_1D && !declared_sampled1d) {   // SPIR-V: Dim=1D needs Sampled1D; storage 1D also needs Image1D
             put(caps, Op_Capability, {Cap_Sampled1D});
             put(caps, Op_Capability, {Cap_Image1D});
@@ -1390,6 +1465,7 @@ struct SpirvCompute {
         stg_img_var[binding] = v;
         stg_img_float[binding] = float_texel;
         stg_img_format[binding] = image_format;
+        stg_img_packed_r11[binding] = packed_r11;
     }
     // Build the integer coordinate operand from `n` raw-bit VGPR coords (u32 texel indices, incl. the
     // array layer as the last component for arrayed images). n=1 -> scalar u32; 2 -> uvec2; 3 -> uvec3.
@@ -1430,6 +1506,15 @@ struct SpirvCompute {
         uint32_t res   = id();
         if (ms) put(code, Op_ImageRead, {vector_type, res, img, coord, ImgOp_Sample, sample});
         else    put(code, Op_ImageRead, {vector_type, res, img, coord});
+        if (stg_img_packed_r11[binding]) {
+            uint32_t packed = id();
+            put(code, Op_CompositeExtract, {t_u32, packed, res, 0});
+            out[0] = unpack_ufloat(packed, 0, 11);
+            out[1] = unpack_ufloat(packed, 11, 11);
+            out[2] = unpack_ufloat(packed, 22, 10);
+            out[3] = bcu(fconstf(1.0f));
+            return;
+        }
         for (uint32_t c = 0; c < 4; c++) {
             uint32_t e = id();
             put(code, Op_CompositeExtract, {float_texel ? t_f32 : t_u32, e, res, c});
@@ -1453,7 +1538,14 @@ struct SpirvCompute {
                                     stg_img_var[binding]});
         uint32_t coord = stg_coord(ncoord, coords);
         uint32_t texel = id();
-        if (float_texel)
+        if (stg_img_packed_r11[binding]) {
+            const uint32_t r = pack_ufloat(vals[0], 6);
+            const uint32_t g = ibin(Op_ShiftLeftLogical, pack_ufloat(vals[1], 6), uconst(11));
+            const uint32_t b = ibin(Op_ShiftLeftLogical, pack_ufloat(vals[2], 5), uconst(22));
+            const uint32_t packed = ibin(Op_BitwiseOr, ibin(Op_BitwiseOr, r, g), b);
+            put(code, Op_CompositeConstruct,
+                {t_v4u(), texel, packed, uconst(0), uconst(0), uconst(0)});
+        } else if (float_texel)
             put(code, Op_CompositeConstruct,
                 {t_v4f, texel, bcf(vals[0]), bcf(vals[1]), bcf(vals[2]), bcf(vals[3])});
         else
@@ -8103,6 +8195,9 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     res->format, components, res->srgb,
                     (b.native_storage_format_support &
                      native_storage_format_support_bit(res->format, components)) != 0);
+                const bool packed_r11 = !native_float && b.packed_r11_storage && ordinary_2d &&
+                    !arrayed && !ms && !is_atomic &&
+                    res->format == DataFormat::Float10_11_11 && components == 3;
                 // Existing load/store-only uint images retain the raw uvec4/Format=Unknown contract
                 // used by the compute backend. The atomic's exact R32_UINT gate above is the only path
                 // that opts into a typed R32ui image.
@@ -8115,7 +8210,9 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 } else {
                     const bool native_r32ui = is_atomic;
                     b.declare_storage_image(res->binding, dim, arrayed, ms, native_float,
-                                            native_r32ui ? ImgFmt_R32ui : ImgFmt_Unknown);
+                                            (native_r32ui || packed_r11)
+                                                ? ImgFmt_R32ui : ImgFmt_Unknown,
+                                            packed_r11);
                 }
                 // Coordinate VGPR per axis. Non-NSA (len==2): consecutive from VADDR (src[0]). NSA (len>2):
                 // split across the extra address dwords — coord0 = VADDR, coord k>=1 = byte (k-1) of
@@ -11500,6 +11597,7 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
     b.native_subgroup_size = config.native_subgroup_size == wave_size &&
         local_count <= UINT32_MAX && local_count % wave_size == 0 ? wave_size : 0u;
     b.native_storage_format_support = config.native_storage_format_support;
+    b.packed_r11_storage = config.packed_r11_storage;
     b.begin(1, rt, local_x, local_y, local_z, wave_size,
             static_cast<uint32_t>(config.user_sgprs.size()));
     b.allow_b32_masks = wave_size == 32;

--- a/prosper/src/gpu/rdna2_to_spirv.hpp
+++ b/prosper/src/gpu/rdna2_to_spirv.hpp
@@ -217,6 +217,10 @@ struct ComputeShaderConfig {
     // frontend. Offline callers default to the portable raw path; live execution supplies the exact
     // physical-device mask so unsupported typed formats compile to the raw uvec4 fallback.
     uint32_t native_storage_format_support = 0;
+    // Use an exact typed R32_UINT storage image for R11G11B10 when the device cannot store that
+    // packed float format natively. The generated shader packs/unpacks the guest word in SPIR-V,
+    // avoiding the portable but much wider RGBA32_UINT CPU-conversion interchange format.
+    bool packed_r11_storage = true;
 };
 
 // Translate a game compute program without the synthetic binding-0 input / binding-1 output used by

--- a/prosper/src/gpu/shader_resources.cpp
+++ b/prosper/src/gpu/shader_resources.cpp
@@ -270,6 +270,7 @@ struct TypeInfo {
     uint32_t width = 0;
     uint32_t storage = 0;
     uint32_t image_sampled = 0;
+    uint32_t image_format = 0;
     uint32_t image_dim = 0xFFFFFFFFu;
     bool image_arrayed = false;
     bool image_depth = false;
@@ -541,6 +542,7 @@ DescriptorValidationReport validate_spirv_descriptor_interface(
                     t.image_arrayed = word(in, 4) != 0;
                     t.image_multisampled = word(in, 5) != 0;
                     t.image_sampled = word(in, 6);
+                    t.image_format = word(in, 7);
                     types[word(in, 0)] = t;
                 }
                 break;
@@ -757,12 +759,14 @@ DescriptorValidationReport validate_spirv_descriptor_interface(
         auto si = sets.find(var), bi = bindings.find(var);
         if (si == sets.end() || bi == bindings.end()) { add_malformed(report); continue; }
         uint32_t image_dim = UINT32_MAX;
+        uint32_t image_format = 0;
         bool image_arrayed = false, image_multisampled = false, image_depth = false;
         auto vi = variables.find(var);
         const TypeInfo* image = vi == variables.end()
             ? nullptr : descriptor_image_type(vi->second, types);
         if (image) {
             image_dim = image->image_dim;
+            image_format = image->image_format;
             image_arrayed = image->image_arrayed;
             image_multisampled = image->image_multisampled;
             image_depth = image->image_depth;
@@ -772,7 +776,7 @@ DescriptorValidationReport validate_spirv_descriptor_interface(
                                       written_vars.count(var) != 0,
                                       normalized_sample_vars.count(var) != 0,
                                       texel_access_vars.count(var) != 0,
-                                      storage_float_vars.count(var) != 0, image_dim,
+                                      storage_float_vars.count(var) != 0, image_format, image_dim,
                                       image_arrayed, image_multisampled, image_depth,
                                       atomic_vars.count(var) != 0});
     }

--- a/prosper/src/gpu/shader_resources.hpp
+++ b/prosper/src/gpu/shader_resources.hpp
@@ -341,6 +341,10 @@ enum class SpirvShaderStage : uint32_t {
     Unknown = 0xFFFFFFFFu,
 };
 
+// SPIR-V Image Format operand used by the exact one-word storage fallback. Keep this public so the
+// recompiler, reflection, live backend, and their contract tests cannot drift through magic values.
+constexpr uint32_t kSpirvImageFormatR32ui = 33;
+
 struct SpirvDescriptorBinding {
     uint32_t variable_id = 0;
     uint32_t set = 0;
@@ -364,6 +368,9 @@ struct SpirvDescriptorBinding {
     // Storage-image sampled type encoded by SPIR-V. This is the backend's authoritative choice
     // between a native float VkFormat and the portable raw-uvec4 conversion path, including replay.
     bool storage_float = false;
+    // Raw SPIR-V Image Format operand. Format=R32ui distinguishes exact single-word storage
+    // fallbacks from the wider formatless uvec4 contract during offline replay.
+    uint32_t storage_image_format = 0;
     // Exact OpTypeImage shape. Backends use this instead of guessing from the guest T#: a DIM=5
     // packet may deliberately compile either as the historical base-slice 2D fallback or as a real
     // 2D-array image whose layer coordinate must match a VK_IMAGE_VIEW_TYPE_2D_ARRAY view. It also

--- a/prosper/tests/test_game_compute.cpp
+++ b/prosper/tests/test_game_compute.cpp
@@ -50,7 +50,7 @@ int main() {
           "image residency policy includes each crossover exactly without caching smaller inputs");
     CHECK(prosper::frontend::storage_writeback_can_tile_mapped_bytes(
               true, 27, false, false),
-          "native tiled storage can feed mapped bytes directly to the tiler");
+          "exact-width tiled storage can feed mapped bytes directly to the tiler");
     CHECK(!prosper::frontend::storage_writeback_can_tile_mapped_bytes(
               false, 27, false, false),
           "converted storage retains its mutable packed buffer");
@@ -907,6 +907,119 @@ int main() {
         CHECK(run_format_copy(DataFormat::Float10_11_11, 3, 4, s) == s,
               "R11G11B10 storage copy round-trips native packed texels bit-exact (#590)");
     }
+    {   // No native R11 storage: shader-side R32_UINT packing must preserve every f11 code.
+        constexpr uint32_t PACKED_W = 2048;
+        std::vector<uint32_t> indices(PACKED_W), src(PACKED_W), dst(PACKED_W, 0x5a5a5a5au);
+        for (uint32_t t = 0; t < PACKED_W; ++t) {
+            indices[t] = t;
+            src[t] = t | (((t * 1031u) & 0x7ffu) << 11) | ((t & 0x3ffu) << 22);
+        }
+        ShaderResourceTable packed_rt = irt;
+        for (ShaderResource& resource : packed_rt.resources) {
+            if (resource.binding == 0) {
+                resource.gpu_addr = reinterpret_cast<uint64_t>(indices.data());
+                resource.size = static_cast<uint32_t>(indices.size() * sizeof(uint32_t));
+            }
+            if (resource.binding != 4 && resource.binding != 5) continue;
+            resource.img_dim = 1;
+            resource.format = DataFormat::Float10_11_11;
+            resource.num_components = 3;
+            resource.width = PACKED_W;
+            resource.height = resource.depth = 1;
+            resource.tile_mode = 0;
+            resource.gpu_addr = reinterpret_cast<uint64_t>(
+                resource.binding == 4 ? src.data() : dst.data());
+            resource.size = PACKED_W * sizeof(uint32_t);
+        }
+        const std::vector<uint32_t> packed_spirv = recompile_valu(
+            image_copy_2d, std::size(image_copy_2d), 1, 0, &packed_rt);
+        const auto packed_report = validate_spirv_descriptor_interface(
+            packed_spirv, &packed_rt, 0, SpirvShaderStage::Compute, false);
+        CHECK(!packed_spirv.empty() && packed_report.ok() &&
+                  packed_report.descriptors.size() == 4 &&
+                  packed_report.descriptors[2].storage_image_format == kSpirvImageFormatR32ui &&
+                  packed_report.descriptors[3].storage_image_format == kSpirvImageFormatR32ui,
+              "R11G11B10 fallback recompiles both 2D storage views as typed R32ui");
+        if (!packed_spirv.empty()) {
+            ComputeItem packed_item;
+            packed_item.spirv = packed_spirv;
+            packed_item.resources = std::make_shared<ShaderResourceTable>(packed_rt);
+            packed_item.launch.threads_x = PACKED_W;
+            packed_item.launch.local_x = 64;
+            packed_item.launch.groups_x = PACKED_W / 64;
+            packed_item.launch.local_y = packed_item.launch.local_z = 1;
+            packed_item.launch.groups_y = packed_item.launch.groups_z = 1;
+            packed_item.code_addr = 0x590b10;
+            const bool packed_executed =
+                prosper::frontend::execute_live_compute_items({packed_item});
+            if (packed_executed && dst != src) {
+                const auto mismatch = std::mismatch(src.begin(), src.end(), dst.begin());
+                const size_t index = static_cast<size_t>(mismatch.first - src.begin());
+                std::printf("  packed R11 mismatch texel=%zu src=%08x dst=%08x\n",
+                            index, src[index], dst[index]);
+            }
+            CHECK(packed_executed && dst == src,
+                  "shader-side R11G11B10 pack/unpack round-trips every encoded f11 value exactly");
+        }
+
+        // Also compare arbitrary raw f32 channel bits against the CPU's exact RNE oracle. The
+        // representable-code round-trip above cannot exercise values on either side of a packing
+        // boundary, negative clamping, f32 underflow, overflow, or payload truncation.
+        std::vector<uint32_t> float_channels(PACKED_W * 4), expected(PACKED_W);
+        const uint32_t edge_bits[] = {
+            0x00000000u, 0x00000001u, 0x007fffffu, 0x00800000u,
+            0x80000000u, 0xbf800000u, 0x3f800000u, 0x3f810000u,
+            0x477fe000u, 0x477ff000u, 0x47800000u, 0x7f800000u,
+            0xff800000u, 0x7f800001u, 0x7fc12345u, 0xffc54321u,
+        };
+        auto bits_float = [](uint32_t bits) {
+            float value = 0.0f;
+            std::memcpy(&value, &bits, sizeof(value));
+            return value;
+        };
+        for (uint32_t t = 0; t < PACKED_W; ++t) {
+            for (uint32_t c = 0; c < 4; ++c)
+                float_channels[t * 4 + c] = t < std::size(edge_bits)
+                    ? edge_bits[(t + c * 5u) % std::size(edge_bits)]
+                    : (t * 2654435761u + c * 2246822519u);
+            expected[t] = static_cast<uint32_t>(float_to_f11(
+                              bits_float(float_channels[t * 4 + 0]))) |
+                          (static_cast<uint32_t>(float_to_f11(
+                              bits_float(float_channels[t * 4 + 1]))) << 11) |
+                          (static_cast<uint32_t>(float_to_f10(
+                              bits_float(float_channels[t * 4 + 2]))) << 22);
+        }
+        std::fill(dst.begin(), dst.end(), 0x5a5a5a5au);
+        ShaderResourceTable conversion_rt = packed_rt;
+        for (ShaderResource& resource : conversion_rt.resources) {
+            if (resource.binding != 4 && resource.binding != 5) continue;
+            resource.gpu_addr = reinterpret_cast<uint64_t>(
+                resource.binding == 4 ? float_channels.data() : dst.data());
+            if (resource.binding == 4) {
+                resource.format = DataFormat::Float32;
+                resource.num_components = 4;
+                resource.size = static_cast<uint32_t>(float_channels.size() * sizeof(uint32_t));
+            }
+        }
+        const std::vector<uint32_t> conversion_spirv = recompile_valu(
+            image_copy_2d, std::size(image_copy_2d), 1, 0, &conversion_rt);
+        if (!conversion_spirv.empty()) {
+            ComputeItem conversion_item;
+            conversion_item.spirv = conversion_spirv;
+            conversion_item.resources = std::make_shared<ShaderResourceTable>(conversion_rt);
+            conversion_item.launch.threads_x = PACKED_W;
+            conversion_item.launch.local_x = 64;
+            conversion_item.launch.groups_x = PACKED_W / 64;
+            conversion_item.launch.local_y = conversion_item.launch.local_z = 1;
+            conversion_item.launch.groups_y = conversion_item.launch.groups_z = 1;
+            conversion_item.code_addr = 0x590b11;
+            CHECK(prosper::frontend::execute_live_compute_items({conversion_item}) &&
+                      dst == expected,
+                  "shader-side R11G11B10 packing matches the CPU oracle for arbitrary f32 bits");
+        } else {
+            CHECK(false, "mixed Float32-to-R11G11B10 storage conversion recompiles");
+        }
+    }
 
     // The backend publishes ordinary tiled texels, not hardware-compressed blocks. Prove that a
     // DCC-enabled storage destination atomically becomes the uncompressed (0xff) metadata state,
@@ -1580,6 +1693,72 @@ int main() {
               "writable renderer RTT publishes guest writeback for cache invalidation");
     }
     set_guest_gpu_write_observer({});
+    set_live_target_reader({});
+    set_live_target_query({});
+
+    // The exact packed fallback must obey the same authority rule. Keep stale zeroes in guest RAM,
+    // publish distinct R11G11B10 renderer pixels, overwrite only row zero, and require every other
+    // row to survive from the snapshot rather than the stale allocation.
+    std::vector<uint32_t> packed_rtt_source(W * TILED_H);
+    std::vector<uint32_t> packed_rtt_guest(W * TILED_H, 0);
+    auto packed_rtt = std::make_shared<std::vector<uint8_t>>(W * TILED_H * sizeof(uint32_t));
+    std::vector<uint32_t> packed_rtt_expected(W * TILED_H);
+    for (size_t t = 0; t < packed_rtt_source.size(); ++t) {
+        packed_rtt_source[t] = static_cast<uint32_t>(float_to_f11((t % 19u) * 0.25f)) |
+            (static_cast<uint32_t>(float_to_f11((t % 23u) * 0.375f)) << 11) |
+            (static_cast<uint32_t>(float_to_f10((t % 29u) * 0.5f)) << 22);
+        const uint32_t live_word = static_cast<uint32_t>(float_to_f11((t % 31u) * 0.125f)) |
+            (static_cast<uint32_t>(float_to_f11((t % 37u) * 0.1875f)) << 11) |
+            (static_cast<uint32_t>(float_to_f10((t % 41u) * 0.3125f)) << 22);
+        std::memcpy(packed_rtt->data() + t * sizeof(live_word), &live_word, sizeof(live_word));
+        packed_rtt_expected[t] = live_word;
+    }
+    std::copy_n(packed_rtt_source.begin(), W, packed_rtt_expected.begin());
+    ShaderResourceTable packed_writable_rt = tiled2d_rt;
+    for (ShaderResource& resource : packed_writable_rt.resources) {
+        if (resource.binding != 4 && resource.binding != 5) continue;
+        resource.format = DataFormat::Float10_11_11;
+        resource.num_components = 3;
+        resource.tile_mode = 0;
+        resource.size = W * TILED_H * sizeof(uint32_t);
+        resource.gpu_addr = reinterpret_cast<uint64_t>(
+            resource.binding == 4 ? packed_rtt_source.data() : packed_rtt_guest.data());
+    }
+    const uint64_t packed_writable_addr =
+        reinterpret_cast<uint64_t>(packed_rtt_guest.data());
+    set_live_target_query(
+        [packed_writable_addr](uint64_t addr) { return addr == packed_writable_addr; });
+    set_live_target_reader(
+        [packed_writable_addr, packed_rtt](uint64_t addr, LiveTargetSnapshot& snapshot) {
+            if (addr != packed_writable_addr) return false;
+            snapshot.width = W;
+            snapshot.height = TILED_H;
+            snapshot.format = LiveTargetPixelFormat::R11G11B10Float;
+            snapshot.pixels = packed_rtt;
+            return true;
+        });
+    const std::vector<uint32_t> packed_writable_spirv = recompile_valu(
+        image_copy_2d, std::size(image_copy_2d), 1, 0, &packed_writable_rt);
+    CHECK(!packed_writable_spirv.empty(),
+          "partial R11G11B10 renderer RTT copy kernel recompiles");
+    if (!packed_writable_spirv.empty()) {
+        ComputeItem item;
+        item.spirv = packed_writable_spirv;
+        item.resources = std::make_shared<ShaderResourceTable>(packed_writable_rt);
+        item.launch.threads_x = W;
+        item.launch.local_x = 64;
+        item.launch.groups_x = 1;
+        item.launch.local_y = item.launch.local_z = 1;
+        item.launch.groups_y = item.launch.groups_z = 1;
+        item.code_addr = 0x590b12;
+        CHECK(prosper::frontend::execute_live_compute_items({item}),
+              "live backend partially writes an authoritative packed renderer RTT");
+        CHECK(packed_rtt_guest == packed_rtt_expected,
+              "packed renderer RTT seeds from live pixels and preserves every untouched row");
+        CHECK(std::any_of(packed_rtt_guest.begin() + W, packed_rtt_guest.end(),
+                          [](uint32_t word) { return word != 0; }),
+              "packed renderer RTT never falls back to its stale zeroed guest backing");
+    }
     set_live_target_reader({});
     set_live_target_query({});
 

--- a/prosper/tests/test_gpu_timeline.cpp
+++ b/prosper/tests/test_gpu_timeline.cpp
@@ -211,6 +211,7 @@ int main() {
     _putenv_s("PROSPER_GPU_TIMELINE_CAPTURE_BUNDLE", bundle_capture.c_str());
     _putenv_s("PROSPER_GPU_TIMELINE_CAPTURE_DEPTH", "2");
     _putenv_s("PROSPER_GPU_TIMELINE_CAPTURE_START_TARGET_DIM", "642x362");
+    _putenv_s("PROSPER_GPU_TIMELINE_CAPTURE_START_TARGET_DRAW_INDEX", "1:1");
     _putenv_s("PROSPER_GPU_TIMELINE_CAPTURE_CHECKPOINT_EVERY", "1");
 #else
     setenv("PROSPER_GPU_TIMELINE", runtime.c_str(), 1);
@@ -221,9 +222,14 @@ int main() {
     setenv("PROSPER_GPU_TIMELINE_CAPTURE_BUNDLE", bundle_capture.c_str(), 1);
     setenv("PROSPER_GPU_TIMELINE_CAPTURE_DEPTH", "2", 1);
     setenv("PROSPER_GPU_TIMELINE_CAPTURE_START_TARGET_DIM", "642x362", 1);
+    setenv("PROSPER_GPU_TIMELINE_CAPTURE_START_TARGET_DRAW_INDEX", "1:1", 1);
     setenv("PROSPER_GPU_TIMELINE_CAPTURE_CHECKPOINT_EVERY", "1", 1);
 #endif
     GpuState prestart_state;
+    prestart_state.cx[prosper::agc::Pm4::CB_COLOR0_ATTRIB2] =
+        ((642u - 1u) << 14) | (362u - 1u);
+    prestart_state.draws.push_back({3});
+    prestart_state.draws.back().command_order = 104;
     prestart_state.command_order = 105;
     prestart_state.dma_copies.push_back({0x200000, 0x100000000ull, 16, 0, 104, 0});
     begin_gpu_timeline_submit(40);
@@ -237,6 +243,9 @@ int main() {
     predecessor_state.cx[prosper::agc::Pm4::DB_HTILE_DATA_BASE] = 0x8200;
     predecessor_state.cx[prosper::agc::Pm4::DB_DEPTH_SIZE_XY] = 0x01690281;
     predecessor_state.draws.push_back({3});
+    predecessor_state.draws.back().command_order = 119;
+    predecessor_state.draws.push_back({3});
+    predecessor_state.draws.back().command_order = 120;
     predecessor_state.command_order = 120;
     begin_gpu_timeline_submit(41);
     record_gpu_timeline_submit(predecessor_state, 41);
@@ -267,11 +276,11 @@ int main() {
     CHECK(runtime_timeline.submits[1].depth_surfaces.size() == 1 &&
           runtime_timeline.submits[1].depth_surfaces[0].depth_read_base == 0x700000 &&
           runtime_timeline.submits[1].depth_surfaces[0].htile_data_base == 0x820000 &&
-          runtime_timeline.submits[1].depth_surfaces[0].depth_test_count == 1,
+          runtime_timeline.submits[1].depth_surfaces[0].depth_test_count == 2,
           "runtime timeline extracts compact DS programming without realizing resources");
     CHECK(runtime_timeline.submits[1].target_spans.size() == 1 &&
           runtime_timeline.submits[1].target_spans[0].first_draw == 0 &&
-          runtime_timeline.submits[1].target_spans[0].draw_count == 1 &&
+          runtime_timeline.submits[1].target_spans[0].draw_count == 2 &&
           runtime_timeline.submits[1].target_spans[0].width == 642 &&
           runtime_timeline.submits[1].target_spans[0].height == 362,
           "runtime timeline records compact semantic target spans");
@@ -288,7 +297,7 @@ int main() {
           runtime_bundle.submits[1].submit_index == 42,
           "exact submit selection writes an ordered same-run capture bundle");
     CHECK(runtime_bundle.submits.front().submit_index == 41,
-          "bundle start target excludes earlier nonmatching submits and includes the first writer");
+          "bundle start target draw window excludes an earlier matching extent and includes the first writer");
 
     const auto compat_v2 = base.string() + "-compat-v2.prgtl";
     GpuTimelineWriter compat_writer;

--- a/prosper/tests/test_shader_recompile_cache.cpp
+++ b/prosper/tests/test_shader_recompile_cache.cpp
@@ -544,6 +544,62 @@ int main() {
               stats.misses == 3 && stats.hits == 1 && stats.entries == 3,
           "compute cache separates device-gated typed storage from the raw fallback and sRGB state");
 
+    // The device-independent R11G11B10 path is an explicit A/B contract: enabled modules use one
+    // typed R32ui word per texel, while the recovery switch restores formatless uvec4 conversion.
+    clear_shader_recompile_cache();
+    static const uint32_t kPackedStorageCompute[] = {
+        0x7e080300u, 0x7e0a0280u,
+        0xf0000f08u, 0x00000004u, 0xbf8c3f70u,
+        0xf0200f08u, 0x00020004u, 0xbf810000u,
+    };
+    ShaderResourceTable packed_storage_table;
+    for (uint32_t i = 0; i < 2; ++i) {
+        ShaderResource image;
+        image.cls = ResourceClass::StorageImage;
+        image.format = DataFormat::Float10_11_11;
+        image.num_components = 3;
+        image.img_dim = 1;
+        image.width = 64;
+        image.height = image.depth = 1;
+        image.size = 64 * sizeof(uint32_t);
+        image.binding = 4 + i;
+        image.sgpr_base = i * 8;
+        packed_storage_table.resources.push_back(image);
+    }
+    ComputeShaderConfig packed_storage_config;
+    packed_storage_config.user_sgprs.resize(16);
+    packed_storage_config.local_x = 64;
+    uint64_t packed_storage_identity = 0;
+    const auto packed_storage = recompile_compute_shader_cached(
+        kPackedStorageCompute, std::size(kPackedStorageCompute), &packed_storage_table,
+        packed_storage_config, &packed_storage_identity);
+    packed_storage_config.packed_r11_storage = false;
+    uint64_t converted_storage_identity = 0;
+    const auto converted_storage = recompile_compute_shader_cached(
+        kPackedStorageCompute, std::size(kPackedStorageCompute), &packed_storage_table,
+        packed_storage_config, &converted_storage_identity);
+    packed_storage_config.packed_r11_storage = true;
+    uint64_t repeated_packed_storage_identity = 0;
+    const auto repeated_packed_storage = recompile_compute_shader_cached(
+        kPackedStorageCompute, std::size(kPackedStorageCompute), &packed_storage_table,
+        packed_storage_config, &repeated_packed_storage_identity);
+    const auto packed_storage_report = validate_spirv_descriptor_interface(
+        packed_storage, &packed_storage_table, 0, SpirvShaderStage::Compute, false);
+    const auto converted_storage_report = validate_spirv_descriptor_interface(
+        converted_storage, &packed_storage_table, 0, SpirvShaderStage::Compute, false);
+    stats = shader_recompile_cache_stats();
+    CHECK(!packed_storage.empty() && !converted_storage.empty() &&
+              packed_storage != converted_storage && repeated_packed_storage == packed_storage &&
+              packed_storage_identity != 0 && converted_storage_identity != 0 &&
+              packed_storage_identity != converted_storage_identity &&
+              repeated_packed_storage_identity == packed_storage_identity &&
+              packed_storage_report.descriptors.size() == 2 &&
+              packed_storage_report.descriptors[0].storage_image_format == kSpirvImageFormatR32ui &&
+              converted_storage_report.descriptors.size() == 2 &&
+              converted_storage_report.descriptors[0].storage_image_format == 0 &&
+              stats.misses == 2 && stats.hits == 1 && stats.entries == 2,
+          "compute cache separates exact packed R11 storage from its raw conversion recovery path");
+
     // Compute image atomics embed the runtime R32_UINT extent in the linearized SSBO index and
     // bounds guard. Reusing a module across extents would retain a stale row stride or bounds.
     clear_shader_recompile_cache();

--- a/prosper/tests/test_shader_resources.cpp
+++ b/prosper/tests/test_shader_resources.cpp
@@ -435,6 +435,9 @@ int main() {
               atomic_image_report.descriptors[0].texel_access &&
               !atomic_image_report.descriptors[0].storage_float,
           "image-texel-pointer atomic reflects an exact readable+writable integer storage image");
+    CHECK(atomic_image_report.descriptors.size() == 1 &&
+              atomic_image_report.descriptors[0].storage_image_format == kSpirvImageFormatR32ui,
+          "typed storage-image reflection preserves the exact SPIR-V image format");
     image_table.resources[0].size = 0;
     auto izr = validate_spirv_descriptor_interface(
         image_spv, &image_table, 1, SpirvShaderStage::Fragment);

--- a/prosper/tools/gpu_timeline/README.md
+++ b/prosper/tools/gpu_timeline/README.md
@@ -56,6 +56,7 @@ PROSPER_GPU_TIMELINE_CAPTURE_BUNDLE=/tmp/dead-cells-gameplay.prgbundle \
 PROSPER_GPU_TIMELINE_CAPTURE_DEPTH=1000 \
 PROSPER_GPU_TIMELINE_CAPTURE_MAX_UNIQUE_MB=1024 \
 PROSPER_GPU_TIMELINE_CAPTURE_START_TARGET_DIM=642x362 \
+PROSPER_GPU_TIMELINE_CAPTURE_START_TARGET_DRAW_INDEX=0:8 \
 PROSPER_GPU_TIMELINE_CAPTURE_WHEN_TARGET_DIM=636x420 \
 PROSPER_GPU_TIMELINE_CAPTURE_TARGET_DRAW_INDEX=77:85 \
 PROSPER_GPU_TIMELINE_CAPTURE_MIN_DRAWS=91 \
@@ -188,6 +189,11 @@ unique-byte budget enforcement remains authoritative.
 that writes a target with that extent. Use it when native-speed lifetime evidence identifies the beginning of
 the relevant surface family; earlier submits remain in the timeline but do not perturb progression or consume
 bundle budget. The matching start submit is included.
+
+`PROSPER_GPU_TIMELINE_CAPTURE_START_TARGET_DRAW_INDEX=MIN:MAX` additionally requires that the start extent
+occur in the zero-based semantic draw-index window. Use it when an extent is shared by unrelated boot and
+gameplay passes; it prevents the earlier pass from starting an expensive rolling capture. It requires
+`PROSPER_GPU_TIMELINE_CAPTURE_START_TARGET_DIM` and does not change the independent endpoint selector.
 
 `PROSPER_GPU_TIMELINE_EXIT_AFTER_CAPTURE=1` terminates the process after the selected standalone
 capsule and any requested bundle have been installed successfully. Use it for long captures instead of a


### PR DESCRIPTION
## Summary

- add a device-independent exact storage fallback for 2D R11G11B10 images: shaders pack/unpack one typed R32ui word per texel instead of expanding each texel to formatless RGBA32_UINT
- preserve the reflected SPIR-V Image Format through replay, include the mode in shader-cache identity, and provide PROSPER_NO_PACKED_R11_STORAGE=1 as an A/B recovery path
- treat exact R11G11B10 renderer snapshots as authoritative for matching writable storage views, including partial writes
- add a timeline bundle-start draw-index selector so captures can distinguish identically sized boot and gameplay targets

This is generic format/device behavior. It contains no title, shader-address, output, scaling, or submit-skipping special case.

Refs #1390.

## Why

On RADV Strix Halo, VK_FORMAT_B10G11R11_UFLOAT_PACK32 is not available for storage images. The portable fallback expanded each 3840x2160 guest surface from 4 bytes to 16 bytes per texel and performed CPU conversion over all 8.3 million texels on upload and writeback.

The new fallback keeps the guest's exact 32-bit packed word in VK_FORMAT_R32_UINT. Loads unpack R11/G11/B10 in SPIR-V; stores use exact round-to-nearest-even packing that matches the existing CPU oracle, including subnormals, ties, carry/overflow, infinities, NaN payloads, and negative clamping.

## Replay evidence

Fresh rolling capture:

- 52 contiguous submits through the selected endpoint
- endpoint realizes 52/54 semantic draws (the two omitted operations are intentionally no-effect) and 27/27 dispatches
- full-resolution output: 3840x2160
- baseline and final BMP SHA-256 are identical:
  fe56d0d4b527f356d2d985925741c58f2d2a065903e287f251217a0c44c4b8b0
- renderer endpoint hash is also unchanged:
  cf0353d2bdb3143c

Final warm-frame compute phases:

| shader | baseline total | packed total | baseline writeback/pack | packed writeback/pack |
|---|---:|---:|---:|---:|
| 0x3017580000 | 69.56 ms | 19.20 ms | 47.84 / 44.61 ms | 3.75 / 0.00 ms |
| 0x3015770000 | 103.44 ms | 28.65 ms | 71.17 / 66.95 ms | 3.91 / 0.11 ms |

Those two passes fall from 173.00 ms to 47.85 ms combined: 125.15 ms removed, or 72.3%.

The next measured bottleneck is intentionally left for follow-up: 0x30180d0000 remains 76.14 ms, including 55.35 ms setup for its sampled-image import.

## Correctness coverage

- real Vulkan execution round-trips every one of the 2,048 possible f11 encodings
- arbitrary raw f32 inputs match float_to_f11/float_to_f10 exactly, including edge cases and pseudorandom bit patterns
- reflection proves the typed R32ui image contract
- shader cache tests prove exact-packed and raw-recovery modules cannot alias
- a stale-guest regression proves a partial storage write seeds untouched rows from the authoritative R11G11B10 renderer snapshot
- timeline tests prove the start draw-index window excludes an earlier target with the same extent
- independent renderer review approved the amended patch after identifying and verifying the authoritative-snapshot regression

## Validation

- complete project build succeeds
- 154/154 applicable CTest tests pass
- test_shader_resources
- test_shader_recompile_cache
- test_game_compute on AMD Radeon 8060S / RADV
- test_gpu_timeline
- test_rdna2_spirv_struct
- full test_rdna2_to_spirv Vulkan execution suite
- final gpu_replay after review reproduces the exact baseline BMP hash

The build is configured against the Plucky dump, so the three dump-specific gates that expect another fixture are not applicable locally:

- module_loads_eboot expects a different import count
- boot_reaches_first_syscall expects Media/Modules/Il2cppUserAssemblies.prx, absent from this dump
- real_shader_render expects that other fixture's embedded shader blobs

All other 154 tests pass.