### PR TITLE
test(snapshot): reviewed rugrats-gameplay guard — PPSA23396 reaches rung 6

### DIFF
--- a/prosper/tools/snapshot/AGENTS.md
+++ b/prosper/tools/snapshot/AGENTS.md
@@ -37,7 +37,8 @@ Baseline evidence requires visual review even though routine regression runs do
 not. This prevents checksums or thresholds from blessing black output or the
 wrong scene.
 
-1. Set `review` to `pending` and run `snapshot.py verify NAME`.
+1. Write the whole candidate entry, **including `_note`**, and set `review` to
+   `pending`. Then run `snapshot.py verify NAME`.
 2. Inspect every image retained from both independent runs in
    `tools/snapshot/review/NAME/`. Confirm the intended gameplay state, expected
    layers, and progression across multiple timestamps.
@@ -50,9 +51,37 @@ wrong scene.
    conservative non-black coverage floor; exact mode records the identical
    pixel hash. Never use exact hashes for threaded gameplay merely because one
    run happened to be stable.
-5. Run `snapshot.py check NAME` after approval.
+5. Replace the generic `review` string that `update` wrote with the factual note
+   describing what was actually inspected.
+6. Run `snapshot.py check NAME` after approval.
 
 See `README.md` for every manifest field and the current title matrix.
+
+### Three ordering traps that silently produce a bad baseline
+
+Each of these leaves a guard that *looks* adopted. None of them fails loudly, so
+follow the order above rather than the obvious one.
+
+- **The factual `review` note must be written after `update --reviewed`, not
+  before.** `approve_content_candidate` unconditionally overwrites `review` with
+  a generic "Approved N composited images ... visually confirmed" string. A note
+  written before approval is destroyed by the approval itself, and the guard then
+  carries boilerplate that records no evidence while still satisfying `check`'s
+  "not pending" test.
+- **`_note` must be set before `verify`, because it is part of the candidate
+  fingerprint.** `entry_fingerprint` excludes only `hash`, `dims`, `review`,
+  `structural_references`, `perceptual_references`, and `min_nonblack_ratio`;
+  every other key, `_note` included, is hashed. Adding or editing `_note` after
+  `verify` makes `update` refuse with "snapshot configuration changed after
+  verify", costing a full two-capture rerun.
+- **`min_content_match_ratio` applies to every frame in the window, not to the
+  qualifying ones.** The requirement is
+  `max(min_structural_matches, ceil(total_window_frames * ratio))`, so at the
+  0.75 default, three quarters of *all* window frames must clear both SSIM and
+  non-black coverage. A window that merely contains good gameplay but also
+  straddles a load, a fade, or a transition will fail on a perfectly healthy run.
+  Place the window entirely inside the settled state and confirm the margin with
+  `profile_route.py` instead of assuming it.
 
 ## Environment
 

--- a/prosper/tools/snapshot/AGENTS.md
+++ b/prosper/tools/snapshot/AGENTS.md
@@ -31,6 +31,35 @@ python3 tools/snapshot/snapshot.py check blasphemous2-gameplay
 - Do not lower a threshold merely to pass. Explain intentional contract changes
   and repeat the baseline-review workflow below.
 
