### PR TITLE
Permit ordinary LDS effects under compute wave branches

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -4183,8 +4183,9 @@ std::vector<ForwardIf> detect_forward_ifs(const std::vector<Rdna2Inst>& ins, boo
     for (const auto& in : ins) {
         if (in.is_end) break;
         if (in.fmt != Rdna2Format::SOPP) continue;
-        // Set when a compute vccz/vccnz if is accepted via the #590 uniformity proof — its region is
-        // then required to be barrier/LDS/cross-lane free (checked after the target/merge is known).
+        // Set when a compute vccz/vccnz if is accepted for exact guest-wave control flow. Its region
+        // must remain free of operations that require every workgroup invocation to reach one common
+        // synchronized phase (checked after the target/merge is known).
         bool compute_uniform_vcc = false;
         switch (in.opcode) {
             case 0x02: continue;                                     // s_branch: validated in pass 2
@@ -4352,22 +4353,26 @@ std::vector<ForwardIf> detect_forward_ifs(const std::vector<Rdna2Inst>& ins, boo
             }
         }
         if (compute_uniform_vcc) {
-            // (#590) the uniformity proof is per-WAVE: reject when the guarded region contains a
-            // barrier / LDS / cross-lane op (mirroring the compute loop-body guard — a barrier under
-            // control flow whose condition could differ across the workgroup's waves would be
-            // workgroup-divergent, UB).
+            // The exact branch decision is per-WAVE, so different waves in one workgroup may take
+            // different arms. Ordinary LDS loads/stores/atomics are valid under that control flow:
+            // they are per-invocation memory effects and impose no reconvergence requirement. A
+            // guest barrier is not valid there, and synthesized wave collectives need the CFG
+            // dispatcher's common phase rather than the compact structured emitter. Keep those
+            // synchronized operations fail-visible here; raw LDS memory effects can remain in-arm.
             const uint32_t region_end = F.has_else ? F.merge_pc : F.target_pc;
             for (const auto& r : ins) {
                 if (r.is_end || r.pc >= region_end) break;
                 if (r.pc <= in.pc) continue;
-                if (r.fmt == Rdna2Format::DS ||
-                    (r.fmt == Rdna2Format::SOPP && r.opcode == 0x0a) ||
+                const bool ds_wave_collective = r.fmt == Rdna2Format::DS &&
+                    (r.opcode == 0x35 || r.opcode == 0x3d || r.opcode == 0x3e);
+                if ((r.fmt == Rdna2Format::SOPP && r.opcode == 0x0a) ||
+                    ds_wave_collective ||
                     (r.fmt == Rdna2Format::VOP3 &&
                      (r.opcode == 0x365 || r.opcode == 0x366))) {
                     if (getenv("PROSPER_DBG"))
                         std::fprintf(stderr,
                                      "[compute-struct-reject] vcc branch pc=%u contains "
-                                     "wave/workgroup op pc=%u fmt=%d op=0x%x\n",
+                                     "synchronized op pc=%u fmt=%d op=0x%x\n",
                                      in.pc, r.pc, static_cast<int>(r.fmt), r.opcode);
                     return reject();
                 }

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -732,6 +732,70 @@ int main() {
     }
     printf("  [ok]   barrier phase terminates and rejoins Astro's crossing Wave32 CFG\n");
 
+    // Astro Bot's Wave64 world-map kernel selects ordinary LDS-write sequences with
+    // S_CBRANCH_VCCZ. The scalar edge is exact per guest wave, but different waves in the workgroup
+    // may choose different arms. That is legal for ordinary LDS loads/stores/atomics: unlike a guest
+    // barrier or synthesized wave collective, they impose no workgroup-wide reconvergence point.
+    // Keep this portable (native_subgroup_size=0) and use two guest waves so the test exercises the
+    // exact scratch vote rather than accidentally inheriting the host subgroup's branch domain.
+    const uint32_t wave64_compute_vcc_lds_write[] = {
+        0x7d840000u,                         // pc0: v_cmp_eq_u32 vcc,v0,v0
+        0xbf860002u,                         // pc1: s_cbranch_vccz -> pc4
+        0xd8340084u, 0x00000002u,            // pc2: ds_write_b32 v2,v0 offset:0x84
+        0xbf810000u,                         // pc4: s_endpgm
+    };
+    ComputeShaderConfig portable_wave64_compute_config;
+    portable_wave64_compute_config.local_x = 128;
+    portable_wave64_compute_config.wave_size = 64;
+    const auto wave64_compute_vcc_lds_spv = recompile_compute(
+        wave64_compute_vcc_lds_write, std::size(wave64_compute_vcc_lds_write), nullptr,
+        portable_wave64_compute_config);
+    if (wave64_compute_vcc_lds_spv.empty() ||
+        !has_opcode(wave64_compute_vcc_lds_spv, 224) || // OpControlBarrier: exact scratch vote
+        !has_opcode(wave64_compute_vcc_lds_spv, 247) || // OpSelectionMerge: retained guest arm
+        !type_result_ids_are_nonzero(wave64_compute_vcc_lds_spv, nullptr) ||
+        !phi_ids_are_nonzero(wave64_compute_vcc_lds_spv)) {
+        printf("  [FAIL] Wave64 VCC branch rejected an ordinary in-arm LDS write\n");
+        return 1;
+    }
+    printf("  [ok]   Wave64 VCC branch retains ordinary LDS effects after an exact wave vote\n");
+
+    // The acceptance above must not become a blanket escape hatch for operations whose lowering
+    // contains a workgroup/subgroup synchronization phase. Those remain fail-visible inside a
+    // per-wave arm until a common-phase transformation proves every invocation participates.
+    const uint32_t wave64_compute_vcc_barrier[] = {
+        0x7d840000u,
+        0xbf860002u,                         // vccz -> pc4
+        0xbf8a0000u,                         // guest workgroup barrier
+        0xbf800000u,
+        0xbf810000u,
+    };
+    const uint32_t wave64_compute_vcc_mbcnt[] = {
+        0x7d840000u,
+        0xbf860002u,                         // vccz -> pc4
+        0xd7650004u, 0x000100c1u,            // v_mbcnt_lo_u32_b32 v4,-1,0
+        0xbf810000u,
+    };
+    const uint32_t wave64_compute_vcc_swizzle[] = {
+        0x7d840000u,
+        0xbf860002u,                         // vccz -> pc4
+        0xd8d4020fu, 0x00000000u,            // ds_swizzle_b32 v0,v0 offset:0x020f
+        0xbf810000u,
+    };
+    if (!recompile_compute(wave64_compute_vcc_barrier,
+                           std::size(wave64_compute_vcc_barrier), nullptr,
+                           portable_wave64_compute_config).empty() ||
+        !recompile_compute(wave64_compute_vcc_mbcnt,
+                           std::size(wave64_compute_vcc_mbcnt), nullptr,
+                           portable_wave64_compute_config).empty() ||
+        !recompile_compute(wave64_compute_vcc_swizzle,
+                           std::size(wave64_compute_vcc_swizzle), nullptr,
+                           portable_wave64_compute_config).empty()) {
+        printf("  [FAIL] synchronized operation escaped through a Wave64 VCC branch\n");
+        return 1;
+    }
+    printf("  [ok]   Wave64 VCC branches still reject synchronized in-arm operations\n");
+
     wave32_compute_config.wave_size = 64;
     if (!recompile_compute(wave32_compute_masks, std::size(wave32_compute_masks), nullptr,
                            wave32_compute_config).empty()) {


### PR DESCRIPTION
## Summary

- distinguish ordinary LDS memory effects from operations that require a synchronized workgroup phase
- retain exact per-wave VCC control flow for LDS loads, stores, and atomics
- keep guest barriers, MBCNT, DS swizzle, and append/consume fail-visible inside those arms
- add portable Wave64 two-wave positive and negative regression coverage

## Why

Astro Bot world-map compute target `0x500571000` has a Wave64 `s_cbranch_vccz` guarding ordinary `ds_write_b32` sequences. The existing structural check rejected every DS instruction in a per-wave arm, even though ordinary LDS memory effects do not impose a reconvergence point. That contradicted the exact CFG emitter and stopped a legal shader before translation.

This is a generic translator correctness fix, not a game-specific bypass. Operations whose lowering genuinely needs a common synchronized phase remain rejected.

Part of #1459. The captured shader now advances past the PC 698 LDS rejection and stops at a separate backward-loop classification problem at PC 1920, which is intentionally out of scope for this PR.

## Validation

- distrobox build succeeded
- full `build-astro/test_rdna2_spirv_struct` passed
- new portable Wave64 test retains an ordinary in-arm LDS write after the exact wave vote
- negative tests continue to reject a guest barrier, MBCNT, and DS swizzle in the same control-flow shape
- frozen v42 capsule retry advances to `[compute-struct-reject] backward else pc=1920 branch=2969 target=2970`
- `git diff --check` passed

No live GPU run was needed. No screenshot is included because the world map remains black and this focused change does not yet produce a new visible frame.