### PR TITLE
gpu: materialize exact scalar 16-bit buffer tails

### DIFF
--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -599,8 +599,10 @@ struct ComputeBufferCacheKey {
     uint64_t gpu_addr = 0;
     uintptr_t host_data = 0;
     uint32_t bytes = 0;
+    ComputeBufferMaterializationDiscriminator materialization;
     bool operator==(const ComputeBufferCacheKey& other) const {
-        return gpu_addr == other.gpu_addr && host_data == other.host_data && bytes == other.bytes;
+        return gpu_addr == other.gpu_addr && host_data == other.host_data &&
+               bytes == other.bytes && materialization == other.materialization;
     }
 };
 
@@ -609,6 +611,10 @@ struct ComputeBufferCacheKeyHash {
         size_t result = std::hash<uint64_t>{}(key.gpu_addr);
         result ^= std::hash<uintptr_t>{}(key.host_data) << 1;
         result ^= std::hash<uint32_t>{}(key.bytes) << 2;
+        result ^= std::hash<uint64_t>{}(key.materialization.logical_bytes) << 3;
+        result ^= std::hash<uint64_t>{}(key.materialization.binding_bytes) << 4;
+        result ^= std::hash<uint32_t>{}(
+            static_cast<uint32_t>(key.materialization.semantic)) << 5;
         return result;
     }
 };
@@ -3020,6 +3026,13 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             buffers[i].resource = resource;
             buffers[i].guest_bytes = resource->size;
             buffers[i].writable = descriptors[i].writable;
+            const StorageBufferMaterializationPlan materialization =
+                plan_storage_buffer_materialization(descriptors[i], *resource);
+            if (!materialization.valid) {
+                skip_buffer(descriptors[i].binding, resource,
+                            "invalid storage-buffer materialization contract");
+                break;
+            }
             buffers[i].atomic_image = descriptors[i].atomic_access &&
                 resource->cls == ResourceClass::StorageImage &&
                 resource->format == DataFormat::Uint32 && resource->num_components == 1 &&
@@ -3054,7 +3067,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 buffers[i].guest_bytes = guest_image_bytes;
             }
             buffers[i].bytes = buffers[i].atomic_image
