### PR TITLE
gpu: reuse RGBA8 values for float texel fetch

### DIFF
--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -142,7 +142,7 @@ uint8_t sampled_float16_to_unorm8(uint16_t half_bits) {
 
 bool direct_sampled_rtt_compatible(prosper::gpu::DataFormat format, uint32_t components,
                                    prosper::gpu::LiveTargetPixelFormat target_format,
-                                   bool normalized_sampling) {
+                                   bool float_sampled_values) {
     using prosper::gpu::DataFormat;
     using prosper::gpu::LiveTargetPixelFormat;
     const bool exact =
@@ -154,13 +154,14 @@ bool direct_sampled_rtt_compatible(prosper::gpu::DataFormat format, uint32_t com
         (components == 3 && format == DataFormat::Float10_11_11 &&
          target_format == LiveTargetPixelFormat::R11G11B10Float);
     // The renderer's RGBA8 fallback already stores the numeric UNORM value. Expanding each byte to
-    // uint16 as byte*257 and sampling R16_UNORM produces exactly byte/255 again, so a shader that
-    // uses only normalized sample/gather operations may bind the RGBA8 image directly. Other image
-    // data-access contracts are deliberately left on the converted exact-format path.
-    const bool normalized_unorm = normalized_sampling && components == 4 &&
+    // uint16 as byte*257 and reading R16_UNORM produces exactly byte/255 again. Vulkan performs
+    // that UNORM-to-float conversion for normalized sampling and integer-coordinate OpImageFetch,
+    // so either operation may consume the canonical RGBA8 image. Coordinate/extent compatibility
+    // is checked separately before a renderer image is borrowed.
+    const bool equivalent_unorm_values = float_sampled_values && components == 4 &&
         format == DataFormat::Unorm16 &&
         target_format == LiveTargetPixelFormat::Rgba8Unorm;
-    return exact || normalized_unorm;
+    return exact || equivalent_unorm_values;
 }
 
 namespace {
@@ -1894,7 +1895,7 @@ struct BoundImage {
     bool storage = false;               // storage image: read back + pack to guest after the dispatch
     bool native_float_storage = false;  // Vulkan performs exact UNORM/float conversion at native width
     bool packed_r11_storage = false;    // shader packs exact R11G11B10 words into typed R32_UINT
-    bool normalized_unorm_rtt = false;  // normalized R16 view reuses authoritative RGBA8 values
+    bool unorm_rtt_value_reuse = false; // float R16 view reuses authoritative RGBA8 values
     bool graphics_sampled_usage = false;// native image was created with SAMPLED usage for export
     bool exact_storage_bytes() const { return native_float_storage || packed_r11_storage; }
     uint32_t texel_depth = 1;           // logical Z/layer count represented in the staging buffer
@@ -2864,7 +2865,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 const long v = e ? std::strtol(e, nullptr, 10) : 1;
                 return v > 0 ? static_cast<uint32_t>(v) : 1u;
             }();
-            static const bool normalized_unorm_bind_enabled =
+            static const bool unorm_rtt_value_reuse_enabled =
+                std::getenv("PROSPER_NO_UNORM_RTT_VALUE_REUSE") == nullptr &&
+                // Preserve the recovery switch published with the normalized-sampling first step.
                 std::getenv("PROSPER_NO_NORMALIZED_UNORM_RTT_BIND") == nullptr;
             if (renderer_owned && (dim_3d || dim_2d_array || r->depth != 1)) {
                 // The renderer cache represents one concrete 2D color image. An address match from
@@ -2880,13 +2883,12 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                  bi.binding, (unsigned long long)r->gpu_addr,
                                  r->width, r->height, r->depth, r->img_dim);
             }
-            // Bind the renderer's own image when it is the authoritative copy and this binding
-            // matches it EXACTLY (#1095, phase 2 of #1091). RGBA8 and RGBA16F targets both have a
-            // byte-identical sampled Vulkan view, so neither needs to round-trip through a CPU
-            // snapshot. The FP16 case is especially important for full-resolution post processing:
-            // converting a 4K target down to UNORM8 cost more than the compute dispatch itself and
-            // also discarded HDR values. Aliases and numerically converted views keep the snapshot
-            // path below.
+            // Bind the renderer's own image when it is authoritative and either exactly matches the
+            // sampled view (#1095, phase 2 of #1091) or carries proven value-equivalent UNORM data.
+            // RGBA8 and RGBA16F exact views avoid a CPU snapshot entirely; a float RGBA16_UNORM view
+            // may also consume canonical RGBA8 because byte*257/65535 == byte/255. The independent
+            // extent check below still rejects a scaled image for texel fetch/query access. Other
+            // aliases and numeric conversions keep the snapshot path below.
             const bool depth_import_eligible = !bi.storage && !dim_1d && !dim_3d &&
                 !dim_2d_array && r->depth == 1 && r->img_dim == 1 &&
                 r->format == DataFormat::Float32 &&
@@ -2901,9 +2903,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 const bool scalable_normalized_sampling =
                     image_descriptors[i].normalized_sampling &&
                     !image_descriptors[i].texel_access;
-                const bool format_normalized_sampling =
-                    image_descriptors[i].normalized_sampling &&
-                    !image_descriptors[i].unnormalized_texel_access;
+                const bool format_float_sampling = image_descriptors[i].sampled_float;
                 const LiveTargetImageRequest import_request{
                     r->width, r->height, render_scale, depth_import_eligible,
                     scalable_normalized_sampling};
@@ -2932,7 +2932,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         : direct_sampled_rtt_compatible(
                               r->format, r->num_components ? r->num_components : 1,
                               import.format,
-                              format_normalized_sampling && normalized_unorm_bind_enabled);
+                              format_float_sampling && unorm_rtt_value_reuse_enabled);
                     const bool compatible_device =
                         import.device == static_cast<void*>(ctx.device);
                     const bool direct_extent =
@@ -3192,14 +3192,12 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                          (unsigned)r->format, nc);
                     }
                 }
