### PR TITLE
fix(compute): stop submitting after Vulkan device loss

### DIFF
--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -207,6 +207,8 @@ std::atomic<bool> g_fail_next_storage_readback_for_test{false};
 std::atomic<bool> g_zero_next_cold_storage_snapshot_minimum_for_test{false};
 std::atomic<bool> g_force_next_image_result_host_fallback_for_test{false};
 std::atomic<bool> g_fail_next_image_result_buffer_retain_for_test{false};
+std::atomic<bool> g_force_next_queue_submit_device_lost_for_test{false};
+std::atomic<uint64_t> g_live_compute_queue_submit_attempts{0};
 
 VkFormat native_storage_vk_format(prosper::gpu::DataFormat format, uint32_t components) {
     using prosper::gpu::DataFormat;
@@ -977,6 +979,13 @@ struct VulkanComputeContext {
     // True when instance/device/queue were ADOPTED from the live renderer (#1091). A borrowed
     // context is owned by the renderer: destroy our own pipelines/pools/memory, never its device.
     bool borrowed = false;
+    // VK_ERROR_DEVICE_LOST is permanent for a VkDevice. Keep the first failure latched so later
+    // PM4 dispatches cannot spend minutes rebuilding resources and submitting work that Vulkan is
+    // required to reject. AGC submit execution serializes access to this context.
+    bool device_lost = false;
+    // A queue API was entered and no fence or queue-idle result proved completion. The current item
+    // and this context then retain objects that Vulkan may still own; neither may be destroyed.
+    bool completion_unproven = false;
 
     ~VulkanComputeContext() {
         release_cached_buffers();
@@ -2928,8 +2937,22 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
     bool pipeline_cached = false;
     std::string pipeline_key;
     bool ok = false;
+    bool submission_entered = false;
+    bool completion_proven = false;
     auto vk_ok = [&](VkResult result, const char* stage) {
         if (result == VK_SUCCESS) return true;
+        if (result == VK_ERROR_DEVICE_LOST && !ctx.device_lost) {
+            ctx.device_lost = true;
+            std::fprintf(stderr,
+                         "[compute] fatal Vulkan device loss stage=%s "
+                         "result=VK_ERROR_DEVICE_LOST(%d) program=0x%llx submit=%llu "
+                         "dispatch=%llu order=%llu; disabling live compute for this process\n",
+                         stage, static_cast<int>(result),
+                         static_cast<unsigned long long>(item.code_addr),
+                         static_cast<unsigned long long>(item.submit_no),
+                         static_cast<unsigned long long>(item.dispatch_index),
+                         static_cast<unsigned long long>(item.command_order));
+        }
         if (trace) std::fprintf(stderr, "[compute]   Vulkan failure stage=%s result=%d\n",
                                 stage, static_cast<int>(result));
         return false;
@@ -5689,24 +5712,37 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         {
             std::unique_lock<std::mutex> lk(prosper::gpu::shared_present_submit_mutex(), std::defer_lock);
             if (prosper::gpu::shared_present_active()) lk.lock();
-            compute_submit_rc = vkQueueSubmit(ctx.queue, 1, &submit, ctx.dispatch_fence);
+            g_live_compute_queue_submit_attempts.fetch_add(1, std::memory_order_relaxed);
+            submission_entered = true;
+            compute_submit_rc = g_force_next_queue_submit_device_lost_for_test.exchange(
+                                    false, std::memory_order_acq_rel)
+                ? VK_ERROR_DEVICE_LOST
+                : vkQueueSubmit(ctx.queue, 1, &submit, ctx.dispatch_fence);
         }
         if (!vk_ok(compute_submit_rc, "queue-submit")) break;
         if (trace) std::fprintf(stderr, "[compute]   waiting for dispatch\n");
-        if (!vk_ok(vkWaitForFences(ctx.device, 1, &ctx.dispatch_fence, VK_TRUE,
-                                   30ull * 1000 * 1000 * 1000), "queue-wait")) {
-            // cleanup() destroys the command buffer and releases the borrowed image's pin. With a
-            // renderer-owned image bound, in-flight work still references it and its layout
-            // transitions, so drain the queue first rather than freeing it underneath the GPU.
+        const VkResult wait_result = vkWaitForFences(
+            ctx.device, 1, &ctx.dispatch_fence, VK_TRUE, 30ull * 1000 * 1000 * 1000);
+        if (!vk_ok(wait_result, "queue-wait")) {
+            // cleanup() releases resources referenced by the command buffer, including a borrowed
+            // renderer image's pin. With that image bound, in-flight work still references it and
+            // its layout transitions, so drain the queue first rather than freeing it underneath
+            // the GPU.
             // readback_persistent_color_target uses the same drain but PROMOTES a successful drain
             // to success; this item stays failed either way, which is the conservative choice for a
             // dispatch whose results we can no longer trust.
-            std::unique_lock<std::mutex> qlk(prosper::gpu::shared_present_submit_mutex(), std::defer_lock);
-            if (prosper::gpu::shared_present_active()) qlk.lock();
-            if (vkQueueWaitIdle(ctx.queue) != VK_SUCCESS && trace)
-                std::fprintf(stderr, "[compute]   queue drain after fence timeout failed\n");
+            if (!ctx.device_lost) {
+                std::unique_lock<std::mutex> qlk(
+                    prosper::gpu::shared_present_submit_mutex(), std::defer_lock);
+                if (prosper::gpu::shared_present_active()) qlk.lock();
+                const VkResult drain_result = vkQueueWaitIdle(ctx.queue);
+                completion_proven = drain_result == VK_SUCCESS;
+                if (!vk_ok(drain_result, "queue-drain") && trace)
+                    std::fprintf(stderr, "[compute]   queue drain after fence timeout failed\n");
+            }
             break;
         }
+        completion_proven = true;
         if (trace) std::fprintf(stderr, "[compute]   dispatch complete\n");
         phase_dispatch = ComputeClock::now();
         const auto writeback_prepare_start = phase_dispatch;
@@ -6334,7 +6370,13 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                          image.guest_bytes >= 16 ? reinterpret_cast<const uint32_t*>(bytes)[3] : 0);
         }
     }
-    cleanup();
+    if (ctx.device_lost && submission_entered && !completion_proven)
+        ctx.completion_unproven = true;
+    // VK_ERROR_DEVICE_LOST from a queue call gives no completion proof for the affected submission.
+    // cleanup() would destroy/recycle command resources and release borrowed renderer-image pins
+    // that the GPU may still own. Deliberately retain this raw-handle closure; the sticky entry
+    // check prevents reuse and the atexit handler retains the context itself.
+    if (!ctx.completion_unproven) cleanup();
     if (phase_timing) {
         const auto phase_cleanup = ComputeClock::now();
         auto milliseconds = [](auto begin, auto end) {
@@ -6466,6 +6508,14 @@ void live_compute_force_next_image_result_host_fallback_for_test() {
 
 void live_compute_fail_next_image_result_buffer_retain_for_test() {
     g_fail_next_image_result_buffer_retain_for_test.store(true, std::memory_order_release);
+}
+
+void live_compute_force_next_queue_submit_device_lost_for_test() {
+    g_force_next_queue_submit_device_lost_for_test.store(true, std::memory_order_release);
+}
+
+uint64_t live_compute_queue_submit_attempts() {
+    return g_live_compute_queue_submit_attempts.load(std::memory_order_relaxed);
 }
 
 void storage_pack_unorm8_range(const uint32_t* channels, uint32_t components,
@@ -6621,7 +6671,10 @@ bool execute_live_compute_items(const std::vector<prosper::gpu::ComputeItem>& it
                 VulkanComputeContext* doomed = context_ptr;
                 context_ptr = nullptr;
                 g_live_compute_context = nullptr;
-                delete doomed;
+                // Returning early from ~VulkanComputeContext would still destroy all of its member
+                // caches after the destructor body. When a lost-device submission has no completion
+                // proof, retain the object itself so no GPU-facing member ownership is released.
+                if (doomed && !doomed->completion_unproven) delete doomed;
             }) != 0) {
             std::fprintf(stderr, "[compute] std::atexit refused the Vulkan teardown handler — "
                                  "the compute device will not be destroyed at exit\n");
@@ -6648,6 +6701,7 @@ bool execute_live_compute_items(const std::vector<prosper::gpu::ComputeItem>& it
     }
     VulkanComputeContext& context = *live_context;
     g_live_compute_context = &context;
+    if (context.device_lost) return false;
     const bool timing_enabled = std::getenv("PROSPER_RENDER_TIMING") != nullptr;
     const auto timing_start = timing_enabled
         ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point{};
@@ -6661,6 +6715,7 @@ bool execute_live_compute_items(const std::vector<prosper::gpu::ComputeItem>& it
             all_ok &= *cpu_result;
         else
             all_ok &= execute_item(context, item);
+        if (context.device_lost) break;
     }
     if (timing_enabled) {
         struct TimingTotals { uint64_t calls = 0, dispatches = 0; double milliseconds = 0; };

--- a/prosper/frontends/shared/live_compute.hpp
+++ b/prosper/frontends/shared/live_compute.hpp
@@ -196,6 +196,12 @@ void live_compute_zero_next_cold_storage_snapshot_minimum_for_test();
 void live_compute_force_next_image_result_host_fallback_for_test();
 void live_compute_fail_next_image_result_buffer_retain_for_test();
 
+// Deterministically model the permanent failure observed in Astro Bot without asking the driver to
+// lose a real device. The attempt count proves both the current batch and later callbacks stop before
+// another vkQueueSubmit after the injected failure.
+void live_compute_force_next_queue_submit_device_lost_for_test();
+uint64_t live_compute_queue_submit_attempts();
+
 // Register the synchronous Vulkan compute backend used by AGC submit processing.
 void register_live_compute();
 

--- a/prosper/tests/test_game_compute.cpp
+++ b/prosper/tests/test_game_compute.cpp
@@ -15,7 +15,14 @@
 #include <cstdio>
 #include <cstring>
 #include <limits>
+#include <string>
 #include <vector>
+
+#ifdef _WIN32
+#include <io.h>
+#else
+#include <unistd.h>
+#endif
 
 #if defined(__linux__)
 #include <sys/mman.h>
@@ -30,6 +37,38 @@ static int fails = 0;
 // that quietly stops executing assertions shows up as a drop rather than as unchanged green.
 static int checks = 0;
 #define CHECK(c, msg) do { ++checks; if (!(c)) { std::printf("FAIL: %s\n", msg); fails++; } } while (0)
+
+static int file_descriptor(FILE* file) {
+#ifdef _WIN32
+    return _fileno(file);
+#else
+    return fileno(file);
+#endif
+}
+
+static int duplicate_descriptor(int fd) {
+#ifdef _WIN32
+    return _dup(fd);
+#else
+    return dup(fd);
+#endif
+}
+
+static int replace_descriptor(int from, int to) {
+#ifdef _WIN32
+    return _dup2(from, to);
+#else
+    return dup2(from, to);
+#endif
+}
+
+static void close_descriptor(int fd) {
+#ifdef _WIN32
+    _close(fd);
+#else
+    close(fd);
+#endif
+}
 
 int main() {
 #ifdef _WIN32
@@ -3349,6 +3388,64 @@ int main() {
                 CHECK(row0_written, "partial store did write the covered row (kernel ran)");
             }
         }
+    }
+
+    // Keep this last: the production contract deliberately latches a lost VkDevice for the rest of
+    // the process. Inject one queue-submit loss into a two-item batch, then call the backend again.
+    // Both checks measure the lever directly: disabling either the in-batch break or the persistent
+    // short-circuit causes another queue-submit attempt and makes a named assertion fail.
+    {
+        FILE* diagnostic_file = std::tmpfile();
+        int saved_stderr = -1;
+        bool capturing = false;
+        if (diagnostic_file) {
+            std::fflush(stderr);
+            saved_stderr = duplicate_descriptor(file_descriptor(stderr));
+            capturing = saved_stderr >= 0 &&
+                        replace_descriptor(file_descriptor(diagnostic_file),
+                                           file_descriptor(stderr)) >= 0;
+        }
+        CHECK(capturing, "device-loss diagnostic capture initialized");
+
+        const uint64_t attempts_before =
+            prosper::frontend::live_compute_queue_submit_attempts();
+        prosper::frontend::live_compute_force_next_queue_submit_device_lost_for_test();
+        const bool batch_result =
+            prosper::frontend::execute_live_compute_items({item, item});
+        const uint64_t attempts_after_loss =
+            prosper::frontend::live_compute_queue_submit_attempts();
+        const bool later_result = prosper::frontend::execute_live_compute_items({item});
+        const uint64_t attempts_after_later_call =
+            prosper::frontend::live_compute_queue_submit_attempts();
+
+        std::string diagnostic;
+        if (capturing) {
+            std::fflush(stderr);
+            if (replace_descriptor(saved_stderr, file_descriptor(stderr)) < 0)
+                capturing = false;
+            close_descriptor(saved_stderr);
+            saved_stderr = -1;
+            std::rewind(diagnostic_file);
+            char buffer[512];
+            while (const size_t bytes = std::fread(buffer, 1, sizeof(buffer), diagnostic_file))
+                diagnostic.append(buffer, bytes);
+        } else if (saved_stderr >= 0) {
+            close_descriptor(saved_stderr);
+        }
+        if (diagnostic_file) std::fclose(diagnostic_file);
+
+        CHECK(!batch_result && attempts_after_loss == attempts_before + 1,
+              "device loss aborts the current batch before another queue submit");
+        CHECK(!later_result && attempts_after_later_call == attempts_after_loss,
+              "latched device loss rejects later callbacks before queue submission");
+        CHECK(capturing &&
+                  diagnostic.find("result=VK_ERROR_DEVICE_LOST(-4)") != std::string::npos &&
+                  diagnostic.find("program=0x401aec200 submit=11 dispatch=7 order=70") !=
+                      std::string::npos &&
+                  diagnostic.find("result=VK_ERROR_DEVICE_LOST(-4)",
+                                  diagnostic.find("result=VK_ERROR_DEVICE_LOST(-4)") + 1) ==
+                      std::string::npos,
+              "device loss is unconditional and identifies the first observed guest dispatch");
     }
 
     if (fails) {


### PR DESCRIPTION
Fixes #1743.

## Failure scenario

Astro Bot's world-map load loses the shared Vulkan device. The first Prosper-observed failure is `VK_ERROR_DEVICE_LOST` at live-compute queue submission; because that diagnostic was trace-only and the callback retained no health state, the backend then rebuilt resources and attempted tens of thousands of dispatches that Vulkan was required to reject. The retained route measured 87,551 casualties and 353 seconds of discarded compute work after the single loss.

## Behavioral contract

- The first `VK_ERROR_DEVICE_LOST` observed by live compute is unconditional and names the Vulkan stage plus guest program, submit, dispatch, and command order.
- Device loss is process-lifetime state. The rest of the current compute batch stops immediately, and every later callback rejects before CPU fast paths, resource setup, or queue submission.
- A queue call that returns device loss without a completion proof retains its per-item Vulkan resources and manual cache/import pins. The process-lifetime compute context is deliberately retained at exit as well; deleting it would destroy member caches even if the destructor body returned early.
- Ordinary unsupported-item failures keep their existing independent-dispatch behavior. They do not poison the backend.

## Regression

The production backend has a deterministic, one-shot queue-submit loss injector plus a monotonic submit-attempt counter. The test sends a valid non-CPU-fast-path item twice in one batch, injects loss on the first queue attempt, then invokes the callback again. It proves:

1. only one submit attempt occurs in the two-item batch;
2. the later callback performs no submit;
3. exactly one unconditional diagnostic identifies the first observed lost-device guest dispatch.

The device-loss case is intentionally last because the production contract is permanently latched for that test process.

## Verification

Exact head: `4146185ad543383671c295446ab4852a72fdf1e3`

Built inside the `ps5ys` distrobox with a worktree-local build and disk-backed `TMPDIR`:

```sh
cmake --build prosper/build-linux --target test_game_compute -j6
ctest --test-dir prosper/build-linux \
  -R '^game_compute_exec(_no_adaptive_storage_result)?$' --output-on-failure
```

Result: 2/2 passed. Direct executable result: `PASS (253 assertions executed)`.

Mutation control kept the injector, test registration, valid item, and all assertions intact, but removed only the current-batch break and future-callback short circuit. Result: exactly these two assertions failed, with the same 253 assertions executed:

- `device loss aborts the current batch before another queue submit`
- `latched device loss rejects later callbacks before queue submission`

`git diff --check origin/master...HEAD`: clean.

## Deliberately unaffected / remaining work

This prevents silent cascades; it does not repair Astro Bot's upstream unbounded indirect work or restore a Vulkan device after loss. The compute device is borrowed from the renderer in the live frontend, so a broader shared-device health contract for renderer/present helpers remains useful follow-up work. This focused change does not overload the renderer's distinct “completion unproven” state and does not rely on `prosper_request_stop()`, which the guest run loop does not yet consume.

No snapshot matrix was run: this changes terminal failure handling and has a direct production-backend regression; the full snapshot matrix remains mandatory before a release, not for this ordinary PR.

