### PR TITLE
test(snapshot): stabilize phase-variable content guards

### DIFF
--- a/prosper/tools/snapshot/AGENTS.md
+++ b/prosper/tools/snapshot/AGENTS.md
@@ -182,6 +182,16 @@ follow the order above rather than the obvious one.
   `required_matches` from `len(summary["records"])` for SSIM, and derives
   `required_nonblack` the same way from `min_nonblack_matches` for coverage. A
   window sized for one is automatically sized for the other.
+- A phase-variable checkpoint may opt into `min_consecutive_content_matches`
+  instead of the whole-window ratio; configuring both is an error. This is not
+  permission to count scattered matches: every adjacent sampler index in the
+  required run must jointly clear colour, SSIM, non-black coverage, and
+  dimensions, and an omitted index breaks the run. Existing reviewed structural
+  references are required to seed plateau identification. `verify` then
+  cross-scores each run using only the other run's identified plateau references
+  before saving plateau-only evidence and a candidate. Inspect the whole profile
+  and score explicit off-scene negatives anyway; a long stable menu, logo, or
+  results screen can otherwise become the wrong plateau.
 
 ## Environment
 

--- a/prosper/tools/snapshot/README.md
+++ b/prosper/tools/snapshot/README.md
@@ -66,6 +66,16 @@ entry can define:
 - `min_content_match_ratio`: fraction of all evidence-window frames that must
   meet both structural and non-black contracts; defaults to `0.75`. This keeps
   a few good frames from hiding an intermittently broken renderer.
+- `min_consecutive_content_matches`: alternative for a phase-variable checkpoint
+  inside a broad boot profile. It requires this many adjacent frames to jointly
+  satisfy colour, SSIM, non-black coverage, and dimensions, so scattered matches
+  from an intro or attract loop cannot add up to a pass. It is mutually exclusive
+  with `min_content_match_ratio`; all existing ratio guards retain their original
+  semantics. This mode needs existing reviewed `structural_references` to seed
+  plateau identification. `verify` first finds each run's plateau against that
+  seed, then requires A-plateau-only references to pass run B and B-plateau-only
+  references to pass run A before it can produce an adoptable candidate. Saved
+  review and candidate references come only from those identified plateaus.
 - `min_nonblack_ratio`: conservative coverage floor generated during baseline
   approval at half the lowest reviewed coverage. It rejects blank output
   without requiring a normally dark game to be bright.
@@ -170,6 +180,13 @@ above the threshold across animation phases, whereas a window straddling a load
 or transition makes the guard fail on healthy frames. Confirm the margin rather
 than assuming it — for `alexkidd-gameplay` the worst of 100 reviewed frames
 scores 0.93 against the reviewed references, against a 0.85 floor.
+
+For a checkpoint whose absolute wall-clock phase moves but whose intended state
+holds, profile the whole bounded boot and use `min_consecutive_content_matches`
+rather than narrowing the window until it happens to fit one run. The required
+run must have real margin in both independent profiles. Explicit intro/menu/
+attract negative controls still have to be scored offline; a consecutive count
+does not identify the intended scene by itself.
 
 ## Environment
 

--- a/prosper/tools/snapshot/snapshot.py
+++ b/prosper/tools/snapshot/snapshot.py
@@ -344,8 +344,30 @@ def structural_similarity(left, right):
         ((2 * mean_left * mean_right + c1) * (2 * covariance + c2)) / denominator))
 
 
+def validate_content_entry(entry):
+    """Reject ambiguous or unusable content-guard configurations before capture."""
+    has_ratio = "min_content_match_ratio" in entry
+    has_consecutive = "min_consecutive_content_matches" in entry
+    if has_ratio and has_consecutive:
+        raise ValueError(
+            "min_content_match_ratio and min_consecutive_content_matches are mutually exclusive")
+    if has_ratio:
+        ratio = float(entry["min_content_match_ratio"])
+        if not 0 <= ratio <= 1:
+            raise ValueError(f"min_content_match_ratio {ratio} is outside [0, 1]")
+    if has_consecutive:
+        required = int(entry["min_consecutive_content_matches"])
+        if required <= 0:
+            raise ValueError("min_consecutive_content_matches must be positive")
+        if not entry.get("structural_references"):
+            raise ValueError(
+                "min_consecutive_content_matches requires existing structural_references "
+                "to seed plateau identification")
+
+
 def analyze_content_manifest(tmp, entry):
     """Measure presented screenshots in the configured evidence window."""
+    validate_content_entry(entry)
     after = float(entry.get("capture_after_seconds", 0))
     before = entry.get("capture_before_seconds")
     before = float(before) if before is not None else None
@@ -365,7 +387,8 @@ def analyze_content_manifest(tmp, entry):
 
     required_source = entry.get("capture_source", "composited")
     records = []
-    for sample in (e for e in events if e.get("type") == "sample"):
+    samples = [event for event in events if event.get("type") == "sample"]
+    for sample_ordinal, sample in enumerate(samples):
         elapsed = float(sample.get("elapsed_seconds", -1))
         if elapsed < after or (before is not None and elapsed > before):
             continue