-                bi.normalized_unorm_rtt = renderer_owned && !bi.storage &&
+                bi.unorm_rtt_value_reuse = renderer_owned && !bi.storage &&
                     r->format == DataFormat::Unorm16 &&
                     direct_sampled_rtt_compatible(
                         r->format, r->num_components ? r->num_components : 1u,
                         live_target.format,
-                        normalized_unorm_bind_enabled &&
-                            image_descriptors[i].normalized_sampling &&
-                            !image_descriptors[i].unnormalized_texel_access);
+                        unorm_rtt_value_reuse_enabled && image_descriptors[i].sampled_float);
             }
             // Exact descriptor aliases share one Vulkan image. Storage aliases must observe the same
             // read/modify/write state and produce one guest writeback; sampled aliases avoid repeatedly
@@ -3208,12 +3206,12 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 const BoundImage& prior = images[j];
                 const ShaderResource* p = prior.resource;
                 // Identical guest descriptors can appear at multiple bindings with different
-                // reflected access contracts. Do not fold an exact R16 upload into the normalized
+                // reflected access contracts. Do not fold an exact R16 upload into the value-equivalent
                 // RGBA8 representation (or vice versa), and only share borrowed renderer images
                 // when both bindings acquired the same concrete image/view format.
                 const bool same_backing_representation =
                     prior.imported == bi.imported &&
