### PR TITLE
test(snapshot): greak-gameplay guard, the conjoined-contract mirror pair, and a Greak doc correction

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -332,9 +332,18 @@ sustained first-level gameplay at native 1920×1080: the player character and it
 parallax terrain and pine forest, volumetric fog, drifting particles, the portrait/health/ammo HUD, the
 ability bar, and the button-prompt overlay.
 
-The route is `prosper/scripts/greak/reach-gameplay.pad`. Note that the title screen only appears after a
-roughly 70-second black asset-loading phase following the intro; a capture window shorter than about
-150 seconds ends before it and misreads the load as a black-screen defect.
+The route is `prosper/scripts/greak/reach-gameplay.pad`, and gameplay is guarded by the
+`greak-gameplay` snapshot. **A capture window placed too early lands in non-gameplay content, not in
+gameplay** — profiling the route once per second across a 255-second boot measured boot and logos to
+45 s, the hand-drawn intro cutscene 46-117 s, a short dark transition 118-122 s, a *letterboxed*
+level-intro cinematic 123-130 s, and full-screen gameplay only from 131 s. Anything shorter than about
+150 seconds therefore ends before the level.
+
+Do **not** expect a long black phase while waiting: an earlier note here described "a roughly
+70-second black asset-loading phase following the intro", but that span does not render black on
+current master. 46-117 s measures 18,685-61,886 distinct colours at 0.99-1.0 non-black coverage and is
+the intro cutscene playing normally. Reading that span as a black-screen defect or a hang is the
+misdiagnosis to avoid.
 
 One shared recompiler gap was found and closed during bring-up: `s_ttracedata` (SOPP `0x16`), a
 thread-trace profiling instruction with no architectural effect, was rejecting the entire vertex stage

--- a/prosper/tools/snapshot/AGENTS.md
+++ b/prosper/tools/snapshot/AGENTS.md
@@ -31,14 +31,24 @@ python3 tools/snapshot/snapshot.py check blasphemous2-gameplay
 - Do not lower a threshold merely to pass. Explain intentional contract changes
   and repeat the baseline-review workflow below.
 
-### Why the content contract is conjoined, measured on a real title
+### Why the content contract is conjoined, measured on real titles
 
 "Colour count must never be the contract on its own" is not a precaution; it is
-a measured result. Profiling the Rugrats route (`PPSA23396`) once per second
-across a whole boot produced both halves of the argument from one run, and they
-fail in **opposite** directions — which is exactly why neither metric can stand
-alone, and why `min_colors`, `min_nonblack_ratio`, SSIM, `dims` and
-`min_pixel_changes` are conjoined:
+a measured result. Two profiled titles settle it by demonstration, and they
+matter as a **pair**: in each one, a different metric goes blind, so neither can
+be the contract alone.
+
+| title | colour count | non-black coverage |
+|---|---|---|
+| **Rugrats** (`PPSA23396`) | separates cleanly — menu 56,090 vs gameplay 17,645 | **blind** — title card fully opaque at 1,551 colours |
+| **Greak** (`PPSA02849`) | **blind** — 87-colour gap (0.27%) between cinematic peak 32,153 and gameplay floor 32,240 | separates cleanly — letterboxed 0.6667 vs gameplay 1.0000 |
+
+Whichever metric you were about to trust on its own, one of these two titles is
+the counter-example. That is the whole argument for conjoining `min_colors`,
+`min_nonblack_ratio`, SSIM, `dims` and `min_pixel_changes`.
+
+Profiling the Rugrats route once per second across a whole boot produced both
+halves of the argument from one run, and they fail in **opposite** directions:
 
 - **Colour count alone prefers a menu to the game.** The two richest frames of
   the entire run are the GAME MODE selector at 56,071-56,090 distinct colours.
@@ -51,6 +61,13 @@ alone, and why `min_colors`, `min_nonblack_ratio`, SSIM, `dims` and
   coverage with as few as 1,551 colours, so a coverage-only guard treats a
   title card as a rendered level.
 
+Greak then supplied the inverse case. Its route passes through a **letterboxed**
+level-intro cinematic immediately before gameplay, and that cinematic peaks at
+32,153 colours while the gameplay floor is 32,240 — a gap of **87 colours, or
+0.27%**. No usable `min_colors` separates them. What does separate them is
+coverage: the letterbox bars hold the cinematic at 0.6667 while every gameplay
+frame measures exactly 1.0000.
+
 The practical rule: let SSIM decide *scene identity*, and keep `min_colors` as a
 gross-collapse floor rather than tuning it to separate two valid scenes. For
 Rugrats the tempting floor is ~16,000 — just under the 17,259 gameplay minimum
@@ -59,6 +76,16 @@ with SSIM while making the guard fragile against a slightly dimmer healthy
 frame. 12,000 was chosen instead: comfortably below the observed gameplay range
 and far above every observed failure state (black at 1 colour, logos at most
 3,830, title card at most 3,448).
