### PR TITLE
Handoff: trace Astro Bot's null BVH world-map blocker

### DIFF
--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -1078,7 +1078,8 @@ static void honor_dma_data(const Pm4Command& c, uint64_t retained_packet_addr = 
     }
     notify_guest_gpu_write(c.dd_dst, c.dd_bytes);
     ring_record(c.dd_dst, c.dd_src, (uint8_t)(c.dd_bytes > 255 ? 255 : c.dd_bytes), 4, packet_addr);
-    if (writer_provenance_enabled() && c.dd_bytes >= 256)
+    if (writer_provenance_enabled() &&
+        (c.dd_bytes >= 256 || writer_provenance_full_enabled()))
         record_guest_write(GuestWriterKind::DmaData, c.dd_dst, c.dd_bytes,
                            0, 0, c.stream_order, packet_addr);
     wake_on_label(c.dd_dst);
@@ -1128,7 +1129,8 @@ static void honor_write_data(const Pm4Command& c) {
     if (getenv("PROSPER_GFXLOG"))
         fprintf(stderr, "[agc]   WriteData [0x%llx] %u dwords (first=0x%08x)\n",
                 (unsigned long long)c.wd_addr, c.wd_num, c.wd_data[0]);
-    if (writer_provenance_enabled() && c.wd_num >= 64)
+    if (writer_provenance_enabled() &&
+        (c.wd_num >= 64 || writer_provenance_full_enabled()))
         record_guest_write(GuestWriterKind::WriteData, c.wd_addr,
                            static_cast<uint64_t>(c.wd_num) * 4, 0, 0,
                            c.stream_order, pkt_addr(c));

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -195,7 +195,8 @@ struct DynFetch {
 // consumer via by_srt_offset(imm) — so `key` here is exactly that immediate, and build_stage_table
 // turns each use into a ShaderResource with srt_offset = key.
 struct SrtUse {
-    int kind = 0;                    // 0 = texture, 1 = constant buffer, 2 = BVH buffer
+    int kind = 0;                    // 0 = texture, 1 = constant buffer, 2 = BVH buffer,
+                                     // 3 = proven guarded null BVH
     uint32_t key = 0;                // the s_load immediate byte offset (== emit_alu's sreg_srt tag);
                                      // 0xFFFFFFFF = key-less (direct entry V#, register-SOFFSET, or
                                      // negative-imm load; resolve by the exact instruction pc instead)

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -149,6 +149,7 @@ struct ShaderResourceCompileKey {
     uint32_t fetch_index_mode = 0;
     uint32_t flat_base_sgpr = 0;
     uint32_t bvh_box_grow = 0;
+    bool null_bvh = false;
     bool srgb = false;
     bool depth_compare = false;
     uint32_t depth_compare_func = 0;
@@ -327,6 +328,7 @@ struct ShaderCompileKeyHash {
             hash = hash_mix(hash, resource.fetch_index_mode);
             hash = hash_mix(hash, resource.flat_base_sgpr);
             hash = hash_mix(hash, resource.bvh_box_grow);
+            hash = hash_mix(hash, resource.null_bvh);
             hash = hash_mix(hash, resource.srgb);
             hash = hash_mix(hash, resource.depth_compare);
             hash = hash_mix(hash, resource.depth_compare_func);
@@ -987,6 +989,7 @@ ShaderCompileKey make_shader_compile_key(ShaderProgramStage stage, const uint32_
             compiled.fetch_index_mode = static_cast<uint32_t>(resource.fetch_index_mode);
             compiled.flat_base_sgpr = resource.flat_base_sgpr;
             compiled.bvh_box_grow = resource.bvh_box_grow;
+            compiled.null_bvh = is_proven_null_bvh(resource);
             compiled.srgb = storage_image && resource.srgb;
             compiled.depth_compare = (manual_compare || storage_image) && resource.depth_compare;
             compiled.depth_compare_func = manual_compare ? resource.depth_compare_func : 0u;
@@ -1608,6 +1611,61 @@ size_t registered_shader_dwords(const AgcShaderHeader& header, uint64_t code_add
     return dwords;
 }
 
+// A null BVH marker is only safe when the static ray instruction is inside a real EXEC region. Prove
+// the narrow compiler shape `EXEC writer; s_cbranch_execz MERGE; ... ray ...; MERGE`, and reject any
+// external branch edge into the region. This is intentionally stronger than merely observing an
+// earlier forward branch: the prior no-hit experiment did not establish dominance and could hide an
+// unguarded missing descriptor.
+bool guarded_bvh_use(const std::vector<Rdna2Inst>& instructions, uint32_t use_pc) {
+    auto changes_exec = [](const Rdna2Inst& in) {
+        if (in.fmt == Rdna2Format::VOPC)
+            return (in.opcode >= 0x10 && in.opcode <= 0x1f) ||
+                   (in.opcode >= 0x90 && in.opcode <= 0x9f) ||
+                   (in.opcode >= 0xd0 && in.opcode <= 0xdf);
+        return in.fmt == Rdna2Format::SOP1 &&
+               ((in.opcode >= 0x24 && in.opcode <= 0x2b) ||
+                in.opcode == 0x37 || in.opcode == 0x38 ||
+                in.opcode == 0x3c || in.opcode == 0x40 || in.opcode == 0x44);
+    };
+    auto is_branch = [](const Rdna2Inst& in) {
+        return in.fmt == Rdna2Format::SOPP &&
+               (in.opcode == 0x02 || (in.opcode >= 0x04 && in.opcode <= 0x09));
+    };
+    auto target = [](const Rdna2Inst& in) -> int64_t {
+        return static_cast<int64_t>(in.pc) + in.len_dwords + in.simm16;
+    };
+
+    for (size_t i = 1; i < instructions.size(); ++i) {
+        const Rdna2Inst& guard = instructions[i];
+        if (guard.fmt != Rdna2Format::SOPP || guard.opcode != 0x08 ||
+            guard.simm16 <= 0 || guard.pc >= use_pc)
+            continue;
+        const int64_t merge64 = target(guard);
+        if (merge64 <= static_cast<int64_t>(use_pc) || merge64 > UINT32_MAX)
+            continue;
+        const uint32_t merge = static_cast<uint32_t>(merge64);
+        const Rdna2Inst& exec_writer = instructions[i - 1];
+        if (exec_writer.pc + exec_writer.len_dwords != guard.pc ||
+            !changes_exec(exec_writer))
+            continue;
+        if (std::none_of(instructions.begin(), instructions.end(),
+                         [&](const Rdna2Inst& in) { return in.pc == merge; }))
+            continue;
+
+        bool external_entry = false;
+        for (const Rdna2Inst& branch : instructions) {
+            if (!is_branch(branch) || &branch == &guard) continue;
+            const int64_t branch_target = target(branch);
+            const bool target_inside = branch_target > static_cast<int64_t>(guard.pc) &&
+                                       branch_target < static_cast<int64_t>(merge);
+            const bool source_inside = branch.pc > guard.pc && branch.pc < merge;
+            if (target_inside && !source_inside) { external_entry = true; break; }
+        }
+        if (!external_entry) return true;
+    }
+    return false;
+}
+
 // --- Bindless-dynamic vertex-fetch resolution (const-fold the scalar setup) ---------------------------
 // This game's NGG vertex shader loads its vertex-buffer V# from a descriptor table at a RUNTIME-computed
 // offset (e.g. `s_load_dwordx4 s[8:11], s[24:25], vcc_hi` where `vcc_hi = (s64<<4)&0x1f0` and
@@ -1705,6 +1763,13 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
     std::bitset<kFoldSgprs> descr8_known;
     std::array<uint32_t, kFoldSgprs> descr8_key{};
     std::bitset<kFoldSgprs> descr8_key_known;
+    // Exact null-pointer dataflow for guarded BVHs. Each mapped zero qword load receives a unique
+    // origin; failed dereferences and scalar address/descriptor ALU retain that origin. A null BVH is
+    // published only when all four live descriptor words carry the SAME origin, so an unrelated
+    // unknown/zero SGPR cannot turn an unresolved ray instruction into a synthetic result.
+    std::array<uint32_t, kFoldSgprs> null_chain_origin{};
+    std::bitset<kFoldSgprs> null_chain_known;
+    uint32_t next_null_chain_origin = 0;
     // SGPRs overwritten by an s_load since seeding — the seed-V# MUBUF fallback below must not use a
     // stale user-data snapshot once the register was RELOADED from memory (ALU patches deliberately
     // don't count: descriptor snapshots are load-time semantics, pre-patch, like `descr`).
@@ -1729,6 +1794,7 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
             val_known.set((size_t)r);
             val_srt_key_known.reset((size_t)r);
             val_seed_origin_known.reset((size_t)r);
+            null_chain_known.reset((size_t)r);
             mask_state[(size_t)r] = FoldMask::Unknown;
         }
     };
@@ -1737,6 +1803,7 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
             val_known.reset((size_t)r);
             val_srt_key_known.reset((size_t)r);
             val_seed_origin_known.reset((size_t)r);
+            null_chain_known.reset((size_t)r);
             mask_state[(size_t)r] = FoldMask::Unknown;
         }
     };
@@ -1776,6 +1843,21 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
         if (!valid_reg(r) || !val_known.test((size_t)r)) return false;
         v = val[(size_t)r];
         return true;
+    };
+    auto null_origin = [&](int r) -> uint32_t {
+        return valid_reg(r) && null_chain_known.test((size_t)r)
+            ? null_chain_origin[(size_t)r] : 0u;
+    };
+    auto mark_null_origin = [&](int r, uint32_t origin) {
+        if (!origin || !valid_reg(r)) return;
+        null_chain_origin[(size_t)r] = origin;
+        null_chain_known.set((size_t)r);
+    };
+    auto operand_null_origin = [&](const Operand& operand) -> uint32_t {
+        if ((operand.kind == OperandKind::SGPR || operand.kind == OperandKind::Special) &&
+            valid_reg(operand.value))
+            return null_origin(operand.value);
+        return 0u;
     };
     auto unchanged_seed_range = [&](int first, int count) {
         if (!untouched_seed_range(first, count)) return false;
@@ -1857,6 +1939,7 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
             case Rdna2Format::SOP1:
                 if (in.opcode == 0x03) {                        // s_mov_b32
                     uint32_t v, source_key = 0;
+                    const uint32_t source_null_origin = operand_null_origin(in.src[0]);
                     const bool source_key_known =
                         in.src[0].kind == OperandKind::SGPR && valid_reg(in.src[0].value) &&
                         val_srt_key_known.test((size_t)in.src[0].value) &&
@@ -1877,6 +1960,7 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                             val_seed_origin_known.set((size_t)in.dst.value);
                         }
                     } else forget(in.dst.value);
+                    mark_null_origin(in.dst.value, source_null_origin);
                 } else if (in.opcode == 0x34) {                 // s_abs_i32
                     // This is a 32-bit destination. Treating every unmodeled SOP1 as a possible
                     // 64-bit pair write erased the untouched adjacent SGPR; Astro Bot keeps the
@@ -1891,6 +1975,25 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                         set_value(in.dst.value, static_cast<int32_t>(v) < 0 ? 0u - v : v);
                     else
                         forget(in.dst.value);
+                } else if ((in.opcode == 0x1c || in.opcode == 0x1d) &&
+                           in.dst.kind == OperandKind::SGPR) {  // s_bitset{0,1}_b32
+                    // These are in-place read/modify/write operations: SDST is both the old value
+                    // and destination, while SRC0 is only the bit index. Astro sets the descriptor's
+                    // SORT bit after extracting a zero BVH base, so preserve the exact null-root
+                    // provenance while applying that constant field patch.
+                    uint32_t old_value = 0, bit_index = 0;
+                    const uint32_t old_null_origin = null_origin(in.dst.value);
+                    const bool old_known = known(in.dst.value, old_value);
+                    const bool bit_known = in.src[0].kind == OperandKind::Literal
+                        ? (bit_index = in.literal, true) : srcval(in.src[0], bit_index);
+                    if (old_known && bit_known) {
+                        const uint32_t bit = 1u << (bit_index & 31u);
+                        set_value(in.dst.value, in.opcode == 0x1c
+                            ? old_value & ~bit : old_value | bit);
+                    } else {
+                        forget(in.dst.value);
+                    }
+                    mark_null_origin(in.dst.value, old_null_origin);
                 } else if (in.opcode == 0x04 &&                 // s_mov_b64
                            in.dst.kind == OperandKind::SGPR &&
                            in.src[0].kind == OperandKind::SGPR) {
@@ -1900,6 +2003,7 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                     std::array<uint32_t, 2> source_values{};
                     std::array<uint32_t, 2> source_keys{};
                     std::array<uint32_t, 2> source_origins{};
+                    std::array<uint32_t, 2> source_null_origins{};
                     std::array<bool, 2> source_key_known{};
                     std::array<bool, 2> source_origin_known{};
                     bool source_known = true;
@@ -1914,6 +2018,7 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                             val_seed_origin_known.test((size_t)src);
                         if (source_origin_known[(size_t)k])
                             source_origins[(size_t)k] = val_seed_origin[(size_t)src];
+                        source_null_origins[(size_t)k] = null_origin(src);
                     }
                     for (int k = 0; k < 2; ++k) {
                         const int dst = in.dst.value + k;
@@ -1930,6 +2035,7 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                             val_seed_origin[(size_t)dst] = source_origins[(size_t)k];
                             val_seed_origin_known.set((size_t)dst);
                         }
