### PR TITLE
fix(hle): bound PROSPER_DMEM_CALLER's stack walk to mapped memory

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -616,6 +616,13 @@ if(TARGET prosper_core)
   target_link_libraries(test_dmem PRIVATE prosper_core)
   add_test(NAME dmem_available COMMAND test_dmem)
 
+  # PROSPER_DMEM_CALLER stack walk (issue #1755): the diagnostic scans up to 160 slots above its
+  # frame and used to read straight off the top of a thread stack, dying with a SIGSEGV that reads
+  # as a guest fault.
+  add_executable(test_dmem_caller_walk tests/test_dmem_caller_walk.cpp)
+  target_link_libraries(test_dmem_caller_walk PRIVATE prosper_core)
+  add_test(NAME dmem_caller_walk COMMAND test_dmem_caller_walk)
+
   # IME keyboard event delivery (issue #1093): sceImeUpdate must invoke the guest handler
   # per queued key event; the old stub delivered none.
   add_executable(test_ime_input tests/test_ime_input.cpp)

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -114,6 +114,7 @@ void prosper_ampr_advance(uint64_t cb, uint64_t bytes) {
 #include <ctime>
 #include <cstdint>
 #include <cstdio>
+#include <pthread.h>   // #1755: thread-stack bounds for the PROSPER_DMEM_CALLER walk
 #include <unordered_map>
 #include <mutex>
 #include <atomic>
@@ -150,13 +151,69 @@ namespace {
     // and never as proof on its own. Off by default, and rate-limited per distinct call chain so an
     // allocation-heavy boot cannot bury the log in duplicates of one site.
     bool dmem_caller_log() { static int v = getenv("PROSPER_DMEM_CALLER") ? 1 : 0; return v != 0; }
+    // #1755: how many slots above `frame` we may actually read. The walk scans UP the stack, so a
+    // frame sitting near the top of its thread stack runs off the last mapped page and takes a
+    // SIGSEGV — which presents as a guest fault and sends the reader hunting a phantom bug in the
+    // title. Prefer the real thread-stack top. Guest fibers swap stacks (hle_fiber.cpp), so the
+    // frame is NOT always inside the stack the OS reports for this thread; treat "outside the
+    // reported range" as unknown rather than trusting it. The fallback is the end of the page this
+    // frame sits in, which is mapped by construction because we are executing on it.
+    // Cached per thread: on glibc pthread_getattr_np reads /proc/self/maps for the main thread, and
+    // this runs on EVERY direct-memory allocation while the diagnostic is on. An instrument that
+    // perturbs the timing it exists to observe is a worse instrument. A thread's stack does not
+    // move, so one query per thread is enough.
+    struct DmemStackRange { uintptr_t lo = 0, hi = 0; bool queried = false; };
+    thread_local DmemStackRange t_dmem_stack;
+
+    int dmem_caller_scan_slots(const volatile uint64_t* frame, int want) {
+        const uintptr_t base = (uintptr_t)frame;
+        DmemStackRange& sr = t_dmem_stack;
+        if (!sr.queried) {
+            sr.queried = true;
+#if defined(__linux__)
+            pthread_attr_t at;
+            if (pthread_getattr_np(pthread_self(), &at) == 0) {
+                void* lo = nullptr;
+                size_t sz = 0;
+                if (pthread_attr_getstack(&at, &lo, &sz) == 0 && lo && sz) {
+                    sr.lo = (uintptr_t)lo;
+                    sr.hi = sr.lo + sz;
+                }
+                pthread_attr_destroy(&at);
+            }
+#elif defined(__APPLE__)
+            // macOS reports the stack BASE (highest address), not the lowest.
+            const uintptr_t top = (uintptr_t)pthread_get_stackaddr_np(pthread_self());
+            const size_t sz = pthread_get_stacksize_np(pthread_self());
+            if (top && sz) { sr.hi = top; sr.lo = top - sz; }
+#elif defined(_WIN32)
+            ULONG_PTR wlo = 0, whi = 0;
+            GetCurrentThreadStackLimits(&wlo, &whi);
+            sr.lo = (uintptr_t)wlo;
+            sr.hi = (uintptr_t)whi;
+#endif
+        }
+        // Containment is re-checked per call, NOT cached: a guest fiber swaps stacks, so the same
+        // thread can present frames inside and outside its reported stack at different times.
+        uintptr_t hi = 0;
+        if (sr.hi && base >= sr.lo && base < sr.hi) hi = sr.hi;
+        if (!hi) {
+            constexpr uintptr_t kPage = 4096;
+            hi = (base + kPage) & ~(kPage - 1);
+        }
+        if (hi <= base) return 0;
+        const uintptr_t slots = (hi - base) / sizeof(uint64_t);
+        return slots < (uintptr_t)want ? (int)slots : want;
+    }
     void log_dmem_caller(const char* what, uint64_t len, const volatile uint64_t* frame) {
         if (!dmem_caller_log()) return;
         constexpr int kWant = 6;          // return addresses to report
         constexpr int kScan = 160;        // stack slots to walk
+        // Never read past the mapped end of this stack (#1755).
+        const int scan = dmem_caller_scan_slots(frame, kScan);
         uint64_t ra[kWant] = {};
         int n = 0;
-        for (int i = 1; i < kScan && n < kWant; i++) {
+        for (int i = 1; i < scan && n < kWant; i++) {
             const uint64_t v = frame[i];
             if (!guest_va_in_module(v)) continue;
             if (n && ra[n - 1] == v) continue;      // collapse an adjacent duplicate spill
@@ -165,17 +222,31 @@ namespace {
         // Rate-limit on the chain itself: one line per distinct (first two frames) pair.
         static std::mutex mx;
         static std::vector<std::pair<uint64_t, uint64_t>> seen;
+        static bool announced_cap = false;
         const std::pair<uint64_t, uint64_t> key{ n > 0 ? ra[0] : 0, n > 1 ? ra[1] : 0 };
         {
             std::lock_guard<std::mutex> lk(mx);
             for (const auto& s : seen) if (s == key) return;
-            if (seen.size() >= 64) return;          // bounded: 64 distinct chains is plenty
+            if (seen.size() >= 64) {
+                // #1755: announce the ceiling once. A silent cap makes the log read as "64 distinct
+                // call sites exist" when it means "we stopped counting" — a limit reported as a
+                // census (instrument-trap 49).
+                if (!announced_cap) {
+                    announced_cap = true;
+                    fprintf(stderr, "[dmem-caller] chain limit 64 reached;"
+                                    " further distinct call chains are NOT shown\n");
+                }
+                return;
+            }
             seen.push_back(key);
         }
         fprintf(stderr, "[dmem-caller] %s len=0x%llx from", what, (unsigned long long)len);
         for (int i = 0; i < n; i++)
             fprintf(stderr, " %s+0x%llx", guest_module_name(ra[i]),
                     (unsigned long long)guest_module_offset(ra[i]));
+        // A clamped scan reports a SHORTER chain, not a shallower one — say which it was (#1755).
+        if (scan < kScan)
+            fprintf(stderr, " [scan clamped to %d/%d slots by stack top]", scan, kScan);
         fprintf(stderr, "\n");
     }
 
@@ -2101,6 +2172,12 @@ void register_kernel_mem_hle() {
     Hle::register_fn("j0+3uJMxYJY", (HleFn)k_ampr_write_address, "sceAmprCommandBufferWriteAddress?");
 }
 
+// #1755 test hook: exposes the internal scan clamp so a unit test can prove the walk stays inside
+// mapped memory. The emulator itself never calls this.
+int dmem_caller_scan_slots_for_test(const volatile uint64_t* frame, int want) {
+    return dmem_caller_scan_slots(frame, want);
+}
+
 } // namespace prosper
 
 #else
@@ -2173,13 +2250,69 @@ namespace {
     // and never as proof on its own. Off by default, and rate-limited per distinct call chain so an
     // allocation-heavy boot cannot bury the log in duplicates of one site.
     bool dmem_caller_log() { static int v = getenv("PROSPER_DMEM_CALLER") ? 1 : 0; return v != 0; }
+    // #1755: how many slots above `frame` we may actually read. The walk scans UP the stack, so a
+    // frame sitting near the top of its thread stack runs off the last mapped page and takes a
+    // SIGSEGV — which presents as a guest fault and sends the reader hunting a phantom bug in the
+    // title. Prefer the real thread-stack top. Guest fibers swap stacks (hle_fiber.cpp), so the
+    // frame is NOT always inside the stack the OS reports for this thread; treat "outside the
+    // reported range" as unknown rather than trusting it. The fallback is the end of the page this
+    // frame sits in, which is mapped by construction because we are executing on it.
+    // Cached per thread: on glibc pthread_getattr_np reads /proc/self/maps for the main thread, and
+    // this runs on EVERY direct-memory allocation while the diagnostic is on. An instrument that
+    // perturbs the timing it exists to observe is a worse instrument. A thread's stack does not
+    // move, so one query per thread is enough.
+    struct DmemStackRange { uintptr_t lo = 0, hi = 0; bool queried = false; };
+    thread_local DmemStackRange t_dmem_stack;
+
+    int dmem_caller_scan_slots(const volatile uint64_t* frame, int want) {
+        const uintptr_t base = (uintptr_t)frame;
+        DmemStackRange& sr = t_dmem_stack;
+        if (!sr.queried) {
+            sr.queried = true;
+#if defined(__linux__)
+            pthread_attr_t at;
+            if (pthread_getattr_np(pthread_self(), &at) == 0) {
+                void* lo = nullptr;
+                size_t sz = 0;
+                if (pthread_attr_getstack(&at, &lo, &sz) == 0 && lo && sz) {
+                    sr.lo = (uintptr_t)lo;
+                    sr.hi = sr.lo + sz;
+                }
+                pthread_attr_destroy(&at);
+            }
+#elif defined(__APPLE__)
+            // macOS reports the stack BASE (highest address), not the lowest.
+            const uintptr_t top = (uintptr_t)pthread_get_stackaddr_np(pthread_self());
+            const size_t sz = pthread_get_stacksize_np(pthread_self());
+            if (top && sz) { sr.hi = top; sr.lo = top - sz; }
+#elif defined(_WIN32)
+            ULONG_PTR wlo = 0, whi = 0;
+            GetCurrentThreadStackLimits(&wlo, &whi);
+            sr.lo = (uintptr_t)wlo;
+            sr.hi = (uintptr_t)whi;
+#endif
+        }
+        // Containment is re-checked per call, NOT cached: a guest fiber swaps stacks, so the same
+        // thread can present frames inside and outside its reported stack at different times.
+        uintptr_t hi = 0;
+        if (sr.hi && base >= sr.lo && base < sr.hi) hi = sr.hi;
+        if (!hi) {
+            constexpr uintptr_t kPage = 4096;
+            hi = (base + kPage) & ~(kPage - 1);
+        }
+        if (hi <= base) return 0;
+        const uintptr_t slots = (hi - base) / sizeof(uint64_t);
+        return slots < (uintptr_t)want ? (int)slots : want;
+    }
     void log_dmem_caller(const char* what, uint64_t len, const volatile uint64_t* frame) {
         if (!dmem_caller_log()) return;
         constexpr int kWant = 6;          // return addresses to report
         constexpr int kScan = 160;        // stack slots to walk
+        // Never read past the mapped end of this stack (#1755).
+        const int scan = dmem_caller_scan_slots(frame, kScan);
         uint64_t ra[kWant] = {};
         int n = 0;
-        for (int i = 1; i < kScan && n < kWant; i++) {
+        for (int i = 1; i < scan && n < kWant; i++) {
             const uint64_t v = frame[i];
             if (!guest_va_in_module(v)) continue;
             if (n && ra[n - 1] == v) continue;      // collapse an adjacent duplicate spill
@@ -2188,17 +2321,31 @@ namespace {
         // Rate-limit on the chain itself: one line per distinct (first two frames) pair.
         static std::mutex mx;
         static std::vector<std::pair<uint64_t, uint64_t>> seen;
+        static bool announced_cap = false;
         const std::pair<uint64_t, uint64_t> key{ n > 0 ? ra[0] : 0, n > 1 ? ra[1] : 0 };
         {
             std::lock_guard<std::mutex> lk(mx);
             for (const auto& s : seen) if (s == key) return;
-            if (seen.size() >= 64) return;          // bounded: 64 distinct chains is plenty
+            if (seen.size() >= 64) {
+                // #1755: announce the ceiling once. A silent cap makes the log read as "64 distinct
+                // call sites exist" when it means "we stopped counting" — a limit reported as a
+                // census (instrument-trap 49).
+                if (!announced_cap) {
+                    announced_cap = true;
+                    fprintf(stderr, "[dmem-caller] chain limit 64 reached;"
+                                    " further distinct call chains are NOT shown\n");
+                }
+                return;
+            }
             seen.push_back(key);
         }
         fprintf(stderr, "[dmem-caller] %s len=0x%llx from", what, (unsigned long long)len);
         for (int i = 0; i < n; i++)
             fprintf(stderr, " %s+0x%llx", guest_module_name(ra[i]),
                     (unsigned long long)guest_module_offset(ra[i]));
+        // A clamped scan reports a SHORTER chain, not a shallower one — say which it was (#1755).
+        if (scan < kScan)
+            fprintf(stderr, " [scan clamped to %d/%d slots by stack top]", scan, kScan);
         fprintf(stderr, "\n");
     }
 
@@ -4878,6 +5025,12 @@ void register_kernel_mem_hle() {
                      "sceAmprMeasureCommandSizeWriteAddress_04_00");
     // APR completion-notification write (#1149) — real behavior on Windows too (see handler above).
     Hle::register_fn("j0+3uJMxYJY", (HleFn)k_ampr_write_address, "sceAmprCommandBufferWriteAddress?");
+}
+
+// #1755 test hook: exposes the internal scan clamp so a unit test can prove the walk stays inside
+// mapped memory. The emulator itself never calls this.
+int dmem_caller_scan_slots_for_test(const volatile uint64_t* frame, int want) {
+    return dmem_caller_scan_slots(frame, want);
 }
 
 } // namespace prosper

--- a/prosper/tests/test_dmem_caller_walk.cpp
+++ b/prosper/tests/test_dmem_caller_walk.cpp
@@ -1,0 +1,72 @@
+// #1755: PROSPER_DMEM_CALLER's stack walk must never read past the end of the mapped region its
+// frame lives in. The walk scans up to 160 slots ABOVE the frame, so a frame near the top of its
+// thread stack used to run straight off the last mapped page. The resulting SIGSEGV presents as a
+// guest fault, which sends the reader hunting a phantom bug in the title rather than at the
+// diagnostic that actually crashed.
+//
+// The decisive case is a frame placed a few slots below a PROT_NONE guard page: before the fix the
+// walk reads through the guard and the process dies by SIGSEGV; after it, the scan clamps to the
+// slots remaining in the mapped page. That half runs in a forked child so a regression reports as
+// a failed test instead of taking the test binary down with it.
+
+#include <cstdint>
+#include <cstdio>
+
+#if defined(_WIN32)
+int main() { printf("skip: POSIX-only (needs fork + mprotect)\nOK\n"); return 0; }
+#else
+#include <sys/mman.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+namespace prosper {
+int dmem_caller_scan_slots_for_test(const volatile uint64_t* frame, int want);
+}
+
+static int failures = 0;
+static void check(bool ok, const char* name) {
+    printf("%s: %s\n", ok ? "PASS" : "FAIL", name);
+    if (!ok) failures++;
+}
+
+int main() {
+    constexpr int kScan = 160;   // the walk's own scan width
+
+    // 1. A frame deep in the real thread stack must permit the FULL scan. This is what proves the
+    //    platform stack-bounds query returned a usable top: if it ever fails to identify the stack,
+    //    the helper falls back to the end of the current page and this count drops below 160.
+    volatile uint64_t here = 0;
+    const int deep = prosper::dmem_caller_scan_slots_for_test(&here, kScan);
+    check(deep == kScan, "deep thread-stack frame permits the full 160-slot scan");
+    if (deep != kScan) printf("       got %d of %d slots\n", deep, kScan);
+
+    // 2. A frame 4 slots below a PROT_NONE page must clamp to those 4 rather than read the guard.
+    const long pg = sysconf(_SC_PAGESIZE);
+    const pid_t pid = fork();
+    if (pid == 0) {
+        char* p = (char*)mmap(nullptr, 2 * pg, PROT_READ | PROT_WRITE,
+                              MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        if (p == MAP_FAILED) _exit(3);
+        if (mprotect(p + pg, pg, PROT_NONE) != 0) _exit(4);
+        auto* frame = (volatile uint64_t*)(p + pg - 4 * (long)sizeof(uint64_t));
+        const int slots = prosper::dmem_caller_scan_slots_for_test(frame, kScan);
+        // Perform the reads the walk itself would, BEFORE judging the count: an over-wide clamp
+        // must fail by reproducing the real #1755 SIGSEGV on the guard page, not by tripping this
+        // test's own arithmetic. The count check below is then only a backstop for a clamp that is
+        // too wide yet still short of the guard.
+        for (int i = 1; i < slots; i++) (void)frame[i];
+        _exit(slots > 4 ? 5 : 0);
+    }
+    int st = 0;
+    waitpid(pid, &st, 0);
+    check(WIFEXITED(st) && WEXITSTATUS(st) == 0,
+          "walk beside a guard page clamps instead of faulting");
+    if (WIFSIGNALED(st))
+        printf("       child died by signal %d — this is the #1755 crash\n", WTERMSIG(st));
+    else if (WIFEXITED(st) && WEXITSTATUS(st) != 0)
+        printf("       child exit=%d (3=mmap 4=mprotect 5=clamp too wide)\n", WEXITSTATUS(st));
+
+    printf("%s\n", failures ? "FAILED" : "OK");
+    return failures ? 1 : 0;
+}
+#endif


### PR DESCRIPTION
Fixes #1755.

## Failure scenario

`PROSPER_DMEM_CALLER=1` walks the stack on each direct-memory allocation to attribute the caller.
The walk scans up to 160 slots **above** its frame, and nothing bounded it. When the allocating
guest frame sits near the top of its thread stack, the scan runs off the last mapped page and the
process dies with a SIGSEGV.

The cost is not just the crash: it **presents as a guest fault**, so the reader goes hunting a
phantom bug in the title rather than in the diagnostic that actually died. Observed while using the
tool on Asterix & Obelix - Babylon Mission (`PPSA30490`, #1748).

## Contract

The walk must never read outside memory known to be mapped, and must never silently report a
truncated result as a complete one.

## Approach

- Clamp the scan to the current thread's stack top: `pthread_getattr_np` (Linux),
  `pthread_get_stackaddr_np` (macOS), `GetCurrentThreadStackLimits` (Windows).
- **Fibers swap stacks** (`hle_fiber.cpp`), so the frame is *not* always inside the range the OS
  reports for this thread. Treat "outside the reported range" as **unknown** rather than trusting
  it, and fall back to the end of the page the frame sits in — mapped by construction, because we
  are executing on it.
- Bounds are cached per thread; **containment is re-checked per call**, because one thread can
  present frames inside and outside its reported stack at different times. The cache matters: on
  glibc `pthread_getattr_np` reads `/proc/self/maps` for the main thread, and this runs on every
  direct-memory allocation while the diagnostic is on. An instrument that perturbs the timing it
  exists to observe is a worse instrument.

Both platform arms of `hle_kernel_mem.cpp` carry the fix — the file is a `#if defined(__linux__) ||
defined(__APPLE__)` / `#else` split and the walk is duplicated in each, per the file's existing
structure.

### Two silent ceilings made visible

Same function, same class as instrument-trap 49 — a limit that reads as a census:

- A **clamped scan** now says so on the line. It reports a *shorter* chain, not a *shallower* one,
  and those are different claims.
- The **64-distinct-chain** rate limit announces itself once instead of dropping the 65th silently.
  As written, the log read as "64 distinct call sites exist" when it meant "we stopped counting."

## Verification

Build and suite (Linux, in the `ps5ys` distrobox):

```
cmake --build . -j8 && ctest --output-on-failure
```

New test `dmem_caller_walk` (`prosper/tests/test_dmem_caller_walk.cpp`), two checks:

1. a frame deep in the real thread stack permits the full 160-slot scan — this is what proves the
   platform bounds query returned a usable top rather than silently degrading to the page fallback;
2. a frame 4 slots below a `PROT_NONE` guard page clamps instead of faulting, run in a forked child
   so a regression reports as a failed test instead of taking the binary down.

**Mutation (the check that matters).** Reverting only the *behaviour* — keep the query and the code
path, discard its result (`return want;`) — must reproduce the defect's shape:

```
PASS: deep thread-stack frame permits the full 160-slot scan
FAIL: walk beside a guard page clamps instead of faulting
       child died by signal 11 — this is the #1755 crash
```

One named check dies, and it dies **by the real SIGSEGV**. An earlier draft of the test checked the
slot count *before* performing the reads, so the mutant failed on the test's own arithmetic and
never reproduced the crash; the order was inverted so the fault itself is the failure signal.

## Affected / unaffected

- Affected: `PROSPER_DMEM_CALLER=1` only. Off by default.
- Unaffected: all allocation behaviour. The helper is read-only and reachable only from the
  diagnostic's log path.

## Residual

The test covers the clamp helper, not its wiring into `log_dmem_caller` — that call site is
internal to an anonymous namespace and needs loaded guest modules to exercise. The wiring is a
one-line substitution (`kScan` → `scan`) visible in the diff, but it is not under test.