+
+The corollary is that **when the usual discriminator goes blind, the other
+threshold has to carry the load, and should be set for that job rather than from
+the generic formula**. `greak-gameplay` therefore sets `min_nonblack_ratio` to
+0.9 instead of the derived 0.5 (half the lowest reviewed coverage): colour count
+provably cannot catch a window drifting into that cinematic, so coverage must,
+and the derived 0.5 would have admitted the 0.6667 letterbox. Raising a
+threshold this way needs the same evidence as lowering one — here, every
+reviewed gameplay frame measured exactly 1.0000 with zero variance across
+independent runs, leaving a 10% margin.
 
 ## New Or Changed Baselines
 

--- a/prosper/tools/snapshot/AGENTS.md
+++ b/prosper/tools/snapshot/AGENTS.md
@@ -37,7 +37,8 @@ Baseline evidence requires visual review even though routine regression runs do
 not. This prevents checksums or thresholds from blessing black output or the
 wrong scene.
 
-1. Set `review` to `pending` and run `snapshot.py verify NAME`.
+1. Write the whole candidate entry, **including `_note`**, and set `review` to
+   `pending`. Then run `snapshot.py verify NAME`.
 2. Inspect every image retained from both independent runs in
    `tools/snapshot/review/NAME/`. Confirm the intended gameplay state, expected
    layers, and progression across multiple timestamps.
@@ -50,9 +51,37 @@ wrong scene.
    conservative non-black coverage floor; exact mode records the identical
    pixel hash. Never use exact hashes for threaded gameplay merely because one
    run happened to be stable.
-5. Run `snapshot.py check NAME` after approval.
+5. Replace the generic `review` string that `update` wrote with the factual note
+   describing what was actually inspected.
+6. Run `snapshot.py check NAME` after approval.
 
 See `README.md` for every manifest field and the current title matrix.
+
+### Three ordering traps that silently produce a bad baseline
+
+Each of these leaves a guard that *looks* adopted. None of them fails loudly, so
+follow the order above rather than the obvious one.
+
+- **The factual `review` note must be written after `update --reviewed`, not
+  before.** `approve_content_candidate` unconditionally overwrites `review` with
+  a generic "Approved N composited images ... visually confirmed" string. A note
+  written before approval is destroyed by the approval itself, and the guard then
+  carries boilerplate that records no evidence while still satisfying `check`'s
+  "not pending" test.
+- **`_note` must be set before `verify`, because it is part of the candidate
+  fingerprint.** `entry_fingerprint` excludes only `hash`, `dims`, `review`,
+  `structural_references`, `perceptual_references`, and `min_nonblack_ratio`;
+  every other key, `_note` included, is hashed. Adding or editing `_note` after
+  `verify` makes `update` refuse with "snapshot configuration changed after
+  verify", costing a full two-capture rerun.
+- **`min_content_match_ratio` applies to every frame in the window, not to the
+  qualifying ones.** The requirement is
+  `max(min_structural_matches, ceil(total_window_frames * ratio))`, so at the
+  0.75 default, three quarters of *all* window frames must clear both SSIM and
+  non-black coverage. A window that merely contains good gameplay but also
+  straddles a load, a fade, or a transition will fail on a perfectly healthy run.
+  Place the window entirely inside the settled state and confirm the margin with
+  `profile_route.py` instead of assuming it.
 
 ## Environment
 

--- a/prosper/tools/snapshot/AGENTS.md
+++ b/prosper/tools/snapshot/AGENTS.md
@@ -31,6 +31,35 @@ python3 tools/snapshot/snapshot.py check blasphemous2-gameplay
 - Do not lower a threshold merely to pass. Explain intentional contract changes
   and repeat the baseline-review workflow below.
 
+### Why the content contract is conjoined, measured on a real title
+
+"Colour count must never be the contract on its own" is not a precaution; it is
+a measured result. Profiling the Rugrats route (`PPSA23396`) once per second
+across a whole boot produced both halves of the argument from one run, and they
+fail in **opposite** directions — which is exactly why neither metric can stand
+alone, and why `min_colors`, `min_nonblack_ratio`, SSIM, `dims` and
+`min_pixel_changes` are conjoined:
+
+- **Colour count alone prefers a menu to the game.** The two richest frames of
+  the entire run are the GAME MODE selector at 56,071-56,090 distinct colours.
+  The best actual gameplay frame reaches 17,645. A colour-only guard would rank
+  a menu **3.2x above every frame of the scene it exists to protect**, so it
+  would pass a build whose gameplay had collapsed as long as the menu still drew.
+- **Coverage alone accepts a nearly colourless screen.** The "BABIES IN
+  GAMELAND" level-title card and its fade are **fully opaque — a 1.0 non-black
+  ratio — at only 1,551-3,448 colours**. 54 frames of the run reach 0.999
+  coverage with as few as 1,551 colours, so a coverage-only guard treats a
+  title card as a rendered level.
+
+The practical rule: let SSIM decide *scene identity*, and keep `min_colors` as a
+gross-collapse floor rather than tuning it to separate two valid scenes. For
+Rugrats the tempting floor is ~16,000 — just under the 17,259 gameplay minimum
+and just over the 15,030 menu ceiling — but that discrimination is redundant
+with SSIM while making the guard fragile against a slightly dimmer healthy
+frame. 12,000 was chosen instead: comfortably below the observed gameplay range
+and far above every observed failure state (black at 1 colour, logos at most
+3,830, title card at most 3,448).
+
 ## New Or Changed Baselines
 
 Baseline evidence requires visual review even though routine regression runs do

