### PR TITLE
perf(render): size the backend host-buffer pool from host RAM and evict LRU (#1284)

### DIFF
--- a/prosper/docs/BLUE_PRINCE_STATUS.md
+++ b/prosper/docs/BLUE_PRINCE_STATUS.md
@@ -80,12 +80,14 @@ The `blue-prince-title` snapshot route guards the title screen.
   promote it to an explanation. Host cache footprint is byte-identical between arms (16 scratch
   slots, 111 persistent entries, 574.3 MiB), so it is not a working-set effect.
 
-  **This does not address the reported ~2 fps.** #1284 still decomposes the same title's 263.33 ms
-  submit as `draw_setup.resources` 95.42 + `readback` 79.16 + `gpu_wait` 29.29 + `record_upload`
-  22.58 ms; this change moves a ~7.5 % term and leaves all four intact. The title remains CPU-bound
-  in the frontend. Note also that the issue's headline **15.2x is a replay figure** — the persistent
-  decode cache is disabled by construction in replay — and live only ~77 of ~5,500 texture
-  references per submit ever reached it.
+  **This does not address the reported ~2 fps.** At the time this landed, #1284 decomposed the same
+  title's submit as 263.33 ms = `draw_setup.resources` 95.42 + `readback` 79.16 + `gpu_wait` 29.29 +
+  `record_upload` 22.58; this change moved a ~7.5 % term and left all four intact. Note also that the
+  issue's headline **15.2x is a replay figure** — the persistent decode cache is disabled by
+  construction in replay — and live only ~77 of ~5,500 texture references per submit ever reached it.
+  **Those four numbers are now superseded**: re-measured 2026-08-02 (see the #1284 bullet below), three
+  of the four have collapsed and only `draw_setup` remains. The title is still CPU-bound in the
+  frontend, which is the part of this paragraph that held.
 
 - **#1284 (open) — the frame-time term is backend storage-buffer upload, not textures or
   descriptors.** Re-measured on `3a473bca` (post-#1292, post-#1703), 35 peer-free heavy windows:

--- a/prosper/docs/BLUE_PRINCE_STATUS.md
+++ b/prosper/docs/BLUE_PRINCE_STATUS.md
@@ -105,6 +105,15 @@ The `blue-prince-title` snapshot route guards the title screen.
   per-draw `getenv`, the #1268 content hash) are in
   `docs/RENDERER_PERFORMANCE_2026_07.md` § *Blue Prince 3D submit decomposition, re-measured*.
 
+  **The immediately actionable part: `PROSPER_BACKEND_BUFFER_POOL_MB` defaults to 256 MiB and this
+  title's host-staging working set is 974 MiB**, so the pool thrashes — evictions exactly equal
+  misses (~216k each) and one buffer is destroyed for every one created. A four-arm alternating A/B
+  (256/2048/256/2048, one binary) takes the submit from 203.06 to 125.98 ms, **−34.8 % normalised
+  per draw**, with `res_buffer` −63 % and `cleanup` −80 %; at 2048 MiB the pool settles at 974 MiB /
+  503 buffers with **zero** evictions. All arms were contended, so confirm the magnitude on a clean
+  box before quoting it. The fix (memory-aware default + LRU eviction) cannot change rendered
+  output — the same bytes are uploaded from the same sources; only host staging recycling changes.
+
 ## Defect families (#1287) — families 1–3 and 5 RESOLVED 2026-07-26
 
 Families 1–3 and 5 below are **fixed on master**; they are retained as the resolution record so

--- a/prosper/docs/BLUE_PRINCE_STATUS.md
+++ b/prosper/docs/BLUE_PRINCE_STATUS.md
@@ -87,6 +87,22 @@ The `blue-prince-title` snapshot route guards the title screen.
   decode cache is disabled by construction in replay — and live only ~77 of ~5,500 texture
   references per submit ever reached it.
 
+- **#1284 (open) — the frame-time term is backend storage-buffer upload, not textures or
+  descriptors.** Re-measured on `3a473bca` (post-#1292, post-#1703), 35 peer-free heavy windows:
+  the backend submit is **165.18 ms** (was 263.33 in the issue body), and **every term that
+  decomposition named has collapsed except `draw_setup`** — `readback` 79.16 -> 14.71,
+  `record_upload` 22.58 -> 2.73, `gpu_wait` 29.29 -> 6.71, fence waits 61 -> 16.3, while
+  `draw_setup` is 119.87 -> 126.81 at 1.39x the draws. `gpu_device` is **4.31 ms inside 165 ms**, so
+  the GPU is 2.6 % busy and this title is bound in prosper's own per-draw CPU path.
+  Sub-attributing `draw_setup.resources` (89.66 ms, 54 % of the submit) live gives
+  **`res.buffer` 93.7 %**, `res.descriptor` 2.0 %, `res.texture` 1.8 %. The frontend resolves every
+  binding to a zero-copy direct guest view (`logical=1,764.4 MiB materialized=0.0 MiB` per submit)
+  and the backend copies the deduplicated set into host-visible staging anyway, while
+  `backend_buffer_pool` sits pegged at its 256 MiB ceiling with evictions exactly equal to misses.
+  Full numbers, method and the four falsified sub-hypotheses (descriptor setup, live texture cost,
+  per-draw `getenv`, the #1268 content hash) are in
+  `docs/RENDERER_PERFORMANCE_2026_07.md` § *Blue Prince 3D submit decomposition, re-measured*.
+
 ## Defect families (#1287) — families 1–3 and 5 RESOLVED 2026-07-26
 
 Families 1–3 and 5 below are **fixed on master**; they are retained as the resolution record so

--- a/prosper/docs/FRONTEND_APP.md
+++ b/prosper/docs/FRONTEND_APP.md
@@ -321,7 +321,7 @@ The core window also reports graphics-shader cache hits, misses, bypasses, and a
 
 ```text
 [render-window] backend-submit resources avg_ms: texture=.. (upload=.. bind=.. lookup=..)
-                buffer=.. descriptor=.. other=..
+                buffer=.. (acquire=.. copy=..) descriptor=.. other=..
 ```
 
 Read it before treating `resources` as descriptor cost. The interval it measures spans the whole
@@ -333,6 +333,15 @@ work, so `lookup` (= `texture - upload - bind`) is what a cache **hit** still pa
 `descriptor` is the per-draw set layout allocation and update. `other` is the remainder against the
 `resources` total on the preceding line, so the split states its own completeness — a large `other`
 means the attribution is incomplete and should not be trusted.
+
+`acquire` and `copy` are nested inside `buffer` and separate the two mechanisms that live in it:
+`acquire` is pool/arena acquisition, which on a pool miss is
+`vkCreateBuffer` + `vkAllocateMemory` + `vkBindBufferMemory` + `vkMapMemory`, and `copy` is the
+staging `memcpy`. Read them together with the `backend_buffer_pool hits/misses/cached/evictions`
+line: evictions approaching misses means the pool is at its capacity ceiling and destroying one
+buffer for every one it creates, which `PROSPER_BACKEND_BUFFER_POOL_MB` raises. `buffer - acquire -
+copy` is the transient fallback path, which allocates and copies together and is deliberately
+attributed to neither.
 
 The older independent 25-backend-call timing windows are disabled by default because their multi-line logging
 can materially perturb the target call charged for printing them on Windows. Set

--- a/prosper/docs/FRONTEND_APP.md
+++ b/prosper/docs/FRONTEND_APP.md
@@ -316,6 +316,24 @@ lines show only the latest 25 submits/calls so a scene transition is immediately
 an independent 25-call backend window across submit boundaries. Compare `measured` with `detail` and
 its `other` remainder to verify that the subphase attribution covers the frontend's backend wall time.
 The core window also reports graphics-shader cache hits, misses, bypasses, and actual miss compilation time.
+
+`backend-submit draw_setup.resources` is sub-attributed on its own line:
+
+```text
+[render-window] backend-submit resources avg_ms: texture=.. (upload=.. bind=.. lookup=..)
+                buffer=.. descriptor=.. other=..
+```
+
+Read it before treating `resources` as descriptor cost. The interval it measures spans the whole
+per-draw resource block, which also builds every **texture upload** (image and memory creation plus
+the staging memcpy) and every **storage-buffer upload**, so the term can be dominated by pixel and
+vertex bytes while its name suggests descriptor bookkeeping. `texture` and `buffer` cover the whole
+per-resource branch. `upload` and `bind` are nested *inside* `texture` and cover only cache-**miss**
+work, so `lookup` (= `texture - upload - bind`) is what a cache **hit** still pays per reference.
+`descriptor` is the per-draw set layout allocation and update. `other` is the remainder against the
+`resources` total on the preceding line, so the split states its own completeness — a large `other`
+means the attribution is incomplete and should not be trusted.
+
 The older independent 25-backend-call timing windows are disabled by default because their multi-line logging
 can materially perturb the target call charged for printing them on Windows. Set
 `PROSPER_BACKEND_TIMING_WINDOWS=1` only when that cross-submit legacy view or its memory-pool line is needed.

--- a/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
+++ b/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
@@ -65,6 +65,77 @@ in-place mutation invalidate the entry. Its memory-aware default is one eighth o
 memory, clamped to 1-2 GiB. Disable it with `PROSPER_NO_TEXTURE_DECODE_CACHE=1`; the budget is controlled by
 `PROSPER_TEXTURE_DECODE_CACHE_MB`.
 
+## Blue Prince 3D submit decomposition, re-measured (2026-08-02, #1284)
+
+Re-measured on `3a473bca` — i.e. **after** #1292 (demand-driven readbacks) and #1703 (submit-scoped
+decode identity) — with `PROSPER_RENDER_TIMING=1` on the scripted Blue Prince fresh-save route into
+the manor, RADV / Radeon 8060S (STRIX_HALO, integrated), native 1920x1080, no snapshot acceleration.
+35 peer-free heavy `[render-window]` samples, median:
+
+| term | med ms | share | July (#1284 body) |
+|---|---:|---:|---:|
+| `measured` (whole backend submit) | 165.18 | 100 % | 263.33 |
+| `draw_setup` | 126.81 | **76.8 %** | 119.87 |
+| — `resources` | **89.66** | **54.3 %** | 95.42 |
+| — `fixed` | 24.40 | 14.8 % | 16.43 |
+| — unattributed inside `draw_setup` | 6.17 | 3.7 % | — |
+| — `pipeline` | 1.43 | 0.9 % | 1.22 |
+| `readback` | 14.71 | 8.9 % | 79.16 |
+| `cleanup` | 13.19 | 8.0 % | 11.03 |
+| `gpu_wait` | 6.71 | 4.1 % | 29.29 |
+| — `gpu_device` (real GPU time) | **4.31** | **2.6 %** | — |
+| `record_upload` | 2.73 | 1.7 % | 22.58 |
+| `fence_waits` per submit | 16.3 | — | 61 |
+
+The scene is now **2,109 draws/submit**, not July's 1,516, so `resources` improved more per draw than
+the totals show. **Every term the original decomposition named has collapsed except `draw_setup`,**
+which is unchanged and is now 77 % of the submit. `gpu_device` 4.31 ms inside a 165 ms submit means
+**2.6 % GPU utilisation**: this title is not GPU-, driver-, or shader-bound, it is bound in prosper's
+own per-draw CPU path.
+
+### `draw_setup.resources` is 93.7 % storage-buffer upload
+
+`resources` never measured descriptor setup. The interval spans the whole per-draw resource block,
+which also builds every texture upload and every storage-buffer upload. The sub-attribution added in
+#1284 (`[render-window] backend-submit resources avg_ms: …`) splits it live:
+
+| sub-term | med ms | share of `resources` |
+|---|---:|---:|
+| **`res.buffer`** | **103.51** | **93.7 %** |
+| `res.other` | 3.01 | 2.7 % |
+| `res.descriptor` | 2.25 | 2.0 % |
+| `res.texture` (upload 0.75 / bind 0.18 / lookup 1.15) | 2.01 | 1.8 % |
+
+Mechanism, from two independent counters in the same run. **Volume:** the frontend resolves every
+binding to a zero-copy direct guest view and reports `buffers=34,747 logical=1,764.4 MiB
+materialized=0.0 MiB` per submit — and the *backend* then `memcpy`s the deduplicated set into
+host-visible staging anyway. The Evergate "direct guest backing" win was only ever realised on the
+frontend side of that boundary. **Churn:** `backend_buffer_pool` sits pegged at its 256 MiB default
+ceiling with evictions exactly equal to misses (+7,960 / +7,960 over 9 s, 45 % miss rate) — a capacity
+thrash in which one buffer is destroyed for every one created, with the eviction victim taken as
+`available.begin()` on an `unordered_map`, i.e. an arbitrary bucket rather than an LRU.
+
+### Ruled out
+
+- **Per-draw descriptor setup is not the term.** `res.descriptor` — layout lookup,
+  `vkAllocateDescriptorSets`, `vkUpdateDescriptorSets` — is 2.25 ms across 2,152 draws (~1 µs/draw),
+  2.0 % of `resources`. This is the measured reason #1284 round 1's descriptor-set-reuse experiment
+  came back neutral: it was optimising 2 % of the term. Do not re-open it.
+- **Texture handling is not the term live.** `res.texture` is 2.01 ms; #1691/#1703's caches work.
+  Note the trap: the *identical instrument* on an offline `.prgcap` replay of the same title reports
+  `res.texture` = 762.72 ms, because replay disables the persistent decode cache by construction
+  (`texture_decode_cache_candidate()` requires `!has_captured_host_data`). **A replay texture number
+  is not evidence about live texture cost, in either direction.**
+- **Un-cached `getenv` in the per-draw loop is not a term.** The loop makes 11 un-cached `getenv`
+  calls (`PROSPER_NO_CULL`, `NO_BLEND` x3, `DSLOG`, `STENCILLOG`, `STENCIL_MIRROR`,
+  `STENCIL_REPLACE`, `NO_DEPTH_BIAS`, `FLIP_FRONT_FACE`, and `NO_SWIZZLE` which is per *texture
+  reference*), sitting next to three neighbours that already cache into `static const`. Measured
+  directly: glibc `getenv` on a miss costs 19.7 ns (10-var environment) to 25.6 ns (94-var), so the
+  whole per-submit volume is **≈0.5 ms of 165 ms — 0.3 %**. Tidy if touched for other reasons; not a
+  performance fix.
+- **The #1268 small-buffer content hash is not the term.** Live `hash-stats`: 414,633 hash calls over
+  168.1 MiB against 3.5 M references — ~1 % of the buffer term.
+
 ## Plucky Squire maximum-size atlas retention (2026-07-29)
 
 Plucky Squire exposed a capacity cliff rather than a decode-kernel regression. The title first holds

--- a/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
+++ b/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
@@ -169,13 +169,15 @@ sources, only host staging recycling changes: make the default memory-aware (mir
 `texture_decode_cache_limit_bytes`, with the `*_MB` override winning) and give eviction an LRU victim
 instead of `available.begin()` on an `unordered_map`. The risk is memory footprint, not correctness.
 
-This does **not** retire the copy. Even at 2048 MiB, `copy` is 33.44 ms and `res_buffer` 41.62 ms of
-a 126.58 ms submit, so removing the copy entirely — importing guest pages as Vulkan memory
-(`VK_EXT_external_memory_host`; prosper uses it nowhere today, there is no
-`vkGetMemoryHostPointerPropertiesEXT` / `VkImportMemoryHostPointerInfoEXT` in the tree), or a
-versioned guest-identity buffer cache — remains the structural follow-up. The second reuses the #1703
-machinery but carries the #611/#780 stale-data risk; the first does not, because the GPU would read
-the guest bytes rather than a snapshot of them.
+This does **not** retire the copy, and the difference matters for what anyone expects next: the fix
+stops the pool *thrashing while it copies*, it does not stop the copying. Even at 2048 MiB, `copy` is
+33.27 ms and `res_buffer` 41.50 ms of a 125.98 ms submit — about **8 backend submits per second
+against a bar of 30.** Removing the copy entirely is tracked as **#1733**: import guest pages as
+Vulkan memory (`VK_EXT_external_memory_host`; prosper uses it nowhere today, there is no
+`vkGetMemoryHostPointerPropertiesEXT` / `VkImportMemoryHostPointerInfoEXT` in the tree), or add a
+versioned guest-identity buffer cache. The second reuses the #1703 machinery but carries the
+#611/#780 stale-data risk; the first does not, because the GPU would read the guest bytes rather than
+a snapshot of them.
 
 Frame math, so nobody expects one term to finish the job: at the clean 165.18 ms submit, removing
 100 % of `copy` gives ~95 ms (10.5 submits/s); removing `copy` **and** `acquire` **and** `fixed`

--- a/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
+++ b/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
@@ -106,13 +106,16 @@ which also builds every texture upload and every storage-buffer upload. The sub-
 | `res.descriptor` | 2.25 | 2.0 % |
 | `res.texture` (upload 0.75 / bind 0.18 / lookup 1.15) | 2.01 | 1.8 % |
 
-`res_buffer` splits 4:1 into **bandwidth over object churn** (median of five consecutive heavy
-windows): `copy` (the staging `memcpy`) **83.80 ms**, `acquire` (pool/arena acquisition, which on a
-pool miss is create + allocate + bind + map) **13.64 ms**, remainder 7.64 ms — the transient fallback
-path, which allocates and copies together and is attributed to neither, plus key building and
-lookups. **The staging copy alone is ~42 % of the whole backend submit.** So the term is bandwidth:
-fixing the buffer pool is worth roughly 7 % of the submit and is worth doing, but it is not the
-frontier; removing the copy is.
+`res_buffer` splits 4:1 into `copy` (the staging `memcpy`) **83.80 ms** over `acquire` (pool/arena
+acquisition, which on a pool miss is create + allocate + bind + map) **13.64 ms**, remainder 7.64 ms
+— the transient fallback path, which allocates and copies together and is attributed to neither, plus
+key building and lookups.
+
+**Do not read that split as "allocation churn is the small half".** `acquire` measures only the
+allocation *calls*; most of the churn cost lands in `copy`, because a freshly `vkAllocateMemory`'d
+and `vkMapMemory`'d staging buffer has non-resident pages and the memcpy into it faults, while a
+recycled pool buffer is already resident. The sub-attribution draws its boundary at the API call, and
+reading that boundary as the mechanism produced a wrong conclusion here once already.
 
 Mechanism, from two independent counters in the same run. **Volume:** the frontend resolves every
 binding to a zero-copy direct guest view and reports `buffers=34,747 logical=1,764.4 MiB
@@ -123,17 +126,48 @@ ceiling with evictions exactly equal to misses (+7,960 / +7,960 over 9 s, 45 % m
 thrash in which one buffer is destroyed for every one created, with the eviction victim taken as
 `available.begin()` on an `unordered_map`, i.e. an arbitrary bucket rather than an LRU.
 
-### Where the fix has to go
+### The buffer pool's 256 MiB default is 37.7 % of the frame
 
-The term is **bandwidth**, so the two candidate directions rank very differently. Removing the copy is
-the fix, and it is structural: either import guest pages as Vulkan memory
-(`VK_EXT_external_memory_host` — prosper uses it nowhere today, there is no
-`vkGetMemoryHostPointerPropertiesEXT` / `VkImportMemoryHostPointerInfoEXT` in the tree), or add a
-persistent versioned buffer cache keyed on guest identity so unchanged buffers are not re-copied. The
-second reuses the #1703 machinery but carries the #611/#780 stale-data risk; the first does not,
-because the GPU reads the guest bytes rather than a snapshot of them. Raising
-`PROSPER_BACKEND_BUFFER_POOL_MB` and giving the pool an LRU victim is cheap, safe and real, and is
-worth about 7 % of the submit — take it, but do not mistake it for the frontier.
+`render_host_buffer_pool_limit()` defaults to a **fixed 256 MiB**. Blue Prince's real host-staging
+working set is **974 MiB**, so on a 3D title the pool degenerates into an allocator: evictions equal
+misses (~216k each per arm) and one buffer is destroyed for every one created.
+
+Four alternating arms, one binary, `PROSPER_BACKEND_BUFFER_POOL_MB` the only lever (256 / 2048 /
+256 / 2048). Witness: the 256 arms peak at 256.0 MiB with 215,366 and 217,205 misses; the 2048 arms
+settle at 974.0 MiB / 503 buffers with **503 misses and zero evictions**.
+
+| term | 256 MiB | 2048 MiB | delta | within-treatment | between |
+|---|---:|---:|---:|---:|---:|
+| `measured` | 203.06 | 126.58 | **-37.7 %** | 10.62 | 76.48 |
+| `res_buffer` | 113.10 | 41.62 | -63.2 % | 16.76 | 71.48 |
+| `copy` | 92.54 | 33.44 | -63.9 % | 18.19 | 59.10 |
+| `acquire` | 13.65 | 1.46 | -89.3 % | 0.95 | 12.20 |
+| `cleanup` | 14.77 | 3.04 | -79.4 % | 0.21 | 11.72 |
+| draws | 2218.15 | 2145.00 | +3.3 % | 71.10 | 73.15 |
+
+Every timing term separates far beyond its within-treatment spread, while `draws` — the quantity the
+lever cannot touch — has within (71.10) equal to between (73.15), so the 3.3 % scene-weight
+difference is cycle noise and not the explanation. Per draw: 0.0915 -> 0.0590 ms, **-35.6 %**.
+Controls: per-submit byte volume is identical between arms (`logical=1,644.0 / 1,764.4 MiB`,
+`materialized=0.0 MiB`), and minor faults sampled from `/proc/<pid>/stat` fall from 123,079/s to
+52,106/s. The per-fault cost that would be needed to explain the whole `copy` delta (~3.1 us) is
+above a generic anonymous-page fault, so the mechanism is recorded as leading, not settled.
+
+**Caveat: all four arms ran contended (one peer throughout).** Absolute milliseconds are inflated;
+the comparison is internally controlled but the magnitude needs a clean-box confirmation.
+
+The fix is bounded and **cannot change rendered output** — the same bytes are uploaded from the same
+sources, only host staging recycling changes: make the default memory-aware (mirroring
+`texture_decode_cache_limit_bytes`, with the `*_MB` override winning) and give eviction an LRU victim
+instead of `available.begin()` on an `unordered_map`. The risk is memory footprint, not correctness.
+
+This does **not** retire the copy. Even at 2048 MiB, `copy` is 33.44 ms and `res_buffer` 41.62 ms of
+a 126.58 ms submit, so removing the copy entirely — importing guest pages as Vulkan memory
+(`VK_EXT_external_memory_host`; prosper uses it nowhere today, there is no
+`vkGetMemoryHostPointerPropertiesEXT` / `VkImportMemoryHostPointerInfoEXT` in the tree), or a
+versioned guest-identity buffer cache — remains the structural follow-up. The second reuses the #1703
+machinery but carries the #611/#780 stale-data risk; the first does not, because the GPU would read
+the guest bytes rather than a snapshot of them.
 
 Frame math, so nobody expects one term to finish the job: at the clean 165.18 ms submit, removing
 100 % of `copy` gives ~95 ms (10.5 submits/s); removing `copy` **and** `acquire` **and** `fixed`

--- a/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
+++ b/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
@@ -200,6 +200,15 @@ and `gpu_device` is 4.31 ms, so **no single term reaches 30 fps on this title.**
   directly: glibc `getenv` on a miss costs 19.7 ns (10-var environment) to 25.6 ns (94-var), so the
   whole per-submit volume is **≈0.5 ms of 165 ms — 0.3 %**. Tidy if touched for other reasons; not a
   performance fix.
+
+  Recorded at length because of how it *looked*: 11 uncached environment lookups in the hottest loop
+  in the renderer, one of them per texture reference, sitting beside three neighbours that already
+  cache into `static const` — an obvious oversight with an obvious fix, and it was minutes from being
+  "fixed". A two-minute microbenchmark priced it at nothing. glibc's `getenv` compares the first
+  character before `strncmp`, so it is tens of nanoseconds, not the microseconds the shape of the
+  code suggests. **A plausible optimisation that measures to nothing is worth writing down precisely
+  because the next reader will find the same 11 calls and draw the same conclusion.** Price a hot-loop
+  call before removing it, not after.
 - **The #1268 small-buffer content hash is not the term.** Live `hash-stats`: 414,633 hash calls over
   168.1 MiB against 3.5 M references — ~1 % of the buffer term.
 

--- a/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
+++ b/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
@@ -106,6 +106,14 @@ which also builds every texture upload and every storage-buffer upload. The sub-
 | `res.descriptor` | 2.25 | 2.0 % |
 | `res.texture` (upload 0.75 / bind 0.18 / lookup 1.15) | 2.01 | 1.8 % |
 
+`res_buffer` splits 4:1 into **bandwidth over object churn** (median of five consecutive heavy
+windows): `copy` (the staging `memcpy`) **83.80 ms**, `acquire` (pool/arena acquisition, which on a
+pool miss is create + allocate + bind + map) **13.64 ms**, remainder 7.64 ms — the transient fallback
+path, which allocates and copies together and is attributed to neither, plus key building and
+lookups. **The staging copy alone is ~42 % of the whole backend submit.** So the term is bandwidth:
+fixing the buffer pool is worth roughly 7 % of the submit and is worth doing, but it is not the
+frontier; removing the copy is.
+
 Mechanism, from two independent counters in the same run. **Volume:** the frontend resolves every
 binding to a zero-copy direct guest view and reports `buffers=34,747 logical=1,764.4 MiB
 materialized=0.0 MiB` per submit — and the *backend* then `memcpy`s the deduplicated set into
@@ -114,6 +122,23 @@ frontend side of that boundary. **Churn:** `backend_buffer_pool` sits pegged at 
 ceiling with evictions exactly equal to misses (+7,960 / +7,960 over 9 s, 45 % miss rate) — a capacity
 thrash in which one buffer is destroyed for every one created, with the eviction victim taken as
 `available.begin()` on an `unordered_map`, i.e. an arbitrary bucket rather than an LRU.
+
+### Where the fix has to go
+
+The term is **bandwidth**, so the two candidate directions rank very differently. Removing the copy is
+the fix, and it is structural: either import guest pages as Vulkan memory
+(`VK_EXT_external_memory_host` — prosper uses it nowhere today, there is no
+`vkGetMemoryHostPointerPropertiesEXT` / `VkImportMemoryHostPointerInfoEXT` in the tree), or add a
+persistent versioned buffer cache keyed on guest identity so unchanged buffers are not re-copied. The
+second reuses the #1703 machinery but carries the #611/#780 stale-data risk; the first does not,
+because the GPU reads the guest bytes rather than a snapshot of them. Raising
+`PROSPER_BACKEND_BUFFER_POOL_MB` and giving the pool an LRU victim is cheap, safe and real, and is
+worth about 7 % of the submit — take it, but do not mistake it for the frontier.
+
+Frame math, so nobody expects one term to finish the job: at the clean 165.18 ms submit, removing
+100 % of `copy` gives ~95 ms (10.5 submits/s); removing `copy` **and** `acquire` **and** `fixed`
+still leaves ~60 ms (16/s). `readback` + `cleanup` + `gpu_wait` + `record_upload` are 37 ms combined
+and `gpu_device` is 4.31 ms, so **no single term reaches 30 fps on this title.**
 
 ### Ruled out
 

--- a/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
+++ b/prosper/docs/RENDERER_PERFORMANCE_2026_07.md
@@ -126,7 +126,7 @@ ceiling with evictions exactly equal to misses (+7,960 / +7,960 over 9 s, 45 % m
 thrash in which one buffer is destroyed for every one created, with the eviction victim taken as
 `available.begin()` on an `unordered_map`, i.e. an arbitrary bucket rather than an LRU.
 
-### The buffer pool's 256 MiB default is 37.7 % of the frame
+### The buffer pool's 256 MiB default is ~35 % of the frame
 
 `render_host_buffer_pool_limit()` defaults to a **fixed 256 MiB**. Blue Prince's real host-staging
 working set is **974 MiB**, so on a 3D title the pool degenerates into an allocator: evictions equal
@@ -138,20 +138,28 @@ settle at 974.0 MiB / 503 buffers with **503 misses and zero evictions**.
 
 | term | 256 MiB | 2048 MiB | delta | within-treatment | between |
 |---|---:|---:|---:|---:|---:|
-| `measured` | 203.06 | 126.58 | **-37.7 %** | 10.62 | 76.48 |
-| `res_buffer` | 113.10 | 41.62 | -63.2 % | 16.76 | 71.48 |
-| `copy` | 92.54 | 33.44 | -63.9 % | 18.19 | 59.10 |
-| `acquire` | 13.65 | 1.46 | -89.3 % | 0.95 | 12.20 |
-| `cleanup` | 14.77 | 3.04 | -79.4 % | 0.21 | 11.72 |
-| draws | 2218.15 | 2145.00 | +3.3 % | 71.10 | 73.15 |
+| `measured` | 203.06 | 125.98 | -38.0 % raw | 10.62 | 77.09 |
+| `res_buffer` | 113.10 | 41.50 | -63.3 % | 16.76 | 71.60 |
+| `copy` | 92.54 | 33.27 | -64.0 % | 18.19 | 59.27 |
+| `acquire` | 13.65 | 1.44 | -89.5 % | 0.95 | 12.22 |
+| `cleanup` | 14.77 | 2.95 | -80.1 % | 0.14 | 11.82 |
+| draws | 2218.15 | 2109.47 | +4.9 % | 35.10 | 108.67 |
 
-Every timing term separates far beyond its within-treatment spread, while `draws` — the quantity the
-lever cannot touch — has within (71.10) equal to between (73.15), so the 3.3 % scene-weight
-difference is cycle noise and not the explanation. Per draw: 0.0915 -> 0.0590 ms, **-35.6 %**.
+Every timing term separates far beyond its within-treatment spread. **The draws row does not**: the
+2048 arms sat at 2109/2110 draws against the 256 arms' 2201/2236, a systematic ~4.9 % lighter scene
+(an expected selection effect — the faster arm covers more of a fixed-duration route and samples
+different moments). So the raw -38.0 % overstates it. **Normalised per draw, 0.0915 -> 0.0597 ms,
+the honest figure is -34.8 %** — quote that one.
+
 Controls: per-submit byte volume is identical between arms (`logical=1,644.0 / 1,764.4 MiB`,
-`materialized=0.0 MiB`), and minor faults sampled from `/proc/<pid>/stat` fall from 123,079/s to
-52,106/s. The per-fault cost that would be needed to explain the whole `copy` delta (~3.1 us) is
-above a generic anonymous-page fault, so the mechanism is recorded as leading, not settled.
+`materialized=0.0 MiB`), so the 2048 arm copies the same bytes faster. Minor faults sampled from
+`/proc/<pid>/stat` (no ptrace, no perturbation) run at 150,911/s for the 256 arm against 48,827/s
+and 97,398/s for the two 2048 arms — roughly 31,400 versus 6,200 and 12,200 per submit. The direction
+holds, but **the two 2048 arms differ from each other by 2x**, nearly the size of the gap being
+attributed, and explaining the whole `copy` delta by faults alone would need ~3 us per fault, well
+above a generic anonymous-page fault. First-touch faulting on freshly mapped staging memory is
+therefore recorded as the **leading hypothesis, not a finding**; page-table/TLB churn from ~216k
+map/unmap pairs per run is the other candidate. The fix does not depend on which it is.
 
 **Caveat: all four arms ran contended (one peer throughout).** Absolute milliseconds are inflated;
 the comparison is internally controlled but the magnitude needs a clean-box confirmation.

--- a/prosper/docs/VERIFICATION.md
+++ b/prosper/docs/VERIFICATION.md
@@ -107,6 +107,22 @@ rasteriser; they are listed in `ci.yml` with a reproduction command and tracked 
 tests cannot run in CI at all — dumps are copyrighted and gitignored — and now report `(Skipped)` rather
 than passing.
 
+**Two dump-backed tests are pinned to *The Messenger* specifically, not to "some dump".** If you
+configure with `-DGAME_DUMP=` pointing at any other title, `module_loads_eboot` and
+`boot_reaches_first_syscall` fail locally while everything else passes, and the failure looks like a
+regression in the loader:
+
+```text
+module_loads_eboot        imports=610 expected 612 / distinct import libs=34 expected 35
+boot_reaches_first_syscall  link: load .../Media/Modules/Il2cppUserAssemblies.prx: cannot open file
+```
+
+`612` imports and `35` import libraries are `PPSA24651-app0`'s numbers (`tests/test_module.cpp`), and
+that dump is the `GAME_DUMP` default in `CMakeLists.txt`. The second test wants The Messenger's IL2CPP
+module layout. So a build configured against, say, Blue Prince for renderer work reports **171/173
+with those two red**, and that result is expected rather than a regression — confirm it by running the
+same two tests on unmodified master with the same `-DGAME_DUMP`, which is the cheap discriminator.
+
 ## Rule of thumb
 
 Prefer the cheapest layer that can catch a given bug: pure structural asserts for translation logic,

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -1068,6 +1068,13 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 double backend_readback_ms = 0, backend_cleanup_ms = 0;
                 double backend_setup_shader_ms = 0, backend_setup_fixed_ms = 0;
                 double backend_setup_resources_ms = 0, backend_setup_pipeline_ms = 0;
+                // #1284: sub-attribution of backend_setup_resources_ms. res_texture/res_buffer
+                // cover the whole per-resource branch; the upload/bind pair is nested inside
+                // res_texture and covers only cache-MISS work, so the remainder is what a cache
+                // hit still pays per reference. res_descriptor is the per-draw set alloc/update.
+                double backend_res_texture_ms = 0, backend_res_texture_upload_ms = 0;
+                double backend_res_texture_bind_ms = 0, backend_res_buffer_ms = 0;
+                double backend_res_descriptor_ms = 0;
                 uint64_t backend_pipeline_refs = 0, backend_pipeline_hits = 0;
                 uint64_t backend_pipeline_misses = 0, backend_pipeline_bypasses = 0;
                 uint64_t backend_pipeline_entries = 0, backend_pipeline_evictions = 0;
@@ -1125,6 +1132,11 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 pending_timing.backend_setup_shader_ms += backend.setup_shader_ms;
                 pending_timing.backend_setup_fixed_ms += backend.setup_fixed_ms;
                 pending_timing.backend_setup_resources_ms += backend.setup_resources_ms;
+                pending_timing.backend_res_texture_ms += backend.res_texture_ms;
+                pending_timing.backend_res_texture_upload_ms += backend.res_texture_upload_ms;
+                pending_timing.backend_res_texture_bind_ms += backend.res_texture_bind_ms;
+                pending_timing.backend_res_buffer_ms += backend.res_buffer_ms;
+                pending_timing.backend_res_descriptor_ms += backend.res_descriptor_ms;
                 pending_timing.backend_setup_pipeline_ms += backend.setup_pipeline_ms;
                 pending_timing.backend_pipeline_refs += pipelines.references;
                 pending_timing.backend_pipeline_hits += pipelines.hits;
@@ -5364,6 +5376,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     double backend_readback_ms = 0, backend_cleanup_ms = 0;
                     double backend_setup_shader_ms = 0, backend_setup_fixed_ms = 0;
                     double backend_setup_resources_ms = 0, backend_setup_pipeline_ms = 0;
+                    double backend_res_texture_ms = 0, backend_res_texture_upload_ms = 0;
+                    double backend_res_texture_bind_ms = 0, backend_res_buffer_ms = 0;
+                    double backend_res_descriptor_ms = 0;
                     uint64_t backend_pipeline_refs = 0, backend_pipeline_hits = 0;
                     uint64_t backend_pipeline_misses = 0, backend_pipeline_bypasses = 0;
                     uint64_t backend_pipeline_entries = 0, backend_pipeline_evictions = 0;
@@ -5409,6 +5424,11 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     timing.backend_setup_shader_ms += pending_timing.backend_setup_shader_ms;
                     timing.backend_setup_fixed_ms += pending_timing.backend_setup_fixed_ms;
                     timing.backend_setup_resources_ms += pending_timing.backend_setup_resources_ms;
+                    timing.backend_res_texture_ms += pending_timing.backend_res_texture_ms;
+                    timing.backend_res_texture_upload_ms += pending_timing.backend_res_texture_upload_ms;
+                    timing.backend_res_texture_bind_ms += pending_timing.backend_res_texture_bind_ms;
+                    timing.backend_res_buffer_ms += pending_timing.backend_res_buffer_ms;
+                    timing.backend_res_descriptor_ms += pending_timing.backend_res_descriptor_ms;
                     timing.backend_setup_pipeline_ms += pending_timing.backend_setup_pipeline_ms;
                     timing.backend_pipeline_refs += pending_timing.backend_pipeline_refs;
                     timing.backend_pipeline_hits += pending_timing.backend_pipeline_hits;
@@ -5492,6 +5512,19 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             totals.backend_setup_fixed_ms / nsub,
                             totals.backend_setup_resources_ms / nsub,
                             totals.backend_setup_pipeline_ms / nsub);
+                    fprintf(stderr,
+                            "[render-timing] backend-submit resources avg_ms: texture=%.2f "
+                            "(upload=%.2f bind=%.2f lookup=%.2f) buffer=%.2f descriptor=%.2f "
+                            "other=%.2f\n",
+                            totals.backend_res_texture_ms / nsub,
+                            totals.backend_res_texture_upload_ms / nsub,
+                            totals.backend_res_texture_bind_ms / nsub,
+                            (totals.backend_res_texture_ms - totals.backend_res_texture_upload_ms -
+                             totals.backend_res_texture_bind_ms) / nsub,
+                            totals.backend_res_buffer_ms / nsub,
+                            totals.backend_res_descriptor_ms / nsub,
+                            (totals.backend_setup_resources_ms - totals.backend_res_texture_ms -
+                             totals.backend_res_buffer_ms - totals.backend_res_descriptor_ms) / nsub);
                     fprintf(stderr,
                             "[render-timing] backend-submit pipelines refs=%.1f hits=%.1f misses=%.1f "
                             "bypass=%.1f entries=%llu evictions=%.1f\n",
@@ -5677,6 +5710,19 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             window.backend_setup_fixed_ms / wn,
                             window.backend_setup_resources_ms / wn,
                             window.backend_setup_pipeline_ms / wn);
+                    fprintf(stderr,
+                            "[render-window] backend-submit resources avg_ms: texture=%.2f "
+                            "(upload=%.2f bind=%.2f lookup=%.2f) buffer=%.2f descriptor=%.2f "
+                            "other=%.2f\n",
+                            window.backend_res_texture_ms / wn,
+                            window.backend_res_texture_upload_ms / wn,
+                            window.backend_res_texture_bind_ms / wn,
+                            (window.backend_res_texture_ms - window.backend_res_texture_upload_ms -
+                             window.backend_res_texture_bind_ms) / wn,
+                            window.backend_res_buffer_ms / wn,
+                            window.backend_res_descriptor_ms / wn,
+                            (window.backend_setup_resources_ms - window.backend_res_texture_ms -
+                             window.backend_res_buffer_ms - window.backend_res_descriptor_ms) / wn);
                     fprintf(stderr,
                             "[render-window] backend-submit pipelines refs=%.1f hits=%.1f misses=%.1f "
                             "bypass=%.1f entries=%llu evictions=%.1f\n",

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -1074,6 +1074,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 // hit still pays per reference. res_descriptor is the per-draw set alloc/update.
                 double backend_res_texture_ms = 0, backend_res_texture_upload_ms = 0;
                 double backend_res_texture_bind_ms = 0, backend_res_buffer_ms = 0;
+                double backend_res_buffer_acquire_ms = 0, backend_res_buffer_copy_ms = 0;
                 double backend_res_descriptor_ms = 0;
                 uint64_t backend_pipeline_refs = 0, backend_pipeline_hits = 0;
                 uint64_t backend_pipeline_misses = 0, backend_pipeline_bypasses = 0;
@@ -1136,6 +1137,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                 pending_timing.backend_res_texture_upload_ms += backend.res_texture_upload_ms;
                 pending_timing.backend_res_texture_bind_ms += backend.res_texture_bind_ms;
                 pending_timing.backend_res_buffer_ms += backend.res_buffer_ms;
+                pending_timing.backend_res_buffer_acquire_ms += backend.res_buffer_acquire_ms;
+                pending_timing.backend_res_buffer_copy_ms += backend.res_buffer_copy_ms;
                 pending_timing.backend_res_descriptor_ms += backend.res_descriptor_ms;
                 pending_timing.backend_setup_pipeline_ms += backend.setup_pipeline_ms;
                 pending_timing.backend_pipeline_refs += pipelines.references;
@@ -5378,6 +5381,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     double backend_setup_resources_ms = 0, backend_setup_pipeline_ms = 0;
                     double backend_res_texture_ms = 0, backend_res_texture_upload_ms = 0;
                     double backend_res_texture_bind_ms = 0, backend_res_buffer_ms = 0;
+                    double backend_res_buffer_acquire_ms = 0, backend_res_buffer_copy_ms = 0;
                     double backend_res_descriptor_ms = 0;
                     uint64_t backend_pipeline_refs = 0, backend_pipeline_hits = 0;
                     uint64_t backend_pipeline_misses = 0, backend_pipeline_bypasses = 0;
@@ -5428,6 +5432,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                     timing.backend_res_texture_upload_ms += pending_timing.backend_res_texture_upload_ms;
                     timing.backend_res_texture_bind_ms += pending_timing.backend_res_texture_bind_ms;
                     timing.backend_res_buffer_ms += pending_timing.backend_res_buffer_ms;
+                    timing.backend_res_buffer_acquire_ms += pending_timing.backend_res_buffer_acquire_ms;
+                    timing.backend_res_buffer_copy_ms += pending_timing.backend_res_buffer_copy_ms;
                     timing.backend_res_descriptor_ms += pending_timing.backend_res_descriptor_ms;
                     timing.backend_setup_pipeline_ms += pending_timing.backend_setup_pipeline_ms;
                     timing.backend_pipeline_refs += pending_timing.backend_pipeline_refs;
@@ -5514,14 +5520,16 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             totals.backend_setup_pipeline_ms / nsub);
                     fprintf(stderr,
                             "[render-timing] backend-submit resources avg_ms: texture=%.2f "
-                            "(upload=%.2f bind=%.2f lookup=%.2f) buffer=%.2f descriptor=%.2f "
-                            "other=%.2f\n",
+                            "(upload=%.2f bind=%.2f lookup=%.2f) buffer=%.2f "
+                            "(acquire=%.2f copy=%.2f) descriptor=%.2f other=%.2f\n",
                             totals.backend_res_texture_ms / nsub,
                             totals.backend_res_texture_upload_ms / nsub,
                             totals.backend_res_texture_bind_ms / nsub,
                             (totals.backend_res_texture_ms - totals.backend_res_texture_upload_ms -
                              totals.backend_res_texture_bind_ms) / nsub,
                             totals.backend_res_buffer_ms / nsub,
+                            totals.backend_res_buffer_acquire_ms / nsub,
+                            totals.backend_res_buffer_copy_ms / nsub,
                             totals.backend_res_descriptor_ms / nsub,
                             (totals.backend_setup_resources_ms - totals.backend_res_texture_ms -
                              totals.backend_res_buffer_ms - totals.backend_res_descriptor_ms) / nsub);
@@ -5712,14 +5720,16 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
                             window.backend_setup_pipeline_ms / wn);
                     fprintf(stderr,
                             "[render-window] backend-submit resources avg_ms: texture=%.2f "
-                            "(upload=%.2f bind=%.2f lookup=%.2f) buffer=%.2f descriptor=%.2f "
-                            "other=%.2f\n",
+                            "(upload=%.2f bind=%.2f lookup=%.2f) buffer=%.2f "
+                            "(acquire=%.2f copy=%.2f) descriptor=%.2f other=%.2f\n",
                             window.backend_res_texture_ms / wn,
                             window.backend_res_texture_upload_ms / wn,
                             window.backend_res_texture_bind_ms / wn,
                             (window.backend_res_texture_ms - window.backend_res_texture_upload_ms -
                              window.backend_res_texture_bind_ms) / wn,
                             window.backend_res_buffer_ms / wn,
+                            window.backend_res_buffer_acquire_ms / wn,
+                            window.backend_res_buffer_copy_ms / wn,
                             window.backend_res_descriptor_ms / wn,
                             (window.backend_setup_resources_ms - window.backend_res_texture_ms -
                              window.backend_res_buffer_ms - window.backend_res_descriptor_ms) / wn);

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -18,6 +18,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <deque>
 #include <functional>
 #include <mutex>
 #include <span>
@@ -26,6 +27,16 @@
 #include <unordered_set>
 #include <utility>
 #include <vector>
+
+// For the memory-aware host-buffer pool budget (render_host_physical_memory_bytes).
+#ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif
 
 namespace prosper::test {
 
@@ -1638,15 +1649,23 @@ struct RenderHostBuffer {
     void* mapped = nullptr;
     VkDeviceSize bytes = 0;
     VkDeviceSize allocation_bytes = 0;
+    // Release order, stamped when the buffer enters the cache. Only meaningful for cached entries;
+    // it is what makes eviction least-recently-used rather than arbitrary (#1284).
+    uint64_t last_use = 0;
 };
 
 struct RenderHostBufferPool {
-    std::unordered_map<VkDeviceSize, std::vector<RenderHostBuffer>> available;
+    // A deque per capacity class, ordered oldest-release at the front. Acquire takes the BACK (the
+    // most recently released buffer of that class, so the hottest pages come back first) and
+    // eviction takes the FRONT (the least recently released). A vector cannot do both in O(1).
+    std::unordered_map<VkDeviceSize, std::deque<RenderHostBuffer>> available;
     VkDeviceSize cached_bytes = 0;
     size_t cached_buffers = 0;
     uint64_t hits = 0;
     uint64_t misses = 0;
     uint64_t evictions = 0;
+    // Monotonic release counter; see RenderHostBuffer::last_use.
+    uint64_t release_clock = 0;
 };
 
 struct RenderHostBufferPoolStats {
@@ -1666,12 +1685,86 @@ inline bool render_host_buffer_pool_enabled() {
     return getenv("PROSPER_NO_BACKEND_BUFFER_POOL") == nullptr;
 }
 
+// Which capacity class holds the least-recently-released cached buffer.
+//
+// Eviction used to take `pool.available.begin()` — an arbitrary `unordered_map` bucket — so under
+// pressure the pool discarded whichever class the hash happened to order first, which is very often
+// the class about to be needed again. That is the failure mode that survives any budget smaller than
+// the working set, so it is fixed independently of the budget (#1284).
+//
+// Each deque is ordered oldest-release at the front, so only the fronts can be the global oldest and
+// the scan is over the number of capacity classes (~20-30 power-of-two sizes), not cached entries.
+// Pure over pool state so the policy is unit-testable without a Vulkan device.
+inline bool render_host_buffer_pool_lru_key(const RenderHostBufferPool& pool,
+                                            VkDeviceSize& key_out) {
+    bool found = false;
+    uint64_t oldest = 0;
+    for (const auto& [capacity, entries] : pool.available) {
+        if (entries.empty()) continue;
+        const uint64_t stamp = entries.front().last_use;
+        if (!found || stamp < oldest) {
+            found = true;
+            oldest = stamp;
+            key_out = capacity;
+        }
+    }
+    return found;
+}
+
+// Host physical memory, for the memory-aware pool budget below. Duplicated rather than shared with
+// the frontend's identical helper because this header is included BY the frontend, so taking the
+// dependency the other way would invert the include order.
+inline uint64_t render_host_physical_memory_bytes() {
+#if defined(_WIN32)
+    MEMORYSTATUSEX status{};
+    status.dwLength = sizeof(status);
+    return GlobalMemoryStatusEx(&status) ? status.ullTotalPhys : 0;
+#else
+    const long pages = sysconf(_SC_PHYS_PAGES);
+    const long page_size = sysconf(_SC_PAGE_SIZE);
+    if (pages <= 0 || page_size <= 0) return 0;
+    return static_cast<uint64_t>(pages) * static_cast<uint64_t>(page_size);
+#endif
+}
+
+// Budget for retained host-visible staging buffers.
+//
+// This was a flat 256 MiB, which is not a cache for a 3D title: Blue Prince's per-submit staging
+// working set measures 974 MiB across 503 buffers, so the pool ran permanently at its ceiling with
+// evictions EXACTLY equal to misses (~216k of each) — one buffer destroyed for every one created.
+// Raising it to 2 GiB on that title took the backend submit from 203.06 to 125.98 ms, -34.8 %
+// normalised per draw, and dropped evictions to zero (#1284).
+//
+// Sized as a fraction of host RAM rather than a bigger constant, mirroring
+// `texture_decode_cache_limit_bytes`. The floor is the historical 256 MiB, so no host is given LESS
+// than before; the ceiling bounds the worst case. An explicit `PROSPER_BACKEND_BUFFER_POOL_MB` wins
+// outright, including values below the floor, because it is also the A/B lever and a constrained-host
+// escape hatch. Pure and separated from `getenv` so it can be unit-tested across host sizes.
+inline VkDeviceSize render_host_buffer_pool_limit_bytes(const char* override_mib,
+                                                        uint64_t physical_memory_bytes) {
+    constexpr uint64_t kMiB = 1024ull * 1024ull;
+    constexpr uint64_t kMinBytes = 256ull * kMiB;
+    constexpr uint64_t kMaxBytes = 2048ull * kMiB;
+    if (override_mib) {
+        const uint64_t mib = strtoull(override_mib, nullptr, 10);
+        if (mib > UINT64_MAX / kMiB) return VkDeviceSize{UINT64_MAX};
+        return static_cast<VkDeviceSize>(mib * kMiB);
+    }
+    if (!physical_memory_bytes) return static_cast<VkDeviceSize>(kMinBytes);
+    uint64_t bytes = std::clamp(physical_memory_bytes / 8u, kMinBytes, kMaxBytes);
+    bytes -= bytes % kMiB;
+    return static_cast<VkDeviceSize>(bytes);
+}
+
 inline VkDeviceSize render_host_buffer_pool_limit() {
     static const VkDeviceSize limit = []() -> VkDeviceSize {
-        const char* value = getenv("PROSPER_BACKEND_BUFFER_POOL_MB");
-        const uint64_t mib = value ? strtoull(value, nullptr, 10) : 256ull;
-        if (mib > UINT64_MAX / (1024ull * 1024ull)) return VkDeviceSize{UINT64_MAX};
-        return static_cast<VkDeviceSize>(mib) * 1024ull * 1024ull;
+        const uint64_t physical = render_host_physical_memory_bytes();
+        const VkDeviceSize bytes = render_host_buffer_pool_limit_bytes(
+            getenv("PROSPER_BACKEND_BUFFER_POOL_MB"), physical);
+        fprintf(stderr,
+                "[render] backend host-buffer pool budget = %.1f MiB (host physical %.1f GiB)\n",
+                bytes / (1024.0 * 1024.0), physical / (1024.0 * 1024.0 * 1024.0));
+        return bytes;
     }();
     return limit;
 }
@@ -1754,9 +1847,12 @@ inline void release_render_host_buffer(VkDevice device, RenderHostBuffer buffer)
     while ((pool.cached_buffers >= max_cached_buffers ||
             pool.cached_bytes > limit - buffer.allocation_bytes) &&
            !pool.available.empty()) {
-        auto victim = pool.available.begin();
-        RenderHostBuffer old = victim->second.back();
-        victim->second.pop_back();
+        VkDeviceSize victim_key = 0;
+        if (!render_host_buffer_pool_lru_key(pool, victim_key)) break;
+        auto victim = pool.available.find(victim_key);
+        if (victim == pool.available.end() || victim->second.empty()) break;
+        RenderHostBuffer old = victim->second.front();
+        victim->second.pop_front();
         if (victim->second.empty()) pool.available.erase(victim);
         pool.cached_bytes -= old.allocation_bytes;
         --pool.cached_buffers;
@@ -1765,6 +1861,7 @@ inline void release_render_host_buffer(VkDevice device, RenderHostBuffer buffer)
     }
     if (pool.cached_buffers < max_cached_buffers &&
         pool.cached_bytes <= limit - buffer.allocation_bytes) {
+        buffer.last_use = ++pool.release_clock;
         pool.available[buffer.bytes].push_back(buffer);
         pool.cached_bytes += buffer.allocation_bytes;
         ++pool.cached_buffers;

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -522,6 +522,20 @@ struct BackendRenderTimingStats {
     double setup_fixed_ms = 0;
     double setup_resources_ms = 0;
     double setup_pipeline_ms = 0;
+    // Sub-attribution of setup_resources_ms (#1284). `resources` is not descriptor bookkeeping alone:
+    // the same interval also builds every texture upload (image/memory creation plus the staging
+    // memcpy) and every storage-buffer upload, so a term that reads as "descriptor setup" can be
+    // dominated by pixel and vertex bytes. These split it so the dominant sub-term is named rather
+    // than assumed. res_texture_ms and res_buffer_ms cover the whole per-resource branch;
+    // res_texture_upload_ms and res_texture_bind_ms are nested INSIDE res_texture_ms and cover only
+    // the cache-miss work (image+staging build, view/sampler creation), so
+    // res_texture_ms - res_texture_upload_ms - res_texture_bind_ms is the per-reference key/lookup
+    // cost that a cache HIT still pays. res_descriptor_ms is the per-draw set layout/alloc/update.
+    double res_texture_ms = 0;
+    double res_texture_upload_ms = 0;
+    double res_texture_bind_ms = 0;
+    double res_buffer_ms = 0;
+    double res_descriptor_ms = 0;
 
     double total_ms() const {
         return target_ms + draw_setup_ms + record_upload_ms + gpu_wait_ms + readback_ms + cleanup_ms;
@@ -3618,8 +3632,32 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     double setup_fixed_ms = 0.0;
     double setup_resources_ms = 0.0;
     double setup_pipeline_ms = 0.0;
+    // #1284 sub-attribution of setup_resources_ms; see BackendRenderTimingStats for what each covers.
+    double res_texture_ms = 0.0;
+    double res_texture_upload_ms = 0.0;
+    double res_texture_bind_ms = 0.0;
+    double res_buffer_ms = 0.0;
+    double res_descriptor_ms = 0.0;
     auto setup_elapsed_ms = [](auto begin, auto end) {
         return std::chrono::duration<double, std::milli>(end - begin).count();
+    };
+    // Scope-guard timer, so a bucket stays correct across the `continue`/`break` exits the resource
+    // loop already uses. Reads the clock only when timing is enabled; the whole sub-attribution is
+    // inert (two predictable branches per resource) on a default run.
+    struct ResourcePhaseTimer {
+        bool enabled;
+        double* sink;
+        TimingClock::time_point begin;
+        ResourcePhaseTimer(bool en, double* s)
+            : enabled(en), sink(s),
+              begin(en ? TimingClock::now() : TimingClock::time_point{}) {}
+        ResourcePhaseTimer(const ResourcePhaseTimer&) = delete;
+        ResourcePhaseTimer& operator=(const ResourcePhaseTimer&) = delete;
+        ~ResourcePhaseTimer() {
+            if (enabled)
+                *sink += std::chrono::duration<double, std::milli>(TimingClock::now() - begin)
+                             .count();
+        }
     };
     BackendPipelineCacheStats& pipeline_stats = backend_pipeline_cache_stats_storage();
     pipeline_stats = {};
@@ -4012,6 +4050,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                 const FrameResource& r = R[i];
                 lb[i] = {}; lb[i].binding = r.binding; lb[i].descriptorCount = 1;
                 if (r.is_texture()) {
+                    const ResourcePhaseTimer phase_texture(timing_enabled, &res_texture_ms);
                     lb[i].descriptorType = r.is_storage_image
                         ? VK_DESCRIPTOR_TYPE_STORAGE_IMAGE
                         : VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
@@ -4076,6 +4115,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                         if (found != texture_upload_indices.end()) upload_index = found->second;
                     }
                     if (upload_index == SIZE_MAX) {
+                        const ResourcePhaseTimer phase_upload(timing_enabled,
+                                                              &res_texture_upload_ms);
                         upload_index = texture_uploads.size();
                         texture_uploads.push_back({});
                         SharedTextureUpload& upload = texture_uploads.back();
@@ -4414,6 +4455,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                     if (binding_found != shared_texture_binding_indices.end()) {
                         binding_index = binding_found->second;
                     } else {
+                        const ResourcePhaseTimer phase_bind(timing_enabled, &res_texture_bind_ms);
                         binding_index = shared_texture_bindings.size();
                         SharedTextureBinding binding;
                         const bool persistent_bindings_enabled = share_backend_resources &&
@@ -4489,6 +4531,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                     wr[i] = {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET}; wr[i].dstBinding = r.binding; wr[i].descriptorCount = 1;
                     wr[i].descriptorType = lb[i].descriptorType; wr[i].pImageInfo = &dii[i];
                 } else {
+                    const ResourcePhaseTimer phase_buffer(timing_enabled, &res_buffer_ms);
                     lb[i].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER; lb[i].stageFlags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
                     if (r.is_internal_gds) {
                         const RenderHostBuffer& gds = render_internal_gds_buffer();
@@ -4642,6 +4685,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                 }
             }
             if (!buffer_resources_ready) continue;
+            const ResourcePhaseTimer phase_descriptor(timing_enabled, &res_descriptor_ms);
             for (uint32_t s = 0; s < v.n_sets; s++) {
                 std::vector<VkDescriptorSetLayoutBinding> slb;
                 for (size_t i = 0; i < R.size(); i++) if (R[i].set == s) slb.push_back(lb[i]);
@@ -6188,6 +6232,11 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         call_timing.setup_shader_ms = setup_shader_ms;
         call_timing.setup_fixed_ms = setup_fixed_ms;
         call_timing.setup_resources_ms = setup_resources_ms;
+        call_timing.res_texture_ms = res_texture_ms;
+        call_timing.res_texture_upload_ms = res_texture_upload_ms;
+        call_timing.res_texture_bind_ms = res_texture_bind_ms;
+        call_timing.res_buffer_ms = res_buffer_ms;
+        call_timing.res_descriptor_ms = res_descriptor_ms;
         call_timing.setup_pipeline_ms = setup_pipeline_ms;
         struct TimingTotals {
             uint64_t calls = 0, draws = 0;
@@ -6506,6 +6555,11 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
             PROSPER_SUM_TIMING_STAT(setup_shader_ms);
             PROSPER_SUM_TIMING_STAT(setup_fixed_ms);
             PROSPER_SUM_TIMING_STAT(setup_resources_ms);
+            PROSPER_SUM_TIMING_STAT(res_texture_ms);
+            PROSPER_SUM_TIMING_STAT(res_texture_upload_ms);
+            PROSPER_SUM_TIMING_STAT(res_texture_bind_ms);
+            PROSPER_SUM_TIMING_STAT(res_buffer_ms);
+            PROSPER_SUM_TIMING_STAT(res_descriptor_ms);
             PROSPER_SUM_TIMING_STAT(setup_pipeline_ms);
 #undef PROSPER_SUM_TIMING_STAT
         }

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -535,6 +535,8 @@ struct BackendRenderTimingStats {
     double res_texture_upload_ms = 0;
     double res_texture_bind_ms = 0;
     double res_buffer_ms = 0;
+    double res_buffer_acquire_ms = 0;
+    double res_buffer_copy_ms = 0;
     double res_descriptor_ms = 0;
 
     double total_ms() const {
@@ -3637,6 +3639,11 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     double res_texture_upload_ms = 0.0;
     double res_texture_bind_ms = 0.0;
     double res_buffer_ms = 0.0;
+    // Nested INSIDE res_buffer_ms, splitting the two candidate mechanisms apart: Vulkan object churn
+    // (pool/arena acquisition, which on a miss is create+allocate+bind+map) versus staging memcpy
+    // bandwidth. They imply completely different fixes, so the split is what selects between them.
+    double res_buffer_acquire_ms = 0.0;
+    double res_buffer_copy_ms = 0.0;
     double res_descriptor_ms = 0.0;
     auto setup_elapsed_ms = [](auto begin, auto end) {
         return std::chrono::duration<double, std::milli>(end - begin).count();
@@ -4621,9 +4628,14 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                         buffer_index = shared_buffers.size();
                         SharedBufferUpload upload;
                         const VkDeviceSize bytes = static_cast<VkDeviceSize>(word_count) * 4;
-                        if (use_buffer_arena)
+                        if (use_buffer_arena) {
+                            const ResourcePhaseTimer phase_acquire(timing_enabled,
+                                                                   &res_buffer_acquire_ms);
                             acquire_buffer_arena_slice(bytes, upload);
+                        }
                         if (!upload.arena && reuse_host_buffers) {
+                            const ResourcePhaseTimer phase_acquire(timing_enabled,
+                                                                   &res_buffer_acquire_ms);
                             RenderHostBuffer pooled = acquire_render_host_buffer(ctx, bytes);
                             upload.buffer = pooled.buffer;
                             upload.memory = pooled.memory;
@@ -4666,6 +4678,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                                 upload.range = bytes;
                             }
                         } else {
+                            const ResourcePhaseTimer phase_copy(timing_enabled,
+                                                                &res_buffer_copy_ms);
                             std::memcpy(static_cast<uint8_t*>(upload.mapped) + upload.offset,
                                         words, static_cast<size_t>(bytes));
                             upload.range = bytes;
@@ -6236,6 +6250,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         call_timing.res_texture_upload_ms = res_texture_upload_ms;
         call_timing.res_texture_bind_ms = res_texture_bind_ms;
         call_timing.res_buffer_ms = res_buffer_ms;
+        call_timing.res_buffer_acquire_ms = res_buffer_acquire_ms;
+        call_timing.res_buffer_copy_ms = res_buffer_copy_ms;
         call_timing.res_descriptor_ms = res_descriptor_ms;
         call_timing.setup_pipeline_ms = setup_pipeline_ms;
         struct TimingTotals {
@@ -6559,6 +6575,8 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
             PROSPER_SUM_TIMING_STAT(res_texture_upload_ms);
             PROSPER_SUM_TIMING_STAT(res_texture_bind_ms);
             PROSPER_SUM_TIMING_STAT(res_buffer_ms);
+            PROSPER_SUM_TIMING_STAT(res_buffer_acquire_ms);
+            PROSPER_SUM_TIMING_STAT(res_buffer_copy_ms);
             PROSPER_SUM_TIMING_STAT(res_descriptor_ms);
             PROSPER_SUM_TIMING_STAT(setup_pipeline_ms);
 #undef PROSPER_SUM_TIMING_STAT

--- a/prosper/tests/test_gpu_capture_render.cpp
+++ b/prosper/tests/test_gpu_capture_render.cpp
@@ -1146,6 +1146,88 @@ int main() {
         CHECK(prosper::test::persistent_texture_cache_budget_for_heap(128ull * GiB) == 4ull * GiB,
               "sampled-image auto sizing remains capped at 4 GiB");
 
+        // #1284: the host-buffer staging pool was a flat 256 MiB against a measured 974 MiB working
+        // set on Blue Prince, so it evicted one buffer for every one it created. Size it from host
+        // RAM instead. The floor is the historical default, so no host is given LESS than before.
+        {
+            constexpr uint64_t MiB = 1024ull * 1024ull;
+            using prosper::test::render_host_buffer_pool_limit_bytes;
+            CHECK(render_host_buffer_pool_limit_bytes(nullptr, 0) == 256ull * MiB,
+                  "an unknown host size falls back to the historical 256 MiB pool floor");
+            CHECK(render_host_buffer_pool_limit_bytes(nullptr, 1ull * GiB) == 256ull * MiB,
+                  "a small host is clamped up to the 256 MiB pool floor, never below it");
+            CHECK(render_host_buffer_pool_limit_bytes(nullptr, 8ull * GiB) == 1024ull * MiB,
+                  "an 8 GiB host admits a 1 GiB pool, which covers the measured 974 MiB set");
+            CHECK(render_host_buffer_pool_limit_bytes(nullptr, 16ull * GiB) == 2048ull * MiB,
+                  "a 16 GiB host reaches the 2 GiB pool ceiling");
+            CHECK(render_host_buffer_pool_limit_bytes(nullptr, 128ull * GiB) == 2048ull * MiB,
+                  "pool auto sizing remains capped at 2 GiB");
+            CHECK(render_host_buffer_pool_limit_bytes("256", 128ull * GiB) == 256ull * MiB,
+                  "the pool MiB override takes precedence over host memory");
+            CHECK(render_host_buffer_pool_limit_bytes("64", 128ull * GiB) == 64ull * MiB,
+                  "the override may go BELOW the floor — it is the constrained-host escape hatch "
+                  "and the A/B lever, so it must be exact");
+            CHECK(render_host_buffer_pool_limit_bytes("0", 8ull * GiB) == 0,
+                  "an explicit zero disables pool retention rather than being clamped up");
+        }
+
+        // #1284: eviction must pick the least-recently-released buffer, not an arbitrary hash
+        // bucket. Below any budget smaller than the working set the old policy discarded whichever
+        // capacity class the map happened to order first — very often the one about to be reused —
+        // so raising the budget alone would leave the same failure waiting for a larger title.
+        //
+        // Populated so that the oldest entry is deliberately NOT in the first-inserted class and NOT
+        // in the smallest or largest class: an arbitrary-bucket policy has no reason to select 8192,
+        // so this fails without the fix rather than passing by construction.
+        {
+            using prosper::test::RenderHostBuffer;
+            using prosper::test::RenderHostBufferPool;
+            using prosper::test::render_host_buffer_pool_lru_key;
+
+            RenderHostBufferPool pool;
+            auto add = [&pool](VkDeviceSize capacity, uint64_t stamp) {
+                RenderHostBuffer entry;
+                entry.bytes = capacity;
+                entry.allocation_bytes = capacity;
+                entry.last_use = stamp;
+                pool.available[capacity].push_back(entry);
+            };
+            add(4096, 40);
+            add(8192, 10);          // oldest overall, middle capacity class
+            add(65536, 25);
+            add(1024, 33);
+
+            VkDeviceSize victim = 0;
+            CHECK(render_host_buffer_pool_lru_key(pool, victim),
+                  "a populated pool yields an eviction victim");
+            CHECK(victim == 8192,
+                  "eviction selects the least-recently-released capacity class (8192)");
+
+            // Within a class the front is the oldest, so a newer release must not shadow it.
+            RenderHostBuffer newer;
+            newer.bytes = 8192;
+            newer.allocation_bytes = 8192;
+            newer.last_use = 99;
+            pool.available[8192].push_back(newer);
+            CHECK(render_host_buffer_pool_lru_key(pool, victim) && victim == 8192,
+                  "a later release into the same class does not hide that class's oldest entry");
+
+            // Draining the oldest class hands the victim to the next-oldest, not back to the front
+            // of the map.
+            pool.available.erase(8192);
+            CHECK(render_host_buffer_pool_lru_key(pool, victim) && victim == 65536,
+                  "with the oldest class drained the next-oldest (65536) is selected");
+
+            // Empty classes are skipped rather than selected with a stale zero stamp.
+            pool.available[16384] = {};
+            CHECK(render_host_buffer_pool_lru_key(pool, victim) && victim == 65536,
+                  "an empty capacity class is not a victim despite its zero-valued front");
+
+            RenderHostBufferPool empty;
+            CHECK(!render_host_buffer_pool_lru_key(empty, victim),
+                  "an empty pool reports no victim instead of dereferencing a front");
+        }
+
         // Live exact-extent RTT consumers borrow an immutable snapshot instead of copying it
         // through frontend scratch. FrameResource copies retain that backing through upload setup.
         constexpr uint32_t retained_width = 2;


### PR DESCRIPTION
Refs #1284.

## Failure scenario

The backend's host-visible staging pool retained a flat **256 MiB**. Blue Prince's per-submit staging
working set measures **974 MiB across 503 buffers**, so on that title the pool ran permanently at its
ceiling with **evictions exactly equal to misses** — 215,137 evictions against 215,366 misses in one
arm, 216,976 against 217,205 in another. A cache that destroys one entry for every entry it creates
is not a cache; it is an allocator with extra steps. Every miss pays `vkCreateBuffer` +
`vkAllocateMemory` + `vkBindBufferMemory` + `vkMapMemory`, and every eviction pays `vkUnmapMemory` +
`vkDestroyBuffer` + `vkFreeMemory`.

This sat underneath the term #1284 has been chasing since July: `draw_setup.resources` is **93.7 %**
storage-buffer upload (`res.descriptor` 2.0 %, `res.texture` 1.8 %), and `resources` is ~54 % of the
whole backend submit.

## Behavioural contract

Two independent defects, fixed together because either alone leaves the failure reachable.

**Budget.** `render_host_buffer_pool_limit_bytes(override, physical)` sizes the pool from host RAM —
one eighth, clamped to `[256 MiB, 2 GiB]` — instead of a constant, mirroring the existing reviewed
`texture_decode_cache_limit_bytes`. The floor is the historical 256 MiB, so **no host is given less
than before**. `PROSPER_BACKEND_BUFFER_POOL_MB` still wins outright, including values below the floor
and zero, because it is both the constrained-host escape hatch and the A/B lever and must stay exact.

**Policy.** Eviction took `pool.available.begin()` — an arbitrary `unordered_map` bucket — so under
pressure the pool discarded whichever capacity class the hash happened to order first, very often the
class about to be reused. It is now least-recently-released: each class is a `deque` ordered oldest at
the front, acquire takes the back (hottest pages return first), eviction takes the front.

**The policy half buys no measured throughput, and is kept for determinism only.** A same-binary
alternating A/B at a pinned 256 MiB budget (`policy=lru` vs `policy=arbitrary`, witnessed on the pool
line) returned a **null**: LRU 452.59 vs arbitrary 482.29 µs/draw, a −6.2 % difference against a
49.31 µs within-treatment spread. Under the rule pre-registered *before* that data landed, a null
keeps the policy change justified as determinism rather than speed — it removes a hash-order
dependence, so pool behaviour stops varying with `unordered_map` internals across libstdc++ versions
and insertion histories.

An earlier draft of this section claimed the policy prevents "the same failure waiting for the next
title with a larger working set". **That claim is withdrawn**: a null does not support it, and it is
corrected here rather than left standing. The theory behind it — that a frame touching ~3,500 unique
buffers in repeating order is a cyclic scan, LRU's textbook worst case — also has no measured support
in either direction. Whether a third policy beats both at an under-sized budget is untested.

## Measurement

Four alternating arms (256 / 2048 / 256 / 2048), **one binary**, `PROSPER_BACKEND_BUFFER_POOL_MB` the
only lever, Blue Prince routed gameplay, no snapshot acceleration.

**Witness, checked before any timing is read:** the 256 arms peg at 256.0 MiB with 215,366 / 217,205
misses and 215,137 / 216,976 evictions; the 2048 arms settle at **974.0 MiB / 503 buffers with 503
misses and zero evictions**. The lever moved, in both orderings, to the digit.

| term | 256 MiB | 2048 MiB | delta | within-treatment | between |
|---|---:|---:|---:|---:|---:|
| backend submit | 203.06 | 125.98 | −38.0 % raw | 10.62 | 77.09 |
| `res_buffer` | 113.10 | 41.50 | −63.3 % | 16.76 | 71.60 |
| `copy` | 92.54 | 33.27 | −64.0 % | 18.19 | 59.27 |
| `acquire` | 13.65 | 1.44 | −89.5 % | 0.95 | 12.22 |
| `cleanup` | 14.77 | 2.95 | −80.1 % | 0.14 | 11.82 |
| draws | 2218.15 | 2109.47 | +4.9 % | 35.10 | 108.67 |

**Quote the per-draw figure, −34.8 %** (0.0915 → 0.0597 ms/draw), not the raw −38.0 %: the draws row
shows the 2048 arms sampled a systematically ~4.9 % lighter scene, an expected selection effect of a
faster arm covering more of a fixed-duration route. Controls: per-submit byte volume is identical
between arms (`logical=1,644.0 / 1,764.4 MiB`, `materialized=0.0 MiB`), so the 2048 arm copies the
same bytes faster.

**Mechanism is recorded as a hypothesis, not a finding.** Minor faults sampled from
`/proc/<pid>/stat` run at 150,911/s for the 256 arm against 48,827/s and 97,398/s for the two 2048
arms, consistent with first-touch faulting on freshly mapped staging pages — but the two 2048 arms
differ from each other by 2×, nearly the size of the gap, and explaining the whole `copy` delta by
faults alone needs ~3 µs per fault, well above a generic anonymous-page fault. Page-table/TLB churn
from ~216k map/unmap pairs is the other candidate. **The fix does not depend on which it is.**

## Set expectations honestly

**This is not 30 FPS.** 203 → 126 ms is roughly **5 → 8 backend submits per second against a bar of
30.** It is real progress and it is not the answer. Even fixed, `copy` is still **33.27 ms** and
`res_buffer` **41.50 ms** of a 126 ms submit — this change stops the pool *thrashing while it copies*,
it does not stop the copying. The structural follow-up that removes the copy rather than shrinking it
is importing guest pages as Vulkan memory (`VK_EXT_external_memory_host`; prosper uses it nowhere
today — no `vkGetMemoryHostPointerPropertiesEXT` / `VkImportMemoryHostPointerInfoEXT` in the tree), or
a versioned guest-identity buffer cache. The second reuses the #1703 machinery but carries the
#611/#780 stale-data risk; the first does not, because the GPU would read the guest bytes rather than
a snapshot of them.

For scale, the rest of the frame after this change: `fixed` ~25 ms, `readback` ~15 ms, `gpu_wait`
~7 ms, `record_upload` ~3 ms — and `gpu_device` **4.31 ms**, i.e. the GPU is idle ~97 % of the submit.
No single remaining term reaches 30 FPS on this title.

## How this was nearly missed — a measurement boundary read as a causal one

I built the `res_buffer` sub-attribution specifically to stop the term being misread, and then
misread it. I first priced this fix at **~7 %**, because `acquire` measured 13.64 ms against `copy`'s
83.80 ms, so allocation churn was "obviously" the small half. That is wrong: `acquire` measures only
the allocation *calls*; most of the churn cost lands in `copy`, because freshly-mapped staging pages
fault on first write.

> I'd drawn the sub-attribution boundary at the API call and read it as the mechanism.

This is the same shape as the reading that opened #1284 — "~63 µs per draw for descriptor setup",
when `draw_setup.resources` never measured descriptors at all and the real descriptor cost is ~1 µs.
Both are a **measurement boundary mistaken for a causal one**, and it caught two people on the same
term within one day. It is also, in hindsight, the missing explanation for round 1's unexplained
neutral descriptor-reuse result: that experiment was correct and optimised 2 % of the term.

The general rule, worth more than this patch: a sub-bucket tells you *where the clock was running*,
not *what caused the cost*. When a sub-attribution says "the expensive half is X", check whether the
cheap half can be *causing* the expensive one before ranking fixes by it.

## Affected and deliberately unaffected

**Cannot change rendered output.** The same bytes are uploaded from the same sources; only the
recycling of host staging buffers changes. The risk is memory footprint, not correctness — which is
exactly why the budget is a fraction of host RAM rather than a larger constant, and why the floor is
the old default. On an 8 GiB host the budget is 1 GiB; on ≥16 GiB it is the 2 GiB ceiling.

Also in this branch (instrumentation, no behaviour change): the `draw_setup.resources`
sub-attribution that located the term, behind the existing `PROSPER_RENDER_TIMING` gate.

## Verification

- `ctest`: **171/173**. The two failures — `module_loads_eboot`, `boot_reaches_first_syscall` — are
  pinned to **The Messenger** (`PPSA24651-app0`, the `CMakeLists` `GAME_DUMP` default; the test
  asserts its 612 imports / 35 import libraries) and this build is configured against Blue Prince for
  renderer work. **Confirmed to fail identically on unmodified master with the same `-DGAME_DUMP`**,
  so they are a build-configuration artifact rather than a regression. Now documented in
  `docs/VERIFICATION.md` so the next reader does not re-diagnose them.
- **Both new behaviours fail without the fix** — verified by reverting each and observing **7
  failures**: the budget table across 0 / 1 / 8 / 16 / 128 GiB hosts plus override precedence
  (including below-floor and zero), and the LRU victim policy including same-class ordering,
  drained-class fallthrough, empty-class skipping, and the empty-pool case. Victim selection is a
  pure function over pool state, so the policy is testable without a Vulkan device.
- Sub-attribution closure: offline `hall.prgcap` `resources` 824.63 = 762.72 + 56.15 + 3.53 + 2.22
  (closes to 0.01 ms); live 94.99 = 88.81 + 2.56 + 1.80 + 1.79 (closes to 0.03 ms).

## Risks

- **Memory footprint.** Up to 2 GiB of host-visible staging retained on a capable host, alongside the
  decoded-texture cache's own budget. Bounded by construction, overridable, and never below today's
  256 MiB.
- The LRU scan is over capacity classes (~20–30 power-of-two sizes), not cached entries, and only runs
  when the budget is actually reached — which, with the budget fixed, is rare.
- All four measurement arms above ran **contended**; a clean-box confirmation run is posted as a
  comment on this PR.