+                        mark_null_origin(dst, source_null_origins[(size_t)k]);
                     }
                 } else if (in.dst.kind == OperandKind::SGPR) {
                     // Not a modeled scalar move -> the dest is unknown. Erase the PAIR: 64-bit SOP1 ops
@@ -1969,6 +2075,22 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                 int d = in.dst.value; bool ok = ka && kc; uint32_t r = 0;
                 uint32_t hi64 = 0; bool wrote_pair = false;
                 int next_scc = scc;
+                const uint32_t null0 = operand_null_origin(in.src[0]);
+                const uint32_t null1 = operand_null_origin(in.src[1]);
+                // s_addc_u32 remains derived from the same pointer chain even when its concrete
+                // carry is unknown; the taint is provenance, not a claim about the folded value.
+                const bool null_chain_opcode =
+                    in.opcode <= 0x04 || in.opcode == 0x0E || in.opcode == 0x10 ||
+                    in.opcode == 0x12 || in.opcode == 0x1E || in.opcode == 0x20 ||
+                    in.opcode == 0x26 || (in.opcode >= 0x2E && in.opcode <= 0x31) ||
+                    in.opcode == 0x27 || in.opcode == 0x1F || in.opcode == 0x21 ||
+                    in.opcode == 0x29;
+                uint32_t propagated_null_origin = 0;
+                if (null_chain_opcode) {
+                    if (null0 && null1 && null0 == null1) propagated_null_origin = null0;
+                    else if (null0 && !null1 && kc) propagated_null_origin = null0;
+                    else if (null1 && !null0 && ka) propagated_null_origin = null1;
+                }
                 if (ok) switch (in.opcode) {
                     case 0x00: {                                           // s_add_u32
                         const uint64_t sum = static_cast<uint64_t>(a) + c;
@@ -2069,6 +2191,9 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                 // opcode switch may not have reached the point that marks wrote_pair).
                 else    { forget(d); if (wrote_pair || in.opcode == 0x1F || in.opcode == 0x21 ||
                                          in.opcode == 0x29) forget(d + 1); }
+                mark_null_origin(d, propagated_null_origin);
+                if (wrote_pair || in.opcode == 0x1F || in.opcode == 0x21 || in.opcode == 0x29)
+                    mark_null_origin(d + 1, propagated_null_origin);
                 break;
             }
             case Rdna2Format::SOPC: {   // scalar compare -> SCC (feeds the format patch's s_cselect)
@@ -2100,6 +2225,10 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                 switch (in.opcode & 7) { case 0: n = 1; break; case 1: n = 2; break; case 2: n = 4; break;
                                          case 3: n = 8; break; case 4: n = 16; break; default: n = 0; }
                 int sbase = in.src[0].value, sdst = in.dst.value;
+                const uint32_t null_base_lo = null_origin(sbase);
+                const uint32_t null_base_hi = null_origin(sbase + 1);
+                const uint32_t null_base_origin =
+                    null_base_lo && null_base_lo == null_base_hi ? null_base_lo : 0u;
                 uint32_t soff_field = (in.words[1] >> 25) & 0x7Fu;         // SOFFSET SGPR (125 = null)
                 uint32_t soff_val = 0; bool soff_ok = true;
                 if (soff_field < 106) soff_ok = known((int)soff_field, soff_val);          // SGPR
@@ -2173,7 +2302,10 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                     // or gets folded to zero.
                     if (have_pending_srt_use && n != 0 && base_ok && !soff_ok)
                         srt_uses->push_back(pending_srt_use);
-                    for (uint32_t k = 0; k < n; k++) forget(sdst + (int)k);
+                    for (uint32_t k = 0; k < n; k++) {
+                        forget(sdst + (int)k);
+                        mark_null_origin(sdst + (int)k, null_base_origin);
+                    }
                     break;
                 }
                 // in.literal is the SIGN-EXTENDED 21-bit immediate (#149) — add it as signed so a
@@ -2210,10 +2342,41 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                 }
                 if (is_buffer) addr_readable = readable(addr, n * 4);
                 if (!addr_readable) { if (trc) fprintf(stderr, "[dyntrace]   addr 0x%llx unreadable\n", (unsigned long long)addr);
-                                      for (uint32_t k = 0; k < n; k++) forget(sdst + (int)k); break; }
+                                      for (uint32_t k = 0; k < n; k++) {
+                                          forget(sdst + (int)k);
+                                          mark_null_origin(sdst + (int)k, null_base_origin);
+                                      }
+                                      break; }
+                if (trc && writer_provenance_enabled()) {
+                    const auto writer = last_guest_write_overlap(addr, n * 4);
+                    if (writer) {
+                        fprintf(stderr,
+                                "[dyntrace]   latest GPU writer kind=%s seq=%llu "
+                                "range=[0x%llx,+0x%llx) submit=%llu item=%llu order=%llu "
+                                "identity=0x%llx\n",
+                                guest_writer_kind_name(writer->kind),
+                                (unsigned long long)writer->sequence,
+                                (unsigned long long)writer->addr,
+                                (unsigned long long)writer->size,
+                                (unsigned long long)writer->submit,
+                                (unsigned long long)writer->item,
+                                (unsigned long long)writer->order,
+                                (unsigned long long)writer->identity);
+                    } else {
+                        fprintf(stderr,
+                                "[dyntrace]   no recorded GPU writer overlaps [0x%llx,+0x%x)\n",
+                                (unsigned long long)addr, n * 4);
+                    }
+                }
                 const uint32_t* mem = (const uint32_t*)(uintptr_t)addr;
                 const bool imm_only = (soff_field == 125) && (int32_t)in.literal >= 0;   // SGPR_NULL soffset
                 for (uint32_t k = 0; k < n; k++) set_value(sdst + (int)k, mem[k]);
