### PR TITLE
tools(gpu_replay): report resolved SPI_PS_INPUT_CNTL linkage in --inspect-only

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -725,6 +725,12 @@ if(TARGET prosper_core)
   target_link_libraries(test_gpu_replay_shader_dump PRIVATE prosper_core)
   add_test(NAME gpu_replay_shader_dump COMMAND test_gpu_replay_shader_dump)
 
+  # Offline SPI_PS_INPUT_CNTL linkage classification: a pixel-shader input wired to the constant
+  # form consumes no producer export, and must never be reported as a PARAM consumer.
+  add_executable(test_gpu_replay_pixel_inputs tests/test_gpu_replay_pixel_inputs.cpp)
+  target_link_libraries(test_gpu_replay_pixel_inputs PRIVATE prosper_core)
+  add_test(NAME gpu_replay_pixel_inputs COMMAND test_gpu_replay_pixel_inputs)
+
   add_executable(test_gpu_dependency_graph tests/test_gpu_dependency_graph.cpp)
   target_link_libraries(test_gpu_dependency_graph PRIVATE prosper_core)
   add_test(NAME gpu_dependency_graph COMMAND test_gpu_dependency_graph)

--- a/prosper/tests/test_gpu_replay_pixel_inputs.cpp
+++ b/prosper/tests/test_gpu_replay_pixel_inputs.cpp
@@ -1,0 +1,124 @@
+// Offline SPI_PS_INPUT_CNTL linkage classification (see tools/gpu_replay/pixel_input_linkage.hpp).
+//
+// The distinction this pins down is behavioral, not cosmetic: an input wired to the constant form
+// (OFFSET=0x20) consumes NO producer export, so reporting it as "param 32" — or worse, silently as
+// "param 0" after masking — would tell an investigator that a varying carries real vertex-stage
+// data when the interpolator is actually synthesizing a constant. That is precisely the question an
+// offline capsule investigation needs answered, so every branch is asserted here.
+
+#include "../tools/gpu_replay/pixel_input_linkage.hpp"
+
+#include <cstdio>
+
+using namespace prosper::gpu;
+using namespace prosper::gpu::replay_tool;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { std::printf("  [FAIL] %s\n", m); ++fails; } \
+                         else std::printf("  [ok]   %s\n", m); } while (0)
+
+int main() {
+    std::printf("== test_gpu_replay_pixel_inputs ==\n");
+
+    {
+        // A slot outside valid_mask consumes nothing, whatever its stale control word says.
+        PixelInputMapping mapping;
+        mapping.controls[4] = 7;
+        mapping.valid_mask = 0;
+        const auto linkage = pixel_input_linkage(mapping, 4);
+        CHECK(linkage.kind == PixelInputKind::Unused, "invalid slot reports Unused");
+    }
+
+    {
+        // Ordinary linkage: OFFSET names the producer PARAM slot directly.
+        PixelInputMapping mapping;
+        mapping.controls[1] = 1;
+        mapping.controls[2] = 3;
+        mapping.valid_mask = (1u << 1) | (1u << 2);
+        const auto one = pixel_input_linkage(mapping, 1);
+        CHECK(one.kind == PixelInputKind::Param && one.param == 1, "input1 -> PARAM1");
+        const auto two = pixel_input_linkage(mapping, 2);
+        CHECK(two.kind == PixelInputKind::Param && two.param == 3, "input2 -> PARAM3");
+    }
+
+    {
+        // OFFSET=0x20 is the constant form. This is the case the whole diagnostic exists for:
+        // it must NOT be reported as consuming a PARAM export.
+        PixelInputMapping mapping;
+        mapping.controls[6] = 0x20u;
+        mapping.valid_mask = 1u << 6;
+        const auto linkage = pixel_input_linkage(mapping, 6);
+        CHECK(linkage.kind == PixelInputKind::ConstantDefault,
+              "OFFSET=0x20 reports ConstantDefault, not a PARAM consumer");
+        CHECK(!linkage.default_xyz_one && !linkage.default_w_one,
+              "DEFAULT_VAL=0 -> xyz 0.0, w 0.0");
+    }
+
+    {
+        // GFX10 DEFAULT_VAL picks 0.0/1.0 independently for xyz and for w. A varying defaulted to
+        // 1.0 is indistinguishable from a legitimately-computed 1.0 downstream, so decode it here.
+        PixelInputMapping mapping;
+        mapping.valid_mask = (1u << 0) | (1u << 1) | (1u << 2);
+        mapping.controls[0] = 0x20u | (1u << 8);   // DEFAULT_VAL=1
+        mapping.controls[1] = 0x20u | (2u << 8);   // DEFAULT_VAL=2
+        mapping.controls[2] = 0x20u | (3u << 8);   // DEFAULT_VAL=3
+        const auto w_one = pixel_input_linkage(mapping, 0);
+        CHECK(w_one.kind == PixelInputKind::ConstantDefault &&
+              !w_one.default_xyz_one && w_one.default_w_one,
+              "DEFAULT_VAL=1 -> xyz 0.0, w 1.0");
+        const auto xyz_one = pixel_input_linkage(mapping, 1);
+        CHECK(xyz_one.kind == PixelInputKind::ConstantDefault &&
+              xyz_one.default_xyz_one && !xyz_one.default_w_one,
+              "DEFAULT_VAL=2 -> xyz 1.0, w 0.0");
+        const auto both = pixel_input_linkage(mapping, 2);
+        CHECK(both.kind == PixelInputKind::ConstantDefault &&
+              both.default_xyz_one && both.default_w_one,
+              "DEFAULT_VAL=3 -> xyz 1.0, w 1.0");
+    }
+
+    {
+        // Explicit parameter-cache pass-through: OFFSET bit 5 + FLAT_SHADE with a nonzero low
+        // OFFSET. The consumed PARAM is the LOW five bits, not the full six-bit OFFSET field.
+        PixelInputMapping mapping;
+        mapping.controls[3] = 0x420u | 5u;
+        mapping.valid_mask = 1u << 3;
+        const auto linkage = pixel_input_linkage(mapping, 3);
+        CHECK(linkage.kind == PixelInputKind::ParamPassthrough && linkage.param == 5,
+              "pass-through encoding -> PARAM5 via the low five OFFSET bits");
+    }
+
+    {
+        // The ambiguous PARAM0 pass-through encoding (0x420 with a zero low OFFSET) is NOT treated
+        // as pass-through by effective_passthrough_mask(), so it falls through to the constant
+        // form. Pinned so the classifier keeps agreeing with the recompiler's own predicate.
+        PixelInputMapping mapping;
+        mapping.controls[3] = 0x420u;
+        mapping.valid_mask = 1u << 3;
+        const auto linkage = pixel_input_linkage(mapping, 3);
+        CHECK(linkage.kind == PixelInputKind::ConstantDefault,
+              "ambiguous 0x420 PARAM0 encoding follows the constant form");
+    }
+
+    {
+        // An explicitly-flagged pass-through slot is honored even without the register encoding
+        // (this is the metadata-derived path).
+        PixelInputMapping mapping;
+        mapping.controls[7] = 2u;
+        mapping.valid_mask = 1u << 7;
+        mapping.passthrough_mask = 1u << 7;
+        const auto linkage = pixel_input_linkage(mapping, 7);
+        CHECK(linkage.kind == PixelInputKind::ParamPassthrough && linkage.param == 2,
+              "explicit passthrough_mask slot -> ParamPassthrough");
+    }
+
+    {
+        // Out-of-range slots never read past the fixed 32-entry control array.
+        PixelInputMapping mapping;
+        mapping.valid_mask = 0xffffffffu;
+        const auto linkage = pixel_input_linkage(mapping, 32);
+        CHECK(linkage.kind == PixelInputKind::Unused, "slot 32 is out of range and reports Unused");
+    }
+
+    std::printf(fails ? "== FAILED (%d) ==\n" : "== PASSED ==\n", fails);
+    return fails ? 1 : 0;
+}

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -94,6 +94,33 @@ not ask for — visible **offline** from a capsule, without a live boot. It was 
 menu wedges) could only be diagnosed by booting the game repeatedly with `PROSPER_DRAWLOG`; the capsule stored
 only the realized `vcount=1024`, hiding that the guest's real count was 6.
 
