### PR TITLE
tools(gpu_replay): name the selected target on the output line, not just its size

### DIFF
--- a/prosper/tests/test_gpu_replay_extent.cpp
+++ b/prosper/tests/test_gpu_replay_extent.cpp
@@ -82,6 +82,70 @@ int main() {
     CHECK(extent.width == 3840 && extent.height == 2160,
           "capture-sized renderer output overrides stale native draw dimensions");
 
+    // Regression for the #1486 class of false bisect boundary. Two adjacent ordered-prefix cutoffs
+    // that resolve to DIFFERENT color targets must report different addresses, so that comparing
+    // their images is visibly not like-for-like. Reporting only an extent is what let op116
+    // (a 1920x1080 post-process input) and op117 (the 3840x2160 graded scene) read as a single
+    // surface being corrupted between two cutoffs, when they were never the same buffer.
+    {
+        GpuReplayFrame bisect;
+        bisect.metadata.width = 3840;
+        bisect.metadata.height = 2160;
+
+        DrawItem post;                       // the post-process input a later draw samples
+        post.draw_index = 88;
+        post.color0_base = 0x3083db0000ull;
+        post.color0_width = 1920;
+        post.color0_height = 1080;
+
+        DrawItem scene;                      // the full-resolution graded scene
+        scene.draw_index = 90;
+        scene.color0_base = 0x30867e0000ull;
+        scene.color0_width = 3840;
+        scene.color0_height = 2160;
+
+        bisect.items = {post, scene};
+        bisect.operations = {
+            {SubmitOperationKind::Draw, 88, 100, true},
+            {SubmitOperationKind::Dispatch, 26, 200, true},
+            {SubmitOperationKind::Draw, 90, 300, true},
+        };
+
+        const OutputExtent earlier = replay_output_extent(
+            bisect, OutputExtentMode::OrderedPrefix, static_cast<size_t>(1920) * 1080 * 4, 2);
+        const OutputExtent later_cut = replay_output_extent(
+            bisect, OutputExtentMode::OrderedPrefix, static_cast<size_t>(3840) * 2160 * 4, 3);
+
+        CHECK(earlier.target_addr == 0x3083db0000ull && earlier.target_draw_index == 88,
+              "prefix ending at a dispatch reports the draw target it actually rendered");
+        CHECK(later_cut.target_addr == 0x30867e0000ull && later_cut.target_draw_index == 90,
+              "the next cutoff reports the full-resolution target");
+        CHECK(earlier.target_addr != later_cut.target_addr,
+              "adjacent cutoffs on different surfaces report different targets");
+    }
+
+    // The capture-extent fallback must not claim a draw target whose dimensions it does not report;
+    // an address next to the wrong extent would be worse than reporting none.
+    {
+        GpuReplayFrame plain;
+        plain.metadata.width = 64;
+        plain.metadata.height = 64;
+        DrawItem odd;
+        odd.draw_index = 3;
+        odd.color0_base = 0x1234000ull;
+        odd.color0_width = 8;
+        odd.color0_height = 8;
+        plain.items = {odd};
+        plain.operations = {{SubmitOperationKind::Draw, 3, 10, true}};
+
+        const OutputExtent fallback = replay_output_extent(
+            plain, OutputExtentMode::OrderedPrefix, static_cast<size_t>(64) * 64 * 4, 1);
+        CHECK(fallback.width == 64 && fallback.height == 64,
+              "byte count disproving the draw extent falls back to the capture extent");
+        CHECK(fallback.target_addr == 0,
+              "capture-extent fallback reports no target rather than a mismatched address");
+    }
+
     if (fails) { std::printf("== FAIL: %d ==\n", fails); return 1; }
     std::printf("== PASS ==\n");
     return 0;

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -457,6 +457,21 @@ order and all earlier work. Prefix output uses the last executed draw target's n
 a hash-verified seeded final capsule for fast composition bisection; unlike `--draw`, it does not discard
 DMA copies, compute dispatches, or earlier draws.
 
+**Always read `target=` before comparing two cutoffs.** Because prefix output follows the *last executed draw
+target*, adjacent cutoffs can render two completely different buffers, and comparing them then looks like one
+surface changing. The render summary names the surface it selected:
+
+```text
+[gpureplay] output=1920x1080 target=0000003083db0000 draw=88 bytes=8294400 hash=…
+[gpureplay] output=3840x2160 target=00000030867e0000 draw=90 bytes=33177600 hash=…
+```
+
+Differing `target=` values mean the two images are **not like-for-like** and no conclusion may be drawn from
+their difference. `target=capture` means the extent came from the capture's presentation metadata rather than
+a draw, so no single draw target describes it. This exists because #1486's "exact corruption boundary" was
+derived from exactly such a pair — a 1920x1080 post-process input versus the 3840x2160 graded scene — and the
+resulting hypothesis shaped two sessions of work before the extents were noticed.
+
 `--draw-steps PREFIX [--draw-steps-every N] [--draw-steps-target WxH]` is the **visual bisection** primitive —
 the fastest way to localize a composition defect (a black quad, a lost layer, a wrong-blended overlay) to the
 exact operation that introduces it, with **no oracle screenshot**. It renders the `--through-operation` prefix

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -2584,9 +2584,18 @@ int main(int argc, char** argv) {
     const uint32_t output_width = output_extent.width;
     const uint32_t output_height = output_extent.height;
     uint64_t hash = prosper::gpu::gpu_capture_hash(pixels);
-    std::fprintf(stderr, "[gpureplay] output=%ux%u bytes=%zu hash=%016llx "
+    // Name the surface, not just its size. A prefix replay renders the LAST EXECUTED DRAW TARGET, so
+    // adjacent `--through-operation` cutoffs can report two different buffers; without the address that
+    // reads as one surface changing. `target=` makes such a comparison self-invalidating.
+    char target_tag[64] = " target=capture";
+    if (output_extent.target_addr)
+        std::snprintf(target_tag, sizeof target_tag, " target=%016llx draw=%llu",
+                      static_cast<unsigned long long>(output_extent.target_addr),
+                      static_cast<unsigned long long>(output_extent.target_draw_index));
+    std::fprintf(stderr, "[gpureplay] output=%ux%u%s bytes=%zu hash=%016llx "
                          "expected_bytes=%llu expected_hash=%016llx\n",
-                 output_width, output_height, pixels.size(), static_cast<unsigned long long>(hash),
+                 output_width, output_height, target_tag,
+                 pixels.size(), static_cast<unsigned long long>(hash),
                  static_cast<unsigned long long>(replay.expected_output_bytes),
                  static_cast<unsigned long long>(replay.expected_output_hash));
     if (positional.size() == 2 && !pixels.empty() &&

--- a/prosper/tools/gpu_replay/replay_output_extent.hpp
+++ b/prosper/tools/gpu_replay/replay_output_extent.hpp
@@ -17,6 +17,17 @@ enum class OutputExtentMode {
 struct OutputExtent {
     uint32_t width = 0;
     uint32_t height = 0;
+    // Guest base address of the color target the reported extent came from, and the draw that wrote
+    // it. Zero when the extent came from the capture's presentation metadata rather than a draw.
+    //
+    // Reporting WHICH surface was selected matters because a prefix replay renders the last executed
+    // draw target, so two adjacent `--through-operation` cutoffs can display two completely different
+    // buffers. Without the address, that reads as one surface changing between the cutoffs -- which is
+    // how #1486's "exact corruption boundary" was derived from op116 (1920x1080, a post-process input)
+    // versus op117 (3840x2160, the graded scene). They were never the same surface. Printing the
+    // address makes that class of false boundary self-evident instead of load-bearing.
+    uint64_t target_addr = 0;
+    uint64_t target_draw_index = 0;
 };
 
 struct OutputTarget {
@@ -57,7 +68,8 @@ inline OutputExtent replay_output_extent(const GpuReplayFrame& replay, OutputExt
     OutputExtent selected_extent = capture_extent;
     auto select_draw = [&](const DrawItem& draw) {
         if (draw.color0_width && draw.color0_height)
-            selected_extent = {draw.color0_width, draw.color0_height};
+            selected_extent = {draw.color0_width, draw.color0_height,
+                               draw.color0_base, draw.draw_index};
     };
 
     if (mode == OutputExtentMode::SelectedDraws) {
@@ -83,8 +95,18 @@ inline OutputExtent replay_output_extent(const GpuReplayFrame& replay, OutputExt
                                    capture_extent.height * 4;
     const uint64_t selected_bytes = static_cast<uint64_t>(selected_extent.width) *
                                     selected_extent.height * 4;
-    if (capture_bytes == output_bytes) return capture_extent;
-    return selected_bytes == output_bytes ? selected_extent : capture_extent;
+    // Attach the target identity only when the returned extent is the one that draw actually
+    // produced. Reporting an address next to dimensions it does not describe would be worse than
+    // reporting none, since the whole point is to identify the surface on screen.
+    auto with_target = [&](OutputExtent chosen) {
+        if (chosen.width == selected_extent.width && chosen.height == selected_extent.height) {
+            chosen.target_addr = selected_extent.target_addr;
+            chosen.target_draw_index = selected_extent.target_draw_index;
+        }
+        return chosen;
+    };
+    if (capture_bytes == output_bytes) return with_target(capture_extent);
+    return with_target(selected_bytes == output_bytes ? selected_extent : capture_extent);
 }
 
 } // namespace prosper::gpu::replay_tool


### PR DESCRIPTION
## Purpose

`gpu_replay`'s `[gpureplay] output=` line reports the rendered **extent** but not **which surface** produced it. This adds `target=<addr> draw=<n>`.

It is a small, title-agnostic diagnostic change that kills a whole **class** of false conclusions.

## The failure it prevents — with a concrete, expensive instance

A prefix replay renders the **last executed draw target**, so two adjacent `--through-operation` cutoffs can display two completely different buffers. Without the address, that reads as *one surface changing between the cutoffs*.

That is exactly how issue #1486's "exact corruption boundary" was derived. op116 was reported as a coherent dark 1920x1080 frame and op117 as the first overexposed 3840x2160 frame, and the transition between them was treated as the corruption event. **They were never the same surface.** op116 is a post-process input that draw90 consumes (its output selects op115's target = draw90's `b35`, and its content matches `tap-142`, draw90's own sample of that buffer, to three decimals). It is dark because such buffers are dark.

Every cutoff in that bisect was a different resolution — op104 30x34, op111 480x270, op114 960x1080, op116 1920x1080, op117 3840x2160 — and nobody noticed, because the tool never said which surface it had picked. That false boundary shaped every hypothesis in the lane across two sessions.

Had the line read `op116 target=0x3083db0000` beside `op117 target=0x30867e0000`, it would have been self-evidently bogus on day one.

## Behavioral contract

- `replay_output_extent` resolves the target address **alongside** the extent decision, so the reported target cannot drift from the dimensions printed next to it.
- The identity attaches **only when the returned extent is the one that draw actually produced**. An address printed beside dimensions it does not describe would be worse than no address at all, since the entire point is to identify the surface on screen.
- `target=capture` explicitly marks the presentation-metadata path, rather than printing a misleading zero.

## Compatibility

**No log format is broken.** `regress.py` keys on `hash=`, and this adds no `hash=` token — the new field is inserted before `bytes=`.

## Tests

Five new assertions in `test_gpu_replay_output_extent`, including **the exact adjacent-cutoff case**: a 1920x1080 post-process input and a 3840x2160 scene must report *different* addresses.

Fails-without-fix proven by neutering the population: `the next cutoff reports the full-resolution target` goes `[FAIL]`, suite exit 1.

`ctest -R "gpu_replay|tile|detile"` **6/6** on a full build. `git diff --check` clean. Branched fresh from `336ea104`.

## Known limitation — deliberately stated

The **selection logic** is unit-tested, but the **printed line** has not been eyeballed on a real capsule, because printing it requires rendering and therefore the GPU. A bounded two-cutoff replay is queued to confirm the line renders as expected; that run is itself the demonstration this change exists for, since it should print two different `target=` values for two adjacent operations.

## Related

Groundwork for #1486's restatement. The lane has now measured correct: the grading LUT, tile27 detile, DCC, 10:10:10:2 unpack, 3D sampling, filtering, shader translation, film grain, chromatic aberration, op103 input format and content, interpolant delivery, and both exposure constants (`s97 = 8192.0` PreExposure with `1/8192` adjacent — cancellation by design). No mechanism for an overexposure defect survives.