### PR TITLE
Render DCC fast clears on the GPU

### DIFF
--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -3026,6 +3026,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             (!timing_trace_only || trace);
         for (size_t i = 0; i < image_descriptors.size() && images_ready; i++) {
             const auto image_start = ComputeClock::now();
+            double import_ms = 0.0;
+            double view_ms = 0.0;
+            double sampler_ms = 0.0;
             const ShaderResource* r = item.resources->by_binding(image_descriptors[i].binding);
             if (!r || !r->width || !r->height) { skip_image(r, "no/degenerate resource"); break; }
             BoundImage& bi = images[i];
@@ -3044,10 +3047,14 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 r->format == DataFormat::Float10_11_11 && descriptor_components == 3;
             const bool ordinary_2d_storage = r->img_dim == 1 && r->depth == 1 &&
                                              !r->depth_compare;
-            const bool native_storage_supported = native_float_storage_image_supported(
-                r->format, descriptor_components, r->srgb,
-                ordinary_2d_storage && native_storage_image_create_supported(
-                    ctx.physical, native_storage_format, r->width, r->height));
+            // vkGetPhysicalDeviceImageFormatProperties is a driver query, not a cheap metadata
+            // lookup. Sampled and raw-uvec4 descriptors cannot take this typed-storage path, so do
+            // not repeat that query for every one of their per-frame bindings.
+            const bool native_storage_supported = spirv_native_storage &&
+                native_float_storage_image_supported(
+                    r->format, descriptor_components, r->srgb,
+                    ordinary_2d_storage && native_storage_image_create_supported(
+                        ctx.physical, native_storage_format, r->width, r->height));
             if (spirv_native_storage && !native_storage_supported) {
                 skip_image(r, "compiled typed storage format is unsupported by this device");
                 break;
@@ -3198,8 +3205,11 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 const LiveTargetImageRequest import_request{
                     r->width, r->height, render_scale, depth_import_eligible,
                     scalable_normalized_sampling};
+                const auto import_start = ComputeClock::now();
                 const bool import_available = import_live_render_target_image(
                     r->gpu_addr, import_request, import);
+                import_ms = std::chrono::duration<double, std::milli>(
+                    ComputeClock::now() - import_start).count();
                 if (trace)
                     std::fprintf(stderr,
                                  "[compute]   direct RTT candidate binding=%u addr=0x%llx "
@@ -4528,8 +4538,11 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             const VkImageAspectFlags image_aspect = (sampled_depth || bi.imported_depth)
                 ? VK_IMAGE_ASPECT_DEPTH_BIT : VK_IMAGE_ASPECT_COLOR_BIT;
             vci.subresourceRange = {image_aspect, 0, 1, 0, ici.arrayLayers};
+            const auto view_start = ComputeClock::now();
             if (!vk_ok(vkCreateImageView(ctx.device, &vci, nullptr, &bi.view),
                        "image-view")) { images_ready = false; break; }
+            view_ms = std::chrono::duration<double, std::milli>(
+                ComputeClock::now() - view_start).count();
             if (!bi.storage) {
                 // Sampler from the decoded S# (mag/min filter, SQ_TEX CLAMP wrap enums) — the same
                 // fields the renderer honors; defaults reproduce LINEAR/clamp.
@@ -4558,14 +4571,18 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 smci.borderColor = VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK;
                 smci.compareEnable = sampled_depth ? VK_TRUE : VK_FALSE;
                 smci.compareOp = static_cast<VkCompareOp>(r->depth_compare_func & 0x7u);
+                const auto sampler_start = ComputeClock::now();
                 if (!vk_ok(vkCreateSampler(ctx.device, &smci, nullptr, &bi.sampler), "image-sampler")) {
                     images_ready = false; break; }
+                sampler_ms = std::chrono::duration<double, std::milli>(
+                    ComputeClock::now() - sampler_start).count();
             }
             if (image_timing)
                 std::fprintf(stderr,
                              "[compute-image] code=0x%llx binding=%u class=%s imported=%u "
                              "extent=%ux%ux%u guest=%zu staging=%llu "
-                             "normalized=%u texel=%u sampled-float=%u rgba8-reuse=%u ms=%.3f\n",
+                             "normalized=%u texel=%u sampled-float=%u rgba8-reuse=%u "
+                             "import_ms=%.3f view_ms=%.3f sampler_ms=%.3f ms=%.3f\n",
                              (unsigned long long)item.code_addr, bi.binding,
                              bi.storage ? "storage" : "sampled", bi.imported ? 1u : 0u,
                              r->width, r->height, r->depth, bi.guest_bytes,
@@ -4574,6 +4591,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                              image_descriptors[i].texel_access ? 1u : 0u,
                              image_descriptors[i].sampled_float ? 1u : 0u,
                              bi.unorm_rtt_value_reuse ? 1u : 0u,
+                             import_ms, view_ms, sampler_ms,
                              std::chrono::duration<double, std::milli>(
                                  ComputeClock::now() - image_start).count());
         }

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -1533,14 +1533,6 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 }
                             }
                         }
-                        const bool has_cpu_live_rtt = !fr.is_storage_image && r.img_dim == 1u &&
-                            live_rtt != g_rtt.end() &&
-                            live_rtt->second.w && live_rtt->second.h && live_rtt->second.rgba &&
-                            prosper::frontend::live_rtt_cpu_snapshot_matches(
-                                live_rtt->second.w, live_rtt->second.h,
-                                prosper::test::backend_color_bytes_per_pixel(
-                                    prosper::test::backend_color_format(live_rtt->second.format)),
-                                live_rtt->second.rgba->size());
                         static const bool retain_cpu_rtt_snapshots =
                             getenv("PROSPER_NO_RTT_SNAPSHOT_BORROW") == nullptr;
                         // Pixel-mutating/inspection diagnostics intentionally retain their owned
@@ -1553,6 +1545,21 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             getenv("PROSPER_TESTLUT") || getenv("PROSPER_TESTLUT32") ||
                             getenv("PROSPER_DUMP_TEX") || getenv("PROSPER_DUMP_ATLAS") ||
                             getenv("PROSPER_KILL_RING");
+                        const bool uniform_cpu_diagnostic_path =
+                            live_rtt != g_rtt.end() &&
+                            prosper::frontend::live_rtt_uniform_uses_cpu_diagnostic_path(
+                                live_rtt->second.has_uniform_color,
+                                cpu_rtt_copy_diagnostics);
+                        if (uniform_cpu_diagnostic_path)
+                            materialize_uniform_rtt(live_rtt->second);
+                        const bool has_cpu_live_rtt = !fr.is_storage_image && r.img_dim == 1u &&
+                            live_rtt != g_rtt.end() &&
+                            live_rtt->second.w && live_rtt->second.h && live_rtt->second.rgba &&
+                            prosper::frontend::live_rtt_cpu_snapshot_matches(
+                                live_rtt->second.w, live_rtt->second.h,
+                                prosper::test::backend_color_bytes_per_pixel(
+                                    prosper::test::backend_color_format(live_rtt->second.format)),
+                                live_rtt->second.rgba->size());
                         // Match the established CPU injection gate below. Cube descriptors and
                         // mismatched 2D views can also retain identical materialized bytes; 3D
                         // volumes, storage images, and mip tails remain on their specialized paths.
@@ -1578,7 +1585,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 r.gpu_addr, live_rtt->second.w, live_rtt->second.h,
                                 live_rtt->second.format) != nullptr;
                         const bool has_uniform_live_rtt = !fr.is_storage_image &&
