### PR TITLE
gpu: avoid cold compute image snapshot copies

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -805,12 +805,9 @@ if(TARGET prosper_core)
       add_executable(test_game_compute tests/test_game_compute.cpp)
       target_link_libraries(test_game_compute PRIVATE prosper_live_renderer)
       add_test(NAME game_compute_exec COMMAND test_game_compute)
-      add_test(NAME game_compute_exec_cold_storage_snapshot COMMAND test_game_compute)
-      set_tests_properties(game_compute_exec_cold_storage_snapshot PROPERTIES
-        ENVIRONMENT "PROSPER_COLD_STORAGE_SNAPSHOT_MIN_MB=0")
       add_test(NAME game_compute_exec_no_adaptive_storage_result COMMAND test_game_compute)
       set_tests_properties(game_compute_exec_no_adaptive_storage_result PROPERTIES
-        ENVIRONMENT "PROSPER_NO_ADAPTIVE_STORAGE_RESULT_VALIDATION=1;PROSPER_COLD_STORAGE_SNAPSHOT_MIN_MB=0")
+        ENVIRONMENT "PROSPER_NO_ADAPTIVE_STORAGE_RESULT_VALIDATION=1")
     else()
       message(STATUS "Vulkan not found — Windows boot_trace built without the live renderer")
     endif()
@@ -943,12 +940,9 @@ if(TARGET prosper_core)
       add_executable(test_game_compute tests/test_game_compute.cpp)
       target_link_libraries(test_game_compute PRIVATE prosper_live_renderer)
       add_test(NAME game_compute_exec COMMAND test_game_compute)
-      add_test(NAME game_compute_exec_cold_storage_snapshot COMMAND test_game_compute)
-      set_tests_properties(game_compute_exec_cold_storage_snapshot PROPERTIES
-        ENVIRONMENT "PROSPER_COLD_STORAGE_SNAPSHOT_MIN_MB=0")
       add_test(NAME game_compute_exec_no_adaptive_storage_result COMMAND test_game_compute)
       set_tests_properties(game_compute_exec_no_adaptive_storage_result PROPERTIES
-        ENVIRONMENT "PROSPER_NO_ADAPTIVE_STORAGE_RESULT_VALIDATION=1;PROSPER_COLD_STORAGE_SNAPSHOT_MIN_MB=0")
+        ENVIRONMENT "PROSPER_NO_ADAPTIVE_STORAGE_RESULT_VALIDATION=1")
 
       # Prove our own SPIR-V emitter produces valid, correct, runnable SPIR-V (execution-differential).
       add_executable(test_spirv_builder tests/test_spirv_builder.cpp)

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -805,9 +805,12 @@ if(TARGET prosper_core)
       add_executable(test_game_compute tests/test_game_compute.cpp)
       target_link_libraries(test_game_compute PRIVATE prosper_live_renderer)
       add_test(NAME game_compute_exec COMMAND test_game_compute)
+      add_test(NAME game_compute_exec_cold_storage_snapshot COMMAND test_game_compute)
+      set_tests_properties(game_compute_exec_cold_storage_snapshot PROPERTIES
+        ENVIRONMENT "PROSPER_COLD_STORAGE_SNAPSHOT_MIN_MB=0")
       add_test(NAME game_compute_exec_no_adaptive_storage_result COMMAND test_game_compute)
       set_tests_properties(game_compute_exec_no_adaptive_storage_result PROPERTIES
-        ENVIRONMENT "PROSPER_NO_ADAPTIVE_STORAGE_RESULT_VALIDATION=1")
+        ENVIRONMENT "PROSPER_NO_ADAPTIVE_STORAGE_RESULT_VALIDATION=1;PROSPER_COLD_STORAGE_SNAPSHOT_MIN_MB=0")
     else()
       message(STATUS "Vulkan not found — Windows boot_trace built without the live renderer")
     endif()
@@ -940,9 +943,12 @@ if(TARGET prosper_core)
       add_executable(test_game_compute tests/test_game_compute.cpp)
       target_link_libraries(test_game_compute PRIVATE prosper_live_renderer)
       add_test(NAME game_compute_exec COMMAND test_game_compute)
+      add_test(NAME game_compute_exec_cold_storage_snapshot COMMAND test_game_compute)
+      set_tests_properties(game_compute_exec_cold_storage_snapshot PROPERTIES
+        ENVIRONMENT "PROSPER_COLD_STORAGE_SNAPSHOT_MIN_MB=0")
       add_test(NAME game_compute_exec_no_adaptive_storage_result COMMAND test_game_compute)
       set_tests_properties(game_compute_exec_no_adaptive_storage_result PROPERTIES
-        ENVIRONMENT "PROSPER_NO_ADAPTIVE_STORAGE_RESULT_VALIDATION=1")
+        ENVIRONMENT "PROSPER_NO_ADAPTIVE_STORAGE_RESULT_VALIDATION=1;PROSPER_COLD_STORAGE_SNAPSHOT_MIN_MB=0")
 
       # Prove our own SPIR-V emitter produces valid, correct, runnable SPIR-V (execution-differential).
       add_executable(test_spirv_builder tests/test_spirv_builder.cpp)

--- a/prosper/docs/FRONTEND_APP.md
+++ b/prosper/docs/FRONTEND_APP.md
@@ -355,6 +355,13 @@ same exact-first rule, with `PROSPER_COMPUTE_WRITE_WATCH_PROMOTE_HITS` and
 `PROSPER_COMPUTE_WRITE_WATCH_PROMOTE_MB`. `PROSPER_WRITE_WATCH_MAX_KB` is an emergency host-wide range
 limit (zero/unset is unbounded); a declined watch always returns to exact comparison.
 
+Proven-full write-only storage targets at least 16 MiB do not copy their first successful result into
+an immediately redundant CPU source baseline. If the same cache identity returns, ordinary exact
+validation establishes the baseline needed for later identical-result skips; partial/readable and
+replay-owned targets retain their original exact contract. Set
+`PROSPER_COLD_STORAGE_SNAPSHOT_MIN_MB` to retune the crossover. The broader
+`PROSPER_NO_ADAPTIVE_STORAGE_RESULT_VALIDATION=1` control restores immediate storage-result snapshots.
+
 Windows protection-fault watches are deliberately unsupported: the Windows
 exception dispatcher writes below the interrupted stack pointer before a vectored handler runs, which can
 corrupt the guest's valid SysV red-zone locals. Timing therefore reports those watch attempts as `unknown`

--- a/prosper/docs/FRONTEND_APP.md
+++ b/prosper/docs/FRONTEND_APP.md
@@ -356,9 +356,11 @@ same exact-first rule, with `PROSPER_COMPUTE_WRITE_WATCH_PROMOTE_HITS` and
 limit (zero/unset is unbounded); a declined watch always returns to exact comparison.
 
 Proven-full write-only storage targets at least 16 MiB do not copy their first successful result into
