### PR TITLE
gpu: execute Astro Bot world-map BVH compute

### DIFF
--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -243,6 +243,21 @@ std::vector<SrtUse> add_compute_buffer_resources(ShaderResourceTable& table,
                                                  uint32_t linear_threads_x = 0,
                                                  uint32_t tgid_x_sgpr = UINT32_MAX);
 
+// Apply the exact dispatch-scoped resource-path specialization used by the live compute executor.
+// The report makes the production decision observable to tests and diagnostics: callers can verify
+// which raw PCs disappeared and which instruction-scoped resources were removed before translation.
+// A proven-null marker is retained even after its fetch disappears because recompile_compute repeats
+// the same proof from raw shader bytes; dropping that marker would silently undo the specialization.
+struct ComputeResourcePathSpecializationReport {
+    size_t proven_null_exits = 0;
+    size_t shader_constant_branches = 0;
+    size_t removed_resources = 0;
+    std::vector<uint32_t> removed_pcs;
+};
+ComputeResourcePathSpecializationReport specialize_compute_resource_paths(
+    std::vector<Rdna2Inst>& instructions, ShaderResourceTable& resources,
+    uint32_t wave_size);
+
 // The dynamic descriptor fold and shader-cache key builder both walk immutable shader instructions
 // on every draw. Cache only the decoded instructions, validating the complete consumed byte range on
 // every hit. Concrete SGPR values and descriptor-table memory remain per-draw inputs to the fold.

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -4121,8 +4121,9 @@ std::vector<ComputeItem> realize_compute_dispatches(
             rdna2_walk(reinterpret_cast<const uint32_t*>(static_cast<uintptr_t>(code_addr)),
                        shader_dwords, decoded);
             // Keep dispatch-scoped resource discovery and translation on the same specialized
-            // instruction stream. A proven-null BVH can collapse only the exact no-hit loop exit;
-            // after that, shader-byte constant folding may remove the now-unreachable loop arm.
+            // instruction stream. A proven-null BVH can collapse only the exact no-hit exit and a
+            // fully matched empty-stack traversal cycle; shader-byte constant folding may then
+            // remove any remaining unreachable arm.
             // Drop only instruction-scoped resources whose consumers disappeared. Direct resources
             // (fetch_pc == UINT32_MAX) remain available to every surviving use of their SGPR/SRT key.
             std::vector<Rdna2Inst> resource_paths = decoded;

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -32,6 +32,7 @@
 #include <thread>
 #include <vector>
 #include <unordered_map>
+#include <unordered_set>
 #ifdef _WIN32
 #include <windows.h>
 #else
@@ -3899,6 +3900,9 @@ std::vector<ComputeItem> realize_compute_dispatches(
         auto field = [&](uint32_t shift, uint32_t mask) { return (rsrc2 >> shift) & mask; };
         const uint32_t user_count = field(P::COMPUTE_PGM_RSRC2_USER_SGPR_SHIFT,
                                           P::COMPUTE_PGM_RSRC2_USER_SGPR_MASK);
+        const uint32_t compute_wave_size = ((dispatch.modifier >>
+            P::COMPUTE_DISPATCH_INITIATOR_CS_W32_EN_SHIFT) &
+            P::COMPUTE_DISPATCH_INITIATOR_CS_W32_EN_MASK) ? 32u : 64u;
         const ComputeLaunchDimensions launch = resolve_compute_launch(dispatch);
         const bool tgid_x_en = field(P::COMPUTE_PGM_RSRC2_TGID_X_EN_SHIFT,
                                      P::COMPUTE_PGM_RSRC2_TGID_X_EN_MASK) != 0;
@@ -4111,12 +4115,30 @@ std::vector<ComputeItem> realize_compute_dispatches(
                                  fl.load_pc, fl.base_sgpr, (unsigned long long)base, w.size);
             }
         }
-        assign_convention_bindings(*table, 2);
         bool native_multiwave_wave_work = false;
         {
             std::vector<Rdna2Inst> decoded;
             rdna2_walk(reinterpret_cast<const uint32_t*>(static_cast<uintptr_t>(code_addr)),
                        shader_dwords, decoded);
+            // Keep dispatch-scoped resource discovery and translation on the same specialized
+            // instruction stream. A proven-null BVH can collapse only the exact no-hit loop exit;
+            // after that, shader-byte constant folding may remove the now-unreachable loop arm.
+            // Drop only instruction-scoped resources whose consumers disappeared. Direct resources
+            // (fetch_pc == UINT32_MAX) remain available to every surviving use of their SGPR/SRT key.
+            std::vector<Rdna2Inst> resource_paths = decoded;
+            if (rdna2_specialize_proven_null_bvh_paths(
+                    resource_paths, table.get(), compute_wave_size)) {
+                (void)rdna2_specialize_shader_constant_branches(resource_paths);
+                std::unordered_set<uint32_t> live_pcs;
+                live_pcs.reserve(resource_paths.size());
+                for (const Rdna2Inst& instruction : resource_paths)
+                    live_pcs.insert(instruction.pc);
+                std::erase_if(table->resources, [&](const ShaderResource& resource) {
+                    return resource.fetch_pc != 0xFFFFFFFFu &&
+                           !live_pcs.contains(resource.fetch_pc);
+                });
+            }
+            assign_convention_bindings(*table, 2);
             native_multiwave_wave_work = compute_shader_prefers_native_multiwave(
                 decoded, reinterpret_cast<const uint32_t*>(static_cast<uintptr_t>(code_addr)),
                 shader_dwords);
@@ -4149,9 +4171,7 @@ std::vector<ComputeItem> realize_compute_dispatches(
         config.threads_x = launch.threads_x;
         config.threads_y = launch.threads_y;
         config.threads_z = launch.threads_z;
-        config.wave_size = ((dispatch.modifier >>
-            P::COMPUTE_DISPATCH_INITIATOR_CS_W32_EN_SHIFT) &
-            P::COMPUTE_DISPATCH_INITIATOR_CS_W32_EN_MASK) ? 32u : 64u;
+        config.wave_size = compute_wave_size;
         const SharedVulkanContext shared_vulkan = shared_vulkan_context();
         const bool shared_compute_adoptable = shared_vulkan.valid() &&
             shared_vulkan.compute_queue_supported &&

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -366,7 +366,9 @@ ShaderCache& shader_cache() {
 struct DecodedShader {
     std::vector<uint32_t> code;
     std::vector<Rdna2Inst> instructions;
+    std::vector<Rdna2Inst> shader_constant_instructions;
     size_t source_dwords = 0;
+    bool shader_constant_specialized = false;
     bool terminated = false;
     uint64_t bytes = 0;
 };
@@ -588,43 +590,56 @@ std::shared_ptr<const DecodedShader> decode_shader_cached(const uint32_t* code, 
                     scalar_spill_vgprs.insert(instruction.src[0].value);    // v_readlane_b32
             }
         }
+        auto retain_fold_instructions = [&](const std::vector<Rdna2Inst>& source,
+                                            std::vector<Rdna2Inst>& retained) {
+            retained.reserve(source.size());
+            for (const Rdna2Inst& instruction : source) {
+                if (instruction.is_end) break;
+                const bool scalar_spill = instruction.fmt == Rdna2Format::VOP3 &&
+                                          (instruction.opcode == 0x360 || instruction.opcode == 0x361);
+                const bool vector_index_select =
+                    ((instruction.fmt == Rdna2Format::VOP3 && instruction.opcode == 0x101) ||
+                     (instruction.fmt == Rdna2Format::VOP2 && instruction.opcode == 0x01)) &&
+                    instruction.dst.kind == OperandKind::VGPR &&
+                    fetch_vaddr_vgprs.contains(instruction.dst.value);
+                // Index provenance begins at the hardware ABI VGPRs and is killed by any later shader
+                // computation of a register used as VADDR. Keep only writes to actual fetch-address
+                // registers; retaining every VALU instruction would make the otherwise-small scalar fold
+                // walk large UE shaders in full. This is what distinguishes DQ's first v5=vertex_id fetch
+                // from its later v5=3*vertex_id+1 packed-attribute fetch.
+                const bool fetch_vaddr_write = instruction.dst.kind == OperandKind::VGPR &&
+                                               fetch_vaddr_vgprs.contains(instruction.dst.value);
+                const bool scalar_spill_invalidation = instruction.dst.kind == OperandKind::VGPR &&
+                                                       scalar_spill_vgprs.contains(instruction.dst.value);
+                const bool fold_format = instruction.fmt == Rdna2Format::SOP1 ||
+                                         instruction.fmt == Rdna2Format::SOP2 ||
+                                         instruction.fmt == Rdna2Format::SOPC ||
+                                         instruction.fmt == Rdna2Format::SOPK ||
+                                         instruction.fmt == Rdna2Format::SOPP ||
+                                         instruction.fmt == Rdna2Format::SMEM ||
+                                         instruction.fmt == Rdna2Format::MIMG ||
+                                         instruction.fmt == Rdna2Format::MUBUF ||
+                                         instruction.fmt == Rdna2Format::MTBUF;
+                if (fold_format || scalar_spill || vector_index_select || fetch_vaddr_write ||
+                    scalar_spill_invalidation || instruction.dst.kind == OperandKind::SGPR)
+                    retained.push_back(instruction);
+            }
+        };
         // Retain only instructions that can affect fold state or emit a descriptor use, preserving
-        // their original order and PCs.
-        result->instructions.reserve(decoded.size());
-        for (const Rdna2Inst& instruction : decoded) {
-            if (instruction.is_end) break;
-            const bool scalar_spill = instruction.fmt == Rdna2Format::VOP3 &&
-                                      (instruction.opcode == 0x360 || instruction.opcode == 0x361);
-            const bool vector_index_select =
-                ((instruction.fmt == Rdna2Format::VOP3 && instruction.opcode == 0x101) ||
-                 (instruction.fmt == Rdna2Format::VOP2 && instruction.opcode == 0x01)) &&
-                instruction.dst.kind == OperandKind::VGPR &&
-                fetch_vaddr_vgprs.contains(instruction.dst.value);
-            // Index provenance begins at the hardware ABI VGPRs and is killed by any later shader
-            // computation of a register used as VADDR. Keep only writes to actual fetch-address
-            // registers; retaining every VALU instruction would make the otherwise-small scalar fold
-            // walk large UE shaders in full. This is what distinguishes DQ's first v5=vertex_id fetch
-            // from its later v5=3*vertex_id+1 packed-attribute fetch.
-            const bool fetch_vaddr_write = instruction.dst.kind == OperandKind::VGPR &&
-                                           fetch_vaddr_vgprs.contains(instruction.dst.value);
-            const bool scalar_spill_invalidation = instruction.dst.kind == OperandKind::VGPR &&
-                                                   scalar_spill_vgprs.contains(instruction.dst.value);
-            const bool fold_format = instruction.fmt == Rdna2Format::SOP1 ||
-                                     instruction.fmt == Rdna2Format::SOP2 ||
-                                     instruction.fmt == Rdna2Format::SOPC ||
-                                     instruction.fmt == Rdna2Format::SOPK ||
-                                     instruction.fmt == Rdna2Format::SOPP ||
-                                     instruction.fmt == Rdna2Format::SMEM ||
-                                     instruction.fmt == Rdna2Format::MIMG ||
-                                     instruction.fmt == Rdna2Format::MUBUF ||
-                                     instruction.fmt == Rdna2Format::MTBUF;
-            if (fold_format || scalar_spill || vector_index_select || fetch_vaddr_write ||
-                scalar_spill_invalidation ||
-                instruction.dst.kind == OperandKind::SGPR)
-                result->instructions.push_back(instruction);
-        }
+        // their original order and PCs. Prove shader-constant branches against the FULL decoded
+        // stream first: the compact fold stream intentionally omits most VALU, including implicit
+        // VCC writers that must invalidate a scalar-data proof through s106:s107.
+        retain_fold_instructions(decoded, result->instructions);
+        std::vector<Rdna2Inst> shader_constant_decoded = decoded;
+        result->shader_constant_specialized =
+            rdna2_specialize_shader_constant_branches(shader_constant_decoded) != 0;
+        if (result->shader_constant_specialized)
+            retain_fold_instructions(shader_constant_decoded,
+                                     result->shader_constant_instructions);
         result->bytes = static_cast<uint64_t>(result->code.size()) * sizeof(uint32_t) +
-                        static_cast<uint64_t>(result->instructions.size()) * sizeof(Rdna2Inst);
+                        static_cast<uint64_t>(result->instructions.size() +
+                                              result->shader_constant_instructions.size()) *
+                            sizeof(Rdna2Inst);
         return result;
     };
 
@@ -1707,6 +1722,11 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
         }
         fold_instructions = &specialized;
     }
