### PR TITLE
Lower known Astro Bot BVH traversal safely

### DIFF
--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -2454,17 +2454,25 @@ bool trace_compute_item(const prosper::gpu::ComputeItem& item) {
 void maybe_dump_traced_compute_spirv(const prosper::gpu::ComputeItem& item, bool trace) {
     const char* path = std::getenv("PROSPER_COMPUTELOG_SPIRV");
     if (!trace || !path || !*path || item.spirv.empty()) return;
+    uint64_t module_hash = 1469598103934665603ull;
+    for (uint32_t word : item.spirv) {
+        module_hash ^= word;
+        module_hash *= 1099511628211ull;
+    }
     static std::mutex mutex;
     static std::unordered_set<uint64_t> dumped;
     std::lock_guard lock(mutex);
-    if (!dumped.insert(item.code_addr).second) return;
+    if (dumped.contains(module_hash)) return;
     FILE* file = std::fopen(path, "wb");
     const size_t bytes = item.spirv.size() * sizeof(uint32_t);
     const bool ok = file && std::fwrite(item.spirv.data(), 1, bytes, file) == bytes;
     if (file) std::fclose(file);
+    if (ok) dumped.insert(module_hash);
     std::fprintf(stderr,
-                 "[compute]   traced SPIR-V program=0x%llx words=%zu path=%s result=%s\n",
-                 static_cast<unsigned long long>(item.code_addr), item.spirv.size(), path,
+                 "[compute]   traced SPIR-V program=0x%llx module=%016llx words=%zu "
+                 "path=%s result=%s\n",
+                 static_cast<unsigned long long>(item.code_addr),
+                 static_cast<unsigned long long>(module_hash), item.spirv.size(), path,
                  ok ? "written" : "failed");
 }
 

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -2451,6 +2451,23 @@ bool trace_compute_item(const prosper::gpu::ComputeItem& item) {
     return true;
 }
 
+void maybe_dump_traced_compute_spirv(const prosper::gpu::ComputeItem& item, bool trace) {
+    const char* path = std::getenv("PROSPER_COMPUTELOG_SPIRV");
+    if (!trace || !path || !*path || item.spirv.empty()) return;
+    static std::mutex mutex;
+    static std::unordered_set<uint64_t> dumped;
+    std::lock_guard lock(mutex);
+    if (!dumped.insert(item.code_addr).second) return;
+    FILE* file = std::fopen(path, "wb");
+    const size_t bytes = item.spirv.size() * sizeof(uint32_t);
+    const bool ok = file && std::fwrite(item.spirv.data(), 1, bytes, file) == bytes;
+    if (file) std::fclose(file);
+    std::fprintf(stderr,
+                 "[compute]   traced SPIR-V program=0x%llx words=%zu path=%s result=%s\n",
+                 static_cast<unsigned long long>(item.code_addr), item.spirv.size(), path,
+                 ok ? "written" : "failed");
+}
+
 std::optional<bool> execute_cpu_fast_path(const prosper::gpu::ComputeItem& item) {
     using prosper::gpu::ComputeCpuFastPath;
     using prosper::gpu::ResourceClass;
@@ -2542,6 +2559,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
     double writeback_publish_ms = 0.0;
     const std::vector<uint32_t>& spirv = item.spirv;
     const bool trace = trace_compute_item(item);
+    maybe_dump_traced_compute_spirv(item, trace);
     if (item.required_subgroup_size &&
         (!ctx.borrowed || !ctx.native_subgroup_contract ||
          item.required_subgroup_size < ctx.min_native_subgroup_size ||
@@ -4680,7 +4698,11 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     VK_PIPELINE_SHADER_STAGE_CREATE_REQUIRE_FULL_SUBGROUPS_BIT;
             }
             cpci.layout = pipeline_layout;
-            if (trace) std::fprintf(stderr, "[compute]   creating compute pipeline\n");
+            if (trace)
+                std::fprintf(stderr,
+                             "[compute]   creating compute pipeline words=%zu descriptors=%zu "
+                             "subgroup=%u\n",
+                             spirv.size(), descriptors.size(), item.required_subgroup_size);
             if (!vk_ok(vkCreateComputePipelines(ctx.device, ctx.pipeline_cache, 1, &cpci, nullptr,
                                                 &pipeline), "compute-pipeline")) break;
             if (trace) std::fprintf(stderr, "[compute]   compute pipeline ready\n");

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -562,7 +562,17 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
     // exact-match identity and immutable CPU snapshot used by live compute (#590).
     prosper::gpu::set_live_target_query([invalidate_ds](uint64_t addr) {
         drain_guest_gpu_writes(g_rtt, invalidate_ds);
-        return g_rtt.count(addr) != 0;
+        auto it = g_rtt.find(addr);
+        if (it == g_rtt.end()) return false;
+        const RttSurf& surface = it->second;
+        const VkFormat format = prosper::test::backend_color_format(surface.format);
+        const uint32_t bytes_per_pixel =
+            prosper::test::backend_color_bytes_per_pixel(format);
+        const bool has_cpu_snapshot = surface.rgba &&
+            prosper::frontend::live_rtt_cpu_snapshot_matches(
+                surface.w, surface.h, bytes_per_pixel, surface.rgba->size());
+        return prosper::frontend::live_rtt_compute_authoritative(
+            surface.gpu_valid, has_cpu_snapshot);
     });
     prosper::gpu::set_live_target_reader(
         [invalidate_ds](uint64_t addr, prosper::gpu::LiveTargetSnapshot& snapshot) {

--- a/prosper/frontends/shared/rtt_authority.hpp
+++ b/prosper/frontends/shared/rtt_authority.hpp
@@ -24,6 +24,13 @@ constexpr bool live_rtt_gpu_importable(bool gpu_valid, bool has_cpu_snapshot) {
     return authority == LiveRttAuthority::gpu || authority == LiveRttAuthority::mirrored;
 }
 
+// Compute must override guest backing only while the renderer actually owns a current pixel
+// representation. A cache entry can survive with identity/metadata alone after an invalidation;
+// treating that stale shell as authoritative makes a later dispatch reject valid guest bytes.
+constexpr bool live_rtt_compute_authoritative(bool gpu_valid, bool has_cpu_snapshot) {
+    return live_rtt_authority(gpu_valid, has_cpu_snapshot) != LiveRttAuthority::none;
+}
+
 constexpr bool live_rtt_cpu_snapshot_matches(uint32_t width, uint32_t height,
                                              uint32_t bytes_per_pixel,
                                              size_t snapshot_bytes) {

--- a/prosper/frontends/shared/test_rtt_scale.cpp
+++ b/prosper/frontends/shared/test_rtt_scale.cpp
@@ -17,6 +17,7 @@ using prosper::frontend::rtt_scaled_axis;
 using prosper::frontend::rtt_scaled_extent_compatible;
 using prosper::frontend::LiveRttAuthority;
 using prosper::frontend::live_rtt_authority;
+using prosper::frontend::live_rtt_compute_authoritative;
 using prosper::frontend::live_rtt_cpu_snapshot_matches;
 using prosper::frontend::live_rtt_gpu_importable;
 using prosper::frontend::LiveRttGuestWriteEffect;
@@ -87,6 +88,10 @@ int main() {
     CHECK(live_rtt_gpu_importable(true, true));
     CHECK(!live_rtt_gpu_importable(false, true));
     CHECK(!live_rtt_gpu_importable(false, false));
+    CHECK(live_rtt_compute_authoritative(true, false));
+    CHECK(live_rtt_compute_authoritative(true, true));
+    CHECK(live_rtt_compute_authoritative(false, true));
+    CHECK(!live_rtt_compute_authoritative(false, false));
     CHECK(live_rtt_cpu_snapshot_matches(1920, 1080, 8, 1920ull * 1080 * 8));
     CHECK(!live_rtt_cpu_snapshot_matches(1920, 1080, 8, 1920ull * 1080 * 4));
     CHECK(!live_rtt_cpu_snapshot_matches(0, 1080, 8, 0));

--- a/prosper/src/gpu/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc_shader_layout.cpp
@@ -167,6 +167,7 @@ DecodedBvhDescriptor decode_bvh_descriptor(const uint32_t v[4]) {
     d.base = base_256 << 8;
     d.size_bytes = (size_64_minus_one + 1u) << 6;
     d.type = static_cast<uint8_t>(v[3] >> 28);
+    d.box_grow = static_cast<uint8_t>((v[1] >> 23) & 0xFFu);
     d.triangle_return_mode = (v[3] & (1u << 24)) != 0;
     d.box_node_64b = (v[3] & (1u << 20)) != 0;
     d.sort_enabled = (v[1] & (1u << 31)) != 0;

--- a/prosper/src/gpu/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc_shader_layout.cpp
@@ -158,6 +158,21 @@ DecodedBufferDescriptor decode_buffer_descriptor(const uint32_t v[4]) {
     return d;
 }
 
+DecodedBvhDescriptor decode_bvh_descriptor(const uint32_t v[4]) {
+    DecodedBvhDescriptor d;
+    const uint64_t base_256 = static_cast<uint64_t>(v[0]) |
+                              (static_cast<uint64_t>(v[1] & 0xFFu) << 32);
+    const uint64_t size_64_minus_one = static_cast<uint64_t>(v[2]) |
+                                       (static_cast<uint64_t>(v[3] & 0x3FFu) << 32);
+    d.base = base_256 << 8;
+    d.size_bytes = (size_64_minus_one + 1u) << 6;
+    d.type = static_cast<uint8_t>(v[3] >> 28);
+    d.triangle_return_mode = (v[3] & (1u << 24)) != 0;
+    d.box_node_64b = (v[3] & (1u << 20)) != 0;
+    d.sort_enabled = (v[1] & (1u << 31)) != 0;
+    return d;
+}
+
 // The Gen5 T# carries a 9-bit COMBINED IMG_FMT at dword1 bits[28:20] (the GFX10 image-format enum,
 // not the GCN dfmt/nfmt split). Values 1..77 share the buffer-format numbering decoded by
 // rdna2_buffer_format above; image-only values sit at 128+ — SRGB at 128..130, BC1..BC7 at 169..182 —

--- a/prosper/src/gpu/agc_shader_layout.hpp
+++ b/prosper/src/gpu/agc_shader_layout.hpp
@@ -127,6 +127,7 @@ struct DecodedBvhDescriptor {
     uint64_t base = 0;
     uint64_t size_bytes = 0;
     uint8_t type = 0;
+    uint8_t box_grow = 0;
     bool triangle_return_mode = false;
     bool box_node_64b = false;
     bool sort_enabled = false;

--- a/prosper/src/gpu/agc_shader_layout.hpp
+++ b/prosper/src/gpu/agc_shader_layout.hpp
@@ -120,6 +120,21 @@ struct DecodedBufferDescriptor {
 // Decode a 4-dword V# (RDNA2/Gen5 buffer resource). Pure; exposed for reuse + testing.
 DecodedBufferDescriptor decode_buffer_descriptor(const uint32_t v[4]);
 
+// A decoded GFX10 BVH resource descriptor (4 dwords). Unlike an image T#, IMAGE_BVH_INTERSECT_RAY
+// consumes a compact descriptor whose base is expressed in 256-byte units and whose size is a
+// 42-bit, 64-byte-unit count-minus-one. TYPE=8 identifies the BVH descriptor class.
+struct DecodedBvhDescriptor {
+    uint64_t base = 0;
+    uint64_t size_bytes = 0;
+    uint8_t type = 0;
+    bool triangle_return_mode = false;
+    bool box_node_64b = false;
+    bool sort_enabled = false;
+};
+
+// Decode a 4-dword GFX10 BVH descriptor. Pure; exposed for reuse + testing.
+DecodedBvhDescriptor decode_bvh_descriptor(const uint32_t v[4]);
+
 // A decoded image resource descriptor (T#, 8 dwords / 256-bit). Layout = Kyty ShaderTextureResource
 // Gen5 getters (Base40/Width5/Height5/Format/TileMode). `base` is the byte address of the texel data
 // in unified guest memory. `tile_mode` 0 = linear (no detiling needed); non-zero = GPU-tiled. GFX10

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -84,7 +84,9 @@ constexpr char kMagic[8] = {'P','R','G','P','C','A','P','\0'};
 // v39: retain each realized compute program's raw RDNA2 stream plus its semantic launch/recompiler
 // inputs. This lets gpu_replay --recompile-raw exercise current compute translation instead of the
 // stored capture-safe SPIR-V, including native-width storage formats supported by the replay device.
-constexpr uint32_t kVersion = 39;
+// v40: retain the BVH descriptor BOX_GROW value for every resource table. The software RTIP 1.1
+// lowering uses it to reproduce the guest's conservative box-interval expansion exactly.
+constexpr uint32_t kVersion = 40;
 constexpr uint32_t kEndian = 0x01020304u;
 constexpr uint64_t kMaxFileBytes = 4ull << 30;
 constexpr uint64_t kMaxBlobBytes = 1ull << 30;
@@ -2062,6 +2064,40 @@ bool serialize_gpu_capture(const GpuCaptureFile& c, std::vector<uint8_t>& bytes,
         w.u32(config.native_subgroup_size);
         w.u32(config.native_storage_format_support);
     }
+    // v40 keeps the BVH BOX_GROW descriptor field in deterministic resource-table order. Failed
+    // stages are included because raw diagnostic replay may recompile those tables later.
+    uint64_t bvh_resource_count = resource_depth_count;
+    for (const auto& diagnostic : c.failure_diagnostics)
+        for (const auto& stage : diagnostic.stages)
+            bvh_resource_count += stage.resource_table.resources.size();
+    if (bvh_resource_count > UINT32_MAX) {
+        error = "invalid BVH resource-state count";
+        return false;
+    }
+    w.u32(static_cast<uint32_t>(bvh_resource_count));
+    auto write_bvh_box_grow = [&](const GpuCapturedTable& table) {
+        for (const auto& captured : table.resources) {
+            if (captured.resource.bvh_box_grow > 0xFFu) return false;
+            w.u32(captured.resource.bvh_box_grow);
+        }
+        return true;
+    };
+    for (const auto& draw : c.draws)
+        if (!write_bvh_box_grow(draw.vrt) || !write_bvh_box_grow(draw.prt)) {
+            error = "invalid BVH box-grow value";
+            return false;
+        }
+    for (const auto& compute : c.computes)
+        if (!write_bvh_box_grow(compute.resources)) {
+            error = "invalid BVH box-grow value";
+            return false;
+        }
+    for (const auto& diagnostic : c.failure_diagnostics)
+        for (const auto& stage : diagnostic.stages)
+            if (!write_bvh_box_grow(stage.resource_table)) {
+                error = "invalid BVH box-grow value";
+                return false;
+            }
     if (w.data.size() > kMaxFileBytes) { error = "capture file exceeds 4 GiB"; return false; }
     bytes = std::move(w.data);
     return true;
@@ -2912,6 +2948,35 @@ bool deserialize_gpu_capture(const std::vector<uint8_t>& bytes, GpuCaptureFile& 
             config.packed_r11_storage = (flags & 16u) != 0;
             if (!validate_compute_recompile_state(compute, error)) return false;
         }
+    }
+    if (version >= 40) {   // BVH descriptor BOX_GROW per resource
+        size_t expected = 0;
+        for (const auto& draw : c.draws)
+            expected += draw.vrt.resources.size() + draw.prt.resources.size();
+        for (const auto& compute : c.computes)
+            expected += compute.resources.resources.size();
+        for (const auto& diagnostic : c.failure_diagnostics)
+            for (const auto& stage : diagnostic.stages)
+                expected += stage.resource_table.resources.size();
+        uint32_t count = 0;
+        if (!r.u32(count) || count != expected) {
+            error = "invalid BVH resource-state count";
+            return false;
+        }
+        auto read_bvh_box_grow = [&](GpuCapturedTable& table) {
+            for (auto& captured : table.resources)
+                if (!r.u32(captured.resource.bvh_box_grow) ||
+                    captured.resource.bvh_box_grow > 0xFFu)
+                    return false;
+            return true;
+        };
+        for (auto& draw : c.draws)
+            if (!read_bvh_box_grow(draw.vrt) || !read_bvh_box_grow(draw.prt)) return false;
+        for (auto& compute : c.computes)
+            if (!read_bvh_box_grow(compute.resources)) return false;
+        for (auto& diagnostic : c.failure_diagnostics)
+            for (auto& stage : diagnostic.stages)
+                if (!read_bvh_box_grow(stage.resource_table)) return false;
     }
     for (auto& draw : c.draws) restore_legacy_color_target_aliases(draw);
     for (auto& diagnostic : c.failure_diagnostics)

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -195,12 +195,13 @@ struct DynFetch {
 // consumer via by_srt_offset(imm) — so `key` here is exactly that immediate, and build_stage_table
 // turns each use into a ShaderResource with srt_offset = key.
 struct SrtUse {
-    int kind = 0;                    // 0 = texture (t8, + s4 sampler when resolved), 1 = constant buffer (v4)
+    int kind = 0;                    // 0 = texture, 1 = constant buffer, 2 = BVH buffer
     uint32_t key = 0;                // the s_load immediate byte offset (== emit_alu's sreg_srt tag);
                                      // 0xFFFFFFFF = key-less (direct entry V#, register-SOFFSET, or
                                      // negative-imm load; resolve by the exact instruction pc instead)
     std::array<uint32_t, 8> t8{};    // T# dwords as loaded (kind 0)
     std::array<uint32_t, 4> v4{};    // V# dwords as loaded (kind 1)
+    std::array<uint32_t, 4> bvh4{};  // BVH descriptor dwords live at IMAGE_BVH_INTERSECT_RAY (kind 2)
     uint32_t instruction_format = UINT32_MAX; // MTBUF BUF_FMT override for kind 1
     bool has_samp = false;
     std::array<uint32_t, 4> s4{};    // paired S# dwords (kind 0, when the SSAMP load also resolved)

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -1965,22 +1965,76 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                 kc = (in.src[1].kind == OperandKind::Literal) ? (c = in.literal, true) : srcval(in.src[1], c);
                 int d = in.dst.value; bool ok = ka && kc; uint32_t r = 0;
                 uint32_t hi64 = 0; bool wrote_pair = false;
+                int next_scc = scc;
                 if (ok) switch (in.opcode) {
-                    case 0x00: case 0x02: r = a + c; break;                 // s_add_u32 / s_add_i32
-                    case 0x01: case 0x03: r = a - c; break;                 // s_sub_u32 / s_sub_i32
-                    case 0x0E: r = a & c; break;                            // s_and_b32
-                    case 0x10: r = a | c; break;                            // s_or_b32
-                    case 0x12: r = a ^ c; break;                            // s_xor_b32
-                    case 0x1E: r = a << (c & 31); break;                    // s_lshl_b32
-                    case 0x20: r = a >> (c & 31); break;                    // s_lshr_b32
+                    case 0x00: {                                           // s_add_u32
+                        const uint64_t sum = static_cast<uint64_t>(a) + c;
+                        r = static_cast<uint32_t>(sum);
+                        next_scc = static_cast<int>(sum >> 32);
+                        break;
+                    }
+                    case 0x01:                                             // s_sub_u32
+                        r = a - c; next_scc = a < c; break;
+                    case 0x02: {                                           // s_add_i32
+                        r = a + c;
+                        next_scc = ((~(a ^ c) & (a ^ r)) >> 31) != 0;
+                        break;
+                    }
+                    case 0x03:                                             // s_sub_i32
+                        r = a - c; next_scc = (((a ^ c) & (a ^ r)) >> 31) != 0; break;
+                    case 0x04: {                                           // s_addc_u32
+                        if (scc < 0) { ok = false; break; }
+                        const uint64_t sum = static_cast<uint64_t>(a) + c +
+                                             static_cast<uint32_t>(scc);
+                        r = static_cast<uint32_t>(sum);
+                        next_scc = static_cast<int>(sum >> 32);
+                        break;
+                    }
+                    case 0x0E: r = a & c; next_scc = r != 0; break;         // s_and_b32
+                    case 0x10: r = a | c; next_scc = r != 0; break;         // s_or_b32
+                    case 0x12: r = a ^ c; next_scc = r != 0; break;         // s_xor_b32
+                    case 0x1E:                                             // s_lshl_b32
+                        r = a << (c & 31); next_scc = r != 0; break;
+                    case 0x20:                                             // s_lshr_b32
+                        r = a >> (c & 31); next_scc = r != 0; break;
                     case 0x26: r = a * c; break;                            // s_mul_i32
-                    case 0x2E: case 0x2F: case 0x30: case 0x31:
-                        r = (a << (in.opcode - 0x2Du)) + c; break;           // s_lshl{1,2,3,4}_add_u32
+                    case 0x2E: case 0x2F: case 0x30: case 0x31: {           // s_lshl{1,2,3,4}_add_u32
+                        const uint32_t shift = in.opcode - 0x2Du;
+                        const uint64_t sum = (static_cast<uint64_t>(a) << shift) + c;
+                        r = static_cast<uint32_t>(sum);
+                        next_scc = sum >= (uint64_t{1} << 32);
+                        break;
+                    }
                     case 0x27: { uint32_t off = c & 0x1f, wid = (c >> 16) & 0x7f;   // s_bfe_u32
-                                 r = wid == 0 ? 0 : (wid >= 32 ? (a >> off) : ((a >> off) & ((1u << wid) - 1))); break; }
+                                 r = wid == 0 ? 0 : (wid >= 32 ? (a >> off) : ((a >> off) & ((1u << wid) - 1)));
+                                 next_scc = r != 0; break; }
                     case 0x0A:   // s_cselect_b32: dst = SCC ? src0 : src1 (the vertex-fetch format patch's tail)
                         if (scc < 0) ok = false; else r = scc ? a : c;
                         break;
+                    case 0x1F: case 0x21: {  // s_lshl_b64 / s_lshr_b64
+                        uint32_t ahi = 0;
+                        bool khi = false;
+                        if (in.src[0].kind == OperandKind::SGPR)
+                            khi = known(in.src[0].value + 1, ahi);
+                        else if (in.src[0].kind == OperandKind::InlineInt) {
+                            ahi = in.src[0].value < 0 ? UINT32_MAX : 0u;
+                            khi = true;
+                        } else if (in.src[0].kind == OperandKind::Literal) {
+                            ahi = 0;
+                            khi = true;
+                        }
+                        if (!khi) { ok = false; wrote_pair = true; break; }
+                        const uint64_t src64 = static_cast<uint64_t>(a) |
+                                               (static_cast<uint64_t>(ahi) << 32);
+                        const uint32_t shift = c & 63u;
+                        const uint64_t result = in.opcode == 0x1Fu
+                            ? src64 << shift : src64 >> shift;
+                        r = static_cast<uint32_t>(result);
+                        hi64 = static_cast<uint32_t>(result >> 32);
+                        wrote_pair = true;
+                        next_scc = result != 0;
+                        break;
+                    }
                     case 0x29: {  // s_bfe_u64: dst[63:0] = bitfield of src0[63:0] (format patch reads a small field)
                         uint32_t off = c & 0x3f, wid = (c >> 16) & 0x7f, ahi = 0;
                         // src0's high dword (RDNA2 ISA 64-bit scalar-operand rules, #155): the next SGPR
@@ -1998,20 +2052,20 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                         if (!khi && wid != 0 && off + wid > 32) { ok = false; wrote_pair = true; break; }
                         uint64_t src64 = (uint64_t)a | ((uint64_t)ahi << 32);
                         uint64_t res = wid == 0 ? 0 : (wid >= 64 ? (src64 >> off) : ((src64 >> off) & (((uint64_t)1 << wid) - 1)));
-                        r = (uint32_t)res; hi64 = (uint32_t)(res >> 32); wrote_pair = true; break;
+                        r = (uint32_t)res; hi64 = (uint32_t)(res >> 32); wrote_pair = true;
+                        next_scc = res != 0; break;
                     }
                     default: ok = false; break;                            // SCC-dependent / unmodeled -> unknown
                 }
                 if (trc)   // unfiltered like the SMEM/MUBUF traces (one shader walk — volume is bounded)
                     fprintf(stderr, "[dyntrace]   SOP2 pc=%u op=0x%x dst=s%d src0=%d(k%d) src1=%d(k%d) ok=%d r=0x%x\n",
                             in.pc, in.opcode, d, in.src[0].value, ka, in.src[1].value, kc, ok, r);
-                // Every SOP2 ALU op except s_cselect writes SCC to a value we don't track here — invalidate so a
-                // later s_cselect only trusts SCC set by an immediately-preceding s_cmp.
-                if (in.opcode != 0x0A) scc = -1;
+                scc = ok ? next_scc : -1;
                 if (ok) { set_value(d, r); if (wrote_pair) set_value(d + 1, hi64); }
-                // A 64-bit-dst op (s_bfe_u64) invalidates BOTH dwords even when its sources were
-                // unknown (the opcode switch never ran, so wrote_pair may still be false).
-                else    { forget(d); if (wrote_pair || in.opcode == 0x29) forget(d + 1); }
+                // A 64-bit-dst op invalidates BOTH dwords even when its source was unknown (the
+                // opcode switch may not have reached the point that marks wrote_pair).
+                else    { forget(d); if (wrote_pair || in.opcode == 0x1F || in.opcode == 0x21 ||
+                                         in.opcode == 0x29) forget(d + 1); }
                 break;
             }
             case Rdna2Format::SOPC: {   // scalar compare -> SCC (feeds the format patch's s_cselect)

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -155,6 +155,7 @@ struct ShaderResourceCompileKey {
     uint32_t addr_u = 0;
     uint32_t addr_v = 0;
     uint32_t border_color_type = 0;
+    bool bvh_no_hit_fallback = false;
 
     bool operator==(const ShaderResourceCompileKey&) const = default;
 };
@@ -332,6 +333,7 @@ struct ShaderCompileKeyHash {
             hash = hash_mix(hash, resource.addr_u);
             hash = hash_mix(hash, resource.addr_v);
             hash = hash_mix(hash, resource.border_color_type);
+            hash = hash_mix(hash, resource.bvh_no_hit_fallback);
         }
         return static_cast<size_t>(hash);
     }
@@ -991,6 +993,7 @@ ShaderCompileKey make_shader_compile_key(ShaderProgramStage stage, const uint32_
             compiled.addr_u = manual_compare ? resource.addr_uvw[0] : 0u;
             compiled.addr_v = manual_compare ? resource.addr_uvw[1] : 0u;
             compiled.border_color_type = manual_compare ? resource.border_color_type : 0u;
+            compiled.bvh_no_hit_fallback = is_bvh_no_hit_fallback(resource);
             key.resources.push_back(compiled);
         }
     }
@@ -2311,11 +2314,18 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                             }
                             fputc('\n', stderr);
                         }
-                        if (plausible) {
+                        if (plausible || (!live_known &&
+                                          (snapshot_provenance || seed_provenance))) {
                             SrtUse u;
                             u.kind = 2;
                             u.key = 0xFFFFFFFFu;
-                            u.bvh4 = live_bvh;
+                            // A descriptor load can be control-flow guarded even though static
+                            // translation still sees the later BVH instruction. Preserve an
+                            // all-zero marker when that load did not resolve: resource
+                            // materialization binds a bounded no-hit BVH so the rest of the
+                            // compute program can execute. A known but malformed descriptor is
+                            // deliberately not converted into this fallback.
+                            if (plausible) u.bvh4 = live_bvh;
                             u.use_pc = in.pc;
                             srt_uses->push_back(u);
                         }
@@ -2843,6 +2853,27 @@ std::vector<SrtUse> add_compute_buffer_resources(ShaderResourceTable& table,
     for (const auto& u : srt_uses) {
         if (u.kind == 2) {
             const DecodedBvhDescriptor d = decode_bvh_descriptor(u.bvh4.data());
+            const bool unresolved = std::all_of(u.bvh4.begin(), u.bvh4.end(),
+                                                [](uint32_t word) { return word == 0; });
+            if (unresolved) {
+                const uint64_t dk = 0x8000000200000000ull | u.use_pc;
+                if (!seen.insert(dk).second) continue;
+                // Guest control flow normally skips this unresolved descriptor. The exact
+                // host-owned marker lets the recompiler emit a compact deterministic no-hit if
+                // the static instruction remains in the module, without instantiating a large
+                // software traversal body merely to satisfy Vulkan pipeline compilation.
+                alignas(256) static std::array<uint8_t, 256> null_bvh{};
+                ShaderResource r;
+                r.cls = ResourceClass::ConstantBuffer;
+                r.format = DataFormat::Uint32;
+                r.num_components = 1;
+                r.size = static_cast<uint32_t>(null_bvh.size());
+                r.fetch_pc = u.use_pc;
+                r.host_data = null_bvh.data();
+                r.host_data_size = null_bvh.size();
+                table.resources.push_back(r);
+                continue;
+            }
             if (d.type != 8u || d.base <= 0x10000u || d.size_bytes == 0 ||
                 d.size_bytes > 0x10000000u || d.size_bytes > UINT32_MAX ||
                 !d.triangle_return_mode || d.box_node_64b || d.sort_enabled)

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -2223,6 +2223,51 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                 break;
             }
             case Rdna2Format::MIMG: {
+                // IMAGE_BVH_INTERSECT_RAY consumes a four-dword BVH descriptor, not an eight-dword
+                // image T#. Preserve the words live at this exact instruction and materialize the
+                // acceleration-structure bytes as a raw read-only SSBO for software lowering.
+                if (in.opcode == 0xE6u) {
+                    if (srt_uses) {
+                        const int bbase = in.src[1].value;
+                        std::array<uint32_t, 4> live_bvh{};
+                        bool live_known = valid_reg(bbase) && valid_reg(bbase + 3);
+                        for (int k = 0; live_known && k < 4; ++k)
+                            live_known &= known(bbase + k, live_bvh[(size_t)k]);
+                        const bool snapshot_provenance = valid_reg(bbase) &&
+                            descr_known.test((size_t)bbase);
+                        const bool seed_provenance = !snapshot_provenance &&
+                            (untouched_seed_range(bbase, 4) ||
+                             consecutive_seed_copy_range(bbase, 4));
+                        const DecodedBvhDescriptor d = live_known
+                            ? decode_bvh_descriptor(live_bvh.data()) : DecodedBvhDescriptor{};
+                        const bool plausible = live_known && (snapshot_provenance || seed_provenance) &&
+                            d.type == 8u && d.base > 0x10000u && d.size_bytes != 0;
+                        if (trc) {
+                            fprintf(stderr,
+                                    "[dyntrace] BVH pc=%u srsrc=s%d snapshot=%d seed=%d bvh=",
+                                    in.pc, bbase, snapshot_provenance, seed_provenance);
+                            if (plausible) {
+                                for (uint32_t word : live_bvh) fprintf(stderr, "%08x ", word);
+                                fprintf(stderr, "-> base=0x%llx size=0x%llx type=%u tri_mode=%u",
+                                        (unsigned long long)d.base,
+                                        (unsigned long long)d.size_bytes, d.type,
+                                        d.triangle_return_mode);
+                            } else {
+                                fprintf(stderr, "<unknown>");
+                            }
+                            fputc('\n', stderr);
+                        }
+                        if (plausible) {
+                            SrtUse u;
+                            u.kind = 2;
+                            u.key = 0xFFFFFFFFu;
+                            u.bvh4 = live_bvh;
+                            u.use_pc = in.pc;
+                            srt_uses->push_back(u);
+                        }
+                    }
+                    break;
+                }
                 // Descriptor-table use (#294): an image op's SRSRC (src[1]) is an 8-dword T#; if it was
                 // snapshotted from a table load, report it as a Texture use — with the paired SSAMP
                 // (src[2]) S# when that 4-dword load also resolved. VGPR-only dest: no SGPR state.
@@ -2742,6 +2787,33 @@ std::vector<SrtUse> add_compute_buffer_resources(ShaderResourceTable& table,
 
     std::set<uint64_t> seen;
     for (const auto& u : srt_uses) {
+        if (u.kind == 2) {
+            const DecodedBvhDescriptor d = decode_bvh_descriptor(u.bvh4.data());
+            if (d.type != 8u || d.base <= 0x10000u || d.size_bytes == 0 ||
+                d.size_bytes > 0x10000000u || d.size_bytes > UINT32_MAX ||
+                !d.triangle_return_mode || d.box_node_64b || d.sort_enabled)
+                continue;
+            const uint64_t dk = 0x8000000200000000ull | u.use_pc;
+            if (!seen.insert(dk).second) continue;
+            bool mapped = false;
+            for (auto& r0 : table.resources) {
+                if (r0.cls != ResourceClass::ConstantBuffer || r0.gpu_addr != d.base ||
+                    r0.size != static_cast<uint32_t>(d.size_bytes))
+                    continue;
+                if (r0.fetch_pc == 0xFFFFFFFFu) r0.fetch_pc = u.use_pc;
+                if (r0.fetch_pc == u.use_pc) { mapped = true; break; }
+            }
+            if (mapped) continue;
+            ShaderResource r;
+            r.cls = ResourceClass::ConstantBuffer;
+            r.format = DataFormat::Uint32;
+            r.num_components = 1;
+            r.gpu_addr = d.base;
+            r.size = static_cast<uint32_t>(d.size_bytes);
+            r.fetch_pc = u.use_pc;
+            table.resources.push_back(r);
+            continue;
+        }
         if (u.kind != 1) continue;
         if (u.use_pc == proven_linear_store_pc) continue;
         if (u.instruction_format != UINT32_MAX && ((u.v4[3] >> 12) & 0x7Fu) == 0)
@@ -3914,7 +3986,7 @@ std::vector<ComputeItem> realize_compute_dispatches(
                                          "t8=%08x:%08x:%08x:%08x:%08x:%08x:%08x:%08x\n",
                                          u.key, u.use_pc, u.t8[0], u.t8[1], u.t8[2], u.t8[3],
                                          u.t8[4], u.t8[5], u.t8[6], u.t8[7]);
-                        } else {
+                        } else if (u.kind == 1) {
                             const DecodedBufferDescriptor d = decode_buffer_descriptor(u.v4.data());
                             std::fprintf(stderr,
                                          "[dynfail]     BUF(v4) key=0x%x use_pc=%u "
@@ -3923,6 +3995,17 @@ std::vector<ComputeItem> realize_compute_dispatches(
                                          u.key, u.use_pc, u.v4[0], u.v4[1], u.v4[2], u.v4[3],
                                          (unsigned long long)d.base, d.stride, d.num_records,
                                          d.size_bytes, u.required_size);
+                        } else {
+                            const DecodedBvhDescriptor d = decode_bvh_descriptor(u.bvh4.data());
+                            std::fprintf(stderr,
+                                         "[dynfail]     BVH(bvh4) use_pc=%u "
+                                         "bvh4=%08x:%08x:%08x:%08x base=0x%llx size=%llu "
+                                         "type=%u tri_mode=%u box64=%u sort=%u\n",
+                                         u.use_pc, u.bvh4[0], u.bvh4[1], u.bvh4[2], u.bvh4[3],
+                                         (unsigned long long)d.base,
+                                         (unsigned long long)d.size_bytes, d.type,
+                                         (unsigned)d.triangle_return_mode,
+                                         (unsigned)d.box_node_64b, (unsigned)d.sort_enabled);
                         }
                     }
                 }
@@ -4011,7 +4094,8 @@ struct OrderedGpustateCaptureTrace {
 static OrderedSubmitResult execute_ordered_gpustate(
     const GpuState& st, uint32_t width, uint32_t height, uint64_t submit_no,
     const LiveRenderFn& render, const LiveComputeFn& compute,
-    OrderedGpustateCaptureTrace* capture_trace = nullptr);
+    OrderedGpustateCaptureTrace* capture_trace = nullptr,
+    const std::vector<DrawItem>* eager_draws = nullptr);
 
 bool execute_nonrender_submit_work(const GpuState& st, uint64_t submit_no) {
     if (st.dma_copies.empty() && (!g_compute || st.dispatches.empty())) return false;
@@ -5014,7 +5098,8 @@ static OrderedSubmitResult execute_ordered_gpustate(const GpuState& st, uint32_t
                                                      uint32_t height, uint64_t submit_no,
                                                      const LiveRenderFn& render,
                                                      const LiveComputeFn& compute,
-                                                     OrderedGpustateCaptureTrace* capture_trace) {
+                                                     OrderedGpustateCaptureTrace* capture_trace,
+                                                     const std::vector<DrawItem>* eager_draws) {
     GuestGpuWriteSubmitScope guest_gpu_write_scope;
     if (st.dma_execution_rejected) {
         static std::atomic<int> warned{0};
@@ -5043,6 +5128,11 @@ static OrderedSubmitResult execute_ordered_gpustate(const GpuState& st, uint32_t
     std::stable_sort(executable.begin(), executable.end(), [](const auto& a, const auto& b) {
         return a.command_order < b.command_order;
     });
+
+    std::unordered_map<size_t, size_t> eager_draw_by_index;
+    if (eager_draws)
+        for (size_t i = 0; i < eager_draws->size(); ++i)
+            eager_draw_by_index[static_cast<size_t>((*eager_draws)[i].draw_index)] = i;
 
     size_t total_spans = 0;
     bool in_draw_span = false;
@@ -5090,7 +5180,18 @@ static OrderedSubmitResult execute_ordered_gpustate(const GpuState& st, uint32_t
                     break;
                 }
                 DrawItem item;
-                if (realize_retained_draw(st, operation.index, scale_x, scale_y, item)) {
+                bool realized = false;
+                if (eager_draws) {
+                    const auto found = eager_draw_by_index.find(operation.index);
+                    if (found != eager_draw_by_index.end()) {
+                        item = (*eager_draws)[found->second];
+                        realized = true;
+                    }
+                } else {
+                    realized = realize_retained_draw(
+                        st, operation.index, scale_x, scale_y, item);
+                }
+                if (realized) {
                     if (capture_trace) capture_trace->draws.push_back(item);
                     span.push_back(std::move(item));
                 }
@@ -5403,10 +5504,13 @@ bool execute_ordered_and_present(const GpuState& st, uint32_t width, uint32_t he
                                          [](const auto& draw) { return draw.indirect; }) ||
                               std::any_of(st.dispatches.begin(), st.dispatches.end(),
                                          [](const auto& dispatch) { return dispatch.indirect; });
-    const bool needs_ordered_realization = has_ordered_dma || has_indirect;
-    // DMA and indirect consumers must be realized at their ordered position below. Pre-realizing
-    // would snapshot bytes before an earlier copy or compute shader updates their backing.
-    std::vector<DrawItem> draws = !needs_ordered_realization && g_live && width && height
+    const bool needs_ordered_realization = has_ordered_dma || has_indirect || !st.dispatches.empty();
+    // Draws without DMA/indirect arguments remain safe to prepare in parallel. Compute resources,
+    // however, are always realized at their ordered position: a preceding dispatch in the same
+    // submit can write a pointer or descriptor consumed by the next dispatch (Astro Bot's BVH root
+    // is one such dependency). Pre-realizing every compute snapshots stale guest bytes.
+    const bool can_eagerly_realize_draws = !has_ordered_dma && !has_indirect;
+    std::vector<DrawItem> draws = can_eagerly_realize_draws && g_live && width && height
         ? realize_gpustate_draws(st, 0x10000, sx, sy, nullptr, true)
         : std::vector<DrawItem>{};
     const ShaderRecompileCacheStats shader_after = timing_enabled
@@ -5431,13 +5535,14 @@ bool execute_ordered_and_present(const GpuState& st, uint32_t width, uint32_t he
     auto pending_capture = begin_requested_gpu_capture(
         draws, computes, operations, width, height, &st, submit_no,
         static_cast<uint64_t>(st.draws.size()), nullptr,
-        /*defer_materialization=*/has_indirect);
+        /*defer_materialization=*/needs_ordered_realization);
     snapshot_pending_gpu_capture_compute_gds(
         pending_capture.get(), g_compute_gds.data(), g_compute_gds.size());
     OrderedGpustateCaptureTrace capture_trace;
     OrderedSubmitResult result = needs_ordered_realization
         ? execute_ordered_gpustate(st, width, height, submit_no, g_live, g_compute,
-                                   pending_capture ? &capture_trace : nullptr)
+                                   pending_capture ? &capture_trace : nullptr,
+                                   can_eagerly_realize_draws ? &draws : nullptr)
         : execute_ordered_items(operations, draws, computes, g_live, g_compute, width, height);
     const auto timing_backend_done = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
     const std::vector<uint8_t>& px = result.frame.bytes();

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -148,6 +148,7 @@ struct ShaderResourceCompileKey {
     uint32_t fetch_pc = 0;
     uint32_t fetch_index_mode = 0;
     uint32_t flat_base_sgpr = 0;
+    uint32_t bvh_box_grow = 0;
     bool srgb = false;
     bool depth_compare = false;
     uint32_t depth_compare_func = 0;
@@ -155,7 +156,6 @@ struct ShaderResourceCompileKey {
     uint32_t addr_u = 0;
     uint32_t addr_v = 0;
     uint32_t border_color_type = 0;
-    bool bvh_no_hit_fallback = false;
 
     bool operator==(const ShaderResourceCompileKey&) const = default;
 };
@@ -326,6 +326,7 @@ struct ShaderCompileKeyHash {
             hash = hash_mix(hash, resource.fetch_pc);
             hash = hash_mix(hash, resource.fetch_index_mode);
             hash = hash_mix(hash, resource.flat_base_sgpr);
+            hash = hash_mix(hash, resource.bvh_box_grow);
             hash = hash_mix(hash, resource.srgb);
             hash = hash_mix(hash, resource.depth_compare);
             hash = hash_mix(hash, resource.depth_compare_func);
@@ -333,7 +334,6 @@ struct ShaderCompileKeyHash {
             hash = hash_mix(hash, resource.addr_u);
             hash = hash_mix(hash, resource.addr_v);
             hash = hash_mix(hash, resource.border_color_type);
-            hash = hash_mix(hash, resource.bvh_no_hit_fallback);
         }
         return static_cast<size_t>(hash);
     }
@@ -986,6 +986,7 @@ ShaderCompileKey make_shader_compile_key(ShaderProgramStage stage, const uint32_
             compiled.fetch_pc = resource.fetch_pc;
             compiled.fetch_index_mode = static_cast<uint32_t>(resource.fetch_index_mode);
             compiled.flat_base_sgpr = resource.flat_base_sgpr;
+            compiled.bvh_box_grow = resource.bvh_box_grow;
             compiled.srgb = storage_image && resource.srgb;
             compiled.depth_compare = (manual_compare || storage_image) && resource.depth_compare;
             compiled.depth_compare_func = manual_compare ? resource.depth_compare_func : 0u;
@@ -993,7 +994,6 @@ ShaderCompileKey make_shader_compile_key(ShaderProgramStage stage, const uint32_
             compiled.addr_u = manual_compare ? resource.addr_uvw[0] : 0u;
             compiled.addr_v = manual_compare ? resource.addr_uvw[1] : 0u;
             compiled.border_color_type = manual_compare ? resource.border_color_type : 0u;
-            compiled.bvh_no_hit_fallback = is_bvh_no_hit_fallback(resource);
             key.resources.push_back(compiled);
         }
     }
@@ -2305,27 +2305,20 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                                     in.pc, bbase, snapshot_provenance, seed_provenance);
                             if (plausible) {
                                 for (uint32_t word : live_bvh) fprintf(stderr, "%08x ", word);
-                                fprintf(stderr, "-> base=0x%llx size=0x%llx type=%u tri_mode=%u",
+                                fprintf(stderr, "-> base=0x%llx size=0x%llx type=%u tri_mode=%u grow=%u",
                                         (unsigned long long)d.base,
                                         (unsigned long long)d.size_bytes, d.type,
-                                        d.triangle_return_mode);
+                                        d.triangle_return_mode, d.box_grow);
                             } else {
                                 fprintf(stderr, "<unknown>");
                             }
                             fputc('\n', stderr);
                         }
-                        if (plausible || (!live_known &&
-                                          (snapshot_provenance || seed_provenance))) {
+                        if (plausible) {
                             SrtUse u;
                             u.kind = 2;
                             u.key = 0xFFFFFFFFu;
-                            // A descriptor load can be control-flow guarded even though static
-                            // translation still sees the later BVH instruction. Preserve an
-                            // all-zero marker when that load did not resolve: resource
-                            // materialization binds a bounded no-hit BVH so the rest of the
-                            // compute program can execute. A known but malformed descriptor is
-                            // deliberately not converted into this fallback.
-                            if (plausible) u.bvh4 = live_bvh;
+                            u.bvh4 = live_bvh;
                             u.use_pc = in.pc;
                             srt_uses->push_back(u);
                         }
@@ -2853,27 +2846,6 @@ std::vector<SrtUse> add_compute_buffer_resources(ShaderResourceTable& table,
     for (const auto& u : srt_uses) {
         if (u.kind == 2) {
             const DecodedBvhDescriptor d = decode_bvh_descriptor(u.bvh4.data());
-            const bool unresolved = std::all_of(u.bvh4.begin(), u.bvh4.end(),
-                                                [](uint32_t word) { return word == 0; });
-            if (unresolved) {
-                const uint64_t dk = 0x8000000200000000ull | u.use_pc;
-                if (!seen.insert(dk).second) continue;
-                // Guest control flow normally skips this unresolved descriptor. The exact
-                // host-owned marker lets the recompiler emit a compact deterministic no-hit if
-                // the static instruction remains in the module, without instantiating a large
-                // software traversal body merely to satisfy Vulkan pipeline compilation.
-                alignas(256) static std::array<uint8_t, 256> null_bvh{};
-                ShaderResource r;
-                r.cls = ResourceClass::ConstantBuffer;
-                r.format = DataFormat::Uint32;
-                r.num_components = 1;
-                r.size = static_cast<uint32_t>(null_bvh.size());
-                r.fetch_pc = u.use_pc;
-                r.host_data = null_bvh.data();
-                r.host_data_size = null_bvh.size();
-                table.resources.push_back(r);
-                continue;
-            }
             if (d.type != 8u || d.base <= 0x10000u || d.size_bytes == 0 ||
                 d.size_bytes > 0x10000000u || d.size_bytes > UINT32_MAX ||
                 !d.triangle_return_mode || d.box_node_64b || d.sort_enabled)
@@ -2883,7 +2855,8 @@ std::vector<SrtUse> add_compute_buffer_resources(ShaderResourceTable& table,
             bool mapped = false;
             for (auto& r0 : table.resources) {
                 if (r0.cls != ResourceClass::ConstantBuffer || r0.gpu_addr != d.base ||
-                    r0.size != static_cast<uint32_t>(d.size_bytes))
+                    r0.size != static_cast<uint32_t>(d.size_bytes) ||
+                    r0.bvh_box_grow != d.box_grow)
                     continue;
                 if (r0.fetch_pc == 0xFFFFFFFFu) r0.fetch_pc = u.use_pc;
                 if (r0.fetch_pc == u.use_pc) { mapped = true; break; }
@@ -2896,6 +2869,7 @@ std::vector<SrtUse> add_compute_buffer_resources(ShaderResourceTable& table,
             r.gpu_addr = d.base;
             r.size = static_cast<uint32_t>(d.size_bytes);
             r.fetch_pc = u.use_pc;
+            r.bvh_box_grow = d.box_grow;
             table.resources.push_back(r);
             continue;
         }
@@ -4085,12 +4059,13 @@ std::vector<ComputeItem> realize_compute_dispatches(
                             std::fprintf(stderr,
                                          "[dynfail]     BVH(bvh4) use_pc=%u "
                                          "bvh4=%08x:%08x:%08x:%08x base=0x%llx size=%llu "
-                                         "type=%u tri_mode=%u box64=%u sort=%u\n",
+                                         "type=%u tri_mode=%u box64=%u sort=%u grow=%u\n",
                                          u.use_pc, u.bvh4[0], u.bvh4[1], u.bvh4[2], u.bvh4[3],
                                          (unsigned long long)d.base,
                                          (unsigned long long)d.size_bytes, d.type,
                                          (unsigned)d.triangle_return_mode,
-                                         (unsigned)d.box_node_64b, (unsigned)d.sort_enabled);
+                                         (unsigned)d.box_node_64b, (unsigned)d.sort_enabled,
+                                         (unsigned)d.box_grow);
                         }
                     }
                 }

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -4,6 +4,7 @@
 #include "rdna2_decode.hpp"
 #include "shader_resources.hpp"
 #include <algorithm>
+#include <bit>
 #include <cstring>
 #include <cstdio>
 #include <cstdlib>
@@ -5323,8 +5324,8 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 const uint32_t in_half = in.dst.value == 106
                     ? b.ucmp(Op_ULessThan, lane, b.uconst(32))
                     : b.ucmp(Op_UGreaterThanEqual, lane, b.uconst(32));
-                const uint32_t prior_vcc = rs.vcc ? rs.vcc : b.bfalse();
-                rs.vcc = b.bsel(in_half, b.logical_not(prior_vcc), prior_vcc);
+                if (!rs.vcc) { ok = false; return true; }
+                rs.vcc = b.bsel(in_half, b.logical_not(rs.vcc), rs.vcc);
                 rs.sreg_bool[in.dst.value] = rs.vcc;
                 rs.sreg_bool_narrowed[in.dst.value] = true;
                 if (b.allow_b32_masks) rs.sreg_bool_b32.insert(in.dst.value);
@@ -5892,8 +5893,8 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                         b.ibin(Op_BitwiseAnd,
                                b.ibin(Op_ShiftRightLogical, result, bit), b.uconst(1)),
                         b.uconst(0));
-                    rs.vcc = b.bsel(in_written_half, result_bit,
-                                    rs.vcc ? rs.vcc : b.bfalse());
+                    if (!rs.vcc) { ok = false; return true; }
+                    rs.vcc = b.bsel(in_written_half, result_bit, rs.vcc);
                     rs.sreg_bool[in.dst.value] = rs.vcc;
                     rs.sreg_bool_narrowed[in.dst.value] = true;
                     return true;
@@ -5933,8 +5934,8 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                                       : in.opcode == 0x18 ? b.lor(n0, n1)
                                       : in.opcode == 0x1a ? b.land(n0, n1)
                                       : b.logical_not(x);
-                rs.vcc = b.bsel(in_written_half, result,
-                                rs.vcc ? rs.vcc : b.bfalse());
+                if (!rs.vcc) { ok = false; return true; }
+                rs.vcc = b.bsel(in_written_half, result, rs.vcc);
                 rs.sreg_bool[in.dst.value] = rs.vcc;
                 rs.sreg_bool_narrowed[in.dst.value] = true;
                 rs.sreg.erase(in.dst.value);
@@ -6664,6 +6665,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             uint32_t& d = vreg[in.dst.value];
             switch (in.opcode) {
                 case 0x01: {                                         // v_cndmask_b32: dst = vcc ? src1 : src0
+                    if (!vcc) { ok = false; return true; }
                     if (in.sdwa_dst_sel == 6) { d = b.sel(vcc, c, a); break; }
                     auto word = [&](uint32_t raw, uint8_t sel) {
                         if (sel == 5) raw = b.ibin(Op_ShiftRightLogical, raw, b.uconst(16));
@@ -6716,6 +6718,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 // Carry ops (VOP2 e32 form): carry-in + carry-out are VCC. v_add_co_ci(0x28)/
                 // v_sub_co_ci(0x29)/v_subrev_co_ci(0x2a). Mirrors the VOP3B 0x128/129/12A logic with VCC.
                 case 0x28: case 0x29: case 0x2A: {
+                    if (!vcc) { ok = false; return true; }
                     uint32_t cin = b.sel(vcc, b.uconst(1), b.uconst(0));
                     uint32_t carry;
                     if (in.opcode == 0x28) {                          // (a + c) + cin
@@ -8588,21 +8591,6 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     return true;
                 }
 
-                // The front-half emits this marker only when descriptor provenance is proven but
-                // the guarded descriptor load resolved to null. The instruction must still compile
-                // because it exists in the static control-flow graph, but no BVH bytes exist to
-                // traverse. Four invalid child IDs are the conservative no-hit result and avoid
-                // triplicating the large software intersection body in Astro Bot's world-map kernel.
-                if (is_bvh_no_hit_fallback(*bvh)) {
-                    for (uint32_t k = 0; k < 4; ++k) {
-                        const int vd = in.dst.value + static_cast<int>(k);
-                        const uint32_t old = vreg_old(b, rs, vd);
-                        rs.vreg[vd] = b.uconst(0xffffffffu);
-                        predicate_write(b, rs, vd, old);
-                    }
-                    return true;
-                }
-
                 auto addr_vgpr = [&](uint32_t k) -> int {
                     if (k == 0u) return in.src[0].value;
                     const uint32_t j = k - 1u;
@@ -8760,12 +8748,12 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     const uint32_t nan_interval = b.lor(
                         b.fcmp(Op_FUnordNotEqual, near_unclamped, near_unclamped),
                         b.fcmp(Op_FUnordNotEqual, far_unclamped, far_unclamped));
+                    const float box_multiplier = 1.0f +
+                        static_cast<float>(bvh->bvh_box_grow) * (1.0f / 16777216.0f);
                     const uint32_t hit = b.land(
                         b.logical_not(nan_interval),
-                        // RTIP 1.1 grows the post-projection far edge by 6 * 2^-24;
-                        // at 1.0f that multiplier is exactly three float ULPs.
                         b.fcmp(Op_FOrdLessThanEqual, near_t,
-                               fmul(far_t, b.uconst(0x3f800003u))));
+                               fmul(far_t, b.uconst(std::bit_cast<uint32_t>(box_multiplier)))));
                     box_out[child] = b.sel(b.land(box_valid, hit), w[child], invalid);
                 }
 
@@ -10662,10 +10650,10 @@ bool emit_cfg_state_machine(
         b.store_function(kv.second, value);
     }
     b.store_function(scc_var, initial.scc ? initial.scc : no);
-    // VCC can be deliberately poisoned (id 0) when its physical SGPR word is recycled as scalar
-    // data. As with SCC, a dispatcher boundary ends that unrepresentable lifetime; persist false
-    // until a later architectural mask writer establishes a fresh value.
-    b.store_function(vcc_var, initial.vcc ? initial.vcc : no);
+    // The dispatcher has no runtime type tag for a physical VCC word recycled as scalar data.
+    // Keep that unsupported join fail-visible instead of persisting an invented false mask.
+    if (!initial.vcc) return false;
+    b.store_function(vcc_var, initial.vcc);
     b.store_function(exec_var, initial.exec);
     b.store_function(pc_var, b.uconst(0));
     b.store_function(active_var, yes);
@@ -10764,7 +10752,7 @@ bool emit_cfg_state_machine(
         // A poisoned (0) SCC degrades to bfalse at the block boundary: the same-block consumers
         // reject on the sentinel; cross-block staleness matches the pre-poison model.
         b.store_function(scc_var, state.scc ? state.scc : b.bfalse());
-        b.store_function(vcc_var, state.vcc ? state.vcc : b.bfalse());
+        b.store_function(vcc_var, state.vcc);
         b.store_function(exec_var, state.exec);
     };
 
@@ -11053,6 +11041,8 @@ bool emit_cfg_state_machine(
                 b.store_function(vote_to_scc_var, yes);
             }
         }
+        if (!state.vcc)
+            return reject_cfg(starts[final_block], "poisoned-vcc-boundary");
         save_state(state, dispatch);
         if (mbcnt) {
             if (!set_next(mbcnt->pc + mbcnt->len_dwords))
@@ -11815,6 +11805,7 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
             // the last architectural SCC writer, unrepresentable per-lane) must reject — this is
             // exactly the non-adjacent stale-SCC consumer from the ISA audit (#879).
             if (!F.on_exec && !F.on_vcc && !rs.scc) return false;
+            if (F.on_vcc && !rs.vcc) return false;
             uint32_t condition = F.on_exec ? rs.exec : (F.on_vcc ? rs.vcc : rs.scc);
             if (b.is_fragment && (F.on_exec || F.on_vcc))
                 condition = b.fragment_wave_any(condition);
@@ -11872,9 +11863,8 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                 rs.scc = b.emit_phi_2way(b.t_bool, then_scc ? then_scc : b.bfalse(), then_block,
                                          rs.scc ? rs.scc : b.bfalse(), else_block);
             if (then_vcc != rs.vcc)
-                rs.vcc = b.emit_phi_2way(
-                    b.t_bool, then_vcc ? then_vcc : b.bfalse(), then_block,
-                    rs.vcc ? rs.vcc : b.bfalse(), else_block);
+                rs.vcc = !then_vcc || !rs.vcc ? 0u : b.emit_phi_2way(
+                    b.t_bool, then_vcc, then_block, rs.vcc, else_block);
             if (then_exec != rs.exec)
                 rs.exec = b.emit_phi_2way(b.t_bool, then_exec, then_block, rs.exec, else_block);
             rs.exec_narrowed = then_narrowed || rs.exec_narrowed;
@@ -11922,7 +11912,7 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
         // A poisoned (0) SCC live-in degrades to bfalse — the loop shapes re-produce SCC via their
         // in-loop s_cmp before any read, so the phi seed is dead in practice; 0 would be invalid SSA.
         { size_t p; uint32_t ph = b.emit_phi2(b.t_bool, rs.scc ? rs.scc : b.bfalse(), preheader, p); rs.scc = ph; phis.push_back({0, 2, ph, p}); }
-        { size_t p; uint32_t ph = b.emit_phi2(b.t_bool, rs.vcc ? rs.vcc : b.bfalse(), preheader, p); rs.vcc = ph; phis.push_back({0, 3, ph, p}); }
+        if (rs.vcc) { size_t p; uint32_t ph = b.emit_phi2(b.t_bool, rs.vcc, preheader, p); rs.vcc = ph; phis.push_back({0, 3, ph, p}); }
         if (carry_vertex_exec) {
             size_t p;
             uint32_t ph = b.emit_phi2(b.t_bool, rs.exec, preheader, p);
@@ -11964,8 +11954,9 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                         : pr.dom == 1 ? sget(pr.reg)
                         : pr.dom == 2 ? rs.scc
                         : pr.dom == 3 ? rs.vcc : rs.exec;
-            if (!nv && (pr.dom == 2 || pr.dom == 3))
-                nv = b.bfalse(); // poisoned transient wave flag: false at the loop boundary
+            if (!nv && pr.dom == 3) return false;
+            if (!nv && pr.dom == 2)
+                nv = b.bfalse(); // poisoned SCC back-edge value: false when dead in practice
             b.patch_phi(pr.patch, nv, cont);
         }
         b.emit_branch(hdr);
@@ -12222,7 +12213,7 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
             // A poisoned (0) SCC live-in degrades to bfalse (invalid as an SSA phi input; dead in
             // practice — the loop shapes re-produce SCC before any read).
             { size_t p; uint32_t ph = b.emit_phi2(b.t_bool, rs.scc ? rs.scc : b.bfalse(), preheader, p); rs.scc = ph; phis.push_back({0, 2, ph, p}); }
-            { size_t p; uint32_t ph = b.emit_phi2(b.t_bool, rs.vcc ? rs.vcc : b.bfalse(), preheader, p); rs.vcc = ph; phis.push_back({0, 3, ph, p}); }
+            if (rs.vcc) { size_t p; uint32_t ph = b.emit_phi2(b.t_bool, rs.vcc, preheader, p); rs.vcc = ph; phis.push_back({0, 3, ph, p}); }
             { size_t p; uint32_t ph = b.emit_phi2(b.t_bool, rs.exec, preheader, p); rs.exec = ph; phis.push_back({0, 4, ph, p}); }
             std::vector<int> mask_keys;                        // saved masks live at entry: loop-carried bools
             for (auto& kv : rs.sreg_bool) mask_keys.push_back(kv.first);
@@ -12242,6 +12233,7 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
             const uint32_t exec_chk = rs.exec, vcc_chk = rs.vcc, scc_chk = rs.scc;
             const std::unordered_map<int, uint32_t> bool_chk = rs.sreg_bool;
             uint32_t loop_cond = L.condition == DivLoop::Condition::Exec ? rs.exec : rs.vcc;
+            if (!loop_cond) return false;
             // EXECZ/VCCZ are scalar wave decisions. Keeping every fragment invocation in the loop
             // until the complete guest wave becomes empty makes scalar state and nested wave votes
             // exact; vector writes remain predicated by the per-lane EXEC bool.
@@ -12282,22 +12274,24 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                             : pr.dom == 3 ? rs.vcc
                             : pr.dom == 4 ? rs.exec
                             : (rs.sreg_bool.count(pr.reg) ? rs.sreg_bool[pr.reg] : pr.phi);
-                if (!nv && (pr.dom == 2 || pr.dom == 3)) nv = b.bfalse();
+                if (!nv && pr.dom == 3) return false;
+                if (!nv && pr.dom == 2) nv = b.bfalse();
                 b.patch_phi(pr.patch, nv, cont);
             }
             b.emit_branch(hdr);
             b.emit_label(merge);
             for (auto& pr : phis) {
+                if (pr.dom == 3 && (!vcc_chk || !rs.vcc)) return false;
                 uint32_t chk_value = pr.dom == 0 ? (condv.count(pr.reg) ? condv_val[pr.reg] : pr.phi)
                                    : pr.dom == 1 ? (conds.count(pr.reg) ? conds_val[pr.reg] : pr.phi)
                                    : pr.dom == 2 ? (scc_chk ? scc_chk : b.bfalse())
-                                   : pr.dom == 3 ? (vcc_chk ? vcc_chk : b.bfalse())
+                                   : pr.dom == 3 ? vcc_chk
                                    : pr.dom == 4 ? exec_chk
                                    : (bool_chk.count(pr.reg) ? bool_chk.at(pr.reg) : pr.phi);
                 uint32_t body_value = pr.dom == 0 ? vget(pr.reg)
                                     : pr.dom == 1 ? sget(pr.reg)
                                     : pr.dom == 2 ? (rs.scc ? rs.scc : b.bfalse())
-                                    : pr.dom == 3 ? (rs.vcc ? rs.vcc : b.bfalse())
+                                    : pr.dom == 3 ? rs.vcc
                                     : pr.dom == 4 ? rs.exec
                                     : (rs.sreg_bool.count(pr.reg) ? rs.sreg_bool[pr.reg] : pr.phi);
                 const uint32_t merged = (L.direct_exec_breaks || L.direct_wave_breaks) &&
@@ -12348,6 +12342,7 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                 // A poisoned SCC (0: last written by a 64-bit mask op) cannot condition a real
                 // structured if — reject (the ISA-audit #879 stale-SCC consumer).
                 if (!F.on_exec && !F.on_vcc && !rs.scc) return false;
+                if (F.on_vcc && !rs.vcc) return false;
                 // Compute VCC/EXEC branches normally return through the exact guest-wave dispatcher.
                 // The narrow structured-wave path above accepts only top-level vote sites, where all
                 // workgroup invocations may participate in the scratch barriers uniformly.
@@ -12418,9 +12413,8 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                         rs.scc = b.emit_phi_2way(b.t_bool, pre_scc ? pre_scc : b.bfalse(), preblock,
                                                  then_scc ? then_scc : b.bfalse(), thenEnd);
                     if (then_vcc != pre_vcc)
-                        rs.vcc = b.emit_phi_2way(
-                            b.t_bool, pre_vcc ? pre_vcc : b.bfalse(), preblock,
-                            then_vcc ? then_vcc : b.bfalse(), thenEnd);
+                        rs.vcc = !pre_vcc || !then_vcc ? 0u : b.emit_phi_2way(
+                            b.t_bool, pre_vcc, preblock, then_vcc, thenEnd);
                     // EXEC changed inside the arm (saveexec / v_cmpx / restore): merge it like any value.
                     // Narrowed-ness is sticky (either edge narrowed → post-merge writes stay predicated).
                     if (then_exec != pre_exec) rs.exec = b.emit_phi_2way(b.t_bool, pre_exec, preblock, then_exec, thenEnd);
@@ -12488,9 +12482,8 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                         rs.scc = b.emit_phi_2way(b.t_bool, then_scc ? then_scc : b.bfalse(), thenEnd,
                                                  rs.scc ? rs.scc : b.bfalse(), elseEnd);
                     if (then_vcc != rs.vcc)
-                        rs.vcc = b.emit_phi_2way(
-                            b.t_bool, then_vcc ? then_vcc : b.bfalse(), thenEnd,
-                            rs.vcc ? rs.vcc : b.bfalse(), elseEnd);
+                        rs.vcc = !then_vcc || !rs.vcc ? 0u : b.emit_phi_2way(
+                            b.t_bool, then_vcc, thenEnd, rs.vcc, elseEnd);
                     if (then_exec != rs.exec) rs.exec = b.emit_phi_2way(b.t_bool, then_exec, thenEnd, rs.exec, elseEnd);
                     rs.exec_narrowed = then_narrowed || rs.exec_narrowed;
                     rs.sreg_written.insert(then_written.begin(), then_written.end());

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -5323,7 +5323,8 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 const uint32_t in_half = in.dst.value == 106
                     ? b.ucmp(Op_ULessThan, lane, b.uconst(32))
                     : b.ucmp(Op_UGreaterThanEqual, lane, b.uconst(32));
-                rs.vcc = b.bsel(in_half, b.logical_not(rs.vcc), rs.vcc);
+                const uint32_t prior_vcc = rs.vcc ? rs.vcc : b.bfalse();
+                rs.vcc = b.bsel(in_half, b.logical_not(prior_vcc), prior_vcc);
                 rs.sreg_bool[in.dst.value] = rs.vcc;
                 rs.sreg_bool_narrowed[in.dst.value] = true;
                 if (b.allow_b32_masks) rs.sreg_bool_b32.insert(in.dst.value);
@@ -5891,7 +5892,8 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                         b.ibin(Op_BitwiseAnd,
                                b.ibin(Op_ShiftRightLogical, result, bit), b.uconst(1)),
                         b.uconst(0));
-                    rs.vcc = b.bsel(in_written_half, result_bit, rs.vcc);
+                    rs.vcc = b.bsel(in_written_half, result_bit,
+                                    rs.vcc ? rs.vcc : b.bfalse());
                     rs.sreg_bool[in.dst.value] = rs.vcc;
                     rs.sreg_bool_narrowed[in.dst.value] = true;
                     return true;
@@ -5931,7 +5933,8 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                                       : in.opcode == 0x18 ? b.lor(n0, n1)
                                       : in.opcode == 0x1a ? b.land(n0, n1)
                                       : b.logical_not(x);
-                rs.vcc = b.bsel(in_written_half, result, rs.vcc);
+                rs.vcc = b.bsel(in_written_half, result,
+                                rs.vcc ? rs.vcc : b.bfalse());
                 rs.sreg_bool[in.dst.value] = rs.vcc;
                 rs.sreg_bool_narrowed[in.dst.value] = true;
                 rs.sreg.erase(in.dst.value);
@@ -8585,6 +8588,21 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     return true;
                 }
 
+                // The front-half emits this marker only when descriptor provenance is proven but
+                // the guarded descriptor load resolved to null. The instruction must still compile
+                // because it exists in the static control-flow graph, but no BVH bytes exist to
+                // traverse. Four invalid child IDs are the conservative no-hit result and avoid
+                // triplicating the large software intersection body in Astro Bot's world-map kernel.
+                if (is_bvh_no_hit_fallback(*bvh)) {
+                    for (uint32_t k = 0; k < 4; ++k) {
+                        const int vd = in.dst.value + static_cast<int>(k);
+                        const uint32_t old = vreg_old(b, rs, vd);
+                        rs.vreg[vd] = b.uconst(0xffffffffu);
+                        predicate_write(b, rs, vd, old);
+                    }
+                    return true;
+                }
+
                 auto addr_vgpr = [&](uint32_t k) -> int {
                     if (k == 0u) return in.src[0].value;
                     const uint32_t j = k - 1u;
@@ -10643,8 +10661,11 @@ bool emit_cfg_state_machine(
         }
         b.store_function(kv.second, value);
     }
-    b.store_function(scc_var, initial.scc);
-    b.store_function(vcc_var, initial.vcc);
+    b.store_function(scc_var, initial.scc ? initial.scc : no);
+    // VCC can be deliberately poisoned (id 0) when its physical SGPR word is recycled as scalar
+    // data. As with SCC, a dispatcher boundary ends that unrepresentable lifetime; persist false
+    // until a later architectural mask writer establishes a fresh value.
+    b.store_function(vcc_var, initial.vcc ? initial.vcc : no);
     b.store_function(exec_var, initial.exec);
     b.store_function(pc_var, b.uconst(0));
     b.store_function(active_var, yes);
@@ -10743,7 +10764,7 @@ bool emit_cfg_state_machine(
         // A poisoned (0) SCC degrades to bfalse at the block boundary: the same-block consumers
         // reject on the sentinel; cross-block staleness matches the pre-poison model.
         b.store_function(scc_var, state.scc ? state.scc : b.bfalse());
-        b.store_function(vcc_var, state.vcc);
+        b.store_function(vcc_var, state.vcc ? state.vcc : b.bfalse());
         b.store_function(exec_var, state.exec);
     };
 
@@ -11851,7 +11872,9 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                 rs.scc = b.emit_phi_2way(b.t_bool, then_scc ? then_scc : b.bfalse(), then_block,
                                          rs.scc ? rs.scc : b.bfalse(), else_block);
             if (then_vcc != rs.vcc)
-                rs.vcc = b.emit_phi_2way(b.t_bool, then_vcc, then_block, rs.vcc, else_block);
+                rs.vcc = b.emit_phi_2way(
+                    b.t_bool, then_vcc ? then_vcc : b.bfalse(), then_block,
+                    rs.vcc ? rs.vcc : b.bfalse(), else_block);
             if (then_exec != rs.exec)
                 rs.exec = b.emit_phi_2way(b.t_bool, then_exec, then_block, rs.exec, else_block);
             rs.exec_narrowed = then_narrowed || rs.exec_narrowed;
@@ -11899,7 +11922,7 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
         // A poisoned (0) SCC live-in degrades to bfalse — the loop shapes re-produce SCC via their
         // in-loop s_cmp before any read, so the phi seed is dead in practice; 0 would be invalid SSA.
         { size_t p; uint32_t ph = b.emit_phi2(b.t_bool, rs.scc ? rs.scc : b.bfalse(), preheader, p); rs.scc = ph; phis.push_back({0, 2, ph, p}); }
-        { size_t p; uint32_t ph = b.emit_phi2(b.t_bool, rs.vcc, preheader, p); rs.vcc = ph; phis.push_back({0, 3, ph, p}); }
+        { size_t p; uint32_t ph = b.emit_phi2(b.t_bool, rs.vcc ? rs.vcc : b.bfalse(), preheader, p); rs.vcc = ph; phis.push_back({0, 3, ph, p}); }
         if (carry_vertex_exec) {
             size_t p;
             uint32_t ph = b.emit_phi2(b.t_bool, rs.exec, preheader, p);
@@ -11941,7 +11964,8 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                         : pr.dom == 1 ? sget(pr.reg)
                         : pr.dom == 2 ? rs.scc
                         : pr.dom == 3 ? rs.vcc : rs.exec;
-            if (!nv && pr.dom == 2) nv = b.bfalse();   // poisoned SCC back-edge value: bfalse (dead in practice)
+            if (!nv && (pr.dom == 2 || pr.dom == 3))
+                nv = b.bfalse(); // poisoned transient wave flag: false at the loop boundary
             b.patch_phi(pr.patch, nv, cont);
         }
         b.emit_branch(hdr);
@@ -12198,7 +12222,7 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
             // A poisoned (0) SCC live-in degrades to bfalse (invalid as an SSA phi input; dead in
             // practice — the loop shapes re-produce SCC before any read).
             { size_t p; uint32_t ph = b.emit_phi2(b.t_bool, rs.scc ? rs.scc : b.bfalse(), preheader, p); rs.scc = ph; phis.push_back({0, 2, ph, p}); }
-            { size_t p; uint32_t ph = b.emit_phi2(b.t_bool, rs.vcc, preheader, p); rs.vcc = ph; phis.push_back({0, 3, ph, p}); }
+            { size_t p; uint32_t ph = b.emit_phi2(b.t_bool, rs.vcc ? rs.vcc : b.bfalse(), preheader, p); rs.vcc = ph; phis.push_back({0, 3, ph, p}); }
             { size_t p; uint32_t ph = b.emit_phi2(b.t_bool, rs.exec, preheader, p); rs.exec = ph; phis.push_back({0, 4, ph, p}); }
             std::vector<int> mask_keys;                        // saved masks live at entry: loop-carried bools
             for (auto& kv : rs.sreg_bool) mask_keys.push_back(kv.first);
@@ -12258,7 +12282,7 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                             : pr.dom == 3 ? rs.vcc
                             : pr.dom == 4 ? rs.exec
                             : (rs.sreg_bool.count(pr.reg) ? rs.sreg_bool[pr.reg] : pr.phi);
-                if (!nv && pr.dom == 2) nv = b.bfalse();   // poisoned SCC back-edge value
+                if (!nv && (pr.dom == 2 || pr.dom == 3)) nv = b.bfalse();
                 b.patch_phi(pr.patch, nv, cont);
             }
             b.emit_branch(hdr);
@@ -12267,13 +12291,13 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                 uint32_t chk_value = pr.dom == 0 ? (condv.count(pr.reg) ? condv_val[pr.reg] : pr.phi)
                                    : pr.dom == 1 ? (conds.count(pr.reg) ? conds_val[pr.reg] : pr.phi)
                                    : pr.dom == 2 ? (scc_chk ? scc_chk : b.bfalse())
-                                   : pr.dom == 3 ? vcc_chk
+                                   : pr.dom == 3 ? (vcc_chk ? vcc_chk : b.bfalse())
                                    : pr.dom == 4 ? exec_chk
                                    : (bool_chk.count(pr.reg) ? bool_chk.at(pr.reg) : pr.phi);
                 uint32_t body_value = pr.dom == 0 ? vget(pr.reg)
                                     : pr.dom == 1 ? sget(pr.reg)
                                     : pr.dom == 2 ? (rs.scc ? rs.scc : b.bfalse())
-                                    : pr.dom == 3 ? rs.vcc
+                                    : pr.dom == 3 ? (rs.vcc ? rs.vcc : b.bfalse())
                                     : pr.dom == 4 ? rs.exec
                                     : (rs.sreg_bool.count(pr.reg) ? rs.sreg_bool[pr.reg] : pr.phi);
                 const uint32_t merged = (L.direct_exec_breaks || L.direct_wave_breaks) &&
@@ -12393,7 +12417,10 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                     if (then_scc != pre_scc)   // poisoned (0) inputs degrade to bfalse across the merge
                         rs.scc = b.emit_phi_2way(b.t_bool, pre_scc ? pre_scc : b.bfalse(), preblock,
                                                  then_scc ? then_scc : b.bfalse(), thenEnd);
-                    if (then_vcc != pre_vcc) rs.vcc = b.emit_phi_2way(b.t_bool, pre_vcc, preblock, then_vcc, thenEnd);
+                    if (then_vcc != pre_vcc)
+                        rs.vcc = b.emit_phi_2way(
+                            b.t_bool, pre_vcc ? pre_vcc : b.bfalse(), preblock,
+                            then_vcc ? then_vcc : b.bfalse(), thenEnd);
                     // EXEC changed inside the arm (saveexec / v_cmpx / restore): merge it like any value.
                     // Narrowed-ness is sticky (either edge narrowed → post-merge writes stay predicated).
                     if (then_exec != pre_exec) rs.exec = b.emit_phi_2way(b.t_bool, pre_exec, preblock, then_exec, thenEnd);
@@ -12460,7 +12487,10 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                     if (then_scc != rs.scc)   // poisoned (0) inputs degrade to bfalse across the merge
                         rs.scc = b.emit_phi_2way(b.t_bool, then_scc ? then_scc : b.bfalse(), thenEnd,
                                                  rs.scc ? rs.scc : b.bfalse(), elseEnd);
-                    if (then_vcc != rs.vcc) rs.vcc = b.emit_phi_2way(b.t_bool, then_vcc, thenEnd, rs.vcc, elseEnd);
+                    if (then_vcc != rs.vcc)
+                        rs.vcc = b.emit_phi_2way(
+                            b.t_bool, then_vcc ? then_vcc : b.bfalse(), thenEnd,
+                            rs.vcc ? rs.vcc : b.bfalse(), elseEnd);
                     if (then_exec != rs.exec) rs.exec = b.emit_phi_2way(b.t_bool, then_exec, thenEnd, rs.exec, elseEnd);
                     rs.exec_narrowed = then_narrowed || rs.exec_narrowed;
                     rs.sreg_written.insert(then_written.begin(), then_written.end());

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -8566,6 +8566,201 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             if (!allow_smem || !rt) { ok = false; return true; }
             const uint32_t SQ_DIM_2D = 1u;
             auto vread = [&](int r){ auto it = rs.vreg.find(r); return it == rs.vreg.end() ? b.uconst(0) : it->second; };
+
+            // IMAGE_BVH_INTERSECT_RAY (GFX10 opcode 0xe6) has an image encoding but consumes a
+            // four-dword BVH descriptor and eleven NSA VGPR operands. Vulkan ray-query support is
+            // not available on every backend/device Prosper supports, so lower the exact RTIP 1.1
+            // contract used by Astro Bot to ordinary read-only SSBO loads and scalar ALU. The
+            // front-half admits only TYPE=8, triangle-return-mode=1, unsorted descriptors; keeping
+            // the instruction gate equally narrow makes every unverified variant fail visibly.
+            if (in.opcode == 0xe6u) {
+                const ShaderResource* bvh = rt->by_fetch_pc(in.pc);
+                if (in.words[0] != 0xf1989f07u || in.len_dwords != 5u ||
+                    in.mimg_dmask != 0xfu || !in.mimg_unorm || in.mimg_dim != 0u ||
+                    in.mimg_glc || in.src[2].value != 0 || (in.words[4] & 0xffff0000u) != 0u ||
+                    !bvh || bvh->cls != ResourceClass::ConstantBuffer ||
+                    bvh->format != DataFormat::Uint32 || bvh->num_components != 1u ||
+                    bvh->size < 128u || (bvh->size & 3u) != 0u) {
+                    ok = false;
+                    return true;
+                }
+
+                auto addr_vgpr = [&](uint32_t k) -> int {
+                    if (k == 0u) return in.src[0].value;
+                    const uint32_t j = k - 1u;
+                    return static_cast<int>((in.words[2u + j / 4u] >> (8u * (j % 4u))) & 0xffu);
+                };
+                uint32_t a[11]{};
+                for (uint32_t k = 0; k < 11; ++k) a[k] = vread(addr_vgpr(k));
+
+                const uint32_t node = a[0];
+                const uint32_t node_type = b.ibin(Op_BitwiseAnd, node, b.uconst(7u));
+                const uint32_t node_offset = b.ibin(Op_BitwiseAnd, node, b.uconst(~7u));
+                const uint32_t word_base = b.ibin(Op_ShiftLeftLogical, node_offset, b.uconst(1u));
+                const uint32_t dword_count = bvh->size / 4u;
+                const uint32_t valid64 = b.ucmp(
+                    Op_ULessThanEqual, node_offset, b.uconst((bvh->size - 64u) / 8u));
+                const uint32_t valid128 = b.ucmp(
+                    Op_ULessThanEqual, node_offset, b.uconst((bvh->size - 128u) / 8u));
+
+                // Every speculative load is independently clamped to dword zero. Results from a
+                // malformed/out-of-range pointer are discarded below, but the clamp also prevents
+                // an invalid guest pointer from becoming an out-of-bounds Vulkan SSBO access.
+                auto load_node = [&](uint32_t rel) {
+                    const uint32_t idx = rel
+                        ? b.ibin(Op_IAdd, word_base, b.uconst(rel)) : word_base;
+                    const uint32_t safe_idx = b.sel(
+                        b.ucmp(Op_ULessThan, idx, b.uconst(dword_count)), idx, b.uconst(0u));
+                    return b.cbuf_load(safe_idx, bvh->binding);
+                };
+                uint32_t w[28]{};
+                for (uint32_t k = 0; k < 28; ++k) w[k] = load_node(k);
+
+                const uint32_t zero = b.uconst(0u);
+                const uint32_t one = b.uconst(fbits(1.0f));
+                const uint32_t invalid = b.uconst(0xffffffffu);
+                const uint32_t is_tri0 = b.ucmp(Op_IEqual, node_type, b.uconst(0u));
+                const uint32_t is_tri1 = b.ucmp(Op_IEqual, node_type, b.uconst(1u));
+                const uint32_t is_box16 = b.ucmp(Op_IEqual, node_type, b.uconst(4u));
+                const uint32_t is_box32 = b.ucmp(Op_IEqual, node_type, b.uconst(5u));
+                const uint32_t tri_valid = b.land(b.lor(is_tri0, is_tri1), valid64);
+                const uint32_t box_valid = b.lor(b.land(is_box16, valid64),
+                                                 b.land(is_box32, valid128));
+
+                auto fadd = [&](uint32_t x, uint32_t y) { return b.fbin(Op_FAdd, x, y); };
+                auto fsub = [&](uint32_t x, uint32_t y) { return b.fbin(Op_FSub, x, y); };
+                auto fmul = [&](uint32_t x, uint32_t y) { return b.fbin(Op_FMul, x, y); };
+                auto dot3 = [&](const uint32_t x[3], const uint32_t y[3]) {
+                    return fadd(fadd(fmul(x[0], y[0]), fmul(x[1], y[1])), fmul(x[2], y[2]));
+                };
+                auto cross3 = [&](const uint32_t x[3], const uint32_t y[3], uint32_t out[3]) {
+                    out[0] = fsub(fmul(x[1], y[2]), fmul(x[2], y[1]));
+                    out[1] = fsub(fmul(x[2], y[0]), fmul(x[0], y[2]));
+                    out[2] = fsub(fmul(x[0], y[1]), fmul(x[1], y[0]));
+                };
+
+                // Triangle node types 0 and 1 share a 64-byte quad. Type 0 selects V0,V1,V2;
+                // type 1 selects V1,V3,V2. The four hardware return values are the unnormalised
+                // t numerator, determinant, I numerator and J numerator (mode 1).
+                uint32_t tv0[3] = {
+                    b.sel(is_tri1, w[3], w[0]),
+                    b.sel(is_tri1, w[4], w[1]),
+                    b.sel(is_tri1, w[5], w[2]),
+                };
+                uint32_t tv1[3] = {
+                    b.sel(is_tri1, w[9], w[3]),
+                    b.sel(is_tri1, w[10], w[4]),
+                    b.sel(is_tri1, w[11], w[5]),
+                };
+                uint32_t tv2[3] = {w[6], w[7], w[8]};
+                uint32_t edge1[3], edge2[3], from_v0[3];
+                for (uint32_t k = 0; k < 3; ++k) {
+                    edge1[k] = fsub(tv1[k], tv0[k]);
+                    edge2[k] = fsub(tv2[k], tv0[k]);
+                    from_v0[k] = fsub(a[2u + k], tv0[k]);
+                }
+                uint32_t ray_dir[3] = {a[5], a[6], a[7]};
+                uint32_t s1[3], s2[3];
+                cross3(ray_dir, edge2, s1);
+                cross3(from_v0, edge1, s2);
+                const uint32_t t_num = dot3(edge2, s2);
+                const uint32_t t_denom = dot3(s1, edge1);
+                const uint32_t i_num = dot3(from_v0, s1);
+                const uint32_t j_num = dot3(ray_dir, s2);
+                const uint32_t t = b.fbin(Op_FDiv, t_num, t_denom);
+                const uint32_t bary_i = b.fbin(Op_FDiv, i_num, t_denom);
+                const uint32_t bary_j = b.fbin(Op_FDiv, j_num, t_denom);
+                uint32_t tri_miss = b.lor(
+                    b.fcmp(Op_FOrdLessThan, bary_i, zero),
+                    b.fcmp(Op_FOrdGreaterThan, bary_i, one));
+                tri_miss = b.lor(tri_miss, b.fcmp(Op_FOrdLessThan, bary_j, zero));
+                tri_miss = b.lor(tri_miss,
+                    b.fcmp(Op_FOrdGreaterThan, fadd(bary_i, bary_j), one));
+                tri_miss = b.lor(tri_miss, b.fcmp(Op_FOrdLessThan, t, zero));
+                uint32_t tri_out[4] = {
+                    b.sel(tri_miss, b.uconst(0x7f800000u), t_num),
+                    b.sel(tri_miss, one, t_denom),
+                    i_num,
+                    j_num,
+                };
+
+                // Undo the pair-compression vertex rotation encoded in the final triangle-node
+                // dword. The two 2-bit fields select from {1-I-J, I, J}; valid RTIP 1.1 nodes never
+                // use selector 3, whose conservative fallback here is 1-I-J.
+                const uint32_t bary0_num = fsub(fsub(tri_out[1], i_num), j_num);
+                const uint32_t tri_shift = b.ibin(
+                    Op_ShiftLeftLogical,
+                    b.ibin(Op_BitwiseAnd, node_type, b.uconst(3u)), b.uconst(3u));
+                const uint32_t i_selector = b.ibin(
+                    Op_BitwiseAnd,
+                    b.ibin(Op_ShiftRightLogical, w[15], tri_shift), b.uconst(3u));
+                const uint32_t j_selector = b.ibin(
+                    Op_BitwiseAnd,
+                    b.ibin(Op_ShiftRightLogical, w[15],
+                           b.ibin(Op_IAdd, tri_shift, b.uconst(2u))),
+                    b.uconst(3u));
+                auto swizzled_bary = [&](uint32_t selector) {
+                    return b.sel(b.ucmp(Op_IEqual, selector, b.uconst(1u)), i_num,
+                        b.sel(b.ucmp(Op_IEqual, selector, b.uconst(2u)), j_num,
+                              bary0_num));
+                };
+                tri_out[2] = swizzled_bary(i_selector);
+                tri_out[3] = swizzled_bary(j_selector);
+
+                // Convert each FP16 box payload to the same six-float representation as an FP32
+                // box, then apply the slab test to all four children. Sorting is deliberately absent:
+                // the admitted Astro descriptor has BOX_SORT_EN=0, so architectural order is kept.
+                uint32_t box_out[4]{};
+                uint32_t ray_inv[3] = {a[8], a[9], a[10]};
+                for (uint32_t child = 0; child < 4; ++child) {
+                    const uint32_t hbase = 4u + child * 3u;
+                    uint32_t fp16_bounds[6] = {
+                        b.unpack_half(w[hbase], 0u), b.unpack_half(w[hbase], 1u),
+                        b.unpack_half(w[hbase + 1u], 0u), b.unpack_half(w[hbase + 1u], 1u),
+                        b.unpack_half(w[hbase + 2u], 0u), b.unpack_half(w[hbase + 2u], 1u),
+                    };
+                    const uint32_t fbase = 4u + child * 6u;
+                    uint32_t bmin[3], bmax[3];
+                    for (uint32_t axis = 0; axis < 3; ++axis) {
+                        bmin[axis] = b.sel(is_box16, fp16_bounds[axis], w[fbase + axis]);
+                        bmax[axis] = b.sel(is_box16, fp16_bounds[3u + axis], w[fbase + 3u + axis]);
+                    }
+                    uint32_t near_axis[3], far_axis[3];
+                    for (uint32_t axis = 0; axis < 3; ++axis) {
+                        const uint32_t t0 = fmul(fsub(bmin[axis], a[2u + axis]), ray_inv[axis]);
+                        const uint32_t t1 = fmul(fsub(bmax[axis], a[2u + axis]), ray_inv[axis]);
+                        const uint32_t positive = b.fcmp(Op_FOrdGreaterThanEqual, ray_inv[axis], zero);
+                        near_axis[axis] = b.sel(positive, t0, t1);
+                        far_axis[axis] = b.sel(positive, t1, t0);
+                    }
+                    const uint32_t near_unclamped = b.fext2(
+                        Glsl_FMax, b.fext2(Glsl_FMax, near_axis[0], near_axis[1]), near_axis[2]);
+                    const uint32_t far_unclamped = b.fext2(
+                        Glsl_FMin, b.fext2(Glsl_FMin, far_axis[0], far_axis[1]), far_axis[2]);
+                    const uint32_t near_t = b.fext2(Glsl_FMax, near_unclamped, zero);
+                    const uint32_t far_t = b.fext2(Glsl_FMin, far_unclamped, a[1]);
+                    const uint32_t nan_interval = b.lor(
+                        b.fcmp(Op_FUnordNotEqual, near_unclamped, near_unclamped),
+                        b.fcmp(Op_FUnordNotEqual, far_unclamped, far_unclamped));
+                    const uint32_t hit = b.land(
+                        b.logical_not(nan_interval),
+                        // RTIP 1.1 grows the post-projection far edge by 6 * 2^-24;
+                        // at 1.0f that multiplier is exactly three float ULPs.
+                        b.fcmp(Op_FOrdLessThanEqual, near_t,
+                               fmul(far_t, b.uconst(0x3f800003u))));
+                    box_out[child] = b.sel(b.land(box_valid, hit), w[child], invalid);
+                }
+
+                for (uint32_t k = 0; k < 4; ++k) {
+                    const uint32_t result = b.sel(tri_valid, tri_out[k], box_out[k]);
+                    const int vd = in.dst.value + static_cast<int>(k);
+                    const uint32_t old = vreg_old(b, rs, vd);
+                    rs.vreg[vd] = result;
+                    predicate_write(b, rs, vd, old);
+                }
+                return true;
+            }
+
             // Resolve the T#/U# via SRSRC (src[1]) provenance: s_load tag (indirect) else user-data SGPR.
             const ShaderResource* res = rt->by_fetch_pc(in.pc);
             if (!res || (res->cls != ResourceClass::Texture && res->cls != ResourceClass::StorageImage)) {

--- a/prosper/src/gpu/shader_resources.hpp
+++ b/prosper/src/gpu/shader_resources.hpp
@@ -298,6 +298,18 @@ struct ShaderResource {
     uint64_t       host_data_size   = 0;
 };
 
+// A statically proven missing BVH descriptor is materialized as this exact host-owned resource.
+// Guest address zero cannot name a real BVH allocation, so the recompiler may replace the guarded
+// IMAGE_BVH_INTERSECT_RAY use with a compact deterministic no-hit result. Keeping the marker derived
+// from serialized resource fields also preserves capture/replay without changing the capture ABI.
+inline bool is_bvh_no_hit_fallback(const ShaderResource& resource) {
+    return resource.cls == ResourceClass::ConstantBuffer &&
+           resource.format == DataFormat::Uint32 && resource.num_components == 1u &&
+           resource.gpu_addr == 0 && resource.size == 256u && resource.stride == 0u &&
+           resource.fetch_pc != 0xFFFFFFFFu && resource.host_data != nullptr &&
+           resource.host_data_size >= resource.size;
+}
+
 // The set of resources a shader uses. The front-half builds it from the shader's user_data; the
 // recompiler consults it while translating memory ops and the pipeline binds from it. Pure data.
 struct ShaderResourceTable {

--- a/prosper/src/gpu/shader_resources.hpp
+++ b/prosper/src/gpu/shader_resources.hpp
@@ -184,6 +184,11 @@ struct ShaderResource {
     uint32_t      fetch_pc      = 0xFFFFFFFFu;
     VertexFetchIndexMode fetch_index_mode = VertexFetchIndexMode::Automatic;
 
+    // BVH descriptor BOX_GROW (bits 62:55). IMAGE_BVH_INTERSECT_RAY expands box intervals by
+    // this many 2^-24 increments; zero is exact/no growth. Meaningful only for the per-fetch raw
+    // ConstantBuffer view created from a validated BVH descriptor.
+    uint32_t      bvh_box_grow  = 0;
+
     // FLAT-window (#1171) provenance: for a general flat_load whose 64-bit source pointer lives in the
     // consecutive user SGPRs s[flat_base_sgpr : +1], the executor binds the containing guest allocation
     // as this SSBO (keyed by the load's fetch_pc) and the emitter lowers the load to an indexed read at
@@ -297,18 +302,6 @@ struct ShaderResource {
     uint8_t*       host_data        = nullptr;
     uint64_t       host_data_size   = 0;
 };
-
-// A statically proven missing BVH descriptor is materialized as this exact host-owned resource.
-// Guest address zero cannot name a real BVH allocation, so the recompiler may replace the guarded
-// IMAGE_BVH_INTERSECT_RAY use with a compact deterministic no-hit result. Keeping the marker derived
-// from serialized resource fields also preserves capture/replay without changing the capture ABI.
-inline bool is_bvh_no_hit_fallback(const ShaderResource& resource) {
-    return resource.cls == ResourceClass::ConstantBuffer &&
-           resource.format == DataFormat::Uint32 && resource.num_components == 1u &&
-           resource.gpu_addr == 0 && resource.size == 256u && resource.stride == 0u &&
-           resource.fetch_pc != 0xFFFFFFFFu && resource.host_data != nullptr &&
-           resource.host_data_size >= resource.size;
-}
 
 // The set of resources a shader uses. The front-half builds it from the shader's user_data; the
 // recompiler consults it while translating memory ops and the pipeline binds from it. Pure data.

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -682,6 +682,41 @@ int main() {
               astro_bvh_table.resources[0].fetch_pc == 0,
           "Astro BVH bytes materialize as the instruction-scoped read-only compute buffer");
 
+    // Recreate the live descriptor builder rather than seeding its final words: the header pointer
+    // is stored in 8-byte units, the allocation count is loaded from byte offset 0x58, and a
+    // carry-propagating subtract produces the 64-byte count-minus-one before TYPE/mode are ORed in.
+    // Dropping either S_LSHL_B64's high half or S_ADDC_U32's carry leaves this use unresolved.
+    astro_bvh_backing[22] = 64u;
+    astro_bvh_backing[23] = 0u;
+    const uint32_t astro_bvh_builder[] = {
+        0x8F88831Cu,                         // pc0:  s_lshl_b64 s[8:9], s[28:29], 3
+        0xF4100404u, 0xFA000000u,            // pc1:  s_load_dwordx16 s[16:31], s[8:9], 0
+        0xF4080904u, 0xFA000058u,            // pc3:  s_load_dwordx4 s[36:39], s[8:9], 0x58
+        0x8012C124u,                         // pc5:  s_add_u32 s18, s36, -1
+        0x8213C125u,                         // pc6:  s_addc_u32 s19, s37, -1
+        0x876A13FFu, 0x000003FFu,            // pc7:  s_and_b32 s106, 0x3ff, s19
+        0x9490FF08u, 0x00280008u,            // pc9:  s_bfe_u64 s[16:17], s[8:9], 8:40
+        0x8813FF6Au, 0x81000000u,            // pc11: s_or_b32 s19, s106, TYPE/mode
+        0xF1989F07u, 0x00040303u, 0x43440D3Fu, 0x46424140u, 0x00004847u,
+        0xBF810000u,
+    };
+    std::array<uint32_t, 40> astro_builder_seed{};
+    const uint64_t astro_bvh_base8 = astro_bvh_base >> 3;
+    astro_builder_seed[28] = static_cast<uint32_t>(astro_bvh_base8);
+    astro_builder_seed[29] = static_cast<uint32_t>(astro_bvh_base8 >> 32);
+    std::vector<SrtUse> astro_builder_uses;
+    resolve_dynamic_fetch(astro_bvh_builder, std::size(astro_bvh_builder),
+                          astro_builder_seed.data(), astro_builder_seed.size(), 0,
+                          &astro_builder_uses);
+    const DecodedBvhDescriptor built_bvh = astro_builder_uses.size() == 1
+        ? decode_bvh_descriptor(astro_builder_uses[0].bvh4.data())
+        : DecodedBvhDescriptor{};
+    CHECK(astro_builder_uses.size() == 1 && astro_builder_uses[0].kind == 2 &&
+              built_bvh.base == astro_bvh_base &&
+              built_bvh.size_bytes == sizeof(astro_bvh_backing) &&
+              built_bvh.type == 8u && built_bvh.triangle_return_mode,
+          "Astro's carry/shift descriptor builder resolves the exact BVH binding");
+
     // Astro Bot's live visibility packet consumes a direct R32_UINT T# in s[0:7]. Opcode 0x0f is
     // IMAGE_ATOMIC_SWAP, so its instruction-scoped resource must be materialized as a storage image
     // even though the packet's unused SSAMP field aliases s0.

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -642,6 +642,46 @@ int main() {
           direct_uses[0].s4[0] == seed5d[8] && direct_uses[0].s4[3] == seed5d[11],
           "direct user-SGPR T#/S# dwords are preserved");
 
+    // Astro Bot's world-map kernel uses IMAGE_BVH_INTERSECT_RAY with a compact four-dword BVH
+    // descriptor in s[16:19]. It must not be mistaken for an eight-dword texture descriptor.
+    alignas(256) static uint32_t astro_bvh_backing[1024]{};
+    const uint64_t astro_bvh_base = reinterpret_cast<uint64_t>(astro_bvh_backing);
+    const uint32_t astro_bvh_seed[4] = {
+        static_cast<uint32_t>(astro_bvh_base >> 8),
+        static_cast<uint32_t>((astro_bvh_base >> 40) & 0xFFu),
+        63u,                         // (63 + 1) * 64 = 4096 bytes
+        0x81000000u,                // TYPE=8, TRIANGLE_RETURN_MODE=1
+    };
+    const uint32_t astro_bvh_intersect[] = {
+        0xf1989f07u, 0x00040303u, 0x43440d3fu, 0x46424140u, 0x00004847u,
+        0xbf810000u,
+    };
+    const DecodedBvhDescriptor decoded_bvh = decode_bvh_descriptor(astro_bvh_seed);
+    CHECK(decoded_bvh.base == astro_bvh_base && decoded_bvh.size_bytes == sizeof(astro_bvh_backing) &&
+              decoded_bvh.type == 8u && decoded_bvh.triangle_return_mode &&
+              !decoded_bvh.box_node_64b && !decoded_bvh.sort_enabled,
+          "GFX10 BVH descriptor decodes its 256-byte base, 64-byte count and flags");
+    std::vector<SrtUse> astro_bvh_uses;
+    resolve_dynamic_fetch(astro_bvh_intersect, std::size(astro_bvh_intersect),
+                          astro_bvh_seed, std::size(astro_bvh_seed), 16, &astro_bvh_uses);
+    CHECK(astro_bvh_uses.size() == 1 && astro_bvh_uses[0].kind == 2 &&
+              astro_bvh_uses[0].use_pc == 0 && astro_bvh_uses[0].bvh4[0] == astro_bvh_seed[0] &&
+              astro_bvh_uses[0].bvh4[3] == astro_bvh_seed[3],
+          "Astro IMAGE_BVH_INTERSECT_RAY publishes its live four-word BVH descriptor by pc");
+    std::array<uint32_t, 20> astro_compute_seed{};
+    std::copy(std::begin(astro_bvh_seed), std::end(astro_bvh_seed),
+              astro_compute_seed.begin() + 16);
+    ShaderResourceTable astro_bvh_table;
+    add_compute_buffer_resources(astro_bvh_table, astro_bvh_intersect,
+                                 std::size(astro_bvh_intersect), astro_compute_seed.data(),
+                                 astro_compute_seed.size());
+    CHECK(astro_bvh_table.resources.size() == 1 &&
+              astro_bvh_table.resources[0].cls == ResourceClass::ConstantBuffer &&
+              astro_bvh_table.resources[0].gpu_addr == astro_bvh_base &&
+              astro_bvh_table.resources[0].size == sizeof(astro_bvh_backing) &&
+              astro_bvh_table.resources[0].fetch_pc == 0,
+          "Astro BVH bytes materialize as the instruction-scoped read-only compute buffer");
+
     // Astro Bot's live visibility packet consumes a direct R32_UINT T# in s[0:7]. Opcode 0x0f is
     // IMAGE_ATOMIC_SWAP, so its instruction-scoped resource must be materialized as a storage image
     // even though the packet's unused SSAMP field aliases s0.

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -682,6 +682,43 @@ int main() {
               astro_bvh_table.resources[0].fetch_pc == 0,
           "Astro BVH bytes materialize as the instruction-scoped read-only compute buffer");
 
+    // The first live world-map dispatch reaches static BVH instructions with a null descriptor
+    // table entry. Guest control flow guards those instructions, but static SPIR-V translation
+    // still needs their descriptor bindings. A failed descriptor snapshot therefore receives a
+    // bounded host-owned marker that the recompiler specializes to a deterministic no-hit result
+    // if the guarded path is unexpectedly taken.
+    const uint32_t unresolved_bvh_intersect[] = {
+        0xF4100404u, 0xFA000000u,            // s_load_dwordx16 s[16:31], s[8:9], 0 (prior block)
+        0xF4100405u, 0xFA000000u,            // s_load_dwordx16 s[16:31], s[10:11], 0 (null)
+        0xF1989F07u, 0x00040303u, 0x43440D3Fu, 0x46424140u, 0x00004847u,
+        0xBF810000u,
+    };
+    std::array<uint32_t, 32> null_bvh_seed{};
+    null_bvh_seed[8] = static_cast<uint32_t>(astro_bvh_base);
+    null_bvh_seed[9] = static_cast<uint32_t>(astro_bvh_base >> 32);
+    std::vector<SrtUse> unresolved_bvh_uses;
+    resolve_dynamic_fetch(unresolved_bvh_intersect, std::size(unresolved_bvh_intersect),
+                          null_bvh_seed.data(), null_bvh_seed.size(), 0,
+                          &unresolved_bvh_uses);
+    CHECK(unresolved_bvh_uses.size() == 1 && unresolved_bvh_uses[0].kind == 2 &&
+              unresolved_bvh_uses[0].use_pc == 4 &&
+              std::all_of(unresolved_bvh_uses[0].bvh4.begin(),
+                          unresolved_bvh_uses[0].bvh4.end(),
+                          [](uint32_t word) { return word == 0; }),
+          "guarded unresolved Astro BVH use retains an exact-pc no-hit marker");
+    ShaderResourceTable unresolved_bvh_table;
+    add_compute_buffer_resources(unresolved_bvh_table, unresolved_bvh_intersect,
+                                 std::size(unresolved_bvh_intersect), null_bvh_seed.data(),
+                                 null_bvh_seed.size());
+    CHECK(unresolved_bvh_table.resources.size() == 1 &&
+              unresolved_bvh_table.resources[0].cls == ResourceClass::ConstantBuffer &&
+              unresolved_bvh_table.resources[0].gpu_addr == 0 &&
+              unresolved_bvh_table.resources[0].size == 256 &&
+              unresolved_bvh_table.resources[0].fetch_pc == 4 &&
+              unresolved_bvh_table.resources[0].host_data != nullptr &&
+              unresolved_bvh_table.resources[0].host_data_size == 256,
+          "guarded unresolved Astro BVH use materializes a bounded host no-hit buffer");
+
     // Recreate the live descriptor builder rather than seeding its final words: the header pointer
     // is stored in 8-byte units, the allocation count is loaded from byte offset 0x58, and a
     // carry-propagating subtract produces the 64-byte count-minus-one before TYPE/mode are ORed in.

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -648,7 +648,7 @@ int main() {
     const uint64_t astro_bvh_base = reinterpret_cast<uint64_t>(astro_bvh_backing);
     const uint32_t astro_bvh_seed[4] = {
         static_cast<uint32_t>(astro_bvh_base >> 8),
-        static_cast<uint32_t>((astro_bvh_base >> 40) & 0xFFu),
+        static_cast<uint32_t>((astro_bvh_base >> 40) & 0xFFu) | (6u << 23),
         63u,                         // (63 + 1) * 64 = 4096 bytes
         0x81000000u,                // TYPE=8, TRIANGLE_RETURN_MODE=1
     };
@@ -659,8 +659,14 @@ int main() {
     const DecodedBvhDescriptor decoded_bvh = decode_bvh_descriptor(astro_bvh_seed);
     CHECK(decoded_bvh.base == astro_bvh_base && decoded_bvh.size_bytes == sizeof(astro_bvh_backing) &&
               decoded_bvh.type == 8u && decoded_bvh.triangle_return_mode &&
-              !decoded_bvh.box_node_64b && !decoded_bvh.sort_enabled,
+              decoded_bvh.box_grow == 6u && !decoded_bvh.box_node_64b &&
+              !decoded_bvh.sort_enabled,
           "GFX10 BVH descriptor decodes its 256-byte base, 64-byte count and flags");
+    uint32_t zero_grow_bvh_seed[4];
+    std::copy(std::begin(astro_bvh_seed), std::end(astro_bvh_seed), zero_grow_bvh_seed);
+    zero_grow_bvh_seed[1] &= ~(0xFFu << 23);
+    CHECK(decode_bvh_descriptor(zero_grow_bvh_seed).box_grow == 0u,
+          "GFX10 BVH descriptor preserves a zero box-grow value");
     std::vector<SrtUse> astro_bvh_uses;
     resolve_dynamic_fetch(astro_bvh_intersect, std::size(astro_bvh_intersect),
                           astro_bvh_seed, std::size(astro_bvh_seed), 16, &astro_bvh_uses);
@@ -679,45 +685,9 @@ int main() {
               astro_bvh_table.resources[0].cls == ResourceClass::ConstantBuffer &&
               astro_bvh_table.resources[0].gpu_addr == astro_bvh_base &&
               astro_bvh_table.resources[0].size == sizeof(astro_bvh_backing) &&
+              astro_bvh_table.resources[0].bvh_box_grow == 6u &&
               astro_bvh_table.resources[0].fetch_pc == 0,
           "Astro BVH bytes materialize as the instruction-scoped read-only compute buffer");
-
-    // The first live world-map dispatch reaches static BVH instructions with a null descriptor
-    // table entry. Guest control flow guards those instructions, but static SPIR-V translation
-    // still needs their descriptor bindings. A failed descriptor snapshot therefore receives a
-    // bounded host-owned marker that the recompiler specializes to a deterministic no-hit result
-    // if the guarded path is unexpectedly taken.
-    const uint32_t unresolved_bvh_intersect[] = {
-        0xF4100404u, 0xFA000000u,            // s_load_dwordx16 s[16:31], s[8:9], 0 (prior block)
-        0xF4100405u, 0xFA000000u,            // s_load_dwordx16 s[16:31], s[10:11], 0 (null)
-        0xF1989F07u, 0x00040303u, 0x43440D3Fu, 0x46424140u, 0x00004847u,
-        0xBF810000u,
-    };
-    std::array<uint32_t, 32> null_bvh_seed{};
-    null_bvh_seed[8] = static_cast<uint32_t>(astro_bvh_base);
-    null_bvh_seed[9] = static_cast<uint32_t>(astro_bvh_base >> 32);
-    std::vector<SrtUse> unresolved_bvh_uses;
-    resolve_dynamic_fetch(unresolved_bvh_intersect, std::size(unresolved_bvh_intersect),
-                          null_bvh_seed.data(), null_bvh_seed.size(), 0,
-                          &unresolved_bvh_uses);
-    CHECK(unresolved_bvh_uses.size() == 1 && unresolved_bvh_uses[0].kind == 2 &&
-              unresolved_bvh_uses[0].use_pc == 4 &&
-              std::all_of(unresolved_bvh_uses[0].bvh4.begin(),
-                          unresolved_bvh_uses[0].bvh4.end(),
-                          [](uint32_t word) { return word == 0; }),
-          "guarded unresolved Astro BVH use retains an exact-pc no-hit marker");
-    ShaderResourceTable unresolved_bvh_table;
-    add_compute_buffer_resources(unresolved_bvh_table, unresolved_bvh_intersect,
-                                 std::size(unresolved_bvh_intersect), null_bvh_seed.data(),
-                                 null_bvh_seed.size());
-    CHECK(unresolved_bvh_table.resources.size() == 1 &&
-              unresolved_bvh_table.resources[0].cls == ResourceClass::ConstantBuffer &&
-              unresolved_bvh_table.resources[0].gpu_addr == 0 &&
-              unresolved_bvh_table.resources[0].size == 256 &&
-              unresolved_bvh_table.resources[0].fetch_pc == 4 &&
-              unresolved_bvh_table.resources[0].host_data != nullptr &&
-              unresolved_bvh_table.resources[0].host_data_size == 256,
-          "guarded unresolved Astro BVH use materializes a bounded host no-hit buffer");
 
     // Recreate the live descriptor builder rather than seeding its final words: the header pointer
     // is stored in 8-byte units, the allocation count is loaded from byte offset 0x58, and a

--- a/prosper/tests/test_gpu_capture.cpp
+++ b/prosper/tests/test_gpu_capture.cpp
@@ -100,6 +100,7 @@ int main() {
     a.fetch_index_mode = VertexFetchIndexMode::Instance;
     ShaderResource b{}; b.cls = ResourceClass::ConstantBuffer; b.binding = 2; b.gpu_addr = 0x1008;
     b.size = 16; b.format = DataFormat::Float32; b.num_components = 4; b.srt_offset = 0x20;
+    b.bvh_box_grow = 6;
     ShaderResource dcc{}; dcc.cls = ResourceClass::Texture; dcc.binding = 4; dcc.gpu_addr = 0x1000;
     dcc.size = 16; dcc.format = DataFormat::Unorm8; dcc.num_components = 4;
     dcc.width = dcc.height = 2; dcc.max_uncompressed_block_size = 2;
@@ -372,6 +373,17 @@ int main() {
         return bytes;
     };
 
+    // v40: one BOX_GROW value per realized and failed-stage resource.
+    auto v40_tail = [](const GpuCaptureFile& f) -> size_t {
+        size_t rc = 0;
+        for (const auto& d : f.draws) rc += d.vrt.resources.size() + d.prt.resources.size();
+        for (const auto& cm : f.computes) rc += cm.resources.resources.size();
+        for (const auto& diagnostic : f.failure_diagnostics)
+            for (const auto& stage : diagnostic.stages)
+                rc += stage.resource_table.resources.size();
+        return 4 + 4 * rc;
+    };
+
     // v25 (#1240): byte length of the trailing resolve-state block.
     auto v25_tail = [](const GpuCaptureFile& f) -> size_t {
         size_t present_failures = 0;
@@ -403,6 +415,7 @@ int main() {
               v16_scissor_bytes.size() >= 25,
           "v17 capture serializes effective guest scissor state");
     if (v16_scissor_bytes.size() >= 25) {
+        v16_scissor_bytes.resize(v16_scissor_bytes.size() - v40_tail(v16_scissor_source));
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - v39_tail(v16_scissor_source));
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - v37_tail(v16_scissor_source));
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - v36_tail(v16_scissor_source));
@@ -510,7 +523,7 @@ int main() {
     };
     GpuCaptureFile video_capture;
     CHECK(capture_draw_items({video_draw}, meta, video_reader, video_capture, error) &&
-              video_capture.format_version == 39 && video_capture.blobs.size() == 1 &&
+              video_capture.format_version == 40 && video_capture.blobs.size() == 1 &&
               video_capture.blobs[0].bytes.size() == video_memory.size() &&
               video_capture.draws[0].prt.resources[0].captured_size == video_memory.size() &&
               video_capture.draws[0].prt.resources[0].resource.linear_row_pitch_bytes == 2048,
@@ -520,7 +533,7 @@ int main() {
     GpuReplayFrame video_replay;
     CHECK(serialize_gpu_capture(video_capture, video_capture_bytes, error) &&
               deserialize_gpu_capture(video_capture_bytes, video_loaded, error) &&
-              video_loaded.format_version == 39 &&
+              video_loaded.format_version == 40 &&
               video_loaded.draws[0].prt.resources[0].captured_size == video_memory.size() &&
               video_loaded.draws[0].prt.resources[0].resource.linear_row_pitch_bytes == 2048 &&
               materialize_gpu_replay(video_loaded, video_replay, error) &&
@@ -543,7 +556,7 @@ int main() {
     GpuReplayFrame upgraded_video_replay;
     CHECK(serialize_gpu_capture(legacy_video, upgraded_video_bytes, error) &&
               deserialize_gpu_capture(upgraded_video_bytes, upgraded_video, error) &&
-              upgraded_video.format_version == 39 &&
+              upgraded_video.format_version == 40 &&
               upgraded_video.draws[0].prt.resources[0].captured_size == video_chroma.size &&
               upgraded_video.draws[0].prt.resources[0].resource.linear_row_pitch_bytes == 2048 &&
               materialize_gpu_replay(upgraded_video, upgraded_video_replay, error) &&
@@ -625,7 +638,7 @@ int main() {
           "Plucky RGBA16 32-cubed S3 capture uses its four true 3D macroblocks");
     CHECK(serialize_gpu_capture(array_layout_capture, array_layout_bytes, error) &&
               deserialize_gpu_capture(array_layout_bytes, array_layout_loaded, error) &&
-              array_layout_loaded.format_version == 39 &&
+              array_layout_loaded.format_version == 40 &&
               array_layout_loaded.draws[0].vrt.resources[0].resource.layer_stride_bytes == 720896u &&
               array_layout_loaded.draws[0].vrt.resources[0].resource.layer_mip_offset_bytes == 65536u,
           "v32 capture round-trips thin-array slice stride and selected-mip offset");
@@ -724,6 +737,7 @@ int main() {
           "writer rejects an out-of-bounds DCC metadata reference");
     CHECK(serialize_gpu_capture(volume_capture, volume_bytes, error),
           "recreated valid v12 DCC bytes after malformed-reference check");
+    volume_bytes.resize(volume_bytes.size() - v40_tail(volume_capture));
     volume_bytes.resize(volume_bytes.size() - v39_tail(volume_capture));
     volume_bytes.resize(volume_bytes.size() - v37_tail(volume_capture));
     volume_bytes.resize(volume_bytes.size() - v36_tail(volume_capture));
@@ -821,6 +835,7 @@ int main() {
     CHECK(serialize_gpu_capture(pre_v31_source, v20_bytes, error) && v20_bytes.size() >= 21,
           "v21 capture serializes the logic-op extension");
     if (v20_bytes.size() >= 21) {
+        v20_bytes.resize(v20_bytes.size() - v40_tail(pre_v31_source));
         v20_bytes.resize(v20_bytes.size() - v39_tail(pre_v31_source));
         v20_bytes.resize(v20_bytes.size() - v37_tail(pre_v31_source));
         v20_bytes.resize(v20_bytes.size() - v36_tail(pre_v31_source));
@@ -880,10 +895,13 @@ int main() {
     CHECK(loaded.draws[0].vrt.resources[0].resource.fetch_index_mode ==
               VertexFetchIndexMode::Instance,
           "v30 fetch-index provenance round-trips explicitly for gpu_replay");
+    CHECK(loaded.draws[0].vrt.resources[1].resource.bvh_box_grow == 6,
+          "v40 BVH box-grow state round-trips explicitly for raw replay");
     std::vector<uint8_t> v24_resolve_bytes;
     GpuCaptureFile v24_resolve_loaded;
     CHECK(serialize_gpu_capture(pre_v31_source, v24_resolve_bytes, error) &&
-          v24_resolve_bytes.size() >= v39_tail(pre_v31_source) +
+          v24_resolve_bytes.size() >= v40_tail(pre_v31_source) +
+              v39_tail(pre_v31_source) +
               v37_tail(pre_v31_source) +
               v36_tail(pre_v31_source) +
               v35_tail(pre_v31_source) + v34_tail(pre_v31_source) +
@@ -893,7 +911,8 @@ int main() {
               v27_tail(pre_v31_source) + v26_tail(pre_v31_source) +
               v25_tail(pre_v31_source),
           "v25 capture exposes a removable trailing resolve-state block");
-    if (v24_resolve_bytes.size() >= v39_tail(pre_v31_source) +
+    if (v24_resolve_bytes.size() >= v40_tail(pre_v31_source) +
+            v39_tail(pre_v31_source) +
             v37_tail(pre_v31_source) +
             v36_tail(pre_v31_source) +
             v35_tail(pre_v31_source) + v34_tail(pre_v31_source) +
@@ -902,6 +921,7 @@ int main() {
             v29_tail(pre_v31_source) + v28_tail(pre_v31_source) +
             v27_tail(pre_v31_source) + v26_tail(pre_v31_source) +
             v25_tail(pre_v31_source)) {
+        v24_resolve_bytes.resize(v24_resolve_bytes.size() - v40_tail(pre_v31_source));
         v24_resolve_bytes.resize(v24_resolve_bytes.size() - v39_tail(pre_v31_source));
         v24_resolve_bytes.resize(v24_resolve_bytes.size() - v37_tail(pre_v31_source));
         v24_resolve_bytes.resize(v24_resolve_bytes.size() - v36_tail(pre_v31_source));
@@ -994,7 +1014,8 @@ int main() {
     CHECK(serialize_gpu_capture(captured, v37_compatible_bytes, error) &&
               v37_compatible_bytes.size() >= 12,
           "current capture prepares the layout-compatible v37 fixture");
-    if (v37_compatible_bytes.size() >= v39_tail(captured)) {
+    if (v37_compatible_bytes.size() >= v40_tail(captured) + v39_tail(captured)) {
+        v37_compatible_bytes.resize(v37_compatible_bytes.size() - v40_tail(captured));
         v37_compatible_bytes.resize(v37_compatible_bytes.size() - v39_tail(captured));
         v37_compatible_bytes[8] = 37;
         v37_compatible_bytes[9] = v37_compatible_bytes[10] =
@@ -1171,10 +1192,13 @@ int main() {
     v36_compute_source.raw_shader_versions.clear();
     CHECK(serialize_gpu_capture(v36_compute_source, v36_compute_bytes, error) &&
               v36_compute_bytes.size() >=
-                  v39_tail(v36_compute_source) + v37_tail(v36_compute_source),
+                  v40_tail(v36_compute_source) + v39_tail(v36_compute_source) +
+                      v37_tail(v36_compute_source),
           "v37 capture exposes a removable compute subgroup-contract tail");
     if (v36_compute_bytes.size() >=
-        v39_tail(v36_compute_source) + v37_tail(v36_compute_source)) {
+        v40_tail(v36_compute_source) + v39_tail(v36_compute_source) +
+            v37_tail(v36_compute_source)) {
+        v36_compute_bytes.resize(v36_compute_bytes.size() - v40_tail(v36_compute_source));
         v36_compute_bytes.resize(v36_compute_bytes.size() - v39_tail(v36_compute_source));
         v36_compute_bytes.resize(v36_compute_bytes.size() - v37_tail(v36_compute_source));
         v36_compute_bytes[8] = 36;
@@ -1487,6 +1511,7 @@ int main() {
     if (v13_bytes.size() >= 32) {
         const size_t legacy_resource_count = legacy_source.draws[0].vrt.resources.size() +
                                              legacy_source.draws[0].prt.resources.size();
+        v13_bytes.resize(v13_bytes.size() - v40_tail(legacy_source));
         v13_bytes.resize(v13_bytes.size() - v39_tail(legacy_source));
         v13_bytes.resize(v13_bytes.size() - v37_tail(legacy_source));
         v13_bytes.resize(v13_bytes.size() - v36_tail(legacy_source));
@@ -1524,6 +1549,7 @@ int main() {
     if (legacy_bytes.size() >= 32) {
         const size_t legacy_resource_count = legacy_source.draws[0].vrt.resources.size() +
                                              legacy_source.draws[0].prt.resources.size();
+        legacy_bytes.resize(legacy_bytes.size() - v40_tail(legacy_source));
         legacy_bytes.resize(legacy_bytes.size() - v39_tail(legacy_source));
         legacy_bytes.resize(legacy_bytes.size() - v37_tail(legacy_source));
         legacy_bytes.resize(legacy_bytes.size() - v36_tail(legacy_source));
@@ -1587,9 +1613,9 @@ int main() {
     CHECK(deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
           !legacy_loaded.failure_diagnostics_available && legacy_loaded.failure_diagnostics.empty(),
           "v6 capture reopens with failed-operation diagnostics reported unavailable");
-    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 40;   // kVersion + 1: a future version
+    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 41;   // kVersion + 1: a future version
     CHECK(!deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
-          error == "unsupported capture version 40",
+          error == "unsupported capture version 41",
           "future capture versions fail with a concrete version error");
 
     GpuCaptureFile bad_hash = mixed;

--- a/prosper/tests/test_gpu_execute.cpp
+++ b/prosper/tests/test_gpu_execute.cpp
@@ -44,6 +44,7 @@ alignas(256) static const uint32_t kDccPs[] = {
     0x7E000280u, 0xF8001803u, 0x00000000u, 0xBF810000u,
 };
 alignas(256) static const uint32_t kNoopCs[] = {0xBF810000u};
+alignas(256) static uint32_t kOrderedLateCs[] = {0u};
 static void set_pgm(GpuState& st, uint32_t lo_off, uint32_t hi_off, const void* p) {
     uint64_t a = (uint64_t)(uintptr_t)p;
     st.sh[lo_off] = (uint32_t)((a >> 8) & 0xFFFFFFFFu);
@@ -925,6 +926,62 @@ int main() {
                   resolved_large.groups_x == large_indirect_args[0] &&
                   resolved_large.groups_y == 1 && resolved_large.groups_z == 1,
               "indirect dispatch retains workgroup counts above Vulkan's portable minimum");
+
+        // Direct compute packets also need ordered realization. The first backend call stands in for
+        // a producer that updates guest-visible shader/resource bytes; the later direct dispatch must
+        // be realized only after that producer completes. Eager whole-submit realization would reject
+        // kOrderedLateCs while it still contains an unsupported zero word and invoke the backend once.
+        ShaderReg late_registers[2] = {
+            {P::COMPUTE_PGM_LO, 0}, {P::COMPUTE_PGM_HI, 0},
+        };
+        AgcShaderHeader late_header{};
+        late_header.file_header = 0x34333231u;
+        late_header.version = 0x18;
+        late_header.sh_registers = late_registers;
+        late_header.shader_size = sizeof(kOrderedLateCs);
+        late_header.type = 0;
+        late_header.num_sh_registers = 2;
+        registered_shader = nullptr;
+        kOrderedLateCs[0] = 0u;
+        CHECK(create_shader &&
+                  create_shader(reinterpret_cast<uint64_t>(&registered_shader),
+                                reinterpret_cast<uint64_t>(&late_header),
+                                reinterpret_cast<uint64_t>(kOrderedLateCs), 0, 0, 0) == 0 &&
+                  registered_shader == &late_header,
+              "register a mutable late compute consumer for ordered realization");
+        GpuState direct_ordered;
+        auto first_state = std::make_shared<GpuState>();
+        first_state->sh[P::COMPUTE_PGM_LO] = compute_registers[0].value;
+        first_state->sh[P::COMPUTE_PGM_HI] = compute_registers[1].value;
+        auto late_state = std::make_shared<GpuState>();
+        late_state->sh[P::COMPUTE_PGM_LO] = late_registers[0].value;
+        late_state->sh[P::COMPUTE_PGM_HI] = late_registers[1].value;
+        GpuState::Dispatch first_direct;
+        first_direct.threads_x = first_direct.threads_y = first_direct.threads_z = 1;
+        first_direct.command_order = 10;
+        first_direct.state = first_state;
+        GpuState::Dispatch late_direct = first_direct;
+        late_direct.command_order = 20;
+        late_direct.state = late_state;
+        direct_ordered.dispatches = {first_direct, late_direct};
+        uint32_t ordered_compute_calls = 0;
+        bool late_consumer_executed = false;
+        set_submit_compute([&](const std::vector<ComputeItem>& items) {
+            if (items.empty()) return false;
+            ++ordered_compute_calls;
+            if (items.front().code_addr == reinterpret_cast<uint64_t>(kNoopCs)) {
+                kOrderedLateCs[0] = 0xBF810000u;
+            } else if (items.front().code_addr ==
+                       reinterpret_cast<uint64_t>(kOrderedLateCs)) {
+                late_consumer_executed = true;
+            }
+            return true;
+        });
+        execute_ordered_and_present(direct_ordered, W, H, 1443, /*publish=*/false);
+        set_submit_compute({});
+        CHECK(ordered_compute_calls == 2 && late_consumer_executed,
+              "direct compute consumer is realized after its in-submit producer completes");
+        kOrderedLateCs[0] = 0u;
     }
 
     // Lazy realization can drop a semantic draw only after earlier spans have already executed.

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -276,6 +276,36 @@ bool phi_ids_are_nonzero(const std::vector<uint32_t>& spv) {
     return true;
 }
 
+bool store_object_ids_are_nonzero(const std::vector<uint32_t>& spv) {
+    constexpr uint32_t OpStore = 62;
+    if (spv.size() < 5) return false;
+    for (size_t i = 5; i < spv.size();) {
+        const uint32_t word = spv[i];
+        const uint32_t op = word & 0xffffu, wc = word >> 16u;
+        if (wc == 0 || i + wc > spv.size()) return false;
+        if (op == OpStore && (wc < 3 || spv[i + 1] == 0 || spv[i + 2] == 0)) return false;
+        i += wc;
+    }
+    return true;
+}
+
+bool select_ids_are_nonzero(const std::vector<uint32_t>& spv) {
+    constexpr uint32_t OpSelect = 169;
+    if (spv.size() < 5) return false;
+    for (size_t i = 5; i < spv.size();) {
+        const uint32_t word = spv[i];
+        const uint32_t op = word & 0xffffu, wc = word >> 16u;
+        if (wc == 0 || i + wc > spv.size()) return false;
+        if (op == OpSelect) {
+            if (wc != 6) return false;
+            for (uint32_t operand = 1; operand < wc; ++operand)
+                if (spv[i + operand] == 0) return false;
+        }
+        i += wc;
+    }
+    return true;
+}
+
 // Whether the module contains OpDecorate (71) with the given decoration (word[i+2]).
 bool has_decoration(const std::vector<uint32_t>& spv, uint32_t decoration) {
     enum : uint32_t { OpDecorateL = 71 };
@@ -427,6 +457,44 @@ int main() {
         printf("  [FAIL] proven Wave32 compute mask moves did not recompile\n");
         return 1;
     }
+    // A Wave32 VOPC creates a VCC mask lifetime; one arm then recycles VCC_LO as ordinary scalar
+    // data. The mask view is deliberately poisoned on that arm, but the structured merge and CFG
+    // boundary must use a real false id rather than emitting an illegal id-zero OpPhi/OpStore.
+    const uint32_t wave32_compute_recycled_vcc[] = {
+        0x7d840000u,                         // v_cmp_eq_u32 vcc, v0, v0
+        0xbf060000u,                         // s_cmp_eq_u32 s0, s0
+        0xbf840001u,                         // s_cbranch_scc0 +1
+        0xbeea0385u,                         // s_mov_b32 vcc_lo, 5 (scalar-data lifetime)
+        0x7e020280u,                         // v_mov_b32 v1, 0
+        0xbf810000u,
+    };
+    wave32_compute_config.native_subgroup_size = 32;
+    wave32_compute_config.local_x = 32;
+    const auto recycled_vcc_spv = recompile_compute(
+        wave32_compute_recycled_vcc, std::size(wave32_compute_recycled_vcc), nullptr,
+        wave32_compute_config);
+    if (recycled_vcc_spv.empty() || !phi_ids_are_nonzero(recycled_vcc_spv) ||
+        !store_object_ids_are_nonzero(recycled_vcc_spv) ||
+        !select_ids_are_nonzero(recycled_vcc_spv)) {
+        printf("  [FAIL] recycled Wave32 VCC lifetime emitted an id-zero merge/store\n");
+        return 1;
+    }
+    printf("  [ok]   recycled Wave32 VCC lifetime stays valid across CFG boundaries\n");
+    const uint32_t wave32_compute_recycled_vcc_half[] = {
+        0x7d840000u,                         // v_cmp_eq_u32 vcc, v0, v0
+        0xbeea0385u,                         // s_mov_b32 vcc_lo, 5 (poisons mask view)
+        0x876b0100u,                         // s_and_b32 vcc_hi, s0, s1
+        0xbf810000u,
+    };
+    wave32_compute_config.user_sgprs = {1u, 1u};
+    const auto recycled_vcc_half_spv = recompile_compute(
+        wave32_compute_recycled_vcc_half, std::size(wave32_compute_recycled_vcc_half), nullptr,
+        wave32_compute_config);
+    if (recycled_vcc_half_spv.empty() || !select_ids_are_nonzero(recycled_vcc_half_spv)) {
+        printf("  [FAIL] recycled Wave32 VCC half-write selected an id-zero prior mask\n");
+        return 1;
+    }
+    printf("  [ok]   recycled Wave32 VCC half-write selects a valid false prior mask\n");
     wave32_compute_config.wave_size = 64;
     if (!recompile_compute(wave32_compute_masks, std::size(wave32_compute_masks), nullptr,
                            wave32_compute_config).empty()) {
@@ -1875,6 +1943,23 @@ int main() {
         printf("  [FAIL] IMAGE_BVH_INTERSECT_RAY lacks its SSBO/ALU lowering\n");
         return 1;
     }
+    uint32_t null_bvh_words[64]{};
+    ShaderResourceTable rt_null_bvh;
+    { ShaderResource bvh{}; bvh.cls = ResourceClass::ConstantBuffer;
+      bvh.format = DataFormat::Uint32; bvh.num_components = 1;
+      bvh.binding = 4; bvh.size = sizeof(null_bvh_words); bvh.fetch_pc = 0;
+      bvh.host_data = reinterpret_cast<uint8_t*>(null_bvh_words);
+      bvh.host_data_size = sizeof(null_bvh_words); rt_null_bvh.resources.push_back(bvh); }
+    const std::vector<uint32_t> null_bvh_spv = recompile_compute(
+        cs_bvh_intersect, std::size(cs_bvh_intersect), &rt_null_bvh, bvh_config);
+    const DescriptorValidationReport null_bvh_report = validate_spirv_descriptor_interface(
+        null_bvh_spv, &rt_null_bvh, 0, SpirvShaderStage::Compute, false);
+    if (null_bvh_spv.empty() || !null_bvh_report.ok() ||
+        null_bvh_spv.size() >= bvh_spv.size() || has_opcode(null_bvh_spv, 136u)) {
+        printf("  [FAIL] null IMAGE_BVH_INTERSECT_RAY did not specialize to no-hit\n");
+        return 1;
+    }
+    printf("  [ok]   null IMAGE_BVH_INTERSECT_RAY specializes to compact no-hit\n");
     if (!recompile_compute(cs_bvh_intersect, std::size(cs_bvh_intersect),
                            nullptr, bvh_config).empty()) {
         printf("  [FAIL] IMAGE_BVH_INTERSECT_RAY was accepted without its BVH bytes\n");

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -276,36 +276,6 @@ bool phi_ids_are_nonzero(const std::vector<uint32_t>& spv) {
     return true;
 }
 
-bool store_object_ids_are_nonzero(const std::vector<uint32_t>& spv) {
-    constexpr uint32_t OpStore = 62;
-    if (spv.size() < 5) return false;
-    for (size_t i = 5; i < spv.size();) {
-        const uint32_t word = spv[i];
-        const uint32_t op = word & 0xffffu, wc = word >> 16u;
-        if (wc == 0 || i + wc > spv.size()) return false;
-        if (op == OpStore && (wc < 3 || spv[i + 1] == 0 || spv[i + 2] == 0)) return false;
-        i += wc;
-    }
-    return true;
-}
-
-bool select_ids_are_nonzero(const std::vector<uint32_t>& spv) {
-    constexpr uint32_t OpSelect = 169;
-    if (spv.size() < 5) return false;
-    for (size_t i = 5; i < spv.size();) {
-        const uint32_t word = spv[i];
-        const uint32_t op = word & 0xffffu, wc = word >> 16u;
-        if (wc == 0 || i + wc > spv.size()) return false;
-        if (op == OpSelect) {
-            if (wc != 6) return false;
-            for (uint32_t operand = 1; operand < wc; ++operand)
-                if (spv[i + operand] == 0) return false;
-        }
-        i += wc;
-    }
-    return true;
-}
-
 // Whether the module contains OpDecorate (71) with the given decoration (word[i+2]).
 bool has_decoration(const std::vector<uint32_t>& spv, uint32_t decoration) {
     enum : uint32_t { OpDecorateL = 71 };
@@ -458,43 +428,41 @@ int main() {
         return 1;
     }
     // A Wave32 VOPC creates a VCC mask lifetime; one arm then recycles VCC_LO as ordinary scalar
-    // data. The mask view is deliberately poisoned on that arm, but the structured merge and CFG
-    // boundary must use a real false id rather than emitting an illegal id-zero OpPhi/OpStore.
+    // data. The mask view is unknown after the merge, so consuming it with cndmask must remain
+    // fail-visible instead of silently treating the poisoned edge as architectural false.
     const uint32_t wave32_compute_recycled_vcc[] = {
         0x7d840000u,                         // v_cmp_eq_u32 vcc, v0, v0
         0xbf060000u,                         // s_cmp_eq_u32 s0, s0
         0xbf840001u,                         // s_cbranch_scc0 +1
         0xbeea0385u,                         // s_mov_b32 vcc_lo, 5 (scalar-data lifetime)
-        0x7e020280u,                         // v_mov_b32 v1, 0
+        0x02020100u,                         // v_cndmask_b32 v1, v0, v0, vcc
         0xbf810000u,
     };
     wave32_compute_config.native_subgroup_size = 32;
     wave32_compute_config.local_x = 32;
-    const auto recycled_vcc_spv = recompile_compute(
-        wave32_compute_recycled_vcc, std::size(wave32_compute_recycled_vcc), nullptr,
-        wave32_compute_config);
-    if (recycled_vcc_spv.empty() || !phi_ids_are_nonzero(recycled_vcc_spv) ||
-        !store_object_ids_are_nonzero(recycled_vcc_spv) ||
-        !select_ids_are_nonzero(recycled_vcc_spv)) {
-        printf("  [FAIL] recycled Wave32 VCC lifetime emitted an id-zero merge/store\n");
+    if (!recompile_compute(wave32_compute_recycled_vcc,
+                           std::size(wave32_compute_recycled_vcc), nullptr,
+                           wave32_compute_config).empty()) {
+        printf("  [FAIL] poisoned Wave32 VCC was consumed after a CFG merge\n");
         return 1;
     }
-    printf("  [ok]   recycled Wave32 VCC lifetime stays valid across CFG boundaries\n");
+    printf("  [ok]   poisoned Wave32 VCC consumption after a CFG merge is rejected\n");
     const uint32_t wave32_compute_recycled_vcc_half[] = {
         0x7d840000u,                         // v_cmp_eq_u32 vcc, v0, v0
-        0xbeea0385u,                         // s_mov_b32 vcc_lo, 5 (poisons mask view)
+        0xbf060000u,                         // s_cmp_eq_u32 s0, s0
+        0xbf840001u,                         // s_cbranch_scc0 +1
+        0xbeea0385u,                         // one arm recycles vcc_lo as scalar data
         0x876b0100u,                         // s_and_b32 vcc_hi, s0, s1
         0xbf810000u,
     };
     wave32_compute_config.user_sgprs = {1u, 1u};
-    const auto recycled_vcc_half_spv = recompile_compute(
-        wave32_compute_recycled_vcc_half, std::size(wave32_compute_recycled_vcc_half), nullptr,
-        wave32_compute_config);
-    if (recycled_vcc_half_spv.empty() || !select_ids_are_nonzero(recycled_vcc_half_spv)) {
-        printf("  [FAIL] recycled Wave32 VCC half-write selected an id-zero prior mask\n");
+    if (!recompile_compute(wave32_compute_recycled_vcc_half,
+                           std::size(wave32_compute_recycled_vcc_half), nullptr,
+                           wave32_compute_config).empty()) {
+        printf("  [FAIL] partial VCC write accepted an unknown prior mask\n");
         return 1;
     }
-    printf("  [ok]   recycled Wave32 VCC half-write selects a valid false prior mask\n");
+    printf("  [ok]   partial VCC write rejects an unknown prior mask\n");
     wave32_compute_config.wave_size = 64;
     if (!recompile_compute(wave32_compute_masks, std::size(wave32_compute_masks), nullptr,
                            wave32_compute_config).empty()) {
@@ -1943,23 +1911,6 @@ int main() {
         printf("  [FAIL] IMAGE_BVH_INTERSECT_RAY lacks its SSBO/ALU lowering\n");
         return 1;
     }
-    uint32_t null_bvh_words[64]{};
-    ShaderResourceTable rt_null_bvh;
-    { ShaderResource bvh{}; bvh.cls = ResourceClass::ConstantBuffer;
-      bvh.format = DataFormat::Uint32; bvh.num_components = 1;
-      bvh.binding = 4; bvh.size = sizeof(null_bvh_words); bvh.fetch_pc = 0;
-      bvh.host_data = reinterpret_cast<uint8_t*>(null_bvh_words);
-      bvh.host_data_size = sizeof(null_bvh_words); rt_null_bvh.resources.push_back(bvh); }
-    const std::vector<uint32_t> null_bvh_spv = recompile_compute(
-        cs_bvh_intersect, std::size(cs_bvh_intersect), &rt_null_bvh, bvh_config);
-    const DescriptorValidationReport null_bvh_report = validate_spirv_descriptor_interface(
-        null_bvh_spv, &rt_null_bvh, 0, SpirvShaderStage::Compute, false);
-    if (null_bvh_spv.empty() || !null_bvh_report.ok() ||
-        null_bvh_spv.size() >= bvh_spv.size() || has_opcode(null_bvh_spv, 136u)) {
-        printf("  [FAIL] null IMAGE_BVH_INTERSECT_RAY did not specialize to no-hit\n");
-        return 1;
-    }
-    printf("  [ok]   null IMAGE_BVH_INTERSECT_RAY specializes to compact no-hit\n");
     if (!recompile_compute(cs_bvh_intersect, std::size(cs_bvh_intersect),
                            nullptr, bvh_config).empty()) {
         printf("  [FAIL] IMAGE_BVH_INTERSECT_RAY was accepted without its BVH bytes\n");

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -1,6 +1,7 @@
 // test_rdna2_spirv_struct -- structural checks for RDNA2->SPIR-V output that do not require Vulkan.
 #include "../src/gpu/rdna2_to_spirv.hpp"
 #include "../src/gpu/shader_resources.hpp"
+#include <algorithm>
 #include <cstdint>
 #include <cstdio>
 #include <iterator>
@@ -1845,6 +1846,49 @@ int main() {
         return 1;
     }
     printf("  [ok]   compute atomic-buffer view rejects compressed and mip-tail images\n");
+
+    // Astro Bot's world-map traversal kernel uses the RTIP 1.1 BVH instruction with eleven NSA
+    // address operands. It is lowered to ordinary SSBO loads and scalar ALU, so this remains usable
+    // on Vulkan devices without a ray-query feature. Keep the gate exact: accepting a nearby MIMG
+    // flag combination would silently assign the wrong hardware intersection contract.
+    const uint32_t cs_bvh_intersect[] = {
+        0xf1989f07u, 0x00040303u, 0x43440d3fu, 0x46424140u, 0x00004847u,
+        0xbf810000u,
+    };
+    uint32_t bvh_node_words[32]{};
+    ShaderResourceTable rt_bvh;
+    { ShaderResource bvh{}; bvh.cls = ResourceClass::ConstantBuffer;
+      bvh.format = DataFormat::Uint32; bvh.num_components = 1;
+      bvh.binding = 4; bvh.size = sizeof(bvh_node_words); bvh.fetch_pc = 0;
+      bvh.host_data = reinterpret_cast<uint8_t*>(bvh_node_words);
+      bvh.host_data_size = sizeof(bvh_node_words); rt_bvh.resources.push_back(bvh); }
+    ComputeShaderConfig bvh_config;
+    bvh_config.local_x = 1;
+    const std::vector<uint32_t> bvh_spv = recompile_compute(
+        cs_bvh_intersect, std::size(cs_bvh_intersect), &rt_bvh, bvh_config);
+    const DescriptorValidationReport bvh_report = validate_spirv_descriptor_interface(
+        bvh_spv, &rt_bvh, 0, SpirvShaderStage::Compute, false);
+    if (bvh_spv.empty() || !bvh_report.ok() || bvh_report.descriptors.size() != 1 ||
+        bvh_report.descriptors[0].kind != SpirvDescriptorKind::StorageBuffer ||
+        !has_opcode(bvh_spv, 61u) || !has_opcode(bvh_spv, 129u) ||
+        !has_opcode(bvh_spv, 133u) || !has_opcode(bvh_spv, 169u)) {
+        printf("  [FAIL] IMAGE_BVH_INTERSECT_RAY lacks its SSBO/ALU lowering\n");
+        return 1;
+    }
+    if (!recompile_compute(cs_bvh_intersect, std::size(cs_bvh_intersect),
+                           nullptr, bvh_config).empty()) {
+        printf("  [FAIL] IMAGE_BVH_INTERSECT_RAY was accepted without its BVH bytes\n");
+        return 1;
+    }
+    uint32_t unsupported_bvh[std::size(cs_bvh_intersect)];
+    std::copy(std::begin(cs_bvh_intersect), std::end(cs_bvh_intersect), unsupported_bvh);
+    unsupported_bvh[0] &= ~(1u << 15); // R128=0 has a different destination contract.
+    if (!recompile_compute(unsupported_bvh, std::size(unsupported_bvh),
+                           &rt_bvh, bvh_config).empty()) {
+        printf("  [FAIL] unverified IMAGE_BVH_INTERSECT_RAY flags were accepted\n");
+        return 1;
+    }
+    printf("  [ok]   Astro IMAGE_BVH_INTERSECT_RAY lowers through a bounded BVH SSBO\n");
 
     // Astro Bot's visibility kernel sanitizes a generated coordinate with an explicit-SDST
     // v_cmp_class_f32 SDWA (mask 3 = sNaN|qNaN), followed by v_cndmask reading s[8:9]. Rejecting

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -5325,9 +5325,8 @@ int main() {
         }
         CHECK(box_ok, "IMAGE_BVH_INTERSECT_RAY returns the four unsorted FP32-box child hits");
 
-        // RTIP 1.1 conservatively grows the far edge by six 2^-24 increments. Make the
-        // X near edge one float ULP beyond the Y far edge: an exact slab comparison misses,
-        // while the architectural interval growth retains the edge-touching child.
+        // Make the X near edge one float ULP beyond the Y far edge. BOX_GROW=0 must miss;
+        // BOX_GROW=6 expands the far edge by six 2^-24 increments and retains the child.
         for (uint32_t lane = 0; lane < lanes; ++lane) {
             set_ray(lane, 5u, 0.0f, 0.0f, 0.0f);
             bvh_inputs[lane * inputs_per_lane + 64] = 1.0f;
@@ -5344,10 +5343,21 @@ int main() {
             bvh_code, std::size(bvh_code), inputs_per_lane, 3, &bvh_rt);
         const std::vector<float> edge_output = prosper::test::run_compute(
             edge_module, bvh_inputs, lanes, lanes, box_words);
-        bool edge_ok = edge_output.size() == lanes;
+        bool edge_zero_ok = edge_output.size() == lanes;
         for (uint32_t lane = 0; lane < edge_output.size(); ++lane)
-            edge_ok &= bits_of(edge_output[lane]) == 0x100u;
-        CHECK(edge_ok, "IMAGE_BVH_INTERSECT_RAY conservatively retains edge-touching boxes");
+            edge_zero_ok &= bits_of(edge_output[lane]) == 0xffffffffu;
+        CHECK(edge_zero_ok, "IMAGE_BVH_INTERSECT_RAY honors zero box growth");
+
+        bvh_rt.resources[0].bvh_box_grow = 6u;
+        const std::vector<uint32_t> grown_edge_module = recompile_valu(
+            bvh_code, std::size(bvh_code), inputs_per_lane, 3, &bvh_rt);
+        const std::vector<float> grown_edge_output = prosper::test::run_compute(
+            grown_edge_module, bvh_inputs, lanes, lanes, box_words);
+        bool edge_grown_ok = grown_edge_output.size() == lanes;
+        for (uint32_t lane = 0; lane < grown_edge_output.size(); ++lane)
+            edge_grown_ok &= bits_of(grown_edge_output[lane]) == 0x100u;
+        CHECK(edge_grown_ok,
+              "IMAGE_BVH_INTERSECT_RAY applies descriptor-selected box growth");
 
         std::vector<uint32_t> tri_words(32, 0u);
         tri_words[0] = bits_of(9.0f); tri_words[1] = bits_of(9.0f); tri_words[2] = bits_of(9.0f);

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -5261,6 +5261,111 @@ int main() {
               "#590: partially-overlapping loops remain REJECTED (unstructured region)");
     }
 
+    // Astro Bot's exact RTIP 1.1 IMAGE_BVH_INTERSECT_RAY lowering, executed on real Vulkan. The
+    // first fixture intersects child 0 of an FP32 box node and misses the other three. The second
+    // uses triangle node type 1 (V1,V3,V2), which catches the compressed-pair vertex mapping as well
+    // as the mode-1 numerator/denominator result contract.
+    {
+        const uint32_t bvh_code[] = {
+            0xf1989f07u, 0x00040303u, 0x43440d3fu, 0x46424140u, 0x00004847u,
+            0xbf810000u,
+        };
+        ShaderResourceTable bvh_rt;
+        ShaderResource bvh{};
+        bvh.cls = ResourceClass::ConstantBuffer;
+        bvh.format = DataFormat::Uint32;
+        bvh.num_components = 1;
+        bvh.binding = 2;
+        bvh.size = 128;
+        bvh.fetch_pc = 0;
+        bvh_rt.resources.push_back(bvh);
+
+        constexpr uint32_t lanes = 64;
+        constexpr uint32_t inputs_per_lane = 73;
+        std::vector<float> bvh_inputs(lanes * inputs_per_lane, 0.0f);
+        auto set_input_bits = [&](uint32_t lane, uint32_t vgpr, uint32_t bits) {
+            bvh_inputs[lane * inputs_per_lane + vgpr] = std::bit_cast<float>(bits);
+        };
+        auto set_ray = [&](uint32_t lane, uint32_t node, float ox, float oy, float oz) {
+            set_input_bits(lane, 3, node);
+            bvh_inputs[lane * inputs_per_lane + 63] = 100.0f; // ray extent
+            bvh_inputs[lane * inputs_per_lane + 13] = ox;
+            bvh_inputs[lane * inputs_per_lane + 68] = oy;
+            bvh_inputs[lane * inputs_per_lane + 67] = oz;
+            bvh_inputs[lane * inputs_per_lane + 64] = 0.0f;
+            bvh_inputs[lane * inputs_per_lane + 65] = 0.0f;
+            bvh_inputs[lane * inputs_per_lane + 66] = 1.0f;
+            bvh_inputs[lane * inputs_per_lane + 70] = std::numeric_limits<float>::infinity();
+            bvh_inputs[lane * inputs_per_lane + 71] = std::numeric_limits<float>::infinity();
+            bvh_inputs[lane * inputs_per_lane + 72] = 1.0f;
+        };
+        for (uint32_t lane = 0; lane < lanes; ++lane) set_ray(lane, 5u, 0.0f, 0.0f, -5.0f);
+
+        std::vector<uint32_t> box_words(32, 0u);
+        box_words[0] = 0x100u; box_words[1] = 0x200u;
+        box_words[2] = 0x300u; box_words[3] = 0x400u;
+        for (uint32_t child = 0; child < 4; ++child) {
+            const float lo = child == 0 ? -1.0f : 10.0f + static_cast<float>(child);
+            const float hi = child == 0 ?  1.0f : 11.0f + static_cast<float>(child);
+            const uint32_t base = 4u + child * 6u;
+            box_words[base + 0] = bits_of(lo); box_words[base + 1] = bits_of(lo);
+            box_words[base + 2] = bits_of(lo); box_words[base + 3] = bits_of(hi);
+            box_words[base + 4] = bits_of(hi); box_words[base + 5] = bits_of(hi);
+        }
+        const uint32_t box_expect[4] = {0x100u, 0xffffffffu, 0xffffffffu, 0xffffffffu};
+        bool box_ok = true;
+        for (uint32_t component = 0; component < 4; ++component) {
+            const std::vector<uint32_t> module = recompile_valu(
+                bvh_code, std::size(bvh_code), inputs_per_lane, 3u + component, &bvh_rt);
+            const std::vector<float> output = prosper::test::run_compute(
+                module, bvh_inputs, lanes, lanes, box_words);
+            box_ok &= output.size() == lanes;
+            for (uint32_t lane = 0; lane < output.size(); ++lane)
+                box_ok &= bits_of(output[lane]) == box_expect[component];
+        }
+        CHECK(box_ok, "IMAGE_BVH_INTERSECT_RAY returns the four unsorted FP32-box child hits");
+
+        // RTIP 1.1 conservatively grows the far edge by six 2^-24 increments. Make the
+        // X near edge one float ULP beyond the Y far edge: an exact slab comparison misses,
+        // while the architectural interval growth retains the edge-touching child.
+        for (uint32_t lane = 0; lane < lanes; ++lane) {
+            set_ray(lane, 5u, 0.0f, 0.0f, 0.0f);
+            bvh_inputs[lane * inputs_per_lane + 64] = 1.0f;
+            bvh_inputs[lane * inputs_per_lane + 65] = 1.0f;
+            bvh_inputs[lane * inputs_per_lane + 66] = 1.0f;
+            bvh_inputs[lane * inputs_per_lane + 70] = 1.0f;
+            bvh_inputs[lane * inputs_per_lane + 71] = 1.0f;
+            bvh_inputs[lane * inputs_per_lane + 72] = 1.0f;
+        }
+        box_words[4] = 0x3f800001u; box_words[5] = bits_of(0.0f);
+        box_words[6] = bits_of(0.0f); box_words[7] = bits_of(2.0f);
+        box_words[8] = bits_of(1.0f); box_words[9] = bits_of(2.0f);
+        const std::vector<uint32_t> edge_module = recompile_valu(
+            bvh_code, std::size(bvh_code), inputs_per_lane, 3, &bvh_rt);
+        const std::vector<float> edge_output = prosper::test::run_compute(
+            edge_module, bvh_inputs, lanes, lanes, box_words);
+        bool edge_ok = edge_output.size() == lanes;
+        for (uint32_t lane = 0; lane < edge_output.size(); ++lane)
+            edge_ok &= bits_of(edge_output[lane]) == 0x100u;
+        CHECK(edge_ok, "IMAGE_BVH_INTERSECT_RAY conservatively retains edge-touching boxes");
+
+        std::vector<uint32_t> tri_words(32, 0u);
+        tri_words[0] = bits_of(9.0f); tri_words[1] = bits_of(9.0f); tri_words[2] = bits_of(9.0f);
+        tri_words[3] = bits_of(0.0f); tri_words[4] = bits_of(0.0f); tri_words[5] = bits_of(0.0f); // V1
+        tri_words[6] = bits_of(0.0f); tri_words[7] = bits_of(1.0f); tri_words[8] = bits_of(0.0f); // V2
+        tri_words[9] = bits_of(1.0f); tri_words[10] = bits_of(0.0f); tri_words[11] = bits_of(0.0f); // V3
+        tri_words[15] = 0x00000900u; // type-1 I=vertex1, J=vertex2
+        for (uint32_t lane = 0; lane < lanes; ++lane) set_ray(lane, 1u, 0.25f, 0.25f, -1.0f);
+        const std::vector<uint32_t> tri_module = recompile_valu(
+            bvh_code, std::size(bvh_code), inputs_per_lane, 3, &bvh_rt);
+        const std::vector<float> tri_output = prosper::test::run_compute(
+            tri_module, bvh_inputs, lanes, lanes, tri_words);
+        bool tri_ok = tri_output.size() == lanes;
+        for (uint32_t lane = 0; lane < tri_output.size(); ++lane)
+            tri_ok &= bits_of(tri_output[lane]) == bits_of(-1.0f);
+        CHECK(tri_ok, "IMAGE_BVH_INTERSECT_RAY type-1 triangle returns its exact t numerator");
+    }
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;

--- a/prosper/tests/test_shader_recompile_cache.cpp
+++ b/prosper/tests/test_shader_recompile_cache.cpp
@@ -640,6 +640,38 @@ int main() {
               stats.misses == 2 && stats.hits == 1 && stats.entries == 2,
           "compute cache separates image-atomic modules with different embedded extents");
 
+    // BVH BOX_GROW is embedded as the slab-test far-edge multiplier. A descriptor change must
+    // compile a distinct module even when the BVH allocation and instruction provenance match.
+    clear_shader_recompile_cache();
+    static const uint32_t kBvhCompute[] = {
+        0xf1989f07u, 0x00040303u, 0x43440d3fu, 0x46424140u, 0x00004847u,
+        0xbf810000u,
+    };
+    ShaderResource bvh;
+    bvh.cls = ResourceClass::ConstantBuffer;
+    bvh.format = DataFormat::Uint32;
+    bvh.num_components = 1;
+    bvh.binding = 4;
+    bvh.size = 128;
+    bvh.fetch_pc = 0;
+    ShaderResourceTable bvh_table;
+    bvh_table.resources.push_back(bvh);
+    ComputeShaderConfig bvh_config;
+    bvh_config.local_x = 1;
+    const auto bvh_grow_0 = recompile_compute_shader_cached(
+        kBvhCompute, std::size(kBvhCompute), &bvh_table, bvh_config);
+    bvh_table.resources[0].bvh_box_grow = 6;
+    const auto bvh_grow_6 = recompile_compute_shader_cached(
+        kBvhCompute, std::size(kBvhCompute), &bvh_table, bvh_config);
+    bvh_table.resources[0].bvh_box_grow = 0;
+    const auto bvh_grow_0_again = recompile_compute_shader_cached(
+        kBvhCompute, std::size(kBvhCompute), &bvh_table, bvh_config);
+    stats = shader_recompile_cache_stats();
+    CHECK(!bvh_grow_0.empty() && !bvh_grow_6.empty() &&
+              bvh_grow_0 != bvh_grow_6 && bvh_grow_0_again == bvh_grow_0 &&
+              stats.misses == 2 && stats.hits == 1 && stats.entries == 2,
+          "compute cache separates descriptor-selected BVH box growth");
+
     // Manual shadow comparison bakes the enable, compare op, filter mode, address modes, and border
     // color into SPIR-V. In particular depth_compare=false must not reuse a previously successful
     // module: that descriptor contract is supposed to reject this comparison-sample shader.

--- a/prosper/tools/shader_inspect/README.md
+++ b/prosper/tools/shader_inspect/README.md
@@ -23,6 +23,19 @@ success_cs_6f6a5fdd6e9f8d73_2339aa565126d182.bin
 success_cs_6f6a5fdd6e9f8d73_2339aa565126d182.spv
 ```
 
+For a large live compute program that reaches the backend but fails during Vulkan pipeline creation,
+filter the backend trace by guest code address and dump only that exact translated module:
+
+```sh
+PROSPER_COMPUTELOG_CODE=0x50057b800 \
+PROSPER_COMPUTELOG_SPIRV=~/prosper-shaders/target.spv \
+  ./build-linux/prosper-app --dump <DUMP_ROOT>/PPSA21564-app0
+spirv-val --target-env vulkan1.2 ~/prosper-shaders/target.spv
+```
+
+The destination directory must already exist. As with raw shader dumps, the resulting SPIR-V is
+title-derived diagnostic data: keep it local and do not commit it.
+
 The first hash identifies the translated SPIR-V and the second identifies the exact raw RDNA2 stream.
 Pass the `.bin` file to `shader_inspect`; use the adjacent `.spv` for SPIR-V disassembly or validation.
 The dump directory is created automatically. `vs`, `ps`, and `cs` identify vertex, pixel, and compute stages.

--- a/prosper/tools/spv_validate/spv_validate.cpp
+++ b/prosper/tools/spv_validate/spv_validate.cpp
@@ -138,6 +138,15 @@ int main(int argc, char** argv) {
       dst.format=DataFormat::Uint32; dst.num_components=1; dst.binding=3;
       dst.stride=12; dst.sgpr_base=16; rt.resources.push_back(dst);
       dump(dir, "compute_store_x3", recompile_valu(c, sizeof(c)/4, 1, 0, &rt)); }
+    // Astro Bot's exact RTIP 1.1 BVH instruction. The software intersection path is intentionally
+    // scalar/SSBO SPIR-V so it does not require Vulkan ray-query capabilities.
+    { const uint32_t c[] = {0xf1989f07u,0x00040303u,0x43440d3fu,0x46424140u,0x00004847u,
+                            0xbf810000u};
+      ShaderResourceTable rt; ShaderResource bvh{}; bvh.cls=ResourceClass::ConstantBuffer;
+      bvh.format=DataFormat::Uint32; bvh.num_components=1; bvh.binding=4;
+      bvh.size=128; bvh.fetch_pc=0; rt.resources.push_back(bvh);
+      ComputeShaderConfig cfg; cfg.local_x=1;
+      dump(dir, "compute_bvh_intersect", recompile_compute(c, sizeof(c)/4, &rt, cfg)); }
     // Compute EXEC-predicated store (v_cmpx + guard execz + store).
     { const uint32_t c[] = {0x7e040f00u,0x06060100u,0x7e0a0284u,0x7da20b02u,0xbf880002u,0xe0102000u,0x80020302u,0xbf810000u};
       ShaderResourceTable rt; ShaderResource vb{}; vb.cls=ResourceClass::VertexBuffer; vb.format=DataFormat::Float32;


### PR DESCRIPTION
Advances #1459.

## Problem

Astro Bot reaches `worldmap`, where a large compute shader uses RDNA2's
`IMAGE_BVH_INTERSECT_RAY`. Prosper did not understand the compact BVH resource descriptor or lower
the instruction, and its dynamic resource analysis also lost part of the scalar address-building
chain. Separately, stale render-target authority and poisoned VCC state could suppress valid backing
or turn an unsupported mask lifetime into invalid or silently incorrect SPIR-V.

## Changes

- Decode validated GFX10 BVH descriptors and materialize known BVH allocations as bounded,
  instruction-scoped read-only buffers.
- Lower Astro Bot's exact RTIP 1.1 traversal form to portable SSBO loads and ALU, including triangle
  and FP16/FP32 box nodes.
- Decode descriptor `BOX_GROW`, carry it through capture/replay and shader-cache identity, and apply
  the selected interval growth in lowering.
- Fold the observed scalar address/count construction used by Astro Bot's BVH descriptor builder.
- Keep unresolved or unverified BVH descriptors fail-visible. An earlier revision substituted
  synthetic no-hit results for unknown descriptors; review correctly found that descriptor
  provenance did not prove the instruction unreachable, so that shortcut has been removed.
- Reject unknown/poisoned VCC when it reaches a consumer or CFG boundary instead of converting it to
  architectural false.
- Only let the live render-target cache override guest backing when it owns current GPU pixels or a
  correctly sized CPU snapshot.
- Make the opt-in traced compute dump identify the actual translated module and retry failed writes.

## Current live status

This is trustworthy BVH translation groundwork, not completed world-map rendering. Known descriptors
now lower and execute in focused real-Vulkan tests. The live world-map shader still fails visibly
when its dynamic BVH descriptor cannot be resolved; the earlier claim that the shader executed to a
black frame depended on the removed no-hit approximation and is withdrawn.

Astro Bot's intro FMV remains visually correct (including the prior checkerboard fix) but advances at
roughly 5 FPS. That performance work remains separate from this correctness PR.

## Verification

- `git diff --check`
- `prosper-app` build
- `test_dynfetch_fold`
- `test_gpu_capture`
- `test_rdna2_spirv_struct`
- `test_rdna2_to_spirv` on AMD RADV, including zero/nonzero BVH box-growth execution
- `test_shader_recompile_cache`
- `test_recompile_coverage`
- `test_rtt_scale`
- `test_gpu_execute`
- `spv_validate` with every generated module passing `spirv-val`

Snapshot tests were not run: they are optional for development/PR work, this is not a release, and
the remaining live output is still unresolved.

## Follow-up

The next world-map task is to preserve enough path-sensitive scalar descriptor state to resolve the
real BVH binding without inventing execution results. The FMV's roughly 5 FPS decode/upload cadence
also remains to be profiled independently.
