### PR TITLE
fix(render): stop a depth-only pass publishing its blank readback as color

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -2298,6 +2298,17 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // RTT (#167): if this texture's base is a color target we rendered into, inject those
                         // pixels (nearest-scaled to tw x th) instead of reading empty guest memory.
                         bool rtt_hit = false;
+                        // Why a sampled resource never consulted the renderer-owned RTT cache. Without
+                        // this, a draw that reads a target prosper rendered but takes the guest-decode
+                        // path instead is invisible in the log: no "sample tex" line is emitted at all,
+                        // and the draw silently samples empty guest memory.
+                        if (rtt_log && (fr.is_storage_image || !rtt_on || is_volume || r.in_mip_tail))
+                            fprintf(stderr,
+                                    "[rtt] sample tex addr=0x%llx %ux%u fmt=%u -> RTT PATH SKIPPED "
+                                    "(storage=%d rtt_on=%d volume=%d mip_tail=%d)\n",
+                                    (unsigned long long)r.gpu_addr, tw, th, (unsigned)r.format,
+                                    (int)fr.is_storage_image, (int)rtt_on, (int)is_volume,
+                                    (int)r.in_mip_tail);
                         if (!fr.is_storage_image && rtt_on && !is_volume && !r.in_mip_tail) {
                             auto rit = g_rtt.find(r.gpu_addr);
                             if (rit != g_rtt.end() && rit->second.w && rit->second.h && rit->second.rgba &&

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -3935,6 +3935,16 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                draw->ps.depth_clear_enable || draw->ps.stencil_enable ||
                                draw->ps.stencil_clear_enable;
                     });
+                    // A depth/stencil-only pass writes no color, so its readback must not be published as
+                    // this base's surface nor as the presented frame — see pass_publishes_color(). DQ VII's
+                    // title screen went black exactly this way: a 5-draw CB_TARGET_MASK=0 pass, sized
+                    // 3840x2160 from its viewport, overwrote the live 960x1080 bloom target sharing its
+                    // dummy color base, and the composite then sampled a blank surface (#1510).
+                    const bool publishes_color = prosper::frontend::pass_publishes_color(
+                        color_disabled,
+                        std::any_of(pass.begin(), pass.end(), [](const auto* draw) {
+                            return draw->ps.has_clear_color;
+                        }));
                     if (color_disabled && uses_ds && w && h) {
                         float viewport_x = 0.0f, viewport_y = 0.0f;
                         for (const auto* draw : pass) {
@@ -4261,7 +4271,12 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         pending_timing.color_target_cached_entries = color_target_call.cached_entries;
                     }
                     auto pass_pixels = std::make_shared<const std::vector<uint8_t>>(std::move(gpx));
-                    if (base && color_target_call.writes) {
+                    if (rtt_log && base && !publishes_color)
+                        fprintf(stderr,
+                                "[rtt] pass target=0x%llx extent=%ux%u (%zu draws) color-disabled -> "
+                                "not published (depth/stencil-only pass, dummy color binding)\n",
+                                (unsigned long long)base, gw, gh, pass.size());
+                    if (base && publishes_color && color_target_call.writes) {
                         RttSurf& surface = g_rtt[base];
                         surface.w = gw;
                         surface.h = gh;
@@ -4296,7 +4311,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 }
                             }
                         }
-                    } else if (base && !pass_pixels->empty()) {
+                    } else if (base && publishes_color && !pass_pixels->empty()) {
                         RttSurf& surface = g_rtt[base];
                         surface.rgba = pass_pixels;
                         surface.w = gw;
@@ -4524,7 +4539,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             }
                         }
                     }
