### PR TITLE
Prove Astro Wave64 null traversal exit

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -10277,7 +10277,7 @@ size_t specialize_shader_constant_branches(std::vector<Rdna2Inst>& ins) {
 size_t specialize_proven_null_bvh_exits(std::vector<Rdna2Inst>& ins,
                                         const ShaderResourceTable* rt,
                                         uint32_t wave_size) {
-    if (!rt || wave_size != 32 || ins.empty()) return 0;
+    if (!rt || (wave_size != 32 && wave_size != 64) || ins.empty()) return 0;
     std::unordered_map<uint32_t, size_t> index_by_pc;
     for (size_t i = 0; i < ins.size(); ++i) index_by_pc.emplace(ins[i].pc, i);
 
@@ -10302,9 +10302,13 @@ size_t specialize_proven_null_bvh_exits(std::vector<Rdna2Inst>& ins,
         //   s_cmp_lg_u32 0, sM
         //   s_mov_b32 exec_lo, vcc_lo
         //   s_cbranch_scc0 EXIT
+        // The Wave64 sibling uses the complete two-word mask instead:
+        //   v_cmp_ne_u32 s[M:M+1], -1, vN
+        //   s_cmp_lg_u64 s[M:M+1], 0
+        //   s_mov_b64 exec, vcc
         // The null lowering writes -1 to every ray result for each active lane. The saved compare
         // mask is therefore exactly zero, making SCC zero and the exit unconditional. Requiring the
-        // explicit one-word mask form and Wave32 avoids assuming anything about an unobserved high
+        // exact width-specific compare and EXEC copy avoids assuming anything about an unobserved
         // mask half. Adjacency and exact register links prevent a nearby unrelated compare from
         // proving the branch.
         const bool ray_shape = ray.fmt == Rdna2Format::MIMG && ray.opcode == 0xe6u &&
@@ -10314,17 +10318,26 @@ size_t specialize_proven_null_bvh_exits(std::vector<Rdna2Inst>& ins,
             wait.words[0] == 0xbf8c3f70u; // s_waitcnt vmcnt(0)
         const bool compare_shape = compare.pc == wait.pc + wait.len_dwords &&
             compare.fmt == Rdna2Format::VOPC && compare.opcode == 0xc5u &&
-            compare.dst.kind == OperandKind::SGPR && compare.dst.value <= 105 &&
+            compare.dst.kind == OperandKind::SGPR &&
+            compare.dst.value <= (wave_size == 32 ? 105 : 104) &&
             compare.src[0].kind == OperandKind::InlineInt && compare.src[0].value == -1 &&
             compare.src[1].kind == OperandKind::VGPR && compare.src[1].value == ray.dst.value;
         const bool scalar_shape = scalar_compare.pc == compare.pc + compare.len_dwords &&
-            scalar_compare.fmt == Rdna2Format::SOPC && scalar_compare.opcode == 0x07u &&
-            scalar_compare.src[0].kind == OperandKind::InlineInt &&
-            scalar_compare.src[0].value == 0 &&
-            scalar_compare.src[1].kind == OperandKind::SGPR &&
-            scalar_compare.src[1].value == compare.dst.value;
+            scalar_compare.fmt == Rdna2Format::SOPC &&
+            (wave_size == 32
+                ? scalar_compare.opcode == 0x07u &&
+                  scalar_compare.src[0].kind == OperandKind::InlineInt &&
+                  scalar_compare.src[0].value == 0 &&
+                  scalar_compare.src[1].kind == OperandKind::SGPR &&
+                  scalar_compare.src[1].value == compare.dst.value
+                : scalar_compare.opcode == 0x13u &&
+                  scalar_compare.src[0].kind == OperandKind::SGPR &&
+                  scalar_compare.src[0].value == compare.dst.value &&
+                  scalar_compare.src[1].kind == OperandKind::InlineInt &&
+                  scalar_compare.src[1].value == 0);
         const bool copy_shape = exec_copy.pc == scalar_compare.pc + scalar_compare.len_dwords &&
-            exec_copy.fmt == Rdna2Format::SOP1 && exec_copy.opcode == 0x03u &&
+            exec_copy.fmt == Rdna2Format::SOP1 &&
+            exec_copy.opcode == (wave_size == 32 ? 0x03u : 0x04u) &&
             exec_copy.dst.kind == OperandKind::SGPR && exec_copy.dst.value == 126 &&
             exec_copy.src[0].kind == OperandKind::Special && exec_copy.src[0].value == 106;
         const bool exit_shape = exit.pc == exec_copy.pc + exec_copy.len_dwords &&
@@ -10385,10 +10398,15 @@ size_t specialize_proven_null_bvh_exits(std::vector<Rdna2Inst>& ins,
             const Rdna2Inst& empty_guard = ins[root_block + 5];
             const Rdna2Inst& root_index = ins[root_block + 6];
             const Rdna2Inst& root_nop = ins[root_block + 7];
-            if (mask_copy.fmt != Rdna2Format::SOP1 || mask_copy.opcode != 0x3cu ||
-                mask_copy.dst.kind != OperandKind::SGPR || mask_copy.dst.value != 106 ||
-                mask_copy.src[0].kind != OperandKind::Special ||
-                mask_copy.src[0].value != 107 ||
+            const bool mask_copy_shape = wave_size == 32
+                ? mask_copy.fmt == Rdna2Format::SOP1 && mask_copy.opcode == 0x3cu &&
+                  mask_copy.dst.kind == OperandKind::SGPR && mask_copy.dst.value == 106 &&
+                  mask_copy.src[0].kind == OperandKind::Special &&
+                  mask_copy.src[0].value == 107
+                : mask_copy.fmt == Rdna2Format::SOP1 && mask_copy.opcode == 0x24u &&
+                  mask_copy.dst.kind == OperandKind::SGPR && mask_copy.dst.value == 106 &&
+                  mask_copy.src[0].kind == OperandKind::SGPR;
+            if (!mask_copy_shape ||
                 empty_guard.fmt != Rdna2Format::SOPP || empty_guard.opcode != 0x08u ||
                 scalar_branch_target(empty_guard) != scalar_compare.pc ||
                 root_index.fmt != Rdna2Format::VOP1 || root_index.opcode != 0x01u ||
@@ -10399,7 +10417,7 @@ size_t specialize_proven_null_bvh_exits(std::vector<Rdna2Inst>& ins,
                 return false;
 
             size_t selector_branch_index = SIZE_MAX;
-            size_t selector_init_index = SIZE_MAX;
+            size_t stack_init_index = SIZE_MAX;
             bool selector_scc = false;
             for (size_t i = root_block; i-- > 2;) {
                 const Rdna2Inst& branch = ins[i];
@@ -10410,29 +10428,59 @@ size_t specialize_proven_null_bvh_exits(std::vector<Rdna2Inst>& ins,
                     continue;
                 for (size_t j = i - 1; j-- > 1;) {
                     const Rdna2Inst& selector_init = ins[j];
-                    const Rdna2Inst& stack_init = ins[j - 1];
-                    if (stack_init.pc + stack_init.len_dwords != selector_init.pc ||
-                        stack_init.fmt != Rdna2Format::SOP1 || stack_init.opcode != 0x03u ||
-                        stack_init.dst.kind != OperandKind::SGPR ||
-                        stack_init.dst.value != stack_reg ||
-                        stack_init.src[0].kind != OperandKind::InlineInt ||
-                        stack_init.src[0].value != 0 ||
-                        selector_init.fmt != Rdna2Format::SOP1 ||
+                    if (selector_init.fmt != Rdna2Format::SOP1 ||
                         selector_init.opcode != 0x03u ||
                         selector_init.dst.kind != OperandKind::SGPR ||
                         selector_init.src[0].kind != OperandKind::InlineInt ||
                         selector_init.src[0].value != 37 ||
                         root_index.src[0].value != selector_init.dst.value)
                         continue;
+                    size_t candidate_stack_init = SIZE_MAX;
+                    if (wave_size == 32) {
+                        const Rdna2Inst& stack_init = ins[j - 1];
+                        if (stack_init.pc + stack_init.len_dwords == selector_init.pc &&
+                            stack_init.fmt == Rdna2Format::SOP1 &&
+                            stack_init.opcode == 0x03u &&
+                            stack_init.dst.kind == OperandKind::SGPR &&
+                            stack_init.dst.value == stack_reg &&
+                            stack_init.src[0].kind == OperandKind::InlineInt &&
+                            stack_init.src[0].value == 0)
+                            candidate_stack_init = j - 1;
+                    } else {
+                        // The Wave64 sibling schedules independent scalar address setup between
+                        // `stack=0` and `selector=37`. Accept only the nearest in-block write to the
+                        // derived stack register, and require it to be the exact zero initializer.
+                        for (size_t k = j; k-- > 0;) {
+                            bool writes_candidate = false;
+                            for_each_scalar_write(ins[k], [&](int base, uint32_t width) {
+                                writes_candidate |= base <= stack_reg &&
+                                    stack_reg < base + static_cast<int>(width);
+                            });
+                            if (!writes_candidate) {
+                                if (scalar_cfg_branch(ins[k]) || ins[k].is_end) break;
+                                continue;
+                            }
+                            const Rdna2Inst& stack_init = ins[k];
+                            if (stack_init.fmt == Rdna2Format::SOP1 &&
+                                stack_init.opcode == 0x03u &&
+                                stack_init.dst.kind == OperandKind::SGPR &&
+                                stack_init.dst.value == stack_reg &&
+                                stack_init.src[0].kind == OperandKind::InlineInt &&
+                                stack_init.src[0].value == 0)
+                                candidate_stack_init = k;
+                            break;
+                        }
+                    }
+                    if (candidate_stack_init == SIZE_MAX) continue;
                     bool has_branch = false;
-                    for (size_t k = j; k < i; ++k)
+                    for (size_t k = candidate_stack_init + 1; k < i; ++k)
                         has_branch |= scalar_cfg_branch(ins[k]);
                     if (has_branch ||
                         !shader_constant_compare(ins, j, i - 1, selector_scc) ||
                         !selector_scc)
                         continue;
                     selector_branch_index = i;
-                    selector_init_index = j;
+                    stack_init_index = candidate_stack_init;
                     break;
                 }
                 if (selector_branch_index != SIZE_MAX) break;
@@ -10444,18 +10492,18 @@ size_t specialize_proven_null_bvh_exits(std::vector<Rdna2Inst>& ins,
                 for_each_scalar_write(instruction, [&](int base, uint32_t width) {
                     writes |= base <= stack_reg &&
                         stack_reg < base + static_cast<int>(width);
-                }, /*proven_wave32_masks*/true);
+                }, /*wave32_one_word_masks=*/wave_size == 32);
                 return writes;
             };
             // Only the selector setup, root/no-hit block, and empty-stack comparison are reachable
             // before the proven exits.  None may alter the initialized stack depth.
-            for (size_t i = selector_init_index; i <= selector_branch_index; ++i)
+            for (size_t i = stack_init_index + 1; i <= selector_branch_index; ++i)
                 if (writes_stack(ins[i])) return false;
             for (size_t i = root_block; i <= ray_index + 5; ++i)
                 if (writes_stack(ins[i])) return false;
             if (writes_stack(stack_compare)) return false;
 
-            const uint32_t proof_begin = ins[selector_init_index - 1].pc;
+            const uint32_t proof_begin = ins[stack_init_index].pc;
             // An indirect transfer or an external edge into the middle of the proof could bypass
             // the zero initializer.  Re-entry at the initializer itself is harmless: it resets the
             // invariant before the selector is evaluated again.

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -1020,6 +1020,209 @@ int main() {
                           [](const Rdna2Inst& in) { return in.pc == 968 || in.pc == 1007; }),
           "external entry that bypasses the zero initializer keeps the cycle fail-visible");
 
+    // Exact reduced Wave64 sibling from Astro's larger traversal shader. PC2148/2187 are reachable
+    // only through loop back-edges, while the first selector (s20=37) enters the guarded root at
+    // PC2434. A null result creates a complete zero mask pair, takes the u64 SCC0 exit, then observes
+    // the s46=0 stack. This proves that no first work item can reach either unresolved ray site.
+    std::vector<Rdna2Inst> wave64_loop;
+    auto append_wave64_instruction = [&](uint32_t pc,
+                                         std::initializer_list<uint32_t> words) {
+        Rdna2Inst instruction = rdna2_decode_one(words.begin(), words.size());
+        instruction.pc = pc;
+        wave64_loop.push_back(instruction);
+    };
+    append_wave64_instruction(2029, {0xBEAE0380u}); // s_mov_b32 s46, 0 (empty stack)
+    append_wave64_instruction(2032, {0x802F080Au}); // independent address setup
+    append_wave64_instruction(2033, {0xBE9403A5u}); // s_mov_b32 s20, 37 (root selector)
+    append_wave64_instruction(2039, {0xBE88047Eu}); // loop header: s_mov_b64 s[8:9], exec
+    append_wave64_instruction(2040, {0x876A8714u});
+    append_wave64_instruction(2041, {0x816AC46Au});
+    append_wave64_instruction(2042, {0xBF0B826Au});
+    append_wave64_instruction(2043, {0xBF85017Eu}); // s_cbranch_scc1 2426
+    append_wave64_instruction(2148, {0xF1989F07u, 0x00040505u, 0x4442413Du,
+                                     0x4543403Eu, 0x00004746u}); // unresolved loop BVH
+    append_wave64_instruction(2187, {0xF1989F07u, 0x00040505u, 0x4442413Du,
+                                     0x4543403Eu, 0x00004746u}); // unresolved loop BVH
+    append_wave64_instruction(2426, {0x7E0A02C1u}); // v5..v8 = invalid
+    append_wave64_instruction(2427, {0x7E0C02C1u});
+    append_wave64_instruction(2428, {0x7E0E02C1u});
+    append_wave64_instruction(2429, {0x7E1002C1u});
+    append_wave64_instruction(2430, {0xBEEA2408u}); // s_and_saveexec_b64 vcc, s[8:9]
+    append_wave64_instruction(2431, {0xBF88000Au}); // empty EXEC -> no-hit compare
+    append_wave64_instruction(2432, {0x7E0A0214u}); // root index from s20
+    append_wave64_instruction(2433, {0xBF800000u});
+    append_wave64_instruction(2434, {0xF1989F07u, 0x00010505u, 0x39370A3Du,
+                                     0x33323130u, 0x00003534u}); // guarded null BVH
+    append_wave64_instruction(2439, {0xBF8C3F70u});
+    append_wave64_instruction(2440, {0x7D8A0AF9u, 0x068688C1u}); // v_cmp_ne_u32 s[8:9],-1,v5
+    append_wave64_instruction(2442, {0xBF138008u});              // s_cmp_lg_u64 s[8:9],0
+    append_wave64_instruction(2443, {0xBEFE046Au});              // s_mov_b64 exec,vcc
+    append_wave64_instruction(2444, {0xBF8400D8u});              // s_cbranch_scc0 2661
+    append_wave64_instruction(2624, {0xBE9403C1u});              // loop-carried s20 = -1
+    append_wave64_instruction(2660, {0xBF82FD93u});              // s_branch 2040
+    append_wave64_instruction(2661, {0xBF072E80u});              // s_cmp_lg_u32 0,s46
+    append_wave64_instruction(2662, {0xBF840004u});              // empty stack -> 2667
+    append_wave64_instruction(2663, {0x812EC12Eu});              // pop stack
+    append_wave64_instruction(2664, {0xD7600014u, 0x00005D3Bu});
+    append_wave64_instruction(2666, {0xBF82FD8Cu});              // s_branch 2039
+    append_wave64_instruction(2667, {0x060A7AFFu, 0x3A83126Fu});
+    append_wave64_instruction(3271, {0xBF810000u});
+
+    alignas(256) std::array<uint8_t, 256> wave64_null_bvh{};
+    auto wave64_resources = [&]() {
+        ShaderResourceTable table;
+        ShaderResource marker{};
+        marker.cls = ResourceClass::ConstantBuffer;
+        marker.format = DataFormat::Uint32;
+        marker.num_components = 1;
+        marker.binding = 4;
+        marker.size = wave64_null_bvh.size();
+        marker.fetch_pc = 2434;
+        marker.host_data = wave64_null_bvh.data();
+        marker.host_data_size = wave64_null_bvh.size();
+        table.resources.push_back(marker);
+        for (uint32_t fetch_pc : {2148u, 2187u}) {
+            ShaderResource unresolved{};
+            unresolved.cls = ResourceClass::ConstantBuffer;
+            unresolved.format = DataFormat::Uint32;
+            unresolved.num_components = 1;
+            unresolved.binding = static_cast<uint32_t>(table.resources.size() + 4);
+            unresolved.size = 4;
+            unresolved.fetch_pc = fetch_pc;
+            table.resources.push_back(unresolved);
+        }
+        return table;
+    };
+    std::vector<Rdna2Inst> wave64_constant_only = wave64_loop;
+    CHECK(rdna2_specialize_shader_constant_branches(wave64_constant_only) == 0 &&
+              std::any_of(wave64_constant_only.begin(), wave64_constant_only.end(),
+                          [](const Rdna2Inst& in) {
+                              return in.pc == 2148 || in.pc == 2187;
+                          }),
+          "Wave64 loop-carried selector keeps unresolved BVHs before the null-cycle proof");
+
+    ShaderResourceTable wave64_pruned_resources = wave64_resources();
+    std::vector<Rdna2Inst> wave64_pruned_loop = wave64_loop;
+    const ComputeResourcePathSpecializationReport wave64_path_report =
+        specialize_compute_resource_paths(wave64_pruned_loop, wave64_pruned_resources, 64);
+    CHECK(wave64_path_report.proven_null_exits == 1 &&
+              wave64_path_report.shader_constant_branches == 0 &&
+              wave64_path_report.removed_resources == 2 &&
+              std::find(wave64_path_report.removed_pcs.begin(),
+                        wave64_path_report.removed_pcs.end(), 2148) !=
+                  wave64_path_report.removed_pcs.end() &&
+              std::find(wave64_path_report.removed_pcs.begin(),
+                        wave64_path_report.removed_pcs.end(), 2187) !=
+                  wave64_path_report.removed_pcs.end() &&
+              std::none_of(wave64_pruned_loop.begin(), wave64_pruned_loop.end(),
+                           [](const Rdna2Inst& in) {
+                               return in.pc == 2148 || in.pc == 2187 || in.pc == 2624 ||
+                                      in.pc == 2660 || in.pc == 2663 || in.pc == 2666;
+                           }) &&
+              wave64_pruned_resources.resources.size() == 1 &&
+              is_proven_null_bvh(wave64_pruned_resources.resources.front()) &&
+              wave64_pruned_resources.resources.front().fetch_pc == 2434,
+          "exact Wave64 null cycle prunes loop BVHs, back-edges, and their resources");
+
+    // Materialize the same exact-PC reduced stream with NOPs in omitted spans so the production raw
+    // translator repeats the proof. Retain an independent runtime loop at entry so this follows the
+    // target shader's arbitrary-CFG compute path (which already supports its exact Wave64 mask tail),
+    // rather than accidentally exercising the ordinary structured emitter after reducing the target.
+    // Every exit from this loop still reaches the stack initializer, so it cannot bypass the proof.
+    // The synthetic terminal at PC2667 is the proven empty-stack target.
+    std::vector<uint32_t> wave64_null_exit_shader(2668, 0xBF800000u);
+    wave64_null_exit_shader[0] = 0xBF850002u; // s_cbranch_scc1 pc3
+    wave64_null_exit_shader[1] = 0xBF840001u; // s_cbranch_scc0 pc3
+    wave64_null_exit_shader[2] = 0xBF82FFFDu; // s_branch pc0 (multi-exit back-edge)
+    for (const Rdna2Inst& instruction : wave64_loop) {
+        if (instruction.pc >= 2667) continue;
+        for (uint32_t word = 0; word < instruction.len_dwords; ++word)
+            wave64_null_exit_shader[instruction.pc + word] = instruction.words[word];
+    }
+    wave64_null_exit_shader[2667] = 0xBF810000u;
+    ShaderResourceTable wave64_translation_resources = wave64_resources();
+    ComputeShaderConfig wave64_null_exit_config;
+    wave64_null_exit_config.local_x = 1;
+    wave64_null_exit_config.wave_size = 64;
+    CHECK(!recompile_compute(wave64_null_exit_shader.data(),
+                             wave64_null_exit_shader.size(),
+                             &wave64_translation_resources,
+                             wave64_null_exit_config).empty(),
+          "exact-PC Wave64 null cycle reaches production compute translation");
+
+    auto wave64_has_unresolved_sites = [](const std::vector<Rdna2Inst>& instructions) {
+        return std::any_of(instructions.begin(), instructions.end(),
+                           [](const Rdna2Inst& in) {
+                               return in.pc == 2148 || in.pc == 2187;
+                           });
+    };
+    for (int deviation = 0; deviation < 7; ++deviation) {
+        std::vector<Rdna2Inst> changed = wave64_loop;
+        auto at = [&](uint32_t pc) {
+            return std::find_if(changed.begin(), changed.end(),
+                                [&](const Rdna2Inst& in) { return in.pc == pc; });
+        };
+        if (deviation == 0) at(2442)->opcode = 0x07u;       // low-word compare only
+        if (deviation == 1) at(2442)->src[0].value = 10;    // different mask pair
+        if (deviation == 2) at(2443)->opcode = 0x03u;       // low-word EXEC copy only
+        if (deviation == 3) at(2440)->dst.value = 106;      // not an ordinary complete pair
+        if (deviation == 4) at(2440)->src[0].value = 0;     // compare is not against no-hit -1
+        if (deviation == 5) at(2440)->src[1].value = 6;     // compare is not the ray result
+        if (deviation == 6) at(2440)->dst.value = 105;      // pair overlaps architectural VCC
+        ShaderResourceTable table = wave64_resources();
+        CHECK(rdna2_specialize_proven_null_bvh_paths(changed, &table, 64) == 0 &&
+                  wave64_has_unresolved_sites(changed),
+              "Wave64 no-hit proof rejects width/pair/EXEC/result shape deviations");
+    }
+
+    ShaderResourceTable wave64_nonnull_resources = wave64_resources();
+    wave64_nonnull_resources.resources[0].gpu_addr = 0x10000u;
+    std::vector<Rdna2Inst> wave64_nonnull_loop = wave64_loop;
+    CHECK(rdna2_specialize_proven_null_bvh_paths(
+              wave64_nonnull_loop, &wave64_nonnull_resources, 64) == 0 &&
+              wave64_has_unresolved_sites(wave64_nonnull_loop),
+          "Wave64 cycle keeps unresolved sites when the root resource is not proven null");
+
+    for (int deviation = 0; deviation < 2; ++deviation) {
+        std::vector<Rdna2Inst> changed = wave64_loop;
+        auto at = [&](uint32_t pc) {
+            return std::find_if(changed.begin(), changed.end(),
+                                [&](const Rdna2Inst& in) { return in.pc == pc; });
+        };
+        if (deviation == 0) at(2029)->src[0].value = 1; // non-empty initial stack
+        if (deviation == 1) at(2033)->src[0].value = 36;// different root selector
+        ShaderResourceTable table = wave64_resources();
+        CHECK(rdna2_specialize_proven_null_bvh_paths(changed, &table, 64) == 1 &&
+                  wave64_has_unresolved_sites(changed),
+              "Wave64 empty-cycle proof rejects stack/selector deviations");
+    }
+
+    std::vector<Rdna2Inst> wave64_stack_pair_clobber = wave64_loop;
+    const std::array<uint32_t, 1> stack_pair_clobber_words{
+        0xBEAD047Eu}; // s_mov_b64 s[45:46], exec: high word overlaps stack s46
+    Rdna2Inst stack_pair_clobber = rdna2_decode_one(
+        stack_pair_clobber_words.data(), stack_pair_clobber_words.size());
+    stack_pair_clobber.pc = 2032;
+    *std::find_if(wave64_stack_pair_clobber.begin(), wave64_stack_pair_clobber.end(),
+                  [](const Rdna2Inst& in) { return in.pc == 2032; }) = stack_pair_clobber;
+    ShaderResourceTable wave64_stack_pair_resources = wave64_resources();
+    CHECK(rdna2_specialize_proven_null_bvh_paths(
+              wave64_stack_pair_clobber, &wave64_stack_pair_resources, 64) == 1 &&
+              wave64_has_unresolved_sites(wave64_stack_pair_clobber),
+          "Wave64 empty-cycle proof sees a B64 high-word stack clobber");
+
+    std::vector<Rdna2Inst> wave64_external_entry = wave64_loop;
+    const std::array<uint32_t, 1> wave64_external_words{0xBF82000Au}; // pc2028 -> pc2039
+    Rdna2Inst wave64_external = rdna2_decode_one(
+        wave64_external_words.data(), wave64_external_words.size());
+    wave64_external.pc = 2028;
+    wave64_external_entry.insert(wave64_external_entry.begin(), wave64_external);
+    ShaderResourceTable wave64_external_resources = wave64_resources();
+    CHECK(rdna2_specialize_proven_null_bvh_paths(
+              wave64_external_entry, &wave64_external_resources, 64) == 1 &&
+              wave64_has_unresolved_sites(wave64_external_entry),
+          "Wave64 external entry bypassing stack initialization keeps the cycle fail-visible");
+
     const uint32_t runtime_dead_fetch[] = {
         0xBF0B8200u,             // pc0: s_cmp_le_u32 s0, 2 (entry/user SGPR)
         0xBF850002u,             // pc1: s_cbranch_scc1 pc4


### PR DESCRIPTION
## Summary

Extend the existing exact Wave32 proven-null traversal exit to Astro Bot's Wave64 sibling without weakening BVH/resource validation.

- require the exact complete Wave64 VOPC mask pair, `s_cmp_lg_u64`, and `s_mov_b64 exec,vcc` no-hit tail
- derive the empty scalar-stack initializer across independent scalar setup while refusing branch crossings and intervening writes
- make scalar-write overlap checks width-aware for Wave64
- prune the loop-carried PC2148/2187 ray sites and their resources only after proving the exact null-root, selector, no-hit, and empty-stack cycle
- preserve the existing Wave32 path unchanged

The live trace established that PC2148/2187 have unknown runtime descriptors but are skipped on the proven first iteration; PC2434 is the exact proven-null root, whose no-hit tail forces the empty-stack exit before any backedge can seed the unresolved sites.

The patch remains fail-closed on pair width/identity, EXEC copy, compare/result linkage, non-null roots, nonempty stacks, selector changes, wide stack clobbers, and external entries. It does not relax MIMG/BVH validation.

Frozen v42 retry remains expected to fail because failed-stage capture intentionally strips `host_data` and therefore cannot retain the live null marker; no legacy metadata trust is inferred in this PR.

Continues #1459.

## Verification

- focused `test_dynfetch_fold` passes
- exact positive report removes PC2148/2187, loop backedges, and two unresolved resources
- representative complex Wave64 CFG reaches production translation
- independent negative fixtures retain unresolved sites/fail-visible behavior
- `git diff --check`

No screenshot is included because the Astro world map remains black pending a post-merge live run. Snapshot tests were intentionally not run for this focused development PR; repository policy requires them for releases, not routine PRs.