### PR TITLE
diag(gpu): report the stage user-data pointer map — falsifies #1607's premise, reproduces #305 loudly

### DIFF
--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -3359,6 +3359,17 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
             if (!any) fprintf(stderr, " none");
             fprintf(stderr, "\n");
         }
+        // A stage pointer may carry aperture/tag bits above the title's usable GPU VA, exactly as the
+        // scalar fold's S_LOAD canonicalization assumes. Accept a dword pair as a pointer when the
+        // raw 64-bit value or either canonical form is mapped, so a tagged-but-valid table pointer is
+        // never reported as unmapped.
+        const auto pointer_is_mapped = [](uint64_t value) {
+            for (uint64_t mask : {~uint64_t{0}, uint64_t{0xFFFFFFFFFFFF}, uint64_t{0xFFFFFFFFFF}}) {
+                const uint64_t candidate = value & mask;
+                if (candidate > 0x10000 && guest_readable(candidate, 8)) return true;
+            }
+            return false;
+        };
         if (const AgcShaderUserData* ud = hdr->user_data) {
             uint32_t sgprs[kUserSgprs]; read_user_sgprs(st.sh, bases[0] + range_start, sgprs);
             fprintf(stderr, "[udmap] %s code=0x%llx declared direct:",
@@ -3370,7 +3381,7 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
                     (uint64_t)sgprs[off] | ((uint64_t)sgprs[off + 1] << 32);
                 fprintf(stderr, " [%u]@dw%u=0x%llx(%s)", t, off,
                         (unsigned long long)candidate,
-                        guest_readable(candidate, 8) ? "readable" : "UNMAPPED");
+                        pointer_is_mapped(candidate) ? "readable" : "UNMAPPED");
             }
             // Self-validating half: search the 32-dword window for the ONE seed offset at which
             // EVERY declared direct pointer becomes a mapped guest address. If that offset equals
@@ -3391,7 +3402,7 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
                     if (off + 1 >= kUserSgprs) { all_mapped = false; break; }
                     const uint64_t value =
                         (uint64_t)probe[off] | ((uint64_t)probe[off + 1] << 32);
-                    all_mapped = value > 0x10000 && guest_readable(value, 8);
+                    all_mapped = pointer_is_mapped(value);
                 }
                 if (all_mapped) { implied = seed; break; }
             }

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -3335,6 +3335,74 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
             for (uint32_t i = 0; i < kUserSgprs; i++) fprintf(stderr, " %08x", sgprs[i]);
             fprintf(stderr, "\n");
         }
