### PR TITLE
tools(gpu): add PROSPER_REGWATCH and print colour-state for suppressed pipelines

### DIFF
--- a/prosper/scripts/astrobot/README.md
+++ b/prosper/scripts/astrobot/README.md
@@ -14,6 +14,22 @@ GAME: Level has started: intro_next
 PLAY: SubLevelLocator sublevel_locator_hub [hub_crashsite_tutorial], state changed 1->4
 ```
 
+### Route pacing is frontend-sensitive
+
+`reach-first-level.pad` mixes wall-time pulses (60-96 s) with flip-anchored pulses at `f3800`+. Under
+`boot_trace` the wall-time pulses are all spent by 96 s while the run is only near frame 1100, so
+`f3800` is never reached and the guest stalls at `title_controller_ship`. That route is calibrated for
+a frontend that flips far more slowly per wall-second than headless `boot_trace` does.
+
+To reach the **world map** under `boot_trace`, use a flip-anchored route in the f730-960 window
+instead; that is the pacing the retained world-map captures were produced with. Check
+`PROSPER_PAD_SCRIPT_LOG=1` output against the observed frame counter before assuming a route applies
+to a new frontend.
+
+`boot_trace` also writes a 3840x2160 BMP per sampled frame by default (`dump=1`), which reaches
+gigabytes over a multi-minute route. Set `PROSPER_NO_FRAME_DUMPS=1` for capture runs that only need
+the `.prgbundle`.
+
 ## Captures
 
 These are unmodified frontend captures from the documented routes. The incomplete rendering is

--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -32,6 +32,73 @@ namespace prosper { void prosper_eq_trigger_eop(); }
 
 namespace prosper::gpu {
 
+std::vector<RegWatchEntry> parse_reg_watch(const char* setting) {
+    std::vector<RegWatchEntry> entries;
+    if (!setting || !*setting) return entries;
+    const std::string text(setting);
+    size_t start = 0;
+    while (start <= text.size()) {
+        const size_t comma = text.find(',', start);
+        std::string item = text.substr(start, comma == std::string::npos ? std::string::npos
+                                                                         : comma - start);
+        start = comma == std::string::npos ? text.size() + 1 : comma + 1;
+        // Trim surrounding spaces so a human-written list stays forgiving.
+        while (!item.empty() && std::isspace(static_cast<unsigned char>(item.front())))
+            item.erase(item.begin());
+        while (!item.empty() && std::isspace(static_cast<unsigned char>(item.back())))
+            item.pop_back();
+        if (item.empty()) continue;
+        RegWatchEntry entry;
+        const size_t colon = item.find(':');
+        if (colon != std::string::npos) {
+            const std::string cls = item.substr(0, colon);
+            if (cls == "Cx" || cls == "cx") entry.reg_class = RegClass::Cx;
+            else if (cls == "Sh" || cls == "sh") entry.reg_class = RegClass::Sh;
+            else if (cls == "Uc" || cls == "uc") entry.reg_class = RegClass::Uc;
+            else continue;   // unknown class: skip this entry, keep the rest of the list
+            item = item.substr(colon + 1);
+            if (item.empty()) continue;
+        }
+        char* end = nullptr;
+        errno = 0;
+        const unsigned long parsed = std::strtoul(item.c_str(), &end, 0);
+        if (errno || !end || *end || parsed > 0xFFFFFFFFul) continue;
+        entry.offset = static_cast<uint32_t>(parsed);
+        if (std::find(entries.begin(), entries.end(), entry) == entries.end())
+            entries.push_back(entry);
+    }
+    return entries;
+}
+
+namespace {
+const std::vector<RegWatchEntry>& reg_watch_entries() {
+    static const std::vector<RegWatchEntry> entries =
+        parse_reg_watch(std::getenv("PROSPER_REGWATCH"));
+    return entries;
+}
+
+// One line per watched write. `values`/`count` describe a direct multi-register span so a watched
+// offset inside a larger SET_*_REG range still reports the dword that actually landed on it.
+void reg_watch_report(RegClass reg_class, uint32_t offset, uint32_t value, uint32_t count,
+                      const uint32_t* values, const char* path, uint64_t command_order) {
+    const auto& entries = reg_watch_entries();
+    if (entries.empty()) return;
+    for (const auto& entry : entries) {
+        if (entry.reg_class != reg_class) continue;
+        if (entry.offset < offset || entry.offset >= offset + (count ? count : 1u)) continue;
+        const uint32_t index = entry.offset - offset;
+        const uint32_t written = values && index < count ? values[index] : value;
+        static std::atomic<int> emitted{0};
+        if (emitted.fetch_add(1) >= 400000) return;
+        const char* cn = reg_class == RegClass::Cx ? "Cx"
+                       : reg_class == RegClass::Sh ? "Sh" : "Uc";
+        std::fprintf(stderr, "[regwatch] class=%s off=0x%x val=0x%08x path=%s span=0x%x+%u order=%llu\n",
+                     cn, entry.offset, written, path, offset, count,
+                     static_cast<unsigned long long>(command_order));
+    }
+}
+}  // namespace
+
 // Readability probe (gpu_executor.cpp, declared in gpu_execute.hpp): page-granular check that a
 // guest range is mapped, so the Jump fold below never walks an unmapped segment address.
 bool guest_readable(uint64_t addr, uint32_t bytes);
@@ -2005,6 +2072,11 @@ void GpuState::apply(const Pm4Command& c) {
                 }
                 // Hardware drops writes to nonexistent register offsets; mirror that instead of
                 // folding placeholder/stale array slots into the register file (see kRegOffsetLimit).
+                // PROSPER_REGWATCH: indirect-path half. Reported before the bounds drop for the same
+                // reason as the direct path — a watched register whose only writes are dropped here
+                // is a different finding from one that is never written.
+                reg_watch_report(c.reg_class, offset, regs[i].value, 1u, nullptr,
+                                 "indirect", command_order);
                 if (offset >= kRegOffsetLimit) {
                     if (bad++ == 0) first_bad = i;
                     static std::atomic<int> dropped_note{0};
@@ -2095,6 +2167,13 @@ void GpuState::apply(const Pm4Command& c) {
             break;
         }
         case K::SetRegDirect: {
+            // PROSPER_REGWATCH: direct-path half of the register-write watch (see below for the
+            // indirect half). Emitted before the bounds check so a dropped out-of-range write is
+            // still observable — "the write happened but landed nowhere" is a distinct diagnosis
+            // from "the write never happened".
+            reg_watch_report(c.reg_class, c.reg_offset,
+                             c.reg_data && c.reg_count ? c.reg_data[0] : c.reg_value,
+                             c.reg_data ? c.reg_count : 1u, c.reg_data, "direct", command_order);
             // SET_*_REG writes a consecutive range into the file named by its opcode. SH commonly
             // uploads a whole user-data SGPR block, while the direct APIs emit one Cx/Sh/Uc pair.
             auto& file = (c.reg_class == RegClass::Cx) ? cx

--- a/prosper/src/gpu/command_processor.hpp
+++ b/prosper/src/gpu/command_processor.hpp
@@ -232,6 +232,26 @@ extern "C" void prosper_gpu_set_fold_origin(uint8_t origin);
 // from the submit paths, under the submit mutex.
 void submit_completion_pulse(bool submit_rejected = false);
 
+// PROSPER_REGWATCH=[Cx:|Sh:|Uc:]OFF[,...]: log every write to nominated registers from BOTH the
+// direct (SET_*_REG) and indirect (Set*RegsIndirect) paths, with value and command order.
+//
+// Resolved state alone cannot answer "which packet wrote this register, and was it ever written at
+// all?" — a register the guest never programs and one it programs to a value that happens to look
+// like a default are indistinguishable after folding, yet they resolve to opposite behaviour for
+// several registers (an absent CB_TARGET_MASK means write-all; a present zero means write-nothing).
+// Keeping the parse pure makes the selector testable without a guest, a GPU, or an environment.
+struct RegWatchEntry {
+    RegClass reg_class = RegClass::Cx;
+    uint32_t offset = 0;
+    bool operator==(const RegWatchEntry& o) const {
+        return reg_class == o.reg_class && offset == o.offset;
+    }
+};
+
+// Parses the selector. Unparsable or out-of-range entries are skipped rather than aborting the list,
+// so one bad entry cannot silently disable a whole watch. An empty/absent setting yields no entries.
+std::vector<RegWatchEntry> parse_reg_watch(const char* setting);
+
 } // namespace prosper::gpu
 
 // Apply every pending pipe-drain completion write NOW, in submission order (#312 — see the

--- a/prosper/tests/test_command_processor.cpp
+++ b/prosper/tests/test_command_processor.cpp
@@ -494,6 +494,43 @@ int main() {
         }
     }
 
+    // PROSPER_REGWATCH selector (#1459). The parse is pure so the register-write watch can be
+    // validated without a guest, a GPU, or an environment variable.
+    {
+        using prosper::gpu::parse_reg_watch;
+        using prosper::gpu::RegClass;
+
+        CHECK(parse_reg_watch(nullptr).empty() && parse_reg_watch("").empty(),
+              "an absent or empty PROSPER_REGWATCH watches nothing");
+
+        const auto plain = parse_reg_watch("0x202");
+        CHECK(plain.size() == 1 && plain[0].offset == 0x202u &&
+                  plain[0].reg_class == RegClass::Cx,
+              "a bare offset defaults to the Cx context register file");
+
+        const auto list = parse_reg_watch(" 0x202 , 0x8e,0x8f ");
+        CHECK(list.size() == 3 && list[0].offset == 0x202u && list[1].offset == 0x8eu &&
+                  list[2].offset == 0x8fu,
+              "a comma list parses every entry and tolerates surrounding spaces");
+
+        const auto classed = parse_reg_watch("Sh:0x10,Uc:2,cx:0x202");
+        CHECK(classed.size() == 3 && classed[0].reg_class == RegClass::Sh &&
+                  classed[1].reg_class == RegClass::Uc && classed[1].offset == 2u &&
+                  classed[2].reg_class == RegClass::Cx,
+              "an explicit class prefix selects the register file and decimal offsets parse");
+
+        // One malformed entry must not silently disable the rest of the watch: a selector that
+        // quietly narrows itself would make "no writes observed" mean two different things.
+        const auto tolerant = parse_reg_watch("0x202,notahex,Zz:5,,0x8e");
+        CHECK(tolerant.size() == 2 && tolerant[0].offset == 0x202u &&
+                  tolerant[1].offset == 0x8eu,
+              "unparsable and unknown-class entries are skipped without dropping valid ones");
+
+        const auto deduped = parse_reg_watch("0x202,0x202,Cx:0x202");
+        CHECK(deduped.size() == 1,
+              "a repeated register is watched once so one write reports one line");
+    }
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -637,6 +637,29 @@ void inspect_frame(const prosper::gpu::GpuReplayFrame& replay, uint32_t format_v
                                 failure.pipeline.stencil_op_val[1]);
             }
             std::printf("\n");
+            // #1459: a suppressed draw is usually suppressed BECAUSE its resolved write mask is
+            // zero, so the raw registers behind that mask are exactly what this population needs to
+            // explain. Realized draws print the same line; without it here the no-effect draws --
+            // often the bulk of a frame's geometry -- stay unattributable offline.
+            if (failure.pipeline_present) {
+                if (format_version >= 43)
+                    std::printf("  color-state cb-control=%d:%08x mode=%u target-mask=%d:%08x "
+                                "shader-mask=%d:%08x effective=%02x\n",
+                                failure.pipeline.has_cb_color_control,
+                                failure.pipeline.cb_color_control,
+                                (failure.pipeline.cb_color_control >>
+                                 prosper::agc::Pm4::CB_COLOR_CONTROL_MODE_SHIFT) &
+                                    prosper::agc::Pm4::CB_COLOR_CONTROL_MODE_MASK,
+                                failure.pipeline.has_cb_target_mask,
+                                failure.pipeline.cb_target_mask,
+                                failure.pipeline.has_cb_shader_mask,
+                                failure.pipeline.cb_shader_mask,
+                                (failure.pipeline.cb_target_mask &
+                                 failure.pipeline.cb_shader_mask) & 0xFFu);
+                else
+                    std::printf("  color-state unavailable (capture v%u predates v43)\n",
+                                format_version);
+            }
         } else {
             const auto& launch = failure.compute_launch;
             std::printf("  threads=%ux%ux%u local=%ux%ux%u groups=%ux%ux%u\n",


### PR DESCRIPTION
## Purpose

Two generic diagnostic seams plus a route-pacing note. Supports #1459; no renderer behaviour changes.

The `--inspect` change is not incidental — **it produced the decisive evidence** for the Astro investigation the same hour it was written.

## What the print path revealed

Capture v43 (#1576) *retains* colour-state for failed and suppressed pipelines, but `--inspect` only *printed* it for **realized** draws. On Astro Bot's world map the 171 suppressed no-effect draws are the bulk of the geometry — exactly the population under investigation. A seam that captures data it cannot display is half a seam.

With the print path added, that population is unanimous:

| effective mask | draws | cause of suppression |
|---|---|---|
| `0x07` / `0x0f` / `0x37` / `0x3f` | **166** | `MODE=0` alone |
| `0x00` | 5 | genuine — `shader-mask=0x00` |

**166 of 171 suppressed draws carry a coherent non-zero colour write mask and are killed purely by the mode.** Together with the 30 realized mode-0 draws, roughly **196 geometry draws** in the frame have meaningful, per-pass-varying masks (`0x737`, `0x0f`, `0x07`, `0x37`, `0x3f`) and are suppressed entirely by `CB_COLOR_CONTROL.MODE`. Modes 2 and 6 appear on only 4 and 6 draws, and **`MODE=1 (CB_NORMAL)` occurs zero times in the entire frame.**

## `PROSPER_REGWATCH`

`PROSPER_REGWATCH=[Cx:|Sh:|Uc:]OFF[,...]` logs writes to selected context/shader/user-config registers.

Two deliberate design points:

- It logs from **both** the direct and the indirect register paths, so a value arriving via `SetRegsIndirect` is as visible as a direct write.
- It logs **before** the `kRegOffsetLimit` drop, so *"written but landed nowhere"* stays distinguishable from *"never written"*. Those two are the same silence otherwise, and this project has already lost time to a register that was present-and-zero being mistaken for absent.

The selector parse is pure and unit-tested.

## Verification

`test_command_processor` **74 ok, 0 fail**. Full ctest **160/162** — the two failures are the documented Astro-vs-Messenger dump-selection tests (#1573), which reproduce on a clean tree. `git diff --check` clean. Branched from `7a795e16`.

## Also included

`scripts/astrobot/README.md` records two traps that each cost a route attempt:

- The maintained `reach-first-level.pad` mixes wall-time pulses (60–96 s) with frame-anchored `f3800+` pulses. Under `boot_trace` the wall-time pulses all fire by 96 s while the frame anchor is unreachable, stalling at the title. The retained `worldmap-frame-route.pad` (f730–960) works. That pad is frontend-sensitive.
- `boot_trace` defaults to `dump=1` and wrote **3.2 GB** of 4K BMPs on one run; `PROSPER_NO_FRAME_DUMPS=1` disables it. Filed separately as #1584.

## Context on #1459

The fresh v43 capture **falsified** the stale-register-fold hypothesis: nothing is present-and-zero. `CB_TARGET_MASK=0x737`, `CB_SHADER_MASK=0xff`, effective `0x37` — a coherent G-buffer mask varying correctly per pass, with `CB_COLOR_CONTROL` toggling at pass boundaries, so prosper is tracking genuine guest writes.

The decode was then verified sound: `MODE` at bits [6:4] and `ROP3` at [23:16] match the GFX10 spec, and three observed values (`0x00cc0000`, `0x00cc0020`, `0x00cc0060`) differ *only* in the MODE nibble while all carrying the canonical `0xcc` in exactly the ROP3 field — which would not happen if a neighbouring register were being read.

That leaves the value→semantics mapping as the open question, and it remains **open**. This PR ships the instruments, not a conclusion.