### PR TITLE
perf(gpu): retain larger compute image working sets

### DIFF
--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -5860,6 +5860,10 @@ uint64_t live_compute_sampled_image_upload_skips() {
     return g_sampled_image_upload_skips.load(std::memory_order_relaxed);
 }
 
+uint64_t live_compute_cpu_fill_dispatches() {
+    return g_cpu_fill_dispatches.load(std::memory_order_relaxed);
+}
+
 uint64_t live_compute_storage_result_snapshot_bytes() {
     return g_live_compute_context ? g_live_compute_context->storage_result_snapshot_bytes : 0;
 }

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -2456,13 +2456,25 @@ std::optional<bool> execute_cpu_fast_path(const prosper::gpu::ComputeItem& item)
     using prosper::gpu::ResourceClass;
     if (item.cpu_fast_path == ComputeCpuFastPath::None) return std::nullopt;
     if (item.cpu_fast_path != ComputeCpuFastPath::FillSgprUvec4 ||
-        !item.resources || item.user_sgprs.size() < 8 ||
+        !item.resources || item.resources->resources.size() != 1 ||
+        item.user_sgprs.size() != 8 || !item.recompile_config_available ||
+        !item.recompile_config.tgid_x_en || item.recompile_config.tgid_y_en ||
+        item.recompile_config.tgid_z_en ||
         item.launch.local_x != 64 || item.launch.local_y != 1 || item.launch.local_z != 1 ||
-        !item.launch.groups_x || !item.launch.groups_y || !item.launch.groups_z)
+        !item.launch.groups_x || item.launch.groups_y != 1 || item.launch.groups_z != 1 ||
+        item.launch.threads_y != 1 || item.launch.threads_z != 1)
         return std::nullopt;
 
     const prosper::gpu::ShaderResource* resource = item.resources->by_binding(2);
-    if (!resource || !resource->size || resource->cls != ResourceClass::ConstantBuffer)
+    // The matched MUBUF instruction uses idxen with the direct V# in s[0:3]. Its element address and
+    // store conversion therefore still depend on the live descriptor: only the observed 16-byte,
+    // four-dword contract is equivalent to the raw record writes below. Similar shaders bound to a
+    // different descriptor must retain the normal translator/backend semantics.
+    if (!resource || !resource->size || resource->cls != ResourceClass::ConstantBuffer ||
+        resource->sgpr_base != 0 || item.resources->by_sgpr_base(0) != resource ||
+        resource->stride != 16 ||
+        resource->num_components != 4 ||
+        prosper::gpu::data_format_bytes(resource->format) != sizeof(uint32_t))
         return std::nullopt;
 
     const uint64_t dispatched_records =

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -28,6 +28,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <system_error>
 #include <thread>
@@ -776,14 +777,25 @@ bool persistent_compute_image_enabled(VkDeviceSize bytes,
     return enabled && bytes >= minimum;
 }
 
