### PR TITLE
perf(timeline): gate detailed capture behind semantic phases

### DIFF
--- a/prosper/scripts/plucky-squire/README.md
+++ b/prosper/scripts/plucky-squire/README.md
@@ -1,0 +1,23 @@
+# The Plucky Squire routes
+
+Run the realtime fresh-save route from the repository root with:
+
+```sh
+scripts/plucky-squire/run-first-gameplay.sh /path/to/PPSA15319-app0
+```
+
+The launcher renders every submit at native scale and drives
+`reach-first-gameplay.pad`. It prints the new run directory before starting. Set
+`PROSPER_ARTIFACT_ROOT` to choose the parent directory, or pass a second argument
+that names a new, nonexistent run directory.
+
+Plucky can use two independent PS5 save paths. `PROSPER_SAVE0` backs files mounted
+under guest `/savedata0`; `PROSPER_SAVEDATA_DIR` backs SaveDataMemory slot blobs.
+They are cached independently on first use, so setting one does not configure the
+other. The launcher always creates separate fresh `save0/` and `savedata/` roots
+before the guest starts. Reuse an old run only for an intentional continuation;
+use a new run when comparing progression or renderer behavior.
+
+The longer `reach-first-gameplay.pad` route is intended for synchronous realtime
+rendering. `capture-first-gameplay.pad` is the accelerated trace/capture variant;
+it is not a timing-equivalent visual route.

