### PR TITLE
Reuse Astro Bot FMV texture allocations

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -253,6 +253,16 @@ std::vector<uint8_t> inspection_rgba8(const std::vector<uint8_t>& pixels,
         }
         return rgba;
     }
+    if (format == VK_FORMAT_R8G8_UNORM && pixels.size() == texels * 2) {
+        std::vector<uint8_t> rgba(texels * 4);
+        for (size_t texel = 0; texel < texels; ++texel) {
+            rgba[texel * 4 + 0] = pixels[texel * 2 + 0];
+            rgba[texel * 4 + 1] = pixels[texel * 2 + 1];
+            rgba[texel * 4 + 2] = 0;
+            rgba[texel * 4 + 3] = 255;
+        }
+        return rgba;
+    }
     // R16G16B16A16_UNORM: 16-bit fixed-point per channel -> 8-bit (high byte). Without this, a 64-bit
     // UNORM color target (a common non-float HDR/deep surface) inspected to black regardless of content,
     // which is misleading for RTT diagnostics.

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -347,6 +347,7 @@ struct DecodedTexture {
     uint32_t output_height = 0;
     bool narrow = false;
     uint64_t persistent_id = 0;
+    uint64_t persistent_version = 0;
 };
 
 struct PersistentDecodedTexture {
@@ -360,6 +361,7 @@ struct PersistentDecodedTexture {
     bool narrow = false;
     uint64_t last_use = 0;
     uint64_t persistent_id = 0;
+    uint64_t persistent_version = 0;
     prosper::gpu::GuestGpuWriteSnapshot validation_snapshot;
     prosper::host::GuestWriteWatch source_watch;
     uint32_t source_watch_dirty_count = 0;
@@ -1644,6 +1646,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             r.format == prosper::gpu::DataFormat::Unorm8 &&
                             r.num_components == 1 && r.tile_mode == 0u &&
                             !r.compression_enabled && !linear_padded_read;
+                        // AvPlayer's exact chroma plane is already tight interleaved RG8. Keeping it
+                        // native halves the upload bytes and avoids the CPU RGBA expansion on every
+                        // decoded frame while the descriptor swizzle still preserves U/V semantics.
+                        const bool native_rg8_sampled = avplayer_chroma_layout;
                         // Storage-image atomics require a typed integer Vulkan view. Keep R32_UINT
                         // texels byte-exact through the existing 4-B read/detile path instead of
                         // silently normalizing the view to RGBA8_UNORM.
@@ -1652,7 +1658,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             r.format == prosper::gpu::DataFormat::Uint32 &&
                             r.num_components == 1 && !r.compression_enabled;
                         const bool persistent_source_matches_pixels =
-                            native_r8_sampled ||
+                            native_r8_sampled || native_rg8_sampled ||
                             (persistent_unorm8_texture && r.num_components == 4 &&
                              !linear_padded_read &&
                              !prosper::gpu::tile_mode_is_tiled(r.tile_mode) &&
@@ -2002,7 +2008,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                     persistent_reuse = {cached->second.pixels.data(),
                                                         cached->second.output_height,
                                                         cached->second.narrow,
-                                                        cached->second.persistent_id};
+                                                        cached->second.persistent_id,
+                                                        cached->second.persistent_version};
                                     decoded_reuse = &persistent_reuse;
                                     resource_persistent_hit = true;
                                     if (timing_enabled) pending_timing.persistent_hits++;
@@ -2107,6 +2114,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             fr.img_dim = r.img_dim;
                             if (native_r8_sampled)
                                 fr.texture_format = VK_FORMAT_R8_UNORM;
+                            else if (native_rg8_sampled)
+                                fr.texture_format = VK_FORMAT_R8G8_UNORM;
                             else if (sampled_source_f32)
                                 fr.texture_format = VK_FORMAT_R16G16B16A16_SFLOAT;
                             // #1272: plain 2D guest textures only — cube outputs stack 6 faces into
@@ -2116,9 +2125,11 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 fr.declared_mip_levels = r.declared_mip_levels;
                             narrow_done = decoded_reuse->narrow;
                             fr.persistent_texture_id = decoded_reuse->persistent_id;
+                            fr.persistent_texture_version = decoded_reuse->persistent_version;
                             decoded_textures.emplace(
                                 decode_key, DecodedTexture{fr.tex_rgba, fr.th, narrow_done,
-                                                          fr.persistent_texture_id});
+                                                          fr.persistent_texture_id,
+                                                          fr.persistent_texture_version});
                             if (timing_enabled) pending_timing.texture_reuses++;
                         } else {
                         // PROSPER_DETILE_STATS: this branch is the texture-decode MISS path — the cache
@@ -2244,8 +2255,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             ? live_rtt->second.format
                             : (native_r32ui_storage ? VK_FORMAT_R32_UINT
                                : (native_r8_sampled ? VK_FORMAT_R8_UNORM
+                               : (native_rg8_sampled ? VK_FORMAT_R8G8_UNORM
                                : (sampled_source_f32 ? VK_FORMAT_R16G16B16A16_SFLOAT
-                                                     : VK_FORMAT_R8G8B8A8_UNORM)));
+                                                     : VK_FORMAT_R8G8B8A8_UNORM))));
                         fr.texture_format = live_rtt_format;
                         const uint32_t output_bpp =
                             prosper::test::backend_color_bytes_per_pixel(live_rtt_format);
