### PR TITLE
Keep phase-gated timeline capture on the renderer fast path

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -388,6 +388,10 @@ if(TARGET prosper_core)
   target_include_directories(test_readback_policy PRIVATE frontends/shared)
   add_test(NAME readback_policy COMMAND test_readback_policy)
 
+  add_executable(test_capture_renderer_policy frontends/shared/test_capture_renderer_policy.cpp)
+  target_include_directories(test_capture_renderer_policy PRIVATE frontends/shared)
+  add_test(NAME capture_renderer_policy COMMAND test_capture_renderer_policy)
+
   add_executable(test_write_watch_policy frontends/shared/test_write_watch_policy.cpp)
   target_include_directories(test_write_watch_policy PRIVATE frontends/shared)
   add_test(NAME write_watch_policy COMMAND test_write_watch_policy)

--- a/prosper/frontends/shared/capture_renderer_policy.hpp
+++ b/prosper/frontends/shared/capture_renderer_policy.hpp
@@ -1,0 +1,14 @@
+// capture_renderer_policy.hpp - renderer residency policy for detailed GPU capture.
+#pragma once
+
+namespace prosper::frontend {
+
+// Immediate timeline capture needs authoritative CPU pixels throughout the run. A validated,
+// nonzero AFTER_COMPUTE gate does not: it remains inert before the semantic phase and materializes
+// referenced live targets through the capture RTT reader once armed.
+constexpr bool timeline_capture_allows_persistent_targets(
+    bool timeline_capture_requested, bool after_compute_gated) {
+    return !timeline_capture_requested || after_compute_gated;
+}
+
+} // namespace prosper::frontend

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -5,10 +5,12 @@
 #include "rtt_injection.hpp"
 #include "rtt_scale.hpp"
 #include "readback_policy.hpp"
+#include "capture_renderer_policy.hpp"
 #include "write_watch_policy.hpp"
 #include "live_compute.hpp"
 
 #include "gpu/gpu_execute.hpp"          // DrawItem, set_submit_renderer
+#include "gpu/gpu_timeline.hpp"         // phase-gated detailed-capture policy
 #include "gpu/writer_provenance.hpp"
 #include "gpu/gpu_capture.hpp"          // temporal RTT capture/replay seeds
 #include "gpu/guest_texture_layout.hpp" // exact pitch for HLE-produced guest textures
@@ -918,17 +920,27 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
     static const bool pertarget = getenv("PROSPER_RTT_PERTARGET") != nullptr ||
                                   getenv("PROSPER_RTT_SINGLE_TARGET") == nullptr;
     static const bool rtt_on = getenv("PROSPER_RTT") != nullptr || pertarget;
+    static const bool timeline_capture_requested =
+        getenv("PROSPER_GPU_TIMELINE_CAPTURE") != nullptr;
+    static const bool timeline_capture_phase_gated = timeline_capture_requested &&
+        prosper::gpu::gpu_timeline_capture_is_after_compute_gated();
+    static const bool timeline_capture_permits_live_targets =
+        timeline_capture_allows_persistent_targets(
+            timeline_capture_requested, timeline_capture_phase_gated);
     // Retain intermediate color targets on the GPU by default. Captures and per-target pixel
     // diagnostics require authoritative CPU pixels at every pass, so they retain the established
     // readback path. The explicit opt-out keeps a direct A/B and a recovery switch for driver issues.
     static const bool live_gpu_targets = pertarget &&
         !getenv("PROSPER_NO_LIVE_PERSISTENT_COLOR_TARGETS") && !getenv("PROSPER_GPU_CAPTURE") &&
-        !getenv("PROSPER_GPU_TIMELINE_CAPTURE") && !getenv("PROSPER_GPU_REPLAY_EXPORT_RTT") &&
+        timeline_capture_permits_live_targets && !getenv("PROSPER_GPU_REPLAY_EXPORT_RTT") &&
         !getenv("PROSPER_GPU_REPLAY_RTT_SEEDS") && !getenv("PROSPER_DUMP_SAMPLED_RTT") &&
         !getenv("PROSPER_DUMP_RTGROUPS") && !getenv("PROSPER_DUMP_RTGROUPS_RGBA") &&
         !getenv("PROSPER_DUMP_DRAWSTEPS") &&
         !getenv("PROSPER_RESOURCE_HASH_DIM") && !getenv("PROSPER_TARGET_STEP_HASH_DIM") &&
         !getenv("PROSPER_RTTLOG");
+    if (timeline_capture_phase_gated)
+        fprintf(stderr, "[render] phase-gated timeline capture retains live targets; "
+                        "capture readback is on demand\n");
     static const bool defer_intermediate_scanout = live_gpu_targets &&
         !getenv("PROSPER_NO_INTERMEDIATE_SCANOUT_DEFER");
     // Ordered passes share one queue and keep their attachments GPU-resident, so submit the callback's