-VkDeviceSize persistent_compute_image_limit() {
-    static const VkDeviceSize limit = []() -> VkDeviceSize {
+VkDeviceSize persistent_compute_image_limit(
+    const VkPhysicalDeviceMemoryProperties& memory) {
+    static const std::optional<VkDeviceSize> override_limit = []()
+        -> std::optional<VkDeviceSize> {
         const char* value = std::getenv("PROSPER_COMPUTE_IMAGE_CACHE_MB");
-        const uint64_t mib = value ? std::strtoull(value, nullptr, 10) : 512ull;
+        if (!value) return std::nullopt;
+        const uint64_t mib = std::strtoull(value, nullptr, 10);
         if (mib > UINT64_MAX / (1024ull * 1024ull)) return VkDeviceSize{UINT64_MAX};
         return static_cast<VkDeviceSize>(mib) * 1024ull * 1024ull;
     }();
-    return limit;
+    if (override_limit) return *override_limit;
+
+    VkDeviceSize largest_local_heap = 0;
+    for (uint32_t index = 0; index < memory.memoryHeapCount; ++index) {
+        if (memory.memoryHeaps[index].flags & VK_MEMORY_HEAP_DEVICE_LOCAL_BIT)
+            largest_local_heap = std::max(largest_local_heap,
+                                          memory.memoryHeaps[index].size);
+    }
+    return compute_image_cache_default_limit_bytes(largest_local_heap);
 }
 
 uint32_t compute_write_watch_promotion_validations() {
@@ -1458,7 +1470,7 @@ struct VulkanComputeContext {
     }
 
     bool make_image_cache_room(VkDeviceSize bytes) {
-        const VkDeviceSize limit = persistent_compute_image_limit();
+        const VkDeviceSize limit = persistent_compute_image_limit(memory);
         if (bytes > limit) return false;
         while (image_cache_bytes > limit - bytes) {
             auto victim = image_cache.end();
@@ -1933,6 +1945,7 @@ struct VulkanComputeContext {
 
 VulkanComputeContext* g_live_compute_context = nullptr;
 std::atomic<uint64_t> g_sampled_image_upload_skips{0};
+std::atomic<uint64_t> g_cpu_fill_dispatches{0};
 
 struct BorrowedComputeImageLease {
     VulkanComputeContext* context = nullptr;
@@ -2438,6 +2451,69 @@ bool trace_compute_item(const prosper::gpu::ComputeItem& item) {
     return true;
 }
 
+std::optional<bool> execute_cpu_fast_path(const prosper::gpu::ComputeItem& item) {
+    using prosper::gpu::ComputeCpuFastPath;
+    using prosper::gpu::ResourceClass;
+    if (item.cpu_fast_path == ComputeCpuFastPath::None) return std::nullopt;
+    if (item.cpu_fast_path != ComputeCpuFastPath::FillSgprUvec4 ||
+        !item.resources || item.user_sgprs.size() < 8 ||
+        item.launch.local_x != 64 || item.launch.local_y != 1 || item.launch.local_z != 1 ||
+        !item.launch.groups_x || !item.launch.groups_y || !item.launch.groups_z)
+        return std::nullopt;
+
+    const prosper::gpu::ShaderResource* resource = item.resources->by_binding(2);
+    if (!resource || !resource->size || resource->cls != ResourceClass::ConstantBuffer)
+        return std::nullopt;
+
+    const uint64_t dispatched_records =
+        static_cast<uint64_t>(item.launch.groups_x) * item.launch.local_x;
+    const uint64_t records = item.launch.threads_x
+        ? std::min<uint64_t>(item.launch.threads_x, dispatched_records)
+        : dispatched_records;
+    if (!records || records > UINT64_MAX / 16u) return std::nullopt;
+    const uint64_t written_bytes = records * 16u;
+    if (written_bytes > resource->size || written_bytes > SIZE_MAX) return std::nullopt;
+
+    uint8_t* destination = nullptr;
+    if (resource->host_data && resource->host_data_size >= written_bytes) {
+        destination = resource->host_data;
+    } else if (resource->gpu_addr && written_bytes <= UINT32_MAX &&
+               prosper::gpu::guest_writable(
+                   resource->gpu_addr, static_cast<uint32_t>(written_bytes))) {
+        destination = reinterpret_cast<uint8_t*>(static_cast<uintptr_t>(resource->gpu_addr));
+    }
+    if (!destination) return std::nullopt;
+
+    if (!resource->host_data && resource->gpu_addr)
+        prosper::host::guest_write_watch_notify_host_write(
+            resource->gpu_addr, static_cast<size_t>(written_bytes));
+    const uint32_t pattern[4] = {
+        item.user_sgprs[4], item.user_sgprs[5], item.user_sgprs[6], item.user_sgprs[7]};
+    if (!(pattern[0] | pattern[1] | pattern[2] | pattern[3])) {
+        std::memset(destination, 0, static_cast<size_t>(written_bytes));
+    } else {
+        for (uint64_t record = 0; record < records; ++record)
+            std::memcpy(destination + record * sizeof(pattern), pattern, sizeof(pattern));
+    }
+    // Match the Vulkan path's conservative invalidation contract: padding beyond the exact launch
+    // remains untouched, but every alias of the declared resource must be considered stale.
+    if (resource->gpu_addr)
+        prosper::gpu::notify_guest_gpu_write(resource->gpu_addr, resource->size);
+    if (!resource->host_data && prosper::gpu::writer_provenance_enabled())
+        prosper::gpu::record_guest_write(
+            prosper::gpu::GuestWriterKind::ComputeBuffer,
+            resource->gpu_addr, resource->size, item.submit_no, item.dispatch_index,
+            item.command_order, item.code_addr);
+    g_cpu_fill_dispatches.fetch_add(1, std::memory_order_relaxed);
+    if (trace_compute_item(item))
+        std::fprintf(stderr,
+                     "[compute] CPU fill program 0x%llx records=%llu bytes=%llu\n",
+                     static_cast<unsigned long long>(item.code_addr),
+                     static_cast<unsigned long long>(records),
+                     static_cast<unsigned long long>(written_bytes));
+    return true;
+}
+
 bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& item) {
     using namespace prosper::gpu;
     using ComputeClock = std::chrono::steady_clock;
@@ -2448,6 +2524,10 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
     auto phase_writeback = phase_start;
     double pack_ms = 0.0;
     double layout_ms = 0.0;
+    double writeback_prepare_ms = 0.0;
+    double writeback_buffers_ms = 0.0;
+    double writeback_images_ms = 0.0;
+    double writeback_publish_ms = 0.0;
     const std::vector<uint32_t>& spirv = item.spirv;
     const bool trace = trace_compute_item(item);
     if (item.required_subgroup_size &&
@@ -2565,7 +2645,11 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         });
     // The phase timer is also useful for buffer-only kernels. Astro Bot's heaviest dispatcher writes
     // buffers exclusively, so the historical storage-image gate hid the actual frame bottleneck.
-    const bool phase_timing = std::getenv("PROSPER_COMPUTE_PHASE_TIMING") != nullptr;
+    const bool timing_trace_only =
+        std::getenv("PROSPER_COMPUTE_TIMING_TRACE_ONLY") != nullptr;
+    const bool phase_timing =
+        std::getenv("PROSPER_COMPUTE_PHASE_TIMING") != nullptr &&
+        (!timing_trace_only || trace);
     if (has_storage_images && !ctx.image_support) {
         static bool warned = false;
         if (!warned) { warned = true;
@@ -2899,7 +2983,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             }
             images_ready = false;
         };
-        const bool image_timing = std::getenv("PROSPER_COMPUTE_IMAGE_TIMING") != nullptr;
+        const bool image_timing =
+            std::getenv("PROSPER_COMPUTE_IMAGE_TIMING") != nullptr &&
+            (!timing_trace_only || trace);
         for (size_t i = 0; i < image_descriptors.size() && images_ready; i++) {
             const auto image_start = ComputeClock::now();
             const ShaderResource* r = item.resources->by_binding(image_descriptors[i].binding);
@@ -5124,6 +5210,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         }
         if (trace) std::fprintf(stderr, "[compute]   dispatch complete\n");
         phase_dispatch = ComputeClock::now();
+        const auto writeback_prepare_start = phase_dispatch;
 
         if (!compare_targets.empty()) {
             void* mapped = nullptr;
@@ -5174,6 +5261,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             }
         }
 
+        writeback_prepare_ms = std::chrono::duration<double, std::milli>(
+            ComputeClock::now() - writeback_prepare_start).count();
+        const auto writeback_buffers_start = ComputeClock::now();
         bool readback_ok = true;
         for (auto& buffer : buffers) {
             if (buffer.alias_of != SIZE_MAX || !buffer.writable) continue;
@@ -5285,7 +5375,10 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                    item.submit_no, item.dispatch_index,
                                    item.command_order, item.code_addr);
         }
+        writeback_buffers_ms = std::chrono::duration<double, std::milli>(
+            ComputeClock::now() - writeback_buffers_start).count();
         if (!readback_ok) break;
+        const auto writeback_images_start = ComputeClock::now();
         // Storage-image writeback (#590): copy exact-width texels or pack raw uvec4 channels back
         // into the guest format, then restore its linear or 3D tiled address layout and notify the
         // render side exactly like the buffer path.
@@ -5606,7 +5699,10 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                  bi.binding, (unsigned long long)r->gpu_addr, linear_bytes);
             }
         }
+        writeback_images_ms = std::chrono::duration<double, std::milli>(
+            ComputeClock::now() - writeback_images_start).count();
         if (!readback_ok) break;
+        const auto writeback_publish_start = ComputeClock::now();
         // Every storage image is back in GENERAL, all exact guest writebacks/notifications have
         // completed, and a failed dispatch cannot reach here. Publish only retained native results;
         // raw interchange images are never descriptor-compatible with a graphics sampled view.
@@ -5616,6 +5712,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 image.cache_candidate && image.persistent)
                 ctx.authorize_cached_image_export(image.cache_key);
         }
