### PR TITLE
diag(gpu): PROSPER_PROVENANCE_ADDR, and a dispatch cap that proves Astro Bot's device loss is caused by dispatch size

### DIFF
--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -4180,6 +4180,31 @@ ComputeLaunchDimensions resolve_compute_launch(const GpuState::Dispatch& d) {
         out.threads_y = total_threads(out.groups_y, out.local_y);
         out.threads_z = total_threads(out.groups_z, out.local_z);
     }
+    // PROSPER_MAX_DISPATCH_GROUPS=N — DIAGNOSTIC ONLY, default off. Caps the workgroup count of every
+    // dispatch. This deliberately computes WRONG results (a clamped kernel processes part of its
+    // domain), so it is never a correctness or progression mode; it exists to test whether an
+    // enormous dispatch is what loses the Vulkan device (#1742 -> #1743). Without it, Astro Bot
+    // reaches 752,646 workgroups in one dispatch and the device is lost permanently a few submits
+    // later; with it, the same route can be run to the same point with the size bounded.
+    static const uint32_t group_cap = [] {
+        const char* value = std::getenv("PROSPER_MAX_DISPATCH_GROUPS");
+        return value && *value ? static_cast<uint32_t>(strtoul(value, nullptr, 0)) : 0u;
+    }();
+    if (group_cap) {
+        auto clamp_groups = [&](uint32_t& groups, uint32_t& threads, uint32_t local) {
+            if (groups <= group_cap) return;
+            static std::atomic<int> reported{0};
+            if (reported.fetch_add(1) < 16)
+                std::fprintf(stderr, "[dispatch-cap] clamping %u workgroups to %u\n",
+                             groups, group_cap);
+            groups = group_cap;
+            threads = static_cast<uint32_t>(std::min<uint64_t>(
+                static_cast<uint64_t>(groups) * local, UINT32_MAX));
+        };
+        clamp_groups(out.groups_x, out.threads_x, out.local_x);
+        clamp_groups(out.groups_y, out.threads_y, out.local_y);
+        clamp_groups(out.groups_z, out.threads_z, out.local_z);
+    }
     return out;
 }
 

--- a/prosper/src/gpu/writer_provenance.cpp
+++ b/prosper/src/gpu/writer_provenance.cpp
@@ -2,6 +2,7 @@
 
 #include <atomic>
 #include <cstring>
+#include <cstdio>
 #include <cstdlib>
 #include <limits>
 #include <mutex>
@@ -34,8 +35,40 @@ uint64_t span_end(uint64_t addr, uint64_t size) {
 
 } // namespace
 