--- a/prosper/frontends/shared/test_capture_renderer_policy.cpp
+++ b/prosper/frontends/shared/test_capture_renderer_policy.cpp
@@ -1,0 +1,21 @@
+#include "capture_renderer_policy.hpp"
+
+#include <cstdio>
+
+using prosper::frontend::timeline_capture_allows_persistent_targets;
+
+int main() {
+    if (!timeline_capture_allows_persistent_targets(false, false)) {
+        std::fprintf(stderr, "normal rendering unexpectedly disabled persistent targets\n");
+        return 1;
+    }
+    if (!timeline_capture_allows_persistent_targets(true, true)) {
+        std::fprintf(stderr, "phase-gated timeline capture unexpectedly disabled persistent targets\n");
+        return 1;
+    }
+    if (timeline_capture_allows_persistent_targets(true, false)) {
+        std::fprintf(stderr, "immediate timeline capture unexpectedly retained persistent targets\n");
+        return 1;
+    }
+    return 0;
+}

--- a/prosper/src/gpu/gpu_capture_bundle.cpp
+++ b/prosper/src/gpu/gpu_capture_bundle.cpp
@@ -412,6 +412,54 @@ bool materialize_gpu_capture_bundle_submit(const GpuCaptureBundle& bundle, size_
     return true;
 }
 
