### PR TITLE
fix(gpu): DMA_DATA with a GDS destination selector was silently discarded (#1750)

### DIFF
--- a/prosper/docs/ASTROBOT_LINUX_HANDOFF_2026_07_19.md
+++ b/prosper/docs/ASTROBOT_LINUX_HANDOFF_2026_07_19.md
@@ -597,11 +597,18 @@ than re-deriving a dead answer at full cost.
 - **"The count is something prosper derives or inflates."** False. `0x500571000` is an *indirect*
   dispatch; `resolve_indirect_dispatch_arguments` reads the value verbatim from guest memory at
   `0x5074063c0` (an address stable across runs), and that memory already holds the growing series.
-- **"A CP-DMA / WRITE_DATA writes the count."** False. `PROSPER_DMA_WATCH_DST=0x5074063c0` over a
-  routed run reports **zero** hits. `PROSPER_PROVENANCE_ADDR=0x5074063c0:12` names the sole writer:
-  compute program `0x5006eac00`, every write `compute-buffer`, nothing else.
+- **"A CP-DMA / WRITE_DATA writes the count."** False. `PROSPER_DMA_WATCH_DST=0x5074063c0` (on master)
+  over a routed run reports **zero** hits. The sole writer is compute program `0x5006eac00` — every
+  write `compute-buffer`, nothing else — established with `PROSPER_PROVENANCE_ADDR`, which is **added
+  in PR #1752 and is not on master**; until that lands, reproduce this with that branch.
 - **"#1743's 87,551 failing dispatches are 87,551 independent failures."** False. They are one
   `VK_ERROR_DEVICE_LOST` and its casualties: for `0x5006eac00`, 329 successes at submits 1..2341 and
   249 failures at 2349..4333, with **zero successes after the first failure**. The device is lost once
-  and never recovers. `CONFIDENCE: MED` that #1742's ~1.5 s / 192 M-invocation dispatch is what trips
-  the watchdog; falsifiable with `PROSPER_MAX_DISPATCH_GROUPS=N`.
+  and never recovers. Reproduce the failure reason on master with
+  `PROSPER_COMPUTELOG_CODE=0x5006eac00`, which un-gags the `if (trace)` failure paths.
+- **"The device loss has some cause other than the dispatch size."** False, and this is what makes
+  #1742 upstream of #1743. Capping the workgroup count prevents it outright: unclamped, the device is
+  lost at ~submit 2345 after 329 successes; with the cap the same route reaches submit 3373 with
+  **458 successes and zero device losses**. The cap is `PROSPER_MAX_DISPATCH_GROUPS=N`, also **added in
+  PR #1752 and not on master** — it is a diagnostic that computes wrong results and must never be used
+  as a fix.

--- a/prosper/docs/ASTROBOT_LINUX_HANDOFF_2026_07_19.md
+++ b/prosper/docs/ASTROBOT_LINUX_HANDOFF_2026_07_19.md
@@ -582,3 +582,26 @@ direct evidence of:
 6. applicable tests, all-title renderer guards, hosted CI, screenshots, and the final PR merged.
 
 Until those conditions hold, keep advancing the live failure frontier.
+
+## Ruled out
+
+One line per falsified hypothesis, the evidence that killed it, and the issue/PR. Extend this rather
+than re-deriving a dead answer at full cost.
+
+- **"Astro Bot's unbounded indirect dispatch (#1742) is caused by the dropped GDS counter resets."**
+  False, and measured rather than argued. The guest does reset GDS counters with `DMA_DATA` packets
+  whose destination selector names a GDS offset, and prosper *was* discarding every one of them —
+  that is a real defect, fixed in #1750 / PR #1751, restoring **343 writes per routed run where 0
+  landed before**. It changes nothing here: with the lever demonstrably moved, `groups_x` still runs
+  1, 1, 2, 3, 4, 5, 7, 15, 6711, 26783, 40167, 66927. Whatever accumulates that count is elsewhere.
+- **"The count is something prosper derives or inflates."** False. `0x500571000` is an *indirect*
+  dispatch; `resolve_indirect_dispatch_arguments` reads the value verbatim from guest memory at
+  `0x5074063c0` (an address stable across runs), and that memory already holds the growing series.
+- **"A CP-DMA / WRITE_DATA writes the count."** False. `PROSPER_DMA_WATCH_DST=0x5074063c0` over a
+  routed run reports **zero** hits. `PROSPER_PROVENANCE_ADDR=0x5074063c0:12` names the sole writer:
+  compute program `0x5006eac00`, every write `compute-buffer`, nothing else.
+- **"#1743's 87,551 failing dispatches are 87,551 independent failures."** False. They are one
+  `VK_ERROR_DEVICE_LOST` and its casualties: for `0x5006eac00`, 329 successes at submits 1..2341 and
+  249 failures at 2349..4333, with **zero successes after the first failure**. The device is lost once
+  and never recovers. `CONFIDENCE: MED` that #1742's ~1.5 s / 192 M-invocation dispatch is what trips
+  the watchdog; falsifiable with `PROSPER_MAX_DISPATCH_GROUPS=N`.

--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -111,6 +111,10 @@ bool guest_readable(uint64_t addr, uint32_t bytes);
 bool guest_writable(uint64_t addr, uint32_t bytes);
 // Guest GPU writes invalidate renderer-owned copies of overlapping resources.
 void notify_guest_gpu_write(uint64_t addr, uint64_t size);
+// The 64 KiB Global Data Share (gpu_executor.cpp, declared in gpu_execute.hpp). DMA_DATA can name a
+// GDS offset rather than a guest address as its destination, and shaders reach the same backing.
+uint8_t* compute_gds_backing();
+size_t compute_gds_size();
 
 // Wake any thread blocked in sync_on_address (a futex) on `addr`. A GPU completion label write only
 // changes memory; a futex waiter does NOT wake on a value change — it needs an explicit FUTEX_WAKE. The
@@ -1053,13 +1057,37 @@ static void honor_event_write(const Pm4Command& c) {
 // vocabulary. Source mappedness plus the established 32-bit immediate ABI is the safe discriminator;
 // GDS offsets and malformed/unmapped endpoints remain fail-closed.
 // CONFIDENCE: HIGH on immediate fill and mapped address-copy behavior; MED on the large-fill form.
-enum class DmaDataForm { Invalid, Immediate, Copy };
+enum class DmaDataForm { Invalid, Immediate, Copy, GdsImmediate };
+
+// The destination selector occupies the LOW byte of the packed `dd_sels` word: the HLE builder writes
+// `(a2 & 0xff) | ((a3 & 0xff) << 8)`, and a2 is the argument that tracks the destination DOMAIN.
+// Evidence (Astro Bot, #1742): across a routed run every DMA_DATA with a2==1 carries a tiny
+// destination (0x4, 0xc68, 0xc70, 0xc74) while every a2==3 carries a full 64-bit guest address —
+// so a2 selects where the destination lives, and 1 is the PM4 GDS encoding. This also resolves the
+// `srcSel?`/`dstSel?` question the HLE prototype left open at CONFIDENCE: MED; the two names were
+// transposed. Corroboration: Sony's own parameter is `dstAddressOrOffset` (from the patcher export
+// `sceAgcDmaDataPatchSetDstAddressOrOffset`), an offset domain that in DMA_DATA is GDS, and
+// `sceAgcDcbAtomicGds` / `sceAgcDriverRegisterGdsResource` are part of the same published surface.
+// CONFIDENCE: MED-HIGH on dst_sel==1 meaning GDS; the guard below keeps every other form unchanged.
+static constexpr uint32_t kDmaDstSelGds = 1;
+static uint32_t dma_data_dst_sel(const Pm4Command& c) { return c.dd_sels & 0xffu; }
 
 static DmaDataForm dma_data_form(const Pm4Command& c, bool source_materialized = false) {
     constexpr uint32_t kMaxImmediateBytes = 0x1000000;   // existing 16 MiB fill safety bound
     constexpr uint32_t kMaxCopyBytes = 0x10000000;      // HLE builder's 256 MiB API bound
-    if (!c.dd_valid || !c.dd_bytes || c.dd_bytes > kMaxCopyBytes || c.dd_dst < 0x10000)
-        return DmaDataForm::Invalid;
+    if (!c.dd_valid || !c.dd_bytes || c.dd_bytes > kMaxCopyBytes) return DmaDataForm::Invalid;
+    // A GDS destination is an OFFSET into the 64 KiB share, not a guest address, so it is legitimately
+    // below the 0x10000 floor that rejects malformed guest pointers — which is exactly why every one
+    // of these was being discarded. Only the immediate (<=32-bit source) form is accepted here: a
+    // GDS-to-memory or memory-to-GDS copy has no title evidence yet and stays fail-closed.
+    if (dma_data_dst_sel(c) == kDmaDstSelGds) {
+        const size_t gds_size = compute_gds_size();
+        const bool in_range = c.dd_dst < gds_size && c.dd_bytes <= gds_size - c.dd_dst;
+        return (c.dd_src <= UINT32_MAX && in_range && !(c.dd_dst & 3) && !(c.dd_bytes & 3))
+                   ? DmaDataForm::GdsImmediate
+                   : DmaDataForm::Invalid;
+    }
+    if (c.dd_dst < 0x10000) return DmaDataForm::Invalid;
     // Preserve the established ABI discriminator: every <=32-bit source is immediate data. Guest
     // image/heap addresses in prosper are 64-bit, so address copies occupy the other domain.
     if (c.dd_src <= UINT32_MAX) {
@@ -1102,6 +1130,20 @@ static void honor_dma_data(const Pm4Command& c, uint64_t retained_packet_addr = 
     }
     if (form == DmaDataForm::Invalid) {
         report_invalid_dma_data(c);
+        return;
+    }
+    if (form == DmaDataForm::GdsImmediate) {
+        // A GDS counter reset. The guest zeroes its append/consume counters here every frame; the
+        // shaders that increment them reach the same 64 KiB backing through the internal binding.
+        // Dropping this write is what made Astro Bot's indirect dispatch grow without bound (#1742):
+        // the counter accumulated by a constant per frame and was consumed as a workgroup count.
+        uint8_t* gds = compute_gds_backing();
+        const uint32_t v32 = (uint32_t)c.dd_src;
+        for (uint32_t i = 0; i + 4 <= c.dd_bytes; i += 4)
+            memcpy(gds + c.dd_dst + i, &v32, 4);
+        if (getenv("PROSPER_GFXLOG") || getenv("PROSPER_GDSLOG"))
+            fprintf(stderr, "[agc]   DmaData GDS fill [gds+0x%llx] := 0x%x (%u bytes)\n",
+                    (unsigned long long)c.dd_dst, v32, c.dd_bytes);
         return;
     }
     uint8_t* dst = (uint8_t*)(uintptr_t)c.dd_dst;

--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -1060,17 +1060,31 @@ static void honor_event_write(const Pm4Command& c) {
 enum class DmaDataForm { Invalid, Immediate, Copy, GdsImmediate };
 
 // The destination selector occupies the LOW byte of the packed `dd_sels` word: the HLE builder writes
-// `(a2 & 0xff) | ((a3 & 0xff) << 8)`, and a2 is the argument that tracks the destination DOMAIN.
-// Evidence (Astro Bot, #1742): across a routed run every DMA_DATA with a2==1 carries a tiny
-// destination (0x4, 0xc68, 0xc70, 0xc74) while every a2==3 carries a full 64-bit guest address —
-// so a2 selects where the destination lives, and 1 is the PM4 GDS encoding. This also resolves the
-// `srcSel?`/`dstSel?` question the HLE prototype left open at CONFIDENCE: MED; the two names were
-// transposed. Corroboration: Sony's own parameter is `dstAddressOrOffset` (from the patcher export
-// `sceAgcDmaDataPatchSetDstAddressOrOffset`), an offset domain that in DMA_DATA is GDS, and
-// `sceAgcDcbAtomicGds` / `sceAgcDriverRegisterGdsResource` are part of the same published surface.
-// CONFIDENCE: MED-HIGH on dst_sel==1 meaning GDS; the guard below keeps every other form unchanged.
-static constexpr uint32_t kDmaDstSelGds = 1;
+// `(a2 & 0xff) | ((a3 & 0xff) << 8)`, and a2 is the argument that tracks the destination DOMAIN. This
+// resolves the `srcSel?`/`dstSel?` question the HLE prototype left open at CONFIDENCE: MED — the two
+// names are transposed. `agc_acb_dma_data` packs the FIRST of its two selector arguments into the low
+// byte as well, so one rule covers both builders; `Pm4Command::queue_origin` can split them if a title
+// ever forces it.
+//
+// Evidence, all of it title evidence rather than a hardware table:
+//  - Across a routed Astro Bot run the low byte partitions destinations with no overlap: 1 appears
+//    only with GDS-sized offsets (0x4, 0x24, 0xc64, 0xc68, 0xc6c, 0xc70, 0xc74, 0xc78, 0xc7c) and 3
+//    only with full 64-bit guest addresses.
+//  - Sony's parameter is `dstAddressOrOffset` (export `sceAgcDmaDataPatchSetDstAddressOrOffset`), so
+//    an offset domain exists; GDS is the only offset domain DMA_DATA has, and `sceAgcDcbAtomicGds` /
+//    `sceAgcAcbAtomicGds` / `sceAgcDriverRegisterGdsResource` are published exports.
+//  - DOLL's #312 packet (immediate zero into a memory label) passes 3 in the low byte, consistent
+//    with 3 meaning a memory destination.
+//
+// Do NOT read these values as PM4's: that same DOLL packet passes 3 in the HIGH byte for a source
+// that is demonstrably an immediate, where PM4 encodes DATA as 2. The AGC enum is its own vocabulary,
+// so the specific value 1 is pinned by prosper's title evidence above and by nothing else.
+// CONFIDENCE: MED on dst_sel==1 meaning GDS — the partition is clean and the API naming corroborates
+// it, but the sample is a handful of call sites, and no shader has yet been shown to READ these
+// offsets. The guards below keep every unrecognised form fail-closed.
+static constexpr uint32_t kDmaSelGds = 1;
 static uint32_t dma_data_dst_sel(const Pm4Command& c) { return c.dd_sels & 0xffu; }
+static uint32_t dma_data_src_sel(const Pm4Command& c) { return (c.dd_sels >> 8) & 0xffu; }
 
 static DmaDataForm dma_data_form(const Pm4Command& c, bool source_materialized = false) {
     constexpr uint32_t kMaxImmediateBytes = 0x1000000;   // existing 16 MiB fill safety bound
@@ -1079,8 +1093,14 @@ static DmaDataForm dma_data_form(const Pm4Command& c, bool source_materialized =
     // A GDS destination is an OFFSET into the 64 KiB share, not a guest address, so it is legitimately
     // below the 0x10000 floor that rejects malformed guest pointers — which is exactly why every one
     // of these was being discarded. Only the immediate (<=32-bit source) form is accepted here: a
-    // GDS-to-memory or memory-to-GDS copy has no title evidence yet and stays fail-closed.
-    if (dma_data_dst_sel(c) == kDmaDstSelGds) {
+    // GDS-to-memory or memory-to-GDS copy has no title evidence yet and stays fail-closed
+    // (the source guard above is what makes that true of the GDS-to-memory direction).
+    // A GDS SOURCE would make `dd_src` a small offset, which the immediate path below cannot tell from
+    // a 32-bit fill value — it would write the offset itself into guest memory. There is no title
+    // evidence for that form, so reject it rather than mis-execute it. (This is a behaviour change
+    // only for a packet whose high selector byte is 1, which no observed title emits.)
+    if (dma_data_src_sel(c) == kDmaSelGds) return DmaDataForm::Invalid;
+    if (dma_data_dst_sel(c) == kDmaSelGds) {
         const size_t gds_size = compute_gds_size();
         const bool in_range = c.dd_dst < gds_size && c.dd_bytes <= gds_size - c.dd_dst;
         return (c.dd_src <= UINT32_MAX && in_range && !(c.dd_dst & 3) && !(c.dd_bytes & 3))
@@ -1133,10 +1153,14 @@ static void honor_dma_data(const Pm4Command& c, uint64_t retained_packet_addr = 
         return;
     }
     if (form == DmaDataForm::GdsImmediate) {
-        // A GDS counter reset. The guest zeroes its append/consume counters here every frame; the
-        // shaders that increment them reach the same 64 KiB backing through the internal binding.
-        // Dropping this write is what made Astro Bot's indirect dispatch grow without bound (#1742):
-        // the counter accumulated by a constant per frame and was consumed as a workgroup count.
+        // A GDS counter reset: the guest zeroes these offsets every frame, and the shaders that use
+        // GDS reach the same 64 KiB backing through the internal binding. Dropping the write loses
+        // guest state outright.
+        //
+        // NOT the cause of #1742 — this was the hypothesis that motivated the fix and it was tested
+        // and FALSIFIED. With these writes restored (343 per routed run, against 0 before), Astro
+        // Bot's indirect dispatch still grows 1, 1, 2, 3, 4, 5, 7, 15, 6711, 26783, 40167, 66927.
+        // Whatever accumulates that count is elsewhere; do not re-derive this.
         uint8_t* gds = compute_gds_backing();
         const uint32_t v32 = (uint32_t)c.dd_src;
         for (uint32_t i = 0; i + 4 <= c.dd_bytes; i += 4)

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -1827,4 +1827,12 @@ bool execute_and_present(const GpuState& st, uint32_t width, uint32_t height,
 bool execute_ordered_and_present(const GpuState& st, uint32_t width, uint32_t height,
                                  uint64_t submit_no = 0, bool publish = true);
 
+// The 64 KiB Global Data Share. Compute shaders reach it through the internal binding installed when
+// a kernel decodes a `ds_*` instruction with the GDS flag; the command processor reaches it here,
+// because DMA_DATA can name a GDS OFFSET rather than a guest address as its endpoint (Sony's own
+// parameter is `dstAddressOrOffset`, and `sceAgcDcbAtomicGds` is part of the same API surface).
+// Returns the backing and its size so a caller can bounds-check an offset without assuming 64 KiB.
+uint8_t* compute_gds_backing();
+size_t compute_gds_size();
+
 } // namespace prosper::gpu

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -6047,6 +6047,8 @@ static OrderedSubmitResult execute_ordered_gpustate(const GpuState& st, uint32_t
 
 void set_submit_renderer(LiveRenderFn fn) { g_live = std::move(fn); }
 bool have_submit_renderer()               { return static_cast<bool>(g_live); }
+uint8_t* compute_gds_backing()            { return g_compute_gds.data(); }
+size_t   compute_gds_size()               { return g_compute_gds.size(); }
 void set_submit_compute(LiveComputeFn fn) { g_compute = std::move(fn); }
 bool have_submit_compute()                { return static_cast<bool>(g_compute); }
 

--- a/prosper/tests/test_eop_write.cpp
+++ b/prosper/tests/test_eop_write.cpp
@@ -317,6 +317,59 @@ int main() {
               "DMA_DATA notified renderer caches about the guest-memory write");
     }
 
+    // #1742: a DMA_DATA whose destination selector is GDS names an OFFSET into the 64 KiB Global
+    // Data Share, not a guest address. Such a destination is legitimately below the 0x10000 floor
+    // that rejects malformed guest pointers, so every one of these writes used to be discarded as
+    // "invalid/unmapped form" — silently, since the report is capped at 24 lines per run. Astro Bot
+    // resets its GDS append counters this way, and the drop is a real loss of guest state.
+    {
+        uint8_t* gds = compute_gds_backing();
+        const uint32_t offset = 0xc68;   // an offset this title actually uses
+        memset(gds + offset, 0xAB, 8);
+        uint32_t dma[7] = {};
+        dma[0] = PM4(7, IT_NOP, R_DMA_DATA);
+        dma[1] = offset; dma[2] = 0;     // destination is a GDS offset, well below 0x10000
+        dma[3] = 0;      dma[4] = 0;     // 32-bit immediate source: zero the counter
+        dma[5] = 4;
+        dma[6] = 1;                      // dst_sel (low byte) == 1 == GDS
+        GpuState st; run_cb(dma, 7, st);
+        uint32_t written = 0xFFFFFFFFu;
+        memcpy(&written, gds + offset, sizeof written);
+        CHECK(written == 0, "DMA_DATA with a GDS destination selector zeroes the GDS counter");
+        CHECK(gds[offset + 4] == 0xAB, "GDS fill wrote exactly the requested byte span");
+    }
+
+    // ...and the guard that made it fail-closed still rejects a genuinely malformed guest pointer:
+    // a sub-0x10000 destination WITHOUT the GDS selector must remain unwritten, or the fix above
+    // would have turned every malformed packet into a wild write at a low address.
+    {
+        uint32_t dma[7] = {};
+        dma[0] = PM4(7, IT_NOP, R_DMA_DATA);
+        dma[1] = 0xc68; dma[2] = 0;
+        dma[3] = 0;     dma[4] = 0;
+        dma[5] = 4;
+        dma[6] = 3;                      // dst_sel == 3 == memory: 0xc68 is not a valid address
+        GpuState st; run_cb(dma, 7, st);
+        CHECK(true, "a low destination without the GDS selector is still rejected (no crash)");
+    }
+
+    // A GDS offset that would run past the 64 KiB share must be rejected rather than clamped —
+    // an out-of-range offset is a decode error, and writing a truncated span would corrupt state
+    // the shaders read.
+    {
+        uint8_t* gds = compute_gds_backing();
+        const uint32_t offset = (uint32_t)compute_gds_size() - 4;
+        memset(gds + offset, 0x5A, 4);
+        uint32_t dma[7] = {};
+        dma[0] = PM4(7, IT_NOP, R_DMA_DATA);
+        dma[1] = offset; dma[2] = 0;
+        dma[3] = 0;      dma[4] = 0;
+        dma[5] = 16;                     // 16 bytes from 4 bytes before the end: out of range
+        dma[6] = 1;
+        GpuState st; run_cb(dma, 7, st);
+        CHECK(gds[offset] == 0x5A, "an out-of-range GDS span is rejected, not clamped");
+    }
+
     // A queued upload before an address copy is the copy's ordered prefix. The first retained copy
     // must drain it before execution; otherwise a compute-only/non-render submit can copy stale bytes.
     {

--- a/prosper/tests/test_eop_write.cpp
+++ b/prosper/tests/test_eop_write.cpp
@@ -341,8 +341,12 @@ int main() {
 
     // ...and the guard that made it fail-closed still rejects a genuinely malformed guest pointer:
     // a sub-0x10000 destination WITHOUT the GDS selector must remain unwritten, or the fix above
-    // would have turned every malformed packet into a wild write at a low address.
+    // would have turned every malformed packet into a wild write at a low address. Assert on GDS
+    // CONTENT, not on survival: if the selector test were dropped and the range check alone routed
+    // the packet, it would land in GDS and a non-crash assertion would still pass.
     {
+        uint8_t* gds = compute_gds_backing();
+        gds[0xc68] = 0x77;
         uint32_t dma[7] = {};
         dma[0] = PM4(7, IT_NOP, R_DMA_DATA);
         dma[1] = 0xc68; dma[2] = 0;
@@ -350,7 +354,45 @@ int main() {
         dma[5] = 4;
         dma[6] = 3;                      // dst_sel == 3 == memory: 0xc68 is not a valid address
         GpuState st; run_cb(dma, 7, st);
-        CHECK(true, "a low destination without the GDS selector is still rejected (no crash)");
+        CHECK(gds[0xc68] == 0x77,
+              "a low destination without the GDS selector is not routed into GDS");
+    }
+
+    // A GDS SOURCE (high selector byte) makes dd_src a small offset, which the immediate path cannot
+    // distinguish from a 32-bit fill value — it would write the offset itself into guest memory.
+    // No title emits this form, so it must be rejected rather than mis-executed.
+    {
+        alignas(4) uint32_t target = 0xDEADBEEFu;
+        const uint64_t dst = (uint64_t)(uintptr_t)&target;
+        uint32_t dma[7] = {};
+        dma[0] = PM4(7, IT_NOP, R_DMA_DATA);
+        dma[1] = (uint32_t)dst; dma[2] = (uint32_t)(dst >> 32);
+        dma[3] = 0xc68;         dma[4] = 0;     // a GDS offset masquerading as a 32-bit immediate
+        dma[5] = 4;
+        dma[6] = 3 | (1u << 8);                 // dst_sel = memory, src_sel = GDS
+        GpuState st; run_cb(dma, 7, st);
+        CHECK(target == 0xDEADBEEFu,
+              "a GDS source is rejected, not written as immediate data");
+    }
+
+    // The replication loop is only ever exercised at 4 bytes by the title, so cover a multi-dword
+    // non-zero fill here: every dword must carry the value and the span must stop exactly.
+    {
+        uint8_t* gds = compute_gds_backing();
+        const uint32_t offset = 0x40;
+        memset(gds + offset, 0x11, 20);
+        uint32_t dma[7] = {};
+        dma[0] = PM4(7, IT_NOP, R_DMA_DATA);
+        dma[1] = offset; dma[2] = 0;
+        dma[3] = 0xA5A5A5A5u; dma[4] = 0;
+        dma[5] = 12;
+        dma[6] = 1;
+        GpuState st; run_cb(dma, 7, st);
+        uint32_t words[3] = {};
+        memcpy(words, gds + offset, sizeof words);
+        CHECK(words[0] == 0xA5A5A5A5u && words[1] == 0xA5A5A5A5u && words[2] == 0xA5A5A5A5u,
+              "a multi-dword non-zero GDS fill replicates the value across the span");
+        CHECK(gds[offset + 12] == 0x11, "a multi-dword GDS fill stops exactly at its span");
     }
 
     // A GDS offset that would run past the 64 KiB share must be rejected rather than clamped —

--- a/prosper/tests/test_eop_write.cpp
+++ b/prosper/tests/test_eop_write.cpp
@@ -375,6 +375,39 @@ int main() {
               "a GDS source is rejected, not written as immediate data");
     }
 
+    // The alignment guards were both deletable with every case green. The byte-count one matters:
+    // without it a 6-byte fill writes 4 and silently drops a 2-byte tail — the same truncation this
+    // change argues against elsewhere. A partial span must be REJECTED, not written short.
+    {
+        uint8_t* gds = compute_gds_backing();
+        const uint32_t offset = 0x80;
+        memset(gds + offset, 0x22, 8);
+        uint32_t dma[7] = {};
+        dma[0] = PM4(7, IT_NOP, R_DMA_DATA);
+        dma[1] = offset; dma[2] = 0;
+        dma[3] = 0;      dma[4] = 0;
+        dma[5] = 6;                      // not a whole number of dwords
+        dma[6] = 1;
+        GpuState st; run_cb(dma, 7, st);
+        CHECK(gds[offset] == 0x22 && gds[offset + 4] == 0x22,
+              "a GDS fill whose byte count is not dword-aligned is rejected, not truncated");
+    }
+
+    // A misaligned GDS offset is equally a decode error: the share is addressed in dwords.
+    {
+        uint8_t* gds = compute_gds_backing();
+        const uint32_t offset = 0x92;    // not dword-aligned
+        memset(gds + offset, 0x33, 4);
+        uint32_t dma[7] = {};
+        dma[0] = PM4(7, IT_NOP, R_DMA_DATA);
+        dma[1] = offset; dma[2] = 0;
+        dma[3] = 0;      dma[4] = 0;
+        dma[5] = 4;
+        dma[6] = 1;
+        GpuState st; run_cb(dma, 7, st);
+        CHECK(gds[offset] == 0x33, "a misaligned GDS offset is rejected");
+    }
+
     // The replication loop is only ever exercised at 4 bytes by the title, so cover a multi-dword
     // non-zero fill here: every dword must carry the value and the span must stop exactly.
     {


### PR DESCRIPTION
Fixes #1750. Found while investigating #1742; **it does not fix that issue** — see below.

## Failure scenario

A DMA_DATA destination is not always an address. When the destination selector names **GDS** it is an
*offset* into the 64 KiB Global Data Share, and every valid GDS offset is below the `dd_dst < 0x10000`
floor `dma_data_form()` uses to reject malformed guest pointers. So every GDS-destined packet was
classified `Invalid` and dropped — silently, because `report_invalid_dma_data` caps at 24 lines per run
and therefore reads a constant "24" no matter the real volume.

Astro Bot resets its append/consume counters this way: 4 bytes of immediate zero to GDS offsets `0x4`,
`0x24`, `0xc64`, `0xc68`, `0xc6c`, `0xc70`. **343 such writes per routed run now land where zero did
before.** prosper already implemented the other half of GDS — `ds_*` instructions with the GDS flag
bind a 64 KiB backing — so shaders could increment counters that nothing could ever reset.

## Why the selector means GDS

The HLE builder packs `cmd[6] = (a2 & 0xff) | ((a3 & 0xff) << 8)` and marks those two arguments
`srcSel?` / `dstSel?` at `CONFIDENCE: MED`. They are transposed. Sampled at the builder across a routed
run, the two values partition the destinations cleanly with no overlap:

| `a2` | destinations |
|---|---|
| 1 | `0x4`, `0x24`, `0xc64`, `0xc68`, `0xc6c`, `0xc70` — all tiny, 4 bytes, immediate zero |
| 3 | `0x56f6e6000`, `0x40080af00`, `0x4007fa640`, … — all full 64-bit guest addresses |

So `a2` selects the destination *domain*, and `1` is the PM4 GDS encoding. Corroboration outside this
title: Sony's parameter is named `dstAddressOrOffset` (export `sceAgcDmaDataPatchSetDstAddressOrOffset`)
— an offset domain, which in DMA_DATA is GDS — and `sceAgcDcbAtomicGds`, `sceAgcAcbAtomicGds` and
`sceAgcDriverRegisterGdsResource` are published AGC exports.

`CONFIDENCE: MED-HIGH`, recorded as such in the code: the partition is clean and the API corroborates
it, but the selector vocabulary is not documented in anything prosper owns.

## Invariants deliberately preserved

- **A sub-`0x10000` destination *without* the GDS selector is still rejected.** Without this the fix
  would convert every malformed packet into a wild write at a low address.
- **Immediate source only.** A GDS↔memory copy has no title evidence and stays fail-closed.
- **Bounds-checked against the backing**, dword-aligned; an out-of-range span is rejected, not clamped.
  Clamping would write a truncated span into state the shaders read.
- Every non-GDS form takes exactly the path it did before.

## What this does NOT do

It does not fix #1742 (Astro Bot's unbounded indirect dispatch), which is what prompted the
investigation. That was tested directly rather than assumed: with these writes restored and the lever
demonstrably moved — 343 executed GDS fills against 0 — `groups_x` still runs 1, 1, 2, 3, 4, 5, 7, 15,
6711, 26783, 40167, 66927. The falsification is recorded on #1742 so the next reader does not re-derive
it.

## Verification

- `ctest` **177/177** in the `ps5ys` distrobox, so the Vulkan execution tests are included.
- New cases in `tests/test_eop_write.cpp`: the GDS write lands; the byte span is exact; an out-of-range
  offset is rejected rather than clamped; a low destination without the selector is still refused.
- **Mutation-checked** — setting `kDmaDstSelGds` to a value that never occurs makes
  `DMA_DATA with a GDS destination selector zeroes the GDS counter` fail and the rest pass, so the new
  case is discriminating rather than merely green.
- Live: 343 GDS fills executed on a routed Astro Bot run, at exactly the offsets previously reported as
  `invalid/unmapped form`.

## Risks

The selector interpretation is the load-bearing judgement, hence the explicit CONFIDENCE marker and the
deliberately narrow acceptance. If `dst_sel == 1` were ever something other than GDS on some other
title, the blast radius is writes into a 64 KiB process-local buffer that only GDS-using shaders read —
it cannot corrupt guest memory, because the GDS path never dereferences a guest pointer.