+// PROSPER_PROVENANCE_ADDR=0xADDR[:SIZE] — report every recorded write overlapping one guest range,
+// naming the writer kind and its identity (for a compute buffer, the program's code address). This
+// answers "who writes this address", which nothing else could: the history was queryable only from
+// C++ via last_guest_write_overlap(), and the dimension probes select by resource shape, so a small
+// counter or an indirect-argument word had no diagnostic surface at all (#1742).
+struct ProvenanceAddrWatch {
+    bool active = false;
+    uint64_t addr = 0;
+    uint64_t size = 4;
+};
+
+const ProvenanceAddrWatch& provenance_addr_watch() {
+    static const ProvenanceAddrWatch watch = [] {
+        ProvenanceAddrWatch w;
+        const char* value = std::getenv("PROSPER_PROVENANCE_ADDR");
+        if (!value || !*value) return w;
+        char* end = nullptr;
+        const unsigned long long addr = std::strtoull(value, &end, 0);
+        if (!addr || end == value) return w;
+        w.addr = addr;
+        if (end && *end == ':') {
+            const unsigned long long size = std::strtoull(end + 1, nullptr, 0);
+            if (size) w.size = size;
+        }
+        w.active = true;
+        std::fprintf(stderr, "[provenance] watching guest range 0x%llx..0x%llx\n",
+                     (unsigned long long)w.addr, (unsigned long long)(w.addr + w.size));
+        return w;
+    }();
+    return watch;
+}
+
 bool writer_provenance_enabled() {
-    const bool explicitly_on = writer_provenance_full_enabled();
+    const bool explicitly_on = writer_provenance_full_enabled() || provenance_addr_watch().active;
     const char* dimension_mode = std::getenv("PROSPER_PROVENANCE_DIM");
     const char* resource_hash_mode = std::getenv("PROSPER_RESOURCE_HASH_DIM");
     const char* timeline_depth_hash_mode = std::getenv("PROSPER_GPU_TIMELINE_DEPTH_HASH_DIM");
@@ -46,7 +79,10 @@ bool writer_provenance_enabled() {
 
 bool writer_provenance_full_enabled() {
     const char* value = std::getenv("PROSPER_WRITER_PROVENANCE");
-    return value && *value && std::strcmp(value, "0") && std::strcmp(value, "off");
+    // The address watch needs the same unfiltered retention: the ranges it exists to explain are
+    // single words, which the dimension probes' large-resource filter would discard.
+    return provenance_addr_watch().active ||
+           (value && *value && std::strcmp(value, "0") && std::strcmp(value, "off"));
 }
 
 const char* guest_writer_kind_name(GuestWriterKind kind) {
@@ -74,6 +110,21 @@ uint64_t record_guest_write(GuestWriterKind kind, uint64_t addr, uint64_t size,
     event.identity = identity;
     event.width = width;
     event.height = height;
+    if (const ProvenanceAddrWatch& watch = provenance_addr_watch();
+        watch.active && addr < span_end(watch.addr, watch.size) &&
+        watch.addr < span_end(addr, size)) {
+        // Every overlap, uncapped and unaggregated: the question this answers is "which writer", and
+        // a rate limit would hide a writer that only appears after a scene change. The switch is
+        // off by default and selects a single range, so the volume is bounded by the guest's own
+        // writes to that one address.
+        std::fprintf(stderr,
+                     "[provenance] %-14s addr=0x%llx size=%llu submit=%llu item=%llu order=%llu "
+                     "identity=0x%llx seq=%llu\n",
+                     guest_writer_kind_name(kind), (unsigned long long)addr,
+                     (unsigned long long)size, (unsigned long long)submit,
+                     (unsigned long long)item, (unsigned long long)order,
+                     (unsigned long long)identity, (unsigned long long)event.sequence);
+    }
     std::lock_guard<std::mutex> lock(g_mutex);
     EventKey key{kind, addr};
     if (g_events.size() == kMaxEvents && !g_events.count(key)) {


### PR DESCRIPTION
Two diagnostics, both built to answer questions nothing in the tree could answer, and both already
load-bearing for #1742 / #1743.

## `PROSPER_PROVENANCE_ADDR=0xADDR[:SIZE]`

Reports every recorded guest write overlapping one range, naming the writer kind and its identity —
for a compute buffer, the producing program's code address.

prosper already *records* this (`record_guest_write`), but it could only be queried from C++ via
`last_guest_write_overlap()`, and the existing probes (`PROSPER_PROVENANCE_DIM`,
`PROSPER_RESOURCE_HASH_DIM`) select by resource **shape**. A single counter word or an indirect-argument
dword therefore had no diagnostic surface at all — you could not ask "who writes this address".

It answered #1742 in one run:

```
[provenance] watching guest range 0x5074063c0..0x5074063cc
[provenance] compute-buffer  addr=0x5074063c0 ... identity=0x5006eac00
```

Every write to that indirect-args counter comes from compute program `0x5006eac00`, and nothing else
touches it. That is the producer of the unbounded workgroup count, found after `PROSPER_DMA_WATCH_DST`
had already excluded every CP-DMA path.

Implementation notes: it forces the same unfiltered retention as `PROSPER_WRITER_PROVENANCE` (the
dimension probes' large-resource filter would discard a 4-byte counter), and it is deliberately
**uncapped and unaggregated** — the question is *which writer*, and a rate limit would hide one that
only appears after a scene change. The volume is bounded by the guest's own writes to one address.

## `PROSPER_MAX_DISPATCH_GROUPS=N`

Caps the workgroup count of every dispatch. **Diagnostic only, never a correctness or progression
mode** — a clamped kernel processes part of its domain and computes wrong results. It exists to test
one causal claim, and it settled it.

#1743 recorded 87,551 compute dispatches failing. Tracing showed every failure is
`Vulkan failure stage=queue-submit result=-4` — `VK_ERROR_DEVICE_LOST` — and the ordering showed it is
one permanent event, not a population: for `0x5006eac00`, **329 successes at submits 1..2341, then 249
failures at 2349..4333, with zero successes after the first failure**.

The hypothesis was that #1742's 192.7 M-invocation, ~1.5 s dispatch trips the GPU watchdog. This switch
tests it directly:

| run | dispatch size | device losses | producer successes | reached |
|---|---|---:|---:|---|
| unclamped | up to 752,646 groups | **loss at ~submit 2345** | 329, then 249 straight failures | dies |
| `PROSPER_MAX_DISPATCH_GROUPS=4096` | capped (witness: `[dispatch-cap] clamping 8192 workgroups to 4096`) | **0** | **458 and counting** | submit 3373 |

Capping the dispatch prevents the device loss. That raises "#1742 causes #1743" from `CONFIDENCE: MED`
to `HIGH`, and means **#1742, #1743 and probably #1459 are one bug** with #1742 upstream.

The lever has its own witness (`[dispatch-cap]` lines), so an arm where the switch silently did nothing
is distinguishable from a genuine negative.

## Verification

- `ctest` 177/177 in the `ps5ys` distrobox.
- Both switches default off; with neither set, no behaviour changes (the cap reads its env once into a
  static and returns immediately at 0, the provenance watch leaves `writer_provenance_enabled()` exactly
  as it was).
- Live evidence for each is quoted above, from routed Astro Bot runs with no other GPU consumer at
  either boundary.

Refs #1742, #1743.
