### PR TITLE
gpu: lower Wave32 mask SCC in dispatchers

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -9857,6 +9857,31 @@ bool emit_cfg_state_machine(
                           : in.opcode == 0x09;                // 0 >= mask
     };
 
+    // A Wave32 B32 logical writes SCC=any(result mask). The ordinary lane-local emitter poisons
+    // that SCC because it cannot reduce a guest wave by itself. Inside an exact native dispatcher,
+    // however, every lane reaches the same switch case and an immediately consuming SCC branch can
+    // use one exact subgroup vote. Restrict the vote to the last architectural SCC writer before
+    // the branch; generated traversal kernels often chain several mask intersections and only the
+    // final result is live, so voting after every intermediate AND would add needless hot-loop work.
+    auto b32_mask_logical_opcode = [](uint32_t opcode) {
+        return opcode == 0x0e || opcode == 0x10 || opcode == 0x12 ||
+               opcode == 0x14 || opcode == 0x16 || opcode == 0x18 ||
+               opcode == 0x1a || opcode == 0x1c;
+    };
+    std::unordered_set<uint32_t> native_b32_mask_scc_vote_pcs;
+    if (b.native_subgroup_size && proven_wave32_masks) {
+        for (size_t i = 0; i + 1 < ins.size(); ++i) {
+            const Rdna2Inst& producer = ins[i];
+            const Rdna2Inst& consumer = ins[i + 1];
+            if (producer.fmt == Rdna2Format::SOP2 &&
+                b32_mask_logical_opcode(producer.opcode) &&
+                consumer.fmt == Rdna2Format::SOPP &&
+                (consumer.opcode == 0x04 || consumer.opcode == 0x05) &&
+                producer.pc + producer.len_dwords == consumer.pc)
+                native_b32_mask_scc_vote_pcs.insert(producer.pc);
+        }
+    }
+
     // Split at every branch target/fallthrough and around every cross-lane operation. Case values are
     // dense block indices, not guest PCs. A cross-lane op must end its block so the common synchronized
     // phase can publish its result before any invocation advances to the following guest instruction.
