### PR TITLE
gpu: split render wait from device execution

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -923,7 +923,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 uint64_t backend_gpu_timestamp_samples = 0;
                 double backend_target_ms = 0, backend_draw_setup_ms = 0;
                 double backend_record_upload_ms = 0, backend_gpu_wait_ms = 0;
-                double backend_gpu_execute_ms = 0;
+                double backend_gpu_device_ms = 0;
                 double backend_readback_ms = 0, backend_cleanup_ms = 0;
                 double backend_setup_shader_ms = 0, backend_setup_fixed_ms = 0;
                 double backend_setup_resources_ms = 0, backend_setup_pipeline_ms = 0;
@@ -978,7 +978,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 pending_timing.backend_draw_setup_ms += backend.draw_setup_ms;
                 pending_timing.backend_record_upload_ms += backend.record_upload_ms;
                 pending_timing.backend_gpu_wait_ms += backend.gpu_wait_ms;
-                pending_timing.backend_gpu_execute_ms += backend.gpu_execute_ms;
+                pending_timing.backend_gpu_device_ms += backend.gpu_device_ms;
                 pending_timing.backend_readback_ms += backend.readback_ms;
                 pending_timing.backend_cleanup_ms += backend.cleanup_ms;
                 pending_timing.backend_setup_shader_ms += backend.setup_shader_ms;
@@ -1001,8 +1001,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     "[rtt-timing] submit=%d target=0x%llx extent=%ux%u draws=%zu "
                     "span=%d/%d authoritative=%d deferred=%d cmd=%llu submit=%llu wait=%llu "
                     "measured=%.2f detail=%.2f other=%.2f target_setup=%.2f "
-                    "draw_setup=%.2f record_upload=%.2f gpu_wait=%.2f "
-                    "gpu_device=%.2f gpu_overhead=%.2f timestamps=%llu "
+                    "draw_setup=%.2f record_upload=%.2f batch_wait=%.2f "
+                    "batch_device=%.2f batch_overhead=%.2f batch_timestamps=%llu "
                     "readback=%.2f cleanup=%.2f gpu_target=%llu load=%llu sample=%llu cpu=%llu\n",
                     record.submit, (unsigned long long)record.target,
                     record.width, record.height, record.draws,
@@ -1014,8 +1014,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     record.measured_ms, detail_ms,
                     record.measured_ms - detail_ms,
                     timing.target_ms, timing.draw_setup_ms, timing.record_upload_ms,
-                    timing.gpu_wait_ms, timing.gpu_execute_ms,
-                    std::max(0.0, timing.gpu_wait_ms - timing.gpu_execute_ms),
+                    timing.gpu_wait_ms, timing.gpu_device_ms,
+                    std::max(0.0, timing.gpu_wait_ms - timing.gpu_device_ms),
                     (unsigned long long)timing.gpu_timestamp_samples,
                     timing.readback_ms, timing.cleanup_ms,
                     (unsigned long long)record.color_target.writes,
@@ -4780,7 +4780,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     uint64_t backend_gpu_timestamp_samples = 0;
                     double backend_target_ms = 0, backend_draw_setup_ms = 0;
                     double backend_record_upload_ms = 0, backend_gpu_wait_ms = 0;
-                    double backend_gpu_execute_ms = 0;
+                    double backend_gpu_device_ms = 0;
                     double backend_readback_ms = 0, backend_cleanup_ms = 0;
                     double backend_setup_shader_ms = 0, backend_setup_fixed_ms = 0;
                     double backend_setup_resources_ms = 0, backend_setup_pipeline_ms = 0;
@@ -4818,7 +4818,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     timing.backend_draw_setup_ms += pending_timing.backend_draw_setup_ms;
                     timing.backend_record_upload_ms += pending_timing.backend_record_upload_ms;
                     timing.backend_gpu_wait_ms += pending_timing.backend_gpu_wait_ms;
-                    timing.backend_gpu_execute_ms += pending_timing.backend_gpu_execute_ms;
+                    timing.backend_gpu_device_ms += pending_timing.backend_gpu_device_ms;
                     timing.backend_readback_ms += pending_timing.backend_readback_ms;
                     timing.backend_cleanup_ms += pending_timing.backend_cleanup_ms;
                     timing.backend_setup_shader_ms += pending_timing.backend_setup_shader_ms;
@@ -4882,8 +4882,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             totals.backend_ms / nsub, backend_detail_ms / nsub,
                             totals.backend_target_ms / nsub, totals.backend_draw_setup_ms / nsub,
                             totals.backend_record_upload_ms / nsub, totals.backend_gpu_wait_ms / nsub,
