### PR TITLE
fix(render): keep live RTT snapshots authoritative

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -466,6 +466,17 @@ bool texture_decode_cache_candidate(bool has_live_color_target,
         is_sampled_texture && format_supported;
 }
 
+bool persistent_texture_decode_cache_eligible(bool guest_decode_candidate,
+                                              bool compute_image_hit,
+                                              bool is_storage_image,
+                                              bool cache_disabled,
+                                              bool compression_supported,
+                                              size_t cache_limit,
+                                              size_t source_size) {
+    return guest_decode_candidate && !compute_image_hit && !is_storage_image &&
+        !cache_disabled && compression_supported && cache_limit && source_size;
+}
+
 uint64_t texture_decode_source_address(uint64_t gpu_address,
                                        uint32_t image_dimension,
                                        bool in_mip_tail,
@@ -1903,12 +1914,14 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 ? copy_dcc_metadata(dst, bytes)
                                 : copy_resource(dst, sampled_source_addr, bytes);
                         };
-                        const bool persistent_cache_eligible = !resource_compute_image_hit &&
-                            !fr.is_storage_image &&
-                            !getenv("PROSPER_NO_TEXTURE_DECODE_CACHE") &&
-                            (!r.compression_enabled || persistent_dcc_uncompressed ||
-                             persistent_dcc_fast_clear) &&
-                            persistent_decode_limit && persistent_source_size != 0;
+                        const bool persistent_cache_eligible =
+                            persistent_texture_decode_cache_eligible(
+                                persistent_sampled_texture, resource_compute_image_hit,
+                                fr.is_storage_image,
+                                getenv("PROSPER_NO_TEXTURE_DECODE_CACHE") != nullptr,
+                                !r.compression_enabled || persistent_dcc_uncompressed ||
+                                    persistent_dcc_fast_clear,
+                                persistent_decode_limit, persistent_source_size);
                         static const bool cross_submit_watch_enabled =
                             !getenv("PROSPER_NO_CROSS_SUBMIT_TEXTURE_WRITE_WATCH");
                         // Page-protection watches have a fixed setup/query cost and may need to

--- a/prosper/frontends/shared/live_renderer.hpp
+++ b/prosper/frontends/shared/live_renderer.hpp
@@ -41,6 +41,17 @@ bool texture_decode_cache_candidate(bool has_live_color_target,
                                     bool is_sampled_texture,
                                     bool format_supported);
 
+// Apply the remaining runtime gates to a texture_decode_cache_candidate(). Keeping the candidate
+// explicit is important: DCC metadata can provide a nonzero source span even when renderer-owned
+// color is authoritative, but that metadata must never make guest decode-cache state eligible.
+bool persistent_texture_decode_cache_eligible(bool guest_decode_candidate,
+                                              bool compute_image_hit,
+                                              bool is_storage_image,
+                                              bool cache_disabled,
+                                              bool compression_supported,
+                                              size_t cache_limit,
+                                              size_t source_size);
+
 // Graphics currently lowers sampled 2D arrays to a 2D base-slice image. Array descriptors retain
 // the allocation base plus the selected mip's per-layer offset, so CPU decode must begin at that
 // offset (except for packed mip tails, whose coordinates are relative to the shared block base).

