### PR TITLE
perf(gpu): scale texture residency to 4 GiB

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -390,7 +390,7 @@ size_t texture_decode_cache_limit_bytes(const char* override_mib,
                                         uint64_t physical_memory_bytes) {
     constexpr uint64_t kMiB = 1024ull * 1024ull;
     constexpr uint64_t kMinBytes = 1024ull * kMiB;
-    constexpr uint64_t kMaxBytes = 2048ull * kMiB;
+    constexpr uint64_t kMaxBytes = 4096ull * kMiB;
     uint64_t bytes = kMinBytes;
     if (override_mib) {
         const uint64_t mib = strtoull(override_mib, nullptr, 10);

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -1269,11 +1269,11 @@ inline void init_persistent_color_target_device_budget(
 // Sampled images and color targets are independent residency pools. A large immutable source can
 // legitimately approach one GiB by itself (for example a maximum-size block-compressed atlas after
 // expansion), so the historical fixed 1 GiB image budget can continuously evict the rest of a hot
-// set. Keep small GPUs at that old bound while allowing capable devices up to 2 GiB. Unlike an
+// set. Keep small GPUs at that old bound while allowing capable devices up to 4 GiB. Unlike an
 // allocation, this is only a ceiling; memory is committed on exact-version cache insertion.
 inline VkDeviceSize persistent_texture_cache_budget_for_heap(VkDeviceSize heap) {
     constexpr VkDeviceSize min_bytes = 1024ull * 1024ull * 1024ull;
-    constexpr VkDeviceSize max_bytes = 2048ull * 1024ull * 1024ull;
+    constexpr VkDeviceSize max_bytes = 4096ull * 1024ull * 1024ull;
     return std::clamp<VkDeviceSize>(heap / 8u, min_bytes, max_bytes);
 }
 

--- a/prosper/tests/test_gpu_capture_render.cpp
+++ b/prosper/tests/test_gpu_capture_render.cpp
@@ -919,7 +919,7 @@ int main() {
               "an absurd declaration is still bounded by the 64 MiB ceiling");
     }
 
-    // A cache ceiling is not a preallocation. Scale capable hosts/devices to 2 GiB so one large
+    // A cache ceiling is not a preallocation. Scale capable hosts/devices to 4 GiB so one large
     // immutable atlas cannot evict the rest of a frame's hot set, while an 8 GiB machine retains the
     // historical 1 GiB bound. Explicit overrides remain exact for diagnostics and constrained hosts.
     {
@@ -929,12 +929,20 @@ int main() {
               "an 8 GiB host keeps the 1 GiB decoded-texture ceiling");
         CHECK(texture_decode_cache_limit_bytes(nullptr, 16ull * GiB) == 2ull * GiB,
               "a capable host admits the 2 GiB decoded-texture ceiling");
+        CHECK(texture_decode_cache_limit_bytes(nullptr, 32ull * GiB) == 4ull * GiB,
+              "a large host admits the 4 GiB decoded-texture ceiling");
+        CHECK(texture_decode_cache_limit_bytes(nullptr, 128ull * GiB) == 4ull * GiB,
+              "decoded-texture auto sizing remains capped at 4 GiB");
         CHECK(texture_decode_cache_limit_bytes("512", 128ull * GiB) == 512ull * 1024ull * 1024ull,
               "the decoded-texture MiB override takes precedence over host memory");
         CHECK(prosper::test::persistent_texture_cache_budget_for_heap(8ull * GiB) == 1ull * GiB,
               "an 8 GiB device keeps the 1 GiB sampled-image ceiling");
         CHECK(prosper::test::persistent_texture_cache_budget_for_heap(16ull * GiB) == 2ull * GiB,
               "a capable device admits the 2 GiB sampled-image ceiling");
+        CHECK(prosper::test::persistent_texture_cache_budget_for_heap(32ull * GiB) == 4ull * GiB,
+              "a large device admits the 4 GiB sampled-image ceiling");
+        CHECK(prosper::test::persistent_texture_cache_budget_for_heap(128ull * GiB) == 4ull * GiB,
+              "sampled-image auto sizing remains capped at 4 GiB");
 
         using prosper::frontend::texture_decode_cache_candidate;
         CHECK(texture_decode_cache_candidate(false, false, false, 1u, true, true),


### PR DESCRIPTION
## Summary

- raise the automatic decoded-texture cache ceiling from 2 GiB to 4 GiB on hosts with at least 32 GiB RAM
- raise the automatic persistent sampled-image cache ceiling from 2 GiB to 4 GiB on devices with at least 32 GiB local/shared heap
- preserve the existing one-eighth scaling, so 8 GiB and 16 GiB systems remain at 1 GiB and 2 GiB respectively
- keep explicit environment overrides exact
- test the complete 1/2/4 GiB scaling and 4 GiB clamp for both cache layers

## Why

After #1497 removed the mapping-probe hotspot, a matched Plucky Squire gameplay profile showed the two 2 GiB texture caches at their ceilings while the renderer continued to decode and upload a larger working set. This is a ceiling, not a preallocation.

Three full 4K runs used the same savedata, wall-clock input script, real `/Game/Levels/_Persistent/MainLevel` route, timing instrumentation, audio, and Vulkan presentation:

1. shipped 2 GiB frontend + 2 GiB backend
2. 4 GiB frontend + 4 GiB backend
3. shipped 2 GiB frontend + 4 GiB backend

Matched later gameplay windows 21–31:

| Budget | callbacks/window | frontend build | backend | frontend total |
| --- | ---: | ---: | ---: | ---: |
| 2 + 2 GiB | 1.65 | 23.21 ms | 35.10 ms | 59.80 ms |
| 2 + 4 GiB | 1.67 | 23.81 ms | 30.01 ms | 55.02 ms |
| 4 + 4 GiB | 1.71 | 23.45 ms | 26.62 ms | 50.83 ms |

The combined policy reduced total time by **15.0%** versus the shipped ceilings. The isolated backend increase recovered about 8%; preserving decoded versions in the frontend provided the rest by reducing backend version/upload churn.

At the equal-route 31st gameplay window, the combined run had nearly identical backend texture references (1.659M vs 1.663M) while cumulative upload traffic fell from **43.5 GiB to 36.8 GiB (-15.3%)** and uploads fell from 3409 to 3178. The frontend held 3.70 GiB / 822 entries and the backend 4.08 GiB, proving the extra capacity was used. Peak observed process RSS was about 12 GiB on the 121 GiB test host.

This is generic device/host scaling only: no game ID, shader address, title-specific path, or output substitution.

## Verification

- focused `test_gpu_capture_render` builds and passes
- budget coverage verifies:
  - 8 GiB -> 1 GiB
  - 16 GiB -> 2 GiB
  - 32 GiB -> 4 GiB
  - 128 GiB remains clamped to 4 GiB
  - explicit frontend override still wins
- full app and all local targets build
- full local CTest: **154/157**, with only the same expected private-dump fixture mismatches:
  - `module_loads_eboot`
  - `boot_reaches_first_syscall`
  - `real_shader_render`
- matched live artifacts:
  - 2 + 2 GiB: `/home/mattias800/plucky-diagnostics/range-lookup-after.WrcQdX`
  - 4 + 4 GiB: `/home/mattias800/plucky-diagnostics/cache4g.b24Ibu`
  - 2 + 4 GiB: `/home/mattias800/plucky-diagnostics/backend4g-only`

Continues #1390.