--- a/prosper/tools/snapshot/snapshots.json
+++ b/prosper/tools/snapshot/snapshots.json
@@ -732,6 +732,87 @@
         }
       ],
       "min_nonblack_ratio": 0.5
+    },
+    {
+      "name": "rugrats-gameplay",
+      "dump": "PPSA23396-app0",
+      "scale": 4,
+      "timeout": 180,
+      "capture_after_seconds": 118,
+      "capture_before_seconds": 175,
+      "pad_script": "scripts/rugrats/reach-gameplay.pad",
+      "savedata_policy": "fresh",
+      "env": {},
+      "min_colors": 12000,
+      "min_qualifying_frames": 20,
+      "min_pixel_changes": 20,
+      "min_structural_similarity": 0.85,
+      "min_structural_matches": 20,
+      "min_content_match_ratio": 0.75,
+      "dims": [
+        480,
+        270
+      ],
+      "review": "Approved all 16 composited images from two independent runs on 2026-07-31. Every image is the first nursery level (BABIES IN GAMELAND) at 480x270: the pink nursery wall, the textured green carpet, the stacked multi-colour block platform, the expanding wooden playpen gate with its dark-red section and gold padlock, the orange curtain and daylit window, both babies (Tommy and Chuckie) with their animation, and both baby-bottle HUD icons -- fully composited, with no black regions, missing layers, or diagnostic-only output. The babies occupy visibly different gate heights and poses across all eight timestamps of each run and between the two runs, confirming a live progressing scene rather than a frozen frame; the window's 57 frames hold 33 and 34 distinct pixel CRCs while every consecutive pair differs, which is the repeating climb/jump cycle the route's Cross presses drive. Measured 17,256-17,565 distinct colours and 0.9976-0.9978 non-black coverage in all 57 window frames of both runs, identical in range across runs. Contrasting states measured on the same route: the GAME MODE menu reaches 56,090 colours, the BABIES IN GAMELAND title card is fully opaque at 1,551 colours, and the boot's black frames measure 1 colour at 0.0 coverage -- so min_colors=12000 and min_nonblack_ratio=0.4988 sit well below the reviewed gameplay range and well above every observed failure state.",
+      "_note": "Reviewed fresh-save guard for Rugrats: Adventure in Gameland's first nursery level (BABIES IN GAMELAND). Profiling the committed route once per second across the whole boot placed the level at 98s, so the evidence window opens at 118s -- twenty seconds later -- and runs to 175s, giving 57 samples entirely inside settled gameplay. Because min_content_match_ratio rejects a window once a quarter of its frames are off-scene, that start also tolerates the level arriving as late as roughly 132s before the guard can fail on healthy output. Colour count is deliberately ONE of five conjoined conditions (richness, non-black coverage, SSIM against reviewed luminance references, stable dimensions, frame-to-frame change) and must never become the contract on its own. This title demonstrates why with unusual clarity: the two richest frames in the entire run are the GAME MODE selector at 56,071-56,090 colours, which is 3.2x richer than the best gameplay frame in the run at 17,645, so a colour-only guard would rank a menu above every frame of the scene it is supposed to protect. Coverage alone fails symmetrically -- the BABIES IN GAMELAND level-title card and its fade score a full 1.0 non-black ratio at only 1,551-3,448 colours, and 54 frames of the run reach 0.999 coverage with as few as 1,551 colours.",
+      "structural_references": [
+        {
+          "luma16x9": "a5a3a6a6a6a6a6a6a6a6a6a69c8f8eb19d7d7383a5a3a5a3a5a3a2a4968887c877707a7b8d8d909d897c7e8e896894bea3736e8b888d8bab858a7888948498b220446f7489888a9a886f8092958f776b304a7d7584888488848676829192869a2a1a21577b787c777a787178807c74837e7e7c7e7d7d7f7b7e7b7e7f7f7e7e7e74757376767776757576767377767773",
+          "average_hash": "0000c4cc7c8cfdff",
+          "difference_hash": "a028381090505940"
+        },
+        {
+          "luma16x9": "a5a3a6a6a6a6a6a6a6a6a6a69c8f8eb19d7d7383a5a3a5a3a5a3a2a4968887c877707a7b8d8d93a589797d8e896894bea3736e8b888d89a2878a7b88948498b220446f7489888a9788738192958f776b304a7d7584888488848877829192869a2a1a21577b787c777a787178807c74837e7e7c7e7d7d7f7b7e7b7e7f7f7e7e7e74757376767776757576767377767773",
+          "average_hash": "0000c4cc7c8cfdff",
+          "difference_hash": "a028381090505940"
+        },
+        {
+          "luma16x9": "a5a3a6a6a6a6a6a6a6a6a6a69c8f8eb19d7d7383a5a3a5a3a5a3a2a4968887c877707a7b8d8d98bb897b7f8e896894bea3736e8b888d8a9d86867a88948498b220446f748988898a887f7e92958f776b304a7d7584888488848877829192869a2a1a21577b787c777a787178807c74837e7e7c7e7d7d7f7b7e7b7e7f7f7e7e7e74757376767776757576767377767773",
+          "average_hash": "0000c4dc5c8cfdff",
+          "difference_hash": "a028380090505940"
+        },
+        {
+          "luma16x9": "a5a3a6a6a6a6a6a6a6a6a6a69c8f8eb19d7d7383a5a3a5a2a5a3a2a4968887c877707a7b8d8d98c0887c7d8e896894bea3736e8b888d8b9b88817b88948498b220446f748988898988827e92958f776b304a7d7584888488848877829192869a2a1a21577b787c777a787178807c74837e7e7c7e7d7d7f7b7e7b7e7f7f7e7e7e74757376767776757576767377767773",
+          "average_hash": "0000c4dc4c8cfdff",
+          "difference_hash": "a028380090505140"
+        },
+        {
+          "luma16x9": "a5a3a6a6a6a6a6a6a6a6a6a69c8f8eb19d7d7383a5a3a5a7a59fa0a4968887c877707a7b8d8d95c1868c7b8e896894bea3736e8b888d8c9388717688948498b220446f748988898988878192958f776b304a7d7584888488848877829192869a2a1a21577b787c777a787178807c74837e7e7c7e7d7d7f7b7e7b7e7f7f7e7e7e74757376767776757576767377767773",
+          "average_hash": "0000c4dc4c9cfdff",
+          "difference_hash": "a028380098505140"
+        },
+        {
+          "luma16x9": "a5a3a6a6a6a6a6a6a6a6a6a69c8f8eb19d7d7383a5a3a5aaa59fa0a4968887c877707a7b8d8d94be868c7b8e896894bea3736e8b888d8c9388717688948498b220446f748988898988878192958f776b304a7d7584888488848877829192869a2a1a21577b787c777a787178807c74837e7e7c7e7d7d7f7b7e7b7e7f7f7e7e7e74757376767776757576767377767773",
+          "average_hash": "0000c4dc4c9cfdff",
+          "difference_hash": "a028380098505140"
+        },
+        {
+          "luma16x9": "a5a3a6a6a6a6a6a6a6a6a6a69c8f8eb19d7d7383a5a3a6b0a59b9fa4968887c877707a7b8d8d92b785867a8e896894bea3736e8b888d8b9289737988948498b220446f748988898988878692958f776b304a7d7584888488848877829192869a2a1a21577b787c777a787178807c74837e7e7c7e7d7d7f7b7e7b7e7f7f7e7e7e74757376767776757576767377767773",
+          "average_hash": "0000c4dc6c8cfdff",
+          "difference_hash": "a028380098505140"
+        },
+        {
+          "luma16x9": "a5a3a6a6a6a6a6a6a6a6a6a69c8f8eb19d7d7383a5a3a6b3a4969da4968887c877707a7b8d8d91b385897a8e896894bea3736e8b888d8b9189707988948498b220446f748988898988888692958f776b304a7d7584888488848877829192869a2a1a21577b787c777a787178807c74837e7e7c7e7d7d7f7b7e7b7e7f7f7e7e7e74757376767776757576767377767773",
+          "average_hash": "0000c4dc6c8cfdff",
+          "difference_hash": "a028380098505140"
+        },
+        {
+          "luma16x9": "a5a3a6a6a6a6a6a6a6a6a6a69c8f8eb19d7d7383a5a3a5a2a5a3a2a4968887c877707a7b8d8d98c0897b7d8e896894bea3736e8b888d8b9b88837b88948498b220446f748988898988817e92958f776b304a7d7584888488848877829192869a2a1a21577b787c777a787178807c74837e7e7c7e7d7d7f7b7e7b7e7f7f7e7e7e74757376767776757576767377767773",
+          "average_hash": "0000c4dc4c8cfdff",
+          "difference_hash": "a028380090505140"
+        },
+        {
+          "luma16x9": "a5a3a6a6a6a6a6a6a6a6a6a69c8f8eb19d7d7383a5a3a5aca59b9fa4968887c877707a7b8d8d93bb85867a8e896894bea3736e8b888d8c9289737988948498b220446f748988898988878692958f776b304a7d7584888488848877829192869a2a1a21577b787c777a787178807c74837e7e7c7e7d7d7f7b7e7b7e7f7f7e7e7e74757376767776757576767377767773",
+          "average_hash": "0000c4dc6c8cfdff",
+          "difference_hash": "a028380098505140"
+        },
+        {
+          "luma16x9": "a5a3a6a6a6a6a6a6a6a6a6a69c8f8eb19d7d7383a5a3a7b6a1939aa4968887c877707a7b8d8d91ae87897a8e896894bea3736e8b888d8a9189727a88948498b220446f748988898988898692958f776b304a7d7584888488848877829192869a2a1a21577b787c777a787178807c74837e7e7c7e7d7d7f7b7e7b7e7f7f7e7e7e74757376767776757576767377767773",
+          "average_hash": "0000c4dc7c8cfdff",
+          "difference_hash": "a028380098505140"
+        }
+      ],
+      "min_nonblack_ratio": 0.498796
     }
   ]
 }

