### PR TITLE
test(infra): give every test its own scratch directory off the tmpfs (#1613)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ eboot.bin
 *.prgtl
 
 # ---- Build output ----
+# tests/test_scratch.h fallback root when a test binary is run by hand outside ctest.
+prosper-test-scratch/
 /prosper/build/
 build/
 build-*/

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -1429,3 +1429,24 @@ if(TARGET prosper_live_renderer AND TARGET prosper_core)
   target_link_libraries(test_present_blit PRIVATE prosper_live_renderer prosper_core Vulkan::Vulkan)
   add_test(NAME present_blit COMMAND test_present_blit)
 endif()
+
+# ---------------------------------------------------------------------------
+# Per-case scratch directory for every registered test (#1613).
+#
+# Tests that must touch the real filesystem take their paths from
+# tests/test_scratch.h, which reads PROSPER_TEST_SCRATCH_DIR. Giving each ctest
+# *case* its own root is what makes `ctest -j` safe: one test binary is
+# sometimes registered as several cases (game_compute_exec and
+# game_compute_exec_no_adaptive_storage_result are the same executable), so
+# per-binary uniqueness is not enough. The helper adds a pid component
+# underneath, which separates concurrent ctest invocations from different
+# worktrees. The root is inside the build directory, never /tmp — see the
+# header for why that matters on this machine.
+#
+# This must stay at the very end of the file: it snapshots the DIRECTORY TESTS
+# property, so any add_test() below it would not be covered.
+get_property(prosper_registered_tests DIRECTORY PROPERTY TESTS)
+foreach(prosper_test_case IN LISTS prosper_registered_tests)
+  set_property(TEST ${prosper_test_case} APPEND PROPERTY ENVIRONMENT
+    "PROSPER_TEST_SCRATCH_DIR=${CMAKE_CURRENT_BINARY_DIR}/test-scratch/${prosper_test_case}")
+endforeach()

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -1444,7 +1444,11 @@ endif()
 # header for why that matters on this machine.
 #
 # This must stay at the very end of the file: it snapshots the DIRECTORY TESTS
-# property, so any add_test() below it would not be covered.
+# property, so any add_test() below it would not be covered. A test that did get
+# missed still fails safe rather than silently — test_scratch.h falls back to
+# <cwd>/prosper-test-scratch/, and ctest's working directory is this same build
+# directory, so it lands off the tmpfs either way; it merely loses the per-case
+# split (the pid component still separates concurrent processes).
 get_property(prosper_registered_tests DIRECTORY PROPERTY TESTS)
 foreach(prosper_test_case IN LISTS prosper_registered_tests)
   set_property(TEST ${prosper_test_case} APPEND PROPERTY ENVIRONMENT

--- a/prosper/tests/test_file_binary.cpp
+++ b/prosper/tests/test_file_binary.cpp
@@ -251,10 +251,14 @@ int main() {
 #ifndef _WIN32
     // WSL's /mnt/c metadata bridge reports synthetic permission bits. Verify exact POSIX chmod
     // behavior on a unique native-filesystem fixture while retaining /app0 translation above.
-    // Deliberately NOT tests/test_scratch.h (#1613): the point of this fixture is the *native*
-    // temporary filesystem's metadata semantics, and under WSL the build directory is the /mnt/c
-    // mount whose bridge is what this checks against. mkstemp already makes the name unique, and
-    // the file is empty, so neither the tmpfs quota nor a concurrent ctest case is exposed here.
+    // Deliberately NOT tests/test_scratch.h (#1613). What this fixture needs is a filesystem that
+    // keeps real POSIX metadata, and under WSL the build directory is the /mnt/c mount whose bridge
+    // is exactly what it guards against — routing it through the scratch helper would break it
+    // there unconditionally. mkstemp already makes the name unique and the file is empty, so
+    // neither the tmpfs quota nor a concurrent ctest case is exposed.
+    // Caveat: temp_directory_path() honors TMPDIR, so pointing TMPDIR at a metadata-lossy mount
+    // does reach this fixture. That is fail-visible (the assertions below fail; they cannot
+    // silently pass), which is why it is left as a caveat rather than pinned to a literal path.
     std::string mode_path =
         (std::filesystem::temp_directory_path() / "prosper-test-chmod-mode-XXXXXX").string();
     const int mode_fd = ::mkstemp(mode_path.data());

--- a/prosper/tests/test_file_binary.cpp
+++ b/prosper/tests/test_file_binary.cpp
@@ -251,6 +251,10 @@ int main() {
 #ifndef _WIN32
     // WSL's /mnt/c metadata bridge reports synthetic permission bits. Verify exact POSIX chmod
     // behavior on a unique native-filesystem fixture while retaining /app0 translation above.
+    // Deliberately NOT tests/test_scratch.h (#1613): the point of this fixture is the *native*
+    // temporary filesystem's metadata semantics, and under WSL the build directory is the /mnt/c
+    // mount whose bridge is what this checks against. mkstemp already makes the name unique, and
+    // the file is empty, so neither the tmpfs quota nor a concurrent ctest case is exposed here.
     std::string mode_path =
         (std::filesystem::temp_directory_path() / "prosper-test-chmod-mode-XXXXXX").string();
     const int mode_fd = ::mkstemp(mode_path.data());
@@ -311,6 +315,7 @@ int main() {
 #else
     // The source tree can live on WSL's /mnt/c mount, whose metadata bridge truncates subsecond
     // timestamps. Exercise microsecond preservation on the native temporary filesystem instead.
+    // Deliberately NOT tests/test_scratch.h — see the chmod fixture above for why (#1613).
     std::string precision_path =
         (std::filesystem::temp_directory_path() / "prosper-test-utimes-precision-XXXXXX").string();
     const int precision_fd = ::mkstemp(precision_path.data());

--- a/prosper/tests/test_game_compute.cpp
+++ b/prosper/tests/test_game_compute.cpp
@@ -5,6 +5,7 @@
 #include "../src/host/guest_write_watch.hpp"
 #include "live_compute.hpp"
 #include "seed_reprove.hpp"
+#include "test_scratch.h"
 
 #include <algorithm>
 #include <array>
@@ -973,9 +974,13 @@ int main() {
     constexpr uint32_t kGdsPostSubmitSentinel = 0xfedcba98u;
     std::memcpy(gds_initial.data(), &kGdsPreSubmitSentinel,
                 sizeof(kGdsPreSubmitSentinel));
+    // Per-process path: this binary runs as two concurrent ctest cases, so a fixed name made both
+    // read back the other run's bytes (#1613).
+    const std::string deferred_gds_capture_path =
+        prosper_test::test_scratch_file("prosper_deferred_gds_capture.prgcap");
     auto deferred_gds_pending = std::make_unique<PendingGpuCapture>();
     deferred_gds_pending->materialized = false;
-    deferred_gds_pending->path = "/tmp/prosper_deferred_gds_capture.prgcap";
+    deferred_gds_pending->path = deferred_gds_capture_path;
     snapshot_pending_gpu_capture_compute_gds(
         deferred_gds_pending.get(), gds_initial.data(), gds_initial.size());
     std::memcpy(gds_initial.data(), &kGdsPostSubmitSentinel,
@@ -989,7 +994,7 @@ int main() {
     GpuCaptureFile deferred_gds_capture;
     GpuReplayFrame deferred_gds_replay;
     const bool deferred_gds_reopened = read_gpu_capture(
-        "/tmp/prosper_deferred_gds_capture.prgcap", deferred_gds_capture, gds_error) &&
+        deferred_gds_capture_path, deferred_gds_capture, gds_error) &&
         materialize_gpu_replay(deferred_gds_capture, deferred_gds_replay, gds_error);
     const uint32_t* deferred_gds_words = deferred_gds_reopened &&
         !deferred_gds_replay.computes.empty() &&
@@ -1000,7 +1005,7 @@ int main() {
             : nullptr;
     CHECK(deferred_gds_words && deferred_gds_words[0] == kGdsPreSubmitSentinel,
           "deferred capture replay restores pre-submit persistent GDS, not post-submit bytes");
-    std::remove("/tmp/prosper_deferred_gds_capture.prgcap");
+    std::remove(deferred_gds_capture_path.c_str());
     gds_initial.fill(0);
     CHECK(capture_submit_items({}, {gds_first, gds_second}, gds_operations, gds_metadata,
                                [](uint64_t, uint8_t*, size_t) { return size_t{0}; },

--- a/prosper/tests/test_gpu_capture.cpp
+++ b/prosper/tests/test_gpu_capture.cpp
@@ -11,6 +11,7 @@
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#include "test_scratch.h"
 
 using namespace prosper::gpu;
 namespace P = prosper::agc::Pm4;
@@ -852,7 +853,7 @@ int main() {
     captured.ds_seeds.push_back(ds_seed);
     captured.draws[0].vrt.resources[0].resource.depth = 7;
 
-    auto path = std::filesystem::temp_directory_path() / "prosper_gpu_capture_test.prgcap";
+    auto path = prosper_test::test_scratch_dir() / "prosper_gpu_capture_test.prgcap";
     GpuCaptureFile duplicate_seed = captured; duplicate_seed.rtt_seeds.push_back(captured.rtt_seeds[0]);
     CHECK(!write_gpu_capture(path.string(), duplicate_seed, error) && error == "duplicate RTT seed address",
           "writer rejects duplicate temporal RTT seed addresses");
@@ -1168,7 +1169,7 @@ int main() {
           "replay resources point into shared owned backing at captured offsets");
     CHECK(replay.expected_output_valid && replay.expected_output_hash == captured.expected_output_hash,
           "expected render oracle round-trips");
-    const auto no_oracle_path = std::filesystem::temp_directory_path() /
+    const auto no_oracle_path = prosper_test::test_scratch_dir() /
         "prosper_gpu_capture_no_oracle_test.prgcap";
     auto no_oracle_pending = std::make_unique<PendingGpuCapture>();
     no_oracle_pending->path = no_oracle_path.string();
@@ -1257,7 +1258,7 @@ int main() {
     CHECK(mixed.failure_diagnostics_available && mixed.failure_diagnostics.size() == 1 &&
           mixed.failure_diagnostics[0].reason == RealizationFailureReason::Unknown,
           "pre-realized capture inputs label an unexplained omission explicitly");
-    const auto mixed_path = std::filesystem::temp_directory_path() / "prosper_gpu_capture_mixed_test.prgcap";
+    const auto mixed_path = prosper_test::test_scratch_dir() / "prosper_gpu_capture_mixed_test.prgcap";
     CHECK(write_gpu_capture(mixed_path.string(), mixed, error), "mixed versioned capture writes");
     GpuCaptureFile mixed_loaded;
     CHECK(read_gpu_capture(mixed_path.string(), mixed_loaded, error) &&
@@ -1563,7 +1564,7 @@ int main() {
     // Live one-shot capture receives the already-realized backend list as well as the original
     // semantic state. A failed operation is necessarily absent from that backend list, but must not
     // lose the exact reason/program/pipeline that the semantic realization can still diagnose.
-    request_interactive_gpu_capture("/tmp/prosper_semantic_failure_diagnostic.prgcap");
+    request_interactive_gpu_capture(prosper_test::test_scratch_file("prosper_semantic_failure_diagnostic.prgcap"));
     auto semantic_failure_pending = begin_requested_gpu_capture(
         {}, {}, plan_submit_operations(failed_state), 640, 360, &failed_state, 101,
         failed_state.draws.size());
@@ -1647,7 +1648,7 @@ int main() {
     set_test_env("PROSPER_GPU_CAPTURE_AT", nullptr);
     set_test_env("PROSPER_GPU_CAPTURE", nullptr);
 
-    const auto failed_path = std::filesystem::temp_directory_path() /
+    const auto failed_path = prosper_test::test_scratch_dir() /
         "prosper_gpu_capture_failed_diagnostic_test.prgcap";
     failed_capture.failure_diagnostics[0].pipeline.cb_resolve = true;
     // NGG draws can have a separately allocated vertex prolog and vertex main.  A failed capture
@@ -2039,7 +2040,7 @@ int main() {
     one_shot_ds_draw.ps.stencil_read_base = ds_seed.stencil_read_base;
     one_shot_ds_draw.ps.stencil_write_base = ds_seed.stencil_write_base;
     one_shot_ds_draw.ps.htile_data_base = ds_seed.htile_data_base;
-    request_interactive_gpu_capture("/tmp/prosper_interactive_ds_checkpoint.prgcap");
+    request_interactive_gpu_capture(prosper_test::test_scratch_file("prosper_interactive_ds_checkpoint.prgcap"));
     auto one_shot_ds_pending = begin_requested_gpu_capture(
         {one_shot_ds_draw}, {}, {{SubmitOperationKind::Draw, 0, 0}}, 2, 2);
     CHECK(one_shot_ds_pending && one_shot_ds_pending->capture.ds_seeds.size() == 1 &&
@@ -2077,7 +2078,7 @@ int main() {
     // Not armed + no env => begin_requested is inert, even with drawing work present.
     { DrawItem d; CHECK(begin_requested_gpu_capture({d}, {}, {}, 64, 64) == nullptr,
                         "no capture when neither env nor interactive is set"); }
-    request_interactive_gpu_capture("/tmp/prosper_interactive_grab.prgcap");
+    request_interactive_gpu_capture(prosper_test::test_scratch_file("prosper_interactive_grab.prgcap"));
     CHECK(interactive_gpu_capture_armed(), "request_interactive_gpu_capture arms a one-shot grab");
     // A ZERO-draw invocation must NOT consume the arm (the grab should land on real frame content).
     (void)begin_requested_gpu_capture({}, {}, {}, 64, 64);
@@ -2087,7 +2088,7 @@ int main() {
     { DrawItem d; (void)begin_requested_gpu_capture({d}, {}, {}, 64, 64); }
     CHECK(!interactive_gpu_capture_armed(), "a drawing invocation consumes the armed grab (one-shot)");
     // Re-arming and re-disarming works (a second press).
-    request_interactive_gpu_capture("/tmp/prosper_interactive_grab2.prgcap");
+    request_interactive_gpu_capture(prosper_test::test_scratch_file("prosper_interactive_grab2.prgcap"));
     CHECK(interactive_gpu_capture_armed(), "the grab can be re-armed for a subsequent press");
     { DrawItem d; (void)begin_requested_gpu_capture({d}, {}, {}, 64, 64); }
     CHECK(!interactive_gpu_capture_armed(), "the re-armed grab is consumed by the next drawing invocation");

--- a/prosper/tests/test_gpu_capture_bundle.cpp
+++ b/prosper/tests/test_gpu_capture_bundle.cpp
@@ -7,6 +7,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iterator>
+#include "test_scratch.h"
 
 using namespace prosper::gpu;
 
@@ -17,7 +18,7 @@ static int fails = 0;
 int main() {
     std::printf("== test_gpu_capture_bundle ==\n");
     const auto nonce = std::chrono::steady_clock::now().time_since_epoch().count();
-    const auto path = std::filesystem::temp_directory_path() /
+    const auto path = prosper_test::test_scratch_dir() /
         ("prosper-gpu-bundle-" + std::to_string(nonce) + ".prgbundle");
     const auto corrupt_path = path.string() + ".corrupt";
 
@@ -238,14 +239,14 @@ int main() {
     CHECK(!interactive_capture_bundle_active(), "frame-bundle grab is inert by default");
     record_gpu_timeline_present(1, 0, 0, 1920, 1080);
     CHECK(!interactive_capture_bundle_active(), "a present with no armed grab stays inert");
-    request_interactive_capture_bundle("/tmp/prosper_frame_grab_unit.prgbundle");
+    request_interactive_capture_bundle(prosper_test::test_scratch_file("prosper_frame_grab_unit.prgbundle"));
     CHECK(interactive_capture_bundle_active(), "F9 arms a whole-frame grab");
     record_gpu_timeline_present(2, 0, 0, 1920, 1080);   // start capturing the next frame
     CHECK(interactive_capture_bundle_active(), "the next present starts the frame (still active)");
     record_gpu_timeline_present(3, 0, 0, 1920, 1080);   // end the frame (no submits captured here)
     CHECK(!interactive_capture_bundle_active(),
           "the following present ends the frame and disarms (no re-arm)");
-    request_interactive_capture_bundle("/tmp/prosper_frame_grab_unit2.prgbundle");
+    request_interactive_capture_bundle(prosper_test::test_scratch_file("prosper_frame_grab_unit2.prgbundle"));
     CHECK(interactive_capture_bundle_active(), "the grab can be re-armed for another press");
     record_gpu_timeline_present(4, 0, 0, 1920, 1080);
     record_gpu_timeline_present(5, 0, 0, 1920, 1080);
@@ -254,7 +255,7 @@ int main() {
     // Persistent depth/stencil images can predate the captured frame (for example a shadow-atlas
     // cascade retained from the previous frame). F9 must snapshot them at the capture boundary and
     // attach them to the first submit so bundle replay does not start those planes at zero (#1307).
-    const auto ds_bundle_path = std::filesystem::temp_directory_path() /
+    const auto ds_bundle_path = prosper_test::test_scratch_dir() /
         ("prosper-f9-ds-seed-" + std::to_string(nonce) + ".prgbundle");
     unsigned ds_snapshots = 0;
     set_gpu_capture_ds_seed_snapshot_reader(

--- a/prosper/tests/test_gpu_capture_render.cpp
+++ b/prosper/tests/test_gpu_capture_render.cpp
@@ -15,6 +15,7 @@
 #include <string>
 #include <vector>
 #include <vulkan/vulkan.h>
+#include "test_scratch.h"
 
 using namespace prosper::gpu;
 
@@ -232,7 +233,7 @@ int main() {
 
     {
         const auto nonce = std::chrono::steady_clock::now().time_since_epoch().count();
-        const std::filesystem::path dump_dir = std::filesystem::temp_directory_path() /
+        const std::filesystem::path dump_dir = prosper_test::test_scratch_dir() /
             ("prosper-rtgroup-rgba8-" + std::to_string(nonce));
         std::filesystem::create_directories(dump_dir);
         set_env("PROSPER_FRAME_DIR", dump_dir.string());

--- a/prosper/tests/test_gpu_execute.cpp
+++ b/prosper/tests/test_gpu_execute.cpp
@@ -10,6 +10,7 @@
 #include "../src/hle/dispatch.hpp"
 #include "../src/host/guest_write_watch.hpp"
 #include "render_runner.h"
+#include "test_scratch.h"
 #include <algorithm>
 #include <cstdio>
 #include <cstdint>
@@ -660,7 +661,7 @@ int main() {
             reinterpret_cast<uint64_t>(consumed_args),
             reinterpret_cast<uint64_t>(generated_args), sizeof(consumed_args), 0, 100, 0});
         const std::filesystem::path capture_path =
-            std::filesystem::temp_directory_path() /
+            prosper_test::test_scratch_dir() /
             "prosper_dma_indirect_draw_capture.prgcap";
         std::error_code capture_filesystem_error;
         std::filesystem::remove(capture_path, capture_filesystem_error);
@@ -802,7 +803,7 @@ int main() {
         unresolved_dispatch.command_order = 19;
         nonrender.dispatches.push_back(unresolved_dispatch);
         const std::filesystem::path path =
-            std::filesystem::temp_directory_path() / "prosper_nonrender_submit_capture.prgcap";
+            prosper_test::test_scratch_dir() / "prosper_nonrender_submit_capture.prgcap";
         std::error_code filesystem_error;
         std::filesystem::remove(path, filesystem_error);
 #ifdef _WIN32

--- a/prosper/tests/test_gpu_timeline.cpp
+++ b/prosper/tests/test_gpu_timeline.cpp
@@ -11,6 +11,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include "test_scratch.h"
 #ifndef _WIN32
 #include <sys/wait.h>
 #endif
@@ -93,7 +94,7 @@ static GpuState selector_submit(
 
 static int run_selector_env_child(const std::string& mode) {
     const auto nonce = std::chrono::steady_clock::now().time_since_epoch().count();
-    const auto base = std::filesystem::temp_directory_path() /
+    const auto base = prosper_test::test_scratch_dir() /
         ("prosper-gpu-timeline-selector-" + mode + "-" + std::to_string(nonce));
     const std::string timeline_path = base.string() + ".prgtl";
     const std::string capture_path = base.string() + ".prgcap";
@@ -462,7 +463,7 @@ int main(int argc, char** argv) {
     CHECK(run_self(argv[0], "after-submit-zero") == 0,
           "cross-submit compute gate retains a submit-zero arm for a later submit-one capture");
     const auto nonce = std::chrono::steady_clock::now().time_since_epoch().count();
-    const auto base = std::filesystem::temp_directory_path() /
+    const auto base = prosper_test::test_scratch_dir() /
         ("prosper-gpu-timeline-" + std::to_string(nonce));
     const auto good = base.string() + ".prgtl";
     const auto truncated = base.string() + "-truncated.prgtl";

--- a/prosper/tests/test_guest_log_capture.cpp
+++ b/prosper/tests/test_guest_log_capture.cpp
@@ -11,6 +11,7 @@
 #include <string>
 #include <thread>
 #include <vector>
+#include "test_scratch.h"
 #ifdef _WIN32
 #include <io.h>
 #else
@@ -50,7 +51,7 @@ static int stream_fd(FILE* stream) {
 int main() {
     std::printf("== test_guest_log_capture ==\n");
     const auto nonce = std::chrono::steady_clock::now().time_since_epoch().count();
-    const auto bundle_path = std::filesystem::temp_directory_path() /
+    const auto bundle_path = prosper_test::test_scratch_dir() /
         ("prosper-guest-log-capture-" + std::to_string(nonce) + ".prgbundle");
 
     clear_test_env("PROSPER_CAPTURE_BUNDLE_AT_PRESENT");

--- a/prosper/tests/test_ime_input.cpp
+++ b/prosper/tests/test_ime_input.cpp
@@ -15,6 +15,7 @@
 #include <fstream>
 #include <string>
 #include <vector>
+#include "test_scratch.h"
 
 using namespace prosper;
 
@@ -42,7 +43,7 @@ static void fake_handler(uint64_t arg, void* ev) {
 int main() {
     printf("== test_ime_input ==\n");
     const std::filesystem::path script_path =
-        std::filesystem::temp_directory_path() / "prosper_test_ime_input.route";
+        prosper_test::test_scratch_dir() / "prosper_test_ime_input.route";
     { std::ofstream route(script_path); route << "# headless keyboard route\nf5-6:0x2c\nf7-7:0x28\n"; }
     const std::string script_source = "@" + script_path.string();
 #ifdef _WIN32

--- a/prosper/tests/test_module_path_case.cpp
+++ b/prosper/tests/test_module_path_case.cpp
@@ -11,6 +11,7 @@
 #include <filesystem>
 #include <fstream>
 #include <string>
+#include "test_scratch.h"
 
 namespace fs = std::filesystem;
 using prosper::resolve_host_path_case;
@@ -21,7 +22,7 @@ static int fails = 0;
 
 int main() {
     std::error_code ec;
-    const fs::path root = fs::temp_directory_path() / "prosper_test_module_path_case";
+    const fs::path root = prosper_test::test_scratch_dir() / "prosper_test_module_path_case";
     fs::remove_all(root, ec);                       // stale run debris
     fs::create_directories(root / "Media" / "Modules");
     { std::ofstream(root / "Media" / "Modules" / "Il2CppUserAssemblies.prx") << "x"; }  // uppercase C on disk

--- a/prosper/tests/test_pad.cpp
+++ b/prosper/tests/test_pad.cpp
@@ -15,6 +15,7 @@
 #include <filesystem>
 #include <fstream>
 #include <thread>
+#include "test_scratch.h"
 
 using namespace prosper;
 using namespace prosper::input;
@@ -471,7 +472,7 @@ int main() {
               (SCE_PAD_BUTTON_UP | SCE_PAD_BUTTON_CROSS), "route: time range active");
 
         const auto unique = std::chrono::steady_clock::now().time_since_epoch().count();
-        const auto route_path = std::filesystem::temp_directory_path() /
+        const auto route_path = prosper_test::test_scratch_dir() /
                                 ("prosper_test_pad_route_" + std::to_string(unique) + ".pad");
         { std::ofstream route(route_path); route << "# loaded route\nf7-12:options\np20-24:cross\n"; }
         std::string route_error;

--- a/prosper/tests/test_savedata_ime.cpp
+++ b/prosper/tests/test_savedata_ime.cpp
@@ -10,6 +10,7 @@
 #include <cstring>
 #include <filesystem>
 #include <string>
+#include "test_scratch.h"
 #ifdef _WIN32
 #include <process.h>
 #else
@@ -69,7 +70,7 @@ int main() {
 #else
         (int)getpid();
 #endif
-    const std::filesystem::path test_root = std::filesystem::temp_directory_path() /
+    const std::filesystem::path test_root = prosper_test::test_scratch_dir() /
         ("prosper-savedata-selftest-" + std::to_string(process_id));
     const std::filesystem::path mount_root = test_root / "mount";
     const std::filesystem::path memory_root = test_root / "memory";

--- a/prosper/tests/test_scratch.h
+++ b/prosper/tests/test_scratch.h
@@ -1,0 +1,105 @@
+// Per-process scratch paths for tests that must touch the real filesystem (#1613).
+//
+// Two rules this exists to enforce, both learned the hard way:
+//
+//  1. **Never `/tmp`.** On the Linux dev box `/tmp` is a RAM-backed tmpfs with a per-user quota
+//     shared by every concurrent agent. A `.prgcap` is 200 MB-2.7 GB, so a couple of capture tests
+//     can exhaust it, and an exhausted tmpfs does not merely fail the write — it takes down the
+//     tooling for everyone on the machine. `std::filesystem::temp_directory_path()` resolves to
+//     exactly that tmpfs unless `TMPDIR` happens to be set, so it is not a safe default either.
+//
+//  2. **Never a path two processes can both pick.** ctest runs cases in parallel under `-j`, the
+//     same test binary can be registered as several ctest cases with different environments
+//     (`game_compute_exec` / `game_compute_exec_no_adaptive_storage_result` are one binary), and
+//     several worktrees on this box run ctest at the same time. A fixed path is then a data race
+//     whose symptom is a *content-comparison* assertion failing on correct code — the failure mode
+//     most likely to send a reader hunting for a capture or GDS defect that does not exist.
+//
+// The root comes from `PROSPER_TEST_SCRATCH_DIR`, which `prosper/CMakeLists.txt` sets per ctest
+// case to `<build-dir>/test-scratch/<ctest case name>`; running a test binary by hand instead uses
+// `<cwd>/prosper-test-scratch/<binary or fallback name>`. A pid component underneath that keeps two
+// concurrent ctest invocations (two worktrees, or a manual run alongside one) apart, and the
+// directory is removed when the process exits normally — including after a failed CHECK, because
+// the test harness counts failures and returns from main rather than aborting.
+
+#pragma once
+
+#include <cstdlib>
+#include <filesystem>
+#include <string>
+#include <string_view>
+#include <system_error>
+
+#if defined(_WIN32)
+#include <process.h>
+#else
+#include <unistd.h>
+#endif
+
+namespace prosper_test {
+
+namespace detail {
+
+inline int scratch_process_id() {
+#if defined(_WIN32)
+    return static_cast<int>(::_getpid());
+#else
+    return static_cast<int>(::getpid());
+#endif
+}
+
+// Creates the directory on construction and removes it (and everything under it) on destruction.
+// Held by a function-local static so the removal runs during normal process exit.
+struct ScratchDirectory {
+    std::filesystem::path path;
+
+    ScratchDirectory() {
+        std::filesystem::path root;
+        if (const char* configured = std::getenv("PROSPER_TEST_SCRATCH_DIR");
+            configured != nullptr && *configured != '\0') {
+            root = configured;
+        } else {
+            // Hand-run binary: keep artifacts next to the invocation instead of on the tmpfs.
+            std::error_code cwd_error;
+            std::filesystem::path cwd = std::filesystem::current_path(cwd_error);
+            if (cwd_error) cwd = std::filesystem::path(".");
+            root = cwd / "prosper-test-scratch";
+        }
+        path = root / ("pid-" + std::to_string(scratch_process_id()));
+        std::error_code error;
+        std::filesystem::remove_all(path, error);   // debris from a recycled pid
+        std::filesystem::create_directories(path, error);
+    }
+
+    ~ScratchDirectory() {
+        std::error_code error;
+        std::filesystem::remove_all(path, error);
+        // Courtesy: drop the per-case root too, but only via the non-recursive remove, which fails
+        // harmlessly while a concurrent process still holds a pid directory underneath it.
+        std::filesystem::remove(path.parent_path(), error);
+    }
+
+    ScratchDirectory(const ScratchDirectory&) = delete;
+    ScratchDirectory& operator=(const ScratchDirectory&) = delete;
+};
+
+}   // namespace detail
+
+// The calling process's private scratch directory. Created on first use, removed at normal exit.
+inline const std::filesystem::path& test_scratch_dir() {
+    static const detail::ScratchDirectory directory;
+    return directory.path;
+}
+
+// A path for `name` inside this process's scratch directory. `name` may contain '/' to nest, in
+// which case the caller creates the intermediate directories.
+inline std::filesystem::path test_scratch_path(std::string_view name) {
+    return test_scratch_dir() / std::filesystem::path(std::string(name));
+}
+
+// Convenience for the common `write it, read it back, compare` shape.
+inline std::string test_scratch_file(std::string_view name) {
+    return test_scratch_path(name).string();
+}
+
+}   // namespace prosper_test

--- a/prosper/tests/test_scratch.h
+++ b/prosper/tests/test_scratch.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <cstdio>
 #include <cstdlib>
 #include <filesystem>
 #include <string>
@@ -68,9 +69,30 @@ struct ScratchDirectory {
         path = root / ("pid-" + std::to_string(scratch_process_id()));
         std::error_code error;
         std::filesystem::remove_all(path, error);   // debris from a recycled pid
+        error.clear();
         std::filesystem::create_directories(path, error);
+        // Fail LOUDLY and immediately. If the directory does not exist, every test below writes to a
+        // path that cannot be opened and then fails on a *content* assertion — which is precisely the
+        // mystifying failure class this header exists to remove (#1613). A read-only or full build
+        // directory must not masquerade as a capture defect.
+        if (error || !std::filesystem::is_directory(path)) {
+            std::fprintf(stderr,
+                         "FATAL: cannot create the test scratch directory '%s': %s\n"
+                         "       (root came from %s)\n",
+                         path.string().c_str(), error.message().c_str(),
+                         std::getenv("PROSPER_TEST_SCRATCH_DIR") != nullptr
+                             ? "PROSPER_TEST_SCRATCH_DIR"
+                             : "the current working directory");
+            std::fflush(stderr);
+            std::abort();
+        }
     }
 
+    // NOTE for a future forking test: `path` is captured at construction, not re-derived from the
+    // live pid, so a forked child that returns from main (or calls exit()) would delete its
+    // *parent's* directory. Call test_scratch_dir() only after the fork, or have the child leave via
+    // _exit(). Nothing in the suite forks today; both remove_all calls below are bounded to a
+    // `pid-<n>` leaf, so even a mis-set PROSPER_TEST_SCRATCH_DIR cannot widen the deletion.
     ~ScratchDirectory() {
         std::error_code error;
         std::filesystem::remove_all(path, error);

--- a/prosper/tests/test_service_getters.cpp
+++ b/prosper/tests/test_service_getters.cpp
@@ -12,6 +12,7 @@
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#include "test_scratch.h"
 
 using namespace prosper;
 
@@ -46,7 +47,7 @@ int main() {
     // waiting to become available (#1373).
     {
         namespace fs = std::filesystem;
-        const fs::path app0 = fs::temp_directory_path() /
+        const fs::path app0 = prosper_test::test_scratch_dir() /
             ("prosper-playgo-" + std::to_string((uintptr_t)&fails));
         std::error_code ec;
         fs::remove_all(app0, ec);

--- a/prosper/tests/test_shader_recompile_cache.cpp
+++ b/prosper/tests/test_shader_recompile_cache.cpp
@@ -5,6 +5,7 @@
 #include <filesystem>
 #include <iterator>
 #include <vector>
+#include "test_scratch.h"
 
 using namespace prosper::gpu;
 
@@ -65,7 +66,7 @@ int main() {
 
     const auto direct_vs = recompile_vertex(kVs, std::size(kVs), &table);
     const std::filesystem::path dump_directory =
-        std::filesystem::temp_directory_path() / "prosper-shader-dump-test";
+        prosper_test::test_scratch_dir() / "prosper-shader-dump-test";
     std::error_code dump_ec;
     std::filesystem::remove_all(dump_directory, dump_ec);
     set_test_env("PROSPER_SHADER_DUMP_SUCCESS", dump_directory.string().c_str());

--- a/prosper/tests/test_translate_sandbox.cpp
+++ b/prosper/tests/test_translate_sandbox.cpp
@@ -19,6 +19,7 @@
 #include <filesystem>
 #include <fstream>
 #include <string>
+#include "test_scratch.h"
 
 namespace fs = std::filesystem;
 using namespace prosper;
@@ -32,7 +33,7 @@ static bool denied(const std::string& r) { return r.rfind("/prosper-denied", 0) 
 int main() {
     std::printf("== test_translate_sandbox ==\n");
     std::error_code ec;
-    const fs::path root = fs::temp_directory_path() / "prosper_test_translate_sandbox";
+    const fs::path root = prosper_test::test_scratch_dir() / "prosper_test_translate_sandbox";
     fs::remove_all(root, ec);                       // stale run debris
     fs::create_directories(root / "data");
     fs::create_directories(root / "arcrunner" / "content" / "movies");   // dump-style lowercase


### PR DESCRIPTION
Fixes #1613

## Failure scenario

`game_compute_exec` and `game_compute_exec_no_adaptive_storage_result` are the **same executable**
registered as two ctest cases (only the environment differs). Both hard-coded one path:

- `prosper/tests/test_game_compute.cpp:978` — `deferred_gds_pending->path = "/tmp/prosper_deferred_gds_capture.prgcap"`
- `:992` — reads that same path back
- `:1003` — `std::remove()`s it

Under `ctest -j` the two processes write, read back and delete the same file. The loser reads the
other run's bytes, or a file the other run already deleted, and the GDS content assertions fail on
correct code:

```
FAIL: deferred capture writes exact compute operations with snapshotted GDS input
FAIL: deferred capture replay restores pre-submit persistent GDS, not post-submit bytes
```

This is the worst class of false positive: a **content-comparison** failure, the one a reader is
most likely to believe and then go hunting for a capture/GDS defect that does not exist. It also
makes every other lane's `ctest` verification untrustworthy.

## Contract

A test that touches the real filesystem gets a path that

1. **is not on `/tmp`** — the shared RAM-backed tmpfs with a per-user quota; a `.prgcap` there is
   exactly the artifact class CLAUDE.md names, and exhausting it kills the Bash tool for every
   concurrent agent; and
2. **cannot be chosen by any other live process** — not another ctest case of the same binary, not
   another `ctest -j` slot, not another worktree's ctest run.

## Approach

New header `prosper/tests/test_scratch.h`:

- `prosper_test::test_scratch_dir()` / `test_scratch_path(name)` / `test_scratch_file(name)`
- root = `PROSPER_TEST_SCRATCH_DIR`, which `prosper/CMakeLists.txt` now sets for **every registered
  ctest case** to `<build-dir>/test-scratch/<case name>`, appended so existing per-test
  `ENVIRONMENT` entries survive (verified: `game_compute_exec_no_adaptive_storage_result` still
  carries `PROSPER_NO_ADAPTIVE_STORAGE_RESULT_VALIDATION=1`, `gpu_surface_detile_threaded` still
  carries `PROSPER_DETILE_THREADS=8`)
- per **case**, not per binary — one binary backing several cases is precisely this bug
- a `pid-<pid>` component underneath, so two concurrent ctest invocations (two worktrees, or a
  manual run alongside one) stay apart
- created on first use, removed at normal process exit — which includes a failed run, because the
  test harness counts failures and returns from `main` rather than aborting
- fallback for a hand-run binary: `<cwd>/prosper-test-scratch/` (gitignored), never the tmpfs

The CMake loop is at the very end of the file and snapshots the `DIRECTORY`/`TESTS` property, with a
comment saying so — an `add_test()` added below it would not be covered.

### Sweep

The issue asked whether the one pair was the only occurrence. It was not. **34 temp-path uses across
15 test files**, in three classes:

**Class 1 — the reported race (1 site, fixed).** `test_game_compute.cpp`: fixed path, two concurrent
ctest cases.

**Class 2 — `/tmp` artifacts, no intra-run race but a cross-worktree namespace collision and a
tmpfs-quota exposure (13 files, all converted).** `test_gpu_capture.cpp`, `test_gpu_capture_bundle.cpp`,
`test_gpu_capture_render.cpp`, `test_gpu_execute.cpp`, `test_gpu_timeline.cpp`,
`test_guest_log_capture.cpp`, `test_ime_input.cpp`, `test_module_path_case.cpp`, `test_pad.cpp`,
`test_savedata_ime.cpp`, `test_service_getters.cpp`, `test_shader_recompile_cache.cpp`,
`test_translate_sandbox.cpp`. Several already nonce- or pid-unique, but all on the tmpfs. Evidence
they really do leak: two zero-byte leftovers from a 30 Jul run were still sitting in `/tmp`
(`prosper-gpu-bundle-610902833312065.prgbundle.tmp`, `prosper-gpu-timeline-610903319645781.prgtl`).

**Class 3 — deliberate, left alone (2 sites, commented).** `test_file_binary.cpp:255,:315` use
`mkstemp` on the native temporary filesystem *on purpose*: they verify POSIX `chmod` bits and
microsecond `utimes` preservation, which WSL's `/mnt/c` metadata bridge does not preserve — and under
WSL the build directory is on that mount. Moving them would silently weaken the assertion on the
Windows/WSL substrate. `mkstemp` already makes the name unique and the files are empty, so neither
the quota nor a concurrent case is exposed. Both now carry a comment saying not to "fix" them.

Three `/tmp` string literals that are never touched on disk (`test_gpu_capture.cpp:84,:88,:188`
savedata-root metadata values, `test_gpu_timeline.cpp:512` a `capture_path` record field) are left
as-is; they are test data, not artifacts.

### Not changed, reported instead

A separate class exists: tests that write **fixed relative names into the ctest working directory**
(`test_gpu_timeline_capture_exit.cpp`, `test_apr_registry.cpp`, `test_ampr_measure.cpp`,
`test_apr_stat_audio.cpp`, `test_file_binary.cpp`, `test_win_exception_delivery.cpp`). Those names are
unique per test case and the working directory is already the per-build-dir `CMAKE_CURRENT_BINARY_DIR`,
so they do **not** race under `ctest -j` — the exposure is only build-dir debris on a failure path, and
two ctest runs against one build directory. `test_gpu_timeline_capture_exit.cpp` additionally relies
on the shared cwd for a genuine parent→child artifact handoff (the child writes
`timeline-capture-predecessor.prgcap`, the parent reads it), so a naive per-pid conversion would break
it. Filed separately rather than folded in here. `CONFIDENCE: HIGH` — verified by reading each site.

## Affected / unaffected

**Affected:** where test artifacts land. Nothing about what any test asserts. The two `game_compute`
cases assert exactly what they did before — and non-vacuously: if the write went nowhere,
`read_gpu_capture` fails, `deferred_gds_reopened` is false and the CHECK still fails.

**Unaffected:** production code (zero `src/` changes), test semantics, the cwd-relative class above,
the two deliberate `mkstemp` fixtures, and any test that does not touch the filesystem.

## Risks

- Four of the automated include insertions initially landed **inside** `#ifdef _WIN32` / `#if defined(__linux__)`
  blocks (`test_gpu_execute.cpp`, `test_gpu_timeline.cpp`, `test_guest_log_capture.cpp`,
  `test_savedata_ime.cpp`), which would have broken the MinGW build. All four were moved above the
  conditional and are unconditional now. (An earlier revision of this note said Linux CI cannot catch
  that — wrong: `.github/workflows/ci.yml` has a `windows-mingw` job that builds every target and runs
  the full ctest under UCRT64, and it gates release. That job is the real gate here.)
- `set_property(TEST … APPEND PROPERTY ENVIRONMENT …)` must not clobber existing per-test
  environments. Verified via `ctest --show-only=json-v1` (values quoted above).
- The destructor's `remove(parent_path())` is the non-recursive form, so it fails harmlessly while a
  concurrent process still holds a pid directory underneath. `CONFIDENCE: HIGH`.
- A test binary that aborts (rather than returning from `main`) leaves its pid directory behind. That
  is inside the build dir, bounded, and visible — a deliberate tradeoff over a signal handler.
- Failing to create the scratch directory would otherwise be silent, and would surface as a *content*
  assertion failure — the very class this PR removes. It now aborts with the path, the OS error and the
  source of the root; verified by pointing `PROSPER_TEST_SCRATCH_DIR` at an uncreatable path (exit 134
  with the diagnostic). Raised in review.

## Verification (exact head `22c201a3`, Linux, distrobox `ps5ys`, `Vulkan found` confirmed at configure)

```
cmake -S prosper -B prosper/build-linux -G Ninja -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0
cmake --build prosper/build-linux -j8                     # exit 0, no warnings
```

Race reproduction, **before** the fix — 30 consecutive `ctest -R "^game_compute_exec" -j2` runs:

```
PRE-FIX pair failures: 12 / 30
```

Same loop **after** the fix:

```
POST-FIX pair failures: 0 / 30
```

Full suite:

```
ctest -j8   x6   -> 100% tests passed out of 163   (six for six)
ctest -j8   x5   -> 100% tests passed out of 163   (re-run after the final commit, from a clean test-scratch)
ctest        x1  -> 100% tests passed out of 163   (serial control)
```

Artifact hygiene after those runs: `find test-scratch -type f` -> 0 files, `test-scratch/` itself
empty; no new `prosper*`/`*.prgcap`/`*.prgbundle`/`*.prgtl` in `/tmp`.

Hand-run fallback (no `PROSPER_TEST_SCRATCH_DIR`): `test_ime_input` from an arbitrary cwd exits 0 and
creates only `<cwd>/prosper-test-scratch/`.

Re-verified after the review fixes at head `f19fd932`: pair loop 0/30, `ctest -j8` 5/5 at 163/163,
serial control 163/163, 0 leftover files.

`git diff --check` clean. No snapshot run: no `src/` change, so rendered output cannot move — and per
CLAUDE.md snapshots are a release-time inventory, not a per-PR gate.
