### PR TITLE
fix(tools): make periodic frame dumps opt-in

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -460,6 +460,12 @@ if(TARGET prosper_core)
   target_include_directories(test_capture_renderer_policy PRIVATE frontends/shared)
   add_test(NAME capture_renderer_policy COMMAND test_capture_renderer_policy)
 
+  # boot_trace periodic BMPs are opt-in, with the legacy disable taking priority. This exercises the
+  # exact environment-name lookup and registrar forwarding without constructing Vulkan or writing files.
+  add_executable(test_frame_dump_policy frontends/shared/test_frame_dump_policy.cpp)
+  target_include_directories(test_frame_dump_policy PRIVATE frontends/shared)
+  add_test(NAME frame_dump_policy COMMAND test_frame_dump_policy)
+
   add_executable(test_capture_compute_policy tests/test_capture_compute_policy.cpp)
   target_include_directories(test_capture_compute_policy PRIVATE src)
   add_test(NAME capture_compute_policy COMMAND test_capture_compute_policy)

--- a/prosper/frontends/shared/frame_dump_policy.hpp
+++ b/prosper/frontends/shared/frame_dump_policy.hpp
@@ -1,0 +1,56 @@
+// frame_dump_policy.hpp — opt-in policy for boot_trace's periodic BMP output.
+#pragma once
+
+#include <string>
+#include <utility>
+
+namespace prosper::frontend {
+
+// The environment is represented by presence, matching prosper's other diagnostic switches. Keeping
+// the resolver independent of getenv makes both precedence and boot_trace-to-renderer wiring testable
+// without creating a Vulkan device or writing an image.
+struct FrameDumpEnvironment {
+    const char* frame_dir = nullptr;
+    const char* frame_dumps = nullptr;
+    const char* dump_content = nullptr;
+    const char* dump_first = nullptr;
+    const char* dump_every = nullptr;
+    const char* no_frame_dumps = nullptr;
+};
+
+constexpr bool frame_dump_request_allowed(bool requested, const char* no_frame_dumps) {
+    return requested && no_frame_dumps == nullptr;
+}
+
+constexpr bool frame_dumps_enabled(const FrameDumpEnvironment& env) {
+    return frame_dump_request_allowed(
+        env.frame_dumps != nullptr || env.dump_content != nullptr ||
+            env.dump_first != nullptr || env.dump_every != nullptr,
+        env.no_frame_dumps);
+}
+
+inline constexpr bool kFrameDumpsByDefault = frame_dumps_enabled({});
+
+template <typename Lookup>
+FrameDumpEnvironment read_frame_dump_environment(Lookup&& lookup) {
+    return {
+        lookup("PROSPER_FRAME_DIR"),
+        lookup("PROSPER_FRAME_DUMPS"),
+        lookup("PROSPER_DUMP_CONTENT"),
+        lookup("PROSPER_FRAME_DUMP_FIRST"),
+        lookup("PROSPER_FRAME_DUMP_EVERY"),
+        lookup("PROSPER_NO_FRAME_DUMPS"),
+    };
+}
+
+// This is boot_trace's complete policy-to-registrar path. Tests substitute a pure lookup and a fake
+// registrar, while production supplies getenv and register_live_renderer.
+template <typename Lookup, typename Registrar>
+void register_live_renderer_from_environment(Lookup&& lookup, Registrar&& registrar) {
+    const FrameDumpEnvironment env =
+        read_frame_dump_environment(std::forward<Lookup>(lookup));
+    std::forward<Registrar>(registrar)(env.frame_dir ? env.frame_dir : ".",
+                                      frame_dumps_enabled(env));
+}
+
+} // namespace prosper::frontend

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -551,7 +551,11 @@ uint32_t buffer_upload_bytes(uint32_t declared_bytes) {
     return std::min(declared_bytes, ceiling) & ~3u;
 }
 
