### PR TITLE
diag(gpu): PROSPER_SHARPLOG — separate "the shader never declared it" from "we dropped it"

### DIFF
--- a/prosper/src/gpu/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc_shader_layout.cpp
@@ -6,6 +6,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <mutex>
+#include <unordered_set>
 #include <set>
 #include <vector>
 
@@ -463,6 +464,50 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
 
     uint32_t binding = 0;
 
+    // PROSPER_SHARPLOG=1: report the stage's DECLARED resource-usage table before any of it is
+    // decoded, deduped per user-data block. Every existing diagnostic here describes what came OUT
+    // of this function (`[t#]`, `[mimg-unresolved]`'s table dump), so a slot that is declared by the
+    // shader and then dropped by one of the ~10 `continue`s below is invisible: the reader cannot
+    // tell "the front half never saw a second texture" from "it saw one and rejected it", and those
+    // point at completely different code. Printing the raw declaration separates them in one line
+    // (#1590: Earthion's rejected 320x224 composite samples two T#s and the table holds one).
+    if (getenv("PROSPER_SHARPLOG")) {
+        static std::mutex mx;
+        static std::unordered_set<const void*> seen;
+        bool first = false;
+        { std::lock_guard<std::mutex> lk(mx); first = seen.insert((const void*)ud).second; }
+        if (first) {
+            fprintf(stderr, "[sharp] ud=%p nsgpr=%u base=%u eud_size_dw=%u srt_size_dw=%u "
+                            "counts: ro=%u rw=%u samp=%u cbuf=%u direct=%u\n",
+                    (const void*)ud, num_user_sgprs, user_sgpr_base, ud->eud_size_dw, ud->srt_size_dw,
+                    ud->sharp_resource_count[0], ud->sharp_resource_count[1],
+                    ud->sharp_resource_count[2], ud->sharp_resource_count[3],
+                    ud->direct_resource_count);
+            static const char* kCat[4] = { "ro", "rw", "samp", "cbuf" };
+            for (int cat = 0; cat < 4; cat++) {
+                const AgcShaderSharp* arr = ud->sharp_resource_offset[cat];
+                if (!arr_ok(arr, ud->sharp_resource_count[cat], sizeof(AgcShaderSharp))) {
+                    if (ud->sharp_resource_count[cat])
+                        fprintf(stderr, "[sharp]   %s[]: %u declared but the array is unreadable\n",
+                                kCat[cat], ud->sharp_resource_count[cat]);
+                    continue;
+                }
+                for (uint16_t slot = 0; slot < ud->sharp_resource_count[cat]; slot++) {
+                    const AgcShaderSharp& s = arr[slot];
+                    fprintf(stderr, "[sharp]   %s[%u]: bits=0x%04x offset_dw=%u size=%u%s%s\n",
+                            kCat[cat], slot, s.bits, s.offset_dw(), s.size(),
+                            s.empty() ? " EMPTY" : "",
+                            (!s.empty() && s.offset_dw() >= num_user_sgprs) ? " (EUD)" : "");
+                }
+            }
+            if (const uint16_t* dro = ud->direct_resource_offset)
+                if (arr_ok(dro, ud->direct_resource_count, sizeof(uint16_t)))
+                    for (uint16_t i = 0; i < ud->direct_resource_count; i++)
+                        if (dro[i] != 0xffff)
+                            fprintf(stderr, "[sharp]   direct[%u]: sgpr=%u\n", i, dro[i]);
+        }
+    }
+
     // Extended User Data (EUD): descriptors whose offset_dw is beyond the user-SGPR block live in a guest
     // memory spill area. Its base pointer sits in the user SGPR named by direct_resource_offset[5] (usage
     // type 5) — confirmed against the shader's own `s_load_dwordx4 sX, s[EUD:EUD+1], <off>`. A sharp at
