### PR TITLE
ci: run the GPU suite, and make a skipped test say so (#1675)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,19 @@ jobs:
       - name: Build
         run: cmake --build prosper/build-ci
 
+      # The runner has no GPU, so this is Mesa's lavapipe software rasteriser. Four tests are
+      # driver-divergent: they pass on real hardware (RADV) and fail on lavapipe, reproducibly in both
+      # places. They are EXCLUDED BY NAME rather than by disabling the suite — the defect #1675
+      # documents is a gap nobody can enumerate, and four named exclusions in a workflow file are the
+      # opposite of that. Tracked in #1681; delete from this list as each is resolved.
+      #   game_compute_exec[_no_adaptive_storage_result]  — R11G11B10 pack/unpack exactness
+      #   recompiled_fragment_render / recompiled_shaders_render — rendered-pixel comparisons
+      # Reproduce either way locally:
+      #   VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/lvp_icd.x86_64.json ctest -R '<name>'
       - name: Test
-        run: ctest --test-dir prosper/build-ci --output-on-failure --timeout 600
+        run: |
+          ctest --test-dir prosper/build-ci --output-on-failure --timeout 600 \
+            -E '^(game_compute_exec|game_compute_exec_no_adaptive_storage_result|recompiled_fragment_render|recompiled_shaders_render)$'
 
   linux-app:
     name: Linux App

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,26 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y ninja-build pkg-config libavformat-dev libavcodec-dev \
-            libavutil-dev libswresample-dev libswscale-dev libva-dev
+            libavutil-dev libswresample-dev libswscale-dev libva-dev \
+            libvulkan-dev mesa-vulkan-drivers
 
+      # #1675: Vulkan was disabled here because it was never installed, not by choice — and that
+      # silently removed 27 tests (~1,700 assertions) from every "green" CI run, including every
+      # shader-recompiler and GPU-execution differential. They are designed for a software device
+      # (llvmpipe/lavapipe) and run in seconds locally, so CI can run them too.
       - name: Configure
-        run: cmake -S prosper -B prosper/build-ci -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_DISABLE_FIND_PACKAGE_Vulkan=TRUE
+        run: cmake -S prosper -B prosper/build-ci -G Ninja -DCMAKE_BUILD_TYPE=Debug
+
+      # A configuration that quietly loses Vulkan would silently drop those tests again and still
+      # report 100% green. Fail the job instead of shrinking the suite.
+      - name: Verify the GPU tests are actually registered
+        run: |
+          n=$(ctest --test-dir prosper/build-ci -N | tail -1 | grep -oE '[0-9]+$')
+          echo "registered tests: $n"
+          if [ "$n" -lt 160 ]; then
+            echo "::error::only $n tests registered — the Vulkan-gated suite is missing (see #1675)"
+            exit 1
+          fi
 
       - name: Build
         run: cmake --build prosper/build-ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,14 +31,23 @@ jobs:
 
       # A configuration that quietly loses Vulkan would silently drop those tests again and still
       # report 100% green. Fail the job instead of shrinking the suite.
-      - name: Verify the GPU tests are actually registered
+      # Guard the CLASS, not the instance: a configure that quietly loses Vulkan would drop the GPU
+      # suite again and still report 100% green, which is precisely the defect #1675 documents.
+      #
+      # By NAME, not by count. A "at least N tests" floor rots silently — the suite only grows, so a
+      # threshold that is meaningful today is passed by the non-GPU tests alone once enough are added,
+      # and the guard stops guarding without ever failing. These three cannot exist unless Vulkan was
+      # found, and they stay meaningful however large the suite gets.
+      - name: Verify the Vulkan-gated tests are actually registered
         run: |
-          n=$(ctest --test-dir prosper/build-ci -N | tail -1 | grep -oE '[0-9]+$')
-          echo "registered tests: $n"
-          if [ "$n" -lt 160 ]; then
-            echo "::error::only $n tests registered — the Vulkan-gated suite is missing (see #1675)"
-            exit 1
-          fi
+          for t in rdna2_to_spirv_exec gpu_execute vulkan_triangle_render; do
+            if ! ctest --test-dir prosper/build-ci -N -R "^${t}$" | grep -q "Test *#"; then
+              echo "::error::${t} is not registered — the Vulkan-gated suite is missing (see #1675)"
+              exit 1
+            fi
+          done
+          echo "Vulkan-gated suite present; total registered: \
+            $(ctest --test-dir prosper/build-ci -N | tail -1 | grep -oE '[0-9]+$')"
 
       - name: Build
         run: cmake --build prosper/build-ci

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -546,8 +546,10 @@ if(TARGET prosper_core)
   target_link_libraries(test_plugin_autolink PRIVATE prosper_core)
   if(HAVE_GAME_DUMP)
     add_test(NAME plugin_autolink COMMAND test_plugin_autolink "${GAME_DUMP}")
+    set_tests_properties(plugin_autolink PROPERTIES SKIP_RETURN_CODE 77)
   else()
     add_test(NAME plugin_autolink COMMAND test_plugin_autolink)
+    set_tests_properties(plugin_autolink PROPERTIES SKIP_RETURN_CODE 77)
   endif()
 
   # ATRAC9 decode (vendored LibAtrac9 + prosper glue): an embedded 16-superframe slice of a real PS5

--- a/prosper/docs/GAME_COMPAT_ORCHESTRATION.md
+++ b/prosper/docs/GAME_COMPAT_ORCHESTRATION.md
@@ -128,6 +128,17 @@ count, read the last row's number.
   ran*, not of when the events happened. Print a common ordinal (`command_order`) on both and join on it. This
   is why the `order=` field exists on the `[exec] skip draw early` line — **it is not redundant with the
   register values on the same line, and removing it silently re-opens the phantom above.**
+- **Before recording that something cannot be measured, check the tools you are claiming cannot measure
+  it.** This is nastier than a wrong fact and it is self-sealing. A wrong claim about the *subject* gets
+  tested by the next measurement; a wrong claim about the *instrument* stops the measurement from
+  happening, so nothing ever contradicts it. #1635 shipped "severity is unknowable — `self_dump` has no
+  import listing" into a PR body. `self_dump` prints `[IMPORTS BY LIBRARY]`, documented in
+  `tools/re/README.md`, and answering the question took ten minutes once someone looked: 21 aliased NIDs,
+  **0** imported by anything. An "unanswerable" is a claim about a tool, and claims about tools are the
+  cheapest of all to verify — run `--help`, grep the README, read the source. The same session produced
+  the mirror image in #1675: CI's green tick was believed to mean "the suite passed" when it meant "the
+  138 tests that got registered passed", and the 32 missing ones — ~1,822 assertions — were invisible
+  because nothing reports a test that was never registered.
 - **A fix that makes an instrument lie more convincingly is worse than the bug.** This one is about
   *repairs*, not measurements, and it is the inverse of everything else on this page. #1659's own fix
   briefly introduced it: the diagnostics were widened to resolve any guest module, but several kept a

--- a/prosper/docs/VERIFICATION.md
+++ b/prosper/docs/VERIFICATION.md
@@ -82,10 +82,30 @@ See `tools/snapshot/README.md` for the complete approval workflow.
 
 ## CI
 
-A GitHub Actions workflow builds + runs `ctest` on **Linux and Windows/MinGW** for every push/PR
-(Vulkan discovery disabled on the runners, so the GPU-independent layers 1/4b gate CI; the
-Vulkan-execution layers 2–4 run locally under llvmpipe). Dump-backed tests auto-skip when the private
-game dump is absent.
+A GitHub Actions workflow builds + runs `ctest` on **Linux and Windows/MinGW** for every push/PR.
+
+**Linux CI runs the Vulkan-execution layers** on Mesa's lavapipe software rasteriser (#1675). It did not
+until then: no Vulkan package was ever installed on the runner, so `-DCMAKE_DISABLE_FIND_PACKAGE_Vulkan`
+was describing that fact rather than deciding anything — and it silently removed **27 tests / ~1,800
+assertions** from every green run, including the entire shader-recompiler differential and the sole
+coverage for GPU execution, render state and present. An unregistered test is invisible by construction:
+there is no line to read and no count to compare against, so 138/138 looked exactly like full coverage.
+
+Two guards keep that from recurring, and both matter more than the flag itself:
+
+* the Linux job **fails if too few tests register**, so a configure that quietly loses Vulkan is an error
+  rather than a smaller green suite;
+* a test that skips its substantive block returns ctest's `SKIP_RETURN_CODE`, so the summary reads
+  `(Skipped)` instead of counting it as a pass. CI runs `ctest --output-on-failure`, which suppresses
+  test stdout on green runs — so a printed `[skip]` line alone is invisible in the summary *and* in the
+  log body.
+
+**Windows/MinGW and macOS still disable Vulkan**, so layers 2–4 are Linux-and-local only there.
+
+Four tests are excluded by name on lavapipe because they pass on real hardware and fail on the software
+rasteriser; they are listed in `ci.yml` with a reproduction command and tracked in #1681. Dump-backed
+tests cannot run in CI at all — dumps are copyrighted and gitignored — and now report `(Skipped)` rather
+than passing.
 
 ## Rule of thumb
 

--- a/prosper/tests/test_plugin_autolink.cpp
+++ b/prosper/tests/test_plugin_autolink.cpp
@@ -223,6 +223,7 @@ int main(int argc, char** argv) {
         } else {
             printf("  [skip] %s has no Media/Plugins/PSN.prx — link wiring not exercised\n",
                    dump_root.c_str());
+            skipped_link_wiring = true;   // #1675: 21 of 30 local dumps ship no PSN.prx
         }
     } else {
         printf("  [skip] no game dump argument — link wiring not exercised\n");

--- a/prosper/tests/test_plugin_autolink.cpp
+++ b/prosper/tests/test_plugin_autolink.cpp
@@ -40,6 +40,7 @@ static bool has(const std::vector<std::string>& v, const std::string& s) {
 }
 
 int main(int argc, char** argv) {
+    bool skipped_link_wiring = false;   // #1675: report a skipped block as SKIP, not as a pass
     std::error_code ec;
     const fs::path root = prosper_test::test_scratch_dir() / "prosper_test_plugin_autolink";
     fs::remove_all(root, ec);
@@ -225,8 +226,14 @@ int main(int argc, char** argv) {
         }
     } else {
         printf("  [skip] no game dump argument — link wiring not exercised\n");
+        skipped_link_wiring = true;
     }
 
     printf(fails ? "FAILED (%d)\n" : "PASSED\n", fails);
-    return fails ? 1 : 0;
+    if (fails) return 1;
+    // #1675: exit 77 (ctest SKIP_RETURN_CODE) when the substantive block never ran. Without this the
+    // run reports "passed" for assertions that did not execute, and under CI's `--output-on-failure`
+    // the "[skip]" line is suppressed entirely — so the skip was invisible in the summary AND in the
+    // log body. A reader could not discover it at all.
+    return skipped_link_wiring ? 77 : 0;
 }


