### PR TITLE
gpu: retain unresolved indirect shader captures

### DIFF
--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -3331,6 +3331,69 @@ bool materialize_pending_gpu_capture(PendingGpuCapture& pending,
         failures.insert(failures.end(),
                         std::make_move_iterator(compute_failures.begin()),
                         std::make_move_iterator(compute_failures.end()));
+    } else if (semantic_state && exact_failures) {
+        // Argument resolution can fail before execute_ordered_gpustate has enough information to
+        // append an exact OperationRealizationFailure. Add those missing dispatch records here,
+        // before capture_submit_items would otherwise synthesize a permanently empty Unknown.
+        for (size_t index = 0; index < semantic_state->dispatches.size(); ++index) {
+            const GpuState::Dispatch& dispatch = semantic_state->dispatches[index];
+            const bool captured_operation = operations.empty() || std::any_of(
+                operations.begin(), operations.end(), [&](const SubmitOperation& operation) {
+                    return operation.kind == SubmitOperationKind::Dispatch &&
+                           operation.index == index &&
+                           operation.command_order == dispatch.command_order;
+                });
+            if (!captured_operation) continue;
+            const bool realized = std::any_of(
+                computes.begin(), computes.end(), [&](const ComputeItem& item) {
+                    return item.dispatch_index == index &&
+                           item.command_order == dispatch.command_order;
+                });
+            const bool diagnosed = std::any_of(
+                failures.begin(), failures.end(), [&](const OperationRealizationFailure& failure) {
+                    return failure.kind == SubmitOperationKind::Dispatch &&
+                           failure.index == index &&
+                           failure.command_order == dispatch.command_order;
+                });
+            if (realized || diagnosed) continue;
+            OperationRealizationFailure failure;
+            failure.kind = SubmitOperationKind::Dispatch;
+            failure.index = index;
+            failure.command_order = dispatch.command_order;
+            failure.reason = RealizationFailureReason::Unknown;
+            failure.compute_launch = resolve_compute_launch(dispatch);
+            failures.push_back(std::move(failure));
+        }
+        // Ordered execution can reject an indirect dispatch before shader realization when an
+        // earlier producer leaves its argument buffer unreadable or empty. The exact trace owns the
+        // operation outcome and launch facts, but its Unknown failure then has no stage at all. Use
+        // the retained pre-submit register snapshot only to recover the shader diagnostic: this does
+        // not resolve the arguments, mark the operation realized, or execute GPU work. Keeping the
+        // raw program/resource metadata makes a COMPUTE_ADDR-selected capsule useful for offline
+        // inspection even when the missing producer is the very bug under investigation.
+        for (auto& failure : failures) {
+            if (failure.kind != SubmitOperationKind::Dispatch || !failure.stages.empty() ||
+                failure.index >= semantic_state->dispatches.size())
+                continue;
+            const GpuState::Dispatch& dispatch = semantic_state->dispatches[failure.index];
+            GpuState diagnostic_state = dispatch.state ? *dispatch.state : *semantic_state;
+            diagnostic_state.dispatches.clear();
+            diagnostic_state.dispatches.push_back(dispatch);
+            std::vector<OperationRealizationFailure> semantic_failures;
+            std::vector<ComputeItem> semantic_items = realize_compute_dispatches(
+                diagnostic_state, metadata.submit_index, &semantic_failures);
+            if (!semantic_items.empty()) {
+                ShaderRealizationDiagnostic stage;
+                stage.stage = ShaderProgramStage::Compute;
+                stage.program_addr = semantic_items.front().code_addr;
+                stage.resources = semantic_items.front().resources;
+                stage.recompiled = !semantic_items.front().spirv.empty();
+                failure.stages.push_back(std::move(stage));
+            } else if (!semantic_failures.empty() &&
+                       !semantic_failures.front().stages.empty()) {
+                failure.stages = std::move(semantic_failures.front().stages);
+            }
+        }
     }
     const std::vector<ComputeItem> snapshot_computes =
         with_pending_gds_snapshot(pending, computes);

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -3376,6 +3376,7 @@ bool materialize_pending_gpu_capture(PendingGpuCapture& pending,
                 failure.index >= semantic_state->dispatches.size())
                 continue;
             const GpuState::Dispatch& dispatch = semantic_state->dispatches[failure.index];
+            if (failure.command_order != dispatch.command_order) continue;
             GpuState diagnostic_state = dispatch.state ? *dispatch.state : *semantic_state;
             diagnostic_state.dispatches.clear();
             diagnostic_state.dispatches.push_back(dispatch);
