### PR TITLE
perf(gpu): borrow exact RTT snapshots

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -1474,8 +1474,12 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // scratch copy. The normal exact-extent path can borrow the immutable RTT
                         // snapshot and avoid copying it into texstore before the backend upload.
                         static const bool cpu_rtt_copy_diagnostics =
-                            getenv("PROSPER_DUMP_SAMPLED_RTT") || getenv("PROSPER_DUMP_TEX") ||
-                            getenv("PROSPER_DUMP_ATLAS") || getenv("PROSPER_KILL_RING");
+                            getenv("PROSPER_DUMP_SAMPLED_RTT") || getenv("PROSPER_DUMP_RAWTEX") ||
+                            getenv("PROSPER_GFXLOG") || getenv("PROSPER_RESOURCE_HASH_DIM") ||
+                            getenv("PROSPER_PALETTELOG") || getenv("PROSPER_TESTTEX") ||
+                            getenv("PROSPER_TESTLUT") || getenv("PROSPER_TESTLUT32") ||
+                            getenv("PROSPER_DUMP_TEX") || getenv("PROSPER_DUMP_ATLAS") ||
+                            getenv("PROSPER_KILL_RING");
                         const bool borrow_cpu_live_rtt = has_cpu_live_rtt &&
                             borrow_exact_cpu_rtt && !cpu_rtt_copy_diagnostics &&
                             prosper::frontend::exact_rtt_snapshot_borrowable(

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -1468,6 +1468,21 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 prosper::test::backend_color_bytes_per_pixel(
                                     prosper::test::backend_color_format(live_rtt->second.format)),
                                 live_rtt->second.rgba->size());
+                        static const bool borrow_exact_cpu_rtt =
+                            getenv("PROSPER_NO_RTT_SNAPSHOT_BORROW") == nullptr;
+                        // Pixel-mutating/inspection diagnostics intentionally retain their owned
+                        // scratch copy. The normal exact-extent path can borrow the immutable RTT
+                        // snapshot and avoid copying it into texstore before the backend upload.
+                        static const bool cpu_rtt_copy_diagnostics =
+                            getenv("PROSPER_DUMP_SAMPLED_RTT") || getenv("PROSPER_DUMP_TEX") ||
+                            getenv("PROSPER_DUMP_ATLAS") || getenv("PROSPER_KILL_RING");
+                        const bool borrow_cpu_live_rtt = has_cpu_live_rtt &&
+                            borrow_exact_cpu_rtt && !cpu_rtt_copy_diagnostics &&
+                            prosper::frontend::exact_rtt_snapshot_borrowable(
+                                tw, th, live_rtt->second.w, live_rtt->second.h,
+                                prosper::test::backend_color_bytes_per_pixel(
+                                    live_rtt->second.format),
+                                live_rtt->second.rgba->size());
                         // A retained render target was created for color-attachment + sampled usage,
                         // not storage usage. Storage images therefore take the decoded/upload path.
                         const bool has_gpu_live_rtt = !fr.is_storage_image && live_gpu_targets &&
@@ -2218,7 +2233,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         size_t linear_source_prefix_size = 0;
                         if (texstore_used == texstore.size()) texstore.emplace_back();
                         std::vector<uint8_t>& texture_pixels = texstore[texstore_used++];
