### PR TITLE
fix(hle): implement sceKernelAprSubmitCommandBuffer, and correct its sibling's name (#1629)

### DIFF
--- a/prosper/docs/UE4_APR_IOSTORE_BRINGUP.md
+++ b/prosper/docs/UE4_APR_IOSTORE_BRINGUP.md
@@ -452,7 +452,9 @@ disassembly (all offsets eboot-relative):
      async read: exactly the GlobalShaderCache region of pakchunk0-ps5.pak (fileId from APR
      resolve). Implemented as `f_apr_read_direct` in hle_file.cpp (pread + lazy-commit dst write +
      completion token/event).
-   - `libkernel::ASoW5WE-UPo (cb, ring_1based, u64* out1, u64* out2)` — the APR **submit**
+   - `libkernel::ASoW5WE-UPo (cb, ring_1based, u64* out1, u64* out2)` —
+     `sceKernelAprSubmitCommandBufferAndGetResult` (name from the 3.20 firmware database, #1629;
+     earlier notes called this "the APR submit", which is the *sibling* `eE4Szl8sil8`) — the APR **submit**
      (wrapper +0x59b6420 → thunk +0x669afd0; the completion handler resubmits queued CBs with
      `ring = (data>>58)+1`, proving 1-based). Nonzero return = error (checked at +0x22a1d55);
      the completion token is returned through the OUT slots. Implemented as `k_apr_submit`.

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -4735,8 +4735,8 @@ void register_kernel_mem_hle() {
                      "sceKernelAprSubmitCommandBufferAndGetResult");
     // The Windows Ampr submit resets the command buffer and writes nothing, which satisfies the plain
     // form's contract exactly. It is NOT equivalent to the POSIX handler in general: the token,
