### PR TITLE
gpu: structure scalar multi-loops

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -3726,8 +3726,8 @@ CountedLoop detect_counted_loop(const std::vector<Rdna2Inst>& ins) {
     return L;
 }
 
-// DIVERGENT EXEC/VCC-EXIT LOOPS (#273/#615 — post-process and light-accumulation PSes, the title-composite
-// content producers). The compiled shape:
+// MULTI-LOOP EXEC/VCC/SCC EXITS (#273/#615/#1554 — post-process and light-accumulation PSes,
+// title-composite content producers, and compute histogram loops). The divergent compiled shape:
 //     header: <exec recompute: v_cmpx_.. counter,bound  |  v_cmp..;s_andn2_b64 exec,exec,vcc>
 //             s_cbranch_execz EXIT                      ; leave when no lane remains
 //     body:   ... (nested forward-execz if regions, saveexec/restore, scalar counter++) ...
@@ -3746,15 +3746,18 @@ CountedLoop detect_counted_loop(const std::vector<Rdna2Inst>& ins) {
 // supports a VCCZ break with an unconditional back-edge by carrying the uniform continue vote to the
 // loop latch and branching the complete wave directly to the loop merge.
 struct DivLoop {
-    enum class Condition : uint8_t { Exec, Vcc };
+    enum class Condition : uint8_t { Exec, Vcc, Scc };
     uint32_t header_pc = 0;        // back-edge target; condition region = [header_pc, exit_branch_pc)
-    uint32_t exit_branch_pc = 0;   // canonical forward execz/vccz branch whose target is exit_pc
+    uint32_t exit_branch_pc = 0;   // canonical forward execz/vccz/scc branch whose target is exit_pc
     uint32_t backedge_pc = 0;      // backward s_branch (unconditional) or s_cbranch_execnz
     uint32_t exit_pc = 0;          // backedge_pc + its length (first pc after the loop)
     std::vector<uint32_t> break_pcs;   // extra forward vccz/execz -> exit_pc (lowered as body ifs)
     bool direct_exec_breaks = false;   // unconditional back-edge: an interior execz exits directly
     bool direct_wave_breaks = false;   // fragment wave64: an interior vccz exits the complete wave
     Condition condition = Condition::Exec;
+    // EXECZ/VCCZ and SCC0 all continue while their represented predicate is set. SCC1 is the one
+    // admitted opposite-polarity canonical exit: it leaves the loop while SCC is set.
+    bool continue_on_set = true;
 };
 
 // Number of consecutive VGPRs an instruction writes, starting at dst. This is intentionally an
@@ -4042,6 +4045,13 @@ std::vector<DivLoop> detect_divergent_loops(const std::vector<Rdna2Inst>& ins,
                         // Fragment reduces the real VCC mask through a forced wave64 vote. Other
                         // structured stages require the compare to be proven uniform first.
                         L.condition = DivLoop::Condition::Vcc;
+                    } else if ((in.opcode == 0x04 || in.opcode == 0x05) && !execnz) {
+                        // A scalar SCC exit with an unconditional back-edge is the same canonical
+                        // top-tested while loop accepted by CountedLoop. Keep it in this multi-loop
+                        // region form when several disjoint/nested loops coexist in one shader.
+                        // scc0 exits while SCC==0 (continue on set); scc1 has the opposite polarity.
+                        L.condition = DivLoop::Condition::Scc;
+                        L.continue_on_set = in.opcode == 0x04;
                     } else {
                         return {};
                     }
@@ -4252,6 +4262,7 @@ std::vector<ForwardIf> detect_forward_ifs(const std::vector<Rdna2Inst>& ins, boo
                 }
                 break;
             case 0x04: case 0x05:                                    // scc0 / scc1
+                if (loop_exit(in.pc)) continue;                      // scalar loop condition: loop emitter owns it
                 if (skip && skip->count(in.pc)) continue;            // kill-mask branch: linearized, not an if
                 break;
             default: continue;                                       // hints
@@ -6344,6 +6355,25 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     rs.sreg[in.dst.value] = b.ibin(
                         Op_IMul, a, b.uconst(static_cast<uint32_t>(in.simm16)));
                     rs.sreg_srt.erase(in.dst.value);
+                    break;
+                }
+                case 0x0F: {                                // s_addk_i32 (read-modify-write)
+                    // SIMM16 is sign-extended, the destination receives the low 32 bits, and SCC
+                    // reports signed overflow. This is the immediate form of SOP2 s_add_i32, so use
+                    // the same two's-complement overflow identity: (~(a^c)) & (a^d), bit 31.
+                    const uint32_t a = val(in.dst);
+                    const uint32_t c = b.uconst(static_cast<uint32_t>(in.simm16));
+                    const uint32_t d = b.ibin(Op_IAdd, a, c);
+                    const uint32_t overflow = b.ibin(
+                        Op_BitwiseAnd,
+                        b.iun(Op_Not, b.ibin(Op_BitwiseXor, a, c)),
+                        b.ibin(Op_BitwiseXor, a, d));
+                    rs.sreg[in.dst.value] = d;
+                    rs.sreg_srt.erase(in.dst.value);
+                    rs.scc = b.ucmp(
+                        Op_INotEqual,
+                        b.ibin(Op_ShiftRightLogical, overflow, b.uconst(31)),
+                        b.uconst(0));
                     break;
                 }
                 case 0x03: case 0x04: case 0x05: case 0x06:
