### PR TITLE
fix(docs): /var/tmp is container-private, so run artifacts must live under $HOME

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -272,9 +272,15 @@ Messenger depth, vertex-fetch, geometry, palette, or tiling hypotheses without c
   reaches 1.5 GB, so a few sessions of ordinary capture work exhaust the quota. When that happens it does
   not just fail your write — it **eats the machine's RAM and kills the Bash tool outright for every
   agent**, because the harness stores each command's output under `$TMPDIR`. Put captures, frame dumps,
-  screenshots and logs in a gitignored worktree-local directory or under `/var/tmp` (real disk, and
-  `systemd-tmpfiles` already ages it), and always build with `TMPDIR` off the tmpfs — gcc's compile
-  temporaries are large enough on their own to break a `-j8` build with
+  screenshots and logs under **`$HOME`** — a gitignored worktree-local directory, or a scratch directory
+  such as `~/dq-work/`. **Do not send a run's artifacts to `/var/tmp`: distrobox shares `$HOME` but NOT
+  `/var/tmp`**, so anything the emulator writes there lands in the *container's* private `/var/tmp` and is
+  invisible from the host (the host path shows up inside the container as `/run/host/var/tmp`). The shell
+  redirect that captures a run log happens on the host, so a `/var/tmp` run directory silently ends up
+  holding only the log while every screenshot and capsule goes somewhere you cannot see. `/var/tmp` is
+  still fine for host-side scratch (it is real disk and `systemd-tmpfiles` ages it) — just not for output
+  produced inside the container. Always build with `TMPDIR` off the tmpfs too; gcc's compile temporaries
+  are large enough on their own to break a `-j8` build with
   `error writing to /tmp/ccXXXX.s: Disk quota exceeded`:
   ```bash
   mkdir -p <worktree>/build/tmpdir


### PR DESCRIPTION
Corrects the artifact-location rule I added in #1501.

## The mistake

#1501 told agents to put captures, frame dumps and logs "in a gitignored worktree-local directory **or
under `/var/tmp`**". The second half is wrong for anything the emulator produces: prosper runs inside the
`ps5ys` distrobox, and **distrobox shares `$HOME` but not `/var/tmp`**. The container gets its own private
`/var/tmp`, so output written there is invisible from the host. (The host's `/var/tmp` does appear inside
the container, but as `/run/host/var/tmp`.)

## Why it is worth a follow-up rather than leaving it

The failure mode is quiet and actively misleading. The shell redirect that captures a run log executes on
the *host*, so a `/var/tmp` run directory ends up holding **only** `run.log` — while every screenshot,
`.prgtl` and `.prgcap` the log reports writing is nowhere to be found on the host:

```
$ ls /var/tmp/dq-work/prov/
run.log                       # host-written redirect
$ grep '\[shot\] done' /var/tmp/dq-work/prov/run.log
[shot] done: 30 screenshot(s) in /var/tmp/dq-work/prov ... status=ok
$ distrobox enter ps5ys -- ls /var/tmp/dq-work/prov | wc -l
32                            # they were here all along
```

The log says the artifacts were written and they are simply not there. It cost one 30-screenshot
diagnostic run to work out, and it would cost every agent that follows the rule the same.

## What changed

The bullet now points artifacts at `$HOME` (a gitignored worktree-local directory, or a scratch directory
like `~/dq-work/`), states the distrobox sharing asymmetry explicitly, and describes the
only-`run.log`-survives symptom so anyone who hits it recognises it immediately. `/var/tmp` is still
endorsed for host-side scratch — which is what the `TMPDIR` build recipe directly below it uses, and that
recipe is unchanged and correct, since `cmake`/gcc temporaries are written by the container against a
worktree-local path under `$HOME`.

## Affected / unaffected

Documentation only. No build, test or runtime behavior changes.

## Verification

`git diff --check` clean. Recovery of the affected run's artifacts confirmed the diagnosis:
`distrobox enter ps5ys -- cp -a /var/tmp/dq-work/prov ~/dq-work/` produced all 32 files, and
`gpu_timeline` then opened the recovered `.prgtl` normally.