### PR TITLE
perf(gpu): share scaled RTT snapshots

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -1248,6 +1248,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     target_step_w = target_step_h = 0;
             const size_t target_step_min_draws = getenv("PROSPER_TARGET_STEP_HASH_MIN_DRAWS")
                 ? std::max<long>(2, atol(getenv("PROSPER_TARGET_STEP_HASH_MIN_DRAWS"))) : 2;
+            prosper::frontend::RttInjectionCache rtt_injection_cache;
             // Build one draw's set-tagged resources from its VS (set 0) + PS (set 1) tables — read the
             // bytes from 1:1-mapped guest memory, detile textures. (Each constant/vertex buffer + texture
             // gets its own binding; the recompiler declared a storage buffer / image sampler at each.)
@@ -1468,11 +1469,11 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 prosper::test::backend_color_bytes_per_pixel(
                                     prosper::test::backend_color_format(live_rtt->second.format)),
                                 live_rtt->second.rgba->size());
-                        static const bool borrow_exact_cpu_rtt =
+                        static const bool retain_cpu_rtt_snapshots =
                             getenv("PROSPER_NO_RTT_SNAPSHOT_BORROW") == nullptr;
                         // Pixel-mutating/inspection diagnostics intentionally retain their owned
-                        // scratch copy. The normal exact-extent path can borrow the immutable RTT
-                        // snapshot and avoid copying it into texstore before the backend upload.
+                        // scratch copy. Normal consumers retain exact immutable snapshots directly
+                        // and share each scaled materialization within this submit callback.
                         static const bool cpu_rtt_copy_diagnostics =
                             getenv("PROSPER_DUMP_SAMPLED_RTT") || getenv("PROSPER_DUMP_RAWTEX") ||
                             getenv("PROSPER_GFXLOG") || getenv("PROSPER_RESOURCE_HASH_DIM") ||
@@ -1480,10 +1481,15 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             getenv("PROSPER_TESTLUT") || getenv("PROSPER_TESTLUT32") ||
                             getenv("PROSPER_DUMP_TEX") || getenv("PROSPER_DUMP_ATLAS") ||
                             getenv("PROSPER_KILL_RING");