@@ -2669,6 +2681,15 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                           texture_pixels.end(), 0);
                             narrow_decode_done = true;
                             narrow_done = true;
+                        } else if (native_rg8_sampled) {
+                            // Tight RG8 is already the backend's two-byte sampled representation.
+                            linear_source_prefix_size = copy_resource(
+                                texture_pixels.data(), r.gpu_addr, texture_pixels.size());
+                            if (linear_source_prefix_size < texture_pixels.size())
+                                std::fill(texture_pixels.begin() + linear_source_prefix_size,
+                                          texture_pixels.end(), 0);
+                            narrow_decode_done = true;
+                            narrow_done = true;
                         } else if (bpt < 4) {
                             // Narrow (single/dual-channel) surface: read at the REAL element size and detile
                             // with the matching bpe geometry (1 B -> 64x64, 2 B -> 64x32 micro-tiles, #119),
@@ -2948,6 +2969,16 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                             texture_pixels[((size_t)z * th + y) * tw + x] =
                                                 ck ? 200 : 40;
                                         }
+                            } else if (fr.texture_format == VK_FORMAT_R8G8_UNORM) {
+                                for (uint32_t z = 0; z < slices; ++z)
+                                    for (uint32_t y = 0; y < th; ++y)
+                                        for (uint32_t x = 0; x < tw; ++x) {
+                                            const bool ck = ((x / 64) ^ (y / 64) ^ z) & 1;
+                                            uint8_t* p = &texture_pixels[
+                                                (((size_t)z * th + y) * tw + x) * 2];
+                                            p[0] = ck ? 200 : 40;
+                                            p[1] = ck ? 40 : 200;
+                                        }
                             } else {
                                 for (uint32_t z = 0; z < slices; ++z)
                                     for (uint32_t y = 0; y < th; ++y)
@@ -3038,6 +3069,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             bool inherited_watch_disabled = false;
                             prosper::host::GuestWriteWatch inherited_source_watch =
                                 std::move(pending_source_watch);
+                            uint64_t inherited_persistent_id = 0;
+                            uint64_t inherited_persistent_version = 0;
                             if (old != persistent_decoded_textures.end() &&
                                 old->second.source_addr == persistent_source_addr &&
                                 old->second.source_size == persistent_source_size) {
@@ -3047,6 +3080,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 inherited_watch_disabled = old->second.source_watch_disabled;
                                 if (!inherited_watch_disabled)
                                     inherited_source_watch = std::move(old->second.source_watch);
+                                inherited_persistent_id = old->second.persistent_id;
+                                inherited_persistent_version = old->second.persistent_version;
                             }
                             const bool can_replace = old == persistent_decoded_textures.end() ||
                                 old->second.last_use != decode_generation;
@@ -3089,9 +3124,14 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 cached.output_height = fr.th;
                                 cached.narrow = narrow_done;
                                 cached.last_use = decode_generation;
-                                cached.persistent_id = ++persistent_texture_id;
-                                if (!cached.persistent_id)
+                                cached.persistent_id = inherited_persistent_id;
+                                if (!cached.persistent_id) {
                                     cached.persistent_id = ++persistent_texture_id;
+                                    if (!cached.persistent_id)
+                                        cached.persistent_id = ++persistent_texture_id;
+                                }
+                                cached.persistent_version = inherited_persistent_version + 1;
+                                if (!cached.persistent_version) cached.persistent_version = 1;
                                 cached.validation_snapshot =
                                     prosper::gpu::guest_gpu_write_snapshot();
                                 cached.source_watch_dirty_count = inherited_watch_dirty_count;
@@ -3105,13 +3145,16 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                     persistent_decoded_texture_bytes += inserted->second.bytes();
                                     fr.tex_rgba = inserted->second.pixels.data();
                                     fr.persistent_texture_id = inserted->second.persistent_id;
+                                    fr.persistent_texture_version =
+                                        inserted->second.persistent_version;
                                 }
                             }
                         }
                         if (!resource_rtt_hit && !resource_compute_image_hit && !has_live_rtt)
                             decoded_textures.emplace(
                                 decode_key, DecodedTexture{fr.tex_rgba, fr.th, narrow_done,
-                                                          fr.persistent_texture_id});
+                                                          fr.persistent_texture_id,
+                                                          fr.persistent_texture_version});
                         }
                         if (native_r32ui_storage && writable_storage_image) {
                             const uint32_t writeback_pitch = getenv("PROSPER_PITCH")

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -3428,6 +3428,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         VkDeviceSize bytes = 0;
         uint64_t last_use = 0;
         uint64_t content_version = 0;
+        bool content_valid = true;
         std::unordered_map<TextureBindingKey, PersistentTextureBinding,
                            TextureBindingKeyHash> bindings;
     };
