### PR TITLE
capture: retain raw color-state provenance (v43) and surface it in gpu_replay --inspect

### DIFF
--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -92,7 +92,14 @@ constexpr char kMagic[8] = {'P','R','G','P','C','A','P','\0'};
 // v42: retain the exact ComputeShaderConfig for failed compute stages. Raw code and v41 resources do
 // not encode user SGPRs, dispatch dimensions, wave ABI, LDS size, or subgroup/storage policy, so an
 // offline retry must never reconstruct those inputs from defaults.
-constexpr uint32_t kVersion = 42;
+// v43 (#1459): retain the raw color-state triple — CB_COLOR_CONTROL, CB_TARGET_MASK, CB_SHADER_MASK,
+// each with an explicit present flag — for realized and failed draw pipelines. A capsule stores an
+// already-resolved pipeline, so a zero color write mask was previously unattributable offline: an
+// absent target/shader mask resolves to write-all, meaning a zero resolved mask implies one of those
+// registers is PRESENT with value zero, or MODE is DISABLE. Those causes demand different fixes and
+// only the raw registers separate them. Append-only tail; v1-v42 prefixes stay byte-exact and older
+// captures report the state as unavailable rather than inventing write-all defaults.
+constexpr uint32_t kVersion = 43;
 constexpr uint32_t kEndian = 0x01020304u;
 constexpr uint64_t kMaxFileBytes = 4ull << 30;
 constexpr uint64_t kMaxBlobBytes = 1ull << 30;
@@ -201,6 +208,28 @@ struct Reader {
         v.resize(static_cast<size_t>(n)); return take(v.data(), v.size());
     }
 };
+
+// v43 (#1459): the raw color-state triple behind a resolved color write mask. Presence is packed
+// alongside the values because "absent" and "present with value 0" resolve to opposite masks —
+// write-all versus write-nothing — and only the raw registers distinguish them offline.
+void write_color_state(Writer& w, const ResolvedPipelineState& ps) {
+    const uint8_t present = (ps.has_cb_color_control ? 1u : 0u) |
+                            (ps.has_cb_target_mask ? 2u : 0u) |
+                            (ps.has_cb_shader_mask ? 4u : 0u);
+    w.u8(present);
+    w.u32(ps.cb_color_control);
+    w.u32(ps.cb_target_mask);
+    w.u32(ps.cb_shader_mask);
+}
+
+bool read_color_state(Reader& r, ResolvedPipelineState& ps) {
+    uint8_t present = 0;
+    if (!r.u8(present) || present > 7u) return false;
+    ps.has_cb_color_control = (present & 1u) != 0;
+    ps.has_cb_target_mask = (present & 2u) != 0;
+    ps.has_cb_shader_mask = (present & 4u) != 0;
+    return r.u32(ps.cb_color_control) && r.u32(ps.cb_target_mask) && r.u32(ps.cb_shader_mask);
+}
 
 void write_compute_config(Writer& w, const ComputeShaderConfig& config) {
     w.words(config.user_sgprs);
@@ -2270,6 +2299,14 @@ bool serialize_gpu_capture(const GpuCaptureFile& c, std::vector<uint8_t>& bytes,
                 write_compute_config(w, stage.recompile_config);
         }
     }
+    // v43 (#1459) appends the raw color-state triple that determines every resolved color write
+    // mask. Presence travels with each value because an absent CB_TARGET_MASK/CB_SHADER_MASK means
+    // write-all, not zero. Enumeration matches the v25/v26 blocks so the tail stays removable.
+    w.u32(static_cast<uint32_t>(c.draws.size()));
+    for (const auto& draw : c.draws) write_color_state(w, draw.ps);
+    w.u32(static_cast<uint32_t>(c.failure_diagnostics.size()));
+    for (const auto& diagnostic : c.failure_diagnostics)
+        if (diagnostic.pipeline_present) write_color_state(w, diagnostic.pipeline);
     if (w.data.size() > kMaxFileBytes) { error = "capture file exceeds 4 GiB"; return false; }
     bytes = std::move(w.data);
     return true;
@@ -3243,6 +3280,22 @@ bool deserialize_gpu_capture(const std::vector<uint8_t>& bytes, GpuCaptureFile& 
                 }
             }
         }
+    }
+    if (version >= 43) {   // #1459: raw color-state provenance for every resolved write mask
+        uint32_t draw_count = 0;
+        if (!r.u32(draw_count) || draw_count != c.draws.size()) {
+            error = "invalid color-state draw count"; return false;
+        }
+        for (auto& draw : c.draws)
+            if (!read_color_state(r, draw.ps)) { error = "invalid color-state draw record"; return false; }
+        uint32_t failure_count = 0;
+        if (!r.u32(failure_count) || failure_count != c.failure_diagnostics.size()) {
+            error = "invalid color-state failure count"; return false;
+        }
+        for (auto& diagnostic : c.failure_diagnostics) if (diagnostic.pipeline_present)
+            if (!read_color_state(r, diagnostic.pipeline)) {
+                error = "invalid color-state failure record"; return false;
+            }
     }
     for (auto& draw : c.draws) restore_legacy_color_target_aliases(draw);
     for (auto& diagnostic : c.failure_diagnostics)