### PR DESCRIPTION
Refs #1675

## The measurement first — the scope question, answered

**CI registers 138 tests. A full local configure registers 170.** The 32 absent are not "skipped": they
are never built and never registered, so ctest's total is simply smaller and *nothing reports their
absence*. Behind them sit roughly **1,822 `CHECK` assertions**.

The largest by assertion count:

| assertions | test | |
| ---: | --- | --- |
| 555 | `rdna2_to_spirv_exec` | the entire shader-recompiler differential |
| 248 | `game_compute_exec` | compute execution |
| 248 | `game_compute_exec_no_adaptive_storage_result` | (same binary, second config) |
| 98 | `gpu_capture_render_replay` | |
| 96 | `gpu_execute` | the executor spine |

**Cause split:**

- **5 dump-gated** — `boot_reaches_first_syscall`, `module_loads_eboot`, `nid_hash_matches_imports`,
  `trap_identifies_imports`, `real_shader_render`. These can *never* run in CI: dumps are copyrighted
  and gitignored.
- **27 Vulkan-gated** — and this is the finding: **Vulkan was disabled because it was never installed**,
  not by choice. The `Install dependencies` step lists no Vulkan package, so
  `-DCMAKE_DISABLE_FIND_PACKAGE_Vulkan=TRUE` was describing reality rather than making a decision.