@@ -385,7 +408,9 @@ def analyze_content_manifest(tmp, entry):
         if dims[0] <= 0 or dims[1] <= 0:
             raise RuntimeError(f"manifest screenshot has invalid dimensions: {dims}")
         records.append({
-            "index": int(sample.get("index", len(records))),
+            # Current manifests carry the sampler's index. The ordinal fallback preserves
+            # gaps when an older manifest's interspersed source is filtered out.
+            "index": int(sample.get("index", sample_ordinal)),
             "path": path, "filename": os.path.basename(path), "elapsed": elapsed,
             "colors": int(sample["distinct_rgb_colors"]), "dims": dims,
             "hash": str(sample["pixel_crc32"]), "source": sample.get("source"),
@@ -419,7 +444,7 @@ def analyze_content_manifest(tmp, entry):
             similarities.append(similarity)
     minimum_similarity = float(entry.get("min_structural_similarity", 0.85))
     minimum_coverage = float(entry.get("min_nonblack_ratio", 0))
-    return {
+    summary = {
         "records": records,
         "qualifying": qualifying,
         "richest": richest,
@@ -431,6 +456,8 @@ def analyze_content_manifest(tmp, entry):
         "nonblack_matches": sum(record["nonblack_ratio"] >= minimum_coverage
                                 for record in records),
     }
+    summary["longest_content_run"] = longest_content_run(entry, records)
+    return summary
 
 
 def choose_review_records(summary, count=8):
@@ -449,14 +476,89 @@ def choose_review_records(summary, count=8):
     return sorted({r["path"]: r for r in selected}.values(), key=lambda r: r["elapsed"])
 
 
+def longest_content_run(entry, records, reference_signatures=None, include_structural=True):
+    """Return the longest adjacent run satisfying the complete content contract.
+
+    A broad boot profile can contain logos, an intro, the intended checkpoint, and an
+    attract loop. Counting matches across that whole profile is not enough: unrelated
+    phases can contribute isolated matches. This helper deliberately keeps order and
+    requires one sustained run in the intended state.
+
+    reference_signatures overrides the entry's stored references for cross-run scoring.
+    """
+    expected_dims = tuple(entry["dims"]) if entry.get("dims") else None
+    minimum_similarity = float(entry.get("min_structural_similarity", 0.85))
+    minimum_coverage = entry.get("min_nonblack_ratio")
+    minimum_coverage = float(minimum_coverage) if minimum_coverage is not None else None
+
+    if reference_signatures is None and include_structural:
+        reference_signatures = [
+            decode_luma16x9(reference["luma16x9"])
+            for reference in entry.get("structural_references", [])
+        ]
+
+    best = []
+    current = []
+    for record in records:
+        if current and record.get("index") != current[-1].get("index", -2) + 1:
+            current = []
+        matches = record["colors"] >= int(entry["min_colors"])
+        matches = matches and (expected_dims is None or record["dims"] == expected_dims)
+        if minimum_coverage is not None:
+            matches = matches and record["nonblack_ratio"] >= minimum_coverage
+        if include_structural:
+            if not reference_signatures:
+                matches = False
+            else:
+                similarity = max(
+                    structural_similarity(record["luma16x9"], reference)
+                    for reference in reference_signatures
+                )
+                matches = matches and similarity >= minimum_similarity
+        if matches:
+            current.append(record)
+            if len(current) > len(best):
+                best = list(current)
+        else:
+            current = []
+    return best
+
+
+def cross_run_content_run(entry, source_summary, target_summary):
+    """Return target's run scored against references derived from source only."""
+    source_run = source_summary["longest_content_run"]
+    if not source_run:
+        return []
+    review_summary = dict(source_summary)
+    review_summary["records"] = source_run
+    review_summary["richest"] = max(source_run, key=lambda record: record["colors"])
+    references = [record["luma16x9"] for record in choose_review_records(review_summary)]
+    return longest_content_run(entry, target_summary["records"], references)
+
+
+def cross_run_content_streak(entry, source_summary, target_summary):
+    """Return the length of target's source-only cross-scored content run."""
+    return len(cross_run_content_run(entry, source_summary, target_summary))
+
+
 def content_result(entry, summary, include_structural=True):
     required_frames = int(entry.get("min_qualifying_frames", 2))
     required_changes = int(entry.get("min_pixel_changes", 0))
-    match_ratio = float(entry.get("min_content_match_ratio", 0.75))
+    consecutive_required = entry.get("min_consecutive_content_matches")
+    if ("min_content_match_ratio" in entry and
+            "min_consecutive_content_matches" in entry):
+        return False, [
+            "min_content_match_ratio and min_consecutive_content_matches are mutually exclusive"]
+    match_ratio = (None if consecutive_required is not None
+                   else float(entry.get("min_content_match_ratio", 0.75)))
     expected_dims = tuple(entry["dims"]) if entry.get("dims") else None
     failures = []
-    if not 0 <= match_ratio <= 1:
+    if match_ratio is not None and not 0 <= match_ratio <= 1:
         failures.append(f"min_content_match_ratio {match_ratio} is outside [0, 1]")
+    if consecutive_required is not None:
+        consecutive_required = int(consecutive_required)
+        if consecutive_required <= 0:
+            failures.append("min_consecutive_content_matches must be positive")
     if len(summary["qualifying"]) < required_frames:
         failures.append(f"qualifying frames {len(summary['qualifying'])} < {required_frames}")
     if summary["pixel_changes"] < required_changes:
@@ -467,27 +569,44 @@ def content_result(entry, summary, include_structural=True):
         failures.append(f"dimensions {summary['dims']} != {expected_dims}")
     references = entry.get("structural_references", [])
     if include_structural and references:
-        required_matches = max(int(entry.get("min_structural_matches", required_frames)),
-                               math.ceil(len(summary["records"]) * match_ratio))
+        required_matches = int(entry.get("min_structural_matches", required_frames))
+        if match_ratio is not None:
+            required_matches = max(
+                required_matches, math.ceil(len(summary["records"]) * match_ratio))
         if summary["structural_matches"] < required_matches:
             failures.append(
                 f"structural matches {summary['structural_matches']} < {required_matches} "
                 f"(minimum SSIM {entry.get('min_structural_similarity', 0.85)})")
     if entry.get("min_nonblack_ratio") is not None:
-        required_nonblack = max(int(entry.get("min_nonblack_matches", required_frames)),
-                                math.ceil(len(summary["records"]) * match_ratio))
+        required_nonblack = int(entry.get("min_nonblack_matches", required_frames))
+        if match_ratio is not None:
+            required_nonblack = max(
+                required_nonblack, math.ceil(len(summary["records"]) * match_ratio))
         if summary["nonblack_matches"] < required_nonblack:
             failures.append(
                 f"non-black coverage matches {summary['nonblack_matches']} < {required_nonblack} "
                 f"(minimum ratio {entry['min_nonblack_ratio']})")
+    if include_structural and consecutive_required is not None and consecutive_required > 0:
+        observed = len(summary.get("longest_content_run", []))
+        if observed < consecutive_required:
+            failures.append(
+                f"consecutive content matches {observed} < {consecutive_required}")
     return not failures, failures
 
 
-def save_content_evidence(name, run_number, summary):
+def save_content_evidence(name, run_number, summary, entry=None):
     out_dir = os.path.join(REVIEW_DIR, name)
     os.makedirs(out_dir, exist_ok=True)
     saved = []
-    selected = choose_review_records(summary)
+    review_summary = summary
+    if entry and entry.get("min_consecutive_content_matches") is not None:
+        plateau = summary.get("verified_content_run") or summary["longest_content_run"]
+        if not plateau:
+            raise RuntimeError("no content plateau available for review evidence")
+        review_summary = dict(summary)
+        review_summary["records"] = plateau
+        review_summary["richest"] = max(plateau, key=lambda record: record["colors"])
+    selected = choose_review_records(review_summary)
     review_names = {}
     for index, record in enumerate(selected):
         stem, extension = os.path.splitext(record["filename"])
@@ -520,12 +639,18 @@ def save_content_metadata(path, summary, review_names=None):
             "best_structural_similarity": record["best_structural_similarity"],
             "review_png": review_names.get(record["path"]),
         })
+    metadata = {
+        "schema": 1, "records": records,
+        "qualifying_frames": len(summary["qualifying"]),
+        "pixel_changes": summary["pixel_changes"],
+    }
+    if "verified_content_run" in summary:
+        metadata["longest_consecutive_content_matches"] = len(
+            summary.get("longest_content_run", []))
+        metadata["cross_verified_consecutive_content_matches"] = len(
+            summary["verified_content_run"])
     with open(path, "w") as f:
-        json.dump({
-            "schema": 1, "records": records,
-            "qualifying_frames": len(summary["qualifying"]),
-            "pixel_changes": summary["pixel_changes"],
-        }, f, indent=2)
+        json.dump(metadata, f, indent=2)
         f.write("\n")
 
 
@@ -580,7 +705,16 @@ def save_content_candidate(entry, summaries):
     out_dir = os.path.join(REVIEW_DIR, entry["name"])
     records = []
     for summary in summaries:
-        records.extend(choose_review_records(summary))
+        review_summary = summary
+        if entry.get("min_consecutive_content_matches") is not None:
+            plateau = summary.get("verified_content_run") or summary["longest_content_run"]
+            if not plateau:
+                raise RuntimeError("no content plateau available for candidate references")
+            review_summary = dict(summary)
+            review_summary["records"] = plateau
+            review_summary["richest"] = max(
+                plateau, key=lambda record: record["colors"])
+        records.extend(choose_review_records(review_summary))
     references = []
     seen = set()
     for record in records:
@@ -738,6 +872,7 @@ def capture(entry, run_log=None):
 
 def capture_content(entry, run_log=None):
     """Run the title and measure normal composited screenshots, never renderer intermediates."""
+    validate_content_entry(entry)
     frontend = screenshot_path()
     if not os.path.exists(frontend):
         raise RuntimeError(f"screenshot not found at {frontend} (build it, or set PROSPER_SCREENSHOT)")
@@ -869,15 +1004,29 @@ def cmd_verify(m, names):
                 out_dir = reset_review_evidence(s["name"])
                 _, summary1, t1 = capture_content(s, run_log=os.path.join(out_dir, "run1.log"))
                 temps.append(t1)
-                saved1 = save_content_evidence(s["name"], 1, summary1)
-                _cleanup(t1)
                 _, summary2, t2 = capture_content(s, run_log=os.path.join(out_dir, "run2.log"))
                 temps.append(t2)
-                saved2 = save_content_evidence(s["name"], 2, summary2)
-                _cleanup(t2)
                 ok1, why1 = content_result(s, summary1, include_structural=False)
                 ok2, why2 = content_result(s, summary2, include_structural=False)
                 ok = ok1 and ok2 and summary1["dims"] == summary2["dims"]
+                cross_ab = cross_ba = None
+                consecutive_required = s.get("min_consecutive_content_matches")
+                if consecutive_required is not None:
+                    consecutive_required = int(consecutive_required)
+                    cross_run2 = cross_run_content_run(s, summary1, summary2)
+                    cross_run1 = cross_run_content_run(s, summary2, summary1)
+                    summary1["verified_content_run"] = cross_run1
+                    summary2["verified_content_run"] = cross_run2
+                    cross_ab = len(cross_run2)
+                    cross_ba = len(cross_run1)
+                    ok = (ok and
+                          len(summary1["longest_content_run"]) >= consecutive_required and
+                          len(summary2["longest_content_run"]) >= consecutive_required and
+                          cross_ab >= consecutive_required and cross_ba >= consecutive_required)
+                saved1 = save_content_evidence(s["name"], 1, summary1, s)
+                saved2 = save_content_evidence(s["name"], 2, summary2, s)
+                _cleanup(t1)
+                _cleanup(t2)
                 if ok:
                     save_content_candidate(s, (summary1, summary2))
                 print(f"[verify] {s['name']}: {'CONTENT-STABLE' if ok else 'UNSTABLE'} "
@@ -886,6 +1035,10 @@ def cmd_verify(m, names):
                       f"changes={summary1['pixel_changes']}/{summary2['pixel_changes']}, "
                       f"dims={summary1['dims'][0]}x{summary1['dims'][1]}/"
                       f"{summary2['dims'][0]}x{summary2['dims'][1]})")
+                if cross_ab is not None:
+                    print(f"         consecutive={len(summary1['longest_content_run'])}/"
+                          f"{len(summary2['longest_content_run'])}; cross-run A->B={cross_ab} "
+                          f"B->A={cross_ba}; required={consecutive_required}")
                 if why1 or why2:
                     print(f"         failures: run1={why1 or 'none'} run2={why2 or 'none'}")
                 print(f"         REVIEW REQUIRED: inspect {len(saved1) + len(saved2)} images in {out_dir}")
@@ -937,12 +1090,17 @@ def cmd_check(m, names):
                 _, summary, tmp = capture_content(s, run_log=log)
                 ok, failures = content_result(s, summary)
                 if ok:
+                    consecutive_detail = ""
+                    if s.get("min_consecutive_content_matches") is not None:
+                        consecutive_detail = (
+                            f", consecutive_matches={len(summary['longest_content_run'])}")
                     print(f"[check] {s['name']}: OK ({summary['dims'][0]}x{summary['dims'][1]}, "
                           f"frames={len(summary['records'])}, qualifying={len(summary['qualifying'])}, "
                           f"richest={summary['richest']['colors']} colors, "
                           f"pixel_changes={summary['pixel_changes']}, "
                           f"structural_matches={summary['structural_matches']}, "
-                          f"nonblack_matches={summary['nonblack_matches']})")
+                          f"nonblack_matches={summary['nonblack_matches']}"
+                          f"{consecutive_detail})")
                     os.remove(log) if os.path.exists(log) else None
                 else:
                     failure_paths = []

