### PR TITLE
Keep gated compute capture native before arming

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -392,6 +392,10 @@ if(TARGET prosper_core)
   target_include_directories(test_capture_renderer_policy PRIVATE frontends/shared)
   add_test(NAME capture_renderer_policy COMMAND test_capture_renderer_policy)
 
+  add_executable(test_capture_compute_policy tests/test_capture_compute_policy.cpp)
+  target_include_directories(test_capture_compute_policy PRIVATE src)
+  add_test(NAME capture_compute_policy COMMAND test_capture_compute_policy)
+
   add_executable(test_write_watch_policy frontends/shared/test_write_watch_policy.cpp)
   target_include_directories(test_write_watch_policy PRIVATE frontends/shared)
   add_test(NAME write_watch_policy COMMAND test_write_watch_policy)

--- a/prosper/src/gpu/capture_compute_policy.hpp
+++ b/prosper/src/gpu/capture_compute_policy.hpp
@@ -1,0 +1,14 @@
+// capture_compute_policy.hpp - compute shader portability policy for detailed GPU capture.
+#pragma once
+
+namespace prosper::gpu {
+
+// Immediate timeline capture must compile device-independent storage-image paths from startup.
+// A validated nonzero AFTER_COMPUTE request is inert until its semantic gate arms, at which point
+// the compile key switches to the portable variant for the gate submit and all later capture work.
+constexpr bool timeline_capture_requires_portable_compute(
+    bool timeline_capture_requested, bool after_compute_gated, bool after_compute_armed) {
+    return timeline_capture_requested && (!after_compute_gated || after_compute_armed);
+}
+
+} // namespace prosper::gpu

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -7,6 +7,7 @@
 #include "gpu_execute.hpp"
 #include "gpu_capture.hpp"
 #include "gpu_timeline.hpp"
+#include "capture_compute_policy.hpp"
 #include "videoout_present.hpp"   // present_write_frame
 #include "agc_shader_layout.hpp"  // AgcShaderHeader + build_shader_resources
 #include "pm4_registers.hpp"      // SPI_SHADER_USER_DATA_* offsets
