### PR TITLE
Fix scalar bitset opcode handling

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -5416,10 +5416,12 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 rs.sreg_bool_narrowed.erase(in.dst.value);
                 return true;
             }
-            if (in.opcode == 0x1c || in.opcode == 0x1d) {
+            if (in.opcode == 0x1b || in.opcode == 0x1d) {
                 // s_bitset{0,1}_b32 is an in-place scalar read/modify/write. The encoded source is
                 // the bit index while SDST supplies both the old value and destination. Astro's
-                // world-map kernel uses `s_bitset1_b32 s5,31` in a resource-table address path.
+                // world-map kernel uses `s_bitset1_b32 s5,31` in a resource-table address path;
+                // Plucky's post-Desk transition uses `s_bitset0_b32 vcc_hi,31`. Opcode 0x1c is the
+                // distinct B64 clear form and must remain fail-visible until both words are modeled.
                 if (in.dst.value == 126 || in.dst.value == 127) {
                     ok = false; return true;
                 }
@@ -5437,7 +5439,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 if (!ok) return true;
                 const uint32_t mask = b.ibin(
                     Op_ShiftLeftLogical, b.uconst(1), bit);
-                rs.sreg[in.dst.value] = in.opcode == 0x1c
+                rs.sreg[in.dst.value] = in.opcode == 0x1b
                     ? b.ibin(Op_BitwiseAnd, old_value, b.iun(Op_Not, mask))
                     : b.ibin(Op_BitwiseOr, old_value, mask);
                 rs.sreg_srt.erase(in.dst.value);

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -297,6 +297,22 @@ int main() {
     printf("  kernel9 mismatches=%u (out[5]=%g expect=%g)\n", bad9, got9.size()==N?got9[5]:-1, exp9[5]);
     CHECK(got9.size()==N && bad9==0, "recompiled kernel 9 (scalar s_mov/s_add/s_lshl) computes a0+30");
 
+    // Plucky Squire's post-Desk transition shader clears the top bit of a scalar-data VCC_HI
+    // lifetime before combining the two VCC dwords into a buffer address. This is the exact
+    // gfx1030 s_bitset0_b32 packet retained by the failed-dispatch capsule for #1554.
+    const uint32_t code9b[] = {
+        0xbeeb03c1u,              // s_mov_b32 vcc_hi, -1
+        0xbeeb1b9fu,              // s_bitset0_b32 vcc_hi, 31
+        0x7e00026bu,              // v_mov_b32 v0, vcc_hi
+        0xbf810000u,
+    };
+    const std::vector<uint32_t> spv9b = recompile_valu(
+        code9b, std::size(code9b), 1, 0);
+    CHECK(!spv9b.empty(), "recompiled Plucky s_bitset0_b32 scalar-data sequence -> SPIR-V");
+    const std::vector<float> got9b = prosper::test::run_compute(spv9b, {0.0f}, 1, 1);
+    CHECK(got9b.size() == 1 && bits_of(got9b[0]) == 0x7fffffffu,
+          "s_bitset0_b32 clears the selected bit of its in-place scalar destination");
+
     // Kernel 10: VOP3 3-operand ops. u2=mad24(u0,u1,u1); u3=add3(u0,u1,u2); u3=bfi(u0,u1,u3);
     //            u3=bfe_u(u3, off=u0, cnt=u1); out=(float)u3.
     const uint32_t code10[] = {

--- a/prosper/tests/test_recompile_coverage.cpp
+++ b/prosper/tests/test_recompile_coverage.cpp
@@ -526,6 +526,22 @@ int main() {
                              compute_cfg_dispatch_bitset.size(), &dispatch_rt,
                              wave32_dispatch_config).empty(),
           "the dispatcher preserves an in-place scalar bitset update");
+    const uint32_t plucky_scalar_bitset0[] = {
+        0xBEEB03C1u, // s_mov_b32 vcc_hi, -1 (scalar-data lifetime)
+        0xBEEB1B9Fu, // s_bitset0_b32 vcc_hi, 31 (exact Plucky #1554 packet)
+        0xBF810000u, // s_endpgm
+    };
+    CHECK(!recompile_compute(plucky_scalar_bitset0, std::size(plucky_scalar_bitset0),
+                             nullptr, ComputeShaderConfig{}).empty(),
+          "Plucky scalar-data s_bitset0_b32 sequence recompiles");
+    const uint32_t scalar_bitset0_b64[] = {
+        0xBE8404C1u, // s_mov_b64 s[4:5], -1
+        0xBE841C9Fu, // s_bitset0_b64 s[4:5], 31 (distinct unsupported opcode 0x1c)
+        0xBF810000u, // s_endpgm
+    };
+    CHECK(recompile_compute(scalar_bitset0_b64, std::size(scalar_bitset0_b64),
+                            nullptr, ComputeShaderConfig{}).empty(),
+          "unmodeled B64 bitset remains fail-visible instead of using B32 semantics");
     std::vector<uint32_t> compute_cfg_dispatch_scalar_shift = {
         0xBEEA0381u, // s_mov_b32 vcc_lo, 1 (scalar-data lifetime)
         0xBEEB0380u, // s_mov_b32 vcc_hi, 0


### PR DESCRIPTION
## Summary

Fix the exact scalar instruction that blocked a captured Plucky Squire post-Desk transition compute shader.

- map architectural SOP1 opcode `0x1b` to `s_bitset0_b32` while retaining `0x1d` as `s_bitset1_b32`
- stop accidentally treating distinct opcode `0x1c` (`s_bitset0_b64`) as the B32 clear form
- add exact compile and Vulkan execution coverage for the captured B32 packet
- add a negative llvm-mc-derived B64 fixture so the unmodeled two-word form remains fail-visible

The thin #1554 capsule failed on raw hash `0a99f1b3f42d90e5` at PC85/SOP1 `0x1b` before this patch. The exact failed stage now recompiles to 7613 SPIR-V dwords with all 27 captured resources. This proves missing GPU work is restored for that dispatch; it does not yet prove causality for Plucky's black scene.

Continues #1554 and #1390.

## Verification

- regression demonstrated failing before the fix
- full `test_recompile_coverage` passes after the fix
- full Vulkan `test_rdna2_to_spirv` passes, including the exact 0x7fffffff execution result
- `gpu_replay --retry-failed-stage 0:0` succeeds on capsule SHA-256 `476163d975c6e1ffe75fe004eafc7741147f1dfce1b97771d71d91e867ef51eb`
- `git diff --check`

No screenshot is included because no post-fix guest rerun was performed and the last established Plucky frame remains black. Snapshot tests were intentionally not run for this focused development PR; repository policy requires them for releases, not routine PRs.