### PR TITLE
fix(docs-check): a fence between a table and more rows is not a split (#1709)

### DIFF
--- a/prosper/tools/docs/check_numbered_table.py
+++ b/prosper/tools/docs/check_numbered_table.py
@@ -80,10 +80,8 @@ fix -- abutment keeps the genuine defect, and the shape it misreads has zero ins
 tracked corpus and is bounded to a single message. If it starts appearing, narrowing to "gap
 contains no blank line" trades it the other way at a known cost.
 
-A fence opening immediately after a table is misread the same way, but that half IS separable by a
-rule as principled as the blank-line one -- record fence line numbers and skip a gap containing one.
-It is not implemented here only to keep this change scoped after five review rounds; tracked as
-#1709 so the next reader looks for the rule that exists instead of taking this block as settled.
+(A fence between a table and further rows was misread the same way. That half was separable and is
+now fixed -- #1709: fence line numbers are recorded and a gap containing one is not a split.)
 """
 
 from __future__ import annotations
@@ -134,16 +132,25 @@ class Table:
         return self.lines[0].strip() if self.lines else ""
 
 
-def parse_tables(lines: list[str]) -> tuple[list[Table], set[int]]:
-    """Split into table runs, ignoring fenced code. Returns (tables, blank_line_numbers)."""
+def parse_tables(lines: list[str]) -> tuple[list[Table], set[int], set[int]]:
+    """Split into table runs, ignoring fenced code.
+
+    Returns (tables, blank_line_numbers, fence_line_numbers). The fence lines are needed
+    because a fence opening straight after a table looks exactly like the interruption of
+    a split table (#1709) -- it is a non-blank line between two pipe runs -- but it is a
+    correct document. It is separable by a rule as principled as the blank-line one, which
+    is why this is a fix rather than another entry in KNOWN LIMIT.
+    """
     tables: list[Table] = []
     blanks: set[int] = set()
+    fences: set[int] = set()
     fenced = False
     run: list[str] = []
     run_start = 0
 
     for i, line in enumerate(lines, start=1):
         if FENCE.match(line):
+            fences.add(i)
             fenced = not fenced
             if run:
                 tables.append(Table(run_start, run))
@@ -168,7 +175,7 @@ def parse_tables(lines: list[str]) -> tuple[list[Table], set[int]]:
             run = []
     if run:
         tables.append(Table(run_start, run))
-    return tables, blanks
+    return tables, blanks, fences
 
 
 def check(path: Path, sequential: bool, table_header: str | None) -> list[str]:
@@ -181,7 +188,7 @@ def check(path: Path, sequential: bool, table_header: str | None) -> list[str]:
         return [f"{path}: is not valid UTF-8: {exc}"]
 
     lines = text.split("\n")
-    tables, blanks = parse_tables(lines)
+    tables, blanks, fences = parse_tables(lines)
     if not tables:
         # Under --sequential we were pointed at ONE specific table, so its absence means the path
         # is wrong or the format changed, and failing here is what stops this check passing
@@ -222,6 +229,13 @@ def check(path: Path, sequential: bool, table_header: str | None) -> list[str]:
         # blank, or the line immediately above the fragment is itself the interruption.
         gap_start = previous.start + len(previous.lines)
         gap = range(gap_start, current.start)
+        # #1709: a fence opening immediately after a table is a correct document, not an
+        # interruption. It is separable from a genuine split because a genuine one never
+        # contains a fence delimiter -- the fenced content is skipped entirely, so the run
+        # below it is code, not orphaned rows.
+        if any(n in fences for n in gap):
+            origin = None
+            continue
         all_blank = all(n in blanks for n in gap)
         interrupted_at = current.start - 1
         if not all_blank and interrupted_at in blanks:
@@ -329,7 +343,7 @@ def main() -> int:
         return 1
 
     for path in args.paths:
-        tables, _ = parse_tables(path.read_text(encoding="utf-8").split("\n"))
+        tables, _, _ = parse_tables(path.read_text(encoding="utf-8").split("\n"))
         proper = [t for t in tables if t.proper]
         rows = sum(len(t.body) for t in proper)
         detail = "contiguous and unbroken" if args.sequential else "unbroken"

--- a/prosper/tools/docs/test_check_numbered_table.py
+++ b/prosper/tools/docs/test_check_numbered_table.py
@@ -193,6 +193,14 @@ run("table-like lines inside a fenced block",
     TABLE + "\n```\n| 33 | 34 | 35 | 32 |\n| 9 | more output |\n```\n",
     want_problems=False)
 
+# #1709: a fence opening IMMEDIATELY after a table — no blank line between. Before the
+# fence-gap rule this reported a split, because the fence delimiter is a non-blank line
+# between two pipe runs, which is exactly the lost-leading-pipe shape. Discriminating:
+# reverting the rule makes this case, and only this case, fail.
+run("a fenced block between a table and more rows is not a split",
+    "| # | What |\n|---|---|\n| 1 | a |\n```\nsome output\n```\n| 2 | b |\n",
+    want_problems=False)
+
 run("fenced block between two tables",
     "| # | a |\n|---|---|\n| 1 | x |\n\n```\n| 9 | z |\n```\n\n| # | b |\n|---|---|\n| 1 | y |\n",
     want_problems=False)


### PR DESCRIPTION
Fixes #1709.

## The failure

A **correct** document was reported as a broken table: a table, a fenced code block, then more rows.

```
| # | What |
|---|---|
| 1 | a |
```​
some output
```​
| 2 | b |
```

On master this reports:

> `:6: line is not a table row but sits inside the table that starts at line 1, ending it … Did it lose its leading '|'? Line reads: '```'`

The closing fence is a non-blank line between two pipe runs — structurally identical to the
lost-leading-pipe shape the checker exists to catch. And the message *instructs*: it tells the author
their fence lost a leading `|`. A false positive that gives a confident wrong instruction is the class
this tool's own trap entries warn about, since an agent that follows it damages the file.

## The fix

Separable by a rule as principled as the blank-line one, exactly as #1701's review established:
**record fence line numbers during parsing and treat a gap containing one as not-a-split.** The fenced
content is skipped entirely, so a run below a fence is code, not orphaned rows.

`KNOWN LIMIT` in the docstring is narrowed to the one shape that genuinely remains inseparable — a
pipe-leading line mid-paragraph below an unrelated table.

## The first test did not discriminate, and I replaced it

Worth recording because it is the defect this checker is for. My first case was a fence with **nothing
after it** — which produces a single table run, so the break logic never fires and the case passed
with the rule reverted. It proved nothing.

Replaced with the shape that reproduces on master. Mutation-checked at **check granularity**:

| state | result |
|---|---|
| rule present | 29/29 pass |
| rule reverted (`if False and …`) | **exactly one** case fails — `a fenced block between a table and more rows is not a split` |

## Verification

- Three real defect shapes each still report exactly **one** error: blank split, lost leading pipe,
  duplicate row number.
- Corpus: all 78 tracked Markdown files pass structure.
- Trap table: 12 tables, 108 rows, contiguous and unbroken under `--sequential`.
- `ctest -R doc_table_checker`: 29 cases.

## Risk

Tooling and tests only; no production code. The change can only make the checker report **fewer**
false splits — it adds a skip condition and removes none, so it cannot mask a genuine break that does
not contain a fence delimiter in its gap.
