### PR TITLE
perf(renderer): cache graphics 2D-array base slices

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -1472,6 +1472,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             }
                             return false;
                         }();
+                        const uint64_t sampled_source_addr = texture_decode_source_address(
+                            r.gpu_addr, r.img_dim, r.in_mip_tail,
+                            r.layer_mip_offset_bytes);
+                        const bool sampled_2d_view = r.img_dim == 1u || r.img_dim == 5u;
                         const TextureDecodeKey decode_key{
                             r.gpu_addr, static_cast<uint64_t>(reinterpret_cast<uintptr_t>(r.host_data)),
                             r.host_data_size, r.size, static_cast<uint32_t>(r.cls),
@@ -1496,7 +1500,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             r.in_mip_tail,
                             avplayer_chroma_layout,
                         };
-                        auto live_rtt = rtt_on ? g_rtt.find(r.gpu_addr) : g_rtt.end();
+                        auto live_rtt = rtt_on ? g_rtt.find(sampled_source_addr) : g_rtt.end();
                         static const uint32_t render_scale = [] {
                             const char* e = std::getenv("PROSPER_RENDER_SCALE");
                             const long v = e ? std::strtol(e, nullptr, 10) : 1;
@@ -1516,9 +1520,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                     normalized_sampling);
                             const bool direct_serves = !fr.is_storage_image && r.img_dim == 1u &&
                                 sampled_extent_compatible &&
-                                r.gpu_addr != draw.color0_base &&
+                                sampled_source_addr != draw.color0_base &&
                                 prosper::test::find_persistent_color_target(
-                                    r.gpu_addr, surface.w, surface.h, surface.format) != nullptr;
+                                    sampled_source_addr, surface.w, surface.h,
+                                    surface.format) != nullptr;
                             const VkFormat surface_format =
                                 prosper::test::backend_color_format(surface.format);
                             const uint32_t surface_bpp =
@@ -1532,7 +1537,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 std::vector<uint8_t> materialized;
                                 std::string error;
                                 if (prosper::test::readback_persistent_color_target(
-                                        r.gpu_addr, surface.w, surface.h, surface_format,
+                                        sampled_source_addr, surface.w, surface.h, surface_format,
                                         materialized, error) &&
                                     materialized.size() == surface_texels * surface_bpp) {
                                     surface.rgba = std::make_shared<const std::vector<uint8_t>>(
@@ -1543,7 +1548,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                         fprintf(stderr,
                                                 "[rtt] lazy sampled target readback failed: "
                                                 "base=0x%llx extent=%ux%u error=%s\n",
-                                                (unsigned long long)r.gpu_addr, surface.w,
+                                                (unsigned long long)sampled_source_addr, surface.w,
                                                 surface.h, error.c_str());
                                 }
                             }
@@ -1567,7 +1572,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 cpu_rtt_copy_diagnostics);
                         if (uniform_cpu_diagnostic_path)
                             materialize_uniform_rtt(live_rtt->second);
-                        const bool has_cpu_live_rtt = !fr.is_storage_image && r.img_dim == 1u &&
+                        const bool has_cpu_live_rtt = !fr.is_storage_image && sampled_2d_view &&
+                            !r.in_mip_tail &&
                             live_rtt != g_rtt.end() &&
                             live_rtt->second.w && live_rtt->second.h && live_rtt->second.rgba &&
                             prosper::frontend::live_rtt_cpu_snapshot_matches(
@@ -1595,21 +1601,28 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             prosper::frontend::rtt_sampled_extent_compatible(
                                 tw, th, live_rtt->second.w, live_rtt->second.h, render_scale,
                                 normalized_sampling) &&
-                            r.gpu_addr != draw.color0_base &&
+                            sampled_source_addr != draw.color0_base &&
                             prosper::test::find_persistent_color_target(
-                                r.gpu_addr, live_rtt->second.w, live_rtt->second.h,
+                                sampled_source_addr, live_rtt->second.w, live_rtt->second.h,
                                 live_rtt->second.format) != nullptr;
                         const bool has_uniform_live_rtt = !fr.is_storage_image &&
-                            !uniform_cpu_diagnostic_path && r.img_dim == 1u &&
+                            !uniform_cpu_diagnostic_path && sampled_2d_view &&
                             !r.in_mip_tail && live_rtt != g_rtt.end() &&
                             live_rtt->second.has_uniform_color && live_rtt->second.w &&
                             live_rtt->second.h &&
                             prosper::frontend::rtt_sampled_extent_compatible(
                                 tw, th, live_rtt->second.w, live_rtt->second.h, render_scale,
-                                normalized_sampling) && r.gpu_addr != draw.color0_base;
+                                normalized_sampling) && sampled_source_addr != draw.color0_base;
                         const bool has_live_rtt =
                             has_cpu_live_rtt || has_gpu_live_rtt || has_uniform_live_rtt;
-                        resource_has_live_rtt = has_live_rtt;
+                        // A dim-5 base-slice view may need the CPU injection path rather than a direct
+                        // Vulkan bind, but the selected renderer target is still authoritative even if
+                        // an on-demand readback cannot currently materialize it. Never validate/cache a
+                        // guest decode for that identity: renderer-only writes cannot dirty guest pages.
+                        const bool has_live_rtt_authority = has_live_rtt ||
+                            (!fr.is_storage_image && r.img_dim == 5u && !r.in_mip_tail &&
+                             live_rtt != g_rtt.end());
+                        resource_has_live_rtt = has_live_rtt_authority;
                         // Resolve renderer-owned depth before considering guest-byte texture
                         // decoding. A sampled depth attachment has no authoritative color payload
                         // in guest memory: the retained Vulkan image is the source of truth. The old
@@ -1627,9 +1640,6 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         resource_has_ds_live = has_ds_live;
                         const bool is_cube = r.img_dim == 3u;   // CUBE: six faces stacked vertically (#273)
                         const bool is_volume = r.img_dim == 2u;
-                        const uint64_t sampled_source_addr = texture_decode_source_address(
-                            r.gpu_addr, r.img_dim, r.in_mip_tail,
-                            r.layer_mip_offset_bytes);
                         const uint32_t persistent_pitch = getenv("PROSPER_PITCH")
                             ? static_cast<uint32_t>(atoi(getenv("PROSPER_PITCH"))) : 0;
                         const uint32_t persistent_bc_block_bytes =
@@ -1697,7 +1707,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             persistent_packed32_texture ||
                             (persistent_bc_block_bytes != 0 && !is_volume);
                         const bool persistent_sampled_texture = texture_decode_cache_candidate(
-                            has_live_rtt, has_ds_live, r.host_data != nullptr, r.img_dim,
+                            has_live_rtt_authority, has_ds_live, r.host_data != nullptr, r.img_dim,
                             r.cls == RC::Texture, persistent_format_supported);
                         resource_persistent_candidate = persistent_sampled_texture;
                         const bool persistent_source_is_tiled =
@@ -1706,10 +1716,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // A sampled LINEAR (tile_mode 0) 2D surface (or the selected base slice of a
                         // 2D array) whose tight row is not 256-aligned
                         // is pitch-padded: RDNA2 requires a sampled linear texture's row pitch to be aligned
-                        // (256 B here), so its real pitch is align(tw*bytes_per_texel,256). The decode
-                        // below must read it row-by-row at that pitch (else every row drifts -> horizontal
-                        // scramble, e.g. Dead Cells' 348-wide Motion Twin splash whose real pitch is 384
-                        // texels). Guards keep
+                        // (256 B here), so its real pitch aligns either texel rows or BC block rows. The
+                        // decode below must read it row-by-row at that pitch (else every row drifts ->
+                        // horizontal scramble, e.g. Dead Cells' 348-wide Motion Twin splash whose real
+                        // pitch is 384 texels). Guards keep
                         // this narrow and regression-safe: 2D or the already-selected 2D-array base slice
                         // only (volume/cube layouts untouched); tile_mode == 0 exactly, so
                         // unrecognized/actually-tiled modes are NOT strided (they fall to the contiguous
@@ -1719,7 +1729,14 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // The tightly-packed
                         // LINEAR_GENERAL layout is a buffer/copy layout, not a sampled-texture layout, so it
                         // does not reach here. r.size is the TIGHT extent (tw*th*bpp), so it cannot gate this.
-                        const size_t linear_dst_row = (size_t)tw * sampled_source_bpt;
+                        const uint32_t linear_row_width = persistent_bc_block_bytes
+                            ? tw / 4u + static_cast<uint32_t>(tw % 4u != 0u) : tw;
+                        const uint32_t linear_row_count = persistent_bc_block_bytes
+                            ? th / 4u + static_cast<uint32_t>(th % 4u != 0u) : th;
+                        const uint32_t linear_row_element_bytes = persistent_bc_block_bytes
+                            ? persistent_bc_block_bytes : sampled_source_bpt;
+                        const size_t linear_dst_row =
+                            static_cast<size_t>(linear_row_width) * linear_row_element_bytes;
                         const uint32_t registered_linear_pitch = linear_dst_row <= UINT32_MAX
                             ? prosper::gpu::guest_linear_texture_row_pitch(
                                   r.gpu_addr, static_cast<uint32_t>(linear_dst_row))
@@ -1728,14 +1745,16 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             ? r.linear_row_pitch_bytes
                             : (registered_linear_pitch
                                    ? registered_linear_pitch
-                                   : prosper::gpu::linear_sampled_row_pitch(tw, sampled_source_bpt));
+                                   : prosper::gpu::linear_sampled_row_pitch(
+                                         linear_row_width, linear_row_element_bytes));
                         if (const char* lp = getenv("PROSPER_LINPITCH"))