+bool replace_gpu_capture_bundle_submit_ds_seeds(
+    GpuCaptureBundle& bundle, size_t submit_index,
+    const std::vector<GpuCaptureDsSeed>& ds_seeds, std::string& error) {
+    error.clear();
+    if (bundle.version != kVersion || submit_index >= bundle.submits.size()) {
+        error = "bundle DS replacement requires a current-version submit";
+        return false;
+    }
+    GpuCaptureFile manifest;
+    if (!materialize_gpu_capture_bundle_manifest(bundle, submit_index, manifest, error))
+        return false;
+    manifest.ds_seeds = ds_seeds;
+    std::vector<uint8_t> bytes;
+    if (!serialize_gpu_capture(manifest, bytes, error)) return false;
+
+    GpuCaptureBundleSubmit& submit = bundle.submits[submit_index];
+    const size_t old_chunk_count = bundle.chunks.size();
+    const size_t old_hash_count = bundle.chunk_hashes.size();
+    const uint64_t old_manifest_bytes = submit.manifest_bytes;
+    const uint64_t old_logical_bytes = submit.logical_bytes;
+    if (old_logical_bytes < old_manifest_bytes) {
+        error = "bundle submit logical size is smaller than its manifest";
+        return false;
+    }
+    const uint64_t resource_bytes = old_logical_bytes - old_manifest_bytes;
+    if (bytes.size() > UINT64_MAX - resource_bytes ||
+        bundle.logical_bytes < old_logical_bytes ||
+        bundle.logical_bytes - old_logical_bytes >
+            UINT64_MAX - (bytes.size() + resource_bytes)) {
+        error = "bundle DS replacement size overflow";
+        return false;
+    }
+    std::vector<uint32_t> indices;
+    if (!append_chunks(bundle, bytes, indices, error)) {
+        bundle.chunks.resize(old_chunk_count);
+        bundle.chunk_hashes.resize(old_hash_count);
+        bundle.chunk_indices_by_hash.clear();
+        for (uint32_t i = 0; i < bundle.chunks.size(); ++i)
+            bundle.chunk_indices_by_hash[bundle.chunk_hashes[i]].push_back(i);
+        return false;
+    }
+    submit.chunk_indices = std::move(indices);
+    submit.manifest_bytes = bytes.size();
+    submit.logical_bytes = bytes.size() + resource_bytes;
+    bundle.logical_bytes = bundle.logical_bytes - old_logical_bytes + submit.logical_bytes;
+    return true;
+}
+
 bool compact_gpu_capture_bundle(GpuCaptureBundle& bundle, std::string& error) {
     error.clear();
     if (bundle.chunk_hashes.size() != bundle.chunks.size()) {

--- a/prosper/src/gpu/gpu_capture_bundle.hpp
+++ b/prosper/src/gpu/gpu_capture_bundle.hpp
@@ -52,6 +52,11 @@ bool materialize_gpu_capture_bundle_manifest(const GpuCaptureBundle& bundle, siz
                                              GpuCaptureFile& capture, std::string& error);
 bool materialize_gpu_capture_bundle_submit(const GpuCaptureBundle& bundle, size_t submit_index,
                                            GpuCaptureFile& capture, std::string& error);
+// Replace only one submit manifest's depth/stencil boundary. Resource dictionary references stay
+// intact; callers may compact afterward to discard the superseded manifest chunks.
+bool replace_gpu_capture_bundle_submit_ds_seeds(
+    GpuCaptureBundle& bundle, size_t submit_index,
+    const std::vector<GpuCaptureDsSeed>& ds_seeds, std::string& error);
 bool compact_gpu_capture_bundle(GpuCaptureBundle& bundle, std::string& error);
 bool write_gpu_capture_bundle(const std::string& path, const GpuCaptureBundle& bundle,
                               std::string& error);

--- a/prosper/src/gpu/gpu_timeline.cpp
+++ b/prosper/src/gpu/gpu_timeline.cpp
@@ -539,6 +539,11 @@ RuntimeDetailRequest& runtime_detail_request() {
     return request;
 }
 
+bool runtime_detail_request_is_after_compute_gated() {
+    const RuntimeDetailRequest& request = runtime_detail_request();
+    return request.valid && request.select_after_compute_program != 0;
+}
+
 struct RuntimeTargetWrite {
     uint64_t submit_no = 0;
     uint64_t draw_index = 0;
@@ -707,6 +712,11 @@ RuntimeProducerHistory& runtime_producer_history() {
 }
 
 struct RuntimeCaptureBundle {
+    struct BoundaryDs {
+        uint64_t submit_no = 0;
+        uint64_t bytes = 0;
+        std::vector<GpuCaptureDsSeed> seeds;
+    };
     GpuCaptureBundle bundle;
     bool budget_exhausted = false;
     bool failed = false;
@@ -714,6 +724,8 @@ struct RuntimeCaptureBundle {
     std::chrono::steady_clock::time_point started_at;
     uint64_t captured_resource_bytes = 0;
     uint64_t captured_submit_count = 0;
+    uint64_t boundary_ds_bytes = 0;
+    std::deque<BoundaryDs> boundary_ds;
     GpuTimelineBundleProvenanceState provenance;
 };
 
@@ -956,11 +968,97 @@ bool append_runtime_capture_bundle(const GpuCaptureFile& capture, uint64_t max_u
 }
 
 void trim_runtime_capture_bundle(size_t max_submits) {
-    GpuCaptureBundle& bundle = runtime_capture_bundle().bundle;
+    RuntimeCaptureBundle& state = runtime_capture_bundle();
+    GpuCaptureBundle& bundle = state.bundle;
     while (bundle.submits.size() > max_submits) {
+        const uint64_t removed_submit = bundle.submits.front().submit_index;
         bundle.logical_bytes -= bundle.submits.front().logical_bytes;
         bundle.submits.erase(bundle.submits.begin());
+        if (!state.boundary_ds.empty() && state.boundary_ds.front().submit_no == removed_submit) {
+            state.boundary_ds_bytes -= state.boundary_ds.front().bytes;
+            state.boundary_ds.pop_front();
+        }
     }
+}
+
+bool capture_metadata_only(const GpuCaptureFile& capture) {
+    return std::any_of(
+        capture.metadata.renderer_env.begin(), capture.metadata.renderer_env.end(),
+        [](const auto& entry) {
+            return entry.first == "PROSPER_GPU_CAPTURE_METADATA_ONLY" &&
+                   !entry.second.empty() && entry.second != "0" && entry.second != "off";
+        });
+}
+
+bool snapshot_runtime_bundle_boundary_ds(const GpuCaptureFile& capture, uint64_t submit_no,
+                                         uint64_t max_bytes,
+                                         RuntimeCaptureBundle::BoundaryDs& boundary,
+                                         std::string& error) {
+    boundary = {};
+    boundary.submit_no = submit_no;
+    if (capture_metadata_only(capture) || !gpu_capture_ds_seed_snapshot_available()) return true;
+    if (!read_all_gpu_capture_ds_seeds(boundary.seeds, error)) return false;
+    for (const auto& seed : boundary.seeds) {
+        const uint64_t bytes = seed.depth.size() + seed.stencil.size();
+        if (boundary.bytes > UINT64_MAX - bytes) {
+            error = "phase-bundle DS boundary size overflow";
+            return false;
+        }
+        boundary.bytes += bytes;
+    }
+    const RuntimeCaptureBundle& state = runtime_capture_bundle();
+    if (boundary.bytes > max_bytes || state.boundary_ds_bytes > max_bytes - boundary.bytes) {
+        error = "phase-bundle DS boundaries exceed the capture byte budget";
+        return false;
+    }
+    return true;
+}
+
+bool install_runtime_bundle_boundary_ds(std::string& error) {
+    RuntimeCaptureBundle& state = runtime_capture_bundle();
+    if (state.bundle.submits.empty() || state.boundary_ds.empty()) return true;
+    if (state.bundle.submits.front().submit_index != state.boundary_ds.front().submit_no) {
+        error = "phase-bundle DS boundary does not match its first retained submit";
+        return false;
+    }
+    return replace_gpu_capture_bundle_submit_ds_seeds(
+        state.bundle, 0, state.boundary_ds.front().seeds, error);
+}
+
+bool runtime_capture_bundle_within_budget(uint64_t max_unique_bytes, std::string& error) {
+    RuntimeCaptureBundle& state = runtime_capture_bundle();
+    const uint64_t unique_bytes = gpu_capture_bundle_unique_bytes(state.bundle);
+    if (unique_bytes <= max_unique_bytes) return true;
+    state.budget_exhausted = true;
+    error = "capture bundle unique bytes " + std::to_string(unique_bytes) +
+            " exceeded limit " + std::to_string(max_unique_bytes) +
+            " after installing the DS boundary";
+    return false;
+}
+
+bool write_runtime_capture_bundle_checkpoint(const std::string& path,
+                                             uint64_t max_unique_bytes,
+                                             std::string& error) {
+    RuntimeCaptureBundle& state = runtime_capture_bundle();
+    const bool has_boundary = !state.bundle.submits.empty() && !state.boundary_ds.empty();
+    if (!install_runtime_bundle_boundary_ds(error) ||
+        !compact_gpu_capture_bundle(state.bundle, error))
+        return false;
+    const bool written = runtime_capture_bundle_within_budget(max_unique_bytes, error) &&
+        write_gpu_capture_bundle(path, state.bundle, error);
+    const std::string write_error = error;
+    if (!has_boundary) return written;
+    std::string restore_error;
+    const bool restored = replace_gpu_capture_bundle_submit_ds_seeds(
+        state.bundle, 0, {}, restore_error) &&
+        compact_gpu_capture_bundle(state.bundle, restore_error);
+    if (!restored) {
+        error = "could not restore rolling bundle after DS checkpoint: " + restore_error;
+        state.failed = true;
+        return false;
+    }
+    if (!written) error = write_error;
+    return written;
 }
 
 GpuCaptureMetadata runtime_capture_metadata(uint64_t submit_no) {
@@ -1018,6 +1116,10 @@ void log_capture_detail(const GpuTimelineDetail& detail) {
 }
 
 } // namespace
+
+bool gpu_timeline_capture_is_after_compute_gated() {
+    return runtime_detail_request_is_after_compute_gated();
+}
 
 GpuTimelineCaptureCounters gpu_timeline_capture_counters() {
     const RuntimeDetailRequest& request = runtime_detail_request();
@@ -2064,16 +2166,26 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
         submit_no >= bundle_first &&
         (!request.bundle_start_target_width || request.bundle_start_reached) &&
         !capture_endpoint) {
+        // Semantic endpoints are not known until they arrive. Keep the rolling predecessor window
+        // at depth-2 before appending this submit, so its exact pre-submit DS snapshot can become the
+        // boundary if older constituents roll out.
+        if (request.semantic_selector)
+            trim_runtime_capture_bundle(request.bundle_depth - 2);
         begin_runtime_capture_bundle();
         GpuCaptureFile predecessor;
         const GpuCaptureMetadata metadata = runtime_capture_metadata(submit_no);
-        const bool captured = request.bundle_target_width
+        bool captured = request.bundle_target_width
             ? capture_gpustate_target_submit(state, submit_no, metadata.width, metadata.height,
                                              request.bundle_target_width, request.bundle_target_height,
                                              metadata, predecessor, error)
             : capture_gpustate_submit(state, submit_no, metadata.width, metadata.height,
                                       metadata, predecessor, error);
         RuntimeCaptureBundle& bundle_state = runtime_capture_bundle();
+        RuntimeCaptureBundle::BoundaryDs boundary_ds;
+        if (captured && history.phase_bounded &&
+            !snapshot_runtime_bundle_boundary_ds(
+                predecessor, submit_no, request.bundle_max_unique_bytes, boundary_ds, error))
+            captured = false;
         const bool provenance_was_complete = bundle_state.provenance.complete;
         if (captured && history.phase_bounded) {
             std::string provenance_error;
@@ -2099,13 +2211,16 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
             std::fprintf(stderr, "[timeline] bundle submit %llu capture failed: %s\n",
                          static_cast<unsigned long long>(submit_no), error.c_str());
         } else {
-            if (request.semantic_selector)
-                trim_runtime_capture_bundle(request.bundle_depth - 1);
+            if (history.phase_bounded) {
+                bundle_state.boundary_ds_bytes += boundary_ds.bytes;
+                bundle_state.boundary_ds.push_back(std::move(boundary_ds));
+            }
             ++bundle_state.captured_submit_count;
             request.bundle_submits_captured.fetch_add(1, std::memory_order_relaxed);
             if (request.bundle_checkpoint_interval &&
                 !(bundle_state.captured_submit_count % request.bundle_checkpoint_interval)) {
-                if (!write_gpu_capture_bundle(request.bundle_path, bundle_state.bundle, error)) {
+                if (!write_runtime_capture_bundle_checkpoint(
+                        request.bundle_path, request.bundle_max_unique_bytes, error)) {
                     std::fprintf(stderr,
                                  "[timeline] capture bundle checkpoint at submit %llu failed: %s\n",
                                  static_cast<unsigned long long>(submit_no), error.c_str());
@@ -2367,9 +2482,29 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
         } else if (state.budget_exhausted) {
             error = "capture bundle unique-byte budget was exhausted before the selected submit";
         }
-        if (state.failed || state.budget_exhausted || !append_runtime_capture_bundle(
-                capture, request.bundle_max_unique_bytes, error) ||
+        const bool phase_bundle = history.phase_bounded;
+        std::vector<GpuCaptureDsSeed> standalone_ds;
+        RuntimeCaptureBundle::BoundaryDs endpoint_boundary;
+        bool endpoint_boundary_ok = true;
+        if (phase_bundle) {
+            standalone_ds = std::move(capture.ds_seeds);
+            endpoint_boundary.submit_no = submit_no;
+            if (state.boundary_ds.empty())
+                endpoint_boundary_ok = snapshot_runtime_bundle_boundary_ds(
+                    capture, submit_no, request.bundle_max_unique_bytes,
+                    endpoint_boundary, error);
+        }
+        const bool appended = !state.failed && !state.budget_exhausted &&
+            endpoint_boundary_ok && append_runtime_capture_bundle(
+                capture, request.bundle_max_unique_bytes, error);
+        if (phase_bundle) capture.ds_seeds = std::move(standalone_ds);
+        if (appended && phase_bundle) {
+            state.boundary_ds_bytes += endpoint_boundary.bytes;
+            state.boundary_ds.push_back(std::move(endpoint_boundary));
+        }
+        if (!appended || !install_runtime_bundle_boundary_ds(error) ||
             !compact_gpu_capture_bundle(bundle, error) ||
+            !runtime_capture_bundle_within_budget(request.bundle_max_unique_bytes, error) ||
             !write_gpu_capture_bundle(request.bundle_path, bundle, error)) {
             requested_artifacts_written = false;
             std::fprintf(stderr, "[timeline] capture bundle write failed: %s\n", error.c_str());

--- a/prosper/src/gpu/gpu_timeline.cpp
+++ b/prosper/src/gpu/gpu_timeline.cpp
@@ -1041,12 +1041,12 @@ bool write_runtime_capture_bundle_checkpoint(const std::string& path,
                                              std::string& error) {
     RuntimeCaptureBundle& state = runtime_capture_bundle();
     const bool has_boundary = !state.bundle.submits.empty() && !state.boundary_ds.empty();
-    if (!install_runtime_bundle_boundary_ds(error) ||
-        !compact_gpu_capture_bundle(state.bundle, error))
-        return false;
-    const bool written = runtime_capture_bundle_within_budget(max_unique_bytes, error) &&
+    if (!install_runtime_bundle_boundary_ds(error)) return false;
+    const bool prepared = compact_gpu_capture_bundle(state.bundle, error);
+    const bool written = prepared &&
+        runtime_capture_bundle_within_budget(max_unique_bytes, error) &&
         write_gpu_capture_bundle(path, state.bundle, error);
-    const std::string write_error = error;
+    const std::string operation_error = error;
     if (!has_boundary) return written;
     std::string restore_error;
     const bool restored = replace_gpu_capture_bundle_submit_ds_seeds(
@@ -1057,7 +1057,7 @@ bool write_runtime_capture_bundle_checkpoint(const std::string& path,
         state.failed = true;
         return false;
     }
-    if (!written) error = write_error;
+    if (!written) error = operation_error;
     return written;
 }
 
@@ -2486,19 +2486,22 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
         std::vector<GpuCaptureDsSeed> standalone_ds;
         RuntimeCaptureBundle::BoundaryDs endpoint_boundary;
         bool endpoint_boundary_ok = true;
+        bool captured_endpoint_boundary = false;
         if (phase_bundle) {
             standalone_ds = std::move(capture.ds_seeds);
             endpoint_boundary.submit_no = submit_no;
-            if (state.boundary_ds.empty())
+            if (state.boundary_ds.empty()) {
+                captured_endpoint_boundary = true;
                 endpoint_boundary_ok = snapshot_runtime_bundle_boundary_ds(
                     capture, submit_no, request.bundle_max_unique_bytes,
                     endpoint_boundary, error);
+            }
         }
         const bool appended = !state.failed && !state.budget_exhausted &&
             endpoint_boundary_ok && append_runtime_capture_bundle(
                 capture, request.bundle_max_unique_bytes, error);
         if (phase_bundle) capture.ds_seeds = std::move(standalone_ds);
-        if (appended && phase_bundle) {
+        if (appended && captured_endpoint_boundary) {
             state.boundary_ds_bytes += endpoint_boundary.bytes;
             state.boundary_ds.push_back(std::move(endpoint_boundary));
         }

--- a/prosper/src/gpu/gpu_timeline.hpp
+++ b/prosper/src/gpu/gpu_timeline.hpp
@@ -245,6 +245,9 @@ bool read_gpu_timeline(const std::string& path, GpuTimelineFile& timeline, std::
 bool gpu_timeline_submit_matches(const GpuTimelineSubmit& submit,
                                  const GpuTimelineSelector& selector);
 GpuTimelineCaptureCounters gpu_timeline_capture_counters();
+// True only for a fully valid detailed-capture request with a nonzero AFTER_COMPUTE phase gate.
+// Frontends use this canonical parse to distinguish dormant phase capture from eager capture.
+bool gpu_timeline_capture_is_after_compute_gated();
 
 // Runtime hooks. Inert unless PROSPER_GPU_TIMELINE=<path> is set. They record folded semantic state
 // before renderer sampling and never realize shaders, copy resources, or invoke Vulkan.

--- a/prosper/tests/test_gpu_timeline.cpp
+++ b/prosper/tests/test_gpu_timeline.cpp
@@ -99,6 +99,15 @@ static int run_selector_env_child(const std::string& mode) {
     const std::string capture_path = base.string() + ".prgcap";
     const std::string bundle_path = base.string() + ".prgbundle";
     bool intermediate_ok = true;
+    unsigned ds_snapshots = 0;
+    GpuCaptureDsSeed expected_ds_seed;
+    expected_ds_seed.depth_read_base = expected_ds_seed.depth_write_base = 0x310000;
+    expected_ds_seed.htile_data_base = 0x300000;
+    expected_ds_seed.width = 2;
+    expected_ds_seed.height = 2;
+    expected_ds_seed.format = GpuCaptureDsFormat::D32Float;
+    expected_ds_seed.depth_valid = true;
+    expected_ds_seed.depth.assign(16, 0x5a);
     set_test_env("PROSPER_GPU_TIMELINE", timeline_path);
     set_test_env("PROSPER_GPU_TIMELINE_CAPTURE", capture_path);
     if (mode != "after-work")
@@ -107,12 +116,14 @@ static int run_selector_env_child(const std::string& mode) {
     if (mode == "invalid") {
         set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT", "1");
         set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_WHEN_VERTEX_PROGRAM", "not-an-address");
+        intermediate_ok = !gpu_timeline_capture_is_after_compute_gated();
         begin_gpu_timeline_submit(1);
         record_gpu_timeline_submit(GpuState{}, 1);
     } else if (mode == "after-invalid") {
         set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT", "1");
         set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_AFTER_COMPUTE_PROGRAM",
                      "not-an-address");
+        intermediate_ok = !gpu_timeline_capture_is_after_compute_gated();
         begin_gpu_timeline_submit(1);
         record_gpu_timeline_submit(GpuState{}, 1);
     } else if (mode == "zero") {
@@ -120,6 +131,7 @@ static int run_selector_env_child(const std::string& mode) {
         set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_WHEN_VERTEX_PROGRAM", "0");
         set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_WHEN_FRAGMENT_PROGRAM", "0x0");
         set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_AFTER_COMPUTE_PROGRAM", "0");
+        intermediate_ok = !gpu_timeline_capture_is_after_compute_gated();
         begin_gpu_timeline_submit(1);
         record_gpu_timeline_submit(GpuState{}, 1);
     } else if (mode == "semantic") {
@@ -131,6 +143,7 @@ static int run_selector_env_child(const std::string& mode) {
                      program_address(kSelectorPs));
         set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_WHEN_COMPUTE_PROGRAM",
                      program_address(kSelectorCompute));
+        intermediate_ok = !gpu_timeline_capture_is_after_compute_gated();
 
         const auto exact = selector_draw_state(642, 362, kSelectorVs, kSelectorPs);
         const auto wrong_vs = selector_draw_state(642, 362, kWrongSelectorVs, kSelectorPs);
@@ -172,6 +185,7 @@ static int run_selector_env_child(const std::string& mode) {
                      program_address(kSelectorPs));
         set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_AFTER_COMPUTE_PROGRAM",
                      program_address(kSelectorCompute));
+        intermediate_ok = gpu_timeline_capture_is_after_compute_gated();
 
         const auto exact = selector_draw_state(642, 362, kSelectorVs, kSelectorPs);
         const auto wrong_vs = selector_draw_state(642, 362, kWrongSelectorVs, kSelectorPs);
@@ -200,6 +214,7 @@ static int run_selector_env_child(const std::string& mode) {
                      program_address(kSelectorPs));
         set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_AFTER_COMPUTE_PROGRAM",
                      program_address(kSelectorCompute));
+        intermediate_ok = gpu_timeline_capture_is_after_compute_gated();
 
         const auto exact = selector_draw_state(642, 362, kSelectorVs, kSelectorPs);
         std::vector<GpuState> submits;
@@ -223,13 +238,22 @@ static int run_selector_env_child(const std::string& mode) {
         set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_START_TARGET_DRAW_INDEX", "0:0");
         set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_CHECKPOINT_EVERY", "1");
 
+        intermediate_ok = gpu_timeline_capture_is_after_compute_gated();
+        set_gpu_capture_ds_seed_snapshot_reader(
+            [&](std::vector<GpuCaptureDsSeed>& seeds, std::string&) {
+                ++ds_snapshots;
+                seeds = {expected_ds_seed};
+                return true;
+            });
+
         const auto exact = selector_draw_state(642, 362, kSelectorVs, kSelectorPs);
+        const auto wrong_target = selector_draw_state(1, 1, kSelectorVs, kSelectorPs);
         begin_gpu_timeline_submit(1);
         record_gpu_timeline_submit(selector_submit({exact}, 10, kWrongSelectorCompute), 1);
         begin_gpu_timeline_submit(2);
         record_gpu_timeline_submit(selector_submit({exact}, 20), 2);
         GpuTimelineCaptureCounters counters = gpu_timeline_capture_counters();
-        intermediate_ok = counters.phase_observation_submits == 2 &&
+        intermediate_ok = intermediate_ok && counters.phase_observation_submits == 2 &&
             counters.phase_dispatches_scanned == 1 &&
             counters.prearm_history_submits_skipped == 2 &&
             counters.prearm_history_draws_skipped == 2 &&
@@ -240,6 +264,7 @@ static int run_selector_env_child(const std::string& mode) {
             counters.bundle_provenance_failures == 0 &&
             counters.history_lower_bound_submit_no == 0 &&
             !counters.history_phase_bounded &&
+            ds_snapshots == 0 &&
             !std::filesystem::exists(bundle_path) &&
             !std::filesystem::exists(capture_path);
 
@@ -247,6 +272,7 @@ static int run_selector_env_child(const std::string& mode) {
         record_gpu_timeline_submit(selector_submit({exact}, 30, kSelectorCompute), 3);
         counters = gpu_timeline_capture_counters();
         GpuCaptureBundle armed_bundle;
+        GpuCaptureFile armed_capture;
         std::string armed_error;
         intermediate_ok = intermediate_ok && counters.phase_observation_submits == 3 &&
             counters.phase_dispatches_scanned == 2 &&
@@ -256,12 +282,19 @@ static int run_selector_env_child(const std::string& mode) {
             counters.detail_submits_captured == 0 &&
             counters.history_lower_bound_submit_no == 3 &&
             counters.history_phase_bounded &&
+            ds_snapshots == 1 &&
             read_gpu_capture_bundle(bundle_path, armed_bundle, armed_error) &&
             armed_bundle.submits.size() == 1 &&
-            armed_bundle.submits[0].submit_index == 3;
+            armed_bundle.submits[0].submit_index == 3 &&
+            materialize_gpu_capture_bundle_submit(
+                armed_bundle, 0, armed_capture, armed_error) &&
+            armed_capture.ds_seeds.size() == 1 &&
+            armed_capture.ds_seeds[0].depth == expected_ds_seed.depth;
 
         begin_gpu_timeline_submit(4);
-        record_gpu_timeline_submit(selector_submit({exact}, 40), 4);
+        record_gpu_timeline_submit(selector_submit({wrong_target}, 40), 4);
+        begin_gpu_timeline_submit(5);
+        record_gpu_timeline_submit(selector_submit({exact}, 50), 5);
     } else if (mode == "after-submit-zero") {
         set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT", "1");
         set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_WHEN_TARGET_DIM", "642x362");
@@ -271,6 +304,7 @@ static int run_selector_env_child(const std::string& mode) {
                      program_address(kSelectorPs));
         set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_AFTER_COMPUTE_PROGRAM",
                      program_address(kSelectorCompute));
+        intermediate_ok = gpu_timeline_capture_is_after_compute_gated();
 
         const auto exact = selector_draw_state(642, 362, kSelectorVs, kSelectorPs);
         begin_gpu_timeline_submit(0);
@@ -285,7 +319,7 @@ static int run_selector_env_child(const std::string& mode) {
     GpuTimelineFile timeline;
     std::string error;
     const bool timeline_ok = read_gpu_timeline(timeline_path, timeline, error);
-    bool ok = timeline_ok;
+    bool ok = timeline_ok && intermediate_ok;
     if (mode == "invalid" || mode == "after-invalid") {
         ok = ok && timeline.submits.size() == 1 && timeline.details.empty() &&
              !std::filesystem::exists(capture_path);
@@ -311,21 +345,30 @@ static int run_selector_env_child(const std::string& mode) {
     } else if (mode == "after-work") {
         GpuCaptureFile capture;
         GpuCaptureBundle bundle;
+        GpuCaptureFile first_bundle_capture, second_bundle_capture;
         const GpuTimelineCaptureCounters counters = gpu_timeline_capture_counters();
         const auto lower_bound = [&](const auto& entry) {
             return entry.first == "PROSPER_CAPTURE_HISTORY_LOWER_BOUND_SUBMIT" &&
                    entry.second == "3";
         };
-        ok = ok && intermediate_ok && timeline.submits.size() == 4 &&
-             timeline.details.size() == 2 && timeline.details[0].submit_no == 3 &&
-             timeline.details[1].submit_no == 4 && counters.history_submits_recorded == 2 &&
-             counters.bundle_submits_captured == 2 && counters.detail_submits_captured == 1 &&
+        ok = ok && intermediate_ok && timeline.submits.size() == 5 &&
+             timeline.details.size() == 3 && timeline.details[0].submit_no == 3 &&
+             timeline.details[1].submit_no == 4 && timeline.details[2].submit_no == 5 &&
+             counters.history_submits_recorded == 3 &&
+             counters.bundle_submits_captured == 3 && counters.detail_submits_captured == 1 &&
              counters.bundle_provenance_failures == 0 &&
-             read_gpu_capture(capture_path, capture, error) && capture.metadata.submit_index == 4 &&
+             read_gpu_capture(capture_path, capture, error) && capture.metadata.submit_index == 5 &&
              std::any_of(capture.metadata.renderer_env.begin(), capture.metadata.renderer_env.end(),
                          lower_bound) &&
              read_gpu_capture_bundle(bundle_path, bundle, error) && bundle.submits.size() == 2 &&
-             bundle.submits[0].submit_index == 3 && bundle.submits[1].submit_index == 4;
+             bundle.submits[0].submit_index == 4 && bundle.submits[1].submit_index == 5 &&
+             materialize_gpu_capture_bundle_submit(
+                 bundle, 0, first_bundle_capture, error) &&
+             materialize_gpu_capture_bundle_submit(
+                 bundle, 1, second_bundle_capture, error) &&
+             first_bundle_capture.ds_seeds.size() == 1 &&
+             first_bundle_capture.ds_seeds[0].depth == expected_ds_seed.depth &&
+             second_bundle_capture.ds_seeds.empty() && ds_snapshots == 3;
     } else {
         GpuCaptureFile capture;
         const auto zero_lower_bound = [&](const auto& entry) {
@@ -338,6 +381,7 @@ static int run_selector_env_child(const std::string& mode) {
              std::any_of(capture.metadata.renderer_env.begin(), capture.metadata.renderer_env.end(),
                          zero_lower_bound);
     }
+    set_gpu_capture_ds_seed_snapshot_reader({});
     std::error_code ec;
     std::filesystem::remove(timeline_path, ec);
     std::filesystem::remove(capture_path, ec);


### PR DESCRIPTION
Closes #1544.

## Problem

Merely setting `PROSPER_GPU_TIMELINE_CAPTURE` disabled persistent GPU color targets and backend target-submit batching for the entire process. That was necessary for an immediate capture, but it also applied to a valid `PROSPER_GPU_TIMELINE_CAPTURE_AFTER_COMPUTE` request while the gate was still dormant. Plucky Squire therefore spent its whole pre-gate route on the eager readback path even though the phase-gated capture did not need any image readback until it armed.

## Contract and implementation

- A valid nonzero after-compute gate keeps the normal persistent-target and backend-batching renderer path before arming.
- Immediate capture behavior and all existing renderer opt-outs remain unchanged.
- Gate classification has one canonical parser-backed API instead of duplicating environment parsing in the renderer.
- Phase-bounded bundles snapshot the full live depth/stencil boundary for the first retained constituent only. Later constituents do not reset it.
- Rolling checkpoint serialization temporarily installs that boundary and always restores the in-memory no-seed form; a failed restore marks the runtime bundle failed.
- Standalone endpoint capsules retain their own depth/stencil seeds.

This uses the existing on-demand persistent RTT seed reader once the capture actually arms. It does not change default rendering when timeline capture is absent.

## Plucky Squire live A/B

I ran the same fresh-save realtime first-gameplay route twice with render scale/every at their normal interactive defaults, an after-compute gate at `0x30130f0000`, endpoint vertex `0x3019080000`, bundle depth 8, checkpoint interval 1, and capture-exit enabled. The control added only `PROSPER_NO_LIVE_PERSISTENT_COLOR_TARGETS=1` to recreate the old eager renderer policy. The GPU slot was exclusive for these runs.

| Measurement | eager control | gated fast path |
|---|---:|---:|
| gate wall time | 253.941 s | 190.092 s |
| endpoint wall time | 256.035 s | 193.196 s |
| submit rate | 15.9/s | 44.8/s |
| present rate | 4.9/s | 14.1/s |
| timeline submits / presents | 4,064 / 1,247 | 8,651 / 2,725 |
| max RSS (`/usr/bin/time`) | 12,051,140 KB | 13,347,856 KB |

The gate arrived 25.1% sooner and the endpoint 24.5% sooner. Submit and present throughput were about 2.8x higher. Because the route is realtime rather than frame-count scripted, the faster run also allowed the guest to execute substantially more game work before the same scripted endpoint.

Both timelines were valid and non-truncated. The patched endpoint captured 54/56 realized draws and 27/27 dispatches. Its latest successful five-submit checkpoint extracted with 7 depth/stencil seeds on submit 8643 and zero on submits 8644-8647, proving the boundary is present once at the first retained constituent. Final bundle closure still fails visibly on the known unresolved temporal dependency; the standalone endpoint capsule remains available.

The renderer log for the patched run contains:

```text
[render] phase-gated timeline capture retains live targets; capture readback is on demand
[render] persistent GPU color targets enabled (experimental)
[render] backend target-submit batching enabled (experimental)
```

Raw local evidence is retained under `$HOME/.local/state/prosper-plucky/issue1544-730f726b.Mcz4I4/` and was not uploaded.

## Verification

Exact author-verified head after rebasing onto `origin/master` `98b3c902`: `58aee3889a8194eebac44ecde97825d27de204f5`.

The rebase was conflict-free. Both stable patch IDs and the aggregate binary diff SHA-256 remained identical (`135eb265...`, `827d1e55...`, and `acc626fe...` respectively), so the live A/B evidence above is unchanged.

Built in the project distrobox:

```text
TMPDIR=$PWD/build/tmpdir cmake --build build --target gpu_replay prosper-app test_gpu_timeline test_gpu_capture_bundle -j6
```

Focused tests, all passing:

```text
ctest --test-dir build --output-on-failure -R '^(capture_renderer_policy|gpu_timeline_roundtrip|gpu_capture_bundle_roundtrip|gpu_capture_roundtrip|gpu_timeline_capture_exit|readback_policy|rtt_scale|rtt_injection|gpu_execute)$'
9/9 passed
```

Snapshot tests were not run: this is normal development rather than a release. There is no screenshot because this changes throughput and capture behavior without changing the visible checkpoint or intended pixels.

## Risk and deliberate non-scope

- The fast path increased measured peak RSS by about 1.3 GB, although the realtime runs performed different amounts of game work, so this is not an allocation-matched comparison.
- Immediate timeline captures still take the conservative path.
- A separate pre-arm compute/executor policy issue is tracked in #1547 and is intentionally not changed here.
