### PR TITLE
feat(videoout): implement sceVideoOutWaitVblank instead of returning immediately

### DIFF
--- a/prosper/src/hle/hle_graphics.cpp
+++ b/prosper/src/hle/hle_graphics.cpp
@@ -25,6 +25,7 @@
 #include <atomic>
 #include <chrono>
 #include <cstddef>
+#include <thread>
 #include <unordered_set>
 #include <utility>
 
@@ -455,6 +456,17 @@ HLE(g_vo_resstatus)   {
     return 0;
 }
 
+// The one monotonic ~59.94 Hz vblank timebase. sceVideoOutGetVblankStatus's `count` and
+// sceVideoOutWaitVblank's wake-up boundary MUST come from the same clock: a game that waits for a
+// vblank and then reads the count has to observe the count it just waited for. Anchored on the
+// first use so both are process-relative, exactly as the previous status-only anchor was.
+constexpr uint64_t kVblankNs = 16683350;             // 59.94 Hz period
+uint64_t vblank_now_ns() {
+    return (uint64_t)std::chrono::duration_cast<std::chrono::nanoseconds>(
+               std::chrono::steady_clock::now().time_since_epoch()).count();
+}
+uint64_t vblank_epoch_ns() { static const uint64_t t0 = vblank_now_ns(); return t0; }
+
 // sceVideoOutGetVblankStatus (SceVideoOutVblankStatus, 0x28 bytes — Kyty VideoOut.cpp:94:
 // u64 count @0, u64 processTime @8, u64 tsc @0x10, u64 reserved @0x18, u8 flags @0x20).
 // The count is derived from a monotonic ~59.94 Hz timebase — the previous ++g_vblank_count