@@ -4108,6 +4109,27 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                             persistent_textures_enabled &&
                             r.persistent_texture_id) {
                             auto cached = persistent_texture_images.find(persistent_key);
+                            // A failed queued upload may have left this owned allocation in an
+                            // unknown layout with undefined contents. The failure callback cannot
+                            // destroy it while an indeterminate submission might still be in flight;
+                            // a later usable backend call can safely retire it before rebuilding.
+                            if (cached != persistent_texture_images.end() &&
+                                !cached->second.content_valid) {
+                                for (const auto& [key, binding] : cached->second.bindings) {
+                                    (void)key;
+                                    if (binding.sampler)
+                                        vkDestroySampler(dev, binding.sampler, nullptr);
+                                    if (binding.view)
+                                        vkDestroyImageView(dev, binding.view, nullptr);
+                                }
+                                if (cached->second.image)
+                                    vkDestroyImage(dev, cached->second.image, nullptr);
+                                if (cached->second.memory)
+                                    vkFreeMemory(dev, cached->second.memory, nullptr);
+                                persistent_texture_bytes -= cached->second.bytes;
+                                persistent_texture_images.erase(cached);
+                                cached = persistent_texture_images.end();
+                            }
                             if (cached != persistent_texture_images.end()) {
                                 cached->second.last_use = texture_generation;
                                 upload.image = cached->second.image;
@@ -4126,7 +4148,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                                             auto found = persistent_texture_images.find(
                                                 persistent_key);
                                             if (found != persistent_texture_images.end())
-                                                found->second.content_version = 0;
+                                                found->second.content_valid = false;
                                         });
                                     ++persistent_texture_misses;
                                 } else {
@@ -5566,8 +5588,13 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
             persistent_texture_bytes <= persistent_texture_limit - upload.image_bytes) {
             auto [cached, inserted] = persistent_texture_images.emplace(
                 key, PersistentTextureImage{upload.image, upload.memory, upload.image_bytes,
-                                            texture_generation, upload.persistent_version});
+                                            texture_generation, upload.persistent_version, true});
             if (inserted) {
+                active_submission.add_failure_cleanup([key]() {
+                    auto found = persistent_texture_images.find(key);
+                    if (found != persistent_texture_images.end())
+                        found->second.content_valid = false;
+                });
                 persistent_texture_bytes += upload.image_bytes;
                 upload.image = VK_NULL_HANDLE;
                 upload.memory = VK_NULL_HANDLE;

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -141,6 +141,10 @@ struct FrameResource {
     // prove these decoded pixels are the same content version as a prior callback. The Vulkan
     // backend may retain an uploaded image under this ID; zero remains callback-local/transient.
     uint64_t persistent_texture_id = 0;
+    // A non-zero version lets mutable, exactly-validated guest textures retain the allocation named
+    // above while replacing its contents. Equal versions skip upload; a newer version records one
+    // ordered refresh into the existing image. Zero preserves the historical immutable-ID contract.
+    uint64_t persistent_texture_version = 0;
     // Non-zero identifies a color target retained by an earlier backend call. When that exact
     // target is available, bind its GPU image directly instead of uploading `tex_rgba` again.
     // `tex_rgba` remains an optional conservative fallback for an invalidated/missing target.
@@ -202,6 +206,8 @@ inline VkFormat backend_color_format(VkFormat format) {
         return format;
     if (format == VK_FORMAT_R8_UNORM)
         return VK_FORMAT_R8_UNORM;
+    if (format == VK_FORMAT_R8G8_UNORM)
+        return VK_FORMAT_R8G8_UNORM;
     if (format == VK_FORMAT_R32_UINT)
         return VK_FORMAT_R32_UINT;
     return VK_FORMAT_R8G8B8A8_UNORM;
@@ -211,6 +217,7 @@ inline uint32_t backend_color_bytes_per_pixel(VkFormat format) {
     format = backend_color_format(format);
     if (format == VK_FORMAT_R16G16B16A16_SFLOAT) return 8u;
     if (format == VK_FORMAT_R8_UNORM) return 1u;
+    if (format == VK_FORMAT_R8G8_UNORM) return 2u;
     return 4u;
 }
 
@@ -3360,8 +3367,10 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         VkBuffer staging = VK_NULL_HANDLE;
         VkDeviceMemory staging_memory = VK_NULL_HANDLE;
         uint64_t persistent_id = 0;
+        uint64_t persistent_version = 0;
         VkDeviceSize image_bytes = 0;
         bool persistent_hit = false;
+        bool persistent_refresh = false;
         bool borrowed_target = false;
         bool borrowed_compute = false;
         VkImageLayout borrowed_compute_layout = VK_IMAGE_LAYOUT_UNDEFINED;
@@ -3418,6 +3427,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         VkDeviceMemory memory = VK_NULL_HANDLE;
         VkDeviceSize bytes = 0;
         uint64_t last_use = 0;
+        uint64_t content_version = 0;
         std::unordered_map<TextureBindingKey, PersistentTextureBinding,
                            TextureBindingKeyHash> bindings;
     };
@@ -4089,6 +4099,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                         }
                         upload.persistent_id =
                             r.is_storage_image || upload.borrowed_ds ? 0 : r.persistent_texture_id;
+                        upload.persistent_version = r.persistent_texture_version;
                         const PersistentTextureKey persistent_key{
                             r.persistent_texture_id, r.tw, r.th, r.td, r.img_dim,
                             texture_key.mip_levels, backend_color_format(r.texture_format)};
@@ -4101,8 +4112,27 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                                 cached->second.last_use = texture_generation;
                                 upload.image = cached->second.image;
                                 upload.image_bytes = cached->second.bytes;
-                                upload.persistent_hit = true;
-                                ++persistent_texture_hits;
+                                // Immutable callers keep version zero and the historical exact-ID
+                                // contract. Versioned callers may refresh the same allocation after
+                                // frontend byte validation proves that its contents changed.
+                                if (upload.persistent_version &&
+                                    cached->second.content_version !=
+                                        upload.persistent_version) {
+                                    upload.persistent_refresh = true;
+                                    cached->second.content_version =
+                                        upload.persistent_version;
+                                    active_submission.add_failure_cleanup(
+                                        [persistent_key]() {
+                                            auto found = persistent_texture_images.find(
+                                                persistent_key);
+                                            if (found != persistent_texture_images.end())
+                                                found->second.content_version = 0;
+                                        });
+                                    ++persistent_texture_misses;
+                                } else {
+                                    upload.persistent_hit = true;
+                                    ++persistent_texture_hits;
+                                }
                             } else {
                                 ++persistent_texture_misses;
                             }