-                            r.img_dim == 1u && !r.in_mip_tail && live_rtt != g_rtt.end() &&
+                            !uniform_cpu_diagnostic_path && r.img_dim == 1u &&
+                            !r.in_mip_tail && live_rtt != g_rtt.end() &&
                             live_rtt->second.has_uniform_color && live_rtt->second.w &&
                             live_rtt->second.h &&
                             prosper::frontend::rtt_sampled_extent_compatible(

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -18,6 +18,7 @@
 #include "gpu/rdna2_to_spirv.hpp"       // recompile_fragment (diagnostic solid-color PS)
 #include "gpu/videoout_present.hpp"     // present_front_index (flip-anchored present selection)
 #include "present_blit.hpp"             // GPU scanout handoff (#1270 unified-device present)
+#include "present_blit_policy.hpp"      // flip-anchored scanout publication policy
 #include "host/guest_write_watch.hpp"
 #include "render_runner.h"              // offscreen Vulkan backend (render_draws_rgba) + dump_bmp
 
@@ -55,6 +56,7 @@ extern "C" int prosper_try_commit_dmem(uint64_t addr, uint64_t len, int write);
 // BEFORE the submit's execute_and_present, so at render time these identify this frame's scanout VA.
 extern "C" int      prosper_vo_buffer_count();
 extern "C" uint64_t prosper_vo_buffer_addr(int i);
+extern "C" uint64_t prosper_vo_flip_count();
 
 namespace prosper::frontend {
 
@@ -74,6 +76,10 @@ constexpr uint32_t kMaxBufferUploadBytes = 64u << 20;
 
 struct RttSurf {
     std::shared_ptr<const std::vector<uint8_t>> rgba;
+    // Uniform DCC fast-clears remain compact until a consumer genuinely needs CPU bytes. Graphics
+    // sampling and attachment LOADs can realize the value directly on the GPU.
+    bool has_uniform_color = false;
+    std::array<float, 4> uniform_color{};
     uint32_t w = 0, h = 0;
     VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
     bool gpu_valid = false;
@@ -84,6 +90,39 @@ struct RttSurf {
     uint64_t dcc_metadata_bytes = 0;
     bool dcc_metadata_dirty = false;
 };
+
+bool materialize_uniform_rtt(RttSurf& surface) {
+    if (!surface.has_uniform_color || !surface.w || !surface.h) return false;
+    const VkFormat format = prosper::test::backend_color_format(surface.format);
+    const uint32_t bpp = prosper::test::backend_color_bytes_per_pixel(format);
+    const uint64_t texels = static_cast<uint64_t>(surface.w) * surface.h;
+    if (!bpp || texels > SIZE_MAX / bpp) return false;
+    std::vector<uint8_t> pixels(static_cast<size_t>(texels) * bpp);
+    if (format == VK_FORMAT_R8G8B8A8_UNORM) {
+        uint8_t native[4];
+        for (uint32_t channel = 0; channel < 4; ++channel)
+            native[channel] = static_cast<uint8_t>(std::clamp(
+                surface.uniform_color[channel], 0.0f, 1.0f) * 255.0f + 0.5f);
+        prosper::frontend::fill_repeating_pixel(pixels, native, sizeof(native));
+    } else if (format == VK_FORMAT_R16G16B16A16_SFLOAT) {
+        uint16_t native[4];
+        for (uint32_t channel = 0; channel < 4; ++channel)
+            native[channel] = prosper::gpu::float_to_half(surface.uniform_color[channel]);
+        prosper::frontend::fill_repeating_pixel(
+            pixels, reinterpret_cast<const uint8_t*>(native), sizeof(native));
+    } else if (format == VK_FORMAT_B10G11R11_UFLOAT_PACK32) {
+        const uint32_t native =
+            static_cast<uint32_t>(prosper::gpu::float_to_f11(surface.uniform_color[0])) |
+            (static_cast<uint32_t>(prosper::gpu::float_to_f11(surface.uniform_color[1])) << 11) |
+            (static_cast<uint32_t>(prosper::gpu::float_to_f10(surface.uniform_color[2])) << 22);
+        prosper::frontend::fill_repeating_pixel(
+            pixels, reinterpret_cast<const uint8_t*>(&native), sizeof(native));
+    } else {
+        return false;
+    }
+    surface.rgba = std::make_shared<const std::vector<uint8_t>>(std::move(pixels));
+    return true;
+}
 
 using RttCache = std::unordered_map<uint64_t, RttSurf>;
 
@@ -124,6 +163,7 @@ void invalidate_cpu_rtt_guest_write(RttCache& cache, uint64_t addr, uint64_t siz
             // the descriptor in the following graphics span, but never LOAD or sample stale pixels.
             prosper::test::invalidate_persistent_color_target(it->first);
             it->second.rgba.reset();
+            it->second.has_uniform_color = false;
             it->second.gpu_valid = false;
             it->second.dcc_metadata_dirty = true;
             ++it;
@@ -491,6 +531,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
             if (surface.rgba && prosper::frontend::live_rtt_cpu_snapshot_matches(
                     surface.w, surface.h, bytes_per_pixel, surface.rgba->size()))
                 return true;
+            if (materialize_uniform_rtt(surface)) return true;
             if (!surface.gpu_valid) return false;
             std::vector<uint8_t> materialized;
             if (!prosper::test::readback_persistent_color_target(
@@ -580,9 +621,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
         const VkFormat format = prosper::test::backend_color_format(surface.format);
         const uint32_t bytes_per_pixel =
             prosper::test::backend_color_bytes_per_pixel(format);
-        const bool has_cpu_snapshot = surface.rgba &&
+        const bool has_cpu_snapshot = (surface.rgba &&
             prosper::frontend::live_rtt_cpu_snapshot_matches(
-                surface.w, surface.h, bytes_per_pixel, surface.rgba->size());
+                surface.w, surface.h, bytes_per_pixel, surface.rgba->size())) ||
+            surface.has_uniform_color;
         return prosper::frontend::live_rtt_compute_authoritative(
             surface.gpu_valid, has_cpu_snapshot);
     });
@@ -597,6 +639,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
             const uint64_t texels = static_cast<uint64_t>(surface.w) * surface.h;
             if (!bytes_per_pixel || texels > UINT64_MAX / bytes_per_pixel) return false;
             const uint64_t expected = texels * bytes_per_pixel;
+            if ((!surface.rgba || surface.rgba->size() != expected) &&
+                surface.has_uniform_color)
+                materialize_uniform_rtt(surface);
             // Graphics-to-graphics intermediates normally stay in the persistent Vulkan target.
             // Compute cannot import that color attachment directly, so materialize its current
             // pixels only when an ordered compute dispatch actually consumes the surface.
@@ -761,6 +806,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 return;
             RttSurf& published = g_rtt[write.gpu_addr];
             published.rgba.reset();
+            published.has_uniform_color = false;
             published.w = write.width;
             published.h = write.height;
             published.format = format;
@@ -783,6 +829,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 const uint64_t target_bytes = pixels * bpp;
                 const uint64_t offset = addr - base;
                 if (offset >= target_bytes) continue;
+                if ((!surface.rgba || surface.rgba->size() != target_bytes) &&
+                    surface.has_uniform_color)
+                    materialize_uniform_rtt(surface);
                 if ((!surface.rgba || surface.rgba->size() != target_bytes) &&
                     surface.gpu_valid) {
                     std::vector<uint8_t> materialized;
@@ -831,6 +880,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
             surface.w = seed.width; surface.h = seed.height;
             surface.format = format;
             surface.rgba = std::make_shared<const std::vector<uint8_t>>(seed.rgba);
+            surface.has_uniform_color = false;
             surface.gpu_valid = false;
             surface.dcc_metadata_dirty = false;
             prosper::test::invalidate_persistent_color_target(seed.guest_addr);
@@ -938,7 +988,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
             using RenderClock = std::chrono::steady_clock;
             struct RenderTiming {
                 uint64_t callbacks = 0;
-                double total_ms = 0, build_resources_ms = 0, backend_ms = 0, output_copy_ms = 0;
+                double total_ms = 0, prelude_ms = 0, pass_ms = 0;
+                double build_resources_ms = 0, backend_ms = 0, output_copy_ms = 0;
+                double dcc_materialize_ms = 0;
+                uint64_t dcc_materialize_surfaces = 0, dcc_materialize_bytes = 0;
                 uint64_t backend_calls = 0, backend_draws = 0;
                 uint64_t backend_command_buffers = 0, backend_queue_submits = 0;
                 uint64_t backend_fence_waits = 0;
@@ -1141,6 +1194,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
             // A uniform DCC clear is self-contained in metadata. If the ordered compute span dirtied
             // a retained target's metadata, materialize that clear now so the following graphics pass
             // loads the clear value rather than stale pixels (or an arbitrary fallback clear).
+            const auto dcc_materialize_start = timing_enabled
+                ? RenderClock::now() : RenderClock::time_point{};
+            uint64_t dcc_materialize_surfaces = 0;
+            uint64_t dcc_materialize_bytes = 0;
             for (const auto& item : items) {
                 const prosper::gpu::ShaderResourceTable* tables[] = {
                     item.vrt.get(), item.prt.get(),
@@ -1179,37 +1236,30 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         uint8_t clear_rgba[4]{};
                         if (!prosper::gpu::gfx10_dcc_fast_clear_rgba8(
                                 clear_rgba, 1, metadata.data(), metadata.size(),
-                                resource.num_components, resource.alpha_is_on_msb))
+                            resource.num_components, resource.alpha_is_on_msb))
                             continue;
-                        std::vector<uint8_t> pixels(static_cast<size_t>(texels) * bpp);
-                        if (format == VK_FORMAT_R8G8B8A8_UNORM) {
-                            for (size_t texel = 0; texel < static_cast<size_t>(texels); ++texel)
-                                std::memcpy(pixels.data() + texel * 4, clear_rgba, 4);
-                        } else if (format == VK_FORMAT_R16G16B16A16_SFLOAT) {
-                            uint16_t native[4];
-                            for (uint32_t channel = 0; channel < 4; ++channel)
-                                native[channel] = prosper::gpu::float_to_half(
-                                    clear_rgba[channel] ? 1.0f : 0.0f);
-                            for (size_t texel = 0; texel < static_cast<size_t>(texels); ++texel)
-                                std::memcpy(pixels.data() + texel * 8, native, sizeof(native));
-                        } else if (format == VK_FORMAT_B10G11R11_UFLOAT_PACK32) {
-                            const uint32_t native =
-                                static_cast<uint32_t>(prosper::gpu::float_to_f11(
-                                    clear_rgba[0] ? 1.0f : 0.0f)) |
-                                (static_cast<uint32_t>(prosper::gpu::float_to_f11(
-                                    clear_rgba[1] ? 1.0f : 0.0f)) << 11) |
-                                (static_cast<uint32_t>(prosper::gpu::float_to_f10(
-                                    clear_rgba[2] ? 1.0f : 0.0f)) << 22);
-                            for (size_t texel = 0; texel < static_cast<size_t>(texels); ++texel)
-                                std::memcpy(pixels.data() + texel * 4, &native, sizeof(native));
-                        } else {
+                        if (format != VK_FORMAT_R8G8B8A8_UNORM &&
+                            format != VK_FORMAT_R16G16B16A16_SFLOAT &&
+                            format != VK_FORMAT_B10G11R11_UFLOAT_PACK32) {
                             continue;
                         }
-                        found->second.rgba =
-                            std::make_shared<const std::vector<uint8_t>>(std::move(pixels));
+                        found->second.rgba.reset();
+                        found->second.has_uniform_color = true;
+                        for (uint32_t channel = 0; channel < 4; ++channel)
+                            found->second.uniform_color[channel] =
+                                clear_rgba[channel] ? 1.0f : 0.0f;
                         found->second.dcc_metadata_dirty = false;
+                        ++dcc_materialize_surfaces;
+                        dcc_materialize_bytes += sizeof(found->second.uniform_color);
                     }
                 }
+            }
+            if (timing_enabled) {
+                pending_timing.dcc_materialize_ms +=
+                    std::chrono::duration<double, std::milli>(
+                        RenderClock::now() - dcc_materialize_start).count();
+                pending_timing.dcc_materialize_surfaces += dcc_materialize_surfaces;
+                pending_timing.dcc_materialize_bytes += dcc_materialize_bytes;
             }
             auto safe_equal = [](const uint8_t* expected, uint64_t a, size_t n,
                                  size_t& compared) -> bool {
@@ -1527,7 +1577,15 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             prosper::test::find_persistent_color_target(
                                 r.gpu_addr, live_rtt->second.w, live_rtt->second.h,
                                 live_rtt->second.format) != nullptr;
-                        const bool has_live_rtt = has_cpu_live_rtt || has_gpu_live_rtt;
+                        const bool has_uniform_live_rtt = !fr.is_storage_image &&
+                            r.img_dim == 1u && !r.in_mip_tail && live_rtt != g_rtt.end() &&
+                            live_rtt->second.has_uniform_color && live_rtt->second.w &&
+                            live_rtt->second.h &&
+                            prosper::frontend::rtt_sampled_extent_compatible(
+                                tw, th, live_rtt->second.w, live_rtt->second.h, render_scale,
+                                normalized_sampling) && r.gpu_addr != draw.color0_base;
+                        const bool has_live_rtt =
+                            has_cpu_live_rtt || has_gpu_live_rtt || has_uniform_live_rtt;
                         // Resolve renderer-owned depth before considering guest-byte texture
                         // decoding. A sampled depth attachment has no authoritative color payload
                         // in guest memory: the retained Vulkan image is the source of truth. The old
@@ -2058,6 +2116,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                         (unsigned long long)at, (unsigned long long)r.gpu_addr,
                                         tw, th, r.img_dim, (unsigned)r.format,
                                         has_gpu_live_rtt          ? "gpu-bind"
+                                        : has_uniform_live_rtt    ? "uniform-clear"
                                         : has_cpu_live_rtt        ? "cpu-rtt"
                                         : resource_compute_image_hit ? "compute-bind"
                                         : decoded_reuse           ? "decode-cache"
@@ -2083,6 +2142,15 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             fr.tw = live_rtt->second.w;
                             fr.th = live_rtt->second.h;
                             fr.td = 1; fr.img_dim = r.img_dim;
+                            fr.texture_format = live_rtt->second.format;
+                            resource_rtt_hit = true;
+                        } else if (has_uniform_live_rtt) {
+                            fr.has_uniform_color = true;
+                            fr.uniform_color = live_rtt->second.uniform_color;
+                            fr.tw = live_rtt->second.w;
+                            fr.th = live_rtt->second.h;
+                            fr.td = 1;
+                            fr.img_dim = r.img_dim;
                             fr.texture_format = live_rtt->second.format;
                             resource_rtt_hit = true;
                         } else if (resource_compute_image_hit) {
@@ -3736,6 +3804,11 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
             auto clear_for = [](const std::vector<const prosper::gpu::DrawItem*>& g) -> const float* {
                 return g.empty() ? nullptr : g.front()->ps.clear_color;
             };
+            const auto pass_timing_start = timing_enabled
+                ? RenderClock::now() : RenderClock::time_point{};
+            if (timing_enabled)
+                pending_timing.prelude_ms += std::chrono::duration<double, std::milli>(
+                    pass_timing_start - callback_timing_start).count();
             std::shared_ptr<const std::vector<uint8_t>> selected_pixels;
             bool published_gpu = false;
             if (pertarget) {
@@ -3864,6 +3937,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         const uint64_t rsrc = pass.front()->color0_base;
                         const uint64_t rdst = pass.front()->color1_base;
                         auto src_it = rsrc ? g_rtt.find(rsrc) : g_rtt.end();
+                        if (src_it != g_rtt.end() && src_it->second.has_uniform_color)
+                            materialize_uniform_rtt(src_it->second);
                         // Deferred RTT readback (#1284): the resolve is a CPU copy of the source's
                         // pixels, and the source pass usually rendered EARLIER IN THIS BATCH with its
                         // readback deferred. The consumer scan cannot see a resolve (it consumes via
@@ -4075,6 +4150,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         }
                     }
                     const uint8_t* seed = nullptr;
+                    const float* retained_uniform_clear = nullptr;
                     bool gpu_seed_available = false;
                     const VkFormat pass_format = format0;
                     uint32_t mrt_count = requested_color_count;
@@ -4112,6 +4188,11 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             sit->second.format == pass_format && sit->second.rgba &&
                             sit->second.rgba->size() == pass_bytes)
                             seed = sit->second.rgba->data();
+                        if (!gpu_seed_available && !seed && sit != g_rtt.end() &&
+                            sit->second.w == gw && sit->second.h == gh &&
+                            sit->second.format == pass_format &&
+                            sit->second.has_uniform_color)
+                            retained_uniform_clear = sit->second.uniform_color.data();
                         // Gated seed-decision diagnostic: a pass that should LOAD prior target
                         // content but silently falls back to its clear color erases everything the
                         // earlier pass produced (an opaque-black clear wipes a transparent UI RT —
@@ -4258,6 +4339,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         }
                     }
                     const uint8_t* seed1 = nullptr;
