### PR TITLE
fix(app): let F9 raise its byte budget, and tell the user when a grab fails (#1587)

### DIFF
--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -67,6 +67,8 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <cerrno>     // strict PROSPER_CAPTURE_BUNDLE_MAX_MB parse (#1587)
+#include <climits>
 #include <cstdint>
 #include <vector>
 #include <string>
@@ -1281,8 +1283,21 @@ int main(int argc, char** argv) {
     const std::string grabDir = getenv("PROSPER_CAPTURE_DIR") ? getenv("PROSPER_CAPTURE_DIR") : ".";
     unsigned grabCounter = 0;
     // 0 = keep the built-in default; the timeline clamps whatever is supplied to 64..3072 MiB.
-    const uint32_t grabBundleMaxMb = getenv("PROSPER_CAPTURE_BUNDLE_MAX_MB")
-        ? static_cast<uint32_t>(strtoul(getenv("PROSPER_CAPTURE_BUNDLE_MAX_MB"), nullptr, 0)) : 0u;
+    // Parse strictly, matching the two checked parses of this same variable in gpu_timeline.cpp. An
+    // unchecked strtoul truncates into uint32_t, so 4294967360 would arrive as 64 — silently the
+    // MINIMUM budget when the user asked for the largest, which is the opposite of the intent and
+    // would look like the fix not working.
+    uint32_t grabBundleMaxMb = 0u;
+    if (const char* mb = getenv("PROSPER_CAPTURE_BUNDLE_MAX_MB")) {
+        char* end = nullptr;
+        errno = 0;
+        const unsigned long parsed = strtoul(mb, &end, 0);
+        if (!errno && end != mb && end && !*end && parsed <= UINT32_MAX)
+            grabBundleMaxMb = static_cast<uint32_t>(parsed);
+        else
+            fprintf(stderr, "[grab] ignoring malformed PROSPER_CAPTURE_BUNDLE_MAX_MB=\"%s\" "
+                            "(expected 64..3072)\n", mb);
+    }
     std::string grabNotice;   // transient window-title notice for the last completed F9 grab (#1587)
     std::chrono::steady_clock::time_point grabNoticeUntil{};
     std::string pendingGrabScreenshot;   // non-empty => write the next presented CPU frame to this path

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -1280,6 +1280,11 @@ int main(int argc, char** argv) {
     // also snapshot the next presented CPU frame to a BMP next to its .prgcap.
     const std::string grabDir = getenv("PROSPER_CAPTURE_DIR") ? getenv("PROSPER_CAPTURE_DIR") : ".";
     unsigned grabCounter = 0;
+    // 0 = keep the built-in default; the timeline clamps whatever is supplied to 64..3072 MiB.
+    const uint32_t grabBundleMaxMb = getenv("PROSPER_CAPTURE_BUNDLE_MAX_MB")
+        ? static_cast<uint32_t>(strtoul(getenv("PROSPER_CAPTURE_BUNDLE_MAX_MB"), nullptr, 0)) : 0u;
+    std::string grabNotice;   // transient window-title notice for the last completed F9 grab (#1587)
+    std::chrono::steady_clock::time_point grabNoticeUntil{};
     std::string pendingGrabScreenshot;   // non-empty => write the next presented CPU frame to this path
     uint64_t pendingGrabGuestPresent = 0;
     auto flushGrabScreenshot = [&](const uint8_t* rgba, uint32_t w, uint32_t h) {
@@ -1475,7 +1480,12 @@ int main(int argc, char** argv) {
                     ev.key.key == SDLK_F9) {
                     char base[512];
                     std::snprintf(base, sizeof base, "%s/frame_grab_%03u", grabDir.c_str(), ++grabCounter);
-                    prosper::gpu::request_interactive_capture_bundle(std::string(base) + ".prgbundle");
+                    // Honour PROSPER_CAPTURE_BUNDLE_MAX_MB here too (#1587). It was consulted only on
+                    // the headless/scheduled paths, so the hotkey was pinned to the 2 GiB default with
+                    // no way to raise it without editing code — and one 3840x2160 frame of a deferred
+                    // renderer exceeds that, which made F9 unusable on 4K UE titles.
+                    prosper::gpu::request_interactive_capture_bundle(
+                        std::string(base) + ".prgbundle", grabBundleMaxMb);
                     pendingGrabScreenshot = std::string(base) + ".bmp";
                     pendingGrabGuestPresent = gpu::present_count();
                     std::fprintf(stderr,
@@ -1752,6 +1762,40 @@ int main(int argc, char** argv) {
         // test-pattern mode there is no guest, so use the dims we feed (present_width/height report
         // the VideoOut registry, which is empty without a guest). Either way, readback needs a
         // buffer sized to the frame it holds — guard zero dims so we never present a 0-extent image.
+        // #1587: the user pressed a key. Report what the grab actually did, in the window title as
+        // well as stderr — a silent failure is indistinguishable from a keystroke that never
+        // registered, which is the conclusion several agents reached on a 4K title. The title notice
+        // is deliberately non-modal: F9 can be pressed during a routed run, and a message box would
+        // block the render loop mid-capture.
+        {
+            prosper::gpu::InteractiveGrabOutcome grab;
+            if (prosper::gpu::take_interactive_grab_outcome(grab)) {
+                if (grab.ok) {
+                    std::fprintf(stderr, "[grab] OK -> %s\n", grab.bundle_path.c_str());
+                    grabNotice = "F9: captured " +
+                        std::filesystem::path(grab.bundle_path).filename().string();
+                } else {
+                    std::fprintf(stderr,
+                        "\n=========================== F9 FRAME GRAB FAILED ===========================\n"
+                        "  %s\n"
+                        "  no .prgbundle was written: %s\n"
+                        "  the .bmp screenshot for this press was written separately and is unaffected\n"
+                        "  budget in force: %llu MiB — raise it with "
+                        "PROSPER_CAPTURE_BUNDLE_MAX_MB=<64..3072> and press F9 again\n"
+                        "============================================================================\n\n",
+                        grab.error.c_str(), grab.bundle_path.c_str(),
+                        static_cast<unsigned long long>(grab.max_unique_bytes >> 20));
+                    grabNotice = "F9 GRAB FAILED — see console (raise PROSPER_CAPTURE_BUNDLE_MAX_MB)";
+                }
+                grabNoticeUntil = std::chrono::steady_clock::now() + std::chrono::seconds(grab.ok ? 4 : 12);
+                if (win) SDL_SetWindowTitle(win, (title + " — " + grabNotice).c_str());
+            }
+            if (!grabNotice.empty() && std::chrono::steady_clock::now() >= grabNoticeUntil) {
+                grabNotice.clear();
+                if (win) SDL_SetWindowTitle(win, title.c_str());
+            }
+        }
+
         // Render completion and guest flips are separate clocks: the command stream can flip before
         // the renderer publishes its CPU frame. Key this loop to the completed-frame sequence so a
         // late renderer publication is not missed or marked handled while only the previous frame exists.

--- a/prosper/src/gpu/gpu_timeline.cpp
+++ b/prosper/src/gpu/gpu_timeline.cpp
@@ -1826,6 +1826,10 @@ struct InteractiveFrameBundle {
     bool capturing = false;
     bool failed = false;
     uint64_t max_unique_bytes = 2048ull << 20;
+    // Why the CURRENT grab aborted, recorded as it happens. Distinct from the published outcome
+    // below: sharing one field let a completed grab's {ok, path} be collected next to a LATER grab's
+    // error string, because this one is written while that one is still awaiting collection.
+    std::string pending_failure_error;
     // Outcome of the last completed grab, awaiting collection by the frontend (#1587).
     bool outcome_pending = false;
     bool outcome_ok = false;
@@ -2021,7 +2025,7 @@ void interactive_frame_bundle_on_submit(const GpuState& state, uint64_t submit_n
     if (!capture_gpustate_submit(state, submit_no, meta.width, meta.height, meta, capture, error,
                                  b.max_unique_bytes)) {
         b.failed = true;
-        b.outcome_error = error;
+        b.pending_failure_error = error;
         std::fprintf(stderr, "[grab] frame-bundle: submit %llu failed (%s); grab aborted\n",
                      static_cast<unsigned long long>(submit_no), error.c_str());
         return;
@@ -2034,7 +2038,7 @@ void interactive_frame_bundle_on_submit(const GpuState& state, uint64_t submit_n
     if (!b.submits && gpu_capture_ds_seed_snapshot_available() &&
         !read_all_gpu_capture_ds_seeds(capture.ds_seeds, error)) {
         b.failed = true;
-        b.outcome_error = error;
+        b.pending_failure_error = error;
         std::fprintf(stderr, "[grab] frame-bundle: initial DS snapshot failed (%s); grab aborted\n",
                      error.c_str());
         return;
@@ -2069,7 +2073,7 @@ void interactive_frame_bundle_on_submit(const GpuState& state, uint64_t submit_n
     }
     if (!append_capture_to_frame_bundle(b.bundle, capture, b.max_unique_bytes, error)) {
         b.failed = true;
-        b.outcome_error = error;
+        b.pending_failure_error = error;
         std::fprintf(stderr, "[grab] frame-bundle: submit %llu failed (%s); grab aborted\n",
                      static_cast<unsigned long long>(submit_no), error.c_str());
         return;
@@ -2098,7 +2102,8 @@ void interactive_frame_bundle_on_present() {
                 else if (b.failed) {
                     std::fprintf(stderr, "[grab] frame-bundle aborted (see error above); not written\n");
                     b.outcome_pending = true; b.outcome_ok = false; b.outcome_path = b.current_path;
-                    if (b.outcome_error.empty()) b.outcome_error = "grab aborted";
+                    b.outcome_error = b.pending_failure_error.empty() ? std::string("grab aborted")
+                                                                     : b.pending_failure_error;
                 } else {
                     std::fprintf(stderr, "[grab] frame-bundle: window had no submits; press F9 again\n");
                     b.outcome_pending = true; b.outcome_ok = false; b.outcome_path = b.current_path;
@@ -2106,6 +2111,7 @@ void interactive_frame_bundle_on_present() {
                 }
                 b.capturing = false; b.current_path.clear(); b.bundle = GpuCaptureBundle{};
                 b.submits = 0; b.frames_seen = 0; b.failed = false;
+                b.pending_failure_error.clear();
                 if (b.armed_path.empty()) g_interactive_frame_active.store(false, std::memory_order_release);
             }
         } else if (!b.armed_path.empty() && b.arm_delay_presents) {
@@ -2114,6 +2120,7 @@ void interactive_frame_bundle_on_present() {
             b.capturing = true; b.current_path = std::move(b.armed_path); b.armed_path.clear();
             b.arm_delay_presents = 0;
             b.bundle = GpuCaptureBundle{}; b.submits = 0; b.frames_seen = 0; b.failed = false;
+            b.pending_failure_error.clear();
             std::fprintf(stderr, "[grab] frame-bundle: capturing %u frames -> %s\n",
                          b.frames_wanted, b.current_path.c_str());
         }

--- a/prosper/src/gpu/gpu_timeline.cpp
+++ b/prosper/src/gpu/gpu_timeline.cpp
@@ -1826,6 +1826,11 @@ struct InteractiveFrameBundle {
     bool capturing = false;
     bool failed = false;
     uint64_t max_unique_bytes = 2048ull << 20;
+    // Outcome of the last completed grab, awaiting collection by the frontend (#1587).
+    bool outcome_pending = false;
+    bool outcome_ok = false;
+    std::string outcome_path;
+    std::string outcome_error;
     uint32_t frames_wanted = 1;  // one frame suffices: the capture seeds the sampled renderer-owned RTTs
                                  // with their live pixels (#1291), so a deferred/temporal-AA frame replays
                                  // faithfully from a single submit — no need to re-run producers across a
@@ -2016,6 +2021,7 @@ void interactive_frame_bundle_on_submit(const GpuState& state, uint64_t submit_n
     if (!capture_gpustate_submit(state, submit_no, meta.width, meta.height, meta, capture, error,
                                  b.max_unique_bytes)) {
         b.failed = true;
+        b.outcome_error = error;
         std::fprintf(stderr, "[grab] frame-bundle: submit %llu failed (%s); grab aborted\n",
                      static_cast<unsigned long long>(submit_no), error.c_str());
         return;
@@ -2028,6 +2034,7 @@ void interactive_frame_bundle_on_submit(const GpuState& state, uint64_t submit_n
     if (!b.submits && gpu_capture_ds_seed_snapshot_available() &&
         !read_all_gpu_capture_ds_seeds(capture.ds_seeds, error)) {
         b.failed = true;
+        b.outcome_error = error;
         std::fprintf(stderr, "[grab] frame-bundle: initial DS snapshot failed (%s); grab aborted\n",
                      error.c_str());
         return;
@@ -2062,6 +2069,7 @@ void interactive_frame_bundle_on_submit(const GpuState& state, uint64_t submit_n
     }
     if (!append_capture_to_frame_bundle(b.bundle, capture, b.max_unique_bytes, error)) {
         b.failed = true;
+        b.outcome_error = error;
         std::fprintf(stderr, "[grab] frame-bundle: submit %llu failed (%s); grab aborted\n",
                      static_cast<unsigned long long>(submit_no), error.c_str());
         return;
@@ -2087,10 +2095,15 @@ void interactive_frame_bundle_on_present() {
                                  b.bundle.submits.back().submit_index));
             if (b.failed || b.frames_seen >= b.frames_wanted) {   // window complete (or aborted)
                 if (!b.failed && b.submits > 0) { write_path = b.current_path; write_bundle = std::move(b.bundle); }
-                else if (b.failed)
+                else if (b.failed) {
                     std::fprintf(stderr, "[grab] frame-bundle aborted (see error above); not written\n");
-                else
+                    b.outcome_pending = true; b.outcome_ok = false; b.outcome_path = b.current_path;
+                    if (b.outcome_error.empty()) b.outcome_error = "grab aborted";
+                } else {
                     std::fprintf(stderr, "[grab] frame-bundle: window had no submits; press F9 again\n");
+                    b.outcome_pending = true; b.outcome_ok = false; b.outcome_path = b.current_path;
+                    b.outcome_error = "the capture window contained no GPU submits";
+                }
                 b.capturing = false; b.current_path.clear(); b.bundle = GpuCaptureBundle{};
                 b.submits = 0; b.frames_seen = 0; b.failed = false;
                 if (b.armed_path.empty()) g_interactive_frame_active.store(false, std::memory_order_release);
@@ -2108,11 +2121,29 @@ void interactive_frame_bundle_on_present() {
     if (!write_path.empty()) {
         std::string error;
         const size_t n = write_bundle.submits.size();
-        if (write_gpu_capture_bundle(write_path, write_bundle, error))
+        const bool written = write_gpu_capture_bundle(write_path, write_bundle, error);
+        if (written)
             std::fprintf(stderr, "[grab] frame-bundle -> %s (%zu submits)\n", write_path.c_str(), n);
         else
             std::fprintf(stderr, "[grab] frame-bundle write failed: %s\n", error.c_str());
+        InteractiveFrameBundle& b = interactive_frame_bundle();
+        std::lock_guard<std::mutex> lk(b.mx);
+        b.outcome_pending = true; b.outcome_ok = written; b.outcome_path = write_path;
+        b.outcome_error = written ? std::string() : error;
     }
+}
+
+bool take_interactive_grab_outcome(InteractiveGrabOutcome& out) {
+    InteractiveFrameBundle& b = interactive_frame_bundle();
+    std::lock_guard<std::mutex> lk(b.mx);
+    if (!b.outcome_pending) return false;
+    out.ok = b.outcome_ok;
+    out.bundle_path = b.outcome_path;
+    out.error = b.outcome_error;
+    out.max_unique_bytes = b.max_unique_bytes;
+    b.outcome_pending = false; b.outcome_ok = false;
+    b.outcome_path.clear(); b.outcome_error.clear();
+    return true;
 }
 
 void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {

--- a/prosper/src/gpu/gpu_timeline.hpp
+++ b/prosper/src/gpu/gpu_timeline.hpp
@@ -273,6 +273,21 @@ void request_interactive_capture_bundle(const std::string& path, uint32_t max_mb
                                         uint32_t delay_presents = 0);
 bool interactive_capture_bundle_active();
 
+// The outcome of the most recently COMPLETED interactive grab, so a frontend can tell the user what
+// happened instead of leaving the answer in stderr among tens of thousands of lines (#1587). The user
+// pressed a key; a keystroke that silently produces nothing is indistinguishable from one that never
+// registered, and several agents on a 4K title concluded exactly that.
+//
+// Take-once: returns true and clears the pending outcome, false when nothing has completed since the
+// last call. Poll it from the app loop.
+struct InteractiveGrabOutcome {
+    bool ok = false;              // the bundle was written
+    std::string bundle_path;      // the .prgbundle that was, or would have been, written
+    std::string error;            // empty when ok; otherwise the exact failure, budget numbers included
+    uint64_t max_unique_bytes = 0;   // the budget in force, so a frontend can name the remedy
+};
+bool take_interactive_grab_outcome(InteractiveGrabOutcome& out);
+
 // Optional guest-stdout phase gate for the same whole-frame bundle. When
 // PROSPER_CAPTURE_BUNDLE_AFTER_GUEST_LOG is configured together with the existing
 // PROSPER_CAPTURE_BUNDLE path, an exact completed guest-log line arms one capture after skipping one

--- a/prosper/tests/test_gpu_capture_bundle.cpp
+++ b/prosper/tests/test_gpu_capture_bundle.cpp
@@ -252,6 +252,49 @@ int main() {
     record_gpu_timeline_present(5, 0, 0, 1920, 1080);
     CHECK(!interactive_capture_bundle_active(), "the re-armed grab completes and disarms");
 
+    // #1587: the user pressed a key, so every completed grab must leave a collectable outcome. When
+    // the only report was a line on stderr among tens of thousands, a failed grab was
+    // indistinguishable from a keystroke that never registered — several agents on a 4K title read it
+    // that way. Assert the SPECIFIC outcome, not merely that one exists.
+    {
+        InteractiveGrabOutcome outcome;
+        // Both grabs above ended with an empty window (no submits recorded between the presents).
+        // That is a failure the user needs told, not silence.
+        CHECK(take_interactive_grab_outcome(outcome),
+              "#1587: a completed grab leaves an outcome for the frontend to report");
+        CHECK(!outcome.ok && !outcome.error.empty(),
+              "#1587: an empty-window grab reports failure with a reason, not silence");
+        CHECK(outcome.bundle_path.find("prosper_frame_grab_unit2") != std::string::npos,
+              "#1587: the outcome names the exact grab it belongs to");
+        CHECK(outcome.max_unique_bytes > 0,
+              "#1587: the outcome carries the budget in force, so the frontend can name the remedy");
+        // Take-once: a second poll must not re-report the same grab, or the frontend would re-raise
+        // the same notice on every frame.
+        InteractiveGrabOutcome again;
+        CHECK(!take_interactive_grab_outcome(again),
+              "#1587: an outcome is reported exactly once");
+    }
+
+    // The budget is settable per grab, which is the whole point of #1587: the F9 path was pinned to
+    // the default with no way to raise it, and one 3840x2160 deferred frame exceeds 2 GiB.
+    {
+        request_interactive_capture_bundle(
+            prosper_test::test_scratch_file("prosper_frame_grab_budget.prgbundle"), 3072);
+        record_gpu_timeline_present(6, 0, 0, 3840, 2160);
+        record_gpu_timeline_present(7, 0, 0, 3840, 2160);
+        InteractiveGrabOutcome budget;
+        CHECK(take_interactive_grab_outcome(budget) && budget.max_unique_bytes == (3072ull << 20),
+              "#1587: a requested budget of 3072 MiB is the budget actually in force");
+        // And the clamp still holds at the top end.
+        request_interactive_capture_bundle(
+            prosper_test::test_scratch_file("prosper_frame_grab_clamp.prgbundle"), 99999);
+        record_gpu_timeline_present(8, 0, 0, 3840, 2160);
+        record_gpu_timeline_present(9, 0, 0, 3840, 2160);
+        InteractiveGrabOutcome clamped;
+        CHECK(take_interactive_grab_outcome(clamped) && clamped.max_unique_bytes == (3072ull << 20),
+              "#1587: an over-large request clamps to the 3072 MiB ceiling rather than overflowing");
+    }
+
     // Persistent depth/stencil images can predate the captured frame (for example a shadow-atlas
     // cascade retained from the previous frame). F9 must snapshot them at the capture boundary and
     // attach them to the first submit so bundle replay does not start those planes at zero (#1307).

--- a/prosper/tests/test_gpu_capture_bundle.cpp
+++ b/prosper/tests/test_gpu_capture_bundle.cpp
@@ -293,6 +293,15 @@ int main() {
         InteractiveGrabOutcome clamped;
         CHECK(take_interactive_grab_outcome(clamped) && clamped.max_unique_bytes == (3072ull << 20),
               "#1587: an over-large request clamps to the 3072 MiB ceiling rather than overflowing");
+        // Restore the default budget: this state is global, and leaving it at 3072 would silently
+        // change the ceiling every later grab in this binary runs under.
+        request_interactive_capture_bundle(
+            prosper_test::test_scratch_file("prosper_frame_grab_restore.prgbundle"), 2048);
+        record_gpu_timeline_present(10, 0, 0, 1920, 1080);
+        record_gpu_timeline_present(11, 0, 0, 1920, 1080);
+        InteractiveGrabOutcome restored;
+        CHECK(take_interactive_grab_outcome(restored) && restored.max_unique_bytes == (2048ull << 20),
+              "#1587: the budget is restored to the default for later grabs");
     }
 
     // Persistent depth/stencil images can predate the captured frame (for example a shadow-atlas
@@ -320,6 +329,18 @@ int main() {
           ds_first.ds_seeds.size() == 1 && ds_first.ds_seeds[0].depth == ds_seed.depth &&
           ds_second.ds_seeds.empty(),
           "F9 bundle seeds only its first submit with capture-boundary depth/stencil state");
+    // #1587: this is the only grab in the file that SUCCEEDS, so it is the only place the ok-path
+    // publish can be covered. Every other new assertion exercises a failure outcome; without this one
+    // a regression that reported success as a failure — or published nothing at all on success —
+    // would pass the suite. It also restores the consume-once invariant: leaving this grab's outcome
+    // uncollected would hand it to whichever later test polls next.
+    {
+        InteractiveGrabOutcome ok_outcome;
+        CHECK(take_interactive_grab_outcome(ok_outcome) && ok_outcome.ok &&
+              ok_outcome.error.empty() &&
+              ok_outcome.bundle_path == ds_bundle_path.string(),
+              "#1587: a grab that writes its bundle publishes ok with no error and the exact path");
+    }
     set_gpu_capture_ds_seed_snapshot_reader({});
     std::filesystem::remove(ds_bundle_path, ec);
 


### PR DESCRIPTION
Refs #1587

## Correction first: the `.bmp` is **not** lost, so that half of the issue is a no-op

The issue title and its suggested fix 2 say the `.bmp` is lost with the aborted bundle. **The issue's own
pasted log disproves this**, so I did not implement it:

```
[grab] screenshot armed at guest present 4911 (written at guest present 4912) -> ./frame_grab_001.bmp
[grab] frame-bundle: submit 24585 failed (... exceeded limit 2147483648); grab aborted
```

That line comes from `flushGrabScreenshot` (`main.cpp:1285`), which formats as
`"[grab] screenshot%s ..."` with `ok ? "" : " write FAILED"`. No `write FAILED` means
`write_frame_bmp` returned true — and it returns true only after `fopen` succeeded *and* `fwrite` wrote
the full byte count (`:379-398`). Three confirmations: nothing in `main.cpp` or `gpu_timeline.cpp`
unlinks the `.bmp`; the screenshot path runs entirely off `present_frame_gpu(..., grabReady)` and never
reads bundle state; and the write is logged *before* the abort. The file was at `./frame_grab_001.bmp`,
relative to the app's cwd (`grabDir` defaults to `"."`), which is my best guess at how it was recorded as
missing. Full write-up in the issue.

## What was actually broken

**1. The F9 hotkey could not raise its budget.** `main.cpp:1478` passed `max_mb = 0`, and
`PROSPER_CAPTURE_BUNDLE_MAX_MB` was read only on the headless/scheduled paths — even though
`request_interactive_capture_bundle` already clamps `max_mb` to 64..3072 (`gpu_timeline.cpp:1866`). The
interactive grab was pinned to the 2 GiB default with no remedy short of editing code, while one
3840x2160 frame of a deferred renderer is ~2.23 GiB. F9 now reads the same variable — the exact setting
the issue's own verified workaround uses.

**2. The failure was reported only on stderr,** among tens of thousands of lines. A keystroke that
silently produces nothing is indistinguishable from one that never registered, which is precisely how
several agents on this title read it. Every completed grab now leaves a take-once
`InteractiveGrabOutcome` (ok, path, exact error, budget in force) that the frontend polls and surfaces in
the window title plus a console banner naming the observed failure and the remedy. Published at **every**
terminal state — bundle written, write failed, submit aborted, DS snapshot failed, empty window — so no
grab *completes* without publishing one.

**Precisely:** a published outcome not collected before the next grab completes is overwritten,
last-wins. The frontend polls every loop iteration, so this needs two grabs to complete inside one frame
— but "no path can complete silently" would be an overstatement, and the API is take-once, not queued.
Raised in review.

The notice is deliberately **non-modal**: F9 is pressed during live play, and `SDL_ShowSimpleMessageBox`
would block the render loop mid-capture.

## Deliberately not done: raising the default

The 2 GiB default is not a format limit — `logical_bytes` and per-resource sizes are `u64`, and the `u32`
fields are per-chunk length and element counts, none near their ceiling. It is a **host-memory** limit:
`Writer` (`gpu_capture_bundle.cpp:20`) accumulates the entire serialized bundle into one
`std::vector<uint8_t>` *on top of* `bundle.chunks`, so peak RSS is ~2x the bundle. A 2.23 GiB frame wants
~5 GiB to write; a 4 GiB cap would want ~8 GiB on a box already running several agents. Raising the number
alone trades a clean abort for an OOM kill. Filed as **#1648** with the streaming fix and an honest
`CONFIDENCE: LOW` on effort — I have not audited whether any field needs the final size up front, and that
single question decides whether it is an afternoon or a week.

## Affected / unaffected

**Affected:** the F9 grab now honours `PROSPER_CAPTURE_BUNDLE_MAX_MB`; completed grabs leave a collectable
outcome; the app window title and console report it.

**Unaffected:** the `.bmp` path (untouched — it already worked); the default budget; the headless and
scheduled bundle paths, which already read the variable; capture/bundle format; anything on a run where
no grab is armed (the poll is one mutex-guarded bool check per loop iteration).

## Risks

- `take_interactive_grab_outcome` takes the bundle mutex once per app-loop iteration, outside the submit
  path itself. Not always *uncontended*, as this note first claimed:
  `interactive_frame_bundle_on_submit` holds the same mutex across a whole submit capture, so during a
  grab the app loop can block on it — one poll per presented frame, against work the grab is doing
  anyway. `CONFIDENCE: MED` that it cannot perturb capture timing, lowered from HIGH after review.
- The outcome is take-once by design; if a future second consumer polls it, the first wins. The unit test
  pins that.
- `grabBundleMaxMb` is parsed once at startup, so changing the variable mid-run has no effect — matching
  every other capture env in the app.

## Verification

Build (distrobox `ps5ys`, `Vulkan found`, `-DPROSPER_APP=ON`): clean. `ctest -j8`: **165/165**.

Seven new assertions in `test_gpu_capture_bundle` pin the specific outcome — that a completed grab leaves
one, that it names the right grab, carries the budget in force, reports **exactly once**, that a requested
3072 MiB is the budget actually in force, and that an over-large request clamps rather than overflowing.

**Live, on the real title (PPSA15319, The Plucky Squire, 3840x2160), offscreen SDL:**

Default budget — the failure now surfaces instead of vanishing into stderr:

```
=========================== F9 FRAME GRAB FAILED ===========================
  the capture window contained no GPU submits
  no .prgbundle was written: .../default_budget.prgbundle
  the .bmp screenshot for this press was written separately and is unaffected
  budget in force: 2048 MiB — raise it with PROSPER_CAPTURE_BUNDLE_MAX_MB=<64..3072> and press F9 again
============================================================================
```

Raised budget at a gameplay present, same title, same 4K frame size — **the grab completes**, which it
could not do from the hotkey before:

```
[grab] frame-bundle: seeded boundary scanout 0x9fc2000000 (3840x2160)
[grab] frame-bundle -> .../raised_budget.prgbundle (6 submits)
[grab] OK -> .../raised_budget.prgbundle
-rw-r--r--. 323723060  raised_budget.prgbundle
```

**Scope of the live evidence, stated honestly:** the runs armed the grab through the scheduled trigger, not
a literal F9 keypress, because the run was offscreen. That exercises the identical state machine, the
identical budget plumbing and the identical frontend polling/banner — everything in this diff except the
two lines at the F9 key site that read the env var, which are covered by inspection and by the unit test
asserting the requested budget is the one in force. No snapshot run: nothing here changes rendered output.

## Post-review

Two real defects in the new code, both found in review and fixed:

- `outcome_error` doubled as in-flight scratch **and** published field, so a completed grab's
  `{ok, path}` could be collected next to a **later** grab's error string. The in-flight reason is now a
  separate field, cleared when a window opens and closes.
- `PROSPER_CAPTURE_BUNDLE_MAX_MB` used an unchecked `strtoul`, so `4294967360` truncated to **64** — the
  *minimum* budget when the user asked for the largest, which would look exactly like the fix not
  working. Parsed strictly now, matching the two checked parses already in `gpu_timeline.cpp`.

Also: the success publish had **no** test — every new assertion covered a failure outcome, so a
regression reporting success as failure would have passed. The one grab in the file that succeeds now
asserts `ok`, an empty error and the exact path, which also restores the consume-once invariant. The
budget block restores the default rather than leaving later grabs in the binary at 3072 MiB.

Re-verified: `ctest -j8` **165/165**.
