### PR TITLE
docs(orchestration): mark the Dragon Quest corruption boundary as a bisect artifact

### DIFF
--- a/prosper/docs/GAME_COMPAT_ORCHESTRATION.md
+++ b/prosper/docs/GAME_COMPAT_ORCHESTRATION.md
@@ -392,9 +392,25 @@ Durable comments:
 
 The A/B manifest SHA-256 is `f2f44602c178226539ba456d9a9879c1ab5b04634f3cb590010434577771290d`.
 
-### Exact corruption boundary
+### The "exact corruption boundary" is a BISECT ARTIFACT — retained as a warning
 
-Adaptive operation-prefix replay found:
+> **FALSIFIED 2026-07-31.** The op116 -> op117 "corruption boundary" below, on which this entire lane was
+> founded, **does not exist**. `--through-operation N` renders **the last executed draw target**, so
+> consecutive cutoffs display *different surfaces*. The retained logs show it plainly — every cutoff is a
+> different resolution: op104 30x34, op111 480x270, op114 960x1080, **op116 1920x1080, op117 3840x2160**.
+>
+> **op116 and op117 were never the same buffer, so the transition between them cannot be a corruption event.**
+>
+> op116's identity is pinned independently: it is a *dispatch*, so its output selects op115's target
+> `0x3083db0000` = draw90's `b35`, and its content (R .0124 / G .0443 / B .1865) matches `tap-142` —
+> draw90's own sample of b35 — to three decimals. **op116 is a post-process input that draw90 consumes.
+> It is dark because such buffers are dark**, not because it is the last good frame before corruption.
+>
+> Do not re-derive a boundary from prefix replay without first confirming both prefixes render the **same
+> target at the same resolution**. This is the single most expensive mistake recorded in this document: it
+> shaped every hypothesis in the lane for two sessions.
+
+The original (now-falsified) table, retained only so the claim is recognisable if it resurfaces:
 
 | Prefix | Output | Hash / metrics |
 |---|---|---|


### PR DESCRIPTION
## Purpose

Corrects a **falsified claim that I merged earlier today** in #1577. Documentation only.

The op116 → op117 "exact corruption boundary" — the finding that issue #1486 and this entire lane were founded on — **does not exist**, and the orchestration document currently presents it as established fact.

## Why it is wrong

`--through-operation N` renders **the last executed draw target**, so consecutive cutoffs display *different surfaces*. The retained logs make it unmissable once you look, because every cutoff is a different resolution:

| Prefix | Resolution |
|---|---|
| op104 | 30x34 |
| op111 | 480x270 |
| op114 | 960x1080 |
| **op116** | **1920x1080** |
| **op117** | **3840x2160** |

**op116 and op117 were never the same buffer**, so the transition between them cannot be a corruption event.

op116's identity is pinned independently rather than by elimination: it is a *dispatch*, so its output selects op115's target `0x3083db0000` = draw90's `b35` — and its content (R .0124 / G .0443 / B .1865) matches `tap-142`, draw90's own sample of b35, to three decimals. **op116 is a post-process input that draw90 consumes. It is dark because such buffers are dark**, not because it is the last good frame before corruption.

## What changes

The falsified table is **retained**, not deleted, so the claim stays recognisable if it resurfaces in an old issue comment or someone's notes — with a prominent warning above it. The warning states the general rule: a prefix-replay boundary means nothing unless both prefixes render the **same target at the same resolution**.

This is recorded as the most expensive mistake in the document because it shaped every hypothesis in the lane across two sessions.

## Context

The same lane has now measured correct: the grading LUT, tile27 detile, DCC, 10:10:10:2 unpack, 3D sampling, filtering, shader translation, film grain, chromatic aberration, op103 input format and content, interpolant delivery, and both exposure constants (`s97 = 8192.0` PreExposure with `1/8192` in the adjacent dword — cancellation by design, no base-pass change needed).

**No mechanism for an overexposure defect survives, and the observation that motivated the search is not established.** One like-for-like comparison remains — operation 120 (draw 92), the last pre-Slate composite, against the oracle — and it has never been done.

## Verification

Documentation only; no code, tests, or build affected. `git diff --check` clean. No local host paths.