+                if (!is_buffer && n == 2 && mem[0] == 0 && mem[1] == 0) {
+                    uint32_t origin = ++next_null_chain_origin;
+                    if (!origin) origin = ++next_null_chain_origin;
+                    mark_null_origin(sdst, origin);
+                    mark_null_origin(sdst + 1, origin);
+                }
                 if ((n == 4 || n == 8) && valid_reg(sdst) && valid_reg(sdst + (int)n - 1)) {
                     const uint32_t key = (imm_only && !is_buffer) ? in.literal : 0xFFFFFFFFu;
                     for (uint32_t k = 0; k < n; ++k) {
@@ -2299,6 +2462,12 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                             ? decode_bvh_descriptor(live_bvh.data()) : DecodedBvhDescriptor{};
                         const bool plausible = live_known && (snapshot_provenance || seed_provenance) &&
                             d.type == 8u && d.base > 0x10000u && d.size_bytes != 0;
+                        uint32_t proven_null_origin = valid_reg(bbase) ? null_origin(bbase) : 0u;
+                        for (int k = 1; proven_null_origin && k < 4; ++k)
+                            if (null_origin(bbase + k) != proven_null_origin)
+                                proven_null_origin = 0;
+                        const bool guarded_null = !plausible && proven_null_origin &&
+                            guarded_bvh_use(ins, in.pc);
                         if (trc) {
                             fprintf(stderr,
                                     "[dyntrace] BVH pc=%u srsrc=s%d snapshot=%d seed=%d bvh=",
@@ -2309,6 +2478,8 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                                         (unsigned long long)d.base,
                                         (unsigned long long)d.size_bytes, d.type,
                                         d.triangle_return_mode, d.box_grow);
+                            } else if (guarded_null) {
+                                fprintf(stderr, "<guarded-null origin=%u>", proven_null_origin);
                             } else {
                                 fprintf(stderr, "<unknown>");
                             }
@@ -2319,6 +2490,12 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                             u.kind = 2;
                             u.key = 0xFFFFFFFFu;
                             u.bvh4 = live_bvh;
+                            u.use_pc = in.pc;
+                            srt_uses->push_back(u);
+                        } else if (guarded_null) {
+                            SrtUse u;
+                            u.kind = 3;
+                            u.key = 0xFFFFFFFFu;
                             u.use_pc = in.pc;
                             srt_uses->push_back(u);
                         }
@@ -2844,6 +3021,21 @@ std::vector<SrtUse> add_compute_buffer_resources(ShaderResourceTable& table,
 
     std::set<uint64_t> seen;
     for (const auto& u : srt_uses) {
+        if (u.kind == 3) {
+            const uint64_t dk = 0x8000000300000000ull | u.use_pc;
+            if (!seen.insert(dk).second) continue;
+            alignas(256) static std::array<uint8_t, 256> null_bvh{};
+            ShaderResource r;
+            r.cls = ResourceClass::ConstantBuffer;
+            r.format = DataFormat::Uint32;
+            r.num_components = 1;
+            r.size = static_cast<uint32_t>(null_bvh.size());
+            r.fetch_pc = u.use_pc;
+            r.host_data = null_bvh.data();
+            r.host_data_size = null_bvh.size();
+            table.resources.push_back(r);
+            continue;
+        }
         if (u.kind == 2) {
             const DecodedBvhDescriptor d = decode_bvh_descriptor(u.bvh4.data());
             if (d.type != 8u || d.base <= 0x10000u || d.size_bytes == 0 ||

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -8592,6 +8592,20 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     return true;
                 }
 
+                // The front-half only creates this marker when one mapped zero qword load taints all
+                // four descriptor words and the ray instruction is dominated by an EXEC-narrowing
+                // guard with no external region entry. This is an explicit empty acceleration
+                // structure for this dispatch, not a fallback for an unresolved descriptor.
+                if (is_proven_null_bvh(*bvh)) {
+                    for (uint32_t k = 0; k < 4; ++k) {
+                        const int vd = in.dst.value + static_cast<int>(k);
+                        const uint32_t old = vreg_old(b, rs, vd);
+                        rs.vreg[vd] = b.uconst(0xffffffffu);
+                        predicate_write(b, rs, vd, old);
+                    }
+                    return true;
+                }
+
                 auto addr_vgpr = [&](uint32_t k) -> int {
                     if (k == 0u) return in.src[0].value;
                     const uint32_t j = k - 1u;

--- a/prosper/src/gpu/shader_resources.hpp
+++ b/prosper/src/gpu/shader_resources.hpp
@@ -313,6 +313,18 @@ struct ShaderResource {
     uint64_t       host_data_size   = 0;
 };
 
+// A null BVH is represented by a bounded host-owned marker. The front-half creates this only after
+// proving that a mapped zero pointer feeds the complete descriptor inside an EXEC-guarded region.
+// The exact shape survives capture/replay without adding a capture-format field and cannot alias a
+// title allocation because gpu_addr is zero.
+inline bool is_proven_null_bvh(const ShaderResource& resource) {
+    return resource.cls == ResourceClass::ConstantBuffer &&
+           resource.format == DataFormat::Uint32 && resource.num_components == 1u &&
+           resource.gpu_addr == 0 && resource.size == 256u && resource.stride == 0u &&
+           resource.fetch_pc != 0xFFFFFFFFu && resource.host_data != nullptr &&
+           resource.host_data_size >= resource.size;
+}
+
 // The set of resources a shader uses. The front-half builds it from the shader's user_data; the
 // recompiler consults it while translating memory ops and the pipeline binds from it. Pure data.
 struct ShaderResourceTable {

--- a/prosper/src/gpu/writer_provenance.cpp
+++ b/prosper/src/gpu/writer_provenance.cpp
@@ -35,16 +35,18 @@ uint64_t span_end(uint64_t addr, uint64_t size) {
 } // namespace
 
 bool writer_provenance_enabled() {
-    const char* explicit_mode = std::getenv("PROSPER_WRITER_PROVENANCE");
+    const bool explicitly_on = writer_provenance_full_enabled();
     const char* dimension_mode = std::getenv("PROSPER_PROVENANCE_DIM");
     const char* resource_hash_mode = std::getenv("PROSPER_RESOURCE_HASH_DIM");
     const char* timeline_depth_hash_mode = std::getenv("PROSPER_GPU_TIMELINE_DEPTH_HASH_DIM");
-    const bool explicitly_on = explicit_mode && *explicit_mode &&
-                               std::strcmp(explicit_mode, "0") &&
-                               std::strcmp(explicit_mode, "off");
     return explicitly_on || (dimension_mode && *dimension_mode) ||
            (resource_hash_mode && *resource_hash_mode) ||
            (timeline_depth_hash_mode && *timeline_depth_hash_mode);
+}
+
+bool writer_provenance_full_enabled() {
+    const char* value = std::getenv("PROSPER_WRITER_PROVENANCE");
+    return value && *value && std::strcmp(value, "0") && std::strcmp(value, "off");
 }
 
 const char* guest_writer_kind_name(GuestWriterKind kind) {

--- a/prosper/src/gpu/writer_provenance.hpp
+++ b/prosper/src/gpu/writer_provenance.hpp
@@ -26,6 +26,9 @@ struct GuestWriteEvent {
 
 // The opt-in live history is enabled by either the existing dimension probe or its explicit alias.
 bool writer_provenance_enabled();
+// Explicit provenance requests retain even tiny label/pointer writes. The dimension probes keep
+// their historical large-resource filter so their diagnostic overhead does not unexpectedly grow.
+bool writer_provenance_full_enabled();
 const char* guest_writer_kind_name(GuestWriterKind kind);
 
 uint64_t record_guest_write(GuestWriterKind kind, uint64_t addr, uint64_t size,

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -689,6 +689,56 @@ int main() {
               astro_bvh_table.resources[0].fetch_pc == 0,
           "Astro BVH bytes materialize as the instruction-scoped read-only compute buffer");
 
+    // Astro's first world-map dispatch explicitly writes a null qword to the root pointer consumed
+    // by this scalar chain. Preserve that fact only through the exact dependent descriptor ALU, and
+    // only when an EXEC-changing instruction plus forward EXECZ branch dominates the ray use. This
+    // is deliberately stricter than the old generic unresolved-BVH fallback rejected in review.
+    alignas(8) uint64_t null_bvh_root = 0;
+    const uint64_t null_bvh_root_addr = reinterpret_cast<uint64_t>(&null_bvh_root);
+    std::array<uint32_t, 8> null_bvh_seed{};
+    null_bvh_seed[0] = static_cast<uint32_t>(null_bvh_root_addr);
+    null_bvh_seed[1] = static_cast<uint32_t>(null_bvh_root_addr >> 32);
+    std::array<uint32_t, 24> guarded_null_bvh = {
+        0xBEAB446Au,                         // pc0:  Astro s_andn1_saveexec_b32 (narrows EXEC)
+        0xBF880014u,                         // pc1:  s_cbranch_execz pc22
+        0xF4040080u, 0xFA000000u,            // pc2:  s_load_dwordx2 s[2:3], s[0:1], 0 -> null
+        0xBF8CC07Fu,                         // pc4:  s_waitcnt
+        0xF4040181u, 0xFA000058u,            // pc5:  s_load_dwordx2 s[6:7], s[2:3], 0x58
+        0xBF8CC07Fu,                         // pc7:  s_waitcnt
+        0x8006C106u,                         // pc8:  s_add_u32 s6,s6,-1
+        0x8207C107u,                         // pc9:  s_addc_u32 s7,s7,-1
+        0x876A07FFu, 0x000003FFu,            // pc10: s_and_b32 s106, 0x3ff, s7
+        0x9484FF02u, 0x00280008u,            // pc12: s_bfe_u64 s[4:5], s[2:3], 8:40
+        0x8807FF6Au, 0x81000000u,            // pc14: s_or_b32 s7, s106, TYPE/mode
+        0xBE851D9Fu,                         // pc16: s_bitset1_b32 s5,31 (SORT field)
+        0xF1989F07u, 0x00010303u, 0x094F4E3Fu, 0x11100F0Eu, 0x00001312u,
+        0xBF800000u,                         // pc22: merge
+        0xBF810000u,                         // pc23: s_endpgm
+    };
+    std::vector<SrtUse> guarded_null_uses;
+    resolve_dynamic_fetch(guarded_null_bvh.data(), guarded_null_bvh.size(),
+                          null_bvh_seed.data(), null_bvh_seed.size(), 0,
+                          &guarded_null_uses);
+    CHECK(guarded_null_uses.size() == 1 && guarded_null_uses[0].kind == 3 &&
+              guarded_null_uses[0].use_pc == 17,
+          "mapped null BVH root plus dominating EXEC guard publishes an exact-pc null use");
+    ShaderResourceTable guarded_null_table;
+    add_compute_buffer_resources(guarded_null_table, guarded_null_bvh.data(),
+                                 guarded_null_bvh.size(), null_bvh_seed.data(),
+                                 null_bvh_seed.size());
+    CHECK(guarded_null_table.resources.size() == 1 &&
+              is_proven_null_bvh(guarded_null_table.resources[0]) &&
+              guarded_null_table.resources[0].fetch_pc == 17,
+          "proven null BVH materializes as a bounded capture-stable marker");
+
+    guarded_null_bvh[1] = 0xBF800000u;       // remove the EXECZ region proof
+    std::vector<SrtUse> unguarded_null_uses;
+    resolve_dynamic_fetch(guarded_null_bvh.data(), guarded_null_bvh.size(),
+                          null_bvh_seed.data(), null_bvh_seed.size(), 0,
+                          &unguarded_null_uses);
+    CHECK(unguarded_null_uses.empty(),
+          "mapped null BVH root without a dominating EXEC guard remains fail-visible");
+
     // Recreate the live descriptor builder rather than seeding its final words: the header pointer
     // is stored in 8-byte units, the allocation count is loaded from byte offset 0x58, and a
     // carry-propagating subtract produces the 64-byte count-minus-one before TYPE/mode are ORed in.

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -5301,6 +5301,23 @@ int main() {
         };
         for (uint32_t lane = 0; lane < lanes; ++lane) set_ray(lane, 5u, 0.0f, 0.0f, -5.0f);
 
+        alignas(256) static std::array<uint8_t, 256> null_bvh_bytes{};
+        ShaderResourceTable null_bvh_rt = bvh_rt;
+        null_bvh_rt.resources[0].gpu_addr = 0;
+        null_bvh_rt.resources[0].size = static_cast<uint32_t>(null_bvh_bytes.size());
+        null_bvh_rt.resources[0].host_data = null_bvh_bytes.data();
+        null_bvh_rt.resources[0].host_data_size = null_bvh_bytes.size();
+        const std::vector<uint32_t> null_bvh_module = recompile_valu(
+            bvh_code, std::size(bvh_code), inputs_per_lane, 3, &null_bvh_rt);
+        const std::vector<float> null_bvh_output = prosper::test::run_compute(
+            null_bvh_module, bvh_inputs, lanes, lanes,
+            std::vector<uint32_t>(null_bvh_bytes.size() / sizeof(uint32_t)));
+        bool null_bvh_ok = !null_bvh_module.empty() && null_bvh_output.size() == lanes;
+        for (float value : null_bvh_output)
+            null_bvh_ok &= bits_of(value) == 0xffffffffu;
+        CHECK(null_bvh_ok,
+              "proven guarded null BVH returns architectural no-hit child IDs");
+
         std::vector<uint32_t> box_words(32, 0u);
         box_words[0] = 0x100u; box_words[1] = 0x200u;
         box_words[2] = 0x300u; box_words[3] = 0x400u;

--- a/prosper/tests/test_shader_recompile_cache.cpp
+++ b/prosper/tests/test_shader_recompile_cache.cpp
@@ -666,11 +666,24 @@ int main() {
     bvh_table.resources[0].bvh_box_grow = 0;
     const auto bvh_grow_0_again = recompile_compute_shader_cached(
         kBvhCompute, std::size(kBvhCompute), &bvh_table, bvh_config);
+    alignas(256) static uint32_t null_bvh_words[64] = {};
+    bvh_table.resources[0].size = sizeof(null_bvh_words);
+    bvh_table.resources[0].host_data = reinterpret_cast<uint8_t*>(null_bvh_words);
+    bvh_table.resources[0].host_data_size = sizeof(null_bvh_words);
+    const auto guarded_null_bvh = recompile_compute_shader_cached(
+        kBvhCompute, std::size(kBvhCompute), &bvh_table, bvh_config);
+    bvh_table.resources[0].size = 128;
+    bvh_table.resources[0].host_data = nullptr;
+    bvh_table.resources[0].host_data_size = 0;
+    const auto bvh_grow_0_after_null = recompile_compute_shader_cached(
+        kBvhCompute, std::size(kBvhCompute), &bvh_table, bvh_config);
     stats = shader_recompile_cache_stats();
     CHECK(!bvh_grow_0.empty() && !bvh_grow_6.empty() &&
               bvh_grow_0 != bvh_grow_6 && bvh_grow_0_again == bvh_grow_0 &&
-              stats.misses == 2 && stats.hits == 1 && stats.entries == 2,
-          "compute cache separates descriptor-selected BVH box growth");
+              !guarded_null_bvh.empty() && guarded_null_bvh != bvh_grow_0 &&
+              bvh_grow_0_after_null == bvh_grow_0 &&
+              stats.misses == 3 && stats.hits == 2 && stats.entries == 3,
+          "compute cache separates BVH box growth and guarded-null lowering");
 
     // Manual shadow comparison bakes the enable, compare op, filter mode, address modes, and border
     // color into SPIR-V. In particular depth_compare=false must not reuse a previously successful


### PR DESCRIPTION
## Handoff purpose

This draft is a checkpoint for the proposed orchestrator/subagent workflow. It contains the current Astro Bot world-map investigation, the reusable diagnostics added along the way, the narrowly proven part of the fix, and the exact remaining blocker. It is intentionally **not** presented as a completed visual fix: Astro Bot still reaches a black world map and the target ray-compute shader still fails closed.

No game binaries, shader dumps, captures, title-derived data, or local diagnostic logs are included in this branch.

## Current user-visible state

- The app boots Astro Bot normally with the live Vulkan renderer, VA-API video, SDL audio, and scripted controller input.
- The Sony intro remains visually clean: the earlier checkerboard and rhythmic black-frame flicker are fixed by already-merged work. The blue FMV also remains visually correct.
- Ballpark performance in the final uncontended run was about **12.9 FPS** in the Sony section, **4.1 FPS** in the heavier blue FMV, and **4.9 FPS** after entering the world-map state. These are diagnostic numbers, not a controlled benchmark.
- The route reaches `PLAY: Playing: , Continue: worldmap` and `LevelDocument Loaded: worldmap [worldmap]`.
- The world map is still black because compute program `0x50057b800` remains unsupported. There is no new screenshot because there is no new non-black visual result. The clean blue-intro screenshot is documented in [PR #1525](https://github.com/mattias800/prosper/pull/1525).

## Context from earlier merged work

- [PR #1520](https://github.com/mattias800/prosper/pull/1520) added the static software BVH traversal groundwork. Review correctly rejected a generic “unresolved BVH means no hit” approximation, so the merged version stayed fail-visible.
- [PR #1525](https://github.com/mattias800/prosper/pull/1525) bound compute-produced 3D volumes directly and documented the clean Astro Bot intro. The current branch starts from the merge of that work plus current `master`.

The first world-map blocker is a Wave32 compute shader at guest address `0x50057b800` (modifier `0x8001`, local size 16×16 / 256 lanes). It contains three statically present `IMAGE_BVH_INTERSECT_RAY` sites at dword PCs 968, 1007, and 1346.

## Decisive diagnosis

The exact live user-SGPR root pointer for this shader is `s0:s1 = 0x50b441e00`.

An opt-in full writer-provenance trace found no GPU writer for the qword loaded at PC 822. A process-wide CPU write watch then caught the title itself writing zero to that exact address immediately before the dispatch and again after world-map load:

```text
PLAY: Playing: , Continue: worldmap
[lwatch] #1 write fa=0x50b441e00 rip=eboot+0x171069a1 ... pre[0]=0x0 pre[8]=0x0
[lwatch]   -> slot now [0]=0x0 [8]=0x0
...
LevelDocument Loaded: worldmap [worldmap]
[lwatch] #2 write fa=0x50b441e00 rip=eboot+0x171069a1 ... pre[0]=0x0 pre[8]=0x0
[lwatch]   -> slot now [0]=0x0 [8]=0x0
```

This rules out a missing GPU producer, stale cache, or overlooked DMA write for the root. The title deliberately dispatches this shader with a null BVH root.

The relevant live descriptor construction is:

- PC 822 loads the zero root qword.
- Failed dependent scalar loads from offsets `0x18`, `0x30`, and `0x58` remain tied to that root.
- PC 839 extracts the BVH base with `s_bfe_u64`.
- PC 841 patches the TYPE/mode word.
- PC 852 uses `s_bitset1_b32 s5,31` to patch the SORT field in place.
- An EXEC-changing instruction at PC 820 followed by `s_cbranch_execz` at PC 821 guards the ray region and merges at PC 1717.

## What this branch changes

### More useful opt-in writer provenance

`PROSPER_WRITER_PROVENANCE=1` now retains small DMA_DATA and WRITE_DATA events, not only the large resource writes used by dimension probes. Filtered scalar dyntraces report the most recent overlapping GPU writer for every mapped scalar load. Existing dimension-oriented probes keep their historical size filters, so their overhead does not unexpectedly increase.

This was what separated “the GPU forgot to populate the table” from “the guest intentionally wrote null.”

### Narrow guarded-null BVH proof

The scalar fold now assigns an origin to an exact mapped zero-qword load and propagates it only through dependent failed dereferences and modeled scalar descriptor operations, including Astro's real `s_bitset1_b32` and carry-chain encodings.

A null BVH use is published only when:

1. all four descriptor words retain the same exact null-root origin;
2. the ray instruction is inside the structural shape `EXEC writer; s_cbranch_execz MERGE; ... ray ...; MERGE`;
3. no branch from outside enters the guarded region.

Unknown or unguarded descriptors remain absent and therefore fail visibly. This is not the generic no-hit fallback rejected during #1520.

The proven empty acceleration structure is represented as a bounded 256-byte host-owned marker. Its shape survives existing capture/replay serialization without a new capture-format field, and its identity is included in the shader compile key so a real BVH module cannot alias a guarded-null module.

### SPIR-V behavior

When the exact marker reaches `IMAGE_BVH_INTERSECT_RAY`, the lowering writes architectural no-hit child IDs (`0xffffffff`) under the existing lane predicate. The real Vulkan execution test covers this path.

## Final live result and exact remaining blocker

The last trace proves the reachable ray site correctly:

```text
[dyntrace] BVH pc=968  srsrc=s16 ... bvh=<unknown>
[dyntrace] BVH pc=1007 srsrc=s16 ... bvh=<unknown>
[dyntrace] BVH pc=1346 srsrc=s4  ... bvh=<guarded-null origin=1>
[compute] skip unsupported program 0x50057b800
LevelDocument Loaded: worldmap [worldmap]
```

PCs 968 and 1007 sit in a block skipped by the shader's scalar branch at PC 859. The branch condition is built from a shader constant (`s11 = 37`); the live fold computes SCC=true and the branch jumps to PC 1338. However, resource discovery currently walks the instruction list linearly. It continues through the dead block, lets those dead instructions overwrite the `s16:s19` proof, discovers two unresolved ray instructions, and the recompiler correctly fails closed because they have no resource.

This means the next task is **path-sensitive scalar resource discovery or an equivalently sound constant-dead-block specialization**. It is not another descriptor guess.

Important cache constraint: if specialization ever depends on entry user-SGPR values or mutable guest memory, those inputs must participate in the compile identity. The PC 859 case appears to be shader-constant, but the implementation should prove that rather than assuming every known fold branch is cache-stable.

## Suggested next investigation order

1. Teach resource discovery to follow provably constant scalar branches, starting with the exact PC 848–859 sequence, and retain a test showing that an input-dependent branch is not specialized without a matching compile key.
2. Ensure statically unreachable BVH instructions do not require bindings while reachable unknown BVHs still fail visibly.
3. Re-run `0x50057b800`; success means all reachable ray sites either have a real BVH or the guarded-null marker.
4. Continue through the next three captured ray-compute programs: `0x5005a8100`, `0x5005d7d00`, and `0x500609f00`.
5. Keep correctness ahead of performance until the world map produces non-black pixels. Attach a screenshot to the next PR as soon as it does.
6. Once the rendering path works, profile the FMV/render loop separately; current video playback remains approximately 4–13 FPS depending on the section.

## Validation

Built in the `ps5ys` distrobox because it provides the development headers:

```bash
distrobox enter ps5ys -- bash -lc 'cd /var/home/mattias800/repos/ps5ys-codex-astrobot-fmv/prosper && cmake --build build-astrobot-fmv -j8 --target test_shader_recompile_cache test_dynfetch_fold test_rdna2_to_spirv test_rdna2_spirv_struct test_recompile_coverage test_gpu_capture test_writer_provenance prosper-app'
```

Focused test suite, **8/8 passed**:

```bash
distrobox enter ps5ys -- bash -lc 'cd /var/home/mattias800/repos/ps5ys-codex-astrobot-fmv/prosper && ctest --test-dir build-astrobot-fmv --output-on-failure -R "shader_recompile_cache|dynfetch_fold|rdna2_to_spirv_exec|rdna2_spirv_struct|recompile_coverage|gpu_capture_roundtrip|gpu_capture_bundle_roundtrip|writer_provenance_ranges"'
```

The suite covers guarded versus unguarded null propagation, Astro's exact bit-set/carry descriptor operations, real Vulkan no-hit execution, shader-cache separation, structural SPIR-V checks, writer ranges, and capture round-trips.

Normal live reproduction outside the distrobox:

```bash
PROSPER_DYNTRACE=1 \
PROSPER_DYNTRACE_ADDR=0x50057b800 \
PROSPER_DYNTRACE_ONCE=1 \
PROSPER_COMPUTELOG_CODE=0x50057b800 \
PROSPER_PAD_SCRIPT=@../.astro1459.GxuHSb/live-map-route.pad \
timeout --signal=INT --kill-after=10s 105s \
build-astrobot-fmv/prosper-app --dump /var/home/mattias800/repos/ps5ys/PPSA21564-app0
```

Snapshot tests were not run because this is a development/handoff draft, not a release. Project policy requires the snapshot suite before releases, while routine PR authors may choose focused validation during heavy development.

## Local-only artifacts for the next Astro Bot agent

These remain in the private worktree and are intentionally untracked:

- Worktree: `/var/home/mattias800/repos/ps5ys-codex-astrobot-fmv/prosper`
- Scratch directory: `/var/home/mattias800/repos/ps5ys-codex-astrobot-fmv/.astro1459.GxuHSb/`
- Route: `live-map-route.pad`
- Shader: `compute-50057b800.bin`
- Final linear-fold trace: `live-guarded-null-carry.log`
- Offline CFG listing: `compute-50057b800-inspect-final.log`
- Earlier provenance evidence: `live-provenance-20260730-2.log`
- CPU write-watch evidence: `live-root-watch-20260730.log`

The scratch directory can be retained for the handoff agent but must never be staged or uploaded.