-                            linear_src_row = (size_t)strtoull(lp, nullptr, 0) * sampled_source_bpt;
+                            linear_src_row =
+                                (size_t)strtoull(lp, nullptr, 0) * linear_row_element_bytes;
                         const bool linear_padded_read =
                             r.cls == RC::Texture && (r.img_dim == 1u || r.img_dim == 5u) &&
                             r.tile_mode == 0 &&
                             (!r.host_data || r.linear_row_pitch_bytes != 0) &&
-                            !r.compression_enabled && persistent_bc_block_bytes == 0 &&
+                            !r.compression_enabled &&
                             linear_dst_row != 0 && linear_src_row > linear_dst_row;
                         // Dynamic single-channel video/coverage surfaces are already exactly what a
                         // VK_FORMAT_R8_UNORM sampled image consumes. Expanding every byte to RGBA on the
@@ -1771,7 +1790,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 return persistent_source_is_tiled
                                     ? prosper::gpu::tiled_elements_bytes(
                                           bw, bh, persistent_bc_block_bytes, r.tile_mode)
-                                    : static_cast<size_t>(bw) * bh * persistent_bc_block_bytes;
+                                    : (linear_padded_read
+                                           ? linear_src_row * linear_row_count
+                                           : static_cast<size_t>(bw) * bh *
+                                                 persistent_bc_block_bytes);
                             }
                             if (persistent_packed32_texture)
                                 return persistent_source_is_tiled
@@ -2171,7 +2193,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // like the color-target bridge above. Keep the actual image extent in the
                         // backend resource so its exact cache lookup remains unambiguous.
                         if (has_gpu_live_rtt) {
-                            fr.persistent_render_target_id = r.gpu_addr;
+                            fr.persistent_render_target_id = sampled_source_addr;
                             fr.tw = live_rtt->second.w;
                             fr.th = live_rtt->second.h;
                             fr.td = 1; fr.img_dim = r.img_dim;
@@ -2289,9 +2311,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 else if (!live_rtt->second.gpu_valid) rtt_notvalid++;
                                 else if (live_rtt->second.w != tw || live_rtt->second.h != th)
                                     rtt_dimmismatch++;
-                                else if (r.gpu_addr == draw.color0_base) rtt_self++;
+                                else if (sampled_source_addr == draw.color0_base) rtt_self++;
                                 else if (prosper::test::find_persistent_color_target(
-                                             r.gpu_addr, tw, th, live_rtt->second.format) == nullptr)
+                                             sampled_source_addr, tw, th,
+                                             live_rtt->second.format) == nullptr)
                                     rtt_noptarget++;   // evicted from / absent in the backend target cache
                                 else rtt_unknown++;
                             }
@@ -2378,9 +2401,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         std::vector<uint8_t>& texture_pixels = texstore[texstore_used++];
                         if (retain_cpu_live_rtt) texture_pixels.clear();
                         else texture_pixels.resize(nb);
-                        auto copy_linear_padded_rows = [&](uint8_t* dst, size_t dst_row) {
+                        auto copy_linear_padded_rows = [&](uint8_t* dst, size_t dst_row,
+                                                           uint32_t rows) {
                             size_t total = 0;
-                            for (uint32_t y = 0; y < th; ++y) {
+                            for (uint32_t y = 0; y < rows; ++y) {
                                 uint8_t* drow = dst + (size_t)y * dst_row;
                                 const size_t got = copy_resource(
                                     drow, sampled_source_addr + (uint64_t)y * linear_src_row,
@@ -2435,7 +2459,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // pixels (nearest-scaled to tw x th) instead of reading empty guest memory.
                         bool rtt_hit = false;
                         if (!fr.is_storage_image && rtt_on && !is_volume && !r.in_mip_tail) {
-                            auto rit = g_rtt.find(r.gpu_addr);
+                            auto rit = g_rtt.find(sampled_source_addr);
                             if (rit != g_rtt.end() && rit->second.w && rit->second.h && rit->second.rgba &&
                                 !rit->second.rgba->empty()) {
                                 const RttSurf& s = rit->second;
@@ -2458,7 +2482,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                     // composite/tint that darkens otherwise-correct input.
                                     if (getenv("PROSPER_DUMP_SAMPLED_RTT")) {
                                         static std::set<uint64_t> seen;
-                                        if (seen.insert(r.gpu_addr).second) {
+                                        if (seen.insert(sampled_source_addr).second) {
                                             const std::vector<uint8_t> inspected = inspection_rgba8(
                                                 texture_pixels, tw, th, s.format);
                                             size_t nz = 0, rgbnz = 0;
@@ -2471,14 +2495,16 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                                                    dd ? dd : ".", (unsigned long long)r.gpu_addr, tw, th);
                                             prosper::test::dump_bmp(fn, inspected, tw, th);
                                             fprintf(stderr, "[sampledrtt] addr=0x%llx %ux%u rgb_nonblack=%zu/%u -> %s\n",
-                                                    (unsigned long long)r.gpu_addr, tw, th, rgbnz, tw*th, fn);
+                                                    (unsigned long long)sampled_source_addr,
+                                                    tw, th, rgbnz, tw*th, fn);
                                         }
                                     }
                                 } // malformed/incomplete RTT bytes => miss; decode guest backing below
                             }
                             if (rtt_log)
                                 fprintf(stderr, "[rtt] sample tex addr=0x%llx %ux%u fmt=%u -> %s (cache_size=%zu)\n",
-                                        (unsigned long long)r.gpu_addr, tw, th, (unsigned)r.format,
+                                        (unsigned long long)sampled_source_addr, tw, th,
+                                        (unsigned)r.format,
                                         rtt_hit ? "HIT" : "miss", g_rtt.size());
                         }
                         // CUBE texture (#273 — DOLL's title reflection probes / skybox): decode six
@@ -2688,6 +2714,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 else
                                     prosper::gpu::detile_elements(
                                         lin.data(), traw.data(), tbytes, bw, bh, bcb, r.tile_mode);
+                            } else if (linear_padded_read) {
+                                copy_linear_padded_rows(
+                                    lin.data(), static_cast<size_t>(bw) * bcb, bh);
                             } else {
                                 copy_resource(lin.data(), sampled_source_addr, comp_bytes);
                             }
@@ -2730,7 +2759,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                         flin.data(), traw.data(), tw, th, r.tile_mode, 0, bpt);
                                 }
                             } else if (linear_padded_read) {
-                                copy_linear_padded_rows(flin.data(), (size_t)tw * bpt);
+                                copy_linear_padded_rows(flin.data(), (size_t)tw * bpt, th);
                             } else {
                                 copy_resource(flin.data(), sampled_source_addr, flin.size());
                             }
@@ -2776,7 +2805,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 else prosper::gpu::detile_surface(
                                     hlin.data(), traw.data(), tw, th, r.tile_mode, 0, bpt);
                             } else if (linear_padded_read) {
-                                copy_linear_padded_rows(hlin.data(), (size_t)tw * bpt);
+                                copy_linear_padded_rows(hlin.data(), (size_t)tw * bpt, th);
                             } else {
                                 copy_resource(hlin.data(), sampled_source_addr, hlin.size());
                             }
@@ -2848,7 +2877,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 else prosper::gpu::detile_surface(
                                     nlin.data(), traw.data(), tw, th, r.tile_mode, 0, bpt);
                             } else if (linear_padded_read) {
-                                copy_linear_padded_rows(nlin.data(), (size_t)tw * bpt);
+                                copy_linear_padded_rows(nlin.data(), (size_t)tw * bpt, th);
                             } else {
                                 copy_resource(nlin.data(), sampled_source_addr, nlin.size());
                             }
@@ -2881,7 +2910,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             // per-row padding. copy_resource is fault-safe when an old capture has a short
                             // backing because its pre-v28 writer omitted the final padded rows.
                             linear_source_prefix_size = copy_linear_padded_rows(
-                                texture_pixels.data(), linear_dst_row);
+                                texture_pixels.data(), linear_dst_row, th);
                         } else {
                             const size_t got = copy_resource(
                                 texture_pixels.data(), sampled_source_addr, nb);

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -461,8 +461,19 @@ bool texture_decode_cache_candidate(bool has_live_color_target,
                                     bool is_sampled_texture,
                                     bool format_supported) {
     return !has_live_color_target && !has_live_depth_target &&
-        !has_captured_host_data && (image_dimension == 1u || image_dimension == 2u) &&
+        !has_captured_host_data &&
+        (image_dimension == 1u || image_dimension == 2u || image_dimension == 5u) &&
         is_sampled_texture && format_supported;
+}
+
+uint64_t texture_decode_source_address(uint64_t gpu_address,
+                                       uint32_t image_dimension,
+                                       bool in_mip_tail,
+                                       uint32_t layer_mip_offset_bytes) {
+    if (image_dimension != 5u || in_mip_tail ||
+        gpu_address > UINT64_MAX - layer_mip_offset_bytes)
+        return gpu_address;
+    return gpu_address + layer_mip_offset_bytes;
 }
 
 bool texture_source_snapshot_can_follow_watch(bool source_matches_pixels,
@@ -1368,6 +1379,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     bool resource_texture_watch_active = false;
                     bool resource_texture_watch_disabled = false;
                     bool resource_texture_watch_only = false;
+                    bool resource_has_live_rtt = false;
+                    bool resource_has_ds_live = false;
+                    bool resource_persistent_candidate = false;
+                    size_t resource_persistent_source_size = 0;
                     prosper::test::FrameResource fr; fr.binding = r.binding; fr.set = set;
                     fr.is_storage_image = r.cls == RC::StorageImage;
                     const bool normalized_sampling =
@@ -1594,6 +1609,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 normalized_sampling) && r.gpu_addr != draw.color0_base;
                         const bool has_live_rtt =
                             has_cpu_live_rtt || has_gpu_live_rtt || has_uniform_live_rtt;
+                        resource_has_live_rtt = has_live_rtt;
                         // Resolve renderer-owned depth before considering guest-byte texture
                         // decoding. A sampled depth attachment has no authoritative color payload
                         // in guest memory: the retained Vulkan image is the source of truth. The old
@@ -1608,8 +1624,12 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                       r.gpu_addr, tw, th, render_scale, normalized_sampling)
                                 : prosper::test::PersistentDsSampled{};
                         const bool has_ds_live = sampled_ds.image != nullptr;
