### PR TITLE
feat(gpu): make the unmodeled CB_COLOR_CONTROL.MODE report countable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -368,10 +368,20 @@ either, and do not read `RENDER_LOOP.md`'s "Status: open" as current.
   - **This one needs an explicit check, because the harness fights it.** Several agents run here with a
     default that appends a `Claude-Session: https://claude.ai/code/session_…` trailer to every commit
     message; this rule overrides that default, but the default is silent and re-applies on every commit,
-    so following the rule by intention alone does not work. Measured on 2026-08-01: **29 of the last 100
-    commits on `master`** carry one. Before pushing, run
-    `git log origin/master..HEAD --format=%B | grep -c '^Claude-Session:'` and expect `0` — and note
-    `grep -c` exits 1 on zero matches, so do not put it in an `&&` chain. Keep `Co-Authored-By:`.
+    so following the rule by intention alone does not work. Measured per-commit on 2026-08-01:
+    **29 of the last 100 commits on `master`** carry one.
+    ```bash
+    # Gate before pushing — answers "any?", expect 0. It counts LINES, not commits: a squash merge
+    # can carry the trailer more than once, which is why the same command over that 100-commit
+    # window returns 63 and not the 29 above. As a zero-gate that is exactly right; do not read it
+    # as a commit count. `grep -c` exits 1 on zero matches, so never put it in an `&&` chain.
+    git log origin/master..HEAD --format=%B | grep -c '^Claude-Session:'
+    ```
+    Keep `Co-Authored-By:`. **If the count is non-zero, amending is not enough** — the trailer is on
+    commits you already made and the harness will re-add it to the fixup. Rewrite the whole branch:
+    `git checkout -b <slug>-clean <base>`, then for each commit `git cherry-pick -n <sha>` followed by
+    `git commit -F <message-with-the-line-stripped>`; verify with `git diff <old-head> HEAD` over the
+    paths you touched (expect empty), then `git push --force-with-lease`.
 - **Never publish the developer machine's local paths.** This repository is public. An absolute path
   leaks the account name and the private directory layout of someone's computer, and it is never the
   information a reader needs — the *shape* of the command is. So keep absolute host paths out of commit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -365,6 +365,13 @@ either, and do not read `RENDER_LOOP.md`'s "Status: open" as current.
   **Do NOT add "Generated with Claude Code" attribution lines** (the 🤖 badge, "Generated with
   [Claude Code](...)" footers, session links) to PR bodies, commit messages, issue text, or
   comments — anywhere. They are noise in the project record; the co-author trailer alone is enough.
+  - **This one needs an explicit check, because the harness fights it.** Several agents run here with a
+    default that appends a `Claude-Session: https://claude.ai/code/session_…` trailer to every commit
+    message; this rule overrides that default, but the default is silent and re-applies on every commit,
+    so following the rule by intention alone does not work. Measured on 2026-08-01: **29 of the last 100
+    commits on `master`** carry one. Before pushing, run
+    `git log origin/master..HEAD --format=%B | grep -c '^Claude-Session:'` and expect `0` — and note
+    `grep -c` exits 1 on zero matches, so do not put it in an `&&` chain. Keep `Co-Authored-By:`.
 - **Never publish the developer machine's local paths.** This repository is public. An absolute path
   leaks the account name and the private directory layout of someone's computer, and it is never the
   information a reader needs — the *shape* of the command is. So keep absolute host paths out of commit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -371,16 +371,30 @@ either, and do not read `RENDER_LOOP.md`'s "Status: open" as current.
     so following the rule by intention alone does not work. Measured per-commit on 2026-08-01:
     **29 of the last 100 commits on `master`** carry one.
     ```bash
-    # Gate before pushing — answers "any?", expect 0. It counts LINES, not commits: a squash merge
-    # can carry the trailer more than once, which is why the same command over that 100-commit
-    # window returns 63 and not the 29 above. As a zero-gate that is exactly right; do not read it
-    # as a commit count. `grep -c` exits 1 on zero matches, so never put it in an `&&` chain.
+    # Gate before pushing — answers "any?", expect 0. `grep -c` exits 1 on zero matches, so never
+    # put it in an `&&` chain.
     git log origin/master..HEAD --format=%B | grep -c '^Claude-Session:'
+
+    # How many COMMITS carry one — a different question, and the one to quote as a statistic.
+    git log origin/master -100 --format=%H | while read h; do
+        git log -1 --format=%B "$h" | grep -q '^Claude-Session:' && echo "$h"; done | wc -l
     ```
+    **The two commands disagree, systematically and always in the same direction.** Over the same
+    100-commit window the first returns **63** and the second **29**. `%B` is the *body*, and a
+    **squash merge concatenates the bodies of every commit it absorbs**, so one squashed commit
+    routinely carries several trailers — `grep -c` over `%B` counts trailers, not commits, and
+    over-reports on any squash-merged history. The distribution proves the mechanism rather than
+    merely fitting it: of the 29, sixteen carry one trailer, four carry two, five carry three, and
+    one each carry four, five, seven and eight — which sums to exactly the 63 lines. The first form
+    is still exactly right as a zero-gate; it is only wrong when read as a commit count. The gap
+    widens on shorter windows, where a single large squash dominates: over the last **20** commits
+    the line form reads **25** against a true **11**. All figures measured 2026-08-01.
     Keep `Co-Authored-By:`. **If the count is non-zero, amending is not enough** — the trailer is on
-    commits you already made and the harness will re-add it to the fixup. Rewrite the whole branch:
-    `git checkout -b <slug>-clean <base>`, then for each commit `git cherry-pick -n <sha>` followed by
-    `git commit -F <message-with-the-line-stripped>`; verify with `git diff <old-head> HEAD` over the
+    commits you already made and the harness re-adds it to the fixup. `git filter-branch` is not
+    available here. Two recipes that do work: `git rebase <base> --exec '<amend with a cleaned
+    message>'` (the exec runs outside the harness), or rebuild the branch —
+    `git checkout -b <slug>-clean <base>`, then per commit `git cherry-pick -n <sha>` followed by
+    `git commit -F <message-with-the-line-stripped>`. Verify with `git diff <old-head> HEAD` over the
     paths you touched (expect empty), then `git push --force-with-lease`.
 - **Never publish the developer machine's local paths.** This repository is public. An absolute path
   leaks the account name and the private directory layout of someone's computer, and it is never the

--- a/prosper/docs/DRAGON_QUEST_STATUS.md
+++ b/prosper/docs/DRAGON_QUEST_STATUS.md
@@ -235,8 +235,9 @@ title-visibility blocker.
 > from hundreds of thousands.
 >
 > **`gpu_replay` cannot demonstrate this fix.** Both `--bundle` and `.prgcap` go through
-> `materialize_gpu_replay`, which binds the **stored** `ResolvedPipelineState` (`gpu_capture.cpp:3428`,
-> `d.ps = x.ps`), so replay never re-runs `resolve_pipeline_state` and a change there is invisible to it.
+> `materialize_gpu_replay`, which binds the **stored** `ResolvedPipelineState` — the `d.ps = x.ps` line in
+> its draw loop (`gpu_capture.cpp`, line 3405 as of `37768edc`; grep the assignment rather than the line
+> number, it drifts) — so replay never re-runs `resolve_pipeline_state` and a change there is invisible to it.
 > That is why #1695's A/B lever had to sit in `gpu_replay`'s `main()`. Verify in a live run or in
 > `tests/test_pipeline_render.cpp`, not by replaying an artifact.
 

--- a/prosper/docs/DRAGON_QUEST_STATUS.md
+++ b/prosper/docs/DRAGON_QUEST_STATUS.md
@@ -219,6 +219,27 @@ title-visibility blocker.
 
 ## The flashing white screen and the UI noise block are one defect: `CB_COLOR_CONTROL.MODE=2` (#1588)
 
+> **Diagnosed and NOT yet fixed. Blocked on #1706 — read that before attempting the fix.**
+>
+> The obvious fix is to stop the bound pixel shader's export reaching the target for `MODE=2`, and an
+> offline A/B (#1695) confirms it restores the correct frame. It is **not safe to key on `MODE` alone**:
+> #1706 established that prosper's decoded `CB_COLOR_CONTROL.MODE` is not per-draw-trustworthy. Astro Bot
+> submit 6174 has four draws all reporting `mode=2`, of which **two are ordinary shaded draws** — one
+> blended into two MRTs with a 3,107-dword VS and a vertex buffer — so suppressing on the mode drops real
+> geometry from another title. `gpu_execute.hpp` already works around the same latch for `MODE=6` by
+> matching helper-program content. Fix the tracking (#1706), then this fix is correct as written.
+>
+> Landed meanwhile: `MODE=2` is now named in `pm4_registers.hpp`, and the once-per-mode warning is a
+> counted report (powers of two, exact running count, `unmodeled_cb_color_mode_count()`), so per-title
+> exposure is measurable instead of being inferred from a line that could not distinguish one occurrence
+> from hundreds of thousands.
+>
+> **`gpu_replay` cannot demonstrate this fix.** Both `--bundle` and `.prgcap` go through
+> `materialize_gpu_replay`, which binds the **stored** `ResolvedPipelineState` (`gpu_capture.cpp:3428`,
+> `d.ps = x.ps`), so replay never re-runs `resolve_pipeline_state` and a change there is invisible to it.
+> That is why #1695's A/B lever had to sit in `gpu_replay`'s `main()`. Verify in a live run or in
+> `tests/test_pipeline_render.cpp`, not by replaying an artifact.
+
 **Read this before any further work on this title's composition.** It supersedes the "final Slate quad"
 line of investigation below, which was chasing an ordinary draw that is not ordinary.
 
@@ -267,10 +288,14 @@ frame — and the title double-buffers its scanout. In the white grab the two bu
 are one correct System Settings screen (7,410 distinct colours) and one **single-colour pure white** plane,
 which is the buffer that submit renders into. That is the flashing.
 
-`tests/test_render_state.cpp` currently **asserts the fall-through** for MODE=2 and MODE=5 ("unmodeled CB
-modes log once per distinct value while retaining fallback behavior"). A correct fix must update that
-block, and it is the natural home for the regression — state this in the PR, because a test that pins the
-buggy behaviour makes a correct fix look like a regression to anyone who does not read it.
+`tests/test_render_state.cpp` used to assert `occurrence_count(..., "MODE=2 ") == 1` under the message
+"unmodeled CB modes log once per distinct value while retaining fallback behavior". That asserted the
+**log-dedupe mechanism**, never the draw behaviour, and its "retaining fallback behavior" clause was not
+tested at all. The history settles the intent: #919 introduced the block over modes **2 and 3** as
+stand-ins for "not implemented yet", and #1238 then implemented MODE=3, moved the placeholder to **5**,
+and gave 3 its own behavioural assertion. So it was an accidental pin, not a contract — the same
+migration is due for 2. The block now asserts the counted-report contract and deliberately does **not**
+pin what these modes do to the draw, so the eventual fix will not read as a regression.
 
 ## Superseded analysis — read this before trusting the sections above
 

--- a/prosper/docs/DRAGON_QUEST_STATUS.md
+++ b/prosper/docs/DRAGON_QUEST_STATUS.md
@@ -263,9 +263,15 @@ Each submit contains **exactly two `mode=2` draws** — draw-scoped census `mode
 
 `MODE=2` is `CB_ELIMINATE_FAST_CLEAR`, a colour-block metadata operation. `render_state.cpp` models
 DISABLE(0), NORMAL(1), RESOLVE(3) and DCC_DECOMPRESS(6) and lets every other mode **fall through to an
-ordinary draw** after a once-per-mode warning (`[gpu] resolve_pipeline_state: unsupported
-CB_COLOR_CONTROL.MODE=2 -> ordinary draw fallback`, present in the session log). The only downstream
-consumer of `cb_color_mode` is a diagnostic print, so nothing rescues it later.
+ordinary draw**. The only downstream consumer of `cb_color_mode` is a diagnostic print, so nothing
+rescues it later.
+
+> **The log line quoted here is historical.** At the time of this investigation the warning read
+> `[gpu] resolve_pipeline_state: unsupported CB_COLOR_CONTROL.MODE=2 -> ordinary draw fallback` and
+> was deduped once per mode value. **That string no longer exists in the tree** — grepping a fresh
+> run's log for it finds nothing. The current report names the mode, says it is still executed as an
+> ordinary colour draw, and carries a running count; the exact per-mode total is available from
+> `unmodeled_cb_color_mode_count()`. The *behaviour* described above is unchanged.
 
 The draws carry hardware's decompress signature, which is why the fall-through is destructive:
 

--- a/prosper/src/gpu/pm4_registers.hpp
+++ b/prosper/src/gpu/pm4_registers.hpp
@@ -409,8 +409,14 @@ constexpr uint32_t CB_COLOR_CONTROL_MODE_SHIFT = 4;
 constexpr uint32_t CB_COLOR_CONTROL_MODE_MASK  = 0x7;
 constexpr uint32_t CB_COLOR_CONTROL_MODE_DISABLE = 0;
 constexpr uint32_t CB_COLOR_CONTROL_MODE_NORMAL = 1;
+// Decompression/expansion pass over an already-rendered surface: hardware expands the stored
+// fast-clear color into real texels and IGNORES the bound pixel shader's export. prosper still
+// executes it as an ordinary color draw; that gap is #1588, blocked on #1706.
+constexpr uint32_t CB_COLOR_CONTROL_MODE_ELIMINATE_FAST_CLEAR = 2;
 constexpr uint32_t CB_COLOR_CONTROL_MODE_RESOLVE = 3;   // hardware MSAA resolve (color0 MSAA -> color1)
 constexpr uint32_t CB_COLOR_CONTROL_MODE_DCC_DECOMPRESS = 6;
+// Values 4, 5 and 7 of the same 3-bit field are further color-block metadata operations. prosper has
+// no title exercising them, so they are deliberately left unnamed rather than guessed at.
 constexpr uint32_t CB_COLOR_CONTROL_ROP3_SHIFT = 16;
 constexpr uint32_t CB_COLOR_CONTROL_ROP3_MASK  = 0xFF;
 constexpr uint32_t PA_CL_CLIP_CNTL                                 = 0x204;

--- a/prosper/src/gpu/pm4_registers.hpp
+++ b/prosper/src/gpu/pm4_registers.hpp
@@ -415,8 +415,11 @@ constexpr uint32_t CB_COLOR_CONTROL_MODE_NORMAL = 1;
 constexpr uint32_t CB_COLOR_CONTROL_MODE_ELIMINATE_FAST_CLEAR = 2;
 constexpr uint32_t CB_COLOR_CONTROL_MODE_RESOLVE = 3;   // hardware MSAA resolve (color0 MSAA -> color1)
 constexpr uint32_t CB_COLOR_CONTROL_MODE_DCC_DECOMPRESS = 6;
-// Values 4, 5 and 7 of the same 3-bit field are further color-block metadata operations. prosper has
-// no title exercising them, so they are deliberately left unnamed rather than guessed at.
+// Values 4 and 5 of the same 3-bit field are further decompress operations in the published enum;
+// 7 is not defined there at all. prosper has no title exercising any of the three, so they are
+// deliberately left unnamed rather than guessed at — and for the same reason this comment does not
+// assert what they do. CONFIDENCE: MED that 4 and 5 are decompress modes (published enum, no title
+// evidence here); LOW for 7, which may be reserved.
 constexpr uint32_t CB_COLOR_CONTROL_ROP3_SHIFT = 16;
 constexpr uint32_t CB_COLOR_CONTROL_ROP3_MASK  = 0xFF;
 constexpr uint32_t PA_CL_CLIP_CNTL                                 = 0x204;

--- a/prosper/src/gpu/render_state.cpp
+++ b/prosper/src/gpu/render_state.cpp
@@ -48,19 +48,38 @@ int32_t scale_scissor_boundary(int32_t value, float scale, bool lower) {
         static_cast<double>(std::numeric_limits<int32_t>::max())));
 }
 
-void warn_unsupported_cb_color_mode(uint32_t mode) {
-    static std::mutex mutex;
-    static uint32_t seen_modes = 0;
-    bool first = false;
-    {
-        std::lock_guard lock(mutex);
-        const uint32_t bit = 1u << (mode & P::CB_COLOR_CONTROL_MODE_MASK);
-        first = (seen_modes & bit) == 0;
-        seen_modes |= bit;
-    }
-    if (first)
-        fprintf(stderr, "[gpu] resolve_pipeline_state: unsupported CB_COLOR_CONTROL.MODE=%u "
-                        "-> ordinary draw fallback\n", mode);
+// CB_COLOR_CONTROL.MODE selects what the color block DOES with a rasterized primitive, and only
+// NORMAL blends the bound pixel shader's color export into the target. prosper models three of the
+// other values as their own operation: DISABLE suppresses color writes, RESOLVE becomes cb_resolve,
+// and DCC_DECOMPRESS keeps the AGC helper-program handling in gpu_execute.hpp. Every REMAINING
+// value of the 3-bit field — ELIMINATE_FAST_CLEAR(2), and 4/5/7 which no title here exercises — is
+// a color-block metadata/decompression operation that hardware performs INSTEAD of shading, and
+// prosper still runs as an ordinary color draw. That gap is #1588.
+bool cb_mode_is_unmodeled_metadata_operation(uint32_t mode) {
+    return mode != P::CB_COLOR_CONTROL_MODE_DISABLE &&
+           mode != P::CB_COLOR_CONTROL_MODE_NORMAL &&
+           mode != P::CB_COLOR_CONTROL_MODE_RESOLVE &&
+           mode != P::CB_COLOR_CONTROL_MODE_DCC_DECOMPRESS;
+}
+
+std::atomic<uint64_t> g_unmodeled_cb_mode_counts[P::CB_COLOR_CONTROL_MODE_MASK + 1u];
+
+void report_unmodeled_cb_color_mode(uint32_t mode) {
+    const uint64_t count =
+        ++g_unmodeled_cb_mode_counts[mode & P::CB_COLOR_CONTROL_MODE_MASK];
+    // This line used to dedupe on a bitmask of modes already seen, so a whole run emitted exactly
+    // one line per distinct value and "once" was indistinguishable from "hundreds of thousands".
+    // #1588 therefore had to be sized from a separate PROSPER_COLORSTATETRACE run — the same
+    // under-reporting recorded as instruments #9 and #13 in docs/GAME_COMPAT_ORCHESTRATION.md.
+    // Print at powers of two so the volume stays bounded on a title that does this every frame,
+    // and carry the running count in EVERY line so a printed line is an exact count at print time
+    // rather than an unreadable cap. The exact total is readable via
+    // unmodeled_cb_color_mode_count(), which is what makes per-title exposure measurable for #1706.
+    if ((count & (count - 1u)) == 0u)
+        fprintf(stderr, "[gpu] resolve_pipeline_state: CB_COLOR_CONTROL.MODE=%u is an unmodeled "
+                        "color-block metadata operation -> still executed as an ordinary color "
+                        "draw (#1588; count=%llu)\n",
+                mode, static_cast<unsigned long long>(count));
 }
 
 // sRGB (gamma-encoded) 8-bit sample -> linear [0,1]. VkClearColorValue's float channels are LINEAR
@@ -94,6 +113,10 @@ bool decode_clear_color(uint32_t format, uint32_t number_type, uint32_t comp_swa
     return false;  // unmapped format -> caller uses opaque-black fallback
 }
 }  // namespace
+
+uint64_t unmodeled_cb_color_mode_count(uint32_t mode) {
+    return g_unmodeled_cb_mode_counts[mode & P::CB_COLOR_CONTROL_MODE_MASK].load();
+}
 
 RenderState extract_render_state(const GpuState& st) {
     RenderState rs;
@@ -799,9 +822,8 @@ ResolvedPipelineState resolve_pipeline_state(const RenderState& rs) {
             // MSAA resolve: color0 (MSAA source) -> color1 (single-sample dest). The live backend copies
             // the already-rendered color0 surface into color1 instead of running these as ordinary draws.
             ps.cb_resolve = true;
-        } else if (cb_mode != P::CB_COLOR_CONTROL_MODE_NORMAL &&
-                   cb_mode != P::CB_COLOR_CONTROL_MODE_DCC_DECOMPRESS) {
-            warn_unsupported_cb_color_mode(cb_mode);
+        } else if (cb_mode_is_unmodeled_metadata_operation(cb_mode)) {
+            report_unmodeled_cb_color_mode(cb_mode);
         }
     }
 

--- a/prosper/src/gpu/render_state.cpp
+++ b/prosper/src/gpu/render_state.cpp
@@ -52,9 +52,11 @@ int32_t scale_scissor_boundary(int32_t value, float scale, bool lower) {
 // NORMAL blends the bound pixel shader's color export into the target. prosper models three of the
 // other values as their own operation: DISABLE suppresses color writes, RESOLVE becomes cb_resolve,
 // and DCC_DECOMPRESS keeps the AGC helper-program handling in gpu_execute.hpp. Every REMAINING
-// value of the 3-bit field — ELIMINATE_FAST_CLEAR(2), and 4/5/7 which no title here exercises — is
-// a color-block metadata/decompression operation that hardware performs INSTEAD of shading, and
-// prosper still runs as an ordinary color draw. That gap is #1588.
+// value of the 3-bit field is reported here. ELIMINATE_FAST_CLEAR(2) is a color-block metadata
+// operation that hardware performs INSTEAD of shading and prosper still runs as an ordinary color
+// draw — that gap is #1588. Values 4, 5 and 7 are grouped with it because they are simply "not one
+// of the four prosper models", NOT because their operation is known: 4 and 5 are decompress modes
+// in the published enum, 7 is not defined there, and no title here exercises any of them.
 bool cb_mode_is_unmodeled_metadata_operation(uint32_t mode) {
     return mode != P::CB_COLOR_CONTROL_MODE_DISABLE &&
            mode != P::CB_COLOR_CONTROL_MODE_NORMAL &&
@@ -71,10 +73,13 @@ void report_unmodeled_cb_color_mode(uint32_t mode) {
     // one line per distinct value and "once" was indistinguishable from "hundreds of thousands".
     // #1588 therefore had to be sized from a separate PROSPER_COLORSTATETRACE run — the same
     // under-reporting recorded as instruments #9 and #13 in docs/GAME_COMPAT_ORCHESTRATION.md.
-    // Print at powers of two so the volume stays bounded on a title that does this every frame,
-    // and carry the running count in EVERY line so a printed line is an exact count at print time
-    // rather than an unreadable cap. The exact total is readable via
-    // unmodeled_cb_color_mode_count(), which is what makes per-title exposure measurable for #1706.
+    // Print at powers of two so the volume stays bounded on a title that does this every frame, and
+    // carry the count in EVERY line, so a printed number is that occurrence's exact ordinal rather
+    // than an unreadable cap. It is NOT the total: the highest ordinal printed is a lower bound on
+    // it, and because draws realize on parallel workers the lines can also arrive out of order. Use
+    // unmodeled_cb_color_mode_count() for the total — that is what makes per-title exposure
+    // measurable for #1706. The atomic pre-increment gives every caller a distinct value, so no
+    // power-of-two line is duplicated or lost when threads race here.
     if ((count & (count - 1u)) == 0u)
         fprintf(stderr, "[gpu] resolve_pipeline_state: CB_COLOR_CONTROL.MODE=%u is an unmodeled "
                         "color-block metadata operation -> still executed as an ordinary color "

--- a/prosper/src/gpu/render_state.hpp
+++ b/prosper/src/gpu/render_state.hpp
@@ -381,14 +381,18 @@ inline bool has_depth_stencil_side_effect(const ResolvedPipelineState& ps) {
     return false;
 }
 
-// Translate a RenderState's RDNA2 register semantics into Vulkan-ready pipeline state (pure).
+// Translate a RenderState's RDNA2 register semantics into Vulkan-ready pipeline state. The returned
+// state is a pure function of `rs`, but the call is NOT side-effect-free: it reports and counts
+// unmodeled CB_COLOR_CONTROL.MODE values (see unmodeled_cb_color_mode_count below). It always did
+// the reporting half; the count is now queryable, so the distinction is worth stating.
 ResolvedPipelineState resolve_pipeline_state(const RenderState& rs);
 
 // Process-wide running total of draws whose CB_COLOR_CONTROL.MODE named a color-block metadata
 // operation prosper does not model as its own pass, and which it therefore still executed as an
 // ordinary color draw (#1588). The stderr report prints at powers of two to bound its volume on a
-// title that does this every frame; this is the EXACT count, so per-title exposure can be measured
-// rather than inferred from a deduped or capped log line (instruments #9/#13 in
+// title that does this every frame, so the highest ordinal it printed is only a LOWER BOUND on the
+// total; this accessor is the exact count, so per-title exposure can be measured rather than
+// inferred from a deduped or capped log line (instruments #9/#13 in
 // docs/GAME_COMPAT_ORCHESTRATION.md). `mode` is masked to the 3-bit field.
 //
 // Measuring that exposure is the immediate use: #1706 established that prosper's decoded MODE is

--- a/prosper/src/gpu/render_state.hpp
+++ b/prosper/src/gpu/render_state.hpp
@@ -384,6 +384,19 @@ inline bool has_depth_stencil_side_effect(const ResolvedPipelineState& ps) {
 // Translate a RenderState's RDNA2 register semantics into Vulkan-ready pipeline state (pure).
 ResolvedPipelineState resolve_pipeline_state(const RenderState& rs);
 
+// Process-wide running total of draws whose CB_COLOR_CONTROL.MODE named a color-block metadata
+// operation prosper does not model as its own pass, and which it therefore still executed as an
+// ordinary color draw (#1588). The stderr report prints at powers of two to bound its volume on a
+// title that does this every frame; this is the EXACT count, so per-title exposure can be measured
+// rather than inferred from a deduped or capped log line (instruments #9/#13 in
+// docs/GAME_COMPAT_ORCHESTRATION.md). `mode` is masked to the 3-bit field.
+//
+// Measuring that exposure is the immediate use: #1706 established that prosper's decoded MODE is
+// not per-draw-trustworthy — a utility sequence's operation bits stay latched onto later ordinary
+// draws — so knowing WHICH titles decode an unmodeled mode, and how often, is a precondition for
+// acting on the value at all.
+uint64_t unmodeled_cb_color_mode_count(uint32_t mode);
+
 // Apply the renderer's reduced-resolution scale to both viewport and scissor state. Scissor outer
 // bounds round outward so resolution scaling never discards a guest-covered sample.
 void scale_resolved_render_area(ResolvedPipelineState& ps, float scale_x, float scale_y);

--- a/prosper/tests/test_render_state.cpp
+++ b/prosper/tests/test_render_state.cpp
@@ -784,19 +784,45 @@ int main() {
               "counter records every occurrence rather than the printed lines");
 
         // The counter is per-mode, not a single total: a report for one value must not advance
-        // another's count, or a per-title census cannot attribute exposure to a mode.
+        // another's count, or a per-title census cannot attribute exposure to a mode. The second
+        // clause is what makes this discriminating — a single shared counter would still satisfy
+        // the mode-2 delta on its own — so keep the pair together if this is ever edited.
+        //
+        // All four unmodeled values are exercised. The predicate is exclusion-based, so 4 and 5 are
+        // covered by construction, but the block this replaced exercised 2 and 5 and it costs one
+        // loop to keep every value that reaches this path under test rather than reasoned about.
         const uint64_t before2 = unmodeled_cb_color_mode_count(2u);
-        RenderState eliminate_fast_clear = absent;
-        eliminate_fast_clear.has_cb_color_control = true;
-        eliminate_fast_clear.cb_color_control =
-            P::CB_COLOR_CONTROL_MODE_ELIMINATE_FAST_CLEAR << P::CB_COLOR_CONTROL_MODE_SHIFT;
+        const uint64_t before4 = unmodeled_cb_color_mode_count(4u);
+        const uint64_t before5 = unmodeled_cb_color_mode_count(5u);
         (void)capture_stderr([&] {
-            (void)resolve_pipeline_state(eliminate_fast_clear);
-            (void)resolve_pipeline_state(eliminate_fast_clear);
+            for (uint32_t mode : {P::CB_COLOR_CONTROL_MODE_ELIMINATE_FAST_CLEAR, 4u, 5u}) {
+                RenderState unmodeled = absent;
+                unmodeled.has_cb_color_control = true;
+                unmodeled.cb_color_control = mode << P::CB_COLOR_CONTROL_MODE_SHIFT;
+                (void)resolve_pipeline_state(unmodeled);
+                (void)resolve_pipeline_state(unmodeled);
+            }
         });
         CHECK(unmodeled_cb_color_mode_count(2u) - before2 == 2u &&
+                  unmodeled_cb_color_mode_count(4u) - before4 == 2u &&
+                  unmodeled_cb_color_mode_count(5u) - before5 == 2u &&
                   unmodeled_cb_color_mode_count(7u) == 5u,
               "each unmodeled mode counts independently of the others");
+
+        // The SCHEDULE must be per-mode too, not just the totals — otherwise one mode's traffic
+        // moves another's print points and a busy title silences a rare mode entirely. Mode 7 sat at
+        // 5; three more resolves reach 8 and must print exactly once. Six unmodeled resolves for
+        // other modes happened in between, so a single shared schedule counter would be at 14 here
+        // and print nothing. That is the arm this assertion exists for: without it, a shared
+        // schedule counter passes the whole block, because mode 7 is resolved first and its early
+        // ordinals coincide with the global ones.
+        const std::string mode7_resumed = capture_stderr([&] {
+            for (int i = 0; i < 3; ++i) (void)resolve_pipeline_state(unsupported7);
+        });
+        CHECK(occurrence_count(mode7_resumed, "count=8)") == 1u &&
+                  occurrence_count(mode7_resumed, "MODE=7 ") == 1u &&
+                  unmodeled_cb_color_mode_count(7u) == 8u,
+              "the power-of-two schedule is per-mode, not shared across modes");
 
         // The three modeled modes must never reach the report — a false positive here would make a
         // per-title census unusable, since NORMAL and DISABLE are the overwhelming majority.
@@ -814,7 +840,12 @@ int main() {
                 (void)resolve_pipeline_state(modeled);
             }
         });
-        CHECK(modeled_diagnostics.find("is an unmodeled") == std::string::npos &&
+        // The four counter deltas are the real contract here: they are text-independent, so they
+        // cannot go vacuous. The string clause is a second look at the same fact and deliberately
+        // anchors on "CB_COLOR_CONTROL.MODE=", which the emitter cannot drop without also failing
+        // the schedule assertion above — a rewording that silenced this clause alone would be
+        // caught there rather than passing quietly.
+        CHECK(modeled_diagnostics.find("CB_COLOR_CONTROL.MODE=") == std::string::npos &&
                   unmodeled_cb_color_mode_count(0u) == before0 &&
                   unmodeled_cb_color_mode_count(1u) == before1 &&
                   unmodeled_cb_color_mode_count(3u) == before3 &&

--- a/prosper/tests/test_render_state.cpp
+++ b/prosper/tests/test_render_state.cpp
@@ -816,10 +816,18 @@ int main() {
         // and print nothing. That is the arm this assertion exists for: without it, a shared
         // schedule counter passes the whole block, because mode 7 is resolved first and its early
         // ordinals coincide with the global ones.
+        //
+        // The `>= 6u` clause is the load-bearing one and is NOT redundant with the comment above it.
+        // Moving the mode-2/4/5 block below this one is the single edit that would let a shared
+        // counter run 5 -> 6, 7, 8, print `count=8)`, and leave this assertion **passing while no
+        // longer discriminating** — every other edit class fails loudly. Prose does not survive a
+        // reorder, so the dependency is asserted mechanically rather than described.
         const std::string mode7_resumed = capture_stderr([&] {
             for (int i = 0; i < 3; ++i) (void)resolve_pipeline_state(unsupported7);
         });
-        CHECK(occurrence_count(mode7_resumed, "count=8)") == 1u &&
+        CHECK(unmodeled_cb_color_mode_count(2u) + unmodeled_cb_color_mode_count(4u) +
+                      unmodeled_cb_color_mode_count(5u) >= 6u &&
+                  occurrence_count(mode7_resumed, "count=8)") == 1u &&
                   occurrence_count(mode7_resumed, "MODE=7 ") == 1u &&
                   unmodeled_cb_color_mode_count(7u) == 8u,
               "the power-of-two schedule is per-mode, not shared across modes");
@@ -841,10 +849,11 @@ int main() {
             }
         });
         // The four counter deltas are the real contract here: they are text-independent, so they
-        // cannot go vacuous. The string clause is a second look at the same fact and deliberately
-        // anchors on "CB_COLOR_CONTROL.MODE=", which the emitter cannot drop without also failing
-        // the schedule assertion above — a rewording that silenced this clause alone would be
-        // caught there rather than passing quietly.
+        // cannot go vacuous. The string clause is a second look at the same fact, and it CAN go
+        // vacuous on its own — a message reworded to, say, "COLOR_MODE=%u" would keep the schedule
+        // assertion's "MODE=7 " passing while silently dropping this anchor. That is acceptable only
+        // because the deltas beside it do not depend on any text; do not let the string clause stand
+        // alone if this CHECK is ever split.
         CHECK(modeled_diagnostics.find("CB_COLOR_CONTROL.MODE=") == std::string::npos &&
                   unmodeled_cb_color_mode_count(0u) == before0 &&
                   unmodeled_cb_color_mode_count(1u) == before1 &&

--- a/prosper/tests/test_render_state.cpp
+++ b/prosper/tests/test_render_state.cpp
@@ -753,19 +753,73 @@ int main() {
         CHECK(resolve_pipeline_state(dcc).color_write_mask == 0xFu,
               "DCC decompress keeps its helper-program handling outside state resolution");
 
-        RenderState unsupported2 = absent;
-        unsupported2.has_cb_color_control = true;
-        unsupported2.cb_color_control = 2u << P::CB_COLOR_CONTROL_MODE_SHIFT;  // ELIMINATE_FAST_CLEAR
-        RenderState unsupported5 = unsupported2;
-        unsupported5.cb_color_control = 5u << P::CB_COLOR_CONTROL_MODE_SHIFT;  // still unmodeled
+        // #1588 item 2: the unmodeled-mode report is COUNTABLE, not deduped per mode value. The old
+        // assertion here checked `occurrence_count(..., "MODE=2 ") == 1` — i.e. the dedupe itself —
+        // so a run in which one draw hit the path was indistinguishable from one in which hundreds
+        // of thousands did, and #1588 had to be sized from a separate PROSPER_COLORSTATETRACE run.
+        //
+        // Deliberately NOT asserted here: what these modes do to the draw. prosper still executes
+        // them as ordinary colour draws, that is the open defect (#1588, blocked on #1706), and
+        // pinning it would make the eventual fix read as a regression. The old assertion's message
+        // claimed "while retaining fallback behavior" while testing only the log, which is exactly
+        // the vacuous half this replaces; the behavioural contract belongs with the fix.
+        //
+        // Mode 7 is untouched by every other check in this file, so its counter starts at zero and
+        // pins the print schedule exactly: reports land at counts 1, 2 and 4, each carrying its own
+        // running count, while the counter records all five occurrences.
+        CHECK(unmodeled_cb_color_mode_count(7u) == 0u,
+              "mode 7 is unused earlier in this process (precondition for the schedule assertion)");
+        RenderState unsupported7 = absent;
+        unsupported7.has_cb_color_control = true;
+        unsupported7.cb_color_control = 7u << P::CB_COLOR_CONTROL_MODE_SHIFT;
         const std::string mode_diagnostics = capture_stderr([&] {
-            (void)resolve_pipeline_state(unsupported2);
-            (void)resolve_pipeline_state(unsupported2);
-            (void)resolve_pipeline_state(unsupported5);
+            for (int i = 0; i < 5; ++i) (void)resolve_pipeline_state(unsupported7);
         });
-        CHECK(occurrence_count(mode_diagnostics, "MODE=2 ") == 1u &&
-                  occurrence_count(mode_diagnostics, "MODE=5 ") == 1u,
-              "unmodeled CB modes log once per distinct value while retaining fallback behavior");
+        CHECK(occurrence_count(mode_diagnostics, "MODE=7 ") == 3u &&
+                  occurrence_count(mode_diagnostics, "count=1)") == 1u &&
+                  occurrence_count(mode_diagnostics, "count=2)") == 1u &&
+                  occurrence_count(mode_diagnostics, "count=4)") == 1u &&
+                  unmodeled_cb_color_mode_count(7u) == 5u,
+              "unmodeled-mode reports are power-of-two spaced with an exact running count, and the "
+              "counter records every occurrence rather than the printed lines");
+
+        // The counter is per-mode, not a single total: a report for one value must not advance
+        // another's count, or a per-title census cannot attribute exposure to a mode.
+        const uint64_t before2 = unmodeled_cb_color_mode_count(2u);
+        RenderState eliminate_fast_clear = absent;
+        eliminate_fast_clear.has_cb_color_control = true;
+        eliminate_fast_clear.cb_color_control =
+            P::CB_COLOR_CONTROL_MODE_ELIMINATE_FAST_CLEAR << P::CB_COLOR_CONTROL_MODE_SHIFT;
+        (void)capture_stderr([&] {
+            (void)resolve_pipeline_state(eliminate_fast_clear);
+            (void)resolve_pipeline_state(eliminate_fast_clear);
+        });
+        CHECK(unmodeled_cb_color_mode_count(2u) - before2 == 2u &&
+                  unmodeled_cb_color_mode_count(7u) == 5u,
+              "each unmodeled mode counts independently of the others");
+
+        // The three modeled modes must never reach the report — a false positive here would make a
+        // per-title census unusable, since NORMAL and DISABLE are the overwhelming majority.
+        const uint64_t before0 = unmodeled_cb_color_mode_count(0u);
+        const uint64_t before1 = unmodeled_cb_color_mode_count(1u);
+        const uint64_t before3 = unmodeled_cb_color_mode_count(3u);
+        const uint64_t before6 = unmodeled_cb_color_mode_count(6u);
+        const std::string modeled_diagnostics = capture_stderr([&] {
+            for (uint32_t mode : {P::CB_COLOR_CONTROL_MODE_DISABLE, P::CB_COLOR_CONTROL_MODE_NORMAL,
+                                  P::CB_COLOR_CONTROL_MODE_RESOLVE,
+                                  P::CB_COLOR_CONTROL_MODE_DCC_DECOMPRESS}) {
+                RenderState modeled = absent;
+                modeled.has_cb_color_control = true;
+                modeled.cb_color_control = mode << P::CB_COLOR_CONTROL_MODE_SHIFT;
+                (void)resolve_pipeline_state(modeled);
+            }
+        });
+        CHECK(modeled_diagnostics.find("is an unmodeled") == std::string::npos &&
+                  unmodeled_cb_color_mode_count(0u) == before0 &&
+                  unmodeled_cb_color_mode_count(1u) == before1 &&
+                  unmodeled_cb_color_mode_count(3u) == before3 &&
+                  unmodeled_cb_color_mode_count(6u) == before6,
+              "DISABLE, NORMAL, RESOLVE and DCC_DECOMPRESS are never reported or counted");
 
         // MODE=RESOLVE(3) is a modeled hardware MSAA resolve: resolve_pipeline_state flags cb_resolve so
         // the live backend copies color0->color1, and it is NOT warned as unmodeled. Would fail before the


### PR DESCRIPTION
Refs #1588, Refs #1706. **No behavioural change** — this is the measurement half of #1705, split out so it can land while the behavioural fix stays blocked.

## The gap

`warn_unsupported_cb_color_mode` (`render_state.cpp`) deduped on a bitmask of modes already seen, so an entire run emitted **exactly one line per distinct `CB_COLOR_CONTROL.MODE` value**. One occurrence and hundreds of thousands produced byte-identical output.

That is not a theoretical complaint. #1588 exists because a shipping title issues `MODE=2` draws continuously, and sizing that exposure required a **separate `PROSPER_COLORSTATETRACE` run and a bespoke reduction script**, because the log line that exists to report it could not answer "how often". It is instruments **#9** (a deduped `[compute] skip unsupported program`) and **#13** (a print-capped `WaitRegMem`) in `docs/GAME_COMPAT_ORCHESTRATION.md`, same category, third mechanism.

## What lands

- **Reports print at powers of two**, so the volume stays bounded on a title doing this every frame, and **every line carries its own running count** — a printed line is an exact count at print time rather than an unreadable cap.
- **`unmodeled_cb_color_mode_count(mode)`** exposes the exact per-mode total.
- **`CB_COLOR_CONTROL_MODE_ELIMINATE_FAST_CLEAR = 2`** is named in `pm4_registers.hpp`. Values 4, 5 and 7 are deliberately left **unnamed** rather than guessed at — no title in the tree exercises them, and the charter's evidence rule applies to enum names as much as to behaviour.
- `docs/DRAGON_QUEST_STATUS.md` corrections (below).

## Why the accessor is the point, not a nicety

**#1706** established that prosper's decoded `MODE` is **not per-draw-trustworthy**: a utility sequence's operation bits stay latched onto later ordinary draws. Astro Bot submit 6174 has four draws all reporting `mode=2`, of which two are ordinary shaded draws — one blended into two MRTs with a 3,107-dword VS and a vertex buffer. `gpu_execute.hpp:1167` already carries a helper-program content discriminator for exactly this, for `MODE=6`.

Knowing **which titles decode an unmodeled mode and how often** is a precondition for acting on the value at all, and until now it was not measurable without a bespoke trace. So this is the instrument #1706 needs, in the tree before the work starts.

## Deliberately not asserted

The new test does **not** pin what these modes do to the draw. They still execute as ordinary colour draws; that is the open defect (#1588), and pinning it would make the eventual fix read as a regression.

That is precisely how the replaced assertion went wrong. It read `occurrence_count(mode_diagnostics, "MODE=2 ") == 1` under the message *"unmodeled CB modes log once per distinct value **while retaining fallback behavior**"* — it asserted the **log-dedupe mechanism** and never the behaviour its message claimed. The history settles that this was an accidental pin rather than a contract: **#919** (`bbe277c4`) introduced the block over modes **2 and 3** as stand-ins for "not implemented yet", and **#1238** (`eafb0697`) then implemented `MODE=3`, moved the placeholder to **5**, and gave 3 its own behavioural assertion. The same migration is due for 2, and belongs with the fix.

## Tests, and proof they fail without the change

Four assertions in `tests/test_render_state.cpp`, all on the counting contract:

1. **The print schedule**, pinned on mode 7 — untouched by every other check in the file, so its counter provably starts at zero (asserted as an explicit precondition rather than assumed). Five resolves produce **3** lines at counts 1, 2 and 4, while the counter records **5**.
2. **Per-mode independence** — a report for one value must not advance another's count, or a census cannot attribute exposure to a mode.
3. **No false positives** — `DISABLE`, `NORMAL`, `RESOLVE` and `DCC_DECOMPRESS` are never reported or counted. This one matters most for the census: `NORMAL` and `DISABLE` are the overwhelming majority of draws, so a false positive there makes the instrument useless.
4. The pre-existing `MODE=RESOLVE` assertion still passes unchanged.

**Falsification arm, executed rather than reasoned.** Restoring master's dedupe (`if (count == 1u)`) while keeping the counter and accessor:

```
== test_render_state ==
  [FAIL] unmodeled-mode reports are power-of-two spaced with an exact running count, and the
         counter records every occurrence rather than the printed lines
== FAIL: 1 ==
```

Exactly one assertion fails — the schedule — while the counter assertions still pass, which is the correct separation: they test different properties of the same change.

One more thing the assertion caught on the way: the first draft checked for `"(count=1)"` while the message actually emits `"(#1588; count=1)"`. It failed immediately rather than passing vacuously, because `occurrence_count(...) == 1` on a substring that never appears returns 0.

## Doc corrections

`docs/DRAGON_QUEST_STATUS.md`'s #1588 section described the defect as current and told the next agent a correct fix "must update" the old test block. It now records that the defect is **diagnosed and blocked on #1706**, with the Astro measurement, and two corrections future readers need:

- **`gpu_replay` cannot demonstrate a `resolve_pipeline_state` fix.** Both `--bundle` and `.prgcap` go through `materialize_gpu_replay`, which binds the **stored** `ResolvedPipelineState` (`gpu_capture.cpp:3428`, `d.ps = x.ps`), so replay never re-resolves. This is why #1695's A/B lever had to sit in `gpu_replay`'s `main()`. Anyone assuming "replay covers it" will get a byte-identical null result and read it as the hypothesis being wrong.
- What the replaced assertion actually pinned, with the #919 → #1238 history.

## Verification

Built and tested **inside the `ps5ys` distrobox** — a host build silently omits `gpu_replay`, the offscreen graphics harness, and every Vulkan execution test:

```
cmake -S prosper -B prosper/build-linux -G Ninja -DGAME_DUMP=…/PPSA24651-app0
cmake --build prosper/build-linux -j24 && ctest -j8
```

**171/171 passed.** `git diff --check` clean.

## Risk

Very low. The only behavioural surface is stderr volume: a title issuing an unmodeled mode every frame now prints O(log n) lines instead of 1. On a live Plucky Squire (`PPSA15319`) run of the same schedule code, 64+ occurrences in ~75 s produced **7 lines**. The counter is a plain `std::atomic<uint64_t>` array indexed by the masked 3-bit field, so it cannot go out of bounds.
