### PR TITLE
review: PROSPER_SHARPLOG follow-up — identity on every line, reason-keyed dedupe, correct EUD predicate

### DIFF
--- a/prosper/docs/RESOURCE_BINDING.md
+++ b/prosper/docs/RESOURCE_BINDING.md
@@ -158,3 +158,12 @@ fold *N+1*, and every sampled failing draw is the first bind-or-draw event of it
 
 **Instruments** (`PROSPER_UDPROV`, `PROSPER_BINDTRACE`, `[udcand]`, `PROSPER_SHADER_HEADER_NEWEST`,
 `PROSPER_UD_TAIL_ALIGN`) are on PR #1639 — reuse them rather than rebuilding this measurement.
+
+`PROSPER_SHARPLOG=1` is the fourth one and answers a different question from the rest. They all
+describe what the front half *produced*; this one prints what the shader **declared** — the stage's
+raw sharp table (per-category counts, each slot's `bits`/`offset_dw`/`size`/EUD residency, and the
+direct slots) — and then names the exact reason a declared texture slot was dropped. Between the two
+sits a chain of about ten `continue`s, and without the input side "the front half never saw this
+resource" and "it saw it and rejected it" produce identical evidence while pointing at different
+files. Reach for it before concluding anything about descriptor *recovery*: on Earthion (#1590) it
+overturned exactly that conclusion in one run.

--- a/prosper/src/gpu/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc_shader_layout.cpp
@@ -6,6 +6,8 @@
 #include <cstdio>
 #include <cstdlib>
 #include <mutex>
+#include <string>
+#include <tuple>
 #include <unordered_set>
 #include <set>
 #include <vector>
@@ -471,12 +473,19 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
     // tell "the front half never saw a second texture" from "it saw one and rejected it", and those
     // point at completely different code. Printing the raw declaration separates them in one line
     // (#1590: Earthion's rejected 320x224 composite samples two T#s and the table holds one).
-    if (getenv("PROSPER_SHARPLOG")) {
+    static const bool sharplog_on = getenv("PROSPER_SHARPLOG") != nullptr;
+    if (sharplog_on) {
         static std::mutex mx;
         static std::unordered_set<const void*> seen;
-        bool first = false;
-        { std::lock_guard<std::mutex> lk(mx); first = seen.insert((const void*)ud).second; }
-        if (first) {
+        // Hold the lock across the WHOLE dump, not just the dedupe test. Stage builds run
+        // concurrently, and only the header line carries `ud=`, so interleaved line groups would
+        // let a reader attribute a slot to the wrong stage — the exact ambiguity this instrument
+        // exists to remove. Serializing a once-per-stage diagnostic costs nothing.
+        // NOTE: `ud` is a guest pointer, so a freed-and-reused user-data block is deduped as the
+        // same stage. The ABSENCE of a `[sharp]` line therefore does not prove a stage was never
+        // built.
+        std::lock_guard<std::mutex> lk(mx);
+        if (seen.insert((const void*)ud).second) {
             fprintf(stderr, "[sharp] ud=%p nsgpr=%u base=%u eud_size_dw=%u srt_size_dw=%u "
                             "counts: ro=%u rw=%u samp=%u cbuf=%u direct=%u\n",
                     (const void*)ud, num_user_sgprs, user_sgpr_base, ud->eud_size_dw, ud->srt_size_dw,
@@ -484,6 +493,11 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
                     ud->sharp_resource_count[2], ud->sharp_resource_count[3],
                     ud->direct_resource_count);
             static const char* kCat[4] = { "ro", "rw", "samp", "cbuf" };
+            // load_sharp's EUD test is `off + n > num_user_sgprs`, and n is the descriptor width:
+            // a sharp[0] slot may be an 8-dword T# or a 4-dword V#, so its residency is reported
+            // as a range rather than claimed. Using `off >= num_user_sgprs` here would mislabel
+            // every descriptor that straddles the boundary — the exact case a reader of this log
+            // would be trying to resolve.
             for (int cat = 0; cat < 4; cat++) {
                 const AgcShaderSharp* arr = ud->sharp_resource_offset[cat];
                 if (!arr_ok(arr, ud->sharp_resource_count[cat], sizeof(AgcShaderSharp))) {
@@ -494,10 +508,16 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
                 }
                 for (uint16_t slot = 0; slot < ud->sharp_resource_count[cat]; slot++) {
                     const AgcShaderSharp& s = arr[slot];
+                    const uint32_t off = s.offset_dw();
+                    const char* eud = "";
+                    if (!s.empty()) {
+                        const bool eud_at_4 = (uint64_t)off + 4 > num_user_sgprs;   // V#/S#/cbuf
+                        const bool eud_at_8 = (uint64_t)off + 8 > num_user_sgprs;   // T#
+                        eud = eud_at_4 ? " (EUD)" : (eud_at_8 ? " (EUD if 8dw)" : "");
+                    }
                     fprintf(stderr, "[sharp]   %s[%u]: bits=0x%04x offset_dw=%u size=%u%s%s\n",
-                            kCat[cat], slot, s.bits, s.offset_dw(), s.size(),
-                            s.empty() ? " EMPTY" : "",
-                            (!s.empty() && s.offset_dw() >= num_user_sgprs) ? " (EUD)" : "");
+                            kCat[cat], slot, s.bits, off, s.size(),
+                            s.empty() ? " EMPTY" : "", eud);
                 }
             }
             if (const uint16_t* dro = ud->direct_resource_offset)
@@ -665,14 +685,21 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
         // identical to "the shader never declared it" — which is a completely different bug in a
         // completely different file (#1590). Deduped per (user-data block, slot) so it costs one
         // line per stage, not one per draw.
-        const bool sharplog = getenv("PROSPER_SHARPLOG") != nullptr;
         auto tex_drop = [&](uint16_t slot, uint32_t off, const char* why) {
-            if (!sharplog) return;
+            if (!sharplog_on) return;
             static std::mutex mx;
-            static std::set<std::pair<const void*, uint32_t>> seen;
+            static std::set<std::tuple<const void*, uint32_t, std::string>> seen;
             std::lock_guard<std::mutex> lk(mx);
-            if (!seen.insert({(const void*)ud, slot}).second) return;
-            fprintf(stderr, "[sharp]   ro[%u] offset_dw=%u DROPPED as texture: %s\n", slot, off, why);
+            // Key on the REASON as well as the slot. The T# dwords come from per-draw SGPR
+            // contents, so one slot can decode cleanly on one draw and as residue on the next —
+            // which is exactly the #1590 case. Deduping on (block, slot) alone would print the
+            // first reason only and read as "always dropped for this reason" when the truth is
+            // "dropped for this reason on the first draw that reached here".
+            if (!seen.insert({(const void*)ud, slot, std::string(why)}).second) return;
+            // `ud=` on every line: the header is emitted once and concurrent stages interleave,
+            // so a drop line reached on a later draw can appear with no header in front of it.
+            fprintf(stderr, "[sharp]   ud=%p ro[%u] offset_dw=%u DROPPED as texture: %s\n",
+                    (const void*)ud, slot, off, why);
         };
         for (uint16_t slot = 0; slot < ud->sharp_resource_count[0]; slot++) {
             const AgcShaderSharp& s = texs[slot];
@@ -693,7 +720,7 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
                 !valid_image_type(d.type) ||
                 d.base_array != 0 ||
                 d.width > 16384 || d.height > 16384) {          // skip a garbage/degenerate T#
-                if (sharplog) {
+                if (sharplog_on) {
                     char buf[192];
                     snprintf(buf, sizeof buf,
                              "degenerate T# base=0x%llx %ux%ux%u type=%u base_array=%u fmt=%u "


### PR DESCRIPTION
Follow-up to #1758, which merged before this round of review findings could be folded into it.
Refs #1590.

An independent review of #1758 found five things, and they share a shape worth stating plainly:
**the instrument could reproduce the exact ambiguity it was built to remove.** None of them is a
correctness bug in the default path — with `PROSPER_SHARPLOG` unset nothing here executes — but a
diagnostic that can mislead is worse than no diagnostic, because its output is believed.

| | finding | fix |
| --- | --- | --- |
| G1 | The dump held its mutex only across the dedupe test, so concurrent stage builds could interleave line groups — and **only the header line carried `ud=`**. A reader could attribute a slot to the wrong stage. Worse for drops: `tex_drop` has its own dedupe set, so a slot first dropped on a later draw prints with **no header in front of it at all**. | Hold the lock across the whole dump (a once-per-stage diagnostic; serializing costs nothing), and put `ud=` on the drop line too. |
| G2 | The drop dedupe keyed on `(block, slot)`, so only the **first** reason and the first draw's raw dwords were ever printed. T# dwords come from per-draw SGPR contents, so one slot can decode cleanly on one draw and as residue on the next — **exactly the #1590 case** — and the log reads as "always dropped for this reason" when the truth is "dropped for this reason on the first draw that reached here". | Key on the reason string as well. |
| G3 | The `(EUD)` annotation used `offset_dw >= num_user_sgprs`, but `load_sharp`'s real test is `off + n > num_user_sgprs` with `n` the descriptor width (8 for a T#, 4 for a V#/S#/cbuf). A T# straddling the boundary was reported as in-block — the exact case a reader of this log is trying to resolve. | Report residency per width: `(EUD)` at 4 dwords, `(EUD if 8dw)` for the straddle, nothing when it is genuinely in-block at both widths. |
| G4 | Both `getenv` calls sat on a per-draw-per-stage path. | `static const bool`, matching the pattern already used at `agc_shader_layout.cpp:772`. |
| G5 | `ud` is a guest pointer, so a freed-and-reused user-data block dedupes as the same stage — the **absence** of a `[sharp]` line does not prove a stage was never built. | Recorded in the code, next to the dedupe. |
| G6 | `docs/RESOURCE_BINDING.md`'s instrument list is where the next agent looks for exactly this, and `PROSPER_SHARPLOG` was not on it. | Added, with the one sentence that distinguishes it from the other three: they describe what the front half *produced*, this one prints what the shader *declared*. |

## Affected and deliberately unaffected

Diagnostic output only. No decode, classification, provenance key, or binding number changes, and
the default path is unchanged.

## Verification

```
cmake --build build -j6 && ctest --test-dir build -j4
100% tests passed out of 175
ctest -R doc_table                       100% tests passed out of 1
git diff --check origin/master..HEAD     clean
```

Re-verified live on **PPSA28061** (Earthion, `boot_trace`, `PROSPER_GUEST_FS=1
PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 PROSPER_SHARPLOG=1`) — the finding
reproduces with the new formatting and now carries its own identity:

```
[sharp]   ro[0]: bits=0x0001 offset_dw=1 size=0
[sharp]   ro[1]: bits=0x0009 offset_dw=9 size=0
[sharp]   samp[0]: bits=0x8011 offset_dw=17 size=1
[sharp]   ud=0x4101b8f70 ro[1] offset_dw=9 DROPPED as texture: degenerate T# base=0xbf00
          15043x11648x1 type=0 base_array=0 fmt=267 raw 000000bf 90ba4900 8b5ffeb0 00007fa7
```

Note the raw dwords differ from the run quoted on #1590 (`c71ffeb0 00007f88` there,
`8b5ffeb0 00007fa7` here). That is the residue being residue — a different host thread-stack
address each run — which is corroboration of the diagnosis, and it is also precisely what G2's
dedupe would have hidden across draws.

## The review also found a pre-existing bug, filed separately

Not fixed here: `agc_shader_layout.cpp`'s EUD offset is computed in 32-bit arithmetic before
widening, so a descriptor that straddles the user-SGPR boundary wraps. See the linked issue.