### PR TITLE
fix(loader): link the Unity native plugins a title actually ships, without duplicating exports

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -517,10 +517,18 @@ if(TARGET prosper_core)
 
   # Unity native-plugin auto-link (#1609): a title's own Media/Plugins/*.prx that the fixed preload
   # list never named must still be linked, or its first P/Invoke raises a DllNotFoundException that
-  # IL2CPP captures into a Task and never prints. Pure std::filesystem; no game dump needed.
+  # IL2CPP captures into a Task and never prints. Also guards the export-collision rule that keeps
+  # auto-linking from introducing a duplicate NID export (Evergate ships libfmod.prx AND libfmodL.prx,
+  # the same library's release and logging builds). The discovery and predicate assertions are pure
+  # std::filesystem/struct work and need no dump; the dump, when configured, additionally exercises
+  # link_program's honouring of the skip flag.
   add_executable(test_plugin_autolink tests/test_plugin_autolink.cpp)
   target_link_libraries(test_plugin_autolink PRIVATE prosper_core)
-  add_test(NAME plugin_autolink COMMAND test_plugin_autolink)
+  if(HAVE_GAME_DUMP)
+    add_test(NAME plugin_autolink COMMAND test_plugin_autolink "${GAME_DUMP}")
+  else()
+    add_test(NAME plugin_autolink COMMAND test_plugin_autolink)
+  endif()
 
   # ATRAC9 decode (vendored LibAtrac9 + prosper glue): an embedded 16-superframe slice of a real PS5
   # snd0.at9 decodes bit-exact vs the LibAtrac9 reference (CRC32). Pure, no game dump; runs in CI.

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -515,6 +515,13 @@ if(TARGET prosper_core)
   target_link_libraries(test_module_path_case PRIVATE prosper_core)
   add_test(NAME module_path_case COMMAND test_module_path_case)
 
+  # Unity native-plugin auto-link (#1609): a title's own Media/Plugins/*.prx that the fixed preload
+  # list never named must still be linked, or its first P/Invoke raises a DllNotFoundException that
+  # IL2CPP captures into a Task and never prints. Pure std::filesystem; no game dump needed.
+  add_executable(test_plugin_autolink tests/test_plugin_autolink.cpp)
+  target_link_libraries(test_plugin_autolink PRIVATE prosper_core)
+  add_test(NAME plugin_autolink COMMAND test_plugin_autolink)
+
   # ATRAC9 decode (vendored LibAtrac9 + prosper glue): an embedded 16-superframe slice of a real PS5
   # snd0.at9 decodes bit-exact vs the LibAtrac9 reference (CRC32). Pure, no game dump; runs in CI.
   add_executable(test_atrac9 tests/test_atrac9.cpp)

--- a/prosper/docs/GAME_COMPAT_ORCHESTRATION.md
+++ b/prosper/docs/GAME_COMPAT_ORCHESTRATION.md
@@ -101,6 +101,14 @@ highest-value page in this document.
      nonzero, **rename the log to `DISCARD-…`** instead of dropping it. Contention then becomes *visible in
      the record* rather than invisible in the mean, and the discarded run stays auditable afterwards instead
      of surviving as an unexplained outlier.
+  4. **Alternate the arms, then check the residuals for cycle correlation** before attributing any
+     difference to the treatment. Running all of arm A then all of arm B lets a *time-varying* confound
+     land entirely on one arm and become a phantom effect. Alternating forces it onto both, which makes it
+     detectable: in #1609's 12-run experiment the slowest run was **cycle 2 in all four title × arm
+     combinations**, so the residual variance tracked *when* a run happened, not *which arm* it was. That is
+     not an argument that the gap is noise — it is a demonstration, from the same data that would otherwise
+     have produced the phantom. If the extremes line up by cycle rather than by arm, the treatment is not
+     the explanation.
   Report **whole-run and steady-state (tail-window) rates separately**: a one-off boot cost and a per-frame
   cost are indistinguishable in a whole-run average, because a run that reaches steady state one second later
   and then performs identically still shows a lower average. Report min/max spread and an explicit

--- a/prosper/docs/GAME_COMPAT_ORCHESTRATION.md
+++ b/prosper/docs/GAME_COMPAT_ORCHESTRATION.md
@@ -50,8 +50,8 @@ session. Prefer breadth when a hard lane stalls — overall library progress mat
 
 ### The instrument-not-the-subject list — read this before believing any surprising measurement
 
-**Fourteen phantom defects came from the measuring apparatus, not the subject** (eleven in one session on
-2026-07-31, three more on 2026-08-01). Several cost hours; one cost two sessions. This is the single
+**Twenty phantom defects came from the measuring apparatus, not the subject** (eleven in one session on
+2026-07-31, nine more on 2026-08-01). Several cost hours; one cost two sessions. This is the single
 highest-value page in this document.
 
 | # | Instrument | How it lied |
@@ -74,6 +74,9 @@ highest-value page in this document.
 | 15 | "is this dword pair a mapped pointer?" | The user-data window is 32 dwords and holds many live pointers, so **several** seed offsets satisfy "every declared descriptor is readable". On #305 a shifted seed made all declared pointers land cleanly on **9 of 9** stages — and the hardware field that bounds the window (`SPI_SHADER_PGM_RSRC2_GS.USER_SGPR`) proved the stage cannot see there at all. A live A/B then raised rejects 118-141 -> 521. A numeric fit over a pointer-shaped predicate is weak evidence; find the register that bounds the search space. |
 | 16 | One diagnostic **label** covering two packet kinds | #305's bind trace emitted `[bind] DRAW` from all five per-item snapshot sites in `GpuState::apply` — and **two of those are compute dispatches**. A dispatch never consumes `SPI_SHADER_PGM_LO_ES`, so a bind/draw agreement statistic computed over those lines mixes in events that cannot agree by construction. Graphics-queue dispatches read the *graphics* register file, so they print plausible `es_lo` and are **indistinguishable from draws in the log** — a re-run, not a re-parse. **Re-measured after relabelling** (a fresh boot — the two figures are not the same run: 434,239 bind packets vs 193,397), the contaminated "871,648 of 876,217 (99.5%)" became **300,404 of 300,404 (100%)**, so the residue had been dispatches. Tag every emitter with the kind it actually observed. |
 | 17 | **Asymmetric** exhaustion of per-site caps | A cousin of #13. When one side of a paired trace caps (bind lines, one counter at 4,000) and the other runs on **five independent counters**, the first side dies during the pre-title load while the second keeps emitting; a "does each draw follow a bind?" analysis then reported a 41% mismatch that was pure counter exhaustion. Bound the analysis to the region where **every** stream is still logging. Related: `command_order` is **per-submit and resets**, so ordering events globally by it interleaves submits and manufactures impossible pairs. |
