### PR TITLE
fix(packaging): repair the dead glibc-ABI gate and harden the Linux release checks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,7 @@ shared-GPU policy, the instrument-not-the-subject list, and the dated current ha
 | UE4 / IoStore bring-up (shared) | — | `docs/UE4_APR_IOSTORE_BRINGUP.md`, `docs/CROSS_ENGINE_UE4.md` |
 | Renderer performance | July pass complete; the stop decision is recorded | `docs/RENDERER_PERFORMANCE_2026_07.md` |
 | Windows port / release | native SDL3+Vulkan frontend, screenshots, release path | `docs/WINDOWS_PORT_HANDOFF.md`, `docs/WINDOWS_RELEASE.md` |
+| Linux desktop release (AppImage + tarball) | published on `v*` tags; packaging is built and verified on every PR | `docs/LINUX_RELEASE.md` (users), `packaging/linux/README.md` (how, and its `## Ruled out`) |
 | GPU capture / replay / timeline tooling | F9 frame grab → offline `.prgbundle` / `.prgcap` workflow, and every `PROSPER_*` graphics diagnostic | `tools/gpu_replay/README.md`, `tools/gpu_timeline/README.md`, `tools/AGENTS.md` |
 | Graphics architecture, resource binding, recompiler | — | `docs/GRAPHICS.md`, `docs/RESOURCE_BINDING.md`, `docs/RECOMPILER_REMAINING.md` |
 | AGC command-packet sizes (a builder's dword count is an ABI contract with the guest's own reservations) | — | `docs/AGC_PACKET_SIZES.md` |

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ The detailed native build, screenshot, and diagnostic recipe is in
 ## Windows download and use
 
 A `v*` tag publishes `prosper-windows-x64.zip` and its `.sha256` on the repository's
