### PR TITLE
perf(compute): materialize uniform FP16 DCC clears

### DIFF
--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -46,6 +46,35 @@
 
 namespace prosper::frontend {
 
+bool compute_sampled_dcc_fast_clear_rgba8(
+    const prosper::gpu::ShaderResource& resource,
+    bool ordinary_guest_backed_sampled_view,
+    bool arrayed_sampled_view,
+    bool disabled,
+    uint8_t* rgba,
+    size_t texel_count,
+    const uint8_t* metadata,
+    size_t metadata_bytes,
+    uint8_t* clear_code) {
+    const uint32_t components = resource.num_components ? resource.num_components : 1u;
+    if (disabled || !ordinary_guest_backed_sampled_view || arrayed_sampled_view ||
+        resource.cls != prosper::gpu::ResourceClass::Texture ||
+        resource.format != prosper::gpu::DataFormat::Float16 || components != 4u ||
+        resource.img_dim != 1u || resource.depth != 1u ||
+        resource.declared_mip_levels != 1u || resource.in_mip_tail ||
+        resource.layer_stride_bytes || resource.layer_mip_offset_bytes ||
+        resource.srgb || resource.depth_compare || !resource.compression_enabled ||
+        !resource.metadata_addr || !rgba || !texel_count)
+        return false;
+    const uint64_t expected_metadata = prosper::gpu::gpu_capture_dcc_metadata_footprint(resource);
+    if (!expected_metadata || expected_metadata > SIZE_MAX ||
+        metadata_bytes != static_cast<size_t>(expected_metadata))
+        return false;
+    return prosper::gpu::gfx10_dcc_fast_clear_rgba8(
+        rgba, texel_count, metadata, metadata_bytes, components,
+        resource.alpha_is_on_msb, clear_code);
+}
+
 uint8_t storage_pack_unorm8(uint32_t float_bits) {
     float value;
     std::memcpy(&value, &float_bits, sizeof(value));
@@ -3912,8 +3941,13 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             const bool sampled_f32 = sampled_float32;
             size_t sampled_guest_need = 0;
             const uint8_t* sampled_guest_source = nullptr;
+            const uint8_t* sampled_dcc_metadata = nullptr;
+            size_t sampled_dcc_metadata_bytes = 0;
+            bool sampled_dcc_fast_clear = false;
             static const bool imported_guest_bypass_disabled =
                 std::getenv("PROSPER_NO_IMPORTED_IMAGE_GUEST_BYPASS") != nullptr;
+            static const bool sampled_dcc_fast_clear_disabled =
+                std::getenv("PROSPER_NO_COMPUTE_DCC_FAST_CLEAR") != nullptr;
             if (compute_sampled_guest_prepare_required(
                     bi.storage, renderer_owned, bi.imported,
                     imported_guest_bypass_disabled)) {
@@ -4014,27 +4048,66 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     skip_image(r, "sampled backing exceeds the 512 MiB backend bound"); break;
                 }
                 bi.guest_bytes = sampled_guest_need;
-                sampled_guest_source = resource_bytes_for(r, sampled_guest_need);
-                const bool readable =
-                    (r->host_data && r->host_data_size >= sampled_guest_need) ||
-                    guest_readable(r->gpu_addr, static_cast<uint32_t>(sampled_guest_need));
-                if (!readable) { skip_image(r, "sampled surface unreadable"); break; }
+
+                // A complete uniform DCC fast-clear plane is the authoritative image contents;
+                // compressed base bytes are intentionally meaningless in that state. Restrict the
+                // first compute materialization to the ordinary 2D RGBA16F -> RGBA8 sampled path,
+                // where the renderer already proves the same embedded 0/1 clear codes. This probe
+                // happens before resolving the base pointer so a valid fast clear never reads or
+                // validates tens of MiB of irrelevant compressed allocation bytes.
+                if (r->compression_enabled) {
+                    const uint64_t metadata_bytes = gpu_capture_dcc_metadata_footprint(*r);
+                    if (metadata_bytes && metadata_bytes <= SIZE_MAX &&
+                        metadata_bytes <= UINT32_MAX) {
+                        sampled_dcc_metadata_bytes = static_cast<size_t>(metadata_bytes);
+                        if (r->dcc_metadata_host_data &&
+                            r->dcc_metadata_host_data_size >= metadata_bytes) {
+                            sampled_dcc_metadata = r->dcc_metadata_host_data;
+                        } else if (guest_readable(
+                                       r->metadata_addr,
+                                       static_cast<uint32_t>(metadata_bytes))) {
+                            sampled_dcc_metadata = reinterpret_cast<const uint8_t*>(
+                                uintptr_t(r->metadata_addr));
+                        }
+                    }
+                }
+                uint8_t sampled_dcc_clear_pixel[4]{};
+                uint8_t sampled_dcc_clear_code = 0;
+                sampled_dcc_fast_clear = compute_sampled_dcc_fast_clear_rgba8(
+                    *r, !bi.storage && !renderer_owned && !bi.imported,
+                    image_descriptors[i].image_arrayed,
+                    sampled_dcc_fast_clear_disabled,
+                    sampled_dcc_clear_pixel, 1,
+                    sampled_dcc_metadata, sampled_dcc_metadata_bytes,
+                    &sampled_dcc_clear_code);
+                if (sampled_dcc_fast_clear && trace)
+                    std::fprintf(stderr,
+                                 "[compute]   sampled DCC fast-clear binding=%u addr=0x%llx "
+                                 "meta=0x%llx code=0x%02x -> RGBA8 staging\n",
+                                 bi.binding, (unsigned long long)r->gpu_addr,
+                                 (unsigned long long)r->metadata_addr,
+                                 sampled_dcc_clear_code);
+
+                if (!sampled_dcc_fast_clear) {
+                    sampled_guest_source = resource_bytes_for(r, sampled_guest_need);
+                    const bool readable =
+                        (r->host_data && r->host_data_size >= sampled_guest_need) ||
+                        guest_readable(r->gpu_addr, static_cast<uint32_t>(sampled_guest_need));
+                    if (!readable) { skip_image(r, "sampled surface unreadable"); break; }
+                }
 
                 bool dcc_cache_safe = !r->compression_enabled;
                 if (r->compression_enabled) {
-                    const uint64_t metadata_bytes = gpu_capture_dcc_metadata_footprint(*r);
-                    const uint8_t* metadata =
-                        r->dcc_metadata_host_data &&
-                                r->dcc_metadata_host_data_size >= metadata_bytes
-                            ? r->dcc_metadata_host_data : nullptr;
-                    if (!metadata && metadata_bytes && metadata_bytes <= UINT32_MAX &&
-                        guest_readable(r->metadata_addr, static_cast<uint32_t>(metadata_bytes)))
-                        metadata = reinterpret_cast<const uint8_t*>(uintptr_t(r->metadata_addr));
-                    dcc_cache_safe = metadata && metadata_bytes &&
-                        std::all_of(metadata, metadata + metadata_bytes,
+                    dcc_cache_safe = sampled_dcc_metadata && sampled_dcc_metadata_bytes &&
+                        std::all_of(sampled_dcc_metadata,
+                                    sampled_dcc_metadata + sampled_dcc_metadata_bytes,
                                     [](uint8_t value) { return value == 0xff; });
                 }
-                bi.cache_candidate = dcc_cache_safe &&
+                // Fast clears are keyed by metadata, not by the inactive base allocation. Keep
+                // this first narrow path uncached rather than teaching the existing base-byte key
+                // an unsafe partial identity; staging materialization is still far cheaper than
+                // detiling and converting the 2x-larger FP16 base.
+                bi.cache_candidate = !sampled_dcc_fast_clear && dcc_cache_safe &&
                     persistent_compute_image_enabled(sbytes, ComputeImageCacheClass::sampled);
                 if (bi.cache_candidate) {
                     const auto cache_lookup_start = ComputeClock::now();
@@ -4532,7 +4605,16 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     const uint8_t* src = sampled_guest_source;
                     const bool needs_sampled_upload = !bi.upload_skipped &&
                         !bi.compute_transfer_seed_borrowed;
-                    if (needs_sampled_upload && bpb) {               // BCn: (block-detile ->) decode
+                    if (needs_sampled_upload && sampled_dcc_fast_clear) {
+                        if (!compute_sampled_dcc_fast_clear_rgba8(
+                                *r, true, image_descriptors[i].image_arrayed,
+                                sampled_dcc_fast_clear_disabled,
+                                upload, static_cast<size_t>(volume_texels),
+                                sampled_dcc_metadata, sampled_dcc_metadata_bytes)) {
+                            skip_image(r, "sampled DCC fast-clear materialization changed");
+                            break;
+                        }
+                    } else if (needs_sampled_upload && bpb) {        // BCn: (block-detile ->) decode
                         const uint32_t bw = (r->width + 3) / 4, bh = (r->height + 3) / 4;
                         const size_t linear_slice = static_cast<size_t>(bw) * bh * bpb;
                         const uint32_t layers = sampled_layers;

--- a/prosper/frontends/shared/live_compute.hpp
+++ b/prosper/frontends/shared/live_compute.hpp
@@ -38,6 +38,22 @@ constexpr bool compute_sampled_guest_prepare_required(bool storage_image,
            (!imported_image || imported_bypass_disabled);
 }
 
+// Materialize a proven uniform DCC fast clear for the narrow sampled representation used by an
+// ordinary guest-backed 2D RGBA16F compute input. The complete metadata plane, guest shape,
+// reflected non-arrayed view, and rollback state are part of the proof; any unsupported state
+// returns false and leaves the caller on its established base-byte path. `texel_count` may be one
+// for eligibility probing or the complete image size for staging materialization.
+bool compute_sampled_dcc_fast_clear_rgba8(
+    const prosper::gpu::ShaderResource& resource,
+    bool ordinary_guest_backed_sampled_view,
+    bool arrayed_sampled_view,
+    bool disabled,
+    uint8_t* rgba,
+    size_t texel_count,
+    const uint8_t* metadata,
+    size_t metadata_bytes,
+    uint8_t* clear_code = nullptr);
+
 // Keep enough persistent image residency for modern multi-pass workloads without claiming an
 // unreasonable share of small discrete GPUs. The 512 MiB historical floor remains appropriate for
 // a 4 GiB heap, while larger devices contribute one eighth of their local heap up to 2 GiB. An

--- a/prosper/tests/test_game_compute.cpp
+++ b/prosper/tests/test_game_compute.cpp
@@ -143,6 +143,104 @@ int main() {
     CHECK(half_range_x4_matches,
           "packed RGBA binary16 sampled range matches every scalar lookup value");
 
+    // Compute's ordinary guest-backed 2D RGBA16F sampled path uses an RGBA8 staging image. A
+    // uniform embedded DCC clear is authoritative over the compressed base allocation, so prove
+    // that the narrow fast-clear gate produces exactly the same sampled bytes as an explicitly
+    // materialized uncompressed FP16 image. DCC_CLEAR_0001 is especially important: its alpha-one
+    // value is absent from a zero-filled compressed base and is consumed by Plucky's composite.
+    {
+        constexpr uint32_t clear_width = 64;
+        constexpr size_t clear_texels = clear_width;
+        ShaderResource clear_resource{};
+        clear_resource.cls = ResourceClass::Texture;
+        clear_resource.format = DataFormat::Float16;
+        clear_resource.num_components = 4;
+        clear_resource.img_dim = 1;
+        clear_resource.width = clear_width;
+        clear_resource.height = clear_resource.depth = 1;
+        clear_resource.tile_mode = static_cast<uint32_t>(TileMode::Sw64KbRX);
+        clear_resource.size = static_cast<uint32_t>(
+            tiled_surface_bytes(clear_width, 1, clear_resource.tile_mode, 0, 8));
+        clear_resource.compression_enabled = true;
+        clear_resource.meta_pipe_aligned = true;
+        clear_resource.alpha_is_on_msb = true;
+        clear_resource.metadata_addr = 0x301758d000ull;
+        const size_t clear_metadata_bytes = gpu_capture_dcc_metadata_footprint(clear_resource);
+        std::vector<uint8_t> clear_metadata(clear_metadata_bytes, 0x40);
+        std::vector<uint8_t> clear_rgba(clear_texels * 4, 0xa5);
+        uint8_t clear_code = 0;
+        CHECK(clear_metadata_bytes &&
+              prosper::frontend::compute_sampled_dcc_fast_clear_rgba8(
+                  clear_resource, true, false, false, clear_rgba.data(), clear_texels,
+                  clear_metadata.data(), clear_metadata.size(), &clear_code) &&
+              clear_code == 0x40,
+              "compute recognizes a complete uniform RGBA16F DCC_CLEAR_0001 plane");
+
+        std::vector<uint8_t> explicit_fp16(clear_texels * 8, 0);
+        const uint16_t half_one = float_to_half(1.0f);
+        for (size_t texel = 0; texel < clear_texels; ++texel)
+            std::memcpy(explicit_fp16.data() + texel * 8 + 6,
+                        &half_one, sizeof(half_one));
+        std::vector<uint8_t> explicit_rgba(clear_texels * 4, 0);
+        prosper::frontend::sampled_float16_to_unorm8_range(
+            explicit_fp16.data(), 4, clear_texels, explicit_rgba.data());
+        CHECK(clear_rgba == explicit_rgba,
+              "DCC_CLEAR_0001 matches explicitly materialized FP16 (0,0,0,1)");
+        bool clear_channels_match = true;
+        for (size_t texel = 0; texel < clear_texels; ++texel)
+            clear_channels_match &= clear_rgba[texel * 4 + 0] == 0 &&
+                                    clear_rgba[texel * 4 + 1] == 0 &&
+                                    clear_rgba[texel * 4 + 2] == 0 &&
+                                    clear_rgba[texel * 4 + 3] == 255;
+        CHECK(clear_channels_match,
+              "MSB alpha placement preserves the DCC alpha-one sampled channel");
+
+        ShaderResource lsb_alpha = clear_resource;
+        lsb_alpha.alpha_is_on_msb = false;
+        uint8_t lsb_pixel[4]{};
+        CHECK(prosper::frontend::compute_sampled_dcc_fast_clear_rgba8(
+                  lsb_alpha, true, false, false, lsb_pixel, 1,
+                  clear_metadata.data(), clear_metadata.size()) &&
+              std::vector<uint8_t>(lsb_pixel, lsb_pixel + 4) ==
+                  std::vector<uint8_t>({255, 0, 0, 0}),
+              "LSB alpha placement routes DCC_CLEAR_0001 to component zero");
+
+        std::vector<uint8_t> rejected = clear_metadata;
+        rejected.back() = 0x00;
+        uint8_t rejected_pixel[4]{};
+        CHECK(!prosper::frontend::compute_sampled_dcc_fast_clear_rgba8(
+                  clear_resource, true, false, false, rejected_pixel, 1,
+                  rejected.data(), rejected.size()) &&
+              !prosper::frontend::compute_sampled_dcc_fast_clear_rgba8(
+                  clear_resource, true, false, false, rejected_pixel, 1,
+                  clear_metadata.data(), clear_metadata.size() - 1) &&
+              !prosper::frontend::compute_sampled_dcc_fast_clear_rgba8(
+                  clear_resource, false, false, false, rejected_pixel, 1,
+                  clear_metadata.data(), clear_metadata.size()) &&
+              !prosper::frontend::compute_sampled_dcc_fast_clear_rgba8(
+                  clear_resource, true, true, false, rejected_pixel, 1,
+                  clear_metadata.data(), clear_metadata.size()) &&
+              !prosper::frontend::compute_sampled_dcc_fast_clear_rgba8(
+                  clear_resource, true, false, true, rejected_pixel, 1,
+                  clear_metadata.data(), clear_metadata.size()),
+              "mixed, incomplete, non-guest, arrayed, and rollback DCC states retain the old path");
+        std::fill(rejected.begin(), rejected.end(), 0xff);
+        ShaderResource wrong_shape = clear_resource;
+        wrong_shape.declared_mip_levels = 2;
+        ShaderResource wrong_format = clear_resource;
+        wrong_format.format = DataFormat::Unorm8;
+        CHECK(!prosper::frontend::compute_sampled_dcc_fast_clear_rgba8(
+                  clear_resource, true, false, false, rejected_pixel, 1,
+                  rejected.data(), rejected.size()) &&
+              !prosper::frontend::compute_sampled_dcc_fast_clear_rgba8(
+                  wrong_shape, true, false, false, rejected_pixel, 1,
+                  clear_metadata.data(), clear_metadata.size()) &&
+              !prosper::frontend::compute_sampled_dcc_fast_clear_rgba8(
+                  wrong_format, true, false, false, rejected_pixel, 1,
+                  clear_metadata.data(), clear_metadata.size()),
+              "uncompressed metadata, mip chains, and non-FP16 views fail closed");
+    }
+
     std::vector<uint32_t> half_storage_x4(65536u);
     prosper::frontend::storage_unpack_float16x4_range(
         half_source_x4.data(), 65536u / 4u, half_storage_x4.data());
@@ -1251,6 +1349,102 @@ int main() {
     // DCC-enabled storage destination atomically becomes the uncompressed (0xff) metadata state,
     // including replay-owned metadata that a later sampled descriptor shares by logical address.
     const uint32_t dcc_tile = static_cast<uint32_t>(TileMode::Sw64KbRX);
+
+    // The production sampled-image path must agree with a semantic uncompressed reference, not with
+    // the old compressed-base fallback. A zero base plus DCC_CLEAR_0001 logically contains
+    // FP16 (0,0,0,1); copy both representations through the same generated shader and require the
+    // resulting guest RGBA8 storage bytes and hashes to match exactly.
+    {
+        const size_t clear_source_bytes = tiled_surface_bytes(W, 1, dcc_tile, 0, 8);
+        const size_t clear_metadata_bytes =
+            gfx10_dcc_metadata_bytes(W, 1, 1, dcc_tile, 8, true);
+        std::vector<uint8_t> compressed_base(clear_source_bytes, 0);
+        std::vector<uint8_t> clear_metadata(clear_metadata_bytes, 0x40);
+        std::vector<uint8_t> reference_linear(W * 8, 0);
+        const uint16_t one = float_to_half(1.0f);
+        for (uint32_t texel = 0; texel < W; ++texel)
+            std::memcpy(reference_linear.data() + texel * 8 + 6, &one, sizeof(one));
+        std::vector<uint8_t> reference_tiled(clear_source_bytes, 0);
+        tile_surface(reference_tiled.data(), reference_linear.data(), W, 1,
+                     dcc_tile, 0, 8);
+        std::vector<uint8_t> clear_dst(W * 4, 0xa5);
+        std::vector<uint8_t> reference_dst(W * 4, 0x5a);
+
+        auto sampled_clear_table = [&](std::vector<uint8_t>& source,
+                                       std::vector<uint8_t>& destination,
+                                       bool compressed) {
+            ShaderResourceTable table = irt;
+            for (ShaderResource& resource : table.resources) {
+                if (resource.binding != 4 && resource.binding != 5) continue;
+                resource.img_dim = 1;
+                resource.width = W;
+                resource.height = resource.depth = 1;
+                resource.declared_mip_levels = 1;
+                resource.in_mip_tail = false;
+                resource.layer_stride_bytes = resource.layer_mip_offset_bytes = 0;
+                if (resource.binding == 4) {
+                    resource.cls = ResourceClass::Texture;
+                    resource.format = DataFormat::Float16;
+                    resource.num_components = 4;
+                    resource.tile_mode = dcc_tile;
+                    resource.gpu_addr = reinterpret_cast<uint64_t>(source.data());
+                    resource.size = static_cast<uint32_t>(source.size());
+                    resource.swizzle[0] = 4;
+                    resource.swizzle[1] = 5;
+                    resource.swizzle[2] = 6;
+                    resource.swizzle[3] = 7;
+                    resource.compression_enabled = compressed;
+                    resource.meta_pipe_aligned = compressed;
+                    resource.alpha_is_on_msb = compressed;
+                    resource.metadata_addr = compressed ? 0x301758d000ull : 0;
+                    resource.dcc_metadata_size = compressed ? clear_metadata.size() : 0;
+                    resource.dcc_metadata_host_data = compressed ? clear_metadata.data() : nullptr;
+                    resource.dcc_metadata_host_data_size = compressed ? clear_metadata.size() : 0;
+                } else {
+                    resource.cls = ResourceClass::StorageImage;
+                    resource.format = DataFormat::Unorm8;
+                    resource.num_components = 4;
+                    resource.tile_mode = 0;
+                    resource.gpu_addr = reinterpret_cast<uint64_t>(destination.data());
+                    resource.size = static_cast<uint32_t>(destination.size());
+                }
+            }
+            return table;
+        };
+        ShaderResourceTable clear_rt = sampled_clear_table(
+            compressed_base, clear_dst, true);
+        ShaderResourceTable reference_rt = sampled_clear_table(
+            reference_tiled, reference_dst, false);
+        const std::vector<uint32_t> clear_spirv = recompile_valu(
+            image_copy_2d, std::size(image_copy_2d), 1, 0, &clear_rt);
+        CHECK(!clear_spirv.empty(),
+              "sampled DCC fast-clear semantic-reference kernel recompiles");
+        auto run_clear = [&](ShaderResourceTable& table, uint64_t code_addr) {
+            if (clear_spirv.empty()) return false;
+            ComputeItem item;
+            item.spirv = clear_spirv;
+            item.resources = std::make_shared<ShaderResourceTable>(table);
+            item.launch.threads_x = W;
+            item.launch.local_x = 64;
+            item.launch.groups_x = 1;
+            item.launch.local_y = item.launch.local_z = 1;
+            item.launch.groups_y = item.launch.groups_z = 1;
+            item.code_addr = code_addr;
+            return prosper::frontend::execute_live_compute_items({item});
+        };
+        const bool clear_ok = run_clear(clear_rt, 0x301758d1) &&
+                              run_clear(reference_rt, 0x301758d2);
+        std::vector<uint8_t> expected(W * 4, 0);
+        for (uint32_t texel = 0; texel < W; ++texel) expected[texel * 4 + 3] = 255;
+        const uint64_t clear_hash = gpu_capture_hash(clear_dst.data(), clear_dst.size());
+        const uint64_t reference_hash =
+            gpu_capture_hash(reference_dst.data(), reference_dst.size());
+        const uint64_t expected_hash = gpu_capture_hash(expected.data(), expected.size());
+        CHECK(clear_ok && clear_dst == reference_dst && clear_dst == expected &&
+                  clear_hash == reference_hash && clear_hash == expected_hash,
+              "sampled DCC clear output matches explicit uncompressed FP16 (0,0,0,1)");
+    }
+
     const size_t tiled_bytes = tiled_surface_bytes(W, 1, dcc_tile, 0, 4);
     const size_t metadata_bytes = gfx10_dcc_metadata_bytes(W, 1, 1, dcc_tile, 4, true);
     std::vector<uint8_t> tiled_src(tiled_bytes, 0), tiled_dst(tiled_bytes, 0);


### PR DESCRIPTION
## Summary

- materialize authoritative uniform GFX10 DCC fast-clears directly into the existing RGBA8 sampled-image staging path
- avoid reading, detiling, and half-to-UNORM conversion of meaningless compressed base bytes
- keep the optimization generic and fail-closed: ordinary guest-backed single-level non-arrayed 2D Float16x4 sampled views only
- reject mixed, incomplete, unrecognized, mip, layer, array, imported, renderer-owned, and rollback states
- add semantic-reference and production-backend coverage for alpha/channel placement and rejection behavior

Advances the Plucky Squire compute path tracked in #1390.

## Root cause and correctness impact

The dominant 0x301758 sampled input has a complete uniform DCC 0x40 fast-clear plane. That metadata represents logical FP16 (0,0,0,1), while the compressed base bytes are not authoritative. The previous compute fallback ignored non-0xff DCC metadata, detiled/converted zero base bytes, and therefore supplied alpha zero. The new path reuses the existing GFX10 fast-clear decoder and preserves the same guest-visible RGBA8 Vulkan image.

A production semantic-reference test compares the compressed fast-clear form against an explicitly tiled uncompressed FP16 (0,0,0,1) image; both produce exact output hash 72b4bd4f97d64d83. One-call retained traces are fault-free and give identical binding-21 before/after hashes in control and candidate arms.

## Isolated performance evidence

Exact compute[20] capture, 221 calls per arm, first 20 discarded, n=201 retained, persistent compute images disabled identically so every sample exercises cold preparation. Only the rollback switch differs. Metrics are isolated cold-path upper bounds, not live FPS claims.

| Metric | Control p50 / p95 | Candidate p50 / p95 | Change |
| --- | ---: | ---: | ---: |
| setup | 12.30 / 13.49 ms | 5.11 / 5.43 ms | -58.5% / -59.7% |
| binding 15 prepare | 7.922 / 9.058 ms | 0.955 / 0.983 ms | -87.9% / -89.1% |
| dispatch | 2.46 / 2.67 ms | 2.42 / 2.63 ms | about -1.6% |
| writeback | 2.91 / 3.22 ms | 2.75 / 2.95 ms | -5.5% / -8.4% |
| total | 17.69 / 18.98 ms | 10.32 / 10.86 ms | -41.7% / -42.8% |

Harness wall time fell from 5.25s to 3.65s. Both arms completed 221/221 calls with zero compute faults or rejections.

## Validation

- distrobox build: test_game_compute, gpu_replay, prosper-app PASS
- test_game_compute PASS, including explicit FP16 semantic reference and array/mip/metadata rejection gates
- filtered production trace selects sampled DCC fast-clear code 0x40
- final normal 225s Plucky route reaches title, play-style menu, MainLevel, and both target shaders with no Vulkan/device/compute/pipeline fault
- progression matches control; the later known black world-map/loading view remains unchanged
- git diff --check: clean

## Visual documentation

No compatibility screenshot is added. The live route introduces no new visible milestone: existing title/menu output remains correct and the later world-map view remains the known black screen with a small book icon. This PR is a correctness and compute-cost improvement, not a claimed gameplay-visual advance.