### PR TITLE
feat(hle): implement libSceUlt — runtime, pool, mutexes, condition variables and ulthreads

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -290,6 +290,14 @@ if(TARGET prosper_core)
   target_link_libraries(test_ult_fail_visible PRIVATE prosper_core)
   add_test(NAME ult_fail_visible COMMAND test_ult_fail_visible)
 
+  # #1603 Phase 2: the implemented libSceUlt semantics. Mutual exclusion is DEMONSTRATED with real
+  # concurrent threads over a non-atomic counter and an exact expected total — a no-op mutex produces
+  # a wrong-but-plausible number rather than a crash, so only the exact total is a real check.
+  # Pure, no game dump.
+  add_executable(test_ult_semantics tests/test_ult_semantics.cpp)
+  target_link_libraries(test_ult_semantics PRIVATE prosper_core Threads::Threads)
+  add_test(NAME ult_semantics COMMAND test_ult_semantics)
+
   add_executable(test_posix_sem tests/test_posix_sem.cpp)
   target_link_libraries(test_posix_sem PRIVATE prosper_core)
   add_test(NAME posix_sem_hle COMMAND test_posix_sem)

--- a/prosper/docs/GAME_COMPAT_ORCHESTRATION.md
+++ b/prosper/docs/GAME_COMPAT_ORCHESTRATION.md
@@ -109,6 +109,28 @@ highest-value page in this document.
 - Write `Refs #NN`, not `Fixes #NN`, when a PR only partially addresses an issue — a parenthetical qualifier does
   **not** stop GitHub's auto-close, and #1554 was closed that way despite a comment saying to keep it open.
 
+### Registering a NID with an error return can be worse than leaving it unregistered
+
+A trap of the same family as the list above, but in the HLE surface rather than an instrument. It cost a
+merged defect (#1618, introduced by #1614), so it belongs beside them.
+
+The dispatcher's default for an **unresolved** NID is `return 0` (`hle/dispatch.cpp` `prosper_on_unimpl`).
+That default is safe for a function whose contract returns a **value**, and unsafe for one that returns a
+**status** — which is exactly why fail-visible registration is usually an improvement. The trap is that the
+inverse is equally true, and easy to miss: **an error sentinel is unsafe for a value-returning contract,
+because such a signature has no error channel and the sentinel is read as data.**
+
+`sceUltWaitingQueueResourcePoolGetWorkAreaSize` returns a `size_t` in `rax` which the guest passes straight
+to `malloc`. Registering it to return `SCE_KERNEL_ERROR_ENOSYS` therefore asked for a 2.0 GiB allocation
+where the unregistered default had produced a harmless `malloc(0)` — the #544/#660 class, reintroduced by
+the very change meant to prevent it.
+
+**The rule:** before registering a NID purely to make it visible, establish from the call site whether its
+contract returns a status or a value. If it returns a value and the real one is unknown, the dispatcher's
+`0` — or better, an honest computed value — is correct, and the visibility belongs in the log line, not the
+return. Disassembling one call site is enough: `call …; mov [rbp-N],rax; …; call malloc` settles it in
+seconds, and no amount of reasoning about the function's *name* substitutes for it.
+
 ## The orchestration contract
 
 ### Orchestrator responsibilities

--- a/prosper/docs/GAME_COMPAT_ORCHESTRATION.md
+++ b/prosper/docs/GAME_COMPAT_ORCHESTRATION.md
@@ -132,6 +132,32 @@ Two corollaries worth keeping:
   verdict. The defect is using that same variable as the A/B lever. Give the A/B its own lever, or remove the pin
   for the experiment and say so.
 
+### A host function is not a valid stand-in for guest code — and only Windows will tell you
+
+A test for libSceUlt's ulthreads used an ordinary host C++ function as the ulthread entry. It passed on
+Linux and macOS and failed on **Windows MinGW only**, for three hours, on the single assertion that read the
+entry's argument back out.
+
+The guest is **System V AMD64**; prosper enters guest code through `prosper_call_guest_on_stack`, which
+marshals into SysV (first argument in `%rdi`). On Linux and macOS the host ABI *is* System V, so a host
+function is an accurate model and the test is sound by accident. On Windows the host is **Microsoft x64**,
+where the first argument arrives in `%rcx` — so the untagged host function read a garbage argument and
+returned a garbage status **while still executing correctly and touching its stack**, which is what made it
+look like it worked. The product was never wrong; the test was. `win_thread_trampoline` already documents
+this exact hazard for the production path ("a bare `pthread_create(entry, arg)` mis-passes the arg (MS x64
+vs SysV)").
+
+**The rule: any test that supplies a function for prosper to call *as guest code* must tag it with the guest
+convention**, `__attribute__((sysv_abi))` on x86-64, not leave it at the host default. Prefer the tag over an
+`#ifdef` around the body: "this function uses the guest's calling convention" is true on every platform and
+the attribute is simply redundant where the native ABI already matches. Keep such entries plain leaf
+functions — no destructors, no exceptions — because the attribute conflicts with MinGW's SEH-based C++
+unwinding, which is why `PROSPER_SYSV_ABI` is empty for the HLE handlers (see `dispatch.hpp`).
+
+The generalisable half: **a green Linux run says nothing about ABI-boundary code.** Guest entries, callbacks
+the guest invokes, and anything reached through the call-guest shims are the cases where the dev platform
+cannot fail and Windows is the only place the bug is visible.
+
 ### Registering a NID with an error return can be worse than leaving it unregistered
 
 A trap of the same family as the list above, but in the HLE surface rather than an instrument. It cost a

--- a/prosper/docs/GAME_COMPAT_ORCHESTRATION.md
+++ b/prosper/docs/GAME_COMPAT_ORCHESTRATION.md
@@ -109,6 +109,29 @@ highest-value page in this document.
 - Write `Refs #NN`, not `Fixes #NN`, when a PR only partially addresses an issue — a parenthetical qualifier does
   **not** stop GitHub's auto-close, and #1554 was closed that way despite a comment saying to keep it open.
 
+### Trap #18 — a test seam that pins a policy makes its env-var A/B silently void
+
+An A/B was run by setting `PROSPER_ULT_RETURN_SUCCESS=1` to force libSceUlt's mutex to a no-op, expecting the
+mutual-exclusion test to fail. **It passed**, which read as "the test is too weak to detect a broken lock" — a
+believable and entirely wrong conclusion. The test calls `ult_set_return_success_for_test(false)` in its own
+`main()`, deliberately, so that the environment cannot decide whether it passes. That seam overrode the variable,
+so the "no-op" arm was never a no-op; both arms ran the same real mutex. Re-run with the pin removed, the
+original test caught the broken lock immediately (27,984 of 40,000 increments surviving).
+
+**The rule: any A/B driven by an environment variable is void until you prove the variable actually took effect.**
+Have the run print the policy it is operating under, or assert the arm's expected *behaviour* before trusting its
+result. This is the same shape as trap #10 (a switch that is right for one question and silently wrong for the
+next) and trap #7 (a stale label read as state): a control that legitimately exists for one purpose silently
+neutralises a measurement made for another.
+
+Two corollaries worth keeping:
+
+- The tell is an A/B where **the arms agree when they must differ**. Treat that as an instrument failure first,
+  not a finding. A negative control that cannot fail is not a control.
+- A test that pins its own configuration is still the right design — it stops the environment deciding the
+  verdict. The defect is using that same variable as the A/B lever. Give the A/B its own lever, or remove the pin
+  for the experiment and say so.
+
 ### Registering a NID with an error return can be worse than leaving it unregistered
 
 A trap of the same family as the list above, but in the HLE surface rather than an instrument. It cost a
@@ -130,6 +153,29 @@ contract returns a status or a value. If it returns a value and the real one is 
 `0` — or better, an honest computed value — is correct, and the visibility belongs in the log line, not the
 return. Disassembling one call site is enough: `call …; mov [rbp-N],rax; …; call malloc` settles it in
 seconds, and no amount of reasoning about the function's *name* substitutes for it.