-void register_live_renderer(const std::string& frame_dir, bool dump_bmps) {
+void register_live_renderer(const std::string& frame_dir, bool dump_bmps_requested) {
+    // Keep the legacy global disable authoritative for every frontend, including callers with their
+    // own explicit opt-in such as PROSPER_APP_DUMP_FRAMES.
+    const bool dump_bmps = frame_dump_request_allowed(
+        dump_bmps_requested, getenv("PROSPER_NO_FRAME_DUMPS"));
     // Create (and thereby PUBLISH) the renderer's Vulkan device up front so the compute backend can
     // adopt it (#1091). Compute initializes lazily on its first dispatch, and titles routinely
     // dispatch before their first draw -- without this the compute device would be created first and

--- a/prosper/frontends/shared/live_renderer.hpp
+++ b/prosper/frontends/shared/live_renderer.hpp
@@ -10,6 +10,7 @@
 #include <cstdint>
 #include <string>
 
+#include "frame_dump_policy.hpp"
 #include "gpu/gpu_execute.hpp"          // GuestGpuWriteQuery — the in-submit mutation proof
 
 namespace prosper::frontend {
@@ -123,9 +124,10 @@ bool texture_source_snapshot_can_follow_watch(bool source_matches_pixels,
                                               size_t retained_source_bytes,
                                               size_t expected_source_bytes);
 
-// Register the live renderer. `frame_dir` is where periodic BMP screenshots are written; pass
-// `dump_bmps = false` (the frontend app) to suppress them — a windowed app presents to screen and
-// doesn't want the periodic disk writes the headless runner uses for verification.
-void register_live_renderer(const std::string& frame_dir = ".", bool dump_bmps = true);
+// Register the live renderer. `frame_dir` only selects where explicitly requested periodic BMPs are
+// written; it does not enable them. PROSPER_NO_FRAME_DUMPS remains a final kill switch even when a
+// caller explicitly requests dumps.
+void register_live_renderer(const std::string& frame_dir = ".",
+                            bool dump_bmps = kFrameDumpsByDefault);
 
 } // namespace prosper::frontend

--- a/prosper/frontends/shared/test_frame_dump_policy.cpp
+++ b/prosper/frontends/shared/test_frame_dump_policy.cpp
@@ -1,0 +1,76 @@
+#include "frame_dump_policy.hpp"
+
+#include <cstdio>
+#include <cstring>
+#include <initializer_list>
+#include <string>
+#include <utility>
+
+using prosper::frontend::kFrameDumpsByDefault;
+using prosper::frontend::frame_dump_request_allowed;
+using prosper::frontend::register_live_renderer_from_environment;
+
+namespace {
+
+struct Registration {
+    unsigned calls = 0;
+    std::string frame_dir;
+    bool dump_bmps = true;
+};
+
+bool check(const char* name,
+           std::initializer_list<std::pair<const char*, const char*>> variables,
+           const char* expected_dir, bool expected_dump) {
+    Registration observed;
+    auto lookup = [&](const char* key) -> const char* {
+        for (const auto& [name, value] : variables)
+            if (std::strcmp(name, key) == 0) return value;
+        return nullptr;
+    };
+    register_live_renderer_from_environment(
+        lookup,
+        [&](const std::string& frame_dir, bool dump_bmps) {
+            ++observed.calls;
+            observed.frame_dir = frame_dir;
+            observed.dump_bmps = dump_bmps;
+        });
+    if (observed.calls != 1 || observed.frame_dir != expected_dir ||
+        observed.dump_bmps != expected_dump) {
+        std::fprintf(stderr,
+                     "%s: calls=%u dir=%s dump=%d, expected calls=1 dir=%s dump=%d\n",
+                     name, observed.calls, observed.frame_dir.c_str(),
+                     (int)observed.dump_bmps, expected_dir, (int)expected_dump);
+        return false;
+    }
+    return true;
+}
+
+} // namespace
+
+int main() {
+    static_assert(!kFrameDumpsByDefault,
+                  "the shared renderer must not dump periodic BMPs by default");
+    static_assert(frame_dump_request_allowed(true, nullptr));
+    static_assert(!frame_dump_request_allowed(true, "1"));
+
+    bool ok = true;
+    ok &= check("no variables", {}, ".", false);
+    ok &= check("output directory only", {{"PROSPER_FRAME_DIR", "frames"}}, "frames", false);
+
+    constexpr const char* opt_ins[] = {
+        "PROSPER_FRAME_DUMPS",
+        "PROSPER_DUMP_CONTENT",
+        "PROSPER_FRAME_DUMP_FIRST",
+        "PROSPER_FRAME_DUMP_EVERY",
+    };
+    for (const char* opt_in : opt_ins) {
+        const std::string enabled_name = std::string(opt_in) + " enables";
+        ok &= check(enabled_name.c_str(), {{opt_in, "1"}}, ".", true);
+
+        const std::string disabled_name = std::string(opt_in) + " overridden by disable";
+        ok &= check(disabled_name.c_str(),
+                    {{opt_in, "1"}, {"PROSPER_NO_FRAME_DUMPS", "1"}}, ".", false);
+    }
+    ok &= check("disable alone", {{"PROSPER_NO_FRAME_DUMPS", "1"}}, ".", false);
+    return ok ? 0 : 1;
+}

--- a/prosper/scripts/astrobot/README.md
+++ b/prosper/scripts/astrobot/README.md
@@ -26,9 +26,9 @@ instead; that is the pacing the retained world-map captures were produced with. 
 `PROSPER_PAD_SCRIPT_LOG=1` output against the observed frame counter before assuming a route applies
 to a new frontend.
 
-`boot_trace` also writes a 3840x2160 BMP per sampled frame by default (`dump=1`), which reaches
-gigabytes over a multi-minute route. Set `PROSPER_NO_FRAME_DUMPS=1` for capture runs that only need
-the `.prgbundle`.
+`boot_trace` frame BMPs are opt-in because 3840x2160 output reaches gigabytes over a multi-minute
+route. Set `PROSPER_FRAME_DUMPS=1` only when the periodic images are needed; bundle-only capture runs
+write no BMP sequence by default.
 
 ## The opening needs no route at all
 

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -32,6 +32,10 @@ the shipped runtime. Build them from `build-linux/` like everything else.
 - **`boot_trace/`** — boots a SELF/ELF game image through the loader + HLE and
   runs it, with the fault handler, GPU executor, and (under `PROSPER_RENDER`) the
   live Vulkan renderer. The main harness for exercising a real title headlessly.
+  - **Periodic BMP frame dumps are opt-in.** `PROSPER_FRAME_DIR` only selects the output directory;
+    it does not enable writes. Set `PROSPER_FRAME_DUMPS=1` for the existing first-60/every-10 cadence,
+    or use `PROSPER_DUMP_CONTENT`, `PROSPER_FRAME_DUMP_FIRST`, or `PROSPER_FRAME_DUMP_EVERY` as a
+    deliberate selector. `PROSPER_NO_FRAME_DUMPS=1` has highest priority and disables all of them.
   - **Who allocated this memory?** `PROSPER_MEMLOG=1` reports every direct-memory reserve / allocate
     / map with its size, which answers *how much* but never *who* — and the same guest allocator
     serves every subsystem, so a title whose heap grows without bound looks identical to one that is

--- a/prosper/tools/boot_trace/boot_trace.cpp
+++ b/prosper/tools/boot_trace/boot_trace.cpp
@@ -40,6 +40,7 @@ extern "C" int prosper_reserved_range_state(uint64_t);   // memory-HLE mapping c
 #include "gpu/shader_resources.hpp"       // ShaderResourceTable / ResourceClass (bind the shaders' resources)
 #include "gpu/rdna2_to_spirv.hpp"         // recompile_fragment (diagnostic solid-color PS)
 #include "../../tests/render_runner.h"   // offscreen Vulkan backend (render_triangle_rgba) + dump_bmp
+#include "../../frontends/shared/frame_dump_policy.hpp" // explicit periodic-BMP policy
 #include "../../frontends/shared/live_renderer.hpp"   // shared live renderer (also used by prosper-app)
 #include "../../frontends/shared/live_compute.hpp"    // synchronous AGC compute execution
 #include <atomic>
@@ -254,13 +255,15 @@ int main(int argc, char** argv) {
     }
     // PROSPER_RENDER=1: register the live Vulkan renderer (shared with prosper-app via
     // frontends/shared/live_renderer) so execute_and_present composites every submitted Dcb with
-    // draws and hands the frame to the present path; periodic BMP screenshots go to PROSPER_FRAME_DIR
-    // (default cwd). Set PROSPER_NO_FRAME_DUMPS=1 for renderer-equivalence diagnostics without that
-    // boot_trace-only disk I/O. llvmpipe renders headless in WSL.
+    // draws and hands the frame to the present path. Periodic BMP screenshots are off by default;
+    // PROSPER_FRAME_DUMPS or one of the existing dump selectors opts in, PROSPER_FRAME_DIR selects
+    // the destination, and PROSPER_NO_FRAME_DUMPS always wins. llvmpipe renders headless in WSL.
     if (getenv("PROSPER_RENDER")) {
-        std::string fdir = getenv("PROSPER_FRAME_DIR") ? getenv("PROSPER_FRAME_DIR") : ".";
-        const bool dump_bmps = getenv("PROSPER_NO_FRAME_DUMPS") == nullptr;
-        prosper::frontend::register_live_renderer(fdir, dump_bmps);
+        prosper::frontend::register_live_renderer_from_environment(
+            [](const char* name) { return getenv(name); },
+            [](const std::string& frame_dir, bool dump_bmps) {
+                prosper::frontend::register_live_renderer(frame_dir, dump_bmps);
+            });
     }
 #endif
 


### PR DESCRIPTION
## Problem

`boot_trace` enabled full-resolution periodic BMP output whenever `PROSPER_RENDER` was present unless callers also knew to set the legacy disable. A normal long route could therefore write gigabytes of images that were not requested, distort timing-sensitive runs, and fill shared storage.

Closes #1584.

## Behavioral contract

- Periodic BMP output is off when no dump setting is present.
- `PROSPER_FRAME_DIR` selects a destination only; it does not enable writes.
- `PROSPER_FRAME_DUMPS`, `PROSPER_DUMP_CONTENT`, `PROSPER_FRAME_DUMP_FIRST`, or `PROSPER_FRAME_DUMP_EVERY` explicitly opts in.
- `PROSPER_NO_FRAME_DUMPS` has highest priority, including over a frontend's direct request.
- The existing dump cadence and selector behavior are unchanged after opt-in.
- The existing `PROSPER_APP_DUMP_FRAMES` opt-in remains supported; only the global disable can override it.

## Implementation

The environment-name lookup, precedence rule, destination default, and renderer-registration forwarding now live in one small shared policy. `boot_trace` uses that complete path, while the shared renderer's API default is tied to the same false default and reapplies the global disable as defense in depth.

A pure test substitutes an environment lookup and fake registrar, so it checks the actual wiring without creating Vulkan, starting a game, or writing an image. Tooling guidance and the Astro Bot route note now describe the opt-in behavior.

Environment switches retain prosper's established presence semantics. The documented form is `=1`; a present value such as `PROSPER_FRAME_DUMPS=0` is still considered present.

## Verification

Exact head: `f3bc873fe6d98e81ab58433e541fc16eabde50b0`

```text
distrobox enter ps5ys -- bash -lc 'cd <WORKTREE> && TMPDIR=$PWD/prosper/build-frame-dump/tmpdir cmake --build prosper/build-frame-dump --target test_frame_dump_policy test_command_provenance boot_trace -j6'
PASS

distrobox enter ps5ys -- bash -lc 'cd <WORKTREE> && TMPDIR=$PWD/prosper/build-frame-dump/tmpdir ctest --test-dir prosper/build-frame-dump --output-on-failure -R "^(frame_dump_policy|command_provenance|doc_table_checker)$"'
3/3 PASS

git diff origin/master...HEAD --check
PASS
```

Mutation checks against the focused guard:

- change the shared default to `true` -> killed by the default assertion;
- invert the resolved value forwarded to the registrar -> all named policy cases fail;
- ignore `PROSPER_NO_FRAME_DUMPS` -> killed by the disable-precedence assertion.

The original source was restored after each mutation. Following the rebase onto `df6a85967be8b02df0017e085bdb45fff1a06cd2`, the non-CMake patch's binary diff hash was unchanged; CMake retains both independently added tests, and the exact-head build/tests above were rerun. No game, GPU, or snapshot run was needed for this CPU-only output-selection change.
