### PR TITLE
fix(runtime): retry concurrent write-watch fault deliveries

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -5331,7 +5331,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             "[render-timing] write_watch create=%llu ok=%llu pages=%llu no_map=%llu "
                             "alias=%llu oversized=%llu sizes=%llu/%llu/%llu/%llu protect=%llu "
                             "query=%llu unchanged=%llu dirty=%llu "
-                            "unknown=%llu faults=%llu physical=%llu rearms=%llu\n",
+                            "unknown=%llu faults=%llu stale=%llu physical=%llu rearms=%llu\n",
                             (unsigned long long)write_watch.create_attempts,
                             (unsigned long long)write_watch.registrations,
                             (unsigned long long)write_watch.registered_pages,
@@ -5348,6 +5348,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             (unsigned long long)write_watch.dirty,
                             (unsigned long long)write_watch.unknown,
                             (unsigned long long)write_watch.faults,
+                            (unsigned long long)write_watch.stale_faults,
                             (unsigned long long)write_watch.physical_writes,
                             (unsigned long long)write_watch.rearms);
                     const double wn = static_cast<double>(window.submits);

--- a/prosper/scripts/cobra/reach-title-or-gameplay.pad
+++ b/prosper/scripts/cobra/reach-title-or-gameplay.pad
@@ -3,8 +3,9 @@
 # pulses continue across the title and default new-game setup even when renderer throughput changes
 # the number of flips reached before each screen. The opening movies expose a hold-Square skip meter,
 # so separated Square holds skip those rather than sending ineffective Cross presses into the FMV.
-# Later Cross pulses advance dialogue; the final Right hold proves that the routed tutorial is
-# player-controlled rather than an attract sequence.
+# The first combat dialogue visibly asks for Cross, then the tutorial asks for R2. Separated R2
+# windows cover prompt timing variance while alternating left/right movement provides causal player
+# control evidence and avoids mistaking autonomous enemy fire for progression.
 # Validate this route with the default write-watch configuration; disabling or limiting watches does
 # not exercise the Unity worker-fault path that previously stopped progression at the movie skip.
 f300-312:cross
@@ -36,23 +37,10 @@ f4100-4112:cross
 55-56:cross
 60-64:square
 70-74:square
-80-84:square
-90-94:square
-100-104:square
-110-111:cross
-115-116:cross
-120-121:cross
-125-126:cross
-130-131:cross
-135-136:cross
-140-141:cross
-145-146:cross
-150-151:cross
-155-156:cross
-160-161:cross
-165-166:cross
-170-171:cross
-175-176:cross
-180-181:cross
-185-186:cross
-190-220:left-stick-right
+75-77:cross
+78-80:cross
+82-84:r2
+86-94:r2+left-stick-left
+96-104:r2+left-stick-right
+106-114:r2+left-stick-left
+116-124:r2+left-stick-right

--- a/prosper/src/host/guest_write_watch.cpp
+++ b/prosper/src/host/guest_write_watch.cpp
@@ -84,6 +84,7 @@ struct AtomicStats {
     std::atomic<uint64_t> dirty{0};
     std::atomic<uint64_t> unknown{0};
     std::atomic<uint64_t> faults{0};
+    std::atomic<uint64_t> stale_faults{0};
     std::atomic<uint64_t> physical_writes{0};
     std::atomic<uint64_t> rearms{0};
 };
@@ -339,6 +340,7 @@ GuestWriteWatchStats guest_write_watch_stats() {
         value.dirty.load(std::memory_order_relaxed),
         value.unknown.load(std::memory_order_relaxed),
         value.faults.load(std::memory_order_relaxed),
+        value.stale_faults.load(std::memory_order_relaxed),
         value.physical_writes.load(std::memory_order_relaxed),
         value.rearms.load(std::memory_order_relaxed),
     };
@@ -495,7 +497,8 @@ struct AtomicStats {
         create_bytes_le_1m{0}, create_bytes_le_8m{0}, create_bytes_le_32m{0},
         create_bytes_gt_32m{0},
         create_protect_failures{0},
-        queries{0}, unchanged{0}, dirty{0}, unknown{0}, faults{0}, physical_writes{0}, rearms{0};
+        queries{0}, unchanged{0}, dirty{0}, unknown{0}, faults{0}, stale_faults{0},
+        physical_writes{0}, rearms{0};
 };
 AtomicStats& stats() { static AtomicStats* value = new AtomicStats; return *value; }
 inline void bump(std::atomic<uint64_t>& c) { c.fetch_add(1, std::memory_order_relaxed); }
