### PR TITLE
feat(loader): real runtime PRX loading for sceKernelLoadStartModule (#639)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -961,6 +961,17 @@ if(TARGET prosper_core)
                COMMAND test_boot_linux "${GAME_DUMP}")
     endif()
 
+    if(NOT APPLE)
+      # Real runtime PRX loading (#639). Hermetic: the test writes its own synthetic PRX outside
+      # Media/Plugins, so it needs no game dump — but it maps that module at the fixed runtime-module
+      # base and EXECUTES its module_start, so it is host-x86-64 only (the same constraint every
+      # guest-execution test here has). Its scratch root goes in the build tree, never /tmp.
+      add_executable(test_runtime_prx_load tests/test_runtime_prx_load.cpp)
+      target_link_libraries(test_runtime_prx_load PRIVATE prosper_core)
+      add_test(NAME runtime_prx_load
+               COMMAND test_runtime_prx_load "${CMAKE_CURRENT_BINARY_DIR}/runtime-prx-test-root")
+    endif()
+
     # Regression test for the real setjmp/longjmp impl (x86-64 asm; used by the GC's root scan).
     add_executable(test_setjmp tests/test_setjmp.cpp)
     target_link_libraries(test_setjmp PRIVATE prosper_core)

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -961,11 +961,11 @@ if(TARGET prosper_core)
                COMMAND test_boot_linux "${GAME_DUMP}")
     endif()
 
-    if(NOT APPLE)
+    if(NOT APPLE AND CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|amd64|AMD64)$")
       # Real runtime PRX loading (#639). Hermetic: the test writes its own synthetic PRX outside
       # Media/Plugins, so it needs no game dump — but it maps that module at the fixed runtime-module