@@ -10662,6 +10687,13 @@ bool emit_cfg_state_machine(
                         std::fprintf(stderr, "[cfg-recompile-reject] pc=%u fmt=%d op=0x%x\n",
                                      in.pc, static_cast<int>(in.fmt), in.opcode);
                     return false;
+                }
+                if (!state.scc && native_b32_mask_scc_vote_pcs.contains(in.pc)) {
+                    const auto result = state.sreg_bool.find(in.dst.value);
+                    if (result == state.sreg_bool.end() ||
+                        !state.sreg_bool_b32.contains(in.dst.value))
+                        return reject_cfg(in.pc, "missing-b32-mask-scc-source");
+                    state.scc = b.native_wave_any(result->second);
                 }
             }
             const bool last = member + 1 == dispatch_blocks[dispatch].size();

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -606,6 +606,34 @@ int main() {
     native_cfg17d1.local_x = 64;
     native_cfg17d1.wave_size = 32;
     native_cfg17d1.native_subgroup_size = 32;
+    // Astro's traversal combines three VOPC masks, then immediately branches on the SCC written by
+    // the final B32 AND. Keep the irreducible dispatcher tail from kernel 17d and prove that this
+    // exact native path adds one (and only one) subgroup vote for the live final intersection.
+    std::vector<uint32_t> code17d1s = {
+        0xbe9b037eu,              // s_mov_b32 s27, exec_lo
+        0x7d8a0a15u,              // v_cmp_* vcc, s21, v5
+        0x7d8a0af9u, 0x0686eb19u, // v_cmp_* s107, s25, v5
+        0x7d8a0af9u, 0x06869c1au, // v_cmp_* s28, s26, v5
+        0x876a6a1bu,              // s_and_b32 vcc_lo, s27, vcc_lo
+        0x876a6b6au,              // s_and_b32 vcc_lo, vcc_lo, vcc_hi
+        0x876a1c6au,              // s_and_b32 vcc_lo, vcc_lo, s28
+        0xbf840001u,              // s_cbranch_scc0 +1
+        0xbf800000u,              // fallthrough work
+    };
+    code17d1s.insert(code17d1s.end(), std::begin(code17d), std::end(code17d));
+    const std::vector<uint32_t> native_spv17d32 = recompile_compute(
+        code17d, std::size(code17d), nullptr, native_cfg17d1);
+    const std::vector<uint32_t> native_spv17d1s = recompile_compute(
+        code17d1s.data(), code17d1s.size(), nullptr, native_cfg17d1);
+    CHECK(!native_spv17d32.empty() && !native_spv17d1s.empty() &&
+              count_spirv_opcode(native_spv17d1s, 335) ==
+                  count_spirv_opcode(native_spv17d32, 335) + 1,
+          "Wave32 mask SCC branch emits only the final live subgroup-any vote");
+    ComputeShaderConfig portable_cfg17d1s = native_cfg17d1;
+    portable_cfg17d1s.native_subgroup_size = 0;
+    CHECK(recompile_compute(code17d1s.data(), code17d1s.size(), nullptr,
+                            portable_cfg17d1s).empty(),
+          "Wave32 mask SCC branch rejects without an exact native subgroup contract");
     const std::vector<uint32_t> native_spv17d1 = recompile_compute(
         code17d1, std::size(code17d1), &rt17d1, native_cfg17d1);
     CHECK(!native_spv17d1.empty() && count_spirv_opcode(native_spv17d1, 349) >= 2 &&

--- a/prosper/tests/test_recompile_coverage.cpp
+++ b/prosper/tests/test_recompile_coverage.cpp
@@ -433,6 +433,33 @@ int main() {
                              compute_cfg_dispatch_vcc_gt_zero.size(), &dispatch_rt,
                              wave32_dispatch_config).empty(),
           "the complex dispatcher preserves Wave32 VCC_LO > 0 scalar mask semantics");
+    // Astro's world-map traversal intersects three complete Wave32 predicates in VCC_LO, then
+    // branches on the SCC written by the final s_and_b32. Hardware SCC is any(result mask), so an
+    // exact 32-lane native subgroup can lower it without scalarizing or guessing at one lane.
+    std::vector<uint32_t> compute_cfg_dispatch_mask_scc = {
+        0xBE9B037Eu,              // s_mov_b32 s27, exec_lo
+        0x7D8A0A15u,              // v_cmp_* vcc, s21, v5       (Astro PC1079)
+        0x7D8A0AF9u, 0x0686EB19u, // v_cmp_* s107, s25, v5      (Astro PC1080)
+        0x7D8A0AF9u, 0x06869C1Au, // v_cmp_* s28, s26, v5       (Astro PC1082)
+        0x876A6A1Bu,              // s_and_b32 vcc_lo, s27, vcc_lo
+        0x876A6B6Au,              // s_and_b32 vcc_lo, vcc_lo, vcc_hi
+        0x876A1C6Au,              // s_and_b32 vcc_lo, vcc_lo, s28
+        0xBF840001u,              // s_cbranch_scc0 +1
+        0xBF800000u,              // fallthrough work
+    };
+    compute_cfg_dispatch_mask_scc.insert(
+        compute_cfg_dispatch_mask_scc.end(), compute_cfg_dispatch,
+        compute_cfg_dispatch + std::size(compute_cfg_dispatch));
+    CHECK(!recompile_compute(compute_cfg_dispatch_mask_scc.data(),
+                             compute_cfg_dispatch_mask_scc.size(), &dispatch_rt,
+                             wave32_dispatch_config).empty(),
+          "the exact Wave32 dispatcher branches on the SCC from a B32 mask intersection");
+    ComputeShaderConfig portable_mask_scc_config = wave32_dispatch_config;
+    portable_mask_scc_config.native_subgroup_size = 0;
+    CHECK(recompile_compute(compute_cfg_dispatch_mask_scc.data(),
+                            compute_cfg_dispatch_mask_scc.size(), &dispatch_rt,
+                            portable_mask_scc_config).empty(),
+          "a portable dispatcher rejects unsynchronized Wave32 mask SCC instead of using stale state");
     std::vector<uint32_t> compute_cfg_dispatch_ff1 = {
         0xBE800385u, // s_mov_b32 s0, 5
         0x7D840000u, // v_cmp_eq_u32 vcc, s0, v0


### PR DESCRIPTION
## What changed

Lower the SCC result of immediately consumed Wave32 B32 mask logical operations inside the exact native compute CFG dispatcher.

Astro Bot's world-map traversal shader intersects three complete Wave32 predicate masks, then branches on the SCC produced by the final `s_and_b32`. Hardware defines that SCC as `any(result mask)`; the ordinary lane-local emitter deliberately leaves it poisoned because a single invocation cannot answer that question.

When the runtime proves an exact native 32-lane subgroup, this change:

- recognizes only a B32 mask logical immediately followed by `s_cbranch_scc0/1`;
- performs one subgroup-wide `any` for the final live mask result;
- keeps portable/non-exact subgroup paths fail-visible;
- avoids adding votes for the intermediate mask intersections in the hot traversal loop.

## Why

The repeated Astro Bot compute program at `0x50057b800` reached this exact sequence around guest PCs 1079–1088 and was rejected at the SCC branch. A routed live diagnostic run after the change translated past the former `poisoned-scc` blocker and compiled the complete shader when the separately unresolved BVH query was locally replaced with an all-miss diagnostic result.

This is a partial #1459 checkpoint. The world map remains black and the newly accepted live GPU path exposed RADV/GPUVM instability, so this PR does not claim visible rendering progress.

## Verification

Exact head: `dd049ed7931b05e67a75c56dba37a3376a14a244`

- `./build-astrobot-fmv/test_recompile_coverage` — PASS
- `./build-astrobot-fmv/test_rdna2_to_spirv` — PASS
- `git diff --check origin/master...HEAD` — PASS
- Target-shaped regressions prove the exact Wave32 path accepts the SCC branch, the portable path rejects it, and only one final `OpGroupNonUniformAny` is emitted.

The local BVH all-miss diagnostic used to reach this later blocker is not included in the commit. Full snapshots were not run; this is a focused development PR, not a release. No screenshot is attached because the reached world-map frame is still black/diagnostic-only.