### PR TITLE
chore: remove the developer machine's absolute paths from the repository

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,7 +247,7 @@ Messenger depth, vertex-fetch, geometry, palette, or tiling hypotheses without c
   ```bash
   git worktree add .claude/worktrees/<your-slug> -b <your-branch>   # isolated tree + branch
   # build in a worktree-local build dir; pass -DGAME_DUMP=... (dump lives outside the worktree)
-  cmake -S prosper -B prosper/build-linux -DGAME_DUMP=<REPO_ROOT>/PPSA24651-app0
+  cmake -S prosper -B prosper/build-linux -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0
   ```
   Never `cd` back to the main repo root to run git or builds. If you MUST touch the main checkout,
   assume another agent is actively working there — check `git status` first and don't reset/stash/
@@ -261,7 +261,7 @@ Messenger depth, vertex-fetch, geometry, palette, or tiling hypotheses without c
   only for cmake/build/run**. Don't mix the two on one repo (it also avoids CRLF/filemode index churn).
 - **Build/run in WSL Ubuntu-24.04 as root.** Build dir `prosper/build-linux` (Linux, primary),
   `prosper/build-windows` (Windows/MinGW, secondary). Game dump at
-  `<REPO_ROOT>/PPSA24651-app0` (gitignored — **never commit it**).
+  `<DUMP_ROOT>/PPSA24651-app0` (gitignored — **never commit it**).
   ```bash
   cd <REPO_ROOT>/prosper/build-linux
   cmake --build . -j8 && ctest        # 99/99 expected green on Linux

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,7 +247,7 @@ Messenger depth, vertex-fetch, geometry, palette, or tiling hypotheses without c
   ```bash
   git worktree add .claude/worktrees/<your-slug> -b <your-branch>   # isolated tree + branch
   # build in a worktree-local build dir; pass -DGAME_DUMP=... (dump lives outside the worktree)
-  cmake -S prosper -B prosper/build-linux -DGAME_DUMP=/mnt/c/Users/matti/repos/ps5ys/PPSA24651-app0
+  cmake -S prosper -B prosper/build-linux -DGAME_DUMP=<REPO_ROOT>/PPSA24651-app0
   ```
   Never `cd` back to the main repo root to run git or builds. If you MUST touch the main checkout,
   assume another agent is actively working there — check `git status` first and don't reset/stash/
@@ -261,9 +261,9 @@ Messenger depth, vertex-fetch, geometry, palette, or tiling hypotheses without c
   only for cmake/build/run**. Don't mix the two on one repo (it also avoids CRLF/filemode index churn).
 - **Build/run in WSL Ubuntu-24.04 as root.** Build dir `prosper/build-linux` (Linux, primary),
   `prosper/build-windows` (Windows/MinGW, secondary). Game dump at
-  `/mnt/c/Users/matti/repos/ps5ys/PPSA24651-app0` (gitignored — **never commit it**).
+  `<REPO_ROOT>/PPSA24651-app0` (gitignored — **never commit it**).
   ```bash
-  cd /mnt/c/Users/matti/repos/ps5ys/prosper/build-linux
+  cd <REPO_ROOT>/prosper/build-linux
   cmake --build . -j8 && ctest        # 99/99 expected green on Linux
   ```
 - **Write run artifacts and build temporaries to the real disk, never `/tmp`.** On the Linux box `/tmp`

--- a/prosper/docs/ASTROBOT_LINUX_HANDOFF_2026_07_19.md
+++ b/prosper/docs/ASTROBOT_LINUX_HANDOFF_2026_07_19.md
@@ -273,12 +273,12 @@ Interpreted as floats:
 The local-only artifacts on the originating Windows machine are:
 
 ```text
-C:\Users\matti\Downloads\AstroBot-Linux-handoff-tail-probe.bin
-C:\Users\matti\Downloads\AstroBot-Linux-handoff-tail-probe.log
-C:\Users\matti\Downloads\AstroBot-shaders-current\exec_ps_5002af200.bin
-C:\Users\matti\Downloads\AstroBot-Linux-1030-title-diag.log
-C:\Users\matti\Downloads\AstroBot-Linux-1030-title-diag\
-C:\Users\matti\Downloads\AstroBot-linux-60-20260719-183308\
+%USERPROFILE%\Downloads\AstroBot-Linux-handoff-tail-probe.bin
+%USERPROFILE%\Downloads\AstroBot-Linux-handoff-tail-probe.log
+%USERPROFILE%\Downloads\AstroBot-shaders-current\exec_ps_5002af200.bin
+%USERPROFILE%\Downloads\AstroBot-Linux-1030-title-diag.log
+%USERPROFILE%\Downloads\AstroBot-Linux-1030-title-diag\
+%USERPROFILE%\Downloads\AstroBot-linux-60-20260719-183308\
 ```
 
 These contain title-derived data and remain gitignored/local-only. Do not commit them. Transfer the

--- a/prosper/docs/DEAD_CELLS_STATUS.md
+++ b/prosper/docs/DEAD_CELLS_STATUS.md
@@ -114,7 +114,7 @@ Build in WSL from the repository root. Adjust the dump path if needed:
 ```bash
 cd prosper
 cmake -S . -B build-linux \
-  -DGAME_DUMP=<REPO_ROOT>/PPSA15552-app0
+  -DGAME_DUMP=<DUMP_ROOT>/PPSA15552-app0
 cmake --build build-linux -j8 --target boot_trace gpu_timeline gpu_replay
 ```
 
@@ -143,7 +143,7 @@ PROSPER_GPU_TIMELINE_CAPTURE_MIN_DISPATCHES=8 \
 PROSPER_GPU_TIMELINE_CAPTURE_MAX_DISPATCHES=8 \
 PROSPER_GPU_TIMELINE_EXIT_AFTER_CAPTURE=1 \
   ./build-linux/boot_trace \
-  <REPO_ROOT>/PPSA15552-app0 \
+  <DUMP_ROOT>/PPSA15552-app0 \
   > /tmp/dead-cells-current.log 2>&1
 ```
 

--- a/prosper/docs/DEAD_CELLS_STATUS.md
+++ b/prosper/docs/DEAD_CELLS_STATUS.md
@@ -114,7 +114,7 @@ Build in WSL from the repository root. Adjust the dump path if needed:
 ```bash
 cd prosper
 cmake -S . -B build-linux \
-  -DGAME_DUMP=/mnt/c/Users/matti/repos/ps5ys/PPSA15552-app0
+  -DGAME_DUMP=<REPO_ROOT>/PPSA15552-app0
 cmake --build build-linux -j8 --target boot_trace gpu_timeline gpu_replay
 ```
 
@@ -143,7 +143,7 @@ PROSPER_GPU_TIMELINE_CAPTURE_MIN_DISPATCHES=8 \
 PROSPER_GPU_TIMELINE_CAPTURE_MAX_DISPATCHES=8 \
 PROSPER_GPU_TIMELINE_EXIT_AFTER_CAPTURE=1 \
   ./build-linux/boot_trace \
-  /mnt/c/Users/matti/repos/ps5ys/PPSA15552-app0 \
+  <REPO_ROOT>/PPSA15552-app0 \
   > /tmp/dead-cells-current.log 2>&1
 ```
 

--- a/prosper/docs/NEXT_STEP_VERTEX_FETCH.md
+++ b/prosper/docs/NEXT_STEP_VERTEX_FETCH.md
@@ -44,7 +44,7 @@ Boot + render chain (Linux 45/45, Windows 20/20):
 
 ### Reproduce
 ```bash
-cd /mnt/c/Users/matti/repos/ps5ys/prosper/build-linux
+cd <REPO_ROOT>/prosper/build-linux
 cmake --build . --target boot_trace -j8
 PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct \
   PROSPER_GFXLOG=1 PROSPER_RENDER=1 PROSPER_FRAME_DIR=/tmp/frames \
@@ -160,5 +160,5 @@ This mirrors how real drivers stage a fetch shader. Needs the draw's vertex-buff
 | Repro switches | `PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_RESDUMP=1 PROSPER_SHADER_DUMP=/tmp PROSPER_FRAME_DIR=/tmp/frames` |
 
 **Environment:** build/run in WSL Ubuntu-24.04 as root; game dump at
-`/mnt/c/Users/matti/repos/ps5ys/PPSA24651-app0` (gitignored, never commit). `llvm-mc`, `spirv-val`,
+`<REPO_ROOT>/PPSA24651-app0` (gitignored, never commit). `llvm-mc`, `spirv-val`,
 `glslangValidator`, ImageMagick, Vulkan/llvmpipe are installed.

--- a/prosper/docs/NEXT_STEP_VERTEX_FETCH.md
+++ b/prosper/docs/NEXT_STEP_VERTEX_FETCH.md
@@ -160,5 +160,5 @@ This mirrors how real drivers stage a fetch shader. Needs the draw's vertex-buff
 | Repro switches | `PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_RESDUMP=1 PROSPER_SHADER_DUMP=/tmp PROSPER_FRAME_DIR=/tmp/frames` |
 
 **Environment:** build/run in WSL Ubuntu-24.04 as root; game dump at
-`<REPO_ROOT>/PPSA24651-app0` (gitignored, never commit). `llvm-mc`, `spirv-val`,
+`<DUMP_ROOT>/PPSA24651-app0` (gitignored, never commit). `llvm-mc`, `spirv-val`,
 `glslangValidator`, ImageMagick, Vulkan/llvmpipe are installed.

--- a/prosper/docs/WINDOWS_PORT_HANDOFF.md
+++ b/prosper/docs/WINDOWS_PORT_HANDOFF.md
@@ -142,7 +142,7 @@ cmake -S prosper -B prosper/build-mingw-app -G Ninja `
   -DCMAKE_BUILD_TYPE=RelWithDebInfo `
   -DCMAKE_C_COMPILER="$wlb\gcc.exe" -DCMAKE_CXX_COMPILER="$wlb\g++.exe" `
   -DPROSPER_APP=ON -DPROSPER_AUDIO_SDL3=ON -DPROSPER_PAD_SDL3=ON `
-  -DGAME_DUMP=C:/Users/matti/repos/ps5ys/PPSA24651-app0
+  -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0
 cmake --build prosper/build-mingw-app -j 8
 ```
 
@@ -152,7 +152,7 @@ Smoke-test the actual SDL window and Vulkan swapchain without a game, then run t
 prosper/build-mingw-app/prosper-app.exe --test-pattern --frames 120
 $env:PROSPER_GUEST_FS = '1'
 $env:PROSPER_GUEST_ARGS = '-force-gfx-direct'
-prosper/build-mingw-app/prosper-app.exe --dump C:/Users/matti/repos/ps5ys/PPSA24651-app0
+prosper/build-mingw-app/prosper-app.exe --dump <DUMP_ROOT>/PPSA24651-app0
 ```
 
 For unattended evidence, `screenshot.exe` uses Windows Imaging Component to write normal PNGs and
@@ -162,10 +162,10 @@ fully lit first-level milestones:
 
 ```powershell
 $stamp = Get-Date -Format 'yyyyMMdd-HHmmss'
-$env:PROSPER_PAD_SCRIPT = '@C:/Users/matti/repos/ps5ys/prosper/scripts/messenger/reach-first-level-windows.pad'
+$env:PROSPER_PAD_SCRIPT = '@<REPO_ROOT>/prosper/scripts/messenger/reach-first-level-windows.pad'
 $env:PROSPER_PAD_SCRIPT_LOG = '1'
 $env:PROSPER_SAVEDATA_DIR = "$env:TEMP/prosper-messenger-$stamp"
-prosper/build-mingw-app/screenshot.exe C:/Users/matti/repos/ps5ys/PPSA24651-app0 `
+prosper/build-mingw-app/screenshot.exe <DUMP_ROOT>/PPSA24651-app0 `
   --seconds 10 --count 36 --out "$env:USERPROFILE/Downloads/messenger-windows-$stamp" `
   --min-distinct-frames 25 --min-pixel-distinct-frames 10 --require-composited-frame
 ```
@@ -186,11 +186,11 @@ This smaller Git Bash recipe remains useful when only `boot_trace` and verbose c
 needed. It shares the same compiler and Vulkan SDK prerequisites as the full build above:
 
 ```bash