+                        resource_has_ds_live = has_ds_live;
                         const bool is_cube = r.img_dim == 3u;   // CUBE: six faces stacked vertically (#273)
                         const bool is_volume = r.img_dim == 2u;
+                        const uint64_t sampled_source_addr = texture_decode_source_address(
+                            r.gpu_addr, r.img_dim, r.in_mip_tail,
+                            r.layer_mip_offset_bytes);
                         const uint32_t persistent_pitch = getenv("PROSPER_PITCH")
                             ? static_cast<uint32_t>(atoi(getenv("PROSPER_PITCH"))) : 0;
                         const uint32_t persistent_bc_block_bytes =
@@ -1679,6 +1699,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         const bool persistent_sampled_texture = texture_decode_cache_candidate(
                             has_live_rtt, has_ds_live, r.host_data != nullptr, r.img_dim,
                             r.cls == RC::Texture, persistent_format_supported);
+                        resource_persistent_candidate = persistent_sampled_texture;
                         const bool persistent_source_is_tiled =
                             persistent_sampled_texture && !getenv("PROSPER_NODETILE") &&
                             prosper::gpu::tile_mode_is_tiled(r.tile_mode);
@@ -1806,9 +1827,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 sampled_dcc_metadata.data(), sampled_dcc_metadata.size(),
                                 r.num_components, r.alpha_is_on_msb);
                         const uint64_t persistent_source_addr = persistent_dcc_fast_clear
-                            ? r.metadata_addr : r.gpu_addr;
+                            ? r.metadata_addr : sampled_source_addr;
                         const size_t persistent_source_size = persistent_dcc_fast_clear
                             ? sampled_dcc_metadata.size() : persistent_base_source_size;
+                        resource_persistent_source_size = persistent_source_size;
                         resource_texture_source_bytes = persistent_source_size;
                         // A successful typed-storage compute dispatch may still own this exact
                         // sampled image on the shared Vulkan device. Prefer that image only for the
@@ -1851,7 +1873,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         auto copy_persistent_source = [&](uint8_t* dst, size_t bytes) {
                             return persistent_dcc_fast_clear
                                 ? copy_dcc_metadata(dst, bytes)
-                                : copy_resource(dst, r.gpu_addr, bytes);
+                                : copy_resource(dst, sampled_source_addr, bytes);
                         };
                         const bool persistent_cache_eligible = !resource_compute_image_hit &&
                             !fr.is_storage_image &&
@@ -2358,7 +2380,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             for (uint32_t y = 0; y < th; ++y) {
                                 uint8_t* drow = dst + (size_t)y * dst_row;
                                 const size_t got = copy_resource(
-                                    drow, r.gpu_addr + (uint64_t)y * linear_src_row, dst_row);
+                                    drow, sampled_source_addr + (uint64_t)y * linear_src_row,
+                                    dst_row);
                                 total += got;
                                 if (got < dst_row) std::fill(drow + got, drow + dst_row, 0);
                             }
@@ -2370,7 +2393,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // touched, so we read zeros -> the scene samples black (#300 black-gameplay probe).
                         if (getenv("PROSPER_TEXCOMMIT")) {
                             const size_t PG = 0x10000; size_t committed = 0;
-                            for (uint64_t a = r.gpu_addr; a < r.gpu_addr + nb; a += PG)
+                            for (uint64_t a = sampled_source_addr;
+                                 a < sampled_source_addr + nb; a += PG)
                                 if (a >= 0x1000 && prosper_reserved_range_state(a) != 0) committed += PG;
                             static std::set<uint64_t> tcseen;
                             if (tcseen.insert(r.gpu_addr).second) {
@@ -2380,7 +2404,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 // problem. tile_mode tells tiled vs linear.
                                 uint32_t w0[8] = {0}; size_t nzb = 0;
                                 if (committed) {
-                                    const uint8_t* p = (const uint8_t*)(uintptr_t)r.gpu_addr;
+                                    const uint8_t* p =
+                                        (const uint8_t*)(uintptr_t)sampled_source_addr;
                                     for (int i = 0; i < 8; i++) w0[i] = ((const uint32_t*)p)[i];
                                     for (size_t i = 0; i < nb; i += 997) nzb += (p[i] != 0);   // sparse scan
                                 }
@@ -2652,7 +2677,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             if (tiled) {
                                 size_t tbytes = prosper::gpu::tiled_elements_bytes(bw, bh, bcb, r.tile_mode);
                                 std::vector<uint8_t> traw(tbytes, 0);
-                                copy_resource(traw.data(), r.gpu_addr, tbytes);
+                                copy_resource(traw.data(), sampled_source_addr, tbytes);
                                 if (r.in_mip_tail)
                                     prosper::gpu::detile_elements_level(
                                         lin.data(), traw.data(), tbytes, bw, bh, bcb,
@@ -2661,7 +2686,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                     prosper::gpu::detile_elements(
                                         lin.data(), traw.data(), tbytes, bw, bh, bcb, r.tile_mode);
                             } else {
-                                copy_resource(lin.data(), r.gpu_addr, comp_bytes);
+                                copy_resource(lin.data(), sampled_source_addr, comp_bytes);
                             }
                             if (!prosper::gpu::bc_decode_surface(
                                     texture_pixels.data(), lin.data(), lin.size(), tw, th, r.format))
@@ -2686,9 +2711,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                           tw, th, r.tile_mode, 0, bpt);
                                 std::vector<uint8_t> traw(tbytes, 0);
                                 const size_t got = copy_resource(
-                                    traw.data(), r.gpu_addr, tbytes);
+                                    traw.data(), sampled_source_addr, tbytes);
                                 if (got < flin.size()) {
-                                    copy_resource(flin.data(), r.gpu_addr, flin.size());
+                                    copy_resource(flin.data(), sampled_source_addr, flin.size());
                                 } else if (is_volume) {
                                     prosper::gpu::detile_volume(
                                         flin.data(), traw.data(), got, tw, th, r.depth,
@@ -2704,7 +2729,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             } else if (linear_padded_read) {
                                 copy_linear_padded_rows(flin.data(), (size_t)tw * bpt);
                             } else {
-                                copy_resource(flin.data(), r.gpu_addr, flin.size());
+                                copy_resource(flin.data(), sampled_source_addr, flin.size());
                             }
                             for (size_t t = 0; t < volume_texels; ++t) {
                                 for (uint32_t c = 0; c < 4; ++c) {
@@ -2736,8 +2761,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                     ? prosper::gpu::tiled_volume_bytes(tw, th, r.depth, r.tile_mode, bpt)
                                     : prosper::gpu::tiled_surface_bytes(tw, th, r.tile_mode, 0, bpt);
                                 std::vector<uint8_t> traw(tbytes, 0);
-                                size_t got = copy_resource(traw.data(), r.gpu_addr, tbytes);
-                                if (got < hlin.size()) copy_resource(hlin.data(), r.gpu_addr, hlin.size());  // short backing -> linear fallback
+                                size_t got = copy_resource(
+                                    traw.data(), sampled_source_addr, tbytes);
+                                if (got < hlin.size())
+                                    copy_resource(hlin.data(), sampled_source_addr, hlin.size());  // short backing -> linear fallback
                                 else if (is_volume) prosper::gpu::detile_volume(
                                     hlin.data(), traw.data(), got, tw, th, r.depth, r.tile_mode, bpt);
                                 else if (r.in_mip_tail) prosper::gpu::detile_surface_level(
@@ -2748,7 +2775,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             } else if (linear_padded_read) {
                                 copy_linear_padded_rows(hlin.data(), (size_t)tw * bpt);
                             } else {
-                                copy_resource(hlin.data(), r.gpu_addr, hlin.size());
+                                copy_resource(hlin.data(), sampled_source_addr, hlin.size());
                             }
                             // Same NaN/negative/positive-infinity clamp and absent-channel defaults
                             // as the historical scalar loop, exhaustively checked over all binary16
@@ -2761,7 +2788,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             // copy feeds the backend's 1-byte staging upload; the view swizzle below makes
                             // every sampled component equal R, byte-for-byte matching the old RGBA result.
                             linear_source_prefix_size = copy_resource(
-                                texture_pixels.data(), r.gpu_addr, texture_pixels.size());
+                                texture_pixels.data(), sampled_source_addr,
+                                texture_pixels.size());
                             if (linear_source_prefix_size < texture_pixels.size())
                                 std::fill(texture_pixels.begin() + linear_source_prefix_size,
                                           texture_pixels.end(), 0);
@@ -2770,7 +2798,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         } else if (native_rg8_sampled) {
                             // Tight RG8 is already the backend's two-byte sampled representation.
                             linear_source_prefix_size = copy_resource(
-                                texture_pixels.data(), r.gpu_addr, texture_pixels.size());
+                                texture_pixels.data(), sampled_source_addr,
+                                texture_pixels.size());
                             if (linear_source_prefix_size < texture_pixels.size())
                                 std::fill(texture_pixels.begin() + linear_source_prefix_size,
                                           texture_pixels.end(), 0);
@@ -2792,7 +2821,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                     ? prosper::gpu::tiled_volume_bytes(tw, th, r.depth, r.tile_mode, bpt)
                                     : prosper::gpu::tiled_surface_bytes(tw, th, r.tile_mode, 0, bpt);
                                 std::vector<uint8_t> traw(tbytes, 0);
-                                size_t got = copy_resource(traw.data(), r.gpu_addr, tbytes);
+                                size_t got = copy_resource(
+                                    traw.data(), sampled_source_addr, tbytes);
                                 // PROSPER_DUMP_RAWTILE (narrow path): the single/dual-channel RAW TILED bytes,
                                 // once per address, for offline 8-bpp de-swizzle sweeps (the SDF font atlas).
                                 if (getenv("PROSPER_DUMP_RAWTILE") && got >= nlin.size() && tw <= 2048 && th <= 1024) {
@@ -2805,7 +2835,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                             fprintf(stderr, "[render] narrow raw tiled -> %s (%zu, bpt=%u)\n", bn, traw.size(), bpt); fflush(stderr); }
                                     }
                                 }
