### PR TITLE
fix(agc): implement sceAgcSet{Cx,Sh,Uc}RegIndirectPatchSetNumRegisters

### DIFF
--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -1755,6 +1755,62 @@ HLE(agc_patch_add_registers) {  // (cmd, num_regs): cmd[1] += num_regs
     cmd[1] += (uint32_t)a1; return 0;
 }
 
+// sceAgcSet{Cx,Sh,Uc}RegIndirectPatchSetNumRegisters — SET, not accumulate, the register count of a
+// packet returned by the matching Set*RegistersIndirect call.
+//
+// The record-then-patch idiom reserves the packet BEFORE the register array is known: the builder
+// emits Set*RegistersIndirect(dcb, <placeholder>, <placeholder count>), fills the array as the
+// draw's state is assembled, then patches in the final address and count. `PatchAddRegisters`
+// accumulates while the array grows; `PatchSetNumRegisters` writes the final count outright and is
+// the only member of the family that can LOWER one — so it is the only way an over-counted packet
+// can be corrected, and no amount of AddRegisters can substitute for it.
+//
+// All three were unregistered, so they took the unimplemented-import path (dispatch.cpp
+// prosper_on_unimpl: log once, return 0) and the packet kept its RECORD-TIME count. The failure that
+// leaves is silent in both directions: a packet reserved with count 0 applies NOTHING (the
+// SetRegsIndirect arm of GpuState::apply returns early on num_regs == 0), so a whole register write
+// disappears from the decoded stream; a packet whose count the guest lowered keeps its high-water
+// count and folds whatever follows the real registers in as further register writes.
+//
+// Every UE4 title dumped here imports these NIDs, but no title measured so far CALLS them (a
+// 460 s Nikoderiko/PPSA23760 boot through gameplay logs no unimplemented hit for nCUgItdN2ms), so
+// this is a gap fill against a real ABI, not a fix for any diagnosed defect. In particular it is NOT
+// the cause of the stale user-data block in #305 — that was measured to a different mechanism — and
+// the register-file bloat of #1264 was separately attributed to stale arena slots. Do not infer a
+// causal link to either from this handler's presence.
+//
+// The packet layout is the one the Set*RegsIndirect builder emits (cmd[1] = count,
+// cmd[2..3] = array vaddr), and the header sub-op is verified first, so a pointer that is not the
+// expected packet is refused loudly rather than silently corrupting the stream.
+// CONFIDENCE: HIGH on the count-slot semantics (the packet layout is prosper's own, the SET-vs-ADD
+// distinction is the name, and the sibling patchers in this family already write these same slots).
+// CONFIDENCE: MED that no live title needs it yet — absence of a call in the routes measured is not
+// proof of absence across titles, which is exactly why it should be implemented rather than left to
+// return 0.
+static uint64_t patch_set_num_registers(uint64_t cmd_addr, uint64_t num, uint32_t want_r,
+                                        const char* who) {
+    auto* cmd = (uint32_t*)(uintptr_t)cmd_addr; if (!cmd) return 0;
+    if (!patch_check(cmd, want_r, who)) return 0;
+    static const bool regbloat = getenv("PROSPER_REGBLOAT") != nullptr;
+    if (regbloat) {
+        static std::atomic<int> n{0};
+        if (n.fetch_add(1) < 96)
+            fprintf(stderr, "[regbloat-patch] set_num_registers cmd=%p old_num=%u new=%u\n",
+                    (void*)cmd, cmd[1], (uint32_t)num);
+    }
+    cmd[1] = (uint32_t)num;
+    return 0;
+}
+HLE(agc_patch_set_num_registers_cx) {
+    return patch_set_num_registers(a0, a1, R_CX_REGS_INDIRECT, "SetCxRegIndirectPatchSetNumRegisters");
+}
+HLE(agc_patch_set_num_registers_sh) {
+    return patch_set_num_registers(a0, a1, R_SH_REGS_INDIRECT, "SetShRegIndirectPatchSetNumRegisters");
+}
+HLE(agc_patch_set_num_registers_uc) {
+    return patch_set_num_registers(a0, a1, R_UC_REGS_INDIRECT, "SetUcRegIndirectPatchSetNumRegisters");
+}
+
 // --- Sync-packet address patch family (issue #213/#222 — the DOLL per-draw fence cluster). ------
 //
 // RE'd from DOLL's statically-linked AGC fence builder (eboot+0x59a1780, gdb-verified live): the
