### PR TITLE
gpu: execute padded tiled image atomics

### DIFF
--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -1852,6 +1852,7 @@ struct BoundBuffer {
     VkDeviceMemory memory = VK_NULL_HANDLE;
     size_t alias_of = SIZE_MAX;         // exact guest range sharing an earlier storage buffer
     size_t bytes = 0;                   // Vulkan buffer bytes (may be a detiled image view)
+    size_t guest_bytes = 0;             // physical guest backing (may exceed logical image bytes)
     bool writable = false;              // reflected OpStore/writing-atomic reachability
     bool atomic_image = false;           // R32_UINT StorageImage exposed as a linear atomic SSBO
     bool persistent = false;
@@ -2560,12 +2561,29 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
 
     do {
         std::vector<VkDescriptorSetLayoutBinding> layout_bindings(descriptors.size());
+        bool buffer_setup_failure_reported = false;
+        auto skip_buffer = [&](uint32_t binding, const ShaderResource* resource,
+                               const char* why) {
+            buffer_setup_failure_reported = true;
+            if (!trace) return;
+            std::fprintf(stderr,
+                         "[compute]   buffer setup failed binding=%u addr=0x%llx size=%u: %s\n",
+                         binding,
+                         (unsigned long long)(resource ? resource->gpu_addr : 0),
+                         resource ? resource->size : 0, why);
+        };
         for (size_t i = 0; i < descriptors.size(); i++) {
             const ShaderResource* resource = item.resources->by_binding(descriptors[i].binding);
             if (!resource || !resource->size ||
                 ((!resource->host_data || resource->host_data_size < resource->size) &&
-                 !guest_readable(resource->gpu_addr, resource->size))) break;
+                 !guest_readable(resource->gpu_addr, resource->size))) {
+                skip_buffer(descriptors[i].binding, resource,
+                            !resource ? "missing resource" :
+                            !resource->size ? "empty resource" : "unreadable backing");
+                break;
+            }
             buffers[i].resource = resource;
+            buffers[i].guest_bytes = resource->size;
             buffers[i].writable = descriptors[i].writable;
             buffers[i].atomic_image = descriptors[i].atomic_access &&
                 resource->cls == ResourceClass::StorageImage &&
@@ -2586,8 +2604,19 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 if (linear_image_bytes > UINT32_MAX ||
                     (!resource->tile_mode && resource->linear_row_pitch_bytes &&
                      resource->linear_row_pitch_bytes < tight_pitch) ||
-                    !guest_image_bytes || guest_image_bytes > resource->size)
+                    !guest_image_bytes || guest_image_bytes > UINT32_MAX) {
+                    skip_buffer(descriptors[i].binding, resource,
+                                "invalid atomic-image buffer layout");
                     break;
+                }
+                if ((!resource->host_data || resource->host_data_size < guest_image_bytes) &&
+                    !guest_readable(resource->gpu_addr,
+                                    static_cast<uint32_t>(guest_image_bytes))) {
+                    skip_buffer(descriptors[i].binding, resource,
+                                "unreadable atomic-image physical backing");
+                    break;
+                }
+                buffers[i].guest_bytes = guest_image_bytes;
             }
             buffers[i].bytes = buffers[i].atomic_image
                 ? static_cast<size_t>(linear_image_bytes) : resource->size;
@@ -2597,6 +2626,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     prior->size != resource->size ||
                     buffers[j].atomic_image != buffers[i].atomic_image ||
                     buffers[j].bytes != buffers[i].bytes ||
+                    buffers[j].guest_bytes != buffers[i].guest_bytes ||
                     prior->host_data != resource->host_data ||
                     prior->host_data_size != resource->host_data_size)
                     continue;
