### PR TITLE
fix(gpu): record why a draw failed instead of discarding it (#1636)

### DIFF
--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -1093,7 +1093,7 @@ bool validate_failure_diagnostics(const GpuCaptureFile& capture, std::string& er
     for (const auto& diagnostic : capture.failure_diagnostics) {
         if (diagnostic.kind > SubmitOperationKind::Dispatch ||
             diagnostic.reason <= RealizationFailureReason::None ||
-            diagnostic.reason > RealizationFailureReason::Filtered ||
+            diagnostic.reason > kMaxRealizationFailureReason ||
             diagnostic.stages.size() > kMaxFailureStages) {
             error = "invalid failed-operation diagnostic metadata";
             return false;
@@ -1324,6 +1324,9 @@ const char* realization_failure_reason_name(RealizationFailureReason reason) {
         case RealizationFailureReason::NoEffect: return "no-effect";
         case RealizationFailureReason::ZeroVertices: return "zero-vertices";
         case RealizationFailureReason::Filtered: return "filtered";
+        case RealizationFailureReason::RetainedDrawNotSelected: return "retained-draw-not-selected";
+        case RealizationFailureReason::IndirectArguments: return "indirect-arguments";
+        case RealizationFailureReason::IndirectDependencies: return "indirect-dependencies";
     }
     return "unknown";
 }
@@ -2486,7 +2489,7 @@ bool deserialize_gpu_capture(const std::vector<uint8_t>& bytes, GpuCaptureFile& 
             if (!r.u8(kind) || kind > static_cast<uint8_t>(SubmitOperationKind::Dispatch) ||
                 !r.u64(diagnostic.source_index) || !r.u64(diagnostic.command_order) ||
                 !r.u8(reason) || reason <= static_cast<uint8_t>(RealizationFailureReason::None) ||
-                reason > static_cast<uint8_t>(RealizationFailureReason::Filtered) ||
+                reason > static_cast<uint8_t>(kMaxRealizationFailureReason) ||
                 !r.u8(pipeline_present)) {
                 error = "invalid failed-operation diagnostic metadata";
                 return false;

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -490,7 +490,9 @@ enum class RealizationFailureReason : uint8_t {
     // Unknown because "nothing was attempted, and here is why" is the answer an investigation needs
     // (#1636) — collapsing them to Unknown is indistinguishable from the reason being lost.
     RetainedDrawNotSelected,   // the retained-submit policy did not select this draw index
-    IndirectArguments,         // indirect draw/dispatch arguments could not be resolved
+    IndirectArguments,         // indirect DRAW arguments could not be resolved. Dispatches
+                               // have the same failure but realize_retained_compute still
+                               // returns a bare false for it, so they remain Unknown.
     IndirectDependencies,      // an indirect operation's producer had not landed for this submit
 };
 inline constexpr RealizationFailureReason kMaxRealizationFailureReason =

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -474,6 +474,8 @@ struct ParallelDrawRealizationStats {
 };
 ParallelDrawRealizationStats parallel_draw_realization_stats();
 
+// APPEND ONLY, and update kMaxRealizationFailureReason below. The value is serialized as a raw byte
+// into .prgcap, and both the in-memory validator and the reader bound-check it against that maximum.
 enum class RealizationFailureReason : uint8_t {
     None,
     Unknown,
@@ -483,7 +485,16 @@ enum class RealizationFailureReason : uint8_t {
     NoEffect,
     ZeroVertices,
     Filtered,
+    // The three exits below are reached in the ordered-submit path BEFORE realize_draw_item runs, so
+    // they can never carry a shader/pipeline diagnostic. They are distinct reasons rather than
+    // Unknown because "nothing was attempted, and here is why" is the answer an investigation needs
+    // (#1636) — collapsing them to Unknown is indistinguishable from the reason being lost.
+    RetainedDrawNotSelected,   // the retained-submit policy did not select this draw index
+    IndirectArguments,         // indirect draw/dispatch arguments could not be resolved
+    IndirectDependencies,      // an indirect operation's producer had not landed for this submit
 };
+inline constexpr RealizationFailureReason kMaxRealizationFailureReason =
+    RealizationFailureReason::IndirectDependencies;
 
 // Capture-facing facts collected at the exact point an operation is dropped. These contain no raw
 // shader bytes; gpu_capture reads those through its fault-safe, size-bounded memory reader.

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -5518,12 +5518,14 @@ bool resolve_indirect_dispatch_arguments(const GpuState::Dispatch& source,
 bool realize_retained_draw(const GpuState& st, size_t index, float scale_x, float scale_y,
                            DrawItem& item, OperationRealizationFailure* failure = nullptr) {
     const auto note = [&](RealizationFailureReason reason) {
-        if (!failure) return false;
+        // An out-of-range index has no planned operation to attach to, and a record whose identity
+        // matches nothing fails validate_failure_diagnostics for the WHOLE capture. Report nothing
+        // rather than poison the capture; the caller still sees false.
+        if (!failure || index >= st.draws.size()) return false;
         *failure = {};
         failure->kind = SubmitOperationKind::Draw;
         failure->index = index;
-        failure->command_order =
-            index < st.draws.size() ? st.draws[index].command_order : 0;
+        failure->command_order = st.draws[index].command_order;
         failure->reason = reason;
         return false;
     };
@@ -5695,9 +5697,13 @@ static OrderedSubmitResult execute_ordered_gpustate(const GpuState& st, uint32_t
                         failure.command_order = operation.command_order;
                         capture_trace->failures.push_back(std::move(failure));
                     } else {
-                        // Eager path: the draw was realized (or dropped) in an earlier pass whose
-                        // reason is genuinely not available here, so Unknown is the honest answer
-                        // rather than a guess.
+                        // Eager path: realize_gpustate_draws DOES have a failures out-parameter,
+                        // but this submit's call site (:6023) passes nullptr, so the reason was
+                        // dropped in that earlier pass and Unknown is the honest answer here rather
+                        // than a guess. Not a simple plumb-through to fix: requesting failures also
+                        // takes the serial path (gpu_execute.hpp:1650 gates parallel realization on
+                        // `!failures`), so it trades draw-realization throughput for diagnostics.
+                        // Tracked in #1643.
                         capture_trace->failures.push_back({
                             SubmitOperationKind::Draw, operation.index,
                             operation.command_order, RealizationFailureReason::Unknown});

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -5511,16 +5511,43 @@ bool resolve_indirect_dispatch_arguments(const GpuState::Dispatch& source,
     return true;
 }
 
+// `failure`, when supplied, is filled on every false return — mirroring realize_retained_compute.
+// The two exits above realize_draw_item name themselves, because nothing was attempted there and a
+// shader/pipeline diagnostic cannot exist; the third forwards whatever realize_draw_item determined
+// (#1636). Callers that do not want a diagnostic keep passing nothing.
 bool realize_retained_draw(const GpuState& st, size_t index, float scale_x, float scale_y,
-                           DrawItem& item) {
-    if (index >= st.draws.size() || !retained_draw_selected(st, index)) return false;
+                           DrawItem& item, OperationRealizationFailure* failure = nullptr) {
+    const auto note = [&](RealizationFailureReason reason) {
+        if (!failure) return false;
+        *failure = {};
+        failure->kind = SubmitOperationKind::Draw;
+        failure->index = index;
+        failure->command_order =
+            index < st.draws.size() ? st.draws[index].command_order : 0;
+        failure->reason = reason;
+        return false;
+    };
+    if (index >= st.draws.size() || !retained_draw_selected(st, index))
+        return note(RealizationFailureReason::RetainedDrawNotSelected);
     const bool per_draw = use_per_draw_policy(st);
     const GpuState& draw_state = per_draw ? st.state_at_draw(index) : st;
     GpuState::Draw draw;
-    if (!resolve_indirect_draw_arguments(st, st.draws[index], draw)) return false;
+    if (!resolve_indirect_draw_arguments(st, st.draws[index], draw))
+        return note(RealizationFailureReason::IndirectArguments);
     const bool log = getenv("PROSPER_GFXLOG") != nullptr || getenv("PROSPER_EXECLOG") != nullptr;
     if (!realize_draw_item(draw_state, &draw, draw.index_count, 0x10000, log, item,
-                           nullptr, true)) return false;
+                           failure, true)) {
+        // realize_draw_item resets and fills the record, including pipeline/targets/extent, but has
+        // no notion of which retained operation it belongs to.
+        if (failure) {
+            failure->kind = SubmitOperationKind::Draw;
+            failure->index = index;
+            failure->command_order = draw.command_order;
+            if (failure->reason == RealizationFailureReason::None)
+                failure->reason = RealizationFailureReason::Unknown;
+        }
+        return false;
+    }
     item.draw_index = index;
     item.command_order = draw.command_order;
     if (scale_x != 1.0f || scale_y != 1.0f)
@@ -5637,12 +5664,15 @@ static OrderedSubmitResult execute_ordered_gpustate(const GpuState& st, uint32_t
                     if (capture_trace) {
                         capture_trace->failures.push_back({
                             SubmitOperationKind::Draw, operation.index,
-                            operation.command_order, RealizationFailureReason::Unknown});
+                            operation.command_order,
+                            RealizationFailureReason::IndirectDependencies});
                     }
                     break;
                 }
                 DrawItem item;
                 bool realized = false;
+                OperationRealizationFailure failure;
+                bool failure_known = false;
                 if (eager_draws) {
                     const auto found = eager_draw_by_index.find(operation.index);
                     if (found != eager_draw_by_index.end()) {
@@ -5651,11 +5681,27 @@ static OrderedSubmitResult execute_ordered_gpustate(const GpuState& st, uint32_t
                     }
                 } else {
                     realized = realize_retained_draw(
-                        st, operation.index, scale_x, scale_y, item);
+                        st, operation.index, scale_x, scale_y, item,
+                        capture_trace ? &failure : nullptr);
+                    failure_known = capture_trace != nullptr;
                 }
                 if (realized) {
                     if (capture_trace) capture_trace->draws.push_back(item);
                     span.push_back(std::move(item));
+                } else if (capture_trace) {
+                    // The reason used to die here: this path simply broke, and gpu_capture later
+                    // synthesized an empty Unknown record for the unrealized operation (#1636).
+                    if (failure_known) {
+                        failure.command_order = operation.command_order;
+                        capture_trace->failures.push_back(std::move(failure));
+                    } else {
+                        // Eager path: the draw was realized (or dropped) in an earlier pass whose
+                        // reason is genuinely not available here, so Unknown is the honest answer
+                        // rather than a guess.
+                        capture_trace->failures.push_back({
+                            SubmitOperationKind::Draw, operation.index,
+                            operation.command_order, RealizationFailureReason::Unknown});
+                    }
                 }
                 break;
             }
@@ -5666,7 +5712,8 @@ static OrderedSubmitResult execute_ordered_gpustate(const GpuState& st, uint32_t
                     if (capture_trace) {
                         capture_trace->failures.push_back({
                             SubmitOperationKind::Dispatch, operation.index,
-                            operation.command_order, RealizationFailureReason::Unknown});
+                            operation.command_order,
+                            RealizationFailureReason::IndirectDependencies});
                     }
                     producer_epoch_ok = false;
                     break;

--- a/prosper/tests/test_gpu_execute.cpp
+++ b/prosper/tests/test_gpu_execute.cpp
@@ -24,6 +24,16 @@
 #endif
 
 using namespace prosper::gpu;
+
+// Set or clear an environment variable (nullptr clears), so a test can arm a capture and disarm it
+// again without leaking the setting into the rest of the run.
+static void set_test_env(const char* name, const char* value) {
+#ifdef _WIN32
+    _putenv_s(name, value ? value : "");
+#else
+    if (value) setenv(name, value, 1); else unsetenv(name);
+#endif
+}
 namespace P = prosper::agc::Pm4;
 
 static int fails = 0;
@@ -1122,6 +1132,112 @@ int main() {
         CHECK(backend.vs_words() == std::vector<uint32_t>({0x07230203u, 999u}) &&
                   !backend.vs_shared && backend.vs_identity == 0,
               "BackendDraw::set_vs substitutes and clears the shared value and identity");
+    }
+
+
+    // #1636: a draw that does not realize must record WHY, at the point it failed. This path used to
+    // `break` without touching capture_trace->failures, so gpu_capture synthesized an empty Unknown
+    // record and offline inspection reported reason=unknown with no target, extent or pipeline.
+    //
+    // Each case below asserts the SPECIFIC reason. Asserting merely that a record exists, or that it
+    // is non-empty, would pass against a fix that reports Unknown for everything — which is the exact
+    // failure mode this guards.
+    {
+        const auto capture_path =
+            prosper_test::test_scratch_dir() / "prosper_draw_failure_reasons.prgcap";
+        auto run_and_read = [&](const GpuState& state, uint64_t submit_no,
+                                GpuCaptureFile& captured) -> bool {
+            std::error_code ec;
+            std::filesystem::remove(capture_path, ec);
+            // The interactive (F9) arm deliberately bypasses every env AT/AFTER/MIN selector, so it
+            // is the only trigger that reliably fires on an arbitrary submit inside a test process.
+            request_interactive_gpu_capture(capture_path.string());
+            set_submit_renderer([&](const std::vector<DrawItem>&, uint32_t, uint32_t) {
+                return RenderedFrame{};
+            });
+            execute_ordered_and_present(state, W, H, submit_no, /*publish=*/false);
+            set_submit_renderer({});
+            std::string error;
+            return read_gpu_capture(capture_path.string(), captured, error);
+        };
+        auto reason_for_draw = [](const GpuCaptureFile& captured, uint64_t command_order) {
+            for (const auto& diagnostic : captured.failure_diagnostics)
+                if (diagnostic.kind == SubmitOperationKind::Draw &&
+                    diagnostic.command_order == command_order)
+                    return diagnostic.reason;
+            return RealizationFailureReason::None;
+        };
+
+        // (a) Unresolvable indirect arguments — returns before realize_draw_item is ever reached, so
+        // it cannot inherit a shader/pipeline diagnostic and needs a reason of its own.
+        {
+            GpuState indirect = st;
+            indirect.draws.clear();
+            indirect.dispatches.clear();
+            indirect.dma_copies.clear();
+            indirect.ordered_memory_effects.clear();
+            GpuState::Draw bad_args;
+            bad_args.indirect = true;
+            bad_args.indirect_args_addr = 0xdead00000000ull;   // not guest-readable
+            bad_args.command_order = 300;
+            indirect.draws.push_back(bad_args);
+            GpuCaptureFile captured;
+            const bool read = run_and_read(indirect, 2101, captured);
+            const auto reason = reason_for_draw(captured, 300);
+            CHECK(read && reason == RealizationFailureReason::IndirectArguments,
+                  "#1636: an unresolvable indirect draw records reason=indirect-arguments");
+            CHECK(read && reason != RealizationFailureReason::Unknown,
+                  "#1636: ...and specifically NOT the old synthesized Unknown");
+        }
+
+        // (b) A draw whose realization genuinely fails inside realize_draw_item must FORWARD that
+        // reason, not flatten it. No pixel shader is bound here, so the executor knows exactly why.
+        {
+            uint32_t dma_source[2] = {1, 2};
+            uint32_t dma_destination[2] = {};
+            GpuState no_program = st;
+            no_program.draws.clear();
+            no_program.dispatches.clear();
+            no_program.dma_copies.clear();
+            no_program.ordered_memory_effects.clear();
+            no_program.sh[P::SPI_SHADER_PGM_LO_PS] = 0;
+            no_program.sh[P::SPI_SHADER_PGM_HI_PS] = 0;
+            no_program.sh[P::SPI_SHADER_PGM_LO_ES] = 0;
+            no_program.sh[P::SPI_SHADER_PGM_HI_ES] = 0;
+            GpuState::Draw plain;
+            plain.index_count = 3;
+            plain.command_order = 310;
+            no_program.draws.push_back(plain);
+            // An ordered DMA both routes the submit through the ordered path AND disables eager
+            // pre-realization (can_eagerly_realize_draws = !has_ordered_dma && !has_indirect), so
+            // the draw is realized by realize_retained_draw — the function this issue is about.
+            // With eager realization active the reason is lost in a DIFFERENT pass that has no
+            // failure channel at all; that is tracked separately and is NOT what this asserts.
+            no_program.dma_copies.push_back({
+                (uint64_t)(uintptr_t)dma_destination, (uint64_t)(uintptr_t)dma_source,
+                sizeof(dma_destination), 0, 305, 0});
+            GpuCaptureFile captured;
+            const bool read = run_and_read(no_program, 2102, captured);
+            const auto reason = reason_for_draw(captured, 310);
+            CHECK(read && reason != RealizationFailureReason::None,
+                  "#1636: a draw that fails inside realize_draw_item records a failure at all");
+            CHECK(read && reason != RealizationFailureReason::Unknown,
+                  "#1636: ...and forwards realize_draw_item's specific reason rather than Unknown");
+            CHECK(read && reason == RealizationFailureReason::MissingProgram,
+                  "#1636: an unbound shader program records reason=missing-program");
+        }
+
+        // (c) The reason names must round-trip through the capture format. A new enum value that the
+        // validator or the reader still bounds at Filtered would fail the whole capture write.
+        CHECK(std::string(realization_failure_reason_name(
+                  RealizationFailureReason::IndirectArguments)) == "indirect-arguments" &&
+              std::string(realization_failure_reason_name(
+                  RealizationFailureReason::IndirectDependencies)) == "indirect-dependencies" &&
+              std::string(realization_failure_reason_name(
+                  RealizationFailureReason::RetainedDrawNotSelected)) == "retained-draw-not-selected",
+              "#1636: the new reasons have names, so gpu_replay --inspect-only can print them");
+        std::error_code cleanup;
+        std::filesystem::remove(capture_path, cleanup);
     }
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }

--- a/prosper/tests/test_gpu_execute.cpp
+++ b/prosper/tests/test_gpu_execute.cpp
@@ -25,15 +25,6 @@
 
 using namespace prosper::gpu;
 
-// Set or clear an environment variable (nullptr clears), so a test can arm a capture and disarm it
-// again without leaking the setting into the rest of the run.
-static void set_test_env(const char* name, const char* value) {
-#ifdef _WIN32
-    _putenv_s(name, value ? value : "");
-#else
-    if (value) setenv(name, value, 1); else unsetenv(name);
-#endif
-}
 namespace P = prosper::agc::Pm4;
 
 static int fails = 0;
@@ -1211,14 +1202,19 @@ int main() {
             // An ordered DMA both routes the submit through the ordered path AND disables eager
             // pre-realization (can_eagerly_realize_draws = !has_ordered_dma && !has_indirect), so
             // the draw is realized by realize_retained_draw — the function this issue is about.
-            // With eager realization active the reason is lost in a DIFFERENT pass that has no
-            // failure channel at all; that is tracked separately and is NOT what this asserts.
+            // With eager realization active the reason is lost in a DIFFERENT pass, whose call
+            // site passes no failures out-parameter; that is tracked separately (#1643) and is NOT
+            // what this asserts.
             no_program.dma_copies.push_back({
                 (uint64_t)(uintptr_t)dma_destination, (uint64_t)(uintptr_t)dma_source,
                 sizeof(dma_destination), 0, 305, 0});
             GpuCaptureFile captured;
             const bool read = run_and_read(no_program, 2102, captured);
             const auto reason = reason_for_draw(captured, 310);
+            // DELIBERATELY WEAK, and it PASSES against the unfixed code: gpu_capture synthesizes an
+            // empty Unknown for any unrealized operation, so "a record exists" proves nothing. Kept
+            // next to the specific assertion below as a standing demonstration of that trap — do not
+            // "tighten" it, and do not treat it as coverage.
             CHECK(read && reason != RealizationFailureReason::None,
                   "#1636: a draw that fails inside realize_draw_item records a failure at all");
             CHECK(read && reason != RealizationFailureReason::Unknown,
@@ -1227,8 +1223,10 @@ int main() {
                   "#1636: an unbound shader program records reason=missing-program");
         }
 
-        // (c) The reason names must round-trip through the capture format. A new enum value that the
-        // validator or the reader still bounds at Filtered would fail the whole capture write.
+        // (c) The new reasons must have names, or gpu_replay --inspect-only prints "unknown" for them
+        // and the fix is invisible exactly where it pays off. (That a new reason survives the capture
+        // validator and reader — which both bounded at Filtered — is proven by case (a) above, which
+        // round-trips IndirectArguments through a real written .prgcap.)
         CHECK(std::string(realization_failure_reason_name(
                   RealizationFailureReason::IndirectArguments)) == "indirect-arguments" &&
               std::string(realization_failure_reason_name(


### PR DESCRIPTION
Fixes #1636

## Failure scenario

`realize_retained_compute` has taken an `OperationRealizationFailure*` since it was written.
`realize_retained_draw` did not — it passed a literal `nullptr` into `realize_draw_item`, which already
computes the reason, the resolved pipeline, the colour targets and the extent. The ordered-submit caller
then discarded the outcome entirely: on `!realized` it simply `break`ed, pushing nothing onto
`capture_trace->failures`.

`gpu_capture.cpp:1248` later noticed an unrealized operation with no diagnostic and synthesized an empty
`Unknown` record. So offline inspection reported `reason=unknown` with empty target, extent and pipeline —
not because the reason was unknowable, but because it had been thrown away. Two lanes hit this today from
different titles and both spent time reconstructing facts prosper already had.

## Contract

A draw that does not realize records **why**, at the point it failed, with whatever pipeline and target
state was resolved before it failed.

## Approach

- `realize_retained_draw` takes an `OperationRealizationFailure*` and forwards it to `realize_draw_item`.
- The caller pushes the record on the `!realized` path.
- The two exits **above** `realize_draw_item` name themselves, because nothing was attempted there and no
  shader/pipeline diagnostic can exist: `IndirectArguments` and `RetainedDrawNotSelected`. Letting them
  fall through to `Unknown` would have looked like a fix while still reporting nothing useful.
- The indirect-dependency / producer-epoch guards for Draw **and** Dispatch already pushed a record but
  hard-coded `Unknown`; they now report `IndirectDependencies`.

### A trap the spec did not cover

Adding enum values is **not** self-contained. `Filtered` was the maximum valid reason and was hard-coded
as a bound in two places — `gpu_capture.cpp:1096` (`validate_failure_diagnostics`) and `:2489` (the
deserializer). A new reason would have failed the **whole capture write** with "invalid failed-operation
diagnostic metadata", then been rejected at read time. Both now use `kMaxRealizationFailureReason`, and
the enum carries an `APPEND ONLY` note pointing at it. `realization_failure_reason_name` gains the new
names, or `gpu_replay --inspect-only` prints `unknown` for them and the fix is invisible exactly where it
is meant to pay off.

Forward-compatibility, stated deliberately: the reason is a raw byte in `.prgcap` and is not version-gated,
so a capture carrying a new reason is rejected by an older `gpu_replay`. Normal for a new enum value.

## Two corrections to the spec, both verified by reading

**1. `RetainedDrawNotSelected` is unreachable from the only caller.** `execute_ordered_gpustate` builds its
executable list with `if (retained_draw_selected(st, i))` (`gpu_executor.cpp:5604`), so a draw failing that
predicate is never enqueued and the first exit is defensive only. I kept the distinct reason — the function
is now a general "why did this draw not realize" answer and a future second caller should not get
`Unknown` — but I do **not** claim test coverage for it, because it cannot be forced from this caller.
`CONFIDENCE: HIGH`.

**2. The reason is discarded in a second place, and it is the more common one.** When
`can_eagerly_realize_draws` is true (no ordered DMA, no indirect — the ordinary case), draws are realized by
`realize_gpustate_draws`, whose call site passes no `failures` out-parameter, so the reason is dropped
there and the caller can only record `Unknown`. (The channel itself exists — an earlier draft of #1643 said
otherwise and has been corrected. Using it also forces the serial path, since `gpu_execute.hpp:1650` gates
parallel realization on `!failures`, so it is a throughput trade-off rather than a plumb-through.) This was measured, not assumed: the regression
test first asserted `missing-program` and got `unknown` for exactly this reason. Filed as **#1643** rather
than widened into this PR, and the test now forces the non-eager path so it asserts what this fix actually
does.

## Affected / unaffected

**Affected:** what is recorded when a draw does not realize; three new `RealizationFailureReason` values and
their names; the two capture bounds.

**One behavioural difference, found in review and stated rather than buried:** `realize_draw_item` calls
`add_stage_diagnostic` unconditionally, so with a capture armed `validate_spirv_descriptor_interface` now
runs per stage per draw including *successful* ones. The only global effect is the mutex-guarded
reflection-cache LRU, and it is confined to the one captured submit — but "purely additive" is not literally
true and should not be read that way.

**Unaffected — explicitly:** **nothing changes whether a draw realizes.** No control flow that decides
realization was touched; every edit either adds a record on a path that already returned `false`, or
replaces a hard-coded `Unknown` with a specific reason on a path that already pushed a record. The failure
pointer is only passed when `capture_trace` is non-null, so a run with no capture armed does the same work
it did before. Compute realization, the eager path's behaviour (#1643), and all existing reasons are
unchanged.

## Risks

- The capture bound change is the one that could bite: if any **other** hard-coded `Filtered` comparison
  exists that I missed, new reasons would be rejected there. I grepped `prosper/src` and `prosper/tools`
  for `RealizationFailureReason::Filtered` and `static_cast<RealizationFailureReason>` and found exactly the
  three sites changed here. `CONFIDENCE: HIGH`.
- The eager-path `else` branch records `Unknown` where previously **nothing** was recorded. The end state is
  identical — `gpu_capture` synthesized the same `Unknown` — so this only moves where it is produced.
- New reasons make captures forward-incompatible with older `gpu_replay` builds, as above.

## Verification (exact head `9fecff38`, distrobox `ps5ys`, `Vulkan found` confirmed)

```
cmake --build prosper/build-linux -j8      # exit 0, no new warnings
ctest -j8                                  # 100% tests passed out of 163
```

Six new assertions in `test_gpu_execute` drive each reachable exit through the real
`execute_ordered_and_present` path and assert the **specific** reason.

**Reverting only `gpu_executor.cpp` to master, with the test unchanged:**

```
[FAIL] #1636: an unresolvable indirect draw records reason=indirect-arguments
[FAIL] #1636: ...and specifically NOT the old synthesized Unknown
[ok]   #1636: a draw that fails inside realize_draw_item records a failure at all
[FAIL] #1636: ...and forwards realize_draw_item's specific reason rather than Unknown
[FAIL] #1636: an unbound shader program records reason=missing-program
[ok]   #1636: the new reasons have names, so gpu_replay --inspect-only can print them
```

Note the third line. **"records a failure at all" passes against the broken code**, because `gpu_capture`
synthesizes the empty `Unknown`. It is in the test deliberately, sitting next to the specific assertion
that does fail, as a standing demonstration of why this test must assert the reason and not merely the
existence of a record — which is the trap the issue warns about.

No log-volume or log-adjacency evidence is used anywhere in this verification: every assertion reads a
structured `.prgcap` field, joined on the draw's explicit `command_order`. (`resolve_indirect_draw_arguments`
and the indirect dispatch logger are capped at 24 and 256 printed lines respectively, so their line counts
are not measurements.)

No snapshot run: nothing here changes rendered output, only what is recorded about draws that produce none.