-WLB="/c/Users/matti/AppData/Local/Microsoft/WinGet/Packages/BrechtSanders.WinLibs.POSIX.UCRT_Microsoft.Winget.Source_8wekyb3d8bbwe/mingw64/bin"
+WLB="$HOME/AppData/Local/Microsoft/WinGet/Packages/BrechtSanders.WinLibs.POSIX.UCRT_Microsoft.Winget.Source_8wekyb3d8bbwe/mingw64/bin"
 export PATH="$WLB:$PATH"   # + the Ninja package bin
 cmake -S prosper -B prosper/build-mingw-vk -G Ninja -DCMAKE_BUILD_TYPE=Debug \
   -DCMAKE_C_COMPILER="$WLB/gcc.exe" -DCMAKE_CXX_COMPILER="$WLB/g++.exe" \
-  -DGAME_DUMP=/c/Users/matti/repos/ps5ys/PPSA24651-app0     # VULKAN_SDK must be in env
+  -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0     # VULKAN_SDK must be in env
 cmake --build prosper/build-mingw-vk --target boot_trace -j8
 ```
 
@@ -199,7 +199,7 @@ Run from Git Bash (guest-fs is default-on on Windows):
 ```bash
 cd prosper/build-mingw-vk
 PROSPER_GFXLOG=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 \
