### PR TITLE
perf(memory): index reserved mapping probes

### DIFF
--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -8,8 +8,10 @@
 #include "sync_futex.hpp"   // shared futex wake + waiter registration (also used by the GPU's label wake)
 #include "../host/guest_memory_map.hpp"
 #include "../host/guest_write_watch.hpp"
+#include <algorithm>
 #include <chrono>
 #include <condition_variable>
+#include <iterator>
 #include <mutex>
 #include <thread>
 #include <unordered_map>
@@ -170,6 +172,16 @@ namespace {
     };
     std::mutex g_mx;
     std::vector<Mapping> g_maps;
+    // Tracking writers split away every overlap. Keep the remaining intervals in base order so
+    // the signal-handler/resource safety probe can find one containing range logarithmically.
+    void insert_mapping_by_base(std::vector<Mapping>& mappings, const Mapping& mapping) {
+        const auto insertion = std::lower_bound(
+            mappings.begin(), mappings.end(), mapping.base,
+            [](const Mapping& candidate, uint64_t address) {
+                return candidate.base < address;
+            });
+        mappings.insert(insertion, mapping);
+    }
     // Direct ("physical") memory: a bump allocator over a FINITE pool. The pool size is what
     // sceKernelGetDirectMemorySize advertises, and exhaustion MUST fail with ENOMEM like real
     // hardware: guests rely on it — UE4 (PPSA17942) sizes its pool requests from
@@ -344,7 +356,7 @@ namespace {
             m.query_flags = query_flags;
             m.committed = committed;
             if (nm) { strncpy(m.name, nm, sizeof m.name - 1); }
-            out.push_back(m);
+            insert_mapping_by_base(out, m);
             g_maps.swap(out);
         }
         host::notify_guest_mapping_added(base, size, committed && (prot & 0x1));
@@ -427,7 +439,7 @@ namespace {
                 changed.guest_prot = guest_prot;
                 changed.committed = true;
                 if (nm) strncpy(changed.name, nm, sizeof changed.name - 1);
-                out.push_back(changed);
+                insert_mapping_by_base(out, changed);
                 retagged.push_back(changed);
             }
             g_maps.swap(out);