@@ -466,10 +478,10 @@ HLE(g_vo_vblankstatus) {
     VideoOutHandleGuard handle(a0);
     if (!handle.valid()) return kVoErrorInvalidHandle;
     uint8_t* s = (uint8_t*)(uintptr_t)a1; memset(s, 0, 0x28);
-    uint64_t ns = (uint64_t)std::chrono::duration_cast<std::chrono::nanoseconds>(
-                      std::chrono::steady_clock::now().time_since_epoch()).count();
-    static const uint64_t t0 = ns;                       // process-relative, first-call anchored
-    constexpr uint64_t kVblankNs = 16683350;             // 59.94 Hz period
+    // Anchor BEFORE sampling: on the very first call the epoch IS this instant, and sampling `ns`
+    // first would make t0 the later of the two and underflow (ns - t0).
+    const uint64_t t0 = vblank_epoch_ns();               // process-relative, first-use anchored
+    const uint64_t ns = vblank_now_ns();
     // A live VideoOut handle has already observed at least one vblank. Returning zero on
     // the first query made Astro Bot compute a frame-rate sample as
     // `(frames * refresh) / (count - previous_count)` with both counts zero and trap on
@@ -479,6 +491,37 @@ HLE(g_vo_vblankstatus) {
     *(uint64_t*)(s + 0x10) = ns;                         // tsc (monotonic ns; matches ReadTsc's unit)
     return 0;
 }
+// sceVideoOutWaitVblank (j6RaAUlaLv0): block the calling thread until the port's next vertical
+// blank, then return 0. This is the CPU-side half of display pacing — the counterpart to the
+// vblank kevent source — and titles use it as the whole body of a display/present thread's loop.
+//
+// It was unregistered, so it fell to the generic unimplemented stub and returned IMMEDIATELY. That
+// is not a harmless no-op: the caller is a `for(;;) { WaitVblank(port); ...; }` thread, so instead
+// of waking 59.94 times a second it spins one host core flat out and the work it paces (movie
+// decode, present, frame timing) runs unbounded. Found on PPSA26414 (R-Type Delta: HD Boosted,
+// #1746), whose display thread is exactly that loop.
+//
+// The wait boundary comes from vblank_epoch_ns()/kVblankNs — the SAME timebase
+// sceVideoOutGetVblankStatus reports — so a thread that waits for a vblank and then reads the
+// status observes the tick it waited for, not a disagreeing second clock. The handle is validated
+// under g_vo_handle_mx and the guard is released BEFORE sleeping: holding it across a ~16 ms sleep
+// would serialize every other VideoOut call in the process behind one waiter.
+// CONFIDENCE: HIGH on the contract (single handle argument, blocking, 0 on success — the guest's
+// call site passes exactly one register and ignores nothing else); HIGH that returning instantly
+// is wrong.
+HLE(g_vo_wait_vblank) {
+    { VideoOutHandleGuard handle(a0);
+      if (!handle.valid()) return kVoErrorInvalidHandle; }
+    const uint64_t t0 = vblank_epoch_ns();
+    const uint64_t now = vblank_now_ns();
+    // Next strictly-future boundary: a caller that is already exactly on one still waits a full
+    // period, which is what "wait for the NEXT vblank" means.
+    const uint64_t next = t0 + ((now - t0) / kVblankNs + 1) * kVblankNs;
+    std::this_thread::sleep_until(std::chrono::steady_clock::time_point(
+        std::chrono::nanoseconds(next)));
+    return 0;
+}
+
 // PROSPER_HDR (the frontends' --hdr flag): advertise an HDR-capable display. Default is SDR —
 // the common case for prosper users, and the mode whose output path titles tonemap themselves.
 // Deliberately uncached: capability queries are boot-time-rare, and tests exercise both modes in
@@ -982,6 +1025,7 @@ void register_graphics_hle() {
     R("sceVideoOutGetFlipStatus", g_vo_flipstatus);
     R("sceVideoOutGetResolutionStatus", g_vo_resstatus);
     R("sceVideoOutGetVblankStatus", g_vo_vblankstatus);
+    R("sceVideoOutWaitVblank", g_vo_wait_vblank);   // j6RaAUlaLv0 (#1746)
     R("sceVideoOutGetDeviceCapabilityInfo", g_vo_devcap);
     R("sceVideoOutRegisterBuffers", g_vo_register_buffers);R("sceVideoOutSetBufferAttribute", g_vo_set_buffer_attribute);
     // PS5 "2"/query variants — the 5 previously-unimplemented VideoOut NIDs (resolved via shadPS4

--- a/prosper/src/hle/hle_graphics.cpp
+++ b/prosper/src/hle/hle_graphics.cpp
@@ -456,10 +456,18 @@ HLE(g_vo_resstatus)   {
     return 0;
 }
 
-// The one monotonic ~59.94 Hz vblank timebase. sceVideoOutGetVblankStatus's `count` and
-// sceVideoOutWaitVblank's wake-up boundary MUST come from the same clock: a game that waits for a
-// vblank and then reads the count has to observe the count it just waited for. Anchored on the
-// first use so both are process-relative, exactly as the previous status-only anchor was.
+// The monotonic ~59.94 Hz timebase shared by sceVideoOutGetVblankStatus's `count` and
+// sceVideoOutWaitVblank's wake-up boundary. They MUST share it in PHASE, not merely in period: a
+// game that waits for a vblank and then reads the count has to observe the tick it just waited for,
+// which is a statement about where the boundaries fall, not about how far apart they are. Anchored
+// on first use so both are process-relative, exactly as the previous status-only anchor was.
+//
+// It is NOT the only vblank clock in the process, and this comment previously claimed it was.
+// hle_kernel_time.cpp's `vblank_pump` (:731) posts the VideoOut vblank kevent from its own
+// `nanosleep(16666667)` loop — 60.000 Hz, its own phase, started when the first equeue source is
+// registered. So the kevent stream and this grid drift by roughly one tick per second and their
+// boundaries do not coincide. Aligning them is a real follow-up; asserting they are aligned is
+// wrong, and a title that cross-checks the two would see the disagreement.
 // Internal linkage on purpose: the "epoch before now" ordering invariant below is only
 // enforceable by reading this one file, so nothing outside it may reach these.
 namespace {

--- a/prosper/src/hle/hle_graphics.cpp
+++ b/prosper/src/hle/hle_graphics.cpp
@@ -460,12 +460,16 @@ HLE(g_vo_resstatus)   {
 // sceVideoOutWaitVblank's wake-up boundary MUST come from the same clock: a game that waits for a
 // vblank and then reads the count has to observe the count it just waited for. Anchored on the
 // first use so both are process-relative, exactly as the previous status-only anchor was.
+// Internal linkage on purpose: the "epoch before now" ordering invariant below is only
+// enforceable by reading this one file, so nothing outside it may reach these.
+namespace {
 constexpr uint64_t kVblankNs = 16683350;             // 59.94 Hz period
 uint64_t vblank_now_ns() {
     return (uint64_t)std::chrono::duration_cast<std::chrono::nanoseconds>(
                std::chrono::steady_clock::now().time_since_epoch()).count();
 }
 uint64_t vblank_epoch_ns() { static const uint64_t t0 = vblank_now_ns(); return t0; }
+}  // namespace
 
 // sceVideoOutGetVblankStatus (SceVideoOutVblankStatus, 0x28 bytes — Kyty VideoOut.cpp:94:
 // u64 count @0, u64 processTime @8, u64 tsc @0x10, u64 reserved @0x18, u8 flags @0x20).
@@ -506,19 +510,34 @@ HLE(g_vo_vblankstatus) {
 // status observes the tick it waited for, not a disagreeing second clock. The handle is validated
 // under g_vo_handle_mx and the guard is released BEFORE sleeping: holding it across a ~16 ms sleep
 // would serialize every other VideoOut call in the process behind one waiter.
-// CONFIDENCE: HIGH on the contract (single handle argument, blocking, 0 on success — the guest's
-// call site passes exactly one register and ignores nothing else); HIGH that returning instantly
-// is wrong.
+// CONFIDENCE: HIGH that blocking is the behaviour and that returning instantly is wrong, and HIGH
+// on the shape (one argument, 0 on success). MED that the argument is an sceVideoOutOpen handle
+// rather than a port index: the guest's call site passes exactly one register, but no title has yet
+// been observed reaching this call with a handle we can compare against. That matters because the
+// reject arm is NEW behaviour — the previous stub returned 0 for everything — so it is made
+// fail-visible rather than silent: a title passing something we do not recognise would otherwise
+// turn a paced loop into an error spin with nothing printed, which is worse than the original spin.
 HLE(g_vo_wait_vblank) {
     { VideoOutHandleGuard handle(a0);
-      if (!handle.valid()) return kVoErrorInvalidHandle; }
+      if (!handle.valid()) {
+          static std::atomic<bool> warned{false};
+          if (!warned.exchange(true))
+              fprintf(stderr, "[vo] sceVideoOutWaitVblank: unknown handle 0x%llx — returning "
+                              "INVALID_HANDLE and NOT waiting. If this repeats, the argument is "
+                              "probably not an sceVideoOutOpen handle (see the CONFIDENCE note).\n",
+                      (unsigned long long)a0);
+          return kVoErrorInvalidHandle;
+      } }
     const uint64_t t0 = vblank_epoch_ns();
     const uint64_t now = vblank_now_ns();
     // Next strictly-future boundary: a caller that is already exactly on one still waits a full
     // period, which is what "wait for the NEXT vblank" means.
     const uint64_t next = t0 + ((now - t0) / kVblankNs + 1) * kVblankNs;
+    // F5: duration_cast rather than a nanoseconds->time_point construction, which only compiles
+    // because steady_clock::duration happens to be nanoseconds on every toolchain we build with.
     std::this_thread::sleep_until(std::chrono::steady_clock::time_point(
-        std::chrono::nanoseconds(next)));
+        std::chrono::duration_cast<std::chrono::steady_clock::duration>(
+            std::chrono::nanoseconds(next))));
     return 0;
 }
 

--- a/prosper/tests/test_videoout.cpp
+++ b/prosper/tests/test_videoout.cpp
@@ -40,6 +40,7 @@ int main() {
     auto close  = Hle::lookup(nid_hash("sceVideoOutClose"));
     auto res    = Hle::lookup(nid_hash("sceVideoOutGetResolutionStatus"));
     auto vbl    = Hle::lookup(nid_hash("sceVideoOutGetVblankStatus"));
+    auto waitvbl = Hle::lookup(nid_hash("sceVideoOutWaitVblank"));   // j6RaAUlaLv0 (#1746)
     auto cap    = Hle::lookup(nid_hash("sceVideoOutGetDeviceCapabilityInfo"));
     auto issup  = Hle::lookup("Nv8c-Kb+DUM");   // IsOutputSupported
     auto setba  = Hle::lookup(nid_hash("sceVideoOutSetBufferAttribute"));
@@ -253,6 +254,31 @@ int main() {
     vbl(handle, (uint64_t)(uintptr_t)vb, 0, 0, 0, 0); uint64_t c2 = *(uint64_t*)vb;
     CHECK(c2 > c1, "vblank counter advances across a >1-period sleep");
     CHECK(*(uint64_t*)(vb + 0x08) > 0, "vblank processTime filled (Kyty layout @0x08)");
+
+    // WaitVblank must BLOCK to the next ~16.68 ms boundary and land on the tick it waited for
+    // (#1746). Unregistered it fell to the return-0 stub and came back instantly, turning a
+    // title's `for(;;) WaitVblank(port)` display thread into a spin loop with no pacing.
+    CHECK(waitvbl != nullptr, "sceVideoOutWaitVblank is registered (j6RaAUlaLv0)");
+    if (waitvbl) {
+        CHECK((uint32_t)waitvbl(invalid_handle, 0, 0, 0, 0, 0) == kInvalidHandle,
+              "WaitVblank rejects an invalid handle");
+        // Five waits must consume at least four full vblank periods of real time. A stub that
+        // returns immediately finishes in microseconds and fails this outright.
+        vbl(handle, (uint64_t)(uintptr_t)vb, 0, 0, 0, 0);
+        const uint64_t wait_c0 = *(uint64_t*)vb;
+        const auto wait_t0 = std::chrono::steady_clock::now();
+        bool wait_ok = true;
+        for (int i = 0; i < 5; ++i) wait_ok &= waitvbl(handle, 0, 0, 0, 0, 0) == 0;
+        const auto elapsed_us = std::chrono::duration_cast<std::chrono::microseconds>(
+                                    std::chrono::steady_clock::now() - wait_t0).count();
+        vbl(handle, (uint64_t)(uintptr_t)vb, 0, 0, 0, 0);
+        const uint64_t wait_c1 = *(uint64_t*)vb;
+        CHECK(wait_ok, "WaitVblank returns 0 on a live handle");
+        CHECK(elapsed_us >= 4 * 16683,
+              "five WaitVblank calls block for at least four vblank periods");
+        CHECK(wait_c1 >= wait_c0 + 4,
+              "WaitVblank shares GetVblankStatus's timebase (counter advanced by the waits)");
+    }
 
     // Device capability: plain SDR display (capability 0).
     uint64_t dc = 0xDEAD;

--- a/prosper/tests/test_videoout.cpp
+++ b/prosper/tests/test_videoout.cpp
@@ -277,7 +277,30 @@ int main() {
         CHECK(elapsed_us >= 4 * 16683,
               "five WaitVblank calls block for at least four vblank periods");
         CHECK(wait_c1 >= wait_c0 + 4,
-              "WaitVblank shares GetVblankStatus's timebase (counter advanced by the waits)");
+              "WaitVblank advances GetVblankStatus's counter by one tick per wait");
+
+        // PHASE, which the counter assertion above does NOT test. A WaitVblank with its own epoch
+        // shifted half a period — same period, different phase — advances the counter by exactly
+        // the same amount and passes everything above, and phase is the entire content of the
+        // "shared timebase" claim: a game that waits and then reads must land ON the tick it
+        // waited for, not between two.
+        //
+        // GetVblankStatus reports processTime as microseconds since the shared epoch, so the
+        // residue of that against the period says where in the period the wait left us. Sample the
+        // MINIMUM over several waits rather than any single one: sleep_until may overshoot under
+        // host load, which can only move a residue later, so the minimum is the robust statistic
+        // and it can only be small if the two really share an epoch. A half-period-shifted private
+        // epoch floors at ~8.34 ms and cannot produce a small minimum however many samples we take.
+        uint64_t min_phase_ns = UINT64_MAX;
+        for (int i = 0; i < 6; ++i) {
+            waitvbl(handle, 0, 0, 0, 0, 0);
+            vbl(handle, (uint64_t)(uintptr_t)vb, 0, 0, 0, 0);
+            const uint64_t phase_ns = (*(uint64_t*)(vb + 0x08) * 1000ull) % 16683350ull;
+            if (phase_ns < min_phase_ns) min_phase_ns = phase_ns;
+        }
+        CHECK(min_phase_ns < 4000000ull,
+              "WaitVblank shares GetVblankStatus's PHASE, not just its period "
+              "(wakes land on a boundary of the same grid)");
     }
 
     // Device capability: plain SDR display (capability 0).


### PR DESCRIPTION
Refs #1746.

## The failure

`sceVideoOutWaitVblank` (`j6RaAUlaLv0`) was never registered, so it fell through to the generic
unimplemented-import stub and **returned 0 at once**.

That is not a harmless no-op. Titles use this call as the entire body of a display/present thread's
loop, so instead of waking ~59.94 times a second that thread spins one host core flat out and
everything it paces — movie decode, present, frame timing — runs unbounded.

Found on **PPSA26414** (*R-Type Delta: HD Boosted*), whose display thread at `eboot+0x189f0` is
literally `for(;;) { sceVideoOutWaitVblank(port); ... }`. Its eboot imports the NID at PLT `0x350770`
(JMPREL 54, verified against `../PS5-3.20_Libs`).

## Behavioural contract

`int32_t sceVideoOutWaitVblank(int32_t handle)` — block the calling thread until the port's next
vertical blank, return 0. An unknown handle is `SCE_VIDEO_OUT_ERROR_INVALID_HANDLE`, matching every
other handle-taking entry point in this file.

## Approach and invariants

* The wake-up boundary comes from the **same** monotonic 59.94 Hz timebase that
  `sceVideoOutGetVblankStatus` already reports, factored out as `vblank_epoch_ns()` / `kVblankNs`.
  A thread that waits for a vblank and then reads the status must observe the tick it waited for,
  not a second clock that disagrees.
* "The next vblank" is a **strictly future** boundary: a caller already exactly on one waits a full
  period.
* The handle is validated under `g_vo_handle_mx`, and the guard is **released before sleeping**.
  Holding it across a ~16 ms wait would serialize every other VideoOut call in the process behind
  one waiter.

## Affected and deliberately unaffected

* Affected: any guest thread that calls `sceVideoOutWaitVblank` — it now blocks instead of spinning.
* Unaffected: flip submission, flip completion, the equeue vblank pump, and the flip-rate divisor.
  This does **not** pace the guest's frame loop; it paces one call.
* One deliberate behaviour change beyond the new function: the vblank epoch is now anchored on
  first *use* rather than on the first `GetVblankStatus` call. It stays process-relative, and the
  first-call count is still `>= 1` (the `Astro Bot` IDIV guard the existing comment records).

## Risk

The epoch must be sampled **before** `now`, not after — sampling in the other order makes `t0` the
later of the two on the very first call and underflows `ns - t0`. I got that wrong first; the
pre-existing "vblank counter does NOT tick per poll" assertion in `test_videoout` caught it, which
is the one place in this change where an error would have been silent in the new code and visible
only in the old.

## Verification (exact head `18b84687` content, rebuilt on this branch)

```
cmake --build build -j6 && ctest --test-dir build -j4
100% tests passed out of 175
```

New assertions in `prosper/tests/test_videoout.cpp`:

* `sceVideoOutWaitVblank is registered (j6RaAUlaLv0)` — also confirms the name→NID hash matches the
  NID the guest imports.
* `WaitVblank rejects an invalid handle`
* `WaitVblank returns 0 on a live handle`
* `five WaitVblank calls block for at least four vblank periods` — a stub that returns immediately
  finishes in microseconds and fails this outright.
* `WaitVblank shares GetVblankStatus's timebase (counter advanced by the waits)`

**Counter-arm, executed:** commenting out the single registration line and rebuilding turns the
suite red on the new block (`[FAIL] sceVideoOutWaitVblank is registered`), and restoring it turns it
green again. The test cannot pass against the previous behaviour.

No snapshots were run: this touches no render path.

## What it does not do

It does **not** unblock R-Type Delta. That title's blocker is a startup race documented on #1746 —
its display thread is not even reached before the fault. This is a real defect found on the way
there, fixed on its own terms.