-                    prior.normalized_unorm_rtt == bi.normalized_unorm_rtt &&
+                    prior.unorm_rtt_value_reuse == bi.unorm_rtt_value_reuse &&
                     (!bi.imported ||
                      (prior.image == bi.image &&
                       prior.imported_depth == bi.imported_depth &&
@@ -3338,7 +3336,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 ? (bi.imported_pixel_format == LiveTargetPixelFormat::Rgba16Float ? 8u : 4u)
                 : 0u;
             const uint32_t texel_bytes = imported_color_bytes ? imported_color_bytes
-                                         : bi.normalized_unorm_rtt ? 4u
+                                         : bi.unorm_rtt_value_reuse ? 4u
                                          : bi.exact_storage_bytes() ? native_storage_bytes
                                          : bi.storage ? 16u
                                          : sampled_float32_native ? sampled_components * 4u
@@ -3359,7 +3357,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                        : bi.imported_pixel_format == LiveTargetPixelFormat::R11G11B10Float
                            ? VK_FORMAT_B10G11R11_UFLOAT_PACK32
                            : VK_FORMAT_R8G8B8A8_UNORM)
-                : bi.normalized_unorm_rtt ? VK_FORMAT_R8G8B8A8_UNORM
+                : bi.unorm_rtt_value_reuse ? VK_FORMAT_R8G8B8A8_UNORM
                 : bi.packed_r11_storage ? VK_FORMAT_R32_UINT
                 : bi.native_float_storage
                 ? (r->format == DataFormat::Unorm8
@@ -3854,7 +3852,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 const bool r11g11b10 = sampled_r11g11b10;
                 if (renderer_owned) {
                     const std::vector<uint8_t>& pixels = *live_target.pixels;
-                    if (bi.normalized_unorm_rtt) {
+                    if (bi.unorm_rtt_value_reuse) {
                         std::memcpy(upload, pixels.data(), upload_size);
                     } else if (r11g11b10) {
                         if (!pack_live_target_r11g11b10(live_target, upload, upload_size)) {
@@ -4272,15 +4270,15 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 std::fprintf(stderr,
                              "[compute-image] code=0x%llx binding=%u class=%s imported=%u "
                              "extent=%ux%ux%u guest=%zu staging=%llu "
-                             "normalized=%u texel=%u unnormalized-data=%u rgba8-reuse=%u ms=%.3f\n",
+                             "normalized=%u texel=%u sampled-float=%u rgba8-reuse=%u ms=%.3f\n",
                              (unsigned long long)item.code_addr, bi.binding,
                              bi.storage ? "storage" : "sampled", bi.imported ? 1u : 0u,
                              r->width, r->height, r->depth, bi.guest_bytes,
                              (unsigned long long)sbytes,
                              image_descriptors[i].normalized_sampling ? 1u : 0u,
                              image_descriptors[i].texel_access ? 1u : 0u,
-                             image_descriptors[i].unnormalized_texel_access ? 1u : 0u,
-                             bi.normalized_unorm_rtt ? 1u : 0u,
+                             image_descriptors[i].sampled_float ? 1u : 0u,
+                             bi.unorm_rtt_value_reuse ? 1u : 0u,
                              std::chrono::duration<double, std::milli>(
                                  ComputeClock::now() - image_start).count());
         }

--- a/prosper/frontends/shared/live_compute.hpp
+++ b/prosper/frontends/shared/live_compute.hpp
@@ -58,10 +58,11 @@ constexpr bool storage_writeback_can_tile_mapped_bytes(bool exact_storage_bytes,
 
 // Whether a sampled guest view can bind a renderer-owned target without a CPU readback/conversion.
 // Exact Vulkan formats may always be reused. The sole cross-format case is RGBA16_UNORM backed by
-// canonical RGBA8 values, and only when reflection proves a normalized sample/gather-only contract.
+// canonical RGBA8 values, and only when reflection proves that the sampled image returns float
+// values. Exact-extent checks remain a separate coordinate contract for texel fetch and queries.
 bool direct_sampled_rtt_compatible(prosper::gpu::DataFormat format, uint32_t components,
                                    prosper::gpu::LiveTargetPixelFormat target_format,
-                                   bool normalized_sampling);
+                                   bool float_sampled_values);
 
 // Reconstruct a packed R11G11B10 sampled surface from the renderer's canonical color snapshot.
 // The renderer keeps float targets as RGBA16F and ordinary targets as RGBA8; compute descriptors

--- a/prosper/src/gpu/shader_resources.cpp
+++ b/prosper/src/gpu/shader_resources.cpp
@@ -368,10 +368,10 @@ const TypeInfo* descriptor_image_type(const VariableInfo& var,
     return nullptr;
 }
 
-bool descriptor_storage_float(const VariableInfo& var,
-                              const std::unordered_map<uint32_t, TypeInfo>& types) {
+bool descriptor_image_float(const VariableInfo& var,
+                            const std::unordered_map<uint32_t, TypeInfo>& types) {
     const TypeInfo* image = descriptor_image_type(var, types);
-    if (!image || image->image_sampled != 2) return false;
+    if (!image) return false;
     const auto sampled_type = types.find(image->element);
     return sampled_type != types.end() &&
            sampled_type->second.kind == TypeKind::Scalar &&
@@ -590,14 +590,18 @@ DescriptorValidationReport validate_spirv_descriptor_interface(
     }
 
     std::unordered_map<uint32_t, SpirvDescriptorKind> descriptor_vars;
+    std::set<uint32_t> sampled_float_vars;
     std::set<uint32_t> storage_float_vars;
     for (const auto& [id, var] : variables) {
         SpirvDescriptorKind kind = descriptor_kind(var, types);
         if (kind != SpirvDescriptorKind::Unknown) {
             descriptor_vars[id] = kind;
-            if (kind == SpirvDescriptorKind::StorageImage &&
-                descriptor_storage_float(var, types))
-                storage_float_vars.insert(id);
+            if (descriptor_image_float(var, types)) {
+                if (kind == SpirvDescriptorKind::CombinedImageSampler)
+                    sampled_float_vars.insert(id);
+                else if (kind == SpirvDescriptorKind::StorageImage)
+                    storage_float_vars.insert(id);
+            }
         }
     }
 
@@ -607,7 +611,6 @@ DescriptorValidationReport validate_spirv_descriptor_interface(
     std::set<uint32_t> atomic_vars;
     std::set<uint32_t> normalized_sample_vars;
     std::set<uint32_t> texel_access_vars;
-    std::set<uint32_t> unnormalized_texel_access_vars;
     std::unordered_map<uint32_t, PointerAccess> accesses;
     // Result id of OpLoad/OpSampledImage -> descriptor variable. An image descriptor load accesses
     // the descriptor object, not its texels; only the later image opcode establishes read/write data
@@ -663,7 +666,6 @@ DescriptorValidationReport validate_spirv_descriptor_interface(
                 access.pointee_type = pointer_type->second.element;
                 accesses[result] = access;
                 texel_access_vars.insert(image_var);
-                unnormalized_texel_access_vars.insert(image_var);
             }
         } else if (in.opcode == OpLoad && n >= 3) {
             const uint32_t root = pointer_root(word(in, 2));
@@ -699,11 +701,6 @@ DescriptorValidationReport validate_spirv_descriptor_interface(
             const bool normalized = (in.opcode >= 87u && in.opcode <= 94u) ||
                                     in.opcode == 96u || in.opcode == 97u;
             mark_image_coordinate_contract(word(in, 2), normalized);
-            if (!normalized) {
-                auto origin = image_objects.find(word(in, 2));
-                if (origin != image_objects.end())
-                    unnormalized_texel_access_vars.insert(origin->second);
-            }
         } else if (in.opcode == 99u /* OpImageWrite */ && n >= 1) {
             mark_image(word(in, 0), false, true);
         } else if (in.opcode == 100u /* OpImage */ && n >= 3) {
@@ -783,7 +780,7 @@ DescriptorValidationReport validate_spirv_descriptor_interface(
                                       written_vars.count(var) != 0,
                                       normalized_sample_vars.count(var) != 0,
                                       texel_access_vars.count(var) != 0,
-                                      unnormalized_texel_access_vars.count(var) != 0,
+                                      sampled_float_vars.count(var) != 0,
                                       storage_float_vars.count(var) != 0, image_format, image_dim,
                                       image_arrayed, image_multisampled, image_depth,
                                       atomic_vars.count(var) != 0});

--- a/prosper/src/gpu/shader_resources.hpp
+++ b/prosper/src/gpu/shader_resources.hpp
@@ -361,13 +361,14 @@ struct SpirvDescriptorBinding {
     bool readable = false;
     bool writable = false;
     // Coordinate contract for sampled images. Normalized sampling (OpImageSample*/Gather) may bind a
-    // uniformly render-scaled image directly; texel-space access (OpImageFetch/Read) requires the
-    // descriptor's exact declared extent. A binding can use both, in which case exact extent wins.
+    // uniformly render-scaled image directly; texel-space access (OpImageFetch/Read) and image-size
+    // queries require the descriptor's exact declared extent. A binding can use both, in which case
+    // exact extent wins.
     bool normalized_sampling = false;
     bool texel_access = false;
-    // True only for data reads that consume integer texel coordinates (OpImageFetch/Read), not
-    // size/LOD queries. A query requires the exact extent but does not observe texel format/width.
-    bool unnormalized_texel_access = false;
+    // Sampled-image component type encoded by SPIR-V. UNORM formats return this float type for both
+    // normalized sample/gather operations and integer-coordinate OpImageFetch.
+    bool sampled_float = false;
     // Storage-image sampled type encoded by SPIR-V. This is the backend's authoritative choice
     // between a native float VkFormat and the portable raw-uvec4 conversion path, including replay.
     bool storage_float = false;

--- a/prosper/tests/test_game_compute.cpp
+++ b/prosper/tests/test_game_compute.cpp
@@ -189,7 +189,7 @@ int main() {
                                          LiveTargetPixelFormat::Rgba8Unorm, false) &&
           !direct_sampled_rtt_compatible(DataFormat::Unorm16, 2,
                                          LiveTargetPixelFormat::Rgba8Unorm, true),
-          "normalized-only RGBA16-UNORM sampling may reuse RGBA8 without widening texels");
+          "float RGBA16-UNORM sampled values may reuse RGBA8 without widening texels");
     // A renderer-owned target is stored canonically as RGBA8 or RGBA16F, while a later compute
     // descriptor can alias it as packed R11G11B10. Reconstruct the descriptor-visible words rather
     // than sampling stale guest backing or dropping the dispatch.

--- a/prosper/tests/test_shader_resources.cpp
+++ b/prosper/tests/test_shader_resources.cpp
@@ -49,10 +49,11 @@ static std::vector<uint32_t> atomic_descriptor_test_spirv() {
     return s;
 }
 
-static std::vector<uint32_t> image_test_spirv() {
+static std::vector<uint32_t> image_test_spirv(bool sampled_float = true) {
     std::vector<uint32_t> s = {0x07230203u, 0x00010000u, 0, 16, 0};
     emit(s, 15, {4, 10, 0x6e69616d, 0});                    // OpEntryPoint Fragment %10 "main"
-    emit(s, 22, {1, 32});                                  // %1 = f32
+    if (sampled_float) emit(s, 22, {1, 32});                // %1 = f32
+    else emit(s, 21, {1, 32, 0});                           // %1 = u32
     emit(s, 25, {2, 1, 1, 0, 0, 0, 1, 0});                // %2 = sampled 2D image
     emit(s, 27, {3, 2});                                   // %3 = sampled-image %2
     emit(s, 32, {4, 0, 3});                                // %4 = UniformConstant pointer
@@ -63,8 +64,8 @@ static std::vector<uint32_t> image_test_spirv() {
     return s;
 }
 
-static std::vector<uint32_t> image_fetch_test_spirv() {
-    std::vector<uint32_t> s = image_test_spirv();
+static std::vector<uint32_t> image_fetch_test_spirv(bool sampled_float = true) {
+    std::vector<uint32_t> s = image_test_spirv(sampled_float);
     // Replace the terminal normalized sample with OpImageFetch. Reflection only needs the image
     // object's provenance and opcode class; the fixture is not submitted to a SPIR-V implementation.
     s[s.size() - 5] = (5u << 16) | 95u;
@@ -388,7 +389,7 @@ int main() {
     CHECK(ir.ok() && ir.descriptors.size() == 1 &&
           ir.descriptors[0].kind == SpirvDescriptorKind::CombinedImageSampler &&
           ir.descriptors[0].normalized_sampling && !ir.descriptors[0].texel_access &&
-          !ir.descriptors[0].unnormalized_texel_access &&
+          ir.descriptors[0].sampled_float &&
           ir.descriptors[0].image_dim == 1 && !ir.descriptors[0].image_arrayed &&
           !ir.descriptors[0].image_multisampled,
           "sampled-image reflection validates its concrete 2D non-array texture binding");
@@ -399,14 +400,19 @@ int main() {
     CHECK(fetch_report.ok() && fetch_report.descriptors.size() == 1 &&
               !fetch_report.descriptors[0].normalized_sampling &&
               fetch_report.descriptors[0].texel_access &&
-              fetch_report.descriptors[0].unnormalized_texel_access,
+              fetch_report.descriptors[0].sampled_float,
           "OpImageFetch reflection requires the descriptor's exact texel extent");
+    const auto uint_fetch_report = validate_spirv_descriptor_interface(
+        image_fetch_test_spirv(false), &image_table, 1, SpirvShaderStage::Fragment);
+    CHECK(uint_fetch_report.ok() && uint_fetch_report.descriptors.size() == 1 &&
+              !uint_fetch_report.descriptors[0].sampled_float,
+          "sampled-image reflection preserves an integer OpTypeImage component contract");
     const auto mixed_access_report = validate_spirv_descriptor_interface(
         image_sample_fetch_test_spirv(), &image_table, 1, SpirvShaderStage::Fragment);
     CHECK(mixed_access_report.ok() && mixed_access_report.descriptors.size() == 1 &&
               mixed_access_report.descriptors[0].normalized_sampling &&
               mixed_access_report.descriptors[0].texel_access &&
-              mixed_access_report.descriptors[0].unnormalized_texel_access,
+              mixed_access_report.descriptors[0].sampled_float,
           "a normalized sample does not hide an unnormalized texel read on the same image");
     const auto query_report = validate_spirv_descriptor_interface(
         image_query_test_spirv(), &image_table, 0, SpirvShaderStage::Compute);
@@ -414,14 +420,14 @@ int main() {
               query_report.descriptors[0].readable &&
               !query_report.descriptors[0].normalized_sampling &&
               query_report.descriptors[0].texel_access &&
-              !query_report.descriptors[0].unnormalized_texel_access,
+              !query_report.descriptors[0].sampled_float,
           "query-only sampled images stay reflected and require their exact guest extent");
     const auto sample_query_report = validate_spirv_descriptor_interface(
         image_sample_query_test_spirv(), &image_table, 1, SpirvShaderStage::Fragment);
     CHECK(sample_query_report.ok() && sample_query_report.descriptors.size() == 1 &&
               sample_query_report.descriptors[0].normalized_sampling &&
               sample_query_report.descriptors[0].texel_access &&
-              !sample_query_report.descriptors[0].unnormalized_texel_access,
+              sample_query_report.descriptors[0].sampled_float,
           "image queries preserve exact-extent requirements without blocking normalized values");
 
     ShaderResource storage_src{};
@@ -441,12 +447,14 @@ int main() {
               !storage_report.descriptors[1].readable && storage_report.descriptors[1].writable &&
               storage_report.descriptors[0].texel_access &&
               !storage_report.descriptors[0].normalized_sampling &&
+              !storage_report.descriptors[0].sampled_float &&
               !storage_report.descriptors[0].storage_float,
           "storage-image texel access is classified per binding");
     const auto float_storage_report = validate_spirv_descriptor_interface(
         storage_image_access_test_spirv(true), &storage_table, 0, SpirvShaderStage::Compute);
     CHECK(float_storage_report.ok() && float_storage_report.descriptors.size() == 2 &&
               float_storage_report.descriptors[0].storage_float &&
+              !float_storage_report.descriptors[0].sampled_float &&
               float_storage_report.descriptors[1].storage_float,
           "storage-image reflection preserves the SPIR-V float sampled-type contract");
     ShaderResource atomic_image = storage_src;


### PR DESCRIPTION
## Summary

- reflect whether each sampled SPIR-V image returns floating-point values
- allow authoritative RGBA8 render targets to satisfy float RGBA16_UNORM sampled views used by both normalized sampling and `OpImageFetch`
- retain exact-extent enforcement for texel fetches and image-size queries
- keep integer sampled images, storage images, non-RGBA views, and unrelated formats on their existing paths
- add `PROSPER_NO_UNORM_RTT_VALUE_REUSE=1` as a recovery switch while preserving `PROSPER_NO_NORMALIZED_UNORM_RTT_BIND=1` as a compatibility alias

Refs #1390.

## Why this is correct

The affected Plucky Squire shader declares a sampled 2D image with a float sampled type and accesses it with `OpImageFetch`. Vulkan decodes UNORM texels to floating-point values for formatted image reads. For every authoritative RGBA8 byte `b`, the canonical value is `b / 255`; the previous widened RGBA16_UNORM upload stored `b * 257`, which returns `(b * 257) / 65535 == b / 255`. Reusing RGBA8 therefore preserves the shader-visible value while avoiding the widening copy.

The coordinate contract remains separate: `texel_access` still prevents a render-scaled image from satisfying fetch/query access unless its extent exactly matches the descriptor.

Relevant specifications:

- [SPIR-V `OpImageFetch`](https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpImageFetch)
- [Vulkan formatted image reads](https://docs.vulkan.org/spec/latest/chapters/images.html#images-reads)
- [Vulkan fixed-point conversion](https://docs.vulkan.org/spec/latest/chapters/fundamentals.html#fundamentals-fixedconv)

## Plucky Squire replay evidence

Tested exact head: `3513ef79489f782927673300ddd90ebfee2e04e2`

Full 52-submit replay bundle, default vs recovery mode:

- default output SHA-256: `fe56d0d4b527f356d2d985925741c58f2d2a065903e287f251217a0c44c4b8b0`
- `PROSPER_NO_UNORM_RTT_VALUE_REUSE=1` output SHA-256: `fe56d0d4b527f356d2d985925741c58f2d2a065903e287f251217a0c44c4b8b0`

Measured averages:

- program `0x3015770000`, binding 8 image setup: **23.144 ms → 1.815 ms**
- program `0x3015770000`, whole pass: **34.525 ms → 13.315 ms**
- program `0x3015770000`, setup total: **25.290 ms → 3.790 ms**
- second affected program `0x30181a0000`, binding 22: **17.082 ms → 1.276 ms**
- staging bytes for the primary 4K binding: **66,355,200 → 33,177,600**

## Verification

- full Linux build: pass
- `test_shader_resources`: pass
- `game_compute_exec`: pass
- actual `0x3015770000` extracted shader: `spirv-val --target-env vulkan1.2` pass
- full local suite: 154/157 applicable tests pass
- the three failures are the known capture-specific tests because this worktree is configured with the Plucky dump rather than their expected fixture: `module_loads_eboot`, `boot_reaches_first_syscall`, and `real_shader_render`
- independent pre-publish renderer review: approved with no findings