@@ -1784,11 +1796,15 @@ HLE(k_release_dmem) {
 // entry points take it, briefly); a contended lock just waits for the other thread's release.
 extern "C" int prosper_reserved_range_state(uint64_t addr) {
     std::lock_guard<std::mutex> lk(g_mx);
-    const Mapping* best = nullptr;
-    for (auto& m : g_maps)
-        if (addr >= m.base && addr < m.base + m.size)
-            if (!best || m.base > best->base) best = &m;
-    return best ? (best->committed ? 2 : 1) : 0;
+    const auto after = std::upper_bound(
+        g_maps.begin(), g_maps.end(), addr,
+        [](uint64_t address, const Mapping& mapping) {
+            return address < mapping.base;
+        });
+    if (after == g_maps.begin()) return 0;
+    const Mapping& mapping = *std::prev(after);
+    const bool contains = addr >= mapping.base && addr - mapping.base < mapping.size;
+    return contains ? (mapping.committed ? 2 : 1) : 0;
 }
 
 // sceKernelBatchMap(SceKernelBatchMapEntry* entries, int numberOfEntries, int* numberOfEntriesOut)
@@ -2048,6 +2064,16 @@ namespace {
     };
     std::mutex g_mx;
     std::vector<Mapping> g_maps;
+    // Keep parity with the POSIX tracker: non-overlapping intervals stay base-ordered for the
+    // fault/resource probe's logarithmic containing-range lookup.
+    void insert_mapping_by_base(std::vector<Mapping>& mappings, const Mapping& mapping) {
+        const auto insertion = std::lower_bound(
+            mappings.begin(), mappings.end(), mapping.base,
+            [](const Mapping& candidate, uint64_t address) {
+                return candidate.base < address;
+            });
+        mappings.insert(insertion, mapping);
+    }
     bool sparse_dmem_view_overlaps(uint64_t begin, uint64_t end);
     constexpr uint64_t kDmemBase  = 0x10000000;
     // Direct-memory budget the pool holds AND sceKernelGetDirectMemorySize advertises. Real PS5
@@ -2195,7 +2221,7 @@ namespace {
             m.query_flags = query_flags;
             m.committed = committed;
             if (nm) { strncpy(m.name, nm, sizeof m.name - 1); }
-            out.push_back(m);
+            insert_mapping_by_base(out, m);
             g_maps.swap(out);
         }
         host::notify_guest_mapping_added(base, size,
@@ -2261,7 +2287,7 @@ namespace {
                 changed.guest_prot = guest_prot;
                 changed.committed = true;
                 if (nm) strncpy(changed.name, nm, sizeof changed.name - 1);
-                out.push_back(changed);
+                insert_mapping_by_base(out, changed);
                 retagged.push_back(changed);
             }
             g_maps.swap(out);
@@ -4097,12 +4123,16 @@ extern "C" int prosper_reserved_range_state(uint64_t addr) {
     bool committed = false;
     {
         std::lock_guard<std::mutex> lk(g_mx);
-        const Mapping* best = nullptr;
-        for (auto& m : g_maps)
-            if (addr >= m.base && addr < m.base + m.size)
-                if (!best || m.base > best->base) best = &m;
-        tracked = best != nullptr;
-        committed = best && best->committed;
+        const auto after = std::upper_bound(
+            g_maps.begin(), g_maps.end(), addr,
+            [](uint64_t address, const Mapping& mapping) {
+                return address < mapping.base;
+            });
+        if (after != g_maps.begin()) {
+            const Mapping& mapping = *std::prev(after);
+            tracked = addr >= mapping.base && addr - mapping.base < mapping.size;
+            committed = tracked && mapping.committed;
+        }
     }
     if (!tracked) return 0;
     if (!committed) return 1;

--- a/prosper/tests/test_retrack_reservation.cpp
+++ b/prosper/tests/test_retrack_reservation.cpp
@@ -283,6 +283,10 @@ int main() {
         volatile uint32_t* cell = (volatile uint32_t*)(uintptr_t)committed;
         *cell = 0x343343u;
         CHECK(*cell == 0x343343u, "the committed page is writable");
+        CHECK(prosper_reserved_range_state(base) == 1 &&
+                  prosper_reserved_range_state(middle) == 2 &&
+                  prosper_reserved_range_state(middle + page) == 1,
+              "ordered lazy-commit lookup preserves split reservation states");
     }
     memset(info, 0, sizeof(info));
     CHECK(query(middle, 0, (uint64_t)(uintptr_t)info, sizeof(info), 0, 0) == 0 &&
@@ -332,6 +336,10 @@ int main() {
           "range protection keeps the trailing page uncommitted");
 
     CHECK(unmap(base, len, 0, 0, 0, 0) == 0, "the test reservation unmaps cleanly");
+    CHECK(prosper_reserved_range_state(base) == 0 &&
+              prosper_reserved_range_state(middle) == 0 &&
+              prosper_reserved_range_state(middle + page) == 0,
+          "ordered lazy-commit lookup rejects every unmapped split");
     protection_start = UINT64_MAX;
     protection_end = UINT64_MAX;
     protection_value = UINT32_MAX;


### PR DESCRIPTION
## Summary

- keep the Linux and Windows guest mapping trackers ordered by base whenever a mapping is inserted
- replace the renderer/fault-path `prosper_reserved_range_state` linear scan with a logarithmic containing-range lookup
- cover committed middle splits, reserved neighbors, and complete unmap rejection in the shared reservation regression

## Why

A fresh, unmodified 4K Plucky Squire run on merged master reached the real `/Game/Levels/_Persistent/MainLevel` gameplay world with Vulkan presentation, SDL/PipeWire audio, and normal input. Portable device timestamps showed that the graphics fence wait is mostly real device work (representative stable window: 5.84 ms device of 7.37 ms wait), but the warmed CPU profile found a larger avoidable host bottleneck:

- `prosper_reserved_range_state`: **9.55% self CPU** on `AgcSubmissionThread`
- `__memmove_avx512_unaligned_erms`: 14.24%
- `__memcmp_evex_movbe`: 3.84%

Safe buffer/texture reads call the range-state probe frequently, including once per 64 KiB chunk. The tracker already removes overlaps on every mutation, but the lookup scanned the complete vector. Preserving base order makes the same exact state decision in O(log n) without weakening the unmapped/reserved/committed distinction.

This is shared memory infrastructure; there are no game IDs, shader addresses, output substitutions, or title-specific policy.

## Verification

- full app and all local targets build
- focused memory suite: 6/6
  - `dmem_available`
  - `reserve_placement`
  - `retrack_reservation`
  - `map_noreplace`
  - `prot_none`
  - `guest_memory_map`
- full local CTest: **154/157**, with only the same expected private-dump fixture mismatches:
  - `module_loads_eboot`
  - `boot_reaches_first_syscall`
  - `real_shader_render`

## Matched live A/B

The post-change run used the same executable path, 4K rendering, savedata, wall-clock input route, timing instrumentation, and `/Game/Levels/_Persistent/MainLevel` gameplay path as the baseline.

First 20 gameplay timing windows:

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| callbacks/window | 2.30 | 2.30 | matched |
| frontend build-resources | 19.68 ms | 13.43 ms | **-31.8%** |
| frontend total | 34.97 ms | 27.30 ms | **-21.9%** |
| backend | 14.78 ms | 13.17 ms | -10.9% |

A fresh 30-second, zero-lost-sample gameplay profile no longer reports `prosper_reserved_range_state` above the 0.05% reporting floor, down from 9.55% self CPU in the baseline. The remaining top host cost is resource movement (`__memmove_avx512_unaligned_erms`, 8.19% overall); this PR intentionally stops at the independently measured mapping lookup.

Artifacts are preserved locally in:
- before: `/home/mattias800/plucky-diagnostics/gpu-device-profile.9yMSUF`
- after: `/home/mattias800/plucky-diagnostics/range-lookup-after.WrcQdX`

Closes no issue; continues #1390.
