### PR TITLE
docs(snapshot): record three ordering traps and measure why the content contract is conjoined

### DIFF
--- a/prosper/tools/snapshot/AGENTS.md
+++ b/prosper/tools/snapshot/AGENTS.md
@@ -37,7 +37,8 @@ Baseline evidence requires visual review even though routine regression runs do
 not. This prevents checksums or thresholds from blessing black output or the
 wrong scene.
 
-1. Set `review` to `pending` and run `snapshot.py verify NAME`.
+1. Write the whole candidate entry, **including `_note`**, and set `review` to
+   `pending`. Then run `snapshot.py verify NAME`.
 2. Inspect every image retained from both independent runs in
    `tools/snapshot/review/NAME/`. Confirm the intended gameplay state, expected
    layers, and progression across multiple timestamps.
@@ -50,9 +51,37 @@ wrong scene.
    conservative non-black coverage floor; exact mode records the identical
    pixel hash. Never use exact hashes for threaded gameplay merely because one
    run happened to be stable.
-5. Run `snapshot.py check NAME` after approval.
+5. Replace the generic `review` string that `update` wrote with the factual note
+   describing what was actually inspected.
+6. Run `snapshot.py check NAME` after approval.
 
 See `README.md` for every manifest field and the current title matrix.
+
+### Three ordering traps that silently produce a bad baseline
+
+Each of these leaves a guard that *looks* adopted. None of them fails loudly, so
+follow the order above rather than the obvious one.
+
+- **The factual `review` note must be written after `update --reviewed`, not
+  before.** `approve_content_candidate` unconditionally overwrites `review` with
+  a generic "Approved N composited images ... visually confirmed" string. A note
+  written before approval is destroyed by the approval itself, and the guard then
+  carries boilerplate that records no evidence while still satisfying `check`'s
+  "not pending" test.
+- **`_note` must be set before `verify`, because it is part of the candidate
+  fingerprint.** `entry_fingerprint` excludes only `hash`, `dims`, `review`,
+  `structural_references`, `perceptual_references`, and `min_nonblack_ratio`;
+  every other key, `_note` included, is hashed. Adding or editing `_note` after
+  `verify` makes `update` refuse with "snapshot configuration changed after
+  verify", costing a full two-capture rerun.
+- **`min_content_match_ratio` applies to every frame in the window, not to the
+  qualifying ones.** The requirement is
+  `max(min_structural_matches, ceil(total_window_frames * ratio))`, so at the
+  0.75 default, three quarters of *all* window frames must clear both SSIM and
+  non-black coverage. A window that merely contains good gameplay but also
+  straddles a load, a fade, or a transition will fail on a perfectly healthy run.
+  Place the window entirely inside the settled state and confirm the margin with
+  `profile_route.py` instead of assuming it.
 
 ## Environment
 

--- a/prosper/tools/snapshot/AGENTS.md
+++ b/prosper/tools/snapshot/AGENTS.md
@@ -31,6 +31,35 @@ python3 tools/snapshot/snapshot.py check blasphemous2-gameplay
 - Do not lower a threshold merely to pass. Explain intentional contract changes
   and repeat the baseline-review workflow below.
 
+### Why the content contract is conjoined, measured on a real title
+
+"Colour count must never be the contract on its own" is not a precaution; it is
+a measured result. Profiling the Rugrats route (`PPSA23396`) once per second
+across a whole boot produced both halves of the argument from one run, and they
+fail in **opposite** directions — which is exactly why neither metric can stand
+alone, and why `min_colors`, `min_nonblack_ratio`, SSIM, `dims` and
+`min_pixel_changes` are conjoined:
+
+- **Colour count alone prefers a menu to the game.** The two richest frames of
+  the entire run are the GAME MODE selector at 56,071-56,090 distinct colours.
+  The best actual gameplay frame reaches 17,645. A colour-only guard would rank
+  a menu **3.2x above every frame of the scene it exists to protect**, so it
+  would pass a build whose gameplay had collapsed as long as the menu still drew.
+- **Coverage alone accepts a nearly colourless screen.** The "BABIES IN
+  GAMELAND" level-title card and its fade are **fully opaque — a 1.0 non-black
+  ratio — at only 1,551-3,448 colours**. 54 frames of the run reach 0.999
+  coverage with as few as 1,551 colours, so a coverage-only guard treats a
+  title card as a rendered level.
+
+The practical rule: let SSIM decide *scene identity*, and keep `min_colors` as a
+gross-collapse floor rather than tuning it to separate two valid scenes. For
+Rugrats the tempting floor is ~16,000 — just under the 17,259 gameplay minimum
+and just over the 15,030 menu ceiling — but that discrimination is redundant
+with SSIM while making the guard fragile against a slightly dimmer healthy
+frame. 12,000 was chosen instead: comfortably below the observed gameplay range
+and far above every observed failure state (black at 1 colour, logos at most
+3,830, title card at most 3,448).
+
 ## New Or Changed Baselines
 
 Baseline evidence requires visual review even though routine regression runs do


