### PR TITLE
fix(hle): select/pselect must honour their timeout — a no-op sleep was burning a core at 9M calls/s

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,8 +121,9 @@ The standing warnings that are **not** title-specific:
 - **`PROSPER_UD_TAIL_ALIGN` must stay off.** It exists only so the A/B that falsified the
   user-data-tail hypothesis stays reproducible (`docs/RESOURCE_BINDING.md` § Ruled out).
 - **Read `GAME_COMPAT_ORCHESTRATION.md`'s instrument-not-the-subject list before believing any
-  surprising measurement** — fourteen phantom defects have come from the apparatus rather than the
-  subject, and several cost hours. Two of its positive rules bind on any graphics investigation, not
+  surprising measurement** — every entry on it is a phantom defect that came from the apparatus
+  rather than the subject, and several cost hours. (Deliberately no count here: the list is appended
+  to by concurrent lanes, so a restated total is stale as soon as it is written.) Two of its positive rules bind on any graphics investigation, not
   just orchestrated ones: **a decoded-draw census is meaningless without the render phase and a
   positive control** (draw counts vary by two orders of magnitude *within one title* — count per
   sample interval, calibrate against a title known to render the thing you claim is missing, and

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -247,6 +247,12 @@ if(TARGET prosper_core)
   target_link_libraries(test_wall_clock PRIVATE prosper_core)
   add_test(NAME wall_clock COMMAND test_wall_clock)
 
+  # select/pselect pure-sleep shape honours its timeout; a descriptor-set query stays fail-visible
+  # (#1660). Asserts elapsed time, not the return value -- the stub this replaces also returned 0.
+  add_executable(test_select_sleep tests/test_select_sleep.cpp)
+  target_link_libraries(test_select_sleep PRIVATE prosper_core)
+  add_test(NAME select_sleep COMMAND test_select_sleep)
+
   # Opt-in flip-paced monotonic clock (#240): exact frame steps, thread-safe first-flip anchor,
   # and no coupling into CLOCK_REALTIME while virtual time is paused between flips.
   add_executable(test_det_clock tests/test_det_clock.cpp)

--- a/prosper/docs/GAME_COMPAT_ORCHESTRATION.md
+++ b/prosper/docs/GAME_COMPAT_ORCHESTRATION.md
@@ -50,9 +50,13 @@ session. Prefer breadth when a hard lane stalls — overall library progress mat
 
 ### The instrument-not-the-subject list — read this before believing any surprising measurement
 
-**Twenty phantom defects came from the measuring apparatus, not the subject** (eleven in one session on
-2026-07-31, nine more on 2026-08-01). Several cost hours; one cost two sessions. This is the single
-highest-value page in this document.
+**Every entry below is a phantom defect that came from the measuring apparatus, not the subject.**
+Several cost hours; one cost two sessions. This is the single highest-value page in this document.
+
+*Maintenance:* **append, never renumber** — an existing number may already be cited from an issue or a
+commit message. Deliberately no total is stated here: a restated count goes stale the moment a lane
+appends, and it already had (the header read "Fourteen" against a 17-row table). If you need the
+count, read the last row's number.
 
 | # | Instrument | How it lied |
 |---|---|---|
@@ -77,6 +81,8 @@ highest-value page in this document.
 | 18 | `VAR=1 $unquoted_var cmd` | The shell expands `$unquoted_var` **after** it has decided which word is the command, so an expansion like `PROSPER_NO_PLUGIN_AUTOLINK=1` becomes the **command name**, not an assignment. The arm never runs, exits 127, and — with stdout redirected to a per-arm log — leaves an empty file that reads exactly like a legitimate "no output" result. #1609's founding 14,666-vs-18,167 "20% regression" came from an A/B whose OFF arm had never executed. Build env into the command directly, or use `env VAR=1 cmd`. |
 | 19 | `$HOME` read as private scratch | Every lane on this box shares one `$HOME` (410 files at the time of writing). Generic scratch names — `pr-body.md`, `ab-result.md`, `app.log`, `apr.log` — **already collide across lanes**. Writing one destroys another agent's work in flight, and reading one silently answers your question with someone else's data. Title-scope every scratch file (`tales-pr-body.md`, `tales-rate-*.log`). The tell that saved it here: the Write tool **refused to overwrite a file it had not read**. A tool declining to clobber is a safety net, not an obstacle — an agent that "fixes" it by deleting the file and retrying destroys the thing the guard was protecting. |
 | 20 | An **empty CI rollup** read as "queued" | GitHub does **not run checks on a conflicting branch at all**, so a PR whose base has moved reports `pass=0 fail=0 pending=0` with `mergeStateStatus=DIRTY` — permanently, until it is rebased. That is byte-identical to the "checks have not registered yet" state, and #1656 sat in it while master moved twice. Same shape as #18's empty log: **an absent signal mimicking a pending one**. Read `mergeable`/`mergeStateStatus` before concluding anything from a check count, and never wait on zeros. |
+| 21 | The **same draw census, now read without the resident *content*** — trap 14 firing a second time, on the lane that recorded it | #1641 spent a session treating "~23 draws/frame is implausibly few for a 4K UE4 title" as the anomaly. Decoding the title's own asset reads against its pak index showed it loads **exactly one of the 481 maps** in the container — `L_GameloftSplash.umap`, **7,870 bytes** — and never opens `L_Main` or `L_StartMap`. 23 draws is a **complete and correct** deferred frame over a splash world. Worse, the premise was invalid in *both* directions: `L_Main.uexp` is **616 bytes**, so this title's front end is UMG/Slate and a *working* title screen would also decode few 3D draws. Nothing was ever missing. |
+| 22 | A **runtime `eboot+0x…` offset** | Several diagnostics subtract the literal `0x400000000` while the eboot maps at `BOOT_EBOOT = 0x410000000`, so the printed offset is **`0x10000000` too high** — wrong but entirely plausible, and every downstream `edis.py`/`xref.py`/`PROSPER_BP` lookup then fails in a way that looks like a code problem. `boot_trace.cpp:97` uses the right constant, so two conventions coexist under one label. Filed as **#1659**. Tell: an `eboot+0x1…` offset **past the module image size** is a labelling artifact, not a wild pointer. |
 
 **Working rules that follow:**
 
@@ -125,6 +131,17 @@ highest-value page in this document.
   printed *every* occurrence. That read turned #1606's "dozens per second" into 18 and 21 events for two
   entire runs.
 
+- **Before concluding that geometry is missing, establish what content is actually resident.** A draw
+  count describes the frame; it says nothing about whether the world has anything in it. For a
+  UE4/pak title this is one offline command against a log you already have —
+  `tools/re/pak_index.py GAME.pak --log run.log --distinct` resolves the `[apr] read-submit` byte
+  offsets to asset names, so "which maps/blueprints/widgets did the guest load, and where did
+  loading stop?" is answered with no boot and no GPU. Run it *first*. On #1641 it dissolved a
+  session's worth of GPU investigation in one pass.
+- **A trap you have already recorded is the one most likely to catch you.** Trap 15 is trap 14, hit
+  by the lane that wrote trap 14 down, because the rule had been internalised as "check the render
+  *phase*" when the general form is "check the *denominator* — phase, resident content, and engine
+  architecture — before treating a low count as a defect."
 - Prefer experiments that **detect their own invalidity** — e.g. render two adjacent operations and assert both
   return the same resolution, so a surface switch invalidates the comparison instead of producing a phantom.
 - **Open the image.** Believe neither a metric win nor a metric failure without looking. A diagnostic clear can
@@ -325,6 +342,31 @@ Safe to overlap in normal circumstances:
 - short deterministic correctness replays where timing is irrelevant;
 - game-list or no-game frontend tests that only render light ImGui content;
 - builds and non-Vulkan tests.
+
+**Omitting `PROSPER_RENDER` does NOT make a run GPU-free.** This has been read as "no GPU" in
+briefs and in lane planning, and it is wrong. `tools/boot_trace/boot_trace.cpp:285` gates only the
+**live renderer** on `PROSPER_RENDER`; a few lines earlier, `:277` unconditionally calls
+`prosper::frontend::register_live_compute()`, which executes the title's compute dispatches through
+Vulkan. A "CPU-only" `boot_trace` run of PPSA19244 executed **~135,000 dispatches** over 310 s — a
+real, sustained GPU consumer that any peer measuring frame time would have felt.
+
+The genuinely Vulkan-free path is **`PROSPER_NO_COMPUTE=1`**, which selects the progression-only
+no-op backend at `boot_trace.cpp:270-276` instead. It retains semantic dispatches and mutates no
+guest GPU resources, so it is sound for CPU-side questions — asset/file I/O, pad, HLE call counts,
+guest backtraces, boot progression — but **not** for anything whose result depends on compute
+output. Validate it per investigation rather than assuming: on PPSA19244 the `NO_COMPUTE` arm was
+confirmed to reach the same steady state (same ~23 draws/submit, same asset set, same stall) as the
+compute-enabled arm before any conclusion was drawn from it.
+
+So the honest classification is:
+
+| run | Vulkan? |
+|---|---|
+| `PROSPER_RENDER=1` | yes — renderer **and** compute |
+| no `PROSPER_RENDER` | **yes — compute still runs** |
+| no `PROSPER_RENDER` + `PROSPER_NO_COMPUTE=1` | no |
+| `gpu_replay`, `screenshot`, `prosper-app` | yes |
+| `gpu_timeline`, `self_dump`, `shader_histo`, `tools/re/*`, `tools/il2cpp/*` | no |
 
 Ask the orchestrator for an exclusive lease when:
 

--- a/prosper/docs/GAME_COMPAT_ORCHESTRATION.md
+++ b/prosper/docs/GAME_COMPAT_ORCHESTRATION.md
@@ -83,6 +83,7 @@ count, read the last row's number.
 | 20 | An **empty CI rollup** read as "queued" | GitHub does **not run checks on a conflicting branch at all**, so a PR whose base has moved reports `pass=0 fail=0 pending=0` with `mergeStateStatus=DIRTY` — permanently, until it is rebased. That is byte-identical to the "checks have not registered yet" state, and #1656 sat in it while master moved twice. Same shape as #18's empty log: **an absent signal mimicking a pending one**. Read `mergeable`/`mergeStateStatus` before concluding anything from a check count, and never wait on zeros. |
 | 21 | The **same draw census, now read without the resident *content*** — trap 14 firing a second time, on the lane that recorded it | #1641 spent a session treating "~23 draws/frame is implausibly few for a 4K UE4 title" as the anomaly. Decoding the title's own asset reads against its pak index showed it loads **exactly one of the 481 maps** in the container — `L_GameloftSplash.umap`, **7,870 bytes** — and never opens `L_Main` or `L_StartMap`. 23 draws is a **complete and correct** deferred frame over a splash world. Worse, the premise was invalid in *both* directions: `L_Main.uexp` is **616 bytes**, so this title's front end is UMG/Slate and a *working* title screen would also decode few 3D draws. Nothing was ever missing. |
 | 22 | A **runtime `eboot+0x…` offset** | Several diagnostics subtract the literal `0x400000000` while the eboot maps at `BOOT_EBOOT = 0x410000000`, so the printed offset is **`0x10000000` too high** — wrong but entirely plausible, and every downstream `edis.py`/`xref.py`/`PROSPER_BP` lookup then fails in a way that looks like a code problem. `boot_trace.cpp:97` uses the right constant, so two conventions coexist under one label. Filed as **#1659**. Tell: an `eboot+0x1…` offset **past the module image size** is a labelling artifact, not a wild pointer. |
+| 23 | A **call-count table read as evidence of *what* is being waited on** | `PROSPER_PROGRESS_UNIMPL`'s per-NID counts showed **1,300,185,430 `select()` calls in 144 s** on PPSA19244 while every other socket call stayed a frozen singleton — a real, liveness-controlled measurement. It was then read as "the guest is blocked polling a socket", and a shared-substrate design decision (implement a loopback socket backing) was nearly escalated on it. Reading the **arguments** took one `PROSPER_STUBDUMP` lookup plus one gdb breakpoint and showed `select(nfds=0, NULL, NULL, NULL, {3,0})` — the portable **`sleep()`** idiom, no descriptor involved. The thread was trying to sleep 3 s; the 0-returning stub made it a no-op. Not a socket poll, not the stall — a CPU tax. A count answers *"is something spinning?"*; it can **never** answer *"on what?"*, and the function's name is not evidence. |
 
 **Working rules that follow:**
 
@@ -138,7 +139,23 @@ count, read the last row's number.
   offsets to asset names, so "which maps/blueprints/widgets did the guest load, and where did
   loading stop?" is answered with no boot and no GPU. Run it *first*. On #1641 it dissolved a
   session's worth of GPU investigation in one pass.
-- **A trap you have already recorded is the one most likely to catch you.** Trap 15 is trap 14, hit
+- **Read an unimplemented call's *arguments* before inferring what it is doing.** This is cheap and
+  almost never done. `PROSPER_STUBDUMP=1` prints one line per import — `[stub] #877 off=0x148e0
+  libScePosix::T8fER+tIGgk` — and each stub lives at `0x600000000 + off`, so a gdb breakpoint at the
+  **stub entry** catches the guest's argument registers fully intact (the stub has not clobbered
+  anything yet; note the generic unimplemented path *does* overwrite `rdi`/`rsi`/`rdx` by the time it
+  reaches `prosper_on_unimpl`, so break on the stub, not the C++ handler):
+
+  ```bash
+  PROSPER_STUBDUMP=1 … boot_trace <dump> 2>&1 | grep '<NID>'      # -> off=0x148e0
+  gdb -p $(pgrep -x boot_trace) -batch -ex 'set pagination off' \
+      -ex 'break *0x6000148e0' -ex continue -ex 'info registers rdi rsi rdx rcx r8'
+  ```
+
+  The stub table is per-run — re-read it, never reuse an address. On PPSA19244 this converted
+  "1.3 billion socket polls" into "a 3-second sleep that returns instantly", and stopped a
+  substantial piece of shared work from being scoped against a wrong premise.
+- **A trap you have already recorded is the one most likely to catch you.** Trap 21 is trap 14, hit
   by the lane that wrote trap 14 down, because the rule had been internalised as "check the render
   *phase*" when the general form is "check the *denominator* — phase, resident content, and engine
   architecture — before treating a low count as a defect."

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -20,6 +20,7 @@
 #include <cstdio>
 #include <cstring>
 #include <atomic>
