### PR TITLE
fix(tile): address packed mip-tail levels at their real element origin

### DIFF
--- a/prosper/src/gpu/tile.cpp
+++ b/prosper/src/gpu/tile.cpp
@@ -1214,8 +1214,21 @@ TiledMipLevelLayout tiled_mip_level_layout(uint32_t ew, uint32_t eh, uint32_t bp
             }
         }
         result.byte_offset = mip_offset;
-        result.tail_x = mip_x * (block_width >> 4u);   // Block256_2d element dimensions
-        result.tail_y = mip_y * (block_height >> 4u);
+        // mip_x/mip_y count whole 256-BYTE blocks, so converting them to elements needs that block's
+        // element extent, which depends ONLY on the element size (AddrLib Block256_2d): 1B=16x16,
+        // 2B=16x8, 4B=8x8, 8B=8x4, 16B=4x4. The previous `block_width >> 4` derived the multiplier
+        // from the macroblock instead, which is right only when the macroblock happens to be 16x the
+        // 256-byte block (the 64 KiB modes) and four times too small for every 4 KiB mode. A 4 KiB
+        // 32-bpp macroblock is 32x32 elements, so it produced tail_x=4 where the level really starts
+        // at element 16 -- i.e. byte 0x80 instead of the byte_offset 0x800 reported alongside it, so
+        // the two origins in this same struct disagreed and packed-tail levels decoded foreign texels.
+        // The invariant now asserted by the tile tests: the element origin must address exactly
+        // byte_offset under the surface's own swizzle.
+        static constexpr uint32_t kBlock256Width[5]  = {16, 16, 8, 8, 4};
+        static constexpr uint32_t kBlock256Height[5] = {16,  8, 8, 4, 4};
+        if (elem_log2 >= 5) return {};
+        result.tail_x = mip_x * kBlock256Width[elem_log2];
+        result.tail_y = mip_y * kBlock256Height[elem_log2];
         result.tail_block_bytes = 1u << block_log2;
         result.in_tail = true;
         return result;

