### PR TITLE
docs: never publish the developer machine's local paths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -449,6 +449,21 @@ Messenger depth, vertex-fetch, geometry, palette, or tiling hypotheses without c
   **Do NOT add "Generated with Claude Code" attribution lines** (the 🤖 badge, "Generated with
   [Claude Code](...)" footers, session links) to PR bodies, commit messages, issue text, or
   comments — anywhere. They are noise in the project record; the co-author trailer alone is enough.
+- **Never publish the developer machine's local paths.** This repository is public. An absolute path
+  leaks the account name and the private directory layout of someone's computer, and it is never the
+  information a reader needs — the *shape* of the command is. So keep absolute host paths out of commit
+  messages, PR titles/bodies/comments, issue text and review comments, and out of committed files
+  (docs, scripts, tests, code comments). Use placeholders instead, or a path relative to the repository:
+  ```text
+  <REPO_ROOT>    the checkout root          <WORKTREE>   a worktree root
+  <DUMP_ROOT>    where the game dumps live  ~/           the developer's home
+  ```
+  So write `-DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0`, not the real path, and
+  `cd <WORKTREE> && cmake --build build -j6`. Paths *inside* the repo (`prosper/src/gpu/…`) and generic
+  system paths (`/usr/lib64/libc.so.6`, `/tmp`, `/var/tmp`) are fine — the rule is about the private
+  part above the repository root. This is a privacy matter, not a security one: nothing here is secret,
+  and it still should not be published. Sanitize before you post; if something already published slipped
+  through, edit it (`gh api -X PATCH repos/OWNER/REPO/issues/comments/<id> -f body=…` edits a comment).
 - **Track work in GitHub issues** (`gh issue ...`). The rules:
   - **Any bug you find but do not fix in the same session gets an issue, immediately**, while the
     context is fresh: exact `file:line`, the concrete failure scenario (inputs/state → wrong


### PR DESCRIPTION
## Why

This repository is public. An absolute host path published in a commit message, PR body, issue text,
review comment or a committed file leaks the account name and the private directory layout of someone's
computer — and it is never the information a reader actually needs. What matters is the *shape* of the
command, which a placeholder conveys just as well.

This is a privacy matter rather than a security one: nothing involved is secret, and it still should not
be published.

Prompted by the repository owner after I posted an absolute game-dump path in a PR #1487 verification
comment. That comment has been edited and the same path has been removed from
`prosper/docs/DRAGON_QUEST_STATUS.md` before it could reach `master`.

## What changed

One bullet in `CLAUDE.md`, next to the commit-style rule that already governs what goes into the project
record. It states the rule, gives the placeholder vocabulary (`<REPO_ROOT>`, `<WORKTREE>`, `<DUMP_ROOT>`,
`~/`), draws the line explicitly — paths inside the repository and generic system paths such as
`/usr/lib64/libc.so.6` or `/var/tmp` are fine, because the rule is about the private part *above* the
repository root — and records the `gh api -X PATCH .../issues/comments/<id>` call that edits an
already-published comment when something slips through.

## Pre-existing footprint (not touched here)

`master` already carries the same leak from earlier work, which I have deliberately left alone rather
than bundle a large mechanical rewrite into a policy change:

| where | occurrences |
|-------|-------------|
| `prosper/tools/dbg/*.sh` | ~20 scripts with a hard-coded `WT=<windows-user-path>/…/worktrees/agent-…` |
| `CLAUDE.md` | the WSL-era build/run recipes |
| `prosper/docs/DEAD_CELLS_STATUS.md`, `prosper/docs/NEXT_STEP_VERTEX_FETCH.md` | recipe paths |

Happy to follow up with a focused sanitisation pass over those if wanted — it is mechanical, but it
rewrites the documented build recipes, so it deserves its own review rather than riding along here.

## Affected / unaffected

Documentation only. No build, test or runtime behavior changes.

## Verification

`git diff --check` clean.