+    // The cache specializes the full decoded stream before compacting it for the scalar fold. A
+    // PC-relative dispatch is already a separate explicit specialization and keeps its historical
+    // filtered stream here; combining the two requires proving the selected full-stream CFG first.
+    if (fold_instructions == &decoded->instructions && decoded->shader_constant_specialized)
+        fold_instructions = &decoded->shader_constant_instructions;
     const auto& ins = *fold_instructions;
 
     auto readable = [&](uint64_t addr, uint32_t bytes) {

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -3137,6 +3137,44 @@ std::vector<SrtUse> add_compute_buffer_resources(ShaderResourceTable& table,
 
 namespace { constexpr uint32_t kPsBindingBase = 32; }
 
+// Preserve the exact resource-path proof across the decoded analysis and raw-byte translation
+// passes. Ordinary instruction-scoped resources disappear with their consumers, but the dispatch-
+// scoped null marker must survive because the raw translator independently repeats the proof.
+ComputeResourcePathSpecializationReport specialize_compute_resource_paths(
+        std::vector<Rdna2Inst>& instructions, ShaderResourceTable& resources,
+        uint32_t wave_size) {
+    ComputeResourcePathSpecializationReport report;
+    std::vector<uint32_t> original_pcs;
+    original_pcs.reserve(instructions.size());
+    for (const Rdna2Inst& instruction : instructions)
+        original_pcs.push_back(instruction.pc);
+
+    report.proven_null_exits = rdna2_specialize_proven_null_bvh_paths(
+        instructions, &resources, wave_size);
+    if (!report.proven_null_exits) return report;
+    report.shader_constant_branches =
+        rdna2_specialize_shader_constant_branches(instructions);
+
+    std::unordered_set<uint32_t> live_pcs;
+    live_pcs.reserve(instructions.size());
+    for (const Rdna2Inst& instruction : instructions)
+        live_pcs.insert(instruction.pc);
+    for (uint32_t pc : original_pcs)
+        if (!live_pcs.contains(pc)) report.removed_pcs.push_back(pc);
+
+    const size_t resources_before = resources.resources.size();
+    std::erase_if(resources.resources, [&](const ShaderResource& resource) {
+        // The raw-byte translator repeats resource-path specialization. Keep its dispatch-scoped
+        // null proof even though the marked IMAGE_BVH instruction disappeared from this analysis
+        // stream; all ordinary instruction-scoped resources can be pruned with their consumer.
+        return resource.fetch_pc != 0xFFFFFFFFu &&
+               !is_proven_null_bvh(resource) &&
+               !live_pcs.contains(resource.fetch_pc);
+    });
+    report.removed_resources = resources_before - resources.resources.size();
+    return report;
+}
+
 // Assign each resource its OWN descriptor binding, starting at `first` (0/1 reserved). The N-buffer
 // model: the shader reads several distinct constant buffers (Unity's per-draw transform, per-frame,
 // …) + vertex buffers + textures, and each must land at a separate binding so they don't collapse.
@@ -4127,17 +4165,20 @@ std::vector<ComputeItem> realize_compute_dispatches(
             // Drop only instruction-scoped resources whose consumers disappeared. Direct resources
             // (fetch_pc == UINT32_MAX) remain available to every surviving use of their SGPR/SRT key.
             std::vector<Rdna2Inst> resource_paths = decoded;
-            if (rdna2_specialize_proven_null_bvh_paths(
-                    resource_paths, table.get(), compute_wave_size)) {
-                (void)rdna2_specialize_shader_constant_branches(resource_paths);
-                std::unordered_set<uint32_t> live_pcs;
-                live_pcs.reserve(resource_paths.size());
-                for (const Rdna2Inst& instruction : resource_paths)
-                    live_pcs.insert(instruction.pc);
-                std::erase_if(table->resources, [&](const ShaderResource& resource) {
-                    return resource.fetch_pc != 0xFFFFFFFFu &&
-                           !live_pcs.contains(resource.fetch_pc);
-                });
+            const ComputeResourcePathSpecializationReport path_report =
+                specialize_compute_resource_paths(resource_paths, *table, compute_wave_size);
+            if (std::getenv("PROSPER_DBG") && path_report.proven_null_exits) {
+                std::fprintf(stderr,
+                             "[compute-resource-specialization] code=0x%llx null-exits=%zu constants=%zu "
+                             "removed-resources=%zu removed-pcs=",
+                             static_cast<unsigned long long>(code_addr),
+                             path_report.proven_null_exits,
+                             path_report.shader_constant_branches,
+                             path_report.removed_resources);
+                for (size_t index = 0; index < path_report.removed_pcs.size(); ++index)
+                    std::fprintf(stderr, "%s%u", index ? "," : "",
+                                 path_report.removed_pcs[index]);
+                std::fprintf(stderr, "\n");
             }
             assign_convention_bindings(*table, 2);
             native_multiwave_wave_work = compute_shader_prefers_native_multiwave(
@@ -4250,7 +4291,9 @@ std::vector<ComputeItem> realize_compute_dispatches(
             if (getenv("PROSPER_DYNTRACE_FAIL")) {
                 static std::set<uint64_t> traced_cs;
                 if (traced_cs.insert(code_addr).second) {
-                    std::fprintf(stderr, "[dynfail] replaying COMPUTE 0x%llx resource build with trace:\n",
+                    std::fprintf(stderr,
+                                 "[dynfail] replaying PRE-SPECIALIZATION raw COMPUTE 0x%llx "
+                                 "resource build with trace:\n",
                                  (unsigned long long)code_addr);
                     std::fprintf(stderr, "[dynfail]   compute user-data SGPRs (s0..s%u):\n", kUserSgprs - 1);
                     std::fprintf(stderr,
@@ -4269,7 +4312,9 @@ std::vector<ComputeItem> realize_compute_dispatches(
                     resolve_dynamic_fetch((const uint32_t*)(uintptr_t)code_addr, shader_dwords,
                                           sgprs, kUserSgprs, 0, &cs_uses);
                     g_dyntrace_force = false;
-                    std::fprintf(stderr, "[dynfail]   const-fold recovered %zu descriptor use(s):\n",
+                    std::fprintf(stderr,
+                                 "[dynfail]   pre-specialization raw const-fold recovered %zu "
+                                 "descriptor use(s):\n",
                                  cs_uses.size());
                     for (const auto& u : cs_uses) {
                         if (u.kind == 0) {

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -4892,9 +4892,9 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // idioms that wave64 shaders express with s_mov_b64.  A wave mask is one bool in this
             // per-invocation model, so preserve that bool domain when either source is an
             // unambiguous low-half mask or EXEC_LO is the destination.  VCC_LO remains available as
-            // ordinary scalar scratch when its source is ordinary data, matching the data path
-            // below.  High-half moves remain unsupported: without the guest wave mode they may name
-            // another lane rather than this invocation's bit.
+            // ordinary scalar scratch; when that scalar dword is copied back to EXEC_LO, select this
+            // invocation's bit from the complete Wave32 value.  High-half moves remain unsupported:
+            // without the guest wave mode they may name another lane rather than this invocation's bit.
             if (b.allow_b32_masks && in.opcode == 0x03) {   // s_mov_b32 (mask-domain form)
                 const auto data_value_present = [&](int reg) {
                     return rs.sreg.contains(reg) || rs.sreg_input.contains(reg);
@@ -4909,7 +4909,26 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     rs.sreg_bool_b32.contains(in.src[0].value) &&
                     !data_value_present(in.src[0].value);
                 const bool dst_exec_lo = in.dst.value == 126;
+                uint32_t scalar_mask_data = 0;
+                bool src_scalar_data = false;
+                if (dst_exec_lo &&
+                    (in.src[0].kind == OperandKind::SGPR ||
+                     (in.src[0].kind == OperandKind::Special &&
+                      in.src[0].value >= 106 && in.src[0].value <= 124))) {
+                    auto current = rs.sreg.find(in.src[0].value);
+                    if (current != rs.sreg.end()) {
+                        scalar_mask_data = current->second;
+                        src_scalar_data = true;
+                    } else {
+                        auto input = rs.sreg_input.find(in.src[0].value);
+                        if (input != rs.sreg_input.end()) {
+                            scalar_mask_data = input->second;
+                            src_scalar_data = true;
+                        }
+                    }
+                }
                 const bool mask_move = src_exec_lo || src_vcc_lo || src_saved_mask ||
+                    src_scalar_data ||
                     (dst_exec_lo && in.src[0].kind == OperandKind::InlineInt);
                 if (mask_move) {
                     uint32_t mask = 0;
@@ -4925,6 +4944,14 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                         mask = saved->second;
                         auto state = rs.sreg_bool_narrowed.find(in.src[0].value);
                         narrowed = state == rs.sreg_bool_narrowed.end() || state->second;
+                    } else if (src_scalar_data) {
+                        const uint32_t lane = b.ibin(
+                            Op_BitwiseAnd, b.guest_lane_id(), b.uconst(31));
+                        const uint32_t bit = b.ibin(
+                            Op_BitwiseAnd,
+                            b.ibin(Op_ShiftRightLogical, scalar_mask_data, lane),
+                            b.uconst(1));
+                        mask = b.ucmp(Op_INotEqual, bit, b.uconst(0));
                     } else if (in.src[0].value == -1) {
                         mask = b.btrue();
                         narrowed = false;
@@ -10022,6 +10049,52 @@ bool shader_constant_compare(const std::vector<Rdna2Inst>& ins, size_t block_fir
     return true;
 }
 
+bool scalar_cfg_branch(const Rdna2Inst& in) {
+    return in.fmt == Rdna2Format::SOPP &&
+        (in.opcode == 0x02 || (in.opcode >= 0x04 && in.opcode <= 0x09));
+}
+
+void prune_scalar_cfg_reachability(std::vector<Rdna2Inst>& ins) {
+    if (ins.empty()) return;
+    std::unordered_map<uint32_t, size_t> index_by_pc;
+    for (size_t i = 0; i < ins.size(); ++i) index_by_pc.emplace(ins[i].pc, i);
+
+    std::vector<bool> reachable(ins.size(), false);
+    std::vector<size_t> pending{0};
+    while (!pending.empty()) {
+        const size_t i = pending.back();
+        pending.pop_back();
+        if (i >= ins.size() || reachable[i]) continue;
+        reachable[i] = true;
+        const Rdna2Inst& in = ins[i];
+        if (in.is_end || (in.fmt == Rdna2Format::SOPP && in.opcode == 0x12)) continue;
+        if (scalar_cfg_branch(in)) {
+            const auto target = index_by_pc.find(scalar_branch_target(in));
+            if (target != index_by_pc.end()) pending.push_back(target->second);
+            if (in.opcode == 0x02) continue;
+        }
+        if (i + 1 < ins.size()) pending.push_back(i + 1);
+    }
+
+    std::vector<Rdna2Inst> retained;
+    retained.reserve(ins.size());
+    for (size_t i = 0; i < ins.size(); ++i)
+        if (reachable[i]) retained.push_back(ins[i]);
+    // Once a taken branch's omitted arm is gone, its target is often the next retained instruction.
+    // Turn that now-redundant edge into a no-op so the ordinary straight-line/structured paths do not
+    // need to reconstruct an empty branch region.
+    for (size_t i = 0; i + 1 < retained.size(); ++i) {
+        Rdna2Inst& in = retained[i];
+        if (in.fmt == Rdna2Format::SOPP && in.opcode == 0x02 &&
+            scalar_branch_target(in) == retained[i + 1].pc) {
+            in.opcode = 0x00;
+            in.simm16 = 0;
+            in.words[0] = 0xbf800000u;
+        }
+    }
+    ins = std::move(retained);
+}
+
 size_t specialize_shader_constant_branches(std::vector<Rdna2Inst>& ins) {
     if (ins.empty()) return 0;
     // An indirect PC transfer can enter code outside the explicit SOPP graph. Keep the whole shader
@@ -10035,17 +10108,13 @@ size_t specialize_shader_constant_branches(std::vector<Rdna2Inst>& ins) {
     for (size_t i = 0; i < ins.size(); ++i) index_by_pc.emplace(ins[i].pc, i);
 
     std::set<size_t> block_starts{0};
-    auto is_branch = [](const Rdna2Inst& in) {
-        return in.fmt == Rdna2Format::SOPP &&
-            (in.opcode == 0x02 || (in.opcode >= 0x04 && in.opcode <= 0x09));
-    };
     for (size_t i = 0; i < ins.size(); ++i) {
         const Rdna2Inst& in = ins[i];
-        if (is_branch(in)) {
+        if (scalar_cfg_branch(in)) {
             const auto target = index_by_pc.find(scalar_branch_target(in));
             if (target != index_by_pc.end()) block_starts.insert(target->second);
         }
-        if ((is_branch(in) || in.is_end ||
+        if ((scalar_cfg_branch(in) || in.is_end ||
              (in.fmt == Rdna2Format::SOPP && in.opcode == 0x12)) &&
             i + 1 < ins.size())
             block_starts.insert(i + 1);
@@ -10085,41 +10154,76 @@ size_t specialize_shader_constant_branches(std::vector<Rdna2Inst>& ins) {
     // Entry-rooted reachability after replacing proven conditions. Unknown conditional branches
     // retain both successors, so an unresolved resource remains in the instruction stream whenever
     // any runtime path can execute it.
-    std::vector<bool> reachable(ins.size(), false);
-    std::vector<size_t> pending{0};
-    while (!pending.empty()) {
-        const size_t i = pending.back();
-        pending.pop_back();
-        if (i >= ins.size() || reachable[i]) continue;
-        reachable[i] = true;
-        const Rdna2Inst& in = ins[i];
-        if (in.is_end || (in.fmt == Rdna2Format::SOPP && in.opcode == 0x12)) continue;
-        if (is_branch(in)) {
-            const auto target = index_by_pc.find(scalar_branch_target(in));
-            if (target != index_by_pc.end()) pending.push_back(target->second);
-            if (in.opcode == 0x02) continue;
-        }
-        if (i + 1 < ins.size()) pending.push_back(i + 1);
-    }
-
-    std::vector<Rdna2Inst> retained;
-    retained.reserve(ins.size());
-    for (size_t i = 0; i < ins.size(); ++i)
-        if (reachable[i]) retained.push_back(ins[i]);
-    // Once a taken branch's omitted arm is gone, its target is often the next retained instruction.
-    // Turn that now-redundant edge into a no-op so the ordinary straight-line/structured paths do not
-    // need to reconstruct an empty branch region.
-    for (size_t i = 0; i + 1 < retained.size(); ++i) {
-        Rdna2Inst& in = retained[i];
-        if (in.fmt == Rdna2Format::SOPP && in.opcode == 0x02 &&
-            scalar_branch_target(in) == retained[i + 1].pc) {
-            in.opcode = 0x00;
-            in.simm16 = 0;
-            in.words[0] = 0xbf800000u;
-        }
-    }
-    ins = std::move(retained);
+    prune_scalar_cfg_reachability(ins);
     return specialized_count;
+}
+
+size_t specialize_proven_null_bvh_exits(std::vector<Rdna2Inst>& ins,
+                                        const ShaderResourceTable* rt,
+                                        uint32_t wave_size) {
+    if (!rt || wave_size != 32 || ins.empty()) return 0;
+    std::unordered_map<uint32_t, size_t> index_by_pc;
+    for (size_t i = 0; i < ins.size(); ++i) index_by_pc.emplace(ins[i].pc, i);
+
+    size_t specialized = 0;
+    for (const ShaderResource& resource : rt->resources) {
+        if (!is_proven_null_bvh(resource)) continue;
+        const auto found = index_by_pc.find(resource.fetch_pc);
+        if (found == index_by_pc.end()) continue;
+        const size_t ray_index = found->second;
+        if (ray_index + 5 >= ins.size()) continue;
+        const Rdna2Inst& ray = ins[ray_index];
+        const Rdna2Inst& wait = ins[ray_index + 1];
+        const Rdna2Inst& compare = ins[ray_index + 2];
+        const Rdna2Inst& scalar_compare = ins[ray_index + 3];
+        const Rdna2Inst& exec_copy = ins[ray_index + 4];
+        Rdna2Inst& exit = ins[ray_index + 5];
+
+        // Exact Wave32 no-hit idiom:
+        //   image_bvh_intersect_ray vN..vN+3, NULL_BVH
+        //   s_waitcnt ...
+        //   v_cmp_ne_u32 sM, -1, vN
+        //   s_cmp_lg_u32 0, sM
+        //   s_mov_b32 exec_lo, vcc_lo
+        //   s_cbranch_scc0 EXIT
+        // The null lowering writes -1 to every ray result for each active lane. The saved compare
+        // mask is therefore exactly zero, making SCC zero and the exit unconditional. Requiring the
+        // explicit one-word mask form and Wave32 avoids assuming anything about an unobserved high
+        // mask half. Adjacency and exact register links prevent a nearby unrelated compare from
+        // proving the branch.
+        const bool ray_shape = ray.fmt == Rdna2Format::MIMG && ray.opcode == 0xe6u &&
+            ray.mimg_dmask == 0xfu && ray.dst.kind == OperandKind::VGPR;
+        const bool wait_shape = wait.pc == ray.pc + ray.len_dwords &&
+            wait.fmt == Rdna2Format::SOPP && wait.opcode == 0x0cu &&
+            wait.words[0] == 0xbf8c3f70u; // s_waitcnt vmcnt(0)
+        const bool compare_shape = compare.pc == wait.pc + wait.len_dwords &&
+            compare.fmt == Rdna2Format::VOPC && compare.opcode == 0xc5u &&
+            compare.dst.kind == OperandKind::SGPR && compare.dst.value <= 105 &&
+            compare.src[0].kind == OperandKind::InlineInt && compare.src[0].value == -1 &&
+            compare.src[1].kind == OperandKind::VGPR && compare.src[1].value == ray.dst.value;
+        const bool scalar_shape = scalar_compare.pc == compare.pc + compare.len_dwords &&
+            scalar_compare.fmt == Rdna2Format::SOPC && scalar_compare.opcode == 0x07u &&
+            scalar_compare.src[0].kind == OperandKind::InlineInt &&
+            scalar_compare.src[0].value == 0 &&
+            scalar_compare.src[1].kind == OperandKind::SGPR &&
+            scalar_compare.src[1].value == compare.dst.value;
+        const bool copy_shape = exec_copy.pc == scalar_compare.pc + scalar_compare.len_dwords &&
+            exec_copy.fmt == Rdna2Format::SOP1 && exec_copy.opcode == 0x03u &&
+            exec_copy.dst.kind == OperandKind::SGPR && exec_copy.dst.value == 126 &&
+            exec_copy.src[0].kind == OperandKind::Special && exec_copy.src[0].value == 106;
+        const bool exit_shape = exit.pc == exec_copy.pc + exec_copy.len_dwords &&
+            exit.fmt == Rdna2Format::SOPP && exit.opcode == 0x04u && exit.simm16 > 0 &&
+            index_by_pc.contains(scalar_branch_target(exit));
+        if (!ray_shape || !wait_shape || !compare_shape || !scalar_shape || !copy_shape ||
+            !exit_shape)
+            continue;
+
+        exit.opcode = 0x02;
+        exit.words[0] = 0xbf820000u | static_cast<uint16_t>(exit.simm16);
+        ++specialized;
+    }
+    if (specialized) prune_scalar_cfg_reachability(ins);
+    return specialized;
 }
 
 } // namespace
@@ -10133,6 +10237,12 @@ bool rdna2_specialize_pcrel_dispatch(std::vector<Rdna2Inst>& instructions,
 size_t rdna2_specialize_shader_constant_branches(
         std::vector<Rdna2Inst>& instructions) {
     return specialize_shader_constant_branches(instructions);
+}
+
+size_t rdna2_specialize_proven_null_bvh_paths(
+        std::vector<Rdna2Inst>& instructions, const ShaderResourceTable* resources,
+        uint32_t wave_size) {
+    return specialize_proven_null_bvh_exits(instructions, resources, wave_size);
 }
 
 PcrelDispatchInfo rdna2_pcrel_dispatch_info(const uint32_t* code, size_t dwords) {
@@ -12789,6 +12899,10 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
                                         const ComputeShaderConfig& config) {
     std::vector<Rdna2Inst> ins;
     rdna2_walk(code, dwords, ins);
+    // A dispatch-scoped proven-null BVH can collapse the exact no-hit loop exit before generic
+    // shader-byte constant folding. Resource identity (including null marker + fetch PC) is already
+    // part of the compute module cache key, so a later non-null dispatch receives a distinct module.
+    (void)rdna2_specialize_proven_null_bvh_paths(ins, rt, config.wave_size);
     (void)rdna2_specialize_shader_constant_branches(ins);
     // See recompile_valu: compute has no branch-external EXP state, so the common host-shell merge is
     // only a place to finish the invocation after either guest arm has terminated.

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -10218,6 +10218,146 @@ size_t specialize_proven_null_bvh_exits(std::vector<Rdna2Inst>& ins,
             !exit_shape)
             continue;
 
+        // Some compiler-generated traversal loops enter with an empty scalar stack, visit one
+        // root ray, then pop work written by that ray.  When the dispatch-scoped root is proven
+        // null, the exact no-hit branch above reaches the empty-stack test without writing the
+        // depth.  That makes the pop/back-edge arm unreachable, which in turn proves that the
+        // loop-selected ray sites cannot seed themselves.  Keep this deliberately narrower than
+        // ordinary scalar constant propagation: every entry, register relationship, and branch on
+        // the first path must match the observed stack idiom.
+        auto specialize_empty_stack = [&]() {
+            const uint32_t null_exit_pc = scalar_branch_target(exit);
+            const auto tail_found = index_by_pc.find(null_exit_pc);
+            if (tail_found == index_by_pc.end() || tail_found->second + 1 >= ins.size())
+                return false;
+            const size_t tail_index = tail_found->second;
+            const Rdna2Inst& stack_compare = ins[tail_index];
+            Rdna2Inst& stack_exit = ins[tail_index + 1];
+            if (stack_compare.fmt != Rdna2Format::SOPC || stack_compare.opcode != 0x07u ||
+                stack_compare.src[0].kind != OperandKind::InlineInt ||
+                stack_compare.src[0].value != 0 ||
+                stack_compare.src[1].kind != OperandKind::SGPR ||
+                stack_compare.src[1].value != 45 ||
+                stack_exit.pc != stack_compare.pc + stack_compare.len_dwords ||
+                stack_exit.fmt != Rdna2Format::SOPP || stack_exit.opcode != 0x04u ||
+                stack_exit.simm16 <= 0 ||
+                !index_by_pc.contains(scalar_branch_target(stack_exit)))
+                return false;
+            const uint32_t stack_exit_pc = scalar_branch_target(stack_exit);
+
+            // The first-iteration selector branch targets the block that initializes all four
+            // ray results to invalid before the guarded root query.  Requiring this complete
+            // eight-instruction prefix prevents a nearby null ray from being mistaken for the
+            // traversal root that owns the scalar stack below.
+            if (ray_index < 8) return false;
+            const size_t root_block = ray_index - 8;
+            for (uint32_t lane = 0; lane < 4; ++lane) {
+                const Rdna2Inst& init = ins[root_block + lane];
+                if (init.fmt != Rdna2Format::VOP1 || init.opcode != 0x01u ||
+                    init.dst.kind != OperandKind::VGPR ||
+                    init.dst.value != ray.dst.value + static_cast<int>(lane) ||
+                    init.src[0].kind != OperandKind::InlineInt || init.src[0].value != -1)
+                    return false;
+            }
+            const Rdna2Inst& mask_copy = ins[root_block + 4];
+            const Rdna2Inst& empty_guard = ins[root_block + 5];
+            const Rdna2Inst& root_index = ins[root_block + 6];
+            const Rdna2Inst& root_nop = ins[root_block + 7];
+            if (mask_copy.fmt != Rdna2Format::SOP1 || mask_copy.opcode != 0x3cu ||
+                mask_copy.dst.kind != OperandKind::SGPR || mask_copy.dst.value != 106 ||
+                mask_copy.src[0].kind != OperandKind::Special ||
+                mask_copy.src[0].value != 107 ||
+                empty_guard.fmt != Rdna2Format::SOPP || empty_guard.opcode != 0x08u ||
+                scalar_branch_target(empty_guard) != scalar_compare.pc ||
+                root_index.fmt != Rdna2Format::VOP1 || root_index.opcode != 0x01u ||
+                root_index.dst.kind != OperandKind::VGPR ||
+                root_index.dst.value != ray.dst.value ||
+                root_index.src[0].kind != OperandKind::SGPR ||
+                root_nop.fmt != Rdna2Format::SOPP || root_nop.opcode != 0x00u)
+                return false;
+
+            size_t selector_branch_index = SIZE_MAX;
+            size_t selector_init_index = SIZE_MAX;
+            bool selector_scc = false;
+            for (size_t i = root_block; i-- > 2;) {
+                const Rdna2Inst& branch = ins[i];
+                if (branch.fmt != Rdna2Format::SOPP || branch.opcode != 0x05u ||
+                    scalar_branch_target(branch) != ins[root_block].pc ||
+                    ins[i - 1].pc + ins[i - 1].len_dwords != branch.pc ||
+                    ins[i - 1].fmt != Rdna2Format::SOPC)
+                    continue;
+                for (size_t j = i - 1; j-- > 1;) {
+                    const Rdna2Inst& selector_init = ins[j];
+                    const Rdna2Inst& stack_init = ins[j - 1];
+                    if (stack_init.pc + stack_init.len_dwords != selector_init.pc ||
+                        stack_init.fmt != Rdna2Format::SOP1 || stack_init.opcode != 0x03u ||
+                        stack_init.dst.kind != OperandKind::SGPR || stack_init.dst.value != 45 ||
+                        stack_init.src[0].kind != OperandKind::InlineInt ||
+                        stack_init.src[0].value != 0 ||
+                        selector_init.fmt != Rdna2Format::SOP1 ||
+                        selector_init.opcode != 0x03u ||
+                        selector_init.dst.kind != OperandKind::SGPR ||
+                        selector_init.src[0].kind != OperandKind::InlineInt ||
+                        selector_init.src[0].value != 37 ||
+                        root_index.src[0].value != selector_init.dst.value)
+                        continue;
+                    bool has_branch = false;
+                    for (size_t k = j; k < i; ++k)
+                        has_branch |= scalar_cfg_branch(ins[k]);
+                    if (has_branch ||
+                        !shader_constant_compare(ins, j, i - 1, selector_scc) ||
+                        !selector_scc)
+                        continue;
+                    selector_branch_index = i;
+                    selector_init_index = j;
+                    break;
+                }
+                if (selector_branch_index != SIZE_MAX) break;
+            }
+            if (selector_branch_index == SIZE_MAX) return false;
+
+            auto writes_stack = [&](const Rdna2Inst& instruction) {
+                bool writes = false;
+                for_each_scalar_write(instruction, [&](int base, uint32_t width) {
+                    writes |= base <= 45 && 45 < base + static_cast<int>(width);
+                }, /*proven_wave32_masks*/true);
+                return writes;
+            };
+            // Only the selector setup, root/no-hit block, and empty-stack comparison are reachable
+            // before the proven exits.  None may alter the initialized stack depth.
+            for (size_t i = selector_init_index; i <= selector_branch_index; ++i)
+                if (writes_stack(ins[i])) return false;
+            for (size_t i = root_block; i <= ray_index + 5; ++i)
+                if (writes_stack(ins[i])) return false;
+            if (writes_stack(stack_compare)) return false;
+
+            const uint32_t proof_begin = ins[selector_init_index - 1].pc;
+            // An indirect transfer or an external edge into the middle of the proof could bypass
+            // the zero initializer.  Re-entry at the initializer itself is harmless: it resets the
+            // invariant before the selector is evaluated again.
+            for (const Rdna2Inst& instruction : ins) {
+                if (instruction.fmt == Rdna2Format::SOP1 &&
+                    instruction.opcode >= 0x20u && instruction.opcode <= 0x22u)
+                    return false;
+                if (!scalar_cfg_branch(instruction)) continue;
+                const uint32_t target = scalar_branch_target(instruction);
+                const bool source_inside = instruction.pc >= proof_begin &&
+                    instruction.pc < stack_exit_pc;
+                if (!source_inside && target > proof_begin && target < stack_exit_pc)
+                    return false;
+            }
+
+            Rdna2Inst& selector_branch = ins[selector_branch_index];
+            selector_branch.opcode = 0x02u;
+            selector_branch.words[0] = 0xbf820000u |
+                static_cast<uint16_t>(selector_branch.simm16);
+            stack_exit.opcode = 0x02u;
+            stack_exit.words[0] = 0xbf820000u |
+                static_cast<uint16_t>(stack_exit.simm16);
+            return true;
+        };
+
+        (void)specialize_empty_stack();
         exit.opcode = 0x02;
         exit.words[0] = 0xbf820000u | static_cast<uint16_t>(exit.simm16);
         ++specialized;
@@ -12899,9 +13039,10 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
                                         const ComputeShaderConfig& config) {
     std::vector<Rdna2Inst> ins;
     rdna2_walk(code, dwords, ins);
-    // A dispatch-scoped proven-null BVH can collapse the exact no-hit loop exit before generic
-    // shader-byte constant folding. Resource identity (including null marker + fetch PC) is already
-    // part of the compute module cache key, so a later non-null dispatch receives a distinct module.
+    // A dispatch-scoped proven-null BVH can collapse an exact no-hit exit and fully matched empty-stack
+    // traversal cycle before generic shader-byte constant folding. Resource identity (including null
+    // marker + fetch PC) is already part of the compute module cache key, so a later non-null dispatch
+    // receives a distinct module.
     (void)rdna2_specialize_proven_null_bvh_paths(ins, rt, config.wave_size);
     (void)rdna2_specialize_shader_constant_branches(ins);
     // See recompile_valu: compute has no branch-external EXP state, so the common host-shell merge is

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -9923,12 +9923,216 @@ bool specialize_pcrel_dispatch(std::vector<Rdna2Inst>& ins, const PcrelDispatchI
     return true;
 }
 
+struct ShaderConstantValue {
+    bool known = false;
+    uint32_t value = 0;
+};
+
+ShaderConstantValue shader_constant_operand(
+        const std::vector<Rdna2Inst>& ins, size_t block_first, size_t use_index,
+        const Rdna2Inst& use, const Operand& operand, uint32_t depth) {
+    if (depth > 16) return {};
+    if (operand.kind == OperandKind::InlineInt)
+        return {true, static_cast<uint32_t>(operand.value)};
+    if (operand.kind == OperandKind::Literal)
+        return use.has_literal ? ShaderConstantValue{true, use.literal} : ShaderConstantValue{};
+    if (operand.kind != OperandKind::SGPR && operand.kind != OperandKind::Special)
+        return {};
+
+    const int reg = operand.value;
+    for (size_t i = use_index; i-- > block_first;) {
+        const Rdna2Inst& writer = ins[i];
+        // VCC_LO/HI can temporarily hold ordinary scalar data, as in Astro's exact branch setup,
+        // but any intervening vector ALU may replace the architectural VCC pair implicitly. The
+        // shared scalar-writer inventory intentionally models that in the Bool domain, so reject it
+        // explicitly here instead of walking past a VOPC to an obsolete scalar definition.
+        if ((reg == 106 || reg == 107) &&
+            (writer.fmt == Rdna2Format::VOP1 || writer.fmt == Rdna2Format::VOP2 ||
+             writer.fmt == Rdna2Format::VOPC || writer.fmt == Rdna2Format::VOP3 ||
+             writer.fmt == Rdna2Format::VOP3P))
+            return {};
+        bool writes = false;
+        uint32_t width = 0;
+        int base = -1;
+        for_each_scalar_write(writer, [&](int candidate_base, uint32_t candidate_width) {
+            if (reg >= candidate_base &&
+                reg < candidate_base + static_cast<int>(candidate_width)) {
+                writes = true;
+                base = candidate_base;
+                width = candidate_width;
+            }
+        });
+        if (!writes) continue;
+
+        // Only one-dword pure scalar data writers participate. A pair write, memory result, lane
+        // read, or wave-mask producer is intentionally not a shader-constant proof.
+        if (base != reg || width != 1) return {};
+        if (writer.fmt == Rdna2Format::SOP1 && writer.opcode == 0x03) { // s_mov_b32
+            return shader_constant_operand(
+                ins, block_first, i, writer, writer.src[0], depth + 1);
+        }
+        if (writer.fmt != Rdna2Format::SOP2) return {};
+
+        const ShaderConstantValue lhs = shader_constant_operand(
+            ins, block_first, i, writer, writer.src[0], depth + 1);
+        const ShaderConstantValue rhs = shader_constant_operand(
+            ins, block_first, i, writer, writer.src[1], depth + 1);
+        if (!lhs.known || !rhs.known) return {};
+
+        switch (writer.opcode) {
+            case 0x00: return {true, lhs.value + rhs.value}; // s_add_u32
+            case 0x01: return {true, lhs.value - rhs.value}; // s_sub_u32
+            case 0x02: return {true, lhs.value + rhs.value}; // s_add_i32
+            case 0x03: return {true, lhs.value - rhs.value}; // s_sub_i32
+            case 0x0e: return {true, lhs.value & rhs.value}; // s_and_b32
+            default: return {};
+        }
+    }
+    // No in-block writer means an entry/user SGPR or other runtime state. Never specialize it.
+    return {};
+}
+
+bool shader_constant_compare(const std::vector<Rdna2Inst>& ins, size_t block_first,
+                             size_t compare_index, bool& result) {
+    const Rdna2Inst& compare = ins[compare_index];
+    if (compare.fmt != Rdna2Format::SOPC || compare.opcode > 0x0b) return false;
+    const ShaderConstantValue lhs = shader_constant_operand(
+        ins, block_first, compare_index, compare, compare.src[0], 0);
+    const ShaderConstantValue rhs = shader_constant_operand(
+        ins, block_first, compare_index, compare, compare.src[1], 0);
+    if (!lhs.known || !rhs.known) return false;
+    const int32_t signed_lhs = std::bit_cast<int32_t>(lhs.value);
+    const int32_t signed_rhs = std::bit_cast<int32_t>(rhs.value);
+
+    switch (compare.opcode) {
+        case 0x00: result = signed_lhs == signed_rhs; break;
+        case 0x01: result = signed_lhs != signed_rhs; break;
+        case 0x02: result = signed_lhs >  signed_rhs; break;
+        case 0x03: result = signed_lhs >= signed_rhs; break;
+        case 0x04: result = signed_lhs <  signed_rhs; break;
+        case 0x05: result = signed_lhs <= signed_rhs; break;
+        case 0x06: result = lhs.value == rhs.value; break;
+        case 0x07: result = lhs.value != rhs.value; break;
+        case 0x08: result = lhs.value >  rhs.value; break;
+        case 0x09: result = lhs.value >= rhs.value; break;
+        case 0x0a: result = lhs.value <  rhs.value; break;
+        case 0x0b: result = lhs.value <= rhs.value; break;
+        default: return false;
+    }
+    return true;
+}
+
+size_t specialize_shader_constant_branches(std::vector<Rdna2Inst>& ins) {
+    if (ins.empty()) return 0;
+    // An indirect PC transfer can enter code outside the explicit SOPP graph. Keep the whole shader
+    // unspecialized rather than treating its lexical successor as the only possible destination.
+    if (std::any_of(ins.begin(), ins.end(), [](const Rdna2Inst& in) {
+            return in.fmt == Rdna2Format::SOP1 &&
+                   in.opcode >= 0x20 && in.opcode <= 0x22;
+        })) return 0;
+
+    std::unordered_map<uint32_t, size_t> index_by_pc;
+    for (size_t i = 0; i < ins.size(); ++i) index_by_pc.emplace(ins[i].pc, i);
+
+    std::set<size_t> block_starts{0};
+    auto is_branch = [](const Rdna2Inst& in) {
+        return in.fmt == Rdna2Format::SOPP &&
+            (in.opcode == 0x02 || (in.opcode >= 0x04 && in.opcode <= 0x09));
+    };
+    for (size_t i = 0; i < ins.size(); ++i) {
+        const Rdna2Inst& in = ins[i];
+        if (is_branch(in)) {
+            const auto target = index_by_pc.find(scalar_branch_target(in));
+            if (target != index_by_pc.end()) block_starts.insert(target->second);
+        }
+        if ((is_branch(in) || in.is_end ||
+             (in.fmt == Rdna2Format::SOPP && in.opcode == 0x12)) &&
+            i + 1 < ins.size())
+            block_starts.insert(i + 1);
+    }
+
+    size_t specialized_count = 0;
+    for (size_t i = 1; i < ins.size(); ++i) {
+        Rdna2Inst& branch = ins[i];
+        if (branch.fmt != Rdna2Format::SOPP ||
+            (branch.opcode != 0x04 && branch.opcode != 0x05) || branch.simm16 <= 0)
+            continue; // shader-constant SCC only; VCCZ/EXECZ remain runtime wave conditions
+        if (!index_by_pc.contains(scalar_branch_target(branch)))
+            continue; // do not specialize an exit beyond the decoded instruction graph
+        const Rdna2Inst& compare = ins[i - 1];
+        if (compare.pc + compare.len_dwords != branch.pc ||
+            compare.fmt != Rdna2Format::SOPC)
+            continue;
+        const auto block = block_starts.upper_bound(i - 1);
+        const size_t block_first = block == block_starts.begin() ? 0 : *std::prev(block);
+        if (block_first > i - 1) continue;
+
+        bool scc = false;
+        if (!shader_constant_compare(ins, block_first, i - 1, scc)) continue;
+        const bool taken = branch.opcode == 0x05 ? scc : !scc;
+        if (taken) {
+            branch.opcode = 0x02; // s_branch: retain the exact immediate target
+            branch.words[0] = 0xbf820000u | static_cast<uint16_t>(branch.simm16);
+        } else {
+            branch.opcode = 0x00; // s_nop 0: retain fallthrough
+            branch.simm16 = 0;
+            branch.words[0] = 0xbf800000u;
+        }
+        ++specialized_count;
+    }
+    if (!specialized_count) return 0;
+
+    // Entry-rooted reachability after replacing proven conditions. Unknown conditional branches
+    // retain both successors, so an unresolved resource remains in the instruction stream whenever
+    // any runtime path can execute it.
+    std::vector<bool> reachable(ins.size(), false);
+    std::vector<size_t> pending{0};
+    while (!pending.empty()) {
+        const size_t i = pending.back();
+        pending.pop_back();
+        if (i >= ins.size() || reachable[i]) continue;
+        reachable[i] = true;
+        const Rdna2Inst& in = ins[i];
+        if (in.is_end || (in.fmt == Rdna2Format::SOPP && in.opcode == 0x12)) continue;
+        if (is_branch(in)) {
+            const auto target = index_by_pc.find(scalar_branch_target(in));
+            if (target != index_by_pc.end()) pending.push_back(target->second);
+            if (in.opcode == 0x02) continue;
+        }
+        if (i + 1 < ins.size()) pending.push_back(i + 1);
+    }
+
+    std::vector<Rdna2Inst> retained;
+    retained.reserve(ins.size());
+    for (size_t i = 0; i < ins.size(); ++i)
+        if (reachable[i]) retained.push_back(ins[i]);
+    // Once a taken branch's omitted arm is gone, its target is often the next retained instruction.
+    // Turn that now-redundant edge into a no-op so the ordinary straight-line/structured paths do not
+    // need to reconstruct an empty branch region.
+    for (size_t i = 0; i + 1 < retained.size(); ++i) {
+        Rdna2Inst& in = retained[i];
+        if (in.fmt == Rdna2Format::SOPP && in.opcode == 0x02 &&
+            scalar_branch_target(in) == retained[i + 1].pc) {
+            in.opcode = 0x00;
+            in.simm16 = 0;
+            in.words[0] = 0xbf800000u;
+        }
+    }
+    ins = std::move(retained);
+    return specialized_count;
+}
+
 } // namespace
 
 bool rdna2_specialize_pcrel_dispatch(std::vector<Rdna2Inst>& instructions,
                                      const PcrelDispatchInfo& info,
                                      uint32_t selected_target) {
     return specialize_pcrel_dispatch(instructions, info, selected_target);
+}
+
+size_t rdna2_specialize_shader_constant_branches(
+        std::vector<Rdna2Inst>& instructions) {
+    return specialize_shader_constant_branches(instructions);
 }
 
 PcrelDispatchInfo rdna2_pcrel_dispatch_info(const uint32_t* code, size_t dwords) {
@@ -12585,6 +12789,7 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
                                         const ComputeShaderConfig& config) {
     std::vector<Rdna2Inst> ins;
     rdna2_walk(code, dwords, ins);
+    (void)rdna2_specialize_shader_constant_branches(ins);
     // See recompile_valu: compute has no branch-external EXP state, so the common host-shell merge is
     // only a place to finish the invocation after either guest arm has terminated.
     (void)extend_terminating_if_else(code, dwords, ins);

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -5920,6 +5920,24 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                         b.ibin(Op_BitwiseAnd,
                                b.ibin(Op_ShiftRightLogical, result, bit), b.uconst(1)),
                         b.uconst(0));
+                    if (b.wave_size == 32) {
+                        // A complete scalar write covers every architectural bit of VCC_LO in
+                        // Wave32, so it establishes a fresh predicate without needing the old VCC
+                        // lifetime. VCC_HI is ordinary scratch outside the 32-lane mask and cannot
+                        // affect the implicit VCC condition at all. This distinction matters for
+                        // generated kernels that load scalar data into LO, derive a flag in HI, and
+                        // compare both as uints before creating their next vector predicate.
+                        if (writes_hi) {
+                            rs.sreg_bool.erase(107);
+                            rs.sreg_bool_narrowed.erase(107);
+                            rs.sreg_bool_b32.erase(107);
+                        } else {
+                            rs.vcc = result_bit;
+                            rs.sreg_bool[106] = result_bit;
+                            rs.sreg_bool_narrowed[106] = true;
+                        }
+                        return true;
+                    }
                     if (!rs.vcc) { ok = false; return true; }
                     rs.vcc = b.bsel(in_written_half, result_bit, rs.vcc);
                     rs.sreg_bool[in.dst.value] = rs.vcc;
@@ -7660,7 +7678,17 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 vreg[in.dst.value] = fresult(b.sel(anyz, zb, b.fbin(Op_FMul, s0b, s1b)));
             } else if (in.opcode == 0x101) {                          // v_cndmask_b32_e64: src2_mask ? src1 : src0
                 const Operand& s2 = in.src[2]; uint32_t m = 0;        // src2 is an SGPR-pair (or VCC) wave mask
-                if (s2.value == 106 || s2.value == 107) m = rs.vcc;
+                if (s2.value == 106 || s2.value == 107) {
+                    // Wave32 e64/SDWA forms may explicitly select either physical VCC word as an
+                    // independent one-dword mask. Prefer that typed lifetime when present. Only
+                    // VCC_LO may fall back to the architectural implicit predicate; VCC_HI is a
+                    // distinct word in Wave32 and must have its own proven mask lifetime.
+                    auto it = rs.sreg_bool.find(s2.value);
+                    if (rs.sreg_bool_b32.contains(s2.value) && it != rs.sreg_bool.end())
+                        m = it->second;
+                    else if (s2.value == 106)
+                        m = rs.vcc;
+                }
                 else if (s2.kind == OperandKind::SGPR) {
                     auto it = rs.sreg_bool.find(s2.value);
                     if (it != rs.sreg_bool.end()) {
@@ -10432,7 +10460,8 @@ bool emit_cfg_state_machine(
     const bool graphics = b.is_fragment || b.is_vertex;
     auto reject_cfg = [&](uint32_t pc, const char* reason) {
         if (getenv("PROSPER_DBG"))
-            std::fprintf(stderr, "[graphics-cfg-reject] pc=%u reason=%s\n", pc, reason);
+            std::fprintf(stderr, "[%s-cfg-reject] pc=%u reason=%s\n",
+                         b.is_compute ? "compute" : "graphics", pc, reason);
         return false;
     };
     if ((!b.is_compute && !graphics) || ins.empty()) return false;
@@ -10758,7 +10787,37 @@ bool emit_cfg_state_machine(
     if (b.allow_b32_masks && !starts.empty()) {
         b32_mask_in.front().insert(
             initial.sreg_bool_b32.begin(), initial.sreg_bool_b32.end());
+        // `vcc` is the implicit VCC_LO mask even when no instruction has needed an explicit
+        // sreg_bool[106] alias yet. Preserve that valid entry lifetime in the same physical-domain
+        // analysis as explicit Wave32 masks. A zero SSA id instead means the caller currently has
+        // ordinary scalar data in the VCC words, so it deliberately does not seed the mask domain.
+        if (initial.vcc) b32_mask_in.front().insert(106);
         b32_mask_reachable.front() = true;
+        auto implicit_vcc_mask_source = [](const Rdna2Inst& in) -> int {
+            if (in.fmt == Rdna2Format::SOPP &&
+                (in.opcode == 0x06 || in.opcode == 0x07))
+                return 106; // s_cbranch_vccz/nz
+            if (in.fmt == Rdna2Format::VOP2 &&
+                (in.opcode == 0x01 ||
+                 (in.opcode >= 0x28 && in.opcode <= 0x2a)))
+                return 106; // e32 cndmask and carry-in/out forms use implicit VCC
+            if (in.fmt == Rdna2Format::VOP3 &&
+                (in.opcode == 0x101 ||
+                 (in.opcode >= 0x128 && in.opcode <= 0x12a))) {
+                const Operand& mask = in.src[2];
+                if ((mask.kind == OperandKind::SGPR || mask.kind == OperandKind::Special) &&
+                    (mask.value == 106 || mask.value == 107))
+                    return mask.value;
+            }
+            if (in.fmt == Rdna2Format::VOP3 &&
+                (in.opcode == 0x365 || in.opcode == 0x366)) {
+                const Operand& mask = in.src[0];
+                if ((mask.kind == OperandKind::SGPR || mask.kind == OperandKind::Special) &&
+                    (mask.value == 106 || mask.value == 107))
+                    return mask.value;
+            }
+            return -1;
+        };
         std::vector<uint32_t> pending{0};
         while (!pending.empty()) {
             const uint32_t block = pending.back();
@@ -10769,6 +10828,21 @@ bool emit_cfg_state_machine(
             const uint32_t hi = block + 1 < starts.size() ? starts[block + 1] : UINT32_MAX;
             for (const auto& in : ins) {
                 if (in.pc < lo || in.pc >= hi || in.is_end) continue;
+
+                // The dispatcher may use a false backing value for a physical VCC lifetime that is
+                // provably dead. Do not let that implementation placeholder become observable: every
+                // instruction whose ISA encoding requires a VCC mask must see one on all incoming
+                // paths. Explicit SGPR operands remain governed by the data/mask-domain checks below.
+                const int implicit_vcc = implicit_vcc_mask_source(in);
+                if (implicit_vcc >= 0 &&
+                    (!masks.contains(implicit_vcc) || ambiguous.contains(implicit_vcc))) {
+                    if (getenv("PROSPER_DBG"))
+                        std::fprintf(stderr,
+                                     "[%s-cfg-reject] pc=%u "
+                                     "reason=missing-wave32-vcc-mask\n",
+                                     b.is_compute ? "compute" : "graphics", in.pc);
+                    return false;
+                }
 
                 bool reads_ambiguous = false;
                 for (uint32_t source = 0; source < in.n_src; ++source) {
@@ -10784,8 +10858,9 @@ bool emit_cfg_state_machine(
                 if (reads_ambiguous) {
                     if (getenv("PROSPER_DBG"))
                         std::fprintf(stderr,
-                                     "[graphics-cfg-reject] pc=%u reason=wave32-ambiguous-mask-read\n",
-                                     in.pc);
+                                     "[%s-cfg-reject] pc=%u "
+                                     "reason=wave32-ambiguous-mask-read\n",
+                                     b.is_compute ? "compute" : "graphics", in.pc);
                     return false;
                 }
 
@@ -11126,9 +11201,13 @@ bool emit_cfg_state_machine(
     }
     b.store_function(scc_var, initial.scc ? initial.scc : no);
     // The dispatcher has no runtime type tag for a physical VCC word recycled as scalar data.
-    // Keep that unsupported join fail-visible instead of persisting an invented false mask.
-    if (!initial.vcc) return false;
-    b.store_function(vcc_var, initial.vcc);
+    // Wave32's compile-time mask-domain analysis above proves whether each implicit VCC consumer
+    // sees a real mask. It is therefore safe to persist false while that lifetime is absent/dead;
+    // load_state keeps the placeholder out of RegState on those entries. Other modes retain the
+    // old fail-visible contract because they have no equivalent proof.
+    if (!initial.vcc && !proven_wave32_masks)
+        return reject_cfg(ins.front().pc, "missing-entry-vcc");
+    b.store_function(vcc_var, initial.vcc ? initial.vcc : no);
     b.store_function(exec_var, initial.exec);
     b.store_function(pc_var, b.uconst(0));
     b.store_function(active_var, yes);
@@ -11164,7 +11243,8 @@ bool emit_cfg_state_machine(
             state.vgpr_lane_mask_slots[kv.first.first][kv.first.second] =
                 b.load_function(b.t_bool, kv.second);
         state.scc = b.load_function(b.t_bool, scc_var);
-        state.vcc = b.load_function(b.t_bool, vcc_var);
+        state.vcc = (!entry_b32 || entry_b32->contains(106))
+            ? b.load_function(b.t_bool, vcc_var) : 0;
         state.exec = b.load_function(b.t_bool, exec_var);
         if (entry_b32) {
             for (int reg : *entry_b32) {
@@ -11227,7 +11307,7 @@ bool emit_cfg_state_machine(
         // A poisoned (0) SCC degrades to bfalse at the block boundary: the same-block consumers
         // reject on the sentinel; cross-block staleness matches the pre-poison model.
         b.store_function(scc_var, state.scc ? state.scc : b.bfalse());
-        b.store_function(vcc_var, state.vcc);
+        b.store_function(vcc_var, state.vcc ? state.vcc : no);
         b.store_function(exec_var, state.exec);
     };
 
@@ -11516,8 +11596,6 @@ bool emit_cfg_state_machine(
                 b.store_function(vote_to_scc_var, yes);
             }
         }
-        if (!state.vcc)
-            return reject_cfg(starts[final_block], "poisoned-vcc-boundary");
         save_state(state, dispatch);
         if (mbcnt) {
             if (!set_next(mbcnt->pc + mbcnt->len_dwords))
@@ -11941,6 +12019,17 @@ bool emit_cfg_state_machine(
     // Expose the final emulated state to the caller. Graphics exports are emitted in their exact
     // cases, while any post-body bookkeeping still sees this invocation's final register values.
     initial = load_state();
+    if (proven_wave32_masks) {
+        const auto end_block = block_for_pc.find(end_pc);
+        if (end_block != block_for_pc.end() &&
+            (!b32_mask_reachable[end_block->second] ||
+             !b32_mask_in[end_block->second].contains(106))) {
+            initial.vcc = 0;
+            initial.sreg_bool.erase(106);
+            initial.sreg_bool_narrowed.erase(106);
+            initial.sreg_bool_b32.erase(106);
+        }
+    }
     return true;
 }
 
@@ -12078,17 +12167,31 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
 
             size_t phase_begin = phased.guard_index + 1;
             for (size_t barrier_index : phased.barriers) {
-                const std::vector<Rdna2Inst> phase(
+                std::vector<Rdna2Inst> phase(
                     ins.begin() + phase_begin, ins.begin() + barrier_index);
                 if (!phase.empty()) {
+                    // A phase is a complete control-flow region even though the guest's real
+                    // S_ENDPGM follows the final phase. The arbitrary-CFG fallback requires an end
+                    // block so its persistent dispatcher can become inactive and rejoin this outer
+                    // barrier sequence. Give each proven split a synthetic, emitter-only terminator
+                    // at the boundary; no branch crosses the boundary (proved above), and the raw
+                    // barrier remains emitted exactly once by this outer shell.
+                    Rdna2Inst phase_end;
+                    phase_end.pc = ins[barrier_index].pc;
+                    phase_end.fmt = Rdna2Format::SOPP;
+                    phase_end.opcode = 0x01u;
+                    phase_end.len_dwords = 1;
+                    phase_end.is_end = true;
+                    phase.push_back(phase_end);
                     if (getenv("PROSPER_DBG"))
                         std::fprintf(stderr, "[compute-phase] begin=%u end=%u barrier=%u\n",
-                                     phase.front().pc, phase.back().pc, ins[barrier_index].pc);
+                                     phase.front().pc, phase[phase.size() - 2].pc,
+                                     ins[barrier_index].pc);
                     if (!emit_body(b, rs, phase, safe, rt, allow_exec_update, allow_smem,
                                    exp_fn, code, dwords, &dead_masks)) {
                         if (getenv("PROSPER_DBG"))
                             std::fprintf(stderr, "[compute-phase-reject] begin=%u end=%u\n",
-                                         phase.front().pc, phase.back().pc);
+                                         phase.front().pc, phase[phase.size() - 2].pc);
                         return false;
                     }
                 }
@@ -12816,13 +12919,30 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                 // mask bits to the architecture's wave-wide "any lane active" predicate.
                 // A poisoned SCC (0: last written by a 64-bit mask op) cannot condition a real
                 // structured if — reject (the ISA-audit #879 stale-SCC consumer).
-                if (!F.on_exec && !F.on_vcc && !rs.scc) return false;
-                if (F.on_vcc && !rs.vcc) return false;
+                if (!F.on_exec && !F.on_vcc && !rs.scc) {
+                    if (getenv("PROSPER_DBG"))
+                        std::fprintf(stderr,
+                                     "[compute-struct-reject] poisoned SCC at branch pc=%u\n",
+                                     F.branch_pc);
+                    return false;
+                }
+                if (F.on_vcc && !rs.vcc) {
+                    if (getenv("PROSPER_DBG"))
+                        std::fprintf(stderr,
+                                     "[compute-struct-reject] missing VCC at branch pc=%u\n",
+                                     F.branch_pc);
+                    return false;
+                }
                 // Compute VCC/EXEC branches normally return through the exact guest-wave dispatcher.
                 // The narrow structured-wave path above accepts only top-level vote sites, where all
                 // workgroup invocations may participate in the scratch barriers uniformly.
-                if (b.is_compute && (F.on_exec || F.on_vcc) && !structured_compute_wave_cfg)
+                if (b.is_compute && (F.on_exec || F.on_vcc) && !structured_compute_wave_cfg) {
+                    if (getenv("PROSPER_DBG"))
+                        std::fprintf(stderr,
+                                     "[compute-struct-reject] unavailable wave vote at branch pc=%u\n",
+                                     F.branch_pc);
                     return false;
+                }
                 uint32_t cond_reg = F.on_exec ? rs.exec : (F.on_vcc ? rs.vcc : rs.scc);
                 if (b.is_compute && (F.on_exec || F.on_vcc))
                     cond_reg = b.native_subgroup_size
@@ -12922,7 +13042,14 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                     // `hi` and the merge coincides with the region end.
                     uint32_t else_hi = F.merge_pc;
                     if (F.merge_pc >= hi) {
-                        if (F.merge_pc != cont && F.merge_pc != hi) return false;
+                        if (F.merge_pc != cont && F.merge_pc != hi) {
+                            if (getenv("PROSPER_DBG"))
+                                std::fprintf(stderr,
+                                             "[compute-struct-reject] escaping merge pc=%u merge=%u "
+                                             "region=%u continuation=%u\n",
+                                             F.branch_pc, F.merge_pc, hi, cont);
+                            return false;
+                        }
                         else_hi = hi;
                     }
                     const RegState pre = rs;                // FULL snapshot: the else-arm re-runs from it
@@ -12993,7 +13120,18 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
         // scalar already; EXECZ/VCCZ use fragment_wave_any), so native wave operations in any
         // structured arm observe the complete guest wave.
         wave_ok = b.is_fragment;
-        if (!emit_structured(0, UINT32_MAX, UINT32_MAX)) return false;
+        if (!emit_structured(0, UINT32_MAX, UINT32_MAX)) {
+            if (getenv("PROSPER_DBG")) {
+                const uint32_t next_pc = idx < ins.size() ? ins[idx].pc : UINT32_MAX;
+                const uint32_t next_if = bi < Fs.size() ? Fs[bi].branch_pc : UINT32_MAX;
+                const uint32_t next_loop = li < Ls.size() ? Ls[li].header_pc : UINT32_MAX;
+                std::fprintf(stderr,
+                             "[compute-struct-reject] structured emission stopped next-pc=%u "
+                             "next-if=%u next-loop=%u\n",
+                             next_pc, next_if, next_loop);
+            }
+            return false;
+        }
     }
     (void)safe_branches;
     return true;

--- a/prosper/src/gpu/rdna2_to_spirv.hpp
+++ b/prosper/src/gpu/rdna2_to_spirv.hpp
@@ -70,11 +70,11 @@ bool rdna2_specialize_pcrel_dispatch(std::vector<Rdna2Inst>& instructions,
 size_t rdna2_specialize_shader_constant_branches(
     std::vector<Rdna2Inst>& instructions);
 
-// A dispatch-scoped proven-null BVH can make the exact Wave32 no-hit loop exit unconditional. Prune
-// that resource-dependent path before shader-byte-only branch folding; the compute resource builder
-// and translator call this same helper so dead instruction-scoped descriptors cannot diverge. The
-// resource table's null marker and fetch PC are part of the module cache key. Returns the number of
-// proven exits specialized.
+// A dispatch-scoped proven-null BVH can make an exact Wave32 no-hit exit unconditional and, for the
+// fully proven empty-stack idiom, remove an unseeded traversal cycle. Prune that resource-dependent
+// path before shader-byte-only branch folding; the compute resource builder and translator call this
+// same helper so dead instruction-scoped descriptors cannot diverge. The resource table's null marker
+// and fetch PC are part of the module cache key. Returns the number of proven exits specialized.
 size_t rdna2_specialize_proven_null_bvh_paths(
     std::vector<Rdna2Inst>& instructions, const ShaderResourceTable* resources,
     uint32_t wave_size);

--- a/prosper/src/gpu/rdna2_to_spirv.hpp
+++ b/prosper/src/gpu/rdna2_to_spirv.hpp
@@ -70,6 +70,15 @@ bool rdna2_specialize_pcrel_dispatch(std::vector<Rdna2Inst>& instructions,
 size_t rdna2_specialize_shader_constant_branches(
     std::vector<Rdna2Inst>& instructions);
 
+// A dispatch-scoped proven-null BVH can make the exact Wave32 no-hit loop exit unconditional. Prune
+// that resource-dependent path before shader-byte-only branch folding; the compute resource builder
+// and translator call this same helper so dead instruction-scoped descriptors cannot diverge. The
+// resource table's null marker and fetch PC are part of the module cache key. Returns the number of
+// proven exits specialized.
+size_t rdna2_specialize_proven_null_bvh_paths(
+    std::vector<Rdna2Inst>& instructions, const ShaderResourceTable* resources,
+    uint32_t wave_size);
+
 // Return the portion of a raw shader blob that participates in recompilation. This normally ends at
 // S_ENDPGM, but compiler-generated PC-relative lookup tables may live immediately after the program and
 // must remain part of an owning/cache copy. The result never exceeds `dwords`.

--- a/prosper/src/gpu/rdna2_to_spirv.hpp
+++ b/prosper/src/gpu/rdna2_to_spirv.hpp
@@ -62,6 +62,14 @@ bool rdna2_specialize_pcrel_dispatch(std::vector<Rdna2Inst>& instructions,
                                      const PcrelDispatchInfo& info,
                                      uint32_t selected_target);
 
+// Prove scalar conditional branches whose SCC input depends only on shader-embedded integer
+// constants, then remove instructions unreachable from the shader entry. The proof deliberately
+// excludes entry/user SGPRs, memory loads, wave masks, and values crossing another basic-block
+// boundary, so specialization depends only on shader bytes already present in the compile key.
+// Returns the number of conditional branches specialized.
+size_t rdna2_specialize_shader_constant_branches(
+    std::vector<Rdna2Inst>& instructions);
+
 // Return the portion of a raw shader blob that participates in recompilation. This normally ends at
 // S_ENDPGM, but compiler-generated PC-relative lookup tables may live immediately after the program and
 // must remain part of an owning/cache copy. The result never exceeds `dwords`.

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -767,18 +767,20 @@ int main() {
                                 constant_branch_seed.data(), constant_branch_seed.size(), 0).empty(),
           "dynamic resource discovery ignores the provably dead buffer fetch");
 
-    // Exact instruction words and PCs from the live loop shape that motivated this pass. Although
-    // the first entry computes the same true condition as the straight-line fixture above, PC855 is
-    // also a loop header and the back-edge path rewrites s11 to -1. The next iteration therefore has
-    // a different SCC result. Keep this title-derived evidence deliberately minimal: only the
-    // preheader, condition, target, mutation, back-edge, and terminator needed to preserve the CFG.
+    // Exact instruction words and PCs from the live traversal loop. The loop-selected BVH sites at
+    // PC968/1007 can write work into v59/v60 and return through PC1671/1674, so shader-constant
+    // folding alone must retain them. The first entry, however, initializes s45=0 and s11=37, visits
+    // the dispatch-proven null root at PC1346, and reaches the PC1665 empty-stack exit without a
+    // write to s45. That closed cycle has no first work item and can be pruned only as one proof.
     std::vector<Rdna2Inst> loop_variant_branch;
     auto append_exact_instruction = [&](uint32_t pc, std::initializer_list<uint32_t> words) {
         Rdna2Inst instruction = rdna2_decode_one(words.begin(), words.size());
         instruction.pc = pc;
         loop_variant_branch.push_back(instruction);
     };
-    append_exact_instruction(848,  {0xBE8B03A5u}); // s_mov_b32 s11, 37 (preheader)
+    append_exact_instruction(847,  {0xBEAD0380u}); // s_mov_b32 s45, 0 (empty stack)
+    append_exact_instruction(848,  {0xBE8B03A5u}); // s_mov_b32 s11, 37 (root selector)
+    append_exact_instruction(854,  {0xBE88037Eu}); // loop header
     append_exact_instruction(855,  {0x876A870Bu}); // loop: s_and_b32 s106, s11, 7
     append_exact_instruction(856,  {0x876B087Eu});
     append_exact_instruction(857,  {0x816AC46Au}); // s_add_i32 s106, s106, -4
@@ -788,7 +790,14 @@ int main() {
                                     0x46424140u, 0x00004847u}); // unresolved loop BVH
     append_exact_instruction(1007, {0xF1989F07u, 0x00040303u, 0x43440D3Fu,
                                     0x46424140u, 0x00004847u}); // unresolved loop BVH
-    append_exact_instruction(1338, {0x7E0602C1u}); // exact taken target
+    append_exact_instruction(1338, {0x7E0602C1u}); // v3..v6 = invalid
+    append_exact_instruction(1339, {0x7E0802C1u});
+    append_exact_instruction(1340, {0x7E0A02C1u});
+    append_exact_instruction(1341, {0x7E0C02C1u});
+    append_exact_instruction(1342, {0xBEEA3C6Bu});
+    append_exact_instruction(1343, {0xBF88000Au}); // empty EXEC skips to the no-hit compare
+    append_exact_instruction(1344, {0x7E06020Bu}); // root index from s11
+    append_exact_instruction(1345, {0xBF800000u});
     append_exact_instruction(1346, {0xF1989F07u, 0x00010303u, 0x094F4E3Fu,
                                     0x11100F0Eu, 0x00001312u}); // guarded null BVH
     append_exact_instruction(1351, {0xBF8C3F70u});
@@ -798,12 +807,22 @@ int main() {
     append_exact_instruction(1356, {0xBF840133u});              // s_cbranch_scc0 1664
     append_exact_instruction(1610, {0xBE8B03C1u});              // s_mov_b32 s11, -1
     append_exact_instruction(1663, {0xBF82FCD7u});              // s_branch 855 (back-edge)
-    append_exact_instruction(1664, {0xBF072D80u});              // exact null-exit target
+    append_exact_instruction(1664, {0xBF072D80u});              // s_cmp_lg_u32 0,s45
+    append_exact_instruction(1665, {0xBF840009u});              // empty stack -> 1675
+    append_exact_instruction(1666, {0x812DC12Du});              // pop stack
+    append_exact_instruction(1667, {0xBF09A02Du});
+    append_exact_instruction(1668, {0xBF840003u});
+    append_exact_instruction(1669, {0xD760000Bu, 0x00005B3Cu}); // s11 = readlane(v60,s45)
+    append_exact_instruction(1671, {0xBF82FCCEu});              // s_branch 854
+    append_exact_instruction(1672, {0xD760000Bu, 0x00005B3Bu}); // s11 = readlane(v59,s45)
+    append_exact_instruction(1674, {0xBF82FCCBu});              // s_branch 854
+    append_exact_instruction(1675, {0x06067EFFu, 0x3A83126Fu}); // exact empty-stack target
     append_exact_instruction(3276, {0xBF810000u});              // s_endpgm
     CHECK(rdna2_specialize_shader_constant_branches(loop_variant_branch) == 0 &&
-              loop_variant_branch.size() == 19 &&
-              loop_variant_branch[5].fmt == Rdna2Format::SOPP &&
-              loop_variant_branch[5].opcode == 0x05,
+              std::any_of(loop_variant_branch.begin(), loop_variant_branch.end(),
+                          [](const Rdna2Inst& in) {
+                              return in.pc == 859 && in.opcode == 0x05;
+                          }),
           "loop-carried scalar mutation prevents one-shot SCC branch specialization");
 
     alignas(256) std::array<uint8_t, 256> loop_null_bvh{};
@@ -820,12 +839,13 @@ int main() {
     std::vector<Rdna2Inst> null_pruned_loop = loop_variant_branch;
     CHECK(rdna2_specialize_proven_null_bvh_paths(
               null_pruned_loop, &loop_null_table, 32) == 1 &&
-              rdna2_specialize_shader_constant_branches(null_pruned_loop) == 1 &&
+              rdna2_specialize_shader_constant_branches(null_pruned_loop) == 0 &&
               std::none_of(null_pruned_loop.begin(), null_pruned_loop.end(),
                            [](const Rdna2Inst& in) {
-                               return in.pc == 968 || in.pc == 1007 || in.pc == 1610 || in.pc == 1663;
+                               return in.pc == 968 || in.pc == 1007 || in.pc == 1610 ||
+                                      in.pc == 1663 || in.pc == 1671 || in.pc == 1674;
                            }),
-          "exact null-BVH exit removes loop back-edges before constant preheader pruning");
+          "exact null-root plus empty stack removes the unseeded traversal cycle");
 
     ShaderResourceTable nonnull_loop_table = loop_null_table;
     nonnull_loop_table.resources[0].gpu_addr = 0x10000u;
@@ -853,6 +873,38 @@ int main() {
                   changed, &loop_null_table, 32) == 0,
               "null-BVH exit proof rejects opcode/register/guard deviations");
     }
+
+    for (int deviation = 0; deviation < 5; ++deviation) {
+        std::vector<Rdna2Inst> changed = loop_variant_branch;
+        auto at = [&](uint32_t pc) {
+            return std::find_if(changed.begin(), changed.end(),
+                                [&](const Rdna2Inst& in) { return in.pc == pc; });
+        };
+        if (deviation == 0) at(847)->src[0].value = 1;
+        if (deviation == 1) at(1339)->dst.value = 5;
+        if (deviation == 2) at(1342)->opcode = 0x03u;
+        if (deviation == 3) at(1664)->src[1].value = 44;
+        if (deviation == 4) at(1665)->opcode = 0x05u;
+        CHECK(rdna2_specialize_proven_null_bvh_paths(
+                  changed, &loop_null_table, 32) == 1 &&
+                  std::any_of(changed.begin(), changed.end(),
+                              [](const Rdna2Inst& in) {
+                                  return in.pc == 968 || in.pc == 1007;
+                              }),
+              "empty-stack cycle proof rejects initializer/prefix/tail deviations");
+    }
+
+    std::vector<Rdna2Inst> externally_entered_loop = loop_variant_branch;
+    const std::array<uint32_t, 1> external_entry_words{0xBF820007u}; // pc846 -> pc854
+    Rdna2Inst external_entry = rdna2_decode_one(external_entry_words.data(),
+                                                external_entry_words.size());
+    external_entry.pc = 846;
+    externally_entered_loop.insert(externally_entered_loop.begin(), external_entry);
+    CHECK(rdna2_specialize_proven_null_bvh_paths(
+              externally_entered_loop, &loop_null_table, 32) == 1 &&
+              std::any_of(externally_entered_loop.begin(), externally_entered_loop.end(),
+                          [](const Rdna2Inst& in) { return in.pc == 968 || in.pc == 1007; }),
+          "external entry that bypasses the zero initializer keeps the cycle fail-visible");
 
     const uint32_t runtime_dead_fetch[] = {
         0xBF0B8200u,             // pc0: s_cmp_le_u32 s0, 2 (entry/user SGPR)

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -740,10 +740,9 @@ int main() {
     CHECK(unguarded_null_uses.empty(),
           "mapped null BVH root without a dominating EXEC guard remains fail-visible");
 
-    // Astro's live PC848..859 sequence computes its branch condition exclusively from shader
-    // constants: 37 & 7 = 5; 5 + (-4) = 1; 1 <= 2, so s_cbranch_scc1 skips the two lexical BVH
-    // sites that cannot execute. Resource discovery and translation must consume the same pruned
-    // instruction stream. The proof must not broaden to an entry/user-SGPR comparison.
+    // A straight-line compiler sequence can compute a branch condition exclusively from shader
+    // constants: 37 & 7 = 5; 5 + (-4) = 1; 1 <= 2. Resource discovery and translation must consume
+    // the same pruned instruction stream. The proof must not broaden to an entry/user-SGPR comparison.
     const uint32_t shader_constant_dead_fetch[] = {
         0xBE8B03A5u,             // pc0: s_mov_b32 s11, 37
         0x876A870Bu,             // pc1: s_and_b32 s106, s11, 7
@@ -767,6 +766,93 @@ int main() {
                                 std::size(shader_constant_dead_fetch),
                                 constant_branch_seed.data(), constant_branch_seed.size(), 0).empty(),
           "dynamic resource discovery ignores the provably dead buffer fetch");
+
+    // Exact instruction words and PCs from the live loop shape that motivated this pass. Although
+    // the first entry computes the same true condition as the straight-line fixture above, PC855 is
+    // also a loop header and the back-edge path rewrites s11 to -1. The next iteration therefore has
+    // a different SCC result. Keep this title-derived evidence deliberately minimal: only the
+    // preheader, condition, target, mutation, back-edge, and terminator needed to preserve the CFG.
+    std::vector<Rdna2Inst> loop_variant_branch;
+    auto append_exact_instruction = [&](uint32_t pc, std::initializer_list<uint32_t> words) {
+        Rdna2Inst instruction = rdna2_decode_one(words.begin(), words.size());
+        instruction.pc = pc;
+        loop_variant_branch.push_back(instruction);
+    };
+    append_exact_instruction(848,  {0xBE8B03A5u}); // s_mov_b32 s11, 37 (preheader)
+    append_exact_instruction(855,  {0x876A870Bu}); // loop: s_and_b32 s106, s11, 7
+    append_exact_instruction(856,  {0x876B087Eu});
+    append_exact_instruction(857,  {0x816AC46Au}); // s_add_i32 s106, s106, -4
+    append_exact_instruction(858,  {0xBF0B826Au}); // s_cmp_le_u32 s106, 2
+    append_exact_instruction(859,  {0xBF8501DEu}); // s_cbranch_scc1 1338
+    append_exact_instruction(968,  {0xF1989F07u, 0x00040303u, 0x43440D3Fu,
+                                    0x46424140u, 0x00004847u}); // unresolved loop BVH
+    append_exact_instruction(1007, {0xF1989F07u, 0x00040303u, 0x43440D3Fu,
+                                    0x46424140u, 0x00004847u}); // unresolved loop BVH
+    append_exact_instruction(1338, {0x7E0602C1u}); // exact taken target
+    append_exact_instruction(1346, {0xF1989F07u, 0x00010303u, 0x094F4E3Fu,
+                                    0x11100F0Eu, 0x00001312u}); // guarded null BVH
+    append_exact_instruction(1351, {0xBF8C3F70u});
+    append_exact_instruction(1352, {0x7D8A06F9u, 0x068688C1u}); // v_cmp_ne_u32 s8,-1,v3
+    append_exact_instruction(1354, {0xBF070880u});              // s_cmp_lg_u32 0,s8
+    append_exact_instruction(1355, {0xBEFE036Au});              // s_mov_b32 exec_lo,vcc_lo
+    append_exact_instruction(1356, {0xBF840133u});              // s_cbranch_scc0 1664
+    append_exact_instruction(1610, {0xBE8B03C1u});              // s_mov_b32 s11, -1
+    append_exact_instruction(1663, {0xBF82FCD7u});              // s_branch 855 (back-edge)
+    append_exact_instruction(1664, {0xBF072D80u});              // exact null-exit target
+    append_exact_instruction(3276, {0xBF810000u});              // s_endpgm
+    CHECK(rdna2_specialize_shader_constant_branches(loop_variant_branch) == 0 &&
+              loop_variant_branch.size() == 19 &&
+              loop_variant_branch[5].fmt == Rdna2Format::SOPP &&
+              loop_variant_branch[5].opcode == 0x05,
+          "loop-carried scalar mutation prevents one-shot SCC branch specialization");
+
+    alignas(256) std::array<uint8_t, 256> loop_null_bvh{};
+    ShaderResourceTable loop_null_table;
+    { ShaderResource marker{};
+      marker.cls = ResourceClass::ConstantBuffer;
+      marker.format = DataFormat::Uint32;
+      marker.num_components = 1;
+      marker.size = loop_null_bvh.size();
+      marker.fetch_pc = 1346;
+      marker.host_data = loop_null_bvh.data();
+      marker.host_data_size = loop_null_bvh.size();
+      loop_null_table.resources.push_back(marker); }
+    std::vector<Rdna2Inst> null_pruned_loop = loop_variant_branch;
+    CHECK(rdna2_specialize_proven_null_bvh_paths(
+              null_pruned_loop, &loop_null_table, 32) == 1 &&
+              rdna2_specialize_shader_constant_branches(null_pruned_loop) == 1 &&
+              std::none_of(null_pruned_loop.begin(), null_pruned_loop.end(),
+                           [](const Rdna2Inst& in) {
+                               return in.pc == 968 || in.pc == 1007 || in.pc == 1610 || in.pc == 1663;
+                           }),
+          "exact null-BVH exit removes loop back-edges before constant preheader pruning");
+
+    ShaderResourceTable nonnull_loop_table = loop_null_table;
+    nonnull_loop_table.resources[0].gpu_addr = 0x10000u;
+    std::vector<Rdna2Inst> nonnull_loop = loop_variant_branch;
+    CHECK(rdna2_specialize_proven_null_bvh_paths(
+              nonnull_loop, &nonnull_loop_table, 32) == 0 &&
+              rdna2_specialize_shader_constant_branches(nonnull_loop) == 0 &&
+              std::any_of(nonnull_loop.begin(), nonnull_loop.end(),
+                          [](const Rdna2Inst& in) { return in.pc == 968 || in.pc == 1007; }),
+          "non-null resource preserves loop-reachable BVH sites");
+
+    for (int deviation = 0; deviation < 4; ++deviation) {
+        std::vector<Rdna2Inst> changed = loop_variant_branch;
+        auto wait = std::find_if(changed.begin(), changed.end(),
+                                 [](const Rdna2Inst& in) { return in.pc == 1351; });
+        auto compare = std::find_if(changed.begin(), changed.end(),
+                                    [](const Rdna2Inst& in) { return in.pc == 1352; });
+        auto exit = std::find_if(changed.begin(), changed.end(),
+                                 [](const Rdna2Inst& in) { return in.pc == 1356; });
+        if (deviation == 0) compare->opcode = 0xc4u;
+        if (deviation == 1) compare->src[1].value = 4;
+        if (deviation == 2) exit->opcode = 0x05u;
+        if (deviation == 3) wait->words[0] = 0xbf8c3f71u;
+        CHECK(rdna2_specialize_proven_null_bvh_paths(
+                  changed, &loop_null_table, 32) == 0,
+              "null-BVH exit proof rejects opcode/register/guard deviations");
+    }
 
     const uint32_t runtime_dead_fetch[] = {
         0xBF0B8200u,             // pc0: s_cmp_le_u32 s0, 2 (entry/user SGPR)
@@ -827,6 +913,70 @@ int main() {
                              &shader_constant_bvh_table,
                              shader_constant_bvh_config).empty(),
           "compute translation omits a dead BVH site proven by shader constants");
+
+    // Contiguous form of the exact null-result loop relationship above. PC5 is unresolved but can
+    // execute only through a loop back-edge. A proven null marker at PC10 makes the PC20 SCC0 exit
+    // unconditional; after that prune, the shader-constant PC4 entry branch removes PC5. This tests
+    // the complete translation path rather than only the decoded-instruction helper.
+    const uint32_t null_exit_loop_shader[] = {
+        0xBE8B03A5u,                         // pc0:  s_mov_b32 s11, 37
+        0x876A870Bu,                         // pc1:  loop condition from s11
+        0x816AC46Au,                         // pc2
+        0xBF0B826Au,                         // pc3
+        0xBF850005u,                         // pc4:  initial entry -> pc10
+        0xF1989F07u, 0x00040303u, 0x43440D3Fu, 0x46424140u, 0x00004847u,
+        0xF1989F07u, 0x00010303u, 0x094F4E3Fu, 0x11100F0Eu, 0x00001312u,
+        0xBF8C3F70u,                         // pc15: wait for null ray
+        0x7D8A06F9u, 0x068688C1u,            // pc16: v_cmp_ne_u32 s8,-1,v3
+        0xBF070880u,                         // pc18: s_cmp_lg_u32 0,s8
+        0xBEFE036Au,                         // pc19: s_mov_b32 exec_lo,vcc_lo
+        0xBF840002u,                         // pc20: s_cbranch_scc0 pc23
+        0xBE8B03C1u,                         // pc21: loop-carried s11 = -1
+        0xBF82FFEAu,                         // pc22: s_branch pc1
+        0xBF810000u,                         // pc23: s_endpgm
+    };
+    ShaderResourceTable null_exit_loop_table;
+    { ShaderResource marker{};
+      marker.cls = ResourceClass::ConstantBuffer;
+      marker.format = DataFormat::Uint32;
+      marker.num_components = 1;
+      marker.binding = 4;
+      marker.size = shader_constant_null_bvh.size();
+      marker.fetch_pc = 10;
+      marker.host_data = shader_constant_null_bvh.data();
+      marker.host_data_size = shader_constant_null_bvh.size();
+      null_exit_loop_table.resources.push_back(marker); }
+    ComputeShaderConfig null_exit_loop_config;
+    null_exit_loop_config.local_x = 1;
+    null_exit_loop_config.wave_size = 32;
+    std::vector<Rdna2Inst> contiguous_null_exit;
+    rdna2_walk(null_exit_loop_shader, std::size(null_exit_loop_shader), contiguous_null_exit);
+    CHECK(rdna2_specialize_proven_null_bvh_paths(
+              contiguous_null_exit, &null_exit_loop_table, 32) == 1 &&
+              rdna2_specialize_shader_constant_branches(contiguous_null_exit) == 1 &&
+              std::none_of(contiguous_null_exit.begin(), contiguous_null_exit.end(),
+                           [](const Rdna2Inst& in) { return in.pc == 5 || in.pc == 21 || in.pc == 22; }),
+          "contiguous null-result loop shares the discovery/translation specialization decision");
+    CHECK(!recompile_compute(null_exit_loop_shader,
+                             std::size(null_exit_loop_shader),
+                             &null_exit_loop_table,
+                             null_exit_loop_config).empty(),
+          "proven null result prunes loop-reachable unresolved BVH before translation");
+
+    ShaderResourceTable nonnull_exit_loop_table = null_exit_loop_table;
+    nonnull_exit_loop_table.resources[0].gpu_addr = 0x20000u;
+    CHECK(recompile_compute(null_exit_loop_shader,
+                            std::size(null_exit_loop_shader),
+                            &nonnull_exit_loop_table,
+                            null_exit_loop_config).empty(),
+          "different/non-null resource preserves unresolved loop BVH fail-visible");
+    std::vector<uint32_t> changed_null_exit(std::begin(null_exit_loop_shader),
+                                           std::end(null_exit_loop_shader));
+    changed_null_exit[20] = 0xBF850002u;      // SCC1 is not the proven no-hit exit
+    CHECK(recompile_compute(changed_null_exit.data(), changed_null_exit.size(),
+                            &null_exit_loop_table,
+                            null_exit_loop_config).empty(),
+          "null loop guard opcode deviation remains fail-visible in translation");
 
     const uint32_t runtime_dead_bvh[] = {
         0xBF0B8200u,                         // pc0: s_cmp_le_u32 s0, 2

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -10,6 +10,7 @@
 // tracked values, routing the s_bfe_u64 result into V#.dword3 (desc_v3). All encodings assembled /
 // round-trip verified with llvm-mc -mcpu=gfx1030.
 #include "../src/gpu/gpu_execute.hpp"
+#include "../src/gpu/rdna2_decode.hpp"
 #include "../src/gpu/rdna2_to_spirv.hpp"
 #include <algorithm>
 #include <cstdio>
@@ -738,6 +739,109 @@ int main() {
                           &unguarded_null_uses);
     CHECK(unguarded_null_uses.empty(),
           "mapped null BVH root without a dominating EXEC guard remains fail-visible");
+
+    // Astro's live PC848..859 sequence computes its branch condition exclusively from shader
+    // constants: 37 & 7 = 5; 5 + (-4) = 1; 1 <= 2, so s_cbranch_scc1 skips the two lexical BVH
+    // sites that cannot execute. Resource discovery and translation must consume the same pruned
+    // instruction stream. The proof must not broaden to an entry/user-SGPR comparison.
+    const uint32_t shader_constant_dead_fetch[] = {
+        0xBE8B03A5u,             // pc0: s_mov_b32 s11, 37
+        0x876A870Bu,             // pc1: s_and_b32 s106, s11, 7
+        0x816AC46Au,             // pc2: s_add_i32 s106, s106, -4
+        0xBF0B826Au,             // pc3: s_cmp_le_u32 s106, 2
+        0xBF850002u,             // pc4: s_cbranch_scc1 pc7
+        0xE0002000u, 0x80030100u,// pc5: dead buffer_load_format_x ..., s[12:15]
+        0xBF810000u,             // pc7: s_endpgm
+    };
+    std::array<uint32_t, 16> constant_branch_seed{};
+    constant_branch_seed[12] = 0x10000u;
+    constant_branch_seed[14] = 64u;
+    std::vector<Rdna2Inst> pruned_constant_branch;
+    rdna2_walk(shader_constant_dead_fetch, std::size(shader_constant_dead_fetch),
+               pruned_constant_branch);
+    CHECK(rdna2_specialize_shader_constant_branches(pruned_constant_branch) == 1 &&
+              std::none_of(pruned_constant_branch.begin(), pruned_constant_branch.end(),
+                           [](const Rdna2Inst& in) { return in.pc == 5; }),
+          "shader-constant SCC branch prunes its dead resource block");
+    CHECK(resolve_dynamic_fetch(shader_constant_dead_fetch,
+                                std::size(shader_constant_dead_fetch),
+                                constant_branch_seed.data(), constant_branch_seed.size(), 0).empty(),
+          "dynamic resource discovery ignores the provably dead buffer fetch");
+
+    const uint32_t runtime_dead_fetch[] = {
+        0xBF0B8200u,             // pc0: s_cmp_le_u32 s0, 2 (entry/user SGPR)
+        0xBF850002u,             // pc1: s_cbranch_scc1 pc4
+        0xE0002000u, 0x80030100u,// pc2: runtime-reachable buffer_load_format_x ..., s[12:15]
+        0xBF810000u,             // pc4: s_endpgm
+    };
+    std::vector<DynFetch> runtime_branch_fetch = resolve_dynamic_fetch(
+        runtime_dead_fetch, std::size(runtime_dead_fetch), constant_branch_seed.data(),
+        constant_branch_seed.size(), 0);
+    CHECK(runtime_branch_fetch.size() == 1 && runtime_branch_fetch[0].fetch_pc == 2,
+          "entry-dependent scalar branch keeps both resource paths fail-visible");
+
+    const uint32_t vcc_clobbered_dead_fetch[] = {
+        0xBEEA0381u,             // pc0: s_mov_b32 s106, 1 (ordinary scalar-data lifetime)
+        0x7D846A80u,             // pc1: v_cmp_* -> implicit architectural VCC overwrite
+        0xBF0B826Au,             // pc2: s_cmp_le_u32 s106, 2 (reads the new VCC bits)
+        0xBF850002u,             // pc3: s_cbranch_scc1 pc6
+        0xE0002000u, 0x80030100u,// pc4: potentially reachable buffer fetch
+        0xBF810000u,             // pc6: s_endpgm
+    };
+    std::vector<Rdna2Inst> vcc_clobbered_instructions;
+    rdna2_walk(vcc_clobbered_dead_fetch, std::size(vcc_clobbered_dead_fetch),
+               vcc_clobbered_instructions);
+    CHECK(rdna2_specialize_shader_constant_branches(vcc_clobbered_instructions) == 0 &&
+              resolve_dynamic_fetch(vcc_clobbered_dead_fetch,
+                                    std::size(vcc_clobbered_dead_fetch),
+                                    constant_branch_seed.data(),
+                                    constant_branch_seed.size(), 0).size() == 1,
+          "implicit VCC writer invalidates a prior scalar-data constant in s106:s107");
+
+    const uint32_t shader_constant_dead_bvh[] = {
+        0xBE8B03A5u,                         // pc0:  s_mov_b32 s11, 37
+        0x876A870Bu,                         // pc1:  s_and_b32 s106, s11, 7
+        0x816AC46Au,                         // pc2:  s_add_i32 s106, s106, -4
+        0xBF0B826Au,                         // pc3:  s_cmp_le_u32 s106, 2
+        0xBF850005u,                         // pc4:  s_cbranch_scc1 pc10
+        0xF1989F07u, 0x00040303u, 0x43440D3Fu, 0x46424140u, 0x00004847u,
+        0xF1989F07u, 0x00010303u, 0x094F4E3Fu, 0x11100F0Eu, 0x00001312u,
+        0xBF810000u,                         // pc15: s_endpgm
+    };
+    alignas(256) std::array<uint8_t, 256> shader_constant_null_bvh{};
+    ShaderResourceTable shader_constant_bvh_table;
+    { ShaderResource marker{};
+      marker.cls = ResourceClass::ConstantBuffer;
+      marker.format = DataFormat::Uint32;
+      marker.num_components = 1;
+      marker.binding = 4;
+      marker.size = shader_constant_null_bvh.size();
+      marker.fetch_pc = 10;
+      marker.host_data = shader_constant_null_bvh.data();
+      marker.host_data_size = shader_constant_null_bvh.size();
+      shader_constant_bvh_table.resources.push_back(marker); }
+    ComputeShaderConfig shader_constant_bvh_config;
+    shader_constant_bvh_config.local_x = 1;
+    CHECK(!recompile_compute(shader_constant_dead_bvh,
+                             std::size(shader_constant_dead_bvh),
+                             &shader_constant_bvh_table,
+                             shader_constant_bvh_config).empty(),
+          "compute translation omits a dead BVH site proven by shader constants");
+
+    const uint32_t runtime_dead_bvh[] = {
+        0xBF0B8200u,                         // pc0: s_cmp_le_u32 s0, 2
+        0xBF850005u,                         // pc1: s_cbranch_scc1 pc7
+        0xF1989F07u, 0x00040303u, 0x43440D3Fu, 0x46424140u, 0x00004847u,
+        0xF1989F07u, 0x00010303u, 0x094F4E3Fu, 0x11100F0Eu, 0x00001312u,
+        0xBF810000u,                         // pc12: s_endpgm
+    };
+    ShaderResourceTable runtime_bvh_table = shader_constant_bvh_table;
+    runtime_bvh_table.resources[0].fetch_pc = 7;
+    ComputeShaderConfig runtime_bvh_config = shader_constant_bvh_config;
+    runtime_bvh_config.user_sgprs = {1u};
+    CHECK(recompile_compute(runtime_dead_bvh, std::size(runtime_dead_bvh),
+                            &runtime_bvh_table, runtime_bvh_config).empty(),
+          "compute translation rejects an unresolved BVH on an entry-dependent branch");
 
     // Recreate the live descriptor builder rather than seeding its final words: the header pointer
     // is stored in 8-byte units, the allocation count is loaded from byte offset 0x58, and a

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -836,16 +836,37 @@ int main() {
       marker.host_data = loop_null_bvh.data();
       marker.host_data_size = loop_null_bvh.size();
       loop_null_table.resources.push_back(marker); }
+    for (uint32_t fetch_pc : {968u, 1007u}) {
+        ShaderResource dead{};
+        dead.cls = ResourceClass::ConstantBuffer;
+        dead.format = DataFormat::Uint32;
+        dead.num_components = 1;
+        dead.size = 4;
+        dead.fetch_pc = fetch_pc;
+        loop_null_table.resources.push_back(dead);
+    }
     std::vector<Rdna2Inst> null_pruned_loop = loop_variant_branch;
-    CHECK(rdna2_specialize_proven_null_bvh_paths(
-              null_pruned_loop, &loop_null_table, 32) == 1 &&
-              rdna2_specialize_shader_constant_branches(null_pruned_loop) == 0 &&
+    const ComputeResourcePathSpecializationReport null_path_report =
+        specialize_compute_resource_paths(null_pruned_loop, loop_null_table, 32);
+    CHECK(null_path_report.proven_null_exits == 1 &&
+              null_path_report.shader_constant_branches == 0 &&
+              null_path_report.removed_resources == 2 &&
+              std::find(null_path_report.removed_pcs.begin(),
+                        null_path_report.removed_pcs.end(), 968) !=
+                  null_path_report.removed_pcs.end() &&
+              std::find(null_path_report.removed_pcs.begin(),
+                        null_path_report.removed_pcs.end(), 1007) !=
+                  null_path_report.removed_pcs.end() &&
               std::none_of(null_pruned_loop.begin(), null_pruned_loop.end(),
                            [](const Rdna2Inst& in) {
                                return in.pc == 968 || in.pc == 1007 || in.pc == 1610 ||
                                       in.pc == 1663 || in.pc == 1671 || in.pc == 1674;
-                           }),
-          "exact null-root plus empty stack removes the unseeded traversal cycle");
+                           }) &&
+              loop_null_table.resources.size() == 1 &&
+              is_proven_null_bvh(loop_null_table.resources.front()) &&
+              loop_null_table.resources.front().fetch_pc == 1346,
+          "executor resource-path specialization reports the exact removed traversal PCs, "
+          "prunes their resources, and retains the null proof for raw translation");
 
     ShaderResourceTable nonnull_loop_table = loop_null_table;
     nonnull_loop_table.resources[0].gpu_addr = 0x10000u;

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -453,6 +453,7 @@ int main() {
         0xbf840001u,                         // s_cbranch_scc0 +1
         0xbeea0385u,                         // one arm recycles vcc_lo as scalar data
         0x876b0100u,                         // s_and_b32 vcc_hi, s0, s1
+        0x02020100u,                         // implicit VCC_LO read remains ambiguous
         0xbf810000u,
     };
     wave32_compute_config.user_sgprs = {1u, 1u};
@@ -462,7 +463,160 @@ int main() {
         printf("  [FAIL] partial VCC write accepted an unknown prior mask\n");
         return 1;
     }
-    printf("  [ok]   partial VCC write rejects an unknown prior mask\n");
+    printf("  [ok]   partial VCC_HI write cannot validate an ambiguous VCC_LO read\n");
+
+    // A complete scalar-data write to VCC_LO defines every architectural predicate bit in Wave32.
+    // Consume it immediately through the implicit e32 cndmask form so this cannot pass merely by
+    // treating the new lifetime as dead scalar scratch.
+    const uint32_t wave32_compute_scalar_vcc_lo_consumer[] = {
+        0x876a8181u,                         // s_and_b32 vcc_lo, 1, 1
+        0x02020100u,                         // v_cndmask_b32 v1, v0, v0, vcc
+        0xbf810000u,
+    };
+    if (recompile_compute(wave32_compute_scalar_vcc_lo_consumer,
+                          std::size(wave32_compute_scalar_vcc_lo_consumer), nullptr,
+                          wave32_compute_config).empty()) {
+        printf("  [FAIL] full Wave32 scalar VCC_LO write did not feed implicit cndmask\n");
+        return 1;
+    }
+    printf("  [ok]   full Wave32 scalar VCC_LO write feeds its implicit mask consumer\n");
+
+    // Astro's exact PC458 packet explicitly selects physical VCC_HI in Wave32. A typed B32 mask in
+    // that word must drive the select independently of VCC_LO; absent or path-dependent HI mask
+    // lifetimes must remain fail-visible instead of falling back to the implicit VCC predicate.
+    const uint32_t wave32_compute_explicit_vcc_hi_cndmask[] = {
+        0xbf060000u,                         // s_cmp_eq_u32 s0,s0
+        0x856b807eu,                         // s_cselect_b32 vcc_hi, exec_lo, 0
+        0xd5010000u, 0x01ad0280u,            // v_cndmask_b32_e64 v0, 0, 1, vcc_hi
+        0xbf810000u,
+    };
+    const auto explicit_vcc_hi_cndmask_spv = recompile_compute(
+        wave32_compute_explicit_vcc_hi_cndmask,
+        std::size(wave32_compute_explicit_vcc_hi_cndmask), nullptr,
+        wave32_compute_config);
+    if (explicit_vcc_hi_cndmask_spv.empty() ||
+        !type_result_ids_are_nonzero(explicit_vcc_hi_cndmask_spv, nullptr) ||
+        !phi_ids_are_nonzero(explicit_vcc_hi_cndmask_spv)) {
+        printf("  [FAIL] explicit Wave32 VCC_HI cndmask source was not preserved\n");
+        return 1;
+    }
+    const uint32_t wave32_compute_absent_vcc_hi_cndmask[] = {
+        0xbeeb0380u,                         // scalar-data vcc_hi=0, not a mask
+        0xd5010000u, 0x01ad0280u,            // v_cndmask_b32_e64 v0, 0, 1, vcc_hi
+        0xbf810000u,
+    };
+    if (!recompile_compute(wave32_compute_absent_vcc_hi_cndmask,
+                           std::size(wave32_compute_absent_vcc_hi_cndmask), nullptr,
+                           wave32_compute_config).empty()) {
+        printf("  [FAIL] explicit VCC_HI cndmask accepted an absent mask lifetime\n");
+        return 1;
+    }
+    const uint32_t wave32_compute_ambiguous_vcc_hi_cndmask[] = {
+        0xbf060000u,                         // pc0: scalar branch condition
+        0xbf840001u,                         // pc1: one edge skips the HI definition
+        0x856b807eu,                         // pc2: other edge defines a VCC_HI mask
+        0xd5010000u, 0x01ad0280u,            // pc3: joined VCC_HI read
+        0xbf810000u,
+    };
+    if (!recompile_compute(wave32_compute_ambiguous_vcc_hi_cndmask,
+                           std::size(wave32_compute_ambiguous_vcc_hi_cndmask), nullptr,
+                           wave32_compute_config).empty()) {
+        printf("  [FAIL] explicit VCC_HI cndmask accepted a path-dependent mask lifetime\n");
+        return 1;
+    }
+    printf("  [ok]   explicit Wave32 VCC_HI cndmask requires its own unambiguous mask\n");
+
+    // Exact control/data lifetime from Astro Bot's world-map phase, reduced only to its register-
+    // independent instructions: a scalar-data VCC_LO lifetime feeds CMPX (which changes EXEC but
+    // preserves VCC), one crossing arm defines and immediately consumes a fresh VCC mask, and the
+    // other arm skips that definition. The rejoined VCC lifetime is invalid but dead. Crossing
+    // EXECZ regions force the same arbitrary-CFG dispatcher as the 216..306 production phase.
+    const uint32_t wave32_compute_dead_vcc_join[] = {
+        0xbeea0385u,                         // pc0: scalar-data vcc_lo=5
+        0x7da40100u,                         // pc1: v_cmpx_eq_u32 v0,v0 (EXEC only)
+        0xbf880003u,                         // pc2: execz -> pc6, skipping the VCC definition
+        0x7d840100u,                         // pc3: v_cmp_eq_u32 vcc,v0,v0 (fresh mask)
+        0x02020100u,                         // pc4: v_cndmask_b32 v1,v0,v0,vcc
+        0xbf880002u,                         // pc5: execz -> pc8 (crosses the pc2 region)
+        0xbf060000u,                         // pc6: rejoin; scalar compare, no VCC read
+        0xbf850001u,                         // pc7: third branch -> pc9 forces complex CFG
+        0x7e040280u,                         // pc8: no mask read before termination
+        0xbf810000u,
+    };
+    const auto dead_vcc_join_spv = recompile_compute(
+        wave32_compute_dead_vcc_join, std::size(wave32_compute_dead_vcc_join), nullptr,
+        wave32_compute_config);
+    if (dead_vcc_join_spv.empty() || !has_opcode(dead_vcc_join_spv, 251) ||
+        !type_result_ids_are_nonzero(dead_vcc_join_spv, nullptr) ||
+        !phi_ids_are_nonzero(dead_vcc_join_spv)) {
+        printf("  [FAIL] Wave32 CFG rejected Astro's dead VCC lifetime at a crossing join\n");
+        return 1;
+    }
+    printf("  [ok]   Wave32 CFG carries Astro's invalid-but-dead VCC lifetime across a join\n");
+
+    std::vector<uint32_t> dead_vcc_read_at_join(
+        std::begin(wave32_compute_dead_vcc_join),
+        std::end(wave32_compute_dead_vcc_join));
+    dead_vcc_read_at_join[6] = 0x02040500u; // v_cndmask_b32 v2,v0,v2,vcc
+    if (!recompile_compute(dead_vcc_read_at_join.data(), dead_vcc_read_at_join.size(),
+                           nullptr, wave32_compute_config).empty()) {
+        printf("  [FAIL] Wave32 CFG accepted a VCC read after the ambiguous join\n");
+        return 1;
+    }
+    std::vector<uint32_t> dead_vcc_missing_definition(
+        std::begin(wave32_compute_dead_vcc_join),
+        std::end(wave32_compute_dead_vcc_join));
+    dead_vcc_missing_definition[3] = 0x7da40100u; // CMPX does not define VCC
+    if (!recompile_compute(dead_vcc_missing_definition.data(),
+                           dead_vcc_missing_definition.size(), nullptr,
+                           wave32_compute_config).empty()) {
+        printf("  [FAIL] Wave32 CFG accepted a cndmask after replacing its VCC definition\n");
+        return 1;
+    }
+    std::vector<uint32_t> dead_vcc_entered_consumer(
+        std::begin(wave32_compute_dead_vcc_join),
+        std::end(wave32_compute_dead_vcc_join));
+    dead_vcc_entered_consumer[2] = 0xbf880001u; // topology now enters pc4, past the definition
+    if (!recompile_compute(dead_vcc_entered_consumer.data(),
+                           dead_vcc_entered_consumer.size(), nullptr,
+                           wave32_compute_config).empty()) {
+        printf("  [FAIL] Wave32 CFG accepted a branch edge entering past the VCC definition\n");
+        return 1;
+    }
+    printf("  [ok]   Wave32 CFG rejects VCC-read, definition, and branch-topology deviations\n");
+
+    // The production shader wraps barrier-separated work in a workgroup-uniform early-out. Its
+    // first barrier-free phase has the same crossing Wave32 CFG as the fixture above and no guest
+    // S_ENDPGM of its own. The phase splitter must supply an emitter-only terminator so the
+    // dispatcher can become inactive, rejoin the uniform outer shell, and reach the guest barrier.
+    const uint32_t wave32_compute_guarded_cfg_phase[] = {
+        0xbf060000u,                         // pc0: uniform s_cmp_eq_u32 s0,s0
+        0xbf84000cu,                         // pc1: early-out -> terminal pc14
+        0xbeea0385u,                         // pc2: scalar-data vcc_lo=5
+        0x7da40100u,                         // pc3: v_cmpx_eq_u32 v0,v0 (EXEC only)
+        0xbf880003u,                         // pc4: execz -> pc8
+        0x7d840100u,                         // pc5: fresh VCC definition
+        0x02020100u,                         // pc6: consume the fresh VCC
+        0xbf880002u,                         // pc7: execz -> pc10
+        0xbf060000u,                         // pc8: rejoin without reading VCC
+        0xbf850001u,                         // pc9: branch -> pc11, skipping pc10
+        0x7e040280u,                         // pc10: first arm
+        0x7e060280u,                         // pc11: phase-local join
+        0xbf8a0000u,                         // pc12: uniform guest barrier
+        0x7e080280u,                         // pc13: tail phase
+        0xbf810000u,                         // pc14: terminal s_endpgm
+    };
+    const auto guarded_cfg_phase_spv = recompile_compute(
+        wave32_compute_guarded_cfg_phase, std::size(wave32_compute_guarded_cfg_phase), nullptr,
+        wave32_compute_config);
+    if (guarded_cfg_phase_spv.empty() || !has_opcode(guarded_cfg_phase_spv, 251) ||
+        !type_result_ids_are_nonzero(guarded_cfg_phase_spv, nullptr) ||
+        !phi_ids_are_nonzero(guarded_cfg_phase_spv)) {
+        printf("  [FAIL] barrier phase rejected Astro's crossing Wave32 CFG\n");
+        return 1;
+    }
+    printf("  [ok]   barrier phase terminates and rejoins Astro's crossing Wave32 CFG\n");
+
     wave32_compute_config.wave_size = 64;
     if (!recompile_compute(wave32_compute_masks, std::size(wave32_compute_masks), nullptr,
                            wave32_compute_config).empty()) {

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -665,6 +665,57 @@ int main() {
                     subgroup17d1.size);
     }
 
+    // Kernel 17d1m: Astro reuses physical VCC_LO as ordinary scalar data, then copies that complete
+    // dword into EXEC_LO.  A Wave32 translation must select this invocation's bit from the scalar
+    // value: mask 1 activates lane zero of each guest wave and leaves every other destination word
+    // untouched.  An untracked special-register source remains fail-visible.
+    const uint32_t code17d1m[] = {
+        0xbe800381u,              // s_mov_b32 s0, 1
+        0xbefe0300u,              // s_mov_b32 exec_lo, s0
+        0x7e020287u,              // v_mov_b32 v1, 7
+        0xe0702000u, 0x80020100u, // buffer_store_dword v1, v0, s[8:11] idxen
+        0xbf810000u,
+    };
+    const std::vector<uint32_t> native_spv17d1m = recompile_compute(
+        code17d1m, std::size(code17d1m), &rt17d1, native_cfg17d1);
+    CHECK(!native_spv17d1m.empty(),
+          "Wave32 scalar-data dword lowers when copied into EXEC_LO");
+    const std::vector<uint32_t> portable_spv17d1m = recompile_compute(
+        code17d1m, std::size(code17d1m), &rt17d1, portable_cfg17d1);
+    CHECK(!portable_spv17d1m.empty(),
+          "Wave32 scalar-data EXEC mask does not require native subgroup operations");
+    const uint32_t code17d1m_bad[] = {
+        0xbefe037cu,              // s_mov_b32 exec_lo, untracked m0
+        0xbf810000u,
+    };
+    CHECK(recompile_compute(code17d1m_bad, std::size(code17d1m_bad), nullptr,
+                            native_cfg17d1).empty(),
+          "untracked scalar source copied into EXEC_LO remains fail-visible");
+    const uint32_t code17d1m_wave64[] = {
+        0xbe800381u,              // s_mov_b32 s0, 1
+        0xbefe0300u,              // s_mov_b32 exec_lo, s0
+        0xbf810000u,
+    };
+    CHECK(recompile_compute(code17d1m_wave64, std::size(code17d1m_wave64), nullptr,
+                            native_cfg17d).empty(),
+          "Wave64 scalar-data EXEC-half writes remain fail-visible");
+    std::vector<uint32_t> initial17d1m(64, 0xdeadbeefu), got17d1m;
+    prosper::test::run_compute(portable_spv17d1m, std::vector<float>(64, 0.0f),
+                               64, 64, {}, initial17d1m, &got17d1m);
+    uint32_t bad17d1m = 0;
+    for (uint32_t lane = 0; lane < 64 && got17d1m.size() == 64; ++lane) {
+        const uint32_t expected = (lane & 31u) == 0 ? 7u : 0xdeadbeefu;
+        bad17d1m += got17d1m[lane] != expected;
+    }
+    std::printf("  scalar-exec out[0]=0x%08x out[1]=0x%08x "
+                "out[32]=0x%08x out[33]=0x%08x mismatches=%u\n",
+                got17d1m.size() == 64 ? got17d1m[0] : 0u,
+                got17d1m.size() == 64 ? got17d1m[1] : 0u,
+                got17d1m.size() == 64 ? got17d1m[32] : 0u,
+                got17d1m.size() == 64 ? got17d1m[33] : 0u, bad17d1m);
+    CHECK(got17d1m.size() == 64 && bad17d1m == 0,
+          "Wave32 scalar mask activates only its selected guest lanes");
+
     // Kernel 17d1w: the next Astro traversal instruction writes a scalar-data VCC_HI value to the
     // VGPR lane selected by s45. Preserve v1's local-id value in every other lane so execution tests
     // both halves of V_WRITELANE's read/modify/write behavior. These are the exact GFX10 packets for


### PR DESCRIPTION
## Summary

- prune only shader-constant scalar branches whose complete input bytes prove the outcome
- specialize the exact proven-null Wave32 BVH no-hit and empty-stack traversal paths while retaining the null proof across decoded and raw translation passes
- carry invalid-but-dead Wave32 VCC lifetimes through proven CFG joins, handle barrier-separated compute phases, and cover explicit VCC_HI mask semantics
- expose the live specialization decision with code address and removed PCs for reproducible diagnostics

## Game evidence

On the exact current-master Astro Bot route, compute program `0x50057b800` executed successfully 136/136 times. Every report removed the proven traversal PCs 968 and 1007; there were zero target skips or target translation rejects. The title reached `LevelDocument Loaded: worldmap`.

The native frontend frame is still effectively black, so this PR does not claim a visual milestone and intentionally adds no screenshot. Remaining observed blockers include unsupported siblings `0x5005a8100` and `0x500571000`. Full evidence is recorded on #1459.

## Validation

- `PROSPER_DBG=1 test_rdna2_spirv_struct`
- `test_dynfetch_fold`
- `test_recompile_coverage`
- `test_shader_recompile_cache`
- Vulkan `test_rdna2_to_spirv` before the final diagnostics-only address field
- exact live Astro Bot route, 580 presented frames, clean exit
- `git diff --check origin/master...HEAD`

Snapshot tests were not run; they are optional for normal development PRs and required before releases.

Progresses #1459.