### PR TITLE
fix(hle): make libSceUlt fail-visible — 1,005,742 silent calls became one log line

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -284,6 +284,12 @@ if(TARGET prosper_core)
   target_link_libraries(test_fiber PRIVATE prosper_core)
   add_test(NAME fiber_hle COMMAND test_fiber)
 
+  # #1603: libSceUlt has no implementation, so it must fail VISIBLY rather than return 0 = SCE_OK.
+  # Pure, no game dump.
+  add_executable(test_ult_fail_visible tests/test_ult_fail_visible.cpp)
+  target_link_libraries(test_ult_fail_visible PRIVATE prosper_core)
+  add_test(NAME ult_fail_visible COMMAND test_ult_fail_visible)
+
   add_executable(test_posix_sem tests/test_posix_sem.cpp)
   target_link_libraries(test_posix_sem PRIVATE prosper_core)
   add_test(NAME posix_sem_hle COMMAND test_posix_sem)

--- a/prosper/src/hle/dispatch.cpp
+++ b/prosper/src/hle/dispatch.cpp
@@ -182,6 +182,10 @@ void dump_call_log(FILE* f) {
                 nid.c_str(), nm.empty() ? "" : "  [", nm.c_str(), nm.empty() ? "" : "]");
     }
     fprintf(f, "  (%zu distinct unimplemented functions)\n", g_order.size());
+    // libSceUlt is registered (hle_ult.cpp) precisely so its calls do NOT land in the deduped table
+    // above, which reported one line for 1,005,742 sceUltMutexLock calls. Its own per-call table
+    // follows, and prints nothing when the title never touched Ult.
+    ult_dump_call_log(f);
 }
 
 } // namespace prosper

--- a/prosper/src/hle/dispatch.hpp
+++ b/prosper/src/hle/dispatch.hpp
@@ -103,6 +103,20 @@ void register_http_hle();
 void register_font_hle();
 // libSceFiber cooperative guest-stack switching; called by register_builtin_hle().
 void register_fiber_hle();
+// libSceUlt (user-level threading) — deliberately NOT implemented. Registers fail-VISIBLE counted
+// stubs for the entry points titles actually import, so the missing semantics stop being silent
+// (#1603); see hle_ult.cpp. Called by register_builtin_hle().
+void register_ult_hle();
+// Calls made to the unimplemented libSceUlt surface, by NID (0 for an unregistered/uncalled NID).
+// Counted PER CALL, unlike the first-seen dedup in prosper_on_unimpl. Diagnostics + tests.
+uint64_t ult_call_count(const char* nid);
+// Append the libSceUlt call table to `f` (nothing if the title never touched Ult). Called from
+// dump_call_log so the existing PROSPER_PROGRESS_UNIMPL periodic dump reports real Ult volume.
+void ult_dump_call_log(FILE* f);
+// Test seams for the return policy (PROSPER_ULT_RETURN_SUCCESS) and the counters. Returns the
+// previous policy. Production code must not call these.
+bool ult_set_return_success_for_test(bool return_success);
+void ult_reset_counts_for_test();
 // libScePad game-controller input (real host controller via input/pad.cpp); called by register_builtin_hle().
 void register_pad_hle();
 // Headless graphics bring-up (libSceAgc/libSceVideoOut placeholders); see hle_graphics.cpp.

