### PR TITLE
gpu: retain capture-owned compute images

### DIFF
--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -607,6 +607,11 @@ struct CachedComputeBuffer {
 
 struct ComputeImageCacheKey {
     uint64_t gpu_addr = 0;
+    // Replay/capture resources preserve the architectural address for descriptor identity, but
+    // expose their bytes through owned host storage. Keep that storage identity in the key just as
+    // the persistent buffer cache does: two loaded captures may reuse a guest address while their
+    // owned byte arrays have unrelated lifetimes.
+    uintptr_t host_data = 0;
     uint32_t guest_bytes = 0;
     uint32_t resource_bytes = 0;
     uint32_t width = 0, height = 0, depth = 0;
@@ -631,7 +636,7 @@ struct ComputeImageCacheKeyHash {
             result ^= std::hash<uint64_t>{}(value) + 0x9e3779b97f4a7c15ull +
                       (result << 6) + (result >> 2);
         };
-        mix(key.guest_bytes); mix(key.resource_bytes);
+        mix(key.host_data); mix(key.guest_bytes); mix(key.resource_bytes);
         mix(key.width); mix(key.height); mix(key.depth);
         mix(key.format); mix(key.components); mix(key.tile_mode); mix(key.img_dim);
         mix(key.linear_row_pitch); mix(key.layer_stride); mix(key.layer_mip_offset);
@@ -646,7 +651,8 @@ ComputeImageCacheKey storage_image_cache_key(const prosper::gpu::ShaderResource&
                                               uint32_t guest_bytes,
                                               VkFormat native_format) {
     return {
-        resource.gpu_addr, guest_bytes, resource.size,
+        resource.gpu_addr, reinterpret_cast<uintptr_t>(resource.host_data),
+        guest_bytes, resource.size,
         resource.width, resource.height, resource.depth,
         static_cast<uint32_t>(resource.format),
         resource.num_components ? resource.num_components : 1u,
@@ -1462,21 +1468,27 @@ struct VulkanComputeContext {
         ++cached.pins;
         image = cached.image;
         memory = cached.memory;
-        if (validation_epoch && cached.validation_epoch == validation_epoch) {
+        if (!key.host_data && validation_epoch && cached.validation_epoch == validation_epoch) {
             upload_skipped = cached.validation_result;
             return true;
         }
-        const bool submit_unchanged = cached.content_valid &&
+        // Capture-owned bytes are not architectural guest mappings: direct writes to host_data do
+        // not enter the submit journal and cannot be protected by GuestWriteWatch. Validate those
+        // entries only against their exact retained snapshot. This makes warm replay exercise the
+        // same image residency as live execution without ever trusting an unrelated guest address.
+        const bool exact_source_only = key.host_data != 0;
+        const bool submit_unchanged = cached.content_valid && !exact_source_only &&
             prosper::gpu::guest_gpu_writes_since(cached.validation_snapshot,
                                                   key.gpu_addr, key.guest_bytes) ==
                 prosper::gpu::GuestGpuWriteQuery::Unchanged;
         const prosper::host::GuestWriteWatchQuery watch_query =
-            !submit_unchanged && cached.content_valid && cached.write_watch
+            !exact_source_only && !submit_unchanged && cached.content_valid && cached.write_watch
                 ? cached.write_watch.query()
                 : prosper::host::GuestWriteWatchQuery::Unknown;
         const bool watch_unchanged = !submit_unchanged &&
             watch_query == prosper::host::GuestWriteWatchQuery::Unchanged;
-        if (cached.content_valid && !submit_unchanged && !watch_unchanged && source) {
+        if (!exact_source_only && cached.content_valid && !submit_unchanged &&
+            !watch_unchanged && source) {
             // Rearm a dirtied watch, or promote a repeatedly stable exact source, before memcmp.
             // A write racing the comparison then remains Dirty for the next acquisition instead of
             // being erased by a post-comparison rearm.
@@ -1496,10 +1508,12 @@ struct VulkanComputeContext {
         cached.validation_epoch = validation_epoch;
         cached.validation_result = upload_skipped;
         if (exact_unchanged) {
-            cached.validation_snapshot = prosper::gpu::guest_gpu_write_snapshot();
-            cached.write_watch_stable_validations = update_write_watch_stability(
-                cached.write_watch_stable_validations, true,
-                compute_write_watch_promotion_validations());
+            if (!exact_source_only) {
+                cached.validation_snapshot = prosper::gpu::guest_gpu_write_snapshot();
+                cached.write_watch_stable_validations = update_write_watch_stability(
+                    cached.write_watch_stable_validations, true,
+                    compute_write_watch_promotion_validations());
+            }
         } else if (!upload_skipped && source) {
             cached.write_watch_stable_validations = 0;
             cached.source_snapshot.assign(source, source + key.guest_bytes);
@@ -1552,7 +1566,8 @@ struct VulkanComputeContext {
         cached.allocation_bytes = allocation_bytes;
         cached.last_use = ++image_cache_clock;
         cached.pins = 1;
-        cached.validation_snapshot = prosper::gpu::guest_gpu_write_snapshot();
+        if (!key.host_data)
+            cached.validation_snapshot = prosper::gpu::guest_gpu_write_snapshot();
         if (source)
             cached.source_snapshot.assign(source, source + key.guest_bytes);
         auto [it, inserted] = image_cache.emplace(key, std::move(cached));
@@ -1589,8 +1604,13 @@ struct VulkanComputeContext {
             cached.source_snapshot.assign(current_source,
                                           current_source + key.guest_bytes);
         cached.content_valid = true;
-        cached.validation_snapshot = prosper::gpu::guest_gpu_write_snapshot();
+        if (!key.host_data)
+            cached.validation_snapshot = prosper::gpu::guest_gpu_write_snapshot();
         cached.write_watch_stable_validations = 0;
+        if (key.host_data) {
+            cached.write_watch.reset();
+            return;
+        }
         if (cached.write_watch && cached.write_watch.rearm()) return;
         cached.write_watch.reset();
     }
@@ -1837,6 +1857,7 @@ struct VulkanComputeContext {
 };
 
 VulkanComputeContext* g_live_compute_context = nullptr;
+std::atomic<uint64_t> g_sampled_image_upload_skips{0};
 
 struct BorrowedComputeImageLease {
     VulkanComputeContext* context = nullptr;
@@ -3539,11 +3560,12 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         std::all_of(metadata, metadata + metadata_bytes,
                                     [](uint8_t value) { return value == 0xff; });
                 }
-                bi.cache_candidate = !r->host_data && dcc_cache_safe &&
+                bi.cache_candidate = dcc_cache_safe &&
                     persistent_compute_image_enabled(sbytes, ComputeImageCacheClass::sampled);
                 if (bi.cache_candidate) {
                     bi.cache_key = {
-                        r->gpu_addr, static_cast<uint32_t>(sampled_guest_need), r->size,
+                        r->gpu_addr, reinterpret_cast<uintptr_t>(r->host_data),
+                        static_cast<uint32_t>(sampled_guest_need), r->size,
                         r->width, r->height, r->depth,
                         static_cast<uint32_t>(r->format), sampled_components,
                         r->tile_mode, r->img_dim, r->linear_row_pitch_bytes,
@@ -3555,6 +3577,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     bi.persistent = ctx.acquire_cached_image(
                         bi.cache_key, sampled_guest_source, image_validation_epoch,
                         bi.image, bi.memory, bi.upload_skipped);
+                    if (bi.persistent && bi.upload_skipped)
+                        g_sampled_image_upload_skips.fetch_add(1, std::memory_order_relaxed);
                     if (trace && bi.persistent)
                         std::fprintf(stderr,
                                      "[compute]   persistent sampled image binding=%u "
@@ -3680,7 +3704,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     (bi.dcc_metadata && bi.dcc_metadata_bytes &&
                      std::all_of(bi.dcc_metadata, bi.dcc_metadata + bi.dcc_metadata_bytes,
                                  [](uint8_t value) { return value == 0xff; }));
-                bi.cache_candidate = !renderer_owned && !r->host_data && dcc_cache_safe &&
+                bi.cache_candidate = !renderer_owned && dcc_cache_safe &&
                     !bi.poison_verify && (bi.exact_storage_bytes() || bi.seed_skip) &&
                     persistent_compute_image_enabled(sbytes, ComputeImageCacheClass::storage);
                 if (bi.cache_candidate) {
@@ -5563,6 +5587,10 @@ bool import_live_compute_storage_image(const prosper::gpu::ShaderResource& sampl
 
 uint64_t live_compute_buffer_gpu_result_skips() {
     return g_buffer_gpu_result_skips.load(std::memory_order_relaxed);
+}
+
+uint64_t live_compute_sampled_image_upload_skips() {
+    return g_sampled_image_upload_skips.load(std::memory_order_relaxed);
 }
 
 void live_compute_fail_next_storage_readback_for_test() {

--- a/prosper/frontends/shared/live_compute.hpp
+++ b/prosper/frontends/shared/live_compute.hpp
@@ -99,6 +99,9 @@ bool import_live_compute_storage_image(const prosper::gpu::ShaderResource& sampl
 // Monotonic diagnostic count of writable-buffer results whose exact GPU comparison avoided a host
 // mapping/scan. Exposed so the production-backend test can prove that optimization path executes.
 uint64_t live_compute_buffer_gpu_result_skips();
+// Monotonic diagnostic count of retained sampled-image hits whose validated source omitted upload.
+// Capture/replay tests use this to prove residency without relying on timing-sensitive assertions.
+uint64_t live_compute_sampled_image_upload_skips();
 
 // Deterministic failure injection for the storage-image recovery regression test. The next storage
 // readback fails after dispatch, exercising retained-image invalidation without a Vulkan fault.

--- a/prosper/tests/test_game_compute.cpp
+++ b/prosper/tests/test_game_compute.cpp
@@ -1913,6 +1913,85 @@ int main() {
     CHECK(sampled_uint_roundtrip(DataFormat::Uint16, 4, 8, 0x590164),
           "tiled RGBA16_UINT sampled values reach storage writeback byte-exactly");
 
+    // GPU captures preserve descriptor addresses but materialize resource bytes in owned host
+    // arrays. Warm replay must retain those sampled images just like the live guest-backed path,
+    // while validating by exact bytes because host_data mutations never enter the guest journal or
+    // page write-watch system. Prove both the unchanged hit and a direct unreported mutation.
+    {
+        constexpr uint32_t host_texel_bytes = 4;
+        std::vector<uint8_t> linear_src(W * host_texel_bytes);
+        std::vector<uint8_t> linear_dst(W * host_texel_bytes, 0xA5);
+        for (size_t i = 0; i < linear_src.size(); ++i)
+            linear_src[i] = static_cast<uint8_t>(i * 41 + 13);
+        const size_t tiled_size = tiled_surface_bytes(
+            W, 1, dcc_tile, 0, host_texel_bytes);
+        std::vector<uint8_t> capture_owned_src(tiled_size, 0);
+        tile_surface(capture_owned_src.data(), linear_src.data(), W, 1,
+                     dcc_tile, 0, host_texel_bytes);
+
+        ShaderResourceTable host_rt = irt;
+        for (ShaderResource& resource : host_rt.resources) {
+            if (resource.binding != 4 && resource.binding != 5) continue;
+            resource.img_dim = 1;
+            resource.format = DataFormat::Uint8;
+            resource.num_components = 4;
+            resource.width = W;
+            resource.height = resource.depth = 1;
+            if (resource.binding == 4) {
+                resource.cls = ResourceClass::Texture;
+                resource.tile_mode = dcc_tile;
+                resource.gpu_addr = 0x71c0000000ull;
+                resource.size = static_cast<uint32_t>(capture_owned_src.size());
+                resource.host_data = capture_owned_src.data();
+                resource.host_data_size = capture_owned_src.size();
+                resource.swizzle[0] = 4;
+                resource.swizzle[1] = 5;
+                resource.swizzle[2] = 6;
+                resource.swizzle[3] = 7;
+            } else {
+                resource.tile_mode = 0;
+                resource.gpu_addr = reinterpret_cast<uint64_t>(linear_dst.data());
+                resource.size = static_cast<uint32_t>(linear_dst.size());
+            }
+        }
+        const std::vector<uint32_t> host_spirv = recompile_valu(
+            image_copy_2d, std::size(image_copy_2d), 1, 0, &host_rt);
+        CHECK(!host_spirv.empty(),
+              "capture-owned sampled-image copy kernel recompiles");
+        if (!host_spirv.empty()) {
+            ComputeItem host_item;
+            host_item.spirv = host_spirv;
+            host_item.resources = std::make_shared<ShaderResourceTable>(host_rt);
+            host_item.launch.threads_x = W;
+            host_item.launch.local_x = 64;
+            host_item.launch.groups_x = 1;
+            host_item.launch.local_y = host_item.launch.local_z = 1;
+            host_item.launch.groups_y = host_item.launch.groups_z = 1;
+            host_item.code_addr = 0x590ca9;
+            CHECK(prosper::frontend::execute_live_compute_items({host_item}) &&
+                      linear_dst == linear_src,
+                  "capture-owned sampled image establishes an exact retained source");
+
+            const uint64_t skips_before =
+                prosper::frontend::live_compute_sampled_image_upload_skips();
+            CHECK(prosper::frontend::execute_live_compute_items({host_item}) &&
+                      prosper::frontend::live_compute_sampled_image_upload_skips() >
+                          skips_before,
+                  "unchanged capture-owned sampled image skips its warm-replay upload");
+
+            linear_src[0] ^= 0xff;
+            tile_surface(capture_owned_src.data(), linear_src.data(), W, 1,
+                         dcc_tile, 0, host_texel_bytes);
+            const uint64_t skips_before_mutation =
+                prosper::frontend::live_compute_sampled_image_upload_skips();
+            CHECK(prosper::frontend::execute_live_compute_items({host_item}) &&
+                      linear_dst == linear_src &&
+                      prosper::frontend::live_compute_sampled_image_upload_skips() ==
+                          skips_before_mutation,
+                  "direct capture-owned mutation refreshes the retained sampled image exactly");
+        }
+    }
+
     // --- #1122 seed-skip coverage proof. A write-only storage image whose dispatch fully covers the
     // extent can skip the (expensive) seed -- BUT ONLY after proving the write actually stores every
     // texel. covers_extent is necessary, not sufficient: a shader that stores a SUBSET of a covering


### PR DESCRIPTION
## What changed

- allow capture/replay-owned sampled and eligible storage images to use the persistent compute-image cache
- include the owned host pointer in image cache identity, alongside the preserved architectural GPU address
- validate host-backed entries only with an exact byte snapshot; never trust the guest submit journal or page write watches for direct `host_data` mutations
- retain the existing journal/write-watch fast path for live guest-backed resources
- expose a monotonic sampled-upload skip diagnostic and add a production Vulkan regression that proves:
  - an unchanged capture-owned sampled image skips its warm-replay upload
  - a direct host-byte mutation with no guest write notification is detected and uploaded exactly

## Why

GPU captures preserve guest descriptor addresses but materialize resource bytes in capture-owned host arrays. The compute backend excluded every such image from persistence, so `gpu_replay --warmup-repeats` reconstructed, converted, and uploaded large images on each repeat even though the live game retains them. This made replay profiling disagree with the live path and could send optimization work toward replay-only costs.

Simply removing the exclusion would be incorrect: direct writes to `host_data` never enter the guest GPU-write journal and cannot be covered by `GuestWriteWatch`. This patch gives host-backed entries a separate fail-closed contract based on exact source bytes, while also keying their allocation identity so unrelated loaded captures cannot alias through a reused guest address.

## Plucky replay evidence

Fresh v39 capture: `submit-30180d.prgcap` (395 MiB), program `0x30180d0000`, 3840×2160.

After residency is established:

- binding 21 (33.4 MiB normalized sampled source): persistent, upload skipped
- binding 23 (8.8 MiB sampled source): persistent, upload skipped
- binding 30 (66.8 MiB storage target): persistent; exact GPU-identical result skips host writeback
- target writeback: 5.18 ms before → 0.01 ms after
- replay image is byte-identical to baseline:
  `9e2733eda3327c11ae662cd59708b9d5b344fa59f2b694009c9854755a59745e`
- all warm/final output hashes remain `04ae14a8c71e6679`

This is primarily a replay-fidelity prerequisite, not a claimed live-FPS win: replay still must exact-compare capture-owned bytes, while the live game can validate unchanged guest mappings through its journal/write-watch authority.

## Validation

- full project build: passed
- focused replay/compute suite: 8/8 passed
  - `gpu_replay_regress_logic`
  - `gpu_capture_roundtrip`
  - `gpu_capture_bundle_roundtrip`
  - `gpu_replay_output_extent`
  - `gpu_replay_shader_dump`
  - `gpu_capture_render_replay`
  - `compute_exec_differential`
  - `game_compute_exec`
- full CTest: 154/157 passed
- the same three dump-selection failures remain because this build is configured against Plucky rather than the fixture title: `module_loads_eboot`, `boot_reaches_first_syscall`, and `real_shader_render`

Closes no issue; continues #1390.