--- a/prosper/tests/test_build_shader_resources.cpp
+++ b/prosper/tests/test_build_shader_resources.cpp
@@ -155,7 +155,7 @@ int main() {
         const DecodedImageView vmip7 = image_base_level_view(dmip7, mip_format);
         CHECK(vmip7.supported && vmip7.in_mip_tail && vmip7.base == 0x18000000ull &&
                   vmip7.width == 16 && vmip7.height == 9 && vmip7.mip_offset == 2048 &&
-                  vmip7.mip_tail_bytes == 4096 && vmip7.mip_tail_x == 4 &&
+                  vmip7.mip_tail_bytes == 4096 && vmip7.mip_tail_x == 16 &&
                   vmip7.mip_tail_y == 0,
               "packed-tail base level keeps the shared block base and exact in-block origin");
         uint32_t tmip_cube[8];
@@ -299,7 +299,7 @@ int main() {
         CHECK(tail && tail->gpu_addr == 0x18000000ull && tail->width == 16 &&
                   tail->height == 9 && tail->size == 16u * 9u * 4u &&
                   tail->in_mip_tail && tail->mip_tail_offset == 2048 &&
-                  tail->mip_tail_bytes == 4096 && tail->mip_tail_x == 4 &&
+                  tail->mip_tail_bytes == 4096 && tail->mip_tail_x == 16 &&
                   tail->mip_tail_y == 0,
               "packed-tail resource retains the shared base and exact swizzled level coordinate");
         CHECK(tail && !tail->compression_enabled && tail->metadata_addr == 0,

--- a/prosper/tests/test_tile.cpp
+++ b/prosper/tests/test_tile.cpp
@@ -408,12 +408,12 @@ int main() {
         const TiledMipLevelLayout tail7 =
             tiled_mip_level_layout(2048, 1152, 4, M, 11, 7);
         CHECK(tail7.supported && tail7.in_tail && tail7.byte_offset == 2048 &&
-                  tail7.tail_x == 4 && tail7.tail_y == 0 && tail7.tail_block_bytes == 4096,
+                  tail7.tail_x == 16 && tail7.tail_y == 0 && tail7.tail_block_bytes == 4096,
               "first SW_4KB_S tail level exposes AddrLib byte and element origins");
         const TiledMipLevelLayout tail11 =
             tiled_mip_level_layout(2048, 1152, 4, M, 11, 11);
         CHECK(tail11.supported && tail11.in_tail && tail11.byte_offset == 768 &&
-                  tail11.tail_x == 2 && tail11.tail_y == 2,
+                  tail11.tail_x == 8 && tail11.tail_y == 8,
               "last allocated tail level retains its sparse max-tail slot");
 
         // Pack level 7 into its shared block using the equivalent global tail coordinate, then read
@@ -448,6 +448,56 @@ int main() {
         for (size_t i = 0; i < rewritten.size(); ++i) changed += rewritten[i] != shared_tail[i];
         CHECK(changed <= replacement.size(),
               "tail writeback does not clear or overwrite sibling padding bytes");
+    }
+
+    // A packed-tail level reports TWO origins for the same texels: byte_offset and (tail_x, tail_y).
+    // They must agree, i.e. the element origin has to land on byte_offset under the surface's own
+    // swizzle. The round-trip above cannot see a disagreement because it both writes and reads at
+    // (tail_x, tail_y); only cross-checking against byte_offset pins the real placement. This caught
+    // 4 KiB tail levels resolving to a quarter of their true element origin (#320: PPSA02664's
+    // mipped 4x4 SpriteMask sprites decoded foreign, fully transparent texels, so every mask
+    // fragment failed its alpha test and a "visible outside mask" fill covered the whole frame).
+    {
+        struct Case { uint32_t mode, bpe, w, h, max_mip; };
+        const Case cases[] = {
+            {(uint32_t)TileMode::Sw4KbS,   4,    4,    4,  2},   // PPSA02664 mask sprite
+            {(uint32_t)TileMode::Sw4KbS,   4, 2048, 1152, 11},
+            {(uint32_t)TileMode::Sw4KbS,   8,  256,  256,  8},
+            {(uint32_t)TileMode::Sw4KbS,  16,  256,  256,  8},
+            {(uint32_t)TileMode::Sw64KbS,  4, 1920, 1080,  7},
+            {(uint32_t)TileMode::Sw64KbS,  8,  512,  512,  9},
+        };
+        size_t checked = 0, disagreed = 0;
+        for (const Case& c : cases) {
+            // Element extent of one whole block for this mode/bpe, found through the public API.
+            const size_t block_bytes = tiled_elements_bytes(1, 1, c.bpe, c.mode);
+            uint32_t bw = 0, bh = 0;
+            for (uint32_t w = 1; w <= 1024 && !bw; w <<= 1)
+                for (uint32_t h = 1; h <= 1024; h <<= 1)
+                    if ((size_t)w * h * c.bpe == block_bytes &&
+                        tiled_elements_bytes(w, h, c.bpe, c.mode) == block_bytes) { bw = w; bh = h; break; }
+            if (!bw || !bh) continue;
+            // Stamp every element of one block with its own coordinate, then tile it.
+            std::vector<uint8_t> linear(block_bytes, 0), tiled(block_bytes, 0);
+            for (uint32_t y = 0; y < bh; ++y) for (uint32_t x = 0; x < bw; ++x) {
+                const uint32_t stamp = (y << 16) | x;
+                std::memcpy(linear.data() + ((size_t)y * bw + x) * c.bpe, &stamp, 4);
+            }
+            tile_surface(tiled.data(), linear.data(), bw, bh, c.mode, 0, c.bpe);
+            for (uint32_t level = 0; level <= c.max_mip; ++level) {
+                const TiledMipLevelLayout l =
+                    tiled_mip_level_layout(c.w, c.h, c.bpe, c.mode, c.max_mip, level);
+                if (!l.supported || !l.in_tail) continue;
+                if (l.byte_offset + 4 > tiled.size()) continue;
+                uint32_t stamp = 0;
+                std::memcpy(&stamp, tiled.data() + l.byte_offset, 4);
+                ++checked;
+                if ((stamp & 0xffffu) != l.tail_x || (stamp >> 16) != l.tail_y) ++disagreed;
+            }
+        }
+        CHECK(checked >= 20, "tail-origin cross-check exercised the packed-tail levels");
+        CHECK(disagreed == 0,
+              "every packed-tail element origin addresses exactly its reported byte_offset");
     }
 
     // Tiled footprint: a 64KB block holds 65536 bytes; its element dims depend on bpe


### PR DESCRIPTION
## Purpose

Fixes the packed mip-tail element origin for 4 KiB tile modes. This is a **generic tiling defect in shared
code**, not a title-specific workaround — but its visible consequence is that *Alex Kidd in Miracle World DX*
(`PPSA02664`) now reaches the **gameplay rung** with a visually correct first level.

Advances #320 (see *What remains* below).

## Progression evidence

Direct, unmodified SDL3/Vulkan frontend captures at native 1920x1080, routed with
`scripts/ppsa02664/reach-first-gameplay.pad`. No forced guest state, no diagnostic substitution.

![Alex Kidd — Mt. Eternal gameplay with dialogue](https://raw.githubusercontent.com/mattias800/prosper/pr-assets/ppsa02664-gameplay-dialogue.png)

![Alex Kidd — Mt. Eternal level composition](https://raw.githubusercontent.com/mattias800/prosper/pr-assets/ppsa02664-gameplay-level.png)

Player sprite, HUD (lives counter and item slot), dialogue box, floating platforms with grass and dirt strata,
clouds, god rays, enemy sprite, item blocks, and parallax mountains all composite correctly. Before this fix the
same route rendered **100% black behind the dialogue box**.

## Failure scenario

`tiled_mip_level_layout` reports **two origins for the same texels**: `byte_offset`, and the element coordinate
`(tail_x, tail_y)`. They disagreed.

`mip_x`/`mip_y` count whole **256-byte** blocks, so converting them to elements requires that block's element
extent, which depends only on element size — AddrLib `Block256_2d`: 1B=16x16, 2B=16x8, 4B=8x8, 8B=8x4, 16B=4x4
(every entry multiplying to exactly 256 bytes). The old code derived the multiplier from the **macroblock**
(`block_width >> 4`), which is correct only when the macroblock happens to be 16x the 256-byte block — true for
the 64 KiB modes, and **four times too small for every 4 KiB mode**.

Concretely, a 4 KiB 32-bpp macroblock is 32x32 elements, so the code produced `tail_x=4` (byte `0x80`) for a level
whose own `byte_offset` field said `0x800`. The consumer uses `tail_x`, so packed-tail levels decoded **foreign
texels**.

**53 of 130 packed-tail levels violated the origin-agreement invariant before this change; 0 after.**

### How that produced a black screen

The chain is worth recording because the symptom is several layers from the cause. `PPSA02664`'s Unity
**SpriteMask** sprites are mipped 4x4 surfaces in a 4 KiB mode. With a quarter-sized element origin they decoded
to foreign, **fully transparent** texels, so every mask fragment failed its alpha test, and the shader's
*legitimate* "visible outside mask" fill then covered the whole frame. The world was being rendered correctly the
entire time and then painted over.

## Behavioral contract

A packed mip-tail level's element origin must address exactly its reported `byte_offset` under the surface's own
swizzle. Element sizes above 16 bytes return empty (fail-visible) rather than indexing past the table.

## Tests

New origin-agreement invariant in `test_tile.cpp`. It is **derived from first principles, not a restated
constant**: it stamps every element of a block with its own `(x, y)` coordinate, tiles it through the real
`tile_surface`, then reads the 4 bytes at each packed-tail level's `byte_offset` and asserts the stamp matches
`(tail_x, tail_y)`. It would catch this defect regardless of what the multiplier constant is.

It covers both 4 KiB and 64 KiB modes at bpe 4/8/16, and asserts `checked >= 20` so it **cannot pass vacuously**
by exercising nothing.

Two existing fixtures in `test_tile.cpp` and `test_build_shader_resources.cpp` change (`mip_tail_x` 4 -> 16, and
2 -> 8). **Those expected values encoded the bug** — which is exactly why the new invariant is derived
independently rather than asserting the new numbers.

## Verification

Author: full ctest **158/160**, both failures proven pre-existing by reverting the patch and re-running on a clean
tree (they are dump-identity artifacts of configuring `-DGAME_DUMP=PPSA02664` rather than The Messenger).

Integrator, independently, in the `ps5ys` distrobox:

- `gpu_surface_detile`, `gpu_surface_detile_threaded`, `build_shader_resources` pass at the branch head.
- **Fails-without-fix confirmed**: reverting only `prosper/src/gpu/tile.cpp` to master and rebuilding gives
  3 failures, including `every packed-tail element origin addresses exactly its reported byte_offset` — while its
  vacuity guard `tail-origin cross-check exercised the packed-tail levels` still **passes**, proving the invariant
  genuinely exercised cases rather than passing empty.
- Current master is **162/162** when configured against `PPSA24651`.
- `git diff --check` clean.

### Snapshot matrix — 6 of 8, and both failures are pre-existing

Run under an exclusive GPU lease, because a shared tiling change alters texture decode for every title.

| Baseline | Result |
|---|---|
| messenger-scene | OK (frames=29) |
| evergate-title | OK (richest=52,882 colors) |
| evergate-gameplay | OK (richest=64,664 colors) |
| dead-cells-gameplay | OK (richest=9,884 colors) |
| blasphemous2-gameplay | OK (frames=98) |
| blue-prince-title | OK (richest=16,102 colors) |
| blue-prince-hall | FAIL — **also fails identically on master without this change** |
| terminator-boot | FAIL — **also fails identically on master** (`structural matches 10 < 16` both runs) |

A control run of those two baselines on master settles attribution: **neither failure is caused by this change.**

Both retained images were also inspected rather than judged from metrics, and neither is a rendering collapse:
`blue-prince-hall` retained a fully-rendered, correctly-lit gramophone close-up (the guard expects the entrance
hall, so the route landed in a different scene), and `terminator-boot` retained a healthy attract-mode frame with
gold endoskeleton, blue arcs and spark particles. Both are animated scenes judged by SSIM against fixed luminance
signatures, which makes them phase-sensitive.

## Risks

Blast radius is **shared tiling**: any title sampling a small mipped 4 KiB surface changes behaviour. That is the
point of the fix — those surfaces were decoding foreign texels — and the snapshot matrix above is the evidence
that no guarded title regressed.

One consequence worth knowing: existing `.prgcap` files **bake the resolved tail coordinates**, so pre-fix
capsules replay unchanged even on a fixed binary. Any offline re-verification of tiling behaviour needs a
**fresh** capture.

## What remains (#320 stays open)

- A title-level snapshot guard for `PPSA02664`. Proposed contract: route
  `scripts/ppsa02664/reach-first-gameplay.pad`, sample 70-120 s, richest frame must have non-black >= 95% **and**
  >= 20,000 distinct colours (pre-fix: 13.7% and 3,010 — roughly 7x and 50x separation), paired with the existing
  SSIM comparison. Deliberately **not** colour count alone: a seed-miss gradient can outscore real content.
  Needs `snapshot.py verify` plus review of every retained image before adopting a baseline.
- #710 (title/menu renders incorrectly, described as alpha under-applied on overlays) is plausibly the same root
  cause and is now cheap to re-check.
- `gpu_replay --inspect-only` prints no `in_mip_tail`/`mip_tail_*` fields; adding them is a small diagnostic win.

## Falsified along the way — do not revive

Descriptor selection, Gen5 size decode, the 4x4 fallback, blend/stencil semantics, guest-state divergence, stale
texture content, and "draw #12 is a mis-activated Unity object". The guest's T# is **genuinely 4x4 with
`base_level=0`** (`PROSPER_TDUMP`, hand-decoded `t1=0xc3800000`/`t2=0x0000c000`), so both prior size hypotheses
stay dead — the size was never the issue. The much older "`fs2949` premultiplies by vertex-colour alpha 0"
diagnosis also remains falsified: that capsule was the intro narration crawl, where alpha-0 is correct.
