### PR TITLE
gpu: reuse normalized RGBA8 render-target values

### DIFF
--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -141,16 +141,26 @@ uint8_t sampled_float16_to_unorm8(uint16_t half_bits) {
 }
 
 bool direct_sampled_rtt_compatible(prosper::gpu::DataFormat format, uint32_t components,
-                                   prosper::gpu::LiveTargetPixelFormat target_format) {
+                                   prosper::gpu::LiveTargetPixelFormat target_format,
+                                   bool normalized_sampling) {
     using prosper::gpu::DataFormat;
     using prosper::gpu::LiveTargetPixelFormat;
-    return (components == 4 &&
-            ((format == DataFormat::Unorm8 &&
-              target_format == LiveTargetPixelFormat::Rgba8Unorm) ||
-             (format == DataFormat::Float16 &&
-              target_format == LiveTargetPixelFormat::Rgba16Float))) ||
-           (components == 3 && format == DataFormat::Float10_11_11 &&
-            target_format == LiveTargetPixelFormat::R11G11B10Float);
+    const bool exact =
+        (components == 4 &&
+         ((format == DataFormat::Unorm8 &&
+           target_format == LiveTargetPixelFormat::Rgba8Unorm) ||
+          (format == DataFormat::Float16 &&
+           target_format == LiveTargetPixelFormat::Rgba16Float))) ||
+        (components == 3 && format == DataFormat::Float10_11_11 &&
+         target_format == LiveTargetPixelFormat::R11G11B10Float);
+    // The renderer's RGBA8 fallback already stores the numeric UNORM value. Expanding each byte to
+    // uint16 as byte*257 and sampling R16_UNORM produces exactly byte/255 again, so a shader that
+    // uses only normalized sample/gather operations may bind the RGBA8 image directly. Other image
+    // data-access contracts are deliberately left on the converted exact-format path.
+    const bool normalized_unorm = normalized_sampling && components == 4 &&
+        format == DataFormat::Unorm16 &&
+        target_format == LiveTargetPixelFormat::Rgba8Unorm;
+    return exact || normalized_unorm;
 }
 
 namespace {
@@ -1884,6 +1894,7 @@ struct BoundImage {
     bool storage = false;               // storage image: read back + pack to guest after the dispatch
     bool native_float_storage = false;  // Vulkan performs exact UNORM/float conversion at native width
     bool packed_r11_storage = false;    // shader packs exact R11G11B10 words into typed R32_UINT
+    bool normalized_unorm_rtt = false;  // normalized R16 view reuses authoritative RGBA8 values
     bool graphics_sampled_usage = false;// native image was created with SAMPLED usage for export
     bool exact_storage_bytes() const { return native_float_storage || packed_r11_storage; }
     uint32_t texel_depth = 1;           // logical Z/layer count represented in the staging buffer
@@ -2853,6 +2864,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 const long v = e ? std::strtol(e, nullptr, 10) : 1;
                 return v > 0 ? static_cast<uint32_t>(v) : 1u;
             }();
+            static const bool normalized_unorm_bind_enabled =
+                std::getenv("PROSPER_NO_NORMALIZED_UNORM_RTT_BIND") == nullptr;
             if (renderer_owned && (dim_3d || dim_2d_array || r->depth != 1)) {
                 // The renderer cache represents one concrete 2D color image. An address match from
                 // a 3D/layered descriptor is therefore a resource-lifetime alias, not that cached
@@ -2885,12 +2898,15 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 !dim_1d && !dim_3d && !dim_2d_array &&
                 r->depth == 1 && !r->depth_compare) {
                 LiveTargetImageImport import;
-                const bool normalized_sampling =
+                const bool scalable_normalized_sampling =
                     image_descriptors[i].normalized_sampling &&
                     !image_descriptors[i].texel_access;
+                const bool format_normalized_sampling =
+                    image_descriptors[i].normalized_sampling &&
+                    !image_descriptors[i].unnormalized_texel_access;
                 const LiveTargetImageRequest import_request{
                     r->width, r->height, render_scale, depth_import_eligible,
-                    normalized_sampling};
+                    scalable_normalized_sampling};
                 const bool import_available = import_live_render_target_image(
                     r->gpu_addr, import_request, import);
                 if (trace)
@@ -2915,13 +2931,14 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                depth_format == VK_FORMAT_D32_SFLOAT_S8_UINT)
                         : direct_sampled_rtt_compatible(
                               r->format, r->num_components ? r->num_components : 1,
-                              import.format);
+                              import.format,
+                              format_normalized_sampling && normalized_unorm_bind_enabled);
                     const bool compatible_device =
                         import.device == static_cast<void*>(ctx.device);
                     const bool direct_extent =
                         prosper::frontend::rtt_direct_import_compatible(
                             bi.storage, r->width, r->height, import.width, import.height,
-                            render_scale, normalized_sampling);
+                            render_scale, scalable_normalized_sampling);
                     if (compatible_format && direct_extent && compatible_device) {
                         bi.imported = true;
                         bi.imported_depth = depth_import;
@@ -3175,6 +3192,14 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                          (unsigned)r->format, nc);
                     }
                 }
