### PR TITLE
gpu: capture frames at exact guest log phases

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -709,6 +709,12 @@ if(TARGET prosper_core)
   target_link_libraries(test_gpu_timeline_capture_exit PRIVATE prosper_core)
   add_test(NAME gpu_timeline_capture_exit COMMAND test_gpu_timeline_capture_exit)
 
+  # Generic guest-log phase gate: exact bounded lines arm the existing seeded whole-frame capture
+  # after one completed present. Pure/cross-platform; no game dump or Vulkan device.
+  add_executable(test_guest_log_capture tests/test_guest_log_capture.cpp)
+  target_link_libraries(test_guest_log_capture PRIVATE prosper_core)
+  add_test(NAME guest_log_capture COMMAND test_guest_log_capture)
+
   # gpu_replay output dimensions follow the selected draw/prefix target when its byte count agrees.
   # Pure/cross-platform so focused replay tooling remains available in CI.
   add_executable(test_gpu_replay_extent tests/test_gpu_replay_extent.cpp)

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -802,31 +802,52 @@ inline uint32_t resolve_nonindexed_vertex_count(uint32_t draw_count, uint32_t vb
     return draw_count ? draw_count : vb_records;
 }
 
+struct ColorStateTraceConfig {
+    bool enabled = false;
+    bool filter_by_dimension = false;
+    uint32_t width = 0, height = 0;
+};
+
+// Parse the process-wide diagnostic switch once. Draw realization is a hot path even when tracing is
+// disabled, so its ordinary per-draw cost is only a cached boolean check -- never getenv or sscanf.
+inline const ColorStateTraceConfig& color_state_trace_config() {
+    static const ColorStateTraceConfig config = [] {
+        ColorStateTraceConfig parsed;
+        const char* setting = std::getenv("PROSPER_COLORSTATETRACE");
+        if (!setting || !*setting) return parsed;
+        if (std::strcmp(setting, "1") == 0 || std::strcmp(setting, "all") == 0) {
+            parsed.enabled = true;
+            return parsed;
+        }
+
+        char trailing = 0;
+        if (std::sscanf(setting, "%ux%u%c", &parsed.width, &parsed.height, &trailing) == 2 &&
+            parsed.width && parsed.height) {
+            parsed.enabled = true;
+            parsed.filter_by_dimension = true;
+            return parsed;
+        }
+        std::fprintf(stderr,
+                     "[color-state] invalid PROSPER_COLORSTATETRACE='%s' "
+                     "(expected 1, all, or WxH)\n",
+                     setting);
+        return ColorStateTraceConfig{};
+    }();
+    return config;
+}
+
 // PROSPER_COLORSTATETRACE=1|all|WxH: one raw-to-resolved color/depth state record per matching draw.
 // This deliberately runs before the no-effect fast path so a zero raw mask remains observable even
 // when shader/resource realization is skipped. It is diagnostic-only and does not mutate draw state.
 inline void trace_color_state_if_requested(const RenderState& rs,
                                            const ResolvedPipelineState& ps) {
-    const char* setting = std::getenv("PROSPER_COLORSTATETRACE");
-    if (!setting || !*setting) return;
+    const ColorStateTraceConfig& config = color_state_trace_config();
+    if (!config.enabled) return;
 
     const ColorStateTraceSnapshot snapshot = snapshot_color_state_trace(rs, ps);
-    if (std::strcmp(setting, "1") != 0 && std::strcmp(setting, "all") != 0) {
-        uint32_t width = 0, height = 0;
-        char trailing = 0;
-        if (std::sscanf(setting, "%ux%u%c", &width, &height, &trailing) != 2 ||
-            !width || !height) {
-            static std::once_flag warned;
-            std::call_once(warned, [&] {
-                std::fprintf(stderr,
-                             "[color-state] invalid PROSPER_COLORSTATETRACE='%s' "
-                             "(expected 1, all, or WxH)\n",
-                             setting);
-            });
-            return;
-        }
-        if (!color_state_trace_matches_dimension(snapshot, width, height)) return;
-    }
+    if (config.filter_by_dimension &&
+        !color_state_trace_matches_dimension(snapshot, config.width, config.height))
+        return;
 
     // Draw realization may run on worker threads. Keep each snapshot contiguous so target rows do
     // not become associated with another draw's raw register line in a busy live trace.

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -802,6 +802,70 @@ inline uint32_t resolve_nonindexed_vertex_count(uint32_t draw_count, uint32_t vb
     return draw_count ? draw_count : vb_records;
 }
 
+// PROSPER_COLORSTATETRACE=1|all|WxH: one raw-to-resolved color/depth state record per matching draw.
+// This deliberately runs before the no-effect fast path so a zero raw mask remains observable even
+// when shader/resource realization is skipped. It is diagnostic-only and does not mutate draw state.
+inline void trace_color_state_if_requested(const RenderState& rs,
+                                           const ResolvedPipelineState& ps) {
+    const char* setting = std::getenv("PROSPER_COLORSTATETRACE");
+    if (!setting || !*setting) return;
+
+    const ColorStateTraceSnapshot snapshot = snapshot_color_state_trace(rs, ps);
+    if (std::strcmp(setting, "1") != 0 && std::strcmp(setting, "all") != 0) {
+        uint32_t width = 0, height = 0;
+        char trailing = 0;
+        if (std::sscanf(setting, "%ux%u%c", &width, &height, &trailing) != 2 ||
+            !width || !height) {
+            static std::once_flag warned;
+            std::call_once(warned, [&] {
+                std::fprintf(stderr,
+                             "[color-state] invalid PROSPER_COLORSTATETRACE='%s' "
+                             "(expected 1, all, or WxH)\n",
+                             setting);
+            });
+            return;
+        }
+        if (!color_state_trace_matches_dimension(snapshot, width, height)) return;
+    }
+
+    // Draw realization may run on worker threads. Keep each snapshot contiguous so target rows do
+    // not become associated with another draw's raw register line in a busy live trace.
+    static std::mutex trace_mutex;
+    std::lock_guard lock(trace_mutex);
+    std::fprintf(stderr,
+                 "[color-state] es=0x%llx ps=0x%llx "
+                 "cb-control=%d:%08x mode=%u target-mask=%d:%08x "
+                 "shader-mask=%d:%08x\n",
+                 static_cast<unsigned long long>(snapshot.es_addr),
+                 static_cast<unsigned long long>(snapshot.ps_addr),
+                 snapshot.has_cb_color_control, snapshot.cb_color_control,
+                 snapshot.cb_color_mode, snapshot.has_cb_target_mask,
+                 snapshot.cb_target_mask, snapshot.has_cb_shader_mask,
+                 snapshot.cb_shader_mask);
+    for (uint32_t slot = 0; slot < snapshot.color_targets.size(); ++slot) {
+        const auto& target = snapshot.color_targets[slot];
+        if (!target.base && !target.raw_format && !target.resolved_format &&
+            !target.resolved_write_mask)
+            continue;
+        std::fprintf(stderr,
+                     "[color-state]   color%u=0x%llx %ux%u raw-format=%u "
+                     "resolved-format=%u resolved-cwm=%x\n",
+                     slot, static_cast<unsigned long long>(target.base),
+                     target.width, target.height, target.raw_format,
+                     target.resolved_format, target.resolved_write_mask);
+    }
+    std::fprintf(stderr,
+                 "[color-state]   depth=%d:%ux%u raw-size=%08x test=%d write=%d "
+                 "z=0x%llx/0x%llx s=0x%llx/0x%llx htile=0x%llx stencil=%d\n",
+                 snapshot.has_depth_extent, snapshot.depth_width, snapshot.depth_height,
+                 snapshot.raw_depth_size_xy, ps.depth_test_enable, ps.depth_write_enable,
+                 static_cast<unsigned long long>(snapshot.depth_read_base),
+                 static_cast<unsigned long long>(snapshot.depth_write_base),
+                 static_cast<unsigned long long>(snapshot.stencil_read_base),
+                 static_cast<unsigned long long>(snapshot.stencil_write_base),
+                 static_cast<unsigned long long>(snapshot.htile_data_base), ps.stencil_enable);
+}
+
 // Realize ONE draw of `ds` (a register snapshot or the folded state) into a DrawItem: recompile the
 // VS+PS, resolve fixed-function state, and — for an indexed draw — fetch the guest index buffer.
 // `draw` is the PM4 draw record (index count + indexed/index_addr); null means "no record" (hand-built
@@ -871,6 +935,7 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
     }
     const ResolvedPipelineState resolved_pipeline = failure
         ? failure->pipeline : resolve_pipeline_state(rs);