--- a/prosper/src/gpu/render_state.cpp
+++ b/prosper/src/gpu/render_state.cpp
@@ -579,6 +579,15 @@ ResolvedPipelineState resolve_pipeline_state(const RenderState& rs) {
         vk_color_format(rs.color1_format, rs.color1_number_type, rs.color1_comp_swap)) : 0u;
     ps.spi_shader_col_format = rs.spi_shader_col_format;
     ps.sx_ps_downconvert = rs.sx_ps_downconvert;
+    // Carry the raw color-state triple through resolution unchanged (#1459). These are pure
+    // provenance for the masks computed below: nothing here reads them back, so a resolved pipeline
+    // keeps recording WHY its color write mask ended up where it did, not merely what it became.
+    ps.has_cb_color_control = rs.has_cb_color_control;
+    ps.has_cb_target_mask = rs.has_cb_target_mask;
+    ps.has_cb_shader_mask = rs.has_cb_shader_mask;
+    ps.cb_color_control = rs.cb_color_control;
+    ps.cb_target_mask = rs.cb_target_mask;
+    ps.cb_shader_mask = rs.cb_shader_mask;
 
     // Fast-clear color: decode the CB_COLOR0_CLEAR_WORD when the game programmed one (#309). A
     // decode miss (no fast-clear, or an unmapped format) leaves has_clear_color false and the