--- a/prosper/src/hle/hle_libc.cpp
+++ b/prosper/src/hle/hle_libc.cpp
@@ -790,6 +790,7 @@ void register_builtin_hle() {
     register_http_hle();     // libSceHttp local URI parsing
     register_font_hle();     // libSceFont opaque handles + deterministic text/metric fallback
     register_fiber_hle();    // libSceFiber cooperative guest-stack execution
+    register_ult_hle();      // libSceUlt: NOT implemented — fail-visible counted stubs (#1603)
     register_pad_hle();      // libScePad: real game-controller input (input/pad.cpp)
     register_audio_hle();    // libSceAudioOut backed by a headless/pluggable AudioSink
     register_graphics_hle(); // headless libSceAgc/libSceVideoOut placeholders (bring-up)

--- a/prosper/src/hle/hle_ult.cpp
+++ b/prosper/src/hle/hle_ult.cpp
@@ -118,6 +118,9 @@ uint64_t ult_report(size_t index) {
     const bool success = g_return_success.load(std::memory_order_relaxed);
     const uint64_t ret = success ? 0ull : kUltNotImplemented;
     // Log at 1, 10, 100, 1e3, ... — bounded (a 1e6-call spin costs 7 lines) but never silent.
+    // The threshold is a plain load/store rather than a CAS: guest threads racing here can at worst
+    // emit the SAME milestone line twice, never suppress one. A duplicate diagnostic line is
+    // harmless; a lock taken to avoid it would sit on a path the guest hits a million times.
     uint64_t due = g_next_report[index].load(std::memory_order_relaxed);
     if (n >= due) {
         uint64_t next = due ? due * 10 : 10;

--- a/prosper/src/hle/hle_ult.cpp
+++ b/prosper/src/hle/hle_ult.cpp
@@ -1,0 +1,207 @@
+// hle_ult.cpp — fail-VISIBLE libSceUlt surface (#1603). This file deliberately implements NO
+// user-level threading semantics; it exists so that the absence of them stops being silent.
+//
+// libSceUlt is Sony's user-level threading library: cooperative "ulthreads" plus the mutexes,
+// condition variables, queues, semaphores and reader/writer locks that schedule on top of them.
+// prosper implements none of it. Before this file existed, every call fell through to the generic
+// unresolved-import path (dispatch.cpp `prosper_on_unimpl`), which logs the NID **once** and
+// returns **0** — and for this ABI family 0 is SCE_OK, i.e. success. The guest was therefore told:
+//
+//   * `_sceUltUlthreadCreate`  -> "your thread was created"   ... it never runs;
+//   * `sceUltMutexLock/Unlock` -> "the lock is held/released" ... there is no mutual exclusion;
+//   * the `*GetWorkAreaSize` queries -> "success" with the size out-param left UNWRITTEN, i.e.
+//     whatever stack garbage the caller had there (the #544/#660 class that made Dead Cells
+//     allocate multiple gigabytes).
+//
+// Nothing crashed. The guest proceeded on false premises and the damage surfaced far from its
+// cause. That is strictly worse than an unimplemented call that fails loudly, which is what this
+// file makes it: every entry point is counted per call and reported, and by default returns a real
+// error instead of a fake success.
+//
+// Measured on Earthion (PPSA28061 — the ONLY dump in the library that imports libSceUlt, 16
+// functions per `self_dump --symbols`): a 118 s CPU-only boot called `sceUltMutexLock` and
+// `sceUltMutexUnlock` 1,005,742 times **each**, and the deduped unimplemented-import log printed
+// exactly one line for each. Four ulthreads were reported created and none of them ever ran.
+//
+// SCOPE: Phase 1 of #1603 only — visibility. Implementing ulthreads, the mutex/condvar semantics
+// and the scheduler is Phase 2 and must be derived from live title evidence and the guest's own
+// disassembly, not assumed. Do not grow this file into a fake implementation.
+#include "dispatch.hpp"
+
+#include <atomic>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <utility>
+
+namespace prosper {
+namespace {
+
+// The registered surface. Driven by what titles ACTUALLY import, not by the library's full export
+// list: the PS5 3.20 firmware database exports 64 `sceUlt*` symbols, and a byte-scan of every dump
+// plus prosper's own `self_dump --symbols` agree that exactly these 16 are imported, by exactly one
+// title (Earthion / PPSA28061). Any other Ult NID a future title imports still falls through to the
+// generic unimplemented-import path, which logs it — add it here when that happens.
+// CONFIDENCE: HIGH (two independent instruments agree on the NID<->name mapping and the import set).
+struct UltEntry { const char* nid; const char* name; };
+constexpr UltEntry kUlt[] = {
+    { "jw9FkZBXo-g", "_sceUltUlthreadRuntimeCreate" },
+    { "grs2pbc2awM", "sceUltUlthreadRuntimeGetWorkAreaSize" },
+    { "znI3q8S7KQ4", "_sceUltUlthreadCreate" },
+    { "gCeAI57LGgI", "sceUltUlthreadJoin" },
+    { "mmt8Sa6tL6c", "_sceUltMutexCreate" },
+    { "8hEGkR1pfr8", "sceUltMutexLock" },
+    { "h0XebKiMBtk", "sceUltMutexUnlock" },
+    { "jW+HnafeS3Y", "sceUltMutexDestroy" },
+    { "jnKaHGkrxZ4", "_sceUltConditionVariableCreate" },
+    { "5xGAHCxA8M0", "sceUltConditionVariableWait" },
+    { "JTw1cAVkuc0", "sceUltConditionVariableSignal" },
+    { "xrmmI832R4U", "sceUltConditionVariableDestroy" },
+    { "YiHujOG9vXY", "_sceUltWaitingQueueResourcePoolCreate" },
+    { "WIWV1Qd7PFU", "sceUltWaitingQueueResourcePoolGetWorkAreaSize" },
+    { "hZIg1EWGsHM", "sceUltInitialize" },
+    { "d-kSG2fLrvI", "sceUltFinalize" },
+};
+constexpr size_t kUltCount = sizeof(kUlt) / sizeof(kUlt[0]);
+
+// Return value for every entry point.
+//
+// prosper has NO primary evidence for libSceUlt's own `SCE_ULT_ERROR_*` numbering — no live capture
+// of a real console's return, no published constant, and the firmware symbol database gives names
+// and NIDs only, never values. Fabricating a libSceUlt-shaped constant would look authoritative
+// while being a guess, so this deliberately does not do that. Instead it returns the libkernel
+// errno-family code that states exactly the truth — "function not implemented" — using the
+// documented `0x80020000 | freebsd_errno` convention already used across hle_file.cpp. ENOSYS is
+// 78 (0x4E) on the FreeBSD-derived PS5 kernel (it is 38 on Linux; do not copy that value here).
+//
+// CONFIDENCE: HIGH that 0 is wrong — every Sony API in this family treats 0 as SCE_OK, so a guest
+//             that checks `ret != SCE_OK` MUST see a failure here.
+// CONFIDENCE: LOW  that 0x8002004E is the specific value the real libSceUlt would return. A guest
+//             that compares against a particular SCE_ULT_ERROR_* constant will not recognise it and
+//             should fall into its generic error path. That is still the correct outcome: the call
+//             genuinely failed.
+constexpr uint64_t kUltNotImplemented = 0x8002004Eull;   // SCE_KERNEL_ERROR_ENOSYS
+
+std::atomic<uint64_t> g_calls[kUltCount];
+std::atomic<uint64_t> g_next_report[kUltCount];   // 0 = "report the next call" (i.e. the first)
+std::atomic<bool>     g_banner_printed{false};
+
+// PROSPER_ULT_RETURN_SUCCESS=1 restores the pre-#1603 `return 0` for A/B measurement of what the
+// fake success was buying a title. It is OFF by default and it does NOT silence anything: the
+// counting and the log lines below are emitted either way, so no configuration of prosper is ever
+// silently wrong about Ult again.
+std::atomic<bool> g_return_success{false};
+bool env_return_success() {
+    const char* e = getenv("PROSPER_ULT_RETURN_SUCCESS");
+    return e && *e && std::strcmp(e, "0") != 0;
+}
+
+void print_banner() {
+    if (g_banner_printed.exchange(true)) return;
+    fprintf(stderr,
+        "[prosper] ==== libSceUlt IS NOT IMPLEMENTED (#1603) ====================================\n"
+        "[prosper]   libSceUlt is Sony's USER-LEVEL THREADING library (ulthreads, mutexes,\n"
+        "[prosper]   condition variables, queues). prosper implements NONE of its semantics.\n"
+        "[prosper]   Every ulthread this title creates NEVER RUNS, and any guest state it guards\n"
+        "[prosper]   with an Ult mutex or condvar is COMPLETELY UNSYNCHRONISED.\n"
+        "[prosper]   Calls below are reported per function at call 1 and then at each power of ten,\n"
+        "[prosper]   so a polling loop cannot hide behind a single deduped line.\n"
+        "[prosper] ==============================================================================\n");
+}
+
+// Report the call and hand back the policy's return value. Counting is per call (an atomic
+// increment), NOT per first-seen NID: the whole point of this file is that the generic path's
+// first-seen dedup reported one line for a million calls.
+uint64_t ult_report(size_t index) {
+    const uint64_t n = g_calls[index].fetch_add(1, std::memory_order_relaxed) + 1;
+    const bool success = g_return_success.load(std::memory_order_relaxed);
+    const uint64_t ret = success ? 0ull : kUltNotImplemented;
+    // Log at 1, 10, 100, 1e3, ... — bounded (a 1e6-call spin costs 7 lines) but never silent.
+    uint64_t due = g_next_report[index].load(std::memory_order_relaxed);
+    if (n >= due) {
+        uint64_t next = due ? due * 10 : 10;
+        while (next <= n && next <= (uint64_t)1e18) next *= 10;
+        g_next_report[index].store(next, std::memory_order_relaxed);
+        print_banner();
+        // The magnitude has to be readable at a glance. A skimmed log must show "this is being
+        // hammered a million times", not a bare count the reader has to notice and compare: on
+        // Earthion the deduped generic path reported ONE line for 1,005,742 sceUltMutexLock calls.
+        const char* scale = n >= 1000000 ? "  *** >=1,000,000 CALLS — the guest is SPINNING on an "
+                                           "unimplemented user-level lock ***"
+                          : n >= 1000    ? "  *** >=1,000 CALLS — hot path, not a one-off ***"
+                                         : "";
+        fprintf(stderr, "[prosper] libSceUlt UNIMPLEMENTED: %s (%s) call #%llu -> returning 0x%llx%s%s\n",
+                kUlt[index].name, kUlt[index].nid, (unsigned long long)n,
+                (unsigned long long)ret,
+                success ? "  [PROSPER_ULT_RETURN_SUCCESS: FAKE SUCCESS, guest is being lied to]"
+                        : " (SCE_KERNEL_ERROR_ENOSYS)",
+                scale);
+    }
+    return ret;
+}
+
+// One distinct host function per NID so the handler knows which entry point was called.
+//
+// The guest arguments are read by NOTHING here, and — the deliberate part — no guest out-param is
+// ever written. That decision is load-bearing for the two size queries in the table,
+// `sceUltUlthreadRuntimeGetWorkAreaSize` and `sceUltWaitingQueueResourcePoolGetWorkAreaSize`, which
+// exist to fill a `size_t*` the guest then allocates from. prosper has no evidence of what those
+// sizes should be, and writing a plausible-looking number would be exactly the #544/#660 defect in
+// a new costume: an AGC "success" stub that left its required-memory output unwritten made Dead
+// Cells allocate multiple gigabytes. Returning a real error and touching nothing is the honest
+// pairing — a guest that checks the return sees failure and must not read the buffer; a guest that
+// ignores the failure and consumes uninitialised memory is now displaying ITS OWN bug, on a call
+// that also just logged loudly, instead of silently inheriting a fabricated value from us.
+// CONFIDENCE: HIGH (writing an invented size is strictly worse than writing nothing).
+template <size_t Index>
+PROSPER_SYSV_ABI uint64_t ult_stub(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t) {
+    return ult_report(Index);
+}
+
+template <size_t... Index>
+void register_all(std::index_sequence<Index...>) {
+    (Hle::register_fn(kUlt[Index].nid, (HleFn)ult_stub<Index>, kUlt[Index].name), ...);
+}
+
+}  // namespace
+
+void register_ult_hle() {
+    g_return_success.store(env_return_success(), std::memory_order_relaxed);
+    register_all(std::make_index_sequence<kUltCount>{});
+}
+
+uint64_t ult_call_count(const char* nid) {
+    if (!nid) return 0;
+    for (size_t i = 0; i < kUltCount; ++i)
+        if (std::strcmp(nid, kUlt[i].nid) == 0) return g_calls[i].load(std::memory_order_relaxed);
+    return 0;
+}
+
+bool ult_set_return_success_for_test(bool return_success) {
+    return g_return_success.exchange(return_success, std::memory_order_relaxed);
+}
+
+void ult_reset_counts_for_test() {
+    for (size_t i = 0; i < kUltCount; ++i) {
+        g_calls[i].store(0, std::memory_order_relaxed);
+        g_next_report[i].store(0, std::memory_order_relaxed);
+    }
+    g_banner_printed.store(false, std::memory_order_relaxed);
+}
+
+void ult_dump_call_log(FILE* f) {
+    uint64_t total = 0;
+    for (size_t i = 0; i < kUltCount; ++i) total += g_calls[i].load(std::memory_order_relaxed);
+    if (!total) return;
+    fprintf(f, "\n=== libSceUlt calls (UNIMPLEMENTED — user-level threading, #1603) ===\n");
+    for (size_t i = 0; i < kUltCount; ++i) {
+        const uint64_t n = g_calls[i].load(std::memory_order_relaxed);
+        if (!n) continue;
+        fprintf(f, "  %10llu x  %-24s %s\n", (unsigned long long)n, kUlt[i].nid, kUlt[i].name);
+    }
+    fprintf(f, "  (%llu total calls; ulthreads created by this title never ran and Ult-guarded\n"
+               "   guest state was never synchronised)\n", (unsigned long long)total);
+}
+
+}  // namespace prosper

--- a/prosper/tests/test_ult_fail_visible.cpp
+++ b/prosper/tests/test_ult_fail_visible.cpp
@@ -1,0 +1,114 @@
+// test_ult_fail_visible.cpp — #1603 regression guard: libSceUlt must FAIL VISIBLY.
+//
+// Before hle_ult.cpp existed, none of these NIDs was registered, so every libSceUlt call fell to the
+// generic unresolved-import path, which returns 0 (= SCE_OK for this ABI family) and logs the NID
+// exactly ONCE no matter how often it is called. On Earthion that was one log line for 1,005,742
+// sceUltMutexLock calls, and four "successfully created" ulthreads that never ran.
+//
+// Each assertion below fails on the pre-fix tree:
+//   * Hle::lookup() returns nullptr for every Ult NID -> the first two checks fail outright;
+//   * the generic path returns 0 -> the "not success" check fails;
+//   * the generic path counts by first-seen import index, not per call, and is not reachable
+//     without a linked import table -> the per-call counting check fails.
+#include "../src/hle/dispatch.hpp"
+
+#include <cstdint>
+#include <cstdio>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { std::printf("  [FAIL] %s\n", m); ++fails; } \
+                         else std::printf("  [ok]   %s\n", m); } while (0)
+
+// SCE_KERNEL_ERROR_ENOSYS — 0x80020000 | FreeBSD errno 78. See hle_ult.cpp for why this specific
+// value is a derived convention rather than an invented libSceUlt constant.
+static constexpr uint64_t kEnosys = 0x8002004Eull;
+
+// The NIDs Earthion (PPSA28061) actually imports and actually calls, spanning every family in the
+// library's exercised surface: runtime, ulthread, mutex, condvar, resource pool, lifecycle.
+static const char* const kCalledNids[] = {
+    "hZIg1EWGsHM",  // sceUltInitialize
+    "jw9FkZBXo-g",  // _sceUltUlthreadRuntimeCreate
+    "grs2pbc2awM",  // sceUltUlthreadRuntimeGetWorkAreaSize
+    "znI3q8S7KQ4",  // _sceUltUlthreadCreate
+    "mmt8Sa6tL6c",  // _sceUltMutexCreate
+    "8hEGkR1pfr8",  // sceUltMutexLock
+    "h0XebKiMBtk",  // sceUltMutexUnlock
+    "jnKaHGkrxZ4",  // _sceUltConditionVariableCreate
+    "JTw1cAVkuc0",  // sceUltConditionVariableSignal
+    "YiHujOG9vXY",  // _sceUltWaitingQueueResourcePoolCreate
+    "WIWV1Qd7PFU",  // sceUltWaitingQueueResourcePoolGetWorkAreaSize
+};
+// Imported but not observed in the measured window (teardown / blocking paths). Registered anyway,
+// because "not seen in 118 seconds" is not "never called".
+static const char* const kImportedNids[] = {
+    "gCeAI57LGgI",  // sceUltUlthreadJoin
+    "jW+HnafeS3Y",  // sceUltMutexDestroy
+    "5xGAHCxA8M0",  // sceUltConditionVariableWait
+    "xrmmI832R4U",  // sceUltConditionVariableDestroy
+    "d-kSG2fLrvI",  // sceUltFinalize
+};
+
+int main() {
+    register_builtin_hle();
+    ult_reset_counts_for_test();
+    // The environment must not decide whether this test passes: pin the default policy explicitly.
+    ult_set_return_success_for_test(false);
+
+    bool all_registered = true;
+    for (const char* nid : kCalledNids)   all_registered &= Hle::lookup(nid) != nullptr;
+    for (const char* nid : kImportedNids) all_registered &= Hle::lookup(nid) != nullptr;
+    CHECK(all_registered,
+          "every libSceUlt NID Earthion imports is registered (no longer the silent generic path)");
+
+    auto lock = Hle::lookup("8hEGkR1pfr8");     // sceUltMutexLock
+    auto unlock = Hle::lookup("h0XebKiMBtk");   // sceUltMutexUnlock
+    CHECK(lock && unlock, "sceUltMutexLock / sceUltMutexUnlock resolve to prosper handlers");
+    if (!lock || !unlock) { std::printf("== FAIL: %d ==\n", ++fails); return 1; }
+
+    // A lock that is not implemented must not claim to have been taken.
+    const uint64_t locked = lock(0x1234, 0, 0, 0, 0, 0);
+    CHECK(locked != 0, "sceUltMutexLock does NOT report success (0 = SCE_OK would be a false lock)");
+    CHECK(locked == kEnosys, "sceUltMutexLock returns SCE_KERNEL_ERROR_ENOSYS (0x8002004e)");
+
+    // Per-call counting is the whole point: the generic path's first-seen dedup made a million
+    // calls indistinguishable from one.
+    lock(0x1234, 0, 0, 0, 0, 0);
+    lock(0x1234, 0, 0, 0, 0, 0);
+    unlock(0x1234, 0, 0, 0, 0, 0);
+    CHECK(ult_call_count("8hEGkR1pfr8") == 3 && ult_call_count("h0XebKiMBtk") == 1,
+          "calls are counted individually, not deduped to one first-seen entry");
+
+    // Every registered entry point must refuse, not just the mutex pair.
+    bool all_refuse = true;
+    for (const char* nid : kCalledNids)   all_refuse &= Hle::lookup(nid)(0, 0, 0, 0, 0, 0) != 0;
+    for (const char* nid : kImportedNids) all_refuse &= Hle::lookup(nid)(0, 0, 0, 0, 0, 0) != 0;
+    CHECK(all_refuse, "no libSceUlt entry point reports success");
+
+    // The size queries must leave the guest's out-param untouched — writing an invented size is the
+    // #544/#660 failure (a "success" stub whose unwritten required-memory output drove a
+    // multi-gigabyte allocation). A sentinel proves prosper wrote nothing.
+    uint64_t work_area = 0xdeadbeefcafef00dull;
+    const uint64_t runtime_size = Hle::lookup("grs2pbc2awM")(
+        (uint64_t)(uintptr_t)&work_area, 4, 0, 0, 0, 0);
+    const uint64_t pool_size = Hle::lookup("WIWV1Qd7PFU")(
+        (uint64_t)(uintptr_t)&work_area, 4, 0, 0, 0, 0);
+    CHECK(runtime_size != 0 && pool_size != 0 && work_area == 0xdeadbeefcafef00dull,
+          "the *GetWorkAreaSize queries fail and write no invented size into the out-param");
+
+    // The A/B escape hatch restores the legacy return but must never restore the silence.
+    const uint64_t before = ult_call_count("8hEGkR1pfr8");
+    const bool prev = ult_set_return_success_for_test(true);
+    const uint64_t legacy = lock(0x1234, 0, 0, 0, 0, 0);
+    ult_set_return_success_for_test(prev);
+    CHECK(prev == false, "the default policy is the error, not the legacy fake success");
+    CHECK(legacy == 0 && ult_call_count("8hEGkR1pfr8") == before + 1,
+          "PROSPER_ULT_RETURN_SUCCESS reproduces the legacy 0 but is still counted");
+
+    // The default must be restored for any later assertion in this process.
+    CHECK(lock(0x1234, 0, 0, 0, 0, 0) == kEnosys, "the error policy is restored after the A/B");
+
+    std::printf(fails ? "== FAIL: %d ==\n" : "== PASS ==\n", fails);
+    return fails ? 1 : 0;
+}


### PR DESCRIPTION
## Purpose

Makes `libSceUlt` **fail-visible**. Fixes #1603.

This is Phase 1 only — **no ulthread semantics are implemented**, deliberately. The goal is to convert an invisible correctness hazard into a diagnosable one.

## The hazard, measured

`libSceUlt` is Sony's user-level threading library (cooperative ulthreads, mutexes, condition variables, queues). prosper implemented **none** of it, so every call landed in `prosper_on_unimpl` (`dispatch.cpp:140`) and returned **0** — which in this ABI means **success**.

A 118-second CPU-only Earthion boot on pre-change master:

```
1,005,742 x  libSceUlt  8hEGkR1pfr8  [sceUltMutexLock]    ->  ONE log line
1,005,742 x  libSceUlt  h0XebKiMBtk  [sceUltMutexUnlock]  ->  ONE log line
        4 x             znI3q8S7KQ4  [_sceUltUlthreadCreate]
```

**A 1,005,742-to-1 call-to-log ratio.** The guest spins roughly 8,500 lock/unlock pairs per second with **no mutual exclusion whatsoever**, and four ulthreads are reported created that never run. The log line did not even name the function — prosper's NidDb has no `libSceUlt` entries.

The dedup at `dispatch.cpp:146` (`log only when c == 1`) is what hid the magnitude. That is the same shape as the deduped `[compute] skip unsupported program` line that made 3,501 successful executions look like a permanent block earlier this session.

### A second hazard, arguably worse

`sceUltUlthreadRuntimeGetWorkAreaSize` and `sceUltWaitingQueueResourcePoolGetWorkAreaSize` are **size queries with out-parameters**. Returning 0 = success *without writing the out-param* leaves whatever was on the stack — precisely the #544 / #660 Dead Cells class, where success stubs left stack data in max-name and required-memory outputs and caused intermittent multi-gigabyte allocations.

## Scope, established by measurement

**Exactly one dump imports `libSceUlt`: Earthion (`PPSA28061`), 16 functions.** The other 29 have zero Ult evidence. Two independent instruments agree exactly — a byte-scan for `<NID>#` across every `eboot.bin`/`game.bin`/`*.prx`, and prosper's own `self_dump --symbols`, which reports `libSceUlt 16 functions` with the same NIDs. 11 of the 16 are called in the measured window; the rest are teardown and blocking paths.

This also corrects the issue text: **the real export count is 64**, not 384 — that figure was a raw `grep -c sceUlt` line count rather than an export count. Corrected on #1603.

## What this implements

`prosper/src/hle/hle_ult.cpp` registers exactly those 16 NIDs, which takes them off the generic dedup path so the file owns real per-function accounting:

- **per-call atomic counting**, with a line at call 1 and at each power of ten — so a million-call spin produces ~7 unmistakable lines rather than one, and never a firehose;
- a one-time hazard banner, and at the top end `*** >=1,000,000 CALLS — the guest is SPINNING on an unimplemented user-level lock ***`, so the magnitude is readable at a glance instead of requiring arithmetic;
- a real per-call table appended to `dump_call_log()`.

**Return value:** `SCE_KERNEL_ERROR_ENOSYS` = `0x8002004E`, via the documented `0x80020000 | freebsd_errno` convention already used across the codebase (`hle_kernel.cpp:2567`, `:2582`, `:2599`). FreeBSD `ENOSYS` is 78. This is a **derived convention, not an invented libSceUlt-shaped constant**, and the confidence is deliberately split in the source: `CONFIDENCE: HIGH` that 0 is wrong and a guest checking `ret != SCE_OK` must see failure; `CONFIDENCE: LOW` that this is the specific value real libSceUlt returns.

**No guest out-param is ever written** — deliberate, documented, and asserted by a sentinel test. Inventing a size for the two `*GetWorkAreaSize` queries would be #544/#660 in a new costume. A guest that checks the return now sees failure; a guest that ignores it and uses uninitialised memory is exhibiting *its own* bug, visibly, rather than inheriting ours silently.

`PROSPER_ULT_RETURN_SUCCESS=1` restores the legacy `0` for A/B. Off by default, and **still fully logged**, so no configuration is ever silent again.

## Tests

`ult_fail_visible` — 10 assertions covering registration, refusal, the exact ENOSYS value, per-call counting surviving the dedup, the untouched out-param sentinel, and the A/B switch.

**Fails without the fix**, verified by reverting only the single `register_ult_hle()` call and rebuilding: 3 failures, exit 1.

## Verification

Full suite in the `ps5ys` distrobox with Vulkan enabled (`-DGAME_DUMP=PPSA24651`): **163/163 serially**. `git diff --check` clean.

`ctest -j4` shows 2 `game_compute_exec*` failures caused by a **pre-existing hard-coded `/tmp` path race**, unrelated to this change — filed as **#1613**.

## Progression: no regression, stated honestly

Same binary, single variable, counters at t=110 s:

| build | submits | draws | flips |
|---|---:|---:|---:|
| ENOSYS (this PR) | 392,547 | 681,454 | 79,670 |
| legacy-0 control | 378,472 | 658,934 | 76,855 |
| pre-change master | 383,861 | 667,557 | 77,932 |

All within run-to-run variance, with ENOSYS marginally fastest. **Earthion ignores every `libSceUlt` return value**, so the old fake success was buying it nothing — the entire hazard is the missing semantics, not the return code.

**Caveat, stated plainly:** those are CPU-only counters, not rendered frames. Identical submit/draw/flip volume plus a change that cannot reach the renderer makes rung 1 preservation near-certain, but screenshots were not re-captured — a peer agent held the GPU throughout. A rendered re-check is cheap for whoever next has it.

## Also filed

**#1612** — `hle_kernel.cpp:2514-2515` returns **Linux** errno values inside the FreeBSD-derived family: `0x80020026` is `ENOTSOCK`, not `ENOSYS` (which is 78 = `0x4E`); and `0x80020023` is `EAGAIN`, not `EDEADLK`. The second is the more dangerous — a *retry* hint where a deadlock was intended.

**#1613** — the `ctest -j4` hard-coded `/tmp` path race.

## Explicitly out of scope

Implementing ulthreads, mutexes or the scheduler. That needs ABI and scheduling semantics derived from live title evidence and guest disassembly, and should be driven by what titles actually exercise.
