### PR TITLE
gpu: compose counted loops with structured preludes

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -12820,7 +12820,8 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                bool allow_exec_update, bool allow_smem,
                const std::function<bool(RegState&, const Rdna2Inst&)>& exp_fn,
                const uint32_t* code = nullptr, size_t dwords = 0,
-               const std::unordered_set<uint32_t>* inherited_dead_masks = nullptr) {
+               const std::unordered_set<uint32_t>* inherited_dead_masks = nullptr,
+               bool allow_cfg_dispatcher = true) {
                // code/dwords: raw stream for forward-if target checks; inherited_dead_masks keeps
                // whole-shader liveness valid when a barrier-separated body is compiled in phases.
     rs.max_vgpr = std::max(rs.max_vgpr, shader_max_vgpr(ins));
@@ -13056,11 +13057,12 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
         // detect_forward_ifs clamps a branch to an immediate s_endpgm at its artificial end marker
         // and records it as early_out. In this truncated prelude that can be a real branch over the
         // entire counted loop, so it cannot be structured as an ordinary one-arm conditional.
-        const bool preloop_if_unsupported = !preloop_ifs.empty() &&
-            (preloop_ifs[0].early_out ||
-             (preloop_ifs[0].has_else ? preloop_ifs[0].merge_pc : preloop_ifs[0].target_pc) >
-                 L.header_pc);
-        if (preloop_rejected || preloop_ifs.size() > 1 || preloop_if_unsupported) {
+        const bool preloop_if_unsupported = std::any_of(
+            preloop_ifs.begin(), preloop_ifs.end(), [&](const ForwardIf& branch) {
+                return branch.early_out ||
+                    (branch.has_else ? branch.merge_pc : branch.target_pc) > L.header_pc;
+            });
+        if (preloop_rejected || preloop_if_unsupported) {
             if (getenv("PROSPER_DBG"))
                 fprintf(stderr,
                         "[recompile-reject] counted-loop prelude cfg rejected=%u ifs=%zu header=%u\n",
@@ -13069,6 +13071,26 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
         }
         if (preloop_ifs.empty()) {
             if (!emit_range(0, L.header_pc)) return false;
+        } else if (preloop_ifs.size() > 1) {
+            // The general structurizer already owns nested and disjoint ForwardIf trees, including
+            // exact guest-wave EXEC/VCC tests in compute. Reuse it for a multi-choice prefix instead
+            // of duplicating another recursive IF emitter inside the counted-loop path. Keep every
+            // real prefix instruction here (including a proven-safe guard spanning the whole loop):
+            // the truncated scan above intentionally omitted that guard only so it was not mistaken
+            // for an early-out at the artificial end marker. effective_safe still makes emit_alu
+            // linearize a proven spanning guard, and inherited dead masks retain whole-shader liveness.
+            std::vector<Rdna2Inst> preloop_body;
+            for (const auto& in : ins) {
+                if (in.pc >= L.header_pc) break;
+                preloop_body.push_back(in);
+            }
+            preloop_body.push_back(preloop_end);
+            if (!emit_body(b, rs, preloop_body, effective_safe, rt, allow_exec_update,
+                           allow_smem, exp_fn, code, dwords, &dead_masks,
+                           /*allow_cfg_dispatcher*/false))
+                return false;
+            while (idx < ins.size() && ins[idx].pc < L.header_pc) ++idx;
+            if (idx >= ins.size() || ins[idx].pc != L.header_pc) return false;
         } else {
             const ForwardIf F = preloop_ifs[0];
             if (!emit_range(0, F.branch_pc)) return false;
@@ -13410,7 +13432,7 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                          "structured_ifs=%zu loops=%zu cf_rejected=%d\n",
                          b.is_fragment ? "fragment" : "vertex", cfg_branches,
                          cfg_has_backedge, complex_graphics_cfg, Fs.size(), Ls.size(), cf_rejected);
-        if (exact_compute_wave_cfg && !structured_compute_wave_cfg) {
+        if (allow_cfg_dispatcher && exact_compute_wave_cfg && !structured_compute_wave_cfg) {
             // Native Vulkan subgroup widths may be 8/16/32 while the guest wave is 32/64. A native
             // subgroupAny would let different pieces of one guest wave take different scalar edges.
             // The dispatcher performs the reduction through Workgroup scratch and synchronized common
@@ -13423,7 +13445,7 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                 return false;
             return true;
         }
-        if (complex_compute_cfg && (cf_rejected || Ls.empty()) &&
+        if (allow_cfg_dispatcher && complex_compute_cfg && (cf_rejected || Ls.empty()) &&
             emit_cfg_state_machine(b, rs, ins, safe, rt,
                                    allow_exec_update, allow_smem, exp_fn, code, dwords))
             return true;
@@ -13431,7 +13453,7 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
         // control flow therefore needs no workgroup vote: the dispatcher selects the next block from
         // this pixel/vertex's SCC, VCC, or EXEC bit. Keep ordinary structured shaders on their compact
         // SSA path and use the Function-variable fallback only after the narrow structurizer rejects.
-        if (complex_graphics_cfg && cf_rejected &&
+        if (allow_cfg_dispatcher && complex_graphics_cfg && cf_rejected &&
             emit_cfg_state_machine(b, rs, ins, safe, rt,
                                    allow_exec_update, allow_smem, exp_fn, code, dwords))
             return true;
@@ -14154,9 +14176,47 @@ RecompileCoverage recompile_coverage(const uint32_t* code, size_t dwords) {
     // back-edge + exit, and the forward-if branch) as handled, so coverage matches what actually recompiles
     // (previously the MSAA-resolve loop shaders 031-034 were mis-flagged "blocked" at their s_cbranch_scc0).
     const CountedLoop cL = detect_counted_loop(ins);
-    const std::vector<ForwardIf> cFs = detect_forward_ifs(ins, /*allow_vcc*/false, code, dwords,
-                                                          nullptr, nullptr, nullptr,
-                                                          /*compute_wave_branches*/true);   // matches the compute shell (#590)
+    std::vector<ForwardIf> cFs;
+    if (cL.found) {
+        // Match emit_body's counted-loop composition: inspect the truncated prefix independently
+        // from the loop exit/back-edge, then inspect the recursively-emitted suffix. Feeding the
+        // complete stream to detect_forward_ifs makes the canonical exit look like an IF whose
+        // alleged else terminator is the backward loop branch, so otherwise-valid prefix/postfix
+        // branches are incorrectly counted as unsupported.
+        std::vector<Rdna2Inst> prefix;
+        for (const auto& in : ins) {
+            if (in.pc >= cL.header_pc) break;
+            if (in.fmt == Rdna2Format::SOPP && in.opcode == 0x08 &&
+                branch_target(in) >= cL.header_pc) continue;
+            prefix.push_back(in);
+        }
+        Rdna2Inst prefix_end;
+        prefix_end.pc = cL.header_pc;
+        prefix_end.is_end = true;
+        prefix.push_back(prefix_end);
+        bool prefix_rejected = false;
+        std::vector<ForwardIf> prefix_ifs = detect_forward_ifs(
+            prefix, /*allow_vcc*/false, code, dwords, &safe_branches, nullptr,
+            &prefix_rejected, /*compute_wave_branches*/true);
+        const bool prefix_crosses_loop = std::any_of(
+            prefix_ifs.begin(), prefix_ifs.end(), [&](const ForwardIf& branch) {
+                return branch.early_out ||
+                    (branch.has_else ? branch.merge_pc : branch.target_pc) > cL.header_pc;
+            });
+        if (!prefix_rejected && !prefix_crosses_loop)
+            cFs.insert(cFs.end(), prefix_ifs.begin(), prefix_ifs.end());
+
+        std::vector<Rdna2Inst> suffix;
+        for (const auto& in : ins) if (in.pc >= cL.exit_pc) suffix.push_back(in);
+        std::vector<ForwardIf> suffix_ifs = detect_forward_ifs(
+            suffix, /*allow_vcc*/false, code, dwords, &safe_branches, nullptr, nullptr,
+            /*compute_wave_branches*/true);
+        cFs.insert(cFs.end(), suffix_ifs.begin(), suffix_ifs.end());
+    } else {
+        cFs = detect_forward_ifs(ins, /*allow_vcc*/false, code, dwords,
+                                 nullptr, nullptr, nullptr,
+                                 /*compute_wave_branches*/true);   // matches the compute shell (#590)
+    }
     auto cf_reconstructed = [&](const Rdna2Inst& i) {
         if (cL.found && (i.pc == cL.backedge_pc || i.pc == cL.exit_branch_pc)) return true;
         for (const auto& F : cFs)

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -2630,6 +2630,89 @@ int main() {
     CHECK(got43a_taken.size() == N && got43a_skipped.size() == N && bad43a == 0,
           "kernel 43a merges taken/skipped pre-loop values into the counted loop exactly");
 
+    // Kernel 43a2: TWO disjoint choices before the same counted loop. This is the composition used by
+    // Plucky Squire's histogram kernel: an exact guest-wave EXECZ one-arm region is followed by a
+    // scalar SCC if/else, and both merged values seed the counted loop. Wave 0 enters the EXEC arm
+    // (s4=3); wave 1 is empty and skips it (s4=0). Compile both scalar outcomes so all four material
+    // combinations reach the loop: (EXEC enter/skip) x (SCC then/else).
+    const uint32_t code43a2_then[] = {
+        0x7E000F00u, 0x7E020F01u, 0xBE840380u, 0x7DA80300u, 0xBF880001u,
+        0xBE840383u, 0xBEFE04C1u, 0xB0020003u, 0xB0030005u, 0xBF0A0302u,
+        0xBF840002u, 0xBE85038Au, 0xBF820001u, 0xBE850394u, 0x80060504u,
+        0xB0010005u, 0xBE800380u, 0xBF0A0100u, 0xBF840003u, 0x80060006u,
+        0x81008100u, 0xBF82FFFBu, 0x7E040C06u, 0xBF810000u,
+    };
+    const uint32_t code43a2_else[] = {
+        0x7E000F00u, 0x7E020F01u, 0xBE840380u, 0x7DA80300u, 0xBF880001u,
+        0xBE840383u, 0xBEFE04C1u, 0xB0020005u, 0xB0030003u, 0xBF0A0302u,
+        0xBF840002u, 0xBE85038Au, 0xBF820001u, 0xBE850394u, 0x80060504u,
+        0xB0010005u, 0xBE800380u, 0xBF0A0100u, 0xBF840003u, 0x80060006u,
+        0x81008100u, 0xBF82FFFBu, 0x7E040C06u, 0xBF810000u,
+    };
+    const RecompileCoverage coverage43a2_then = recompile_coverage(
+        code43a2_then, std::size(code43a2_then));
+    const RecompileCoverage coverage43a2_else = recompile_coverage(
+        code43a2_else, std::size(code43a2_else));
+    CHECK(coverage43a2_then.unsupported == 0 && coverage43a2_else.unsupported == 0,
+          "kernel 43a2 coverage claims both pre-loop choices and the counted loop");
+    const auto spv43a2_then = recompile_valu(
+        code43a2_then, std::size(code43a2_then), 2, 2);
+    const auto spv43a2_else = recompile_valu(
+        code43a2_else, std::size(code43a2_else), 2, 2);
+    CHECK(!spv43a2_then.empty() && !spv43a2_else.empty(),
+          "recompiled kernel 43a2 (EXEC one-arm + SCC if/else + counted loop) -> SPIR-V");
+    std::vector<float> in43a2(N * 2), exp43a2_then(N), exp43a2_else(N);
+    for (uint32_t i = 0; i < N; ++i) {
+        const bool exec_arm = i < 64;
+        in43a2[i * 2 + 0] = exec_arm ? 2.0f : 1.0f;
+        in43a2[i * 2 + 1] = exec_arm ? 1.0f : 2.0f;
+        exp43a2_then[i] = exec_arm ? 23.0f : 20.0f;
+        exp43a2_else[i] = exec_arm ? 33.0f : 30.0f;
+    }
+    const auto got43a2_then = prosper::test::run_compute(spv43a2_then, in43a2, N, N);
+    const auto got43a2_else = prosper::test::run_compute(spv43a2_else, in43a2, N, N);
+    uint32_t bad43a2 = 0;
+    for (uint32_t i = 0;
+         i < N && got43a2_then.size() == N && got43a2_else.size() == N; ++i) {
+        if (got43a2_then[i] != exp43a2_then[i] ||
+            got43a2_else[i] != exp43a2_else[i]) ++bad43a2;
+    }
+    CHECK(got43a2_then.size() == N && got43a2_else.size() == N && bad43a2 == 0,
+          "kernel 43a2 preserves all EXEC/SCC pre-loop PHI combinations through the loop");
+
+    // A per-wave VCC early-out may not contain a workgroup barrier: different waves can take
+    // different arms, which would make Vulkan barrier participation non-uniform. The accepted
+    // two-choice prelude and counted loop must not hide that independent post-loop rejection.
+    const uint32_t code43a2_barrier_vcc[] = {
+        0x7E000F00u, 0x7E020F01u, 0xBE840380u, 0x7DA80300u, 0xBF880001u,
+        0xBE840383u, 0xBEFE04C1u, 0xB0020003u, 0xB0030005u, 0xBF0A0302u,
+        0xBF840002u, 0xBE85038Au, 0xBF820001u, 0xBE850394u, 0x80060504u,
+        0xB0010005u, 0xBE800380u, 0xBF0A0100u, 0xBF840003u, 0x80060006u,
+        0x81008100u, 0xBF82FFFBu, 0x7E040C06u, 0x7C020300u, 0xBF860002u,
+        0xBF8A0000u, 0x7E040281u, 0xBF810000u,
+    };
+    const RecompileCoverage coverage43a2_barrier_vcc = recompile_coverage(
+        code43a2_barrier_vcc, std::size(code43a2_barrier_vcc));
+    CHECK(coverage43a2_barrier_vcc.unsupported == 1 &&
+              coverage43a2_barrier_vcc.first_bad_fmt >= 0 &&
+              coverage43a2_barrier_vcc.first_bad_op == 0x06u &&
+              coverage43a2_barrier_vcc.first_bad_pc == 24u,
+          "kernel 43a2 leaves only the post-loop VCCZ-with-barrier branch unsupported");
+    CHECK(recompile_valu(code43a2_barrier_vcc, std::size(code43a2_barrier_vcc), 2, 2).empty(),
+          "kernel 43a2 rejects a per-wave VCC arm spanning a workgroup barrier");
+
+    // Partially-overlapping pre-loop regions are not a structured IF tree. Their branch intervals
+    // [3,7) and [5,9) cross, so the prefix must reject instead of entering the counted loop with
+    // invented merge semantics.
+    const uint32_t code43a2_overlap[] = {
+        0xBE800383u, 0xBE810385u, 0xBF0A0100u, 0xBF840003u, 0xBF0A0100u,
+        0xBF840003u, 0xBE830381u, 0xBE830382u, 0xBE830383u, 0xB0020005u,
+        0xBE800380u, 0x7E020280u, 0xBF0A0200u, 0xBF840003u, 0x4A020200u,
+        0x81008100u, 0xBF82FFFBu, 0x7E000D01u, 0xBF810000u,
+    };
+    CHECK(recompile_valu(code43a2_overlap, std::size(code43a2_overlap), 0, 0).empty(),
+          "kernel 43a2 rejects partially-overlapping pre-loop IF regions");
+
     // Kernel 43b: a pre-loop conditional that jumps over the complete counted loop to s_endpgm.
     // The prelude CFG scan uses the loop header as an artificial end marker, so it must preserve the
     // early-out classification and reject rather than silently execute the loop on both outcomes.


### PR DESCRIPTION
## Summary

- compose multiple already-supported structured prelude conditionals with the existing counted-loop lowering
- keep recursive prefix emission on the structured path so it cannot silently fall into the generic CFG dispatcher
- make coverage use the same truncated-prefix and post-loop classification as the real emitter
- retain fail-visible rejection for overlapping regions, early-outs across the loop, and per-wave branches spanning a workgroup barrier

## Why

The retained Plucky Squire compute shader at `0x3017460000` contains two disjoint choices before a canonical counted loop: an EXECZ one-arm region followed by an SCC if/else. Each construct was already supported, but the counted-loop path rejected any prefix containing more than one forward conditional.

This change composes those existing transformations instead of adding title-specific behavior. On the exact retained 8,448-byte shader, offline coverage advances from four unsupported control-flow instructions to one:

- `total=1326`
- `alu=1260`
- `table=65`
- `unsupported=1`
- remaining rejection: VCC branch at pc 915 contains a synchronized `S_BARRIER` at pc 1118

That final region is intentionally untouched: without a workgroup-uniformity proof, translating a per-wave arm across a workgroup barrier would be unsafe. The complete raw stage therefore still rejects, and this PR does not claim a visible Plucky milestone.

## Verification

Focused CTest run, 7/7 passed:

- `recompile_coverage`
- `rdna2_spirv_struct`
- `game_compute_exec`
- `game_compute_exec_no_adaptive_storage_result`
- `rdna2_to_spirv_exec`
- `recompiled_fragment_render`
- `recompiled_shaders_render`

Additional checks:

- exact retained shader coverage: one deliberate unsupported branch remains
- exact raw-stage recompile: rejects as expected
- `git diff --check` passed
- no live game run; no snapshot suite (optional for ordinary PR development)

## Traceability

Continues #1554. The merged live baseline proved `0x3017450000` executes and identified `0x3017460000` as the immediate next shader. This PR is the next generic, evidence-led control-flow step.