+### Why the content contract is conjoined, measured on a real title
+
+"Colour count must never be the contract on its own" is not a precaution; it is
+a measured result. Profiling the Rugrats route (`PPSA23396`) once per second
+across a whole boot produced both halves of the argument from one run, and they
+fail in **opposite** directions — which is exactly why neither metric can stand
+alone, and why `min_colors`, `min_nonblack_ratio`, SSIM, `dims` and
+`min_pixel_changes` are conjoined:
+
+- **Colour count alone prefers a menu to the game.** The two richest frames of
+  the entire run are the GAME MODE selector at 56,071-56,090 distinct colours.
+  The best actual gameplay frame reaches 17,645. A colour-only guard would rank
+  a menu **3.2x above every frame of the scene it exists to protect**, so it
+  would pass a build whose gameplay had collapsed as long as the menu still drew.
+- **Coverage alone accepts a nearly colourless screen.** The "BABIES IN
+  GAMELAND" level-title card and its fade are **fully opaque — a 1.0 non-black
+  ratio — at only 1,551-3,448 colours**. 54 frames of the run reach 0.999
+  coverage with as few as 1,551 colours, so a coverage-only guard treats a
+  title card as a rendered level.
+
+The practical rule: let SSIM decide *scene identity*, and keep `min_colors` as a
+gross-collapse floor rather than tuning it to separate two valid scenes. For
+Rugrats the tempting floor is ~16,000 — just under the 17,259 gameplay minimum
+and just over the 15,030 menu ceiling — but that discrimination is redundant
+with SSIM while making the guard fragile against a slightly dimmer healthy
+frame. 12,000 was chosen instead: comfortably below the observed gameplay range
+and far above every observed failure state (black at 1 colour, logos at most
+3,830, title card at most 3,448).
+
 ## New Or Changed Baselines
 
 Baseline evidence requires visual review even though routine regression runs do

--- a/prosper/tools/snapshot/snapshots.json
+++ b/prosper/tools/snapshot/snapshots.json
@@ -732,6 +732,87 @@
         }
       ],
       "min_nonblack_ratio": 0.5