-an immediately redundant CPU source baseline. If the same cache identity returns, ordinary exact
-validation establishes the baseline needed for later identical-result skips; partial/readable and
-replay-owned targets retain their original exact contract. Set
+an immediately redundant CPU source baseline. The submit journal remains the initial source authority;
+if another architectural writer invalidates it, the next invocation takes ordinary writeback and
+establishes the exact baseline needed for later identical-result skips. A failed attempt to replace a
+host result fallback with a GPU baseline invalidates that obsolete fallback before returning. Partial,
+readable, and replay-owned targets retain their original exact contract. Set
 `PROSPER_COLD_STORAGE_SNAPSHOT_MIN_MB` to retune the crossover. The broader
 `PROSPER_NO_ADAPTIVE_STORAGE_RESULT_VALIDATION=1` control restores immediate storage-result snapshots.
 

--- a/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
+++ b/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
@@ -1465,11 +1465,12 @@ already captured each exact guest source before transfer, but `retain_image` cop
 again instead of adopting it.
 
 Two generic lifetime fixes remove those copies. A cold proven-full write-only guest target at least
-16 MiB defers its source snapshot until that exact cache identity actually repeats; the old seed is
-unobservable, and a later external guest write still forces ordinary exact repair before an identical
+16 MiB defers its source snapshot until a later use actually needs exact source authority; the old seed
+is unobservable, and a later external guest write still forces ordinary exact repair before an identical
 GPU result may skip writeback. An aligned exact storage result also goes directly into its retained GPU
 comparison buffer instead of first filling a host vector that the successful ownership transfer
-immediately clears. Separately, sampled-image admission now moves its already-snapshotted source into
+immediately clears. If that ownership transfer fails, any older host result fallback is invalidated so
+it cannot suppress a later changed writeback. Separately, sampled-image admission now moves its already-snapshotted source into
 the cache. Small, partial/readable, replay-owned, failed-recovery, and non-GPU-comparable paths retain
 their prior snapshots. `PROSPER_COLD_STORAGE_SNAPSHOT_MIN_MB` tunes the cold crossover, while
 `PROSPER_NO_ADAPTIVE_STORAGE_RESULT_VALIDATION=1` remains the complete storage-source control.
@@ -1490,6 +1491,12 @@ progression sanity check. Both normal and disabled adaptive production-backend v
 the failure-repair, external-mutation, direct-import, partial-write, and raw-volume contracts. Timing now
 also attributes map, result preparation, guest-watch, notification, cache, and host result-fallback
 snapshot costs, so later cache churn cannot hide inside the aggregate writeback phase again.
+
+The production-backend suite also runs a reduced cold target with the real crossover set to zero. It
+proves first admission omits the source copy, the first invalidated repeat repairs and establishes exact
+authority, an external mutation forces writeback, and the disable switch preserves immediate snapshots.
+An alternating A/B/A regression injects GPU-baseline ownership failure after B and proves an older host A
+fallback cannot leave B in guest memory when A returns.
 
 ## Next renderer step
 

--- a/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
+++ b/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
@@ -1470,9 +1470,10 @@ is unobservable, and a later external guest write still forces ordinary exact re
 GPU result may skip writeback. An aligned exact storage result also goes directly into its retained GPU
 comparison buffer instead of first filling a host vector that the successful ownership transfer
 immediately clears. If that ownership transfer fails, any older host result fallback is invalidated so
-it cannot suppress a later changed writeback. Separately, sampled-image admission now moves its already-snapshotted source into
-the cache. Small, partial/readable, replay-owned, failed-recovery, and non-GPU-comparable paths retain
-their prior snapshots. `PROSPER_COLD_STORAGE_SNAPSHOT_MIN_MB` tunes the cold crossover, while
+it cannot suppress a later changed writeback. Separately, sampled-image admission now moves its
+already-snapshotted source into the cache. Small, partial/readable, replay-owned, failed-recovery, and
+non-GPU-comparable paths retain their prior snapshots. `PROSPER_COLD_STORAGE_SNAPSHOT_MIN_MB` tunes the
+cold crossover, while
 `PROSPER_NO_ADAPTIVE_STORAGE_RESULT_VALIDATION=1` remains the complete storage-source control.
 
 Matched 160-second native-resolution runs used the same build, route, audio/input frontends, and timing
@@ -1484,6 +1485,12 @@ smaller title-screen use:
 | merged baseline | 88.01 ms | 113.17 ms | 206.61 ms | 103 |
 | cold-result copies removed | 95.19 ms | 68.98 ms | 168.42 ms | 103 |
 | sampled snapshots moved too | 91.53 ms | 12.79 ms | 110.25 ms | 115 |
+
+These measurements predate the adaptive image-cache sizing merged in #1519. That change raises the
+historical 512 MiB default to one eighth of the largest device-local heap, capped at 2 GiB, and should
+reduce how often the same Plucky identities become cold. The table therefore measures the cost of an
+observed cold dispatch, not the frequency or whole-route impact on the current combined renderer; those
+must be measured again on the rebased exact head.
 
 The final dispatch-local total is 46.6% below the merged baseline; writeback is 88.7% lower. Presented
 frame totals varied with route progression (2,430 / 2,209 / 2,544), so they are recorded only as a

--- a/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
+++ b/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
@@ -1455,10 +1455,48 @@ bounded at 5.92 ms p95 and 15.47 ms maximum, with no recurrence of the experimen
 Different submit counts reflect real route progression, so these are supporting live measurements rather
 than a standalone FPS or pixel-equality claim.
 
+## Plucky cold image-cache snapshot copies
+
+Per-image timing on the full-resolution gameplay route localized the remaining
+`0x30180d0000` writeback cost more precisely. Its 3840x2160 RGBA16F output spent only about
+8-10 ms in the required tiled guest layout, while cache admission spent a 41.61 ms median copying
+66,846,720 bytes. The two large sampled inputs had a second copy after the fence as well: setup had
+already captured each exact guest source before transfer, but `retain_image` copied that owned vector
+again instead of adopting it.
+
+Two generic lifetime fixes remove those copies. A cold proven-full write-only guest target at least
+16 MiB defers its source snapshot until that exact cache identity actually repeats; the old seed is
+unobservable, and a later external guest write still forces ordinary exact repair before an identical
+GPU result may skip writeback. An aligned exact storage result also goes directly into its retained GPU
+comparison buffer instead of first filling a host vector that the successful ownership transfer
+immediately clears. Separately, sampled-image admission now moves its already-snapshotted source into
+the cache. Small, partial/readable, replay-owned, failed-recovery, and non-GPU-comparable paths retain
+their prior snapshots. `PROSPER_COLD_STORAGE_SNAPSHOT_MIN_MB` tunes the cold crossover, while
+`PROSPER_NO_ADAPTIVE_STORAGE_RESULT_VALIDATION=1` remains the complete storage-source control.
+
+Matched 160-second native-resolution runs used the same build, route, audio/input frontends, and timing
+settings. Filtering to the gameplay form of `0x30180d0000` (`setup_ms > 50`) avoids mixing its much
+smaller title-screen use:
+
+| state | setup median | writeback median | total median | samples |
+|---|---:|---:|---:|---:|
+| merged baseline | 88.01 ms | 113.17 ms | 206.61 ms | 103 |
+| cold-result copies removed | 95.19 ms | 68.98 ms | 168.42 ms | 103 |
+| sampled snapshots moved too | 91.53 ms | 12.79 ms | 110.25 ms | 115 |
+
+The final dispatch-local total is 46.6% below the merged baseline; writeback is 88.7% lower. Presented
+frame totals varied with route progression (2,430 / 2,209 / 2,544), so they are recorded only as a
+progression sanity check. Both normal and disabled adaptive production-backend variants pass, including
+the failure-repair, external-mutation, direct-import, partial-write, and raw-volume contracts. Timing now
+also attributes map, result preparation, guest-watch, notification, cache, and host result-fallback
+snapshot costs, so later cache churn cannot hide inside the aggregate writeback phase again.
+
 ## Next renderer step
 