@@ -4110,38 +4140,44 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
 
                         if (!upload.persistent_hit && !upload.borrowed_target &&
                             !upload.borrowed_compute && !upload.borrowed_ds) {
-                            VkImageCreateInfo tci{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
-                            const bool texture_3d = r.img_dim == 2;
-                            tci.imageType = texture_3d ? VK_IMAGE_TYPE_3D : VK_IMAGE_TYPE_2D;
-                            tci.format = backend_color_format(r.texture_format);
-                            tci.extent = {r.tw, r.th, r.td};
-                            tci.mipLevels = upload.key.mip_levels; tci.arrayLayers = 1;
-                            tci.samples = VK_SAMPLE_COUNT_1_BIT; tci.tiling = VK_IMAGE_TILING_OPTIMAL;
-                            tci.usage = (r.is_storage_image ? VK_IMAGE_USAGE_STORAGE_BIT
-                                                          : VK_IMAGE_USAGE_SAMPLED_BIT) |
-                                        VK_IMAGE_USAGE_TRANSFER_DST_BIT |
-                                        (r.is_storage_image
-                                             ? VK_IMAGE_USAGE_TRANSFER_SRC_BIT : 0u) |
-                                        (upload.key.mip_levels > 1 ? VK_IMAGE_USAGE_TRANSFER_SRC_BIT
-                                                                   : 0u);   // blit-cascade source (#1272)
-                            vkCreateImage(dev, &tci, nullptr, &upload.image);
-                            VkMemoryRequirements tr;
-                            vkGetImageMemoryRequirements(dev, upload.image, &tr);
-                            upload.image_bytes = tr.size;
-                            VkMemoryAllocateInfo tai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO};
-                            tai.allocationSize = tr.size;
-                            tai.memoryTypeIndex = pick(tr.memoryTypeBits, 0);
-                            const bool retain = !r.is_storage_image && persistent_textures_enabled &&
-                                                upload.persistent_id &&
-                                                tr.size <= persistent_texture_limit;
-                            if (retain && vkAllocateMemory(dev, &tai, nullptr, &upload.memory) == VK_SUCCESS)
-                                upload.direct_memory = true;
-                            if (!upload.memory) {
-                                upload.persistent_id = 0;
-                                upload.memory = allocate_transient_render_memory(
-                                    dev, tai.allocationSize, tai.memoryTypeIndex);
+                            if (!upload.persistent_refresh) {
+                                VkImageCreateInfo tci{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
+                                const bool texture_3d = r.img_dim == 2;
+                                tci.imageType = texture_3d ? VK_IMAGE_TYPE_3D : VK_IMAGE_TYPE_2D;
+                                tci.format = backend_color_format(r.texture_format);
+                                tci.extent = {r.tw, r.th, r.td};
+                                tci.mipLevels = upload.key.mip_levels;
+                                tci.arrayLayers = 1;
+                                tci.samples = VK_SAMPLE_COUNT_1_BIT;
+                                tci.tiling = VK_IMAGE_TILING_OPTIMAL;
+                                tci.usage = (r.is_storage_image ? VK_IMAGE_USAGE_STORAGE_BIT
+                                                              : VK_IMAGE_USAGE_SAMPLED_BIT) |
+                                            VK_IMAGE_USAGE_TRANSFER_DST_BIT |
+                                            (r.is_storage_image
+                                                 ? VK_IMAGE_USAGE_TRANSFER_SRC_BIT : 0u) |
+                                            (upload.key.mip_levels > 1
+                                                 ? VK_IMAGE_USAGE_TRANSFER_SRC_BIT : 0u);
+                                vkCreateImage(dev, &tci, nullptr, &upload.image);
+                                VkMemoryRequirements tr;
+                                vkGetImageMemoryRequirements(dev, upload.image, &tr);
+                                upload.image_bytes = tr.size;
+                                VkMemoryAllocateInfo tai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO};
+                                tai.allocationSize = tr.size;
+                                tai.memoryTypeIndex = pick(tr.memoryTypeBits, 0);
+                                const bool retain = !r.is_storage_image &&
+                                    persistent_textures_enabled && upload.persistent_id &&
+                                    tr.size <= persistent_texture_limit;
+                                if (retain &&
+                                    vkAllocateMemory(dev, &tai, nullptr, &upload.memory) ==
+                                        VK_SUCCESS)
+                                    upload.direct_memory = true;
+                                if (!upload.memory) {
+                                    upload.persistent_id = 0;
+                                    upload.memory = allocate_transient_render_memory(
+                                        dev, tai.allocationSize, tai.memoryTypeIndex);
+                                }
+                                vkBindImageMemory(dev, upload.image, upload.memory, 0);
                             }
-                            vkBindImageMemory(dev, upload.image, upload.memory, 0);
 
                             // #1272: staging carries level 0 only; levels 1..N-1 are produced on the
                             // GPU by a linear-filtered vkCmdBlitImage cascade at upload time (see the
@@ -4322,7 +4358,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                             persistent_textures_enabled &&
                             getenv("PROSPER_NO_BACKEND_PERSISTENT_TEXTURE_BINDINGS") == nullptr;
                         auto persistent_image = persistent_texture_images.end();
-                        if (persistent_bindings_enabled && upload.persistent_hit &&
+                        if (persistent_bindings_enabled &&
+                            (upload.persistent_hit || upload.persistent_refresh) &&
                             upload.persistent_id && !r.is_storage_image) {
                             persistent_image = persistent_texture_images.find(
                                 {upload.persistent_id, upload.key.width, upload.key.height,
@@ -4988,11 +5025,19 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     for (const auto& upload : texture_uploads) {
         if (!upload.staging) continue;  // exact-validated persistent image already has shader-read layout
         VkImageMemoryBarrier b0{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
-        b0.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED; b0.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+        b0.oldLayout = upload.persistent_refresh
+            ? VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL : VK_IMAGE_LAYOUT_UNDEFINED;
+        b0.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
         b0.image = upload.image;
         b0.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, upload.key.mip_levels, 0, 1};
-        b0.srcAccessMask = 0; b0.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
-        vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr, 1, &b0);
+        b0.srcAccessMask = upload.persistent_refresh ? VK_ACCESS_SHADER_READ_BIT : 0;
+        b0.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+        vkCmdPipelineBarrier(
+            cmd,
+            upload.persistent_refresh
+                ? (VK_PIPELINE_STAGE_VERTEX_SHADER_BIT | VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT)
+                : VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+            VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr, 1, &b0);
         VkBufferImageCopy tc{}; tc.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
         tc.imageExtent = {upload.key.width, upload.key.height, upload.key.depth};
         vkCmdCopyBufferToImage(cmd, upload.staging, upload.image,
@@ -5506,7 +5551,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         return true;
     };
     for (auto& upload : texture_uploads) {
-        if (!upload.direct_memory || !upload.persistent_id || upload.persistent_hit) continue;
+        if (!upload.direct_memory || !upload.persistent_id || upload.persistent_hit ||
+            upload.persistent_refresh) continue;
         const PersistentTextureKey key{upload.persistent_id, upload.key.width, upload.key.height,
                                        upload.key.depth, upload.key.img_dim,
                                        upload.key.mip_levels, upload.key.format};
@@ -5520,7 +5566,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
             persistent_texture_bytes <= persistent_texture_limit - upload.image_bytes) {
             auto [cached, inserted] = persistent_texture_images.emplace(
                 key, PersistentTextureImage{upload.image, upload.memory, upload.image_bytes,
-                                            texture_generation});
+                                            texture_generation, upload.persistent_version});
             if (inserted) {
                 persistent_texture_bytes += upload.image_bytes;
                 upload.image = VK_NULL_HANDLE;
@@ -5999,7 +6045,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
             for (SharedBufferArena& arena : shared_buffer_arenas)
                 release_render_host_buffer(dev, arena.buffer);
             for (auto& upload : texture_uploads) {
-                if (upload.image && !upload.persistent_hit && !upload.borrowed_target &&
+                if (upload.image && !upload.persistent_hit && !upload.persistent_refresh &&
+                    !upload.borrowed_target &&
                     !upload.borrowed_compute && !upload.borrowed_ds)
                     vkDestroyImage(dev, upload.image, nullptr);
                 if (upload.memory) {

--- a/prosper/tests/test_texture_sample_render.cpp
+++ b/prosper/tests/test_texture_sample_render.cpp
@@ -127,6 +127,10 @@ int main() {
               "native R8 sampled upload broadcasts its channel without RGBA expansion");
         CHECK(prosper::test::backend_color_bytes_per_pixel(VK_FORMAT_R8_UNORM) == 1,
               "native R8 upload accounts one byte per texel");
+        CHECK(prosper::test::backend_color_format(VK_FORMAT_R8G8_UNORM) ==
+                  VK_FORMAT_R8G8_UNORM &&
+                  prosper::test::backend_color_bytes_per_pixel(VK_FORMAT_R8G8_UNORM) == 2,
+              "native RG8 upload retains two channels and accounts two bytes per texel");
         CHECK(prosper::test::backend_color_format(VK_FORMAT_R32_UINT) == VK_FORMAT_R32_UINT &&
                   prosper::test::backend_color_bytes_per_pixel(VK_FORMAT_R32_UINT) == 4,
               "R32_UINT storage images retain their typed four-byte Vulkan format");
@@ -261,7 +265,27 @@ int main() {
         std::memcpy(changed_texels, texels, sizeof(texels));
         changed_texels[4] = 255;  // sampled top-right texel: green -> yellow
         resource.tex_rgba = changed_texels;
+        resource.persistent_texture_version = 1;
+        draw.R = {resource};
+        std::vector<uint8_t> refreshed = prosper::test::render_draws_rgba({draw}, W, H);
+        const auto refreshed_stats = prosper::test::backend_texture_upload_stats();
+        std::vector<uint8_t> refreshed_reuse = prosper::test::render_draws_rgba({draw}, W, H);
+        const auto refreshed_reuse_stats = prosper::test::backend_texture_upload_stats();
+        CHECK(refreshed_stats.persistent_misses == 1 &&
+                  refreshed_stats.unique_uploads == 1 &&
+                  refreshed_stats.persistent_cached_bytes == reused_stats.persistent_cached_bytes,
+              "a newer validated version refreshes its existing persistent image allocation");
+        CHECK(refreshed_reuse_stats.persistent_hits == 1 &&
+                  refreshed_reuse_stats.unique_uploads == 0 &&
+                  refreshed_reuse_stats.persistent_cached_bytes ==
+                      reused_stats.persistent_cached_bytes,
+              "the refreshed version skips its next callback upload without growing the cache");
+        CHECK(!refreshed.empty() && refreshed != reused && refreshed == refreshed_reuse,
+              "versioned persistent refresh renders changed pixels and then reuses them exactly");
+
+        resource.tex_rgba = changed_texels;
         resource.persistent_texture_id = 0x7020000000000002ull;
+        resource.persistent_texture_version = 0;
         draw.R = {resource};
         std::vector<uint8_t> changed = prosper::test::render_draws_rgba({draw}, W, H);
         const auto changed_stats = prosper::test::backend_texture_upload_stats();

--- a/prosper/tests/test_texture_sample_render.cpp
+++ b/prosper/tests/test_texture_sample_render.cpp
@@ -205,6 +205,31 @@ int main() {
         prosper::test::BackendDraw draw;
         draw.vs = vert; draw.fs = frag; draw.R = {resource}; draw.vcount = 3;
 
+        // A first upload is published to the persistent map while its command buffer is merely
+        // queued, so a discarded batch must invalidate that speculative image. Retrying the same
+        // version must upload again rather than sampling undefined contents as an exact-version hit.
+        prosper::test::FrameResource failed_resource = resource;
+        failed_resource.persistent_texture_id = 0x70200000000000f1ull;
+        failed_resource.persistent_texture_version = 1;
+        prosper::test::BackendDraw failed_draw = draw;
+        failed_draw.R = {failed_resource};
+        constexpr uint64_t failed_target_id = 0x75900000000000f1ull;
+        prosper::test::BackendColorTarget failed_target{failed_target_id, false, false};
+        prosper::test::BackendSubmissionBatch failed_batch;
+        const std::vector<uint8_t> failed_pending = prosper::test::render_draws_rgba(
+            {failed_draw}, W, H, nullptr, nullptr, false, &failed_target,
+            nullptr, nullptr, nullptr, &failed_batch, false);
+        failed_batch.discard();
+        failed_batch.complete();
+        const std::vector<uint8_t> failed_retry = prosper::test::render_draws_rgba(
+            {failed_draw}, W, H);
+        const auto failed_retry_stats = prosper::test::backend_texture_upload_stats();
+        CHECK(failed_pending.empty() && !failed_batch.pending() &&
+                  failed_retry_stats.persistent_misses == 1 &&
+                  failed_retry_stats.unique_uploads == 1 && !failed_retry.empty(),
+              "a discarded first versioned upload is rebuilt before reuse");
+        prosper::test::invalidate_persistent_color_target(failed_target_id);
+
         std::vector<uint8_t> first = prosper::test::render_draws_rgba({draw}, W, H);
         const auto first_stats = prosper::test::backend_texture_upload_stats();
         std::vector<uint8_t> reused = prosper::test::render_draws_rgba({draw}, W, H);


### PR DESCRIPTION
## Summary

- preserve AvPlayer chroma as native two-channel RG8 instead of expanding it to RGBA on the CPU
- refresh mutable, exactly validated guest textures in their existing Vulkan allocations
- keep immutable persistent texture IDs backward compatible
- add coverage for refresh, reuse, cache-size stability, and native RG8 accounting

## Astro Bot measurements

A 100-second run of the 3840x2160 intro FMV showed:

- backend persistent sampled-texture cache stayed near 342 MiB instead of growing past 4 GiB
- graphics submissions fell from roughly 20–22 ms to 16–18 ms
- delivered video frames increased from 459 to 489 in the same run window
- visual output remained unchanged; this does not yet make the FMV real-time

The decoder itself remains capable of feeding frames. Guest compute and render work per decoded frame is now the main bottleneck and will be investigated separately.

## Verification

- built `prosper-app`, `test_gpu_capture_render`, and `test_texture_sample_render`
- 19 focused Vulkan renderer/compute tests pass
- live Astro Bot run through the intro FMV
- snapshot suite intentionally not run; project policy makes snapshots optional during development and required for releases

Refs #841