+        // USER-DATA POINTER MAP. A stage's descriptor-table pointers are ordinary 64-bit guest
+        // addresses sitting in consecutive user-data dwords, and every bindless descriptor chain
+        // starts by dereferencing one. When a stage fails to resolve its V#/T#, the first question
+        // is whether the seeded block even CONTAINS the pointers the shader loads from — the AGC
+        // header's direct-resource offsets and the shader's own SBASE registers both name dword
+        // positions, so a block whose readable pointers sit elsewhere is not the block that shader
+        // ran with. Report every dword pair that is a mapped guest address, plus the readability of
+        // each header-declared direct offset, so that question is answered by data rather than by
+        // eye. Probing is bounded to the 32-dword window and uses the fault-safe readability probe.
+        for (uint32_t base : bases) {
+            uint32_t sgprs[kUserSgprs]; read_user_sgprs(st.sh, base, sgprs);
+            fprintf(stderr, "[udmap] %s code=0x%llx base=0x%x readable-ptr dwords:",
+                    is_ps ? "PS" : "VS", (unsigned long long)code_addr, base);
+            bool any = false;
+            for (uint32_t i = 0; i + 1 < kUserSgprs; i++) {
+                const uint64_t candidate =
+                    (uint64_t)sgprs[i] | ((uint64_t)sgprs[i + 1] << 32);
+                if (candidate <= 0x10000 || !guest_readable(candidate, 8)) continue;
+                fprintf(stderr, " [%u]=0x%llx", i, (unsigned long long)candidate);
+                any = true;
+            }
+            if (!any) fprintf(stderr, " none");
+            fprintf(stderr, "\n");
+        }
+        if (const AgcShaderUserData* ud = hdr->user_data) {
+            uint32_t sgprs[kUserSgprs]; read_user_sgprs(st.sh, bases[0] + range_start, sgprs);
+            fprintf(stderr, "[udmap] %s code=0x%llx declared direct:",
+                    is_ps ? "PS" : "VS", (unsigned long long)code_addr);
+            for (uint16_t t = 0; t < ud->direct_resource_count && t < 16; t++) {
+                const uint32_t off = ud->direct_resource_offset[t];
+                if (off == 0xFFFFu || off + 1 >= kUserSgprs) continue;
+                const uint64_t candidate =
+                    (uint64_t)sgprs[off] | ((uint64_t)sgprs[off + 1] << 32);
+                fprintf(stderr, " [%u]@dw%u=0x%llx(%s)", t, off,
+                        (unsigned long long)candidate,
+                        guest_readable(candidate, 8) ? "readable" : "UNMAPPED");
+            }
+            // Self-validating half: search the 32-dword window for the ONE seed offset at which
+            // EVERY declared direct pointer becomes a mapped guest address. If that offset equals
+            // the shader's raw user_data_range_start, the block is simply seeded from the wrong
+            // register and the metadata already said so; if no offset works, the block genuinely
+            // does not contain this shader's pointers and the seeding origin is not the defect.
+            uint32_t implied = UINT32_MAX;
+            uint32_t declared_pointers = 0;
+            for (uint16_t t = 0; t < ud->direct_resource_count && t < 16; t++)
+                if (ud->direct_resource_offset[t] != 0xFFFFu) ++declared_pointers;
+            for (uint32_t seed = 0; declared_pointers && seed < kUserSgprs; ++seed) {
+                uint32_t probe[kUserSgprs];
+                read_user_sgprs(st.sh, bases[0] + seed, probe);
+                bool all_mapped = true;
+                for (uint16_t t = 0; all_mapped && t < ud->direct_resource_count && t < 16; t++) {
+                    const uint32_t off = ud->direct_resource_offset[t];
+                    if (off == 0xFFFFu) continue;
+                    if (off + 1 >= kUserSgprs) { all_mapped = false; break; }
+                    const uint64_t value =
+                        (uint64_t)probe[off] | ((uint64_t)probe[off + 1] << 32);
+                    all_mapped = value > 0x10000 && guest_readable(value, 8);
+                }
+                if (all_mapped) { implied = seed; break; }
+            }
+            const uint32_t raw_start = hdr->specials ? hdr->specials->user_data_range_start : 0u;
+            const uint32_t raw_end = hdr->specials ? hdr->specials->user_data_range_end : 0u;
+            fprintf(stderr, " | specials raw=[%u,%u) seeded=%u implied=",
+                    raw_start, raw_end, range_start);
+            if (implied == UINT32_MAX) fprintf(stderr, "none");
+            else fprintf(stderr, "%u", implied);
+            fprintf(stderr, "\n");
+        }
         // ALL set sh registers (sorted) — finds where the user-data SGPRs actually landed, including
         // any at unexpected offsets (a wrong indirect-register decode would scatter them).
         fprintf(stderr, "[resdump]   %zu sh regs set; lowest 48 offsets:", st.sh.size());


### PR DESCRIPTION
## Purpose

Adds a `[udmap]` diagnostic that reports the stage user-data pointer map alongside a failed resource build, and canonicalizes its pointer probes the same way the scalar fold does.

**Diagnostic only — no fix, deliberately.** Advances #1607 and supplies #305 with the loud reproduction it has been missing.

## It falsified the premise it was built to investigate

#1607 recorded that Nikoderiko's 3D world is dropped because the 8-SGPR `SRSRC` range is *computed inside the shader*, defeating descriptor provenance. **That is wrong.**

Every failing vertex stage uses the canonical bindless table read that `resolve_dynamic_fetch` already exists to handle — straight-line, no branches (`exec_vs_300e710000.bin`):

```
pc=18  s_load_dwordx4 s[16:19], s[14:15], 0x0    ; attr-spec block (s[14:15] = direct slot 10)
pc=34  s_lshl_b32     s107, s18, 4
pc=35  s_bfe_u32      s106, s18, 0x0001001a
pc=37  s_and_b32      s107, s107, 0x1f0          ; table slot = (s18<<4) & 0x1f0
pc=40  s_load_dwordx4 s[8:11], s[12:13], s107    ; V# from the table (s[12:13] = direct slot 8)
pc=68  buffer_load_format_xy v[9:10], v0, s[8:11], s107 idxen
```