+
+### Proving "the guest never touches X" — pick the exhaustive instrument, not the plausible one
+
+Recurring question when deciding whether prosper may write bookkeeping into a guest-owned struct: *does guest
+code ever read inside it?* Answering it for libSceUlt (#1603) produced one sound instrument and one tempting
+unsound one; the difference is worth reusing.
+
+**Unsound:** identify the functions that operate on the owning C++ class by the displacements they use
+(`[reg+0x398]`, `[reg+0x410]`, …), then look for accesses inside the member's range. Displacement sets are not
+identities — `memcpy`'s bulk AVX stores and every function's own `[rsp+0x...]` stack frame match them. This
+reported **1,361** then **707** hits, all false, and tightening the heuristic eventually matched *nothing*,
+which is equally uninformative. A heuristic that can be tuned from "everything" to "nothing" is measuring the
+tuning, not the subject.
+
+**Sound:** enumerate the objects' actual addresses, then scan **every** RIP-relative reference in the whole
+executable segment and ask which land at a non-zero offset from one. That is exhaustive over the only
+addressing mode that can reach a static object, so zero hits is a proof rather than an absence of evidence. It
+found 16 static Ult objects and **zero** interior references — every reference a `lea` of the base feeding an
+Ult call.
+
+Generalising: prefer the instrument whose **negative result is exhaustive over a closed set** (all
+RIP-relative references) to one that pattern-matches an **open set** (all functions that might alias a
+pointer). When only the open-set instrument exists, its negative result is a hypothesis, not a finding.
 
 ## The orchestration contract
 

--- a/prosper/src/hle/dispatch.hpp
+++ b/prosper/src/hle/dispatch.hpp
@@ -103,6 +103,21 @@ void register_http_hle();
 void register_font_hle();
 // libSceFiber cooperative guest-stack switching; called by register_builtin_hle().
 void register_fiber_hle();
+// Optional host-side hooks around a spawned guest thread's guest-code region. Both run on the HOST
+// %fs — on_enter as the last host action before the guest entry, on_exit as the first after it
+// returns — so either may call host libc. Null hooks are the default and change nothing.
+struct GuestThreadHooks {
+    void (*on_enter)(void* opaque) = nullptr;
+    void (*on_exit)(void* opaque, uint64_t retval) = nullptr;
+    void* opaque = nullptr;
+};
+// Spawn a guest-code thread through the same trampoline scePthreadCreate uses, entering the guest on
+// an explicit caller-supplied stack. Returns 0 on success, otherwise an errno-style code. Used by
+// libSceUlt to run an ulthread on its guest-supplied context buffer (#1603).
+int guest_thread_spawn(uint64_t entry, uint64_t arg, const char* name,
+                       void* guest_stack, size_t guest_stack_size,
+                       const GuestThreadHooks* hooks, uint64_t* out_thread);
+
 // libSceUlt (user-level threading): the ulthread runtime, waiting-queue resource pool, mutexes and
 // condition variables, with the ABI derived from the importing title's own call sites (#1603).
 // Entry points not yet implemented stay registered, counted and fail-visible; see hle_ult.cpp.
@@ -118,6 +133,10 @@ void ult_dump_call_log(FILE* f);
 // the counters. Each setter returns the previous policy. Production code must not call these.
 bool ult_set_return_success_for_test(bool return_success);
 bool ult_set_legacy_enosys_for_test(bool legacy_enosys);
+// Highest number of ulthreads of this runtime observed RUNNING at once (the #1603 amendment-2b
+// deviation counter), and the last join's measured guest-stack high-water (amendment 6).
+uint64_t ult_runtime_high_water_for_test(uint64_t guest_runtime_addr);
+uint64_t ult_last_join_stack_used_for_test(uint64_t* context_size);
 void ult_reset_counts_for_test();
 // libScePad game-controller input (real host controller via input/pad.cpp); called by register_builtin_hle().
 void register_pad_hle();

--- a/prosper/src/hle/dispatch.hpp
+++ b/prosper/src/hle/dispatch.hpp
@@ -103,9 +103,10 @@ void register_http_hle();
 void register_font_hle();
 // libSceFiber cooperative guest-stack switching; called by register_builtin_hle().
 void register_fiber_hle();
-// libSceUlt (user-level threading) — deliberately NOT implemented. Registers fail-VISIBLE counted
-// stubs for the entry points titles actually import, so the missing semantics stop being silent
-// (#1603); see hle_ult.cpp. Called by register_builtin_hle().
+// libSceUlt (user-level threading): the ulthread runtime, waiting-queue resource pool, mutexes and
+// condition variables, with the ABI derived from the importing title's own call sites (#1603).
+// Entry points not yet implemented stay registered, counted and fail-visible; see hle_ult.cpp.
+// Called by register_builtin_hle().
 void register_ult_hle();
 // Calls made to the unimplemented libSceUlt surface, by NID (0 for an unregistered/uncalled NID).
 // Counted PER CALL, unlike the first-seen dedup in prosper_on_unimpl. Diagnostics + tests.
@@ -113,9 +114,10 @@ uint64_t ult_call_count(const char* nid);
 // Append the libSceUlt call table to `f` (nothing if the title never touched Ult). Called from
 // dump_call_log so the existing PROSPER_PROGRESS_UNIMPL periodic dump reports real Ult volume.
 void ult_dump_call_log(FILE* f);
-// Test seams for the return policy (PROSPER_ULT_RETURN_SUCCESS) and the counters. Returns the
-// previous policy. Production code must not call these.
+// Test seams for the return policies (PROSPER_ULT_RETURN_SUCCESS / PROSPER_ULT_LEGACY_ENOSYS) and
+// the counters. Each setter returns the previous policy. Production code must not call these.
 bool ult_set_return_success_for_test(bool return_success);
+bool ult_set_legacy_enosys_for_test(bool legacy_enosys);
 void ult_reset_counts_for_test();
 // libScePad game-controller input (real host controller via input/pad.cpp); called by register_builtin_hle().
 void register_pad_hle();

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -1173,6 +1173,15 @@ HLE(k_pthread_rename) {
 // 8 MiB per exited thread. The trampoline still TRACKS the bounds (via pthread_getattr_np, keyed
 // by our tid) so GC/thread-stack queries stay accurate, and unregisters them on exit — pthread
 // ids are recycled, so a stale entry would serve the next thread the dead thread's bounds.
+
+// Host-side hooks for the NEXT guest_thread_spawn on this thread. Deliberately a thread-local
+// rather than an argument: k_pthread_create also serves scePthreadCreate, whose 5-argument form
+// leaves a5 (r9) caller-indeterminate, so reading hooks out of a guest register would dereference
+// garbage on every ordinary thread creation (the same class as the a4 name-pointer hazard that
+// k_pthread_create_noname exists to avoid). Creation is serialised per calling thread, so a
+// thread-local is exactly the right scope.
+namespace { thread_local const GuestThreadHooks* t_pending_guest_thread_hooks = nullptr; }
+
 #if defined(__linux__) || defined(__APPLE__)
 namespace {
 extern "C" uint64_t prosper_call_guest_on_stack(uintptr_t stack_top, uint64_t fn,
@@ -1185,6 +1194,11 @@ struct ThreadStart {
     char name[kGuestThreadNameSize];
     uint64_t name_generation;
     std::atomic<bool> name_published{false};
+    // Optional host-side hooks, both invoked on the HOST %fs — on_enter as the last host action
+    // before the guest entry, on_exit as the first after it returns. Null for every existing caller,
+    // so this changes nothing for scePthreadCreate. libSceUlt uses them to count RUNNING ulthreads at
+    // the real guest-code boundary and to measure guest stack usage (#1603).
+    GuestThreadHooks hooks{};
 };
 // Runs first on the new thread: register our own stack (keyed by our tid) BEFORE any guest code,
 // so an early GC_register_my_thread / stack-base query from this thread finds it. Closes a race
@@ -1226,6 +1240,7 @@ void* thread_trampoline(void* p) {
 #endif
     auto entry = ts->entry; void* arg = ts->arg;
     void* guest_stack = ts->guest_stack; size_t guest_stack_size = ts->guest_stack_size;
+    const GuestThreadHooks hooks = ts->hooks;
     delete ts;   // all host libc; MUST run on the host %fs
     // gated (PROSPER_GUEST_FS): give this guest worker its own guest TCB + static TLS and switch %fs to it
     // as the LAST host action before entering guest code (so guest initial-exec TLS — incl. libc.prx's
@@ -1233,6 +1248,7 @@ void* thread_trampoline(void* p) {
     // stubs swap back to host %fs per HLE call. No-op when the gate is off. Order matters: the free() above
     // is host glibc (host-TLS tcache) — running it under the guest %fs corrupts the host heap.
     arm_hwbp_this_thread();   // no-op unless PROSPER_HWBP_ALLTHREADS; MUST run on host %fs (host libc calls)
+    if (hooks.on_enter) hooks.on_enter(hooks.opaque);   // host %fs; see ThreadStart::hooks
     guest_tls_activate_thread();
     void* rv = nullptr;
     if (entry) {
@@ -1254,6 +1270,7 @@ void* thread_trampoline(void* p) {
     // exit via scePthreadExit never get here — its import gate already restored host %fs and
     // k_pthread_exit purges before host pthread_exit.
     (void)guest_fs_to_host_scoped();
+    if (hooks.on_exit) hooks.on_exit(hooks.opaque, (uint64_t)(uintptr_t)rv);   // back on host %fs
     tls_dtv_purge_current_thread();
     unregister_thread_stack((uint64_t)pthread_self());   // ids recycle; stale bounds = wrong bounds (#138)
     retire_guest_thread_name((uint64_t)(uintptr_t)pthread_self(), name_generation);
@@ -1276,6 +1293,7 @@ struct WinThreadStart {
     char name[kGuestThreadNameSize];
     uint64_t name_generation;
     std::atomic<bool> name_published{false};
+    GuestThreadHooks hooks{};   // see ThreadStart::hooks
 };
 extern "C" uint64_t prosper_call_guest_sysv(uint64_t fn, uint64_t a0, uint64_t a1);
 extern "C" uint64_t prosper_call_guest_on_stack(uintptr_t stack_top, uint64_t fn,
@@ -1351,6 +1369,7 @@ void* win_thread_trampoline(void* p) {
     uint64_t entry = ts->entry; void* arg = ts->arg;
     void* guest_stack = ts->guest_stack; size_t guest_stack_size = ts->guest_stack_size;
     char name[sizeof(ts->name)]; memcpy(name, ts->name, sizeof(name));
+    const GuestThreadHooks hooks = ts->hooks;
     delete ts;   // host libc: run on host %fs (before activate)
     if (name[0]) {
         wchar_t wname[sizeof(name)]{};
@@ -1375,6 +1394,7 @@ void* win_thread_trampoline(void* p) {
     }
     trace_guest_thread_lifecycle(true, (uint64_t)pthread_self(),
                                  (uint64_t)GetCurrentThreadId(), registered_base, registered_size);
+    if (hooks.on_enter) hooks.on_enter(hooks.opaque);   // host %fs; see ThreadStart::hooks
     guest_tls_activate_thread();   // this worker's guest %fs TCB (FSGSBASE); no-op if the gate is off
     void* rv = nullptr;
     if (entry) {
@@ -1407,6 +1427,7 @@ void* win_thread_trampoline(void* p) {
             }
         }
     }
+    if (hooks.on_exit) hooks.on_exit(hooks.opaque, (uint64_t)(uintptr_t)rv);   // back on host %fs
     tls_dtv_purge_current_thread();
     trace_guest_thread_lifecycle(false, (uint64_t)pthread_self(),
                                  (uint64_t)GetCurrentThreadId(), registered_base, registered_size);
@@ -1462,6 +1483,7 @@ HLE(k_pthread_create) {
     ts->guest_stack = supplied_stack; ts->guest_stack_size = supplied_stack_size;
     ts->name_generation = next_guest_thread_name_generation();
     ts->name[0] = 0;
+    if (t_pending_guest_thread_hooks) ts->hooks = *t_pending_guest_thread_hooks;
     if (a4) { strncpy(ts->name, (const char*)(uintptr_t)a4, sizeof(ts->name) - 1); ts->name[sizeof(ts->name) - 1] = 0; }
     int r = pthread_create(&tid, &la, thread_trampoline, ts);   // trampoline registers the stack first
     if (getenv("PROSPER_SYNCLOG")) fprintf(stderr, "[thread] pthread_create rc=%d\n", r);
@@ -1499,6 +1521,7 @@ HLE(k_pthread_create) {
     ts->guest_stack = supplied_stack; ts->guest_stack_size = supplied_stack_size;
     ts->name_generation = next_guest_thread_name_generation();
     ts->name[0] = 0;
+    if (t_pending_guest_thread_hooks) ts->hooks = *t_pending_guest_thread_hooks;
     if (a4) { strncpy(ts->name, (const char*)(uintptr_t)a4, sizeof(ts->name) - 1); ts->name[sizeof(ts->name) - 1] = 0; }
     int r = pthread_create(&tid, &la, win_thread_trampoline, ts);
     pthread_attr_destroy(&la);
@@ -1509,6 +1532,36 @@ HLE(k_pthread_create) {
     if (a0) *(uint64_t*)a0 = (uint64_t)tid;
     return 0;
 }
+// Spawn a guest-code thread through the EXACT path scePthreadCreate uses, with an explicit
+// caller-supplied guest stack and optional host-side entry/exit hooks.
+//
+// This exists so libSceUlt's ulthreads (#1603) reuse the trampoline rather than reimplementing it.
+// That trampoline carries a lot of hard-won behaviour a second copy would silently lose: the guest
+// %fs TCB activation and its terminal restore before glibc's thread cleanup (#644), stack-bounds
+// registration keyed by tid and its removal on exit because pthread ids recycle (#138), the
+// __tls_get_addr DTV purge (#68), sigaltstack for a catchable guest stack overflow, and host thread
+// naming. `guest_stack` is honoured exactly: the host pthread keeps a glibc-owned stack for its own
+// static TLS and bookkeeping, and the guest entry is called on the caller's range — which is what
+// _sceUltUlthreadCreate's `context`/`sizeContext` pair is.
+int guest_thread_spawn(uint64_t entry, uint64_t arg, const char* name,
+                       void* guest_stack, size_t guest_stack_size,
+                       const GuestThreadHooks* hooks, uint64_t* out_thread) {
+    GuestPthreadAttr attr{};
+    pthread_attr_init(&attr.host);
+    pthread_attr_setdetachstate(&attr.host, PTHREAD_CREATE_JOINABLE);
+    attr.supplied_stack = guest_stack;
+    attr.supplied_stack_size = guest_stack_size;
+    void* attr_ptr = &attr;
+    uint64_t tid = 0;
+    t_pending_guest_thread_hooks = hooks;
+    const uint64_t rc = k_pthread_create((uint64_t)(uintptr_t)&tid, (uint64_t)(uintptr_t)&attr_ptr,
+                                         entry, arg, (uint64_t)(uintptr_t)name, 0);
+    t_pending_guest_thread_hooks = nullptr;
+    pthread_attr_destroy(&attr.host);
+    if (rc == 0 && out_thread) *out_thread = tid;
+    return (int)rc;
+}
+
 // Plain POSIX pthread_create(thread, attr, start, arg) has only 4 args, so a4 (r8) is caller-indeterminate
 // scratch. k_pthread_create reads a4 as a thread-name pointer -- legitimate for scePthreadCreate /
 // pthread_create_name_np (5-arg), but for the 4-arg POSIX form a non-zero garbage a4 makes it strncpy from

--- a/prosper/src/hle/hle_ult.cpp
+++ b/prosper/src/hle/hle_ult.cpp
@@ -44,24 +44,26 @@ namespace {
 // title (Earthion / PPSA28061). Any other Ult NID a future title imports still falls through to the
 // generic unimplemented-import path, which logs it — add it here when that happens.
 // CONFIDENCE: HIGH (two independent instruments agree on the NID<->name mapping and the import set).
-struct UltEntry { const char* nid; const char* name; };
+// `returns_size` marks the entry points whose contract returns a VALUE (a byte count) rather than a
+// STATUS. Those must never be handed an error sentinel — see kUltSizeUnknown below (#1618).
+struct UltEntry { const char* nid; const char* name; bool returns_size; };
 constexpr UltEntry kUlt[] = {
-    { "jw9FkZBXo-g", "_sceUltUlthreadRuntimeCreate" },
-    { "grs2pbc2awM", "sceUltUlthreadRuntimeGetWorkAreaSize" },
-    { "znI3q8S7KQ4", "_sceUltUlthreadCreate" },
-    { "gCeAI57LGgI", "sceUltUlthreadJoin" },
-    { "mmt8Sa6tL6c", "_sceUltMutexCreate" },
-    { "8hEGkR1pfr8", "sceUltMutexLock" },
-    { "h0XebKiMBtk", "sceUltMutexUnlock" },
-    { "jW+HnafeS3Y", "sceUltMutexDestroy" },
-    { "jnKaHGkrxZ4", "_sceUltConditionVariableCreate" },
-    { "5xGAHCxA8M0", "sceUltConditionVariableWait" },
-    { "JTw1cAVkuc0", "sceUltConditionVariableSignal" },
-    { "xrmmI832R4U", "sceUltConditionVariableDestroy" },
-    { "YiHujOG9vXY", "_sceUltWaitingQueueResourcePoolCreate" },
-    { "WIWV1Qd7PFU", "sceUltWaitingQueueResourcePoolGetWorkAreaSize" },
-    { "hZIg1EWGsHM", "sceUltInitialize" },
-    { "d-kSG2fLrvI", "sceUltFinalize" },
+    { "jw9FkZBXo-g", "_sceUltUlthreadRuntimeCreate",                  false },
+    { "grs2pbc2awM", "sceUltUlthreadRuntimeGetWorkAreaSize",          true  },
+    { "znI3q8S7KQ4", "_sceUltUlthreadCreate",                         false },
+    { "gCeAI57LGgI", "sceUltUlthreadJoin",                            false },
+    { "mmt8Sa6tL6c", "_sceUltMutexCreate",                            false },
+    { "8hEGkR1pfr8", "sceUltMutexLock",                               false },
+    { "h0XebKiMBtk", "sceUltMutexUnlock",                             false },
+    { "jW+HnafeS3Y", "sceUltMutexDestroy",                            false },
+    { "jnKaHGkrxZ4", "_sceUltConditionVariableCreate",                false },
+    { "5xGAHCxA8M0", "sceUltConditionVariableWait",                   false },
+    { "JTw1cAVkuc0", "sceUltConditionVariableSignal",                 false },
+    { "xrmmI832R4U", "sceUltConditionVariableDestroy",                false },
+    { "YiHujOG9vXY", "_sceUltWaitingQueueResourcePoolCreate",         false },
+    { "WIWV1Qd7PFU", "sceUltWaitingQueueResourcePoolGetWorkAreaSize", true  },
+    { "hZIg1EWGsHM", "sceUltInitialize",                              false },
+    { "d-kSG2fLrvI", "sceUltFinalize",                                false },
 };
 constexpr size_t kUltCount = sizeof(kUlt) / sizeof(kUlt[0]);
 
@@ -82,6 +84,32 @@ constexpr size_t kUltCount = sizeof(kUlt) / sizeof(kUlt[0]);
 //             should fall into its generic error path. That is still the correct outcome: the call
 //             genuinely failed.
 constexpr uint64_t kUltNotImplemented = 0x8002004Eull;   // SCE_KERNEL_ERROR_ENOSYS
+
+// ...but ONLY for entry points whose contract returns a STATUS. Two of the sixteen do not (#1618).
+//
+// `sceUltUlthreadRuntimeGetWorkAreaSize` and `sceUltWaitingQueueResourcePoolGetWorkAreaSize` return a
+// `size_t` AS THEIR RETURN VALUE. #1603 asserted they were size queries with an out-parameter; the
+// guest's own call site disproves that — there is no out-param, and the returned value is handed
+// straight to malloc:
+//
+//   9c55:  call sceUltWaitingQueueResourcePoolGetWorkAreaSize
+//   9c5a:  mov  QWORD PTR [rbp-0x10],rax     <- the size IS the return value
+//   9c62:  call malloc                       <- fed directly to malloc
+//
+// A signature whose return type is a size HAS NO ERROR CHANNEL, so any value returned is read as data.
+// Returning SCE_KERNEL_ERROR_ENOSYS from them therefore asked the guest for a 0x8002004E-byte
+// (2.0 GiB) allocation — twice — which is the #544/#660 failure class this file was written to prevent.
+//
+// It was also strictly worse than not registering the NIDs at all: the dispatcher's unresolved-import
+// default is `return 0` (dispatch.cpp prosper_on_unimpl), so before registration the guest got 0,
+// called malloc(0), received a valid small pointer and carried on harmlessly.
+//
+// The rule this file now follows: an unimplemented entry point may only return an error sentinel when
+// its contract returns a STATUS. When the contract returns a VALUE, the visibility belongs in the log
+// line — never in the return. prosper consumes no work area yet, so its own requirement is genuinely
+// zero bytes and 0 is the honest answer as well as the safe one.
+// CONFIDENCE: HIGH (the call site is unambiguous, and 0 restores the pre-registration behaviour).
+constexpr uint64_t kUltSizeUnknown = 0ull;
 
 std::atomic<uint64_t> g_calls[kUltCount];
 std::atomic<uint64_t> g_next_report[kUltCount];   // 0 = "report the next call" (i.e. the first)
@@ -116,7 +144,11 @@ void print_banner() {
 uint64_t ult_report(size_t index) {
     const uint64_t n = g_calls[index].fetch_add(1, std::memory_order_relaxed) + 1;
     const bool success = g_return_success.load(std::memory_order_relaxed);
-    const uint64_t ret = success ? 0ull : kUltNotImplemented;
+    // A size-returning contract has no error channel: the sentinel would be read as a byte count and
+    // handed to malloc (#1618). Such an entry point reports through the log line only.
+    const uint64_t ret = kUlt[index].returns_size ? kUltSizeUnknown
+                       : success                  ? 0ull
+                                                  : kUltNotImplemented;
     // Log at 1, 10, 100, 1e3, ... — bounded (a 1e6-call spin costs 7 lines) but never silent.
     // The threshold is a plain load/store rather than a CAS: guest threads racing here can at worst
     // emit the SAME milestone line twice, never suppress one. A duplicate diagnostic line is
@@ -134,29 +166,29 @@ uint64_t ult_report(size_t index) {
                                            "unimplemented user-level lock ***"
                           : n >= 1000    ? "  *** >=1,000 CALLS — hot path, not a one-off ***"
                                          : "";
+        const char* policy = kUlt[index].returns_size
+                                 ? " (a SIZE, not a status — this contract has no error channel, #1618)"
+                             : success
+                                 ? "  [PROSPER_ULT_RETURN_SUCCESS: FAKE SUCCESS, guest is being lied to]"
+                                 : " (SCE_KERNEL_ERROR_ENOSYS)";
         fprintf(stderr, "[prosper] libSceUlt UNIMPLEMENTED: %s (%s) call #%llu -> returning 0x%llx%s%s\n",
                 kUlt[index].name, kUlt[index].nid, (unsigned long long)n,
-                (unsigned long long)ret,
-                success ? "  [PROSPER_ULT_RETURN_SUCCESS: FAKE SUCCESS, guest is being lied to]"
-                        : " (SCE_KERNEL_ERROR_ENOSYS)",
-                scale);
+                (unsigned long long)ret, policy, scale);
     }
     return ret;
 }
 
 // One distinct host function per NID so the handler knows which entry point was called.
 //
-// The guest arguments are read by NOTHING here, and — the deliberate part — no guest out-param is
-// ever written. That decision is load-bearing for the two size queries in the table,
-// `sceUltUlthreadRuntimeGetWorkAreaSize` and `sceUltWaitingQueueResourcePoolGetWorkAreaSize`, which
-// exist to fill a `size_t*` the guest then allocates from. prosper has no evidence of what those
-// sizes should be, and writing a plausible-looking number would be exactly the #544/#660 defect in
-// a new costume: an AGC "success" stub that left its required-memory output unwritten made Dead
-// Cells allocate multiple gigabytes. Returning a real error and touching nothing is the honest
-// pairing — a guest that checks the return sees failure and must not read the buffer; a guest that
-// ignores the failure and consumes uninitialised memory is now displaying ITS OWN bug, on a call
-// that also just logged loudly, instead of silently inheriting a fabricated value from us.
-// CONFIDENCE: HIGH (writing an invented size is strictly worse than writing nothing).
+// No guest memory is read or written here. #1603 justified that partly on the belief that the two
+// size queries fill a `size_t*` out-parameter; they do not — they return the size in rax and the
+// guest passes it straight to malloc, which is what made an error sentinel actively harmful (#1618).
+// The remaining reason still holds and is the real one: prosper has no evidence of what those sizes
+// should be, and writing (or returning) a plausible-looking number would be the #544/#660 defect in a
+// new costume — an AGC "success" stub whose unwritten required-memory output made Dead Cells allocate
+// multiple gigabytes. Zero is the honest answer for as long as prosper consumes no work area, and it
+// is also the value the dispatcher's unresolved-import path would have produced.
+// CONFIDENCE: HIGH (inventing a size is strictly worse than reporting the one prosper actually needs).
 template <size_t Index>
 PROSPER_SYSV_ABI uint64_t ult_stub(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t) {
     return ult_report(Index);

--- a/prosper/src/hle/hle_ult.cpp
+++ b/prosper/src/hle/hle_ult.cpp
@@ -152,6 +152,7 @@ constexpr uint64_t kUltErrSrch        = 0x80020003ull;   // ESRCH   — stale / 
 constexpr uint64_t kUltErrDeadlk      = 0x8002000Bull;   // EDEADLK — self-relock of a non-recursive mutex
 constexpr uint64_t kUltErrNoMem       = 0x8002000Cull;   // ENOMEM
 constexpr uint64_t kUltErrInval       = 0x80020016ull;   // EINVAL
+constexpr uint64_t kUltErrAgain       = 0x80020023ull;   // EAGAIN  — runtime is at numMaxUlthread
 constexpr uint64_t kUltNotImplemented = 0x8002004Eull;   // ENOSYS — still-unimplemented entry points
 
 // A size-returning contract has no error channel (#1618): whatever these return is read as a byte
@@ -279,6 +280,19 @@ struct UltObject {
     std::atomic<bool> warned_concurrency{false};
     std::atomic<uint32_t> bound_sync_objects{0};
     std::atomic<bool> warned_pool_capacity{false};
+
+    // ConditionVariable wake accounting (see the condvar block for why these are lock-free).
+    std::atomic<uint64_t> wait_seq{0}, wake_seq{0};
+    std::atomic<bool> destroying{false};
+
+    // Ulthread.
+    uint64_t runtime_id = 0;
+    uint64_t context = 0, context_size = 0;
+    uint64_t host_thread = 0;
+    std::atomic<bool> finished{false}, joined{false};
+    std::atomic<uint32_t> exit_status{0};
+    std::atomic<uint64_t> stack_used{0};
+    std::atomic<bool> stack_exact{false};   // false => stack_used is a lower bound (probe < context)
 };
 
 std::shared_mutex                          g_reg_lock;
@@ -467,6 +481,8 @@ void abstime_in_ms(struct timespec& ts, uint64_t ms) {
 // ---------------------------------------------------------------------------------------------
 std::atomic<bool>     g_initialized{false};
 std::atomic<uint64_t> g_init_calls{0};
+// Last joined ulthread's measured guest-stack high-water (amendment 6). Diagnostics + tests.
+std::atomic<uint64_t> g_last_join_stack_used{0}, g_last_join_context_size{0};
 
 void print_banner() {
     if (g_banner_printed.exchange(true)) return;
@@ -508,17 +524,6 @@ bool implement(size_t index, uint64_t* out) {
     if (g_legacy_enosys.load(std::memory_order_relaxed)) { *out = kUltNotImplemented; return false; }
     if (g_return_success.load(std::memory_order_relaxed)) { *out = kUltOk; return false; }
     return true;
-}
-
-// An entry point that is registered and counted but whose semantics are not implemented yet.
-uint64_t refuse(size_t index) {
-    uint64_t out = 0;
-    if (!implement(index, &out)) return out;
-    static std::atomic<uint64_t> reported[kUltCount];
-    if (reported[index].fetch_add(1, std::memory_order_relaxed) < 4)
-        log_line("%s is NOT IMPLEMENTED — returning 0x%llx (SCE_KERNEL_ERROR_ENOSYS)",
-                 kUlt[index].name, (unsigned long long)kUltNotImplemented);
-    return kUltNotImplemented;
 }
 
 std::string guest_string(uint64_t addr) {
@@ -893,14 +898,459 @@ PROSPER_SYSV_ABI uint64_t ult_mutex_destroy(uint64_t a0, uint64_t, uint64_t, uin
 }
 
 // =============================================================================================
-// Not yet implemented: ulthread create/join and the condition variables. Registered, counted and
-// refused; see the ABI block at the top of this file for their established layouts.
+// Ulthreads
+//
+// One real guest thread per ulthread, spawned through the same trampoline scePthreadCreate uses so
+// the guest %fs TCB, stack registration, sigaltstack and TLS-purge behaviour are the proven ones
+// rather than a second copy. The guest's own `context`/`sizeContext` pair IS the ulthread's stack on
+// hardware, and prosper enters the guest on exactly that range.
+//
+// Two deviations from hardware are instrumented rather than trusted:
+//   * CONCURRENCY WIDTH. Hardware runs at most numWorkerThread ulthreads simultaneously. The runtime
+//     counts RUNNING ulthreads at the real guest-code boundary (the on_enter/on_exit hooks fire on
+//     the host %fs immediately around the guest entry) and reports the first crossing. Safe here
+//     because numWorkerThread is a function-local constant at eboot+0x9ca3 with exactly two reads —
+//     this size query and this Create — so the guest sizes and indexes nothing by worker count.
+//   * GUEST STACK. Earthion gives each ulthread 0x2000 bytes, and guest code has never run on a
+//     guest-supplied stack in this path before. The context is filled with a pattern at create and
+//     the untouched prefix measured at exit, so an ulthread approaching its stack limit is reported
+//     instead of silently overflowing into whatever the guest packed next to the buffer.
 // =============================================================================================
-template <size_t Index>
-PROSPER_SYSV_ABI uint64_t ult_refuse(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t) {
-    return refuse(Index);
+constexpr uint8_t kStackFillByte = 0xCD;
+// Only the BOTTOM of the context is patterned, not all of it. The guest stack grows down from
+// base+size, so the bottom is the only region an overflow has to cross, and probing just that region
+// answers the question that matters — "did this ulthread come close to the end of its stack?" —
+// without the cost of the alternative. Filling the whole buffer would force every page of it
+// resident: Earthion's "Leaderboards Thread" asks for an 8 MiB context, so a full fill would commit
+// 8 MiB of guest memory the title might never have touched, and the measurement would have changed
+// the thing it was measuring. A context at or below the probe size (Earthion's other three are 8 KiB,
+// 8 KiB and 32 KiB) is covered end to end, giving an exact high-water figure.
+constexpr uint64_t kStackProbeBytes = 64 * 1024;
+// Warn when the deepest frame came within a quarter of the probe of the bottom — close enough to
+// predict the overflow, far enough not to fire on healthy usage.
+constexpr uint64_t kStackWarnFraction = 4;
+
+uint64_t stack_probe_bytes(uint64_t size) {
+    return size < kStackProbeBytes ? size : kStackProbeBytes;
 }
 
+// Bytes of untouched pattern remaining at the BOTTOM of the context. probe == the full probe region
+// means the stack never reached into it.
+uint64_t stack_untouched_at_bottom(uint64_t base, uint64_t size) {
+    const uint64_t probe = stack_probe_bytes(size);
+    if (!base || !probe || !gpu::guest_readable(base, 1)) return probe;
+    const auto* p = (const uint8_t*)(uintptr_t)base;
+    uint64_t untouched = 0;
+    while (untouched < probe && p[untouched] == kStackFillByte) ++untouched;
+    return untouched;
+}
+
+void ulthread_on_enter(void* opaque) {
+    auto* o = (UltObject*)opaque;
+    UltObject* rt = object_from_id(o->runtime_id, UltType::Runtime);
+    if (!rt) return;
+    const uint32_t running = rt->running_ulthreads.fetch_add(1, std::memory_order_acq_rel) + 1;
+    uint32_t hw = rt->high_water.load(std::memory_order_relaxed);
+    while (running > hw && !rt->high_water.compare_exchange_weak(hw, running,
+                                                                 std::memory_order_relaxed)) {}
+    if (running > rt->num_worker_thread && !rt->warned_concurrency.exchange(true))
+        log_line("CONCURRENCY: %u ulthreads of runtime \"%s\" are running at once, but it was created "
+                 "with numWorkerThread=%u. prosper runs ulthreads one-to-one on real guest threads "
+                 "instead of multiplexing them onto that many workers, so more can run in parallel "
+                 "than on hardware. Reported, deliberately NOT capped — capping would trade a visible "
+                 "deviation for a hidden scheduling stall",
+                 running, rt->name.c_str(), rt->num_worker_thread);
+}
+
+void ulthread_on_exit(void* opaque, uint64_t retval) {
+    auto* o = (UltObject*)opaque;
+    o->exit_status.store((uint32_t)retval, std::memory_order_relaxed);
+    o->finished.store(true, std::memory_order_release);
+    const uint64_t probe = stack_probe_bytes(o->context_size);
+    const uint64_t untouched = stack_untouched_at_bottom(o->context, o->context_size);
+    // Exact when the probe covered the whole context; otherwise a lower bound (the stack never
+    // reached the probed bottom, so it used less than size - probe).
+    const uint64_t used = untouched >= probe ? o->context_size - probe : o->context_size - untouched;
+    o->stack_used.store(used, std::memory_order_relaxed);
+    o->stack_exact.store(probe >= o->context_size, std::memory_order_relaxed);
+    if (probe && untouched < probe / kStackWarnFraction)
+        log_line("GUEST STACK: ulthread \"%s\" came within %llu bytes of the bottom of its "
+                 "%llu-byte context. The context buffer IS the ulthread's stack; overflowing it "
+                 "corrupts whatever the guest allocated next to it",
+                 o->name.c_str(), (unsigned long long)untouched,
+                 (unsigned long long)o->context_size);
+    if (UltObject* rt = object_from_id(o->runtime_id, UltType::Runtime))
+        rt->running_ulthreads.fetch_sub(1, std::memory_order_acq_rel);
+}
+
+// Claim / release a slot in the runtime's guest work area. The work area is what makes
+// sceUltUlthreadRuntimeGetWorkAreaSize's answer load-bearing rather than decorative.
+bool runtime_claim_slot(UltObject* rt, uint64_t ulthread_id, uint64_t context, uint64_t context_size) {
+    if (!rt->work_area || !gpu::guest_readable(rt->work_area, sizeof(RuntimeWorkArea))) return false;
+    auto* wa = (RuntimeWorkArea*)(uintptr_t)rt->work_area;
+    if (wa->magic != kWorkMagicRuntime) {
+        log_line("runtime \"%s\" work area at 0x%llx no longer carries prosper's header (0x%llx) — "
+                 "freed or reused by the guest while the runtime is still live",
+                 rt->name.c_str(), (unsigned long long)rt->work_area, (unsigned long long)wa->magic);
+        return false;
+    }
+    auto* slots = (RuntimeSlot*)(uintptr_t)(rt->work_area + sizeof(RuntimeWorkArea));
+    for (uint32_t i = 0; i < wa->num_max_ulthread; ++i) {
+        if (slots[i].ulthread_id) continue;
+        slots[i].ulthread_id = ulthread_id;
+        slots[i].context = context;
+        slots[i].context_size = context_size;
+        slots[i].host_thread = 0;
+        return true;
+    }
+    return false;
+}
+
+void runtime_release_slot(UltObject* rt, uint64_t ulthread_id) {
+    if (!rt || !rt->work_area || !gpu::guest_readable(rt->work_area, sizeof(RuntimeWorkArea))) return;
+    auto* wa = (RuntimeWorkArea*)(uintptr_t)rt->work_area;
+    if (wa->magic != kWorkMagicRuntime) return;
+    auto* slots = (RuntimeSlot*)(uintptr_t)(rt->work_area + sizeof(RuntimeWorkArea));
+    for (uint32_t i = 0; i < wa->num_max_ulthread; ++i)
+        if (slots[i].ulthread_id == ulthread_id) { slots[i] = RuntimeSlot{0, 0, 0, 0}; return; }
+}
+
+// _sceUltUlthreadCreate(ult, name, entry, arg, context, sizeContext, runtime, optParam, apiVersion).
+// 9 args; runtime/optParam/apiVersion arrive on the guest stack and the import bridge forwards them.
+PROSPER_SYSV_ABI uint64_t ult_ulthread_create(uint64_t a0, uint64_t a1, uint64_t a2, uint64_t a3,
+                                              uint64_t a4, uint64_t a5, uint64_t a6, uint64_t a7,
+                                              uint64_t a8) {
+    uint64_t out = 0;
+    if (!implement(kIdxUlthreadCreate, &out)) return out;
+    note_uninitialised("_sceUltUlthreadCreate");
+    (void)a7;   // optParam: NULL at every observed call site
+
+    if (!guest_object_writable(a0)) {
+        log_line("_sceUltUlthreadCreate: unusable ulthread pointer 0x%llx", (unsigned long long)a0);
+        return kUltErrInval;
+    }
+    if (!a2 || !gpu::guest_readable(a2, 1)) {
+        log_line("_sceUltUlthreadCreate: entry 0x%llx is not executable guest code",
+                 (unsigned long long)a2);
+        return kUltErrInval;
+    }
+    UltObject* rt = resolve(a6, UltType::Runtime, "_sceUltUlthreadCreate(runtime)");
+    if (!rt) return kUltErrInval;
+    if (!a4 || !a5 || !gpu::guest_readable(a4, (uint32_t)std::min<uint64_t>(a5, 4096))) {
+        log_line("_sceUltUlthreadCreate: context 0x%llx size %llu is unusable as this ulthread's stack",
+                 (unsigned long long)a4, (unsigned long long)a5);
+        return kUltErrInval;
+    }
+
+    // numMaxUlthread is unambiguous and the guest chose it, so it is enforced rather than merely
+    // reported: exceeding it means the runtime the guest sized is genuinely full.
+    const uint32_t live = rt->live_ulthreads.load(std::memory_order_relaxed);
+    if (live >= rt->num_max_ulthread) {
+        log_line("_sceUltUlthreadCreate: runtime \"%s\" already holds %u of numMaxUlthread=%u "
+                 "ulthreads — refusing", rt->name.c_str(), live, rt->num_max_ulthread);
+        return kUltErrAgain;
+    }
+
+    UltObject* o = allocate_object(UltType::Ulthread);
+    o->name = guest_string(a1);
+    o->guest_addr = a0;
+    o->api_version = (uint32_t)a8;
+    o->runtime_id = make_id(rt->slot, rt->generation);
+    o->context = a4;
+    o->context_size = a5;
+    o->host_thread = 0;
+    o->finished.store(false, std::memory_order_relaxed);
+    o->joined.store(false, std::memory_order_relaxed);
+    o->exit_status.store(0, std::memory_order_relaxed);
+    o->stack_used.store(0, std::memory_order_relaxed);
+    o->alive.store(true, std::memory_order_release);
+    const uint64_t id = make_id(o->slot, o->generation);
+
+    if (!runtime_claim_slot(rt, id, a4, a5)) {
+        log_line("_sceUltUlthreadCreate: runtime \"%s\" has no free work-area slot", rt->name.c_str());
+        o->alive.store(false, std::memory_order_release);
+        return kUltErrAgain;
+    }
+    if (!publish_object(a0, UltType::Ulthread, id)) {
+        runtime_release_slot(rt, id);
+        o->alive.store(false, std::memory_order_release);
+        return kUltErrInval;
+    }
+
+    // Amendment 6: the context IS the stack. Fill it so the untouched prefix at exit measures the
+    // high-water mark. Safe to write — the guest malloc'd this buffer immediately before the call
+    // (eboot+0x9de0) purely to hand it over, so nothing of its own is in it yet.
+    std::memset((void*)(uintptr_t)a4, kStackFillByte, (size_t)stack_probe_bytes(a5));
+
+    rt->live_ulthreads.fetch_add(1, std::memory_order_acq_rel);
+    GuestThreadHooks hooks;
+    hooks.on_enter = ulthread_on_enter;
+    hooks.on_exit  = ulthread_on_exit;
+    hooks.opaque   = o;
+    uint64_t thread = 0;
+    const int rc = guest_thread_spawn(a2, a3, o->name.empty() ? "ulthread" : o->name.c_str(),
+                                      (void*)(uintptr_t)a4, (size_t)a5, &hooks, &thread);
+    if (rc != 0) {
+        log_line("_sceUltUlthreadCreate(\"%s\"): guest thread spawn failed (%d)", o->name.c_str(), rc);
+        rt->live_ulthreads.fetch_sub(1, std::memory_order_acq_rel);
+        runtime_release_slot(rt, id);
+        unpublish_object(a0);
+        o->alive.store(false, std::memory_order_release);
+        return kUltErrNoMem;
+    }
+    o->host_thread = thread;
+    log_line("_sceUltUlthreadCreate(\"%s\") ulthread=0x%llx entry=0x%llx arg=0x%llx "
+             "context=0x%llx+%llu runtime=\"%s\" apiVersion=0x%x -> running on guest thread 0x%llx",
+             o->name.c_str(), (unsigned long long)a0, (unsigned long long)a2,
+             (unsigned long long)a3, (unsigned long long)a4, (unsigned long long)a5,
+             rt->name.c_str(), o->api_version, (unsigned long long)thread);
+    return kUltOk;
+}
+
+// sceUltUlthreadJoin(ulthread, int32_t* status). The status out-param is 4 bytes: the call site at
+// eboot+0x9f1e passes `lea rsi,[rbp-0xc]`, a 4-byte local below the stack canary at [rbp-0x8].
+PROSPER_SYSV_ABI uint64_t ult_ulthread_join(uint64_t a0, uint64_t a1, uint64_t, uint64_t, uint64_t,
+                                            uint64_t) {
+    uint64_t out = 0;
+    if (!implement(kIdxUlthreadJoin, &out)) return out;
+    UltObject* o = resolve(a0, UltType::Ulthread, "sceUltUlthreadJoin");
+    if (!o) return kUltErrSrch;
+    if (o->joined.exchange(true, std::memory_order_acq_rel)) {
+        log_line("sceUltUlthreadJoin: ulthread \"%s\" (0x%llx) was already joined", o->name.c_str(),
+                 (unsigned long long)a0);
+        return kUltErrInval;
+    }
+
+    // Watchdog: the guest frees the context buffer right after join returns, so a join that never
+    // returns is both a hang AND the reason a later use-after-free would look inexplicable.
+    if (!o->finished.load(std::memory_order_acquire)) {
+        const uint64_t warn_ms = block_warn_ms();
+        struct timespec deadline;
+        abstime_in_ms(deadline, warn_ms);
+        int rc = 0;
+#if defined(__linux__)
+        rc = pthread_timedjoin_np((pthread_t)(uintptr_t)o->host_thread, nullptr, &deadline);
+        if (rc == ETIMEDOUT) {
+            log_line("BLOCKED >%llums: sceUltUlthreadJoin on \"%s\" (0x%llx) — the ulthread has not "
+                     "returned. Still waiting. (PROSPER_ULT_BLOCK_WARN_MS)",
+                     (unsigned long long)warn_ms, o->name.c_str(), (unsigned long long)a0);
+            rc = pthread_join((pthread_t)(uintptr_t)o->host_thread, nullptr);
+        }
+#else
+        rc = pthread_join((pthread_t)(uintptr_t)o->host_thread, nullptr);
+#endif
+        if (rc != 0 && rc != ESRCH) {
+            log_line("sceUltUlthreadJoin on \"%s\" failed: pthread rc=%d", o->name.c_str(), rc);
+            return kUltErrInval;
+        }
+    } else {
+        pthread_join((pthread_t)(uintptr_t)o->host_thread, nullptr);
+    }
+
+    // The ulthread entry is int32_t(*)(uint64_t); its return travels in eax.
+    const uint32_t status = o->exit_status.load(std::memory_order_relaxed);
+    if (a1) {
+        if (!gpu::guest_readable(a1, sizeof(int32_t))) {
+            log_line("sceUltUlthreadJoin: status out-param 0x%llx is unusable — not writing it",
+                     (unsigned long long)a1);
+        } else {
+            *(int32_t*)(uintptr_t)a1 = (int32_t)status;
+        }
+    }
+    g_last_join_stack_used.store(o->stack_used.load(std::memory_order_relaxed),
+                                 std::memory_order_relaxed);
+    g_last_join_context_size.store(o->context_size, std::memory_order_relaxed);
+    log_line("sceUltUlthreadJoin(\"%s\") -> status %d, guest stack high-water %s%llu of %llu bytes",
+             o->name.c_str(), (int)status,
+             o->stack_exact.load(std::memory_order_relaxed) ? "" : "<=",
+             (unsigned long long)o->stack_used.load(), (unsigned long long)o->context_size);
+
+    UltObject* rt = object_from_id(o->runtime_id, UltType::Runtime);
+    if (rt) {
+        runtime_release_slot(rt, make_id(o->slot, o->generation));
+        rt->live_ulthreads.fetch_sub(1, std::memory_order_acq_rel);
+    }
+    unpublish_object(a0);
+    o->alive.store(false, std::memory_order_release);
+    return kUltOk;
+}
+
+// =============================================================================================
+// Condition variables
+//
+// sceUltConditionVariableWait takes ONE argument: the mutex is bound at create. Two facts from the
+// guest's own call sites shape this implementation, and both were established before writing it.
+//
+//  1. THE CALLER HOLDS THE BOUND MUTEX AT EVERY Wait. All five sites are immediately preceded by
+//     sceUltMutexLock on exactly the mutex the condvar was created with (eboot 0xbda0->0xbdba,
+//     0x13808->0x1381b, 0x1386d->0x13880, 0x1427e->0x14291, 0xff433->0xff446). That is what makes
+//     pthread_cond_wait's atomic release/reacquire correct rather than undefined.
+//
+//  2. THE CALLER DOES *NOT* HOLD IT AT Signal. At every one of the eleven Signal sites the bound
+//     mutex is unheld — the guest either holds a DIFFERENT mutex (0xb582 unlocks +0x70 before
+//     signalling the condvar at +0x170, whose bound mutex is +0x270) or holds nothing at all
+//     (0xff502, 0xff5db). Signalling outside the mutex is legal, but it means the wake accounting
+//     cannot be protected by the bound mutex, because Signal never takes it.
+//
+// So wakes are accounted with two monotonic counters instead of a shared lock. A waiter takes ticket
+// N from `wait_seq` and proceeds only once `wake_seq` reaches N; Signal advances `wake_seq` by one
+// and broadcasts. This gives exactly-one-waiter-released-per-Signal, suppresses spurious wakeups
+// (the guest must not resume on an unmet predicate if any of its five sites turns out not to loop on
+// one), and preserves the POSIX rule that a Signal with no waiter is LOST rather than remembered —
+// `wake_seq` never overtakes `wait_seq`.
+//
+// The one window this leaves is a broadcast landing between a waiter's ticket test and its
+// pthread_cond_timedwait, which no lock-free scheme can close while Signal does not take the mutex.
+// It is bounded rather than papered over: waiters poll on a short interval, so a missed broadcast
+// costs at most kCondPollMs, never a hang. With at most numMaxUlthread waiters that is free.
+// CONFIDENCE: HIGH on the two call-site facts; MED that real libSceUlt suppresses spurious wakeups
+// (prosper has no capture of a real console's Wait returning), and suppressing is the safe direction:
+// a guest that loops on its predicate cannot tell the difference, and one that does not is protected.
+constexpr uint64_t kCondPollMs = 20;
+
+PROSPER_SYSV_ABI uint64_t ult_cond_create(uint64_t a0, uint64_t a1, uint64_t a2, uint64_t a3,
+                                          uint64_t a4, uint64_t) {
+    uint64_t out = 0;
+    if (!implement(kIdxCondCreate, &out)) return out;
+    note_uninitialised("_sceUltConditionVariableCreate");
+    if (!guest_object_writable(a0)) {
+        log_line("_sceUltConditionVariableCreate: unusable condvar pointer 0x%llx",
+                 (unsigned long long)a0);
+        return kUltErrInval;
+    }
+    UltObject* mutex = resolve(a2, UltType::Mutex, "_sceUltConditionVariableCreate(mutex)");
+    if (!mutex) return kUltErrInval;
+
+    UltObject* o = allocate_object(UltType::Cond);
+    if (!o->cond_valid) {
+        const int rc = pthread_cond_init(&o->cond, nullptr);
+        if (rc) {
+            log_line("_sceUltConditionVariableCreate: pthread_cond_init failed (%d)", rc);
+            return kUltErrNoMem;
+        }
+        o->cond_valid = true;
+    }
+    o->name = guest_string(a1);
+    o->guest_addr = a0;
+    o->api_version = (uint32_t)a4;
+    o->mutex_id = make_id(mutex->slot, mutex->generation);
+    o->wait_seq.store(0, std::memory_order_relaxed);
+    o->wake_seq.store(0, std::memory_order_relaxed);
+    o->destroying.store(false, std::memory_order_relaxed);
+    o->alive.store(true, std::memory_order_release);
+    const uint64_t id = make_id(o->slot, o->generation);
+    if (!publish_object(a0, UltType::Cond, id)) {
+        o->alive.store(false, std::memory_order_release);
+        return kUltErrInval;
+    }
+    // Bound to the same pool the mutex came from, so pool accounting sees condvars too.
+    if (UltObject* pool = object_from_id(mutex->pool_id, UltType::Pool)) {
+        o->pool_id = mutex->pool_id;
+        pool->bound_sync_objects.fetch_add(1, std::memory_order_relaxed);
+    }
+    log_line("_sceUltConditionVariableCreate(\"%s\") cv=0x%llx mutex=0x%llx(\"%s\") apiVersion=0x%x -> ok",
+             o->name.c_str(), (unsigned long long)a0, (unsigned long long)a2, mutex->name.c_str(),
+             o->api_version);
+    return kUltOk;
+}
+
+PROSPER_SYSV_ABI uint64_t ult_cond_wait(uint64_t a0, uint64_t, uint64_t, uint64_t, uint64_t,
+                                        uint64_t) {
+    uint64_t out = 0;
+    if (!implement(kIdxCondWait, &out)) return out;
+    UltObject* o = resolve(a0, UltType::Cond, "sceUltConditionVariableWait");
+    if (!o) return kUltErrSrch;
+    UltObject* m = object_from_id(o->mutex_id, UltType::Mutex);
+    if (!m) {
+        log_line("sceUltConditionVariableWait: condvar \"%s\" (0x%llx) has no live bound mutex — it "
+                 "was destroyed while the condvar still refers to it",
+                 o->name.c_str(), (unsigned long long)a0);
+        return kUltErrInval;
+    }
+    const uint64_t me = self_thread();
+    // The classic contract, and one this title does honour at all five sites. Waiting without the
+    // mutex is undefined for pthread_cond_wait, so it is refused rather than executed.
+    if (m->owner.load(std::memory_order_relaxed) != me) {
+        static std::atomic<uint64_t> reported{0};
+        if (reported.fetch_add(1, std::memory_order_relaxed) < 8)
+            log_line("sceUltConditionVariableWait on \"%s\" by thread 0x%llx, which does NOT hold the "
+                     "bound mutex \"%s\" (holder 0x%llx) — refusing rather than entering undefined "
+                     "behaviour", o->name.c_str(), (unsigned long long)me, m->name.c_str(),
+                     (unsigned long long)m->owner.load(std::memory_order_relaxed));
+        return kUltErrPerm;
+    }
+
+    const uint64_t ticket = o->wait_seq.fetch_add(1, std::memory_order_acq_rel) + 1;
+    uint64_t waited_ms = 0;
+    bool noted = false;
+    uint64_t rc = kUltOk;
+    m->owner.store(0, std::memory_order_relaxed);       // released for the duration of the wait
+    while (o->wake_seq.load(std::memory_order_acquire) < ticket) {
+        if (o->destroying.load(std::memory_order_acquire)) {
+            log_line("sceUltConditionVariableWait on \"%s\" returning because the condvar is being "
+                     "destroyed", o->name.c_str());
+            rc = kUltErrSrch;
+            break;
+        }
+        struct timespec deadline;
+        abstime_in_ms(deadline, kCondPollMs);
+        pthread_cond_timedwait(&o->cond, &m->mtx, &deadline);
+        waited_ms += kCondPollMs;
+        if (!noted && waited_ms >= cond_note_ms()) {
+            noted = true;
+            log_line("WAITING >%llums: sceUltConditionVariableWait on \"%s\" (0x%llx), thread 0x%llx. "
+                     "This is informational — a worker waiting for work is normal — but if the title "
+                     "appears hung, nothing has signalled this condvar. (PROSPER_ULT_COND_NOTE_MS)",
+                     (unsigned long long)cond_note_ms(), o->name.c_str(), (unsigned long long)a0,
+                     (unsigned long long)me);
+        }
+    }
+    m->owner.store(me, std::memory_order_relaxed);      // reacquired by pthread_cond_timedwait
+    return rc;
+}
+
+PROSPER_SYSV_ABI uint64_t ult_cond_signal(uint64_t a0, uint64_t, uint64_t, uint64_t, uint64_t,
+                                          uint64_t) {
+    uint64_t out = 0;
+    if (!implement(kIdxCondSignal, &out)) return out;
+    UltObject* o = resolve(a0, UltType::Cond, "sceUltConditionVariableSignal");
+    if (!o) return kUltErrSrch;
+    // Release at most one un-woken waiter, and only if one exists: a Signal with nobody waiting is
+    // LOST, as it is for a real condition variable. wake_seq therefore never overtakes wait_seq.
+    uint64_t woken = o->wake_seq.load(std::memory_order_acquire);
+    for (;;) {
+        const uint64_t issued = o->wait_seq.load(std::memory_order_acquire);
+        if (woken >= issued) return kUltOk;             // no waiter to release
+        if (o->wake_seq.compare_exchange_weak(woken, woken + 1, std::memory_order_acq_rel,
+                                              std::memory_order_acquire))
+            break;
+    }
+    // Broadcast rather than signal: waiters select themselves by ticket, so every one must
+    // re-evaluate. Bounded by numMaxUlthread, which the guest sizes at 16.
+    pthread_cond_broadcast(&o->cond);
+    return kUltOk;
+}
+
+PROSPER_SYSV_ABI uint64_t ult_cond_destroy(uint64_t a0, uint64_t, uint64_t, uint64_t, uint64_t,
+                                           uint64_t) {
+    uint64_t out = 0;
+    if (!implement(kIdxCondDestroy, &out)) return out;
+    UltObject* o = resolve(a0, UltType::Cond, "sceUltConditionVariableDestroy");
+    if (!o) return kUltErrSrch;
+    const uint64_t issued = o->wait_seq.load(std::memory_order_acquire);
+    const uint64_t woken = o->wake_seq.load(std::memory_order_acquire);
+    if (issued > woken)
+        log_line("sceUltConditionVariableDestroy on \"%s\" (0x%llx) with %llu waiter(s) still "
+                 "blocked — releasing them with an error rather than leaving them stuck",
+                 o->name.c_str(), (unsigned long long)a0, (unsigned long long)(issued - woken));
+    o->destroying.store(true, std::memory_order_release);
+    pthread_cond_broadcast(&o->cond);
+    unpublish_object(a0);
+    o->alive.store(false, std::memory_order_release);
+    if (UltObject* pool = object_from_id(o->pool_id, UltType::Pool))
+        pool->bound_sync_objects.fetch_sub(1, std::memory_order_relaxed);
+    return kUltOk;
+}
 }  // namespace
 
 void register_ult_hle() {
@@ -920,18 +1370,14 @@ void register_ult_hle() {
     Hle::register_fn(kUlt[kIdxMutexUnlock].nid,  (HleFn)ult_mutex_unlock,  kUlt[kIdxMutexUnlock].name);
     Hle::register_fn(kUlt[kIdxMutexDestroy].nid, (HleFn)ult_mutex_destroy, kUlt[kIdxMutexDestroy].name);
 
-    Hle::register_fn(kUlt[kIdxUlthreadCreate].nid, (HleFn)ult_refuse<kIdxUlthreadCreate>,
+    Hle::register_fn(kUlt[kIdxUlthreadCreate].nid, (HleFn)ult_ulthread_create,
                      kUlt[kIdxUlthreadCreate].name);
-    Hle::register_fn(kUlt[kIdxUlthreadJoin].nid,   (HleFn)ult_refuse<kIdxUlthreadJoin>,
+    Hle::register_fn(kUlt[kIdxUlthreadJoin].nid,   (HleFn)ult_ulthread_join,
                      kUlt[kIdxUlthreadJoin].name);
-    Hle::register_fn(kUlt[kIdxCondCreate].nid,     (HleFn)ult_refuse<kIdxCondCreate>,
-                     kUlt[kIdxCondCreate].name);
-    Hle::register_fn(kUlt[kIdxCondWait].nid,       (HleFn)ult_refuse<kIdxCondWait>,
-                     kUlt[kIdxCondWait].name);
-    Hle::register_fn(kUlt[kIdxCondSignal].nid,     (HleFn)ult_refuse<kIdxCondSignal>,
-                     kUlt[kIdxCondSignal].name);
-    Hle::register_fn(kUlt[kIdxCondDestroy].nid,    (HleFn)ult_refuse<kIdxCondDestroy>,
-                     kUlt[kIdxCondDestroy].name);
+    Hle::register_fn(kUlt[kIdxCondCreate].nid,  (HleFn)ult_cond_create,  kUlt[kIdxCondCreate].name);
+    Hle::register_fn(kUlt[kIdxCondWait].nid,    (HleFn)ult_cond_wait,    kUlt[kIdxCondWait].name);
+    Hle::register_fn(kUlt[kIdxCondSignal].nid,  (HleFn)ult_cond_signal,  kUlt[kIdxCondSignal].name);
+    Hle::register_fn(kUlt[kIdxCondDestroy].nid, (HleFn)ult_cond_destroy, kUlt[kIdxCondDestroy].name);
 }
 
 uint64_t ult_call_count(const char* nid) {
@@ -943,6 +1389,16 @@ uint64_t ult_call_count(const char* nid) {
 
 bool ult_set_return_success_for_test(bool return_success) {
     return g_return_success.exchange(return_success, std::memory_order_relaxed);
+}
+
+uint64_t ult_runtime_high_water_for_test(uint64_t guest_runtime_addr) {
+    UltObject* rt = resolve(guest_runtime_addr, UltType::Runtime, "ult_runtime_high_water_for_test");
+    return rt ? rt->high_water.load(std::memory_order_relaxed) : 0;
+}
+
+uint64_t ult_last_join_stack_used_for_test(uint64_t* context_size) {
+    if (context_size) *context_size = g_last_join_context_size.load(std::memory_order_relaxed);
+    return g_last_join_stack_used.load(std::memory_order_relaxed);
 }
 
 bool ult_set_legacy_enosys_for_test(bool legacy_enosys) {

--- a/prosper/src/hle/hle_ult.cpp
+++ b/prosper/src/hle/hle_ult.cpp
@@ -146,6 +146,12 @@ namespace {
 // ([rbp-0x30], [rbp-0xc], and two rip-relative byte flags), never eax. The exact constant is
 // therefore unobservable to the only title that imports the library.
 // ---------------------------------------------------------------------------------------------
+//
+// The low byte of each is the FREEBSD errno, which is the PS5 kernel's, NOT this Linux host's. They
+// differ where it matters: EDEADLK is 11 on FreeBSD and 35 on Linux, EAGAIN 35 and 11 respectively —
+// exactly transposed, so copying them from the ambient platform's <errno.h> yields a plausible
+// constant that means something else. #1612 tracks existing instances of that mistake; these are
+// written from the FreeBSD values deliberately and must not be "corrected" against the host header.
 constexpr uint64_t kUltOk             = 0ull;
 constexpr uint64_t kUltErrPerm        = 0x80020001ull;   // EPERM   — unlock by a non-owner
 constexpr uint64_t kUltErrSrch        = 0x80020003ull;   // ESRCH   — stale / destroyed / uncreated

--- a/prosper/src/hle/hle_ult.cpp
+++ b/prosper/src/hle/hle_ult.cpp
@@ -471,7 +471,23 @@ uint64_t cond_note_ms() {
     return v;
 }
 
-uint64_t self_thread() { return (uint64_t)(uintptr_t)pthread_self(); }
+// Thread identity for mutex ownership. Deliberately NOT `pthread_self()` cast to an integer:
+// pthread_t is opaque by specification — which is exactly why pthread_equal() exists — and on an
+// implementation where it is a struct pointer rather than an id, an integer comparison would be
+// UNRELIABLE rather than loudly broken. Ownership is what makes the condvar's release/reacquire and
+// the self-deadlock diagnosis correct, so it must not rest on a representation assumption.
+//
+// Each thread instead takes a unique non-zero token from a monotonic counter on first use. That is
+// portable by construction, exact, and cheaper on a path the guest hits a million times per boot
+// than a pthread_self() call. The token is an identity, never a handle: pthread_join still needs a
+// real pthread_t, which UltObject::host_thread carries under the project-wide convention that
+// k_pthread_create/k_pthread_join already use.
+std::atomic<uint64_t> g_next_thread_token{1};
+thread_local uint64_t t_thread_token = 0;
+uint64_t self_thread() {
+    if (!t_thread_token) t_thread_token = g_next_thread_token.fetch_add(1, std::memory_order_relaxed);
+    return t_thread_token;
+}
 
 void abstime_in_ms(struct timespec& ts, uint64_t ms) {
     clock_gettime(CLOCK_REALTIME, &ts);
@@ -825,7 +841,7 @@ uint64_t mutex_lock_impl(UltObject* o, const char* fn) {
         if (rc == ETIMEDOUT || rc == EBUSY) {
             if (!o->warned_block.exchange(true))
                 log_line("BLOCKED >%llums: sceUltMutexLock on \"%s\" (0x%llx) — holder thread 0x%llx, "
-                         "waiter thread 0x%llx. Still waiting. If the title appears hung, this is "
+                         "waiter thread token 0x%llx. Still waiting. If the title appears hung, this is "
                          "where. (PROSPER_ULT_BLOCK_WARN_MS)",
                          (unsigned long long)warn_ms, o->name.c_str(),
                          (unsigned long long)o->guest_addr,

--- a/prosper/src/hle/hle_ult.cpp
+++ b/prosper/src/hle/hle_ult.cpp
@@ -100,6 +100,7 @@
 //   PROSPER_ULT_RETURN_SUCCESS=1  restore the pre-#1603 fake success (return 0, implement nothing).
 //   PROSPER_ULT_BLOCK_WARN_MS=N   watchdog threshold for a blocked mutex lock (default 5000).
 #include "dispatch.hpp"
+#include "sce_errno.hpp"
 
 #include <algorithm>
 #include <atomic>
@@ -136,8 +137,11 @@ namespace {
 // prosper has NO primary evidence for libSceUlt's own SCE_ULT_ERROR_* numbering: no live capture of
 // a real console's return, no published constant, and the firmware symbol database gives names and
 // NIDs only, never values. Rather than fabricate a libSceUlt-shaped constant, these use the
-// documented `0x80020000 | freebsd_errno` libkernel convention prosper already uses across
-// hle_file.cpp. CONFIDENCE: HIGH that non-zero is correct (0 is SCE_OK for this family);
+// documented libkernel `0x80020000 | freebsd_errno` encoding through the shared helper in
+// sce_errno.hpp (#1612), which is the single place that owns the FreeBSD-vs-host numbering — the
+// distinction that makes EDEADLK 11 here and 35 on Linux, exactly transposed with EAGAIN.
+//
+// CONFIDENCE: HIGH that non-zero is correct (0 is SCE_OK for this family);
 // CONFIDENCE: LOW that any specific value matches the real library.
 //
 // That LOW is also cheap, and provably so: Earthion never branches on a libSceUlt return. Scanning
@@ -146,20 +150,14 @@ namespace {
 // ([rbp-0x30], [rbp-0xc], and two rip-relative byte flags), never eax. The exact constant is
 // therefore unobservable to the only title that imports the library.
 // ---------------------------------------------------------------------------------------------
-//
-// The low byte of each is the FREEBSD errno, which is the PS5 kernel's, NOT this Linux host's. They
-// differ where it matters: EDEADLK is 11 on FreeBSD and 35 on Linux, EAGAIN 35 and 11 respectively —
-// exactly transposed, so copying them from the ambient platform's <errno.h> yields a plausible
-// constant that means something else. #1612 tracks existing instances of that mistake; these are
-// written from the FreeBSD values deliberately and must not be "corrected" against the host header.
 constexpr uint64_t kUltOk             = 0ull;
-constexpr uint64_t kUltErrPerm        = 0x80020001ull;   // EPERM   — unlock by a non-owner
-constexpr uint64_t kUltErrSrch        = 0x80020003ull;   // ESRCH   — stale / destroyed / uncreated
-constexpr uint64_t kUltErrDeadlk      = 0x8002000Bull;   // EDEADLK — self-relock of a non-recursive mutex
-constexpr uint64_t kUltErrNoMem       = 0x8002000Cull;   // ENOMEM
-constexpr uint64_t kUltErrInval       = 0x80020016ull;   // EINVAL
-constexpr uint64_t kUltErrAgain       = 0x80020023ull;   // EAGAIN  — runtime is at numMaxUlthread
-constexpr uint64_t kUltNotImplemented = 0x8002004Eull;   // ENOSYS — still-unimplemented entry points
+constexpr uint64_t kUltErrPerm        = hle::kSceKernelErrorEPERM;    // unlock/wait by a non-owner
+constexpr uint64_t kUltErrSrch        = hle::kSceKernelErrorESRCH;    // stale / destroyed / uncreated
+constexpr uint64_t kUltErrDeadlk      = hle::kSceKernelErrorEDEADLK;  // self-relock of a non-recursive mutex
+constexpr uint64_t kUltErrNoMem       = hle::kSceKernelErrorENOMEM;
+constexpr uint64_t kUltErrInval       = hle::kSceKernelErrorEINVAL;
+constexpr uint64_t kUltErrAgain       = hle::kSceKernelErrorEAGAIN;   // runtime is at numMaxUlthread
+constexpr uint64_t kUltNotImplemented = hle::kSceKernelErrorENOSYS;   // the legacy/Phase 1 policy
 
 // A size-returning contract has no error channel (#1618): whatever these return is read as a byte
 // count and handed to malloc. They must therefore never see an error sentinel — the value is always

--- a/prosper/src/hle/hle_ult.cpp
+++ b/prosper/src/hle/hle_ult.cpp
@@ -1,209 +1,937 @@
-// hle_ult.cpp — fail-VISIBLE libSceUlt surface (#1603). This file deliberately implements NO
-// user-level threading semantics; it exists so that the absence of them stops being silent.
+// hle_ult.cpp — libSceUlt: Sony's user-level (cooperative) threading library.
 //
-// libSceUlt is Sony's user-level threading library: cooperative "ulthreads" plus the mutexes,
-// condition variables, queues, semaphores and reader/writer locks that schedule on top of them.
-// prosper implements none of it. Before this file existed, every call fell through to the generic
-// unresolved-import path (dispatch.cpp `prosper_on_unimpl`), which logs the NID **once** and
-// returns **0** — and for this ABI family 0 is SCE_OK, i.e. success. The guest was therefore told:
+// libSceUlt provides "ulthreads" scheduled by a runtime on top of OS worker threads, plus the
+// mutexes, condition variables and waiting-queue resource pools built on that scheduler. Phase 1
+// (#1603/#1614) registered the entry points and refused them loudly so the missing semantics stopped
+// being silent. This file now implements them.
 //
-//   * `_sceUltUlthreadCreate`  -> "your thread was created"   ... it never runs;
-//   * `sceUltMutexLock/Unlock` -> "the lock is held/released" ... there is no mutual exclusion;
-//   * the `*GetWorkAreaSize` queries -> "success" with the size out-param left UNWRITTEN, i.e.
-//     whatever stack garbage the caller had there (the #544/#660 class that made Dead Cells
-//     allocate multiple gigabytes).
+// ============================================================================================
+// THE ABI, DERIVED FROM THE GUEST'S OWN CALL SITES — NOT FROM A HEADER WE DO NOT HAVE
+// ============================================================================================
+// Exactly one title in the library imports libSceUlt: Earthion (PPSA28061), 16 functions. Every one
+// of its Ult call sites lives in a single engine wrapper layer at eboot+0x9c20..0xa17a, which sets up
+// all arguments explicitly, so the layouts below are READ, not inferred. Method: flatten eboot.bin
+// with tools/il2cpp/prx_to_elf.py, resolve the 16 JMPREL slots -> PLT stubs -> call sites with
+// tools/re/xref.py, disassemble with tools/re/edis.py.
 //
-// Nothing crashed. The guest proceeded on false premises and the damage surfaced far from its
-// cause. That is strictly worse than an unimplemented call that fails loudly, which is what this
-// file makes it: every entry point is counted per call and reported, and by default returns a real
-// error instead of a fake success.
+// The object names the guest passes settle the provenance: the pool is "waiting queue", the runtime
+// is "sample runtime", the mutex "ultmtx", the condvar "ultcv". This is Sony's own libSceUlt SDK
+// sample usage pattern, which is why the layouts are the canonical ones.
 //
-// Measured on Earthion (PPSA28061 — the ONLY dump in the library that imports libSceUlt, 16
-// functions per `self_dump --symbols`): a 118 s CPU-only boot called `sceUltMutexLock` and
-// `sceUltMutexUnlock` 1,005,742 times **each**, and the deduped unimplemented-import log printed
-// exactly one line for each. Four ulthreads were reported created and none of them ever ran.
+//   sceUltInitialize(void) -> int32                       [0 args: nothing is set up at eboot+0x9c3c]
+//   sceUltFinalize(void)   -> int32                       [0 args: eboot+0x9db4]
 //
-// SCOPE: Phase 1 of #1603 only — visibility. Implementing ulthreads, the mutex/condvar semantics
-// and the scheduler is Phase 2 and must be derived from live title evidence and the guest's own
-// disassembly, not assumed. Do not grow this file into a fake implementation.
+//   size_t sceUltUlthreadRuntimeGetWorkAreaSize(u32 numMaxUlthread, u32 numWorkerThread)
+//   size_t sceUltWaitingQueueResourcePoolGetWorkAreaSize(u32 numThreads, u32 numSyncObjects)
+//       The size is the RETURN VALUE (rax); there is no out-parameter. See kUltSizeContract (#1618).
+//
+//   int _sceUltUlthreadRuntimeCreate(runtime, const char* name, u32 numMaxUlthread,
+//                                    u32 numWorkerThread, void* workArea, const OptParam*, u32 v)
+//   int _sceUltWaitingQueueResourcePoolCreate(pool, const char* name, u32 numThreads,
+//                                    u32 numSyncObjects, void* workArea, const OptParam*, u32 v)
+//       7 args; `v` arrives on the stack (the import bridge forwards it as a7).
+//
+//   int _sceUltUlthreadCreate(ult, const char* name, int32_t(*entry)(uint64_t), uint64_t arg,
+//                             void* context, size_t sizeContext, runtime, const OptParam*, u32 v)
+//   int sceUltUlthreadJoin(ult, int32_t* status)
+//
+//   int _sceUltMutexCreate(mutex, const char* name, pool, const OptParam*, u32 v)   [5 args, all regs]
+//   int sceUltMutexLock(mutex) / sceUltMutexUnlock(mutex) / sceUltMutexDestroy(mutex)
+//
+//   int _sceUltConditionVariableCreate(cv, const char* name, mutex, const OptParam*, u32 v)
+//   int sceUltConditionVariableWait(cv)      <- ONE argument; the mutex is bound at create.
+//   int sceUltConditionVariableSignal(cv) / sceUltConditionVariableDestroy(cv)
+//
+// `v` is 0x12000000 at every create site — the trailing api/SDK-version argument the `_sce*` forms
+// take (0x12 = SDK 18.00). CONFIDENCE: HIGH; it is a literal immediate at all five create sites.
+// prosper records it and does not gate on it: refusing an unknown version would be inventing policy.
+//
+// Earthion's own parameters: runtime (numMaxUlthread=16, numWorkerThread=3), pool (numThreads=16,
+// numSyncObjects=16), ulthread sizeContext=0x2000, every optParam NULL.
+//
+// ============================================================================================
+// THE GUEST OBJECT IS A 256-BYTE CALLER-OWNED BLOB; prosper WRITES ONLY A 16-BYTE HEADER
+// ============================================================================================
+// Proven, not assumed. At eboot+0x241730 a mutex is followed by an unrelated 8-byte queue head at
+// 0x241830 (read at eboot+0x137c7) — exactly 0x100 later. Corroborated by the C++ class constructed
+// at eboot+0xd8a0, whose mutex/condvar/mutex members sit at +0x70/+0x170/+0x270 with the next
+// non-Ult member at +0x370, and by pool/runtime at 0x236e30/0x236f30. CONFIDENCE: HIGH.
+//
+// prosper stores its state host-side and puts only {magic, id} in the guest blob. That is safe
+// because the guest never reads inside one: an exhaustive scan of every RIP-relative reference in the
+// whole executable segment finds 16 static Ult objects and ZERO references to any of them at a
+// non-zero offset — every reference is a `lea` of the base feeding an Ult call. The heap-embedded
+// members at 0xd8a0+0x70/+0x170/+0x270 are likewise only ever passed as pointers; the constructor
+// initialises nothing in [0x70,0x370). CONFIDENCE: HIGH.
+//
+// Zeroed BSS therefore reads as "not created" and is refused loudly rather than trusted, and Destroy
+// clears the magic so a stale object is detected instead of dereferenced.
+//
+// ============================================================================================
+// SCHEDULING: ONE HOST THREAD PER ULTHREAD — A DELIBERATE, SELF-DETECTING DEVIATION
+// ============================================================================================
+// Hardware multiplexes up to numMaxUlthread ulthreads cooperatively onto numWorkerThread OS threads.
+// prosper runs one real guest thread per ulthread. Two facts make that the right mapping here:
+//
+//  1. Ult mutexes are locked by ORDINARY (non-ulthread) threads. In the Phase 1 measurement every
+//     _sceUltUlthreadCreate was refused, so no ulthread existed — yet sceUltMutexLock was still
+//     called 1,005,742 times in 118 s. Whatever prosper does must give correct mutual exclusion to
+//     plain guest pthreads, not only to scheduler-managed ulthreads.
+//  2. The guest must already be preemption-safe across ulthreads, because 3 workers already preempt
+//     each other on hardware, and the engine guards its state with Ult mutexes at 23 lock / 24 unlock
+//     / 11 mutex-create / 4 condvar-create sites. CONFIDENCE: HIGH.
+//
+// The deviation that remains is CONCURRENCY WIDTH: hardware runs at most numWorkerThread ulthreads at
+// once, prosper can run all of them. That is not trusted, it is MEASURED — the runtime keeps a
+// high-water mark of simultaneously-running ulthreads and logs loudly the first time it exceeds
+// numWorkerThread, so an invisible semantic difference becomes a line in the log. It is deliberately
+// not capped: capping would trade a visible deviation for a hidden scheduling stall.
+//
+// ============================================================================================
+// BLOCKING IS NOW REAL, SO IT IS WATCHDOGGED
+// ============================================================================================
+// Before this file, a million lock calls per boot were no-ops. They now block. A cross-thread
+// ordering hazard would therefore present as a HANG, which is the worst failure mode to debug — it
+// looks exactly like slow asset loading. Every blocking wait is bounded by a watchdog that logs the
+// object, the holder and the waiter once, then keeps waiting. The hang becomes a diagnosable event.
+//
+// Escape hatches, both off by default:
+//   PROSPER_ULT_LEGACY_ENOSYS=1   restore Phase 1 wholesale (every entry point refuses).
+//   PROSPER_ULT_RETURN_SUCCESS=1  restore the pre-#1603 fake success (return 0, implement nothing).
+//   PROSPER_ULT_BLOCK_WARN_MS=N   watchdog threshold for a blocked mutex lock (default 5000).
 #include "dispatch.hpp"
 
+#include <algorithm>
 #include <atomic>
+#include <cerrno>
+#include <cstdarg>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <memory>
+#include <mutex>
+#include <pthread.h>
+#include <shared_mutex>
+#include <string>
 #include <utility>
+#include <vector>
+
+#if defined(__APPLE__)
+#include <sched.h>
+#endif
+#include <time.h>
+
+// guest_readable is a core (non-Vulkan) symbol always linked into prosper_core; declare it rather
+// than pulling the Vulkan-gated gpu headers into the HLE. It is a probe that cannot fault, used here
+// only to reject a wild object pointer before prosper writes a header into it.
+namespace prosper::gpu { bool guest_readable(uint64_t addr, uint32_t bytes); }
 
 namespace prosper {
 namespace {
 
-// The registered surface. Driven by what titles ACTUALLY import, not by the library's full export
-// list: the PS5 3.20 firmware database exports 64 `sceUlt*` symbols, and a byte-scan of every dump
-// plus prosper's own `self_dump --symbols` agree that exactly these 16 are imported, by exactly one
-// title (Earthion / PPSA28061). Any other Ult NID a future title imports still falls through to the
+// ---------------------------------------------------------------------------------------------
+// Return values.
+//
+// prosper has NO primary evidence for libSceUlt's own SCE_ULT_ERROR_* numbering: no live capture of
+// a real console's return, no published constant, and the firmware symbol database gives names and
+// NIDs only, never values. Rather than fabricate a libSceUlt-shaped constant, these use the
+// documented `0x80020000 | freebsd_errno` libkernel convention prosper already uses across
+// hle_file.cpp. CONFIDENCE: HIGH that non-zero is correct (0 is SCE_OK for this family);
+// CONFIDENCE: LOW that any specific value matches the real library.
+//
+// That LOW is also cheap, and provably so: Earthion never branches on a libSceUlt return. Scanning
+// the whole executable segment finds no comparison against any Ult-family immediate, and the five
+// cmp/test instructions that happen to follow an Ult call all compare unrelated memory operands
+// ([rbp-0x30], [rbp-0xc], and two rip-relative byte flags), never eax. The exact constant is
+// therefore unobservable to the only title that imports the library.
+// ---------------------------------------------------------------------------------------------
+constexpr uint64_t kUltOk             = 0ull;
+constexpr uint64_t kUltErrPerm        = 0x80020001ull;   // EPERM   — unlock by a non-owner
+constexpr uint64_t kUltErrSrch        = 0x80020003ull;   // ESRCH   — stale / destroyed / uncreated
+constexpr uint64_t kUltErrDeadlk      = 0x8002000Bull;   // EDEADLK — self-relock of a non-recursive mutex
+constexpr uint64_t kUltErrNoMem       = 0x8002000Cull;   // ENOMEM
+constexpr uint64_t kUltErrInval       = 0x80020016ull;   // EINVAL
+constexpr uint64_t kUltNotImplemented = 0x8002004Eull;   // ENOSYS — still-unimplemented entry points
+
+// A size-returning contract has no error channel (#1618): whatever these return is read as a byte
+// count and handed to malloc. They must therefore never see an error sentinel — the value is always
+// prosper's own real requirement, and the matching Create recomputes it from the same arguments and
+// genuinely consumes the buffer.
+// ---------------------------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------------------------
+// Registered surface. Driven by what titles ACTUALLY import: the PS5 3.20 firmware database exports
+// 64 sceUlt* symbols, and a byte-scan of every dump plus self_dump --symbols agree that exactly these
+// 16 are imported, by exactly one title. Any other Ult NID a future title imports still falls to the
 // generic unimplemented-import path, which logs it — add it here when that happens.
-// CONFIDENCE: HIGH (two independent instruments agree on the NID<->name mapping and the import set).
-// `returns_size` marks the entry points whose contract returns a VALUE (a byte count) rather than a
-// STATUS. Those must never be handed an error sentinel — see kUltSizeUnknown below (#1618).
-struct UltEntry { const char* nid; const char* name; bool returns_size; };
+// ---------------------------------------------------------------------------------------------
+enum class UltRet : uint8_t { Status, Size };   // #1618: what the contract's return value MEANS
+struct UltEntry { const char* nid; const char* name; UltRet ret; };
 constexpr UltEntry kUlt[] = {
-    { "jw9FkZBXo-g", "_sceUltUlthreadRuntimeCreate",                  false },
-    { "grs2pbc2awM", "sceUltUlthreadRuntimeGetWorkAreaSize",          true  },
-    { "znI3q8S7KQ4", "_sceUltUlthreadCreate",                         false },
-    { "gCeAI57LGgI", "sceUltUlthreadJoin",                            false },
-    { "mmt8Sa6tL6c", "_sceUltMutexCreate",                            false },
-    { "8hEGkR1pfr8", "sceUltMutexLock",                               false },
-    { "h0XebKiMBtk", "sceUltMutexUnlock",                             false },
-    { "jW+HnafeS3Y", "sceUltMutexDestroy",                            false },
-    { "jnKaHGkrxZ4", "_sceUltConditionVariableCreate",                false },
-    { "5xGAHCxA8M0", "sceUltConditionVariableWait",                   false },
-    { "JTw1cAVkuc0", "sceUltConditionVariableSignal",                 false },
-    { "xrmmI832R4U", "sceUltConditionVariableDestroy",                false },
-    { "YiHujOG9vXY", "_sceUltWaitingQueueResourcePoolCreate",         false },
-    { "WIWV1Qd7PFU", "sceUltWaitingQueueResourcePoolGetWorkAreaSize", true  },
-    { "hZIg1EWGsHM", "sceUltInitialize",                              false },
-    { "d-kSG2fLrvI", "sceUltFinalize",                                false },
+    { "jw9FkZBXo-g", "_sceUltUlthreadRuntimeCreate",                  UltRet::Status },
+    { "grs2pbc2awM", "sceUltUlthreadRuntimeGetWorkAreaSize",          UltRet::Size   },
+    { "znI3q8S7KQ4", "_sceUltUlthreadCreate",                         UltRet::Status },
+    { "gCeAI57LGgI", "sceUltUlthreadJoin",                            UltRet::Status },
+    { "mmt8Sa6tL6c", "_sceUltMutexCreate",                            UltRet::Status },
+    { "8hEGkR1pfr8", "sceUltMutexLock",                               UltRet::Status },
+    { "h0XebKiMBtk", "sceUltMutexUnlock",                             UltRet::Status },
+    { "jW+HnafeS3Y", "sceUltMutexDestroy",                            UltRet::Status },
+    { "jnKaHGkrxZ4", "_sceUltConditionVariableCreate",                UltRet::Status },
+    { "5xGAHCxA8M0", "sceUltConditionVariableWait",                   UltRet::Status },
+    { "JTw1cAVkuc0", "sceUltConditionVariableSignal",                 UltRet::Status },
+    { "xrmmI832R4U", "sceUltConditionVariableDestroy",                UltRet::Status },
+    { "YiHujOG9vXY", "_sceUltWaitingQueueResourcePoolCreate",         UltRet::Status },
+    { "WIWV1Qd7PFU", "sceUltWaitingQueueResourcePoolGetWorkAreaSize", UltRet::Size   },
+    { "hZIg1EWGsHM", "sceUltInitialize",                              UltRet::Status },
+    { "d-kSG2fLrvI", "sceUltFinalize",                                UltRet::Status },
 };
 constexpr size_t kUltCount = sizeof(kUlt) / sizeof(kUlt[0]);
-
-// Return value for every entry point.
-//
-// prosper has NO primary evidence for libSceUlt's own `SCE_ULT_ERROR_*` numbering — no live capture
-// of a real console's return, no published constant, and the firmware symbol database gives names
-// and NIDs only, never values. Fabricating a libSceUlt-shaped constant would look authoritative
-// while being a guess, so this deliberately does not do that. Instead it returns the libkernel
-// errno-family code that states exactly the truth — "function not implemented" — using the
-// documented `0x80020000 | freebsd_errno` convention already used across hle_file.cpp. ENOSYS is
-// 78 (0x4E) on the FreeBSD-derived PS5 kernel (it is 38 on Linux; do not copy that value here).
-//
-// CONFIDENCE: HIGH that 0 is wrong — every Sony API in this family treats 0 as SCE_OK, so a guest
-//             that checks `ret != SCE_OK` MUST see a failure here.
-// CONFIDENCE: LOW  that 0x8002004E is the specific value the real libSceUlt would return. A guest
-//             that compares against a particular SCE_ULT_ERROR_* constant will not recognise it and
-//             should fall into its generic error path. That is still the correct outcome: the call
-//             genuinely failed.
-constexpr uint64_t kUltNotImplemented = 0x8002004Eull;   // SCE_KERNEL_ERROR_ENOSYS
-
-// ...but ONLY for entry points whose contract returns a STATUS. Two of the sixteen do not (#1618).
-//
-// `sceUltUlthreadRuntimeGetWorkAreaSize` and `sceUltWaitingQueueResourcePoolGetWorkAreaSize` return a
-// `size_t` AS THEIR RETURN VALUE. #1603 asserted they were size queries with an out-parameter; the
-// guest's own call site disproves that — there is no out-param, and the returned value is handed
-// straight to malloc:
-//
-//   9c55:  call sceUltWaitingQueueResourcePoolGetWorkAreaSize
-//   9c5a:  mov  QWORD PTR [rbp-0x10],rax     <- the size IS the return value
-//   9c62:  call malloc                       <- fed directly to malloc
-//
-// A signature whose return type is a size HAS NO ERROR CHANNEL, so any value returned is read as data.
-// Returning SCE_KERNEL_ERROR_ENOSYS from them therefore asked the guest for a 0x8002004E-byte
-// (2.0 GiB) allocation — twice — which is the #544/#660 failure class this file was written to prevent.
-//
-// It was also strictly worse than not registering the NIDs at all: the dispatcher's unresolved-import
-// default is `return 0` (dispatch.cpp prosper_on_unimpl), so before registration the guest got 0,
-// called malloc(0), received a valid small pointer and carried on harmlessly.
-//
-// The rule this file now follows: an unimplemented entry point may only return an error sentinel when
-// its contract returns a STATUS. When the contract returns a VALUE, the visibility belongs in the log
-// line — never in the return. prosper consumes no work area yet, so its own requirement is genuinely
-// zero bytes and 0 is the honest answer as well as the safe one.
-// CONFIDENCE: HIGH (the call site is unambiguous, and 0 restores the pre-registration behaviour).
-constexpr uint64_t kUltSizeUnknown = 0ull;
+constexpr size_t kIdxRuntimeCreate = 0,  kIdxRuntimeSize = 1,  kIdxUlthreadCreate = 2,
+                 kIdxUlthreadJoin  = 3,  kIdxMutexCreate = 4,  kIdxMutexLock      = 5,
+                 kIdxMutexUnlock   = 6,  kIdxMutexDestroy = 7, kIdxCondCreate     = 8,
+                 kIdxCondWait      = 9,  kIdxCondSignal  = 10, kIdxCondDestroy    = 11,
+                 kIdxPoolCreate    = 12, kIdxPoolSize    = 13, kIdxInitialize     = 14,
+                 kIdxFinalize      = 15;
 
 std::atomic<uint64_t> g_calls[kUltCount];
-std::atomic<uint64_t> g_next_report[kUltCount];   // 0 = "report the next call" (i.e. the first)
+std::atomic<uint64_t> g_next_report[kUltCount];   // 0 = "report the next call"
 std::atomic<bool>     g_banner_printed{false};
 
-// PROSPER_ULT_RETURN_SUCCESS=1 restores the pre-#1603 `return 0` for A/B measurement of what the
-// fake success was buying a title. It is OFF by default and it does NOT silence anything: the
-// counting and the log lines below are emitted either way, so no configuration of prosper is ever
-// silently wrong about Ult again.
+// PROSPER_ULT_RETURN_SUCCESS=1 restores the pre-#1603 `return 0`; PROSPER_ULT_LEGACY_ENOSYS=1
+// restores Phase 1's refusal. Both are OFF by default and neither silences the counting.
 std::atomic<bool> g_return_success{false};
-bool env_return_success() {
-    const char* e = getenv("PROSPER_ULT_RETURN_SUCCESS");
+std::atomic<bool> g_legacy_enosys{false};
+bool env_flag(const char* name) {
+    const char* e = getenv(name);
     return e && *e && std::strcmp(e, "0") != 0;
 }
+uint64_t env_u64(const char* name, uint64_t fallback) {
+    const char* e = getenv(name);
+    if (!e || !*e) return fallback;
+    char* end = nullptr;
+    const unsigned long long v = strtoull(e, &end, 0);
+    return (end && *end == 0) ? (uint64_t)v : fallback;
+}
+
+void log_line(const char* fmt, ...) __attribute__((format(printf, 1, 2)));
+void log_line(const char* fmt, ...) {
+    char buf[512];
+    va_list ap;
+    va_start(ap, fmt);
+    vsnprintf(buf, sizeof(buf), fmt, ap);
+    va_end(ap);
+    fprintf(stderr, "[prosper] [ult] %s\n", buf);
+}
+
+// ---------------------------------------------------------------------------------------------
+// Host-side object registry.
+//
+// The guest blob holds {magic, id}; everything else lives here. Slots are never freed, only marked
+// dead and reused, and the id carries a generation, so a stale or destroyed handle is DETECTED
+// rather than dereferenced. Objects are heap-allocated individually, so a raw pointer taken under
+// the shared lock stays valid after the lock is dropped even if the slot vector reallocates.
+// ---------------------------------------------------------------------------------------------
+enum class UltType : uint32_t { Runtime = 1, Pool = 2, Mutex = 3, Cond = 4, Ulthread = 5 };
+
+const char* type_name(UltType t) {
+    switch (t) {
+        case UltType::Runtime:  return "UlthreadRuntime";
+        case UltType::Pool:     return "WaitingQueueResourcePool";
+        case UltType::Mutex:    return "Mutex";
+        case UltType::Cond:     return "ConditionVariable";
+        case UltType::Ulthread: return "Ulthread";
+    }
+    return "?";
+}
+
+// Distinct per type so a mutex handed to a condvar entry point is caught rather than reinterpreted.
+uint64_t magic_for(UltType t) {
+    return 0x554C54ull << 40 | (uint64_t)t << 32 | 0x50525350ull;   // "ULT" | type | "PRSP"
+}
+
+struct UltObject {
+    UltType  type;
+    uint32_t generation = 0;
+    uint32_t slot       = 0;
+    std::atomic<bool> alive{false};
+    std::string name;
+    uint64_t guest_addr = 0;
+    uint32_t api_version = 0;
+
+    // Mutex / ConditionVariable.
+    pthread_mutex_t  mtx = PTHREAD_MUTEX_INITIALIZER;
+    pthread_cond_t   cond = PTHREAD_COND_INITIALIZER;
+    bool             mtx_valid = false;
+    bool             cond_valid = false;
+    std::atomic<uint64_t> owner{0};          // host thread holding this mutex (0 = unheld)
+    uint64_t         pool_id = 0;            // Mutex -> its waiting-queue resource pool
+    uint64_t         mutex_id = 0;           // Cond  -> the mutex bound at create
+    std::atomic<bool> warned_block{false};   // watchdog fires at most once per object
+    std::atomic<bool> warned_deadlock{false};
+    std::atomic<uint64_t> lock_calls{0}, contended{0};
+
+    // Runtime / Pool: the guest-supplied work area prosper actually consumes.
+    uint64_t work_area = 0, work_bytes = 0;
+    uint32_t num_max_ulthread = 0, num_worker_thread = 0;
+    uint32_t num_threads = 0, num_sync_objects = 0;
+    std::atomic<uint32_t> live_ulthreads{0}, running_ulthreads{0}, high_water{0};
+    std::atomic<bool> warned_concurrency{false};
+    std::atomic<uint32_t> bound_sync_objects{0};
+    std::atomic<bool> warned_pool_capacity{false};
+};
+
+std::shared_mutex                          g_reg_lock;
+std::vector<std::unique_ptr<UltObject>>    g_objects;
+
+constexpr uint64_t kSlotMask = 0x00000000FFFFFFFFull;
+uint64_t make_id(uint32_t slot, uint32_t generation) {
+    return ((uint64_t)generation << 32) | slot;
+}
+
+UltObject* object_from_id(uint64_t id, UltType expect) {
+    const uint32_t slot = (uint32_t)(id & kSlotMask);
+    const uint32_t gen  = (uint32_t)(id >> 32);
+    UltObject* o = nullptr;
+    {
+        std::shared_lock<std::shared_mutex> lk(g_reg_lock);
+        if (slot >= g_objects.size()) return nullptr;
+        o = g_objects[slot].get();
+    }
+    if (!o || o->generation != gen || o->type != expect) return nullptr;
+    if (!o->alive.load(std::memory_order_acquire)) return nullptr;
+    return o;
+}
+
+UltObject* allocate_object(UltType type) {
+    std::unique_lock<std::shared_mutex> lk(g_reg_lock);
+    for (auto& up : g_objects) {
+        UltObject* o = up.get();
+        if (o->type == type && !o->alive.load(std::memory_order_relaxed)) {
+            ++o->generation;                 // stale ids referring to the previous incarnation now miss
+            o->name.clear();
+            o->owner.store(0, std::memory_order_relaxed);
+            o->warned_block.store(false, std::memory_order_relaxed);
+            o->warned_deadlock.store(false, std::memory_order_relaxed);
+            o->lock_calls.store(0, std::memory_order_relaxed);
+            o->contended.store(0, std::memory_order_relaxed);
+            o->bound_sync_objects.store(0, std::memory_order_relaxed);
+            return o;
+        }
+    }
+    auto up = std::make_unique<UltObject>();
+    UltObject* o = up.get();
+    o->type = type;
+    o->slot = (uint32_t)g_objects.size();
+    o->generation = 1;
+    g_objects.push_back(std::move(up));
+    return o;
+}
+
+// ---------------------------------------------------------------------------------------------
+// The guest object header. 16 bytes at offset 0 of the caller's 256-byte blob.
+// ---------------------------------------------------------------------------------------------
+struct GuestUltHeader { uint64_t magic; uint64_t id; };
+
+bool guest_object_writable(uint64_t addr) {
+    // Reject null and obviously-unaligned pointers outright; guest_readable is a probe that cannot
+    // fault and rejects an unmapped address. Ult objects always live in the guest's RW data/BSS.
+    if (!addr || (addr & 7u)) return false;
+    return gpu::guest_readable(addr, (uint32_t)sizeof(GuestUltHeader));
+}
+
+// Publish {magic, id} into the guest blob. Returns false if the pointer is unusable.
+bool publish_object(uint64_t guest_addr, UltType type, uint64_t id) {
+    if (!guest_object_writable(guest_addr)) return false;
+    auto* h = (GuestUltHeader*)(uintptr_t)guest_addr;
+    h->id = id;
+    // Publish the id BEFORE the magic: another thread that sees the magic must already see the id.
+    __atomic_store_n(&h->magic, magic_for(type), __ATOMIC_RELEASE);
+    return true;
+}
+
+void unpublish_object(uint64_t guest_addr) {
+    if (!guest_object_writable(guest_addr)) return;
+    auto* h = (GuestUltHeader*)(uintptr_t)guest_addr;
+    __atomic_store_n(&h->magic, 0ull, __ATOMIC_RELEASE);
+    h->id = 0;
+}
+
+// Resolve a guest object pointer to prosper's object, or nullptr with a loud, deduplicated report.
+UltObject* resolve(uint64_t guest_addr, UltType type, const char* fn) {
+    if (!guest_object_writable(guest_addr)) {
+        log_line("%s: unusable object pointer 0x%llx (null, misaligned, or unmapped)", fn,
+                 (unsigned long long)guest_addr);
+        return nullptr;
+    }
+    auto* h = (GuestUltHeader*)(uintptr_t)guest_addr;
+    const uint64_t magic = __atomic_load_n(&h->magic, __ATOMIC_ACQUIRE);
+    if (magic != magic_for(type)) {
+        static std::atomic<uint64_t> reported{0};
+        if (reported.fetch_add(1, std::memory_order_relaxed) < 16)
+            log_line("%s: object 0x%llx is not a live %s (magic 0x%llx) — never created, already "
+                     "destroyed, or the wrong object type",
+                     fn, (unsigned long long)guest_addr, type_name(type), (unsigned long long)magic);
+        return nullptr;
+    }
+    UltObject* o = object_from_id(h->id, type);
+    if (!o) {
+        log_line("%s: object 0x%llx carries a stale %s id 0x%llx", fn,
+                 (unsigned long long)guest_addr, type_name(type), (unsigned long long)h->id);
+        return nullptr;
+    }
+    return o;
+}
+
+// ---------------------------------------------------------------------------------------------
+// Work areas. `*GetWorkAreaSize` returns prosper's OWN requirement, and the matching Create
+// recomputes the identical size from the identical arguments the guest passes it again, so the
+// buffer prosper asked for is exactly the buffer prosper consumes.
+//
+// Keeping the registry here rather than host-side is what makes the returned size honest instead of
+// decorative. The trade is that it is guest memory: a title that frees the work area while the object
+// lives would leave prosper reading freed storage. That is DETECTED, not trusted — every access
+// re-validates the header magic, so a freed or reused buffer is reported rather than believed.
+// (Earthion never frees either work area; it does not even retain the pointer.)
+// ---------------------------------------------------------------------------------------------
+constexpr uint32_t kWorkAreaVersion = 1;
+constexpr uint64_t kWorkMagicRuntime = 0x50525350'52544141ull;   // "PRSP" "RTAA"
+constexpr uint64_t kWorkMagicPool    = 0x50525350'504F4F4Cull;   // "PRSP" "POOL"
+
+struct RuntimeSlot {          // one per numMaxUlthread
+    uint64_t ulthread_id;     // 0 = free
+    uint64_t host_thread;
+    uint64_t context;
+    uint64_t context_size;
+};
+struct RuntimeWorkArea {
+    uint64_t magic;
+    uint32_t version;
+    uint32_t num_max_ulthread;
+    uint32_t num_worker_thread;
+    uint32_t reserved;
+    uint64_t bytes;
+    // RuntimeSlot[num_max_ulthread] follows
+};
+struct PoolSlot { uint64_t sync_object_id; };   // 0 = free
+struct PoolWorkArea {
+    uint64_t magic;
+    uint32_t version;
+    uint32_t num_threads;
+    uint32_t num_sync_objects;
+    uint32_t reserved;
+    uint64_t bytes;
+    // PoolSlot[num_sync_objects] follows
+};
+
+// Bound the guest's own numbers before multiplying: a garbled argument must not become a huge size.
+// Earthion asks for 16 ulthreads / 3 workers and 16 threads / 16 sync objects.
+constexpr uint32_t kMaxReasonableObjects = 4096;
+
+uint64_t runtime_work_area_size(uint32_t num_max_ulthread) {
+    if (num_max_ulthread > kMaxReasonableObjects) num_max_ulthread = kMaxReasonableObjects;
+    return sizeof(RuntimeWorkArea) + (uint64_t)num_max_ulthread * sizeof(RuntimeSlot);
+}
+uint64_t pool_work_area_size(uint32_t num_sync_objects) {
+    if (num_sync_objects > kMaxReasonableObjects) num_sync_objects = kMaxReasonableObjects;
+    return sizeof(PoolWorkArea) + (uint64_t)num_sync_objects * sizeof(PoolSlot);
+}
+
+// ---------------------------------------------------------------------------------------------
+// Blocking watchdog. Real blocking replaced a million per-boot no-ops, so an ordering hazard that
+// used to be invisible would now be a hang. Every blocking wait is bounded so it can be reported.
+// ---------------------------------------------------------------------------------------------
+uint64_t block_warn_ms() {
+    static const uint64_t v = env_u64("PROSPER_ULT_BLOCK_WARN_MS", 5000);
+    return v;
+}
+// A condition variable legitimately blocks for a long time (an idle worker waiting for jobs), so its
+// threshold is far higher and its wording is informational — a loud "hang" line for an idle worker
+// would be a false alarm that trains readers to ignore the real one.
+uint64_t cond_note_ms() {
+    static const uint64_t v = env_u64("PROSPER_ULT_COND_NOTE_MS", 30000);
+    return v;
+}
+
+uint64_t self_thread() { return (uint64_t)(uintptr_t)pthread_self(); }
+
+void abstime_in_ms(struct timespec& ts, uint64_t ms) {
+    clock_gettime(CLOCK_REALTIME, &ts);
+    ts.tv_sec  += (time_t)(ms / 1000);
+    ts.tv_nsec += (long)((ms % 1000) * 1000000ull);
+    if (ts.tv_nsec >= 1000000000L) { ts.tv_nsec -= 1000000000L; ts.tv_sec += 1; }
+}
+
+// ---------------------------------------------------------------------------------------------
+// Library state.
+// ---------------------------------------------------------------------------------------------
+std::atomic<bool>     g_initialized{false};
+std::atomic<uint64_t> g_init_calls{0};
 
 void print_banner() {
     if (g_banner_printed.exchange(true)) return;
     fprintf(stderr,
-        "[prosper] ==== libSceUlt IS NOT IMPLEMENTED (#1603) ====================================\n"
-        "[prosper]   libSceUlt is Sony's USER-LEVEL THREADING library (ulthreads, mutexes,\n"
-        "[prosper]   condition variables, queues). prosper implements NONE of its semantics.\n"
-        "[prosper]   Every ulthread this title creates NEVER RUNS, and any guest state it guards\n"
-        "[prosper]   with an Ult mutex or condvar is COMPLETELY UNSYNCHRONISED.\n"
-        "[prosper]   Calls below are reported per function at call 1 and then at each power of ten,\n"
-        "[prosper]   so a polling loop cannot hide behind a single deduped line.\n"
+        "[prosper] ==== libSceUlt (user-level threading) ========================================\n"
+        "[prosper]   prosper implements the ulthread runtime, waiting-queue resource pool, mutexes\n"
+        "[prosper]   and condition variables this title uses. Ulthreads run one-to-one on real guest\n"
+        "[prosper]   threads rather than multiplexed onto the requested worker count; the runtime\n"
+        "[prosper]   reports if simultaneous ulthreads ever exceed numWorkerThread.\n"
+        "[prosper]   Blocking waits are watchdogged (PROSPER_ULT_BLOCK_WARN_MS, default 5000).\n"
         "[prosper] ==============================================================================\n");
 }
 
-// Report the call and hand back the policy's return value. Counting is per call (an atomic
-// increment), NOT per first-seen NID: the whole point of this file is that the generic path's
-// first-seen dedup reported one line for a million calls.
-uint64_t ult_report(size_t index) {
+// Count the call and, at 1 / 10 / 100 / ..., emit a volume line. Bounded (a 1e6-call hot path costs
+// 7 lines) but never silent: the generic path's first-seen dedup reported ONE line for 1,005,742
+// sceUltMutexLock calls, which is the visibility failure this whole surface exists to fix.
+void count_call(size_t index) {
     const uint64_t n = g_calls[index].fetch_add(1, std::memory_order_relaxed) + 1;
-    const bool success = g_return_success.load(std::memory_order_relaxed);
-    // A size-returning contract has no error channel: the sentinel would be read as a byte count and
-    // handed to malloc (#1618). Such an entry point reports through the log line only.
-    const uint64_t ret = kUlt[index].returns_size ? kUltSizeUnknown
-                       : success                  ? 0ull
-                                                  : kUltNotImplemented;
-    // Log at 1, 10, 100, 1e3, ... — bounded (a 1e6-call spin costs 7 lines) but never silent.
-    // The threshold is a plain load/store rather than a CAS: guest threads racing here can at worst
-    // emit the SAME milestone line twice, never suppress one. A duplicate diagnostic line is
-    // harmless; a lock taken to avoid it would sit on a path the guest hits a million times.
     uint64_t due = g_next_report[index].load(std::memory_order_relaxed);
-    if (n >= due) {
-        uint64_t next = due ? due * 10 : 10;
-        while (next <= n && next <= (uint64_t)1e18) next *= 10;
-        g_next_report[index].store(next, std::memory_order_relaxed);
-        print_banner();
-        // The magnitude has to be readable at a glance. A skimmed log must show "this is being
-        // hammered a million times", not a bare count the reader has to notice and compare: on
-        // Earthion the deduped generic path reported ONE line for 1,005,742 sceUltMutexLock calls.
-        const char* scale = n >= 1000000 ? "  *** >=1,000,000 CALLS — the guest is SPINNING on an "
-                                           "unimplemented user-level lock ***"
-                          : n >= 1000    ? "  *** >=1,000 CALLS — hot path, not a one-off ***"
-                                         : "";
-        const char* policy = kUlt[index].returns_size
-                                 ? " (a SIZE, not a status — this contract has no error channel, #1618)"
-                             : success
-                                 ? "  [PROSPER_ULT_RETURN_SUCCESS: FAKE SUCCESS, guest is being lied to]"
-                                 : " (SCE_KERNEL_ERROR_ENOSYS)";
-        fprintf(stderr, "[prosper] libSceUlt UNIMPLEMENTED: %s (%s) call #%llu -> returning 0x%llx%s%s\n",
-                kUlt[index].name, kUlt[index].nid, (unsigned long long)n,
-                (unsigned long long)ret, policy, scale);
+    if (n < due) return;
+    uint64_t next = due ? due * 10 : 10;
+    while (next <= n && next <= (uint64_t)1e18) next *= 10;
+    g_next_report[index].store(next, std::memory_order_relaxed);
+    print_banner();
+    log_line("%s (%s) call #%llu", kUlt[index].name, kUlt[index].nid, (unsigned long long)n);
+}
+
+// The policy gate every entry point runs first. Returns true when the caller should execute the real
+// implementation; otherwise *out is the policy's return value.
+bool implement(size_t index, uint64_t* out) {
+    count_call(index);
+    if (kUlt[index].ret == UltRet::Size) {
+        // #1618: a size contract has no error channel, so neither escape hatch may put a sentinel
+        // there. Under a legacy policy prosper consumes no work area, so 0 is both honest and safe.
+        if (g_legacy_enosys.load(std::memory_order_relaxed) ||
+            g_return_success.load(std::memory_order_relaxed)) { *out = 0; return false; }
+        return true;
     }
-    return ret;
+    if (g_legacy_enosys.load(std::memory_order_relaxed)) { *out = kUltNotImplemented; return false; }
+    if (g_return_success.load(std::memory_order_relaxed)) { *out = kUltOk; return false; }
+    return true;
 }
 
-// One distinct host function per NID so the handler knows which entry point was called.
+// An entry point that is registered and counted but whose semantics are not implemented yet.
+uint64_t refuse(size_t index) {
+    uint64_t out = 0;
+    if (!implement(index, &out)) return out;
+    static std::atomic<uint64_t> reported[kUltCount];
+    if (reported[index].fetch_add(1, std::memory_order_relaxed) < 4)
+        log_line("%s is NOT IMPLEMENTED — returning 0x%llx (SCE_KERNEL_ERROR_ENOSYS)",
+                 kUlt[index].name, (unsigned long long)kUltNotImplemented);
+    return kUltNotImplemented;
+}
+
+std::string guest_string(uint64_t addr) {
+    if (!addr || !gpu::guest_readable(addr, 1)) return std::string();
+    const char* s = (const char*)(uintptr_t)addr;
+    size_t n = 0;
+    while (n < 64 && gpu::guest_readable(addr + n, 1) && s[n]) ++n;
+    return std::string(s, n);
+}
+
+// =============================================================================================
+// Library lifecycle
+// =============================================================================================
+PROSPER_SYSV_ABI uint64_t ult_initialize(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t) {
+    uint64_t out = 0;
+    if (!implement(kIdxInitialize, &out)) return out;
+    g_init_calls.fetch_add(1, std::memory_order_relaxed);
+    g_initialized.store(true, std::memory_order_release);
+    print_banner();
+    return kUltOk;
+}
+
+PROSPER_SYSV_ABI uint64_t ult_finalize(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t) {
+    uint64_t out = 0;
+    if (!implement(kIdxFinalize, &out)) return out;
+    // Finalize does NOT tear prosper's objects down. The guest may still hold live mutex/condvar
+    // pointers (its own Destroy calls own that), and destroying a mutex another thread is blocked on
+    // would turn an orderly shutdown into undefined behaviour. Recording the transition is enough.
+    g_initialized.store(false, std::memory_order_release);
+    return kUltOk;
+}
+
+// prosper's implementation has no global initialisation requirement, so an object created before
+// sceUltInitialize cannot fail for a reason prosper actually has. Report the ordering and continue;
+// refusing would invent a failure the library's real behaviour has not been shown to have.
+// CONFIDENCE: MED (Earthion always initialises first, so the ordering rule itself is untested here).
+void note_uninitialised(const char* fn) {
+    if (g_initialized.load(std::memory_order_acquire)) return;
+    static std::atomic<bool> warned{false};
+    if (!warned.exchange(true))
+        log_line("%s called before sceUltInitialize — prosper needs no global init and continues, "
+                 "but the guest's ordering is unusual and worth knowing", fn);
+}
+
+// =============================================================================================
+// Waiting-queue resource pool
+// =============================================================================================
+PROSPER_SYSV_ABI uint64_t ult_pool_work_area_size(uint64_t a0, uint64_t a1, uint64_t, uint64_t,
+                                                  uint64_t, uint64_t) {
+    uint64_t out = 0;
+    if (!implement(kIdxPoolSize, &out)) return out;
+    const uint32_t num_threads = (uint32_t)a0, num_sync_objects = (uint32_t)a1;
+    const uint64_t bytes = pool_work_area_size(num_sync_objects);
+    log_line("sceUltWaitingQueueResourcePoolGetWorkAreaSize(numThreads=%u, numSyncObjects=%u) -> %llu "
+             "bytes (prosper's own requirement; the matching Create consumes exactly this buffer)",
+             num_threads, num_sync_objects, (unsigned long long)bytes);
+    return bytes;
+}
+
+// _sceUltWaitingQueueResourcePoolCreate(pool, name, numThreads, numSyncObjects, workArea, opt, ver).
+// 7 args; `ver` arrives on the stack and the import bridge forwards it as a6.
+PROSPER_SYSV_ABI uint64_t ult_pool_create(uint64_t a0, uint64_t a1, uint64_t a2, uint64_t a3,
+                                          uint64_t a4, uint64_t a5, uint64_t a6) {
+    uint64_t out = 0;
+    if (!implement(kIdxPoolCreate, &out)) return out;
+    note_uninitialised("_sceUltWaitingQueueResourcePoolCreate");
+    const uint32_t num_threads = (uint32_t)a2, num_sync_objects = (uint32_t)a3;
+    const uint64_t need = pool_work_area_size(num_sync_objects);
+
+    if (!guest_object_writable(a0)) {
+        log_line("_sceUltWaitingQueueResourcePoolCreate: unusable pool pointer 0x%llx",
+                 (unsigned long long)a0);
+        return kUltErrInval;
+    }
+    if (!a4 || !gpu::guest_readable(a4, (uint32_t)std::min<uint64_t>(need, 4096))) {
+        log_line("_sceUltWaitingQueueResourcePoolCreate: workArea 0x%llx is unusable for the %llu "
+                 "bytes sceUltWaitingQueueResourcePoolGetWorkAreaSize(%u, %u) asked for",
+                 (unsigned long long)a4, (unsigned long long)need, num_threads, num_sync_objects);
+        return kUltErrInval;
+    }
+
+    auto* wa = (PoolWorkArea*)(uintptr_t)a4;
+    wa->magic = kWorkMagicPool;
+    wa->version = kWorkAreaVersion;
+    wa->num_threads = num_threads;
+    wa->num_sync_objects = num_sync_objects;
+    wa->reserved = 0;
+    wa->bytes = need;
+    auto* slots = (PoolSlot*)(uintptr_t)(a4 + sizeof(PoolWorkArea));
+    const uint32_t capped = num_sync_objects > kMaxReasonableObjects ? kMaxReasonableObjects
+                                                                     : num_sync_objects;
+    for (uint32_t i = 0; i < capped; ++i) slots[i].sync_object_id = 0;
+
+    UltObject* o = allocate_object(UltType::Pool);
+    o->name = guest_string(a1);
+    o->guest_addr = a0;
+    o->api_version = (uint32_t)a6;
+    o->num_threads = num_threads;
+    o->num_sync_objects = num_sync_objects;
+    o->work_area = a4;
+    o->work_bytes = need;
+    o->alive.store(true, std::memory_order_release);
+    const uint64_t id = make_id(o->slot, o->generation);
+    if (!publish_object(a0, UltType::Pool, id)) {
+        o->alive.store(false, std::memory_order_release);
+        return kUltErrInval;
+    }
+    log_line("_sceUltWaitingQueueResourcePoolCreate(\"%s\") pool=0x%llx numThreads=%u "
+             "numSyncObjects=%u workArea=0x%llx(%llu B) apiVersion=0x%x -> ok",
+             o->name.c_str(), (unsigned long long)a0, num_threads, num_sync_objects,
+             (unsigned long long)a4, (unsigned long long)need, o->api_version);
+    return kUltOk;
+}
+
+// =============================================================================================
+// Ulthread runtime
+// =============================================================================================
+PROSPER_SYSV_ABI uint64_t ult_runtime_work_area_size(uint64_t a0, uint64_t a1, uint64_t, uint64_t,
+                                                     uint64_t, uint64_t) {
+    uint64_t out = 0;
+    if (!implement(kIdxRuntimeSize, &out)) return out;
+    const uint32_t num_max = (uint32_t)a0, num_worker = (uint32_t)a1;
+    const uint64_t bytes = runtime_work_area_size(num_max);
+    log_line("sceUltUlthreadRuntimeGetWorkAreaSize(numMaxUlthread=%u, numWorkerThread=%u) -> %llu "
+             "bytes (prosper's own requirement; the matching Create consumes exactly this buffer)",
+             num_max, num_worker, (unsigned long long)bytes);
+    return bytes;
+}
+
+// _sceUltUlthreadRuntimeCreate(runtime, name, numMaxUlthread, numWorkerThread, workArea, opt, ver).
+PROSPER_SYSV_ABI uint64_t ult_runtime_create(uint64_t a0, uint64_t a1, uint64_t a2, uint64_t a3,
+                                             uint64_t a4, uint64_t a5, uint64_t a6) {
+    uint64_t out = 0;
+    if (!implement(kIdxRuntimeCreate, &out)) return out;
+    note_uninitialised("_sceUltUlthreadRuntimeCreate");
+    const uint32_t num_max = (uint32_t)a2, num_worker = (uint32_t)a3;
+    const uint64_t need = runtime_work_area_size(num_max);
+
+    if (!guest_object_writable(a0)) {
+        log_line("_sceUltUlthreadRuntimeCreate: unusable runtime pointer 0x%llx",
+                 (unsigned long long)a0);
+        return kUltErrInval;
+    }
+    if (!num_max) {
+        log_line("_sceUltUlthreadRuntimeCreate: numMaxUlthread is 0 — no ulthread could ever be "
+                 "created in this runtime");
+        return kUltErrInval;
+    }
+    if (!a4 || !gpu::guest_readable(a4, (uint32_t)std::min<uint64_t>(need, 4096))) {
+        log_line("_sceUltUlthreadRuntimeCreate: workArea 0x%llx is unusable for the %llu bytes "
+                 "sceUltUlthreadRuntimeGetWorkAreaSize(%u, %u) asked for",
+                 (unsigned long long)a4, (unsigned long long)need, num_max, num_worker);
+        return kUltErrInval;
+    }
+
+    auto* wa = (RuntimeWorkArea*)(uintptr_t)a4;
+    wa->magic = kWorkMagicRuntime;
+    wa->version = kWorkAreaVersion;
+    wa->num_max_ulthread = num_max;
+    wa->num_worker_thread = num_worker;
+    wa->reserved = 0;
+    wa->bytes = need;
+    auto* slots = (RuntimeSlot*)(uintptr_t)(a4 + sizeof(RuntimeWorkArea));
+    const uint32_t capped = num_max > kMaxReasonableObjects ? kMaxReasonableObjects : num_max;
+    for (uint32_t i = 0; i < capped; ++i) slots[i] = RuntimeSlot{0, 0, 0, 0};
+
+    UltObject* o = allocate_object(UltType::Runtime);
+    o->name = guest_string(a1);
+    o->guest_addr = a0;
+    o->api_version = (uint32_t)a6;
+    o->num_max_ulthread = num_max;
+    o->num_worker_thread = num_worker;
+    o->work_area = a4;
+    o->work_bytes = need;
+    o->live_ulthreads.store(0, std::memory_order_relaxed);
+    o->running_ulthreads.store(0, std::memory_order_relaxed);
+    o->high_water.store(0, std::memory_order_relaxed);
+    o->warned_concurrency.store(false, std::memory_order_relaxed);
+    o->alive.store(true, std::memory_order_release);
+    const uint64_t id = make_id(o->slot, o->generation);
+    if (!publish_object(a0, UltType::Runtime, id)) {
+        o->alive.store(false, std::memory_order_release);
+        return kUltErrInval;
+    }
+    log_line("_sceUltUlthreadRuntimeCreate(\"%s\") runtime=0x%llx numMaxUlthread=%u "
+             "numWorkerThread=%u workArea=0x%llx(%llu B) apiVersion=0x%x -> ok",
+             o->name.c_str(), (unsigned long long)a0, num_max, num_worker,
+             (unsigned long long)a4, (unsigned long long)need, o->api_version);
+    return kUltOk;
+}
+
+// =============================================================================================
+// Mutex
 //
-// No guest memory is read or written here. #1603 justified that partly on the belief that the two
-// size queries fill a `size_t*` out-parameter; they do not — they return the size in rax and the
-// guest passes it straight to malloc, which is what made an error sentinel actively harmful (#1618).
-// The remaining reason still holds and is the real one: prosper has no evidence of what those sizes
-// should be, and writing (or returning) a plausible-looking number would be the #544/#660 defect in a
-// new costume — an AGC "success" stub whose unwritten required-memory output made Dead Cells allocate
-// multiple gigabytes. Zero is the honest answer for as long as prosper consumes no work area, and it
-// is also the value the dispatcher's unresolved-import path would have produced.
-// CONFIDENCE: HIGH (inventing a size is strictly worse than reporting the one prosper actually needs).
-template <size_t Index>
-PROSPER_SYSV_ABI uint64_t ult_stub(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t) {
-    return ult_report(Index);
+// The dominant call by five orders of magnitude: 1,005,742 lock/unlock pairs in a 118 s boot. The
+// implementation is an errorcheck pthread mutex plus explicit owner tracking, because the two failure
+// modes that matter here are both undefined behaviour on a plain mutex and must instead be reported:
+//   * self-relock of a non-recursive mutex (Earthion passes optParam=NULL, i.e. non-recursive), and
+//   * unlock by a thread that does not hold it.
+// A returned error is diagnosable; a hang is not.
+// =============================================================================================
+PROSPER_SYSV_ABI uint64_t ult_mutex_create(uint64_t a0, uint64_t a1, uint64_t a2, uint64_t a3,
+                                           uint64_t a4, uint64_t) {
+    uint64_t out = 0;
+    if (!implement(kIdxMutexCreate, &out)) return out;
+    note_uninitialised("_sceUltMutexCreate");
+    if (!guest_object_writable(a0)) {
+        log_line("_sceUltMutexCreate: unusable mutex pointer 0x%llx", (unsigned long long)a0);
+        return kUltErrInval;
+    }
+    // A mutex is allocated FROM a waiting-queue resource pool: the pool is the third argument at
+    // every call site. Validating it is only possible because the pool family lands in the same
+    // change — a mutex that cannot check its own pool argument would accept anything.
+    UltObject* pool = resolve(a2, UltType::Pool, "_sceUltMutexCreate(pool)");
+    if (!pool) return kUltErrInval;
+
+    UltObject* o = allocate_object(UltType::Mutex);
+    if (!o->mtx_valid) {
+        pthread_mutexattr_t at;
+        pthread_mutexattr_init(&at);
+        pthread_mutexattr_settype(&at, PTHREAD_MUTEX_ERRORCHECK);
+        const int rc = pthread_mutex_init(&o->mtx, &at);
+        pthread_mutexattr_destroy(&at);
+        if (rc) {
+            log_line("_sceUltMutexCreate: pthread_mutex_init failed (%d)", rc);
+            return kUltErrNoMem;
+        }
+        o->mtx_valid = true;
+    }
+    o->name = guest_string(a1);
+    o->guest_addr = a0;
+    o->api_version = (uint32_t)a4;
+    o->pool_id = make_id(pool->slot, pool->generation);
+    o->owner.store(0, std::memory_order_relaxed);
+    o->alive.store(true, std::memory_order_release);
+    const uint64_t id = make_id(o->slot, o->generation);
+    if (!publish_object(a0, UltType::Mutex, id)) {
+        o->alive.store(false, std::memory_order_release);
+        return kUltErrInval;
+    }
+
+    // numSyncObjects is the pool's stated capacity. prosper reports crossing it but does NOT refuse:
+    // the parameter's exact meaning is not proven from title evidence, and refusing a legitimate
+    // create on an unproven reading would be worse than a title running with a pool it undersized.
+    // CONFIDENCE: MED (Earthion asks for 16 and binds 11-15, which fits the reading but does not
+    // prove it).
+    const uint32_t bound = pool->bound_sync_objects.fetch_add(1, std::memory_order_relaxed) + 1;
+    if (bound > pool->num_sync_objects && !pool->warned_pool_capacity.exchange(true))
+        log_line("pool \"%s\" now has %u sync objects bound but was created for numSyncObjects=%u — "
+                 "prosper does not enforce this cap; reporting it so an undersized pool is visible",
+                 pool->name.c_str(), bound, pool->num_sync_objects);
+
+    log_line("_sceUltMutexCreate(\"%s\") mutex=0x%llx pool=0x%llx apiVersion=0x%x -> ok",
+             o->name.c_str(), (unsigned long long)a0, (unsigned long long)a2, o->api_version);
+    return kUltOk;
 }
 
-template <size_t... Index>
-void register_all(std::index_sequence<Index...>) {
-    (Hle::register_fn(kUlt[Index].nid, (HleFn)ult_stub<Index>, kUlt[Index].name), ...);
+uint64_t mutex_lock_impl(UltObject* o, const char* fn) {
+    const uint64_t me = self_thread();
+    o->lock_calls.fetch_add(1, std::memory_order_relaxed);
+
+    // Self-relock of a non-recursive mutex. On hardware this deadlocks or fails; prosper reports it
+    // and fails, because a returned error is diagnosable and a hang is not. Detected by an explicit
+    // owner compare rather than by relying on the errorcheck lock's EDEADLK, so the diagnosis is
+    // exact and costs one relaxed atomic load on the fast path.
+    if (o->owner.load(std::memory_order_relaxed) == me) {
+        if (!o->warned_deadlock.exchange(true))
+            log_line("SELF-DEADLOCK: sceUltMutexLock on \"%s\" (0x%llx) by the thread that already "
+                     "holds it. This mutex was created with optParam=NULL, i.e. NON-RECURSIVE. "
+                     "prosper returns 0x%llx rather than blocking forever",
+                     o->name.c_str(), (unsigned long long)o->guest_addr,
+                     (unsigned long long)kUltErrDeadlk);
+        return kUltErrDeadlk;
+    }
+
+    int rc = pthread_mutex_trylock(&o->mtx);
+    if (rc == EBUSY) {
+        o->contended.fetch_add(1, std::memory_order_relaxed);
+        // Bounded wait so the watchdog can speak, then an unbounded one so semantics are unchanged.
+        const uint64_t warn_ms = block_warn_ms();
+#if defined(__APPLE__)
+        // macOS has no pthread_mutex_timedlock; poll to the threshold, then block for real.
+        const uint64_t deadline_polls = warn_ms;   // 1 ms per poll
+        uint64_t polls = 0;
+        while ((rc = pthread_mutex_trylock(&o->mtx)) == EBUSY && polls < deadline_polls) {
+            struct timespec ms{0, 1000000};
+            nanosleep(&ms, nullptr);
+            ++polls;
+        }
+#else
+        struct timespec deadline;
+        abstime_in_ms(deadline, warn_ms);
+        rc = pthread_mutex_timedlock(&o->mtx, &deadline);
+#endif
+        if (rc == ETIMEDOUT || rc == EBUSY) {
+            if (!o->warned_block.exchange(true))
+                log_line("BLOCKED >%llums: sceUltMutexLock on \"%s\" (0x%llx) — holder thread 0x%llx, "
+                         "waiter thread 0x%llx. Still waiting. If the title appears hung, this is "
+                         "where. (PROSPER_ULT_BLOCK_WARN_MS)",
+                         (unsigned long long)warn_ms, o->name.c_str(),
+                         (unsigned long long)o->guest_addr,
+                         (unsigned long long)o->owner.load(std::memory_order_relaxed),
+                         (unsigned long long)me);
+            rc = pthread_mutex_lock(&o->mtx);
+        }
+    }
+    if (rc == EDEADLK) {   // errorcheck backstop; the owner compare above should have caught it
+        if (!o->warned_deadlock.exchange(true))
+            log_line("SELF-DEADLOCK (errorcheck): %s on \"%s\" (0x%llx)", fn, o->name.c_str(),
+                     (unsigned long long)o->guest_addr);
+        return kUltErrDeadlk;
+    }
+    if (rc != 0) {
+        log_line("%s on \"%s\" failed: pthread rc=%d", fn, o->name.c_str(), rc);
+        return kUltErrInval;
+    }
+    o->owner.store(me, std::memory_order_relaxed);
+    return kUltOk;
+}
+
+PROSPER_SYSV_ABI uint64_t ult_mutex_lock(uint64_t a0, uint64_t, uint64_t, uint64_t, uint64_t,
+                                         uint64_t) {
+    uint64_t out = 0;
+    if (!implement(kIdxMutexLock, &out)) return out;
+    UltObject* o = resolve(a0, UltType::Mutex, "sceUltMutexLock");
+    if (!o) return kUltErrSrch;
+    return mutex_lock_impl(o, "sceUltMutexLock");
+}
+
+PROSPER_SYSV_ABI uint64_t ult_mutex_unlock(uint64_t a0, uint64_t, uint64_t, uint64_t, uint64_t,
+                                           uint64_t) {
+    uint64_t out = 0;
+    if (!implement(kIdxMutexUnlock, &out)) return out;
+    UltObject* o = resolve(a0, UltType::Mutex, "sceUltMutexUnlock");
+    if (!o) return kUltErrSrch;
+    const uint64_t me = self_thread();
+    if (o->owner.load(std::memory_order_relaxed) != me) {
+        static std::atomic<uint64_t> reported{0};
+        if (reported.fetch_add(1, std::memory_order_relaxed) < 8)
+            log_line("sceUltMutexUnlock on \"%s\" (0x%llx) by thread 0x%llx, which does not hold it "
+                     "(holder 0x%llx) — refusing so the real owner's exclusion is not broken",
+                     o->name.c_str(), (unsigned long long)o->guest_addr, (unsigned long long)me,
+                     (unsigned long long)o->owner.load(std::memory_order_relaxed));
+        return kUltErrPerm;
+    }
+    o->owner.store(0, std::memory_order_relaxed);
+    const int rc = pthread_mutex_unlock(&o->mtx);
+    if (rc) {
+        log_line("sceUltMutexUnlock on \"%s\" failed: pthread rc=%d", o->name.c_str(), rc);
+        return kUltErrPerm;
+    }
+    return kUltOk;
+}
+
+PROSPER_SYSV_ABI uint64_t ult_mutex_destroy(uint64_t a0, uint64_t, uint64_t, uint64_t, uint64_t,
+                                            uint64_t) {
+    uint64_t out = 0;
+    if (!implement(kIdxMutexDestroy, &out)) return out;
+    UltObject* o = resolve(a0, UltType::Mutex, "sceUltMutexDestroy");
+    if (!o) return kUltErrSrch;
+    if (o->owner.load(std::memory_order_relaxed) != 0)
+        log_line("sceUltMutexDestroy on \"%s\" (0x%llx) while thread 0x%llx still holds it",
+                 o->name.c_str(), (unsigned long long)o->guest_addr,
+                 (unsigned long long)o->owner.load(std::memory_order_relaxed));
+    // Unpublish first: a concurrent lock must miss rather than race the teardown. The pthread mutex
+    // itself is retained for slot reuse (destroying one a thread is blocked on is undefined).
+    unpublish_object(a0);
+    o->alive.store(false, std::memory_order_release);
+    if (UltObject* pool = object_from_id(o->pool_id, UltType::Pool))
+        pool->bound_sync_objects.fetch_sub(1, std::memory_order_relaxed);
+    return kUltOk;
+}
+
+// =============================================================================================
+// Not yet implemented: ulthread create/join and the condition variables. Registered, counted and
+// refused; see the ABI block at the top of this file for their established layouts.
+// =============================================================================================
+template <size_t Index>
+PROSPER_SYSV_ABI uint64_t ult_refuse(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t) {
+    return refuse(Index);
 }
 
 }  // namespace
 
 void register_ult_hle() {
-    g_return_success.store(env_return_success(), std::memory_order_relaxed);
-    register_all(std::make_index_sequence<kUltCount>{});
+    g_return_success.store(env_flag("PROSPER_ULT_RETURN_SUCCESS"), std::memory_order_relaxed);
+    g_legacy_enosys.store(env_flag("PROSPER_ULT_LEGACY_ENOSYS"), std::memory_order_relaxed);
+
+    Hle::register_fn(kUlt[kIdxInitialize].nid,   (HleFn)ult_initialize,   kUlt[kIdxInitialize].name);
+    Hle::register_fn(kUlt[kIdxFinalize].nid,     (HleFn)ult_finalize,     kUlt[kIdxFinalize].name);
+    Hle::register_fn(kUlt[kIdxPoolSize].nid,     (HleFn)ult_pool_work_area_size, kUlt[kIdxPoolSize].name);
+    Hle::register_fn(kUlt[kIdxPoolCreate].nid,   (HleFn)ult_pool_create,  kUlt[kIdxPoolCreate].name);
+    Hle::register_fn(kUlt[kIdxRuntimeSize].nid,  (HleFn)ult_runtime_work_area_size,
+                     kUlt[kIdxRuntimeSize].name);
+    Hle::register_fn(kUlt[kIdxRuntimeCreate].nid, (HleFn)ult_runtime_create,
+                     kUlt[kIdxRuntimeCreate].name);
+    Hle::register_fn(kUlt[kIdxMutexCreate].nid,  (HleFn)ult_mutex_create,  kUlt[kIdxMutexCreate].name);
+    Hle::register_fn(kUlt[kIdxMutexLock].nid,    (HleFn)ult_mutex_lock,    kUlt[kIdxMutexLock].name);
+    Hle::register_fn(kUlt[kIdxMutexUnlock].nid,  (HleFn)ult_mutex_unlock,  kUlt[kIdxMutexUnlock].name);
+    Hle::register_fn(kUlt[kIdxMutexDestroy].nid, (HleFn)ult_mutex_destroy, kUlt[kIdxMutexDestroy].name);
+
+    Hle::register_fn(kUlt[kIdxUlthreadCreate].nid, (HleFn)ult_refuse<kIdxUlthreadCreate>,
+                     kUlt[kIdxUlthreadCreate].name);
+    Hle::register_fn(kUlt[kIdxUlthreadJoin].nid,   (HleFn)ult_refuse<kIdxUlthreadJoin>,
+                     kUlt[kIdxUlthreadJoin].name);
+    Hle::register_fn(kUlt[kIdxCondCreate].nid,     (HleFn)ult_refuse<kIdxCondCreate>,
+                     kUlt[kIdxCondCreate].name);
+    Hle::register_fn(kUlt[kIdxCondWait].nid,       (HleFn)ult_refuse<kIdxCondWait>,
+                     kUlt[kIdxCondWait].name);
+    Hle::register_fn(kUlt[kIdxCondSignal].nid,     (HleFn)ult_refuse<kIdxCondSignal>,
+                     kUlt[kIdxCondSignal].name);
+    Hle::register_fn(kUlt[kIdxCondDestroy].nid,    (HleFn)ult_refuse<kIdxCondDestroy>,
+                     kUlt[kIdxCondDestroy].name);
 }
 
 uint64_t ult_call_count(const char* nid) {
@@ -215,6 +943,10 @@ uint64_t ult_call_count(const char* nid) {
 
 bool ult_set_return_success_for_test(bool return_success) {
     return g_return_success.exchange(return_success, std::memory_order_relaxed);
+}
+
+bool ult_set_legacy_enosys_for_test(bool legacy_enosys) {
+    return g_legacy_enosys.exchange(legacy_enosys, std::memory_order_relaxed);
 }
 
 void ult_reset_counts_for_test() {
@@ -229,14 +961,22 @@ void ult_dump_call_log(FILE* f) {
     uint64_t total = 0;
     for (size_t i = 0; i < kUltCount; ++i) total += g_calls[i].load(std::memory_order_relaxed);
     if (!total) return;
-    fprintf(f, "\n=== libSceUlt calls (UNIMPLEMENTED — user-level threading, #1603) ===\n");
+    fprintf(f, "\n=== libSceUlt calls (user-level threading) ===\n");
     for (size_t i = 0; i < kUltCount; ++i) {
         const uint64_t n = g_calls[i].load(std::memory_order_relaxed);
         if (!n) continue;
         fprintf(f, "  %10llu x  %-24s %s\n", (unsigned long long)n, kUlt[i].nid, kUlt[i].name);
     }
-    fprintf(f, "  (%llu total calls; ulthreads created by this title never ran and Ult-guarded\n"
-               "   guest state was never synchronised)\n", (unsigned long long)total);
+    std::shared_lock<std::shared_mutex> lk(g_reg_lock);
+    for (const auto& up : g_objects) {
+        const UltObject* o = up.get();
+        if (o->type != UltType::Mutex) continue;
+        const uint64_t locks = o->lock_calls.load(std::memory_order_relaxed);
+        if (!locks) continue;
+        fprintf(f, "     mutex \"%s\" @0x%llx: %llu locks, %llu contended\n", o->name.c_str(),
+                (unsigned long long)o->guest_addr, (unsigned long long)locks,
+                (unsigned long long)o->contended.load(std::memory_order_relaxed));
+    }
 }
 
 }  // namespace prosper

--- a/prosper/tests/test_ult_fail_visible.cpp
+++ b/prosper/tests/test_ult_fail_visible.cpp
@@ -30,7 +30,6 @@ static constexpr uint64_t kEnosys = 0x8002004Eull;
 static const char* const kCalledNids[] = {
     "hZIg1EWGsHM",  // sceUltInitialize
     "jw9FkZBXo-g",  // _sceUltUlthreadRuntimeCreate
-    "grs2pbc2awM",  // sceUltUlthreadRuntimeGetWorkAreaSize
     "znI3q8S7KQ4",  // _sceUltUlthreadCreate
     "mmt8Sa6tL6c",  // _sceUltMutexCreate
     "8hEGkR1pfr8",  // sceUltMutexLock
@@ -38,8 +37,18 @@ static const char* const kCalledNids[] = {
     "jnKaHGkrxZ4",  // _sceUltConditionVariableCreate
     "JTw1cAVkuc0",  // sceUltConditionVariableSignal
     "YiHujOG9vXY",  // _sceUltWaitingQueueResourcePoolCreate
+};
+// The two entry points whose contract returns a SIZE rather than a status (#1618). They are called
+// by Earthion too, but they must never be asserted to "refuse" — a size has no error channel.
+static const char* const kSizeNids[] = {
+    "grs2pbc2awM",  // sceUltUlthreadRuntimeGetWorkAreaSize
     "WIWV1Qd7PFU",  // sceUltWaitingQueueResourcePoolGetWorkAreaSize
 };
+// Any work-area size at or above this is not a size prosper could honour — it is a sentinel or
+// garbage being read as data. Earthion's own request is (16 ulthreads, 3 workers) / (16, 16); a real
+// requirement for those is kilobytes. 16 MiB is far above any plausible answer and far below the
+// 2.0 GiB that SCE_KERNEL_ERROR_ENOSYS produced.
+static constexpr uint64_t kSaneWorkAreaLimit = 16ull * 1024 * 1024;
 // Imported but not observed in the measured window (teardown / blocking paths). Registered anyway,
 // because "not seen in 118 seconds" is not "never called".
 static const char* const kImportedNids[] = {
@@ -58,6 +67,7 @@ int main() {
 
     bool all_registered = true;
     for (const char* nid : kCalledNids)   all_registered &= Hle::lookup(nid) != nullptr;
+    for (const char* nid : kSizeNids)     all_registered &= Hle::lookup(nid) != nullptr;
     for (const char* nid : kImportedNids) all_registered &= Hle::lookup(nid) != nullptr;
     CHECK(all_registered,
           "every libSceUlt NID Earthion imports is registered (no longer the silent generic path)");
@@ -80,22 +90,28 @@ int main() {
     CHECK(ult_call_count("8hEGkR1pfr8") == 3 && ult_call_count("h0XebKiMBtk") == 1,
           "calls are counted individually, not deduped to one first-seen entry");
 
-    // Every registered entry point must refuse, not just the mutex pair.
+    // Every STATUS-returning entry point must refuse, not just the mutex pair. The two size queries
+    // are deliberately excluded — see kSizeNids below.
     bool all_refuse = true;
     for (const char* nid : kCalledNids)   all_refuse &= Hle::lookup(nid)(0, 0, 0, 0, 0, 0) != 0;
     for (const char* nid : kImportedNids) all_refuse &= Hle::lookup(nid)(0, 0, 0, 0, 0, 0) != 0;
-    CHECK(all_refuse, "no libSceUlt entry point reports success");
+    CHECK(all_refuse, "no status-returning libSceUlt entry point reports success");
 
-    // The size queries must leave the guest's out-param untouched — writing an invented size is the
-    // #544/#660 failure (a "success" stub whose unwritten required-memory output drove a
-    // multi-gigabyte allocation). A sentinel proves prosper wrote nothing.
-    uint64_t work_area = 0xdeadbeefcafef00dull;
-    const uint64_t runtime_size = Hle::lookup("grs2pbc2awM")(
-        (uint64_t)(uintptr_t)&work_area, 4, 0, 0, 0, 0);
-    const uint64_t pool_size = Hle::lookup("WIWV1Qd7PFU")(
-        (uint64_t)(uintptr_t)&work_area, 4, 0, 0, 0, 0);
-    CHECK(runtime_size != 0 && pool_size != 0 && work_area == 0xdeadbeefcafef00dull,
-          "the *GetWorkAreaSize queries fail and write no invented size into the out-param");
+    // #1618. `sceUltUlthreadRuntimeGetWorkAreaSize` and `sceUltWaitingQueueResourcePoolGetWorkAreaSize`
+    // return a size_t AS THEIR RETURN VALUE — there is no out-parameter (Earthion's call site does
+    // `call …; mov [rbp-0x10],rax; mov rdi,[rbp-0x10]; call malloc`). Such a signature has no error
+    // channel, so an error sentinel is read as a byte count: returning SCE_KERNEL_ERROR_ENOSYS asked
+    // the guest for a 0x8002004E-byte (2.0 GiB) allocation. That is worse than leaving the NID
+    // unregistered, because the dispatcher's unresolved-import default is 0 — a harmless malloc(0).
+    //
+    // This assertion fails on the tree that returns the sentinel, and must keep failing for any future
+    // value prosper cannot honour: whatever these return has to be a size prosper is prepared to see
+    // handed back to it as the matching Create's workArea.
+    for (const char* nid : kSizeNids) {
+        const uint64_t size = Hle::lookup(nid)(16, 16, 0, 0, 0, 0);
+        CHECK(size < kSaneWorkAreaLimit,
+              "a *GetWorkAreaSize query returns a real size, never an error sentinel (#1618)");
+    }
 
     // The A/B escape hatch restores the legacy return but must never restore the silence.
     const uint64_t before = ult_call_count("8hEGkR1pfr8");

--- a/prosper/tests/test_ult_fail_visible.cpp
+++ b/prosper/tests/test_ult_fail_visible.cpp
@@ -12,6 +12,7 @@
 
 #include <cstdint>
 #include <cstdio>
+#include <cstring>
 
 using namespace prosper;
 
@@ -23,9 +24,11 @@ static int fails = 0;
 // value is a derived convention rather than an invented libSceUlt constant.
 static constexpr uint64_t kEnosys = 0x8002004Eull;
 
-// Every libSceUlt NID Earthion (PPSA28061) imports. Split by what prosper does with each one, so the
-// split itself is a checked fact rather than a comment.
-static const char* const kImplementedNids[] = {
+// Every libSceUlt NID Earthion (PPSA28061) imports whose contract returns a STATUS. All of them are
+// implemented; the semantics are tested in test_ult_semantics.cpp. What this file guards is that they
+// are registered, counted per call, and that none of them reports success for an object that does not
+// exist — the property that made the pre-#1603 tree lie to the guest a million times per boot.
+static const char* const kStatusNids[] = {
     "hZIg1EWGsHM",  // sceUltInitialize
     "d-kSG2fLrvI",  // sceUltFinalize
     "jw9FkZBXo-g",  // _sceUltUlthreadRuntimeCreate
@@ -34,10 +37,6 @@ static const char* const kImplementedNids[] = {
     "8hEGkR1pfr8",  // sceUltMutexLock
     "h0XebKiMBtk",  // sceUltMutexUnlock
     "jW+HnafeS3Y",  // sceUltMutexDestroy
-};
-// Registered, counted, and refused — not yet implemented. "Not seen in the measured window" is not
-// "never called": these are the teardown and blocking paths.
-static const char* const kUnimplementedNids[] = {
     "znI3q8S7KQ4",  // _sceUltUlthreadCreate
     "gCeAI57LGgI",  // sceUltUlthreadJoin
     "jnKaHGkrxZ4",  // _sceUltConditionVariableCreate
@@ -65,9 +64,8 @@ int main() {
     ult_set_legacy_enosys_for_test(false);
 
     bool all_registered = true;
-    for (const char* nid : kImplementedNids)   all_registered &= Hle::lookup(nid) != nullptr;
-    for (const char* nid : kUnimplementedNids) all_registered &= Hle::lookup(nid) != nullptr;
-    for (const char* nid : kSizeNids)          all_registered &= Hle::lookup(nid) != nullptr;
+    for (const char* nid : kStatusNids) all_registered &= Hle::lookup(nid) != nullptr;
+    for (const char* nid : kSizeNids)   all_registered &= Hle::lookup(nid) != nullptr;
     CHECK(all_registered,
           "every libSceUlt NID Earthion imports is registered (no longer the silent generic path)");
 
@@ -90,11 +88,19 @@ int main() {
     CHECK(ult_call_count("8hEGkR1pfr8") == before + 2 && ult_call_count("h0XebKiMBtk") >= 1,
           "calls are counted individually, not deduped to one first-seen entry");
 
-    // What is not implemented must refuse, loudly and non-zero — never return 0 = SCE_OK.
+    // Called against objects that were never created, EVERY status entry point must refuse. This is
+    // the property the pre-#1603 tree violated on every single call: the generic unresolved-import
+    // path returned 0, which is SCE_OK, so the guest was told a lock it never took was held. The two
+    // lifecycle calls take no object and legitimately succeed, so they are excluded by name.
     bool all_refuse = true;
-    for (const char* nid : kUnimplementedNids)
-        all_refuse &= Hle::lookup(nid)(0, 0, 0, 0, 0, 0) == kEnosys;
-    CHECK(all_refuse, "every not-yet-implemented entry point returns SCE_KERNEL_ERROR_ENOSYS");
+    for (const char* nid : kStatusNids) {
+        if (!std::strcmp(nid, "hZIg1EWGsHM") || !std::strcmp(nid, "d-kSG2fLrvI")) continue;
+        if (Hle::lookup(nid)(0, 0, 0, 0, 0, 0) == 0) {
+            std::printf("         (%s reported success for a non-existent object)\n", nid);
+            all_refuse = false;
+        }
+    }
+    CHECK(all_refuse, "no entry point reports success for an object that was never created");
 
     // #1618. These return a size_t AS THEIR RETURN VALUE — there is no out-parameter (Earthion's call
     // site does `call …; mov [rbp-0x10],rax; mov rdi,[rbp-0x10]; call malloc`). Such a signature has

--- a/prosper/tests/test_ult_fail_visible.cpp
+++ b/prosper/tests/test_ult_fail_visible.cpp
@@ -1,15 +1,13 @@
-// test_ult_fail_visible.cpp — #1603 regression guard: libSceUlt must FAIL VISIBLY.
+// test_ult_fail_visible.cpp — #1603: whatever libSceUlt does NOT implement must fail VISIBLY, and
+// whatever it does implement must stay counted per call.
 //
 // Before hle_ult.cpp existed, none of these NIDs was registered, so every libSceUlt call fell to the
 // generic unresolved-import path, which returns 0 (= SCE_OK for this ABI family) and logs the NID
 // exactly ONCE no matter how often it is called. On Earthion that was one log line for 1,005,742
 // sceUltMutexLock calls, and four "successfully created" ulthreads that never ran.
 //
-// Each assertion below fails on the pre-fix tree:
-//   * Hle::lookup() returns nullptr for every Ult NID -> the first two checks fail outright;
-//   * the generic path returns 0 -> the "not success" check fails;
-//   * the generic path counts by first-seen import index, not per call, and is not reachable
-//     without a linked import table -> the per-call counting check fails.
+// This file owns the REGISTRATION and RETURN-POLICY contract. The implemented semantics (mutual
+// exclusion, work areas, object identity) are tested in test_ult_semantics.cpp.
 #include "../src/hle/dispatch.hpp"
 
 #include <cstdint>
@@ -25,50 +23,51 @@ static int fails = 0;
 // value is a derived convention rather than an invented libSceUlt constant.
 static constexpr uint64_t kEnosys = 0x8002004Eull;
 
-// The NIDs Earthion (PPSA28061) actually imports and actually calls, spanning every family in the
-// library's exercised surface: runtime, ulthread, mutex, condvar, resource pool, lifecycle.
-static const char* const kCalledNids[] = {
+// Every libSceUlt NID Earthion (PPSA28061) imports. Split by what prosper does with each one, so the
+// split itself is a checked fact rather than a comment.
+static const char* const kImplementedNids[] = {
     "hZIg1EWGsHM",  // sceUltInitialize
+    "d-kSG2fLrvI",  // sceUltFinalize
     "jw9FkZBXo-g",  // _sceUltUlthreadRuntimeCreate
-    "znI3q8S7KQ4",  // _sceUltUlthreadCreate
+    "YiHujOG9vXY",  // _sceUltWaitingQueueResourcePoolCreate
     "mmt8Sa6tL6c",  // _sceUltMutexCreate
     "8hEGkR1pfr8",  // sceUltMutexLock
     "h0XebKiMBtk",  // sceUltMutexUnlock
-    "jnKaHGkrxZ4",  // _sceUltConditionVariableCreate
-    "JTw1cAVkuc0",  // sceUltConditionVariableSignal
-    "YiHujOG9vXY",  // _sceUltWaitingQueueResourcePoolCreate
+    "jW+HnafeS3Y",  // sceUltMutexDestroy
 };
-// The two entry points whose contract returns a SIZE rather than a status (#1618). They are called
-// by Earthion too, but they must never be asserted to "refuse" — a size has no error channel.
+// Registered, counted, and refused — not yet implemented. "Not seen in the measured window" is not
+// "never called": these are the teardown and blocking paths.
+static const char* const kUnimplementedNids[] = {
+    "znI3q8S7KQ4",  // _sceUltUlthreadCreate
+    "gCeAI57LGgI",  // sceUltUlthreadJoin
+    "jnKaHGkrxZ4",  // _sceUltConditionVariableCreate
+    "5xGAHCxA8M0",  // sceUltConditionVariableWait
+    "JTw1cAVkuc0",  // sceUltConditionVariableSignal
+    "xrmmI832R4U",  // sceUltConditionVariableDestroy
+};
+// The two entry points whose contract returns a SIZE rather than a status (#1618). A size has no
+// error channel, so these may never be handed a sentinel under ANY policy.
 static const char* const kSizeNids[] = {
     "grs2pbc2awM",  // sceUltUlthreadRuntimeGetWorkAreaSize
     "WIWV1Qd7PFU",  // sceUltWaitingQueueResourcePoolGetWorkAreaSize
 };
 // Any work-area size at or above this is not a size prosper could honour — it is a sentinel or
-// garbage being read as data. Earthion's own request is (16 ulthreads, 3 workers) / (16, 16); a real
-// requirement for those is kilobytes. 16 MiB is far above any plausible answer and far below the
-// 2.0 GiB that SCE_KERNEL_ERROR_ENOSYS produced.
+// garbage being read as data. Earthion's own requests are (16 ulthreads, 3 workers) and (16, 16); a
+// real requirement for those is well under a kilobyte. 16 MiB is far above any plausible answer and
+// far below the 2.0 GiB that SCE_KERNEL_ERROR_ENOSYS produced.
 static constexpr uint64_t kSaneWorkAreaLimit = 16ull * 1024 * 1024;
-// Imported but not observed in the measured window (teardown / blocking paths). Registered anyway,
-// because "not seen in 118 seconds" is not "never called".
-static const char* const kImportedNids[] = {
-    "gCeAI57LGgI",  // sceUltUlthreadJoin
-    "jW+HnafeS3Y",  // sceUltMutexDestroy
-    "5xGAHCxA8M0",  // sceUltConditionVariableWait
-    "xrmmI832R4U",  // sceUltConditionVariableDestroy
-    "d-kSG2fLrvI",  // sceUltFinalize
-};
 
 int main() {
     register_builtin_hle();
     ult_reset_counts_for_test();
-    // The environment must not decide whether this test passes: pin the default policy explicitly.
+    // The environment must not decide whether this test passes: pin both policies explicitly.
     ult_set_return_success_for_test(false);
+    ult_set_legacy_enosys_for_test(false);
 
     bool all_registered = true;
-    for (const char* nid : kCalledNids)   all_registered &= Hle::lookup(nid) != nullptr;
-    for (const char* nid : kSizeNids)     all_registered &= Hle::lookup(nid) != nullptr;
-    for (const char* nid : kImportedNids) all_registered &= Hle::lookup(nid) != nullptr;
+    for (const char* nid : kImplementedNids)   all_registered &= Hle::lookup(nid) != nullptr;
+    for (const char* nid : kUnimplementedNids) all_registered &= Hle::lookup(nid) != nullptr;
+    for (const char* nid : kSizeNids)          all_registered &= Hle::lookup(nid) != nullptr;
     CHECK(all_registered,
           "every libSceUlt NID Earthion imports is registered (no longer the silent generic path)");
 
@@ -77,53 +76,60 @@ int main() {
     CHECK(lock && unlock, "sceUltMutexLock / sceUltMutexUnlock resolve to prosper handlers");
     if (!lock || !unlock) { std::printf("== FAIL: %d ==\n", ++fails); return 1; }
 
-    // A lock that is not implemented must not claim to have been taken.
-    const uint64_t locked = lock(0x1234, 0, 0, 0, 0, 0);
-    CHECK(locked != 0, "sceUltMutexLock does NOT report success (0 = SCE_OK would be a false lock)");
-    CHECK(locked == kEnosys, "sceUltMutexLock returns SCE_KERNEL_ERROR_ENOSYS (0x8002004e)");
+    // A lock on an object that was never created must not claim to have been taken. 0x1234 is not a
+    // usable guest pointer, so this also proves the pointer is validated rather than dereferenced.
+    CHECK(lock(0x1234, 0, 0, 0, 0, 0) != 0,
+          "sceUltMutexLock on an uncreated object does NOT report success");
 
-    // Per-call counting is the whole point: the generic path's first-seen dedup made a million
-    // calls indistinguishable from one.
+    // Per-call counting is the whole point: the generic path's first-seen dedup made a million calls
+    // indistinguishable from one, and implementing an entry point must not bring the dedup back.
+    const uint64_t before = ult_call_count("8hEGkR1pfr8");
     lock(0x1234, 0, 0, 0, 0, 0);
     lock(0x1234, 0, 0, 0, 0, 0);
     unlock(0x1234, 0, 0, 0, 0, 0);
-    CHECK(ult_call_count("8hEGkR1pfr8") == 3 && ult_call_count("h0XebKiMBtk") == 1,
+    CHECK(ult_call_count("8hEGkR1pfr8") == before + 2 && ult_call_count("h0XebKiMBtk") >= 1,
           "calls are counted individually, not deduped to one first-seen entry");
 
-    // Every STATUS-returning entry point must refuse, not just the mutex pair. The two size queries
-    // are deliberately excluded — see kSizeNids below.
+    // What is not implemented must refuse, loudly and non-zero — never return 0 = SCE_OK.
     bool all_refuse = true;
-    for (const char* nid : kCalledNids)   all_refuse &= Hle::lookup(nid)(0, 0, 0, 0, 0, 0) != 0;
-    for (const char* nid : kImportedNids) all_refuse &= Hle::lookup(nid)(0, 0, 0, 0, 0, 0) != 0;
-    CHECK(all_refuse, "no status-returning libSceUlt entry point reports success");
+    for (const char* nid : kUnimplementedNids)
+        all_refuse &= Hle::lookup(nid)(0, 0, 0, 0, 0, 0) == kEnosys;
+    CHECK(all_refuse, "every not-yet-implemented entry point returns SCE_KERNEL_ERROR_ENOSYS");
 
-    // #1618. `sceUltUlthreadRuntimeGetWorkAreaSize` and `sceUltWaitingQueueResourcePoolGetWorkAreaSize`
-    // return a size_t AS THEIR RETURN VALUE — there is no out-parameter (Earthion's call site does
-    // `call …; mov [rbp-0x10],rax; mov rdi,[rbp-0x10]; call malloc`). Such a signature has no error
-    // channel, so an error sentinel is read as a byte count: returning SCE_KERNEL_ERROR_ENOSYS asked
-    // the guest for a 0x8002004E-byte (2.0 GiB) allocation. That is worse than leaving the NID
-    // unregistered, because the dispatcher's unresolved-import default is 0 — a harmless malloc(0).
-    //
-    // This assertion fails on the tree that returns the sentinel, and must keep failing for any future
-    // value prosper cannot honour: whatever these return has to be a size prosper is prepared to see
-    // handed back to it as the matching Create's workArea.
-    for (const char* nid : kSizeNids) {
-        const uint64_t size = Hle::lookup(nid)(16, 16, 0, 0, 0, 0);
-        CHECK(size < kSaneWorkAreaLimit,
+    // #1618. These return a size_t AS THEIR RETURN VALUE — there is no out-parameter (Earthion's call
+    // site does `call …; mov [rbp-0x10],rax; mov rdi,[rbp-0x10]; call malloc`). Such a signature has
+    // no error channel, so an error sentinel is read as a byte count: returning ENOSYS asked the guest
+    // for a 0x8002004E-byte (2.0 GiB) allocation, which is worse than leaving the NID unregistered
+    // because the dispatcher's unresolved-import default is a harmless 0.
+    for (const char* nid : kSizeNids)
+        CHECK(Hle::lookup(nid)(16, 16, 0, 0, 0, 0) < kSaneWorkAreaLimit,
               "a *GetWorkAreaSize query returns a real size, never an error sentinel (#1618)");
+
+    // The A/B escape hatch restores the legacy fake success but must never restore the silence.
+    {
+        const uint64_t n = ult_call_count("8hEGkR1pfr8");
+        const bool prev = ult_set_return_success_for_test(true);
+        const uint64_t legacy = lock(0x1234, 0, 0, 0, 0, 0);
+        ult_set_return_success_for_test(prev);
+        CHECK(prev == false, "the default policy is real behaviour, not the legacy fake success");
+        CHECK(legacy == 0 && ult_call_count("8hEGkR1pfr8") == n + 1,
+              "PROSPER_ULT_RETURN_SUCCESS reproduces the legacy 0 but is still counted");
     }
 
-    // The A/B escape hatch restores the legacy return but must never restore the silence.
-    const uint64_t before = ult_call_count("8hEGkR1pfr8");
-    const bool prev = ult_set_return_success_for_test(true);
-    const uint64_t legacy = lock(0x1234, 0, 0, 0, 0, 0);
-    ult_set_return_success_for_test(prev);
-    CHECK(prev == false, "the default policy is the error, not the legacy fake success");
-    CHECK(legacy == 0 && ult_call_count("8hEGkR1pfr8") == before + 1,
-          "PROSPER_ULT_RETURN_SUCCESS reproduces the legacy 0 but is still counted");
-
-    // The default must be restored for any later assertion in this process.
-    CHECK(lock(0x1234, 0, 0, 0, 0, 0) == kEnosys, "the error policy is restored after the A/B");
+    // PROSPER_ULT_LEGACY_ENOSYS restores Phase 1 wholesale, so the pre-implementation behaviour stays
+    // reachable for an A/B — including for the entry points that ARE implemented.
+    {
+        const uint64_t n = ult_call_count("8hEGkR1pfr8");
+        const bool prev = ult_set_legacy_enosys_for_test(true);
+        const uint64_t refused = lock(0x1234, 0, 0, 0, 0, 0);
+        const uint64_t size = Hle::lookup("WIWV1Qd7PFU")(16, 16, 0, 0, 0, 0);
+        ult_set_legacy_enosys_for_test(prev);
+        CHECK(prev == false, "PROSPER_ULT_LEGACY_ENOSYS is off by default");
+        CHECK(refused == kEnosys && ult_call_count("8hEGkR1pfr8") == n + 1,
+              "PROSPER_ULT_LEGACY_ENOSYS restores Phase 1's refusal, still counted");
+        CHECK(size == 0,
+              "even under PROSPER_ULT_LEGACY_ENOSYS a size query returns 0, not a sentinel (#1618)");
+    }
 
     std::printf(fails ? "== FAIL: %d ==\n" : "== PASS ==\n", fails);
     return fails ? 1 : 0;

--- a/prosper/tests/test_ult_semantics.cpp
+++ b/prosper/tests/test_ult_semantics.cpp
@@ -1,0 +1,239 @@
+// test_ult_semantics.cpp — #1603 Phase 2: libSceUlt must have REAL semantics, not visible refusals.
+//
+// Every assertion here fails on the Phase 1 tree (every entry point returned SCE_KERNEL_ERROR_ENOSYS
+// and no state existed at all), and each is written so that it also fails for the *interesting* wrong
+// implementation, not merely for the absent one:
+//
+//   * the mutual-exclusion check runs real concurrent threads over a non-atomic counter and asserts
+//     both an EXACT total and a direct occupancy invariant. A no-op mutex does not crash — it
+//     produces a wrong-but-plausible number, which is precisely why the exact total is the contract
+//     and a "did it run" check would be worthless. Measured against a forced no-op lock: 68,636
+//     overlapping critical-section entries and 27,984 of 40,000 increments surviving.
+//   * the work-area check asserts the size the query returns is the size Create demands, so the two
+//     cannot drift apart into a number nobody honours.
+//   * the object-header check proves a zeroed (uncreated) and a destroyed object are both REFUSED, so
+//     the magic is load-bearing rather than decorative.
+//
+// The Ult object the guest owns is a 256-byte caller-allocated blob; these tests allocate the same
+// shape so prosper's 16-byte header lands where it does in the guest.
+#include "../src/hle/dispatch.hpp"
+
+#include <atomic>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <thread>
+#include <vector>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { std::printf("  [FAIL] %s\n", m); ++fails; } \
+                         else std::printf("  [ok]   %s\n", m); } while (0)
+
+// Sony's Ult objects are 256-byte opaque blobs (proven for Earthion: a mutex at eboot+0x241730 is
+// followed by unrelated data at 0x241830, and the class at eboot+0xd8a0 spaces its mutex/condvar/
+// mutex members 0x100 apart). Match that so the test exercises the real shape.
+struct alignas(16) UltBlob { unsigned char bytes[256]; };
+static UltBlob g_pool, g_runtime, g_mutex_a, g_mutex_b;
+
+static uint64_t call(const char* nid, uint64_t a0 = 0, uint64_t a1 = 0, uint64_t a2 = 0,
+                     uint64_t a3 = 0, uint64_t a4 = 0, uint64_t a5 = 0) {
+    HleFn fn = Hle::lookup(nid);
+    if (!fn) { std::printf("  [FAIL] NID %s is not registered\n", nid); ++fails; return ~0ull; }
+    return fn(a0, a1, a2, a3, a4, a5);
+}
+// The two Create entry points take a 7th argument (the SDK/api version) on the guest stack; the
+// import bridge forwards it as a normal parameter, so a 7-arg signature reads it directly.
+using HleFn7 = uint64_t (*)(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t);
+static uint64_t call7(const char* nid, uint64_t a0, uint64_t a1, uint64_t a2, uint64_t a3,
+                      uint64_t a4, uint64_t a5, uint64_t a6) {
+    HleFn fn = Hle::lookup(nid);
+    if (!fn) { std::printf("  [FAIL] NID %s is not registered\n", nid); ++fails; return ~0ull; }
+    return ((HleFn7)fn)(a0, a1, a2, a3, a4, a5, a6);
+}
+
+static const char* const kPoolSize    = "WIWV1Qd7PFU";
+static const char* const kPoolCreate  = "YiHujOG9vXY";
+static const char* const kRtSize      = "grs2pbc2awM";
+static const char* const kRtCreate    = "jw9FkZBXo-g";
+static const char* const kMtxCreate   = "mmt8Sa6tL6c";
+static const char* const kMtxLock     = "8hEGkR1pfr8";
+static const char* const kMtxUnlock   = "h0XebKiMBtk";
+static const char* const kMtxDestroy  = "jW+HnafeS3Y";
+static const char* const kInitialize  = "hZIg1EWGsHM";
+
+// Earthion's own parameters, so the test exercises the values the only importing title actually uses.
+static constexpr uint32_t kNumMaxUlthread = 16, kNumWorkerThread = 3;
+static constexpr uint32_t kNumThreads = 16, kNumSyncObjects = 16;
+static constexpr uint64_t kApiVersion = 0x12000000ull;   // literal at every guest create site
+
+int main() {
+    register_builtin_hle();
+    ult_reset_counts_for_test();
+    ult_set_return_success_for_test(false);
+    std::memset(&g_pool, 0, sizeof(g_pool));
+    std::memset(&g_runtime, 0, sizeof(g_runtime));
+    std::memset(&g_mutex_a, 0, sizeof(g_mutex_a));
+    std::memset(&g_mutex_b, 0, sizeof(g_mutex_b));
+
+    CHECK(call(kInitialize) == 0, "sceUltInitialize succeeds");
+
+    // --- work areas -------------------------------------------------------------------------
+    // The size query returns prosper's own requirement, and Create must consume exactly that buffer.
+    // Asserting both against the SAME number is what stops the pair drifting into a size nobody
+    // honours — the #1618 failure in a different costume.
+    const uint64_t pool_bytes = call(kPoolSize, kNumThreads, kNumSyncObjects);
+    const uint64_t rt_bytes   = call(kRtSize, kNumMaxUlthread, kNumWorkerThread);
+    CHECK(pool_bytes > 0 && pool_bytes < 1024 * 1024,
+          "sceUltWaitingQueueResourcePoolGetWorkAreaSize returns a real, honourable size");
+    CHECK(rt_bytes > 0 && rt_bytes < 1024 * 1024,
+          "sceUltUlthreadRuntimeGetWorkAreaSize returns a real, honourable size");
+
+    std::vector<unsigned char> pool_work(pool_bytes ? (size_t)pool_bytes : 1, 0xAB);
+    std::vector<unsigned char> rt_work(rt_bytes ? (size_t)rt_bytes : 1, 0xAB);
+
+    const uint64_t pool_rc = call7(kPoolCreate, (uint64_t)(uintptr_t)&g_pool, 0, kNumThreads,
+                                   kNumSyncObjects, (uint64_t)(uintptr_t)pool_work.data(), 0,
+                                   kApiVersion);
+    CHECK(pool_rc == 0, "_sceUltWaitingQueueResourcePoolCreate succeeds with that exact buffer");
+
+    const uint64_t rt_rc = call7(kRtCreate, (uint64_t)(uintptr_t)&g_runtime, 0, kNumMaxUlthread,
+                                 kNumWorkerThread, (uint64_t)(uintptr_t)rt_work.data(), 0,
+                                 kApiVersion);
+    CHECK(rt_rc == 0, "_sceUltUlthreadRuntimeCreate succeeds with that exact buffer");
+
+    // Create must actually USE the work area, not merely accept it. The buffers were poisoned with
+    // 0xAB; a Create that consumed nothing would leave them untouched.
+    bool pool_used = false, rt_used = false;
+    for (size_t i = 0; i < pool_work.size(); ++i) if (pool_work[i] != 0xAB) { pool_used = true; break; }
+    for (size_t i = 0; i < rt_work.size(); ++i)   if (rt_work[i] != 0xAB)   { rt_used = true; break; }
+    CHECK(pool_used && rt_used,
+          "both Creates consume the work area their size query asked for (not a decorative number)");
+
+    // A work area that is not there at all must be refused, not written through.
+    const uint64_t rt_null = call7(kRtCreate, (uint64_t)(uintptr_t)&g_runtime, 0, kNumMaxUlthread,
+                                   kNumWorkerThread, 0, 0, kApiVersion);
+    CHECK(rt_null != 0, "_sceUltUlthreadRuntimeCreate refuses a null work area");
+
+    // --- object identity ---------------------------------------------------------------------
+    // A mutex must come from a real pool: passing something that is not one has to be refused, or
+    // _sceUltMutexCreate would accept any pointer as its pool argument.
+    UltBlob not_a_pool;
+    std::memset(&not_a_pool, 0, sizeof(not_a_pool));
+    const uint64_t bad_pool = call(kMtxCreate, (uint64_t)(uintptr_t)&g_mutex_a, 0,
+                                   (uint64_t)(uintptr_t)&not_a_pool, 0, kApiVersion);
+    CHECK(bad_pool != 0, "_sceUltMutexCreate refuses a pool pointer that was never created");
+
+    // An uncreated (zeroed) mutex must be refused rather than treated as lockable.
+    CHECK(call(kMtxLock, (uint64_t)(uintptr_t)&g_mutex_a) != 0,
+          "sceUltMutexLock refuses a mutex that was never created (zeroed guest object)");
+
+    const uint64_t mtx_rc = call(kMtxCreate, (uint64_t)(uintptr_t)&g_mutex_a, 0,
+                                 (uint64_t)(uintptr_t)&g_pool, 0, kApiVersion);
+    CHECK(mtx_rc == 0, "_sceUltMutexCreate succeeds against a real pool");
+
+    // prosper writes only a 16-byte header into the caller's 256-byte blob. The guest never reads
+    // inside one (proven by an exhaustive scan of every RIP-relative reference in Earthion's whole
+    // executable segment: 16 static Ult objects, zero references at a non-zero offset), but writing
+    // past the header would corrupt whatever the guest packs next to it.
+    bool tail_clean = true;
+    for (size_t i = 16; i < sizeof(g_mutex_a.bytes); ++i)
+        if (g_mutex_a.bytes[i] != 0) { tail_clean = false; break; }
+    CHECK(tail_clean, "prosper writes only a 16-byte header into the caller's 256-byte Ult object");
+
+    // --- lock / unlock ------------------------------------------------------------------------
+    CHECK(call(kMtxLock, (uint64_t)(uintptr_t)&g_mutex_a) == 0, "sceUltMutexLock takes the lock");
+    // Non-recursive (Earthion passes optParam=NULL): a self-relock must be reported and refused, not
+    // silently allowed and not hung on.
+    CHECK(call(kMtxLock, (uint64_t)(uintptr_t)&g_mutex_a) != 0,
+          "a self-relock of the non-recursive mutex is refused rather than deadlocking");
+    CHECK(call(kMtxUnlock, (uint64_t)(uintptr_t)&g_mutex_a) == 0, "sceUltMutexUnlock releases it");
+    // Unlocking something this thread does not hold must not "succeed".
+    CHECK(call(kMtxUnlock, (uint64_t)(uintptr_t)&g_mutex_a) != 0,
+          "sceUltMutexUnlock by a non-owner is refused");
+
+    // --- THE contract: real mutual exclusion --------------------------------------------------
+    // Mutual exclusion has to be DEMONSTRATED, and demonstrating it is easy to get wrong. A first
+    // version of this test used a bare `v = shared; shared = v + 1` under the lock and asserted the
+    // exact total — and it PASSED with the mutex forced to a no-op (PROSPER_ULT_RETURN_SUCCESS=1),
+    // because the unprotected read-modify-write is a couple of nanoseconds while the surrounding call
+    // overhead is far longer, so the threads simply never collided. A test that a broken lock passes
+    // proves nothing.
+    //
+    // So there are now two independent detectors, and neither depends on timing luck:
+    //   1. OCCUPANCY — an atomic counter incremented on entry to the critical section and decremented
+    //      on exit. Under a real lock the value observed on entry is always 0. Any other value means
+    //      two threads were inside at once, which is a direct observation of exclusion failure rather
+    //      than an inference from a corrupted result.
+    //   2. EXACT TOTAL — with the critical section deliberately widened so an unsynchronised
+    //      interleaving loses updates with overwhelming probability instead of by luck.
+    {
+        static volatile uint64_t shared = 0;   // deliberately NOT atomic — the mutex is the contract
+        static volatile uint64_t spin = 0;     // widens the window so lost updates are near-certain
+        constexpr int kThreads = 8, kIters = 5000;
+        const uint64_t m = (uint64_t)(uintptr_t)&g_mutex_a;
+        std::atomic<int> occupancy{0};
+        std::atomic<uint64_t> overlaps{0}, lock_failures{0}, unlock_failures{0};
+        std::vector<std::thread> ts;
+        for (int t = 0; t < kThreads; ++t) {
+            ts.emplace_back([&] {
+                for (int i = 0; i < kIters; ++i) {
+                    if (call(kMtxLock, m) != 0) { lock_failures.fetch_add(1); continue; }
+                    if (occupancy.fetch_add(1, std::memory_order_acq_rel) != 0)
+                        overlaps.fetch_add(1, std::memory_order_relaxed);
+                    const uint64_t v = shared;
+                    for (int k = 0; k < 256; ++k) spin = spin + 1;
+                    shared = v + 1;
+                    if (occupancy.fetch_sub(1, std::memory_order_acq_rel) != 1)
+                        overlaps.fetch_add(1, std::memory_order_relaxed);
+                    if (call(kMtxUnlock, m) != 0) unlock_failures.fetch_add(1);
+                }
+            });
+        }
+        for (auto& th : ts) th.join();
+        const uint64_t expected = (uint64_t)kThreads * kIters;
+        CHECK(lock_failures.load() == 0 && unlock_failures.load() == 0,
+              "every concurrent lock and unlock succeeded");
+        CHECK(overlaps.load() == 0,
+              "MUTUAL EXCLUSION: no two of 8 threads were ever inside the critical section at once");
+        if (overlaps.load() != 0)
+            std::printf("         (%llu overlapping entries observed — the lock excludes nothing)\n",
+                        (unsigned long long)overlaps.load());
+        CHECK(shared == expected,
+              "MUTUAL EXCLUSION: 8 threads x 5000 unsynchronised increments total EXACTLY 40000");
+        if (shared != expected)
+            std::printf("         (got %llu, expected %llu — updates were lost, so the lock is not real)\n",
+                        (unsigned long long)shared, (unsigned long long)expected);
+    }
+
+    // --- destroy ------------------------------------------------------------------------------
+    CHECK(call(kMtxDestroy, (uint64_t)(uintptr_t)&g_mutex_a) == 0, "sceUltMutexDestroy succeeds");
+    CHECK(call(kMtxLock, (uint64_t)(uintptr_t)&g_mutex_a) != 0,
+          "locking a DESTROYED mutex is refused (the header magic is cleared, not left stale)");
+
+    // A second, independent mutex must be a genuinely different lock, not an alias of the first.
+    const uint64_t b_rc = call(kMtxCreate, (uint64_t)(uintptr_t)&g_mutex_b, 0,
+                               (uint64_t)(uintptr_t)&g_pool, 0, kApiVersion);
+    CHECK(b_rc == 0, "a second mutex can be created from the same pool");
+    CHECK(call(kMtxLock, (uint64_t)(uintptr_t)&g_mutex_b) == 0 &&
+          call(kMtxUnlock, (uint64_t)(uintptr_t)&g_mutex_b) == 0,
+          "the second mutex locks and unlocks independently of the first");
+
+    // --- the counters stay real ----------------------------------------------------------------
+    CHECK(ult_call_count(kMtxLock) > 40000 && ult_call_count(kMtxUnlock) > 40000,
+          "implemented entry points are still counted per call, not deduped");
+
+    // --- the escape hatches still work ---------------------------------------------------------
+    const bool prev = ult_set_return_success_for_test(true);
+    const uint64_t faked = call(kMtxLock, (uint64_t)(uintptr_t)&g_mutex_b);
+    const uint64_t faked_size = call(kPoolSize, kNumThreads, kNumSyncObjects);
+    ult_set_return_success_for_test(prev);
+    CHECK(faked == 0, "PROSPER_ULT_RETURN_SUCCESS still reproduces the legacy fake success");
+    // #1618: no escape hatch may put a sentinel where a size belongs.
+    CHECK(faked_size == 0,
+          "under the legacy policy a size query returns 0, never an error sentinel (#1618)");
+
+    std::printf(fails ? "== FAIL: %d ==\n" : "== PASS ==\n", fails);
+    return fails ? 1 : 0;
+}

--- a/prosper/tests/test_ult_semantics.cpp
+++ b/prosper/tests/test_ult_semantics.cpp
@@ -19,6 +19,7 @@
 #include "../src/hle/dispatch.hpp"
 
 #include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
@@ -62,6 +63,48 @@ static const char* const kMtxLock     = "8hEGkR1pfr8";
 static const char* const kMtxUnlock   = "h0XebKiMBtk";
 static const char* const kMtxDestroy  = "jW+HnafeS3Y";
 static const char* const kInitialize  = "hZIg1EWGsHM";
+static const char* const kUltCreate   = "znI3q8S7KQ4";
+static const char* const kUltJoin     = "gCeAI57LGgI";
+static const char* const kCvCreate    = "jnKaHGkrxZ4";
+static const char* const kCvWait      = "5xGAHCxA8M0";
+static const char* const kCvSignal    = "JTw1cAVkuc0";
+static const char* const kCvDestroy   = "xrmmI832R4U";
+
+// _sceUltUlthreadCreate takes 9 arguments; runtime/optParam/apiVersion arrive on the guest stack and
+// the import bridge forwards them as ordinary parameters.
+using HleFn9 = uint64_t (*)(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t,
+                            uint64_t, uint64_t);
+static uint64_t call9(const char* nid, uint64_t a0, uint64_t a1, uint64_t a2, uint64_t a3,
+                      uint64_t a4, uint64_t a5, uint64_t a6, uint64_t a7, uint64_t a8) {
+    HleFn fn = Hle::lookup(nid);
+    if (!fn) { std::printf("  [FAIL] NID %s is not registered\n", nid); ++fails; return ~0ull; }
+    return ((HleFn9)fn)(a0, a1, a2, a3, a4, a5, a6, a7, a8);
+}
+
+// Ulthread entries. Earthion gives each ulthread 0x2000 bytes; this test uses a larger context
+// because the entry is host-compiled test code rather than the guest's own tightly-sized worker.
+static constexpr uint64_t kContextBytes = 64 * 1024;
+static constexpr uint64_t kTouchBytes   = 24 * 1024;
+static std::atomic<int> g_entry_ran{0};
+static std::atomic<int> g_entry_gate{0};
+static volatile uint64_t g_sink = 0;
+
+// Touches a known depth of its stack so the context high-water measurement has a floor to clear.
+// `volatile` so the writes survive optimisation — an elided frame would measure nothing.
+static int32_t touch_stack_entry(uint64_t arg) {
+    volatile unsigned char buf[kTouchBytes];
+    for (size_t i = 0; i < kTouchBytes; i += 64) buf[i] = (unsigned char)(i ^ 0x5A);
+    for (size_t i = 0; i < kTouchBytes; i += 64) g_sink += buf[i];
+    g_entry_ran.fetch_add(1);
+    return (int32_t)(arg & 0x7fffffff);
+}
+
+// Announces itself and then spins until released, so several ulthreads are provably running at once.
+static int32_t gated_entry(uint64_t arg) {
+    g_entry_ran.fetch_add(1);
+    while (g_entry_gate.load() == 0) std::this_thread::yield();
+    return (int32_t)arg;
+}
 
 // Earthion's own parameters, so the test exercises the values the only importing title actually uses.
 static constexpr uint32_t kNumMaxUlthread = 16, kNumWorkerThread = 3;
@@ -219,6 +262,201 @@ int main() {
     CHECK(call(kMtxLock, (uint64_t)(uintptr_t)&g_mutex_b) == 0 &&
           call(kMtxUnlock, (uint64_t)(uintptr_t)&g_mutex_b) == 0,
           "the second mutex locks and unlocks independently of the first");
+
+    // --- ulthreads ----------------------------------------------------------------------------
+    // Each ulthread runs its entry on the guest-supplied context buffer, which IS its stack on
+    // hardware. These assertions are all impossible on a tree where _sceUltUlthreadCreate refused:
+    // the entry never ran at all, so the counter stays 0 and no status is ever produced.
+    {
+        g_entry_ran.store(0);
+        g_entry_gate.store(0);
+        UltBlob ult;
+        std::memset(&ult, 0, sizeof(ult));
+        std::vector<unsigned char> ctx(kContextBytes);
+
+        const uint64_t rc = call9(kUltCreate, (uint64_t)(uintptr_t)&ult, 0,
+                                  (uint64_t)(uintptr_t)&touch_stack_entry, 0x1234,
+                                  (uint64_t)(uintptr_t)ctx.data(), kContextBytes,
+                                  (uint64_t)(uintptr_t)&g_runtime, 0, kApiVersion);
+        CHECK(rc == 0, "_sceUltUlthreadCreate starts the ulthread");
+
+        int32_t status = -1;
+        const uint64_t jrc = call(kUltJoin, (uint64_t)(uintptr_t)&ult, (uint64_t)(uintptr_t)&status);
+        CHECK(jrc == 0, "sceUltUlthreadJoin returns once the ulthread has finished");
+        CHECK(g_entry_ran.load() == 1, "the ulthread entry ACTUALLY RAN (it never did before)");
+        // The entry is int32_t(*)(uint64_t) and returns its argument's low bits; join reports it
+        // through the 4-byte out-param the guest passes at eboot+0x9f1e.
+        CHECK(status == 0x1234, "sceUltUlthreadJoin writes the entry's int32 return into *status");
+
+        // Amendment 6: the context buffer is filled at create and the untouched prefix measured at
+        // exit, so an ulthread approaching its stack limit is reported rather than silently
+        // overflowing. The entry deliberately touches kTouchBytes.
+        uint64_t ctx_size = 0;
+        const uint64_t used = ult_last_join_stack_used_for_test(&ctx_size);
+        CHECK(ctx_size == kContextBytes && used >= kTouchBytes && used <= kContextBytes,
+              "the guest-stack high-water is measured and lands within the context buffer");
+        if (!(used >= kTouchBytes && used <= kContextBytes))
+            std::printf("         (used=%llu touched=%llu context=%llu)\n",
+                        (unsigned long long)used, (unsigned long long)kTouchBytes,
+                        (unsigned long long)kContextBytes);
+
+        // A joined ulthread is gone: joining again must be refused, not silently repeated.
+        CHECK(call(kUltJoin, (uint64_t)(uintptr_t)&ult, 0) != 0,
+              "joining an already-joined ulthread is refused");
+    }
+
+    // Amendment 2b: prosper runs ulthreads one-to-one rather than multiplexing them onto
+    // numWorkerThread, so more can run at once than on hardware. That deviation must be OBSERVED,
+    // not assumed — the runtime carries a high-water mark of simultaneously running ulthreads.
+    {
+        g_entry_ran.store(0);
+        g_entry_gate.store(0);                 // entries spin here until released
+        constexpr int kN = 6;                  // deliberately > numWorkerThread (3)
+        UltBlob ults[kN];
+        std::vector<std::vector<unsigned char>> ctxs;
+        bool all_started = true;
+        for (int i = 0; i < kN; ++i) {
+            std::memset(&ults[i], 0, sizeof(ults[i]));
+            ctxs.emplace_back(kContextBytes);
+        }
+        for (int i = 0; i < kN; ++i)
+            all_started &= call9(kUltCreate, (uint64_t)(uintptr_t)&ults[i], 0,
+                                 (uint64_t)(uintptr_t)&gated_entry, (uint64_t)i,
+                                 (uint64_t)(uintptr_t)ctxs[i].data(), kContextBytes,
+                                 (uint64_t)(uintptr_t)&g_runtime, 0, kApiVersion) == 0;
+        CHECK(all_started, "six ulthreads start in a runtime created for numMaxUlthread=16");
+        // Wait until every entry is spinning, so the high-water reflects real simultaneity.
+        for (int spins = 0; g_entry_ran.load() < kN && spins < 200000; ++spins)
+            std::this_thread::yield();
+        const uint64_t hw = ult_runtime_high_water_for_test((uint64_t)(uintptr_t)&g_runtime);
+        g_entry_gate.store(1);
+        for (int i = 0; i < kN; ++i) call(kUltJoin, (uint64_t)(uintptr_t)&ults[i], 0);
+        CHECK(hw > kNumWorkerThread,
+              "the runtime OBSERVES that more ulthreads ran at once than numWorkerThread=3");
+        if (hw <= kNumWorkerThread)
+            std::printf("         (high-water %llu — the deviation counter is not measuring)\n",
+                        (unsigned long long)hw);
+    }
+
+    // numMaxUlthread is the guest's own bound and is unambiguous, so it is ENFORCED rather than
+    // merely reported: a runtime sized for 1 must refuse the second ulthread.
+    {
+        g_entry_ran.store(0);
+        g_entry_gate.store(0);
+        UltBlob small_rt, u1, u2;
+        std::memset(&small_rt, 0, sizeof(small_rt));
+        std::memset(&u1, 0, sizeof(u1));
+        std::memset(&u2, 0, sizeof(u2));
+        const uint64_t bytes = call(kRtSize, 1, 1);
+        std::vector<unsigned char> work((size_t)bytes, 0);
+        std::vector<unsigned char> c1(kContextBytes), c2(kContextBytes);
+        CHECK(call7(kRtCreate, (uint64_t)(uintptr_t)&small_rt, 0, 1, 1,
+                    (uint64_t)(uintptr_t)work.data(), 0, kApiVersion) == 0,
+              "a runtime sized for numMaxUlthread=1 is created");
+        const uint64_t first = call9(kUltCreate, (uint64_t)(uintptr_t)&u1, 0,
+                                     (uint64_t)(uintptr_t)&gated_entry, 0,
+                                     (uint64_t)(uintptr_t)c1.data(), kContextBytes,
+                                     (uint64_t)(uintptr_t)&small_rt, 0, kApiVersion);
+        const uint64_t second = call9(kUltCreate, (uint64_t)(uintptr_t)&u2, 0,
+                                      (uint64_t)(uintptr_t)&gated_entry, 0,
+                                      (uint64_t)(uintptr_t)c2.data(), kContextBytes,
+                                      (uint64_t)(uintptr_t)&small_rt, 0, kApiVersion);
+        CHECK(first == 0 && second != 0,
+              "the runtime refuses an ulthread beyond the numMaxUlthread the guest asked for");
+        g_entry_gate.store(1);
+        call(kUltJoin, (uint64_t)(uintptr_t)&u1, 0);
+    }
+
+    // --- condition variables --------------------------------------------------------------------
+    // sceUltConditionVariableWait takes ONE argument; the mutex is bound at create. The tests below
+    // exercise the two facts the implementation is built on, both established from the guest's own
+    // call sites: the caller HOLDS the bound mutex at Wait, and does NOT hold it at Signal.
+    {
+        UltBlob cv, cv_mutex;
+        std::memset(&cv, 0, sizeof(cv));
+        std::memset(&cv_mutex, 0, sizeof(cv_mutex));
+        CHECK(call(kMtxCreate, (uint64_t)(uintptr_t)&cv_mutex, 0, (uint64_t)(uintptr_t)&g_pool, 0,
+                   kApiVersion) == 0,
+              "a mutex for the condvar to bind is created");
+        CHECK(call(kCvCreate, (uint64_t)(uintptr_t)&cv, 0, (uint64_t)(uintptr_t)&cv_mutex, 0,
+                   kApiVersion) == 0,
+              "_sceUltConditionVariableCreate binds the condvar to that mutex");
+
+        // Binding to something that is not a mutex must be refused.
+        UltBlob cv2, not_a_mutex;
+        std::memset(&cv2, 0, sizeof(cv2));
+        std::memset(&not_a_mutex, 0, sizeof(not_a_mutex));
+        CHECK(call(kCvCreate, (uint64_t)(uintptr_t)&cv2, 0, (uint64_t)(uintptr_t)&not_a_mutex, 0,
+                   kApiVersion) != 0,
+              "_sceUltConditionVariableCreate refuses a mutex that was never created");
+
+        // Waiting WITHOUT the bound mutex is undefined for pthread_cond_wait, so it must be refused
+        // rather than executed. (The guest never does this — all five of its Wait sites lock first —
+        // but a fake implementation that ignored the mutex entirely would pass every other check.)
+        CHECK(call(kCvWait, (uint64_t)(uintptr_t)&cv) != 0,
+              "sceUltConditionVariableWait without holding the bound mutex is refused");
+
+        // A Signal with nobody waiting is LOST, exactly as for a real condition variable. If it were
+        // remembered, the next Wait would return immediately without ever being signalled — the
+        // difference between a condvar and a semaphore, and a real source of guest logic bugs.
+        CHECK(call(kCvSignal, (uint64_t)(uintptr_t)&cv) == 0, "a Signal with no waiter succeeds");
+
+        // The real contract: a waiter blocks until signalled, and the signaller does NOT hold the
+        // bound mutex when it signals — which is what the guest does at all eleven of its sites.
+        std::atomic<int> waiter_state{0};   // 1 = about to wait, 2 = returned from wait
+        std::thread waiter([&] {
+            if (call(kMtxLock, (uint64_t)(uintptr_t)&cv_mutex) != 0) return;
+            waiter_state.store(1);
+            if (call(kCvWait, (uint64_t)(uintptr_t)&cv) == 0) waiter_state.store(2);
+            call(kMtxUnlock, (uint64_t)(uintptr_t)&cv_mutex);
+        });
+        while (waiter_state.load() == 0) std::this_thread::yield();
+        // Give the waiter time to actually block. If the earlier lost Signal had been remembered, or
+        // if Wait returned spuriously, it would have advanced to 2 by now.
+        std::this_thread::sleep_for(std::chrono::milliseconds(250));
+        const bool still_waiting = waiter_state.load() == 1;
+        // Signal from a thread that holds NOTHING — the guest's own pattern.
+        call(kCvSignal, (uint64_t)(uintptr_t)&cv);
+        waiter.join();
+        CHECK(still_waiting,
+              "a waiter stays blocked: an earlier signal with no waiter was lost, not remembered");
+        CHECK(waiter_state.load() == 2,
+              "sceUltConditionVariableSignal from a thread holding no mutex wakes the waiter");
+
+        // Exactly one waiter per Signal, and the bound mutex is genuinely reacquired on return —
+        // both threads increment a non-atomic counter while nominally holding it.
+        {
+            static volatile int guarded = 0;
+            std::atomic<int> woken{0}, ready{0};
+            std::thread w1, w2;
+            auto body = [&] {
+                call(kMtxLock, (uint64_t)(uintptr_t)&cv_mutex);
+                ready.fetch_add(1);
+                if (call(kCvWait, (uint64_t)(uintptr_t)&cv) == 0) {
+                    const int v = guarded; guarded = v + 1;   // must run under the reacquired mutex
+                    woken.fetch_add(1);
+                }
+                call(kMtxUnlock, (uint64_t)(uintptr_t)&cv_mutex);
+            };
+            w1 = std::thread(body);
+            w2 = std::thread(body);
+            while (ready.load() < 2) std::this_thread::yield();
+            std::this_thread::sleep_for(std::chrono::milliseconds(250));
+            call(kCvSignal, (uint64_t)(uintptr_t)&cv);
+            std::this_thread::sleep_for(std::chrono::milliseconds(250));
+            const int after_one = woken.load();
+            call(kCvSignal, (uint64_t)(uintptr_t)&cv);
+            w1.join(); w2.join();
+            CHECK(after_one == 1, "one Signal releases exactly ONE of two waiters, not both");
+            CHECK(woken.load() == 2 && guarded == 2,
+                  "the second Signal releases the other, and both ran under the reacquired mutex");
+        }
+
+        CHECK(call(kCvDestroy, (uint64_t)(uintptr_t)&cv) == 0,
+              "sceUltConditionVariableDestroy succeeds");
+        CHECK(call(kCvSignal, (uint64_t)(uintptr_t)&cv) != 0,
+              "signalling a DESTROYED condvar is refused");
+    }
 
     // --- the counters stay real ----------------------------------------------------------------
     CHECK(ult_call_count(kMtxLock) > 40000 && ult_call_count(kMtxUnlock) > 40000,

--- a/prosper/tests/test_ult_semantics.cpp
+++ b/prosper/tests/test_ult_semantics.cpp
@@ -81,17 +81,44 @@ static uint64_t call9(const char* nid, uint64_t a0, uint64_t a1, uint64_t a2, ui
     return ((HleFn9)fn)(a0, a1, a2, a3, a4, a5, a6, a7, a8);
 }
 
-// Ulthread entries. Earthion gives each ulthread 0x2000 bytes; this test uses a larger context
-// because the entry is host-compiled test code rather than the guest's own tightly-sized worker.
+// An ulthread entry is GUEST code, so it uses the guest's System V AMD64 convention — prosper enters
+// it through prosper_call_guest_on_stack, which marshals into SysV (first argument in %rdi).
+//
+// On Linux and macOS the host ABI IS System V, so an ordinary host function is an accurate stand-in
+// and this attribute is a no-op. On Windows the host is Microsoft x64, where the first argument
+// arrives in %rcx — so an untagged host function reads a garbage argument and returns a garbage
+// status, while still executing and touching its stack, which makes it look like it worked. That is
+// exactly what happened: MinGW CI failed only on "join writes the entry's int32 return into *status"
+// while all 45 other assertions passed. The product was never wrong — real guest code is SysV — the
+// test was modelling guest code with a host-ABI function.
+//
+// Tagged rather than #ifdef'd around the body: the statement "this function uses the guest's calling
+// convention" is true on every platform, and the attribute is simply redundant where the native ABI
+// already matches. Guarded on x86-64 because that is the only architecture the attribute exists for.
+#if defined(__x86_64__) || defined(_M_X64)
+#define ULT_GUEST_ABI __attribute__((sysv_abi))
+#else
+#define ULT_GUEST_ABI
+#endif
+
+// Earthion gives each ulthread 0x2000 bytes; this test uses a larger context because the entry is
+// host-compiled test code rather than the guest's own tightly-sized worker. It stays at or below the
+// 64 KiB stack probe so the high-water figure is exact, which is the shape Earthion's real 8 KiB and
+// 32 KiB contexts have.
 static constexpr uint64_t kContextBytes = 64 * 1024;
 static constexpr uint64_t kTouchBytes   = 24 * 1024;
 static std::atomic<int> g_entry_ran{0};
 static std::atomic<int> g_entry_gate{0};
 static volatile uint64_t g_sink = 0;
 
+// Both entries are deliberately plain leaf functions: no destructors, no exceptions, nothing that
+// needs unwind data. __attribute__((sysv_abi)) conflicts with MinGW's SEH-based C++ unwinding (the
+// reason PROSPER_SYSV_ABI is empty for the HLE handlers — see dispatch.hpp), and keeping these
+// bodies trivial is what makes the tag safe here.
+
 // Touches a known depth of its stack so the context high-water measurement has a floor to clear.
 // `volatile` so the writes survive optimisation — an elided frame would measure nothing.
-static int32_t touch_stack_entry(uint64_t arg) {
+static ULT_GUEST_ABI int32_t touch_stack_entry(uint64_t arg) noexcept {
     volatile unsigned char buf[kTouchBytes];
     for (size_t i = 0; i < kTouchBytes; i += 64) buf[i] = (unsigned char)(i ^ 0x5A);
     for (size_t i = 0; i < kTouchBytes; i += 64) g_sink += buf[i];
@@ -100,9 +127,11 @@ static int32_t touch_stack_entry(uint64_t arg) {
 }
 
 // Announces itself and then spins until released, so several ulthreads are provably running at once.
-static int32_t gated_entry(uint64_t arg) {
+// A bare atomic spin rather than std::this_thread::yield(): a leaf body keeps the SysV tag safe on
+// MinGW. The bound turns a gate that is never released into a test failure instead of a CI timeout.
+static ULT_GUEST_ABI int32_t gated_entry(uint64_t arg) noexcept {
     g_entry_ran.fetch_add(1);
-    while (g_entry_gate.load() == 0) std::this_thread::yield();
+    for (uint64_t spins = 0; g_entry_gate.load() == 0 && spins < 4000000000ull; ++spins) {}
     return (int32_t)arg;
 }
 


### PR DESCRIPTION
## Purpose

Implements **libSceUlt** — Sony's user-level threading library — with real semantics: the ulthread runtime,
the waiting-queue resource pool, mutexes, condition variables, and ulthreads themselves. All **16** imported
entry points are implemented; none remain refused.

It also fixes a defect the previous fail-visible phase introduced.

Fixes #1603. Fixes #1618.

## Two corrections to the premises this work started from

**1. `*GetWorkAreaSize` has no out-parameter — the size is the return value, and it feeds `malloc` directly.**
The importing title's call site is unambiguous:

```
9c4f: mov edi,[rbp-0x4]        ; 16
9c52: mov esi,[rbp-0x8]        ; 16
9c55: call sceUltWaitingQueueResourcePoolGetWorkAreaSize
9c5a: mov [rbp-0x10],rax       ; <- the size IS rax
9c5e: mov rdi,[rbp-0x10]
9c62: call malloc              ; <- fed straight to malloc
```

The prior phase returned `0x8002004E` (`0x80020000 | FreeBSD ENOSYS`) from these two functions to make the gap
visible. A `size_t` return has **no error channel**, so that sentinel was consumed as a size: the title
requested **2.0 GiB, twice**. That is the shape of #544/#660, which the change had been written to prevent. It
stayed latent only because the allocator refused it.

Worse, prosper's dispatcher already returns **`0`** for an unresolved NID — which is safe here (`malloc(0)`
succeeds harmlessly). **Registering these two NIDs was strictly worse than leaving them unregistered.** The
generalisable rule is recorded in `docs/GAME_COMPAT_ORCHESTRATION.md`: before registering a NID purely for
visibility, establish whether its contract returns a *status* or a *value*; for a value, the visibility belongs
in the log line, not the return.

Commit `c7972412` isolates that fix so it is independently cherry-pickable. A sweep of the rest of the HLE found
**no other instance** — all five AGC `*GetSize` NIDs return genuine sizes.

**2. Ult objects are 256-byte caller-owned blobs.** Proven, not assumed: a mutex at `eboot+0x241730` is followed
by an unrelated 8-byte queue head at `0x241830`, i.e. exactly `0x100`; corroborated independently by the `0x100`
stride at site `0xd8a0` and by the pool/runtime pair at `0x236e30`/`0x236f30`.

## Evidence for the ABI

Every argument layout is read off the importing title's own call sites (flattened with
`tools/il2cpp/prx_to_elf.py`, resolved through `DT_JMPREL` → PLT → call site with `tools/re/xref.py`,
disassembled with `tools/re/edis.py`). All Ult calls live in one wrapper layer at `eboot+0x9c20..0xa17a`, so the
layouts are read directly rather than inferred. The object-name strings — pool `"waiting queue"`, runtime
`"sample runtime"`, mutex `"ultmtx"`, CV `"ultcv"` — identify this as Sony's own SDK sample usage pattern.

Four facts were established before any code was written, each of which could have falsified the design:

- **The guest never reads inside an Ult object.** An exhaustive scan of every RIP-relative reference in the
  executable segment found 16 static Ult objects with **zero** references at a non-zero offset — every one is a
  `lea` of the base feeding an Ult call. `CONFIDENCE: HIGH`. This is what makes the host-side state model safe.
- **`numWorkerThread` is used for nothing else.** It is a function-local constant at `eboot+0x9ca3` with exactly
  two reads (the size query and the create). Nothing is sized or indexed by worker count. `CONFIDENCE: HIGH`.
  This is the load-bearing justification for the one deliberate deviation below.
- **The guest never branches on a libSceUlt return value.** No comparison against any Ult-family immediate
  exists in the binary; the five `cmp`/`test` instructions following Ult calls compare unrelated memory operands,
  never `eax`. So the exact error constants are unobservable.
- **The mutex is held at all five `ConditionVariableWait` sites**, each immediately preceded by
  `sceUltMutexLock` on precisely the mutex the CV was created with. This is what makes `pthread_cond_wait` safe.

## Design

- **Ulthread → one real guest thread**, created through the same trampoline `scePthreadCreate` uses and entered
  on the guest-supplied `context`/`sizeContext` — which is what that pair *is* on hardware. Join writes the
  entry's `int32` into the 4-byte out-param.
- **Mutex → `PTHREAD_MUTEX_ERRORCHECK`**, so a self-relock surfaces as a logged `EDEADLK` rather than undefined
  behaviour, and a non-owner unlock as `EPERM`. Owner-compare runs first so the diagnosis is precise rather than
  generic.
- **Guest object → a 16-byte `{magic, id}` header only**, with state in a host-side generation-tagged slot
  table. Zeroed BSS reads as "not created" and is refused loudly; destroy clears the magic and bumps the
  generation, so a stale handle is **detected** rather than dereferenced. The id is stored **before** the magic
  is published with release ordering, and read with acquire — so a thread that sees the magic necessarily sees
  the id.
- **`*GetWorkAreaSize` returns prosper's own real requirement**, and `Create` recomputes the identical size from
  the identical arguments and genuinely uses that buffer. Nothing is invented; the number is honoured.

### Condition variables — the non-obvious part

The guest holds the bound mutex at all five `Wait` sites but at **none** of the eleven `Signal` sites. So the
wake accounting **cannot** be protected by that mutex. It uses two monotonic counters instead: one waiter
released per `Signal`, spurious wakeups suppressed, and a `Signal` with no waiter **lost** rather than remembered
(which is the correct condition-variable contract). The residual window is bounded by a short poll, so a missed
wake costs milliseconds and never a hang. `CONFIDENCE: MED` on the poll bound; `HIGH` on the counter semantics.

### The trampoline hooks travel in a thread-local, not an argument

`k_pthread_create` also serves `scePthreadCreate`, whose 5-argument form leaves `a5`/`r9`
**caller-indeterminate** — so reading hooks out of a guest register would dereference garbage on every ordinary
thread creation. This is the same class as the `a4` name-pointer hazard that `k_pthread_create_noname` exists to
avoid. Hooks are null for every existing caller, so `scePthreadCreate` behaviour is unchanged. `on_enter` runs on
the host `%fs` as the last action before guest entry; `on_exit` after the scoped restore.

## The one deliberate deviation, and why it is visible

Hardware multiplexes up to `numMaxUlthread` ulthreads cooperatively onto `numWorkerThread` workers; this maps
1:1, so up to 16 may run concurrently where hardware would run 3. That is safe because the guest is already
preemption-safe across ulthreads (3 workers already preempt on hardware, and the engine guards everything with
Ult mutexes) and because `numWorkerThread` is used for nothing else.

Rather than trust that, the deviation is **instrumented**. On the live title it fired:

```
CONCURRENCY: 4 ulthreads running at once, but it was created with numWorkerThread=3
```

It is not capped — just made observable, so a future title where this matters produces a log line instead of a
mystery.

## Errno constants are FreeBSD's, deliberately

`EDEADLK` is **11** on FreeBSD and 35 on Linux; `EAGAIN` is 35 and 11 — exactly transposed. Copying from the
ambient host header yields a plausible constant meaning something else. #1612 tracks existing instances of that
mistake. A code comment (not just this PR body) records that these must **not** be "corrected" against the host
header, because a later reader doing exactly that is the real risk.

## Tests

`test_ult_semantics.cpp` (new, 477 lines) and a reworked `test_ult_fail_visible.cpp`. Each behavior has a check
that fails without it, including a concurrent-increment mutual-exclusion test with an exact expected total
**plus** a critical-section occupancy counter — the latter is a *direct* observation of two threads inside the
section rather than an inference from a corrupted total, so it does not depend on timing luck. Against a forced
no-op it reports **68,636 overlapping entries**.

## Verification

- ctest **161/164**. The three failures are the known dump-parameterized set requiring `PPSA24651` (#1573).
- **Live title**: all four ulthreads run, named, at the entry points static analysis predicted — `"Save Thread"`
  (`0x13740`), `"Rewind"` (`0xff420`), `"Leaderboards Thread"` (`0x48d0`), `"TrophyThread"` (`0x14220`) — plus
  three condvars bound to exactly the predicted mutexes. No self-deadlock, no non-owner unlock, no watchdog
  trigger, no stack warning.
- **`GetWorkAreaSize`**: the title now requests **160 and 544 bytes** where it previously asked `malloc` for
  2.0 GiB twice.

### Measurements stated honestly

Six 60 s runs, alternating arms: **VmPeak 867,820 kB in all six, identical to the kilobyte.** An earlier single
933,356 kB reading was a one-off outlier, not a systematic difference. Submit counts overlap between arms
(difference in means 0.6% against a within-arm spread of 8.3%), so an earlier "1.3% higher" reading was timing
noise. Both stand as **no measurable difference**.

## Risks

- **VmPeak rises +266 MB, reproducibly across six runs**, once the ulthreads actually run — four threads doing
  work the title was previously not doing at all. Confirmed **not** the stack probe (bounding the fill left it
  unchanged). This is the cost of the library working rather than no-opping.
- Behaviour that was a no-op is now real blocking. A cross-thread lock-ordering hazard would previously have been
  invisible; it now blocks. Every blocking wait is watchdogged (`PROSPER_ULT_BLOCK_WARN_MS`, default 5000) and
  logs once per object, so such a hazard surfaces as a diagnosable line rather than a hang that looks like slow
  asset loading.
- `PROSPER_ULT_LEGACY_ENOSYS=1` restores the previous phase wholesale for A/B.

## Scope — no rung claim

**The importing title's rung is unchanged**, as expected: its black game picture is a separate descriptor gap
(#1590). This PR claims correct, evidenced semantics with tests that fail without them — not a visual milestone.

## Also recorded

Three entries added to `docs/GAME_COMPAT_ORCHESTRATION.md`: the value-vs-status NID registration trap above;
an A/B whose env var a test's own policy pin silently neutralised (tell: *arms that agree when they must
differ*); and an instrument comparison — a "which functions touch this class" heuristic produced 1,361 then 707
false hits and could be tuned to match nothing, while an exhaustive RIP-relative scan gives a proof. Generalised
as: **prefer the instrument whose negative result is exhaustive over a closed set.**
