### PR TITLE
fix(gpu): give every capped fence diagnostic an ordinal and a sparse tail

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -623,6 +623,11 @@ if(TARGET prosper_core)
   target_link_libraries(test_dmem_caller_walk PRIVATE prosper_core)
   add_test(NAME dmem_caller_walk COMMAND test_dmem_caller_walk)
 
+  # Capped-diagnostic rate limit (issue #1761): a print budget must never be readable as a
+  # population. Pins the sparse tail and the per-key budget; header-only, no GPU state.
+  add_executable(test_diag_ratelimit tests/test_diag_ratelimit.cpp)
+  add_test(NAME diag_ratelimit COMMAND test_diag_ratelimit)
+
   # IME keyboard event delivery (issue #1093): sceImeUpdate must invoke the guest handler
   # per queued key event; the old stub delivered none.
   add_executable(test_ime_input tests/test_ime_input.cpp)

--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -1,5 +1,6 @@
 // command_processor.cpp — see command_processor.hpp.
 #include "command_processor.hpp"
+#include "diag_ratelimit.hpp"   // #1761: single-sourced ordinal + sparse-tail rule for capped logs
 #include "mb3_freelist.hpp"
 #include "pm4_registers.hpp"
 #include "writer_provenance.hpp"
@@ -264,7 +265,7 @@ void write_trap_report(const char* kind, uint64_t dst, uint64_t pre, uint32_t v,
     // the value actually under investigation ever gets a line — which would turn this instrument's
     // own recommended workflow into a silent false negative. And a bare cap makes "64 hits" or
     // "256 hits" read as a count: that is the #1226 trap this file exists to stop repeating.
-    if (ord <= 64 || (ord & (ord - 1)) == 0)
+    if (diag_should_print(ord))
         fprintf(stderr,
                 "[agc] WRITE-TRAP #%llu[val=0x%x] kind=%s dst=0x%llx+%u pre=0x%llx pkt=0x%llx t=%llums\n",
                 (unsigned long long)ord, v, kind, (unsigned long long)dst, byte_off,
@@ -724,7 +725,7 @@ static void forge_trip(const char* kind, uint64_t dst, uint64_t pre, uint64_t va
     // reports a population must never let its own limit masquerade as the measurement.
     static std::atomic<uint64_t> n{0};
     const uint64_t ord = n.fetch_add(1) + 1;
-    if (ord <= 64 || (ord & (ord - 1)) == 0) {
+    if (diag_should_print(ord)) {
         // #1226: report WHY the paired guard did or did not decline, in the same line. The guard is
         // `forge_guard() && label_is_consumed_marker(dst) && !live_pair`, and a bare hit count could
         // not distinguish "the label has no tracked init protocol at all" (cm=0 — every #312 guard is
@@ -863,7 +864,7 @@ static void init_trip(const Pm4Command& c, uint64_t pre, uint32_t v32) {
     // schedule front-loads its samples: a population that only appears late — which is exactly what
     // `member` does here — is absent from every early line, and quoting one of those as the run's
     // answer is the cap-as-count trap wearing a different hat.
-    const bool detail = ord <= 64 || (ord & (ord - 1)) == 0;
+    const bool detail = diag_should_print(ord);
     if (detail) {
         char self[256]; mb3_freelist_selftest(self, sizeof self);
         fprintf(stderr, "[agc] INIT-TRIP-SELFTEST #%llu %s\n", (unsigned long long)ord, self);
@@ -912,7 +913,7 @@ static bool init_suppress(const Pm4Command& c, uint64_t pre, uint32_t v32) {
     if (mode == 2 && !mb3_freelist_contains_stable(c.dd_dst)) return false;
     static std::atomic<uint64_t> n{0};
     const uint64_t ord = n.fetch_add(1, std::memory_order_relaxed) + 1;
-    if (ord <= 64 || (ord & (ord - 1)) == 0)
+    if (diag_should_print(ord))
         fprintf(stderr, "[agc] INIT-SUPPRESS #%llu mode=%s dst=0x%llx pre=0x%llx t=%llums\n",
                 (unsigned long long)ord, mode == 1 ? "ptr" : "member",
                 (unsigned long long)c.dd_dst, (unsigned long long)pre,
@@ -973,11 +974,14 @@ static bool dma_build_pre_changed(const Pm4Command& c, uint64_t pre, uint64_t* b
     return true;
 }
 static void stale_dma_change_report(uint64_t addr, uint64_t build_pre, uint64_t pre, uint64_t pkt) {
-    static std::atomic<uint32_t> n{0};
-    if (n.fetch_add(1, std::memory_order_relaxed) < 256)
-        fprintf(stderr, "[agc] DMA-GENERATION-CHANGED-STALE-SUPPRESS [0x%llx] build-pre=0x%llx "
+    // #1761: same class as the tripwires above — a suppression reporter whose line count is read as
+    // "how many writes were suppressed". Ordinal on every line, sparse tail past the cap.
+    static std::atomic<uint64_t> n{0};
+    const uint64_t ord = n.fetch_add(1, std::memory_order_relaxed) + 1;
+    if (diag_should_print(ord, 256))
+        fprintf(stderr, "[agc] DMA-GENERATION-CHANGED-STALE-SUPPRESS #%llu [0x%llx] build-pre=0x%llx "
                         "exec-pre=0x%llx pkt=0x%llx t=%llums\n",
-                (unsigned long long)addr, (unsigned long long)build_pre,
+                (unsigned long long)ord, (unsigned long long)addr, (unsigned long long)build_pre,
                 (unsigned long long)pre, (unsigned long long)pkt,
                 (unsigned long long)now_ms());
 }
@@ -1015,12 +1019,15 @@ static bool stale_release_generation(const Pm4Command& c, uint64_t pre) {
     uint64_t initialized = c.rel_build_pre & 0xffffffff00000000ull;
     uint64_t signaled = initialized | 1ull;
     if (pre == initialized || pre == signaled) return false;
-    static std::atomic<uint32_t> n{0};
-    if (n.fetch_add(1, std::memory_order_relaxed) < 256)
-        fprintf(stderr, "[agc] REL-GENERATION-CHANGED-STALE-SUPPRESS [0x%llx] "
+    // #1761: as above — the count of this line is read as the suppressed-write population.
+    static std::atomic<uint64_t> n{0};
+    const uint64_t ord = n.fetch_add(1, std::memory_order_relaxed) + 1;
+    if (diag_should_print(ord, 256))
+        fprintf(stderr, "[agc] REL-GENERATION-CHANGED-STALE-SUPPRESS #%llu [0x%llx] "
                         "build-pre-hi=0x%08x expected-init=0x%llx exec-pre=0x%llx "
                         "pkt=0x%llx t=%llums\n",
-                (unsigned long long)c.rel_addr, (unsigned)(c.rel_build_pre >> 32),
+                (unsigned long long)ord, (unsigned long long)c.rel_addr,
+                (unsigned)(c.rel_build_pre >> 32),
                 (unsigned long long)initialized, (unsigned long long)pre,
                 (unsigned long long)pkt_addr(c), (unsigned long long)now_ms());
     label_hist_rel_free(c.rel_addr, 0);
@@ -1028,12 +1035,15 @@ static bool stale_release_generation(const Pm4Command& c, uint64_t pre) {
 }
 static void mb3_freelist_report(const char* kind, uint64_t addr, uint64_t pre,
                                 const Mb3FreelistMatch* match, bool debt) {
-    static std::atomic<uint32_t> n{0};
-    uint32_t i = n.fetch_add(1, std::memory_order_relaxed);
-    if (i < 64 || (i & 4095u) == 0)
-        fprintf(stderr, "[agc] MB3-FREE-SUPPRESS kind=%s [0x%llx] pre=0x%llx via=%s "
+    // #1761: the old rule (i < 64 || (i & 4095) == 0) put the 65th line on the 4,097th event and
+    // carried no ordinal, so "64 suppressed live-protocol writes per ArcRunner run" — quoted on
+    // #1226 — bounded the population only below 4,096 rather than measuring it.
+    static std::atomic<uint64_t> n{0};
+    const uint64_t ord = n.fetch_add(1, std::memory_order_relaxed) + 1;
+    if (diag_should_print(ord))
+        fprintf(stderr, "[agc] MB3-FREE-SUPPRESS #%llu kind=%s [0x%llx] pre=0x%llx via=%s "
                         "pool=0x%llx list=%u head=0x%llx hops=%u t=%llums\n",
-                kind, (unsigned long long)addr, (unsigned long long)pre,
+                (unsigned long long)ord, kind, (unsigned long long)addr, (unsigned long long)pre,
                 debt ? "dma-debt" : "membership",
                 (unsigned long long)(match ? match->pool_base : 0), match ? match->list : 0,
                 (unsigned long long)(match ? match->head : 0), match ? match->hops : 0,
@@ -1072,14 +1082,24 @@ static void report_suspect_write(const char* kindtag, uint64_t addr, uint64_t va
                                  uint64_t pkt) {
     // Skip the first 2 s (module-load churn); the protocol is steady-state by then.
     if (now_ms() < 2000) return;
-    static std::atomic<int> n{0};
-    if (n.fetch_add(1) >= 192) return;
+    // #1761: ordinal on every line, budget PER KIND, sparse tail past the cap. The old form printed
+    // at most 192 lines shared across ALL kinds and carried no ordinal, so (a) "192 suspect writes"
+    // read as a census when it was the ceiling, and (b) a noisy REL1-LIVE could exhaust the budget
+    // before REL1-FORGE — the kind under investigation — ever got a line.
+    static const char* const kKinds[] = {"REL1-LIVE", "REL1-NOINIT", "REL1-FORGE", "REL2-LIVE",
+                                         "WDATA"};
+    static constexpr size_t kNKinds = sizeof(kKinds) / sizeof(kKinds[0]);
+    static std::atomic<uint64_t> per_kind[kNKinds + 1];
+    const uint64_t ord =
+        per_kind[diag_key_slot(kindtag, kKinds, kNKinds)].fetch_add(1, std::memory_order_relaxed) + 1;
+    if (!diag_should_print(ord, 192)) return;
     uint64_t baddr = 0, bpre = 0, bt = 0;
     int have = prosper_fence_journal_lookup(pkt, &baddr, &bpre, &bt);
     char hist[512]; label_hist_report(addr, hist, sizeof hist);
-    fprintf(stderr, "[agc] SUSPECT-%s [0x%llx] pre=0x%llx value=0x%llx pkt=0x%llx t=%llums | "
+    fprintf(stderr, "[agc] SUSPECT-%s #%llu [0x%llx] pre=0x%llx value=0x%llx pkt=0x%llx t=%llums | "
                     "journal:%s built@%llums(age=%lldms) built-addr=0x%llx%s pre@build=0x%llx%s | %s\n",
-            kindtag, (unsigned long long)addr, (unsigned long long)pre, (unsigned long long)value,
+            kindtag, (unsigned long long)ord, (unsigned long long)addr, (unsigned long long)pre,
+            (unsigned long long)value,
             (unsigned long long)pkt, (unsigned long long)now_ms(),
             have ? "" : " MISS", (unsigned long long)bt,
             have ? (long long)(now_ms() - bt) : -1,
@@ -1157,12 +1177,17 @@ void clockfence_record(uint64_t addr, uint64_t pre, uint64_t value, uint64_t pkt
         // The durable form of #1226's one-off REL3 diagnostic: a clock fence overwriting memory
         // that currently holds a pointer — a recycled label, or a live allocator/RHI structure
         // (the crash class). Bounded and off by default (PROSPER_CLOCKFENCE_LOG=1).
-        static std::atomic<int> n{0};
-        if (clockfence_log() && n.fetch_add(1) < 64)
-            fprintf(stderr,
-                    "[agc] CLOCKFENCE-OVER-PTR kind=%u [0x%llx] pre=0x%llx clock=0x%llx pkt=0x%llx t=%llums\n",
-                    kind, (unsigned long long)addr, (unsigned long long)pre,
+        // #1761: its count is quoted the same way the forge tripwire's was, so it carries an
+        // ordinal on every line and keeps printing sparsely past the cap.
+        static std::atomic<uint64_t> n{0};
+        if (clockfence_log()) {
+            const uint64_t ord = n.fetch_add(1, std::memory_order_relaxed) + 1;
+            if (diag_should_print(ord))
+                fprintf(stderr,
+                    "[agc] CLOCKFENCE-OVER-PTR #%llu kind=%u [0x%llx] pre=0x%llx clock=0x%llx pkt=0x%llx t=%llums\n",
+                    (unsigned long long)ord, kind, (unsigned long long)addr, (unsigned long long)pre,
                     (unsigned long long)value, (unsigned long long)pkt, (unsigned long long)t);
+        }
     }
 }
 }
@@ -1348,12 +1373,17 @@ static void honor_eop_write(const Pm4Command& c) {
                   // not executed — two fence generations in the pipe together (see label_rel_overlap).
                   // Content-independent: catches the late-pair stomp class even when pre reads 0.
                   if (int ov = label_rel_overlap(c.rel_addr); ov >= 1) {
-                      static std::atomic<int> novl{0};
-                      if (now_ms() >= 2000 && novl.fetch_add(1) < 64) {
-                          char hist[512]; label_hist_report(c.rel_addr, hist, sizeof hist);
-                          fprintf(stderr, "[agc] SUSPECT-REL1-OVERLAP [0x%llx] pending-inits=%d pre=0x%llx t=%llums | %s\n",
-                                  (unsigned long long)c.rel_addr, ov, (unsigned long long)pre,
-                                  (unsigned long long)now_ms(), hist);
+                      static std::atomic<uint64_t> novl{0};
+                      if (now_ms() >= 2000) {
+                          // #1761: ordinal on every line and a sparse tail — a bare 64-line cap made
+                          // this tripwire's ceiling indistinguishable from its population.
+                          const uint64_t ord = novl.fetch_add(1, std::memory_order_relaxed) + 1;
+                          if (diag_should_print(ord)) {
+                              char hist[512]; label_hist_report(c.rel_addr, hist, sizeof hist);
+                              fprintf(stderr, "[agc] SUSPECT-REL1-OVERLAP #%llu [0x%llx] pending-inits=%d pre=0x%llx t=%llums | %s\n",
+                                      (unsigned long long)ord, (unsigned long long)c.rel_addr, ov,
+                                      (unsigned long long)pre, (unsigned long long)now_ms(), hist);
+                          }
                       }
                   }
                   uint32_t v = (uint32_t)c.rel_value;

--- a/prosper/src/gpu/diag_ratelimit.hpp
+++ b/prosper/src/gpu/diag_ratelimit.hpp
@@ -1,0 +1,45 @@
+#pragma once
+// Rate-limiting contract for capped diagnostics (#1761; instrument-trap 49).
+//
+// A capped diagnostic must never let its own ceiling masquerade as the measurement. #1226 spent
+// multiple sessions comparing "the forge tripwire fires 64 times" against "64 suppressed MB3
+// writes" as if they were the same population. Both numbers were print artifacts — the forge
+// population is above 1,024, and the MB3 figure was bounded only *below* 4,096 — and the apparent
+// numerical coincidence shaped the investigation.
+//
+// The contract has two halves, and only both together are sufficient:
+//
+//   1. Carry the 1-based ordinal on EVERY line. The last line's ordinal is then a lower bound on
+//      the population; the line COUNT never is. Without this a reader cannot tell the two apart,
+//      which is the whole defect.
+//   2. Keep printing past the cap, sparsely, so the tail exists at all. Powers of two cost
+//      O(log n) lines for an unbounded population.
+//
+// Budget PER KEY wherever a diagnostic has several (kinds, values, addresses): with one shared
+// counter a noisy key exhausts the log before the key actually under investigation ever gets a
+// line. That is not hypothetical — it blocked finding B2 on #1754.
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+namespace prosper {
+
+// True if the event with 1-based ordinal `ord` should be printed: the first `first_n`, then every
+// power of two. Pure and total, so it is unit-testable without any GPU state.
+inline bool diag_should_print(uint64_t ord, uint64_t first_n = 64) {
+    if (ord == 0) return false;                    // 0 is not a valid 1-based ordinal
+    return ord <= first_n || (ord & (ord - 1)) == 0;
+}
+
+// Index of `key` within `keys[0..n)`, or `n` (one past the end) as a shared overflow slot for an
+// unlisted key — so an unexpected kind still prints rather than silently vanishing. Callers size
+// their counter array `n + 1`.
+inline size_t diag_key_slot(const char* key, const char* const* keys, size_t n) {
+    if (!key) return n;
+    for (size_t i = 0; i < n; i++)
+        if (keys[i] && std::strcmp(key, keys[i]) == 0) return i;
+    return n;
+}
+
+}  // namespace prosper

--- a/prosper/tests/test_diag_ratelimit.cpp
+++ b/prosper/tests/test_diag_ratelimit.cpp
@@ -1,0 +1,95 @@
+// #1761: the rate-limiting contract for capped diagnostics.
+//
+// The defect this guards is not a crash — it is a number. #1226 spent multiple sessions comparing
+// "the forge tripwire fires 64 times" against "64 suppressed MB3 writes" as if they described the
+// same population. Both were print artifacts. This suite pins the two properties that make such a
+// number trustworthy: the tail exists (so the ceiling is not the finding), and each key gets its
+// own budget (so a noisy key cannot starve the one under investigation).
+
+#include "../src/gpu/diag_ratelimit.hpp"
+
+#include <cstdint>
+#include <cstdio>
+
+using namespace prosper;
+
+static int failures = 0;
+static void check(bool ok, const char* name) {
+    printf("%s: %s\n", ok ? "PASS" : "FAIL", name);
+    if (!ok) failures++;
+}
+
+int main() {
+    // --- the print window ------------------------------------------------------------------
+    bool all_first = true;
+    for (uint64_t o = 1; o <= 64; o++) if (!diag_should_print(o)) all_first = false;
+    check(all_first, "ordinals 1..64 all print");
+
+    bool gap_silent = true;
+    for (uint64_t o = 65; o <= 127; o++) if (diag_should_print(o)) gap_silent = false;
+    check(gap_silent, "ordinals 65..127 are suppressed");
+
+    check(diag_should_print(128) && diag_should_print(256) && diag_should_print(4096),
+          "powers of two print past the cap");
+
+    bool between_quiet = true;
+    for (uint64_t o = 129; o <= 255; o++) if (diag_should_print(o)) between_quiet = false;
+    check(between_quiet, "non-powers between 128 and 256 stay suppressed");
+
+    check(!diag_should_print(0), "ordinal 0 is not a valid 1-based ordinal and does not print");
+
+    // --- the #1226 discriminator -----------------------------------------------------------
+    // The old mb3_freelist_report rule was `i < 64 || (i & 4095) == 0`, which put the 65th printed
+    // line on the 4,097th event. That is precisely why "64 suppressed live-protocol writes"
+    // bounded the population only BELOW 4,096 instead of measuring it. The 65th line must land on
+    // ordinal 128 — close enough behind the window that the tail is actually informative.
+    uint64_t printed = 0, sixty_fifth = 0;
+    for (uint64_t o = 1; o <= 8192 && !sixty_fifth; o++)
+        if (diag_should_print(o)) { printed++; if (printed == 65) sixty_fifth = o; }
+    check(sixty_fifth == 128, "the 65th printed line lands on ordinal 128, not 4096");
+    if (sixty_fifth != 128) printf("       got %llu\n", (unsigned long long)sixty_fifth);
+
+    // A 4,096-event population is now legible from the log alone: the LAST ordinal is a true lower
+    // bound on the population, where the line count never was.
+    printed = 0;
+    uint64_t last = 0;
+    for (uint64_t o = 1; o <= 4096; o++) if (diag_should_print(o)) { printed++; last = o; }
+    check(printed == 70, "4,096 events produce 70 lines (64 + six powers of two)");
+    check(last == 4096, "the last line of a 4,096-event population carries ordinal 4096");
+
+    // Growth is logarithmic, so the tail is affordable on an unbounded population.
+    printed = 0;
+    for (uint64_t o = 1; o <= (1u << 20); o++) if (diag_should_print(o)) printed++;
+    check(printed == 78, "2^20 events produce 78 lines (64 + fourteen powers of two)");
+
+    // --- caller-supplied windows -------------------------------------------------------------
+    // report_suspect_write budgets 192 and the generation reporters budget 256; the window must
+    // follow first_n rather than a hardcoded 64.
+    check(diag_should_print(192, 192) && !diag_should_print(193, 192) && diag_should_print(256, 192),
+          "first_n=192 window is honored, with the tail resuming at 256");
+    check(diag_should_print(256, 256) && !diag_should_print(257, 256) && diag_should_print(512, 256),
+          "first_n=256 window is honored, with the tail resuming at 512");
+
+    // --- per-key budgets ---------------------------------------------------------------------
+    static const char* const kKinds[] = {"REL1-LIVE", "REL1-NOINIT", "REL1-FORGE"};
+    check(diag_key_slot("REL1-LIVE", kKinds, 3) == 0, "first key maps to slot 0");
+    check(diag_key_slot("REL1-FORGE", kKinds, 3) == 2, "last key maps to its own slot");
+    check(diag_key_slot("WDATA", kKinds, 3) == 3, "an unlisted key gets the overflow slot");
+    check(diag_key_slot(nullptr, kKinds, 3) == 3, "a null key gets the overflow slot");
+
+    // The property that blocked finding B2 on #1754: with ONE shared counter, a noisy kind
+    // exhausts the budget before the kind under investigation ever prints. Per-key budgets must
+    // make the quiet kind's output independent of the noisy kind's volume.
+    uint64_t counters[4] = {0, 0, 0, 0};
+    for (int i = 0; i < 10000; i++)
+        (void)diag_should_print(++counters[diag_key_slot("REL1-LIVE", kKinds, 3)]);
+    uint64_t quiet_printed = 0;
+    for (int i = 0; i < 3; i++)
+        if (diag_should_print(++counters[diag_key_slot("REL1-FORGE", kKinds, 3)])) quiet_printed++;
+    check(quiet_printed == 3, "10,000 events on a noisy key do not starve a quiet key's budget");
+
+    // Trailing summary, present iff the run completed — an abort partway through must not read as
+    // a pass.
+    printf("%s (%d failed)\n", failures ? "FAILED" : "OK", failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
Refs #1761.

## Failure scenario

Instrument-trap 49: *a capped diagnostic must carry its ordinal and keep printing sparsely past the
cap, or its ceiling becomes the finding.*

#1226 spent multiple sessions comparing **"the forge tripwire fires 64 times"** against **"64
suppressed MB3 writes"** as if they described the same population. Both numbers were print
artifacts — the forge population is above 1,024, and the MB3 figure was bounded only *below* 4,096
— and the apparent numerical coincidence shaped the investigation. #1754 fixed `forge_trip`; the
neighbours in the same file kept the defect, and they are the logs those sessions actually read.

## Six sites, not the three on the issue

Sweeping `command_processor.cpp` for the shape rather than trusting the list found three more:

| Site | Diagnostic | Was |
| --- | --- | --- |
| `report_suspect_write` | `SUSPECT-REL1-*`, `REL2-LIVE`, `WDATA` | cap 192 shared across **all five kinds**, no ordinal, no tail |
| REL1-OVERLAP tripwire | `SUSPECT-REL1-OVERLAP` | cap 64, no ordinal |
| `mb3_freelist_report` | `MB3-FREE-SUPPRESS` | sparse tail, no ordinal, 65th line on the 4,097th event |
| **`clockfence` tripwire** | `CLOCKFENCE-OVER-PTR` | cap 64, no ordinal — **#1226's own REL3 diagnostic** |
| **`stale_dma_change_report`** | `DMA-GENERATION-CHANGED-STALE-SUPPRESS` | cap 256, no ordinal |
| **REL-generation reporter** | `REL-GENERATION-CHANGED-STALE-SUPPRESS` | cap 256, no ordinal |

Two specifics worth calling out:

- **`report_suspect_write` shared one budget across five kinds.** A noisy `REL1-LIVE` could exhaust
  it before `REL1-FORGE` — the kind under investigation — printed at all. That is the same failure
  that blocked finding B2 on #1754, so it now budgets **per kind**.
- **`mb3_freelist_report`'s tail was `i < 64 || (i & 4095) == 0`**, which put the 65th line on the
  4,097th event. That is the exact mechanism by which its "64" bounded the population instead of
  measuring it.

## Contract

Print the first `first_n`, then every power of two, and carry the **1-based ordinal on every line**.
The last ordinal printed is then a true lower bound on the population, where a line count never was.
Both halves are required: the tail alone still leaves the reader unable to tell a budget from a
census.

The rule moves to `src/gpu/diag_ratelimit.hpp` so it has one definition and one test. The four sites
that were already correct now call the helper instead of repeating the expression — an identical
substitution, behaviour unchanged. All ten rate-limited `[agc]` lines in the file carry `#%llu`,
verified site by site.

## Deliberately not converted

The file has ~20 other capped counters. They are spam guards on warnings about *single events*
("RELEASE_MEM label unmapped — write SKIPPED", unsupported-packet notices), not censuses of a
protocol population, and no session has quoted their counts as a finding. Converting them blind
would be a large diff with no evidence behind it. Recorded on the issue rather than decided
silently.

## Verification

`test_diag_ratelimit` — 16 checks, header-only, no GPU state.

**Three mutations, each shaped like a different real defect.** The point is not that the suite goes
red but that the checks separate *which* defect occurred:

| Mutation | Named checks killed |
| --- | --- |
| M1 — restore mb3's old `(ord & 4095) == 0` tail | 6, incl. *"the 65th printed line lands on ordinal 128, not 4096"* |
| M2 — bare cap, no tail at all | 7 — M1's six **plus** *"the last line of a 4,096-event population carries ordinal 4096"* |
| M3 — all keys share one budget slot | exactly 2, both per-key checks |

The M1/M2 difference is the interesting one and is load-bearing: under M1, ordinal 4096 *does*
still print (`4096 & 4095 == 0`), so that check correctly stays green; only M2 kills it. The suite
distinguishes two different wrong tails rather than merely detecting that something changed. M3
touches nothing but the per-key checks.

Full suite (Linux, inside the `ps5ys` distrobox) results posted as a comment on the exact head.

## Risk

Diagnostic-only. Every touched path is behind an existing env gate or an existing tripwire
condition; none of them alters GPU behaviour. The only non-mechanical change is `report_suspect_write`
moving from one shared counter to a per-kind array, which strictly increases what gets printed.

## Residual

The tests cover the *rule*. That each `fprintf` carries `#%llu` is verified by inspection across all
ten sites (and shown in the diff), but is not mechanically enforced — a future seventh site could
omit it. I considered a source lint and did not add one: the check needs a ~40-line lookahead to
span `forge_trip`'s comment block, which makes it brittle enough to be more likely disabled than
obeyed. Single-sourcing the rule so a new caller copies a correct neighbour is the weaker but more
durable mitigation.