@@ -841,7 +844,8 @@ GuestWriteWatchStats guest_write_watch_stats() {
             v.create_bytes_le_8m.load(), v.create_bytes_le_32m.load(),
             v.create_bytes_gt_32m.load(), v.create_protect_failures.load(),
             v.queries.load(), v.unchanged.load(), v.dirty.load(),
-            v.unknown.load(), v.faults.load(), v.physical_writes.load(), v.rearms.load()};
+            v.unknown.load(), v.faults.load(), v.stale_faults.load(),
+            v.physical_writes.load(), v.rearms.load()};
 }
 
 void guest_write_watch_set_fault_onstack(bool on_altstack) {
@@ -1009,9 +1013,27 @@ bool guest_write_watch_handle_fault(uint64_t addr) {
         sched_yield();
         return true;
     }
-    auto it = w.pages_by_addr.find(addr & ~(kPage - 1));
-    if (it == w.pages_by_addr.end() || !it->second || !it->second->armed) return false;
+    const uint64_t fault_page = addr & ~(kPage - 1);
+    auto it = w.pages_by_addr.find(fault_page);
+    if (it == w.pages_by_addr.end() || !it->second) return false;
     WatchedPage* page = it->second;
+    if (!page->armed) {
+        // Two guest workers can take the same RO-page fault before either signal handler runs. The
+        // first handler restores RW and clears `armed`; the second delivery is already queued and used
+        // to fall through as a fatal guest fault despite the store now being safe to retry (Cobra's
+        // parallel vertex jobs hit exactly this race). Accept the stale delivery only while the live
+        // topology still describes this VA as CPU-writable. Protection changes update `w.aliases`, and
+        // unmaps remove both the alias and address index, so real read-only/unmapped faults stay fatal.
+        const bool live_cpu_writable = std::any_of(
+            w.aliases.begin(), w.aliases.end(), [&](const AliasRange& alias) {
+                return fault_page >= alias.addr && fault_page < alias.addr + alias.size &&
+                       cpu_writable(alias.prot);
+            });
+        if (!live_cpu_writable) return false;
+        bump(stats().faults);
+        bump(stats().stale_faults);
+        return true;
+    }
     // Allocation-free (signal context): restore write directly on the page's aliases. mprotect is a
     // syscall; the alias vector is already allocated and mutation-protected by the held lock. Do NOT
     // call set_pages_armed here — its rollback vector would malloc, which can deadlock a thread caught
@@ -1019,7 +1041,6 @@ bool guest_write_watch_handle_fault(uint64_t addr) {
     // store would re-fault forever, so keep the page armed (retry) rather than clearing it and dropping
     // into the fatal handler on the next fault. Disarming (RO->RW) merges VMAs and effectively never
     // fails, so this is a belt-and-braces guard, not an expected path.
-    const uint64_t fault_page = addr & ~(kPage - 1);
     bool faulting_alias_restored = true;
     for (const PageAlias& al : page->aliases) {
         if (!cpu_writable(al.prot)) continue;

--- a/prosper/src/host/guest_write_watch.hpp
+++ b/prosper/src/host/guest_write_watch.hpp
@@ -28,6 +28,7 @@ struct GuestWriteWatchStats {
     uint64_t dirty = 0;
     uint64_t unknown = 0;
     uint64_t faults = 0;
+    uint64_t stale_faults = 0;
     uint64_t physical_writes = 0;
     uint64_t rearms = 0;
 };

--- a/prosper/tests/test_guest_write_watch.cpp
+++ b/prosper/tests/test_guest_write_watch.cpp
@@ -178,6 +178,30 @@ int main() {
     CHECK(a[page + 0x40] == 0x5a, "write through alias A lands (no lost store)");
     CHECK(watch.query() == GuestWriteWatchQuery::Dirty, "watch reads Dirty after a CPU write");
 
+    // Two workers can fault on the same armed page before either handler restores it. Model the
+    // second, already-queued delivery deterministically: the first real signal above disarmed the
+    // still-live CPU-writable page, so a sibling delivery must be accepted and allowed to retry.
+    CHECK(prosper::host::guest_write_watch_handle_fault(
+              reinterpret_cast<uint64_t>(a + page + 0x48)),
+          "a stale sibling fault on a known writable page retries instead of becoming fatal");
+    CHECK(!prosper::host::guest_write_watch_handle_fault(0x9000000000ULL),
+          "an unknown stale-fault address remains unhandled");
+
+    // Fail closed when guest topology has genuinely made the known VA read-only. WatchedPage retains
+    // its registration until query/reset, so this specifically proves the stale-delivery path consults
+    // current mapping topology instead of accepting every known-but-disarmed page.
+    CHECK(mprotect(a + page, page, PROT_READ) == 0,
+          "known watched alias can be reprotected read-only for stale-fault test");
+    prosper::host::guest_write_watch_notify_direct_mapping_protection(
+        reinterpret_cast<uint64_t>(a + page), page, 0x1 /* CPU_READ only */);
+    CHECK(!prosper::host::guest_write_watch_handle_fault(
+              reinterpret_cast<uint64_t>(a + page + 0x48)),
+          "a genuine fault on a known read-only alias remains unhandled");
+    CHECK(mprotect(a + page, page, PROT_READ | PROT_WRITE) == 0,
+          "known watched alias restored writable after stale-fault test");
+    prosper::host::guest_write_watch_notify_direct_mapping_protection(
+        reinterpret_cast<uint64_t>(a + page), page, kCpuRw);
+
     // Re-arm, don't write -> Unchanged again.
     CHECK(watch.rearm(), "rearm succeeds");
     CHECK(watch.query() == GuestWriteWatchQuery::Unchanged, "no write since rearm -> Unchanged");
@@ -375,6 +399,7 @@ int main() {
     const auto stats = prosper::host::guest_write_watch_stats();
     CHECK(stats.registrations >= 1, "at least one watch armed");
     CHECK(stats.faults >= 2, "both alias-A and alias-B write faults were handled");
+    CHECK(stats.stale_faults >= 1, "stale concurrent fault delivery was counted");
     CHECK(stats.rearms >= 2, "rearm path exercised");
     CHECK(stats.create_oversized >= 1, "oversized exact-comparison fallback is observable");
 

--- a/prosper/tests/test_pad.cpp
+++ b/prosper/tests/test_pad.cpp
@@ -310,6 +310,7 @@ int main() {
         CHECK(pad_button_by_name("options") == SCE_PAD_BUTTON_OPTIONS, "name: options -> OPTIONS");
         CHECK(pad_button_by_name("cross")   == SCE_PAD_BUTTON_CROSS,   "name: cross -> CROSS");
         CHECK(pad_button_by_name("x")       == SCE_PAD_BUTTON_CROSS,   "name: x -> CROSS");
+        CHECK(pad_button_by_name("r2")      == SCE_PAD_BUTTON_R2,      "name: r2 -> R2");
         CHECK(pad_button_by_name("up")      == SCE_PAD_BUTTON_UP,      "name: up -> UP");
         CHECK(pad_button_by_name("nonsense")== 0,                      "name: unknown -> 0");
         CHECK(pad_button_names(SCE_PAD_BUTTON_OPTIONS) == "options", "names: options is canonical");
@@ -379,6 +380,16 @@ int main() {
         CHECK(overlaid.left_x == 0x80 && overlaid.left_y == 0x80 &&
               overlaid.right_x == 0x22 && overlaid.right_y == 0x00,
               "overlay: active axes map to Sony bytes and unspecified axes remain unchanged");
+
+        auto trigger_move = parse_pad_script("1-3:r2+left-stick-left");
+        CHECK(trigger_move.size() == 1 && trigger_move[0].button_mask == SCE_PAD_BUTTON_R2 &&
+              trigger_move[0].axis_mask == PAD_SCRIPT_LEFT_X && trigger_move[0].left_x == -1,
+              "parse: R2 and left-stick movement share a route entry");
+        const auto trigger_move_state = pad_script_state_at(trigger_move, 2.0, hold);
+        CHECK(trigger_move_state.button_mask == SCE_PAD_BUTTON_R2 &&
+              trigger_move_state.axis_mask == PAD_SCRIPT_LEFT_X &&
+              trigger_move_state.left_x == -1,
+              "eval: combined R2 and movement stay active inside their explicit range");
 
         // Malformed pieces are skipped, not fatal; an all-unknown entry drops out.
         auto s2 = parse_pad_script("nocolon;5:garbagebtn;7:down");


### PR DESCRIPTION
## Summary

- retry an already-queued sibling write fault when another worker has just disarmed the same watched page
- accept that retry only while the current live mapping topology still grants CPU write access; unknown, unmapped, and read-only faults remain fatal
- expose stale-delivery accounting and add deterministic positive and fail-closed regression tests
- refine Cobra’s deterministic route through both dialogue pages into R2 shooting and alternating movement

## Why

Cobra intermittently faulted in a normal `vmovss [rcx], xmm0` while the target VMA was already writable. Two workers could fault on the same armed page before either signal handler ran. The first handler restored write access and cleared the armed flag; the second queued delivery then looked unwatched and was incorrectly treated as a real guest crash.

## Validation

- focused memory/TLS suite: 5/5 green (`guest_write_watch`, dmem, initfault, ime_fs, DTV purge)
- `pad_input` green
- `git diff --check` clean
- fresh default Cobra run: 150.2s, 75/75 native frames, clean exit
- 63 registrations, 65,504 watched pages, 8,787 handled write faults, no worker crash
- both dialogue pages advanced; the R2 prompt cleared; Psychogun action and alternating player movement were visible
- no new screenshot: the run remains in the tutorial area already documented in the repository
- snapshot suite not run; this is not a release

Detailed private-run evidence and visual chronology: https://github.com/mattias800/prosper/issues/1356#issuecomment-5139154704

References #1356.