--- a/prosper/scripts/plucky-squire/run-first-gameplay.sh
+++ b/prosper/scripts/plucky-squire/run-first-gameplay.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    echo "usage: $0 DUMP_DIR [NEW_RUN_DIR]" >&2
+}
+
+if (( $# < 1 || $# > 2 )); then
+    usage
+    exit 2
+fi
+
+script_dir="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+repo_root="$(CDPATH='' cd -- "$script_dir/../.." && pwd)"
+dump_dir="$1"
+app="${PROSPER_APP:-$repo_root/build-linux/prosper-app}"
+
+if [[ ! -d "$dump_dir" ]]; then
+    echo "Plucky Squire dump directory does not exist: $dump_dir" >&2
+    exit 2
+fi
+if [[ ! -x "$app" ]]; then
+    echo "prosper-app is not executable: $app" >&2
+    exit 2
+fi
+app="$(CDPATH='' cd -- "$(dirname -- "$app")" && pwd)/$(basename -- "$app")"
+
+if (( $# == 2 )); then
+    run_dir="$2"
+    if ! mkdir -- "$run_dir"; then
+        echo "NEW_RUN_DIR must not already exist: $run_dir" >&2
+        exit 2
+    fi
+else
+    user_state_root="${XDG_STATE_HOME:-${HOME:?HOME must be set}/.local/state}"
+    artifact_root="${PROSPER_ARTIFACT_ROOT:-$user_state_root/prosper-plucky}"
+    mkdir -p -- "$artifact_root"
+    run_dir="$(mktemp -d "$artifact_root/first-gameplay.XXXXXX")"
+fi
+
+mkdir -- "$run_dir/save0" "$run_dir/savedata"
+run_dir="$(CDPATH='' cd -- "$run_dir" && pwd)"
+dump_dir="$(CDPATH='' cd -- "$dump_dir" && pwd)"
+
+export PROSPER_GUEST_FS=1
+export PROSPER_GUEST_ARGS="${PROSPER_GUEST_ARGS:--force-gfx-direct}"
+export PROSPER_RENDER=1
+export PROSPER_RENDER_EVERY=1
+export PROSPER_RENDER_SCALE=1
+export PROSPER_PAD_SCRIPT=@scripts/plucky-squire/reach-first-gameplay.pad
+export PROSPER_CAPTURE_TITLE=PPSA15319
+export PROSPER_SAVE0="$run_dir/save0"
+export PROSPER_SAVEDATA_DIR="$run_dir/savedata"
+
+printf 'Plucky Squire fresh route\n'
+printf '  run directory: %s\n' "$run_dir"
+printf '  SAVE0 file-mount root: %s\n' "$PROSPER_SAVE0"
+printf '  SaveDataMemory root: %s\n' "$PROSPER_SAVEDATA_DIR"
+
+cd "$repo_root"
+exec "$app" --dump "$dump_dir"

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -1180,6 +1180,17 @@ void annotate_gpu_capture_scanout(GpuCaptureMetadata& metadata) {
         existing->second = value;
 }
 
+void annotate_gpu_capture_save_roots(GpuCaptureMetadata& metadata) {
+    const char* configured = std::getenv(kGpuCaptureSave0Env);
+    const std::string effective = configured ? configured : kGpuCaptureDefaultSave0Root;
+    const auto existing = std::find_if(metadata.renderer_env.begin(), metadata.renderer_env.end(),
+        [](const auto& entry) { return entry.first == kGpuCaptureSave0Env; });
+    if (existing == metadata.renderer_env.end())
+        metadata.renderer_env.emplace_back(kGpuCaptureSave0Env, effective);
+    else
+        existing->second = effective;
+}
+
 uint64_t parse_gpu_replay_scanout_address(const char* value) {
     if (!value || !*value) return 0;
     char* end = nullptr;
@@ -3645,6 +3656,7 @@ std::unique_ptr<PendingGpuCapture> begin_requested_gpu_capture(
         "PROSPER_TESTLUT", "PROSPER_TESTLUT32"
     };
     for (const char* name : render_env) if (const char* value = std::getenv(name)) m.renderer_env.emplace_back(name, value);
+    annotate_gpu_capture_save_roots(m);
     annotate_gpu_capture_scanout(m);
     pending->capture.metadata = m;
     if ((output_triggered || defer_materialization) && semantic_state &&

--- a/prosper/src/gpu/gpu_capture.hpp
+++ b/prosper/src/gpu/gpu_capture.hpp
@@ -25,10 +25,16 @@ struct GpuCaptureMetadata {
 
 inline constexpr const char* kGpuReplayScanoutAddressEnv =
     "PROSPER_GPU_REPLAY_SCANOUT_ADDR";
+inline constexpr const char* kGpuCaptureSave0Env = "PROSPER_SAVE0";
+inline constexpr const char* kGpuCaptureDefaultSave0Root = "/tmp/prosper-savedata0";
 
 // Preserve the exact registered front-buffer identity as replay metadata. The replay process has no
 // live VideoOut registry, so extent alone cannot distinguish scanout from same-sized intermediates.
 void annotate_gpu_capture_scanout(GpuCaptureMetadata& metadata);
+
+// Capture the effective host root behind guest /savedata0. This is distinct from savedata_dir,
+// which describes the SaveDataMemory API, and is cached independently by the HLE runtime.
+void annotate_gpu_capture_save_roots(GpuCaptureMetadata& metadata);
 
 // Parse the replay-only front-buffer identity. Bundle replay updates this value at each captured
 // submit, so consumers must not cache the result across renderer callbacks.

--- a/prosper/src/gpu/gpu_dependency_graph.cpp
+++ b/prosper/src/gpu/gpu_dependency_graph.cpp
@@ -51,7 +51,8 @@ void append_accesses(const ShaderResourceTable* table, const char* stage,
         const uint64_t size = resource_size(resource);
         if (!resource.gpu_addr || !size || resource.cls == ResourceClass::Sampler) continue;
         accesses.push_back({resource.gpu_addr, size, resource.width, resource.height,
-                            resource.binding, resource.cls, stage});
+                            resource.binding, resource.cls, stage, resource.format,
+                            resource.num_components, resource.srgb});
     }
 }
 
@@ -70,7 +71,8 @@ void append_compute_accesses(const ComputeItem& compute,
             if (!resource->gpu_addr || !size) continue;
             if (descriptor.readable)
                 reads.push_back({resource->gpu_addr, size, resource->width, resource->height,
-                                 resource->binding, resource->cls, "cs"});
+                                 resource->binding, resource->cls, "cs", resource->format,
+                                 resource->num_components, resource->srgb});
             if (descriptor.writable)
                 writes.push_back({0, resource->gpu_addr, size, resource->width,
                                   resource->height,
@@ -88,6 +90,27 @@ void append_compute_accesses(const ComputeItem& compute,
 }
 
 } // namespace
+
+bool gpu_dependency_rtt_seed_matches(const GpuDependencyAccess& access,
+                                     const GpuCaptureRttSeed& seed) {
+    if (!access.addr || !access.width || !access.height || access.srgb ||
+        seed.guest_addr != access.addr || seed.width != access.width ||
+        seed.height != access.height)
+        return false;
+    switch (seed.format) {
+        case GpuCaptureColorFormat::Rgba8Unorm:
+            return access.format == DataFormat::Unorm8 && access.num_components == 4;
+        case GpuCaptureColorFormat::Rgba16Float:
+            return access.format == DataFormat::Float16 && access.num_components == 4;
+        case GpuCaptureColorFormat::R11G11B10Float:
+            return access.format == DataFormat::Float10_11_11 && access.num_components == 3;
+        case GpuCaptureColorFormat::R8Unorm:
+            return access.format == DataFormat::Unorm8 && access.num_components == 1;
+        case GpuCaptureColorFormat::R32Uint:
+            return access.format == DataFormat::Uint32 && access.num_components == 1;
+    }
+    return false;
+}
 
 bool build_gpu_dependency_graph(const GpuReplayFrame& replay,
                                 GpuDependencyGraph& graph, std::string& error) {
@@ -160,7 +183,14 @@ bool build_gpu_dependency_graph(const GpuReplayFrame& replay,
             if (producer == writers.rend()) {
                 auto leaf = std::find_if(graph.external_leaves.begin(), graph.external_leaves.end(),
                     [&](const GpuDependencyLeaf& candidate) {
-                        return candidate.access.addr == access.addr && candidate.access.size == access.size;
+                        return candidate.access.addr == access.addr &&
+                               candidate.access.size == access.size &&
+                               candidate.access.width == access.width &&
+                               candidate.access.height == access.height &&
+                               candidate.access.resource_class == access.resource_class &&
+                               candidate.access.format == access.format &&
+                               candidate.access.num_components == access.num_components &&
+                               candidate.access.srgb == access.srgb;
                     });
                 if (leaf == graph.external_leaves.end())
                     graph.external_leaves.push_back({access, {static_cast<uint32_t>(operation_index)}, UINT32_MAX});

--- a/prosper/src/gpu/gpu_dependency_graph.hpp
+++ b/prosper/src/gpu/gpu_dependency_graph.hpp
@@ -16,6 +16,9 @@ struct GpuDependencyAccess {
     uint32_t binding = 0;
     ResourceClass resource_class = ResourceClass::ConstantBuffer;
     std::string stage;
+    DataFormat format = DataFormat::Unknown;
+    uint32_t num_components = 0;
+    bool srgb = false;
 };
 
 struct GpuDependencyNode {
@@ -46,5 +49,11 @@ struct GpuDependencyGraph {
 
 bool build_gpu_dependency_graph(const GpuReplayFrame& replay,
                                 GpuDependencyGraph& graph, std::string& error);
+
+// A live RTT seed is a closed external image dependency only when it represents the exact sampled
+// view. Address-only matches are unsafe: the same allocation can be reinterpreted at another extent
+// or format, which would make a nominally complete bundle replay different pixels.
+bool gpu_dependency_rtt_seed_matches(const GpuDependencyAccess& access,
+                                     const GpuCaptureRttSeed& seed);
 
 } // namespace prosper::gpu

--- a/prosper/src/gpu/gpu_timeline.cpp
+++ b/prosper/src/gpu/gpu_timeline.cpp
@@ -664,24 +664,24 @@ struct RuntimeProducerHistory {
         enabled = true;
     }
 
-    const RuntimeTargetWrite* latest_overlap(uint64_t addr, uint64_t size) const {
-        auto end = [](uint64_t base, uint64_t bytes) {
-            return bytes > UINT64_MAX - base ? UINT64_MAX : base + bytes;
-        };
+    const RuntimeTargetWrite* latest_image(uint64_t addr, uint32_t width,
+                                           uint32_t height) const {
         for (auto submit = submits.rbegin(); submit != submits.rend(); ++submit)
             for (auto write = submit->rbegin(); write != submit->rend(); ++write)
-                if (addr < end(write->addr, write->size) && write->addr < end(addr, size))
+                if (write->addr == addr && (!width || write->width == width) &&
+                    (!height || write->height == height))
                     return &*write;
         return nullptr;
     }
 
-    RuntimeTargetLifetime lifetime_overlap(uint64_t addr, uint64_t size) const {
-        auto end = [](uint64_t base, uint64_t bytes) {
-            return bytes > UINT64_MAX - base ? UINT64_MAX : base + bytes;
-        };
+    RuntimeTargetLifetime lifetime_image(uint64_t addr, uint32_t width,
+                                         uint32_t height) const {
         RuntimeTargetLifetime lifetime;
         for (const auto& [key, aggregate] : lifetimes) {
-            if (addr >= end(key.addr, key.size) || key.addr >= end(addr, size)) continue;
+            (void)key;
+            if (aggregate.last.addr != addr || (width && aggregate.last.width != width) ||
+                (height && aggregate.last.height != height))
+                continue;
             if (!lifetime.first || aggregate.first.submit_no < lifetime.first->submit_no ||
                 (aggregate.first.submit_no == lifetime.first->submit_no &&
                  aggregate.first.command_order < lifetime.first->command_order))
@@ -714,6 +714,7 @@ struct RuntimeCaptureBundle {
     std::chrono::steady_clock::time_point started_at;
     uint64_t captured_resource_bytes = 0;
     uint64_t captured_submit_count = 0;
+    GpuTimelineBundleProvenanceState provenance;
 };
 
 RuntimeCaptureBundle& runtime_capture_bundle() {
@@ -723,6 +724,42 @@ RuntimeCaptureBundle& runtime_capture_bundle() {
 
 void reset_runtime_capture_bundle() {
     runtime_capture_bundle() = {};
+}
+
+GpuTimelineProducerProvenance runtime_image_provenance(
+    const GpuDependencyAccess& access, const GpuCaptureFile& capture,
+    const RuntimeProducerHistory& history) {
+    if (history.latest_image(access.addr, access.width, access.height))
+        return GpuTimelineProducerProvenance::ProducerHistory;
+    if (std::any_of(capture.rtt_seeds.begin(), capture.rtt_seeds.end(),
+                    [&](const GpuCaptureRttSeed& seed) {
+                        return gpu_dependency_rtt_seed_matches(access, seed);
+                    }))
+        return GpuTimelineProducerProvenance::ExactRttSeed;
+    return history.phase_bounded
+        ? GpuTimelineProducerProvenance::PhaseHistoryBounded
+        : GpuTimelineProducerProvenance::Unknown;
+}
+
+bool observe_runtime_bundle_provenance(const GpuCaptureFile& capture,
+                                       const RuntimeProducerHistory& history,
+                                       GpuTimelineBundleProvenanceState& provenance,
+                                       uint64_t submit_no, std::string& error) {
+    GpuReplayFrame replay;
+    GpuDependencyGraph graph;
+    if (!materialize_gpu_replay(capture, replay, error) ||
+        !build_gpu_dependency_graph(replay, graph, error))
+        return false;
+    for (const auto& leaf : graph.external_leaves) {
+        if (leaf.access.resource_class != ResourceClass::Texture &&
+            leaf.access.resource_class != ResourceClass::StorageImage)
+            continue;
+        gpu_timeline_observe_bundle_provenance(
+            provenance, submit_no,
+            runtime_image_provenance(leaf.access, capture, history),
+            leaf.first_future_writer);
+    }
+    return true;
 }
 
 enum class RuntimeCapturePhaseObservation { Ready, Waiting, ArmedThisSubmit };
@@ -1014,6 +1051,15 @@ bool gpu_timeline_bundle_provenance_complete(GpuTimelineProducerProvenance prove
                                              uint32_t future_writer_operation) {
     return future_writer_operation == UINT32_MAX ||
            provenance != GpuTimelineProducerProvenance::PhaseHistoryBounded;
+}
+
+void gpu_timeline_observe_bundle_provenance(
+    GpuTimelineBundleProvenanceState& state, uint64_t submit_no,
+    GpuTimelineProducerProvenance provenance, uint32_t future_writer_operation) {
+    if (gpu_timeline_bundle_provenance_complete(provenance, future_writer_operation)) return;
+    if (state.complete) state.first_incomplete_submit_no = submit_no;
+    state.complete = false;
+    ++state.bounded_unknown_leaf_count;
 }
 
 struct GpuTimelineWriter::Impl {
@@ -2027,15 +2073,34 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
                                              metadata, predecessor, error)
             : capture_gpustate_submit(state, submit_no, metadata.width, metadata.height,
                                       metadata, predecessor, error);
-        if (!captured ||
+        RuntimeCaptureBundle& bundle_state = runtime_capture_bundle();
+        const bool provenance_was_complete = bundle_state.provenance.complete;
+        if (captured && history.phase_bounded) {
+            std::string provenance_error;
+            if (!observe_runtime_bundle_provenance(
+                    predecessor, history, bundle_state.provenance, submit_no,
+                    provenance_error)) {
+                bundle_state.provenance.complete = false;
+                bundle_state.provenance.graph_unavailable = true;
+                bundle_state.provenance.first_incomplete_submit_no = submit_no;
+                error = "dependency graph unavailable for phase-bounded bundle submit: " +
+                        provenance_error;
+            } else if (!bundle_state.provenance.complete) {
+                error = "phase-bounded producer history leaves temporal image dependencies "
+                        "unresolved in bundle submit " + std::to_string(
+                            bundle_state.provenance.first_incomplete_submit_no);
+            }
+            if (provenance_was_complete && !bundle_state.provenance.complete)
+                request.bundle_provenance_failures.fetch_add(1, std::memory_order_relaxed);
+        }
+        if (!captured || !bundle_state.provenance.complete ||
             !append_runtime_capture_bundle(predecessor, request.bundle_max_unique_bytes, error)) {
-            runtime_capture_bundle().failed = !runtime_capture_bundle().budget_exhausted;
+            bundle_state.failed = !bundle_state.budget_exhausted;
             std::fprintf(stderr, "[timeline] bundle submit %llu capture failed: %s\n",
                          static_cast<unsigned long long>(submit_no), error.c_str());
         } else {
             if (request.semantic_selector)
                 trim_runtime_capture_bundle(request.bundle_depth - 1);
-            RuntimeCaptureBundle& bundle_state = runtime_capture_bundle();
             ++bundle_state.captured_submit_count;
             request.bundle_submits_captured.fetch_add(1, std::memory_order_relaxed);
             if (request.bundle_checkpoint_interval &&
@@ -2160,8 +2225,10 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
                  static_cast<unsigned long long>(total_ms), request.path.c_str());
     GpuReplayFrame replay;
     GpuDependencyGraph graph;
-    bool bundle_provenance_complete = true;
-    size_t bounded_temporal_leaf_count = 0;
+    RuntimeCaptureBundle* requested_bundle = request.bundle_path.empty()
+        ? nullptr : &runtime_capture_bundle();
+    const bool endpoint_provenance_was_complete =
+        !requested_bundle || requested_bundle->provenance.complete;
     if (materialize_gpu_replay(capture, replay, error) &&
         build_gpu_dependency_graph(replay, graph, error)) {
         for (const auto& leaf : graph.external_leaves) {
@@ -2175,8 +2242,8 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
             producer.resource_size = leaf.access.size;
             producer.resource_width = leaf.access.width;
             producer.resource_height = leaf.access.height;
-            const RuntimeTargetLifetime lifetime = history.lifetime_overlap(
-                leaf.access.addr, leaf.access.size);
+            const RuntimeTargetLifetime lifetime = history.lifetime_image(
+                leaf.access.addr, leaf.access.width, leaf.access.height);
             producer.history_window_first_submit_no = history.window_first_submit_no();
             producer.history_lower_bound_submit_no = history.lower_bound_submit_no;
             producer.lifetime_truncated = history.lifetime_truncated;
@@ -2198,32 +2265,22 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
                 producer.first_color_format = lifetime.first->color_format;
             }
             const RuntimeTargetWrite* match = lifetime.last
-                ? lifetime.last : history.latest_overlap(leaf.access.addr, leaf.access.size);
+                ? lifetime.last : history.latest_image(
+                    leaf.access.addr, leaf.access.width, leaf.access.height);
+            producer.provenance = runtime_image_provenance(leaf.access, capture, history);
             if (match) {
                 producer.resolved = true;
-                producer.provenance = GpuTimelineProducerProvenance::ProducerHistory;
                 producer.producer_submit_no = match->submit_no;
                 producer.producer_draw_index = match->draw_index;
                 producer.producer_command_order = match->command_order;
                 producer.producer_target_addr = match->addr;
                 producer.producer_width = match->width;
                 producer.producer_height = match->height;
-            } else {
-                const bool exact_rtt_seed = std::any_of(
-                    capture.rtt_seeds.begin(), capture.rtt_seeds.end(),
-                    [&](const GpuCaptureRttSeed& seed) {
-                        return gpu_dependency_rtt_seed_matches(leaf.access, seed);
-                    });
-                if (exact_rtt_seed)
-                    producer.provenance = GpuTimelineProducerProvenance::ExactRttSeed;
-                else if (history.phase_bounded)
-                    producer.provenance = GpuTimelineProducerProvenance::PhaseHistoryBounded;
             }
-            if (!gpu_timeline_bundle_provenance_complete(
-                    producer.provenance, leaf.first_future_writer)) {
-                bundle_provenance_complete = false;
-                ++bounded_temporal_leaf_count;
-            }
+            if (requested_bundle)
+                gpu_timeline_observe_bundle_provenance(
+                    requested_bundle->provenance, submit_no, producer.provenance,
+                    leaf.first_future_writer);
             if (!writer->append_producer(producer, error)) {
                 runtime_recorder().mark_failed(error);
                 history.remember(state, submit_no);
@@ -2272,10 +2329,17 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
     } else {
         std::fprintf(stderr, "[timeline] dependency graph failed for submit %llu: %s\n",
                      static_cast<unsigned long long>(submit_no), error.c_str());
-        if (history.phase_bounded && !request.bundle_path.empty())
-            bundle_provenance_complete = false;
+        if (history.phase_bounded && requested_bundle) {
+            if (requested_bundle->provenance.complete)
+                requested_bundle->provenance.first_incomplete_submit_no = submit_no;
+            requested_bundle->provenance.complete = false;
+            requested_bundle->provenance.graph_unavailable = true;
+        }
         error.clear();
     }
+    if (requested_bundle && endpoint_provenance_was_complete &&
+        !requested_bundle->provenance.complete)
+        request.bundle_provenance_failures.fetch_add(1, std::memory_order_relaxed);
     const bool predecessor_requested = !request.semantic_selector &&
         !request.predecessor_path.empty() && request.submit_no > 1;
     bool requested_artifacts_written = !predecessor_requested ||
@@ -2283,15 +2347,17 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
     if (!request.bundle_path.empty()) {
         RuntimeCaptureBundle& state = runtime_capture_bundle();
         GpuCaptureBundle& bundle = state.bundle;
-        if (!bundle_provenance_complete) {
+        if (!state.provenance.complete) {
             state.failed = true;
-            request.bundle_provenance_failures.fetch_add(1, std::memory_order_relaxed);
-            if (bounded_temporal_leaf_count)
-                error = "phase-bounded producer history leaves " +
-                    std::to_string(bounded_temporal_leaf_count) +
-                    " temporal image dependency/dependencies unresolved";
+            if (state.provenance.bounded_unknown_leaf_count)
+                error = "phase-bounded bundle submit " + std::to_string(
+                    state.provenance.first_incomplete_submit_no) + " has " +
+                    std::to_string(state.provenance.bounded_unknown_leaf_count) +
+                    " unresolved temporal image dependency/dependencies";
             else
-                error = "phase-bounded dependency graph unavailable; temporal closure is unknown";
+                error = "phase-bounded dependency graph unavailable at bundle submit " +
+                    std::to_string(state.provenance.first_incomplete_submit_no) +
+                    "; temporal closure is unknown";
             std::fprintf(stderr,
                          "[timeline] capture bundle finalization refused: %s; standalone capsule "
                          "remains available at %s\n",

--- a/prosper/src/gpu/gpu_timeline.cpp
+++ b/prosper/src/gpu/gpu_timeline.cpp
@@ -37,7 +37,7 @@ namespace {
 
 constexpr uint8_t kFileMagic[8] = {'P', 'R', 'G', 'T', 'L', 'N', '\0', '\0'};
 constexpr uint8_t kRecordMagic[4] = {'T', 'L', 'R', 'C'};
-constexpr uint32_t kVersion = 8;
+constexpr uint32_t kVersion = 9;
 constexpr uint32_t kEndian = 0x01020304u;
 constexpr uint32_t kMaxPayloadBytes = 1u << 20;
 constexpr uint32_t kFlushInterval = 256;
@@ -270,6 +270,17 @@ struct RuntimeDetailRequest {
     std::atomic<bool> predecessor_failed{false};
     bool bundle_start_reached = false;
     bool after_compute_seen = false;
+    std::atomic<uint64_t> phase_observation_submits{0};
+    std::atomic<uint64_t> phase_dispatches_scanned{0};
+    std::atomic<uint64_t> prearm_history_submits_skipped{0};
+    std::atomic<uint64_t> prearm_history_draws_skipped{0};
+    std::atomic<uint64_t> prearm_bundle_submits_skipped{0};
+    std::atomic<uint64_t> history_submits_recorded{0};
+    std::atomic<uint64_t> bundle_submits_captured{0};
+    std::atomic<uint64_t> detail_submits_captured{0};
+    std::atomic<uint64_t> bundle_provenance_failures{0};
+    std::atomic<uint64_t> history_lower_bound_submit_no{0};
+    std::atomic<bool> history_phase_bounded{false};
 
     RuntimeDetailRequest() {
         const char* path_env = std::getenv("PROSPER_GPU_TIMELINE_CAPTURE");
@@ -581,9 +592,12 @@ struct RuntimeProducerHistory {
     uint64_t dropped_submits = 0;
     std::unordered_map<RuntimeTargetKey, RuntimeTargetAggregate, RuntimeTargetKeyHash> lifetimes;
     bool lifetime_truncated = false;
+    uint64_t lower_bound_submit_no = 0;
+    bool phase_bounded = false;
 
     RuntimeProducerHistory() {
-        enabled = runtime_detail_request().valid;
+        const RuntimeDetailRequest& request = runtime_detail_request();
+        enabled = request.valid && !request.select_after_compute_program;
         if (const char* value = std::getenv("PROSPER_GPU_TIMELINE_HISTORY")) {
             char* end = nullptr;
             const uint64_t parsed = std::strtoull(value, &end, 0);
@@ -593,6 +607,7 @@ struct RuntimeProducerHistory {
 
     void remember(const GpuState& state, uint64_t submit_no) {
         if (!enabled) return;
+        runtime_detail_request().history_submits_recorded.fetch_add(1, std::memory_order_relaxed);
         if (!first_submit_no) first_submit_no = submit_no;
         std::vector<RuntimeTargetWrite> writes;
         writes.reserve(state.draws.size() * kColorTargetCount);
@@ -636,6 +651,17 @@ struct RuntimeProducerHistory {
         }
         submits.push_back(std::move(writes));
         while (submits.size() > capacity) { submits.pop_front(); ++dropped_submits; }
+    }
+
+    void begin_phase(uint64_t submit_no) {
+        submits.clear();
+        lifetimes.clear();
+        first_submit_no = 0;
+        dropped_submits = 0;
+        lifetime_truncated = false;
+        lower_bound_submit_no = submit_no;
+        phase_bounded = true;
+        enabled = true;
     }
 
     const RuntimeTargetWrite* latest_overlap(uint64_t addr, uint64_t size) const {
@@ -695,27 +721,50 @@ RuntimeCaptureBundle& runtime_capture_bundle() {
     return state;
 }
 
+void reset_runtime_capture_bundle() {
+    runtime_capture_bundle() = {};
+}
+
+enum class RuntimeCapturePhaseObservation { Ready, Waiting, ArmedThisSubmit };
+
+RuntimeCapturePhaseObservation observe_runtime_capture_phase(RuntimeDetailRequest& request,
+                                                             const GpuState& state,
+                                                             uint64_t submit_no) {
+    if (!request.select_after_compute_program || request.after_compute_seen)
+        return RuntimeCapturePhaseObservation::Ready;
+    request.phase_observation_submits.fetch_add(1, std::memory_order_relaxed);
+    for (const auto& dispatch : state.dispatches) {
+        request.phase_dispatches_scanned.fetch_add(1, std::memory_order_relaxed);
+        if (compute_dispatch_code_addr(state, dispatch) != request.select_after_compute_program)
+            continue;
+        request.after_compute_submit_no = submit_no;
+        request.after_compute_seen = true;
+        std::fprintf(stderr,
+                     "[timeline] capture after-compute gate armed submit=%llu program=0x%llx "
+                     "observed-submits=%llu dispatches-scanned=%llu history-submits-skipped=%llu "
+                     "history-draws-skipped=%llu bundle-submits-skipped=%llu\n",
+                     static_cast<unsigned long long>(submit_no),
+                     static_cast<unsigned long long>(request.select_after_compute_program),
+                     static_cast<unsigned long long>(
+                         request.phase_observation_submits.load(std::memory_order_relaxed)),
+                     static_cast<unsigned long long>(
+                         request.phase_dispatches_scanned.load(std::memory_order_relaxed)),
+                     static_cast<unsigned long long>(
+                         request.prearm_history_submits_skipped.load(std::memory_order_relaxed)),
+                     static_cast<unsigned long long>(
+                         request.prearm_history_draws_skipped.load(std::memory_order_relaxed)),
+                     static_cast<unsigned long long>(
+                         request.prearm_bundle_submits_skipped.load(std::memory_order_relaxed)));
+        return RuntimeCapturePhaseObservation::ArmedThisSubmit;
+    }
+    return RuntimeCapturePhaseObservation::Waiting;
+}
+
 bool runtime_capture_endpoint_matches(RuntimeDetailRequest& request,
                                       const GpuTimelineSubmit& submit,
                                       const GpuState& state) {
     const uint64_t submit_no = submit.submit_no;
     if (request.select_after_compute_program) {
-        if (!request.after_compute_seen) {
-            for (const auto& dispatch : state.dispatches) {
-                if (compute_dispatch_code_addr(state, dispatch) !=
-                    request.select_after_compute_program)
-                    continue;
-                request.after_compute_submit_no = submit_no;
-                request.after_compute_seen = true;
-                std::fprintf(stderr,
-                             "[timeline] capture after-compute gate armed submit=%llu "
-                             "program=0x%llx\n",
-                             static_cast<unsigned long long>(submit_no),
-                             static_cast<unsigned long long>(
-                                 request.select_after_compute_program));
-                break;
-            }
-        }
         // The phase program's submit only arms the request. Even if it also satisfies every
         // endpoint predicate, capture begins with a strictly later submit.
         if (!request.after_compute_seen ||
@@ -891,6 +940,12 @@ GpuCaptureMetadata runtime_capture_metadata(uint64_t submit_no) {
     metadata.title_id = env_or_empty("PROSPER_CAPTURE_TITLE");
     metadata.input_route = env_or_empty("PROSPER_PAD_SCRIPT");
     metadata.savedata_dir = env_or_empty("PROSPER_SAVEDATA_DIR");
+    RuntimeDetailRequest& request = runtime_detail_request();
+    const uint64_t history_lower_bound =
+        request.history_lower_bound_submit_no.load(std::memory_order_relaxed);
+    if (request.history_phase_bounded.load(std::memory_order_relaxed))
+        metadata.renderer_env.emplace_back(
+            "PROSPER_CAPTURE_HISTORY_LOWER_BOUND_SUBMIT", std::to_string(history_lower_bound));
     annotate_gpu_capture_scanout(metadata);
     return metadata;
 }
@@ -925,6 +980,40 @@ void log_capture_detail(const GpuTimelineDetail& detail) {
 }
 
 } // namespace
+
+GpuTimelineCaptureCounters gpu_timeline_capture_counters() {
+    const RuntimeDetailRequest& request = runtime_detail_request();
+    GpuTimelineCaptureCounters counters;
+    counters.phase_observation_submits =
+        request.phase_observation_submits.load(std::memory_order_relaxed);
+    counters.phase_dispatches_scanned =
+        request.phase_dispatches_scanned.load(std::memory_order_relaxed);
+    counters.prearm_history_submits_skipped =
+        request.prearm_history_submits_skipped.load(std::memory_order_relaxed);
+    counters.prearm_history_draws_skipped =
+        request.prearm_history_draws_skipped.load(std::memory_order_relaxed);
+    counters.prearm_bundle_submits_skipped =
+        request.prearm_bundle_submits_skipped.load(std::memory_order_relaxed);
+    counters.history_submits_recorded =
+        request.history_submits_recorded.load(std::memory_order_relaxed);
+    counters.bundle_submits_captured =
+        request.bundle_submits_captured.load(std::memory_order_relaxed);
+    counters.detail_submits_captured =
+        request.detail_submits_captured.load(std::memory_order_relaxed);
+    counters.bundle_provenance_failures =
+        request.bundle_provenance_failures.load(std::memory_order_relaxed);
+    counters.history_lower_bound_submit_no =
+        request.history_lower_bound_submit_no.load(std::memory_order_relaxed);
+    counters.history_phase_bounded =
+        request.history_phase_bounded.load(std::memory_order_relaxed);
+    return counters;
+}
+
+bool gpu_timeline_bundle_provenance_complete(GpuTimelineProducerProvenance provenance,
+                                             uint32_t future_writer_operation) {
+    return future_writer_operation == UINT32_MAX ||
+           provenance != GpuTimelineProducerProvenance::PhaseHistoryBounded;
+}
 
 struct GpuTimelineWriter::Impl {
     FILE* file = nullptr;
@@ -1126,6 +1215,8 @@ bool GpuTimelineWriter::append_producer(const GpuTimelineProducer& producer, std
     payload.u32(producer.first_color_control_mode);
     payload.u32(producer.first_target_mask);
     payload.u32(producer.first_color_format);
+    payload.u64(producer.history_lower_bound_submit_no);
+    payload.u32(static_cast<uint32_t>(producer.provenance));
     return impl_->append(RecordType::Producer, payload, error);
 }
 
@@ -1404,6 +1495,18 @@ bool read_gpu_timeline(const std::string& path, GpuTimelineFile& timeline, std::
                 producer.lifetime_truncated = lifetime_truncated != 0;
                 producer.history_window_truncated = window_truncated != 0;
                 producer.first_color_has_clear = has_clear != 0;
+            }
+            if (version >= 9) {
+                uint32_t provenance = 0;
+                if (!p.u64(producer.history_lower_bound_submit_no) || !p.u32(provenance) ||
+                    provenance > static_cast<uint32_t>(
+                        GpuTimelineProducerProvenance::PhaseHistoryBounded)) {
+                    error = "invalid timeline producer provenance record";
+                    return false;
+                }
+                producer.provenance = static_cast<GpuTimelineProducerProvenance>(provenance);
+            } else if (producer.resolved) {
+                producer.provenance = GpuTimelineProducerProvenance::ProducerHistory;
             }
             if (p.left) { error = "invalid timeline producer record size"; return false; }
             timeline.producers.push_back(std::move(producer));
@@ -1871,6 +1974,27 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
 
     RuntimeDetailRequest& request = runtime_detail_request();
     RuntimeProducerHistory& history = runtime_producer_history();
+    const RuntimeCapturePhaseObservation phase = request.valid
+        ? observe_runtime_capture_phase(request, state, submit_no)
+        : RuntimeCapturePhaseObservation::Ready;
+    if (phase == RuntimeCapturePhaseObservation::Waiting) {
+        request.prearm_history_submits_skipped.fetch_add(1, std::memory_order_relaxed);
+        request.prearm_history_draws_skipped.fetch_add(state.draws.size(),
+                                                       std::memory_order_relaxed);
+        if (!request.bundle_path.empty())
+            request.prearm_bundle_submits_skipped.fetch_add(1, std::memory_order_relaxed);
+        return;
+    }
+    if (phase == RuntimeCapturePhaseObservation::ArmedThisSubmit) {
+        history.begin_phase(submit_no);
+        request.history_lower_bound_submit_no.store(submit_no, std::memory_order_relaxed);
+        request.history_phase_bounded.store(true, std::memory_order_relaxed);
+        reset_runtime_capture_bundle();
+        // A bundle-start target observed before the semantic phase is not a valid post-phase
+        // boundary. Re-evaluate the arming submit below so it can be retained when it is the first
+        // valid start and producer.
+        request.bundle_start_reached = false;
+    }
     if (request.valid && request.bundle_start_target_width && !request.bundle_start_reached &&
         runtime_submit_has_target(state, request.bundle_start_target_width,
                                   request.bundle_start_target_height,
@@ -1912,6 +2036,7 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
                 trim_runtime_capture_bundle(request.bundle_depth - 1);
             RuntimeCaptureBundle& bundle_state = runtime_capture_bundle();
             ++bundle_state.captured_submit_count;
+            request.bundle_submits_captured.fetch_add(1, std::memory_order_relaxed);
             if (request.bundle_checkpoint_interval &&
                 !(bundle_state.captured_submit_count % request.bundle_checkpoint_interval)) {
                 if (!write_gpu_capture_bundle(request.bundle_path, bundle_state.bundle, error)) {
@@ -1969,6 +2094,7 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
 
     GpuCaptureFile capture;
     if (!request.bundle_path.empty()) begin_runtime_capture_bundle();
+    request.detail_submits_captured.fetch_add(1, std::memory_order_relaxed);
     const auto capture_started = std::chrono::steady_clock::now();
     std::fprintf(stderr, "[timeline] submit %llu detailed capture starting: semantic-draws=%zu "
                          "semantic-dispatches=%zu metadata-only=%s\n",
@@ -2033,6 +2159,8 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
                  static_cast<unsigned long long>(total_ms), request.path.c_str());
     GpuReplayFrame replay;
     GpuDependencyGraph graph;
+    bool bundle_provenance_complete = true;
+    size_t bounded_temporal_leaf_count = 0;
     if (materialize_gpu_replay(capture, replay, error) &&
         build_gpu_dependency_graph(replay, graph, error)) {
         for (const auto& leaf : graph.external_leaves) {
@@ -2049,6 +2177,7 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
             const RuntimeTargetLifetime lifetime = history.lifetime_overlap(
                 leaf.access.addr, leaf.access.size);
             producer.history_window_first_submit_no = history.window_first_submit_no();
+            producer.history_lower_bound_submit_no = history.lower_bound_submit_no;
             producer.lifetime_truncated = history.lifetime_truncated;
             producer.history_window_truncated = history.dropped_submits != 0;
             producer.history_write_count = lifetime.write_count;
@@ -2071,22 +2200,48 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
                 ? lifetime.last : history.latest_overlap(leaf.access.addr, leaf.access.size);
             if (match) {
                 producer.resolved = true;
+                producer.provenance = GpuTimelineProducerProvenance::ProducerHistory;
                 producer.producer_submit_no = match->submit_no;
                 producer.producer_draw_index = match->draw_index;
                 producer.producer_command_order = match->command_order;
                 producer.producer_target_addr = match->addr;
                 producer.producer_width = match->width;
                 producer.producer_height = match->height;
+            } else {
+                const bool exact_rtt_seed = std::any_of(
+                    capture.rtt_seeds.begin(), capture.rtt_seeds.end(),
+                    [&](const GpuCaptureRttSeed& seed) {
+                        return gpu_dependency_rtt_seed_matches(leaf.access, seed);
+                    });
+                if (exact_rtt_seed)
+                    producer.provenance = GpuTimelineProducerProvenance::ExactRttSeed;
+                else if (history.phase_bounded)
+                    producer.provenance = GpuTimelineProducerProvenance::PhaseHistoryBounded;
+            }
+            if (!gpu_timeline_bundle_provenance_complete(
+                    producer.provenance, leaf.first_future_writer)) {
+                bundle_provenance_complete = false;
+                ++bounded_temporal_leaf_count;
             }
             if (!writer->append_producer(producer, error)) {
                 runtime_recorder().mark_failed(error);
                 history.remember(state, submit_no);
                 return;
             }
+            const char* provenance = "unknown";
+            switch (producer.provenance) {
+                case GpuTimelineProducerProvenance::ProducerHistory:
+                    provenance = "producer-history"; break;
+                case GpuTimelineProducerProvenance::ExactRttSeed:
+                    provenance = "exact-rtt-seed"; break;
+                case GpuTimelineProducerProvenance::PhaseHistoryBounded:
+                    provenance = "phase-history-bounded/unknown"; break;
+                case GpuTimelineProducerProvenance::Unknown: break;
+            }
             std::fprintf(stderr, "[timeline] temporal resource 0x%llx/%ux%u op=%u -> %s",
                          static_cast<unsigned long long>(producer.resource_addr),
                          producer.resource_width, producer.resource_height,
-                         producer.consumer_operation, producer.resolved ? "producer" : "unresolved");
+                         producer.consumer_operation, provenance);
             if (producer.resolved)
                 std::fprintf(stderr, " submit=%llu draw=%llu order=%llu target=0x%llx/%ux%u",
                              static_cast<unsigned long long>(producer.producer_submit_no),
@@ -2107,11 +2262,17 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
                              producer.first_color_has_clear ? "programmed" : "absent",
                              producer.first_color_control_mode, producer.first_target_mask,
                              producer.first_color_format);
+            if (history.phase_bounded)
+                std::fprintf(stderr, " history-lower-bound=%llu",
+                             static_cast<unsigned long long>(
+                                 producer.history_lower_bound_submit_no));
             std::fprintf(stderr, "\n");
         }
     } else {
         std::fprintf(stderr, "[timeline] dependency graph failed for submit %llu: %s\n",
                      static_cast<unsigned long long>(submit_no), error.c_str());
+        if (history.phase_bounded && !request.bundle_path.empty())
+            bundle_provenance_complete = false;
         error.clear();
     }
     const bool predecessor_requested = !request.semantic_selector &&
@@ -2121,7 +2282,20 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
     if (!request.bundle_path.empty()) {
         RuntimeCaptureBundle& state = runtime_capture_bundle();
         GpuCaptureBundle& bundle = state.bundle;
-        if (state.failed) {
+        if (!bundle_provenance_complete) {
+            state.failed = true;
+            request.bundle_provenance_failures.fetch_add(1, std::memory_order_relaxed);
+            if (bounded_temporal_leaf_count)
+                error = "phase-bounded producer history leaves " +
+                    std::to_string(bounded_temporal_leaf_count) +
+                    " temporal image dependency/dependencies unresolved";
+            else
+                error = "phase-bounded dependency graph unavailable; temporal closure is unknown";
+            std::fprintf(stderr,
+                         "[timeline] capture bundle finalization refused: %s; standalone capsule "
+                         "remains available at %s\n",
+                         error.c_str(), request.path.c_str());
+        } else if (state.failed) {
             error = "capture bundle has a failed or missing predecessor submit";
         } else if (state.budget_exhausted) {
             error = "capture bundle unique-byte budget was exhausted before the selected submit";
@@ -2133,6 +2307,7 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
             requested_artifacts_written = false;
             std::fprintf(stderr, "[timeline] capture bundle write failed: %s\n", error.c_str());
         } else {
+            request.bundle_submits_captured.fetch_add(1, std::memory_order_relaxed);
             const uint64_t unique_bytes = gpu_capture_bundle_unique_bytes(bundle);
             const GpuCaptureBundleStats stats = gpu_capture_bundle_stats(bundle);
             const uint64_t capture_ms = state.started ? static_cast<uint64_t>(

--- a/prosper/src/gpu/gpu_timeline.cpp
+++ b/prosper/src/gpu/gpu_timeline.cpp
@@ -946,6 +946,7 @@ GpuCaptureMetadata runtime_capture_metadata(uint64_t submit_no) {
     if (request.history_phase_bounded.load(std::memory_order_relaxed))
         metadata.renderer_env.emplace_back(
             "PROSPER_CAPTURE_HISTORY_LOWER_BOUND_SUBMIT", std::to_string(history_lower_bound));
+    annotate_gpu_capture_save_roots(metadata);
     annotate_gpu_capture_scanout(metadata);
     return metadata;
 }

--- a/prosper/src/gpu/gpu_timeline.hpp
+++ b/prosper/src/gpu/gpu_timeline.hpp
@@ -197,6 +197,20 @@ struct GpuTimelineCaptureCounters {
 bool gpu_timeline_bundle_provenance_complete(GpuTimelineProducerProvenance provenance,
                                              uint32_t future_writer_operation);
 
+// Bundle closure is cumulative across every retained submit. Once one constituent exposes a
+// phase-bounded temporal image with no seed/producer, a later closed endpoint cannot make the
+// earlier submit reproducible.
+struct GpuTimelineBundleProvenanceState {
+    bool complete = true;
+    bool graph_unavailable = false;
+    uint64_t first_incomplete_submit_no = 0;
+    uint64_t bounded_unknown_leaf_count = 0;
+};
+
+void gpu_timeline_observe_bundle_provenance(
+    GpuTimelineBundleProvenanceState& state, uint64_t submit_no,
+    GpuTimelineProducerProvenance provenance, uint32_t future_writer_operation);
+
 struct GpuTimelineFile {
     uint32_t version = 0;
     GpuTimelineMetadata metadata;

--- a/prosper/src/gpu/gpu_timeline.hpp
+++ b/prosper/src/gpu/gpu_timeline.hpp
@@ -127,6 +127,16 @@ enum class GpuTimelineWriterKind : uint32_t {
     WriteData = 4,
 };
 
+// How an external image input was made reproducible, or why its producer remains unknown. A phase-
+// bounded result is deliberately distinct from a generic miss: the capture only observed producers
+// at/after an explicit semantic gate and must not imply that no earlier renderer writer existed.
+enum class GpuTimelineProducerProvenance : uint32_t {
+    Unknown = 0,
+    ProducerHistory = 1,
+    ExactRttSeed = 2,
+    PhaseHistoryBounded = 3,
+};
+
 struct GpuTimelineProducer {
     uint64_t sequence = 0;
     uint64_t elapsed_ns = 0;
@@ -151,6 +161,8 @@ struct GpuTimelineProducer {
     uint64_t history_write_count = 0;
     uint64_t history_submit_count = 0;
     uint64_t history_window_first_submit_no = 0;
+    uint64_t history_lower_bound_submit_no = 0;
+    GpuTimelineProducerProvenance provenance = GpuTimelineProducerProvenance::Unknown;
     bool lifetime_truncated = false;
     bool history_window_truncated = false;
     bool first_color_has_clear = false;
@@ -161,6 +173,29 @@ struct GpuTimelineProducer {
     uint32_t first_target_mask = 0;
     uint32_t first_color_format = 0;
 };
+
+// Cheap runtime counters for semantic detailed-capture diagnostics and focused tests. The counters
+// distinguish compact phase observation from producer history and full submit materialization, so a
+// long boot can prove that an AFTER_COMPUTE gate remained lightweight before it armed.
+struct GpuTimelineCaptureCounters {
+    uint64_t phase_observation_submits = 0;
+    uint64_t phase_dispatches_scanned = 0;
+    uint64_t prearm_history_submits_skipped = 0;
+    uint64_t prearm_history_draws_skipped = 0;
+    uint64_t prearm_bundle_submits_skipped = 0;
+    uint64_t history_submits_recorded = 0;
+    uint64_t bundle_submits_captured = 0;
+    uint64_t detail_submits_captured = 0;
+    uint64_t bundle_provenance_failures = 0;
+    uint64_t history_lower_bound_submit_no = 0;
+    bool history_phase_bounded = false;
+};
+
+// A read-before-write image leaf is temporal. Phase-bounded unknown provenance cannot close that
+// dependency, so a requested bundle must remain an explicitly failed checkpoint instead of being
+// advertised as complete. Non-temporal inputs remain ordinary guest-memory resources.
+bool gpu_timeline_bundle_provenance_complete(GpuTimelineProducerProvenance provenance,
+                                             uint32_t future_writer_operation);
 
 struct GpuTimelineFile {
     uint32_t version = 0;
@@ -195,6 +230,7 @@ private:
 bool read_gpu_timeline(const std::string& path, GpuTimelineFile& timeline, std::string& error);
 bool gpu_timeline_submit_matches(const GpuTimelineSubmit& submit,
                                  const GpuTimelineSelector& selector);
+GpuTimelineCaptureCounters gpu_timeline_capture_counters();
 
 // Runtime hooks. Inert unless PROSPER_GPU_TIMELINE=<path> is set. They record folded semantic state
 // before renderer sampling and never realize shaders, copy resources, or invoke Vulkan.

--- a/prosper/tests/test_gpu_capture.cpp
+++ b/prosper/tests/test_gpu_capture.cpp
@@ -74,6 +74,23 @@ static void set_test_env(const char* name, const char* value) {
 
 int main() {
     std::printf("== test_gpu_capture ==\n");
+    const char* original_save0_value = std::getenv(kGpuCaptureSave0Env);
+    const bool had_original_save0 = original_save0_value != nullptr;
+    const std::string original_save0 = original_save0_value ? original_save0_value : "";
+    GpuCaptureMetadata save_roots;
+    set_test_env(kGpuCaptureSave0Env, "/tmp/prosper-test-effective-save0");
+    annotate_gpu_capture_save_roots(save_roots);
+    CHECK(save_roots.renderer_env.size() == 1 &&
+              save_roots.renderer_env[0].first == kGpuCaptureSave0Env &&
+              save_roots.renderer_env[0].second == "/tmp/prosper-test-effective-save0",
+          "capture diagnostics retain the effective /savedata0 host root");
+    set_test_env(kGpuCaptureSave0Env, nullptr);
+    annotate_gpu_capture_save_roots(save_roots);
+    CHECK(save_roots.renderer_env.size() == 1 &&
+              save_roots.renderer_env[0].second == kGpuCaptureDefaultSave0Root,
+          "capture diagnostics make the default /savedata0 root explicit");
+    set_test_env(kGpuCaptureSave0Env,
+                 had_original_save0 ? original_save0.c_str() : nullptr);
     std::vector<uint8_t> memory(32);
     for (size_t i = 0; i < memory.size(); ++i) memory[i] = static_cast<uint8_t>(0x40 + i);
     auto reader = [&](uint64_t addr, uint8_t* dst, size_t n) -> size_t {

--- a/prosper/tests/test_gpu_dependency_graph.cpp
+++ b/prosper/tests/test_gpu_dependency_graph.cpp
@@ -168,9 +168,30 @@ int main() {
     CHECK(build_gpu_dependency_graph(reflected_replay, reflected_graph, error) &&
               reflected_graph.external_leaves.size() == 1 &&
               reflected_graph.external_leaves[0].access.addr == reflected_src.gpu_addr &&
+              reflected_graph.external_leaves[0].access.format == DataFormat::Unorm8 &&
+              reflected_graph.external_leaves[0].access.num_components == 4 &&
               reflected_graph.external_leaves[0].first_future_writer == UINT32_MAX,
           "reflected compute graph keeps the read-only input and does not invent a temporal "
           "read of the write-only output");
+    GpuCaptureRttSeed exact_seed;
+    exact_seed.guest_addr = reflected_src.gpu_addr;
+    exact_seed.width = exact_seed.height = 1;
+    exact_seed.format = GpuCaptureColorFormat::Rgba8Unorm;
+    exact_seed.rgba.resize(4);
+    CHECK(gpu_dependency_rtt_seed_matches(reflected_graph.external_leaves[0].access, exact_seed),
+          "an exact live RTT address, extent, and format closes an image dependency");
+    GpuCaptureRttSeed wrong_extent = exact_seed;
+    wrong_extent.width = 2;
+    GpuCaptureRttSeed wrong_format = exact_seed;
+    wrong_format.format = GpuCaptureColorFormat::Rgba16Float;
+    GpuDependencyAccess srgb_access = reflected_graph.external_leaves[0].access;
+    srgb_access.srgb = true;
+    CHECK(!gpu_dependency_rtt_seed_matches(reflected_graph.external_leaves[0].access,
+                                           wrong_extent) &&
+              !gpu_dependency_rtt_seed_matches(reflected_graph.external_leaves[0].access,
+                                               wrong_format) &&
+              !gpu_dependency_rtt_seed_matches(srgb_access, exact_seed),
+          "address-only RTT matches cannot hide extent, format, or sRGB reinterpretation");
 
     GpuReplayFrame image_overlap_replay;
     DrawItem image_writer;

--- a/prosper/tests/test_gpu_timeline.cpp
+++ b/prosper/tests/test_gpu_timeline.cpp
@@ -374,6 +374,22 @@ int main(int argc, char** argv) {
     CHECK(gpu_timeline_bundle_provenance_complete(
               GpuTimelineProducerProvenance::PhaseHistoryBounded, UINT32_MAX),
           "a non-temporal guest image input does not require pre-phase producer history");
+    GpuTimelineBundleProvenanceState unresolved_arm;
+    gpu_timeline_observe_bundle_provenance(
+        unresolved_arm, 3, GpuTimelineProducerProvenance::PhaseHistoryBounded, 7);
+    gpu_timeline_observe_bundle_provenance(
+        unresolved_arm, 4, GpuTimelineProducerProvenance::ExactRttSeed, 8);
+    CHECK(!unresolved_arm.complete && unresolved_arm.first_incomplete_submit_no == 3 &&
+              unresolved_arm.bounded_unknown_leaf_count == 1,
+          "a closed endpoint cannot repair an unresolved phase-arm bundle constituent");
+    GpuTimelineBundleProvenanceState closed_constituents;
+    gpu_timeline_observe_bundle_provenance(
+        closed_constituents, 3, GpuTimelineProducerProvenance::ExactRttSeed, 7);
+    gpu_timeline_observe_bundle_provenance(
+        closed_constituents, 4, GpuTimelineProducerProvenance::ProducerHistory, 8);
+    CHECK(closed_constituents.complete &&
+              closed_constituents.bounded_unknown_leaf_count == 0,
+          "exactly seeded and post-arm-produced constituents keep the whole bundle closed");
     CHECK(run_self(argv[0], "invalid") == 0,
           "malformed graphics-program selector is rejected without capturing");
     CHECK(run_self(argv[0], "after-invalid") == 0,

--- a/prosper/tests/test_gpu_timeline.cpp
+++ b/prosper/tests/test_gpu_timeline.cpp
@@ -97,9 +97,12 @@ static int run_selector_env_child(const std::string& mode) {
         ("prosper-gpu-timeline-selector-" + mode + "-" + std::to_string(nonce));
     const std::string timeline_path = base.string() + ".prgtl";
     const std::string capture_path = base.string() + ".prgcap";
+    const std::string bundle_path = base.string() + ".prgbundle";
+    bool intermediate_ok = true;
     set_test_env("PROSPER_GPU_TIMELINE", timeline_path);
     set_test_env("PROSPER_GPU_TIMELINE_CAPTURE", capture_path);
-    set_test_env("PROSPER_GPU_CAPTURE_METADATA_ONLY", "1");
+    if (mode != "after-work")
+        set_test_env("PROSPER_GPU_CAPTURE_METADATA_ONLY", "1");
 
     if (mode == "invalid") {
         set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT", "1");
@@ -209,6 +212,56 @@ static int run_selector_env_child(const std::string& mode) {
             begin_gpu_timeline_submit(submit_no);
             record_gpu_timeline_submit(submits[i], submit_no);
         }
+    } else if (mode == "after-work") {
+        set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT", "1");
+        set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_WHEN_TARGET_DIM", "642x362");
+        set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_AFTER_COMPUTE_PROGRAM",
+                     program_address(kSelectorCompute));
+        set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_BUNDLE", bundle_path);
+        set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_DEPTH", "2");
+        set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_START_TARGET_DIM", "642x362");
+        set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_START_TARGET_DRAW_INDEX", "0:0");
+        set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_CHECKPOINT_EVERY", "1");
+
+        const auto exact = selector_draw_state(642, 362, kSelectorVs, kSelectorPs);
+        begin_gpu_timeline_submit(1);
+        record_gpu_timeline_submit(selector_submit({exact}, 10, kWrongSelectorCompute), 1);
+        begin_gpu_timeline_submit(2);
+        record_gpu_timeline_submit(selector_submit({exact}, 20), 2);
+        GpuTimelineCaptureCounters counters = gpu_timeline_capture_counters();
+        intermediate_ok = counters.phase_observation_submits == 2 &&
+            counters.phase_dispatches_scanned == 1 &&
+            counters.prearm_history_submits_skipped == 2 &&
+            counters.prearm_history_draws_skipped == 2 &&
+            counters.prearm_bundle_submits_skipped == 2 &&
+            counters.history_submits_recorded == 0 &&
+            counters.bundle_submits_captured == 0 &&
+            counters.detail_submits_captured == 0 &&
+            counters.bundle_provenance_failures == 0 &&
+            counters.history_lower_bound_submit_no == 0 &&
+            !counters.history_phase_bounded &&
+            !std::filesystem::exists(bundle_path) &&
+            !std::filesystem::exists(capture_path);
+
+        begin_gpu_timeline_submit(3);
+        record_gpu_timeline_submit(selector_submit({exact}, 30, kSelectorCompute), 3);
+        counters = gpu_timeline_capture_counters();
+        GpuCaptureBundle armed_bundle;
+        std::string armed_error;
+        intermediate_ok = intermediate_ok && counters.phase_observation_submits == 3 &&
+            counters.phase_dispatches_scanned == 2 &&
+            counters.prearm_history_submits_skipped == 2 &&
+            counters.history_submits_recorded == 1 &&
+            counters.bundle_submits_captured == 1 &&
+            counters.detail_submits_captured == 0 &&
+            counters.history_lower_bound_submit_no == 3 &&
+            counters.history_phase_bounded &&
+            read_gpu_capture_bundle(bundle_path, armed_bundle, armed_error) &&
+            armed_bundle.submits.size() == 1 &&
+            armed_bundle.submits[0].submit_index == 3;
+
+        begin_gpu_timeline_submit(4);
+        record_gpu_timeline_submit(selector_submit({exact}, 40), 4);
     } else if (mode == "after-submit-zero") {
         set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT", "1");
         set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_WHEN_TARGET_DIM", "642x362");
@@ -255,15 +308,40 @@ static int run_selector_env_child(const std::string& mode) {
         ok = ok && timeline.submits.size() == 4 && timeline.details.size() == 1 &&
              timeline.details[0].submit_no == 4 &&
              read_gpu_capture(capture_path, capture, error) && capture.metadata.submit_index == 4;
+    } else if (mode == "after-work") {
+        GpuCaptureFile capture;
+        GpuCaptureBundle bundle;
+        const GpuTimelineCaptureCounters counters = gpu_timeline_capture_counters();
+        const auto lower_bound = [&](const auto& entry) {
+            return entry.first == "PROSPER_CAPTURE_HISTORY_LOWER_BOUND_SUBMIT" &&
+                   entry.second == "3";
+        };
+        ok = ok && intermediate_ok && timeline.submits.size() == 4 &&
+             timeline.details.size() == 2 && timeline.details[0].submit_no == 3 &&
+             timeline.details[1].submit_no == 4 && counters.history_submits_recorded == 2 &&
+             counters.bundle_submits_captured == 2 && counters.detail_submits_captured == 1 &&
+             counters.bundle_provenance_failures == 0 &&
+             read_gpu_capture(capture_path, capture, error) && capture.metadata.submit_index == 4 &&
+             std::any_of(capture.metadata.renderer_env.begin(), capture.metadata.renderer_env.end(),
+                         lower_bound) &&
+             read_gpu_capture_bundle(bundle_path, bundle, error) && bundle.submits.size() == 2 &&
+             bundle.submits[0].submit_index == 3 && bundle.submits[1].submit_index == 4;
     } else {
         GpuCaptureFile capture;
+        const auto zero_lower_bound = [&](const auto& entry) {
+            return entry.first == "PROSPER_CAPTURE_HISTORY_LOWER_BOUND_SUBMIT" &&
+                   entry.second == "0";
+        };
         ok = ok && timeline.submits.size() == 2 && timeline.details.size() == 1 &&
              timeline.details[0].submit_no == 1 &&
-             read_gpu_capture(capture_path, capture, error) && capture.metadata.submit_index == 1;
+             read_gpu_capture(capture_path, capture, error) && capture.metadata.submit_index == 1 &&
+             std::any_of(capture.metadata.renderer_env.begin(), capture.metadata.renderer_env.end(),
+                         zero_lower_bound);
     }
     std::error_code ec;
     std::filesystem::remove(timeline_path, ec);
     std::filesystem::remove(capture_path, ec);
+    std::filesystem::remove(bundle_path, ec);
     if (!ok) {
         std::fprintf(stderr, "selector child '%s' failed: %s\n", mode.c_str(), error.c_str());
         return 91;
@@ -285,6 +363,17 @@ int main(int argc, char** argv) {
     if (argc == 3 && std::string(argv[1]) == "--selector-child")
         return run_selector_env_child(argv[2]);
     std::printf("== test_gpu_timeline ==\n");
+    CHECK(!gpu_timeline_bundle_provenance_complete(
+              GpuTimelineProducerProvenance::PhaseHistoryBounded, 9),
+          "a temporal phase-bounded unknown makes requested bundle closure fail");
+    CHECK(gpu_timeline_bundle_provenance_complete(
+              GpuTimelineProducerProvenance::ExactRttSeed, 9) &&
+              gpu_timeline_bundle_provenance_complete(
+                  GpuTimelineProducerProvenance::ProducerHistory, 9),
+          "an exact live RTT seed or post-arm producer closes a temporal bundle dependency");
+    CHECK(gpu_timeline_bundle_provenance_complete(
+              GpuTimelineProducerProvenance::PhaseHistoryBounded, UINT32_MAX),
+          "a non-temporal guest image input does not require pre-phase producer history");
     CHECK(run_self(argv[0], "invalid") == 0,
           "malformed graphics-program selector is rejected without capturing");
     CHECK(run_self(argv[0], "after-invalid") == 0,
@@ -299,6 +388,9 @@ int main(int argc, char** argv) {
           "graphics conjunction once");
     CHECK(run_self(argv[0], "after-bound") == 0,
           "cross-submit compute gate may arm before the independent endpoint lower bound");
+    CHECK(run_self(argv[0], "after-work") == 0,
+          "phase-gated capture performs no history or full bundle work before arming, then retains "
+          "the arm submit and a strictly later endpoint");
     CHECK(run_self(argv[0], "after-submit-zero") == 0,
           "cross-submit compute gate retains a submit-zero arm for a later submit-one capture");
     const auto nonce = std::chrono::steady_clock::now().time_since_epoch().count();
@@ -367,12 +459,23 @@ int main(int argc, char** argv) {
     producer.history_first_submit_no = 2; producer.history_first_draw_index = 7;
     producer.history_first_command_order = 80; producer.history_write_count = 31;
     producer.history_submit_count = 8; producer.history_window_first_submit_no = 1;
+    producer.history_lower_bound_submit_no = 2;
+    producer.provenance = GpuTimelineProducerProvenance::ProducerHistory;
     producer.lifetime_truncated = true; producer.history_window_truncated = true;
     producer.first_color_has_clear = true; producer.first_color_clear_word0 = 0x11223344;
     producer.first_color_clear_word1 = 0x55667788; producer.first_color_control = 0x60;
     producer.first_color_control_mode = 6; producer.first_target_mask = 0xf;
     producer.first_color_format = 10;
     CHECK(writer.append_producer(producer, error), "writer appends a prior-producer identity");
+    GpuTimelineProducer bounded;
+    bounded.consumer_submit_no = 10; bounded.consumer_operation = 20;
+    bounded.future_writer_operation = 29; bounded.resource_addr = 0x900000;
+    bounded.resource_size = 642ull * 362 * 4; bounded.resource_width = 642;
+    bounded.resource_height = 362; bounded.history_window_first_submit_no = 7;
+    bounded.history_lower_bound_submit_no = 7;
+    bounded.provenance = GpuTimelineProducerProvenance::PhaseHistoryBounded;
+    CHECK(writer.append_producer(bounded, error),
+          "writer appends explicit phase-bounded unknown provenance");
     GpuTimelineSubmit second = first;
     second.submit_no = 11; second.draw_count = 4; second.dispatch_count = 0;
     second.target_spans[1].draw_count = 3;
@@ -386,12 +489,12 @@ int main(int argc, char** argv) {
           timeline.metadata.title_id == metadata.title_id &&
           timeline.metadata.input_route == metadata.input_route,
           "metadata round-trips");
-    CHECK(timeline.version == 8 && timeline.submits.size() == 2 && timeline.presents.size() == 1 &&
-          timeline.details.size() == 1 && timeline.producers.size() == 1,
+    CHECK(timeline.version == 9 && timeline.submits.size() == 2 && timeline.presents.size() == 1 &&
+          timeline.details.size() == 1 && timeline.producers.size() == 2,
           "version and record counts round-trip");
     CHECK(timeline.submits[0].sequence == 1 && timeline.presents[0].sequence == 2 &&
           timeline.details[0].sequence == 3 && timeline.producers[0].sequence == 4 &&
-          timeline.submits[1].sequence == 5,
+          timeline.producers[1].sequence == 5 && timeline.submits[1].sequence == 6,
           "global record ordering round-trips");
     CHECK(timeline.submits[0].color0_base == 0x12340000 &&
           timeline.submits[0].color0_width == 642 && timeline.submits[0].color0_height == 362,
@@ -448,12 +551,20 @@ int main(int argc, char** argv) {
           timeline.producers[0].resource_width == 642 &&
           timeline.producers[0].history_first_submit_no == 2 &&
           timeline.producers[0].history_write_count == 31 &&
+          timeline.producers[0].history_lower_bound_submit_no == 2 &&
+          timeline.producers[0].provenance ==
+              GpuTimelineProducerProvenance::ProducerHistory &&
           timeline.producers[0].first_writer_kind == GpuTimelineWriterKind::Graphics &&
           timeline.producers[0].lifetime_truncated &&
           timeline.producers[0].history_window_truncated &&
           timeline.producers[0].first_color_has_clear &&
           timeline.producers[0].first_color_clear_word1 == 0x55667788,
           "prior-producer resource and writer identities round-trip");
+    CHECK(!timeline.producers[1].resolved &&
+          timeline.producers[1].history_lower_bound_submit_no == 7 &&
+          timeline.producers[1].provenance ==
+              GpuTimelineProducerProvenance::PhaseHistoryBounded,
+          "phase-bounded unknown provenance remains fail-visible after round-trip");
 
     std::ifstream input(good, std::ios::binary);
     std::vector<uint8_t> bytes((std::istreambuf_iterator<char>(input)), {});
@@ -463,7 +574,7 @@ int main(int argc, char** argv) {
     GpuTimelineFile partial;
     CHECK(read_gpu_timeline(truncated, partial, error), "reader recovers complete records from a truncated tail");
     CHECK(partial.truncated_tail && partial.submits.size() == 1 && partial.presents.size() == 1 &&
-          partial.details.size() == 1 && partial.producers.size() == 1,
+          partial.details.size() == 1 && partial.producers.size() == 2,
           "truncated final submit is ignored explicitly");
 
     std::vector<uint8_t> corrupt_bytes = bytes;

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -169,12 +169,14 @@ After a translator change, use `gpu_replay --retry-failed-stage FAILURE:STAGE` f
 `--retry-failed-chain FAILURE` for a captured split vertex prolog/main pair. These offline paths reuse the exact
 captured resource table and report whether the current production recompiler now produces SPIR-V, without a
 guest boot or Vulkan replay.
-Timeline version 6 retains the version-5 sliding graphics-target window plus full-run aggregate lifetime metadata
+Timeline version 9 retains the version-5 sliding graphics-target window plus aggregate lifetime metadata
 when a detailed capture is requested. `PROSPER_GPU_TIMELINE_HISTORY=N` raises the window to at most 65536.
 Producer records identify the latest overlapping prior submit/draw/PM4 order, earliest observed graphics
 writer, write/submit counts, truncation, and raw first-writer clear/target state. Raw clear registers are
-provenance, not proof of an implicit hardware clear. The timeline intentionally retains no delayed pointers
-to mutable guest bytes.
+provenance, not proof of an implicit hardware clear. Version 9 also records an explicit producer-history lower
+bound and classifies each external image as producer-history, exact-RTT-seeded, generic unknown, or
+`phase-history-bounded/unknown`; the last state must never be treated as a proven initialization or replaced
+with synthetic zeroes. The timeline intentionally retains no delayed pointers to mutable guest bytes.
 Every current submit also records the v5 distinct DS plane/HTILE identities, raw view/format/size programming,
 target extents, and test/write/clear counts. `gpu_timeline FILE --depth-summary [WxH]` groups their full lifetimes.
 For a focused run, `PROSPER_GPU_TIMELINE_DEPTH_HASH_DIM=WxH` adds guest depth/stencil/HTILE hashes and latest
@@ -236,9 +238,15 @@ conjunction, not evidence of a producer/consumer relationship.
 For a strict cross-submit phase gate, use
 `PROSPER_GPU_TIMELINE_CAPTURE_AFTER_COMPUTE_PROGRAM=ADDR`. The exact program arms the runtime request even
 before the endpoint lower bound, its own submit is never eligible, and normal endpoint predicates are allowed
-only on a later submit at or after the bound. Zero/unset disables it. The pre-arm path scans only retained
-dispatch register snapshots; the request-local latch adds no compute realization, resource reads, allocation,
-or Vulkan work and is not dependency evidence.
+only on a later submit at or after the bound. Zero/unset disables it. Before the gate, the runtime writes only
+the compact timeline and scans retained dispatch register snapshots: producer history, bundle-start matching,
+bundle capture, resource reads, and Vulkan work remain disabled. The arming submit resets and begins the
+explicitly bounded producer/bundle window, so it is retained as a possible producer while the endpoint remains
+strictly later. The arm log includes observation/skip counters; detailed capsules record the history lower
+bound in their capture environment. A requested bundle is not finalized when a read-before-write image leaf
+has only `phase-history-bounded/unknown` provenance; the standalone capsule remains available for diagnosis.
+Exact live RTT seeds are accepted only when address, extent, and sampled format semantics agree. The phase
+latch is not dependency evidence.
 When the endpoint moves, predecessor manifests roll forward so the final bundle retains the latest requested
 depth; dictionary bytes observed by evicted manifests still count against the unique-byte budget.
 Per-target RTT is the normal renderer path. `PROSPER_RTT_SINGLE_TARGET=1` restores the obsolete flattened

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -243,8 +243,9 @@ the compact timeline and scans retained dispatch register snapshots: producer hi
 bundle capture, resource reads, and Vulkan work remain disabled. The arming submit resets and begins the
 explicitly bounded producer/bundle window, so it is retained as a possible producer while the endpoint remains
 strictly later. The arm log includes observation/skip counters; detailed capsules record the history lower
-bound in their capture environment. A requested bundle is not finalized when a read-before-write image leaf
-has only `phase-history-bounded/unknown` provenance; the standalone capsule remains available for diagnosis.
+bound in their capture environment. Every constituent is checked before append/checkpoint; a requested bundle
+is latched failed when any constituent has a read-before-write image leaf with only
+`phase-history-bounded/unknown` provenance. The standalone endpoint capsule remains available for diagnosis.
 Exact live RTT seeds are accepted only when address, extent, and sampled format semantics agree. The phase
 latch is not dependency evidence.
 When the endpoint moves, predecessor manifests roll forward so the final bundle retains the latest requested

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -2299,6 +2299,15 @@ int main(int argc, char** argv) {
                  replay.ds_seeds.size(),
                  replay.expected_output_valid ? "yes" : "no",
                  metadata_only ? "omitted" : "present");
+    const auto history_lower_bound = std::find_if(
+        m.renderer_env.begin(), m.renderer_env.end(), [](const auto& entry) {
+            return entry.first == "PROSPER_CAPTURE_HISTORY_LOWER_BOUND_SUBMIT";
+        });
+    if (history_lower_bound != m.renderer_env.end())
+        std::fprintf(stderr,
+                     "[gpureplay] producer history is phase-bounded at submit=%s; "
+                     "unseeded earlier temporal provenance is unknown\n",
+                     history_lower_bound->second.c_str());
     if (inspect) inspect_frame(replay);
     if (validate_only) return validate_frame(replay) ? 0 : 1;
     if (inspect_only) return 0;

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -2308,6 +2308,14 @@ int main(int argc, char** argv) {
                      "[gpureplay] producer history is phase-bounded at submit=%s; "
                      "unseeded earlier temporal provenance is unknown\n",
                      history_lower_bound->second.c_str());
+    const auto save0 = std::find_if(
+        m.renderer_env.begin(), m.renderer_env.end(), [](const auto& entry) {
+            return entry.first == prosper::gpu::kGpuCaptureSave0Env;
+        });
+    if (save0 != m.renderer_env.end() || !m.savedata_dir.empty())
+        std::fprintf(stderr, "[gpureplay] capture save roots: save0=%s savedata-memory=%s\n",
+                     save0 == m.renderer_env.end() ? "unknown" : save0->second.c_str(),
+                     m.savedata_dir.empty() ? "unknown" : m.savedata_dir.c_str());
     if (inspect) inspect_frame(replay);
     if (validate_only) return validate_frame(replay) ? 0 : 1;
     if (inspect_only) return 0;

--- a/prosper/tools/gpu_timeline/gpu_timeline.cpp
+++ b/prosper/tools/gpu_timeline/gpu_timeline.cpp
@@ -22,6 +22,16 @@ const char* writer_kind_name(GpuTimelineWriterKind kind) {
     }
 }
 
+const char* producer_provenance_name(GpuTimelineProducerProvenance provenance) {
+    switch (provenance) {
+        case GpuTimelineProducerProvenance::ProducerHistory: return "producer-history";
+        case GpuTimelineProducerProvenance::ExactRttSeed: return "exact-rtt-seed";
+        case GpuTimelineProducerProvenance::PhaseHistoryBounded:
+            return "phase-history-bounded/unknown";
+        default: return "unknown";
+    }
+}
+
 struct DepthKey {
     GpuTimelineDepthSurface ds;
     bool operator<(const DepthKey& other) const {
@@ -361,7 +371,7 @@ int main(int argc, char** argv) {
         std::printf("producer consumer=%llu/op%u resource=%016llx/%ux%u -> %s"
                     " submit=%llu draw=%llu order=%llu target=%016llx/%ux%u "
                     "lifetime=%llu..%llu submits=%llu writes=%llu window-first=%llu "
-                    "lifetime-truncated=%s window-truncated=%s "
+                    "lifetime-truncated=%s window-truncated=%s lower-bound=%llu provenance=%s "
                     "first-kind=%s first-draw=%llu first-order=%llu clear=%s/%08x:%08x "
                     "mode=%u mask=%x format=%u\n",
                     static_cast<unsigned long long>(producer.consumer_submit_no),
@@ -381,6 +391,8 @@ int main(int argc, char** argv) {
                     static_cast<unsigned long long>(producer.history_window_first_submit_no),
                     producer.lifetime_truncated ? "yes" : "no",
                     producer.history_window_truncated ? "yes" : "no",
+                    static_cast<unsigned long long>(producer.history_lower_bound_submit_no),
+                    producer_provenance_name(producer.provenance),
                     writer_kind_name(producer.first_writer_kind),
                     static_cast<unsigned long long>(producer.history_first_draw_index),
                     static_cast<unsigned long long>(producer.history_first_command_order),
@@ -471,8 +483,8 @@ int main(int argc, char** argv) {
                 const auto& x = timeline.producers[xi++];
                 std::printf("%llu %.6f producer consumer=%llu/op%u resource=%016llx/%ux%u "
                             "future=%u resolved=%s submit=%llu draw=%llu order=%llu "
-                            "lifetime=%llu..%llu/%llu writes=%llu window=%llu "
-                            "lifetime-truncated=%s window-truncated=%s kind=%s\n",
+                            "lifetime=%llu..%llu/%llu writes=%llu window=%llu lower-bound=%llu "
+                            "lifetime-truncated=%s window-truncated=%s provenance=%s kind=%s\n",
                             static_cast<unsigned long long>(x.sequence), x.elapsed_ns / 1e9,
                             static_cast<unsigned long long>(x.consumer_submit_no), x.consumer_operation,
                             static_cast<unsigned long long>(x.resource_addr), x.resource_width,
@@ -485,8 +497,10 @@ int main(int argc, char** argv) {
                             static_cast<unsigned long long>(x.history_submit_count),
                             static_cast<unsigned long long>(x.history_write_count),
                             static_cast<unsigned long long>(x.history_window_first_submit_no),
+                            static_cast<unsigned long long>(x.history_lower_bound_submit_no),
                             x.lifetime_truncated ? "yes" : "no",
                             x.history_window_truncated ? "yes" : "no",
+                            producer_provenance_name(x.provenance),
                             writer_kind_name(x.first_writer_kind));
             }
         }


### PR DESCRIPTION
Closes #1536.

## Summary

- keep AFTER_COMPUTE pre-arm recording compact: scan only dispatch program addresses and skip producer history, bundle capture, dependency graphs, detailed resource capture, and Vulkan/readback work
- start producer history and bundle state at the exact phase lower bound, while requiring a strictly later endpoint submit
- classify exact live RTT seeds separately from producer history and reject inexact extent, format, or sRGB matches
- make temporal closure bundle-wide: the first unresolved phase-bounded image dependency latches the bundle failed, while preserving a standalone endpoint capsule for diagnosis
- add phase counters/logging and focused boundary/closure tests
- add a Plucky Squire fresh-route launcher that isolates both SAVE0 and SaveDataMemory roots under the user state directory
- record effective SAVE0 in captures and show both save roots during replay inspection

## Live Plucky Squire evidence

The timeline-only control on `d3c107e7` reached MainLevel at about 154s and completed Desk_C01 at about 171.5s. Its valid v9 timeline ran 359.130s with 22,810 submits and 4,946 presents.

The full-data run proved zero detailed work before the gate: 3,981 history submits, 81,179 draws, and 3,981 bundle submits were explicitly skipped. The gate armed at submit 3982 and the endpoint matched at submit 3990.

The standalone endpoint is valid and inspectable: 943,544,031 bytes, 54/56 realized draws, 27/27 dispatches, 83 operations, 148 resources, 597,371,632 resource bytes, and two referenced DS checkpoints. Realization took 1.086s and writing took 10.806s.

Bundle closure failed visibly and correctly: submit 3987 introduced four unresolved temporal image dependencies, so no misleading bundle was written; the standalone endpoint remained available. The process then hit the known shutdown hang after requesting nonzero exit. We verified no core write, killed only the exact controller/child, confirmed all descendants gone, and did not rerun.

## Validation

- built `prosper-app`, `gpu_timeline`, `gpu_replay`, `test_gpu_capture`, `test_gpu_timeline`, and `test_gpu_dependency_graph`
- focused capture/timeline/exit/dependency tests: 4/4 passed
- launcher `bash -n` and ShellCheck 0.11.0 passed
- `git diff --check origin/master..HEAD` passed
- snapshot suite not run; this is not a release

## Follow-ups

The A/B exposed a separate renderer-mode confound: any timeline capture currently disables persistent GPU targets and backend submit batching before the semantic gate. A fresh follow-up will keep the fast renderer path for phase-gated requests and add a first-constituent DS boundary checkpoint. The general false-producer/write-mask issue remains tracked in #1537.

Detailed run evidence: https://github.com/mattias800/prosper/issues/1536#issuecomment-5139351544

Exact cleanup: https://github.com/mattias800/prosper/issues/1536#issuecomment-5139356132

No screenshot is included because this changes capture/tooling behavior, not rendered output.