### PR TITLE
gpu: preserve VCC_HI data across Wave32 VOPC

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -7052,14 +7052,21 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                         rs.sreg_srt.erase(in.dst.value);
                         if (in.dst.value == 106) vcc = masked;
                     } else {
-                        // VOPC architecturally overwrites VCC, including any earlier scalar-data use
-                        // of its physical words. In Wave32 the low word is itself the complete mask;
-                        // retain that domain marker so a following s_mov_b32 save sees the fresh VCC
-                        // rather than stale dispatcher-loaded scalar data.
+                        // VOPC replaces the architectural VCC predicate. In Wave32 the complete mask
+                        // occupies VCC_LO only; VCC_HI remains available as ordinary scalar scratch
+                        // (Astro's sibling traversal keeps a float there across an implicit compare).
+                        // Wave64 still replaces both physical words. Retain the low-word mask marker
+                        // so a following s_mov_b32 save sees the fresh predicate rather than stale
+                        // dispatcher-loaded scalar data.
                         vcc = masked;
-                        mask_write_clobbers_pair(rs, 106);
+                        if (b.wave_size == 32) {
+                            rs.sreg.erase(106);
+                            rs.sreg_srt.erase(106);
+                        } else {
+                            mask_write_clobbers_pair(rs, 106);
+                        }
                         rs.sreg_bool_narrowed[106] = true;
-                        rs.sreg_bool_narrowed[107] = true;
+                        if (b.wave_size != 32) rs.sreg_bool_narrowed[107] = true;
                         if (b.allow_b32_masks &&
                             (b.is_fragment || (b.is_compute && b.wave_size == 32))) {
                             rs.sreg_bool[106] = masked;

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -481,6 +481,34 @@ int main() {
     }
     printf("  [ok]   full Wave32 scalar VCC_LO write feeds its implicit mask consumer\n");
 
+    // Astro's larger world-map sibling keeps an ordinary scalar in VCC_HI while an implicit VOPC
+    // compare replaces the complete Wave32 predicate in VCC_LO. The unused high word must retain
+    // its data lifetime; the same sequence is intentionally invalid in Wave64, where VCC_HI is the
+    // upper half of the compare mask and is therefore overwritten.
+    const uint32_t wave32_compute_vopc_preserves_vcc_hi_data[] = {
+        0xbeeb03ffu, 0x3f400000u,            // s_mov_b32 vcc_hi, 0.75f
+        0x7d841680u,                         // v_cmp_eq_u32 vcc, 0, v11
+        0x7e4e026bu,                         // v_mov_b32 v39, vcc_hi
+        0xbf810000u,
+    };
+    if (recompile_compute(wave32_compute_vopc_preserves_vcc_hi_data,
+                          std::size(wave32_compute_vopc_preserves_vcc_hi_data), nullptr,
+                          wave32_compute_config).empty()) {
+        printf("  [FAIL] implicit Wave32 VOPC clobbered adjacent VCC_HI scalar data\n");
+        return 1;
+    }
+    ComputeShaderConfig wave64_compute_config = wave32_compute_config;
+    wave64_compute_config.wave_size = 64;
+    wave64_compute_config.native_subgroup_size = 64;
+    wave64_compute_config.local_x = 64;
+    if (!recompile_compute(wave32_compute_vopc_preserves_vcc_hi_data,
+                           std::size(wave32_compute_vopc_preserves_vcc_hi_data), nullptr,
+                           wave64_compute_config).empty()) {
+        printf("  [FAIL] implicit Wave64 VOPC preserved overwritten VCC_HI scalar data\n");
+        return 1;
+    }
+    printf("  [ok]   implicit VOPC preserves VCC_HI scalar data only in Wave32\n");
+
     // Astro's exact PC458 packet explicitly selects physical VCC_HI in Wave32. A typed B32 mask in
     // that word must drive the select independently of VCC_LO; absent or path-dependent HI mask
     // lifetimes must remain fail-visible instead of falling back to the implicit VCC predicate.


### PR DESCRIPTION
Refs #1459.

## Outcome

This removes the next fail-visible Astro Bot world-map compute blocker. The exact formerly rejected program `0x5005d7d00` now translates, validates, and executed successfully in every traced live invocation; the routed game progressed through the controller-ship title into `LevelDocument Loaded: worldmap`. The world-map presentation remains dark, so this PR makes no visual-completion claim and adds no screenshot.

## Root cause and contract

In Wave32, an implicit VOPC predicate write replaces the complete mask in `VCC_LO`; `VCC_HI` remains available as ordinary scalar scratch. Astro’s sibling traversal keeps a float in physical `s107` across such a compare. The translator invalidated both scalar/SRT halves as if every VOPC were a Wave64 mask write, lost that live value, and rejected the exact tail at PC 652.

The fix narrows implicit VOPC invalidation to `VCC_LO` only for Wave32, while preserving conservative two-half invalidation for Wave64. The regression proves both the Wave32 preservation and Wave64 fail-closed behavior. Explicit compares targeting either physical VCC half remain governed by their existing independent-mask path.

## Live acceptance

Normal RADV frontend with real VA-API, audio, scripted input, rendering, and compute:

- progressed `ps_logo` → `title_controller_ship` → `Continue: worldmap` → `LevelDocument Loaded: worldmap`
- exact program `0x5005d7d00`: 354/354 traced executions with `result=ok` and phase `ok=1`
- translated module: 126,209 SPIR-V words, hash `7459de315c201acd`, Wave32, local size 16×16×1
- observed dispatches ranged from 12,848×16×1 through 5,331,168×16×1
- zero unsupported skips or recompile rejections for the target
- the only other unsupported program in the full route was the next blocker, `0x500571000`, once

Evidence: https://github.com/mattias800/prosper/issues/1459#issuecomment-5139427264

## Validation

- `test_rdna2_spirv_struct`: pass
- `test_dynfetch_fold`: pass
- `test_shader_recompile_cache`: pass
- `test_recompile_coverage`: pass
- `git diff --check`: clean
- conflict-free rebase retained identical patch-id `162b39ce619002eb51bf44f64e0f44fb63a6fe98`
- snapshot suite not run: this is not a release and pre-PR snapshots are optional