-Attribute the remaining compute-image source snapshots by cache entry and distinguish unavoidable readable
-storage inputs from cache churn. In parallel, capture a fresh v39 rolling temporal window around the Plucky
+The remaining gameplay form of `0x30180d0000` spends roughly 60-70 ms converting two guest-backed
+3840x2160 Float16 inputs to RGBA8 on the CPU. Measure a generic raw-FP16 upload/GPU conversion or exact
+native-sampling alternative against the known RADV regression that originally selected RGBA8; do not simply
+re-enable native FP16 globally. In parallel, capture a fresh v39 rolling temporal window around the Plucky
 title/gameplay transition. It must include the producers for the two 48x48 volumes and close with zero
 unresolved leaves, providing a native pixel oracle as well as exact compute pipeline contracts. Keep the
 exact-byte and disable-switch A/B discipline used here, and preserve screenshot/capture correctness while

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -838,6 +838,19 @@ bool native_3d_transfer_enabled() {
     return enabled;
 }
 
+size_t cold_storage_result_snapshot_defer_min_bytes() {
+    static const size_t bytes = [] {
+        const char* value = std::getenv("PROSPER_COLD_STORAGE_SNAPSHOT_MIN_MB");
+        char* end = nullptr;
+        const uint64_t parsed = value ? std::strtoull(value, &end, 10) : 16ull;
+        const uint64_t mib = value && (!end || *end) ? 16ull : parsed;
+        return static_cast<size_t>(
+            std::min<uint64_t>(mib, SIZE_MAX / (1024ull * 1024ull)) *
+            (1024ull * 1024ull));
+    }();
+    return bytes;
+}
+
 struct CachedComputePipeline {
     VkDescriptorSetLayout descriptor_layout = VK_NULL_HANDLE;
     VkShaderModule shader = VK_NULL_HANDLE;
@@ -895,6 +908,8 @@ struct VulkanComputeContext {
     uint64_t image_source_snapshot_bytes = 0;
     uint64_t storage_result_snapshot_copies = 0;
     uint64_t storage_result_snapshot_bytes = 0;
+    uint64_t image_result_snapshot_copies = 0;
+    uint64_t image_result_snapshot_bytes = 0;
     VkDescriptorSetLayout compare_descriptor_layout = VK_NULL_HANDLE;
     VkShaderModule compare_shader = VK_NULL_HANDLE;
     VkPipelineLayout compare_pipeline_layout = VK_NULL_HANDLE;
@@ -1658,6 +1673,36 @@ struct VulkanComputeContext {
     }
 
     bool retain_image(const ComputeImageCacheKey& key, VkImage image, VkDeviceMemory memory,
+                      VkDeviceSize allocation_bytes,
+                      std::vector<uint8_t>&& prepared_source_snapshot) {
+        if (!prepared_source_snapshot.empty() &&
+            prepared_source_snapshot.size() != key.guest_bytes)
+            return false;
+        if (!make_image_cache_room(allocation_bytes)) return false;
+        CachedComputeImage cached;
+        cached.image = image;
+        cached.memory = memory;
+        cached.allocation_bytes = allocation_bytes;
+        cached.last_use = ++image_cache_clock;
+        cached.pins = 1;
+        if (!key.host_data)
+            cached.validation_snapshot = prosper::gpu::guest_gpu_write_snapshot();
+        if (!prepared_source_snapshot.empty()) {
+            cached.source_snapshot = std::move(prepared_source_snapshot);
+            ++image_source_snapshot_copies;
+            image_source_snapshot_bytes += key.guest_bytes;
+            if (key.storage) {
+                ++storage_result_snapshot_copies;
+                storage_result_snapshot_bytes += key.guest_bytes;
+            }
+        }
+        auto [it, inserted] = image_cache.emplace(key, std::move(cached));
+        if (!inserted) return false;
+        image_cache_bytes += allocation_bytes;
+        return true;
+    }
+
+    bool retain_image(const ComputeImageCacheKey& key, VkImage image, VkDeviceMemory memory,
                       VkDeviceSize allocation_bytes, const uint8_t* source) {
         if (!make_image_cache_room(allocation_bytes)) return false;
         CachedComputeImage cached;
@@ -1834,8 +1879,11 @@ struct VulkanComputeContext {
         if (found == image_cache.end()) return;
         // A retained GPU baseline is updated in the dispatch command buffer. Keep the old host
         // snapshot only as the exact fallback for small/unaligned results that cannot use it.
-        if (!found->second.result_buffer)
+        if (!found->second.result_buffer) {
             found->second.result_snapshot.assign(result, result + bytes);
+            ++image_result_snapshot_copies;
+            image_result_snapshot_bytes += bytes;
+        }
     }
 
     bool prepare_compare_pipeline() {
@@ -2656,6 +2704,11 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
     double writeback_buffers_ms = 0.0;
     double writeback_images_ms = 0.0;
     double writeback_publish_ms = 0.0;
+    double image_map_ms = 0.0;
+    double image_prepare_ms = 0.0;
+    double image_watch_ms = 0.0;
+    double image_notify_ms = 0.0;
+    double image_cache_ms = 0.0;
     const std::vector<uint32_t>& spirv = item.spirv;
     const bool trace = trace_compute_item(item);
     maybe_dump_traced_compute_spirv(item, trace);
@@ -5511,10 +5564,13 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         ctx.validate_cached_image_source(image.cache_key);
                 }
             } else if (image.image && image.memory && image.allocation_bytes &&
-                       ctx.retain_image(image.cache_key, image.image, image.memory,
-                                        image.allocation_bytes,
-                                        image.cache_source_snapshot.empty()
-                                            ? nullptr : image.cache_source_snapshot.data())) {
+                       (image.cache_source_snapshot.empty()
+                            ? ctx.retain_image(image.cache_key, image.image, image.memory,
+                                               image.allocation_bytes,
+                                               static_cast<const uint8_t*>(nullptr))
+                            : ctx.retain_image(image.cache_key, image.image, image.memory,
+                                               image.allocation_bytes,
+                                               std::move(image.cache_source_snapshot)))) {
                 image.persistent = true;
                 if (trace)
                     std::fprintf(stderr,
@@ -5650,6 +5706,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         for (size_t i = 0; i < images.size() && readback_ok; i++) {
             BoundImage& bi = images[i];
             if (!bi.storage || bi.alias_of != SIZE_MAX || bi.imported) continue;
+            const auto image_writeback_start = ComputeClock::now();
+            const bool image_cache_hit = bi.persistent;
             const ShaderResource* r = bi.resource;
             const uint32_t cb = data_format_bytes(r->format);
             const uint32_t nc = r->num_components ? r->num_components : 1;
@@ -5674,6 +5732,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 continue;
             }
             void* mapped = nullptr;
+            const auto map_start = ComputeClock::now();
             if (g_fail_next_storage_readback_for_test.exchange(
                     false, std::memory_order_acq_rel)) {
                 if (trace)
@@ -5687,6 +5746,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 readback_ok = false;
                 break;
             }
+            const auto map_done = ComputeClock::now();
             const bool array_image = backend_uses_2d_array(*r);
             static const bool direct_tiled_writeback_disabled =
                 std::getenv("PROSPER_NO_DIRECT_TILED_WRITEBACK") != nullptr;
@@ -5709,6 +5769,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             const bool repeated_output = bi.cache_candidate && bi.persistent &&
                 bi.upload_skipped && bi.exact_storage_bytes() &&
                 ctx.cached_image_result_matches(bi.cache_key, native_texels, linear_bytes);
+            const auto prepare_done = ComputeClock::now();
             if (repeated_output) {
                 if (trace)
                     std::fprintf(stderr,
@@ -5727,6 +5788,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             if (!r->host_data && r->gpu_addr)
                 prosper::host::guest_write_watch_notify_host_write(
                     r->gpu_addr, bi.guest_bytes);
+            const auto watch_done = ComputeClock::now();
             // #1122 proving-frame poison scan: a texel still fully poison was NOT stored by the write.
             // Zero survivors == the shader covers every texel (safe to fast-skip its seed henceforth);
             // any survivor == partial coverage (must always seed). Cache the verdict per (code,binding)
@@ -5893,6 +5955,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             pack_ms += std::chrono::duration<double, std::milli>(pack_done - pack_start).count();
             layout_ms += std::chrono::duration<double, std::milli>(layout_done - pack_done).count();
             if (trace) bi.after_hash = fnv1a(destination, bi.guest_bytes);
+            const auto notify_start = ComputeClock::now();
             notify_guest_gpu_write(r->gpu_addr, bi.guest_bytes);
             if (!r->host_data && writer_provenance_enabled())
                 record_guest_write(GuestWriterKind::ComputeBuffer,
@@ -5925,6 +5988,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                  bi.binding, (unsigned long long)r->gpu_addr,
                                  mirror.imported_width, mirror.imported_height);
             }
+            const auto notify_done = ComputeClock::now();
+            bool retain_gpu_result_baseline = false;
             if (bi.cache_candidate) {
                 if (bi.persistent) {
                     // Guest bytes now mirror the retained image again. A changing full-overwrite
@@ -5936,7 +6001,13 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                             native_3d_transfer_enabled());
                 } else if (bi.image && bi.memory && bi.allocation_bytes &&
                            ctx.retain_image(bi.cache_key, bi.image, bi.memory,
-                                            bi.allocation_bytes, destination)) {
+                                            bi.allocation_bytes,
+                                            (adaptive_storage_result_validation_enabled() &&
+                                             cold_storage_result_snapshot_can_defer(
+                                                 r->host_data != nullptr, bi.seed_skip,
+                                                 bi.guest_bytes,
+                                                 cold_storage_result_snapshot_defer_min_bytes()))
+                                                ? nullptr : destination)) {
                     bi.persistent = true;
                     if (trace)
                         std::fprintf(stderr,
@@ -5945,16 +6016,23 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                      bi.binding, (unsigned long long)r->gpu_addr,
                                      (unsigned long long)bi.allocation_bytes);
                 }
-                if (bi.persistent)
+                // An aligned exact result is retained as the staging buffer immediately below.
+                // Copying it into a host vector first only to clear that vector after ownership
+                // transfer is pure churn (66.4 MiB for a native 4K RGBA16F target). If GPU baseline
+                // setup fails, omitting this optional optimization remains fail-safe: the next
+                // dispatch simply takes the ordinary writeback path.
+                retain_gpu_result_baseline = bi.persistent && !bi.result_baseline &&
+                    bi.exact_result_bytes && !(bi.exact_result_bytes & 15u) &&
+                    ctx.prepare_compare_pipeline();
+                if (bi.persistent && !retain_gpu_result_baseline)
                     ctx.remember_cached_image_result(
                         bi.cache_key, native_texels,
                         static_cast<size_t>(bi.exact_result_bytes));
             }
+            const auto cache_done = ComputeClock::now();
             ctx.unmap_memory(staging_memory[i]);
             const VkBuffer retained_result = staging[i];
-            if (bi.cache_candidate && bi.persistent && !bi.result_baseline &&
-                bi.exact_result_bytes && !(bi.exact_result_bytes & 15u) &&
-                ctx.prepare_compare_pipeline() &&
+            if (retain_gpu_result_baseline &&
                 ctx.retain_cached_image_result_buffer(
                     bi.cache_key, staging[i], staging_memory[i],
                     bi.staging_allocation_bytes, bi.exact_result_bytes)) {
@@ -5965,6 +6043,34 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                  "addr=0x%llx bytes=%zu\n",
                                  bi.binding, (unsigned long long)r->gpu_addr, linear_bytes);
             }
+            const auto image_writeback_done = ComputeClock::now();
+            const auto image_milliseconds = [](auto begin, auto end) {
+                return std::chrono::duration<double, std::milli>(end - begin).count();
+            };
+            image_map_ms += image_milliseconds(map_start, map_done);
+            image_prepare_ms += image_milliseconds(map_done, prepare_done);
+            image_watch_ms += image_milliseconds(prepare_done, watch_done);
+            image_notify_ms += image_milliseconds(notify_start, notify_done);
+            image_cache_ms += image_milliseconds(notify_done, cache_done);
+            if (image_timing)
+                std::fprintf(stderr,
+                             "[compute-image-writeback] code=0x%llx binding=%u addr=0x%llx "
+                             "fmt=%u comps=%u tile=%u bytes=%zu cache-hit=%u seed-skip=%u "
+                             "poison=%u map_ms=%.3f prepare_ms=%.3f watch_ms=%.3f "
+                             "pack_ms=%.3f layout_ms=%.3f notify_ms=%.3f cache_ms=%.3f "
+                             "total_ms=%.3f\n",
+                             (unsigned long long)item.code_addr, bi.binding,
+                             (unsigned long long)r->gpu_addr, (unsigned)r->format, nc,
+                             r->tile_mode, bi.guest_bytes, image_cache_hit ? 1u : 0u,
+                             bi.seed_skip ? 1u : 0u, bi.poison_verify ? 1u : 0u,
+                             image_milliseconds(map_start, map_done),
+                             image_milliseconds(map_done, prepare_done),
+                             image_milliseconds(prepare_done, watch_done),
+                             image_milliseconds(pack_start, pack_done),
+                             image_milliseconds(pack_done, layout_done),
+                             image_milliseconds(notify_start, notify_done),
+                             image_milliseconds(notify_done, cache_done),
+                             image_milliseconds(image_writeback_start, image_writeback_done));
         }
         writeback_images_ms = std::chrono::duration<double, std::milli>(
             ComputeClock::now() - writeback_images_start).count();
@@ -6049,7 +6155,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                      "pipeline_ms=%.2f dispatch_ms=%.2f "
                      "writeback_ms=%.2f writeback_prepare_ms=%.2f "
                      "writeback_buffers_ms=%.2f writeback_images_ms=%.2f "
-                     "writeback_publish_ms=%.2f pack_ms=%.2f layout_ms=%.2f "
+                     "writeback_publish_ms=%.2f map_ms=%.2f prepare_ms=%.2f watch_ms=%.2f "
+                     "pack_ms=%.2f layout_ms=%.2f notify_ms=%.2f cache_ms=%.2f "
                      "cleanup_ms=%.2f total_ms=%.2f subgroup=%u\n",
                      (unsigned long long)item.submit_no, (unsigned long long)item.code_addr,
                      ok ? 1u : 0u, milliseconds(phase_start, phase_setup),
@@ -6059,7 +6166,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                      milliseconds(phase_dispatch, phase_writeback),
                      writeback_prepare_ms, writeback_buffers_ms,
                      writeback_images_ms, writeback_publish_ms,
-                     pack_ms, layout_ms,
+                     image_map_ms, image_prepare_ms, image_watch_ms,
+                     pack_ms, layout_ms, image_notify_ms, image_cache_ms,
                      milliseconds(phase_writeback, phase_cleanup),
                      milliseconds(phase_start, phase_cleanup), item.required_subgroup_size);
     }