+    trace_color_state_if_requested(rs, resolved_pipeline);
     // CB_TARGET_MASK/CB_SHADER_MASK are upstream hardware gates: a fragment export can narrow these
     // masks, but cannot enable a component that they already disabled.  When fixed-function state also
     // has no depth/stencil side effect, shader/resource realization cannot change the no-op verdict.

--- a/prosper/src/gpu/gpu_timeline.cpp
+++ b/prosper/src/gpu/gpu_timeline.cpp
@@ -1881,6 +1881,7 @@ struct GuestLogCaptureBundleState {
     std::atomic<bool> fired{false};
     std::mutex mx;
     std::string line;
+    uint32_t line_sources = 0;
     bool discard_line = false;
     bool suppress_lf_after_cr = false;
 
@@ -1926,11 +1927,13 @@ bool guest_log_capture_bundle_enabled() {
     return state.enabled && !state.fired.load(std::memory_order_acquire);
 }
 
-void observe_guest_log_for_capture(const char* bytes, size_t size) {
+void observe_guest_log_for_capture(const char* bytes, size_t size,
+                                   GuestLogCaptureSource source) {
     GuestLogCaptureBundleState& state = guest_log_capture_bundle_state();
     if (!state.enabled || !bytes || !size || state.fired.load(std::memory_order_acquire)) return;
 
     bool matched = false;
+    uint32_t matched_sources = 0;
     {
         std::lock_guard<std::mutex> lock(state.mx);
         if (state.fired.load(std::memory_order_relaxed)) return;
@@ -1938,8 +1941,10 @@ void observe_guest_log_for_capture(const char* bytes, size_t size) {
             if (!state.discard_line && state.line == state.marker) {
                 state.fired.store(true, std::memory_order_release);
                 matched = true;
+                matched_sources = state.line_sources;
             }
             state.line.clear();
+            state.line_sources = 0;
             state.discard_line = false;
         };
         for (size_t i = 0; i < size && !matched; ++i) {
@@ -1948,6 +1953,7 @@ void observe_guest_log_for_capture(const char* bytes, size_t size) {
                 state.suppress_lf_after_cr = false;
                 if (ch == '\n') continue;
             }
+            state.line_sources |= uint32_t{1} << static_cast<uint32_t>(source);
             if (ch == '\r') {
                 complete_line();
                 state.suppress_lf_after_cr = true;
@@ -1969,10 +1975,19 @@ void observe_guest_log_for_capture(const char* bytes, size_t size) {
     // transition boundary cannot be mistaken for the scene it announced, then use the established
     // F9 whole-frame path to retain every submit and persistent RTT/DS boundary seed.
     request_interactive_capture_bundle(state.path, state.max_mb, 1);
+    std::string source_names;
+    constexpr const char* names[] = {
+        "unknown", "printf", "puts", "putchar", "fputs", "fwrite", "write",
+    };
+    for (uint32_t i = 0; i < sizeof(names) / sizeof(names[0]); ++i) {
+        if (!(matched_sources & (uint32_t{1} << i))) continue;
+        if (!source_names.empty()) source_names += ',';
+        source_names += names[i];
+    }
     std::fprintf(stderr,
-                 "[grab] exact guest-log line matched; whole-frame capture armed after one "
-                 "completed present -> %s\n",
-                 state.path.c_str());
+                 "[grab] exact guest-log line matched via %s; whole-frame capture armed after "
+                 "one completed present -> %s\n",
+                 source_names.empty() ? "unknown" : source_names.c_str(), state.path.c_str());
 }
 
 void observe_guest_log_capture_gap() {
@@ -1981,6 +1996,7 @@ void observe_guest_log_capture_gap() {
     std::lock_guard<std::mutex> lock(state.mx);
     if (state.fired.load(std::memory_order_relaxed)) return;
     state.line.clear();
+    state.line_sources = 0;
     state.discard_line = true;
     state.suppress_lf_after_cr = false;
 }

--- a/prosper/src/gpu/gpu_timeline.cpp
+++ b/prosper/src/gpu/gpu_timeline.cpp
@@ -1872,6 +1872,119 @@ bool interactive_capture_bundle_active() {
     return g_interactive_frame_active.load(std::memory_order_acquire);
 }
 
+namespace {
+struct GuestLogCaptureBundleState {
+    bool enabled = false;
+    std::string marker;
+    std::string path;
+    uint32_t max_mb = 0;
+    std::atomic<bool> fired{false};
+    std::mutex mx;
+    std::string line;
+    bool discard_line = false;
+    bool suppress_lf_after_cr = false;
+
+    GuestLogCaptureBundleState() {
+        const char* marker_env = std::getenv("PROSPER_CAPTURE_BUNDLE_AFTER_GUEST_LOG");
+        if (!marker_env || !*marker_env) return;
+        const char* path_env = std::getenv("PROSPER_CAPTURE_BUNDLE");
+        if (!path_env || !*path_env) {
+            std::fprintf(stderr,
+                         "[grab] PROSPER_CAPTURE_BUNDLE_AFTER_GUEST_LOG requires "
+                         "PROSPER_CAPTURE_BUNDLE\n");
+            return;
+        }
+        marker = marker_env;
+        path = path_env;
+        if (marker.size() > kGuestLogCaptureMaxLineBytes) {
+            std::fprintf(stderr,
+                         "[grab] PROSPER_CAPTURE_BUNDLE_AFTER_GUEST_LOG exceeds the %zu-byte "
+                         "line limit\n",
+                         kGuestLogCaptureMaxLineBytes);
+            return;
+        }
+        if (const char* limit = std::getenv("PROSPER_CAPTURE_BUNDLE_MAX_MB")) {
+            char* end = nullptr;
+            errno = 0;
+            const unsigned long parsed = std::strtoul(limit, &end, 0);
+            if (!errno && end != limit && end && !*end && parsed <= UINT32_MAX)
+                max_mb = static_cast<uint32_t>(parsed);
+        }
+        line.reserve(std::min<size_t>(marker.size() + 16, kGuestLogCaptureMaxLineBytes));
+        enabled = true;
+    }
+};
+
+GuestLogCaptureBundleState& guest_log_capture_bundle_state() {
+    static GuestLogCaptureBundleState state;
+    return state;
+}
+} // namespace
+
+bool guest_log_capture_bundle_enabled() {
+    const GuestLogCaptureBundleState& state = guest_log_capture_bundle_state();
+    return state.enabled && !state.fired.load(std::memory_order_acquire);
+}
+
+void observe_guest_log_for_capture(const char* bytes, size_t size) {
+    GuestLogCaptureBundleState& state = guest_log_capture_bundle_state();
+    if (!state.enabled || !bytes || !size || state.fired.load(std::memory_order_acquire)) return;
+
+    bool matched = false;
+    {
+        std::lock_guard<std::mutex> lock(state.mx);
+        if (state.fired.load(std::memory_order_relaxed)) return;
+        auto complete_line = [&] {
+            if (!state.discard_line && state.line == state.marker) {
+                state.fired.store(true, std::memory_order_release);
+                matched = true;
+            }
+            state.line.clear();
+            state.discard_line = false;
+        };
+        for (size_t i = 0; i < size && !matched; ++i) {
+            const char ch = bytes[i];
+            if (state.suppress_lf_after_cr) {
+                state.suppress_lf_after_cr = false;
+                if (ch == '\n') continue;
+            }
+            if (ch == '\r') {
+                complete_line();
+                state.suppress_lf_after_cr = true;
+            } else if (ch == '\n') {
+                complete_line();
+            } else if (!state.discard_line) {
+                if (state.line.size() < kGuestLogCaptureMaxLineBytes) {
+                    state.line.push_back(ch);
+                } else {
+                    state.line.clear();
+                    state.discard_line = true;
+                }
+            }
+        }
+    }
+    if (!matched) return;
+
+    // The marker is a phase gate, not a frame oracle. Skip exactly one completed present so the
+    // transition boundary cannot be mistaken for the scene it announced, then use the established
+    // F9 whole-frame path to retain every submit and persistent RTT/DS boundary seed.
+    request_interactive_capture_bundle(state.path, state.max_mb, 1);
+    std::fprintf(stderr,
+                 "[grab] exact guest-log line matched; whole-frame capture armed after one "
+                 "completed present -> %s\n",
+                 state.path.c_str());
+}
+
+void observe_guest_log_capture_gap() {
+    GuestLogCaptureBundleState& state = guest_log_capture_bundle_state();
+    if (!state.enabled || state.fired.load(std::memory_order_acquire)) return;
+    std::lock_guard<std::mutex> lock(state.mx);
+    if (state.fired.load(std::memory_order_relaxed)) return;
+    state.line.clear();
+    state.discard_line = true;
+    state.suppress_lf_after_cr = false;
+}
+
 // Called per submit: when a frame grab is in progress, append this submit's realized state to the bundle.
 void interactive_frame_bundle_on_submit(const GpuState& state, uint64_t submit_no) {
     if (!g_interactive_frame_active.load(std::memory_order_acquire)) return;

--- a/prosper/src/gpu/gpu_timeline.hpp
+++ b/prosper/src/gpu/gpu_timeline.hpp
@@ -279,8 +279,19 @@ bool interactive_capture_bundle_active();
 // completed present. The byte-stream observer is fragment-safe and bounded; normal play pays only the
 // enabled check when the environment variable is absent.
 inline constexpr size_t kGuestLogCaptureMaxLineBytes = 4096;
+enum class GuestLogCaptureSource : uint8_t {
+    Unknown,
+    Printf,
+    Puts,
+    Putchar,
+    Fputs,
+    Fwrite,
+    Write,
+};
 bool guest_log_capture_bundle_enabled();
-void observe_guest_log_for_capture(const char* bytes, size_t size);
+void observe_guest_log_for_capture(
+    const char* bytes, size_t size,
+    GuestLogCaptureSource source = GuestLogCaptureSource::Unknown);
 // Marks bytes omitted by a bounded stdout adapter. It deliberately discards through the next observed
 // line ending so an unobserved suffix can cause only a missed match, never a false exact-line match.
 void observe_guest_log_capture_gap();

--- a/prosper/src/gpu/gpu_timeline.hpp
+++ b/prosper/src/gpu/gpu_timeline.hpp
@@ -3,6 +3,7 @@
 
 #include "command_processor.hpp"
 
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -271,5 +272,17 @@ void close_gpu_timeline();
 void request_interactive_capture_bundle(const std::string& path, uint32_t max_mb = 0,
                                         uint32_t delay_presents = 0);
 bool interactive_capture_bundle_active();
+
+// Optional guest-stdout phase gate for the same whole-frame bundle. When
+// PROSPER_CAPTURE_BUNDLE_AFTER_GUEST_LOG is configured together with the existing
+// PROSPER_CAPTURE_BUNDLE path, an exact completed guest-log line arms one capture after skipping one
+// completed present. The byte-stream observer is fragment-safe and bounded; normal play pays only the
+// enabled check when the environment variable is absent.
+inline constexpr size_t kGuestLogCaptureMaxLineBytes = 4096;
+bool guest_log_capture_bundle_enabled();
+void observe_guest_log_for_capture(const char* bytes, size_t size);
+// Marks bytes omitted by a bounded stdout adapter. It deliberately discards through the next observed
+// line ending so an unobserved suffix can cause only a missed match, never a false exact-line match.
+void observe_guest_log_capture_gap();
 
 } // namespace prosper::gpu

--- a/prosper/src/gpu/render_state.cpp
+++ b/prosper/src/gpu/render_state.cpp
@@ -254,6 +254,7 @@ RenderState extract_render_state(const GpuState& st) {
     rs.db_render_override = rd(st.cx, P::DB_RENDER_OVERRIDE);
     rs.db_render_override2 = rd(st.cx, P::DB_RENDER_OVERRIDE2);
     rs.htile_data_base = addr_of(rd(st.cx, P::DB_HTILE_DATA_BASE), rd(st.cx, P::DB_HTILE_DATA_BASE_HI));
+    rs.has_db_depth_size_xy = st.cx.count(P::DB_DEPTH_SIZE_XY) != 0;
     rs.db_depth_size_xy = rd(st.cx, P::DB_DEPTH_SIZE_XY);
     rs.db_dfsm_control = rd(st.cx, P::DB_DFSM_CONTROL);
     rs.db_depth_info = rd(st.cx, P::DB_DEPTH_INFO);
@@ -348,11 +349,13 @@ RenderState extract_render_state(const GpuState& st) {
     // NOT 0 — reading 0 dropped every color draw (color_write_mask==0 skip), i.e. the "blue screen" where
     // the real art rendered only under PROSPER_FORCE_COLORWRITE. A register that IS present (even 0) is
     // honored, so a genuine depth-only pass that programs mask 0 still skips correctly.
+    rs.has_cb_target_mask = st.cx.count(P::CB_TARGET_MASK) != 0;
     rs.cb_target_mask    = st.cx.count(P::CB_TARGET_MASK) ? rd(st.cx, P::CB_TARGET_MASK) : 0xFFFFFFFFu;
     // CB_SHADER_MASK is programmed from the pixel shader's color-export contract. Like the target
     // mask, an absent register must not suppress color in synthetic/legacy command streams. The
     // resolved Vulkan write mask intersects both registers so channels the shader does not export
     // preserve their existing attachment contents (AMD RDNA2 EXP EN semantics, Table 56).
+    rs.has_cb_shader_mask = st.cx.count(P::CB_SHADER_MASK) != 0;
     rs.cb_shader_mask    = st.cx.count(P::CB_SHADER_MASK) ? rd(st.cx, P::CB_SHADER_MASK) : 0xFFFFFFFFu;
     rs.spi_shader_col_format = st.cx.count(P::SPI_SHADER_COL_FORMAT)
         ? rd(st.cx, P::SPI_SHADER_COL_FORMAT) : 0u;
@@ -521,6 +524,50 @@ RenderState extract_render_state(const GpuState& st) {
     }
 
     return rs;
+}
+
+ColorStateTraceSnapshot snapshot_color_state_trace(const RenderState& rs,
+                                                   const ResolvedPipelineState& ps) {
+    ColorStateTraceSnapshot out;
+    out.es_addr = rs.es_addr;
+    out.ps_addr = rs.ps_addr;
+    out.has_cb_color_control = rs.has_cb_color_control;
+    out.has_cb_target_mask = rs.has_cb_target_mask;
+    out.has_cb_shader_mask = rs.has_cb_shader_mask;
+    out.cb_color_control = rs.cb_color_control;
+    out.cb_color_mode = PM4_FIELD(rs.cb_color_control, CB_COLOR_CONTROL, MODE);
+    out.cb_target_mask = rs.cb_target_mask;
+    out.cb_shader_mask = rs.cb_shader_mask;
+    for (uint32_t slot = 0; slot < out.color_targets.size(); ++slot) {
+        out.color_targets[slot] = {
+            rs.color_targets[slot].base,
+            rs.color_targets[slot].width,
+            rs.color_targets[slot].height,
+            rs.color_targets[slot].format,
+            ps.color_targets[slot].format,
+            ps.color_targets[slot].write_mask,
+        };
+    }
+    out.has_depth_extent = rs.has_db_depth_size_xy;
+    out.raw_depth_size_xy = rs.db_depth_size_xy;
+    if (out.has_depth_extent) {
+        out.depth_width = PM4_FIELD(rs.db_depth_size_xy, DB_DEPTH_SIZE_XY, X_MAX) + 1u;
+        out.depth_height = PM4_FIELD(rs.db_depth_size_xy, DB_DEPTH_SIZE_XY, Y_MAX) + 1u;
+    }
+    out.depth_read_base = rs.depth_read_base;
+    out.depth_write_base = rs.depth_write_base;
+    out.stencil_read_base = rs.stencil_read_base;
+    out.stencil_write_base = rs.stencil_write_base;
+    out.htile_data_base = rs.htile_data_base;
+    return out;
+}
+
+bool color_state_trace_matches_dimension(const ColorStateTraceSnapshot& snapshot,
+                                         uint32_t width, uint32_t height) {
+    return std::any_of(snapshot.color_targets.begin(), snapshot.color_targets.end(),
+                       [&](const auto& target) {
+                           return target.width == width && target.height == height;
+                       });
 }
 
 ResolvedPipelineState resolve_pipeline_state(const RenderState& rs) {

--- a/prosper/src/gpu/render_state.hpp
+++ b/prosper/src/gpu/render_state.hpp
@@ -114,6 +114,7 @@ struct RenderState {
     // plane bases alone do not distinguish mip/slice views, HTILE metadata, or a re-described backing.
     uint32_t db_depth_view = 0, db_render_override = 0, db_render_override2 = 0;
     uint64_t htile_data_base = 0;
+    bool has_db_depth_size_xy = false;
     uint32_t db_depth_size_xy = 0, db_dfsm_control = 0, db_depth_info = 0;
     uint32_t db_z_info = 0, db_stencil_info = 0;
     uint32_t db_depth_size = 0, db_depth_slice = 0;
@@ -153,10 +154,14 @@ struct RenderState {
     bool     has_cb_color_control = false;
     uint32_t cb_color_control  = 0;   // CB_COLOR_CONTROL
     uint32_t cb_blend0_control = 0;   // CB_BLEND0_CONTROL
+    // The effective values below intentionally default to write-all when absent. Keep presence as a
+    // separate diagnostic fact so a zero programmed mask can be distinguished from that fallback.
+    bool     has_cb_target_mask = false;
     uint32_t cb_target_mask    = 0;   // CB_TARGET_MASK (per-MRT write mask)
     // Synthetic/direct RenderState users historically supplied only CB_TARGET_MASK. Match the
     // hardware/command-stream absent-register fallback so adding CB_SHADER_MASK cannot silently
     // turn those otherwise-valid color writes off.
+    bool     has_cb_shader_mask = false;
     uint32_t cb_shader_mask    = 0xFFFFFFFFu; // CB_SHADER_MASK (components exported by the pixel shader)
     uint32_t spi_shader_col_format = 0; // SPI_SHADER_COL_FORMAT (4-bit export format per MRT)
     uint32_t sx_ps_downconvert = 0;      // SX_PS_DOWNCONVERT (4-bit target conversion per MRT)
@@ -323,6 +328,33 @@ struct ResolvedPipelineState {
     // Complete hardware MRT state. Slots 0/1 mirror the legacy named fields above.
     std::array<ColorTarget, kColorTargetCount> color_targets{};
 };
+
+// Immutable facts emitted by the opt-in late-draw color-state trace. Keeping construction pure makes
+// the diagnostic boundary testable without environment variables, logging, shader recompilation, or
+// Vulkan. Raw-register presence is intentionally distinct from its effective fallback value.
+struct ColorStateTraceSnapshot {
+    struct Target {
+        uint64_t base = 0;
+        uint32_t width = 0, height = 0;
+        uint32_t raw_format = 0, resolved_format = 0, resolved_write_mask = 0;
+    };
+
+    uint64_t es_addr = 0, ps_addr = 0;
+    bool has_cb_color_control = false, has_cb_target_mask = false, has_cb_shader_mask = false;
+    uint32_t cb_color_control = 0, cb_color_mode = 0;
+    uint32_t cb_target_mask = 0, cb_shader_mask = 0;
+    std::array<Target, kColorTargetCount> color_targets{};
+
+    bool has_depth_extent = false;
+    uint32_t depth_width = 0, depth_height = 0, raw_depth_size_xy = 0;
+    uint64_t depth_read_base = 0, depth_write_base = 0;
+    uint64_t stencil_read_base = 0, stencil_write_base = 0, htile_data_base = 0;
+};
+
+ColorStateTraceSnapshot snapshot_color_state_trace(const RenderState& rs,
+                                                   const ResolvedPipelineState& ps);
+bool color_state_trace_matches_dimension(const ColorStateTraceSnapshot& snapshot,
+                                         uint32_t width, uint32_t height);
 
 // A color-disabled draw must still execute when it can change the depth/stencil attachment consumed
 // by later draws. KEEP-only stencil tests without a depth write have no attachment side effect.

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -7,6 +7,7 @@
 #include "dispatch.hpp"
 #include "nid.hpp"
 #include "heap_mutex.hpp"   // #707: keep the APR mutex off macOS __DATA
+#include "../gpu/gpu_timeline.hpp" // optional exact guest-stdout capture gate
 #include "../host/guest_write_watch.hpp"   // #1144 B5: disarm texture watches before reading into guest mem
 #include "../host/boot_program.hpp"        // #1226: resolve_host_path_case (PS5 FS namespace is case-insensitive)
 #include <cctype>        // #1237: case-insensitive PROSPER_DENY_SUBSTR matching
@@ -908,7 +909,14 @@ HLE(f_fread)   { if (!a3) return 0;
                       P(a0), (unsigned long long)a1, (unsigned long long)a2, (void*)f,
                       (unsigned long long)n, feof(f), ferror(f), errno);
                   return (uint64_t)n; }
-HLE(f_fwrite)  { return a3 ? (uint64_t)fwrite(P(a0), a1, a2, (FILE*)P(a3)) : 0; }
+HLE(f_fwrite)  { if (!a3) return 0;
+                  FILE* stream = (FILE*)P(a3);
+                  const size_t items = fwrite(P(a0), a1, a2, stream);
+                  if (stream == stdout && items && a1 <= SIZE_MAX / items)
+                      gpu::observe_guest_log_for_capture(
+                          (const char*)P(a0), items * (size_t)a1,
+                          gpu::GuestLogCaptureSource::Fwrite);
+                  return (uint64_t)items; }
 HLE(f_fseek)   { return a0 ? (uint64_t)(int64_t)fseek((FILE*)P(a0), (long)a1, (int)a2) : -1; }
 HLE(f_ftell)   { return a0 ? (uint64_t)(int64_t)ftell((FILE*)P(a0)) : -1; }
 HLE(f_fgets)   { return (uint64_t)(uintptr_t)(a2 ? fgets((char*)P(a0), (int)a1, (FILE*)P(a2)) : nullptr); }
@@ -1422,12 +1430,18 @@ HLE(f_read)  { int fd = (int)a0; int64_t off = -1;
 #endif
              }
 HLE(f_write) {
+               int64_t written;
 #ifndef _WIN32
-               return (uint64_t)write_full((int)a0, P(a1), (size_t)a2, false, 0);
+               written = write_full((int)a0, P(a1), (size_t)a2, false, 0);
 #else
                ScopedCrtInvalidParameterHandler suppress_invalid_parameter;
-               return (uint64_t)(int64_t)::write((int)a0, P(a1), (size_t)a2);
+               written = (int64_t)::write((int)a0, P(a1), (size_t)a2);
 #endif
+               if ((int)a0 == 1 && written > 0)
+                   gpu::observe_guest_log_for_capture(
+                       (const char*)P(a1), (size_t)written,
+                       gpu::GuestLogCaptureSource::Write);
+               return (uint64_t)written;
              }
 HLE(f_lseek) { if (fdlog_on() && ((int)a2 != SEEK_CUR || a1 != 0)) preadlog("lseek", a0, a1, (uint64_t)a2);
 #ifdef _WIN32

--- a/prosper/src/hle/hle_libc.cpp
+++ b/prosper/src/hle/hle_libc.cpp
@@ -3,6 +3,7 @@
 // host C library. Registered by NID so the loader binds imports directly to them.
 #include "dispatch.hpp"
 #include "nid.hpp"
+#include "gpu/gpu_timeline.hpp"
 #include <cstring>
 #include <cstdlib>
 #include <cstdint>
@@ -19,6 +20,7 @@
 #include <condition_variable>
 #include <thread>
 #include <unordered_map>
+#include <vector>
 
 // setjmp/longjmp — the guest's Boehm GC calls setjmp to flush callee-saved registers to a
 // buffer so it can scan them as GC roots (and the runtime uses it for exception unwinding).
@@ -417,8 +419,72 @@ static uint64_t h_sprintf(void* buf, const char* fmt, ...) {
     va_list ap; va_start(ap, fmt); int r = vsprintf((char*)buf, fmt, ap); va_end(ap);
     return (uint64_t)(int64_t)r;
 }
+
+namespace {
+// A %n conversion writes through a guest pointer while formatting. The capture adapter must never
+// evaluate it speculatively, so conservatively leave such calls on the original one-pass vprintf path.
+bool format_may_write_n(const char* format) {
+    if (!format) return false;
+    constexpr const char* conversions = "diouxXfFeEgGaAcspnm%";
+    for (const char* p = format; *p; ++p) {
+        if (*p != '%') continue;
+        ++p;
+        if (!*p) break;
+        if (*p == '%') continue;
+        while (*p) {
+            if (std::strchr(conversions, *p)) {
+                if (*p == 'n') return true;
+                break;
+            }
+            ++p;
+        }
+        if (!*p) break;
+    }
+    return false;
+}
+
+int capture_aware_vprintf(const char* format, va_list args) {
+    if (!prosper::gpu::guest_log_capture_bundle_enabled() || format_may_write_n(format))
+        return vprintf(format, args);
+
+    // One byte beyond the accepted line limit is enough to put the bounded observer into its
+    // overlong-line state. Ordinary guest log calls fit and are formatted exactly once; unusually
+    // large calls fall back to the original vprintf for complete stdout fidelity, while the observer
+    // consumes only this bounded prefix and marks the omitted suffix as a safe discontinuity.
+    std::vector<char> formatted(prosper::gpu::kGuestLogCaptureMaxLineBytes + 2);
+    va_list observed;
+    va_copy(observed, args);
+    const int wanted = vsnprintf(formatted.data(), formatted.size(), format, observed);
+    va_end(observed);
+    if (wanted < 0) return vprintf(format, args);
+
+    if (static_cast<size_t>(wanted) < formatted.size()) {
+        const size_t bytes = static_cast<size_t>(wanted);
+        const size_t written = fwrite(formatted.data(), 1, bytes, stdout);
+        if (written) prosper::gpu::observe_guest_log_for_capture(formatted.data(), written);
+        return written == bytes ? wanted : -1;
+    }
+
+    const int result = vprintf(format, args);
+    if (result >= 0) {
+        prosper::gpu::observe_guest_log_for_capture(formatted.data(), formatted.size() - 1);
+        prosper::gpu::observe_guest_log_capture_gap();
+    }
+    return result;
+}
+
+void observe_guest_c_string(const char* text, bool known_newline) {
+    if (!text || !prosper::gpu::guest_log_capture_bundle_enabled()) return;
+    const size_t probe = prosper::gpu::kGuestLogCaptureMaxLineBytes + 1;
+    const size_t bytes = strnlen(text, probe);
+    prosper::gpu::observe_guest_log_for_capture(text, bytes);
+    if (bytes == probe) prosper::gpu::observe_guest_log_capture_gap();
+    if (known_newline) prosper::gpu::observe_guest_log_for_capture("\n", 1);
+}
+} // namespace
+
 static uint64_t h_printf(const char* fmt, ...) {
-    va_list ap; va_start(ap, fmt); int r = vprintf(fmt, ap); va_end(ap);
+    va_list ap; va_start(ap, fmt); int r = capture_aware_vprintf(fmt, ap); va_end(ap);
     return (uint64_t)(int64_t)r;
 }
 // sscanf: a REAL variadic host thunk (like the *printf family) — the import stub tail-jumps with the
@@ -429,9 +495,15 @@ static uint64_t h_sscanf(const char* s, const char* fmt, ...) {
     va_list ap; va_start(ap, fmt); int r = vsscanf(s, fmt, ap); va_end(ap);
     return (uint64_t)(int64_t)r;
 }
-HLE(h_puts)      { int r = fputs((const char*)P(a0), stdout); fputc('\n', stdout); return (uint64_t)(int64_t)r; }
-HLE(h_putchar)   { return (uint64_t)(int64_t)putchar((int)a0); }
-HLE(h_fputs)     { return (uint64_t)(int64_t)fputs((const char*)P(a0), a1 ? (FILE*)P(a1) : stdout); }
+HLE(h_puts)      { const char* s = (const char*)P(a0); int r = fputs(s, stdout); int nl = fputc('\n', stdout);
+                   if (r != EOF && nl != EOF) observe_guest_c_string(s, true);
+                   return (uint64_t)(int64_t)r; }
+HLE(h_putchar)   { int r = putchar((int)a0); if (r != EOF) { const char c = (char)a0;
+                   prosper::gpu::observe_guest_log_for_capture(&c, 1); }
+                   return (uint64_t)(int64_t)r; }
+HLE(h_fputs)     { const char* s = (const char*)P(a0); FILE* stream = a1 ? (FILE*)P(a1) : stdout;
+                   int r = fputs(s, stream); if (r != EOF && stream == stdout) observe_guest_c_string(s, false);
+                   return (uint64_t)(int64_t)r; }
 
 // --- locale / ctype (Dinkumware CRT: _Getpctype/_Getpt{o,}lower return table ptrs) ---
 // The 257-entry C-locale table and masks match Dinkumware 5.00: _XD=0x01, _UP=0x02,

--- a/prosper/src/hle/hle_libc.cpp
+++ b/prosper/src/hle/hle_libc.cpp
@@ -461,25 +461,29 @@ int capture_aware_vprintf(const char* format, va_list args) {
     if (static_cast<size_t>(wanted) < formatted.size()) {
         const size_t bytes = static_cast<size_t>(wanted);
         const size_t written = fwrite(formatted.data(), 1, bytes, stdout);
-        if (written) prosper::gpu::observe_guest_log_for_capture(formatted.data(), written);
+        if (written) prosper::gpu::observe_guest_log_for_capture(
+            formatted.data(), written, prosper::gpu::GuestLogCaptureSource::Printf);
         return written == bytes ? wanted : -1;
     }
 
     const int result = vprintf(format, args);
     if (result >= 0) {
-        prosper::gpu::observe_guest_log_for_capture(formatted.data(), formatted.size() - 1);
+        prosper::gpu::observe_guest_log_for_capture(
+            formatted.data(), formatted.size() - 1,
+            prosper::gpu::GuestLogCaptureSource::Printf);
         prosper::gpu::observe_guest_log_capture_gap();
     }
     return result;
 }
 
-void observe_guest_c_string(const char* text, bool known_newline) {
+void observe_guest_c_string(const char* text, bool known_newline,
+                            prosper::gpu::GuestLogCaptureSource source) {
     if (!text || !prosper::gpu::guest_log_capture_bundle_enabled()) return;
     const size_t probe = prosper::gpu::kGuestLogCaptureMaxLineBytes + 1;
     const size_t bytes = strnlen(text, probe);
-    prosper::gpu::observe_guest_log_for_capture(text, bytes);
+    prosper::gpu::observe_guest_log_for_capture(text, bytes, source);
     if (bytes == probe) prosper::gpu::observe_guest_log_capture_gap();
-    if (known_newline) prosper::gpu::observe_guest_log_for_capture("\n", 1);
+    if (known_newline) prosper::gpu::observe_guest_log_for_capture("\n", 1, source);
 }
 } // namespace
 
@@ -496,13 +500,16 @@ static uint64_t h_sscanf(const char* s, const char* fmt, ...) {
     return (uint64_t)(int64_t)r;
 }
 HLE(h_puts)      { const char* s = (const char*)P(a0); int r = fputs(s, stdout); int nl = fputc('\n', stdout);
-                   if (r != EOF && nl != EOF) observe_guest_c_string(s, true);
+                   if (r != EOF && nl != EOF) observe_guest_c_string(
+                       s, true, prosper::gpu::GuestLogCaptureSource::Puts);
                    return (uint64_t)(int64_t)r; }
 HLE(h_putchar)   { int r = putchar((int)a0); if (r != EOF) { const char c = (char)a0;
-                   prosper::gpu::observe_guest_log_for_capture(&c, 1); }
+                   prosper::gpu::observe_guest_log_for_capture(
+                       &c, 1, prosper::gpu::GuestLogCaptureSource::Putchar); }
                    return (uint64_t)(int64_t)r; }
 HLE(h_fputs)     { const char* s = (const char*)P(a0); FILE* stream = a1 ? (FILE*)P(a1) : stdout;
-                   int r = fputs(s, stream); if (r != EOF && stream == stdout) observe_guest_c_string(s, false);
+                   int r = fputs(s, stream); if (r != EOF && stream == stdout) observe_guest_c_string(
+                       s, false, prosper::gpu::GuestLogCaptureSource::Fputs);
                    return (uint64_t)(int64_t)r; }
 
 // --- locale / ctype (Dinkumware CRT: _Getpctype/_Getpt{o,}lower return table ptrs) ---

--- a/prosper/tests/test_guest_log_capture.cpp
+++ b/prosper/tests/test_guest_log_capture.cpp
@@ -11,6 +11,11 @@
 #include <string>
 #include <thread>
 #include <vector>
+#ifdef _WIN32
+#include <io.h>
+#else
+#include <unistd.h>
+#endif
 
 using namespace prosper::gpu;
 
@@ -34,6 +39,14 @@ static void clear_test_env(const char* name) {
 #endif
 }
 
+static int stream_fd(FILE* stream) {
+#ifdef _WIN32
+    return _fileno(stream);
+#else
+    return fileno(stream);
+#endif
+}
+
 int main() {
     std::printf("== test_guest_log_capture ==\n");
     const auto nonce = std::chrono::steady_clock::now().time_since_epoch().count();
@@ -51,12 +64,17 @@ int main() {
 
     prosper::register_builtin_hle();
     using PrintfFn = int (*)(const char*, ...);
-    using FputsHleFn = uint64_t (*)(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t);
+    using HleFn = uint64_t (*)(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t);
     auto guest_printf = reinterpret_cast<PrintfFn>(
         reinterpret_cast<void*>(prosper::Hle::lookup(prosper::nid_hash("printf"))));
-    auto guest_fputs = reinterpret_cast<FputsHleFn>(
+    auto guest_fputs = reinterpret_cast<HleFn>(
         reinterpret_cast<void*>(prosper::Hle::lookup(prosper::nid_hash("fputs"))));
-    CHECK(guest_printf && guest_fputs, "guest stdout adapters are registered for the integration probe");
+    auto guest_fwrite = reinterpret_cast<HleFn>(
+        reinterpret_cast<void*>(prosper::Hle::lookup(prosper::nid_hash("fwrite"))));
+    auto guest_write = reinterpret_cast<HleFn>(
+        reinterpret_cast<void*>(prosper::Hle::lookup(prosper::nid_hash("sceKernelWrite"))));
+    CHECK(guest_printf && guest_fputs && guest_fwrite && guest_write,
+          "guest stdout adapters are registered for the integration probe");
 
     guest_printf("prefix %s suffix\n", "phase-ready");
     observe_guest_log_for_capture("phase-ready-suffix\r\n", 20);
@@ -70,15 +88,39 @@ int main() {
     observe_guest_log_for_capture("\r", 1);
     CHECK(!interactive_capture_bundle_active(), "an overlong line is discarded through its terminator");
 
+    FILE* non_stdout = std::tmpfile();
+    CHECK(non_stdout != nullptr, "create non-stdout stream exclusion probe");
+    if (non_stdout) {
+        const char excluded[] = "phase-ready\n";
+        CHECK(guest_fwrite(reinterpret_cast<uint64_t>(excluded), 1, sizeof(excluded) - 1,
+                           reinterpret_cast<uint64_t>(non_stdout), 0, 0) == sizeof(excluded) - 1,
+              "guest fwrite reports its successful item count");
+        std::fflush(non_stdout);
+        const int non_stdout_fd = stream_fd(non_stdout);
+        CHECK(non_stdout_fd >= 0 && non_stdout_fd != 1,
+              "non-stdout stream has a distinct file descriptor");
+        if (non_stdout_fd >= 0 && non_stdout_fd != 1)
+            CHECK(guest_write(non_stdout_fd, reinterpret_cast<uint64_t>(excluded),
+                              sizeof(excluded) - 1, 0, 0, 0) == sizeof(excluded) - 1,
+                  "guest write reports its successful byte count");
+        std::fclose(non_stdout);
+    }
+    CHECK(!interactive_capture_bundle_active(),
+          "fwrite on a non-stdout stream and write on fd != 1 are excluded");
+
     const char fragment_a[] = "phase-";
-    const char fragment_b[] = "ready";
-    const char fragment_crlf[] = "\r\n";
+    const char fragment_b[] = "rea";
+    const char fragment_c[] = "dy\r\n";
     guest_fputs(reinterpret_cast<uint64_t>(fragment_a), 0, 0, 0, 0, 0);
-    guest_fputs(reinterpret_cast<uint64_t>(fragment_b), 0, 0, 0, 0, 0);
+    CHECK(guest_fwrite(reinterpret_cast<uint64_t>(fragment_b), sizeof(fragment_b) - 1, 1,
+                       reinterpret_cast<uint64_t>(stdout), 0, 0) == 1,
+          "stdout fwrite observes exactly its reported complete items");
     CHECK(!interactive_capture_bundle_active(), "a fragmented exact line waits for completion");
-    guest_fputs(reinterpret_cast<uint64_t>(fragment_crlf), 0, 0, 0, 0, 0);
+    CHECK(guest_write(1, reinterpret_cast<uint64_t>(fragment_c), sizeof(fragment_c) - 1,
+                      0, 0, 0) == sizeof(fragment_c) - 1,
+          "fd 1 write observes exactly its reported successful bytes");
     CHECK(interactive_capture_bundle_active() && !guest_log_capture_bundle_enabled(),
-          "fragmented CRLF exact match arms once and suppresses the LF half");
+          "fputs/fwrite/write fragmented CRLF exact match arms once and suppresses the LF half");
 
     // The first completed present is deliberately skipped. Repeating the exact marker afterward must
     // not re-arm/reset that delay, including concurrent duplicate observers.

--- a/prosper/tests/test_guest_log_capture.cpp
+++ b/prosper/tests/test_guest_log_capture.cpp
@@ -1,0 +1,115 @@
+// Exact guest-log phase gate for whole-frame captures. Pure/offline: no guest or Vulkan device.
+#include "../src/gpu/gpu_capture_bundle.hpp"
+#include "../src/gpu/gpu_timeline.hpp"
+#include "../src/hle/dispatch.hpp"
+#include "../src/hle/nid.hpp"
+
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <string>
+#include <thread>
+#include <vector>
+
+using namespace prosper::gpu;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { std::printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { std::printf("  [ok]   %s\n", m); } } while (0)
+
+static void set_test_env(const char* name, const std::string& value) {
+#ifdef _WIN32
+    _putenv_s(name, value.c_str());
+#else
+    setenv(name, value.c_str(), 1);
+#endif
+}
+
+static void clear_test_env(const char* name) {
+#ifdef _WIN32
+    _putenv_s(name, "");
+#else
+    unsetenv(name);
+#endif
+}
+
+int main() {
+    std::printf("== test_guest_log_capture ==\n");
+    const auto nonce = std::chrono::steady_clock::now().time_since_epoch().count();
+    const auto bundle_path = std::filesystem::temp_directory_path() /
+        ("prosper-guest-log-capture-" + std::to_string(nonce) + ".prgbundle");
+
+    clear_test_env("PROSPER_CAPTURE_BUNDLE_AT_PRESENT");
+    clear_test_env("PROSPER_GPU_TIMELINE");
+    set_test_env("PROSPER_CAPTURE_BUNDLE_AFTER_GUEST_LOG", "phase-ready");
+    set_test_env("PROSPER_CAPTURE_BUNDLE", bundle_path.string());
+    set_test_env("PROSPER_CAPTURE_BUNDLE_MAX_MB", "64");
+    set_test_env("PROSPER_CAPTURE_FRAMES", "1");
+
+    CHECK(guest_log_capture_bundle_enabled(), "exact-line gate enables only with marker and bundle path");
+
+    prosper::register_builtin_hle();
+    using PrintfFn = int (*)(const char*, ...);
+    using FputsHleFn = uint64_t (*)(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t);
+    auto guest_printf = reinterpret_cast<PrintfFn>(
+        reinterpret_cast<void*>(prosper::Hle::lookup(prosper::nid_hash("printf"))));
+    auto guest_fputs = reinterpret_cast<FputsHleFn>(
+        reinterpret_cast<void*>(prosper::Hle::lookup(prosper::nid_hash("fputs"))));
+    CHECK(guest_printf && guest_fputs, "guest stdout adapters are registered for the integration probe");
+
+    guest_printf("prefix %s suffix\n", "phase-ready");
+    observe_guest_log_for_capture("phase-ready-suffix\r\n", 20);
+    observe_guest_log_for_capture("phase-ready", 11);
+    CHECK(!interactive_capture_bundle_active(), "substring, extended, and incomplete lines do not match");
+    observe_guest_log_for_capture("x\n", 2);
+    CHECK(!interactive_capture_bundle_active(), "a later terminator cannot turn a non-exact line into a match");
+
+    std::string overlong(kGuestLogCaptureMaxLineBytes + 1, 'x');
+    observe_guest_log_for_capture(overlong.data(), overlong.size());
+    observe_guest_log_for_capture("\r", 1);
+    CHECK(!interactive_capture_bundle_active(), "an overlong line is discarded through its terminator");
+
+    const char fragment_a[] = "phase-";
+    const char fragment_b[] = "ready";
+    const char fragment_crlf[] = "\r\n";
+    guest_fputs(reinterpret_cast<uint64_t>(fragment_a), 0, 0, 0, 0, 0);
+    guest_fputs(reinterpret_cast<uint64_t>(fragment_b), 0, 0, 0, 0, 0);
+    CHECK(!interactive_capture_bundle_active(), "a fragmented exact line waits for completion");
+    guest_fputs(reinterpret_cast<uint64_t>(fragment_crlf), 0, 0, 0, 0, 0);
+    CHECK(interactive_capture_bundle_active() && !guest_log_capture_bundle_enabled(),
+          "fragmented CRLF exact match arms once and suppresses the LF half");
+
+    // The first completed present is deliberately skipped. Repeating the exact marker afterward must
+    // not re-arm/reset that delay, including concurrent duplicate observers.
+    record_gpu_timeline_present(1, 0, 0, 4, 4);
+    std::vector<std::thread> duplicates;
+    for (unsigned i = 0; i < 4; ++i) {
+        duplicates.emplace_back([] {
+            observe_guest_log_for_capture("phase-ready\n", 12);
+        });
+    }
+    for (auto& thread : duplicates) thread.join();
+
+    record_gpu_timeline_present(2, 0, 0, 4, 4);
+    GpuState state;
+    state.command_order = 7;
+    record_gpu_timeline_submit(state, 77);
+    CHECK(!std::filesystem::exists(bundle_path),
+          "capture starts only after the one-present delay and remains open until the next present");
+    record_gpu_timeline_present(3, 0, 0, 4, 4);
+
+    GpuCaptureBundle bundle;
+    std::string error;
+    CHECK(read_gpu_capture_bundle(bundle_path.string(), bundle, error),
+          "the marker request hands off to the existing whole-frame bundle writer");
+    CHECK(bundle.submits.size() == 1 && bundle.submits[0].submit_index == 77,
+          "one-present delay and duplicate one-shot preserve the intended captured frame");
+    CHECK(!interactive_capture_bundle_active(), "one-shot capture disarms after the frame is written");
+
+    std::error_code ec;
+    std::filesystem::remove(bundle_path, ec);
+    if (fails) { std::printf("== FAIL: %d ==\n", fails); return 1; }
+    std::printf("== PASS ==\n");
+    return 0;
+}

--- a/prosper/tests/test_render_state.cpp
+++ b/prosper/tests/test_render_state.cpp
@@ -620,8 +620,52 @@ int main() {
     CHECK(rs.db_depth_control  == 0x00000046u, "db_depth_control raw preserved");
     CHECK(rs.has_cb_color_control && rs.cb_color_control == 0x00CC0010u,
           "programmed cb_color_control presence and raw value preserved");
-    CHECK(rs.cb_target_mask    == 0x000000FFu, "cb_target_mask raw preserved");
-    CHECK(rs.cb_shader_mask    == 0x000000F3u, "cb_shader_mask raw preserved");
+    CHECK(rs.has_cb_target_mask && rs.cb_target_mask == 0x000000FFu,
+          "programmed cb_target_mask presence and raw value preserved");
+    CHECK(rs.has_cb_shader_mask && rs.cb_shader_mask == 0x000000F3u,
+          "programmed cb_shader_mask presence and raw value preserved");
+    CHECK(rs.has_db_depth_size_xy,
+          "programmed DB_DEPTH_SIZE_XY presence is distinct from an absent zero value");
+
+    // The opt-in late-draw trace snapshots the raw-to-resolved boundary without depending on
+    // environment variables or logging. This is the evidence needed to distinguish an explicit
+    // disabled color mode from either fixed-function mask suppressing an otherwise-live shader.
+    {
+        const ResolvedPipelineState resolved = resolve_pipeline_state(rs);
+        const ColorStateTraceSnapshot trace = snapshot_color_state_trace(rs, resolved);
+        CHECK(trace.es_addr == rs.es_addr && trace.ps_addr == rs.ps_addr &&
+              trace.has_cb_color_control && trace.cb_color_control == 0x00CC0010u &&
+              trace.cb_color_mode == P::CB_COLOR_CONTROL_MODE_NORMAL,
+              "color-state snapshot retains shader identity and raw CB color mode");
+        CHECK(trace.has_cb_target_mask && trace.cb_target_mask == 0xFFu &&
+              trace.has_cb_shader_mask && trace.cb_shader_mask == 0xF3u &&
+              trace.color_targets[0].resolved_write_mask == 0x3u &&
+              trace.color_targets[1].resolved_write_mask == 0xFu,
+              "color-state snapshot relates raw target/shader masks to every resolved MRT mask");
+        CHECK(trace.color_targets[0].base == rs.color0_base &&
+              trace.color_targets[0].width == 1024u && trace.color_targets[0].height == 32u &&
+              trace.color_targets[0].raw_format == 0xAu,
+              "color-state snapshot retains color target identity, dimensions, and raw format");
+        CHECK(trace.has_depth_extent && trace.depth_width == 0x235u &&
+              trace.depth_height == 0x124u && trace.raw_depth_size_xy == 0x01230234u &&
+              trace.depth_read_base == rs.depth_read_base &&
+              trace.depth_write_base == rs.depth_write_base &&
+              trace.stencil_read_base == rs.stencil_read_base &&
+              trace.stencil_write_base == rs.stencil_write_base &&
+              trace.htile_data_base == rs.htile_data_base,
+              "color-state snapshot retains decoded depth extent and every backing identity");
+        CHECK(color_state_trace_matches_dimension(trace, 1024u, 32u) &&
+              !color_state_trace_matches_dimension(trace, 3840u, 2160u),
+              "color-state trace dimension filter matches programmed color targets only");
+
+        const RenderState empty = extract_render_state(GpuState{});
+        const ColorStateTraceSnapshot empty_trace =
+            snapshot_color_state_trace(empty, resolve_pipeline_state(empty));
+        CHECK(!empty_trace.has_cb_color_control && !empty_trace.has_cb_target_mask &&
+              !empty_trace.has_cb_shader_mask && empty_trace.cb_target_mask == 0xFFFFFFFFu &&
+              empty_trace.cb_shader_mask == 0xFFFFFFFFu && !empty_trace.has_depth_extent,
+              "color-state snapshot distinguishes absent registers from effective write-all fallbacks");
+    }
 
     // #919: an explicit MODE=DISABLE suppresses MRT writes but must not suppress depth/stencil.
     // Presence matters because zero is also the historical value of an absent register in direct

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -133,6 +133,14 @@ renderer: the capture **seeds** the renderer-owned RTTs the frame *samples* (def
 temporal-AA history) with their live pixels (#1291), so a single submit no longer replays black. Drill
 into one submit with `--bundle-extract-submit K sub.prgcap`, then `--draw-steps` / `--inspect-only` /
 `--dump-resource`.
+For a scripted route with a stable guest phase line, set
+`PROSPER_CAPTURE_BUNDLE_AFTER_GUEST_LOG='exact complete line'` together with the existing
+`PROSPER_CAPTURE_BUNDLE=/path/frame.prgbundle` and optional `PROSPER_CAPTURE_BUNDLE_MAX_MB=N` settings.
+The matcher is one-shot, requires exact line equality (CR, LF, and CRLF are equivalent terminators), and
+arms the same seeded whole-frame capture after skipping exactly one completed present. It is safe across
+fragmented `printf`/`puts` output and deliberately rejects overlong lines; do not use a substring or a
+program address as a substitute for a real phase marker. Persistent color/depth targets must remain enabled
+so the bundle can seed the frame boundary it is intended to preserve.
 `PROSPER_SUBMITLOG_DIM=WxH` prints the exact renderer invocation for any submit targeting that Gen5
 surface extent, even while `PROSPER_RENDER_FIRST` skips Vulkan work. Use it to start a later render
 window on a one-time offscreen producer rather than after the producer has already been lost.

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -138,9 +138,11 @@ For a scripted route with a stable guest phase line, set
 `PROSPER_CAPTURE_BUNDLE=/path/frame.prgbundle` and optional `PROSPER_CAPTURE_BUNDLE_MAX_MB=N` settings.
 The matcher is one-shot, requires exact line equality (CR, LF, and CRLF are equivalent terminators), and
 arms the same seeded whole-frame capture after skipping exactly one completed present. It is safe across
-fragmented `printf`/`puts` output and deliberately rejects overlong lines; do not use a substring or a
-program address as a substitute for a real phase marker. Persistent color/depth targets must remain enabled
-so the bundle can seed the frame boundary it is intended to preserve.
+fragmented stdout `printf`/`puts`/`putchar`/`fputs`/`fwrite`/fd-write output and deliberately rejects
+overlong lines; non-stdout streams and descriptors are ignored. The one match diagnostic names every
+adapter that contributed to the line. Do not use a substring or a program address as a substitute for a
+real phase marker. Persistent color/depth targets must remain enabled so the bundle can seed the frame
+boundary it is intended to preserve.
 `PROSPER_SUBMITLOG_DIM=WxH` prints the exact renderer invocation for any submit targeting that Gen5
 surface extent, even while `PROSPER_RENDER_FIRST` skips Vulkan work. Use it to start a later render
 window on a one-time offscreen producer rather than after the producer has already been lost.

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -24,7 +24,9 @@ When the guest emits a deterministic phase line, a single run can bypass that ca
 set `PROSPER_CAPTURE_BUNDLE_AFTER_GUEST_LOG='exact complete line'` with
 `PROSPER_CAPTURE_BUNDLE=/path/frame.prgbundle`. The exact, bounded, one-shot line match skips one completed
 present and then records the following whole frame using the same persistent RTT/DS seeds as F9. The gate
-does not accept substrings; CR, LF, and CRLF differ only as line terminators. Keep persistent targets enabled.
+does not accept substrings; CR, LF, and CRLF differ only as line terminators. Fragmented guest stdout via
+`printf`, `puts`, `putchar`, `fputs`, `fwrite`, or fd writes is observed, and the match diagnostic names the
+contributing adapter(s). Non-stdout output is ignored. Keep persistent targets enabled.
 
 Normal capture preflights merged resource ranges and rejects plans above 512 MiB before allocating.
 `PROSPER_GPU_CAPTURE_MAX_MB=1..3072` overrides that bound. If descriptor metadata is the evidence you

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -20,6 +20,12 @@ The app logs both the guest-present count saved when it arms the screenshot and 
 the readback finishes. Use the armed count, not the host frame number or later written count: swapchain
 presents and guest VideoOut flips are separate clocks, and the guest can advance during readback.
 
+When the guest emits a deterministic phase line, a single run can bypass that calibration round trip:
+set `PROSPER_CAPTURE_BUNDLE_AFTER_GUEST_LOG='exact complete line'` with
+`PROSPER_CAPTURE_BUNDLE=/path/frame.prgbundle`. The exact, bounded, one-shot line match skips one completed
+present and then records the following whole frame using the same persistent RTT/DS seeds as F9. The gate
+does not accept substrings; CR, LF, and CRLF differ only as line terminators. Keep persistent targets enabled.
+
 Normal capture preflights merged resource ranges and rejects plans above 512 MiB before allocating.
 `PROSPER_GPU_CAPTURE_MAX_MB=1..3072` overrides that bound. If descriptor metadata is the evidence you
 need, `PROSPER_GPU_CAPTURE_METADATA_ONLY=1` writes a thin capsule with shaders, operations, pipeline


### PR DESCRIPTION
Continues #1459.

## Failure scenario

Late-scene graphics defects were difficult to retain reproducibly. Wall-time and frame-count capture windows drift badly when complex titles render at a few FPS, while an F9 injection can miss the Wayland window. Astro Bot also emits its world-map phase line through `sceKernelWrite`, a stdout path the first observer did not see. Earlier generic captures consequently stopped before the authored world map or retained unrelated boot frames.

## Behavioral contract

- `PROSPER_CAPTURE_BUNDLE_AFTER_GUEST_LOG` matches one exact bounded guest stdout line, treats CR/LF/CRLF as terminators, remains fragment-safe across adapters, and arms the established whole-frame bundle path after one completed present.
- Marker observation covers successful `printf`, `puts`, `putchar`, `fputs`, `fwrite`, and fd-1 writes. Non-stdout streams/descriptors are ignored, and partial writes contribute only bytes reported successful.
- A line may span multiple adapters; the match diagnostic names every contributing source.
- The gate is disabled by default, one-shot, bounded to 4,096 bytes, and requires the normal bundle path/max configuration.
- Optional raw late-draw color-state tracing records the exact programmed mode/mask/helper provenance without changing render-state classification. Environment parsing is cached so disabled tracing does not add repeated hot-path lookups.

## Scope and risk

This PR adds diagnostics and deterministic capture selection only. It does not change shader translation, resource binding, color-write behavior, draw execution, or presentation semantics. The main risks are false marker matches, duplicated stdout observation, and hot-path overhead; exact-line, gap, returned-count, adapter-provenance, one-shot, and cached-configuration tests cover those boundaries.

## Live proof

A normal-rendering fresh-save Astro Bot run at evidence revision `c5698376f325e819fb130fbcf8a9974ae97a09bc` used guest-frame input windows and reached `title_controller_ship`, `Continue: worldmap`, then the exact line `LevelDocument Loaded: worldmap [worldmap]`. The diagnostic reported `matched via write`, proving the newly covered fd-1 path mattered. After one completed present, the gate retained a 7-submit 3840x2160 bundle ending at submit 6284 with its boundary scanout seed.

Bundle SHA-256: `20117d488bd01434cbc89a4fb315241990820e8ed857fc055906f7fc1718594d`.

Offline replay succeeds, but the result is black/near-black and reports two failed intermediate renders plus seven unresolved producer dependencies. This proves deterministic authored-world-map capture, not visible world-map rendering. No screenshot is attached because there is no meaningful visible content yet. Full evidence is recorded on issue #1459.

## Verification

Exact PR head `ddd60f7358c8e4b83109a73bc90a3f8c7c638155`, rebased on master `1634c1e7597731b4d2a5da8d616e2755ef202518`.

Passed:
- build `prosper-app`
- `guest_log_capture`
- `printf_varargs`
- `file_binary_roundtrip`
- `gpu_timeline_roundtrip`
- `git diff --check`

The full snapshot suite was not run for this ordinary development/tooling PR. No baseline is changed.