### PR TITLE
Correct Dragon Quest clean-save route and controls

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -204,17 +204,19 @@ individually probed and confirmed as legitimate frustum culls (#1435).
 </p>
 
 This Unreal Engine 4 target renders its localized, animated title screen at native 3840×2160. A
-fresh-save current-master run reached it in about 28 seconds with six ordinary Cross pulses; the
-representative image above is an unmodified native frontend capture from that route. The title window
-advanced at roughly 20–22 presented frames per second in that run. Some animation samples still show a
-dark/purple background behind the stable logo, so visual correctness and full-speed performance remain
-open.
+current-master run with unique roots for both save backends reached it in about 34 seconds with seven
+ordinary Cross pulses; the representative image above is an unmodified native frontend capture of the
+same validated title state. Title performance remains below full speed and varies with concurrent GPU work. Some
+animation samples still show a dark/purple background behind the stable logo, so visual correctness and
+full-speed performance remain open.
 
 The apparently permanent black frame in no-input runs is authored UI state, not a lost final composite:
 the complete sky/ocean scene exists underneath an opaque-black Slate background, and the routed input
 changes the foreground lifecycle so the title becomes visible. Older work navigated the save-slot menu
-and began content loading, but that later path has not been revalidated on current master and no gameplay
-milestone is claimed. See the exact route in
+and began content loading. A current isolated run now reaches the new-save name keyboard and remains
+alive there without the historical allocator failure. A focused probe confirmed that the post-title
+flow advanced the highlighted unused slot with Circle, while Cross did not advance and behaved as
+cancel. A complete corrected route and gameplay are still unvalidated. See the exact title route in
 [`prosper/scripts/dragon-quest-vii/README.md`](prosper/scripts/dragon-quest-vii/README.md) and the renderer
 analysis in [`prosper/docs/DRAGON_QUEST_STATUS.md`](prosper/docs/DRAGON_QUEST_STATUS.md).
 

--- a/prosper/docs/DRAGON_QUEST_STATUS.md
+++ b/prosper/docs/DRAGON_QUEST_STATUS.md
@@ -1,9 +1,17 @@
 # Dragon Quest VII Reimagined (`PPSA17942`) — title-screen status
 
 **Status as of 2026-07-31.** Current master reaches the localized, animated title screen at native
-3840x2160 from a fresh save. The validated route sends six Cross pulses at 3, 6, 9, 12, 15, and 18
-seconds; the title first appeared at about 28 seconds and remained animated through the 40-second
-capture. Bring-up ladder rung: **2 (title screen rendered)**. Gameplay has not been validated.
+3840x2160 from a genuinely isolated save. The validated route sends seven Cross pulses at 3, 6, 9,
+12, 15, 18, and 30 seconds; the title first appeared at about 34 seconds and remained animated through
+the 40-second capture. Bring-up ladder rung: **2 (title screen rendered)**. Gameplay has not been
+validated.
+
+Extended clean runs also reach the new-save name keyboard and remain alive through at least 262 seconds
+without the historical MallocBinned3 failure. A focused control probe established that these post-title
+menus advance differently: Circle advanced the highlighted unused adventure slot to the normal “Which
+slot would you like to use?” prompt, while Cross did not advance and behaved as cancel in the probed
+flow. A complete corrected route has not yet been validated, so save creation and gameplay remain
+unproven; the name-entry screen is not a gameplay milestone.
 
 The same build can remain black after the startup sequence when run with **no input**. That is authored
 Slate state, not a lost final composite: current-master operation-prefix replay shows a coherent
@@ -18,15 +26,17 @@ by #1486; the earlier recompiler gap was fixed by #1483.
 
 ## Reproduction recipe
 
-Direct native Vulkan frontend capture, no diagnostic substitution. Run from `prosper/` with a fresh
-save root. In the recipe, `<EVIDENCE_ROOT>` is a unique directory created under `$HOME`; substitute
-its absolute path before running the command so screenshots stay outside the worktree and `/tmp`.
+Direct native Vulkan frontend capture, no diagnostic substitution. Run from `prosper/` with unique
+save roots under `$HOME`. In the recipe, `<EVIDENCE_ROOT>` and `<FRESH_SAVE_ROOT>` are unique
+directories created under `$HOME`; substitute their absolute paths before running the command so
+screenshots and both save backends stay outside the worktree and `/tmp`.
 
 ```bash
 PROSPER_GUEST_FS=1 \
 PROSPER_NULL_PAGE=1 \
 PROSPER_GUEST_ARGS= \
-PROSPER_SAVEDATA_DIR=<FRESH_SAVE_ROOT> \
+PROSPER_SAVE0=<FRESH_SAVE_ROOT>/save0 \
+PROSPER_SAVEDATA_DIR=<FRESH_SAVE_ROOT>/savedata \
 PROSPER_PAD_SCRIPT=@scripts/dragon-quest-vii/reach-title-screen.pad \
 PROSPER_PAD_SCRIPT_LOG=1 \
 ./build-linux/screenshot <DUMP_ROOT>/PPSA17942-app0 \
@@ -38,16 +48,16 @@ default (`-force-gfx-direct`) is wrong for this title. `tools/screenshot` defaul
 value explicitly. The reusable route and its input-delivery expectations are documented in
 [`scripts/dragon-quest-vii/README.md`](../scripts/dragon-quest-vii/README.md).
 
-The validated run observed all six Cross/neutral edges. It presented roughly 20–22 frames per second
-during the title window; treat that as a ballpark single-run observation, not a performance benchmark.
+The validated run observed all seven Cross/neutral edges. Performance varies with concurrent GPU work;
+treat the current title cadence as a ballpark observation, not a benchmark.
 
 ### Routed current-master progression
 
 | t | content |
 |---|---------|
-| 0–27 s | startup logos/movie transitions, advanced by Cross |
-| ~28 s | **localized Dragon Quest VII Reimagined title appears** |
-| 28–40 s | animated logo, sky/ocean, birds and water |
+| 0–33 s | startup logos/movie transitions and post-logo black state, advanced by Cross |
+| ~34 s | **localized Dragon Quest VII Reimagined title appears** |
+| 34–40 s | animated logo, sky/ocean, birds and water |
 
 Some one-second samples show a dark/purple background behind the stable logo while adjacent samples
 show the expected sky and ocean. That may be an authored transition or a remaining rhythmic background
@@ -203,10 +213,12 @@ current build.
 
 ## What is actually established (measured, current)
 
-- **The title screen is reached on current master.** A fresh-save direct frontend run with
+- **The title screen is reached on current master.** A direct frontend run with unique roots for both
+  `PROSPER_SAVE0` and `PROSPER_SAVEDATA_DIR` and
   `reach-title-screen.pad` produced the localized Dragon Quest VII logo over animated sky/ocean from
-  28 through 40 seconds at native 3840x2160. All six Cross/neutral transitions were observed by the
-  guest. The representative repository screenshot is an unmodified frame from that run.
+  about 34 through 40 seconds at native 3840x2160. All seven Cross/neutral transitions were observed by the
+  guest. The representative repository screenshot is an unmodified native frontend capture of the same
+  validated title state; its earlier capture did not isolate both save roots.
 - **Draw 92 is healthy.** Mixed-operation prefix replay through operation 120 produces the coherent
   scene (sky, ocean, islands and ships). A fragment tap at draw 92 also preserves that structured
   content. The old statement that draw 92 leaves alpha only is false.

--- a/prosper/scripts/dragon-quest-vii/README.md
+++ b/prosper/scripts/dragon-quest-vii/README.md
@@ -5,10 +5,11 @@ Reusable `PROSPER_PAD_SCRIPT` routes for Dragon Quest VII Reimagined
 
 ## Title screen
 
-`reach-title-screen.pad` sends six ordinary Cross pulses, three seconds apart,
-to skip the startup logos and movie, then returns to neutral so the title can
-idle. This exact sequence was revalidated from a fresh save on current master:
-the native 3840x2160 frontend reached the animated title at about 28 seconds.
+`reach-title-screen.pad` sends six ordinary Cross pulses three seconds apart,
+then a seventh at 30 seconds to leave the post-logo authored-black state. It
+returns to neutral so the title can idle. This exact sequence was revalidated
+from genuinely isolated save roots on current master: the native 3840x2160
+frontend reached the animated title at about 34 seconds.
 
 Without input, the startup flow can remain behind an authored opaque-black
 Slate background. That state is not evidence that the scene underneath failed
@@ -22,7 +23,8 @@ screenshots do not land in the worktree or `/tmp`.
 PROSPER_GUEST_FS=1 \
 PROSPER_NULL_PAGE=1 \
 PROSPER_GUEST_ARGS= \
-PROSPER_SAVEDATA_DIR=<FRESH_SAVE_ROOT> \
+PROSPER_SAVE0=<FRESH_SAVE_ROOT>/save0 \
+PROSPER_SAVEDATA_DIR=<FRESH_SAVE_ROOT>/savedata \
 PROSPER_PAD_SCRIPT=@scripts/dragon-quest-vii/reach-title-screen.pad \
 PROSPER_PAD_SCRIPT_LOG=1 \
 ./build-linux/screenshot <DUMP_ROOT>/PPSA17942-app0 \
@@ -33,6 +35,16 @@ PROSPER_PAD_SCRIPT_LOG=1 \
 Keep `PROSPER_PAD_SCRIPT_LOG=1`: it proves the game observed every press and
 neutral edge. Point entries intentionally use the standard scripted-input hold;
 no title-specific parser behavior or renderer override is involved.
+
+Set both save roots for a genuinely fresh run. Dragon Quest VII stores its normal
+files through the mounted `/savedata0` backend controlled by `PROSPER_SAVE0`;
+`PROSPER_SAVEDATA_DIR` covers the separate SaveDataMemory API and does not isolate
+those mounted files by itself.
+
+A focused post-title probe advanced the highlighted unused slot with Circle;
+Cross did not advance and behaved as cancel in that flow. The startup/title
+route intentionally retains Cross because those screens accept it. Validate the
+remaining Circle presses before committing a later checkpoint route.
 
 The title is animated. Some retained frames currently show a dark/purple
 background behind the stable logo while adjacent frames show the expected sky

--- a/prosper/scripts/dragon-quest-vii/reach-title-screen.pad
+++ b/prosper/scripts/dragon-quest-vii/reach-title-screen.pad
@@ -1,9 +1,10 @@
 # Dragon Quest VII Reimagined — skip the startup sequence and idle at the title.
-# These are the six point pulses used by the original title-screen capture and
-# revalidated from a fresh save on current master. No input is sent after 18 s.
+# A genuinely isolated console needs the seventh pulse after the post-logo
+# authored-black state. No input is sent after 30 s so the title can idle.
 3:cross
 6:cross
 9:cross
 12:cross
 15:cross
 18:cross
+30:cross


### PR DESCRIPTION
## Summary

- isolate both Dragon Quest save backends in the documented fresh-run recipe
- add the seventh startup Cross pulse required by a genuinely clean console state
- correct title timing and remove a noisy single-run FPS figure
- document the measured post-title Circle-confirm / Cross-cancel behavior without claiming gameplay
- correct the provenance wording for the existing genuine title screenshot

## Why

The route merged in #1545 isolated `PROSPER_SAVEDATA_DIR` but not the mounted `/savedata0` backend controlled by `PROSPER_SAVE0`. Its save slots were unused, so the rendered title milestone was real, but the run inherited older System and Language files and was not a genuinely fresh console state.

With unique `$HOME` roots for both backends, six early Cross pulses leave the authored black post-logo state. A seventh Cross at 30 seconds reveals the same localized native 3840x2160 title at about 34 seconds. The reusable pad route and all compatibility/status wording now match that clean result.

Extended isolated runs remain alive through the new-save name keyboard without the historical allocator failure, but do not yet prove save creation or gameplay. A focused ordinary-pad probe showed Circle advancing the highlighted unused adventure slot while Cross did not advance and behaved as cancel. The next route will validate the remaining Circle steps separately.

Part of #1486.

## Validation

- exact head `bd4d82f749712ec277f4893621cc9a6e482e261a` based directly on current master
- rebased distrobox build of `test_pad` passed
- `ctest --test-dir build-dq -R ^pad_input$ --output-on-failure`: 1/1 passed
- clean dual-save-root title run observed all seven Cross/neutral edges
- bounded Circle probe advanced the highlighted unused slot to the authored slot prompt and remained fatal-free
- `git diff --check` passed

The existing title screenshot is retained because the visual state is unchanged. It is an unmodified native frontend image of the same validated title state; the documentation now explicitly avoids attributing that older file to the newly isolated run.