### PR TITLE
perf(compute): keep Astro Bot FMV volumes on GPU

### DIFF
--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -168,6 +168,7 @@ bool direct_sampled_rtt_compatible(prosper::gpu::DataFormat format, uint32_t com
 namespace {
 
 std::atomic<uint64_t> g_buffer_gpu_result_skips{0};
+std::atomic<uint64_t> g_compute_storage_transfer_seeds{0};
 std::atomic<bool> g_fail_next_storage_readback_for_test{false};
 
 VkFormat native_storage_vk_format(prosper::gpu::DataFormat format, uint32_t components) {
@@ -198,17 +199,22 @@ VkFormat native_storage_vk_format(prosper::gpu::DataFormat format, uint32_t comp
 }
 
 bool native_storage_image_create_supported(VkPhysicalDevice physical, VkFormat format,
-                                           uint32_t width, uint32_t height,
+                                           VkImageType image_type, uint32_t width,
+                                           uint32_t height, uint32_t depth,
+                                           uint32_t array_layers,
                                            VkImageUsageFlags extra_usage = 0) {
-    if (!physical || format == VK_FORMAT_UNDEFINED || !width || !height) return false;
+    if (!physical || format == VK_FORMAT_UNDEFINED || !width || !height || !depth ||
+        !array_layers)
+        return false;
     const VkImageUsageFlags usage = VK_IMAGE_USAGE_STORAGE_BIT |
         VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | extra_usage;
     VkImageFormatProperties properties{};
     return vkGetPhysicalDeviceImageFormatProperties(
-               physical, format, VK_IMAGE_TYPE_2D, VK_IMAGE_TILING_OPTIMAL,
+               physical, format, image_type, VK_IMAGE_TILING_OPTIMAL,
                usage, 0, &properties) == VK_SUCCESS &&
            width <= properties.maxExtent.width && height <= properties.maxExtent.height &&
-           properties.maxExtent.depth >= 1 && properties.maxArrayLayers >= 1;
+           depth <= properties.maxExtent.depth &&
+           array_layers <= properties.maxArrayLayers;
 }
 
 // Storage images use an RGBA32_UINT interchange surface so format conversion remains bit-exact on
@@ -686,6 +692,8 @@ struct CachedComputeImage {
     // dispatch can leave the old guest mirror valid while making the Vulkan result unknowable.
     prosper::gpu::GuestGpuWriteSnapshot graphics_export_snapshot;
     bool graphics_export_valid = false;
+    prosper::gpu::GuestGpuWriteSnapshot compute_transfer_snapshot;
+    bool compute_transfer_valid = false;
     std::vector<uint8_t> source_snapshot;
     // Exact row-major bytes produced by the last storage dispatch. Full-overwrite post-processes
     // commonly reproduce the same large target on successive frames. Retaining the result lets a
@@ -821,6 +829,12 @@ size_t compute_write_watch_promotion_budget_bytes() {
 bool adaptive_storage_result_validation_enabled() {
     static const bool enabled =
         std::getenv("PROSPER_NO_ADAPTIVE_STORAGE_RESULT_VALIDATION") == nullptr;
+    return enabled;
+}
+
+bool native_3d_transfer_enabled() {
+    static const bool enabled =
+        std::getenv("PROSPER_NO_NATIVE_3D_COMPUTE_TRANSFER") == nullptr;
     return enabled;
 }
 
@@ -1559,13 +1573,16 @@ struct VulkanComputeContext {
             // submit leaves this false, so the next use refreshes instead of skipping stale pixels.
             cached.content_valid = false;
             cached.graphics_export_valid = false;
+            cached.compute_transfer_valid = false;
         }
         return true;
     }
 
     void invalidate_cached_image_export(const ComputeImageCacheKey& key) {
         const auto found = image_cache.find(key);
-        if (found != image_cache.end()) found->second.graphics_export_valid = false;
+        if (found == image_cache.end()) return;
+        found->second.graphics_export_valid = false;
+        found->second.compute_transfer_valid = false;
     }
 
     void authorize_cached_image_export(const ComputeImageCacheKey& key) {
@@ -1574,6 +1591,14 @@ struct VulkanComputeContext {
             return;
         found->second.graphics_export_snapshot = prosper::gpu::guest_gpu_write_snapshot();
         found->second.graphics_export_valid = true;
+    }
+
+    void authorize_cached_image_compute_transfer(const ComputeImageCacheKey& key) {
+        const auto found = image_cache.find(key);
+        if (found == image_cache.end() || !found->second.content_valid || !found->second.image)
+            return;
+        found->second.compute_transfer_snapshot = prosper::gpu::guest_gpu_write_snapshot();
+        found->second.compute_transfer_valid = true;
     }
 
     bool borrow_cached_image_for_graphics(const ComputeImageCacheKey& key,
@@ -1589,6 +1614,43 @@ struct VulkanComputeContext {
         const bool watch_unchanged = !submit_unchanged && cached.write_watch &&
             cached.write_watch.query() == prosper::host::GuestWriteWatchQuery::Unchanged;
         if (!submit_unchanged && !watch_unchanged) return false;
+        cached.last_use = ++image_cache_clock;
+        ++cached.pins;
+        image = cached.image;
+        return true;
+    }
+
+    bool borrow_cached_image_for_compute_transfer(const ComputeImageCacheKey& key,
+                                                  VkImage& image, bool trace = false) {
+        const auto found = image_cache.find(key);
+        if (found == image_cache.end()) {
+            if (trace) std::fprintf(stderr, "[compute]   native 3D transfer miss: no storage cache\n");
+            return false;
+        }
+        CachedComputeImage& cached = found->second;
+        if (!cached.compute_transfer_valid || !cached.content_valid || !cached.image) {
+            if (trace)
+                std::fprintf(stderr,
+                             "[compute]   native 3D transfer miss: export=%u content=%u image=%u\n",
+                             cached.compute_transfer_valid ? 1u : 0u,
+                             cached.content_valid ? 1u : 0u, cached.image ? 1u : 0u);
+            return false;
+        }
+        const prosper::gpu::GuestGpuWriteQuery submit_query =
+            prosper::gpu::guest_gpu_writes_since(cached.compute_transfer_snapshot,
+                                                  key.gpu_addr, key.guest_bytes);
+        const bool submit_unchanged =
+            submit_query == prosper::gpu::GuestGpuWriteQuery::Unchanged;
+        const bool watch_unchanged = !submit_unchanged && cached.write_watch &&
+            cached.write_watch.query() == prosper::host::GuestWriteWatchQuery::Unchanged;
+        if (!submit_unchanged && !watch_unchanged) {
+            if (trace)
+                std::fprintf(stderr,
+                             "[compute]   native 3D transfer miss: submit-query=%u watch=%u\n",
+                             static_cast<unsigned>(submit_query),
+                             cached.write_watch ? 1u : 0u);
+            return false;
+        }
         cached.last_use = ++image_cache_clock;
         ++cached.pins;
         image = cached.image;
@@ -1626,6 +1688,7 @@ struct VulkanComputeContext {
         CachedComputeImage& cached = found->second;
         cached.content_valid = false;
         cached.graphics_export_valid = false;
+        cached.compute_transfer_valid = false;
         cached.write_watch.reset();
         if (!cached.source_snapshot.empty())
             std::vector<uint8_t>().swap(cached.source_snapshot);
@@ -1636,10 +1699,24 @@ struct VulkanComputeContext {
         cached.validation_result = false;
     }
 
+    void validate_cached_image_source_from_compute_transfer(
+        const ComputeImageCacheKey& key) {
+        const auto found = image_cache.find(key);
+        if (found == image_cache.end()) return;
+        CachedComputeImage& cached = found->second;
+        cached.content_valid = true;
+        cached.validation_snapshot = prosper::gpu::guest_gpu_write_snapshot();
+        cached.write_watch_stable_validations = 0;
+        cached.write_watch.reset();
+        if (!cached.source_snapshot.empty())
+            std::vector<uint8_t>().swap(cached.source_snapshot);
+    }
+
     void validate_cached_image_source(const ComputeImageCacheKey& key,
                                       const uint8_t* current_source = nullptr,
                                       bool result_unchanged = false,
-                                      bool source_snapshot_required = true) {
+                                      bool source_snapshot_required = true,
+                                      bool compute_transfer_watch = false) {
         auto found = image_cache.find(key);
         if (found == image_cache.end()) return;
         CachedComputeImage& cached = found->second;
@@ -1683,7 +1760,15 @@ struct VulkanComputeContext {
         // queries walk one record per host page and were slower than memcmp for Plucky's stable
         // post-process targets. A repeated result keeps one collision-free baseline; an identical
         // GPU skip never reaches this function, so that baseline is not recopied.
-        cached.write_watch.reset();
+        if (compute_transfer_watch) {
+            if (cached.write_watch && !cached.write_watch.rearm())
+                cached.write_watch.reset();
+            if (!cached.write_watch)
+                cached.write_watch = prosper::host::GuestWriteWatch::create(
+                    key.gpu_addr, key.guest_bytes);
+        } else {
+            cached.write_watch.reset();
+        }
         if (!source_was_valid) {
             // A failed dispatch/readback may have advanced the retained GPU result while leaving
             // guest memory at the old baseline. The successful repair must replace that invalidated
@@ -2045,6 +2130,12 @@ struct BoundImage {
     size_t compare_flag_index = SIZE_MAX;
     bool gpu_result_unchanged = false;
     ComputeImageCacheKey cache_key{};
+    // A prior native storage result can seed the sampled cache with a device-local copy. It remains
+    // a distinct image because a dispatch may sample the old guest value while writing a new value
+    // to the same address; binding one VkImage for both would introduce an in-dispatch data race.
+    VkImage compute_transfer_seed = VK_NULL_HANDLE;
+    ComputeImageCacheKey compute_transfer_seed_key{};
+    bool compute_transfer_seed_borrowed = false;
     std::vector<uint8_t> cache_source_snapshot; // first-use source captured before the transfer
     bool seed_skip = false;             // #1122: write-only full-coverage storage image; no seed needed
     bool poison_verify = false;         // #1122: proving frame -- seed poison, prove full coverage
@@ -2768,6 +2859,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             if (images[i].alias_of != SIZE_MAX) continue;
             if (images[i].sampler) vkDestroySampler(ctx.device, images[i].sampler, nullptr);
             if (images[i].view) vkDestroyImageView(ctx.device, images[i].view, nullptr);
+            if (images[i].compute_transfer_seed_borrowed)
+                ctx.release_cached_image(images[i].compute_transfer_seed_key);
             if (images[i].persistent) {
                 // A failed submit/readback can leave the retained VkImage and its exact-result
                 // baseline newer than guest memory. Force the retry to upload and publish again;
@@ -3047,14 +3140,21 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 r->format == DataFormat::Float10_11_11 && descriptor_components == 3;
             const bool ordinary_2d_storage = r->img_dim == 1 && r->depth == 1 &&
                                              !r->depth_compare;
+            const bool ordinary_3d_storage = r->img_dim == 2 && r->depth &&
+                                             !r->depth_compare;
+            const VkImageType native_storage_type = ordinary_3d_storage
+                ? VK_IMAGE_TYPE_3D : VK_IMAGE_TYPE_2D;
             // vkGetPhysicalDeviceImageFormatProperties is a driver query, not a cheap metadata
             // lookup. Sampled and raw-uvec4 descriptors cannot take this typed-storage path, so do
             // not repeat that query for every one of their per-frame bindings.
             const bool native_storage_supported = spirv_native_storage &&
                 native_float_storage_image_supported(
                     r->format, descriptor_components, r->srgb,
-                    ordinary_2d_storage && native_storage_image_create_supported(
-                        ctx.physical, native_storage_format, r->width, r->height));
+                    (ordinary_2d_storage || ordinary_3d_storage) &&
+                        native_storage_image_create_supported(
+                            ctx.physical, native_storage_format, native_storage_type,
+                            r->width, r->height,
+                            ordinary_3d_storage ? r->depth : 1u, 1u));
             if (spirv_native_storage && !native_storage_supported) {
                 skip_image(r, "compiled typed storage format is unsupported by this device");
                 break;
@@ -3063,9 +3163,10 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             // if this replay device supports the optional typed format, while a live module is only
             // emitted as float after the frontend's physical-device feature query.
             bi.native_float_storage = spirv_native_storage;
-            bi.graphics_sampled_usage = bi.native_float_storage &&
+            bi.graphics_sampled_usage = bi.native_float_storage && ordinary_2d_storage &&
                 native_storage_image_create_supported(
-                    ctx.physical, native_storage_format, r->width, r->height,
+                    ctx.physical, native_storage_format, VK_IMAGE_TYPE_2D,
+                    r->width, r->height, 1u, 1u,
                     VK_IMAGE_USAGE_SAMPLED_BIT);
             if (trace)
                 std::fprintf(stderr,
@@ -3609,12 +3710,14 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             // R32 image to RGBA32F every dispatch. Three-channel optimal images are not universally
             // supported, so retain the portable four-channel expansion for that uncommon case.
             const bool sampled_float32_native = sampled_float32 && sampled_components != 3;
-            // Imported renderer-owned RGBA16F is already the exact native sampled representation.
-            // Guest-backed FP16 retains the historical RGBA8 conversion: native RG16F sampling is
-            // exact, but was measured 7x slower in Astro Bot's full-resolution composite on RADV.
-            const bool sampled_float16_native = !bi.storage && bi.imported &&
-                                                r->format == DataFormat::Float16 &&
-                                                sampled_components == 4;
+            // Renderer imports and compute 3D RGBA16F textures can use their exact native sampled
+            // representation. Narrowing a volume to RGBA8 discarded its HDR range and prevented a
+            // retained native storage result from seeding the next ping-pong sample on the GPU.
+            // Ordinary guest-backed 2D FP16 keeps its historical RGBA8 conversion: native RGBA16F
+            // sampling was measured 7x slower in Astro Bot's full-resolution composite on RADV.
+            const bool sampled_float16_native = !bi.storage &&
+                r->format == DataFormat::Float16 && sampled_components == 4 &&
+                (bi.imported || dim_3d);
             const bool sampled_unorm8x2 = !bi.storage && r->format == DataFormat::Unorm8 &&
                                           sampled_components == 2;
             const bool sampled_unorm16_native = !bi.storage && r->format == DataFormat::Unorm16 &&
@@ -3854,9 +3957,36 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         r->mip_tail_x, r->mip_tail_y,
                         static_cast<uint32_t>(image_format), bi.storage, r->in_mip_tail,
                         r->srgb, r->depth_compare};
+                    // A native typed 3D storage result is byte- and format-identical to the sampled
+                    // upload that follows it. Borrow that retained result only as a TRANSFER source:
+                    // the sampled cache remains a separate image so a read/modify/write dispatch can
+                    // sample the old volume while producing its replacement at the same guest address.
+                    const VkFormat native_format =
+                        native_storage_vk_format(r->format, sampled_components);
+                    if (dim_3d && !r->host_data && native_format == image_format &&
+                        adaptive_storage_result_validation_enabled() &&
+                        native_3d_transfer_enabled()) {
+                        const ComputeImageCacheKey storage_key = storage_image_cache_key(
+                            *r, static_cast<uint32_t>(sampled_guest_need), native_format);
+                        if (ctx.borrow_cached_image_for_compute_transfer(
+                                storage_key, bi.compute_transfer_seed, trace)) {
+                            bi.compute_transfer_seed_key = storage_key;
+                            bi.compute_transfer_seed_borrowed = true;
+                            g_compute_storage_transfer_seeds.fetch_add(
+                                1, std::memory_order_relaxed);
+                            if (trace)
+                                std::fprintf(stderr,
+                                             "[compute]   sampled 3D binding=%u addr=0x%llx "
+                                             "seeded from retained native storage image\n",
+                                             bi.binding,
+                                             (unsigned long long)r->gpu_addr);
+                        }
+                    }
                     bi.persistent = ctx.acquire_cached_image(
-                        bi.cache_key, sampled_guest_source, image_validation_epoch,
-                        bi.image, bi.memory, bi.upload_skipped);
+                        bi.cache_key,
+                        bi.compute_transfer_seed_borrowed ? nullptr : sampled_guest_source,
+                        image_validation_epoch, bi.image, bi.memory, bi.upload_skipped,
+                        !bi.compute_transfer_seed_borrowed);
                     if (bi.persistent && bi.upload_skipped)
                         g_sampled_image_upload_skips.fetch_add(1, std::memory_order_relaxed);
                     if (trace && bi.persistent)
@@ -3865,7 +3995,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                      "addr=0x%llx guest=%zu upload-skipped=%u\n",
                                      bi.binding, (unsigned long long)r->gpu_addr,
                                      sampled_guest_need, bi.upload_skipped ? 1u : 0u);
-                    if (!bi.persistent)
+                    if (!bi.persistent && !bi.compute_transfer_seed_borrowed)
                         bi.cache_source_snapshot.assign(
                             sampled_guest_source,
                             sampled_guest_source + sampled_guest_need);
@@ -3877,11 +4007,14 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             // here -- an extra 132 MiB CPU pass for Astro Bot's 4K RGBA32 storage representation.
             ScopedMappedMemory upload_mapping(ctx);
             const size_t upload_size = (bi.imported || bi.seed_skip ||
-                                        bi.seed_from_imported != SIZE_MAX)
+                                        bi.seed_from_imported != SIZE_MAX ||
+                                        bi.compute_transfer_seed_borrowed)
                 ? size_t{0} : (size_t)sbytes;
             // A retained storage image still needs a fresh destination for its post-dispatch
             // transfer. Only a read-only sampled cache hit can omit staging altogether.
-            if (!bi.imported && (bi.storage || !(bi.persistent && bi.upload_skipped))) {
+            if (!bi.imported &&
+                (bi.storage || (!bi.compute_transfer_seed_borrowed &&
+                                !(bi.persistent && bi.upload_skipped)))) {
                 VkBufferCreateInfo sci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
                 sci.size = sbytes;
                 sci.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT |
@@ -3900,6 +4033,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 }
                 upload_mapping.memory = staging_memory[i];
                 if (!bi.seed_skip && bi.seed_from_imported == SIZE_MAX &&
+                    !bi.compute_transfer_seed_borrowed &&
                     !(bi.persistent && bi.upload_skipped) &&
                     !vk_ok(ctx.map_memory(staging_memory[i], 0, sbytes,
                                           &upload_mapping.data), "image-staging-map")) {
@@ -4295,7 +4429,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 } else {
                     const size_t need = sampled_guest_need;
                     const uint8_t* src = sampled_guest_source;
-                    if (!bi.upload_skipped && bpb) {                 // BCn: (block-detile ->) decode
+                    const bool needs_sampled_upload = !bi.upload_skipped &&
+                        !bi.compute_transfer_seed_borrowed;
+                    if (needs_sampled_upload && bpb) {               // BCn: (block-detile ->) decode
                         const uint32_t bw = (r->width + 3) / 4, bh = (r->height + 3) / 4;
                         const size_t linear_slice = static_cast<size_t>(bw) * bh * bpb;
                         const uint32_t layers = sampled_layers;
@@ -4350,7 +4486,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                             }
                         }
                         if (!images_ready) break;
-                    } else if (!bi.upload_skipped) {
+                    } else if (needs_sampled_upload) {
                         const uint32_t bpt = r11g11b10 ? 4u : cb * nc;
                         const size_t linear_bytes = static_cast<size_t>(volume_texels) * bpt;
                         std::unique_ptr<uint8_t[]> linear;
@@ -4441,7 +4577,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                             sampled_unorm8x2 || sampled_unorm16_native ||
                             sampled_uint8_native || sampled_uint16_native ||
                             sampled_uint32_native || sampled_float32_native ||
-                            sampled_depth) {                            // Native sampled texels
+                            sampled_float16_native || sampled_depth) {  // Native sampled texels
                             std::memcpy(upload, sampled_source, linear_bytes);
                         } else if (f32) {                           // Native float channels + default fill
                             parallel_compute_texels(texels, linear_bytes + texels * 16u,
@@ -4941,6 +5077,69 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                      1, &to_general);
                 continue;
             }
+            if (bi.compute_transfer_seed_borrowed) {
+                VkImageMemoryBarrier source_to_copy{
+                    VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
+                source_to_copy.srcAccessMask = VK_ACCESS_SHADER_READ_BIT |
+                    VK_ACCESS_SHADER_WRITE_BIT | VK_ACCESS_TRANSFER_READ_BIT |
+                    VK_ACCESS_TRANSFER_WRITE_BIT;
+                source_to_copy.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+                source_to_copy.oldLayout = VK_IMAGE_LAYOUT_GENERAL;
+                source_to_copy.newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+                source_to_copy.srcQueueFamilyIndex = source_to_copy.dstQueueFamilyIndex =
+                    VK_QUEUE_FAMILY_IGNORED;
+                source_to_copy.image = bi.compute_transfer_seed;
+                source_to_copy.subresourceRange = {
+                    VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, bi.array_layers};
+                vkCmdPipelineBarrier(command, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+                                     VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0,
+                                     nullptr, 1, &source_to_copy);
+
+                VkImageMemoryBarrier target_to_copy{
+                    VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
+                target_to_copy.srcAccessMask = bi.persistent
+                    ? VK_ACCESS_SHADER_READ_BIT : 0u;
+                target_to_copy.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+                target_to_copy.oldLayout = bi.persistent
+                    ? VK_IMAGE_LAYOUT_GENERAL : VK_IMAGE_LAYOUT_UNDEFINED;
+                target_to_copy.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+                target_to_copy.srcQueueFamilyIndex = target_to_copy.dstQueueFamilyIndex =
+                    VK_QUEUE_FAMILY_IGNORED;
+                target_to_copy.image = bi.image;
+                target_to_copy.subresourceRange = {
+                    VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, bi.array_layers};
+                vkCmdPipelineBarrier(command,
+                                     bi.persistent ? VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT
+                                                   : VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                                     VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0,
+                                     nullptr, 1, &target_to_copy);
+
+                VkImageCopy copy{};
+                copy.srcSubresource = {
+                    VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, bi.array_layers};
+                copy.dstSubresource = copy.srcSubresource;
+                copy.extent = {r->width,
+                               bi.stacked_cube ? r->height * 6u : r->height,
+                               bi.array_layers > 1 ? 1u : bi.texel_depth};
+                vkCmdCopyImage(command, bi.compute_transfer_seed,
+                               VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                               bi.image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copy);
+
+                VkImageMemoryBarrier ready[2]{source_to_copy, target_to_copy};
+                ready[0].srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+                ready[0].dstAccessMask = VK_ACCESS_SHADER_READ_BIT |
+                                         VK_ACCESS_SHADER_WRITE_BIT;
+                ready[0].oldLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+                ready[0].newLayout = VK_IMAGE_LAYOUT_GENERAL;
+                ready[1].srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+                ready[1].dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+                ready[1].oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+                ready[1].newLayout = VK_IMAGE_LAYOUT_GENERAL;
+                vkCmdPipelineBarrier(command, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                                     VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, 0, 0, nullptr,
+                                     0, nullptr, 2, ready);
+                continue;
+            }
             if (bi.seed_from_imported != SIZE_MAX) {
                 const BoundImage& source = images[bi.seed_from_imported];
                 VkImageMemoryBarrier source_to_copy{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
@@ -5303,8 +5502,13 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 });
             if (replaced_by_storage) continue;
             if (image.persistent) {
-                if (!image.upload_skipped)
-                    ctx.validate_cached_image_source(image.cache_key);
+                if (!image.upload_skipped) {
+                    if (image.compute_transfer_seed_borrowed)
+                        ctx.validate_cached_image_source_from_compute_transfer(
+                            image.cache_key);
+                    else
+                        ctx.validate_cached_image_source(image.cache_key);
+                }
             } else if (image.image && image.memory && image.allocation_bytes &&
                        ctx.retain_image(image.cache_key, image.image, image.memory,
                                         image.allocation_bytes,
@@ -5726,7 +5930,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     // target needs no source snapshot; the first repeated result retains one exact
                     // baseline, and subsequent identical GPU skips do not recopy it.
                     ctx.validate_cached_image_source(
-                        bi.cache_key, destination, bi.gpu_result_unchanged, !bi.seed_skip);
+                        bi.cache_key, destination, bi.gpu_result_unchanged, !bi.seed_skip,
+                        bi.seed_skip && bi.native_float_storage && r->img_dim == 2 &&
+                            native_3d_transfer_enabled());
                 } else if (bi.image && bi.memory && bi.allocation_bytes &&
                            ctx.retain_image(bi.cache_key, bi.image, bi.memory,
                                             bi.allocation_bytes, destination)) {
@@ -5764,12 +5970,15 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         if (!readback_ok) break;
         const auto writeback_publish_start = ComputeClock::now();
         // Every storage image is back in GENERAL, all exact guest writebacks/notifications have
-        // completed, and a failed dispatch cannot reach here. Publish only retained native results;
-        // raw interchange images are never descriptor-compatible with a graphics sampled view.
+        // completed, and a failed dispatch cannot reach here. Native results may seed a later
+        // sampled cache with a device-local copy; only 2D images created with SAMPLED usage may also
+        // be exported directly to graphics. Raw interchange images are compatible with neither.
         for (const BoundImage& image : images) {
-            if (image.storage && image.native_float_storage && image.graphics_sampled_usage &&
-                image.alias_of == SIZE_MAX &&
-                image.cache_candidate && image.persistent)
+            if (!image.storage || !image.native_float_storage ||
+                image.alias_of != SIZE_MAX || !image.cache_candidate || !image.persistent)
+                continue;
+            ctx.authorize_cached_image_compute_transfer(image.cache_key);
+            if (image.graphics_sampled_usage)
                 ctx.authorize_cached_image_export(image.cache_key);
         }
         writeback_publish_ms = std::chrono::duration<double, std::milli>(
@@ -5906,6 +6115,22 @@ uint64_t live_compute_buffer_gpu_result_skips() {
 
 uint64_t live_compute_sampled_image_upload_skips() {
     return g_sampled_image_upload_skips.load(std::memory_order_relaxed);
+}
+
+uint64_t live_compute_storage_transfer_seeds() {
+    return g_compute_storage_transfer_seeds.load(std::memory_order_relaxed);
+}
+
+bool live_compute_native_storage_3d_supported(prosper::gpu::DataFormat format,
+                                              uint32_t components,
+                                              uint32_t width, uint32_t height,
+                                              uint32_t depth) {
+    VulkanComputeContext* context = g_live_compute_context;
+    if (!context || !context->physical) return false;
+    const VkFormat native_format = native_storage_vk_format(format, components);
+    return native_storage_image_create_supported(
+        context->physical, native_format, VK_IMAGE_TYPE_3D,
+        width, height, depth, 1u);
 }
 
 uint64_t live_compute_cpu_fill_dispatches() {
@@ -6087,13 +6312,15 @@ bool execute_live_compute_items(const std::vector<prosper::gpu::ComputeItem>& it
                          (unsigned long long)pool.discarded);
             std::fprintf(stderr,
                          "[render-timing] compute_image_source snapshots=%llu %.1f MiB "
-                         "storage_results=%llu %.1f MiB\n",
+                         "storage_results=%llu %.1f MiB gpu_transfer_seeds=%llu\n",
                          (unsigned long long)context.image_source_snapshot_copies,
                          static_cast<double>(context.image_source_snapshot_bytes) /
                              (1024.0 * 1024.0),
                          (unsigned long long)context.storage_result_snapshot_copies,
                          static_cast<double>(context.storage_result_snapshot_bytes) /
-                             (1024.0 * 1024.0));
+                             (1024.0 * 1024.0),
+                         (unsigned long long)g_compute_storage_transfer_seeds.load(
+                             std::memory_order_relaxed));
             std::fprintf(stderr,
                          "[render-window] compute calls=%llu dispatches=%.1f avg_ms=%.2f\n",
                          (unsigned long long)window.calls,

--- a/prosper/frontends/shared/live_compute.hpp
+++ b/prosper/frontends/shared/live_compute.hpp
@@ -113,6 +113,15 @@ uint64_t live_compute_buffer_gpu_result_skips();
 // Monotonic diagnostic count of retained sampled-image hits whose validated source omitted upload.
 // Capture/replay tests use this to prove residency without relying on timing-sensitive assertions.
 uint64_t live_compute_sampled_image_upload_skips();
+// Monotonic count of sampled 3D images seeded from an exact retained native storage result with a
+// device-local image copy instead of a guest-memory conversion/upload.
+uint64_t live_compute_storage_transfer_seeds();
+// Query the initialized live backend for the exact typed 3D storage+transfer image contract. Tests
+// use this to exercise native-volume execution only on devices that can create the Vulkan image.
+bool live_compute_native_storage_3d_supported(prosper::gpu::DataFormat format,
+                                              uint32_t components,
+                                              uint32_t width, uint32_t height,
+                                              uint32_t depth);
 // Monotonic count of exact compute fills executed by the structurally guarded CPU path. Tests use
 // the delta to distinguish the intended bypass from a successful Vulkan fallback.
 uint64_t live_compute_cpu_fill_dispatches();

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -926,7 +926,6 @@ bool validate_compute_recompile_state(const GpuCapturedCompute& compute,
         return true;
     }
     const ComputeShaderConfig& config = compute.recompile_config;
-    constexpr uint32_t kNativeStorageFormatMask = (1u << 10) - 1u;
     const bool subgroup_valid = config.native_subgroup_size == 0 ||
         config.native_subgroup_size == 32 || config.native_subgroup_size == 64;
     if ((compute.required_subgroup_size != 0 && compute.required_subgroup_size != 32 &&
@@ -944,7 +943,7 @@ bool validate_compute_recompile_state(const GpuCapturedCompute& compute,
         config.tidig_comp_cnt > 3 || config.lds_bytes > 65536 ||
         (config.lds_bytes & 511u) ||
         config.native_subgroup_size != compute.required_subgroup_size ||
-        (config.native_storage_format_support & ~kNativeStorageFormatMask)) {
+        (config.native_storage_format_support & ~kNativeStorageFormatSupportMask)) {
         error = "invalid compute recompile state";
         return false;
     }

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -638,8 +638,9 @@ struct SharedVulkanContext {
     uint32_t max_compute_workgroup_subgroups = 0;
     uint32_t max_compute_workgroup_size_x = 0;
     uint32_t max_compute_workgroup_invocations = 0;
-    // Vulkan-independent mask from native_storage_format_support_bit(). The renderer queries
-    // optimal-tiling STORAGE_IMAGE support before publishing its physical device.
+    // Vulkan-independent mask from native_storage_format_support_bit() and its 3D counterpart. The
+    // renderer queries dimension-specific optimal-tiling STORAGE_IMAGE support before publishing
+    // its physical device.
     uint32_t native_storage_format_support = 0;
     bool compute_queue_supported = false;
     // Present unification (#1270): when present_capable, prosper-app may create its window surface on

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -8571,6 +8571,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // image+sampler). Other opcodes / NSA / gradient / compare variants are rejected (deferred).
             if (!allow_smem || !rt) { ok = false; return true; }
             const uint32_t SQ_DIM_2D = 1u;
+            const uint32_t SQ_DIM_3D = 2u;
             auto vread = [&](int r){ auto it = rs.vreg.find(r); return it == rs.vreg.end() ? b.uconst(0) : it->second; };
 
             // IMAGE_BVH_INTERSECT_RAY (GFX10 opcode 0xe6) has an image encoding but consumes a
@@ -8841,10 +8842,16 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 }
                 const bool ordinary_2d = res->img_dim == 1 && res->depth == 1 &&
                                          !res->depth_compare;
-                const bool native_float = ordinary_2d && native_float_storage_image_supported(
-                    res->format, components, res->srgb,
-                    (b.native_storage_format_support &
-                     native_storage_format_support_bit(res->format, components)) != 0);
+                const bool ordinary_3d = in.mimg_dim == SQ_DIM_3D && res->img_dim == 2 &&
+                                         res->depth && !arrayed && !ms &&
+                                         !res->depth_compare;
+                const uint32_t native_support_bit = ordinary_3d
+                    ? native_storage_3d_format_support_bit(res->format, components)
+                    : native_storage_format_support_bit(res->format, components);
+                const bool native_float = (ordinary_2d || ordinary_3d) &&
+                    native_float_storage_image_supported(
+                        res->format, components, res->srgb,
+                        (b.native_storage_format_support & native_support_bit) != 0);
                 const bool packed_r11 = !native_float && b.packed_r11_storage && ordinary_2d &&
                     !arrayed && !ms && !is_atomic &&
                     res->format == DataFormat::Float10_11_11 && components == 3;

--- a/prosper/src/gpu/shader_resources.hpp
+++ b/prosper/src/gpu/shader_resources.hpp
@@ -114,6 +114,16 @@ constexpr uint32_t native_storage_format_support_bit(DataFormat format, uint32_t
     return 0;
 }
 
+// 3D optimal images have a dimension-specific Vulkan support query. Keep their capabilities in
+// the upper half of the same replay-stable mask so a device that supports typed 2D storage but not
+// the corresponding 3D image never compiles a shader the live backend cannot bind.
+constexpr uint32_t native_storage_3d_format_support_bit(DataFormat format,
+                                                        uint32_t components) {
+    return native_storage_format_support_bit(format, components) << 10;
+}
+
+constexpr uint32_t kNativeStorageFormatSupportMask = (1u << 20) - 1u;
+
 // IEEE-754 binary16 -> binary32 (handles subnormals, +/-inf, NaN). Used by the texture upload path to
 // convert a sampled Float16 surface to the RGBA8 the backend uploads (#290). Pure + testable.
 float half_to_float(uint16_t h);

--- a/prosper/src/host/guest_write_watch.cpp
+++ b/prosper/src/host/guest_write_watch.cpp
@@ -500,11 +500,6 @@ struct AtomicStats {
 AtomicStats& stats() { static AtomicStats* value = new AtomicStats; return *value; }
 inline void bump(std::atomic<uint64_t>& c) { c.fetch_add(1, std::memory_order_relaxed); }
 
-const AliasRange* alias_at(const WatchState& w, uint64_t addr) {
-    for (const AliasRange& a : w.aliases)
-        if (addr >= a.addr && addr < a.addr + a.size) return &a;
-    return nullptr;
-}
 // Does any recorded alias overlap [begin, end)? O(alias ranges). Lets the notify hooks skip the O(watched
 // pages) purge on the common path: a fresh VA (no reuse) or a non-dmem munmap (every guest heap free).
 bool va_range_has_alias(const WatchState& w, uint64_t begin, uint64_t end) {
@@ -512,17 +507,6 @@ bool va_range_has_alias(const WatchState& w, uint64_t begin, uint64_t end) {
         if (a.addr < end && a.addr + a.size > begin) return true;
     return false;
 }
-// All guest VAs currently mapping `phys` (page-granular). Returns false (leaving `out` empty) if the
-// page is unmapped or any alias is inaccessible (PROT_NONE) -> caller falls back to Unknown.
-bool collect_aliases(const WatchState& w, uint64_t phys, std::vector<PageAlias>& out) {
-    for (const AliasRange& a : w.aliases) {
-        if (phys < a.phys || phys + kPage > a.phys + a.size) continue;
-        if (a.prot == 0) return false;                    // PROT_NONE alias: cannot safely protect
-        out.push_back({a.addr + (phys - a.phys), a.prot});
-    }
-    return !out.empty();
-}
-
 struct ProtectionRun {
     uint64_t addr = 0;
     uint64_t size = 0;
@@ -693,17 +677,75 @@ GuestWriteWatch GuestWriteWatch::create(uint64_t addr, uint64_t size) {
     }
     std::lock_guard lock(w.mutex);
 
-    // First pass: resolve every guest page to a physical page whose full alias set is known. Any gap
-    // (non-dmem heap, PROT_NONE alias, unmapped) aborts to Unknown WITHOUT touching protections.
-    struct Resolved { uint64_t phys; std::vector<PageAlias> aliases; };
+    // Resolve the watched VA pages and every physical alias in linear passes over the mapping table.
+    // The old implementation called alias_at() and collect_aliases() for every 4 KiB page; registering
+    // a 16 MiB video volume therefore rescanned the complete guest mapping table about eight thousand
+    // times. Astro Bot could spend longer creating that watch than rendering the whole intro.
+    //
+    // Any gap (non-dmem heap, PROT_NONE alias, or partial physical alias) still aborts to Unknown
+    // before changing protections. Keep one Resolved entry per watched VA page so duplicate aliases
+    // preserve the existing registration/reference-count contract.
+    struct Resolved { uint64_t phys; };
     std::vector<Resolved> resolved;
+    resolved.reserve(static_cast<size_t>(watch_bytes / kPage));
+
+    std::vector<const AliasRange*> va_aliases;
+    for (const AliasRange& alias : w.aliases) {
+        if (alias.addr < end && alias.addr + alias.size > begin)
+            va_aliases.push_back(&alias);
+    }
+    std::sort(va_aliases.begin(), va_aliases.end(),
+              [](const AliasRange* a, const AliasRange* b) {
+                  return a->addr < b->addr;
+              });
+    size_t va_alias_index = 0;
     for (uint64_t va = begin; va < end; va += kPage) {
-        const AliasRange* a = alias_at(w, va);
-        if (!a) { bump(stats().create_no_mapping); return {}; }
-        const uint64_t phys = a->phys + (va - a->addr);
-        std::vector<PageAlias> al;
-        if (!collect_aliases(w, phys, al)) { bump(stats().create_incomplete_aliases); return {}; }
-        resolved.push_back({phys, std::move(al)});
+        while (va_alias_index < va_aliases.size() &&
+               va_aliases[va_alias_index]->addr + va_aliases[va_alias_index]->size <= va)
+            ++va_alias_index;
+        if (va_alias_index == va_aliases.size() ||
+            va < va_aliases[va_alias_index]->addr) {
+            bump(stats().create_no_mapping);
+            return {};
+        }
+        const AliasRange& alias = *va_aliases[va_alias_index];
+        resolved.push_back({alias.phys + (va - alias.addr)});
+    }
+
+    std::vector<uint64_t> watched_phys;
+    watched_phys.reserve(resolved.size());
+    for (const Resolved& page : resolved) watched_phys.push_back(page.phys);
+    std::sort(watched_phys.begin(), watched_phys.end());
+    watched_phys.erase(std::unique(watched_phys.begin(), watched_phys.end()),
+                       watched_phys.end());
+
+    struct PhysicalAliases {
+        std::vector<PageAlias> aliases;
+        bool inaccessible = false;
+    };
+    std::unordered_map<uint64_t, PhysicalAliases> aliases_by_phys;
+    aliases_by_phys.reserve(watched_phys.size());
+    for (const AliasRange& alias : w.aliases) {
+        const uint64_t alias_phys_end = alias.phys + alias.size;
+        auto physical = std::lower_bound(watched_phys.begin(), watched_phys.end(), alias.phys);
+        while (physical != watched_phys.end() && *physical < alias_phys_end) {
+            const uint64_t page_phys = *physical++;
+            if (page_phys > UINT64_MAX - kPage || page_phys + kPage > alias_phys_end)
+                continue;
+            PhysicalAliases& set = aliases_by_phys[page_phys];
+            if (alias.prot == 0)
+                set.inaccessible = true;
+            else
+                set.aliases.push_back({alias.addr + (page_phys - alias.phys), alias.prot});
+        }
+    }
+    for (uint64_t phys : watched_phys) {
+        const auto found = aliases_by_phys.find(phys);
+        if (found == aliases_by_phys.end() || found->second.inaccessible ||
+            found->second.aliases.empty()) {
+            bump(stats().create_incomplete_aliases);
+            return {};
+        }
     }
 
     // Second pass: get-or-create the WatchedPage per phys, arm newly-referenced pages, build the reg.
@@ -717,7 +759,8 @@ GuestWriteWatch GuestWriteWatch::create(uint64_t addr, uint64_t size) {
         WatchedPage* page;
         if (it == w.pages_by_phys.end()) {
             auto up = std::make_unique<WatchedPage>();
-            up->phys = r.phys; up->aliases = std::move(r.aliases);
+            up->phys = r.phys;
+            up->aliases = std::move(aliases_by_phys[r.phys].aliases);
             page = up.get();
             w.pages_by_phys.emplace(r.phys, std::move(up));
             for (const PageAlias& al : page->aliases) w.pages_by_addr[al.addr & ~(kPage - 1)] = page;
@@ -824,8 +867,8 @@ void guest_write_watch_notify_direct_mapping_added(uint64_t addr, uint64_t size,
     const uint64_t begin = addr & ~(kPage - 1);
     const uint64_t end = (addr + size + kPage - 1) & ~(kPage - 1);
     // VA-reuse safety: only if this VA range still carries stale coverage (rare: a MAP_FIXED reuse of a VA
-    // never unmapped) do we purge it and its topology before recording the new alias, so alias_at() can't
-    // resolve to the old phys. The common fresh-VA path skips the O(watched pages) scan.
+    // never unmapped) do we purge it and its topology before recording the new alias, so a later watch
+    // cannot resolve to the old phys. The common fresh-VA path skips the O(watched pages) scan.
     if (va_range_has_alias(w, begin, end)) purge_va_range_locked(w, begin, end, /*remove_topology=*/true);
     w.aliases.push_back({addr, size, phys, protection});
 

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -870,6 +870,11 @@ inline const RenderVkCtx& render_vk_ctx() {
                         usage, 0, &properties) == VK_SUCCESS)
                     shared.native_storage_format_support |=
                         prosper::gpu::native_storage_format_support_bit(format, components);
+                if (vkGetPhysicalDeviceImageFormatProperties(
+                        r.phys, vk_format, VK_IMAGE_TYPE_3D, VK_IMAGE_TILING_OPTIMAL,
+                        usage, 0, &properties) == VK_SUCCESS)
+                    shared.native_storage_format_support |=
+                        prosper::gpu::native_storage_3d_format_support_bit(format, components);
             };
             add_native_storage_format(prosper::gpu::DataFormat::Unorm8, 1, VK_FORMAT_R8_UNORM);
             add_native_storage_format(prosper::gpu::DataFormat::Unorm8, 2, VK_FORMAT_R8G8_UNORM);

--- a/prosper/tests/test_game_compute.cpp
+++ b/prosper/tests/test_game_compute.cpp
@@ -2652,6 +2652,125 @@ int main() {
                       raw_repair_notifications == 1,
                   "external raw 3D mirror change forces exact writeback and invalidation");
         }
+
+        // The same 3D FP16 resource can stay at its exact eight-byte native width when the device
+        // advertises dimension-specific support. This is Astro Bot's 240x135x64 ping-pong shape;
+        // reflection must select float storage rather than the sixteen-byte raw-uvec4 interchange.
+        ComputeShaderConfig native_3d_config = raw_config;
+        native_3d_config.native_storage_format_support =
+            native_storage_3d_format_support_bit(DataFormat::Float16, 4);
+        const std::vector<uint32_t> native_3d_spirv = recompile_compute(
+            fill_3d, std::size(fill_3d), &raw_rt, native_3d_config);
+        CHECK(!native_3d_spirv.empty(), "native typed 3D fill kernel recompiles");
+        if (!native_3d_spirv.empty()) {
+            const DescriptorValidationReport native_3d_report =
+                validate_spirv_descriptor_interface(
+                    native_3d_spirv, &raw_rt, 0, SpirvShaderStage::Compute, false);
+            const SpirvDescriptorBinding* native_3d_binding =
+                find_spirv_descriptor_binding(native_3d_report, 0, raw_dst.binding);
+            CHECK(native_3d_report.ok() && native_3d_binding &&
+                      native_3d_binding->kind == SpirvDescriptorKind::StorageImage &&
+                      native_3d_binding->storage_float && native_3d_binding->image_dim == 2,
+                  "dimension-capable FP16 volume reflects exact float 3D storage");
+
+#if defined(__linux__)
+            const bool native_3d_runtime_supported =
+                prosper::frontend::live_compute_native_storage_3d_supported(
+                    DataFormat::Float16, 4, RW, RH, RD);
+#else
+            constexpr bool native_3d_runtime_supported = false;
+#endif
+            if (native_3d_runtime_supported &&
+                adaptive_storage_result_validation_enabled) {
+#if defined(__linux__)
+                prosper::host::guest_write_watch_notify_host_write(
+                    reinterpret_cast<uint64_t>(raw_guest), raw_guest_bytes);
+#endif
+                std::fill_n(raw_guest, raw_guest_bytes, 0x3a);
+                ComputeItem native_3d_item;
+                native_3d_item.spirv = native_3d_spirv;
+                native_3d_item.resources = std::make_shared<ShaderResourceTable>(raw_rt);
+                native_3d_item.launch.threads_x = RW;
+                native_3d_item.launch.threads_y = RH;
+                native_3d_item.launch.threads_z = RD;
+                native_3d_item.launch.local_x = RW;
+                native_3d_item.launch.local_y = RH;
+                native_3d_item.launch.local_z = RD;
+                native_3d_item.launch.groups_x = native_3d_item.launch.groups_y =
+                    native_3d_item.launch.groups_z = 1;
+                native_3d_item.code_addr = 0x1122f14du;
+                CHECK(prosper::frontend::execute_live_compute_items({native_3d_item}),
+                      "native typed 3D fill executes at exact guest width");
+                const std::vector<uint8_t> native_3d_expected(
+                    raw_guest, raw_guest + raw_guest_bytes);
+                CHECK(std::any_of(native_3d_expected.begin(), native_3d_expected.end(),
+                                  [](uint8_t byte) { return byte != 0x3a; }),
+                      "native typed 3D fill overwrites its guest volume");
+                CHECK(prosper::frontend::execute_live_compute_items({native_3d_item}) &&
+                          std::equal(raw_guest, raw_guest + raw_guest_bytes,
+                                     native_3d_expected.begin()),
+                      "retained native 3D result is byte-exact across repeated dispatches");
+#if defined(__linux__)
+                // The first successful dispatch proves full coverage and the second retains the
+                // image. Force one exact repair so the retained result establishes the cross-submit
+                // page watch that authorizes the following device-local sampled copy.
+                raw_guest[0] ^= 0x5a;
+                CHECK(prosper::frontend::execute_live_compute_items({native_3d_item}) &&
+                          std::equal(raw_guest, raw_guest + raw_guest_bytes,
+                                     native_3d_expected.begin()),
+                      "native 3D result repairs an external mirror write before transfer");
+#endif
+
+                static const uint32_t sampled_copy_3d[] = {
+                    0x7E080300u,             // v4 = v0 (x)
+                    0x7E0A0301u,             // v5 = v1 (y)
+                    0x7E0C0302u,             // v6 = v2 (z)
+                    0xF0000F10u, 0x00000004u,// IMAGE_LOAD v0..v3 at (v4,v5,v6), dim:3D
+                    0xBF8C3F70u,             // s_waitcnt vmcnt(0)
+                    0xF0200F10u, 0x00020004u,// IMAGE_STORE to a distinct 3D destination
+                    0xBF810000u,
+                };
+                std::vector<uint8_t> native_copy_guest(raw_guest_bytes, 0x71);
+                ShaderResourceTable native_copy_rt;
+                ShaderResource native_copy_src = raw_dst;
+                native_copy_src.cls = ResourceClass::Texture;
+                native_copy_src.binding = 4;
+                native_copy_src.sgpr_base = 0;
+                native_copy_rt.resources.push_back(native_copy_src);
+                ShaderResource native_copy_dst = raw_dst;
+                native_copy_dst.gpu_addr =
+                    reinterpret_cast<uint64_t>(native_copy_guest.data());
+                native_copy_rt.resources.push_back(native_copy_dst);
+                const std::vector<uint32_t> native_copy_spirv = recompile_compute(
+                    sampled_copy_3d, std::size(sampled_copy_3d),
+                    &native_copy_rt, native_3d_config);
+                CHECK(!native_copy_spirv.empty(),
+                      "sampled-to-storage native 3D copy kernel recompiles");
+                if (!native_copy_spirv.empty()) {
+                    ComputeItem native_copy_item = native_3d_item;
+                    native_copy_item.spirv = native_copy_spirv;
+                    native_copy_item.resources =
+                        std::make_shared<ShaderResourceTable>(native_copy_rt);
+                    native_copy_item.code_addr = 0x1122f15du;
+                    const uint64_t transfer_seeds_before =
+                        prosper::frontend::live_compute_storage_transfer_seeds();
+                    CHECK(prosper::frontend::execute_live_compute_items({native_copy_item}),
+                          "sampled 3D consumer executes from retained native storage output");
+                    CHECK(prosper::frontend::live_compute_storage_transfer_seeds() >
+                              transfer_seeds_before,
+                          "sampled 3D consumer seeds on-GPU without a guest upload");
+                    std::vector<uint8_t> native_source_linear(RW * RH * RD * 8u);
+                    std::vector<uint8_t> native_copy_linear(native_source_linear.size());
+                    CHECK(detile_volume(native_source_linear.data(), raw_guest,
+                                        raw_guest_bytes, RW, RH, RD, raw_mode, 8) &&
+                              detile_volume(native_copy_linear.data(),
+                                            native_copy_guest.data(), raw_guest_bytes,
+                                            RW, RH, RD, raw_mode, 8) &&
+                              native_copy_linear == native_source_linear,
+                          "device-local native 3D seed preserves every logical FP16 voxel");
+                }
+            }
+        }
 #if defined(__linux__)
         prosper::host::guest_write_watch_notify_direct_mapping_removed(
             reinterpret_cast<uint64_t>(raw_guest), raw_guest_bytes);

--- a/prosper/tests/test_shader_resources.cpp
+++ b/prosper/tests/test_shader_resources.cpp
@@ -285,10 +285,15 @@ int main() {
         native_storage_format_support_bit(DataFormat::Unorm8, 2);
     const uint32_t packed_storage =
         native_storage_format_support_bit(DataFormat::Float10_11_11, 3);
-    CHECK(r8_storage && rg8_storage && packed_storage && r8_storage != rg8_storage &&
+    const uint32_t fp16_3d_storage =
+        native_storage_3d_format_support_bit(DataFormat::Float16, 4);
+    CHECK(r8_storage && rg8_storage && packed_storage && fp16_3d_storage &&
+              r8_storage != rg8_storage &&
               rg8_storage != packed_storage &&
+              !(fp16_3d_storage & ((1u << 10) - 1u)) &&
+              !(fp16_3d_storage & ~kNativeStorageFormatSupportMask) &&
               native_storage_format_support_bit(DataFormat::Float16, 3) == 0,
-          "native storage capability bits distinguish exact typed VkFormat candidates");
+          "native storage capability bits distinguish exact typed VkFormat and dimension candidates");
 
     uint8_t rgba10[4] = {};
     unorm2_10_10_10_to_rgba8(0xFFFFFFFFu, rgba10);


### PR DESCRIPTION
## Summary

- compile ordinary 3D typed-storage kernels against dimension-specific Vulkan capabilities
- keep Astro Bot's 240x135x64 RGBA16F FMV volumes at their native 8-byte texel width
- seed sampled ping-pong volumes from retained storage images with a device-local copy
- make large guest write-watch registration linear in pages plus mapping ranges

## Why

Astro Bot's FMV compute chain repeatedly writes and samples two 240x135x64 RGBA16F volumes. The old path expanded storage to a 16-byte raw interchange format, read it back, detiled it on the CPU, narrowed the next sampled upload to RGBA8, and uploaded it again. That moved tens of gigabytes through CPU snapshots during a short intro run.

The new path uses native typed 3D storage where the device advertises it, preserves exact RGBA16F sampling, and copies a retained storage result into the distinct sampled image on the GPU. The images remain distinct because one dispatch may read the old value while writing the replacement at the same guest address.

The first implementation also exposed the old O(pages x mapping-ranges) write-watch registration cost and a missing CPU-upload bypass after a GPU seed. Both are fixed and covered by the production-backend test.

## Astro Bot A/B

Same machine, build, route, 60-second bounded run; the control sets `PROSPER_NO_NATIVE_3D_COMPUTE_TRANSFER=1`.

| Metric | Control | GPU bridge | Change |
| --- | ---: | ---: | ---: |
| completed FMV volume frames (`0x500543700`) | 653 | 690 | +5.7% |
| main volume pass | 6.211 ms | 3.271 ms | -47.3% |
| companion volume pass (`0x500546800`) | 3.140 ms | 1.005 ms | -68.0% |
| CPU image-source snapshot traffic | 43.8 GiB | 13.6 GiB | -69.0% |

The intro is still far below the end goal, but this removes a large repeated CPU round trip without render skipping or resolution changes.

## Visual checkpoint

The clean run reaches the visible Sony intro with no checkerboard regression:

![Astro Bot Sony Interactive Entertainment intro](https://gist.githubusercontent.com/mattias800/1ce04fa1d9069992439af92cd5ce360d/raw/7c26ceeff518b4ac1eacefb9b14ab95b1ada6432/astrobot-fmv-image-bridge.png)

## Validation

- full distrobox build: `cmake --build build-astrobot-fmv -j 12`
- 11/11 targeted tests passed:
  - `shader_recompile_cache`
  - `guest_write_watch`
  - `shader_resource_contract`
  - `gpu_capture_roundtrip`
  - `gpu_replay_shader_dump`
  - `compute_exec_differential`
  - `game_compute_exec`
  - `game_compute_exec_no_adaptive_storage_result`
  - `texture_sample_render`
  - `storage_image_copy`
  - `shared_vulkan_device`
- clean bounded Astro Bot run exited through its 60-second timeout with no validation errors

Snapshot tests were not run for this development PR; repository policy makes them optional before PRs and mandatory before releases.

Related: #1459