+#include <cerrno>       // select/pselect fail-visible path sets errno for __error() (#1660)
 #include <ctime>
 #include <deque>
 #include <mutex>
@@ -398,6 +399,100 @@ HLE(k_usleep)   { uint64_t us = a0; struct timespec ts{ (time_t)(us / 1000000), 
 // infinite busy-sleep. We always sleep the full duration, so return 0 (Kyty KernelSleep returns OK/0).
 HLE(k_sleep_s)  { struct timespec ts{ (time_t)a0, 0 }; nanosleep(&ts, nullptr); return 0; }
 HLE(k_nanosleep){ if (a0) nanosleep((const struct timespec*)P(a0), a1 ? (struct timespec*)P(a1) : nullptr); return 0; }
+
+// --- select / pselect: the PURE-SLEEP shape only (#1660) --------------------------------------
+//
+// `select(0, NULL, NULL, NULL, &tv)` — nfds <= 0 with all three descriptor sets NULL — is the
+// canonical portable sleep idiom. No descriptor is involved, so it needs no socket backing at all:
+// wait out the timeout and return 0. **0 is the CORRECT return here** ("timed out, nothing became
+// ready"); returning it *immediately* is the defect. What has to be honoured is the timeout.
+//
+// Evidence: on PPSA19244 (The Oregon Trail) the Gameloft SDK's `OLD_HTTPClient` service thread uses
+// exactly this call as its 3-second inter-pass sleep — arguments captured live at the import stub
+// (`PROSPER_STUBDUMP` -> 0x600000000+off -> breakpoint at stub entry), six consecutive hits, all
+// `select(nfds=0, NULL, NULL, NULL, {tv_sec=3, tv_usec=0})`. Falling through to the generic
+// unimplemented stub returned 0 in ~111 ns, collapsing a 3 s sleep into a no-op: the loop ran
+// **9.0 million times per second — 1,300,185,430 calls in 144 s**, saturating a core through the
+// dispatch path. That is both a performance cost and a measurement hazard, because the burn
+// attributes itself to prosper's dispatch rather than to the guest and distorts any CPU profile of
+// a title in this state. `select`-as-sleep is a portable idiom, so this is not title-specific.
+//
+// A query with an actual descriptor set is NOT implemented and deliberately stays fail-visible:
+// prosper has no socket backing, so replying "0 = nothing ready" would be precisely the
+// success-shaped answer-we-cannot-honour that caused this bug. Log it loudly and fail.
+// CONFIDENCE: HIGH on the sleep shape (arguments observed live); the descriptor shape is
+// intentionally unimplemented, not unknown.
+namespace {
+// True for the pure-sleep shape: no descriptor may be examined.
+bool select_is_pure_sleep(uint64_t nfds, uint64_t readfds, uint64_t writefds, uint64_t exceptfds) {
+    return (int64_t)nfds <= 0 && readfds == 0 && writefds == 0 && exceptfds == 0;
+}
+
+// Sleep the FULL duration. A bare nanosleep returns early on a signal, and prosper delivers signals
+// on its own (the SIGSEGV fault handler), so a short sleep would reintroduce a faster spin.
+void sleep_full(struct timespec want) {
+    while (want.tv_sec > 0 || want.tv_nsec > 0) {
+        struct timespec rem{0, 0};
+        if (nanosleep(&want, &rem) == 0) return;
+        if (errno != EINTR) return;
+        want = rem;
+    }
+}
+
+// A NULL timeout in the pure-sleep shape means "block forever". Sleep in bounded chunks rather than
+// one unbounded call so the process still responds to termination.
+void sleep_forever() { for (;;) sleep_full(timespec{1, 0}); }
+
+uint64_t select_unsupported(const char* fn, uint64_t nfds,
+                            uint64_t readfds, uint64_t writefds, uint64_t exceptfds) {
+    static std::atomic<int> logged{0};
+    const int n = logged.fetch_add(1);
+    // Distinguish the two ways a call can miss the implemented shape, because they mean very
+    // different things. A real descriptor set genuinely cannot be answered without socket backing.
+    // `nfds > 0` with every set NULL examines no descriptor either, so it is *probably* also a
+    // sleep — but no title has been observed doing it, so it is refused rather than assumed, and
+    // called out here so the first title that does hit it is immediately visible instead of
+    // silently inheriting a widened contract. See #1660 before extending the shape.
+    const bool no_sets = (readfds == 0 && writefds == 0 && exceptfds == 0);
+    if (n < 8)
+        fprintf(stderr, "[posix] %s: %s is UNIMPLEMENTED (no socket backing) "
+                        "nfds=%lld readfds=%#llx writefds=%#llx exceptfds=%#llx -> -1 ENOSYS "
+                        "(#%d; only the nfds<=0 + all-NULL pure-sleep shape is supported, see #1660)%s\n",
+                fn, no_sets ? "descriptor-free call with nfds>0" : "descriptor-set query",
+                (long long)(int64_t)nfds, (unsigned long long)readfds,
+                (unsigned long long)writefds, (unsigned long long)exceptfds, n,
+                no_sets ? "  <- examines no descriptor; likely a sleep, but unobserved: report it"
+                        : "");
+    // Follows the existing libScePosix wrapper convention in hle_file.cpp: set the host errno that
+    // __error()/h_errno_location hands back and return -1. Whether that number should be translated
+    // to FreeBSD's is the separate concern tracked by #1612, not something to diverge on here.
+    errno = ENOSYS;
+    return (uint64_t)(int64_t)-1;
+}
+} // namespace
+
+// select(int nfds, fd_set* r, fd_set* w, fd_set* e, struct timeval* timeout)
+HLE(k_select) {
+    if (!select_is_pure_sleep(a0, a1, a2, a3)) return select_unsupported("select", a0, a1, a2, a3);
+    if (!a4) sleep_forever();
+    else {
+        const int64_t* tv = (const int64_t*)P(a4);   // struct timeval { time_t sec; suseconds_t usec; }
+        sleep_full(timespec{ (time_t)tv[0], (long)(tv[1] * 1000) });
+    }
+    return 0;   // timed out with nothing ready — the correct answer for a descriptor-free wait
+}
+
+// pselect(int nfds, fd_set* r, fd_set* w, fd_set* e, const struct timespec* timeout,
+//         const sigset_t* sigmask). Same rule; the timeout is a timespec, not a timeval.
+HLE(k_pselect) {
+    if (!select_is_pure_sleep(a0, a1, a2, a3)) return select_unsupported("pselect", a0, a1, a2, a3);
+    if (!a4) sleep_forever();
+    else {
+        const int64_t* ts = (const int64_t*)P(a4);
+        sleep_full(timespec{ (time_t)ts[0], (long)ts[1] });
+    }
+    return 0;
+}
 // Guest-visible process id. Keep it stable across host runs and distinct from the kernel's
 // special pid 0; shadPS4 uses the same 0xBAD1 compatibility pid. Returning generic-stub success
 // (zero) violates POSIX and can collapse per-process paths/ownership keys. CONFIDENCE: HIGH.
@@ -1347,6 +1442,11 @@ void register_kernel_time_hle() {
     R("pthread_setcancelstate", k_pthread_setcancelstate);
     R("_sigprocmask", k_sigprocmask_noop);
     R("_is_signal_return", k_is_signal_return);
+    // select/pselect — pure-sleep shape only (#1660). nid_hash("select") == "T8fER+tIGgk" and
+    // nid_hash("pselect") == "ZO2nWoTAv60", matching the PS5 3.20 libkernel/libkernel_web/
+    // libkernel_sys export tables and the import PPSA19244 actually binds.
+    R("select", k_select);
+    R("pselect", k_pselect);
     #undef R
 }
 

--- a/prosper/tests/test_select_sleep.cpp
+++ b/prosper/tests/test_select_sleep.cpp
@@ -1,0 +1,135 @@
+// test_select_sleep — select/pselect honour the pure-sleep shape and refuse everything else (#1660).
+//
+// `select(0, NULL, NULL, NULL, &tv)` is the portable sleep idiom: nfds <= 0 with all three
+// descriptor sets NULL, so no descriptor is ever examined. Before this was implemented the call fell
+// through to the generic unimplemented stub, which returns 0 in ~111 ns — collapsing a 3-second
+// sleep into a no-op. On PPSA19244 that made one service thread spin **9.0 million times per
+// second** (1,300,185,430 calls in 144 s), saturating a core through the dispatch path.
+//
+// The contract under test, and the reason each half matters:
+//
+//   1. The pure-sleep shape must WAIT. `0` is the correct return ("timed out, nothing ready") — the
+//      defect was returning it immediately. So the assertion is on ELAPSED TIME, not the value: a
+//      test that only checked the return value passes against the very stub this replaces.
+//   2. A descriptor-set query must stay FAIL-VISIBLE. prosper has no socket backing, so answering
+//      "0 = nothing ready" would be the same success-shaped lie in a new place. It must return -1.
+//
+// Both halves fail without the fix: (1) elapses ~0 ms against the unimplemented stub, and (2)
+// returns 0 rather than -1.
+#include "../src/hle/dispatch.hpp"
+#include "../src/hle/nid.hpp"
+#include <chrono>
+#include <cerrno>
+#include <cstdint>
+#include <cstdio>
+#include <functional>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+static int64_t elapsed_ms(const std::function<void()>& body) {
+    const auto t0 = std::chrono::steady_clock::now();
+    body();
+    return std::chrono::duration_cast<std::chrono::milliseconds>(
+               std::chrono::steady_clock::now() - t0).count();
+}
+
+int main() {
+    printf("test_select_sleep\n");
+    register_builtin_hle();
+
+    // The guest binds these by NID; assert the hash matches the real PS5 3.20 export so the
+    // registration cannot silently stop binding (nid_hash is the same function the stub emitter
+    // uses, and these are the NIDs PPSA19244's import table actually carries).
+    CHECK(nid_hash("select") == "T8fER+tIGgk", "nid_hash(\"select\") matches the PS5 3.20 export");
+    CHECK(nid_hash("pselect") == "ZO2nWoTAv60", "nid_hash(\"pselect\") matches the PS5 3.20 export");
+
+    auto select_fn  = Hle::lookup(nid_hash("select"));
+    auto pselect_fn = Hle::lookup(nid_hash("pselect"));
+    CHECK(select_fn != nullptr, "select is registered (not left to the unimplemented stub)");
+    CHECK(pselect_fn != nullptr, "pselect is registered");
+    if (!select_fn || !pselect_fn) { printf("FAILED (%d)\n", ++fails); return 1; }
+
+    // --- 1. the pure-sleep shape actually waits -------------------------------------------------
+    // 150 ms is long enough to be unambiguous against scheduler noise and short enough for ctest.
+    // Assert a small tolerance below the request rather than exact equality: nanosleep may round.
+    {
+        int64_t tv[2] = { 0, 150000 };                       // struct timeval { sec, usec }
+        uint64_t rc = 0;
+        const int64_t ms = elapsed_ms([&] {
+            rc = select_fn(0, 0, 0, 0, (uint64_t)(uintptr_t)tv, 0);
+        });
+        printf("  select(0,NULL,NULL,NULL,{0,150000}) -> %llu in %lld ms\n",
+               (unsigned long long)rc, (long long)ms);
+        CHECK(ms >= 140, "select honours a 150 ms timeout (the stub returned in ~0 ms)");
+        CHECK(rc == 0, "select returns 0 (timed out, nothing ready) after waiting");
+    }
+    {
+        int64_t ts[2] = { 0, 150000000 };                    // struct timespec { sec, nsec }
+        uint64_t rc = 0;
+        const int64_t ms = elapsed_ms([&] {
+            rc = pselect_fn(0, 0, 0, 0, (uint64_t)(uintptr_t)ts, 0);
+        });
+        printf("  pselect(0,NULL,NULL,NULL,{0,150000000}) -> %llu in %lld ms\n",
+               (unsigned long long)rc, (long long)ms);
+        CHECK(ms >= 140, "pselect honours a 150 ms timespec timeout");
+        CHECK(rc == 0, "pselect returns 0 after waiting");
+    }
+
+    // A zero timeout is a legal poll of an empty set: it must return promptly, and must not be
+    // confused with the unbounded-wait (NULL timeout) case.
+    {
+        int64_t tv[2] = { 0, 0 };
+        uint64_t rc = 0;
+        const int64_t ms = elapsed_ms([&] {
+            rc = select_fn(0, 0, 0, 0, (uint64_t)(uintptr_t)tv, 0);
+        });
+        CHECK(ms < 100, "select with a zero timeout returns promptly");
+        CHECK(rc == 0, "select with a zero timeout returns 0");
+    }
+
+    // --- 2. a descriptor-set query stays fail-visible --------------------------------------------
+    // This is the half that keeps the fix honest: the sleep path must NOT be widened to cover a
+    // real readiness query, because prosper has no socket backing to answer one with.
+    {
+        uint64_t fdset[16] = {0};                            // contents irrelevant; non-NULL is
+        int64_t tv[2] = { 0, 0 };                            // what makes this a real query
+        const uint64_t rc = select_fn(4, (uint64_t)(uintptr_t)fdset, 0, 0,
+                                      (uint64_t)(uintptr_t)tv, 0);
+        printf("  select(4, &readfds, ...) -> %lld (errno=%d)\n", (long long)(int64_t)rc, errno);
+        CHECK((int64_t)rc == -1, "select with a readfds set fails visibly (-1), never a false 0");
+        CHECK(errno == ENOSYS, "select sets errno=ENOSYS for the unimplemented descriptor query");
+    }
+    {
+        uint64_t fdset[16] = {0};
+        const uint64_t rc = select_fn(4, 0, (uint64_t)(uintptr_t)fdset, 0, 0, 0);
+        CHECK((int64_t)rc == -1, "select with a writefds set fails visibly (-1)");
+    }
+    {
+        uint64_t fdset[16] = {0};
+        const uint64_t rc = select_fn(4, 0, 0, (uint64_t)(uintptr_t)fdset, 0, 0);
+        CHECK((int64_t)rc == -1, "select with an exceptfds set fails visibly (-1)");
+    }
+    {
+        uint64_t fdset[16] = {0};
+        const uint64_t rc = pselect_fn(4, (uint64_t)(uintptr_t)fdset, 0, 0, 0, 0);
+        CHECK((int64_t)rc == -1, "pselect with a readfds set fails visibly (-1)");
+    }
+    // Deliberate scope boundary. `nfds > 0` with every set NULL examines no descriptor either, so by
+    // POSIX semantics it is *also* a sleep — but no title has been observed making that call, so the
+    // implemented shape stays exactly the one the evidence supports (`nfds <= 0` AND all sets NULL)
+    // and this form is refused loudly rather than assumed. Pinning it here means widening the
+    // contract later has to be a deliberate edit with its own evidence, not an accident.
+    {
+        int64_t tv[2] = { 0, 0 };
+        const uint64_t rc = select_fn(8, 0, 0, 0, (uint64_t)(uintptr_t)tv, 0);
+        CHECK((int64_t)rc == -1,
+              "nfds>0 with all sets NULL is outside the observed shape: refused, not assumed");
+    }
+
+    printf(fails ? "FAILED (%d)\n" : "PASSED\n", fails);
+    return fails ? 1 : 0;
+}

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -30,6 +30,12 @@ the shipped runtime. Build them from `build-linux/` like everything else.
   counts alone do not prove that the image changed; see `screenshot/README.md`.
 - **`self_dump/`** — parse a SELF/ELF and print its segment/program-header map, import NIDs, and
   export RVAs. Use `--find-symbol NID` for a focused import/export query.
+- **`guest_bt/`** — symbolicated **guest**-thread backtraces for a live or frozen prosper process:
+  "what is this thread doing / waiting for?". Answers it for **any** title, not just IL2CPP/Unity —
+  the managed-symbol step is optional, and on a stripped native C++ UE4 title it still walks every
+  guest thread under its **real engine thread name** (`RenderThread 1`, `TaskGraphThread`,
+  `FAPREventQueueL`, …) with the prosper-side wait frame attached, which is usually enough to say
+  which subsystem is stuck. See `guest_bt/README.md`.
 - **`re/pak_index.py`** — resolve UE4 `.pak` byte offsets to asset names, and decode a
   `PROSPER_FILELOG=1` run's `[apr] read-submit` stream into an ordered asset load trace. Answers
   "which map/blueprint/texture did the guest actually load, and where did loading stop?" offline,

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -30,6 +30,13 @@ the shipped runtime. Build them from `build-linux/` like everything else.
   counts alone do not prove that the image changed; see `screenshot/README.md`.
 - **`self_dump/`** — parse a SELF/ELF and print its segment/program-header map, import NIDs, and
   export RVAs. Use `--find-symbol NID` for a focused import/export query.
+- **`re/pak_index.py`** — resolve UE4 `.pak` byte offsets to asset names, and decode a
+  `PROSPER_FILELOG=1` run's `[apr] read-submit` stream into an ordered asset load trace. Answers
+  "which map/blueprint/texture did the guest actually load, and where did loading stop?" offline,
+  from a log captured earlier — no boot and no GPU. Check what content is resident *before*
+  concluding that geometry is missing: on PPSA19244 it showed the title loads exactly one of 481
+  maps (a splash level), which made its empty base pass correct rather than a defect. See
+  `re/README.md`.
 - **`re/xref.py`** — find relative data pointers, direct references, runtime function-table
   writers, and indirect callers in a flattened guest module. See `re/README.md`.
 - **`shader_histo/`** — histogram RDNA2 opcodes across a title's shaders.

--- a/prosper/tools/guest_bt/README.md
+++ b/prosper/tools/guest_bt/README.md
@@ -3,6 +3,17 @@
 Answer *"what is this guest thread actually doing / waiting for?"* with a real call stack — including
 **managed C# method names** for IL2CPP/Unity titles — for any live or frozen prosper process.
 
+**It is not IL2CPP-only.** The managed-symbol step is optional; everything else — the re-sectioned
+`.eh_frame` unwind, the HLE stub bridge, and per-thread reporting — works on any title. On a
+**stripped native C++ UE4** title (PPSA19244, no `script.json`, no symbols at all) it walked all
+**68** guest threads and reported them under their **real engine thread names**, because the guest's
+own `pthread_setname` values survive: `RenderThread 1`, `RTHeartBeat 1`, `FAsyncPurge`,
+`FAPREventQueueL`, `TaskGraphThread` ×21, `PoolThread 0..8`, `HttpManagerThre`, `OnlineAsyncTask`.
+Guest frames show as bare `eboot+offset`, but the thread name plus the prosper-side wait function
+(`k_cond_wait` / `k_cond_timedwait` / `k_usleep` / `k_eq_wait`) is usually enough to answer "which
+subsystem is stuck": on that title it isolated the **two** threads of 68 still executing guest code
+in a boot that had otherwise gone completely quiet. Reach for it on native titles, not just Unity.
+
 ## Why gdb alone can't do this
 
 Two things defeat gdb's native unwinder on a prosper guest thread:
@@ -80,6 +91,8 @@ in `guest_bt_gdb.py._StubUnwinder` (and this note) together.
 
 - Managed (IL2CPP, `0x440000000..`) frames get method names; the Unity **player** eboot
   (`0x410000000`) and system PRXs are stripped C++, so those frames show as bare `module+offset`.
+  The same is true of an entirely native title — no managed frames means no method names, but the
+  walk, the thread names, and the prosper-side wait frames are all still there (see above).
 - The unwind is only as good as the modules' `.eh_frame`; a frame whose module ships no CFI ends the
   walk. `mk_sym_elf.py` reports which modules had CFI.
 - Linux/`%fs`-swap stubs only. The Windows/macOS stub shapes differ; the rule would need porting.

--- a/prosper/tools/re/README.md
+++ b/prosper/tools/re/README.md
@@ -73,3 +73,45 @@ code at a site does. It complements `xref.py to <slot>`, which lists the *sites*
 `xref.py`, then read each one with `edis.py`. Unlike `tools/dbg/dis.sh`, which disassembles a pre-extracted
 `/tmp/text.bin` for one title, `edis.py` takes any flattened module ELF directly, so the same command works
 for every title. Requires `objdump` (binutils) on PATH.
+
+## `pak_index.py` — turn a UE4 `.pak` byte offset into an asset name
+
+A UE4 title on PS5 streams content through the Ampr/APR async-read path, and `PROSPER_FILELOG=1`
+logs every request:
+
+```text
+[apr] read-submit id=1 …/game-ps5.pak -> dst=0x…(guest) off=0x89a1be4 size=3080 got=3080 OK
+```
+
+That records *how much* was read and *whether it succeeded* — but not **what** was read. In a
+stripped shipping eboot the read stream is often the only readable statement of the engine's
+loading state, and those offsets are raw byte positions in a multi-gigabyte container.
+
+`pak_index.py` parses the pak's own index (footer → encoded entries → full directory index) and
+maps offsets back to asset paths, so the APR stream becomes a load trace:
+
+```bash
+# what is at this offset?
+python3 tools/re/pak_index.py GAME.pak --resolve 0x89a1be4
+
+# decode a whole run into the assets it loaded, in order
+python3 tools/re/pak_index.py GAME.pak --log run.log --distinct
+python3 tools/re/pak_index.py GAME.pak --log run.log --summary
+
+# does the title even ship this map?
+python3 tools/re/pak_index.py GAME.pak --list '*/Maps/*.umap'
+```
+
+It is offline and read-only — no boot, no GPU, and it works against a log captured earlier.
+
+**Why it is worth reaching for.** On PPSA19244 (The Oregon Trail) the open question was why UE4's
+base pass drew nothing. One `--distinct` pass over a retained `PROSPER_FILELOG=1` log answered it
+without another run: of the 481 `.umap` files in the container the title loads exactly one,
+`TheOregonTrail/Content/Maps/L_GameloftSplash.umap` (a 12 KB splash level), and never opens
+`L_Main` or `L_StartMap`. An empty base pass is the *correct* output for that world — so the draw
+count was never the defect. Use this before concluding anything about missing geometry: confirm
+which content is actually resident first.
+
+Limits: unencrypted index only, pak index versions 10-11 (the v10+ encoded-entry + full-directory
+layout). IoStore `.utoc`/`.ucas` containers are a different format and are not handled. Run
+`--self-test` to check the entry decoder, the offset lookup, and the log parser without a pak.

--- a/prosper/tools/re/pak_index.py
+++ b/prosper/tools/re/pak_index.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""pak_index — resolve UE4 `.pak` byte offsets to asset names, and decode a prosper APR read log.
+
+Why this exists
+---------------
+A UE4 title on PS5 streams its content through the Ampr/APR async-read path. prosper logs every
+one of those reads under `PROSPER_FILELOG=1`:
+
+    [apr] read-submit id=1 <host-path-to.pak> -> dst=0x…(guest) off=0x89a1be4 size=3080 got=3080 OK
+
+That tells you *how much* the guest read and *whether it succeeded*, but not **what it read**.
+The offsets are raw byte positions inside a multi-gigabyte `.pak`, and a stripped shipping eboot
+gives no other handle on the engine's loading state.
+
+This tool closes that gap: it parses the pak's own index, so an offset becomes an asset path.
+The read stream then reads like a load trace — which maps opened, which blueprints/widgets/
+textures/sound banks were pulled in, in what order, and exactly where loading stopped. On
+PPSA19244 (The Oregon Trail) that turned "the base pass draws nothing" into "the only map the
+title ever loads is `Content/Maps/L_GameloftSplash.umap`" in one pass, with no game run at all.
+
+It is offline and read-only: it needs the `.pak` and (optionally) a log file. No GPU, no boot.
+
+Supported containers
+--------------------
+Pak index versions 8..11 (UE 4.22-4.27), unencrypted index, with either the v10+
+path-hash/full-directory index pair or the older single directory index. IoStore
+(`.utoc`/`.ucas`) containers are a different format and are **not** handled here.
+
+Usage
+-----
+    # what asset lives at these pak offsets?
+    pak_index.py GAME.pak --resolve 0x89a1be4 0xf161d288
+
+    # decode a prosper run's whole APR read stream into an asset load trace
+    pak_index.py GAME.pak --log run.log                 # every read, in order
+    pak_index.py GAME.pak --log run.log --distinct      # first read of each asset, in order
+    pak_index.py GAME.pak --log run.log --summary       # counts by extension / top directories
+
+    # list what is in the container at all (does the title even ship map X?)
+    pak_index.py GAME.pak --list '*.umap'
+
+    pak_index.py --self-test        # no pak needed
+"""
+
+import argparse
+import bisect
+import fnmatch
+import os
+import re
+import struct
+import sys
+from collections import Counter
+
+PAK_MAGIC = 0x5A6F12E1
+
+# The footer grew over time; probe the known sizes from the end of the file. Only the fields this
+# tool needs are read, so a footer whose tail carries extra data still parses.
+#   u32 magic, u32 version, u64 indexOffset, u64 indexSize, u8 indexHash[20], then version extras.
+_FOOTER_FIXED = 4 + 4 + 8 + 8 + 20
+
+
+class PakError(Exception):
+    pass
+
+
+def _find_footer(data: bytes, file_size: int):
+    """Return (version, index_offset, index_size) from a trailing chunk of the pak."""
+    magic_le = struct.pack('<I', PAK_MAGIC)
+    # Search from the end: the real footer is the last magic in the file.
+    pos = data.rfind(magic_le)
+    while pos >= 0:
+        if len(data) - pos >= _FOOTER_FIXED:
+            version, = struct.unpack_from('<I', data, pos + 4)
+            index_off, index_size = struct.unpack_from('<QQ', data, pos + 8)
+            if 8 <= version <= 11 and 0 < index_size and index_off + index_size <= file_size:
+                return version, index_off, index_size
+        pos = data.rfind(magic_le, 0, pos)
+    raise PakError('no usable pak footer found (encrypted index, IoStore container, or truncated file)')
+
+
+class _Cursor:
+    """Little-endian reader for UE4's FArchive primitives."""
+
+    def __init__(self, buf: bytes):
+        self.buf = buf
+        self.off = 0
+
+    def u32(self):
+        v, = struct.unpack_from('<I', self.buf, self.off)
+        self.off += 4
+        return v
+
+    def i32(self):
+        v, = struct.unpack_from('<i', self.buf, self.off)
+        self.off += 4
+        return v
+
+    def i64(self):
+        v, = struct.unpack_from('<q', self.buf, self.off)
+        self.off += 8
+        return v
+
+    def u64(self):
+        v, = struct.unpack_from('<Q', self.buf, self.off)
+        self.off += 8
+        return v
+
+    def skip(self, n):
+        self.off += n
+
+    def fstring(self):
+        n = self.i32()
+        if n < 0:                       # negative length => UTF-16, count is in characters
+            raw = self.buf[self.off:self.off + (-n) * 2]
+            self.off += (-n) * 2
+            return raw.decode('utf-16-le', 'replace').rstrip('\0')
+        raw = self.buf[self.off:self.off + n]
+        self.off += n
+        return raw.decode('utf-8', 'replace').rstrip('\0')
+
+
+def decode_entry(blob: bytes, at: int):
+    """Decode one FPakEntry from UE4's EncodedPakEntries bitfield form.
+
+    Layout of the leading u32 (FPakFile::DecodePakEntry):
+      bit 31    offset is 32-bit
+      bit 30    uncompressed size is 32-bit
+      bit 29    compressed size is 32-bit (only present when compressed)
+      bits 28-23 compression method index
+      bit 22    encrypted
+      bits 21-6 compression block count
+      bits 5-0  compression block size / 2048
+    Returns (offset, size, uncompressed_size, compression_method_index).
+    """
+    c = _Cursor(blob)
+    c.off = at
+    value = c.u32()
+    method = (value >> 23) & 0x3F
+    offset = c.u32() if value & (1 << 31) else c.i64()
+    uncompressed = c.u32() if value & (1 << 30) else c.i64()
+    if method != 0:
+        size = c.u32() if value & (1 << 29) else c.i64()
+    else:
+        size = uncompressed
+    return offset, size, uncompressed, method
+
+
+def load_entries(pak_path: str):
+    """Return (mount_point, sorted list of (offset, size, uncompressed, name, method))."""
+    size = os.path.getsize(pak_path)
+    with open(pak_path, 'rb') as f:
+        tail_len = min(size, 4096)
+        f.seek(size - tail_len)
+        version, index_off, index_size = _find_footer(f.read(tail_len), size)
+
+        f.seek(index_off)
+        index = _Cursor(f.read(index_size))
+        mount = index.fstring()
+        index.i32()                                  # num entries (recomputed below)
+
+        if version >= 10:
+            index.u64()                              # path hash seed
+            if index.i32():                          # has path-hash index
+                index.i64(); index.i64(); index.skip(20)
+            has_full_dir = index.i32()
+            if not has_full_dir:
+                raise PakError('pak has no full directory index; filenames are unavailable '
+                               '(only the path-hash index is present)')
+            dir_off, dir_size = index.i64(), index.i64()
+            index.skip(20)
+            encoded_size = index.i32()
+            encoded = index.buf[index.off:index.off + encoded_size]
+            f.seek(dir_off)
+            directory = _Cursor(f.read(dir_size))
+        else:
+            # v8/v9 keep the directory inline and store full FPakEntry records, not the encoded form.
+            raise PakError('pak index version %d is not supported yet (needs the v10+ '
+                           'encoded-entry + full-directory layout)' % version)
+
+        out = []
+        for _ in range(directory.i32()):
+            dir_name = directory.fstring()
+            for _ in range(directory.i32()):
+                file_name = directory.fstring()
+                enc_at = directory.u32()
+                try:
+                    off, sz, unc, method = decode_entry(encoded, enc_at)
+                except struct.error:
+                    continue
+                out.append((off, sz, unc, dir_name + file_name, method))
+    out.sort()
+    return mount, out
+
+
+class PakMap:
+    """Offset -> asset-name lookup over a decoded pak index."""
+
+    # A read may start at the entry header rather than the payload; UE4's per-entry header is well
+    # under 4 KiB, so allow that much slack before calling a hit "past the end of this entry".
+    HEADER_SLACK = 4096
+
+    def __init__(self, entries):
+        self.entries = entries
+        self.starts = [e[0] for e in entries]
+
+    def resolve(self, offset: int):
+        """Return (name, exact) — exact=False means the offset fell past the entry's payload."""
+        i = bisect.bisect_right(self.starts, offset) - 1
+        if i < 0:
+            return None, False
+        off, size, _unc, name, _m = self.entries[i]
+        return name, offset < off + size + self.HEADER_SLACK
+
+
+_READ_RE = re.compile(
+    r'\[apr\] read-submit id=(?P<id>\d+) (?P<path>\S+) -> dst=\S+ '
+    r'off=(?P<off>0x[0-9a-fA-F]+) size=(?P<size>\d+) got=(?P<got>\d+) (?P<status>\S+)')
+
+
+def parse_read_log(path: str):
+    """Yield (offset, size, got, status) for each `[apr] read-submit` result line."""
+    with open(path, 'r', errors='replace') as f:
+        for line in f:
+            m = _READ_RE.search(line)
+            if m:
+                yield (int(m.group('off'), 16), int(m.group('size')),
+                       int(m.group('got')), m.group('status'))
+
+
+def _self_test():
+    # decode_entry: 32-bit offset + 32-bit uncompressed, uncompressed (method 0).
+    value = (1 << 31) | (1 << 30)
+    blob = struct.pack('<III', value, 0x1000, 0x40)
+    assert decode_entry(blob, 0) == (0x1000, 0x40, 0x40, 0), decode_entry(blob, 0)
+
+    # 64-bit offset + 64-bit sizes, compressed (method 1) so the compressed size is a separate field.
+    value = (1 << 23)
+    blob = struct.pack('<Iqqq', value, 0x1_0000_0000, 0x200, 0x100)
+    assert decode_entry(blob, 0) == (0x1_0000_0000, 0x100, 0x200, 1), decode_entry(blob, 0)
+
+    # PakMap: exact hit, header slack, and a miss past the entry.
+    m = PakMap([(0, 100, 100, 'a.uasset', 0), (1000, 50, 50, 'b.uexp', 0)])
+    assert m.resolve(0) == ('a.uasset', True)
+    assert m.resolve(99) == ('a.uasset', True)
+    assert m.resolve(1049) == ('b.uexp', True)
+    assert m.resolve(1000 + 50 + PakMap.HEADER_SLACK) == ('b.uexp', False)
+    assert m.resolve(-1) == (None, False)
+
+    # A read landing in the gap after an entry still attributes to that entry while it is inside
+    # the header slack; past the slack the caller is told the match is not exact. 500 is only
+    # 400 bytes past a.uasset's payload, so it is still reported as an exact hit.
+    assert m.resolve(500) == ('a.uasset', True)
+    # Past the LAST entry's payload+slack there is nothing left to attribute to, so the nearest
+    # preceding entry is returned with exact=False rather than silently claimed as a hit.
+    assert m.resolve(1000 + 50 + PakMap.HEADER_SLACK + 1) == ('b.uexp', False)
+
+    # Log parsing, including a failed read (status is preserved, not filtered).
+    import tempfile
+    with tempfile.NamedTemporaryFile('w', suffix='.log', delete=False) as fh:
+        fh.write("noise\n")
+        fh.write("[apr] read-submit id=1 /x/y.pak -> dst=0x30(guest) off=0x1000 size=64 got=64 OK\n")
+        fh.write("[apr] read-submit id=1 /x/y.pak -> dst=0x30(guest) off=0x2000 size=8 got=0 FAIL\n")
+        name = fh.name
+    try:
+        rows = list(parse_read_log(name))
+        assert rows == [(0x1000, 64, 64, 'OK'), (0x2000, 8, 0, 'FAIL')], rows
+    finally:
+        os.unlink(name)
+
+    # _find_footer picks the LAST magic, and rejects a bogus one.
+    body = b'\x00' * 64 + struct.pack('<I', PAK_MAGIC) + b'\xff' * 60
+    footer = struct.pack('<IIQQ', PAK_MAGIC, 11, 16, 32) + b'\x00' * 20
+    data = body + footer
+    assert _find_footer(data, 4096) == (11, 16, 32)
+
+    print('pak_index self-test OK')
+    return 0
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__.split('\n')[0],
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('pak', nargs='?', help='path to the title .pak')
+    ap.add_argument('--resolve', nargs='+', metavar='OFF',
+                    help='resolve these pak byte offsets (decimal or 0x…) to asset names')
+    ap.add_argument('--log', metavar='FILE',
+                    help='a prosper run log captured with PROSPER_FILELOG=1; decode its '
+                         '[apr] read-submit stream into an asset load trace')
+    ap.add_argument('--distinct', action='store_true',
+                    help='with --log: print each asset once, in first-read order')
+    ap.add_argument('--summary', action='store_true',
+                    help='with --log: print extension and directory histograms instead of a trace')
+    ap.add_argument('--list', metavar='GLOB',
+                    help='list container entries whose path matches this glob (e.g. "*.umap")')
+    ap.add_argument('--self-test', action='store_true', help='run unit checks; no pak needed')
+    args = ap.parse_args(argv)
+
+    if args.self_test:
+        return _self_test()
+    if not args.pak:
+        ap.error('a .pak path is required (or use --self-test)')
+
+    mount, entries = load_entries(args.pak)
+    pak = PakMap(entries)
+    print(f'# {args.pak}: {len(entries)} entries, mount point {mount!r}', file=sys.stderr)
+
+    if args.list:
+        for _off, _sz, _unc, name, _m in entries:
+            if fnmatch.fnmatch(name, args.list):
+                print(name)
+
+    if args.resolve:
+        for token in args.resolve:
+            off = int(token, 0)
+            name, exact = pak.resolve(off)
+            mark = '' if exact else '   (past this entry — offset is in a gap or unmapped)'
+            print(f'{off:#x}  {name}{mark}')
+
+    if args.log:
+        reads = list(parse_read_log(args.log))
+        if not reads:
+            print('no [apr] read-submit result lines found — was PROSPER_FILELOG=1 set?',
+                  file=sys.stderr)
+            return 1
+        resolved = [(off, size, status, pak.resolve(off)[0]) for off, size, _got, status in reads]
+        failed = sum(1 for _o, _s, st, _n in resolved if st != 'OK')
+        total = sum(s for _o, s, _st, _n in resolved)
+        print(f'# {len(resolved)} reads, {total/1e6:.1f} MB, {failed} not OK', file=sys.stderr)
+
+        if args.summary:
+            names = [n for _o, _s, _st, n in resolved if n]
+            uniq = list(dict.fromkeys(names))
+            print(f'distinct assets: {len(uniq)}')
+            ext = Counter(n.rsplit('.', 1)[-1] if '.' in n else '?' for n in uniq)
+            print('by extension:', ext.most_common(20))
+            top = Counter('/'.join(n.split('/')[:3]) for n in uniq)
+            print('by directory:', top.most_common(20))
+        elif args.distinct:
+            for n in dict.fromkeys(n for _o, _s, _st, n in resolved):
+                print(n)
+        else:
+            for off, size, status, name in resolved:
+                flag = '' if status == 'OK' else f'  [{status}]'
+                print(f'{off:#012x} {size:>9} {name}{flag}')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
## A saturated CPU core, and a measurement hazard that blames prosper for the guest's behaviour

`select(0, NULL, NULL, NULL, &tv)` — `nfds <= 0` with all three descriptor sets `NULL` — is the
portable **`sleep()`** idiom. No descriptor is involved. It fell through to the generic unimplemented
stub, which returns `0` in **~111 ns**, so every such sleep became a no-op.

On PPSA19244 (The Oregon Trail) the Gameloft SDK's `OLD_HTTPClient` service thread uses exactly this
call as its 3-second inter-pass sleep. The result:

| | before | after |
|---|---|---|
| `select()` calls | **1,300,185,430 in 144 s** (~9.0 M/s, ~153,600 per presented frame) | not in the unimplemented table at all |
| `OLD_HTTPClient` CPU | **3,543 jiffies — rank 1 of 68 threads, 23× the next** | **0** |
| whole `OLD_*` thread group | one core saturated | `0 / 0 / 0 / 0 / 1` |

**This is a measurement hazard as much as a performance one.** The burn happens inside prosper's
dispatch path, so it attributes itself to prosper rather than to the guest and would poison any CPU
profile taken of a title in this state. And because `select`-as-sleep is a *portable* idiom, this is
not title-specific — any middleware service thread written that way pays it.

## The contract

**`0` is the correct return here** ("timed out, nothing became ready"). Returning it *immediately* is
the defect. What had to be honoured was the **timeout**. That keeps the general rule intact and
sharpens it:

> No entry point may return a success-shaped value it cannot honour.

* `select`/`pselect` with `nfds <= 0` **and** all fd-set pointers `NULL` → wait out the timeout,
  return 0. A `NULL` timeout in that shape blocks.
* A query carrying an **actual descriptor set** stays **fail-visible** — prosper has no socket
  backing, so answering "0 = nothing ready" would be the same success-shaped lie in a new place. It
  logs loudly (capped at 8) and returns `-1`/`ENOSYS`.
* `nfds > 0` with every set `NULL` examines no descriptor either and is *probably* also a sleep, but
  **no title has been observed doing it**, so it is refused with its own distinct log message rather
  than folded into the implemented shape on an assumption. Pinned by a test so widening it later has
  to be a deliberate edit with its own evidence.

## Evidence

Arguments captured live at the import stub — `PROSPER_STUBDUMP=1` gives each import its own stub
(`[stub] #877 off=0x148e0 libScePosix::T8fER+tIGgk`), and a breakpoint at the **stub entry** reads the
guest's argument registers intact. Six consecutive hits, all identical:

```
select(nfds=0, readfds=NULL, writefds=NULL, exceptfds=NULL, timeout={tv_sec=3, tv_usec=0})
```

Registration is by `nid_hash`, verified against the PS5 3.20 export tables:
`nid_hash("select") == T8fER+tIGgk`, `nid_hash("pselect") == ZO2nWoTAv60` — the NIDs PPSA19244's
import table actually binds. Asserted in the test so the binding cannot silently lapse.

## This fixes a real defect and does **not** fix the title

Stated plainly, because a hopeful link would be worse than useless:

* PPSA19244 still stops on `L_GameloftSplash`. **#1641's root cause is open again** — the `select()`
  spin was a CPU tax, not the stall.
* The socket calls proper — `socket`/`bind`/`listen`/`getsockname`/`connect`/`accept`/`send` — remain
  unimplemented and success-shaped (`socket()` still returns fd **0**, a valid descriptor). Nothing
  currently shows they block the boot, so no backing is proposed here.
* This PR is `Refs #1660`, not `Fixes`.

## Verification

Built and tested in the `ps5ys` distrobox (`Vulkan found`).

**`ctest`: 163/166.** The 3 failures are the known `-DGAME_DUMP`-against-a-non-Messenger-title set
(`module_loads_eboot`, `boot_reaches_first_syscall`, `real_shader_render`), documented as expected and
tracked by #1573 — unrelated to this change. New `select_sleep` test passes.

**The test is built to fail without the fix.** It asserts **elapsed time**, not the return value — a
test that only checked the return value would pass against the very stub this replaces. Both halves
fail on master: the sleep shape elapses ~0 ms, and the descriptor shape returns 0 rather than -1.

**Live, headless, Vulkan-free** (`PROSPER_NO_COMPUTE=1`, no `PROSPER_RENDER` — note that omitting
`PROSPER_RENDER` alone still runs compute through Vulkan, see the GPU-scheduling note in this branch):

* `select` disappears from the `PROSPER_PROGRESS_UNIMPL` table entirely.
* **Zero** `[posix] select:` refusal lines — the title only ever uses the pure-sleep shape, which
  validates the narrow contract against the real workload rather than against my reading of it.
* `OLD_HTTPClient` 3,543 → 0 jiffies over a comparable window.
* Steady state unchanged: 23 draws/frame, flips advancing, same asset set.

## Also on this branch (separable on request)

Three commits from the investigation that produced the fix. Happy to split them out if you would
rather land them independently:

* **`tools/re/pak_index.py`** — resolve UE4 `.pak` byte offsets to asset names and decode a
  `PROSPER_FILELOG=1` run into an ordered asset load trace. Offline, no boot, no GPU. This is what
  showed PPSA19244 loads exactly **one of 481 maps**, which reframed #1641.
* **GPU scheduling correction** — omitting `PROSPER_RENDER` is **not** a GPU-free run
  (`boot_trace.cpp:277` registers live compute unconditionally; a "CPU-only" run executed ~135,000
  dispatches). `PROSPER_NO_COMPUTE=1` is the genuinely Vulkan-free path. Includes a table classifying
  every common run.
* **Instrument traps 15-17**, including trap 17, which is this investigation's own wrong turn: a
  call-count table answers *"is something spinning?"* and can never answer *"on what?"*. I read the
  1.3 billion calls as a socket poll and nearly had a loopback-socket backing scoped off it. Capturing
  the arguments took two commands. The recipe is now documented.