@@ -615,9 +660,24 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
     // image-sampler at the same binding by the backend, so we don't emit a separate Sampler resource.
     const AgcShaderSharp* texs = ud->sharp_resource_offset[0];
     if (arr_ok(texs, ud->sharp_resource_count[0], sizeof(AgcShaderSharp))) {
+        // PROSPER_SHARPLOG: name the exact reason a DECLARED texture slot is dropped. Ten different
+        // `continue`s below can silently remove one, and from the outside every one of them looks
+        // identical to "the shader never declared it" — which is a completely different bug in a
+        // completely different file (#1590). Deduped per (user-data block, slot) so it costs one
+        // line per stage, not one per draw.
+        const bool sharplog = getenv("PROSPER_SHARPLOG") != nullptr;
+        auto tex_drop = [&](uint16_t slot, uint32_t off, const char* why) {
+            if (!sharplog) return;
+            static std::mutex mx;
+            static std::set<std::pair<const void*, uint32_t>> seen;
+            std::lock_guard<std::mutex> lk(mx);
+            if (!seen.insert({(const void*)ud, slot}).second) return;
+            fprintf(stderr, "[sharp]   ro[%u] offset_dw=%u DROPPED as texture: %s\n", slot, off, why);
+        };
         for (uint16_t slot = 0; slot < ud->sharp_resource_count[0]; slot++) {
             const AgcShaderSharp& s = texs[slot];
-            if (s.empty() || readonly_buffer_slots[slot]) continue;
+            if (s.empty()) continue;
+            if (readonly_buffer_slots[slot]) { tex_drop(slot, s.offset_dw(), "claimed by the V# path"); continue; }
             uint32_t off = s.offset_dw();
             // A T# may live in the user-SGPR block OR spill into the EUD, exactly like the cbuf path
             // (#257/#382) — the old hard `continue` for off+8 > num_user_sgprs silently DROPPED any
@@ -625,13 +685,25 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
             // load_sharp (bounds-checked; copies verbatim from the SGPR block for the in-block case, so
             // that path stays byte-identical) and decode from that buffer.
             uint32_t tv[8]; uint32_t tsrt = load_sharp(off, 8, tv);
-            if (tsrt == 0xFFFFFFFFu) continue;                  // out of block / EUD absent / unreadable
+            if (tsrt == 0xFFFFFFFFu) {                          // out of block / EUD absent / unreadable
+                tex_drop(slot, off, "load_sharp failed (out of block / EUD absent / unreadable)"); continue; }
             const bool tex_in_eud = (uint64_t)off + 8 > num_user_sgprs;
             DecodedImageDescriptor d = decode_image_descriptor(tv);
             if (d.base == 0 || d.width == 0 || d.height == 0 || d.depth == 0 ||
                 !valid_image_type(d.type) ||
                 d.base_array != 0 ||
-                d.width > 16384 || d.height > 16384) continue;  // skip a garbage/degenerate T#
+                d.width > 16384 || d.height > 16384) {          // skip a garbage/degenerate T#
+                if (sharplog) {
+                    char buf[192];
+                    snprintf(buf, sizeof buf,
+                             "degenerate T# base=0x%llx %ux%ux%u type=%u base_array=%u fmt=%u "
+                             "raw %08x %08x %08x %08x", (unsigned long long)d.base,
+                             d.width, d.height, d.depth, d.type, d.base_array, d.format,
+                             tv[0], tv[1], tv[2], tv[3]);
+                    tex_drop(slot, off, buf);
+                }
+                continue;
+            }
             // PROSPER_DUMP_TILERAW (issue #282 derivation): dump the raw guest texel bytes of a tiled
             // texture once per address, so its GPU tile swizzle can be reversed offline (coherence
             // scoring). Fires at T#-decode time (every draw's stage build), so it captures textures even
@@ -703,6 +775,7 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
                     if (!warned[d.format & 511u]) { warned[d.format & 511u] = true;
                         fprintf(stderr, "[t#] UNMAPPED Gen5 IMG_FMT %u (%ux%u T#) -> skipping texture binding "
                                         "(extend gen5_image_format)\n", d.format, d.width, d.height); }
+                    tex_drop(slot, off, "unmapped Gen5 IMG_FMT");
                     continue;
                 }
                 fi.format = DataFormat::Unorm8; fi.num_components = 4; fi.bytes_per_block = 4;
@@ -719,12 +792,14 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
                                     "wired; skipping texture binding\n", d.format,
                             fi.format == DataFormat::Bc6 ? "BC6H SF16" : "SNORM BCn",
                             d.width, d.height); }
+                tex_drop(slot, off, "signed block-compressed format (decode not wired)");
                 continue;
             }
             ShaderResource r;
             const DecodedImageView view = image_base_level_view(d, fi);
             if (!view.supported) {
                 warn_unsupported_image_view(d);
+                tex_drop(slot, off, "unsupported image view (mip/array layout)");
                 continue;
             }
             r.cls           = ResourceClass::Texture;
@@ -771,7 +846,8 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
             const uint64_t backing_bytes = is_bcn
                 ? static_cast<uint64_t>((view.width + 3) / 4) * ((view.height + 3) / 4) * d.depth * fi.bytes_per_block
                 : static_cast<uint64_t>(view.width) * view.height * d.depth * fi.bytes_per_block;