+                    const float* retained_uniform_clear1 = nullptr;
                     bool gpu_seed1_available = false;
                     if (seed_rtt && use_color1) { auto sit = g_rtt.find(base1);
                         gpu_seed1_available = live_gpu_targets && sit != g_rtt.end() &&
@@ -4271,7 +4353,12 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             sit->second.format == pass_format1 && sit->second.rgba &&
                             sit->second.rgba->size() == static_cast<size_t>(gw) * gh *
                                 prosper::test::backend_color_bytes_per_pixel(pass_format1))
-                            seed1 = sit->second.rgba->data(); }
+                            seed1 = sit->second.rgba->data();
+                        if (!gpu_seed1_available && !seed1 && sit != g_rtt.end() &&
+                            sit->second.w == gw && sit->second.h == gh &&
+                            sit->second.format == pass_format1 &&
+                            sit->second.has_uniform_color)
+                            retained_uniform_clear1 = sit->second.uniform_color.data(); }
                     if (base1 && !use_color1 && rtt_log) {
                         const auto* first = render_pass.empty() ? nullptr : render_pass.front();
                         fprintf(stderr,
@@ -4294,9 +4381,11 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     prosper::test::BackendMrtOutputs mrt_outputs;
                     mrt_outputs.color_count = mrt_count;
                     std::vector<uint8_t> gpx = prosper::test::render_draws_rgba(
-                        backend_draws, gw, gh, seed, clear_for(render_pass), true,
+                        backend_draws, gw, gh, seed,
+                        retained_uniform_clear ? retained_uniform_clear : clear_for(render_pass), true,
                         live_gpu_targets && base ? &backend_target : nullptr,
-                        seed1, use_color1 ? render_pass.front()->ps.clear_color1 : nullptr,
+                        seed1, retained_uniform_clear1 ? retained_uniform_clear1
+                            : (use_color1 ? render_pass.front()->ps.clear_color1 : nullptr),
                         nullptr,
                         batch_backend_submits ? &backend_submission : nullptr,
                         pass_i == items.size(), &mrt_outputs);
@@ -4329,6 +4418,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         surface.w = gw;
                         surface.h = gh;
                         surface.format = pass_format;
+                        surface.has_uniform_color = false;
                         surface.dcc_metadata_dirty = false;
                         surface.gpu_valid = prosper::test::find_persistent_color_target(
                             base, gw, gh, pass_format) != nullptr;
@@ -4366,6 +4456,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         surface.h = gh;
                         surface.format = pass_format;
                         surface.gpu_valid = false;
+                        surface.has_uniform_color = false;
                         surface.dcc_metadata_dirty = false;
                     }
                     for (uint32_t slot = 1; slot < mrt_count; ++slot) {
@@ -4388,6 +4479,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         surface.w = gw;
                         surface.h = gh;
                         surface.format = pass_formats[slot];
+                        surface.has_uniform_color = false;
                         surface.dcc_metadata_dirty = false;
                         surface.gpu_valid = slot == 1 &&
                             prosper::test::find_persistent_color_target(
@@ -4718,6 +4810,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         RttSurf& s = g_rtt[tgt];
                         s.rgba = selected_pixels; s.w = w; s.h = h;
                         s.format = VK_FORMAT_R8G8B8A8_UNORM; s.gpu_valid = false;
+                        s.has_uniform_color = false;
                         s.dcc_metadata_dirty = false;
                         prosper::test::invalidate_persistent_color_target(tgt);
                     }
@@ -4728,10 +4821,15 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         fprintf(stderr, ") px_nonzero=%zu cache_size=%zu\n", nz, g_rtt.size()); }
                 }
             }