--- a/prosper/tools/snapshot/snapshots.json
+++ b/prosper/tools/snapshot/snapshots.json
@@ -581,8 +581,8 @@
       "dump": "PPSA25872-app0",
       "scale": 4,
       "timeout": 62,
-      "capture_after_seconds": 25,
-      "capture_before_seconds": 49,
+      "capture_after_seconds": 0,
+      "capture_before_seconds": 62,
       "pad_script": null,
       "savedata_policy": "fresh",
       "env": {},
@@ -591,38 +591,53 @@
       "min_pixel_changes": 1,
       "min_structural_similarity": 0.85,
       "min_structural_matches": 10,
-      "min_content_match_ratio": 0.65,
+      "min_consecutive_content_matches": 15,
       "dims": [
         480,
         270
       ],
-      "review": "Approved 16 composited images from two independent runs on 2026-07-22; intended scene, layers, and progression visually confirmed.",
-      "_note": "Menu-reach guard for Terminator 2D: NO FATE (PPSA25872, Unity/IL2CPP). A headless boot from a fresh save renders the T2 chrome logo and the Terminator-in-flames intro, then reaches the main menu (\"TERMINATOR 2D / NO FATE / START / OPTIONS / HIGH SCORES\") at ~30s. The menu is a static 335-color screen: 19 consecutive frames are byte-identical and match the reference at SSIM 1.0. Window 25-49s captures the boot intro plus the menu plateau (boot->menu transition gives the required pixel changes). The attract character-bio cutscene and demo gameplay after ~49s reproduce but are intentionally excluded: their animation drifts run-to-run and cannot SSIM-match static references. Captured via capture_content at scale=4 with the tool-default PROSPER_FAULT_ONSTACK=1 (Linux write-watch armed); the boot reaches the menu with the write-watch active, so #1147 is NOT the cause of the separate scale=1 headless slowdown tracked in #1181. Scope matches the user-verified checkpoint: reach the main menu.",
+      "review": "Approved all 16 composited images from two independent fresh-save runs on 2026-08-03: every retained 42-61s frame is the fully visible, correctly layered animated main menu; final verify found 20/20 local and 20/20 cross-run consecutive matches (15 required).",
+      "_note": "Phase-self-identifying menu-reach guard for Terminator 2D: NO FATE (PPSA25872, Unity/IL2CPP). A fresh-save boot renders the Reef and Bitmap Bureau logos, the T2 chrome/logo and character/flames intro, then reaches the animated main menu (\"TERMINATOR 2D / NO FATE / START / OPTIONS / HIGH SCORES\"). The former 25-49s window was unsound: the menu appeared at ~30s when adopted but at ~42-43s on current profiling, leaving healthy intro frames inside the supposed menu window and only 10 structural matches against 16 required. This guard profiles the bounded 0-62s boot instead and requires 15 CONSECUTIVE frames to jointly clear min_colors=300, SSIM>=0.85 against menu-only references, non-black coverage>=0.85 and 480x270 dimensions. Two initial discriminating profiles produced 20/20 seed-identified frames and 20/19 opposite-run-validated menu frames; final rebased verification produced 20/20 in both local and cross-run directions (five frames of margin). The worst initial cross-run menu SSIM was 0.9972. Explicit pre-menu negatives scored 0/41 and 0/42 matches (best SSIM 0.3082/0.3284), and the published unmodified attract-gameplay capture scored -0.0099/-0.0118 against the two menu reference sets. min_pixel_changes=1 is retained only as a broad-boot liveness check; the menu milestone itself is carried by the sustained conjoined plateau and no longer depends on straddling the intro-to-menu transition. Captured at scale=4 with the tool-default PROSPER_FAULT_ONSTACK=1 (Linux write-watch armed); scope remains the user-verified main-menu checkpoint.",
       "structural_references": [
-        {
-          "luma16x9": "607c7584775d7d7782755c797f7e755f7476968b7178737a9c7c72758a947d6e6876938e6d6b6d5e5e6767738798706661848b9e6b5a787b575c517b8aa37750747185876c71737955646f767c87776a6781786e6c686675597b6774836a72664c886e6564494e5e4531477878675e4b5b6c5e7387533040534e19306c685d535c8178a36576493a3f34495079907c56",
-          "average_hash": "470043ebeb4bff5b",
-          "difference_hash": "9e94d68e9e9a9296"
-        },
-        {
-          "luma16x9": "34373c3d3b3c3e3b3b3e42525c4f3e34364b3f44453a36453c34393f3f5f836c3a83866b423d3f3e54505c6d7e68867c3d7093a049728392a69b878c868737593c607dbd6da1b8bcb09c8f75583d29444e8aadd793aaa38a75525451514b4f466fadaaa16d675b533d302f303028303f415348454f3e3a3a414344464744382c2f2f3235434a40373436353635342f2a",
-          "average_hash": "00030f3e7ef38000",
-          "difference_hash": "c8c75ef8f2c6158a"
-        },
-        {
-          "luma16x9": "3d2d1e262d32373a3f434134271e2e3d3738222a2f35393e4245453b2c1f35313c322930353a4144474848413324414d8875676460545b676d5d594c405485a8bb834c47525b5f6b645055483d4484a19b653b424d61635e5852574a40355f5556493e42484c5957524b44403d3a3c303a3c434a544f54514f4d48413c3e3e433d3d4d5d6165685659524d49424d3f37",
-          "average_hash": "3e1c19bdff900000",
-          "difference_hash": "b870717937616161"
-        },
         {
           "luma16x9": "15171e262d32373a3f434134271e1c1b171b222a2f35393e4245453b2c1f1c1b191e2930353a41444748484133241c1b2a50676460545b676d5d594c4054532b22364c47525b5f6b655055493d44392328333b424e62645e5852594b403528202d393d42474c5754524a45403c3a2d23363f4348525052504e4f44413d3c3c304f5152575c6a675c605251504a4b464a",
           "average_hash": "ff3e3c3cfe381010",
           "difference_hash": "f8f0f0f8b6e0e0e0"
         },
         {
-          "luma16x9": "6a7b878379697d85847a687c858679666f7592856e766f86b4896f6f8790796c6378949a6c5e6e78607257768aa46f57688185976f6577815a50617985987a607075847a6b6d7377705069787b7e77665a82766b6a626c6c688e5a7681696b5d4f8061616c4c6c6559415f7d725c5a4b6471708278522845433b1e34787b715b57817280726e2a261f2a4f69738b7954",
-          "average_hash": "4642286bef4bffff",
-          "difference_hash": "8e96d29e969ab292"
+          "luma16x9": "15171e262d32373a3f434134271e1c1b171b222a2f35393e4245453b2c1f1c1b191e2930353a41444748484133241c1b2a50676460545b676d5d594c4054532b22374b48525c606c655156493d453a2328333b424e62645e5853594a403528202c383e42484b5855534a45403d3a2d23373f4349535054504e4f47413d3d3d304b4f505b5f6968595d524f4e464d4a4c",
+          "average_hash": "ff3e3c3cfe381010",
+          "difference_hash": "f8f0f0f8b6e0e0e0"
+        },
+        {
+          "luma16x9": "15171e262d32373a3f434134271e1c1b171b222a2f35393e4245453b2c1f1c1b191e2930353a41444748484133241c1b2a50676460545b676d5d594c4054532b22364c47525b5f6b655055493d44392328333b424e62635d5852594b4035282030393e42484c5956514a45413e3a2d233b3e454c544f55534f4f48433e403d30514d58626861655a5b5654504d515747",
+          "average_hash": "ff3e3c3cfe381000",
+          "difference_hash": "bcf0f0f8b6e0e0e0"
+        },
+        {
+          "luma16x9": "15171e262d32373a3f434134271e1c1b171b222a2f35393e4245453b2c1f1c1b191e2930353a41444748484133241c1b2a50676460545b676d5d594c4054532b22374b48525c606c655156493d453a2327333b424e62635d5853594a4036282030393e42484c5955514a45413e3a2d223a3f454d504f56544f4e47433f413b31514e5b63695f655f5d55554d52525745",
+          "average_hash": "ff3e3c3cfe381000",
+          "difference_hash": "bcf0f0f8b6e0e0e0"
+        },
+        {
+          "luma16x9": "15171e262d32373a3f434134271e1c1b171b222a2f35393e4245453b2c1f1c1b191e2930353a41444748484133241c1b2a50676460545b676d5d594c4054532b22364c47525b5f6b645055483d44392327333b424d61635d5852584a4035282030393e42484c5756514a45403d3a2e213940464d4f5057534f4d464340413a31504f5d656a5e66605f55515053565844",
+          "average_hash": "ff3e3c3cfe381000",
+          "difference_hash": "bcf0f0f8b6e0e0e0"
+        },
+        {
+          "luma16x9": "15171e262d32373a3f434134271e1c1b171b222a2f35393e4245453b2c1f1c1b191e2930353a41444748484133241c1b2a50676461545b676d5d594b4054532b22364c47525b5f6a644f54483d42382327333b424e61635d5752584a403528202e383e42484c5655514944403d3a2d22374143484f505550504d45433e3c3a30545959575c6a666262535359534b4848",
+          "average_hash": "ff3e3c3cfe381000",
+          "difference_hash": "d8f0f0f8b6e0e0e0"
+        },
+        {
+          "luma16x9": "15171e262d32373a3f434134271e1c1b171b222a2f35393e4245453b2c1f1c1b191e2930353a41444748484133241c1b2a50676460545b676d5d594c4054532b22364c47525b5f6b645055483d44392329333b424d61635e5852574a403528202d393e42484c5957524b44403d3a2c23393e434a544f5451504e48413c3e3e3048494d5d6165685659524d49424d4e49",
+          "average_hash": "ff3e3c3cfe381010",
+          "difference_hash": "b8f0f0f8b6e0e0e0"
+        },
+        {
+          "luma16x9": "15171e262d32373a3f434134271e1c1b171b222a2f35393e4245453b2c1f1c1b191e2930353a41444748484133241c1b2a50676461545b676d5d594b4054532b22364c47525b5f6a644f54483d42382328333b424e61635d5752584a403528202e393e42484b5956534b45413d3a2c233b3d444b534f5452514e49413c403e304d49535f656466585954534b484e5249",
+          "average_hash": "ff3e3c3cfe381010",
+          "difference_hash": "bcf0f0f8b6e0e0e0"
         }
       ],
       "min_nonblack_ratio": 0.85