### PR DESCRIPTION
## Purpose

Documents three **silent-wrong-result traps** in the snapshot baseline-adoption workflow, and rewrites the numbered steps into the safe order so the traps are actionable rather than merely noted.

Documentation only — `tools/snapshot/AGENTS.md`.

## The traps

Each was verified against the code, not recalled:

1. **`approve_content_candidate` (`snapshot.py:633`) assigns `entry["review"]` unconditionally.** A factual review note written *before* approval is silently destroyed and replaced with a generic "Approved N composited images…" string. The note must be written **after** `update --reviewed`.

2. **`_note` is inside `entry_fingerprint` (`snapshot.py:539`).** The fingerprint excludes exactly `hash`, `dims`, `review`, `structural_references`, `perceptual_references` and `min_nonblack_ratio` — so `_note` *is* hashed. Setting it after `verify` raises "snapshot configuration changed after verify" and costs a **two-capture rerun**. It must be set **before** `verify`.

3. **`min_content_match_ratio` is computed over *all* window records, not the qualifying subset** (`snapshot.py:470`): `required_matches = max(min_structural_matches, ceil(len(summary["records"]) * match_ratio))`. The same applies to the non-black requirement. So at 0.75 the window must be **almost entirely settled gameplay** — it is not enough that it merely contains some.

## Why this is worth a PR on its own

All three fail *quietly in the direction of a bad baseline*. Follow the natural ordering and you get a baseline that looks adopted but carries a generic review note, a stale fingerprint, or a window that will fail on perfectly healthy future runs.

That last one is the same failure mode already observed in production: today's full matrix had `blue-prince-hall` and `terminator-boot` both FAIL while retaining fully-rendered healthy frames, purely because their windows had drifted relative to the reviewed states. **A guard that cries wolf is worse than no guard**, and trap 3 is a direct route to building one.

The `alexkidd-gameplay` baseline landed earlier today got this ordering right, but partly by luck — that should not be load-bearing for the next agent.

## Verification

`git diff --check` clean. `python3 -m unittest` over `tools/snapshot/test_snapshot.py` **9/9 OK**. `ctest` **162/162** green (configured with `-DGAME_DUMP=PPSA24651-app0`; a non-Messenger `GAME_DUMP` trips the known #1573 `module_loads_eboot` artifact, which is a configure artifact rather than a regression).

Claim 3 independently re-verified by the integrator against `origin/master`.

## Scope

Documentation only; no code, tests or tooling behaviour changes. The snapshot guards this branch was opened for are **not** in this PR — no route has been validated yet and no `.pad` files are committed. They will follow separately, and only for routes that actually produce their claimed state.
---

## Update: the conjoined-contract rule is now *measured*, not asserted

A second commit (`95005d65`) adds a section, **"Why the content contract is conjoined, measured on a real title"**, derived from profiling the Rugrats route (`PPSA23396`) once per second across a whole 175-second boot.

Both halves of the argument came out of one run, and they **fail in opposite directions** — which is precisely why neither metric can stand alone:

- **Colour count alone prefers a menu to the game.** The two richest frames of the entire run are the GAME MODE selector at **56,071–56,090** distinct colours. The best actual gameplay frame reaches **17,645**. A colour-only guard would rank a menu **3.2× above every frame of the scene it exists to protect.**
- **Coverage alone accepts a nearly colourless screen.** 54 frames reach ≥0.999 non-black coverage with as few as **1,551** colours — the "BABIES IN GAMELAND" level-title card is fully opaque and almost colourless.

Both images were opened and visually confirmed rather than judged from metrics.

It also records a threshold decision worth preserving: the *tempting* `min_colors` value is ~16,000 — just below the 17,259 observed gameplay floor and just above the 15,030 menu ceiling — and it would genuinely discriminate on colour alone. It was **rejected as redundant-with-SSIM but fragile**: a slightly dimmer gameplay frame at 15,900 would fail a healthy run, and this project has already had two baselines FAIL today on fully-rendered healthy frames. Scene identity is left to SSIM, which is the check designed for it.

This turns a rule of thumb that the docs have asserted for months into a demonstrated fact with numbers behind it.
