### PR TITLE
tools(colorstate): reduce a COLORSTATETRACE log to a scanout/suppression verdict

### DIFF
--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -54,6 +54,13 @@ the shipped runtime. Build them from `build-linux/` like everything else.
 - **`gpu_timeline/`** — inspect a native-speed `.prgtl` submit/present index recorded with
   `PROSPER_GPU_TIMELINE=<path>`. It does not invoke Vulkan; use it to locate progression and producer
   windows before making an expensive realized `.prgcap`. Timeline files are gitignored and local-only.
+- **`colorstate/colorstate_report.py`** — reduce a `PROSPER_COLORSTATETRACE` log to a verdict on the
+  "why is it black?" question: do draws reach the **scanout** (vs offscreen only), and are their colour
+  writes enabled or suppressed by `CB_COLOR_CONTROL.MODE=DISABLE` / a zero target/shader mask? Prints a
+  per-guest-minute suppressed-percentage series. **Always compare a known-good phase against the bad one** —
+  on Plucky the suppressed fraction is *higher* while the world renders correctly (88-95%) than while the
+  screen is black (83%), because `CB_DISABLE` is the depth/shadow prepass. Reading one phase alone yields a
+  confident wrong answer. `--selftest` needs no capture. See `tools/colorstate/README.md`.
 - **`spv_validate/`** — `spirv-val` wrapper for recompiled SPIR-V.
 - **`niddiag/`, `fetch_niddb.sh`** — NID (Sony symbol hash) resolution helpers.
 - **`hostprof/hostprof.py`** — poor-man's **native sampling profiler**: attach to a running process

--- a/prosper/tools/colorstate/README.md
+++ b/prosper/tools/colorstate/README.md
@@ -1,0 +1,63 @@
+# colorstate_report — "do draws reach the scanout, and with what colour state?"
+
+When a title presents black, four explanations compete:
+
+1. **No graphics draws at all** — the render path never submits.
+2. **Draws exist but only target offscreen surfaces**, never composited to scanout.
+3. **Draws write scanout with colour suppressed** — `CB_COLOR_CONTROL.MODE=DISABLE`,
+   or a zero `CB_TARGET_MASK` / `CB_SHADER_MASK`.
+4. **Content is produced and the present path drops it.**
+
+`PROSPER_COLORSTATETRACE` emits the raw register evidence that separates 1–3, but on a
+4K title it is millions of lines. This tool reduces it to a verdict.
+
+## Recipe
+
+Get the scanout VA from the guest's own memory map — the emulator logs
+`Frame Buffer va range <lo> - <hi>` during boot. Everything outside it is offscreen.
+
+```bash
+# One routed run. WxH filters to scanout-sized colour targets and keeps the log bounded.
+PROSPER_COLORSTATETRACE=3840x2160 <your route> > run.log 2>&1
+
+python3 tools/colorstate/colorstate_report.py run.log --scanout-prefix 0x9fc
+```
+
+Output names the scanout surfaces actually written, breaks scanout draws down by
+`mode` / effective mask / resolved write mask, and gives a per-guest-minute
+suppressed-percentage series.
+
+`--selftest` runs the parser and reporter against a fixture; it needs no capture.
+
+## Read the per-minute series, not a single number
+
+**A suppressed-draw count means nothing on its own.** Compare a phase whose output is
+known good against the phase under investigation, using screenshots to label them.
+
+The Plucky Squire is the cautionary case. When its screen goes black, scanout draws
+flip to 83% `mode=0` — which looks exactly like explanation 3 and is the same shape
+that explains Astro Bot's black world map. It is not the cause. While the world is
+*visibly rendering*, the suppressed fraction is **higher still**:
+
+```
+16:08  total=  15072  suppressed=  7.3%   <- menu, renders correctly
+16:09  total=  40336  suppressed=  3.3%   <- menu, renders correctly
+16:10  total= 179621  suppressed= 83.2%   <- black
+16:13  total=   6692  suppressed= 87.6%   <- world VISIBLE
+16:14  total=   7799  suppressed= 95.3%   <- world VISIBLE
+```
+
+`CB_DISABLE` here is the engine's depth and shadow prepass, which scales with scene
+geometry. Reading only the black phase would have produced a confident wrong answer.
+
+## Caveats
+
+- Records are attributed to the **most recent guest log timestamp**, so a minute in
+  which the guest logs nothing absorbs neighbouring records. Treat bucket boundaries as
+  approximate and lean on buckets you can independently label from screenshots.
+- The trace runs *before* draw realization, so a record here is a draw the guest
+  programmed — not proof it was realized. Confirm realization with
+  `gpu_replay --inspect-only` on a capture.
+- An **absent** mask means write-all; a **present zero** means write-nothing. The tool
+  preserves that distinction, which is the reason the raw triple is retained at all.
+- The scanout VA is title- and run-specific. The tool refuses to guess a default.