+## Interpolant linkage — `ps-inputs` on each `--inspect-only` draw line (#1486)
+
+Each draw also reports the resolved `SPI_PS_INPUT_CNTL` linkage retained with the capture (v36+):
+
+```text
+  ps-inputs valid=ffffffff passthrough=00000000 effective-passthrough=00000000 0=param0 1=param1 2=param2 …
+```
+
+Each `N=…` entry names what pixel-shader input slot `N` actually consumes:
+
+- `param<K>` — consumes producer PARAM export `K`.
+- `param<K>/pass` — explicit parameter-cache pass-through of PARAM `K`.
+- `default(xyz=…,w=…)` — `OFFSET=0x20`: the interpolator **synthesizes a constant** and consumes no
+  producer export at all. `DEFAULT_VAL` selects 0.0 or 1.0 independently for xyz and for w.
+
+Slots outside `valid` are omitted; a pre-v36 capture prints `ps-inputs none` rather than inventing a mapping.
+
+This answers "is this varying carrying real vertex-stage data, or a hardware constant?" — a question the VS/FS
+instruction streams cannot answer on their own, because a shader wired to `default` looks perfectly correct in
+isolation while receiving no producer output. `PROSPER_INTERPLOG` reports the same linkage but only fires on
+the **live executor** path, so offline capsule analysis previously had no way to see it. It was added while
+localizing #1486's overexposed Dragon Quest VII composite, to decide whether the tonemapper's `ExposureScale`
+varying reached the pixel shader from the vertex stage or was being replaced by a constant 1.0 (it reached it:
+draw 90 reports `1=param1`, matching the VS's `PARAM1` export). The classifier lives in
+`pixel_input_linkage.hpp` and mirrors `recompile_vertex_impl`'s own export predicates, so the diagnostic
+cannot describe a mapping the lowering does not perform; `test_gpu_replay_pixel_inputs` pins every branch.
+
 ## Reading graph output
 
 - `edge producer=P consumer=C` means operation `C` reads a range last written by earlier operation `P`.

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -8,6 +8,7 @@
 #include "replay_output_extent.hpp"
 #include "compute_recompile.hpp"
 #include "realized_shader_dump.hpp"
+#include "pixel_input_linkage.hpp"
 #include "render_runner.h"
 
 #include <algorithm>
@@ -450,6 +451,38 @@ void inspect_frame(const prosper::gpu::GpuReplayFrame& replay) {
                     d.ps.src_color_blend_factor, d.ps.dst_color_blend_factor, d.ps.color_blend_op,
                     d.ps.src_alpha_blend_factor, d.ps.dst_alpha_blend_factor, d.ps.alpha_blend_op,
                     d.ps.logic_op_enable, d.ps.logic_op);
+        // Resolved SPI_PS_INPUT_CNTL linkage (see pixel_input_linkage.hpp): which producer PARAM
+        // slot each pixel-shader input actually reads, or whether the interpolator synthesizes a
+        // constant instead. Retained since capture v36; older captures print `none` rather than
+        // inventing a mapping.
+        if (!d.has_pixel_inputs) {
+            std::printf("  ps-inputs none\n");
+        } else {
+            const auto& pi = d.pixel_inputs;
+            const uint32_t effective = pi.effective_passthrough_mask();
+            std::printf("  ps-inputs valid=%08x passthrough=%08x effective-passthrough=%08x",
+                        pi.valid_mask, pi.passthrough_mask, effective);
+            for (uint32_t input = 0; input < pi.controls.size(); ++input) {
+                const auto linkage = prosper::gpu::replay_tool::pixel_input_linkage(
+                    pi, input, effective);
+                switch (linkage.kind) {
+                    case prosper::gpu::replay_tool::PixelInputKind::Unused:
+                        break;
+                    case prosper::gpu::replay_tool::PixelInputKind::Param:
+                        std::printf(" %u=param%u", input, linkage.param);
+                        break;
+                    case prosper::gpu::replay_tool::PixelInputKind::ParamPassthrough:
+                        std::printf(" %u=param%u/pass", input, linkage.param);
+                        break;
+                    case prosper::gpu::replay_tool::PixelInputKind::ConstantDefault:
+                        std::printf(" %u=default(xyz=%s,w=%s)", input,
+                                    linkage.default_xyz_one ? "1.0" : "0.0",
+                                    linkage.default_w_one ? "1.0" : "0.0");
+                        break;
+                }
+            }
+            std::printf("\n");
+        }
         for (uint32_t slot = 2; slot < d.color_targets.size(); ++slot) {
             const auto& target = d.color_targets[slot];
             const auto& pipeline = d.ps.color_targets[slot];

--- a/prosper/tools/gpu_replay/pixel_input_linkage.hpp
+++ b/prosper/tools/gpu_replay/pixel_input_linkage.hpp
@@ -1,0 +1,72 @@
+#pragma once
+
+#include "gpu/rdna2_to_spirv.hpp"
+
+#include <cstdint>
+
+namespace prosper::gpu::replay_tool {
+
+// Offline classification of the resolved SPI_PS_INPUT_CNTL linkage retained with a captured draw
+// (capture v36+).
+//
+// Why this exists: a pixel-shader input either consumes a producer PARAM export or asks the
+// interpolator to synthesize a CONSTANT instead. Nothing in the VS/FS instruction streams reveals
+// which — a varying wired to `default` carries no producer data at all, so a stage that looks
+// perfectly correct in isolation can still be fed a hardware constant. `PROSPER_INTERPLOG` reports
+// the same linkage but only fires on the live executor path, so capsule analysis had no way to see
+// it. Deciding whether a suspect varying is real producer output or a synthesized constant
+// otherwise required a live boot.
+//
+// The predicates below deliberately mirror recompile_vertex_impl's export lowering (the
+// effective-passthrough test, the OFFSET==0x20 constant form, and the DEFAULT_VAL decode) so this
+// diagnostic can never describe a mapping the lowering does not actually perform.
+
+enum class PixelInputKind {
+    Unused,            // the control is not valid for this input slot
+    Param,             // consumes producer PARAM `param`
+    ConstantDefault,   // OFFSET=0x20: interpolator synthesizes a constant, no PARAM consumed
+    ParamPassthrough,  // explicit parameter-cache pass-through of PARAM `param`
+};
+
+struct PixelInputLinkage {
+    PixelInputKind kind = PixelInputKind::Unused;
+    // Producer PARAM slot for Param / ParamPassthrough. Meaningless for the other kinds.
+    uint32_t param = 0;
+    // ConstantDefault only: GFX10 DEFAULT_VAL selects 0.0 or 1.0 independently for xyz and for w.
+    bool default_xyz_one = false;
+    bool default_w_one = false;
+};
+
+// Classify one pixel-shader input slot. `effective_passthrough` is the caller-hoisted result of
+// mapping.effective_passthrough_mask(); it is passed in so a loop over all 32 slots does not
+// recompute that O(32) scan per slot.
+inline PixelInputLinkage pixel_input_linkage(const PixelInputMapping& mapping, uint32_t input,
+                                             uint32_t effective_passthrough) {
+    PixelInputLinkage linkage;
+    if (input >= mapping.controls.size()) return linkage;
+    if (!(mapping.valid_mask & (1u << input))) return linkage;
+
+    const uint32_t control = mapping.controls[input];
+    if (effective_passthrough & (1u << input)) {
+        linkage.kind = PixelInputKind::ParamPassthrough;
+        linkage.param = control & 0x1Fu;
+        return linkage;
+    }
+    const uint32_t raw_offset = control & 0x3Fu;
+    if (raw_offset == 0x20u) {
+        linkage.kind = PixelInputKind::ConstantDefault;
+        const uint32_t default_val = (control >> 8) & 0x3u;
+        linkage.default_xyz_one = (default_val & 0x2u) != 0u;
+        linkage.default_w_one = (default_val & 0x1u) != 0u;
+        return linkage;
+    }
+    linkage.kind = PixelInputKind::Param;
+    linkage.param = raw_offset;
+    return linkage;
+}
+
+inline PixelInputLinkage pixel_input_linkage(const PixelInputMapping& mapping, uint32_t input) {
+    return pixel_input_linkage(mapping, input, mapping.effective_passthrough_mask());
+}
+
+}  // namespace prosper::gpu::replay_tool


### PR DESCRIPTION
## Purpose

Adds an offline diagnostic seam to `gpu_replay --inspect-only`: the resolved `SPI_PS_INPUT_CNTL`
linkage for every realized draw. Supports the investigation on #1486; it is **not** a fix and does
not change any rendered output.

## Failure scenario this closes

A pixel-shader input either consumes a producer `PARAM` export or asks the interpolator to
synthesize a **constant** instead. Nothing in the VS/FS instruction streams reveals which — a
varying wired to `default` carries no producer data at all, so a stage that looks perfectly correct
in isolation can still be fed a hardware constant.

`PROSPER_INTERPLOG` already reports this linkage, but **only fires on the live executor path**.
Capsule analysis therefore had no way to see it, and deciding whether a suspect varying was real
producer output or a synthesized constant required a live boot — which is exactly the loop this
project tries to avoid for a question answerable from a retained capsule.

This mattered concretely on Dragon Quest VII: proving that draw90's exposure interpolant is
`1=param1` — a real `PARAM1` export of the `IMAGE_LOAD` result, consumed at `pc=0177`
(`v9 = s97 * v6`) — rather than a synthesized constant, was a load-bearing step in clearing the
auto-exposure delivery path.

## Behavioral contract

- Data comes from `PixelInputMapping`, retained since **capture v36**. Nothing new is captured.
- A draw without retained pixel inputs prints `ps-inputs none`. Older captures are **never** given
  an invented mapping.
- The classifier deliberately mirrors `recompile_vertex_impl`'s export lowering — the
  effective-passthrough test, the `OFFSET == 0x20` constant form, and the GFX10 `DEFAULT_VAL` decode
  (0.0/1.0 selected independently for xyz and for w) — so the diagnostic can never describe a
  mapping the lowering does not actually perform.
- Output is additive: a new `ps-inputs` line per draw. Every existing `--inspect` field is
  unchanged.

Classification is `Unused` / `Param` / `ParamPassthrough` / `ConstantDefault`.

## Scope

Purely additive: **+262 lines across 5 files, zero deletions.** Tooling and tests only — no
renderer, executor, recompiler, or capture-format change, so no rendered output can move. The
classifier is factored into a header (`pixel_input_linkage.hpp`) so it is unit-testable rather than
buried in a print statement.

## Tests

`test_gpu_replay_pixel_inputs.cpp`, 12 assertions covering `Param`, `ParamPassthrough`,
`ConstantDefault` with each `DEFAULT_VAL` combination, invalid/unused slots, and out-of-range input
indices. It **fails without the `OFFSET == 0x20` branch** — that is the assertion which pins the
constant-vs-param distinction the seam exists to make.

## Verification

- New test passes all 12 assertions; confirmed failing when the `OFFSET == 0x20` branch is removed.
- `--inspect-only` output on a real v38 capsule is **byte-identical** before and after factoring the
  classifier into its own header — so the refactor provably changed no existing output.
- `git diff --check` clean.
- Three ctest failures in the author's run (`module_loads_eboot` and friends) are dump-identity
  artifacts of configuring `-DGAME_DUMP` against a non-Messenger title (`imports=2049 expected 612`,
  a property of which `eboot.bin` is on disk). They reference nothing this PR touches, confirmed by
  grep, and reproduce on a clean tree. Tracked separately as #1573.

Build and test **inside the `ps5ys` distrobox** — a host-only configure silently omits `gpu_replay`
itself along with the offscreen graphics harness, logging only `Vulkan not found`.

## Risks

Low. The seam reads already-retained data and only adds output. The main risk would be a
*misleading* diagnostic, which is why the classifier mirrors the real lowering and why pre-v36
captures print `none` rather than a fabricated default.

## Related

Investigation context on #1486. This PR does not close it: binding 36 is exonerated
(LUT contents, tile27 volume detile, DCC, 10:10:10:2 unpack, 3D coordinate wiring, dimensional
opcode, dmask, swizzle, address modes, sampler filtering, and draw90 shader translation are all
ruled out), the op103 auto-exposure producer and interpolant delivery are now **also** cleared, and
the overexposure is currently localized to a ~14x amplification introduced by the `v_mac_f32` bloom
accumulate at pc=254/255/256.