+            if (timing_enabled)
+                pending_timing.pass_ms += std::chrono::duration<double, std::milli>(
+                    RenderClock::now() - pass_timing_start).count();
             // Ordered submits may invoke this callback for several graphics spans separated by
             // compute dispatches. Intermediate spans only update g_rtt. At the final span, recover
             // the flipped scanout from that persistent cache even when it was rendered earlier in
             // the transaction, and advance frame/dump state exactly once.
+            const auto output_copy_start = timing_enabled && phase.final_span
+                ? RenderClock::now() : RenderClock::time_point{};
             if (phase.final_span && pertarget) {
                 auto cached_scanout = [&](uint64_t addr) -> const RttSurf* {
                     auto it = g_rtt.find(addr);
@@ -4740,6 +4838,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         return nullptr;
                     RttSurf& surface = it->second;
                     const size_t expected = static_cast<size_t>(w) * h * 4;
+                    if ((!surface.rgba || surface.rgba->size() != expected) &&
+                        surface.has_uniform_color)
+                        materialize_uniform_rtt(surface);
                     if ((!surface.rgba || surface.rgba->size() != expected) && surface.gpu_valid) {
                         std::vector<uint8_t> materialized;
                         std::string error;
@@ -4762,6 +4863,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     return surface.rgba && surface.rgba->size() == expected ? &surface : nullptr;
                 };
                 const int front = prosper::gpu::present_front_index();
+                static uint64_t last_gpu_publish_flip = UINT64_MAX;
+                const uint64_t current_flip = prosper_vo_flip_count();
+                const bool new_gpu_flip = prosper::frontend::present_blit_has_new_flip(
+                    last_gpu_publish_flip, current_flip);
                 // GPU present (#1270): when prosper-app has adopted this device and is consuming the
                 // front-buffer image directly, blit it into a scanout slot on the GPU and SKIP the CPU
                 // readback+reupload entirely. gpu_present_active() is false in every headless/test/
@@ -4770,7 +4875,12 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 // through to the CPU readback below, which still publishes a CPU frame; prosper-app
                 // presents that CPU frame when no GPU frame was published (main.cpp), so a miss degrades to
                 // the CPU present path rather than freezing the window.
-                if (front >= 0 && prosper::gpu::gpu_present_active()) {
+                if (front >= 0 && prosper::gpu::gpu_present_active() && !new_gpu_flip) {
+                    // The previously published slot remains the correct scanout for this guest
+                    // flip. Treat it as a successful GPU publication so intermediate render
+                    // submissions do not fall through to the expensive CPU readback path.
+                    published_gpu = true;
+                } else if (front >= 0 && prosper::gpu::gpu_present_active()) {
                     const uint64_t front_va = prosper_vo_buffer_addr(front);
                     auto rit = g_rtt.find(front_va);
                     if (rit != g_rtt.end() && rit->second.gpu_valid && rit->second.w && rit->second.h) {
@@ -4783,6 +4893,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             published_gpu = prosper::frontend::present_blit_publish(
                                 tgt->image, tgt->layout, fmt, rit->second.w, rit->second.h,
                                 gpu_present_seq.fetch_add(1) + 1);
+                            if (published_gpu) last_gpu_publish_flip = current_flip;
                         }
                     }
                 }
@@ -4817,6 +4928,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             scanout ? "HIT" : "MISS", nb);
                 }
             }
