### PR TITLE
feat(diag): PROSPER_DMEM_CALLER — attribute a direct-memory allocation to the guest code that asked for it

### DIFF
--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -135,6 +135,50 @@ namespace {
     bool memlog() { static int v = getenv("PROSPER_MEMLOG") ? 1 : 0; return v; }
     #define MLOG(...) do { if (memlog()) fprintf(stderr, "[memhle] " __VA_ARGS__); } while (0)
 
+    // PROSPER_DMEM_CALLER=1: attribute each direct-memory allocation to the guest code that asked
+    // for it. `[memhle] alloc_main_dmem len=…` answers "how much" but never "who", and a title whose
+    // heap grows without bound cannot be diagnosed from the sizes — the same allocator serves every
+    // subsystem, so only the callers above it separate a legitimate load from a leak. Asterix &
+    // Obelix - Babylon Mission (#1748) is the motivating case: ~13 × 16 MiB blocks per second, eight
+    // releases in the whole run, the direct-memory pool empty in ~125 s, and nothing in `[memhle]`
+    // to say which subsystem was responsible.
+    //
+    // The walk is a DIAGNOSTIC-ONLY stack scan, the same technique hle_agc.cpp's fence1-builder
+    // attribution uses: from this frame, report every value that lies inside a loaded guest module.
+    // It is a heuristic — a stale spill slot looks exactly like a return address — so treat the
+    // result as a callsite HINT to confirm against the module's disassembly, never as an ABI input
+    // and never as proof on its own. Off by default, and rate-limited per distinct call chain so an
+    // allocation-heavy boot cannot bury the log in duplicates of one site.
+    bool dmem_caller_log() { static int v = getenv("PROSPER_DMEM_CALLER") ? 1 : 0; return v != 0; }
+    void log_dmem_caller(const char* what, uint64_t len, const volatile uint64_t* frame) {
+        if (!dmem_caller_log()) return;
+        constexpr int kWant = 6;          // return addresses to report
+        constexpr int kScan = 160;        // stack slots to walk
+        uint64_t ra[kWant] = {};
+        int n = 0;
+        for (int i = 1; i < kScan && n < kWant; i++) {
+            const uint64_t v = frame[i];
+            if (!guest_va_in_module(v)) continue;
+            if (n && ra[n - 1] == v) continue;      // collapse an adjacent duplicate spill
+            ra[n++] = v;
+        }
+        // Rate-limit on the chain itself: one line per distinct (first two frames) pair.
+        static std::mutex mx;
+        static std::vector<std::pair<uint64_t, uint64_t>> seen;
+        const std::pair<uint64_t, uint64_t> key{ n > 0 ? ra[0] : 0, n > 1 ? ra[1] : 0 };
+        {
+            std::lock_guard<std::mutex> lk(mx);
+            for (const auto& s : seen) if (s == key) return;
+            if (seen.size() >= 64) return;          // bounded: 64 distinct chains is plenty
+            seen.push_back(key);
+        }
+        fprintf(stderr, "[dmem-caller] %s len=0x%llx from", what, (unsigned long long)len);
+        for (int i = 0; i < n; i++)
+            fprintf(stderr, " %s+0x%llx", guest_module_name(ra[i]),
+                    (unsigned long long)guest_module_offset(ra[i]));
+        fprintf(stderr, "\n");
+    }
+
     constexpr uint32_t kVirtualQueryFlexible = 0x01;
     constexpr uint32_t kVirtualQueryDirect   = 0x02;
     constexpr uint32_t kVirtualQueryCommitted = 0x10;
@@ -936,6 +980,7 @@ HLE(k_alloc_main_dmem) {
     dmem_zero(off, sz);                       // fresh allocation -> zeroed pages (console semantics)
     *(uint64_t*)a3 = off;
     MLOG("alloc_main_dmem len=0x%llx -> phys=0x%llx\n", (unsigned long long)a0, (unsigned long long)off);
+    log_dmem_caller("alloc_main_dmem", a0, (const volatile uint64_t*)__builtin_frame_address(0));
     return 0;
 }
 
@@ -2112,6 +2157,50 @@ namespace prosper {
 namespace {
     bool memlog() { static int v = getenv("PROSPER_MEMLOG") ? 1 : 0; return v; }
     #define MLOG(...) do { if (memlog()) fprintf(stderr, "[memhle] " __VA_ARGS__); } while (0)
+
+    // PROSPER_DMEM_CALLER=1: attribute each direct-memory allocation to the guest code that asked
+    // for it. `[memhle] alloc_main_dmem len=…` answers "how much" but never "who", and a title whose
+    // heap grows without bound cannot be diagnosed from the sizes — the same allocator serves every
+    // subsystem, so only the callers above it separate a legitimate load from a leak. Asterix &
+    // Obelix - Babylon Mission (#1748) is the motivating case: ~13 × 16 MiB blocks per second, eight
+    // releases in the whole run, the direct-memory pool empty in ~125 s, and nothing in `[memhle]`
+    // to say which subsystem was responsible.
+    //
+    // The walk is a DIAGNOSTIC-ONLY stack scan, the same technique hle_agc.cpp's fence1-builder
+    // attribution uses: from this frame, report every value that lies inside a loaded guest module.
+    // It is a heuristic — a stale spill slot looks exactly like a return address — so treat the
+    // result as a callsite HINT to confirm against the module's disassembly, never as an ABI input
+    // and never as proof on its own. Off by default, and rate-limited per distinct call chain so an
+    // allocation-heavy boot cannot bury the log in duplicates of one site.
+    bool dmem_caller_log() { static int v = getenv("PROSPER_DMEM_CALLER") ? 1 : 0; return v != 0; }
+    void log_dmem_caller(const char* what, uint64_t len, const volatile uint64_t* frame) {
+        if (!dmem_caller_log()) return;
+        constexpr int kWant = 6;          // return addresses to report
+        constexpr int kScan = 160;        // stack slots to walk
+        uint64_t ra[kWant] = {};
+        int n = 0;
+        for (int i = 1; i < kScan && n < kWant; i++) {
+            const uint64_t v = frame[i];
+            if (!guest_va_in_module(v)) continue;
+            if (n && ra[n - 1] == v) continue;      // collapse an adjacent duplicate spill
+            ra[n++] = v;
+        }
+        // Rate-limit on the chain itself: one line per distinct (first two frames) pair.
+        static std::mutex mx;
+        static std::vector<std::pair<uint64_t, uint64_t>> seen;
+        const std::pair<uint64_t, uint64_t> key{ n > 0 ? ra[0] : 0, n > 1 ? ra[1] : 0 };
+        {
+            std::lock_guard<std::mutex> lk(mx);
+            for (const auto& s : seen) if (s == key) return;
+            if (seen.size() >= 64) return;          // bounded: 64 distinct chains is plenty
+            seen.push_back(key);
+        }
+        fprintf(stderr, "[dmem-caller] %s len=0x%llx from", what, (unsigned long long)len);
+        for (int i = 0; i < n; i++)
+            fprintf(stderr, " %s+0x%llx", guest_module_name(ra[i]),
+                    (unsigned long long)guest_module_offset(ra[i]));
+        fprintf(stderr, "\n");
+    }
 
     // --- VA tracker + direct-memory pool: PURE logic, copied verbatim from the Linux path -----
     constexpr uint32_t kVirtualQueryFlexible = 0x01;
@@ -4314,6 +4403,7 @@ HLE(k_alloc_main_dmem) {
     dmem_prepare_allocation(off, sz);
     *(uint64_t*)a3 = off;
     MLOG("alloc_main_dmem len=0x%llx -> phys=0x%llx\n", (unsigned long long)a0, (unsigned long long)off);
+    log_dmem_caller("alloc_main_dmem", a0, (const volatile uint64_t*)__builtin_frame_address(0));
     return 0;
 }
 

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -32,6 +32,18 @@ the shipped runtime. Build them from `build-linux/` like everything else.
 - **`boot_trace/`** — boots a SELF/ELF game image through the loader + HLE and
   runs it, with the fault handler, GPU executor, and (under `PROSPER_RENDER`) the
   live Vulkan renderer. The main harness for exercising a real title headlessly.
+  - **Who allocated this memory?** `PROSPER_MEMLOG=1` reports every direct-memory reserve / allocate
+    / map with its size, which answers *how much* but never *who* — and the same guest allocator
+    serves every subsystem, so a title whose heap grows without bound looks identical to one that is
+    legitimately loading. Add **`PROSPER_DMEM_CALLER=1`** to print, once per distinct call chain, the
+    guest return addresses above each `sceKernelAllocateMainDirectMemory`:
+    ```text
+    [dmem-caller] alloc_main_dmem len=0x1000000 from eboot+0x1b2454f eboot+0x7d0a00 eboot+0x22b1e80 …
+    ```
+    Feed the first address to `tools/re/edis.py` / `tools/re/xref.py` to name the caller. The walk is
+    a heuristic stack scan (a stale spill slot looks exactly like a return address), so treat the
+    result as a callsite **hint** to confirm against the module's disassembly — never as proof on its
+    own. Bounded to 64 distinct chains so an allocation-heavy boot cannot bury the log.
 - **`screenshot/`** — writes normal composited PNG sequences plus a JSONL evidence manifest. Use
   `--seconds 1` for wall-clock sampling, warmup or `--render-every N --render-every-for-seconds S`
   for slow software rendering,


### PR DESCRIPTION
Refs #1748.

## The gap

`PROSPER_MEMLOG=1` logs every direct-memory reserve / allocate / map with its size. That answers
*how much*, and never *who* — one guest allocator serves every subsystem, so a title whose heap grows
without bound produces a log that is indistinguishable from one that is legitimately loading assets.

That is exactly where #1748 (*Asterix & Obelix - Babylon Mission*, `PPSA30490`) sits: about **13 ×
16 MiB blocks per second, eight releases in the entire run**, the direct-memory pool empty in ~125 s,
and 5,000 lines of `[memhle]` that cannot say which subsystem is responsible.

## What this adds

`PROSPER_DMEM_CALLER=1` prints, **once per distinct call chain**, the guest return addresses above
each `sceKernelAllocateMainDirectMemory`:

```text
[dmem-caller] alloc_main_dmem len=0x100000  from STUB+0x48fd eboot+0x1b2454f eboot+0x7d0b00 …
[dmem-caller] alloc_main_dmem len=0x870000  from STUB+0x48fd eboot+0x16bb255 eboot+0x22afd60 …
[dmem-caller] alloc_main_dmem len=0x1000000 from eboot+0x1b2454f eboot+0x7d0a00 eboot+0x22b1e80 …
[dmem-caller] alloc_main_dmem len=0x1000000 from eboot+0x1b2454f eboot+0x7d0b00 eboot+0x22b1e80 …
```

Four lines instead of a thousand, and the first address feeds straight into `tools/re/edis.py` /
`tools/re/xref.py`. On `PPSA30490` that immediately separated the runaway 16 MiB block growth — two
chains, both through `eboot+0x1b2454f`, the return site of the title's PS5 memory-block provider —
from the ordinary sized allocations around it, and named the `DynamicHeapAllocator` above it.

## Honesty about what it is

The walk is a **diagnostic-only stack scan**, the same technique `hle_agc.cpp`'s `fence1-builder`
attribution already uses: from the handler's frame, report every value that lies inside a loaded
guest module. A stale spill slot looks exactly like a return address, so the output is a callsite
**hint to confirm against the module's disassembly** — never an ABI input, never proof on its own.
The code comment and `tools/AGENTS.md` both say this in those words.

Bounded on purpose: 6 addresses per line, 160 stack slots scanned, 64 distinct chains retained. An
allocation-heavy boot cannot bury the log, and the retained set cannot grow without limit.

## Affected / unaffected

* Off by default. With `PROSPER_DMEM_CALLER` unset the only cost is one `getenv`-backed static bool
  test per allocation, and **no** output — verified by a boot with the variable unset producing zero
  `[dmem-caller]` lines.
* Present on both the Linux and the Windows direct-memory paths (`hle_kernel_mem.cpp` keeps a
  verbatim copy of the VA-tracker/dmem namespace per platform), so a Windows investigation is not
  left without it.
* No behavioural change to allocation, mapping, or any returned value.

## Verification

```
cmake -S prosper -B build -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0
cmake --build build -j8      # clean
ctest                        # 173/173 passed
```

Live, `PPSA30490`, Linux `boot_trace`:

| Run | `[dmem-caller]` lines |
| --- | --- |
| `PROSPER_DMEM_CALLER=1` | 4 |
| variable unset | 0 |