-                    if (!rendered_pixels.empty() && pass_format == VK_FORMAT_R8G8B8A8_UNORM) {
+                    if (!rendered_pixels.empty() && publishes_color &&
+                        pass_format == VK_FORMAT_R8G8B8A8_UNORM) {
                         if (base && base == front_va) px_front = pass_pixels;  // the flipped buffer
                         if (is_vo)                    px_vo = pass_pixels;     // any registered scanout
                         px_last = pass_pixels;                                  // last non-empty (fallback)

--- a/prosper/frontends/shared/rtt_injection.hpp
+++ b/prosper/frontends/shared/rtt_injection.hpp
@@ -12,6 +12,22 @@
 
 namespace prosper::frontend {
 
+// Whether a render pass produces color that may be published as the content of its color0 base.
+//
+// A pass whose every draw masks off all color components (the MRT0 nibble of CB_TARGET_MASK is 0) is a
+// depth/stencil-only pass — a depth prepass, or an occlusion/predication pass. The hardware writes no
+// color for it at all, and its color binding is a dummy: `color0_base` can name a completely different,
+// smaller live surface, while the extent the renderer uses for such a pass is deliberately derived from
+// the viewport to size the DEPTH image rather than from that surface. Publishing its readback as color
+// therefore replaces a real surface with a blank one at the wrong extent, and every later sample of that
+// address reads nothing.
+//
+// The one case where a color-disabled pass does produce color is a programmed fast clear, which the
+// backend applies to the attachment before the draws — so that keeps publishing.
+inline bool pass_publishes_color(bool all_draws_color_write_masked, bool any_draw_has_clear_color) {
+    return !all_draws_color_write_masked || any_draw_has_clear_color;
+}
+
 // An immutable CPU RTT snapshot can back a FrameResource directly only when the consumer uses the
 // producer's exact extent and byte layout. Scaled views still need their owned nearest-neighbor copy;
 // malformed snapshots stay on the guest-decode fallback.

--- a/prosper/frontends/shared/test_rtt_injection.cpp
+++ b/prosper/frontends/shared/test_rtt_injection.cpp
@@ -6,6 +6,7 @@
 
 using prosper::frontend::inject_rtt_pixels;
 using prosper::frontend::exact_rtt_snapshot_borrowable;
+using prosper::frontend::pass_publishes_color;
 using prosper::frontend::RttInjectionCache;
 
 static int failures = 0;
@@ -91,6 +92,17 @@ int main() {
     CHECK(!cache.materialize(
         std::make_shared<const std::vector<uint8_t>>(malformed), 1, 1, 1, 1, 8));
     CHECK(cache.size() == 3);
+
+    // pass_publishes_color (#1510): a pass whose every draw masks off all color components writes no
+    // color, so its readback must not be published as its color0 base's surface or as the presented
+    // frame. DQ VII's title went black because a CB_TARGET_MASK=0 depth prepass, sized from its 4K
+    // viewport, replaced the live 960x1080 bloom target that shared its dummy color base.
+    CHECK(pass_publishes_color(/*all_masked=*/false, /*any_clear=*/false)); // ordinary color pass
+    CHECK(!pass_publishes_color(/*all_masked=*/true, /*any_clear=*/false)); // depth/stencil-only pass
+    // A programmed fast clear is the one case where a color-disabled pass does produce color: the
+    // backend applies it to the attachment before the draws, so that result stays authoritative.
+    CHECK(pass_publishes_color(/*all_masked=*/true, /*any_clear=*/true));
+    CHECK(pass_publishes_color(/*all_masked=*/false, /*any_clear=*/true));
 
     if (!failures) std::printf("rtt_injection: OK\n");
     return failures ? 1 : 0;


### PR DESCRIPTION
Fixes #1510

## Failure scenario

A pass whose every draw masks off all color components (the MRT0 nibble of `CB_TARGET_MASK` is 0) is a
depth/stencil-only pass — a depth prepass, or an occlusion/predication pass. The hardware writes no color
for it, and its color binding is a **dummy**: `color0_base` can name a completely different, smaller live
surface, while the extent the renderer uses for such a pass is deliberately derived from the viewport in
order to size the **depth** image rather than that surface.

The color0 publication in `live_renderer.cpp` did not know that:

```cpp
if (base && color_target_call.writes) { ... }
else if (base && !pass_pixels->empty()) {      // reached precisely BECAUSE no color was written
    RttSurf& surface = g_rtt[base];
    surface.rgba = pass_pixels;
    surface.w = gw; surface.h = gh;            // gw/gh = viewport-derived DEPTH extent
```

so a depth prepass replaced a real render target with a blank surface at the wrong extent, and every
later sample of that address read nothing. The presented-frame publication
(`px_front` / `px_vo` / `px_last`) had the same hole, so a depth prepass whose dummy color base happened
to be the scanout buffer could blank the presented frame outright.

Observed live on Dragon Quest VII (`PPSA17942`) — the cache holds the correct entry and the depth pass
wins:

```
[rtt] seed miss target=…83e90000 reason=mismatch entry=960x1080 rgba=4147200 want=3840x2160 bytes=33177600
[rtt]   draw#0..4 tgt=…83e90000 mask=0x0 vp=1(0.00,2160.00 3840.00x-2160.00) z=1 zw=1
[rtt] pass target=…83e90000 extent=3840x2160 (5 draws) px_nonzero=0
```

Every draw `mask=0x0`, `px_nonzero=0`. The same run also clobbered other bloom levels and the 2048×2048
shadow atlas the same way, so this is shared-substrate breakage rather than one title's quirk.

## Approach

A new pure predicate in `prosper/frontends/shared/rtt_injection.hpp`:

```cpp
bool pass_publishes_color(bool all_draws_color_write_masked, bool any_draw_has_clear_color);
```

guards both `g_rtt` publication branches and the presented-frame publication. Leaving the previous
contents in place is exactly what the hardware does when the write mask is zero.

**A programmed fast clear is the one case where a color-disabled pass does produce color** — the backend
applies it to the attachment before the draws — so `has_clear_color` keeps it publishing. DQ VII's
clobbering passes report `clear=0/0`, so the fix applies to them.

## Deliberately unaffected

- **The viewport-derived extent inference is untouched.** Sizing the persistent depth image from a tiny
  dummy color target's extent is the bug that inference exists to prevent; this change only stops that
  extent being used to publish *color*.
- **MRT slots ≥ 1.** `color_write_mask` is documented as the MRT0 nibble, so the predicate speaks only
  for slot 0, which is what `base` refers to. The per-slot loop is left alone.
- Passes that write any color component, and colour-disabled passes carrying a fast clear, behave as
  before.
- Depth/stencil production is unchanged — the pass still renders.

`PROSPER_RTTLOG=1` now reports each skipped pass, so the behavior is observable rather than silent.

## Risk

Low, and bounded to passes that provably write no color. The one judgement call is the fast-clear
carve-out; without it a `CB_TARGET_MASK=0` pass carrying a decoded fast clear would stop publishing the
cleared attachment. `CONFIDENCE: HIGH` on the write-mask semantics (`CB_TARGET_MASK` gates ROP color
writes), `CONFIDENCE: MED` that no title depends on the previous behavior — hence the request for review
below.

## Verification (exact head `5582b513`)

```
cmake -S prosper -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0
cmake --build build -j6
ctest --output-on-failure -j4      ->  100% tests passed, 155 of 155
```

Unit coverage added to `prosper/frontends/shared/test_rtt_injection.cpp` next to the existing
`exact_rtt_snapshot_borrowable` cases: ordinary pass publishes, colour-disabled pass does not,
colour-disabled + fast clear publishes.

**Live effect** — DQ VII, Linux `tools/screenshot`, native Vulkan (RADV STRIX_HALO), 3840×2160, route in
`prosper/docs/DRAGON_QUEST_STATUS.md`. Distinct-colour count per sampled frame, same route before/after:

```
before:  194 194 303 303 223   1 377   1 1 1 …
after:   194 194 303 3842 223 377 377   1 1 1 …
                     ^^^^      ^^^
```

A spurious blanked frame between the Unreal Engine and CRIWARE splashes is gone, and the title scene's
sky/ocean/islands now composite at correct exposure (3842 distinct colours) instead of being replaced by
a blank surface.

## Not a completion claim

Dragon Quest VII's **sustained** title state is still black, so this PR claims no bring-up rung and
attaches no progression screenshot. It removes one of the causes; the remaining one is being tracked in
#1486 (a full-screen Slate quad samples a surface that a *partially*-masked pass blanks the same way,
which this predicate deliberately does not cover). #1510 is fully addressed.

Note that reproducing any of this on master currently needs `PROSPER_NO_RTT_SNAPSHOT_BORROW=1` because of
#1505.