### PR TITLE
gpu: advance Astro Bot Wave32 traversal lowering

### DIFF
--- a/prosper/src/gpu/rdna2_decode.cpp
+++ b/prosper/src/gpu/rdna2_decode.cpp
@@ -695,16 +695,19 @@ Rdna2Inst rdna2_decode_one(const uint32_t* code, size_t max_dwords) {
             case 0x3c: {
                 // MIMG is 2 dwords, plus NSA (Non-Sequential Address) extra dwords holding the split
                 // address VGPRs. The NSA field (dword0[2:1], 0..3) gives the extra-dword count — miss
-                // it and every NSA image op mis-aligns the rest of the stream. (Verified against
-                // llvm-mc gfx1030: 2D non-NSA=2 dw, NSA 1-extra=3 dw, NSA 2-extra=4 dw.)
+                // it and every NSA image op mis-aligns the rest of the stream. One- and two-extra
+                // forms were verified against llvm-mc gfx1030; Astro Bot's
+                // IMAGE_BVH_INTERSECT_RAY uses all 3 extra dwords (5 total).
                 i.fmt = Rdna2Format::MIMG;
                 uint32_t extra = (w >> 1) & 0x3u;
                 i.len_dwords = 2 + extra;
                 if (max_dwords >= 2) i.words[1] = code[1];
                 // NSA extra dwords hold the split (non-sequential) address VGPRs, one per byte; keep them
-                // so the recompiler can gather the coords (dword2 = addr1..4, dword3 = addr5..8).
+                // so the recompiler can gather the coordinates (dword2 = addr1..4, dword3 = addr5..8,
+                // dword4 = addr9..12).
                 if (extra >= 1 && max_dwords >= 3) i.words[2] = code[2];
                 if (extra >= 2 && max_dwords >= 4) i.words[3] = code[3];
+                if (extra >= 3 && max_dwords >= 5) i.words[4] = code[4];
                 break;
             }
             case 0x3d: two_dword(Rdna2Format::SMEM);  break;

--- a/prosper/src/gpu/rdna2_decode.hpp
+++ b/prosper/src/gpu/rdna2_decode.hpp
@@ -46,8 +46,8 @@ float inline_float_value(uint32_t code);
 struct Rdna2Inst {
     Rdna2Format fmt = Rdna2Format::Unknown;
     uint32_t    pc = 0;            // dword offset from the start of the stream
-    uint32_t    words[4] = {0, 0, 0, 0}; // the instruction dwords (not incl. a trailing literal); [2]/[3]
-                                         // hold MIMG NSA extra address dwords (0 for every other encoding)
+    uint32_t    words[5] = {0, 0, 0, 0, 0}; // instruction dwords (not incl. a trailing literal); [2]..[4]
+                                            // hold MIMG NSA address dwords (0 for every other encoding)
     uint32_t    len_dwords = 1;    // total length incl. any inline literal
     bool        has_literal = false;
     uint32_t    literal = 0;       // the inline 32-bit constant, if has_literal

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -7017,14 +7017,43 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // SCALAR-SPILL lane slots (#273): v_writelane_b32 (0x361) / v_readlane_b32 (0x360) with a
             // COMPILE-TIME lane index — the pack-scalars-into-a-VGPR's-lanes idiom (DOLL's big post PS
             // spills 19 s_buffer_load results into v36 and reads them back). Per-invocation each
-            // (vgpr, lane) is a named wave-uniform scalar. The portable NGG vertex shell additionally
-            // projects an ordinary VGPR read from any physical lane onto its one represented live
-            // lane; this is the same collapsed-wave contract used for MBCNT and Function LDS. Other
-            // compute/fragment stages use a native subgroup shuffle for ordinary VGPR reads and
-            // therefore support both scalar and inline lane selectors. Neither op is EXEC-predicated
-            // on hardware, so no predicate_write.
+            // (vgpr, lane) is a named wave-uniform scalar. An exact native compute wave also supports
+            // a dynamic writelane selector by updating the one matching subgroup invocation in an
+            // ordinary VGPR lifetime. The portable NGG vertex shell additionally projects an ordinary
+            // VGPR read from any physical lane onto its one represented live lane; this is the same
+            // collapsed-wave contract used for MBCNT and Function LDS. Other compute/fragment stages
+            // use a native subgroup shuffle for ordinary VGPR reads and therefore support both scalar
+            // and inline lane selectors. Neither op is EXEC-predicated on hardware, so no
+            // predicate_write.
             // VERIFIED(round-trip llvm-mc gfx1030: 0xd761 v_writelane_b32 / 0xd760 v_readlane_b32).
             if (in.opcode == 0x361) {                                 // v_writelane_b32 vDST, sSRC, lane
+                if (b.is_compute && b.wave_size == 32 && b.native_subgroup_size == 32 &&
+                    in.src[1].kind != OperandKind::InlineInt) {
+                    // RDNA2 masks the scalar selector to the Wave32 lane range and replaces VDST
+                    // only in that physical lane. Under the enforced 32-wide native-subgroup
+                    // contract, SubgroupLocalInvocationId is that architectural lane. The scalar
+                    // source and selector are uniform, so this needs no shuffle or barrier. Astro's
+                    // traversal kernel reaches this form after readlane publishes its chosen hit as
+                    // scalar data.
+                    if (in.src[1].kind == OperandKind::VGPR ||
+                        rs.vgpr_lane_slots.count(in.dst.value) ||
+                        rs.vgpr_lane_mask_slots.count(in.dst.value)) {
+                        ok = false; return true;
+                    }
+                    const uint32_t value = val(in.src[0]);
+                    const uint32_t selector = val(in.src[1]);
+                    if (!ok) return true;
+                    const uint32_t lane = b.subgroup_local_id();
+                    const uint32_t selected = b.ucmp(
+                        Op_IEqual, lane,
+                        b.ibin(Op_BitwiseAnd, selector, b.uconst(31)));
+                    rs.vreg[in.dst.value] = b.sel(
+                        selected, value, vreg_old(b, rs, in.dst.value));
+                    rs.invalidated_vgpr_lane_slots.erase(in.dst.value);
+                    rs.vgpr_lane_slots.erase(in.dst.value);
+                    rs.vgpr_lane_mask_slots.erase(in.dst.value);
+                    return true;
+                }
                 if (in.src[1].kind != OperandKind::InlineInt || in.src[1].value < 0 || in.src[1].value > 63) {
                     ok = false; return true;
                 }

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -563,6 +563,28 @@ struct SpirvCompute {
             {t_bool, result, uconst(Scope_Subgroup), value});
         return result;
     }
+    uint32_t native_wave_first_active(uint32_t mask_bit) {
+        if (!native_subgroup_size) return 0;
+        const uint32_t lane = subgroup_local_id();
+        if (!declared_subgroup_arithmetic) {
+            put(caps, Op_Capability, {Cap_GroupNonUniformArithmetic});
+            declared_subgroup_arithmetic = true;
+        }
+        // The exclusive population count is zero only for the first active lane. Exactly one lane
+        // therefore contributes its index to the reduction; an empty mask is distinguished by the
+        // accompanying wave vote. This is exact only under the enforced guest-size subgroup
+        // contract checked by the caller.
+        const uint32_t contribution = sel(mask_bit, uconst(1), uconst(0));
+        uint32_t prefix = id();
+        put(code, Op_GroupNonUniformIAdd,
+            {t_u32, prefix, uconst(Scope_Subgroup), GroupOp_ExclusiveScan, contribution});
+        const uint32_t elected = land(mask_bit, ucmp(Op_IEqual, prefix, uconst(0)));
+        const uint32_t selected_lane = sel(elected, lane, uconst(0));
+        uint32_t first = id();
+        put(code, Op_GroupNonUniformIAdd,
+            {t_u32, first, uconst(Scope_Subgroup), GroupOp_Reduce, selected_lane});
+        return sel(native_wave_any(mask_bit), first, uconst(0xffffffffu));
+    }
     uint32_t native_compute_mbcnt(uint32_t mask_bit, uint32_t acc_bits, uint32_t lo) {
         if (!native_subgroup_size) return 0;
         const uint32_t lane = subgroup_local_id();
@@ -4777,6 +4799,51 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
     if (in.has_modifier) { ok = false; return true; }
     switch (in.fmt) {
         case Rdna2Format::SOP1: {
+            if (b.is_compute && b.wave_size == 32 && b.native_subgroup_size == 32 &&
+                in.opcode == 0x13) { // s_ff1_i32_b32
+                // RDNA2 returns the first set bit from the low end, or 0xffffffff for an empty
+                // source. In Wave32, VCC_LO/EXEC_LO and one-word saved masks are complete scalar
+                // masks. The live Astro traversal kernel uses this to select the first hit lane.
+                // A required 32-wide Vulkan subgroup makes the reduction architectural rather than
+                // an implementation-width approximation.
+                const auto data_value_present = [&](int reg) {
+                    return rs.sreg.contains(reg) || rs.sreg_input.contains(reg);
+                };
+                uint32_t mask = 0;
+                if (in.src[0].value == 126 && !data_value_present(126)) {
+                    mask = rs.exec;
+                } else if (in.src[0].value == 106 && !data_value_present(106)) {
+                    mask = rs.vcc;
+                } else if ((in.src[0].kind == OperandKind::SGPR ||
+                            in.src[0].kind == OperandKind::Special) &&
+                           rs.sreg_bool_b32.contains(in.src[0].value) &&
+                           !data_value_present(in.src[0].value)) {
+                    auto saved = rs.sreg_bool.find(in.src[0].value);
+                    if (saved != rs.sreg_bool.end()) mask = saved->second;
+                }
+                if (!mask || in.dst.value == 126 || in.dst.value == 127) {
+                    ok = false;
+                    return true;
+                }
+
+                const uint32_t result = b.native_wave_first_active(mask);
+                rs.sreg[in.dst.value] = result;
+                rs.sreg_srt.erase(in.dst.value);
+                rs.sreg_bool.erase(in.dst.value);
+                rs.sreg_bool_narrowed.erase(in.dst.value);
+                rs.sreg_bool_b32.erase(in.dst.value);
+                if (in.dst.value == 106) {
+                    // VCC_LO is also a physical scalar dword. Preserve its architectural mask view
+                    // for any implicit VCC consumer while publishing the same bits as scalar data.
+                    const uint32_t lane = b.subgroup_local_id();
+                    const uint32_t bit = b.ibin(
+                        Op_BitwiseAnd,
+                        b.ibin(Op_ShiftRightLogical, result, lane), b.uconst(1));
+                    rs.vcc = b.ucmp(Op_INotEqual, bit, b.uconst(0));
+                }
+                // S_FF1 does not modify SCC.
+                return true;
+            }
             if ((b.is_compute || b.is_fragment) && b.wave_size == 64 &&
                 in.opcode == 0x03 && (in.dst.value == 126 || in.dst.value == 127) &&
                 (in.src[0].value == 106 || in.src[0].value == 107) &&

--- a/prosper/tests/test_rdna2_decode.cpp
+++ b/prosper/tests/test_rdna2_decode.cpp
@@ -303,6 +303,17 @@ int main() {
     CHECK(n3.fmt == Rdna2Format::MIMG && n3.opcode == 0x00u && n3.len_dwords == 3 && n3.mimg_dim == 2u &&
           (n3.words[1] & 0xFFu) == 0u && (n3.words[2] & 0xFFu) == 7u && ((n3.words[2] >> 8) & 0xFFu) == 3u,
           "NSA MIMG 3D captures the extra address dword; coords decode to v0,v7,v3");
+    // Astro Bot's world-map ray traversal uses the maximum three NSA dwords to name eleven input
+    // VGPRs. Retaining dword4 is required for ray_inv_dir.y/z (v71/v72).
+    const uint32_t mimg_bvh[] = {
+        0xf1989f07u, 0x00040303u, 0x43440d3fu, 0x46424140u, 0x00004847u,
+    };
+    Rdna2Inst bvh = rdna2_decode_one(mimg_bvh, std::size(mimg_bvh));
+    CHECK(bvh.fmt == Rdna2Format::MIMG && bvh.opcode == 0xe6u && bvh.len_dwords == 5 &&
+          bvh.mimg_dmask == 0xfu && bvh.mimg_unorm && bvh.mimg_dim == 0u &&
+          bvh.dst.value == 3 && bvh.src[0].value == 3 && bvh.src[1].value == 16 &&
+          bvh.words[4] == 0x00004847u,
+          "Astro IMAGE_BVH_INTERSECT_RAY retains its third NSA address dword");
     // Astro Bot's live image_atomic_swap packet. Bit 13 is GLC: atomically exchange v9 with the
     // R32_UINT texel at (v0,v1), returning the pre-operation value to v9.
     const uint32_t mimg_atomic_swap[] = { 0xf03c2108u, 0x00000900u };

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -585,6 +585,58 @@ int main() {
     CHECK(has_spirv_local_size(native_spv17d, 64, 1, 1),
           "multidimensional guest wave flattens Vulkan LocalSize X for full subgroups");
 
+    // Kernel 17d1: Astro's Wave32 BVH traversal turns a VOPC predicate into the first matching
+    // lane with s_ff1_i32_b32, then immediately uses VCC_LO as ordinary scalar data. The first
+    // subgroup has one match at lane 5; the second subgroup is empty and must return -1. Store the
+    // scalar result from every invocation so real Vulkan execution checks the complete reduction.
+    const uint32_t code17d1[] = {
+        0xbe800385u,              // s_mov_b32 s0, 5
+        0x7d840000u,              // v_cmp_eq_u32 vcc, s0, v0
+        0xbeea136au,              // s_ff1_i32_b32 vcc_lo, vcc_lo (exact live destination/source)
+        0x7e02026au,              // v_mov_b32 v1, vcc_lo (scalar-data lifetime)
+        0xe0702000u, 0x80020100u, // buffer_store_dword v1, v0, s[8:11] idxen
+        0xbf810000u,
+    };
+    ShaderResourceTable rt17d1;
+    { ShaderResource dst{}; dst.cls = ResourceClass::ConstantBuffer;
+      dst.format = DataFormat::Uint32; dst.num_components = 1;
+      dst.binding = 3; dst.stride = 4; dst.sgpr_base = 8;
+      rt17d1.resources.push_back(dst); }
+    ComputeShaderConfig native_cfg17d1;
+    native_cfg17d1.local_x = 64;
+    native_cfg17d1.wave_size = 32;
+    native_cfg17d1.native_subgroup_size = 32;
+    const std::vector<uint32_t> native_spv17d1 = recompile_compute(
+        code17d1, std::size(code17d1), &rt17d1, native_cfg17d1);
+    CHECK(!native_spv17d1.empty() && count_spirv_opcode(native_spv17d1, 349) >= 2 &&
+              count_spirv_opcode(native_spv17d1, 335) >= 1,
+          "Wave32 s_ff1_i32_b32 lowers to an exact first-active subgroup reduction");
+    ComputeShaderConfig portable_cfg17d1 = native_cfg17d1;
+    portable_cfg17d1.native_subgroup_size = 0;
+    CHECK(recompile_compute(code17d1, std::size(code17d1), &rt17d1,
+                            portable_cfg17d1).empty(),
+          "s_ff1_i32_b32 rejects without an exact 32-lane subgroup contract");
+    const auto subgroup17d1 = prosper::test::default_compute_subgroup_properties();
+    const bool can_execute17d1 = subgroup17d1.size == 32 &&
+        (subgroup17d1.stages & VK_SHADER_STAGE_COMPUTE_BIT) &&
+        (subgroup17d1.operations & VK_SUBGROUP_FEATURE_ARITHMETIC_BIT) &&
+        (subgroup17d1.operations & VK_SUBGROUP_FEATURE_VOTE_BIT);
+    if (can_execute17d1) {
+        std::vector<uint32_t> initial17d1(64, 0u), got17d1;
+        prosper::test::run_compute(native_spv17d1, std::vector<float>(64, 0.0f),
+                                   64, 64, {}, initial17d1, &got17d1);
+        uint32_t bad17d1 = 0;
+        for (uint32_t lane = 0; lane < 64 && got17d1.size() == 64; ++lane) {
+            const uint32_t expected = lane < 32 ? 5u : 0xffffffffu;
+            bad17d1 += got17d1[lane] != expected;
+        }
+        CHECK(got17d1.size() == 64 && bad17d1 == 0,
+              "Wave32 s_ff1 returns lane 5 for a hit and -1 for an empty mask");
+    } else {
+        std::printf("  [skip] s_ff1 execution: host default subgroup is %u or lacks vote/arithmetic\n",
+                    subgroup17d1.size);
+    }
+
     // Kernel 17d2: Astro's mask-priority sequence compares a VOPC-produced SGPR pair against zero,
     // then uses that wave-uniform SCC in s_cselect_b64.  Keep the irreducible prefix so this exercises
     // the generic dispatcher.  Wave 0's mask is empty and selects all lanes; wave 1 has one set bit in

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -637,6 +637,42 @@ int main() {
                     subgroup17d1.size);
     }
 
+    // Kernel 17d1w: the next Astro traversal instruction writes a scalar-data VCC_HI value to the
+    // VGPR lane selected by s45. Preserve v1's local-id value in every other lane so execution tests
+    // both halves of V_WRITELANE's read/modify/write behavior. These are the exact GFX10 packets for
+    // a dynamic scalar selector; the selector is not an inline lane-slot spill.
+    const uint32_t code17d1w[] = {
+        0x7e020300u,              // v_mov_b32 v1, v0
+        0xbeeb0389u,              // s_mov_b32 vcc_hi, 9 (ordinary scalar-data lifetime)
+        0xbead0385u,              // s_mov_b32 s45, 5
+        0xd7610001u, 0x00005a6bu, // v_writelane_b32 v1, vcc_hi, s45
+        0xe0702000u, 0x80020100u, // buffer_store_dword v1, v0, s[8:11] idxen
+        0xbf810000u,
+    };
+    const std::vector<uint32_t> native_spv17d1w = recompile_compute(
+        code17d1w, std::size(code17d1w), &rt17d1, native_cfg17d1);
+    CHECK(!native_spv17d1w.empty(),
+          "Wave32 dynamic v_writelane_b32 lowers under an exact native subgroup contract");
+    CHECK(recompile_compute(code17d1w, std::size(code17d1w), &rt17d1,
+                            portable_cfg17d1).empty(),
+          "dynamic v_writelane_b32 rejects without an exact 32-lane subgroup contract");
+    if (can_execute17d1) {
+        std::vector<uint32_t> initial17d1w(64, 0u), got17d1w;
+        prosper::test::run_compute(native_spv17d1w, std::vector<float>(64, 0.0f),
+                                   64, 64, {}, initial17d1w, &got17d1w);
+        uint32_t bad17d1w = 0;
+        for (uint32_t lane = 0; lane < 64 && got17d1w.size() == 64; ++lane) {
+            const uint32_t wave_lane = lane & 31u;
+            const uint32_t expected = wave_lane == 5 ? 9u : lane;
+            bad17d1w += got17d1w[lane] != expected;
+        }
+        CHECK(got17d1w.size() == 64 && bad17d1w == 0,
+              "dynamic v_writelane changes only selected lane 5 in each Wave32");
+    } else {
+        std::printf("  [skip] dynamic writelane execution: host default subgroup is %u\n",
+                    subgroup17d1.size);
+    }
+
     // Kernel 17d2: Astro's mask-priority sequence compares a VOPC-produced SGPR pair against zero,
     // then uses that wave-uniform SCC in s_cselect_b64.  Keep the irreducible prefix so this exercises
     // the generic dispatcher.  Wave 0's mask is empty and selects all lanes; wave 1 has one set bit in

--- a/prosper/tests/test_recompile_coverage.cpp
+++ b/prosper/tests/test_recompile_coverage.cpp
@@ -446,6 +446,21 @@ int main() {
                              compute_cfg_dispatch_ff1.size(), &dispatch_rt,
                              wave32_dispatch_config).empty(),
           "the complex dispatcher lowers exact Wave32 s_ff1 mask reduction to scalar data");
+    std::vector<uint32_t> compute_cfg_dispatch_dynamic_writelane = {
+        0x7E780300u,              // v_mov_b32 v60, v0
+        0xBEEB0389u,              // s_mov_b32 vcc_hi, 9 (scalar data)
+        0xBEAD0385u,              // s_mov_b32 s45, 5
+        0xD761003Cu, 0x00005A6Bu, // v_writelane_b32 v60, vcc_hi, s45 (Astro PC1039)
+        0xD7600000u, 0x00005B3Cu, // v_readlane_b32 s0, v60, s45
+        0x7E040200u,              // v_mov_b32 v2, s0 (consume selected scalar)
+    };
+    compute_cfg_dispatch_dynamic_writelane.insert(
+        compute_cfg_dispatch_dynamic_writelane.end(), compute_cfg_dispatch,
+        compute_cfg_dispatch + std::size(compute_cfg_dispatch));
+    CHECK(!recompile_compute(compute_cfg_dispatch_dynamic_writelane.data(),
+                             compute_cfg_dispatch_dynamic_writelane.size(), &dispatch_rt,
+                             wave32_dispatch_config).empty(),
+          "the complex dispatcher lowers Astro's exact dynamic v_writelane packet");
     // A physical VCC half may hold ordinary scalar data before a later block starts a mask lifetime
     // in the same word. Block discovery must not retroactively reinterpret the earlier comparison as
     // a wave vote after the B32 dataflow learns about that later lifetime (Astro world-map PC436).

--- a/prosper/tests/test_recompile_coverage.cpp
+++ b/prosper/tests/test_recompile_coverage.cpp
@@ -433,6 +433,19 @@ int main() {
                              compute_cfg_dispatch_vcc_gt_zero.size(), &dispatch_rt,
                              wave32_dispatch_config).empty(),
           "the complex dispatcher preserves Wave32 VCC_LO > 0 scalar mask semantics");
+    std::vector<uint32_t> compute_cfg_dispatch_ff1 = {
+        0xBE800385u, // s_mov_b32 s0, 5
+        0x7D840000u, // v_cmp_eq_u32 vcc, s0, v0
+        0xBEEA136Au, // s_ff1_i32_b32 vcc_lo, vcc_lo
+        0x7E04026Au, // v_mov_b32 v2, vcc_lo (consume the scalar-data result)
+    };
+    compute_cfg_dispatch_ff1.insert(
+        compute_cfg_dispatch_ff1.end(), compute_cfg_dispatch,
+        compute_cfg_dispatch + std::size(compute_cfg_dispatch));
+    CHECK(!recompile_compute(compute_cfg_dispatch_ff1.data(),
+                             compute_cfg_dispatch_ff1.size(), &dispatch_rt,
+                             wave32_dispatch_config).empty(),
+          "the complex dispatcher lowers exact Wave32 s_ff1 mask reduction to scalar data");
     // A physical VCC half may hold ordinary scalar data before a later block starts a mask lifetime
     // in the same word. Block discovery must not retroactively reinterpret the earlier comparison as
     // a wave vote after the B32 dataflow learns about that later lifetime (Astro world-map PC436).


### PR DESCRIPTION
## What changed

- Retain all five dwords of maximum-length GFX10 MIMG NSA packets, including Astro Bot's BVH traversal operands.
- Lower Wave32 `s_ff1_i32_b32` from EXEC/VCC/saved-mask data with an exact 32-lane subgroup reduction.
- Lower dynamically indexed Wave32 `v_writelane_b32` as an exact per-lane read/modify/write under the same native subgroup contract.
- Add exact packet, structural, complex-CFG, and execution-capable regression coverage.

## Why

Astro Bot's world-map traversal compute shader was losing the fifth NSA address dword and then stopped successively at two cross-lane instructions that the translator could not represent exactly. Required 32-wide Vulkan subgroups give us a one-to-one hardware-wave model, so the mask scan and dynamic lane write can be lowered without approximation or workgroup barriers.

## Impact

With the existing local-only BVH-miss diagnostic, a normal scripted game run now reaches the world map and advances the target compute program from the original BVH packet at PC968 through the former PC1029 and PC1039 blockers. Its next visible program blocker is now an EXEC-mask branch at PC336.

The world map is still black. The real BVH resource/pointer is still unresolved, and this PR deliberately does **not** include the diagnostic BVH-miss bypass. Issue #1459 remains open.

No screenshot is attached because the newly reached world-map frame is still effectively black; the live visual evidence policy asks for screenshots once there is meaningful non-black output.

## Validation

- `test_recompile_coverage` — PASS
- `test_rdna2_to_spirv` — PASS
- Live host app run with realtime audio/input and `scripts/astrobot/reach-first-level.pad`
  - reached `LevelDocument Loaded: worldmap [worldmap]`
  - target shader no longer rejects at PC1029 or PC1039
  - next target program rejection: PC336
- The optional numerical Wave32 subgroup checks skip on this host because its default compute subgroup is 64; exact packet and structural/CFG coverage pass.

Snapshots were not run: this is a development PR rather than a release, consistent with the repository snapshot policy.