--- a/prosper/tools/colorstate/colorstate_report.py
+++ b/prosper/tools/colorstate/colorstate_report.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Summarise a PROSPER_COLORSTATETRACE log: do draws reach the scanout, and with
+what colour state?
+
+`PROSPER_COLORSTATETRACE=1|all|WxH` makes the live backend emit one raw-to-resolved
+colour/depth record per matching draw (see `prosper/src/gpu/gpu_execute.hpp`). On a
+4K title that is millions of lines, which is unreadable by hand. This tool answers
+the questions those lines exist to answer:
+
+  1. Do graphics draws write the *scanout* surface at all, or only offscreen targets?
+  2. Are their colour writes enabled, or suppressed by CB_COLOR_CONTROL.MODE=DISABLE
+     or by a zero CB_TARGET_MASK / CB_SHADER_MASK?
+  3. How does that change over the run -- e.g. between a phase that renders correctly
+     and a phase that presents black?
+
+Question 3 is the important one. A suppressed-draw count is only interpretable
+against a phase where output is known good: on The Plucky Squire the suppressed
+fraction is *higher* while the world renders correctly (88-95%) than during a black
+phase, because CB_DISABLE is the engine's depth/shadow prepass scaling with scene
+geometry. Reading a single phase in isolation invites exactly that false positive.
+
+The scanout range is title- and run-specific. Take it from the guest's own memory
+map (`Frame Buffer va range <lo> - <hi>`) and pass `--scanout-prefix`; there is no
+safe default, so the tool refuses to guess.
+
+Usage:
+    colorstate_report.py LOG --scanout-prefix 0x9fc [--top N]
+    colorstate_report.py --selftest
+"""
+
+import argparse
+import re
+import sys
+from collections import Counter, defaultdict
+
+# [color-state] es=0x.. ps=0x.. cb-control=P:HHHH mode=M target-mask=P:H shader-mask=P:H
+RE_HEAD = re.compile(
+    r"^\[color-state\] es=(0x[0-9a-f]+) ps=(0x[0-9a-f]+) "
+    r"cb-control=(\d):([0-9a-f]+) mode=(\d+) "
+    r"target-mask=(\d):([0-9a-f]+) shader-mask=(\d):([0-9a-f]+)")
+# [color-state]   colorN=0xADDR WxH raw-format=.. resolved-format=.. resolved-cwm=H
+RE_COLOR = re.compile(
+    r"^\[color-state\]\s+color(\d)=(0x[0-9a-f]+) (\d+)x(\d+) "
+    r"raw-format=(\d+) resolved-format=(\d+) resolved-cwm=([0-9a-f]+)")
+# Unreal writes [YYYY.MM.DD-HH.MM.SS:mmm][frame] on every guest line; used only to
+# attribute records to a guest-clock minute.
+RE_TS = re.compile(r"^\[\d{4}\.\d\d\.\d\d-(\d\d)\.(\d\d)\.(\d\d)")
+
+MODE_NAMES = {0: "DISABLE", 1: "NORMAL", 2: "ELIM_FAST_CLEAR", 3: "RESOLVE",
+              6: "DCC_DECOMPRESS"}
+
+
+def parse(lines):
+    """Yield one dict per colour-state draw record."""
+    cur, ts = None, None
+    for line in lines:
+        m = RE_TS.match(line)
+        if m:
+            ts = f"{m.group(1)}:{m.group(2)}"
+            continue
+        m = RE_HEAD.match(line)
+        if m:
+            if cur:
+                yield cur
+            cur = {"ts": ts, "ps": m.group(2), "mode": int(m.group(5)),
+                   "tmask_present": int(m.group(6)), "tmask": int(m.group(7), 16),
+                   "smask_present": int(m.group(8)), "smask": int(m.group(9), 16),
+                   "targets": []}
+            continue
+        m = RE_COLOR.match(line)
+        if m and cur is not None:
+            cur["targets"].append({"slot": int(m.group(1)), "addr": m.group(2),
+                                   "w": int(m.group(3)), "h": int(m.group(4)),
+                                   "cwm": int(m.group(7), 16)})
+    if cur:
+        yield cur
+
+
+def effective_mask(rec):
+    """An ABSENT mask means write-all; a PRESENT zero means write-nothing. That
+    distinction is why the raw triple is retained rather than the resolved value."""
+    t = rec["tmask"] if rec["tmask_present"] else 0xFF
+    s = rec["smask"] if rec["smask_present"] else 0xFF
+    return t & s & 0xFF
+
+
+def report(records, scanout_prefix, top, out=sys.stdout):
+    def hits_scanout(rec):
+        return any(t["addr"].startswith(scanout_prefix) for t in rec["targets"])
+
+    total = scan = 0
+    combos = Counter()
+    per_minute = defaultdict(Counter)
+    addrs = Counter()
+
+    for rec in records:
+        total += 1
+        if not hits_scanout(rec):
+            continue
+        scan += 1
+        eff = effective_mask(rec)
+        cwms = {t["cwm"] for t in rec["targets"]
+                if t["addr"].startswith(scanout_prefix)}
+        writes_colour = rec["mode"] != 0 and eff != 0 and any(cwms)
+        combos[(rec["mode"], eff, tuple(sorted(cwms)))] += 1
+        per_minute[rec["ts"] or "??:??"][rec["mode"]] += 1
+        for t in rec["targets"]:
+            if t["addr"].startswith(scanout_prefix):
+                addrs[(t["addr"], t["w"], t["h"], writes_colour)] += 1
+
+    print(f"colour-state draw records: {total}", file=out)
+    print(f"  writing scanout ({scanout_prefix}...): {scan}", file=out)
+    print(f"  offscreen only:                       {total - scan}", file=out)
+    if not scan:
+        print("\nNO draw wrote the scanout. The render path never reaches the "
+              "presented surface.", file=out)
+        return
+    print("\nscanout surfaces:", file=out)
+    for (addr, w, h, vis), n in sorted(addrs.items()):
+        print(f"  {addr} {w}x{h} writes-colour={str(vis):5s} draws={n}", file=out)
+    print("\nscanout draws by mode / effective mask / resolved cwm:", file=out)
+    for (mode, eff, cwms), n in combos.most_common(top):
+        name = MODE_NAMES.get(mode, "UNKNOWN")
+        cwm = ",".join(f"{c:x}" for c in cwms)
+        note = ""
+        if mode == 0 or eff == 0 or not any(cwms):
+            note = "   [colour writes suppressed]"
+        elif mode not in (1, 3, 6):
+            note = "   [mode not implemented -- runs as an ordinary draw]"
+        print(f"  mode={mode} ({name:15s}) effective={eff:02x} cwm={cwm:<6s} "
+              f"draws={n}{note}", file=out)
+    print("\nscanout draws per guest-clock minute (compare a good phase against a "
+          "bad one):", file=out)
+    for minute in sorted(per_minute):
+        c = per_minute[minute]
+        tot = sum(c.values())
+        supp = c.get(0, 0)
+        modes = " ".join(f"mode{m}={n}" for m, n in sorted(c.items()))
+        print(f"  {minute}  total={tot:7d}  suppressed={100.0 * supp / tot:5.1f}%  "
+              f"{modes}", file=out)
+
+
+SELFTEST = """\
+[2026.07.31-16.09.04:786][992]LogSlate: Took 0.000306 second
+[color-state] es=0x1 ps=0x2 cb-control=1:00cc0010 mode=1 target-mask=1:0000000f shader-mask=1:0000000f
+[color-state]   color0=0x9fc2000000 3840x2160 raw-format=10 resolved-format=44 resolved-cwm=f
+[color-state]   depth=1:1x1 raw-size=00000000 test=0 write=0 z=0x0/0x0 s=0x0/0x0 htile=0x0 stencil=0
+[color-state] es=0x1 ps=0x3 cb-control=1:00cc0000 mode=0 target-mask=1:00000000 shader-mask=1:00000000
+[color-state]   color0=0x9fc2000000 3840x2160 raw-format=10 resolved-format=44 resolved-cwm=0
+[color-state] es=0x1 ps=0x4 cb-control=1:00cc0010 mode=1 target-mask=1:0000000f shader-mask=1:0000000f
+[color-state]   color0=0x3005120000 1920x1080 raw-format=10 resolved-format=44 resolved-cwm=f
+"""
+
+
+def selftest():
+    import io
+    recs = list(parse(SELFTEST.splitlines()))
+    assert len(recs) == 3, recs
+    assert recs[0]["mode"] == 1 and effective_mask(recs[0]) == 0x0F
+    assert recs[1]["mode"] == 0 and effective_mask(recs[1]) == 0x00
+    assert recs[2]["targets"][0]["addr"] == "0x3005120000"
+    assert recs[0]["ts"] == "16:09"
+    # An absent mask must mean write-all, not write-nothing.
+    assert effective_mask({"tmask_present": 0, "tmask": 0,
+                           "smask_present": 0, "smask": 0}) == 0xFF
+    buf = io.StringIO()
+    report(list(parse(SELFTEST.splitlines())), "0x9fc", 10, out=buf)
+    text = buf.getvalue()
+    assert "writing scanout (0x9fc...): 2" in text, text
+    assert "offscreen only:                       1" in text, text
+    assert "colour writes suppressed" in text, text
+    # The offscreen-only draw must not be counted as reaching the scanout.
+    assert "0x3005120000" not in text, text
+    print("selftest OK")
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("log", nargs="?", help="run log containing [color-state] lines")
+    ap.add_argument("--scanout-prefix",
+                    help="address prefix of the guest scanout, e.g. 0x9fc "
+                         "(from the guest's 'Frame Buffer va range' line)")
+    ap.add_argument("--top", type=int, default=20)
+    ap.add_argument("--selftest", action="store_true")
+    args = ap.parse_args()
+    if args.selftest:
+        selftest()
+        return 0
+    if not args.log or not args.scanout_prefix:
+        ap.error("LOG and --scanout-prefix are required "
+                 "(the scanout VA is title-specific; the tool will not guess)")
+    with open(args.log, "r", errors="replace") as fh:
+        report(parse(fh), args.scanout_prefix.lower(), args.top)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Purpose

Adds `tools/colorstate/colorstate_report.py`, which reduces a `PROSPER_COLORSTATETRACE` log to a per-phase scanout/suppression verdict. Tooling only — **no fix, no renderer change.** Advances #1390.

## Why it exists

Answering "do draws reach the scanout, and is colour suppressed?" previously meant eyeballing a multi-hundred-thousand-line trace. This reduces it to a verdict with a per-phase series, which is what made the result below provable rather than impressionistic.

## The result it produced — a falsification, including of its own author's hypothesis

**The inherited premise that The Plucky Squire "reaches gameplay logic but never presents" is FALSE.** The title presents real content throughout, every frame opened and inspected:

| phase | window |
|---|---|
| menu | SAVE FILES / SELECT SLOT in full colour, **1,502 distinct colours** |
| load fade | solid white, exactly **one** distinct colour |
| loading (~2.5 min) | black plus the game's **own loading-book glyph** — only 4,177 of 2,033,000 pixels non-zero, all of them that glyph |
| world | real geometry: desk surface with wood grain and stains, desk lip, scattered pencil-like objects |

The earlier "8 black frames + 1 white flash" samples were honest and the method sound — they simply landed inside the **loading** phase, whose black-with-indicator screen is the game's own correct output. And `0x3017460000` executing 486 times never implied the game was *in* gameplay: that program runs throughout loading too.

## The four-shape question resolves to **none of the four**

- **1 (no draws)** — ruled out: 253,962 scanout-targeted draw records in one run.
- **2 (offscreen only)** — ruled out: draws write `0x9fc0000000` / `0x9fc2000000` directly at 3840x2160.
- **3 (colour suppressed)** — ruled out **by a control that killed the leading hypothesis.** Suppression jumps to 83% when the screen goes black, which looks decisive — but while the world is *visibly rendering* it is **higher**: 87.6%, then 95.3%, then 100%. `CB_DISABLE` here is UE's depth/shadow prepass scaling with geometry. **Astro Bot's shape does not explain Plucky.**
- **4 (present/publish drops it)** — ruled out: both scanout buffers written symmetrically, and the presented frame demonstrably contains content.

Offline confirmation, CPU-only: extracted submit 7706 has 63 draws / 16 computes, **30 targeting scanout**, 58 at `mode=1 effective=0f`, one suppressed.

**So the defect is not presentation or composition at all.** What remains is a darkness/lighting question, and even that is not yet established — the single world frame may be mid-fade-in.

## The tool

`colorstate_report.py` parses a `PROSPER_COLORSTATETRACE` log and reports scanout targeting and suppression rates as a per-phase series. `--selftest` passes with no capture required, so it is verifiable without a game dump and by any agent.

## Verification

`--selftest` OK. `git diff --cached --check` clean. Branched from `04c3980a`. Documented in `tools/AGENTS.md` and its own README.

## Related issues filed

- **#1587** — the F9 frame grab **silently loses both the bundle and the `.bmp`** when a frame exceeds a 2 GiB cap the F9 path cannot raise. One Plucky 4K frame is **2.23 GiB**. This is why multiple agents concluded "F9 never fired": it fired and discarded the result with no diagnostic. F9 is documented in `CLAUDE.md` as the fastest loop for any graphical bug, so a silent total loss on large frames is a significant gap.
- **#1588** — `CB_COLOR_CONTROL.MODE=2` (ELIMINATE_FAST_CLEAR) is executed as an ordinary draw, 264 scanout occurrences in one run, and the warning dedupes per mode so the volume is invisible.

## Note on a retracted claim

An earlier "world geometry, 711 colours" observation from this lane was **retracted**: it was a fixed screen crop scoring the terminal after the game window moved. The confirmed world frame was verified by opening the image, not by a proxy metric, and the tool now flags that class of error.
