### PR TITLE
Target failed shader descriptor tracing

### DIFF
--- a/prosper/docs/DOLL_POSTPROCESS_HANDOFF.md
+++ b/prosper/docs/DOLL_POSTPROCESS_HANDOFF.md
@@ -191,7 +191,9 @@ All gated, off by default. Names are `PROSPER_*` env vars unless noted.
 - **`PROSPER_DYNTRACE_FAIL=1`** — for a compute dispatch that fails to recompile, dumps the **user
   SGPRs** and replays `resolve_dynamic_fetch`, printing each recovered descriptor (`[dynfail] …`,
   `[dyntrace] MUBUF fetch pc=… SRSRC=sN … have_descr=…`). This is how you read a shader's actual V#
-  format/stride/base for a failing dispatch (e.g. it revealed the stride-2 Uint16 store).
+  format/stride/base for a failing dispatch (e.g. it revealed the stride-2 Uint16 store). Add
+  **`PROSPER_DYNTRACE_FAIL_ADDR=<hex code address>`** to replay only that exact failed program; a BVH
+  trace prints all four live descriptor words even when their provenance is insufficient to bind it.
 - **`PROSPER_SHADER_DUMP=<dir>`** — writes each failing shader's raw bytes to
   `<dir>/exec_cs_<addr>.bin` (also `exec_vs_/exec_ps_`). Decode offline with **`shader_inspect
   <file>`** (built tool): per-dword PCs, decoded fmt/op, branch targets. This is how you read a

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -294,6 +294,11 @@ void clear_shader_analysis_cache();
 // draw without needing the shader's address up front (the UI draws it targets are rare/phase-bound).
 extern bool g_dyntrace_force;
 
+// True when failed-shader tracing is enabled for this exact program. With no address filter this
+// preserves the historical behavior of tracing every distinct failed program; the optional filter
+// keeps a long boot's diagnostic volume bounded to one known shader.
+bool dyntrace_failed_shader_enabled(uint64_t code_addr);
+
 // Assign each resource in `t` a descriptor binding from `first`: constant/vertex buffers first, then
 // textures / storage images — never on binding 2 or 3 (the recompiler's two hardwired cbufs) so a
 // texture-first shader can't collide two descriptor types at one binding (#157). Exposed for testing.
@@ -1120,7 +1125,7 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
         // PROSPER_DYNTRACE_FAIL=1: replay the FAILED vertex stage's resource build with the
         // dynamic-fetch walk trace + user-data block dump forced on (once per distinct VS), so the
         // failing draw's exact seeding/s_load chain is captured without knowing its address up front.