@@ -4234,8 +4235,18 @@ std::vector<ComputeItem> realize_compute_dispatches(
         // device-independent storage paths (raw uvec4 or exact packed R32ui), so optional format
         // support never becomes an artifact ABI. Capture v39 also retains the raw shader and
         // semantic launch ABI, allowing --recompile-raw to reconstruct a device-specific module.
+        static const bool timeline_capture_requested =
+            std::getenv("PROSPER_GPU_TIMELINE_CAPTURE") != nullptr;
+        static const bool timeline_capture_after_compute_gated =
+            timeline_capture_requested && gpu_timeline_capture_is_after_compute_gated();
+        const bool timeline_capture_after_compute_armed =
+            timeline_capture_after_compute_gated &&
+            gpu_timeline_capture_after_compute_gate_armed();
+        const bool timeline_capture_bound = timeline_capture_requires_portable_compute(
+            timeline_capture_requested, timeline_capture_after_compute_gated,
+            timeline_capture_after_compute_armed);
         const bool capture_bound = std::getenv("PROSPER_GPU_CAPTURE") ||
-            std::getenv("PROSPER_GPU_TIMELINE_CAPTURE") ||
+            timeline_capture_bound ||
             interactive_gpu_capture_armed() || interactive_capture_bundle_active();
         if (capture_bound)
             config.native_storage_format_support = 0;

--- a/prosper/src/gpu/gpu_timeline.cpp
+++ b/prosper/src/gpu/gpu_timeline.cpp
@@ -269,7 +269,7 @@ struct RuntimeDetailRequest {
     std::atomic<bool> predecessor_claimed{false};
     std::atomic<bool> predecessor_failed{false};
     bool bundle_start_reached = false;
-    bool after_compute_seen = false;
+    std::atomic<bool> after_compute_seen{false};
     std::atomic<uint64_t> phase_observation_submits{0};
     std::atomic<uint64_t> phase_dispatches_scanned{0};
     std::atomic<uint64_t> prearm_history_submits_skipped{0};
@@ -779,7 +779,8 @@ enum class RuntimeCapturePhaseObservation { Ready, Waiting, ArmedThisSubmit };
 RuntimeCapturePhaseObservation observe_runtime_capture_phase(RuntimeDetailRequest& request,
                                                              const GpuState& state,
                                                              uint64_t submit_no) {
-    if (!request.select_after_compute_program || request.after_compute_seen)
+    if (!request.select_after_compute_program ||
+        request.after_compute_seen.load(std::memory_order_acquire))
         return RuntimeCapturePhaseObservation::Ready;
     request.phase_observation_submits.fetch_add(1, std::memory_order_relaxed);
     for (const auto& dispatch : state.dispatches) {
@@ -787,7 +788,7 @@ RuntimeCapturePhaseObservation observe_runtime_capture_phase(RuntimeDetailReques
         if (compute_dispatch_code_addr(state, dispatch) != request.select_after_compute_program)
             continue;
         request.after_compute_submit_no = submit_no;
-        request.after_compute_seen = true;
+        request.after_compute_seen.store(true, std::memory_order_release);
         std::fprintf(stderr,
                      "[timeline] capture after-compute gate armed submit=%llu program=0x%llx "
                      "observed-submits=%llu dispatches-scanned=%llu history-submits-skipped=%llu "
@@ -816,7 +817,7 @@ bool runtime_capture_endpoint_matches(RuntimeDetailRequest& request,
     if (request.select_after_compute_program) {
         // The phase program's submit only arms the request. Even if it also satisfies every
         // endpoint predicate, capture begins with a strictly later submit.
-        if (!request.after_compute_seen ||
+        if (!request.after_compute_seen.load(std::memory_order_acquire) ||
             submit_no <= request.after_compute_submit_no)
             return false;
     }
@@ -1119,6 +1120,12 @@ void log_capture_detail(const GpuTimelineDetail& detail) {
 
 bool gpu_timeline_capture_is_after_compute_gated() {
     return runtime_detail_request_is_after_compute_gated();
+}
+
+bool gpu_timeline_capture_after_compute_gate_armed() {
+    const RuntimeDetailRequest& request = runtime_detail_request();
+    return request.valid && request.select_after_compute_program != 0 &&
+        request.after_compute_seen.load(std::memory_order_acquire);
 }
 
 GpuTimelineCaptureCounters gpu_timeline_capture_counters() {

--- a/prosper/src/gpu/gpu_timeline.hpp
+++ b/prosper/src/gpu/gpu_timeline.hpp
@@ -248,6 +248,9 @@ GpuTimelineCaptureCounters gpu_timeline_capture_counters();
 // True only for a fully valid detailed-capture request with a nonzero AFTER_COMPUTE phase gate.
 // Frontends use this canonical parse to distinguish dormant phase capture from eager capture.
 bool gpu_timeline_capture_is_after_compute_gated();
+// True once the matching AFTER_COMPUTE dispatch has been observed. Published atomically because
+// compute realization uses it to change capture portability policy at the semantic boundary.
+bool gpu_timeline_capture_after_compute_gate_armed();
 
 // Runtime hooks. Inert unless PROSPER_GPU_TIMELINE=<path> is set. They record folded semantic state
 // before renderer sampling and never realize shaders, copy resources, or invoke Vulkan.

--- a/prosper/tests/test_capture_compute_policy.cpp
+++ b/prosper/tests/test_capture_compute_policy.cpp
@@ -1,0 +1,25 @@
+#include "gpu/capture_compute_policy.hpp"
+
+#include <cstdio>
+
+using prosper::gpu::timeline_capture_requires_portable_compute;
+
+int main() {
+    if (timeline_capture_requires_portable_compute(false, false, false)) {
+        std::fprintf(stderr, "normal compute unexpectedly required portable capture storage\n");
+        return 1;
+    }
+    if (timeline_capture_requires_portable_compute(true, true, false)) {
+        std::fprintf(stderr, "dormant phase gate unexpectedly required portable capture storage\n");
+        return 1;
+    }
+    if (!timeline_capture_requires_portable_compute(true, true, true)) {
+        std::fprintf(stderr, "armed phase gate unexpectedly retained native storage formats\n");
+        return 1;
+    }
+    if (!timeline_capture_requires_portable_compute(true, false, false)) {
+        std::fprintf(stderr, "immediate capture unexpectedly retained native storage formats\n");
+        return 1;
+    }
+    return 0;
+}

--- a/prosper/tests/test_gpu_timeline.cpp
+++ b/prosper/tests/test_gpu_timeline.cpp
@@ -116,14 +116,16 @@ static int run_selector_env_child(const std::string& mode) {
     if (mode == "invalid") {
         set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT", "1");
         set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_WHEN_VERTEX_PROGRAM", "not-an-address");
-        intermediate_ok = !gpu_timeline_capture_is_after_compute_gated();
+        intermediate_ok = !gpu_timeline_capture_is_after_compute_gated() &&
+            !gpu_timeline_capture_after_compute_gate_armed();
         begin_gpu_timeline_submit(1);
         record_gpu_timeline_submit(GpuState{}, 1);
     } else if (mode == "after-invalid") {
         set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT", "1");
         set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_AFTER_COMPUTE_PROGRAM",
                      "not-an-address");
-        intermediate_ok = !gpu_timeline_capture_is_after_compute_gated();
+        intermediate_ok = !gpu_timeline_capture_is_after_compute_gated() &&
+            !gpu_timeline_capture_after_compute_gate_armed();
         begin_gpu_timeline_submit(1);
         record_gpu_timeline_submit(GpuState{}, 1);
     } else if (mode == "zero") {
@@ -131,7 +133,8 @@ static int run_selector_env_child(const std::string& mode) {
         set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_WHEN_VERTEX_PROGRAM", "0");
         set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_WHEN_FRAGMENT_PROGRAM", "0x0");
         set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_AFTER_COMPUTE_PROGRAM", "0");
-        intermediate_ok = !gpu_timeline_capture_is_after_compute_gated();
+        intermediate_ok = !gpu_timeline_capture_is_after_compute_gated() &&
+            !gpu_timeline_capture_after_compute_gate_armed();
         begin_gpu_timeline_submit(1);
         record_gpu_timeline_submit(GpuState{}, 1);
     } else if (mode == "semantic") {
@@ -185,7 +188,8 @@ static int run_selector_env_child(const std::string& mode) {
                      program_address(kSelectorPs));
         set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_AFTER_COMPUTE_PROGRAM",
                      program_address(kSelectorCompute));
-        intermediate_ok = gpu_timeline_capture_is_after_compute_gated();
+        intermediate_ok = gpu_timeline_capture_is_after_compute_gated() &&
+            !gpu_timeline_capture_after_compute_gate_armed();
 
         const auto exact = selector_draw_state(642, 362, kSelectorVs, kSelectorPs);
         const auto wrong_vs = selector_draw_state(642, 362, kWrongSelectorVs, kSelectorPs);
@@ -214,7 +218,8 @@ static int run_selector_env_child(const std::string& mode) {
                      program_address(kSelectorPs));
         set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_AFTER_COMPUTE_PROGRAM",
                      program_address(kSelectorCompute));
-        intermediate_ok = gpu_timeline_capture_is_after_compute_gated();
+        intermediate_ok = gpu_timeline_capture_is_after_compute_gated() &&
+            !gpu_timeline_capture_after_compute_gate_armed();
 
         const auto exact = selector_draw_state(642, 362, kSelectorVs, kSelectorPs);
         std::vector<GpuState> submits;
@@ -238,7 +243,8 @@ static int run_selector_env_child(const std::string& mode) {
         set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_START_TARGET_DRAW_INDEX", "0:0");
         set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_CHECKPOINT_EVERY", "1");
 
-        intermediate_ok = gpu_timeline_capture_is_after_compute_gated();
+        intermediate_ok = gpu_timeline_capture_is_after_compute_gated() &&
+            !gpu_timeline_capture_after_compute_gate_armed();
         set_gpu_capture_ds_seed_snapshot_reader(
             [&](std::vector<GpuCaptureDsSeed>& seeds, std::string&) {
                 ++ds_snapshots;
@@ -264,6 +270,7 @@ static int run_selector_env_child(const std::string& mode) {
             counters.bundle_provenance_failures == 0 &&
             counters.history_lower_bound_submit_no == 0 &&
             !counters.history_phase_bounded &&
+            !gpu_timeline_capture_after_compute_gate_armed() &&
             ds_snapshots == 0 &&
             !std::filesystem::exists(bundle_path) &&
             !std::filesystem::exists(capture_path);
@@ -282,6 +289,7 @@ static int run_selector_env_child(const std::string& mode) {
             counters.detail_submits_captured == 0 &&
             counters.history_lower_bound_submit_no == 3 &&
             counters.history_phase_bounded &&
+            gpu_timeline_capture_after_compute_gate_armed() &&
             ds_snapshots == 1 &&
             read_gpu_capture_bundle(bundle_path, armed_bundle, armed_error) &&
             armed_bundle.submits.size() == 1 &&


### PR DESCRIPTION
## Summary

- keep native storage-format compute shaders enabled while a valid nonzero `AFTER_COMPUTE` timeline gate is dormant
- switch to the portable capture shader contract on the gate submit and retain it afterward
- preserve eager portable behavior for immediate, invalid, and zero-gate capture modes
- publish gate state atomically and cover the policy and phase transition with focused tests

## Why

The mere presence of `PROSPER_GPU_TIMELINE_CAPTURE` previously disabled native compute storage formats from process startup. For a capture gated minutes into boot, that selected slower portable storage-image paths for every pre-arm dispatch even though no artifact could yet be produced.

Timeline phase observation occurs before live compute realization. This lets the matching submit atomically publish the armed state before its shaders are realized: dormant submits retain the normal native policy, while the gate submit and later capture work use device-independent storage paths. Immediate capture behavior is unchanged.

The native storage support mask already participates in full shader compile-key equality and hashing, and the existing cache regression proves native and raw variants receive distinct module identities, so no cache flush is required.

Closes #1547.

## Validation

- distrobox build passed at exact head `2e3266af7266e1fe3f1d7ca5e19bbcb467746dbe`
- `capture_compute_policy` passed the normal, dormant-gated, armed-gated, and immediate truth table
- `gpu_timeline_roundtrip` passed invalid/zero dormant assertions and the valid pre-arm to arm transition
- `shader_recompile_cache` passed native/raw module identity coverage
- focused ctest selection: 3/3 passed
- `git diff --check HEAD` passed

No live GPU run or screenshot was needed: this is a focused capture-policy correction and does not change game output.