## Is the skip visible? No — not even in the log body

CI runs `ctest --output-on-failure`, which suppresses test stdout on green runs. So the one test that
*does* run and skip internally (`plugin_autolink`) printed `[skip] no game dump argument` **nowhere in a
passing CI log**. Proven directly:

```
ctest --output-on-failure  (what CI runs):  grep -c "[skip]"  ->  0
ctest -V                                 :  grep -c "[skip]"  ->  1
```

Not in the summary, not in the body. **The skip was undiscoverable**, which is precisely what let a green
tick read as coverage.

## Is any of it sole coverage? Yes

The 27 Vulkan-gated tests are the *only* coverage for shader recompilation, GPU execution, render state
and present — nothing dump-free duplicates them. `plugin_autolink`'s gated block is the only coverage for
`link_program`'s collision guard and the duplicate-export alias recording added in #1670.

## What this changes

**1. Run the 27.** Install `libvulkan-dev` + `mesa-vulkan-drivers` and drop the disable flag. These tests
target a software device and finish in seconds. Verified locally **in the exact CI configuration** (no
`GAME_DUMP`, Vulkan on): **165 registered, 165 passed, 5.9 s**.

**2. Fail if they vanish again.** A configure that quietly loses Vulkan would drop them and still report
100% green — the same defect in a new form. The job now fails below 160 registered tests. 165 is the true
count for that configuration (170 minus the 5 dump-gated), so the floor has margin without being slack.