-    // binding and equeue-post machinery is POSIX-only, so Windows keeps that pre-existing gap for
-    // BOTH forms. This change does not widen it — it strictly adds a previously-missing entry point.
+    // binding and equeue-post machinery is POSIX-only, so AndGetResult returns success here without
+    // publishing a token. Pre-existing, not widened by this change, and tracked as #1657.
     // The _TEST-suffixed NIDs are deliberately left unimplemented — see the POSIX block for why.
     Hle::register_fn("eE4Szl8sil8", (HleFn)k_ampr_submit, "sceKernelAprSubmitCommandBuffer");
     Hle::register_fn("GnxKOHEawhk", (HleFn)k_ampr_get_current_offset,

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -1668,6 +1668,15 @@ HLE(k_apr_submit) {   // sceKernelAprSubmitCommandBufferAndGetResult (cb, ring_1
 // system (cri_ware_unity.prx) drives its reads through this one, and the default success stub left the
 // command buffer unconsumed so the guest's read never completed (#1629).
 HLE(k_apr_submit_plain) {
+    // Log the caller's real a2/a3 before discarding them. The firmware database gives this entry
+    // point's NAME but not its signature, so its arity is CONFIDENCE: MED — and these two values are
+    // precisely the evidence that would settle it. If they are ever consistently valid, aligned guest
+    // pointers across a run, the plain form has out-parameters after all and this handler is wrong.
+    if (amprlog())
+        fprintf(stderr, "[amprlog] AprSubmit(plain) eE4Szl8sil8 cb=0x%llx ring1b=%llu "
+                        "unused_a2=0x%llx unused_a3=0x%llx (discarded: no result slots)\n",
+                (unsigned long long)a0, (unsigned long long)a1,
+                (unsigned long long)a2, (unsigned long long)a3);
     return apr_submit_common(a0, a1, /*out1=*/0, /*out2=*/0, /*write_result_outputs=*/false);
 }
 // sceAmprCommandBufferGetCurrentOffset: byte cursor after the commands appended since construction,
@@ -4724,7 +4733,10 @@ void register_kernel_mem_hle() {
                      "sceAmprCommandBufferWriteKernelEventQueueOnCompletion");
     Hle::register_fn("ASoW5WE-UPo", (HleFn)k_ampr_submit,
                      "sceKernelAprSubmitCommandBufferAndGetResult");
-    // The Windows Ampr submit already writes no result slots, so it is the plain form unchanged.
+    // The Windows Ampr submit resets the command buffer and writes nothing, which satisfies the plain
+    // form's contract exactly. It is NOT equivalent to the POSIX handler in general: the token,
+    // binding and equeue-post machinery is POSIX-only, so Windows keeps that pre-existing gap for
+    // BOTH forms. This change does not widen it — it strictly adds a previously-missing entry point.
     // The _TEST-suffixed NIDs are deliberately left unimplemented — see the POSIX block for why.
     Hle::register_fn("eE4Szl8sil8", (HleFn)k_ampr_submit, "sceKernelAprSubmitCommandBuffer");
     Hle::register_fn("GnxKOHEawhk", (HleFn)k_ampr_get_current_offset,

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -1607,7 +1607,18 @@ HLE(k_apr_cb_set_equeue) {       // H896Pt-yB4I: legacy eager path keeps zero us
 HLE(k_apr_cb_set_equeue_320) {   // o67gODLFpls: PS5 3.20 0x20-byte completion command
     return apr_cb_set_equeue(0x20, true, a0, a1, a2, a3, a4, a5);
 }
-HLE(k_apr_submit) {              // libkernel ASoW5WE-UPo (cb, ring_1based, out1, out2)
+// Shared body of the APR submit family. `write_result_outputs` distinguishes the two entry points
+// the 3.20 firmware database actually names (#1629):
+//
+//   sceKernelAprSubmitCommandBufferAndGetResult  ASoW5WE-UPo, 0ers1N4C9CY   (cb, ring, out1, out2)
+//   sceKernelAprSubmitCommandBuffer              eE4Szl8sil8, Omr9X+YmT7I   (cb, ring)
+//
+// The plain form has NO result out-parameters, so a2/a3 hold whatever the caller's registers happened
+// to contain. Writing a token through those would be writing through residue — and this file already
+// documents that a nonzero value landing in a request's completion record marks the read FAILED
+// (eboot+0x22738a5). That is why the plain variant is a separate entry rather than an alias.
+static uint64_t apr_submit_common(uint64_t a0, uint64_t a1, uint64_t a2, uint64_t a3,
+                                  bool write_result_outputs) {
     unsigned ring = a1 ? (unsigned)(a1 - 1) & 0x3f : 0;
     // Completion-token contract (issues #180/#208 — guest submit path eboot+0x22a02b0, handler
     // +0x229dcb0, listener +0x22740b0, listener-ctx ctor +0x22a0670; full write-up in
@@ -1632,11 +1643,12 @@ HLE(k_apr_submit) {              // libkernel ASoW5WE-UPo (cb, ring_1based, out1
     const bool bound = apr_cb_submit_state(a0, &bc, &should_post);
     const bool tag_echo = bound && bc.tag && bc.eq;
     uint64_t token = tag_echo ? bc.tag : prosper_apr_next_token(ring);
-    if (!bound) {
+    if (!bound && write_result_outputs) {
         if (a2 > 0xffff) *(uint64_t*)(uintptr_t)a2 = token;
         if (a3 > 0xffff) *(uint64_t*)(uintptr_t)a3 = token;
     }
-    if (amprlog()) fprintf(stderr, "[amprlog] ASoW5WE-UPo(Submit) cb=0x%llx ring1b=%llu out1=0x%llx out2=0x%llx -> token=0x%llx%s%s\n",
+    if (amprlog()) fprintf(stderr, "[amprlog] AprSubmit%s cb=0x%llx ring1b=%llu out1=0x%llx out2=0x%llx -> token=0x%llx%s%s\n",
+                           write_result_outputs ? "AndGetResult" : "",
                            (unsigned long long)a0, (unsigned long long)a1,
                            (unsigned long long)a2, (unsigned long long)a3, (unsigned long long)token,
                            bound ? " (bound)" : "", apr_req_eventful(a0) ? " (arg8-async)" : "");
@@ -1647,6 +1659,16 @@ HLE(k_apr_submit) {              // libkernel ASoW5WE-UPo (cb, ring_1based, out1
     // cursor even though the fixed capacity remains attached to the command-buffer object.
     ampr_cb_reset(a0);
     return 0;
+}
+
+HLE(k_apr_submit) {   // sceKernelAprSubmitCommandBufferAndGetResult (cb, ring_1based, out1, out2)
+    return apr_submit_common(a0, a1, a2, a3, /*write_result_outputs=*/true);
+}
+// sceKernelAprSubmitCommandBuffer (cb, ring_1based). Same submit, no result slots — CRI ADX2's file
+// system (cri_ware_unity.prx) drives its reads through this one, and the default success stub left the
+// command buffer unconsumed so the guest's read never completed (#1629).
+HLE(k_apr_submit_plain) {
+    return apr_submit_common(a0, a1, /*out1=*/0, /*out2=*/0, /*write_result_outputs=*/false);
 }
 // sceAmprCommandBufferGetCurrentOffset: byte cursor after the commands appended since construction,
 // reset, or clear. Pathless uses this with GetSize to decide when an IoStore batch must be submitted.
@@ -1960,7 +1982,20 @@ void register_kernel_mem_hle() {
     Hle::register_fn("H896Pt-yB4I", (HleFn)k_apr_cb_set_equeue, "AprCbSetEventQueue?");
     Hle::register_fn("o67gODLFpls", (HleFn)k_apr_cb_set_equeue_320,
                      "sceAmprCommandBufferWriteKernelEventQueueOnCompletion");
-    Hle::register_fn("ASoW5WE-UPo", (HleFn)k_apr_submit,        "AprSubmitCommandBuffer?");
+    // Names from the PS5 3.20 firmware export database, which corrects a guess: ASoW5WE-UPo is
+    // sceKernelAprSubmitCommandBufferAndGetResult, NOT the plain submit prosper had labelled it (#1629).
+    //
+    // Deliberately NOT registered: Omr9X+YmT7I and 0ers1N4C9CY. They look like alias NIDs of these two
+    // names and are not — the database resolves them to sceKernelAprSubmitCommandBuffer_TEST and
+    // ...AndGetResult_TEST, separate exports whose behaviour is not observable from any title evidence
+    // prosper has. Binding them to the production handlers would be inventing semantics for a debug
+    // entry point. They stay unimplemented, which is fail-visible, rather than silently doing a real
+    // submit. (Caution for the next reader: a `__ptr_sceKernelApr[A-Za-z]*` grep truncates at the
+    // underscore and makes these look like plain aliases. Match [A-Za-z0-9_]* instead.)
+    Hle::register_fn("ASoW5WE-UPo", (HleFn)k_apr_submit,
+                     "sceKernelAprSubmitCommandBufferAndGetResult");
+    Hle::register_fn("eE4Szl8sil8", (HleFn)k_apr_submit_plain,
+                     "sceKernelAprSubmitCommandBuffer");
     Hle::register_fn("GnxKOHEawhk", (HleFn)k_ampr_get_current_offset,
                      "sceAmprCommandBufferGetCurrentOffset");
     Hle::register_fn("4fgtGfXDrFc", (HleFn)k_ampr_measure_write_address,
@@ -4687,7 +4722,11 @@ void register_kernel_mem_hle() {
     Hle::register_fn("H896Pt-yB4I", (HleFn)k_ampr_append_equeue_legacy, "AprCbSetEventQueue?");
     Hle::register_fn("o67gODLFpls", (HleFn)k_ampr_append_equeue_320,
                      "sceAmprCommandBufferWriteKernelEventQueueOnCompletion");
-    Hle::register_fn("ASoW5WE-UPo", (HleFn)k_ampr_submit, "AprSubmitCommandBuffer?");
+    Hle::register_fn("ASoW5WE-UPo", (HleFn)k_ampr_submit,
+                     "sceKernelAprSubmitCommandBufferAndGetResult");
+    // The Windows Ampr submit already writes no result slots, so it is the plain form unchanged.
+    // The _TEST-suffixed NIDs are deliberately left unimplemented — see the POSIX block for why.
+    Hle::register_fn("eE4Szl8sil8", (HleFn)k_ampr_submit, "sceKernelAprSubmitCommandBuffer");
     Hle::register_fn("GnxKOHEawhk", (HleFn)k_ampr_get_current_offset,
                      "sceAmprCommandBufferGetCurrentOffset");
     Hle::register_fn("4fgtGfXDrFc", (HleFn)k_ampr_measure_write_address,

--- a/prosper/tests/test_apr_registry.cpp
+++ b/prosper/tests/test_apr_registry.cpp
@@ -405,10 +405,16 @@ int main() {
               "#1629: sceKernelAprSubmitCommandBuffer (eE4Szl8sil8) resolves to a real handler");
         CHECK(submit_result_a != nullptr,
               "#1629: sceKernelAprSubmitCommandBufferAndGetResult (ASoW5WE-UPo) still resolves");
+#ifndef _WIN32
+        // POSIX only. On Windows both NIDs share k_ampr_submit, which resets the command buffer and
+        // writes nothing — the token/event machinery this distinction is about is POSIX-only, so the
+        // two forms are legitimately the same handler there and these assertions would fail on the
+        // windows-mingw CI job rather than catching a defect.
         // Both halves required: before #1629 the plain NID resolved to nothing, so a bare "these
         // differ" comparison passed vacuously against nullptr.
         CHECK(submit_plain && submit_result_a && submit_plain != submit_result_a,
               "#1629: the plain submit exists AND is not an alias of the AndGetResult form");
+#endif
         // The _TEST-suffixed exports must stay unimplemented. They are NOT alias NIDs of the two
         // names above — the firmware database resolves them to sceKernelAprSubmitCommandBuffer_TEST
         // and ...AndGetResult_TEST — and binding a debug entry point to a production handler would be
@@ -424,17 +430,21 @@ int main() {
         alignas(64) uint8_t fake_cb[256] = {};
         const uint64_t cb = (uint64_t)(uintptr_t)fake_cb;
 
+#ifndef _WIN32
         if (submit_result_a) {
             out1 = out2 = kResidue;
             submit_result_a(cb, 1, (uint64_t)(uintptr_t)&out1, (uint64_t)(uintptr_t)&out2, 0, 0);
             CHECK(out1 != kResidue && out2 != kResidue && out1 == out2,
                   "#1629: AndGetResult still publishes one completion token through both out slots");
         }
+#endif
         if (submit_plain) {
             out1 = out2 = kResidue;
             // Exactly the call the plain form receives: whatever happens to be in the argument
             // registers. If the handler treated them as out-pointers it would clobber them.
             submit_plain(cb, 1, (uint64_t)(uintptr_t)&out1, (uint64_t)(uintptr_t)&out2, 0, 0);
+            // Holds on BOTH platforms and is the property that actually matters, so it is not
+            // guarded: POSIX suppresses the writes deliberately, Windows never had them.
             CHECK(out1 == kResidue && out2 == kResidue,
                   "#1629: the plain submit writes NO result slots — a2/a3 are residue, not outputs");
         }

--- a/prosper/tests/test_apr_registry.cpp
+++ b/prosper/tests/test_apr_registry.cpp
@@ -406,10 +406,13 @@ int main() {
         CHECK(submit_result_a != nullptr,
               "#1629: sceKernelAprSubmitCommandBufferAndGetResult (ASoW5WE-UPo) still resolves");
 #ifndef _WIN32
-        // POSIX only. On Windows both NIDs share k_ampr_submit, which resets the command buffer and
-        // writes nothing — the token/event machinery this distinction is about is POSIX-only, so the
-        // two forms are legitimately the same handler there and these assertions would fail on the
-        // windows-mingw CI job rather than catching a defect.
+        // POSIX only, and this guard hides a REAL gap rather than an irrelevance: on Windows both NIDs
+        // share k_ampr_submit, which resets the command buffer and writes nothing, so AndGetResult
+        // silently returns success without publishing a completion token. That is pre-existing and is
+        // tracked as #1657 — REMOVE THIS GUARD when it is fixed; the assertions below are already the
+        // proof. They are guarded rather than deleted so the Windows contract is not quietly forgotten.
+        // The plain form's contract IS satisfied on Windows (it has no result slots), which is why its
+        // residue assertion further down stays unguarded.
         // Both halves required: before #1629 the plain NID resolved to nothing, so a bare "these
         // differ" comparison passed vacuously against nullptr.
         CHECK(submit_plain && submit_result_a && submit_plain != submit_result_a,
@@ -430,7 +433,7 @@ int main() {
         alignas(64) uint8_t fake_cb[256] = {};
         const uint64_t cb = (uint64_t)(uintptr_t)fake_cb;
 
-#ifndef _WIN32
+#ifndef _WIN32   // see #1657 — Windows publishes no token; remove with that fix
         if (submit_result_a) {
             out1 = out2 = kResidue;
             submit_result_a(cb, 1, (uint64_t)(uintptr_t)&out1, (uint64_t)(uintptr_t)&out2, 0, 0);

--- a/prosper/tests/test_apr_registry.cpp
+++ b/prosper/tests/test_apr_registry.cpp
@@ -389,6 +389,57 @@ int main() {
 #endif
     }
 
+
+    // #1629: sceKernelAprSubmitCommandBuffer (eE4Szl8sil8) was unimplemented, so the default stub
+    // returned 0 = success without consuming the command buffer and CRI ADX2's reads never completed.
+    //
+    // The 3.20 firmware export database also corrects a name prosper had guessed: ASoW5WE-UPo is
+    // sceKernelAprSubmitCommandBufferAndGetResult (cb, ring, out1, out2), NOT the plain submit. The
+    // plain form takes no result slots, so a2/a3 hold caller residue — writing a token through them
+    // is the specific bug an alias-style "fix" would introduce, and this file already documents that a
+    // nonzero value in a completion record marks the read FAILED.
+    {
+        HleFn submit_plain = Hle::lookup("eE4Szl8sil8");
+        HleFn submit_result_a = Hle::lookup("ASoW5WE-UPo");
+        CHECK(submit_plain != nullptr,
+              "#1629: sceKernelAprSubmitCommandBuffer (eE4Szl8sil8) resolves to a real handler");
+        CHECK(submit_result_a != nullptr,
+              "#1629: sceKernelAprSubmitCommandBufferAndGetResult (ASoW5WE-UPo) still resolves");
+        // Both halves required: before #1629 the plain NID resolved to nothing, so a bare "these
+        // differ" comparison passed vacuously against nullptr.
+        CHECK(submit_plain && submit_result_a && submit_plain != submit_result_a,
+              "#1629: the plain submit exists AND is not an alias of the AndGetResult form");
+        // The _TEST-suffixed exports must stay unimplemented. They are NOT alias NIDs of the two
+        // names above — the firmware database resolves them to sceKernelAprSubmitCommandBuffer_TEST
+        // and ...AndGetResult_TEST — and binding a debug entry point to a production handler would be
+        // inventing behaviour no title evidence supports.
+        CHECK(Hle::lookup("Omr9X+YmT7I") == nullptr && Hle::lookup("0ers1N4C9CY") == nullptr,
+              "#1629: the _TEST-suffixed submit NIDs are left unimplemented, not aliased");
+
+        // An unbound command buffer is the case that hands a token back through the out slots, so it
+        // is the one that can demonstrate the difference.
+        alignas(8) uint64_t out1 = 0xdeadbeefcafef00dull;
+        alignas(8) uint64_t out2 = 0xdeadbeefcafef00dull;
+        constexpr uint64_t kResidue = 0xdeadbeefcafef00dull;
+        alignas(64) uint8_t fake_cb[256] = {};
+        const uint64_t cb = (uint64_t)(uintptr_t)fake_cb;
+
+        if (submit_result_a) {
+            out1 = out2 = kResidue;
+            submit_result_a(cb, 1, (uint64_t)(uintptr_t)&out1, (uint64_t)(uintptr_t)&out2, 0, 0);
+            CHECK(out1 != kResidue && out2 != kResidue && out1 == out2,
+                  "#1629: AndGetResult still publishes one completion token through both out slots");
+        }
+        if (submit_plain) {
+            out1 = out2 = kResidue;
+            // Exactly the call the plain form receives: whatever happens to be in the argument
+            // registers. If the handler treated them as out-pointers it would clobber them.
+            submit_plain(cb, 1, (uint64_t)(uintptr_t)&out1, (uint64_t)(uintptr_t)&out2, 0, 0);
+            CHECK(out1 == kResidue && out2 == kResidue,
+                  "#1629: the plain submit writes NO result slots — a2/a3 are residue, not outputs");
+        }
+    }
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;


### PR DESCRIPTION
Fixes #1629

## Failure scenario

*Tales of Graces f Remastered* (`PPSA19991`) links `cri_ware_unity.prx`, and CRI ADX2's file system
drives its reads through the PS5 APR engine rather than `pread`. It finishes each command buffer with
`sceKernelAprSubmitCommandBuffer` (`eE4Szl8sil8`), which prosper did not implement:

```
[prosper] unimplemented: libkernel::eE4Szl8sil8  -> returning 0
```

The default stub returns 0 = success without consuming the command buffer, so the read never completes
and the guest's loader thread waits forever — one submit, then only Unity's TRC watchdog repeating.

## What identified the contract

The PS5 3.20 firmware export database, which **corrects a name prosper had guessed**:

| NID | prosper's label | firmware database |
| --- | --- | --- |
| `ASoW5WE-UPo` | `"AprSubmitCommandBuffer?"` | **`sceKernelAprSubmitCommandBufferAndGetResult`** |
| `eE4Szl8sil8` | *(unimplemented)* | **`sceKernelAprSubmitCommandBuffer`** |

That is the whole insight. The already-working sibling is the **result-returning** form
`(cb, ring, out1, out2)` — its two out-pointers are the "AndGetResult" outputs, which is exactly why the
existing handler writes a token there. The missing entry point is the same submit with **no result
slots**. The `?` in the old label was the codebase correctly marking the name as unverified; it was wrong.

`CONFIDENCE: HIGH` on both names — the database is the authoritative PS5-specific NID↔name map, and the
existing implementation's `(cb, ring, out1, out2)` shape independently corroborates the AndGetResult
reading.

## Approach

Both forms share one body, split on whether the result slots are written.

**The plain form must not write them, and this is the substantive correctness point.** With no
out-parameters, `a2`/`a3` hold whatever the caller's registers happened to contain. `hle_kernel_mem.cpp`
already documents that a nonzero value landing in a request's completion record marks that read
**FAILED** (checked at `eboot+0x22738a5`, live-verified "GEngineLoop.PreInit Failed!"). So aliasing the
new NID onto the existing handler — the obvious one-line "fix" — would write a completion token through
residue, and the resulting failure would look like a corrupted read rather than a wrong stub. The
regression test pins exactly this.

### Two NIDs I deliberately did **not** register

`Omr9X+YmT7I` and `0ers1N4C9CY` look like alias NIDs of these two names. **They are not.** The database
resolves them to `sceKernelAprSubmitCommandBuffer_TEST` and `...AndGetResult_TEST` — separate,
debug-suffixed exports whose behaviour no title evidence prosper holds can show. Binding them to the
production handlers would be inventing semantics, so they stay unimplemented and fail-visible.

I nearly registered them. My first NID sweep used `__ptr_sceKernelApr[A-Za-z]*`, which **truncates at the
underscore** and rendered both `_TEST` symbols as bare aliases of the production names. The correct class
is `[A-Za-z0-9_]*`. Both the code comment and the test record this, because the mistake is silent and
reproducible.

**The truncation is not a wider problem, and that is now settled rather than assumed.** Review extracted
all 31,275 NID→name pairs across all 275 libraries in the database and confirmed the only two
`_TEST`-suffixed exports in the entire firmware surface are exactly the two declined here — so no other
registration anywhere in `prosper/src/hle/` binds a suffixed export while believing it is the production
one. An exhaustive negative, which closes the question permanently instead of leaving it as a standing
doubt.

## Affected / unaffected

**Affected:** `eE4Szl8sil8` now performs a real submit instead of returning a silent success;
`ASoW5WE-UPo` is registered under its correct name (behaviour unchanged — it still writes both result
slots on the unbound path and still echoes the binding tag on the bound path).

**Unaffected:** the AndGetResult token/event contract, including the bound/unbound split and the
deferred equeue post; the read path (`sceAmprAprCommandBufferReadFile` already performs the read and
completes the record — submit consumes the buffer); every other APR sibling; the `_TEST` NIDs; Windows,
where the existing Ampr submit already writes no result slots and is therefore the plain form unchanged.

## Risks

- The label change on `ASoW5WE-UPo` alters diagnostic output (`[amprlog]` now prints
  `AprSubmitAndGetResult` / `AprSubmit`). Cosmetic, but greps over old logs will not match.
- `CONFIDENCE: MED` that the plain form's arity is exactly `(cb, ring)`. The database gives the name, not
  the signature. The implementation only reads `a0`/`a1`, which are positionally identical to the
  AndGetResult form, so a wider real signature cannot harm it — and it writes nothing it was not given.
- **No live progression run.** Stated plainly rather than implied: reaching this call requires the Unity
  plugin auto-link work on `investigate/issue-1609-tales-composite`, which is unmerged, and the GPU is
  with that lane. The call *being reached* is already established by the issue's own trace. What is not
  yet shown is that the boot advances past the stall with this fix. The Tales lane can confirm that for
  free on its next run, which is cheaper than my re-deriving their base.

## Verification

Build clean (distrobox `ps5ys`, `Vulkan found`). `ctest -j8`: **165/165**.

Six new assertions in `test_apr_registry`. Reverting only `hle_kernel_mem.cpp`:

```
[FAIL] #1629: sceKernelAprSubmitCommandBuffer (eE4Szl8sil8) resolves to a real handler
[FAIL] #1629: the plain submit exists AND is not an alias of the AndGetResult form
[FAIL] #1629: the _TEST-suffixed submit NIDs are left unimplemented, not aliased
```

The "is not an alias" assertion is written as `plain && result && plain != result` on purpose: the bare
inequality passed vacuously pre-fix, because the plain NID resolved to `nullptr`.

**A gotcha worth recording:** configuring with `-DGAME_DUMP=<DUMP_ROOT>/PPSA19991-app0` makes
`module_loads_eboot` and `boot_reaches_first_syscall` fail. That is **#1573**, not this change — those
tests are dump-parameterized and assume The Messenger. With `PPSA24651-app0` the suite is 165/165.