@@ -3387,11 +3388,16 @@ bool materialize_pending_gpu_capture(PendingGpuCapture& pending,
                 stage.stage = ShaderProgramStage::Compute;
                 stage.program_addr = semantic_items.front().code_addr;
                 stage.resources = semantic_items.front().resources;
-                stage.recompiled = !semantic_items.front().spirv.empty();
                 failure.stages.push_back(std::move(stage));
             } else if (!semantic_failures.empty() &&
                        !semantic_failures.front().stages.empty()) {
-                failure.stages = std::move(semantic_failures.front().stages);
+                const ShaderRealizationDiagnostic& semantic_stage =
+                    semantic_failures.front().stages.front();
+                ShaderRealizationDiagnostic stage;
+                stage.stage = semantic_stage.stage;
+                stage.program_addr = semantic_stage.program_addr;
+                stage.resources = semantic_stage.resources;
+                failure.stages.push_back(std::move(stage));
             }
         }
     }

--- a/prosper/tests/test_gpu_execute.cpp
+++ b/prosper/tests/test_gpu_execute.cpp
@@ -795,6 +795,11 @@ int main() {
         direct_dispatch.threads_x = direct_dispatch.threads_y = direct_dispatch.threads_z = 1;
         direct_dispatch.command_order = 17;
         nonrender.dispatches.push_back(direct_dispatch);
+        GpuState::Dispatch unresolved_dispatch;
+        unresolved_dispatch.indirect = true;
+        unresolved_dispatch.indirect_args_addr = 0xdead00000000ull;
+        unresolved_dispatch.command_order = 19;
+        nonrender.dispatches.push_back(unresolved_dispatch);
         const std::filesystem::path path =
             std::filesystem::temp_directory_path() / "prosper_nonrender_submit_capture.prgcap";
         std::error_code filesystem_error;
@@ -822,63 +827,75 @@ int main() {
 #endif
         GpuCaptureFile captured;
         std::string capture_error;
-        CHECK(executed && compute_calls == 1 &&
-                  read_gpu_capture(path.string(), captured, capture_error) &&
+        const bool captured_read = read_gpu_capture(path.string(), captured, capture_error);
+        const GpuCapturedOperationFailure* unresolved_failure = captured.failure_diagnostics.empty()
+            ? nullptr : &captured.failure_diagnostics.front();
+        const GpuCapturedStageDiagnostic* unresolved_stage = unresolved_failure &&
+            unresolved_failure->stages.size() == 1
+                ? &unresolved_failure->stages.front() : nullptr;
+        CHECK(executed && compute_calls == 1 && captured_read &&
                   captured.metadata.submit_index == 1441 && captured.computes.size() == 1 &&
                   captured.computes[0].code_addr == reinterpret_cast<uint64_t>(kNoopCs) &&
-                  captured.operations.size() == 1 && captured.operations[0].realized &&
+                  captured.operations.size() == 2 && captured.operations[0].realized &&
                   captured.operations[0].kind == SubmitOperationKind::Dispatch &&
-                  !captured.expected_output_valid,
-              "environment capture retains the exact executed direct-compute submit");
-        std::filesystem::remove(path, filesystem_error);
-
-        // A failed producer can leave an indirect dispatch's argument buffer empty before the
-        // selected operation is reached. The exact ordered trace correctly keeps that dispatch
-        // unrealized, but capture must still retain the program from its semantic register snapshot
-        // so the shader can be dumped and inspected without another title boot.
-        alignas(4) uint32_t unavailable_indirect_args[3] = {};
-        GpuState unresolved = nonrender;
-        unresolved.dispatches.clear();
-        GpuState::Dispatch unresolved_dispatch;
-        unresolved_dispatch.indirect = true;
-        unresolved_dispatch.indirect_args_addr =
-            reinterpret_cast<uint64_t>(unavailable_indirect_args);
-        unresolved_dispatch.command_order = 19;
-        unresolved.dispatches.push_back(unresolved_dispatch);
-        const std::vector<SubmitOperation> unresolved_operations = {
-            {SubmitOperationKind::Dispatch, 0, unresolved_dispatch.command_order},
-        };
-        auto unresolved_pending = std::make_unique<PendingGpuCapture>();
-        unresolved_pending->materialized = false;
-        unresolved_pending->path = path.string();
-        unresolved_pending->capture.metadata.submit_index = 1442;
-        const std::vector<DrawItem> no_draws;
-        const std::vector<ComputeItem> no_computes;
-        // Argument resolution failed before the ordered trace could populate the exact failure
-        // list. Capture must create and enrich the missing dispatch diagnostic itself.
-        const std::vector<OperationRealizationFailure> unresolved_failures;
-        const bool unresolved_written = finish_requested_gpu_capture(
-            std::move(unresolved_pending), {}, capture_error, &no_draws, &no_computes,
-            &unresolved_operations, &unresolved, &unresolved_failures);
-        GpuCaptureFile unresolved_capture;
-        const bool unresolved_read = unresolved_written &&
-            read_gpu_capture(path.string(), unresolved_capture, capture_error);
-        const GpuCapturedStageDiagnostic* unresolved_stage = unresolved_read &&
-            unresolved_capture.failure_diagnostics.size() == 1 &&
-            unresolved_capture.failure_diagnostics[0].stages.size() == 1
-                ? &unresolved_capture.failure_diagnostics[0].stages[0] : nullptr;
-        CHECK(unresolved_stage && unresolved_capture.computes.empty() &&
-                  unresolved_capture.operations.size() == 1 &&
-                  !unresolved_capture.operations[0].realized &&
-                  unresolved_capture.failure_diagnostics[0].reason ==
+                  captured.operations[0].source_index == 0 &&
+                  captured.operations[0].command_order == direct_dispatch.command_order &&
+                  !captured.operations[1].realized &&
+                  captured.operations[1].kind == SubmitOperationKind::Dispatch &&
+                  captured.operations[1].source_index == 1 &&
+                  captured.operations[1].command_order == unresolved_dispatch.command_order &&
+                  captured.failure_diagnostics.size() == 1 && unresolved_failure &&
+                  unresolved_failure->kind == SubmitOperationKind::Dispatch &&
+                  unresolved_failure->source_index == 1 &&
+                  unresolved_failure->command_order == unresolved_dispatch.command_order &&
+                  unresolved_failure->reason ==
                       RealizationFailureReason::Unknown &&
+                  unresolved_failure->compute_launch.groups_x == 0 &&
+                  unresolved_failure->compute_launch.groups_y == 0 &&
+                  unresolved_failure->compute_launch.groups_z == 0 &&
+                  unresolved_stage && !unresolved_stage->recompiled &&
                   unresolved_stage->stage == ShaderProgramStage::Compute &&
                   unresolved_stage->program_addr == reinterpret_cast<uint64_t>(kNoopCs) &&
                   unresolved_stage->raw_shader_index <
-                      unresolved_capture.raw_shader_versions.size() &&
-                  unresolved_capture.raw_shader_versions[unresolved_stage->raw_shader_index].words ==
-                      std::vector<uint32_t>(std::begin(kNoopCs), std::end(kNoopCs)),
-              "deferred capture retains the shader for an unresolved indirect dispatch");
+                      captured.raw_shader_versions.size() &&
+                  captured.raw_shader_versions[unresolved_stage->raw_shader_index].words ==
+                      std::vector<uint32_t>(std::begin(kNoopCs), std::end(kNoopCs)) &&
+                  !captured.expected_output_valid,
+              "ordered capture retains exact direct and unresolved indirect compute evidence");
+        std::filesystem::remove(path, filesystem_error);
+
+        // A partial exact trace can identify an operation whose source index happens to exist in
+        // the semantic state but whose command order does not. Never attach that other dispatch's
+        // program or resources to the exact failure.
+        constexpr uint64_t kMismatchedOrder = 20;
+        auto mismatched_pending = std::make_unique<PendingGpuCapture>();
+        mismatched_pending->materialized = false;
+        mismatched_pending->path = path.string();
+        mismatched_pending->capture.metadata.submit_index = 1442;
+        const std::vector<SubmitOperation> mismatched_operations = {
+            {SubmitOperationKind::Dispatch, 1, kMismatchedOrder},
+        };
+        const std::vector<OperationRealizationFailure> mismatched_failures = {
+            {SubmitOperationKind::Dispatch, 1, kMismatchedOrder,
+             RealizationFailureReason::Unknown},
+        };
+        const std::vector<DrawItem> no_draws;
+        const std::vector<ComputeItem> no_computes;
+        const bool mismatched_written = finish_requested_gpu_capture(
+            std::move(mismatched_pending), {}, capture_error, &no_draws, &no_computes,
+            &mismatched_operations, &nonrender, &mismatched_failures);
+        GpuCaptureFile mismatched_capture;
+        const bool mismatched_read = mismatched_written &&
+            read_gpu_capture(path.string(), mismatched_capture, capture_error);
+        CHECK(mismatched_read && mismatched_capture.operations.size() == 1 &&
+                  mismatched_capture.operations[0].source_index == 1 &&
+                  mismatched_capture.operations[0].command_order == kMismatchedOrder &&
+                  !mismatched_capture.operations[0].realized &&
+                  mismatched_capture.failure_diagnostics.size() == 1 &&
+                  mismatched_capture.failure_diagnostics[0].source_index == 1 &&
+                  mismatched_capture.failure_diagnostics[0].command_order == kMismatchedOrder &&
+                  mismatched_capture.failure_diagnostics[0].stages.empty(),
+              "semantic stage enrichment requires exact dispatch command-order identity");
         std::filesystem::remove(path, filesystem_error);
 
         // Vulkan guarantees only 65,535 workgroups per axis, but real devices may advertise more

--- a/prosper/tests/test_gpu_execute.cpp
+++ b/prosper/tests/test_gpu_execute.cpp
@@ -832,6 +832,55 @@ int main() {
               "environment capture retains the exact executed direct-compute submit");
         std::filesystem::remove(path, filesystem_error);
 
+        // A failed producer can leave an indirect dispatch's argument buffer empty before the
+        // selected operation is reached. The exact ordered trace correctly keeps that dispatch
+        // unrealized, but capture must still retain the program from its semantic register snapshot
+        // so the shader can be dumped and inspected without another title boot.
+        alignas(4) uint32_t unavailable_indirect_args[3] = {};
+        GpuState unresolved = nonrender;
+        unresolved.dispatches.clear();
+        GpuState::Dispatch unresolved_dispatch;
+        unresolved_dispatch.indirect = true;
+        unresolved_dispatch.indirect_args_addr =
+            reinterpret_cast<uint64_t>(unavailable_indirect_args);
+        unresolved_dispatch.command_order = 19;
+        unresolved.dispatches.push_back(unresolved_dispatch);
+        const std::vector<SubmitOperation> unresolved_operations = {
+            {SubmitOperationKind::Dispatch, 0, unresolved_dispatch.command_order},
+        };
+        auto unresolved_pending = std::make_unique<PendingGpuCapture>();
+        unresolved_pending->materialized = false;
+        unresolved_pending->path = path.string();
+        unresolved_pending->capture.metadata.submit_index = 1442;
+        const std::vector<DrawItem> no_draws;
+        const std::vector<ComputeItem> no_computes;
+        // Argument resolution failed before the ordered trace could populate the exact failure
+        // list. Capture must create and enrich the missing dispatch diagnostic itself.
+        const std::vector<OperationRealizationFailure> unresolved_failures;
+        const bool unresolved_written = finish_requested_gpu_capture(
+            std::move(unresolved_pending), {}, capture_error, &no_draws, &no_computes,
+            &unresolved_operations, &unresolved, &unresolved_failures);
+        GpuCaptureFile unresolved_capture;
+        const bool unresolved_read = unresolved_written &&
+            read_gpu_capture(path.string(), unresolved_capture, capture_error);
+        const GpuCapturedStageDiagnostic* unresolved_stage = unresolved_read &&
+            unresolved_capture.failure_diagnostics.size() == 1 &&
+            unresolved_capture.failure_diagnostics[0].stages.size() == 1
+                ? &unresolved_capture.failure_diagnostics[0].stages[0] : nullptr;
+        CHECK(unresolved_stage && unresolved_capture.computes.empty() &&
+                  unresolved_capture.operations.size() == 1 &&
+                  !unresolved_capture.operations[0].realized &&
+                  unresolved_capture.failure_diagnostics[0].reason ==
+                      RealizationFailureReason::Unknown &&
+                  unresolved_stage->stage == ShaderProgramStage::Compute &&
+                  unresolved_stage->program_addr == reinterpret_cast<uint64_t>(kNoopCs) &&
+                  unresolved_stage->raw_shader_index <
+                      unresolved_capture.raw_shader_versions.size() &&
+                  unresolved_capture.raw_shader_versions[unresolved_stage->raw_shader_index].words ==
+                      std::vector<uint32_t>(std::begin(kNoopCs), std::end(kNoopCs)),
+              "deferred capture retains the shader for an unresolved indirect dispatch");
+        std::filesystem::remove(path, filesystem_error);
+
         // Vulkan guarantees only 65,535 workgroups per axis, but real devices may advertise more
         // (RADV exposes UINT32_MAX in X). Astro Bot emits indirect 1D dispatches above the portable
         // minimum during world-map loading, after already using a 131,072-group direct dispatch.

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -95,7 +95,10 @@ counts matching invocations that reach the registered renderer, after the normal
 sampling. Aim the live run near the target first; the capture itself writes once.
 `PROSPER_GPU_CAPTURE_COMPUTE_ADDR=0x...` additionally requires the exact compute program address.
 Use it for a late or intermittent compute fault when predicting a renderer invocation or semantic
-submit number would be fragile.
+submit number would be fragile. If an earlier producer failure leaves a selected indirect dispatch's
+arguments unavailable, the capsule keeps that operation unrealized with its zero/unknown launch but
+still retains the semantic program's bounded raw shader and descriptor metadata. Inspect or dump that
+failed stage offline instead of rerunning the title merely to recover its shader bytes.
 `PROSPER_GPU_CAPTURE_SHADER_ADDR=0x...` does the same for any realized or semantic draw stage,
 including a shader whose draw failed realization and therefore never reached the renderer.
 `PROSPER_GPU_CAPTURE_TARGET_DIM=WxH` requires at least one realized or semantic color target with the

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -350,6 +350,10 @@ stage is fault-safely read once, content-deduplicated, capped at 64 KiB, and sto
 `s_endpgm`/unknown instruction or the cap. Total failed-stage data is capped at 64 MiB, diagnostics cannot
 outnumber semantic operations, and every reference/hash is validated while reading. Captures v1-v6 remain
 readable and print `failure-diagnostics: unavailable (capture predates v7)` rather than inventing evidence.
+An indirect compute dispatch whose argument producer failed remains explicitly unrealized with an unknown/zero
+launch, but current runtime capture enriches that failure from its retained register snapshot so the exact raw
+compute program and descriptor metadata remain inspectable and dumpable. It does not invent the missing launch
+specialization; failed-compute retry still requires a later capture whose dispatch arguments were resolved.
 
 `--retry-failed-stage FAILURE:STAGE` reruns one retained stage through the current recompiler with its exact
 captured resource table. For split vertex programs, `--retry-failed-chain FAILURE` instead reconstructs the


### PR DESCRIPTION
Fixes #1509.

## What changed

Deferred GPU capture now preserves a compute-stage diagnostic when an indirect dispatch cannot resolve its launch arguments:

- add a missing `Unknown` dispatch failure only when the operation is part of the captured submit and has neither an exact failure nor a realized compute item;
- enrich empty exact/missing dispatch failures from the retained semantic register snapshot;
- retain the bounded raw compute program and descriptor metadata without resolving arguments, marking the operation realized, or executing GPU work;
- document the behavior and its deliberately unknown launch specialization.

## Root cause

`resolve_indirect_dispatch_arguments` can fail before ordered execution creates an `OperationRealizationFailure`. Deferred capture trusted the exact failure list, so `capture_submit_items` later synthesized a generic `reason=unknown stages=0` record. A `PROSPER_GPU_CAPTURE_COMPUTE_ADDR` selector could therefore match the semantic program but write a capsule that omitted the selected shader entirely.

## Impact and invariants

The failed operation remains unrealized and retains its exact unknown/zero launch. The semantic pass is diagnostic-only: it rebuilds shader/resource metadata from the retained pre-submit state but does not invent producer output or submit work to Vulkan. Existing realized operations and more precise exact failures remain authoritative.

This turns a late shader recovery loop into a GPU-free capture/inspect loop. A routed Astro Bot validation reached `worldmap` in under a minute and the resulting metadata-only capsule retained compute program `0x50057b800`, all 3,296 raw dwords (13,184 bytes), and 64 resource descriptors even though its indirect launch remained unresolved.

No screenshot is attached because this tooling run used no rendering and provides no visible progression evidence.

## Verification

Exact head: `c94249c2c85a09b9c94cb4ba234dd77c564e947b`

- `./build-astrobot-fmv/test_gpu_capture` — PASS
- `./build-astrobot-fmv/test_gpu_execute` — PASS
- `./build-astrobot-fmv/test_game_compute` — PASS
- `git diff --check` — PASS
- Astro Bot GPU-free route with `PROSPER_NO_COMPUTE=1`, `PROSPER_GPU_CAPTURE_COMPUTE_ADDR=0x50057b800`, and metadata-only capture:
  - reached `worldmap`;
  - `gpu_replay --inspect-only` reports the exact target as `reason=unknown stages=1`, `raw=yes`, 3,296 dwords, 64 descriptors.

Full snapshots were not run; this is a focused development/tooling PR, not a release.