### PR TITLE
chore: keep run artifacts and build temporaries off the /tmp tmpfs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -266,6 +266,27 @@ Messenger depth, vertex-fetch, geometry, palette, or tiling hypotheses without c
   cd /mnt/c/Users/matti/repos/ps5ys/prosper/build-linux
   cmake --build . -j8 && ctest        # 99/99 expected green on Linux
   ```
+- **Write run artifacts and build temporaries to the real disk, never `/tmp`.** On the Linux box `/tmp`
+  is a **RAM-backed tmpfs sized at 50% of RAM, with a per-user quota shared by every concurrent agent**.
+  A single `.prgcap` is 200 MB–2.7 GB, a 4K `.bmp` is 24 MB, and a `PROSPER_GFXLOG`/`PROSPER_DBG` run log
+  reaches 1.5 GB, so a few sessions of ordinary capture work exhaust the quota. When that happens it does
+  not just fail your write — it **eats the machine's RAM and kills the Bash tool outright for every
+  agent**, because the harness stores each command's output under `$TMPDIR`. Put captures, frame dumps,
+  screenshots and logs in a gitignored worktree-local directory or under `/var/tmp` (real disk, and
+  `systemd-tmpfiles` already ages it), and always build with `TMPDIR` off the tmpfs — gcc's compile
+  temporaries are large enough on their own to break a `-j8` build with
+  `error writing to /tmp/ccXXXX.s: Disk quota exceeded`:
+  ```bash
+  mkdir -p <worktree>/build/tmpdir
+  distrobox enter ps5ys -- bash -lc "cd <worktree> && TMPDIR=\$PWD/build/tmpdir cmake --build build -j6"
+  ```
+  **Diagnosing an exhausted `/tmp`:** every Bash call returns exit 1 with no output — including `true`
+  and `echo hello`, foreground or background — which looks identical to a dead working directory. The
+  tell is the **Write tool returning `EDQUOT`** for a path under `/tmp` (if Write to `/tmp` succeeds, it
+  is the cwd instead). It is recoverable from inside the session: the commands still *execute*, only the
+  output capture fails, so redirect stdout **and** stderr to a file on the real disk, end with `exit 0`,
+  read that file, and `rm -rf` scratch that is a day or more old. Leave `/tmp/claude-*` and anything
+  touched in the last few hours alone — other agents are live.
 - **Verification is agentic-first / programmatic** (`docs/VERIFICATION.md`): ctest exit code is truth;
   shaders are `spirv-val`-gated; rendered frames are asserted by pixels, hashes, or routed content
   metrics. Snapshots are a **release-time regression inventory**, not a day-to-day development or merge


### PR DESCRIPTION
## Why

`/tmp` on the Linux development box is a **RAM-backed tmpfs sized at 50% of RAM (61 GiB here) with a
per-user quota (48.6 GiB) shared by every concurrent agent session**. The artifacts this project's normal
workflow produces are large:

| artifact | size |
|----------|------|
| one `.prgcap` | 200 MB – 2.7 GB |
| one 4K `.bmp` frame dump | 24 MB |
| one `PROSPER_DBG` / `PROSPER_GFXLOG` run log | up to 1.5 GB |

So a few sessions of ordinary capture work fill it. Measured on 2026-07-30: 43.4 of 48.6 GiB consumed,
30.7 GB of which was scratch from the preceding five days across the concurrent agents.

Exhausting the quota is not a local failure. It **kills the Bash tool outright for every agent**, because
the harness writes each command's stdout to `$TMPDIR/claude-*/…`: every call returns exit 1 with no
output, including `true`. It also costs real RAM — reclaiming those 30 GB moved `MemAvailable` from
27.8 GB to 45.9 GB, which directly affects the emulator runs sharing the machine. It happened twice on
2026-07-30, once mid-build as `error writing to /tmp/ccXXXX.s: Disk quota exceeded` and once as a total
tool outage.

## What changed

One bullet in `CLAUDE.md`, next to the build instructions that need it:

- artifacts (captures, frame dumps, screenshots, logs) belong in a gitignored worktree-local directory or
  under `/var/tmp` — real disk, and `systemd-tmpfiles` already ages it at 30 days;
- builds pass `TMPDIR` off the tmpfs, since gcc's compile temporaries alone are enough to break a `-j8`
  build;
- the failure's signature is recorded, because it is easy to misdiagnose: exit 1 with no output looks
  exactly like a dead working directory. The discriminator is the **Write tool returning `EDQUOT`** for a
  path under `/tmp`;
- the in-session recovery is recorded: the commands still *execute*, only the output capture fails, so
  redirecting stdout and stderr to the real disk works and the stale scratch can be removed without a
  restart. This corrects the assumption that the session must be abandoned.

## Affected / unaffected

Documentation only — no build, test, or runtime behavior changes, so CI is the only gate. Existing
worktree-local build dirs already follow the recipe; nothing needs migrating.

## Verification

`git diff --check` clean. No code paths touched.