### PR TITLE
gpu: skip guest prep for imported images

### DIFF
--- a/prosper/docs/FRONTEND_APP.md
+++ b/prosper/docs/FRONTEND_APP.md
@@ -340,6 +340,10 @@ target calls are retained without logging the boot/menu workloads. For example, 
 Dead Cells post-parse workload while excluding its 54-56-draw loading loop.
 Selected lightweight records are formatted together and written to stderr in one batch at submit completion;
 this preserves one parseable line per target without paying a Windows console write for every target.
+Compute phase/image timing can likewise be restricted to one exact program address with
+`PROSPER_COMPUTE_TIMING_CODE=0x...`. This filter does not enable the heavier compute trace or its hashing,
+so use it for a representative long-running dispatch A/B rather than flooding every compute program's
+per-image records.
 
 Ordered graphics/compute submits retain a bounded journal of exact guest-memory ranges written by the
 compute backend. A persistent texture validated in an earlier graphics span can therefore skip its repeated
@@ -363,6 +367,12 @@ host result fallback with a GPU baseline invalidates that obsolete fallback befo
 readable, and replay-owned targets retain their original exact contract. Set
 `PROSPER_COLD_STORAGE_SNAPSHOT_MIN_MB` to retune the crossover. The broader
 `PROSPER_NO_ADAPTIVE_STORAGE_RESULT_VALIDATION=1` control restores immediate storage-result snapshots.
+
+A sampled image that successfully imports an authoritative renderer-owned Vulkan image does not validate,
+snapshot, convert, or cache its guest backing. This includes a persistent depth/stencil import, whose
+authority is intentionally separate from the color-RTT registry: the imported image is the descriptor the
+dispatch consumes, while the raw guest bytes may be stale. Set
+`PROSPER_NO_IMPORTED_IMAGE_GUEST_BYPASS=1` to restore the redundant guest preparation for an A/B.
 
 Windows protection-fault watches are deliberately unsupported: the Windows
 exception dispatcher writes below the interrupted stack pointer before a vectored handler runs, which can

--- a/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
+++ b/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
@@ -1505,13 +1505,59 @@ authority, an external mutation forces writeback, and the disable switch preserv
 An alternating A/B/A regression injects GPU-baseline ownership failure after B and proves an older host A
 fallback cannot leave B in guest memory when A returns.
 
+## Plucky imported-depth guest preparation
+
+The cold-image measurements above predated the adaptive compute-image cache sizing from #1519. A fresh
+160-second comparison on the combined renderer confirmed that capacity now controls how often the old
+`0x30180d0000` cold path occurs: a forced 512 MiB cache produced 113 calls with `setup_ms > 50` and
+49,522 MiB of source snapshots, while the adaptive 2 GiB default produced three such calls and
+21,796 MiB. The ordinary (not cold-filtered) program median was neutral at 2.87 versus 2.89 ms. This closes
+the repeated cold-snapshot bottleneck as a priority; it does not make the whole title fast.
+
+The next per-image trace instead exposed a renderer-authority error in sampled compute inputs. A persistent
+Vulkan depth image can be imported directly even though it deliberately is not registered as a color render
+target. The import populated the descriptor's `VkImage`, but the sampled-source condition checked only the
+color `renderer_owned` flag. It therefore fell through to guest validation, cache lookup, and sometimes
+conversion of raw depth backing that was stale and never consumed. A cache hit was also allowed to replace
+the imported `VkImage` while the binding remained marked imported, making the redundant path a potential
+correctness and lifetime hazard as well as CPU work.
+
+Sampled guest preparation now runs only when neither renderer authority path supplied the image. The policy
+is expressed as a small independently tested helper and covers guest-backed, color-renderer-owned,
+direct-depth-imported, storage, and recovery-switch cases. `PROSPER_NO_IMPORTED_IMAGE_GUEST_BYPASS=1`
+restores the previous fall-through for a same-binary diagnostic. Per-binding timing now separates renderer
+query/import, cache lookup, staging, source preparation, allocation, view, and sampler costs;
+`PROSPER_COMPUTE_TIMING_CODE=0x...` limits those records to one exact program without enabling compute trace
+hashing.
+
+Two 160-second full-resolution runs of the same binary and scripted route compared that recovery switch.
+For `0x3017580000` binding 14, the imported-depth samples spent a 1.519 ms median in cache lookup and
+1.524 ms total under the old path (282 imported samples of 283). With the bypass, all 98 observed samples
+were imported and spent 0.000 ms in cache lookup / 0.003 ms total. Whole-program medians and aggregate
+snapshot totals are not treated as an A/B result: the game reached different resource-authority states,
+with binding 15 imported in 276 control samples but guest-backed in all fixed samples. That difference
+changed the program mix despite similar presented-frame totals (1,403 / 1,350). The binding-14 comparison
+isolates the fixed branch because its imported contract is identical in both runs.
+
+An uninstrumented 90-second route presented 1,348 frames (about 15 FPS), confirming that the remaining broad
+slowdown is real rather than entirely caused by diagnostics. A heavily logged run showed white flashes over
+the studio/publisher intro; intrusive output clearly worsened cadence, but the flashes have not yet been
+confirmed or disproved in a clean capture. Treat that visual report as an open correctness item, not as a
+known timing artifact.
+
 ## Next renderer step
 