-                        const bool borrow_cpu_live_rtt = has_cpu_live_rtt &&
-                            borrow_exact_cpu_rtt && !cpu_rtt_copy_diagnostics &&
-                            prosper::frontend::exact_rtt_snapshot_borrowable(
-                                tw, th, live_rtt->second.w, live_rtt->second.h,
+                        // Match the established CPU injection gate below. Cube descriptors and
+                        // mismatched 2D views can also retain identical materialized bytes; 3D
+                        // volumes, storage images, and mip tails remain on their specialized paths.
+                        const bool retain_cpu_live_rtt = retain_cpu_rtt_snapshots &&
+                            !cpu_rtt_copy_diagnostics && !fr.is_storage_image &&
+                            r.img_dim != 2u && !r.in_mip_tail && live_rtt != g_rtt.end() &&
+                            live_rtt->second.w && live_rtt->second.h && live_rtt->second.rgba &&
+                            prosper::frontend::live_rtt_cpu_snapshot_matches(
+                                live_rtt->second.w, live_rtt->second.h,
                                 prosper::test::backend_color_bytes_per_pixel(
                                     live_rtt->second.format),
                                 live_rtt->second.rgba->size());
@@ -2237,7 +2243,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         size_t linear_source_prefix_size = 0;
                         if (texstore_used == texstore.size()) texstore.emplace_back();
                         std::vector<uint8_t>& texture_pixels = texstore[texstore_used++];
-                        if (borrow_cpu_live_rtt) texture_pixels.clear();
+                        if (retain_cpu_live_rtt) texture_pixels.clear();
                         else texture_pixels.resize(nb);
                         auto copy_linear_padded_rows = [&](uint8_t* dst, size_t dst_row) {
                             size_t total = 0;
@@ -2298,9 +2304,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 !rit->second.rgba->empty()) {
                                 const RttSurf& s = rit->second;
                                 const uint32_t rtt_bpp = prosper::test::backend_color_bytes_per_pixel(s.format);
-                                if (borrow_cpu_live_rtt) {
-                                    fr.tex_rgba_owner = s.rgba;
-                                    fr.tex_rgba = s.rgba->data();
+                                if (retain_cpu_live_rtt &&
+                                    (fr.tex_rgba_owner = rtt_injection_cache.materialize(
+                                         s.rgba, tw, th, s.w, s.h, rtt_bpp))) {
+                                    fr.tex_rgba = fr.tex_rgba_owner->data();
                                     fr.texture_format = s.format;
                                     rtt_hit = true;
                                     resource_rtt_hit = true;

--- a/prosper/frontends/shared/rtt_injection.hpp
+++ b/prosper/frontends/shared/rtt_injection.hpp
@@ -126,9 +126,10 @@ inline bool inject_rtt_pixels(std::vector<uint8_t>& dst, uint32_t dst_w, uint32_
 }
 
 // One immutable producer snapshot is commonly bound through the same scaled view by many draws and
-// bindings in a submit. Materialize each (snapshot identity, source shape, destination shape, stride)
-// only once. The retained source owner prevents allocator address reuse from aliasing a live key; the
-// retained output lets FrameResource copies and the backend's raw-pointer upload key share the bytes.
+// bindings in a submit. Materialize each (snapshot identity, source shape, destination shape,
+// bytes-per-pixel) only once. The retained source owner prevents allocator address reuse from aliasing
+// a live key; the retained output lets FrameResource copies and the backend's raw-pointer upload key
+// share the bytes.
 class RttInjectionCache {
 public:
     std::shared_ptr<const std::vector<uint8_t>> materialize(

--- a/prosper/frontends/shared/rtt_injection.hpp
+++ b/prosper/frontends/shared/rtt_injection.hpp
@@ -3,7 +3,11 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <functional>
 #include <limits>
+#include <memory>
+#include <unordered_map>
+#include <utility>
 #include <vector>
 
 namespace prosper::frontend {
@@ -120,5 +124,68 @@ inline bool inject_rtt_pixels(std::vector<uint8_t>& dst, uint32_t dst_w, uint32_
     }
     return true;
 }
+
+// One immutable producer snapshot is commonly bound through the same scaled view by many draws and
+// bindings in a submit. Materialize each (snapshot identity, source shape, destination shape, stride)
+// only once. The retained source owner prevents allocator address reuse from aliasing a live key; the
+// retained output lets FrameResource copies and the backend's raw-pointer upload key share the bytes.
+class RttInjectionCache {
+public:
+    std::shared_ptr<const std::vector<uint8_t>> materialize(
+        std::shared_ptr<const std::vector<uint8_t>> source,
+        uint32_t dst_w, uint32_t dst_h, uint32_t src_w, uint32_t src_h,
+        uint32_t bytes_per_pixel) {
+        if (!source) return {};
+        if (exact_rtt_snapshot_borrowable(
+                dst_w, dst_h, src_w, src_h, bytes_per_pixel, source->size()))
+            return source;
+
+        const Key key{source.get(), dst_w, dst_h, src_w, src_h, bytes_per_pixel};
+        auto found = entries_.find(key);
+        if (found != entries_.end()) return found->second.pixels;
+
+        auto mutable_pixels = std::make_shared<std::vector<uint8_t>>();
+        if (!inject_rtt_pixels(*mutable_pixels, dst_w, dst_h, *source,
+                               src_w, src_h, bytes_per_pixel))
+            return {};
+        std::shared_ptr<const std::vector<uint8_t>> pixels = std::move(mutable_pixels);
+        entries_.emplace(key, Entry{std::move(source), pixels});
+        return pixels;
+    }
+
+    size_t size() const { return entries_.size(); }
+
+private:
+    struct Key {
+        const std::vector<uint8_t>* source = nullptr;
+        uint32_t dst_w = 0, dst_h = 0, src_w = 0, src_h = 0, bytes_per_pixel = 0;
+
+        bool operator==(const Key& other) const {
+            return source == other.source && dst_w == other.dst_w && dst_h == other.dst_h &&
+                src_w == other.src_w && src_h == other.src_h &&
+                bytes_per_pixel == other.bytes_per_pixel;
+        }
+    };
+
+    struct KeyHash {
+        size_t operator()(const Key& key) const {
+            size_t hash = std::hash<const void*>{}(key.source);
+            auto mix = [&](uint32_t value) {
+                hash ^= std::hash<uint32_t>{}(value) + 0x9e3779b9u +
+                    (hash << 6u) + (hash >> 2u);
+            };
+            mix(key.dst_w); mix(key.dst_h); mix(key.src_w); mix(key.src_h);
+            mix(key.bytes_per_pixel);
+            return hash;
+        }
+    };
+
+    struct Entry {
+        std::shared_ptr<const std::vector<uint8_t>> source;
+        std::shared_ptr<const std::vector<uint8_t>> pixels;
+    };
+
+    std::unordered_map<Key, Entry, KeyHash> entries_;
+};
 
 } // namespace prosper::frontend

--- a/prosper/frontends/shared/test_rtt_injection.cpp
+++ b/prosper/frontends/shared/test_rtt_injection.cpp
@@ -6,6 +6,7 @@
 
 using prosper::frontend::inject_rtt_pixels;
 using prosper::frontend::exact_rtt_snapshot_borrowable;
+using prosper::frontend::RttInjectionCache;
 
 static int failures = 0;
 #define CHECK(cond) do { if (!(cond)) { \
@@ -62,10 +63,30 @@ int main() {
     };
     CHECK(odd_scaled == odd_expected);
 
+    // A submit-scoped cache returns the immutable producer itself for exact views and one shared
+    // nearest-scaled materialization for every repeated consumer of the same version and shape.
+    auto shared_source = std::make_shared<const std::vector<uint8_t>>(rgba_source);
+    RttInjectionCache cache;
+    CHECK(cache.materialize(shared_source, 2, 2, 2, 2, 4) == shared_source);
+    auto cached_scaled = cache.materialize(shared_source, 4, 4, 2, 2, 4);
+    auto repeated_scaled = cache.materialize(shared_source, 4, 4, 2, 2, 4);
+    CHECK(cached_scaled && cached_scaled == repeated_scaled &&
+          cached_scaled->data() == repeated_scaled->data() &&
+          *cached_scaled == rgba_expected && cache.size() == 1);
+    auto different_shape = cache.materialize(shared_source, 3, 3, 2, 2, 4);
+    CHECK(different_shape && *different_shape == odd_expected &&
+          different_shape != cached_scaled && cache.size() == 2);
+    auto equal_new_version = std::make_shared<const std::vector<uint8_t>>(rgba_source);
+    auto new_version_scaled = cache.materialize(equal_new_version, 4, 4, 2, 2, 4);
+    CHECK(new_version_scaled && *new_version_scaled == rgba_expected &&
+          new_version_scaled != cached_scaled && cache.size() == 3);
+
     std::vector<uint8_t> malformed(7), fallback_bytes = {0xaa, 0xbb, 0xcc, 0xdd};
     consumer = fallback_bytes;
     CHECK(!inject_rtt_pixels(consumer, 1, 1, malformed, 1, 1, 8));
     CHECK(consumer == fallback_bytes); // rejection preserves the caller's guest-decode fallback buffer
+    CHECK(!cache.materialize(
+        std::make_shared<const std::vector<uint8_t>>(malformed), 1, 1, 1, 1, 8));
 
     if (!failures) std::printf("rtt_injection: OK\n");
     return failures ? 1 : 0;

--- a/prosper/frontends/shared/test_rtt_injection.cpp
+++ b/prosper/frontends/shared/test_rtt_injection.cpp
@@ -66,6 +66,7 @@ int main() {
     // A submit-scoped cache returns the immutable producer itself for exact views and one shared
     // nearest-scaled materialization for every repeated consumer of the same version and shape.
     auto shared_source = std::make_shared<const std::vector<uint8_t>>(rgba_source);
+    std::weak_ptr<const std::vector<uint8_t>> retained_source = shared_source;
     RttInjectionCache cache;
     CHECK(cache.materialize(shared_source, 2, 2, 2, 2, 4) == shared_source);
     auto cached_scaled = cache.materialize(shared_source, 4, 4, 2, 2, 4);
@@ -80,6 +81,8 @@ int main() {
     auto new_version_scaled = cache.materialize(equal_new_version, 4, 4, 2, 2, 4);
     CHECK(new_version_scaled && *new_version_scaled == rgba_expected &&
           new_version_scaled != cached_scaled && cache.size() == 3);
+    shared_source.reset();
+    CHECK(!retained_source.expired());
 
     std::vector<uint8_t> malformed(7), fallback_bytes = {0xaa, 0xbb, 0xcc, 0xdd};
     consumer = fallback_bytes;
@@ -87,6 +90,7 @@ int main() {
     CHECK(consumer == fallback_bytes); // rejection preserves the caller's guest-decode fallback buffer
     CHECK(!cache.materialize(
         std::make_shared<const std::vector<uint8_t>>(malformed), 1, 1, 1, 1, 8));
+    CHECK(cache.size() == 3);
 
     if (!failures) std::printf("rtt_injection: OK\n");
     return failures ? 1 : 0;


### PR DESCRIPTION
## Summary

- materialize each immutable RTT snapshot + scaled consumer shape once per frontend submit callback
- retain the source owner in every cache entry so allocator address reuse cannot alias content versions
- let repeated `FrameResource` instances share the scaled owner/raw pointer, which also lets the backend coalesce identical uploads inside a draw batch
- keep exact snapshots zero-copy and preserve the established scratch path for mutation/inspection diagnostics
- test exact reuse, repeated scaled reuse, shape and version separation, retained source lifetime, malformed rejection, and cache/output identity

## Failure scenario and contract

After #1500 removed copies for exact-size RTT consumers, Plucky's warmed gameplay still repeatedly sampled one immutable 1920x1080 producer through a 1501x2773 view. Focused telemetry counted 4,812 occurrences of that shape in 5,250 injections: about 76,404 MiB of duplicate frontend destination bytes in 30 seconds.

The generic contract is that the same immutable producer version, source shape, destination shape, and bytes-per-pixel produces identical materialized bytes for every consumer in one synchronous submit callback. Those consumers may share one materialization and upload identity. A different source owner/version or geometry must not alias it, and all borrowed bytes must remain owned until backend upload setup completes.

`RttInjectionCache` implements that contract. Its key contains immutable source identity plus source/destination geometry and bytes-per-pixel. Each entry retains both source and scaled output; retaining the source prevents allocator pointer reuse from colliding with a live key. Exact views return the immutable source itself. The cache lives only for one frontend submit callback, matching the existing synchronous `FrameResource` ownership boundary.

## Affected and unaffected behavior

The optimization applies only to the established renderer-owned CPU RTT injection path. 3D volumes, storage images, mip tails, malformed/incomplete snapshots, and renderer diagnostics that inspect or mutate scratch pixels keep their prior paths. Source pixels, nearest-scaling behavior, texture format, and fallback guest decode are unchanged. `PROSPER_NO_RTT_SNAPSHOT_BORROW=1` restores the pre-change exact-copy and scaled-copy behavior for same-binary A/B testing.

The cache is title-independent: it contains no game identity, guest address, shader identity, or output substitution.

## Evidence

The post-#1500 warm CPU profile that motivated this change showed:

- `inject_rtt_pixels`: 4.01% self CPU
- `__memmove_avx512_unaligned_erms`: 10.18% self CPU

A clean candidate profile reduced `inject_rtt_pixels` to 0.11% self CPU with zero lost samples.

The final live comparison used the exact same `prosper-app` binary at `7c1d835033efb30450162cb77d939bb214d40c17`. Both arms used fresh save/frame directories, the same deterministic input route, native 3840x2160 rendering, real Vulkan presentation, audio, and input, and were anchored after `/Game/Levels/_Persistent/MainLevel`. The fallback arm set only `PROSPER_NO_RTT_SNAPSHOT_BORROW=1`.

| Post-MainLevel windows 21-42 (22 × 25 submits) | Fallback | Candidate | Change |
|---|---:|---:|---:|
| callbacks/window | 1.705 | 1.714 | +0.5% |
| frontend build-resources | 19.627 ms | 8.157 ms | -58.4% |
| backend | 27.803 ms | 11.523 ms | -58.6% |
| total frontend submission | 48.945 ms | 20.394 ms | -58.3% |

The corresponding medians were 47.945 -> 18.375 ms total, 18.495 -> 6.995 ms build-resources, and 25.290 -> 10.780 ms backend. Both routes remained visually stable through the sampled gameplay window.

## Verification

Exact head `7c1d835033efb30450162cb77d939bb214d40c17`:

- `TMPDIR=$PWD/build-linux/tmpdir cmake --build build-linux -j2`: pass
- `TMPDIR=$PWD/build-linux/tmpdir ./build-linux/test_rtt_injection`: pass
- `TMPDIR=$PWD/build-linux/tmpdir ./build-linux/test_gpu_capture_render`: pass
- `TMPDIR=$PWD/build-linux/tmpdir ctest --test-dir build-linux --output-on-failure -j2`: 154/157 pass
  - unchanged local private-fixture mismatches: GTA eboot expectations, absent private `Media/Modules/Il2cppUserAssemblies.prx`, and absent embedded RDNA2 shader blobs
- exact-head live Vulkan/audio/input Plucky route and same-binary fallback A/B: pass
- `git diff --check origin/master...HEAD`: pass
- all six required Linux, Linux App, Windows MinGW, Windows App, macOS, and macOS App CI jobs: pass

Continues #1390.