@@ -6141,6 +6249,15 @@ uint64_t live_compute_cpu_fill_dispatches() {
 
 uint64_t live_compute_storage_result_snapshot_bytes() {
     return g_live_compute_context ? g_live_compute_context->storage_result_snapshot_bytes : 0;
+}
+
+uint64_t live_compute_image_result_snapshot_bytes() {
+    return g_live_compute_context ? g_live_compute_context->image_result_snapshot_bytes : 0;
+}
+
+bool cold_storage_result_snapshot_can_defer(bool host_data, bool full_overwrite,
+                                            size_t guest_bytes, size_t minimum_bytes) {
+    return !host_data && full_overwrite && guest_bytes >= minimum_bytes;
 }
 
 void live_compute_fail_next_storage_readback_for_test() {
@@ -6314,12 +6431,16 @@ bool execute_live_compute_items(const std::vector<prosper::gpu::ComputeItem>& it
                          (unsigned long long)pool.discarded);
             std::fprintf(stderr,
                          "[render-timing] compute_image_source snapshots=%llu %.1f MiB "
-                         "storage_results=%llu %.1f MiB gpu_transfer_seeds=%llu\n",
+                         "storage_results=%llu %.1f MiB result_fallbacks=%llu %.1f MiB "
+                         "gpu_transfer_seeds=%llu\n",
                          (unsigned long long)context.image_source_snapshot_copies,
                          static_cast<double>(context.image_source_snapshot_bytes) /
                              (1024.0 * 1024.0),
                          (unsigned long long)context.storage_result_snapshot_copies,
                          static_cast<double>(context.storage_result_snapshot_bytes) /
+                             (1024.0 * 1024.0),
+                         (unsigned long long)context.image_result_snapshot_copies,
+                         static_cast<double>(context.image_result_snapshot_bytes) /
                              (1024.0 * 1024.0),
                          (unsigned long long)g_compute_storage_transfer_seeds.load(
                              std::memory_order_relaxed));

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -170,6 +170,8 @@ namespace {
 std::atomic<uint64_t> g_buffer_gpu_result_skips{0};
 std::atomic<uint64_t> g_compute_storage_transfer_seeds{0};
 std::atomic<bool> g_fail_next_storage_readback_for_test{false};
+std::atomic<bool> g_force_next_image_result_host_fallback_for_test{false};
+std::atomic<bool> g_fail_next_image_result_buffer_retain_for_test{false};
 
 VkFormat native_storage_vk_format(prosper::gpu::DataFormat format, uint32_t components) {
     using prosper::gpu::DataFormat;
@@ -1858,6 +1860,15 @@ struct VulkanComputeContext {
         if (found == image_cache.end()) return false;
         CachedComputeImage& cached = found->second;
         if (cached.result_buffer) return false;
+        // This staging buffer contains the current dispatch result. Once the caller chooses it as
+        // the replacement baseline, an older host fallback is no longer authoritative even when
+        // ownership fails (for example because every cache entry is pinned). Leaving that fallback
+        // behind could let a later A result match stale A after failed result B remained in guest
+        // memory, incorrectly suppressing the required A writeback.
+        std::vector<uint8_t>().swap(cached.result_snapshot);
+        if (g_fail_next_image_result_buffer_retain_for_test.exchange(
+                false, std::memory_order_acq_rel))
+            return false;
         if (!make_image_cache_room(allocation_bytes)) return false;
         cached.result_buffer = buffer;
         cached.result_memory = memory;
@@ -1867,8 +1878,6 @@ struct VulkanComputeContext {
         image_cache_bytes += allocation_bytes;
         buffer = VK_NULL_HANDLE;
         memory = VK_NULL_HANDLE;
-        cached.result_snapshot.clear();
-        cached.result_snapshot.shrink_to_fit();
         return true;
     }
 
@@ -6018,12 +6027,17 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 }
                 // An aligned exact result is retained as the staging buffer immediately below.
                 // Copying it into a host vector first only to clear that vector after ownership
-                // transfer is pure churn (66.4 MiB for a native 4K RGBA16F target). If GPU baseline
-                // setup fails, omitting this optional optimization remains fail-safe: the next
-                // dispatch simply takes the ordinary writeback path.
+                // transfer is pure churn (66.4 MiB for a native 4K RGBA16F target). Unavailable GPU
+                // setup keeps the exact current host fallback; a failed ownership attempt invalidates
+                // any older fallback so the next dispatch takes the ordinary writeback path.
+                const bool force_host_result_fallback =
+                    bi.persistent && !bi.result_baseline && bi.exact_result_bytes &&
+                    !(bi.exact_result_bytes & 15u) &&
+                    g_force_next_image_result_host_fallback_for_test.exchange(
+                        false, std::memory_order_acq_rel);
                 retain_gpu_result_baseline = bi.persistent && !bi.result_baseline &&
                     bi.exact_result_bytes && !(bi.exact_result_bytes & 15u) &&
-                    ctx.prepare_compare_pipeline();
+                    !force_host_result_fallback && ctx.prepare_compare_pipeline();
                 if (bi.persistent && !retain_gpu_result_baseline)
                     ctx.remember_cached_image_result(
                         bi.cache_key, native_texels,
@@ -6262,6 +6276,14 @@ bool cold_storage_result_snapshot_can_defer(bool host_data, bool full_overwrite,
 
 void live_compute_fail_next_storage_readback_for_test() {
     g_fail_next_storage_readback_for_test.store(true, std::memory_order_release);
+}
+
+void live_compute_force_next_image_result_host_fallback_for_test() {
+    g_force_next_image_result_host_fallback_for_test.store(true, std::memory_order_release);
+}
+
+void live_compute_fail_next_image_result_buffer_retain_for_test() {
+    g_fail_next_image_result_buffer_retain_for_test.store(true, std::memory_order_release);
 }
 
 void storage_pack_unorm8_range(const uint32_t* channels, uint32_t components,

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -170,6 +170,7 @@ namespace {
 std::atomic<uint64_t> g_buffer_gpu_result_skips{0};
 std::atomic<uint64_t> g_compute_storage_transfer_seeds{0};
 std::atomic<bool> g_fail_next_storage_readback_for_test{false};
+std::atomic<bool> g_zero_next_cold_storage_snapshot_minimum_for_test{false};
 std::atomic<bool> g_force_next_image_result_host_fallback_for_test{false};
 std::atomic<bool> g_fail_next_image_result_buffer_retain_for_test{false};
 
@@ -841,6 +842,9 @@ bool native_3d_transfer_enabled() {
 }
 
 size_t cold_storage_result_snapshot_defer_min_bytes() {
+    if (g_zero_next_cold_storage_snapshot_minimum_for_test.exchange(
+            false, std::memory_order_acq_rel))
+        return 0;
     static const size_t bytes = [] {
         const char* value = std::getenv("PROSPER_COLD_STORAGE_SNAPSHOT_MIN_MB");
         char* end = nullptr;
@@ -6276,6 +6280,11 @@ bool cold_storage_result_snapshot_can_defer(bool host_data, bool full_overwrite,
 
 void live_compute_fail_next_storage_readback_for_test() {
     g_fail_next_storage_readback_for_test.store(true, std::memory_order_release);
+}
+
+void live_compute_zero_next_cold_storage_snapshot_minimum_for_test() {
+    g_zero_next_cold_storage_snapshot_minimum_for_test.store(
+        true, std::memory_order_release);
 }
 
 void live_compute_force_next_image_result_host_fallback_for_test() {

--- a/prosper/frontends/shared/live_compute.hpp
+++ b/prosper/frontends/shared/live_compute.hpp
@@ -140,6 +140,10 @@ bool cold_storage_result_snapshot_can_defer(bool host_data, bool full_overwrite,
 // readback fails after dispatch, exercising retained-image invalidation without a Vulkan fault.
 void live_compute_fail_next_storage_readback_for_test();
 
+// Deterministically lower the next eligible cold storage admission crossover to zero. This lets a
+// compact production-backend fixture execute the real deferral predicate and retention branch.
+void live_compute_zero_next_cold_storage_snapshot_minimum_for_test();
+
 // Deterministic setup/ownership failure injection for the storage-result fallback regression. The
 // pair models a transient compare-pipeline failure followed by a cache-capacity failure without
 // relying on driver behavior.

--- a/prosper/frontends/shared/live_compute.hpp
+++ b/prosper/frontends/shared/live_compute.hpp
@@ -128,6 +128,13 @@ uint64_t live_compute_cpu_fill_dispatches();
 // Monotonic attribution for storage-result source validation. Production-backend tests use this to
 // prove that changing proven-full results do not copy a redundant guest-byte snapshot.
 uint64_t live_compute_storage_result_snapshot_bytes();
+// Monotonic attribution for the collision-free host fallback used when a retained storage result
+// cannot keep an exact GPU comparison buffer. Eligible GPU baselines must not be copied here first.
+uint64_t live_compute_image_result_snapshot_bytes();
+// A cold, proven-full guest target has no observable old seed. Large targets may defer their exact
+// source baseline until an address actually repeats; replay-owned and partial targets may not.
+bool cold_storage_result_snapshot_can_defer(bool host_data, bool full_overwrite,
+                                            size_t guest_bytes, size_t minimum_bytes);
 
 // Deterministic failure injection for the storage-image recovery regression test. The next storage
 // readback fails after dispatch, exercising retained-image invalidation without a Vulkan fault.

--- a/prosper/frontends/shared/live_compute.hpp
+++ b/prosper/frontends/shared/live_compute.hpp
@@ -140,6 +140,12 @@ bool cold_storage_result_snapshot_can_defer(bool host_data, bool full_overwrite,
 // readback fails after dispatch, exercising retained-image invalidation without a Vulkan fault.
 void live_compute_fail_next_storage_readback_for_test();
 
+// Deterministic setup/ownership failure injection for the storage-result fallback regression. The
+// pair models a transient compare-pipeline failure followed by a cache-capacity failure without
+// relying on driver behavior.
+void live_compute_force_next_image_result_host_fallback_for_test();
+void live_compute_fail_next_image_result_buffer_retain_for_test();
+
 // Register the synchronous Vulkan compute backend used by AGC submit processing.
 void register_live_compute();
 

--- a/prosper/tests/test_game_compute.cpp
+++ b/prosper/tests/test_game_compute.cpp
@@ -35,11 +35,8 @@ int main() {
 #endif
     const bool adaptive_storage_result_validation_enabled =
         std::getenv("PROSPER_NO_ADAPTIVE_STORAGE_RESULT_VALIDATION") == nullptr;
-    const char* cold_storage_snapshot_min_mb =
-        std::getenv("PROSPER_COLD_STORAGE_SNAPSHOT_MIN_MB");
     const bool cold_storage_snapshot_deferral_enabled =
-        adaptive_storage_result_validation_enabled && cold_storage_snapshot_min_mb &&
-        std::strcmp(cold_storage_snapshot_min_mb, "0") == 0;
+        adaptive_storage_result_validation_enabled;
     using prosper::frontend::ComputeImageCacheClass;
     CHECK(prosper::frontend::compute_image_cache_default_minimum_bytes(
               ComputeImageCacheClass::sampled) == 1024ull * 1024ull &&
@@ -2552,6 +2549,7 @@ int main() {
                 prosper::frontend::live_compute_storage_result_snapshot_bytes();
             const uint64_t cold_result_snapshots_before =
                 prosper::frontend::live_compute_image_result_snapshot_bytes();
+            prosper::frontend::live_compute_zero_next_cold_storage_snapshot_minimum_for_test();
             CHECK(prosper::frontend::execute_live_compute_items({cold_item}),
                   "proven-full writer executes on a cold retained target");
             const uint64_t cold_source_snapshots_after =

--- a/prosper/tests/test_game_compute.cpp
+++ b/prosper/tests/test_game_compute.cpp
@@ -35,6 +35,11 @@ int main() {
 #endif
     const bool adaptive_storage_result_validation_enabled =
         std::getenv("PROSPER_NO_ADAPTIVE_STORAGE_RESULT_VALIDATION") == nullptr;
+    const char* cold_storage_snapshot_min_mb =
+        std::getenv("PROSPER_COLD_STORAGE_SNAPSHOT_MIN_MB");
+    const bool cold_storage_snapshot_deferral_enabled =
+        adaptive_storage_result_validation_enabled && cold_storage_snapshot_min_mb &&
+        std::strcmp(cold_storage_snapshot_min_mb, "0") == 0;
     using prosper::frontend::ComputeImageCacheClass;
     CHECK(prosper::frontend::compute_image_cache_default_minimum_bytes(
               ComputeImageCacheClass::sampled) == 1024ull * 1024ull &&
@@ -2530,12 +2535,13 @@ int main() {
                           "disabled adaptive policy preserves exact dynamic snapshots");
                 }
             }
+#endif
 
             // The first dispatch to a new target is the cache-churn shape seen in full-resolution
             // post-processing: the shader/extent already has a Full proof, but this address has no
-            // retained image yet. This reduced target deliberately stays below the cold-source
-            // deferral crossover, while its aligned exact GPU result must still avoid a transient
-            // host vector before becoming the comparison baseline.
+            // retained image yet. A dedicated invocation lowers the production crossover to zero so
+            // this reduced target exercises the real deferring branch without a 64 MiB allocation;
+            // the ordinary and disable-switch invocations retain the previous immediate baseline.
             std::vector<uint8_t> cold_guest(W * 8, 0x6b);
             ShaderResourceTable cold_rt = fill_rt;
             cold_rt.resources.back().gpu_addr =
@@ -2552,9 +2558,34 @@ int main() {
                 prosper::frontend::live_compute_storage_result_snapshot_bytes();
             const uint64_t cold_result_snapshots_after =
                 prosper::frontend::live_compute_image_result_snapshot_bytes();
-            CHECK(cold_source_snapshots_after >=
-                      cold_source_snapshots_before + fill_guest_bytes,
-                  "small cold target retains its immediately useful source snapshot");
+            if (cold_storage_snapshot_deferral_enabled) {
+                CHECK(cold_source_snapshots_after == cold_source_snapshots_before,
+                      "deferring policy admits a cold proven-full target without a source copy");
+
+                // A later standalone backend invocation has no same-submit journal authority. The
+                // first repeat therefore cannot trust the deferred source: it must take ordinary
+                // writeback and establish the exact baseline used by later source validation.
+                const std::vector<uint8_t> cold_expected = cold_guest;
+                const uint64_t repeat_snapshots_before =
+                    prosper::frontend::live_compute_storage_result_snapshot_bytes();
+                CHECK(prosper::frontend::execute_live_compute_items({cold_item}),
+                      "first invalidated repeat repairs a deferred cold target");
+                CHECK(cold_guest == cold_expected &&
+                          prosper::frontend::live_compute_storage_result_snapshot_bytes() >=
+                              repeat_snapshots_before + fill_guest_bytes,
+                      "first invalidated repeat establishes exact source authority");
+
+                cold_guest[0] ^= 0xff;
+                CHECK(cold_guest != cold_expected,
+                      "external mutation changes the deferred target fixture");
+                CHECK(prosper::frontend::execute_live_compute_items({cold_item}) &&
+                          cold_guest == cold_expected,
+                      "external mutation forces deferred target writeback and exact repair");
+            } else {
+                CHECK(cold_source_snapshots_after >=
+                          cold_source_snapshots_before + fill_guest_bytes,
+                      "default or disabled policy retains the cold source immediately");
+            }
             CHECK(cold_result_snapshots_after == cold_result_snapshots_before,
                   "cold exact target retains its GPU baseline without a transient host copy");
             CHECK(prosper::frontend::cold_storage_result_snapshot_can_defer(
@@ -2566,7 +2597,71 @@ int main() {
                       !prosper::frontend::cold_storage_result_snapshot_can_defer(
                           false, true, 8u << 20, 16u << 20),
                   "cold snapshot deferral is limited to large proven-full guest targets");
-#endif
+
+            // Model the exact stale-fallback sequence from the review: transient setup stores host
+            // result A, result B reaches guest memory but GPU-baseline ownership fails, then A runs
+            // again. The failed B ownership attempt must invalidate host A; otherwise the final A
+            // can be misclassified as repeated and leave B in architectural guest memory.
+            if (!changed_spirv.empty()) {
+                std::vector<uint8_t> fallback_guest(W * 8, 0x42);
+                ShaderResourceTable fallback_rt = fill_rt;
+                fallback_rt.resources.back().gpu_addr =
+                    reinterpret_cast<uint64_t>(fallback_guest.data());
+                ComputeItem fallback_a = it;
+                fallback_a.resources = std::make_shared<ShaderResourceTable>(fallback_rt);
+                ComputeItem fallback_b = fallback_a;
+                fallback_b.spirv = changed_spirv;
+                fallback_b.code_addr = 0x1122f12du;
+                fallback_b.dispatch_index = 51;
+                fallback_b.command_order = 10;
+                fallback_a.dispatch_index = 52;
+                fallback_a.command_order = 20;
+
+                const uint64_t fallback_snapshots_before =
+                    prosper::frontend::live_compute_image_result_snapshot_bytes();
+                prosper::frontend::live_compute_force_next_image_result_host_fallback_for_test();
+                CHECK(prosper::frontend::execute_live_compute_items({fallback_a}),
+                      "transient baseline setup fallback publishes result A");
+                const uint64_t fallback_snapshots_after_a =
+                    prosper::frontend::live_compute_image_result_snapshot_bytes();
+                CHECK(std::equal(fallback_guest.begin(), fallback_guest.end(),
+                                 after_prove.begin()) &&
+                          fallback_snapshots_after_a >=
+                              fallback_snapshots_before + fill_guest_bytes,
+                      "transient setup fallback retains exact host result A");
+
+                prosper::frontend::live_compute_fail_next_image_result_buffer_retain_for_test();
+                size_t fallback_dispatches = 0;
+                bool fallback_dispatches_ok = true;
+                bool failed_retain_published_b = false;
+                const OrderedSubmitResult fallback_submit = execute_ordered_items(
+                    {{SubmitOperationKind::Dispatch, fallback_b.dispatch_index,
+                      fallback_b.command_order},
+                     {SubmitOperationKind::Dispatch, fallback_a.dispatch_index,
+                      fallback_a.command_order}},
+                    {}, {fallback_b, fallback_a},
+                    [](const std::vector<DrawItem>&, uint32_t, uint32_t) {
+                        return RenderedFrame{};
+                    },
+                    [&](const std::vector<ComputeItem>& items) {
+                        const bool ok = prosper::frontend::execute_live_compute_items(items);
+                        fallback_dispatches_ok &= ok;
+                        if (fallback_dispatches++ == 0)
+                            failed_retain_published_b = std::equal(
+                                fallback_guest.begin(), fallback_guest.end(),
+                                changed_proof_guest.begin()) &&
+                                prosper::frontend::live_compute_image_result_snapshot_bytes() ==
+                                    fallback_snapshots_after_a;
+                        return ok;
+                    },
+                    1, 1);
+                CHECK(fallback_submit.compute_executed && fallback_dispatches_ok &&
+                          fallback_dispatches == 2 && failed_retain_published_b,
+                      "result B survives injected GPU-baseline ownership failure");
+                CHECK(std::equal(fallback_guest.begin(), fallback_guest.end(),
+                                 after_prove.begin()),
+                      "stale host result A cannot suppress required A-after-B writeback");
+            }
         }
 #if defined(__linux__)
         prosper::host::guest_write_watch_notify_direct_mapping_removed(

--- a/prosper/tests/test_game_compute.cpp
+++ b/prosper/tests/test_game_compute.cpp
@@ -2530,6 +2530,42 @@ int main() {
                           "disabled adaptive policy preserves exact dynamic snapshots");
                 }
             }
+
+            // The first dispatch to a new target is the cache-churn shape seen in full-resolution
+            // post-processing: the shader/extent already has a Full proof, but this address has no
+            // retained image yet. This reduced target deliberately stays below the cold-source
+            // deferral crossover, while its aligned exact GPU result must still avoid a transient
+            // host vector before becoming the comparison baseline.
+            std::vector<uint8_t> cold_guest(W * 8, 0x6b);
+            ShaderResourceTable cold_rt = fill_rt;
+            cold_rt.resources.back().gpu_addr =
+                reinterpret_cast<uint64_t>(cold_guest.data());
+            ComputeItem cold_item = it;
+            cold_item.resources = std::make_shared<ShaderResourceTable>(cold_rt);
+            const uint64_t cold_source_snapshots_before =
+                prosper::frontend::live_compute_storage_result_snapshot_bytes();
+            const uint64_t cold_result_snapshots_before =
+                prosper::frontend::live_compute_image_result_snapshot_bytes();
+            CHECK(prosper::frontend::execute_live_compute_items({cold_item}),
+                  "proven-full writer executes on a cold retained target");
+            const uint64_t cold_source_snapshots_after =
+                prosper::frontend::live_compute_storage_result_snapshot_bytes();
+            const uint64_t cold_result_snapshots_after =
+                prosper::frontend::live_compute_image_result_snapshot_bytes();
+            CHECK(cold_source_snapshots_after >=
+                      cold_source_snapshots_before + fill_guest_bytes,
+                  "small cold target retains its immediately useful source snapshot");
+            CHECK(cold_result_snapshots_after == cold_result_snapshots_before,
+                  "cold exact target retains its GPU baseline without a transient host copy");
+            CHECK(prosper::frontend::cold_storage_result_snapshot_can_defer(
+                      false, true, 64u << 20, 16u << 20) &&
+                      !prosper::frontend::cold_storage_result_snapshot_can_defer(
+                          true, true, 64u << 20, 16u << 20) &&
+                      !prosper::frontend::cold_storage_result_snapshot_can_defer(
+                          false, false, 64u << 20, 16u << 20) &&
+                      !prosper::frontend::cold_storage_result_snapshot_can_defer(
+                          false, true, 8u << 20, 16u << 20),
+                  "cold snapshot deferral is limited to large proven-full guest targets");
 #endif
         }
 #if defined(__linux__)


### PR DESCRIPTION
## Summary

- move already-materialized sampled-image source snapshots into the persistent compute cache instead of copying the complete vectors again after the GPU fence
- defer the first source snapshot for cold, proven-full write-only guest storage targets at or above a generic 16 MiB crossover
- retain eligible exact storage results directly as GPU comparison buffers instead of first creating a transient host result copy
- invalidate an older host result fallback before a selected GPU-baseline ownership attempt can fail
- extend compute-image timing so map, result preparation, write-watch, notification, cache, and host-result fallback costs are visible independently
- document the policy, recovery controls, measured Plucky Squire cold-dispatch result, and interaction with the newer adaptive image-cache sizing

## Root cause

The full-resolution gameplay form of compute program `0x30180d0000` was not predominantly slow in its shader or tiler. Per-image attribution showed two redundant ownership copies hidden inside aggregate writeback:

1. a cold 66,846,720-byte proven-full storage result was copied into a CPU source snapshot even though its old seed is unobservable, then copied again into a temporary host result baseline immediately before the exact staging buffer became the retained GPU baseline;
2. each large sampled input had already captured its exact source before transfer, but cache admission copied that owned vector a second time after the fence.

The review also identified a correctness edge in the original direct-retention implementation: if result A already existed as a host fallback, result B reached guest memory, and B's GPU-baseline ownership failed, stale fallback A could remain authoritative. A later A dispatch with valid B source authority could then suppress required writeback. A selected ownership attempt now invalidates that obsolete host fallback before any capacity failure.

## Correctness contract

This is resource-policy based, not title or shader-address based.

- only guest-backed, write-only targets with an existing full-coverage proof and at least 16 MiB may defer the cold source snapshot;
- small, partial/readable, replay-owned, failure-recovery, and non-GPU-comparable paths keep their previous exact snapshots;
- when exact source authority is unavailable, the next invocation takes ordinary writeback and establishes the baseline needed for later identical-result skips;
- external guest mutation still forces exact repair;
- failed GPU result-baseline ownership cannot leave an older host result authoritative;
- `PROSPER_NO_ADAPTIVE_STORAGE_RESULT_VALIDATION=1` restores the complete prior storage-source policy;
- `PROSPER_COLD_STORAGE_SNAPSHOT_MIN_MB` retunes the cold crossover.

The production regression lowers the next cold admission crossover only for one compact target, exercising the real predicate and retention branch without changing unrelated fixtures. It proves first admission omits the source snapshot, the first invalidated repeat repairs and establishes authority, external mutation forces writeback, and the disable switch retains the previous policy. A second A/B/A regression injects GPU-baseline ownership failure after B and proves stale host A cannot leave B in guest memory.

## Measured cold-dispatch impact

Matched 160-second native-resolution Plucky routes on the pre-#1519 512 MiB image-cache default used the same scripted audio/input path and timing settings. Samples select the gameplay form of `0x30180d0000` with `setup_ms > 50`.

| state | setup median | writeback median | total median | samples |
|---|---:|---:|---:|---:|
| merged baseline | 88.01 ms | 113.17 ms | 206.61 ms | 103 |
| cold-result copies removed | 95.19 ms | 68.98 ms | 168.42 ms | 103 |
| sampled snapshots moved too | 91.53 ms | 12.79 ms | 110.25 ms | 115 |

For an observed cold dispatch, total fell 46.6% and writeback fell 88.7%. Master now scales the image cache from the historical 512 MiB floor to one eighth of the largest device-local heap, capped at 2 GiB. That should reduce cold frequency, so these numbers are not presented as current whole-route impact; the rebased combination is being profiled separately.

## Validation

- exact published head `77c61a399668b0c4147ab00a359894ae22c63dba`
- rebased onto remote `master` `a4ab60ff695c6c06727edbfa0804a04cb6c4c032`
- `cmake --build build-linux -j2`
- `ctest --test-dir build-linux --output-on-failure -j2`: 159/159 passed
- focused production compute regression in normal adaptive mode
- focused production compute regression with `PROSPER_NO_ADAPTIVE_STORAGE_RESULT_VALIDATION=1`
- prior matched full-resolution Plucky profiling routes plus a 3840x2160 scheduled capture

Refs #1390