@@ -2013,6 +2069,10 @@ void register_agc_hle() {
     RN("vcmNN+AAXnY", agc_patch_set_address);   RN("d-6uF9sZDIU", agc_patch_add_registers);   // Cx
     RN("Qrj4c+61z4A", agc_patch_set_address);   RN("z2duB-hHQSM", agc_patch_add_registers);   // Sh
     RN("6lNcCp+fxi4", agc_patch_set_address);   RN("vRoArM9zaIk", agc_patch_add_registers);   // Uc
+    // ...PatchSetNumRegisters: the SET (non-accumulating) count patcher of the same family (#305).
+    RN("whb1RL7K4Ss", agc_patch_set_num_registers_cx);   // sceAgcSetCxRegIndirectPatchSetNumRegisters
+    RN("nCUgItdN2ms", agc_patch_set_num_registers_sh);   // sceAgcSetShRegIndirectPatchSetNumRegisters
+    RN("fRG-JOH5+sI", agc_patch_set_num_registers_uc);   // sceAgcSetUcRegIndirectPatchSetNumRegisters
     RN("LtTouSCZjHM", agc_cb_nop);              // sceAgcCbNop — append padding dwords (#117)
     // Sync-packet address patchers + compute dispatch (issue #213 — the DOLL per-draw fence
     // cluster; RE write-up at each handler). These OVERRIDE the glog no-op thunks (map insert

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -1790,14 +1790,28 @@ HLE(agc_patch_add_registers) {  // (cmd, num_regs): cmd[1] += num_regs
 static uint64_t patch_set_num_registers(uint64_t cmd_addr, uint64_t num, uint32_t want_r,
                                         const char* who) {
     auto* cmd = (uint32_t*)(uintptr_t)cmd_addr; if (!cmd) return 0;
-    if (!patch_check(cmd, want_r, who)) return 0;
+    // These NIDs previously reached prosper_on_unimpl and touched nothing, so this is a NEW guest
+    // dereference on a path that used to be inert. Probe the packet header before reading it: a
+    // caller passing a freed or never-built packet must not take the host down (the sibling
+    // patchers predate this guard; see the follow-up issue).
+    if (!gpu::guest_readable(cmd_addr, 2 * sizeof(uint32_t))) {
+        static std::atomic<int> n{0};
+        if (n.fetch_add(1) < 8)
+            fprintf(stderr, "[agc] %s: packet 0x%llx unmapped — patch skipped\n", who,
+                    (unsigned long long)cmd_addr);
+        return 0;
+    }
+    // Report BEFORE the sub-op check, and report the refusal too: an investigation into a wrong
+    // register count most wants the case where the patch did not land.
     static const bool regbloat = getenv("PROSPER_REGBLOAT") != nullptr;
+    const bool ok = patch_check(cmd, want_r, who);
     if (regbloat) {
         static std::atomic<int> n{0};
         if (n.fetch_add(1) < 96)
-            fprintf(stderr, "[regbloat-patch] set_num_registers cmd=%p old_num=%u new=%u\n",
-                    (void*)cmd, cmd[1], (uint32_t)num);
+            fprintf(stderr, "[regbloat-patch] set_num_registers cmd=%p hdr=0x%08x old_num=%u new=%u%s\n",
+                    (void*)cmd, cmd[0], cmd[1], (uint32_t)num, ok ? "" : " REFUSED");
     }
+    if (!ok) return 0;
     cmd[1] = (uint32_t)num;
     return 0;
 }

--- a/prosper/tests/test_agc_dcb.cpp
+++ b/prosper/tests/test_agc_dcb.cpp
@@ -27,7 +27,8 @@ static uint32_t PM4(uint32_t len, uint32_t op, uint32_t r) {
 constexpr uint32_t IT_NOP = 0x10, IT_NUM_INSTANCES = 0x2F, IT_SET_CONTEXT_REG = 0x69,
                    IT_SET_SH_REG = 0x76, IT_SET_UCONFIG_REG = 0x79,
                    R_DRAW_RESET = 0x05, R_PUSH_MARKER = 0x0b, R_POP_MARKER = 0x0c,
-                   R_CX_REGS_INDIRECT = 0x12, R_DMA_DATA = 0x19;
+                   R_SH_REGS_INDIRECT = 0x11, R_CX_REGS_INDIRECT = 0x12,
+                   R_UC_REGS_INDIRECT = 0x13, R_DMA_DATA = 0x19;
 
 struct ShaderRegister { uint32_t offset, value; };
 
@@ -101,6 +102,48 @@ int main() {
     CHECK(cmd[1] == 8, "PatchAddRegisters did cmd[1] += 5 (3 -> 8)");
     p_addr(rc, 0xAABBCCDD00112233ull, 0, 0, 0, 0);
     CHECK(cmd[2] == 0x00112233u && cmd[3] == 0xAABBCCDDu, "PatchSetAddress rewrote cmd[2]/cmd[3]");
+
+    // PatchSetNumRegisters SETS the count outright — the only member of this family that can
+    // LOWER one. The AGC record-then-patch idiom reserves the packet before the register array is
+    // known, so an ignored patch leaves the RECORD-TIME placeholder in cmd[1]: a packet reserved
+    // with 0 applies no registers at all (GpuState::apply returns early on num_regs == 0) and the
+    // whole bind disappears from the decoded stream. All three class variants must be registered,
+    // must write the count slot, and must refuse a packet of the wrong class.
+    auto p_num_cx = Hle::lookup("whb1RL7K4Ss");   // sceAgcSetCxRegIndirectPatchSetNumRegisters
+    auto p_num_sh = Hle::lookup("nCUgItdN2ms");   // sceAgcSetShRegIndirectPatchSetNumRegisters
+    auto p_num_uc = Hle::lookup("fRG-JOH5+sI");   // sceAgcSetUcRegIndirectPatchSetNumRegisters
+    auto setsh_ind = Hle::lookup("-HOOCn0JY48");  // sceAgcDcbSetShRegistersIndirect
+    auto setuc_ind = Hle::lookup("hvUfkUIQcOE");  // sceAgcDcbSetUcRegistersIndirect
+    CHECK(p_num_cx && p_num_sh && p_num_uc && setsh_ind && setuc_ind,
+          "all three PatchSetNumRegisters NIDs and the Sh/Uc indirect builders are registered");
+    if (p_num_cx && p_num_sh && p_num_uc && setsh_ind && setuc_ind) {
+        p_num_cx(rc, 2, 0, 0, 0, 0);
+        CHECK(cmd[1] == 2, "Cx PatchSetNumRegisters SETS the count (8 -> 2), it does not accumulate");
+        CHECK(cmd[2] == 0x00112233u && cmd[3] == 0xAABBCCDDu,
+              "Cx PatchSetNumRegisters leaves the array address untouched");
+
+        // The record-with-a-placeholder-count sequence the defect turned into a dropped bind.
+        uint64_t sh_rc = setsh_ind(D, 0, 0, 0, 0, 0);
+        auto* sh_cmd = (uint32_t*)(uintptr_t)sh_rc;
+        CHECK(sh_cmd && sh_cmd[0] == PM4(4, IT_NOP, R_SH_REGS_INDIRECT) && sh_cmd[1] == 0,
+              "SetShRegistersIndirect reserves a packet with the placeholder count 0");
+        p_addr(sh_rc, 0x0000000340000000ull, 0, 0, 0, 0);
+        p_num_sh(sh_rc, 12, 0, 0, 0, 0);
+        CHECK(sh_cmd[1] == 12, "Sh PatchSetNumRegisters turns the reserved 0-count packet into 12");
+        CHECK(sh_cmd[2] == 0x40000000u && sh_cmd[3] == 0x00000003u,
+              "Sh reserved packet keeps its patched array address");
+
+        uint64_t uc_rc = setuc_ind(D, 0, 7, 0, 0, 0);
+        auto* uc_cmd = (uint32_t*)(uintptr_t)uc_rc;
+        p_num_uc(uc_rc, 1, 0, 0, 0, 0);
+        CHECK(uc_cmd && uc_cmd[1] == 1, "Uc PatchSetNumRegisters lowers a recorded count (7 -> 1)");
+
+        // Class check: the Sh patcher must refuse the Cx packet rather than corrupt its count.
+        const uint32_t cx_num_before = cmd[1];
+        p_num_sh(rc, 999, 0, 0, 0, 0);
+        CHECK(cmd[1] == cx_num_before,
+              "PatchSetNumRegisters refuses a packet of a different register class");
+    }
 
     // #395 F5: all three single-register direct NIDs append the native packet opcode and preserve
     // the by-value ShaderRegister's offset/value halves. Previously SH was dead code and Cx/Uc fell


### PR DESCRIPTION
## What this fixes

`sceAgcSetCxRegIndirectPatchSetNumRegisters` (`whb1RL7K4Ss`),
`sceAgcSetShRegIndirectPatchSetNumRegisters` (`nCUgItdN2ms`) and
`sceAgcSetUcRegIndirectPatchSetNumRegisters` (`fRG-JOH5+sI`) were unregistered. All three fell
through to the unimplemented-import path (`dispatch.cpp prosper_on_unimpl`: log once, return 0), so
a `Set*RegistersIndirect` packet kept whatever register count it was recorded with.

## Failure scenario

AGC's record-then-patch idiom reserves the packet **before** the register array is known:

```
pkt = sceAgcDcbSetShRegistersIndirect(dcb, <placeholder array>, <placeholder count>);
...  fill the array as the draw's state is assembled  ...
sceAgcSetShRegIndirectPatchSetAddress(pkt, array);        // implemented
sceAgcSetShRegIndirectPatchSetNumRegisters(pkt, count);   // was a no-op
```

`PatchAddRegisters` (already implemented) accumulates while the array grows. `PatchSetNumRegisters`
writes the final count outright and is the **only** member of the family that can LOWER one, so an
over-counted packet cannot be corrected without it.

Dropping it is silent in both directions:

* a packet reserved with count 0 applies **nothing** — `GpuState::apply`'s `SetRegsIndirect` arm
  returns early on `num_regs == 0` — so a whole register write disappears from the decoded stream;
* a packet whose count the guest lowered keeps its high-water count and folds whatever follows the
  real registers in as further register writes.

## Contract and invariants

`cmd[1] = num_regs` on the packet the matching `Set*RegsIndirect` builder emitted (`cmd[1]` = count,
`cmd[2..3]` = array vaddr). Each class variant verifies the packet's own header sub-op
(`R_CX_REGS_INDIRECT` / `R_SH_REGS_INDIRECT` / `R_UC_REGS_INDIRECT`) through the existing
`patch_check` before writing, so a pointer that is not the expected packet is **refused** rather than
silently corrupting the stream — the same contract the sync-packet address patchers use. A null `cmd`
is rejected, and the header read is `guest_readable`-probed first because these NIDs previously
reached `prosper_on_unimpl` and touched nothing: this is a new guest dereference on a path that used
to be inert. Caveat on "loudly": `patch_check`'s diagnostic budget is a **single** 8-message counter
shared by every patcher family in the translation unit, so a mismatch here can be silent once that
budget is spent. `PROSPER_REGBLOAT` therefore now reports the attempt *before* the check, with the
header dword, and marks refusals. Making the budget per-callsite is filed as #1650. The count is not clamped here: `kMaxRegsPerPacket` already drops an insane count at fold time. Note
that drop is a bare `return`, not a logged reject — silent, which is the class the charter calls out.
Correcting it belongs to that arm, not here.

`CONFIDENCE: HIGH` on the count-slot semantics — the packet layout is prosper's own, the SET-vs-ADD
distinction is the function name, and the sibling patchers in this family already write these exact
slots.

## Scope — this is a gap fill, not a fix for a diagnosed defect

**No measured title calls these entry points.** Every UE4 dump here imports the NIDs, but a 460 s
Nikoderiko (`PPSA23760`) boot through gameplay logs no unimplemented hit for `nCUgItdN2ms`.

It is explicitly **not** the cause of #305's stale user-data block — that was measured to a different
mechanism (see the findings comment on #305) — and #1264's register-file bloat was separately
attributed to stale arena slots. The handler comment states both, so a later reader cannot infer a
causal link that does not exist. `CONFIDENCE: MED` that no live title needs it yet: absence of a call
in the routes measured is not proof of absence across titles, which is precisely why it should be
implemented rather than left returning 0.

## Affected / deliberately unaffected

* Affected: only the three NIDs that previously reached `prosper_on_unimpl`.
* Unaffected: no rendered output, no default behaviour, no other AGC path. `PatchSetAddress` and
  `PatchAddRegisters` are untouched.

## Risks

Low. The only new writes happen on calls that were previously no-ops, and each is guarded by a header
sub-op check that refuses on mismatch. The realistic risk is a title that relied on the no-op
behaviour, which cannot be the case: a no-op leaves the guest's own count unapplied.

## Verification (exact head `28bd199d`, rebased on current master, Linux, ps5ys distrobox)

```
cmake -S prosper -B prosper/build-linux -G Ninja -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0
cmake --build prosper/build-linux -j8      # clean
ctest                                       # 100% tests passed, 165/165, 15.47 s
```

New `test_agc_dcb` cases. Without this change the registration assertion fails outright (the NID
lookups return null) and the remaining assertions are skipped inside that guard; run against an
ADD-semantics or no-`patch_check` implementation, the individual cases discriminate as noted:

* all three NIDs resolve through the registry
* Cx `PatchSetNumRegisters` **sets** the count (8 -> 2) rather than accumulating — kills an ADD
  implementation
* it leaves the array address untouched
* a Sh packet reserved with placeholder count 0 becomes 12 and keeps its patched array address
  (the dropped-bind sequence)
* Uc `PatchSetNumRegisters` **lowers** a recorded count (7 -> 1) — also kills an ADD implementation
* a patcher refuses a packet of a different register class without modifying it — kills a
  no-`patch_check` implementation, and any NID-to-class transposition turns one positive assertion
  into a refusal

  (The Sh `0 -> 12` case alone cannot distinguish SET from ADD; the Cx and Uc cases carry that.)

Note: with `GAME_DUMP` pointed at a non-Messenger dump, `module_loads_eboot`,
`boot_reaches_first_syscall` and `real_shader_render` fail on dump-specific expectations (import
counts, `Il2cppUserAssemblies.prx`, embedded shader blobs). That is a configuration artifact, not a
regression — the 163/163 run above uses `PPSA24651`.

Refs #305


---

### Review round 1 addressed (`28bd199d`)

Independent review found **no blocking issues**. Acted on two findings:

* the new packet dereference is now `gpu::guest_readable`-probed before `patch_check`, because these
  NIDs previously reached `prosper_on_unimpl` and touched nothing;
* `PROSPER_REGBLOAT` now reports before the sub-op check, includes the header dword, and marks
  refusals — the case an investigation most wants.

Also corrected in this description: "fail-visibly" for the oversized-count drop (it is a silent
`return`), "refused loudly" (the diagnostic budget is shared), and "each of which fails without this
change" (only the registration assertion executes; the rest are skipped inside its guard).

The reviewer's finding that the two **sibling** patchers (`PatchSetAddress`, `PatchAddRegisters`)
have neither guard — leaving the family half-guarded — is filed as **#1650** rather than fixed here,
because tightening them changes existing working behaviour and needs a live boot on a title that
exercises them.
