### PR TITLE
chore: ignore the local per-game launch scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ frame_*.png
 # Python bytecode from tools/ scripts (e.g. tools/hostprof, tools/snapshot)
 __pycache__/
 *.pyc
+
+# Local per-game launch scripts (prosper/scripts/play/) — convenience only, not project state.
+prosper/scripts/play/


### PR DESCRIPTION
Adds `prosper/scripts/play/` to `.gitignore`.

That directory holds one convenience launcher per title — real user-facing settings (audio, pad,
guest FS, and explicitly *not* the snapshot acceleration knobs `PROSPER_RENDER_SCALE`/
`PROSPER_RENDER_EVERY`) — plus a shared `_common.sh`. They reference a local dump root and a
local save directory, so they are developer convenience rather than project state.

Without this, all 32 scripts show as untracked on every `git status`.

One line, no code paths touched.