--- a/prosper/tests/test_gpu_capture_render.cpp
+++ b/prosper/tests/test_gpu_capture_render.cpp
@@ -1147,17 +1147,28 @@ int main() {
 
         // Live exact-extent RTT consumers borrow an immutable snapshot instead of copying it
         // through frontend scratch. FrameResource copies retain that backing through upload setup.
-        auto pixels = std::make_shared<const std::vector<uint8_t>>(16, 0x5a);
+        constexpr uint32_t retained_width = 2;
+        constexpr uint32_t retained_height = 2;
+        constexpr VkFormat retained_format = VK_FORMAT_R16G16B16A16_SFLOAT;
+        const size_t retained_bytes = static_cast<size_t>(retained_width) * retained_height *
+            prosper::test::backend_color_bytes_per_pixel(retained_format);
+        auto pixels = std::make_shared<const std::vector<uint8_t>>(retained_bytes, 0x5a);
         prosper::test::FrameResource source;
         source.tex_rgba_owner = pixels;
         source.tex_rgba = pixels->data();
+        source.tw = retained_width;
+        source.th = retained_height;
+        source.texture_format = retained_format;
         prosper::test::FrameResource retained = source;
         source.tex_rgba_owner.reset();
         pixels.reset();
         CHECK(retained.tex_rgba_owner &&
                   retained.tex_rgba == retained.tex_rgba_owner->data() &&
+                  retained.tex_rgba_owner->size() == retained_bytes &&
+                  retained.tw == retained_width && retained.th == retained_height &&
+                  retained.texture_format == retained_format &&
                   retained.tex_rgba_owner->front() == 0x5a,
-              "a copied FrameResource retains borrowed RTT pixels");
+              "a copied FrameResource retains the borrowed RTT lifetime, extent, and FP16 format");
 
         using prosper::frontend::texture_decode_cache_candidate;
         CHECK(texture_decode_cache_candidate(false, false, false, 1u, true, true),
@@ -1172,6 +1183,25 @@ int main() {
               "a retained sampled-depth image bypasses guest-byte decode-cache work");
         CHECK(!texture_decode_cache_candidate(true, false, false, 1u, true, true),
               "a retained color image bypasses guest-byte decode-cache work");
+
+        using prosper::frontend::persistent_texture_decode_cache_eligible;
+        CHECK(persistent_texture_decode_cache_eligible(
+                  /*guest_decode_candidate=*/true, /*compute_image_hit=*/false,
+                  /*is_storage_image=*/false, /*cache_disabled=*/false,
+                  /*compression_supported=*/true, /*cache_limit=*/1u << 30,
+                  /*source_size=*/retained_bytes),
+              "an ordinary supported guest texture remains eligible for persistent decode caching");
+        CHECK(!persistent_texture_decode_cache_eligible(
+                   texture_decode_cache_candidate(
+                       /*has_live_color_target=*/true, /*has_live_depth_target=*/false,
+                       /*has_captured_host_data=*/false, /*image_dimension=*/1u,
+                       /*is_sampled_texture=*/true, /*format_supported=*/true),
+                   /*compute_image_hit=*/false, /*is_storage_image=*/false,
+                   /*cache_disabled=*/false, /*compression_supported=*/true,
+                   /*cache_limit=*/1u << 30,
+                   // DCC metadata can make this nonzero even though live color is authoritative.
+                   /*source_size=*/retained_bytes),
+              "a live FP16 RTT cannot be overwritten by a DCC-backed guest decode-cache entry");
 
         using prosper::frontend::texture_decode_source_address;
         CHECK(texture_decode_source_address(0x100000u, 5u, false, 0x24000u) == 0x124000u,


### PR DESCRIPTION
## Summary

- keep renderer-owned live RTT snapshots authoritative when DCC metadata also exposes a nonzero guest source span
- require the existing guest-decode authority candidate before persistent texture decode-cache publication can overwrite a FrameResource texture pointer
- cover live FP16 RTT ownership, DCC-backed guest spans, and copied FrameResource lifetime/extent/format

Closes the coordinate-ramp investigation in #1486.

## Root cause

Dragon Quest VII draw 95 truthfully samples an opaque-black 3840x2160 RGBA16F live target through a 1920x1080 view. The retained owner contained the correct scaled bytes, but persistent guest decode-cache publication later replaced the raw FrameResource pointer while leaving the owner intact. DCC metadata made the guest source span nonzero even though live color authority had already excluded guest decoding. The backend then uploaded unrelated guest-decoded bytes and presented the visible u,v,u coordinate ramp.

## Validation

- test_rtt_injection: PASS
- test_gpu_capture_render: PASS
- exact retained Dragon Quest replay with default settings: output hash 26ed8b6191338383
- corrected BMP SHA-256: df8375ed116debe8dad86bc400efd4aabd8f37e8228316d7a2b3d1d2789c5b7f
- corrected output is byte-identical to the PROSPER_NO_RTT_SNAPSHOT_BORROW=1 recovery control
- git diff --check: clean

## Visual documentation

No compatibility screenshot is added: the corrected frame is intentionally opaque black at this stage of the captured draw sequence, and it does not constitute new visible game progression. The prior coordinate ramp was an upload artifact rather than game content. Full traceability and hashes are recorded on #1486.