--- a/prosper/tools/snapshot/test_snapshot.py
+++ b/prosper/tools/snapshot/test_snapshot.py
@@ -227,6 +227,178 @@ while True:
         self.assertFalse(ok)
         self.assertEqual(3, len(failures))
 
+    def test_consecutive_mode_rejects_enough_total_but_interspersed_matches(self):
+        entry = {
+            "min_qualifying_frames": 3,
+            "min_structural_matches": 3,
+            "min_nonblack_ratio": 0.5,
+            "min_nonblack_matches": 3,
+            "min_consecutive_content_matches": 3,
+            "structural_references": [{"luma16x9": "00" * (16 * 9)}],
+        }
+        summary = {
+            # Every aggregate floor passes. Only adjacency distinguishes the defect shape:
+            # three intended frames separated by intro/attract frames are not one plateau.
+            "records": [{}, {}, {}, {}, {}, {}],
+            "qualifying": [{}, {}, {}],
+            "pixel_changes": 5,
+            "dimensions_consistent": True,
+            "dims": (2, 1),
+            "structural_matches": 3,
+            "nonblack_matches": 6,
+            "longest_content_run": [{}],
+        }
+        ok, failures = SNAPSHOT.content_result(entry, summary)
+        self.assertFalse(ok)
+        self.assertEqual(["consecutive content matches 1 < 3"], failures)
+
+        summary["longest_content_run"] = [{}, {}, {}]
+        ok, failures = SNAPSHOT.content_result(entry, summary)
+        self.assertTrue(ok, failures)
+
+    def test_consecutive_mode_and_ratio_are_mutually_exclusive(self):
+        entry = {
+            "min_content_match_ratio": 0.75,
+            "min_consecutive_content_matches": 3,
+            "structural_references": [{"luma16x9": "00" * (16 * 9)}],
+        }
+        expected = (
+            "min_content_match_ratio and min_consecutive_content_matches are mutually exclusive")
+        with self.assertRaisesRegex(ValueError, expected):
+            SNAPSHOT.validate_content_entry(entry)
+        ok, failures = SNAPSHOT.content_result(entry, {})
+        self.assertFalse(ok)
+        self.assertEqual([expected], failures)
+
+    def test_consecutive_mode_requires_existing_reference_seed(self):
+        entry = {"min_consecutive_content_matches": 3}
+        with self.assertRaisesRegex(
+                ValueError, "requires existing structural_references to seed plateau"):
+            SNAPSHOT.validate_content_entry(entry)
+
+    def test_missing_sample_breaks_consecutive_content_run(self):
+        signature = tuple([0] * (16 * 9))
+        entry = {
+            "min_colors": 300,
+            "dims": [2, 1],
+            "min_nonblack_ratio": 0.5,
+            "min_structural_similarity": 0.85,
+            "structural_references": [{"luma16x9": "00" * (16 * 9)}],
+        }
+        records = [
+            {
+                "index": index, "colors": 335, "dims": (2, 1),
+                "nonblack_ratio": 1.0, "luma16x9": signature,
+            }
+            for index in (4, 5, 7, 8)
+        ]
+        self.assertEqual(2, len(SNAPSHOT.longest_content_run(entry, records)))
+
+    def test_default_ratio_mode_still_uses_the_whole_window(self):
+        entry = {
+            "min_qualifying_frames": 2,
+            "min_structural_matches": 2,
+            "min_nonblack_ratio": 0.5,
+            "min_nonblack_matches": 2,
+            "min_content_match_ratio": 0.75,
+            "structural_references": [{"luma16x9": "00" * (16 * 9)}],
+        }
+        summary = {
+            "records": [{} for _ in range(8)],
+            "qualifying": [{}, {}],
+            "pixel_changes": 0,
+            "dimensions_consistent": True,
+            "dims": (2, 1),
+            "structural_matches": 5,
+            "nonblack_matches": 5,
+        }
+        ok, failures = SNAPSHOT.content_result(entry, summary)
+        self.assertFalse(ok)
+        self.assertEqual([
+            "structural matches 5 < 6 (minimum SSIM 0.85)",
+            "non-black coverage matches 5 < 6 (minimum ratio 0.5)",
+        ], failures)
+
+    def test_cross_run_streak_uses_source_only_references_and_preserves_order(self):
+        menu = tuple([0] * 72 + [255] * 72)
+        negative = tuple([255] * 72 + [0] * 72)
+        entry = {
+            "min_colors": 300,
+            "dims": [2, 1],
+            "min_nonblack_ratio": 0.5,
+            "min_structural_similarity": 0.85,
+        }
+
+        def record(index, signature):
+            return {
+                "index": index,
+                "path": f"frame-{index}.png", "filename": f"frame-{index}.png",
+                "elapsed": float(index), "colors": 335, "dims": (2, 1),
+                "nonblack_ratio": 1.0, "luma16x9": signature,
+            }
+
+        source_run = [record(index, menu) for index in range(3)]
+        source = {
+            "records": source_run, "longest_content_run": source_run,
+            "richest": source_run[0],
+        }
+        target_run = [record(10, negative)] + [record(index, menu) for index in range(11, 14)]
+        target = {"records": target_run}
+        self.assertEqual(3, SNAPSHOT.cross_run_content_streak(entry, source, target))
+        self.assertEqual(
+            [11, 12, 13],
+            [item["index"] for item in SNAPSHOT.cross_run_content_run(entry, source, target)],
+        )
+
+        interspersed = [
+            record(20, menu), record(21, negative), record(22, menu),
+            record(23, negative), record(24, menu),
+        ]
+        self.assertEqual(
+            1, SNAPSHOT.cross_run_content_streak(entry, source, {"records": interspersed}))
+
+    def test_cross_run_plateau_excludes_transition_admitted_by_seed(self):
+        menu = tuple([0] * 72 + [255] * 72)
+        transition = tuple([255] * 72 + [0] * 72)
+        entry = {
+            "min_colors": 300,
+            "dims": [2, 1],
+            "min_nonblack_ratio": 0.5,
+            "min_structural_similarity": 0.85,
+            # The old reviewed seed contains both phases, so it alone admits the transition.
+            "structural_references": [
+                {"luma16x9": bytes(menu).hex()},
+                {"luma16x9": bytes(transition).hex()},
+            ],
+        }
+
+        def record(index, signature):
+            return {
+                "index": index,
+                "path": f"frame-{index}.png", "filename": f"frame-{index}.png",
+                "elapsed": float(index), "colors": 335, "dims": (2, 1),
+                "nonblack_ratio": 1.0, "luma16x9": signature,
+            }
+
+        run_a_records = [record(index, menu) for index in range(4)]
+        run_b_records = [record(10, transition)] + [
+            record(index, menu) for index in range(11, 14)
+        ]
+        run_a = {
+            "records": run_a_records,
+            "longest_content_run": SNAPSHOT.longest_content_run(entry, run_a_records),
+            "richest": run_a_records[0],
+        }
+        run_b = {
+            "records": run_b_records,
+            "longest_content_run": SNAPSHOT.longest_content_run(entry, run_b_records),
+            "richest": run_b_records[0],
+        }
+        self.assertEqual([10, 11, 12, 13], [
+            item["index"] for item in run_b["longest_content_run"]])
+        self.assertEqual([11, 12, 13], [
+            item["index"] for item in SNAPSHOT.cross_run_content_run(entry, run_a, run_b)])
+
     def test_entry_env_resolves_route_and_uses_fresh_save(self):
         with tempfile.TemporaryDirectory() as tmp:
             route = os.path.join(tmp, "route.pad")


