### PR TITLE
fix(shader_inspect): report a missing resource table as undetermined, not as a shader rejection

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -670,6 +670,15 @@ if(TARGET prosper_core)
   add_executable(shader_inspect tools/shader_inspect/shader_inspect.cpp)
   target_link_libraries(shader_inspect PRIVATE prosper_core)
 
+  # Resource-table honesty (#1571): a raw dump carries no descriptors, so a table-less stage
+  # rejection must be reported as an UNDETERMINED tool limitation, never as a shader defect.
+  if(Python3_Interpreter_FOUND)
+    add_test(NAME shader_inspect_resource_table_honesty
+             COMMAND "${Python3_EXECUTABLE}"
+                     "${CMAKE_CURRENT_SOURCE_DIR}/tools/shader_inspect/test_shader_inspect.py"
+                     "$<TARGET_FILE:shader_inspect>")
+  endif()
+
   # spv_validate: recompile one shader from every path and run spirv-val on each — a strict-validation
   # gate (the render tests only prove llvmpipe accepts them; llvmpipe is lenient). No Vulkan needed;
   # skips validation gracefully if spirv-val is not on PATH (still checks recompilation succeeds).

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -36,6 +36,16 @@ the shipped runtime. Build them from `build-linux/` like everything else.
 - **`shader_inspect/`** — decode one raw `PROSPER_SHADER_DUMP` binary offline. It prints bounded
   instruction PCs, operands, raw words, signed branch immediates, and resolved branch targets so a
   failed shader's CFG can be mapped without hand-counting variable-length instructions.