+        writeback_publish_ms = std::chrono::duration<double, std::milli>(
+            ComputeClock::now() - writeback_publish_start).count();
         ok = true;
         phase_writeback = ComputeClock::now();
     } while (false);
@@ -5679,7 +5777,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                      "[compute-phase] submit=%llu code=0x%llx ok=%u "
                      "setup_ms=%.2f setup_validate_ms=%.2f setup_buffers_ms=%.2f "
                      "pipeline_ms=%.2f dispatch_ms=%.2f "
-                     "writeback_ms=%.2f pack_ms=%.2f layout_ms=%.2f "
+                     "writeback_ms=%.2f writeback_prepare_ms=%.2f "
+                     "writeback_buffers_ms=%.2f writeback_images_ms=%.2f "
+                     "writeback_publish_ms=%.2f pack_ms=%.2f layout_ms=%.2f "
                      "cleanup_ms=%.2f total_ms=%.2f subgroup=%u\n",
                      (unsigned long long)item.submit_no, (unsigned long long)item.code_addr,
                      ok ? 1u : 0u, milliseconds(phase_start, phase_setup),
@@ -5687,6 +5787,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                      milliseconds(phase_setup, phase_pipeline),
                      milliseconds(phase_pipeline, phase_dispatch),
                      milliseconds(phase_dispatch, phase_writeback),