@@ -2608,7 +2638,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 break;
             }
             if (buffers[i].alias_of == SIZE_MAX) {
-                const uint8_t* source = resource_bytes(resource);
+                const uint8_t* source = buffers[i].atomic_image
+                    ? resource_bytes_for(resource, buffers[i].guest_bytes)
+                    : resource_bytes(resource);
                 if (buffers[i].atomic_image) {
                     buffers[i].linear_seed.resize(buffers[i].bytes);
                     if (resource->tile_mode) {
@@ -2652,19 +2684,30 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     // Keep one canonical representation transfer-source capable from allocation.
                     bci.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT |
                                 VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
-                    if (vkCreateBuffer(ctx.device, &bci, nullptr, &buffers[i].buffer) != VK_SUCCESS)
+                    if (!vk_ok(vkCreateBuffer(ctx.device, &bci, nullptr, &buffers[i].buffer),
+                               "buffer-create"))
                         break;
                     VkMemoryRequirements requirements{};
                     vkGetBufferMemoryRequirements(ctx.device, buffers[i].buffer, &requirements);
                     const uint32_t memory_type = ctx.host_memory_type(requirements.memoryTypeBits);
-                    if (memory_type == UINT32_MAX) break;
+                    if (memory_type == UINT32_MAX) {
+                        skip_buffer(descriptors[i].binding, resource,
+                                    "no host-visible memory type");
+                        break;
+                    }
                     buffers[i].memory = ctx.allocate_memory(requirements.size, memory_type, true);
-                    if (!buffers[i].memory) break;
-                    if (vkBindBufferMemory(ctx.device, buffers[i].buffer, buffers[i].memory, 0) !=
-                        VK_SUCCESS)
+                    if (!buffers[i].memory) {
+                        skip_buffer(descriptors[i].binding, resource,
+                                    "host-visible memory allocation failed");
+                        break;
+                    }
+                    if (!vk_ok(vkBindBufferMemory(ctx.device, buffers[i].buffer,
+                                                  buffers[i].memory, 0),
+                               "buffer-bind"))
                         break;
                     void* mapped = nullptr;
-                    if (ctx.map_memory(buffers[i].memory, 0, buffers[i].bytes, &mapped) != VK_SUCCESS)
+                    if (!vk_ok(ctx.map_memory(buffers[i].memory, 0, buffers[i].bytes, &mapped),
+                               "buffer-map"))
                         break;
                     // Pooled host-visible allocations retain their previous contents. Compare them
                     // with current guest memory before uploading: any mutation takes the exact copy.
@@ -2698,7 +2741,17 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     buffer.cache_key, buffer.resource->size, buffer.result_baseline);
         bool buffers_ready = true;
         for (const auto& buffer : buffers) buffers_ready &= buffer.resource && buffer.memory;
-        if (!buffers_ready) break;
+        if (!buffers_ready) {
+            if (trace && !buffer_setup_failure_reported) {
+                for (size_t i = 0; i < buffers.size(); ++i) {
+                    if (buffers[i].resource && buffers[i].memory) continue;
+                    skip_buffer(descriptors[i].binding, buffers[i].resource,
+                                "binding was not prepared");
+                    break;
+                }
+            }
+            break;
+        }
         setup_buffers_ms = std::chrono::duration<double, std::milli>(
             ComputeClock::now() - setup_validate_start).count() - setup_validate_ms;
 
@@ -5034,7 +5087,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 readback_ok = false;
                 break;
             }
-            uint8_t* destination = resource_bytes(buffer.resource);
+            uint8_t* destination = buffer.atomic_image
+                ? resource_bytes_for(buffer.resource, buffer.guest_bytes)
+                : resource_bytes(buffer.resource);
             const auto* result = static_cast<const uint8_t*>(mapped);
             if (buffer.atomic_image) {
                 if (trace) {
@@ -5044,7 +5099,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 }
                 if (!buffer.resource->host_data && buffer.resource->gpu_addr)
                     prosper::host::guest_write_watch_notify_host_write(
-                        buffer.resource->gpu_addr, buffer.resource->size);
+                        buffer.resource->gpu_addr, buffer.guest_bytes);
                 if (buffer.resource->tile_mode) {
                     tile_surface(destination, result,
                                  buffer.resource->width, buffer.resource->height,
@@ -5059,10 +5114,10 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 }
                 ctx.unmap_memory(buffer.memory);
                 if (buffer.resource->gpu_addr)
-                    notify_guest_gpu_write(buffer.resource->gpu_addr, buffer.resource->size);
+                    notify_guest_gpu_write(buffer.resource->gpu_addr, buffer.guest_bytes);
                 if (!buffer.resource->host_data && writer_provenance_enabled())
                     record_guest_write(GuestWriterKind::ComputeBuffer,
-                                       buffer.resource->gpu_addr, buffer.resource->size,
+                                       buffer.resource->gpu_addr, buffer.guest_bytes,
                                        item.submit_no, item.dispatch_index,
                                        item.command_order, item.code_addr);
                 continue;

--- a/prosper/tests/test_game_compute.cpp
+++ b/prosper/tests/test_game_compute.cpp
@@ -486,6 +486,80 @@ int main() {
     CHECK(unchanged_write_notifications == 1,
           "idempotent compute writes still invalidate divergent renderer-resident state");
 
+    // Astro Bot's world-map visibility kernel lowers IMAGE_ATOMIC_ADD on a tiled R32_UINT image
+    // to a linear SSBO atomic. The descriptor's declared size is the logical texel count, while a
+    // Sw64KbRX backing includes whole-tile padding and can therefore be larger. Replay provides that
+    // physical capture through host_data_size; rejecting it against the logical size skipped the
+    // entire visibility pass.
+    {
+        static const uint32_t image_atomic_add[] = {
+            0x7e000280u, 0x7e020280u, 0x7e120281u,
+            0xf0442108u, 0x00000900u, 0xbf810000u,
+        };
+        constexpr uint32_t atomic_width = 2048;
+        constexpr uint32_t atomic_height = 64;
+        constexpr uint32_t atomic_tile = static_cast<uint32_t>(TileMode::Sw64KbRX);
+        constexpr size_t atomic_logical_bytes =
+            static_cast<size_t>(atomic_width) * atomic_height * sizeof(uint32_t);
+        const size_t atomic_guest_bytes = tiled_surface_bytes(
+            atomic_width, atomic_height, atomic_tile, 0, sizeof(uint32_t));
+        CHECK(atomic_guest_bytes > atomic_logical_bytes,
+              "world-map atomic image fixture includes physical tile padding");
+        std::vector<uint8_t> atomic_guest(atomic_guest_bytes, 0);
+
+        ShaderResourceTable atomic_rt;
+        ShaderResource atomic_image;
+        atomic_image.cls = ResourceClass::StorageImage;
+        atomic_image.format = DataFormat::Uint32;
+        atomic_image.num_components = 1;
+        atomic_image.binding = 4;
+        atomic_image.sgpr_base = 0;
+        atomic_image.img_dim = 1;
+        atomic_image.width = atomic_width;
+        atomic_image.height = atomic_height;
+        atomic_image.depth = 1;
+        atomic_image.tile_mode = atomic_tile;
+        atomic_image.size = static_cast<uint32_t>(atomic_logical_bytes);
+        atomic_image.gpu_addr = reinterpret_cast<uint64_t>(atomic_guest.data());
+        atomic_image.host_data = atomic_guest.data();
+        atomic_image.host_data_size = atomic_guest.size();
+        atomic_rt.resources.push_back(atomic_image);
+
+        ComputeShaderConfig atomic_config;
+        atomic_config.local_x = 1;
+        const std::vector<uint32_t> atomic_spirv = recompile_compute(
+            image_atomic_add, std::size(image_atomic_add), &atomic_rt, atomic_config);
+        CHECK(!atomic_spirv.empty(), "world-map tiled image-atomic kernel recompiles");
+        if (!atomic_spirv.empty()) {
+            ComputeItem atomic_item;
+            atomic_item.spirv = atomic_spirv;
+            atomic_item.resources = std::make_shared<ShaderResourceTable>(atomic_rt);
+            atomic_item.launch.threads_x = atomic_item.launch.threads_y =
+                atomic_item.launch.threads_z = 1;
+            atomic_item.launch.local_x = atomic_item.launch.local_y =
+                atomic_item.launch.local_z = 1;
+            atomic_item.launch.groups_x = atomic_item.launch.groups_y =
+                atomic_item.launch.groups_z = 1;
+            atomic_item.code_addr = 0x500525200;
+
+            uint64_t atomic_notified_bytes = 0;
+            set_guest_gpu_write_observer([&](uint64_t addr, uint64_t bytes) {
+                if (addr == atomic_image.gpu_addr) atomic_notified_bytes = bytes;
+            });
+            CHECK(prosper::frontend::execute_live_compute_items({atomic_item}),
+                  "world-map tiled image-atomic dispatch accepts its physical backing");
+            set_guest_gpu_write_observer({});
+
+            std::vector<uint32_t> atomic_linear(atomic_width * atomic_height, 0);
+            detile_surface(reinterpret_cast<uint8_t*>(atomic_linear.data()), atomic_guest.data(),
+                           atomic_width, atomic_height, atomic_tile, 0, sizeof(uint32_t));
+            CHECK(atomic_linear[0] == 1,
+                  "world-map tiled image-atomic dispatch publishes its atomic result");
+            CHECK(atomic_notified_bytes == atomic_guest_bytes,
+                  "world-map tiled image-atomic write invalidates the full physical backing");
+        }
+    }
+
     // Plucky Squire binds the same 32 MiB writable lighting buffer to consecutive kernels even
     // when their output is byte-identical to the previous frame. Exercise the production cache at
     // its one-MiB retention threshold: the second dispatch can use the exact GPU-side baseline,


### PR DESCRIPTION
## Summary

- distinguish a tiled atomic image's logical texel size from its larger physical guest backing
- detile/upload and retile/write back the full physical allocation
- invalidate the full physical guest range after the atomic pass
- add fail-visible buffer setup diagnostics
- add a regression test matching Astro Bot's 2048x64 Sw64KbRX visibility image

## Root cause

Astro Bot's world-map visibility compute pass binds a 2048x64 R32_UINT atomic image. Its logical texel size is 524,288 bytes, while its Sw64KbRX backing occupies 1,048,576 bytes. The compute backend compared the physical tiled footprint against the logical descriptor size and rejected the otherwise valid binding before creating the Vulkan pipeline.

## Astro Bot result

On the saved world-map capture, dispatch `0x500525200` changes from `result=failed` to `result=ok`. It now publishes the atomic visibility result and its 4096x64 output image.

The complete seven-submit replay still ends at the same black frame hash (`26ed8b6191338383`), so this restores a missing producer but does not claim the world map is visually fixed. No screenshot is attached because the output remains black.

Part of #1459.

## Validation

- full `build-astrobot-fmv` build
- `game_compute_exec`
- `gpu_surface_detile`
- `rdna2_spirv_struct`
- `build_shader_resources`
- `rdna2_to_spirv_exec`
- isolated captured dispatch replay: failed before the change, successful after it
- full seven-submit world-map bundle replay: successful, final hash unchanged/black