-                ? static_cast<size_t>(linear_image_bytes) : resource->size;
+                ? static_cast<size_t>(linear_image_bytes)
+                : static_cast<size_t>(materialization.binding_bytes);
             for (size_t j = 0; j < i; ++j) {
                 const ShaderResource* prior = buffers[j].resource;
                 if (!prior || prior->gpu_addr != resource->gpu_addr ||
@@ -3099,11 +3113,22 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                      (unsigned long long)resource->gpu_addr,
                                      resource->width, resource->height,
                                      resource->tile_mode, buffers[i].bytes);
+                } else if (materialization.zero_padded_tail) {
+                    buffers[i].linear_seed.resize(buffers[i].bytes);
+                    if (!materialize_storage_buffer_bytes(
+                            materialization, source, buffers[i].guest_bytes,
+                            buffers[i].linear_seed.data(), buffers[i].linear_seed.size())) {
+                        skip_buffer(descriptors[i].binding, resource,
+                                    "failed zero-padded storage-buffer materialization");
+                        break;
+                    }
+                    source = buffers[i].linear_seed.data();
                 }
                 if (trace) buffers[i].before_hash = fnv1a(source, buffers[i].bytes);
                 buffers[i].cache_key = {
                     resource->gpu_addr, reinterpret_cast<uintptr_t>(resource->host_data),
-                    static_cast<uint32_t>(buffers[i].bytes)};
+                    static_cast<uint32_t>(buffers[i].bytes),
+                    compute_buffer_materialization_discriminator(materialization)};
                 const bool cache_candidate = !buffers[i].atomic_image &&
                     persistent_compute_buffer_enabled(static_cast<uint32_t>(buffers[i].bytes));
                 if (cache_candidate && ctx.acquire_cached_buffer(

--- a/prosper/frontends/shared/live_compute.hpp
+++ b/prosper/frontends/shared/live_compute.hpp
@@ -10,6 +10,24 @@ namespace prosper::frontend {
 
 enum class ComputeImageCacheClass : uint8_t { sampled, storage };
 
+// Persistent SSBO identity must distinguish guest bytes from their Vulkan materialization. A
+// one-record 16-bit source and an ordinary four-byte source can otherwise share address, host-data
+// identity, and bound size while requiring different upper bytes and typed shader semantics.
+struct ComputeBufferMaterializationDiscriminator {
+    uint64_t logical_bytes = 0;
+    uint64_t binding_bytes = 0;
+    prosper::gpu::StorageBufferTailSemantic semantic =
+        prosper::gpu::StorageBufferTailSemantic::None;
+
+    bool operator==(const ComputeBufferMaterializationDiscriminator&) const = default;
+};
+
+constexpr ComputeBufferMaterializationDiscriminator
+compute_buffer_materialization_discriminator(
+    const prosper::gpu::StorageBufferMaterializationPlan& plan) {
+    return {plan.logical_bytes, plan.binding_bytes, plan.semantic};
+}
+
 // Read-only sampled inputs are often tiny, numerous, and cheap to upload; retaining all of them
 // wastes cache identities and device memory. A storage target has a different cost model: even a
 // small repeated output otherwise incurs staging readback, guest-format packing, and layout work.

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -3467,6 +3467,16 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         if (getenv("PROSPER_ALPHA1")) fr.swizzle[3] = 1;
                     } else {
                         fr.buffer_identity = r.gpu_addr;
+                        const prosper::gpu::StorageBufferMaterializationPlan materialization =
+                            prosper::gpu::plan_storage_buffer_materialization(
+                                *reflected_binding, r);
+                        if (!materialization.valid) {
+                            fprintf(stderr,
+                                    "[buffer-materialization-reject] set=%u binding=%u addr=%llx "
+                                    "declared=%u\n",
+                                    set, r.binding, (unsigned long long)r.gpu_addr, r.size);
+                            continue;
+                        }
                         // #1427: the guest's declared V#/V-buffer size is the real requirement — a
                         // vertex fetch indexes anywhere inside it. The old 1 MiB clamp silently
                         // truncated larger buffers, so every element past the cap read ZEROS: those
@@ -3480,7 +3490,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // truncation that does happen FAIL-VISIBLE. PROSPER_MAX_BUFFER_UPLOAD_MB
                         // lowers the ceiling for a same-build A/B of this exact defect.
                         const uint32_t requested_bytes = r.size ? r.size : 256u;
-                        uint32_t nb = prosper::frontend::buffer_upload_bytes(requested_bytes);
+                        uint32_t nb = materialization.zero_padded_tail
+                            ? static_cast<uint32_t>(materialization.binding_bytes)
+                            : prosper::frontend::buffer_upload_bytes(requested_bytes);
                         if (nb < (requested_bytes & ~3u)) {
                             static std::set<uint64_t> truncated_reported;
                             if (truncated_reported.size() < 32 &&
@@ -3500,7 +3512,29 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         const bool unavailable_guest_buffer = !r.host_data &&
                             (r.gpu_addr < 0x1000 ||
                              prosper_reserved_range_state(r.gpu_addr) == 0);
-                        if (unavailable_guest_buffer) {
+                        if (materialization.zero_padded_tail) {
+                            uint8_t logical[2] = {};
+                            const uint8_t* logical_source = nullptr;
+                            if (r.host_data && r.host_data_size >= sizeof(logical)) {
+                                logical_source = r.host_data;
+                            } else if (!r.host_data && !unavailable_guest_buffer &&
+                                       copy_resource(logical, r.gpu_addr, sizeof(logical)) ==
+                                           sizeof(logical)) {
+                                logical_source = logical;
+                            }
+                            fr.dwords.assign(1, 0);
+                            if (!logical_source ||
+                                !prosper::gpu::materialize_storage_buffer_bytes(
+                                    materialization, logical_source, sizeof(logical),
+                                    reinterpret_cast<uint8_t*>(fr.dwords.data()),
+                                    sizeof(uint32_t))) {
+                                fprintf(stderr,
+                                        "[buffer-materialization-reject] set=%u binding=%u "
+                                        "two-byte source unavailable\n",
+                                        set, r.binding);
+                                continue;
+                            }
+                        } else if (unavailable_guest_buffer) {
                             const uint64_t minimum_bytes = std::min<uint64_t>(
                                 std::max<uint64_t>(reflected_binding->required_bytes, 256u),
                                 kMaxBufferUploadBytes);
@@ -3520,7 +3554,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         }
                         const auto copy_start = timing_enabled
                             ? RenderClock::now() : RenderClock::time_point{};
-                        if (!unavailable_guest_buffer && !fr.dwords_view_count &&
+                        if (!materialization.zero_padded_tail &&
+                            !unavailable_guest_buffer && !fr.dwords_view_count &&
                             use_direct_buffer_views) {
                             if (nb >= 4) {
                                 fr.dwords.assign(nb / sizeof(uint32_t), 0);
@@ -3529,7 +3564,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                     fr.dwords.clear();
                             }
                             if (fr.dwords.empty()) fr.dwords.assign(64, 0);
-                        } else if (!unavailable_guest_buffer && !use_direct_buffer_views) {
+                        } else if (!materialization.zero_padded_tail &&
+                                   !unavailable_guest_buffer && !use_direct_buffer_views) {
                             if (nb >= 4) {
                                 std::vector<uint8_t> tmp(nb, 0);
                                 if (copy_resource(tmp.data(), r.gpu_addr, nb) > 0)

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -157,6 +157,7 @@ struct ShaderResourceCompileKey {
     bool compression_enabled = false;
     uint32_t binding = 0;
     uint32_t stride = 0;
+    uint32_t one_record_tail_semantic = 0;
     uint32_t srt_offset = 0;
     uint32_t sgpr_base = 0;
     uint32_t fetch_pc = 0;
@@ -336,6 +337,7 @@ struct ShaderCompileKeyHash {
             hash = hash_mix(hash, resource.compression_enabled);
             hash = hash_mix(hash, resource.binding);
             hash = hash_mix(hash, resource.stride);
+            hash = hash_mix(hash, resource.one_record_tail_semantic);
             hash = hash_mix(hash, resource.srt_offset);
             hash = hash_mix(hash, resource.sgpr_base);
             hash = hash_mix(hash, resource.fetch_pc);
@@ -1012,6 +1014,14 @@ ShaderCompileKey make_shader_compile_key(ShaderProgramStage stage, const uint32_
             compiled.compression_enabled = storage_image && resource.compression_enabled;
             compiled.binding = resource.binding;
             compiled.stride = resource.stride;
+            const bool one_record_tail = resource.num_components == 1u &&
+                resource.stride == 2u && resource.size == 2u;
+            compiled.one_record_tail_semantic = static_cast<uint32_t>(
+                one_record_tail && resource.format == DataFormat::Uint16
+                    ? StorageBufferTailSemantic::Uint16
+                    : one_record_tail && resource.format == DataFormat::Float16
+                        ? StorageBufferTailSemantic::Float16
+                        : StorageBufferTailSemantic::None);
             compiled.srt_offset = resource.srt_offset;
             compiled.sgpr_base = resource.sgpr_base;
             compiled.fetch_pc = resource.fetch_pc;

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -224,6 +224,11 @@ struct SpirvCompute {
     int32_t guest_scratch_min_byte=0, guest_scratch_saddr=-1;
     uint32_t guest_scratch_dwords=0;
     std::map<uint32_t, uint32_t> cbuf_var;          // binding -> storage-buffer var (N-buffer model; 2/3 map to v_cbuf/v_cbuf1)
+    // A two-byte guest V# can only back our u32 SSBO ABI when every use of that binding is the exact
+    // one-record Uint16/Float16 path. Ordinary load/store/atomic helpers blacklist their bindings;
+    // finish() emits the explicit typed zero-pad contract only for candidates with no competing use.
+    std::map<uint32_t, StorageBufferTailSemantic> cbuf_zero_pad_candidates;
+    std::set<uint32_t> cbuf_ordinary_accesses;
     bool     is_fragment=0;                          // true in the fragment shell (gates VINTRP interp)
     bool     is_vertex=0;                            // true in every vertex shell
     bool     allow_b32_masks=0;                      // proven Wave32 or byte-exact graphics exception
@@ -1676,15 +1681,27 @@ struct SpirvCompute {
     }
     // Load one dword (raw bits) from the constant/vertex buffer at descriptor `binding` at dword index
     // `idx` (SMEM). The 1-arg form keeps the legacy slot convention (0 -> binding 2, 1 -> binding 3).
-    uint32_t cbuf_load(uint32_t idx, uint32_t binding = 2) {
+    uint32_t cbuf_load_impl(uint32_t idx, uint32_t binding) {
         uint32_t buf = buf_for_binding(binding);
         uint32_t p = id(); putv(code, Op_AccessChain, {t_ptr_sb_u32, p, buf, uconst(0), idx});
         uint32_t r = id(); put(code, Op_Load, {t_u32, r, p}); return r;
+    }
+    uint32_t cbuf_load(uint32_t idx, uint32_t binding = 2) {
+        cbuf_ordinary_accesses.insert(binding);
+        return cbuf_load_impl(idx, binding);
+    }
+    uint32_t cbuf_load_zero_padded_tail(uint32_t binding,
+                                        StorageBufferTailSemantic semantic) {
+        auto [candidate, inserted] = cbuf_zero_pad_candidates.emplace(binding, semantic);
+        if (!inserted && candidate->second != semantic)
+            cbuf_ordinary_accesses.insert(binding);
+        return cbuf_load_impl(uconst(0), binding);
     }
     // Store one dword `value` to the buffer at descriptor `binding` at dword index `idx` (MUBUF store).
     // When `predicated`, the store is wrapped in a selection merge on `pred` (the per-lane EXEC bool) so
     // inactive lanes do not write — a real conditional store, not a select of a loaded old value.
     void cbuf_store(uint32_t idx, uint32_t value, uint32_t binding, bool predicated, uint32_t pred) {
+        cbuf_ordinary_accesses.insert(binding);
         uint32_t buf = buf_for_binding(binding);
         if (!predicated) {
             uint32_t p = id(); putv(code, Op_AccessChain, {t_ptr_sb_u32, p, buf, uconst(0), idx});
@@ -1704,6 +1721,7 @@ struct SpirvCompute {
     // clobber VDATA, hence the predicated path joins the old destination through OpPhi.
     uint32_t cbuf_atomic_rtn(uint32_t op, uint32_t idx, uint32_t value, uint32_t binding,
                              bool predicated, uint32_t pred, uint32_t fallback) {
+        cbuf_ordinary_accesses.insert(binding);
         const uint32_t buf = buf_for_binding(binding);
         auto emit = [&]() {
             uint32_t p = id(); putv(code, Op_AccessChain, {t_ptr_sb_u32, p, buf, uconst(0), idx});
@@ -2707,6 +2725,18 @@ struct SpirvCompute {
             char marker[64];
             std::snprintf(marker, sizeof marker, "Prosper.FragmentSubgroupSize=%u",
                           fragment_required_subgroup_size);
+            std::vector<uint32_t> words;
+            pstr(words, marker);
+            putv(debug, Op_ModuleProcessed, words);
+        }
+        for (const auto& [binding, semantic] : cbuf_zero_pad_candidates) {
+            if (cbuf_ordinary_accesses.count(binding)) continue;
+            char marker[96];
+            const char* token = semantic == StorageBufferTailSemantic::Uint16 ? "u16" :
+                                semantic == StorageBufferTailSemantic::Float16 ? "f16" : nullptr;
+            if (!token) continue;
+            std::snprintf(marker, sizeof marker, "Prosper.StorageBufferZeroPad=%u,%u,2,4,%s",
+                          desc_set, binding, token);
             std::vector<uint32_t> words;
             pstr(words, marker);
             putv(debug, Op_ModuleProcessed, words);
@@ -8239,6 +8269,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                                        // attribute fetch, whose element address is exactly gl_VertexIndex*stride.
             bool instance_vfetch = false;
             bool folded_vfetch = false; // by-fetch V# base already includes OFFSET/SOFFSET
+            const ShaderResource* resolved_buffer = nullptr;
             if (is_format) {
                 // A format load reads a vertex/buffer attribute — it needs the V# descriptor for the
                 // binding, stride, and data format. Resolve SRSRC (src[1]) via provenance: an s_load
@@ -8329,6 +8360,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     }
                     ok = false; return true;
                 }
+                resolved_buffer = res;
                 binding = res->binding;
                 stride = res->stride;
                 if (in.fmt == Rdna2Format::MTBUF) {
@@ -8370,6 +8402,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     }
                     ok = false; return true;   // unresolvable V# -> reject; NEVER default to binding 2
                 }
+                resolved_buffer = res;
                 binding = res->binding;
                 stride  = res->stride;
                 // fmt stays raw Uint32: untyped ops move raw dwords regardless of the V#'s declared format.
@@ -8412,6 +8445,27 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // below wrongly rejected as unaligned. Handle it with a runtime byte/halfword extract.
             const bool int_subword = is_format && !raw_subword && (is_uint || is_sint) &&
                                      (comp_bytes == 1 || comp_bytes == 2);
+            const bool zero_soffset =
+                (in.src[2].kind == OperandKind::Special && in.src[2].value == 125) ||
+                (in.src[2].kind == OperandKind::InlineInt && in.src[2].value == 0);
+            // Vulkan exposes storage buffers as u32 arrays in Prosper's portable ABI. Admit a two-byte
+            // guest range only for Plucky Squire's exact one-record UINT16/FLOAT16 scalar format fetch:
+            // the original element index itself is checked against zero, the sole load is constant
+            // dword 0, and the host supplies a zero upper half. No raw/store/atomic/offset variant can
+            // inherit this contract.
+            const StorageBufferTailSemantic one_record_tail_semantic = !resolved_buffer
+                ? StorageBufferTailSemantic::None
+                : resolved_buffer->format == DataFormat::Uint16
+                    ? StorageBufferTailSemantic::Uint16
+                    : resolved_buffer->format == DataFormat::Float16
+                        ? StorageBufferTailSemantic::Float16
+                        : StorageBufferTailSemantic::None;
+            const bool one_record_16bit_tail =
+                in.fmt == Rdna2Format::MUBUF && in.opcode == 0u && n == 1u &&
+                one_record_tail_semantic != StorageBufferTailSemantic::None &&
+                resolved_buffer->num_components == 1u && resolved_buffer->stride == 2u &&
+                resolved_buffer->size == 2u && idxen && !offen && offset == 0u && zero_soffset &&
+                !folded_vfetch && in.src[0].kind == OperandKind::VGPR;
             float norm = 0.0f;
             switch (fmt) {
                 case DataFormat::Unorm8:  norm = 255.0f;   break;
@@ -8609,6 +8663,16 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 if (is_format && fmt_ncomp && k >= fmt_ncomp) {
                     uint32_t one = fmt_is_int ? 1u : 0x3f800000u;   // integer 1 vs float 1.0 (raw bits)
                     value = b.uconst(in.fmt != Rdna2Format::MTBUF && k == 3 ? one : 0u);
+                } else if (one_record_16bit_tail) {
+                    const uint32_t packed_value = b.cbuf_load_zero_padded_tail(
+                        binding, one_record_tail_semantic);
+                    const uint32_t in_bounds = b.ucmp(
+                        Op_IEqual, val(in.src[0]), b.uconst(0));
+                    const uint32_t typed_value =
+                        one_record_tail_semantic == StorageBufferTailSemantic::Float16
+                            ? b.unpack_half(packed_value, 0)
+                            : b.bfe_u(packed_value, b.uconst(0), b.uconst(16));
+                    value = b.sel(in_bounds, typed_value, b.uconst(0));
                 } else if (raw_subword) {
                     // Raw byte/short loads use their full byte address, unlike typed packed-format
                     // loads whose component packing is descriptor-defined. A 16-bit access may begin

--- a/prosper/src/gpu/shader_resources.cpp
+++ b/prosper/src/gpu/shader_resources.cpp
@@ -2,12 +2,14 @@
 #include "shader_resources.hpp"
 
 #include <algorithm>
+#include <charconv>
 #include <cstring>
 #include <iterator>
 #include <limits>
 #include <map>
 #include <mutex>
 #include <set>
+#include <string_view>
 #include <unordered_map>
 
 namespace prosper::gpu {
@@ -233,6 +235,7 @@ enum : uint32_t {
     OpAtomicFlagClear = 319,
     OpDecorate = 71,
     OpMemberDecorate = 72,
+    OpModuleProcessed = 330,
 };
 enum : uint32_t {
     StorageUniformConstant = 0,
@@ -249,6 +252,59 @@ struct Instruction {
     uint16_t words = 0;
     uint16_t opcode = 0;
 };
+
+struct StorageBufferZeroPadMarker {
+    uint32_t set = 0;
+    uint32_t binding = 0;
+    uint64_t logical_bytes = 0;
+    uint64_t binding_bytes = 0;
+    StorageBufferTailSemantic semantic = StorageBufferTailSemantic::None;
+};
+
+std::string instruction_string(const std::vector<uint32_t>& spirv,
+                               const Instruction& instruction) {
+    std::string value;
+    bool terminated = false;
+    for (uint32_t operand = 0; operand + 1u < instruction.words; ++operand) {
+        const uint32_t packed = spirv[instruction.offset + 1u + operand];
+        for (uint32_t byte = 0; byte < 4; ++byte) {
+            const char c = static_cast<char>(packed >> (byte * 8u));
+            if (!c) {
+                terminated = true;
+                break;
+            }
+            value.push_back(c);
+        }
+        if (terminated) break;
+    }
+    return terminated ? value : std::string{};
+}
+
+bool parse_storage_buffer_zero_pad_marker(const std::string& text,
+                                          StorageBufferZeroPadMarker& marker) {
+    constexpr const char kPrefix[] = "Prosper.StorageBufferZeroPad=";
+    if (!text.starts_with(kPrefix)) return false;
+    const char* cursor = text.data() + sizeof(kPrefix) - 1u;
+    const char* end = text.data() + text.size();
+    auto parse = [&](auto& value, char delimiter) {
+        const auto result = std::from_chars(cursor, end, value);
+        if (result.ec != std::errc{} || result.ptr == cursor) return false;
+        cursor = result.ptr;
+        if (delimiter) {
+            if (cursor == end || *cursor != delimiter) return false;
+            ++cursor;
+        }
+        return true;
+    };
+    if (!parse(marker.set, ',') || !parse(marker.binding, ',') ||
+        !parse(marker.logical_bytes, ',') || !parse(marker.binding_bytes, ','))
+        return false;
+    const std::string_view token(cursor, static_cast<size_t>(end - cursor));
+    if (token == "u16") marker.semantic = StorageBufferTailSemantic::Uint16;
+    else if (token == "f16") marker.semantic = StorageBufferTailSemantic::Float16;
+    else return false;
+    return true;
+}
 
 enum class TypeKind {
     Unknown,
@@ -430,6 +486,64 @@ uint64_t reflection_entry_bytes(const DescriptorReflectionCacheEntry& entry) {
 
 } // namespace
 
+StorageBufferMaterializationPlan plan_storage_buffer_materialization(
+    const SpirvDescriptorBinding& descriptor,
+    const ShaderResource& resource) {
+    StorageBufferMaterializationPlan plan;
+    plan.logical_bytes = resource.size;
+    plan.binding_bytes = resource.size;
+
+    const bool has_logical = descriptor.zero_pad_logical_bytes != 0;
+    const bool has_binding = descriptor.zero_pad_binding_bytes != 0;
+    const bool has_semantic =
+        descriptor.zero_pad_semantic != StorageBufferTailSemantic::None;
+    if (!has_logical && !has_binding && !has_semantic) {
+        plan.valid = true;
+        return plan;
+    }
+    if (!has_logical || !has_binding || !has_semantic) return plan;
+
+    const bool buffer_resource = resource.cls == ResourceClass::ConstantBuffer ||
+                                 resource.cls == ResourceClass::VertexBuffer;
+    const bool semantic_matches =
+        (descriptor.zero_pad_semantic == StorageBufferTailSemantic::Uint16 &&
+         resource.format == DataFormat::Uint16) ||
+        (descriptor.zero_pad_semantic == StorageBufferTailSemantic::Float16 &&
+         resource.format == DataFormat::Float16);
+    if (descriptor.kind != SpirvDescriptorKind::StorageBuffer || !buffer_resource ||
+        !descriptor.readable || descriptor.writable || descriptor.atomic_access ||
+        descriptor.dynamic_access || descriptor.required_bytes != 4u ||
+        descriptor.zero_pad_logical_bytes != 2u ||
+        descriptor.zero_pad_binding_bytes != 4u ||
+        !semantic_matches || resource.num_components != 1u ||
+        resource.stride != 2u || resource.size != 2u)
+        return plan;
+
+    plan.logical_bytes = 2;
+    plan.binding_bytes = 4;
+    plan.semantic = descriptor.zero_pad_semantic;
+    plan.zero_padded_tail = true;
+    plan.valid = true;
+    return plan;
+}
+
+bool materialize_storage_buffer_bytes(
+    const StorageBufferMaterializationPlan& plan,
+    const uint8_t* source,
+    uint64_t source_bytes,
+    uint8_t* destination,
+    uint64_t destination_bytes) {
+    if (!plan.valid || plan.logical_bytes > plan.binding_bytes ||
+        source_bytes < plan.logical_bytes || destination_bytes < plan.binding_bytes ||
+        (plan.logical_bytes && !source) || (plan.binding_bytes && !destination))
+        return false;
+    if (plan.binding_bytes)
+        std::memset(destination, 0, static_cast<size_t>(plan.binding_bytes));
+    if (plan.logical_bytes)
+        std::memcpy(destination, source, static_cast<size_t>(plan.logical_bytes));
+    return true;
+}
+
 bool DescriptorValidationReport::ok() const {
     for (const auto& issue : issues) if (issue.error) return false;
     return true;
@@ -515,6 +629,8 @@ DescriptorValidationReport validate_spirv_descriptor_interface(
     std::unordered_map<uint32_t, uint32_t> sets, bindings;
     std::unordered_map<uint32_t, uint64_t> array_strides;
     std::unordered_map<uint64_t, uint64_t> member_offsets;
+    std::map<uint64_t, StorageBufferZeroPadMarker> zero_pad_markers;
+    bool malformed_zero_pad_marker = false;
     auto word = [&](const Instruction& in, uint32_t operand) { return spirv[in.offset + 1u + operand]; };
     for (const Instruction& in : insts) {
         const uint32_t n = in.words - 1u;
@@ -579,10 +695,28 @@ DescriptorValidationReport validate_spirv_descriptor_interface(
                 if (n >= 4 && word(in, 2) == DecorationOffset)
                     member_offsets[member_key(word(in, 0), word(in, 1))] = word(in, 3);
                 break;
+            case OpModuleProcessed: {
+                const std::string marker_text = instruction_string(spirv, in);
+                constexpr const char kPrefix[] = "Prosper.StorageBufferZeroPad=";
+                if (!marker_text.starts_with(kPrefix)) break;
+                StorageBufferZeroPadMarker marker;
+                if (!parse_storage_buffer_zero_pad_marker(marker_text, marker) ||
+                    marker.logical_bytes != 2u || marker.binding_bytes != 4u ||
+                    marker.semantic == StorageBufferTailSemantic::None) {
+                    malformed_zero_pad_marker = true;
+                    break;
+                }
+                const uint64_t key = (static_cast<uint64_t>(marker.set) << 32u) |
+                                     marker.binding;
+                if (!zero_pad_markers.emplace(key, marker).second)
+                    malformed_zero_pad_marker = true;
+                break;
+            }
             default:
                 break;
         }
     }
+    if (malformed_zero_pad_marker) add_malformed(report);
     for (auto& [id, type] : types) if (type.kind == TypeKind::Array) {
         auto ci = constants.find(type.count_id);
         if (ci != constants.end() && ci->second <= std::numeric_limits<uint32_t>::max())
@@ -759,6 +893,7 @@ DescriptorValidationReport validate_spirv_descriptor_interface(
         }
     }
 
+    std::set<uint64_t> consumed_zero_pad_markers;
     for (uint32_t var : used_vars) {
         auto si = sets.find(var), bi = bindings.find(var);
         if (si == sets.end() || bi == bindings.end()) { add_malformed(report); continue; }
@@ -775,16 +910,33 @@ DescriptorValidationReport validate_spirv_descriptor_interface(
             image_multisampled = image->image_multisampled;
             image_depth = image->image_depth;
         }
-        report.descriptors.push_back({var, si->second, bi->second, descriptor_vars[var], stage,
-                                      required[var], dynamic[var], read_vars.count(var) != 0,
-                                      written_vars.count(var) != 0,
-                                      normalized_sample_vars.count(var) != 0,
-                                      texel_access_vars.count(var) != 0,
-                                      sampled_float_vars.count(var) != 0,
-                                      storage_float_vars.count(var) != 0, image_format, image_dim,
-                                      image_arrayed, image_multisampled, image_depth,
-                                      atomic_vars.count(var) != 0});
+        SpirvDescriptorBinding descriptor{
+            var, si->second, bi->second, descriptor_vars[var], stage,
+            required[var], dynamic[var], read_vars.count(var) != 0,
+            written_vars.count(var) != 0,
+            normalized_sample_vars.count(var) != 0,
+            texel_access_vars.count(var) != 0,
+            sampled_float_vars.count(var) != 0,
+            storage_float_vars.count(var) != 0, image_format, image_dim,
+            image_arrayed, image_multisampled, image_depth,
+            atomic_vars.count(var) != 0};
+        const uint64_t marker_key = (static_cast<uint64_t>(descriptor.set) << 32u) |
+                                    descriptor.binding;
+        if (auto marker = zero_pad_markers.find(marker_key); marker != zero_pad_markers.end()) {
+            if (descriptor.kind != SpirvDescriptorKind::StorageBuffer ||
+                descriptor.required_bytes != 4u || descriptor.dynamic_access ||
+                !descriptor.readable || descriptor.writable || descriptor.atomic_access) {
+                add_malformed(report);
+            } else {
+                descriptor.zero_pad_logical_bytes = marker->second.logical_bytes;
+                descriptor.zero_pad_binding_bytes = marker->second.binding_bytes;
+                descriptor.zero_pad_semantic = marker->second.semantic;
+                consumed_zero_pad_markers.insert(marker_key);
+            }
+        }
+        report.descriptors.push_back(descriptor);
     }
+    if (consumed_zero_pad_markers.size() != zero_pad_markers.size()) add_malformed(report);
     std::sort(report.descriptors.begin(), report.descriptors.end(), [](const auto& a, const auto& b) {
         return a.set != b.set ? a.set < b.set : a.binding < b.binding;
     });
@@ -876,7 +1028,16 @@ DescriptorValidationReport validate_spirv_descriptor_interface(
             continue;
         }
         if (d.kind == SpirvDescriptorKind::StorageBuffer) {
-            uint64_t minimum = std::max<uint64_t>(d.required_bytes, 4);
+            const StorageBufferMaterializationPlan materialization =
+                plan_storage_buffer_materialization(d, r);
+            if (!materialization.valid) {
+                report.issues.push_back({DescriptorIssueCode::InvalidBufferMetadata, true, d.set,
+                                         d.binding, d.kind, actual, d.required_bytes, r.size});
+                continue;
+            }
+            const uint64_t minimum = materialization.zero_padded_tail
+                ? materialization.logical_bytes
+                : std::max<uint64_t>(d.required_bytes, 4);
             uint64_t available = r.size;
             if (r.host_data) available = std::min<uint64_t>(available, r.host_data_size);
             if (!null_descriptor && available < minimum)

--- a/prosper/src/gpu/shader_resources.hpp
+++ b/prosper/src/gpu/shader_resources.hpp
@@ -368,6 +368,15 @@ enum class SpirvShaderStage : uint32_t {
     Unknown = 0xFFFFFFFFu,
 };
 
+// Semantic carried by the strict two-byte -> one-dword storage-buffer materialization contract.
+// It is explicit because Uint16 and Float16 share the same physical bytes but produce different
+// guest VGPR values; a cached module or replay marker must never infer one from the other.
+enum class StorageBufferTailSemantic : uint32_t {
+    None = 0,
+    Uint16,
+    Float16,
+};
+
 // SPIR-V Image Format operand used by the exact one-word storage fallback. Keep this public so the
 // recompiler, reflection, live backend, and their contract tests cannot drift through magic values.
 constexpr uint32_t kSpirvImageFormatR32ui = 33;
@@ -416,7 +425,40 @@ struct SpirvDescriptorBinding {
     // The descriptor is reached by an OpAtomic*. Compute uses this to recognize the deliberately
     // buffer-backed view of an exact R32_UINT StorageImage (the RADV image-atomic workaround).
     bool atomic_access = false;
+    // A generated module may prove that every access to this storage-buffer binding is an exact
+    // one-record scalar Uint16/Float16 format-load contract. Vulkan storage buffers are arrays of u32 in our
+    // portable ABI, so that two-byte guest record is materialized as one zero-padded dword. These
+    // values are non-zero only when a strict Prosper.OpModuleProcessed marker survives reflection;
+    // ordinary/raw accesses never receive the exception.
+    uint64_t zero_pad_logical_bytes = 0;
+    uint64_t zero_pad_binding_bytes = 0;
+    StorageBufferTailSemantic zero_pad_semantic = StorageBufferTailSemantic::None;
 };
+
+struct StorageBufferMaterializationPlan {
+    uint64_t logical_bytes = 0;
+    uint64_t binding_bytes = 0;
+    StorageBufferTailSemantic semantic = StorageBufferTailSemantic::None;
+    bool zero_padded_tail = false;
+    bool valid = false;
+};
+
+// Derive the exact host binding range from reflected shader semantics plus the runtime V#. The only
+// range expansion currently admitted is a read-only one-record scalar Uint16/Float16 FORMAT load
+// (2 -> 4 bytes).
+// Any marker/runtime mismatch fails closed. Ordinary buffers keep logical==binding==resource.size.
+StorageBufferMaterializationPlan plan_storage_buffer_materialization(
+    const SpirvDescriptorBinding& descriptor,
+    const ShaderResource& resource);
+
+// Deterministically seed a planned binding. The destination is cleared before the exact logical
+// source bytes are copied, so a padded tail can never borrow bytes from the following guest object.
+bool materialize_storage_buffer_bytes(
+    const StorageBufferMaterializationPlan& plan,
+    const uint8_t* source,
+    uint64_t source_bytes,
+    uint8_t* destination,
+    uint64_t destination_bytes);
 
 enum class DescriptorIssueCode : uint32_t {
     MalformedSpirv,

--- a/prosper/tests/test_gpu_replay_shader_dump.cpp
+++ b/prosper/tests/test_gpu_replay_shader_dump.cpp
@@ -194,6 +194,30 @@ int main() {
               !failed_compute_spirv.empty() &&
               failed_compute_spirv == direct_failed_compute_spirv,
           "failed compute retry reproduces the exact captured specialization byte-for-byte");
+    const gpu::DescriptorValidationReport retry_contract =
+        tools::validate_recompiled_failed_stage_contract(
+            failed_compute.stage, failed_compute_spirv, nullptr);
+    const gpu::DescriptorValidationReport live_contract =
+        gpu::validate_spirv_descriptor_interface(
+            failed_compute_spirv, nullptr, 0, gpu::SpirvShaderStage::Compute, false);
+    CHECK(retry_contract.ok() == live_contract.ok() &&
+          retry_contract.descriptors.size() == live_contract.descriptors.size() &&
+          retry_contract.issues.size() == live_contract.issues.size(),
+          "failed-stage retry reports the same accepted descriptor contract as live compute");
+    const std::vector<uint32_t> rejected_retry_spirv;
+    const gpu::DescriptorValidationReport rejected_retry_contract =
+        tools::validate_recompiled_failed_stage_contract(
+            failed_compute.stage, rejected_retry_spirv, nullptr);
+    const gpu::DescriptorValidationReport rejected_live_contract =
+        gpu::validate_spirv_descriptor_interface(
+            rejected_retry_spirv, nullptr, 0, gpu::SpirvShaderStage::Compute, false);
+    CHECK(!rejected_retry_contract.ok() &&
+          rejected_retry_contract.ok() == rejected_live_contract.ok() &&
+          rejected_retry_contract.issues.size() == rejected_live_contract.issues.size() &&
+          !rejected_retry_contract.issues.empty() &&
+          rejected_retry_contract.issues.front().code ==
+              gpu::DescriptorIssueCode::MalformedSpirv,
+          "failed-stage retry preserves live contract rejection instead of becoming a fallback");
     auto different_failed_compute = failed_compute;
     different_failed_compute.recompile_config.local_x = 4;
     std::vector<uint32_t> different_failed_compute_spirv;

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -4029,6 +4029,172 @@ int main() {
     CHECK(!spvT13structured.empty() && gotT13structured.size() == N && badT13structured == 0,
           "T13 structured: stride-2 Uint16 format load uses computed VADDR and runtime half");
 
+    // Plucky Squire's post-desk compute shader binds three one-record Uint16 V#s. Prosper's portable
+    // SSBO ABI loads u32, so each exact two-byte guest range carries a reflected 2 -> 4 zero-pad
+    // contract. The shader itself guards the original record index: record 0 reads the low half and
+    // every later record returns zero, even if the materialized upper half is deliberately poisoned.
+    const uint32_t codeT13tail[] = {
+        0x7e020f00u,                         // v1 = uint(input v0): record index
+        0xe0002000u, 0x80020101u,           // format_x v1, v1, s[8:11], idxen
+        0xbf8c3f70u, 0x7e000d01u, 0xbf810000u,
+    };
+    uint16_t tail_host_value = 0x1234u;
+    ShaderResourceTable rtT13tail;
+    { ShaderResource cb{}; cb.cls = ResourceClass::ConstantBuffer;
+      cb.format = DataFormat::Uint16; cb.num_components = 1; cb.binding = 3;
+      cb.size = 2; cb.stride = 2; cb.sgpr_base = 8; cb.fetch_pc = 1;
+      cb.host_data = reinterpret_cast<uint8_t*>(&tail_host_value); cb.host_data_size = 2;
+      rtT13tail.resources.push_back(cb); }
+    const std::vector<uint32_t> spvT13tail = recompile_valu(
+        codeT13tail, std::size(codeT13tail), 1, 0, &rtT13tail);
+    uint32_t shell_binding_value = 0;
+    ShaderResourceTable rtT13tailValidation = rtT13tail;
+    for (uint32_t binding : {0u, 1u}) {
+        ShaderResource shell{};
+        shell.cls = ResourceClass::ConstantBuffer;
+        shell.format = DataFormat::Uint32;
+        shell.num_components = 1;
+        shell.binding = binding;
+        shell.size = sizeof(shell_binding_value);
+        shell.stride = sizeof(shell_binding_value);
+        shell.host_data = reinterpret_cast<uint8_t*>(&shell_binding_value);
+        shell.host_data_size = sizeof(shell_binding_value);
+        rtT13tailValidation.resources.push_back(shell);
+    }
+    const DescriptorValidationReport tail_report = validate_spirv_descriptor_interface(
+        spvT13tail, &rtT13tailValidation, 0, SpirvShaderStage::Compute, false);
+    const SpirvDescriptorBinding* tail_binding =
+        find_spirv_descriptor_binding(tail_report, 0, 3);
+    for (const auto& descriptor : tail_report.descriptors)
+        printf("  T13 tail descriptor binding=%u required=%llu%s zero-pad=%llu->%llu\n",
+               descriptor.binding, (unsigned long long)descriptor.required_bytes,
+               descriptor.dynamic_access ? "+dynamic" : "",
+               (unsigned long long)descriptor.zero_pad_logical_bytes,
+               (unsigned long long)descriptor.zero_pad_binding_bytes);
+    for (const auto& issue : tail_report.issues)
+        printf("  T13 tail issue=%s error=%d binding=%u required=%llu available=%llu\n",
+               descriptor_issue_name(issue.code), issue.error, issue.binding,
+               (unsigned long long)issue.required_bytes,
+               (unsigned long long)issue.available_bytes);
+    CHECK(!spvT13tail.empty() && tail_report.ok() && tail_binding &&
+          tail_binding->required_bytes == 4 && !tail_binding->dynamic_access &&
+          tail_binding->zero_pad_logical_bytes == 2 &&
+          tail_binding->zero_pad_binding_bytes == 4 &&
+          tail_binding->zero_pad_semantic == StorageBufferTailSemantic::Uint16,
+          "one-record Uint16 format load reflects and accepts the strict 2 -> 4 contract");
+    const std::vector<float> tail_indices = {0.0f, 1.0f};
+    const std::vector<uint32_t> poisoned_tail_word = {0xdead1234u};
+    const std::vector<float> gotT13tail = prosper::test::run_compute(
+        spvT13tail, tail_indices, 2, 2, {}, poisoned_tail_word);
+    CHECK(gotT13tail.size() == 2 && gotT13tail[0] == 0x1234u && gotT13tail[1] == 0.0f,
+          "one-record Uint16 format load returns record 0 and rejects the poisoned padded record");
+
+    const uint32_t codeT13floatTail[] = {
+        0x7e020f00u,                         // v1 = uint(input v0): record index
+        0xe0002000u, 0x80020101u,           // format_x v1, v1, s[8:11], idxen
+        0xbf8c3f70u, 0xbf810000u,
+    };
+    uint16_t float_tail_host_value = 0x3e00u; // binary16 1.5
+    ShaderResourceTable rtT13floatTail;
+    { ShaderResource cb{}; cb.cls = ResourceClass::ConstantBuffer;
+      cb.format = DataFormat::Float16; cb.num_components = 1; cb.binding = 3;
+      cb.size = 2; cb.stride = 2; cb.sgpr_base = 8; cb.fetch_pc = 1;
+      cb.host_data = reinterpret_cast<uint8_t*>(&float_tail_host_value); cb.host_data_size = 2;
+      rtT13floatTail.resources.push_back(cb); }
+    const std::vector<uint32_t> spvT13floatTail = recompile_valu(
+        codeT13floatTail, std::size(codeT13floatTail), 1, 1, &rtT13floatTail);
+    ShaderResourceTable rtT13floatTailValidation = rtT13floatTail;
+    rtT13floatTailValidation.resources.insert(
+        rtT13floatTailValidation.resources.end(),
+        rtT13tailValidation.resources.end() - 2,
+        rtT13tailValidation.resources.end());
+    const DescriptorValidationReport float_tail_report = validate_spirv_descriptor_interface(
+        spvT13floatTail, &rtT13floatTailValidation, 0, SpirvShaderStage::Compute, false);
+    const SpirvDescriptorBinding* float_tail_binding =
+        find_spirv_descriptor_binding(float_tail_report, 0, 3);
+    const std::vector<uint32_t> poisoned_float_tail_word = {0xdead3e00u};
+    const std::vector<float> gotT13floatTail = prosper::test::run_compute(
+        spvT13floatTail, tail_indices, 2, 2, {}, poisoned_float_tail_word);
+    CHECK(!spvT13floatTail.empty() && float_tail_report.ok() && float_tail_binding &&
+          float_tail_binding->zero_pad_semantic == StorageBufferTailSemantic::Float16 &&
+          gotT13floatTail.size() == 2 && gotT13floatTail[0] == 1.5f &&
+          gotT13floatTail[1] == 0.0f,
+          "one-record Float16 format load unpacks record 0 and rejects the poisoned padded record");
+
+    const uint32_t codeT13threeTail[] = {
+        0x7e020f00u,
+        0xe0002000u, 0x80020101u,           // pc 1: s[8:11]  -> binding 6
+        0xe0002000u, 0x80030101u,           // pc 3: s[12:15] -> binding 8
+        0xe0002000u, 0x80040101u,           // pc 5: s[16:19] -> binding 10
+        0xbf8c3f70u, 0x7e000d01u, 0xbf810000u,
+    };
+    uint16_t three_tail_values[] = {0x3c00u, 0x4000u, 0x4200u};
+    ShaderResourceTable rtT13threeTail;
+    for (uint32_t i = 0; i < 3; ++i) {
+        ShaderResource cb{};
+        cb.cls = ResourceClass::ConstantBuffer;
+        cb.format = DataFormat::Float16;
+        cb.num_components = 1;
+        cb.binding = 6u + i * 2u;
+        cb.size = 2;
+        cb.stride = 2;
+        cb.sgpr_base = 8u + i * 4u;
+        cb.fetch_pc = 1u + i * 2u;
+        cb.host_data = reinterpret_cast<uint8_t*>(&three_tail_values[i]);
+        cb.host_data_size = 2;
+        rtT13threeTail.resources.push_back(cb);
+    }
+    const std::vector<uint32_t> spvT13threeTail = recompile_valu(
+        codeT13threeTail, std::size(codeT13threeTail), 1, 0, &rtT13threeTail);
+    ShaderResourceTable rtT13threeTailValidation = rtT13threeTail;
+    rtT13threeTailValidation.resources.insert(
+        rtT13threeTailValidation.resources.end(),
+        rtT13tailValidation.resources.end() - 2,
+        rtT13tailValidation.resources.end());
+    const DescriptorValidationReport three_tail_report = validate_spirv_descriptor_interface(
+        spvT13threeTail, &rtT13threeTailValidation, 0, SpirvShaderStage::Compute, false);
+    for (const auto& descriptor : three_tail_report.descriptors)
+        printf("  T13 three-tail descriptor binding=%u required=%llu%s zero-pad=%llu->%llu\n",
+               descriptor.binding, (unsigned long long)descriptor.required_bytes,
+               descriptor.dynamic_access ? "+dynamic" : "",
+               (unsigned long long)descriptor.zero_pad_logical_bytes,
+               (unsigned long long)descriptor.zero_pad_binding_bytes);
+    for (const auto& issue : three_tail_report.issues)
+        printf("  T13 three-tail issue=%s error=%d binding=%u required=%llu available=%llu\n",
+               descriptor_issue_name(issue.code), issue.error, issue.binding,
+               (unsigned long long)issue.required_bytes,
+               (unsigned long long)issue.available_bytes);
+    bool all_three_tail_bindings = three_tail_report.ok();
+    for (uint32_t binding : {6u, 8u, 10u}) {
+        const SpirvDescriptorBinding* reflected =
+            find_spirv_descriptor_binding(three_tail_report, 0, binding);
+        all_three_tail_bindings &= reflected && reflected->required_bytes == 4 &&
+            !reflected->dynamic_access && reflected->zero_pad_logical_bytes == 2 &&
+            reflected->zero_pad_binding_bytes == 4 &&
+            reflected->zero_pad_semantic == StorageBufferTailSemantic::Float16;
+    }
+    CHECK(!spvT13threeTail.empty() && all_three_tail_bindings,
+          "Plucky reduced contract accepts all three one-record bindings 6/8/10");
+
+    const uint32_t codeT13rawTail[] = {
+        0x7e020f00u,
+        0xe0302000u, 0x80020101u,           // raw buffer_load_dword, same size-2 V#
+        0xbf8c3f70u, 0x7e000d01u, 0xbf810000u,
+    };
+    const std::vector<uint32_t> spvT13rawTail = recompile_valu(
+        codeT13rawTail, std::size(codeT13rawTail), 1, 0, &rtT13tail);
+    const DescriptorValidationReport raw_tail_report = validate_spirv_descriptor_interface(
+        spvT13rawTail, &rtT13tailValidation, 0, SpirvShaderStage::Compute, false);
+    const SpirvDescriptorBinding* raw_tail_binding =
+        find_spirv_descriptor_binding(raw_tail_report, 0, 3);
+    bool raw_tail_undersized = false;
+    for (const auto& issue : raw_tail_report.issues)
+        raw_tail_undersized |= issue.error && issue.code == DescriptorIssueCode::UndersizedBuffer &&
+                              issue.required_bytes == 4 && issue.available_bytes == 2;
+    CHECK(!spvT13rawTail.empty() && !raw_tail_report.ok() && raw_tail_binding &&
+          raw_tail_binding->zero_pad_logical_bytes == 0 && raw_tail_undersized,
+          "raw u32 load against the same two-byte V# remains rejected required=4 available=2");
+
     // Kernel T14: SINT8x1 vertex fetch — sign-extended integer. Same code; V# format Sint8; the
     // final convert is v_cvt_f32_i32 so -1 (0xFF) comes back as -1.0.
     const uint32_t codeT14[] = { 0x7e020f00u, 0xe0002000u, 0x80020101u, 0xbf8c3f70u, 0x7e000b01u, 0xbf810000u };

--- a/prosper/tests/test_shader_recompile_cache.cpp
+++ b/prosper/tests/test_shader_recompile_cache.cpp
@@ -480,6 +480,46 @@ int main() {
               changed_compute != direct_compute && stats.misses == 2 && stats.hits == 1,
           "compute cache reuses push-constant variants and separates launch-specialized modules");
 
+    // A one-record 16-bit V# emits an explicit index guard and typed tail marker. Keep the cache
+    // partition compact (none/u16/f16), while ensuring a wider range or the sibling conversion can
+    // never reuse that specialized module.
+    clear_shader_recompile_cache();
+    static const uint32_t kTailCompute[] = {
+        0xe0002000u, 0x80020100u, // buffer_load_format_x v1, v0, s[8:11], idxen
+        0xbf810000u,
+    };
+    ShaderResource tail_buffer;
+    tail_buffer.cls = ResourceClass::ConstantBuffer;
+    tail_buffer.format = DataFormat::Uint16;
+    tail_buffer.num_components = 1;
+    tail_buffer.binding = 3;
+    tail_buffer.size = 2;
+    tail_buffer.stride = 2;
+    tail_buffer.sgpr_base = 8;
+    tail_buffer.fetch_pc = 0;
+    ShaderResourceTable tail_table;
+    tail_table.resources.push_back(tail_buffer);
+    ComputeShaderConfig tail_config;
+    tail_config.user_sgprs.resize(12);
+    tail_config.local_x = 64;
+    const auto cached_u16_tail = recompile_compute_shader_cached(
+        kTailCompute, std::size(kTailCompute), &tail_table, tail_config);
+    tail_table.resources[0].size = 4;
+    const auto cached_wide_tail = recompile_compute_shader_cached(
+        kTailCompute, std::size(kTailCompute), &tail_table, tail_config);
+    tail_table.resources[0].size = 2;
+    tail_table.resources[0].format = DataFormat::Float16;
+    const auto cached_f16_tail = recompile_compute_shader_cached(
+        kTailCompute, std::size(kTailCompute), &tail_table, tail_config);
+    tail_table.resources[0].format = DataFormat::Uint16;
+    const auto repeated_u16_tail = recompile_compute_shader_cached(
+        kTailCompute, std::size(kTailCompute), &tail_table, tail_config);
+    stats = shader_recompile_cache_stats();
+    CHECK(!cached_u16_tail.empty() && !cached_wide_tail.empty() && !cached_f16_tail.empty() &&
+              cached_u16_tail != cached_wide_tail && cached_u16_tail != cached_f16_tail &&
+              repeated_u16_tail == cached_u16_tail && stats.misses == 3 && stats.hits == 1,
+          "compute cache partitions ordinary/u16/f16 one-record tail semantics exactly");
+
     // Resource descriptor fields that specialize SPIR-V must participate in the cache identity.
     // Storage-image sRGB state changes whether the module declares a native float image or the raw
     // uint-channel fallback, even when the guest code and every binding/provenance field are equal.

--- a/prosper/tests/test_shader_resources.cpp
+++ b/prosper/tests/test_shader_resources.cpp
@@ -2,6 +2,7 @@
 // and the recompiler/pipeline lookups both halves rely on. Pure (no Vulkan), runs in CI.
 #include "../src/gpu/shader_resources.hpp"
 #include "../src/gpu/gpu_execute.hpp"
+#include "../frontends/shared/live_compute.hpp"
 #include <cstdio>
 #include <cstdlib>
 #include <initializer_list>
@@ -15,6 +16,47 @@ static int fails = 0;
 static void emit(std::vector<uint32_t>& spv, uint16_t op, std::initializer_list<uint32_t> words) {
     spv.push_back((static_cast<uint32_t>(words.size() + 1) << 16) | op);
     spv.insert(spv.end(), words.begin(), words.end());
+}
+
+static void emit_string(std::vector<uint32_t>& spv, uint16_t op, const char* string) {
+    std::vector<uint32_t> words;
+    uint32_t packed = 0;
+    uint32_t byte = 0;
+    do {
+        const uint8_t value = static_cast<uint8_t>(*string);
+        packed |= static_cast<uint32_t>(value) << (byte * 8u);
+        if (++byte == 4u) {
+            words.push_back(packed);
+            packed = 0;
+            byte = 0;
+        }
+        if (!value) break;
+        ++string;
+    } while (true);
+    if (byte) words.push_back(packed);
+    spv.push_back((static_cast<uint32_t>(words.size() + 1u) << 16u) | op);
+    spv.insert(spv.end(), words.begin(), words.end());
+}
+
+static std::vector<uint32_t> tail_marker_test_spirv(bool writable = false,
+                                                    bool dynamic = false) {
+    std::vector<uint32_t> s = {0x07230203u, 0x00010000u, 0, 32, 0};
+    emit(s, 15, {5, 20, 0x6e69616d, 0});                    // OpEntryPoint Compute %20 "main"
+    emit_string(s, 330, "Prosper.StorageBufferZeroPad=0,9,2,4,u16");
+    emit(s, 21, {1, 32, 0});                               // %1 = u32
+    emit(s, 29, {2, 1});                                   // %2 = runtime array u32
+    emit(s, 30, {3, 2});                                   // %3 = struct {%2}
+    emit(s, 32, {4, 12, 3});                               // %4 = StorageBuffer pointer to %3
+    emit(s, 32, {5, 12, 1});                               // %5 = StorageBuffer pointer to u32
+    emit(s, 43, {1, 6, 0});                                // %6 = 0
+    emit(s, 59, {4, 8, 12});                               // %8 = buffer
+    emit(s, 71, {2, 6, 4});                                // ArrayStride 4
+    emit(s, 72, {3, 0, 35, 0});                            // member 0 Offset 0
+    emit(s, 71, {8, 34, 0}); emit(s, 71, {8, 33, 9});     // set 0 binding 9
+    emit(s, 65, {5, 9, 8, 6, dynamic ? 20u : 6u});        // %9 = &buffer[0][index]
+    if (writable) emit(s, 62, {9, 6});                     // store %9
+    else emit(s, 61, {1, 10, 9});                         // %10 = load %9
+    return s;
 }
 
 static std::vector<uint32_t> descriptor_test_spirv() {
@@ -162,6 +204,130 @@ int main() {
     CHECK(data_format_bytes(DataFormat::Unorm8) == 1 && data_format_bytes(DataFormat::Sint8) == 1,
           "8-bit formats are 1 byte");
     CHECK(data_format_bytes(DataFormat::Unknown) == 0, "Unknown format is 0 bytes");
+
+    SpirvDescriptorBinding tail_descriptor;
+    tail_descriptor.kind = SpirvDescriptorKind::StorageBuffer;
+    tail_descriptor.required_bytes = 4;
+    tail_descriptor.readable = true;
+    tail_descriptor.zero_pad_logical_bytes = 2;
+    tail_descriptor.zero_pad_binding_bytes = 4;
+    tail_descriptor.zero_pad_semantic = StorageBufferTailSemantic::Uint16;
+    ShaderResource tail_resource;
+    tail_resource.cls = ResourceClass::ConstantBuffer;
+    tail_resource.format = DataFormat::Uint16;
+    tail_resource.num_components = 1;
+    tail_resource.size = 2;
+    tail_resource.stride = 2;
+    const StorageBufferMaterializationPlan tail_plan =
+        plan_storage_buffer_materialization(tail_descriptor, tail_resource);
+    const uint8_t tail_source[2] = {0x34, 0x12};
+    uint8_t tail_destination[4] = {0xa5, 0xa5, 0xa5, 0xa5};
+    CHECK(tail_plan.valid && tail_plan.zero_padded_tail &&
+          tail_plan.logical_bytes == 2 && tail_plan.binding_bytes == 4 &&
+          materialize_storage_buffer_bytes(
+              tail_plan, tail_source, sizeof(tail_source),
+              tail_destination, sizeof(tail_destination)) &&
+          tail_destination[0] == 0x34 && tail_destination[1] == 0x12 &&
+          tail_destination[2] == 0 && tail_destination[3] == 0,
+          "one-record Uint16 materialization copies two bytes and deterministically clears the tail");
+    ShaderResource ordinary_four_byte_resource = tail_resource;
+    ordinary_four_byte_resource.format = DataFormat::Uint32;
+    ordinary_four_byte_resource.size = 4;
+    ordinary_four_byte_resource.stride = 4;
+    SpirvDescriptorBinding ordinary_descriptor;
+    ordinary_descriptor.kind = SpirvDescriptorKind::StorageBuffer;
+    ordinary_descriptor.required_bytes = 4;
+    ordinary_descriptor.readable = true;
+    const StorageBufferMaterializationPlan ordinary_four_byte_plan =
+        plan_storage_buffer_materialization(
+            ordinary_descriptor, ordinary_four_byte_resource);
+    auto float_tail_descriptor = tail_descriptor;
+    float_tail_descriptor.zero_pad_semantic = StorageBufferTailSemantic::Float16;
+    ShaderResource float_tail_resource = tail_resource;
+    float_tail_resource.format = DataFormat::Float16;
+    const StorageBufferMaterializationPlan float_tail_plan =
+        plan_storage_buffer_materialization(float_tail_descriptor, float_tail_resource);
+    const auto tail_cache_discriminator =
+        prosper::frontend::compute_buffer_materialization_discriminator(tail_plan);
+    const auto ordinary_cache_discriminator =
+        prosper::frontend::compute_buffer_materialization_discriminator(
+            ordinary_four_byte_plan);
+    const auto float_tail_cache_discriminator =
+        prosper::frontend::compute_buffer_materialization_discriminator(float_tail_plan);
+    CHECK(ordinary_four_byte_plan.valid && float_tail_plan.valid &&
+          !(tail_cache_discriminator == ordinary_cache_discriminator) &&
+          !(tail_cache_discriminator == float_tail_cache_discriminator),
+          "persistent compute cache partitions logical2/u16/f16 from ordinary bound4 sources");
+    auto writable_tail_descriptor = tail_descriptor;
+    writable_tail_descriptor.writable = true;
+    CHECK(!plan_storage_buffer_materialization(
+               writable_tail_descriptor, tail_resource).valid,
+          "zero-padded tail contract rejects writable storage buffers");
+    SpirvDescriptorBinding partial_tail_descriptor;
+    partial_tail_descriptor.zero_pad_semantic = StorageBufferTailSemantic::Uint16;
+    CHECK(!plan_storage_buffer_materialization(
+               partial_tail_descriptor, tail_resource).valid,
+          "semantic-only partial zero-pad metadata fails closed");
+
+    uint8_t marker_host[2] = {0x34, 0x12};
+    tail_resource.binding = 9;
+    tail_resource.host_data = marker_host;
+    tail_resource.host_data_size = sizeof(marker_host);
+    ShaderResourceTable tail_runtime;
+    tail_runtime.resources.push_back(tail_resource);
+    const DescriptorValidationReport valid_tail_marker =
+        validate_spirv_descriptor_interface(
+            tail_marker_test_spirv(), &tail_runtime, 0, SpirvShaderStage::Compute, false);
+    const SpirvDescriptorBinding* valid_tail_binding =
+        find_spirv_descriptor_binding(valid_tail_marker, 0, 9);
+    CHECK(valid_tail_marker.ok() && valid_tail_binding &&
+          valid_tail_binding->zero_pad_logical_bytes == 2 &&
+          valid_tail_binding->zero_pad_binding_bytes == 4,
+          "strict zero-pad marker reflects one exact read-only constant-index SSBO contract");
+    ShaderResourceTable mismatched_tail_runtime = tail_runtime;
+    mismatched_tail_runtime.resources[0].format = DataFormat::Float16;
+    const DescriptorValidationReport mismatched_tail_marker =
+        validate_spirv_descriptor_interface(
+            tail_marker_test_spirv(), &mismatched_tail_runtime,
+            0, SpirvShaderStage::Compute, false);
+    CHECK(!mismatched_tail_marker.ok() &&
+          has_issue(mismatched_tail_marker, DescriptorIssueCode::InvalidBufferMetadata),
+          "u16 zero-pad marker rejects a runtime Float16 V# instead of inferring semantics");
+
+    auto malformed_tail_marker = tail_marker_test_spirv();
+    emit_string(malformed_tail_marker, 330,
+                "Prosper.StorageBufferZeroPad=0,9,two,4,u16");
+    auto duplicate_tail_marker = tail_marker_test_spirv();
+    emit_string(duplicate_tail_marker, 330,
+                "Prosper.StorageBufferZeroPad=0,9,2,4,u16");
+    auto wrong_binding_tail_marker = tail_marker_test_spirv();
+    emit_string(wrong_binding_tail_marker, 330,
+                "Prosper.StorageBufferZeroPad=0,10,2,4,u16");
+    auto non_ssbo_tail_marker = image_test_spirv();
+    emit_string(non_ssbo_tail_marker, 330,
+                "Prosper.StorageBufferZeroPad=1,4,2,4,u16");
+    auto unknown_semantic_tail_marker = tail_marker_test_spirv();
+    emit_string(unknown_semantic_tail_marker, 330,
+                "Prosper.StorageBufferZeroPad=0,9,2,4,unknown");
+    const auto strict_marker_rejects = [&](const std::vector<uint32_t>& spirv) {
+        const DescriptorValidationReport report = validate_spirv_descriptor_interface(
+            spirv, &tail_runtime, 0, SpirvShaderStage::Compute, false);
+        return !report.ok() && has_issue(report, DescriptorIssueCode::MalformedSpirv);
+    };
+    CHECK(strict_marker_rejects(malformed_tail_marker),
+          "malformed zero-pad marker rejects as malformed SPIR-V");
+    CHECK(strict_marker_rejects(unknown_semantic_tail_marker),
+          "unknown zero-pad semantic token rejects as malformed SPIR-V");
+    CHECK(strict_marker_rejects(duplicate_tail_marker),
+          "duplicate zero-pad marker for one binding rejects as malformed SPIR-V");
+    CHECK(strict_marker_rejects(wrong_binding_tail_marker),
+          "unconsumed zero-pad marker for the wrong binding rejects as malformed SPIR-V");
+    CHECK(strict_marker_rejects(tail_marker_test_spirv(true, false)),
+          "zero-pad marker inconsistent with a writable SSBO rejects as malformed SPIR-V");
+    CHECK(strict_marker_rejects(tail_marker_test_spirv(false, true)),
+          "zero-pad marker inconsistent with a dynamic SSBO access rejects as malformed SPIR-V");
+    CHECK(strict_marker_rejects(non_ssbo_tail_marker),
+          "zero-pad marker inconsistent with a non-SSBO descriptor rejects as malformed SPIR-V");
 
     CHECK(float_to_half(0.0f) == 0x0000u && float_to_half(-0.0f) == 0x8000u &&
           float_to_half(1.0f) == 0x3c00u && float_to_half(-2.0f) == 0xc000u &&

--- a/prosper/tools/gpu_replay/compute_recompile.hpp
+++ b/prosper/tools/gpu_replay/compute_recompile.hpp
@@ -110,4 +110,29 @@ inline bool recompile_failed_compute_stage(
     return true;
 }
 
+// A retry is diagnostic recompilation, not a bypass around the live descriptor contract. Validate
+// the resulting module with the same stage/set mapping used by execution so a capsule cannot report
+// "recompiled" while the live backend will immediately reject its resources.
+inline gpu::DescriptorValidationReport validate_recompiled_failed_stage_contract(
+    gpu::ShaderProgramStage stage,
+    const std::vector<uint32_t>& spirv,
+    const gpu::ShaderResourceTable* resources) {
+    uint32_t set = 0;
+    gpu::SpirvShaderStage spirv_stage = gpu::SpirvShaderStage::Unknown;
+    switch (stage) {
+        case gpu::ShaderProgramStage::Vertex:
+            spirv_stage = gpu::SpirvShaderStage::Vertex;
+            break;
+        case gpu::ShaderProgramStage::Fragment:
+            set = 1;
+            spirv_stage = gpu::SpirvShaderStage::Fragment;
+            break;
+        case gpu::ShaderProgramStage::Compute:
+            spirv_stage = gpu::SpirvShaderStage::Compute;
+            break;
+    }
+    return gpu::validate_spirv_descriptor_interface(
+        spirv, resources, set, spirv_stage, false);
+}
+
 } // namespace prosper::tools

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -2186,12 +2186,27 @@ int main(int argc, char** argv) {
                 }
                 break;
         }
+        const prosper::gpu::DescriptorValidationReport retry_contract =
+            prosper::tools::validate_recompiled_failed_stage_contract(
+                stage.stage, spirv, resources);
         std::fprintf(stderr,
-                     "[retry-failed-stage] %s %s resources=%zu spirv-dwords=%zu\n",
+                     "[retry-failed-stage] %s %s resources=%zu spirv-dwords=%zu contract=%s\n",
                      retry_failed_stage_spec.c_str(),
                      spirv.empty() ? "rejected" : "recompiled",
-                     table.resources.size(), spirv.size());
-        if (positional.size() == 1 && !inspect) return spirv.empty() ? 1 : 0;
+                     table.resources.size(), spirv.size(),
+                     retry_contract.ok() ? "accepted" : "rejected");
+        for (const auto& issue : retry_contract.issues) {
+            if (!issue.error) continue;
+            std::fprintf(stderr,
+                         "[retry-failed-stage] contract error=%s set=%u binding=%u "
+                         "required=%llu available=%llu\n",
+                         prosper::gpu::descriptor_issue_name(issue.code), issue.set,
+                         issue.binding,
+                         static_cast<unsigned long long>(issue.required_bytes),
+                         static_cast<unsigned long long>(issue.available_bytes));
+        }
+        if (positional.size() == 1 && !inspect)
+            return spirv.empty() || !retry_contract.ok() ? 1 : 0;
     }
     if (!compute_shader_spec.empty()) {
         char* end = nullptr;


### PR DESCRIPTION
## Summary

- recognize only proven one-record scalar `Uint16` and `Float16` `buffer_load_format_x` programs
- reflect a strict typed materialization contract into the runtime descriptor interface
- copy the exact two guest bytes into a deterministic zero-padded four-byte Vulkan storage-buffer binding
- partition the persistent compute-buffer cache by logical size, bound size, and scalar semantic
- fail closed for writable, dynamic, aliased, mismatched, or otherwise ordinary buffer accesses

## Evidence

This advances #1554 and #1390. After #1559 removed the first opcode wall in Plucky Squire compute program `0x3017d90000`, its retained failed stage reached a precise descriptor rejection: one read-only scalar 16-bit record had two logical guest bytes while the portable Vulkan ABI needs one four-byte word.

The exact thin capsule at `/var/home/mattias800/plucky-work/op1554-thin/program3017d9-thin.prgcap` now retries successfully:

```text
[retry-failed-stage] 0:0 recompiled resources=27 spirv-dwords=7429 contract=accepted
```

This PR does not claim a visual improvement yet. The first unmodified guest A/B is deliberately scheduled after merge on the exact merged revision; title-derived capsule data remains local and is not committed.

## Verification

- `test_shader_resources`
- `test_gpu_replay_shader_dump`
- `test_shader_recompile_cache`
- full Vulkan `test_rdna2_to_spirv` in distrobox
- `prosper_live_renderer` build
- `gpu_replay` build
- exact retained capsule retry
- `git diff --check`

Snapshot tests are intentionally deferred under the project development policy; they are required for releases, and this is not a release.