### PR TITLE
docs(orchestration): record two more instrument traps — cross-stage joins and print caps

### DIFF
--- a/prosper/docs/GAME_COMPAT_ORCHESTRATION.md
+++ b/prosper/docs/GAME_COMPAT_ORCHESTRATION.md
@@ -50,8 +50,9 @@ session. Prefer breadth when a hard lane stalls — overall library progress mat
 
 ### The instrument-not-the-subject list — read this before believing any surprising measurement
 
-**Eleven phantom defects in one session (2026-07-31) came from the measuring apparatus, not the subject.**
-Several cost hours; one cost two sessions. This is the single highest-value page in this document.
+**Thirteen phantom defects came from the measuring apparatus, not the subject** (eleven in one session on
+2026-07-31, two more on 2026-08-01). Several cost hours; one cost two sessions. This is the single
+highest-value page in this document.
 
 | # | Instrument | How it lied |
 |---|---|---|
@@ -66,8 +67,22 @@ Several cost hours; one cost two sessions. This is the single highest-value page
 | 9 | `[compute] skip unsupported program` | **Deduped per `code_addr`**: one line means "failed at least once", NOT "always fails". A program running 763 times and failing once looks identical to a permanently blocked one. |
 | 10 | `PROSPER_COMPUTELOG_CODE=<addr>` | Correctly protects a realtime route from ~13k submits of logging, and thereby **suppresses `execute` lines for every other program**. Right for one question, silently wrong for the next asked of the same log. |
 | 11 | SHA reachability after a **squash** merge | `git merge-base --is-ancestor` reports "unmerged" for work that *is* on master. Verify by **content**, not by SHA. |
+| 12 | `PROSPER_REGWATCH` **joined to** `PROSPER_EXECLOG` by stream adjacency | The two timestamp at **different pipeline stages** — REGWATCH at command-processor *decode*, EXECLOG at *realization* — and the phases interleave per submit. Read by log order, #1606 said **1,049 of 1,050** suppressed draws resolved against a *future* register write. Clean, compelling, and entirely false. Fixed by #1633's `order=`. |
+| 13 | A **print-capped** diagnostic read as a frequency | `[agc] WaitRegMem … NOT satisfied` prints the first 40 then every 1024th (`ln < 40 \|\| (ln & 1023) == 0`); `[agc] out-of-range indirect reg write dropped` stops after **4**; `[agc] indexed indirect draw skipped` after 24. #1606 called the `WaitRegMem` volume "the loudest signal, dozens per second"; the true rate is **~1.5/s** (see below). A line count from these is a cap, not a rate. Same trap as #9's dedupe, different mechanism. |
 
 **Working rules that follow:**
+
+- **Joining two instruments requires an explicit shared ordinal, never stream adjacency.** If two diagnostics
+  are emitted at different pipeline stages, their interleaving in the log is an artifact of *when each stage
+  ran*, not of when the events happened. Print a common ordinal (`command_order`) on both and join on it. This
+  is why the `order=` field exists on the `[exec] skip draw early` line — **it is not redundant with the
+  register values on the same line, and removing it silently re-opens the phantom above.**
+- **Before quoting a diagnostic's line count as a rate, grep for its cap.** These sites use a
+  `static std::atomic<int>` counter or a per-key dedupe set; check for one before concluding "this fires N
+  times" or "this is rare". When the site prints its own counter — `WaitRegMem #%d` *is* `ln` — the true
+  total is free: the highest `#N` in the log bounds it, and a run whose maximum stays under the cap has
+  printed *every* occurrence. That read turned #1606's "dozens per second" into 18 and 21 events for two
+  entire runs.
 
 - Prefer experiments that **detect their own invalidity** — e.g. render two adjacent operations and assert both
   return the same resolution, so a surface switch invalidates the comparison instead of producing a phantom.


### PR DESCRIPTION
Adds two entries to the instrument-not-the-subject list in `GAME_COMPAT_ORCHESTRATION.md`, both from the #1606 investigation. Docs only.

## Instrument #12 — cross-stage instrument joins

`PROSPER_REGWATCH` reports at command-processor **decode** time; `PROSPER_EXECLOG` reports at **realization** time. The two phases interleave per submit, so the order the lines appear in the log is an artifact of *when each stage ran*, not of when the events happened.

Read by stream adjacency, the #1606 log says **1,049 of 1,050** suppressed draws were resolved against a register write with a *higher* command order than the draw — an apparent future-read. It is clean, compelling, reproducible, and completely false. Joined correctly (last watched write with `order <= D`) the same data shows **1,050 of 1,050 exact matches, zero mismatches**, which is the opposite conclusion and the one that actually cleared prosper of a register-tracking defect.

This is the same family as the existing entry #5 (`--through-operation` bisects across different surfaces), which the doc records as having cost two sessions.

The stated rule is the generalization: **joining two instruments that timestamp at different pipeline stages requires an explicit shared ordinal, never stream adjacency.** #1633 supplied the remedy by printing `command_order` on the `[exec] skip draw early` line, and the doc now says explicitly that the field is *not* redundant with the register values printed beside it, so a future reader does not remove it as duplicated noise.

## Instrument #13 — print-capped diagnostics read as frequencies

`[agc] out-of-range indirect reg write dropped` stops after four lines (`dropped_note.fetch_add(1) < 4`, `command_processor.cpp:2083`), and `[agc] indexed indirect draw skipped` stops after 24 (`gpu_executor.cpp:5416`). A line count from either is a cap, not a rate. This bit during #1606 triage: exactly four dropped-write lines looked like a bounded, negligible event, and the count carried no information at all.

The doc already carries entry #9 for the same hazard via per-`code_addr` dedupe; this records the atomic-counter mechanism as a distinct thing to grep for.

## Affected and unaffected

* Affected: `prosper/docs/GAME_COMPAT_ORCHESTRATION.md` only — two table rows, two working rules, and the section count updated from eleven to thirteen with the second date noted.
* Unaffected: all code, tests, and tooling. No behavior change.

## Verification

`git diff --check` clean. Docs-only change; no build or test run is applicable.

Refs #1606
