### PR TITLE
fix(agc): probe PatchSetNumRegisters packets with the WRITE predicate

### DIFF
--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -1791,17 +1791,26 @@ static uint64_t patch_set_num_registers(uint64_t cmd_addr, uint64_t num, uint32_
                                         const char* who) {
     auto* cmd = (uint32_t*)(uintptr_t)cmd_addr; if (!cmd) return 0;
     // These NIDs previously reached prosper_on_unimpl and touched nothing, so this is a NEW guest
-    // dereference on a path that used to be inert. Probe the packet header before reading it: a
-    // caller passing a freed or never-built packet must not take the host down (the sibling
-    // patchers predate this guard; see the follow-up issue).
-    if (!gpu::guest_readable(cmd_addr, 2 * sizeof(uint32_t))) {
+    // dereference AND a new guest STORE on a path that used to be inert. The probe must therefore be
+    // the WRITE predicate: guest_readable would pass a read-only mapping (on Linux/macOS it probes
+    // by having the kernel read the byte, and on Windows it explicitly accepts PAGE_READONLY /
+    // PAGE_WRITECOPY / PAGE_EXECUTE_READ), and the store below would then fault on a page the probe
+    // just called fine — the module's own .text/.rodata are large read-only mappings in this same
+    // address space. guest_writable covers the freed/unmapped case as well.
+    //
+    // COST CAVEAT, do not copy this call verbatim onto a hot path: guest_writable is UNCACHED, and
+    // on Linux it fopen()s and parses /proc/self/maps on every call — unlike guest_readable, which
+    // has a thread-local range cache. That is harmless here because no measured title calls these
+    // NIDs at all, but the sibling patchers (#1650) run per draw on Blue Prince, and tightening
+    // those needs a cached predicate rather than this one.
+    if (!gpu::guest_writable(cmd_addr, 2 * sizeof(uint32_t))) {
         static std::atomic<int> n{0};
         if (n.fetch_add(1) < 8)
-            fprintf(stderr, "[agc] %s: packet 0x%llx unmapped — patch skipped\n", who,
+            fprintf(stderr, "[agc] %s: packet 0x%llx not writable — patch skipped\n", who,
                     (unsigned long long)cmd_addr);
         return 0;
     }
-    // Report BEFORE the sub-op check, and report the refusal too: an investigation into a wrong
+    // Report before the early return, and report the refusal too: an investigation into a wrong
     // register count most wants the case where the patch did not land.
     static const bool regbloat = getenv("PROSPER_REGBLOAT") != nullptr;
     const bool ok = patch_check(cmd, want_r, who);


### PR DESCRIPTION
Follow-up to #1637 (merged as `26d189a0`), fixing a blocking finding from its round-2 review that
landed after the merge.

## The defect

#1637 guarded its new packet dereference with `gpu::guest_readable`. That is a **read** predicate,
and the function **writes**:

```cpp
if (!gpu::guest_readable(cmd_addr, 2 * sizeof(uint32_t))) return 0;   // proves cmd[1] is READABLE
...
cmd[1] = (uint32_t)num;                                                // ...then STORES to it
```

A **read-only mapping passes the probe and then SIGSEGVs on the store** — precisely what the comment
claimed the probe prevented:

* **Linux/macOS** — `guest_readable`'s `probe_byte` is `write(pipe_fd, addr, 1)`, so the *kernel*
  reads the byte and a `PROT_READ`-only page succeeds.
* **Windows** — `guest_readable` explicitly accepts `PAGE_READONLY`, `PAGE_WRITECOPY` and
  `PAGE_EXECUTE_READ`, and its lazy commit calls `prosper_try_commit_dmem(..., write=0)`.

The module's own `.text`/`.rodata` are large read-only mappings in the same address space, so a stray
packet pointer landing in one is not far-fetched.

## The fix

`gpu::guest_writable` already exists (`gpu_execute.hpp`), is implemented for Win32/Darwin/Linux, and
is already used a few hundred lines away in this same file (`agc_build_interpolant_mapping`). One
identifier. It covers the freed/unmapped case as well, so nothing is lost.

## Severity — latent, not active

**No measured title calls these NIDs.** A 460 s Nikoderiko (`PPSA23760`) boot through gameplay logs
no unimplemented hit for `nCUgItdN2ms`, and the same was true of every dump checked. So this could
not have faulted anything today.

That does not make it optional. A comment asserting a safety property the predicate does not provide
is the same class of defect as an overclaim, and it was on master where the next reader would trust
it — including whoever takes #1650 and reaches for the nearest example.

## Cost caveat, carried to the call site

`guest_writable` is **uncached**, and on Linux it `fopen`s and parses `/proc/self/maps` on **every
call** — unlike `guest_readable`, which has a thread-local range cache. Harmless here because nothing
calls these NIDs, but it **must not be copied verbatim onto the sibling patchers** in #1650, which
Blue Prince hits per draw. That warning now sits next to the call site, not only in the issue.

## Also folded in

The neighbouring comment said "Report BEFORE the sub-op check"; `patch_check` actually runs first, so
it now reads "before the early return". The skip message says "not writable" rather than "unmapped".

## Affected / unaffected

* Affected: the three `PatchSetNumRegisters` handlers' probe, and two comments.
* Unaffected: the patch semantics, the sub-op check, the tests, every other AGC path.

## Verification (exact head `e16c11fa`, Linux, ps5ys distrobox)

```
cmake -S prosper -B prosper/build-linux -G Ninja -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0
cmake --build prosper/build-linux -j8      # clean
ctest                                       # 100% tests passed, 165/165, 16.87 s
```

`test_agc_dcb`'s six `PatchSetNumRegisters` cases still pass, including the wrong-class refusal.

Refs #305, refs #1650
