### PR TITLE
fix(hle): every errno the guest observes is a FreeBSD errno (#1612)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -294,6 +294,13 @@ if(TARGET prosper_core)
   target_link_libraries(test_posix_sem PRIVATE prosper_core)
   add_test(NAME posix_sem_hle COMMAND test_posix_sem)
 
+  # FreeBSD errno numbering across the libkernel 0x80020000|errno family (#1612). Pins the encoding
+  # vocabulary, the host->FreeBSD table, and the guest-observable values on the paths a Linux/macOS
+  # host can actually reach (sem trywait, timed mutex, wait-on-address, POSIX setcancelstate).
+  add_executable(test_sce_errno tests/test_sce_errno.cpp)
+  target_link_libraries(test_sce_errno PRIVATE prosper_core)
+  add_test(NAME sce_errno_freebsd COMMAND test_sce_errno)
+
   # PlatformUi hook (#347): the app frontend can service the guest's ImeDialog with real UI; with no
   # backend registered the headless auto-complete default is unchanged. Pure, no game dump.
   add_executable(test_platform_ui tests/test_platform_ui.cpp)

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -6,6 +6,7 @@
 #endif
 #include "dispatch.hpp"
 #include "nid.hpp"
+#include "sce_errno.hpp"    // #1612: the guest reads FreeBSD errnos, not this host's
 #include "heap_mutex.hpp"   // #707: keep the APR mutex off macOS __DATA
 #include "../gpu/gpu_timeline.hpp" // optional exact guest-stdout capture gate
 #include "../host/guest_write_watch.hpp"   // #1144 B5: disarm texture watches before reading into guest mem
@@ -1022,52 +1023,12 @@ static int host_open_flags(uint64_t f) {
 // the values after ERANGE diverge on Linux (for example ELOOP and ENAMETOOLONG), so translate
 // host errors instead of copying their numbers into an SCE result.
 static uint32_t file_sce_error(int error) {
-    int guest_error = 5;  // EIO is the conservative fallback for an unmapped host failure.
-    if (error == EPERM) guest_error = 1;
-    else if (error == ENOENT) guest_error = 2;
-    else if (error == EINTR) guest_error = 4;
-    else if (error == EIO) guest_error = 5;
-    else if (error == ENXIO) guest_error = 6;
-    else if (error == EBADF) guest_error = 9;
-    else if (error == ENOMEM) guest_error = 12;
-    else if (error == EACCES) guest_error = 13;
-    else if (error == EFAULT) guest_error = 14;
-    else if (error == EBUSY) guest_error = 16;
-    else if (error == EEXIST) guest_error = 17;
-    else if (error == EXDEV) guest_error = 18;
-    else if (error == ENODEV) guest_error = 19;
-    else if (error == ENOTDIR) guest_error = 20;
-    else if (error == EISDIR) guest_error = 21;
-    else if (error == EINVAL) guest_error = 22;
-    else if (error == ENFILE) guest_error = 23;
-    else if (error == EMFILE) guest_error = 24;
-    else if (error == ENOTTY) guest_error = 25;
-#ifdef ETXTBSY
-    else if (error == ETXTBSY) guest_error = 26;
-#endif
-    else if (error == EFBIG) guest_error = 27;
-    else if (error == ENOSPC) guest_error = 28;
-    else if (error == ESPIPE) guest_error = 29;
-    else if (error == EROFS) guest_error = 30;
-    else if (error == EMLINK) guest_error = 31;
-    else if (error == EPIPE) guest_error = 32;
-    else if (error == EAGAIN) guest_error = 35;
-#ifdef EWOULDBLOCK
-    else if (error == EWOULDBLOCK) guest_error = 35;
-#endif
-#ifdef ELOOP
-    else if (error == ELOOP) guest_error = 62;
-#endif
-#ifdef ENAMETOOLONG
-    else if (error == ENAMETOOLONG) guest_error = 63;
-#endif
-#ifdef EDQUOT
-    else if (error == EDQUOT) guest_error = 69;
-#endif
-#ifdef EOVERFLOW
-    else if (error == EOVERFLOW) guest_error = 84;
-#endif
-    return 0x80020000u | (uint32_t)guest_error;
+    // This used to be a 45-line if/else ladder mapping host errnos to FreeBSD numbers by hand — the
+    // third independent copy of that mapping in the HLE, alongside fbsd_errno() in hle_kernel.cpp
+    // and a scattering of `rc == ETIMEDOUT ? 60 : ...` special cases. #1612 folded all of them onto
+    // one table in sce_errno.hpp; the values here are unchanged (the test asserts that explicitly),
+    // including the deliberate EIO fallback for a host failure with no FreeBSD counterpart.
+    return (uint32_t)prosper::hle::sce_error_from_host_errno(error, prosper::hle::FreeBsdErrno::EIo);
 }
 
 HLE(f_open)  { std::string h = translate(CS(a0)); int host_flags = host_open_flags(a1);
@@ -1852,8 +1813,13 @@ HLE(k_rmdir) { uint64_t r = f_rmdir(a0, a1, a2, a3, a4, a5); int e = errno; retu
 // getdents64 on the SAME fd so the kernel keeps the directory cursor; Linux and BSD DT_* type
 // values match. Returns bytes written (0 = end of directory), or an SCE error. UE4 (PPSA17942)
 // enumerates its pak directory with this during IO-stack init.
+// `error` is a HOST errno (from opendir/fdopendir/... or a literal EINVAL). The guest reads the low
+// byte with FreeBSD numbering, so it must be translated rather than poured in raw (#1612). The
+// errnos these calls actually produce today — ENOENT, EBADF, ENOMEM, EACCES, ENOTDIR, EMFILE — all
+// happen to be below 35, where Linux and FreeBSD agree, so this was latent rather than broken; the
+// translation makes it stay correct when a new caller reaches a divergent value.
 static uint64_t directory_sce_error(int error) {
-    return 0x80020000ull | (uint64_t)(error & 0xff);
+    return prosper::hle::sce_error_from_host_errno(error);
 }
 
 static bool directory_result_is_error(uint64_t result) {
@@ -1865,7 +1831,11 @@ static bool directory_result_is_error(uint64_t result) {
 // large positive byte count on failure and could walk an untouched directory buffer as valid data.
 static uint64_t directory_result_to_posix(uint64_t result) {
     if (!directory_result_is_error(result)) return result;
-    errno = (int)(result & 0xff);
+    // The encoded byte is a FreeBSD errno; host libc's `errno` must receive the HOST number, so this
+    // is the exact inverse of directory_sce_error(). Assigning the raw byte would corrupt the round
+    // trip on any value where the two numberings differ (#1612).
+    errno = prosper::hle::host_errno_from_freebsd(
+        static_cast<prosper::hle::FreeBsdErrno>(result & 0xff));
     return (uint64_t)(int64_t)-1;
 }
 

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -591,7 +591,11 @@ namespace {
         return 0;
 #else
         rusage usage{};
-        if (getrusage(RUSAGE_SELF, &usage) != 0) return fbsd_errno(errno ? errno : EINVAL);
+        // HOST errno on purpose: this helper's result flows up to k_cond_timedwait, which applies
+        // fbsd_errno() itself. Translating here would translate twice — and the second pass reads a
+        // FreeBSD number as a host one, so ETIMEDOUT (60) would come back out as EINVAL. Its sibling
+        // return paths are host errnos for the same reason.
+        if (getrusage(RUSAGE_SELF, &usage) != 0) return errno ? errno : EINVAL;
         int64_t sec = usage.ru_utime.tv_sec;
         int64_t usec = usage.ru_utime.tv_usec;
         if (clock_id == kSonyClockProf) {
@@ -2481,6 +2485,20 @@ void win_exc_log(const char* msg) {
     WriteFile(GetStdHandle(STD_ERROR_HANDLE), msg, (DWORD)strlen(msg), &written, nullptr);
 }
 
+// The guest-visible result is a FreeBSD errno, so the Win32 status that produced it is not
+// recoverable from the return value (#1612). Keep the raw code where a developer can still see it —
+// it is the part that actually names what the host refused to do.
+static uint64_t win_exc_sce_error(const char* where, DWORD win32_error) {
+    if (g_exc_log || g_exc_log2) {
+        char msg[160];
+        std::snprintf(msg, sizeof(msg), "[exc] %s failed: Win32 %lu -> 0x%llx\n", where,
+                      (unsigned long)win32_error,
+                      (unsigned long long)prosper::hle::sce_error_from_win32(win32_error));
+        win_exc_log(msg);
+    }
+    return prosper::hle::sce_error_from_win32(win32_error);
+}
+
 extern "C" __attribute__((noinline, noreturn))
 void prosper_win_exc_delivery(WinExcDelivery* delivery) {
     PCONTEXT captured = delivery->saved;
@@ -2576,7 +2594,7 @@ uint64_t win_raise_exception(uint64_t target, uint64_t type) {
         if (previous_suspend == (DWORD)-1) {
             DWORD e = GetLastError();
             VirtualFree(delivery, 0, MEM_RELEASE);
-            return prosper::hle::sce_error_from_win32(e);
+            return win_exc_sce_error("SuspendThread", e);
         }
         if (previous_suspend != 0) {
             ResumeThread(thread);
@@ -2591,7 +2609,7 @@ uint64_t win_raise_exception(uint64_t target, uint64_t type) {
             DWORD e = GetLastError();
             ResumeThread(thread);
             VirtualFree(delivery, 0, MEM_RELEASE);
-            return prosper::hle::sce_error_from_win32(e);
+            return win_exc_sce_error("GetThreadContext", e);
         }
         const uintptr_t rsp = static_cast<uintptr_t>(captured.Rsp);
         if (rsp >= exception_stack && rsp < exception_stack + kWinExcStackSize) {
@@ -2608,7 +2626,7 @@ uint64_t win_raise_exception(uint64_t target, uint64_t type) {
     }
 
     DWORD previous_suspend = target_suspended ? 0 : SuspendThread(thread);
-    if (previous_suspend == (DWORD)-1) { DWORD e = GetLastError(); stack_slot->active.store(0, std::memory_order_release); VirtualFree(delivery, 0, MEM_RELEASE); return prosper::hle::sce_error_from_win32(e); }
+    if (previous_suspend == (DWORD)-1) { DWORD e = GetLastError(); stack_slot->active.store(0, std::memory_order_release); VirtualFree(delivery, 0, MEM_RELEASE); return win_exc_sce_error("raise-exception host call", e); }
     if (previous_suspend != 0) {
         ResumeThread(thread);
         win_exc_log_rejected("already-suspended", g_win_exc_suspended_busy,
@@ -2627,7 +2645,7 @@ uint64_t win_raise_exception(uint64_t target, uint64_t type) {
     }
     if (!GetThreadContext(thread, delivery->saved)) {
         DWORD e = GetLastError(); ResumeThread(thread); stack_slot->active.store(0, std::memory_order_release); VirtualFree(delivery, 0, MEM_RELEASE);
-        return prosper::hle::sce_error_from_win32(e);
+        return win_exc_sce_error("raise-exception host call", e);
     }
     win_exc_trace(WinExcTraceKind::Redirect, target, GetThreadId(thread),
                   delivery->saved->Rip, delivery->saved->Rsp);
@@ -2645,11 +2663,11 @@ uint64_t win_raise_exception(uint64_t target, uint64_t type) {
                             &delivery_ptr, sizeof(delivery_ptr), &written) ||
         written != sizeof(delivery_ptr)) {
         DWORD e = GetLastError(); ResumeThread(thread); stack_slot->active.store(0, std::memory_order_release); VirtualFree(delivery, 0, MEM_RELEASE);
-        return prosper::hle::sce_error_from_win32(e);
+        return win_exc_sce_error("raise-exception host call", e);
     }
     if (!SetThreadContext(thread, &injected)) {
         DWORD e = GetLastError(); ResumeThread(thread); stack_slot->active.store(0, std::memory_order_release); VirtualFree(delivery, 0, MEM_RELEASE);
-        return prosper::hle::sce_error_from_win32(e);
+        return win_exc_sce_error("raise-exception host call", e);
     }
     // Wake while the target is still suspended. Its registration is stable until resume, and the
     // wait will be ready to return as soon as Windows restores the redirected context. This avoids
@@ -2662,7 +2680,7 @@ uint64_t win_raise_exception(uint64_t target, uint64_t type) {
             stack_slot->active.store(0, std::memory_order_release);
             VirtualFree(delivery, 0, MEM_RELEASE);
         }
-        return prosper::hle::sce_error_from_win32(e);
+        return win_exc_sce_error("raise-exception host call", e);
     }
     // A redirected Windows CONTEXT is not dispatched until a blocking syscall returns. Current
     // IL2CPP targets commonly sit in a condition-variable or WaitOnAddress HLE; waking its registered

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -14,6 +14,7 @@
 #endif
 #include "dispatch.hpp"
 #include "nid.hpp"
+#include "sce_errno.hpp"
 #include "sync_futex.hpp"
 #include "../gpu/mb3_freelist.hpp"
 #include "../host/exec_image.hpp"
@@ -454,14 +455,19 @@ HLE(k_mutex_init) {
     guest_mutex_register(m, host_type);
     return 0;
 }
-// The guest sees FreeBSD errno values; EBUSY(16)/EPERM(1)/EINVAL(22) coincide with both Linux and
-// MinGW, but EDEADLK differs on every host (FreeBSD 11, Linux 35, MinGW/winpthreads 36) — an
-// ERRORCHECK relock must report the FreeBSD value. `EDEADLK` is the HOST's own constant, so the
-// comparison remaps whatever the host returns on ALL platforms (the Windows CI build hit exactly
-// this: winpthreads returned its EDEADLK=36 and the old __linux__-only guard left it unremapped).
+// The guest sees FreeBSD errno values. EBUSY(16)/EPERM(1)/EINVAL(22) coincide with Linux and MinGW,
+// which is why this went unnoticed for so long — but the values that differ are the ones these
+// wrappers actually return on their interesting paths: EDEADLK is FreeBSD 11 / Linux 35 /
+// MinGW-winpthreads 36, and EAGAIN is the mirror image (FreeBSD 35 / Linux 11). Handing back the
+// host number swaps those two, so "would block, try again" arrives as "deadlock" and vice versa.
+//
+// This used to special-case EDEADLK alone and leave every other divergent value raw, which is why
+// callers below had to bolt on their own `rc == ETIMEDOUT ? 60 : ...` (Linux ETIMEDOUT is 110,
+// FreeBSD's is 60). The complete host->FreeBSD table now lives in sce_errno.hpp; keep this thin
+// alias so existing call sites read the same, and never return a bare host errno to a guest (#1612).
 namespace { inline uint64_t fbsd_errno(int host) {
-    if (host == EDEADLK) return 11;
-    return (uint64_t)(unsigned)host;
+    if (host == 0) return 0;
+    return (uint64_t)static_cast<uint32_t>(prosper::hle::freebsd_errno_from_host(host));
 } }
 HLE(k_mutex_destroy) { if (a0 && !pt_static_sentinel(*(void**)a0)) { auto* m = (pthread_mutex_t*)*(void**)a0; guest_mutex_unregister(m); pthread_mutex_destroy(m); free(m); } if (a0) *(void**)a0 = nullptr; return 0; }
 // PROSPER_MUTEX_FAILLOG: report any mutex op that returns a non-zero (EINVAL/EDEADLK/...) result,
@@ -585,7 +591,7 @@ namespace {
         return 0;
 #else
         rusage usage{};
-        if (getrusage(RUSAGE_SELF, &usage) != 0) return errno ? errno : EINVAL;
+        if (getrusage(RUSAGE_SELF, &usage) != 0) return fbsd_errno(errno ? errno : EINVAL);
         int64_t sec = usage.ru_utime.tv_sec;
         int64_t usec = usage.ru_utime.tv_usec;
         if (clock_id == kSonyClockProf) {
@@ -732,7 +738,7 @@ HLE(k_cond_timedwait) {
     if (!a2) {
         int rc = interruptible_cond_wait(c, m, GuestWaitKind::ConditionSequence, 0,
                                          nullptr, kGuestMutexCondWaitBookkeeping);
-        return (uint64_t)rc;
+        return fbsd_errno(rc);
     }
     const int64_t* gts = (const int64_t*)(uintptr_t)a2;
     if (gts[0] < 0 || gts[1] < 0 || gts[1] >= 1'000'000'000ll) return 22;
@@ -740,8 +746,7 @@ HLE(k_cond_timedwait) {
     const int32_t clock_id = guest_cond_snapshot(c).clock_id;
     int rc = interruptible_cond_clock_timedwait(
         c, m, dl, clock_id, nullptr, kGuestMutexCondWaitBookkeeping);
-    if (rc == ETIMEDOUT) return 60;                            // FreeBSD ETIMEDOUT
-    return (uint64_t)rc;
+    return fbsd_errno(rc);   // host ETIMEDOUT (Linux 110) -> FreeBSD 60
 }
 
 // --- read/write locks (opaque handle -> host pthread_rwlock_t). Real libc.prx uses these for its
@@ -765,7 +770,7 @@ HLE(k_rwlockattr_init) {
     auto* attr = (pthread_rwlockattr_t*)calloc(1, sizeof(pthread_rwlockattr_t));
     if (!attr) return 12;
     const int rc = pthread_rwlockattr_init(attr);
-    if (rc) { free(attr); return (uint64_t)(unsigned)rc; }
+    if (rc) { free(attr); return fbsd_errno(rc); }
     *(void**)(uintptr_t)a0 = attr;
     return 0;
 }
@@ -864,7 +869,7 @@ HLE(k_attr_setstack) {
     auto* at = (GuestPthreadAttr*)*(void**)(uintptr_t)a0;
     int rc = pthread_attr_setstacksize(&at->host, (size_t)a2);
     if (!rc) { at->supplied_stack = (void*)(uintptr_t)a1; at->supplied_stack_size = (size_t)a2; }
-    return (uint64_t)(unsigned)rc;
+    return fbsd_errno(rc);
 #else
     auto* at = (GuestPthreadAttr*)*(void**)(uintptr_t)a0;
     int rc = pthread_attr_setstack(&at->host, (void*)(uintptr_t)a1, (size_t)a2);
@@ -872,7 +877,7 @@ HLE(k_attr_setstack) {
         fprintf(stderr, "[thread] attr setstack attr=%p base=%p size=0x%llx rc=%d\n",
                 (void*)at, (void*)(uintptr_t)a1, (unsigned long long)a2, rc);
     if (!rc) { at->supplied_stack = (void*)(uintptr_t)a1; at->supplied_stack_size = (size_t)a2; }
-    return (uint64_t)(unsigned)rc;
+    return fbsd_errno(rc);
 #endif
 }
 HLE(k_attr_setguardsize) {
@@ -887,7 +892,7 @@ HLE(k_attr_setguardsize) {
     return 0;
 #else
     int rc = pthread_attr_setguardsize(&at->host, (size_t)a1);
-    return (uint64_t)(unsigned)rc;
+    return fbsd_errno(rc);
 #endif
 }
 HLE(k_attr_noop)        { return 0; }
@@ -1457,7 +1462,7 @@ HLE(k_pthread_create) {
     int r = pthread_create(&tid, &la, thread_trampoline, ts);   // trampoline registers the stack first
     if (getenv("PROSPER_SYNCLOG")) fprintf(stderr, "[thread] pthread_create rc=%d\n", r);
     pthread_attr_destroy(&la);
-    if (r) { delete ts; return (uint64_t)r; }
+    if (r) { delete ts; return fbsd_errno(r); }   // EAGAIN (out of threads) is 11 here, 35 on the PS5
     (void)publish_guest_thread_name((uint64_t)(uintptr_t)tid, ts->name_generation, ts->name);
     ts->name_published.store(true, std::memory_order_release);
 #else
@@ -1493,7 +1498,7 @@ HLE(k_pthread_create) {
     if (a4) { strncpy(ts->name, (const char*)(uintptr_t)a4, sizeof(ts->name) - 1); ts->name[sizeof(ts->name) - 1] = 0; }
     int r = pthread_create(&tid, &la, win_thread_trampoline, ts);
     pthread_attr_destroy(&la);
-    if (r) { delete ts; return (uint64_t)r; }
+    if (r) { delete ts; return fbsd_errno(r); }   // EAGAIN (out of threads) is 11 here, 35 on the PS5
     (void)publish_guest_thread_name((uint64_t)(uintptr_t)tid, ts->name_generation, ts->name);
     ts->name_published.store(true, std::memory_order_release);
 #endif
@@ -1625,11 +1630,11 @@ HLE(k_key_create) {
     }
     if (r) {
         if (thunk) VirtualFree(thunk, 0, MEM_RELEASE);
-        return (uint64_t)r;
+        return fbsd_errno(r);
     }
 #else
     int r = pthread_key_create(&k, (void (*)(void*))(uintptr_t)a1);
-    if (r) return (uint64_t)r;
+    if (r) return fbsd_errno(r);   // EAGAIN (keys exhausted) is 11 here, 35 on the PS5
 #endif
     *(uint32_t*)(uintptr_t)a0 = (uint32_t)k;   // hand the guest our host key
     return 0;
@@ -1734,7 +1739,7 @@ HLE(k_mutex_timedlock) {
     timespec dl = abs_deadline_us(a1);
     int rc = pthread_mutex_timedlock(m, &dl);
     if (rc == 0) guest_mutex_acquired(m);
-    return rc == ETIMEDOUT ? 60u : fbsd_errno(rc);
+    return fbsd_errno(rc);   // the table maps host ETIMEDOUT -> FreeBSD 60
 }
 // scePthreadCondTimedwait(cond, mutex, SceKernelUseconds usec): the Sony 3rd arg is a RELATIVE µs scalar,
 // NOT an abstime pointer -> it must NOT be aliased to the POSIX k_cond_timedwait (which reads a2 as a
@@ -1748,7 +1753,7 @@ HLE(k_cond_timedwait_sce) {
     timespec dl = abs_deadline_us(a2);
     int rc = interruptible_cond_timedwait(c, m, &dl, GuestWaitKind::ConditionSequence, 0,
                                           nullptr, kGuestMutexCondWaitBookkeeping);
-    return rc == ETIMEDOUT ? 0x8002003cu : (uint64_t)rc;
+    return rc == ETIMEDOUT ? prosper::hle::kSceKernelErrorETIMEDOUT : fbsd_errno(rc);
 }
 // scePthreadRwlockTimedrd/wrlock(rwlock, SceKernelUseconds usec): acquire with a RELATIVE µs timeout.
 // Were MISSING -> the generic stub returned 0 (= "lock held") without taking the lock, so the guest ran
@@ -1757,13 +1762,15 @@ HLE(k_rwlock_timedrdlock) {
     auto* rw = ensure_rwlock(a0); if (!rw) return 0x16;   // EINVAL
     timespec dl = abs_deadline_us(a1);
     int rc = pthread_rwlock_timedrdlock(rw, &dl);
-    return rc == ETIMEDOUT ? 60u : (uint64_t)rc;
+    // EAGAIN here means "too many concurrent readers"; unmapped it reached the guest as
+    // FreeBSD EDEADLK, turning a retryable condition into a deadlock report (#1612).
+    return fbsd_errno(rc);
 }
 HLE(k_rwlock_timedwrlock) {
     auto* rw = ensure_rwlock(a0); if (!rw) return 0x16;   // EINVAL
     timespec dl = abs_deadline_us(a1);
     int rc = pthread_rwlock_timedwrlock(rw, &dl);
-    return rc == ETIMEDOUT ? 60u : (uint64_t)rc;
+    return fbsd_errno(rc);
 }
 // scePthreadSem* -- POSIX-style counting semaphores (DISTINCT from sceKernelCreateSema). Were MISSING ->
 // the generic stub returned 0: SemInit created nothing, SemWait returned immediately (never blocked),
@@ -1771,10 +1778,10 @@ HLE(k_rwlock_timedwrlock) {
 // synchronization (the silent-unsync / UAF class). Back them with host sem_t.
 namespace { bool semlog() { static const bool on = getenv("PROSPER_SEMLOG") != nullptr; return on; } }
 HLE(k_sem_init)      { if (!a0) return 0x16; auto* s = (sem_t*)calloc(1, sizeof(sem_t)); sem_init(s, 0, (unsigned)a2); *(void**)(uintptr_t)a0 = s; if (semlog()) fprintf(stderr, "[sem] init slot=%p value=%u\n", (void*)(uintptr_t)a0, (unsigned)a2); return 0; }
-HLE(k_sem_wait)      { auto* s = ensure_sem(a0); if (!s) return 0x16; if (semlog()) fprintf(stderr, "[sem] wait slot=%p enter\n", (void*)(uintptr_t)a0); int rc = sem_wait(s); if (semlog()) fprintf(stderr, "[sem] wait slot=%p exit rc=%d\n", (void*)(uintptr_t)a0, rc); return rc == 0 ? 0 : (uint64_t)(unsigned)errno; }
-HLE(k_sem_trywait)   { auto* s = ensure_sem(a0); if (!s) return 0x16; return sem_trywait(s) == 0 ? 0 : (uint64_t)(unsigned)errno; }
-HLE(k_sem_timedwait) { auto* s = ensure_sem(a0); if (!s) return 0x16; timespec dl = abs_deadline_us(a1); int rc = sem_timedwait(s, &dl); return rc == 0 ? 0 : (errno == ETIMEDOUT ? 60u : (uint64_t)(unsigned)errno); }
-HLE(k_sem_post)      { auto* s = ensure_sem(a0); if (!s) return 0x16; int rc = sem_post(s); if (semlog()) fprintf(stderr, "[sem] post slot=%p rc=%d\n", (void*)(uintptr_t)a0, rc); return rc == 0 ? 0 : (uint64_t)(unsigned)errno; }
+HLE(k_sem_wait)      { auto* s = ensure_sem(a0); if (!s) return 0x16; if (semlog()) fprintf(stderr, "[sem] wait slot=%p enter\n", (void*)(uintptr_t)a0); int rc = sem_wait(s); if (semlog()) fprintf(stderr, "[sem] wait slot=%p exit rc=%d\n", (void*)(uintptr_t)a0, rc); return rc == 0 ? 0 : fbsd_errno(errno); }
+HLE(k_sem_trywait)   { auto* s = ensure_sem(a0); if (!s) return 0x16; return sem_trywait(s) == 0 ? 0 : fbsd_errno(errno); }   // EAGAIN (would block) is 11 here, 35 on the PS5
+HLE(k_sem_timedwait) { auto* s = ensure_sem(a0); if (!s) return 0x16; timespec dl = abs_deadline_us(a1); int rc = sem_timedwait(s, &dl); return rc == 0 ? 0 : fbsd_errno(errno); }
+HLE(k_sem_post)      { auto* s = ensure_sem(a0); if (!s) return 0x16; int rc = sem_post(s); if (semlog()) fprintf(stderr, "[sem] post slot=%p rc=%d\n", (void*)(uintptr_t)a0, rc); return rc == 0 ? 0 : fbsd_errno(errno); }
 HLE(k_sem_getvalue)  { auto* s = ensure_sem(a0); if (!s) return 0x16; int v = 0; sem_getvalue(s, &v); if (a1) *(int*)(uintptr_t)a1 = v; return 0; }
 HLE(k_sem_destroy)   { if (a0) { void** slot = (void**)(uintptr_t)a0; if (!pt_static_sentinel(*slot)) { sem_destroy((sem_t*)*slot); free(*slot); *slot = nullptr; } } return 0; }
 // scePthreadBarrier* -- were MISSING -> the generic stub returned 0, so BarrierWait let every thread sail
@@ -1782,7 +1789,7 @@ HLE(k_sem_destroy)   { if (a0) { void** slot = (void**)(uintptr_t)a0; if (!pt_st
 // reads of not-yet-produced data (the async-load race class). Back with host pthread_barrier_t; the serial
 // thread gets -1 (PTHREAD_BARRIER_SERIAL_THREAD, FreeBSD's value), the rest 0. Barrierattr are no-ops.
 HLE(k_barrier_init)    { if (!a0 || a2 == 0) return 0x16; auto* b = (pthread_barrier_t*)calloc(1, sizeof(pthread_barrier_t)); pthread_barrier_init(b, nullptr, (unsigned)a2); *(void**)(uintptr_t)a0 = b; return 0; }
-HLE(k_barrier_wait)    { auto* b = ensure_barrier(a0); if (!b) return 0x16; int rc = pthread_barrier_wait(b); return rc == PTHREAD_BARRIER_SERIAL_THREAD ? (uint64_t)(int64_t)-1 : (uint64_t)(unsigned)rc; }
+HLE(k_barrier_wait)    { auto* b = ensure_barrier(a0); if (!b) return 0x16; int rc = pthread_barrier_wait(b); return rc == PTHREAD_BARRIER_SERIAL_THREAD ? (uint64_t)(int64_t)-1 : fbsd_errno(rc); }
 HLE(k_barrier_destroy) { if (a0) { void** slot = (void**)(uintptr_t)a0; if (!pt_static_sentinel(*slot)) { pthread_barrier_destroy((pthread_barrier_t*)*slot); free(*slot); *slot = nullptr; } } return 0; }
 HLE(k_ef_wait)    { // (ef, pattern, waitMode, resultPat*, SceKernelUseconds* timeout)
     // The timeout arg (a4) was previously IGNORED — a bounded guest wait blocked forever (the
@@ -2511,8 +2518,13 @@ void prosper_win_exc_delivery(WinExcDelivery* delivery) {
 
 uint64_t win_raise_exception(uint64_t target, uint64_t type) {
     if (!target || type >= 128 || !g_exc_handlers[type]) return 0;
-    if (pthread_equal((pthread_t)target, pthread_self())) return 0x80020023ull; // EDEADLK-ish
-    if (!g_rtl_restore_context) return 0x80020026ull;                         // ENOSYS-ish
+    // FreeBSD numbering, not this host's: 0x...23 (35) is EAGAIN on the PS5, and EAGAIN is a RETRY
+    // hint, so a guest told "try again" for "you raised an exception on yourself" can spin on a
+    // condition that can never change. 0x...26 (38) is likewise ENOTSOCK, not ENOSYS (#1612).
+    if (pthread_equal((pthread_t)target, pthread_self()))
+        return prosper::hle::kSceKernelErrorEDEADLK;   // FreeBSD EDEADLK = 11
+    if (!g_rtl_restore_context)
+        return prosper::hle::kSceKernelErrorENOSYS;    // FreeBSD ENOSYS = 78
 
     // Hold a real duplicate for the complete queue/fallback transaction. This both validates the
     // pthread before publishing cooperative state and keeps a detached target's kernel object alive
@@ -2564,7 +2576,7 @@ uint64_t win_raise_exception(uint64_t target, uint64_t type) {
         if (previous_suspend == (DWORD)-1) {
             DWORD e = GetLastError();
             VirtualFree(delivery, 0, MEM_RELEASE);
-            return 0x80020000ull | (e & 0xffff);
+            return prosper::hle::sce_error_from_win32(e);
         }
         if (previous_suspend != 0) {
             ResumeThread(thread);
@@ -2579,7 +2591,7 @@ uint64_t win_raise_exception(uint64_t target, uint64_t type) {
             DWORD e = GetLastError();
             ResumeThread(thread);
             VirtualFree(delivery, 0, MEM_RELEASE);
-            return 0x80020000ull | (e & 0xffff);
+            return prosper::hle::sce_error_from_win32(e);
         }
         const uintptr_t rsp = static_cast<uintptr_t>(captured.Rsp);
         if (rsp >= exception_stack && rsp < exception_stack + kWinExcStackSize) {
@@ -2596,7 +2608,7 @@ uint64_t win_raise_exception(uint64_t target, uint64_t type) {
     }
 
     DWORD previous_suspend = target_suspended ? 0 : SuspendThread(thread);
-    if (previous_suspend == (DWORD)-1) { DWORD e = GetLastError(); stack_slot->active.store(0, std::memory_order_release); VirtualFree(delivery, 0, MEM_RELEASE); return 0x80020000ull | (e & 0xffff); }
+    if (previous_suspend == (DWORD)-1) { DWORD e = GetLastError(); stack_slot->active.store(0, std::memory_order_release); VirtualFree(delivery, 0, MEM_RELEASE); return prosper::hle::sce_error_from_win32(e); }
     if (previous_suspend != 0) {
         ResumeThread(thread);
         win_exc_log_rejected("already-suspended", g_win_exc_suspended_busy,
@@ -2615,7 +2627,7 @@ uint64_t win_raise_exception(uint64_t target, uint64_t type) {
     }
     if (!GetThreadContext(thread, delivery->saved)) {
         DWORD e = GetLastError(); ResumeThread(thread); stack_slot->active.store(0, std::memory_order_release); VirtualFree(delivery, 0, MEM_RELEASE);
-        return 0x80020000ull | (e & 0xffff);
+        return prosper::hle::sce_error_from_win32(e);
     }
     win_exc_trace(WinExcTraceKind::Redirect, target, GetThreadId(thread),
                   delivery->saved->Rip, delivery->saved->Rsp);
@@ -2633,11 +2645,11 @@ uint64_t win_raise_exception(uint64_t target, uint64_t type) {
                             &delivery_ptr, sizeof(delivery_ptr), &written) ||
         written != sizeof(delivery_ptr)) {
         DWORD e = GetLastError(); ResumeThread(thread); stack_slot->active.store(0, std::memory_order_release); VirtualFree(delivery, 0, MEM_RELEASE);
-        return 0x80020000ull | (e & 0xffff);
+        return prosper::hle::sce_error_from_win32(e);
     }
     if (!SetThreadContext(thread, &injected)) {
         DWORD e = GetLastError(); ResumeThread(thread); stack_slot->active.store(0, std::memory_order_release); VirtualFree(delivery, 0, MEM_RELEASE);
-        return 0x80020000ull | (e & 0xffff);
+        return prosper::hle::sce_error_from_win32(e);
     }
     // Wake while the target is still suspended. Its registration is stable until resume, and the
     // wait will be ready to return as soon as Windows restores the redirected context. This avoids
@@ -2650,7 +2662,7 @@ uint64_t win_raise_exception(uint64_t target, uint64_t type) {
             stack_slot->active.store(0, std::memory_order_release);
             VirtualFree(delivery, 0, MEM_RELEASE);
         }
-        return 0x80020000ull | (e & 0xffff);
+        return prosper::hle::sce_error_from_win32(e);
     }
     // A redirected Windows CONTEXT is not dispatched until a blocking syscall returns. Current
     // IL2CPP targets commonly sit in a condition-variable or WaitOnAddress HLE; waking its registered
@@ -3038,7 +3050,9 @@ HLE(k_raise_exception) {       // (targetThread /*host pthread_t*/, exceptionTyp
         if (g_exc_log2)
             fprintf(stderr, "[exc2] RAISE by tid=%ld target=0x%llx type=0x%llx sigqueue=%d\n",
                     sctid(), (unsigned long long)a0, (unsigned long long)a1, qr);
-        if (qr != 0) return 0x80020000u | (uint32_t)qr;   // deliverance FAILED — report, don't lie
+        // qr is a HOST errno from pthread_sigqueue/pthread_kill; the guest reads FreeBSD numbering,
+        // where EAGAIN and EDEADLK are swapped relative to Linux (#1612).
+        if (qr != 0) return prosper::hle::sce_error_from_host_errno(qr);   // FAILED — report, don't lie
     } else if (g_exc_log2) {
         fprintf(stderr, "[exc2] RAISE-NOOP by tid=%ld target=0x%llx type=0x%llx (no handler)\n",
                 sctid(), (unsigned long long)a0, (unsigned long long)a1);

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -5,6 +5,7 @@
 // log/debug the guest's address-space construction.
 #include "dispatch.hpp"
 #include "nid.hpp"
+#include "sce_errno.hpp"
 #include "sync_futex.hpp"   // shared futex wake + waiter registration (also used by the GPU's label wake)
 #include "../host/guest_memory_map.hpp"
 #include "../host/guest_write_watch.hpp"
@@ -1135,7 +1136,10 @@ HLE(k_wait_on_address) {
     // produced → phantom item → crash in the exception unwinder. On a futex timeout, report the Sony
     // timeout error so the guest's bounded wait re-loops / handles it instead of proceeding on garbage.
     // CONFIDENCE: HIGH on the semantics (must distinguish timeout from wake).
-    // CONFIDENCE: MED on the exact code value 0x80020060 (SCE_KERNEL_ERROR_ETIMEDOUT).
+    // The value was 0x80020060, which is the decimal 60 written as if it were hex: 0x60 is 96, and
+    // FreeBSD 96 is EOWNERDEAD ("the mutex owner died"), not ETIMEDOUT. Every other timeout in the
+    // emulator already encodes the correct 0x8002003c, so this one site disagreed with the rest of
+    // the codebase and told the guest something unrelated had gone wrong (#1612).
     if (r < 0 && e == ETIMEDOUT) {
         if (punch_secs > 0 && punch_site && punch_budget.load() > 0 && *(volatile uint32_t*)(uintptr_t)a0 == (uint32_t)a1) {
             // Fabricate the awaited signal: bump the count so the guest's loop acquires and proceeds.
@@ -1147,7 +1151,7 @@ HLE(k_wait_on_address) {
                     (unsigned long long)(gra - 0x400000000ull), punch_budget.load());
             return 0;
         }
-        return 0x80020060ull;   // SCE_KERNEL_ERROR_ETIMEDOUT
+        return prosper::hle::kSceKernelErrorETIMEDOUT;   // 0x8002003c: FreeBSD ETIMEDOUT is 60
     }
     return 0;   // woken, or EAGAIN (value already changed) — treat as success; guest re-checks the count
 }
@@ -4599,7 +4603,7 @@ HLE(k_wait_on_address) {
             ULONGLONG now = GetTickCount64();
             if (now >= deadline) {
                 if (wsynclog()) fprintf(stderr, "[sync] WAIT.exit  addr=0x%llx TIMEOUT\n", (unsigned long long)a0);
-                return 0x80020060ull;   // SCE_KERNEL_ERROR_ETIMEDOUT
+                return prosper::hle::kSceKernelErrorETIMEDOUT;   // 0x8002003c: FreeBSD ETIMEDOUT is 60
             }
             wait_ms = (DWORD)(deadline - now);
         }
@@ -4613,7 +4617,7 @@ HLE(k_wait_on_address) {
         if (!woke && wait_error == ERROR_TIMEOUT) {
             if (*wa == expected) {
                 if (wsynclog()) fprintf(stderr, "[sync] WAIT.exit  addr=0x%llx TIMEOUT\n", (unsigned long long)a0);
-                return 0x80020060ull;
+                return prosper::hle::kSceKernelErrorETIMEDOUT;   // 0x8002003c: FreeBSD ETIMEDOUT is 60
             }
         }
         // else: woken or spurious — loop re-checks *addr

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -3,6 +3,7 @@
 #include "dispatch.hpp"
 #include "nid.hpp"
 #include "hle_kernel_time.hpp"
+#include "sce_errno.hpp"    // #1612: the guest reads FreeBSD errnos, not this host's
 #include "heap_mutex.hpp"   // #707: keep hot equeue/APR mutexes off macOS __DATA
 #include "sync_futex.hpp"
 #include <pthread.h>
@@ -1263,7 +1264,11 @@ HLE(k_convert_local_to_utc) {
 // nothing is ever cancelled.) CONFIDENCE: HIGH.
 HLE(k_pthread_setcancelstate) {
     int state = (int)a0;
-    if (state != 0 && state != 1) return 0x80020016ull;   // EINVAL
+    // This is registered ONLY as the POSIX `pthread_setcancelstate`, whose contract returns a plain
+    // errno — not the 0x80020000-encoded libkernel form its sceKernel siblings use. It returned
+    // 0x80020016, so a guest comparing the result against EINVAL never matched (#1612).
+    if (state != 0 && state != 1)
+        return (uint64_t)static_cast<uint32_t>(prosper::hle::FreeBsdErrno::EInval);   // 22
     if (a1) *(int*)P(a1) = 0;                              // previous state = ENABLE (default)
     return 0;
 }

--- a/prosper/src/hle/sce_errno.hpp
+++ b/prosper/src/hle/sce_errno.hpp
@@ -1,0 +1,371 @@
+// SCE_KERNEL_ERROR_* — the PS5 libkernel error encoding, which is `0x80020000 | errno`.
+//
+//   ############################################################################################
+//   #  The low byte is a **FreeBSD** errno. It is NOT this host's <errno.h> value.             #
+//   #  Never write `0x80020000 | errno` with a host errno, and never pick the low byte by      #
+//   #  looking a name up in the Linux (or Windows) headers on your desk.                       #
+//   ############################################################################################
+//
+// The PS5 kernel is FreeBSD-derived, so the guest interprets that byte with FreeBSD's numbering.
+// Linux and FreeBSD agree on 1..34 and diverge from 35 upward — which is exactly why a wrong
+// constant survives review. Every value a developer double-checks by reflex (EINVAL 22, ENOENT 2,
+// EFAULT 14, ENOMEM 12) is identical on both, so the mistake only bites on the values nobody
+// second-guesses:
+//
+//      value  |  FreeBSD (what the guest reads)  |  Linux (where the wrong value came from)
+//      -------+----------------------------------+------------------------------------------
+//         11  |  EDEADLK                         |  EAGAIN
+//         35  |  EAGAIN / EWOULDBLOCK            |  EDEADLK
+//         38  |  ENOTSOCK                        |  ENOSYS
+//         60  |  ETIMEDOUT                       |  ENOTCONN
+//         78  |  ENOSYS                          |  EBADFD
+//        110  |  (unallocated)                   |  ETIMEDOUT
+//
+// The failure is silent and easy to misdiagnose: a guest that branches on the errno sees a
+// plausible-but-different condition. `EAGAIN` is the worst of them, because it is a *retry* hint —
+// a guest handed EAGAIN where the emulator meant "deadlock" or "unsupported" can loop forever on a
+// condition that will never change, and the resulting hang looks like a scheduling bug rather than
+// a wrong constant. This is #1612.
+//
+// Use these helpers instead of a literal:
+//   * a fixed condition the emulator itself decides  -> sce_kernel_error(FreeBsdErrno::EDeadlk)
+//   * a host errno from a failed libc/pthread call   -> sce_error_from_host_errno(e)
+//   * a Win32 GetLastError() code                    -> sce_error_from_win32(e)
+//
+// CONFIDENCE: HIGH on the numbering — it is FreeBSD's <sys/errno.h>, unchanged since 4.2BSD for the
+// low range, and corroborated inside prosper by the values that were already right: ETIMEDOUT is
+// encoded as 0x8002003c (60) in a dozen places, which is the BSD value (Linux ETIMEDOUT is 110),
+// and hle_ult.cpp encodes ENOSYS as 0x8002004E (78), also the BSD value.
+
+#pragma once
+
+#include <cerrno>
+#include <cstdint>
+
+namespace prosper::hle {
+
+// FreeBSD <sys/errno.h> numbering. Deliberately spelled as an enum rather than macros so it can
+// never be confused with the host's EINVAL/EAGAIN/... macros in the same translation unit.
+enum class FreeBsdErrno : uint32_t {
+    EPerm           = 1,
+    ENoEnt          = 2,
+    ESrch           = 3,
+    EIntr           = 4,
+    EIo             = 5,
+    ENxIo           = 6,
+    E2Big           = 7,
+    ENoExec         = 8,
+    EBadF           = 9,
+    EChild          = 10,
+    EDeadlk         = 11,   // Linux calls 11 EAGAIN
+    ENoMem          = 12,
+    EAcces          = 13,
+    EFault          = 14,
+    EBusy           = 16,
+    EExist          = 17,
+    EXDev           = 18,
+    ENoDev          = 19,
+    ENotDir         = 20,
+    EIsDir          = 21,
+    EInval          = 22,
+    ENFile          = 23,
+    EMFile          = 24,
+    ENotTty         = 25,
+    ETxtBsy         = 26,
+    EFBig           = 27,
+    ENoSpc          = 28,
+    ESPipe          = 29,
+    ERoFs           = 30,
+    EMLink          = 31,
+    EPipe           = 32,
+    EDom            = 33,
+    ERange          = 34,
+    EAgain          = 35,   // Linux calls 35 EDEADLK
+    EInProgress     = 36,
+    EAlready        = 37,
+    ENotSock        = 38,   // Linux calls 38 ENOSYS
+    EDestAddrReq    = 39,
+    EMsgSize        = 40,
+    EOpNotSupp      = 45,
+    EAddrInUse      = 48,
+    ENetDown        = 50,
+    ENetUnreach     = 51,
+    EConnAborted    = 53,
+    EConnReset      = 54,
+    ENoBufs         = 55,
+    EIsConn         = 56,
+    ENotConn        = 57,
+    ETimedOut       = 60,   // Linux calls 60 ENOTCONN; Linux ETIMEDOUT is 110
+    EConnRefused    = 61,
+    ELoop           = 62,
+    ENameTooLong    = 63,
+    EHostUnreach    = 65,
+    ENotEmpty       = 66,
+    EDQuot          = 69,
+    EStale          = 70,
+    ENoLck          = 77,
+    ENoSys          = 78,   // Linux calls 78 EBADFD
+    EIdRm           = 82,
+    ENoMsg          = 83,
+    EOverflow       = 84,
+    ECanceled       = 85,
+    EIlSeq          = 86,
+    ENoAttr         = 87,
+    EBadMsg         = 89,
+    EMultiHop       = 90,
+    ENoLink         = 91,
+    EProto          = 92,
+    ENotRecoverable = 95,
+    EOwnerDead      = 96,
+};
+
+// The libkernel encoding. Guests test the result as a signed 32-bit value, where 0x8002xxxx is
+// negative, so a nonzero return reads as failure.
+constexpr uint64_t sce_kernel_error(FreeBsdErrno e) {
+    return 0x80020000ull | static_cast<uint64_t>(e);
+}
+
+// A handful of names used often enough to be worth spelling out at the call site.
+inline constexpr uint64_t kSceKernelErrorEPERM     = sce_kernel_error(FreeBsdErrno::EPerm);
+inline constexpr uint64_t kSceKernelErrorENOENT    = sce_kernel_error(FreeBsdErrno::ENoEnt);
+inline constexpr uint64_t kSceKernelErrorESRCH     = sce_kernel_error(FreeBsdErrno::ESrch);
+inline constexpr uint64_t kSceKernelErrorEBADF     = sce_kernel_error(FreeBsdErrno::EBadF);
+inline constexpr uint64_t kSceKernelErrorEDEADLK   = sce_kernel_error(FreeBsdErrno::EDeadlk);
+inline constexpr uint64_t kSceKernelErrorENOMEM    = sce_kernel_error(FreeBsdErrno::ENoMem);
+inline constexpr uint64_t kSceKernelErrorEACCES    = sce_kernel_error(FreeBsdErrno::EAcces);
+inline constexpr uint64_t kSceKernelErrorEFAULT    = sce_kernel_error(FreeBsdErrno::EFault);
+inline constexpr uint64_t kSceKernelErrorEBUSY     = sce_kernel_error(FreeBsdErrno::EBusy);
+inline constexpr uint64_t kSceKernelErrorEINVAL    = sce_kernel_error(FreeBsdErrno::EInval);
+inline constexpr uint64_t kSceKernelErrorEAGAIN    = sce_kernel_error(FreeBsdErrno::EAgain);
+inline constexpr uint64_t kSceKernelErrorETIMEDOUT = sce_kernel_error(FreeBsdErrno::ETimedOut);
+inline constexpr uint64_t kSceKernelErrorENOSYS    = sce_kernel_error(FreeBsdErrno::ENoSys);
+
+// Translate one of THIS host's errno values to the FreeBSD number the guest expects.
+//
+// The table is keyed on the host's own macro NAMES, never on numbers, so it is correct wherever it
+// is compiled: on a BSD-numbered host (macOS) most entries are identities, on Linux the divergent
+// ones are remapped, and a host that lacks a macro entirely just drops that row. An unrecognized
+// errno falls back to EInval rather than being passed through raw, because passing it through is
+// precisely the defect this function exists to prevent — a raw Linux 38 would reach the guest as
+// ENOTSOCK.
+//
+// `fallback` is what an unrecognized errno becomes; callers that already had a considered answer
+// keep it (the file layer uses EIo, "an unclassified host failure", rather than claiming EInval).
+//
+// CONFIDENCE: HIGH on the mapping; the only judgement is the fallback, and a wrong-but-in-range
+// EINVAL is strictly safer than a number that means something unrelated.
+inline FreeBsdErrno freebsd_errno_from_host(int host_errno,
+                                            FreeBsdErrno fallback = FreeBsdErrno::EInval) {
+    switch (host_errno) {
+#define PROSPER_ERRNO_ROW(host_macro, freebsd_name) \
+    case host_macro: return FreeBsdErrno::freebsd_name;
+        PROSPER_ERRNO_ROW(EPERM,        EPerm)
+        PROSPER_ERRNO_ROW(ENOENT,       ENoEnt)
+        PROSPER_ERRNO_ROW(ESRCH,        ESrch)
+        PROSPER_ERRNO_ROW(EINTR,        EIntr)
+        PROSPER_ERRNO_ROW(EIO,          EIo)
+        PROSPER_ERRNO_ROW(ENXIO,        ENxIo)
+        PROSPER_ERRNO_ROW(E2BIG,        E2Big)
+        PROSPER_ERRNO_ROW(ENOEXEC,      ENoExec)
+        PROSPER_ERRNO_ROW(EBADF,        EBadF)
+        PROSPER_ERRNO_ROW(ECHILD,       EChild)
+        PROSPER_ERRNO_ROW(EDEADLK,      EDeadlk)      // Linux 35 -> FreeBSD 11
+        PROSPER_ERRNO_ROW(ENOMEM,       ENoMem)
+        PROSPER_ERRNO_ROW(EACCES,       EAcces)
+        PROSPER_ERRNO_ROW(EFAULT,       EFault)
+        PROSPER_ERRNO_ROW(EBUSY,        EBusy)
+        PROSPER_ERRNO_ROW(EEXIST,       EExist)
+        PROSPER_ERRNO_ROW(EXDEV,        EXDev)
+        PROSPER_ERRNO_ROW(ENODEV,       ENoDev)
+        PROSPER_ERRNO_ROW(ENOTDIR,      ENotDir)
+        PROSPER_ERRNO_ROW(EISDIR,       EIsDir)
+        PROSPER_ERRNO_ROW(EINVAL,       EInval)
+        PROSPER_ERRNO_ROW(ENFILE,       ENFile)
+        PROSPER_ERRNO_ROW(EMFILE,       EMFile)
+        PROSPER_ERRNO_ROW(ENOTTY,       ENotTty)
+#ifdef ETXTBSY
+        PROSPER_ERRNO_ROW(ETXTBSY,      ETxtBsy)
+#endif
+        PROSPER_ERRNO_ROW(EFBIG,        EFBig)
+        PROSPER_ERRNO_ROW(ENOSPC,       ENoSpc)
+        PROSPER_ERRNO_ROW(ESPIPE,       ESPipe)
+        PROSPER_ERRNO_ROW(EROFS,        ERoFs)
+        PROSPER_ERRNO_ROW(EMLINK,       EMLink)
+        PROSPER_ERRNO_ROW(EPIPE,        EPipe)
+        PROSPER_ERRNO_ROW(EDOM,         EDom)
+        PROSPER_ERRNO_ROW(ERANGE,       ERange)
+        PROSPER_ERRNO_ROW(EAGAIN,       EAgain)       // Linux 11 -> FreeBSD 35
+        PROSPER_ERRNO_ROW(EINPROGRESS,  EInProgress)
+        PROSPER_ERRNO_ROW(EALREADY,     EAlready)
+        PROSPER_ERRNO_ROW(ENOTSOCK,     ENotSock)
+        PROSPER_ERRNO_ROW(EDESTADDRREQ, EDestAddrReq)
+        PROSPER_ERRNO_ROW(EMSGSIZE,     EMsgSize)
+        PROSPER_ERRNO_ROW(EOPNOTSUPP,   EOpNotSupp)
+        PROSPER_ERRNO_ROW(EADDRINUSE,   EAddrInUse)
+        PROSPER_ERRNO_ROW(ENETDOWN,     ENetDown)
+        PROSPER_ERRNO_ROW(ENETUNREACH,  ENetUnreach)
+        PROSPER_ERRNO_ROW(ECONNABORTED, EConnAborted)
+        PROSPER_ERRNO_ROW(ECONNRESET,   EConnReset)
+        PROSPER_ERRNO_ROW(ENOBUFS,      ENoBufs)
+        PROSPER_ERRNO_ROW(EISCONN,      EIsConn)
+        PROSPER_ERRNO_ROW(ENOTCONN,     ENotConn)
+        PROSPER_ERRNO_ROW(ETIMEDOUT,    ETimedOut)    // Linux 110 -> FreeBSD 60
+        PROSPER_ERRNO_ROW(ECONNREFUSED, EConnRefused)
+        PROSPER_ERRNO_ROW(ELOOP,        ELoop)        // Linux 40 -> FreeBSD 62
+        PROSPER_ERRNO_ROW(ENAMETOOLONG, ENameTooLong) // Linux 36 -> FreeBSD 63
+        PROSPER_ERRNO_ROW(EHOSTUNREACH, EHostUnreach)
+        PROSPER_ERRNO_ROW(ENOTEMPTY,    ENotEmpty)    // Linux 39 -> FreeBSD 66
+        PROSPER_ERRNO_ROW(EDQUOT,       EDQuot)
+        PROSPER_ERRNO_ROW(ESTALE,       EStale)
+        PROSPER_ERRNO_ROW(ENOLCK,       ENoLck)       // Linux 37 -> FreeBSD 77
+        PROSPER_ERRNO_ROW(ENOSYS,       ENoSys)       // Linux 38 -> FreeBSD 78
+        PROSPER_ERRNO_ROW(EIDRM,        EIdRm)
+        PROSPER_ERRNO_ROW(ENOMSG,       ENoMsg)
+        PROSPER_ERRNO_ROW(EOVERFLOW,    EOverflow)
+        PROSPER_ERRNO_ROW(ECANCELED,    ECanceled)
+        PROSPER_ERRNO_ROW(EILSEQ,       EIlSeq)
+        PROSPER_ERRNO_ROW(EBADMSG,      EBadMsg)
+        PROSPER_ERRNO_ROW(EPROTO,       EProto)
+        PROSPER_ERRNO_ROW(EMULTIHOP,    EMultiHop)
+        PROSPER_ERRNO_ROW(ENOLINK,      ENoLink)
+#ifdef ENOTRECOVERABLE
+        PROSPER_ERRNO_ROW(ENOTRECOVERABLE, ENotRecoverable)
+#endif
+#ifdef EOWNERDEAD
+        PROSPER_ERRNO_ROW(EOWNERDEAD,   EOwnerDead)
+#endif
+#undef PROSPER_ERRNO_ROW
+    default: return fallback;
+    }
+}
+
+// The inverse, for the few places that must hand a guest-facing SCE error back to host libc (the
+// POSIX shims that answer with -1 and set the host's errno). Without this the round trip would
+// re-introduce the bug in the opposite direction.
+inline int host_errno_from_freebsd(FreeBsdErrno e) {
+    switch (e) {
+#define PROSPER_ERRNO_ROW(host_macro, freebsd_name) \
+    case FreeBsdErrno::freebsd_name: return host_macro;
+        PROSPER_ERRNO_ROW(EPERM,        EPerm)
+        PROSPER_ERRNO_ROW(ENOENT,       ENoEnt)
+        PROSPER_ERRNO_ROW(ESRCH,        ESrch)
+        PROSPER_ERRNO_ROW(EINTR,        EIntr)
+        PROSPER_ERRNO_ROW(EIO,          EIo)
+        PROSPER_ERRNO_ROW(ENXIO,        ENxIo)
+        PROSPER_ERRNO_ROW(E2BIG,        E2Big)
+        PROSPER_ERRNO_ROW(ENOEXEC,      ENoExec)
+        PROSPER_ERRNO_ROW(EBADF,        EBadF)
+        PROSPER_ERRNO_ROW(ECHILD,       EChild)
+        PROSPER_ERRNO_ROW(EDEADLK,      EDeadlk)
+        PROSPER_ERRNO_ROW(ENOMEM,       ENoMem)
+        PROSPER_ERRNO_ROW(EACCES,       EAcces)
+        PROSPER_ERRNO_ROW(EFAULT,       EFault)
+        PROSPER_ERRNO_ROW(EBUSY,        EBusy)
+        PROSPER_ERRNO_ROW(EEXIST,       EExist)
+        PROSPER_ERRNO_ROW(EXDEV,        EXDev)
+        PROSPER_ERRNO_ROW(ENODEV,       ENoDev)
+        PROSPER_ERRNO_ROW(ENOTDIR,      ENotDir)
+        PROSPER_ERRNO_ROW(EISDIR,       EIsDir)
+        PROSPER_ERRNO_ROW(EINVAL,       EInval)
+        PROSPER_ERRNO_ROW(ENFILE,       ENFile)
+        PROSPER_ERRNO_ROW(EMFILE,       EMFile)
+        PROSPER_ERRNO_ROW(ENOTTY,       ENotTty)
+#ifdef ETXTBSY
+        PROSPER_ERRNO_ROW(ETXTBSY,      ETxtBsy)
+#endif
+        PROSPER_ERRNO_ROW(EFBIG,        EFBig)
+        PROSPER_ERRNO_ROW(ENOSPC,       ENoSpc)
+        PROSPER_ERRNO_ROW(ESPIPE,       ESPipe)
+        PROSPER_ERRNO_ROW(EROFS,        ERoFs)
+        PROSPER_ERRNO_ROW(EMLINK,       EMLink)
+        PROSPER_ERRNO_ROW(EPIPE,        EPipe)
+        PROSPER_ERRNO_ROW(EDOM,         EDom)
+        PROSPER_ERRNO_ROW(ERANGE,       ERange)
+        PROSPER_ERRNO_ROW(EAGAIN,       EAgain)
+        PROSPER_ERRNO_ROW(EINPROGRESS,  EInProgress)
+        PROSPER_ERRNO_ROW(EALREADY,     EAlready)
+        PROSPER_ERRNO_ROW(ENOTSOCK,     ENotSock)
+        PROSPER_ERRNO_ROW(EDESTADDRREQ, EDestAddrReq)
+        PROSPER_ERRNO_ROW(EMSGSIZE,     EMsgSize)
+        PROSPER_ERRNO_ROW(EOPNOTSUPP,   EOpNotSupp)
+        PROSPER_ERRNO_ROW(EADDRINUSE,   EAddrInUse)
+        PROSPER_ERRNO_ROW(ENETDOWN,     ENetDown)
+        PROSPER_ERRNO_ROW(ENETUNREACH,  ENetUnreach)
+        PROSPER_ERRNO_ROW(ECONNABORTED, EConnAborted)
+        PROSPER_ERRNO_ROW(ECONNRESET,   EConnReset)
+        PROSPER_ERRNO_ROW(ENOBUFS,      ENoBufs)
+        PROSPER_ERRNO_ROW(EISCONN,      EIsConn)
+        PROSPER_ERRNO_ROW(ENOTCONN,     ENotConn)
+        PROSPER_ERRNO_ROW(ETIMEDOUT,    ETimedOut)
+        PROSPER_ERRNO_ROW(ECONNREFUSED, EConnRefused)
+        PROSPER_ERRNO_ROW(ELOOP,        ELoop)
+        PROSPER_ERRNO_ROW(ENAMETOOLONG, ENameTooLong)
+        PROSPER_ERRNO_ROW(EHOSTUNREACH, EHostUnreach)
+        PROSPER_ERRNO_ROW(ENOTEMPTY,    ENotEmpty)
+        PROSPER_ERRNO_ROW(EDQUOT,       EDQuot)
+        PROSPER_ERRNO_ROW(ESTALE,       EStale)
+        PROSPER_ERRNO_ROW(ENOLCK,       ENoLck)
+        PROSPER_ERRNO_ROW(ENOSYS,       ENoSys)
+        PROSPER_ERRNO_ROW(EIDRM,        EIdRm)
+        PROSPER_ERRNO_ROW(ENOMSG,       ENoMsg)
+        PROSPER_ERRNO_ROW(EOVERFLOW,    EOverflow)
+        PROSPER_ERRNO_ROW(ECANCELED,    ECanceled)
+        PROSPER_ERRNO_ROW(EILSEQ,       EIlSeq)
+        PROSPER_ERRNO_ROW(EBADMSG,      EBadMsg)
+        PROSPER_ERRNO_ROW(EPROTO,       EProto)
+        PROSPER_ERRNO_ROW(EMULTIHOP,    EMultiHop)
+        PROSPER_ERRNO_ROW(ENOLINK,      ENoLink)
+#ifdef ENOTRECOVERABLE
+        PROSPER_ERRNO_ROW(ENOTRECOVERABLE, ENotRecoverable)
+#endif
+#ifdef EOWNERDEAD
+        PROSPER_ERRNO_ROW(EOWNERDEAD,   EOwnerDead)
+#endif
+#undef PROSPER_ERRNO_ROW
+    default: return EINVAL;
+    }
+}
+
+// Encode a failed host libc/pthread call for the guest.
+inline uint64_t sce_error_from_host_errno(int host_errno,
+                                          FreeBsdErrno fallback = FreeBsdErrno::EInval) {
+    return sce_kernel_error(freebsd_errno_from_host(host_errno, fallback));
+}
+
+// Decode the errno out of an encoded SCE error. Returns false when `value` is not in the family.
+inline bool sce_kernel_error_errno(uint64_t value, FreeBsdErrno& out) {
+    if ((value & ~0xffull) != 0x80020000ull) return false;
+    out = static_cast<FreeBsdErrno>(value & 0xffull);
+    return true;
+}
+
+#if defined(_WIN32)
+// Encode a Win32 GetLastError() code for the guest.
+//
+// A Win32 status is NOT an errno in any numbering, so it cannot be poured into the low byte: the
+// codes overlap the errno range while meaning something else (ERROR_ACCESS_DENIED is 5, which the
+// guest would read as EIO), and many exceed 255 outright, so masking pushes the value out of the
+// errno byte and into an unrelated part of the SCE error space (ERROR_INVALID_ADDRESS, 487, lands
+// on 0x800201E7). Map deliberately, and keep the raw code in the emulator log rather than in the
+// guest-visible value.
+//
+// CONFIDENCE: MED — the mapping is the conventional Win32->POSIX correspondence, but which errno a
+// real PS5 libkernel would report for these conditions is not observable from a Windows host. The
+// fallback is EIO ("an unclassified host failure"), chosen because it is unambiguous: no caller
+// treats it as retryable, which is the property that made the original bug harmful.
+inline uint64_t sce_error_from_win32(unsigned long win32_error) {
+    switch (win32_error) {
+    case 5UL:    return sce_kernel_error(FreeBsdErrno::EPerm);    // ERROR_ACCESS_DENIED
+    case 6UL:    return sce_kernel_error(FreeBsdErrno::ESrch);    // ERROR_INVALID_HANDLE
+    case 8UL:                                                     // ERROR_NOT_ENOUGH_MEMORY
+    case 14UL:   return sce_kernel_error(FreeBsdErrno::ENoMem);   // ERROR_OUTOFMEMORY
+    case 87UL:   return sce_kernel_error(FreeBsdErrno::EInval);   // ERROR_INVALID_PARAMETER
+    case 170UL:  return sce_kernel_error(FreeBsdErrno::EBusy);    // ERROR_BUSY
+    case 1450UL: return sce_kernel_error(FreeBsdErrno::ENoMem);   // ERROR_NO_SYSTEM_RESOURCES
+    case 1816UL: return sce_kernel_error(FreeBsdErrno::ENoMem);   // ERROR_NOT_ENOUGH_QUOTA
+    default:     return sce_kernel_error(FreeBsdErrno::EIo);
+    }
+}
+#endif
+
+}   // namespace prosper::hle

--- a/prosper/src/hle/sce_errno.hpp
+++ b/prosper/src/hle/sce_errno.hpp
@@ -7,18 +7,19 @@
 //   ############################################################################################
 //
 // The PS5 kernel is FreeBSD-derived, so the guest interprets that byte with FreeBSD's numbering.
-// Linux and FreeBSD agree on 1..34 and diverge from 35 upward — which is exactly why a wrong
-// constant survives review. Every value a developer double-checks by reflex (EINVAL 22, ENOENT 2,
-// EFAULT 14, ENOMEM 12) is identical on both, so the mistake only bites on the values nobody
-// second-guesses:
+// Linux and FreeBSD agree across most of 1..34 and diverge from 35 upward — which is exactly why a
+// wrong constant survives review. Every value a developer double-checks by reflex (EINVAL 22,
+// ENOENT 2, EFAULT 14, ENOMEM 12) is identical on both, so the mistake only bites on the values
+// nobody second-guesses. Note 11 is INSIDE the "low" range and still differs — it is the headline
+// case here, so "anything under 35 is safe" is not a valid shortcut:
 //
 //      value  |  FreeBSD (what the guest reads)  |  Linux (where the wrong value came from)
 //      -------+----------------------------------+------------------------------------------
 //         11  |  EDEADLK                         |  EAGAIN
 //         35  |  EAGAIN / EWOULDBLOCK            |  EDEADLK
 //         38  |  ENOTSOCK                        |  ENOSYS
-//         60  |  ETIMEDOUT                       |  ENOTCONN
-//         78  |  ENOSYS                          |  EBADFD
+//         60  |  ETIMEDOUT                       |  ENOSTR
+//         78  |  ENOSYS                          |  EREMCHG
 //        110  |  (unallocated)                   |  ETIMEDOUT
 //
 // The failure is silent and easy to misdiagnose: a guest that branches on the errno sees a
@@ -144,7 +145,13 @@ inline constexpr uint64_t kSceKernelErrorENOSYS    = sce_kernel_error(FreeBsdErr
 //
 // The table is keyed on the host's own macro NAMES, never on numbers, so it is correct wherever it
 // is compiled: on a BSD-numbered host (macOS) most entries are identities, on Linux the divergent
-// ones are remapped, and a host that lacks a macro entirely just drops that row. An unrecognized
+// ones are remapped, and a host that lacks a macro entirely drops that row — every row carries its
+// own #ifdef, because MinGW/UCRT genuinely lacks EDQUOT, ESTALE and EMULTIHOP.
+//
+// EWOULDBLOCK and ENOTSUP need an inequality guard as well as an #ifdef: they alias EAGAIN and
+// EOPNOTSUPP on Linux/macOS (where an unguarded row is a duplicate case label and will not compile)
+// but are DISTINCT values on MinGW/UCRT, where omitting the row silently drops them to the
+// caller's fallback. An unrecognized
 // errno falls back to EInval rather than being passed through raw, because passing it through is
 // precisely the defect this function exists to prevent — a raw Linux 38 would reach the guest as
 // ENOTSOCK.
@@ -157,84 +164,219 @@ inline constexpr uint64_t kSceKernelErrorENOSYS    = sce_kernel_error(FreeBsdErr
 inline FreeBsdErrno freebsd_errno_from_host(int host_errno,
                                             FreeBsdErrno fallback = FreeBsdErrno::EInval) {
     switch (host_errno) {
-#define PROSPER_ERRNO_ROW(host_macro, freebsd_name) \
-    case host_macro: return FreeBsdErrno::freebsd_name;
-        PROSPER_ERRNO_ROW(EPERM,        EPerm)
-        PROSPER_ERRNO_ROW(ENOENT,       ENoEnt)
-        PROSPER_ERRNO_ROW(ESRCH,        ESrch)
-        PROSPER_ERRNO_ROW(EINTR,        EIntr)
-        PROSPER_ERRNO_ROW(EIO,          EIo)
-        PROSPER_ERRNO_ROW(ENXIO,        ENxIo)
-        PROSPER_ERRNO_ROW(E2BIG,        E2Big)
-        PROSPER_ERRNO_ROW(ENOEXEC,      ENoExec)
-        PROSPER_ERRNO_ROW(EBADF,        EBadF)
-        PROSPER_ERRNO_ROW(ECHILD,       EChild)
-        PROSPER_ERRNO_ROW(EDEADLK,      EDeadlk)      // Linux 35 -> FreeBSD 11
-        PROSPER_ERRNO_ROW(ENOMEM,       ENoMem)
-        PROSPER_ERRNO_ROW(EACCES,       EAcces)
-        PROSPER_ERRNO_ROW(EFAULT,       EFault)
-        PROSPER_ERRNO_ROW(EBUSY,        EBusy)
-        PROSPER_ERRNO_ROW(EEXIST,       EExist)
-        PROSPER_ERRNO_ROW(EXDEV,        EXDev)
-        PROSPER_ERRNO_ROW(ENODEV,       ENoDev)
-        PROSPER_ERRNO_ROW(ENOTDIR,      ENotDir)
-        PROSPER_ERRNO_ROW(EISDIR,       EIsDir)
-        PROSPER_ERRNO_ROW(EINVAL,       EInval)
-        PROSPER_ERRNO_ROW(ENFILE,       ENFile)
-        PROSPER_ERRNO_ROW(EMFILE,       EMFile)
-        PROSPER_ERRNO_ROW(ENOTTY,       ENotTty)
-#ifdef ETXTBSY
-        PROSPER_ERRNO_ROW(ETXTBSY,      ETxtBsy)
+#ifdef EPERM
+    case EPERM: return FreeBsdErrno::EPerm;
 #endif
-        PROSPER_ERRNO_ROW(EFBIG,        EFBig)
-        PROSPER_ERRNO_ROW(ENOSPC,       ENoSpc)
-        PROSPER_ERRNO_ROW(ESPIPE,       ESPipe)
-        PROSPER_ERRNO_ROW(EROFS,        ERoFs)
-        PROSPER_ERRNO_ROW(EMLINK,       EMLink)
-        PROSPER_ERRNO_ROW(EPIPE,        EPipe)
-        PROSPER_ERRNO_ROW(EDOM,         EDom)
-        PROSPER_ERRNO_ROW(ERANGE,       ERange)
-        PROSPER_ERRNO_ROW(EAGAIN,       EAgain)       // Linux 11 -> FreeBSD 35
-        PROSPER_ERRNO_ROW(EINPROGRESS,  EInProgress)
-        PROSPER_ERRNO_ROW(EALREADY,     EAlready)
-        PROSPER_ERRNO_ROW(ENOTSOCK,     ENotSock)
-        PROSPER_ERRNO_ROW(EDESTADDRREQ, EDestAddrReq)
-        PROSPER_ERRNO_ROW(EMSGSIZE,     EMsgSize)
-        PROSPER_ERRNO_ROW(EOPNOTSUPP,   EOpNotSupp)
-        PROSPER_ERRNO_ROW(EADDRINUSE,   EAddrInUse)
-        PROSPER_ERRNO_ROW(ENETDOWN,     ENetDown)
-        PROSPER_ERRNO_ROW(ENETUNREACH,  ENetUnreach)
-        PROSPER_ERRNO_ROW(ECONNABORTED, EConnAborted)
-        PROSPER_ERRNO_ROW(ECONNRESET,   EConnReset)
-        PROSPER_ERRNO_ROW(ENOBUFS,      ENoBufs)
-        PROSPER_ERRNO_ROW(EISCONN,      EIsConn)
-        PROSPER_ERRNO_ROW(ENOTCONN,     ENotConn)
-        PROSPER_ERRNO_ROW(ETIMEDOUT,    ETimedOut)    // Linux 110 -> FreeBSD 60
-        PROSPER_ERRNO_ROW(ECONNREFUSED, EConnRefused)
-        PROSPER_ERRNO_ROW(ELOOP,        ELoop)        // Linux 40 -> FreeBSD 62
-        PROSPER_ERRNO_ROW(ENAMETOOLONG, ENameTooLong) // Linux 36 -> FreeBSD 63
-        PROSPER_ERRNO_ROW(EHOSTUNREACH, EHostUnreach)
-        PROSPER_ERRNO_ROW(ENOTEMPTY,    ENotEmpty)    // Linux 39 -> FreeBSD 66
-        PROSPER_ERRNO_ROW(EDQUOT,       EDQuot)
-        PROSPER_ERRNO_ROW(ESTALE,       EStale)
-        PROSPER_ERRNO_ROW(ENOLCK,       ENoLck)       // Linux 37 -> FreeBSD 77
-        PROSPER_ERRNO_ROW(ENOSYS,       ENoSys)       // Linux 38 -> FreeBSD 78
-        PROSPER_ERRNO_ROW(EIDRM,        EIdRm)
-        PROSPER_ERRNO_ROW(ENOMSG,       ENoMsg)
-        PROSPER_ERRNO_ROW(EOVERFLOW,    EOverflow)
-        PROSPER_ERRNO_ROW(ECANCELED,    ECanceled)
-        PROSPER_ERRNO_ROW(EILSEQ,       EIlSeq)
-        PROSPER_ERRNO_ROW(EBADMSG,      EBadMsg)
-        PROSPER_ERRNO_ROW(EPROTO,       EProto)
-        PROSPER_ERRNO_ROW(EMULTIHOP,    EMultiHop)
-        PROSPER_ERRNO_ROW(ENOLINK,      ENoLink)
+#ifdef ENOENT
+    case ENOENT: return FreeBsdErrno::ENoEnt;
+#endif
+#ifdef ESRCH
+    case ESRCH: return FreeBsdErrno::ESrch;
+#endif
+#ifdef EINTR
+    case EINTR: return FreeBsdErrno::EIntr;
+#endif
+#ifdef EIO
+    case EIO: return FreeBsdErrno::EIo;
+#endif
+#ifdef ENXIO
+    case ENXIO: return FreeBsdErrno::ENxIo;
+#endif
+#ifdef E2BIG
+    case E2BIG: return FreeBsdErrno::E2Big;
+#endif
+#ifdef ENOEXEC
+    case ENOEXEC: return FreeBsdErrno::ENoExec;
+#endif
+#ifdef EBADF
+    case EBADF: return FreeBsdErrno::EBadF;
+#endif
+#ifdef ECHILD
+    case ECHILD: return FreeBsdErrno::EChild;
+#endif
+#ifdef EDEADLK
+    case EDEADLK: return FreeBsdErrno::EDeadlk;
+#endif
+#ifdef ENOMEM
+    case ENOMEM: return FreeBsdErrno::ENoMem;
+#endif
+#ifdef EACCES
+    case EACCES: return FreeBsdErrno::EAcces;
+#endif
+#ifdef EFAULT
+    case EFAULT: return FreeBsdErrno::EFault;
+#endif
+#ifdef EBUSY
+    case EBUSY: return FreeBsdErrno::EBusy;
+#endif
+#ifdef EEXIST
+    case EEXIST: return FreeBsdErrno::EExist;
+#endif
+#ifdef EXDEV
+    case EXDEV: return FreeBsdErrno::EXDev;
+#endif
+#ifdef ENODEV
+    case ENODEV: return FreeBsdErrno::ENoDev;
+#endif
+#ifdef ENOTDIR
+    case ENOTDIR: return FreeBsdErrno::ENotDir;
+#endif
+#ifdef EISDIR
+    case EISDIR: return FreeBsdErrno::EIsDir;
+#endif
+#ifdef EINVAL
+    case EINVAL: return FreeBsdErrno::EInval;
+#endif
+#ifdef ENFILE
+    case ENFILE: return FreeBsdErrno::ENFile;
+#endif
+#ifdef EMFILE
+    case EMFILE: return FreeBsdErrno::EMFile;
+#endif
+#ifdef ENOTTY
+    case ENOTTY: return FreeBsdErrno::ENotTty;
+#endif
+#ifdef ETXTBSY
+    case ETXTBSY: return FreeBsdErrno::ETxtBsy;
+#endif
+#ifdef EFBIG
+    case EFBIG: return FreeBsdErrno::EFBig;
+#endif
+#ifdef ENOSPC
+    case ENOSPC: return FreeBsdErrno::ENoSpc;
+#endif
+#ifdef ESPIPE
+    case ESPIPE: return FreeBsdErrno::ESPipe;
+#endif
+#ifdef EROFS
+    case EROFS: return FreeBsdErrno::ERoFs;
+#endif
+#ifdef EMLINK
+    case EMLINK: return FreeBsdErrno::EMLink;
+#endif
+#ifdef EPIPE
+    case EPIPE: return FreeBsdErrno::EPipe;
+#endif
+#ifdef EDOM
+    case EDOM: return FreeBsdErrno::EDom;
+#endif
+#ifdef ERANGE
+    case ERANGE: return FreeBsdErrno::ERange;
+#endif
+#ifdef EAGAIN
+    case EAGAIN: return FreeBsdErrno::EAgain;
+#endif
+#ifdef EINPROGRESS
+    case EINPROGRESS: return FreeBsdErrno::EInProgress;
+#endif
+#ifdef EALREADY
+    case EALREADY: return FreeBsdErrno::EAlready;
+#endif
+#ifdef ENOTSOCK
+    case ENOTSOCK: return FreeBsdErrno::ENotSock;
+#endif
+#ifdef EDESTADDRREQ
+    case EDESTADDRREQ: return FreeBsdErrno::EDestAddrReq;
+#endif
+#ifdef EMSGSIZE
+    case EMSGSIZE: return FreeBsdErrno::EMsgSize;
+#endif
+#ifdef EOPNOTSUPP
+    case EOPNOTSUPP: return FreeBsdErrno::EOpNotSupp;
+#endif
+#ifdef EADDRINUSE
+    case EADDRINUSE: return FreeBsdErrno::EAddrInUse;
+#endif
+#ifdef ENETDOWN
+    case ENETDOWN: return FreeBsdErrno::ENetDown;
+#endif
+#ifdef ENETUNREACH
+    case ENETUNREACH: return FreeBsdErrno::ENetUnreach;
+#endif
+#ifdef ECONNABORTED
+    case ECONNABORTED: return FreeBsdErrno::EConnAborted;
+#endif
+#ifdef ECONNRESET
+    case ECONNRESET: return FreeBsdErrno::EConnReset;
+#endif
+#ifdef ENOBUFS
+    case ENOBUFS: return FreeBsdErrno::ENoBufs;
+#endif
+#ifdef EISCONN
+    case EISCONN: return FreeBsdErrno::EIsConn;
+#endif
+#ifdef ENOTCONN
+    case ENOTCONN: return FreeBsdErrno::ENotConn;
+#endif
+#ifdef ETIMEDOUT
+    case ETIMEDOUT: return FreeBsdErrno::ETimedOut;
+#endif
+#ifdef ECONNREFUSED
+    case ECONNREFUSED: return FreeBsdErrno::EConnRefused;
+#endif
+#ifdef ELOOP
+    case ELOOP: return FreeBsdErrno::ELoop;
+#endif
+#ifdef ENAMETOOLONG
+    case ENAMETOOLONG: return FreeBsdErrno::ENameTooLong;
+#endif
+#ifdef EHOSTUNREACH
+    case EHOSTUNREACH: return FreeBsdErrno::EHostUnreach;
+#endif
+#ifdef ENOTEMPTY
+    case ENOTEMPTY: return FreeBsdErrno::ENotEmpty;
+#endif
+#ifdef EDQUOT
+    case EDQUOT: return FreeBsdErrno::EDQuot;
+#endif
+#ifdef ESTALE
+    case ESTALE: return FreeBsdErrno::EStale;
+#endif
+#ifdef ENOLCK
+    case ENOLCK: return FreeBsdErrno::ENoLck;
+#endif
+#ifdef ENOSYS
+    case ENOSYS: return FreeBsdErrno::ENoSys;
+#endif
+#ifdef EIDRM
+    case EIDRM: return FreeBsdErrno::EIdRm;
+#endif
+#ifdef ENOMSG
+    case ENOMSG: return FreeBsdErrno::ENoMsg;
+#endif
+#ifdef EOVERFLOW
+    case EOVERFLOW: return FreeBsdErrno::EOverflow;
+#endif
+#ifdef ECANCELED
+    case ECANCELED: return FreeBsdErrno::ECanceled;
+#endif
+#ifdef EILSEQ
+    case EILSEQ: return FreeBsdErrno::EIlSeq;
+#endif
+#ifdef EBADMSG
+    case EBADMSG: return FreeBsdErrno::EBadMsg;
+#endif
+#ifdef EPROTO
+    case EPROTO: return FreeBsdErrno::EProto;
+#endif
+#ifdef EMULTIHOP
+    case EMULTIHOP: return FreeBsdErrno::EMultiHop;
+#endif
+#ifdef ENOLINK
+    case ENOLINK: return FreeBsdErrno::ENoLink;
+#endif
 #ifdef ENOTRECOVERABLE
-        PROSPER_ERRNO_ROW(ENOTRECOVERABLE, ENotRecoverable)
+    case ENOTRECOVERABLE: return FreeBsdErrno::ENotRecoverable;
 #endif
 #ifdef EOWNERDEAD
-        PROSPER_ERRNO_ROW(EOWNERDEAD,   EOwnerDead)
+    case EOWNERDEAD: return FreeBsdErrno::EOwnerDead;
 #endif
-#undef PROSPER_ERRNO_ROW
+#if defined(EWOULDBLOCK) && defined(EAGAIN) && EWOULDBLOCK != EAGAIN
+    case EWOULDBLOCK: return FreeBsdErrno::EAgain;
+#endif
+#if defined(ENOTSUP) && defined(EOPNOTSUPP) && ENOTSUP != EOPNOTSUPP
+    case ENOTSUP: return FreeBsdErrno::EOpNotSupp;
+#endif
     default: return fallback;
     }
 }
@@ -244,84 +386,213 @@ inline FreeBsdErrno freebsd_errno_from_host(int host_errno,
 // re-introduce the bug in the opposite direction.
 inline int host_errno_from_freebsd(FreeBsdErrno e) {
     switch (e) {
-#define PROSPER_ERRNO_ROW(host_macro, freebsd_name) \
-    case FreeBsdErrno::freebsd_name: return host_macro;
-        PROSPER_ERRNO_ROW(EPERM,        EPerm)
-        PROSPER_ERRNO_ROW(ENOENT,       ENoEnt)
-        PROSPER_ERRNO_ROW(ESRCH,        ESrch)
-        PROSPER_ERRNO_ROW(EINTR,        EIntr)
-        PROSPER_ERRNO_ROW(EIO,          EIo)
-        PROSPER_ERRNO_ROW(ENXIO,        ENxIo)
-        PROSPER_ERRNO_ROW(E2BIG,        E2Big)
-        PROSPER_ERRNO_ROW(ENOEXEC,      ENoExec)
-        PROSPER_ERRNO_ROW(EBADF,        EBadF)
-        PROSPER_ERRNO_ROW(ECHILD,       EChild)
-        PROSPER_ERRNO_ROW(EDEADLK,      EDeadlk)
-        PROSPER_ERRNO_ROW(ENOMEM,       ENoMem)
-        PROSPER_ERRNO_ROW(EACCES,       EAcces)
-        PROSPER_ERRNO_ROW(EFAULT,       EFault)
-        PROSPER_ERRNO_ROW(EBUSY,        EBusy)
-        PROSPER_ERRNO_ROW(EEXIST,       EExist)
-        PROSPER_ERRNO_ROW(EXDEV,        EXDev)
-        PROSPER_ERRNO_ROW(ENODEV,       ENoDev)
-        PROSPER_ERRNO_ROW(ENOTDIR,      ENotDir)
-        PROSPER_ERRNO_ROW(EISDIR,       EIsDir)
-        PROSPER_ERRNO_ROW(EINVAL,       EInval)
-        PROSPER_ERRNO_ROW(ENFILE,       ENFile)
-        PROSPER_ERRNO_ROW(EMFILE,       EMFile)
-        PROSPER_ERRNO_ROW(ENOTTY,       ENotTty)
-#ifdef ETXTBSY
-        PROSPER_ERRNO_ROW(ETXTBSY,      ETxtBsy)
+#ifdef EPERM
+    case FreeBsdErrno::EPerm: return EPERM;
 #endif
-        PROSPER_ERRNO_ROW(EFBIG,        EFBig)
-        PROSPER_ERRNO_ROW(ENOSPC,       ENoSpc)
-        PROSPER_ERRNO_ROW(ESPIPE,       ESPipe)
-        PROSPER_ERRNO_ROW(EROFS,        ERoFs)
-        PROSPER_ERRNO_ROW(EMLINK,       EMLink)
-        PROSPER_ERRNO_ROW(EPIPE,        EPipe)
-        PROSPER_ERRNO_ROW(EDOM,         EDom)
-        PROSPER_ERRNO_ROW(ERANGE,       ERange)
-        PROSPER_ERRNO_ROW(EAGAIN,       EAgain)
-        PROSPER_ERRNO_ROW(EINPROGRESS,  EInProgress)
-        PROSPER_ERRNO_ROW(EALREADY,     EAlready)
-        PROSPER_ERRNO_ROW(ENOTSOCK,     ENotSock)
-        PROSPER_ERRNO_ROW(EDESTADDRREQ, EDestAddrReq)
-        PROSPER_ERRNO_ROW(EMSGSIZE,     EMsgSize)
-        PROSPER_ERRNO_ROW(EOPNOTSUPP,   EOpNotSupp)
-        PROSPER_ERRNO_ROW(EADDRINUSE,   EAddrInUse)
-        PROSPER_ERRNO_ROW(ENETDOWN,     ENetDown)
-        PROSPER_ERRNO_ROW(ENETUNREACH,  ENetUnreach)
-        PROSPER_ERRNO_ROW(ECONNABORTED, EConnAborted)
-        PROSPER_ERRNO_ROW(ECONNRESET,   EConnReset)
-        PROSPER_ERRNO_ROW(ENOBUFS,      ENoBufs)
-        PROSPER_ERRNO_ROW(EISCONN,      EIsConn)
-        PROSPER_ERRNO_ROW(ENOTCONN,     ENotConn)
-        PROSPER_ERRNO_ROW(ETIMEDOUT,    ETimedOut)
-        PROSPER_ERRNO_ROW(ECONNREFUSED, EConnRefused)
-        PROSPER_ERRNO_ROW(ELOOP,        ELoop)
-        PROSPER_ERRNO_ROW(ENAMETOOLONG, ENameTooLong)
-        PROSPER_ERRNO_ROW(EHOSTUNREACH, EHostUnreach)
-        PROSPER_ERRNO_ROW(ENOTEMPTY,    ENotEmpty)
-        PROSPER_ERRNO_ROW(EDQUOT,       EDQuot)
-        PROSPER_ERRNO_ROW(ESTALE,       EStale)
-        PROSPER_ERRNO_ROW(ENOLCK,       ENoLck)
-        PROSPER_ERRNO_ROW(ENOSYS,       ENoSys)
-        PROSPER_ERRNO_ROW(EIDRM,        EIdRm)
-        PROSPER_ERRNO_ROW(ENOMSG,       ENoMsg)
-        PROSPER_ERRNO_ROW(EOVERFLOW,    EOverflow)
-        PROSPER_ERRNO_ROW(ECANCELED,    ECanceled)
-        PROSPER_ERRNO_ROW(EILSEQ,       EIlSeq)
-        PROSPER_ERRNO_ROW(EBADMSG,      EBadMsg)
-        PROSPER_ERRNO_ROW(EPROTO,       EProto)
-        PROSPER_ERRNO_ROW(EMULTIHOP,    EMultiHop)
-        PROSPER_ERRNO_ROW(ENOLINK,      ENoLink)
+#ifdef ENOENT
+    case FreeBsdErrno::ENoEnt: return ENOENT;
+#endif
+#ifdef ESRCH
+    case FreeBsdErrno::ESrch: return ESRCH;
+#endif
+#ifdef EINTR
+    case FreeBsdErrno::EIntr: return EINTR;
+#endif
+#ifdef EIO
+    case FreeBsdErrno::EIo: return EIO;
+#endif
+#ifdef ENXIO
+    case FreeBsdErrno::ENxIo: return ENXIO;
+#endif
+#ifdef E2BIG
+    case FreeBsdErrno::E2Big: return E2BIG;
+#endif
+#ifdef ENOEXEC
+    case FreeBsdErrno::ENoExec: return ENOEXEC;
+#endif
+#ifdef EBADF
+    case FreeBsdErrno::EBadF: return EBADF;
+#endif
+#ifdef ECHILD
+    case FreeBsdErrno::EChild: return ECHILD;
+#endif
+#ifdef EDEADLK
+    case FreeBsdErrno::EDeadlk: return EDEADLK;
+#endif
+#ifdef ENOMEM
+    case FreeBsdErrno::ENoMem: return ENOMEM;
+#endif
+#ifdef EACCES
+    case FreeBsdErrno::EAcces: return EACCES;
+#endif
+#ifdef EFAULT
+    case FreeBsdErrno::EFault: return EFAULT;
+#endif
+#ifdef EBUSY
+    case FreeBsdErrno::EBusy: return EBUSY;
+#endif
+#ifdef EEXIST
+    case FreeBsdErrno::EExist: return EEXIST;
+#endif
+#ifdef EXDEV
+    case FreeBsdErrno::EXDev: return EXDEV;
+#endif
+#ifdef ENODEV
+    case FreeBsdErrno::ENoDev: return ENODEV;
+#endif
+#ifdef ENOTDIR
+    case FreeBsdErrno::ENotDir: return ENOTDIR;
+#endif
+#ifdef EISDIR
+    case FreeBsdErrno::EIsDir: return EISDIR;
+#endif
+#ifdef EINVAL
+    case FreeBsdErrno::EInval: return EINVAL;
+#endif
+#ifdef ENFILE
+    case FreeBsdErrno::ENFile: return ENFILE;
+#endif
+#ifdef EMFILE
+    case FreeBsdErrno::EMFile: return EMFILE;
+#endif
+#ifdef ENOTTY
+    case FreeBsdErrno::ENotTty: return ENOTTY;
+#endif
+#ifdef ETXTBSY
+    case FreeBsdErrno::ETxtBsy: return ETXTBSY;
+#endif
+#ifdef EFBIG
+    case FreeBsdErrno::EFBig: return EFBIG;
+#endif
+#ifdef ENOSPC
+    case FreeBsdErrno::ENoSpc: return ENOSPC;
+#endif
+#ifdef ESPIPE
+    case FreeBsdErrno::ESPipe: return ESPIPE;
+#endif
+#ifdef EROFS
+    case FreeBsdErrno::ERoFs: return EROFS;
+#endif
+#ifdef EMLINK
+    case FreeBsdErrno::EMLink: return EMLINK;
+#endif
+#ifdef EPIPE
+    case FreeBsdErrno::EPipe: return EPIPE;
+#endif
+#ifdef EDOM
+    case FreeBsdErrno::EDom: return EDOM;
+#endif
+#ifdef ERANGE
+    case FreeBsdErrno::ERange: return ERANGE;
+#endif
+#ifdef EAGAIN
+    case FreeBsdErrno::EAgain: return EAGAIN;
+#endif
+#ifdef EINPROGRESS
+    case FreeBsdErrno::EInProgress: return EINPROGRESS;
+#endif
+#ifdef EALREADY
+    case FreeBsdErrno::EAlready: return EALREADY;
+#endif
+#ifdef ENOTSOCK
+    case FreeBsdErrno::ENotSock: return ENOTSOCK;
+#endif
+#ifdef EDESTADDRREQ
+    case FreeBsdErrno::EDestAddrReq: return EDESTADDRREQ;
+#endif
+#ifdef EMSGSIZE
+    case FreeBsdErrno::EMsgSize: return EMSGSIZE;
+#endif
+#ifdef EOPNOTSUPP
+    case FreeBsdErrno::EOpNotSupp: return EOPNOTSUPP;
+#endif
+#ifdef EADDRINUSE
+    case FreeBsdErrno::EAddrInUse: return EADDRINUSE;
+#endif
+#ifdef ENETDOWN
+    case FreeBsdErrno::ENetDown: return ENETDOWN;
+#endif
+#ifdef ENETUNREACH
+    case FreeBsdErrno::ENetUnreach: return ENETUNREACH;
+#endif
+#ifdef ECONNABORTED
+    case FreeBsdErrno::EConnAborted: return ECONNABORTED;
+#endif
+#ifdef ECONNRESET
+    case FreeBsdErrno::EConnReset: return ECONNRESET;
+#endif
+#ifdef ENOBUFS
+    case FreeBsdErrno::ENoBufs: return ENOBUFS;
+#endif
+#ifdef EISCONN
+    case FreeBsdErrno::EIsConn: return EISCONN;
+#endif
+#ifdef ENOTCONN
+    case FreeBsdErrno::ENotConn: return ENOTCONN;
+#endif
+#ifdef ETIMEDOUT
+    case FreeBsdErrno::ETimedOut: return ETIMEDOUT;
+#endif
+#ifdef ECONNREFUSED
+    case FreeBsdErrno::EConnRefused: return ECONNREFUSED;
+#endif
+#ifdef ELOOP
+    case FreeBsdErrno::ELoop: return ELOOP;
+#endif
+#ifdef ENAMETOOLONG
+    case FreeBsdErrno::ENameTooLong: return ENAMETOOLONG;
+#endif
+#ifdef EHOSTUNREACH
+    case FreeBsdErrno::EHostUnreach: return EHOSTUNREACH;
+#endif
+#ifdef ENOTEMPTY
+    case FreeBsdErrno::ENotEmpty: return ENOTEMPTY;
+#endif
+#ifdef EDQUOT
+    case FreeBsdErrno::EDQuot: return EDQUOT;
+#endif
+#ifdef ESTALE
+    case FreeBsdErrno::EStale: return ESTALE;
+#endif
+#ifdef ENOLCK
+    case FreeBsdErrno::ENoLck: return ENOLCK;
+#endif
+#ifdef ENOSYS
+    case FreeBsdErrno::ENoSys: return ENOSYS;
+#endif
+#ifdef EIDRM
+    case FreeBsdErrno::EIdRm: return EIDRM;
+#endif
+#ifdef ENOMSG
+    case FreeBsdErrno::ENoMsg: return ENOMSG;
+#endif
+#ifdef EOVERFLOW
+    case FreeBsdErrno::EOverflow: return EOVERFLOW;
+#endif
+#ifdef ECANCELED
+    case FreeBsdErrno::ECanceled: return ECANCELED;
+#endif
+#ifdef EILSEQ
+    case FreeBsdErrno::EIlSeq: return EILSEQ;
+#endif
+#ifdef EBADMSG
+    case FreeBsdErrno::EBadMsg: return EBADMSG;
+#endif
+#ifdef EPROTO
+    case FreeBsdErrno::EProto: return EPROTO;
+#endif
+#ifdef EMULTIHOP
+    case FreeBsdErrno::EMultiHop: return EMULTIHOP;
+#endif
+#ifdef ENOLINK
+    case FreeBsdErrno::ENoLink: return ENOLINK;
+#endif
 #ifdef ENOTRECOVERABLE
-        PROSPER_ERRNO_ROW(ENOTRECOVERABLE, ENotRecoverable)
+    case FreeBsdErrno::ENotRecoverable: return ENOTRECOVERABLE;
 #endif
 #ifdef EOWNERDEAD
-        PROSPER_ERRNO_ROW(EOWNERDEAD,   EOwnerDead)
+    case FreeBsdErrno::EOwnerDead: return EOWNERDEAD;
 #endif
-#undef PROSPER_ERRNO_ROW
     default: return EINVAL;
     }
 }
@@ -346,8 +617,8 @@ inline bool sce_kernel_error_errno(uint64_t value, FreeBsdErrno& out) {
 // codes overlap the errno range while meaning something else (ERROR_ACCESS_DENIED is 5, which the
 // guest would read as EIO), and many exceed 255 outright, so masking pushes the value out of the
 // errno byte and into an unrelated part of the SCE error space (ERROR_INVALID_ADDRESS, 487, lands
-// on 0x800201E7). Map deliberately, and keep the raw code in the emulator log rather than in the
-// guest-visible value.
+// on 0x800201E7). Map deliberately; this helper does not log, so a caller that wants the raw status
+// preserved must log it itself (hle_kernel.cpp's win_exc_sce_error does exactly that).
 //
 // CONFIDENCE: MED — the mapping is the conventional Win32->POSIX correspondence, but which errno a
 // real PS5 libkernel would report for these conditions is not observable from a Windows host. The

--- a/prosper/tests/test_kernel_signal_time.cpp
+++ b/prosper/tests/test_kernel_signal_time.cpp
@@ -70,7 +70,12 @@ int main() {
     uint64_t c2b = setcancel(1 /*DISABLE*/, 0 /*NULL old*/, 0, 0, 0, 0);
     CHECK(c2b == 0, "setcancelstate with NULL old_state -> OK (no write)");
     uint64_t c3 = setcancel(7 /*invalid*/, 0, 0, 0, 0, 0);
-    CHECK(c3 == 0x80020016ull, "setcancelstate(invalid) -> EINVAL");
+    // Plain errno 22, not the 0x80020016 SCE encoding (#1612). This handler is registered ONLY as the
+    // POSIX `pthread_setcancelstate`, whose contract returns an errno directly — and every other
+    // pthread entry point in the emulator (mutex, rwlock, key, cond, sem) already returns a bare
+    // FreeBSD errno from the same shared handlers. A guest comparing the result against EINVAL could
+    // never match the encoded form.
+    CHECK(c3 == 22ull, "setcancelstate(invalid) -> EINVAL (POSIX contract: a plain errno)");
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");

--- a/prosper/tests/test_sce_errno.cpp
+++ b/prosper/tests/test_sce_errno.cpp
@@ -1,8 +1,8 @@
 // #1612: every errno the guest observes must be a FreeBSD errno.
 //
-// The PS5 kernel is FreeBSD-derived. Linux and FreeBSD agree on 1..34 and diverge above it, so a
-// constant copied out of the host's <errno.h> looks right in review and reaches the guest meaning
-// something else. The pair that matters most is EAGAIN/EDEADLK, which the two systems *swap*:
+// The PS5 kernel is FreeBSD-derived. Linux and FreeBSD agree across most of 1..34 and diverge above
+// it, so a constant copied out of the host's <errno.h> looks right in review and reaches the guest
+// meaning something else. 11 is the exception inside the low range, and it is the headline case. The pair that matters most is EAGAIN/EDEADLK, which the two systems *swap*:
 // FreeBSD EAGAIN=35 / EDEADLK=11, Linux EAGAIN=11 / EDEADLK=35. Handing back the host number turns
 // "would block, retry" into "deadlock avoided" and vice versa — and a guest that retries on EAGAIN
 // can spin forever on a condition that will never change.
@@ -93,6 +93,29 @@ int main() {
         CHECK(all, "the shared table reproduces every value of the file layer's original ladder");
         CHECK(prosper::hle::freebsd_errno_from_host(0x7ffffffe, FreeBsdErrno::EIo) == FreeBsdErrno::EIo,
               "the file layer keeps its EIO fallback for an unmapped host failure");
+        // The original ladder had an explicit EWOULDBLOCK arm. On Linux/macOS it aliases EAGAIN, so
+        // a host-value comparison cannot tell whether the row survived the fold — but on MinGW/UCRT
+        // EWOULDBLOCK is 140, a distinct value that would silently take the fallback. Assert by
+        // NAME so the check is meaningful on the platform where it can actually regress.
+        CHECK(prosper::hle::freebsd_errno_from_host(EWOULDBLOCK) == FreeBsdErrno::EAgain,
+              "EWOULDBLOCK maps to FreeBSD EAGAIN even where it is not an alias of host EAGAIN");
+        CHECK(prosper::hle::freebsd_errno_from_host(EOPNOTSUPP) == FreeBsdErrno::EOpNotSupp &&
+              prosper::hle::freebsd_errno_from_host(ENOTSUP) == FreeBsdErrno::EOpNotSupp,
+              "both spellings of 'not supported' reach FreeBSD EOPNOTSUPP");
+        // Rows MinGW/UCRT does not define at all must still work where the host does define them,
+        // and must not have been dropped from the table to make Windows compile.
+#ifdef EDQUOT
+        CHECK(prosper::hle::freebsd_errno_from_host(EDQUOT) == FreeBsdErrno::EDQuot,
+              "EDQUOT survives the per-row #ifdef guarding");
+#endif
+#ifdef ESTALE
+        CHECK(prosper::hle::freebsd_errno_from_host(ESTALE) == FreeBsdErrno::EStale,
+              "ESTALE survives the per-row #ifdef guarding");
+#endif
+#ifdef EMULTIHOP
+        CHECK(prosper::hle::freebsd_errno_from_host(EMULTIHOP) == FreeBsdErrno::EMultiHop,
+              "EMULTIHOP survives the per-row #ifdef guarding");
+#endif
     }
 
     FreeBsdErrno decoded{};

--- a/prosper/tests/test_sce_errno.cpp
+++ b/prosper/tests/test_sce_errno.cpp
@@ -1,0 +1,197 @@
+// #1612: every errno the guest observes must be a FreeBSD errno.
+//
+// The PS5 kernel is FreeBSD-derived. Linux and FreeBSD agree on 1..34 and diverge above it, so a
+// constant copied out of the host's <errno.h> looks right in review and reaches the guest meaning
+// something else. The pair that matters most is EAGAIN/EDEADLK, which the two systems *swap*:
+// FreeBSD EAGAIN=35 / EDEADLK=11, Linux EAGAIN=11 / EDEADLK=35. Handing back the host number turns
+// "would block, retry" into "deadlock avoided" and vice versa — and a guest that retries on EAGAIN
+// can spin forever on a condition that will never change.
+//
+// These assertions are written against the FreeBSD numbers the guest expects, so on a Linux host
+// they fail against the pre-#1612 code and pass after it. On a BSD-numbered host (macOS) several
+// were already correct; the contract they pin is the same either way.
+
+#include "../src/hle/dispatch.hpp"
+#include "../src/hle/nid.hpp"
+#include "../src/hle/sce_errno.hpp"
+
+#include <cerrno>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <thread>
+
+using namespace prosper;
+using prosper::hle::FreeBsdErrno;
+
+static int failures;
+#define CHECK(c, m) do { if (!(c)) { std::printf("  [FAIL] %s\n", m); ++failures; } \
+                         else std::printf("  [ok]   %s\n", m); } while (0)
+
+int main() {
+    std::printf("== test_sce_errno ==\n");
+
+    // ---- the vocabulary itself -------------------------------------------------------------
+    // Spelled as literals on purpose: if someone "simplifies" the table by pointing it at the host
+    // headers, these are the assertions that catch it.
+    CHECK(prosper::hle::sce_kernel_error(FreeBsdErrno::EDeadlk) == 0x8002000bull,
+          "SCE encoding of FreeBSD EDEADLK is 0x8002000b (11), not the Linux 35");
+    CHECK(prosper::hle::sce_kernel_error(FreeBsdErrno::EAgain) == 0x80020023ull,
+          "SCE encoding of FreeBSD EAGAIN is 0x80020023 (35), not the Linux 11");
+    CHECK(prosper::hle::sce_kernel_error(FreeBsdErrno::ENoSys) == 0x8002004eull,
+          "SCE encoding of FreeBSD ENOSYS is 0x8002004e (78), not the Linux 38");
+    CHECK(prosper::hle::sce_kernel_error(FreeBsdErrno::ETimedOut) == 0x8002003cull,
+          "SCE encoding of FreeBSD ETIMEDOUT is 0x8002003c (60), not the Linux 110");
+    CHECK(prosper::hle::sce_kernel_error(FreeBsdErrno::EInval) == 0x80020016ull,
+          "the values Linux and FreeBSD share are unchanged (EINVAL 22)");
+    CHECK(prosper::hle::sce_kernel_error(FreeBsdErrno::EOwnerDead) == 0x80020060ull,
+          "0x80020060 is EOWNERDEAD (96) — the value a decimal-60 typo produces, NOT a timeout");
+
+    // ---- host -> FreeBSD translation -------------------------------------------------------
+    CHECK(prosper::hle::freebsd_errno_from_host(EAGAIN) == FreeBsdErrno::EAgain,
+          "host EAGAIN maps to FreeBSD 35 whatever this host numbers it");
+    CHECK(prosper::hle::freebsd_errno_from_host(EDEADLK) == FreeBsdErrno::EDeadlk,
+          "host EDEADLK maps to FreeBSD 11 whatever this host numbers it");
+    CHECK(prosper::hle::freebsd_errno_from_host(ETIMEDOUT) == FreeBsdErrno::ETimedOut,
+          "host ETIMEDOUT maps to FreeBSD 60");
+    CHECK(prosper::hle::freebsd_errno_from_host(ENOSYS) == FreeBsdErrno::ENoSys,
+          "host ENOSYS maps to FreeBSD 78");
+    CHECK(prosper::hle::freebsd_errno_from_host(EINVAL) == FreeBsdErrno::EInval,
+          "host EINVAL maps to FreeBSD 22");
+    // An unknown errno must NOT be passed through raw — passing it through is the original defect.
+    CHECK(prosper::hle::freebsd_errno_from_host(0x7fffffff) == FreeBsdErrno::EInval,
+          "an unrecognized host errno degrades to EINVAL rather than leaking a raw number");
+    // Round trip: the file layer converts an SCE result back into a host errno for its libc alias.
+    CHECK(prosper::hle::host_errno_from_freebsd(FreeBsdErrno::EAgain) == EAGAIN &&
+          prosper::hle::host_errno_from_freebsd(FreeBsdErrno::EDeadlk) == EDEADLK &&
+          prosper::hle::host_errno_from_freebsd(FreeBsdErrno::ETimedOut) == ETIMEDOUT,
+          "FreeBSD -> host is the exact inverse for the divergent values");
+
+    // The file layer's 45-line hand-rolled ladder was folded onto this table (#1612). Its values are
+    // reproduced exactly, including the deliberate EIO fallback rather than EINVAL — an independent
+    // check on the table, since that ladder was written separately and already had them right.
+    {
+        struct Row { int host; uint32_t freebsd; };
+        const Row rows[] = {
+            {EPERM,1},{ENOENT,2},{EINTR,4},{EIO,5},{ENXIO,6},{EBADF,9},{ENOMEM,12},{EACCES,13},
+            {EFAULT,14},{EBUSY,16},{EEXIST,17},{EXDEV,18},{ENODEV,19},{ENOTDIR,20},{EISDIR,21},
+            {EINVAL,22},{ENFILE,23},{EMFILE,24},{ENOTTY,25},
+#ifdef ETXTBSY
+            {ETXTBSY,26},
+#endif
+            {EFBIG,27},{ENOSPC,28},
+            {ESPIPE,29},{EROFS,30},{EMLINK,31},{EPIPE,32},{EAGAIN,35},{ELOOP,62},
+            {ENAMETOOLONG,63},{EDQUOT,69},{EOVERFLOW,84},
+        };
+        bool all = true;
+        for (const Row& r : rows)
+            if (static_cast<uint32_t>(prosper::hle::freebsd_errno_from_host(r.host)) != r.freebsd) {
+                std::printf("    mismatch: host %d -> %u, expected %u\n", r.host,
+                            (unsigned)prosper::hle::freebsd_errno_from_host(r.host), r.freebsd);
+                all = false;
+            }
+        CHECK(all, "the shared table reproduces every value of the file layer's original ladder");
+        CHECK(prosper::hle::freebsd_errno_from_host(0x7ffffffe, FreeBsdErrno::EIo) == FreeBsdErrno::EIo,
+              "the file layer keeps its EIO fallback for an unmapped host failure");
+    }
+
+    FreeBsdErrno decoded{};
+    CHECK(prosper::hle::sce_kernel_error_errno(0x8002000bull, decoded) &&
+          decoded == FreeBsdErrno::EDeadlk,
+          "an encoded error decodes back to its FreeBSD errno");
+    CHECK(!prosper::hle::sce_kernel_error_errno(0x80020100ull, decoded),
+          "a value outside the errno byte is not treated as a member of the family");
+
+    register_builtin_hle();
+
+    // ---- behavioral: scePthreadSemTrywait on an empty semaphore ---------------------------
+    // sem_trywait fails with EAGAIN ("would block"). Unmapped, the guest received the HOST 11,
+    // which on the PS5 is EDEADLK: a retryable poll reported as a deadlock.
+    {
+        auto sem_init    = Hle::lookup(nid_hash("scePthreadSemInit"));
+        auto sem_trywait = Hle::lookup(nid_hash("scePthreadSemTrywait"));
+        auto sem_destroy = Hle::lookup(nid_hash("scePthreadSemDestroy"));
+        if (sem_init && sem_trywait && sem_destroy) {
+            alignas(16) uint8_t slot[32]{};
+            CHECK(sem_init((uint64_t)slot, 0, 0, 0, 0, 0) == 0, "zero-count guest semaphore initializes");
+            const uint64_t rc = sem_trywait((uint64_t)slot, 0, 0, 0, 0, 0);
+            CHECK(rc == static_cast<uint64_t>(FreeBsdErrno::EAgain),
+                  "scePthreadSemTrywait on an empty semaphore reports FreeBSD EAGAIN (35), not host 11");
+            sem_destroy((uint64_t)slot, 0, 0, 0, 0, 0);
+        } else {
+            std::printf("  [skip] scePthreadSem* not registered on this platform\n");
+        }
+    }
+
+    // ---- behavioral: scePthreadMutexTimedlock timeout --------------------------------------
+    {
+        auto mtx_init = Hle::lookup(nid_hash("scePthreadMutexInit"));
+        auto mtx_lock = Hle::lookup(nid_hash("scePthreadMutexLock"));
+        auto mtx_timedlock = Hle::lookup(nid_hash("scePthreadMutexTimedlock"));
+        auto mtx_unlock = Hle::lookup(nid_hash("scePthreadMutexUnlock"));
+        if (mtx_init && mtx_lock && mtx_timedlock && mtx_unlock) {
+            alignas(16) uint8_t slot[32]{};
+            CHECK(mtx_init((uint64_t)slot, 0, 0, 0, 0, 0) == 0, "guest mutex initializes");
+            // Hold it on another thread so the timed lock genuinely expires.
+            std::atomic<bool> held{false}, release{false};
+            std::thread holder([&] {
+                mtx_lock((uint64_t)slot, 0, 0, 0, 0, 0);
+                held.store(true, std::memory_order_release);
+                while (!release.load(std::memory_order_acquire)) std::this_thread::yield();
+                mtx_unlock((uint64_t)slot, 0, 0, 0, 0, 0);
+            });
+            while (!held.load(std::memory_order_acquire)) std::this_thread::yield();
+            const uint64_t rc = mtx_timedlock((uint64_t)slot, 20000 /* µs */, 0, 0, 0, 0);
+            CHECK(rc == static_cast<uint64_t>(FreeBsdErrno::ETimedOut),
+                  "scePthreadMutexTimedlock expiry reports FreeBSD ETIMEDOUT (60), not host 110");
+            release.store(true, std::memory_order_release);
+            holder.join();
+        } else {
+            std::printf("  [skip] scePthreadMutex* not registered on this platform\n");
+        }
+    }
+
+    // ---- behavioral: sceKernelWaitOnAddress timeout ----------------------------------------
+    // This returned 0x80020060 — decimal 60 written as hex, i.e. EOWNERDEAD(96) — while every other
+    // timeout in the emulator encodes 0x8002003c. A guest comparing against the real
+    // SCE_KERNEL_ERROR_ETIMEDOUT never matched it.
+    {
+        // Registered by raw NID: the 3.20 firmware symbol dump has no name for it, so prosper labels
+        // it "sceKernelWaitOnAddress?" and there is no nid_hash() spelling to look it up by.
+        auto wait_on_address = Hle::lookup("Hc4CaR6JBL0");
+        if (wait_on_address) {
+            // a0 = wait address, a1 = expected value (blocks while *addr == a1),
+            // a2 = pointer to a uint32 microsecond timeout. Nothing ever writes `word`, so the wait
+            // can only end by expiring.
+            alignas(8) uint32_t word = 0x5a5a5a5au;
+            uint32_t timeout_us = 20000;
+            const auto started = std::chrono::steady_clock::now();
+            const uint64_t rc = wait_on_address((uint64_t)(uintptr_t)&word, 0x5a5a5a5au,
+                                                (uint64_t)(uintptr_t)&timeout_us, 0, 0, 0);
+            const auto elapsed = std::chrono::steady_clock::now() - started;
+            CHECK(rc == prosper::hle::kSceKernelErrorETIMEDOUT,
+                  "sceKernelWaitOnAddress timeout is SCE_KERNEL_ERROR_ETIMEDOUT (0x8002003c)");
+            CHECK(rc != 0x80020060ull,
+                  "sceKernelWaitOnAddress no longer reports EOWNERDEAD(96) for a timeout");
+            CHECK(elapsed >= std::chrono::milliseconds(5),
+                  "the timeout result came from a real expiry, not an immediate rejection");
+        } else {
+            std::printf("  [skip] sceKernelWaitOnAddress not registered on this platform\n");
+        }
+    }
+
+    // ---- behavioral: pthread_setcancelstate is a POSIX contract, not an SCE one -------------
+    {
+        auto setcancelstate = Hle::lookup(nid_hash("pthread_setcancelstate"));
+        if (setcancelstate) {
+            const uint64_t rc = setcancelstate(7 /* neither ENABLE nor DISABLE */, 0, 0, 0, 0, 0);
+            CHECK(rc == static_cast<uint64_t>(FreeBsdErrno::EInval),
+                  "POSIX pthread_setcancelstate reports a plain errno (22), not 0x80020016");
+        } else {
+            std::printf("  [skip] pthread_setcancelstate not registered on this platform\n");
+        }
+    }
+
+    std::printf(failures ? "== FAIL: %d ==\n" : "== PASS ==\n", failures);
+    return failures ? 1 : 0;
+}

--- a/prosper/tests/test_sce_errno.cpp
+++ b/prosper/tests/test_sce_errno.cpp
@@ -2,7 +2,9 @@
 //
 // The PS5 kernel is FreeBSD-derived. Linux and FreeBSD agree across most of 1..34 and diverge above
 // it, so a constant copied out of the host's <errno.h> looks right in review and reaches the guest
-// meaning something else. 11 is the exception inside the low range, and it is the headline case. The pair that matters most is EAGAIN/EDEADLK, which the two systems *swap*:
+// meaning something else. 11 is the exception inside the low range, and it is the headline case.
+//
+// The pair that matters most is EAGAIN/EDEADLK, which the two systems *swap*:
 // FreeBSD EAGAIN=35 / EDEADLK=11, Linux EAGAIN=11 / EDEADLK=35. Handing back the host number turns
 // "would block, retry" into "deadlock avoided" and vice versa — and a guest that retries on EAGAIN
 // can spin forever on a condition that will never change.
@@ -81,7 +83,11 @@ int main() {
 #endif
             {EFBIG,27},{ENOSPC,28},
             {ESPIPE,29},{EROFS,30},{EMLINK,31},{EPIPE,32},{EAGAIN,35},{ELOOP,62},
-            {ENAMETOOLONG,63},{EDQUOT,69},{EOVERFLOW,84},
+            {ENAMETOOLONG,63},
+#ifdef EDQUOT
+            {EDQUOT,69},
+#endif
+            {EOVERFLOW,84},
         };
         bool all = true;
         for (const Row& r : rows)

--- a/prosper/tests/test_sync_on_address.cpp
+++ b/prosper/tests/test_sync_on_address.cpp
@@ -48,7 +48,7 @@ int main() {
     waiter.join();
 
     // Timed wait honors the timeout by DEFAULT (#139): a wait on a still-matching value with a short
-    // timeout must return the Sony ETIMEDOUT (0x80020060) after ~the timeout — not block forever and
+    // timeout must return the Sony ETIMEDOUT (0x8002003c) after ~the timeout — not block forever and
     // return 0 (=signaled). Previously this was gated off (PROSPER_WAIT_TIMEOUT) so it blocked forever.
     {
         alignas(4) uint32_t tw = 5;
@@ -58,7 +58,14 @@ int main() {
                            (uint64_t)(uintptr_t)&timeout_us, 0, 0, 0);
         auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
                            std::chrono::steady_clock::now() - t0).count();
-        CHECK(rc == 0x80020060ull, "timed wait returns SCE ETIMEDOUT (0x80020060), not 0/blocked-forever");
+        // The expected value changed in #1612. It was 0x80020060, which is the decimal 60 written as
+        // if it were hex: the libkernel encoding is 0x80020000|errno with a FreeBSD errno, and 0x60
+        // is 96 = EOWNERDEAD, not a timeout. FreeBSD ETIMEDOUT is 60 = 0x3c, which is what every
+        // other timeout in the emulator already encodes (event flags, semaphores, cond timedwait) —
+        // so this one site was telling a guest that a mutex owner had died. The old assertion pinned
+        // the emulator's own output rather than the contract; it was introduced alongside an explicit
+        // "CONFIDENCE: MED on the exact code value".
+        CHECK(rc == 0x8002003cull, "timed wait returns SCE ETIMEDOUT (0x8002003c), not 0/blocked-forever");
         CHECK(elapsed >= 20 && elapsed < 2000, "timed wait actually waited ~the timeout (not the old 5 s cap / forever)");
     }
 


### PR DESCRIPTION
Fixes #1612

## Failure scenario

`0x80020000 | errno` is the PS5 libkernel error encoding, and the PS5 kernel is FreeBSD-derived, so
the low byte must carry a **FreeBSD** errno. `prosper/src/hle/hle_kernel.cpp:2514-2515` returned
`0x80020023` intending `EDEADLK` and `0x80020026` intending `ENOSYS` — both **Linux** numbers. The
guest reads them as `EAGAIN` and `ENOTSOCK`.

`EAGAIN` is the damaging one: it is a *retry* hint. A guest told "try again" for "you raised an
exception on yourself" or "unsupported on this host" can loop on a condition that will never change,
and the resulting hang reads as a scheduling bug rather than a wrong constant.

This survives review because Linux and FreeBSD agree on 1..34. Every value a reader double-checks by
reflex — `EINVAL` 22, `ENOENT` 2, `EFAULT` 14, `ENOMEM` 12 — is identical on both. Only the values
nobody second-guesses are wrong, and `EAGAIN`/`EDEADLK` are *swapped* between the two systems
(FreeBSD 35/11, Linux 11/35).

## Contract

Every errno the guest observes is a FreeBSD errno — in the `0x80020000|errno` family and in the bare
errno the `pthread_*` entry points return.

## Approach

New `prosper/src/hle/sce_errno.hpp`: the FreeBSD errno vocabulary, `sce_kernel_error()`, and
host↔FreeBSD translation. The table is keyed on **the host's macro names, never on numbers**, so it
is correct wherever it compiles — on macOS most rows are identities, on Linux the divergent ones are
remapped, and a host missing a macro drops that row.

**This is not a new concept in the codebase — it is the fourth attempt at it.** The HLE had already
hand-rolled the same mapping three times, each partially:

| Existing | Covered | Missing |
| --- | --- | --- |
| `fbsd_errno()` (`hle_kernel.cpp:462`) | `EDEADLK` only | everything else, so callers bolted on `rc == ETIMEDOUT ? 60 : …` by hand |
| a 45-line ladder (`hle_file.cpp:1025`) | 32 errnos, all correct | not reachable from the kernel/mem layers |
| scattered `? 60u :` / `? 0x8002003cu :` | `ETIMEDOUT` at 4 sites | inconsistent with each other |

All three now share one table. That existing ladder is also **independent corroboration** of the
numbering: it was written separately and already had `EAGAIN` 35, `ELOOP` 62, `ENAMETOOLONG` 63,
`EDQUOT` 69, `EOVERFLOW` 84 — every value matching the new table.

### Sweep

The two sites in the issue were the entry point, not the extent. Ordered by how reachable each is:

1. **`sceKernelWaitOnAddress` timeout — `0x80020060`** (`hle_kernel_mem.cpp`, 3 sites, POSIX + Windows).
   That is decimal 60 written as if it were hex: `0x60` is **96**, FreeBSD `EOWNERDEAD` — "the mutex
   owner died". FreeBSD `ETIMEDOUT` is 60 = `0x3c`, which is what the emulator already encoded in a
   dozen other places. **No guest comparing against `SCE_KERNEL_ERROR_ETIMEDOUT` could ever match
   it**, so its bounded waits fell through to an unknown-error path. The original commit marked
   `CONFIDENCE: MED on the exact code value 0x80020060`.
2. **Bare host errnos from the `scePthread*` family.** `sem_wait`/`trywait`/`timedwait`/`post`, both
   rwlock timedlocks, cond wait, `pthread_create`, `pthread_key_create`, barrier wait. `sem_trywait`
   reports `EAGAIN` for "would block" — an empty-semaphore poll was telling the guest **EDEADLK**.
   `pthread_create` and `pthread_key_create` report `EAGAIN` on resource exhaustion, likewise.
3. **`sceKernelRaiseException`** passed `pthread_sigqueue`'s host errno straight into the encoded field.
4. **`win_raise_exception`, 7 sites**: `0x80020000ull | (GetLastError() & 0xffff)`. A Win32 status is
   not an errno in any numbering — `ERROR_ACCESS_DENIED` is 5, which the guest reads as `EIO` — and
   codes above 255 escape the errno byte entirely (`ERROR_INVALID_ADDRESS`, 487, lands on
   `0x800201E7`, a different part of the SCE error space). Now mapped deliberately, with the raw Win32
   code kept in the emulator log rather than in the guest-visible value. `CONFIDENCE: MED` on the
   mapping; the fallback is `EIO`, chosen because nothing treats it as retryable.
5. **`pthread_setcancelstate`** is registered *only* under its POSIX name, whose contract returns a
   plain errno, but returned the `0x80020016` SCE form. Every sibling `pthread_*` handler in the
   emulator already returns a bare errno, so this was the outlier.
6. **`directory_sce_error`/`directory_result_to_posix`** (`hle_file.cpp`) poured a host errno in and
   read a raw byte back out. Latent — every errno `opendir`/`fdopendir` actually produces is below 35
   — but now translated in both directions, which the round trip requires.

### The more serious shape: error constants in value-returning contracts

Swept for this separately, as instructed. **Outside `hle_ult.cpp` (owned elsewhere, untouched) there
are none.** Every size/count-shaped Sony name in the HLE either returns a genuine value
(`sceKernelGetDirectMemorySize` → `kDmemTotal`, `sceAudioOut2GetSpeakerArrayMemorySize` → a computed
size, `sceKernelGetProcessTimeCounterFrequency` → 1e9) or has an out-parameter and a real error
channel (`sceKernelAvailableDirectMemorySize`, `sceKernelAvailableFlexibleMemorySize` — both write
`*out` and return status). `sceKernelGetdents` returns a byte count *or* a negative SCE error, and
prosper already handles that hazard explicitly at `hle_file.cpp:1863` for its libc alias.

## Affected / unaffected

**Affected — guest-visible values.** Every change makes a wrong errno right; none changes whether a
call succeeds. The behavioral consequence is that guests can now *recognize* these conditions:
matching `SCE_KERNEL_ERROR_ETIMEDOUT`, taking a retry branch on `EAGAIN`, taking a deadlock branch on
`EDEADLK`.

**Two asserted contracts changed**, called out because a reviewer should weigh them, not skim them:
`test_sync_on_address` asserted the `0x80020060` timeout and `test_kernel_signal_time` asserted the
encoded `pthread_setcancelstate` result. Both pinned *the emulator's own output*, not evidence about
the PS5; neither cites a title. The reasoning is now recorded in both test comments.

**Unaffected:** success paths; every errno ≤ 34, where the two numberings agree (which is the large
majority of existing constants — they were already right); `hle_ult.cpp`; the GPU/renderer, so no
rendered output can move; `scePthreadMutexLock` and friends returning a bare errno rather than the
SCE form, which is pre-existing behavior with title evidence behind it and out of scope here.

## Risks

- **`sceKernelWaitOnAddress` is on a live boot path.** If a title branches on the old `0x80020060`
  it would change behavior — but 0x80020060 is not a value any Sony header defines for a timeout, so
  a guest can only be treating it as "some error", and the change makes the real timeout branch
  reachable. `CONFIDENCE: HIGH` that 60 is right: it is arithmetic from FreeBSD's `<sys/errno.h>`,
  it is what a dozen other sites in this codebase already encode, and 96 is `EOWNERDEAD`.
- **Win32 mapping is judgement.** `CONFIDENCE: MED`; documented at the function, and strictly better
  than the previous behavior, which could not even stay inside the errno byte.
- The `freebsd_errno_from_host` fallback is `EINVAL` rather than pass-through. Passing through *is*
  the defect, so a wrong-but-in-range value is the safer failure. The file layer keeps its considered
  `EIO` fallback via the new parameter.
- Folding the `hle_file.cpp` ladder onto the shared table is a refactor of working code. It is
  covered by an explicit equivalence test — **which caught a real omission during development**
  (`ETXTBSY` was missing from the shared table and silently became `EINVAL`). That is the strongest
  evidence the test is doing its job.

## Verification (exact head, distrobox `ps5ys`, `Vulkan found` confirmed at configure)

```
cmake -S prosper -B prosper/build-linux -G Ninja -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0
cmake --build prosper/build-linux -j8          # exit 0, no new warnings
ctest -j8                                      # 100% tests passed out of 164
ctest -j8  x3 more                             # 3/3 clean, 164/164 each
```

**Each fix fails without it.** Reverting only `prosper/src/hle/` to master and rebuilding, with the
new test unchanged:

```
[FAIL] scePthreadSemTrywait on an empty semaphore reports FreeBSD EAGAIN (35), not host 11
[FAIL] sceKernelWaitOnAddress timeout is SCE_KERNEL_ERROR_ETIMEDOUT (0x8002003c)
[FAIL] sceKernelWaitOnAddress no longer reports EOWNERDEAD(96) for a timeout
[FAIL] POSIX pthread_setcancelstate reports a plain errno (22), not 0x80020016
== FAIL: 4 ==
```

`scePthreadMutexTimedlock` passes in both directions, honestly: it already carried the ad-hoc
`rc == ETIMEDOUT ? 60u` special case that this change generalizes. The Windows-only
`win_raise_exception` sites cannot be exercised from a Linux host and are covered by the encoding
assertions plus the `windows-mingw` CI build.

New test `prosper/tests/test_sce_errno.cpp` (ctest case `sce_errno_freebsd`) pins the encoding
vocabulary as literals, the host→FreeBSD table both directions, ladder equivalence, and the four
behavioral paths above.

`git diff --check` clean. No snapshot run: no GPU/renderer code is touched, so rendered output cannot
move.