-                            totals.backend_gpu_execute_ms / nsub,
-                            std::max(0.0, totals.backend_gpu_wait_ms - totals.backend_gpu_execute_ms) / nsub,
+                            totals.backend_gpu_device_ms / nsub,
+                            std::max(0.0, totals.backend_gpu_wait_ms - totals.backend_gpu_device_ms) / nsub,
                             totals.backend_readback_ms / nsub, totals.backend_cleanup_ms / nsub,
                             (totals.backend_ms - backend_detail_ms) / nsub);
                     fprintf(stderr,
@@ -5047,8 +5047,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             window.backend_ms / wn, window_backend_detail_ms / wn,
                             window.backend_target_ms / wn, window.backend_draw_setup_ms / wn,
                             window.backend_record_upload_ms / wn, window.backend_gpu_wait_ms / wn,
-                            window.backend_gpu_execute_ms / wn,
-                            std::max(0.0, window.backend_gpu_wait_ms - window.backend_gpu_execute_ms) / wn,
+                            window.backend_gpu_device_ms / wn,
+                            std::max(0.0, window.backend_gpu_wait_ms - window.backend_gpu_device_ms) / wn,
                             window.backend_readback_ms / wn, window.backend_cleanup_ms / wn,
                             (window.backend_ms - window_backend_detail_ms) / wn);
                     fprintf(stderr,

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -920,8 +920,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 uint64_t backend_calls = 0, backend_draws = 0;
                 uint64_t backend_command_buffers = 0, backend_queue_submits = 0;
                 uint64_t backend_fence_waits = 0;
+                uint64_t backend_gpu_timestamp_samples = 0;
                 double backend_target_ms = 0, backend_draw_setup_ms = 0;
                 double backend_record_upload_ms = 0, backend_gpu_wait_ms = 0;
+                double backend_gpu_execute_ms = 0;
                 double backend_readback_ms = 0, backend_cleanup_ms = 0;
                 double backend_setup_shader_ms = 0, backend_setup_fixed_ms = 0;
                 double backend_setup_resources_ms = 0, backend_setup_pipeline_ms = 0;
@@ -971,10 +973,12 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 pending_timing.backend_command_buffers += backend.command_buffers;
                 pending_timing.backend_queue_submits += backend.queue_submits;
                 pending_timing.backend_fence_waits += backend.fence_waits;
+                pending_timing.backend_gpu_timestamp_samples += backend.gpu_timestamp_samples;
                 pending_timing.backend_target_ms += backend.target_ms;
                 pending_timing.backend_draw_setup_ms += backend.draw_setup_ms;
                 pending_timing.backend_record_upload_ms += backend.record_upload_ms;
                 pending_timing.backend_gpu_wait_ms += backend.gpu_wait_ms;
+                pending_timing.backend_gpu_execute_ms += backend.gpu_execute_ms;
                 pending_timing.backend_readback_ms += backend.readback_ms;
                 pending_timing.backend_cleanup_ms += backend.cleanup_ms;
                 pending_timing.backend_setup_shader_ms += backend.setup_shader_ms;
@@ -998,6 +1002,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     "span=%d/%d authoritative=%d deferred=%d cmd=%llu submit=%llu wait=%llu "
                     "measured=%.2f detail=%.2f other=%.2f target_setup=%.2f "
                     "draw_setup=%.2f record_upload=%.2f gpu_wait=%.2f "
+                    "gpu_device=%.2f gpu_overhead=%.2f timestamps=%llu "
                     "readback=%.2f cleanup=%.2f gpu_target=%llu load=%llu sample=%llu cpu=%llu\n",
                     record.submit, (unsigned long long)record.target,
                     record.width, record.height, record.draws,
@@ -1009,7 +1014,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     record.measured_ms, detail_ms,
                     record.measured_ms - detail_ms,
                     timing.target_ms, timing.draw_setup_ms, timing.record_upload_ms,
-                    timing.gpu_wait_ms, timing.readback_ms, timing.cleanup_ms,
+                    timing.gpu_wait_ms, timing.gpu_execute_ms,
+                    std::max(0.0, timing.gpu_wait_ms - timing.gpu_execute_ms),
+                    (unsigned long long)timing.gpu_timestamp_samples,
+                    timing.readback_ms, timing.cleanup_ms,
                     (unsigned long long)record.color_target.writes,
                     (unsigned long long)record.color_target.write_hits,
                     (unsigned long long)record.color_target.sampled_hits,
@@ -4769,8 +4777,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     uint64_t backend_calls = 0, backend_draws = 0;
                     uint64_t backend_command_buffers = 0, backend_queue_submits = 0;
                     uint64_t backend_fence_waits = 0;
+                    uint64_t backend_gpu_timestamp_samples = 0;
                     double backend_target_ms = 0, backend_draw_setup_ms = 0;
                     double backend_record_upload_ms = 0, backend_gpu_wait_ms = 0;
+                    double backend_gpu_execute_ms = 0;
                     double backend_readback_ms = 0, backend_cleanup_ms = 0;
                     double backend_setup_shader_ms = 0, backend_setup_fixed_ms = 0;
                     double backend_setup_resources_ms = 0, backend_setup_pipeline_ms = 0;
@@ -4803,10 +4813,12 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     timing.backend_command_buffers += pending_timing.backend_command_buffers;
                     timing.backend_queue_submits += pending_timing.backend_queue_submits;
                     timing.backend_fence_waits += pending_timing.backend_fence_waits;
+                    timing.backend_gpu_timestamp_samples += pending_timing.backend_gpu_timestamp_samples;
                     timing.backend_target_ms += pending_timing.backend_target_ms;
                     timing.backend_draw_setup_ms += pending_timing.backend_draw_setup_ms;
                     timing.backend_record_upload_ms += pending_timing.backend_record_upload_ms;
                     timing.backend_gpu_wait_ms += pending_timing.backend_gpu_wait_ms;
+                    timing.backend_gpu_execute_ms += pending_timing.backend_gpu_execute_ms;
                     timing.backend_readback_ms += pending_timing.backend_readback_ms;
                     timing.backend_cleanup_ms += pending_timing.backend_cleanup_ms;
                     timing.backend_setup_shader_ms += pending_timing.backend_setup_shader_ms;
@@ -4864,19 +4876,23 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     fprintf(stderr,
                             "[render-timing] backend-submit calls=%.2f draws=%.1f avg_ms: measured=%.2f "
                             "detail=%.2f target=%.2f draw_setup=%.2f record_upload=%.2f "
-                            "gpu_wait=%.2f readback=%.2f cleanup=%.2f other=%.2f\n",
+                            "gpu_wait=%.2f gpu_device=%.2f gpu_overhead=%.2f readback=%.2f "
+                            "cleanup=%.2f other=%.2f\n",
                             totals.backend_calls / nsub, totals.backend_draws / nsub,
                             totals.backend_ms / nsub, backend_detail_ms / nsub,
                             totals.backend_target_ms / nsub, totals.backend_draw_setup_ms / nsub,
                             totals.backend_record_upload_ms / nsub, totals.backend_gpu_wait_ms / nsub,
+                            totals.backend_gpu_execute_ms / nsub,
+                            std::max(0.0, totals.backend_gpu_wait_ms - totals.backend_gpu_execute_ms) / nsub,
                             totals.backend_readback_ms / nsub, totals.backend_cleanup_ms / nsub,
                             (totals.backend_ms - backend_detail_ms) / nsub);
                     fprintf(stderr,
                             "[render-timing] backend-submit synchronization command_buffers=%.2f "
-                            "queue_submits=%.2f fence_waits=%.2f\n",
+                            "queue_submits=%.2f fence_waits=%.2f timestamps=%.2f\n",
                             totals.backend_command_buffers / nsub,
                             totals.backend_queue_submits / nsub,
-                            totals.backend_fence_waits / nsub);
+                            totals.backend_fence_waits / nsub,
+                            totals.backend_gpu_timestamp_samples / nsub);
                     fprintf(stderr,
                             "[render-timing] backend-submit draw_setup avg_ms: shaders=%.2f fixed=%.2f "
                             "resources=%.2f pipeline=%.2f\n",
@@ -5025,19 +5041,23 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     fprintf(stderr,
                             "[render-window] backend-submit calls=%.2f draws=%.1f avg_ms: measured=%.2f "
                             "detail=%.2f target=%.2f draw_setup=%.2f record_upload=%.2f "
-                            "gpu_wait=%.2f readback=%.2f cleanup=%.2f other=%.2f\n",
+                            "gpu_wait=%.2f gpu_device=%.2f gpu_overhead=%.2f readback=%.2f "
+                            "cleanup=%.2f other=%.2f\n",
                             window.backend_calls / wn, window.backend_draws / wn,
                             window.backend_ms / wn, window_backend_detail_ms / wn,
                             window.backend_target_ms / wn, window.backend_draw_setup_ms / wn,
                             window.backend_record_upload_ms / wn, window.backend_gpu_wait_ms / wn,
+                            window.backend_gpu_execute_ms / wn,
+                            std::max(0.0, window.backend_gpu_wait_ms - window.backend_gpu_execute_ms) / wn,
                             window.backend_readback_ms / wn, window.backend_cleanup_ms / wn,
                             (window.backend_ms - window_backend_detail_ms) / wn);
                     fprintf(stderr,
                             "[render-window] backend-submit synchronization command_buffers=%.2f "
-                            "queue_submits=%.2f fence_waits=%.2f\n",
+                            "queue_submits=%.2f fence_waits=%.2f timestamps=%.2f\n",
                             window.backend_command_buffers / wn,
                             window.backend_queue_submits / wn,
-                            window.backend_fence_waits / wn);
+                            window.backend_fence_waits / wn,
+                            window.backend_gpu_timestamp_samples / wn);
                     fprintf(stderr,
                             "[render-window] backend-submit draw_setup avg_ms: shaders=%.2f fixed=%.2f "
                             "resources=%.2f pipeline=%.2f\n",

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -4845,6 +4845,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         });
     const bool synchronous_results_requested =
         readback_requested || storage_writeback_requested;