-[GitHub Releases page](https://github.com/mattias800/ps5ys/releases). The archive contains
+[GitHub Releases page](https://github.com/mattias800/prosper/releases). The archive contains
 `prosper-app.exe`, a one-command PowerShell launcher, and its usage guide; it never contains games,
 firmware, or keys.
 
@@ -235,7 +235,7 @@ save-data selection, the complete keyboard mapping, recordings, and troubleshoot
 ## Linux download and use
 
 A `v*` tag publishes `prosper-linux-x86_64.AppImage` and `prosper-linux-x86_64.tar.gz`, each with a
-`.sha256`, on the same [GitHub Releases page](https://github.com/mattias800/ps5ys/releases). Take the
+`.sha256`, on the same [GitHub Releases page](https://github.com/mattias800/prosper/releases). Take the
 AppImage for normal desktop use and the tarball when the AppImage runtime cannot start (it needs
 FUSE). Like the Windows archive, neither contains games, firmware, or keys.
 
@@ -253,9 +253,9 @@ tar -xzf prosper-linux-x86_64.tar.gz && cd prosper-linux-x86_64
 ./start-prosper.sh ~/ps5/PPSA24651-app0
 ```
 
-FFmpeg and libva travel inside the archive because their sonames differ on every distribution; SDL3
-is statically linked. What you must supply is **glibc 2.39 or newer** and a working Vulkan driver —
-no archive can carry either. `./prosper-linux-x86_64.AppImage --list-games --games-dir ~/ps5` prints
+FFmpeg, libva and the Vulkan loader travel inside the archive because their sonames differ on every
+distribution; SDL3 is statically linked. What you must supply is **glibc 2.39 or newer** and your
+GPU's Vulkan driver — no archive can carry either. `./prosper-linux-x86_64.AppImage --list-games --games-dir ~/ps5` prints
 the titles it can see and exits without opening a window, which is the quickest way to confirm a
 download runs. See [`LINUX_RELEASE.md`](prosper/docs/LINUX_RELEASE.md) for the full requirements,
 keyboard mapping, recordings, and troubleshooting, and

--- a/prosper/docs/LINUX_RELEASE.md
+++ b/prosper/docs/LINUX_RELEASE.md
@@ -29,18 +29,21 @@ same tree with `./prosper-linux-x86_64.AppImage --appimage-extract`, run it once
   on the oldest runner that is still supported and that build's glibc is the floor. Older
   distributions must build from source. `BUILD.txt` inside the archive records the floor actually
   measured for that build, which is often a little lower than the 2.39 stated here.
-- A Vulkan 1.1-capable driver and a working loader (`libvulkan.so.1` plus your GPU's ICD — the
-  `mesa-vulkan-drivers`, `vulkan-radeon`, `vulkan-intel`, or proprietary NVIDIA package for your
-  distribution). The loader is deliberately **not** bundled, because it has to match the driver
-  installed on your machine.
-- The usual desktop libraries: X11 or Wayland, `libfontconfig`, `libfreetype`, `glib`, `libdrm`.
-  These are excluded from the bundle on purpose — they must match your display stack.
+- A Vulkan 1.1-capable **driver** for your GPU — the `mesa-vulkan-drivers`, `vulkan-radeon`,
+  `vulkan-intel`, or proprietary NVIDIA package for your distribution. The archive carries the Vulkan
+  *loader* (`libvulkan.so.1`), but a loader has nothing to load without your driver's ICD, which is
+  installed system-wide and cannot be bundled.
+- A graphical session: X11 or Wayland, plus the usual desktop libraries (`libX11`, `libwayland-*`,
+  `libfontconfig`, `libfreetype`, `libdrm`). These are host-provided on purpose — they must match
+  your display stack — and every mainstream desktop install already has them.
 - An unpacked title directory conventionally named `<TITLE_ID>-app0`, containing `eboot.bin` and the
   title's other files.
 
-FFmpeg and libva **are** bundled, in `usr/lib` inside the archive. Their sonames differ on every
-distribution (Ubuntu 24.04 ships `libavcodec.so.60`, Fedora 43 ships `libavcodec.so.62`), so a build
-that relied on yours would not start anywhere else. SDL3 is statically linked into the binary.
+What the archive **does** carry, in `usr/lib`: FFmpeg, libva, the Vulkan loader, and their
+dependencies — 116 libraries in the current build. FFmpeg and libva are the reason the archive exists
+in this shape: their sonames differ on every distribution (Ubuntu 24.04 ships `libavcodec.so.60`,
+Fedora 43 ships `libavcodec.so.62`), so a build that relied on yours would not start anywhere else.
+SDL3 is not in that list at all — it is statically linked into the binary.
 
 ## Start a title
 
@@ -69,6 +72,11 @@ Use a separate save location when testing a fresh save or keeping titles isolate
 
 `-force-gfx-direct` is the current Unity default. For a title that must not receive it, launch with
 `--guest-args ''`.
+
+**Launching from a desktop icon does not supply it.** The `.desktop` entry inside the AppImage runs
+`prosper-app` with no added environment, so a title started from the library picker after clicking
+the icon never receives `-force-gfx-direct`. Use one of the command-line forms above for any title
+that needs it.
 
 Presentation defaults to FIFO vsync. Pass `--present-mode mailbox` for low-latency vsync or
 `--present-mode immediate` to permit tearing; either optional mode falls back to FIFO when

--- a/prosper/packaging/linux/README.md
+++ b/prosper/packaging/linux/README.md
@@ -85,7 +85,8 @@ upload is conditional:
   downloaded and opened by hand without giving every PR a release-sized artifact.
 
 Adding the label does not re-run the workflow on its own (`labeled` is not among the default
-`pull_request` event types); push a commit, or re-run the job, after applying it.
+`pull_request` event types), and re-running the job does not help either — a re-run replays the
+**original** event payload, which still does not carry the label. Push a commit after applying it.
 
 ## Pinned tooling
 

--- a/prosper/packaging/linux/glibc-floor.sh
+++ b/prosper/packaging/linux/glibc-floor.sh
@@ -7,9 +7,9 @@
 # that BUILT the artifact sets the floor for everyone who runs it. Reported as a plain `2.NN` on
 # stdout so BUILD.txt can state it and verify-linux-app.sh can gate on it.
 #
-# Non-numeric GLIBC_ABI_* tags (e.g. GLIBC_ABI_GNU2_TLS) are printed to stderr. They are a floor too,
-# but not one that sorts against `2.NN`, so callers gate on them separately rather than folding them
-# into the number.
+# Non-numeric GLIBC_ABI_* tags (e.g. GLIBC_ABI_DT_RELR, GLIBC_ABI_GNU2_TLS) are printed to stderr.
+# They are a floor too, but not one that sorts against `2.NN`, so callers gate on them separately
+# rather than folding them into the number.
 #
 # Usage: glibc-floor.sh <dir-or-file>
 set -euo pipefail
@@ -18,8 +18,13 @@ target="${1:-}"
 [ -n "$target" ] || { echo "glibc-floor.sh: pass a directory or file" >&2; exit 2; }
 
 scan() {
-    # `objdump -T` on a non-ELF file is an error, not a finding: ignore it rather than abort the scan.
-    objdump -T "$1" 2>/dev/null || true
+    # `objdump -p`, NOT `-T`. The dynamic symbol table only carries versions that some symbol is
+    # bound to, which misses two things: the GLIBC_ABI_* tags (they hang off .gnu.version_r with no
+    # symbol attached, so `-T` never shows one and a gate built on it can never fire), and plain
+    # version references no local symbol happens to use. Measured on the shipped artifact, `-T` sees
+    # {2.4, 2.9, 2.34, 2.35, 2.38} while `-p` also sees {2.3.4, 2.32, 2.33}. The maximum agreed here,
+    # but only by luck -- `-p` is the section that actually states what the loader must provide.
+    objdump -p "$1" 2>/dev/null || true
 }
 
 files=()

--- a/prosper/packaging/linux/package-linux-app.sh
+++ b/prosper/packaging/linux/package-linux-app.sh
@@ -37,6 +37,7 @@ build_info=""
 
 while [ $# -gt 0 ]; do
     case "$1" in
+        --*) [ $# -ge 2 ] || { echo "package-linux-app.sh: $1 needs a value" >&2; exit 2; } ;;&
         --build-dir)  build_dir="$2"; shift 2 ;;
         --out-dir)    out_dir="$2";   shift 2 ;;
         --tools-dir)  tools_dir="$2"; shift 2 ;;
@@ -116,10 +117,14 @@ echo "package: bundling the shared-library closure"
 cp "$repo_root/prosper/docs/LINUX_RELEASE.md" "$appdir/README.md"
 cp "$repo_root/prosper/scripts/start-prosper.sh" "$appdir/start-prosper.sh"
 chmod +x "$appdir/start-prosper.sh"
+# Computed into a variable first: inside `echo "... $(...)"` the substitution's failure is masked by
+# echo's own zero status, and BUILD.txt would silently record an empty floor.
+floor="$("$here/glibc-floor.sh" "$appdir")" \
+    || { echo "package-linux-app.sh: could not measure the glibc floor" >&2; exit 1; }
 {
     echo "prosper Linux x86_64"
     if [ -n "$build_info" ]; then printf '%s\n' "$build_info"; fi
-    echo "glibc floor: $("$here/glibc-floor.sh" "$appdir")"
+    echo "glibc floor: $floor"
 } > "$appdir/BUILD.txt"
 
 echo "package: building the AppImage"

--- a/prosper/packaging/linux/verify-linux-app.sh
+++ b/prosper/packaging/linux/verify-linux-app.sh
@@ -35,6 +35,13 @@ done
 [ -n "$out_dir" ] || { echo "verify-linux-app.sh: --out-dir is required" >&2; exit 2; }
 out_dir="$(cd "$out_dir" && pwd)"
 
+# A non-version value would pass the comparison below VACUOUSLY: `sort -V` puts "abc" above "2.39",
+# so `highest` equals the bogus maximum and the floor goes unchecked. Reject it up front.
+case "$max_glibc" in
+    [0-9]*.[0-9]*) ;;
+    *) echo "verify-linux-app.sh: --max-glibc must look like N.NN, got '$max_glibc'" >&2; exit 2 ;;
+esac
+
 fail() { echo "verify: FAIL: $*" >&2; exit 1; }
 ok()   { echo "verify: ok: $*"; }
 
@@ -53,7 +60,10 @@ ok "all four artifacts present"
     || fail "AppImage sha256 does not match"
 ok "both sha256 files verify against their archives"
 
-work="$(mktemp -d)"
+# Beside the artifacts, NOT in /tmp. This extracts the whole bundled tree and then unpacks the
+# AppImage once per arm; on the developer box /tmp is a RAM-backed tmpfs with a per-user quota
+# shared by every concurrent agent, and filling it breaks far more than this script.
+work="$(mktemp -d -p "$out_dir")"
 trap 'rm -rf "$work"' EXIT
 
 # --- fixtures for the runtime arms -----------------------------------------------------------
@@ -73,11 +83,11 @@ smoke() {
 
     rc=0; out="$("$@" --list-games --games-dir "$work/games-empty" 2>&1)" || rc=$?
     [ "$rc" -eq 1 ] || fail "$label: empty games dir should exit 1, got $rc ($out)"
-    grep -q '0 title(s)' <<<"$out" || fail "$label: empty games dir did not report 0 titles: $out"
+    grep -q ' 0 title(s)' <<<"$out" || fail "$label: empty games dir did not report 0 titles: $out"
 
     rc=0; out="$("$@" --list-games --games-dir "$work/games-one" 2>&1)" || rc=$?
     [ "$rc" -eq 0 ] || fail "$label: one-title games dir should exit 0, got $rc ($out)"
-    grep -q '1 title(s)' <<<"$out" || fail "$label: one-title games dir did not report 1 title: $out"
+    grep -q ' 1 title(s)' <<<"$out" || fail "$label: one-title games dir did not report 1 title: $out"
     grep -q 'FAKE00001-app0' <<<"$out" || fail "$label: the title record is missing: $out"
 
     ok "$label: ran headless and distinguished all three library states (exit 2 / 1 / 0)"
@@ -98,7 +108,9 @@ ok "tarball extracts with the binary, launcher, README, BUILD.txt and AppRun"
 
 # The binary must find its bundled libraries by RUNPATH alone. Anything else means the tree only
 # works where it was built.
-runpath="$(objdump -p "$bin" | awk '/RUNPATH|RPATH/ {print $2; exit}')"
+# No `exit` in the awk: closing the pipe early can SIGPIPE objdump, and under `pipefail` that would
+# abort the script with no message instead of reporting a bad RUNPATH.
+runpath="$(objdump -p "$bin" | awk '/RUNPATH|RPATH/ && !seen {seen=1; v=$2} END {print v}')"
 [ "$runpath" = '$ORIGIN/../lib' ] || fail "RUNPATH is '$runpath', expected \$ORIGIN/../lib"
 ok "RUNPATH is \$ORIGIN/../lib"
 
@@ -120,7 +132,7 @@ for soname in libavcodec libavformat libavutil libswresample libswscale libva; d
     # Match the extracted tree, not a `usr/lib` spelling: RUNPATH is $ORIGIN/../lib, so ldd prints
     # the path it actually walked -- `.../usr/bin/../lib/libavcodec.so.NN`. What matters is only
     # that the resolved file lies inside the archive rather than on the host.
-    grep -q "$tree/" <<<"$line" \
+    grep -qF "$tree/" <<<"$line" \
         || fail "$soname resolves outside the archive, so it was not bundled: $line"
 done
 ok "FFmpeg and libva resolve to the bundled copies in usr/lib"
@@ -146,19 +158,32 @@ highest="$(printf '%s\n%s\n' "$floor" "$max_glibc" | sort -V | tail -1)"
         --max-glibc deliberately."
 if [ -s "$floor_err" ]; then
     cat "$floor_err" >&2
-    fail "the tree requires non-numeric glibc ABI tags, which raise the floor beyond $floor"
+    # Deliberately fatal and deliberately NOT quantified. A GLIBC_ABI_* tag states a requirement the
+    # numeric scan cannot express, and the mapping from tag to glibc version is not something this
+    # script can derive -- so guessing one would be worse than stopping. Refuse, and let a human
+    # decide what the tag means for the floor. The shipped ubuntu-24.04 artifact carries none; a
+    # Fedora 43 build carries GLIBC_ABI_GNU2_TLS, which is what this is here to catch.
+    fail "the tree requires non-numeric glibc ABI tags (above). They raise the floor by an amount
+        this check cannot quantify, so the measured $floor cannot be trusted. Investigate the tag
+        before publishing."
 fi
 ok "glibc floor is $floor (declared maximum $max_glibc)"
 
 # --- runtime ------------------------------------------------------------------------------------
-smoke "tarball" "$bin"
+# LD_BIND_NOW so a bundled library that resolves as a FILE but is missing a symbol prosper-app calls
+# fails here rather than at some later call site: --list-games returns before any FFmpeg entry point,
+# so lazy binding would let that through all three arms. LD_LIBRARY_PATH is scrubbed for the same
+# reason the ldd check above scrubs it -- the run must depend only on the archive's own RUNPATH.
+smoke "tarball" env -u LD_LIBRARY_PATH LD_BIND_NOW=1 "$bin"
 
 # --- AppImage -----------------------------------------------------------------------------------
 [ -x "$appimage" ] || fail "the AppImage is not executable"
 file "$appimage" | grep -q 'ELF 64-bit' || fail "the AppImage is not an ELF image"
-# CI containers have no FUSE; this is the supported way to run an AppImage without it.
+# CI containers have no FUSE; this is the supported way to run an AppImage without it. TMPDIR is
+# redirected for the same reason as `work` above: each run extracts the whole image.
 export APPIMAGE_EXTRACT_AND_RUN=1
-smoke "AppImage" "$appimage"
+export TMPDIR="$work"
+smoke "AppImage" env -u LD_LIBRARY_PATH LD_BIND_NOW=1 "$appimage"
 
 echo
 echo "verify: all Linux release artifact checks passed"

--- a/prosper/scripts/start-prosper.sh
+++ b/prosper/scripts/start-prosper.sh
@@ -50,14 +50,21 @@ while [ $# -gt 0 ]; do
     case "$1" in
         --savedata-dir)  savedata_dir="$2"; shift 2 ;;
         --guest-args)    guest_args="$2";   shift 2 ;;
-        --present-mode)  present_mode="$2"; shift 2 ;;
+        # Lower-cased to match start-prosper.ps1, whose [ValidateSet] is case-insensitive and
+        # which passes .ToLowerInvariant() to the app: `--present-mode FIFO` must not be an error
+        # on Linux when `-PresentMode FIFO` works on Windows.
+        --present-mode)  present_mode="$(printf '%s' "$2" | tr '[:upper:]' '[:lower:]')"; shift 2 ;;
         --frames)        frames="$2";       shift 2 ;;
         --record)        record="$2";       shift 2 ;;
-        --record-axis)   record_axis="$2";  shift 2 ;;
+        --record-axis)   record_axis="$(printf '%s' "$2" | tr '[:upper:]' '[:lower:]')"; shift 2 ;;
         --test-pattern)  test_pattern=1;    shift ;;
         -h|--help)       usage; exit 0 ;;
         -*) echo "start-prosper.sh: unknown option: $1" >&2; usage; exit 2 ;;
-        *)  dump="$1"; shift ;;
+        *)  if [ -n "$dump" ]; then
+                echo "start-prosper.sh: pass one app0 directory, not several ('$dump' then '$1')" >&2
+                exit 2
+            fi
+            dump="$1"; shift ;;
     esac
 done
 


### PR DESCRIPTION
Follow-up to #1783, which merged while these fixes were being written. Refs #1782.

An independent review of #1783 found no blocking issues but did find one real defect and several
weaknesses. All are fixed here. Nothing in #1783's shipped behaviour changes — the artifacts are
byte-for-byte the same shape; what changes is that the checks around them now actually check.

## The defect: a gate that could never fire

`glibc-floor.sh` scanned with `objdump -T`, the dynamic **symbol** table. `GLIBC_ABI_*` version
requirements hang off `.gnu.version_r` with no symbol attached, so they never appear there. Measured:

```
$ objdump -T /usr/bin/ls | grep -c GLIBC_ABI_   → 0
$ objdump -p /usr/bin/ls | grep -c GLIBC_ABI_   → 1     (GLIBC_ABI_DT_RELR)
```

So `abi_tags` was always empty, the `[ -s "$floor_err" ]` branch in `verify-linux-app.sh` was
unreachable, and three separate places described it as a live gate. That is precisely a discriminator
that cannot show its lever moved.

Now scanned with `objdump -p`, which is the section that states what the loader must provide. It also
catches numeric references no local symbol happens to bind — on the shipped artifact `-T` sees
`{2.4, 2.9, 2.34, 2.35, 2.38}` while `-p` also sees `{2.3.4, 2.32, 2.33}`. The maximum agreed there,
but only by luck.

A tag is now **fatal and deliberately not quantified**. Mapping a tag to a glibc version is not
something this script can derive, and guessing one would be worse than stopping — so it refuses and
lets a human decide. Confirmed live: on a Fedora binary the script now prints
`glibc-floor: non-numeric ABI tags required: GLIBC_ABI_DT_RELR`, where the old one was silent.

## Other correctness fixes

- **A typo'd `--max-glibc` disabled the floor check vacuously.** `sort -V` ranks `abc` above `2.39`,
  so `highest` equalled the bogus ceiling and nothing was enforced. Rejected up front now.
- **The runtime arms could pass with an unresolvable symbol.** `--list-games` returns before any
  FFmpeg entry point and binding is lazy, so a bundled library that resolves as a *file* but is
  missing a symbol would sail through all three arms. They now run under `LD_BIND_NOW=1`, with
  `LD_LIBRARY_PATH` scrubbed so the executed run is as strict as the inspected one.
- **Scratch moved off `/tmp`.** The verifier extracts the whole bundled tree plus one AppImage
  per arm — several hundred MB — and `/tmp` on the developer box is a RAM-backed tmpfs with a
  per-user quota shared by every concurrent agent. Now `mktemp -d -p "$out_dir"`, with `TMPDIR`
  pointed there too so `APPIMAGE_EXTRACT_AND_RUN` follows.
- `grep -q ' 0 title(s)'` / `' 1 title(s)'` anchored (they also matched `10`/`21`), `grep -qF` for
  the interpolated path, and an `awk` that cannot SIGPIPE `objdump` under `pipefail`.
- `package-linux-app.sh`: a `glibc-floor.sh` failure was masked by `echo`'s own exit status, so
  `BUILD.txt` could silently record an empty floor — the one line users are asked to quote in bug
  reports. Also a missing option value now gets our message instead of bash's `$2: unbound variable`.

## Documentation that did not match the code

- **`LINUX_RELEASE.md` claimed the Vulkan loader is not bundled, and that glib is host-provided.**
  Both are bundled — `ldd` resolves `libvulkan.so.1` and `libglib-2.0.so.0` inside `usr/lib`. What
  the user must supply is the driver's **ICD**, not the loader. Rewritten to state what the archive
  actually carries (116 libraries) against what it does not (`libX11`, `libwayland-*`,
  `libfontconfig`, `libfreetype`, `libdrm`, libc, libstdc++).
- **The `ci:artifacts` label advice was wrong.** "or re-run the job" does not work — a re-run replays
  the *original* event payload, which still lacks the label. Only a new commit does.
- **The AppImage desktop entry supplies no `PROSPER_GUEST_ARGS`.** `Exec=prosper-app` with
  linuxdeploy's stock AppRun means a title launched by clicking the icon never receives
  `-force-gfx-direct`, while the docs tell users it is required. Documented as a caveat rather than
  papered over with a custom AppRun that could not be tested here.
- The two release links this PR's predecessor authored pointed at `mattias800/ps5ys`; the remote is
  `mattias800/prosper`. Corrected in the two paragraphs #1783 wrote (other stale occurrences are
  pre-existing and survive on GitHub's rename redirect).
- `LINUX_RELEASE.md` is now listed in `CLAUDE.md`'s "which doc to read next" table, beside the
  Windows release row.

## Launcher parity

`start-prosper.sh` gains two behaviours `start-prosper.ps1` already had: `--present-mode` and
`--record-axis` accept any case (`[ValidateSet]` is case-insensitive on Windows, so
`-PresentMode FIFO` worked while `--present-mode FIFO` was an error), and a second positional
directory is now an error instead of silently replacing the first.

## Verification

Run against the **artifact downloaded from #1783's CI run**, on Bazzite / Fedora 43:

```
verify: ok: all four artifacts present
verify: ok: both sha256 files verify against their archives
verify: ok: tarball extracts with the binary, launcher, README, BUILD.txt and AppRun
verify: ok: RUNPATH is $ORIGIN/../lib
verify: ok: ldd resolves every dependency with no 'not found'
verify: ok: FFmpeg and libva resolve to the bundled copies in usr/lib
verify: ok: SDL3 is statically linked (no libSDL3 dependency)
verify: ok: glibc floor is 2.38 (declared maximum 2.39)
verify: ok: tarball: ran headless and distinguished all three library states (exit 2 / 1 / 0)
verify: ok: AppImage: ran headless and distinguished all three library states (exit 2 / 1 / 0)
```

Both new counter-arms fire, so the added gates are levers rather than decoration:

- `--max-glibc abc` → `--max-glibc must look like N.NN, got 'abc'`, exit 2 (previously: passed).
- `--max-glibc 2.30` → `glibc floor is 2.38, above the declared maximum 2.30`, exit 1.
- `glibc-floor.sh /usr/bin/ls` → reports `GLIBC_ABI_DT_RELR` (previously: silent).

Launcher arms, from the extracted tarball: `--present-mode FIFO` accepted; `--present-mode MAILBOX
--test-pattern` reaches exec and brings up the window; two positional directories rejected with exit
2; `--present-mode bogus` still rejected. Shellcheck clean at `-S warning` on all four scripts;
`git diff --check` clean; the docs table gates pass.

The branch was rebuilt onto master by cherry-picking the single commit (#1783 was squash-merged), and
every deleted line in the resulting diff was inspected to confirm it is one of #1783's own lines being
replaced rather than another lane's work being reverted.

## Risks

Low. No change to what the artifacts contain or how they are built; the packaging path is untouched
except for the two `package-linux-app.sh` error-handling fixes. The verifier gets strictly stricter,
which is a merge risk only in the sense that it can now fail where it previously could not — which is
the point.