+| 18 | `VAR=1 $unquoted_var cmd` | The shell expands `$unquoted_var` **after** it has decided which word is the command, so an expansion like `PROSPER_NO_PLUGIN_AUTOLINK=1` becomes the **command name**, not an assignment. The arm never runs, exits 127, and — with stdout redirected to a per-arm log — leaves an empty file that reads exactly like a legitimate "no output" result. #1609's founding 14,666-vs-18,167 "20% regression" came from an A/B whose OFF arm had never executed. Build env into the command directly, or use `env VAR=1 cmd`. |
+| 19 | `$HOME` read as private scratch | Every lane on this box shares one `$HOME` (410 files at the time of writing). Generic scratch names — `pr-body.md`, `ab-result.md`, `app.log`, `apr.log` — **already collide across lanes**. Writing one destroys another agent's work in flight, and reading one silently answers your question with someone else's data. Title-scope every scratch file (`tales-pr-body.md`, `tales-rate-*.log`). The tell that saved it here: the Write tool **refused to overwrite a file it had not read**. A tool declining to clobber is a safety net, not an obstacle — an agent that "fixes" it by deleting the file and retrying destroys the thing the guard was protecting. |
+| 20 | An **empty CI rollup** read as "queued" | GitHub does **not run checks on a conflicting branch at all**, so a PR whose base has moved reports `pass=0 fail=0 pending=0` with `mergeStateStatus=DIRTY` — permanently, until it is rebased. That is byte-identical to the "checks have not registered yet" state, and #1656 sat in it while master moved twice. Same shape as #18's empty log: **an absent signal mimicking a pending one**. Read `mergeable`/`mergeStateStatus` before concluding anything from a check count, and never wait on zeros. |
 
 **Working rules that follow:**
 
@@ -86,6 +89,22 @@ highest-value page in this document.
   explanation for the gap. Then confirm the phase by **opening the frames**: #1641's Nikoderiko row was
   only interpretable once the images showed samples 10-11 carrying ~160k distinct colours while 3-9 were
   black, which proved the census was tracking real workload rather than drifting.
+- **Build a timing measurement that cannot lie quietly.** Everything above is "this instrument lied"; this is
+  the counterpart — the shape of a measurement that reports its own invalidity instead of averaging it away.
+  Seven lanes share one GPU, so vigilance does not scale: a run *will* eventually overlap someone else's
+  capture, and a contended sample looks exactly like a real regression. Three properties, all cheap:
+  1. **Self-lock** (`flock` on a lockfile) so a second copy of the driver refuses to start rather than racing
+     the first. Two waiters queued behind the same "GPU free" condition both fire when it clears.
+  2. **Build strictly before measuring, never concurrently.** A `-j8` compile landing on top of a run costs
+     more throughput than whatever is being measured. Put the build inside the driver, ahead of the loop.
+  3. **Discard, don't average.** Sample the foreign-process count **before and after** each run; if either is
+     nonzero, **rename the log to `DISCARD-…`** instead of dropping it. Contention then becomes *visible in
+     the record* rather than invisible in the mean, and the discarded run stays auditable afterwards instead
+     of surviving as an unexplained outlier.
+  Report **whole-run and steady-state (tail-window) rates separately**: a one-off boot cost and a per-frame
+  cost are indistinguishable in a whole-run average, because a run that reaches steady state one second later
+  and then performs identically still shows a lower average. Report min/max spread and an explicit
+  **overlap verdict** across arms — if the arms overlap, say so plainly and the question is closed.
 - **Joining two instruments requires an explicit shared ordinal, never stream adjacency.** If two diagnostics
   are emitted at different pipeline stages, their interleaving in the log is an artifact of *when each stage
   ran*, not of when the events happened. Print a common ordinal (`command_order`) on both and join on it. This

--- a/prosper/src/host/boot_program.cpp
+++ b/prosper/src/host/boot_program.cpp
@@ -175,7 +175,12 @@ bool boot_program(const std::string& d, Program& p, std::string* err,
             }
             const uint64_t base = BOOT_PLUGIN_AUTO_BASE + (uint64_t)slot * BOOT_PLUGIN_AUTO_STRIDE;
             printf("plugin auto-link: %s @ 0x%llx\n", path.c_str(), (unsigned long long)base);
-            in.insert(in.begin() + (ptrdiff_t)(insert_at + slot), { path, base });
+            // skip_on_export_collision: never introduce a duplicate NID export. A title can ship two
+            // builds of the same library (Evergate's libfmod.prx + libfmodL.prx export identical
+            // NIDs); linking both would run two init_arrays and make dlsym answer differently per
+            // module handle. Deduplicating on exports rather than on a filename suffix also degrades
+            // correctly for a title that ships only the debug variant — nothing collides, so it links.
+            in.insert(in.begin() + (ptrdiff_t)(insert_at + slot), { path, base, true });
             slot++;
         }
     }