-      # base and EXECUTES its module_start, so it is host-x86-64 only (the same constraint every
-      # guest-execution test here has). Its scratch root goes in the build tree, never /tmp.
+      # base and EXECUTES its module_start, whose bytes the test emits by hand, so it is host-x86-64
+      # only. Its scratch root goes in the build tree, never /tmp.
       add_executable(test_runtime_prx_load tests/test_runtime_prx_load.cpp)
       target_link_libraries(test_runtime_prx_load PRIVATE prosper_core)
       add_test(NAME runtime_prx_load

--- a/prosper/src/hle/dispatch.cpp
+++ b/prosper/src/hle/dispatch.cpp
@@ -41,7 +41,7 @@ namespace {
 #ifdef _WIN32
     bool executable_guest_address(uint64_t address) {
         // #1659: module range, not the pre-#825 literal (which admitted the DMEM aperture).
-        if (!prosper::guest_va_in_module(address) || address >= prosper::BOOT_STUB) return false;
+        if (!prosper::guest_va_in_module_code(address)) return false;
         MEMORY_BASIC_INFORMATION memory{};
         if (!VirtualQuery((const void*)(uintptr_t)address, &memory, sizeof(memory)) ||
             memory.State != MEM_COMMIT || (memory.Protect & PAGE_GUARD)) return false;
@@ -136,11 +136,12 @@ void dispatch_init(const std::vector<ImportSlot>* slots, NidDb* db) {
     if (slots) { std::lock_guard<std::mutex> lk(g_unimpl_mx); g_count.assign(slots->size(), 0); }
 }
 void dispatch_grow_slots(const std::vector<ImportSlot>* slots) {
-    g_slots = slots;
-    if (!slots) return;
+    if (!slots) { std::lock_guard<std::mutex> lk(g_unimpl_mx); g_slots = nullptr; return; }
     // resize(), not assign(): the run is already under way and the counts of the pre-linked slots
-    // are live census data. New slots start at zero like every other slot did.
+    // are live census data. New slots start at zero like every other slot did. Both the pointer and
+    // the count vector are published UNDER the lock prosper_on_unimpl reads them under.
     std::lock_guard<std::mutex> lk(g_unimpl_mx);
+    g_slots = slots;
     if (g_count.size() < slots->size()) g_count.resize(slots->size(), 0);
 }
 size_t dispatch_append_slots(std::vector<ImportSlot>* slots, const std::vector<ImportSlot>& add) {

--- a/prosper/src/hle/dispatch.cpp
+++ b/prosper/src/hle/dispatch.cpp
@@ -135,6 +135,22 @@ void dispatch_init(const std::vector<ImportSlot>* slots, NidDb* db) {
     // Pre-size the call-count vector to the import table so prosper_on_unimpl never allocates.
     if (slots) { std::lock_guard<std::mutex> lk(g_unimpl_mx); g_count.assign(slots->size(), 0); }
 }
+void dispatch_grow_slots(const std::vector<ImportSlot>* slots) {
+    g_slots = slots;
+    if (!slots) return;
+    // resize(), not assign(): the run is already under way and the counts of the pre-linked slots
+    // are live census data. New slots start at zero like every other slot did.
+    std::lock_guard<std::mutex> lk(g_unimpl_mx);
+    if (g_count.size() < slots->size()) g_count.resize(slots->size(), 0);
+}
+size_t dispatch_append_slots(std::vector<ImportSlot>* slots, const std::vector<ImportSlot>& add) {
+    std::lock_guard<std::mutex> lk(g_unimpl_mx);
+    const size_t first = slots->size();
+    slots->insert(slots->end(), add.begin(), add.end());
+    g_slots = slots;
+    if (g_count.size() < slots->size()) g_count.resize(slots->size(), 0);
+    return first;
+}
 void reset_call_log() { std::lock_guard<std::mutex> lk(g_unimpl_mx); g_order.clear();
                         for (auto& c : g_count) c = 0; }
 const std::vector<uint32_t>& call_order() { return g_order; }

--- a/prosper/src/hle/dispatch.hpp
+++ b/prosper/src/hle/dispatch.hpp
@@ -68,6 +68,18 @@ public:
 // Wire the unimplemented-call logger to the global stub-slot table + name DB.
 void dispatch_init(const std::vector<ImportSlot>* slots, NidDb* db);
 
+// Re-point the logger at a stub-slot table that GREW after dispatch_init (#639: a runtime-loaded
+// PRX appends slots for imports no already-linked module satisfies). Unlike dispatch_init this
+// only extends the per-slot call-count vector — it must not reset the counts of slots the guest
+// has already called, or the unimplemented-call census silently restarts mid-run.
+void dispatch_grow_slots(const std::vector<ImportSlot>* slots);
+
+// Append import slots to the live table under the SAME lock prosper_on_unimpl takes (#639).
+// The runtime loader appends from a guest thread while other guest threads may be calling an
+// unimplemented import, and an unsynchronised push_back would move the vector's buffer out from
+// under `(*g_slots)[idx]`. Returns the index the first appended slot landed on.
+size_t dispatch_append_slots(std::vector<ImportSlot>* slots, const std::vector<ImportSlot>& add);
+
 // Register the built-in HLE implementations (libc thunks, CRT no-ops, libkernel
 // primitives). Call before install_stubs.
 void register_builtin_hle();
@@ -239,6 +251,11 @@ struct UnwindModuleDesc {
 };
 // Install module unwind descriptors (call after images are mapped). Enables sceKernelGetModuleInfoForUnwind.
 void set_unwind_modules(const UnwindModuleDesc* descs, size_t count);
+// Append one module's unwind descriptor after boot (#639), returning the index it landed on.
+// `d.name` must outlive the run. The caller must append the same module's export table
+// (add_module_export_table) so the two orders stay parallel — sceKernelGetModuleInfoFromAddr
+// derives a handle from the unwind order and sceKernelDlsym consumes it against the export order.
+size_t add_unwind_module(const UnwindModuleDesc& d);
 
 // Windows-only fatal-fault diagnostics. Other hosts provide empty implementations.
 void trace_guest_stack_query(uint64_t target, bool found, void* base, size_t size);
@@ -279,7 +296,19 @@ void set_module_exports(const std::unordered_map<std::string, uint64_t>* exports
 // when the requested path names one of these (basename match), and sceKernelDlsym consults the
 // handle's module before the global first-definition-wins table. Table pointers must outlive the run.
 struct ModuleExportTable { std::string path; const std::unordered_map<std::string, uint64_t>* nids; };
+// Base of the handles sceKernelLoadStartModule and sceKernelGetModuleInfoFromAddr hand out.
+// SceKernelModule is a 32-bit int on PS5 (R-Type Delta stores it in an int array and tests it
+// against zero), so the handle space must stay small and positive.
+inline constexpr uint64_t kSceModuleHandleBase = 0x10000;
 void set_module_export_tables(std::vector<ModuleExportTable> tables);
+// Append ONE module's export table after boot (#639: real runtime PRX loading). Additive
+// counterpart of set_module_export_tables — the pre-linked set keeps its handles and its
+// first-definition-wins precedence, and the new module is appended after it. Safe to call while
+// the guest runs; `nids` must outlive the run and must not be mutated afterwards. Returns the
+// handle sceKernelLoadStartModule reports for the module (the same value module_handle_for_path
+// answers for its path from then on).
+uint64_t add_module_export_table(std::string path,
+                                 const std::unordered_map<std::string, uint64_t>* nids);
 // Handle for a guest load path naming a registered module (basename match), or 0 if unknown —
 // the caller (k_load_start_mod) then falls back to its synthetic success handle.
 uint64_t module_handle_for_path(const char* path);

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -1991,7 +1991,7 @@ namespace {
     // Real linked-module handles are stable by load order. The unwind descriptors and per-module
     // export tables are built from that same order, so address lookup can publish the handle expected
     // by sceKernelGetModuleInfoFromAddr and later consume it in sceKernelDlsym.
-    constexpr uint64_t kModuleHandleBase = 0x10000;
+    constexpr uint64_t kModuleHandleBase = kSceModuleHandleBase;
     // Decode the eh_frame pointer out of an .eh_frame_hdr. Layout: [0]=version(1), [1]=eh_frame_ptr_enc,
     // [2]=fde_count_enc, [3]=table_enc, [4..]=eh_frame_ptr (encoded). The common encoding is 0x1B
     // (DW_EH_PE_pcrel|sdata4): a signed 32-bit offset from the field's own address.
@@ -2062,6 +2062,16 @@ HLE(k_get_module_info_from_addr) {   // (VAddr addr, int n, ModuleInfo* info)
 }
 void set_unwind_modules(const UnwindModuleDesc* d, size_t c) {
     std::lock_guard<std::mutex> lk(g_unwind_mx); g_unwind_mods.assign(d, d + c);
+}
+// #639: a runtime-loaded module appends here. The index it lands on is the same index the module's
+// export table lands on in g_mod_exports below, because k_get_module_info_from_addr derives a
+// handle from THIS vector while sceKernelDlsym consumes it against THAT one — the two must stay
+// parallel or an address-derived handle names a different module than it resolves through. The
+// runtime loader appends to both, once per module, and checks the two indices agree.
+size_t add_unwind_module(const UnwindModuleDesc& d) {
+    std::lock_guard<std::mutex> lk(g_unwind_mx);
+    g_unwind_mods.push_back(d);
+    return g_unwind_mods.size() - 1;
 }
 
 // ---- Async exception delivery = the IL2CPP GC's stop-the-world thread suspension ----
@@ -3157,6 +3167,11 @@ HLE(k_is_stack) {   // sceKernelIsStack(void* addr): is addr within the current 
 namespace {
     const std::unordered_map<std::string, uint64_t>* g_exports = nullptr;
     std::vector<ModuleExportTable> g_mod_exports;   // per-module tables (#147)
+    // Guards g_mod_exports only. Before #639 the vector was written once, before the guest ran;
+    // real runtime PRX loading appends to it from a guest thread while other guest threads are
+    // inside sceKernelDlsym / sceKernelLoadStartModule. The registered maps themselves are never
+    // mutated after publication, so the lock covers the vector and the lookup that borrows into it.
+    std::mutex g_mod_exports_mx;
     const char* path_basename(const char* p) {
         const char* b = p;
         for (const char* c = p; *c; c++) if (*c == '/' || *c == '\\') b = c + 1;
@@ -3173,10 +3188,20 @@ namespace {
     }
 }
 void set_module_exports(const std::unordered_map<std::string, uint64_t>* exports) { g_exports = exports; }
-void set_module_export_tables(std::vector<ModuleExportTable> tables) { g_mod_exports = std::move(tables); }
+void set_module_export_tables(std::vector<ModuleExportTable> tables) {
+    std::lock_guard<std::mutex> lk(g_mod_exports_mx);
+    g_mod_exports = std::move(tables);
+}
+uint64_t add_module_export_table(std::string path,
+                                 const std::unordered_map<std::string, uint64_t>* nids) {
+    std::lock_guard<std::mutex> lk(g_mod_exports_mx);
+    g_mod_exports.push_back({ std::move(path), nids });
+    return kModuleHandleBase + (g_mod_exports.size() - 1);
+}
 uint64_t module_handle_for_path(const char* path) {
     if (!path || !*path) return 0;
     const char* want = path_basename(path);
+    std::lock_guard<std::mutex> lk(g_mod_exports_mx);
     for (size_t i = 0; i < g_mod_exports.size(); i++)
         if (ieq(path_basename(g_mod_exports[i].path.c_str()), want))
             return kModuleHandleBase + i;
@@ -3191,24 +3216,54 @@ HLE(k_dlsym) {   // sceKernelDlsym(SceKernelModule handle, const char* name, voi
     // name; synthetic handles for unknown paths land here). We hash the name to its Sony NID
     // (nid_hash); a hit is written through *funcAddr and reported as success.
     const char* name = a1 ? (const char*)(uintptr_t)a1 : nullptr;
-    if (name && a0 >= kModuleHandleBase && a0 - kModuleHandleBase < g_mod_exports.size()) {
-        if (const auto* nids = g_mod_exports[a0 - kModuleHandleBase].nids) {
-            auto it = nids->find(nid_hash(name));
-            if (it != nids->end()) {
-                if (a2) *(uint64_t*)(uintptr_t)a2 = it->second;
-                if (getenv("PROSPER_SYNCLOG"))
-                    fprintf(stderr, "[dlsym] '%s' (module handle 0x%llx) -> 0x%llx\n",
-                            name, (unsigned long long)a0, (unsigned long long)it->second);
-                return 0;
-            }
+    const std::string want = name ? nid_hash(name) : std::string();
+    if (name) {
+        uint64_t hit = 0;
+        {
+            std::lock_guard<std::mutex> lk(g_mod_exports_mx);
+            if (a0 >= kModuleHandleBase && a0 - kModuleHandleBase < g_mod_exports.size())
+                if (const auto* nids = g_mod_exports[a0 - kModuleHandleBase].nids) {
+                    auto it = nids->find(want);
+                    if (it != nids->end()) hit = it->second;
+                }
+        }
+        if (hit) {
+            if (a2) *(uint64_t*)(uintptr_t)a2 = hit;
+            if (getenv("PROSPER_SYNCLOG"))
+                fprintf(stderr, "[dlsym] '%s' (module handle 0x%llx) -> 0x%llx\n",
+                        name, (unsigned long long)a0, (unsigned long long)hit);
+            return 0;
         }
     }
     if (name && g_exports) {
-        auto it = g_exports->find(nid_hash(name));
+        auto it = g_exports->find(want);
         if (it != g_exports->end()) {
             if (a2) *(uint64_t*)(uintptr_t)a2 = it->second;   // *funcAddr = export
             if (getenv("PROSPER_SYNCLOG"))
                 fprintf(stderr, "[dlsym] '%s' -> 0x%llx\n", name, (unsigned long long)it->second);
+            return 0;
+        }
+    }
+    // #639: g_exports covers only the pre-linked program, so a name-only dlsym (no handle, or a
+    // handle the caller never obtained from LoadStartModule) would miss a module the guest loaded
+    // at runtime. Scan the registered per-module tables in registration order — for a pre-linked
+    // module this can only reproduce what g_exports already answered above, so the pre-linked
+    // first-definition-wins order is preserved and only runtime modules are added, last.
+    if (name) {
+        uint64_t hit = 0; const char* from = nullptr;
+        {
+            std::lock_guard<std::mutex> lk(g_mod_exports_mx);
+            for (const auto& me : g_mod_exports) {
+                if (!me.nids) continue;
+                auto it = me.nids->find(want);
+                if (it != me.nids->end()) { hit = it->second; from = me.path.c_str(); break; }
+            }
+        }
+        if (hit) {
+            if (a2) *(uint64_t*)(uintptr_t)a2 = hit;
+            if (getenv("PROSPER_SYNCLOG"))
+                fprintf(stderr, "[dlsym] '%s' -> 0x%llx (runtime-loaded %s)\n", name,
+                        (unsigned long long)hit, from ? from : "?");
             return 0;
         }
     }

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -2920,7 +2920,7 @@ void dump_guest_thread_trace(const char* path, uint64_t pthread_filter) {
         for (size_t i = 0; i < stack_bytes / sizeof(uint64_t) && guest_return_count < 8; ++i) {
             const uint64_t candidate = stack_words[i];
             // #1659: module range, not the pre-#825 literal.
-            if (!prosper::guest_va_in_module(candidate) || candidate >= prosper::BOOT_STUB) continue;
+            if (!prosper::guest_va_in_module_code(candidate)) continue;
             bool in_guest_module = false;
             for (const UnwindModuleDesc& guest_module : modules)
                 in_guest_module |= candidate >= guest_module.lo && candidate < guest_module.hi;
@@ -3250,20 +3250,21 @@ HLE(k_dlsym) {   // sceKernelDlsym(SceKernelModule handle, const char* name, voi
     // module this can only reproduce what g_exports already answered above, so the pre-linked
     // first-definition-wins order is preserved and only runtime modules are added, last.
     if (name) {
-        uint64_t hit = 0; const char* from = nullptr;
-        {
+        uint64_t hit = 0;
+        std::string from;   // COPY, not c_str(): a concurrent add_module_export_table can realloc
+        {                   // g_mod_exports and free the string buffer the moment the lock drops.
             std::lock_guard<std::mutex> lk(g_mod_exports_mx);
             for (const auto& me : g_mod_exports) {
                 if (!me.nids) continue;
                 auto it = me.nids->find(want);
-                if (it != me.nids->end()) { hit = it->second; from = me.path.c_str(); break; }
+                if (it != me.nids->end()) { hit = it->second; from = me.path; break; }
             }
         }
         if (hit) {
             if (a2) *(uint64_t*)(uintptr_t)a2 = hit;
             if (getenv("PROSPER_SYNCLOG"))
                 fprintf(stderr, "[dlsym] '%s' -> 0x%llx (runtime-loaded %s)\n", name,
-                        (unsigned long long)hit, from ? from : "?");
+                        (unsigned long long)hit, from.c_str());
             return 0;
         }
     }

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -4629,7 +4629,7 @@ uint64_t sync_guest_caller() {
         uint64_t v = sp[i];
         // #1659: says "guest MODULES only" and now means it — the old lower bound admitted the
         // pre-#825 aperture, which is direct memory, not a module.
-        if (!prosper::guest_va_in_module(v) || v >= prosper::BOOT_STUB) continue;
+        if (!prosper::guest_va_in_module_code(v)) continue;
         if ((v & 0xfff) < 8) continue;                             // keep the 6-byte look-back on v's page
         // A stack word in the guest range may be data, not a return address, and could point at an
         // UNMAPPED gap between modules — so confirm the page is committed+readable before dereferencing

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -4,6 +4,9 @@
 #include "nid.hpp"
 #include "hle_kernel_time.hpp"
 #include "../host/boot_program.hpp"   // #1659: shared guest-module labelling
+#include "../host/posix_shim.hpp"     // PROSPER_ASM_TRAMPOLINE (pass entry %rsp as 7th arg)
+#include "../host/runtime_module_load.hpp"   // #639: real runtime PRX loading
+#include "callback_fs.hpp"            // recover the caller's guest %fs from the import-stub frame
 #include "sce_errno.hpp"    // #1612: the guest reads FreeBSD errnos, not this host's
 #include "heap_mutex.hpp"   // #707: keep hot equeue/APR mutexes off macOS __DATA
 #include "sync_futex.hpp"
@@ -516,13 +519,50 @@ HLE(k_ok)              { return 0; }                       // generic success no
 // load succeeded and called exports that resolved to ESRCH fallbacks / the wrong module instead of
 // getting the honest ENOENT. Return SCE_KERNEL_ERROR_ENOENT for a miss so the guest takes its
 // module-not-found path. Both current titles preload every PRX they use, so no real load misses.
-HLE(k_load_start_mod)  {
-    if (uint64_t h = module_handle_for_path(a0 ? (const char*)P(a0) : nullptr)) return h;
+// sceKernelLoadStartModule(const char* name, size_t args, const void* argp, uint32_t flags,
+//                          const SceKernelLoadModuleOpt* opt, int* pRes)
+static uint64_t load_start_mod_run(uint64_t a0, uint64_t a1, uint64_t a2, uint64_t a5,
+                                   uint64_t guest_fs) {
+    const char* path = a0 ? (const char*)P(a0) : nullptr;
+    // A pre-linked module (the fixed set plus the Media/Plugins auto-link, #1609) already has a
+    // handle; hand back the same one rather than mapping a second copy. This is also what makes a
+    // repeat load of a runtime-loaded module idempotent — it is registered here too, by basename,
+    // which is the PS5's own module identity.
+    if (uint64_t h = module_handle_for_path(path)) {
+        if (a5) *(int32_t*)P(a5) = 0;
+        return h;
+    }
+    // Not pre-linked: load it for real (#639). Only an absent/unloadable file is an error now.
+    uint64_t handle = 0; int32_t res = 0;
+    const uint64_t rc = runtime_load_start_module(path, a1, a2, guest_fs, &res, &handle);
+    if (rc == 0) {
+        if (a5) *(int32_t*)P(a5) = res;
+        return handle;
+    }
     if (getenv("PROSPER_MODLOG"))
-        fprintf(stderr, "[loadmod] '%s' not in the linked module set -> ENOENT\n",
-                a0 ? (const char*)P(a0) : "(null)");
-    return 0x80020002ull;   // SCE_KERNEL_ERROR_ENOENT (a non-preloaded PRX isn't present)
+        fprintf(stderr, "[loadmod] '%s' could not be loaded -> 0x%llx\n",
+                path ? path : "(null)", (unsigned long long)rc);
+    return rc;
 }
+#ifndef _WIN32
+// The module's own module_start / init_array is GUEST code. Under the guest-%fs gate this handler
+// runs on the host %fs (the import stub swapped), so recover the caller's guest thread pointer from
+// the import-stub frame and start the module on it — the same entry-rsp trampoline the AvPlayer and
+// IME callbacks use (#1286). callback_guest_fs_from_entry_stack returns 0 for a non-guest frame, so
+// a plain tail-jump boot is an unchanged direct call.
+extern "C" uint64_t k_load_start_mod_c(uint64_t a0, uint64_t a1, uint64_t a2, uint64_t a3,
+                                       uint64_t a4, uint64_t a5, uint64_t entry_rsp) {
+    (void)a3; (void)a4;
+    return load_start_mod_run(a0, a1, a2, a5, callback_guest_fs_from_entry_stack(entry_rsp));
+}
+PROSPER_ASM_TRAMPOLINE(k_load_start_mod_entry, k_load_start_mod_c)
+extern "C" void k_load_start_mod_entry();
+#else
+HLE(k_load_start_mod) {   // Windows/MinGW: no import-boundary %fs swap -> guest_fs = 0
+    (void)a3; (void)a4;
+    return load_start_mod_run(a0, a1, a2, a5, 0);
+}
+#endif
 
 // _exit(status): terminate the process. Previously an unimplemented stub RETURNED 0, so libc's
 // exit path fell through into its deliberate ud2 (SIGILL) — terminate for real, loudly.
@@ -1421,7 +1461,11 @@ void register_kernel_time_hle() {
     R("sceSysmoduleLoadModule", k_ok);
     R("sceSysmoduleUnloadModule", k_ok);
     R("sceSysmoduleIsLoaded", k_ok);
+#ifndef _WIN32
+    R("sceKernelLoadStartModule", k_load_start_mod_entry);   // entry-rsp trampoline (#639)
+#else
     R("sceKernelLoadStartModule", k_load_start_mod);
+#endif
     R("sceKernelStopUnloadModule", k_ok);
     // Thread scheduling: Set*/Get* are registered in hle_kernel.cpp, where the Get* handlers FILL
     // their out-params (affinity mask 0xff, priority 700) — a Get* that returns success without

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -512,13 +512,12 @@ HLE(k_clock_getres) { if (a1) { int64_t* r = (int64_t*)P(a1); r[0] = 0; r[1] = 1
 
 // --- assorted libkernel stubs ---
 HLE(k_ok)              { return 0; }                       // generic success no-op
-// sceKernelLoadStartModule(path, ...): the PRX are pre-linked into our address space, so "loading"
-// resolves the path to its linked module and returns a REAL handle — dlsym then consults that
-// module's own exports first (#147). A path NOT in the linked set previously got a fake
-// monotonically-increasing success handle while loading nothing (#146): the guest then believed the
-// load succeeded and called exports that resolved to ESRCH fallbacks / the wrong module instead of
-// getting the honest ENOENT. Return SCE_KERNEL_ERROR_ENOENT for a miss so the guest takes its
-// module-not-found path. Both current titles preload every PRX they use, so no real load misses.
+// sceKernelLoadStartModule: a PRX already in the linked set resolves to its REAL handle, and dlsym
+// then consults that module's own exports first (#147). A path NOT in the linked set used to get a
+// fake monotonically-increasing success handle while loading nothing (#146) — the guest believed
+// the load succeeded and called exports that resolved to ESRCH fallbacks — and then, once that was
+// removed, an honest ENOENT for a capability prosper did not have. Since #639 it is a real load:
+// only a genuinely absent or unloadable file is an error. See host/runtime_module_load.hpp.
 // sceKernelLoadStartModule(const char* name, size_t args, const void* argp, uint32_t flags,
 //                          const SceKernelLoadModuleOpt* opt, int* pRes)
 static uint64_t load_start_mod_run(uint64_t a0, uint64_t a1, uint64_t a2, uint64_t a5,

--- a/prosper/src/host/boot_program.cpp
+++ b/prosper/src/host/boot_program.cpp
@@ -91,6 +91,7 @@ std::vector<std::string> discover_extra_plugin_modules(
 
 #if defined(__linux__) || defined(__APPLE__) || defined(_WIN32)
 #include "host/exec_image.hpp"
+#include "host/runtime_module_load.hpp"
 #include "hle/dispatch.hpp"
 #include "self/module.hpp"     // PT_SCE_PROCPARAM
 #include <cstdio>
@@ -268,8 +269,14 @@ bool boot_program(const std::string& d, Program& p, std::string* err,
     for (auto& s : p.mods[0]->segments)
         if (s.type == PT_SCE_PROCPARAM) { set_proc_param(BOOT_EBOOT + s.vaddr); break; }
 
+    // A runtime sceKernelLoadStartModule appends import slots to this same vector (#639). Reserve
+    // headroom so the common case never reallocates the buffer the dispatcher indexes; the append
+    // is synchronised either way (dispatch_append_slots), this just avoids the copy.
+    p.slots.reserve(p.slots.size() + 1024);
     if (!install_stubs(p.slots, p.stub_base, p.stub_size, &e)) return fail("stubs failed: " + e);
     install_trap_handler();
+    // Enable real runtime PRX loading now that the fixed set is linked, mapped and stubbed (#639).
+    runtime_module_loader_init(&p);
 
     // PSN.prx / SaveData.prx native plugins validate a module-param descriptor and null-fault if
     // started with (argc=0, argp=NULL). Register their guest ranges so run_guest_inits starts them

--- a/prosper/src/host/boot_program.hpp
+++ b/prosper/src/host/boot_program.hpp
@@ -39,6 +39,18 @@ inline constexpr uint64_t BOOT_PLUGIN_AUTO_BASE  = 0x5d0000000ull;
 inline constexpr uint64_t BOOT_PLUGIN_AUTO_STRIDE = 0x4000000ull;   // 64 MiB
 inline constexpr unsigned BOOT_PLUGIN_AUTO_SLOTS  = 10;
 inline constexpr uint64_t BOOT_STUB     = 0x600000000ull;
+// Base pool for PRXs the guest loads at RUNTIME via sceKernelLoadStartModule (#639) — modules that
+// are NOT in the fixed preload list above, because the path is only known while the title runs
+// (R-Type Delta ships 24 per-stage modules under /app0/prx/). Placed ABOVE the import-stub
+// aperture: callback_fs.hpp recognises a guest import-stub frame by a return address in
+// [0x600000000,0x700000000), so nothing else may be mapped inside that window. 128 MiB per slot
+// bounds each module (the whole local corpus's largest module image is ~251 MiB, and the loader
+// refuses anything that does not fit rather than overlapping its neighbour).
+inline constexpr uint64_t BOOT_RUNTIME_MODULE_BASE   = 0x700000000ull;
+inline constexpr uint64_t BOOT_RUNTIME_MODULE_STRIDE = 0x8000000ull;   // 128 MiB
+inline constexpr unsigned BOOT_RUNTIME_MODULE_SLOTS  = 48;
+inline constexpr uint64_t BOOT_RUNTIME_MODULE_END =
+    BOOT_RUNTIME_MODULE_BASE + (uint64_t)BOOT_RUNTIME_MODULE_SLOTS * BOOT_RUNTIME_MODULE_STRIDE;
 
 // --- Guest-address labelling, shared by every diagnostic that prints "<module>+0x<rva>" ----------
 //
@@ -77,6 +89,10 @@ inline const char* guest_module_name(uint64_t a) {
     if (a >= BOOT_LIBC          && a < BOOT_PLUGIN_AUTO_BASE) return "libc.prx";
     if (a >= BOOT_PLUGIN_AUTO_BASE && a < BOOT_STUB)       return "plugin";
     if (a >= BOOT_STUB          && a < 0x610000000ull)     return "STUB";
+    // Runtime-loaded PRX (#639). Like the plugin pool this is one label for the whole aperture:
+    // which slot holds which module is a run-local fact, so the offset is reported modulo the
+    // stride and the exact module comes from the loader's own [loadmod] line.
+    if (a >= BOOT_RUNTIME_MODULE_BASE && a < BOOT_RUNTIME_MODULE_END) return "runtime-prx";
     return "mapped/host";
 }
 inline uint64_t guest_module_offset(uint64_t a) {
@@ -98,11 +114,14 @@ inline uint64_t guest_module_offset(uint64_t a) {
     if (a >= BOOT_PLUGIN_AUTO_BASE && a < BOOT_STUB)
         return (a - BOOT_PLUGIN_AUTO_BASE) % BOOT_PLUGIN_AUTO_STRIDE;
     if (a >= BOOT_STUB          && a < 0x610000000ull)     return a - BOOT_STUB;
+    if (a >= BOOT_RUNTIME_MODULE_BASE && a < BOOT_RUNTIME_MODULE_END)
+        return (a - BOOT_RUNTIME_MODULE_BASE) % BOOT_RUNTIME_MODULE_STRIDE;
     return a;
 }
 // True when `a` lies inside some fixed guest module, i.e. "<name>+0x<offset>" is meaningful.
 inline bool guest_va_in_module(uint64_t a) {
-    return a >= BOOT_EBOOT && a < 0x610000000ull;
+    return (a >= BOOT_EBOOT && a < 0x610000000ull) ||
+           (a >= BOOT_RUNTIME_MODULE_BASE && a < BOOT_RUNTIME_MODULE_END);
 }
 
 // Boot the title rooted at `dump_root` (the app0 directory): link the fixed module set (dropping any

--- a/prosper/src/host/boot_program.hpp
+++ b/prosper/src/host/boot_program.hpp
@@ -46,7 +46,10 @@ inline constexpr uint64_t BOOT_STUB     = 0x600000000ull;
 // [0x600000000,0x700000000), so nothing else may be mapped inside that window. 128 MiB per slot
 // bounds each module (the whole local corpus's largest module image is ~251 MiB, and the loader
 // refuses anything that does not fit rather than overlapping its neighbour).
-inline constexpr uint64_t BOOT_RUNTIME_MODULE_BASE   = 0x700000000ull;
+// (Kept clear of the ad-hoc stub bases a few unit tests pass to install_stubs — 0x680000000,
+// 0x710000000, 0x720000000, 0x730000000 — so a future test that boots a program and loads a module
+// in one process cannot alias them.)
+inline constexpr uint64_t BOOT_RUNTIME_MODULE_BASE   = 0x800000000ull;
 inline constexpr uint64_t BOOT_RUNTIME_MODULE_STRIDE = 0x8000000ull;   // 128 MiB
 inline constexpr unsigned BOOT_RUNTIME_MODULE_SLOTS  = 48;
 inline constexpr uint64_t BOOT_RUNTIME_MODULE_END =
@@ -118,10 +121,23 @@ inline uint64_t guest_module_offset(uint64_t a) {
         return (a - BOOT_RUNTIME_MODULE_BASE) % BOOT_RUNTIME_MODULE_STRIDE;
     return a;
 }
+// End of the import-stub aperture. install_stubs reserves this whole window (never more), so a stub
+// address is exactly [BOOT_STUB, BOOT_STUB_END) and nothing else may be mapped inside it —
+// callback_fs.hpp identifies a guest import-stub frame by a return address in this range.
+inline constexpr uint64_t BOOT_STUB_END = 0x610000000ull;
+
 // True when `a` lies inside some fixed guest module, i.e. "<name>+0x<offset>" is meaningful.
 inline bool guest_va_in_module(uint64_t a) {
-    return (a >= BOOT_EBOOT && a < 0x610000000ull) ||
+    return (a >= BOOT_EBOOT && a < BOOT_STUB_END) ||
            (a >= BOOT_RUNTIME_MODULE_BASE && a < BOOT_RUNTIME_MODULE_END);
+}
+// True when `a` is guest MODULE CODE — in a module but not in the import-stub aperture. Stack scans
+// that recover a guest callsite want this, not guest_va_in_module: a stub address is a real guest
+// address but names prosper's own trampoline, not the caller. Written as one helper because the
+// three sites that used to spell it `guest_va_in_module(a) && a < BOOT_STUB` silently stopped
+// covering the runtime-module aperture the moment it was placed ABOVE the stubs (#639).
+inline bool guest_va_in_module_code(uint64_t a) {
+    return guest_va_in_module(a) && !(a >= BOOT_STUB && a < BOOT_STUB_END);
 }
 
 // Boot the title rooted at `dump_root` (the app0 directory): link the fixed module set (dropping any

--- a/prosper/src/host/exec_image.hpp
+++ b/prosper/src/host/exec_image.hpp
@@ -13,6 +13,12 @@
 
 namespace prosper {
 
+// The address aperture the import-stub table lives in. install_stubs claims exactly this much from
+// stub_base and append_stubs (#639) grows inside it, so no stub address ever moves and nothing else
+// may be mapped in the window. For the production base this is [BOOT_STUB, BOOT_STUB_END), the same
+// range guest_module_name labels STUB and callback_fs.hpp treats as an import-stub return address.
+inline constexpr uint64_t kStubApertureBytes = 0x10000000ull;   // 256 MiB
+
 // Map the (already relocated) image at img.base as executable. `false`+*err on failure.
 // Call once per module in a linked program.
 bool map_image(const LoadedImage& img, std::string* err);

--- a/prosper/src/host/exec_image.hpp
+++ b/prosper/src/host/exec_image.hpp
@@ -22,6 +22,14 @@ bool map_image(const LoadedImage& img, std::string* err);
 bool install_stubs(const std::vector<ImportSlot>& slots, uint64_t stub_base,
                    uint64_t stub_size, std::string* err);
 
+// Extend the stub region in place for slots appended AFTER install_stubs ran (#639: a runtime
+// sceKernelLoadStartModule adds a slot for each import no already-loaded module satisfies).
+// `slots` must be the SAME vector install_stubs was given, grown at the back; `first_new` is the
+// old size. Only the pages the new slots need are mapped — the pages already handed out to
+// relocated guest code are never remapped, so a thread executing a stub cannot have it torn away.
+// Publishes the grown table to the dispatcher after the last new stub is written.
+bool append_stubs(const std::vector<ImportSlot>& slots, size_t first_new, std::string* err);
+
 // Install the fault handler for genuine guest faults during a run.
 void install_trap_handler();
 

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -2454,6 +2454,32 @@ bool map_image(const LoadedImage& img, std::string* err) {
     return true;
 }
 
+// The one place a slot's stub bytes are chosen. install_stubs and append_stubs (#639) must emit
+// byte-identical stubs for the same slot, or a runtime-loaded module's imports would take a
+// different path into the HLE than the pre-linked ones.
+static size_t emit_one_stub(uint8_t* slot, const ImportSlot& s, uint32_t idx, bool swap) {
+    HleFn fn = Hle::lookup(s.nid);
+    HleReturnHook return_hook = Hle::return_hook_of(s.nid);
+    if (fn) {
+        if (return_hook) return emit_impl_hook(slot, (uint64_t)fn, (uint64_t)return_hook, swap);
+        return swap ? emit_impl_swap(slot, (uint64_t)fn) : emit_impl(slot, (uint64_t)fn);
+    }
+    return swap ? emit_unimpl_swap(slot, idx, (uint64_t)&prosper_on_unimpl)
+                : emit_unimpl(slot, idx, (uint64_t)&prosper_on_unimpl);
+}
+
+// Whether the emitted stubs must swap %fs (see install_stubs' original comment).
+static bool stub_swap_mode() {
+#ifdef __APPLE__
+    // macOS trap mode NEVER swaps %fs: the CPU fs base stays 0 and HLE handlers run on the host's own
+    // (%gs) TLS, so the plain tail-jump stub is correct. (The swap stub uses rdfsbase/wrfsbase, which
+    // SIGILL on Rosetta — emitting it here made every guest import call trap.)
+    return false;
+#else
+    return guest_tls_enabled();   // gated: emit the %fs swap stubs so HLE handlers run on the host TCB
+#endif
+}
+
 bool install_stubs(const std::vector<ImportSlot>& slots, uint64_t stub_base,
                    uint64_t stub_size, std::string* err) {
     auto fail = [&](const char* s){ if (err) *err = s; return false; };
@@ -2472,27 +2498,11 @@ bool install_stubs(const std::vector<ImportSlot>& slots, uint64_t stub_base,
                                        MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
     if (got == MAP_FAILED || got != want) return fail("mmap stub region failed");
 
-#ifdef __APPLE__
-    // macOS trap mode NEVER swaps %fs: the CPU fs base stays 0 and HLE handlers run on the host's own
-    // (%gs) TLS, so the plain tail-jump stub is correct. (The swap stub uses rdfsbase/wrfsbase, which
-    // SIGILL on Rosetta — emitting it here made every guest import call trap.)
-    bool swap = false;
-#else
-    bool swap = guest_tls_enabled();   // gated: emit the %fs swap stubs so HLE handlers run on the host TCB
-#endif
+    const bool swap = stub_swap_mode();
     if (swap && stub_size < 96) return fail("stub_size too small for guest-%fs swap stub (need >= 96)");
     uint8_t* base = (uint8_t*)got;
     for (uint64_t i = 0; i < n; i++) {
-        uint8_t* slot = base + i * stub_size;
-        HleFn fn = Hle::lookup(slots[i].nid);
-        HleReturnHook return_hook = Hle::return_hook_of(slots[i].nid);
-        size_t emitted = 0;
-        if (fn) { if (return_hook) emitted = emit_impl_hook(slot, (uint64_t)fn,
-                                                            (uint64_t)return_hook, swap);
-                  else if (swap) emitted = emit_impl_swap(slot, (uint64_t)fn);
-                  else emitted = emit_impl(slot, (uint64_t)fn); }
-        else    { if (swap) emitted = emit_unimpl_swap(slot, (uint32_t)i, (uint64_t)&prosper_on_unimpl);
-                  else      emitted = emit_unimpl(slot, (uint32_t)i, (uint64_t)&prosper_on_unimpl); }
+        const size_t emitted = emit_one_stub(base + i * stub_size, slots[i], (uint32_t)i, swap);
         if (emitted > stub_size) return fail("generated import stub exceeds stub_size");
     }
     g_stub_base = stub_base; g_stub_size = stub_size; g_nstubs = n;
@@ -2505,6 +2515,45 @@ bool install_stubs(const std::vector<ImportSlot>& slots, uint64_t stub_base,
                     (unsigned long long)(i * stub_size), slots[i].lib.c_str(), slots[i].nid.c_str(), nm.c_str());
         }
     }
+    return true;
+}
+
+bool append_stubs(const std::vector<ImportSlot>& slots, size_t first_new, std::string* err) {
+    auto fail = [&](const char* s){ if (err) *err = s; return false; };
+    if (!g_stub_size) return fail("append_stubs before install_stubs");
+    const uint64_t n = slots.size();
+    if (first_new > n || first_new != g_nstubs) return fail("append_stubs: slot table is not an extension");
+    if (first_new == n) return true;                    // nothing new to emit
+    const bool swap = stub_swap_mode();
+    if (swap && g_stub_size < 96) return fail("stub_size too small for guest-%fs swap stub (need >= 96)");
+    // Grow the region only by the pages the new slots need. The already-mapped pages are NEVER
+    // remapped: relocated guest code already holds addresses inside them, and a fresh MAP_FIXED
+    // would tear a stub out from under a thread executing it.
+    const uint64_t mapped_end = page_up(g_nstubs * g_stub_size);
+    const uint64_t need_end   = page_up(n * g_stub_size);
+    if (need_end > mapped_end) {
+        void* want = (void*)(g_stub_base + mapped_end);
+        void* got = prosper_mmap_noreplace(want, need_end - mapped_end,
+                                           PROT_READ | PROT_WRITE | PROT_EXEC,
+                                           MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        if (got == MAP_FAILED || got != want) return fail("mmap stub region extension failed");
+    }
+    for (uint64_t i = first_new; i < n; i++) {
+        const size_t emitted =
+            emit_one_stub((uint8_t*)(uintptr_t)(g_stub_base + i * g_stub_size), slots[i],
+                          (uint32_t)i, swap);
+        if (emitted > g_stub_size) return fail("generated import stub exceeds stub_size");
+    }
+    g_nstubs = n;
+    // Publish the grown table only after every new stub is written: prosper_on_unimpl indexes it.
+    dispatch_grow_slots(&slots);
+    if (getenv("PROSPER_STUBDUMP"))
+        for (uint64_t i = first_new; i < n; i++) {
+            const std::string& nm = g_nid_db ? g_nid_db->resolve(slots[i].nid) : std::string();
+            fprintf(stderr, "[stub] +#%llu off=0x%llx %s::%s %s\n", (unsigned long long)i,
+                    (unsigned long long)(i * g_stub_size), slots[i].lib.c_str(),
+                    slots[i].nid.c_str(), nm.c_str());
+        }
     return true;
 }
 

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -2493,6 +2493,7 @@ bool install_stubs(const std::vector<ImportSlot>& slots, uint64_t stub_base,
     // the empty table and succeed.
     if (n == 0) { g_stub_base = stub_base; g_stub_size = stub_size; g_nstubs = 0; return true; }
     uint64_t region = page_up(n * stub_size);
+    if (region > kStubApertureBytes) return fail("import stub table exceeds the stub aperture");
     void* want = (void*)stub_base;
     void* got = prosper_mmap_noreplace(want, region, PROT_READ | PROT_WRITE | PROT_EXEC,
                                        MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
@@ -2531,6 +2532,7 @@ bool append_stubs(const std::vector<ImportSlot>& slots, size_t first_new, std::s
     // would tear a stub out from under a thread executing it.
     const uint64_t mapped_end = page_up(g_nstubs * g_stub_size);
     const uint64_t need_end   = page_up(n * g_stub_size);
+    if (need_end > kStubApertureBytes) return fail("import stub table exceeds the stub aperture");
     if (need_end > mapped_end) {
         void* want = (void*)(g_stub_base + mapped_end);
         void* got = prosper_mmap_noreplace(want, need_end - mapped_end,

--- a/prosper/src/host/exec_image_win.cpp
+++ b/prosper/src/host/exec_image_win.cpp
@@ -1149,9 +1149,19 @@ bool install_stubs(const std::vector<ImportSlot>& slots, uint64_t stub_base,
     dispatch_init(&slots, g_nid_db);
 
     uint64_t n = slots.size();
+    // RESERVE the whole stub aperture up front, then COMMIT only the pages the current slots need.
+    // Windows places a MEM_RESERVE at 64 KiB allocation granularity (lpAddress rounds DOWN), so a
+    // later reservation starting at the 4 KiB-aligned end of this one would round back INTO it and
+    // fail with ERROR_INVALID_ADDRESS — append_stubs (#639) could then never extend the table.
+    // MEM_COMMIT is page-granular inside an existing reservation, so growth is committing, not
+    // reserving. The aperture is the same [BOOT_STUB, BOOT_STUB_END) window guest_module_name
+    // already labels STUB and callback_fs.hpp already treats as stubs-only.
+    if (!VirtualAlloc((void*)(uintptr_t)stub_base, kStubApertureBytes, MEM_RESERVE, PAGE_NOACCESS))
+        return fail("VirtualAlloc stub aperture reservation failed");
     if (n == 0) { g_stub_base = stub_base; g_stub_size = stub_size; g_nstubs = 0; return true; }
     uint64_t region = page_up(n * stub_size);
-    void* got = VirtualAlloc((void*)(uintptr_t)stub_base, region, MEM_RESERVE | MEM_COMMIT, PAGE_EXECUTE_READWRITE);
+    if (region > kStubApertureBytes) return fail("import stub table exceeds the stub aperture");
+    void* got = VirtualAlloc((void*)(uintptr_t)stub_base, region, MEM_COMMIT, PAGE_EXECUTE_READWRITE);
     if (!got || got != (void*)(uintptr_t)stub_base) return fail("VirtualAlloc stub region failed");
 
     uint8_t* base = (uint8_t*)got;
@@ -1179,14 +1189,15 @@ bool append_stubs(const std::vector<ImportSlot>& slots, size_t first_new, std::s
     const uint64_t n = slots.size();
     if (first_new > n || first_new != g_nstubs) return fail("append_stubs: slot table is not an extension");
     if (first_new == n) return true;
-    // Commit only the pages the new slots need. The already-committed pages are never re-reserved:
-    // relocated guest code holds addresses inside them.
+    // Commit only the pages the new slots need, inside the aperture install_stubs reserved. The
+    // already-committed pages are never re-committed with different protection: relocated guest
+    // code holds addresses inside them.
     const uint64_t mapped_end = page_up(g_nstubs * g_stub_size);
     const uint64_t need_end   = page_up(n * g_stub_size);
+    if (need_end > kStubApertureBytes) return fail("import stub table exceeds the stub aperture");
     if (need_end > mapped_end) {
         void* want = (void*)(uintptr_t)(g_stub_base + mapped_end);
-        void* got = VirtualAlloc(want, need_end - mapped_end, MEM_RESERVE | MEM_COMMIT,
-                                 PAGE_EXECUTE_READWRITE);
+        void* got = VirtualAlloc(want, need_end - mapped_end, MEM_COMMIT, PAGE_EXECUTE_READWRITE);
         if (!got || got != want) return fail("VirtualAlloc stub region extension failed");
     }
     for (uint64_t i = first_new; i < n; i++) {

--- a/prosper/src/host/exec_image_win.cpp
+++ b/prosper/src/host/exec_image_win.cpp
@@ -1131,6 +1131,16 @@ bool map_image(const LoadedImage& img, std::string* err) {
     return true;
 }
 
+// The one place a slot's stub bytes are chosen. install_stubs and append_stubs (#639) must emit
+// byte-identical stubs for the same slot, or a runtime-loaded module's imports would take a
+// different path into the HLE than the pre-linked ones.
+static size_t emit_one_stub(uint8_t* slot, const ImportSlot& s, uint32_t idx) {
+    HleFn fn = Hle::lookup(s.nid);
+    const uint64_t return_hook = (uint64_t)(uintptr_t)Hle::return_hook_of(s.nid);
+    return fn ? emit_impl(slot, (uint64_t)fn, return_hook)
+              : emit_unimpl(slot, idx, (uint64_t)&prosper_on_unimpl);
+}
+
 bool install_stubs(const std::vector<ImportSlot>& slots, uint64_t stub_base,
                    uint64_t stub_size, std::string* err) {
     auto fail = [&](const char* s){ if (err) *err = s; return false; };
@@ -1146,13 +1156,7 @@ bool install_stubs(const std::vector<ImportSlot>& slots, uint64_t stub_base,
 
     uint8_t* base = (uint8_t*)got;
     for (uint64_t i = 0; i < n; i++) {
-        uint8_t* slot = base + i * stub_size;
-        HleFn fn = Hle::lookup(slots[i].nid);
-        const uint64_t return_hook =
-            (uint64_t)(uintptr_t)Hle::return_hook_of(slots[i].nid);
-        const size_t emitted = fn ? emit_impl(slot, (uint64_t)fn, return_hook)
-                                  : emit_unimpl(slot, (uint32_t)i,
-                                                (uint64_t)&prosper_on_unimpl);
+        const size_t emitted = emit_one_stub(base + i * stub_size, slots[i], (uint32_t)i);
         if (emitted > stub_size) return fail("generated Windows ABI bridge exceeds stub_size");
     }
     g_stub_base = stub_base; g_stub_size = stub_size; g_nstubs = n;
@@ -1166,6 +1170,39 @@ bool install_stubs(const std::vector<ImportSlot>& slots, uint64_t stub_base,
                     (unsigned long long)(i * stub_size), slots[i].lib.c_str(), slots[i].nid.c_str(), nm.c_str());
         }
     }
+    return true;
+}
+
+bool append_stubs(const std::vector<ImportSlot>& slots, size_t first_new, std::string* err) {
+    auto fail = [&](const char* s){ if (err) *err = s; return false; };
+    if (!g_stub_size) return fail("append_stubs before install_stubs");
+    const uint64_t n = slots.size();
+    if (first_new > n || first_new != g_nstubs) return fail("append_stubs: slot table is not an extension");
+    if (first_new == n) return true;
+    // Commit only the pages the new slots need. The already-committed pages are never re-reserved:
+    // relocated guest code holds addresses inside them.
+    const uint64_t mapped_end = page_up(g_nstubs * g_stub_size);
+    const uint64_t need_end   = page_up(n * g_stub_size);
+    if (need_end > mapped_end) {
+        void* want = (void*)(uintptr_t)(g_stub_base + mapped_end);
+        void* got = VirtualAlloc(want, need_end - mapped_end, MEM_RESERVE | MEM_COMMIT,
+                                 PAGE_EXECUTE_READWRITE);
+        if (!got || got != want) return fail("VirtualAlloc stub region extension failed");
+    }
+    for (uint64_t i = first_new; i < n; i++) {
+        const size_t emitted =
+            emit_one_stub((uint8_t*)(uintptr_t)(g_stub_base + i * g_stub_size), slots[i], (uint32_t)i);
+        if (emitted > g_stub_size) return fail("generated Windows ABI bridge exceeds stub_size");
+    }
+    g_nstubs = n;
+    dispatch_grow_slots(&slots);   // publish only after every new stub is written
+    if (getenv("PROSPER_STUBDUMP"))
+        for (uint64_t i = first_new; i < n; i++) {
+            const std::string& nm = g_nid_db ? g_nid_db->resolve(slots[i].nid) : std::string();
+            fprintf(stderr, "[stub] +#%llu off=0x%llx %s::%s %s\n", (unsigned long long)i,
+                    (unsigned long long)(i * g_stub_size), slots[i].lib.c_str(),
+                    slots[i].nid.c_str(), nm.c_str());
+        }
     return true;
 }
 

--- a/prosper/src/host/runtime_module_load.cpp
+++ b/prosper/src/host/runtime_module_load.cpp
@@ -36,7 +36,14 @@ struct RuntimeModule {
     std::unordered_map<std::string, uint64_t> nids;   // this module's own exports (#147)
 };
 
-std::mutex g_mx;                 // serialises the whole load; also guards everything below
+// RECURSIVE, and that is load-bearing: the lock is held across the module's own module_start /
+// init_array, which is guest code, and a module's module_start calling sceKernelLoadStartModule for
+// a dependency is both legal on PS5 and exactly what a "shell eboot + per-stage PRX" title invites.
+// A plain std::mutex would self-deadlock there — silently, which is strictly worse than the ENOENT
+// this replaced. Re-entrancy is safe because every published pointer stays valid across a nested
+// load: g_loaded is a std::deque (push_back never invalidates a reference to an existing element),
+// so the outer frame's `rm` survives, and a nested load can only ever pop its OWN element.
+std::recursive_mutex g_mx;       // serialises the whole load; also guards everything below
 Program* g_prog = nullptr;
 std::deque<RuntimeModule> g_loaded;
 std::unordered_map<std::string, uint32_t> g_nid_to_slot;   // NID -> import stub-slot index
@@ -80,8 +87,13 @@ uint64_t call_module_entry(uint64_t fn, uint64_t args, uint64_t argp, uint64_t g
 } // namespace
 
 void runtime_module_loader_init(Program* p) {
-    std::lock_guard<std::mutex> lk(g_mx);
+    std::lock_guard<std::recursive_mutex> lk(g_mx);
+    // Reset EVERY piece of loader state, not just the tables rebuilt below: a second boot_program in
+    // one process would otherwise inherit the previous program's loaded modules and hand out their
+    // stale handles. (No caller does that today; making the reset total is cheaper than the note.)
     g_prog = p;
+    g_loaded.clear();
+    g_next_base_slot = 0;
     g_nid_to_slot.clear();
     g_tls_symbols.clear();
     if (!p) return;
@@ -101,14 +113,14 @@ void runtime_module_loader_init(Program* p) {
 }
 
 size_t runtime_loaded_module_count() {
-    std::lock_guard<std::mutex> lk(g_mx);
+    std::lock_guard<std::recursive_mutex> lk(g_mx);
     return g_loaded.size();
 }
 
 uint64_t runtime_load_start_module(const char* guest_path, uint64_t args, uint64_t argp,
                                    uint64_t guest_fs, int32_t* out_res, uint64_t* out_handle) {
     if (!guest_path || !*guest_path) return kEinval;
-    std::lock_guard<std::mutex> lk(g_mx);
+    std::lock_guard<std::recursive_mutex> lk(g_mx);
     if (!g_prog) {
         // No booted program to load against (a unit test, or a caller that never ran
         // boot_program). Keep #146's honest answer for a path that is not in the linked set rather
@@ -154,13 +166,30 @@ uint64_t runtime_load_start_module(const char* guest_path, uint64_t args, uint64
                 guest_path, BOOT_RUNTIME_MODULE_SLOTS);
         return kEnomem;
     }
+    // Claim the base slot NOW, before anything below can fail. A failure path that left the slot
+    // free would let the next module map at the same base while this one's rolled-back-but-not-
+    // reverted state (a TLS template whose init_va points into that memory) still named it.
+    // Burning a slot on a failed load is the cheap, safe side of that trade.
     const uint64_t base =
         BOOT_RUNTIME_MODULE_BASE + (uint64_t)g_next_base_slot * BOOT_RUNTIME_MODULE_STRIDE;
+    g_next_base_slot++;
 
     g_loaded.emplace_back();
     RuntimeModule& rm = g_loaded.back();
-    // Publish nothing until the module is fully live; on any failure below, pop it back off.
-    auto abandon = [&](uint64_t err) { g_loaded.pop_back(); return err; };
+    // Publish nothing until the module is fully live. On any failure below, undo in reverse order:
+    // pop the module, drop any TLS template it appended (re-publishing the shorter list is safe —
+    // nothing was relocated against that module id), and forget any NID it claimed a stub slot for.
+    const size_t tls_templates_before = g_prog->tls_templates.size();
+    std::vector<std::string> claimed_nids;
+    auto abandon = [&](uint64_t err) {
+        g_loaded.pop_back();
+        if (g_prog->tls_templates.size() > tls_templates_before) {
+            g_prog->tls_templates.resize(tls_templates_before);
+            set_tls_modules(g_prog->tls_templates.data(), g_prog->tls_templates.size());
+        }
+        for (const auto& nid : claimed_nids) g_nid_to_slot.erase(nid);
+        return err;
+    };
 
     rm.host_path = host_path;
     rm.guest_path = guest_path;
@@ -173,10 +202,13 @@ uint64_t runtime_load_start_module(const char* guest_path, uint64_t args, uint64
         fprintf(stderr, "[loadmod] '%s': %s -> ENOEXEC\n", guest_path, e.c_str());
         return abandon(kEnoexec);
     }
-    if (img.mem.size() > BOOT_RUNTIME_MODULE_STRIDE) {
+    // The module occupies [base + min_vaddr, base + max_vaddr), so max_vaddr — not the image byte
+    // count — is what has to fit the slot: a nonzero min_vaddr would otherwise pass this and still
+    // run into the next slot.
+    if (img.max_vaddr > BOOT_RUNTIME_MODULE_STRIDE) {
         fprintf(stderr,
-                "[loadmod] '%s': image is 0x%llx bytes, larger than the 0x%llx runtime module slot "
-                "(#639) -> ENOMEM\n", guest_path, (unsigned long long)img.mem.size(),
+                "[loadmod] '%s': image spans 0x%llx bytes of VA, larger than the 0x%llx runtime "
+                "module slot (#639) -> ENOMEM\n", guest_path, (unsigned long long)img.max_vaddr,
                 (unsigned long long)BOOT_RUNTIME_MODULE_STRIDE);
         return abandon(kEnomem);
     }
@@ -224,6 +256,7 @@ uint64_t runtime_load_start_module(const char* guest_path, uint64_t args, uint64
             const uint32_t idx = (uint32_t)(first_new_slot + new_slots.size());
             new_slots.push_back({ imp.lib_name, imp.nid });
             slot = g_nid_to_slot.emplace(imp.nid, idx).first;
+            claimed_nids.push_back(imp.nid);   // rolled back by abandon() if the load fails
         }
         img.import_addr[imp.sym_index] = g_prog->stub_base + (uint64_t)slot->second * g_prog->stub_size;
         stubbed++;
@@ -245,7 +278,6 @@ uint64_t runtime_load_start_module(const char* guest_path, uint64_t args, uint64
         fprintf(stderr, "[loadmod] '%s': %s -> ENOMEM\n", guest_path, e.c_str());
         return abandon(kEnomem);
     }
-    g_next_base_slot++;
     rm.lo = base + img.min_vaddr;
     rm.hi = base + img.max_vaddr;
 
@@ -267,11 +299,16 @@ uint64_t runtime_load_start_module(const char* guest_path, uint64_t args, uint64
     ud.name = rm.name.c_str();
     const size_t unwind_index = add_unwind_module(ud);
     rm.handle = add_module_export_table(rm.host_path, &rm.nids);
-    if (rm.handle - kSceModuleHandleBase != unwind_index)
+    if (rm.handle - kSceModuleHandleBase != unwind_index) {
+        // Cannot happen while both appends are serialised by g_mx and nothing else appends after
+        // boot — but if it ever did, every address-derived handle from here on would resolve
+        // against a different module than it names. Refuse the load rather than continue with one.
         fprintf(stderr,
                 "[loadmod] '%s': INTERNAL — unwind index %zu != export index %llu; an "
-                "address-derived module handle now names a different module (#639)\n",
+                "address-derived module handle would name a different module (#639) -> ENOEXEC\n",
                 guest_path, unwind_index, (unsigned long long)(rm.handle - kSceModuleHandleBase));
+        return abandon(kEnoexec);
+    }
 
     fprintf(stderr,
             "[loadmod] loaded '%s' -> %s @ 0x%llx (%zu exports, %zu imports: %zu cross-module, "

--- a/prosper/src/host/runtime_module_load.cpp
+++ b/prosper/src/host/runtime_module_load.cpp
@@ -1,0 +1,318 @@
+// runtime_module_load.cpp — see runtime_module_load.hpp (#639).
+#include "host/runtime_module_load.hpp"
+
+#if defined(__linux__) || defined(__APPLE__) || defined(_WIN32)
+
+#include "host/boot_program.hpp"
+#include "host/exec_image.hpp"
+#include "loader/linker.hpp"
+#include "hle/dispatch.hpp"
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace prosper {
+namespace {
+
+constexpr uint64_t kEnoent  = 0x80020002ull;   // SCE_KERNEL_ERROR_ENOENT
+constexpr uint64_t kEnoexec = 0x80020008ull;   // SCE_KERNEL_ERROR_ENOEXEC
+constexpr uint64_t kEnomem  = 0x8002000cull;   // SCE_KERNEL_ERROR_ENOMEM
+constexpr uint64_t kEinval  = 0x80020016ull;   // SCE_KERNEL_ERROR_EINVAL
+
+// One runtime-loaded module. Held in a deque and never erased: its export map and its name are
+// published to the HLE (sceKernelDlsym / the unwinder) as raw pointers that must stay valid for
+// the rest of the run, and unload is not modelled.
+struct RuntimeModule {
+    std::string host_path, guest_path, name;
+    std::unique_ptr<Module> mod;
+    uint64_t base = 0, lo = 0, hi = 0, handle = 0;
+    std::unordered_map<std::string, uint64_t> nids;   // this module's own exports (#147)
+};
+
+std::mutex g_mx;                 // serialises the whole load; also guards everything below
+Program* g_prog = nullptr;
+std::deque<RuntimeModule> g_loaded;
+std::unordered_map<std::string, uint32_t> g_nid_to_slot;   // NID -> import stub-slot index
+TlsSymbolMap g_tls_symbols;      // exported TLS symbol NID -> {defining module id, in-block offset}
+unsigned g_next_base_slot = 0;
+
+bool modlog() { static const int v = getenv("PROSPER_MODLOG") ? 1 : 0; return v != 0; }
+
+const char* basename_of(const std::string& p) {
+    const char* b = p.c_str();
+    for (const char* c = b; *c; c++) if (*c == '/' || *c == '\\') b = c + 1;
+    return b;
+}
+
+// #639 runs guest code (module_start / init_array) from inside an HLE handler. Under the guest-%fs
+// gate the handler is on the HOST %fs, so the module's own initialisation would read host TLS as
+// guest TLS. Restore the guest thread pointer for exactly the duration of the guest call, the same
+// way the NetCtl/Np callback delivery does (hle_service.cpp). No-op when guest_fs is 0.
+#if !defined(_WIN32) && !defined(__APPLE__)
+inline uint64_t rd_fsbase() { uint64_t v; __asm__ volatile("rdfsbase %0" : "=r"(v)); return v; }
+inline void     wr_fsbase(uint64_t v) { __asm__ volatile("wrfsbase %0" : : "r"(v)); }
+struct GuestFsScope {
+    uint64_t saved = 0, active = 0;
+    explicit GuestFsScope(uint64_t guest_fs) {
+        if (guest_fs) { saved = rd_fsbase(); wr_fsbase(guest_fs); active = guest_fs; }
+    }
+    ~GuestFsScope() { if (active) wr_fsbase(saved); }
+};
+#else
+struct GuestFsScope { explicit GuestFsScope(uint64_t) {} };
+#endif
+
+// Call one module entry with the PS5 module-entry ABI, module_start(size_t argc, const void* argp).
+// Plain init_array ctors take no arguments and ignore rdi/rsi; a real module_start reads both, so
+// passing the guest's own (args, argp) through is what the module was asked to start with.
+uint64_t call_module_entry(uint64_t fn, uint64_t args, uint64_t argp, uint64_t guest_fs) {
+    GuestFsScope fs(guest_fs);
+    return ((uint64_t (*)(uint64_t, uint64_t))(uintptr_t)fn)(args, argp);
+}
+
+} // namespace
+
+void runtime_module_loader_init(Program* p) {
+    std::lock_guard<std::mutex> lk(g_mx);
+    g_prog = p;
+    g_nid_to_slot.clear();
+    g_tls_symbols.clear();
+    if (!p) return;
+    // The linker deduped stub slots by NID but kept that map local to link_program. Rebuild it so a
+    // runtime module's import of an already-stubbed NID reuses the SAME slot: a second slot for the
+    // same NID would double-count it in the unimplemented-call census and emit a duplicate stub.
+    for (size_t i = 0; i < p->slots.size(); i++) g_nid_to_slot.emplace(p->slots[i].nid, (uint32_t)i);
+    // Cross-module general-dynamic TLS: same construction as link_program's, so a runtime module's
+    // DTPMOD64/DTPOFF64 pair against a pre-linked module resolves through one record.
+    for (size_t i = 0; i < p->mods.size() && i < p->imgs.size(); i++) {
+        const uint32_t mid = p->imgs[i].tls_modid;
+        if (!mid) continue;
+        for (const auto& s : p->mods[i]->symbols)
+            if (!s.is_import && !s.nid.empty())
+                g_tls_symbols.emplace(s.nid, TlsSymbolLocation{ mid, s.value });
+    }
+}
+
+size_t runtime_loaded_module_count() {
+    std::lock_guard<std::mutex> lk(g_mx);
+    return g_loaded.size();
+}
+
+uint64_t runtime_load_start_module(const char* guest_path, uint64_t args, uint64_t argp,
+                                   uint64_t guest_fs, int32_t* out_res, uint64_t* out_handle) {
+    if (!guest_path || !*guest_path) return kEinval;
+    std::lock_guard<std::mutex> lk(g_mx);
+    if (!g_prog) {
+        // No booted program to load against (a unit test, or a caller that never ran
+        // boot_program). Keep #146's honest answer for a path that is not in the linked set rather
+        // than inventing a new error the guest has never seen from this call.
+        static bool warned = false;
+        if (!warned) { warned = true;
+            fprintf(stderr, "[loadmod] runtime module loading is not initialised; '%s' -> ENOENT\n",
+                    guest_path); }
+        return kEnoent;
+    }
+
+    // Repeat load of a path this loader already served: hand back the same handle. (The caller's
+    // module_handle_for_path check normally catches this first — it matches on basename, which is
+    // the PS5's own module identity — but a differently spelled path for the same file must not
+    // map the module twice.)
+    for (const auto& m : g_loaded)
+        if (m.guest_path == guest_path) {
+            if (out_handle) *out_handle = m.handle;
+            if (out_res) *out_res = 0;
+            return 0;
+        }
+
+    const std::string host_path = resolve_guest_path(guest_path);
+    if (host_path.empty() || host_path.compare(0, 16, "/prosper-denied/") == 0) return kEnoent;
+    if (FILE* f = fopen(host_path.c_str(), "rb")) fclose(f);
+    else {
+        if (modlog())
+            fprintf(stderr, "[loadmod] '%s' -> '%s' does not exist -> ENOENT\n",
+                    guest_path, host_path.c_str());
+        return kEnoent;
+    }
+
+    std::string e;
+    auto parsed = Module::load(host_path, &e);
+    if (!parsed) {
+        fprintf(stderr, "[loadmod] '%s': cannot parse module (%s) -> ENOEXEC\n",
+                guest_path, e.c_str());
+        return kEnoexec;
+    }
+
+    if (g_next_base_slot >= BOOT_RUNTIME_MODULE_SLOTS) {
+        fprintf(stderr, "[loadmod] '%s': no free runtime module base slot (max %u, #639) -> ENOMEM\n",
+                guest_path, BOOT_RUNTIME_MODULE_SLOTS);
+        return kEnomem;
+    }
+    const uint64_t base =
+        BOOT_RUNTIME_MODULE_BASE + (uint64_t)g_next_base_slot * BOOT_RUNTIME_MODULE_STRIDE;
+
+    g_loaded.emplace_back();
+    RuntimeModule& rm = g_loaded.back();
+    // Publish nothing until the module is fully live; on any failure below, pop it back off.
+    auto abandon = [&](uint64_t err) { g_loaded.pop_back(); return err; };
+
+    rm.host_path = host_path;
+    rm.guest_path = guest_path;
+    rm.name = basename_of(host_path);
+    rm.mod = std::make_unique<Module>(std::move(*parsed));
+    rm.base = base;
+
+    LoadedImage img;
+    if (!build_image(*rm.mod, base, img, &e)) {
+        fprintf(stderr, "[loadmod] '%s': %s -> ENOEXEC\n", guest_path, e.c_str());
+        return abandon(kEnoexec);
+    }
+    if (img.mem.size() > BOOT_RUNTIME_MODULE_STRIDE) {
+        fprintf(stderr,
+                "[loadmod] '%s': image is 0x%llx bytes, larger than the 0x%llx runtime module slot "
+                "(#639) -> ENOMEM\n", guest_path, (unsigned long long)img.mem.size(),
+                (unsigned long long)BOOT_RUNTIME_MODULE_STRIDE);
+        return abandon(kEnomem);
+    }
+
+    // --- TLS. A module with a real PT_TLS gets a NEW general-dynamic module id; static (initial-
+    // exec) TLS cannot be extended once threads exist, so TPOFF64 is reported and left unapplied
+    // by apply_relocations rather than baked to a wrong offset. ---
+    if (rm.mod->tls_memsz) {
+        img.tls_modid = (uint32_t)g_prog->tls_templates.size();
+        g_prog->tls_templates.push_back({ base + rm.mod->tls_vaddr, rm.mod->tls_filesz,
+                                          rm.mod->tls_memsz, rm.mod->tls_align });
+        set_tls_modules(g_prog->tls_templates.data(), g_prog->tls_templates.size());
+        for (const auto& s : rm.mod->symbols)
+            if (!s.is_import && !s.nid.empty())
+                g_tls_symbols.emplace(s.nid, TlsSymbolLocation{ img.tls_modid, s.value });
+    }
+    size_t tpoff = 0;
+    for (const auto& r : rm.mod->relocs) if (r.type == R_X86_64_TPOFF64) tpoff++;
+    if (tpoff)
+        fprintf(stderr,
+                "[loadmod] '%s': %zu initial-exec TLS relocations (R_X86_64_TPOFF64) CANNOT be "
+                "applied to a module loaded after the guest's threads exist; they are left "
+                "unapplied (#639). Report this module.\n", guest_path, tpoff);
+
+    // --- Imports: an export of an already-loaded module beats a stub slot, exactly as at boot. ---
+    const size_t first_new_slot = g_prog->slots.size();
+    std::vector<ImportSlot> new_slots;
+    size_t cross = 0, stubbed = 0;
+    for (const auto& imp : rm.mod->imports) {
+        auto ex = g_prog->exports.find(imp.nid);
+        if (ex != g_prog->exports.end()) { img.import_addr[imp.sym_index] = ex->second; cross++; continue; }
+        bool from_runtime = false;
+        for (const auto& other : g_loaded) {
+            if (&other == &rm) continue;
+            auto it = other.nids.find(imp.nid);
+            if (it != other.nids.end()) {
+                img.import_addr[imp.sym_index] = it->second; cross++; from_runtime = true; break;
+            }
+        }
+        if (from_runtime) continue;
+        auto slot = g_nid_to_slot.find(imp.nid);
+        if (slot == g_nid_to_slot.end()) {
+            // Slot indices are assigned now and the vector is grown in ONE synchronised append
+            // below, so a concurrent unimplemented-import call never sees a moving buffer.
+            const uint32_t idx = (uint32_t)(first_new_slot + new_slots.size());
+            new_slots.push_back({ imp.lib_name, imp.nid });
+            slot = g_nid_to_slot.emplace(imp.nid, idx).first;
+        }
+        img.import_addr[imp.sym_index] = g_prog->stub_base + (uint64_t)slot->second * g_prog->stub_size;
+        stubbed++;
+    }
+    const size_t appended_at = dispatch_append_slots(&g_prog->slots, new_slots);
+    (void)appended_at;   // == first_new_slot; append_stubs re-checks it
+
+    // Emit the stubs BEFORE the relocations point guest code at them. A failure here leaves the
+    // appended slots in place: they are unreferenced (nothing has been relocated to them yet) and
+    // removing them would need the same lock the dispatcher reads them under.
+    if (!append_stubs(g_prog->slots, first_new_slot, &e)) {
+        fprintf(stderr, "[loadmod] '%s': %s -> ENOMEM\n", guest_path, e.c_str());
+        return abandon(kEnomem);
+    }
+
+    apply_relocations(*rm.mod, img, &g_tls_symbols, nullptr);
+
+    if (!map_image(img, &e)) {
+        fprintf(stderr, "[loadmod] '%s': %s -> ENOMEM\n", guest_path, e.c_str());
+        return abandon(kEnomem);
+    }
+    g_next_base_slot++;
+    rm.lo = base + img.min_vaddr;
+    rm.hi = base + img.max_vaddr;
+
+    // --- Exports: this module's own NID -> address table, for handle-first sceKernelDlsym (#147).
+    // It is NOT merged into the program's global first-definition-wins table: that table is what
+    // the ALREADY-RELOCATED modules were bound against, and adding to it now cannot change any of
+    // those bindings while it could change what a later name-only dlsym resolves to. ---
+    for (const auto& s : rm.mod->symbols)
+        if (!s.is_import && !s.nid.empty() && s.value != 0) rm.nids.emplace(s.nid, base + s.value);
+
+    // Unwind descriptor and export table must land on the SAME index: the handle
+    // sceKernelGetModuleInfoFromAddr derives from the unwind order is consumed by sceKernelDlsym
+    // against the export order (hle_kernel.cpp).
+    UnwindModuleDesc ud;
+    ud.lo = rm.lo; ud.hi = rm.hi;
+    for (const auto& s : rm.mod->segments)
+        if (s.type == 0x6474e550u) { ud.ehframe_hdr = base + s.vaddr; ud.ehframe_hdr_sz = s.memsz; }
+    if (!rm.mod->loads.empty()) { ud.seg0 = base + rm.mod->loads[0].vaddr; ud.seg0_sz = rm.mod->loads[0].memsz; }
+    ud.name = rm.name.c_str();
+    const size_t unwind_index = add_unwind_module(ud);
+    rm.handle = add_module_export_table(rm.host_path, &rm.nids);
+    if (rm.handle - kSceModuleHandleBase != unwind_index)
+        fprintf(stderr,
+                "[loadmod] '%s': INTERNAL — unwind index %zu != export index %llu; an "
+                "address-derived module handle now names a different module (#639)\n",
+                guest_path, unwind_index, (unsigned long long)(rm.handle - kSceModuleHandleBase));
+
+    fprintf(stderr,
+            "[loadmod] loaded '%s' -> %s @ 0x%llx (%zu exports, %zu imports: %zu cross-module, "
+            "%zu stubbed, %zu new slots) handle=0x%llx\n",
+            guest_path, rm.name.c_str(), (unsigned long long)base, rm.nids.size(),
+            rm.mod->imports.size(), cross, stubbed, g_prog->slots.size() - first_new_slot,
+            (unsigned long long)rm.handle);
+
+    // --- Start it. DT_INIT (module_start) first, then DT_INIT_ARRAY, matching the order
+    // link_program + run_guest_inits use for a pre-linked dependent module. The init_array entries
+    // were relocated to absolute addresses above, so read them from the mapped image. ---
+    uint64_t res = 0;
+    const std::string guest_path_copy = rm.guest_path;   // rm may be referenced across the calls below
+    const uint64_t init_va = rm.mod->init_va, ia_va = rm.mod->init_array_va, ia_sz = rm.mod->init_array_sz;
+    if (init_va) res = call_module_entry(base + init_va, args, argp, guest_fs);
+    for (uint64_t off = 0; off + 8 <= ia_sz; off += 8) {
+        const uint64_t slot_va = base + ia_va + off;
+        if (slot_va < rm.lo || slot_va + 8 > rm.hi) break;
+        uint64_t fn = 0; memcpy(&fn, (const void*)(uintptr_t)slot_va, 8);
+        if (fn) call_module_entry(fn, 0, 0, guest_fs);
+    }
+    if (modlog())
+        fprintf(stderr, "[loadmod] started '%s' module_start(0x%llx, 0x%llx) -> 0x%llx\n",
+                guest_path_copy.c_str(), (unsigned long long)args, (unsigned long long)argp,
+                (unsigned long long)res);
+
+    if (out_res) *out_res = (int32_t)res;
+    if (out_handle) *out_handle = rm.handle;
+    return 0;
+}
+
+} // namespace prosper
+
+#else   // no guest-execution substrate on this platform
+
+namespace prosper {
+void runtime_module_loader_init(Program*) {}
+uint64_t runtime_load_start_module(const char*, uint64_t, uint64_t, uint64_t, int32_t*, uint64_t*) {
+    return 0x80020002ull;   // SCE_KERNEL_ERROR_ENOENT
+}
+size_t runtime_loaded_module_count() { return 0; }
+} // namespace prosper
+
+#endif

--- a/prosper/src/host/runtime_module_load.hpp
+++ b/prosper/src/host/runtime_module_load.hpp
@@ -1,0 +1,54 @@
+// runtime_module_load.hpp — real runtime PRX loading for sceKernelLoadStartModule (#639).
+//
+// Before this, "loading" a PRX only ever resolved a path against the fixed set `boot_program`
+// linked BEFORE guest entry; anything else was reported ENOENT (#146's honest answer to a
+// capability prosper did not have). That is fine for a title that preloads every module it uses,
+// and wrong for one whose code lives in modules chosen while it runs: R-Type Delta: HD Boosted
+// (PPSA26414) ships 24 per-stage PRXs under /app0/prx/ and its eboot is only a shell, so the very
+// first sceKernelLoadStartModule miss left it calling a NULL DLLLoadStart (#1591).
+//
+// This maps, relocates, links and starts such a module at the point the guest asks for it — the
+// same passes `link_program` runs at boot, applied to one module against the already-linked
+// program. What it deliberately does NOT do, and why:
+//
+//   * It never rebinds an ALREADY-RELOCATED module's imports. prosper binds eagerly at link time,
+//     so a module loaded later cannot retroactively satisfy an earlier module's import; that
+//     import already points at its stub slot. Sony's loader has the same property for a module
+//     that is already started.
+//   * It does not model unload. sceKernelStopUnloadModule is out of scope here; a repeat load of
+//     the same path returns the cached handle rather than re-running module_start.
+//   * A module needing INITIAL-EXEC TLS (R_X86_64_TPOFF64) cannot be given static TLS space after
+//     threads exist. Those relocations are left unapplied by apply_relocations and reported here,
+//     loudly, rather than silently baked to a wrong offset. General-dynamic TLS works.
+#pragma once
+#include <cstdint>
+#include <string>
+
+namespace prosper {
+
+struct Program;
+
+// Enable runtime loading against the booted program. Called once by boot_program after the fixed
+// module set is linked, mapped, stubbed and initialised. `p` must outlive the run: the loader
+// appends to its import-slot table and its TLS templates.
+void runtime_module_loader_init(Program* p);
+
+// Load and start the PRX named by a GUEST path (e.g. "/app0/prx/title_Release.prx").
+//
+// Returns 0 on success with *out_handle set to the module handle sceKernelDlsym accepts, or a
+// SCE_KERNEL_ERROR_* code:
+//   0x80020002 ENOENT   — no such file (unchanged from the pre-#639 behaviour)
+//   0x80020016 EINVAL   — bad arguments / the loader is not initialised
+//   0x8002000c ENOMEM   — no free base slot, or the image does not fit one
+//   0x80020008 ENOEXEC  — the file is not a loadable module
+// `args`/`argp` are the guest's own sceKernelLoadStartModule arguments and are passed to
+// module_start; `guest_fs` is the guest thread pointer to run guest code on (0 = run on the
+// current %fs, which is correct when the guest-%fs gate is off). *out_res, when non-null,
+// receives module_start's return value.
+uint64_t runtime_load_start_module(const char* guest_path, uint64_t args, uint64_t argp,
+                                   uint64_t guest_fs, int32_t* out_res, uint64_t* out_handle);
+
+// Test/diagnostic: how many modules the runtime loader has loaded so far.
+size_t runtime_loaded_module_count();
+
+} // namespace prosper

--- a/prosper/src/host/runtime_module_load.hpp
+++ b/prosper/src/host/runtime_module_load.hpp
@@ -20,6 +20,11 @@
 //   * A module needing INITIAL-EXEC TLS (R_X86_64_TPOFF64) cannot be given static TLS space after
 //     threads exist. Those relocations are left unapplied by apply_relocations and reported here,
 //     loudly, rather than silently baked to a wrong offset. General-dynamic TLS works.
+//   * Module identity is the BASENAME, because that is what the PS5's own namespace uses and what
+//     sceKernelLoadStartModule's caller checks first (module_handle_for_path, #147). Two modules
+//     with the same basename in different directories therefore alias to one handle, and a runtime
+//     path whose basename matches a pre-linked module resolves to that module instead of loading.
+//     Pre-existing semantics; #639 only makes them reachable for guest-composed paths.
 #pragma once
 #include <cstdint>
 #include <string>

--- a/prosper/tests/test_runtime_prx_load.cpp
+++ b/prosper/tests/test_runtime_prx_load.cpp
@@ -57,6 +57,9 @@ enum : uint64_t {
     kFileSize    = 0x1000,
 };
 
+// memcpy, never a type-punned store: the buffer is std::vector<uint8_t> and a uint16_t*/uint32_t*
+// write through it is a strict-aliasing violation even where the alignment happens to work out.
+static void put16(std::vector<uint8_t>& f, uint64_t off, uint16_t v) { memcpy(&f[off], &v, 2); }
 static void put32(std::vector<uint8_t>& f, uint64_t off, uint32_t v) { memcpy(&f[off], &v, 4); }
 static void put64(std::vector<uint8_t>& f, uint64_t off, uint64_t v) { memcpy(&f[off], &v, 8); }
 
@@ -75,17 +78,15 @@ static std::vector<uint8_t> build_module(const std::string& export_nid,
     // --- ELF header (ET_SCE_DYNAMIC PRX, x86-64, FreeBSD ABI, program headers only) ---
     memcpy(&f[0], "\x7f" "ELF", 4);
     f[4] = 2; f[5] = 1; f[6] = 1; f[7] = 9;          // ELF64, LSB, version 1, ELFOSABI_FREEBSD
-    put32(f, 0x10, 0xfe18);                           // e_type = ET_SCE_DYNAMIC (16-bit field)
-    put32(f, 0x12, 0x3e);                             // e_machine = x86-64 (16-bit field)
+    put16(f, 0x10, 0xfe18);                           // e_type = ET_SCE_DYNAMIC
+    put16(f, 0x12, 0x3e);                             // e_machine = x86-64
     put32(f, 0x14, 1);                                // e_version
     put64(f, 0x18, 0);                                // e_entry
     put64(f, 0x20, 0x40);                             // e_phoff
-    put32(f, 0x34, 64);                               // e_ehsize
-    put32(f, 0x36, 56);                               // e_phentsize (16-bit)
-    put32(f, 0x38, 2);                                // e_phnum (16-bit)
-    // e_phentsize/e_phnum share dwords with neighbours; rewrite them as the 16-bit fields they are.
-    *(uint16_t*)&f[0x36] = 56; *(uint16_t*)&f[0x38] = 2;
-    *(uint16_t*)&f[0x3a] = 0;  *(uint16_t*)&f[0x3c] = 0; *(uint16_t*)&f[0x3e] = 0;
+    put16(f, 0x34, 64);                               // e_ehsize
+    put16(f, 0x36, 56);                               // e_phentsize
+    put16(f, 0x38, 2);                                // e_phnum
+    // e_shentsize / e_shnum / e_shstrndx stay zero: this module has no section header table.
 
     // --- program headers: one RWX PT_LOAD covering the file, plus PT_DYNAMIC ---
     auto phdr = [&](int i, uint32_t type, uint32_t flags, uint64_t off, uint64_t va,
@@ -133,7 +134,7 @@ static std::vector<uint8_t> build_module(const std::string& export_nid,
         const uint64_t p = kSymtab + (uint64_t)i * 24;
         put32(f, p + 0, (uint32_t)name_off);
         f[p + 4] = 0x12;                       // STB_GLOBAL | STT_FUNC
-        *(uint16_t*)&f[p + 6] = shndx;
+        put16(f, p + 6, shndx);
         put64(f, p + 8, value);
         put64(f, p + 16, 8);
     };
@@ -179,11 +180,14 @@ int main(int argc, char** argv) {
     const std::string root = (argc >= 2) ? argv[1] : std::string("./runtime-prx-test-root");
     const std::string prx_dir = root + "/prx";          // deliberately NOT Media/Plugins
     const std::string prx_path = prx_dir + "/prosper_runtime_test.prx";
+    {
 #ifdef _WIN32
-    system(("mkdir \"" + prx_dir + "\" 2>nul").c_str());
+        const int rc = system(("mkdir \"" + prx_dir + "\" 2>nul").c_str());
 #else
-    system(("mkdir -p '" + prx_dir + "'").c_str());
+        const int rc = system(("mkdir -p '" + prx_dir + "'").c_str());
 #endif
+        (void)rc;   // an already-existing directory is fine; the fopen below is the real check
+    }
 
     const std::string export_nid = nid_hash("prosperRuntimeTestExport");
     const std::string import_nid = nid_hash("prosperRuntimeTestImport");
@@ -237,6 +241,12 @@ int main(int argc, char** argv) {
           "dlsym through the returned handle resolves the module's export");
     const uint64_t base = addr - kExportFn;
     CHECK(base == BOOT_RUNTIME_MODULE_BASE, "the module is mapped in the runtime-module aperture");
+    // Every stack-scan diagnostic that recovers a guest callsite filters on these two predicates.
+    // Before #639 they stopped at the stub aperture, which now sits BELOW the runtime modules — a
+    // runtime module's return addresses would have been invisible to every one of them.
+    CHECK(guest_va_in_module(addr) && guest_va_in_module_code(addr) &&
+          !guest_va_in_module_code(BOOT_STUB),
+          "a runtime-module address classifies as guest module code, and a stub address does not");
     CHECK(addr && ((uint32_t (*)())(uintptr_t)addr)() == 0x5eed,
           "the resolved export is executable code with the expected behaviour");
 

--- a/prosper/tests/test_runtime_prx_load.cpp
+++ b/prosper/tests/test_runtime_prx_load.cpp
@@ -1,0 +1,272 @@
+// test_runtime_prx_load — real runtime PRX loading (#639).
+//
+// The acceptance test deliberately does NOT reuse the original "Blasphemous 2 resolves
+// FMOD5_Memory_GetStats" criterion: the boot-time Media/Plugins auto-link (#1609) satisfies that
+// one WITHOUT any runtime loading, so it cannot discriminate. This uses the replacement criteria
+// from #639's 2026-08-01 status comment, each of which auto-link fails by construction:
+//
+//   * the module lives OUTSIDE Media/Plugins, at a path composed while the "guest" runs;
+//   * its module_start has NOT run before the guest asks for it, and runs exactly once, at the
+//     load, with the guest's own sceKernelLoadStartModule arguments;
+//   * its DT_INIT_ARRAY runs at the same point (relocated, so it proves relocation happened);
+//   * its exports resolve through the returned handle, and the address is real, callable code;
+//   * a second load of the same path returns the same handle and does not re-run initialisation;
+//   * a genuinely missing path still returns ENOENT;
+//   * an import no loaded module satisfies gets a NEW stub slot appended after boot, and the
+//     module's GOT entry addresses that slot.
+//
+// The module is a synthetic ET_SCE_DYNAMIC ELF written by this test, so the check is hermetic:
+// no game dump, no network, and the "guest" code is bytes this file emits and can therefore
+// assert on exactly.
+#include "../src/hle/dispatch.hpp"
+#include "../src/hle/nid.hpp"
+#include "../src/host/boot_program.hpp"
+#include "../src/host/exec_image.hpp"
+#include "../src/host/runtime_module_load.hpp"
+#include "../src/loader/linker.hpp"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+// ---- synthetic module layout (file offset == vaddr throughout) --------------------------------
+enum : uint64_t {
+    kModuleStart = 0x100,   // DT_INIT
+    kCtor        = 0x140,   // DT_INIT_ARRAY[0]
+    kExportFn    = 0x160,   // the exported symbol
+    kDynamic     = 0x200,
+    kSymtab      = 0x300,
+    kStrtab      = 0x400,
+    kRela        = 0x500,
+    kJmprel      = 0x580,
+    kInitArray   = 0x600,
+    kGot         = 0x700,
+    kStartCount  = 0x800,
+    kSavedArgs   = 0x808,
+    kSavedArgp   = 0x810,
+    kCtorCount   = 0x818,
+    kFileSize    = 0x1000,
+};
+
+static void put32(std::vector<uint8_t>& f, uint64_t off, uint32_t v) { memcpy(&f[off], &v, 4); }
+static void put64(std::vector<uint8_t>& f, uint64_t off, uint64_t v) { memcpy(&f[off], &v, 8); }
+
+// `48 ff 05 d32` incq [rip+d] / `48 89 3d d32` mov [rip+d],rdi / `48 89 35 d32` mov [rip+d],rsi.
+static uint64_t emit_riprel(std::vector<uint8_t>& f, uint64_t at, const uint8_t (&op)[3],
+                            uint64_t target) {
+    f[at] = op[0]; f[at + 1] = op[1]; f[at + 2] = op[2];
+    put32(f, at + 3, (uint32_t)(int32_t)(int64_t)(target - (at + 7)));
+    return at + 7;
+}
+
+static std::vector<uint8_t> build_module(const std::string& export_nid,
+                                         const std::string& import_nid) {
+    std::vector<uint8_t> f(kFileSize, 0);
+
+    // --- ELF header (ET_SCE_DYNAMIC PRX, x86-64, FreeBSD ABI, program headers only) ---
+    memcpy(&f[0], "\x7f" "ELF", 4);
+    f[4] = 2; f[5] = 1; f[6] = 1; f[7] = 9;          // ELF64, LSB, version 1, ELFOSABI_FREEBSD
+    put32(f, 0x10, 0xfe18);                           // e_type = ET_SCE_DYNAMIC (16-bit field)
+    put32(f, 0x12, 0x3e);                             // e_machine = x86-64 (16-bit field)
+    put32(f, 0x14, 1);                                // e_version
+    put64(f, 0x18, 0);                                // e_entry
+    put64(f, 0x20, 0x40);                             // e_phoff
+    put32(f, 0x34, 64);                               // e_ehsize
+    put32(f, 0x36, 56);                               // e_phentsize (16-bit)
+    put32(f, 0x38, 2);                                // e_phnum (16-bit)
+    // e_phentsize/e_phnum share dwords with neighbours; rewrite them as the 16-bit fields they are.
+    *(uint16_t*)&f[0x36] = 56; *(uint16_t*)&f[0x38] = 2;
+    *(uint16_t*)&f[0x3a] = 0;  *(uint16_t*)&f[0x3c] = 0; *(uint16_t*)&f[0x3e] = 0;
+
+    // --- program headers: one RWX PT_LOAD covering the file, plus PT_DYNAMIC ---
+    auto phdr = [&](int i, uint32_t type, uint32_t flags, uint64_t off, uint64_t va,
+                    uint64_t filesz, uint64_t align) {
+        const uint64_t p = 0x40 + (uint64_t)i * 56;
+        put32(f, p + 0, type); put32(f, p + 4, flags);
+        put64(f, p + 8, off);  put64(f, p + 16, va); put64(f, p + 24, va);
+        put64(f, p + 32, filesz); put64(f, p + 40, filesz); put64(f, p + 48, align);
+    };
+    phdr(0, PT_LOAD,    7, 0,        0,        kFileSize, 0x4000);
+    phdr(1, PT_DYNAMIC, 6, kDynamic, kDynamic, 0x100,     8);
+
+    // --- code ---
+    // module_start(size_t args, const void* argp): record that it ran and what it was given.
+    {
+        static const uint8_t incq[3] = { 0x48, 0xff, 0x05 };
+        static const uint8_t movrdi[3] = { 0x48, 0x89, 0x3d };
+        static const uint8_t movrsi[3] = { 0x48, 0x89, 0x35 };
+        uint64_t at = kModuleStart;
+        at = emit_riprel(f, at, incq,   kStartCount);
+        at = emit_riprel(f, at, movrdi, kSavedArgs);
+        at = emit_riprel(f, at, movrsi, kSavedArgp);
+        f[at++] = 0x31; f[at++] = 0xc0;                    // xor eax,eax
+        f[at++] = 0xc3;                                    // ret
+        // DT_INIT_ARRAY[0]: a plain ctor.
+        at = kCtor;
+        at = emit_riprel(f, at, incq, kCtorCount);
+        f[at++] = 0xc3;
+        // The exported symbol: real, callable code returning a value only this test knows.
+        f[kExportFn + 0] = 0xb8; put32(f, kExportFn + 1, 0x5eed);   // mov eax, 0x5eed
+        f[kExportFn + 5] = 0xc3;                                   // ret
+    }
+
+    // --- dynamic string + symbol tables ---
+    // strtab: "\0<export_nid>\0<import_nid>#A#A\0"
+    const std::string import_raw = import_nid + "#A#A";
+    uint64_t so = kStrtab + 1;
+    const uint64_t export_name_off = so - kStrtab;
+    memcpy(&f[so], export_nid.data(), export_nid.size()); so += export_nid.size() + 1;
+    const uint64_t import_name_off = so - kStrtab;
+    memcpy(&f[so], import_raw.data(), import_raw.size()); so += import_raw.size() + 1;
+    const uint64_t strsz = so - kStrtab;
+
+    auto sym = [&](int i, uint64_t name_off, uint16_t shndx, uint64_t value) {
+        const uint64_t p = kSymtab + (uint64_t)i * 24;
+        put32(f, p + 0, (uint32_t)name_off);
+        f[p + 4] = 0x12;                       // STB_GLOBAL | STT_FUNC
+        *(uint16_t*)&f[p + 6] = shndx;
+        put64(f, p + 8, value);
+        put64(f, p + 16, 8);
+    };
+    // 0 = the null symbol (never an export), 1 = our export, 2 = an undefined Sony import.
+    memset(&f[kSymtab], 0, 24);
+    sym(1, export_name_off, 1, kExportFn);
+    sym(2, import_name_off, 0, 0);
+    const uint64_t nsym = 3;
+
+    // --- relocations ---
+    auto rela = [&](uint64_t at, uint64_t offset, uint32_t type, uint32_t symi, int64_t addend) {
+        put64(f, at + 0, offset);
+        put32(f, at + 8, type); put32(f, at + 12, symi);
+        put64(f, at + 16, (uint64_t)addend);
+    };
+    rela(kRela,   kInitArray, R_X86_64_RELATIVE,  0, (int64_t)kCtor);   // init_array[0] = &ctor
+    rela(kJmprel, kGot,       R_X86_64_JUMP_SLOT, 2, 0);                // GOT slot = the import
+
+    // --- dynamic tags. DT_SCE_SYMTABSZ first so the parser's "this is a PS5 .dynamic" run check
+    // sees an SCE tag within its 8-entry window. ---
+    uint64_t d = kDynamic;
+    auto dyn = [&](uint64_t tag, uint64_t val) { put64(f, d, tag); put64(f, d + 8, val); d += 16; };
+    dyn(0x6100003f, nsym * 24);        // DT_SCE_SYMTABSZ
+    dyn(6,  kSymtab);                  // DT_SYMTAB
+    dyn(0xb, 24);                      // DT_SYMENT
+    dyn(5,  kStrtab);                  // DT_STRTAB
+    dyn(0xa, strsz);                   // DT_STRSZ
+    dyn(7,  kRela);                    // DT_RELA
+    dyn(8,  24);                       // DT_RELASZ
+    dyn(0x17, kJmprel);                // DT_JMPREL
+    dyn(2,  24);                       // DT_PLTRELSZ
+    dyn(0xc, kModuleStart);            // DT_INIT
+    dyn(0x19, kInitArray);             // DT_INIT_ARRAY
+    dyn(0x1b, 8);                      // DT_INIT_ARRAYSZ
+    dyn(0, 0);                         // DT_NULL
+    return f;
+}
+
+int main(int argc, char** argv) {
+    printf("== test_runtime_prx_load ==\n");
+    // A scratch "dump root". argv[1] lets CTest place it on real disk (never /tmp on this project's
+    // Linux box); default to the build directory the test is run from.
+    const std::string root = (argc >= 2) ? argv[1] : std::string("./runtime-prx-test-root");
+    const std::string prx_dir = root + "/prx";          // deliberately NOT Media/Plugins
+    const std::string prx_path = prx_dir + "/prosper_runtime_test.prx";
+#ifdef _WIN32
+    system(("mkdir \"" + prx_dir + "\" 2>nul").c_str());
+#else
+    system(("mkdir -p '" + prx_dir + "'").c_str());
+#endif
+
+    const std::string export_nid = nid_hash("prosperRuntimeTestExport");
+    const std::string import_nid = nid_hash("prosperRuntimeTestImport");
+    const std::vector<uint8_t> image = build_module(export_nid, import_nid);
+    if (FILE* f = fopen(prx_path.c_str(), "wb")) {
+        fwrite(image.data(), 1, image.size(), f); fclose(f);
+    } else { printf("  [FAIL] cannot write %s\n", prx_path.c_str()); return 1; }
+
+    register_builtin_hle();
+    set_app0_root(root);
+
+    // Minimal booted program: no modules, no exports, an empty stub table at the usual base. Every
+    // import the runtime module has must therefore become a NEW slot appended after "boot".
+    static Program prog;
+    prog.stub_base = BOOT_STUB;
+    prog.stub_size = 96;
+    std::string err;
+    CHECK(install_stubs(prog.slots, prog.stub_base, prog.stub_size, &err),
+          "install_stubs (empty table) succeeded");
+    runtime_module_loader_init(&prog);
+
+    auto load  = Hle::lookup(nid_hash("sceKernelLoadStartModule"));
+    auto dlsym = Hle::lookup(nid_hash("sceKernelDlsym"));
+    CHECK(load && dlsym, "LoadStartModule + Dlsym registered");
+    if (fails) { printf("== FAIL ==\n"); return 1; }
+
+    auto U = [](const void* p) { return (uint64_t)(uintptr_t)p; };
+
+    // (1) Nothing has been initialised at boot: the module is untouched on disk.
+    CHECK(runtime_loaded_module_count() == 0, "no module is loaded before the guest asks");
+
+    // (2) Load it, through a path composed at run time, outside Media/Plugins.
+    int32_t res = 0x7fffffff;
+    const uint64_t kArgs = 0x10, kArgp = 0xdeadbeef;
+    const uint64_t handle = load(U(("/app0/prx/" + std::string("prosper_runtime_test.prx")).c_str()),
+                                 kArgs, kArgp, 0, 0, U(&res));
+    CHECK(handle >= kSceModuleHandleBase && handle < 0x80000000ull,
+          "a non-prelinked PRX outside Media/Plugins loads and returns a real handle");
+    // Everything below reads the loaded module's memory, so a failed load must stop here rather
+    // than dereference an address the loader never produced.
+    if (handle < kSceModuleHandleBase || handle >= 0x80000000ull) {
+        printf("== FAIL: load returned 0x%llx (no module was loaded) ==\n",
+               (unsigned long long)handle);
+        return 1;
+    }
+    CHECK(runtime_loaded_module_count() == 1, "exactly one module is now loaded");
+
+    // (3) Its exports resolve through THAT handle, and the address is real, callable code.
+    uint64_t addr = 0;
+    CHECK(dlsym(handle, U("prosperRuntimeTestExport"), U(&addr), 0, 0, 0) == 0 && addr != 0,
+          "dlsym through the returned handle resolves the module's export");
+    const uint64_t base = addr - kExportFn;
+    CHECK(base == BOOT_RUNTIME_MODULE_BASE, "the module is mapped in the runtime-module aperture");
+    CHECK(addr && ((uint32_t (*)())(uintptr_t)addr)() == 0x5eed,
+          "the resolved export is executable code with the expected behaviour");
+
+    // (4) module_start ran exactly once, at the load, with the guest's own arguments — the
+    // property boot-time auto-link cannot have.
+    auto peek = [&](uint64_t off) { uint64_t v; memcpy(&v, (const void*)(uintptr_t)(base + off), 8); return v; };
+    CHECK(peek(kStartCount) == 1, "module_start ran exactly once");
+    CHECK(peek(kSavedArgs) == kArgs && peek(kSavedArgp) == kArgp,
+          "module_start received the guest's (args, argp)");
+    CHECK(res == 0, "sceKernelLoadStartModule reported module_start's result through pRes");
+    CHECK(peek(kCtorCount) == 1, "DT_INIT_ARRAY ran (so the entry was relocated and executed)");
+
+    // (5) An import nothing satisfies got a NEW stub slot, and the GOT addresses it.
+    CHECK(prog.slots.size() == 1 && prog.slots[0].nid == import_nid,
+          "the module's unsatisfied import appended one stub slot after boot");
+    uint64_t got = 0; memcpy(&got, (const void*)(uintptr_t)(base + kGot), 8);
+    CHECK(got == prog.stub_base, "the module's GOT entry addresses the newly appended stub");
+
+    // (6) Repeat load: same handle, no re-initialisation.
+    res = 0x7fffffff;
+    const uint64_t again = load(U("/app0/prx/prosper_runtime_test.prx"), kArgs, kArgp, 0, 0, U(&res));
+    CHECK(again == handle, "a repeat load returns the same handle");
+    CHECK(peek(kStartCount) == 1, "a repeat load does not re-run module_start");
+    CHECK(runtime_loaded_module_count() == 1, "a repeat load does not map a second copy");
+
+    // (7) A genuinely absent path is still ENOENT — #146's contract is unchanged.
+    CHECK(load(U("/app0/prx/no_such_module.prx"), 0, 0, 0, 0, 0) == 0x80020002ull,
+          "a missing path still returns SCE_KERNEL_ERROR_ENOENT");
+
+    if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
+    printf("== PASS ==\n");
+    return 0;
+}


### PR DESCRIPTION
Fixes #639.

## The gap

`sceKernelLoadStartModule` only ever resolved a path against the fixed module set `boot_program`
links **before guest entry**. Anything else was reported `ENOENT` — the honest answer #146
established for a capability prosper did not have. That is fine for a title that preloads every PRX
it uses, and fatal for one whose code lives in modules chosen while it runs.

*R-Type Delta: HD Boosted* (`PPSA26414`, #1591) is the extreme case: it ships **24 per-stage PRXs
under `/app0/prx/`** and its eboot is only a shell. Its very first `sceKernelLoadStartModule` missed,
the following `sceKernelDlsym("DLLLoadStart")` returned ESRCH, the guest did not check the result and
called the still-NULL pointer:

```
[loadmod] '/app0/prx/title_Release.prx' not in the linked module set -> ENOENT
[dlsym] unresolved 'DLLLoadStart' -> ESRCH (fallback kept)
GetProcAddress error 80020003
=== RUN ENDED: kind=2  SIGSEGV at addr=(nil)  rip=0x0 (image+0x0) ===
```

The boot-time `Media/Plugins` auto-link stopgap (#1609) cannot reach this: the directory is wrong,
the set is title-specific, and the modules are mutually exclusive by design.

## What this does

`sceKernelLoadStartModule` now maps, relocates, links and starts a module **at the point the guest
asks for it** — the same passes `link_program` runs at boot, applied to one module against the
already-linked program (`src/host/runtime_module_load.cpp`).

* **Bases** come from a new aperture, `BOOT_RUNTIME_MODULE_BASE = 0x800000000`, 128 MiB × 48 slots.
  It sits *above* the import-stub window because `callback_fs.hpp` identifies a guest import-stub
  frame by a return address in `[0x600000000,0x700000000)`; a module mapped inside that window would
  be mistaken for one. It also stays clear of the ad-hoc stub bases a few unit tests pass to
  `install_stubs`. An image whose VA span exceeds its slot, or a run out of slots, is refused loudly.
* **Imports** resolve against the loaded exports first (the program's global table, then earlier
  runtime modules) and otherwise take an import stub slot. Slot indices are assigned first and the
  table is grown in **one append under the dispatcher's own lock** (`dispatch_append_slots`), so a
  concurrent unimplemented-import call on another thread cannot observe a moving buffer.
* **Stubs** grow in place (`append_stubs`): only the pages the new slots need are mapped, and the
  pages already handed out to relocated guest code are *never* remapped, so a thread executing a stub
  cannot have it torn away. `install_stubs` and `append_stubs` emit through one shared
  `emit_one_stub`, so the two cannot drift. On Windows `install_stubs` now **reserves the whole stub
  aperture once and commits incrementally**: a reservation is placed on the 64 KiB allocation
  granularity, so a second `MEM_RESERVE` at the 4 KiB-aligned end of the first rounds back into it
  and fails. Both platforms refuse a table that would leave the aperture.
* **Exports** register as the module's own table, so handle-first `sceKernelDlsym` (#147) resolves
  them. They are deliberately **not** merged into the program's global first-definition-wins table:
  that table is what the already-relocated modules were bound against, so adding to it now cannot
  change any of those bindings while it could change what a later name-only `dlsym` answers. A
  name-only `dlsym` instead falls back to scanning the registered per-module tables in registration
  order — which for a pre-linked module can only reproduce what the global table already answered.
* **Unwind + export tables are appended in lockstep.** `sceKernelGetModuleInfoFromAddr` derives a
  handle from the unwind order and `sceKernelDlsym` consumes it against the export order; the loader
  appends to both once per module and reports if the indices ever disagree.
* **Guest code runs on the guest `%fs`.** `module_start` / `DT_INIT_ARRAY` are guest code, and under
  `PROSPER_GUEST_FS` the HLE handler runs on the *host* `%fs`. The handler is now an entry-rsp
  trampoline that recovers the caller's guest thread pointer from the import-stub frame — the same
  mechanism the AvPlayer/IME/NetCtl callbacks use (#1286). Windows/MinGW never swaps hardware `%fs`
  at the import boundary and keeps a plain handler.
* `module_start` receives the guest's own `(args, argp)` and its result is written through `pRes`.

## Deliberately out of scope (documented in `runtime_module_load.hpp`)

* **No rebinding of already-relocated modules.** prosper binds eagerly at link time, so a module
  loaded later cannot retroactively satisfy an earlier module's import — Sony's loader has the same
  property once a module is started.
* **No unload modelling.** A repeat load of the same path returns the cached handle rather than
  re-running `module_start`. `sceKernelStopUnloadModule` stays as it was.
* **Initial-exec TLS in a runtime module** (`R_X86_64_TPOFF64`) cannot be given static TLS space once
  threads exist. Those relocations are reported loudly by name and count and left unapplied rather
  than baked to a wrong offset. General-dynamic TLS works and gets a new module id.

## Acceptance test

The original acceptance criterion in #639 ("Blasphemous 2 resolves `FMOD5_Memory_GetStats`") no
longer discriminates — the auto-link stopgap satisfies it with no runtime loading at all, as the
issue's own 2026-08-01 status comment warns. `tests/test_runtime_prx_load` uses the replacement
criteria from that comment, each of which auto-link fails **by construction**:

* the module lives outside `Media/Plugins`, at a path composed while the guest runs;
* its `module_start` has not run before the guest asks, runs exactly once at the load, and receives
  the guest's own `(args, argp)`;
* its `DT_INIT_ARRAY` runs (proving the entry was relocated *and* executed);
* its export resolves through the returned handle and the address is real, callable code;
* a second load returns the same handle and does not re-initialise or re-map;
* an unsatisfied import appends a new stub slot after boot and the module's GOT addresses it;
* a missing path still returns `ENOENT`.

The test is **hermetic**: it writes its own synthetic `ET_SCE_DYNAMIC` module, so it needs no game
dump and the "guest" code is bytes the test emits and can assert on exactly.

**Counter-arm (executed).** With `runtime_load_start_module` short-circuited to `ENOENT` — the
pre-#639 behaviour — and everything else unchanged, the test exits **1** at
`a non-prelinked PRX outside Media/Plugins loads and returns a real handle`. Restored, it exits **0**.

## Result on the motivating title

`PPSA26414` on this branch, Linux, `boot_trace`:

```
[loadmod] loaded '/app0/prx/title_Release.prx' -> title_Release.prx @ 0x700000000
          (784 exports, 23 imports: 21 cross-module, 2 stubbed, 0 new slots) handle=0x10002
[loadmod] started '/app0/prx/title_Release.prx' module_start(0x0, 0x0) -> 0x0
...
[graphics-cfg] stage=vertex   branches=6 backedge=0 complex=1 structured_ifs=4 loops=0 cf_rejected=0
[graphics-cfg] stage=fragment branches=1 backedge=0 complex=0 structured_ifs=0 loops=0 cf_rejected=0
request autoload
```

The title now reaches AGC bring-up and recompiles both of its first graphics stages. **It is still
rung 0** — no frame is composited — and this PR claims no progression: the next blocker is a
different, separately filed defect (its logged-in-user list is empty when a pad-binding path takes
`users.front()`). No screenshot is attached because there is nothing rendered to show.

Worth recording: a local prelink of the same module (the measurement #1591 used to size this work)
made `title_Release.prx` win three `std::string` NIDs from `libc.prx` in the global export table.
Real runtime loading produces **no** aliased exports, because the eboot was already bound.

## Affected / unaffected

* Affected: `sceKernelLoadStartModule` for a path not in the linked set — it now loads the module
  instead of reporting `ENOENT`. A genuinely absent path is unchanged.
* Also changed on the pre-linked path: `*pRes` is now written (`0`) on a `module_handle_for_path`
  hit. prosper never wrote that out-parameter before; the guest supplies it and Sony's contract
  fills it, so writing it is closer to the contract than leaving the caller's value — but it is a
  guest-memory write on a path every title takes, so it is called out rather than filed under
  "unaffected".
* Unaffected: which module a pre-linked path resolves to (`module_handle_for_path` still answers
  first), the auto-link stopgap, `sceKernelDlsym`'s existing handle-first and global-table answers,
  and `install_stubs`' emitted stub bytes.
* `set_module_export_tables` / `module_handle_for_path` / `sceKernelDlsym`'s handle lookup are now
  mutex-guarded. Before #639 that vector was written once before the guest ran; it can now be
  appended from a guest thread.

## Risks

* A runtime module maps at a fixed base. `map_image` uses the no-replace mmap, so a collision with a
  guest direct-memory mapping fails loudly rather than silently overlapping.
* A title that previously took a module-not-found fallback will now get a real load. That is the
  correct behaviour, but it is a behavioural change for any title with a present, non-prelinked PRX.
  The Messenger (`PPSA24651`) and Blasphemous 2 (`PPSA13579`) were booted on this branch and neither
  reaches the runtime path at all (no `[loadmod]` line), so both are byte-for-byte unaffected.
* `append_stubs` refuses a slot table that is not an extension of the installed one, rather than
  guessing.
* The loader's mutex is **recursive**, deliberately: it is held across the module's own
  `module_start`, and a `module_start` that loads a dependency is legal on PS5. `g_loaded` is a
  `std::deque`, so no published pointer moves across a nested load.

## Independent review

Reviewed independently; the full findings are in a PR comment. Two blocking issues were found and
fixed (Windows stub-region growth could never succeed and one failure disabled runtime loading for
the rest of the run; the loader's mutex was non-recursive across guest `module_start`), along with
eight non-blocking items. `ctest` is 174/174 on the corrected head and the acceptance test's
counter-arm was re-run.

## Verification

```
cmake -S prosper -B build -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0
cmake --build build -j8            # clean, no new warnings
ctest                              # 174/174 passed  (21.2 s)
build/test_runtime_prx_load        # PASS (18 checks); counter-armed -> exit 1
```

Boots on this branch (Linux, `boot_trace`, `PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct`):

| Title | Result |
| --- | --- |
| The Messenger `PPSA24651` | runs to the 120 s timeout, loading level-3 assets — no `[loadmod]` line |
| Blasphemous 2 `PPSA13579` | runs to the 120 s timeout, seeded render verified — no `[loadmod]` line |
| R-Type Delta `PPSA26414` | loads + starts `title_Release.prx`, recompiles both graphics stages |
