### PR TITLE
fix(loader): report duplicate exports instead of aliasing them silently (#1635)

### DIFF
--- a/prosper/src/host/boot_program.cpp
+++ b/prosper/src/host/boot_program.cpp
@@ -211,8 +211,25 @@ bool boot_program(const std::string& d, Program& p, std::string* err,
     for (const auto& s : p.skipped_modules)
         printf("plugin auto-link: SKIPPED %s — it exports NID %s, already provided by %s\n",
                s.path.c_str(), s.nid.c_str(), s.owner_path.c_str());
-    printf("linked %zu modules; %zu imports (%zu cross-module, %zu stub slots); %zu init fns\n",
-           p.mods.size(), p.total_imports, p.resolved_cross_module, p.slots.size(), p.init_fns.size());
+    // Aliased exports (#1635). first-wins is the policy and is unchanged; being silent about it was
+    // the defect. Both modules stay mapped and both init_arrays run, and sceKernelDlsym consults the
+    // handle's own table first (#147) — so a NID listed here resolves to DIFFERENT addresses
+    // depending on which handle asks. Bounded print, full count, so a busy pair cannot bury the line.
+    if (!p.aliased_exports.empty()) {
+        size_t shown = 0;
+        for (const auto& a : p.aliased_exports) {
+            if (shown++ >= 8) break;
+            printf("export alias: NID %s -> %s (0x%llx); %s also exports it (0x%llx), discarded\n",
+                   a.nid.c_str(), a.winner_path.c_str(), (unsigned long long)a.winner,
+                   a.loser_path.c_str(), (unsigned long long)a.loser);
+        }
+        if (p.aliased_exports.size() > shown)
+            printf("export alias: ... and %zu more\n", p.aliased_exports.size() - shown);
+    }
+    printf("linked %zu modules; %zu imports (%zu cross-module, %zu stub slots); %zu init fns; "
+           "%zu aliased exports\n",
+           p.mods.size(), p.total_imports, p.resolved_cross_module, p.slots.size(),
+           p.init_fns.size(), p.aliased_exports.size());
 
     // sceKernelDlsym resolves exports by name against all loaded modules.
     set_module_exports(&p.exports);

--- a/prosper/src/host/boot_program.cpp
+++ b/prosper/src/host/boot_program.cpp
@@ -216,9 +216,10 @@ bool boot_program(const std::string& d, Program& p, std::string* err,
     // handle's own table first (#147) — so a NID listed here resolves to DIFFERENT addresses
     // depending on which handle asks. Bounded print, full count, so a busy pair cannot bury the line.
     if (!p.aliased_exports.empty()) {
-        size_t shown = 0;
-        for (const auto& a : p.aliased_exports) {
-            if (shown++ >= 8) break;
+        constexpr size_t kMaxShown = 8;
+        const size_t shown = std::min(p.aliased_exports.size(), kMaxShown);
+        for (size_t i = 0; i < shown; i++) {
+            const auto& a = p.aliased_exports[i];
             printf("export alias: NID %s -> %s (0x%llx); %s also exports it (0x%llx), discarded\n",
                    a.nid.c_str(), a.winner_path.c_str(), (unsigned long long)a.winner,
                    a.loser_path.c_str(), (unsigned long long)a.loser);

--- a/prosper/src/loader/linker.cpp
+++ b/prosper/src/loader/linker.cpp
@@ -86,7 +86,21 @@ bool link_program(const std::vector<LinkInput>& inputs, uint64_t stub_base,
         Program::ModuleExports me; me.path = m.path;
         for (auto& s : m.symbols)
             if (!s.is_import && !s.nid.empty() && s.value != 0) {
-                exports.emplace(s.nid, base + s.value);
+                // emplace() is a NO-OP on an existing key, so first-wins — intended, but it was also
+                // silent (#1635). Record every alias: which NID, who won, who lost, and both
+                // addresses. Behaviour is unchanged; only the reporting is new.
+                const auto [it, inserted] = exports.emplace(s.nid, base + s.value);
+                if (!inserted && it->second != base + s.value) {
+                    const char* winner = "?";
+                    for (const auto& prior : out.mod_exports) {
+                        const auto f = prior.nids.find(s.nid);
+                        if (f != prior.nids.end() && f->second == it->second) {
+                            winner = prior.path.c_str(); break;
+                        }
+                    }
+                    out.aliased_exports.push_back({ s.nid, winner, m.path, it->second,
+                                                    base + s.value });
+                }
                 me.nids.emplace(s.nid, base + s.value);   // per-module view for handle-first dlsym (#147)
             }
         out.mod_exports.push_back(std::move(me));

--- a/prosper/src/loader/linker.hpp
+++ b/prosper/src/loader/linker.hpp
@@ -69,6 +69,14 @@ struct Program {
     // all among modules linked BY NAME — PSNCommon.prx + PSNCore.prx share 4 on six titles,
     // libfmod.prx + libfmodstudio.prx share 16, and AkMotion/AkSoundEngine/AkVorbisHwAccelerator
     // share one three ways. See tools/re/dup_exports.py.
+    //
+    // MEASURED SEVERITY TODAY: nil. Cross-referencing self_dump's [IMPORTS BY LIBRARY] for every
+    // linked module of those 7 titles, NONE of the 21 distinct aliased NIDs is imported by anything —
+    // so no import currently resolves through an alias, and no title's behaviour depends on which
+    // module won. That is why this is a diagnostic and not a policy change. It is also why the
+    // diagnostic matters: the moment a title does import one, the winner becomes load-order-dependent
+    // and this is the only thing that would say so. Re-check with tools/re/dup_exports.py before
+    // assuming it still holds for a newly added dump.
     struct AliasedExport { std::string nid, winner_path, loser_path; uint64_t winner, loser; };
     std::vector<AliasedExport> aliased_exports;
 

--- a/prosper/src/loader/linker.hpp
+++ b/prosper/src/loader/linker.hpp
@@ -57,6 +57,21 @@ struct Program {
     struct SkippedModule { std::string path, nid, owner_path; };
     std::vector<SkippedModule> skipped_modules;
 
+    // Exports that were ALIASED rather than skipped: a module linked by name contributed a NID the
+    // global table already had, so `emplace` kept the first definition and discarded this one
+    // silently (#1635). First-wins is the intended policy and is unchanged — going unreported was
+    // not. The loser stays mapped and its init_array still runs, and sceKernelDlsym consults the
+    // handle's own table first (#147), so the same NID can resolve to two different addresses
+    // depending on which handle is asked. Retained rather than only logged so the caller can report
+    // it and a test can assert it.
+    //
+    // This is not hypothetical: a census over 30 local dumps found 41 aliased NIDs across 7 titles,
+    // all among modules linked BY NAME — PSNCommon.prx + PSNCore.prx share 4 on six titles,
+    // libfmod.prx + libfmodstudio.prx share 16, and AkMotion/AkSoundEngine/AkVorbisHwAccelerator
+    // share one three ways. See tools/re/dup_exports.py.
+    struct AliasedExport { std::string nid, winner_path, loser_path; uint64_t winner, loser; };
+    std::vector<AliasedExport> aliased_exports;
+
     // Stats for reporting.
     size_t total_imports = 0, resolved_cross_module = 0, stubbed = 0;
 };

--- a/prosper/tests/test_plugin_autolink.cpp
+++ b/prosper/tests/test_plugin_autolink.cpp
@@ -185,6 +185,30 @@ int main(int argc, char** argv) {
                 CHECK(pg.skipped_modules[0].owner_path == plugin, "skip record names the owner");
                 CHECK(!pg.skipped_modules[0].nid.empty(), "skip record carries the colliding NID");
             }
+
+            // #1635: the CONTROL case is the real-world shape — two modules exporting the same NIDs,
+            // neither flagged, both linked. exports.emplace() keeps the first and discards the second
+            // with no warning, no counter and nothing in the summary. That silence is the defect;
+            // first-wins itself is the intended policy and is unchanged.
+            //
+            // Measured, not hypothetical: a census over 30 local dumps found 41 aliased NIDs across 7
+            // titles, ALL among modules linked by name (tools/re/dup_exports.py).
+            CHECK(!pc.aliased_exports.empty(),
+                  "#1635: linking a duplicate records the aliased exports instead of silently dropping them");
+            CHECK(pg.aliased_exports.empty(),
+                  "#1635: a module the guard skipped contributes no aliases");
+            if (!pc.aliased_exports.empty()) {
+                const auto& a = pc.aliased_exports.front();
+                CHECK(!a.nid.empty(), "#1635: the alias record carries the NID");
+                CHECK(a.winner_path == plugin && a.loser_path == plugin,
+                      "#1635: the alias record names both the winner and the discarded loser");
+                // The two copies are mapped at different bases, so the discarded definition really is
+                // a different address — proof this is an alias, not a duplicate of one address.
+                CHECK(a.winner != a.loser,
+                      "#1635: the discarded definition is a genuinely different address");
+                CHECK(a.winner < a.loser,
+                      "#1635: first-wins is preserved — the earlier-linked module keeps the NID");
+            }
         } else {
             printf("  [skip] %s has no Media/Plugins/PSN.prx — link wiring not exercised\n",
                    dump_root.c_str());

--- a/prosper/tests/test_plugin_autolink.cpp
+++ b/prosper/tests/test_plugin_autolink.cpp
@@ -206,8 +206,18 @@ int main(int argc, char** argv) {
                 // a different address — proof this is an alias, not a duplicate of one address.
                 CHECK(a.winner != a.loser,
                       "#1635: the discarded definition is a genuinely different address");
-                CHECK(a.winner < a.loser,
-                      "#1635: first-wins is preserved — the earlier-linked module keeps the NID");
+                // first-wins means the winner lies inside the image of the EARLIER-linked module.
+                // Comparing the two addresses directly would only assert this fixture's base ordering
+                // (0x5d0000000 < 0x5d4000000) — both records share one RVA, so that comparison is a
+                // statement about the test's own setup, not about the loader's policy.
+                bool winner_in_first = false, loser_in_second = false;
+                if (pc.imgs.size() >= 3) {
+                    const uint64_t b1 = pc.imgs[1].base, b2 = pc.imgs[2].base;
+                    winner_in_first  = a.winner >= b1 && a.winner < b2;
+                    loser_in_second  = a.loser  >= b2;
+                }
+                CHECK(winner_in_first && loser_in_second,
+                      "#1635: first-wins — the winner is in the earlier image, the loser in the later");
             }
         } else {
             printf("  [skip] %s has no Media/Plugins/PSN.prx — link wiring not exercised\n",

--- a/prosper/tools/re/dup_exports.py
+++ b/prosper/tools/re/dup_exports.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Duplicate-export census: which NIDs two LINKED modules both export, per title (#1635).
+
+The loader builds its global export table with `exports.emplace(nid, addr)`, and emplace is a no-op on
+an existing key — so a NID exported by two modules is silently aliased to whichever links first. The
+loser stays mapped, its init_array still runs, and sceKernelDlsym consults the handle's own table
+first (#147), so the same NID can resolve to two different addresses depending on which handle asks.
+
+This answers "is that firing today?" statically, with no boot and no device.
+
+    python3 tools/re/dup_exports.py [dump-root]
+
+It scans only the modules prosper actually LINKS (the fixed named list in boot_program.cpp) — scanning
+every .prx present would report collisions between modules that are never loaded together, which is a
+different and much noisier question.
+
+CAVEAT, learned the hard way: dedupe by RESOLVED FILE. prosper's list carries two spellings of
+Il2CppUserAssemblies, and a case-insensitive resolver maps both to the same file, reporting it as ~300
+self-duplicates. That artifact was ~95% of the first run of this census — the instrument, not the
+subject. Anything that looks like a module colliding with itself is that bug.
+
+Result at the time of writing: 30 dumps scanned, 7 with duplicates, 41 aliased NIDs — all among
+modules linked BY NAME (PSNCommon+PSNCore on six titles, libfmod+libfmodstudio 16 NIDs on one,
+AkMotion/AkSoundEngine/AkVorbisHwAccelerator one NID three ways).
+"""
+import subprocess, pathlib, collections, sys
+
+SELF_DUMP = str(pathlib.Path(__file__).resolve().parents[2] / "build-linux" / "self_dump")
+ROOT = pathlib.Path(sys.argv[1]) if len(sys.argv) > 1 else pathlib.Path(__file__).resolve().parents[3]
+
+# The fixed named list prosper links (boot_program.cpp), plus the eboot itself.
+LINKED = ["eboot.bin",
+          "Media/Modules/Il2CppUserAssemblies.prx", "Media/Modules/Il2cppUserAssemblies.prx",
+          "Media/Modules/PS5Util.prx",
+          "Media/Plugins/AkMotion.prx", "Media/Plugins/AkSoundEngine.prx",
+          "Media/Plugins/AkVorbisHwAccelerator.prx", "Media/Plugins/CommonDialog.prx",
+          "Media/Plugins/libfmod.prx", "Media/Plugins/libfmodstudio.prx",
+          "Media/Plugins/PSNCommon.prx", "Media/Plugins/PSNCore.prx", "Media/Plugins/PSN.prx",
+          "Media/Plugins/SaveData.prx",
+          "sce_module/libc.prx", "sce_module/libSceNpCppWebApi.prx"]
+
+def exports(path):
+    try:
+        r = subprocess.run([SELF_DUMP, str(path), "--symbols"], capture_output=True, text=True, timeout=120)
+    except Exception:
+        return None
+    if r.returncode != 0: return None
+    out, seen = set(), False
+    for line in r.stdout.splitlines():
+        if line.startswith("[EXPORTS]"): seen = True; continue
+        if not seen: continue
+        p = line.split()
+        if len(p) >= 4 and p[0].startswith("0x"): out.add(p[2])
+    return out
+
+def ci_find(root, rel):
+    """Dumps vary in case; resolve case-insensitively like the loader does."""
+    cur = root
+    for part in rel.split("/"):
+        if not cur.is_dir(): return None
+        m = [c for c in cur.iterdir() if c.name.lower() == part.lower()]
+        if not m: return None
+        cur = m[0]
+    return cur if cur.is_file() else None
+
+total_dumps = total_dups = dumps_with_dups = 0
+for dump in sorted(ROOT.glob("PPSA*-app0")):
+    mods, seen_files = {}, set()
+    for rel in LINKED:
+        f = ci_find(dump, rel)
+        if not f: continue
+        # Dedupe by RESOLVED FILE. prosper's list carries two spellings of Il2CppUserAssemblies, and a
+        # case-insensitive resolver maps both to the same file — counting it as 296 self-duplicates.
+        # That artifact was ~95% of the first census run; the instrument, not the subject.
+        key = f.resolve()
+        if key in seen_files: continue
+        seen_files.add(key)
+        e = exports(f)
+        if e: mods[rel] = e
+    if not mods: continue
+    total_dumps += 1
+    owners = collections.defaultdict(list)
+    for rel, nids in mods.items():
+        for n in nids: owners[n].append(rel)
+    dups = {n: o for n, o in owners.items() if len(o) > 1}
+    if dups:
+        dumps_with_dups += 1
+        total_dups += len(dups)
+        pairs = collections.Counter(tuple(sorted(o)) for o in dups.values())
+        print(f"\n=== {dump.name}: {len(dups)} duplicated NID(s) across {len(mods)} linked modules")
+        for combo, cnt in pairs.most_common():
+            print(f"    {cnt:5d} NIDs shared by: {' + '.join(combo)}")
+            ex = [n for n, o in dups.items() if tuple(sorted(o)) == combo][:3]
+            print(f"          e.g. {', '.join(ex)}")
+    else:
+        print(f"{dump.name}: clean ({len(mods)} linked modules)")
+print(f"\n==== {total_dumps} dumps scanned, {dumps_with_dups} with duplicates, {total_dups} duplicated NIDs total ====")

--- a/prosper/tools/re/dup_exports.py
+++ b/prosper/tools/re/dup_exports.py
@@ -26,7 +26,27 @@ AkMotion/AkSoundEngine/AkVorbisHwAccelerator one NID three ways).
 import subprocess, pathlib, collections, sys
 
 SELF_DUMP = str(pathlib.Path(__file__).resolve().parents[2] / "build-linux" / "self_dump")
-ROOT = pathlib.Path(sys.argv[1]) if len(sys.argv) > 1 else pathlib.Path(__file__).resolve().parents[3]
+def _default_root():
+    """Walk up looking for a directory that actually contains dumps.
+
+    parents[3] is wrong from a git worktree: the tree lives under .claude/worktrees/<name>/ while the
+    dumps sit in the main checkout. Searching upward finds either. If nothing is found we say so and
+    exit non-zero rather than printing a confident "0 dumps scanned" — a census that reports nothing
+    because it looked in the wrong place is indistinguishable from one that found nothing.
+    """
+    here = pathlib.Path(__file__).resolve()
+    for cand in list(here.parents):
+        if any(cand.glob("PPSA*-app0")): return cand
+    return None
+
+if len(sys.argv) > 1:
+    ROOT = pathlib.Path(sys.argv[1])
+else:
+    ROOT = _default_root()
+    if ROOT is None:
+        sys.exit("dup_exports: no PPSA*-app0 dumps found above this file; pass a dump root explicitly")
+if not any(ROOT.glob("PPSA*-app0")):
+    sys.exit(f"dup_exports: {ROOT} contains no PPSA*-app0 dumps")
 
 # The fixed named list prosper links (boot_program.cpp), plus the eboot itself.
 LINKED = ["eboot.bin",

--- a/prosper/tools/re/dup_exports.py
+++ b/prosper/tools/re/dup_exports.py
@@ -96,7 +96,13 @@ for dump in sorted(ROOT.glob("PPSA*-app0")):
         if key in seen_files: continue
         seen_files.add(key)
         e = exports(f)
-        if e: mods[rel] = e
+        if e is None:
+            print(f"  !! {dump.name}: self_dump FAILED on {rel} — census incomplete for this title",
+                  file=sys.stderr)
+            continue
+        # An empty set is a real answer (18 eboots export nothing); None is a tool failure. Conflating
+        # them would let a broken self_dump report a title as clean.
+        mods[rel] = e
     if not mods: continue
     total_dumps += 1
     owners = collections.defaultdict(list)


### PR DESCRIPTION
Refs #1635

## It is firing today — measured, not latent

The issue asked whether this is real. **It is, and on modules linked by name**, which is where the
existing auto-link guard does not reach.

A census over **all 30 local dumps** (new `tools/re/dup_exports.py`, static — no boot, no device) finds
**41 aliased NIDs across 7 titles**:

| collision | NIDs | titles |
| --- | --- | --- |
| `PSNCommon.prx` + `PSNCore.prx` | 4 | **6** (PPSA01885, 02801, 02849, 08576, 09804, 13579) |
| `libfmod.prx` + `libfmodstudio.prx` | 16 | 1 (PPSA30140) |
| `AkMotion` + `AkSoundEngine` + `AkVorbisHwAccelerator` | 1 (three-way) | 1 (PPSA09804) |

**This contradicts the issue's premise.** #1635 says "today only the fixed preload list can produce this,
and it happens not to name both variants". `PSNCommon.prx` and `PSNCore.prx` are **both in the named
list**, both linked, and they collide — on six titles, on every boot. The `libfmod`/`libfmodL` pair the
issue predicted is not the live case; the live case is a pair nobody suspected.

None of the colliding NIDs are Sony firmware exports (checked against the 3.20 database) — they are the
plugins' own symbols, which is consistent with two Sony-shipped Unity plugins sharing a static library.

## The policy question, answered as a contract

**First-wins is defensible and is unchanged here.** *Unreported* first-wins is not, and that is the
whole defect. `exports.emplace(nid, addr)` is a no-op on an existing key, so today the loser is
discarded with no warning, no counter, and nothing in the `linked N modules` summary — while:

- the loser stays **mapped** and its **`init_array` still runs**, so two copies initialize;
- `sceKernelDlsym` consults the handle's own table first (#147), so the same NID resolves to
  **different addresses** depending on which handle is asked.

So this PR is the **diagnostic**, deliberately: the linker records every alias (NID, winner path and
address, loser path and address) and `boot_program` prints the first eight plus a total in the summary.
No behaviour changes.

**Which problem is it? Measured, not guessed.** An earlier draft said the import question was
unanswerable because `self_dump` has no import listing. **That was wrong** — it prints
`[IMPORTS BY LIBRARY]` (`self_dump.cpp:373-377`, documented in `tools/re/README.md`). Caught in review.

Cross-referencing every linked module of the 7 affected titles: **none of the 21 distinct aliased NIDs is
imported by anything.** So **measured severity today is nil** — no import resolves through an alias, and
no title's behaviour depends on which module won.

That is exactly why this is a diagnostic rather than a policy change. It is also why the diagnostic
matters: the moment a title *does* import one, the winner becomes load-order-dependent, and this is the
only thing that would say so. The measurement is recorded in `linker.hpp` so it is not redone, with a
note to re-run `dup_exports.py` before assuming it still holds for a newly added dump.

## The census tool carries the mistake that made it

`tools/re/dup_exports.py` is committed with the caveat that cost most of its development. **The first run
reported 5,426 duplicated NIDs. About 95% were fabricated by the instrument**: prosper's module list
holds two spellings of `Il2CppUserAssemblies.prx`, a case-insensitive resolver maps both to the *same
file*, and the census counted it against itself ~300 times per title. Deduping by resolved file gives the
real 41. The docstring says so, and says that anything resembling a module colliding with itself is that
bug.

It also fails loudly rather than quietly: run from a worktree the default root found no dumps and it
printed `0 dumps scanned, 0 duplicated NIDs` — indistinguishable from a clean result. It now searches
upward for `PPSA*-app0` and exits non-zero when it finds none.

## Affected / unaffected

**Affected:** loader diagnostics only — a new `Program::aliased_exports` vector, eight bounded lines, and
a count in the summary.

**Unaffected:** which definition wins (still first), what is mapped, what runs, import resolution,
`sceKernelDlsym`, and the existing `skip_on_export_collision` guard for optional modules.

## Verification

Build clean. `ctest -j8`: **170/170**.

Six new assertions in `test_plugin_autolink`, using the existing **control** case — two copies of one
plugin linked at different bases with no guard flag, which is exactly the real-world shape. They pin that
the aliases are recorded, that a guard-skipped module contributes none, that the record names the NID and
both paths, that the discarded address genuinely differs, and that **first-wins is preserved**
(`winner < loser`). **Correction:** an earlier draft claimed all six fail without the change. Only the first does; the second
passes vacuously and the remaining four sit behind a non-empty guard. Caught in review.

**These assertions do not run in CI** — the test is registered with `GAME_DUMP`, which `ci.yml` never
sets, so CI prints `[skip] no game dump argument` and passes. That is pre-existing and applies to the
whole file, not these additions; filed as #1675 rather than patched here.

Run against `PPSA17337-app0` (a dump with `Media/Plugins/PSN.prx`, which the block requires).

## Post-review

- **BLOCKING, fixed:** the bounded print used `if (shown++ >= 8) break;`, which increments on the
  breaking iteration — understating the remainder by one, contradicting the total on the next line, and
  at exactly 9 aliases dropping the 9th with **no "more" line at all**. A quiet failure inside a
  diagnostic whose whole purpose is not being quiet.
- **Severity measured** (above) — the PR's central open question, closed.
- **The first-wins assertion pinned the fixture, not the loader.** Both records share one RVA, so
  `winner < loser` reduced to comparing the test's own two base addresses. Now asserts image membership.
- `dup_exports.py` conflated a `self_dump` failure with an empty export set, so a broken tool could
  report a title as clean. Failures now go to stderr and are excluded; empty stays a real answer.

Re-verified: `ctest -j8` **170/170**.