-The remaining gameplay form of `0x30180d0000` spends roughly 60-70 ms converting two guest-backed
-3840x2160 Float16 inputs to RGBA8 on the CPU. Measure a generic raw-FP16 upload/GPU conversion or exact
-native-sampling alternative against the known RADV regression that originally selected RGBA8; do not simply
-re-enable native FP16 globally. In parallel, capture a fresh v39 rolling temporal window around the Plucky
-title/gameplay transition. It must include the producers for the two 48x48 volumes and close with zero
-unresolved leaves, providing a native pixel oracle as well as exact compute pipeline contracts. Keep the
-exact-byte and disable-switch A/B discipline used here, and preserve screenshot/capture correctness while
-reducing the synchronous boundaries.
+First reproduce the reported white intro flashes with lightweight capture or a clean live run. Heavy
+per-image/per-dispatch logging changes the title's already-slow timing and must not be the visual oracle.
+If a capture retains the affected producer history, use GPU replay to separate a deterministic renderer
+defect from presentation/cadence behavior.
+
+For performance, a fresh adaptive-cache trace ranked `0x3017580000` and `0x30181a0000` at roughly 16.00 and
+15.41 ms median. The imported-depth work above removes one dead input path, but a guest-backed 3840x2160
+Float16 input in the fixed run still spent about 6.9 ms in source preparation. Measure a generic raw-FP16
+upload/GPU conversion or exact native-sampling alternative against the known RADV regression that originally
+selected RGBA8; do not simply re-enable native FP16 globally. In parallel, capture a fresh v39 rolling
+temporal window around the Plucky title/gameplay transition. It must include the producers for the two
+48x48 volumes and close with zero unresolved leaves, providing a native pixel oracle as well as exact compute
+pipeline contracts. Keep the exact-byte and disable-switch A/B discipline used here, and preserve
+screenshot/capture correctness while reducing the synchronous boundaries.

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <atomic>
 #include <array>
+#include <cerrno>
 #include <chrono>
 #include <cmath>
 #include <cstdlib>
@@ -2603,6 +2604,15 @@ bool trace_compute_item(const prosper::gpu::ComputeItem& item) {
     return true;
 }
 