**3. Make the remaining skip say so.** `plugin_autolink` now returns ctest's `SKIP_RETURN_CODE` (77) when
its block does not run, so the summary reads:

```
The following tests did not run:
	 78 - plugin_autolink (Skipped)
```

instead of counting it as a pass.

## Affected / unaffected

**Affected:** the Linux CI job's dependencies, configure flags, and a new registration-count guard;
`plugin_autolink`'s exit code when it skips.

**Unaffected:** every test's assertions and semantics; the other CI jobs; local builds (`GAME_DUMP`
behaviour is unchanged, and a local run with a dump still registers 170 and skips nothing).

## Risks

- ~~`CONFIDENCE: MED` that a runner's lavapipe drives these~~ — **answered by CI, see below.**
- Runtime grows: the Linux job gains 27 tests. Locally the whole suite is 5.9 s; the job's timeout is
  600 s, so there is a lot of headroom, but a software rasteriser on a shared runner is slower than this
  box.
- The 5 dump-gated tests remain uncovered in CI and this does not change that. A synthetic-fixture
  approach could reach some of them; that is a larger piece of work and deliberately not attempted here.

## Verification

Exact CI configuration, locally: `165 registered, 165 passed, 5.9s`, `plugin_autolink (Skipped)` shown in
the summary. Old configuration for comparison: 138 registered, `[skip]` invisible under
`--output-on-failure`.

## The experiment ran — verdict

**lavapipe drives the GPU suite fine.** The runner registered **165** tests and ran them in **30 s**.
`plugin_autolink (Skipped)` displayed correctly in the real CI summary, confirming the visibility fix
works where it matters.

**Four tests fail on lavapipe and pass on real hardware.** Reproduced in both directions before deciding
anything: 165/165 on this machine's AMD Radeon 8060S (RADV), and identical failures under
`VK_ICD_FILENAMES=.../lvp_icd.x86_64.json` both here and on `ubuntu-latest`. Deterministic and
driver-dependent — **not** flaky, which makes it a list rather than a reason to give up.

They are **excluded by name** in the workflow, with the reproduction command beside them and each tracked
in **#1681**. CI coverage therefore goes **138 → 161**, not back to 138. Verified locally under lavapipe
with the exclusions applied: **161/161 in 13.6 s**.

**Not waived as "just a software-rasteriser difference."** Passing on AMD and failing on lavapipe is
equally consistent with a real defect that permissive hardware masks — and an exactness assertion about
R11G11B10 pack/unpack round-tripping is exactly that shape. #1681 records both explanations and the
evidence that separates them, and deliberately does not pick.

## Two separate facts about today's merges

Both belong here, and conflating them would be the comfortable reading:

1. **The CI gate was blind** — no GPU or shader-recompiler coverage on any Linux run, ~1,822 assertions,
   sole coverage for the recompiler and executor. Exactly as bad as measured.
2. **The damage did not reach today's merges.** Every code-touching PR merged today states a local ctest
   denominator of 163–170, which is only reachable with the 27 Vulkan-gated tests registered — so those
   runs had Vulkan on locally. The five without a stated count are four documentation-only PRs and one
   gated diagnostic whose body records a distrobox build.

The redundancy held *structurally*, because the project's build guidance points everyone at the distrobox
configure — not because anyone coordinated it. That property would vanish silently the first time someone
built on the host, which is a second argument for the registered-count floor: it turns a convention into
an enforced check.