+            if (timing_enabled && phase.final_span)
+                pending_timing.output_copy_ms += std::chrono::duration<double, std::milli>(
+                    RenderClock::now() - output_copy_start).count();
             if (phase.final_span) release_pinned_scanouts();
             if (phase.final_span && lightweight_rtt_timing && rtt_log_in_range &&
                 pending_timing.backend_draws >= rtt_timing_min_draws) {
@@ -4871,7 +4985,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     RenderClock::now() - callback_timing_start).count();
                 struct TimingTotals {
                     uint64_t submits = 0, callbacks = 0;
-                    double total_ms = 0, build_resources_ms = 0, backend_ms = 0, output_copy_ms = 0;
+                    double total_ms = 0, prelude_ms = 0, pass_ms = 0;
+                    double build_resources_ms = 0, backend_ms = 0, output_copy_ms = 0;
+                    double dcc_materialize_ms = 0;
+                    uint64_t dcc_materialize_surfaces = 0, dcc_materialize_bytes = 0;
                     uint64_t backend_calls = 0, backend_draws = 0;
                     uint64_t backend_command_buffers = 0, backend_queue_submits = 0;
                     uint64_t backend_fence_waits = 0;
@@ -4903,9 +5020,14 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     timing.submits++;
                     timing.callbacks += pending_timing.callbacks;
                     timing.total_ms += pending_timing.total_ms;
+                    timing.prelude_ms += pending_timing.prelude_ms;
+                    timing.pass_ms += pending_timing.pass_ms;
                     timing.build_resources_ms += pending_timing.build_resources_ms;
                     timing.backend_ms += pending_timing.backend_ms;
                     timing.output_copy_ms += pending_timing.output_copy_ms;
+                    timing.dcc_materialize_ms += pending_timing.dcc_materialize_ms;
+                    timing.dcc_materialize_surfaces += pending_timing.dcc_materialize_surfaces;
+                    timing.dcc_materialize_bytes += pending_timing.dcc_materialize_bytes;
                     timing.backend_calls += pending_timing.backend_calls;
                     timing.backend_draws += pending_timing.backend_draws;
                     timing.backend_command_buffers += pending_timing.backend_command_buffers;
@@ -4959,14 +5081,21 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 accumulate(window);
                 if (totals.submits % 25 == 0) {
                     const double nsub = static_cast<double>(totals.submits);
-                    const double other = totals.total_ms - totals.build_resources_ms - totals.backend_ms -
+                    const double pass_control = totals.pass_ms - totals.build_resources_ms -
+                                                totals.backend_ms;
+                    const double other = totals.total_ms - totals.prelude_ms - totals.pass_ms -
                                          totals.output_copy_ms;
                     fprintf(stderr,
                             "[render-timing] frontend submits=%llu callbacks=%llu avg_ms: total=%.2f "
-                            "build_resources=%.2f backend=%.2f output_copy=%.2f other=%.2f\n",
+                            "prelude=%.2f build_resources=%.2f backend=%.2f pass_control=%.2f "
+                            "output_copy=%.2f other=%.2f dcc=%.2f/%0.2f/%.1fMiB\n",
                             (unsigned long long)totals.submits, (unsigned long long)totals.callbacks,
-                            totals.total_ms / nsub, totals.build_resources_ms / nsub,
-                            totals.backend_ms / nsub, totals.output_copy_ms / nsub, other / nsub);
+                            totals.total_ms / nsub, totals.prelude_ms / nsub,
+                            totals.build_resources_ms / nsub, totals.backend_ms / nsub,
+                            pass_control / nsub, totals.output_copy_ms / nsub, other / nsub,
+                            totals.dcc_materialize_ms / nsub,
+                            static_cast<double>(totals.dcc_materialize_surfaces) / nsub,
+                            totals.dcc_materialize_bytes / (nsub * 1024.0 * 1024.0));
                     const double backend_detail_ms = totals.backend_target_ms +
                         totals.backend_draw_setup_ms + totals.backend_record_upload_ms +
                         totals.backend_gpu_wait_ms + totals.backend_readback_ms +
@@ -5114,17 +5243,24 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             (unsigned long long)write_watch.physical_writes,
                             (unsigned long long)write_watch.rearms);
                     const double wn = static_cast<double>(window.submits);
