### PR TITLE
diag(exec): attribute the two earliest draw-skip paths to a target and a command order

### DIFF
--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -978,11 +978,12 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
         }
         if (log) fprintf(stderr, "[exec] skip draw early: no color/depth/stencil effect "
                                 "cb_target_mask=0x%x cb_color_control=0x%x color0_fmt=%u "
-                                "color0=0x%llx/%ux%u es=0x%llx ps=0x%llx\n",
+                                "color0=0x%llx/%ux%u es=0x%llx ps=0x%llx order=%llu\n",
                          rs.cb_target_mask, rs.cb_color_control,
                          resolved_pipeline.color0_format,
                          (unsigned long long)rs.color0_base, rs.color0_width, rs.color0_height,
-                         (unsigned long long)rs.es_addr, (unsigned long long)rs.ps_addr);
+                         (unsigned long long)rs.es_addr, (unsigned long long)rs.ps_addr,
+                         (unsigned long long)(draw ? draw->command_order : 0));
         return false;
     }
     const auto* fused_back = static_cast<const AgcShaderHeader*>(

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -950,8 +950,10 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
             add_stage_diagnostic(ShaderProgramStage::Vertex, rs.es_addr, {}, {});
             add_stage_diagnostic(ShaderProgramStage::Fragment, rs.ps_addr, {}, {});
         }
-        if (log) fprintf(stderr, "[exec] skip draw: no PGM bound (es=0x%llx ps=0x%llx)\n",
-                         (unsigned long long)rs.es_addr, (unsigned long long)rs.ps_addr);
+        if (log) fprintf(stderr, "[exec] skip draw: no PGM bound (es=0x%llx ps=0x%llx "
+                                 "color0=0x%llx/%ux%u)\n",
+                         (unsigned long long)rs.es_addr, (unsigned long long)rs.ps_addr,
+                         (unsigned long long)rs.color0_base, rs.color0_width, rs.color0_height);
         return false;
     }
     const ResolvedPipelineState resolved_pipeline = failure
@@ -975,9 +977,12 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
             add_stage_diagnostic(ShaderProgramStage::Fragment, rs.ps_addr, {}, {});
         }
         if (log) fprintf(stderr, "[exec] skip draw early: no color/depth/stencil effect "
-                                "cb_target_mask=0x%x cb_color_control=0x%x color0_fmt=%u\n",
+                                "cb_target_mask=0x%x cb_color_control=0x%x color0_fmt=%u "
+                                "color0=0x%llx/%ux%u es=0x%llx ps=0x%llx\n",
                          rs.cb_target_mask, rs.cb_color_control,
-                         resolved_pipeline.color0_format);
+                         resolved_pipeline.color0_format,
+                         (unsigned long long)rs.color0_base, rs.color0_width, rs.color0_height,
+                         (unsigned long long)rs.es_addr, (unsigned long long)rs.ps_addr);
         return false;
     }
     const auto* fused_back = static_cast<const AgcShaderHeader*>(


### PR DESCRIPTION
## Purpose

Two diagnostic-only additions to the draw-skip logging in `realize_draw_item`. No renderer behaviour
changes; both lines are gated on the existing `PROSPER_GFXLOG` / `PROSPER_EXECLOG` switches and are
inert otherwise.

Refs #1606.

## Failure scenario

`realize_draw_item` has several reject paths. The recompile-failure path already prints the bound
programs, the colour target and the draw's command order. The two paths that fire *earliest* — "no PGM
bound" and the early "no color/depth/stencil effect" gate — printed neither the target nor the order:

```
[exec] skip draw early: no color/depth/stencil effect cb_target_mask=0x0 cb_color_control=0xcc0000 color0_fmt=97
[exec] skip draw: no PGM bound (es=0x3008100000 ps=0x0)
```

An `EXECLOG` run could therefore tell you *that* draws were being suppressed and *why*, but not **which
surface lost its producer** — which is the only thing that matters when a title presents a black frame.
Aggregating those lines yields one undifferentiated count. This is the same class of gap #1606 records
for captures, one layer down: a seam that reports a reason it cannot attribute.

## Change

* `no PGM bound` also prints `color0=<base>/<w>x<h>`.
* early `no color/depth/stencil effect` also prints `color0=<base>/<w>x<h>`, the bound `es`/`ps`
  program addresses, and the draw's `command_order`.

```
[exec] skip draw early: no color/depth/stencil effect cb_target_mask=0x0 cb_color_control=0xcc0000
    color0_fmt=97 color0=0x3012370000/3840x2160 es=0x3008100000 ps=0x300e460000 order=1549
```

## Why the command order specifically

Register writes are reported by `PROSPER_REGWATCH` at command-processor **decode** time, and draws are
logged at **realization** time. The two phases interleave per submit, so *adjacency in the log stream is
not a timeline* — reading it as one manufactures a false "the register was written after the draw"
result. Printing the draw's own `command_order` makes the join computable: for a draw at order D, the
in-effect value is the last watched write with order ≤ D.

## What it produced

On The Oregon Trail (#1606) the target attribution immediately showed that **~960 of ~980 draws
suppressed in a six-second window all target the same 3840×2160 `R16G16B16A16_SFLOAT` surface** — the
one the title's post-process chain samples as its scene source. The order field then joined the skip log
to `PROSPER_REGWATCH` and proved the opposite of the working hypothesis: all **1,050** suppressed draws
resolve *exactly* the `CB_COLOR_CONTROL` and `CB_TARGET_MASK` the guest wrote at or before their own
order — **zero mismatches** — so prosper's colour-state tracking is correct there and the register-fold
explanation is dead. Neither conclusion was reachable from the previous log text.

## Affected and deliberately unaffected

* Affected: the text of two `stderr` diagnostics, only when `PROSPER_GFXLOG` or `PROSPER_EXECLOG` is set.
* Unaffected: every realization decision, all captured `OperationRealizationFailure` records, and the
  default (unset) logging path. No control flow is touched — the additions are extra `printf`
  arguments inside the existing `if (log)` blocks.

## Risks

Low. `rs.color0_base` / `rs.color0_width` / `rs.color0_height` / `rs.es_addr` / `rs.ps_addr` are already
read on these paths, and `draw` is null-guarded exactly as the recompile-failure line already does
(`draw ? draw->command_order : 0`). The only externally visible effect is longer diagnostic lines; any
consumer parsing these by prefix is unaffected, and the added fields are appended, not reordered.

## Verification

Built in the `ps5ys` distrobox (configure reports `Vulkan found`, so `gpu_replay` and the Vulkan
execution tests are present):

```
cmake -S prosper -B prosper/build-linux -G Ninja -DGAME_DUMP=<DUMP_ROOT>/PPSA19244-app0
cmake --build prosper/build-linux -j8          # clean
```

Both lines were then exercised live on `PPSA19244` (Linux, AMD Radeon 8060S / RADV STRIX_HALO,
`screenshot` frontend) and produced the attributed output quoted above.

No snapshot run is included: this patch cannot change a rendered pixel — it adds only `printf`
arguments behind `if (log)` on paths that already `return false` unchanged.