@@ -13227,7 +13257,7 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
             !emit_body(b, rs, postloop, effective_safe, rt, allow_exec_update, allow_smem,
                        exp_fn, code, dwords)) return false;
     } else if (std::vector<DivLoop> Ls; true) {
-        // EXEC/VCC-exit loops (#273/#615) + structured scalar IFs. Each is a real structured SPIR-V
+        // EXEC/VCC/SCC-exit loops (#273/#615/#1554) + structured scalar IFs. Each is a real SPIR-V
         // loop with header phis for carried register/mask state. Fragment conditions are exact wave64
         // votes; vertex and the guarded compute cases retain their per-invocation form. The IF
         // machinery recurses into loop bodies and handles their nested forward-execz regions.
@@ -13247,6 +13277,8 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
             //     workgroup-divergent control flow (UB). DOLL's blocked light/fill kernels are
             //     straight-line bodies, so nothing observed is lost. CONFIDENCE: MED-HIGH (shared
             //     emit machinery; spirv-val + coverage tests + Messenger guard gate it).
+            // SCC-condition loops use exact architectural scalar control and may retain ordinary
+            // LDS effects; their synchronized/cross-lane operations remain rejected below.
             // Condition::Vcc loops are accepted under the detector's uniformity proof (#615/#590).
             // Condition::Exec loops (#590 — DOLL's nested post-process kernel is the observed compute
             // case) lower with the per-invocation model: this invocation
@@ -13260,7 +13292,15 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                 for (const auto& in : ins) {
                     if (in.is_end || in.pc >= L.exit_pc) break;
                     if (in.pc < L.header_pc) continue;
-                    if (in.fmt == Rdna2Format::DS ||
+                    const bool ds_wave_collective = in.fmt == Rdna2Format::DS &&
+                        (in.opcode == 0x35 || in.opcode == 0x3d || in.opcode == 0x3e);
+                    // SCC is architectural scalar control, so an SCC loop executes ordinary LDS
+                    // effects uniformly within each guest wave just like the existing CountedLoop
+                    // path. EXEC/VCC loops retain their per-invocation approximation and therefore
+                    // keep rejecting all LDS. Cross-lane DS collectives, MBCNT, and a guest barrier
+                    // remain unavailable in every multi-loop condition domain.
+                    if ((in.fmt == Rdna2Format::DS &&
+                         (L.condition != DivLoop::Condition::Scc || ds_wave_collective)) ||
                         (in.fmt == Rdna2Format::SOPP && in.opcode == 0x0a) ||
                         (in.fmt == Rdna2Format::VOP3 &&
                          (in.opcode == 0x365 || in.opcode == 0x366))) { compute_ok = false; break; }
@@ -13423,7 +13463,7 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
         // uses its exact guest-wave reduction paths. Either may enter/leave with EXEC narrowed, and
         // EXEC is phi'd across the merge like any other value.
         std::function<bool(uint32_t, uint32_t, uint32_t)> emit_structured;
-        // Emit one EXEC/VCC-exit loop (#273/#615) as structured SPIR-V. Same block shape as
+        // Emit one EXEC/VCC/SCC-exit loop (#273/#615/#1554) as structured SPIR-V. Same block shape as
         // the counted-loop path (hdr -> chk -> body -> cont -> hdr, exit chk->merge) with three
         // differences: (1) fragment votes the complete wave's EXEC/VCC after the header recompute
         // (other guarded stages consume this lane's bool); (2) the body is
@@ -13464,25 +13504,36 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
             for (int k : mask_keys) { size_t p; uint32_t ph = b.emit_phi2(b.t_bool, rs.sreg_bool[k], preheader, p); rs.sreg_bool[k] = ph; phis.push_back({k, 5, ph, p}); }
             invalidate_loop_descriptor_provenance(rs, scalar_may_writes);
             b.emit_loopmerge(merge, cont); b.emit_branch(chk); b.emit_label(chk);
-            // An EXEC-governed loop predicates vector writes. A VCC-governed loop branches on this
-            // invocation's VCC bit but does not itself change EXEC, matching the hardware loop body.
+            // An EXEC-governed loop predicates vector writes. VCC/SCC-governed loops branch on their
+            // represented predicate but do not themselves change EXEC, matching the hardware body.
             if (L.condition == DivLoop::Condition::Exec) rs.exec_narrowed = true;
             // Condition region [header, exit_branch): branch-free (validated), straight-line.
+            const uint32_t condition_entry_scc = rs.scc;
             if (!emit_range(L.header_pc, L.exit_branch_pc)) return false;
+            // A canonical SCC loop must compute a fresh representable scalar predicate on every
+            // header visit. Reusing the header phi would admit stale SCC, while a B64 wave-mask
+            // producer poisons rs.scc to zero; both remain fail-visible.
+            if (L.condition == DivLoop::Condition::Scc &&
+                (!rs.scc || rs.scc == condition_entry_scc))
+                return false;
             // chk-end snapshots: the exit path flows THROUGH this block, so these dominate the merge.
             std::unordered_map<int, uint32_t> condv_val, conds_val;
             for (int r : condv) condv_val[r] = vget(r);
             for (int r : conds) conds_val[r] = sget(r);
             const uint32_t exec_chk = rs.exec, vcc_chk = rs.vcc, scc_chk = rs.scc;
             const std::unordered_map<int, uint32_t> bool_chk = rs.sreg_bool;
-            uint32_t loop_cond = L.condition == DivLoop::Condition::Exec ? rs.exec : rs.vcc;
+            uint32_t loop_cond = L.condition == DivLoop::Condition::Exec ? rs.exec
+                               : L.condition == DivLoop::Condition::Vcc ? rs.vcc : rs.scc;
             if (!loop_cond) return false;
+            if (!L.continue_on_set)
+                loop_cond = b.logical_not(loop_cond);
             // EXECZ/VCCZ are scalar wave decisions. Keeping every fragment invocation in the loop
             // until the complete guest wave becomes empty makes scalar state and nested wave votes
             // exact; vector writes remain predicated by the per-lane EXEC bool.
-            if (b.is_fragment) loop_cond = b.fragment_wave_any(loop_cond);
+            if (b.is_fragment && L.condition != DivLoop::Condition::Scc)
+                loop_cond = b.fragment_wave_any(loop_cond);
             const uint32_t chk_end = b.cur_block;
-            b.emit_condbranch(loop_cond, body, merge);         // execz/vccz exit: continue while bit set
+            b.emit_condbranch(loop_cond, body, merge);         // canonical exit: branch on continue predicate
             while (idx < ins.size() && ins[idx].pc < L.exit_branch_pc) ++idx;
             if (idx < ins.size() && ins[idx].pc == L.exit_branch_pc) ++idx;   // consume the exit branch
             b.emit_label(body);

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -2754,6 +2754,144 @@ int main() {
     std::vector<uint32_t> spv44e = recompile_valu(code44e, sizeof(code44e)/sizeof(code44e[0]), 0, 0);
     CHECK(spv44e.empty(), "kernel 44e: do-while with inner forward scc break conservatively rejects");
 
+    // Kernel 44f (#1554): two SEQUENTIAL top-tested scalar loops. CountedLoop deliberately owns only
+    // one back-edge, so this exercises the multi-loop structurizer's SCC condition alongside ordinary
+    // LDS effects. The second loop contains Plucky's nested EXECZ arm; barriers remain outside both
+    // loops. Each invocation owns one LDS dword: loop 1 adds 1 three times, loop 2 adds 2 three times,
+    // and the final read therefore returns 9.
+    const uint32_t code44f[] = {
+        0x7E020F00u,              //  0: v_cvt_u32_f32 v1,v0 (lane-local LDS index)
+        0x34020282u,              //  1: v_lshlrev_b32 v1,2,v1 (byte address)
+        0x7E040280u,              //  2: v_mov_b32 v2,0 (accumulator)
+        0xBE800380u,              //  3: s_mov_b32 s0,0 (loop-1 counter)
+        0xBE810380u,              //  4: s_mov_b32 s1,0 (loop-2 counter)
+        0xB0020003u,              //  5: s_movk_i32 s2,3 (bound)
+        0xBF8A0000u,              //  6: s_barrier (before both loops)
+        0xBF0A0200u,              //  7: L1: s_cmp_lt_u32 s0,s2
+        0xBF840005u,              //  8: s_cbranch_scc0 -> pc14 (exact loop exit)
+        0x4A040481u,              //  9: v_add_nc_u32 v2,1,v2
+        0xD8340000u, 0x00000201u, // 10: ds_write_b32 v1,v2
+        0x81008100u,              // 12: s_add_i32 s0,s0,1
+        0xBF82FFF9u,              // 13: s_branch -> pc7
+        0xBF0A0201u,              // 14: L2: s_cmp_lt_u32 s1,s2
+        0xBF84000Au,              // 15: s_cbranch_scc0 -> pc26 (exact loop exit)
+        0xBE84047Eu,              // 16: save EXEC in s[4:5]
+        0x7D840100u,              // 17: v_cmp_eq_u32 vcc,v0,v0 (all lanes active)
+        0xBEFE046Au,              // 18: s_mov_b64 exec,vcc
+        0xBF880003u,              // 19: s_cbranch_execz -> pc23 (nested arm)
+        0x4A040482u,              // 20: v_add_nc_u32 v2,2,v2
+        0xD8340000u, 0x00000201u, // 21: ds_write_b32 v1,v2
+        0xBEFE0404u,              // 23: restore EXEC from s[4:5]
+        0x81018101u,              // 24: s_add_i32 s1,s1,1
+        0xBF82FFF4u,              // 25: s_branch -> pc14
+        0xBF8A0000u,              // 26: s_barrier (after both loops)
+        0xD8D80000u, 0x03000001u, // 27: ds_read_b32 v3,v1
+        0xBF8CC07Fu,              // 29: s_waitcnt
+        0x7E000D03u,              // 30: v_cvt_f32_u32 v0,v3
+        0xBF810000u,              // 31: s_endpgm
+    };
+    const std::vector<uint32_t> spv44f = recompile_valu(
+        code44f, std::size(code44f), 1, 0);
+    CHECK(!spv44f.empty(),
+          "kernel 44f: two sequential SCC0 loops + LDS + nested EXECZ recompile");
+    std::vector<float> in44f(64);
+    for (uint32_t i = 0; i < in44f.size(); ++i) in44f[i] = static_cast<float>(i);
+    const std::vector<float> got44f = prosper::test::run_compute(spv44f, in44f, 64, 64);
+    CHECK(got44f.size() == 64 &&
+              std::all_of(got44f.begin(), got44f.end(), [](float value) { return value == 9.0f; }),
+          "kernel 44f: sequential scalar loops preserve PHIs and ordinary LDS effects");
+
+    // The same second loop with the opposite canonical polarity: GE sets SCC at the bound and SCC1
+    // exits. This locks the polarity bit independently of the retained game's SCC0 encoding.
+    std::vector<uint32_t> code44f_scc1(std::begin(code44f), std::end(code44f));
+    code44f_scc1[14] = 0xBF090201u; // s_cmp_ge_u32 s1,s2
+    code44f_scc1[15] = 0xBF85000Au; // s_cbranch_scc1 -> pc26
+    const std::vector<uint32_t> spv44f_scc1 = recompile_valu(
+        code44f_scc1.data(), code44f_scc1.size(), 1, 0);
+    const std::vector<float> got44f_scc1 = prosper::test::run_compute(
+        spv44f_scc1, in44f, 64, 64);
+    CHECK(!spv44f_scc1.empty() && got44f_scc1.size() == 64 &&
+              std::all_of(got44f_scc1.begin(), got44f_scc1.end(),
+                          [](float value) { return value == 9.0f; }),
+          "kernel 44f: SCC1 canonical exit uses the opposite loop polarity");
+
+    // Negative siblings retain fail-visible structural and predicate-domain rejection.
+    std::vector<uint32_t> code44f_bad_target(std::begin(code44f), std::end(code44f));
+    code44f_bad_target[8] = 0xBF840006u; // exits past pc14 instead of backedge+1
+    CHECK(recompile_valu(code44f_bad_target.data(), code44f_bad_target.size(), 1, 0).empty(),
+          "kernel 44f: SCC loop exit must target exactly backedge+1");
+
+    std::vector<uint32_t> code44f_extra_exit(std::begin(code44f), std::end(code44f));
+    code44f_extra_exit[10] = 0xBF060000u; // s_cmp_eq_u32 s0,s0
+    code44f_extra_exit[11] = 0xBF850002u; // second SCC exit -> pc14
+    CHECK(recompile_valu(code44f_extra_exit.data(), code44f_extra_exit.size(), 1, 0).empty(),
+          "kernel 44f: an extra SCC exit inside a canonical loop rejects");
+
+    std::vector<uint32_t> code44f_poisoned(std::begin(code44f), std::end(code44f));
+    code44f_poisoned[7] = 0x87866A6Au; // s_and_b64 s[6:7],vcc,vcc: SCC is a guest-wave reduction
+    CHECK(recompile_valu(code44f_poisoned.data(), code44f_poisoned.size(), 1, 0).empty(),
+          "kernel 44f: mask-poisoned SCC cannot control a scalar loop");
+
+    std::vector<uint32_t> code44f_inner_barrier(std::begin(code44f), std::end(code44f));
+    code44f_inner_barrier[9] = 0xBF8A0000u; // s_barrier inside loop 1
+    CHECK(recompile_valu(code44f_inner_barrier.data(), code44f_inner_barrier.size(), 1, 0).empty(),
+          "kernel 44f: a workgroup barrier inside an SCC loop rejects");
+
+    std::vector<uint32_t> code44f_inner_swizzle(std::begin(code44f), std::end(code44f));
+    code44f_inner_swizzle[10] = 0xD8D4020Fu; // ds_swizzle_b32 v0,v0 offset:0x020f
+    code44f_inner_swizzle[11] = 0x00000000u;
+    CHECK(recompile_valu(code44f_inner_swizzle.data(), code44f_inner_swizzle.size(), 1, 0).empty(),
+          "kernel 44f: a cross-lane DS collective inside an SCC loop rejects");
+
+    // Kernel 44g (#1554): SOPK s_addk_i32 is a signed-16 immediate read/modify/write. Its data result
+    // is the low 32-bit sum and SCC reports signed overflow, matching SOP2 s_add_i32.
+    const uint32_t code44g[] = {
+        0xB000000Au, // s_movk_i32 s0,10
+        0xB780FFFDu, // s_addk_i32 s0,-3
+        0x7E000200u, // v_mov_b32 v0,s0
+        0x7E000B00u, // v_cvt_f32_i32 v0,v0
+        0xBF810000u,
+    };
+    const std::vector<uint32_t> spv44g = recompile_valu(code44g, std::size(code44g), 0, 0);
+    const std::vector<float> got44g = prosper::test::run_compute(spv44g, {0.0f}, 1, 1);
+    CHECK(!spv44g.empty() && got44g.size() == 1 && got44g[0] == 7.0f,
+          "kernel 44g: s_addk_i32 sign-extends SIMM16 and writes the low-32 sum");
+
+    const uint32_t code44g_wrap[] = {
+        0xBE8003FFu, 0x7FFFFFFFu, // s_mov_b32 s0,INT_MAX
+        0xB7800001u,              // s_addk_i32 s0,1 -> INT_MIN bits
+        0x7E000200u,              // v_mov_b32 v0,s0
+        0x7E000B00u,              // v_cvt_f32_i32 v0,v0
+        0xBF810000u,
+    };
+    const std::vector<uint32_t> spv44g_wrap = recompile_valu(
+        code44g_wrap, std::size(code44g_wrap), 0, 0);
+    const std::vector<float> got44g_wrap = prosper::test::run_compute(
+        spv44g_wrap, {0.0f}, 1, 1);
+    CHECK(!spv44g_wrap.empty() && got44g_wrap.size() == 1 &&
+              got44g_wrap[0] == -2147483648.0f,
+          "kernel 44g: s_addk_i32 wraps the data result to the low 32 bits");
+
+    auto addk_overflow_result = [](uint32_t initial, uint32_t addk_word) {
+        const uint32_t code[] = {
+            0xBE8003FFu, initial, // s_mov_b32 s0,literal
+            addk_word,            // s_addk_i32 s0,imm
+            0x85018081u,          // s_cselect_b32 s1,1,0
+            0x7E000201u,          // v_mov_b32 v0,s1
+            0x7E000D00u,          // v_cvt_f32_u32 v0,v0
+            0xBF810000u,
+        };
+        const std::vector<uint32_t> spv = recompile_valu(code, std::size(code), 0, 0);
+        const std::vector<float> got = prosper::test::run_compute(spv, {0.0f}, 1, 1);
+        return got.size() == 1 ? got[0] : -1.0f;
+    };
+    CHECK(addk_overflow_result(0x7FFFFFFFu, 0xB7800001u) == 1.0f,
+          "kernel 44g: s_addk_i32 detects positive signed overflow");
+    CHECK(addk_overflow_result(0x80000000u, 0xB780FFFFu) == 1.0f,
+          "kernel 44g: s_addk_i32 detects negative signed overflow");
+    CHECK(addk_overflow_result(7u, 0xB7800001u) == 0.0f,
+          "kernel 44g: s_addk_i32 leaves SCC clear without signed overflow");
+
     // Kernel 45: EXEC-narrowed-state tracking regression (the review-flagged under-narrow bug). Save all-on
     //   exec to vcc; v_cmp overwrites vcc with a per-lane mask (lanes i<4); restore exec FROM vcc — exec is
     //   now narrowed, so v_mov v2,7 must be EXEC-predicated (only i<4 get 7; i>=4 keep 0). If the narrowed
@@ -2881,15 +3019,29 @@ int main() {
     CHECK(recompile_valu(code47c3.data(), code47c3.size(), 2, 3).empty(),
           "kernel 47c3 rejects when either post-merge branch path reads VCC scratch");
 
-    // Kernel 47d (NEGATIVE, soundness): s5 is written in the block, then an SOPK s_addk_i32 s5 (a
-    // read-modify-write whose SIMM16 operand leaves n_src==0) reads s5 after the merge -> s5 is LIVE. The
-    // liveness scan must NOT mistake the SOPK dst for a redefinition; the block must be rejected. Empty.
+    // Kernel 47d: s5 is written in the block, then SOPK s_addk_i32 s5 (a read-modify-write whose
+    // SIMM16 operand leaves n_src==0) reads s5 after the merge. The liveness scan must NOT mistake the
+    // SOPK dst for a redefinition and linearize the block. The exact wave-uniform EXECZ structurizer
+    // instead carries s5 through its merge, after which ADDK adds 16 to the raw 50.0f bit pattern.
     const uint32_t code47d[] = {
         0x7e0602ffu, 0x42c80000u, 0x7d880300u, 0xbe80246au, 0xbf880003u, 0xbe8503ffu, 0x42480000u,
         0x06060005u, 0xbefe0400u, 0xb7850010u, 0x06060605u, 0xbf810000u,
     };
     std::vector<uint32_t> spv47d = recompile_valu(code47d, sizeof(code47d)/sizeof(code47d[0]), 2, /*out_vgpr*/3);
-    CHECK(spv47d.empty(), "kernel 47d (SOPK RMW reads block scalar after merge) correctly REJECTED");
+    CHECK(!spv47d.empty(),
+          "kernel 47d (live SOPK RMW input uses structured wave-uniform EXECZ) recompiles");
+    float addk47d = 0.0f;
+    const uint32_t addk47d_bits = 0x42480010u;
+    std::memcpy(&addk47d, &addk47d_bits, sizeof(addk47d));
+    const std::vector<float> got47d = prosper::test::run_compute(spv47d, in18, N, N);
+    uint32_t bad47d = 0;
+    for (uint32_t i = 0; i < N && got47d.size() == N; ++i) {
+        const uint32_t u0 = i % 17, u1 = i % 13;
+        const float expected = (u0 > u1 ? static_cast<float>(u0) + 50.0f : 100.0f) + addk47d;
+        if (got47d[i] != expected) ++bad47d;
+    }
+    CHECK(got47d.size() == N && bad47d == 0,
+          "kernel 47d carries the live scalar into s_addk_i32 on both EXEC paths");
 
     // Kernel 48: v_mac_f32 (VOP2 0x1f) = src0*src1 + dst (accumulate). v3 = 3.0; v3 = a0*a1 + v3.
     // op 0x1f is v_mac_f32 on the PS5 ISA — the RDNA1/gfx1010 encoding (removed on desktop gfx1030, where


### PR DESCRIPTION
Progresses #1554.

## Failure scenario

The Plucky Squire compute program at `0x3017450000` contains two disjoint, top-tested scalar loops. The single-loop recognizer deliberately rejects streams with more than one backedge, while the multi-loop structurizer previously understood only EXEC and VCC exits. The stage therefore failed before SPIR-V emission. Its next decoded instruction also uses the previously unsupported `s_addk_i32` form.

## Behavioral contract

- Recognize only canonical SCC0/SCC1 loop exits that are the first branch in the condition region, target exactly the instruction after an unconditional backedge, and retain the existing nesting, disjointness, entry-edge, and break validation.
- Require every SCC loop header to produce a fresh, representable SCC value.
- Carry scalar, vector, mask, EXEC, VCC, and SCC values through the existing structured-loop PHIs.
- Permit ordinary LDS effects under scalar loop control while continuing to reject workgroup barriers, wave-collective DS operations, and MBCNT inside those loops.
- Implement `s_addk_i32` as a sign-extended 16-bit low-32 addition with architectural signed-overflow SCC behavior.

## Scope and risk

The new loop path is restricted to scalar SCC exits with unconditional backedges. Existing EXEC/VCC loops keep their prior LDS restrictions. Malformed targets, extra SCC exits, stale or poisoned SCC, barriers, and cross-lane DS collectives remain fail-visible. The principal risk is control-flow or PHI miscompilation; focused Vulkan execution tests exercise both branch polarities, sequential loop-carried state, LDS effects, and the negative boundaries.

## Verification

Exact head `1a6bf3668215fdef8abe16ecd03b55924574c20f`, rebased on master `7f89e60b4d70f4f843be22202d396cf75b0762ed`.

Passed 7/7 relevant suites:
- `recompile_coverage`
- `rdna2_spirv_struct`
- `game_compute_recompile`
- `game_compute_execution`
- `rdna2_to_spirv_exec`
- `recompiled_fragment_render`
- `recompiled_shaders_render`

`git diff --check` passes. The retained exact `0x3017450000` stage now reports 12 branches, 3 structured conditionals, 2 structured loops, zero control-flow rejection, exact-wave structured execution, 9 resources, and 6,095 SPIR-V dwords.

The full snapshot suite was not run for this ordinary development PR. No visible-progress claim or screenshot is attached: this is an offline shader-unblock milestone, and live guest validation follows after merge.