### PR TITLE
perf(render): scope the texture decode identity map to the submit (#1691)

### DIFF
--- a/prosper/docs/BLUE_PRINCE_STATUS.md
+++ b/prosper/docs/BLUE_PRINCE_STATUS.md
@@ -61,12 +61,31 @@ The `blue-prince-title` snapshot route guards the title screen.
   binding resolves. Two reversed-order routed A/B pairs on an otherwise idle box: persistent-cache
   resolutions **76.7 -> 41.3 per submit (-46 %)**, reproducible to the digit, and heavy-scene frame
   time **246.6 -> 228.4 ms** and **248.1 -> 228.8 ms** (~4.04 -> ~4.38 submits/s).
-  **The frame-time gain does not come from the texture terms** — `build_resources` and its `texture`
-  component are flat across both pairs, and the whole delta appears in `pass_control`, which nothing
-  in that change touches. Treat the mechanism behind that as open rather than settled; the plausible
-  candidate is allocator behaviour (the span-scoped arm rebuilds the map 16.7x per submit while the
-  same pass loop allocates an 8.3 MiB frame buffer per pass), but it has not been measured. The
-  title remains CPU-bound in the frontend and #1284's `draw_setup.resources` is still the top term.
+  **The frame-time gain does not come from the texture terms.** Per-submit, across the two pairs:
+
+  | term | pair 1 (span -> submit) | pair 2 (span -> submit) |
+  |---|---|---|
+  | `build_resources` | 47.60 -> 47.32 ms (**-1.0 %**) | 47.28 -> 48.31 ms (**+0.9 %**) |
+  | `texture` (within it) | 7.31 -> 7.17 ms | 7.15 -> 7.34 ms |
+  | `backend` | 165.91 -> 165.50 ms | 170.3 -> 167.3 ms |
+  | **`pass_control`** | **35.20 -> 15.78 ms (-19.4)** | **28.76 -> 14.82 ms (-13.9)** |
+
+  The sign **flips** between pairs in the term the change touches while the magnitude stays
+  consistent in a term it does not — that pattern is why the mechanism is recorded as open rather
+  than settled, and why the numbers are here instead of the word "unexplained". Either it is a real
+  second-order effect or `pass_control` is misattributing; both are worth knowing, and the next
+  person should be able to tell them apart without re-running the route. The plausible candidate is
+  allocator behaviour (the span-scoped arm rebuilds the identity map 16.7x per submit while the same
+  pass loop allocates an 8.3 MiB frame buffer per pass), but it has **not** been measured — do not
+  promote it to an explanation. Host cache footprint is byte-identical between arms (16 scratch
+  slots, 111 persistent entries, 574.3 MiB), so it is not a working-set effect.
+
+  **This does not address the reported ~2 fps.** #1284 still decomposes the same title's 263.33 ms
+  submit as `draw_setup.resources` 95.42 + `readback` 79.16 + `gpu_wait` 29.29 + `record_upload`
+  22.58 ms; this change moves a ~7.5 % term and leaves all four intact. The title remains CPU-bound
+  in the frontend. Note also that the issue's headline **15.2x is a replay figure** — the persistent
+  decode cache is disabled by construction in replay — and live only ~77 of ~5,500 texture
+  references per submit ever reached it.
 
 ## Defect families (#1287) — families 1–3 and 5 RESOLVED 2026-07-26
 

--- a/prosper/docs/BLUE_PRINCE_STATUS.md
+++ b/prosper/docs/BLUE_PRINCE_STATUS.md
@@ -54,6 +54,20 @@ The `blue-prince-title` snapshot route guards the title screen.
   reported (`[buffer-truncated]`), and `PROSPER_MAX_BUFFER_UPLOAD_MB=N` lowers the ceiling so one
   build reproduces the collapse and the fix back to back.
 
+- **#1691/#1703** — the decoded-texture identity map was scoped to one graphics span, and this title
+  cuts every frame into 21-22 spans at its interleaved dispatches, so each span re-resolved every
+  identity from scratch. It is now scoped to the submit, with cross-span reuse gated on the ordered
+  in-submit write journal plus a re-check that the entry's source range is still the range the
+  binding resolves. Two reversed-order routed A/B pairs on an otherwise idle box: persistent-cache
+  resolutions **76.7 -> 41.3 per submit (-46 %)**, reproducible to the digit, and heavy-scene frame
+  time **246.6 -> 228.4 ms** and **248.1 -> 228.8 ms** (~4.04 -> ~4.38 submits/s).
+  **The frame-time gain does not come from the texture terms** — `build_resources` and its `texture`
+  component are flat across both pairs, and the whole delta appears in `pass_control`, which nothing
+  in that change touches. Treat the mechanism behind that as open rather than settled; the plausible
+  candidate is allocator behaviour (the span-scoped arm rebuilds the map 16.7x per submit while the
+  same pass loop allocates an 8.3 MiB frame buffer per pass), but it has not been measured. The
+  title remains CPU-bound in the frontend and #1284's `draw_setup.resources` is still the top term.
+
 ## Defect families (#1287) — families 1–3 and 5 RESOLVED 2026-07-26
 
 Families 1–3 and 5 below are **fixed on master**; they are retained as the resolution record so
@@ -137,6 +151,11 @@ were confirmed as legitimate frustum culls.
   (`unique-pos=1 (max-mult=19236) -> COLLAPSED` is the fetch-returns-a-constant signature).
 - `PROSPER_MAX_BUFFER_UPLOAD_MB=N` (1..64) — lower the buffer-upload ceiling to reproduce a
   truncation collapse on the same build; `[buffer-truncated]` reports every short upload.
+- `PROSPER_NO_SUBMIT_TEXTURE_DECODE_SCOPE=1` (#1691) — restore the pre-#1691 span-scoped lifetime of
+  the decoded-texture identity map, so one binary A/Bs that change on a routed run.
+  `PROSPER_RENDER_TIMING=1` then reports
+  `[render-timing] decode_scope decodes=… same_span=… cross_span=… invalidated=… pinned=… scope=…`
+  alongside the existing `texture_cache` line.
 - `gpu_replay --recompile-raw` (#1416) — re-recompile every retained raw VS/FS with the CURRENT
   recompiler and replay: the ~5 s offline A/B that resolved family 1 against a ~8 min live route.
   Pair with `PROSPER_MIPLOG=1` (per-binding mip eligibility) and `PROSPER_BUFLOG=1` (per-binding

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -3395,6 +3395,15 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 inherited_persistent_id = old->second.persistent_id;
                                 inherited_persistent_version = old->second.persistent_version;
                             }
+                            // `decode_generation` is per SUBMIT since #1691, so an identity already
+                            // established earlier in this submit is not replaced by a later re-decode
+                            // of the same key. That protection is what makes retained pointers into
+                            // this cache safe. The re-decode itself still renders from its own
+                            // scratch bytes and still populates the submit-scoped map, so the only
+                            // cost is that the persistent copy stays stale until the next submit
+                            // re-validates it and misses. This is reachable only when a guest GPU
+                            // write invalidated the identity mid-submit, which is already the
+                            // expensive path.
                             const bool can_replace = old == persistent_decoded_textures.end() ||
                                 old->second.last_use != decode_generation;
                             if (old != persistent_decoded_textures.end() && can_replace) {
@@ -3472,12 +3481,19 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         }
                         if (decoded_pixels_valid && !resource_rtt_hit &&
                             !resource_compute_image_hit && !has_live_rtt) {
-                            // Pin the scratch slot for as long as this entry can be served: while the
-                            // persistent cache does not own the pixels, the slot IS the storage, and a
-                            // later span reusing it would rewrite what this entry points at.
-                            const size_t pinned_slot =
-                                decoded_pixels_in_texstore ? texture_slot : SIZE_MAX;
-                            if (decoded_pixels_in_texstore) texstore_pinned[texture_slot] = true;
+                            // Pin the scratch slot only for an entry that can actually outlive this
+                            // span AND whose pixels the persistent cache did not take: then the slot
+                            // IS the storage and a later span reusing it would rewrite what the entry
+                            // points at. An entry with no validated range is refused at its first
+                            // cross-span lookup, and within one span the cursor never hands the same
+                            // slot out twice — pinning those would strand one scratch allocation per
+                            // decode, which on a replay submit (every resource carries captured
+                            // backing, so none is retainable) is the whole submit's texture working
+                            // set instead of one span's.
+                            const bool pin_scratch =
+                                decoded_pixels_in_texstore && cross_span_source_size != 0;
+                            const size_t pinned_slot = pin_scratch ? texture_slot : SIZE_MAX;
+                            if (pin_scratch) texstore_pinned[texture_slot] = true;
                             decoded_textures.emplace(
                                 decode_key, DecodedTexture{fr.tex_rgba, fr.th, narrow_done,
                                                           fr.persistent_texture_id,

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -2074,8 +2074,13 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // per texture reference.
                         if (reused != decoded_textures.end()) {
                             const bool same_span = reused->second.span == decode_span_ordinal;
+                            // Unknown, not Unchanged: the predicate ignores this on a same-span
+                            // hit, so the value is unobservable today — but Unchanged is the
+                            // PERMISSIVE verdict, and if the two same-span tests ever drift apart
+                            // the placeholder would silently authorise reuse. Unknown fails closed
+                            // at identical cost.
                             const prosper::gpu::GuestGpuWriteQuery journal_query = same_span
-                                ? prosper::gpu::GuestGpuWriteQuery::Unchanged
+                                ? prosper::gpu::GuestGpuWriteQuery::Unknown
                                 : prosper::gpu::guest_gpu_writes_since(
                                       reused->second.snapshot, reused->second.source_addr,
                                       reused->second.source_size);
@@ -3492,28 +3497,19 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 cached.source_watch = std::move(inherited_source_watch);
                                 auto [inserted, ok] = persistent_decoded_textures.emplace(
                                     decode_key, std::move(cached));
-                                if (ok) {
+                                // `ok == false` is unreachable: the erase above leaves this key
+                                // absent, so the insert cannot collide. It matters anyway, because
+                                // the move has already emptied `texture_pixels` by this point — so
+                                // bind the map's pixels either way (a collision is the same key,
+                                // hence the same decode) and let only the byte accounting depend on
+                                // whether an insertion actually happened. The scratch slot no longer
+                                // owns these bytes in either case.
+                                if (ok)
                                     persistent_decoded_texture_bytes += inserted->second.bytes();
-                                    fr.tex_rgba = inserted->second.pixels.data();
-                                    fr.persistent_texture_id = inserted->second.persistent_id;
-                                    fr.persistent_texture_version =
-                                        inserted->second.persistent_version;
-                                    // The scratch slot no longer owns these bytes; the entry the
-                                    // persistent cache just took is their stable home.
-                                    decoded_pixels_in_texstore = false;
-                                } else {
-                                    // Unreachable: the erase above leaves this key absent, so the
-                                    // insert cannot collide. Were it ever reachable, the move has
-                                    // already emptied `texture_pixels` and `fr.tex_rgba` would point
-                                    // at released bytes — which THIS draw would sample, not only the
-                                    // identity map. Bind the colliding entry's pixels instead; it is
-                                    // the same key, so it is the same decode.
-                                    fr.tex_rgba = inserted->second.pixels.data();
-                                    fr.persistent_texture_id = inserted->second.persistent_id;
-                                    fr.persistent_texture_version =
-                                        inserted->second.persistent_version;
-                                    decoded_pixels_in_texstore = false;
-                                }
+                                fr.tex_rgba = inserted->second.pixels.data();
+                                fr.persistent_texture_id = inserted->second.persistent_id;
+                                fr.persistent_texture_version = inserted->second.persistent_version;
+                                decoded_pixels_in_texstore = false;
                             }
                         }
                         if (!resource_rtt_hit && !resource_compute_image_hit && !has_live_rtt) {
@@ -3529,7 +3525,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             const bool pin_scratch =
                                 decoded_pixels_in_texstore && cross_span_source_size != 0;
                             const size_t pinned_slot = pin_scratch ? texture_slot : SIZE_MAX;
-                            if (pin_scratch) texstore_pinned[texture_slot] = true;
+                            if (pin_scratch) {
+                                texstore_pinned[texture_slot] = true;
+                                ++g_texture_decode_scope.scratch_pins;
+                            }
                             decoded_textures.emplace(
                                 decode_key, DecodedTexture{fr.tex_rgba, fr.th, narrow_done,
                                                           fr.persistent_texture_id,
@@ -5575,11 +5574,12 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     // journal refused to carry across a span boundary.
                     fprintf(stderr,
                             "[render-timing] decode_scope decodes=%llu same_span=%llu "
-                            "cross_span=%llu invalidated=%llu scope=%s\n",
+                            "cross_span=%llu invalidated=%llu pinned=%llu scope=%s\n",
                             (unsigned long long)g_texture_decode_scope.decodes,
                             (unsigned long long)g_texture_decode_scope.same_span_reuses,
                             (unsigned long long)g_texture_decode_scope.cross_span_reuses,
                             (unsigned long long)g_texture_decode_scope.invalidations,
+                            (unsigned long long)g_texture_decode_scope.scratch_pins,
                             submit_decode_scope_disabled ? "span" : "submit");
                     size_t rtt_bytes = 0;
                     for (const auto& [addr, surface] : g_rtt) {

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -343,11 +343,19 @@ bool prefix_inspect_publish() {
     return enabled;
 }
 
-// Pixel decoding is a pure function of these fields for guest-backed textures. Keep this cache local
-// to one renderer callback: graphics spans are split at compute operations, so ordinary guest texture
-// bytes cannot change within its lifetime. Writable storage-image callbacks explicitly invalidate every
-// overlapping entry after publishing their results. Live RTT inputs are excluded separately because an
-// earlier pass in the same callback can replace their pixels.
+// Pixel decoding is a pure function of these fields for guest-backed textures. The identity map keyed
+// by this tuple lives for one SUBMIT (#1691), not one renderer callback. One callback is one graphics
+// span, and a submit is split into a new span at every interleaved compute/DMA operation, so a
+// span-scoped map re-resolved every identity once per span: Blue Prince interleaves 21-22 dispatches
+// through one frame, and its 56 distinct identities were resolved 853 times.
+//
+// The span split exists precisely because an interleaved operation can rewrite guest texture bytes.
+// Retaining an entry past that boundary therefore requires proof that no such write landed on the
+// decoded range, which the ordered in-submit journal (guest_gpu_writes_since) supplies directly and
+// more precisely than the span boundary did. An entry reused inside its own span keeps the historical
+// guarantee unchanged and needs no query. Writable storage-image callbacks still explicitly invalidate
+// every overlapping entry after publishing their results, and live RTT / compute-imported inputs are
+// excluded from the map entirely because an earlier pass in the same callback can replace their pixels.
 struct TextureDecodeKey {
     uint64_t gpu_addr = 0;
     uint64_t host_data = 0;
@@ -401,7 +409,24 @@ struct DecodedTexture {
     bool narrow = false;
     uint64_t persistent_id = 0;
     uint64_t persistent_version = 0;
+    // Everything below exists so the entry can outlive the span that produced it (#1691).
+    // `span` is the renderer-callback ordinal that decoded these pixels: reuse inside that same span
+    // is the historical contract and needs no proof. Crossing a span boundary requires
+    // guest_gpu_writes_since(snapshot, source_addr, source_size) == Unchanged over the exact range
+    // the decode read, so an interleaved compute/DMA/EOP write to the backing forces a fresh resolve
+    // instead of serving pixels the guest has since replaced (the #780 failure shape).
+    // `texstore_slot` pins the scratch slot when the pixels are NOT owned by the persistent cache;
+    // without the pin the next span would hand the same slot to an unrelated decode and this entry
+    // would silently alias another texture's bytes.
+    uint64_t span = 0;
+    prosper::gpu::GuestGpuWriteSnapshot snapshot;
+    uint64_t source_addr = 0;
+    uint64_t source_size = 0;
+    size_t texstore_slot = SIZE_MAX;
 };
+
+// Always-on identity-scope accounting; see TextureDecodeScopeStats in the header.
+thread_local TextureDecodeScopeStats g_texture_decode_scope{};
 
 struct PersistentDecodedTexture {
     uint64_t source_addr = 0;
@@ -456,6 +481,17 @@ size_t texture_decode_cache_limit_bytes(const char* override_mib,
     }
     return static_cast<size_t>(std::min<uint64_t>(bytes, SIZE_MAX));
 }
+
+bool submit_local_texture_decode_reusable(uint64_t entry_span, uint64_t current_span,
+                                          uint64_t source_size,
+                                          prosper::gpu::GuestGpuWriteQuery journal_query) {
+    if (entry_span == current_span) return true;
+    return source_size != 0 &&
+        journal_query == prosper::gpu::GuestGpuWriteQuery::Unchanged;
+}
+
+TextureDecodeScopeStats texture_decode_scope_stats() { return g_texture_decode_scope; }
+void reset_texture_decode_scope_stats() { g_texture_decode_scope = {}; }
 
 bool texture_decode_cache_candidate(bool has_live_color_target,
                                     bool has_live_depth_target,
@@ -1314,16 +1350,47 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
             // released and zero-filled tens of MiB every submit even though the decode paths overwrite
             // all pixels. Reusing same-sized slots avoids both costs; short guest reads explicitly clear
             // their uncovered tail below so stale scratch bytes can never become sampled pixels.
-            static std::vector<std::vector<uint8_t>> texstore;
+            static thread_local std::vector<std::vector<uint8_t>> texstore;
+            // Parallel to `texstore`: a slot is pinned while a retained submit-scoped identity entry
+            // still points into it. Handing a pinned slot to a later span's decode would overwrite the
+            // very bytes that entry promises, so the allocator below skips them and the pins are
+            // released together when the submit's identity map is rebuilt.
+            static thread_local std::vector<bool> texstore_pinned;
             size_t texstore_used = 0;
-            std::unordered_map<TextureDecodeKey, DecodedTexture, TextureDecodeKeyHash> decoded_textures;
+            auto acquire_texstore_slot = [&]() -> size_t {
+                while (texstore_used < texstore.size() && texstore_pinned[texstore_used])
+                    ++texstore_used;
+                if (texstore_used == texstore.size()) {
+                    texstore.emplace_back();
+                    texstore_pinned.push_back(false);
+                }
+                return texstore_used++;
+            };
+            // PROSPER_NO_SUBMIT_TEXTURE_DECODE_SCOPE=1 restores the pre-#1691 span-scoped lifetime on
+            // the same build, so a routed A/B measures the change and not two compilers' luck.
+            static const bool submit_decode_scope_disabled =
+                getenv("PROSPER_NO_SUBMIT_TEXTURE_DECODE_SCOPE") != nullptr;
+            static thread_local std::unordered_map<TextureDecodeKey, DecodedTexture,
+                                                   TextureDecodeKeyHash> decoded_textures;
+            static thread_local uint64_t decode_span_ordinal = 0;
+            ++decode_span_ordinal;
+            const bool rebuild_decode_scope = phase.first_span || submit_decode_scope_disabled;
             const bool use_direct_buffer_views =
                 getenv("PROSPER_NO_FRONTEND_BUFFER_VIEW") == nullptr;
             static std::unordered_map<TextureDecodeKey, PersistentDecodedTexture, TextureDecodeKeyHash>
                 persistent_decoded_textures;
             static size_t persistent_decoded_texture_bytes = 0;
             static uint64_t persistent_decode_generation = 0;
-            const uint64_t decode_generation = ++persistent_decode_generation;
+            // The persistent cache's LRU generation now advances per SUBMIT rather than per span. That
+            // is what keeps a submit-scoped identity entry safe: an entry whose `last_use` equals the
+            // current generation is skipped by the eviction scan, so persistent-cache storage a
+            // retained pointer refers to cannot be freed under it later in the same submit.
+            if (rebuild_decode_scope) ++persistent_decode_generation;
+            const uint64_t decode_generation = persistent_decode_generation;
+            if (rebuild_decode_scope) {
+                decoded_textures.clear();
+                texstore_pinned.assign(texstore.size(), false);
+            }
             static uint64_t persistent_texture_id = 0;
             static std::vector<uint8_t> persistent_validation_scratch;
             static const size_t persistent_decode_limit = [] {
@@ -1927,6 +1994,16 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 !r.compression_enabled || persistent_dcc_uncompressed ||
                                     persistent_dcc_fast_clear,
                                 persistent_decode_limit, persistent_source_size);
+                        // Range a submit-scoped identity entry may be re-proved against across a span
+                        // boundary (#1691). It is exactly the range the persistent decode cache
+                        // validates for this identity — the same bytes `validate_exact()` compares and
+                        // the same range its own in-submit reuse queries — so the fast path never
+                        // asserts more than the cache it short-circuits. Ineligible resources
+                        // (captured replay backing, storage images, unsupported DCC states, cache
+                        // disabled) have no such established range, so they keep the pre-#1691
+                        // span-local lifetime instead of being retained against an unverified extent.
+                        const uint64_t cross_span_source_size =
+                            persistent_cache_eligible ? persistent_source_size : 0u;
                         static const bool cross_submit_watch_enabled =
                             !getenv("PROSPER_NO_CROSS_SUBMIT_TEXTURE_WRITE_WATCH");
                         // Page-protection watches have a fixed setup/query cost and may need to
@@ -1964,10 +2041,40 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         bool narrow_decode_done = false;
                         auto reused = (has_live_rtt || resource_compute_image_hit)
                             ? decoded_textures.end() : decoded_textures.find(decode_key);
+                        // A retained entry from an EARLIER span in this submit is only usable while the
+                        // ordered journal proves nothing wrote the exact range it decoded. Overlap (an
+                        // interleaved compute/DMA/EOP write landed on the backing) and Unknown (no
+                        // journal, overflowed, or a different submit) both drop it, releasing its
+                        // scratch pin, and the resolve falls through to the persistent cache's own
+                        // validation exactly as it did before the map was widened.
+                        if (reused != decoded_textures.end() &&
+                            !submit_local_texture_decode_reusable(
+                                reused->second.span, decode_span_ordinal,
+                                reused->second.source_size,
+                                prosper::gpu::guest_gpu_writes_since(
+                                    reused->second.snapshot, reused->second.source_addr,
+                                    reused->second.source_size))) {
+                            if (reused->second.texstore_slot < texstore_pinned.size())
+                                texstore_pinned[reused->second.texstore_slot] = false;
+                            decoded_textures.erase(reused);
+                            reused = decoded_textures.end();
+                            ++g_texture_decode_scope.invalidations;
+                        }
                         DecodedTexture persistent_reuse;
                         const DecodedTexture* decoded_reuse = reused != decoded_textures.end()
                             ? &reused->second : nullptr;
                         resource_local_reuse = decoded_reuse != nullptr;
+                        if (decoded_reuse) {
+                            if (decoded_reuse->span == decode_span_ordinal) {
+                                ++g_texture_decode_scope.same_span_reuses;
+                            } else {
+                                ++g_texture_decode_scope.cross_span_reuses;
+                                // Unchanged was just proven up to here, so this instant is a valid new
+                                // baseline. Advancing it keeps each later query scanning only the
+                                // writes since the previous use instead of the whole submit journal.
+                                reused->second.snapshot = prosper::gpu::guest_gpu_write_snapshot();
+                            }
+                        }
                         if (!decoded_reuse && persistent_cache_eligible) {
                             auto cached = persistent_decoded_textures.find(decode_key);
                             if (cached != persistent_decoded_textures.end() &&
@@ -2280,10 +2387,20 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             narrow_done = decoded_reuse->narrow;
                             fr.persistent_texture_id = decoded_reuse->persistent_id;
                             fr.persistent_texture_version = decoded_reuse->persistent_version;
+                            // Reached with `decoded_reuse` pointing either at the entry just found in
+                            // this map (emplace is then a no-op on the existing key) or at a persistent
+                            // -cache hit, whose pixels the persistent entry owns. Either way the bytes
+                            // live in storage the scratch allocator never recycles, so no scratch pin
+                            // is needed, and the retained range is the one the persistent cache itself
+                            // validates for this identity.
                             decoded_textures.emplace(
                                 decode_key, DecodedTexture{fr.tex_rgba, fr.th, narrow_done,
                                                           fr.persistent_texture_id,
-                                                          fr.persistent_texture_version});
+                                                          fr.persistent_texture_version,
+                                                          decode_span_ordinal,
+                                                          prosper::gpu::guest_gpu_write_snapshot(),
+                                                          persistent_source_addr,
+                                                          cross_span_source_size, SIZE_MAX});
                             if (timing_enabled) pending_timing.texture_reuses++;
                         } else {
                         // PROSPER_DETILE_STATS: this branch is the texture-decode MISS path — the cache
@@ -2418,8 +2535,16 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             prosper::test::backend_color_bytes_per_pixel(live_rtt_format);
                         size_t nb = volume_texels * output_bpp * (is_cube ? 6u : 1u);
                         size_t linear_source_prefix_size = 0;
-                        if (texstore_used == texstore.size()) texstore.emplace_back();
-                        std::vector<uint8_t>& texture_pixels = texstore[texstore_used++];
+                        ++g_texture_decode_scope.decodes;
+                        const size_t texture_slot = acquire_texstore_slot();
+                        std::vector<uint8_t>& texture_pixels = texstore[texture_slot];
+                        // Set false once the persistent cache takes ownership of these bytes; while it
+                        // is true a retained identity entry must pin `texture_slot`, or the next span
+                        // would decode an unrelated texture into the very slot it points at.
+                        bool decoded_pixels_in_texstore = false;
+                        // Cleared only on the defensive path where ownership moved but no owner was
+                        // established; such pixels must never enter the identity map.
+                        bool decoded_pixels_valid = true;
                         if (retain_cpu_live_rtt) texture_pixels.clear();
                         else texture_pixels.resize(nb);
                         auto copy_linear_padded_rows = [&](uint8_t* dst, size_t dst_row,
@@ -3232,7 +3357,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         if (getenv("PROSPER_KILL_RING") && tw == 1024 && th == 1024 &&
                             r.num_components == 1 && r.cls == RC::Texture)
                             std::fill(texture_pixels.begin(), texture_pixels.end(), 0);
-                        if (!fr.tex_rgba) fr.tex_rgba = texture_pixels.data();
+                        if (!fr.tex_rgba) {
+                            fr.tex_rgba = texture_pixels.data();
+                            decoded_pixels_in_texstore = true;
+                        }
                         fr.tw = tw; fr.th = cube_done ? th * 6u : th;
                         fr.td = is_volume ? r.depth : 1u;
                         fr.img_dim = r.img_dim;
@@ -3331,14 +3459,34 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                     fr.persistent_texture_id = inserted->second.persistent_id;
                                     fr.persistent_texture_version =
                                         inserted->second.persistent_version;
+                                    // The scratch slot no longer owns these bytes; the entry the
+                                    // persistent cache just took is their stable home.
+                                    decoded_pixels_in_texstore = false;
+                                } else {
+                                    // Unreachable while the erase above precedes this emplace, but a
+                                    // failed insert would leave `texture_pixels` moved-from and
+                                    // `fr.tex_rgba` pointing at released bytes. Never retain that.
+                                    decoded_pixels_valid = false;
                                 }
                             }
                         }
-                        if (!resource_rtt_hit && !resource_compute_image_hit && !has_live_rtt)
+                        if (decoded_pixels_valid && !resource_rtt_hit &&
+                            !resource_compute_image_hit && !has_live_rtt) {
+                            // Pin the scratch slot for as long as this entry can be served: while the
+                            // persistent cache does not own the pixels, the slot IS the storage, and a
+                            // later span reusing it would rewrite what this entry points at.
+                            const size_t pinned_slot =
+                                decoded_pixels_in_texstore ? texture_slot : SIZE_MAX;
+                            if (decoded_pixels_in_texstore) texstore_pinned[texture_slot] = true;
                             decoded_textures.emplace(
                                 decode_key, DecodedTexture{fr.tex_rgba, fr.th, narrow_done,
                                                           fr.persistent_texture_id,
-                                                          fr.persistent_texture_version});
+                                                          fr.persistent_texture_version,
+                                                          decode_span_ordinal,
+                                                          prosper::gpu::guest_gpu_write_snapshot(),
+                                                          persistent_source_addr,
+                                                          cross_span_source_size, pinned_slot});
+                        }
                         }
                         if (native_r32ui_storage && writable_storage_image) {
                             const uint32_t writeback_pitch = getenv("PROSPER_PITCH")
@@ -3367,8 +3515,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                     [guest_addr, replay_data, guest_bytes, linear_bytes,
                                      tw, th, tile_mode,
                                      writeback_pitch, in_mip_tail, mip_tail_x,
-                                     mip_tail_y, &decoded_textures](const uint8_t* pixels,
-                                                                  size_t bytes) {
+                                     mip_tail_y, &decoded_textures,
+                                     &texstore_pinned](const uint8_t* pixels,
+                                                       size_t bytes) {
                                         if (!pixels || bytes != linear_bytes) return;
                                         uint8_t* destination = replay_data;
                                         if (!destination) {
@@ -3408,8 +3557,15 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                                 const bool overlaps = cached_addr <= guest_addr
                                                     ? guest_addr - cached_addr < cached_bytes
                                                     : cached_addr - guest_addr < guest_bytes;
-                                                if (overlaps) it = decoded_textures.erase(it);
-                                                else ++it;
+                                                if (overlaps) {
+                                                    if (it->second.texstore_slot <
+                                                        texstore_pinned.size())
+                                                        texstore_pinned[
+                                                            it->second.texstore_slot] = false;
+                                                    it = decoded_textures.erase(it);
+                                                } else {
+                                                    ++it;
+                                                }
                                             }
                                         }
                                     };
@@ -4672,7 +4828,12 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         for (size_t k = 1; k <= render_pass.size(); ++k) {
                             std::vector<const prosper::gpu::DrawItem*> prefix(
                                 render_pass.begin(), render_pass.begin() + k);
+                            // PROSPER_TARGET_STEP_HASH_DIM re-renders growing draw prefixes through
+                            // build_bds(), so every prefix must resolve its own resources from
+                            // scratch. Release the scratch pins with the map they belonged to,
+                            // otherwise each prefix would strand another set of slots.
                             texstore_used = 0;
+                            texstore_pinned.assign(texstore.size(), false);
                             decoded_textures.clear();
                             std::vector<uint8_t> step = prosper::test::render_draws_rgba(
                                 build_bds(prefix), gw, gh, seed, clear_for(prefix), true);
@@ -5353,6 +5514,17 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             persistent_pixel_bytes / (1024.0 * 1024.0),
                             persistent_watch_only_entries,
                             persistent_watch_only_saved_bytes / (1024.0 * 1024.0));
+                    // Identity-scope accounting (#1691). `cross_span` is the reuse submit scope adds
+                    // over the historical span-scoped map; `invalidated` is entries the in-submit
+                    // journal refused to carry across a span boundary.
+                    fprintf(stderr,
+                            "[render-timing] decode_scope decodes=%llu same_span=%llu "
+                            "cross_span=%llu invalidated=%llu scope=%s\n",
+                            (unsigned long long)g_texture_decode_scope.decodes,
+                            (unsigned long long)g_texture_decode_scope.same_span_reuses,
+                            (unsigned long long)g_texture_decode_scope.cross_span_reuses,
+                            (unsigned long long)g_texture_decode_scope.invalidations,
+                            submit_decode_scope_disabled ? "span" : "submit");
                     size_t rtt_bytes = 0;
                     for (const auto& [addr, surface] : g_rtt) {
                         (void)addr;

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -483,10 +483,13 @@ size_t texture_decode_cache_limit_bytes(const char* override_mib,
 }
 
 bool submit_local_texture_decode_reusable(uint64_t entry_span, uint64_t current_span,
-                                          uint64_t source_size,
+                                          uint64_t entry_source_addr, uint64_t entry_source_size,
+                                          uint64_t current_source_addr, uint64_t current_source_size,
                                           prosper::gpu::GuestGpuWriteQuery journal_query) {
     if (entry_span == current_span) return true;
-    return source_size != 0 &&
+    return current_source_size != 0 &&
+        entry_source_addr == current_source_addr &&
+        entry_source_size == current_source_size &&
         journal_query == prosper::gpu::GuestGpuWriteQuery::Unchanged;
 }
 
@@ -1368,13 +1371,32 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
             };
             // PROSPER_NO_SUBMIT_TEXTURE_DECODE_SCOPE=1 restores the pre-#1691 span-scoped lifetime on
             // the same build, so a routed A/B measures the change and not two compilers' luck.
+            //
+            // PROSPER_RESOURCE_HASH_DIM does the same, for a different reason: it correlates each
+            // decode's raw and sampled hashes with that range's writers, and it reports from inside
+            // the decode path. Retaining an identity across a span boundary would silently drop
+            // correlation points a previous build emitted, which would make the instrument disagree
+            // with itself across builds while investigating exactly the kind of question it exists
+            // for. Keep its output identical to pre-#1691 rather than make it cheaper.
             static const bool submit_decode_scope_disabled =
-                getenv("PROSPER_NO_SUBMIT_TEXTURE_DECODE_SCOPE") != nullptr;
+                getenv("PROSPER_NO_SUBMIT_TEXTURE_DECODE_SCOPE") != nullptr ||
+                getenv("PROSPER_RESOURCE_HASH_DIM") != nullptr;
             static thread_local std::unordered_map<TextureDecodeKey, DecodedTexture,
                                                    TextureDecodeKeyHash> decoded_textures;
             static thread_local uint64_t decode_span_ordinal = 0;
             ++decode_span_ordinal;
-            const bool rebuild_decode_scope = phase.first_span || submit_decode_scope_disabled;
+            // `phase.first_span` is the normal submit boundary, but it is not the only one: the
+            // warmup/window gates above (PROSPER_RENDER_FIRST, PROSPER_RENDER_DELAY_MS,
+            // PROSPER_RENDER_LAST) return before this point, so a submit can reach here first at a
+            // later span. Tracking the submit ordinal as well keeps the rebuild exact under those
+            // recipes — without it the pins and the LRU generation would sit frozen across the whole
+            // warmup. Retained entries were never unsafe there (a foreign submit serial makes the
+            // journal query Unknown, which refuses reuse before dereferencing anything), but stale
+            // state that outlives its submit is not something to leave resting on that.
+            static thread_local int decode_scope_submit = -1;
+            const bool rebuild_decode_scope = phase.first_span || submit_decode_scope_disabled ||
+                g_this_submit != decode_scope_submit;
+            decode_scope_submit = g_this_submit;
             const bool use_direct_buffer_views =
                 getenv("PROSPER_NO_FRONTEND_BUFFER_VIEW") == nullptr;
             static std::unordered_map<TextureDecodeKey, PersistentDecodedTexture, TextureDecodeKeyHash>
@@ -2041,24 +2063,33 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         bool narrow_decode_done = false;
                         auto reused = (has_live_rtt || resource_compute_image_hit)
                             ? decoded_textures.end() : decoded_textures.find(decode_key);
-                        // A retained entry from an EARLIER span in this submit is only usable while the
-                        // ordered journal proves nothing wrote the exact range it decoded. Overlap (an
-                        // interleaved compute/DMA/EOP write landed on the backing) and Unknown (no
-                        // journal, overflowed, or a different submit) both drop it, releasing its
-                        // scratch pin, and the resolve falls through to the persistent cache's own
-                        // validation exactly as it did before the map was widened.
-                        if (reused != decoded_textures.end() &&
-                            !submit_local_texture_decode_reusable(
-                                reused->second.span, decode_span_ordinal,
-                                reused->second.source_size,
-                                prosper::gpu::guest_gpu_writes_since(
-                                    reused->second.snapshot, reused->second.source_addr,
-                                    reused->second.source_size))) {
-                            if (reused->second.texstore_slot < texstore_pinned.size())
-                                texstore_pinned[reused->second.texstore_slot] = false;
-                            decoded_textures.erase(reused);
-                            reused = decoded_textures.end();
-                            ++g_texture_decode_scope.invalidations;
+                        // A retained entry from an EARLIER span in this submit is usable only while
+                        // its range is still this binding's range AND the ordered journal proves
+                        // nothing wrote it. Overlap (an interleaved compute/DMA/EOP write landed on
+                        // the backing), a moved range, and Unknown (no journal, overflowed, or a
+                        // different submit) all drop the entry, releasing its scratch pin, and the
+                        // resolve falls through to the persistent cache's own validation exactly as
+                        // it did before the map was widened. The journal query is skipped for a
+                        // same-span hit: its verdict cannot change the answer, and this runs once
+                        // per texture reference.
+                        if (reused != decoded_textures.end()) {
+                            const bool same_span = reused->second.span == decode_span_ordinal;
+                            const prosper::gpu::GuestGpuWriteQuery journal_query = same_span
+                                ? prosper::gpu::GuestGpuWriteQuery::Unchanged
+                                : prosper::gpu::guest_gpu_writes_since(
+                                      reused->second.snapshot, reused->second.source_addr,
+                                      reused->second.source_size);
+                            if (!submit_local_texture_decode_reusable(
+                                    reused->second.span, decode_span_ordinal,
+                                    reused->second.source_addr, reused->second.source_size,
+                                    persistent_source_addr, cross_span_source_size,
+                                    journal_query)) {
+                                if (reused->second.texstore_slot < texstore_pinned.size())
+                                    texstore_pinned[reused->second.texstore_slot] = false;
+                                decoded_textures.erase(reused);
+                                reused = decoded_textures.end();
+                                ++g_texture_decode_scope.invalidations;
+                            }
                         }
                         DecodedTexture persistent_reuse;
                         const DecodedTexture* decoded_reuse = reused != decoded_textures.end()
@@ -2387,20 +2418,22 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             narrow_done = decoded_reuse->narrow;
                             fr.persistent_texture_id = decoded_reuse->persistent_id;
                             fr.persistent_texture_version = decoded_reuse->persistent_version;
-                            // Reached with `decoded_reuse` pointing either at the entry just found in
-                            // this map (emplace is then a no-op on the existing key) or at a persistent
-                            // -cache hit, whose pixels the persistent entry owns. Either way the bytes
-                            // live in storage the scratch allocator never recycles, so no scratch pin
-                            // is needed, and the retained range is the one the persistent cache itself
-                            // validates for this identity.
-                            decoded_textures.emplace(
-                                decode_key, DecodedTexture{fr.tex_rgba, fr.th, narrow_done,
-                                                          fr.persistent_texture_id,
-                                                          fr.persistent_texture_version,
-                                                          decode_span_ordinal,
-                                                          prosper::gpu::guest_gpu_write_snapshot(),
-                                                          persistent_source_addr,
-                                                          cross_span_source_size, SIZE_MAX});
+                            // Only a persistent-cache hit needs to be recorded here; a submit-local
+                            // hit is already in the map under this key, and emplacing over it would
+                            // build and discard a node on every repeat reference. Persistent-hit
+                            // pixels are owned by the persistent entry, so the bytes live in storage
+                            // the scratch allocator never recycles and no pin is needed; the retained
+                            // range is the one that cache itself validates for this identity.
+                            if (!resource_local_reuse)
+                                decoded_textures.emplace(
+                                    decode_key,
+                                    DecodedTexture{fr.tex_rgba, fr.th, narrow_done,
+                                                   fr.persistent_texture_id,
+                                                   fr.persistent_texture_version,
+                                                   decode_span_ordinal,
+                                                   prosper::gpu::guest_gpu_write_snapshot(),
+                                                   persistent_source_addr,
+                                                   cross_span_source_size, SIZE_MAX});
                             if (timing_enabled) pending_timing.texture_reuses++;
                         } else {
                         // PROSPER_DETILE_STATS: this branch is the texture-decode MISS path — the cache
@@ -2542,9 +2575,6 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                         // is true a retained identity entry must pin `texture_slot`, or the next span
                         // would decode an unrelated texture into the very slot it points at.
                         bool decoded_pixels_in_texstore = false;
-                        // Cleared only on the defensive path where ownership moved but no owner was
-                        // established; such pixels must never enter the identity map.
-                        bool decoded_pixels_valid = true;
                         if (retain_cpu_live_rtt) texture_pixels.clear();
                         else texture_pixels.resize(nb);
                         auto copy_linear_padded_rows = [&](uint8_t* dst, size_t dst_row,
@@ -3472,15 +3502,21 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                     // persistent cache just took is their stable home.
                                     decoded_pixels_in_texstore = false;
                                 } else {
-                                    // Unreachable while the erase above precedes this emplace, but a
-                                    // failed insert would leave `texture_pixels` moved-from and
-                                    // `fr.tex_rgba` pointing at released bytes. Never retain that.
-                                    decoded_pixels_valid = false;
+                                    // Unreachable: the erase above leaves this key absent, so the
+                                    // insert cannot collide. Were it ever reachable, the move has
+                                    // already emptied `texture_pixels` and `fr.tex_rgba` would point
+                                    // at released bytes — which THIS draw would sample, not only the
+                                    // identity map. Bind the colliding entry's pixels instead; it is
+                                    // the same key, so it is the same decode.
+                                    fr.tex_rgba = inserted->second.pixels.data();
+                                    fr.persistent_texture_id = inserted->second.persistent_id;
+                                    fr.persistent_texture_version =
+                                        inserted->second.persistent_version;
+                                    decoded_pixels_in_texstore = false;
                                 }
                             }
                         }
-                        if (decoded_pixels_valid && !resource_rtt_hit &&
-                            !resource_compute_image_hit && !has_live_rtt) {
+                        if (!resource_rtt_hit && !resource_compute_image_hit && !has_live_rtt) {
                             // Pin the scratch slot only for an entry that can actually outlive this
                             // span AND whose pixels the persistent cache did not take: then the slot
                             // IS the storage and a later span reusing it would rewrite what the entry

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -3528,12 +3528,16 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                                 const uint32_t mip_tail_x = r.mip_tail_x;
                                 const uint32_t mip_tail_y = r.mip_tail_y;
                                 fr.storage_image_writeback =
+                                    // `decoded_textures` and `texstore_pinned` are thread-local
+                                    // statics since #1691 and are deliberately NOT captured: a
+                                    // variable with static storage duration cannot appear in a
+                                    // capture list (clang rejects it outright), and the body reaches
+                                    // the render thread's own instances directly — which is the
+                                    // right identity, since this callback runs on that thread.
                                     [guest_addr, replay_data, guest_bytes, linear_bytes,
                                      tw, th, tile_mode,
                                      writeback_pitch, in_mip_tail, mip_tail_x,
-                                     mip_tail_y, &decoded_textures,
-                                     &texstore_pinned](const uint8_t* pixels,
-                                                       size_t bytes) {
+                                     mip_tail_y](const uint8_t* pixels, size_t bytes) {
                                         if (!pixels || bytes != linear_bytes) return;
                                         uint8_t* destination = replay_data;
                                         if (!destination) {

--- a/prosper/frontends/shared/live_renderer.hpp
+++ b/prosper/frontends/shared/live_renderer.hpp
@@ -56,6 +56,12 @@ struct TextureDecodeScopeStats {
     uint64_t same_span_reuses = 0;
     uint64_t cross_span_reuses = 0;
     uint64_t invalidations = 0;
+    // Retained entries whose pixels the persistent cache did NOT take, so the scratch slot is their
+    // only storage and had to be pinned against a later span's decode. Exported because it is the
+    // only observable that distinguishes "the pin path ran" from "the pin path was never reached":
+    // a test can otherwise pass while covering nothing, since an entry backed by persistent storage
+    // survives a span boundary whether or not pinning works.
+    uint64_t scratch_pins = 0;
 };
 TextureDecodeScopeStats texture_decode_scope_stats();
 void reset_texture_decode_scope_stats();

--- a/prosper/frontends/shared/live_renderer.hpp
+++ b/prosper/frontends/shared/live_renderer.hpp
@@ -10,7 +10,45 @@
 #include <cstdint>
 #include <string>
 
+#include "gpu/gpu_execute.hpp"          // GuestGpuWriteQuery — the in-submit mutation proof
+
 namespace prosper::frontend {
+
+// The decoded-texture identity map lives for one SUBMIT (#1691). A submit is cut into a new graphics
+// span at every interleaved compute/DMA operation, and that split is exactly what could rewrite guest
+// texture bytes mid-submit, so an entry crossing a span boundary must carry proof that nothing wrote
+// the range it decoded.
+//
+// Reuse inside the span that produced the entry keeps the historical span-local guarantee and needs
+// no proof. Crossing a span boundary needs both halves:
+//
+//   * `source_size` != 0 — a known validated source range. It is the persistent decode cache's own
+//     range for this identity, so the fast path asserts exactly what that cache asserts, and it is
+//     deliberately zero for resources the persistent cache does not validate (captured replay
+//     backing, storage images, unsupported DCC states). Those keep the pre-#1691 span lifetime rather
+//     than being retained against a range nobody established.
+//   * `journal_query` == Unchanged — the ordered in-submit journal proves no retained GPU operation
+//     wrote that range since the entry was established. Overlap means the guest GPU did write it
+//     (the #780 stale-copy shape); Unknown (journal inactive, overflowed, or from a different submit)
+//     is not evidence of anything. Both force a fresh resolve through the persistent cache's exact
+//     validation, which is the pre-#1691 behavior.
+bool submit_local_texture_decode_reusable(uint64_t entry_span, uint64_t current_span,
+                                          uint64_t source_size,
+                                          prosper::gpu::GuestGpuWriteQuery journal_query);
+
+// Identity-scope accounting for the decoded-texture map, maintained unconditionally so a routed run
+// and a regression test can both assert on it. `decodes` counts full CPU resolves (the work #1691
+// removes), `same_span_reuses` is what the old span-scoped map already served, `cross_span_reuses` is
+// what submit scope adds, and `invalidations` counts entries dropped because the journal could not
+// prove their backing unchanged. Per-thread, like the renderer's other submit-scoped state.
+struct TextureDecodeScopeStats {
+    uint64_t decodes = 0;
+    uint64_t same_span_reuses = 0;
+    uint64_t cross_span_reuses = 0;
+    uint64_t invalidations = 0;
+};
+TextureDecodeScopeStats texture_decode_scope_stats();
+void reset_texture_decode_scope_stats();
 
 // Bytes actually uploaded for one non-texture (vertex/index/storage/constant) buffer binding whose
 // descriptor declares `declared_bytes`. A vertex fetch may index anywhere inside the declared range,

--- a/prosper/frontends/shared/live_renderer.hpp
+++ b/prosper/frontends/shared/live_renderer.hpp
@@ -20,20 +20,30 @@ namespace prosper::frontend {
 // the range it decoded.
 //
 // Reuse inside the span that produced the entry keeps the historical span-local guarantee and needs
-// no proof. Crossing a span boundary needs both halves:
+// no proof. Crossing a span boundary needs all three of:
 //
-//   * `source_size` != 0 — a known validated source range. It is the persistent decode cache's own
-//     range for this identity, so the fast path asserts exactly what that cache asserts, and it is
-//     deliberately zero for resources the persistent cache does not validate (captured replay
-//     backing, storage images, unsupported DCC states). Those keep the pre-#1691 span lifetime rather
-//     than being retained against a range nobody established.
+//   * `current_source_size` != 0 — a known validated source range. It is the persistent decode
+//     cache's own range for this identity, and is deliberately zero for resources that cache does
+//     not validate (captured replay backing, storage images, unsupported DCC states). Those keep the
+//     pre-#1691 span lifetime rather than being retained against a range nobody established.
+//   * the entry's range still being THIS binding's range. The resolved range is not a pure function
+//     of `TextureDecodeKey`: it switches to the DCC metadata plane when live metadata content reads
+//     as a fast clear, and it can follow the HLE allocation registry's pitch — neither is in the key.
+//     An entry retained over the base texels must therefore not be served to a binding that now
+//     resolves to the metadata plane, or a metadata-only rewrite between spans would read as
+//     journal-clean over a range that is no longer the authority. The persistent cache makes exactly
+//     this comparison before its own reuse; a fast path that short-circuits it must not assert less.
 //   * `journal_query` == Unchanged — the ordered in-submit journal proves no retained GPU operation
 //     wrote that range since the entry was established. Overlap means the guest GPU did write it
 //     (the #780 stale-copy shape); Unknown (journal inactive, overflowed, or from a different submit)
 //     is not evidence of anything. Both force a fresh resolve through the persistent cache's exact
 //     validation, which is the pre-#1691 behavior.
+//
+// `journal_query` is ignored when the spans match, so a same-span caller may pass any value rather
+// than paying for a query whose verdict cannot matter — this runs once per texture reference.
 bool submit_local_texture_decode_reusable(uint64_t entry_span, uint64_t current_span,
-                                          uint64_t source_size,
+                                          uint64_t entry_source_addr, uint64_t entry_source_size,
+                                          uint64_t current_source_addr, uint64_t current_source_size,
                                           prosper::gpu::GuestGpuWriteQuery journal_query);
 
 // Identity-scope accounting for the decoded-texture map, maintained unconditionally so a routed run

--- a/prosper/tests/test_gpu_capture_render.cpp
+++ b/prosper/tests/test_gpu_capture_render.cpp
@@ -1495,8 +1495,16 @@ int main() {
             std::vector<uint8_t> pin_second, pin_last;
             const uint8_t* pin_span2 = target_center(pin_targets[1], pin_second);
             const uint8_t* pin_span3 = target_center(pin_targets[3], pin_last);
-            CHECK(pinned.cross_span_reuses >= 1 && pinned.invalidations == 1,
-                  "the twice-decoded identity is retained again and served across the next boundary");
+            // `scratch_pins == 1` is what makes this case self-validating rather than merely true.
+            // The pin is only reached because `decode_generation` is per SUBMIT, which is what makes
+            // `can_replace` false for span 2's re-decode. Revert that to a per-span bump and the
+            // pixels move into the persistent cache instead, no pin is taken, and both green
+            // assertions below still pass while covering nothing — so assert the mechanism, not only
+            // its consequence. It doubles as the guard on the per-submit generation, which is
+            // otherwise untestable without provoking a use-after-free.
+            CHECK(pinned.scratch_pins == 1 && pinned.cross_span_reuses == 1 &&
+                      pinned.invalidations == 1 && pinned.decodes == 3,
+                  "the twice-decoded identity is pinned in scratch and served across the next span");
             CHECK(pin_span2 && pin_span3 &&
                       pin_span2[1] > 0xC0 && pin_span2[0] < 0x40 &&
                       pin_span3[1] > 0xC0 && pin_span3[0] < 0x40,

--- a/prosper/tests/test_gpu_capture_render.cpp
+++ b/prosper/tests/test_gpu_capture_render.cpp
@@ -1237,16 +1237,31 @@ int main() {
         using prosper::frontend::submit_local_texture_decode_reusable;
         using prosper::frontend::texture_decode_scope_stats;
 
-        CHECK(submit_local_texture_decode_reusable(9, 9, 0, GuestGpuWriteQuery::Unknown),
+        constexpr uint64_t SRC = 0x40000, LEN = 64;
+        CHECK(submit_local_texture_decode_reusable(9, 9, SRC, LEN, SRC, LEN,
+                                                   GuestGpuWriteQuery::Unknown),
               "reuse inside the span that decoded the pixels keeps the historical guarantee");
-        CHECK(submit_local_texture_decode_reusable(9, 10, 64, GuestGpuWriteQuery::Unchanged),
+        CHECK(submit_local_texture_decode_reusable(9, 10, SRC, LEN, SRC, LEN,
+                                                   GuestGpuWriteQuery::Unchanged),
               "a proven-unchanged source range carries one decode across a span boundary");
-        CHECK(!submit_local_texture_decode_reusable(9, 10, 64, GuestGpuWriteQuery::Overlap),
+        CHECK(!submit_local_texture_decode_reusable(9, 10, SRC, LEN, SRC, LEN,
+                                                    GuestGpuWriteQuery::Overlap),
               "a guest GPU write over the decoded range forces a fresh cross-span resolve");
-        CHECK(!submit_local_texture_decode_reusable(9, 10, 64, GuestGpuWriteQuery::Unknown),
+        CHECK(!submit_local_texture_decode_reusable(9, 10, SRC, LEN, SRC, LEN,
+                                                    GuestGpuWriteQuery::Unknown),
               "an unusable journal never counts as proof that a decode survived a span boundary");
-        CHECK(!submit_local_texture_decode_reusable(9, 10, 0, GuestGpuWriteQuery::Unchanged),
+        CHECK(!submit_local_texture_decode_reusable(9, 10, SRC, LEN, SRC, 0,
+                                                    GuestGpuWriteQuery::Unchanged),
               "a resource with no validated source range keeps the span-local lifetime");
+        // The resolved range is not a pure function of the decode key: a DCC fast clear moves it to
+        // the metadata plane, and the HLE pitch registry can move its extent. An entry proved clean
+        // over its own range says nothing about a range that has since moved.
+        CHECK(!submit_local_texture_decode_reusable(9, 10, SRC, LEN, SRC + 0x1000, LEN,
+                                                    GuestGpuWriteQuery::Unchanged),
+              "a retained entry is refused once the binding resolves to a different source address");
+        CHECK(!submit_local_texture_decode_reusable(9, 10, SRC, LEN, SRC, LEN * 2,
+                                                    GuestGpuWriteQuery::Unchanged),
+              "a retained entry is refused once the binding resolves to a different source extent");
 
         // The end-to-end half needs a LIVE texture: captured replay backing sets host_data, which
         // excludes the resource from the persistent cache and therefore from cross-span retention.
@@ -1418,8 +1433,80 @@ int main() {
                       distinct_keys.invalidations == 0,
                   "two identities differing only in source row pitch decode separately");
 
-            // (4) The identity map does not outlive its submit: an entry established in one submit
-            // must never serve the next, whose indirect descriptor memory may have moved on.
+            // (4) SCRATCH PINNING — the aliasing hazard, which the cases above cannot reach because
+            // the persistent cache accepts their pixels and therefore owns them. Re-decoding an
+            // identity the persistent cache already holds THIS submit cannot replace that entry (its
+            // LRU generation is current), so the fresh pixels stay in the scratch slot and the map
+            // entry points straight at it. A later span must not be handed that slot.
+            //
+            //   span 1: decode -> persistent insert
+            //   dispatch A: rewrite the backing red->green and report it
+            //   span 2: forced re-decode, persistent entry not replaceable -> pixels live in scratch
+            //   dispatch B: write an unrelated range
+            //   span 3: draw a DIFFERENT texture first (the slot grab), then the retained identity
+            //
+            // Unpinned, span 3's first decode takes the slot span 2 is still pointing at and the
+            // second draw renders blue. Pinned, the allocator skips it and green survives.
+            const uint64_t pinned_texture = guest_base + 0x5000;
+            const uint64_t other_texture = guest_base + 0x6000;
+            const std::vector<uint8_t> blue_2x2 = {
+                0, 0, 255, 255,   0, 0, 255, 255,
+                0, 0, 255, 255,   0, 0, 255, 255,
+            };
+            std::memcpy(guest + 0x5000, red_2x2.data(), red_2x2.size());
+            std::memcpy(guest + 0x6000, blue_2x2.data(), blue_2x2.size());
+            std::vector<ComputeItem> two_dispatches(2);
+            two_dispatches[0].dispatch_index = 0;
+            two_dispatches[1].dispatch_index = 1;
+            int dispatch_seen = 0;
+            LiveComputeFn write_then_idle = [&](const std::vector<ComputeItem>&) {
+                if (dispatch_seen++ == 0) {
+                    std::memcpy(reinterpret_cast<void*>(static_cast<uintptr_t>(pinned_texture)),
+                                green_2x2.data(), green_2x2.size());
+                    notify_guest_gpu_write(pinned_texture, green_2x2.size());
+                } else {
+                    notify_guest_gpu_write(unrelated, 4);
+                }
+                return true;
+            };
+            uint64_t pin_targets[4] = {0, 0, 0, 0};
+            uint64_t pin_next_target = 0x101000000ull;
+            auto pin_draw = [&](uint64_t texture_addr, uint64_t draw_index, uint64_t order) {
+                DrawItem draw = texture_draw(texture_addr, 2, 2, 8, 0, order);
+                draw.draw_index = draw_index;
+                draw.color0_base = pin_next_target;
+                pin_targets[draw_index] = pin_next_target;
+                pin_next_target += 0x100000ull;
+                return draw;
+            };
+            dispatch_seen = 0;
+            reset_texture_decode_scope_stats();
+            execute_ordered_items(
+                {{SubmitOperationKind::Draw, 0, 100},
+                 {SubmitOperationKind::Dispatch, 0, 150},
+                 {SubmitOperationKind::Draw, 1, 200},
+                 {SubmitOperationKind::Dispatch, 1, 250},
+                 {SubmitOperationKind::Draw, 2, 300},
+                 {SubmitOperationKind::Draw, 3, 310}},
+                {pin_draw(pinned_texture, 0, 100), pin_draw(pinned_texture, 1, 200),
+                 pin_draw(other_texture, 2, 300), pin_draw(pinned_texture, 3, 310)},
+                two_dispatches, counting_render, write_then_idle, W, H);
+            const auto pinned = texture_decode_scope_stats();
+            std::vector<uint8_t> pin_second, pin_last;
+            const uint8_t* pin_span2 = target_center(pin_targets[1], pin_second);
+            const uint8_t* pin_span3 = target_center(pin_targets[3], pin_last);
+            CHECK(pinned.cross_span_reuses >= 1 && pinned.invalidations == 1,
+                  "the twice-decoded identity is retained again and served across the next boundary");
+            CHECK(pin_span2 && pin_span3 &&
+                      pin_span2[1] > 0xC0 && pin_span2[0] < 0x40 &&
+                      pin_span3[1] > 0xC0 && pin_span3[0] < 0x40,
+                  "a scratch-backed retained entry survives a later span decoding another texture");
+
+            // (5) The identity map does not outlive its submit: an entry established in one submit
+            // must never serve the next, whose indirect descriptor memory may have moved on. The
+            // discriminating counter is `invalidations` — a map that leaked across the boundary
+            // would FIND the stale entry and then refuse it on its foreign submit serial, which is
+            // safe but is not the contract. Zero invalidations means it was never there to find.
             const uint64_t across_texture = guest_base + 0x4000;
             std::memcpy(guest + 0x4000, red_2x2.data(), red_2x2.size());
             dispatch_writes = 0;
@@ -1433,9 +1520,9 @@ int main() {
                                   {texture_draw(across_texture, 2, 2, 8, 0, 100)},
                                   {}, counting_render, interleaved_write, W, H);
             const auto second_submit = texture_decode_scope_stats();
-            CHECK(first_submit.decodes == 1 && first_submit.cross_span_reuses == 0 &&
-                      second_submit.cross_span_reuses == 0 &&
-                      second_submit.same_span_reuses == first_submit.same_span_reuses,
+            CHECK(first_submit.decodes == 1 && first_submit.invalidations == 0 &&
+                      second_submit.invalidations == 0 &&
+                      second_submit.cross_span_reuses == 0,
                   "a new submit rebuilds the identity map instead of inheriting the previous one");
         }
     }

--- a/prosper/tests/test_gpu_capture_render.cpp
+++ b/prosper/tests/test_gpu_capture_render.cpp
@@ -1226,6 +1226,220 @@ int main() {
 
     }
 
+    // #1691 — the decoded-texture identity map is SUBMIT-scoped, not span-scoped. A submit is cut
+    // into a new graphics span at every interleaved compute/DMA operation, so a span-scoped map
+    // re-resolved every identity once per span (Blue Prince: 56 identities, 853 resolves, 15.2x).
+    // Widening the lifetime is only sound while an entry that crosses a span boundary carries proof
+    // that nothing rewrote the bytes it decoded — the failure this guards is #780's shape, where a
+    // compute reset of a backing invalidated one cached view and not another.
+    {
+        using prosper::frontend::reset_texture_decode_scope_stats;
+        using prosper::frontend::submit_local_texture_decode_reusable;
+        using prosper::frontend::texture_decode_scope_stats;
+
+        CHECK(submit_local_texture_decode_reusable(9, 9, 0, GuestGpuWriteQuery::Unknown),
+              "reuse inside the span that decoded the pixels keeps the historical guarantee");
+        CHECK(submit_local_texture_decode_reusable(9, 10, 64, GuestGpuWriteQuery::Unchanged),
+              "a proven-unchanged source range carries one decode across a span boundary");
+        CHECK(!submit_local_texture_decode_reusable(9, 10, 64, GuestGpuWriteQuery::Overlap),
+              "a guest GPU write over the decoded range forces a fresh cross-span resolve");
+        CHECK(!submit_local_texture_decode_reusable(9, 10, 64, GuestGpuWriteQuery::Unknown),
+              "an unusable journal never counts as proof that a decode survived a span boundary");
+        CHECK(!submit_local_texture_decode_reusable(9, 10, 0, GuestGpuWriteQuery::Unchanged),
+              "a resource with no validated source range keeps the span-local lifetime");
+
+        // The end-to-end half needs a LIVE texture: captured replay backing sets host_data, which
+        // excludes the resource from the persistent cache and therefore from cross-span retention.
+        // Map a real committed guest range and decode out of it, exactly as a booted title does.
+        auto map_flexible = prosper::Hle::lookup(prosper::nid_hash("sceKernelMapFlexibleMemory"));
+        uint64_t guest_base = 0;
+        const bool guest_mapped = map_flexible &&
+            map_flexible(reinterpret_cast<uint64_t>(&guest_base), 0x10000u, 0x2u, 0u, 0u, 0u) == 0 &&
+            guest_base != 0;
+        CHECK(guest_mapped,
+              "the decode-scope test maps a committed guest range for a live-decoded texture");
+
+        if (guest_mapped) {
+            constexpr uint32_t TW = 16, TH = 16;                 // color target extent per span
+            auto* guest = reinterpret_cast<uint8_t*>(static_cast<uintptr_t>(guest_base));
+            const std::vector<uint8_t> red_2x2 = {
+                255, 0, 0, 255,   255, 0, 0, 255,
+                255, 0, 0, 255,   255, 0, 0, 255,
+            };
+            const std::vector<uint8_t> green_2x2 = {
+                0, 255, 0, 255,   0, 255, 0, 255,
+                0, 255, 0, 255,   0, 255, 0, 255,
+            };
+
+            // One submit: draw -> dispatch -> draw. The dispatch is what splits the submit into two
+            // graphics spans, and it is also the operation that can rewrite a texture backing.
+            // Each draw gets its own retained color target so both spans stay separately readable:
+            // an intermediate span publishes no frame, so the assertions read the renderer's target
+            // history instead of the callback return.
+            uint64_t next_target = 0x100700000ull;
+            uint64_t span_targets[2] = {0, 0};
+            auto texture_draw = [&](uint64_t texture_addr, uint32_t tw, uint32_t th,
+                                    uint32_t pitch, uint64_t draw_index, uint64_t order) {
+                DrawItem draw = replay.items[0];
+                draw.color0_base = next_target;
+                if (draw_index < 2) span_targets[draw_index] = next_target;
+                next_target += 0x100000ull;
+                draw.color0_width = TW;
+                draw.color0_height = TH;
+                draw.draw_index = draw_index;
+                draw.command_order = order;
+                auto table = std::make_shared<ShaderResourceTable>(compile_rt);
+                table->resources[0].gpu_addr = texture_addr;
+                table->resources[0].width = tw;
+                table->resources[0].height = th;
+                table->resources[0].size = tw * th * 4u;
+                table->resources[0].linear_row_pitch_bytes = pitch;
+                table->resources[0].host_data = nullptr;      // live guest memory, not capture bytes
+                table->resources[0].host_data_size = 0;
+                draw.prt = std::move(table);
+                return draw;
+            };
+
+            // `dispatch_writes` is the range the interleaved operation rewrites and reports through
+            // the ordered guest-write journal. Pointing it AT the sampled backing is the invalidation
+            // case; pointing it elsewhere is the control that must still reuse.
+            uint64_t dispatch_writes = 0;
+            const std::vector<uint8_t>* dispatch_bytes = nullptr;
+            LiveComputeFn interleaved_write = [&](const std::vector<ComputeItem>&) {
+                if (!dispatch_writes || !dispatch_bytes) return true;
+                std::memcpy(reinterpret_cast<void*>(static_cast<uintptr_t>(dispatch_writes)),
+                            dispatch_bytes->data(), dispatch_bytes->size());
+                notify_guest_gpu_write(dispatch_writes, dispatch_bytes->size());
+                return true;
+            };
+
+            size_t rendered_spans = 0;
+            LiveRenderFn counting_render = [&](const std::vector<DrawItem>& items, uint32_t width,
+                                               uint32_t height) {
+                ++rendered_spans;
+                return RenderedFrame(render_submit_items(items, width, height));
+            };
+            // Center texel of a retained 16x16 color target, or nullptr if it is not readable at the
+            // declared extent. Reading through the renderer's own target history keeps the assertion
+            // on the pixels a later pass would actually sample.
+            auto target_center = [&](uint64_t target, std::vector<uint8_t>& keep) -> const uint8_t* {
+                LiveTargetSnapshot snapshot;
+                if (!target || !read_live_render_target(target, snapshot) || !snapshot.pixels ||
+                    snapshot.width != TW || snapshot.height != TH ||
+                    snapshot.pixels->size() != static_cast<size_t>(TW) * TH * 4u)
+                    return nullptr;
+                keep = *snapshot.pixels;
+                return &keep[(static_cast<size_t>(TH / 2) * TW + TW / 2) * 4];
+            };
+
+            std::vector<ComputeItem> dispatches(1);
+            dispatches[0].dispatch_index = 0;
+            const std::vector<SubmitOperation> two_spans = {
+                {SubmitOperationKind::Draw, 0, 100},
+                {SubmitOperationKind::Dispatch, 0, 150},
+                {SubmitOperationKind::Draw, 1, 200},
+            };
+
+            // (1) CONTROL — the dispatch writes an unrelated range. Both spans sample the same
+            // identity, so the submit-scoped map must serve the second one without decoding again.
+            const uint64_t control_texture = guest_base + 0x1000;
+            uint64_t unrelated = guest_base + 0x8000;
+            std::memcpy(guest + 0x1000, red_2x2.data(), red_2x2.size());
+            dispatch_writes = unrelated;
+            dispatch_bytes = &green_2x2;
+            rendered_spans = 0;
+            reset_texture_decode_scope_stats();
+            execute_ordered_items(
+                two_spans,
+                {texture_draw(control_texture, 2, 2, 8, 0, 100),
+                 texture_draw(control_texture, 2, 2, 8, 1, 200)},
+                dispatches, counting_render, interleaved_write, W, H);
+            auto control = texture_decode_scope_stats();
+            CHECK(rendered_spans == 2,
+                  "an interleaved dispatch splits one submit into two graphics spans");
+            CHECK(control.decodes == 1 && control.cross_span_reuses == 1 &&
+                      control.invalidations == 0,
+                  "one identity sampled in two spans of one submit decodes exactly once");
+            std::vector<uint8_t> control_a, control_b;
+            const uint8_t* control_first = target_center(span_targets[0], control_a);
+            const uint8_t* control_second = target_center(span_targets[1], control_b);
+            CHECK(control_first && control_second &&
+                      control_first[0] > 0xC0 && control_first[1] < 0x40 &&
+                      control_second[0] > 0xC0 && control_second[1] < 0x40,
+                  "both spans sample the unchanged red guest texture");
+
+            // (2) INVALIDATION — the same shape, except the dispatch rewrites the sampled backing
+            // and reports it. Serving the retained entry here would publish pixels the guest has
+            // already replaced; the second span must observe the new bytes. This assertion fails if
+            // the widened map skips the in-submit journal check.
+            const uint64_t written_texture = guest_base + 0x2000;
+            std::memcpy(guest + 0x2000, red_2x2.data(), red_2x2.size());
+            dispatch_writes = written_texture;
+            dispatch_bytes = &green_2x2;
+            rendered_spans = 0;
+            reset_texture_decode_scope_stats();
+            execute_ordered_items(
+                two_spans,
+                {texture_draw(written_texture, 2, 2, 8, 0, 100),
+                 texture_draw(written_texture, 2, 2, 8, 1, 200)},
+                dispatches, counting_render, interleaved_write, W, H);
+            auto invalidated = texture_decode_scope_stats();
+            CHECK(invalidated.decodes == 2 && invalidated.cross_span_reuses == 0 &&
+                      invalidated.invalidations == 1,
+                  "a guest GPU write to the backing between spans forces a second decode");
+            std::vector<uint8_t> written_a, written_b;
+            const uint8_t* written_first = target_center(span_targets[0], written_a);
+            const uint8_t* written_second = target_center(span_targets[1], written_b);
+            CHECK(written_first && written_second &&
+                      written_first[0] > 0xC0 && written_first[1] < 0x40 &&
+                      written_second[1] > 0xC0 && written_second[0] < 0x40,
+                  "the span after the write samples the rewritten green texture, not the red cache");
+
+            // (3) KEY COMPLETENESS — two descriptors at the same address and the same extent whose
+            // decoded bytes differ. `linear_row_pitch_bytes` 8 reads 16 contiguous bytes; 16 reads
+            // row 0 at +0 and row 1 at +16. The reuse path re-derives extent and format from the
+            // descriptor and takes only the PIXELS from the map, so an under-specified key shows up
+            // exactly here: dropping the pitch field would serve the first decode to the second draw
+            // and collapse this to one decode with a cross-span reuse.
+            const uint64_t pitch_texture = guest_base + 0x3000;
+            std::memcpy(guest + 0x3000, red_2x2.data(), red_2x2.size());
+            std::memcpy(guest + 0x3010, green_2x2.data(), green_2x2.size());
+            dispatch_writes = unrelated;
+            dispatch_bytes = &green_2x2;
+            rendered_spans = 0;
+            reset_texture_decode_scope_stats();
+            execute_ordered_items(
+                two_spans,
+                {texture_draw(pitch_texture, 2, 2, 8, 0, 100),
+                 texture_draw(pitch_texture, 2, 2, 16, 1, 200)},
+                dispatches, counting_render, interleaved_write, W, H);
+            auto distinct_keys = texture_decode_scope_stats();
+            CHECK(distinct_keys.decodes == 2 && distinct_keys.cross_span_reuses == 0 &&
+                      distinct_keys.invalidations == 0,
+                  "two identities differing only in source row pitch decode separately");
+
+            // (4) The identity map does not outlive its submit: an entry established in one submit
+            // must never serve the next, whose indirect descriptor memory may have moved on.
+            const uint64_t across_texture = guest_base + 0x4000;
+            std::memcpy(guest + 0x4000, red_2x2.data(), red_2x2.size());
+            dispatch_writes = 0;
+            dispatch_bytes = nullptr;
+            reset_texture_decode_scope_stats();
+            execute_ordered_items({{SubmitOperationKind::Draw, 0, 100}},
+                                  {texture_draw(across_texture, 2, 2, 8, 0, 100)},
+                                  {}, counting_render, interleaved_write, W, H);
+            const auto first_submit = texture_decode_scope_stats();
+            execute_ordered_items({{SubmitOperationKind::Draw, 0, 100}},
+                                  {texture_draw(across_texture, 2, 2, 8, 0, 100)},
+                                  {}, counting_render, interleaved_write, W, H);
+            const auto second_submit = texture_decode_scope_stats();
+            CHECK(first_submit.decodes == 1 && first_submit.cross_span_reuses == 0 &&
+                      second_submit.cross_span_reuses == 0 &&
+                      second_submit.same_span_reuses == first_submit.same_span_reuses,
+                  "a new submit rebuilds the identity map instead of inheriting the previous one");
+        }
+    }
+
     if (fails) { std::printf("== FAIL: %d ==\n", fails); return 1; }
     std::printf("== PASS ==\n"); return 0;
 }


### PR DESCRIPTION
Fixes #1691.

## Failure scenario

The decoded-texture identity map (`decoded_textures`, `live_renderer.cpp`) was a plain non-static
local in the per-callback render scope. **One renderer callback is one graphics span**, and a submit
is cut into a new span at every interleaved compute/DMA operation (the retained PM4 ordering from
#584). So a frame of N spans re-resolved every texture identity it touched up to N times.

Blue Prince (PPSA25009) interleaves 21–22 dispatches through its draw stream, so **every frame is
16–22 spans**, and each span re-resolved every identity it touched. #1691 measured 56 distinct decode
identities resolved 853 times in one submit — **but that 15.2× is a replay figure, where the
persistent decode cache is disabled by construction; live the amplification was already almost
entirely absorbed.** See "Scope of the win" below before reading the measurement: the honest live
number is −46 % of one term and ~7.5 % of frame time, not 15×.

Live, most span-local misses land in `persistent_decoded_textures` rather than a full decode — but
that path is not free: each miss costs a map lookup plus either a `guest_gpu_writes_since` query or a
full source-byte `validate_exact()` (measured at 22–25 ms/submit over ~127 MiB in #1040).

## Behavioral contract

**A decode identity resolves at most once per submit.** Reuse *inside the span that decoded the
pixels* keeps the historical guarantee untouched. Crossing a span boundary requires proof, because
the span split exists precisely because an interleaved operation can rewrite guest texture bytes:

1. **A validated source range.** The retained range is the persistent decode cache's own range for
   that identity — the same bytes `validate_exact()` compares and the same range its in-submit reuse
   queries. It is deliberately **zero** for resources the persistent cache does not validate
   (captured replay backing, storage images, unsupported DCC states, cache disabled); those keep the
   pre-#1691 span-local lifetime rather than being retained against an extent nobody established.
2. **That range still being THIS binding's range.** The resolved range is *not* a pure function of
   `TextureDecodeKey`: it switches to the DCC metadata plane when live metadata content reads as a
   fast clear, and it can follow the HLE allocation registry's pitch. Neither is in the key, so an
   entry retained over the base texels must not be served to a binding that now resolves to the
   metadata plane — a metadata-only rewrite between spans would otherwise read as journal-clean over
   a range that is no longer the authority. The persistent cache makes exactly this comparison before
   its own reuse; a fast path short-circuiting it must not assert less. *(This condition was missing
   in the first revision and was the review's blocking finding.)*
3. **`guest_gpu_writes_since(snapshot, addr, size) == Unchanged`** over that range. `Overlap` means
   the guest GPU wrote the backing; `Unknown` (journal inactive, overflowed, or from a different
   submit) is not evidence of anything. Both evict the entry and fall through to the persistent
   cache's existing exact validation — i.e. exactly the pre-#1691 path.

The verdict is fail-closed in both directions when eligibility itself flips between spans (a compute
image import appearing, or DCC metadata changing state): the range comparison then mismatches and the
entry is dropped rather than trusted.

The journal (#611) is the right instrument here by construction; `gpu_execute.hpp` documents it as
*"a validation snapshot is meaningful only inside one synchronous `execute_ordered_items` call. It
lets a backend prove that no retained GPU operation wrote a resource between graphics spans."* That
is literally this question, and it answers it more precisely than the span boundary did.

Live RTT and compute-imported inputs stay excluded from the map entirely, as before. The
storage-image writeback still explicitly evicts every overlapping entry after publishing.
A new submit rebuilds the map (rule 4 of the issue), so indirect descriptor memory that moved between
submits cannot be stale — and an entry that somehow survived would carry a foreign submit serial and
query `Unknown`.

## Two lifetime hazards the widening creates, closed with it

Widening a cache's scope without widening what keeps its contents alive is how #780 happened. Both
new hazards are structural, not hypothetical:

- **Persistent-cache eviction under a retained pointer.** A map entry can point into
  `persistent_decoded_textures[...].pixels`. The LRU victim scan skips entries whose `last_use ==
  decode_generation`, and that generation advanced **per span**. An entry used in span 1 was therefore
  evictable in span 5 — a use-after-free once the map outlives the span. `decode_generation` now
  advances **per submit**, so storage a retained pointer refers to cannot be freed under it.
- **Scratch-slot aliasing.** When the persistent cache does not take the pixels, the `texstore`
  scratch slot *is* the storage, and `texstore_used` reset to 0 at every callback. A retained entry
  would have silently started aliasing whatever the next span decoded into that slot — a wrong-pixels
  bug with no crash and no log line. Slots referenced by a retained entry are now pinned and skipped
  by the allocator, and released with the map. Pinning is bounded to entries that can actually outlive
  their span, so a replay submit (where nothing is retainable) does not strand one allocation per
  decode.

## Key completeness

`TextureDecodeKey` is unchanged: it is the same key the **already cross-submit** persistent cache
uses, so its completeness is load-bearing today and this change does not extend that requirement for
persistent-eligible resources. Auditing every `r.<field>` the decode path reads against the key:
`swizzle` only feeds `preserve_narrow_channels` (in the key) and `fr.swizzle` (re-derived per
binding); `alpha_is_on_msb`, `meta_pipe_aligned`, `write_compress_enabled` and `color_transform` are
in `dcc_flags` under the same `compression_enabled` gate that reads them; `srgb` gates only the
compute-image import, which bypasses the map; `declared_mip_levels` is re-derived on both the reuse
and decode paths. Every derived decode input (`native_r8_sampled`, `linear_padded_read`,
`persistent_source_matches_pixels`, tiling/BC sizes, …) is a function of key fields.

One input is **not** in the key and is worth recording: `guest_linear_texture_row_pitch(gpu_addr, …)`
reads the HLE allocation registry. That registry cannot change during one synchronous submit, so it
is safe at this scope; it is a pre-existing consideration for the cross-submit persistent cache, not
something this PR introduces.

## Regression tests (`tests/test_gpu_capture_render.cpp`, ctest `gpu_capture_render_replay`)

Seven policy assertions on `submit_local_texture_decode_reusable`, plus five end-to-end cases driven
through `execute_ordered_items` as **draw → dispatch → draw** (the dispatch is what splits the submit
into two graphics spans, and is also the operation that can rewrite a backing). The textures are
decoded from a **real committed guest mapping** obtained through `sceKernelMapFlexibleMemory`, because
captured replay backing sets `host_data` and is excluded from cross-span retention by construction —
a replay-backed fixture would have tested nothing.

| case | asserts |
|---|---|
| control — dispatch writes an unrelated range | 1 decode, 1 cross-span reuse, 0 invalidations; both spans sample red |
| **invalidation** — dispatch rewrites the sampled backing red→green and reports it | 2 decodes, 0 cross-span reuse, 1 invalidation; **the span after the write renders green, not the cached red** |
| key completeness — same address and extent, `linear_row_pitch_bytes` 8 vs 16 | 2 decodes, 0 cross-span reuse |
| **scratch pinning** — forced mid-submit re-decode leaves pixels in scratch, then a later span decodes a different texture first | `scratch_pins == 1`, and **the retained identity still renders green rather than the other texture's blue** |
| submit boundary — same identity in two separate submits | `invalidations == 0`, the only counter that distinguishes a rebuilt map from one that leaked and was then refused |

The scratch-pinning case exists because the earlier revision's tests could not reach that path at
all: every fixture used a texture the persistent cache accepts, so the pixels were never scratch-
backed. It also doubles as the guard on the per-submit LRU generation, which is what makes
`can_replace` false for the forced re-decode — I had recorded that mechanism as untestable, and the
re-review showed a counter closes it without asserting on use-after-free behaviour.

**Each fails without the fix**, verified by mutation on the exact head:

| mutation | failures |
|---|---|
| `submit_local_texture_decode_reusable` → `return true` | **9**, incl. both pixel assertions |
| `linear_row_pitch_bytes` dropped from the decode key | **1** |
| `pin_scratch` → `false` | **2**, one on pixels |
| `decode_generation` → per-span `++` | **1** |
| submit-boundary rebuild removed | **1** |
| `PROSPER_NO_SUBMIT_TEXTURE_DECODE_SCOPE=1` (span scope restored) | 2 — both reuse counts collapse to the pre-fix 2-decodes-per-identity while the pixel assertions still pass, which is the expected shape: the old behaviour was slow, not wrong |

Note the counters, not pixels, carry the key-completeness case. That is deliberate: the reuse path
re-derives extent and format from the descriptor every time and takes only the **pixel bytes** from
the map, so an under-specified key manifests as a decode that did not happen.

## Diagnostics

- `PROSPER_NO_SUBMIT_TEXTURE_DECODE_SCOPE=1` restores the span-scoped lifetime **on the same build**,
  so a routed A/B measures this change and not two builds' luck.
- `[render-timing] decode_scope decodes=… same_span=… cross_span=… invalidated=… pinned=… scope=submit|span`
  reports the identity-scope accounting per run.
- `PROSPER_RESOURCE_HASH_DIM` keeps the span-scoped lifetime: it reports from inside the decode path,
  so retaining identities across a boundary would drop correlation points a previous build emitted,
  and the instrument would disagree with itself across builds (issue rule 5).

## Deliberately unaffected

Live RTT / depth-stencil authority still bypasses the map. Storage images and compute-imported images
stay excluded. The persistent cache's validation, write-watch promotion, LRU budget, and every
`PROSPER_*` texture diagnostic keep their behavior; `PROSPER_TARGET_STEP_HASH_DIM` still resolves each
draw prefix from scratch (its clear now releases the scratch pins with the map).

## Risks

- Cross-span reuse rests on the in-submit journal being complete for GPU writes. It is the same
  evidence the persistent cache's own in-submit reuse already trusts, and `Unknown`/overflow are
  fail-closed, so the worst case is the pre-#1691 amount of work.
- Guest **CPU** writes from another thread mid-submit are outside this proof — exactly as they are
  outside the span-scoped map's assumption and the persistent cache's `submit_unchanged` path.
  The window widens from one span to one submit; the persistent cache's `validate_exact` /
  `GuestWriteWatch` remain the mechanism for that class.
- `texstore` and `decoded_textures` became `thread_local`. The renderer callback is single-threaded
  (`g_this_submit`, `pending_timing` are already `thread_local`); this removes a latent race rather
  than adding one.

## Scope of the win — read this before the measurement

### Correction to this issue's headline number, and what the fix is actually worth

**The 15.2× in the title and body is a REPLAY figure, not a live one, and it should not be read as
the size of the available win.** That framing is mine to correct, and it is corrected here rather
than only in a handoff, because anyone arriving at this issue will otherwise expect an order of
magnitude.

The issue reports "56 distinct decode identities decoded 853 times in one frame". Those 853 decodes
were counted in offline `.prgbundle` replay, where the persistent decode cache is **disabled by
construction**: `texture_decode_cache_candidate()` requires `!has_captured_host_data`, and every
replay resource carries captured host backing. The issue's own "Explicitly NOT established" section
says exactly this — "the live cost of this amplification is unquantified… the replay measures the
*unabsorbed* cost, which is an upper bound" — but the 15.2× still sits in the title, so in practice
the caveat loses to the headline.

Live, measured on the routed title:

| per submit, Blue Prince heavy scene | value |
|---|---|
| texture references | ~5 500 |
| … served by the span-scoped map already | ~5 420 |
| … reaching the persistent decode cache at all | **76.7** |
| … after this change | **41.3** |

So the span-scoped map was already absorbing ~98.6 % of repeats *within* each span, and the
persistent cache absorbed nearly all of the rest. **The amplification is real, but live it was
already almost entirely paid for.** What submit scope removes is 35.4 persistent-cache resolutions
per submit — a −46.2 % reduction in that term, exact and reproducible across two independently
ordered A/B pairs — not 800-odd decodes.

Measured live frame time: **246.6 → 228.4 ms** and **248.1 → 228.8 ms** across the two pairs, i.e.
~4.04 → ~4.38 submits/s, **−7.5 %**. Not 15×.

### This does not fix the reported ~2 fps

The owner found Blue Prince unplayable and that is not addressed here. #1284 decomposes the same
title's 263.33 ms submit and the frame time still lives where it did:

| term | ms/submit | share |
|---|---|---|
| `draw_setup.resources` | 95.42 | ~36 % |
| `readback` | 79.16 | ~30 % |
| `gpu_wait` | 29.29 | ~11 % |
| `record_upload` | 22.58 | ~9 % |

This change moves a ~7.5 % term and leaves all four of those intact. The title remains CPU-bound in
the frontend, `draw_setup.resources` is still the top term, and the synchronous readback is still the
architectural one. Treat #1691 as one term closed, not as the performance complaint answered.

## Live measurement (acceptance evidence)

## Live measurement — routed Blue Prince, two independently ordered A/B pairs

**Setup.** One binary per pair, arms switched by `PROSPER_NO_SUBMIT_TEXTURE_DECODE_SCOPE=1`. Route:
the documented fresh-save `PROSPER_IME_AUTOKEY=1` boot (`screenshot PPSA25009-app0`, 460 s), both
save roots redirected per run so each arm starts a genuinely new game — the same `savedata_policy:
fresh` the `blue-prince-hall` snapshot uses. **No snapshot acceleration**: `PROSPER_RENDER_SCALE`,
`PROSPER_RENDER_EVERY` and `PROSPER_RENDER_EVERY_FOR_MS` explicitly unset, native 1920×1080, every
graphics submit rendered. Peer GPU consumers sampled every 2 s for the whole of every run.

**Pair 2 was run in the reversed arm order on the final binary**, because the first pair alone could
not distinguish the effect from route variance: the two arms crossed from the light boot phase into
the heavy scene 425 submits apart, so matched submit ordinals are *not* the same scene. Each arm is
therefore summarised over **its own** steady heavy phase (windows ≥150 ms/submit), and any window
whose wall clock overlaps a peer sample is dropped.

| pair | order | arms clean | span-scoped | submit-scoped | delta |
|---|---|---|---|---|---|
| 1 | span → submit | 52/52, 48/56 (8 dropped) | 246.6 ms · 4.05/s | 228.4 ms · 4.38/s | **−7.4 %** |
| 2 | submit → span | 53/53, 55/55 | 248.1 ms · 4.03/s | 228.8 ms · 4.37/s | **−7.8 %** |

Reproducible in sign and magnitude with the arm order reversed, and with the two arms landing in
*opposite* submit ranges between pairs — so it is not route position. Pair 2 had **zero**
peer-contaminated windows in either arm; pair 1's submit arm lost 8 windows to a peer that appeared
in its last ~55 s, which would bias that arm *worse*, not better.

### Work removed — reproducible to the digit across both pairs, and contention-independent

| per submit | span-scoped | submit-scoped | delta |
|---|---|---|---|
| persistent-cache resolutions | 76.7 | 41.3 | **−46.2 %** |
| … of which `hits` | 45.8 | 28.1 | |
| … of which `submit_reuse` | 17.7 | **0.0** | |
| … of which `watch_reuse` | 12.8 | 12.8 | |
| `validations` | 16.5 (1.80 MiB) | 16.5 (1.80 MiB) | 0 % |
| texture references | ~5 500 | ~5 500 | |
| spans | 16.7 | 16.7 | |

`submit_reuse` going to exactly zero is the mechanism working: those references now resolve from the
submit-scoped identity map and never reach the persistent cache's in-submit reuse query at all. Over
a whole run, `decode_scope` reports **3 367 215 cross-span reuses** against 2 450 journal
invalidations.

`validations` is unchanged, which is the honest reading of the #1040 term: exact validation is driven
by cold and genuinely-changed identities, and this change does not touch those.

### Attribution — the gain is NOT in the term I targeted

| per submit | pair 1 span → submit | pair 2 span → submit |
|---|---|---|
| `build_resources` | 47.60 → 47.32 ms | 47.28 → 48.31 ms |
| `texture` (within it) | 7.31 → 7.17 ms | 7.15 → 7.34 ms |
| `backend` | 165.91 → 165.50 ms | 170.3 → 167.3 ms |
| **`pass_control`** | **35.20 → 15.78 ms** | **28.76 → 14.82 ms** |

The direct texture terms are flat. The entire, reproducible ~14–19 ms comes out of `pass_control`
(`pass_ms − build_resources_ms − backend_ms`) — the per-pass work outside resource building and the
backend call. **I do not have a proven mechanism for that**, and I am not going to invent one. The
most plausible candidate is allocator behaviour: the span-scoped arm builds and tears down the
identity map 16.7× per submit instead of once, and the same pass loop allocates an 8.3 MiB frame
buffer per pass, which glibc serves by `mmap` above its dynamic threshold — but that is a hypothesis,
not a measurement. Host cache footprint is byte-identical between arms (16 scratch slots, 111
persistent entries, 574.3 MiB), so it is not a working-set effect.

**Bottom line, stated plainly:** the amplification the issue identified is real and is removed
(−46 % persistent-cache resolutions per submit, reproducible exactly), the routed live frame time
improves ~7.5 % reproducibly across two reversed pairs on a clean box, and the improvement is not
attributable to the texture-binding cost it was predicted to come from. Blue Prince's heavy scene
goes from ~4.04 to ~4.38 submits/s; it is still CPU-bound in the frontend and #1284's
`draw_setup.resources` remains the dominant term.

`scratch_pins = 0` for the entire live run: the pin path this PR adds is a genuine corner (it needs a
mid-submit re-decode of an identity the persistent cache already holds) and carries no live cost or
memory growth — `decode_scratch` stays at 16 slots in both arms.


## Verification

Built and tested in the `ps5ys` distrobox (Vulkan present — `gpu_replay`, the offscreen harness, and
every Vulkan execution test are built; a host build silently omits them):

```
cmake -S prosper -B prosper/build-linux -G Ninja -DGAME_DUMP=.../PPSA24651-app0
cmake --build prosper/build-linux -j24
ctest -j8      ->  100% tests passed, 170/170
```

`ctest` includes `gpu_capture_render_replay` (this PR's guard), `shared_vulkan_device`,
`real_shader_render`, `rdna2_to_spirv_exec`, `live_target_format`, `present_blit`.


## Snapshot suite

Full 14-title matrix, run from this diff. Two guards failed: **`blue-prince-hall`** and
**`terminator-boot`** — exactly the pair #1697 records as failing on **unmodified master**, both
reproduced there before the v0.2.0 release with their retained frames inspected as healthy.

**The metrics for `blue-prince-hall` read as a total collapse and are not one.** Worth stating
explicitly, because the numbers are alarming enough that a future reader will assume a regression:

| metric | measured | guard requires |
|---|---|---|
| `distinct_rgb_colors` | **236** | 40 000 |
| `best_structural_similarity` | **0.005** | 0.85 |
| `nonblack_ratio` | 0.366 | 0.359 (passes) |

236 colours against a 40 000 floor is a black-frame signature. The retained PNG is a **fully
rendered, healthy frame** — the intro cutscene, gramophone and will-reading subtitle, correctly
letterboxed. The route simply had not reached the entrance hall by the 345 s capture window, so the
guard compared a cutscene against hall references; the low colour count is the cel-shaded cutscene
plus large letterbox bars, not damage. This is #1697's described mode ("the Blue Prince intro
cutscene") and `BLUE_PRINCE_STATUS`'s documented #1417 host-load sensitivity, where long 1080p routes
slide past their capture window and photograph an earlier scene. `terminator-boot` likewise shows
healthy attract-mode content. **Open the image before believing the metric** — the charter says so
for exactly this reason, and it applied here.

**`blue-prince-title` PASSED** on this build: same title, same binary, real rendered content, and a
guard that does not depend on reaching the hall. That already excludes a wholesale rendering break on
the title this PR changes. It does not substitute for the discriminator below.

### Discriminating the hall guard on this build

"#1697 says it is known-failing" is not evidence about *this* build, so the guard is being re-run
twice on **one binary**, switching only `PROSPER_NO_SUBMIT_TEXTURE_DECODE_SCOPE`. Same binary removes
the compiler and base variance a master-vs-branch comparison cannot.

The discriminator carries a **witness**, because "it failed identically both ways, so the change is
not the cause" is valid only if the flag did something — and a misspelled or unread env var produces
two identical runs, which is also exactly what a working discriminator produces. Each arm must prove
the flag took effect on evidence that differs *regardless of the guard's verdict*:

| witness | submit-scope arm | span-scope arm | proves |
|---|---|---|---|
| `scope=` | `submit` | `span` | the flag was read at all |
| `cross_span` | > 0 | 0 | behaviour changed, not just a printed string |
| `submit_reuse` | nonzero | 0 | the term this change removes actually moved |

If those do not differ the run is reported **VOID**, not negative. The harness deletes its per-title
log on success, so the run log is mirrored continuously — otherwise a *passing* arm would destroy its
own evidence, which is the same failure mode one level down.

## Review

Independently reviewed. The first review found a **blocking** correctness gap — cross-span reuse did
not re-check that the entry's range is still the binding's range — plus seven non-blocking findings;
all are addressed above and in the comment thread. The re-review approved the corrected head and
found one further real problem: the scratch-pin case passed while covering nothing, because it
reached the pin path only via a mechanism it did not assert. Both are recorded here rather than only
in the thread, because in both cases my own reasoning was wrong in a way the tests did not catch.

#1707 was filed for the pre-existing same-span short-circuit that skips the range comparison; it is
unchanged by this PR.
