### PR TITLE
gpu(recompiler): implement VOP3 v_sad_u32 — Worms Armageddon reaches its title screen

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -7969,6 +7969,18 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 uint32_t p = b.ibin(Op_IMul, b.ibin(Op_BitwiseAnd, val(in.src[0]), m24),
                                               b.ibin(Op_BitwiseAnd, val(in.src[1]), m24));
                 vreg[in.dst.value] = b.ibin(Op_IAdd, p, val(in.src[2]));
+            } else if (in.opcode == 0x15D) {                          // v_sad_u32 = |s0-s1| (unsigned) + s2
+                // RDNA2 ISA (document 70648), V_SAD_U32: D.u32 = abs(S0.u32 - S1.u32) + S2.u32.
+                // The absolute difference is the UNSIGNED magnitude, so max-min is exact and cannot
+                // wrap (a signed abs would be wrong for operands straddling 0x80000000). Worms
+                // Armageddon's PSSL compiler emits the src1=0 accumulate form `v_sad_u32 vN, sM, 0,
+                // vN` as its vertex-shader index prologue; its shipped .ags shader assets carry the
+                // identical word. VERIFIED(llvm-mc gfx1030: VOP3 0x15d = v_sad_u32).
+                // CONFIDENCE: HIGH.
+                const uint32_t s0 = val(in.src[0]), s1 = val(in.src[1]);
+                const uint32_t diff = b.ibin(Op_ISub, b.uext2(Glsl_UMax, s0, s1),
+                                                       b.uext2(Glsl_UMin, s0, s1));
+                vreg[in.dst.value] = b.ibin(Op_IAdd, diff, val(in.src[2]));
             } else if (in.opcode == 0x148 || in.opcode == 0x149) {    // v_bfe_u32 / v_bfe_i32
                 uint32_t off = b.ibin(Op_BitwiseAnd, val(in.src[1]), b.uconst(31));
                 uint32_t cnt = b.ibin(Op_BitwiseAnd, val(in.src[2]), b.uconst(31));

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -4057,6 +4057,48 @@ int main() {
     CHECK(gotT11e.size()==N && badT11e==0,
           "T11e: v_bcnt_u32_b32 adds the exact 32-bit population count");
 
+    // Worms Armageddon (PPSA20052) rejects every one of its vertex shaders at pc=7 on VOP3 0x15d
+    // (v_sad_u32). Its shipped .ags shader assets carry the identical word, so the encoding is
+    // independently attested. D.u32 = abs(S0.u32 - S1.u32) + S2.u32 — an UNSIGNED magnitude, which
+    // is why the lowering must be max-min and not a signed absolute value.
+    //   v96 = 0x40000000 (the inline 2.0f constant), v95 unwritten = 0.
+    const uint32_t codeTsad1[] = {
+        0x7ec20300u,               // v_mov_b32 v97, v0
+        0x7ec002f4u,               // v_mov_b32 v96, 2.0   (bit pattern 0x40000000)
+        0xd55d0062u, 0x057ec161u,  // v_sad_u32 v98, v97, v96, v95
+        0xbf810000u,
+    };
+    std::vector<uint32_t> spvTsad1 = recompile_valu(
+        codeTsad1, sizeof(codeTsad1)/sizeof(codeTsad1[0]), 1, /*out_vgpr*/98);
+    CHECK(!spvTsad1.empty(), "recompiled Tsad1 (Worms v_sad_u32 word) -> SPIR-V");
+    std::vector<float> gotTsad1 = prosper::test::run_compute(spvTsad1, inX, N, N);
+    uint32_t badTsad1 = 0;
+    for (uint32_t i=0;i<N&&gotTsad1.size()==N;i++) {
+        const uint32_t x = bits_of(inX[i]), c = 0x40000000u;
+        const uint32_t want = (x > c ? x - c : c - x);
+        if (bits_of(gotTsad1[i]) != want) ++badTsad1;
+    }
+    CHECK(gotTsad1.size()==N && badTsad1==0,
+          "Tsad1: v_sad_u32 is the unsigned absolute difference plus the accumulator");
+
+    // The exact form Worms emits: src1 is the inline 0 and src2 is the destination, i.e. an
+    // unsigned accumulate. Seed v98 with 5 so a dropped S2 addend cannot pass.
+    const uint32_t codeTsad2[] = {
+        0x7ec20300u,               // v_mov_b32 v97, v0
+        0x7ec40285u,               // v_mov_b32 v98, 5
+        0xd55d0062u, 0x05890161u,  // v_sad_u32 v98, v97, 0, v98
+        0xbf810000u,
+    };
+    std::vector<uint32_t> spvTsad2 = recompile_valu(
+        codeTsad2, sizeof(codeTsad2)/sizeof(codeTsad2[0]), 1, /*out_vgpr*/98);
+    CHECK(!spvTsad2.empty(), "recompiled Tsad2 (Worms v_sad_u32 accumulate form) -> SPIR-V");
+    std::vector<float> gotTsad2 = prosper::test::run_compute(spvTsad2, inX, N, N);
+    uint32_t badTsad2 = 0;
+    for (uint32_t i=0;i<N&&gotTsad2.size()==N;i++)
+        if (bits_of(gotTsad2[i]) != bits_of(inX[i]) + 5u) ++badTsad2;
+    CHECK(gotTsad2.size()==N && badTsad2==0,
+          "Tsad2: v_sad_u32 with src1=0 adds S0 to the S2 accumulator");
+
     // Astro's next blocker is VOP3B v_mad_u64_u32. Exercise all three architectural
     // outputs with an overflowing case:
     //   0xffffffff*2 + 0xffffffffffffffff = carry:1, hi:1, lo:0xfffffffd.


### PR DESCRIPTION
## Purpose

Implements VOP3 `v_sad_u32` (opcode `0x15D`) in the RDNA2→SPIR-V recompiler.

This is a small generic recompiler gap, and it took **Worms Armageddon: Anniversary Edition (`PPSA20052`) from rung 0 to rung 2 — a rendered title screen at native 1920×1080 on its first boot ever.** Advances #1592.

## Failure scenario

Worms Armageddon's PSSL compiler emits the src1=0 accumulate form `v_sad_u32 vN, sM, 0, vN` as its **vertex-shader index prologue**. Without lowering for `0x15D`, that stage is rejected, and with the vertex prologue gone the title renders nothing at all.

## Behavioral contract

Per the RDNA 2 ISA reference (document 70648), `V_SAD_U32` is:

```
D.u32 = abs(S0.u32 - S1.u32) + S2.u32
```

The absolute difference is the **unsigned magnitude**. The implementation is therefore
`UMax(s0,s1) - UMin(s0,s1)`, which is exact and cannot wrap.

This detail matters: a naive signed `abs(s0 - s1)` would be **wrong for operands straddling `0x80000000`**, which is exactly the range a vertex index prologue can reach. The `UMax`/`UMin` form has no such edge case.

Encoding verified independently: `llvm-mc gfx1030` confirms VOP3 `0x15d` = `v_sad_u32`. The title's own shipped `.ags` shader assets carry the identical instruction word, which is a second, guest-side confirmation.

`CONFIDENCE: HIGH`.

## Tests

New coverage in `test_rdna2_to_spirv.cpp` (+42 lines), including the src1=0 accumulate form the title actually emits.

## Verification

Built and tested inside the `ps5ys` distrobox (a host-only configure silently omits the Vulkan execution tests). `git diff --check` clean. Branched from `586b9acf`.

**Live result:** Worms Armageddon renders its Digital Eclipse studio splash and its full title screen — the Worms Armageddon Anniversary Edition key art with `PRESS ✕ TO START GAME` — at native 1920×1080, verified by opening the captured image rather than trusting a metric.

## Scope

+12 lines of lowering, +42 lines of test, no deletions. Affects only shaders that use `v_sad_u32`, which previously rejected outright; every other stage takes an unchanged path.

## Known limitation (tracked on #1592, not fixed here)

Worms is blocked at **rung 3** for an unrelated reason: the guest calls `scePadInit` and then **never calls `scePadOpen`**, so no scripted input can reach it and the title sits on `PRESS ✕ TO START GAME` indefinitely. That is an HLE/input question, entirely separate from this recompiler fix.