-  PROSPER_FRAME_DIR=/some/dir ./boot_trace.exe /c/Users/matti/repos/ps5ys/PPSA24651-app0
+  PROSPER_FRAME_DIR=/some/dir ./boot_trace.exe <DUMP_ROOT>/PPSA24651-app0
 ```
 
 Performance diagnostics: set `PROSPER_RENDER_TIMING=1` for aggregate graphics/compute stage timings, or

--- a/prosper/scripts/dead-cells/progression-matrix.ps1
+++ b/prosper/scripts/dead-cells/progression-matrix.ps1
@@ -1,6 +1,6 @@
 [CmdletBinding()]
 param(
-    [string]$Dump = 'C:\Users\matti\repos\ps5ys\PPSA15552-app0',
+    [string]$Dump,
     [string]$BuildDir,
     [string]$OutputDir,
     [ValidateSet('all', 'headless-full', 'app-full', 'headless-publish-10',
@@ -19,6 +19,9 @@ if (-not $IsWindows -and $PSVersionTable.PSEdition -eq 'Core') {
 $repoRoot = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\..\..'))
 $prosperRoot = Join-Path $repoRoot 'prosper'
 if (-not $BuildDir) { $BuildDir = Join-Path $prosperRoot 'build-mingw-app' }
+# Default the dump to the checkout root, which is where the gitignored PPSA* dirs live, rather than
+# hard-coding one machine's absolute path into a public repository.
+if (-not $Dump) { $Dump = Join-Path $repoRoot 'PPSA15552-app0' }
 $BuildDir = [IO.Path]::GetFullPath($BuildDir)
 $Dump = (Resolve-Path -LiteralPath $Dump).Path
 

--- a/prosper/tools/dbg/boot232.sh
+++ b/prosper/tools/dbg/boot232.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Issue #232: boot DOLL to the FlushAsyncLoading stall and LEAVE IT RUNNING.
 # PID -> /root/pid232.txt; log -> /root/d232u.log. Kill with: kill -9 $(cat /root/pid232.txt)
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a9e9a0302ab3fc359/prosper
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a9e9a0302ab3fc359/prosper"
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
 # kill any previous instance we started

--- a/prosper/tools/dbg/boot232.sh
+++ b/prosper/tools/dbg/boot232.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Issue #232: boot DOLL to the FlushAsyncLoading stall and LEAVE IT RUNNING.
 # PID -> /root/pid232.txt; log -> /root/d232u.log. Kill with: kill -9 $(cat /root/pid232.txt)
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a9e9a0302ab3fc359/prosper
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a9e9a0302ab3fc359/prosper
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
 # kill any previous instance we started

--- a/prosper/tools/dbg/build_nid2got.sh
+++ b/prosper/tools/dbg/build_nid2got.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-ac66b5fec5918f7aa/prosper
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-ac66b5fec5918f7aa/prosper"
 cd "$WT" || exit 1
 g++ -O1 -std=c++20 -I src tools/dbg/nid2got.cpp src/self/*.cpp -o /root/nid2got 2>&1 | head -20
 ls -la /root/nid2got

--- a/prosper/tools/dbg/build_nid2got.sh
+++ b/prosper/tools/dbg/build_nid2got.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-ac66b5fec5918f7aa/prosper
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-ac66b5fec5918f7aa/prosper
 cd "$WT" || exit 1
 g++ -O1 -std=c++20 -I src tools/dbg/nid2got.cpp src/self/*.cpp -o /root/nid2got 2>&1 | head -20
 ls -la /root/nid2got

--- a/prosper/tools/dbg/core1.sh
+++ b/prosper/tools/dbg/core1.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a36ca69a115e7c61a/prosper
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a36ca69a115e7c61a/prosper
 CORE=$(ls -t /root/cores/core.* | head -1)
 gdb "$WT/build-linux/boot_trace" "$CORE" -batch \
   -ex "set pagination off" \

--- a/prosper/tools/dbg/core1.sh
+++ b/prosper/tools/dbg/core1.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a36ca69a115e7c61a/prosper
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a36ca69a115e7c61a/prosper"
 CORE=$(ls -t /root/cores/core.* | head -1)
 gdb "$WT/build-linux/boot_trace" "$CORE" -batch \
   -ex "set pagination off" \

--- a/prosper/tools/dbg/forge_prove.sh
+++ b/prosper/tools/dbg/forge_prove.sh
@@ -2,7 +2,7 @@
 # #312 forge-guard proof: N synchronous menu-drive runs (no MB3WATCH, undistorted timing) with the
 # REL1-FORGE guard (default ON unless GUARD=0 passed). Tallies fatal/clean/oom + DOLL progression.
 # Usage: forge_prove.sh <N> <timeout_s> [GUARD]   (GUARD=0 to A/B the baseline)
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a48ff9e03b626cc45/prosper
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a48ff9e03b626cc45/prosper
 cd "$WT" || exit 1
 N=${1:-8}; TMO=${2:-150}; GUARD=${3:-1}
 SCRIPT="15:cross;20:start;25:cross;30:start;35:cross;40:cross;45:start;50:cross;60:cross;70:start;80:cross;90:cross;100:cross;110:cross;120:cross;130:cross"

--- a/prosper/tools/dbg/forge_prove.sh
+++ b/prosper/tools/dbg/forge_prove.sh
@@ -2,7 +2,7 @@
 # #312 forge-guard proof: N synchronous menu-drive runs (no MB3WATCH, undistorted timing) with the
 # REL1-FORGE guard (default ON unless GUARD=0 passed). Tallies fatal/clean/oom + DOLL progression.
 # Usage: forge_prove.sh <N> <timeout_s> [GUARD]   (GUARD=0 to A/B the baseline)
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a48ff9e03b626cc45/prosper
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a48ff9e03b626cc45/prosper"
 cd "$WT" || exit 1
 N=${1:-8}; TMO=${2:-150}; GUARD=${3:-1}
 SCRIPT="15:cross;20:start;25:cross;30:start;35:cross;40:cross;45:start;50:cross;60:cross;70:start;80:cross;90:cross;100:cross;110:cross;120:cross;130:cross"

--- a/prosper/tools/dbg/gwalk.sh
+++ b/prosper/tools/dbg/gwalk.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-aa1d2a853141bdab4/prosper
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-aa1d2a853141bdab4/prosper
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1 PROSPER_SC2LOG=1
 ./build-linux/boot_trace /root/PPSA17942-app0 > /root/gwalk.log 2>&1 &

--- a/prosper/tools/dbg/gwalk.sh
+++ b/prosper/tools/dbg/gwalk.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-aa1d2a853141bdab4/prosper
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-aa1d2a853141bdab4/prosper"
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1 PROSPER_SC2LOG=1
 ./build-linux/boot_trace /root/PPSA17942-app0 > /root/gwalk.log 2>&1 &

--- a/prosper/tools/dbg/mb3watch_run.sh
+++ b/prosper/tools/dbg/mb3watch_run.sh
@@ -3,7 +3,7 @@
 # head slot (base+0x20) the instant getspecific/setspecific hands the guest that base — before any
 # store — to catch the off-by-one corruptor in the act. Vars live in this file (safe from cmdline
 # stripping). Usage: mb3watch_run.sh <first> <count> [extra env VAR=VAL ...]
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a48ff9e03b626cc45/prosper
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a48ff9e03b626cc45/prosper"
 cd "$WT" || exit 1
 FIRST=${1:-1}; COUNT=${2:-1}; shift 2 2>/dev/null
 SCRIPT="15:cross;20:start;25:cross;30:start;35:cross;40:cross;45:start;50:cross;60:cross;70:start;80:cross;90:cross;100:cross;110:cross;120:cross;130:cross"

--- a/prosper/tools/dbg/mb3watch_run.sh
+++ b/prosper/tools/dbg/mb3watch_run.sh
@@ -3,7 +3,7 @@
 # head slot (base+0x20) the instant getspecific/setspecific hands the guest that base — before any
 # store — to catch the off-by-one corruptor in the act. Vars live in this file (safe from cmdline
 # stripping). Usage: mb3watch_run.sh <first> <count> [extra env VAR=VAL ...]
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a48ff9e03b626cc45/prosper
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a48ff9e03b626cc45/prosper
 cd "$WT" || exit 1
 FIRST=${1:-1}; COUNT=${2:-1}; shift 2 2>/dev/null
 SCRIPT="15:cross;20:start;25:cross;30:start;35:cross;40:cross;45:start;50:cross;60:cross;70:start;80:cross;90:cross;100:cross;110:cross;120:cross;130:cross"

--- a/prosper/tools/dbg/mount232.sh
+++ b/prosper/tools/dbg/mount232.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Issue #232: boot DOLL and live-catch the savedata mount-wrapper callers with gdb.
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a2d51084866d8d045/prosper
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a2d51084866d8d045/prosper
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_SVCLOG=1
 pkill -9 boot_trace; sleep 1

--- a/prosper/tools/dbg/mount232.sh
+++ b/prosper/tools/dbg/mount232.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Issue #232: boot DOLL and live-catch the savedata mount-wrapper callers with gdb.
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a2d51084866d8d045/prosper
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a2d51084866d8d045/prosper"
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_SVCLOG=1
 pkill -9 boot_trace; sleep 1

--- a/prosper/tools/dbg/msg_reg.sh
+++ b/prosper/tools/dbg/msg_reg.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a48ff9e03b626cc45/prosper
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a48ff9e03b626cc45/prosper
 cd "$WT" || exit 1
 pkill -9 boot_trace 2>/dev/null; sleep 1
 L=/root/msg_reg.log
 timeout 130 env PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 \
-  ./build-linux/boot_trace /mnt/c/Users/matti/repos/ps5ys/PPSA24651-app0 > "$L" 2>&1
+  ./build-linux/boot_trace ${PROSPER_REPO_ROOT:?set to your checkout root}/PPSA24651-app0 > "$L" 2>&1
 echo "rc=$?"
 echo "lines=$(wc -l < $L)"
 echo "vcount: $(grep -oE 'vcount=[0-9]+' $L | tail -1)"

--- a/prosper/tools/dbg/msg_reg.sh
+++ b/prosper/tools/dbg/msg_reg.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a48ff9e03b626cc45/prosper
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a48ff9e03b626cc45/prosper"
 cd "$WT" || exit 1
 pkill -9 boot_trace 2>/dev/null; sleep 1
 L=/root/msg_reg.log
 timeout 130 env PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 \
-  ./build-linux/boot_trace ${PROSPER_REPO_ROOT:?set to your checkout root}/PPSA24651-app0 > "$L" 2>&1
+  ./build-linux/boot_trace "${PROSPER_REPO_ROOT:?set to your checkout root}/PPSA24651-app0" > "$L" 2>&1
 echo "rc=$?"
 echo "lines=$(wc -l < $L)"
 echo "vcount: $(grep -oE 'vcount=[0-9]+' $L | tail -1)"

--- a/prosper/tools/dbg/poll_deep.sh
+++ b/prosper/tools/dbg/poll_deep.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Run DOLL; when flips FREEZE (the poll wall), attach and deep-walk the poll object.
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-aa1d2a853141bdab4/prosper
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-aa1d2a853141bdab4/prosper
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
 ./build-linux/boot_trace /root/PPSA17942-app0 > /root/deep.log 2>&1 &

--- a/prosper/tools/dbg/poll_deep.sh
+++ b/prosper/tools/dbg/poll_deep.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Run DOLL; when flips FREEZE (the poll wall), attach and deep-walk the poll object.
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-aa1d2a853141bdab4/prosper
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-aa1d2a853141bdab4/prosper"
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
 ./build-linux/boot_trace /root/PPSA17942-app0 > /root/deep.log 2>&1 &

--- a/prosper/tools/dbg/poll_probe.sh
+++ b/prosper/tools/dbg/poll_probe.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Run DOLL to steady state, then attach gdb and probe the #232 poll wall.
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-aa1d2a853141bdab4/prosper
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-aa1d2a853141bdab4/prosper
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
 ./build-linux/boot_trace /root/PPSA17942-app0 > /root/poll1.log 2>&1 &

--- a/prosper/tools/dbg/poll_probe.sh
+++ b/prosper/tools/dbg/poll_probe.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Run DOLL to steady state, then attach gdb and probe the #232 poll wall.
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-aa1d2a853141bdab4/prosper
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-aa1d2a853141bdab4/prosper"
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
 ./build-linux/boot_trace /root/PPSA17942-app0 > /root/poll1.log 2>&1 &

--- a/prosper/tools/dbg/poolstomp_ab.sh
+++ b/prosper/tools/dbg/poolstomp_ab.sh
@@ -2,7 +2,7 @@
 # #312 free-canary-guard A/B. Runs N baseline (guard=0) + N guard-on (guard=1) boots, timeout-bounded,
 # tallies MallocBinned3 fatals per arm. All logic in this FILE so claude's wsl.exe $VAR-stripping
 # does not apply. Usage: poolstomp_ab.sh <N> <timeout_s>
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a5d8efe035816c6c7/prosper
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a5d8efe035816c6c7/prosper
 cd "$WT" || exit 1
 N=${1:-4}; TMO=${2:-110}
 SCRIPT="15:cross;20:start;25:cross;30:start;35:cross;40:cross;45:start;50:cross;60:cross;70:start;80:cross;90:cross;100:cross;110:cross"

--- a/prosper/tools/dbg/poolstomp_ab.sh
+++ b/prosper/tools/dbg/poolstomp_ab.sh
@@ -2,7 +2,7 @@
 # #312 free-canary-guard A/B. Runs N baseline (guard=0) + N guard-on (guard=1) boots, timeout-bounded,
 # tallies MallocBinned3 fatals per arm. All logic in this FILE so claude's wsl.exe $VAR-stripping
 # does not apply. Usage: poolstomp_ab.sh <N> <timeout_s>
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a5d8efe035816c6c7/prosper
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a5d8efe035816c6c7/prosper"
 cd "$WT" || exit 1
 N=${1:-4}; TMO=${2:-110}
 SCRIPT="15:cross;20:start;25:cross;30:start;35:cross;40:cross;45:start;50:cross;60:cross;70:start;80:cross;90:cross;100:cross;110:cross"

--- a/prosper/tools/dbg/poolstomp_run.sh
+++ b/prosper/tools/dbg/poolstomp_run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # #312 poolstomp multi-run harness. Variables live in this FILE (bash reads them), so the
 # claude wsl.exe cmdline-stripping of $VAR does not apply. Usage: poolstomp_run.sh <first> <count> [extra env...]
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a5d8efe035816c6c7/prosper
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a5d8efe035816c6c7/prosper
 cd "$WT" || exit 1
 FIRST=${1:-1}; COUNT=${2:-1}; shift 2 2>/dev/null
 SCRIPT="15:cross;20:start;25:cross;30:start;35:cross;40:cross;45:start;50:cross;60:cross;70:start;80:cross;90:cross;100:cross;110:cross"

--- a/prosper/tools/dbg/poolstomp_run.sh
+++ b/prosper/tools/dbg/poolstomp_run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # #312 poolstomp multi-run harness. Variables live in this FILE (bash reads them), so the
 # claude wsl.exe cmdline-stripping of $VAR does not apply. Usage: poolstomp_run.sh <first> <count> [extra env...]
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a5d8efe035816c6c7/prosper
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a5d8efe035816c6c7/prosper"
 cd "$WT" || exit 1
 FIRST=${1:-1}; COUNT=${2:-1}; shift 2 2>/dev/null
 SCRIPT="15:cross;20:start;25:cross;30:start;35:cross;40:cross;45:start;50:cross;60:cross;70:start;80:cross;90:cross;100:cross;110:cross"

--- a/prosper/tools/dbg/poolstomp_val.sh
+++ b/prosper/tools/dbg/poolstomp_val.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # #312 free-canary guard validation: N guard-ON runs, longer timeout, check for fatal/wedge + how far
 # DOLL gets. Vars live in the file (safe from cmdline stripping). Usage: poolstomp_val.sh <N> <timeout_s>
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a5d8efe035816c6c7/prosper
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a5d8efe035816c6c7/prosper"
 cd "$WT" || exit 1
 N=${1:-4}; TMO=${2:-135}; GUARD=${3:-1}
 SCRIPT="15:cross;20:start;25:cross;30:start;35:cross;40:cross;45:start;50:cross;60:cross;70:start;80:cross;90:cross;100:cross;110:cross;120:cross;130:cross"

--- a/prosper/tools/dbg/poolstomp_val.sh
+++ b/prosper/tools/dbg/poolstomp_val.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # #312 free-canary guard validation: N guard-ON runs, longer timeout, check for fatal/wedge + how far
 # DOLL gets. Vars live in the file (safe from cmdline stripping). Usage: poolstomp_val.sh <N> <timeout_s>
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a5d8efe035816c6c7/prosper
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a5d8efe035816c6c7/prosper
 cd "$WT" || exit 1
 N=${1:-4}; TMO=${2:-135}; GUARD=${3:-1}
 SCRIPT="15:cross;20:start;25:cross;30:start;35:cross;40:cross;45:start;50:cross;60:cross;70:start;80:cross;90:cross;100:cross;110:cross;120:cross;130:cross"

--- a/prosper/tools/dbg/probe232w.sh
+++ b/prosper/tools/dbg/probe232w.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # attach probe232w to the live stalled DOLL (pid in /root/pid232.txt), keep target alive
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a9e9a0302ab3fc359/prosper
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a9e9a0302ab3fc359/prosper
 PID=$(cat /root/pid232.txt)
 kill -0 "$PID" || { echo TARGET-DEAD; exit 1; }
 timeout 240 gdb -p "$PID" -batch -x "$WT/tools/dbg/$1" 2>&1 \

--- a/prosper/tools/dbg/probe232w.sh
+++ b/prosper/tools/dbg/probe232w.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # attach probe232w to the live stalled DOLL (pid in /root/pid232.txt), keep target alive
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a9e9a0302ab3fc359/prosper
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a9e9a0302ab3fc359/prosper"
 PID=$(cat /root/pid232.txt)
 kill -0 "$PID" || { echo TARGET-DEAD; exit 1; }
 timeout 240 gdb -p "$PID" -batch -x "$WT/tools/dbg/$1" 2>&1 \

--- a/prosper/tools/dbg/run222.sh
+++ b/prosper/tools/dbg/run222.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Run DOLL under gdb catching the #222 fault.
-cd ${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-ae005ba42de93cd40/prosper
+cd "${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-ae005ba42de93cd40/prosper"
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
 gdb -batch -x tools/dbg/catch222.gdb --args ./build-linux/boot_trace /root/PPSA17942-app0 > /root/catch222.log 2>&1
 echo "gdb done, exit=$?"

--- a/prosper/tools/dbg/run222.sh
+++ b/prosper/tools/dbg/run222.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Run DOLL under gdb catching the #222 fault.
-cd /mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-ae005ba42de93cd40/prosper
+cd ${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-ae005ba42de93cd40/prosper
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
 gdb -batch -x tools/dbg/catch222.gdb --args ./build-linux/boot_trace /root/PPSA17942-app0 > /root/catch222.log 2>&1
 echo "gdb done, exit=$?"

--- a/prosper/tools/dbg/run232b.sh
+++ b/prosper/tools/dbg/run232b.sh
@@ -5,7 +5,7 @@
 # sampling) to see whether threads MOVE. Everything in ONE wsl call (WSL /tmp is wiped between calls).
 SECS=${1:-300}
 STEADY_T=${2:-180}
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-af9660f2dbcb26e7d/prosper
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-af9660f2dbcb26e7d/prosper"
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
 ./build-linux/boot_trace /root/PPSA17942-app0 > /root/d232.log 2>&1 &

--- a/prosper/tools/dbg/run232b.sh
+++ b/prosper/tools/dbg/run232b.sh
@@ -5,7 +5,7 @@
 # sampling) to see whether threads MOVE. Everything in ONE wsl call (WSL /tmp is wiped between calls).
 SECS=${1:-300}
 STEADY_T=${2:-180}
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-af9660f2dbcb26e7d/prosper
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-af9660f2dbcb26e7d/prosper
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
 ./build-linux/boot_trace /root/PPSA17942-app0 > /root/d232.log 2>&1 &

--- a/prosper/tools/dbg/run232c.sh
+++ b/prosper/tools/dbg/run232c.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Issue #232: boot DOLL to the park point (flips stop ~175), then take N spaced gdb python samples.
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-af9660f2dbcb26e7d/prosper
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-af9660f2dbcb26e7d/prosper
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
 ./build-linux/boot_trace /root/PPSA17942-app0 > /root/d232.log 2>&1 &

--- a/prosper/tools/dbg/run232c.sh
+++ b/prosper/tools/dbg/run232c.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Issue #232: boot DOLL to the park point (flips stop ~175), then take N spaced gdb python samples.
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-af9660f2dbcb26e7d/prosper
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-af9660f2dbcb26e7d/prosper"
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
 ./build-linux/boot_trace /root/PPSA17942-app0 > /root/d232.log 2>&1 &

--- a/prosper/tools/dbg/run232d.sh
+++ b/prosper/tools/dbg/run232d.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Issue #232: boot DOLL to the plateau, take a named-thread gdb sample, then run the waketrace.
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-af9660f2dbcb26e7d/prosper
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-af9660f2dbcb26e7d/prosper
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
 ./build-linux/boot_trace /root/PPSA17942-app0 > /root/d232.log 2>&1 &

--- a/prosper/tools/dbg/run232d.sh
+++ b/prosper/tools/dbg/run232d.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Issue #232: boot DOLL to the plateau, take a named-thread gdb sample, then run the waketrace.
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-af9660f2dbcb26e7d/prosper
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-af9660f2dbcb26e7d/prosper"
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
 ./build-linux/boot_trace /root/PPSA17942-app0 > /root/d232.log 2>&1 &

--- a/prosper/tools/dbg/run232e.sh
+++ b/prosper/tools/dbg/run232e.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Issue #232: boot DOLL (with STUBDUMP so import indices are mappable), reach the plateau,
 # then count unimplemented-import calls per thread for 60 s.
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-af9660f2dbcb26e7d/prosper
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-af9660f2dbcb26e7d/prosper
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1 PROSPER_STUBDUMP=1
 ./build-linux/boot_trace /root/PPSA17942-app0 > /root/d232e.log 2>&1 &

--- a/prosper/tools/dbg/run232e.sh
+++ b/prosper/tools/dbg/run232e.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Issue #232: boot DOLL (with STUBDUMP so import indices are mappable), reach the plateau,
 # then count unimplemented-import calls per thread for 60 s.
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-af9660f2dbcb26e7d/prosper
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-af9660f2dbcb26e7d/prosper"
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1 PROSPER_STUBDUMP=1
 ./build-linux/boot_trace /root/PPSA17942-app0 > /root/d232e.log 2>&1 &

--- a/prosper/tools/dbg/run232f.sh
+++ b/prosper/tools/dbg/run232f.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Issue #232: boot to plateau, then run the slot232 poll-loop probe.
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-af9660f2dbcb26e7d/prosper
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-af9660f2dbcb26e7d/prosper
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
 ./build-linux/boot_trace /root/PPSA17942-app0 > /root/d232f.log 2>&1 &

--- a/prosper/tools/dbg/run232f.sh
+++ b/prosper/tools/dbg/run232f.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Issue #232: boot to plateau, then run the slot232 poll-loop probe.
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-af9660f2dbcb26e7d/prosper
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-af9660f2dbcb26e7d/prosper"
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
 ./build-linux/boot_trace /root/PPSA17942-app0 > /root/d232f.log 2>&1 &

--- a/prosper/tools/dbg/run232g.sh
+++ b/prosper/tools/dbg/run232g.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Issue #232: attach EARLY (flips>90, before the ~174 warmup submit) and arm the w1KFAHVqpaU probe.
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-af9660f2dbcb26e7d/prosper
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-af9660f2dbcb26e7d/prosper
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
 ./build-linux/boot_trace /root/PPSA17942-app0 > /root/d232g.log 2>&1 &

--- a/prosper/tools/dbg/run232g.sh
+++ b/prosper/tools/dbg/run232g.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Issue #232: attach EARLY (flips>90, before the ~174 warmup submit) and arm the w1KFAHVqpaU probe.
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-af9660f2dbcb26e7d/prosper
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-af9660f2dbcb26e7d/prosper"
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
 ./build-linux/boot_trace /root/PPSA17942-app0 > /root/d232g.log 2>&1 &

--- a/prosper/tools/dbg/run232h.sh
+++ b/prosper/tools/dbg/run232h.sh
@@ -2,7 +2,7 @@
 # Issue #232: does the w1KFAHVqpaU submit-fold advance DOLL past the RenderThread fence wall?
 # Run 360 s, track flips/submits over time (should NOT plateau at ~178 now), and check for draws.
 SECS=${1:-360}
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-af9660f2dbcb26e7d/prosper
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-af9660f2dbcb26e7d/prosper
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
 timeout "$SECS" ./build-linux/boot_trace /root/PPSA17942-app0 > /root/d232h.log 2>&1 &

--- a/prosper/tools/dbg/run232h.sh
+++ b/prosper/tools/dbg/run232h.sh
@@ -2,7 +2,7 @@
 # Issue #232: does the w1KFAHVqpaU submit-fold advance DOLL past the RenderThread fence wall?
 # Run 360 s, track flips/submits over time (should NOT plateau at ~178 now), and check for draws.
 SECS=${1:-360}
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-af9660f2dbcb26e7d/prosper
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-af9660f2dbcb26e7d/prosper"
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
 timeout "$SECS" ./build-linux/boot_trace /root/PPSA17942-app0 > /root/d232h.log 2>&1 &

--- a/prosper/tools/dbg/run232i.sh
+++ b/prosper/tools/dbg/run232i.sh
@@ -4,7 +4,7 @@
 # focusing on GameThread / RenderThread / RHIThread guest RAs.
 SECS=${1:-420}
 STEADY_T=${2:-180}
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a36ca69a115e7c61a/prosper
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a36ca69a115e7c61a/prosper"
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
 ./build-linux/boot_trace /root/PPSA17942-app0 > /root/d232i.log 2>&1 &

--- a/prosper/tools/dbg/run232i.sh
+++ b/prosper/tools/dbg/run232i.sh
@@ -4,7 +4,7 @@
 # focusing on GameThread / RenderThread / RHIThread guest RAs.
 SECS=${1:-420}
 STEADY_T=${2:-180}
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a36ca69a115e7c61a/prosper
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a36ca69a115e7c61a/prosper
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
 ./build-linux/boot_trace /root/PPSA17942-app0 > /root/d232i.log 2>&1 &

--- a/prosper/tools/dbg/run232j.sh
+++ b/prosper/tools/dbg/run232j.sh
@@ -2,7 +2,7 @@
 # Issue #232 post-fence: robust per-thread sampler (python walker, error-safe).
 # Boots DOLL, waits STEADY_T, then runs gw232.py 3x spaced 12 s.
 STEADY_T=${1:-150}
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a36ca69a115e7c61a/prosper
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a36ca69a115e7c61a/prosper
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
 PID=

--- a/prosper/tools/dbg/run232j.sh
+++ b/prosper/tools/dbg/run232j.sh
@@ -2,7 +2,7 @@
 # Issue #232 post-fence: robust per-thread sampler (python walker, error-safe).
 # Boots DOLL, waits STEADY_T, then runs gw232.py 3x spaced 12 s.
 STEADY_T=${1:-150}
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a36ca69a115e7c61a/prosper
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a36ca69a115e7c61a/prosper"
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
 PID=

--- a/prosper/tools/dbg/run232k.sh
+++ b/prosper/tools/dbg/run232k.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Issue #232: strace the GameThread (main tid) in steady state + finer gdb probing of the tick loop.
 STEADY_T=${1:-60}
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a36ca69a115e7c61a/prosper
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a36ca69a115e7c61a/prosper
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
 PID=

--- a/prosper/tools/dbg/run232k.sh
+++ b/prosper/tools/dbg/run232k.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Issue #232: strace the GameThread (main tid) in steady state + finer gdb probing of the tick loop.
 STEADY_T=${1:-60}
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a36ca69a115e7c61a/prosper
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a36ca69a115e7c61a/prosper"
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
 PID=

--- a/prosper/tools/dbg/run232l.sh
+++ b/prosper/tools/dbg/run232l.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Issue #232/#241: stability A/B — with the exact-length w1K fold, how many of 6 boots survive 90 s?
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a36ca69a115e7c61a/prosper
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a36ca69a115e7c61a/prosper
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
 ok=0

--- a/prosper/tools/dbg/run232l.sh
+++ b/prosper/tools/dbg/run232l.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Issue #232/#241: stability A/B — with the exact-length w1K fold, how many of 6 boots survive 90 s?
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a36ca69a115e7c61a/prosper
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a36ca69a115e7c61a/prosper"
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
 ok=0

--- a/prosper/tools/dbg/run232m.sh
+++ b/prosper/tools/dbg/run232m.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Issue #232: capture the APR channel tail (AMPRLOG) at the moment async loading goes silent.
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a36ca69a115e7c61a/prosper
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a36ca69a115e7c61a/prosper"
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1 PROSPER_AMPRLOG=1
 PID=

--- a/prosper/tools/dbg/run232m.sh
+++ b/prosper/tools/dbg/run232m.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Issue #232: capture the APR channel tail (AMPRLOG) at the moment async loading goes silent.
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a36ca69a115e7c61a/prosper
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a36ca69a115e7c61a/prosper
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1 PROSPER_AMPRLOG=1
 PID=

--- a/prosper/tools/dbg/run232n.sh
+++ b/prosper/tools/dbg/run232n.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Issue #232: live dispatcher-state capture at the stall.
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a36ca69a115e7c61a/prosper
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a36ca69a115e7c61a/prosper"
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
 PID=

--- a/prosper/tools/dbg/run232n.sh
+++ b/prosper/tools/dbg/run232n.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Issue #232: live dispatcher-state capture at the stall.
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a36ca69a115e7c61a/prosper
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a36ca69a115e7c61a/prosper
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
 PID=

--- a/prosper/tools/dbg/run232o.sh
+++ b/prosper/tools/dbg/run232o.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Issue #232: two-phase live capture — find disp early, dump dispatcher state at the stall.
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a36ca69a115e7c61a/prosper
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a36ca69a115e7c61a/prosper
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
 PID=

--- a/prosper/tools/dbg/run232o.sh
+++ b/prosper/tools/dbg/run232o.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Issue #232: two-phase live capture — find disp early, dump dispatcher state at the stall.
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a36ca69a115e7c61a/prosper
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a36ca69a115e7c61a/prosper"
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
 PID=

--- a/prosper/tools/dbg/run232p.sh
+++ b/prosper/tools/dbg/run232p.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Issue #232: catch the stack-smash abort with a real core dump.
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a36ca69a115e7c61a/prosper
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a36ca69a115e7c61a/prosper
 cd "$WT" || exit 1
 echo '/root/cores/core.%p' > /proc/sys/kernel/core_pattern
 mkdir -p /root/cores; rm -f /root/cores/core.*

--- a/prosper/tools/dbg/run232p.sh
+++ b/prosper/tools/dbg/run232p.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Issue #232: catch the stack-smash abort with a real core dump.
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a36ca69a115e7c61a/prosper
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a36ca69a115e7c61a/prosper"
 cd "$WT" || exit 1
 echo '/root/cores/core.%p' > /proc/sys/kernel/core_pattern
 mkdir -p /root/cores; rm -f /root/cores/core.*

--- a/prosper/tools/dbg/run232q.sh
+++ b/prosper/tools/dbg/run232q.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Issue #232: does pumping user events (dispatcher wakes) unstick the final APR batch?
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a36ca69a115e7c61a/prosper
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a36ca69a115e7c61a/prosper"
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1 PROSPER_PUMP_USEREV=1
 PID=

--- a/prosper/tools/dbg/run232q.sh
+++ b/prosper/tools/dbg/run232q.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Issue #232: does pumping user events (dispatcher wakes) unstick the final APR batch?
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a36ca69a115e7c61a/prosper
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a36ca69a115e7c61a/prosper
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1 PROSPER_PUMP_USEREV=1
 PID=

--- a/prosper/tools/dbg/run232r.sh
+++ b/prosper/tools/dbg/run232r.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Issue #232: with ORDERED ptr-tag completions, does the load stream past the old wall into draws?
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a36ca69a115e7c61a/prosper
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a36ca69a115e7c61a/prosper"
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
 PID=

--- a/prosper/tools/dbg/run232r.sh
+++ b/prosper/tools/dbg/run232r.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Issue #232: with ORDERED ptr-tag completions, does the load stream past the old wall into draws?
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a36ca69a115e7c61a/prosper
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a36ca69a115e7c61a/prosper
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
 PID=

--- a/prosper/tools/dbg/run232s.sh
+++ b/prosper/tools/dbg/run232s.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Issue #232: boot with AMPRLOG, wait for the read stall, then locate + dump the dispatcher.
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a36ca69a115e7c61a/prosper
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a36ca69a115e7c61a/prosper
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1 PROSPER_AMPRLOG=1
 PID=

--- a/prosper/tools/dbg/run232s.sh
+++ b/prosper/tools/dbg/run232s.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Issue #232: boot with AMPRLOG, wait for the read stall, then locate + dump the dispatcher.
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a36ca69a115e7c61a/prosper
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a36ca69a115e7c61a/prosper"
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1 PROSPER_AMPRLOG=1
 PID=

--- a/prosper/tools/dbg/run232safe.sh
+++ b/prosper/tools/dbg/run232safe.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Issue #232: does sceSystemServiceGetDisplaySafeAreaInfo=1.0 produce scene draws?
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a9e9a0302ab3fc359/prosper
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a9e9a0302ab3fc359/prosper
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
 [ -f /root/pid232.txt ] && kill -9 "$(cat /root/pid232.txt)" 2>/dev/null

--- a/prosper/tools/dbg/run232safe.sh
+++ b/prosper/tools/dbg/run232safe.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Issue #232: does sceSystemServiceGetDisplaySafeAreaInfo=1.0 produce scene draws?
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a9e9a0302ab3fc359/prosper
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a9e9a0302ab3fc359/prosper"
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
 [ -f /root/pid232.txt ] && kill -9 "$(cat /root/pid232.txt)" 2>/dev/null

--- a/prosper/tools/dbg/run232svc.sh
+++ b/prosper/tools/dbg/run232svc.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Issue #232 session 5: boot DOLL, capture the unimplemented-service call log + draw evidence.
 # Usage: run232svc.sh <logname> [extra soak iterations]
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a2d51084866d8d045/prosper
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a2d51084866d8d045/prosper
 LOG=/root/${1:-d232svc}.log
 ITERS=${2:-8}
 cd "$WT" || exit 1

--- a/prosper/tools/dbg/run232svc.sh
+++ b/prosper/tools/dbg/run232svc.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Issue #232 session 5: boot DOLL, capture the unimplemented-service call log + draw evidence.
 # Usage: run232svc.sh <logname> [extra soak iterations]
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a2d51084866d8d045/prosper
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a2d51084866d8d045/prosper"
 LOG=/root/${1:-d232svc}.log
 ITERS=${2:-8}
 cd "$WT" || exit 1

--- a/prosper/tools/dbg/run232t.sh
+++ b/prosper/tools/dbg/run232t.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Issue #232: long soak — is the post-fix loader a hard wall or a crawl?
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a36ca69a115e7c61a/prosper
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a36ca69a115e7c61a/prosper
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
 PID=

--- a/prosper/tools/dbg/run232t.sh
+++ b/prosper/tools/dbg/run232t.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Issue #232: long soak — is the post-fix loader a hard wall or a crawl?
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a36ca69a115e7c61a/prosper
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a36ca69a115e7c61a/prosper"
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
 PID=

--- a/prosper/tools/dbg/run232u.sh
+++ b/prosper/tools/dbg/run232u.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Issue #232: boot to the FlushAsyncLoading stall, then probe FAsyncLoadingThread2 state.
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a9e9a0302ab3fc359/prosper
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a9e9a0302ab3fc359/prosper
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
 PID=

--- a/prosper/tools/dbg/run232u.sh
+++ b/prosper/tools/dbg/run232u.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Issue #232: boot to the FlushAsyncLoading stall, then probe FAsyncLoadingThread2 state.
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a9e9a0302ab3fc359/prosper
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a9e9a0302ab3fc359/prosper"
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
 PID=

--- a/prosper/tools/dbg/run232v.sh
+++ b/prosper/tools/dbg/run232v.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Issue #232: A/B — deny all .usm movie files; does DOLL advance past the (suspected)
 # opening-cutscene gate into real scene draws?
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a9e9a0302ab3fc359/prosper
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a9e9a0302ab3fc359/prosper"
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
 export PROSPER_DENY_SUBSTR=.usm

--- a/prosper/tools/dbg/run232v.sh
+++ b/prosper/tools/dbg/run232v.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Issue #232: A/B — deny all .usm movie files; does DOLL advance past the (suspected)
 # opening-cutscene gate into real scene draws?
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a9e9a0302ab3fc359/prosper
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a9e9a0302ab3fc359/prosper
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
 export PROSPER_DENY_SUBSTR=.usm

--- a/prosper/tools/dbg/run312.sh
+++ b/prosper/tools/dbg/run312.sh
@@ -2,7 +2,7 @@
 # #312 menu-drive repro + inline summary. Usage: run312.sh <tag> [extra env as VAR=VAL ...]
 # Log: /root/doll312x_<tag>.log
 TAG=$1; shift
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a8ffd958941d2a852/prosper
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a8ffd958941d2a852/prosper"
 LOG=/root/doll312x_${TAG}.log
 cd "$WT" || exit 1
 timeout 170 env PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_FILELOG=1 PROSPER_PROGRESS=5 \

--- a/prosper/tools/dbg/run312.sh
+++ b/prosper/tools/dbg/run312.sh
@@ -2,7 +2,7 @@
 # #312 menu-drive repro + inline summary. Usage: run312.sh <tag> [extra env as VAR=VAL ...]
 # Log: /root/doll312x_<tag>.log
 TAG=$1; shift
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a8ffd958941d2a852/prosper
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a8ffd958941d2a852/prosper
 LOG=/root/doll312x_${TAG}.log
 cd "$WT" || exit 1
 timeout 170 env PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_FILELOG=1 PROSPER_PROGRESS=5 \

--- a/prosper/tools/dbg/run_count18.sh
+++ b/prosper/tools/dbg/run_count18.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-cd ${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-ae005ba42de93cd40/prosper
+cd "${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-ae005ba42de93cd40/prosper"
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1
 gdb -batch -x tools/dbg/count18.gdb --args ./build-linux/boot_trace /root/PPSA17942-app0 > /root/count18.log 2>&1
 echo "rc=$?"

--- a/prosper/tools/dbg/run_count18.sh
+++ b/prosper/tools/dbg/run_count18.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-cd /mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-ae005ba42de93cd40/prosper
+cd ${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-ae005ba42de93cd40/prosper
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1
 gdb -batch -x tools/dbg/count18.gdb --args ./build-linux/boot_trace /root/PPSA17942-app0 > /root/count18.log 2>&1
 echo "rc=$?"

--- a/prosper/tools/dbg/run_doll.sh
+++ b/prosper/tools/dbg/run_doll.sh
@@ -2,7 +2,7 @@
 # Run DOLL for N seconds with full logging, then summarize draw evidence.
 SECS=${1:-300}
 LOG=${2:-/root/scene2.log}
-cd ${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-ae005ba42de93cd40/prosper
+cd "${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-ae005ba42de93cd40/prosper"
 PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1 \
   timeout "$SECS" ./build-linux/boot_trace /root/PPSA17942-app0 > "$LOG" 2>&1
 echo "run done rc=$?"

--- a/prosper/tools/dbg/run_doll.sh
+++ b/prosper/tools/dbg/run_doll.sh
@@ -2,7 +2,7 @@
 # Run DOLL for N seconds with full logging, then summarize draw evidence.
 SECS=${1:-300}
 LOG=${2:-/root/scene2.log}
-cd /mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-ae005ba42de93cd40/prosper
+cd ${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-ae005ba42de93cd40/prosper
 PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1 \
   timeout "$SECS" ./build-linux/boot_trace /root/PPSA17942-app0 > "$LOG" 2>&1
 echo "run done rc=$?"

--- a/prosper/tools/dbg/run_drawnid.sh
+++ b/prosper/tools/dbg/run_drawnid.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-cd ${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-ae005ba42de93cd40/prosper
+cd "${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-ae005ba42de93cd40/prosper"
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1
 gdb -batch -x tools/dbg/drawnid.gdb --args ./build-linux/boot_trace /root/PPSA17942-app0 > /root/drawnid.log 2>&1
 echo "gdb done rc=$?"

--- a/prosper/tools/dbg/run_drawnid.sh
+++ b/prosper/tools/dbg/run_drawnid.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-cd /mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-ae005ba42de93cd40/prosper
+cd ${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-ae005ba42de93cd40/prosper
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1
 gdb -batch -x tools/dbg/drawnid.gdb --args ./build-linux/boot_trace /root/PPSA17942-app0 > /root/drawnid.log 2>&1
 echo "gdb done rc=$?"

--- a/prosper/tools/dbg/run_drawnid2.sh
+++ b/prosper/tools/dbg/run_drawnid2.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-cd ${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-ae005ba42de93cd40/prosper
+cd "${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-ae005ba42de93cd40/prosper"
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1
 gdb -batch -x tools/dbg/drawnid2.gdb --args ./build-linux/boot_trace /root/PPSA17942-app0 > /root/drawnid2.log 2>&1
 echo "gdb done rc=$?"

--- a/prosper/tools/dbg/run_drawnid2.sh
+++ b/prosper/tools/dbg/run_drawnid2.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-cd /mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-ae005ba42de93cd40/prosper
+cd ${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-ae005ba42de93cd40/prosper
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1
 gdb -batch -x tools/dbg/drawnid2.gdb --args ./build-linux/boot_trace /root/PPSA17942-app0 > /root/drawnid2.log 2>&1
 echo "gdb done rc=$?"

--- a/prosper/tools/dbg/run_gotmap.sh
+++ b/prosper/tools/dbg/run_gotmap.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-cd /mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-ae005ba42de93cd40/prosper
+cd ${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-ae005ba42de93cd40/prosper
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_STUBDUMP=1
 gdb -batch -x tools/dbg/gotmap.gdb --args ./build-linux/boot_trace /root/PPSA17942-app0 > /root/gotmap.log 2>&1
 echo "rc=$?"

--- a/prosper/tools/dbg/run_gotmap.sh
+++ b/prosper/tools/dbg/run_gotmap.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-cd ${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-ae005ba42de93cd40/prosper
+cd "${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-ae005ba42de93cd40/prosper"
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_STUBDUMP=1
 gdb -batch -x tools/dbg/gotmap.gdb --args ./build-linux/boot_trace /root/PPSA17942-app0 > /root/gotmap.log 2>&1
 echo "rc=$?"

--- a/prosper/tools/dbg/run_vostatus.sh
+++ b/prosper/tools/dbg/run_vostatus.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-cd /mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-ae005ba42de93cd40/prosper
+cd ${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-ae005ba42de93cd40/prosper
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1
 gdb -batch -x tools/dbg/vostatus.gdb --args ./build-linux/boot_trace /root/PPSA17942-app0 > /root/vostatus.log 2>&1
 echo "rc=$?"

--- a/prosper/tools/dbg/run_vostatus.sh
+++ b/prosper/tools/dbg/run_vostatus.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-cd ${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-ae005ba42de93cd40/prosper
+cd "${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-ae005ba42de93cd40/prosper"
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1
 gdb -batch -x tools/dbg/vostatus.gdb --args ./build-linux/boot_trace /root/PPSA17942-app0 > /root/vostatus.log 2>&1
 echo "rc=$?"

--- a/prosper/tools/dbg/runstate232.sh
+++ b/prosper/tools/dbg/runstate232.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a2d51084866d8d045/prosper
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a2d51084866d8d045/prosper
 PID=$(cat /root/pid232.txt)
 kill -0 $PID 2>/dev/null || { echo "DEAD pid=$PID"; exit 1; }
 echo "probing pid=$PID"

--- a/prosper/tools/dbg/runstate232.sh
+++ b/prosper/tools/dbg/runstate232.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a2d51084866d8d045/prosper
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a2d51084866d8d045/prosper"
 PID=$(cat /root/pid232.txt)
 kill -0 $PID 2>/dev/null || { echo "DEAD pid=$PID"; exit 1; }
 echo "probing pid=$PID"

--- a/prosper/tools/dbg/sample_bt.sh
+++ b/prosper/tools/dbg/sample_bt.sh
@@ -3,7 +3,7 @@
 # Usage: sample_bt.sh <sleep_seconds> <nsamples>
 SLEEP=${1:-150}
 N=${2:-5}
-cd ${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-ae005ba42de93cd40/prosper
+cd "${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-ae005ba42de93cd40/prosper"
 PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1 \
   ./build-linux/boot_trace /root/PPSA17942-app0 > /root/scene1.log 2>&1 &
 PID=$!

--- a/prosper/tools/dbg/sample_bt.sh
+++ b/prosper/tools/dbg/sample_bt.sh
@@ -3,7 +3,7 @@
 # Usage: sample_bt.sh <sleep_seconds> <nsamples>
 SLEEP=${1:-150}
 N=${2:-5}
-cd /mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-ae005ba42de93cd40/prosper
+cd ${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-ae005ba42de93cd40/prosper
 PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1 \
   ./build-linux/boot_trace /root/PPSA17942-app0 > /root/scene1.log 2>&1 &
 PID=$!

--- a/prosper/tools/dbg/sample_stall.sh
+++ b/prosper/tools/dbg/sample_stall.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Run DOLL; when GpuFlip count stops advancing for 30s, gdb-sample all threads (the RenderThread stall).
-cd /mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-ae005ba42de93cd40/prosper
+cd ${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-ae005ba42de93cd40/prosper
 PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1 \
   ./build-linux/boot_trace /root/PPSA17942-app0 > /root/scene3.log 2>&1 &
 PID=$!

--- a/prosper/tools/dbg/sample_stall.sh
+++ b/prosper/tools/dbg/sample_stall.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Run DOLL; when GpuFlip count stops advancing for 30s, gdb-sample all threads (the RenderThread stall).
-cd ${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-ae005ba42de93cd40/prosper
+cd "${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-ae005ba42de93cd40/prosper"
 PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1 \
   ./build-linux/boot_trace /root/PPSA17942-app0 > /root/scene3.log 2>&1 &
 PID=$!

--- a/prosper/tools/dbg/smoke_messenger.sh
+++ b/prosper/tools/dbg/smoke_messenger.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # Messenger render smoke: must render frames (presented) with the live renderer.
-cd /mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-ae005ba42de93cd40/prosper
+cd ${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-ae005ba42de93cd40/prosper
 PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 PROSPER_GFXLOG=1 \
-  timeout 240 ./build-linux/boot_trace /mnt/c/Users/matti/repos/ps5ys/PPSA24651-app0 > /root/smoke.log 2>&1
+  timeout 240 ./build-linux/boot_trace ${PROSPER_REPO_ROOT:?set to your checkout root}/PPSA24651-app0 > /root/smoke.log 2>&1
 echo "rc=$?"
 echo "=== presented frames ==="
 grep -c "presented" /root/smoke.log

--- a/prosper/tools/dbg/smoke_messenger.sh
+++ b/prosper/tools/dbg/smoke_messenger.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # Messenger render smoke: must render frames (presented) with the live renderer.
-cd ${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-ae005ba42de93cd40/prosper
+cd "${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-ae005ba42de93cd40/prosper"
 PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 PROSPER_GFXLOG=1 \
-  timeout 240 ./build-linux/boot_trace ${PROSPER_REPO_ROOT:?set to your checkout root}/PPSA24651-app0 > /root/smoke.log 2>&1
+  timeout 240 ./build-linux/boot_trace "${PROSPER_REPO_ROOT:?set to your checkout root}/PPSA24651-app0" > /root/smoke.log 2>&1
 echo "rc=$?"
 echo "=== presented frames ==="
 grep -c "presented" /root/smoke.log

--- a/prosper/tools/dbg/smoke_messenger2.sh
+++ b/prosper/tools/dbg/smoke_messenger2.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # Messenger render smoke (this worktree): must reach 1000+ frames with 0 faults.
-cd ${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a36ca69a115e7c61a/prosper || exit 1
+cd "${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a36ca69a115e7c61a/prosper" || exit 1
 PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 PROSPER_GFXLOG=1 \
-  timeout 240 ./build-linux/boot_trace ${PROSPER_REPO_ROOT:?set to your checkout root}/PPSA24651-app0 > /root/smoke2.log 2>&1
+  timeout 240 ./build-linux/boot_trace "${PROSPER_REPO_ROOT:?set to your checkout root}/PPSA24651-app0" > /root/smoke2.log 2>&1
 echo "rc=$?"
 echo "flips=$(grep -ac GpuFlip /root/smoke2.log)"
 echo "presented=$(grep -ac presented /root/smoke2.log)"

--- a/prosper/tools/dbg/smoke_messenger2.sh
+++ b/prosper/tools/dbg/smoke_messenger2.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # Messenger render smoke (this worktree): must reach 1000+ frames with 0 faults.
-cd /mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a36ca69a115e7c61a/prosper || exit 1
+cd ${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a36ca69a115e7c61a/prosper || exit 1
 PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 PROSPER_GFXLOG=1 \
-  timeout 240 ./build-linux/boot_trace /mnt/c/Users/matti/repos/ps5ys/PPSA24651-app0 > /root/smoke2.log 2>&1
+  timeout 240 ./build-linux/boot_trace ${PROSPER_REPO_ROOT:?set to your checkout root}/PPSA24651-app0 > /root/smoke2.log 2>&1
 echo "rc=$?"
 echo "flips=$(grep -ac GpuFlip /root/smoke2.log)"
 echo "presented=$(grep -ac presented /root/smoke2.log)"

--- a/prosper/tools/dbg/smoke_messenger3.sh
+++ b/prosper/tools/dbg/smoke_messenger3.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # Messenger render smoke (this worktree): must render frames (presented) with the live renderer.
-cd ${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a2d51084866d8d045/prosper || exit 1
+cd "${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a2d51084866d8d045/prosper" || exit 1
 PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 PROSPER_GFXLOG=1 \
-  timeout 240 ./build-linux/boot_trace ${PROSPER_REPO_ROOT:?set to your checkout root}/PPSA24651-app0 > /root/smoke3.log 2>&1
+  timeout 240 ./build-linux/boot_trace "${PROSPER_REPO_ROOT:?set to your checkout root}/PPSA24651-app0" > /root/smoke3.log 2>&1
 echo "rc=$?"
 echo "=== presented frames ==="
 grep -ac "presented" /root/smoke3.log

--- a/prosper/tools/dbg/smoke_messenger3.sh
+++ b/prosper/tools/dbg/smoke_messenger3.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # Messenger render smoke (this worktree): must render frames (presented) with the live renderer.
-cd /mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a2d51084866d8d045/prosper || exit 1
+cd ${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a2d51084866d8d045/prosper || exit 1
 PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 PROSPER_GFXLOG=1 \
-  timeout 240 ./build-linux/boot_trace /mnt/c/Users/matti/repos/ps5ys/PPSA24651-app0 > /root/smoke3.log 2>&1
+  timeout 240 ./build-linux/boot_trace ${PROSPER_REPO_ROOT:?set to your checkout root}/PPSA24651-app0 > /root/smoke3.log 2>&1
 echo "rc=$?"
 echo "=== presented frames ==="
 grep -ac "presented" /root/smoke3.log

--- a/prosper/tools/dbg/smoke_msg232.sh
+++ b/prosper/tools/dbg/smoke_msg232.sh
@@ -2,10 +2,10 @@
 # Messenger render smoke for issue #232 (shared GPU pm4/command_processor changed). Must still reach
 # real scene draws (vcount=1044) with 0 faults. Runs under a private binary name (other agents pkill
 # boot_trace on this shared WSL). Long run: the scene draws only appear deep in.
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-ac66b5fec5918f7aa/prosper
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-ac66b5fec5918f7aa/prosper"
 cp -f "$WT/build-linux/boot_trace" /root/btmsg
 PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 PROSPER_GFXLOG=1 \
-  timeout 260 /root/btmsg ${PROSPER_REPO_ROOT:?set to your checkout root}/PPSA24651-app0 > /root/smokemsg.log 2>&1
+  timeout 260 /root/btmsg "${PROSPER_REPO_ROOT:?set to your checkout root}/PPSA24651-app0" > /root/smokemsg.log 2>&1
 echo "rc=$?"
 echo "=== presented frames ==="; grep -ac "presented" /root/smokemsg.log
 echo "=== draws (max) ==="; grep -ao "draws so far: [0-9]*" /root/smokemsg.log | awk '{print $4}' | sort -n | tail -2

--- a/prosper/tools/dbg/smoke_msg232.sh
+++ b/prosper/tools/dbg/smoke_msg232.sh
@@ -2,10 +2,10 @@
 # Messenger render smoke for issue #232 (shared GPU pm4/command_processor changed). Must still reach
 # real scene draws (vcount=1044) with 0 faults. Runs under a private binary name (other agents pkill
 # boot_trace on this shared WSL). Long run: the scene draws only appear deep in.
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-ac66b5fec5918f7aa/prosper
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-ac66b5fec5918f7aa/prosper
 cp -f "$WT/build-linux/boot_trace" /root/btmsg
 PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 PROSPER_GFXLOG=1 \
-  timeout 260 /root/btmsg /mnt/c/Users/matti/repos/ps5ys/PPSA24651-app0 > /root/smokemsg.log 2>&1
+  timeout 260 /root/btmsg ${PROSPER_REPO_ROOT:?set to your checkout root}/PPSA24651-app0 > /root/smokemsg.log 2>&1
 echo "rc=$?"
 echo "=== presented frames ==="; grep -ac "presented" /root/smokemsg.log
 echo "=== draws (max) ==="; grep -ao "draws so far: [0-9]*" /root/smokemsg.log | awk '{print $4}' | sort -n | tail -2

--- a/prosper/tools/dbg/snap_check.sh
+++ b/prosper/tools/dbg/snap_check.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-cd /mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a48ff9e03b626cc45/prosper || exit 1
+cd ${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a48ff9e03b626cc45/prosper || exit 1
 pkill -9 boot_trace 2>/dev/null; sleep 1
 python3 tools/snapshot/snapshot.py check
 echo "SNAPSHOT_RC=$?"

--- a/prosper/tools/dbg/snap_check.sh
+++ b/prosper/tools/dbg/snap_check.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-cd ${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a48ff9e03b626cc45/prosper || exit 1
+cd "${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a48ff9e03b626cc45/prosper" || exit 1
 pkill -9 boot_trace 2>/dev/null; sleep 1
 python3 tools/snapshot/snapshot.py check
 echo "SNAPSHOT_RC=$?"

--- a/prosper/tools/dbg/soak232.sh
+++ b/prosper/tools/dbg/soak232.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Issue #232: long DOLL soak; leave running for gdb probing. PID -> /root/pid232.txt.
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a2d51084866d8d045/prosper
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a2d51084866d8d045/prosper
 LOG=/root/${1:-soak232}.log
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1 PROSPER_SVCLOG=1

--- a/prosper/tools/dbg/soak232.sh
+++ b/prosper/tools/dbg/soak232.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Issue #232: long DOLL soak; leave running for gdb probing. PID -> /root/pid232.txt.
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a2d51084866d8d045/prosper
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a2d51084866d8d045/prosper"
 LOG=/root/${1:-soak232}.log
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1 PROSPER_SVCLOG=1

--- a/prosper/tools/dbg/soak232b.sh
+++ b/prosper/tools/dbg/soak232b.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Issue #232 session 6: boot DOLL to steady state and leave running. PID -> /root/pid232.txt.
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-ac66b5fec5918f7aa/prosper
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-ac66b5fec5918f7aa/prosper"
 LOG=/root/${1:-soak232b}.log
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1 PROSPER_SVCLOG=1

--- a/prosper/tools/dbg/soak232b.sh
+++ b/prosper/tools/dbg/soak232b.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Issue #232 session 6: boot DOLL to steady state and leave running. PID -> /root/pid232.txt.
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-ac66b5fec5918f7aa/prosper
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-ac66b5fec5918f7aa/prosper
 LOG=/root/${1:-soak232b}.log
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1 PROSPER_SVCLOG=1

--- a/prosper/tools/dbg/soak232c.sh
+++ b/prosper/tools/dbg/soak232c.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Issue #232 session 6: boot DOLL to steady state, leave running. PID -> /root/pid232s6.txt.
 # NO pkill (other agents run boot_trace on this WSL); kill only our own recorded pid.
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-ac66b5fec5918f7aa/prosper
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-ac66b5fec5918f7aa/prosper"
 LOG=/root/${1:-s6}.log
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_SVCLOG=1

--- a/prosper/tools/dbg/soak232c.sh
+++ b/prosper/tools/dbg/soak232c.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Issue #232 session 6: boot DOLL to steady state, leave running. PID -> /root/pid232s6.txt.
 # NO pkill (other agents run boot_trace on this WSL); kill only our own recorded pid.
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-ac66b5fec5918f7aa/prosper
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-ac66b5fec5918f7aa/prosper
 LOG=/root/${1:-s6}.log
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_SVCLOG=1

--- a/prosper/tools/dbg/stall_bt2.sh
+++ b/prosper/tools/dbg/stall_bt2.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-aa1d2a853141bdab4/prosper
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-aa1d2a853141bdab4/prosper
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
 ./build-linux/boot_trace /root/PPSA17942-app0 > /root/sbt2.log 2>&1 &

--- a/prosper/tools/dbg/stall_bt2.sh
+++ b/prosper/tools/dbg/stall_bt2.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-aa1d2a853141bdab4/prosper
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-aa1d2a853141bdab4/prosper"
 cd "$WT" || exit 1
 export PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1
 ./build-linux/boot_trace /root/PPSA17942-app0 > /root/sbt2.log 2>&1 &

--- a/prosper/tools/dbg/stall_guest_bt.sh
+++ b/prosper/tools/dbg/stall_guest_bt.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Run DOLL; at flip stall, dump raw stacks of ALL threads and extract guest (0x4xxxxxxxx) RAs.
-cd /mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-ae005ba42de93cd40/prosper
+cd ${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-ae005ba42de93cd40/prosper
 PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1 \
   ./build-linux/boot_trace /root/PPSA17942-app0 > /root/scene4.log 2>&1 &
 PID=$!

--- a/prosper/tools/dbg/stall_guest_bt.sh
+++ b/prosper/tools/dbg/stall_guest_bt.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Run DOLL; at flip stall, dump raw stacks of ALL threads and extract guest (0x4xxxxxxxx) RAs.
-cd ${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-ae005ba42de93cd40/prosper
+cd "${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-ae005ba42de93cd40/prosper"
 PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1 \
   ./build-linux/boot_trace /root/PPSA17942-app0 > /root/scene4.log 2>&1 &
 PID=$!

--- a/prosper/tools/dbg/trophy_names.sh
+++ b/prosper/tools/dbg/trophy_names.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Brute-force candidate names for the NpTrophy2 NIDs via the nid test tool if it supports hashing,
 # else compile a one-off hasher against nid.cpp.
-cd /mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-ae005ba42de93cd40/prosper
+cd ${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-ae005ba42de93cd40/prosper
 cat > /tmp/nidhash.cpp << "EOF"
 #include <cstdio>
 #include <string>

--- a/prosper/tools/dbg/trophy_names.sh
+++ b/prosper/tools/dbg/trophy_names.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Brute-force candidate names for the NpTrophy2 NIDs via the nid test tool if it supports hashing,
 # else compile a one-off hasher against nid.cpp.
-cd ${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-ae005ba42de93cd40/prosper
+cd "${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-ae005ba42de93cd40/prosper"
 cat > /tmp/nidhash.cpp << "EOF"
 #include <cstdio>
 #include <string>

--- a/prosper/tools/dbg/waf_sync.sh
+++ b/prosper/tools/dbg/waf_sync.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # #312: test whether SYNCHRONOUS fence writes (PROSPER_EOP_WRITE_SYNC=1, no pend deferral) + the WAF
 # guard close the gate. Usage: waf_sync.sh <first> <N> <timeout_s> [SYNC] [GUARD]
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a8f10a7598f626404/prosper
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a8f10a7598f626404/prosper"
 cd "$WT" || exit 1
 FIRST=${1:-1}; N=${2:-3}; TMO=${3:-120}; SYNC=${4:-1}; GUARD=${5:-1}
 SCRIPT="15:cross;20:start;25:cross;30:start;35:cross;40:cross;45:start;50:cross;60:cross;70:start;80:cross;90:cross;100:cross;110:cross;120:cross;130:cross"

--- a/prosper/tools/dbg/waf_sync.sh
+++ b/prosper/tools/dbg/waf_sync.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # #312: test whether SYNCHRONOUS fence writes (PROSPER_EOP_WRITE_SYNC=1, no pend deferral) + the WAF
 # guard close the gate. Usage: waf_sync.sh <first> <N> <timeout_s> [SYNC] [GUARD]
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a8f10a7598f626404/prosper
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a8f10a7598f626404/prosper
 cd "$WT" || exit 1
 FIRST=${1:-1}; N=${2:-3}; TMO=${3:-120}; SYNC=${4:-1}; GUARD=${5:-1}
 SCRIPT="15:cross;20:start;25:cross;30:start;35:cross;40:cross;45:start;50:cross;60:cross;70:start;80:cross;90:cross;100:cross;110:cross;120:cross;130:cross"

--- a/prosper/tools/dbg/waf_val.sh
+++ b/prosper/tools/dbg/waf_val.sh
@@ -3,7 +3,7 @@
 # timing (no MB3WATCH). Tallies ALL fatal signatures (Canary / unrecognized block / worker-fault /
 # 0x20015f00) + WAF suppression activity + DOLL progression. Vars live in-file (cmdline-strip safe).
 # Usage: waf_val.sh <first> <N> <timeout_s> [GUARD]   (GUARD=0 for the session-10 A/B baseline)
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a8f10a7598f626404/prosper
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a8f10a7598f626404/prosper"
 cd "$WT" || exit 1
 FIRST=${1:-1}; N=${2:-4}; TMO=${3:-120}; GUARD=${4:-1}
 SCRIPT="15:cross;20:start;25:cross;30:start;35:cross;40:cross;45:start;50:cross;60:cross;70:start;80:cross;90:cross;100:cross;110:cross;120:cross;130:cross"

--- a/prosper/tools/dbg/waf_val.sh
+++ b/prosper/tools/dbg/waf_val.sh
@@ -3,7 +3,7 @@
 # timing (no MB3WATCH). Tallies ALL fatal signatures (Canary / unrecognized block / worker-fault /
 # 0x20015f00) + WAF suppression activity + DOLL progression. Vars live in-file (cmdline-strip safe).
 # Usage: waf_val.sh <first> <N> <timeout_s> [GUARD]   (GUARD=0 for the session-10 A/B baseline)
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-a8f10a7598f626404/prosper
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-a8f10a7598f626404/prosper
 cd "$WT" || exit 1
 FIRST=${1:-1}; N=${2:-4}; TMO=${3:-120}; GUARD=${4:-1}
 SCRIPT="15:cross;20:start;25:cross;30:start;35:cross;40:cross;45:start;50:cross;60:cross;70:start;80:cross;90:cross;100:cross;110:cross;120:cross;130:cross"

--- a/prosper/tools/perf/ab_compute.sh
+++ b/prosper/tools/perf/ab_compute.sh
@@ -9,7 +9,7 @@
 #
 # Usage: ab_compute.sh <switch=value> <route.pad> <dump-dir> [reps] [seconds]
 #   e.g. ab_compute.sh PROSPER_NO_DIRECT_RTT_BIND=1 scripts/blasphemous2/title-screen-idle.pad \
-#          /home/mattias800/repos/ps5ys/PPSA13579-app0 3 60
+#          <REPO_ROOT>/PPSA13579-app0 3 60
 # The switch names the OFF (baseline) condition; ON is the same run with the switch unset.
 set -u
 SWITCH="${1:?switch=value naming the OFF condition}"

--- a/prosper/tools/snapshot/snapshot.py
+++ b/prosper/tools/snapshot/snapshot.py
@@ -18,7 +18,7 @@ Usage:
   snapshot.py list
 
 Env overrides:
-  PROSPER_GAME_ROOT   dir holding the <dump> subdirs   (default: /mnt/c/Users/matti/repos/ps5ys)
+  PROSPER_GAME_ROOT   dir holding the <dump> subdirs   (default: the main checkout root)
   PROSPER_BOOT_TRACE  path to the boot_trace binary    (default: <prosper>/build-linux/boot_trace)
   PROSPER_SCREENSHOT  path to the screenshot binary    (default: <prosper>/build-linux/screenshot)
   PROSPER_SNAPSHOT_LOCK path for the cross-worktree capture lock
@@ -39,7 +39,22 @@ PROSPER_ROOT = os.path.normpath(os.path.join(HERE, "..", ".."))
 MANIFEST = os.path.join(HERE, "snapshots.json")
 FAIL_DIR = os.path.join(HERE, "failures")
 REVIEW_DIR = os.path.join(HERE, "review")
-GAME_ROOT = os.environ.get("PROSPER_GAME_ROOT", "/mnt/c/Users/matti/repos/ps5ys")
+# The dumps live beside the MAIN checkout root, so derive the default instead of hard-coding one
+# developer's absolute path into a public repository. Use git's common dir rather than
+# <prosper>/..: everyone here works in worktrees under .claude/worktrees/, where <prosper>/..
+# is the worktree root and holds no dumps, while --git-common-dir always names the main .git.
+def _default_game_root():
+    try:
+        common = subprocess.run(
+            ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
+            cwd=PROSPER_ROOT, capture_output=True, text=True, timeout=10)
+        if common.returncode == 0 and common.stdout.strip():
+            return os.path.dirname(common.stdout.strip())
+    except (OSError, subprocess.SubprocessError):
+        pass
+    return os.path.normpath(os.path.join(PROSPER_ROOT, ".."))
+
+GAME_ROOT = os.environ.get("PROSPER_GAME_ROOT") or _default_game_root()
 
 _PR_SET_PDEATHSIG = 1
 _LIBC = ctypes.CDLL(None, use_errno=True) if sys.platform.startswith("linux") else None

--- a/prosper/tools/snapshot/snapshot.py
+++ b/prosper/tools/snapshot/snapshot.py
@@ -39,22 +39,28 @@ PROSPER_ROOT = os.path.normpath(os.path.join(HERE, "..", ".."))
 MANIFEST = os.path.join(HERE, "snapshots.json")
 FAIL_DIR = os.path.join(HERE, "failures")
 REVIEW_DIR = os.path.join(HERE, "review")
-# The dumps live beside the MAIN checkout root, so derive the default instead of hard-coding one
-# developer's absolute path into a public repository. Use git's common dir rather than
-# <prosper>/..: everyone here works in worktrees under .claude/worktrees/, where <prosper>/..
-# is the worktree root and holds no dumps, while --git-common-dir always names the main .git.
-def _default_game_root():
+# Absolute path of the Git common directory (the MAIN clone's .git, shared by every worktree), or ""
+# when this tree is not a Git checkout — e.g. a source archive. Both callers below need it and must
+# agree, so resolve it once: the snapshot lock has to be shared across worktrees, and the game-dump
+# root has to be the main checkout rather than whichever worktree is running.
+def _git_common_dir():
     try:
-        common = subprocess.run(
+        result = subprocess.run(
             ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
             cwd=PROSPER_ROOT, capture_output=True, text=True, timeout=10)
-        if common.returncode == 0 and common.stdout.strip():
-            return os.path.dirname(common.stdout.strip())
+        return result.stdout.strip() if result.returncode == 0 else ""
     except (OSError, subprocess.SubprocessError):
-        pass
-    return os.path.normpath(os.path.join(PROSPER_ROOT, ".."))
+        return ""
 
-GAME_ROOT = os.environ.get("PROSPER_GAME_ROOT") or _default_game_root()
+
+GIT_COMMON_DIR = _git_common_dir()
+
+# The dumps live beside the MAIN checkout root, so derive the default instead of hard-coding one
+# developer's absolute path into a public repository. Deliberately not <prosper>/..: worktrees hold
+# no dumps, and they are used heavily here, so that would resolve to the wrong tree.
+GAME_ROOT = (os.environ.get("PROSPER_GAME_ROOT")
+             or (os.path.dirname(GIT_COMMON_DIR) if GIT_COMMON_DIR
+                 else os.path.normpath(os.path.join(PROSPER_ROOT, ".."))))
 
 _PR_SET_PDEATHSIG = 1
 _LIBC = ctypes.CDLL(None, use_errno=True) if sys.platform.startswith("linux") else None
@@ -68,17 +74,8 @@ def _snapshot_lock_path():
     # All worktrees of one clone share this directory, unlike PROSPER_ROOT.
     # Keeping the lock there makes independent agent worktrees cooperate without
     # introducing a tracked file in any checkout.
-    try:
-        result = subprocess.run(
-            ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
-            cwd=PROSPER_ROOT, check=True, text=True, stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
-        )
-        common_dir = result.stdout.strip()
-        if common_dir:
-            return os.path.join(common_dir, "prosper-snapshot.lock")
-    except (OSError, subprocess.CalledProcessError):
-        pass
+    if GIT_COMMON_DIR:
+        return os.path.join(GIT_COMMON_DIR, "prosper-snapshot.lock")
 
     # Source archives have no Git common directory. Still coordinate invocations
     # from the same extracted tree without colliding with unrelated checkouts.

--- a/scripts/diag/build.sh
+++ b/scripts/diag/build.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 # Build prosper in this agent worktree (run inside WSL Ubuntu-24.04 as root).
 set -e
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-aa922b2bc59375888
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-aa922b2bc59375888
 cd "$WT/prosper"
 if [ ! -f build-linux/CMakeCache.txt ]; then
-  cmake -S . -B build-linux -DCMAKE_BUILD_TYPE=Release -DGAME_DUMP=/mnt/c/Users/matti/repos/ps5ys/PPSA24651-app0
+  cmake -S . -B build-linux -DCMAKE_BUILD_TYPE=Release -DGAME_DUMP=${PROSPER_REPO_ROOT:?set to your checkout root}/PPSA24651-app0
 fi
 cmake --build build-linux -j16 2>&1 | tail -5
 echo BUILD_OK

--- a/scripts/diag/build.sh
+++ b/scripts/diag/build.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 # Build prosper in this agent worktree (run inside WSL Ubuntu-24.04 as root).
 set -e
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-aa922b2bc59375888
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-aa922b2bc59375888"
 cd "$WT/prosper"
 if [ ! -f build-linux/CMakeCache.txt ]; then
-  cmake -S . -B build-linux -DCMAKE_BUILD_TYPE=Release -DGAME_DUMP=${PROSPER_REPO_ROOT:?set to your checkout root}/PPSA24651-app0
+  cmake -S . -B build-linux -DCMAKE_BUILD_TYPE=Release -DGAME_DUMP="${PROSPER_REPO_ROOT:?set to your checkout root}/PPSA24651-app0"
 fi
 cmake --build build-linux -j16 2>&1 | tail -5
 echo BUILD_OK

--- a/scripts/diag/run1_norender.sh
+++ b/scripts/diag/run1_norender.sh
@@ -3,7 +3,7 @@
 # Boots for DUR seconds with file/event logging + the PROSPER_PROGRESS heartbeat, samples /proc
 # every 20 s, then prints a bucketed progression analysis. Run inside WSL Ubuntu-24.04 as root.
 set -u
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-aa922b2bc59375888
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-aa922b2bc59375888
 BT="$WT/prosper/build-linux/boot_trace"
 DUMP=/root/PPSA17942-app0
 DUR=${DUR:-420}

--- a/scripts/diag/run1_norender.sh
+++ b/scripts/diag/run1_norender.sh
@@ -3,7 +3,7 @@
 # Boots for DUR seconds with file/event logging + the PROSPER_PROGRESS heartbeat, samples /proc
 # every 20 s, then prints a bucketed progression analysis. Run inside WSL Ubuntu-24.04 as root.
 set -u
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-aa922b2bc59375888
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-aa922b2bc59375888"
 BT="$WT/prosper/build-linux/boot_trace"
 DUMP=/root/PPSA17942-app0
 DUR=${DUR:-420}

--- a/scripts/diag/run2_denyusm.sh
+++ b/scripts/diag/run2_denyusm.sh
@@ -3,7 +3,7 @@
 # If the front-end flow is wedged waiting on CRI movie playback that our missing sceVideodec2
 # can't deliver, denying the .usm files should CHANGE progression (skip-movie path).
 set -u
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-aa922b2bc59375888
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-aa922b2bc59375888"
 BT="$WT/prosper/build-linux/boot_trace"
 DUMP=/root/PPSA17942-app0
 DUR=${DUR:-420}

--- a/scripts/diag/run2_denyusm.sh
+++ b/scripts/diag/run2_denyusm.sh
@@ -3,7 +3,7 @@
 # If the front-end flow is wedged waiting on CRI movie playback that our missing sceVideodec2
 # can't deliver, denying the .usm files should CHANGE progression (skip-movie path).
 set -u
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-aa922b2bc59375888
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-aa922b2bc59375888
 BT="$WT/prosper/build-linux/boot_trace"
 DUMP=/root/PPSA17942-app0
 DUR=${DUR:-420}

--- a/scripts/diag/run3_render.sh
+++ b/scripts/diag/run3_render.sh
@@ -2,7 +2,7 @@
 # DOLL progression probe, run 3: WITH live renderer (llvmpipe) — quantify presented-frame
 # throughput and whether render throttling changes guest progression. PADLOG shows input polling.
 set -u
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-aa922b2bc59375888
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-aa922b2bc59375888"
 cp -f "$WT/prosper/build-linux/boot_trace" /root/bt_diag
 BT=/root/bt_diag
 DUMP=/root/PPSA17942-app0

--- a/scripts/diag/run3_render.sh
+++ b/scripts/diag/run3_render.sh
@@ -2,7 +2,7 @@
 # DOLL progression probe, run 3: WITH live renderer (llvmpipe) — quantify presented-frame
 # throughput and whether render throttling changes guest progression. PADLOG shows input polling.
 set -u
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-aa922b2bc59375888
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-aa922b2bc59375888
 cp -f "$WT/prosper/build-linux/boot_trace" /root/bt_diag
 BT=/root/bt_diag
 DUMP=/root/PPSA17942-app0

--- a/scripts/diag/run4_threads.sh
+++ b/scripts/diag/run4_threads.sh
@@ -2,7 +2,7 @@
 # DOLL progression probe, run 4: boot no-render to steady state, then gdb-attach twice (60 s apart)
 # and dump every thread's name/pc/guest-RAs — is anything blocked, and does the picture CHANGE?
 set -u
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-aa922b2bc59375888
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-aa922b2bc59375888
 BT="$WT/prosper/build-linux/boot_trace"
 DUMP=/root/PPSA17942-app0
 LOG=/root/doll_r4.log

--- a/scripts/diag/run4_threads.sh
+++ b/scripts/diag/run4_threads.sh
@@ -2,7 +2,7 @@
 # DOLL progression probe, run 4: boot no-render to steady state, then gdb-attach twice (60 s apart)
 # and dump every thread's name/pc/guest-RAs — is anything blocked, and does the picture CHANGE?
 set -u
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-aa922b2bc59375888
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-aa922b2bc59375888"
 BT="$WT/prosper/build-linux/boot_trace"
 DUMP=/root/PPSA17942-app0
 LOG=/root/doll_r4.log

--- a/scripts/diag/run5_flow.sh
+++ b/scripts/diag/run5_flow.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # DOLL progression probe, run 5: boot no-render to steady state, attach gdb with flow5.py.
 set -u
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-aa922b2bc59375888
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-aa922b2bc59375888
 # Run under a different binary name: sibling agents' cleanup scripts pkill 'boot_trace' and have
 # killed our diagnostic boots mid-probe.
 cp -f "$WT/prosper/build-linux/boot_trace" /root/bt_diag

--- a/scripts/diag/run5_flow.sh
+++ b/scripts/diag/run5_flow.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # DOLL progression probe, run 5: boot no-render to steady state, attach gdb with flow5.py.
 set -u
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-aa922b2bc59375888
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-aa922b2bc59375888"
 # Run under a different binary name: sibling agents' cleanup scripts pkill 'boot_trace' and have
 # killed our diagnostic boots mid-probe.
 cp -f "$WT/prosper/build-linux/boot_trace" /root/bt_diag

--- a/scripts/diag/run6_pumps.sh
+++ b/scripts/diag/run6_pumps.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # DOLL progression probe, run 6: identify the guest callers of the per-frame unimplemented pumps.
 set -u
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-aa922b2bc59375888
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-aa922b2bc59375888
 cp -f "$WT/prosper/build-linux/boot_trace" /root/bt_diag
 DUMP=/root/PPSA17942-app0
 LOG=/root/doll_r6.log

--- a/scripts/diag/run6_pumps.sh
+++ b/scripts/diag/run6_pumps.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # DOLL progression probe, run 6: identify the guest callers of the per-frame unimplemented pumps.
 set -u
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-aa922b2bc59375888
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-aa922b2bc59375888"
 cp -f "$WT/prosper/build-linux/boot_trace" /root/bt_diag
 DUMP=/root/PPSA17942-app0
 LOG=/root/doll_r6.log

--- a/scripts/diag/run7_netctl.sh
+++ b/scripts/diag/run7_netctl.sh
@@ -3,7 +3,7 @@
 # callback (PROSPER_NETCTL_CB=1) and watch whether the boot flow advances (new file IO after the
 # t=6s wall, pad open, sms_opening movie open, new NIDs).
 set -u
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-aa922b2bc59375888
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-aa922b2bc59375888
 cp -f "$WT/prosper/build-linux/boot_trace" /root/bt_diag
 DUMP=/root/PPSA17942-app0
 DUR=${DUR:-300}

--- a/scripts/diag/run7_netctl.sh
+++ b/scripts/diag/run7_netctl.sh
@@ -3,7 +3,7 @@
 # callback (PROSPER_NETCTL_CB=1) and watch whether the boot flow advances (new file IO after the
 # t=6s wall, pad open, sms_opening movie open, new NIDs).
 set -u
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-aa922b2bc59375888
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-aa922b2bc59375888"
 cp -f "$WT/prosper/build-linux/boot_trace" /root/bt_diag
 DUMP=/root/PPSA17942-app0
 DUR=${DUR:-300}

--- a/scripts/diag/run8_matrix.sh
+++ b/scripts/diag/run8_matrix.sh
@@ -2,7 +2,7 @@
 # DOLL progression probe, run 8: pad-connected matrix. 8a = PAD_PRESS only; 8b = PAD_PRESS+NETCTL_CB.
 # Usage: run8_matrix.sh a|b
 set -u
-WT=/mnt/c/Users/matti/repos/ps5ys/.claude/worktrees/agent-aa922b2bc59375888
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-aa922b2bc59375888
 V=$1
 cp -f "$WT/prosper/build-linux/boot_trace" /root/bt_diag_$V
 DUMP=/root/PPSA17942-app0

--- a/scripts/diag/run8_matrix.sh
+++ b/scripts/diag/run8_matrix.sh
@@ -2,7 +2,7 @@
 # DOLL progression probe, run 8: pad-connected matrix. 8a = PAD_PRESS only; 8b = PAD_PRESS+NETCTL_CB.
 # Usage: run8_matrix.sh a|b
 set -u
-WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-aa922b2bc59375888
+WT="${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-aa922b2bc59375888"
 V=$1
 cp -f "$WT/prosper/build-linux/boot_trace" /root/bt_diag_$V
 DUMP=/root/PPSA17942-app0


### PR DESCRIPTION
Implements the rule added in #1506 across the occurrences that predate it. The repository is public, and
these leaked an account name plus the private directory layout of one machine for no benefit to a reader.

Mechanical, documentation-and-scripts only, no runtime code paths — with one deliberate exception noted
below.

## What changed

**74 shell scripts** (`prosper/tools/dbg/`, `prosper/tools/perf/`, `scripts/diag/`) had a hard-coded
checkout root. They now read `${PROSPER_REPO_ROOT:?set to your checkout root}`:

```diff
-WT=/mnt/c/Users/<name>/repos/ps5ys/.claude/worktrees/agent-<hash>/prosper
+WT=${PROSPER_REPO_ROOT:?set to your checkout root}/.claude/worktrees/agent-<hash>/prosper
```

This is strictly better than a bare placeholder: the scripts fail loudly with a usable message instead of
silently pointing at a path that exists on nobody's machine. Several already referenced long-deleted agent
worktrees and could not run as written regardless. Comment lines use `<REPO_ROOT>` instead, matching the
placeholder vocabulary in CLAUDE.md.

**`CLAUDE.md`, `prosper/docs/DEAD_CELLS_STATUS.md`, `prosper/docs/NEXT_STEP_VERTEX_FETCH.md`** use
`<REPO_ROOT>` in their build/run recipes.

**`prosper/tools/snapshot/snapshot.py`** is the exception: real tooling with a hard-coded
`PROSPER_GAME_ROOT` default, so a placeholder would have broken it. It now derives the default from git.

## The one judgement call worth reviewing

My first attempt derived it as `<prosper>/..`, which is wrong for how this project actually works — I
caught it by testing rather than reasoning:

```
GAME_ROOT = <REPO_ROOT>/.claude/worktrees/seed-fallback     # the worktree root: no dumps here
```

Everyone works in worktrees under `.claude/worktrees/`, where `<prosper>/..` is the worktree root and holds
no dumps. `git rev-parse --path-format=absolute --git-common-dir` always names the *main* `.git` whatever
tree you invoke from, so its parent is the main checkout:

```
GAME_ROOT = <REPO_ROOT>      dumps found: 17
```

Falls back to `<prosper>/..` if git is unavailable or fails. `PROSPER_GAME_ROOT` still overrides, so anyone
with dumps elsewhere is unaffected.

## Naming

`PROSPER_REPO_ROOT`, not `PROSPER_ROOT`: `snapshot.py:38` already uses `PROSPER_ROOT` for the `prosper/`
directory, while this names the checkout root that *contains* it and the dumps. Never read from the
environment there, so there is no functional clash — but two identically-named things pointing at
different directories in one repository is a trap, so the longer name keeps the `PROSPER_*` convention
without the ambiguity.

## Verification

- `git grep` for developer absolute paths is **empty** across the tree.
- `bash -n` passes on all 74 rewritten scripts.
- The unset-variable path prints `PROSPER_REPO_ROOT: set to your checkout root`; the set path expands to
  `/some/root/PPSA24651-app0`.
- `snapshot.py`'s derived `GAME_ROOT` resolves to the main checkout **from inside a worktree** and finds all
  17 dumps.
- `git diff --check` clean.

## Affected / unaffected

The snapshot default is the only behavioural change, and it is strictly more correct: previously the default
was one machine's path and everyone else had to set `PROSPER_GAME_ROOT`. No build, test or renderer code is
touched.
