### PR TITLE
feat(input): name the touch-pad button so a route can press it

### DIFF
--- a/prosper/src/input/pad.cpp
+++ b/prosper/src/input/pad.cpp
@@ -126,6 +126,13 @@ void pad_fill_extended_controller_info(ScePadExtendedControllerInformation* out,
 // --- Scripted input (PROSPER_PAD_SCRIPT) pure helpers — see pad.hpp -----------------------------
 uint32_t pad_button_by_name(const std::string& n) {
     if (n == "start" || n == "options") return SCE_PAD_BUTTON_OPTIONS;
+    // The DualSense touch-pad CLICK. Titles bind it as an ordinary button, and
+    // SCE_PAD_BUTTON_TOUCH_PAD has always been in the mask that scePadRead reports — it simply
+    // had no name in either direction, so no PROSPER_PAD_SCRIPT route could press it and no
+    // PROSPER_PAD_RECORD capture could round-trip it. A screen gated on it is unreachable by
+    // any scripted run, and the failure is silent: pad_button_by_name returns 0 for an unknown
+    // name, which parses as "neutral" rather than as an error.
+    if (n == "touchpad")                return SCE_PAD_BUTTON_TOUCH_PAD;
     if (n == "cross" || n == "x")       return SCE_PAD_BUTTON_CROSS;
     if (n == "circle" || n == "o")      return SCE_PAD_BUTTON_CIRCLE;
     if (n == "square")                  return SCE_PAD_BUTTON_SQUARE;
@@ -149,7 +156,7 @@ std::string pad_button_names(uint32_t mask) {
         {SCE_PAD_BUTTON_L1, "l1"}, {SCE_PAD_BUTTON_R1, "r1"},
         {SCE_PAD_BUTTON_L2, "l2"}, {SCE_PAD_BUTTON_R2, "r2"},
         {SCE_PAD_BUTTON_L3, "l3"}, {SCE_PAD_BUTTON_R3, "r3"},
-        {SCE_PAD_BUTTON_OPTIONS, "options"},
+        {SCE_PAD_BUTTON_OPTIONS, "options"}, {SCE_PAD_BUTTON_TOUCH_PAD, "touchpad"},
     };
     std::string result;
     for (const auto& name : names) {

--- a/prosper/src/input/pad.hpp
+++ b/prosper/src/input/pad.hpp
@@ -187,8 +187,10 @@ struct PadScriptState {
     uint8_t axis_mask = 0;
 };
 
-// Map a button name ("start"/"options"/"cross"/"x"/"up"/... case as written) to its SCE_PAD_BUTTON_*
-// bit; 0 if unknown. "start" and "options" both mean the PS5 Options button (the "Start" equivalent).
+// Map a button name ("start"/"options"/"cross"/"x"/"up"/"touchpad"/... case as written) to its
+// SCE_PAD_BUTTON_* bit; 0 if unknown. "start" and "options" both mean the PS5 Options button (the
+// "Start" equivalent); "touchpad" is the DualSense touch-pad click, which titles bind as an
+// ordinary button.
 uint32_t pad_button_by_name(const std::string& name);
 
 // Canonical '+'-joined names for a button mask. The output round-trips through the parser and uses a

--- a/prosper/tests/test_pad.cpp
+++ b/prosper/tests/test_pad.cpp
@@ -340,6 +340,15 @@ int main() {
         CHECK(pad_button_by_name("r2")      == SCE_PAD_BUTTON_R2,      "name: r2 -> R2");
         CHECK(pad_button_by_name("up")      == SCE_PAD_BUTTON_UP,      "name: up -> UP");
         CHECK(pad_button_by_name("nonsense")== 0,                      "name: unknown -> 0");
+        // The touch-pad CLICK is a real button in the reported mask that had no name in either
+        // direction, so no route could press it and no recording could round-trip it.
+        CHECK(pad_button_by_name("touchpad")== SCE_PAD_BUTTON_TOUCH_PAD,
+              "name: touchpad -> TOUCH_PAD");
+        CHECK(pad_button_names(SCE_PAD_BUTTON_TOUCH_PAD) == "touchpad",
+              "names: touchpad is canonical");
+        CHECK(pad_button_by_name(pad_button_names(SCE_PAD_BUTTON_TOUCH_PAD)) ==
+                  SCE_PAD_BUTTON_TOUCH_PAD,
+              "names: touchpad round-trips through the parser");
         CHECK(pad_button_names(SCE_PAD_BUTTON_OPTIONS) == "options", "names: options is canonical");
         CHECK(pad_button_names(SCE_PAD_BUTTON_UP | SCE_PAD_BUTTON_CROSS) == "up+cross",
               "names: stable combined-button order");


### PR DESCRIPTION
## The gap

`SCE_PAD_BUTTON_TOUCH_PAD` (`prosper/src/input/pad.hpp:39`) has always been in the button mask
`scePadRead` reports, but it had **no name in either direction**: `pad_button_by_name` could not
parse it and `pad_button_names` could not emit it. Every other button in the mask is named.

Consequences:

* No `PROSPER_PAD_SCRIPT` route can press the touch-pad click, so any screen a title gates on it is
  unreachable by a scripted run — and by anything built on routes, which is every headless
  reproduction, guard and capture in the project.
* No `PROSPER_PAD_RECORD` capture can round-trip one, so a recorded route silently loses the press.
  `pad_button_names`' documented round-trip invariant did not hold for this bit.

**The failure was silent, which is the part worth fixing.** `pad_button_by_name` returns `0` for an
unknown name, and `0` parses as *neutral* rather than as an error — so `95-96:touchpad` in a route
was accepted, logged by `PROSPER_PAD_SCRIPT_LOG=1` as a state transition, and delivered nothing. The
instrument reported success for an input it could not express.

## Approach

Add the name to both the parser and the canonical-name table, in the same commit, so the round-trip
invariant documented on `pad_button_names` continues to hold. This is closing a hole in an existing
vocabulary, not adding a capability: the bit was already produced and consumed, and `hle_pad.cpp`
needs no change.

## Affected and deliberately unaffected

* Affected: routes and recordings may now use `touchpad`.
* Unaffected: every existing route (no existing name changes meaning), the pad backends, the
  controller-info path, and the touch-pad *geometry* reporting at `pad.cpp:106`, which is a
  different thing from the click.

## Verification

```
cmake --build build -j6 && ctest --test-dir build -j4
100% tests passed out of 175
git diff --check origin/master..HEAD     clean
```

Three new assertions in `prosper/tests/test_pad.cpp`, alongside the existing name-mapping block:
`touchpad -> TOUCH_PAD`, `TOUCH_PAD -> "touchpad"` is canonical, and the round-trip
`pad_button_by_name(pad_button_names(TOUCH_PAD)) == TOUCH_PAD`. All three fail against master
(`pad_button_by_name` returns 0 and `pad_button_names` returns the empty string).

Delivery was also confirmed end-to-end on a live title: `PROSPER_PAD_SCRIPT='…;95-96:touchpad;…'`
with `PROSPER_PAD_SCRIPT_LOG=1` on PPSA19991 logs
`[pad-script] elapsed=95.003 frame=4060 read=8118 buttons=touchpad`, where against master the same
route logs nothing for that window.

## What this does NOT claim

I found this while trying to get *Tales of Graces f Remastered* past its new-game **Options**
screen, whose footer reads `⌷ Confirm Settings` with a glyph that is none of the face buttons. **The
touch-pad is not that button either.** Cross, Circle, Triangle, Options and touch-pad have now all
been delivered into that screen (verified in the `[pad-script]` log, not inferred) and **none of
them advances it**; the title holds on Options for the remaining ~280 s of a 400 s run in every
case. So this PR does not advance that title and does not claim to — the remaining candidates are
Square, the shoulder/stick buttons, or a non-button gesture, and narrowing that is separate work.

Recording the five that were tested so the next agent does not re-test them.