-                                if (got < nlin.size()) copy_resource(nlin.data(), r.gpu_addr, nlin.size());  // short backing -> linear fallback
+                                if (got < nlin.size())
+                                    copy_resource(nlin.data(), sampled_source_addr, nlin.size());  // short backing -> linear fallback
                                 else if (is_volume) prosper::gpu::detile_volume(
                                     nlin.data(), traw.data(), got, tw, th, r.depth, r.tile_mode, bpt);
                                 else if (r.in_mip_tail) prosper::gpu::detile_surface_level(
@@ -2816,7 +2847,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             } else if (linear_padded_read) {
                                 copy_linear_padded_rows(nlin.data(), (size_t)tw * bpt);
                             } else {
-                                copy_resource(nlin.data(), r.gpu_addr, nlin.size());
+                                copy_resource(nlin.data(), sampled_source_addr, nlin.size());
                             }
                             const bool unorm16 = r.format == prosper::gpu::DataFormat::Unorm16;
                             for (size_t t = 0; t < volume_texels; t++) {
@@ -2849,7 +2880,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             linear_source_prefix_size = copy_linear_padded_rows(
                                 texture_pixels.data(), linear_dst_row);
                         } else {
-                            const size_t got = copy_resource(texture_pixels.data(), r.gpu_addr, nb);
+                            const size_t got = copy_resource(
+                                texture_pixels.data(), sampled_source_addr, nb);
                             linear_source_prefix_size = got;
                             if (got < nb)
                                 std::fill(texture_pixels.begin() + got, texture_pixels.end(), 0);
@@ -2880,7 +2912,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 ? prosper::gpu::tiled_volume_bytes(tw, th, r.depth, tmode, 4)
                                 : prosper::gpu::tiled_surface_bytes(tw, th, tmode, pitch);
                             std::vector<uint8_t> tiled(tiled_bytes, 0);
-                            size_t got = copy_resource(tiled.data(), r.gpu_addr, tiled_bytes);
+                            size_t got = copy_resource(
+                                tiled.data(), sampled_source_addr, tiled_bytes);
                             if (got < nb)
                                 // The padded tiled buffer's tail (th rounded to whole 32-row tiles) runs past
                                 // the real backing: fall back to the width*height linear bytes copied above
@@ -2947,7 +2980,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             const size_t raw_size = std::min<size_t>(
                                 r.size ? r.size : volume_texels * 4, 64u << 20);
                             std::vector<uint8_t> raw(raw_size, 0);
-                            const size_t raw_got = copy_resource(raw.data(), r.gpu_addr, raw.size());
+                            const size_t raw_got = copy_resource(
+                                raw.data(), sampled_source_addr, raw.size());
                             auto fnv = [](const uint8_t* data, size_t size) {
                                 uint64_t hash = 1469598103934665603ull;
                                 for (size_t i = 0; i < size; ++i) {
@@ -2967,7 +3001,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 alpha_nonzero += inspected[p + 3] != 0;
                             }
                             const auto writer = prosper::gpu::last_guest_write_overlap(
-                                r.gpu_addr, raw_size);
+                                sampled_source_addr, raw_size);
                             fprintf(stderr,
                                     "[resource-version] render-submit=%llu draw=%llu order=%llu set=%u bind=%u "
                                     "addr=0x%llx dims=%ux%u class=%u fmt=%u tile=%u dcc=%u meta=0x%llx rtt=%d "
@@ -3529,15 +3563,23 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                         }
                                     };
                                     fprintf(stderr,
-                                            "[render-timing] texture addr=0x%llx %ux%u out=%ux%u "
-                                            "fmt=%u comps=%u tile=%u class=%u storage=%d compressed=%d "
+                                            "[render-timing] texture addr=0x%llx %ux%ux%u out=%ux%ux%u "
+                                            "dim=%u fmt=%u comps=%u tile=%u class=%u storage=%d "
+                                            "host=%d live=%d depth-live=%d candidate=%d source=%zu "
+                                            "compressed=%d "
                                             "cache=%s id=%llu validate=%s %.2fms/%zuB/%zuB "
                                             "submit=%s watch=%s active=%d disabled=%d only=%d stable=%u "
                                             "total=%.2f ms\n",
                                             (unsigned long long)r.gpu_addr, r.width, r.height,
-                                            fr.tw, fr.th, (unsigned)r.format, r.num_components,
+                                            r.depth, fr.tw, fr.th, fr.td, r.img_dim,
+                                            (unsigned)r.format, r.num_components,
                                             r.tile_mode, static_cast<unsigned>(r.cls),
                                             static_cast<int>(fr.is_storage_image),
+                                            static_cast<int>(r.host_data != nullptr),
+                                            static_cast<int>(resource_has_live_rtt),
+                                            static_cast<int>(resource_has_ds_live),
+                                            static_cast<int>(resource_persistent_candidate),
+                                            resource_persistent_source_size,
                                             static_cast<int>(r.compression_enabled), cache_state,
                                             (unsigned long long)fr.persistent_texture_id,
                                             resource_texture_exact_validation ? "exact" : "skip",

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -1703,17 +1703,19 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         const bool persistent_source_is_tiled =
                             persistent_sampled_texture && !getenv("PROSPER_NODETILE") &&
                             prosper::gpu::tile_mode_is_tiled(r.tile_mode);
-                        // A sampled LINEAR (tile_mode 0) 2D surface whose tight row is not 256-aligned
+                        // A sampled LINEAR (tile_mode 0) 2D surface (or the selected base slice of a
+                        // 2D array) whose tight row is not 256-aligned
                         // is pitch-padded: RDNA2 requires a sampled linear texture's row pitch to be aligned
                         // (256 B here), so its real pitch is align(tw*bytes_per_texel,256). The decode
                         // below must read it row-by-row at that pitch (else every row drifts -> horizontal
                         // scramble, e.g. Dead Cells' 348-wide Motion Twin splash whose real pitch is 384
                         // texels). Guards keep
-                        // this narrow and regression-safe: 2D only (volume/cube layouts untouched); tile_mode
-                        // == 0 exactly, so unrecognized/actually-tiled modes are NOT strided (they fall to the
-                        // contiguous read + auto-detile pass); exact HLE-producer provenance can select a
-                        // tight guest layout (AvPlayer NV12); !host_data keeps ordinary CPU-uploaded test
-                        // fixtures contiguous unless capture replay supplies an explicit guest-layout pitch.
+                        // this narrow and regression-safe: 2D or the already-selected 2D-array base slice
+                        // only (volume/cube layouts untouched); tile_mode == 0 exactly, so
+                        // unrecognized/actually-tiled modes are NOT strided (they fall to the contiguous
+                        // read + auto-detile pass); exact HLE-producer provenance can select a tight guest
+                        // layout (AvPlayer NV12); !host_data keeps ordinary CPU-uploaded test fixtures
+                        // contiguous unless capture replay supplies an explicit guest-layout pitch.
                         // The tightly-packed
                         // LINEAR_GENERAL layout is a buffer/copy layout, not a sampled-texture layout, so it
                         // does not reach here. r.size is the TIGHT extent (tw*th*bpp), so it cannot gate this.
@@ -1730,7 +1732,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         if (const char* lp = getenv("PROSPER_LINPITCH"))
                             linear_src_row = (size_t)strtoull(lp, nullptr, 0) * sampled_source_bpt;
                         const bool linear_padded_read =
-                            r.cls == RC::Texture && r.img_dim == 1u && r.tile_mode == 0 &&
+                            r.cls == RC::Texture && (r.img_dim == 1u || r.img_dim == 5u) &&
+                            r.tile_mode == 0 &&
                             (!r.host_data || r.linear_row_pitch_bytes != 0) &&
                             !r.compression_enabled && persistent_bc_block_bytes == 0 &&
                             linear_dst_row != 0 && linear_src_row > linear_dst_row;

--- a/prosper/frontends/shared/live_renderer.hpp
+++ b/prosper/frontends/shared/live_renderer.hpp
@@ -32,13 +32,22 @@ size_t texture_decode_cache_limit_bytes(const char* override_mib,
 // Decide whether guest bytes are the authoritative source for a sampled-texture decode. Retained
 // color and depth targets are already represented by Vulkan images and must bypass CPU decode-cache
 // validation; captured host backing, cube textures, and non-texture resources follow their dedicated
-// paths. Supported 3D volume inputs are pure guest-byte decodes and may be retained like 2D inputs.
+// paths. Supported 3D volume inputs and the graphics backend's base-slice 2D-array view are pure
+// guest-byte decodes and may be retained like ordinary 2D inputs.
 bool texture_decode_cache_candidate(bool has_live_color_target,
                                     bool has_live_depth_target,
                                     bool has_captured_host_data,
                                     uint32_t image_dimension,
                                     bool is_sampled_texture,
                                     bool format_supported);
+
+// Graphics currently lowers sampled 2D arrays to a 2D base-slice image. Array descriptors retain
+// the allocation base plus the selected mip's per-layer offset, so CPU decode must begin at that
+// offset (except for packed mip tails, whose coordinates are relative to the shared block base).
+uint64_t texture_decode_source_address(uint64_t gpu_address,
+                                       uint32_t image_dimension,
+                                       bool in_mip_tail,
+                                       uint32_t layer_mip_offset_bytes);
 
 // Once an exact source has been validated while a working write watch is armed, the retained encoded
 // copy is redundant: Unchanged permits reuse, while Dirty/Unknown conservatively forces a re-decode.

--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -1340,43 +1340,136 @@ extern "C" void prosper_gpu_drain_renderer_writes() {
         return;
     }
     PendQueue& p = pend_q();
+    static const bool batch_enabled =
+        std::getenv("PROSPER_NO_BATCH_RENDERER_WRITE_DRAIN") == nullptr;
+    if (!batch_enabled) {
+        for (;;) {
+            std::unique_lock<std::mutex> lk(p.mx);
+            if (p.inflight > 0) {
+                p.cv.wait(lk);
+                continue;
+            }
+            auto overlaps_completion = [&](uint64_t addr, uint64_t bytes) {
+                if (!addr || !bytes) return true;
+                const uint64_t end = addr + bytes;
+                if (end < addr) return true;
+                for (const PendWrite& queued : p.q) {
+                    uint64_t target = 0, target_bytes = 0;
+                    if (queued.cmd.kind == Pm4Command::Kind::ReleaseMem) {
+                        target = queued.cmd.rel_addr;
+                        target_bytes = queued.cmd.rel_data_sel == 1 ? 4 : 8;
+                    } else if (queued.cmd.kind == Pm4Command::Kind::EventWrite) {
+                        target = queued.cmd.event_addr;
+                        target_bytes = 8;
+                    }
+                    if (target && target < end && addr < target + target_bytes) return true;
+                }
+                return false;
+            };
+            auto it = std::find_if(p.q.begin(), p.q.end(), [&](const PendWrite& w) {
+                using K = Pm4Command::Kind;
+                if (w.cmd.kind == K::DmaData)
+                    return !overlaps_completion(w.cmd.dd_dst, w.cmd.dd_bytes);
+                if (w.cmd.kind != K::WriteData || !w.cmd.wd_data || !w.cmd.wd_num)
+                    return false;
+                const uint64_t bytes = (uint64_t)w.cmd.wd_num * 4;
+                return !overlaps_completion(w.cmd.wd_addr, bytes);
+            });
+            if (it == p.q.end()) return;
+            PendWrite w = std::move(*it);
+            p.q.erase(it);
+            p.inflight++;
+            lk.unlock();
+            apply_deferred_effect(w.cmd);
+            lk.lock();
+            p.inflight--;
+            p.cv.notify_all();
+        }
+    }
+
+    struct CompletionSpan {
+        uint64_t begin = 0;
+        uint64_t end = 0;
+    };
     for (;;) {
         std::unique_lock<std::mutex> lk(p.mx);
         if (p.inflight > 0) {
             p.cv.wait(lk);
             continue;
         }
-        auto overlaps_completion = [&](uint64_t addr, uint64_t bytes) {
-            if (!addr || !bytes) return true;
-            const uint64_t end = addr + bytes;
-            if (end < addr) return true;
-            for (const PendWrite& queued : p.q) {
-                uint64_t target = 0, target_bytes = 0;
-                if (queued.cmd.kind == Pm4Command::Kind::ReleaseMem) {
-                    target = queued.cmd.rel_addr;
-                    target_bytes = queued.cmd.rel_data_sel == 1 ? 4 : 8;
-                } else if (queued.cmd.kind == Pm4Command::Kind::EventWrite) {
-                    target = queued.cmd.event_addr;
-                    target_bytes = 8;
-                }
-                if (target && target < end && addr < target + target_bytes) return true;
+        std::vector<CompletionSpan> completion_spans;
+        completion_spans.reserve(p.q.size());
+        for (const PendWrite& queued : p.q) {
+            uint64_t target = 0, target_bytes = 0;
+            if (queued.cmd.kind == Pm4Command::Kind::ReleaseMem) {
+                target = queued.cmd.rel_addr;
+                target_bytes = queued.cmd.rel_data_sel == 1 ? 4 : 8;
+            } else if (queued.cmd.kind == Pm4Command::Kind::EventWrite) {
+                target = queued.cmd.event_addr;
+                target_bytes = 8;
             }
-            return false;
+            if (!target || !target_bytes) continue;
+            completion_spans.push_back({
+                target,
+                target > UINT64_MAX - target_bytes ? UINT64_MAX : target + target_bytes});
+        }
+        std::sort(completion_spans.begin(), completion_spans.end(),
+                  [](const CompletionSpan& a, const CompletionSpan& b) {
+                      return a.begin < b.begin || (a.begin == b.begin && a.end < b.end);
+                  });
+        size_t merged_count = 0;
+        for (const CompletionSpan& span : completion_spans) {
+            if (merged_count && span.begin <= completion_spans[merged_count - 1].end) {
+                completion_spans[merged_count - 1].end =
+                    std::max(completion_spans[merged_count - 1].end, span.end);
+            } else {
+                completion_spans[merged_count++] = span;
+            }
+        }
+        completion_spans.resize(merged_count);
+        auto overlaps_completion = [&](uint64_t addr, uint64_t bytes) {
+            if (!addr || !bytes || addr > UINT64_MAX - bytes) return true;
+            const uint64_t end = addr + bytes;
+            const auto found = std::lower_bound(
+                completion_spans.begin(), completion_spans.end(), addr,
+                [](const CompletionSpan& span, uint64_t value) {
+                    return span.end <= value;
+                });
+            return found != completion_spans.end() && found->begin < end;
         };
-        auto it = std::find_if(p.q.begin(), p.q.end(), [&](const PendWrite& w) {
+        auto renderer_write = [&](const PendWrite& w) {
             using K = Pm4Command::Kind;
             if (w.cmd.kind == K::DmaData)
                 return !overlaps_completion(w.cmd.dd_dst, w.cmd.dd_bytes);
             if (w.cmd.kind != K::WriteData || !w.cmd.wd_data || !w.cmd.wd_num) return false;
             const uint64_t bytes = (uint64_t)w.cmd.wd_num * 4;
             return !overlaps_completion(w.cmd.wd_addr, bytes);
-        });
-        if (it == p.q.end()) return;
-        PendWrite w = std::move(*it);
-        p.q.erase(it);
+        };
+        const size_t ready_count = static_cast<size_t>(std::count_if(
+            p.q.begin(), p.q.end(), renderer_write));
+        if (!ready_count) return;
+
+        // Extract every currently eligible resource write in one stable partition. The previous
+        // loop searched the complete queue for every candidate and erased one deque element at a
+        // time. A submit with thousands of private completion labels therefore became quadratic
+        // before Vulkan saw any work. The lock makes this snapshot atomic with enqueue; writes
+        // appended after the partition are later in queue order and cannot be overtaken.
+        std::vector<PendWrite> ready;
+        ready.reserve(ready_count);
+        std::deque<PendWrite> blocked;
+        while (!p.q.empty()) {
+            PendWrite write = std::move(p.q.front());
+            p.q.pop_front();
+            if (renderer_write(write))
+                ready.push_back(std::move(write));
+            else
+                blocked.push_back(std::move(write));
+        }
+        p.q.swap(blocked);
         p.inflight++;
         lk.unlock();
-        apply_deferred_effect(w.cmd);
+        for (const PendWrite& write : ready)
+            apply_deferred_effect(write.cmd);
         lk.lock();
         p.inflight--;
         p.cv.notify_all();

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -459,12 +459,23 @@ uint64_t resource_footprint_impl(const ShaderResource& r, bool legacy_linear_tig
     bool decoded_is_volume = false;
     if (bc) {
         uint32_t bw = (w + 3) / 4, bh = (h + 3) / 4;
-        decoded = tile_mode_is_tiled(r.tile_mode) ? tiled_elements_bytes(bw, bh, bc, r.tile_mode)
-                                                  : checked_mul(checked_mul(bw, bh), bc);
+        if (tile_mode_is_tiled(r.tile_mode)) {
+            decoded = tiled_elements_bytes(bw, bh, bc, r.tile_mode);
+        } else if (r.tile_mode == static_cast<uint32_t>(TileMode::Linear) &&
+                   r.cls == ResourceClass::Texture &&
+                   (r.img_dim == 1u ||
+                    ((r.img_dim == 3u || r.img_dim == 5u) && r.layer_stride_bytes)) &&
+                   !r.compression_enabled && !legacy_linear_tight) {
+            const uint32_t row_pitch = resolved_linear_row_pitch(r, bw, bc);
+            decoded = checked_mul(row_pitch, bh);
+        } else {
+            decoded = checked_mul(checked_mul(bw, bh), bc);
+        }
     } else {
         uint32_t bpt = data_format_bytes(r.format) * (r.num_components ? r.num_components : 1);
         const bool native_wide = r.cls == ResourceClass::StorageImage ||
-            (r.format == DataFormat::Float16 && (bpt == 2 || bpt == 4 || bpt == 8));
+            (r.format == DataFormat::Float16 && (bpt == 2 || bpt == 4 || bpt == 8)) ||
+            (r.format == DataFormat::Float32 && (bpt == 4 || bpt == 8 || bpt == 16));
         if (bpt == 0 || (bpt > 4 && !native_wide)) bpt = 4;
         if (tile_mode_is_tiled(r.tile_mode)) {
             if (r.img_dim == 2u && r.depth > 1u) {
@@ -480,9 +491,7 @@ uint64_t resource_footprint_impl(const ShaderResource& r, bool legacy_linear_tig
             // Guest-backed linear sampled images default to GFX10's 256-byte row alignment. Exact
             // HLE-producer provenance may override it (AvPlayer's CPU-staged NV12 is tight). Capturing
             // only width*height*bpt made genuinely padded video planes drift and omitted their tail.
-            const uint32_t row_pitch = (r.img_dim == 3u || r.img_dim == 5u)
-                ? static_cast<uint32_t>(linear_sampled_row_pitch(w, bpt))
-                : resolved_linear_row_pitch(r, w, bpt);
+            const uint32_t row_pitch = resolved_linear_row_pitch(r, w, bpt);
             decoded = checked_mul(row_pitch, h);
         } else {
             decoded = checked_mul(checked_mul(w, h), bpt);
@@ -643,16 +652,23 @@ bool capture_table(const ShaderResourceTable* src, const std::vector<Interval>& 
     for (const auto& r : src->resources) {
         GpuCapturedResource c;
         c.resource = r;
-        if (r.cls == ResourceClass::Texture && r.img_dim == 1u &&
+        if (r.cls == ResourceClass::Texture &&
+            (r.img_dim == 1u || (r.img_dim == 5u && r.layer_stride_bytes)) &&
             r.tile_mode == static_cast<uint32_t>(TileMode::Linear) &&
-            !r.compression_enabled && !bc_block_bytes(r.format)) {
-            uint32_t bpt = data_format_bytes(r.format) *
-                           (r.num_components ? r.num_components : 1u);
-            const bool f16 = r.format == DataFormat::Float16 &&
-                             (bpt == 2 || bpt == 4 || bpt == 8);
-            if (bpt == 0 || (bpt > 4 && !f16)) bpt = 4;
+            !r.compression_enabled) {
+            const uint32_t bc = bc_block_bytes(r.format);
+            const uint32_t resource_width = r.width ? r.width : 4u;
+            const uint32_t pitch_width = bc
+                ? resource_width / 4u + static_cast<uint32_t>(resource_width % 4u != 0u)
+                : resource_width;
+            uint32_t bpt = bc ? bc : data_format_bytes(r.format) *
+                (r.num_components ? r.num_components : 1u);
+            const bool native_wide =
+                (r.format == DataFormat::Float16 && (bpt == 2 || bpt == 4 || bpt == 8)) ||
+                (r.format == DataFormat::Float32 && (bpt == 4 || bpt == 8 || bpt == 16));
+            if (bpt == 0 || (bpt > 4 && !native_wide && !bc)) bpt = 4;
             c.resource.linear_row_pitch_bytes = resolved_linear_row_pitch(
-                r, r.width ? r.width : 4u, bpt);
+                r, pitch_width, bpt);
         }
         c.resource.host_data = nullptr; c.resource.host_data_size = 0;
         c.resource.dcc_metadata_host_data = nullptr;

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -844,6 +844,31 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
                          (unsigned long long)rs.es_addr, (unsigned long long)rs.ps_addr);
         return false;
     }
+    const ResolvedPipelineState resolved_pipeline = failure
+        ? failure->pipeline : resolve_pipeline_state(rs);
+    // CB_TARGET_MASK/CB_SHADER_MASK are upstream hardware gates: a fragment export can narrow these
+    // masks, but cannot enable a component that they already disabled.  When fixed-function state also
+    // has no depth/stencil side effect, shader/resource realization cannot change the no-op verdict.
+    // Astro's late FMV/world-map submits contain hundreds of these draws, so rejecting them here avoids
+    // building resource tables, walking RDNA programs, and copying cached SPIR-V merely to discard them.
+    const bool preexport_color_effect = std::any_of(
+        resolved_pipeline.color_targets.begin(), resolved_pipeline.color_targets.end(),
+        [](const auto& target) { return target.write_mask != 0; });
+    if (!preexport_color_effect && !has_depth_stencil_side_effect(resolved_pipeline) &&
+        !getenv("PROSPER_FORCE_COLORWRITE") && !getenv("PROSPER_NO_EARLY_NO_EFFECT")) {
+        if (failure) {
+            failure->reason = RealizationFailureReason::NoEffect;
+            // Keep the bound program addresses in captures without performing shader analysis.  A
+            // no-effect operation does not need compiled modules or descriptor tables for replay.
+            add_stage_diagnostic(ShaderProgramStage::Vertex, rs.es_addr, {}, {});
+            add_stage_diagnostic(ShaderProgramStage::Fragment, rs.ps_addr, {}, {});
+        }
+        if (log) fprintf(stderr, "[exec] skip draw early: no color/depth/stencil effect "
+                                "cb_target_mask=0x%x cb_color_control=0x%x color0_fmt=%u\n",
+                         rs.cb_target_mask, rs.cb_color_control,
+                         resolved_pipeline.color0_format);
+        return false;
+    }
     const auto* fused_back = static_cast<const AgcShaderHeader*>(
         prosper_agc_fused_back_header_for_front(rs.es_addr));
     const bool phase_timing = getenv("PROSPER_RENDER_TIMING") != nullptr;
@@ -960,7 +985,6 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
     PixelSystemInputMapping system_inputs{rs.ps_input_ena, rs.ps_input_addr};
     const PixelSystemInputMapping* system_input_ptr =
         (system_inputs.ena || system_inputs.addr) ? &system_inputs : nullptr;
-    const ResolvedPipelineState resolved_pipeline = resolve_pipeline_state(rs);
     const FragmentInterpolationLayout interpolation = fragment_interpolation_layout_cached(
         reinterpret_cast<const uint32_t*>(static_cast<uintptr_t>(rs.ps_addr)),
         max_shader_dwords, system_input_ptr, pixel_input_ptr);

--- a/prosper/tests/test_agc_shader.cpp
+++ b/prosper/tests/test_agc_shader.cpp
@@ -632,8 +632,8 @@ int main() {
           "persistent realization workers survive repeated batch generations");
 
     // An attempted parallel batch can correctly produce no items. That must not be mistaken for
-    // "parallel disabled" and replay all draws serially. Each no-effect draw reaches both already-warm
-    // shader cache entries once; a serial retry would double this exact hit count.
+    // "parallel disabled" and replay all draws serially. Proven no-effect draws must also be rejected
+    // before either already-warm shader cache is consulted.
     prosper::gpu::GpuState filtered_state = parallel_state;
     filtered_state.cx[P::CB_TARGET_MASK] = 0;
     const auto filtered_parallel_before = prosper::gpu::parallel_draw_realization_stats();
@@ -644,9 +644,8 @@ int main() {
     const auto filtered_parallel_after = prosper::gpu::parallel_draw_realization_stats();
     CHECK(filtered_draws.empty() &&
               filtered_parallel_after.batches == filtered_parallel_before.batches + 1 &&
-              filtered_shader_after.hits ==
-                  filtered_shader_before.hits + filtered_state.draws.size() * 2,
-          "all-filtered parallel batch is not retried through the serial path");
+              filtered_shader_after.hits == filtered_shader_before.hits,
+          "all-filtered parallel batch rejects no-effect draws before shader realization");
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");

--- a/prosper/tests/test_eop_write.cpp
+++ b/prosper/tests/test_eop_write.cpp
@@ -14,6 +14,7 @@
 #include <cstring>
 #include <chrono>
 #include <thread>
+#include <vector>
 #ifdef _WIN32
 #include <windows.h>
 #else
@@ -119,6 +120,51 @@ int main() {
         prosper_gpu_drain_completion_writes();
         CHECK(label == 0xfedcba9876543210ull,
               "ordered label initialization and fence become visible after submit scope end");
+    }
+
+    // Renderer drains routinely encounter hundreds of resource uploads behind thousands of private
+    // completion labels. Exercise the stable batched extraction: every unrelated write must land in
+    // packet order while the overlapping label initialization/release pair remains hidden.
+    {
+        constexpr uint32_t resource_count = 256;
+        uint64_t label = 0x123456789abcdef0ull;
+        std::vector<uint32_t> resources(resource_count, 0);
+        std::vector<uint32_t> stream;
+        stream.reserve(13u + resource_count * 6u);
+        auto append_write = [&](uint64_t addr, uint32_t value) {
+            stream.push_back(PM4(6, IT_NOP, R_WRITE_DATA));
+            stream.push_back(0);
+            stream.push_back(static_cast<uint32_t>(addr));
+            stream.push_back(static_cast<uint32_t>(addr >> 32));
+            stream.push_back(1);
+            stream.push_back(value);
+        };
+        append_write(reinterpret_cast<uint64_t>(&label), 0);
+        stream.push_back(PM4(7, IT_NOP, R_RELEASE_MEM));
+        stream.push_back(static_cast<uint32_t>(reinterpret_cast<uint64_t>(&label)));
+        stream.push_back(static_cast<uint32_t>(reinterpret_cast<uint64_t>(&label) >> 32));
+        stream.push_back(2);
+        stream.push_back(0x76543210u);
+        stream.push_back(0xfedcba98u);
+        stream.push_back(0x04);
+        for (uint32_t i = 0; i < resource_count; ++i)
+            append_write(reinterpret_cast<uint64_t>(&resources[i]), 0x61000000u + i);
+
+        GpuState st;
+        prosper_gpu_submit_scope_begin();
+        const size_t n = run_command_buffer(stream.data(), stream.size(), st);
+        prosper_gpu_drain_renderer_writes();
+        bool resources_ready = true;
+        for (uint32_t i = 0; i < resource_count; ++i)
+            resources_ready &= resources[i] == 0x61000000u + i;
+        CHECK(n == resource_count + 2u && resources_ready,
+              "batched renderer drain applies every unrelated resource write");
+        CHECK(label == 0x123456789abcdef0ull,
+              "batched renderer drain keeps overlapping completion writes private");
+        prosper_gpu_submit_scope_end();
+        prosper_gpu_drain_completion_writes();
+        CHECK(label == 0xfedcba9876543210ull,
+              "batched drain preserves the private label pair's completion order");
     }
 
     // A RELEASE_MEM writing a 64-bit fence value (data_sel==2) to a label, exactly as agc_cb_release_mem

--- a/prosper/tests/test_gpu_capture_render.cpp
+++ b/prosper/tests/test_gpu_capture_render.cpp
@@ -376,6 +376,14 @@ int main() {
                                0x2 /* RW */, 0, source_name, 0) == 0 && source_va,
               "persistent BC test maps guest-readable source memory");
         if (source_va) {
+            auto mapped_reader = [&](uint64_t addr, uint8_t* dst, size_t bytes) -> size_t {
+                if (addr < source_va) return 0;
+                const uint64_t offset = addr - source_va;
+                if (offset > source_mapping_size || bytes > source_mapping_size - offset)
+                    return 0;
+                std::memcpy(dst, reinterpret_cast<const void*>(addr), bytes);
+                return bytes;
+            };
             const uint8_t bc3_red[16] = {
                 0xff, 0x00, 0x88, 0xc6, 0xfa, 0x88, 0xc6, 0xfa,
                 0x00, 0xf8, 0x1f, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -496,7 +504,7 @@ int main() {
             array_resource.depth = 4;
             array_resource.layer_stride_bytes = 0x1000;
             array_resource.layer_mip_offset_bytes = 0x100;
-            array_resource.linear_row_pitch_bytes = array_row_pitch;
+            array_resource.linear_row_pitch_bytes = 0;
             array_draw.prt = std::move(array_table);
 
             const std::vector<uint8_t> first_array =
@@ -523,6 +531,145 @@ int main() {
                   "unchanged 2D-array base slice reuses its decoded and uploaded image");
             CHECK(!first_array.empty() && first_array == reused_array,
                   "2D-array base-slice cache preserves the selected pixels");
+
+            GpuCaptureFile array_capture;
+            error.clear();
+            const bool array_captured = capture_draw_items(
+                {array_draw}, meta, mapped_reader, array_capture, error);
+            CHECK(array_captured &&
+                      array_capture.draws[0].prt.resources[0]
+                              .resource.linear_row_pitch_bytes == array_row_pitch,
+                  "capture derives the aligned row pitch from a normal dim-5 descriptor");
+            GpuReplayFrame array_replay;
+            const bool array_materialized = array_captured &&
+                materialize_gpu_replay(array_capture, array_replay, error);
+            const std::vector<uint8_t> replayed_array = array_materialized
+                ? render_submit_items(array_replay.items, W, H) : std::vector<uint8_t>{};
+            CHECK(array_materialized &&
+                      array_replay.items[0].prt->resources[0].linear_row_pitch_bytes ==
+                          array_row_pitch &&
+                      replayed_array == first_array,
+                  "captured dim-5 base slice replays the same padded selected rows");
+
+            // BC levels apply the same row alignment to their block grid. Keep the two useful
+            // 32-byte rows 256 bytes apart so a tight block copy sees zero padding instead of row 1.
+            uint8_t* bc_array_base = reinterpret_cast<uint8_t*>(source_va + 0x4000);
+            uint8_t* bc_array_selected = bc_array_base + 0x400;
+            uint8_t bc3_green[sizeof(bc3_red)];
+            std::memcpy(bc3_green, bc3_red, sizeof(bc3_red));
+            bc3_green[8] = 0xe0;
+            bc3_green[9] = 0x07;
+            for (uint32_t block = 0; block < 2; ++block) {
+                std::memcpy(bc_array_selected + block * sizeof(bc3_red),
+                            bc3_red, sizeof(bc3_red));
+                std::memcpy(bc_array_selected + array_row_pitch +
+                                block * sizeof(bc3_green),
+                            bc3_green, sizeof(bc3_green));
+            }
+            DrawItem bc_array_draw = bc_draw;
+            bc_array_draw.color0_base = 0xda0000;
+            auto bc_array_table =
+                std::make_shared<ShaderResourceTable>(*bc_array_draw.prt);
+            ShaderResource& bc_array_resource = bc_array_table->resources[0];
+            bc_array_resource.gpu_addr = reinterpret_cast<uint64_t>(bc_array_base);
+            bc_array_resource.size = 2u * 0x1000u;
+            bc_array_resource.width = bc_array_resource.height = 8;
+            bc_array_resource.depth = 2;
+            bc_array_resource.img_dim = 5;
+            bc_array_resource.tile_mode = 0;
+            bc_array_resource.layer_stride_bytes = 0x1000;
+            bc_array_resource.layer_mip_offset_bytes = 0x400;
+            bc_array_resource.linear_row_pitch_bytes = 0;
+            bc_array_draw.prt = std::move(bc_array_table);
+            const uint32_t ps_rdna_lower[] = {
+                0x7e0002ffu, 0x3e800000u, 0x7e0202ffu, 0x3f400000u,
+                0xf0800f08u, 0x00820000u, 0xf800000fu, 0x03020100u,
+                0xbf810000u,
+            };
+            DrawItem bc_array_lower_draw = bc_array_draw;
+            bc_array_lower_draw.color0_base = 0xdb0000;
+            bc_array_lower_draw.fs = recompile_fragment(
+                ps_rdna_lower, std::size(ps_rdna_lower), bc_array_lower_draw.prt.get());
+            const std::vector<uint8_t> first_bc_array =
+                render_submit_items({bc_array_draw}, W, H);
+            const std::vector<uint8_t> first_bc_array_lower =
+                render_submit_items({bc_array_lower_draw}, W, H);
+            const std::vector<uint8_t> reused_bc_array =
+                render_submit_items({bc_array_draw}, W, H);
+            auto pixel_at = [&](const std::vector<uint8_t>& image,
+                                uint32_t x, uint32_t y) -> const uint8_t* {
+                return image.size() != static_cast<size_t>(W) * H * 4u ? nullptr
+                    : &image[(static_cast<size_t>(y) * W + x) * 4u];
+            };
+            const auto red = [](const uint8_t* pixel) {
+                return pixel && pixel[0] > 192 && pixel[1] < 64 && pixel[2] < 64;
+            };
+            const auto green = [](const uint8_t* pixel) {
+                return pixel && pixel[0] < 64 && pixel[1] > 192 && pixel[2] < 64;
+            };
+            CHECK(!bc_array_lower_draw.fs.empty() &&
+                      red(pixel_at(first_bc_array, W / 2, H / 2)) &&
+                      green(pixel_at(first_bc_array_lower, W / 2, H / 2)) &&
+                      reused_bc_array == first_bc_array,
+                  "linear BC array decodes and caches both padded block rows");
+            GpuCaptureFile bc_array_capture;
+            error.clear();
+            const bool bc_array_captured = capture_draw_items(
+                {bc_array_lower_draw}, meta, mapped_reader, bc_array_capture, error);
+            GpuReplayFrame bc_array_replay;
+            const bool bc_array_materialized = bc_array_captured &&
+                materialize_gpu_replay(bc_array_capture, bc_array_replay, error);
+            const std::vector<uint8_t> replayed_bc_array = bc_array_materialized
+                ? render_submit_items(bc_array_replay.items, W, H) : std::vector<uint8_t>{};
+            CHECK(bc_array_materialized &&
+                      bc_array_capture.draws[0].prt.resources[0]
+                              .resource.linear_row_pitch_bytes == array_row_pitch &&
+                      replayed_bc_array == first_bc_array_lower,
+                  "captured BC array preserves its padded block-row pitch and pixels");
+
+            // A live render target at the selected nonzero mip address is authoritative over the
+            // unchanged guest bytes. Re-render it with a new color and prove the array consumer does
+            // not reuse the prior frame from the guest-keyed persistent decode cache.
+            const uint8_t producer_red[16] = {
+                255, 0, 0, 255, 255, 0, 0, 255,
+                255, 0, 0, 255, 255, 0, 0, 255,
+            };
+            const uint8_t producer_green[16] = {
+                0, 255, 0, 255, 0, 255, 0, 255,
+                0, 255, 0, 255, 0, 255, 0, 255,
+            };
+            DrawItem array_rtt_producer = replay.items[0];
+            array_rtt_producer.color0_base =
+                reinterpret_cast<uint64_t>(array_selected);
+            array_rtt_producer.color0_width = array_rtt_producer.color0_height = 2;
+            auto producer_table =
+                std::make_shared<ShaderResourceTable>(*array_rtt_producer.prt);
+            ShaderResource& producer_resource = producer_table->resources[0];
+            producer_resource.gpu_addr = 0xf10000;
+            producer_resource.host_data = const_cast<uint8_t*>(producer_red);
+            producer_resource.host_data_size = sizeof(producer_red);
+            producer_resource.size = sizeof(producer_red);
+            producer_resource.width = producer_resource.height = 2;
+            producer_resource.depth = 1;
+            producer_resource.img_dim = 1;
+            producer_resource.tile_mode = 0;
+            producer_resource.linear_row_pitch_bytes = 8;
+            producer_resource.format = DataFormat::Unorm8;
+            producer_resource.num_components = 4;
+            array_rtt_producer.prt = std::move(producer_table);
+            render_submit_items({array_rtt_producer}, W, H);
+            const std::vector<uint8_t> red_array_rtt =
+                render_submit_items({array_draw}, W, H);
+            producer_resource.host_data = const_cast<uint8_t*>(producer_green);
+            producer_resource.host_data_size = sizeof(producer_green);
+            render_submit_items({array_rtt_producer}, W, H);
+            const std::vector<uint8_t> green_array_rtt =
+                render_submit_items({array_draw}, W, H);
+            const uint8_t* red_center = pixel_at(red_array_rtt, W / 2, H / 2);
+            const uint8_t* green_center = pixel_at(green_array_rtt, W / 2, H / 2);
+            CHECK(red(red_center) && green(green_center) &&
+                      red_array_rtt != green_array_rtt,
+                  "dim-5 selected-address RTT sampling follows renderer-only pixel changes");
             CHECK(unmap(source_va, source_mapping_size, 0, 0, 0, 0) == 0,
                   "persistent BC test unmaps its guest source");
         }

--- a/prosper/tests/test_gpu_capture_render.cpp
+++ b/prosper/tests/test_gpu_capture_render.cpp
@@ -480,7 +480,12 @@ int main() {
                 0.0f, 1.0f, 0.0f, 1.0f, 0.0f, 1.0f, 0.0f, 1.0f,
             };
             std::memcpy(array_base, base_values, sizeof(base_values));
-            std::memcpy(array_selected, float_values, sizeof(float_values));
+            constexpr size_t array_row_pitch = 0x100;
+            constexpr size_t array_tight_row = 2u * 4u * sizeof(float);
+            std::memcpy(array_selected, float_values, array_tight_row);
+            std::memcpy(reinterpret_cast<uint8_t*>(array_selected) + array_row_pitch,
+                        reinterpret_cast<const uint8_t*>(float_values) + array_tight_row,
+                        array_tight_row);
             DrawItem array_draw = cached_float_draw;
             array_draw.color0_base = 0xd90000;
             auto array_table = std::make_shared<ShaderResourceTable>(*array_draw.prt);
@@ -491,6 +496,7 @@ int main() {
             array_resource.depth = 4;
             array_resource.layer_stride_bytes = 0x1000;
             array_resource.layer_mip_offset_bytes = 0x100;
+            array_resource.linear_row_pitch_bytes = array_row_pitch;
             array_draw.prt = std::move(array_table);
 
             const std::vector<uint8_t> first_array =

--- a/prosper/tests/test_gpu_capture_render.cpp
+++ b/prosper/tests/test_gpu_capture_render.cpp
@@ -469,6 +469,54 @@ int main() {
                   "unchanged Float32 texture skips its next narrow/decode/upload callback");
             CHECK(!first_float.empty() && first_float == reused_float,
                   "persistent Float32 reuse preserves the native RGBA16F sampling result");
+
+            // Graphics lowers a sampled 2D array to its base slice today. The descriptor address is
+            // the layer allocation base, while layer_mip_offset selects the level that must be
+            // decoded. Exercise both the offset and the persistent decoded/uploaded reuse contract.
+            float* array_base = reinterpret_cast<float*>(source_va + 0x2000);
+            float* array_selected = reinterpret_cast<float*>(source_va + 0x2100);
+            const float base_values[16] = {
+                0.0f, 1.0f, 0.0f, 1.0f, 0.0f, 1.0f, 0.0f, 1.0f,
+                0.0f, 1.0f, 0.0f, 1.0f, 0.0f, 1.0f, 0.0f, 1.0f,
+            };
+            std::memcpy(array_base, base_values, sizeof(base_values));
+            std::memcpy(array_selected, float_values, sizeof(float_values));
+            DrawItem array_draw = cached_float_draw;
+            array_draw.color0_base = 0xd90000;
+            auto array_table = std::make_shared<ShaderResourceTable>(*array_draw.prt);
+            ShaderResource& array_resource = array_table->resources[0];
+            array_resource.gpu_addr = reinterpret_cast<uint64_t>(array_base);
+            array_resource.size = 4u * 0x1000u;
+            array_resource.img_dim = 5;
+            array_resource.depth = 4;
+            array_resource.layer_stride_bytes = 0x1000;
+            array_resource.layer_mip_offset_bytes = 0x100;
+            array_draw.prt = std::move(array_table);
+
+            const std::vector<uint8_t> first_array =
+                render_submit_items({array_draw}, W, H);
+            const auto first_array_stats = prosper::test::backend_texture_upload_stats();
+            const std::vector<uint8_t> reused_array =
+                render_submit_items({array_draw}, W, H);
+            const auto reused_array_stats = prosper::test::backend_texture_upload_stats();
+            bool array_selected_level =
+                first_array.size() == static_cast<size_t>(W) * H * 4;
+            if (array_selected_level) {
+                const uint8_t* center =
+                    &first_array[(static_cast<size_t>(H / 2) * W + W / 2) * 4];
+                array_selected_level = center[0] >= 120 && center[0] <= 136 &&
+                    center[1] >= 56 && center[1] <= 72 &&
+                    center[2] >= 24 && center[2] <= 40 && center[3] > 240;
+            }
+            CHECK(array_selected_level,
+                  "2D-array base-slice decode reads the selected mip offset, not allocation base");
+            CHECK(first_array_stats.persistent_misses == 1 &&
+                      first_array_stats.unique_uploads == 1 &&
+                      reused_array_stats.persistent_hits == 1 &&
+                      reused_array_stats.unique_uploads == 0,
+                  "unchanged 2D-array base slice reuses its decoded and uploaded image");
+            CHECK(!first_array.empty() && first_array == reused_array,
+                  "2D-array base-slice cache preserves the selected pixels");
             CHECK(unmap(source_va, source_mapping_size, 0, 0, 0, 0) == 0,
                   "persistent BC test unmaps its guest source");
         }
@@ -963,12 +1011,22 @@ int main() {
               "an ordinary supported guest 2D texture uses the decoded-texture cache");
         CHECK(texture_decode_cache_candidate(false, false, false, 2u, true, true),
               "a supported guest 3D volume uses the decoded-texture cache");
+        CHECK(texture_decode_cache_candidate(false, false, false, 5u, true, true),
+              "a supported guest 2D-array base slice uses the decoded-texture cache");
         CHECK(!texture_decode_cache_candidate(false, false, false, 3u, true, true),
               "a cube texture stays on its layer-aware decode path");
         CHECK(!texture_decode_cache_candidate(false, true, false, 1u, true, true),
               "a retained sampled-depth image bypasses guest-byte decode-cache work");
         CHECK(!texture_decode_cache_candidate(true, false, false, 1u, true, true),
               "a retained color image bypasses guest-byte decode-cache work");
+
+        using prosper::frontend::texture_decode_source_address;
+        CHECK(texture_decode_source_address(0x100000u, 5u, false, 0x24000u) == 0x124000u,
+              "a 2D-array base slice decodes from its selected mip offset");
+        CHECK(texture_decode_source_address(0x100000u, 5u, true, 0x24000u) == 0x100000u,
+              "a packed 2D-array mip tail retains its shared block base");
+        CHECK(texture_decode_source_address(0x100000u, 1u, false, 0x24000u) == 0x100000u,
+              "an ordinary 2D texture keeps its descriptor base address");
 
         using prosper::frontend::texture_source_snapshot_can_follow_watch;
         CHECK(texture_source_snapshot_can_follow_watch(false, false, true, 4096u, 4096u),


### PR DESCRIPTION
Progress on #1459.

## What changed

- Decode graphics `2D_ARRAY` resources from the selected per-layer mip offset instead of the allocation base.
- Admit the graphics backend's established base-slice 2D-array view to the exact validated decoded-texture cache, allowing the decoded pixels and Vulkan upload to remain resident.
- Batch deferred renderer-write extraction behind private completion labels instead of repeatedly scanning and erasing the pending queue one write at a time.
- Reject draws whose hardware color mask is already zero and whose fixed-function state has no depth/stencil side effect before building resource tables or consulting shader caches.
- Extend detailed render timing with texture dimension, authoritative-source, eligibility, and selected-source-size facts.

## Root cause and impact

Astro Bot's late FMV/world-map workload repeatedly binds a 1536x1536x16 Float32 `2D_ARRAY`. Graphics currently lowers this class to a 2D base-slice view, but the frontend excluded dimension 5 from its persistent decode cache and read from the allocation base rather than the descriptor's selected mip offset. It therefore copied, detiled, narrowed, uploaded, and destroyed the same large slice over and over.

The selected base slice now follows the same exact-byte validation and guest write-watch policy as ordinary 2D/3D inputs. Packed mip tails deliberately retain their shared block base. A Vulkan-backed regression places different colors at the allocation base and selected offset, proves that the selected pixels render, and proves the unchanged second call performs no new texture upload.

## Astro Bot measurements

Same binary, normal host launch with VA-API video decode, audio, input, and Vulkan rendering:

| Measurement | Before array residency | After |
|---|---:|---:|
| Presented frames in 110 s | 914 | 972 (+6.3%) |
| Repeated 1536x1536 array decode | ~18-20 ms | ~0.5 ms validated hit |
| Late 25-submit windows | ~33-38 ms/submit | ~22-26 ms/submit |

The first array decode is intentionally a miss (~27 ms); subsequent bindings validate the exact 9 MiB selected slice, then promote it behind the existing write watch.

The supporting changes are smaller: batched write drain removes the former drain function from the sampled hot list, and early no-effect rejection reduces late per-window shader hits from about 5 to 3.5 and guest-readability cache traffic from roughly 7,400 to roughly 1,000. Their end-to-end same-binary A/Bs were neutral on their own.

The blue FMV remains visually clean. A fresh F9 screenshot at guest present 999 still has the known dark 14-level world-map output (range 0..13, mean 5.97/255), so this PR does not claim that #1459's visual blocker is fixed and does not attach a black screenshot as visual progress.

## Validation

- `test_eop_write`
- `test_agc_shader`
- `test_gpu_execute` (real RADV Vulkan device)
- `test_gpu_capture`
- `test_gpu_capture_render` (real RADV Vulkan device, including selected-offset and persistent-upload assertions)
- `prosper-app` distrobox build
- Two 110-second normal-host Astro Bot runs for before/after cadence
- Fresh late-scene F9 screenshot inspection
- `git diff --check`

Snapshot tests were not run: repository policy makes them optional for routine development PRs and required before releases; this is not a release.
