### PR TITLE
gpu: retain failed compute retry specialization

### DIFF
--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -89,7 +89,10 @@ constexpr char kMagic[8] = {'P','R','G','P','C','A','P','\0'};
 // v41: complete the v35 failed-stage resource tables with descriptor fields that historical version
 // tails only wrote for realized draw/compute tables, plus flat-load provenance omitted from the base
 // record. Without this, raw failed-stage retry silently reset image/layout and codegen state.
-constexpr uint32_t kVersion = 41;
+// v42: retain the exact ComputeShaderConfig for failed compute stages. Raw code and v41 resources do
+// not encode user SGPRs, dispatch dimensions, wave ABI, LDS size, or subgroup/storage policy, so an
+// offline retry must never reconstruct those inputs from defaults.
+constexpr uint32_t kVersion = 42;
 constexpr uint32_t kEndian = 0x01020304u;
 constexpr uint64_t kMaxFileBytes = 4ull << 30;
 constexpr uint64_t kMaxBlobBytes = 1ull << 30;
@@ -198,6 +201,44 @@ struct Reader {
         v.resize(static_cast<size_t>(n)); return take(v.data(), v.size());
     }
 };
+
+void write_compute_config(Writer& w, const ComputeShaderConfig& config) {
+    w.words(config.user_sgprs);
+    w.u32(config.local_x); w.u32(config.local_y); w.u32(config.local_z);
+    w.u8(config.exact_thread_extent ? 1u : 0u);
+    w.u32(config.threads_x); w.u32(config.threads_y); w.u32(config.threads_z);
+    w.u32(config.wave_size); w.u32(config.tidig_comp_cnt);
+    const uint8_t flags = (config.tgid_x_en ? 1u : 0u) |
+                          (config.tgid_y_en ? 2u : 0u) |
+                          (config.tgid_z_en ? 4u : 0u) |
+                          (config.tg_size_en ? 8u : 0u) |
+                          (config.packed_r11_storage ? 16u : 0u);
+    w.u8(flags);
+    w.u32(config.lds_bytes);
+    w.u32(config.native_subgroup_size);
+    w.u32(config.native_storage_format_support);
+}
+
+bool read_compute_config(Reader& r, ComputeShaderConfig& config) {
+    uint8_t exact = 0, flags = 0;
+    if (!r.words_bounded(config.user_sgprs, 32,
+                         "invalid compute user-SGPR count") ||
+        !r.u32(config.local_x) || !r.u32(config.local_y) ||
+        !r.u32(config.local_z) || !r.u8(exact) || exact > 1u ||
+        !r.u32(config.threads_x) || !r.u32(config.threads_y) ||
+        !r.u32(config.threads_z) || !r.u32(config.wave_size) ||
+        !r.u32(config.tidig_comp_cnt) || !r.u8(flags) || (flags & ~0x1fu) ||
+        !r.u32(config.lds_bytes) || !r.u32(config.native_subgroup_size) ||
+        !r.u32(config.native_storage_format_support))
+        return false;
+    config.exact_thread_extent = exact != 0;
+    config.tgid_x_en = (flags & 1u) != 0;
+    config.tgid_y_en = (flags & 2u) != 0;
+    config.tgid_z_en = (flags & 4u) != 0;
+    config.tg_size_en = (flags & 8u) != 0;
+    config.packed_r11_storage = (flags & 16u) != 0;
+    return true;
+}
 
 void write_pipeline(Writer& w, const ResolvedPipelineState& p) {
     w.u32(p.topology); w.u32(p.color0_format); w.u8(p.has_clear_color); for (float v : p.clear_color) w.f32(v);
@@ -935,6 +976,35 @@ bool capture_raw_shader_version(uint64_t addr, const CaptureMemoryReader& reader
     return true;
 }
 
+bool validate_compute_config(const ComputeShaderConfig& config,
+                             const ComputeLaunchDimensions& launch,
+                             uint32_t required_subgroup_size,
+                             const char* state_error,
+                             std::string& error) {
+    const bool subgroup_valid = config.native_subgroup_size == 0 ||
+        config.native_subgroup_size == 32 || config.native_subgroup_size == 64;
+    if ((required_subgroup_size != 0 && required_subgroup_size != 32 &&
+         required_subgroup_size != 64) || !subgroup_valid) {
+        error = "invalid compute required-subgroup size";
+        return false;
+    }
+    if (config.user_sgprs.size() > 32 || !config.local_x || !config.local_y ||
+        !config.local_z || config.local_x != launch.local_x ||
+        config.local_y != launch.local_y || config.local_z != launch.local_z ||
+        config.threads_x != launch.threads_x ||
+        config.threads_y != launch.threads_y ||
+        config.threads_z != launch.threads_z ||
+        (config.wave_size != 32 && config.wave_size != 64) ||
+        config.tidig_comp_cnt > 3 || config.lds_bytes > 65536 ||
+        (config.lds_bytes & 511u) ||
+        config.native_subgroup_size != required_subgroup_size ||
+        (config.native_storage_format_support & ~kNativeStorageFormatSupportMask)) {
+        error = state_error;
+        return false;
+    }
+    return true;
+}
+
 bool validate_compute_recompile_state(const GpuCapturedCompute& compute,
                                       std::string& error) {
     if (!compute.recompile_config_available) {
@@ -944,29 +1014,9 @@ bool validate_compute_recompile_state(const GpuCapturedCompute& compute,
         }
         return true;
     }
-    const ComputeShaderConfig& config = compute.recompile_config;
-    const bool subgroup_valid = config.native_subgroup_size == 0 ||
-        config.native_subgroup_size == 32 || config.native_subgroup_size == 64;
-    if ((compute.required_subgroup_size != 0 && compute.required_subgroup_size != 32 &&
-         compute.required_subgroup_size != 64) || !subgroup_valid) {
-        error = "invalid compute required-subgroup size";
-        return false;
-    }
-    if (config.user_sgprs.size() > 32 || !config.local_x || !config.local_y ||
-        !config.local_z || config.local_x != compute.launch.local_x ||
-        config.local_y != compute.launch.local_y || config.local_z != compute.launch.local_z ||
-        config.threads_x != compute.launch.threads_x ||
-        config.threads_y != compute.launch.threads_y ||
-        config.threads_z != compute.launch.threads_z ||
-        (config.wave_size != 32 && config.wave_size != 64) ||
-        config.tidig_comp_cnt > 3 || config.lds_bytes > 65536 ||
-        (config.lds_bytes & 511u) ||
-        config.native_subgroup_size != compute.required_subgroup_size ||
-        (config.native_storage_format_support & ~kNativeStorageFormatSupportMask)) {
-        error = "invalid compute recompile state";
-        return false;
-    }
-    return true;
+    return validate_compute_config(compute.recompile_config, compute.launch,
+                                   compute.required_subgroup_size,
+                                   "invalid compute recompile state", error);
 }
 
 bool validate_failure_diagnostics(const GpuCaptureFile& capture, std::string& error) {
@@ -1068,6 +1118,15 @@ bool validate_failure_diagnostics(const GpuCaptureFile& capture, std::string& er
                 error = "failed-stage resource table disagrees with its diagnostic summary";
                 return false;
             }
+            if (stage.recompile_config_available &&
+                (diagnostic.kind != SubmitOperationKind::Dispatch ||
+                 stage.stage != ShaderProgramStage::Compute ||
+                 !validate_compute_config(stage.recompile_config, diagnostic.compute_launch,
+                                          stage.recompile_config.native_subgroup_size,
+                                          "invalid failed-compute recompile state", error))) {
+                if (error.empty()) error = "invalid failed-compute recompile state";
+                return false;
+            }
             if (stage.raw_shader_index != 0xFFFFFFFFu)
                 raw_referenced[stage.raw_shader_index] = true;
             const uint32_t max_issue = static_cast<uint32_t>(DescriptorIssueCode::UnusedRuntimeBinding);
@@ -1133,6 +1192,8 @@ bool capture_failure_diagnostics(
             stage.coverage = runtime_stage.coverage;
             stage.descriptor_issue_count = runtime_stage.descriptor_issue_count;
             stage.first_descriptor_issue = runtime_stage.first_descriptor_issue;
+            stage.recompile_config = runtime_stage.recompile_config;
+            stage.recompile_config_available = runtime_stage.recompile_config_available;
             if (!capture_table(runtime_stage.resources.get(), {}, false,
                                stage.resource_table, error)) return false;
             if (!capture_raw_shader_version(stage.program_addr, reader, capture, raw_words,
@@ -2077,21 +2138,7 @@ bool serialize_gpu_capture(const GpuCaptureFile& c, std::vector<uint8_t>& bytes,
         w.u8(compute.recompile_config_available ? 1u : 0u);
         w.u32(compute.raw_shader_index);
         if (!compute.recompile_config_available) continue;
-        const ComputeShaderConfig& config = compute.recompile_config;
-        w.words(config.user_sgprs);
-        w.u32(config.local_x); w.u32(config.local_y); w.u32(config.local_z);
-        w.u8(config.exact_thread_extent ? 1u : 0u);
-        w.u32(config.threads_x); w.u32(config.threads_y); w.u32(config.threads_z);
-        w.u32(config.wave_size); w.u32(config.tidig_comp_cnt);
-        const uint8_t flags = (config.tgid_x_en ? 1u : 0u) |
-                              (config.tgid_y_en ? 2u : 0u) |
-                              (config.tgid_z_en ? 4u : 0u) |
-                              (config.tg_size_en ? 8u : 0u) |
-                              (config.packed_r11_storage ? 16u : 0u);
-        w.u8(flags);
-        w.u32(config.lds_bytes);
-        w.u32(config.native_subgroup_size);
-        w.u32(config.native_storage_format_support);
+        write_compute_config(w, compute.recompile_config);
     }
     // v40 keeps the BVH BOX_GROW descriptor field in deterministic resource-table order. Failed
     // stages are included because raw diagnostic replay may recompile those tables later.
@@ -2209,6 +2256,20 @@ bool serialize_gpu_capture(const GpuCaptureFile& c, std::vector<uint8_t>& bytes,
     for (const auto& diagnostic : c.failure_diagnostics)
         for (const auto& stage : diagnostic.stages)
             if (!write_failed_resource_state(stage.resource_table)) return false;
+    // v42 retains the exact launch/user-SGPR specialization passed to a failed compute
+    // translation. Failed dispatches never enter the realized-compute list, so v39 could not
+    // preserve this state and offline retry had to refuse rather than invent an ABI. Keep the
+    // append-only tail in diagnostic/stage order so v1-v41 readers remain reproducible by removing
+    // only this block and lowering the version.
+    w.u32(static_cast<uint32_t>(c.failure_diagnostics.size()));
+    for (const auto& diagnostic : c.failure_diagnostics) {
+        w.u32(static_cast<uint32_t>(diagnostic.stages.size()));
+        for (const auto& stage : diagnostic.stages) {
+            w.u8(stage.recompile_config_available ? 1u : 0u);
+            if (stage.recompile_config_available)
+                write_compute_config(w, stage.recompile_config);
+        }
+    }
     if (w.data.size() > kMaxFileBytes) { error = "capture file exceeds 4 GiB"; return false; }
     bytes = std::move(w.data);
     return true;
@@ -3040,23 +3101,7 @@ bool deserialize_gpu_capture(const std::vector<uint8_t>& bytes, GpuCaptureFile& 
                 }
                 continue;
             }
-            ComputeShaderConfig& config = compute.recompile_config;
-            uint8_t exact = 0, flags = 0;
-            if (!r.words_bounded(config.user_sgprs, 32,
-                                 "invalid compute user-SGPR count") ||
-                !r.u32(config.local_x) || !r.u32(config.local_y) ||
-                !r.u32(config.local_z) || !r.u8(exact) || exact > 1 ||
-                !r.u32(config.threads_x) || !r.u32(config.threads_y) ||
-                !r.u32(config.threads_z) || !r.u32(config.wave_size) ||
-                !r.u32(config.tidig_comp_cnt) || !r.u8(flags) || (flags & ~0x1fu) ||
-                !r.u32(config.lds_bytes) || !r.u32(config.native_subgroup_size) ||
-                !r.u32(config.native_storage_format_support)) return false;
-            config.exact_thread_extent = exact != 0;
-            config.tgid_x_en = (flags & 1u) != 0;
-            config.tgid_y_en = (flags & 2u) != 0;
-            config.tgid_z_en = (flags & 4u) != 0;
-            config.tg_size_en = (flags & 8u) != 0;
-            config.packed_r11_storage = (flags & 16u) != 0;
+            if (!read_compute_config(r, compute.recompile_config)) return false;
             if (!validate_compute_recompile_state(compute, error)) return false;
         }
     }
@@ -3165,6 +3210,39 @@ bool deserialize_gpu_capture(const std::vector<uint8_t>& bytes, GpuCaptureFile& 
         for (auto& diagnostic : c.failure_diagnostics)
             for (auto& stage : diagnostic.stages)
                 if (!read_failed_resource_state(stage.resource_table)) return false;
+    }
+    if (version >= 42) {   // exact failed-compute launch and user-SGPR specialization
+        uint32_t failure_count = 0;
+        if (!r.u32(failure_count) || failure_count != c.failure_diagnostics.size()) {
+            error = "invalid failed-compute recompile-state failure count";
+            return false;
+        }
+        for (auto& diagnostic : c.failure_diagnostics) {
+            uint32_t stage_count = 0;
+            if (!r.u32(stage_count) || stage_count != diagnostic.stages.size()) {
+                error = "invalid failed-compute recompile-state stage count";
+                return false;
+            }
+            for (auto& stage : diagnostic.stages) {
+                uint8_t available = 0;
+                if (!r.u8(available) || available > 1u) {
+                    error = "invalid failed-compute recompile-state availability";
+                    return false;
+                }
+                stage.recompile_config_available = available != 0;
+                if (!stage.recompile_config_available) continue;
+                if (diagnostic.kind != SubmitOperationKind::Dispatch ||
+                    stage.stage != ShaderProgramStage::Compute ||
+                    !read_compute_config(r, stage.recompile_config) ||
+                    !validate_compute_config(stage.recompile_config,
+                                             diagnostic.compute_launch,
+                                             stage.recompile_config.native_subgroup_size,
+                                             "invalid failed-compute recompile state", error)) {
+                    if (error.empty()) error = "invalid failed-compute recompile state";
+                    return false;
+                }
+            }
+        }
     }
     for (auto& draw : c.draws) restore_legacy_color_target_aliases(draw);
     for (auto& diagnostic : c.failure_diagnostics)
@@ -3630,6 +3708,11 @@ bool materialize_pending_gpu_capture(PendingGpuCapture& pending,
                 continue;
             const GpuState::Dispatch& dispatch = semantic_state->dispatches[failure.index];
             if (failure.command_order != dispatch.command_order) continue;
+            // The indirect producer may leave group/thread counts unresolved, but the shader
+            // register snapshot still provides the exact local size. Preserve those known fields
+            // (and explicit zero unknowns) so the captured config can be validated without
+            // inventing dispatch arguments.
+            failure.compute_launch = resolve_compute_launch(dispatch);
             GpuState diagnostic_state = dispatch.state ? *dispatch.state : *semantic_state;
             diagnostic_state.dispatches.clear();
             diagnostic_state.dispatches.push_back(dispatch);
@@ -3641,6 +3724,9 @@ bool materialize_pending_gpu_capture(PendingGpuCapture& pending,
                 stage.stage = ShaderProgramStage::Compute;
                 stage.program_addr = semantic_items.front().code_addr;
                 stage.resources = semantic_items.front().resources;
+                stage.recompile_config = semantic_items.front().recompile_config;
+                stage.recompile_config_available =
+                    semantic_items.front().recompile_config_available;
                 failure.stages.push_back(std::move(stage));
             } else if (!semantic_failures.empty() &&
                        !semantic_failures.front().stages.empty()) {
@@ -3650,6 +3736,9 @@ bool materialize_pending_gpu_capture(PendingGpuCapture& pending,
                 stage.stage = semantic_stage.stage;
                 stage.program_addr = semantic_stage.program_addr;
                 stage.resources = semantic_stage.resources;
+                stage.recompile_config = semantic_stage.recompile_config;
+                stage.recompile_config_available =
+                    semantic_stage.recompile_config_available;
                 failure.stages.push_back(std::move(stage));
             }
         }

--- a/prosper/src/gpu/gpu_capture.hpp
+++ b/prosper/src/gpu/gpu_capture.hpp
@@ -175,6 +175,11 @@ struct GpuCapturedStageDiagnostic {
     // table; once a fix realizes the operation, an ordinary follow-up capture retains its renderable
     // resource closure through GpuCapturedDraw/GpuCapturedCompute.
     GpuCapturedTable resource_table;
+    // v42: exact semantic launch/user-SGPR inputs supplied to a failed compute recompile. Resource
+    // state alone cannot reproduce compute translation; graphics stages and older captures leave
+    // this explicitly unavailable.
+    ComputeShaderConfig recompile_config{};
+    bool recompile_config_available = false;
 };
 
 struct GpuCapturedOperationFailure {

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -490,6 +490,10 @@ struct ShaderRealizationDiagnostic {
     bool recompiled = false;
     uint32_t descriptor_issue_count = 0;
     uint32_t first_descriptor_issue = 0xFFFFFFFFu;
+    // Failed compute recompilation depends on the complete dispatch ABI, not only the raw program
+    // and its resource table. Graphics stages leave this unavailable.
+    ComputeShaderConfig recompile_config{};
+    bool recompile_config_available = false;
 };
 
 struct OperationRealizationFailure {

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -3888,7 +3888,8 @@ std::vector<ComputeItem> realize_compute_dispatches(
         failure.compute_launch = resolve_compute_launch(dispatch);
         auto record_failure = [&](RealizationFailureReason reason,
                                   const std::shared_ptr<ShaderResourceTable>& resources,
-                                  const std::vector<uint32_t>& spirv) {
+                                  const std::vector<uint32_t>& spirv,
+                                  const ComputeShaderConfig* recompile_config = nullptr) {
             if (!failures) return;
             failure.reason = reason;
             ShaderRealizationDiagnostic stage;
@@ -3896,6 +3897,10 @@ std::vector<ComputeItem> realize_compute_dispatches(
             stage.program_addr = code_addr;
             stage.resources = resources;
             stage.recompiled = !spirv.empty();
+            if (recompile_config) {
+                stage.recompile_config = *recompile_config;
+                stage.recompile_config_available = true;
+            }
             if (!spirv.empty()) {
                 const DescriptorValidationReport diagnostic_report =
                     validate_spirv_descriptor_interface(spirv, resources.get(), 0,
@@ -4278,7 +4283,8 @@ std::vector<ComputeItem> realize_compute_dispatches(
         item.submit_no = submit_no;
         item.command_order = dispatch.command_order;
         if (item.spirv.empty()) {
-            record_failure(RealizationFailureReason::ShaderRecompile, item.resources, item.spirv);
+            record_failure(RealizationFailureReason::ShaderRecompile, item.resources, item.spirv,
+                           &config);
             // PROSPER_DYNTRACE_FAIL=1: replay the FAILED compute program's resource build with the
             // const-fold walk trace + user-data dump forced on (once per distinct program) — the
             // compute analog of the graphics VS/PS fail-replay (gpu_execute.hpp). Compute dispatches
@@ -4381,7 +4387,8 @@ std::vector<ComputeItem> realize_compute_dispatches(
         const DescriptorValidationReport report = validate_spirv_descriptor_interface(
             item.spirv, item.resources.get(), 0, SpirvShaderStage::Compute, false);
         if (!report.ok()) {
-            record_failure(RealizationFailureReason::DescriptorContract, item.resources, item.spirv);
+            record_failure(RealizationFailureReason::DescriptorContract, item.resources, item.spirv,
+                           &config);
             static std::set<uint64_t> logged;
             if (logged.insert(code_addr).second) {
                 std::fprintf(stderr, "[compute] skip invalid descriptor contract for program 0x%llx\n",

--- a/prosper/tests/test_gpu_capture.cpp
+++ b/prosper/tests/test_gpu_capture.cpp
@@ -27,6 +27,9 @@ alignas(256) static const uint32_t kDiagnosticMainVs[] = {
 alignas(256) static const uint32_t kDiagnosticBadPs[] = {
     0x06000300u, 0xbf820005u, 0xBF810000u,
 };
+alignas(256) static const uint32_t kDiagnosticCompute[] = {
+    0xbf810000u, // s_endpgm
+};
 
 // Astro Bot's fullscreen VS addresses a 72-byte table after S_ENDPGM through an s_getpc_b64-built
 // V#. Captures must retain that proven table span: raw replay otherwise sees only the first 45 words
@@ -105,6 +108,7 @@ int main() {
         if (const size_t read = read_shader(kDiagnosticVs, sizeof(kDiagnosticVs))) return read;
         if (const size_t read = read_shader(kDiagnosticMainVs, sizeof(kDiagnosticMainVs))) return read;
         if (const size_t read = read_shader(kDiagnosticBadPs, sizeof(kDiagnosticBadPs))) return read;
+        if (const size_t read = read_shader(kDiagnosticCompute, sizeof(kDiagnosticCompute))) return read;
         if (const size_t read = read_shader(kDiagnosticPcrelVs, sizeof(kDiagnosticPcrelVs))) return read;
         if (addr < 0x1000 || addr >= 0x1000 + memory.size()) return 0;
         size_t off = static_cast<size_t>(addr - 0x1000), take = std::min(n, memory.size() - off);
@@ -410,6 +414,20 @@ int main() {
         return 4 + 71 * rc;
     };
 
+    // v42: optional exact compute specialization per failed stage.
+    auto v42_tail = [](const GpuCaptureFile& f) -> size_t {
+        size_t bytes = 4;
+        for (const auto& diagnostic : f.failure_diagnostics) {
+            bytes += 4;
+            for (const auto& stage : diagnostic.stages) {
+                bytes += 1;
+                if (stage.recompile_config_available)
+                    bytes += 50 + stage.recompile_config.user_sgprs.size() * 4;
+            }
+        }
+        return bytes;
+    };
+
     // v25 (#1240): byte length of the trailing resolve-state block.
     auto v25_tail = [](const GpuCaptureFile& f) -> size_t {
         size_t present_failures = 0;
@@ -441,6 +459,7 @@ int main() {
               v16_scissor_bytes.size() >= 25,
           "v17 capture serializes effective guest scissor state");
     if (v16_scissor_bytes.size() >= 25) {
+        v16_scissor_bytes.resize(v16_scissor_bytes.size() - v42_tail(v16_scissor_source));
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - v41_tail(v16_scissor_source));
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - v40_tail(v16_scissor_source));
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - v39_tail(v16_scissor_source));
@@ -550,7 +569,7 @@ int main() {
     };
     GpuCaptureFile video_capture;
     CHECK(capture_draw_items({video_draw}, meta, video_reader, video_capture, error) &&
-              video_capture.format_version == 41 && video_capture.blobs.size() == 1 &&
+              video_capture.format_version == 42 && video_capture.blobs.size() == 1 &&
               video_capture.blobs[0].bytes.size() == video_memory.size() &&
               video_capture.draws[0].prt.resources[0].captured_size == video_memory.size() &&
               video_capture.draws[0].prt.resources[0].resource.linear_row_pitch_bytes == 2048,
@@ -560,7 +579,7 @@ int main() {
     GpuReplayFrame video_replay;
     CHECK(serialize_gpu_capture(video_capture, video_capture_bytes, error) &&
               deserialize_gpu_capture(video_capture_bytes, video_loaded, error) &&
-              video_loaded.format_version == 41 &&
+              video_loaded.format_version == 42 &&
               video_loaded.draws[0].prt.resources[0].captured_size == video_memory.size() &&
               video_loaded.draws[0].prt.resources[0].resource.linear_row_pitch_bytes == 2048 &&
               materialize_gpu_replay(video_loaded, video_replay, error) &&
@@ -583,7 +602,7 @@ int main() {
     GpuReplayFrame upgraded_video_replay;
     CHECK(serialize_gpu_capture(legacy_video, upgraded_video_bytes, error) &&
               deserialize_gpu_capture(upgraded_video_bytes, upgraded_video, error) &&
-              upgraded_video.format_version == 41 &&
+              upgraded_video.format_version == 42 &&
               upgraded_video.draws[0].prt.resources[0].captured_size == video_chroma.size &&
               upgraded_video.draws[0].prt.resources[0].resource.linear_row_pitch_bytes == 2048 &&
               materialize_gpu_replay(upgraded_video, upgraded_video_replay, error) &&
@@ -665,7 +684,7 @@ int main() {
           "Plucky RGBA16 32-cubed S3 capture uses its four true 3D macroblocks");
     CHECK(serialize_gpu_capture(array_layout_capture, array_layout_bytes, error) &&
               deserialize_gpu_capture(array_layout_bytes, array_layout_loaded, error) &&
-              array_layout_loaded.format_version == 41 &&
+              array_layout_loaded.format_version == 42 &&
               array_layout_loaded.draws[0].vrt.resources[0].resource.layer_stride_bytes == 720896u &&
               array_layout_loaded.draws[0].vrt.resources[0].resource.layer_mip_offset_bytes == 65536u,
           "v32 capture round-trips thin-array slice stride and selected-mip offset");
@@ -764,6 +783,7 @@ int main() {
           "writer rejects an out-of-bounds DCC metadata reference");
     CHECK(serialize_gpu_capture(volume_capture, volume_bytes, error),
           "recreated valid v12 DCC bytes after malformed-reference check");
+    volume_bytes.resize(volume_bytes.size() - v42_tail(volume_capture));
     volume_bytes.resize(volume_bytes.size() - v41_tail(volume_capture));
     volume_bytes.resize(volume_bytes.size() - v40_tail(volume_capture));
     volume_bytes.resize(volume_bytes.size() - v39_tail(volume_capture));
@@ -863,6 +883,7 @@ int main() {
     CHECK(serialize_gpu_capture(pre_v31_source, v20_bytes, error) && v20_bytes.size() >= 21,
           "v21 capture serializes the logic-op extension");
     if (v20_bytes.size() >= 21) {
+        v20_bytes.resize(v20_bytes.size() - v42_tail(pre_v31_source));
         v20_bytes.resize(v20_bytes.size() - v41_tail(pre_v31_source));
         v20_bytes.resize(v20_bytes.size() - v40_tail(pre_v31_source));
         v20_bytes.resize(v20_bytes.size() - v39_tail(pre_v31_source));
@@ -929,7 +950,8 @@ int main() {
     std::vector<uint8_t> v24_resolve_bytes;
     GpuCaptureFile v24_resolve_loaded;
     CHECK(serialize_gpu_capture(pre_v31_source, v24_resolve_bytes, error) &&
-          v24_resolve_bytes.size() >= v41_tail(pre_v31_source) +
+          v24_resolve_bytes.size() >= v42_tail(pre_v31_source) +
+              v41_tail(pre_v31_source) +
               v40_tail(pre_v31_source) +
               v39_tail(pre_v31_source) +
               v37_tail(pre_v31_source) +
@@ -941,7 +963,8 @@ int main() {
               v27_tail(pre_v31_source) + v26_tail(pre_v31_source) +
               v25_tail(pre_v31_source),
           "v25 capture exposes a removable trailing resolve-state block");
-    if (v24_resolve_bytes.size() >= v41_tail(pre_v31_source) +
+    if (v24_resolve_bytes.size() >= v42_tail(pre_v31_source) +
+            v41_tail(pre_v31_source) +
             v40_tail(pre_v31_source) +
             v39_tail(pre_v31_source) +
             v37_tail(pre_v31_source) +
@@ -952,6 +975,7 @@ int main() {
             v29_tail(pre_v31_source) + v28_tail(pre_v31_source) +
             v27_tail(pre_v31_source) + v26_tail(pre_v31_source) +
             v25_tail(pre_v31_source)) {
+        v24_resolve_bytes.resize(v24_resolve_bytes.size() - v42_tail(pre_v31_source));
         v24_resolve_bytes.resize(v24_resolve_bytes.size() - v41_tail(pre_v31_source));
         v24_resolve_bytes.resize(v24_resolve_bytes.size() - v40_tail(pre_v31_source));
         v24_resolve_bytes.resize(v24_resolve_bytes.size() - v39_tail(pre_v31_source));
@@ -1047,7 +1071,8 @@ int main() {
               v37_compatible_bytes.size() >= 12,
           "current capture prepares the layout-compatible v37 fixture");
     if (v37_compatible_bytes.size() >=
-        v41_tail(captured) + v40_tail(captured) + v39_tail(captured)) {
+        v42_tail(captured) + v41_tail(captured) + v40_tail(captured) + v39_tail(captured)) {
+        v37_compatible_bytes.resize(v37_compatible_bytes.size() - v42_tail(captured));
         v37_compatible_bytes.resize(v37_compatible_bytes.size() - v41_tail(captured));
         v37_compatible_bytes.resize(v37_compatible_bytes.size() - v40_tail(captured));
         v37_compatible_bytes.resize(v37_compatible_bytes.size() - v39_tail(captured));
@@ -1226,14 +1251,17 @@ int main() {
     v36_compute_source.raw_shader_versions.clear();
     CHECK(serialize_gpu_capture(v36_compute_source, v36_compute_bytes, error) &&
               v36_compute_bytes.size() >=
-                  v41_tail(v36_compute_source) + v40_tail(v36_compute_source) +
+                  v42_tail(v36_compute_source) + v41_tail(v36_compute_source) +
+                      v40_tail(v36_compute_source) +
                       v39_tail(v36_compute_source) +
                       v37_tail(v36_compute_source),
           "v37 capture exposes a removable compute subgroup-contract tail");
     if (v36_compute_bytes.size() >=
-        v41_tail(v36_compute_source) + v40_tail(v36_compute_source) +
+        v42_tail(v36_compute_source) + v41_tail(v36_compute_source) +
+            v40_tail(v36_compute_source) +
             v39_tail(v36_compute_source) +
             v37_tail(v36_compute_source)) {
+        v36_compute_bytes.resize(v36_compute_bytes.size() - v42_tail(v36_compute_source));
         v36_compute_bytes.resize(v36_compute_bytes.size() - v41_tail(v36_compute_source));
         v36_compute_bytes.resize(v36_compute_bytes.size() - v40_tail(v36_compute_source));
         v36_compute_bytes.resize(v36_compute_bytes.size() - v39_tail(v36_compute_source));
@@ -1391,6 +1419,87 @@ int main() {
           failed_raw->content_hash == gpu_capture_hash(
               reinterpret_cast<const uint8_t*>(kDiagnosticBadPs), sizeof(kDiagnosticBadPs)),
           "failed stage retains the exact content-addressed raw stream through s_endpgm");
+
+    OperationRealizationFailure compute_failure;
+    compute_failure.kind = SubmitOperationKind::Dispatch;
+    compute_failure.index = 8;
+    compute_failure.command_order = 1026;
+    compute_failure.reason = RealizationFailureReason::ShaderRecompile;
+    compute_failure.compute_launch = {37, 9, 1, 16, 8, 1, 3, 2, 1};
+    ShaderRealizationDiagnostic compute_stage;
+    compute_stage.stage = ShaderProgramStage::Compute;
+    compute_stage.program_addr = reinterpret_cast<uint64_t>(kDiagnosticCompute);
+    compute_stage.resources = std::make_shared<ShaderResourceTable>();
+    compute_stage.recompile_config_available = true;
+    compute_stage.recompile_config.user_sgprs = {
+        0x12345678u, 0x9abcdef0u, 0x0badc0deu,
+    };
+    compute_stage.recompile_config.local_x = 16;
+    compute_stage.recompile_config.local_y = 8;
+    compute_stage.recompile_config.local_z = 1;
+    compute_stage.recompile_config.exact_thread_extent = true;
+    compute_stage.recompile_config.threads_x = 37;
+    compute_stage.recompile_config.threads_y = 9;
+    compute_stage.recompile_config.threads_z = 1;
+    compute_stage.recompile_config.wave_size = 64;
+    compute_stage.recompile_config.tidig_comp_cnt = 2;
+    compute_stage.recompile_config.tgid_x_en = true;
+    compute_stage.recompile_config.tgid_y_en = true;
+    compute_stage.recompile_config.tg_size_en = true;
+    compute_stage.recompile_config.lds_bytes = 512;
+    compute_stage.recompile_config.native_subgroup_size = 64;
+    compute_stage.recompile_config.native_storage_format_support =
+        native_storage_format_support_bit(DataFormat::Float16, 4);
+    compute_failure.stages.push_back(compute_stage);
+    const std::vector<SubmitOperation> failed_compute_operations = {
+        {SubmitOperationKind::Dispatch, 8, 1026},
+    };
+    GpuCaptureFile failed_compute_capture;
+    CHECK(capture_submit_items({}, {}, failed_compute_operations, meta, reader,
+                               failed_compute_capture, error, {}, {compute_failure}) &&
+              failed_compute_capture.failure_diagnostics.size() == 1 &&
+              failed_compute_capture.failure_diagnostics[0].stages.size() == 1 &&
+              failed_compute_capture.failure_diagnostics[0].stages[0]
+                  .recompile_config_available,
+          "v42 capture retains exact specialization for a failed compute translation");
+    std::vector<uint8_t> failed_compute_bytes;
+    GpuCaptureFile failed_compute_loaded;
+    CHECK(serialize_gpu_capture(failed_compute_capture, failed_compute_bytes, error) &&
+              deserialize_gpu_capture(failed_compute_bytes, failed_compute_loaded, error) &&
+              failed_compute_loaded.format_version == 42 &&
+              failed_compute_loaded.failure_diagnostics[0].compute_launch.threads_x == 37 &&
+              failed_compute_loaded.failure_diagnostics[0].stages[0]
+                      .recompile_config.user_sgprs ==
+                  compute_stage.recompile_config.user_sgprs &&
+              failed_compute_loaded.failure_diagnostics[0].stages[0]
+                      .recompile_config.local_y == 8 &&
+              failed_compute_loaded.failure_diagnostics[0].stages[0]
+                      .recompile_config.native_subgroup_size == 64,
+          "v42 failed-compute launch and user-SGPR ABI round-trips exactly");
+
+    std::vector<uint8_t> v41_failed_compute_bytes = failed_compute_bytes;
+    v41_failed_compute_bytes.resize(
+        v41_failed_compute_bytes.size() - v42_tail(failed_compute_capture));
+    v41_failed_compute_bytes[8] = 41;
+    v41_failed_compute_bytes[9] = v41_failed_compute_bytes[10] =
+        v41_failed_compute_bytes[11] = 0;
+    GpuCaptureFile v41_failed_compute_loaded;
+    CHECK(deserialize_gpu_capture(v41_failed_compute_bytes, v41_failed_compute_loaded, error) &&
+              !v41_failed_compute_loaded.failure_diagnostics[0].stages[0]
+                   .recompile_config_available,
+          "v41 failed-compute captures remain readable with specialization unavailable");
+
+    GpuCaptureFile invalid_failed_compute = failed_compute_capture;
+    invalid_failed_compute.failure_diagnostics[0].stages[0]
+        .recompile_config.user_sgprs.resize(33);
+    CHECK(!serialize_gpu_capture(invalid_failed_compute, failed_compute_bytes, error) &&
+              error == "invalid failed-compute recompile state",
+          "capture rejects an oversized failed-compute user-SGPR ABI");
+    invalid_failed_compute = failed_compute_capture;
+    invalid_failed_compute.failure_diagnostics[0].stages[0].recompile_config.local_x = 8;
+    CHECK(!serialize_gpu_capture(invalid_failed_compute, failed_compute_bytes, error) &&
+              error == "invalid failed-compute recompile state",
+          "capture rejects failed-compute specialization that disagrees with its launch");
 
     // Live one-shot capture receives the already-realized backend list as well as the original
     // semantic state. A failed operation is necessarily absent from that backend list, but must not
@@ -1566,7 +1675,7 @@ int main() {
                 loaded_failed_stage->resource_table.resources.size() == 1
             ? &loaded_failed_stage->resource_table.resources[0]
             : nullptr;
-    CHECK(failed_loaded.format_version == 41 && loaded_shadow &&
+    CHECK(failed_loaded.format_version == 42 && loaded_shadow &&
           loaded_shadow->resource.depth == 4 &&
           loaded_shadow->resource.max_uncompressed_block_size == 2 &&
           loaded_shadow->resource.max_compressed_block_size == 1 &&
@@ -1596,9 +1705,12 @@ int main() {
     std::vector<uint8_t> v40_failed_bytes;
     GpuCaptureFile v40_failed_loaded;
     CHECK(serialize_gpu_capture(failed_capture, v40_failed_bytes, error) &&
-              v40_failed_bytes.size() >= v41_tail(failed_capture),
+              v40_failed_bytes.size() >=
+                  v42_tail(failed_capture) + v41_tail(failed_capture),
           "v41 failed-stage resource tail is removable for a v40 compatibility fixture");
-    if (v40_failed_bytes.size() >= v41_tail(failed_capture)) {
+    if (v40_failed_bytes.size() >=
+        v42_tail(failed_capture) + v41_tail(failed_capture)) {
+        v40_failed_bytes.resize(v40_failed_bytes.size() - v42_tail(failed_capture));
         v40_failed_bytes.resize(v40_failed_bytes.size() - v41_tail(failed_capture));
         v40_failed_bytes[8] = 40;
         v40_failed_bytes[9] = v40_failed_bytes[10] = v40_failed_bytes[11] = 0;
@@ -1679,6 +1791,7 @@ int main() {
     if (v13_bytes.size() >= 32) {
         const size_t legacy_resource_count = legacy_source.draws[0].vrt.resources.size() +
                                              legacy_source.draws[0].prt.resources.size();
+        v13_bytes.resize(v13_bytes.size() - v42_tail(legacy_source));
         v13_bytes.resize(v13_bytes.size() - v41_tail(legacy_source));
         v13_bytes.resize(v13_bytes.size() - v40_tail(legacy_source));
         v13_bytes.resize(v13_bytes.size() - v39_tail(legacy_source));
@@ -1718,6 +1831,7 @@ int main() {
     if (legacy_bytes.size() >= 32) {
         const size_t legacy_resource_count = legacy_source.draws[0].vrt.resources.size() +
                                              legacy_source.draws[0].prt.resources.size();
+        legacy_bytes.resize(legacy_bytes.size() - v42_tail(legacy_source));
         legacy_bytes.resize(legacy_bytes.size() - v41_tail(legacy_source));
         legacy_bytes.resize(legacy_bytes.size() - v40_tail(legacy_source));
         legacy_bytes.resize(legacy_bytes.size() - v39_tail(legacy_source));
@@ -1783,9 +1897,9 @@ int main() {
     CHECK(deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
           !legacy_loaded.failure_diagnostics_available && legacy_loaded.failure_diagnostics.empty(),
           "v6 capture reopens with failed-operation diagnostics reported unavailable");
-    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 42;   // kVersion + 1: a future version
+    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 43;   // kVersion + 1: a future version
     CHECK(!deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
-          error == "unsupported capture version 42",
+          error == "unsupported capture version 43",
           "future capture versions fail with a concrete version error");
 
     GpuCaptureFile bad_hash = mixed;

--- a/prosper/tests/test_gpu_replay_shader_dump.cpp
+++ b/prosper/tests/test_gpu_replay_shader_dump.cpp
@@ -164,6 +164,49 @@ int main() {
               raw_compute, compute_raw, nullptr, false, false, true),
           "raw compute replay keeps the stored module when source is unavailable");
 
+    gpu::GpuCapturedStageDiagnostic failed_compute;
+    failed_compute.stage = gpu::ShaderProgramStage::Compute;
+    failed_compute.raw_shader_index = 0;
+    failed_compute.resource_table_present = false;
+    failed_compute.resource_count = 0;
+    failed_compute.recompile_config_available = true;
+    failed_compute.recompile_config.user_sgprs = {0x12345678u, 0x9abcdef0u};
+    failed_compute.recompile_config.local_x = 8;
+    failed_compute.recompile_config.local_y = 4;
+    failed_compute.recompile_config.local_z = 1;
+    failed_compute.recompile_config.exact_thread_extent = true;
+    failed_compute.recompile_config.threads_x = 17;
+    failed_compute.recompile_config.threads_y = 9;
+    failed_compute.recompile_config.threads_z = 1;
+    failed_compute.recompile_config.wave_size = 64;
+    failed_compute.recompile_config.tidig_comp_cnt = 2;
+    failed_compute.recompile_config.tgid_x_en = true;
+    failed_compute.recompile_config.tgid_y_en = true;
+    failed_compute.recompile_config.tg_size_en = true;
+    failed_compute.recompile_config.lds_bytes = 512;
+    failed_compute.recompile_config.native_subgroup_size = 0;
+    std::vector<uint32_t> failed_compute_spirv;
+    const auto direct_failed_compute_spirv = gpu::recompile_compute_shader_cached(
+        compute_raw[0].words.data(), compute_raw[0].words.size(), nullptr,
+        failed_compute.recompile_config);
+    CHECK(tools::recompile_failed_compute_stage(
+              failed_compute, compute_raw, failed_compute_spirv, error) &&
+              !failed_compute_spirv.empty() &&
+              failed_compute_spirv == direct_failed_compute_spirv,
+          "failed compute retry reproduces the exact captured specialization byte-for-byte");
+    auto different_failed_compute = failed_compute;
+    different_failed_compute.recompile_config.local_x = 4;
+    std::vector<uint32_t> different_failed_compute_spirv;
+    CHECK(tools::recompile_failed_compute_stage(
+              different_failed_compute, compute_raw, different_failed_compute_spirv, error) &&
+              different_failed_compute_spirv != failed_compute_spirv,
+          "failed compute retry consumes the captured local-size specialization");
+    failed_compute.recompile_config_available = false;
+    CHECK(!tools::recompile_failed_compute_stage(
+              failed_compute, compute_raw, failed_compute_spirv, error) &&
+              error.find("predates v42") != std::string::npos,
+          "failed compute retry refuses older captures instead of inventing ABI state");
+
     tools::ReplayRenderIntent render_intent;
     render_intent.positional_count = 1;
     CHECK(tools::replay_will_render(render_intent),

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -360,7 +360,10 @@ captured resource table. For split vertex programs, `--retry-failed-chain FAILUR
 first two retained vertex stages as one prolog/main chain and calls the production chain recompiler. Both modes
 exit successfully only when SPIR-V is produced and avoid Vulkan rendering, so they are the fast feedback path
 after a translator change. Chain retry requires the exact resource metadata added in capture v35 and rejects
-older or incomplete diagnostics explicitly.
+older or incomplete diagnostics explicitly. Failed compute retry additionally requires capture v42, which
+retains the exact launch dimensions, user SGPR values, wave/LDS state, and subgroup/storage specialization used
+by the rejected translator invocation. Older or incomplete failed-compute diagnostics are refused explicitly;
+the tool never substitutes default compute ABI state.
 
 Capture v8 adds persistent depth/stencil checkpoints. Each seed stores the renderer's complete guest cache
 identity (depth/stencil read/write bases, HTILE base, extent, and D32/D32S8 format), independent depth/stencil

--- a/prosper/tools/gpu_replay/compute_recompile.hpp
+++ b/prosper/tools/gpu_replay/compute_recompile.hpp
@@ -69,4 +69,45 @@ inline bool recompile_captured_compute(
     return true;
 }
 
+// Retry one failed compute translation without Vulkan. A successful return means the capsule had
+// complete, internally consistent retry inputs; an empty SPIR-V vector remains the translator's
+// fail-visible rejection. Older captures and incomplete diagnostics return false with a precise
+// metadata error instead of silently substituting default launch or user-SGPR state.
+inline bool recompile_failed_compute_stage(
+    const gpu::GpuCapturedStageDiagnostic& stage,
+    const std::vector<gpu::GpuCaptureRawShaderVersion>& raw_shader_versions,
+    std::vector<uint32_t>& spirv,
+    std::string& error) {
+    error.clear();
+    spirv.clear();
+    if (stage.stage != gpu::ShaderProgramStage::Compute) {
+        error = "failed stage is not compute";
+        return false;
+    }
+    if (stage.raw_shader_index >= raw_shader_versions.size()) {
+        error = "failed compute stage has no captured raw stream";
+        return false;
+    }
+    if (stage.resource_table_present != stage.resource_table.present ||
+        stage.resource_count != stage.resource_table.resources.size()) {
+        error = "failed compute stage lacks exact resource metadata (capture predates v35)";
+        return false;
+    }
+    if (!stage.recompile_config_available) {
+        error = "failed compute stage lacks exact specialization "
+                "(capture predates v42 or diagnostic is incomplete)";
+        return false;
+    }
+
+    gpu::ShaderResourceTable table;
+    table.resources.reserve(stage.resource_table.resources.size());
+    for (const auto& captured : stage.resource_table.resources)
+        table.resources.push_back(captured.resource);
+    const gpu::ShaderResourceTable* resources = stage.resource_table.present ? &table : nullptr;
+    const auto& raw = raw_shader_versions[stage.raw_shader_index];
+    spirv = gpu::recompile_compute_shader_cached(
+        raw.words.data(), raw.words.size(), resources, stage.recompile_config);
+    return true;
+}
+
 } // namespace prosper::tools

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -603,6 +603,9 @@ void inspect_frame(const prosper::gpu::GpuReplayFrame& replay) {
                         stage.recompiled ? "yes" : "no",
                         stage.resource_table_present ? "present" : "absent",
                         stage.resource_count, stage.descriptor_issue_count);
+            if (stage.stage == prosper::gpu::ShaderProgramStage::Compute)
+                std::printf(" config=%s",
+                            stage.recompile_config_available ? "present" : "absent");
             if (stage.first_descriptor_issue != 0xFFFFFFFFu)
                 std::printf(" first-descriptor=%s", prosper::gpu::descriptor_issue_name(
                     static_cast<prosper::gpu::DescriptorIssueCode>(stage.first_descriptor_issue)));
@@ -613,6 +616,15 @@ void inspect_frame(const prosper::gpu::GpuReplayFrame& replay) {
                 std::printf(" first-reject pc=%u fmt=%d op=0x%x", stage.coverage.first_bad_pc,
                             stage.coverage.first_bad_fmt, stage.coverage.first_bad_op);
             std::printf("\n");
+            if (stage.recompile_config_available) {
+                const auto& config = stage.recompile_config;
+                std::printf("    compute-config user-sgprs=%zu local=%ux%ux%u "
+                            "threads=%ux%ux%u wave=%u lds=%u subgroup=%u\n",
+                            config.user_sgprs.size(), config.local_x, config.local_y,
+                            config.local_z, config.threads_x, config.threads_y,
+                            config.threads_z, config.wave_size, config.lds_bytes,
+                            config.native_subgroup_size);
+            }
             for (size_t resource_index = 0;
                  resource_index < stage.resource_table.resources.size(); ++resource_index) {
                 const auto& resource =
@@ -2167,10 +2179,12 @@ int main(int argc, char** argv) {
                     raw.words.data(), raw.words.size(), resources);
                 break;
             case prosper::gpu::ShaderProgramStage::Compute:
-                std::fprintf(stderr,
-                             "gpu_replay: failed compute retry needs its launch/user-SGPR "
-                             "specialization, which v35 does not retain\n");
-                return 2;
+                if (!prosper::tools::recompile_failed_compute_stage(
+                        stage, replay.raw_shader_versions, spirv, error)) {
+                    std::fprintf(stderr, "gpu_replay: %s\n", error.c_str());
+                    return 2;
+                }
+                break;
         }
         std::fprintf(stderr,
                      "[retry-failed-stage] %s %s resources=%zu spirv-dwords=%zu\n",


### PR DESCRIPTION
Closes #1548.

## Why

Astro Bot compute program 0x500571000 is retained as a failed stage, but capture v41 only preserves its raw RDNA2 stream and resource table. A failed dispatch never reaches the realized-compute list, so its launch ABI, user SGPR values, wave/LDS state, and subgroup/storage policy were lost. gpu_replay therefore had to refuse offline compute retry rather than inventing translator inputs.

This is the smallest trustworthy prerequisite for continuing #1459: it makes the next selected capture reproduce the exact failed translator invocation offline.

## What changed

- Bump the append-only GPU capture format to v42.
- Retain the exact ComputeShaderConfig on shader-recompile and descriptor-contract failures.
- Preserve the known register-derived launch state for deferred/indirect diagnostics while keeping unresolved thread counts explicitly zero.
- Add a bounded v42 tail with strict failure/stage counts, availability flags, user-SGPR limits, launch consistency, wave/LDS/subgroup validation, and storage-mask validation.
- Keep v1-v41 readable; older failed-compute stages report specialization unavailable.
- Teach gpu_replay --retry-failed-stage to retry compute stages with the exact captured config and exact v35+ resource metadata, without initializing Vulkan.
- Print failed-compute config availability and the key ABI fields in --inspect-only.
- Document the v42 requirement and fail-visible behavior.

## Verification

- Built test_gpu_capture, test_gpu_replay_shader_dump, and gpu_replay in the project distrobox.
- test_gpu_capture passes, including v42 round-trip, v41 compatibility, user-SGPR bounds, and launch/config mismatch coverage.
- test_gpu_replay_shader_dump passes, including byte-for-byte comparison with a direct translation using the same captured config and proof that changing local size changes the rebuilt module.
- The existing Astro v41 capsule is still readable and now refuses compute retry explicitly with: capture predates v42 or diagnostic is incomplete.
- git diff --check passes.

No screenshot: this PR changes diagnostic capture/replay tooling and does not itself change rendered output.