### PR TITLE
fix(hle): name the Videodec2 AVC entry point, and make its rejections self-identifying (#1658)

### DIFF
--- a/prosper/docs/GAME_COMPAT_ORCHESTRATION.md
+++ b/prosper/docs/GAME_COMPAT_ORCHESTRATION.md
@@ -126,6 +126,17 @@ count, read the last row's number.
   ran*, not of when the events happened. Print a common ordinal (`command_order`) on both and join on it. This
   is why the `order=` field exists on the `[exec] skip draw early` line — **it is not redundant with the
   register values on the same line, and removing it silently re-opens the phantom above.**
+- **A fix that makes an instrument lie more convincingly is worse than the bug.** This one is about
+  *repairs*, not measurements, and it is the inverse of everything else on this page. #1659's own fix
+  briefly introduced it: the diagnostics were widened to resolve any guest module, but several kept a
+  hard-coded `eboot+` label. Before the change an Il2Cpp frame printed an offset *larger than the image* —
+  the exact tell the entry below tells you to look for. After it, the same frame printed a small,
+  plausible, in-range offset under the **wrong module name**, with no tell at all. The fault was
+  unchanged; only the symptom was removed. Any correction that deletes a symptom without deleting the
+  fault produces a **quieter** failure, and quiet failures are the expensive ones. When you fix an
+  instrument, ask what its wrongness used to look like and confirm you removed the wrongness rather than
+  the appearance of it. Corollary for tests: a test that exercises the *helper* you added will not catch
+  this — it has to render through the real formatter and assert the text a reader would see.
 - **A `<module>+0x<rva>` offset larger than the module's image is a labelling artifact, not a wild pointer.**
   Guest module bases are fixed constants in `src/host/boot_program.hpp`, and they *move*: #825 relocated the
   eboot from `0x400000000` to `0x410000000` so Astro Bot's direct-memory mapping would stop aliasing code.

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -234,10 +234,18 @@ std::unordered_map<uint64_t, uint32_t> g_vdec_codecs;
 // fires at most a handful of times per boot and is the difference between a one-run diagnosis and a
 // guess. (Tales of Graces f / criMvPly stops exactly here; see #1658.)
 uint64_t vdec_reject(const char* field, uint64_t observed, uint64_t err) {
-    static std::atomic<int> shown{0};
-    if (shown.fetch_add(1) < 8)
-        fprintf(stderr, "[vdec] decoder config REJECTED: %s = 0x%llx -> err=0x%llx\n",
-                field, (unsigned long long)observed, (unsigned long long)err);
+    // Rate-limit PER FIELD, not globally. One shared counter meant a caller looping on an early
+    // condition could burn the whole budget and silence a later, different rejection — including the
+    // one a run was started to capture. `field` is always a string literal, so the pointer is a stable
+    // key and the map stays bounded by the number of call sites.
+    static std::mutex mx;
+    static std::unordered_map<const char*, int> shown;
+    {
+        std::lock_guard<std::mutex> lk(mx);
+        if (shown[field]++ >= 4) return err;
+    }
+    fprintf(stderr, "[vdec] decoder config REJECTED: %s = 0x%llx -> err=0x%llx\n",
+            field, (unsigned long long)observed, (unsigned long long)err);
     return err;
 }
 uint64_t vdec_validate_config(const VdecConfig* c) {
@@ -254,11 +262,23 @@ uint64_t vdec_validate_config(const VdecConfig* c) {
         return vdec_reject("max_width/height",
                            ((uint64_t)(uint32_t)c->max_width << 32) | (uint32_t)c->max_height,
                            VDEC_ERR_DIMS);
-    // NOTE: this is the condition most likely to reject a caller that queries memory sizes BEFORE it
-    // allocates a compute queue — the natural order for "how much do I need?". Whether the real
-    // libSceVideodec2 requires a live queue at QueryDecoderMemoryInfo time is NOT established from
-    // title evidence, so the check is retained (Sonic Origins' CRI Mana backend passes it) and made
-    // self-identifying rather than relaxed on a hunch. CONFIDENCE: LOW that requiring it here is right.
+    // This is the condition most likely to reject a caller that queries memory sizes BEFORE it
+    // allocates a compute queue — the natural order for "how much do I need?".
+    //
+    // Retained, but the honest state of the evidence is: there is NONE either way. The check arrived
+    // in #1368 (8b37be95) with no comment, no rationale and no test — defensive, not derived. No title
+    // is recorded anywhere in this repo as reaching QueryDecoderMemoryInfo at all; the only live
+    // Videodec2 calls in docs/ are QueryComputeMemoryInfo. An earlier version of this comment claimed
+    // "Sonic Origins' CRI Mana backend passes it" — that was unsupported and is withdrawn.
+    //
+    // So this is retained on the weaker ground that removing an unexplained validation is also a
+    // guess, and a rejection is at least visible. Note it does NOT protect a size contract:
+    // s_videodec2_query_decoder_memory ignores compute_queue entirely and writes fixed VDEC_MIN_MEMORY
+    // constants, so rejecting only fails earlier than succeeding would.
+    //
+    // If a live log names this field, the evidenced narrow move is a SPLIT — keep the requirement on
+    // CreateDecoder, which genuinely needs a queue, and drop it from the pure sizing query — rather
+    // than a blanket relaxation. CONFIDENCE: LOW that requiring it here is right.
     if (!c->compute_queue) return vdec_reject("compute_queue", c->compute_queue, VDEC_ERR_CONFIG);
     return 0;
 }
@@ -286,11 +306,17 @@ HLE(s_videodec2_allocate_compute_queue) {
     auto* out = (uint64_t*)PW(a2);
     if (!config || !memory || !out) return VDEC_ERR_ARG;
     if (config->size != sizeof(*config) || memory->size != sizeof(*memory)) return VDEC_ERR_STRUCT;
-    if (config->reserved0 || config->reserved1) return VDEC_ERR_CONFIG;
-    if (config->pipe > 4) return VDEC_ERR_PIPE;
-    if (config->queue > 7) return VDEC_ERR_QUEUE;
-    if (memory->shared_size < VDEC_MIN_MEMORY) return VDEC_ERR_MEMORY_SIZE;
-    if (!memory->shared) return VDEC_ERR_MEMORY_PTR;
+    // These share 0x811d0200/0x811d02xx with the decoder-config validator, so a bare guest error code
+    // cannot say which call produced it. Name them too, or a run that fails HERE prints nothing.
+    if (config->reserved0 || config->reserved1)
+        return vdec_reject("computeQueue.reserved0/1",
+                           ((uint64_t)config->reserved0 << 8) | config->reserved1, VDEC_ERR_CONFIG);
+    if (config->pipe > 4) return vdec_reject("computeQueue.pipe", config->pipe, VDEC_ERR_PIPE);
+    if (config->queue > 7) return vdec_reject("computeQueue.queue", config->queue, VDEC_ERR_QUEUE);
+    if (memory->shared_size < VDEC_MIN_MEMORY)
+        return vdec_reject("computeQueue.shared_size", memory->shared_size, VDEC_ERR_MEMORY_SIZE);
+    if (!memory->shared)
+        return vdec_reject("computeQueue.shared", memory->shared, VDEC_ERR_MEMORY_PTR);
     *out = memory->shared;
     if (svclog()) fprintf(stderr, "[svc]   Videodec2 compute queue -> 0x%llx (%llu bytes)\n",
                           (unsigned long long)*out, (unsigned long long)memory->shared_size);
@@ -370,21 +396,40 @@ HLE(s_videodec2_reset) {
 // mismatch path reports the size the guest actually passed, which IS the evidence needed: the first
 // title to call it prints `sizeof` its own struct, and the layout can then be derived rather than guessed.
 // CONFIDENCE: LOW that a shared layout is correct; HIGH that guessing one would be worse.
-uint64_t vdec_picture_info(const char* which, uint64_t a0) {
+static uint64_t vdec_picture_info(const char* which, uint64_t a0, uint64_t a1, uint64_t a2,
+                                  uint64_t a3) {
+    // Report the FIRST call to each entry point unconditionally, with the later arguments.
+    //
+    // Relying on a size mismatch alone would have been a weak plan: both forms take the same
+    // OutputInfo in a0, so if what distinguishes them is what they WRITE to a later out-param, a0
+    // matches, the mismatch branch never fires, and a run set up to capture the AVC layout captures
+    // nothing while appearing to work. Printing a1..a3 once costs two lines a boot and cannot miss.
+    static std::mutex mx;
+    static std::unordered_map<const char*, int> seen;   // `which` is a literal: stable key
+    bool first = false;
+    { std::lock_guard<std::mutex> lk(mx); first = (seen[which]++ == 0); }
+    if (first)
+        fprintf(stderr, "[vdec] %s FIRST CALL: a0=0x%llx a1=0x%llx a2=0x%llx a3=0x%llx (#1658 — the "
+                        "AVC layout is unestablished; these arguments are the evidence)\n",
+                which, (unsigned long long)a0, (unsigned long long)a1,
+                (unsigned long long)a2, (unsigned long long)a3);
     auto* out = (const VdecOutput*)PW(a0); if (!out) return VDEC_ERR_ARG;
     if (out->size == sizeof(*out)) return 0;
-    static std::atomic<int> shown{0};
-    if (shown.fetch_add(1) < 8)
+    static std::mutex bad_mx;
+    static std::unordered_map<const char*, int> bad;
+    bool report = false;
+    { std::lock_guard<std::mutex> lk(bad_mx); report = (bad[which]++ < 4); }
+    if (report)
         fprintf(stderr, "[vdec] %s: caller struct size 0x%llx != VdecOutput 0x%zx — rejected. If this "
                         "is the AVC form, that size IS its layout evidence (#1658).\n",
                 which, (unsigned long long)out->size, sizeof(*out));
     return VDEC_ERR_STRUCT;
 }
 HLE(s_videodec2_picture_info) {
-    return vdec_picture_info("sceVideodec2GetPictureInfo", a0);
+    return vdec_picture_info("sceVideodec2GetPictureInfo", a0, a1, a2, a3);
 }
 HLE(s_videodec2_avc_picture_info) {
-    return vdec_picture_info("sceVideodec2GetAvcPictureInfo", a0);
+    return vdec_picture_info("sceVideodec2GetAvcPictureInfo", a0, a1, a2, a3);
 }
 // sceUserServiceGetEvent(SceUserServiceEvent* ev): the event stream. A real system delivers the initial
 // user's LOGIN event once at startup, then reports "no more events" so the game's drain loop terminates.

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -228,15 +228,38 @@ static_assert(sizeof(VdecInput) == 48 && sizeof(VdecFrame) == 32 && sizeof(VdecO
 std::mutex g_vdec_mx;
 std::unordered_map<uint64_t, uint32_t> g_vdec_codecs;
 
+// A rejected decoder config is a hard stop for a title's movie playback, and the guest only prints the
+// bare SCE code — 0x811d0200 covers TWO different conditions here, so "err=0x811d0200" alone cannot tell
+// anyone which. Name the failing field and its observed value, unconditionally but rate-limited: this
+// fires at most a handful of times per boot and is the difference between a one-run diagnosis and a
+// guess. (Tales of Graces f / criMvPly stops exactly here; see #1658.)
+uint64_t vdec_reject(const char* field, uint64_t observed, uint64_t err) {
+    static std::atomic<int> shown{0};
+    if (shown.fetch_add(1) < 8)
+        fprintf(stderr, "[vdec] decoder config REJECTED: %s = 0x%llx -> err=0x%llx\n",
+                field, (unsigned long long)observed, (unsigned long long)err);
+    return err;
+}
 uint64_t vdec_validate_config(const VdecConfig* c) {
-    if (!c || c->size != sizeof(*c)) return !c ? VDEC_ERR_ARG : VDEC_ERR_STRUCT;
-    if (c->resource != 1) return VDEC_ERR_RESOURCE;
-    if (c->reserved0 || c->reserved1) return VDEC_ERR_CONFIG;
-    if (!c->input_depth) return VDEC_ERR_INPUT_DEPTH;
-    if (c->max_dpb < -1 || c->max_dpb == 0) return VDEC_ERR_DPB;
+    if (!c) return VDEC_ERR_ARG;
+    if (c->size != sizeof(*c)) return vdec_reject("size", c->size, VDEC_ERR_STRUCT);
+    if (c->resource != 1) return vdec_reject("resource", c->resource, VDEC_ERR_RESOURCE);
+    if (c->reserved0 || c->reserved1)
+        return vdec_reject("reserved0/1", ((uint64_t)c->reserved0 << 8) | c->reserved1,
+                           VDEC_ERR_CONFIG);
+    if (!c->input_depth) return vdec_reject("input_depth", c->input_depth, VDEC_ERR_INPUT_DEPTH);
+    if (c->max_dpb < -1 || c->max_dpb == 0)
+        return vdec_reject("max_dpb", (uint64_t)(int64_t)c->max_dpb, VDEC_ERR_DPB);
     if (c->max_width < -1 || c->max_height < -1 || !c->max_width || !c->max_height)
-        return VDEC_ERR_DIMS;
-    if (!c->compute_queue) return VDEC_ERR_CONFIG;
+        return vdec_reject("max_width/height",
+                           ((uint64_t)(uint32_t)c->max_width << 32) | (uint32_t)c->max_height,
+                           VDEC_ERR_DIMS);
+    // NOTE: this is the condition most likely to reject a caller that queries memory sizes BEFORE it
+    // allocates a compute queue — the natural order for "how much do I need?". Whether the real
+    // libSceVideodec2 requires a live queue at QueryDecoderMemoryInfo time is NOT established from
+    // title evidence, so the check is retained (Sonic Origins' CRI Mana backend passes it) and made
+    // self-identifying rather than relaxed on a hunch. CONFIDENCE: LOW that requiring it here is right.
+    if (!c->compute_queue) return vdec_reject("compute_queue", c->compute_queue, VDEC_ERR_CONFIG);
     return 0;
 }
 void vdec_no_picture(VdecFrame* frame, VdecOutput* out, uint32_t codec) {
@@ -337,9 +360,31 @@ HLE(s_videodec2_flush) {
 HLE(s_videodec2_reset) {
     std::lock_guard<std::mutex> lk(g_vdec_mx); return g_vdec_codecs.count(a0) ? 0 : VDEC_ERR_DECODER;
 }
-HLE(s_videodec2_picture_info) {
+// sceVideodec2GetPictureInfo / ...GetAvcPictureInfo. `which` names the entry point so a size mismatch
+// identifies itself (#1658).
+//
+// Both currently validate against VdecOutput. That is an ASSUMPTION for the AVC form: the two exist as
+// separate exports, which is normally because the AVC one carries codec-specific picture metadata in a
+// larger structure. prosper has no title evidence for that layout — the firmware database gives names
+// and NIDs, never bodies — so inventing a second struct would be fabricating an ABI. Instead the
+// mismatch path reports the size the guest actually passed, which IS the evidence needed: the first
+// title to call it prints `sizeof` its own struct, and the layout can then be derived rather than guessed.
+// CONFIDENCE: LOW that a shared layout is correct; HIGH that guessing one would be worse.
+uint64_t vdec_picture_info(const char* which, uint64_t a0) {
     auto* out = (const VdecOutput*)PW(a0); if (!out) return VDEC_ERR_ARG;
-    return out->size == sizeof(*out) ? 0 : VDEC_ERR_STRUCT;
+    if (out->size == sizeof(*out)) return 0;
+    static std::atomic<int> shown{0};
+    if (shown.fetch_add(1) < 8)
+        fprintf(stderr, "[vdec] %s: caller struct size 0x%llx != VdecOutput 0x%zx — rejected. If this "
+                        "is the AVC form, that size IS its layout evidence (#1658).\n",
+                which, (unsigned long long)out->size, sizeof(*out));
+    return VDEC_ERR_STRUCT;
+}
+HLE(s_videodec2_picture_info) {
+    return vdec_picture_info("sceVideodec2GetPictureInfo", a0);
+}
+HLE(s_videodec2_avc_picture_info) {
+    return vdec_picture_info("sceVideodec2GetAvcPictureInfo", a0);
 }
 // sceUserServiceGetEvent(SceUserServiceEvent* ev): the event stream. A real system delivers the initial
 // user's LOGIN event once at startup, then reports "no more events" so the game's drain loop terminates.
@@ -3022,8 +3067,13 @@ void register_service_hle() {
     Hle::register_fn("852F5+q6+iM", (HleFn)s_videodec2_decode, "sceVideodec2Decode");
     Hle::register_fn("l1hXwscLuCY", (HleFn)s_videodec2_flush, "sceVideodec2Flush");
     Hle::register_fn("wJXikG6QFN8", (HleFn)s_videodec2_reset, "sceVideodec2Reset");
+    // #1658: kjrLbcyhEiw is sceVideodec2GetAvcPictureInfo, not a second NID for the generic form —
+    // the 3.20 firmware database names them separately. They still share a handler because no title
+    // evidence yet shows the AVC output layout differs; the handler says so and captures the first
+    // mismatch rather than assuming they are identical.
     Hle::register_fn("NtXRa3dRzU0", (HleFn)s_videodec2_picture_info, "sceVideodec2GetPictureInfo");
-    Hle::register_fn("kjrLbcyhEiw", (HleFn)s_videodec2_picture_info, "sceVideodec2GetPictureInfo");
+    Hle::register_fn("kjrLbcyhEiw", (HleFn)s_videodec2_avc_picture_info,
+                     "sceVideodec2GetAvcPictureInfo");
     R("sceUserServiceInitialize", s_ok);
     R("sceUserServiceTerminate", s_ok);
     // NP — an honest signed-out console (#306). NIDs verified against the PS5 3.20

--- a/prosper/tests/test_service_getters.cpp
+++ b/prosper/tests/test_service_getters.cpp
@@ -219,6 +219,37 @@ int main() {
                       "Videodec2 flush rejects the 48-byte output ABI without writing past it");
                 CHECK(destroy(decoder, 0, 0, 0, 0, 0) == 0,
                       "Videodec2 decoder lifecycle tears down cleanly");
+
+                // #1658: kjrLbcyhEiw is sceVideodec2GetAvcPictureInfo, a DIFFERENT export from the
+                // generic NtXRa3dRzU0 — the 3.20 firmware database names them separately and prosper
+                // had both under one name.
+                auto picture_info     = Hle::lookup("NtXRa3dRzU0");
+                auto avc_picture_info = Hle::lookup("kjrLbcyhEiw");
+                CHECK(picture_info && avc_picture_info,
+                      "#1658: both Videodec2 picture-info entry points resolve");
+                CHECK(picture_info != avc_picture_info,
+                      "#1658: the AVC form is a distinct handler, not an alias of the generic one");
+                // Both accept the known 56-byte output ABI today. The AVC layout is NOT established
+                // from title evidence, so this pins current behaviour rather than a guessed struct.
+                uint8_t pinfo[56]{}; *(uint64_t*)pinfo = 56;
+                CHECK(picture_info((uint64_t)(uintptr_t)pinfo, 0, 0, 0, 0, 0) == 0 &&
+                      avc_picture_info((uint64_t)(uintptr_t)pinfo, 0, 0, 0, 0, 0) == 0,
+                      "#1658: both picture-info forms accept the 56-byte VdecOutput ABI");
+                // A mismatched size must be REJECTED, not silently accepted — that rejection is what
+                // captures an AVC-specific layout the first time a title passes one.
+                uint8_t pinfo_bad[64]{}; *(uint64_t*)pinfo_bad = 64;
+                CHECK(avc_picture_info((uint64_t)(uintptr_t)pinfo_bad, 0, 0, 0, 0, 0) == 0x811d0101ull,
+                      "#1658: an unexpected AVC struct size is rejected, not assumed compatible");
+
+                // The live Tales blocker: QueryDecoderMemoryInfo returns 0x811d0200 for a config with
+                // no compute queue. Pin that it is still rejected (the check is deliberately retained,
+                // not relaxed on a hunch) — the fix is that it now names the field it rejected.
+                Config no_queue = config;
+                no_queue.queue = 0;
+                uint64_t probe_memory[9] = {72};
+                CHECK(query_decoder((uint64_t)(uintptr_t)&no_queue,
+                                    (uint64_t)(uintptr_t)probe_memory, 0, 0, 0, 0) == 0x811d0200ull,
+                      "#1658: a decoder config with no compute queue is rejected with VDEC_ERR_CONFIG");
             }
         }
     }

--- a/prosper/tests/test_service_getters.cpp
+++ b/prosper/tests/test_service_getters.cpp
@@ -229,15 +229,23 @@ int main() {
                       "#1658: both Videodec2 picture-info entry points resolve");
                 CHECK(picture_info != avc_picture_info,
                       "#1658: the AVC form is a distinct handler, not an alias of the generic one");
+                // The NAME is what #1658 is about, and nothing above asserts it: binding the AVC NID
+                // to a distinct handler under the WRONG name passes every other assertion here. That
+                // is the original defect in a new costume — exactly the corollary this PR adds to the
+                // instrument doc (a test of the helper is not a test of the behaviour).
+                CHECK(std::string(Hle::name_of("kjrLbcyhEiw")) == "sceVideodec2GetAvcPictureInfo",
+                      "#1658: kjrLbcyhEiw is registered as sceVideodec2GetAvcPictureInfo");
+                CHECK(std::string(Hle::name_of("NtXRa3dRzU0")) == "sceVideodec2GetPictureInfo",
+                      "#1658: NtXRa3dRzU0 keeps the generic name");
                 // Both accept the known 56-byte output ABI today. The AVC layout is NOT established
                 // from title evidence, so this pins current behaviour rather than a guessed struct.
-                uint8_t pinfo[56]{}; *(uint64_t*)pinfo = 56;
+                alignas(8) uint8_t pinfo[56]{}; *(uint64_t*)pinfo = 56;
                 CHECK(picture_info((uint64_t)(uintptr_t)pinfo, 0, 0, 0, 0, 0) == 0 &&
                       avc_picture_info((uint64_t)(uintptr_t)pinfo, 0, 0, 0, 0, 0) == 0,
                       "#1658: both picture-info forms accept the 56-byte VdecOutput ABI");
                 // A mismatched size must be REJECTED, not silently accepted — that rejection is what
                 // captures an AVC-specific layout the first time a title passes one.
-                uint8_t pinfo_bad[64]{}; *(uint64_t*)pinfo_bad = 64;
+                alignas(8) uint8_t pinfo_bad[64]{}; *(uint64_t*)pinfo_bad = 64;
                 CHECK(avc_picture_info((uint64_t)(uintptr_t)pinfo_bad, 0, 0, 0, 0, 0) == 0x811d0101ull,
                       "#1658: an unexpected AVC struct size is rejected, not assumed compatible");
 


### PR DESCRIPTION
Refs #1658

## Two separate things, both about not guessing

### 1. The mislabel (#1658 as filed)

`kjrLbcyhEiw` is **`sceVideodec2GetAvcPictureInfo`**, not a second NID for the generic
`NtXRa3dRzU0`. prosper had both registered under one name. Verified **all 11** Videodec2 NIDs prosper registers
against the 3.20 firmware database — this is the only wrong one. (An earlier draft said seven: my grep
missed four whose display name sits on a *continuation line*. Same shape as #1629's character-class hole —
a pattern that silently under-matches. Caught in review.)

**They still share an implementation, deliberately.** Two separate exports normally means the AVC form
carries codec-specific picture metadata in a larger structure. prosper has **no title evidence** for that
layout, and the database gives names and NIDs, never bodies. Inventing a second struct would be
fabricating an ABI.

So instead of guessing, the size-mismatch path now **captures the evidence**:

```
[vdec] sceVideodec2GetAvcPictureInfo: caller struct size 0x40 != VdecOutput 0x38 — rejected.
       If this is the AVC form, that size IS its layout evidence (#1658).
```

The first title to call it prints `sizeof` its own struct, and the layout can then be derived. Until
then the mismatch is **rejected**, not assumed compatible. `CONFIDENCE: LOW` that a shared layout is
correct; `HIGH` that guessing one would be worse.

### 2. The live blocker is a different function

Tales of Graces f now reaches a real frame loop (`submits=113,631`) and stops at:

```
sceVideodec2QueryDecoderMemoryInfo() err=0x811d0200 -> Can't create Video decoder
  -> criMvPly_AllocateWorkBufferWithWork() fails
```

`0x811d0200` is `VDEC_ERR_CONFIG` — **prosper's own validator**, not an unimplemented call.
`sceVideodec2QueryDecoderMemoryInfo` is fully implemented; this is a rejection, and the guest prints only
the bare SCE code.

That code covers **two different conditions** in `vdec_validate_config`, so `err=0x811d0200` alone cannot
say which. Every rejection now names the field and its observed value:

```
[vdec] decoder config REJECTED: compute_queue = 0x0 -> err=0x811d0200
```

Unconditional but rate-limited to 8 — this fires a handful of times per boot at most, and it is the
difference between a one-run diagnosis and a guess.

## What I deliberately did NOT do

**I did not relax the validator.** The likeliest cause is the `compute_queue` check rejecting a caller
that queries memory sizes *before* allocating a queue — the natural order for "how much do I need?".
But:

there is **no evidence either way**. The check arrived in #1368 (`8b37be95`) with no comment, no rationale
and no test — defensive, not derived — and **no title is recorded anywhere in this repo as reaching
`QueryDecoderMemoryInfo` at all**.

An earlier draft of this PR justified retention with "Sonic Origins' CRI Mana backend passes it".
**That was unsupported and is withdrawn** — I held *relaxing* to a title-evidence standard while asserting
*retention* without one. Caught in review.

It is retained on the honest, weaker ground that removing an unexplained validation is equally a guess and
a rejection is at least visible. Two things now recorded at the line: it protects **no size contract**
(`s_videodec2_query_decoder_memory` ignores `compute_queue` and writes fixed `VDEC_MIN_MEMORY` constants,
so rejecting only fails earlier than succeeding would), and if a live log names the field the evidenced
move is a **split** — keep the requirement on `CreateDecoder`, drop it from the pure sizing query — not a
blanket relaxation. `CONFIDENCE: LOW`.

**One run of Tales with this build answers it definitively**: the log will name the rejected field. If it
is `compute_queue`, the question becomes a narrow, evidenced one — does the real API permit a query
before allocation — rather than a guess. I have not taken a GPU slot for it; the Tales lane is already on
that title and gets the answer for free.

## Scope answer: this is a sibling gap, not a subsystem

Videodec2's compute-queue and decoder lifecycle is already implemented and evidence-backed (built for
Sonic's CRI Mana backend, with all output fields written). What Tales hits is one validation branch, not
a missing subsystem. No stop-and-reassess needed.

## Affected / unaffected

**Affected:** `kjrLbcyhEiw`'s registered name and handler identity; the text of Videodec2 rejection paths.

**Unaffected:** every success path; the decoder/compute lifecycle; what any call *returns* — the two
diagnostics added are print-only, and the AVC handler returns exactly what the shared one always did.
No validation was tightened or loosened.

## Also

Adds the session's instrument lesson to `docs/GAME_COMPAT_ORCHESTRATION.md`, in the words it was learned
in: **a fix that makes an instrument lie more convincingly is worse than the bug.** #1659's own fix
briefly introduced exactly that — widening the module filter while leaving a hard-coded `eboot+` label,
which replaced an out-of-range offset (a visible tell) with a plausible in-range one under the wrong
module (no tell at all). The corollary is recorded too: a test that exercises the *helper* you added will
not catch it; it has to render through the real formatter.

## Verification

Build clean. `ctest -j8`: **170/170**.

Five new assertions in `test_service_getters` pin: both picture-info NIDs resolve; the AVC form is a
**distinct handler**, not an alias; both accept the known 56-byte ABI; an unexpected AVC size is
**rejected** rather than assumed compatible; and a config with no compute queue still returns
`VDEC_ERR_CONFIG` — pinning that the check was retained, not quietly relaxed.

Both new diagnostics are shown firing in the test output above.

## Post-review

- **Withdrew an unsupported claim** (above) — the most important correction here.
- **The evidence capture had a silent failure mode.** Both forms take the same `OutputInfo` in `a0`, so if
  the AVC difference lives in what they *write* to a later out-param, `a0` matches, the mismatch branch
  never fires, and the capture collects nothing *while appearing to work* — the exact defect class this PR
  adds to the instrument doc. Each entry point now reports its **first call unconditionally** with `a1..a3`.
- **Rate-limit was global, now per-field**: a caller looping on an early condition could burn the budget
  and silence the very rejection a run was started to capture.
- **`sceVideodec2AllocateComputeQueue` also returns `0x811d0200` and was silent.** If the live error came
  from there, "one run settles it" would have failed quietly. Named too.
- **The test never asserted the NAME** — binding the AVC NID to a distinct handler under the *wrong* name
  passed every assertion. Now checked via `Hle::name_of`, which is this PR's own documented corollary
  applied to itself.

Re-verified: `ctest -j8` **170/170**.