+bool time_compute_item(const prosper::gpu::ComputeItem& item) {
+    const char* code_env = std::getenv("PROSPER_COMPUTE_TIMING_CODE");
+    if (!code_env || !*code_env) return true;
+    char* end = nullptr;
+    errno = 0;
+    const uint64_t wanted = std::strtoull(code_env, &end, 0);
+    return !errno && end != code_env && end && !*end && item.code_addr == wanted;
+}
+
 void maybe_dump_traced_compute_spirv(const prosper::gpu::ComputeItem& item, bool trace) {
     const char* path = std::getenv("PROSPER_COMPUTELOG_SPIRV");
     if (!trace || !path || !*path || item.spirv.empty()) return;
@@ -2844,6 +2854,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         std::getenv("PROSPER_COMPUTE_TIMING_TRACE_ONLY") != nullptr;
     const bool phase_timing =
         std::getenv("PROSPER_COMPUTE_PHASE_TIMING") != nullptr &&
+        time_compute_item(item) &&
         (!timing_trace_only || trace);
     if (has_storage_images && !ctx.image_support) {
         static bool warned = false;
@@ -3182,10 +3193,16 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         };
         const bool image_timing =
             std::getenv("PROSPER_COMPUTE_IMAGE_TIMING") != nullptr &&
+            time_compute_item(item) &&
             (!timing_trace_only || trace);
         for (size_t i = 0; i < image_descriptors.size() && images_ready; i++) {
             const auto image_start = ComputeClock::now();
             double import_ms = 0.0;
+            double query_ms = 0.0;
+            double cache_lookup_ms = 0.0;
+            double staging_ms = 0.0;
+            double prepare_upload_ms = 0.0;
+            double image_allocation_ms = 0.0;
             double view_ms = 0.0;
             double sampler_ms = 0.0;
             const ShaderResource* r = item.resources->by_binding(image_descriptors[i].binding);
@@ -3325,7 +3342,10 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             // descriptors may borrow its Vulkan image directly; storage descriptors use the CPU
             // snapshot path below so their guest writeback keeps overlapping aliases coherent.
             LiveTargetSnapshot live_target;
+            const auto query_start = ComputeClock::now();
             bool renderer_owned = !r->in_mip_tail && is_live_render_target(r->gpu_addr);
+            query_ms = std::chrono::duration<double, std::milli>(
+                ComputeClock::now() - query_start).count();
             static const uint32_t render_scale = [] {
                 const char* e = std::getenv("PROSPER_RENDER_SCALE");
                 const long v = e ? std::strtol(e, nullptr, 10) : 1;
@@ -3892,7 +3912,11 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             const bool sampled_f32 = sampled_float32;
             size_t sampled_guest_need = 0;
             const uint8_t* sampled_guest_source = nullptr;
-            if (!bi.storage && !renderer_owned) {
+            static const bool imported_guest_bypass_disabled =
+                std::getenv("PROSPER_NO_IMPORTED_IMAGE_GUEST_BYPASS") != nullptr;
+            if (compute_sampled_guest_prepare_required(
+                    bi.storage, renderer_owned, bi.imported,
+                    imported_guest_bypass_disabled)) {
                 // Resolve and validate the guest source before allocating staging. A proven cache
                 // hit can then avoid the staging buffer/map as well as conversion and GPU upload.
                 if (sampled_bpb && dim_3d) {
@@ -4013,6 +4037,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 bi.cache_candidate = dcc_cache_safe &&
                     persistent_compute_image_enabled(sbytes, ComputeImageCacheClass::sampled);
                 if (bi.cache_candidate) {
+                    const auto cache_lookup_start = ComputeClock::now();
                     bi.cache_key = {
                         r->gpu_addr, reinterpret_cast<uintptr_t>(r->host_data),
                         static_cast<uint32_t>(sampled_guest_need), r->size,
@@ -4066,6 +4091,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         bi.cache_source_snapshot.assign(
                             sampled_guest_source,
                             sampled_guest_source + sampled_guest_need);
+                    cache_lookup_ms = std::chrono::duration<double, std::milli>(
+                        ComputeClock::now() - cache_lookup_start).count();
                 }
             }
 
@@ -4079,6 +4106,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 ? size_t{0} : (size_t)sbytes;
             // A retained storage image still needs a fresh destination for its post-dispatch
             // transfer. Only a read-only sampled cache hit can omit staging altogether.
+            const auto staging_start = ComputeClock::now();
             if (!bi.imported &&
                 (bi.storage || (!bi.compute_transfer_seed_borrowed &&
                                 !(bi.persistent && bi.upload_skipped)))) {
@@ -4107,7 +4135,10 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     images_ready = false; break;
                 }
             }
+            staging_ms = std::chrono::duration<double, std::milli>(
+                ComputeClock::now() - staging_start).count();
             auto* upload = static_cast<uint8_t*>(upload_mapping.data);
+            const auto prepare_upload_start = ComputeClock::now();
             if (bi.imported) {
                 // The renderer's sampled image is the source, so direct imports need no transfer.
                 bi.guest_bytes = 0;
@@ -4189,6 +4220,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     !bi.poison_verify && (bi.exact_storage_bytes() || bi.seed_skip) &&
                     persistent_compute_image_enabled(sbytes, ComputeImageCacheClass::storage);
                 if (bi.cache_candidate) {
+                    const auto cache_lookup_start = ComputeClock::now();
                     bi.cache_key = storage_image_cache_key(
                         *r, static_cast<uint32_t>(guest_bytes), image_format);
                     bi.persistent = ctx.acquire_cached_image(
@@ -4204,6 +4236,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                      "addr=0x%llx guest=%zu upload-skipped=%u\n",
                                      bi.binding, (unsigned long long)r->gpu_addr,
                                      guest_bytes, bi.upload_skipped ? 1u : 0u);
+                    cache_lookup_ms = std::chrono::duration<double, std::milli>(
+                        ComputeClock::now() - cache_lookup_start).count();
                 }
                 if (!(bi.persistent && bi.upload_skipped)) {
                 const size_t linear_size = (bi.seed_skip || bi.seed_from_imported != SIZE_MAX)
@@ -4682,6 +4716,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
 
             // Host writes are complete before this allocation is consumed by vkCmdCopyBufferToImage.
             upload_mapping.unmap();
+            prepare_upload_ms = std::chrono::duration<double, std::milli>(
+                ComputeClock::now() - prepare_upload_start).count();
 
             // Device-local image.
             VkImageCreateInfo ici{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
@@ -4702,6 +4738,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             ici.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
             // An imported binding already holds the renderer's image; only the view/sampler below
             // are ours to create. `ici` is still filled above so the view matches its format/layers.
+            const auto image_allocation_start = ComputeClock::now();
             if (!bi.imported && !bi.image) {
                 if (!vk_ok(vkCreateImage(ctx.device, &ici, nullptr, &bi.image),
                            "image-create")) { images_ready = false; break; }
@@ -4714,6 +4751,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     !vk_ok(vkBindImageMemory(ctx.device, bi.image, bi.memory, 0), "image-bind")) {
                     images_ready = false; break; }
             }
+            image_allocation_ms = std::chrono::duration<double, std::milli>(
+                ComputeClock::now() - image_allocation_start).count();
             VkImageViewCreateInfo vci{VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO};
             vci.image = bi.image;
             vci.viewType = dim_1d ? VK_IMAGE_VIEW_TYPE_1D
@@ -4785,7 +4824,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                              "[compute-image] code=0x%llx binding=%u class=%s imported=%u "
                              "extent=%ux%ux%u guest=%zu staging=%llu "
                              "normalized=%u texel=%u sampled-float=%u rgba8-reuse=%u "
-                             "import_ms=%.3f view_ms=%.3f sampler_ms=%.3f ms=%.3f\n",
+                             "query_ms=%.3f import_ms=%.3f cache_ms=%.3f "
+                             "staging_ms=%.3f prepare_ms=%.3f allocation_ms=%.3f "
+                             "view_ms=%.3f sampler_ms=%.3f ms=%.3f\n",
                              (unsigned long long)item.code_addr, bi.binding,
                              bi.storage ? "storage" : "sampled", bi.imported ? 1u : 0u,
                              r->width, r->height, r->depth, bi.guest_bytes,
@@ -4794,7 +4835,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                              image_descriptors[i].texel_access ? 1u : 0u,
                              image_descriptors[i].sampled_float ? 1u : 0u,
                              bi.unorm_rtt_value_reuse ? 1u : 0u,
-                             import_ms, view_ms, sampler_ms,
+                             query_ms, import_ms, cache_lookup_ms,
+                             staging_ms, prepare_upload_ms, image_allocation_ms,
+                             view_ms, sampler_ms,
                              std::chrono::duration<double, std::milli>(
                                  ComputeClock::now() - image_start).count());
         }

--- a/prosper/frontends/shared/live_compute.hpp
+++ b/prosper/frontends/shared/live_compute.hpp
@@ -26,6 +26,18 @@ constexpr bool compute_image_cache_default_eligible(
     return bytes >= compute_image_cache_default_minimum_bytes(image_class);
 }
 
+// A sampled descriptor needs guest validation/conversion only when neither renderer authority path
+// supplied its pixels. Depth images can be imported from the persistent Vulkan DS cache even though
+// they deliberately have no color-RTT identity; that import must not fall through and snapshot stale
+// guest backing that the dispatch will never consume.
+constexpr bool compute_sampled_guest_prepare_required(bool storage_image,
+                                                       bool renderer_owned,
+                                                       bool imported_image,
+                                                       bool imported_bypass_disabled = false) {
+    return !storage_image && !renderer_owned &&
+           (!imported_image || imported_bypass_disabled);
+}
+
 // Keep enough persistent image residency for modern multi-pass workloads without claiming an
 // unreasonable share of small discrete GPUs. The 512 MiB historical floor remains appropriate for
 // a 4 GiB heap, while larger devices contribute one eighth of their local heap up to 2 GiB. An

--- a/prosper/tests/test_game_compute.cpp
+++ b/prosper/tests/test_game_compute.cpp
@@ -63,6 +63,17 @@ int main() {
           prosper::frontend::compute_image_cache_default_limit_bytes(UINT64_MAX) ==
               2048ull * 1024ull * 1024ull,
           "image cache limit scales with local memory and retains bounded floor and ceiling");
+    CHECK(prosper::frontend::compute_sampled_guest_prepare_required(false, false, false),
+          "guest-backed sampled image prepares its source");
+    CHECK(!prosper::frontend::compute_sampled_guest_prepare_required(false, true, false),
+          "renderer-owned sampled image uses renderer authority instead of guest backing");
+    CHECK(!prosper::frontend::compute_sampled_guest_prepare_required(false, false, true),
+          "directly imported depth image does not validate unused guest backing");
+    CHECK(prosper::frontend::compute_sampled_guest_prepare_required(
+              false, false, true, true),
+          "imported-image recovery switch restores guest validation");
+    CHECK(!prosper::frontend::compute_sampled_guest_prepare_required(true, false, false),
+          "storage image retains its independent seed/writeback path");
     CHECK(prosper::frontend::storage_writeback_can_tile_mapped_bytes(
               true, 27, false, false),
           "exact-width tiled storage can feed mapped bytes directly to the tiler");


### PR DESCRIPTION
## Handoff summary

This draft packages the current Plucky Squire renderer investigation so it can move to a game-specific subagent without depending on local logs or conversational context.

The code change is a generic renderer-authority fix: when compute successfully imports an authoritative Vulkan image for a sampled descriptor, it no longer validates, snapshots, converts, or caches stale guest backing that the dispatch will never consume. The concrete live case was a persistent depth image, but there is no title-specific address, shader, or format exception in the fix.

This is real mergeable progress, but it does **not** claim that Plucky is complete. An uninstrumented route remains around 15 FPS, and a user-observed white-flash issue during the studio/publisher intro still needs a clean reproduction and capture.

## Base and preceding work

- Base: `10d355ab301c51e61cbb9437214afef082396f99`, current `origin/master` when this PR was published.
- #1516 removed avoidable cold compute-image source/result snapshot copies and is already merged in that base.
- #1519 changed the compute-image cache from the historical fixed 512 MiB ceiling to an adaptive default capped at 2 GiB.
- This branch contains one commit and five intended files; no game dump, captures, generated images, or private paths are included.

## How the investigation moved here

A fresh 160-second, full-resolution comparison on the combined renderer tested the remaining cold form of compute program `0x30180d0000`:

| cache state | cold calls (`setup_ms > 50`) | source snapshots | normal program median |
|---|---:|---:|---:|
| forced 512 MiB | 113 | 49,522.3 MiB | 2.87 ms |
| adaptive 2 GiB | 3 | 21,796.3 MiB | 2.89 ms |

That establishes that #1519 largely removed the repeated cold-capacity cliff. The ordinary program median stayed neutral, so further work shifted to the recurrent programs still visible with the adaptive cache. The largest were:

- `0x3017580000`: 16.00 ms median, 271 samples
- `0x30181a0000`: 15.41 ms median, 272 samples

Per-binding attribution on `0x3017580000` then exposed the authority bug fixed here.

## Root cause

A persistent Vulkan depth image can be imported directly into a sampled compute binding. Depth authority is intentionally separate from the color render-target registry, so this valid state had:

- `renderer_owned == false`
- `bi.imported == true`
- `bi.image` already set to the authoritative persistent depth image

The old sampled-source gate tested only `!storage && !renderer_owned`. It therefore continued into guest source validation/cache preparation even though the guest bytes were stale and unused.

Besides wasting CPU work, this was a lifetime/correctness risk: a guest cache hit was allowed to replace `bi.image` after the binding had been marked imported, while later transition/release behavior still followed the imported contract.

## Changes in this PR

- Gate sampled guest preparation on all renderer authority paths: guest preparation is required only when the binding is neither storage, color-renderer-owned, nor directly imported.
- Express the decision as `compute_sampled_guest_prepare_required(...)`, with focused assertions for guest-backed, renderer-owned, imported-depth, storage, and recovery cases.
- Add `PROSPER_NO_IMPORTED_IMAGE_GUEST_BYPASS=1` to restore the historical redundant path for same-binary diagnosis.
- Expand `[compute-image]` timing into renderer query/import, cache lookup, staging, source preparation, allocation, view, sampler, and total phases.
- Add `PROSPER_COMPUTE_TIMING_CODE=0x...` so one program can be profiled without enabling the heavier compute trace/hashing path.
- Document the controls, measurements, unresolved visual report, and recommended next work.

## Live evidence

Two 160-second full-resolution runs used the same binary and scripted route. The control changed only `PROSPER_NO_IMPORTED_IMAGE_GUEST_BYPASS=1`.

| `0x3017580000` binding 14 | historical/control | fixed |
|---|---:|---:|
| samples | 283 | 98 |
| samples imported | 282 | 98 |
| median cache lookup | 1.519 ms | 0.000 ms |
| median whole binding setup | 1.524 ms | 0.003 ms |

The binding-14 result is the isolated evidence for this fix: its imported-depth contract was the same in both runs.

Whole-program timing and total snapshot traffic are deliberately **not** presented as an A/B win. The game reached different resource-authority states: binding 15 was imported in 276 control samples but guest-backed in every fixed sample. That changed the rest of the setup/writeback mix despite similar frame totals (1,403 / 1,350). This PR avoids turning route nondeterminism into a performance claim.

GPU replay cannot directly exercise this imported-persistent-depth boundary today because replay resources own captured `host_data` rather than the live renderer's persistent Vulkan depth authority. The production live A/B exercises the actual path. Replay remains the right next tool if the reported white flashes can be captured with their producer history.

## Validation

- `cmake --build prosper/build-linux -j2`
- `env TMPDIR=$PWD/prosper/build-linux/tmpdir ctest --test-dir prosper/build-linux --output-on-failure -j2`
- Result: **159/159 tests passed**
- `git diff --check`
- Full-resolution live runs completed without renderer/compute execution failures.

The focused helper assertions are not a synthetic Vulkan persistent-D32 import test; the current compute fixture does not construct that live renderer ownership boundary. The live recovery-switch comparison is therefore the production integration evidence. A future fixture that can host an actual persistent depth import would be a useful strengthening, not a prerequisite hidden by this PR.

## Current Plucky state

- Graphics/title/gameplay progression is substantially further than the original failure, but correctness is not signed off.
- A clean, uninstrumented 90-second run presented 1,348 frames, approximately 15 FPS. The broad slowdown is real; heavy diagnostics only make it worse.
- During an earlier heavily logged run, the user observed white flashes over the studio and publisher names and said the intro looked half speed or slower.
- The diagnostic run was intentionally stopped because unrestricted per-image/per-dispatch output perturbs cadence.
- The white flashes have **not** yet been confirmed or disproved in a clean capture. Do not classify them as a timing artifact without evidence.

## Recommended next assignments

1. **Plucky correctness:** reproduce the intro flashes with lightweight capture or a clean live run. If captured producer history is complete, replay it to determine whether this is deterministic rendering or presentation/cadence behavior. Avoid unrestricted phase/image logging as the visual oracle.
2. **Plucky performance:** profile `0x3017580000` and `0x30181a0000` with the exact-code timing filter. In the fixed run, a guest-backed 3840x2160 Float16 input still spent about 6.9 ms in source preparation.
3. Evaluate a generic raw-FP16 upload/GPU conversion or exact native-sampling path. Do not globally re-enable native FP16 sampling: an earlier RADV measurement made that path about 7x slower in Astro Bot's full-resolution composite.
4. Capture a fresh v39 rolling temporal window around the title/gameplay transition, including the producers for the two 48x48 volumes, and require zero unresolved leaves before treating its PNG/BMP as a native pixel oracle.
5. Preserve the disable-switch A/B discipline and require cross-title-safe contracts; do not add Plucky addresses or shader-specific shortcuts.

This division should let an orchestrator keep the visual-correctness and compute-performance work distinct while avoiding duplicate investigation of the already-closed cold-cache capacity path.