### PR DESCRIPTION
## Summary

- add an opt-in `min_consecutive_content_matches` contract for checkpoints whose wall-clock phase moves between healthy boots
- require every sampled frame in the plateau to jointly satisfy colour, dimensions, coverage, and structural similarity; missing sampler indices break the streak
- identify each run with existing reviewed seed references, then cross-score A with B-only plateau references and B with A-only plateau references before saving plateau-only evidence
- make ratio and consecutive modes mutually exclusive, require a structural-reference seed, and preserve existing ratio-mode semantics and success output
- widen `terminator-boot` to the bounded 0–62 second boot and approve eight menu-only references from 16 inspected frames

## Root cause

The old Terminator guard assumed the main menu would remain inside a fixed 25–49 second window. It did when the baseline was adopted (~30 seconds), but current healthy fresh-save boots reach it around 42–43 seconds. The old guard therefore saw mostly healthy intro frames: 24 evidence frames contained only 10 structural matches against 16 required, so both release runs failed even though both reached a visually correct menu.

A different fixed window would merely move the same timing assumption. The new opt-in mode profiles the whole bounded boot and requires a sustained, self-identified menu plateau instead. `min_pixel_changes=1` remains only a broad-boot liveness check; the menu milestone is carried by the 15-frame conjoined plateau.

