### PR TITLE
Correct Dragon Quest post-title controls

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -213,10 +213,13 @@ full-speed performance remain open.
 The apparently permanent black frame in no-input runs is authored UI state, not a lost final composite:
 the complete sky/ocean scene exists underneath an opaque-black Slate background, and the routed input
 changes the foreground lifecycle so the title becomes visible. Older work navigated the save-slot menu
-and began content loading. A current isolated run now reaches the new-save name keyboard and remains
-alive there without the historical allocator failure. A focused probe confirmed that the post-title
-flow advanced the highlighted unused slot with Circle, while Cross did not advance and behaved as
-cancel. A complete corrected route and gameplay are still unvalidated. See the exact title route in
+and began content loading. Separate isolated runs reach the new-save name keyboard and remain alive
+there without the historical allocator failure. A later exact-master replay corrected #1553's
+temporal/flicker interpretation: Cross at 55 seconds had already entered and highlighted `1: Unused`
+with its slot prompt; Circle at 140 seconds canceled to the adventure-log list, and Circle at 270
+seconds canceled to the title. Start/Options at 330 seconds and Circle at 350 seconds did not advance
+the title. Cross is confirm and Circle is cancel in this flow. A complete corrected route and gameplay
+are still unvalidated. See the unchanged exact title route in
 [`prosper/scripts/dragon-quest-vii/README.md`](prosper/scripts/dragon-quest-vii/README.md) and the renderer
 analysis in [`prosper/docs/DRAGON_QUEST_STATUS.md`](prosper/docs/DRAGON_QUEST_STATUS.md).
 

--- a/prosper/docs/DRAGON_QUEST_STATUS.md
+++ b/prosper/docs/DRAGON_QUEST_STATUS.md
@@ -7,10 +7,13 @@ the 40-second capture. Bring-up ladder rung: **2 (title screen rendered)**. Game
 validated.
 
 Extended clean runs also reach the new-save name keyboard and remain alive through at least 262 seconds
-without the historical MallocBinned3 failure. A focused control probe established that these post-title
-menus advance differently: Circle advanced the highlighted unused adventure slot to the normal “Which
-slot would you like to use?” prompt, while Cross did not advance and behaved as cancel in the probed
-flow. A complete corrected route has not yet been validated, so save creation and gameplay remain
+without the historical MallocBinned3 failure. A later exact-master replay with both save roots isolated
+corrected #1553's temporal/flicker interpretation: Cross at 55 seconds had already entered and highlighted
+`1: Unused` with its normal “Which slot would you like to use?” prompt. Circle at 140 seconds then
+canceled to the adventure-log list, and Circle at 270 seconds canceled again to the title. Start/Options
+at 330 seconds and Circle at 350 seconds did not advance the title. Cross is confirm and Circle is cancel
+in this flow; #1553 incorrectly attributed the already-visible post-Cross prompt to the later Circle
+press. A complete corrected route has not yet been validated, so save creation and gameplay remain
 unproven; the name-entry screen is not a gameplay milestone.
 
 The same build can remain black after the startup sequence when run with **no input**. That is authored

--- a/prosper/scripts/dragon-quest-vii/README.md
+++ b/prosper/scripts/dragon-quest-vii/README.md
@@ -41,10 +41,15 @@ files through the mounted `/savedata0` backend controlled by `PROSPER_SAVE0`;
 `PROSPER_SAVEDATA_DIR` covers the separate SaveDataMemory API and does not isolate
 those mounted files by itself.
 
-A focused post-title probe advanced the highlighted unused slot with Circle;
-Cross did not advance and behaved as cancel in that flow. The startup/title
-route intentionally retains Cross because those screens accept it. Validate the
-remaining Circle presses before committing a later checkpoint route.
+A later exact-master replay corrected #1553's temporal/flicker interpretation.
+Cross at 55 seconds had already entered and highlighted `1: Unused` with its
+normal slot prompt. Circle at 140 seconds canceled to the adventure-log list,
+and Circle at 270 seconds canceled again to the title. Start/Options at 330
+seconds and Circle at 350 seconds did not advance the title. Cross is confirm
+and Circle is cancel in this flow; #1553 incorrectly attributed the already-
+visible post-Cross prompt to the later Circle press. The startup/title route
+above is unchanged. Validate the remaining Cross presses before committing a
+later checkpoint route.
 
 The title is animated. Some retained frames currently show a dark/purple
 background behind the stable logo while adjacent frames show the expected sky


### PR DESCRIPTION
## Summary

Correct the Dragon Quest VII clean-save route documentation after exact frame anchoring disproved the temporal interpretation merged in #1553.

- record that Cross confirms and Circle cancels in the title/adventure-log flow
- document the observed state transitions at exact timestamps
- preserve the known seven-pulse title route and dual-save-root requirement
- explicitly state that the latest clean run did not reach the name keyboard or gameplay

This is a documentation-only correction. The observed visible state remains the title/menu flow, so there is no new visual milestone or screenshot to publish.

Closes no issue; continues #1486.

## Verification

- `git diff --check`
- rebuilt `test_pad`
- `ctest -R ^pad_input$` (1/1 passed)

## Evidence

The clean run showed Cross had entered the highlighted unused-slot prompt by 76.1s; Circle at 140s returned one menu level and Circle at 270s returned to the clean title. Start/Options at 330s and Circle at 350s did not leave the title. No `GameSaveData*.dat` was created.