### PR TITLE
test(gpu): pin submit provenance identity contract

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -671,6 +671,10 @@ if(TARGET prosper_core)
   target_link_libraries(test_command_processor PRIVATE prosper_core)
   add_test(NAME command_processor_apply COMMAND test_command_processor)
 
+  add_executable(test_command_provenance tests/test_command_provenance.cpp)
+  target_link_libraries(test_command_provenance PRIVATE prosper_core)
+  add_test(NAME command_provenance COMMAND test_command_provenance)
+
   # Stage B: CommandProcessor honors RELEASE_MEM/WRITE_DATA memory writes (synchronous end-of-pipe).
   add_executable(test_eop_write tests/test_eop_write.cpp)
   target_link_libraries(test_eop_write PRIVATE prosper_core)

--- a/prosper/docs/GAME_COMPAT_ORCHESTRATION.md
+++ b/prosper/docs/GAME_COMPAT_ORCHESTRATION.md
@@ -1450,24 +1450,32 @@ The same measurement **confirms** two assumptions previously taken on faith: the
 `USER_DATA_<stage>_0 + user_data_range_start`, and the merged-stage convention that user data begins
 at shader SGPR `s8`.
 
-**Remaining candidate:** cross-queue / multi-buffer submit ordering — a larger, later `SET_SH_REG`
-whose ordered position prosper places differently from the guest's intent (another command buffer, a
-`sceAgcDcbJump` segment, or a second submit entry point).
+**Current frontier:** submit identity is already measured, not missing. For every sampled misfit the
+program bind came from a `q1` (Dcb) fold and the larger user-data write from the following `q3`
+(DcbFinal) fold; the diagnostic retains order, path, origin, fold and Jump depth in each draw
+snapshot. A separate pre-mutex instrument also records call order and thread identity. This localizes
+the mismatch but does not prove a cross-queue root cause: the default-off A/B that gave DcbFinal its
+own register file left reject counts within variance and the 3D world identically black.
 
-**Acceptance test for any proposed mechanism: it must explain the GS-versus-PS asymmetry.** Every
-traced pixel stage in this title has its declared direct pointer readable; only the vertex/GS block
-loses. A submit-ordering story that does not say why the PS block survives is incomplete.
+The earlier GS-versus-PS acceptance test is retired. The signature follows window size across the
+measured failure population: vertex windows 8/12/28 lose, vertex windows 30/32 do not, and every
+pixel stage with a declared pointer also has a 30-dword window. The open question is the hardware
+ordering/ring contract that prevents a larger required block from being paired with a smaller bound
+pipeline window; neither provenance nor stage identity answers it.
 
 **Instruments** (`PROSPER_UDPROV`, `PROSPER_BINDTRACE`, `[udcand]`, `PROSPER_SHADER_HEADER_NEWEST`,
 and the deliberately-off `PROSPER_UD_TAIL_ALIGN`) are on PR #1639, with queue/fold/jump-depth write
-provenance following. Use them rather than rebuilding the measurement.
+provenance following; `PROSPER_SUBMITORDER` adds pre-mutex call/thread identity. The synthetic
+`test_command_provenance` contract pins q1/q2/q3, fold, Jump depth, path and order propagation. Use
+them rather than rebuilding the measurement.
 
 **Instrument warning:** the diagnostics serialize draw realization, so the title screen arrives at
 ~112 s rather than ~90 s. A 200 s window times out in the pre-title load with **zero rejects** and
 looks deceptively like the issue is fixed. Budget ~440 s per run.
 
-Estimated cost: **rung 3 ≈ one to two focused sessions** if submit ordering is confirmed; the
-condition is now cheap to detect, so the remaining work is attribution and a generic contract.
+Estimated cost is **not currently bounded**: the condition and its provenance are cheap to detect,
+but the hardware ordering/ring contract is still unknown. Do not turn the negative DcbFinal split A/B
+into a default fix or claim rung 3 from this diagnostic hardening.
 
 ## Suggested allocation for a new orchestrator
 