-                        texture_pixels.resize(nb);
+                        if (borrow_cpu_live_rtt) texture_pixels.clear();
+                        else texture_pixels.resize(nb);
                         auto copy_linear_padded_rows = [&](uint8_t* dst, size_t dst_row) {
                             size_t total = 0;
                             for (uint32_t y = 0; y < th; ++y) {
@@ -2278,8 +2294,15 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 !rit->second.rgba->empty()) {
                                 const RttSurf& s = rit->second;
                                 const uint32_t rtt_bpp = prosper::test::backend_color_bytes_per_pixel(s.format);
-                                if (prosper::frontend::inject_rtt_pixels(
-                                        texture_pixels, tw, th, *s.rgba, s.w, s.h, rtt_bpp)) {
+                                if (borrow_cpu_live_rtt) {
+                                    fr.tex_rgba_owner = s.rgba;
+                                    fr.tex_rgba = s.rgba->data();
+                                    fr.texture_format = s.format;
+                                    rtt_hit = true;
+                                    resource_rtt_hit = true;
+                                } else if (prosper::frontend::inject_rtt_pixels(
+                                               texture_pixels, tw, th, *s.rgba,
+                                               s.w, s.h, rtt_bpp)) {
                                     fr.texture_format = s.format;
                                     rtt_hit = true;
                                     resource_rtt_hit = true;
@@ -2973,7 +2996,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         if (getenv("PROSPER_KILL_RING") && tw == 1024 && th == 1024 &&
                             r.num_components == 1 && r.cls == RC::Texture)
                             std::fill(texture_pixels.begin(), texture_pixels.end(), 0);
-                        fr.tex_rgba = texture_pixels.data(); fr.tw = tw; fr.th = cube_done ? th * 6u : th;
+                        if (!fr.tex_rgba) fr.tex_rgba = texture_pixels.data();
+                        fr.tw = tw; fr.th = cube_done ? th * 6u : th;
                         fr.td = is_volume ? r.depth : 1u;
                         fr.img_dim = r.img_dim;
                         // #1272: see the reuse path — plain 2D guest textures only.

--- a/prosper/frontends/shared/rtt_injection.hpp
+++ b/prosper/frontends/shared/rtt_injection.hpp
@@ -8,6 +8,20 @@
 
 namespace prosper::frontend {
 
+// An immutable CPU RTT snapshot can back a FrameResource directly only when the consumer uses the
+// producer's exact extent and byte layout. Scaled views still need their owned nearest-neighbor copy;
+// malformed snapshots stay on the guest-decode fallback.
+inline bool exact_rtt_snapshot_borrowable(uint32_t dst_w, uint32_t dst_h,
+                                          uint32_t src_w, uint32_t src_h,
+                                          uint32_t bytes_per_pixel,
+                                          size_t source_bytes) {
+    if (!dst_w || !dst_h || dst_w != src_w || dst_h != src_h || !bytes_per_pixel)
+        return false;
+    const uint64_t texels = static_cast<uint64_t>(src_w) * src_h;
+    if (texels > std::numeric_limits<size_t>::max() / bytes_per_pixel) return false;
+    return source_bytes == static_cast<size_t>(texels) * bytes_per_pixel;
+}
+
 namespace detail {
 
 template <size_t BytesPerPixel>

--- a/prosper/frontends/shared/test_rtt_injection.cpp
+++ b/prosper/frontends/shared/test_rtt_injection.cpp
@@ -5,12 +5,21 @@
 #include <vector>
 
 using prosper::frontend::inject_rtt_pixels;
+using prosper::frontend::exact_rtt_snapshot_borrowable;
 
 static int failures = 0;
 #define CHECK(cond) do { if (!(cond)) { \
     std::fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond); ++failures; } } while (0)
 
 int main() {
+    CHECK(exact_rtt_snapshot_borrowable(4, 2, 4, 2, 8, 4 * 2 * 8));
+    CHECK(!exact_rtt_snapshot_borrowable(2, 1, 4, 2, 8, 4 * 2 * 8));
+    CHECK(!exact_rtt_snapshot_borrowable(4, 2, 4, 2, 8, 4 * 2 * 8 - 1));
+    CHECK(!exact_rtt_snapshot_borrowable(4, 2, 4, 2, 0, 0));
+    CHECK(!exact_rtt_snapshot_borrowable(
+        UINT32_MAX, UINT32_MAX, UINT32_MAX, UINT32_MAX, 16,
+        std::numeric_limits<size_t>::max()));
+
     // #1293: a 1D consumer was provisionally allocated at RGBA8 (4 B/px), then an exact-size FP16
     // RTT injection memcpy'd 8 B/px into it. The helper must resize from the producer's real stride.
     std::vector<uint8_t> fp16_source(4 * 2 * 8);

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -99,6 +99,9 @@ struct FrameResource {
     // zero-initialized 64 KiB allocation shared across ordered render calls.
     bool is_internal_gds = false;
     const uint8_t* tex_rgba = nullptr;   // non-null => a texture; then tw/th are its dimensions
+    // Optional immutable owner for borrowed frontend pixels. Keeping this beside the raw pointer
+    // makes FrameResource copies/moves retain the source through synchronous backend upload setup.
+    std::shared_ptr<const std::vector<uint8_t>> tex_rgba_owner;
     uint32_t tw = 0, th = 0, td = 1;
     // T#-declared mip-chain length (#1272). 1 (default) = single-level upload, the historical
     // behavior. >1 lets the backend generate a box-filtered chain — bounded by this declared count —

--- a/prosper/tests/test_gpu_capture_render.cpp
+++ b/prosper/tests/test_gpu_capture_render.cpp
@@ -944,6 +944,20 @@ int main() {
         CHECK(prosper::test::persistent_texture_cache_budget_for_heap(128ull * GiB) == 4ull * GiB,
               "sampled-image auto sizing remains capped at 4 GiB");
 
+        // Live exact-extent RTT consumers borrow an immutable snapshot instead of copying it
+        // through frontend scratch. FrameResource copies retain that backing through upload setup.
+        auto pixels = std::make_shared<const std::vector<uint8_t>>(16, 0x5a);
+        prosper::test::FrameResource source;
+        source.tex_rgba_owner = pixels;
+        source.tex_rgba = pixels->data();
+        prosper::test::FrameResource retained = source;
+        source.tex_rgba_owner.reset();
+        pixels.reset();
+        CHECK(retained.tex_rgba_owner &&
+                  retained.tex_rgba == retained.tex_rgba_owner->data() &&
+                  retained.tex_rgba_owner->front() == 0x5a,
+              "a copied FrameResource retains borrowed RTT pixels");
+
         using prosper::frontend::texture_decode_cache_candidate;
         CHECK(texture_decode_cache_candidate(false, false, false, 1u, true, true),
               "an ordinary supported guest 2D texture uses the decoded-texture cache");


### PR DESCRIPTION
## Summary

- let exact-extent CPU render-target snapshots back a live `FrameResource` directly instead of copying through reusable frontend texture scratch
- carry explicit shared ownership beside the raw texture pointer so resource copies/moves retain immutable bytes through backend upload setup
- keep scaled views and every pixel-mutating/inspection diagnostic on the established owned-copy path
- keep `PROSPER_NO_RTT_SNAPSHOT_BORROW=1` as a matched A/B and conservative fallback
- test exact-shape/malformed/overflow eligibility plus copied-resource ownership

## Why

After #1497 and #1498, the warmed 4K Plucky Squire gameplay profile moved its next visible host costs to:

- `__memmove_avx512_unaligned_erms`: 10.38%
- `prosper::frontend::inject_rtt_pixels`: 3.49%

The frontend RTT cache already stores CPU snapshots as immutable `shared_ptr<const vector<uint8_t>>`. For an exact-size consumer, `inject_rtt_pixels` copied that full snapshot into a reusable vector, after which the backend copied the same bytes into its upload buffer. Retaining the immutable owner in `FrameResource` removes the first copy without weakening lifetime or mutation rules.

Scaled consumers still require nearest-neighbor materialization. Texture dumps, hashes, logs, synthetic texture overrides, and other developer probes retain scratch bytes so their established inspection/mutation behavior is unchanged.

This is generic renderer ownership and shape policy; there is no game identity, shader address, title-specific path, or output substitution.

## Live evidence

Matched full-resolution Vulkan/audio/input Plucky Squire runs used the same save and `reach-first-gameplay.pad` route.

Submission-thread `perf` profile:

| Self CPU | 4 GiB baseline | Borrow candidate |
|---|---:|---:|
| `inject_rtt_pixels` | 3.49% | below 0.05% |
| `__memmove_avx512_unaligned_erms` | 10.38% | below 0.05% |
| samples | — | 9,666 |

Steady matched gameplay windows 21–31:

| Metric | Baseline | Borrow | Change |
|---|---:|---:|---:|
| callbacks/window | 1.71 | 1.66 | -2.9% |
| frontend build | 23.45 ms | 22.21 ms | -5.3% |
| backend | 26.62 ms | 24.52 ms | -7.9% |
| total submission | 50.83 ms | 47.54 ms | -6.5% |

The follow-up commit only broadens the opt-out for developer diagnostics; the default gameplay path measured above is unchanged.

## Verification

Exact head `944aa545a`:

- affected shared-resource build: pass (`prosper-app`, replay/renderer tests and all 39 dependent targets)
- `test_rtt_injection`: pass
  - exact extent/layout accepted
  - scaled extent rejected
  - malformed size rejected
  - zero stride rejected
  - overflow rejected
- `test_gpu_capture_render`: pass, including copied-`FrameResource` borrowed-owner lifetime assertion
- full local CTest: 154/157 pass
  - the same three private-fixture mismatches remain: GTA eboot expectations, missing private Il2cpp PRX, and missing embedded shader fixture
- `git diff --check`: pass

Continues #1390.