+    const bool flush_now = !submission_batch || synchronous_results_requested ||
+                           flush_submission_batch;
     VkBuffer rb = VK_NULL_HANDLE;
     VkDeviceMemory bmem = VK_NULL_HANDLE;
     if (readback_requested) {
@@ -5165,13 +5167,11 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     // Per-draw "fragment funnel" (PROSPER_DRAW_STATS): wrap each recorded draw in pipeline-statistics
     // + occlusion queries to show WHERE its pixels vanish (geometry clipped away, never rasterized,
     // depth/stencil-rejected, or survived) — objective per-draw truth, no oracle needed. Read-only, and
-    // only active with the env var AND a real flush in THIS call (so the results are ready to read back;
-    // the flush condition below is identical to `flush_now` computed after the pass). Query-pool RESET
-    // must be recorded outside a render pass, so it happens here.
+    // only active with the env var AND a real flush in THIS call (so the results are ready to read back).
+    // Query-pool RESET must be recorded outside a render pass, so it happens here.
     const RenderVkCtx& ds_ctx = render_vk_ctx();
-    const bool draw_stats = getenv("PROSPER_DRAW_STATS") && ds_ctx.pipeline_stats_enabled && !dv.empty()
-                            && (!submission_batch || synchronous_results_requested ||
-                                flush_submission_batch);
+    const bool draw_stats = getenv("PROSPER_DRAW_STATS") && ds_ctx.pipeline_stats_enabled &&
+                            !dv.empty() && flush_now;
     VkQueryPool ds_stats_pool = VK_NULL_HANDLE, ds_occ_pool = VK_NULL_HANDLE;
     if (draw_stats) {
         const uint32_t nq = static_cast<uint32_t>(dv.size());
@@ -5218,10 +5218,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
             }) && geom_target < draws.size())
             geom_item = static_cast<size_t>(geom_target);
     }
-    const bool geom_probe = geom_item != SIZE_MAX
-                            && ds_ctx.transform_feedback_enabled
-                            && (!submission_batch || synchronous_results_requested ||
-                                flush_submission_batch);
+    const bool geom_probe = geom_item != SIZE_MAX &&
+                            ds_ctx.transform_feedback_enabled && flush_now;
     static auto p_bindxfb  = reinterpret_cast<PFN_vkCmdBindTransformFeedbackBuffersEXT>(
         vkGetDeviceProcAddr(dev, "vkCmdBindTransformFeedbackBuffersEXT"));
     static auto p_beginxfb = reinterpret_cast<PFN_vkCmdBeginTransformFeedbackEXT>(
@@ -5478,7 +5476,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         restore_persistent_color(persistent_color, readback_color0, img);
         restore_persistent_color(persistent_color1, readback_color1, img1);
     }
-    if (timing_enabled && flush_submission_batch)
+    if (timing_enabled && flush_now)
         active_submission.end_gpu_timestamp(cmd);
     vkEndCommandBuffer(cmd);
 
@@ -5564,8 +5562,6 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         cached_color1->valid = true;
         cached_color1->layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
     }