+    },
+    {
+      "name": "rugrats-gameplay",
+      "dump": "PPSA23396-app0",
+      "scale": 4,
+      "timeout": 180,
+      "capture_after_seconds": 118,
+      "capture_before_seconds": 175,
+      "pad_script": "scripts/rugrats/reach-gameplay.pad",
+      "savedata_policy": "fresh",
+      "env": {},
+      "min_colors": 12000,
+      "min_qualifying_frames": 20,
+      "min_pixel_changes": 20,
+      "min_structural_similarity": 0.85,
+      "min_structural_matches": 20,
+      "min_content_match_ratio": 0.75,
+      "dims": [
+        480,
+        270
+      ],
+      "review": "Approved all 16 composited images from two independent runs on 2026-07-31. Every image is the first nursery level (BABIES IN GAMELAND) at 480x270: the pink nursery wall, the textured green carpet, the stacked multi-colour block platform, the expanding wooden playpen gate with its dark-red section and gold padlock, the orange curtain and daylit window, both babies (Tommy and Chuckie) with their animation, and both baby-bottle HUD icons -- fully composited, with no black regions, missing layers, or diagnostic-only output. The babies occupy visibly different gate heights and poses across all eight timestamps of each run and between the two runs, confirming a live progressing scene rather than a frozen frame; the window's 57 frames hold 33 and 34 distinct pixel CRCs while every consecutive pair differs, which is the repeating climb/jump cycle the route's Cross presses drive. Measured 17,256-17,565 distinct colours and 0.9976-0.9978 non-black coverage in all 57 window frames of both runs, identical in range across runs. Contrasting states measured on the same route: the GAME MODE menu reaches 56,090 colours, the BABIES IN GAMELAND title card is fully opaque at 1,551 colours, and the boot's black frames measure 1 colour at 0.0 coverage -- so min_colors=12000 and min_nonblack_ratio=0.4988 sit well below the reviewed gameplay range and well above every observed failure state.",
+      "_note": "Reviewed fresh-save guard for Rugrats: Adventure in Gameland's first nursery level (BABIES IN GAMELAND). Profiling the committed route once per second across the whole boot placed the level at 98s, so the evidence window opens at 118s -- twenty seconds later -- and runs to 175s, giving 57 samples entirely inside settled gameplay. Because min_content_match_ratio rejects a window once a quarter of its frames are off-scene, that start also tolerates the level arriving as late as roughly 132s before the guard can fail on healthy output. Colour count is deliberately ONE of five conjoined conditions (richness, non-black coverage, SSIM against reviewed luminance references, stable dimensions, frame-to-frame change) and must never become the contract on its own. This title demonstrates why with unusual clarity: the two richest frames in the entire run are the GAME MODE selector at 56,071-56,090 colours, which is 3.2x richer than the best gameplay frame in the run at 17,645, so a colour-only guard would rank a menu above every frame of the scene it is supposed to protect. Coverage alone fails symmetrically -- the BABIES IN GAMELAND level-title card and its fade score a full 1.0 non-black ratio at only 1,551-3,448 colours, and 54 frames of the run reach 0.999 coverage with as few as 1,551 colours.",
+      "structural_references": [
+        {
+          "luma16x9": "a5a3a6a6a6a6a6a6a6a6a6a69c8f8eb19d7d7383a5a3a5a3a5a3a2a4968887c877707a7b8d8d909d897c7e8e896894bea3736e8b888d8bab858a7888948498b220446f7489888a9a886f8092958f776b304a7d7584888488848676829192869a2a1a21577b787c777a787178807c74837e7e7c7e7d7d7f7b7e7b7e7f7f7e7e7e74757376767776757576767377767773",
+          "average_hash": "0000c4cc7c8cfdff",
+          "difference_hash": "a028381090505940"
+        },
+        {
+          "luma16x9": "a5a3a6a6a6a6a6a6a6a6a6a69c8f8eb19d7d7383a5a3a5a3a5a3a2a4968887c877707a7b8d8d93a589797d8e896894bea3736e8b888d89a2878a7b88948498b220446f7489888a9788738192958f776b304a7d7584888488848877829192869a2a1a21577b787c777a787178807c74837e7e7c7e7d7d7f7b7e7b7e7f7f7e7e7e74757376767776757576767377767773",
+          "average_hash": "0000c4cc7c8cfdff",
+          "difference_hash": "a028381090505940"
+        },
+        {
+          "luma16x9": "a5a3a6a6a6a6a6a6a6a6a6a69c8f8eb19d7d7383a5a3a5a3a5a3a2a4968887c877707a7b8d8d98bb897b7f8e896894bea3736e8b888d8a9d86867a88948498b220446f748988898a887f7e92958f776b304a7d7584888488848877829192869a2a1a21577b787c777a787178807c74837e7e7c7e7d7d7f7b7e7b7e7f7f7e7e7e74757376767776757576767377767773",
+          "average_hash": "0000c4dc5c8cfdff",
+          "difference_hash": "a028380090505940"
+        },
+        {
+          "luma16x9": "a5a3a6a6a6a6a6a6a6a6a6a69c8f8eb19d7d7383a5a3a5a2a5a3a2a4968887c877707a7b8d8d98c0887c7d8e896894bea3736e8b888d8b9b88817b88948498b220446f748988898988827e92958f776b304a7d7584888488848877829192869a2a1a21577b787c777a787178807c74837e7e7c7e7d7d7f7b7e7b7e7f7f7e7e7e74757376767776757576767377767773",
+          "average_hash": "0000c4dc4c8cfdff",
+          "difference_hash": "a028380090505140"
+        },
+        {
+          "luma16x9": "a5a3a6a6a6a6a6a6a6a6a6a69c8f8eb19d7d7383a5a3a5a7a59fa0a4968887c877707a7b8d8d95c1868c7b8e896894bea3736e8b888d8c9388717688948498b220446f748988898988878192958f776b304a7d7584888488848877829192869a2a1a21577b787c777a787178807c74837e7e7c7e7d7d7f7b7e7b7e7f7f7e7e7e74757376767776757576767377767773",
+          "average_hash": "0000c4dc4c9cfdff",
+          "difference_hash": "a028380098505140"
+        },
+        {
+          "luma16x9": "a5a3a6a6a6a6a6a6a6a6a6a69c8f8eb19d7d7383a5a3a5aaa59fa0a4968887c877707a7b8d8d94be868c7b8e896894bea3736e8b888d8c9388717688948498b220446f748988898988878192958f776b304a7d7584888488848877829192869a2a1a21577b787c777a787178807c74837e7e7c7e7d7d7f7b7e7b7e7f7f7e7e7e74757376767776757576767377767773",
+          "average_hash": "0000c4dc4c9cfdff",
+          "difference_hash": "a028380098505140"
+        },
+        {
+          "luma16x9": "a5a3a6a6a6a6a6a6a6a6a6a69c8f8eb19d7d7383a5a3a6b0a59b9fa4968887c877707a7b8d8d92b785867a8e896894bea3736e8b888d8b9289737988948498b220446f748988898988878692958f776b304a7d7584888488848877829192869a2a1a21577b787c777a787178807c74837e7e7c7e7d7d7f7b7e7b7e7f7f7e7e7e74757376767776757576767377767773",
+          "average_hash": "0000c4dc6c8cfdff",
+          "difference_hash": "a028380098505140"
+        },
+        {
+          "luma16x9": "a5a3a6a6a6a6a6a6a6a6a6a69c8f8eb19d7d7383a5a3a6b3a4969da4968887c877707a7b8d8d91b385897a8e896894bea3736e8b888d8b9189707988948498b220446f748988898988888692958f776b304a7d7584888488848877829192869a2a1a21577b787c777a787178807c74837e7e7c7e7d7d7f7b7e7b7e7f7f7e7e7e74757376767776757576767377767773",
+          "average_hash": "0000c4dc6c8cfdff",
+          "difference_hash": "a028380098505140"
+        },
+        {
+          "luma16x9": "a5a3a6a6a6a6a6a6a6a6a6a69c8f8eb19d7d7383a5a3a5a2a5a3a2a4968887c877707a7b8d8d98c0897b7d8e896894bea3736e8b888d8b9b88837b88948498b220446f748988898988817e92958f776b304a7d7584888488848877829192869a2a1a21577b787c777a787178807c74837e7e7c7e7d7d7f7b7e7b7e7f7f7e7e7e74757376767776757576767377767773",
+          "average_hash": "0000c4dc4c8cfdff",
+          "difference_hash": "a028380090505140"
+        },
+        {
+          "luma16x9": "a5a3a6a6a6a6a6a6a6a6a6a69c8f8eb19d7d7383a5a3a5aca59b9fa4968887c877707a7b8d8d93bb85867a8e896894bea3736e8b888d8c9289737988948498b220446f748988898988878692958f776b304a7d7584888488848877829192869a2a1a21577b787c777a787178807c74837e7e7c7e7d7d7f7b7e7b7e7f7f7e7e7e74757376767776757576767377767773",
+          "average_hash": "0000c4dc6c8cfdff",
+          "difference_hash": "a028380098505140"
+        },
+        {
+          "luma16x9": "a5a3a6a6a6a6a6a6a6a6a6a69c8f8eb19d7d7383a5a3a7b6a1939aa4968887c877707a7b8d8d91ae87897a8e896894bea3736e8b888d8a9189727a88948498b220446f748988898988898692958f776b304a7d7584888488848877829192869a2a1a21577b787c777a787178807c74837e7e7c7e7d7d7f7b7e7b7e7f7f7e7e7e74757376767776757576767377767773",
+          "average_hash": "0000c4dc7c8cfdff",
+          "difference_hash": "a028380098505140"
+        }
+      ],
+      "min_nonblack_ratio": 0.498796
     }
   ]
 }


