### PR TITLE
feat(timeline): gate captures across submit phases

### DIFF
--- a/prosper/src/gpu/gpu_timeline.cpp
+++ b/prosper/src/gpu/gpu_timeline.cpp
@@ -253,7 +253,11 @@ struct RuntimeDetailRequest {
     uint32_t select_max_draws = UINT32_MAX;
     uint32_t select_min_dispatches = 0;
     uint32_t select_max_dispatches = UINT32_MAX;
+    uint64_t select_vertex_program = 0;
+    uint64_t select_fragment_program = 0;
     uint64_t select_compute_program = 0;
+    uint64_t select_after_compute_program = 0;
+    uint64_t after_compute_submit_no = 0;
     uint32_t select_dispatch_threads_x = 0;
     uint32_t select_dispatch_threads_y = 0;
     uint32_t select_dispatch_threads_z = 0;
@@ -265,6 +269,7 @@ struct RuntimeDetailRequest {
     std::atomic<bool> predecessor_claimed{false};
     std::atomic<bool> predecessor_failed{false};
     bool bundle_start_reached = false;
+    bool after_compute_seen = false;
 
     RuntimeDetailRequest() {
         const char* path_env = std::getenv("PROSPER_GPU_TIMELINE_CAPTURE");
@@ -432,6 +437,30 @@ struct RuntimeDetailRequest {
                          "[timeline] capture minimum dispatches exceeds maximum dispatches\n");
             return;
         }
+        auto parse_graphics_program = [&](const char* env_name, const char* stage,
+                                          uint64_t& selected) {
+            const char* program = std::getenv(env_name);
+            if (!program) return true;
+            char* program_end = nullptr;
+            errno = 0;
+            const uint64_t value = std::strtoull(program, &program_end, 0);
+            if (errno || program_end == program || !program_end || *program_end) {
+                std::fprintf(stderr,
+                             "[timeline] capture %s program must be an address or zero\n",
+                             stage);
+                return false;
+            }
+            selected = value;
+            semantic_selector |= value != 0;
+            return true;
+        };
+        if (!parse_graphics_program(
+                "PROSPER_GPU_TIMELINE_CAPTURE_WHEN_VERTEX_PROGRAM", "vertex",
+                select_vertex_program) ||
+            !parse_graphics_program(
+                "PROSPER_GPU_TIMELINE_CAPTURE_WHEN_FRAGMENT_PROGRAM", "fragment",
+                select_fragment_program))
+            return;
         if (const char* program = std::getenv(
                 "PROSPER_GPU_TIMELINE_CAPTURE_WHEN_COMPUTE_PROGRAM")) {
             char* program_end = nullptr;
@@ -444,6 +473,19 @@ struct RuntimeDetailRequest {
             }
             select_compute_program = value;
             semantic_selector = true;
+        }
+        if (const char* program = std::getenv(
+                "PROSPER_GPU_TIMELINE_CAPTURE_AFTER_COMPUTE_PROGRAM")) {
+            char* program_end = nullptr;
+            errno = 0;
+            const uint64_t value = std::strtoull(program, &program_end, 0);
+            if (errno || program_end == program || !program_end || *program_end) {
+                std::fprintf(stderr,
+                             "[timeline] capture after-compute program must be an address or zero\n");
+                return;
+            }
+            select_after_compute_program = value;
+            semantic_selector |= value != 0;
         }
         if (const char* dimensions = std::getenv(
                 "PROSPER_GPU_TIMELINE_CAPTURE_WHEN_DISPATCH_DIM")) {
@@ -466,12 +508,16 @@ struct RuntimeDetailRequest {
         if (semantic_selector)
             std::fprintf(stderr, "[timeline] semantic capture endpoint submit>=%llu "
                                  "target=%ux%u target-index=%u..%u draws=%u..%u "
-                                 "dispatches=%u..%u compute=0x%llx threads=%ux%ux%u\n",
+                                 "dispatches=%u..%u vertex=0x%llx fragment=0x%llx "
+                                 "compute=0x%llx after-compute=0x%llx threads=%ux%ux%u\n",
                          static_cast<unsigned long long>(submit_no), select_target_width,
                          select_target_height, select_target_min_index,
                          select_target_max_index, select_min_draws, select_max_draws,
                          select_min_dispatches, select_max_dispatches,
+                         static_cast<unsigned long long>(select_vertex_program),
+                         static_cast<unsigned long long>(select_fragment_program),
                          static_cast<unsigned long long>(select_compute_program),
+                         static_cast<unsigned long long>(select_after_compute_program),
                          select_dispatch_threads_x, select_dispatch_threads_y,
                          select_dispatch_threads_z);
     }
@@ -649,10 +695,33 @@ RuntimeCaptureBundle& runtime_capture_bundle() {
     return state;
 }
 
-bool runtime_capture_endpoint_matches(const RuntimeDetailRequest& request,
+bool runtime_capture_endpoint_matches(RuntimeDetailRequest& request,
                                       const GpuTimelineSubmit& submit,
                                       const GpuState& state) {
     const uint64_t submit_no = submit.submit_no;
+    if (request.select_after_compute_program) {
+        if (!request.after_compute_seen) {
+            for (const auto& dispatch : state.dispatches) {
+                if (compute_dispatch_code_addr(state, dispatch) !=
+                    request.select_after_compute_program)
+                    continue;
+                request.after_compute_submit_no = submit_no;
+                request.after_compute_seen = true;
+                std::fprintf(stderr,
+                             "[timeline] capture after-compute gate armed submit=%llu "
+                             "program=0x%llx\n",
+                             static_cast<unsigned long long>(submit_no),
+                             static_cast<unsigned long long>(
+                                 request.select_after_compute_program));
+                break;
+            }
+        }
+        // The phase program's submit only arms the request. Even if it also satisfies every
+        // endpoint predicate, capture begins with a strictly later submit.
+        if (!request.after_compute_seen ||
+            submit_no <= request.after_compute_submit_no)
+            return false;
+    }
     if (submit_no < request.submit_no) return false;
     if (!request.semantic_selector)
         return submit_no == request.submit_no;
@@ -667,6 +736,30 @@ bool runtime_capture_endpoint_matches(const RuntimeDetailRequest& request,
     selector.min_dispatches = request.select_min_dispatches;
     selector.max_dispatches = request.select_max_dispatches;
     if (!gpu_timeline_submit_matches(submit, selector)) return false;
+    if (request.select_vertex_program || request.select_fragment_program) {
+        bool matching_draw = false;
+        for (size_t draw_index = 0; draw_index < state.draws.size(); ++draw_index) {
+            const RenderState render = extract_render_state(state.state_at_draw(draw_index));
+            if (request.select_vertex_program &&
+                render.es_addr != request.select_vertex_program)
+                continue;
+            if (request.select_fragment_program &&
+                render.ps_addr != request.select_fragment_program)
+                continue;
+            // Keep target and program predicates attached to one semantic draw.  Submit-wide
+            // independent matches can otherwise select a pass whose target belongs to one draw
+            // while the requested shader pair belongs to another.
+            if (request.select_target_width &&
+                (render.color0_width != request.select_target_width ||
+                 render.color0_height != request.select_target_height ||
+                 draw_index < request.select_target_min_index ||
+                 draw_index > request.select_target_max_index))
+                continue;
+            matching_draw = true;
+            break;
+        }
+        if (!matching_draw) return false;
+    }
     if (request.select_compute_program || request.select_dispatch_threads_x) {
         bool matching_dispatch = false;
         for (const auto& dispatch : state.dispatches) {

--- a/prosper/tests/test_gpu_timeline.cpp
+++ b/prosper/tests/test_gpu_timeline.cpp
@@ -8,8 +8,12 @@
 #include <filesystem>
 #include <fstream>
 #include <iterator>
+#include <memory>
 #include <string>
 #include <vector>
+#ifndef _WIN32
+#include <sys/wait.h>
+#endif
 
 using namespace prosper::gpu;
 
@@ -23,8 +27,280 @@ static bool write_bytes(const std::filesystem::path& path, const std::vector<uin
     return static_cast<bool>(out);
 }
 
-int main() {
+static void set_test_env(const char* name, const std::string& value) {
+#ifdef _WIN32
+    _putenv_s(name, value.c_str());
+#else
+    setenv(name, value.c_str(), 1);
+#endif
+}
+
+alignas(256) static const uint32_t kSelectorVs[] = {0xBF810000u};
+alignas(256) static const uint32_t kSelectorPs[] = {0xBF810000u};
+alignas(256) static const uint32_t kWrongSelectorVs[] = {0xBF810000u};
+alignas(256) static const uint32_t kWrongSelectorPs[] = {0xBF810000u};
+alignas(256) static const uint32_t kSelectorCompute[] = {0xBF810000u};
+alignas(256) static const uint32_t kWrongSelectorCompute[] = {0xBF810000u};
+
+static std::string program_address(const uint32_t* program) {
+    char value[32];
+    std::snprintf(value, sizeof(value), "0x%llx",
+                  static_cast<unsigned long long>(reinterpret_cast<uint64_t>(program)));
+    return value;
+}
+
+static std::shared_ptr<GpuState> selector_draw_state(
+    uint32_t width, uint32_t height, const uint32_t* vertex, const uint32_t* fragment) {
+    namespace P = prosper::agc::Pm4;
+    auto state = std::make_shared<GpuState>();
+    auto set_program = [&](uint32_t lo, uint32_t hi, const uint32_t* program) {
+        const uint64_t address = reinterpret_cast<uint64_t>(program);
+        state->sh[lo] = static_cast<uint32_t>(address >> 8);
+        state->sh[hi] = static_cast<uint32_t>((address >> 40) & 0xffu);
+    };
+    set_program(P::SPI_SHADER_PGM_LO_ES, P::SPI_SHADER_PGM_HI_ES, vertex);
+    set_program(P::SPI_SHADER_PGM_LO_PS, P::SPI_SHADER_PGM_HI_PS, fragment);
+    state->cx[P::CB_COLOR0_ATTRIB2] = ((width - 1u) << 14) | (height - 1u);
+    return state;
+}
+
+static GpuState selector_submit(
+    std::initializer_list<std::shared_ptr<GpuState>> draw_states, uint64_t first_order,
+    const uint32_t* compute = nullptr) {
+    namespace P = prosper::agc::Pm4;
+    GpuState state;
+    uint64_t order = first_order;
+    for (const auto& draw_state : draw_states) {
+        GpuState::Draw draw{3};
+        draw.state = draw_state;
+        draw.command_order = order++;
+        state.draws.push_back(std::move(draw));
+    }
+    if (compute) {
+        auto dispatch_state = std::make_shared<GpuState>();
+        const uint64_t address = reinterpret_cast<uint64_t>(compute);
+        dispatch_state->sh[P::COMPUTE_PGM_LO] = static_cast<uint32_t>(address >> 8);
+        dispatch_state->sh[P::COMPUTE_PGM_HI] =
+            static_cast<uint32_t>((address >> 40) & 0xffu);
+        GpuState::Dispatch dispatch;
+        dispatch.state = std::move(dispatch_state);
+        dispatch.command_order = order++;
+        state.dispatches.push_back(std::move(dispatch));
+    }
+    state.command_order = order;
+    return state;
+}
+
+static int run_selector_env_child(const std::string& mode) {
+    const auto nonce = std::chrono::steady_clock::now().time_since_epoch().count();
+    const auto base = std::filesystem::temp_directory_path() /
+        ("prosper-gpu-timeline-selector-" + mode + "-" + std::to_string(nonce));
+    const std::string timeline_path = base.string() + ".prgtl";
+    const std::string capture_path = base.string() + ".prgcap";
+    set_test_env("PROSPER_GPU_TIMELINE", timeline_path);
+    set_test_env("PROSPER_GPU_TIMELINE_CAPTURE", capture_path);
+    set_test_env("PROSPER_GPU_CAPTURE_METADATA_ONLY", "1");
+
+    if (mode == "invalid") {
+        set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT", "1");
+        set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_WHEN_VERTEX_PROGRAM", "not-an-address");
+        begin_gpu_timeline_submit(1);
+        record_gpu_timeline_submit(GpuState{}, 1);
+    } else if (mode == "after-invalid") {
+        set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT", "1");
+        set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_AFTER_COMPUTE_PROGRAM",
+                     "not-an-address");
+        begin_gpu_timeline_submit(1);
+        record_gpu_timeline_submit(GpuState{}, 1);
+    } else if (mode == "zero") {
+        set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT", "1");
+        set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_WHEN_VERTEX_PROGRAM", "0");
+        set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_WHEN_FRAGMENT_PROGRAM", "0x0");
+        set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_AFTER_COMPUTE_PROGRAM", "0");
+        begin_gpu_timeline_submit(1);
+        record_gpu_timeline_submit(GpuState{}, 1);
+    } else if (mode == "semantic") {
+        set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT", "3");
+        set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_WHEN_TARGET_DIM", "642x362");
+        set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_WHEN_VERTEX_PROGRAM",
+                     program_address(kSelectorVs));
+        set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_WHEN_FRAGMENT_PROGRAM",
+                     program_address(kSelectorPs));
+        set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_WHEN_COMPUTE_PROGRAM",
+                     program_address(kSelectorCompute));
+
+        const auto exact = selector_draw_state(642, 362, kSelectorVs, kSelectorPs);
+        const auto wrong_vs = selector_draw_state(642, 362, kWrongSelectorVs, kSelectorPs);
+        const auto wrong_ps = selector_draw_state(642, 362, kSelectorVs, kWrongSelectorPs);
+        const auto split_vs = selector_draw_state(642, 362, kSelectorVs, kWrongSelectorPs);
+        const auto split_ps = selector_draw_state(642, 362, kWrongSelectorVs, kSelectorPs);
+        const auto exact_wrong_target = selector_draw_state(1, 1, kSelectorVs, kSelectorPs);
+        const auto target_wrong_pair = selector_draw_state(
+            642, 362, kWrongSelectorVs, kWrongSelectorPs);
+        std::vector<GpuState> submits;
+        submits.push_back(selector_submit(                            // below lower bound
+            {exact}, 10, kSelectorCompute));
+        submits.push_back(selector_submit(                            // below lower bound
+            {exact}, 20, kSelectorCompute));
+        submits.push_back(selector_submit(                            // stages on different draws
+            {split_vs, split_ps}, 30, kSelectorCompute));
+        submits.push_back(selector_submit({wrong_vs}, 40, kSelectorCompute));
+        submits.push_back(selector_submit({wrong_ps}, 50, kSelectorCompute));
+        submits.push_back(selector_submit(                              // submit-wide false positive
+            {exact_wrong_target, target_wrong_pair}, 60, kSelectorCompute));
+        submits.push_back(selector_submit({exact}, 70));               // compute absent
+        submits.push_back(selector_submit({exact}, 80,                 // wrong compute program
+                                          kWrongSelectorCompute));
+        submits.push_back(selector_submit({exact}, 90,                 // first exact conjunction
+                                          kSelectorCompute));
+        submits.push_back(selector_submit({exact}, 100,                // must not retarget
+                                          kSelectorCompute));
+        for (size_t i = 0; i < submits.size(); ++i) {
+            const uint64_t submit_no = i + 1;
+            begin_gpu_timeline_submit(submit_no);
+            record_gpu_timeline_submit(submits[i], submit_no);
+        }
+    } else if (mode == "after") {
+        set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT", "1");
+        set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_WHEN_TARGET_DIM", "642x362");
+        set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_WHEN_VERTEX_PROGRAM",
+                     program_address(kSelectorVs));
+        set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_WHEN_FRAGMENT_PROGRAM",
+                     program_address(kSelectorPs));
+        set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_AFTER_COMPUTE_PROGRAM",
+                     program_address(kSelectorCompute));
+
+        const auto exact = selector_draw_state(642, 362, kSelectorVs, kSelectorPs);
+        const auto wrong_vs = selector_draw_state(642, 362, kWrongSelectorVs, kSelectorPs);
+        const auto split_vs = selector_draw_state(642, 362, kSelectorVs, kWrongSelectorPs);
+        const auto split_ps = selector_draw_state(642, 362, kWrongSelectorVs, kSelectorPs);
+        std::vector<GpuState> submits;
+        submits.push_back(selector_submit({exact}, 10, kWrongSelectorCompute));
+        submits.push_back(selector_submit({exact}, 20));               // wrong gate did not arm
+        submits.push_back(selector_submit({exact}, 30,                 // arm, never capture here
+                                          kSelectorCompute));
+        submits.push_back(selector_submit({wrong_vs}, 40));            // armed, wrong graphics
+        submits.push_back(selector_submit({split_vs, split_ps}, 50));  // split graphics pair
+        submits.push_back(selector_submit({exact}, 60));               // first valid later submit
+        submits.push_back(selector_submit({exact}, 70));               // must not retarget
+        for (size_t i = 0; i < submits.size(); ++i) {
+            const uint64_t submit_no = i + 1;
+            begin_gpu_timeline_submit(submit_no);
+            record_gpu_timeline_submit(submits[i], submit_no);
+        }
+    } else if (mode == "after-bound") {
+        set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT", "4");
+        set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_WHEN_TARGET_DIM", "642x362");
+        set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_WHEN_VERTEX_PROGRAM",
+                     program_address(kSelectorVs));
+        set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_WHEN_FRAGMENT_PROGRAM",
+                     program_address(kSelectorPs));
+        set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_AFTER_COMPUTE_PROGRAM",
+                     program_address(kSelectorCompute));
+
+        const auto exact = selector_draw_state(642, 362, kSelectorVs, kSelectorPs);
+        std::vector<GpuState> submits;
+        submits.push_back(selector_submit({exact}, 10, kSelectorCompute)); // arm before bound
+        submits.push_back(selector_submit({exact}, 20));                   // still below bound
+        submits.push_back(selector_submit({exact}, 30));                   // still below bound
+        submits.push_back(selector_submit({exact}, 40));                   // first at bound
+        for (size_t i = 0; i < submits.size(); ++i) {
+            const uint64_t submit_no = i + 1;
+            begin_gpu_timeline_submit(submit_no);
+            record_gpu_timeline_submit(submits[i], submit_no);
+        }
+    } else if (mode == "after-submit-zero") {
+        set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT", "1");
+        set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_WHEN_TARGET_DIM", "642x362");
+        set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_WHEN_VERTEX_PROGRAM",
+                     program_address(kSelectorVs));
+        set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_WHEN_FRAGMENT_PROGRAM",
+                     program_address(kSelectorPs));
+        set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_AFTER_COMPUTE_PROGRAM",
+                     program_address(kSelectorCompute));
+
+        const auto exact = selector_draw_state(642, 362, kSelectorVs, kSelectorPs);
+        begin_gpu_timeline_submit(0);
+        record_gpu_timeline_submit(selector_submit({exact}, 10, kSelectorCompute), 0);
+        begin_gpu_timeline_submit(1);
+        record_gpu_timeline_submit(selector_submit({exact}, 20), 1);
+    } else {
+        return 90;
+    }
+    close_gpu_timeline();
+
+    GpuTimelineFile timeline;
+    std::string error;
+    const bool timeline_ok = read_gpu_timeline(timeline_path, timeline, error);
+    bool ok = timeline_ok;
+    if (mode == "invalid" || mode == "after-invalid") {
+        ok = ok && timeline.submits.size() == 1 && timeline.details.empty() &&
+             !std::filesystem::exists(capture_path);
+    } else if (mode == "zero") {
+        GpuCaptureFile capture;
+        ok = ok && timeline.details.size() == 1 &&
+             read_gpu_capture(capture_path, capture, error) && capture.metadata.submit_index == 1;
+    } else if (mode == "semantic") {
+        GpuCaptureFile capture;
+        ok = ok && timeline.submits.size() == 10 && timeline.details.size() == 1 &&
+             timeline.details[0].submit_no == 9 &&
+             read_gpu_capture(capture_path, capture, error) && capture.metadata.submit_index == 9;
+    } else if (mode == "after") {
+        GpuCaptureFile capture;
+        ok = ok && timeline.submits.size() == 7 && timeline.details.size() == 1 &&
+             timeline.details[0].submit_no == 6 &&
+             read_gpu_capture(capture_path, capture, error) && capture.metadata.submit_index == 6;
+    } else if (mode == "after-bound") {
+        GpuCaptureFile capture;
+        ok = ok && timeline.submits.size() == 4 && timeline.details.size() == 1 &&
+             timeline.details[0].submit_no == 4 &&
+             read_gpu_capture(capture_path, capture, error) && capture.metadata.submit_index == 4;
+    } else {
+        GpuCaptureFile capture;
+        ok = ok && timeline.submits.size() == 2 && timeline.details.size() == 1 &&
+             timeline.details[0].submit_no == 1 &&
+             read_gpu_capture(capture_path, capture, error) && capture.metadata.submit_index == 1;
+    }
+    std::error_code ec;
+    std::filesystem::remove(timeline_path, ec);
+    std::filesystem::remove(capture_path, ec);
+    if (!ok) {
+        std::fprintf(stderr, "selector child '%s' failed: %s\n", mode.c_str(), error.c_str());
+        return 91;
+    }
+    return 0;
+}
+
+static int run_self(const char* executable, const char* mode) {
+    const std::string command = std::string("\"") + executable + "\" --selector-child " + mode;
+    const int status = std::system(command.c_str());
+#ifdef _WIN32
+    return status;
+#else
+    return WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+#endif
+}
+
+int main(int argc, char** argv) {
+    if (argc == 3 && std::string(argv[1]) == "--selector-child")
+        return run_selector_env_child(argv[2]);
     std::printf("== test_gpu_timeline ==\n");
+    CHECK(run_self(argv[0], "invalid") == 0,
+          "malformed graphics-program selector is rejected without capturing");
+    CHECK(run_self(argv[0], "after-invalid") == 0,
+          "malformed cross-submit compute gate is rejected without capturing");
+    CHECK(run_self(argv[0], "zero") == 0,
+          "zero graphics-program selectors and cross-submit compute gate remain disabled");
+    CHECK(run_self(argv[0], "semantic") == 0,
+          "graphics and compute selectors require one post-bound submit with the same-draw "
+          "graphics conjunction");
+    CHECK(run_self(argv[0], "after") == 0,
+          "cross-submit compute gate arms only on the exact program and captures a later exact "
+          "graphics conjunction once");
+    CHECK(run_self(argv[0], "after-bound") == 0,
+          "cross-submit compute gate may arm before the independent endpoint lower bound");
+    CHECK(run_self(argv[0], "after-submit-zero") == 0,
+          "cross-submit compute gate retains a submit-zero arm for a later submit-one capture");
     const auto nonce = std::chrono::steady_clock::now().time_since_epoch().count();
     const auto base = std::filesystem::temp_directory_path() /
         ("prosper-gpu-timeline-" + std::to_string(nonce));

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -226,6 +226,19 @@ submit at or after `CAPTURE_SUBMIT`; `PROSPER_GPU_TIMELINE_CAPTURE_MIN_DRAWS=N` 
 raw semantic draw sequence. `PROSPER_GPU_TIMELINE_CAPTURE_MIN_DISPATCHES=N` and
 `PROSPER_GPU_TIMELINE_CAPTURE_MAX_DISPATCHES=N` add dispatch-count bounds. Derive the full conjunction from
 repeated positives and nearby negative samples with the offline v6 selector.
+`PROSPER_GPU_TIMELINE_CAPTURE_WHEN_VERTEX_PROGRAM=ADDR` and
+`PROSPER_GPU_TIMELINE_CAPTURE_WHEN_FRAGMENT_PROGRAM=ADDR` further require one semantic draw to bind the
+configured ES/vertex and pixel programs. A target extent/index selector must match that same draw. Zero or
+unset stages are disabled. The program scan happens only after the cheaper timeline predicates and does not
+realize shaders or read resources before the endpoint is claimed.
+Combined graphics and compute selectors require both operations in one submit; treat this only as a phase
+conjunction, not evidence of a producer/consumer relationship.
+For a strict cross-submit phase gate, use
+`PROSPER_GPU_TIMELINE_CAPTURE_AFTER_COMPUTE_PROGRAM=ADDR`. The exact program arms the runtime request even
+before the endpoint lower bound, its own submit is never eligible, and normal endpoint predicates are allowed
+only on a later submit at or after the bound. Zero/unset disables it. The pre-arm path scans only retained
+dispatch register snapshots; the request-local latch adds no compute realization, resource reads, allocation,
+or Vulkan work and is not dependency evidence.
 When the endpoint moves, predecessor manifests roll forward so the final bundle retains the latest requested
 depth; dictionary bytes observed by evicted manifests still count against the unique-byte budget.
 Per-target RTT is the normal renderer path. `PROSPER_RTT_SINGLE_TARGET=1` restores the obsolete flattened

--- a/prosper/tools/gpu_timeline/README.md
+++ b/prosper/tools/gpu_timeline/README.md
@@ -219,5 +219,21 @@ convergence diagnostic, not evidence that the first native frame contained those
 `PROSPER_GPU_TIMELINE_CAPTURE_TARGET_DRAW_INDEX=MIN:MAX` restricts the matching target to a zero-based
 semantic draw-index window. Establish the range across multiple desired captures and nearby negative samples;
 realized replay indices can differ when earlier semantic draws are unrealized.
+`PROSPER_GPU_TIMELINE_CAPTURE_WHEN_VERTEX_PROGRAM=ADDR` and
+`PROSPER_GPU_TIMELINE_CAPTURE_WHEN_FRAGMENT_PROGRAM=ADDR` optionally select semantic ES/vertex and pixel
+program addresses. When both are set, one draw must bind the exact pair; target extent and draw-index
+predicates must also match that draw. Zero or an unset variable disables its stage. Matching only reads the
+already-folded register snapshots after the cheaper submit, target, and count predicates pass; it does not
+realize shaders, read resources, allocate capture data, or invoke Vulkan until an endpoint is selected.
+When combined with a compute-program or dispatch-dimension selector, the graphics draw and compute dispatch
+must occur in the same submit; this is a phase conjunction and does not imply a producer/consumer edge.
+`PROSPER_GPU_TIMELINE_CAPTURE_AFTER_COMPUTE_PROGRAM=ADDR` instead provides an explicit cross-submit phase
+gate. The exact compute program may arm the request before the configured endpoint lower bound, but its own
+submit can never be selected; the ordinary endpoint conjunction is permitted only on a strictly later submit
+at or after the lower bound. Zero or an unset variable disables the gate. Before it is armed, the enabled path
+only scans retained semantic dispatch register snapshots for the program address; after arming, it performs
+only the latched-submit comparison. It does not realize compute, read resources, allocate capture data, or
+invoke Vulkan. The latch belongs to the process-local capture request and still does not establish dependency
+or causality between the phase dispatch and a later draw.
 `PROSPER_GPU_TIMELINE_CAPTURE_MIN_DISPATCHES=N` and
 `PROSPER_GPU_TIMELINE_CAPTURE_MAX_DISPATCHES=N` restrict the same checkpoint by semantic dispatch count.


### PR DESCRIPTION
## Summary

- add same-draw semantic selectors for exact vertex/fragment program pairs, keeping target extent/index predicates attached to that draw
- add `PROSPER_GPU_TIMELINE_CAPTURE_AFTER_COMPUTE_PROGRAM` as a strict cross-submit phase gate: the matching compute submit arms capture, and only later submits may satisfy the endpoint
- keep the disabled path allocation-free and avoid shader realization, guest/resource reads, capture materialization, or Vulkan work while matching
- document the new selector semantics and focused workflow

## Why

Static submit numbers and wall-clock delays drift across long game routes. Plucky Squire first demonstrated the failure mode: submit 3715 occurred during LightingBase preload in one run, despite following Desk completion in another. The new phase gate anchors a detailed capture to semantic GPU work instead.

In the validating route, Desk_C01 finished loading, compute `0x30130f0000` armed the gate at submit 4032, and the exact later graphics pair captured at submit 4034. Offline graph analysis then ruled that pair out as the black base-scene producer: it belongs to five 4K overlay draws after the main VideoOut composition. Evidence is recorded on #1390.

The capsule/timeline remain private diagnostics and are not included. The visual output remains black, so this PR intentionally makes no screenshot or compatibility claim. The separate atomic-exit shutdown hang observed after the capsule flushed is tracked in #1534.

## Validation

- exact-head `test_gpu_timeline` build
- `gpu_timeline_roundtrip`
- `gpu_timeline_capture_exit`
- malformed/zero selectors
- submit-0 phase arming with strict submit-1 capture
- same-submit rejection, wrong/split graphics rejection, lower-bound interaction, and one-shot capture
- deterministic live Plucky phase-gated capture and offline inspect/graph
- `git diff --check origin/master...HEAD`

Snapshot tests were not run; they are optional for normal development PRs and required before releases.

Progresses #1390.