-                    const double window_other = window.total_ms - window.build_resources_ms -
-                                                window.backend_ms - window.output_copy_ms;
+                    const double window_pass_control = window.pass_ms -
+                        window.build_resources_ms - window.backend_ms;
+                    const double window_other = window.total_ms - window.prelude_ms -
+                        window.pass_ms - window.output_copy_ms;
                     fprintf(stderr,
                             "[render-window] frontend submits=%llu callbacks=%.1f avg_ms: total=%.2f "
-                            "build_resources=%.2f backend=%.2f output_copy=%.2f other=%.2f; "
+                            "prelude=%.2f build_resources=%.2f backend=%.2f pass_control=%.2f "
+                            "output_copy=%.2f other=%.2f dcc=%.2f/%0.2f/%.1fMiB; "
                             "resources textures=%.1f "
                             "reused=%.1f %.1f MiB %.2f ms buffers=%.1f views=%.1f "
                             "logical=%.1f MiB materialized=%.1f MiB %.2f ms\n",
                             (unsigned long long)window.submits, window.callbacks / wn,
-                            window.total_ms / wn, window.build_resources_ms / wn,
-                            window.backend_ms / wn, window.output_copy_ms / wn, window_other / wn,
+                            window.total_ms / wn, window.prelude_ms / wn,
+                            window.build_resources_ms / wn, window.backend_ms / wn,
+                            window_pass_control / wn, window.output_copy_ms / wn, window_other / wn,
+                            window.dcc_materialize_ms / wn,
+                            static_cast<double>(window.dcc_materialize_surfaces) / wn,
+                            window.dcc_materialize_bytes / (wn * 1024.0 * 1024.0),
                             window.textures / wn,
                             window.texture_reuses / wn,
                             window.texture_bytes / (wn * 1024.0 * 1024.0), window.texture_ms / wn,

--- a/prosper/frontends/shared/present_blit_policy.hpp
+++ b/prosper/frontends/shared/present_blit_policy.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+#include <limits>
 #include <vulkan/vulkan.h>
 
 namespace prosper::frontend {
@@ -8,6 +10,17 @@ namespace prosper::frontend {
 // device errors leave the submitted command buffer potentially in flight.
 constexpr bool present_blit_wait_completed(VkResult result) {
     return result == VK_SUCCESS;
+}
+
+// Render submissions build the next display image in several ordered pieces, but VideoOut exposes
+// it only when the guest reaches SetFlip. Publishing every intermediate submission both presents
+// partially assembled frames and needlessly synchronizes the renderer with the window system.
+// UINT64_MAX is the initial sentinel so a title that renders before its first flip still gets one
+// recoverable scanout.
+constexpr bool present_blit_has_new_flip(uint64_t last_published_flip,
+                                         uint64_t current_flip) {
+    return last_published_flip == std::numeric_limits<uint64_t>::max() ||
+           last_published_flip != current_flip;
 }
 
 } // namespace prosper::frontend

--- a/prosper/frontends/shared/rtt_authority.hpp
+++ b/prosper/frontends/shared/rtt_authority.hpp
@@ -31,6 +31,14 @@ constexpr bool live_rtt_compute_authoritative(bool gpu_valid, bool has_cpu_snaps
     return live_rtt_authority(gpu_valid, has_cpu_snapshot) != LiveRttAuthority::none;
 }
 
+// Pixel-inspection and mutation diagnostics operate on the renderer's owned CPU texture copy.
+// Uniform fast-clears normally bypass that copy, but the opt-in diagnostic contract takes
+// precedence so dumps and override probes observe the same pixels as ordinary RTT snapshots.
+constexpr bool live_rtt_uniform_uses_cpu_diagnostic_path(bool has_uniform_color,
+                                                         bool cpu_copy_diagnostics) {
+    return has_uniform_color && cpu_copy_diagnostics;
+}
+
 constexpr bool live_rtt_cpu_snapshot_matches(uint32_t width, uint32_t height,
                                              uint32_t bytes_per_pixel,
                                              size_t snapshot_bytes) {

--- a/prosper/frontends/shared/rtt_injection.hpp
+++ b/prosper/frontends/shared/rtt_injection.hpp
@@ -12,6 +12,23 @@
 
 namespace prosper::frontend {
 
+// Fill an already-sized byte buffer with one repeated native-format pixel. Growing the initialized
+// prefix exponentially keeps the operation to O(log(bytes)) bulk copies instead of one tiny memcpy
+// per texel. Source and destination ranges are disjoint on every iteration.
+inline bool fill_repeating_pixel(std::vector<uint8_t>& destination,
+                                 const uint8_t* pixel, size_t pixel_bytes) {
+    if (!pixel || !pixel_bytes || destination.size() % pixel_bytes) return false;
+    if (destination.empty()) return true;
+    std::memcpy(destination.data(), pixel, pixel_bytes);
+    size_t initialized = pixel_bytes;
+    while (initialized < destination.size()) {
+        const size_t copy = std::min(initialized, destination.size() - initialized);
+        std::memcpy(destination.data() + initialized, destination.data(), copy);
+        initialized += copy;
+    }
+    return true;
+}
+
 // An immutable CPU RTT snapshot can back a FrameResource directly only when the consumer uses the
 // producer's exact extent and byte layout. Scaled views still need their owned nearest-neighbor copy;
 // malformed snapshots stay on the guest-decode fallback.

--- a/prosper/frontends/shared/test_present_blit_policy.cpp
+++ b/prosper/frontends/shared/test_present_blit_policy.cpp
@@ -3,6 +3,7 @@
 #include <cstdio>
 
 using prosper::frontend::present_blit_wait_completed;
+using prosper::frontend::present_blit_has_new_flip;
 
 static int failures = 0;
 #define CHECK(cond) do { if (!(cond)) { \
@@ -14,6 +15,14 @@ int main() {
     // #1303: a timeout or device error must not publish a slot whose blit may still be in flight.
     CHECK(!present_blit_wait_completed(VK_TIMEOUT));
     CHECK(!present_blit_wait_completed(VK_ERROR_DEVICE_LOST));
+
+    // Several graphics submits may build one guest frame. Only the first pre-flip image and a
+    // newly flipped image are publishable; repeated submits at the same flip stay GPU-local.
+    CHECK(present_blit_has_new_flip(UINT64_MAX, 0));
+    CHECK(!present_blit_has_new_flip(0, 0));
+    CHECK(present_blit_has_new_flip(0, 1));
+    CHECK(!present_blit_has_new_flip(42, 42));
+    CHECK(present_blit_has_new_flip(UINT64_MAX, UINT64_MAX));
 
     if (!failures) std::printf("present_blit_policy: OK\n");
     return failures ? 1 : 0;

--- a/prosper/frontends/shared/test_rtt_injection.cpp
+++ b/prosper/frontends/shared/test_rtt_injection.cpp
@@ -6,6 +6,7 @@
 
 using prosper::frontend::inject_rtt_pixels;
 using prosper::frontend::exact_rtt_snapshot_borrowable;
+using prosper::frontend::fill_repeating_pixel;
 using prosper::frontend::RttInjectionCache;
 
 static int failures = 0;
@@ -13,6 +14,26 @@ static int failures = 0;
     std::fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond); ++failures; } } while (0)
 
 int main() {
+    const uint8_t rgba_pixel[] = {0x12, 0x34, 0x56, 0x78};
+    std::vector<uint8_t> repeated_rgba(5 * sizeof(rgba_pixel));
+    CHECK(fill_repeating_pixel(
+        repeated_rgba, rgba_pixel, sizeof(rgba_pixel)));
+    for (size_t i = 0; i < repeated_rgba.size(); ++i)
+        CHECK(repeated_rgba[i] == rgba_pixel[i % sizeof(rgba_pixel)]);
+    const uint8_t fp16_pixel[] = {1, 2, 3, 4, 5, 6, 7, 8};
+    std::vector<uint8_t> repeated_fp16(4096 * sizeof(fp16_pixel));
+    CHECK(fill_repeating_pixel(
+        repeated_fp16, fp16_pixel, sizeof(fp16_pixel)));
+    CHECK(std::equal(repeated_fp16.end() - sizeof(fp16_pixel),
+                     repeated_fp16.end(), fp16_pixel));
+    std::vector<uint8_t> empty;
+    CHECK(fill_repeating_pixel(empty, rgba_pixel, sizeof(rgba_pixel)));
+    std::vector<uint8_t> malformed_repeat(7, 0xcc);
+    CHECK(!fill_repeating_pixel(
+        malformed_repeat, rgba_pixel, sizeof(rgba_pixel)));
+    CHECK(std::all_of(malformed_repeat.begin(), malformed_repeat.end(),
+                      [](uint8_t byte) { return byte == 0xcc; }));
+
     CHECK(exact_rtt_snapshot_borrowable(4, 2, 4, 2, 8, 4 * 2 * 8));
     CHECK(!exact_rtt_snapshot_borrowable(2, 1, 4, 2, 8, 4 * 2 * 8));
     CHECK(!exact_rtt_snapshot_borrowable(4, 2, 4, 2, 8, 4 * 2 * 8 - 1));

--- a/prosper/frontends/shared/test_rtt_scale.cpp
+++ b/prosper/frontends/shared/test_rtt_scale.cpp
@@ -20,6 +20,7 @@ using prosper::frontend::live_rtt_authority;
 using prosper::frontend::live_rtt_compute_authoritative;
 using prosper::frontend::live_rtt_cpu_snapshot_matches;
 using prosper::frontend::live_rtt_gpu_importable;
+using prosper::frontend::live_rtt_uniform_uses_cpu_diagnostic_path;
 using prosper::frontend::LiveRttGuestWriteEffect;
 using prosper::frontend::live_rtt_guest_write_effect;
 using prosper::frontend::live_rtt_compute_mirror_eligible;
@@ -92,6 +93,9 @@ int main() {
     CHECK(live_rtt_compute_authoritative(true, true));
     CHECK(live_rtt_compute_authoritative(false, true));
     CHECK(!live_rtt_compute_authoritative(false, false));
+    CHECK(live_rtt_uniform_uses_cpu_diagnostic_path(true, true));
+    CHECK(!live_rtt_uniform_uses_cpu_diagnostic_path(true, false));
+    CHECK(!live_rtt_uniform_uses_cpu_diagnostic_path(false, true));
     CHECK(live_rtt_cpu_snapshot_matches(1920, 1080, 8, 1920ull * 1080 * 8));
     CHECK(!live_rtt_cpu_snapshot_matches(1920, 1080, 8, 1920ull * 1080 * 4));
     CHECK(!live_rtt_cpu_snapshot_matches(0, 1080, 8, 0));

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -102,6 +102,11 @@ struct FrameResource {
     // Optional immutable owner for borrowed frontend pixels. Keeping this beside the raw pointer
     // makes FrameResource copies/moves retain the source through synchronous backend upload setup.
     std::shared_ptr<const std::vector<uint8_t>> tex_rgba_owner;
+    // A DCC fast-clear is already a complete image description. Keep it compact until command
+    // recording and initialize the full-size Vulkan image with vkCmdClearColorImage instead of
+    // allocating, filling, and uploading tens of MiB of identical CPU pixels.
+    bool has_uniform_color = false;
+    std::array<float, 4> uniform_color{};
     uint32_t tw = 0, th = 0, td = 1;
     // T#-declared mip-chain length (#1272). 1 (default) = single-level upload, the historical
     // behavior. >1 lets the backend generate a box-filtered chain — bounded by this declared count —
@@ -170,7 +175,7 @@ struct FrameResource {
         return dwords_view && dwords_view_count ? dwords_view_count : dwords.size();
     }
     bool is_texture() const {
-        return tex_rgba != nullptr || persistent_render_target_id != 0 ||
+        return tex_rgba != nullptr || has_uniform_color || persistent_render_target_id != 0 ||
                persistent_depth_target_id != 0 || borrowed_compute_image != nullptr;
     }
 };
@@ -3336,12 +3341,14 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         uint32_t mip_levels = 1;   // effective uploaded chain length (#1272)
         VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
         bool storage_image = false;
+        std::array<uint32_t, 4> uniform_color_bits{};
         bool operator==(const TextureUploadKey& other) const {
             return pixels == other.pixels && render_target_id == other.render_target_id &&
                    borrowed_compute_image == other.borrowed_compute_image &&
                    width == other.width && height == other.height && depth == other.depth &&
                    img_dim == other.img_dim && mip_levels == other.mip_levels &&
-                   format == other.format && storage_image == other.storage_image;
+                   format == other.format && storage_image == other.storage_image &&
+                   uniform_color_bits == other.uniform_color_bits;
         }
     };
     struct TextureUploadKeyHash {
@@ -3357,6 +3364,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
             h ^= static_cast<size_t>(key.mip_levels) + 0x9e3779b9u + (h << 6) + (h >> 2);
             h ^= static_cast<size_t>(key.format) + 0x9e3779b9u + (h << 6) + (h >> 2);
             h ^= static_cast<size_t>(key.storage_image) + 0x9e3779b9u + (h << 6) + (h >> 2);
+            for (uint32_t bits : key.uniform_color_bits)
+                h ^= static_cast<size_t>(bits) + 0x9e3779b9u + (h << 6) + (h >> 2);
             return h;
         }
     };
@@ -3371,6 +3380,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         VkDeviceSize image_bytes = 0;
         bool persistent_hit = false;
         bool persistent_refresh = false;
+        bool uniform_clear = false;
+        VkClearColorValue uniform_color{};
         bool borrowed_target = false;
         bool borrowed_compute = false;
         VkImageLayout borrowed_compute_layout = VK_IMAGE_LAYOUT_UNDEFINED;
@@ -4029,13 +4040,19 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                     }
                     // A DS-bridged resource shares the id slot: both are guest plane addresses, and
                     // pixels stays null for either direct bind, so distinct surfaces cannot collide.
+                    std::array<uint32_t, 4> uniform_color_bits{};
+                    if (r.has_uniform_color)
+                        for (size_t channel = 0; channel < uniform_color_bits.size(); ++channel)
+                            std::memcpy(&uniform_color_bits[channel], &r.uniform_color[channel],
+                                        sizeof(uint32_t));
                     const TextureUploadKey texture_key{
                         r.tex_rgba,
                         r.persistent_render_target_id ? r.persistent_render_target_id
                                                       : r.persistent_depth_target_id,
                         r.borrowed_compute_image,
                         r.tw, r.th, r.td, r.img_dim,
-                        tex_mip_levels, backend_color_format(r.texture_format), r.is_storage_image};
+                        tex_mip_levels, backend_color_format(r.texture_format), r.is_storage_image,
+                        uniform_color_bits};
                     size_t upload_index = SIZE_MAX;
                     if (share_texture_uploads) {
                         auto found = texture_upload_indices.find(texture_key);
@@ -4206,46 +4223,52 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                             // copy site). A CPU box filter here was the first implementation and
                             // collapsed titles that re-upload large mip-eligible textures per frame
                             // (Evergate's title froze the publish rate — snapshot-gate catch).
-                            const VkDeviceSize tbytes =
-                                static_cast<VkDeviceSize>(r.tw) * r.th * r.td *
-                                backend_color_bytes_per_pixel(r.texture_format);
-                            VkBufferCreateInfo stci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
-                            stci.size = tbytes;
-                            stci.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT |
-                                (r.is_storage_image
-                                     ? VK_BUFFER_USAGE_TRANSFER_DST_BIT : 0u);
-                            vkCreateBuffer(dev, &stci, nullptr, &upload.staging);
-                            VkMemoryRequirements sr;
-                            vkGetBufferMemoryRequirements(dev, upload.staging, &sr);
-                            VkMemoryAllocateInfo sai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO};
-                            sai.allocationSize = sr.size;
-                            sai.memoryTypeIndex = pick(sr.memoryTypeBits,
-                                                       VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
-                                                       VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-                            upload.staging_memory = allocate_transient_render_memory(
-                                dev, sai.allocationSize, sai.memoryTypeIndex);
-                            vkBindBufferMemory(dev, upload.staging, upload.staging_memory, 0);
-                            void* sp = nullptr;
-                            vkMapMemory(dev, upload.staging_memory, 0, tbytes, 0, &sp);
-                            if (r.tex_rgba) {
-                                std::memcpy(sp, r.tex_rgba, static_cast<size_t>(tbytes));
+                            if (r.has_uniform_color) {
+                                upload.uniform_clear = true;
+                                std::copy(r.uniform_color.begin(), r.uniform_color.end(),
+                                          upload.uniform_color.float32);
                             } else {
-                                // Only a declined/missed depth-plane borrow reaches the creation
-                                // path with no CPU pixels (#1275: the bridge deliberately carries
-                                // none — e.g. the consumer samples its own bound DS attachment, or
-                                // the plane was invalidated between the frontend gate and this
-                                // lookup). Bind well-defined zeros — the value the guest-byte
-                                // decode of an unwritten depth address produced — and say so.
-                                std::memset(sp, 0, static_cast<size_t>(tbytes));
-                                static int declined_logged = 0;
-                                if (declined_logged++ < 16)
-                                    fprintf(stderr,
-                                            "[dsbridge] borrow declined/missed for 0x%llx %ux%u -> "
-                                            "zero texture\n",
-                                            (unsigned long long)r.persistent_depth_target_id,
-                                            r.tw, r.th);
+                                const VkDeviceSize tbytes =
+                                    static_cast<VkDeviceSize>(r.tw) * r.th * r.td *
+                                    backend_color_bytes_per_pixel(r.texture_format);
+                                VkBufferCreateInfo stci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
+                                stci.size = tbytes;
+                                stci.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT |
+                                    (r.is_storage_image
+                                         ? VK_BUFFER_USAGE_TRANSFER_DST_BIT : 0u);
+                                vkCreateBuffer(dev, &stci, nullptr, &upload.staging);
+                                VkMemoryRequirements sr;
+                                vkGetBufferMemoryRequirements(dev, upload.staging, &sr);
+                                VkMemoryAllocateInfo sai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO};
+                                sai.allocationSize = sr.size;
+                                sai.memoryTypeIndex = pick(sr.memoryTypeBits,
+                                                           VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
+                                                           VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+                                upload.staging_memory = allocate_transient_render_memory(
+                                    dev, sai.allocationSize, sai.memoryTypeIndex);
+                                vkBindBufferMemory(dev, upload.staging, upload.staging_memory, 0);
+                                void* sp = nullptr;
+                                vkMapMemory(dev, upload.staging_memory, 0, tbytes, 0, &sp);
+                                if (r.tex_rgba) {
+                                    std::memcpy(sp, r.tex_rgba, static_cast<size_t>(tbytes));
+                                } else {
+                                    // Only a declined/missed depth-plane borrow reaches the creation
+                                    // path with no CPU pixels (#1275: the bridge deliberately carries
+                                    // none — e.g. the consumer samples its own bound DS attachment, or
+                                    // the plane was invalidated between the frontend gate and this
+                                    // lookup). Bind well-defined zeros — the value the guest-byte
+                                    // decode of an unwritten depth address produced — and say so.
+                                    std::memset(sp, 0, static_cast<size_t>(tbytes));
+                                    static int declined_logged = 0;
+                                    if (declined_logged++ < 16)
+                                        fprintf(stderr,
+                                                "[dsbridge] borrow declined/missed for 0x%llx %ux%u -> "
+                                                "zero texture\n",
+                                                (unsigned long long)r.persistent_depth_target_id,
+                                                r.tw, r.th);
+                                }
+                                vkUnmapMemory(dev, upload.staging_memory);
                             }
-                            vkUnmapMemory(dev, upload.staging_memory);
                         }
                     }
                     if (r.is_storage_image && r.storage_image_writeback &&
@@ -4885,7 +4908,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     texture_stats.persistent_hits = persistent_texture_hits;
     texture_stats.persistent_misses = persistent_texture_misses;
     for (const auto& upload : texture_uploads) {
-        if (!upload.staging) continue;
+        if (!upload.staging && !upload.uniform_clear) continue;
         ++texture_stats.unique_uploads;
         texture_stats.upload_bytes += static_cast<uint64_t>(upload.key.width) * upload.key.height *
                                       upload.key.depth * backend_color_bytes_per_pixel(upload.key.format);
@@ -5045,7 +5068,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     // Upload each distinct texture once. Draw descriptors may use separate views/samplers over the
     // same image, preserving per-binding swizzle and sampler state without duplicating pixel storage.
     for (const auto& upload : texture_uploads) {
-        if (!upload.staging) continue;  // exact-validated persistent image already has shader-read layout
+        if (!upload.staging && !upload.uniform_clear)
+            continue;  // exact-validated persistent image already has shader-read layout
         VkImageMemoryBarrier b0{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
         b0.oldLayout = upload.persistent_refresh
             ? VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL : VK_IMAGE_LAYOUT_UNDEFINED;
@@ -5060,15 +5084,22 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                 ? (VK_PIPELINE_STAGE_VERTEX_SHADER_BIT | VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT)
                 : VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
             VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr, 1, &b0);
-        VkBufferImageCopy tc{}; tc.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
-        tc.imageExtent = {upload.key.width, upload.key.height, upload.key.depth};
-        vkCmdCopyBufferToImage(cmd, upload.staging, upload.image,
-                               VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &tc);
+        if (upload.uniform_clear) {
+            const VkImageSubresourceRange range{
+                VK_IMAGE_ASPECT_COLOR_BIT, 0, upload.key.mip_levels, 0, 1};
+            vkCmdClearColorImage(cmd, upload.image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                                 &upload.uniform_color, 1, &range);
+        } else {
+            VkBufferImageCopy tc{}; tc.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+            tc.imageExtent = {upload.key.width, upload.key.height, upload.key.depth};
+            vkCmdCopyBufferToImage(cmd, upload.staging, upload.image,
+                                   VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &tc);
+        }
         // #1272: generate levels 1..N-1 with a linear-filtered blit cascade (GPU-side, once per
         // upload — a CPU box filter here collapsed titles that re-upload large textures per frame).
         // Each source level transitions DST->SRC before feeding the next; the final barrier below
         // then flips the whole chain to shader-read. RGBA8 linear-blit support is mandatory Vulkan.
-        for (uint32_t l = 1; l < upload.key.mip_levels; l++) {
+        for (uint32_t l = 1; !upload.uniform_clear && l < upload.key.mip_levels; l++) {
             VkImageMemoryBarrier bs{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
             bs.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
             bs.newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
@@ -5091,7 +5122,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                            upload.image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &blit,
                            VK_FILTER_LINEAR);
         }
-        if (upload.key.mip_levels > 1) {
+        if (!upload.uniform_clear && upload.key.mip_levels > 1) {
             // Levels 0..N-2 sit in TRANSFER_SRC after feeding the cascade; return them to
             // TRANSFER_DST so the single final-layout barrier below covers the whole chain.
             VkImageMemoryBarrier br{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};

--- a/prosper/tests/test_texture_sample_render.cpp
+++ b/prosper/tests/test_texture_sample_render.cpp
@@ -136,6 +136,34 @@ int main() {
               "R32_UINT storage images retain their typed four-byte Vulkan format");
     }
 
+    // A uniform DCC clear reaches the sampled image without a full CPU-sized pixel allocation or
+    // staging upload. Keep the declared extent larger than one texel so this also covers arbitrary
+    // normalized coordinates over the full image.
+    {
+        std::vector<uint32_t> ps(ps_template,
+                                 ps_template + sizeof(ps_template) / sizeof(ps_template[0]));
+        ps[1] = C075; ps[3] = C075;
+        std::vector<uint32_t> frag = recompile_fragment(ps.data(), ps.size(), &rt);
+        prosper::test::FrameResource resource;
+        resource.binding = 4; resource.set = 1;
+        resource.has_uniform_color = true;
+        resource.uniform_color = {0.25f, 0.5f, 0.75f, 1.0f};
+        resource.tw = 64; resource.th = 32;
+        prosper::test::BackendDraw draw;
+        draw.vs = vert; draw.fs = frag; draw.R = {resource}; draw.vcount = 3;
+        const std::vector<uint8_t> pixels =
+            prosper::test::render_draws_rgba({draw}, W, H);
+        const uint8_t* center = pixels.size() == static_cast<size_t>(W) * H * 4
+            ? &pixels[(static_cast<size_t>(H / 2) * W + W / 2) * 4] : nullptr;
+        CHECK(center && center[0] >= 63 && center[0] <= 65 &&
+                         center[1] >= 127 && center[1] <= 129 &&
+                         center[2] >= 190 && center[2] <= 192,
+              "uniform texture is initialized by a GPU clear and samples the requested color");
+        const auto stats = prosper::test::backend_texture_upload_stats();
+        CHECK(stats.unique_uploads == 1 && stats.upload_bytes == 64u * 32u * 4u,
+              "uniform GPU clear is accounted without CPU pixel backing");
+    }
+
     // The live renderer commonly submits hundreds of draws that reference the same few decoded
     // textures. The backend must upload identical pixels once per call while preserving the legacy
     // rendered bytes and separate per-descriptor views/samplers.


### PR DESCRIPTION
## Summary

- retain uniform DCC fast-clears as compact color metadata instead of materializing full CPU images
- initialize sampled Vulkan images with GPU clears and preserve lazy CPU fallback for compute, DMA, captures, resolves, and scanout
- publish completed GPU scanouts only when the guest advances SetFlip, avoiding intermediate partial-frame publication
- skip an inapplicable Vulkan image-format query on sampled/raw compute descriptors
- extend render timing so frontend, DCC, backend, and publication costs can be separated

## Astro Bot result

On the 3840x2160 intro workload, each graphics callback previously allocated, filled, and uploaded roughly 40–46 MiB of identical clear pixels.

- DCC frontend work: ~7–8.5 ms -> ~0.03–0.04 ms per graphics submission
- whole graphics frontend: ~16–18 ms -> ~3–4 ms per graphics submission after warm-up
- guest flips: ~7 fps -> ~12 fps in comparable bounded runs

This is a real rendering-path optimization: resolution, draw count, and guest timing are unchanged. Compute dispatch synchronization is now the largest measured per-frame cost, so the FMV remains below real time.

## Verification

- complete build in distrobox `ps5ys`
- focused renderer tests: `rtt_injection`, `present_blit_policy`, `texture_sample_render`, `shadow_compare_render`, `shared_vulkan_device`, and `present_blit`
- new end-to-end Vulkan test samples a 64x32 uniform image initialized by `vkCmdClearColorImage` and verifies its exact color
- repeated bounded Astro Bot runs on the host with the visible Vulkan frontend
- direct 3840x2160 frontend screenshot captured from the optimized run

Snapshot tests were intentionally not run: this is a development PR, not a release, and project policy makes snapshots optional during development and mandatory before releases.

Refs #841