--- a/prosper/docs/NIKODERIKO_STATUS.md
+++ b/prosper/docs/NIKODERIKO_STATUS.md
@@ -18,11 +18,22 @@ a mapped guest address, under every canonicalization the scalar fold tries. The 
 V# `num_records`/`dword3` tail as a pointer — the `0x0004dfac…` / `0x0001d22c…` constant family — the
 const-fold correctly refuses to invent a descriptor, and the draw is skipped fail-visibly.
 
-The condition that discriminates every failure: **a vertex stage fails exactly when the user-data
-block the guest most recently programmed is LARGER than the bound pipeline's user-SGPR window**
-(`SPI_SHADER_PGM_RSRC2_GS.USER_SGPR`, which equals the shader's own `user_data_range_end`). Full
-measurement, instruments and the complete falsification list are in
-[`RESOURCE_BINDING.md`](RESOURCE_BINDING.md) § `Ruled out`.
+The condition that discriminates the #305 signature is stage-agnostic: **the required user-data
+block is larger than the bound pipeline's user-SGPR window** (`SPI_SHADER_PGM_RSRC2_{GS,PS}.USER_SGPR`,
+which equals the shader's own `user_data_range_end`). The early sample looked vertex/GS-specific
+because every sampled pixel stage with declared pointers had a 30-dword window, equal to the largest
+observed write. The later failure-replay inventory contains vertex stages with 30/32-dword windows
+whose pointers remain readable and smaller 8/12/28-dword vertex windows that show the signature.
+Window fit, not stage identity, predicts it. Full measurement, instruments and the complete
+falsification list are in [`RESOURCE_BINDING.md`](RESOURCE_BINDING.md) § `Ruled out`.
+
+Submit provenance is no longer the missing instrument. `PROSPER_UDPROV` records order, direct versus
+indirect path, submit origin, fold and Jump depth for every SH write and carries them into draw
+snapshots; `PROSPER_SUBMITORDER` separately records pre-mutex call order and submit-thread identity.
+The trace localizes the mismatch (the bound program came from a q1/Dcb fold and the larger write from
+the following q3/DcbFinal fold), but does not by itself establish a cross-queue root cause. Giving
+DcbFinal a separate register file was tested as a default-off A/B and did not restore the world or
+collapse rejects. The underlying ordering/ring contract remains unproven.
 
 **Nikoderiko is the loud reproduction #305 has been missing.** On DOLL / Dragon Quest VII
 (`PPSA17942`) the same defect costs 0–33 UI draws per 7-minute run; here it costs the world — 25
@@ -44,7 +55,7 @@ re-derive these without contradictory new evidence.
 | The 8-SGPR `SRSRC` range is **computed inside the shader**, so `sreg_range_written` is set, the user-data fallback is skipped, and descriptor provenance is defeated | **Falsified — this was #1607's founding premise and its original title.** Of the 27 failing stages dumped, replayed with `PROSPER_DYNTRACE_FAIL=1` and disassembled with `shader_inspect`, **every failing *vertex* stage** uses the **canonical bindless-dynamic vertex fetch** (the pixel-stage failures in this title are a separate matter — see the pixel-stage row below): an ordinary descriptor-table read whose index is wave-uniform (`(s18 << 4) & 0x1f0`) and whose base is a user-data pointer — the exact shape `resolve_dynamic_fetch` was written for, plus the AGC format-patch tail. `sreg_range_written` is the *symptom* of that legitimate reload. **The recompiler's three-step ladder is not the defect.** | #1607 |
 | A wrong **seeding origin** for the user-data window | **Falsified.** `user_data_range_start` is `0` for every shader and `user_data_range_end` equals (last declared direct offset + 2), so the metadata is self-consistent with seeding at `SPI_SHADER_USER_DATA_GS_0 + 0`, which is what the executor does. The hypothesis that Nikoderiko was the first live `range_start != 0` shader was falsified by printing the raw field — that was the point of printing it. | #1607 |
 | **Header decode** is wrong | **Falsified.** The shader's own `SBASE` register equals the header's declared direct offset in all ten stages disassembled (e.g. `0x300e710000` reads `s[14:15]` = dword 6; the header says `[10]=6`). | #1607 |
-| **Pixel stages** are affected too | **No.** Every traced PS has its declared direct pointer readable. Only the vertex/GS user-data block loses. Any proposed mechanism for #305 **must explain this asymmetry** — that is the acceptance test. PS failures in this title are separate (an all-zero T# loaded from descriptor-table offset `0x80`, and MIMG sites whose eight `SRSRC` SGPRs the fold cannot determine). | #1607 |
+| The defect is specific to **vertex/GS**, so GS-versus-PS asymmetry is an acceptance test | **Falsified as a stage property.** The original #1607 sample did find every traced PS direct pointer readable, but all such PS windows were 30 dwords, equal to the largest observed write. A later failure-replay inventory found the #305 signature in 8/12/28-dword vertex windows and not in 30/32-dword vertex windows. Pixel stages were unaffected in that run because their windows fit, not because they were pixel stages. Their separate all-zero T# / unresolved-MIMG failures remain separate. | #305 |
 | This is a general **UE4** defect | **Does not hold as stated.** Same build, same recipe: The Pathless `PPSA01826` has **13 of 13** declared direct pointers readable with `implied=0` everywhere, 0 `mubuf-unresolved` and 2 `mimg-unresolved`; its own rejects are missing opcodes (`fmt=14 op=0x68` ×6, `op=0x47`, `fmt=0 op=0x25`, `fmt=7 op=0x1`) — a different problem. The Plucky Squire `PPSA15319` shows 0 failed stage builds. **ArcRunner `PPSA21406` is inconclusive, not negative** — 175 s produced one presented frame and a 153-line log, so it never reached content that could exercise the path; do not read that row either way. The confirmed set is **Nikoderiko + DOLL**. | #1607 |
 | Its 35.9 decoded draws/frame (peak 53) is #1641's "implausibly few" signature | **Falsified — that run was parked on a 2D UI screen.** A working title's *own menus* decode 7–13 draws/frame, so 53 for a title/EULA screen is normal. The 31→53 rise lands exactly when the rich screen appears: samples 10–11 carry 160,300 and 161,248 distinct colours while samples 3–9 are uniformly black. Testing this title against that signature needs a route into a 3D scene. | #1641, PR #1645 |
 | The EULA route is a prosper defect | **No — it is route work.** `left-stick-down` reaches the guest and the document visibly advances (distinct-colour counts move 24,765 → 23,258 → 23,328 → 23,361 → 23,344; t=186 s shows a different paragraph than t=120 s), but ~20 presses at the default `PROSPER_PAD_HOLD` (300 ms) advance only about two paragraphs, `Apply` stays greyed out, and `cross` does nothing while it is disabled (byte-identical samples across the press window). A working route needs a much longer scroll phase or a raised `PROSPER_PAD_HOLD`. | #1607 |
@@ -58,6 +69,9 @@ re-derive these without contradictory new evidence.
 * The first `[udmap]` probe tested only the raw 64-bit pointer value, so tagged-but-valid pointers read
   as `UNMAPPED`. It was corrected to use the fold's own 48-/40-bit canonicalization **before any number
   from it was trusted**. `UNMAPPED` now means the fold could not reach that address either.
+* `[udmap]` is emitted only during failure replay. Every row therefore describes a stage that already
+  failed; a readable pointer means that stage failed for another reason, not that it is a passing
+  population sample. See instrument trap 24 in `GAME_COMPAT_ORCHESTRATION.md`.
 * `PROSPER_PAD_SCRIPT` timings anchor to the **first pad poll**, not process start. Nikoderiko polls
   the pad during its logo sequence, so script time ≈ wall time here — do not assume that on another
   title.

--- a/prosper/docs/RESOURCE_BINDING.md
+++ b/prosper/docs/RESOURCE_BINDING.md
@@ -140,7 +140,7 @@ is skipped fail-visibly. Confirmed on Nikoderiko (`PPSA23760`, #1607) and DOLL /
 
 | Hypothesis | Verdict and evidence | Source |
 |---|---|---|
-| The **user-data block** is a previous pipeline's leftover (from the founding premise, "first draws run with the previous pipeline's PGM + user data" — the *user-data* half; the PGM half still holds, see **Still open** below) | **Falsified.** This was #305's founding premise and its original title; the issue was **retitled on 2026-08-01** so nobody starts from it. `PROSPER_UDPROV=1` records each SH register's last-write `command_order` and path and carries it into the per-draw snapshot: at **every** failing draw the dwords the shader dereferences were written by the **immediately preceding bind**, a handful of packets before the draw. Identical across 21 measured stages. | #305 |
+| The **user-data block** is a previous pipeline's leftover (from the founding premise, "first draws run with the previous pipeline's PGM + user data" — the *user-data* half; current q1/q3 provenance is summarized under **Current frontier** below) | **Falsified.** This was #305's founding premise and its original title; the issue was **retitled on 2026-08-01** so nobody starts from it. `PROSPER_UDPROV=1` records each SH register's last-write `command_order` and path and carries it into the per-draw snapshot: at **every** failing draw the dwords the shader dereferences were written by the **immediately preceding bind**, a handful of packets before the draw. Identical across 21 measured stages. | #305 |
 | The **shader-header registry lookup is stale** (a recycled code allocation resolves an old layout) | **Falsified.** Real hazard in shape — `prosper_agc_shader_header_for_code` returns the *first* match in an append-only registry — but measured `registrations=1` for every failing address across a 2,725-entry registry. | #305 |
 | A **bind packet is missing, dropped or mis-ordered** in the decoded stream | **Falsified.** `PROSPER_BINDTRACE=1` logs every Sh `Set*RegsIndirect` packet carrying a program register, in stream order, interleaved with draws: **0 of 141** register arrays apply more than one distinct `(es_lo, rsrc2)` over 193,397 packets, and **300,404 of 300,404** draws fold with the immediately preceding bind. Zero `SetRegsIndirect array unmapped`, zero out-of-range Sh writes. *(Use these corrected figures: the numbers first posted — 434,239 packets, 871,648 of 876,217 — were contaminated by compute dispatches mislabelled `DRAW` by the instrument itself, and the issue body still quotes them. The correction tightens the conclusion.)* | #305 correction comment |
 | The stage's user data is the **tail** of the programmed block (a constant seed shift) | **Falsified despite a 9-of-9 numeric fit.** Declared descriptors do land on clean guest pointers exactly `programmed − user_data_range_end` dwords above `USER_DATA_GS_0` — but `USER_SGPR == user_data_range_end` for every stage measured (12/12, 8/8, 24/24, 20/20, 30/30, 32/32), so the hardware loads only that many registers and the stage physically **cannot see** anything above them. A live A/B with the shifted seed raised `exec-recompile-reject` from a 118–141 baseline to **521**. Retained, **off**, as `PROSPER_UD_TAIL_ALIGN`; it must stay off. | #305 |
@@ -149,12 +149,25 @@ is skipped fail-visibly. Confirmed on Nikoderiko (`PPSA23760`, #1607) and DOLL /
 | **#1226's Acb register-file split** is dropping graphics user-data writes | **Falsified.** Measured 1,747 Acb folds with SH offsets confined to `[0x207,0x249]` and **zero** graphics user-data writes, so the split discards nothing hardware would have applied. Candidate closed. | #305 |
 | A **wrong seeding origin** or **header decode** explains the unmapped pointers | **Falsified**, and the same measurement *confirms* two assumptions previously taken on faith: the seeding base `USER_DATA_<stage>_0 + user_data_range_start` (`range_start` is 0 for every shader, `range_end` = last declared direct offset + 2), and the merged-stage convention that user data begins at shader SGPR `s8`. The shader's own `SBASE` equals the header's declared offset in all ten stages disassembled. | #1607, #305 |
 
-**Still open**, and the acceptance test for any proposed mechanism: **it must explain the
-GS-versus-PS asymmetry.** Every traced pixel stage in these titles has its declared direct pointer
-readable; only the vertex/GS block loses. The remaining candidate is cross-queue / multi-buffer
-submit ordering — for every misfitting vertex stage the pipeline was bound in a `q1` (Dcb) stream at
-fold *N* while the user-data block was written by a `q3` (`w1KFAHVqpaU` variant submit) stream at
-fold *N+1*, and every sampled failing draw is the first bind-or-draw event of its own `q3` fold.
+**Current frontier.** The source of each write is already observable: for every sampled misfit the
+pipeline was bound in a `q1` (Dcb) fold *N*, while the larger user-data block was written in the
+following `q3` (`w1KFAHVqpaU` / DcbFinal) fold *N+1*. `PROSPER_UDPROV` retains order, direct/indirect
+path, submit origin, fold and Jump depth in the draw snapshot, and `PROSPER_SUBMITORDER` independently
+records call order and thread identity before the submit mutex. Submit identity is therefore not a
+missing instrument.
+
+That provenance does **not** establish cross-queue ordering as the root cause. Giving DcbFinal a
+separate `GpuState` was tested as a default-off A/B: reject counts stayed within route variance and
+the 3D world remained identically black, so that split is ruled out as a fix. The earlier GS-versus-PS
+acceptance test is retired too. The signature appears in 8/12/28-dword vertex windows and not in
+30/32-dword vertex windows; every pixel stage with a declared pointer in the measured run also had a
+30-dword window. Window fit, not stage identity, predicts the result. What remains open is the
+hardware ordering/ring contract that prevents a larger required block from being paired with the
+smaller bound pipeline window.
+
+`test_command_provenance` pins the diagnostic contract synthetically across q1/q2/q3 origins,
+top-level folds, an inner Jump, direct/indirect paths and retained write/draw order. It protects the
+instrument; it does not fix #305 or assert the still-unknown hardware contract.
 
 **Instruments** (`PROSPER_UDPROV`, `PROSPER_BINDTRACE`, `[udcand]`, `PROSPER_SHADER_HEADER_NEWEST`,
 `PROSPER_UD_TAIL_ALIGN`) are on PR #1639 — reuse them rather than rebuilding this measurement.

--- a/prosper/tests/test_command_provenance.cpp
+++ b/prosper/tests/test_command_provenance.cpp
@@ -1,0 +1,194 @@
+// test_command_provenance — pin the #305 SH-register provenance contract without a title boot.
+//
+// The diagnostic must distinguish the submit entry point (Dcb / Acb / DcbFinal), top-level fold,
+// Jump depth, direct-vs-indirect write path, and write-vs-draw order.  A plausible value alone is
+// not evidence of where it came from, so this test drives the real AGC packet builders and PM4
+// decoder, then checks the maps retained by the draw snapshots.
+#include "../src/gpu/command_processor.hpp"
+#include "../src/gpu/pm4_registers.hpp"
+#include "../src/hle/dispatch.hpp"
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <iterator>
+
+using namespace prosper;
+using namespace prosper::gpu;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { std::printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { std::printf("  [ok]   %s\n", m); } } while (0)
+
+struct Dcb {
+    uint32_t* bottom;
+    uint32_t* top;
+    uint32_t* cursor_up;
+    uint32_t* cursor_down;
+    void* callback;
+    void* user_data;
+    uint32_t reserved_dw;
+    uint32_t pad;
+};
+
+static Dcb make_dcb(uint32_t* words, size_t count) {
+    Dcb dcb{};
+    dcb.bottom = words;
+    dcb.top = words + count;
+    dcb.cursor_up = words;
+    dcb.cursor_down = words + count;
+    return dcb;
+}
+
+static size_t used_dwords(const Dcb& dcb) {
+    return static_cast<size_t>(dcb.cursor_up - dcb.bottom);
+}
+
+struct Source {
+    uint8_t origin = 0;
+    uint8_t jump_depth = 0;
+    uint32_t fold = 0;
+};
+
+static Source unpack_source(uint64_t packed) {
+    return {
+        static_cast<uint8_t>(packed & 0xffu),
+        static_cast<uint8_t>((packed >> 8u) & 0xffu),
+        static_cast<uint32_t>(packed >> 16u),
+    };
+}
+
+static uint64_t pack_reg(uint32_t offset, uint32_t value) {
+    return static_cast<uint64_t>(offset) | (static_cast<uint64_t>(value) << 32u);
+}
+
+int main() {
+    std::printf("== test_command_provenance ==\n");
+#ifdef _WIN32
+    _putenv_s("PROSPER_UDPROV", "1");
+#else
+    setenv("PROSPER_UDPROV", "1", 1);
+#endif
+    CHECK(udprov_enabled(), "PROSPER_UDPROV positive control is armed");
+
+    register_builtin_hle();
+    auto setsh = Hle::lookup("-HOOCn0JY48");       // sceAgcDcbSetShRegistersIndirect
+    auto setsh_direct = Hle::lookup("pFLArOT53+w"); // sceAgcDcbSetShRegisterDirect
+    auto draw = Hle::lookup("Yw0jKSqop+E");         // sceAgcDcbDrawIndexAuto
+    auto jump = Hle::lookup("xSAR0LTcRKM");         // sceAgcDcbJump
+    CHECK(setsh && setsh_direct && draw && jump,
+          "AGC indirect/direct/draw/Jump builders are registered");
+    if (!(setsh && setsh_direct && draw && jump)) return 1;
+
+    namespace P = prosper::agc::Pm4;
+    constexpr uint32_t kUser = P::SPI_SHADER_USER_DATA_GS_0;
+
+    // q1 / Dcb: bind two program registers indirectly, then draw.  The snapshot must retain the
+    // indirect path bit and the root source identity from this first top-level fold.
+    uint32_t q1_words[64]{};
+    Dcb q1 = make_dcb(q1_words, 64);
+    ShaderReg q1_bind[] = {
+        {P::SPI_SHADER_PGM_LO_ES, 0x11110000u},
+        {P::SPI_SHADER_PGM_RSRC2_GS, 0x0000000cu},
+    };
+    setsh(reinterpret_cast<uint64_t>(&q1), reinterpret_cast<uint64_t>(q1_bind),
+          std::size(q1_bind), 0, 0, 0);
+    draw(reinterpret_cast<uint64_t>(&q1), 3, 0, 0, 0, 0);
+
+    GpuState graphics;
+    prosper_gpu_set_fold_origin(1);
+    run_command_buffer(q1_words, used_dwords(q1), graphics);
+    CHECK(graphics.draws.size() == 1 && graphics.draws[0].state,
+          "q1 bind+draw produces a retained snapshot");
+    if (graphics.draws.size() != 1 || !graphics.draws[0].state) return 1;
+    const auto q1_snapshot = graphics.draws[0].state;
+    const uint64_t q1_prov = q1_snapshot->sh_prov.at(P::SPI_SHADER_PGM_LO_ES);
+    const Source q1_src = unpack_source(
+        q1_snapshot->sh_prov_src.at(P::SPI_SHADER_PGM_LO_ES));
+    CHECK((q1_prov & GpuState::kProvIndirect) != 0,
+          "q1 program bind records the indirect write path");
+    CHECK((q1_prov & ~GpuState::kProvIndirect) < graphics.draws[0].command_order,
+          "q1 program bind order precedes its draw order");
+    CHECK(q1_src.origin == 1, "q1 program bind records Dcb origin");
+    CHECK(q1_src.jump_depth == 0, "q1 program bind records root Jump depth");
+    CHECK(q1_src.fold != 0, "q1 program bind records a top-level fold identity");
+
+    // q3 / DcbFinal: write the head of the user-data block directly in the root stream, then call
+    // an inner segment which writes the tail and draws.  The draw sees one fold, but two depths.
+    uint32_t inner_words[64]{};
+    Dcb inner = make_dcb(inner_words, 64);
+    setsh_direct(reinterpret_cast<uint64_t>(&inner), pack_reg(kUser + 2, 0x33333333u),
+                 0, 0, 0, 0);
+    setsh_direct(reinterpret_cast<uint64_t>(&inner), pack_reg(kUser + 3, 0x44444444u),
+                 0, 0, 0, 0);
+    draw(reinterpret_cast<uint64_t>(&inner), 6, 0, 0, 0, 0);
+
+    uint32_t q3_words[64]{};
+    Dcb q3 = make_dcb(q3_words, 64);
+    setsh_direct(reinterpret_cast<uint64_t>(&q3), pack_reg(kUser + 0, 0x11111111u),
+                 0, 0, 0, 0);
+    setsh_direct(reinterpret_cast<uint64_t>(&q3), pack_reg(kUser + 1, 0x22222222u),
+                 0, 0, 0, 0);
+    jump(reinterpret_cast<uint64_t>(&q3), 0, 0,
+         reinterpret_cast<uint64_t>(inner_words), used_dwords(inner), 0);
+    draw(reinterpret_cast<uint64_t>(&q3), 9, 0, 0, 0, 0);
+
+    graphics.draws.clear();
+    prosper_gpu_set_fold_origin(3);
+    run_command_buffer(q3_words, used_dwords(q3), graphics);
+    CHECK(graphics.draws.size() == 2 && graphics.draws[0].state,
+          "q3 root and inner Jump draws are both retained");
+    if (graphics.draws.size() != 2 || !graphics.draws[0].state) return 1;
+    const auto q3_snapshot = graphics.draws[0].state;
+    const uint64_t q3_root_prov = q3_snapshot->sh_prov.at(kUser + 0);
+    const uint64_t q3_jump_prov = q3_snapshot->sh_prov.at(kUser + 2);
+    const Source q3_root_src = unpack_source(q3_snapshot->sh_prov_src.at(kUser + 0));
+    const Source q3_jump_src = unpack_source(q3_snapshot->sh_prov_src.at(kUser + 2));
+    CHECK((q3_root_prov & GpuState::kProvIndirect) == 0 &&
+              (q3_jump_prov & GpuState::kProvIndirect) == 0,
+          "q3 user-data writes record the direct write path");
+    CHECK(q3_root_src.origin == 3 && q3_jump_src.origin == 3,
+          "q3 root and Jump writes record DcbFinal origin");
+    CHECK(q3_root_src.fold > q1_src.fold,
+          "q3 top-level fold identity advances beyond q1");
+    CHECK(q3_jump_src.fold == q3_root_src.fold,
+          "inner Jump retains its parent top-level fold identity");
+    CHECK(q3_root_src.jump_depth == 0,
+          "q3 root user data records root Jump depth");
+    CHECK(q3_jump_src.jump_depth == 1,
+          "q3 inner user data records Jump depth one");
+    CHECK((q3_root_prov & ~GpuState::kProvIndirect) <
+              (q3_jump_prov & ~GpuState::kProvIndirect) &&
+              (q3_jump_prov & ~GpuState::kProvIndirect) < graphics.draws[0].command_order,
+          "q3 provenance orders root write, Jump write, then inner draw");
+    CHECK(q3_snapshot->sh.at(kUser + 0) == 0x11111111u &&
+              q3_snapshot->sh.at(kUser + 2) == 0x33333333u,
+          "q3 draw snapshot retains root and Jump user-data values");
+
+    // q2 / Acb uses a separate register state in production.  A synthetic q2 fold proves the
+    // origin discriminator independently and verifies that no q1/q3 graphics state leaked in.
+    uint32_t q2_words[64]{};
+    Dcb q2 = make_dcb(q2_words, 64);
+    setsh_direct(reinterpret_cast<uint64_t>(&q2), pack_reg(kUser + 4, 0x55555555u),
+                 0, 0, 0, 0);
+    draw(reinterpret_cast<uint64_t>(&q2), 12, 0, 0, 0, 0);
+    GpuState compute;
+    prosper_gpu_set_fold_origin(2);
+    run_command_buffer(q2_words, used_dwords(q2), compute);
+    CHECK(compute.draws.size() == 1 && compute.draws[0].state,
+          "q2 write+work produces its own retained snapshot");
+    if (compute.draws.size() == 1 && compute.draws[0].state) {
+        const auto q2_snapshot = compute.draws[0].state;
+        const Source q2_src = unpack_source(q2_snapshot->sh_prov_src.at(kUser + 4));
+        CHECK(q2_src.origin == 2, "q2 user data records Acb origin");
+        CHECK(q2_src.jump_depth == 0, "q2 user data records root Jump depth");
+        CHECK(q2_src.fold > q3_root_src.fold,
+              "q2 top-level fold identity is distinct from q3");
+        CHECK(q2_snapshot->sh.count(P::SPI_SHADER_PGM_LO_ES) == 0 &&
+                  q2_snapshot->sh.count(kUser + 0) == 0,
+              "q2 state does not inherit q1/q3 graphics registers");
+    }
+
+    prosper_gpu_set_fold_origin(0);
+    std::printf("== %s ==\n", fails ? "FAIL" : "PASS");
+    return fails ? 1 : 0;
+}


### PR DESCRIPTION
Refs #305

## What changed

- add a dedicated CPU test that drives the real AGC packet builders and PM4 decoder
- pin q1/Dcb, q2/Acb, and q3/DcbFinal origin identity
- pin top-level fold advancement and inner Jump fold/depth retention
- pin direct versus indirect SH-write provenance and write-before-draw order
- correct stale Nikoderiko/resource-binding/orchestration text after the landed provenance instruments and the negative DcbFinal state-split A/B

This is diagnostic-contract hardening only. It changes no production behavior, does not fix #305, and does not advance Nikoderiko beyond its current compatibility rung. No screenshot is applicable because rendering is unchanged.

## Self-validation

The positive control explicitly arms `PROSPER_UDPROV`; removing only the registration cannot make this suite green by skipping it. Four independent production mutations were then applied, rebuilt, observed failing by name, and restored:

- origin forced to zero: q1 Dcb, q3 DcbFinal, and q2 Acb origin assertions failed
- fold counter collapsed to one: q3-after-q1 and q2-distinct-fold assertions failed
- Jump depth increment/decrement erased: inner Jump depth and parent-fold-retention assertions failed
- indirect-path bit erased: q1 indirect write-path assertion failed

The restored source passed again.

## Verification

Run in the required `ps5ys` distrobox with `TMPDIR=<WORKTREE>/prosper/build-linux/tmpdir`:

```text
cmake -S . -B build-linux -DBUILD_TESTING=ON
cmake --build build-linux --target test_command_provenance test_command_processor test_wait_barrier test_agc_submit -j6
ctest --test-dir build-linux -R "^(doc_table_checker|command_processor_apply|command_provenance|wait_barrier|agc_submit_to_gpustate)$" --output-on-failure
```

Result: 5/5 passed. `git diff --check` passed. Snapshot tests were not run because this PR changes no renderer behavior; they remain required before release, not before every development PR.