+                     writeback_prepare_ms, writeback_buffers_ms,
+                     writeback_images_ms, writeback_publish_ms,
                      pack_ms, layout_ms,
                      milliseconds(phase_writeback, phase_cleanup),
                      milliseconds(phase_start, phase_cleanup), item.required_subgroup_size);
@@ -5882,8 +5984,12 @@ bool execute_live_compute_items(const std::vector<prosper::gpu::ComputeItem>& it
     // backend can't bind yet, #590) must not abort the rest of the batch — that would regress
     // dispatches that executed before image bindings existed. Run all; report all-succeeded.
     bool all_ok = true;
-    for (const auto& item : items)
-        all_ok &= execute_item(context, item);
+    for (const auto& item : items) {
+        if (const std::optional<bool> cpu_result = execute_cpu_fast_path(item))
+            all_ok &= *cpu_result;
+        else
+            all_ok &= execute_item(context, item);
+    }
     if (timing_enabled) {
         struct TimingTotals { uint64_t calls = 0, dispatches = 0; double milliseconds = 0; };
         static TimingTotals totals;
@@ -5903,6 +6009,10 @@ bool execute_live_compute_items(const std::vector<prosper::gpu::ComputeItem>& it
                          (unsigned long long)totals.calls,
                          (unsigned long long)totals.dispatches,
                          totals.milliseconds / static_cast<double>(totals.calls));
+            std::fprintf(stderr,
+                         "[render-timing] compute_cpu_fast fills=%llu\n",
+                         (unsigned long long)g_cpu_fill_dispatches.load(
+                             std::memory_order_relaxed));
             const ComputeMemoryPoolStats pool = context.memory_pool_stats();
             std::fprintf(stderr,
                          "[render-timing] compute_memory_pool hits=%llu misses=%llu cached=%zu "

--- a/prosper/frontends/shared/live_compute.hpp
+++ b/prosper/frontends/shared/live_compute.hpp
@@ -26,6 +26,17 @@ constexpr bool compute_image_cache_default_eligible(
     return bytes >= compute_image_cache_default_minimum_bytes(image_class);
 }
 
+// Keep enough persistent image residency for modern multi-pass workloads without claiming an
+// unreasonable share of small discrete GPUs. The 512 MiB historical floor remains appropriate for
+// a 4 GiB heap, while larger devices contribute one eighth of their local heap up to 2 GiB. An
+// explicit PROSPER_COMPUTE_IMAGE_CACHE_MB value still overrides this production default.
+constexpr uint64_t compute_image_cache_default_limit_bytes(uint64_t device_local_bytes) {
+    constexpr uint64_t floor = 512ull * 1024ull * 1024ull;
+    constexpr uint64_t ceiling = 2048ull * 1024ull * 1024ull;
+    const uint64_t scaled = device_local_bytes / 8ull;
+    return scaled < floor ? floor : (scaled > ceiling ? ceiling : scaled);
+}
+
 // Pack one raw float32 channel to UNORM8 using the storage-image conversion contract. Kept public
 // so the optimized scalar conversion can be checked directly against the previous lround path.
 uint8_t storage_pack_unorm8(uint32_t float_bits);

--- a/prosper/frontends/shared/live_compute.hpp
+++ b/prosper/frontends/shared/live_compute.hpp
@@ -113,6 +113,9 @@ uint64_t live_compute_buffer_gpu_result_skips();
 // Monotonic diagnostic count of retained sampled-image hits whose validated source omitted upload.
 // Capture/replay tests use this to prove residency without relying on timing-sensitive assertions.
 uint64_t live_compute_sampled_image_upload_skips();
+// Monotonic count of exact compute fills executed by the structurally guarded CPU path. Tests use
+// the delta to distinguish the intended bypass from a successful Vulkan fallback.
+uint64_t live_compute_cpu_fill_dispatches();
 // Monotonic attribution for storage-result source validation. Production-backend tests use this to
 // prove that changing proven-full results do not copy a redundant guest-byte snapshot.
 uint64_t live_compute_storage_result_snapshot_bytes();

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -316,6 +316,16 @@ struct ComputeLaunchDimensions {
 // they are already hardware/Vulkan workgroup counts. Zero local-size registers fall back to one.
 ComputeLaunchDimensions resolve_compute_launch(const GpuState::Dispatch& dispatch);
 
+// A small set of exact, structurally recognized compute programs can execute directly against
+// their guest backing. Classification is based on the raw RDNA2 instruction stream, never a title
+// address; an unrecognized or partially matching program always uses the ordinary Vulkan backend.
+enum class ComputeCpuFastPath : uint8_t {
+    None,
+    FillSgprUvec4,
+};
+
+ComputeCpuFastPath classify_compute_cpu_fast_path(const uint32_t* code, size_t dwords);
+
 // Read the exact bound compute program from a dispatch's retained register snapshot, falling back to
 // the submit state for hand-built records without a snapshot. Capture selectors use this before DMA-
 // ordered realization, so a target program remains discoverable even when the pre-realized list is empty.
@@ -332,6 +342,7 @@ struct ComputeItem {
     uint64_t submit_no = 0;
     uint64_t command_order = 0;
     uint32_t required_subgroup_size = 0;
+    ComputeCpuFastPath cpu_fast_path = ComputeCpuFastPath::None;
     // Capture v39 retains the raw compute program and every semantic launch/recompiler input. The
     // stored SPIR-V remains the default replay artifact; --recompile-raw may rebuild it with the
     // current translator and replay device's optional format/subgroup capabilities.

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -3455,6 +3455,22 @@ ComputeLaunchDimensions resolve_compute_launch(const GpuState::Dispatch& d) {
     return out;
 }
 
+ComputeCpuFastPath classify_compute_cpu_fast_path(const uint32_t* code, size_t dwords) {
+    // Compiler-generated 16-byte buffer fill:
+    //   record = (tgid.x << 6) + tid.x; buffer[record] = {s4, s5, s6, s7}
+    // This exact stream is used by Dead Cells and very frequently by Astro Bot. Keep the match
+    // byte-exact so a different address calculation, descriptor, component mask, or predicate can
+    // never be mistaken for a fill.
+    static constexpr uint32_t kFillSgprUvec4[] = {
+        0xd7460004u, 0x04010c08u, 0x7e000204u, 0x7e020205u, 0x7e040206u,
+        0x7e060207u, 0xe01c2000u, 0x80000004u, 0xbf810000u,
+    };
+    if (code && dwords >= std::size(kFillSgprUvec4) &&
+        std::equal(std::begin(kFillSgprUvec4), std::end(kFillSgprUvec4), code))
+        return ComputeCpuFastPath::FillSgprUvec4;
+    return ComputeCpuFastPath::None;
+}
+
 uint64_t compute_dispatch_code_addr(const GpuState& submit, const GpuState::Dispatch& dispatch) {
     namespace P = prosper::agc::Pm4;
     const GpuState& state = dispatch.state ? *dispatch.state : submit;
@@ -3842,6 +3858,8 @@ std::vector<ComputeItem> realize_compute_dispatches(
             (const uint32_t*)(uintptr_t)code_addr, 0x10000, table.get(), config);
         item.user_sgprs = config.user_sgprs;
         item.required_subgroup_size = config.native_subgroup_size;
+        item.cpu_fast_path = classify_compute_cpu_fast_path(
+            reinterpret_cast<const uint32_t*>(static_cast<uintptr_t>(code_addr)), shader_dwords);
         item.recompile_config = config;
         // Capture-bound SPIR-V deliberately uses the device-independent storage path, but v39 raw
         // replay needs the capability mask that a normal live dispatch would have used.

--- a/prosper/tests/test_game_compute.cpp
+++ b/prosper/tests/test_game_compute.cpp
@@ -467,6 +467,7 @@ int main() {
     item.user_sgprs = config.user_sgprs;
     item.resources = std::make_shared<ShaderResourceTable>(rt);
     item.launch.threads_x = records;
+    item.launch.threads_y = item.launch.threads_z = 1;
     item.launch.local_x = 64;
     item.launch.groups_x = 3;
     item.launch.local_y = item.launch.local_z = 1;
@@ -475,6 +476,8 @@ int main() {
     item.dispatch_index = 7;
     item.submit_no = 11;
     item.command_order = 70;
+    item.recompile_config = config;
+    item.recompile_config_available = true;
     CHECK(prosper::frontend::execute_live_compute_items({item}),
           "production live backend executes the game kernel");
     CHECK(result.size() == launched_records * 4, "compute resource retains its padded declared size");
@@ -502,8 +505,14 @@ int main() {
     std::fill(result.begin(), result.end(), 0xddddddddu);
     ComputeItem cpu_fill_item = item;
     cpu_fill_item.cpu_fast_path = ComputeCpuFastPath::FillSgprUvec4;
+    uint32_t cpu_fill_write_notifications = 0;
+    set_guest_gpu_write_observer([&](uint64_t addr, uint64_t size) {
+        if (addr == buffer.gpu_addr && size == buffer.size)
+            ++cpu_fill_write_notifications;
+    });
     CHECK(prosper::frontend::execute_live_compute_items({cpu_fill_item}),
           "exact buffer-fill program executes through the CPU fast path");
+    set_guest_gpu_write_observer({});
     bool cpu_fill_matches = true;
     for (uint32_t record = 0; record < records && cpu_fill_matches; ++record)
         for (uint32_t component = 0; component < 4; ++component)
@@ -512,8 +521,43 @@ int main() {
     for (uint32_t record = records; record < launched_records; ++record)
         for (uint32_t component = 0; component < 4; ++component)
             cpu_fill_padding_untouched &= result[record * 4 + component] == 0xddddddddu;
-    CHECK(cpu_fill_matches && cpu_fill_padding_untouched,
-          "CPU buffer fill matches Vulkan output and preserves padded invocations");
+    CHECK(cpu_fill_matches && cpu_fill_padding_untouched &&
+              cpu_fill_write_notifications == 1,
+          "CPU fill matches Vulkan, preserves padded lanes, and invalidates the declared range");
+
+    ShaderResourceTable narrow_stride_rt = rt;
+    narrow_stride_rt.resources[0].stride = 8;
+    const std::vector<uint32_t> narrow_stride_spirv = recompile_compute(
+        code, std::size(code), &narrow_stride_rt, config);
+    CHECK(!narrow_stride_spirv.empty(), "alternate-stride fill kernel recompiles");
+    if (!narrow_stride_spirv.empty()) {
+        std::fill(result.begin(), result.end(), 0xabababab);
+        ComputeItem narrow_stride_item = cpu_fill_item;
+        narrow_stride_item.spirv = narrow_stride_spirv;
+        narrow_stride_item.resources =
+            std::make_shared<ShaderResourceTable>(narrow_stride_rt);
+        CHECK(prosper::frontend::execute_live_compute_items({narrow_stride_item}),
+              "noncanonical fill descriptor falls back to Vulkan");
+        CHECK(result[300] == 0xabababab,
+              "CPU fast path does not replace the descriptor's eight-byte stride semantics");
+    }
+
+    ComputeShaderConfig extra_user_config = config;
+    extra_user_config.user_sgprs.push_back(0);
+    const std::vector<uint32_t> extra_user_spirv = recompile_compute(
+        code, std::size(code), &rt, extra_user_config);
+    CHECK(!extra_user_spirv.empty(), "alternate user-SGPR fill kernel recompiles");
+    if (!extra_user_spirv.empty()) {
+        std::fill(result.begin(), result.end(), 0xcdcdcdcdu);
+        ComputeItem extra_user_item = cpu_fill_item;
+        extra_user_item.spirv = extra_user_spirv;
+        extra_user_item.user_sgprs = extra_user_config.user_sgprs;
+        extra_user_item.recompile_config = extra_user_config;
+        CHECK(prosper::frontend::execute_live_compute_items({extra_user_item}),
+              "shifted TGID input fill falls back to Vulkan");
+        CHECK(result[100 * 4] == 0xcdcdcdcdu,
+              "CPU fast path requires TGID.x to occupy the shader's exact s8 input");
+    }
 
     uint32_t unchanged_write_notifications = 0;
     set_guest_gpu_write_observer([&](uint64_t addr, uint64_t size) {

--- a/prosper/tests/test_game_compute.cpp
+++ b/prosper/tests/test_game_compute.cpp
@@ -50,6 +50,17 @@ int main() {
           prosper::frontend::compute_image_cache_default_eligible(
               4ull * 1024ull, ComputeImageCacheClass::storage),
           "image residency policy includes each crossover exactly without caching smaller inputs");
+    CHECK(prosper::frontend::compute_image_cache_default_limit_bytes(0) ==
+              512ull * 1024ull * 1024ull &&
+          prosper::frontend::compute_image_cache_default_limit_bytes(
+              4ull * 1024ull * 1024ull * 1024ull) == 512ull * 1024ull * 1024ull &&
+          prosper::frontend::compute_image_cache_default_limit_bytes(
+              8ull * 1024ull * 1024ull * 1024ull) == 1024ull * 1024ull * 1024ull &&
+          prosper::frontend::compute_image_cache_default_limit_bytes(
+              16ull * 1024ull * 1024ull * 1024ull) == 2048ull * 1024ull * 1024ull &&
+          prosper::frontend::compute_image_cache_default_limit_bytes(UINT64_MAX) ==
+              2048ull * 1024ull * 1024ull,
+          "image cache limit scales with local memory and retains bounded floor and ceiling");
     CHECK(prosper::frontend::storage_writeback_can_tile_mapped_bytes(
               true, 27, false, false),
           "exact-width tiled storage can feed mapped bytes directly to the tiler");
@@ -423,6 +434,17 @@ int main() {
         code, sizeof(code) / sizeof(code[0]), &rt, config);
     CHECK(!spirv.empty(), "real Dead Cells compute kernel recompiles");
     if (spirv.empty()) return 1;
+    CHECK(classify_compute_cpu_fast_path(code, std::size(code)) ==
+              ComputeCpuFastPath::FillSgprUvec4 &&
+          classify_compute_cpu_fast_path(code, std::size(code) - 1) ==
+              ComputeCpuFastPath::None,
+          "buffer-fill CPU fast path requires the complete exact RDNA2 program");
+    std::array<uint32_t, std::size(code)> altered_fill_code{};
+    std::copy_n(code, std::size(code), altered_fill_code.begin());
+    altered_fill_code[6] ^= 1u;
+    CHECK(classify_compute_cpu_fast_path(altered_fill_code.data(), altered_fill_code.size()) ==
+              ComputeCpuFastPath::None,
+          "buffer-fill CPU fast path rejects a one-bit instruction change");
     ComputeShaderConfig alternate_config = config;
     alternate_config.user_sgprs[4] ^= 0xffffffffu;
     alternate_config.user_sgprs[7] ^= 0x13579bdfu;
@@ -476,6 +498,22 @@ int main() {
             padded_lanes_untouched &= result[record * 4 + component] == 0xcccccccc;
     CHECK(padded_lanes_untouched,
           "partial workgroup suppresses all 62 padded invocations without a guest bounds check");
+
+    std::fill(result.begin(), result.end(), 0xddddddddu);
+    ComputeItem cpu_fill_item = item;
+    cpu_fill_item.cpu_fast_path = ComputeCpuFastPath::FillSgprUvec4;
+    CHECK(prosper::frontend::execute_live_compute_items({cpu_fill_item}),
+          "exact buffer-fill program executes through the CPU fast path");
+    bool cpu_fill_matches = true;
+    for (uint32_t record = 0; record < records && cpu_fill_matches; ++record)
+        for (uint32_t component = 0; component < 4; ++component)
+            cpu_fill_matches &= result[record * 4 + component] == expected[component];
+    bool cpu_fill_padding_untouched = true;
+    for (uint32_t record = records; record < launched_records; ++record)
+        for (uint32_t component = 0; component < 4; ++component)
+            cpu_fill_padding_untouched &= result[record * 4 + component] == 0xddddddddu;
+    CHECK(cpu_fill_matches && cpu_fill_padding_untouched,
+          "CPU buffer fill matches Vulkan output and preserves padded invocations");
 
     uint32_t unchanged_write_notifications = 0;
     set_guest_gpu_write_observer([&](uint64_t addr, uint64_t size) {

--- a/prosper/tests/test_game_compute.cpp
+++ b/prosper/tests/test_game_compute.cpp
@@ -510,6 +510,8 @@ int main() {
         if (addr == buffer.gpu_addr && size == buffer.size)
             ++cpu_fill_write_notifications;
     });
+    const uint64_t cpu_fills_before =
+        prosper::frontend::live_compute_cpu_fill_dispatches();
     CHECK(prosper::frontend::execute_live_compute_items({cpu_fill_item}),
           "exact buffer-fill program executes through the CPU fast path");
     set_guest_gpu_write_observer({});
@@ -522,7 +524,9 @@ int main() {
         for (uint32_t component = 0; component < 4; ++component)
             cpu_fill_padding_untouched &= result[record * 4 + component] == 0xddddddddu;
     CHECK(cpu_fill_matches && cpu_fill_padding_untouched &&
-              cpu_fill_write_notifications == 1,
+              cpu_fill_write_notifications == 1 &&
+              prosper::frontend::live_compute_cpu_fill_dispatches() ==
+                  cpu_fills_before + 1,
           "CPU fill matches Vulkan, preserves padded lanes, and invalidates the declared range");
 
     ShaderResourceTable narrow_stride_rt = rt;
@@ -536,9 +540,13 @@ int main() {
         narrow_stride_item.spirv = narrow_stride_spirv;
         narrow_stride_item.resources =
             std::make_shared<ShaderResourceTable>(narrow_stride_rt);
+        const uint64_t narrow_stride_fills_before =
+            prosper::frontend::live_compute_cpu_fill_dispatches();
         CHECK(prosper::frontend::execute_live_compute_items({narrow_stride_item}),
               "noncanonical fill descriptor falls back to Vulkan");
-        CHECK(result[300] == 0xabababab,
+        CHECK(result[300] == 0xabababab &&
+                  prosper::frontend::live_compute_cpu_fill_dispatches() ==
+                      narrow_stride_fills_before,
               "CPU fast path does not replace the descriptor's eight-byte stride semantics");
     }
 
@@ -553,9 +561,13 @@ int main() {
         extra_user_item.spirv = extra_user_spirv;
         extra_user_item.user_sgprs = extra_user_config.user_sgprs;
         extra_user_item.recompile_config = extra_user_config;
+        const uint64_t extra_user_fills_before =
+            prosper::frontend::live_compute_cpu_fill_dispatches();
         CHECK(prosper::frontend::execute_live_compute_items({extra_user_item}),
               "shifted TGID input fill falls back to Vulkan");
-        CHECK(result[100 * 4] == 0xcdcdcdcdu,
+        CHECK(result[100 * 4] == 0xcdcdcdcdu &&
+                  prosper::frontend::live_compute_cpu_fill_dispatches() ==
+                      extra_user_fills_before,
               "CPU fast path requires TGID.x to occupy the shader's exact s8 input");
     }
 


### PR DESCRIPTION
Refs #1459

## Problem

Astro Bot reaches the title and world-map GPU workload, but the map runs at roughly 8.3-8.6 FPS. A child-process sampling profile and routed timing runs show that the physical GPU is not the dominant limit: host-side image copies, exact cache validation, FP16 conversion, and retile work dominate.

The persistent compute-image cache had a fixed 512 MiB limit. The world-map working set exceeds that cap, so retained sampled images and exact storage-result baselines churn. In a 155-second 512 MiB control run, Prosper copied about 80.2 GiB of compute-image source snapshots and discarded 513 cached allocations.

A compiler-generated nine-dword SGPR uvec4 fill kernel is also dispatched thousands of times during the route even though its complete behavior is a bounded 16-byte-per-record guest write.

## Change

- Scale persistent compute-image capacity to one eighth of the largest device-local Vulkan heap, with a 512 MiB floor and 2 GiB ceiling.
- Preserve `PROSPER_COMPUTE_IMAGE_CACHE_MB` as an exact diagnostic/user override.
- Recognize the exact observed RDNA2 fill program structurally and execute it directly against validated writable guest/capture backing.
- Fall back to the normal Vulkan path for every unrecognized program, unsupported launch shape, invalid resource, or inaccessible destination.
- Preserve guest write-watch notification, renderer/cache invalidation, and writer provenance on the CPU path.
- Add trace-only compute phase filtering and split writeback timing into prepare, buffer, image, and publish phases for future profiling.
- Add regressions for cache-limit scaling, exact program classification (including a one-bit mismatch), CPU/Vulkan output equivalence, and padded-lane preservation.

## Routed result

Linux `prosper-app`, native scale/every-submit rendering, real VAAPI video/audio, scripted Astro Bot title-to-world-map route:

- 512 MiB control: approximately 8.3-8.6 FPS
- 1 GiB diagnostic: approximately 13.0-13.8 FPS
- adaptive 2 GiB default on the tested integrated GPU: approximately 13-15 FPS
- snapshot traffic at the end of comparable routes: approximately 80.2 GiB -> 39.4 GiB

These are ballpark live numbers because other lightweight frontend tests can run on the machine, but the cache-capacity A/B is repeatable and large. The intro remains approximately 20 FPS because it refreshes dynamic video images rather than reusing the world-map working set.

This does not claim new visual progression: the world map remains dark/incorrect under #1459, so there is no new representative screenshot to attach.

## Risk and scope

The adaptive cache affects shared compute workloads. Small devices retain the historical 512 MiB floor; larger heaps contribute at most one eighth and never more than 2 GiB. Vulkan allocation failure behavior and the explicit override remain unchanged. The CPU path is intentionally narrower than the shader translator and cannot activate on a merely similar kernel.

## Verification

Exact head includes current `origin/master`.

- Full CMake build: passed
- `ctest --test-dir build-astrobot-fmv --output-on-failure -R '^(compute_exec_differential|game_compute_exec|game_compute_exec_no_adaptive_storage_result|gpu_execute)$'`: 4/4 passed
- `git diff --check origin/master...HEAD`: clean
- Multiple bounded 140-155 second routed Astro Bot GPU runs: reached title and world map; no process left running
- Snapshot matrix not run: this is routine development, and project policy reserves the full matrix for release verification