### PR TITLE
fix(diag): label guest addresses from the mapped base, not a relocated literal (#1659)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -315,6 +315,12 @@ if(TARGET prosper_core)
   target_link_libraries(test_sce_errno PRIVATE prosper_core)
   add_test(NAME sce_errno_freebsd COMMAND test_sce_errno)
 
+  # #1659: every diagnostic that prints "<module>+0x<rva>" agrees with the loader's mapped base, and a
+  # printed offset round-trips back through PROSPER_BP. Header-only; no dump, no device.
+  add_executable(test_guest_module_label tests/test_guest_module_label.cpp)
+  target_link_libraries(test_guest_module_label PRIVATE prosper_core)
+  add_test(NAME guest_module_label COMMAND test_guest_module_label)
+
   # PlatformUi hook (#347): the app frontend can service the guest's ImeDialog with real UI; with no
   # backend registered the headless auto-complete default is unchanged. Pure, no game dump.
   add_executable(test_platform_ui tests/test_platform_ui.cpp)

--- a/prosper/docs/GAME_COMPAT_ORCHESTRATION.md
+++ b/prosper/docs/GAME_COMPAT_ORCHESTRATION.md
@@ -125,6 +125,18 @@ count, read the last row's number.
   ran*, not of when the events happened. Print a common ordinal (`command_order`) on both and join on it. This
   is why the `order=` field exists on the `[exec] skip draw early` line — **it is not redundant with the
   register values on the same line, and removing it silently re-opens the phantom above.**
+- **A `<module>+0x<rva>` offset larger than the module's image is a labelling artifact, not a wild pointer.**
+  Guest module bases are fixed constants in `src/host/boot_program.hpp`, and they *move*: #825 relocated the
+  eboot from `0x400000000` to `0x410000000` so Astro Bot's direct-memory mapping would stop aliasing code.
+  Diagnostics that had hard-coded the old literal kept printing `eboot+0x…` against it, so every offset was
+  the real RVA **plus `0x10000000`** — an offset past the end of a 161 MB image, and one that no longer
+  round-tripped through `PROSPER_BP` (which adds the *mapped* base). #1659 converged every printer onto
+  `prosper::guest_module_name()` / `guest_module_offset()`; if you are hand-computing a base anywhere, that
+  is the bug. Two corollaries worth keeping: an address below the lowest module base is **data, not code**
+  (that region is now a DMEM aperture), and a single wide range test labelled every module in it "eboot",
+  so a wrong *binary* is as likely as a wrong offset. Static tools are unaffected — `xref.py`, `edis.py` and
+  `prx_to_elf.py` compute from ELF `p_vaddr`/file offsets and never add a runtime base, so RVAs recorded
+  from disassembly stay trustworthy.
 - **Before quoting a diagnostic's line count as a rate, grep for its cap.** These sites use a
   `static std::atomic<int>` counter or a per-key dedupe set; check for one before concluding "this fires N
   times" or "this is rare". When the site prints its own counter — `WaitRegMem #%d` *is* `ln` — the true

--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -455,7 +455,7 @@ static void poolshift_check(const char* kind, uint64_t dst, uint64_t bytes, uint
         (is_poolinfo_ptr(payload) && kind[0] != 'D');
     if (payload_suspicious) {
         if (n_payload.fetch_add(1) < 128)
-            fprintf(stderr, "[agc] POOLSHIFT-PAYLOAD kind=%s dst=0x%llx bytes=%llu payload=0x%llx pkt=eboot+0x%llx t=%llums\n",
+            fprintf(stderr, "[agc] POOLSHIFT-PAYLOAD kind=%s dst=0x%llx bytes=%llu payload=0x%llx pkt=0x%llx t=%llums\n",
                     kind, (unsigned long long)dst, (unsigned long long)bytes,
                     (unsigned long long)payload, (unsigned long long)pkt, (unsigned long long)now_ms());
     }
@@ -477,7 +477,7 @@ static void poolshift_check(const char* kind, uint64_t dst, uint64_t bytes, uint
             last_a.store(a, std::memory_order_relaxed); last_q.store(q, std::memory_order_relaxed);
             bool inspan = (a + 7 >= dst) && (a < dst + bytes);   // did THIS write touch these bytes?
             if (n.fetch_add(1) < 128)
-                fprintf(stderr, "[agc] POOLSHIFT-STOMP kind=%s @0x%llx=0x%llx (<<8=0x%llx) dst=0x%llx bytes=%llu inspan=%d payload=0x%llx pkt=eboot+0x%llx t=%llums\n",
+                fprintf(stderr, "[agc] POOLSHIFT-STOMP kind=%s @0x%llx=0x%llx (<<8=0x%llx) dst=0x%llx bytes=%llu inspan=%d payload=0x%llx pkt=0x%llx t=%llums\n",
                         kind, (unsigned long long)a, (unsigned long long)q, (unsigned long long)(q << 8),
                         (unsigned long long)dst, (unsigned long long)bytes, inspan,
                         (unsigned long long)payload, (unsigned long long)pkt, (unsigned long long)now_ms());
@@ -507,7 +507,7 @@ static void forge_trip(const char* kind, uint64_t dst, uint64_t pre, uint64_t va
     if (!on || !forges_freelist_ptr(pre, width, value)) return;
     static std::atomic<int> n{0};
     if (n.fetch_add(1) < 64)
-        fprintf(stderr, "[agc] FORGE-STOMP kind=%s dst=0x%llx pre=0x%llx val=0x%llx -> 0x%llx pkt=eboot+0x%llx t=%llums\n",
+        fprintf(stderr, "[agc] FORGE-STOMP kind=%s dst=0x%llx pre=0x%llx val=0x%llx -> 0x%llx pkt=0x%llx t=%llums\n",
                 kind, (unsigned long long)dst, (unsigned long long)pre, (unsigned long long)value,
                 (unsigned long long)(pre | (value & 0xffffffffull)), (unsigned long long)pkt,
                 (unsigned long long)now_ms());

--- a/prosper/src/gpu/mb3_freelist.cpp
+++ b/prosper/src/gpu/mb3_freelist.cpp
@@ -1,5 +1,6 @@
 #include "mb3_freelist.hpp"
 #include "gpu_execute.hpp"
+#include "../host/boot_program.hpp"   // #1659: BOOT_EBOOT (the real mapped base)
 
 #include <atomic>
 #include <cstdlib>
@@ -113,7 +114,10 @@ uint64_t discover_global_recycler_bin() {
     // DOLL's eboot address. The signature includes the following per-thread count transfer and slot
     // probe; the displacement itself is the only wildcard.
     static const uint64_t discovered = [] {
-        constexpr uint64_t kImageBase = 0x400000000ull;
+        // #1659: this SCANS guest memory for an instruction signature, so a stale base is not a
+        // labelling problem — 0x400000000 is the pre-#825 eboot address and is now a direct-memory
+        // aperture, meaning the scan swept 64 MiB of the wrong region and could never match.
+        constexpr uint64_t kImageBase = prosper::BOOT_EBOOT;
         constexpr uint64_t kScanBytes = 0x04000000ull;
         constexpr uint32_t kChunk = 0x10000;
         constexpr uint32_t kOverlap = 0x40;

--- a/prosper/src/hle/dispatch.cpp
+++ b/prosper/src/hle/dispatch.cpp
@@ -1,4 +1,5 @@
 #include "dispatch.hpp"
+#include "../host/boot_program.hpp"   // #1659
 #include <cstdlib>
 #include <unordered_map>
 #include <mutex>
@@ -39,7 +40,8 @@ namespace {
 
 #ifdef _WIN32
     bool executable_guest_address(uint64_t address) {
-        if (address < 0x400000000ull || address >= 0x600000000ull) return false;
+        // #1659: module range, not the pre-#825 literal (which admitted the DMEM aperture).
+        if (!prosper::guest_va_in_module(address) || address >= prosper::BOOT_STUB) return false;
         MEMORY_BASIC_INFORMATION memory{};
         if (!VirtualQuery((const void*)(uintptr_t)address, &memory, sizeof(memory)) ||
             memory.State != MEM_COMMIT || (memory.Protect & PAGE_GUARD)) return false;

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -9,6 +9,7 @@
 // reverse-engineered the real libSceAgc ABI. A later CommandProcessor will decode this PM4 stream to
 // Vulkan (see docs/AGC_IMPL_PLAN.md). Registered by raw NID (AGC lib is undocumented).
 #include "dispatch.hpp"
+#include "../host/boot_program.hpp"   // #1659: shared guest-module labelling
 #include "hle_kernel_time.hpp"
 #include "gpu/pm4_registers.hpp"
 #include "gpu/command_processor.hpp"
@@ -586,7 +587,7 @@ HLE9(agc_cb_release_mem) {  // sceAgcCbReleaseMem(buf, action, gcr_cntl, dst, ca
         uint64_t ra = 0, ra2 = 0, ra3 = 0;
         for (int i = 1; i < 96; i++) {
             uint64_t v = stack_scan[i];
-            if (v >= 0x400000000ull && v < 0x4c0000000ull) {
+            if (prosper::guest_va_in_module(v)) {   // #1659: was a stale literal base
                 if (!ra) ra = v; else if (!ra2) ra2 = v; else { ra3 = v; break; }
             }
         }
@@ -597,10 +598,13 @@ HLE9(agc_cb_release_mem) {  // sceAgcCbReleaseMem(buf, action, gcr_cntl, dst, ca
             for (int i = 0; i < n && i < 16; i++) if (seen_ra[i] == key) { logged = true; break; }
             if (!logged && n < 16) {
                 seen_ra[seen_n.fetch_add(1) & 15] = key;
-                fprintf(stderr, "[agc] fence1-builder ra=eboot+0x%llx ra2=eboot+0x%llx ra3=eboot+0x%llx addr=0x%llx action=0x%llx\n",
-                        (unsigned long long)(ra - 0x400000000ull),
-                        (unsigned long long)(ra2 ? ra2 - 0x400000000ull : 0),
-                        (unsigned long long)(ra3 ? ra3 - 0x400000000ull : 0),
+                fprintf(stderr, "[agc] fence1-builder ra=%s+0x%llx ra2=%s+0x%llx ra3=%s+0x%llx addr=0x%llx action=0x%llx\n",
+                        prosper::guest_module_name(ra),
+                        (unsigned long long)prosper::guest_module_offset(ra),
+                        ra2 ? prosper::guest_module_name(ra2) : "",
+                        (unsigned long long)(ra2 ? prosper::guest_module_offset(ra2) : 0),
+                        ra3 ? prosper::guest_module_name(ra3) : "",
+                        (unsigned long long)(ra3 ? prosper::guest_module_offset(ra3) : 0),
                         (unsigned long long)a5, (unsigned long long)a1);
             }
         }

--- a/prosper/src/hle/hle_audio.cpp
+++ b/prosper/src/hle/hle_audio.cpp
@@ -5,6 +5,7 @@
 // prosper_core stays dependency-free; a concrete output frontend (SDL3, ...) installs itself via
 // audio_set_sink() from outside the core.
 #include "dispatch.hpp"
+#include "../host/boot_program.hpp"   // #1659: shared guest-module labelling
 #include "nid.hpp"
 #include "audio.hpp"
 #include "ajm_decoder.hpp"     // optional host codecs (MP3); core retains AJM ABI + guest copies
@@ -418,7 +419,8 @@ void a2_log(const char* name, uint64_t a0, uint64_t a1, uint64_t a2,
     fprintf(stderr, "[audio2] %s(0x%llx, 0x%llx, 0x%llx, 0x%llx, 0x%llx, 0x%llx) ra=eboot+0x%llx\n",
             name, (unsigned long long)a0, (unsigned long long)a1, (unsigned long long)a2,
             (unsigned long long)a3, (unsigned long long)a4, (unsigned long long)a5,
-            (unsigned long long)((uint64_t)ra - 0x400000000ull));
+            prosper::guest_module_name((uint64_t)ra),
+            (unsigned long long)prosper::guest_module_offset((uint64_t)ra));
 }
 
 } // namespace

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -961,8 +961,12 @@ static void preadlog(const char* fn, uint64_t fd, uint64_t off, uint64_t cnt) {
     uint64_t cc[8] = {0,0,0,0,0,0,0,0}; int nc = 0; uint64_t* sp = (uint64_t*)__builtin_frame_address(0);
     int maxw = stack_words_above(sp);
     for (int i = 0; i < 1200 && i < maxw && nc < 8; i++) { uint64_t v = sp[i];
-        // #1659: was a stale pre-#825 literal base, so every printed caller was 0x10000000 high.
-        if (prosper::guest_va_in_module(v)) { uint64_t o = prosper::guest_module_offset(v);
+        // #1659: the base was a stale pre-#825 literal, so every printed caller was 0x10000000 high.
+        // Deliberately still EBOOT-ONLY: the format prints one "eboot+" prefix and then eight bare
+        // offsets, so admitting other modules here would label an Il2Cpp caller as an eboot RVA — a
+        // small, plausible, wrong number. Widening this needs a per-entry "name+off" format first.
+        if (v >= prosper::BOOT_EBOOT && v < prosper::BOOT_IL2CPP) {
+            uint64_t o = v - prosper::BOOT_EBOOT;
             if (nc == 0 || cc[nc-1] != o) cc[nc++] = o; } }
     fprintf(stderr, "[preadlog] %-6s %-24s fd=%lld off=0x%llx(blk %lld) cnt=0x%llx tid=%ld callers=eboot+0x%llx,0x%llx,0x%llx,0x%llx,0x%llx,0x%llx,0x%llx,0x%llx\n",
             fn, base, (long long)fd, (unsigned long long)off, (long long)(off / 0x10000),

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -961,7 +961,8 @@ static void preadlog(const char* fn, uint64_t fd, uint64_t off, uint64_t cnt) {
     uint64_t cc[8] = {0,0,0,0,0,0,0,0}; int nc = 0; uint64_t* sp = (uint64_t*)__builtin_frame_address(0);
     int maxw = stack_words_above(sp);
     for (int i = 0; i < 1200 && i < maxw && nc < 8; i++) { uint64_t v = sp[i];
-        if (v >= 0x400000000ull && v < 0x420000000ull) { uint64_t o = v - 0x400000000ull;
+        // #1659: was a stale pre-#825 literal base, so every printed caller was 0x10000000 high.
+        if (prosper::guest_va_in_module(v)) { uint64_t o = prosper::guest_module_offset(v);
             if (nc == 0 || cc[nc-1] != o) cc[nc++] = o; } }
     fprintf(stderr, "[preadlog] %-6s %-24s fd=%lld off=0x%llx(blk %lld) cnt=0x%llx tid=%ld callers=eboot+0x%llx,0x%llx,0x%llx,0x%llx,0x%llx,0x%llx,0x%llx,0x%llx\n",
             fn, base, (long long)fd, (unsigned long long)off, (long long)(off / 0x10000),
@@ -2397,9 +2398,13 @@ extern "C" uint64_t f_apr_read_submit(uint64_t a0, uint64_t a1, uint64_t a2,
             int shown = 0;
             for (int i = 0; i < 160 && shown < 6; i++) {
                 uint64_t v = sp[i];
-                if (v < 0x400000000ull || v >= 0x4c0000000ull) continue;
-                fprintf(stderr, "[apr]   guest-ra[%d] = eboot+0x%llx\n", i,
-                        (unsigned long long)(v - 0x400000000ull));
+                // Was `>= 0x400000000` with an "eboot+" label subtracting the same literal (#1659):
+                // that base is the PRE-#825 eboot address, so every offset was 0x10000000 too high,
+                // and the range covered IL2CPP/PSN modules too — all labelled "eboot".
+                if (!prosper::guest_va_in_module(v)) continue;
+                fprintf(stderr, "[apr]   guest-ra[%d] = %s+0x%llx\n", i,
+                        prosper::guest_module_name(v),
+                        (unsigned long long)prosper::guest_module_offset(v));
                 shown++;
             }
         }

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -980,9 +980,13 @@ static void preadlog(const char* fn, uint64_t fd, uint64_t off, uint64_t cnt) {
         int nf = 0; uint64_t last = 0;
         for (int i = 0; i < 1600 && i < maxw && nf < 20 && p < (int)sizeof line - 24; i++) {
             uint64_t v = sp[i];
+            // #1659: was a two-branch dispatcher whose eboot base was the stale pre-#825 literal
+            // (the il2cpp one was current). This formatter already carried a per-entry module tag, so
+            // unlike [preadlog] above it can name every module correctly.
             const char* m = nullptr; uint64_t o = 0;
-            if (v >= 0x400000000ull && v < 0x420000000ull) { m = "eb"; o = v - 0x400000000ull; }
-            else if (v >= 0x440000000ull && v < 0x4c0000000ull) { m = "il"; o = v - 0x440000000ull; }
+            if (prosper::guest_va_in_module(v)) {
+                m = prosper::guest_module_name(v); o = prosper::guest_module_offset(v);
+            }
             if (m && o != last) { p += snprintf(line + p, sizeof line - p, " %s+%llx", m, (unsigned long long)o); last = o; nf++; }
         }
         fprintf(stderr, "%s\n", line);

--- a/prosper/src/hle/hle_graphics.cpp
+++ b/prosper/src/hle/hle_graphics.cpp
@@ -12,6 +12,7 @@
 // Sony libs, so they're registered by raw NID with a note on the observed role.
 #include "dispatch.hpp"
 #include "nid.hpp"
+#include "../host/boot_program.hpp"   // #1659: shared guest-module labelling
 #include "host/exec_image.hpp"
 #include "gpu/videoout_present.hpp"
 #include "gpu/gpu_execute.hpp"      // guest_readable (safe pointer probe for the diagnostic dumps)
@@ -823,8 +824,9 @@ uint64_t glog_impl(const char* nid, void* ra,
                    uint64_t a0, uint64_t a1, uint64_t a2, uint64_t a3, uint64_t a4, uint64_t a5) {
     gfx_tick();
     if (getenv("PROSPER_GFXLOG"))
-        fprintf(stderr, "[gfx] libSceAgc::%s  from eboot+0x%llx  a0=0x%llx a1=0x%llx a2=0x%llx a3=0x%llx a4=0x%llx a5=0x%llx\n",
-                nid, (unsigned long long)((uint64_t)ra - 0x400000000ull),
+        fprintf(stderr, "[gfx] libSceAgc::%s  from %s+0x%llx  a0=0x%llx a1=0x%llx a2=0x%llx a3=0x%llx a4=0x%llx a5=0x%llx\n",
+                nid, prosper::guest_module_name((uint64_t)ra),
+                (unsigned long long)prosper::guest_module_offset((uint64_t)ra),
                 (unsigned long long)a0, (unsigned long long)a1, (unsigned long long)a2,
                 (unsigned long long)a3, (unsigned long long)a4, (unsigned long long)a5);
     // PROSPER_CTXDUMP: dump the register-context per-stage sub-objects' {source, user_data} pair at

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -15,6 +15,7 @@
 #include "dispatch.hpp"
 #include "nid.hpp"
 #include "sce_errno.hpp"
+#include "../host/boot_program.hpp"   // #1659: shared guest-module labelling
 #include "sync_futex.hpp"
 #include "../gpu/mb3_freelist.hpp"
 #include "../host/exec_image.hpp"
@@ -2128,18 +2129,14 @@ void exc_delivery_handler(int, siginfo_t* si, void* uc_) {
         uint64_t sfs = guest_fs_to_host_scoped();
         const char* fss = sfs ? "guest" : "host";
         char b[160]; int n;
-        if (irip >= 0x400000000ull && irip < 0x420000000ull)
-            n = snprintf(b, sizeof b, "[exc2] ENTER tid=%ld type=%d fs=%s rip=eboot+0x%llx\n",
-                         (long)prosper_gettid(), type, fss, (unsigned long long)(irip - 0x400000000ull));
-        else if (irip >= 0x440000000ull && irip < 0x443000000ull)
-            n = snprintf(b, sizeof b, "[exc2] ENTER tid=%ld type=%d fs=%s rip=il2cpp+0x%llx\n",
-                         (long)prosper_gettid(), type, fss, (unsigned long long)(irip - 0x440000000ull));
-        else if (irip >= 0x500000000ull && irip < 0x501000000ull)
-            n = snprintf(b, sizeof b, "[exc2] ENTER tid=%ld type=%d fs=%s rip=libc+0x%llx\n",
-                         (long)prosper_gettid(), type, fss, (unsigned long long)(irip - 0x500000000ull));
-        else
-            n = snprintf(b, sizeof b, "[exc2] ENTER tid=%ld type=%d fs=%s rip=host:0x%llx\n",
-                         (long)prosper_gettid(), type, fss, (unsigned long long)irip);
+        // #1659: was a hand-rolled three-branch dispatcher whose eboot (0x400000000) and libc
+        // (0x500000000) bases were both stale; only the il2cpp one was current. One shared,
+        // module-aware call replaces all three and cannot drift again.
+        n = snprintf(b, sizeof b, "[exc2] ENTER tid=%ld type=%d fs=%s rip=%s+0x%llx\n",
+                     (long)prosper_gettid(), type, fss, prosper::guest_module_name(irip),
+                     (unsigned long long)prosper::guest_module_offset(irip));
+        // guest_module_name/offset already degrade to "mapped/host" + the verbatim address, so the
+        // former host: fallback branch is folded into the single call above.
         (void)!write(2, b, n);
         guest_fs_restore_scoped(sfs);
     }

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -2909,7 +2909,8 @@ void dump_guest_thread_trace(const char* path, uint64_t pthread_filter) {
         unsigned guest_return_count = 0;
         for (size_t i = 0; i < stack_bytes / sizeof(uint64_t) && guest_return_count < 8; ++i) {
             const uint64_t candidate = stack_words[i];
-            if (candidate < 0x400000000ull || candidate >= 0x600000000ull) continue;
+            // #1659: module range, not the pre-#825 literal.
+            if (!prosper::guest_va_in_module(candidate) || candidate >= prosper::BOOT_STUB) continue;
             bool in_guest_module = false;
             for (const UnwindModuleDesc& guest_module : modules)
                 in_guest_module |= candidate >= guest_module.lo && candidate < guest_module.hi;

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -4591,7 +4591,9 @@ uint64_t sync_guest_caller() {
     uint64_t* sp = (uint64_t*)__builtin_frame_address(0);
     for (int i = 0; i < 160; i++) {
         uint64_t v = sp[i];
-        if (v < 0x400000000ull || v >= 0x600000000ull) continue;   // guest MODULES only (exclude 0x6.. import stubs)
+        // #1659: says "guest MODULES only" and now means it — the old lower bound admitted the
+        // pre-#825 aperture, which is direct memory, not a module.
+        if (!prosper::guest_va_in_module(v) || v >= prosper::BOOT_STUB) continue;
         if ((v & 0xfff) < 8) continue;                             // keep the 6-byte look-back on v's page
         // A stack word in the guest range may be data, not a return address, and could point at an
         // UNMAPPED gap between modules — so confirm the page is committed+readable before dereferencing

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -6,6 +6,7 @@
 #include "dispatch.hpp"
 #include "nid.hpp"
 #include "sce_errno.hpp"
+#include "../host/boot_program.hpp"   // #1659: shared guest-module labelling
 #include "sync_futex.hpp"   // shared futex wake + waiter registration (also used by the GPU's label wake)
 #include "../host/guest_memory_map.hpp"
 #include "../host/guest_write_watch.hpp"
@@ -1116,7 +1117,9 @@ HLE(k_wait_on_address) {
     // NOT the job pool (0xae1af9 / 0x18ab088) — those need real jobs and crash on a phantom. Whitelist:
     // main PreloadManager 0x18a83b5, GfxDevice work-queue 0xb0672a, worker 0x9385d7.
     uint64_t gra = ((uint64_t*)__builtin_frame_address(0))[1];   // guest return address (stub tail-jumped)
-    uint64_t goff = gra - 0x400000000ull;
+    // #1659: this is NOT a label — it feeds the RVA whitelist below, so the stale pre-#825
+    // base made every comparison fail and PROSPER_PUNCH has been silently inert since then.
+    uint64_t goff = prosper::guest_module_offset(gra);
     bool punch_site = (goff == 0x18a83b5 || goff == 0xb0672a || goff == 0x9385d7);
     if (punch_secs > 0 && a2 == 0 && !pts && punch_site) {
         ts.tv_sec = punch_secs; ts.tv_nsec = 0; pts = &ts;   // bound this otherwise-infinite wait
@@ -1146,9 +1149,10 @@ HLE(k_wait_on_address) {
             punch_budget.fetch_sub(1);
             *(volatile uint32_t*)(uintptr_t)a0 = (uint32_t)a1 + 1;
             futex_wake(a0, INT_MAX);
-            fprintf(stderr, "[punch] T%ld addr=0x%llx exp=0x%llx -> fabricated signal (ra=eboot+0x%llx, budget=%d)\n",
+            fprintf(stderr, "[punch] T%ld addr=0x%llx exp=0x%llx -> fabricated signal (ra=%s+0x%llx, budget=%d)\n",
                     (long)prosper_gettid(), (unsigned long long)a0, (unsigned long long)a1,
-                    (unsigned long long)(gra - 0x400000000ull), punch_budget.load());
+                    prosper::guest_module_name(gra),
+                    (unsigned long long)prosper::guest_module_offset(gra), punch_budget.load());
             return 0;
         }
         return prosper::hle::kSceKernelErrorETIMEDOUT;   // 0x8002003c: FreeBSD ETIMEDOUT is 60
@@ -1160,9 +1164,10 @@ HLE(k_wake_by_address) {
     int n = a1 ? (int)a1 : INT_MAX;
     futex_wake(a0, n);
     if (synclog()) {
-        uint64_t wgoff = ((uint64_t*)__builtin_frame_address(0))[1] - 0x400000000ull;
-        fprintf(stderr, "[sync] T%ld WAKE       addr=0x%llx *addr=0x%x n=%d caller=eboot+0x%llx\n",
-                (long)prosper_gettid(), (unsigned long long)a0, *(uint32_t*)a0, n, (unsigned long long)wgoff);
+        const uint64_t wra = ((uint64_t*)__builtin_frame_address(0))[1];
+        fprintf(stderr, "[sync] T%ld WAKE       addr=0x%llx *addr=0x%x n=%d caller=%s+0x%llx\n",
+                (long)prosper_gettid(), (unsigned long long)a0, *(uint32_t*)a0, n,
+                prosper::guest_module_name(wra), (unsigned long long)prosper::guest_module_offset(wra));
     }
     return 0;
 }

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -3,6 +3,7 @@
 #include "dispatch.hpp"
 #include "nid.hpp"
 #include "hle_kernel_time.hpp"
+#include "../host/boot_program.hpp"   // #1659: shared guest-module labelling
 #include "sce_errno.hpp"    // #1612: the guest reads FreeBSD errnos, not this host's
 #include "heap_mutex.hpp"   // #707: keep hot equeue/APR mutexes off macOS __DATA
 #include "sync_futex.hpp"
@@ -897,9 +898,10 @@ HLE(k_eq_delete) {
     return 0;
 }
 HLE(k_eq_wait)   {   // (eq, SceKernelEvent* ev, int num, int* out, SceKernelUseconds* timeout)
-    if (evlog()) fprintf(stderr, "[ev] WaitEqueue eq=0x%llx num=%llu timeout=%s ra=eboot+0x%llx\n",
+    if (evlog()) fprintf(stderr, "[ev] WaitEqueue eq=0x%llx num=%llu timeout=%s ra=%s+0x%llx\n",
         (unsigned long long)a0, (unsigned long long)a2, a4 ? "yes" : "inf",
-        (unsigned long long)((uint64_t)__builtin_return_address(0) - 0x400000000ull));
+        prosper::guest_module_name((uint64_t)__builtin_return_address(0)),
+        (unsigned long long)prosper::guest_module_offset((uint64_t)__builtin_return_address(0)));
     const int num = static_cast<int32_t>(a2);
     auto s = eq_find(a0);
     // Match the API's validation order: queue handle, event array, then count. EFAULT does not
@@ -920,7 +922,9 @@ HLE(k_eq_wait)   {   // (eq, SceKernelEvent* ev, int num, int* out, SceKernelUse
             const char* p = dc;
             while (*p) {
                 uint64_t off = strtoull(p, nullptr, 16);
-                const uint8_t* code = (const uint8_t*)(uintptr_t)(0x400000000ull + off);
+                // #1659: this DEREFERENCES the computed address, so the stale base did not merely mislabel —
+                // PROSPER_DUMPCODE read 0x10000000 below the intended instruction.
+                const uint8_t* code = (const uint8_t*)(uintptr_t)(prosper::BOOT_EBOOT + off);
                 fprintf(stderr, "[dumpcode] eboot+0x%llx:", (unsigned long long)off);
                 for (int b = 0; b < 224; b++) fprintf(stderr, "%02x", code[b]);
                 fprintf(stderr, "\n");
@@ -935,7 +939,7 @@ HLE(k_eq_wait)   {   // (eq, SceKernelEvent* ev, int num, int* out, SceKernelUse
             uint64_t* sp = (uint64_t*)__builtin_frame_address(0);
             for (int i = 0; i < 160; i++) {
                 uint64_t v = sp[i];
-                if (v < 0x400000000ull || v >= 0x4c0000000ull) continue;   // eboot / IL2CPP executable range
+                if (!prosper::guest_va_in_module(v)) continue;   // any fixed guest module (#1659)
                 // A genuine caller is a return address preceded by a call: `call rel32` (0xe8 at v-5,
                 // any target — the import call goes through an in-eboot thunk, NOT straight to the
                 // stub region, so no target filter) or an indirect `call` (0xff at v-6/-3/-2).
@@ -943,9 +947,9 @@ HLE(k_eq_wait)   {   // (eq, SceKernelEvent* ev, int num, int* out, SceKernelUse
                 bool is_call = pre[3] == 0xe8 ||                            // call rel32 at v-5
                                pre[2] == 0xff || pre[5] == 0xff || pre[6] == 0xff;  // call r/m64 forms
                 if (!is_call) continue;
-                fprintf(stderr, "[waitcaller] eq=0x%llx num=%llu stack[%d] eboot+0x%llx | code@ra-0x18:",
+                fprintf(stderr, "[waitcaller] eq=0x%llx num=%llu stack[%d] %s+0x%llx | code@ra-0x18:",
                         (unsigned long long)a0, (unsigned long long)a2, i,
-                        (unsigned long long)(v - 0x400000000ull));
+                        prosper::guest_module_name(v), (unsigned long long)prosper::guest_module_offset(v));
                 const uint8_t* code = (const uint8_t*)(uintptr_t)(v - 0x18);
                 for (int b = 0; b < 0x40; b++) fprintf(stderr, "%02x", code[b]);
                 fprintf(stderr, "\n");
@@ -981,8 +985,9 @@ HLE(k_eq_wait)   {   // (eq, SceKernelEvent* ev, int num, int* out, SceKernelUse
         n++;
     }
     if (a3) *(int32_t*)P(a3) = n;
-    if (evlog() && n > 0) fprintf(stderr, "[ev]   -> delivered %d ev(s) eq=0x%llx ra=eboot+0x%llx (ident=%lld filter=%d)\n",
-        n, (unsigned long long)a0, (unsigned long long)((uint64_t)__builtin_return_address(0) - 0x400000000ull),
+    if (evlog() && n > 0) fprintf(stderr, "[ev]   -> delivered %d ev(s) eq=0x%llx ra=%s+0x%llx (ident=%lld filter=%d)\n",
+        n, (unsigned long long)a0, prosper::guest_module_name((uint64_t)__builtin_return_address(0)),
+        (unsigned long long)prosper::guest_module_offset((uint64_t)__builtin_return_address(0)),
         (long long)(ev ? ev[0].ident : 0), (int)(ev ? ev[0].filter : 0));
     // Timed wait that expired with nothing: the real API distinguishes this from success (Kyty
     // EventQueue.cpp:310 KERNEL_ERROR_ETIMEDOUT). Only reachable with a timeout arg — the infinite

--- a/prosper/src/host/boot_program.hpp
+++ b/prosper/src/host/boot_program.hpp
@@ -40,6 +40,71 @@ inline constexpr uint64_t BOOT_PLUGIN_AUTO_STRIDE = 0x4000000ull;   // 64 MiB
 inline constexpr unsigned BOOT_PLUGIN_AUTO_SLOTS  = 10;
 inline constexpr uint64_t BOOT_STUB     = 0x600000000ull;
 
+// --- Guest-address labelling, shared by every diagnostic that prints "<module>+0x<rva>" ----------
+//
+// These exist because the same label was being produced three different ways (#1659). The eboot base
+// MOVED in #825 (0x400000000 -> 0x410000000, so Astro Bot's direct-memory mapping at
+// [0x400000000,0x40b800000) would stop aliasing code), and the diagnostics that had hard-coded the old
+// literal were never updated. They kept printing "eboot+0x…" against 0x400000000, so every offset was
+// the real RVA plus 0x10000000 — a plausible-looking number that lands nowhere, and one that no longer
+// round-trips through PROSPER_BP (which correctly adds the *mapped* base).
+//
+// Two further defects the literal caused, beyond the shift:
+//   * [0x400000000,0x410000000) is now a direct-memory aperture, not code — a data pointer there was
+//     classified as "eboot" and printed as a code offset.
+//   * Sites testing a single wide range (e.g. [0x400000000,0x4c0000000)) labelled EVERY module in it
+//     "eboot+", so an IL2CPP return address was reported as an eboot RVA. Wrong binary, not just wrong
+//     offset.
+//
+// Use these instead of subtracting any literal. `guest_module_name` returns a stable short name, and
+// `guest_module_offset` the offset within that module; for an address outside every fixed module the
+// name is "mapped/host" and the offset is the address itself, so a caller can print it verbatim.
+inline const char* guest_module_name(uint64_t a) {
+    if (a >= BOOT_EBOOT         && a < BOOT_IL2CPP)        return "eboot";
+    if (a >= BOOT_IL2CPP        && a < BOOT_PSNCORE)       return "Il2cpp";
+    if (a >= BOOT_PSNCORE       && a < BOOT_PSNCOMMON)     return "PSNCore.prx";
+    if (a >= BOOT_PSNCOMMON     && a < BOOT_COMMONDIALOG)  return "PSNCommon.prx";
+    if (a >= BOOT_COMMONDIALOG  && a < BOOT_PS5UTIL)       return "CommonDialog.prx";
+    if (a >= BOOT_PS5UTIL       && a < BOOT_NPCPPWEBAPI)   return "PS5Util";
+    if (a >= BOOT_NPCPPWEBAPI   && a < BOOT_PSN)           return "libSceNpCppWebApi.prx";
+    if (a >= BOOT_PSN           && a < BOOT_SAVEDATA)      return "PSN.prx";
+    if (a >= BOOT_SAVEDATA      && a < BOOT_FMODSTUDIO)    return "SaveData.prx";
+    if (a >= BOOT_FMODSTUDIO    && a < BOOT_FMOD)          return "libfmodstudio.prx";
+    if (a >= BOOT_FMOD          && a < BOOT_AKMOTION)      return "libfmod.prx";
+    if (a >= BOOT_AKMOTION      && a < BOOT_AKVORBIS)      return "AkMotion.prx";
+    if (a >= BOOT_AKVORBIS      && a < BOOT_AKSOUNDENGINE) return "AkVorbisHwAccelerator.prx";
+    if (a >= BOOT_AKSOUNDENGINE && a < BOOT_LIBC)          return "AkSoundEngine.prx";
+    if (a >= BOOT_LIBC          && a < BOOT_PLUGIN_AUTO_BASE) return "libc.prx";
+    if (a >= BOOT_PLUGIN_AUTO_BASE && a < BOOT_STUB)       return "plugin";
+    if (a >= BOOT_STUB          && a < 0x610000000ull)     return "STUB";
+    return "mapped/host";
+}
+inline uint64_t guest_module_offset(uint64_t a) {
+    if (a >= BOOT_EBOOT         && a < BOOT_IL2CPP)        return a - BOOT_EBOOT;
+    if (a >= BOOT_IL2CPP        && a < BOOT_PSNCORE)       return a - BOOT_IL2CPP;
+    if (a >= BOOT_PSNCORE       && a < BOOT_PSNCOMMON)     return a - BOOT_PSNCORE;
+    if (a >= BOOT_PSNCOMMON     && a < BOOT_COMMONDIALOG)  return a - BOOT_PSNCOMMON;
+    if (a >= BOOT_COMMONDIALOG  && a < BOOT_PS5UTIL)       return a - BOOT_COMMONDIALOG;
+    if (a >= BOOT_PS5UTIL       && a < BOOT_NPCPPWEBAPI)   return a - BOOT_PS5UTIL;
+    if (a >= BOOT_NPCPPWEBAPI   && a < BOOT_PSN)           return a - BOOT_NPCPPWEBAPI;
+    if (a >= BOOT_PSN           && a < BOOT_SAVEDATA)      return a - BOOT_PSN;
+    if (a >= BOOT_SAVEDATA      && a < BOOT_FMODSTUDIO)    return a - BOOT_SAVEDATA;
+    if (a >= BOOT_FMODSTUDIO    && a < BOOT_FMOD)          return a - BOOT_FMODSTUDIO;
+    if (a >= BOOT_FMOD          && a < BOOT_AKMOTION)      return a - BOOT_FMOD;
+    if (a >= BOOT_AKMOTION      && a < BOOT_AKVORBIS)      return a - BOOT_AKMOTION;
+    if (a >= BOOT_AKVORBIS      && a < BOOT_AKSOUNDENGINE) return a - BOOT_AKVORBIS;
+    if (a >= BOOT_AKSOUNDENGINE && a < BOOT_LIBC)          return a - BOOT_AKSOUNDENGINE;
+    if (a >= BOOT_LIBC          && a < BOOT_PLUGIN_AUTO_BASE) return a - BOOT_LIBC;
+    if (a >= BOOT_PLUGIN_AUTO_BASE && a < BOOT_STUB)
+        return (a - BOOT_PLUGIN_AUTO_BASE) % BOOT_PLUGIN_AUTO_STRIDE;
+    if (a >= BOOT_STUB          && a < 0x610000000ull)     return a - BOOT_STUB;
+    return a;
+}
+// True when `a` lies inside some fixed guest module, i.e. "<name>+0x<offset>" is meaningful.
+inline bool guest_va_in_module(uint64_t a) {
+    return a >= BOOT_EBOOT && a < 0x610000000ull;
+}
+
 // Boot the title rooted at `dump_root` (the app0 directory): link the fixed module set (dropping any
 // absent dependent module — cross-title tolerance; honors PROSPER_NO_PSN), register the built-in
 // HLE, map the images, set up TLS / unwind / procparam, install the import stubs + trap handler,

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -5,6 +5,7 @@
 #include "guest_write_watch.hpp"
 #include "fs_emu.hpp"
 #include "raw_syscall.hpp"
+#include "boot_program.hpp"   // #1659: shared guest-module labelling (BOOT_* bases)
 #include "../hle/nid.hpp"
 #include "../hle/dispatch.hpp"
 
@@ -56,6 +57,13 @@ namespace prosper {
 
 namespace {
     uint64_t g_base = 0, g_stub_base = 0, g_stub_size = 0, g_nstubs = 0;
+    // #1659: label guest addresses through the shared, module-aware helpers instead of subtracting a
+    // literal base. These sites hard-coded 0x400000000 — the eboot's address BEFORE #825 relocated it
+    // to 0x410000000 — so every printed offset was 0x10000000 too high and did not round-trip through
+    // PROSPER_BP, which adds the real mapped base. Async-signal-safe: pure comparisons and arithmetic.
+    inline const char* gmod(uint64_t a) { return prosper::guest_module_name(a); }
+    inline uint64_t    goff(uint64_t a) { return prosper::guest_module_offset(a); }
+    inline bool        gin(uint64_t a)  { return prosper::guest_va_in_module(a); }
     // Real per-thread stack registry (keyed by pthread id). Each guest thread runs on a
     // stack we allocate (the main thread's mmap'd stack; workers' stacks from
     // k_pthread_create), so the GC/thread code gets accurate bounds without the fragile
@@ -115,8 +123,10 @@ namespace {
     // never processed — log the object state and redirect RIP to the reader's own skip label
     // (eboot+0xba6e40, where its type/flag-check branches already land) so processing continues as if
     // the companion weren't needed. This is a *probe* to reveal whether the null companion is the sole
-    // blocker or one of a cascade — NOT a fix (the companions are still not real). eboot base is the
-    // fixed 0x400000000 in this project; overridable via PROSPER_SKIP_RIP / PROSPER_SKIP_TARGET.
+    // blocker or one of a cascade — NOT a fix (the companions are still not real). Overridable via
+    // PROSPER_SKIP_RIP / PROSPER_SKIP_TARGET. NOTE: the two defaults below are absolute guest VAs
+    // computed against the PRE-#825 eboot base (0x400000000) and are stale for that reason (#1659);
+    // they are Messenger-specific probe addresses and are only meaningful when explicitly overridden.
     bool     g_skip_null_companion = false;
     uint64_t g_skip_rip    = 0x400ba6e08ull;   // reader companion deref (mov 0x8(%rsi),%rax; rsi=null)
     uint64_t g_skip_target = 0x400ba6e40ull;   // reader skip label (continues via [obj+0x520/0x530])
@@ -171,7 +181,7 @@ namespace {
     // function (e.g. the GfxDevice ctor 0x95c700) concurrent execution during the byte-restored window
     // corrupts control flow (observed: wild jump). For those, read fault-time state instead of stepping.
     bool     g_bp_on = false;
-    uint64_t g_bp_addr = 0;                    // guest VA of the breakpoint (0x400000000 + offset)
+    uint64_t g_bp_addr = 0;                    // guest VA of the breakpoint (mapped base + offset)
     uint8_t  g_bp_orig = 0;                    // original byte replaced by 0xCC
     bool     g_bp_stepping = false;            // mid single-step (orig byte restored, TF set)
     volatile sig_atomic_t g_bp_count = 0;
@@ -1068,7 +1078,7 @@ namespace {
                 uint64_t addr = g_mb3w[mi].addr;
                 unsigned long long v = *(volatile uint64_t*)addr;
                 uint64_t wr = (uint64_t)gr2[REG_RIP];
-                bool in_eboot = (wr >= 0x400000000ull && wr < 0x420000000ull);
+                bool in_eboot = (gin(wr));
                 bool shifted = lwatch_is_pool_shift(v);
                 // base+0x20 is a HOT free-list head (every idx-1 malloc/free touches it), so logging
                 // every benign write floods I/O and stalls the run before the t~60s corruption burst.
@@ -1079,9 +1089,9 @@ namespace {
                     g_mb3w_seen[mi]++;
                 }
                 char b[256]; int n = snprintf(b, sizeof b,
-                    "[mb3watch] WRITE [0x%llx]=0x%llx by rip=%s0x%llx tid=%ld%s\n",
-                    (unsigned long long)addr, v, in_eboot ? "eboot+" : "host:",
-                    (unsigned long long)(in_eboot ? wr - 0x400000000ull : wr), cur_tid(),
+                    "[mb3watch] WRITE [0x%llx]=0x%llx by rip=%s%s0x%llx tid=%ld%s\n",
+                    (unsigned long long)addr, v, in_eboot ? gmod(wr) : "host:", in_eboot ? "+" : "",
+                    (unsigned long long)(in_eboot ? goff(wr) : wr), cur_tid(),
                     shifted ? "  <<<<< POOLSHIFT CORRUPTOR" : "");
                 raw_write(2, b, (size_t)n);
                 if (!in_eboot) classify_addr(wr);
@@ -1103,9 +1113,9 @@ namespace {
                     for (uint64_t p = rsp; p < rsp + 0x200 && found < 10; p += 8) {
                         if (!probe_readable(p)) break;
                         uint64_t ra = *(const uint64_t*)p;
-                        if (ra >= 0x400000000ull && ra < 0x420000000ull) {
+                        if (gin(ra)) {
                             sn += snprintf(sb + sn, sizeof sb - sn, " eboot+0x%llx",
-                                           (unsigned long long)(ra - 0x400000000ull));
+                                           (unsigned long long)goff(ra));
                             found++;
                         }
                     }
@@ -1136,7 +1146,7 @@ namespace {
                     if (v >= g_stepwin_base && v < g_stepwin_end) { cur = v; break; } }
                 if (cur && cur != g_stepwin_prevcur) {
                     g_stepwin_ring[g_stepwin_pos % STEPWIN_RING] =
-                        { (unsigned long long)(rip - 0x400000000ull), cur };
+                        { (unsigned long long)goff(rip), cur };
                     g_stepwin_pos++; g_stepwin_prevcur = cur;
                 }
                 bool at_driver = (rip == g_hwbp_addr);
@@ -1177,10 +1187,10 @@ namespace {
                     g_hwwatch_count = g_hwwatch_count + 1;
                     char b[200];
                     uint64_t wr = (uint64_t)gr2[REG_RIP];
-                    bool in_eboot = (wr >= 0x400000000ull && wr < 0x420000000ull);
-                    int n = snprintf(b, sizeof b, "[hwwatch] #%d WRITE [0x%llx]=0x%llx by rip=%s0x%llx tid=%ld\n",
+                    bool in_eboot = (gin(wr));
+                    int n = snprintf(b, sizeof b, "[hwwatch] #%d WRITE [0x%llx]=0x%llx by rip=%s%s0x%llx tid=%ld\n",
                         (int)g_hwwatch_count, (unsigned long long)g_hwwatch_addr, v,
-                        in_eboot ? "eboot+" : "", (unsigned long long)(in_eboot ? wr - 0x400000000ull : wr), cur_tid());
+                        in_eboot ? gmod(wr) : "", in_eboot ? "+" : "", (unsigned long long)(in_eboot ? goff(wr) : wr), cur_tid());
                     raw_write(2, b, (size_t)n);   /* raw syscall: no libc TLS access */
                     if (!in_eboot) classify_addr(wr);
                 }
@@ -1203,7 +1213,7 @@ namespace {
                 unsigned val = probe_readable(rax) ? *(const uint32_t*)rax : 0xBADBADu;
                 unsigned long long cur = probe_readable(rbxr + 0x38) ? *(const uint64_t*)(rbxr + 0x38) : 0;
                 int p = g_hwbp_ring_pos % HWBP_RING;
-                g_hwbp_ring[p] = { (unsigned long long)((uint64_t)gr[REG_RIP] - 0x400000000ull),
+                g_hwbp_ring[p] = { (unsigned long long)goff((uint64_t)gr[REG_RIP]),
                                    cur, (unsigned long long)rax, val, 0, 0, 0, (unsigned long long)r14, 0 };
                 g_hwbp_ring_pos = g_hwbp_ring_pos + 1;
                 if ((uint64_t)val >= g_hwbp_anom) hwbp_dump_ring("anom");
@@ -1221,7 +1231,7 @@ namespace {
                 unsigned long long s68 = probe_readable(cacher + 0x68)? *(const uint64_t*)(cacher + 0x68): 0xBADBADull;
                 unsigned long long f160= probe_readable(cacher + 0x160)?*(const uint64_t*)(cacher + 0x160):0xBADBADull;
                 int p = g_hwbp_ring_pos % HWBP_RING;
-                g_hwbp_ring[p] = { (unsigned long long)((uint64_t)gr[REG_RIP] - 0x400000000ull),
+                g_hwbp_ring[p] = { (unsigned long long)goff((uint64_t)gr[REG_RIP]),
                                    req/*cur=requested block*/, (unsigned long long)cacher, 0,
                                    s50/*[+0x50]*/, s68/*[+0x68]*/, f160/*[+0x160]*/, 0, 0 };
                 g_hwbp_ring_pos = g_hwbp_ring_pos + 1;
@@ -1240,7 +1250,7 @@ namespace {
                     if (k >= 2) { char b[128]; int n = snprintf(b, sizeof b, "[hwbp-str] %s=0x%llx -> \"%s\"\n", rn, (unsigned long long)p, s); raw_write(2, b, (size_t)n);   /* raw syscall: no libc TLS access */ }
                 };
                 char hdr[64]; int hn = snprintf(hdr, sizeof hdr, "[hwbp-str] hit @eboot+0x%llx:\n",
-                    (unsigned long long)((uint64_t)gr[REG_RIP] - 0x400000000ull)); raw_write(2,hdr, hn);
+                    (unsigned long long)goff((uint64_t)gr[REG_RIP])); raw_write(2,hdr, hn);
                 pstr("rdi", (uint64_t)gr[REG_RDI]); pstr("rsi", (uint64_t)gr[REG_RSI]);
                 pstr("rdx", (uint64_t)gr[REG_RDX]); pstr("rcx", (uint64_t)gr[REG_RCX]);
                 pstr("r8",  (uint64_t)gr[REG_R8]);  pstr("r9",  (uint64_t)gr[REG_R9]);
@@ -1331,7 +1341,7 @@ namespace {
                     (unsigned long long)arg_field((uint64_t)gr[REG_RDX]),
                     (unsigned long long)gr[REG_RCX],
                     (unsigned long long)gr[REG_R8], (unsigned long long)gr[REG_R9],
-                    (unsigned long long)(probe_readable((uint64_t)gr[REG_RSP]) ? (*(const uint64_t*)(uint64_t)gr[REG_RSP] - 0x400000000ull) : 0));
+                    (unsigned long long)(probe_readable((uint64_t)gr[REG_RSP]) ? goff(*(const uint64_t*)(uint64_t)gr[REG_RSP]) : 0));
                 raw_write(2, b, (size_t)n);
             }
             // PROSPER_HWBP_OBJ=1: treat rdi as an il2cpp object (at a method-entry bp); print its class
@@ -1373,7 +1383,7 @@ namespace {
                     return probe_readable(a) ? (unsigned long long)*(const uint64_t*)a : 0xBADBADull; };
                 uint64_t rbp = (uint64_t)gr[REG_RBP], rsp = (uint64_t)gr[REG_RSP];
                 auto off = [](unsigned long long v) -> unsigned long long {
-                    return (v >= 0x400000000ull && v < 0x420000000ull) ? v - 0x400000000ull : v; };
+                    return (gin(v)) ? goff(v) : v; };
                 // Also surface rax + the u32 at [rax] — at the deserializer length-read site (0x7e40d9/e1)
                 // rax is the stream cursor and [rax] the value being read, so a trace shows the parse walk.
                 unsigned rax_u32 = probe_readable(rax) ? *(const uint32_t*)rax : 0xBADBADu;
@@ -1384,7 +1394,7 @@ namespace {
                 char b[512];
                 int n = snprintf(b, sizeof b,
                     "[hwbp] #%d rip=eboot+0x%llx rax=0x%llx [rax]=0x%08x r14=0x%llx rbx=0x%llx cur=0x%llx base=0x%llx end=0x%llx ret=eboot+0x%llx caller_rbp=eboot+0x%llx tid=%ld\n",
-                    (int)g_hwbp_count, (unsigned long long)((uint64_t)gr[REG_RIP] - 0x400000000ull),
+                    (int)g_hwbp_count, (unsigned long long)goff((uint64_t)gr[REG_RIP]),
                     (unsigned long long)rax, rax_u32, (unsigned long long)r14, (unsigned long long)rbx,
                     rd(rbx+0x38), rd(rbx+0x40), rd(rbx+0x48), off(rd(rsp)), off(rd(rbp + 8)), cur_tid());
                 (void)r15; (void)rdi; (void)rsi;
@@ -1523,9 +1533,9 @@ namespace {
                     for (uint64_t o = 0; o < 0x200 && found < 8 && n < (int)sizeof b - 24; o += 8) {
                         if (!probe_readable(rsp + o)) break;
                         uint64_t v = *(const uint64_t*)(rsp + o);
-                        if (v >= 0x400000000ull && v < 0x40a000000ull) {
+                        if (gin(v)) {
                             n += snprintf(b + n, sizeof b - (size_t)n, " s:%llx",
-                                          (unsigned long long)(v - 0x400000000ull));
+                                          (unsigned long long)goff(v));
                             found++;
                         }
                     }
@@ -1575,16 +1585,16 @@ namespace {
                 if (lwatch_is_pool_shift(v)) {
                     g_lwatch_hits = g_lwatch_hits + 1;
                     char b[512];
-                    bool guest = g_lwatch_step_rip >= 0x400000000ull && g_lwatch_step_rip < 0x4c0000000ull;
+                    bool guest = gin(g_lwatch_step_rip);
                     int n = snprintf(b, sizeof b,
                         "[lwatch] SHIFT-STOMP fa=0x%llx val=0x%llx (<<8=0x%llx) rip=%s0x%llx tid=%ld",
                         (unsigned long long)g_lwatch_fa, (unsigned long long)v,
                         (unsigned long long)(v << 8), guest ? "eboot+" : "host:",
-                        (unsigned long long)(guest ? g_lwatch_step_rip - 0x400000000ull : g_lwatch_step_rip),
+                        (unsigned long long)(guest ? goff(g_lwatch_step_rip) : g_lwatch_step_rip),
                         cur_tid());
                     for (int i = 0; i < g_lwatch_stkn && n < (int)sizeof b - 24; i++)
                         n += snprintf(b + n, sizeof b - (size_t)n, " s:%llx",
-                                      (unsigned long long)(g_lwatch_stk[i] - 0x400000000ull));
+                                      (unsigned long long)goff(g_lwatch_stk[i]));
                     if (n < (int)sizeof b - 1) b[n++] = '\n';
                     raw_write(2, b, (size_t)n);
                     if (g_lwatch_hits >= g_lwatch_max) {   // caught enough — disarm, leave page RW
@@ -1629,7 +1639,7 @@ namespace {
                     for (uint64_t o = 0; o < 0x400 && g_lwatch_stkn < 8; o += 8) {
                         if (!probe_readable(rsp + o)) break;
                         uint64_t v = *(const uint64_t*)(rsp + o);
-                        if (v >= 0x400000000ull && v < 0x40a000000ull) g_lwatch_stk[g_lwatch_stkn++] = v;
+                        if (gin(v)) g_lwatch_stk[g_lwatch_stkn++] = v;
                     }
                     mprotect((void*)g_lwatch_page, 0x1000, PROT_READ | PROT_WRITE);
                     PROSPER_GREGS(uc)[REG_EFL] |= 0x100ll;   // TF -> single-step the write
@@ -1639,12 +1649,12 @@ namespace {
                 if (fa >= g_lwatch_slot - 0x18 && fa < g_lwatch_slot + 0x20) {
                     g_lwatch_hits = g_lwatch_hits + 1;
                     char b[512];
-                    bool guest = rip >= 0x400000000ull && rip < 0x4c0000000ull;
+                    bool guest = gin(rip);
                     int n = snprintf(b, sizeof b,
                         "[lwatch] #%d write fa=0x%llx rip=%s0x%llx tid=%ld pre[0]=0x%llx pre[8]=0x%llx",
                         (int)g_lwatch_hits, (unsigned long long)fa,
                         guest ? "eboot+" : "host:",
-                        (unsigned long long)(guest ? rip - 0x400000000ull : rip), cur_tid(),
+                        (unsigned long long)(guest ? goff(rip) : rip), cur_tid(),
                         (unsigned long long)*(const uint64_t*)g_lwatch_slot,
                         (unsigned long long)*(const uint64_t*)(g_lwatch_slot + 8));
                     // #312: call-stack capture — scan the writer's stack for eboot-text return
@@ -1656,9 +1666,9 @@ namespace {
                     for (uint64_t o = 0; o < 0x400 && found < 8 && n < (int)sizeof b - 24; o += 8) {
                         if (!probe_readable(rsp + o)) break;
                         uint64_t v = *(const uint64_t*)(rsp + o);
-                        if (v >= 0x400000000ull && v < 0x40a000000ull) {
+                        if (gin(v)) {
                             n += snprintf(b + n, sizeof b - (size_t)n, " s:%llx",
-                                          (unsigned long long)(v - 0x400000000ull));
+                                          (unsigned long long)goff(v));
                             found++;
                         }
                     }
@@ -2756,7 +2766,7 @@ void arm_hwbp_this_thread() {
     }
     ioctl(t_hwbp_fd, PERF_EVENT_IOC_ENABLE, 0);
     char b[128]; int n = snprintf(b, sizeof b, "[hwbp] armed on worker tid=%ld (fd=%d) for eboot+0x%llx\n",
-        (long)prosper_gettid(), t_hwbp_fd, (unsigned long long)(g_hwbp_addr - 0x400000000ull));
+        (long)prosper_gettid(), t_hwbp_fd, (unsigned long long)goff(g_hwbp_addr));
     raw_write(2,b, n);
 }
 

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -277,7 +277,7 @@ namespace {
     // without needing to know the dynamic buffer base or isolate the crash shader up front.
     uint64_t g_hwbp_anom = 0; bool g_hwbp_anom_on = false;
     static const int HWBP_RING = 256;
-    struct HwbpRingEnt { unsigned long long rip_off, cur, rax; unsigned val;
+    struct HwbpRingEnt { const char* rip_mod; unsigned long long rip_off, cur, rax; unsigned val;
                          unsigned long long r8, f8, f10, r14, rcx; };
     HwbpRingEnt g_hwbp_ring[HWBP_RING];
     volatile int g_hwbp_ring_pos = 0;
@@ -297,7 +297,7 @@ namespace {
     uint64_t g_stepwin_base = 0, g_stepwin_end = 0;
     unsigned long long g_stepwin_prevcur = 0; long g_stepwin_steps = 0; long g_stepwin_max = 4000000;
     static const int STEPWIN_RING = 512;
-    struct StepEnt { unsigned long long rip_off, cur; };
+    struct StepEnt { const char* rip_mod; unsigned long long rip_off, cur; };
     StepEnt g_stepwin_ring[STEPWIN_RING]; int g_stepwin_pos = 0;
     // PROSPER_HWBP_BUFDUMP=1: at the driver bp (rbx = reader), write the reader window [rbx+0x40 .. rbx+0x48]
     // to /tmp/prosper_buf_<hit>.bin per hit — captures the EXACT decompressed object buffer the deserializer
@@ -410,8 +410,8 @@ namespace {
             long long dcur = prev_cur ? (long long)(e.cur - prev_cur) : 0;
             char lb[220];
             int ln = snprintf(lb, sizeof lb,
-                "  [%3d] rip=eboot+0x%llx req/cur=0x%llx cacher/rax=0x%llx | s50/r8=0x%llx s68/f8=0x%llx f10=0x%llx r14=0x%llx  %s\n",
-                i, e.rip_off, e.cur, e.rax, e.r8, e.f8, e.f10, e.r14,
+                "  [%3d] rip=%s+0x%llx req/cur=0x%llx cacher/rax=0x%llx | s50/r8=0x%llx s68/f8=0x%llx f10=0x%llx r14=0x%llx  %s\n",
+                i, e.rip_mod ? e.rip_mod : "?", e.rip_off, e.cur, e.rax, e.r8, e.f8, e.f10, e.r14,
                 (e.cur == e.r8 || e.cur == e.f8) ? "<<< MATCH (skip fetch)" : "");
             (void)dcur;
             raw_write(2,lb, ln);
@@ -432,8 +432,8 @@ namespace {
             const StepEnt& e = g_stepwin_ring[(start + i) % STEPWIN_RING];
             long long d = prev ? (long long)(e.cur - prev) : 0;
             char lb[160];
-            int ln = snprintf(lb, sizeof lb, "  [%3d] rip=eboot+0x%llx cur=0x%llx (off 0x%llx) delta=%+lld\n",
-                i, e.rip_off, e.cur, (unsigned long long)(e.cur - g_stepwin_base), d);
+            int ln = snprintf(lb, sizeof lb, "  [%3d] rip=%s+0x%llx cur=0x%llx (off 0x%llx) delta=%+lld\n",
+                i, e.rip_mod ? e.rip_mod : "?", e.rip_off, e.cur, (unsigned long long)(e.cur - g_stepwin_base), d);
             raw_write(2,lb, ln);
             prev = e.cur;
         }
@@ -1114,8 +1114,8 @@ namespace {
                         if (!probe_readable(p)) break;
                         uint64_t ra = *(const uint64_t*)p;
                         if (gin(ra)) {
-                            sn += snprintf(sb + sn, sizeof sb - sn, " eboot+0x%llx",
-                                           (unsigned long long)goff(ra));
+                            sn += snprintf(sb + sn, sizeof sb - sn, " %s+0x%llx",
+                                           gmod(ra), (unsigned long long)goff(ra));
                             found++;
                         }
                     }
@@ -1146,7 +1146,7 @@ namespace {
                     if (v >= g_stepwin_base && v < g_stepwin_end) { cur = v; break; } }
                 if (cur && cur != g_stepwin_prevcur) {
                     g_stepwin_ring[g_stepwin_pos % STEPWIN_RING] =
-                        { (unsigned long long)goff(rip), cur };
+                        { gmod(rip), (unsigned long long)goff(rip), cur };
                     g_stepwin_pos++; g_stepwin_prevcur = cur;
                 }
                 bool at_driver = (rip == g_hwbp_addr);
@@ -1213,7 +1213,7 @@ namespace {
                 unsigned val = probe_readable(rax) ? *(const uint32_t*)rax : 0xBADBADu;
                 unsigned long long cur = probe_readable(rbxr + 0x38) ? *(const uint64_t*)(rbxr + 0x38) : 0;
                 int p = g_hwbp_ring_pos % HWBP_RING;
-                g_hwbp_ring[p] = { (unsigned long long)goff((uint64_t)gr[REG_RIP]),
+                g_hwbp_ring[p] = { gmod((uint64_t)gr[REG_RIP]), (unsigned long long)goff((uint64_t)gr[REG_RIP]),
                                    cur, (unsigned long long)rax, val, 0, 0, 0, (unsigned long long)r14, 0 };
                 g_hwbp_ring_pos = g_hwbp_ring_pos + 1;
                 if ((uint64_t)val >= g_hwbp_anom) hwbp_dump_ring("anom");
@@ -1231,7 +1231,7 @@ namespace {
                 unsigned long long s68 = probe_readable(cacher + 0x68)? *(const uint64_t*)(cacher + 0x68): 0xBADBADull;
                 unsigned long long f160= probe_readable(cacher + 0x160)?*(const uint64_t*)(cacher + 0x160):0xBADBADull;
                 int p = g_hwbp_ring_pos % HWBP_RING;
-                g_hwbp_ring[p] = { (unsigned long long)goff((uint64_t)gr[REG_RIP]),
+                g_hwbp_ring[p] = { gmod((uint64_t)gr[REG_RIP]), (unsigned long long)goff((uint64_t)gr[REG_RIP]),
                                    req/*cur=requested block*/, (unsigned long long)cacher, 0,
                                    s50/*[+0x50]*/, s68/*[+0x68]*/, f160/*[+0x160]*/, 0, 0 };
                 g_hwbp_ring_pos = g_hwbp_ring_pos + 1;
@@ -1249,7 +1249,8 @@ namespace {
                     s[k] = 0;
                     if (k >= 2) { char b[128]; int n = snprintf(b, sizeof b, "[hwbp-str] %s=0x%llx -> \"%s\"\n", rn, (unsigned long long)p, s); raw_write(2, b, (size_t)n);   /* raw syscall: no libc TLS access */ }
                 };
-                char hdr[64]; int hn = snprintf(hdr, sizeof hdr, "[hwbp-str] hit @eboot+0x%llx:\n",
+                char hdr[80]; int hn = snprintf(hdr, sizeof hdr, "[hwbp-str] hit @%s+0x%llx:\n",
+                    gmod((uint64_t)gr[REG_RIP]),
                     (unsigned long long)goff((uint64_t)gr[REG_RIP])); raw_write(2,hdr, hn);
                 pstr("rdi", (uint64_t)gr[REG_RDI]); pstr("rsi", (uint64_t)gr[REG_RSI]);
                 pstr("rdx", (uint64_t)gr[REG_RDX]); pstr("rcx", (uint64_t)gr[REG_RCX]);
@@ -1333,7 +1334,7 @@ namespace {
                     return probe_readable(p + 0x17) ? *(const uint64_t*)(p + 0x10) : 0;
                 };
                 char b[256]; int n = snprintf(b, sizeof b,
-                    "[hwbp-args] rdi=0x%llx [+10]=0x%llx rsi=0x%llx rdx=0x%llx [+10]=0x%llx rcx=0x%llx r8=0x%llx r9=0x%llx ret=eboot+0x%llx\n",
+                    "[hwbp-args] rdi=0x%llx [+10]=0x%llx rsi=0x%llx rdx=0x%llx [+10]=0x%llx rcx=0x%llx r8=0x%llx r9=0x%llx ret=%s+0x%llx\n",
                     (unsigned long long)gr[REG_RDI],
                     (unsigned long long)arg_field((uint64_t)gr[REG_RDI]),
                     (unsigned long long)gr[REG_RSI],
@@ -1341,6 +1342,8 @@ namespace {
                     (unsigned long long)arg_field((uint64_t)gr[REG_RDX]),
                     (unsigned long long)gr[REG_RCX],
                     (unsigned long long)gr[REG_R8], (unsigned long long)gr[REG_R9],
+                    probe_readable((uint64_t)gr[REG_RSP])
+                        ? gmod(*(const uint64_t*)(uint64_t)gr[REG_RSP]) : "?",
                     (unsigned long long)(probe_readable((uint64_t)gr[REG_RSP]) ? goff(*(const uint64_t*)(uint64_t)gr[REG_RSP]) : 0));
                 raw_write(2, b, (size_t)n);
             }
@@ -1384,6 +1387,10 @@ namespace {
                 uint64_t rbp = (uint64_t)gr[REG_RBP], rsp = (uint64_t)gr[REG_RSP];
                 auto off = [](unsigned long long v) -> unsigned long long {
                     return (gin(v)) ? goff(v) : v; };
+                // Companion namer: a widened filter must not keep a hard-coded "eboot+" label, or an
+                // Il2Cpp frame prints a small in-range offset under the wrong module name — worse than
+                // the old out-of-range value, which at least announced itself (#1659 review).
+                auto nm = [](unsigned long long v) -> const char* { return gin(v) ? gmod(v) : "host"; };
                 // Also surface rax + the u32 at [rax] — at the deserializer length-read site (0x7e40d9/e1)
                 // rax is the stream cursor and [rax] the value being read, so a trace shows the parse walk.
                 unsigned rax_u32 = probe_readable(rax) ? *(const uint32_t*)rax : 0xBADBADu;
@@ -1393,10 +1400,12 @@ namespace {
                 uint64_t rbx = (uint64_t)gr[REG_RBX];
                 char b[512];
                 int n = snprintf(b, sizeof b,
-                    "[hwbp] #%d rip=eboot+0x%llx rax=0x%llx [rax]=0x%08x r14=0x%llx rbx=0x%llx cur=0x%llx base=0x%llx end=0x%llx ret=eboot+0x%llx caller_rbp=eboot+0x%llx tid=%ld\n",
-                    (int)g_hwbp_count, (unsigned long long)goff((uint64_t)gr[REG_RIP]),
+                    "[hwbp] #%d rip=%s+0x%llx rax=0x%llx [rax]=0x%08x r14=0x%llx rbx=0x%llx cur=0x%llx base=0x%llx end=0x%llx ret=%s+0x%llx caller_rbp=%s+0x%llx tid=%ld\n",
+                    (int)g_hwbp_count, gmod((uint64_t)gr[REG_RIP]),
+                    (unsigned long long)goff((uint64_t)gr[REG_RIP]),
                     (unsigned long long)rax, rax_u32, (unsigned long long)r14, (unsigned long long)rbx,
-                    rd(rbx+0x38), rd(rbx+0x40), rd(rbx+0x48), off(rd(rsp)), off(rd(rbp + 8)), cur_tid());
+                    rd(rbx+0x38), rd(rbx+0x40), rd(rbx+0x48), nm(rd(rsp)), off(rd(rsp)),
+                    nm(rd(rbp + 8)), off(rd(rbp + 8)), cur_tid());
                 (void)r15; (void)rdi; (void)rsi;
                 raw_write(2, b, (size_t)n);   /* raw syscall: no libc TLS access */
                 // PROSPER_HWBP_DIVCAP: log the typetree-vector transfer's elemSize/byteSize/count from the

--- a/prosper/tests/test_guest_module_label.cpp
+++ b/prosper/tests/test_guest_module_label.cpp
@@ -42,8 +42,10 @@ int main() {
     // The old code computed `va - 0x400000000`. For an eboot VA that is kRva + 0x10000000.
     constexpr uint64_t kStaleBase = 0x400000000ull;
     const uint64_t eboot_va = BOOT_EBOOT + kRva;
-    CHECK(eboot_va - kStaleBase == kRva + 0x10000000ull,
-          "the stale base really does inflate an eboot offset by exactly 0x10000000");
+    // Not "== 0x10000000" — that would be a tautology over two constants and would fail spuriously if
+    // the base moves again. The property is: the stale base over-reports, by the amount the base moved.
+    CHECK(eboot_va - kStaleBase == kRva + (BOOT_EBOOT - kStaleBase),
+          "the stale base over-reports an eboot offset by exactly the relocation distance");
     CHECK(guest_module_offset(eboot_va) != eboot_va - kStaleBase,
           "the shared helper does NOT reproduce the stale-base offset");
     // The reported symptom: 0x14a87368 against a 0x99c74c8-byte image is past the end.
@@ -64,14 +66,12 @@ int main() {
     // ---- round-trip with the breakpoint input contract --------------------------------------
     // PROSPER_BP=0xOFFSET installs at (mapped base + OFFSET). An offset read out of a log must land
     // back on the same instruction — that round-trip was broken while the label used the stale base.
-    for (uint64_t rva : {uint64_t{0}, uint64_t{1}, kRva, uint64_t{0x2fffffff}}) {
-        const uint64_t va = BOOT_EBOOT + rva;
-        if (guest_module_offset(va) != rva) {
-            std::printf("    round-trip broke at rva=0x%llx\n", (unsigned long long)rva);
-            ++fails;
-        }
+    {
+        bool round_trip_ok = true;
+        for (uint64_t rva : {uint64_t{0}, uint64_t{1}, kRva, uint64_t{0x2fffffff}})
+            if (guest_module_offset(BOOT_EBOOT + rva) != rva) round_trip_ok = false;
+        CHECK(round_trip_ok, "printed eboot offsets round-trip through BOOT_EBOOT + offset");
     }
-    CHECK(true, "printed eboot offsets round-trip through BOOT_EBOOT + offset");
 
     // ---- boundaries -------------------------------------------------------------------------
     CHECK(guest_module_offset(BOOT_EBOOT) == 0 &&
@@ -81,6 +81,24 @@ int main() {
           "the last byte below the next module still belongs to the eboot");
     CHECK(guest_va_in_module(BOOT_STUB) && guest_module_offset(BOOT_STUB) == 0,
           "the import-stub region is named and offset like any other module");
+
+    // ---- a CONVERTED CALL SITE, not just the helper -----------------------------------------
+    // Every assertion above tests boot_program.hpp. The defect was in the *callers*, so a mislabel
+    // reintroduced there would pass all of it. This drives the real formatter used by the fault and
+    // HWBP diagnostics and asserts the rendered text, including the module name.
+    {
+        char line[128];
+        const uint64_t il2cpp_ra = BOOT_IL2CPP + 0x1234;
+        std::snprintf(line, sizeof line, "%s+0x%llx",
+                      guest_module_name(il2cpp_ra),
+                      (unsigned long long)guest_module_offset(il2cpp_ra));
+        CHECK(std::strcmp(line, "Il2cpp+0x1234") == 0,
+              "a rendered label names the module it came from — not 'eboot' with a plausible offset");
+        // The specific regression the review caught: a widened filter with a hard-coded label renders
+        // an in-range offset under the wrong module, which has no tell at all.
+        CHECK(std::strncmp(line, "eboot", 5) != 0,
+              "an Il2Cpp address never renders as eboot+");
+    }
 
     std::printf(fails ? "== FAIL: %d ==\n" : "== PASS ==\n", fails);
     return fails ? 1 : 0;

--- a/prosper/tests/test_guest_module_label.cpp
+++ b/prosper/tests/test_guest_module_label.cpp
@@ -1,0 +1,87 @@
+// #1659: every diagnostic that prints "<module>+0x<rva>" must agree, and must agree with the address
+// the loader actually maps to.
+//
+// The eboot base MOVED in #825 — 0x400000000 -> 0x410000000 — so Astro Bot's direct-memory mapping at
+// [0x400000000,0x40b800000) would stop aliasing code. Three subsystems had hard-coded the old literal
+// and were never updated, so they printed the real RVA **plus 0x10000000**: a plausible-looking offset
+// that lands nowhere, past the end of a 161 MB image, and one that no longer round-trips through
+// PROSPER_BP (which adds the real mapped base).
+//
+// These assertions are written against the CONTRACT — "an address N bytes into the eboot labels as
+// eboot+0xN" — not against whichever constant the code currently holds, so they stay meaningful if a
+// base moves again.
+
+#include "../src/host/boot_program.hpp"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { std::printf("  [FAIL] %s\n", m); ++fails; } \
+                         else std::printf("  [ok]   %s\n", m); } while (0)
+
+int main() {
+    std::printf("== test_guest_module_label ==\n");
+
+    // ---- the contract, for each module a diagnostic can name -------------------------------
+    constexpr uint64_t kRva = 0x4a87368ull;   // the real RVA from the #1659 report
+    CHECK(std::strcmp(guest_module_name(BOOT_EBOOT + kRva), "eboot") == 0 &&
+          guest_module_offset(BOOT_EBOOT + kRva) == kRva,
+          "an address kRva into the eboot labels as eboot+kRva");
+    CHECK(std::strcmp(guest_module_name(BOOT_IL2CPP + kRva), "Il2cpp") == 0 &&
+          guest_module_offset(BOOT_IL2CPP + kRva) == kRva,
+          "an IL2CPP address names Il2cpp — not eboot with a shifted offset");
+    CHECK(std::strcmp(guest_module_name(BOOT_LIBC + 0x100), "libc.prx") == 0 &&
+          guest_module_offset(BOOT_LIBC + 0x100) == 0x100,
+          "libc.prx is named and offset from its own base");
+
+    // ---- the exact defect ------------------------------------------------------------------
+    // The old code computed `va - 0x400000000`. For an eboot VA that is kRva + 0x10000000.
+    constexpr uint64_t kStaleBase = 0x400000000ull;
+    const uint64_t eboot_va = BOOT_EBOOT + kRva;
+    CHECK(eboot_va - kStaleBase == kRva + 0x10000000ull,
+          "the stale base really does inflate an eboot offset by exactly 0x10000000");
+    CHECK(guest_module_offset(eboot_va) != eboot_va - kStaleBase,
+          "the shared helper does NOT reproduce the stale-base offset");
+    // The reported symptom: 0x14a87368 against a 0x99c74c8-byte image is past the end.
+    constexpr uint64_t kOregonTrailImageBytes = 0x99c74c8ull;
+    CHECK(eboot_va - kStaleBase > kOregonTrailImageBytes &&
+          guest_module_offset(eboot_va) < kOregonTrailImageBytes,
+          "the stale offset is past the end of the image while the correct one is inside it");
+
+    // ---- the region the old lower bound covered is NOT code ---------------------------------
+    // [0x400000000,0x410000000) is now a direct-memory aperture (Astro Bot maps it before AGC).
+    // A pointer there must not be labelled as a module offset at all.
+    CHECK(!guest_va_in_module(kStaleBase) && !guest_va_in_module(BOOT_EBOOT - 1),
+          "an address in the pre-#825 aperture is not claimed by any module");
+    CHECK(std::strcmp(guest_module_name(kStaleBase), "mapped/host") == 0 &&
+          guest_module_offset(kStaleBase) == kStaleBase,
+          "a non-module address reports mapped/host and its address verbatim, not a fake offset");
+
+    // ---- round-trip with the breakpoint input contract --------------------------------------
+    // PROSPER_BP=0xOFFSET installs at (mapped base + OFFSET). An offset read out of a log must land
+    // back on the same instruction — that round-trip was broken while the label used the stale base.
+    for (uint64_t rva : {uint64_t{0}, uint64_t{1}, kRva, uint64_t{0x2fffffff}}) {
+        const uint64_t va = BOOT_EBOOT + rva;
+        if (guest_module_offset(va) != rva) {
+            std::printf("    round-trip broke at rva=0x%llx\n", (unsigned long long)rva);
+            ++fails;
+        }
+    }
+    CHECK(true, "printed eboot offsets round-trip through BOOT_EBOOT + offset");
+
+    // ---- boundaries -------------------------------------------------------------------------
+    CHECK(guest_module_offset(BOOT_EBOOT) == 0 &&
+          std::strcmp(guest_module_name(BOOT_EBOOT), "eboot") == 0,
+          "the first byte of the eboot is eboot+0x0");
+    CHECK(std::strcmp(guest_module_name(BOOT_IL2CPP - 1), "eboot") == 0,
+          "the last byte below the next module still belongs to the eboot");
+    CHECK(guest_va_in_module(BOOT_STUB) && guest_module_offset(BOOT_STUB) == 0,
+          "the import-stub region is named and offset like any other module");
+
+    std::printf(fails ? "== FAIL: %d ==\n" : "== PASS ==\n", fails);
+    return fails ? 1 : 0;
+}

--- a/prosper/tools/boot_trace/boot_trace.cpp
+++ b/prosper/tools/boot_trace/boot_trace.cpp
@@ -76,8 +76,13 @@ using namespace prosper;
 // appears in a backtrace; the old local table predated FMOD/Wwise and even retained obsolete eboot
 // and libc bases, misclassifying every address in those later slots as SaveData or libc.
 // Module classification/offset now live in boot_program.hpp so the fault, HWBP and APR diagnostics
-// produce the identical label instead of each carrying its own copy (#1659). These were the correct
+// produce the identical label instead of each carrying its own copy (#1659). This was the correct
 // implementation; the others had a stale literal base.
+//
+// NOT byte-identical to what stood here, in three ways — all deliberate, all changing boot_trace's own
+// output: the shared version adds CommonDialog.prx and the auto-plugin pool (which this copy predated),
+// and it offsets BOOT_STUB addresses from BOOT_STUB, where this copy fell through and printed the raw
+// address. So "STUB +0x600000123" in an archived log is "STUB +0x123" now.
 static const char* cls(uint64_t a) { return prosper::guest_module_name(a); }
 static uint64_t    bof(uint64_t a) { return prosper::guest_module_offset(a); }
 

--- a/prosper/tools/boot_trace/boot_trace.cpp
+++ b/prosper/tools/boot_trace/boot_trace.cpp
@@ -75,41 +75,11 @@ using namespace prosper;
 // Fixed module slots from the shared boot path. Keep diagnostics honest when optional plugin code
 // appears in a backtrace; the old local table predated FMOD/Wwise and even retained obsolete eboot
 // and libc bases, misclassifying every address in those later slots as SaveData or libc.
-static const char* cls(uint64_t a) {
-    if (a >= BOOT_EBOOT         && a < BOOT_IL2CPP)       return "eboot";
-    if (a >= BOOT_IL2CPP        && a < BOOT_PSNCORE)      return "Il2cpp";
-    if (a >= BOOT_PSNCORE       && a < BOOT_PSNCOMMON)    return "PSNCore.prx";
-    if (a >= BOOT_PSNCOMMON     && a < BOOT_PS5UTIL)      return "PSNCommon.prx";
-    if (a >= BOOT_PS5UTIL       && a < BOOT_NPCPPWEBAPI)  return "PS5Util";
-    if (a >= BOOT_NPCPPWEBAPI   && a < BOOT_PSN)          return "libSceNpCppWebApi.prx";
-    if (a >= BOOT_PSN           && a < BOOT_SAVEDATA)     return "PSN.prx";
-    if (a >= BOOT_SAVEDATA      && a < BOOT_FMODSTUDIO)   return "SaveData.prx";
-    if (a >= BOOT_FMODSTUDIO    && a < BOOT_FMOD)         return "libfmodstudio.prx";
-    if (a >= BOOT_FMOD          && a < BOOT_AKMOTION)     return "libfmod.prx";
-    if (a >= BOOT_AKMOTION      && a < BOOT_AKVORBIS)     return "AkMotion.prx";
-    if (a >= BOOT_AKVORBIS      && a < BOOT_AKSOUNDENGINE)return "AkVorbisHwAccelerator.prx";
-    if (a >= BOOT_AKSOUNDENGINE && a < BOOT_LIBC)         return "AkSoundEngine.prx";
-    if (a >= BOOT_LIBC          && a < BOOT_STUB)         return "libc.prx";
-    if (a >= BOOT_STUB          && a < 0x610000000ull)    return "STUB";
-    return "mapped/host";
-}
-static uint64_t bof(uint64_t a) {
-    if (a >= BOOT_EBOOT         && a < BOOT_IL2CPP)        return a - BOOT_EBOOT;
-    if (a >= BOOT_IL2CPP        && a < BOOT_PSNCORE)       return a - BOOT_IL2CPP;
-    if (a >= BOOT_PSNCORE       && a < BOOT_PSNCOMMON)     return a - BOOT_PSNCORE;
-    if (a >= BOOT_PSNCOMMON     && a < BOOT_PS5UTIL)       return a - BOOT_PSNCOMMON;
-    if (a >= BOOT_PS5UTIL       && a < BOOT_NPCPPWEBAPI)   return a - BOOT_PS5UTIL;
-    if (a >= BOOT_NPCPPWEBAPI   && a < BOOT_PSN)           return a - BOOT_NPCPPWEBAPI;
-    if (a >= BOOT_PSN           && a < BOOT_SAVEDATA)      return a - BOOT_PSN;
-    if (a >= BOOT_SAVEDATA      && a < BOOT_FMODSTUDIO)    return a - BOOT_SAVEDATA;
-    if (a >= BOOT_FMODSTUDIO    && a < BOOT_FMOD)          return a - BOOT_FMODSTUDIO;
-    if (a >= BOOT_FMOD          && a < BOOT_AKMOTION)      return a - BOOT_FMOD;
-    if (a >= BOOT_AKMOTION      && a < BOOT_AKVORBIS)      return a - BOOT_AKMOTION;
-    if (a >= BOOT_AKVORBIS      && a < BOOT_AKSOUNDENGINE) return a - BOOT_AKVORBIS;
-    if (a >= BOOT_AKSOUNDENGINE && a < BOOT_LIBC)          return a - BOOT_AKSOUNDENGINE;
-    if (a >= BOOT_LIBC          && a < BOOT_STUB)          return a - BOOT_LIBC;
-    return a;
-}
+// Module classification/offset now live in boot_program.hpp so the fault, HWBP and APR diagnostics
+// produce the identical label instead of each carrying its own copy (#1659). These were the correct
+// implementation; the others had a stale literal base.
+static const char* cls(uint64_t a) { return prosper::guest_module_name(a); }
+static uint64_t    bof(uint64_t a) { return prosper::guest_module_offset(a); }
 
 int main(int argc, char** argv) {
     // PROSPER_TERM_BT: install a std::terminate handler that dumps the HOST backtrace + exception

--- a/prosper/tools/re/xref.py
+++ b/prosper/tools/re/xref.py
@@ -19,7 +19,8 @@
 # function at <addr> reference".
 #
 # Input is a FLATTENED ELF (p_offset==p_vaddr) as produced by tools/il2cpp/prx_to_elf.py.
-# Runtime address = module_load_base + VA (e.g. eboot base 0x400000000).
+# Runtime address = module_load_base + VA (e.g. eboot base 0x410000000; it moved from
+# 0x400000000 in #825 — see prosper/src/host/boot_program.hpp for the authoritative set).
 #
 # Usage:
 #   xref.py <module.elf> to   <hexaddr>     # who references this address


### PR DESCRIPTION
Fixes #1659

## Failure scenario

`BOOT_EBOOT` is `0x410000000`. Several diagnostics printed `eboot+0x…` against the literal
`0x400000000`, so every offset was the real RVA **plus `0x10000000`** — a plausible-looking number that
is past the end of a 161 MB image, and one an agent then feeds to `edis.py`, `xref.py`, `objdump` or
`PROSPER_BP`, landing 256 MB away. The miss looks like a code problem, not an instrument problem.

## Root cause — not a typo

`0x400000000` **was** the eboot base. **#825** (`4fd585ac`, "boot Astro Bot to loading screen") relocated
it to `0x410000000` because Astro Bot maps `[0x400000000,0x40b800000)` as direct memory before bringing
up AGC, and the old base made those legitimate mappings alias code. The diagnostics that had hard-coded
the literal were correct before that commit and stale after it. `boot_program.hpp:18-19` records the
move; the instruments never got it.

That also explains why this survived: `PROSPER_BP` *inputs* use `g_base` (the real mapped base), so the
input side was always right while the output side drifted — and the comment at the `g_bp_addr`
declaration asserted `0x400000000 + offset`, describing its own code incorrectly.

## Three defects, not one

1. **The `0x10000000` shift**, as reported.
2. **`[0x400000000,0x410000000)` is now a DMEM aperture, not code.** Sites testing `>= 0x400000000`
   classified a data pointer there as an eboot address and printed it as a code offset.
3. **Wrong binary, not just wrong offset.** Sites testing one wide range — e.g.
   `[0x400000000,0x4c0000000)`, which spans eboot, IL2CPP, PSNCore and PSNCommon — labelled **every**
   module in it `eboot+`. An IL2CPP return address was reported as an eboot RVA.

## Two sites were not diagnostics at all

- **`hle_kernel_time.cpp` `PROSPER_DUMPCODE`** computes `0x400000000 + off` and **dereferences** it. It
  read `0x10000000` below the intended instruction — wrong bytes, not a wrong label.
- **`mb3_freelist.cpp`** scans guest memory for an instruction signature starting at
  `kImageBase = 0x400000000` over `0x4000000` bytes. That sweep covered 64 MiB of the DMEM aperture,
  where the pattern could never match.

## The issue's site list was incomplete

It named `hle_file.cpp` and `exec_image_linux.cpp`. The evidence it quoted —
`[agc] fence1-builder ra=eboot+0x14a87368` — comes from `hle_agc.cpp`, which it did not list. A full
sweep found the stale literal in **seven** files: `exec_image_linux.cpp` (24 sites), `hle_file.cpp` (2),
`hle_agc.cpp`, `hle_graphics.cpp`, `hle_kernel_time.cpp` (5), `mb3_freelist.cpp`, and a mislabel in
`command_processor.cpp`.

`command_processor.cpp`'s `pkt=eboot+0x%llx` had **no subtraction at all** — `pkt` is a PM4
command-buffer pointer, never a module offset — so that was a pure mislabel and the prefix is removed.

## Approach — converged, not patched

`boot_trace.cpp` already had the correct implementation: a module-aware `cls()`/`bof()` pair that names
each module and offsets from *its* base. That is now `prosper::guest_module_name()` /
`guest_module_offset()` / `guest_va_in_module()` in `boot_program.hpp`, beside the `BOOT_*` constants they
read, and every printer calls them. `boot_trace` keeps two one-line wrappers — but its behaviour is **not** unchanged, as an
earlier draft of this claimed: the shared version adds `CommonDialog.prx` and the auto-plugin pool that
this copy predated, and it offsets `BOOT_STUB` addresses from `BOOT_STUB` where the old copy fell through
and printed the raw address. `STUB +0x600000123` in an archived log reads `STUB +0x123` now.

The `exec_image_linux.cpp` wrappers are async-signal-safe (pure comparisons and arithmetic, no
allocation, no locks), which matters because most of those sites run inside the fault/HWBP handler.

## What is NOT affected — verified, not assumed

**Static-analysis offsets never pass through the runtime label, so RVAs already recorded from
disassembly in issues and docs remain correct.** Checked directly:

- `tools/re/xref.py` and `tools/re/edis.py` compute from ELF `p_vaddr` and file offsets; neither adds a
  runtime base.
- `tools/il2cpp/prx_to_elf.py` documents `module_base + RVA` and uses `0x440000000` for
  `Il2CppUserAssemblies.prx`, which is the correct `BOOT_IL2CPP`.

**Existing disassembly-derived records in issues stand and need no revisiting.** Only emulator-printed
offsets shifted.

The one exception is documentation, and it is the most dangerous single line in the whole defect:
`xref.py:22` named `0x400000000` as the eboot base. **The tool is right and the comment is wrong** — which
is worse than both being wrong, because it is the instruction someone follows to convert a *correct*
static RVA into a runtime address, reintroducing the same `0x10000000` error from the clean side.
Corrected.

### Why this survived as long as it did

`exec_image_linux.cpp` **contradicts itself.** `:119` and `:174` describe the base as the "fixed
`0x400000000`", while `:193-194` in the same file correctly derives `0x440000000 = 0x410000000 +
0x30000000`. A file that disagrees with itself hands every reader a citation for whichever value they
already believed — so converging the constant without fixing the prose would have left the trap fully
armed. The two wrong comments are corrected; the correct one is untouched.

`docs/UE4_APR_IOSTORE_BRINGUP.md` mixes both conventions, as #1659 notes. I have **not** rewritten those
recorded offsets: which convention each line used is not determinable from the text alone, and guessing
would replace a known-ambiguous record with a confidently-wrong one. The new doc entry tells a reader how
to spot the shifted form (an offset larger than the image).

## Affected / unaffected

**Affected:** the text of runtime `<module>+0x<rva>` diagnostics; `PROSPER_DUMPCODE`'s read address;
`mb3_freelist`'s scan range.

**Unaffected:** all static tooling; `boot_trace`'s output (already correct, now shared);
`PROSPER_BP`/`PROSPER_SKIP_*` inputs, which already used the mapped base; anything that does not print or
compute a module offset. No behaviour outside diagnostics changes — except the two sites above, which
were reading and scanning the wrong memory and now read the intended memory.

## Risks

- `mb3_freelist`'s scan now covers a region where the pattern can actually appear. Lower risk than an
  earlier draft of this note said: every path there runs under `mb3_freelist_guard()`, which is default
  OFF, and the scan is bounded by `safe_read` + `break`, so there is no fault risk. `CONFIDENCE: HIGH`
  that the old range was wrong.
- Widening single-range tests to `guest_va_in_module` means stack scans now report IL2CPP and libc frames
  where they previously reported nothing. More output, and correct output, but different.
- The `PROSPER_SKIP_RIP`/`PROSPER_SKIP_TARGET` defaults are absolute VAs computed against the old base.
  They are Messenger-specific probe addresses, meaningful only when explicitly overridden; left as-is and
  commented rather than silently rebased onto a title they were not measured against.

## Verification tell

The concrete check, from the report: on PPSA19244 the flattened eboot is `0x99c74c8` bytes and
`[agc] fence1-builder` printed `eboot+0x14a87368` — 2.2x the image. That same site now prints
**`eboot+0x4a87368`**. The regression test encodes exactly this: it asserts the stale offset is past the
end of a 0x99c74c8-byte image while the correct one is inside it.

## Verification

Build clean. `ctest -j8`: **168/168**.

New `test_guest_module_label` (12 assertions) pins the **contract** — "an address N bytes into the eboot
labels as `eboot+0xN`" — rather than whichever constant the code currently holds, so it stays meaningful
if a base moves again. It asserts the exact defect (`stale base inflates by exactly 0x10000000`), that
the stale offset is past the end of the reported 0x99c74c8-byte image while the correct one is inside it,
that the pre-#825 aperture is claimed by no module, that an IL2CPP address names `Il2cpp`, and that
printed offsets round-trip through `BOOT_EBOOT + offset` — the `PROSPER_BP` contract that was broken.

Also adds the trap to the instrument list in `docs/GAME_COMPAT_ORCHESTRATION.md`, including the two
corollaries and the "static tools are unaffected" conclusion.

## Post-review

Review found a **blocking** defect I had introduced: several sites widened their filter to
`guest_va_in_module()` while keeping the literal `"eboot+"` in the format string. That reintroduced this
PR's own defect #3 in a worse form — before, an Il2Cpp frame printed an offset larger than the image (the
tell this PR documents); after, it printed a small in-range offset under the wrong module name, with no
tell. Fixed at every site; `preadlog` deliberately stays eboot-only because its format has one prefix for
eight offsets, and that is commented.

The sweep was also incomplete. **`PROSPER_PUNCH` (`hle_kernel_mem.cpp`) has been silently inert since
#825** — its computed RVA feeds a whitelist comparison, so the stale base made every comparison fail.
That is a *third* non-diagnostic site. Also converted `[punch]`, `[sync] WAKE`, `hle_audio`'s call log,
and `hle_kernel.cpp`'s hand-rolled three-branch dispatcher whose eboot and libc bases were both stale.

The test previously exercised only the helper, so the blocking defect would have passed it. It now renders
a label through the real formatter and asserts an Il2Cpp address never prints as `eboot+`; the stale-base
assertion states the property rather than comparing two constants; the vacuous `CHECK(true)` is gone.

Independently verified in review and worth recording: every changed format string's specifiers match its
argument list (checked in order across six files, including the signal-handler sites), and the shared
helpers are async-signal-safe — plain inline functions, no function-local statics, so no
`__cxa_guard_acquire`.

Re-verified: `ctest -j8` **168/168**.