-            if (!backing_bytes || backing_bytes > UINT32_MAX) continue;
+            if (!backing_bytes || backing_bytes > UINT32_MAX) {
+                tex_drop(slot, off, "implausible backing byte size"); continue; }
             r.size = static_cast<uint32_t>(backing_bytes);
             // SGPR-resident T#: DIRECT provenance (image_sample SRSRC SGPR). EUD-resident T#: INDIRECT
             // (the s_load immediate = tsrt), and sgpr_base must be invalid so a stray by_sgpr_base for an


### PR DESCRIPTION
Refs #1590.

## The problem this instrument solves

Every diagnostic in `build_shader_resources` describes what came **out** of it — `[t#]` prints
decoded descriptors, `[mimg-unresolved]` dumps the finished `ShaderResourceTable`. Nothing described
what went **in**, and roughly ten `continue`s sit between the two.

So a resource slot the shader *declared* and the function then *dropped* produces evidence that is
byte-identical to a slot the front half never saw — and those are different bugs in different files.

That ambiguity has a cost on the record. #1590 measured "the fragment stage's table holds 1 resource
but the shader samples 2 textures", correctly concluded that alias-following could not help, and
re-scoped the blocker to descriptor **recovery** in `agc_shader_layout.cpp`. With this instrument the
recovery turns out to be working.

## What it prints

`PROSPER_SHARPLOG=1`, off by default:

1. Once per user-data block: `num_user_sgprs`, `user_sgpr_base`, `eud_size_dw`, `srt_size_dw`, the
   four per-category sharp counts and the direct count; then every sharp slot's raw `bits`,
   `offset_dw`, `size` flag, `EMPTY` marker and EUD-residency; then every non-`0xffff` direct slot.
2. In the texture path, the exact reason a **declared** slot was dropped — claimed by the V# path,
   `load_sharp` failure, degenerate T#, unmapped Gen5 format, signed BCn, unsupported image view, or
   implausible backing size. The degenerate-T# case also prints the decoded fields and the first four
   raw dwords, which is what identifies residue as residue.

Both are deduped — per user-data block, and per (block, slot) for drops — so a hot draw loop costs
one line per stage, not one per draw.

## Result on PPSA28061 (Earthion)

```
[sharp] ud=0x4101b8f70 nsgpr=32 base=0 eud_size_dw=0 srt_size_dw=1 counts: ro=2 rw=0 samp=1 cbuf=0 direct=11
[sharp]   ro[0]: bits=0x0001 offset_dw=1 size=0
[sharp]   ro[1]: bits=0x0009 offset_dw=9 size=0
[sharp]   samp[0]: bits=0x8011 offset_dw=17 size=1
[sharp]   ro[1] offset_dw=9 DROPPED as texture: degenerate T# base=0xbf00 15043x9728x1 type=0
          base_array=0 fmt=267 raw 000000bf 90ba4900 c71ffeb0 00007f88
```

Both textures are declared and both are reached, exactly matching the shader's own decode in #1590.
`ro[1]` is dropped because the guest's user-data registers hold **host-stack residue** there
(`dw11|dw12` = `0x00007f88c71ffeb0`, a host address in the range prosper maps guest thread stacks
into). `PROSPER_UDPROV=1` shows `dw0..dw20` were all written by one draw, so this is a coherent
programming event from the guest's own command stream, not a stale slot.

That moves the blocker from the GPU front half to an **uninitialised HLE out-parameter** — a
different subsystem from anything that issue had examined. Full measurement and the suggested
next experiment are on #1590.

## Affected and deliberately unaffected

* Behaviour with `PROSPER_SHARPLOG` unset is unchanged. The only structural edit is splitting
  `if (s.empty() || readonly_buffer_slots[slot]) continue;` into two conditions so the second can be
  reported; both still `continue` and the order of the tests is preserved.
* No decode, classification, provenance key, or binding number changes.

## Risk

The added `getenv` is read once into a local `const bool` at the top of the texture path rather than
per slot. The drop reporter is a lambda capturing by reference and is only called on paths that are
about to `continue`. The dedupe sets are function-local statics under their own mutexes, so the
diagnostic is safe on the concurrent stage builds this function already runs under.

## Verification

```
cmake --build build -j6 && ctest --test-dir build -j4
100% tests passed out of 175
```

plus the two live boots quoted above (`boot_trace`, `PROSPER_GUEST_FS=1
PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1`, PPSA28061). No snapshots: the default path
is byte-identical, and this adds no rendered output.

This is a diagnostic, so there is no progression screenshot to attach — the title's picture area is
still missing and this PR does not claim to change that.