-        if (vs_words.empty() && getenv("PROSPER_DYNTRACE_FAIL")) {
+        if (vs_words.empty() && dyntrace_failed_shader_enabled(vs_program_addr)) {
             static std::set<uint64_t> traced;
             if (traced.insert(vs_program_addr).second) {
                 fprintf(stderr, "[dynfail] replaying VS 0x%llx resource build with trace:\n",
@@ -1131,7 +1136,7 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
             }
         }
         // Same replay for a FAILED pixel stage (#273 — the PS-side descriptor-resolution walls).
-        if (fs_words.empty() && getenv("PROSPER_DYNTRACE_FAIL")) {
+        if (fs_words.empty() && dyntrace_failed_shader_enabled(rs.ps_addr)) {
             static std::set<uint64_t> traced_ps;
             if (traced_ps.insert(rs.ps_addr).second) {
                 fprintf(stderr, "[dynfail] replaying PS 0x%llx resource build with trace:\n",

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -17,6 +17,7 @@
 #include "../host/guest_memory_map.hpp"
 #include "../host/guest_write_watch.hpp"
 #include <chrono>
+#include <cerrno>
 #include <cstdlib>
 #include <cstdio>
 #include <cstring>
@@ -130,6 +131,17 @@ void read_user_sgprs(const std::unordered_map<uint32_t, uint32_t>& sh, uint32_t 
 // envs. Set (and cleared) by realize_draw_item's failure replay — the submit path is serialized
 // by the HLE submit mutex, so a plain global is safe there.
 bool g_dyntrace_force = false;
+
+bool dyntrace_failed_shader_enabled(uint64_t code_addr) {
+    if (!std::getenv("PROSPER_DYNTRACE_FAIL")) return false;
+    const char* filter = std::getenv("PROSPER_DYNTRACE_FAIL_ADDR");
+    if (!filter) return true;
+
+    char* end = nullptr;
+    errno = 0;
+    const unsigned long long parsed = std::strtoull(filter, &end, 16);
+    return errno == 0 && end != filter && *end == '\0' && parsed == code_addr;
+}
 
 namespace {
 
@@ -2492,18 +2504,23 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                             guarded_bvh_use(ins, in.pc);
                         if (trc) {
                             fprintf(stderr,
-                                    "[dyntrace] BVH pc=%u srsrc=s%d snapshot=%d seed=%d bvh=",
-                                    in.pc, bbase, snapshot_provenance, seed_provenance);
-                            if (plausible) {
+                                    "[dyntrace] BVH pc=%u srsrc=s%d snapshot=%d seed=%d "
+                                    "live_known=%d bvh=",
+                                    in.pc, bbase, snapshot_provenance, seed_provenance, live_known);
+                            if (live_known) {
                                 for (uint32_t word : live_bvh) fprintf(stderr, "%08x ", word);
+                            } else {
+                                fprintf(stderr, "<unknown> ");
+                            }
+                            if (plausible) {
                                 fprintf(stderr, "-> base=0x%llx size=0x%llx type=%u tri_mode=%u grow=%u",
                                         (unsigned long long)d.base,
                                         (unsigned long long)d.size_bytes, d.type,
                                         d.triangle_return_mode, d.box_grow);
                             } else if (guarded_null) {
                                 fprintf(stderr, "<guarded-null origin=%u>", proven_null_origin);
-                            } else {
-                                fprintf(stderr, "<unknown>");
+                            } else if (live_known) {
+                                fprintf(stderr, "<insufficient-provenance>");
                             }
                             fputc('\n', stderr);
                         }
@@ -4305,7 +4322,7 @@ std::vector<ComputeItem> realize_compute_dispatches(
             // This trace reveals whether the failing dispatch's descriptors ARE const-fold-resolvable
             // (i.e. loaded via a foldable s_load chain) — the ground truth for #590 before extending
             // the compute resource build. Read-only: it does not change what the executor binds.
-            if (getenv("PROSPER_DYNTRACE_FAIL")) {
+            if (dyntrace_failed_shader_enabled(code_addr)) {
                 static std::set<uint64_t> traced_cs;
                 if (traced_cs.insert(code_addr).second) {
                     std::fprintf(stderr,

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -14,6 +14,7 @@
 #include "../src/gpu/rdna2_to_spirv.hpp"
 #include <algorithm>
 #include <cstdio>
+#include <cstdlib>
 #include <vector>
 
 using namespace prosper::gpu;
@@ -22,8 +23,33 @@ static int fails = 0;
 #define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
                          else       { printf("  [ok]   %s\n", m); } } while (0)
 
+static void set_test_env(const char* name, const char* value) {
+#ifdef _WIN32
+    _putenv_s(name, value ? value : "");
+#else
+    if (value) setenv(name, value, 1); else unsetenv(name);
+#endif
+}
+
 int main() {
     printf("== test_dynfetch_fold ==\n");
+
+    set_test_env("PROSPER_DYNTRACE_FAIL", nullptr);
+    set_test_env("PROSPER_DYNTRACE_FAIL_ADDR", nullptr);
+    CHECK(!dyntrace_failed_shader_enabled(0x500571000ull),
+          "failed-shader dyntrace remains disabled by default");
+    set_test_env("PROSPER_DYNTRACE_FAIL", "1");
+    CHECK(dyntrace_failed_shader_enabled(0x500571000ull),
+          "unfiltered failed-shader dyntrace preserves all-program behavior");
+    set_test_env("PROSPER_DYNTRACE_FAIL_ADDR", "0x500571000");
+    CHECK(dyntrace_failed_shader_enabled(0x500571000ull) &&
+              !dyntrace_failed_shader_enabled(0x500571100ull),
+          "failed-shader dyntrace address filter selects one exact program");
+    set_test_env("PROSPER_DYNTRACE_FAIL_ADDR", "not-an-address");
+    CHECK(!dyntrace_failed_shader_enabled(0x500571000ull),
+          "malformed failed-shader dyntrace address filter fails closed");
+    set_test_env("PROSPER_DYNTRACE_FAIL", nullptr);
+    set_test_env("PROSPER_DYNTRACE_FAIL_ADDR", nullptr);
 
     uint32_t readable_probe = 0;
     CHECK(!guest_readable(0, sizeof(uint32_t)), "null guest address is not readable");
@@ -689,6 +715,22 @@ int main() {
               astro_bvh_table.resources[0].bvh_box_grow == 6u &&
               astro_bvh_table.resources[0].fetch_pc == 0,
           "Astro BVH bytes materialize as the instruction-scoped read-only compute buffer");
+
+    // Concrete descriptor words alone are diagnostic evidence, not binding provenance. Keep this
+    // case unresolved while allowing dyntrace to print the exact live words that led to rejection.
+    const uint32_t unproven_live_bvh[] = {
+        0xBE9003FFu, 0x00123456u,            // pc0: s_mov_b32 s16, literal
+        0xBE9103FFu, 0x03000000u,            // pc2: s_mov_b32 s17, literal
+        0xBE9203FFu, 0x0000003Fu,            // pc4: s_mov_b32 s18, literal
+        0xBE9303FFu, 0x81000000u,            // pc6: s_mov_b32 s19, literal
+        0xF1989F07u, 0x00040303u, 0x43440D3Fu, 0x46424140u, 0x00004847u,
+        0xBF810000u,
+    };
+    std::vector<SrtUse> unproven_live_bvh_uses;
+    resolve_dynamic_fetch(unproven_live_bvh, std::size(unproven_live_bvh), nullptr, 0, 0,
+                          &unproven_live_bvh_uses);
+    CHECK(unproven_live_bvh_uses.empty(),
+          "live-known BVH words without descriptor provenance remain fail-visible");
 
     // Astro's first world-map dispatch explicitly writes a null qword to the root pointer consumed
     // by this scalar chain. Preserve that fact only through the exact dependent descriptor ALU, and


### PR DESCRIPTION
## Summary

Make the next Astro Bot world-map descriptor capture precise without changing translation or binding behavior.

- add `PROSPER_DYNTRACE_FAIL_ADDR=<hex>` to restrict forced failed-shader tracing to one exact VS, PS, or compute program
- preserve the existing trace-all-distinct behavior when the address filter is absent
- fail closed on malformed address filters
- print all four live-known BVH descriptor words even when snapshot/seed provenance is insufficient, labeling them as insufficient rather than binding them
- document the selector and add focused filter/provenance tests

This is diagnostic tooling only. PC2148/2187 still reject on the frozen Astro capture because their table-loaded descriptor provenance was not retained. The patch does not weaken MIMG translation, infer null/unreachable resources, or alter SRT/binding decisions.

Continues #1459.

## Verification

- `prosper_core` and `test_dynfetch_fold` build
- `ctest -R ^dynfetch_fold$`
- direct trace fixture prints exact live words plus `<insufficient-provenance>`
- `git diff --check`
- stable patch ID across rebase onto `44e6e778`

No screenshot is included because Astro world-map output remains black. Snapshot tests were intentionally not run for this focused development PR; repository policy requires them for releases, not routine PRs.