--- a/prosper/src/gpu/render_state.hpp
+++ b/prosper/src/gpu/render_state.hpp
@@ -213,6 +213,19 @@ struct ResolvedPipelineState {
     // live backend implements it as a straight copy of the already-rendered color0 surface into color1.
     bool     cb_resolve       = false;
 
+    // Raw color-state registers behind the resolved color write masks (#1459). Presence is
+    // deliberately distinct from the effective fallback value, because an ABSENT CB_TARGET_MASK or
+    // CB_SHADER_MASK resolves to write-all: a resolved mask of zero therefore means one of them is
+    // PRESENT with a zero value, or CB_COLOR_CONTROL.MODE is DISABLE. Only the raw triple can tell
+    // those causes apart, and a capsule stores already-resolved pipeline state, so without these
+    // fields "why is this draw's color write mask zero" is unanswerable offline for every title.
+    bool     has_cb_color_control = false;
+    bool     has_cb_target_mask   = false;
+    bool     has_cb_shader_mask   = false;
+    uint32_t cb_color_control     = 0;
+    uint32_t cb_target_mask       = 0;
+    uint32_t cb_shader_mask       = 0;
+
     // Color-target clear value, decoded from CB_COLOR0_CLEAR_WORD0/1 per the surface format (#309).
     // has_clear_color == the game programmed a fast-clear that we decoded; clear_color is RGBA in
     // Vulkan order (float32[0]=R). When has_clear_color is false the backend clears to opaque black —

--- a/prosper/tests/test_gpu_capture.cpp
+++ b/prosper/tests/test_gpu_capture.cpp
@@ -174,6 +174,11 @@ int main() {
     draw.ps.depth_bias_clamp = 0.5f;
     draw.ps.spi_shader_col_format = 4;
     draw.ps.sx_ps_downconvert = 5;
+    // #1459: v43 raw color-state provenance. A PRESENT zero target mask is deliberately chosen here
+    // because it is exactly the state an absent register must NOT be confused with.
+    draw.ps.has_cb_color_control = true; draw.ps.cb_color_control = 0x00CC0010u;
+    draw.ps.has_cb_target_mask = true;   draw.ps.cb_target_mask = 0u;
+    draw.ps.has_cb_shader_mask = true;   draw.ps.cb_shader_mask = 0x000000FFu;
     draw.ps.has_scissor = true; draw.ps.scissor_left = 12; draw.ps.scissor_top = 19;
     draw.ps.scissor_right = 70; draw.ps.scissor_bottom = 75;
     draw.ps.logic_op_enable = true; draw.ps.logic_op = 6;
@@ -428,6 +433,15 @@ int main() {
         return bytes;
     };
 
+    // v43 (#1459): byte length of the trailing raw color-state block. One present-bitmask byte plus
+    // three raw registers per realized draw and per pipeline-bearing failure diagnostic.
+    auto v43_tail = [](const GpuCaptureFile& f) -> size_t {
+        size_t present_failures = 0;
+        for (const auto& diagnostic : f.failure_diagnostics)
+            if (diagnostic.pipeline_present) ++present_failures;
+        return 4 + f.draws.size() * 13 + 4 + present_failures * 13;
+    };
+
     // v25 (#1240): byte length of the trailing resolve-state block.
     auto v25_tail = [](const GpuCaptureFile& f) -> size_t {
         size_t present_failures = 0;
@@ -459,6 +473,7 @@ int main() {
               v16_scissor_bytes.size() >= 25,
           "v17 capture serializes effective guest scissor state");
     if (v16_scissor_bytes.size() >= 25) {
+        v16_scissor_bytes.resize(v16_scissor_bytes.size() - v43_tail(v16_scissor_source));
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - v42_tail(v16_scissor_source));
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - v41_tail(v16_scissor_source));
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - v40_tail(v16_scissor_source));
@@ -569,7 +584,7 @@ int main() {
     };
     GpuCaptureFile video_capture;
     CHECK(capture_draw_items({video_draw}, meta, video_reader, video_capture, error) &&
-              video_capture.format_version == 42 && video_capture.blobs.size() == 1 &&
+              video_capture.format_version == 43 && video_capture.blobs.size() == 1 &&
               video_capture.blobs[0].bytes.size() == video_memory.size() &&
               video_capture.draws[0].prt.resources[0].captured_size == video_memory.size() &&
               video_capture.draws[0].prt.resources[0].resource.linear_row_pitch_bytes == 2048,
@@ -579,7 +594,7 @@ int main() {
     GpuReplayFrame video_replay;
     CHECK(serialize_gpu_capture(video_capture, video_capture_bytes, error) &&
               deserialize_gpu_capture(video_capture_bytes, video_loaded, error) &&
-              video_loaded.format_version == 42 &&
+              video_loaded.format_version == 43 &&
               video_loaded.draws[0].prt.resources[0].captured_size == video_memory.size() &&
               video_loaded.draws[0].prt.resources[0].resource.linear_row_pitch_bytes == 2048 &&
               materialize_gpu_replay(video_loaded, video_replay, error) &&
@@ -602,7 +617,7 @@ int main() {
     GpuReplayFrame upgraded_video_replay;
     CHECK(serialize_gpu_capture(legacy_video, upgraded_video_bytes, error) &&
               deserialize_gpu_capture(upgraded_video_bytes, upgraded_video, error) &&
-              upgraded_video.format_version == 42 &&
+              upgraded_video.format_version == 43 &&
               upgraded_video.draws[0].prt.resources[0].captured_size == video_chroma.size &&
               upgraded_video.draws[0].prt.resources[0].resource.linear_row_pitch_bytes == 2048 &&
               materialize_gpu_replay(upgraded_video, upgraded_video_replay, error) &&
@@ -684,7 +699,7 @@ int main() {
           "Plucky RGBA16 32-cubed S3 capture uses its four true 3D macroblocks");
     CHECK(serialize_gpu_capture(array_layout_capture, array_layout_bytes, error) &&
               deserialize_gpu_capture(array_layout_bytes, array_layout_loaded, error) &&
-              array_layout_loaded.format_version == 42 &&
+              array_layout_loaded.format_version == 43 &&
               array_layout_loaded.draws[0].vrt.resources[0].resource.layer_stride_bytes == 720896u &&
               array_layout_loaded.draws[0].vrt.resources[0].resource.layer_mip_offset_bytes == 65536u,
           "v32 capture round-trips thin-array slice stride and selected-mip offset");
@@ -783,6 +798,7 @@ int main() {
           "writer rejects an out-of-bounds DCC metadata reference");
     CHECK(serialize_gpu_capture(volume_capture, volume_bytes, error),
           "recreated valid v12 DCC bytes after malformed-reference check");
+    volume_bytes.resize(volume_bytes.size() - v43_tail(volume_capture));
     volume_bytes.resize(volume_bytes.size() - v42_tail(volume_capture));
     volume_bytes.resize(volume_bytes.size() - v41_tail(volume_capture));
     volume_bytes.resize(volume_bytes.size() - v40_tail(volume_capture));
@@ -883,6 +899,7 @@ int main() {
     CHECK(serialize_gpu_capture(pre_v31_source, v20_bytes, error) && v20_bytes.size() >= 21,
           "v21 capture serializes the logic-op extension");
     if (v20_bytes.size() >= 21) {
+        v20_bytes.resize(v20_bytes.size() - v43_tail(pre_v31_source));
         v20_bytes.resize(v20_bytes.size() - v42_tail(pre_v31_source));
         v20_bytes.resize(v20_bytes.size() - v41_tail(pre_v31_source));
         v20_bytes.resize(v20_bytes.size() - v40_tail(pre_v31_source));
@@ -939,6 +956,34 @@ int main() {
     CHECK(loaded.draws[0].ps.spi_shader_col_format == 4 &&
           loaded.draws[0].ps.sx_ps_downconvert == 5,
           "v26 color export/downconversion state round-trips explicitly");
+    CHECK(loaded.draws[0].ps.has_cb_color_control &&
+              loaded.draws[0].ps.cb_color_control == 0x00CC0010u &&
+              loaded.draws[0].ps.has_cb_target_mask &&
+              loaded.draws[0].ps.cb_target_mask == 0u &&
+              loaded.draws[0].ps.has_cb_shader_mask &&
+              loaded.draws[0].ps.cb_shader_mask == 0x000000FFu,
+          "v43 raw color-state round-trips a PRESENT zero target mask distinctly (#1459)");
+    // v43 is an append-only tail, so a v42 fixture is this capture minus exactly that block. It must
+    // reopen reporting the provenance ABSENT rather than fabricating a write-all or zero default.
+    {
+        auto v43_tail = [](const GpuCaptureFile& f) -> size_t {
+            size_t present_failures = 0;
+            for (const auto& diagnostic : f.failure_diagnostics)
+                if (diagnostic.pipeline_present) ++present_failures;
+            return 4 + f.draws.size() * 13 + 4 + present_failures * 13;
+        };
+        std::vector<uint8_t> v42_bytes;
+        CHECK(serialize_gpu_capture(captured, v42_bytes, error),
+              "v43 capture serializes before the color-state downgrade");
+        v42_bytes.resize(v42_bytes.size() - v43_tail(captured));
+        v42_bytes[8] = 42; v42_bytes[9] = v42_bytes[10] = v42_bytes[11] = 0;
+        GpuCaptureFile v42_loaded;
+        CHECK(deserialize_gpu_capture(v42_bytes, v42_loaded, error) &&
+                  !v42_loaded.draws[0].ps.has_cb_color_control &&
+                  !v42_loaded.draws[0].ps.has_cb_target_mask &&
+                  !v42_loaded.draws[0].ps.has_cb_shader_mask,
+              "v42 capture reopens with color-state provenance absent, not a fabricated default");
+    }
     CHECK(loaded.draws[0].raw_draw_modifier == 0x1122334455667788ull &&
           loaded.draws[0].vertex_offset == -37,
           "v27 draw modifier and vertex offset round-trip explicitly");
@@ -950,7 +995,7 @@ int main() {
     std::vector<uint8_t> v24_resolve_bytes;
     GpuCaptureFile v24_resolve_loaded;
     CHECK(serialize_gpu_capture(pre_v31_source, v24_resolve_bytes, error) &&
-          v24_resolve_bytes.size() >= v42_tail(pre_v31_source) +
+          v24_resolve_bytes.size() >= v43_tail(pre_v31_source) + v42_tail(pre_v31_source) +
               v41_tail(pre_v31_source) +
               v40_tail(pre_v31_source) +
               v39_tail(pre_v31_source) +
@@ -963,7 +1008,7 @@ int main() {
               v27_tail(pre_v31_source) + v26_tail(pre_v31_source) +
               v25_tail(pre_v31_source),
           "v25 capture exposes a removable trailing resolve-state block");
-    if (v24_resolve_bytes.size() >= v42_tail(pre_v31_source) +
+    if (v24_resolve_bytes.size() >= v43_tail(pre_v31_source) + v42_tail(pre_v31_source) +
             v41_tail(pre_v31_source) +
             v40_tail(pre_v31_source) +
             v39_tail(pre_v31_source) +
@@ -975,6 +1020,7 @@ int main() {
             v29_tail(pre_v31_source) + v28_tail(pre_v31_source) +
             v27_tail(pre_v31_source) + v26_tail(pre_v31_source) +
             v25_tail(pre_v31_source)) {
+        v24_resolve_bytes.resize(v24_resolve_bytes.size() - v43_tail(pre_v31_source));
         v24_resolve_bytes.resize(v24_resolve_bytes.size() - v42_tail(pre_v31_source));
         v24_resolve_bytes.resize(v24_resolve_bytes.size() - v41_tail(pre_v31_source));
         v24_resolve_bytes.resize(v24_resolve_bytes.size() - v40_tail(pre_v31_source));
@@ -1071,7 +1117,8 @@ int main() {
               v37_compatible_bytes.size() >= 12,
           "current capture prepares the layout-compatible v37 fixture");
     if (v37_compatible_bytes.size() >=
-        v42_tail(captured) + v41_tail(captured) + v40_tail(captured) + v39_tail(captured)) {
+        v43_tail(captured) + v42_tail(captured) + v41_tail(captured) + v40_tail(captured) + v39_tail(captured)) {
+        v37_compatible_bytes.resize(v37_compatible_bytes.size() - v43_tail(captured));
         v37_compatible_bytes.resize(v37_compatible_bytes.size() - v42_tail(captured));
         v37_compatible_bytes.resize(v37_compatible_bytes.size() - v41_tail(captured));
         v37_compatible_bytes.resize(v37_compatible_bytes.size() - v40_tail(captured));
@@ -1105,6 +1152,16 @@ int main() {
     CHECK(materialize_gpu_replay(loaded, replay, error), "capture materializes owned replay draw items");
     CHECK(replay.items.size() == 1 && replay.items[0].ps.cb_resolve,
           "materialized gpu_replay draw retains MODE=3 resolve intent");
+    // #1459: gpu_replay --inspect reads the color-state line from the MATERIALIZED item, so assert
+    // the provenance survives that step too — a round-trip into GpuCaptureFile alone would not prove
+    // the offline diagnostic can actually see a present-and-zero mask.
+    CHECK(replay.items[0].ps.has_cb_color_control &&
+              replay.items[0].ps.cb_color_control == 0x00CC0010u &&
+              replay.items[0].ps.has_cb_target_mask &&
+              replay.items[0].ps.cb_target_mask == 0u &&
+              replay.items[0].ps.has_cb_shader_mask &&
+              replay.items[0].ps.cb_shader_mask == 0x000000FFu,
+          "materialized gpu_replay draw retains the v43 raw color-state provenance (#1459)");
     const auto& rr = replay.items[0].vrt->resources;
     CHECK(rr[0].gpu_addr == 0x1000 && rr[1].gpu_addr == 0x1008, "replay retains logical guest addresses");
     CHECK(rr[0].host_data && rr[1].host_data == rr[0].host_data + 8 && rr[1].host_data[0] == memory[8],
@@ -1251,16 +1308,17 @@ int main() {
     v36_compute_source.raw_shader_versions.clear();
     CHECK(serialize_gpu_capture(v36_compute_source, v36_compute_bytes, error) &&
               v36_compute_bytes.size() >=
-                  v42_tail(v36_compute_source) + v41_tail(v36_compute_source) +
+                  v43_tail(v36_compute_source) + v42_tail(v36_compute_source) + v41_tail(v36_compute_source) +
                       v40_tail(v36_compute_source) +
                       v39_tail(v36_compute_source) +
                       v37_tail(v36_compute_source),
           "v37 capture exposes a removable compute subgroup-contract tail");
     if (v36_compute_bytes.size() >=
-        v42_tail(v36_compute_source) + v41_tail(v36_compute_source) +
+        v43_tail(v36_compute_source) + v42_tail(v36_compute_source) + v41_tail(v36_compute_source) +
             v40_tail(v36_compute_source) +
             v39_tail(v36_compute_source) +
             v37_tail(v36_compute_source)) {
+        v36_compute_bytes.resize(v36_compute_bytes.size() - v43_tail(v36_compute_source));
         v36_compute_bytes.resize(v36_compute_bytes.size() - v42_tail(v36_compute_source));
         v36_compute_bytes.resize(v36_compute_bytes.size() - v41_tail(v36_compute_source));
         v36_compute_bytes.resize(v36_compute_bytes.size() - v40_tail(v36_compute_source));
@@ -1466,7 +1524,7 @@ int main() {
     GpuCaptureFile failed_compute_loaded;
     CHECK(serialize_gpu_capture(failed_compute_capture, failed_compute_bytes, error) &&
               deserialize_gpu_capture(failed_compute_bytes, failed_compute_loaded, error) &&
-              failed_compute_loaded.format_version == 42 &&
+              failed_compute_loaded.format_version == 43 &&
               failed_compute_loaded.failure_diagnostics[0].compute_launch.threads_x == 37 &&
               failed_compute_loaded.failure_diagnostics[0].stages[0]
                       .recompile_config.user_sgprs ==
@@ -1479,7 +1537,8 @@ int main() {
 
     std::vector<uint8_t> v41_failed_compute_bytes = failed_compute_bytes;
     v41_failed_compute_bytes.resize(
-        v41_failed_compute_bytes.size() - v42_tail(failed_compute_capture));
+        v41_failed_compute_bytes.size() - v43_tail(failed_compute_capture) -
+            v42_tail(failed_compute_capture));
     v41_failed_compute_bytes[8] = 41;
     v41_failed_compute_bytes[9] = v41_failed_compute_bytes[10] =
         v41_failed_compute_bytes[11] = 0;
@@ -1675,7 +1734,7 @@ int main() {
                 loaded_failed_stage->resource_table.resources.size() == 1
             ? &loaded_failed_stage->resource_table.resources[0]
             : nullptr;
-    CHECK(failed_loaded.format_version == 42 && loaded_shadow &&
+    CHECK(failed_loaded.format_version == 43 && loaded_shadow &&
           loaded_shadow->resource.depth == 4 &&
           loaded_shadow->resource.max_uncompressed_block_size == 2 &&
           loaded_shadow->resource.max_compressed_block_size == 1 &&
@@ -1706,10 +1765,11 @@ int main() {
     GpuCaptureFile v40_failed_loaded;
     CHECK(serialize_gpu_capture(failed_capture, v40_failed_bytes, error) &&
               v40_failed_bytes.size() >=
-                  v42_tail(failed_capture) + v41_tail(failed_capture),
+                  v43_tail(failed_capture) + v42_tail(failed_capture) + v41_tail(failed_capture),
           "v41 failed-stage resource tail is removable for a v40 compatibility fixture");
     if (v40_failed_bytes.size() >=
-        v42_tail(failed_capture) + v41_tail(failed_capture)) {
+        v43_tail(failed_capture) + v42_tail(failed_capture) + v41_tail(failed_capture)) {
+        v40_failed_bytes.resize(v40_failed_bytes.size() - v43_tail(failed_capture));
         v40_failed_bytes.resize(v40_failed_bytes.size() - v42_tail(failed_capture));
         v40_failed_bytes.resize(v40_failed_bytes.size() - v41_tail(failed_capture));
         v40_failed_bytes[8] = 40;
@@ -1791,6 +1851,7 @@ int main() {
     if (v13_bytes.size() >= 32) {
         const size_t legacy_resource_count = legacy_source.draws[0].vrt.resources.size() +
                                              legacy_source.draws[0].prt.resources.size();
+        v13_bytes.resize(v13_bytes.size() - v43_tail(legacy_source));
         v13_bytes.resize(v13_bytes.size() - v42_tail(legacy_source));
         v13_bytes.resize(v13_bytes.size() - v41_tail(legacy_source));
         v13_bytes.resize(v13_bytes.size() - v40_tail(legacy_source));
@@ -1831,6 +1892,7 @@ int main() {
     if (legacy_bytes.size() >= 32) {
         const size_t legacy_resource_count = legacy_source.draws[0].vrt.resources.size() +
                                              legacy_source.draws[0].prt.resources.size();
+        legacy_bytes.resize(legacy_bytes.size() - v43_tail(legacy_source));
         legacy_bytes.resize(legacy_bytes.size() - v42_tail(legacy_source));
         legacy_bytes.resize(legacy_bytes.size() - v41_tail(legacy_source));
         legacy_bytes.resize(legacy_bytes.size() - v40_tail(legacy_source));
@@ -1897,9 +1959,9 @@ int main() {
     CHECK(deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
           !legacy_loaded.failure_diagnostics_available && legacy_loaded.failure_diagnostics.empty(),
           "v6 capture reopens with failed-operation diagnostics reported unavailable");
-    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 43;   // kVersion + 1: a future version
+    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 44;   // kVersion + 1: a future version
     CHECK(!deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
-          error == "unsupported capture version 43",
+          error == "unsupported capture version 44",
           "future capture versions fail with a concrete version error");
 
     GpuCaptureFile bad_hash = mixed;

--- a/prosper/tests/test_render_state.cpp
+++ b/prosper/tests/test_render_state.cpp
@@ -658,6 +658,54 @@ int main() {
               !color_state_trace_matches_dimension(trace, 3840u, 2160u),
               "color-state trace dimension filter matches programmed color targets only");
 
+        // #1459: a resolved pipeline must carry WHY its color write mask is zero, not merely that it
+        // is. These three states all resolve to color_write_mask == 0 for entirely different reasons
+        // — a present zero target mask, a present zero shader mask, and MODE=DISABLE with both masks
+        // write-all. Each demands a different fix, so a capsule that records only the resolved mask
+        // makes them indistinguishable offline. Assert the retained triple separates all three.
+        GpuState zero_target_state;
+        zero_target_state.cx[P::CB_TARGET_MASK] = 0u;
+        zero_target_state.cx[P::CB_SHADER_MASK] = 0xFFu;
+        zero_target_state.cx[P::CB_COLOR_CONTROL] = 0x00CC0010u;   // MODE = NORMAL
+        const ResolvedPipelineState zero_target =
+            resolve_pipeline_state(extract_render_state(zero_target_state));
+
+        GpuState zero_shader_state;
+        zero_shader_state.cx[P::CB_TARGET_MASK] = 0xFFu;
+        zero_shader_state.cx[P::CB_SHADER_MASK] = 0u;
+        zero_shader_state.cx[P::CB_COLOR_CONTROL] = 0x00CC0010u;   // MODE = NORMAL
+        const ResolvedPipelineState zero_shader =
+            resolve_pipeline_state(extract_render_state(zero_shader_state));
+
+        GpuState disabled_state;
+        disabled_state.cx[P::CB_TARGET_MASK] = 0xFFu;
+        disabled_state.cx[P::CB_SHADER_MASK] = 0xFFu;
+        disabled_state.cx[P::CB_COLOR_CONTROL] = 0x00CC0000u;      // MODE = DISABLE
+        const ResolvedPipelineState disabled =
+            resolve_pipeline_state(extract_render_state(disabled_state));
+
+        CHECK(zero_target.color_write_mask == 0 && zero_shader.color_write_mask == 0 &&
+              disabled.color_write_mask == 0,
+              "all three suppression causes resolve to the same zero color write mask");
+        CHECK(zero_target.has_cb_target_mask && zero_target.cb_target_mask == 0u &&
+              zero_target.has_cb_shader_mask && zero_target.cb_shader_mask == 0xFFu,
+              "a present zero CB_TARGET_MASK is retained as present-and-zero");
+        CHECK(zero_shader.has_cb_shader_mask && zero_shader.cb_shader_mask == 0u &&
+              zero_shader.has_cb_target_mask && zero_shader.cb_target_mask == 0xFFu,
+              "a present zero CB_SHADER_MASK is distinguishable from a zero target mask");
+        CHECK(disabled.has_cb_color_control &&
+              ((disabled.cb_color_control >> P::CB_COLOR_CONTROL_MODE_SHIFT) &
+               P::CB_COLOR_CONTROL_MODE_MASK) == P::CB_COLOR_CONTROL_MODE_DISABLE &&
+              disabled.cb_target_mask == 0xFFu && disabled.cb_shader_mask == 0xFFu,
+              "MODE=DISABLE is distinguishable from either mask being zero");
+
+        // The absent case must stay distinct from all of them: no register programmed at all
+        // resolves to write-all, which is the opposite outcome of a present zero.
+        const ResolvedPipelineState absent = resolve_pipeline_state(extract_render_state(GpuState{}));
+        CHECK(!absent.has_cb_target_mask && !absent.has_cb_shader_mask &&
+              !absent.has_cb_color_control && absent.color_write_mask == 0xFu,
+              "an absent color-state triple stays distinct and still resolves to write-all");
+
         const RenderState empty = extract_render_state(GpuState{});
         const ColorStateTraceSnapshot empty_trace =
             snapshot_color_state_trace(empty, resolve_pipeline_state(empty));

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -338,7 +338,7 @@ void inspect_table(const char* stage, const prosper::gpu::ShaderResourceTable* t
     }
 }
 
-void inspect_frame(const prosper::gpu::GpuReplayFrame& replay) {
+void inspect_frame(const prosper::gpu::GpuReplayFrame& replay, uint32_t format_version) {
     for (const auto& seed : replay.rtt_seeds) {
         const uint64_t hash = prosper::gpu::gpu_capture_hash(seed.rgba);
         const char* format = seed.format == prosper::gpu::GpuCaptureColorFormat::Rgba16Float
@@ -450,6 +450,20 @@ void inspect_frame(const prosper::gpu::GpuReplayFrame& replay) {
                     d.ps.src_color_blend_factor, d.ps.dst_color_blend_factor, d.ps.color_blend_op,
                     d.ps.src_alpha_blend_factor, d.ps.dst_alpha_blend_factor, d.ps.alpha_blend_op,
                     d.ps.logic_op_enable, d.ps.logic_op);
+        // #1459: why this draw's color write mask is what it is. An absent target/shader mask means
+        // write-all, so `present:value` is reported rather than the value alone — a zero mask from a
+        // PRESENT zero register and one from MODE=DISABLE demand completely different fixes.
+        if (format_version >= 43)
+            std::printf("  color-state cb-control=%d:%08x mode=%u target-mask=%d:%08x "
+                        "shader-mask=%d:%08x effective=%02x\n",
+                        d.ps.has_cb_color_control, d.ps.cb_color_control,
+                        (d.ps.cb_color_control >> prosper::agc::Pm4::CB_COLOR_CONTROL_MODE_SHIFT) &
+                            prosper::agc::Pm4::CB_COLOR_CONTROL_MODE_MASK,
+                        d.ps.has_cb_target_mask, d.ps.cb_target_mask,
+                        d.ps.has_cb_shader_mask, d.ps.cb_shader_mask,
+                        (d.ps.cb_target_mask & d.ps.cb_shader_mask) & 0xFFu);
+        else
+            std::printf("  color-state unavailable (capture v%u predates v43)\n", format_version);
         for (uint32_t slot = 2; slot < d.color_targets.size(); ++slot) {
             const auto& target = d.color_targets[slot];
             const auto& pipeline = d.ps.color_targets[slot];
@@ -2345,7 +2359,7 @@ int main(int argc, char** argv) {
         std::fprintf(stderr, "[gpureplay] capture save roots: save0=%s savedata-memory=%s\n",
                      save0 == m.renderer_env.end() ? "unknown" : save0->second.c_str(),
                      m.savedata_dir.empty() ? "unknown" : m.savedata_dir.c_str());
-    if (inspect) inspect_frame(replay);
+    if (inspect) inspect_frame(replay, capture.format_version);
     if (validate_only) return validate_frame(replay) ? 0 : 1;
     if (inspect_only) return 0;
     if (metadata_only) {


### PR DESCRIPTION
## Purpose

Supports #1459. Retains the raw colour-state triple — `CB_COLOR_CONTROL`, `CB_TARGET_MASK`,
`CB_SHADER_MASK`, each with an explicit present flag — per realized and failed draw pipeline, and
surfaces it in `gpu_replay --inspect`.

This is a **diagnostic seam, not a fix**. It makes "why is this draw's colour write mask zero"
answerable offline for any title.

## Failure scenario

A capsule stores an **already-resolved** pipeline, so a zero colour write mask was unattributable
offline. Three entirely different causes produce the identical resolved value:

| Cause | Resolved `color_write_mask` |
|---|---|
| `CB_TARGET_MASK` present with value 0 | 0 |
| `CB_SHADER_MASK` present with value 0 | 0 |
| `CB_COLOR_CONTROL.MODE = DISABLE`, both masks write-all | 0 |

Each demands a different fix. Worse, the *absent* case resolves to the **opposite** outcome —
`render_state.cpp` correctly resolves an absent `CB_TARGET_MASK`/`CB_SHADER_MASK` to **write-all**
(`0xF`) — so a zero resolved mask positively implies one of those registers is *present with value
zero*, or `MODE` is `DISABLE`. Only the raw registers separate them.

This blocks a live investigation: on Astro Bot's world map, **28 realized scene draws** carrying real
indexed geometry (2,776–5,736 verts) and a 140,825-word material fragment shader all resolve to
`cwm=0` *and* `cwm1=0`, with ~170 further draws suppressed as no-effect for the same reason. Only 3
draws in the whole frame write full RGBA. Whether that is guest intent or a prosper defect could not
be attributed from the retained capsule.

Two existing diagnostics were confirmed **inert under replay** and cannot answer it:
`PROSPER_COLORSTATETRACE` yields 0 records and `PROSPER_FORCE_COLORWRITE` gives an identical hash,
because capsules store resolved state. `PROSPER_DBBASETRACE` is hardcoded to DB offsets and only
fires on a nonzero-then-zero-within-one-array signature, so it never fires for a register the guest
never writes.

## Behavioral contract

- Presence is serialized **alongside** each value, because "absent" and "present with value 0"
  resolve to opposite masks.
- `resolve_pipeline_state` carries the triple through unchanged as **pure provenance** — nothing
  reads it back, so no rendered output can move.
- Capture **v43** is an **append-only tail**: v1–v42 prefixes stay byte-exact.
- A pre-v43 capture reports `color-state unavailable (capture vNN predates v43)` and is **never**
  given fabricated write-all or zero defaults.

## The no-invented-data property, demonstrated rather than asserted

The retained Astro capsule is literally v42 (magic `PRGPCAP\0`, version `42`), which makes it the
ideal witness. `gpu_replay --inspect-only` on it prints, for **36 of 36** realized draws:

```
  color-state unavailable (capture v42 predates v43)
```

It does *not* print `cb-control=0:00000000 … effective=00`. That distinction is the entire point: a
zeroed row is indistinguishable from "every register absent", which is the **opposite** conclusion
(absent ⇒ write-all), so the diagnostic reports nothing rather than fabricating state.

## Tests

`test_render_state` — three states that all resolve to `color_write_mask == 0` for different reasons
must stay mutually distinguishable, **plus** the absent case staying distinct and still resolving to
write-all `0xF`. This is asserted at the semantic level, not merely as a round-trip.

`test_gpu_capture` — a **present zero** `CB_TARGET_MASK` round-trips through serialize→deserialize
*and* survives materialization into the `GpuReplayFrame` that `--inspect` actually reads. The second
assertion was added deliberately: a `GpuCaptureFile` round-trip alone would not prove the offline
diagnostic can see it. A v42 downgrade fixture asserts the provenance reopens **absent** rather than
defaulted.

## Verification (head `1c24cf5a`, base `fdfb37f2`, 3 commits, 6 files, +218/−19)

Author: `test_render_state` 157 assertions ok / 0 fail; `test_gpu_capture` 179 assertions ok / 0
fail; full ctest 158/160. Both failures are **dump-selection artifacts, proven not assumed**:
`module_loads_eboot` compares Astro's eboot (1733 imports / 55 libs) against The Messenger's
hardcoded 612/35, and `boot_reaches_first_syscall` cannot find `Il2cppUserAssemblies.prx`, a Unity
path absent from Astro's dump. Rebuilt on the modified tree against `PPSA24651-app0` in a throwaway
build dir: **2/2 pass**. Neither test links anything this PR touches.

Integrator, independently at the exact head, built in the `ps5ys` distrobox: `test_gpu_capture`
`== PASS ==` and `test_render_state` `== PASS ==`. **Fails-without-fix confirmed** by reverting only
the `render_state.cpp` carry-through and rebuilding — the discriminating assertions fail
(`a present zero CB_TARGET_MASK is retained as present-and-zero`,
`a present zero CB_SHADER_MASK is distinguishable from a zero target mask`) while
`all three suppression causes resolve to the same zero color write mask` still passes, which is
precisely the discrimination the seam adds.

`git diff --check` clean on both the working tree and the committed range.

## Risks

The highest-risk surface is mechanical: the version bump required updating ten existing downgrade
fixtures and the future-version guard. The author flagged that a bulk edit had introduced a sign
error on one multi-line trim expression, caught by auditing every subtraction context. Reviewed: each
downgrade site now strips `v43_tail` **before** `v42_tail`, matching append order (newest tail
outermost), and `13 = 1 present byte + 3 × u32` is consistent with the writer. Deserialization
validates the present bitmask (`present > 7` rejected) and both record counts, and the
`pipeline_present` condition is symmetric between writer and reader.

No renderer, executor, or recompiler behaviour changes.

## Related

Also on #1459 and **not** reimplemented here: R11G11B10 storage lowering is empirically correct —
stored (packed R32ui) and current-raw (native typed float) modules take provably different backend
paths yet produce byte-identical output `28b5ea9a3fbd2ca9`. That fork is closed.