`sreg_range_written` being true is a **symptom of that legitimate reload**, not the defect — and step (1) `by_fetch_pc` is precisely the step meant to resolve it. **The recompiler's three-step ladder is not at fault.** Two upstream defects starve it.

## Defect A — the const-fold is path-insensitive (1 of 13 traced VS)

In `300c5c0000`, `pc=22 s_cbranch_vccz -> 187` and `pc=186 s_branch -> 234`, so pc=187 is reachable **only** through pc=22's taken edge. Entry values are correct and mapped. But the fold walks linearly and applies `pc=52 s_buffer_load_dwordx16 s[16:31]` from the **mutually-exclusive fall-through arm**, so pc=187 dereferences `0x3e517e93` — a float.

Resolvable, and the generic contract is stated for whoever takes it: *a PC not reachable by fall-through begins a block whose scalar state is its branch predecessors' state; with exactly one recorded forward branch targeting it, adopt that branch's captured state; with more than one, or a backward edge, **invalidate** rather than continue.* The second half is a tightening — today the fold silently believes a provably impossible value.

## Defect B — the seeded user-data block is a previous pipeline's (11 of 13 traced VS) — this is #305

The dword pair that **both** the AGC header and the shader's own `SBASE` name as the table pointer is unmapped under every canonicalization the fold tries.

The diagnostic in this PR is self-validating, and it **falsified its author's own first hypothesis**: `user_data_range_start` is 0 for every shader and `end` = (last direct offset + 2), which excludes a wrong seeding origin; and `SBASE` equals the declared offset in all ten disassembled stages, which excludes header decode. The block simply holds **a previous pipeline's user data**.

**#305 records the identical signature on DOLL**, including the giveaway constant family — `0x4dfac00000172` there against `0x4dfac00000169` / `0x1d22c00000018` here, a V# `dword3` being read as a pointer's high dword.

Nikoderiko is the reproduction #305 has been waiting for: **0–33 UI draws on DOLL, versus 25 distinct dropped `(es, ps)` pipelines and the entire 3D world here.**

## The cross-title claim does not hold in the form #1607 stated it

I asked for this to be checked before treating the gap as shared UE4 infrastructure. It is not:

| title | result |
|---|---|
| **The Pathless** (`PPSA01826`) | 13/13 stages readable, `implied=0`, **0** `mubuf-unresolved`. Its rejects are missing opcodes (`fmt=14 op=0x68` x6, `op=0x47`, `fmt=0 op=0x25`, `fmt=7 op=0x1`) |
| **The Plucky Squire** (`PPSA15319`) | **0** failed stage builds |
| **ArcRunner** (`PPSA21406`) | **inconclusive**, not negative — 175 s produced one presented frame and a 153-line log |

Confirmed set is **Nikoderiko + DOLL**, both UE4.

## Baseline reject counts

440 s boot, title held from t=112 s: 172 `[recompile-reject]`, 207 `[exec-recompile-reject]` (25 distinct pipelines, 20 VS / 15 PS programs), 95 `[vertex-recompile-reject]`, 90+7 `[mubuf-unresolved]`, 75 `[mimg-unresolved]`. Baseline only — no fix, so no "after".

## Instrument warning worth recording

**`PROSPER_DBG` serializes draw realization**, so the title arrives at ~112 s rather than ~90 s. A first 200 s run timed out in the pre-title load with **zero rejects and briefly looked as though the issue were already fixed.**

That is the same class as the black-asset-load trap that nearly produced a phantom composition defect earlier today: an instrument changed the timing, and the changed timing produced a plausible wrong conclusion.

## Why no fix is included

Defect A is real but worth roughly 1 of 13 stages. Defect B is the 11-of-13 blocker and lives in **AGC register/submit decode** (#305's named candidates: TYPE-0 data packets #140, cross-queue ordering) — **not** in `rdna2_to_spirv.cpp`.

Implementing a provenance change would have been work on a falsified premise, and nothing was shipped that could invent a descriptor binding.

## Verification

`ctest` 159/162 — the three failures are the known dump-parameterized tests (`module_loads_eboot`, `boot_reaches_first_syscall`, `real_shader_render`) because the build is configured against `PPSA23760` rather than `PPSA24651`, tracked as #1573. Vulkan execution tests ran (`rdna2_to_spirv_exec`, `shared_vulkan_device`, `present_blit`), confirming a real distrobox build. `git diff --check` clean.