--- a/prosper/tools/snapshot/snapshots.json
+++ b/prosper/tools/snapshot/snapshots.json
@@ -813,6 +813,112 @@
         }
       ],
       "min_nonblack_ratio": 0.498796
+    },
+    {
+      "name": "greak-gameplay",
+      "dump": "PPSA02849-app0",
+      "scale": 4,
+      "timeout": 250,
+      "capture_after_seconds": 150,
+      "capture_before_seconds": 240,
+      "pad_script": "scripts/greak/reach-gameplay.pad",
+      "savedata_policy": "fresh",
+      "env": {},
+      "min_colors": 20000,
+      "min_qualifying_frames": 30,
+      "min_pixel_changes": 30,
+      "min_structural_similarity": 0.85,
+      "min_structural_matches": 30,
+      "min_content_match_ratio": 0.75,
+      "min_nonblack_ratio": 0.9,
+      "dims": [
+        480,
+        270
+      ],
+      "review": "Approved all 16 composited images from two independent runs on 2026-07-31. Every image is the first level at 480x270: Greak on the cliff-edge platform, layered parallax pine forest receding into volumetric fog, the rock face and distant mountains, drifting snow particles, the circular portrait/health HUD top-left, and the ability indicators bottom-left and bottom-right -- fully composited, with no black regions, missing layers, letterbox bars, or diagnostic-only output. The character is airborne mid-jump in some frames and grounded in others, and its position and pose differ across all eight timestamps of each run and between the runs, confirming a live progressing scene; all 90 window frames of each run carry distinct pixel CRCs. Measured 32,057-43,167 distinct colours in run 1 and 32,125-43,067 in run 2, with non-black coverage of exactly 1.000000 in all 180 frames across both runs and not one frame below 0.95. Contrasting states measured on the same route: the letterboxed level-intro cinematic at 123-130s reaches 32,153 colours -- only 87 below this window's floor -- but is held to 0.6667 coverage by its bars, and the boot's black frames measure 1 colour at 0.0 coverage. min_colors=20000 is therefore a gross-collapse floor only, and min_nonblack_ratio=0.9 is the threshold that actually rejects the cinematic; its 10% margin is backed by 180 reviewed frames with zero observed variance.",
+      "_note": "Reviewed fresh-save guard for Greak: Memories of Azur's first level. Profiling the committed route once per second across a 255s boot placed the phases at: boot and logos to 45s, the hand-drawn intro cutscene 46-117s, a short dark transition 118-122s, a LETTERBOXED level-intro cinematic 123-130s, and full-screen gameplay from 131s to the end of the profile. The evidence window is 150-240s, about twenty seconds after gameplay begins, giving 90 samples entirely inside it; because min_content_match_ratio rejects a window once a quarter of its frames are off-scene, that start also tolerates gameplay arriving as late as roughly 172s. Note the documented 'roughly 70-second black asset load' did NOT appear as black frames on this host: 46-117s measured 18,685-61,886 colours at 0.99-1.0 coverage and is the intro cutscene, so do not treat that span as a hang. This title is the MIRROR IMAGE of rugrats-gameplay for threshold choice, and together they show why the contract must be conjoined. Here colour count is nearly useless as a scene discriminator: the letterboxed cinematic peaks at 32,153 colours while the gameplay floor is 32,240, a gap of only 87 colours (0.27%), so no sane min_colors can separate them. What separates them is COVERAGE -- the cinematic's letterbox bars hold it at 0.6667 while all 90 gameplay frames measure exactly 1.0000 -- plus SSIM. In Rugrats the reverse held: coverage was useless there (its title card is fully opaque at 1,551 colours) and colour count separated the scenes. min_colors is therefore set at 20,000 purely as a gross-collapse floor, not as a scene discriminator, and min_nonblack_ratio is deliberately raised to 0.9 rather than the tool-derived 0.5 so that a window drifting into the letterboxed cinematic fails on coverage instead of passing it.",
+      "structural_references": [
+        {
+          "luma16x9": "d2b5e4e8d2c7c1e0e9edead4c6ecc25bc1b8e6e5e3e2ded8ebece15f6aa5bb73f1efece9e8ebedefdeedab6288afb974efebe8e4e2e5b6f1bde5b77c9aa8b471ece8e4e1c0e27bd9aed58f87938fa375e8e4e1cb7bdd68a0a6a67d877d729a7dd6dbd7a994ab848694916c5750453c399e9b9e958046585b5a5b564e413c3b43a17e8e917e535964565058595a4d4b5b",
+          "average_hash": "000117171f1f1f7f",
+          "difference_hash": "57f67377a7aba6a6"
+        },
+        {
+          "luma16x9": "d3b5e4e9d1c5c0e1e9edead6cbedbe5ac1b8e6e4e3e2ddd8ebece25f69a8bb73f2efece9e8ebedeedfeda85e86afb874efebe8e4e2e6b9f2bae5b4799aa9b570ece8e4e1c3e27bd89cd58e86928fa474e8e4e2cc7ddd669da2a77b877d749b7cd8dcd8aa93b08897a99a705a53463f3c9f9da196804c697d7f705e50413c3b42a17e8d927d58627a67575c5a5a4c4b5b",
+          "average_hash": "000117171f1f1f7f",
+          "difference_hash": "77f67377a7aba6a6"
+        },
+        {
+          "luma16x9": "d3b5e4e9d1c5c0e1e8edead7cceebc5ac1b8e6e4e3e2ddd8ecece2606aa9bb73f2efece9e8ebedeedfeda75e86afb774efebe8e4e2e6baf2bae6b3799aa9b570ece8e4e1c4e27bd99dd58d86938fa473e8e5e2cb7edd659da2a67b877d749c7bd9dcd9aa92b18898a99a715a5346403c9f9ea1967f4c697d7f715e50413c3b42a17e8d927c58627b67585c5a5a4c4a5b",
+          "average_hash": "000117171f1f1f7f",
+          "difference_hash": "77f67377a7bba6a6"
+        },
+        {
+          "luma16x9": "d2b5e4e8d2c7c1e0e9edead3c6edbe5cc1b8e6e5e3e2ded8ebecdf5b6ba7b973f1efece9e8ecedefdeeda66088b0b773efebe7e4e3e6b6f2b8e6b27a9aa8b46fece8e4e1c0e279d79cd58986928ea473e8e4e1c97ddc669da4a57d877c729c7bd6dbd7a894ab8696a7986e5851453b399e9b9e957d4d697d7d6f5d50423d3b43a17e8e927c59627966585d5b5b4c4b5b",
+          "average_hash": "000117171f1f1f7f",
+          "difference_hash": "77f67377a7aba6a6"
+        },
+        {
+          "luma16x9": "d2b5e4e8d2c9c1e0e9edead0c2edbf5dc2b8e7e5e4e3dfd9ebecdc596ca6b874f1efece9e8ebedefdceda5628ab0b773efebe7e4e2e5b3f1b7e5b17b9aa8b36eece8e4e1bde277d59cd48687918da472e7e4e1c77ddb679da5a37f877c709a7bd4dad6a796a78494a6966c574f453a369d999c957b4d697d7b6e5d50423d3c43a17e8e917c5a637866585d5c5b4d4c5c",
+          "average_hash": "000117171f1f1f7f",
+          "difference_hash": "77f67377a7aba6a6"
+        },
+        {
+          "luma16x9": "d0b5e3e6d5d0c5deebeceac3b2e7c260c3b9e8e6e6e4e1dbebecd3516fa4b475f1efebe8e7ebeaf1d8eca5678eb0b871eeeae6e3e1e5a8efb1e4ae7e9aa5b16debe7e4e0b1e172cf9bcf7d878f8aa271e6e3e1c17cd86e9daaa2858375688e73cbd4d2a499978090a18f67544d4438359b939693764d677b75695a4f453e3e45a1808f917e5d6476665a5f5f5d4f4f5e",
+          "average_hash": "000017171f1f1f7f",
+          "difference_hash": "77f6f377a7afaea6"
+        },
+        {
+          "luma16x9": "cfb4e2e5d6d3c7ddececeabbaae3c262c3bae9e6e7e4e3dceaecce4f71a4b275f1eeebe8e7eae9f1d5eca56990b0b871eeeae6e3e1e4a2eeaee4ad7f9aa3b06cebe7e4deace16fcc9acb79878e88a272e6e3e0bd7cd6739fada387807164886fc7d1cfa398907c8d9e8b65544c4337349a909393764e657b7266574f463e3f47a1808f917f5e6575655b60615e50505e",
+          "average_hash": "000003171f1f1f7f",
+          "difference_hash": "5777f377a7afaea6"
+        },
+        {
+          "luma16x9": "cfb5e2e5d7d3c7ddececeabba9e3c262c4bae9e6e7e4e3ddeaeccd4f71a4b275f1eeebe8e7eae8f1d5eca56990b0b870eeeae6e3e1e4a1eeaee4ad7f9aa3af6cebe7e4deabe16fcb9acb78878f88a271e6e3e0bd7cd6739fada3877f7164886fc7d1cfa3988f7c8b9e8b65544b4337349a909393764d657b7266574f463f3f47a1808f917f5f6575665c60625e50505f",
+          "average_hash": "000003171f1f1f7f",
+          "difference_hash": "5777f377a7afaea6"
+        },
+        {
+          "luma16x9": "d2b5e4e8d2c7c1e0e9edead4c6ecc25bc1b8e6e5e4e2ded8ebece15e6aa5bb73f2efece9e8ebedefdeedab6288afb974efebe7e4e2e5b6f1bde5b77c9aa8b471ece8e4e1c0e27bd9aed58f87928ea375e8e4e1cb7bdd68a0a4a67d877d719a7dd6dbd7a994ab848793916c5750453b399e9b9e957f46585c5a5b564e413c3b43a17e8e917e535964575058595a4d4b5b",
+          "average_hash": "000117171f1f1f7f",
+          "difference_hash": "57f67377a7aba6a6"
+        },
+        {
+          "luma16x9": "d3b5e4e9d1c6c0e0e9edead6cbedbf5ac1b8e6e4e3e2ddd8ecece26069a8bc73f2efece9e8ebedeedfeda95e86afb874efece8e4e2e6b9f2bae5b4799aa9b570ece8e4e1c3e27bd89dd58e86928fa474e8e5e2cb7ddd669da3a77b877d749b7cd8dcd8aa93b08897aa9a705a52463e3b9f9da096804c697d7e705e50423c3b42a17e8d927d58627a67575c5a5a4c4b5b",
+          "average_hash": "000117171f1f1f7f",
+          "difference_hash": "77f67377a7aba6a6"
+        },
+        {
+          "luma16x9": "d3b5e4e9d1c6c0e0e9edead6cbedbe5bc1b8e6e4e3e2ddd8ecece15e6aa9bb73f1efece9e8ebedefdfeda75f87b0b874efebe8e4e2e6b9f2bae5b3799aa9b570ece8e4e1c2e27ad89dd58c86928fa473e8e4e2cb7ddd669da3a67c877d749b7bd8dcd8a993b08797a899705a52463f3c9f9da0967f4c697d7f705e50413c3b42a17e8d927d58627a67585c5b5b4c4b5b",
+          "average_hash": "000117171f1f1f7f",
+          "difference_hash": "77f67377a7bba6a6"
+        },
+        {
+          "luma16x9": "d2b5e4e8d2c7c1e0e9edead3c6edbe5cc1b8e6e5e3e2ded8ebecdf5b6ba7b973f1efece9e8ebedefdeeda66088b0b773efebe7e4e2e6b6f2b8e5b27a9aa8b46fece8e4e1c0e279d79cd58986928ea473e8e4e1c97ddc669da4a57d877c729c7bd6dbd7a894ab8696a8986e5851453b399e9b9e957d4d697d7d6f5d50423d3b43a17e8e927c59627966585d5b5b4d4b5b",
+          "average_hash": "000117171f1f1f7f",
+          "difference_hash": "77f67377a7aba6a6"
+        },
+        {
+          "luma16x9": "d2b5e4e8d2c9c1e0e9edead0c3edbe5cc2b8e7e5e4e3dfd9ebecdd596ca7b874f1efece9e8ecedefddeda5628ab0b773efebe7e4e2e5b3f1b7e5b17b9aa8b46eece8e4e1bee277d59cd48787918ea472e7e4e1c77ddb679da5a47f877c709a7ad4dad6a795a78595a5966d574f453a369e999d957b4d697d7c6e5d50423d3c43a17e8e927c5a637966585d5c5b4d4c5c",
+          "average_hash": "000117171f1f1f7f",
+          "difference_hash": "77f67377a7bba6a6"
+        },
+        {
+          "luma16x9": "d1b5e3e7d3ccc3dfeaedeacbbbeac15ec2b9e8e5e5e3e0d9ebecd8556da5b674f1efece8e8ebecf0daeca5648bb0b772eeebe7e3e2e5aef1b4e5b07c9aa6b26eece8e4e0b8e275d29bd28287918ca372e7e4e1c47cda6a9da8a38286796c9477d0d7d4a6989f8292a49369554e4539359c969994794d687c786c5c4f433d3d44a17f8f917d5b637866595d5e5c4e4d5d",
+          "average_hash": "000017171f1f1f7f",
+          "difference_hash": "77f6f377a7abaea6"
+        },
+        {
+          "luma16x9": "d0b5e3e6d5d0c5deebeceac4b2e7c260c3b9e8e6e6e4e1dbebecd3516fa4b475f1efebe8e7ebeaf1d8eca5678eb0b871eeeae7e3e1e5a8efb1e4ae7e9ba5b16debe7e4e0b2e172cf9bcf7d87908aa271e6e3e1c17cd86e9daaa3858375688e73ccd4d2a49997808fa18f67544d4438359b939693774d677b75695a4f453e3e45a1808f917e5d6476665a5f5f5d4f4f5e",
+          "average_hash": "000017171f1f1f7f",
+          "difference_hash": "77f6f377a7afaea6"
+        },
+        {
+          "luma16x9": "cfb5e2e5d7d3c7ddececeabba9e3c362c4bae9e6e7e4e3ddeaecce4f71a4b275f1eeebe8e7eae8f1d5eca66990b0b870eeeae6e3e1e4a1eeaee3ad7f9aa3af6cebe7e4deabe16fcb9acb79878e88a271e6e3e0bd7cd6739faca3877f7164886fc7d1cfa3988f7c8b9e8b65544b4337349a909393764d657b7266574f463f3f47a1808f917f5f6575665c60625e51505f",
+          "average_hash": "000003171f1f1f7f",
+          "difference_hash": "5777f377a7afaaa6"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Purpose

Three related changes:

1. **`greak-gameplay` snapshot guard** — takes **Greak: Memories of Azur (`PPSA02849`) to rung 6**, the third title to be considered done.
2. **`tools/snapshot/AGENTS.md`** — the two-title mirror table that finally *demonstrates* why the content contract must be conjoined, plus the transferable corollary.
3. **`COMPATIBILITY.md`** — corrects a wrong symptom in the Greak entry.

## The guard

Route `scripts/greak/reach-gameplay.pad` (already committed, unmodified), fresh save, scale 4, window **150–240 s**, `dims [480,270]`, `min_colors` 20,000, `min_qualifying_frames` 30, `min_pixel_changes` 30, SSIM ≥ 0.85 with `min_structural_matches` 30, `min_content_match_ratio` 0.75, and **`min_nonblack_ratio` 0.9**.

**`verify`: CONTENT-STABLE** — both runs 90/90 qualifying, 89/89 consecutive changes, colours 32,057–43,167 and 32,125–43,067, all 90 frames per run distinct by CRC.

**`check`: OK** — frames 90, qualifying 90, richest 43,280, pixel_changes 89, structural_matches 90, nonblack_matches 90.

All 16 retained images from both runs were opened and inspected: Greak on the cliff-edge platform, parallax pines into volumetric fog, rock face, distant mountains, drifting snow, portrait/health HUD and ability indicators — airborne in some frames, grounded in others.

## Why this title needed a different threshold — and why that is the interesting part

Greak is the **exact mirror of Rugrats**, and the pair is worth more than either guard.

| title | colour count | coverage |
|---|---|---|
| **Rugrats** (`PPSA23396`) | separates cleanly — menu 56,090 vs gameplay 17,645 | **blind** — title card is fully opaque at 1,551 colours |
| **Greak** (`PPSA02849`) | **blind** — 87-colour gap (0.27%) between cinematic peak 32,153 and gameplay floor 32,240 | separates cleanly — 0.6667 letterboxed vs 1.0000 |

Neither title alone proves the contract must be conjoined. **The pair proves it by demonstration**, with the two metrics failing in opposite roles.

That is why `min_nonblack_ratio` is **0.9** here rather than the tool-derived 0.5. The adjacent failure mode is drifting into the letterboxed level cinematic at 0.6667 coverage, and `min_colors` provably cannot catch it — so coverage has to, and 0.5 would have let the guard pass the very thing it exists to reject.

**The threshold is validated, not assumed:** all **180 frames across both verify runs measured exactly 1.000000**, none below 0.95, so the 10% margin sits against a metric with zero observed variance. It also survived `update --reviewed` (the tool's `setdefault` left it alone).

The transferable rule now in `AGENTS.md`: **when the usual discriminator goes blind, the other threshold must carry the load and be set for that job rather than from the generic formula.**

## Documentation correction

`COMPATIBILITY.md` claimed Greak has "a roughly 70-second black asset-loading phase following the intro". **That is wrong on current master.** The 46–117 s span is the intro **cutscene**, measured at 18,685–61,886 colours and 0.99–1.0 coverage, confirmed by opening frames rather than trusting a metric.

The useful half of the warning is kept — an early window still lands in non-gameplay content — but the entry no longer tells the next agent to expect black frames that do not occur. A doc predicting the wrong symptom is worse than silence, because it invites exactly the misreading it was written to prevent.

## A refinement to the squash-merge note already in the record

The merge was predicted to be trivial because master's `snapshots.json` was **byte-identical** to the branch HEAD. **It conflicted anyway.**

The squash-merge gave the two sides unrelated history for that file, so git could not see that both already contained the same Rugrats entry. **Identical content does not prevent a conflict, because git merges by history, not by content.** The content check tells you a resolution is *safe*; it does not tell you the merge will be *clean*.

The conflict was purely additive and was not resolved by assumption: only the three marker lines were dropped, then it was verified programmatically that zero master entries were altered and exactly one was added, and `check` was re-run on the merged tree.

**Independently confirmed by the integrator**: master carries 10 entries, this branch carries the same 10 plus `greak-gameplay`.

## Explicitly NOT included — three routes remain unvalidated

**New Joe & Mac (`PPSA02801`), Asterix: Slap Them All (`PPSA08576`) and Summer Sports Games (`PPSA03416`) have no committed route and none was ever run.**

Draft `.pad` files exist but are deliberately parked **outside the repository** so they cannot be mistaken for validated routes. They are guesses extrapolated from the Alex Kidd and Rugrats press patterns — a starting point, not evidence. Committing a route that has never produced its claimed state would be worse than committing none, because the next agent would trust it.

## Verification

`git diff --check` clean. Three files, +151/−9. No host paths.