## Discriminating evidence

- two initial fresh-save profiles: seed-local streaks 20/20; opposite-run-validated menu streaks 20/19 (required 15)
- worst cross-run menu SSIM: `0.997173` at a `0.85` threshold
- pre-menu intro/logo negatives: `0/41` and `0/42` matches; best SSIM `0.308162` / `0.328415`
- published unmodified attract-gameplay negative: SSIM `-0.009881` / `-0.011836`
- final rebased verify: local `20/20`, cross-run A→B `20`, B→A `20`, required `15`
- all 16 retained images independently inspected twice; every image is the fully visible, correctly layered main menu with only expected flame/background animation
- two independent post-approval checks: consecutive `19` and `19`, both four frames above the requirement

Representative intended checkpoint (existing tracked project screenshot):

![Terminator 2D: NO FATE main menu](https://raw.githubusercontent.com/mattias800/prosper/master/assets/screenshots/terminator-title.png)

## Defect-shape and mechanism controls

- an interspersed sequence with enough aggregate structural/non-black matches fails because its longest run is one, not three
- a missing sampler index splits an otherwise matching run
- a seed set that admits a transition still produces a transition-free target plateau when cross-scored against the other run
- temporarily replacing the consecutive observation with aggregate structural matches makes `test_consecutive_mode_rejects_enough_total_but_interspersed_matches` fail exactly (`True is not false`); restoring the streak logic returns the suite to green
- a dedicated default-mode test retains the whole-window `ceil(frame_count * ratio)` structural and non-black floors

## Verification

```bash
python3 -m py_compile prosper/tools/snapshot/snapshot.py prosper/tools/snapshot/test_snapshot.py
python3 prosper/tools/snapshot/test_snapshot.py
# Ran 16 tests: OK

mkdir -p <WORKTREE>/.build-tmp
distrobox enter ps5ys -- bash -lc \
  'TMPDIR=<WORKTREE>/.build-tmp cmake --build <WORKTREE>/prosper/build-linux --target screenshot -j2'
# Vulkan enabled; screenshot target built

distrobox enter ps5ys -- bash -lc '
  cd <WORKTREE>/prosper
  export TMPDIR=<WORKTREE>/.snapshot-tmp
  export PROSPER_GAME_ROOT=<REPO_ROOT>
  export PROSPER_SCREENSHOT=<WORKTREE>/prosper/build-linux/screenshot
  python3 tools/snapshot/snapshot.py verify terminator-boot
'
# CONTENT-STABLE: local 20/20; cross-run 20/20; required 15

# After inspecting and approving all 16 retained images:
python3 prosper/tools/snapshot/snapshot.py update terminator-boot --reviewed

# Run twice with the same distrobox environment as verify:
python3 tools/snapshot/snapshot.py check terminator-boot
# OK: frames=61, qualifying=20, changes=55, structural=19, consecutive=19
python3 tools/snapshot/snapshot.py check terminator-boot
# OK: frames=61, qualifying=20, changes=55, structural=19, consecutive=19
```

The full snapshot matrix was intentionally not run; this issue's focused Terminator verify and two independent checks were authorized after rebase. Blue Prince remains separate, so this PR references rather than closes the shared issue.

Refs #1697