+  **`--stage` cannot prove a shader is unsupported (#1571).** A raw dump has no descriptors, so the tool
+  has no `ShaderResourceTable`, and the recompiler correctly refuses `MIMG`/`MUBUF`/`MTBUF` in any stage
+  plus `SMEM` in the vertex/fragment stages (`recompile_fragment_impl` / `recompile_vertex_impl` gate on
+  `allow_smem = (rt != nullptr)`; `recompile_compute` passes `true`, and `emit_alu` holds both the MIMG
+  `!allow_smem || !rt` and SMEM `!allow_smem` rejects). That is a
+  limitation of *this tool's inputs*, not a property of the shader. Such a run reports
+  `status=undetermined-no-resource-table` (exit 3) — treat it as **no verdict**, never as a missing
+  opcode. Before this was fixed the tool called 109 of 114 known-good shaders `rejected` and agents
+  chased those false leads. **For a table-accurate verdict use `gpu_replay --inspect-only`**, which has
+  the real descriptors from a capture. See `shader_inspect/README.md`.
 - **`imgdump/`** — decode/dump a guest texture to an image for inspection.
 - **`gpu_replay/`** — replay a local `PROSPER_GPU_CAPTURE` realized-submit capsule through the same
   Vulkan backend without booting the guest. Capsules include game shaders/resources, use `.prgcap`,

--- a/prosper/tools/shader_inspect/README.md
+++ b/prosper/tools/shader_inspect/README.md
@@ -46,6 +46,43 @@ the stage-agnostic `recompile_coverage` result. That coverage is intentionally c
 control-flow shape may remain listed there even when the vertex/fragment structurizer accepts it.
 `--stage vertex|fragment|compute` additionally runs the complete stage translator, which exposes contextual
 resource and structured-control-flow failures that per-instruction coverage cannot decide.
+
+## `--stage` cannot prove a shader is unsupported (#1571)
+
+**`shader_inspect` has no resource table, and a table-less stage rejection is NOT evidence of a shader
+defect.** A raw dump carries instructions but no descriptors, so the tool can never build a
+`ShaderResourceTable`. The recompiler then refuses — by design — to lower anything that resolves a
+V#/T#/S# through that table: `MIMG`, `MUBUF` and `MTBUF` in every stage, and additionally `SMEM` in the
+**vertex and fragment** stages, which gate scalar memory on `allow_smem = (rt != nullptr)`. Compute
+passes `allow_smem = true`, so constant-buffer loads are fine there — but compute image and buffer ops
+still need the table.
+
+The gates live in `emit_alu` in `src/gpu/rdna2_to_spirv.cpp` (MIMG rejects on `!allow_smem || !rt`,
+SMEM on `!allow_smem`); the per-stage `allow_smem` values are set by `recompile_fragment_impl` and
+`recompile_vertex_impl` (`rt != nullptr`) versus `recompile_compute` (`true`). Those functions are named
+rather than cited by line because line numbers drift — grep the names.
+
+When such an instruction is present the tool now reports:
+
+```text
+stage-recompile stage=fragment status=undetermined-no-resource-table spirv_dwords=0 table_dependent=17
+stage-recompile NOTE: TOOL LIMITATION, NOT A SHADER DEFECT. ...
+```
+
+Treat `undetermined-no-resource-table` as "no verdict", never as a missing opcode. This mattered: on a
+corpus of 114 shaders that had provably recompiled and rendered live, the pre-fix tool called **109 of
+them `rejected`** — 33/35 compute, 27/29 fragment, 49/50 vertex. Agents acted on those false leads.
+
+**For a table-accurate verdict, use `gpu_replay`**, which has the real descriptors from a capture:
+
+```bash
+gpu_replay <capture>.prgcap --inspect-only                     # per-draw realize/fail status
+gpu_replay <capture>.prgcap --dump-failed-shader FAILURE:STAGE out.bin   # a genuinely failed stage
+```
+
+Exit codes: `0` recompiled, `1` genuine defect (truncated stream, or a rejection attributable to the
+shader), `2` usage/IO error, `3` undetermined because no resource table could be supplied. `3` is
+deliberately non-zero — a table-less run is never reported as a pass.
 When a shader contains the fully proven bounded scalar `s_setpc_b64` jump-table idiom, the header also
 prints its constant-buffer selector, adjustment/clamp, complete target list, merge PC, and owning span.
 

--- a/prosper/tools/shader_inspect/shader_inspect.cpp
+++ b/prosper/tools/shader_inspect/shader_inspect.cpp
@@ -44,6 +44,36 @@ void print_operand(const char* label, const Operand& operand) {
     std::printf(" %s=%s:%d", label, operand_kind_name(operand.kind), operand.value);
 }
 
+// Does lowering this instruction require a ShaderResourceTable in this stage?
+//
+// shader_inspect reads a RAW shader dump, which carries instructions but no descriptors, so it can
+// never supply a resource table. The stage recompilers then legitimately refuse to lower any
+// instruction that resolves a V#/T#/S# through that table — see `emit_alu` in rdna2_to_spirv.cpp,
+// which rejects MIMG on `!allow_smem || !rt` and SMEM on `!allow_smem`. That refusal is a property
+// of THIS TOOL's inputs, not of the shader, and must never be reported as an unsupported
+// instruction (#1571).
+//
+// The table-dependent formats are the same ones RecompileCoverage documents (MIMG / MUBUF / MTBUF).
+// SMEM is additionally table-dependent in the GRAPHICS stages only, because `recompile_fragment_impl`
+// and `recompile_vertex_impl` pass `allow_smem = (rt != nullptr)` while `recompile_compute` passes
+// `allow_smem = true` unconditionally.
+//
+// Line numbers drift, so the functions above are named rather than cited by line. At the time of
+// writing (master 276b8f92) they were: emit_alu SMEM reject rdna2_to_spirv.cpp:8280, emit_alu MIMG
+// gate :9109, recompile_compute :14295, recompile_fragment_impl :14828, recompile_vertex_impl :15676.
+bool needs_resource_table(Rdna2Format fmt, const std::string& stage) {
+    switch (fmt) {
+        case Rdna2Format::MIMG:
+        case Rdna2Format::MUBUF:
+        case Rdna2Format::MTBUF:
+            return true;
+        case Rdna2Format::SMEM:
+            return stage == "vertex" || stage == "fragment";
+        default:
+            return false;
+    }
+}
+
 } // namespace
 
 int main(int argc, char** argv) {
@@ -52,6 +82,18 @@ int main(int argc, char** argv) {
     if ((argc != 2 && argc != 4) ||
         (!stage.empty() && stage != "vertex" && stage != "fragment" && stage != "compute")) {
         std::fprintf(stderr, "usage: %s <raw-rdna2.bin> [--stage vertex|fragment|compute]\n", argv[0]);
+        std::fprintf(stderr,
+            "\n"
+            "Decodes a raw RDNA2 shader dump. With --stage it also attempts a stage recompile.\n"
+            "\n"
+            "IMPORTANT: shader_inspect has NO resource table (a raw dump carries no descriptors), so\n"
+            "the recompiler cannot lower MIMG/MUBUF/MTBUF — nor SMEM in the vertex/fragment stages.\n"
+            "When such an instruction is present, a failed stage recompile is reported as\n"
+            "status=undetermined-no-resource-table and is NOT evidence of an unsupported shader.\n"
+            "For a table-accurate verdict use gpu_replay, which has the real descriptors:\n"
+            "  gpu_replay <capture>.prgcap --inspect-only\n"
+            "\n"
+            "Exit: 0 ok, 1 genuine defect, 2 usage/IO error, 3 undetermined (no resource table).\n");
         return 2;
     }
 
@@ -92,6 +134,7 @@ int main(int argc, char** argv) {
                 coverage.first_bad_fmt < 0 ? "none" : format_name(static_cast<Rdna2Format>(coverage.first_bad_fmt)),
                 coverage.first_bad_op);
     bool stage_ok = true;
+    bool stage_undetermined = false;
     if (!stage.empty()) {
         std::vector<uint32_t> spirv;
         if (stage == "vertex") {
@@ -107,8 +150,43 @@ int main(int argc, char** argv) {
             spirv = recompile_compute(words.data(), words.size(), nullptr, config);
         }
         stage_ok = !spirv.empty();
-        std::printf("stage-recompile stage=%s status=%s spirv_dwords=%zu\n",
-                    stage.c_str(), stage_ok ? "ok" : "rejected", spirv.size());
+
+        // A table-less rejection is only attributable to the SHADER when the shader contains no
+        // instruction that would have needed a resource table anyway. Otherwise the rejection is
+        // unattributable and must be reported as such (#1571).
+        uint32_t table_dependent = 0;
+        uint32_t per_format[static_cast<size_t>(Rdna2Format::Unknown) + 1] = {};
+        for (const auto& in : instructions) {
+            if (!needs_resource_table(in.fmt, stage)) continue;
+            ++table_dependent;
+            const size_t index = static_cast<size_t>(in.fmt);
+            if (index < std::size(per_format)) ++per_format[index];
+        }
+        stage_undetermined = !stage_ok && table_dependent > 0;
+
+        std::printf("stage-recompile stage=%s status=%s spirv_dwords=%zu table_dependent=%u\n",
+                    stage.c_str(),
+                    stage_ok ? "ok" : (stage_undetermined ? "undetermined-no-resource-table" : "rejected"),
+                    spirv.size(), table_dependent);
+        if (stage_undetermined) {
+            std::printf("stage-recompile NOTE: TOOL LIMITATION - THIS IS NOT EVIDENCE OF A SHADER DEFECT.\n");
+            std::printf("stage-recompile NOTE: shader_inspect reads a raw dump, which carries no descriptors, so it\n");
+            std::printf("stage-recompile NOTE: cannot supply a resource table. This shader has %u instruction(s)\n",
+                        table_dependent);
+            std::printf("stage-recompile NOTE: that need one (");
+            bool first = true;
+            for (size_t i = 0; i < std::size(per_format); ++i) {
+                if (!per_format[i]) continue;
+                std::printf("%s%s=%u", first ? "" : " ", format_name(static_cast<Rdna2Format>(i)), per_format[i]);
+                first = false;
+            }
+            std::printf("), so the recompiler refused them BY DESIGN and this\n");
+            std::printf("stage-recompile NOTE: rejection is UNATTRIBUTABLE. It is not evidence that the shader is\n");
+            std::printf("stage-recompile NOTE: unsupported - and equally not evidence that it is fine: a genuine\n");
+            std::printf("stage-recompile NOTE: defect may also be present and would look identical here.\n");
+            std::printf("stage-recompile NOTE: For a verdict use gpu_replay, which has the real descriptors:\n");
+            std::printf("stage-recompile NOTE:   gpu_replay <capture>.prgcap --inspect-only\n");
+        }
     }
     const PcrelDispatchInfo dispatch = rdna2_pcrel_dispatch_info(words.data(), words.size());
     if (dispatch.valid) {
@@ -146,5 +224,11 @@ int main(int argc, char** argv) {
         std::printf("\n");
     }
 
-    return ended && stage_ok ? 0 : 1;
+    // Exit codes: 0 = stage recompiled (or no --stage given and the stream ends cleanly);
+    // 1 = genuine defect (truncated stream, or a rejection attributable to the shader);
+    // 2 = usage/IO error; 3 = verdict UNDETERMINED because no resource table could be supplied (#1571).
+    // 3 is deliberately non-zero: shader_inspect must never report a table-less run as a pass.
+    if (!ended) return 1;
+    if (stage_undetermined) return 3;
+    return stage_ok ? 0 : 1;
 }

--- a/prosper/tools/shader_inspect/test_shader_inspect.py
+++ b/prosper/tools/shader_inspect/test_shader_inspect.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Regression test for shader_inspect's resource-table honesty (#1571).
+
+shader_inspect reads a RAW shader dump, which carries instructions but no descriptors, so it can
+never supply a ShaderResourceTable. The stage recompilers then legitimately refuse to lower any
+instruction that resolves a V#/T#/S# through that table. Before #1571 the tool reported that refusal
+as `status=rejected`, i.e. as if the SHADER were unsupported — a tool limitation misattributed as a
+shader defect. It was wrong for 109 of 114 shaders that had provably recompiled and rendered live.
+
+These cases pin the corrected contract. Case 1 is the one that fails without the fix.
+
+Usage: test_shader_inspect.py <path-to-shader_inspect>
+"""
+
+import struct
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+S_ENDPGM = 0xBF810000
+S_NOP = 0xBF800000
+
+
+def s_load_dwordx4(sdata: int, sbase_pair: int, offset: int) -> tuple:
+    """`s_load_dwordx4 s[sdata:sdata+3], s[base:base+1], offset` with SOFFSET = SGPR_NULL (125).
+
+    This is the canonical constant-buffer load emitted by real title shaders: SMEM opcode 0x02,
+    immediate offset, and the SOFFSET field set to NULL rather than a register.
+    """
+    word0 = (0x3D << 26) | (0x02 << 18) | ((sdata & 0x7F) << 6) | (sbase_pair & 0x3F)
+    word1 = (125 << 25) | (offset & 0x1FFFFF)
+    return word0, word1
+
+
+def run(binary: str, words, stage=None):
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "shader.bin"
+        path.write_bytes(struct.pack("<%dI" % len(words), *words))
+        cmd = [binary, str(path)]
+        if stage:
+            cmd += ["--stage", stage]
+        done = subprocess.run(cmd, capture_output=True, text=True)
+        return done.returncode, done.stdout
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: test_shader_inspect.py <path-to-shader_inspect>", file=sys.stderr)
+        return 2
+    binary = sys.argv[1]
+    failures = []
+
+    def check(name, condition, detail=""):
+        if condition:
+            print("ok   - %s" % name)
+        else:
+            print("FAIL - %s %s" % (name, detail))
+            failures.append(name)
+
+    # A minimal graphics shader whose only real work is a constant-buffer load.
+    cbuf_load = list(s_load_dwordx4(sdata=8, sbase_pair=0, offset=0)) + [S_ENDPGM]
+
+    # --- Case 1: the required contract -------------------------------------------------------
+    # A graphics stage with a constant-buffer load must NOT be reported as an unsupported-instruction
+    # rejection when no resource table is supplied. Without the fix this printed `status=rejected`.
+    for stage in ("fragment", "vertex"):
+        code, out = run(binary, cbuf_load, stage)
+        check("%s cbuf load is not reported as a shader rejection" % stage,
+              "status=rejected" not in out, "\n" + out)
+        check("%s cbuf load reports the tool limitation explicitly" % stage,
+              "status=undetermined-no-resource-table" in out, "\n" + out)
+        check("%s cbuf load names the limitation in words" % stage,
+              "TOOL LIMITATION" in out and "NOT EVIDENCE OF A SHADER DEFECT" in out, "\n" + out)
+        # The note must not overcorrect into reassurance: `stage_undetermined` is set whenever a
+        # table-dependent instruction is present, so a genuine defect can be present too and would
+        # look identical. The wording has to say so, or it invites waving real bugs away.
+        check("%s cbuf load does not claim the shader is fine" % stage,
+              "equally not evidence that it is fine" in out, "\n" + out)
+        check("%s cbuf load calls the rejection unattributable" % stage,
+              "UNATTRIBUTABLE" in out, "\n" + out)
+        check("%s cbuf load counts the table-dependent instruction" % stage,
+              "table_dependent=1" in out, "\n" + out)
+        check("%s cbuf load exits 3 (undetermined), never 0" % stage,
+              code == 3, "got exit %d" % code)
+
+    # --- Case 2: the classification is stage-sensitive, not blanket ---------------------------
+    # Compute passes allow_smem=true unconditionally, so the SAME stream needs no table there and
+    # must still recompile normally. This is what proves case 1 is about the missing table and not
+    # about the instruction being unsupported.
+    code, out = run(binary, cbuf_load, "compute")
+    check("identical stream recompiles ok in compute",
+          "status=ok" in out, "\n" + out)
+    check("compute reports no table-dependent instructions",
+          "table_dependent=0" in out, "\n" + out)
+    check("compute cbuf load exits 0", code == 0, "got exit %d" % code)
+
+    # --- Case 3: genuine defects are still genuine --------------------------------------------
+    # A stream that never reaches s_endpgm is a real defect and must not be softened into the new
+    # undetermined status, even though the tool still has no resource table.
+    code, out = run(binary, [S_NOP], "compute")
+    check("stream without s_endpgm is still a genuine failure", code == 1,
+          "got exit %d" % code)
+    check("stream without s_endpgm is not called undetermined",
+          "undetermined" not in out, "\n" + out)
+
+    # A shader with no table-dependent instruction at all keeps the plain verdict vocabulary: it is
+    # attributable, so it must never be labelled undetermined.
+    code, out = run(binary, [S_ENDPGM], "fragment")
+    check("table-free shader is never labelled undetermined",
+          "undetermined" not in out, "\n" + out)
+
+    # --- Case 4: usage errors unchanged --------------------------------------------------------
+    done = subprocess.run([binary], capture_output=True, text=True)
+    check("no arguments still exits 2", done.returncode == 2,
+          "got exit %d" % done.returncode)
+    check("usage text warns about the missing resource table",
+          "resource table" in done.stderr, "\n" + done.stderr)
+
+    print("\n%d checks failed" % len(failures) if failures else "\nall checks passed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Purpose

Fixes #1571.

`shader_inspect` has been reporting a **tool limitation as a shader defect**, sending agents to chase
phantom missing-opcode work in titles whose shaders are entirely fine.

## Failure scenario

`shader_inspect` reads a **raw** RDNA2 dump. A raw dump carries instructions but **no descriptors**,
so the tool can never supply a `ShaderResourceTable`. The stage recompilers then legitimately refuse
to lower any instruction that resolves a V#/T#/S# through that table:

- `emit_alu` rejects MIMG when `!allow_smem || !rt`, and SMEM when `!allow_smem`;
- `recompile_fragment_impl` and `recompile_vertex_impl` pass `allow_smem = (rt != nullptr)`, so with
  no table every graphics stage using a constant buffer rejects at its first `s_load_*` with
  `reason=graphics-disabled`;
- `recompile_compute` passes `allow_smem = true`, so compute is hit through **MIMG/MUBUF** instead.

That refusal is a property of *this tool's inputs*, not of the shader. The old code printed
`status=rejected` and returned exit 1 — indistinguishable from a genuine unsupported-instruction
verdict.

**Measured impact.** Against a corpus of 114 shaders collected with `PROSPER_SHADER_DUMP_SUCCESS`,
i.e. shaders that provably recompiled *and rendered live*, `shader_inspect` reported **109 as
`rejected`: 33 of 35 compute, 27 of 29 fragment, 49 of 50 vertex.** Roughly 96% of known-good
shaders were being labelled defective.

This is how it surfaced: during The Pathless triage, all 12 dumped pixel shaders and 9 of 10 vertex
shaders showed this false lead before being cross-checked against live rejects.

## Behavioral contract

- A stage rejection is attributable to the **shader** only when the shader contains no instruction
  that would have needed a resource table anyway.
- Otherwise the verdict is `status=undetermined-no-resource-table`, with the table-dependent
  instruction count broken down per format.
- Exit codes: `0` ok, `1` genuine defect, `2` usage/IO error, **`3` undetermined**. 3 is deliberately
  **non-zero**: a table-less run must never be reported as a pass.
- The note is **unattributable in both directions** — explicitly *not* evidence that the shader is
  unsupported, and equally *not* evidence that it is fine, since a genuine defect may coexist and
  would look identical here. (`stage_undetermined` fires on `table_dependent > 0` alone.)
- Users are redirected to `gpu_replay --inspect-only`, which has the real descriptors.

**The recompiler is untouched.** No pretending SMEM works table-less, no synthetic or permissive
table. Either would have traded a visible false lead for an invisible one — a fabricated table would
yield coverage numbers that do not hold live.

Deliberately **not** done: teaching `shader_inspect` to accept a real resource table. A raw `.bin`
has no descriptors, so a real table can only come from a capture — which is precisely `gpu_replay`'s
job. Re-implementing that inside `shader_inspect` would be the wrong boundary.

## Tests

New `tools/shader_inspect/test_shader_inspect.py`, wired into ctest as
`shader_inspect_resource_table_honesty`: **22 checks**. Rebuilt at base `276b8f92` and re-run,
**16 fail (exit 1)**; with the fix restored, exit 0. Two of the checks specifically pin the
both-directions wording so it cannot drift back into reassurance.

Known-good corpus re-verified at the exact head: 35 compute / 29 fragment / 50 vertex, **0 still
misreported as `rejected`**.

## Verification (head `713c1483`, single commit on `276b8f92`)

Focused, by name — **13/13 passed**: `messenger_recompile_guard`, `recompile_coverage`,
`shader_recompile_cache`, `rdna2_decode_walk`, `rdna2_spirv_struct`,
`shader_inspect_resource_table_honesty`, `spv_validate`, `agc_submit_to_gpustate`,
`rdna2_to_spirv_exec`, `recompiled_fragment_render`, `recompiled_shaders_render`, `gpustate_render`,
`gpu_execute`.

Full suite **161/161**, zero failures. `git diff --check` clean.

Source citations lead with **function names** (`emit_alu`, `recompile_compute`,
`recompile_fragment_impl`, `recompile_vertex_impl`) so they self-correct as the file drifts; line
numbers are retained only as an explicitly-dated snapshot. The docs cite the gate symbolically and
carry no hard line numbers.

## Notes for reviewers

A correction is embedded in this PR's history worth recording: the first analysis claimed compute was
unaffected. That was wrong because `gpu_replay --dump-compute` writes **SPIR-V**, not raw RDNA2, so
the tool had been fed garbage. Re-tested with `PROSPER_SHADER_DUMP_SUCCESS`, compute turned out to be
affected too — via MIMG (16) and MUBUF (13) rather than via `allow_smem`. The four now-suspect
compute rows on #1570 were retracted.

## Risks

Low, and asymmetric in the safe direction. The tool now returns non-zero (3) in cases where it
previously returned non-zero (1), so no script that treated non-zero as failure changes behaviour; a
script distinguishing exit codes gains information. The residual risk is that a genuine defect
sitting behind a table-dependent instruction is now reported `undetermined` rather than `rejected` —
that is the honest verdict given the tool cannot attribute it, and the note says so in both
directions.

Build and test **inside the `ps5ys` distrobox** — a host-only configure silently omits the offscreen
graphics harness and every Vulkan execution test.