+                bi.normalized_unorm_rtt = renderer_owned && !bi.storage &&
+                    r->format == DataFormat::Unorm16 &&
+                    direct_sampled_rtt_compatible(
+                        r->format, r->num_components ? r->num_components : 1u,
+                        live_target.format,
+                        normalized_unorm_bind_enabled &&
+                            image_descriptors[i].normalized_sampling &&
+                            !image_descriptors[i].unnormalized_texel_access);
             }
             // Exact descriptor aliases share one Vulkan image. Storage aliases must observe the same
             // read/modify/write state and produce one guest writeback; sampled aliases avoid repeatedly
@@ -3182,6 +3207,18 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             for (size_t j = 0; j < i; j++) {
                 const BoundImage& prior = images[j];
                 const ShaderResource* p = prior.resource;
+                // Identical guest descriptors can appear at multiple bindings with different
+                // reflected access contracts. Do not fold an exact R16 upload into the normalized
+                // RGBA8 representation (or vice versa), and only share borrowed renderer images
+                // when both bindings acquired the same concrete image/view format.
+                const bool same_backing_representation =
+                    prior.imported == bi.imported &&
+                    prior.normalized_unorm_rtt == bi.normalized_unorm_rtt &&
+                    (!bi.imported ||
+                     (prior.image == bi.image &&
+                      prior.imported_depth == bi.imported_depth &&
+                      prior.imported_format == bi.imported_format &&
+                      prior.imported_pixel_format == bi.imported_pixel_format));
                 const bool same_dcc_identity = p &&
                     p->max_uncompressed_block_size == r->max_uncompressed_block_size &&
                     p->max_compressed_block_size == r->max_compressed_block_size &&
@@ -3194,7 +3231,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     p->dcc_metadata_size == r->dcc_metadata_size &&
                     p->dcc_metadata_host_data == r->dcc_metadata_host_data &&
                     p->dcc_metadata_host_data_size == r->dcc_metadata_host_data_size;
-                const bool same_view = p && prior.storage == bi.storage &&
+                const bool same_view = p && same_backing_representation &&
+                    prior.storage == bi.storage &&
                     p->gpu_addr == r->gpu_addr && p->size == r->size &&
                     p->width == r->width && p->height == r->height && p->depth == r->depth &&
                     prior.texel_depth == bi.texel_depth && prior.array_layers == bi.array_layers &&
@@ -3296,7 +3334,12 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 ? (r->format == DataFormat::Float10_11_11
                        ? 4u : data_format_bytes(r->format) * sampled_components)
                 : 0u;
-            const uint32_t texel_bytes = bi.exact_storage_bytes() ? native_storage_bytes
+            const uint32_t imported_color_bytes = bi.imported && !bi.imported_depth
+                ? (bi.imported_pixel_format == LiveTargetPixelFormat::Rgba16Float ? 8u : 4u)
+                : 0u;
+            const uint32_t texel_bytes = imported_color_bytes ? imported_color_bytes
+                                         : bi.normalized_unorm_rtt ? 4u
+                                         : bi.exact_storage_bytes() ? native_storage_bytes
                                          : bi.storage ? 16u
                                          : sampled_float32_native ? sampled_components * 4u
                                          : sampled_float32 ? 16u
@@ -3310,6 +3353,13 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             const bool sampled_r11g11b10 = !bi.storage &&
                 r->format == DataFormat::Float10_11_11 && sampled_components == 3;
             const VkFormat image_format = bi.imported_depth ? bi.imported_format
+                : bi.imported
+                    ? (bi.imported_pixel_format == LiveTargetPixelFormat::Rgba16Float
+                           ? VK_FORMAT_R16G16B16A16_SFLOAT
+                       : bi.imported_pixel_format == LiveTargetPixelFormat::R11G11B10Float
+                           ? VK_FORMAT_B10G11R11_UFLOAT_PACK32
+                           : VK_FORMAT_R8G8B8A8_UNORM)
+                : bi.normalized_unorm_rtt ? VK_FORMAT_R8G8B8A8_UNORM
                 : bi.packed_r11_storage ? VK_FORMAT_R32_UINT
                 : bi.native_float_storage
                 ? (r->format == DataFormat::Unorm8
@@ -3804,7 +3854,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 const bool r11g11b10 = sampled_r11g11b10;
                 if (renderer_owned) {
                     const std::vector<uint8_t>& pixels = *live_target.pixels;
-                    if (r11g11b10) {
+                    if (bi.normalized_unorm_rtt) {
+                        std::memcpy(upload, pixels.data(), upload_size);
+                    } else if (r11g11b10) {
                         if (!pack_live_target_r11g11b10(live_target, upload, upload_size)) {
                             skip_image(r, "renderer RTT R11G11B10 reconstruction failed");
                             break;
@@ -4219,11 +4271,16 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             if (image_timing)
                 std::fprintf(stderr,
                              "[compute-image] code=0x%llx binding=%u class=%s imported=%u "
-                             "extent=%ux%ux%u guest=%zu staging=%llu ms=%.3f\n",
+                             "extent=%ux%ux%u guest=%zu staging=%llu "
+                             "normalized=%u texel=%u unnormalized-data=%u rgba8-reuse=%u ms=%.3f\n",
                              (unsigned long long)item.code_addr, bi.binding,
                              bi.storage ? "storage" : "sampled", bi.imported ? 1u : 0u,
                              r->width, r->height, r->depth, bi.guest_bytes,
                              (unsigned long long)sbytes,
+                             image_descriptors[i].normalized_sampling ? 1u : 0u,
+                             image_descriptors[i].texel_access ? 1u : 0u,
+                             image_descriptors[i].unnormalized_texel_access ? 1u : 0u,
+                             bi.normalized_unorm_rtt ? 1u : 0u,
                              std::chrono::duration<double, std::milli>(
                                  ComputeClock::now() - image_start).count());
         }

--- a/prosper/frontends/shared/live_compute.hpp
+++ b/prosper/frontends/shared/live_compute.hpp
@@ -57,10 +57,11 @@ constexpr bool storage_writeback_can_tile_mapped_bytes(bool exact_storage_bytes,
 }
 
 // Whether a sampled guest view can bind a renderer-owned target without a CPU readback/conversion.
-// The formats must describe the same Vulkan texels exactly; aliases or numeric conversions fall back
-// to the snapshot upload path.
+// Exact Vulkan formats may always be reused. The sole cross-format case is RGBA16_UNORM backed by
+// canonical RGBA8 values, and only when reflection proves a normalized sample/gather-only contract.
 bool direct_sampled_rtt_compatible(prosper::gpu::DataFormat format, uint32_t components,
-                                   prosper::gpu::LiveTargetPixelFormat target_format);
+                                   prosper::gpu::LiveTargetPixelFormat target_format,
+                                   bool normalized_sampling);
 
 // Reconstruct a packed R11G11B10 sampled surface from the renderer's canonical color snapshot.
 // The renderer keeps float targets as RGBA16F and ordinary targets as RGBA8; compute descriptors

--- a/prosper/src/gpu/shader_resources.cpp
+++ b/prosper/src/gpu/shader_resources.cpp
@@ -607,6 +607,7 @@ DescriptorValidationReport validate_spirv_descriptor_interface(
     std::set<uint32_t> atomic_vars;
     std::set<uint32_t> normalized_sample_vars;
     std::set<uint32_t> texel_access_vars;
+    std::set<uint32_t> unnormalized_texel_access_vars;
     std::unordered_map<uint32_t, PointerAccess> accesses;
     // Result id of OpLoad/OpSampledImage -> descriptor variable. An image descriptor load accesses
     // the descriptor object, not its texels; only the later image opcode establishes read/write data
@@ -662,6 +663,7 @@ DescriptorValidationReport validate_spirv_descriptor_interface(
                 access.pointee_type = pointer_type->second.element;
                 accesses[result] = access;
                 texel_access_vars.insert(image_var);
+                unnormalized_texel_access_vars.insert(image_var);
             }
         } else if (in.opcode == OpLoad && n >= 3) {
             const uint32_t root = pointer_root(word(in, 2));
@@ -694,9 +696,14 @@ DescriptorValidationReport validate_spirv_descriptor_interface(
             // OpImageSample* (87..94) and Gather/DrefGather (96..97) consume normalized sampler
             // coordinates. OpImageFetch (95) and OpImageRead (98) consume integer texel coordinates
             // and therefore cannot observe a reduced render target as if it had the native extent.
-            mark_image_coordinate_contract(
-                word(in, 2), (in.opcode >= 87u && in.opcode <= 94u) ||
-                                 in.opcode == 96u || in.opcode == 97u);
+            const bool normalized = (in.opcode >= 87u && in.opcode <= 94u) ||
+                                    in.opcode == 96u || in.opcode == 97u;
+            mark_image_coordinate_contract(word(in, 2), normalized);
+            if (!normalized) {
+                auto origin = image_objects.find(word(in, 2));
+                if (origin != image_objects.end())
+                    unnormalized_texel_access_vars.insert(origin->second);
+            }
         } else if (in.opcode == 99u /* OpImageWrite */ && n >= 1) {
             mark_image(word(in, 0), false, true);
         } else if (in.opcode == 100u /* OpImage */ && n >= 3) {
@@ -776,6 +783,7 @@ DescriptorValidationReport validate_spirv_descriptor_interface(
                                       written_vars.count(var) != 0,
                                       normalized_sample_vars.count(var) != 0,
                                       texel_access_vars.count(var) != 0,
+                                      unnormalized_texel_access_vars.count(var) != 0,
                                       storage_float_vars.count(var) != 0, image_format, image_dim,
                                       image_arrayed, image_multisampled, image_depth,
                                       atomic_vars.count(var) != 0});

--- a/prosper/src/gpu/shader_resources.hpp
+++ b/prosper/src/gpu/shader_resources.hpp
@@ -365,6 +365,9 @@ struct SpirvDescriptorBinding {
     // descriptor's exact declared extent. A binding can use both, in which case exact extent wins.
     bool normalized_sampling = false;
     bool texel_access = false;
+    // True only for data reads that consume integer texel coordinates (OpImageFetch/Read), not
+    // size/LOD queries. A query requires the exact extent but does not observe texel format/width.
+    bool unnormalized_texel_access = false;
     // Storage-image sampled type encoded by SPIR-V. This is the backend's authoritative choice
     // between a native float VkFormat and the portable raw-uvec4 conversion path, including replay.
     bool storage_float = false;

--- a/prosper/tests/test_game_compute.cpp
+++ b/prosper/tests/test_game_compute.cpp
@@ -170,19 +170,26 @@ int main() {
 
     using prosper::frontend::direct_sampled_rtt_compatible;
     CHECK(direct_sampled_rtt_compatible(DataFormat::Unorm8, 4,
-                                        LiveTargetPixelFormat::Rgba8Unorm) &&
+                                        LiveTargetPixelFormat::Rgba8Unorm, false) &&
           direct_sampled_rtt_compatible(DataFormat::Float16, 4,
-                                        LiveTargetPixelFormat::Rgba16Float) &&
+                                        LiveTargetPixelFormat::Rgba16Float, false) &&
           direct_sampled_rtt_compatible(DataFormat::Float10_11_11, 3,
-                                        LiveTargetPixelFormat::R11G11B10Float),
+                                        LiveTargetPixelFormat::R11G11B10Float, false),
           "renderer RTT direct bind accepts exact RGBA8, RGBA16F, and R11G11B10 views");
     CHECK(!direct_sampled_rtt_compatible(DataFormat::Float16, 4,
-                                         LiveTargetPixelFormat::Rgba8Unorm) &&
+                                         LiveTargetPixelFormat::Rgba8Unorm, true) &&
           !direct_sampled_rtt_compatible(DataFormat::Unorm8, 4,
-                                         LiveTargetPixelFormat::Rgba16Float) &&
+                                         LiveTargetPixelFormat::Rgba16Float, true) &&
           !direct_sampled_rtt_compatible(DataFormat::Float16, 2,
-                                         LiveTargetPixelFormat::Rgba16Float),
+                                         LiveTargetPixelFormat::Rgba16Float, true),
           "renderer RTT direct bind rejects format conversion and component aliases");
+    CHECK(direct_sampled_rtt_compatible(DataFormat::Unorm16, 4,
+                                        LiveTargetPixelFormat::Rgba8Unorm, true) &&
+          !direct_sampled_rtt_compatible(DataFormat::Unorm16, 4,
+                                         LiveTargetPixelFormat::Rgba8Unorm, false) &&
+          !direct_sampled_rtt_compatible(DataFormat::Unorm16, 2,
+                                         LiveTargetPixelFormat::Rgba8Unorm, true),
+          "normalized-only RGBA16-UNORM sampling may reuse RGBA8 without widening texels");
     // A renderer-owned target is stored canonically as RGBA8 or RGBA16F, while a later compute
     // descriptor can alias it as packed R11G11B10. Reconstruct the descriptor-visible words rather
     // than sampling stale guest backing or dropping the dispatch.

--- a/prosper/tests/test_shader_resources.cpp
+++ b/prosper/tests/test_shader_resources.cpp
@@ -71,6 +71,19 @@ static std::vector<uint32_t> image_fetch_test_spirv() {
     return s;
 }
 
+static std::vector<uint32_t> image_sample_fetch_test_spirv() {
+    std::vector<uint32_t> s = image_test_spirv();
+    emit(s, 95, {1, 9, 6, 8});                             // %9 = OpImageFetch %6
+    return s;
+}
+
+static std::vector<uint32_t> image_sample_query_test_spirv() {
+    std::vector<uint32_t> s = image_test_spirv();
+    emit(s, 100, {2, 9, 6});                               // %9 = OpImage %6
+    emit(s, 106, {1, 10, 9});                              // %10 = OpImageQueryLevels %9
+    return s;
+}
+
 static std::vector<uint32_t> image_query_test_spirv() {
     std::vector<uint32_t> s = {0x07230203u, 0x00010000u, 0, 16, 0};
     emit(s, 15, {5, 12, 0x6e69616d, 0});                    // OpEntryPoint Compute %12 "main"
@@ -375,6 +388,7 @@ int main() {
     CHECK(ir.ok() && ir.descriptors.size() == 1 &&
           ir.descriptors[0].kind == SpirvDescriptorKind::CombinedImageSampler &&
           ir.descriptors[0].normalized_sampling && !ir.descriptors[0].texel_access &&
+          !ir.descriptors[0].unnormalized_texel_access &&
           ir.descriptors[0].image_dim == 1 && !ir.descriptors[0].image_arrayed &&
           !ir.descriptors[0].image_multisampled,
           "sampled-image reflection validates its concrete 2D non-array texture binding");
@@ -384,15 +398,31 @@ int main() {
         image_fetch_test_spirv(), &image_table, 1, SpirvShaderStage::Fragment);
     CHECK(fetch_report.ok() && fetch_report.descriptors.size() == 1 &&
               !fetch_report.descriptors[0].normalized_sampling &&
-              fetch_report.descriptors[0].texel_access,
+              fetch_report.descriptors[0].texel_access &&
+              fetch_report.descriptors[0].unnormalized_texel_access,
           "OpImageFetch reflection requires the descriptor's exact texel extent");
+    const auto mixed_access_report = validate_spirv_descriptor_interface(
+        image_sample_fetch_test_spirv(), &image_table, 1, SpirvShaderStage::Fragment);
+    CHECK(mixed_access_report.ok() && mixed_access_report.descriptors.size() == 1 &&
+              mixed_access_report.descriptors[0].normalized_sampling &&
+              mixed_access_report.descriptors[0].texel_access &&
+              mixed_access_report.descriptors[0].unnormalized_texel_access,
+          "a normalized sample does not hide an unnormalized texel read on the same image");
     const auto query_report = validate_spirv_descriptor_interface(
         image_query_test_spirv(), &image_table, 0, SpirvShaderStage::Compute);
     CHECK(query_report.ok() && query_report.descriptors.size() == 1 &&
               query_report.descriptors[0].readable &&
               !query_report.descriptors[0].normalized_sampling &&
-              query_report.descriptors[0].texel_access,
+              query_report.descriptors[0].texel_access &&
+              !query_report.descriptors[0].unnormalized_texel_access,
           "query-only sampled images stay reflected and require their exact guest extent");
+    const auto sample_query_report = validate_spirv_descriptor_interface(
+        image_sample_query_test_spirv(), &image_table, 1, SpirvShaderStage::Fragment);
+    CHECK(sample_query_report.ok() && sample_query_report.descriptors.size() == 1 &&
+              sample_query_report.descriptors[0].normalized_sampling &&
+              sample_query_report.descriptors[0].texel_access &&
+              !sample_query_report.descriptors[0].unnormalized_texel_access,
+          "image queries preserve exact-extent requirements without blocking normalized values");
 
     ShaderResource storage_src{};
     storage_src.cls = ResourceClass::StorageImage; storage_src.binding = 5;


### PR DESCRIPTION
Refs #1390

## Failure scenario

Plucky Squire compute program `0x30180d0000` samples binding 22 as a 3840x2160 `Unorm16x4` image. The authoritative renderer snapshot is canonical RGBA8, so the backend widened every byte to `byte * 257`, allocated/uploaded 66.4 MB, and spent about 24 ms per full-resolution submission reconstructing values that normalize back to the original `byte / 255`.

## Behavioral contract

An RGBA8 renderer target may satisfy a logical RGBA16_UNORM sampled view only when SPIR-V reflection proves that binding uses normalized sample/gather data access and no `OpImageFetch`, `OpImageRead`, or texel-pointer access. Image queries remain allowed for the value-format optimization, but continue to require the exact guest extent.

This is exact for canonical renderer values:

```
(byte * 257) / 65535 == byte / 255
```

Storage images, integer-coordinate data reads, non-RGBA views, and unrelated formats retain their existing exact-format paths.

## Implementation

- distinguish unnormalized image data reads from extent/LOD queries in descriptor reflection;
- bind/upload canonical RGBA8 directly for the proven normalized RGBA16_UNORM case;
- use the renderer image's actual Vulkan format and byte width for direct imports;
- prevent alias folding across bindings with different reflected representations;
- expose `PROSPER_NO_NORMALIZED_UNORM_RTT_BIND=1` as an A/B recovery switch;
- add reflection tests for sample-only, fetch-only, mixed sample+fetch, query-only, and sample+query contracts, plus format compatibility tests.

## Verification

Exact head: `b1afc864c28d642267385baaf6b9438ed63e7ce6`

- `cmake --build . -j8` — pass
- `ctest --output-on-failure -j8` — 154/157 applicable tests pass. The three failures are pre-existing dump-selection guards because this worktree is configured against the Plucky Squire dump:
  - `module_loads_eboot`
  - `boot_reaches_first_syscall`
  - `real_shader_render`
- `test_shader_resources` — pass
- `test_game_compute` — pass
- enabled and recovery-disabled replay of `window.prgbundle` both produce exact BMP SHA-256:
  `fe56d0d4b527f356d2d985925741c58f2d2a065903e287f251217a0c44c4b8b0`

Five full-resolution A/B submissions:

| Metric | Recovery-disabled | Enabled | Change |
|---|---:|---:|---:|
| binding 22 setup | 23.8 ms avg | 1.6 ms avg | -93% |
| staging bytes | 66,355,200 | 33,177,600 | -50% |
| matching pass total | 80.4 ms avg | 57.3 ms avg | -29% |

The replay output is byte-identical, so there is no changed screenshot to attach.