@@ -201,6 +206,11 @@ bool boot_program(const std::string& d, Program& p, std::string* err,
 
     std::string e;
     if (!link_program(in, BOOT_STUB, p, &e)) return fail("link failed: " + e);
+    // Loud, self-describing report of every auto-linked plugin the linker refused: which module was
+    // dropped, the exact NID that collided, and which already-linked module owns it.
+    for (const auto& s : p.skipped_modules)
+        printf("plugin auto-link: SKIPPED %s — it exports NID %s, already provided by %s\n",
+               s.path.c_str(), s.nid.c_str(), s.owner_path.c_str());
     printf("linked %zu modules; %zu imports (%zu cross-module, %zu stub slots); %zu init fns\n",
            p.mods.size(), p.total_imports, p.resolved_cross_module, p.slots.size(), p.init_fns.size());
 

--- a/prosper/src/host/boot_program.cpp
+++ b/prosper/src/host/boot_program.cpp
@@ -3,9 +3,11 @@
 // (Linux/macOS: exec_image_linux.cpp; Windows: exec_image_win.cpp).
 #include "boot_program.hpp"
 
+#include <algorithm>
 #include <cctype>
 #include <filesystem>
 #include <system_error>
+#include <vector>
 
 namespace prosper {
 
@@ -48,6 +50,41 @@ std::string resolve_host_path_case(const std::string& want) {
     // (fs::path would otherwise rewrite them to the host-native form, e.g. '\' on Windows).
     if (dir != parent) return (fs::path(dir) / base).string();
     return want;
+}
+
+// See boot_program.hpp. Pure filesystem query so it can be unit-tested without a guest image.
+std::vector<std::string> discover_extra_plugin_modules(
+    const std::string& dump_root, const std::vector<std::string>& listed_basenames) {
+    namespace fs = std::filesystem;
+    std::vector<std::string> found;
+    if (dump_root.empty()) return found;
+    auto lower = [](std::string s) {
+        for (auto& c : s) c = (char)std::tolower((unsigned char)c);
+        return s;
+    };
+    std::vector<std::string> listed;
+    listed.reserve(listed_basenames.size());
+    for (const auto& b : listed_basenames) listed.push_back(lower(b));
+
+    std::error_code ec;
+    const std::string dir = resolve_host_path_case(dump_root + "/Media/Plugins");
+    if (!fs::is_directory(fs::path(dir), ec)) return found;
+    for (const auto& e : fs::directory_iterator(dir, fs::directory_options::skip_permission_denied, ec)) {
+        if (!e.is_regular_file(ec)) continue;
+        const std::string name = e.path().filename().string();
+        const std::string lname = lower(name);
+        if (lname.size() < 5 || lname.compare(lname.size() - 4, 4, ".prx") != 0) continue;
+        bool already = false;
+        for (const auto& l : listed) if (l == lname) { already = true; break; }
+        if (!already) found.push_back(e.path().string());
+    }
+    // directory_iterator order is filesystem-defined; sort so a boot is reproducible. DESCENDING by
+    // lowercased basename, because the caller appends this block to a link list whose init functions
+    // run in reverse order — the guest therefore initializes them in ascending name order.
+    std::sort(found.begin(), found.end(), [&](const std::string& a, const std::string& b) {
+        return lower(fs::path(a).filename().string()) > lower(fs::path(b).filename().string());
+    });
+    return found;
 }
 
 } // namespace prosper
@@ -114,6 +151,34 @@ bool boot_program(const std::string& d, Program& p, std::string* err,
         { d + "/sce_module/libSceNpCppWebApi.prx", BOOT_NPCPPWEBAPI },
         { d + "/sce_module/libc.prx", BOOT_LIBC },
     };
+    // #1609: the fixed list above only names plugins some earlier title needed. Link whatever else
+    // this title ships in its own Media/Plugins directory, so a first P/Invoke into it resolves
+    // instead of raising a silent DllNotFoundException (prosper has no runtime PRX loading, #639).
+    // Inserted just before the sce_module entries so these plugins initialize after libc and the
+    // bundled support PRX but before the hard-coded Unity plugins (init runs in reverse list order).
+    if (!getenv("PROSPER_NO_PLUGIN_AUTOLINK")) {
+        std::vector<std::string> listed;
+        for (const auto& e : in) {
+            const size_t slash = e.path.find_last_of("/\\");
+            listed.push_back(slash == std::string::npos ? e.path : e.path.substr(slash + 1));
+        }
+        const std::vector<std::string> extra = discover_extra_plugin_modules(d, listed);
+        size_t insert_at = in.size();
+        for (size_t i = 0; i < in.size(); i++)
+            if (in[i].path.find("/sce_module/") != std::string::npos) { insert_at = i; break; }
+        unsigned slot = 0;
+        for (const auto& path : extra) {
+            if (slot >= BOOT_PLUGIN_AUTO_SLOTS) {
+                printf("plugin auto-link: no free base slot for %s (max %u) — NOT linked\n",
+                       path.c_str(), BOOT_PLUGIN_AUTO_SLOTS);
+                continue;
+            }
+            const uint64_t base = BOOT_PLUGIN_AUTO_BASE + (uint64_t)slot * BOOT_PLUGIN_AUTO_STRIDE;
+            printf("plugin auto-link: %s @ 0x%llx\n", path.c_str(), (unsigned long long)base);
+            in.insert(in.begin() + (ptrdiff_t)(insert_at + slot), { path, base });
+            slot++;
+        }
+    }
     if (getenv("PROSPER_NO_PSN"))
         for (size_t i = in.size(); i-- > 0; )
             if (in[i].path.find("PSN.prx") != std::string::npos ||

--- a/prosper/src/host/boot_program.hpp
+++ b/prosper/src/host/boot_program.hpp
@@ -7,6 +7,7 @@
 #pragma once
 #include "loader/linker.hpp"   // Program
 #include <string>
+#include <vector>
 #include <functional>
 
 namespace prosper {
@@ -31,6 +32,12 @@ inline constexpr uint64_t BOOT_FMOD       = 0x540000000ull;
 inline constexpr uint64_t BOOT_AKMOTION   = 0x560000000ull; // optional Unity Wwise native plugins
 inline constexpr uint64_t BOOT_AKVORBIS   = 0x580000000ull;
 inline constexpr uint64_t BOOT_AKSOUNDENGINE = 0x5a0000000ull;
+// Base pool for auto-discovered Unity native plugins (see discover_extra_plugin_modules). Placed
+// between libc and the import-stub region: every shipped plugin observed so far is under 8 MiB, so a
+// 64 MiB stride leaves a wide margin, and the last slot ends 128 MiB below BOOT_STUB.
+inline constexpr uint64_t BOOT_PLUGIN_AUTO_BASE  = 0x5d0000000ull;
+inline constexpr uint64_t BOOT_PLUGIN_AUTO_STRIDE = 0x4000000ull;   // 64 MiB
+inline constexpr unsigned BOOT_PLUGIN_AUTO_SLOTS  = 10;
 inline constexpr uint64_t BOOT_STUB     = 0x600000000ull;
 
 // Boot the title rooted at `dump_root` (the app0 directory): link the fixed module set (dropping any
@@ -59,5 +66,23 @@ bool boot_program(const std::string& dump_root, Program& out, std::string* err,
 // already exists or no entry matches (the caller's absence handling then applies as before).
 // Consumers: boot_program's preload loop, hle_file's translate(), and the unit test.
 std::string resolve_host_path_case(const std::string& want);
+
+// Enumerate the title's own Unity native plugins that the fixed preload list does not name (#1609).
+//
+// prosper has no runtime PRX loading (#639), so every native plugin a title P/Invokes must be linked
+// at boot. The preload list above grew one plugin at a time (PSN, PSNCore/PSNCommon, CommonDialog,
+// FMOD, Wwise), which means any title shipping a plugin nobody has hard-coded yet fails its very
+// first P/Invoke with `DllNotFoundException` — and because IL2CPP raises that inside an async state
+// machine, the exception is captured into a Task and never printed, so the title simply stops making
+// progress with no diagnostic at all. Tales of Graces f Remastered (PPSA19991) loses three of the
+// thirty singletons its boot state machine awaits that way and then renders an empty scene forever.
+//
+// `<dump_root>/Media/Plugins/*.prx` is the engine's own plugin directory, so its contents are exactly
+// the set the guest may ask for. Returns the paths of the entries whose basename does not
+// case-insensitively match any of `listed_basenames`, ordered so that the caller (which appends them
+// to a link list whose init functions run in reverse order) initializes them in ascending
+// case-insensitive name order. A missing directory yields an empty vector; never throws.
+std::vector<std::string> discover_extra_plugin_modules(
+    const std::string& dump_root, const std::vector<std::string>& listed_basenames);
 
 } // namespace prosper

--- a/prosper/src/loader/linker.cpp
+++ b/prosper/src/loader/linker.cpp
@@ -7,6 +7,28 @@
 
 namespace prosper {
 
+// The one definition of "what this module contributes to the export table". The predicate must stay
+// identical to the one used when `out.exports` is built below.
+static bool is_exported_symbol(const Symbol& s) {
+    return !s.is_import && !s.nid.empty() && s.value != 0;
+}
+
+std::vector<std::string> module_export_nids(const Module& m) {
+    std::vector<std::string> nids;
+    for (const auto& s : m.symbols) if (is_exported_symbol(s)) nids.push_back(s.nid);
+    return nids;
+}
+
+ExportCollision find_export_collision(
+    const Module& m, const std::unordered_map<std::string, std::string>& claimed) {
+    for (const auto& s : m.symbols) {
+        if (!is_exported_symbol(s)) continue;
+        const auto it = claimed.find(s.nid);
+        if (it != claimed.end()) return { s.nid, it->second };
+    }
+    return {};
+}
+
 bool link_program(const std::vector<LinkInput>& inputs, uint64_t stub_base,
                   Program& out, std::string* err) {
     auto fail = [&](const std::string& s) { if (err) *err = s; return false; };
@@ -14,10 +36,23 @@ bool link_program(const std::vector<LinkInput>& inputs, uint64_t stub_base,
     out.stub_base = stub_base;
 
     // --- Pass 1: load every module and build its image at its base. ---
+    // NID -> path of the accepted module that exports it, in list order. Mirrors the
+    // first-definition-wins global export table built in the pass below, so an optional input can be
+    // rejected BEFORE its image is built rather than silently aliasing an earlier module's exports.
+    std::unordered_map<std::string, std::string> nid_owner;
     for (auto& in : inputs) {
         std::string e;
         auto mo = Module::load(in.path, &e);
         if (!mo) return fail("load " + in.path + ": " + e);
+        if (in.skip_on_export_collision) {
+            const ExportCollision hit = find_export_collision(*mo, nid_owner);
+            if (!hit.nid.empty()) {
+                out.skipped_modules.push_back({ in.path, hit.nid, hit.owner_path });
+                continue;
+            }
+        }
+        for (const auto& s : mo->symbols)
+            if (is_exported_symbol(s)) nid_owner.emplace(s.nid, in.path);
         auto mod = std::make_unique<Module>(std::move(*mo));
         LoadedImage img;
         if (!build_image(*mod, in.base, img, &e))
@@ -25,6 +60,9 @@ bool link_program(const std::vector<LinkInput>& inputs, uint64_t stub_base,
         out.mods.push_back(std::move(mod));
         out.imgs.push_back(std::move(img));
     }
+    // Only optional inputs can be dropped above, and the main executable is never optional — but do
+    // not index into an empty vector if a caller ever flags every input.
+    if (out.imgs.empty()) return fail("every module was skipped on an export collision");
     out.entry = out.imgs[0].entry;
 
     // Assign each module with a PT_TLS segment a TLS module id (>=1; 0 = "no TLS"), and record its

--- a/prosper/src/loader/linker.hpp
+++ b/prosper/src/loader/linker.hpp
@@ -13,7 +13,23 @@
 
 namespace prosper {
 
-struct LinkInput { std::string path; uint64_t base; };
+struct LinkInput {
+    std::string path;
+    uint64_t base;
+    // #1609: this input is an OPTIONAL module discovered on disk rather than a named dependency.
+    // Skip it entirely — do not build its image, do not contribute its exports, do not run its
+    // init function — when any NID it exports is already exported by an earlier accepted module.
+    //
+    // Needed because the global export table below is first-definition-wins and SILENT: a second
+    // module exporting the same NIDs is linked, mapped and initialized, but every guest import
+    // aliases to whichever module happens to come first in this list. Evergate (PPSA01885) ships
+    // both `libfmod.prx` and `libfmodL.prx` — FMOD's release and logging builds of the SAME library,
+    // exporting the SAME NIDs. Auto-linking the second one would run a second full FMOD core's
+    // init_array and make `sceKernelDlsym` return a different implementation depending on which
+    // module handle it was asked through. Deduplicating on filename cannot see that (the names
+    // genuinely differ); deduplicating on exports is what the hazard actually is.
+    bool skip_on_export_collision = false;
+};
 
 struct Program {
     std::vector<std::unique_ptr<Module>> mods;   // unique_ptr: stable addresses for imports[]
@@ -35,9 +51,27 @@ struct Program {
     struct ModuleExports { std::string path; std::unordered_map<std::string, uint64_t> nids; };
     std::vector<ModuleExports> mod_exports;
 
+    // Inputs dropped by `LinkInput::skip_on_export_collision`, with the exact NID that collided and
+    // the already-accepted module that owns it. Retained (rather than only logged) so the caller can
+    // report the decision in its own vocabulary and a test can assert it.
+    struct SkippedModule { std::string path, nid, owner_path; };
+    std::vector<SkippedModule> skipped_modules;
+
     // Stats for reporting.
     size_t total_imports = 0, resolved_cross_module = 0, stubbed = 0;
 };
+
+// The exported NIDs a module contributes to the global export table: defined (non-import),
+// NID-bearing symbols with a nonzero value. Kept as one helper so the collision check and the table
+// build below cannot drift apart — if they disagreed, a module could be accepted as collision-free
+// and then still alias someone else's NID.
+std::vector<std::string> module_export_nids(const Module& m);
+
+// First NID of `m` already present in `claimed` (NID -> owning module path), or an empty `nid` when
+// there is no collision. Deterministic: `m`'s symbols are scanned in file order.
+struct ExportCollision { std::string nid, owner_path; };
+ExportCollision find_export_collision(
+    const Module& m, const std::unordered_map<std::string, std::string>& claimed);
 
 // Link the given modules (the first is the main executable). Applies relocations.
 // Returns false with *err on failure.

--- a/prosper/tests/test_plugin_autolink.cpp
+++ b/prosper/tests/test_plugin_autolink.cpp
@@ -12,11 +12,13 @@
 // The contract under test: everything in <dump>/Media/Plugins/*.prx that the caller did not already
 // name (case-insensitively) is returned, in a deterministic order, and nothing else is.
 #include "../src/host/boot_program.hpp"
+#include "../src/loader/linker.hpp"
 #include "test_scratch.h"
 #include <cstdio>
 #include <filesystem>
 #include <fstream>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace fs = std::filesystem;
@@ -37,7 +39,7 @@ static bool has(const std::vector<std::string>& v, const std::string& s) {
     return false;
 }
 
-int main() {
+int main(int argc, char** argv) {
     std::error_code ec;
     const fs::path root = prosper_test::test_scratch_dir() / "prosper_test_plugin_autolink";
     fs::remove_all(root, ec);
@@ -104,6 +106,93 @@ int main() {
     CHECK(has(lcnames, "Extra.prx"), "lower-cased Media/Plugins directory is still discovered");
 
     fs::remove_all(root, ec);
+
+    // ---- export-collision predicate ------------------------------------------------------------
+    // Discovery alone is not enough: a title can ship two builds of the SAME library under different
+    // filenames. Evergate (PPSA01885) ships `libfmod.prx` AND `libfmodL.prx` — FMOD's release and
+    // logging builds, exporting identical NIDs. The global export table is first-definition-wins and
+    // silent, so linking both would run two init_arrays and make sceKernelDlsym answer differently
+    // depending on which module handle it is asked through. Basename dedup cannot see that; the
+    // linker therefore refuses an optional module whose exports collide.
+    //
+    // Module is a plain struct, so the predicate is exercised here on synthetic symbol tables with no
+    // ELF fixture and no game dump — this part runs in CI.
+    auto sym = [](const char* nid, bool is_import, uint64_t value) {
+        prosper::Symbol s; s.nid = nid; s.is_import = is_import; s.value = value; return s;
+    };
+    prosper::Module release;                        // stands in for libfmod.prx
+    release.path = "libfmod.prx";
+    release.symbols = { sym("AAAAAAAAAAA", false, 0x1000), sym("BBBBBBBBBBB", false, 0x2000) };
+    prosper::Module logging;                        // stands in for libfmodL.prx: same NIDs
+    logging.path = "libfmodL.prx";
+    logging.symbols = { sym("AAAAAAAAAAA", false, 0x8000), sym("BBBBBBBBBBB", false, 0x9000) };
+    prosper::Module distinct;                       // stands in for libresonanceaudio.prx
+    distinct.path = "libresonanceaudio.prx";
+    distinct.symbols = { sym("CCCCCCCCCCC", false, 0x1000) };
+
+    CHECK(prosper::module_export_nids(release).size() == 2, "module_export_nids counts real exports");
+
+    std::unordered_map<std::string, std::string> claimed;
+    for (const auto& n : prosper::module_export_nids(release)) claimed.emplace(n, release.path);
+
+    const prosper::ExportCollision dup = prosper::find_export_collision(logging, claimed);
+    CHECK(dup.nid == "AAAAAAAAAAA", "duplicate-export module reports the first colliding NID");
+    CHECK(dup.owner_path == "libfmod.prx", "collision names the module that already owns the NID");
+    CHECK(prosper::find_export_collision(distinct, claimed).nid.empty(),
+          "a module with disjoint exports does not collide");
+    CHECK(prosper::find_export_collision(logging, {}).nid.empty(),
+          "the debug build alone does not collide (a title shipping only it still links it)");
+
+    // The collision predicate must match the export-table predicate exactly, or a module could be
+    // accepted as collision-free and then still alias someone else's NID: imports, empty NIDs and
+    // zero-valued symbols contribute nothing and must never trigger a skip.
+    prosper::Module noise;
+    noise.path = "noise.prx";
+    noise.symbols = { sym("AAAAAAAAAAA", true, 0x1000),    // import of the same NID
+                      sym("BBBBBBBBBBB", false, 0),        // defined but value 0
+                      sym("", false, 0x4000) };            // no NID
+    CHECK(prosper::module_export_nids(noise).empty(),
+          "imports, zero-valued and NID-less symbols are not exports");
+    CHECK(prosper::find_export_collision(noise, claimed).nid.empty(),
+          "importing a claimed NID is not a collision");
+
+    // ---- dump-backed wiring (only when a game dump is configured) ------------------------------
+    // Proves the flag is actually honoured by link_program: the same PRX listed twice is a guaranteed
+    // self-collision, so the flagged second copy must be dropped, and the unflagged control must not.
+    if (argc >= 2) {
+        const std::string dump_root = argv[1];
+        const std::string plugin = dump_root + "/Media/Plugins/PSN.prx";
+        if (fs::exists(fs::path(plugin))) {
+            const std::vector<prosper::LinkInput> control = {
+                { dump_root + "/eboot.bin", 0x410000000ull },
+                { plugin, 0x5d0000000ull },
+                { plugin, 0x5d4000000ull },                 // no flag: linked twice, as before
+            };
+            std::vector<prosper::LinkInput> guarded = control;
+            guarded[2].skip_on_export_collision = true;
+
+            prosper::Program pc, pg;
+            std::string lerr;
+            const bool okc = prosper::link_program(control, 0x600000000ull, pc, &lerr);
+            const bool okg = prosper::link_program(guarded, 0x600000000ull, pg, &lerr);
+            CHECK(okc && okg, "both link runs succeed");
+            CHECK(pc.skipped_modules.empty(), "control: an unflagged duplicate is still linked");
+            CHECK(pc.mods.size() == 3, "control: three modules linked");
+            CHECK(pg.skipped_modules.size() == 1, "guarded: the colliding duplicate is skipped");
+            CHECK(pg.mods.size() == 2, "guarded: only two modules linked");
+            if (pg.skipped_modules.size() == 1) {
+                CHECK(pg.skipped_modules[0].path == plugin, "skip record names the dropped module");
+                CHECK(pg.skipped_modules[0].owner_path == plugin, "skip record names the owner");
+                CHECK(!pg.skipped_modules[0].nid.empty(), "skip record carries the colliding NID");
+            }
+        } else {
+            printf("  [skip] %s has no Media/Plugins/PSN.prx — link wiring not exercised\n",
+                   dump_root.c_str());
+        }
+    } else {
+        printf("  [skip] no game dump argument — link wiring not exercised\n");
+    }
+
     printf(fails ? "FAILED (%d)\n" : "PASSED\n", fails);
     return fails ? 1 : 0;
 }

--- a/prosper/tests/test_plugin_autolink.cpp
+++ b/prosper/tests/test_plugin_autolink.cpp
@@ -1,0 +1,109 @@
+// test_plugin_autolink — guards discover_extra_plugin_modules (#1609): the boot preloader must link
+// the Unity native plugins a title ships that nobody hard-coded into the fixed preload list.
+//
+// Why this matters: prosper has no runtime PRX loading (#639), so a plugin that is not linked at boot
+// makes the guest's first P/Invoke into it raise DllNotFoundException. IL2CPP raises that inside an
+// async state machine, so it is captured into a Task and never printed — the title just stops making
+// progress with no diagnostic. Tales of Graces f Remastered (PPSA19991) ships cri_ware_unity.prx,
+// GameNative.prx, PlayGo.prx and lib_burst_generated.prx; three of the thirty singletons its boot
+// state machine awaits fault that way, so `NobleTask.WhenAll` never completes and the engine renders
+// an empty scene forever at full frame rate.
+//
+// The contract under test: everything in <dump>/Media/Plugins/*.prx that the caller did not already
+// name (case-insensitively) is returned, in a deterministic order, and nothing else is.
+#include "../src/host/boot_program.hpp"
+#include "test_scratch.h"
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace fs = std::filesystem;
+using prosper::discover_extra_plugin_modules;
+
+static int fails = 0;
+#define CHECK(cond, msg) do { if (!(cond)) { printf("  [FAIL] %s\n", msg); fails++; } \
+                              else        { printf("  [ok]   %s\n", msg); } } while (0)
+
+static std::vector<std::string> basenames(const std::vector<std::string>& paths) {
+    std::vector<std::string> out;
+    for (const auto& p : paths) out.push_back(fs::path(p).filename().string());
+    return out;
+}
+
+static bool has(const std::vector<std::string>& v, const std::string& s) {
+    for (const auto& e : v) if (e == s) return true;
+    return false;
+}
+
+int main() {
+    std::error_code ec;
+    const fs::path root = prosper_test::test_scratch_dir() / "prosper_test_plugin_autolink";
+    fs::remove_all(root, ec);
+    fs::create_directories(root / "Media" / "Plugins", ec);
+    auto touch = [&](const char* name) { std::ofstream(root / "Media" / "Plugins" / name) << "x"; };
+    // A PPSA19991-shaped plugin directory: two names the fixed list knows, four it does not.
+    touch("PSN.prx");
+    touch("SaveData.prx");
+    touch("cri_ware_unity.prx");
+    touch("GameNative.prx");
+    touch("PlayGo.prx");
+    touch("lib_burst_generated.prx");
+    touch("lib_burst_generated.txt");   // sibling non-module file must be ignored
+    touch("notaplugin.so");
+
+    const std::string dump = root.string();
+    const std::vector<std::string> listed = { "eboot.bin", "PSN.prx", "SaveData.prx", "libc.prx" };
+
+    const std::vector<std::string> got = discover_extra_plugin_modules(dump, listed);
+    const std::vector<std::string> names = basenames(got);
+
+    CHECK(names.size() == 4, "returns exactly the four unlisted .prx entries");
+    CHECK(has(names, "cri_ware_unity.prx"), "cri_ware_unity.prx discovered");
+    CHECK(has(names, "GameNative.prx"), "GameNative.prx discovered");
+    CHECK(has(names, "PlayGo.prx"), "PlayGo.prx discovered");
+    CHECK(has(names, "lib_burst_generated.prx"), "lib_burst_generated.prx discovered");
+    CHECK(!has(names, "PSN.prx") && !has(names, "SaveData.prx"),
+          "already-listed plugins are not returned twice");
+    CHECK(!has(names, "lib_burst_generated.txt") && !has(names, "notaplugin.so"),
+          "non-.prx files are ignored");
+
+    // Every returned entry must be a real, openable path (the caller links it directly).
+    bool all_exist = true;
+    for (const auto& p : got) if (!fs::exists(fs::path(p))) all_exist = false;
+    CHECK(all_exist, "returned entries are existing absolute paths");
+
+    // Deterministic order: descending case-insensitive basename, so the caller's reverse-order init
+    // runs them ascending. Without this a filesystem-defined order would make boots irreproducible.
+    bool ordered = true;
+    auto lower = [](std::string s) { for (auto& c : s) c = (char)std::tolower((unsigned char)c); return s; };
+    for (size_t i = 1; i < names.size(); i++)
+        if (!(lower(names[i - 1]) > lower(names[i]))) ordered = false;
+    CHECK(ordered, "result is sorted descending by lowercased basename (reproducible boot)");
+
+    // Case-insensitive listed-name match: a dump spelling the plugin differently must still be
+    // treated as already handled, never linked twice at two different bases.
+    const std::vector<std::string> listed_caps = { "psn.PRX", "savedata.prx" };
+    const std::vector<std::string> ci = basenames(discover_extra_plugin_modules(dump, listed_caps));
+    CHECK(!has(ci, "PSN.prx") && !has(ci, "SaveData.prx"),
+          "listed-name comparison is case-insensitive");
+
+    // A dump with no Plugins directory at all must yield nothing (and not throw).
+    const fs::path bare = root / "bare";
+    fs::create_directories(bare / "Media", ec);
+    CHECK(discover_extra_plugin_modules(bare.string(), listed).empty(),
+          "absent Media/Plugins directory yields no entries");
+    CHECK(discover_extra_plugin_modules("", listed).empty(), "empty dump root yields no entries");
+
+    // Case-only mismatch on the directory itself (case-sensitive host filesystems, cf. #1006).
+    const fs::path lc = root / "lowerdir";
+    fs::create_directories(lc / "media" / "plugins", ec);
+    { std::ofstream(lc / "media" / "plugins" / "Extra.prx") << "x"; }
+    const std::vector<std::string> lcnames = basenames(discover_extra_plugin_modules(lc.string(), listed));
+    CHECK(has(lcnames, "Extra.prx"), "lower-cased Media/Plugins directory is still discovered");
+
+    fs::remove_all(root, ec);
+    printf(fails ? "FAILED (%d)\n" : "PASSED\n", fails);
+    return fails ? 1 : 0;
+}


### PR DESCRIPTION
## What this fixes

prosper has no runtime PRX loading (#639), so every native plugin a Unity title P/Invokes must be
linked at boot. The preload list in `src/host/boot_program.cpp` is a hard-coded allowlist that grew
one plugin at a time — PSN, PSNCore/PSNCommon, CommonDialog, FMOD ×2, Wwise ×3. **Any title shipping
a plugin nobody added yet fails its first P/Invoke with `DllNotFoundException`, and IL2CPP raises
that inside an async state machine, so it is captured into a Task and never printed.** The title then
stops making progress with no diagnostic at all.

That is why *Tales of Graces f Remastered* (`PPSA19991`, #1609) looked so healthy while rendering
nothing: 20,296 presents in 180 s at ~113 fps, a complete Unity post chain, zero recompiler rejects,
and a 152-line boot log containing exactly one unimplemented NID.

## Root cause of #1609, measured

Managed symbols recovered with `tools/il2cpp/prx_to_elf.py` + Il2CppDumper (IL2CPP base
`0x440000000`), then `PROSPER_HWBP`:

| method | RVA | hits in 40 s |
|---|---|---|
| `Noble.GameMain.Update` | `0x330C80` | many (instrument control) |
| `Noble.GameMain.<InitSingletonInstancesAsync>d__9.MoveNext` | `0x3319A0` | **1** |
| `Noble.GameMain.InitNativeGameMain` | `0x330E80` | **0** |

`GameMain.State` is `{None, SingletonInitializing, SingletonInitialized, NativeGameMainInitialized,
Update, Terminate}`. The state machine runs once, suspends on its single `await`, and never resumes —
the title is pinned in `SingletonInitializing` forever, so no game object is ever created and the
camera renders an empty scene.

The await is `Noble.NobleTask.WhenAll` over 30 `PersistentScene.RegisterSingletonAsync<T>` tasks.
Breakpointing its completion counter
`NobleTask.<>c__DisplayClass2_0.<WhenAll>g__TryInvokeContinuationWithIncrement|0` shows **27 of 30**
increments fire. Breakpointing `AsyncValueTaskMethodBuilder::SetException` with `PROSPER_HWBP_KLASS=1`
names the three faults, all raised inside `SingletonManager.<RegisterImplAsync>d__19`:

```
[hwbp-klass] rbx obj=… name="DllNotFoundException"
[hwbp-klass] rbx obj=… name="DllNotFoundException"
[hwbp-klass] rbx obj=… name="TargetInvocationException"
```

They are registrations 5 `SaveLoadManager`, 6 `InputManager`, 12 `SoundManager`. Corroboration:
`SaveLoadManager.StartAsync` and `InputManager.StartAsync` get 0 breakpoint hits while
`AccountManager.StartAsync` (registration 4) gets 1 — the fault happens during construction, before
`StartAsync`.

The missing DLLs: the guest opens `Media/Plugins/{cri_ware_unity,GameNative}.prx`, but
`PROSPER_INITLOG=1` shows 7 linked modules and neither is among them.

**The frame itself proves prosper was faithful throughout.** Offline `gpu_replay --inspect-only` on a
retained capture: 28 semantic draws, every one a fullscreen post pass (`vcount=3`, or `vcount=4
topo=4` RectList clear) — zero mesh draws. `draws_last` is `GpuState::draws.size()`, the PM4 packet
count *before* any prosper filtering, so nothing was dropped. Every RTT seed is uniform `000000`
except the 256×16 colour LUT the frame generates itself, and `flips == submits` with
`draws_cum/submits == 28.0` exactly, so no other submit carries geometry.

## The change

`discover_extra_plugin_modules()` enumerates `<dump>/Media/Plugins/*.prx`, drops what the fixed list
already names (case-insensitively, so a differently-spelled dump is not linked twice), and returns the
rest in a deterministic order. `boot_program` links them at bases from a reserved pool between libc
and the import-stub region, inserted so their init functions run after libc and the bundled support
PRX but before the hard-coded Unity plugins (init runs in reverse list order). A bounded slot pool
prints a loud message rather than silently dropping a module. `PROSPER_NO_PLUGIN_AUTOLINK=1` restores
the old behaviour for an A/B.

### Never introduce a duplicate NID export

The global export table is first-definition-wins and **completely silent**: `exports.emplace(nid, addr)`
is a no-op when the NID is already present — no log, no counter, nothing in the boot summary. Two
modules exporting the same NIDs alias to whichever the list names first, while the loser is still
mapped, its `init_array` still runs, and `sceKernelDlsym` answers differently depending on which module
handle it is asked through (#147 consults the handle's own table first).

That is not hypothetical here. **Evergate (`PPSA01885`) ships `libfmod.prx` AND `libfmodL.prx`, plus
`libfmodstudio.prx` AND `libfmodstudioL.prx`** — FMOD's release and logging builds of the same
libraries, exporting identical NIDs. Naive auto-discovery would have linked a second full FMOD core.
Deduplicating on filename cannot see it (the names genuinely differ), and a suffix heuristic would be a
guess that is wrong on some other title. So the guard is on what the hazard actually is — exports.

`LinkInput::skip_on_export_collision` marks an input optional; `link_program` refuses it **before
building its image** if any NID it exports is already exported by an earlier accepted module, and
records path + colliding NID + owner in `Program::skipped_modules`. Live Evergate boot:

```
plugin auto-link: …/libresonanceaudio.prx @ 0x5d0000000
plugin auto-link: …/libfmodstudioL.prx @ 0x5d4000000
plugin auto-link: …/libfmodL.prx @ 0x5d8000000
plugin auto-link: SKIPPED …/libfmodstudioL.prx — it exports NID Hh2wT63cPf4, already provided by …/libfmodstudio.prx
plugin auto-link: SKIPPED …/libfmodL.prx — it exports NID zKjgSnqVqf4, already provided by …/libfmod.prx
linked 11 modules; 3869 imports (2827 cross-module, 732 stub slots); 10 init fns
```

So Evergate's net change is **+1 module, not +3**. It degrades correctly: a title shipping only the
debug build has nothing to collide with, so it still links. Named modules are never flagged.
`module_export_nids()` / `find_export_collision()` are shared with the export-table build so the two
predicates cannot drift — if they disagreed, a module could be accepted as collision-free and still
alias someone else's NID.

The silent-aliasing gap itself is **not** fixed here (it still applies to two *named* modules); it is
filed separately as **#1635**.

## Blast radius — 17 dumps ship `Media/Plugins`, 8 change

| Title | Newly linked | Refused (export collision) | Guards | Result |
|---|---|---|---|---|
| `PPSA01885` Evergate | `libresonanceaudio` | `libfmodL`, `libfmodstudioL` | `evergate-title`, `evergate-gameplay` | **both OK** |
| `PPSA13579` Blasphemous 2 | `lib_burst_generated`, `libresonanceaudio`, `PS5EntitlementsPlugin` | — | `blasphemous2-gameplay` | **OK** |
| `PPSA23396` Rugrats | `lib_burst_generated` | — | `rugrats-gameplay` | **OK** |
| `PPSA25009` Blue Prince | `lib_burst_generated`, `PS5AudioSpatializer` | — | `blue-prince-title`, `blue-prince-hall` | title **OK**; hall pre-existing fail, below |
| `PPSA19991` Tales of Graces f | `cri_ware_unity`, `GameNative`, `lib_burst_generated`, `PlayGo` | — | none (the subject) | advances past the stall |
| `PPSA03416` Summer Sports Games | `lib_burst_generated` | — | none | 10 draws/frame both arms |
| `PPSA30140` Syberia: Remastered | `libresonanceaudio`, `lib_burst_generated` | — | none | 485 vs 479 draws/frame |
| `PPSA30490` Asterix & Obelix | `lib_burst_generated` | — | none | 8 draws/frame both arms |

### `blue-prince-hall` — pre-existing, proven twice

It is a **wall-clock route** (`capture_after_seconds: 345`, "walks through the front door by ~350s"),
and on this machine the route is still in the intro cutscene at 345 s. **I opened the retained images:
they are healthy, fully-rendered letterboxed cinematic** — the will-reading portrait with subtitles,
then a gramophone — not a broken composite. The run was healthy too (`131 screenshots,
source-distinct=130 pixel-distinct=123 status=ok`); `distinct_rgb_colors: 72` is a genuinely dark
cutscene frame, not a collapse.

Attribution, in two steps, because this guard has caused a false attribution before:

1. Same binary, `PROSPER_NO_PLUGIN_AUTOLINK=1`: fails identically, same cutscene, one subtitle earlier.
2. **Unmodified master sources** (`git checkout <master> -- prosper/src prosper/CMakeLists.txt`,
   verified `discover_extra_plugin_modules` count = 0, full rebuild): fails identically and lands on
   the **exact same subtitle line — "my last will and testament,"** — as this branch's frame 00.

### Negative result worth recording

`PPSA30490` (Asterix & Obelix) is a rung-0 all-black Unity 6 title that gains `lib_burst_generated.prx`.
Linking it changes **nothing** (8 draws/frame in both arms), so its black frame is **not** a silent
`DllNotFoundException` — consistent with its own issue attributing it to an MSAA `image_load` fragment
reject. That narrows the "all-black Unity title" signature rather than letting it become a catch-all.

## Throughput

**No measurable steady-state cost. The arms overlap, and the original "20% regression" was an artifact
of a broken invocation plus GPU contention.**

12 alternating `ON/OFF` runs (3 cycles × 2 titles × 2 arms), 90 s each, **0 discarded**. The driver
self-locks, builds strictly before measuring, and samples foreign GPU consumers before *and* after each
run, renaming any contaminated log to `DISCARD-` rather than averaging it in — contention is a named
suspect in this very quantity, so a contended sample must be visible rather than absorbed.

Whole-run and steady-state are reported separately because a **one-off boot cost** (linking + running
`init_array` for extra modules) and a **per-frame cost** are indistinguishable in a whole-run average:
a run that reaches steady state a second later and then performs identically still shows a lower mean.

`PPSA13579` Blasphemous 2 — gains 3 modules, submits/s:

| arm | whole-run mean (min–max) | steady-state mean (min–max) |
|---|---|---|
| ON  | 351.7 (336.3–376.0) | 359.5 (342.0–374.2) |
| OFF | 357.1 (317.9–377.9) | 371.3 (363.8–376.6) |

`PPSA30490` Asterix — gains 1 module, submits/s:

| arm | whole-run mean (min–max) | steady-state mean (min–max) |
|---|---|---|
| ON  | 465.1 (382.7–506.7) | 458.4 (379.4–499.1) |
| OFF | 489.8 (459.4–507.0) | 476.0 (435.4–497.6) |

**Overlap verdict: arms overlap on every measure** — `PPSA13579` steady `ON[342.0..374.2]` vs
`OFF[363.8..376.6]`; `PPSA30490` steady `ON[379.4..499.1]` vs `OFF[435.4..497.6]`. The residual gap
between means is 3.2% and 3.7%, not 20%, and is not resolved by this data.

**The residual variance is cycle-correlated, not arm-correlated.** In **all four** title × arm
combinations the slowest run is **cycle 2** (13579 steady: ON 342.0, OFF 363.8; 30490 steady: ON 379.4,
OFF 435.4). A transient that lands on both arms of the same cycle is background load, not an effect of
the change — which is exactly what the alternating design exists to expose.

For completeness, the founding measurement is now explained rather than merely doubted. The
14,666-vs-18,167 pair was invalid twice over: the OFF arm used `VAR=1 $env_extra timeout …`, where the
shell picks the command word before expanding an unquoted variable, so the assignment became the
command name and **the arm never executed**; the re-run happened in a separate invocation while another
lane held `boot_trace` and `screenshot`. Both traps are now recorded in
`docs/GAME_COMPAT_ORCHESTRATION.md`.

The named alternative suspect is separately falsified: **stub-slot counts are identical in every arm**
(`PPSA30490` 786/786, `PPSA03416` 741/741, `PPSA30140` 821/821), so the extra modules' imports all
resolve cross-module or reuse an existing slot and no new slots exist to lengthen a hot-path lookup.
The only structural deltas are `+1..+2` `init fns` and a handful of cross-module imports.

## Verification

- New ctest **`plugin_autolink`**, 25 assertions. The discovery + predicate half runs **in CI with no
  dump** (`Module` is a plain struct, so synthetic symbol tables cover duplicate / disjoint /
  debug-build-alone, plus the exact export-predicate boundary: an import of a claimed NID, a
  zero-valued symbol and a NID-less symbol must never trigger a skip). With a dump configured it also
  drives `link_program` with the same PRX listed twice — **the unflagged control still links it three
  times**, so the assertions fail without this change.
- Full ctest with `GAME_DUMP=PPSA19991` at the exact pushed head `e467854f`: **165/167**. The two failures (`module_loads_eboot`,
  `boot_reaches_first_syscall`) **reproduce identically with this change stashed** — they assert The
  Messenger's import count and boot path against a different configured dump.
- Snapshot guards: 5 of 6 pass; the sixth is proven pre-existing above.
- `git diff --check` clean.

## What remains for `PPSA19991`

`Refs #1609` rather than `Fixes`, deliberately. This removes the root cause of the empty composite, but
the title is **still rung 0**: with its plugins linked it now stops at

```
[prosper] unimplemented: libkernel::eE4Szl8sil8  -> returning 0
```

= `sceKernelAprSubmitCommandBuffer`, filed as **#1629**. CRI's file system drives its reads through the
APR engine; prosper implements the resolve/stat/wait/`sceAmprAprCommandBufferReadFile` members of that
family but not the submit, so the read never completes. #1609 should stay open until the title renders.

A useful A/B for whoever takes #1629: linking **only** `GameNative.prx` (not CRI) avoids the APR path
and advances further still — the title loads `togf_resident_assets_nowloading_mdl.bundle` and then
null-dereferences in `Noble.SoundManager.ApplyListenerParam` ←
`NativeFuncImporter.NobleNativeGameMain_Initialize` ← `GameMain.Update`, because the CRI-backed sound
singleton is then the only one still missing. That is what identifies CRI as the APR caller.

## Pre-existing observation, not addressed here

`PROSPER_NO_PSN`'s filter is a **substring** match on `PSN.prx`/`SaveData.prx`, which auto-link makes
marginally more reachable (a hypothetical `MyPSN.prx` would be caught by it). Pre-existing, only under
that env var, and deliberately not widened or changed by this PR.

Refs #1609