### PR DESCRIPTION
## Purpose

Adds the reviewed `rugrats-gameplay` snapshot guard, taking **Rugrats: Adventure in Gameland (`PPSA23396`) to rung 6** — a deterministic route plus content guard, the point at which this project considers a title done.

Rugrats reached gameplay earlier today on **completely unmodified master with zero code changes** (#1598). This locks that in against regression.

One file, `snapshots.json`, +81 lines.

## The contract

Route `scripts/ppsa23396`-equivalent `scripts/rugrats/reach-gameplay.pad` (already committed, unmodified), fresh save, scale 4, window **118–175 s**, `dims [480,270]`, 11 reviewed luminance signatures, and five conjoined conditions: `min_colors` 12,000 · `min_nonblack_ratio` 0.4988 (tool-derived) · SSIM ≥ 0.85 with `min_structural_matches` 20 · `min_qualifying_frames` 20 · `min_pixel_changes` 20, at `min_content_match_ratio` 0.75.

## The window was profiled, not guessed

174 one-second samples across the whole boot:

| phase | timing |
|---|---|
| splash logos | → 30 s |
| GAME MODE selector | 33–34 s |
| menus | → 86 s |
| "BABIES IN GAMELAND" title card + fade | 87–96 s |
| **settled gameplay** | **98 s → end** |

The window opens at 118 s — twenty seconds after the observed load, mirroring `alexkidd-gameplay`. Because `min_content_match_ratio` rejects a window once a quarter of its frames are off-scene, that start tolerates the level arriving as late as **~132 s** before the guard could fail on healthy output.

This margin matters: today's full matrix had `blue-prince-hall` and `terminator-boot` both FAIL while retaining fully-rendered healthy frames, purely from window drift. **A guard that cries wolf is worse than no guard.**

## Verification

**`verify`: CONTENT-STABLE.** Both runs 57/57 qualifying frames, 56/56 consecutive-frame changes, colours 17,256–17,565 and coverage 0.9976–0.9978 — *identical ranges across both runs*.

**`check` on a third independent capture: OK** — frames 57, qualifying 57, richest 17,576, pixel_changes 56, structural_matches 57, nonblack_matches 57.

**All 16 retained images from both runs were opened and inspected.** Every one is the first nursery level: pink wall, textured green carpet, stacked block platform, playpen gate with its gold padlock, orange curtain and daylit window, Tommy and Chuckie, and both baby-bottle HUD icons. No black regions, missing layers, or diagnostic output. The babies occupy visibly different gate heights across all eight timestamps of each run *and* between runs, so the scene is live.

`git diff --check` clean. No host paths in the diff.

## A liveness finding worth recording

The 57 window frames hold only **33–34 distinct pixel CRCs**, while **every consecutive pair still differs**. That is the repeating climb/jump cycle the route's Cross presses drive — not a stall.

It is also exactly why `min_pixel_changes` is the right liveness test and CRC-uniqueness would be wrong: a legitimately cyclic scene revisits pixel states, so a uniqueness test would flag healthy gameplay while a consecutive-change test correctly passes it.

## Threshold deliberately not set to the obvious value

`min_colors` is **12,000**, not the tempting ~16,000.

The observed gameplay floor is 17,259 and the menu ceiling is 15,030, so ~16,000 would sit neatly between them and *would* discriminate menu from level on colour alone. It was rejected because that discrimination **duplicates what SSIM already does while making the guard fragile** — a slightly dimmer healthy gameplay frame at 15,900 would fail. 12,000 sits 1.44× below the observed gameplay minimum and far above every observed failure state (black at 1 colour, logos ≤ 3,830, title card ≤ 3,448), leaving scene identity to the check designed for it.

The measured justification for conjoining these conditions at all — a colour-only guard ranking this title's menu **3.2× above every gameplay frame**, and a coverage-only guard accepting a fully-opaque 1,551-colour title card — landed separately in #1611.

## Explicitly not included

**Three routes remain unvalidated: New Joe & Mac (`PPSA02801`), Asterix: Slap Them All (`PPSA08576`), Summer Sports Games (`PPSA03416`).** No committed route exists for any of them and none has been run. Draft `.pad` files were deliberately **moved out of the repository** rather than left untracked, so no stray `git add -A` can commit a route that has never produced its claimed state — which would be worse than none, because the next agent would trust it.

Greak is next; its route is already committed.