-    const bool flush_now = !submission_batch || synchronous_results_requested ||
-                           flush_submission_batch;
     BackendSubmissionBatchResult batch_result;
     if (flush_now)
         batch_result = active_submission.submit_and_wait(dev, queue, backend_trace);

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -498,9 +498,9 @@ struct BackendRenderTimingStats {
     double draw_setup_ms = 0;
     double record_upload_ms = 0;
     double gpu_wait_ms = 0;
-    // Device timestamps cover the queued command buffers themselves. This is a subset of
-    // gpu_wait_ms, which also includes host submission, scheduling, and fence wake-up latency.
-    double gpu_execute_ms = 0;
+    // One device timestamp envelope covers the batch from the first command buffer starting through
+    // the final command buffer finishing. It is a subset of the submit/fence wall-clock interval.
+    double gpu_device_ms = 0;
     double readback_ms = 0;
     double cleanup_ms = 0;
     double setup_shader_ms = 0;
@@ -909,7 +909,7 @@ struct BackendSubmissionBatchResult {
     uint64_t queue_submits = 0;
     uint64_t fence_waits = 0;
     uint64_t gpu_timestamp_samples = 0;
-    double gpu_execute_ms = 0.0;
+    double gpu_device_ms = 0.0;
 };
 
 inline constexpr uint64_t backend_timestamp_delta(uint64_t begin, uint64_t end,
@@ -973,9 +973,34 @@ public:
             commands_.push_back(command);
     }
 
-    void add_gpu_timestamp(VkQueryPool pool, double period_ns, uint32_t valid_bits) {
-        if (!pending_resources_abandoned_ && pool && period_ns > 0.0 && valid_bits)
-            gpu_timestamps_.push_back({pool, period_ns, valid_bits});
+    void begin_gpu_timestamp(VkDevice dev, VkCommandBuffer command,
+                             double period_ns, uint32_t valid_bits) {
+        if (pending_resources_abandoned_ || !commands_.empty() || gpu_timestamp_.pool ||
+            !dev || !command || period_ns <= 0.0 || !valid_bits)
+            return;
+        VkQueryPoolCreateInfo query_info{VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO};
+        query_info.queryType = VK_QUERY_TYPE_TIMESTAMP;
+        query_info.queryCount = 2;
+        VkQueryPool pool = VK_NULL_HANDLE;
+        if (vkCreateQueryPool(dev, &query_info, nullptr, &pool) != VK_SUCCESS || !pool)
+            return;
+        gpu_timestamp_ = {dev, pool, period_ns, valid_bits, false};
+        vkCmdResetQueryPool(command, pool, 0, 2);
+        vkCmdWriteTimestamp(command, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, pool, 0);
+    }
+
+    void end_gpu_timestamp(VkCommandBuffer command) {
+        if (pending_resources_abandoned_ || !gpu_timestamp_.pool || gpu_timestamp_.ended || !command)
+            return;
+        // Command buffers in one queue submission may overlap. Make the final timestamp depend on
+        // every earlier command in the batch, so this is one envelope rather than a sum of overlapping
+        // per-command intervals.
+        vkCmdPipelineBarrier(command, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+                             VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0,
+                             0, nullptr, 0, nullptr, 0, nullptr);
+        vkCmdWriteTimestamp(command, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+                            gpu_timestamp_.pool, 1);
+        gpu_timestamp_.ended = true;
     }
 
     void add_cleanup(std::function<void()> cleanup) {
@@ -999,7 +1024,7 @@ public:
 
     void discard() {
         commands_.clear();
-        gpu_timestamps_.clear();
+        release_gpu_timestamp();
         finish_persistent_state(false);
     }
 
@@ -1012,7 +1037,9 @@ public:
     // (registration follows diagnostics).
     void abandon_pending_resources() {
         commands_.clear();
-        gpu_timestamps_.clear();
+        // Vulkan may still own this query pool. Deliberately leak it with the other submitted
+        // resources; destroying it after unproven completion would violate object lifetime.
+        gpu_timestamp_ = {};
         finish_persistent_state(false);
         pending_resources_abandoned_ = true;
         backend_mark_unproven_submission();
@@ -1081,21 +1108,19 @@ public:
             result.submit_result == VK_SUCCESS,
             result.submit_result == VK_SUCCESS && result.wait_result == VK_SUCCESS);
         if (state != BackendSubmissionState::Pending) {
-            if (state == BackendSubmissionState::Complete) {
-                for (const GpuTimestamp& sample : gpu_timestamps_) {
-                    uint64_t values[2]{};
-                    if (vkGetQueryPoolResults(
-                            dev, sample.pool, 0, 2, sizeof(values), values,
-                            sizeof(uint64_t), VK_QUERY_RESULT_64_BIT) != VK_SUCCESS)
-                        continue;
+            if (state == BackendSubmissionState::Complete && gpu_timestamp_.ended) {
+                uint64_t values[2]{};
+                if (vkGetQueryPoolResults(
+                        dev, gpu_timestamp_.pool, 0, 2, sizeof(values), values,
+                        sizeof(uint64_t), VK_QUERY_RESULT_64_BIT) == VK_SUCCESS) {
                     const uint64_t ticks = backend_timestamp_delta(
-                        values[0], values[1], sample.valid_bits);
-                    result.gpu_execute_ms +=
-                        static_cast<double>(ticks) * sample.period_ns / 1'000'000.0;
-                    ++result.gpu_timestamp_samples;
+                        values[0], values[1], gpu_timestamp_.valid_bits);
+                    result.gpu_device_ms =
+                        static_cast<double>(ticks) * gpu_timestamp_.period_ns / 1'000'000.0;
+                    result.gpu_timestamp_samples = 1;
                 }
             }
-            gpu_timestamps_.clear();
+            release_gpu_timestamp();
             vkDestroyFence(dev, fence, nullptr);
             commands_.clear();
             finish_persistent_state(state == BackendSubmissionState::Complete);
@@ -1111,16 +1136,25 @@ public:
 
     void complete() {
         if (pending_resources_abandoned_) return;
+        if (commands_.empty()) release_gpu_timestamp();
         for (auto& cleanup : cleanups_) cleanup();
         cleanups_.clear();
     }
 
 private:
     struct GpuTimestamp {
+        VkDevice dev = VK_NULL_HANDLE;
         VkQueryPool pool = VK_NULL_HANDLE;
         double period_ns = 0.0;
         uint32_t valid_bits = 0;
+        bool ended = false;
     };
+
+    void release_gpu_timestamp() {
+        if (gpu_timestamp_.pool)
+            vkDestroyQueryPool(gpu_timestamp_.dev, gpu_timestamp_.pool, nullptr);
+        gpu_timestamp_ = {};
+    }
 
     void finish_persistent_state(bool completed) {
         if (!completed)
@@ -1131,7 +1165,7 @@ private:
     }
 
     std::vector<VkCommandBuffer> commands_;
-    std::vector<GpuTimestamp> gpu_timestamps_;
+    GpuTimestamp gpu_timestamp_;
     std::vector<std::function<void()>> cleanups_;
     std::vector<std::function<void()>> failure_cleanups_;
     bool pending_resources_abandoned_ = false;
@@ -4840,19 +4874,9 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     VkCommandBuffer cmd; vkAllocateCommandBuffers(dev, &cbai, &cmd);
     VkCommandBufferBeginInfo cbbi{VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO}; cbbi.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
     vkBeginCommandBuffer(cmd, &cbbi);
-    VkQueryPool gpu_timestamp_pool = VK_NULL_HANDLE;
-    if (timing_enabled && ctx.timestamp_valid_bits && ctx.timestamp_period_ns > 0.0) {
-        VkQueryPoolCreateInfo query_info{VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO};
-        query_info.queryType = VK_QUERY_TYPE_TIMESTAMP;
-        query_info.queryCount = 2;
-        if (vkCreateQueryPool(dev, &query_info, nullptr, &gpu_timestamp_pool) == VK_SUCCESS) {
-            vkCmdResetQueryPool(cmd, gpu_timestamp_pool, 0, 2);
-            vkCmdWriteTimestamp(cmd, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
-                                gpu_timestamp_pool, 0);
-        } else {
-            gpu_timestamp_pool = VK_NULL_HANDLE;
-        }
-    }
+    if (timing_enabled)
+        active_submission.begin_gpu_timestamp(
+            dev, cmd, ctx.timestamp_period_ns, ctx.timestamp_valid_bits);
     if (load_cached_color) {
         VkImageMemoryBarrier load{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
         load.oldLayout = cached_color->layout;
@@ -5454,9 +5478,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         restore_persistent_color(persistent_color, readback_color0, img);
         restore_persistent_color(persistent_color1, readback_color1, img1);
     }
-    if (gpu_timestamp_pool)
-        vkCmdWriteTimestamp(cmd, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
-                            gpu_timestamp_pool, 1);
+    if (timing_enabled && flush_submission_batch)
+        active_submission.end_gpu_timestamp(cmd);
     vkEndCommandBuffer(cmd);
 
     // Publish newly uploaded exact-version textures before a later command buffer in the same batch
@@ -5513,8 +5536,6 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
 
     const auto timing_recorded = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
     active_submission.enqueue(cmd);
-    active_submission.add_gpu_timestamp(
-        gpu_timestamp_pool, ctx.timestamp_period_ns, ctx.timestamp_valid_bits);
     if (cached_ds) {
         active_submission.add_failure_cleanup([cached_ds]() {
             cached_ds->layout_initialized = false;
@@ -5924,7 +5945,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     const bool transient_ds = use_ds && cached_ds == nullptr;
     const RenderVkCtx* ctx_ptr = &ctx;
     active_submission.add_cleanup(
-        [dev, pool, gpu_timestamp_pool, dv = std::move(dv), shared_descriptor_pool,
+        [dev, pool, dv = std::move(dv), shared_descriptor_pool,
          shared_pipeline_layouts = std::move(shared_pipeline_layouts),
          shared_descriptor_set_layouts = std::move(shared_descriptor_set_layouts),
          shared_texture_bindings = std::move(shared_texture_bindings),
@@ -5937,8 +5958,6 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
          geom_buf, geom_mem, geom_counter, geom_counter_mem, ctx_ptr,
          color_target_generation]() mutable {
             vkDestroyCommandPool(dev, pool, nullptr);
-            if (gpu_timestamp_pool)
-                vkDestroyQueryPool(dev, gpu_timestamp_pool, nullptr);
             if (ds_stats_pool) vkDestroyQueryPool(dev, ds_stats_pool, nullptr);
             if (ds_occ_pool) vkDestroyQueryPool(dev, ds_occ_pool, nullptr);
             if (geom_buf) vkDestroyBuffer(dev, geom_buf, nullptr);
@@ -6042,7 +6061,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         call_timing.draw_setup_ms = ms(timing_target_ready, timing_draws_ready);
         call_timing.record_upload_ms = ms(timing_draws_ready, timing_recorded);
         call_timing.gpu_wait_ms = ms(timing_recorded, timing_gpu_done);
-        call_timing.gpu_execute_ms = batch_result.gpu_execute_ms;
+        call_timing.gpu_device_ms = batch_result.gpu_device_ms;
         call_timing.readback_ms = ms(timing_gpu_done, timing_readback_done);
         call_timing.cleanup_ms = ms(timing_readback_done, timing_done);
         call_timing.setup_shader_ms = setup_shader_ms;
@@ -6061,7 +6080,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
             uint64_t pipeline_layout_references = 0, unique_pipeline_layouts = 0;
             uint64_t pipeline_references = 0, pipeline_hits = 0, pipeline_misses = 0;
             uint64_t pipeline_bypasses = 0, pipeline_entries = 0, pipeline_evictions = 0;
-            double target = 0, draw_setup = 0, record = 0, gpu_wait = 0, gpu_execute = 0;
+            double target = 0, draw_setup = 0, record = 0, gpu_wait = 0, gpu_device = 0;
             double readback = 0, cleanup = 0;
             double setup_shader = 0, setup_fixed = 0, setup_resources = 0, setup_pipeline = 0;
         };
@@ -6100,7 +6119,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
             timing.draw_setup += call_timing.draw_setup_ms;
             timing.record += call_timing.record_upload_ms;
             timing.gpu_wait += call_timing.gpu_wait_ms;
-            timing.gpu_execute += call_timing.gpu_execute_ms;
+            timing.gpu_device += call_timing.gpu_device_ms;
             timing.readback += call_timing.readback_ms;
             timing.cleanup += call_timing.cleanup_ms;
             timing.setup_shader += call_timing.setup_shader_ms;
@@ -6122,8 +6141,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                     "gpu_overhead=%.2f readback=%.2f cleanup=%.2f\n",
                     (unsigned long long)totals.calls, (unsigned long long)totals.draws, total / n,
                     totals.target / n, totals.draw_setup / n, totals.record / n,
-                    totals.gpu_wait / n, totals.gpu_execute / n,
-                    std::max(0.0, totals.gpu_wait - totals.gpu_execute) / n,
+                    totals.gpu_wait / n, totals.gpu_device / n,
+                    std::max(0.0, totals.gpu_wait - totals.gpu_device) / n,
                     totals.readback / n, totals.cleanup / n);
             fprintf(stderr,
                     "[render-timing] backend synchronization command_buffers=%llu queue_submits=%llu "
@@ -6180,8 +6199,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                     "gpu_overhead=%.2f readback=%.2f cleanup=%.2f\n",
                     (unsigned long long)window.calls, window.draws / wn, window_total / wn,
                     window.target / wn, window.draw_setup / wn, window.record / wn,
-                    window.gpu_wait / wn, window.gpu_execute / wn,
-                    std::max(0.0, window.gpu_wait - window.gpu_execute) / wn,
+                    window.gpu_wait / wn, window.gpu_device / wn,
+                    std::max(0.0, window.gpu_wait - window.gpu_device) / wn,
                     window.readback / wn, window.cleanup / wn);
             fprintf(stderr,
                     "[render-window] backend synchronization command_buffers=%.1f queue_submits=%.1f "
@@ -6360,7 +6379,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
             PROSPER_SUM_TIMING_STAT(draw_setup_ms);
             PROSPER_SUM_TIMING_STAT(record_upload_ms);
             PROSPER_SUM_TIMING_STAT(gpu_wait_ms);
-            PROSPER_SUM_TIMING_STAT(gpu_execute_ms);
+            PROSPER_SUM_TIMING_STAT(gpu_device_ms);
             PROSPER_SUM_TIMING_STAT(readback_ms);
             PROSPER_SUM_TIMING_STAT(cleanup_ms);
             PROSPER_SUM_TIMING_STAT(setup_shader_ms);

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -493,10 +493,14 @@ struct BackendRenderTimingStats {
     uint64_t command_buffers = 0;
     uint64_t queue_submits = 0;
     uint64_t fence_waits = 0;
+    uint64_t gpu_timestamp_samples = 0;
     double target_ms = 0;
     double draw_setup_ms = 0;
     double record_upload_ms = 0;
     double gpu_wait_ms = 0;
+    // Device timestamps cover the queued command buffers themselves. This is a subset of
+    // gpu_wait_ms, which also includes host submission, scheduling, and fence wake-up latency.
+    double gpu_execute_ms = 0;
     double readback_ms = 0;
     double cleanup_ms = 0;
     double setup_shader_ms = 0;
@@ -545,6 +549,8 @@ struct RenderVkCtx {
     VkInstance inst = VK_NULL_HANDLE; VkPhysicalDevice phys = VK_NULL_HANDLE;
     VkDevice dev = VK_NULL_HANDLE; VkQueue queue = VK_NULL_HANDLE; uint32_t qfi = UINT32_MAX;
     VkDeviceSize storage_buffer_alignment = 1;
+    double timestamp_period_ns = 0.0;
+    uint32_t timestamp_valid_bits = 0;
     bool aniso_enabled = false; float max_aniso_limit = 1.0f;
     bool depth_bias_clamp_enabled = false;   // VkPhysicalDeviceFeatures::depthBiasClamp (#1349)
     bool logic_op_enabled = false; bool ok = false;
@@ -655,7 +661,10 @@ inline const RenderVkCtx& render_vk_ctx() {
             if (nq) {
                 std::vector<VkQueueFamilyProperties> qfp(nq);
                 vkGetPhysicalDeviceQueueFamilyProperties(r.phys, &nq, qfp.data());
-                if (r.qfi < nq) family_queue_count = qfp[r.qfi].queueCount;
+                if (r.qfi < nq) {
+                    family_queue_count = qfp[r.qfi].queueCount;
+                    r.timestamp_valid_bits = qfp[r.qfi].timestampValidBits;
+                }
             }
         }
         float prio[2] = {1.0f, 1.0f};
@@ -674,6 +683,7 @@ inline const RenderVkCtx& render_vk_ctx() {
         r.max_compute_workgroup_invocations = phys_props.limits.maxComputeWorkGroupInvocations;
         r.storage_buffer_alignment = std::max<VkDeviceSize>(
             1, phys_props.limits.minStorageBufferOffsetAlignment);
+        r.timestamp_period_ns = phys_props.limits.timestampPeriod;
         r.aniso_enabled = supported.samplerAnisotropy;
         r.depth_bias_clamp_enabled = supported.depthBiasClamp;
         if (r.depth_bias_clamp_enabled) feats.depthBiasClamp = VK_TRUE;
@@ -898,7 +908,17 @@ struct BackendSubmissionBatchResult {
     uint64_t command_buffers = 0;
     uint64_t queue_submits = 0;
     uint64_t fence_waits = 0;
+    uint64_t gpu_timestamp_samples = 0;
+    double gpu_execute_ms = 0.0;
 };
+
+inline constexpr uint64_t backend_timestamp_delta(uint64_t begin, uint64_t end,
+                                                   uint32_t valid_bits) {
+    if (!valid_bits || valid_bits > 64) return 0;
+    if (valid_bits == 64) return end - begin;
+    const uint64_t mask = (uint64_t{1} << valid_bits) - 1u;
+    return (end - begin) & mask;
+}
 
 // A successful queue submit followed by failed fence and queue-idle waits is not an ordinary
 // failure: Vulkan still owns every referenced resource, so those objects must be retained.
@@ -953,6 +973,11 @@ public:
             commands_.push_back(command);
     }
 
+    void add_gpu_timestamp(VkQueryPool pool, double period_ns, uint32_t valid_bits) {
+        if (!pending_resources_abandoned_ && pool && period_ns > 0.0 && valid_bits)
+            gpu_timestamps_.push_back({pool, period_ns, valid_bits});
+    }
+
     void add_cleanup(std::function<void()> cleanup) {
         if (!pending_resources_abandoned_) {
             cleanups_.push_back(std::move(cleanup));
@@ -974,6 +999,7 @@ public:
 
     void discard() {
         commands_.clear();
+        gpu_timestamps_.clear();
         finish_persistent_state(false);
     }
 
@@ -986,6 +1012,7 @@ public:
     // (registration follows diagnostics).
     void abandon_pending_resources() {
         commands_.clear();
+        gpu_timestamps_.clear();
         finish_persistent_state(false);
         pending_resources_abandoned_ = true;
         backend_mark_unproven_submission();
@@ -1054,6 +1081,21 @@ public:
             result.submit_result == VK_SUCCESS,
             result.submit_result == VK_SUCCESS && result.wait_result == VK_SUCCESS);
         if (state != BackendSubmissionState::Pending) {
+            if (state == BackendSubmissionState::Complete) {
+                for (const GpuTimestamp& sample : gpu_timestamps_) {
+                    uint64_t values[2]{};
+                    if (vkGetQueryPoolResults(
+                            dev, sample.pool, 0, 2, sizeof(values), values,
+                            sizeof(uint64_t), VK_QUERY_RESULT_64_BIT) != VK_SUCCESS)
+                        continue;
+                    const uint64_t ticks = backend_timestamp_delta(
+                        values[0], values[1], sample.valid_bits);
+                    result.gpu_execute_ms +=
+                        static_cast<double>(ticks) * sample.period_ns / 1'000'000.0;
+                    ++result.gpu_timestamp_samples;
+                }
+            }
+            gpu_timestamps_.clear();
             vkDestroyFence(dev, fence, nullptr);
             commands_.clear();
             finish_persistent_state(state == BackendSubmissionState::Complete);
@@ -1074,6 +1116,12 @@ public:
     }
 
 private:
+    struct GpuTimestamp {
+        VkQueryPool pool = VK_NULL_HANDLE;
+        double period_ns = 0.0;
+        uint32_t valid_bits = 0;
+    };
+
     void finish_persistent_state(bool completed) {
         if (!completed)
             for (auto cleanup = failure_cleanups_.rbegin();
@@ -1083,6 +1131,7 @@ private:
     }
 
     std::vector<VkCommandBuffer> commands_;
+    std::vector<GpuTimestamp> gpu_timestamps_;
     std::vector<std::function<void()>> cleanups_;
     std::vector<std::function<void()>> failure_cleanups_;
     bool pending_resources_abandoned_ = false;
@@ -4791,6 +4840,19 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     VkCommandBuffer cmd; vkAllocateCommandBuffers(dev, &cbai, &cmd);
     VkCommandBufferBeginInfo cbbi{VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO}; cbbi.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
     vkBeginCommandBuffer(cmd, &cbbi);
+    VkQueryPool gpu_timestamp_pool = VK_NULL_HANDLE;
+    if (timing_enabled && ctx.timestamp_valid_bits && ctx.timestamp_period_ns > 0.0) {
+        VkQueryPoolCreateInfo query_info{VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO};
+        query_info.queryType = VK_QUERY_TYPE_TIMESTAMP;
+        query_info.queryCount = 2;
+        if (vkCreateQueryPool(dev, &query_info, nullptr, &gpu_timestamp_pool) == VK_SUCCESS) {
+            vkCmdResetQueryPool(cmd, gpu_timestamp_pool, 0, 2);
+            vkCmdWriteTimestamp(cmd, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                                gpu_timestamp_pool, 0);
+        } else {
+            gpu_timestamp_pool = VK_NULL_HANDLE;
+        }
+    }
     if (load_cached_color) {
         VkImageMemoryBarrier load{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
         load.oldLayout = cached_color->layout;
@@ -5392,6 +5454,9 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         restore_persistent_color(persistent_color, readback_color0, img);
         restore_persistent_color(persistent_color1, readback_color1, img1);
     }
+    if (gpu_timestamp_pool)
+        vkCmdWriteTimestamp(cmd, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+                            gpu_timestamp_pool, 1);
     vkEndCommandBuffer(cmd);
 
     // Publish newly uploaded exact-version textures before a later command buffer in the same batch
@@ -5448,6 +5513,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
 
     const auto timing_recorded = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
     active_submission.enqueue(cmd);
+    active_submission.add_gpu_timestamp(
+        gpu_timestamp_pool, ctx.timestamp_period_ns, ctx.timestamp_valid_bits);
     if (cached_ds) {
         active_submission.add_failure_cleanup([cached_ds]() {
             cached_ds->layout_initialized = false;
@@ -5857,7 +5924,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     const bool transient_ds = use_ds && cached_ds == nullptr;
     const RenderVkCtx* ctx_ptr = &ctx;
     active_submission.add_cleanup(
-        [dev, pool, dv = std::move(dv), shared_descriptor_pool,
+        [dev, pool, gpu_timestamp_pool, dv = std::move(dv), shared_descriptor_pool,
          shared_pipeline_layouts = std::move(shared_pipeline_layouts),
          shared_descriptor_set_layouts = std::move(shared_descriptor_set_layouts),
          shared_texture_bindings = std::move(shared_texture_bindings),
@@ -5870,6 +5937,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
          geom_buf, geom_mem, geom_counter, geom_counter_mem, ctx_ptr,
          color_target_generation]() mutable {
             vkDestroyCommandPool(dev, pool, nullptr);
+            if (gpu_timestamp_pool)
+                vkDestroyQueryPool(dev, gpu_timestamp_pool, nullptr);
             if (ds_stats_pool) vkDestroyQueryPool(dev, ds_stats_pool, nullptr);
             if (ds_occ_pool) vkDestroyQueryPool(dev, ds_occ_pool, nullptr);
             if (geom_buf) vkDestroyBuffer(dev, geom_buf, nullptr);
@@ -5968,10 +6037,12 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         call_timing.command_buffers = batch_result.command_buffers;
         call_timing.queue_submits = batch_result.queue_submits;
         call_timing.fence_waits = batch_result.fence_waits;
+        call_timing.gpu_timestamp_samples = batch_result.gpu_timestamp_samples;
         call_timing.target_ms = ms(timing_start, timing_target_ready);
         call_timing.draw_setup_ms = ms(timing_target_ready, timing_draws_ready);
         call_timing.record_upload_ms = ms(timing_draws_ready, timing_recorded);
         call_timing.gpu_wait_ms = ms(timing_recorded, timing_gpu_done);
+        call_timing.gpu_execute_ms = batch_result.gpu_execute_ms;
         call_timing.readback_ms = ms(timing_gpu_done, timing_readback_done);
         call_timing.cleanup_ms = ms(timing_readback_done, timing_done);
         call_timing.setup_shader_ms = setup_shader_ms;
@@ -5981,6 +6052,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         struct TimingTotals {
             uint64_t calls = 0, draws = 0;
             uint64_t command_buffers = 0, queue_submits = 0, fence_waits = 0;
+            uint64_t gpu_timestamp_samples = 0;
             uint64_t texture_references = 0, texture_uploads = 0, texture_upload_bytes = 0;
             uint64_t persistent_hits = 0, persistent_misses = 0, persistent_cached_bytes = 0;
             uint64_t texture_binding_references = 0, unique_texture_bindings = 0;
@@ -5989,7 +6061,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
             uint64_t pipeline_layout_references = 0, unique_pipeline_layouts = 0;
             uint64_t pipeline_references = 0, pipeline_hits = 0, pipeline_misses = 0;
             uint64_t pipeline_bypasses = 0, pipeline_entries = 0, pipeline_evictions = 0;
-            double target = 0, draw_setup = 0, record = 0, gpu_wait = 0, readback = 0, cleanup = 0;
+            double target = 0, draw_setup = 0, record = 0, gpu_wait = 0, gpu_execute = 0;
+            double readback = 0, cleanup = 0;
             double setup_shader = 0, setup_fixed = 0, setup_resources = 0, setup_pipeline = 0;
         };
         static TimingTotals totals;
@@ -6000,6 +6073,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
             timing.command_buffers += call_timing.command_buffers;
             timing.queue_submits += call_timing.queue_submits;
             timing.fence_waits += call_timing.fence_waits;
+            timing.gpu_timestamp_samples += call_timing.gpu_timestamp_samples;
             timing.texture_references += texture_stats.references;
             timing.texture_uploads += texture_stats.unique_uploads;
             timing.texture_upload_bytes += texture_stats.upload_bytes;
@@ -6026,6 +6100,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
             timing.draw_setup += call_timing.draw_setup_ms;
             timing.record += call_timing.record_upload_ms;
             timing.gpu_wait += call_timing.gpu_wait_ms;
+            timing.gpu_execute += call_timing.gpu_execute_ms;
             timing.readback += call_timing.readback_ms;
             timing.cleanup += call_timing.cleanup_ms;
             timing.setup_shader += call_timing.setup_shader_ms;
@@ -6043,16 +6118,20 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                                  totals.gpu_wait + totals.readback + totals.cleanup;
             fprintf(stderr,
                     "[render-timing] backend calls=%llu draws=%llu avg_ms: total=%.2f target=%.2f "
-                    "draw_setup=%.2f record_upload=%.2f gpu_wait=%.2f readback=%.2f cleanup=%.2f\n",
+                    "draw_setup=%.2f record_upload=%.2f gpu_wait=%.2f gpu_device=%.2f "
+                    "gpu_overhead=%.2f readback=%.2f cleanup=%.2f\n",
                     (unsigned long long)totals.calls, (unsigned long long)totals.draws, total / n,
                     totals.target / n, totals.draw_setup / n, totals.record / n,
-                    totals.gpu_wait / n, totals.readback / n, totals.cleanup / n);
+                    totals.gpu_wait / n, totals.gpu_execute / n,
+                    std::max(0.0, totals.gpu_wait - totals.gpu_execute) / n,
+                    totals.readback / n, totals.cleanup / n);
             fprintf(stderr,
                     "[render-timing] backend synchronization command_buffers=%llu queue_submits=%llu "
-                    "fence_waits=%llu\n",
+                    "fence_waits=%llu gpu_timestamps=%llu\n",
                     (unsigned long long)totals.command_buffers,
                     (unsigned long long)totals.queue_submits,
-                    (unsigned long long)totals.fence_waits);
+                    (unsigned long long)totals.fence_waits,
+                    (unsigned long long)totals.gpu_timestamp_samples);
             fprintf(stderr,
                     "[render-timing] draw_setup avg_ms: shaders=%.2f fixed=%.2f resources=%.2f pipeline=%.2f\n",
                     totals.setup_shader / n, totals.setup_fixed / n,
@@ -6097,15 +6176,18 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                                         window.gpu_wait + window.readback + window.cleanup;
             fprintf(stderr,
                     "[render-window] backend calls=%llu draws=%.1f avg_ms: total=%.2f target=%.2f "
-                    "draw_setup=%.2f record_upload=%.2f gpu_wait=%.2f readback=%.2f cleanup=%.2f\n",
+                    "draw_setup=%.2f record_upload=%.2f gpu_wait=%.2f gpu_device=%.2f "
+                    "gpu_overhead=%.2f readback=%.2f cleanup=%.2f\n",
                     (unsigned long long)window.calls, window.draws / wn, window_total / wn,
                     window.target / wn, window.draw_setup / wn, window.record / wn,
-                    window.gpu_wait / wn, window.readback / wn, window.cleanup / wn);
+                    window.gpu_wait / wn, window.gpu_execute / wn,
+                    std::max(0.0, window.gpu_wait - window.gpu_execute) / wn,
+                    window.readback / wn, window.cleanup / wn);
             fprintf(stderr,
                     "[render-window] backend synchronization command_buffers=%.1f queue_submits=%.1f "
-                    "fence_waits=%.1f\n",
+                    "fence_waits=%.1f gpu_timestamps=%.1f\n",
                     window.command_buffers / wn, window.queue_submits / wn,
-                    window.fence_waits / wn);
+                    window.fence_waits / wn, window.gpu_timestamp_samples / wn);
             fprintf(stderr,
                     "[render-window] draw_setup avg_ms: shaders=%.2f fixed=%.2f resources=%.2f pipeline=%.2f\n",
                     window.setup_shader / wn, window.setup_fixed / wn,
@@ -6273,10 +6355,12 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
             PROSPER_SUM_TIMING_STAT(command_buffers);
             PROSPER_SUM_TIMING_STAT(queue_submits);
             PROSPER_SUM_TIMING_STAT(fence_waits);
+            PROSPER_SUM_TIMING_STAT(gpu_timestamp_samples);
             PROSPER_SUM_TIMING_STAT(target_ms);
             PROSPER_SUM_TIMING_STAT(draw_setup_ms);
             PROSPER_SUM_TIMING_STAT(record_upload_ms);
             PROSPER_SUM_TIMING_STAT(gpu_wait_ms);
+            PROSPER_SUM_TIMING_STAT(gpu_execute_ms);
             PROSPER_SUM_TIMING_STAT(readback_ms);
             PROSPER_SUM_TIMING_STAT(cleanup_ms);
             PROSPER_SUM_TIMING_STAT(setup_shader_ms);

--- a/prosper/tests/test_texture_sample_render.cpp
+++ b/prosper/tests/test_texture_sample_render.cpp
@@ -429,10 +429,10 @@ int main() {
         const bool gpu_timestamps_supported = timing_ctx.timestamp_valid_bits != 0 &&
                                               timing_ctx.timestamp_period_ns > 0.0;
         CHECK(!gpu_timestamps_supported ||
-                  (consumer_timing.gpu_timestamp_samples == 2 &&
-                   consumer_timing.gpu_execute_ms >= 0.0 &&
-                   consumer_timing.gpu_execute_ms <= consumer_timing.gpu_wait_ms + 0.25),
-              "batched timing reports one bounded device interval per command buffer");
+                  (consumer_timing.gpu_timestamp_samples == 1 &&
+                   consumer_timing.gpu_device_ms > 0.0 &&
+                   consumer_timing.gpu_device_ms <= consumer_timing.gpu_wait_ms),
+              "batched timing reports one device envelope across all command buffers");
 
         prosper::test::BackendDraw add_green;
         add_green.vs = vert; add_green.fs = green; add_green.ps = &additive;

--- a/prosper/tests/test_texture_sample_render.cpp
+++ b/prosper/tests/test_texture_sample_render.cpp
@@ -31,6 +31,10 @@ int main() {
               backend_submission_state(true, true) == BackendSubmissionState::Complete &&
               backend_submission_state(true, false) == BackendSubmissionState::Pending,
           "submission cleanup distinguishes never-submitted, completed, and pending work");
+    CHECK(prosper::test::backend_timestamp_delta(0xfdu, 0x03u, 8) == 6u &&
+              prosper::test::backend_timestamp_delta(11u, 29u, 64) == 18u &&
+              prosper::test::backend_timestamp_delta(11u, 29u, 0) == 0u,
+          "device timestamp deltas handle valid-bit wrap and unsupported queues");
 
     {
         bool speculative_state_valid = true;
@@ -421,6 +425,14 @@ int main() {
                   consumer_timing.command_buffers == 2 &&
                   consumer_timing.queue_submits == 1 && consumer_timing.fence_waits == 1,
               "batched producer-to-sampler output matches synchronous output with one submit/wait");
+        const auto& timing_ctx = prosper::test::render_vk_ctx();
+        const bool gpu_timestamps_supported = timing_ctx.timestamp_valid_bits != 0 &&
+                                              timing_ctx.timestamp_period_ns > 0.0;
+        CHECK(!gpu_timestamps_supported ||
+                  (consumer_timing.gpu_timestamp_samples == 2 &&
+                   consumer_timing.gpu_execute_ms >= 0.0 &&
+                   consumer_timing.gpu_execute_ms <= consumer_timing.gpu_wait_ms + 0.25),
+              "batched timing reports one bounded device interval per command buffer");
 
         prosper::test::BackendDraw add_green;
         add_green.vs = vert; add_green.fs = green; add_green.ps = &additive;

--- a/prosper/tests/test_texture_sample_render.cpp
+++ b/prosper/tests/test_texture_sample_render.cpp
@@ -413,6 +413,14 @@ int main() {
             {batched_sample}, W, H, nullptr, nullptr, false, nullptr,
             nullptr, nullptr, nullptr, &submission_batch, true);
         const auto consumer_timing = prosper::test::backend_render_timing_stats();
+        constexpr uint64_t forced_sync_target_id = 0x9940000000000002ull;
+        prosper::test::BackendColorTarget forced_sync_target{
+            forced_sync_target_id, false, true};
+        prosper::test::BackendSubmissionBatch forced_sync_batch;
+        const std::vector<uint8_t> forced_sync_pixels = prosper::test::render_draws_rgba(
+            {producer}, W, H, nullptr, nullptr, false, &forced_sync_target,
+            nullptr, nullptr, nullptr, &forced_sync_batch, false);
+        const auto forced_sync_timing = prosper::test::backend_render_timing_stats();
 #ifdef _WIN32
         _putenv_s("PROSPER_RENDER_TIMING", "");
 #else
@@ -433,6 +441,13 @@ int main() {
                    consumer_timing.gpu_device_ms > 0.0 &&
                    consumer_timing.gpu_device_ms <= consumer_timing.gpu_wait_ms),
               "batched timing reports one device envelope across all command buffers");
+        CHECK(forced_sync_pixels == first && forced_sync_timing.queue_submits == 1 &&
+                  (!gpu_timestamps_supported ||
+                   (forced_sync_timing.gpu_timestamp_samples == 1 &&
+                    forced_sync_timing.gpu_device_ms > 0.0 &&
+                    forced_sync_timing.gpu_device_ms <= forced_sync_timing.gpu_wait_ms)),
+              "synchronous readback closes its device envelope despite a deferred-flush hint");
+        prosper::test::invalidate_persistent_color_target(forced_sync_target_id);
 
         prosper::test::BackendDraw add_green;
         add_green.vs = vert; add_green.fs = green; add_green.ps = &additive;


### PR DESCRIPTION
## Goal

Continue the Plucky Squire performance investigation in #1390 by separating the renderer's wall-clock submit/fence wait from time spent inside a Vulkan submission on the device.

The existing `gpu_wait` number includes queue submission, queue backlog/scheduling, fence wake-up latency, and actual GPU work. That made the remaining 7–13 ms live-render wait ambiguous.

## Changes

- record the selected render queue family's timestamp-valid bits and the physical device timestamp period
- when `PROSPER_RENDER_TIMING` is enabled, create one timestamp query pool per backend submission batch
- write the start timestamp at the top of the first command buffer
- insert a final all-commands execution dependency and write the end timestamp at the bottom of the command buffer that actually flushes the batch
- calculate one first-start to last-finish device envelope rather than summing command-buffer intervals that Vulkan may overlap
- close the envelope for explicit final flushes and for early flushes forced by readback or storage writeback
- collect results only after the existing completion fence proves the submission is finished, before releasing the pool
- handle partial-width timestamp wrap portably
- report:
  - `gpu_wait`: existing wall-clock submission/fence interval
  - `gpu_device`: device-side batch envelope
  - `gpu_overhead`: residual outside that envelope
  - timestamp envelope count, so unsupported/unavailable results are visible
- explicitly label RTT-local values `batch_wait`, `batch_device`, and `batch_overhead`: under batching the final RTT flush owns the whole batch result, not target-local execution
- preserve the pending-submission lifetime guard by deliberately retaining the query pool when completion cannot be proven
- keep normal runs unchanged: the query pool and timestamp commands exist only when `PROSPER_RENDER_TIMING` is set

## Review-driven correction

The first pushed revision sampled every command buffer and summed TOP-to-BOTTOM spans. Independent review correctly identified that Vulkan command buffers may overlap, so the sum could overcount. The exact current head replaces that design with a single synchronized batch envelope and makes per-RTT batch attribution explicit.

The corrected exact head has an independent no-blocker review: https://github.com/mattias800/prosper/pull/1496#pullrequestreview-4816351096

## Evidence so far

The focused batched producer/consumer regression returns one envelope across two command buffers, is positive, and is bounded by the wall-clock wait with no arbitrary tolerance. A separate regression proves a synchronous readback closes the envelope even when the caller supplied a deferred-flush hint. The timing regression passed 25/25 consecutive runs.

A diagnostic micro-workload reports a small device component (about 0.02 ms) separately from submit/fence overhead. An uncontended live Plucky Squire profile will use this merged diagnostic as soon as the other authorized game session releases the only hardware GPU.

## Exact-head validation

Head: `4e1e6abf8f2f8429ea62f2ad8c49af727a7c14d5`

- clean full project build: pass
- 16 focused Vulkan/renderer tests: 16/16 pass
- focused timestamp/lifetime regression after the final early-flush correction: pass
- repeated timing regression: 25/25 pass
- full CTest: 154/157 pass
- the same three game-dump-dependent tests fail on this worktree/master setup:
  - `module_loads_eboot`
  - `boot_reaches_first_syscall`
  - `real_shader_render`
- focused regression covers partial-valid-bit timestamp wrap, one synchronized envelope across a two-command batch, and early forced flush
- independent exact-head review: no blockers
- GitHub CI: all six required platform jobs green

Closes no issue; this is diagnostic groundwork for #1390.