### PR TITLE
feat(gpu): execute sampled 4x MSAA image loads

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,7 @@ shared-GPU policy, the instrument-not-the-subject list, and the dated current ha
 | *Syberia: Remastered* `PPSA30140` | rung 3 — gameplay renders; menu 3D layer and gameplay composite degraded (#1619 / #1627) | `docs/SYBERIA_STATUS.md` |
 | *Dragon Quest VII Reimagined* `PPSA17942` (a.k.a. DOLL) | rung 2 — title, name entry, onboarding; composition defect and gameplay open | `docs/DRAGON_QUEST_STATUS.md` |
 | *Nikoderiko* `PPSA23760` | rung 2 — 3D world dropped; **blocked on #305**, not on the recompiler | `docs/NIKODERIKO_STATUS.md` |
+| *Asterix & Obelix: Babylon Mission* `PPSA30490` | rung 0 — sampled 2D-MSAA resolve executes; output remains black (#1599) | `docs/ASTERIX_BABYLON_STATUS.md` |
 | *The Oregon Trail* `PPSA19244` | rung 0 — the guest issues no base pass; prosper decodes 100% of what it submits | `docs/OREGON_TRAIL_STATUS.md` |
 | *GRIS*, *Space Adventure Cobra*, *Sonic Origins* | rung 3 / rung 3 / incomplete dump | `docs/GRIS_SONIC_COBRA_BRINGUP.md` |
 | Astro Bot, The Plucky Squire, The Pathless | active orchestration lanes | `docs/GAME_COMPAT_ORCHESTRATION.md` |

--- a/prosper/docs/ASTERIX_BABYLON_STATUS.md
+++ b/prosper/docs/ASTERIX_BABYLON_STATUS.md
@@ -1,0 +1,168 @@
+# Asterix & Obelix: Babylon Mission status
+
+Tracking: [#1599](https://github.com/mattias800/prosper/issues/1599)
+
+Title ID: `PPSA30490`
+
+Engine: Unity 6000.1.5f1 / IL2CPP
+
+Current verified rung: **0 — frame submission, but no real visible graphics**
+
+## Current symptom
+
+The title boots and publishes source-distinct renderer frames, but the measured output is still black.
+On the pre-fix baseline, the first instruction shown below was the only unique fragment-stage rejection;
+every draw using that stage was dropped. Capturing and independently disassembling the complete 37-dword
+shader then showed that it is a four-sample resolve: one consecutive-vaddr load followed by three exact
+one-extra-dword NSA loads.
+
+```text
+[recompile-reject] pc=17 words=f0000130,00000305 fmt=14 op=0x0
+                   dst=3 src=5 dmask=0x1 dim=6 len=2
+[exec-recompile-reject] ps=0x20117c0900 vs=1821 fs=0 occurrence=8192
+```
+
+```text
+image_load v3, v[5:7],       s[0:7] dmask:x dim:2D_MSAA  # sample v7 = 2
+image_load v2, [v5, v6, v2], s[0:7] dmask:x dim:2D_MSAA  # sample v2 = 1
+image_load v0, [v5, v6, v0], s[0:7] dmask:x dim:2D_MSAA  # sample v0 = 0
+image_load v1, [v5, v6, v1], s[0:7] dmask:x dim:2D_MSAA  # sample v1 = 3
+```
+
+LLVM `llvm-mc --disassemble -triple=amdgcn-amd-amdhsa -mcpu=gfx1030` independently confirms those
+exact operands. In the NSA form, the fixed VADDR byte names X and the extra address dword's low two
+bytes name Y/sample. Its descriptor resolves exactly as 1920x1080 `R32_FLOAT`, four samples,
+`SW_64KB_Z_X` (mode 24), one guest mip.
+
+On this branch all four instructions compile and the live renderer consumes their bindings; no
+`[recompile-reject]` or `[render-msaa-reject]` occurs. A 30-second run published six source-distinct
+sampled frames while all six remained pure black (`crc=064567f8`). This is generic capability progress,
+not visible title progress, and the compatibility rung remains 0.
+
+The historical renderer-publication stop at roughly 125-138 seconds was a separate guest allocation
+failure and was fixed by #1748. Bounded current runs no longer reproduce that failure; it is not part
+of this MSAA work.
+
+## Implemented contract under test
+
+- `2D_MSAA IMAGE_LOAD` lowers to `OpImageFetch` over a single-sample Vulkan 2D-array image. The four
+  guest sample planes become four host array layers; the explicit guest sample VGPR becomes the layer
+  coordinate. The gate accepts only the independently disassembled consecutive-vaddr packet and the
+  exact one-extra-dword NSA `[x,y,sample]` form with unused address bytes zero. This preserves the
+  instruction's exact texel-fetch semantics without inventing a Vulkan multisample upload path.
+- Descriptor, compiled-shader, capture, upload, and persistent-image identities all retain
+  `sample_count`. A 4x module cannot alias the deliberately unsupported 2x variant.
+- The CPU detiler uses AMD's published 16-pipe GFX10 `SW_64KB_Z_X` 4xaa pattern. Its output is
+  plane-major (`sample * width * height + y * width + x`), directly matching the host array layers.
+- The live frontend accepts only the observed 4x/mode-24/R32F/one-mip reflected texel-fetch shape.
+  It requires the complete padded tiled allocation, owns the resulting pixels, and reuses them inside
+  the submit. Cross-span reuse is allowed only when the ordered write journal proves the complete
+  padded source span unchanged.
+- Unsupported shapes, short authoritative allocations, and ambiguous compression metadata remain
+  visible rejections; no fallback black/zero texture is fabricated.
+
+## HTILE, not DCC
+
+The descriptor's compression bit does not make this mode-24 surface color-DCC data. AMD AddrLib's
+`HwlComputeDccInfo` restricts color DCC to `R_X`, while `HwlComputeHtileInfo` accepts pipe-aligned
+`SW_64KB_Z_X`. For the project's 16-pipe GFX10 configuration, one HTILE meta block is 32 KiB and
+covers 1024x512 pixels; 1920x1080 therefore has an exact 196,608-byte metadata plane.
+
+The live path reads base R32F samples only when the **complete** HTILE plane is uniformly one of PAL's
+documented initialization values that disables Z compression:
+
+- depth-only: `0xFFFC000F`
+- depth+stencil: `0xFFFFF3FF`
+
+The title-live plane is a third, importantly different exact state: all 196,608 bytes are zero. PAL's
+`Gfx9Htile::GetClearValue` proves that this is the depth-only fast-clear encoding for +0.0
+(`ZMin=ZMax=0`, `ZMask=0`). In that state metadata is authoritative and the base allocation is stale;
+the frontend materializes exact +0.0 into all four host layers without reading base memory. This is
+not a fabricated black texture: it is the guest's complete uniform fast-clear value. The gate does not
+generalize to nonzero fast clears or depth+stencil encodings.
+
+The descriptor does not otherwise prove which plane kind the title created, so metadata must prove one
+exact complete state. A one-bit-near value, mixed values, unsupported uniform nonzero data, and a short
+read all reject.
+
+Primary sources:
+
+- [AMD AddrLib GFX10 HTILE/DCC sizing](https://github.com/ROCm/ROCR-Runtime/blob/d614ea8bbd73a7832c265725117274d13041ff06/src/image/addrlib/src/gfx10/gfx10addrlib.cpp)
+- [AMD PAL `Gfx9Htile::GetInitialValue`](https://github.com/GPUOpen-Drivers/pal/blob/c5e800072a32f68b6ccc4422936d96167c6e0728/src/core/hw/gfxip/gfx9/gfx9MaskRam.cpp)
+
+Capture v44 retains both the complete tiled base allocation and this exact HTILE span. Because v44
+added sample count in an append-only tail, the reader defers only the 2D-MSAA metadata-footprint equality
+until that tail is read, then validates it before accepting the capture. Versions 1-43 keep their
+historical single-sample default and cannot claim an MSAA HTILE span.
+
+## Verification
+
+Reduced CPU/structural suites pass for:
+
+- independent sample-bit golden offsets plus multi-block round trips at 1/2/4/8/16 bytes per sample;
+- truncated tiled allocations leaving output untouched;
+- exact T# decode and resource backing size;
+- sample-to-layer `OpImageFetch` structure and reflected 2D-array/non-MS/texel-access contract;
+- exact title NSA address-byte mapping, plus rejection of unused bytes and longer NSA forms;
+- v44 capture round trip and v43 compatibility;
+- 1920x1080 HTILE sizing, both exact decompressed constants, and one-bit/nonuniform/short rejection;
+- uniform-zero HTILE producing exact +0.0 in every texel of all four layers while a poison/NaN base is
+  ignored; one-word-nonuniform, uniform-nonzero, short-footprint, wrong-count/layout/format arms reject;
+- offline replay retaining the complete zero-HTILE blob needed to reproduce metadata-owned output;
+- compiled-cache separation of supported 4x and rejected 2x shader variants.
+
+The reduced Vulkan semantic test uploads four distinct R32F planes and fetches four distinct colors.
+Its short-span and unsupported-count arms reject before Vulkan work. This is not yet title-live visual
+verification and does not advance the compatibility rung.
+
+Mutation evidence:
+
+- aliasing all sample offsets to sample zero breaks the named MSAA golden/round-trip tests;
+- skipping the full HTILE-plane scan breaks exactly the named nonuniform-metadata rejection;
+- disabling uniform-zero recognition breaks exactly the named poison-base depth-zero materialization;
+- removing the len-3 gate breaks the exact title NSA layer test while the consecutive packet survives;
+- changing only the shader table's sample count produces a cache miss and the expected 2x rejection.
+
+Live verification was repeated six bounded times after the NSA form compiled. Two early diagnostic runs
+hit an intermittent compute `VK_ERROR_DEVICE_LOST` at program `0x2011734400`; four subsequent runs did
+not, including the 30-second run, and every run remained black. That event is therefore recorded as
+intermittent and non-causal for the stable black output, not promoted to the next blocker without a
+self-validating reproduction.
+
+## Ruled out
+
+- **Unresolved T#/S# lookup:** the title-live descriptor resolves; the rejection is the sampled MIMG
+  dimension gate, not descriptor discovery.
+- **Ordinary 2D or 2D-array sampling:** this packet is integer-coordinate `IMAGE_LOAD`, and the third
+  coordinate is an explicit sample index. Normalized sampling would change semantics.
+- **The first consecutive-vaddr packet is the complete shader:** the raw 37-dword stage contains three
+  further NSA loads. LLVM independently confirms their `[x,y,sample]` address bytes; a len-2-only gate
+  was a self-invalidating instrument because it rejected at the first len-3 packet.
+- **Ordinary single-sample detiling:** it aliases sample zero and under-reads the padded allocation.
+  The published 4xaa sample bits independently select byte offsets 0/4/8/12 for one R32 texel.
+- **Color DCC code `0xff`:** mode-24 metadata is HTILE. Applying the existing `R_X` DCC footprint or
+  decompressed marker here is the wrong instrument.
+- **Treating all compression-enabled base bytes as readable:** only a complete uniform PAL
+  decompressed HTILE state authorizes base decoding. Uniform zero is separately a metadata-owned
+  depth-only +0.0 fast clear and explicitly ignores base. Anything else still needs a real
+  compressed-depth path and is deliberately unsupported.
+- **A short/unreadable metadata plane behind the former `base-uncompressed=0`:** the corrected
+  diagnostic measured exactly 196,608/196,608 bytes, all zero, on all four bindings.
+- **The intermittent compute device loss as the stable black-frame explanation:** it appeared in two
+  of six bounded runs. Four clean runs, including 30 seconds, remained identically black.
+- **A visible-progress claim from reduced tests:** none has been made. A patched live run and human
+  screenshot are still required.
+- **The historical ~125-second publication stall as the current blocker:** its command-packet/allocation
+  failure was fixed by #1748. The current reproduced blocker is black output from the MSAA shader gap.
+
+## Next discriminators
+
+1. Capture one current black live frame into a replayable bundle and use draw-step/resource inspection
+   to identify which final composite draw writes black. The MSAA stage now executes, so another rejected
+   or semantically wrong producer/composite is downstream.
+2. Treat compute program `0x2011734400` as a candidate only if a discriminator independently proves the
+   dispatch ran and reproduces its device loss; two failures in six runs are not a stable cause.
+3. If output becomes non-black, compare source-distinct/pixel-distinct frames and post a screenshot.
+   Until then, do not update `COMPATIBILITY.md` or claim rung progress.
+4. Once output is useful, route beyond 125 seconds as a regression check for #1748; do not reopen the
+   old allocator diagnosis without a newly reproduced failure.

--- a/prosper/docs/GAME_COMPAT_ORCHESTRATION.md
+++ b/prosper/docs/GAME_COMPAT_ORCHESTRATION.md
@@ -975,9 +975,9 @@ itself turned out to rest on a superseded diagnosis:
 - `PROSPER_DBBASETRACE` **cannot decide this**: it is hardcoded to DB offsets and only fires on a
   nonzero-then-zero-within-one-array signature, so it never fires for a register the guest never writes.
 
-**Next Astro step.** Capture **v43** (PR #1576) retains the raw colour-state triple per draw with presence flags
+**Next Astro step.** Capture format **v43+** (PR #1576) retains the raw colour-state triple per draw with presence flags
 and surfaces it in `--inspect`, which is what makes `cwm=0` attributable offline. The retained bundle is v42, so
-it reports `color-state unavailable` — a **fresh v43 capture** is required. Take one, then determine whether the
+it reports `color-state unavailable` — a **fresh current-format capture** is required. Take one, then determine whether the
 zero masks are genuine guest intent or a prosper defect. If they are genuine intent, "real content exists but
 nothing reaches the screen" via small mipped 4 KiB surfaces becomes the natural next suspect.
 
@@ -1482,7 +1482,7 @@ into a default fix or claim rung 3 from this diagnostic hardening.
 
 | Agent | First bounded task | GPU |
 |---|---|---|
-| Astro Bot | Take a **fresh v43** capture, then attribute the frame-wide `cwm=0` from the raw colour-state triple | One bounded capture |
+| Astro Bot | Take a **fresh current-format** capture, then attribute the frame-wide `cwm=0` from the raw colour-state triple | One bounded capture |
 | Dragon Quest VII | Measure `s97`/`s106` with two `--dump-resource` runs; decide PreExposure versus op103 execution | Two ~2 s runs |
 | The Plucky Squire | Live route: confirm `0x3017460000` executes; identify the next skipped stage | ~10 min routed run |
 | Alex Kidd | Land the snapshot guard; re-check #710 against the tiling fix | Snapshot verify |
@@ -1511,8 +1511,8 @@ Do NOT re-run the R11G11B10 storage fork (falsified: byte-identical output acros
 backend paths), compute-writer closure, submit 6279, or the b49 1x1 control.
 The frontier is that no geometry draw writes colour anywhere in the frame: 28 realized draws
 resolve cwm=0 and cwm1=0. An ABSENT target/shader mask resolves to write-all, so cwm=0 means
-present-and-zero, or MODE=DISABLE. Capture v43 retains the raw triple; the retained bundle is
-v42 and reports "color-state unavailable", so take a FRESH v43 capture first. Then determine
+present-and-zero, or MODE=DISABLE. Capture format v43+ retains the raw triple; the retained bundle is
+v42 and reports "color-state unavailable", so take a FRESH current-format capture first. Then determine
 whether the zero masks are guest intent or a prosper defect. The Gen5 stale-fold prior was
 investigated and NOT confirmed; read the lane notes before reviving it.
 ```

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -361,10 +361,12 @@ struct TextureDecodeKey {
     uint64_t host_data = 0;
     uint64_t host_data_size = 0;
     uint32_t size = 0;
+    uint64_t source_span_bytes = 0;
     uint32_t cls = 0;
     uint32_t format = 0;
     uint32_t num_components = 0;
     uint32_t width = 0, height = 0, depth = 1;
+    uint32_t sample_count = 1;
     uint32_t tile_mode = 0;
     uint32_t linear_row_pitch_bytes = 0;
     uint32_t img_dim = 0;
@@ -390,7 +392,9 @@ struct TextureDecodeKeyHash {
             hash *= 1099511628211ull;
         };
         mix(key.gpu_addr); mix(key.host_data); mix(key.host_data_size); mix(key.size);
+        mix(key.source_span_bytes);
         mix(key.cls); mix(key.format); mix(key.num_components); mix(key.width); mix(key.height); mix(key.depth);
+        mix(key.sample_count);
         mix(key.tile_mode); mix(key.linear_row_pitch_bytes); mix(key.img_dim);
         mix(key.mip_tail_bytes); mix(key.mip_tail_x); mix(key.mip_tail_y);
         mix(key.layer_stride_bytes); mix(key.layer_mip_offset_bytes);
@@ -423,6 +427,10 @@ struct DecodedTexture {
     uint64_t source_addr = 0;
     uint64_t source_size = 0;
     size_t texstore_slot = SIZE_MAX;
+    // Exact 2D-MSAA resolves use an owned plane-major allocation rather than a reusable texstore
+    // slot. Retaining the owner here gives same-submit cache hits the same lifetime guarantee as a
+    // pinned scratch slot, without pinning one ~32 MiB vector per distinct surface forever.
+    std::shared_ptr<const std::vector<uint8_t>> pixels_owner;
 };
 
 // Always-on identity-scope accounting; see TextureDecodeScopeStats in the header.
@@ -506,6 +514,20 @@ bool texture_decode_cache_candidate(bool has_live_color_target,
         !has_captured_host_data &&
         (image_dimension == 1u || image_dimension == 2u || image_dimension == 5u) &&
         is_sampled_texture && format_supported;
+}
+
+bool sampled_msaa_fetch_shape_supported(const prosper::gpu::ShaderResource& resource,
+                                        bool is_storage_image,
+                                        bool reflected_msaa_fetch) {
+    using prosper::gpu::DataFormat;
+    using prosper::gpu::ResourceClass;
+    return resource.cls == ResourceClass::Texture && !is_storage_image &&
+        resource.img_dim == 6u && resource.sample_count == 4u &&
+        resource.tile_mode == 24u && resource.format == DataFormat::Float32 &&
+        resource.num_components == 1u && resource.depth == 1u &&
+        resource.declared_mip_levels == 1u && !resource.in_mip_tail &&
+        resource.mip_tail_bytes == 0u && resource.layer_stride_bytes == 0u &&
+        resource.layer_mip_offset_bytes == 0u && reflected_msaa_fetch;
 }
 
 bool persistent_texture_decode_cache_eligible(bool guest_decode_candidate,
@@ -1600,10 +1622,16 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             r.gpu_addr, r.img_dim, r.in_mip_tail,
                             r.layer_mip_offset_bytes);
                         const bool sampled_2d_view = r.img_dim == 1u || r.img_dim == 5u;
+                        const size_t msaa_tiled_source_span = r.img_dim == 6u
+                            ? prosper::gpu::tiled_msaa_surface_bytes(
+                                  tw, th, r.tile_mode, 4u, r.sample_count)
+                            : 0u;
                         const TextureDecodeKey decode_key{
                             r.gpu_addr, static_cast<uint64_t>(reinterpret_cast<uintptr_t>(r.host_data)),
-                            r.host_data_size, r.size, static_cast<uint32_t>(r.cls),
+                            r.host_data_size, r.size, msaa_tiled_source_span,
+                            static_cast<uint32_t>(r.cls),
                             static_cast<uint32_t>(r.format), r.num_components, tw, th, r.depth,
+                            r.sample_count,
                             r.tile_mode, r.linear_row_pitch_bytes, r.img_dim,
                             r.mip_tail_bytes, r.mip_tail_x, r.mip_tail_y,
                             r.layer_stride_bytes, r.layer_mip_offset_bytes,
@@ -1624,6 +1652,249 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             r.in_mip_tail,
                             avplayer_chroma_layout,
                         };
+                        if (r.img_dim == 6u) {
+                            // GFX10 TYPE=2D_MSAA interleaves the sample coordinate into the tiled
+                            // address. It is neither an ordinary 2D texture nor a native Vulkan
+                            // multisample upload: IMAGE_LOAD names one sample explicitly, so the
+                            // recompiler exposes the samples as four layers of a single-sample 2D
+                            // array. Materialize exactly that representation here. Keep the first
+                            // live contract deliberately as narrow as the observed Asterix surface;
+                            // unsupported sample counts/layouts/formats must remain fail-visible.
+                            const bool reflected_msaa_fetch =
+                                reflected_binding->kind ==
+                                    prosper::gpu::SpirvDescriptorKind::CombinedImageSampler &&
+                                reflected_binding->image_dim == 1u &&
+                                reflected_binding->image_arrayed &&
+                                !reflected_binding->image_multisampled &&
+                                reflected_binding->texel_access &&
+                                !reflected_binding->normalized_sampling;
+                            const bool exact_msaa_shape = sampled_msaa_fetch_shape_supported(
+                                r, fr.is_storage_image, reflected_msaa_fetch);
+
+                            prosper::gpu::Gfx10HtileMsaaSource htile_source =
+                                r.compression_enabled
+                                    ? prosper::gpu::Gfx10HtileMsaaSource::Unsupported
+                                    : prosper::gpu::Gfx10HtileMsaaSource::UncompressedBase;
+                            uint32_t decompressed_htile_value = 0;
+                            std::vector<uint8_t> htile_metadata;
+                            size_t htile_metadata_got = 0;
+                            if (exact_msaa_shape && r.compression_enabled) {
+                                const uint64_t metadata_size =
+                                    prosper::gpu::gpu_capture_dcc_metadata_footprint(r);
+                                htile_metadata.resize(
+                                    static_cast<size_t>(metadata_size), 0);
+                                htile_metadata_got = metadata_size
+                                    ? copy_dcc_metadata(htile_metadata.data(),
+                                                        htile_metadata.size())
+                                    : 0u;
+                                // Mode-24 MSAA metadata is HTILE, not color DCC. The two exact PAL
+                                // initialization dwords disable depth compression for depth-only and
+                                // depth+stencil surfaces respectively. The metadata itself must prove
+                                // one uniform state across the complete AddrLib-sized plane; every
+                                // compressed, nonuniform, ambiguous, or short state remains rejected.
+                                htile_source = prosper::gpu::gfx10_htile_msaa_source(
+                                    htile_metadata.data(), htile_metadata_got,
+                                    tw, th, r.tile_mode, 4u, r.sample_count,
+                                    r.meta_pipe_aligned);
+                                if (htile_source ==
+                                    prosper::gpu::Gfx10HtileMsaaSource::UncompressedBase) {
+                                    prosper::gpu::gfx10_htile_metadata_is_decompressed(
+                                        htile_metadata.data(), htile_metadata_got,
+                                        htile_metadata.size(), &decompressed_htile_value);
+                                }
+                            }
+
+                            const bool uncompressed_base = htile_source ==
+                                prosper::gpu::Gfx10HtileMsaaSource::UncompressedBase;
+                            const bool depth_zero_fast_clear = htile_source ==
+                                prosper::gpu::Gfx10HtileMsaaSource::DepthZeroFastClear;
+                            const bool materializable_msaa = exact_msaa_shape &&
+                                (uncompressed_base || depth_zero_fast_clear);
+                            const size_t tiled_bytes = exact_msaa_shape && uncompressed_base
+                                ? msaa_tiled_source_span : 0u;
+                            const uint64_t linear_bytes64 =
+                                static_cast<uint64_t>(tw) * th * r.sample_count * 4u;
+                            if (!materializable_msaa || !linear_bytes64 ||
+                                linear_bytes64 > SIZE_MAX) {
+                                static uint32_t rejected = 0;
+                                const uint32_t ordinal = ++rejected;
+                                if (ordinal <= 32u) {
+                                    uint32_t htile_first = 0;
+                                    uint32_t htile_first_different = 0;
+                                    size_t htile_dwords_different = 0;
+                                    if (htile_metadata_got == htile_metadata.size() &&
+                                        htile_metadata.size() >= sizeof(uint32_t) &&
+                                        (htile_metadata.size() % sizeof(uint32_t)) == 0u) {
+                                        std::memcpy(&htile_first, htile_metadata.data(),
+                                                    sizeof(htile_first));
+                                        for (size_t offset = sizeof(uint32_t);
+                                             offset < htile_metadata.size();
+                                             offset += sizeof(uint32_t)) {
+                                            uint32_t value = 0;
+                                            std::memcpy(&value, htile_metadata.data() + offset,
+                                                        sizeof(value));
+                                            if (value != htile_first) {
+                                                if (!htile_dwords_different)
+                                                    htile_first_different = value;
+                                                ++htile_dwords_different;
+                                            }
+                                        }
+                                    }
+                                    fprintf(stderr,
+                                            "[render-msaa-reject] ordinal=%u set=%u binding=%u "
+                                            "addr=0x%llx "
+                                            "%ux%u samples=%u fmt=%u/%u tile=%u compression=%d "
+                                            "shape=%d reflected=%d base-uncompressed=%d "
+                                            "depth-zero-fast-clear=%d "
+                                            "htile=%zu/%zu first=0x%08x first-different=0x%08x "
+                                            "dwords-different=%zu\n",
+                                            ordinal, set, r.binding,
+                                            (unsigned long long)r.gpu_addr,
+                                            tw, th, r.sample_count, (unsigned)r.format,
+                                            r.num_components, r.tile_mode,
+                                            static_cast<int>(r.compression_enabled),
+                                            static_cast<int>(exact_msaa_shape),
+                                            static_cast<int>(reflected_msaa_fetch),
+                                            static_cast<int>(uncompressed_base),
+                                            static_cast<int>(depth_zero_fast_clear),
+                                            htile_metadata_got, htile_metadata.size(), htile_first,
+                                            htile_first_different, htile_dwords_different);
+                                }
+                                continue;
+                            }
+
+                            // Captured backing and DCC metadata cannot use the one-range journal
+                            // proof across callback spans. They still reuse safely inside the span
+                            // that decoded them. Plain guest backing may cross spans only while the
+                            // ordered write journal proves the complete padded tiled allocation was
+                            // untouched.
+                            const uint64_t cross_span_source_size =
+                                !r.host_data && !r.compression_enabled ? tiled_bytes : 0u;
+                            auto reused = decoded_textures.find(decode_key);
+                            if (reused != decoded_textures.end()) {
+                                const bool same_span =
+                                    reused->second.span == decode_span_ordinal;
+                                const prosper::gpu::GuestGpuWriteQuery journal_query = same_span
+                                    ? prosper::gpu::GuestGpuWriteQuery::Unknown
+                                    : prosper::gpu::guest_gpu_writes_since(
+                                          reused->second.snapshot,
+                                          reused->second.source_addr,
+                                          reused->second.source_size);
+                                if (!submit_local_texture_decode_reusable(
+                                        reused->second.span, decode_span_ordinal,
+                                        reused->second.source_addr, reused->second.source_size,
+                                        sampled_source_addr, cross_span_source_size,
+                                        journal_query) || !reused->second.pixels_owner) {
+                                    decoded_textures.erase(reused);
+                                    reused = decoded_textures.end();
+                                    ++g_texture_decode_scope.invalidations;
+                                }
+                            }
+
+                            if (reused != decoded_textures.end()) {
+                                fr.tex_rgba_owner = reused->second.pixels_owner;
+                                fr.tex_rgba = reused->second.pixels;
+                                resource_local_reuse = true;
+                                if (reused->second.span == decode_span_ordinal) {
+                                    ++g_texture_decode_scope.same_span_reuses;
+                                } else {
+                                    ++g_texture_decode_scope.cross_span_reuses;
+                                    reused->second.snapshot =
+                                        prosper::gpu::guest_gpu_write_snapshot();
+                                }
+                                if (timing_enabled) pending_timing.texture_reuses++;
+                            } else {
+                                std::vector<uint8_t> tiled;
+                                size_t copied = 0;
+                                if (uncompressed_base) {
+                                    tiled.resize(tiled_bytes, 0);
+                                    copied = copy_resource(
+                                        tiled.data(), sampled_source_addr, tiled.size());
+                                }
+                                std::vector<uint8_t> linear(
+                                    static_cast<size_t>(linear_bytes64), 0);
+                                prosper::gpu::Gfx10HtileMsaaSource realized_source =
+                                    prosper::gpu::Gfx10HtileMsaaSource::Unsupported;
+                                const bool materialized = r.compression_enabled
+                                    ? prosper::gpu::materialize_gfx10_htile_msaa_surface(
+                                          linear.data(), linear.size(),
+                                          tiled.empty() ? nullptr : tiled.data(), copied,
+                                          htile_metadata.data(), htile_metadata_got,
+                                          tw, th, r.tile_mode, 4u, r.sample_count,
+                                          r.meta_pipe_aligned, &realized_source)
+                                    : (copied == tiled.size() &&
+                                       prosper::gpu::detile_msaa_surface(
+                                           linear.data(), tiled.data(), copied, tw, th,
+                                           r.tile_mode, 4u, r.sample_count));
+                                if (!materialized ||
+                                    (r.compression_enabled && realized_source != htile_source)) {
+                                    static uint32_t short_sources = 0;
+                                    if (short_sources++ < 32u)
+                                        fprintf(stderr,
+                                                "[render-msaa-reject] set=%u binding=%u addr=0x%llx "
+                                                "source=%zu/%zu bytes\n",
+                                                set, r.binding, (unsigned long long)r.gpu_addr,
+                                                copied, tiled.size());
+                                    continue;
+                                }
+
+                                fr.tex_rgba_owner =
+                                    std::make_shared<const std::vector<uint8_t>>(std::move(linear));
+                                fr.tex_rgba = fr.tex_rgba_owner->data();
+                                ++g_texture_decode_scope.decodes;
+                                DecodedTexture decoded;
+                                decoded.pixels = fr.tex_rgba;
+                                decoded.output_height = th;
+                                decoded.span = decode_span_ordinal;
+                                decoded.snapshot = prosper::gpu::guest_gpu_write_snapshot();
+                                decoded.source_addr = sampled_source_addr;
+                                decoded.source_size = cross_span_source_size;
+                                decoded.pixels_owner = fr.tex_rgba_owner;
+                                decoded_textures.emplace(decode_key, std::move(decoded));
+                            }
+                            fr.tex_byte_size = fr.tex_rgba_owner->size();
+                            fr.tw = tw;
+                            fr.th = th;
+                            fr.td = 1u;
+                            fr.img_dim = r.img_dim;
+                            fr.sample_count = r.sample_count;
+                            fr.declared_mip_levels = 1u;
+                            fr.texture_format = VK_FORMAT_R32_SFLOAT;
+                            resource_texture_source_bytes = depth_zero_fast_clear
+                                ? htile_metadata.size() : tiled_bytes;
+                            if (decompressed_htile_value && getenv("PROSPER_GFXLOG")) {
+                                static uint32_t logged = 0;
+                                if (logged++ < 16u)
+                                    fprintf(stderr,
+                                            "[render-msaa] addr=0x%llx %ux%u samples=%u "
+                                            "decompressed-htile=0x%08x source=%zu bytes\n",
+                                            (unsigned long long)r.gpu_addr, tw, th,
+                                            r.sample_count, decompressed_htile_value, tiled_bytes);
+                            }
+                            if (depth_zero_fast_clear && getenv("PROSPER_GFXLOG")) {
+                                static uint32_t logged_zero_clear = 0;
+                                const uint32_t ordinal = ++logged_zero_clear;
+                                if (ordinal <= 16u)
+                                    fprintf(stderr,
+                                            "[render-msaa] ordinal=%u addr=0x%llx %ux%u "
+                                            "samples=%u depth-zero-fast-clear metadata=%zu bytes\n",
+                                            ordinal, (unsigned long long)r.gpu_addr, tw, th,
+                                            r.sample_count, htile_metadata.size());
+                            }
+
+                            fr.mag_filter = r.mag_filter;
+                            fr.min_filter = r.min_filter;
+                            fr.mip_filter = r.mip_filter;
+                            fr.addr_uvw[0] = r.addr_uvw[0];
+                            fr.addr_uvw[1] = r.addr_uvw[1];
+                            fr.addr_uvw[2] = r.addr_uvw[2];
+                            fr.border_color_type = r.border_color_type;
+                            fr.min_lod = r.min_lod;
+                            fr.max_lod = r.max_lod;
+                            fr.lod_bias = r.lod_bias;
+                            fr.max_aniso_ratio = r.max_aniso_ratio;
+                            for (int k = 0; k < 4; ++k) fr.swizzle[k] = r.swizzle[k];
+                        } else {
                         auto live_rtt = rtt_on ? g_rtt.find(sampled_source_addr) : g_rtt.end();
                         static const uint32_t render_scale = [] {
                             const char* e = std::getenv("PROSPER_RENDER_SCALE");
@@ -3626,8 +3897,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                             for (auto it = decoded_textures.begin();
                                                  it != decoded_textures.end();) {
                                                 const uint64_t cached_addr = it->first.gpu_addr;
-                                                const uint64_t cached_bytes =
-                                                    std::max<uint64_t>(it->first.size, 1u);
+                                                const uint64_t cached_bytes = std::max<uint64_t>(
+                                                    std::max<uint64_t>(it->first.size,
+                                                                       it->first.source_span_bytes),
+                                                    1u);
                                                 const bool overlaps = cached_addr <= guest_addr
                                                     ? guest_addr - cached_addr < cached_bytes
                                                     : cached_addr - guest_addr < guest_bytes;
@@ -3688,6 +3961,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                         // black scene whose textures decode to real RGB but composite to nothing — if the
                         // level appears with this, the alpha channel (decode or DST_SEL swizzle) is the bug (#300).
                         if (getenv("PROSPER_ALPHA1")) fr.swizzle[3] = 1;
+                        }
                     } else {
                         fr.buffer_identity = r.gpu_addr;
                         const prosper::gpu::StorageBufferMaterializationPlan materialization =
@@ -3846,6 +4120,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                         if (fr.is_texture()) {
                             pending_timing.textures++;
                             pending_timing.texture_bytes += static_cast<uint64_t>(fr.tw) * fr.th * fr.td *
+                                fr.sample_count *
                                 prosper::test::backend_color_bytes_per_pixel(fr.texture_format);
                             pending_timing.texture_ms += elapsed;
                             const uint64_t detail_min_submit = getenv("PROSPER_RENDER_TIMING_DETAIL_MIN_SUBMIT")

--- a/prosper/frontends/shared/live_renderer.hpp
+++ b/prosper/frontends/shared/live_renderer.hpp
@@ -96,6 +96,12 @@ bool texture_decode_cache_candidate(bool has_live_color_target,
                                     bool is_sampled_texture,
                                     bool format_supported);
 
+// Exact frontend shape for guest 2D_MSAA IMAGE_LOAD represented as four R32F array layers.
+// Exposed so a regression can prove nearby counts/formats/layouts remain fail-visible before upload.
+bool sampled_msaa_fetch_shape_supported(const prosper::gpu::ShaderResource& resource,
+                                        bool is_storage_image,
+                                        bool reflected_msaa_fetch);
+
 // Apply the remaining runtime gates to a texture_decode_cache_candidate(). Keeping the candidate
 // explicit is important: DCC metadata can provide a nonzero source span even when renderer-owned
 // color is authoritative, but that metadata must never make guest decode-cache state eligible.

--- a/prosper/src/gpu/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc_shader_layout.cpp
@@ -356,6 +356,7 @@ DecodedImageDescriptor decode_image_descriptor(const uint32_t t[8]) {
     d.last_level = (t[3] >> 16) & 0xFu;
     d.max_mip    = (t[5] >> 4) & 0xFu;
     d.type      = (uint8_t)((t[3] >> 28) & 0xFu);                                                  // Type
+    d.sample_count = (d.type == 14 || d.type == 15) ? (1u << d.last_level) : 1u;
     // WORD4.DEPTH is depth-1 for 3D, but the LAST_ARRAY slice for array resources.  BASE_ARRAY is
     // the first selected slice, so an array view contains last-first+1 layers (not last+1).
     const uint32_t depth_or_last = t[4] & 0x1FFFu;
@@ -911,8 +912,9 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
             r.width         = view.width;
             r.height        = view.height;
             r.depth         = d.depth;
-            r.declared_mip_levels =
-                d.last_level >= d.base_level ? (uint32_t)(d.last_level - d.base_level) + 1u : 1u;
+            r.sample_count  = d.sample_count;
+            r.declared_mip_levels = d.sample_count > 1u ? 1u :
+                (d.last_level >= d.base_level ? (uint32_t)(d.last_level - d.base_level) + 1u : 1u);
             r.tile_mode     = d.tile_mode;          // so the renderer can auto-detile a GPU-tiled surface
             r.in_mip_tail   = view.in_mip_tail;
             r.mip_tail_offset = view.in_mip_tail
@@ -944,9 +946,12 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
                 fprintf(stderr, "[t#] SRGB texture fmt=%u %ux%u (binding %u)\n", d.format, d.width, d.height, r.binding);
             // Backing byte size: block-compressed surfaces store one bytes_per_block unit per 4x4 block
             // (ceil dims); uncompressed store bytes_per_block per texel (fmt=56 -> *4).
-            const uint64_t backing_bytes = is_bcn
+            const uint64_t backing_bytes_per_sample = is_bcn
                 ? static_cast<uint64_t>((view.width + 3) / 4) * ((view.height + 3) / 4) * d.depth * fi.bytes_per_block
                 : static_cast<uint64_t>(view.width) * view.height * d.depth * fi.bytes_per_block;
+            if (!d.sample_count || backing_bytes_per_sample > UINT32_MAX / d.sample_count) {
+                tex_drop(slot, off, "implausible multisample backing byte size"); continue; }
+            const uint64_t backing_bytes = backing_bytes_per_sample * d.sample_count;
             if (!backing_bytes || backing_bytes > UINT32_MAX) {
                 tex_drop(slot, off, "implausible backing byte size"); continue; }
             r.size = static_cast<uint32_t>(backing_bytes);

--- a/prosper/src/gpu/agc_shader_layout.hpp
+++ b/prosper/src/gpu/agc_shader_layout.hpp
@@ -153,6 +153,10 @@ struct DecodedImageDescriptor {
     uint8_t  type = 0;        // SQ_RSRC_IMG dim (GFX10: 8=1D, 9=2D, 10=3D, 11=CUBE, 12=1D_ARRAY, 13=2D_ARRAY).
                               // NB: 9 = plain 2D (already handled); 2D_ARRAY is 13 — the decode code in
                               // agc_shader_layout.cpp / gpu_executor.cpp uses these correct values (#378).
+    // For TYPE 14/15 (2D_MSAA[/ARRAY]), LAST_LEVEL is log2(fragment/sample count), not a mip index.
+    // Keeping the decoded count explicit prevents the ordinary mip-chain logic from interpreting the
+    // observed LAST_LEVEL=2 descriptor as three mips instead of four samples.
+    uint32_t sample_count = 1;
     // DST_SEL_X/Y/Z/W channel swizzle (WORD3 [2:0]/[5:3]/[8:6]/[11:9]); SQ_SEL enum:
     // 0=0, 1=1, 4=X(R), 5=Y(G), 6=Z(B), 7=W(A). Default = identity (R,G,B,A).
     uint8_t  dst_sel[4] = {4, 5, 6, 7};

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -99,7 +99,10 @@ constexpr char kMagic[8] = {'P','R','G','P','C','A','P','\0'};
 // registers is PRESENT with value zero, or MODE is DISABLE. Those causes demand different fixes and
 // only the raw registers separate them. Append-only tail; v1-v42 prefixes stay byte-exact and older
 // captures report the state as unavailable rather than inventing write-all defaults.
-constexpr uint32_t kVersion = 43;
+// v44: retain each resource's guest sample count. 2D_MSAA image_load is materialized as host array
+// layers, so replay must not collapse four guest sample planes to the historical single-layer default.
+// The append-only tail covers realized draw/compute and failed-stage tables; v1-v43 default to one.
+constexpr uint32_t kVersion = 44;
 constexpr uint32_t kEndian = 0x01020304u;
 constexpr uint64_t kMaxFileBytes = 4ull << 30;
 constexpr uint64_t kMaxBlobBytes = 1ull << 30;
@@ -481,6 +484,7 @@ bool read_resource(Reader& rd, GpuCapturedResource& c, uint32_t version) {
         !rd.u32(r.stride) || !rd.u32(r.srt_offset) || !rd.u32(r.sgpr_base) || !rd.u32(r.fetch_pc) ||
         !rd.u32(r.img_dim) || !rd.u32(r.width) || !rd.u32(r.height)) return false;
     r.depth = 1;
+    r.sample_count = 1;
     r.depth_compare = false;
     if (!rd.u32(r.tile_mode) || !rd.u8(b)) return false;
     r.srgb = b != 0;
@@ -551,11 +555,15 @@ uint64_t resource_footprint_impl(const ShaderResource& r, bool legacy_linear_tig
             (r.format == DataFormat::Float32 && (bpt == 4 || bpt == 8 || bpt == 16));
         if (bpt == 0 || (bpt > 4 && !native_wide)) bpt = 4;
         if (tile_mode_is_tiled(r.tile_mode)) {
-            if (r.img_dim == 2u && r.depth > 1u) {
+            const bool tiled_msaa = r.img_dim == 6u && r.sample_count > 1u;
+            if (tiled_msaa) {
+                decoded = tiled_msaa_surface_bytes(
+                    w, h, r.tile_mode, bpt, r.sample_count);
+            } else if (r.img_dim == 2u && r.depth > 1u) {
                 decoded = tiled_volume_bytes(w, h, r.depth, r.tile_mode, bpt);
                 decoded_is_volume = decoded != 0;
             }
-            if (!decoded_is_volume)
+            if (!tiled_msaa && !decoded_is_volume)
                 decoded = tiled_surface_bytes(w, h, r.tile_mode, 0, bpt);
         } else if (r.tile_mode == static_cast<uint32_t>(TileMode::Linear) &&
                    ((r.cls == ResourceClass::Texture && r.img_dim == 1u) ||
@@ -568,6 +576,8 @@ uint64_t resource_footprint_impl(const ShaderResource& r, bool legacy_linear_tig
             decoded = checked_mul(row_pitch, h);
         } else {
             decoded = checked_mul(checked_mul(w, h), bpt);
+            if (r.img_dim == 6u && r.sample_count > 1u)
+                decoded = checked_mul(decoded, r.sample_count);
         }
     }
     if (r.layer_stride_bytes && layers > 1) {
@@ -597,6 +607,12 @@ uint64_t dcc_metadata_footprint(const ShaderResource& r) {
         (r.cls != ResourceClass::Texture && r.cls != ResourceClass::StorageImage) ||
         bc_block_bytes(r.format))
         return 0;
+    // A compressed 2D_MSAA Z_X descriptor names HTILE, not color DCC. Retain the exact published
+    // 16-pipe metadata span so offline replay can independently prove whether the base allocation
+    // was decompressed. Other Z_X shapes remain unavailable instead of borrowing DCC sizing.
+    if (r.img_dim == 6u && r.format == DataFormat::Float32 && r.num_components == 1u)
+        return gfx10_htile_msaa_metadata_bytes(
+            r.width, r.height, r.tile_mode, r.sample_count, r.meta_pipe_aligned);
     uint32_t bytes_per_texel = data_format_bytes(r.format) * (r.num_components ? r.num_components : 1u);
     if (!bytes_per_texel &&
         (r.format == DataFormat::Float10_11_11 || r.format == DataFormat::Unorm2_10_10_10))
@@ -2310,6 +2326,35 @@ bool serialize_gpu_capture(const GpuCaptureFile& c, std::vector<uint8_t>& bytes,
     w.u32(static_cast<uint32_t>(c.failure_diagnostics.size()));
     for (const auto& diagnostic : c.failure_diagnostics)
         if (diagnostic.pipeline_present) write_color_state(w, diagnostic.pipeline);
+    // v44 appends guest sample counts in deterministic resource-table order. Failed-stage tables are
+    // included because offline raw retry consumes their descriptor identity just like realized tables.
+    const uint64_t sample_resource_count = resource_depth_count + failed_resource_count;
+    if (sample_resource_count > UINT32_MAX) {
+        error = "invalid resource sample-count count";
+        return false;
+    }
+    w.u32(static_cast<uint32_t>(sample_resource_count));
+    auto write_sample_counts = [&](const GpuCapturedTable& table) {
+        for (const auto& captured : table.resources) {
+            const uint32_t samples = captured.resource.sample_count;
+            if (!samples || samples > 32768u || (samples & (samples - 1u)) != 0) return false;
+            w.u32(samples);
+        }
+        return true;
+    };
+    for (const auto& draw : c.draws)
+        if (!write_sample_counts(draw.vrt) || !write_sample_counts(draw.prt)) {
+            error = "invalid resource sample count"; return false;
+        }
+    for (const auto& compute : c.computes)
+        if (!write_sample_counts(compute.resources)) {
+            error = "invalid resource sample count"; return false;
+        }
+    for (const auto& diagnostic : c.failure_diagnostics)
+        for (const auto& stage : diagnostic.stages)
+            if (!write_sample_counts(stage.resource_table)) {
+                error = "invalid resource sample count"; return false;
+            }
     if (w.data.size() > kMaxFileBytes) { error = "capture file exceeds 4 GiB"; return false; }
     bytes = std::move(w.data);
     return true;
@@ -2653,10 +2698,17 @@ bool deserialize_gpu_capture(const std::vector<uint8_t>& bytes, GpuCaptureFile& 
         }
         auto read_dcc_metadata = [&](GpuCapturedTable& table) {
             for (auto& captured : table.resources) {
+                // v44 kept append-only compatibility, so a 2D_MSAA sample count is serialized
+                // after this v12 metadata-reference tail. Defer only its footprint equality until
+                // that authoritative count has been read; blob bounds and all other invariants are
+                // still checked here. Older versions cannot represent the multi-sample span.
+                const bool defer_msaa_footprint = version >= 44 &&
+                    captured.resource.img_dim == 6u;
                 if (!r.u64(captured.metadata_size) ||
                     !r.u32(captured.metadata_blob_index) ||
                     !r.u64(captured.metadata_blob_offset) ||
-                    captured.metadata_size != dcc_metadata_footprint(captured.resource) ||
+                    (!defer_msaa_footprint &&
+                     captured.metadata_size != dcc_metadata_footprint(captured.resource)) ||
                     (!captured.metadata_size &&
                      (captured.metadata_blob_index != 0xFFFFFFFFu ||
                       captured.metadata_blob_offset != 0)) ||
@@ -3298,6 +3350,62 @@ bool deserialize_gpu_capture(const std::vector<uint8_t>& bytes, GpuCaptureFile& 
         for (auto& diagnostic : c.failure_diagnostics) if (diagnostic.pipeline_present)
             if (!read_color_state(r, diagnostic.pipeline)) {
                 error = "invalid color-state failure record"; return false;
+            }
+    }
+    if (version >= 44) {   // guest sample count; v1-v43 retain ShaderResource's default of one
+        size_t expected = 0;
+        for (const auto& draw : c.draws)
+            expected += draw.vrt.resources.size() + draw.prt.resources.size();
+        for (const auto& compute : c.computes)
+            expected += compute.resources.resources.size();
+        for (const auto& diagnostic : c.failure_diagnostics)
+            for (const auto& stage : diagnostic.stages)
+                expected += stage.resource_table.resources.size();
+        uint32_t count = 0;
+        if (!r.u32(count) || count != expected) {
+            error = "invalid resource sample-count count"; return false;
+        }
+        auto read_sample_counts = [&](GpuCapturedTable& table) {
+            for (auto& captured : table.resources) {
+                uint32_t samples = 0;
+                if (!r.u32(samples) || !samples || samples > 32768u ||
+                    (samples & (samples - 1u)) != 0) return false;
+                captured.resource.sample_count = samples;
+            }
+            return true;
+        };
+        for (auto& draw : c.draws)
+            if (!read_sample_counts(draw.vrt) || !read_sample_counts(draw.prt)) {
+                error = "invalid resource sample count"; return false;
+            }
+        for (auto& compute : c.computes)
+            if (!read_sample_counts(compute.resources)) {
+                error = "invalid resource sample count"; return false;
+            }
+        for (auto& diagnostic : c.failure_diagnostics)
+            for (auto& stage : diagnostic.stages)
+                if (!read_sample_counts(stage.resource_table)) {
+                    error = "invalid resource sample count"; return false;
+                }
+        // Only realized draw/compute tables have v12 metadata blob references. Failed-stage tables
+        // retain descriptor/DCC state through v41 and sample identity through v44, but deliberately
+        // carry no resource or metadata blobs; there is therefore no deferred reference to validate
+        // for those diagnostic tables.
+        auto validate_deferred_msaa_metadata = [&](const GpuCapturedTable& table) {
+            for (const auto& captured : table.resources)
+                if (captured.resource.img_dim == 6u &&
+                    captured.metadata_size != dcc_metadata_footprint(captured.resource))
+                    return false;
+            return true;
+        };
+        for (const auto& draw : c.draws)
+            if (!validate_deferred_msaa_metadata(draw.vrt) ||
+                !validate_deferred_msaa_metadata(draw.prt)) {
+                error = "invalid resource DCC metadata reference"; return false;
+            }
+        for (const auto& compute : c.computes)
+            if (!validate_deferred_msaa_metadata(compute.resources)) {
+                error = "invalid resource DCC metadata reference"; return false;
             }
     }
     for (auto& draw : c.draws) restore_legacy_color_target_aliases(draw);

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -158,6 +158,7 @@ struct ShaderResourceCompileKey {
     uint32_t height = 0;
     uint32_t depth = 0;
     uint32_t img_dim = 0;
+    uint32_t sample_count = 1;
     bool in_mip_tail = false;
     bool compression_enabled = false;
     uint32_t binding = 0;
@@ -338,6 +339,7 @@ struct ShaderCompileKeyHash {
             hash = hash_mix(hash, resource.height);
             hash = hash_mix(hash, resource.depth);
             hash = hash_mix(hash, resource.img_dim);
+            hash = hash_mix(hash, resource.sample_count);
             hash = hash_mix(hash, resource.in_mip_tail);
             hash = hash_mix(hash, resource.compression_enabled);
             hash = hash_mix(hash, resource.binding);
@@ -1015,6 +1017,7 @@ ShaderCompileKey make_shader_compile_key(ShaderProgramStage stage, const uint32_
             compiled.height = atomic_extent ? resource.height : 0u;
             compiled.depth = storage_image ? resource.depth : 0u;
             compiled.img_dim = (texture || storage_image) ? resource.img_dim : 0u;
+            compiled.sample_count = (texture || storage_image) ? resource.sample_count : 1u;
             compiled.in_mip_tail = storage_image && resource.in_mip_tail;
             compiled.compression_enabled = storage_image && resource.compression_enabled;
             compiled.binding = resource.binding;
@@ -3962,7 +3965,8 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
                         for (auto& r0 : t.resources)
                             if (r0.cls == wanted && r0.gpu_addr == view.base &&
                                 r0.width == view.width && r0.height == view.height &&
-                                r0.depth == d.depth && r0.format == fi.format && r0.img_dim == img_dim &&
+                                r0.depth == d.depth && r0.format == fi.format &&
+                                r0.img_dim == img_dim && r0.sample_count == d.sample_count &&
                                 r0.depth_compare == u.is_depth_compare &&
                                 r0.in_mip_tail == view.in_mip_tail &&
                                 r0.mip_tail_offset == (view.in_mip_tail ? view.mip_offset : 0) &&
@@ -3979,8 +3983,10 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
                     r.cls = wanted;
                     r.format = fi.format; r.num_components = fi.num_components;
                     r.gpu_addr = view.base; r.width = view.width; r.height = view.height; r.depth = d.depth;
-                    r.declared_mip_levels =
-                        d.last_level >= d.base_level ? (uint32_t)(d.last_level - d.base_level) + 1u : 1u;
+                    r.sample_count = d.sample_count;
+                    r.declared_mip_levels = d.sample_count > 1u ? 1u :
+                        (d.last_level >= d.base_level ?
+                            (uint32_t)(d.last_level - d.base_level) + 1u : 1u);
                     r.tile_mode = d.tile_mode; r.srgb = fi.srgb;
                     r.in_mip_tail = view.in_mip_tail;
                     r.mip_tail_offset = view.in_mip_tail
@@ -4005,9 +4011,12 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
                     r.depth_compare = u.is_depth_compare;
                     r.swizzle[0] = d.dst_sel[0]; r.swizzle[1] = d.dst_sel[1];
                     r.swizzle[2] = d.dst_sel[2]; r.swizzle[3] = d.dst_sel[3];
-                    const uint64_t backing_bytes = is_bcn
+                    const uint64_t backing_bytes_per_sample = is_bcn
                         ? static_cast<uint64_t>((view.width + 3) / 4) * ((view.height + 3) / 4) * d.depth * fi.bytes_per_block
                         : static_cast<uint64_t>(view.width) * view.height * d.depth * fi.bytes_per_block;
+                    if (!d.sample_count ||
+                        backing_bytes_per_sample > UINT32_MAX / d.sample_count) continue;
+                    const uint64_t backing_bytes = backing_bytes_per_sample * d.sample_count;
                     if (!backing_bytes || backing_bytes > UINT32_MAX) continue;
                     r.size = static_cast<uint32_t>(backing_bytes);
                     r.srt_offset = clash ? 0xFFFFFFFFu : u.key;   // ambiguous/absent key: pc-only provenance
@@ -4388,7 +4397,8 @@ std::vector<ComputeItem> realize_compute_dispatches(
                             if (r0.cls == wanted && r0.gpu_addr == view.base &&
                                 r0.width == view.width && r0.height == view.height &&
                                 r0.depth == d.depth && r0.format == view_format &&
-                                r0.img_dim == img_dim && r0.depth_compare == u.is_depth_compare &&
+                                r0.img_dim == img_dim && r0.sample_count == d.sample_count &&
+                                r0.depth_compare == u.is_depth_compare &&
                                 r0.in_mip_tail == view.in_mip_tail &&
                                 r0.mip_tail_offset == (view.in_mip_tail ? view.mip_offset : 0) &&
                                 r0.mip_tail_x == view.mip_tail_x &&
@@ -4405,22 +4415,31 @@ std::vector<ComputeItem> realize_compute_dispatches(
                     if (mapped_fmt) {
                         r.format = fi.format; r.num_components = fi.num_components;
                         const bool is_bcn = fi.block_width > 1;
-                        const uint64_t bytes = is_bcn
+                        const uint64_t bytes_per_sample = is_bcn
                             ? static_cast<uint64_t>((view.width + 3) / 4) * ((view.height + 3) / 4) * d.depth * fi.bytes_per_block
                             : static_cast<uint64_t>(view.width) * view.height * d.depth * fi.bytes_per_block;
+                        if (!d.sample_count || bytes_per_sample > UINT32_MAX / d.sample_count)
+                            continue;
+                        const uint64_t bytes = bytes_per_sample * d.sample_count;
                         if (!bytes || bytes > UINT32_MAX) continue;
                         r.size = static_cast<uint32_t>(bytes);
                         r.srgb = fi.srgb;
                     } else {
-                        const uint64_t bytes = static_cast<uint64_t>(d.width) * d.height * d.depth * 4;
+                        const uint64_t bytes_per_sample =
+                            static_cast<uint64_t>(d.width) * d.height * d.depth * 4;
+                        if (!d.sample_count || bytes_per_sample > UINT32_MAX / d.sample_count)
+                            continue;
+                        const uint64_t bytes = bytes_per_sample * d.sample_count;
                         if (!bytes || bytes > UINT32_MAX) continue;
                         r.format = DataFormat::Unknown; r.num_components = 4;
                         r.size = static_cast<uint32_t>(bytes);
                     }
                     r.gpu_addr = view.base; r.width = view.width; r.height = view.height; r.depth = d.depth;
+                    r.sample_count = d.sample_count;
                     r.tile_mode = d.tile_mode;
-                    r.declared_mip_levels =
-                        d.last_level >= d.base_level ? (uint32_t)(d.last_level - d.base_level) + 1u : 1u;
+                    r.declared_mip_levels = d.sample_count > 1u ? 1u :
+                        (d.last_level >= d.base_level ?
+                            (uint32_t)(d.last_level - d.base_level) + 1u : 1u);
                     r.in_mip_tail = view.in_mip_tail;
                     r.mip_tail_offset = view.in_mip_tail
                         ? static_cast<uint32_t>(view.mip_offset) : 0;

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -1431,6 +1431,12 @@ struct SpirvCompute {
     // 2-component uint vector (integer texel coordinates for OpImageFetch).
     uint32_t t_v2u_cache = 0;
     uint32_t t_v2u() { if (!t_v2u_cache) { t_v2u_cache = id(); put(types, Op_TypeVector, {t_v2u_cache, t_u32, 2}); } return t_v2u_cache; }
+    uint32_t t_v3u_cache2 = 0;
+    uint32_t t_v3u_fetch() {
+        if (t_v3u) return t_v3u;   // compute/vertex shells already declare a uvec3 for built-ins
+        if (!t_v3u_cache2) { t_v3u_cache2 = id(); put(types, Op_TypeVector, {t_v3u_cache2, t_u32, 3}); }
+        return t_v3u_cache2;
+    }
     // image_load 2D (image_load): texelFetch the image at the combined sampler's `binding` with INTEGER
     // (x,y) coords (raw VGPR bits). OpImage strips the sampler; OpImageFetch at explicit LOD 0.
     void image_fetch_2d(uint32_t binding, uint32_t x_bits, uint32_t y_bits, uint32_t out[4]) {
@@ -1441,14 +1447,23 @@ struct SpirvCompute {
         unpack_texture_result(binding, res, out);
     }
 
+    // Exact sampled IMAGE_LOAD representation for guest 2D_MSAA: the host image is single-sample
+    // 2D-array, with each guest sample plane in one layer. The guest's explicit sample coordinate is
+    // therefore the third integer coordinate; LOD remains zero because the host view has one level.
+    void image_fetch_2d_array(uint32_t binding, uint32_t x_bits, uint32_t y_bits,
+                              uint32_t layer_bits, uint32_t out[4]) {
+        uint32_t si    = id(); put(code, Op_Load, {tex_binding_simg[binding], si, tex_var[binding]});
+        uint32_t img   = id(); put(code, Op_Image, {tex_binding_img[binding], img, si});
+        uint32_t coord = id(); put(code, Op_CompositeConstruct,
+                                   {t_v3u_fetch(), coord, x_bits, y_bits, layer_bits});
+        uint32_t res   = id(); put(code, Op_ImageFetch,
+                                   {texture_vec4(binding), res, img, coord,
+                                    ImgOp_Lod, uconst(0)});
+        unpack_texture_result(binding, res, out);
+    }
+
     // image_load from a 3D texture (integer texel fetch through the combined sampler — DOLL's
     // color-grade LUT, #273): OpImage strips the sampler; OpImageFetch with (x,y,z) integer coords.
-    uint32_t t_v3u_cache2 = 0;
-    uint32_t t_v3u_fetch() {
-        if (t_v3u) return t_v3u;   // compute/vertex shells already declare a uvec3 for built-ins
-        if (!t_v3u_cache2) { t_v3u_cache2 = id(); put(types, Op_TypeVector, {t_v3u_cache2, t_u32, 3}); }
-        return t_v3u_cache2;
-    }
     void image_fetch_3d(uint32_t binding, uint32_t x_bits, uint32_t y_bits, uint32_t z_bits, uint32_t out[4]) {
         uint32_t simg  = tex_binding_simg[binding];
         uint32_t t_img3 = tex_binding_img[binding];   // OpImage's result type must be the pair's Image type
@@ -9568,13 +9583,28 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // SAMPLE_L/LZ is different: Astro Bot's world-map kernel selects both layers of a wide
             // texture atlas, so dropping cvg(2) destroys the lookup. Those forms use a real array below.
             const bool dim2d = (in.mimg_dim == 1u || in.mimg_dim == 5u), dim3d = (in.mimg_dim == 2u);
+            const bool dim_msaa = in.mimg_dim == 6u;
             const bool dimcube = (in.mimg_dim == 3u);   // CUBE: stacked-face 2D lowering (#273, below)
             if (in.mimg_dim == 5u && getenv("PROSPER_GFXLOG"))
                 fprintf(stderr, "[recompile] 2D_ARRAY image_sample -> sampled as base slice 0 (array index dropped; #325)\n");
             if ((!is_sample && !is_load && !is_sample_l && !is_sample_lz && !is_sample_b &&
                  !is_sample_c_lz && !is_gather_lz &&
-                 !is_gather_lz_o && !is_sample_lz_o && !is_sample_d) || (!dim2d && !dim3d && !dimcube)) { ok = false; return true; }
+                 !is_gather_lz_o && !is_sample_lz_o && !is_sample_d) ||
+                (!dim2d && !dim3d && !dimcube && !dim_msaa)) { ok = false; return true; }
             if (res->cls != ResourceClass::Texture) { ok = false; return true; }
+            // Guest 2D_MSAA IMAGE_LOAD is represented exactly as a host single-sample 2D array: the
+            // guest sample coordinate selects the array layer. Asterix's resolve PS mixes the ordinary
+            // consecutive-vaddr packet with three one-extra-dword NSA packets; llvm-mc gfx1030 confirms
+            // those NSA addresses are [x,y,sample] in bytes {VADDR, words[2].lo, words[2].byte1}.
+            // Accept only those two exact address shapes. Nonzero unused NSA bytes could carry further
+            // operands, and every other MSAA op/count/address shape stays fail-visible.
+            const bool msaa_address_shape = in.len_dwords == 2u ||
+                (in.len_dwords == 3u && (in.words[2] & 0xffff0000u) == 0u);
+            const bool msaa_array_fetch = dim_msaa && is_load && msaa_address_shape &&
+                !in.mimg_unorm && !in.has_modifier && res->img_dim == 6u &&
+                res->sample_count == 4u && res->depth == 1u &&
+                res->declared_mip_levels == 1u && !res->depth_compare;
+            if (dim_msaa && !msaa_array_fetch) { ok = false; return true; }
             // UNRM=1 supplies unnormalized (texel-space) coordinates (Table 100). Compilers set it
             // only on loads/stores/atomics — and our fetch paths are already texel-space — but a
             // SAMPLER op with UNRM set would treat texel coords as normalized and sample a wildly
@@ -9721,10 +9751,14 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             } else {
                 const bool array_sample = b.is_compute && in.mimg_dim == 5u &&
                     res->img_dim == 5u && (is_sample || is_sample_l || is_sample_lz);
-                if (!b.declare_texture(res->binding, Dim_2D, uint_texture, array_sample)) {
+                const bool host_array = array_sample || msaa_array_fetch;
+                if (!b.declare_texture(res->binding, Dim_2D, uint_texture, host_array)) {
                     ok = false; return true;
                 }
-                if (array_sample) {
+                if (msaa_array_fetch) {
+                    b.image_fetch_2d_array(
+                        res->binding, vread(cvg(0)), vread(cvg(1)), vread(cvg(2)), out);
+                } else if (array_sample) {
                     // Compute SAMPLE and SAMPLE_LZ both resolve level zero; SAMPLE_L supplies its
                     // explicit LOD. All retain the 2D-array slice in the SPIR-V coordinate.
                     b.image_sample_lod_2d_array(
@@ -13452,7 +13486,7 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
             if (!handled || !ok) {
                 // PROSPER_DBG (gated, off by default): report the instruction that fails recompilation —
                 // the first unsupported op / unresolved resource that makes a shader return empty.
-                if (getenv("PROSPER_DBG"))
+                if (getenv("PROSPER_DBG")) {
                     fprintf(stderr, "[recompile-reject] pc=%u words=%08x,%08x fmt=%d op=0x%x "
                                     "dst=%d(kind%d) src=%d(k%d),%d(k%d),%d(k%d) dmask=0x%x "
                                     "dim=%u glc=%d len=%u modifier=%d dpp=%d sdwa=%u/%u/%u/%u\n",
@@ -13464,6 +13498,16 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                         in.mimg_dmask, in.mimg_dim, (int)in.mimg_glc, in.len_dwords, (int)in.has_modifier,
                         (int)in.has_dpp, in.sdwa_dst_sel, in.sdwa_dst_unused,
                         in.sdwa_src0_sel, in.sdwa_src1_sel);
+                    // The primary line historically printed only the fixed MIMG pair. That hid the
+                    // address VGPRs which distinguished Asterix's rejected NSA form from the accepted
+                    // consecutive-vaddr form. Keep a separate MIMG-only line so an address-shape
+                    // diagnosis sees every decoded extra dword without adding zeros to unrelated ops.
+                    if (in.fmt == Rdna2Format::MIMG && in.len_dwords > 2u)
+                        fprintf(stderr,
+                                "[recompile-reject-mimg-address] pc=%u extra=%u words=%08x,%08x,%08x\n",
+                                in.pc, in.len_dwords - 2u,
+                                in.words[2], in.words[3], in.words[4]);
+                }
                 return false;
             }
         }
@@ -14766,10 +14810,18 @@ RecompileCoverage recompile_coverage(const uint32_t* code, size_t dwords) {
         auto table_dependent = [](const Rdna2Inst& i) {
             switch (i.fmt) {
                 case Rdna2Format::MIMG: {
-                    // Storage load/store handle 1D/2D/3D + 1D/2D_ARRAY (dims 0,1,2,4,5) and NSA; image_load
-                    // also handles 2D_MSAA (dim 6). sample* go through the sampled-texture path (2D, non-NSA).
+                    // Storage load/store handle 1D/2D/3D + 1D/2D_ARRAY (dims 0,1,2,4,5) and NSA.
+                    // Sampled 2D_MSAA IMAGE_LOAD is narrower: only the exact consecutive-address or
+                    // one-extra NSA [x,y,sample] shapes accepted by emit_alu are table-dependent.
+                    // Do not credit dim7 or unused NSA address bytes merely because a T# could exist.
                     const bool st_dim = i.mimg_dim <= 2u || i.mimg_dim == 4u || i.mimg_dim == 5u;
-                    if (i.opcode == 0x00u) return st_dim || i.mimg_dim == 6u || i.mimg_dim == 7u;   // image_load (+ 2D_MSAA[_ARRAY])
+                    if (i.opcode == 0x00u) {
+                        if (st_dim) return true;
+                        const bool msaa_address_shape = i.len_dwords == 2u ||
+                            (i.len_dwords == 3u && (i.words[2] & 0xffff0000u) == 0u);
+                        return i.mimg_dim == 6u && !i.mimg_unorm && !i.has_modifier &&
+                               msaa_address_shape;
+                    }
                     if (i.opcode == 0x08u) return st_dim;                       // image_store (no per-sample MSAA store)
                     if (i.opcode == 0x0fu || i.opcode == 0x11u)                // image_atomic_swap/add R32_UINT 2D
                         return i.mimg_dim == 1u && i.mimg_dmask == 1u &&

--- a/prosper/src/gpu/shader_resources.hpp
+++ b/prosper/src/gpu/shader_resources.hpp
@@ -216,6 +216,9 @@ struct ShaderResource {
     uint32_t      width             = 0;
     uint32_t      height            = 0;
     uint32_t      depth             = 1;
+    // Guest sample count. 2D_MSAA image_load is represented on the host as a single-sample 2D-array
+    // image with one exact sample plane per layer, while this field retains guest descriptor identity.
+    uint32_t      sample_count      = 1;
     uint32_t      tile_mode         = 0;                  // T# GFX10 TileMode; drives auto-detile of a sampled surface
     // Byte distance between rows of a linear sampled image. Zero means derive it from the live
     // descriptor/backing: exact HLE-producer provenance wins, other guest images use the GFX10

--- a/prosper/src/gpu/tile.cpp
+++ b/prosper/src/gpu/tile.cpp
@@ -1,6 +1,7 @@
 // tile.cpp — see tile.hpp. GFX10 SW_4KB_S de-swizzle, generalized over the element size (#119).
 // GFX10 SW_64KB_S / SW_64KB_R_X de-swizzle from the AMD addrlib swizzle-pattern tables (#288).
 #include "tile.hpp"
+#include <array>
 #include <cstring>
 #include <cstdlib>
 #include <cstdio>
@@ -129,6 +130,7 @@ namespace {
 // Defined here (and the SW_64K_S table forward-declared) so sw4kb_morton below can derive the 4KB order
 // from the low bits of the SAME authoritative 64KB pattern (#379); both are defined together lower down.
 struct PatBit { uint16_t x, y; };
+struct PatBitMsaa { uint16_t x, y; uint8_t sample; };
 extern const PatBit kSw64kS[5][16];
 
 // GFX10 SW_256B_S is the micro-tiled standard swizzle used for small textures. AMD AddrLib's
@@ -400,6 +402,29 @@ static const PatBit kSw64kZX[5][16] = {
     { {0x0000,0x0000}, {0x0000,0x0000}, {0x0001,0x0000}, {0x0000,0x0001}, {0x0002,0x0000}, {0x0000,0x0002}, {0x0004,0x0000}, {0x0000,0x0004}, {0x0008,0x0008}, {0x0010,0x0010}, {0x0040,0x0020}, {0x0020,0x0040}, {0x0000,0x0008}, {0x0010,0x0000}, {0x0000,0x0040}, {0x0040,0x0000} },  // 4 bpe
     { {0x0000,0x0000}, {0x0000,0x0000}, {0x0000,0x0000}, {0x0001,0x0000}, {0x0000,0x0001}, {0x0002,0x0000}, {0x0000,0x0002}, {0x0004,0x0000}, {0x0008,0x0008}, {0x0010,0x0010}, {0x0040,0x0020}, {0x0020,0x0040}, {0x0000,0x0004}, {0x0008,0x0000}, {0x0000,0x0010}, {0x0040,0x0000} },  // 8 bpe
     { {0x0000,0x0000}, {0x0000,0x0000}, {0x0000,0x0000}, {0x0000,0x0000}, {0x0001,0x0000}, {0x0000,0x0001}, {0x0002,0x0000}, {0x0000,0x0002}, {0x0008,0x0008}, {0x0010,0x0010}, {0x0040,0x0020}, {0x0020,0x0040}, {0x0000,0x0004}, {0x0004,0x0000}, {0x0000,0x0008}, {0x0010,0x0000} },  // 16 bpe
+};
+
+// SW_64K_Z_X, 4 fragments, 16 pipes. Expanded from AMD AddrLib's
+// GFX10_SW_64K_Z_X_4xaa_PATINFO rows for the five supported element sizes. Unlike the 1xaa table,
+// S0/S1 are real address inputs: dropping them aliases all four samples. Z/slice remains zero for a
+// non-array 2D_MSAA resource. The pipe-count choice matches the established Oberon mode-24 path.
+// Source: AMD ROCr AddrLib gfx10SwizzlePattern.h (MIT), PATINFO rows {18..22, 74/95/96, 31/74..76}.
+static const PatBitMsaa kSw64kZX4x[5][16] = {
+    { {0,0,1}, {0,0,2}, {0x0001,0,0}, {0,0x0001,0}, {0x0002,0,0}, {0,0x0002,0}, {0x0004,0,0}, {0,0x0004,0},
+      {0x0008,0x0008,0}, {0x0010,0x0010,0}, {0x0040,0x0020,0}, {0x0020,0x0040,0},
+      {0,0x0008,0}, {0x0010,0,0}, {0,0x0040,0}, {0x0040,0,0} }, // 1 B
+    { {0,0,0}, {0,0,1}, {0,0,2}, {0x0001,0,0}, {0,0x0001,0}, {0x0002,0,0}, {0,0x0002,0}, {0x0004,0,0},
+      {0x0008,0x0008,0}, {0x0010,0x0010,0}, {0x0040,0x0020,0}, {0x0020,0x0040,0},
+      {0x0008,0,0}, {0,0x0010,0}, {0x0040,0,0}, {0,0x0004 | 0x0040,0} }, // 2 B
+    { {0,0,0}, {0,0,0}, {0,0,1}, {0,0,2}, {0x0001,0,0}, {0,0x0001,0}, {0x0002,0,0}, {0,0x0002,0},
+      {0x0008,0x0008,0}, {0x0010,0x0010,0}, {0x0040,0x0020,0}, {0x0020,0x0040,0},
+      {0,0x0008,0}, {0x0010,0,0}, {0,0x0004 | 0x0040,0}, {0x0004,0x0080,0} }, // 4 B
+    { {0,0,0}, {0,0,0}, {0,0,0}, {0,0,1}, {0,0,2}, {0x0001,0,0}, {0,0x0001,0}, {0x0002,0,0},
+      {0x0008,0x0008,0}, {0x0010,0x0010,0}, {0x0040,0x0020 | 0x0004,0}, {0x0020,0x0040,0},
+      {0,0x0008,0}, {0x0010,0,0}, {0,0x0002 | 0x0040,0}, {0x0004,0x0080,0} }, // 8 B
+    { {0,0,0}, {0,0,0}, {0,0,0}, {0,0,0}, {0,0,1}, {0,0,2}, {0x0001,0,0}, {0,0x0001,0},
+      {0x0008,0x0008,0}, {0x0010,0x0010,0}, {0x0040,0x0020 | 0x0004,0}, {0x0022,0x0040,0},
+      {0,0x0008,0}, {0x0010,0,0}, {0,0x0002 | 0x0040,0}, {0x0004,0x0080,0} }, // 16 B
 };
 
 // SW_64K_R_X (1 fragment): the pattern depends on the pipe count; [pipesLog2][elemLog2][bit].
@@ -1089,6 +1114,207 @@ void tile_surface(uint8_t* dst, const uint8_t* src, uint32_t width, uint32_t hei
         return;
     }
     sw4kb_copy<true>(dst, src, width, height, pitch, bytes_per_texel, dst_bytes);
+}
+
+size_t tiled_msaa_surface_bytes(uint32_t width, uint32_t height, uint32_t tile_mode,
+                                uint32_t bytes_per_texel, uint32_t sample_count) {
+    if (!width || !height || sample_count != 4u ||
+        tile_mode != static_cast<uint32_t>(TileMode::Sw64KbZX))
+        return 0;
+    const uint32_t element_log2 = sw64kb_elem_log2(bytes_per_texel);
+    if (element_log2 == UINT32_MAX || element_log2 + 2u >= 16u) return 0;
+    // AMD AddrLib ComputeThinBlockDimension: log2(elements) = log2(64 KiB) - log2(B/element)
+    // - log2(samples). Four samples use the width-precedent square/square-ish split.
+    const uint32_t element_bits = 16u - element_log2 - 2u;
+    const uint32_t width_bits = (element_bits + 1u) / 2u;
+    const uint32_t block_width = 1u << width_bits;
+    const uint32_t block_height = 1u << (element_bits - width_bits);
+    const uint64_t blocks_x = (static_cast<uint64_t>(width) + block_width - 1u) / block_width;
+    const uint64_t blocks_y = (static_cast<uint64_t>(height) + block_height - 1u) / block_height;
+    if (blocks_x && blocks_y > SIZE_MAX / blocks_x / 65536u) return 0;
+    return static_cast<size_t>(blocks_x * blocks_y * 65536u);
+}
+
+namespace {
+template <bool ToTiled>
+bool sw64kb_zx_4xaa_copy(uint8_t* dst, size_t tiled_bytes, const uint8_t* src,
+                         uint32_t width, uint32_t height, uint32_t bytes_per_texel) {
+    const uint32_t element_log2 = sw64kb_elem_log2(bytes_per_texel);
+    if (!dst || !src || element_log2 == UINT32_MAX) return false;
+    const uint32_t element_bits = 16u - element_log2 - 2u;
+    const uint32_t width_bits = (element_bits + 1u) / 2u;
+    const uint32_t block_width = 1u << width_bits;
+    const uint32_t block_height = 1u << (element_bits - width_bits);
+    const uint64_t blocks_x = (static_cast<uint64_t>(width) + block_width - 1u) / block_width;
+    const PatBitMsaa* pattern = kSw64kZX4x[element_log2];
+
+    std::vector<uint16_t> x_offsets(width), y_offsets(height);
+    std::array<uint16_t, 4> sample_offsets{};
+    for (uint32_t x = 0; x < width; ++x)
+        for (uint32_t bit = element_log2; bit < 16u; ++bit)
+            x_offsets[x] |= static_cast<uint16_t>(
+                (__builtin_popcount(x & pattern[bit].x) & 1u) << bit);
+    for (uint32_t y = 0; y < height; ++y)
+        for (uint32_t bit = element_log2; bit < 16u; ++bit)
+            y_offsets[y] |= static_cast<uint16_t>(
+                (__builtin_popcount(y & pattern[bit].y) & 1u) << bit);
+    for (uint32_t sample = 0; sample < 4u; ++sample)
+        for (uint32_t bit = element_log2; bit < 16u; ++bit)
+            sample_offsets[sample] |= static_cast<uint16_t>(
+                (__builtin_popcount(sample & pattern[bit].sample) & 1u) << bit);
+
+    const size_t plane_texels = static_cast<size_t>(width) * height;
+    for (uint32_t sample = 0; sample < 4u; ++sample) {
+        for (uint32_t y = 0; y < height; ++y) {
+            const uint64_t block_row = static_cast<uint64_t>(y / block_height) * blocks_x;
+            for (uint32_t x = 0; x < width; ++x) {
+                const uint64_t block = block_row + x / block_width;
+                const uint64_t tiled = (block << 16u) |
+                    (x_offsets[x] ^ y_offsets[y] ^ sample_offsets[sample]);
+                const size_t linear =
+                    (static_cast<size_t>(sample) * plane_texels +
+                     static_cast<size_t>(y) * width + x) * bytes_per_texel;
+                if (tiled > tiled_bytes || bytes_per_texel > tiled_bytes - tiled) {
+                    if constexpr (!ToTiled) std::memset(dst + linear, 0, bytes_per_texel);
+                    continue;
+                }
+                if constexpr (ToTiled)
+                    std::memcpy(dst + tiled, src + linear, bytes_per_texel);
+                else
+                    std::memcpy(dst + linear, src + tiled, bytes_per_texel);
+            }
+        }
+    }
+    return true;
+}
+} // namespace
+
+bool detile_msaa_surface(uint8_t* dst, const uint8_t* src, size_t src_bytes,
+                         uint32_t width, uint32_t height, uint32_t tile_mode,
+                         uint32_t bytes_per_texel, uint32_t sample_count) {
+    const size_t expected = tiled_msaa_surface_bytes(
+        width, height, tile_mode, bytes_per_texel, sample_count);
+    if (!expected || src_bytes < expected) return false;
+    return sw64kb_zx_4xaa_copy<false>(dst, src_bytes, src, width, height, bytes_per_texel);
+}
+
+bool tile_msaa_surface(uint8_t* dst, size_t dst_bytes, const uint8_t* src,
+                       uint32_t width, uint32_t height, uint32_t tile_mode,
+                       uint32_t bytes_per_texel, uint32_t sample_count) {
+    const size_t expected = tiled_msaa_surface_bytes(
+        width, height, tile_mode, bytes_per_texel, sample_count);
+    if (!expected || dst_bytes < expected) return false;
+    std::memset(dst, 0, expected);
+    return sw64kb_zx_4xaa_copy<true>(dst, expected, src, width, height, bytes_per_texel);
+}
+
+size_t gfx10_htile_msaa_metadata_bytes(uint32_t width, uint32_t height,
+                                       uint32_t tile_mode, uint32_t sample_count,
+                                       bool pipe_aligned) {
+    if (!width || !height || sample_count != 4u || !pipe_aligned ||
+        tile_mode != static_cast<uint32_t>(TileMode::Sw64KbZX))
+        return 0;
+    // AMD AddrLib HwlComputeHtileInfo/GetMetaBlkSize, 16-pipe GFX10 configuration:
+    //   ROCm/ROCR-Runtime d614ea8bbd73, src/image/addrlib/src/gfx10/gfx10addrlib.cpp
+    // Pipe-aligned thin Z_X uses a 2^15-byte meta block. Its 2^19 covered pixels split
+    // width-precedent into 1024x512. HTILE sizing is independent of the depth sample count, but
+    // this API deliberately retains the observed 4xaa gate rather than claiming broader support.
+    constexpr uint64_t meta_width = 1024u;
+    constexpr uint64_t meta_height = 512u;
+    constexpr uint64_t meta_block_bytes = 1u << 15;
+    const uint64_t blocks_x = (static_cast<uint64_t>(width) + meta_width - 1u) / meta_width;
+    const uint64_t blocks_y = (static_cast<uint64_t>(height) + meta_height - 1u) / meta_height;
+    if (blocks_x && blocks_y > SIZE_MAX / blocks_x / meta_block_bytes) return 0;
+    return static_cast<size_t>(blocks_x * blocks_y * meta_block_bytes);
+}
+
+bool gfx10_htile_metadata_is_decompressed(const uint8_t* metadata, size_t metadata_bytes,
+                                           size_t expected_bytes, uint32_t* uniform_value) {
+    if (uniform_value) *uniform_value = 0;
+    if (!metadata || !expected_bytes || metadata_bytes != expected_bytes ||
+        (metadata_bytes % sizeof(uint32_t)) != 0)
+        return false;
+    uint32_t first = 0;
+    std::memcpy(&first, metadata, sizeof(first));
+    // PAL Gfx9Htile::GetInitialValue(), c5e800072a32, gfx9MaskRam.cpp:
+    // - depth-only:    ZMax=0x3fff, ZMin=0, ZMask=0xf (no Z compression)
+    // - depth+stencil: full Z range, SMem=3 (no stencil compression), SR0/SR1 unknown,
+    //                  ZMask=0xf (no Z compression)
+    constexpr uint32_t depth_only_decompressed = 0xfffc000fu;
+    constexpr uint32_t depth_stencil_decompressed = 0xfffff3ffu;
+    if (first != depth_only_decompressed && first != depth_stencil_decompressed) return false;
+    for (size_t offset = sizeof(uint32_t); offset < metadata_bytes;
+         offset += sizeof(uint32_t)) {
+        uint32_t value = 0;
+        std::memcpy(&value, metadata + offset, sizeof(value));
+        if (value != first) return false;
+    }
+    if (uniform_value) *uniform_value = first;
+    return true;
+}
+
+Gfx10HtileMsaaSource gfx10_htile_msaa_source(
+    const uint8_t* metadata, size_t metadata_bytes,
+    uint32_t width, uint32_t height, uint32_t tile_mode,
+    uint32_t bytes_per_texel, uint32_t sample_count, bool pipe_aligned) {
+    if (bytes_per_texel != sizeof(float)) return Gfx10HtileMsaaSource::Unsupported;
+    const size_t expected = gfx10_htile_msaa_metadata_bytes(
+        width, height, tile_mode, sample_count, pipe_aligned);
+    if (!metadata || !expected || metadata_bytes != expected)
+        return Gfx10HtileMsaaSource::Unsupported;
+
+    // PAL Gfx9Htile::GetClearValue(depth=0), depth-only layout:
+    //   (ZMax << 18) | (ZMin << 4) | ZMask = 0.
+    // A full uniform plane therefore describes every 8x8 block and all samples as +0.0 without
+    // consulting base memory. Do not generalize this to nonzero encodings here: inverse depth
+    // quantization and the depth+stencil layout require their own proven contract.
+    if (std::all_of(metadata, metadata + metadata_bytes,
+                    [](uint8_t value) { return value == 0u; }))
+        return Gfx10HtileMsaaSource::DepthZeroFastClear;
+    if (gfx10_htile_metadata_is_decompressed(
+            metadata, metadata_bytes, expected))
+        return Gfx10HtileMsaaSource::UncompressedBase;
+    return Gfx10HtileMsaaSource::Unsupported;
+}
+
+bool materialize_gfx10_htile_msaa_surface(
+    uint8_t* dst, size_t dst_bytes,
+    const uint8_t* tiled_base, size_t tiled_base_bytes,
+    const uint8_t* metadata, size_t metadata_bytes,
+    uint32_t width, uint32_t height, uint32_t tile_mode,
+    uint32_t bytes_per_texel, uint32_t sample_count, bool pipe_aligned,
+    Gfx10HtileMsaaSource* source) {
+    if (source) *source = Gfx10HtileMsaaSource::Unsupported;
+    if (!dst || !width || !height || !sample_count || !bytes_per_texel)
+        return false;
+    size_t linear_bytes = width;
+    if (linear_bytes > SIZE_MAX / height) return false;
+    linear_bytes *= height;
+    if (linear_bytes > SIZE_MAX / sample_count) return false;
+    linear_bytes *= sample_count;
+    if (linear_bytes > SIZE_MAX / bytes_per_texel) return false;
+    linear_bytes *= bytes_per_texel;
+    if (dst_bytes < linear_bytes) return false;
+
+    const Gfx10HtileMsaaSource selected = gfx10_htile_msaa_source(
+        metadata, metadata_bytes, width, height, tile_mode,
+        bytes_per_texel, sample_count, pipe_aligned);
+    if (selected == Gfx10HtileMsaaSource::DepthZeroFastClear) {
+        // IEEE-754 +0.0 is all-zero bits. Base may be null, short, or poison: fast-clear metadata is
+        // authoritative and the stale tiled allocation must not be observed.
+        std::memset(dst, 0, linear_bytes);
+    } else if (selected == Gfx10HtileMsaaSource::UncompressedBase) {
+        const size_t expected_base = tiled_msaa_surface_bytes(
+            width, height, tile_mode, bytes_per_texel, sample_count);
+        if (!tiled_base || !expected_base || tiled_base_bytes < expected_base ||
+            !detile_msaa_surface(dst, tiled_base, tiled_base_bytes, width, height,
+                                tile_mode, bytes_per_texel, sample_count))
+            return false;
+    } else {
+        return false;
+    }
+    if (source) *source = selected;
+    return true;
 }
 
 size_t tiled_elements_bytes(uint32_t ew, uint32_t eh, uint32_t bpe, uint32_t tile_mode) {

--- a/prosper/src/gpu/tile.hpp
+++ b/prosper/src/gpu/tile.hpp
@@ -60,6 +60,52 @@ std::vector<uint8_t> detile_surface(const std::vector<uint8_t>& src, uint32_t wi
 void tile_surface(uint8_t* dst, const uint8_t* src, uint32_t width, uint32_t height,
                   uint32_t tile_mode, uint32_t pitch = 0, uint32_t bytes_per_texel = 4);
 
+// Exact GFX10 2D-MSAA materialization. The guest swizzle includes sample-coordinate bits in every
+// 64 KiB block; treating it as an ordinary surface both under-reads the allocation and scrambles
+// every texel. The linear representation is Vulkan-2D-array ready: complete sample planes are
+// contiguous (`sample * width * height + y * width + x`). This first implementation is deliberately
+// fail-closed outside the observed/published SW_64KB_Z_X 4xaa contract; zero/false means unsupported.
+size_t tiled_msaa_surface_bytes(uint32_t width, uint32_t height, uint32_t tile_mode,
+                                uint32_t bytes_per_texel, uint32_t sample_count);
+bool detile_msaa_surface(uint8_t* dst, const uint8_t* src, size_t src_bytes,
+                         uint32_t width, uint32_t height, uint32_t tile_mode,
+                         uint32_t bytes_per_texel, uint32_t sample_count);
+bool tile_msaa_surface(uint8_t* dst, size_t dst_bytes, const uint8_t* src,
+                       uint32_t width, uint32_t height, uint32_t tile_mode,
+                       uint32_t bytes_per_texel, uint32_t sample_count);
+
+// Exact GFX10 16-pipe HTILE contract for the observed 2D_MSAA SW_64KB_Z_X surface. AMD AddrLib
+// computes one 32 KiB metadata block per 1024x512 pixels; PAL documents the only two uniform HTILE
+// initialization values that disable Z compression and make ordinary base texels authoritative.
+// The helpers stay fail-closed outside 4xaa, pipe-aligned mode 24. The classifier requires the
+// complete expected plane so a short or mixed metadata read cannot authorize base decoding.
+size_t gfx10_htile_msaa_metadata_bytes(uint32_t width, uint32_t height,
+                                       uint32_t tile_mode, uint32_t sample_count,
+                                       bool pipe_aligned);
+bool gfx10_htile_metadata_is_decompressed(const uint8_t* metadata, size_t metadata_bytes,
+                                           size_t expected_bytes,
+                                           uint32_t* uniform_value = nullptr);
+
+// A complete, uniform zero HTILE plane is PAL's exact depth-only fast-clear encoding for +0.0:
+// ZMin=ZMax=0 and ZMask=0. It does NOT authorize reading the stale base allocation. The source
+// classifier and materializer keep that case distinct from the two ordinary-base initial values.
+enum class Gfx10HtileMsaaSource : uint8_t {
+    Unsupported,
+    UncompressedBase,
+    DepthZeroFastClear,
+};
+Gfx10HtileMsaaSource gfx10_htile_msaa_source(
+    const uint8_t* metadata, size_t metadata_bytes,
+    uint32_t width, uint32_t height, uint32_t tile_mode,
+    uint32_t bytes_per_texel, uint32_t sample_count, bool pipe_aligned);
+bool materialize_gfx10_htile_msaa_surface(
+    uint8_t* dst, size_t dst_bytes,
+    const uint8_t* tiled_base, size_t tiled_base_bytes,
+    const uint8_t* metadata, size_t metadata_bytes,
+    uint32_t width, uint32_t height, uint32_t tile_mode,
+    uint32_t bytes_per_texel, uint32_t sample_count, bool pipe_aligned,
+    Gfx10HtileMsaaSource* source = nullptr);
+
 // General SW_4KB_S de-swizzle for `bpe`-byte ELEMENTS. The 4KB micro-tile holds 4096/bpe elements;
 // its dimensions derive from bpe (wide-before-tall: 16 B -> 16x16, 8 B -> 32x16, ...) — previously
 // a caller-supplied SQUARE tile_side, which could not represent the non-square 8 B geometry (#119).

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -110,6 +110,9 @@ struct FrameResource {
     // zero-initialized 64 KiB allocation shared across ordered render calls.
     bool is_internal_gds = false;
     const uint8_t* tex_rgba = nullptr;   // non-null => a texture; then tw/th are its dimensions
+    // Readable byte span behind tex_rgba. Zero preserves the historical single-sample fixture
+    // contract; multisample plane uploads require an explicit full span and reject before Vulkan.
+    size_t tex_byte_size = 0;
     // Optional immutable owner for borrowed frontend pixels. Keeping this beside the raw pointer
     // makes FrameResource copies/moves retain the source through synchronous backend upload setup.
     std::shared_ptr<const std::vector<uint8_t>> tex_rgba_owner;
@@ -119,6 +122,9 @@ struct FrameResource {
     bool has_uniform_color = false;
     std::array<float, 4> uniform_color{};
     uint32_t tw = 0, th = 0, td = 1;
+    // Guest sample count. 2D_MSAA is uploaded as a single-sample 2D-array with one plane/layer per
+    // sample; the Vulkan image itself always keeps VK_SAMPLE_COUNT_1_BIT.
+    uint32_t sample_count = 1;
     // T#-declared mip-chain length (#1272). 1 (default) = single-level upload, the historical
     // behavior. >1 lets the backend generate a box-filtered chain — bounded by this declared count —
     // for plain-2D RGBA8 sampled textures, so minification stops point-sampling through dense art.
@@ -226,6 +232,8 @@ inline VkFormat backend_color_format(VkFormat format) {
         return VK_FORMAT_R8G8_UNORM;
     if (format == VK_FORMAT_R32_UINT)
         return VK_FORMAT_R32_UINT;
+    if (format == VK_FORMAT_R32_SFLOAT)
+        return VK_FORMAT_R32_SFLOAT;
     return VK_FORMAT_R8G8B8A8_UNORM;
 }
 
@@ -235,6 +243,26 @@ inline uint32_t backend_color_bytes_per_pixel(VkFormat format) {
     if (format == VK_FORMAT_R8_UNORM) return 1u;
     if (format == VK_FORMAT_R8G8_UNORM) return 2u;
     return 4u;
+}
+
+// The first exact guest-MSAA contract is intentionally narrow. Ordinary resources retain their
+// historical implicit byte-span behavior; a 2D_MSAA plane array must prove all four complete R32F
+// planes are readable before any Vulkan object or memcpy is attempted.
+inline bool backend_texture_plane_span_valid(const FrameResource& resource) {
+    if (resource.sample_count == 1u) return true;
+    if (resource.sample_count != 4u || resource.img_dim != 6u || resource.td != 1u ||
+        resource.declared_mip_levels != 1u || resource.is_storage_image ||
+        backend_color_format(resource.texture_format) != VK_FORMAT_R32_SFLOAT ||
+        !resource.tex_rgba || !resource.tw || !resource.th)
+        return false;
+    const size_t row_bytes = static_cast<size_t>(resource.tw) * sizeof(float);
+    if (resource.tw && row_bytes / resource.tw != sizeof(float) ||
+        resource.th > SIZE_MAX / row_bytes)
+        return false;
+    const size_t plane_bytes = row_bytes * resource.th;
+    if (resource.sample_count > SIZE_MAX / plane_bytes) return false;
+    const size_t required = plane_bytes * resource.sample_count;
+    return resource.tex_byte_size >= required;
 }
 
 struct BackendColorTargetStats {
@@ -2817,6 +2845,9 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     if (mrt_outputs)
         for (auto& color : mrt_outputs->colors) color.clear();
     if (draws.empty()) return out;
+    for (const BackendDraw& draw : draws)
+        for (const FrameResource& resource : draw.R)
+            if (!backend_texture_plane_span_valid(resource)) return out;
     if (backend_has_unproven_submission()) return out;
     const RenderVkCtx& ctx = render_vk_ctx();
     if (!ctx.ok) return out;
@@ -3468,6 +3499,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         void* borrowed_compute_image = nullptr;
         uint32_t width = 0, height = 0, depth = 1;
         uint32_t img_dim = 1;
+        uint32_t sample_count = 1;
         uint32_t mip_levels = 1;   // effective uploaded chain length (#1272)
         VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
         bool storage_image = false;
@@ -3476,7 +3508,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
             return pixels == other.pixels && render_target_id == other.render_target_id &&
                    borrowed_compute_image == other.borrowed_compute_image &&
                    width == other.width && height == other.height && depth == other.depth &&
-                   img_dim == other.img_dim && mip_levels == other.mip_levels &&
+                   img_dim == other.img_dim && sample_count == other.sample_count &&
+                   mip_levels == other.mip_levels &&
                    format == other.format && storage_image == other.storage_image &&
                    uniform_color_bits == other.uniform_color_bits;
         }
@@ -3491,6 +3524,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
             h ^= static_cast<size_t>(key.height) + 0x9e3779b9u + (h << 6) + (h >> 2);
             h ^= static_cast<size_t>(key.depth) + 0x9e3779b9u + (h << 6) + (h >> 2);
             h ^= static_cast<size_t>(key.img_dim) + 0x9e3779b9u + (h << 6) + (h >> 2);
+            h ^= static_cast<size_t>(key.sample_count) + 0x9e3779b9u + (h << 6) + (h >> 2);
             h ^= static_cast<size_t>(key.mip_levels) + 0x9e3779b9u + (h << 6) + (h >> 2);
             h ^= static_cast<size_t>(key.format) + 0x9e3779b9u + (h << 6) + (h >> 2);
             h ^= static_cast<size_t>(key.storage_image) + 0x9e3779b9u + (h << 6) + (h >> 2);
@@ -3527,7 +3561,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     };
     struct PersistentTextureKey {
         uint64_t id = 0;
-        uint32_t width = 0, height = 0, depth = 1, img_dim = 1;
+        uint32_t width = 0, height = 0, depth = 1, img_dim = 1, sample_count = 1;
         uint32_t mip_levels = 1;   // a cached image must match the requested chain length (#1272)
         VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
         bool operator==(const PersistentTextureKey&) const = default;
@@ -3539,6 +3573,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                 h ^= static_cast<size_t>(value) + 0x9e3779b9u + (h << 6) + (h >> 2);
             };
             mix(key.width); mix(key.height); mix(key.depth); mix(key.img_dim);
+            mix(key.sample_count);
             mix(key.mip_levels);
             mix(static_cast<uint32_t>(key.format));
             return h;
@@ -4210,7 +4245,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                         r.persistent_render_target_id ? r.persistent_render_target_id
                                                       : r.persistent_depth_target_id,
                         r.borrowed_compute_image,
-                        r.tw, r.th, r.td, r.img_dim,
+                        r.tw, r.th, r.td, r.img_dim, r.sample_count,
                         tex_mip_levels, backend_color_format(r.texture_format), r.is_storage_image,
                         uniform_color_bits};
                     size_t upload_index = SIZE_MAX;
@@ -4282,7 +4317,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                         upload.persistent_version = r.persistent_texture_version;
                         const PersistentTextureKey persistent_key{
                             r.persistent_texture_id, r.tw, r.th, r.td, r.img_dim,
-                            texture_key.mip_levels, backend_color_format(r.texture_format)};
+                            r.sample_count, texture_key.mip_levels,
+                            backend_color_format(r.texture_format)};
                         if (!r.is_storage_image && !upload.borrowed_target &&
                             !upload.borrowed_compute && !upload.borrowed_ds &&
                             persistent_textures_enabled &&
@@ -4348,7 +4384,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                                 tci.format = backend_color_format(r.texture_format);
                                 tci.extent = {r.tw, r.th, r.td};
                                 tci.mipLevels = upload.key.mip_levels;
-                                tci.arrayLayers = 1;
+                                tci.arrayLayers = r.sample_count;
                                 tci.samples = VK_SAMPLE_COUNT_1_BIT;
                                 tci.tiling = VK_IMAGE_TILING_OPTIMAL;
                                 tci.usage = (r.is_storage_image ? VK_IMAGE_USAGE_STORAGE_BIT
@@ -4392,6 +4428,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                             } else {
                                 const VkDeviceSize tbytes =
                                     static_cast<VkDeviceSize>(r.tw) * r.th * r.td *
+                                    r.sample_count *
                                     backend_color_bytes_per_pixel(r.texture_format);
                                 VkBufferCreateInfo stci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
                                 stci.size = tbytes;
@@ -4449,7 +4486,9 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                     // correct sRGB fix is a coordinated linear-working-space + output-encode change (see the
                     // #263 discussion), NOT a per-view format flip. r.srgb is decoded now as groundwork.
                     tvci.image = upload.image;
-                    tvci.viewType = r.img_dim == 2 ? VK_IMAGE_VIEW_TYPE_3D : VK_IMAGE_VIEW_TYPE_2D;
+                    tvci.viewType = r.img_dim == 2 ? VK_IMAGE_VIEW_TYPE_3D
+                        : r.sample_count > 1u ? VK_IMAGE_VIEW_TYPE_2D_ARRAY
+                                             : VK_IMAGE_VIEW_TYPE_2D;
                     tvci.format = backend_color_format(r.texture_format);
                     // T# DST_SEL channel remap (#261): map each SQ_SEL to a VkComponentSwizzle. Identity
                     // (the default, and the narrow/font path) yields IDENTITY == a no-op. PROSPER_NO_SWIZZLE
@@ -4469,7 +4508,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                     if (!r.is_storage_image && !getenv("PROSPER_NO_SWIZZLE"))
                         tvci.components = {vkswz(r.swizzle[0]), vkswz(r.swizzle[1]), vkswz(r.swizzle[2]), vkswz(r.swizzle[3])};
                     tvci.subresourceRange =
-                        {VK_IMAGE_ASPECT_COLOR_BIT, 0, upload.key.mip_levels, 0, 1};
+                        {VK_IMAGE_ASPECT_COLOR_BIT, 0, upload.key.mip_levels,
+                         0, r.sample_count};
                     // Sampled depth bridge (#1275): a borrowed DS image is viewed through its own
                     // depth format's DEPTH aspect (one level — DS surfaces have no mip chains here);
                     // the sampled value arrives in R. The T# swizzle above still applies.
@@ -4550,7 +4590,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                         static_cast<uint64_t>(float_bits(sci.mipLodBias)),
                         static_cast<uint64_t>(sci.anisotropyEnable),
                         static_cast<uint64_t>(float_bits(sci.maxAnisotropy)),
-                        0,
+                        static_cast<uint64_t>(r.sample_count),
                         share_backend_resources ? 0 : ++resource_unique_tag,
                     };
                     ++resource_reuse_stats.texture_binding_references;
@@ -4572,7 +4612,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                             persistent_image = persistent_texture_images.find(
                                 {upload.persistent_id, upload.key.width, upload.key.height,
                                  upload.key.depth, upload.key.img_dim,
-                                 upload.key.mip_levels, upload.key.format});
+                                 upload.key.sample_count, upload.key.mip_levels,
+                                 upload.key.format});
                         }
                         if (persistent_image != persistent_texture_images.end()) {
                             auto cached_binding = persistent_image->second.bindings.find(binding_key);
@@ -5083,7 +5124,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         if (!upload.staging && !upload.uniform_clear) continue;
         ++texture_stats.unique_uploads;
         texture_stats.upload_bytes += static_cast<uint64_t>(upload.key.width) * upload.key.height *
-                                      upload.key.depth * backend_color_bytes_per_pixel(upload.key.format);
+                                      upload.key.depth * upload.key.sample_count *
+                                      backend_color_bytes_per_pixel(upload.key.format);
     }
 
     const auto timing_draws_ready = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
@@ -5247,7 +5289,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
             ? VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL : VK_IMAGE_LAYOUT_UNDEFINED;
         b0.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
         b0.image = upload.image;
-        b0.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, upload.key.mip_levels, 0, 1};
+        b0.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, upload.key.mip_levels,
+                               0, upload.key.sample_count};
         b0.srcAccessMask = upload.persistent_refresh ? VK_ACCESS_SHADER_READ_BIT : 0;
         b0.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
         vkCmdPipelineBarrier(
@@ -5258,11 +5301,14 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
             VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr, 1, &b0);
         if (upload.uniform_clear) {
             const VkImageSubresourceRange range{
-                VK_IMAGE_ASPECT_COLOR_BIT, 0, upload.key.mip_levels, 0, 1};
+                VK_IMAGE_ASPECT_COLOR_BIT, 0, upload.key.mip_levels,
+                0, upload.key.sample_count};
             vkCmdClearColorImage(cmd, upload.image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
                                  &upload.uniform_color, 1, &range);
         } else {
-            VkBufferImageCopy tc{}; tc.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+            VkBufferImageCopy tc{};
+            tc.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0,
+                                   upload.key.sample_count};
             tc.imageExtent = {upload.key.width, upload.key.height, upload.key.depth};
             vkCmdCopyBufferToImage(cmd, upload.staging, upload.image,
                                    VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &tc);
@@ -5276,7 +5322,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
             bs.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
             bs.newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
             bs.image = upload.image;
-            bs.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, l - 1, 1, 0, 1};
+            bs.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, l - 1, 1,
+                                   0, upload.key.sample_count};
             bs.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
             bs.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
             vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT,
@@ -5286,9 +5333,11 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
             const int32_t dw = (int32_t)(upload.key.width >> l ? upload.key.width >> l : 1u);
             const int32_t dh = (int32_t)(upload.key.height >> l ? upload.key.height >> l : 1u);
             VkImageBlit blit{};
-            blit.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, l - 1, 0, 1};
+            blit.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, l - 1, 0,
+                                   upload.key.sample_count};
             blit.srcOffsets[1] = {sw, sh, 1};
-            blit.dstSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, l, 0, 1};
+            blit.dstSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, l, 0,
+                                   upload.key.sample_count};
             blit.dstOffsets[1] = {dw, dh, 1};
             vkCmdBlitImage(cmd, upload.image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
                            upload.image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &blit,
@@ -5301,7 +5350,9 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
             br.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
             br.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
             br.image = upload.image;
-            br.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, upload.key.mip_levels - 1, 0, 1};
+            br.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0,
+                                   upload.key.mip_levels - 1, 0,
+                                   upload.key.sample_count};
             br.srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
             br.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
             vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT,
@@ -5312,7 +5363,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         b1.newLayout = upload.key.storage_image
             ? VK_IMAGE_LAYOUT_GENERAL : VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
         b1.image = upload.image;
-        b1.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, upload.key.mip_levels, 0, 1};
+        b1.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, upload.key.mip_levels,
+                               0, upload.key.sample_count};
         b1.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
         b1.dstAccessMask = VK_ACCESS_SHADER_READ_BIT |
             (upload.key.storage_image ? VK_ACCESS_SHADER_WRITE_BIT : 0);
@@ -5780,7 +5832,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
             upload.persistent_refresh) continue;
         const PersistentTextureKey key{upload.persistent_id, upload.key.width, upload.key.height,
                                        upload.key.depth, upload.key.img_dim,
-                                       upload.key.mip_levels, upload.key.format};
+                                       upload.key.sample_count, upload.key.mip_levels,
+                                       upload.key.format};
         while (!avoid_cache_eviction &&
                (persistent_texture_images.size() >= persistent_texture_max_entries ||
                 (upload.image_bytes <= persistent_texture_limit &&
@@ -6052,7 +6105,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                 !upload.staging_memory)
                 continue;
             const size_t storage_bytes = static_cast<size_t>(upload.key.width) *
-                upload.key.height * upload.key.depth *
+                upload.key.height * upload.key.depth * upload.key.sample_count *
                 backend_color_bytes_per_pixel(upload.key.format);
             void* mapped = nullptr;
             if (!storage_bytes ||

--- a/prosper/tests/test_build_shader_resources.cpp
+++ b/prosper/tests/test_build_shader_resources.cpp
@@ -95,6 +95,16 @@ int main() {
               image_type_to_dim(14) == 6 && image_type_to_dim(15) == 7,
               "T# TYPE array/MSAA variants map to MIMG dims 4..7");
         CHECK(image_type_to_dim(0) == 1, "unknown T# TYPE keeps the conservative 2D fallback");
+        // Exact title-live 1920x1080 R32_FLOAT 2D_MSAA descriptor. TYPE 14 changes the meaning of
+        // LAST_LEVEL: value 2 is log2(4 samples), not a three-level mip range.
+        const uint32_t msaa_tsharp[8] = {
+            0x20382900u, 0xc1600000u, 0x010dc1dfu, 0xe1820924u,
+            0x00000000u, 0x00700020u, 0x80280400u, 0x00201208u,
+        };
+        const DecodedImageDescriptor dmsaa = decode_image_descriptor(msaa_tsharp);
+        CHECK(dmsaa.base == 0x2038290000ull && dmsaa.width == 1920 && dmsaa.height == 1080 &&
+                  dmsaa.type == 14 && dmsaa.last_level == 2 && dmsaa.sample_count == 4,
+              "2D_MSAA T# decodes LAST_LEVEL as four samples while preserving raw descriptor fields");
         uint32_t t3d[8];
         make_tsharp(t3d, 0x12000000ull, 32, 16, /*fmt*/56, /*tile*/0, /*type 3D*/10, /*depth*/8);
         t3d[6] = (2u << 15) | (1u << 17) | (1u << 19) | (1u << 20) |
@@ -264,6 +274,29 @@ int main() {
                   cube->layer_stride_bytes == 720896u &&
                   cube->layer_mip_offset_bytes == 65536u,
               "realized cube resource preserves selected-mip per-face layout");
+    }
+
+    // The runtime resource preserves the guest sample count, exposes one host mip, and bounds the
+    // complete four-plane allocation. This is the identity consumed by recompile, capture, and upload.
+    {
+        uint32_t sg[8];
+        make_tsharp(sg, 0x2038290000ull, 1920, 1080, /*R32_FLOAT*/22,
+                    /*SW_64KB_Z_X*/24, /*2D_MSAA*/14);
+        sg[3] |= 2u << 16; // LAST_LEVEL = log2(4 samples)
+        AgcShaderSharp sharp[1]; sharp[0].bits = 0;
+        AgcShaderUserData ud{};
+        ud.sharp_resource_offset[0] = sharp;
+        ud.sharp_resource_count[0] = 1;
+        AgcShaderHeader sh{};
+        sh.file_header = 0x34333231u; sh.version = 0x18; sh.type = 1; sh.user_data = &ud;
+        const ShaderResourceTable resources = build_shader_resources(sh, sg, 8);
+        const ShaderResource* msaa = resources.by_sgpr_base(0);
+        CHECK(msaa && msaa->img_dim == 6 && msaa->sample_count == 4 &&
+                  msaa->declared_mip_levels == 1 && msaa->depth == 1 &&
+                  msaa->format == DataFormat::Float32 && msaa->num_components == 1,
+              "realized 2D_MSAA resource retains four guest samples as one host mip");
+        CHECK(msaa && msaa->size == 1920u * 1080u * 4u * 4u,
+              "realized 2D_MSAA backing span includes every complete sample plane");
     }
 
     // A shifted thin-2D mip emits the selected extent and a matching backing span. Allocation-level

--- a/prosper/tests/test_gpu_capture.cpp
+++ b/prosper/tests/test_gpu_capture.cpp
@@ -443,6 +443,17 @@ int main() {
         return 4 + f.draws.size() * 13 + 4 + present_failures * 13;
     };
 
+    // v44: one guest sample count per realized and failed-stage resource.
+    auto v44_tail = [](const GpuCaptureFile& f) -> size_t {
+        size_t rc = 0;
+        for (const auto& d : f.draws) rc += d.vrt.resources.size() + d.prt.resources.size();
+        for (const auto& cm : f.computes) rc += cm.resources.resources.size();
+        for (const auto& diagnostic : f.failure_diagnostics)
+            for (const auto& stage : diagnostic.stages)
+                rc += stage.resource_table.resources.size();
+        return 4 + 4 * rc;
+    };
+
     // v25 (#1240): byte length of the trailing resolve-state block.
     auto v25_tail = [](const GpuCaptureFile& f) -> size_t {
         size_t present_failures = 0;
@@ -474,6 +485,7 @@ int main() {
               v16_scissor_bytes.size() >= 25,
           "v17 capture serializes effective guest scissor state");
     if (v16_scissor_bytes.size() >= 25) {
+        v16_scissor_bytes.resize(v16_scissor_bytes.size() - v44_tail(v16_scissor_source));
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - v43_tail(v16_scissor_source));
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - v42_tail(v16_scissor_source));
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - v41_tail(v16_scissor_source));
@@ -545,6 +557,114 @@ int main() {
     CHECK(tail_loaded.draws[0].vrt.resources[0].resource.declared_mip_levels == 5,
           "#1280: v24 capture round-trips the T#-declared mip-chain length (was silently defaulting to 1)");
 
+    ShaderResource msaa_resource{};
+    msaa_resource.cls = ResourceClass::Texture; msaa_resource.binding = 4;
+    msaa_resource.gpu_addr = 0x900000; msaa_resource.size = 65536;
+    msaa_resource.format = DataFormat::Float32; msaa_resource.num_components = 1;
+    msaa_resource.img_dim = 6; msaa_resource.width = 64; msaa_resource.height = 64;
+    msaa_resource.sample_count = 4;
+    msaa_resource.tile_mode = static_cast<uint32_t>(TileMode::Sw64KbZX);
+    msaa_resource.compression_enabled = true;
+    msaa_resource.meta_pipe_aligned = true;
+    msaa_resource.metadata_addr = 0xa00000;
+    // Exact title-live depth-zero fast-clear metadata. Keep it in the ordinary metadata blob: an
+    // offline replay must be able to materialize +0 sample planes without process guest memory.
+    std::vector<uint32_t> msaa_htile(32768u / sizeof(uint32_t), 0u);
+    auto msaa_reader = [&](uint64_t addr, uint8_t* dst, size_t n) -> size_t {
+        if (addr >= msaa_resource.metadata_addr &&
+            addr < msaa_resource.metadata_addr + 32768u) {
+            const size_t offset = static_cast<size_t>(addr - msaa_resource.metadata_addr);
+            const size_t take = std::min(n, 32768u - offset);
+            std::memcpy(dst, reinterpret_cast<const uint8_t*>(msaa_htile.data()) + offset,
+                        take);
+            return take;
+        }
+        return tail_reader(addr, dst, n);
+    };
+    auto msaa_table = std::make_shared<ShaderResourceTable>();
+    msaa_table->resources = {msaa_resource};
+    DrawItem msaa_draw = draw; msaa_draw.vrt = msaa_table;
+    GpuCaptureFile msaa_capture;
+    CHECK(capture_draw_items({msaa_draw}, meta, msaa_reader, msaa_capture, error) &&
+              msaa_capture.blobs.size() == 2 &&
+              msaa_capture.blobs[0].bytes.size() == 65536 &&
+              msaa_capture.draws[0].vrt.resources[0].metadata_size == 32768u &&
+              msaa_capture.draws[0].vrt.resources[0].metadata_blob_index == 1u &&
+              msaa_capture.blobs[1].guest_addr == msaa_resource.metadata_addr &&
+              msaa_capture.blobs[1].bytes.size() == 32768u,
+          "2D_MSAA capture owns the tiled samples and exact HTILE metadata span");
+    std::vector<uint8_t> msaa_bytes;
+    GpuCaptureFile msaa_loaded;
+    const bool msaa_serialized = serialize_gpu_capture(msaa_capture, msaa_bytes, error);
+    if (!msaa_serialized) std::printf("  [diag] MSAA capture serialization: %s\n", error.c_str());
+    const bool msaa_deserialized = msaa_serialized &&
+        deserialize_gpu_capture(msaa_bytes, msaa_loaded, error);
+    if (!msaa_deserialized) std::printf("  [diag] MSAA capture deserialization: %s\n", error.c_str());
+    CHECK(msaa_deserialized &&
+              msaa_loaded.format_version == 44 &&
+              msaa_loaded.draws[0].vrt.resources[0].resource.sample_count == 4 &&
+              msaa_loaded.blobs.size() == 2 &&
+              msaa_loaded.blobs[1].bytes.size() == 32768u &&
+              std::all_of(msaa_loaded.blobs[1].bytes.begin(),
+                          msaa_loaded.blobs[1].bytes.end(),
+                          [](uint8_t value) { return value == 0u; }),
+          "v44 capture round-trips guest 2D_MSAA sample identity and self-contained "
+          "depth-zero HTILE");
+    GpuReplayFrame msaa_replay;
+    const bool msaa_materialized = msaa_deserialized &&
+        materialize_gpu_replay(msaa_loaded, msaa_replay, error);
+    const ShaderResource* replay_msaa_resource =
+        msaa_materialized && !msaa_replay.items.empty() && msaa_replay.items[0].vrt &&
+                !msaa_replay.items[0].vrt->resources.empty()
+            ? &msaa_replay.items[0].vrt->resources[0]
+            : nullptr;
+    CHECK(replay_msaa_resource && replay_msaa_resource->dcc_metadata_host_data &&
+              replay_msaa_resource->dcc_metadata_host_data_size == 32768u &&
+              std::all_of(replay_msaa_resource->dcc_metadata_host_data,
+                          replay_msaa_resource->dcc_metadata_host_data +
+                              replay_msaa_resource->dcc_metadata_host_data_size,
+                          [](uint8_t value) { return value == 0u; }),
+          "offline replay owns the complete zero-HTILE plane needed for fast-clear materialization");
+    std::vector<uint8_t> mismatched_msaa_metadata = msaa_bytes;
+    const uint32_t two_samples = 2;
+    std::memcpy(mismatched_msaa_metadata.data() + mismatched_msaa_metadata.size() - 4u,
+                &two_samples, sizeof(two_samples));
+    GpuCaptureFile mismatched_msaa_loaded;
+    CHECK(!deserialize_gpu_capture(
+                  mismatched_msaa_metadata, mismatched_msaa_loaded, error) &&
+              error == "invalid resource DCC metadata reference",
+          "v44 reader validates deferred HTILE size after reading append-only sample identity");
+    // v43 predates sample-count identity and therefore cannot carry a 2D_MSAA HTILE footprint.
+    // Build its compatibility fixture from the same resource with compression metadata explicitly
+    // unavailable, then remove only the v44 sample tail as an actual old writer would have done.
+    GpuCaptureFile v43_msaa_source = msaa_capture;
+    auto& v43_msaa_captured = v43_msaa_source.draws[0].vrt.resources[0];
+    v43_msaa_captured.resource.compression_enabled = false;
+    v43_msaa_captured.resource.meta_pipe_aligned = false;
+    v43_msaa_captured.resource.metadata_addr = 0;
+    v43_msaa_captured.resource.dcc_metadata_size = 0;
+    v43_msaa_captured.metadata_size = 0;
+    v43_msaa_captured.metadata_blob_index = 0xffffffffu;
+    v43_msaa_captured.metadata_blob_offset = 0;
+    v43_msaa_source.blobs.resize(1);
+    std::vector<uint8_t> v43_msaa_bytes;
+    CHECK(serialize_gpu_capture(v43_msaa_source, v43_msaa_bytes, error),
+          "current writer prepares an uncompressed v43 MSAA compatibility fixture");
+    v43_msaa_bytes.resize(v43_msaa_bytes.size() - v44_tail(v43_msaa_source));
+    v43_msaa_bytes[8] = 43;
+    v43_msaa_bytes[9] = v43_msaa_bytes[10] = v43_msaa_bytes[11] = 0;
+    GpuCaptureFile v43_msaa_loaded;
+    CHECK(deserialize_gpu_capture(v43_msaa_bytes, v43_msaa_loaded, error) &&
+              v43_msaa_loaded.draws[0].vrt.resources[0].resource.sample_count == 1,
+          "v43 capture reopens with the historical single-sample default");
+    // Keep this arm metadata-independent so the observed rejection is specifically the malformed
+    // sample count, not the necessarily-unavailable HTILE span for an unsupported 3xaa shape.
+    GpuCaptureFile invalid_msaa_capture = v43_msaa_source;
+    invalid_msaa_capture.draws[0].vrt.resources[0].resource.sample_count = 3;
+    CHECK(!serialize_gpu_capture(invalid_msaa_capture, msaa_bytes, error) &&
+              error == "invalid resource sample count",
+          "capture rejects a non-power-of-two guest sample count");
+
     auto large_table = std::make_shared<ShaderResourceTable>();
     ShaderResource large_resource = a;
     large_resource.size = 2u << 20;
@@ -585,7 +705,7 @@ int main() {
     };
     GpuCaptureFile video_capture;
     CHECK(capture_draw_items({video_draw}, meta, video_reader, video_capture, error) &&
-              video_capture.format_version == 43 && video_capture.blobs.size() == 1 &&
+              video_capture.format_version == 44 && video_capture.blobs.size() == 1 &&
               video_capture.blobs[0].bytes.size() == video_memory.size() &&
               video_capture.draws[0].prt.resources[0].captured_size == video_memory.size() &&
               video_capture.draws[0].prt.resources[0].resource.linear_row_pitch_bytes == 2048,
@@ -595,7 +715,7 @@ int main() {
     GpuReplayFrame video_replay;
     CHECK(serialize_gpu_capture(video_capture, video_capture_bytes, error) &&
               deserialize_gpu_capture(video_capture_bytes, video_loaded, error) &&
-              video_loaded.format_version == 43 &&
+              video_loaded.format_version == 44 &&
               video_loaded.draws[0].prt.resources[0].captured_size == video_memory.size() &&
               video_loaded.draws[0].prt.resources[0].resource.linear_row_pitch_bytes == 2048 &&
               materialize_gpu_replay(video_loaded, video_replay, error) &&
@@ -618,7 +738,7 @@ int main() {
     GpuReplayFrame upgraded_video_replay;
     CHECK(serialize_gpu_capture(legacy_video, upgraded_video_bytes, error) &&
               deserialize_gpu_capture(upgraded_video_bytes, upgraded_video, error) &&
-              upgraded_video.format_version == 43 &&
+              upgraded_video.format_version == 44 &&
               upgraded_video.draws[0].prt.resources[0].captured_size == video_chroma.size &&
               upgraded_video.draws[0].prt.resources[0].resource.linear_row_pitch_bytes == 2048 &&
               materialize_gpu_replay(upgraded_video, upgraded_video_replay, error) &&
@@ -700,7 +820,7 @@ int main() {
           "Plucky RGBA16 32-cubed S3 capture uses its four true 3D macroblocks");
     CHECK(serialize_gpu_capture(array_layout_capture, array_layout_bytes, error) &&
               deserialize_gpu_capture(array_layout_bytes, array_layout_loaded, error) &&
-              array_layout_loaded.format_version == 43 &&
+              array_layout_loaded.format_version == 44 &&
               array_layout_loaded.draws[0].vrt.resources[0].resource.layer_stride_bytes == 720896u &&
               array_layout_loaded.draws[0].vrt.resources[0].resource.layer_mip_offset_bytes == 65536u,
           "v32 capture round-trips thin-array slice stride and selected-mip offset");
@@ -799,6 +919,7 @@ int main() {
           "writer rejects an out-of-bounds DCC metadata reference");
     CHECK(serialize_gpu_capture(volume_capture, volume_bytes, error),
           "recreated valid v12 DCC bytes after malformed-reference check");
+    volume_bytes.resize(volume_bytes.size() - v44_tail(volume_capture));
     volume_bytes.resize(volume_bytes.size() - v43_tail(volume_capture));
     volume_bytes.resize(volume_bytes.size() - v42_tail(volume_capture));
     volume_bytes.resize(volume_bytes.size() - v41_tail(volume_capture));
@@ -900,6 +1021,7 @@ int main() {
     CHECK(serialize_gpu_capture(pre_v31_source, v20_bytes, error) && v20_bytes.size() >= 21,
           "v21 capture serializes the logic-op extension");
     if (v20_bytes.size() >= 21) {
+        v20_bytes.resize(v20_bytes.size() - v44_tail(pre_v31_source));
         v20_bytes.resize(v20_bytes.size() - v43_tail(pre_v31_source));
         v20_bytes.resize(v20_bytes.size() - v42_tail(pre_v31_source));
         v20_bytes.resize(v20_bytes.size() - v41_tail(pre_v31_source));
@@ -976,6 +1098,7 @@ int main() {
         std::vector<uint8_t> v42_bytes;
         CHECK(serialize_gpu_capture(captured, v42_bytes, error),
               "v43 capture serializes before the color-state downgrade");
+        v42_bytes.resize(v42_bytes.size() - v44_tail(captured));
         v42_bytes.resize(v42_bytes.size() - v43_tail(captured));
         v42_bytes[8] = 42; v42_bytes[9] = v42_bytes[10] = v42_bytes[11] = 0;
         GpuCaptureFile v42_loaded;
@@ -996,7 +1119,8 @@ int main() {
     std::vector<uint8_t> v24_resolve_bytes;
     GpuCaptureFile v24_resolve_loaded;
     CHECK(serialize_gpu_capture(pre_v31_source, v24_resolve_bytes, error) &&
-          v24_resolve_bytes.size() >= v43_tail(pre_v31_source) + v42_tail(pre_v31_source) +
+          v24_resolve_bytes.size() >= v44_tail(pre_v31_source) +
+              v43_tail(pre_v31_source) + v42_tail(pre_v31_source) +
               v41_tail(pre_v31_source) +
               v40_tail(pre_v31_source) +
               v39_tail(pre_v31_source) +
@@ -1009,7 +1133,8 @@ int main() {
               v27_tail(pre_v31_source) + v26_tail(pre_v31_source) +
               v25_tail(pre_v31_source),
           "v25 capture exposes a removable trailing resolve-state block");
-    if (v24_resolve_bytes.size() >= v43_tail(pre_v31_source) + v42_tail(pre_v31_source) +
+    if (v24_resolve_bytes.size() >= v44_tail(pre_v31_source) +
+            v43_tail(pre_v31_source) + v42_tail(pre_v31_source) +
             v41_tail(pre_v31_source) +
             v40_tail(pre_v31_source) +
             v39_tail(pre_v31_source) +
@@ -1021,6 +1146,7 @@ int main() {
             v29_tail(pre_v31_source) + v28_tail(pre_v31_source) +
             v27_tail(pre_v31_source) + v26_tail(pre_v31_source) +
             v25_tail(pre_v31_source)) {
+        v24_resolve_bytes.resize(v24_resolve_bytes.size() - v44_tail(pre_v31_source));
         v24_resolve_bytes.resize(v24_resolve_bytes.size() - v43_tail(pre_v31_source));
         v24_resolve_bytes.resize(v24_resolve_bytes.size() - v42_tail(pre_v31_source));
         v24_resolve_bytes.resize(v24_resolve_bytes.size() - v41_tail(pre_v31_source));
@@ -1118,7 +1244,9 @@ int main() {
               v37_compatible_bytes.size() >= 12,
           "current capture prepares the layout-compatible v37 fixture");
     if (v37_compatible_bytes.size() >=
-        v43_tail(captured) + v42_tail(captured) + v41_tail(captured) + v40_tail(captured) + v39_tail(captured)) {
+        v44_tail(captured) + v43_tail(captured) + v42_tail(captured) + v41_tail(captured) +
+            v40_tail(captured) + v39_tail(captured)) {
+        v37_compatible_bytes.resize(v37_compatible_bytes.size() - v44_tail(captured));
         v37_compatible_bytes.resize(v37_compatible_bytes.size() - v43_tail(captured));
         v37_compatible_bytes.resize(v37_compatible_bytes.size() - v42_tail(captured));
         v37_compatible_bytes.resize(v37_compatible_bytes.size() - v41_tail(captured));
@@ -1309,16 +1437,19 @@ int main() {
     v36_compute_source.raw_shader_versions.clear();
     CHECK(serialize_gpu_capture(v36_compute_source, v36_compute_bytes, error) &&
               v36_compute_bytes.size() >=
-                  v43_tail(v36_compute_source) + v42_tail(v36_compute_source) + v41_tail(v36_compute_source) +
+                  v44_tail(v36_compute_source) + v43_tail(v36_compute_source) +
+                      v42_tail(v36_compute_source) + v41_tail(v36_compute_source) +
                       v40_tail(v36_compute_source) +
                       v39_tail(v36_compute_source) +
                       v37_tail(v36_compute_source),
           "v37 capture exposes a removable compute subgroup-contract tail");
     if (v36_compute_bytes.size() >=
-        v43_tail(v36_compute_source) + v42_tail(v36_compute_source) + v41_tail(v36_compute_source) +
+        v44_tail(v36_compute_source) + v43_tail(v36_compute_source) +
+            v42_tail(v36_compute_source) + v41_tail(v36_compute_source) +
             v40_tail(v36_compute_source) +
             v39_tail(v36_compute_source) +
             v37_tail(v36_compute_source)) {
+        v36_compute_bytes.resize(v36_compute_bytes.size() - v44_tail(v36_compute_source));
         v36_compute_bytes.resize(v36_compute_bytes.size() - v43_tail(v36_compute_source));
         v36_compute_bytes.resize(v36_compute_bytes.size() - v42_tail(v36_compute_source));
         v36_compute_bytes.resize(v36_compute_bytes.size() - v41_tail(v36_compute_source));
@@ -1525,7 +1656,7 @@ int main() {
     GpuCaptureFile failed_compute_loaded;
     CHECK(serialize_gpu_capture(failed_compute_capture, failed_compute_bytes, error) &&
               deserialize_gpu_capture(failed_compute_bytes, failed_compute_loaded, error) &&
-              failed_compute_loaded.format_version == 43 &&
+              failed_compute_loaded.format_version == 44 &&
               failed_compute_loaded.failure_diagnostics[0].compute_launch.threads_x == 37 &&
               failed_compute_loaded.failure_diagnostics[0].stages[0]
                       .recompile_config.user_sgprs ==
@@ -1538,7 +1669,8 @@ int main() {
 
     std::vector<uint8_t> v41_failed_compute_bytes = failed_compute_bytes;
     v41_failed_compute_bytes.resize(
-        v41_failed_compute_bytes.size() - v43_tail(failed_compute_capture) -
+        v41_failed_compute_bytes.size() - v44_tail(failed_compute_capture) -
+            v43_tail(failed_compute_capture) -
             v42_tail(failed_compute_capture));
     v41_failed_compute_bytes[8] = 41;
     v41_failed_compute_bytes[9] = v41_failed_compute_bytes[10] =
@@ -1701,11 +1833,26 @@ int main() {
     failed_shadow.resource.metadata_addr = 0x5006d00000ull;
     failed_shadow.captured_size = 987654;
     failed_shadow.metadata_size = gpu_capture_dcc_metadata_footprint(failed_shadow.resource);
+    GpuCapturedResource failed_msaa;
+    failed_msaa.resource.cls = ResourceClass::Texture;
+    failed_msaa.resource.format = DataFormat::Float32;
+    failed_msaa.resource.num_components = 1;
+    failed_msaa.resource.binding = 98;
+    failed_msaa.resource.gpu_addr = 0x5007d00000ull;
+    failed_msaa.resource.size = 65536;
+    failed_msaa.resource.img_dim = 6;
+    failed_msaa.resource.width = 64;
+    failed_msaa.resource.height = 64;
+    failed_msaa.resource.depth = 1;
+    failed_msaa.resource.sample_count = 4;
+    failed_msaa.resource.tile_mode = static_cast<uint32_t>(TileMode::Sw64KbZX);
+    failed_msaa.resource.declared_mip_levels = 1;
+    failed_msaa.captured_size = 65536;
     if (mutable_failed_stage != failed_capture.failure_diagnostics[0].stages.end()) {
         mutable_failed_stage->resource_table.present = true;
-        mutable_failed_stage->resource_table.resources = {failed_shadow};
+        mutable_failed_stage->resource_table.resources = {failed_shadow, failed_msaa};
         mutable_failed_stage->resource_table_present = true;
-        mutable_failed_stage->resource_count = 1;
+        mutable_failed_stage->resource_count = 2;
     }
     CHECK(write_gpu_capture(failed_path.string(), failed_capture, error),
           "failed-operation diagnostic capture writes linked vertex programs");
@@ -1730,12 +1877,17 @@ int main() {
         failed_loaded.failure_diagnostics[0].stages.end(), [](const auto& stage) {
             return stage.stage == ShaderProgramStage::Fragment;
         });
-    const GpuCapturedResource* loaded_shadow =
-        loaded_failed_stage != failed_loaded.failure_diagnostics[0].stages.end() &&
-                loaded_failed_stage->resource_table.resources.size() == 1
-            ? &loaded_failed_stage->resource_table.resources[0]
-            : nullptr;
-    CHECK(failed_loaded.format_version == 43 && loaded_shadow &&
+    const GpuCapturedResource* loaded_shadow = nullptr;
+    const GpuCapturedResource* loaded_failed_msaa = nullptr;
+    if (loaded_failed_stage != failed_loaded.failure_diagnostics[0].stages.end()) {
+        for (const auto& resource : loaded_failed_stage->resource_table.resources) {
+            if (resource.resource.binding == failed_shadow.resource.binding)
+                loaded_shadow = &resource;
+            if (resource.resource.binding == failed_msaa.resource.binding)
+                loaded_failed_msaa = &resource;
+        }
+    }
+    CHECK(failed_loaded.format_version == 44 && loaded_shadow &&
           loaded_shadow->resource.depth == 4 &&
           loaded_shadow->resource.max_uncompressed_block_size == 2 &&
           loaded_shadow->resource.max_compressed_block_size == 1 &&
@@ -1759,17 +1911,40 @@ int main() {
           loaded_shadow->resource.flat_base_sgpr == 12 &&
           loaded_shadow->resource.bvh_box_grow == 9 &&
           loaded_shadow->metadata_size == failed_shadow.metadata_size &&
-          loaded_shadow->resource.dcc_metadata_size == failed_shadow.metadata_size,
+          loaded_shadow->resource.dcc_metadata_size == failed_shadow.metadata_size &&
+          loaded_failed_msaa && loaded_failed_msaa->resource.img_dim == 6 &&
+          loaded_failed_msaa->resource.sample_count == 4 &&
+          loaded_failed_msaa->captured_size == 65536,
           "v41 failed-stage resources round-trip complete descriptor and codegen state");
+
+    std::vector<uint8_t> malformed_failed_sample_bytes;
+    CHECK(serialize_gpu_capture(failed_capture, malformed_failed_sample_bytes, error),
+          "v44 failed-stage sample identity prepares a corruption fixture");
+    if (malformed_failed_sample_bytes.size() >= sizeof(uint32_t)) {
+        const uint32_t invalid_samples = 3;
+        // Fragment is the final stage with resources, and its MSAA descriptor is the final resource,
+        // so this is exactly its v44 sample-count record rather than a preceding extension field.
+        std::memcpy(malformed_failed_sample_bytes.data() +
+                        malformed_failed_sample_bytes.size() - sizeof(uint32_t),
+                    &invalid_samples, sizeof(invalid_samples));
+    }
+    GpuCaptureFile malformed_failed_sample_loaded;
+    CHECK(!deserialize_gpu_capture(malformed_failed_sample_bytes,
+                                   malformed_failed_sample_loaded, error) &&
+              error == "invalid resource sample count",
+          "v44 reader rejects a malformed failed-stage sample-count tail");
 
     std::vector<uint8_t> v40_failed_bytes;
     GpuCaptureFile v40_failed_loaded;
     CHECK(serialize_gpu_capture(failed_capture, v40_failed_bytes, error) &&
               v40_failed_bytes.size() >=
-                  v43_tail(failed_capture) + v42_tail(failed_capture) + v41_tail(failed_capture),
+                  v44_tail(failed_capture) + v43_tail(failed_capture) +
+                      v42_tail(failed_capture) + v41_tail(failed_capture),
           "v41 failed-stage resource tail is removable for a v40 compatibility fixture");
     if (v40_failed_bytes.size() >=
-        v43_tail(failed_capture) + v42_tail(failed_capture) + v41_tail(failed_capture)) {
+        v44_tail(failed_capture) + v43_tail(failed_capture) +
+            v42_tail(failed_capture) + v41_tail(failed_capture)) {
+        v40_failed_bytes.resize(v40_failed_bytes.size() - v44_tail(failed_capture));
         v40_failed_bytes.resize(v40_failed_bytes.size() - v43_tail(failed_capture));
         v40_failed_bytes.resize(v40_failed_bytes.size() - v42_tail(failed_capture));
         v40_failed_bytes.resize(v40_failed_bytes.size() - v41_tail(failed_capture));
@@ -1783,11 +1958,11 @@ int main() {
         v40_failed_loaded.failure_diagnostics[0].stages.end(), [](const auto& stage) {
             return stage.stage == ShaderProgramStage::Fragment;
         });
-    const GpuCapturedResource* v40_shadow =
-        v40_failed_stage != v40_failed_loaded.failure_diagnostics[0].stages.end() &&
-                v40_failed_stage->resource_table.resources.size() == 1
-            ? &v40_failed_stage->resource_table.resources[0]
-            : nullptr;
+    const GpuCapturedResource* v40_shadow = nullptr;
+    if (v40_failed_stage != v40_failed_loaded.failure_diagnostics[0].stages.end())
+        for (const auto& resource : v40_failed_stage->resource_table.resources)
+            if (resource.resource.binding == failed_shadow.resource.binding)
+                v40_shadow = &resource;
     CHECK(v40_failed_loaded.format_version == 40 && v40_shadow &&
           v40_shadow->resource.bvh_box_grow == 9 && v40_shadow->resource.depth == 1 &&
           !v40_shadow->resource.meta_pipe_aligned &&
@@ -1852,6 +2027,7 @@ int main() {
     if (v13_bytes.size() >= 32) {
         const size_t legacy_resource_count = legacy_source.draws[0].vrt.resources.size() +
                                              legacy_source.draws[0].prt.resources.size();
+        v13_bytes.resize(v13_bytes.size() - v44_tail(legacy_source));
         v13_bytes.resize(v13_bytes.size() - v43_tail(legacy_source));
         v13_bytes.resize(v13_bytes.size() - v42_tail(legacy_source));
         v13_bytes.resize(v13_bytes.size() - v41_tail(legacy_source));
@@ -1893,6 +2069,7 @@ int main() {
     if (legacy_bytes.size() >= 32) {
         const size_t legacy_resource_count = legacy_source.draws[0].vrt.resources.size() +
                                              legacy_source.draws[0].prt.resources.size();
+        legacy_bytes.resize(legacy_bytes.size() - v44_tail(legacy_source));
         legacy_bytes.resize(legacy_bytes.size() - v43_tail(legacy_source));
         legacy_bytes.resize(legacy_bytes.size() - v42_tail(legacy_source));
         legacy_bytes.resize(legacy_bytes.size() - v41_tail(legacy_source));
@@ -1960,9 +2137,9 @@ int main() {
     CHECK(deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
           !legacy_loaded.failure_diagnostics_available && legacy_loaded.failure_diagnostics.empty(),
           "v6 capture reopens with failed-operation diagnostics reported unavailable");
-    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 44;   // kVersion + 1: a future version
+    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 45;   // kVersion + 1: a future version
     CHECK(!deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
-          error == "unsupported capture version 44",
+          error == "unsupported capture version 45",
           "future capture versions fail with a concrete version error");
 
     GpuCaptureFile bad_hash = mixed;

--- a/prosper/tests/test_gpu_capture_render.cpp
+++ b/prosper/tests/test_gpu_capture_render.cpp
@@ -1267,6 +1267,38 @@ int main() {
         CHECK(!texture_decode_cache_candidate(true, false, false, 1u, true, true),
               "a retained color image bypasses guest-byte decode-cache work");
 
+        using prosper::frontend::sampled_msaa_fetch_shape_supported;
+        ShaderResource exact_msaa{};
+        exact_msaa.cls = ResourceClass::Texture;
+        exact_msaa.img_dim = 6;
+        exact_msaa.sample_count = 4;
+        exact_msaa.tile_mode = 24;
+        exact_msaa.format = DataFormat::Float32;
+        exact_msaa.num_components = 1;
+        exact_msaa.depth = 1;
+        exact_msaa.declared_mip_levels = 1;
+        CHECK(sampled_msaa_fetch_shape_supported(
+                  exact_msaa, /*is_storage_image=*/false,
+                  /*reflected_msaa_fetch=*/true),
+              "the exact reflected 4x R32F 2D_MSAA shape reaches materialization");
+        ShaderResource wrong_msaa_format = exact_msaa;
+        wrong_msaa_format.format = DataFormat::Uint32;
+        ShaderResource wrong_msaa_count = exact_msaa;
+        wrong_msaa_count.sample_count = 2;
+        ShaderResource wrong_msaa_layout = exact_msaa;
+        wrong_msaa_layout.tile_mode = 27;
+        CHECK(!sampled_msaa_fetch_shape_supported(
+                   wrong_msaa_format, false, true) &&
+                  !sampled_msaa_fetch_shape_supported(
+                   wrong_msaa_count, false, true) &&
+                  !sampled_msaa_fetch_shape_supported(
+                   wrong_msaa_layout, false, true) &&
+                  !sampled_msaa_fetch_shape_supported(
+                   exact_msaa, true, true) &&
+                  !sampled_msaa_fetch_shape_supported(
+                   exact_msaa, false, false),
+              "wrong MSAA format, count, layout, storage class, and reflection remain fail-visible");
+
         using prosper::frontend::persistent_texture_decode_cache_eligible;
         CHECK(persistent_texture_decode_cache_eligible(
                   /*guest_decode_candidate=*/true, /*compute_image_hit=*/false,

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -2,6 +2,7 @@
 #include "../src/gpu/rdna2_to_spirv.hpp"
 #include "../src/gpu/shader_resources.hpp"
 #include <algorithm>
+#include <array>
 #include <cstdint>
 #include <cstdio>
 #include <iterator>
@@ -151,6 +152,43 @@ bool has_explicit_lod_constant(const std::vector<uint32_t>& spv, uint32_t expect
                 value_id = bitcast->second;
             const auto value = constants.find(value_id);
             if (value != constants.end() && value->second == expected) return true;
+        }
+        i += wc;
+    }
+    return false;
+}
+
+// Resolve the integer coordinate constructed for OpImageFetch and prove its three components are the
+// requested literals. The third component is especially important for guest 2D_MSAA: it must be the
+// explicit sample VGPR, because the host representation stores each sample plane as an array layer.
+bool image_fetch_coord_literals(const std::vector<uint32_t>& spv,
+                                uint32_t x, uint32_t y, uint32_t layer) {
+    constexpr uint32_t OpConstant = 43, OpCompositeConstruct = 80, OpImageFetch = 95;
+    std::unordered_map<uint32_t, uint32_t> constants;
+    std::unordered_map<uint32_t, std::array<uint32_t, 3>> vectors;
+    if (spv.size() < 5) return false;
+    for (size_t i = 5; i < spv.size();) {
+        const uint32_t op = spv[i] & 0xffffu, wc = spv[i] >> 16u;
+        if (!wc || i + wc > spv.size()) return false;
+        if (op == OpConstant && wc == 4) constants[spv[i + 2]] = spv[i + 3];
+        if (op == OpCompositeConstruct && wc == 6)
+            vectors[spv[i + 2]] = {spv[i + 3], spv[i + 4], spv[i + 5]};
+        i += wc;
+    }
+    for (size_t i = 5; i < spv.size();) {
+        const uint32_t op = spv[i] & 0xffffu, wc = spv[i] >> 16u;
+        if (!wc || i + wc > spv.size()) return false;
+        if (op == OpImageFetch && wc >= 7) {
+            const auto coordinate = vectors.find(spv[i + 4]);
+            if (coordinate != vectors.end()) {
+                const auto& ids = coordinate->second;
+                const auto cx = constants.find(ids[0]);
+                const auto cy = constants.find(ids[1]);
+                const auto cl = constants.find(ids[2]);
+                if (cx != constants.end() && cy != constants.end() && cl != constants.end() &&
+                    cx->second == x && cy->second == y && cl->second == layer)
+                    return true;
+            }
         }
         i += wc;
     }
@@ -2631,6 +2669,133 @@ int main() {
         return 1;
     }
     printf("  [ok]   2D-array image_sample_l retains its layer coordinate and reflected view shape\n");
+
+    // Exact title-live IMAGE_LOAD packet: v5/v6 are integer x/y and v7 is the guest sample index.
+    // The host descriptor is deliberately arrayed but non-multisampled; unlike the ordinary 2D-array
+    // sample above it is texel-space (OpImageFetch), and ShaderResource keeps img_dim/sample_count so
+    // backend identity cannot alias these two guest resource kinds.
+    const uint32_t cs_msaa_load_sample3[] = {
+        0x7e0a0280u,                       // v_mov_b32 v5, 0 (x)
+        0x7e0c0280u,                       // v_mov_b32 v6, 0 (y)
+        0x7e0e0283u,                       // v_mov_b32 v7, 3 (sample)
+        0xf0000130u, 0x00000305u,         // image_load v3, v[5:7], s[0:7] dmask:x dim:2D_MSAA
+        0xbf810000u,
+    };
+    ShaderResourceTable rt_msaa;
+    { ShaderResource texture{}; texture.cls = ResourceClass::Texture;
+      texture.format = DataFormat::Float32; texture.num_components = 1;
+      texture.binding = 4; texture.sgpr_base = 0; texture.img_dim = 6;
+      texture.width = 1; texture.height = 1; texture.depth = 1;
+      texture.sample_count = 4; texture.declared_mip_levels = 1;
+      texture.gpu_addr = 0x200000; texture.size = 4 * sizeof(float);
+      rt_msaa.resources.push_back(texture); }
+    const std::vector<uint32_t> msaa_spv = recompile_valu(
+        cs_msaa_load_sample3, std::size(cs_msaa_load_sample3), 8, 0, &rt_msaa);
+    const DescriptorValidationReport msaa_report = validate_spirv_descriptor_interface(
+        msaa_spv, &rt_msaa, 0, SpirvShaderStage::Compute);
+    const SpirvDescriptorBinding* msaa_descriptor = nullptr;
+    for (const auto& descriptor : msaa_report.descriptors)
+        if (descriptor.binding == 4u &&
+            descriptor.kind == SpirvDescriptorKind::CombinedImageSampler)
+            msaa_descriptor = &descriptor;
+    if (msaa_spv.empty() || !msaa_descriptor ||
+        msaa_descriptor->image_dim != 1u || !msaa_descriptor->image_arrayed ||
+        msaa_descriptor->image_multisampled || !msaa_descriptor->texel_access ||
+        msaa_descriptor->normalized_sampling ||
+        !array_l_descriptor->image_arrayed || !array_l_descriptor->normalized_sampling ||
+        array_l_descriptor->texel_access || rt_array.resources[0].sample_count != 1u ||
+        rt_msaa.resources[0].sample_count != 4u) {
+        printf("  [FAIL] guest 2D_MSAA load did not retain its distinct host-array fetch contract "
+               "(words=%zu issues=%zu desc=%zu shape=%u/%d/%d access=%d/%d)\n",
+               msaa_spv.size(), msaa_report.issues.size(), msaa_report.descriptors.size(),
+               msaa_descriptor ? msaa_descriptor->image_dim : UINT32_MAX,
+               msaa_descriptor ? msaa_descriptor->image_arrayed : false,
+               msaa_descriptor ? msaa_descriptor->image_multisampled : false,
+               msaa_descriptor ? msaa_descriptor->texel_access : false,
+               msaa_descriptor ? msaa_descriptor->normalized_sampling : false);
+        return 1;
+    }
+    printf("  [ok]   guest 2D_MSAA fetch is distinct from ordinary 2D-array sampling in reflection and resource identity\n");
+    if (!image_fetch_coord_literals(msaa_spv, 0u, 0u, 3u)) {
+        printf("  [FAIL] 2D_MSAA IMAGE_LOAD did not use the explicit sample VGPR as its host array layer\n");
+        return 1;
+    }
+    uint32_t cs_msaa_load_sample1[std::size(cs_msaa_load_sample3)];
+    std::copy(std::begin(cs_msaa_load_sample3), std::end(cs_msaa_load_sample3),
+              cs_msaa_load_sample1);
+    cs_msaa_load_sample1[2] = 0x7e0e0281u; // mutate only v7: guest sample 3 -> sample 1
+    const std::vector<uint32_t> msaa_sample1_spv = recompile_valu(
+        cs_msaa_load_sample1, std::size(cs_msaa_load_sample1), 8, 0, &rt_msaa);
+    if (!image_fetch_coord_literals(msaa_sample1_spv, 0u, 0u, 1u) ||
+        image_fetch_coord_literals(msaa_sample1_spv, 0u, 0u, 3u)) {
+        printf("  [FAIL] changing the explicit guest sample VGPR did not change the host layer coordinate\n");
+        return 1;
+    }
+    printf("  [ok]   the explicit guest sample VGPR independently selects the host array layer\n");
+
+    // The same title shader uses the one-extra-dword NSA encoding for its other three samples.
+    // llvm-mc gfx1030 disassembles this exact packet as
+    //   image_load v2, [v5, v6, v2], s[0:7] dmask:x dim:2D_MSAA
+    // so the sample VGPR is the second byte of the extra word, independently of VADDR adjacency.
+    const uint32_t cs_msaa_nsa_sample1[] = {
+        0x7e0a0280u,                       // v_mov_b32 v5, 0 (x)
+        0x7e0c0280u,                       // v_mov_b32 v6, 0 (y)
+        0x7e040281u,                       // v_mov_b32 v2, 1 (sample)
+        0x7e060283u,                       // v_mov_b32 v3, 3 (mutation sample)
+        0xf0000132u, 0x00000205u, 0x00000206u,
+        0xbf810000u,
+    };
+    const std::vector<uint32_t> msaa_nsa_sample1_spv = recompile_valu(
+        cs_msaa_nsa_sample1, std::size(cs_msaa_nsa_sample1), 8, 0, &rt_msaa);
+    if (!image_fetch_coord_literals(msaa_nsa_sample1_spv, 0u, 0u, 1u)) {
+        printf("  [FAIL] exact title NSA address did not map its third explicit VGPR to the host layer\n");
+        return 1;
+    }
+    uint32_t cs_msaa_nsa_sample3[std::size(cs_msaa_nsa_sample1)];
+    std::copy(std::begin(cs_msaa_nsa_sample1), std::end(cs_msaa_nsa_sample1),
+              cs_msaa_nsa_sample3);
+    cs_msaa_nsa_sample3[6] = 0x00000306u; // mutate only words[2].byte1: sample v2 -> v3
+    const std::vector<uint32_t> msaa_nsa_sample3_spv = recompile_valu(
+        cs_msaa_nsa_sample3, std::size(cs_msaa_nsa_sample3), 8, 0, &rt_msaa);
+    if (!image_fetch_coord_literals(msaa_nsa_sample3_spv, 0u, 0u, 3u) ||
+        image_fetch_coord_literals(msaa_nsa_sample3_spv, 0u, 0u, 1u)) {
+        printf("  [FAIL] mutating only the NSA sample byte did not change the host layer coordinate\n");
+        return 1;
+    }
+    printf("  [ok]   exact title NSA address bytes independently select the host array layer\n");
+
+    uint32_t unsupported_msaa_nsa_bytes[std::size(cs_msaa_nsa_sample1)];
+    std::copy(std::begin(cs_msaa_nsa_sample1), std::end(cs_msaa_nsa_sample1),
+              unsupported_msaa_nsa_bytes);
+    unsupported_msaa_nsa_bytes[6] |= 0x00010000u; // a nonzero, unmodelled fourth address byte
+    const uint32_t unsupported_msaa_two_extra[] = {
+        0x7e0a0280u, 0x7e0c0280u, 0x7e040281u,
+        0xf0000134u, 0x00000205u, 0x00000206u, 0x00000000u,
+        0xbf810000u,
+    };
+    if (!recompile_valu(unsupported_msaa_nsa_bytes, std::size(unsupported_msaa_nsa_bytes),
+                        8, 0, &rt_msaa).empty() ||
+        !recompile_valu(unsupported_msaa_two_extra, std::size(unsupported_msaa_two_extra),
+                        8, 0, &rt_msaa).empty()) {
+        printf("  [FAIL] unproved NSA address bytes/counts did not remain fail-visible\n");
+        return 1;
+    }
+    printf("  [ok]   unproved NSA address bytes and extra-dword counts remain fail-visible\n");
+
+    ShaderResourceTable unsupported_msaa = rt_msaa;
+    unsupported_msaa.resources[0].sample_count = 2;
+    uint32_t unsupported_msaa_op[std::size(cs_msaa_load_sample3)];
+    std::copy(std::begin(cs_msaa_load_sample3), std::end(cs_msaa_load_sample3),
+              unsupported_msaa_op);
+    unsupported_msaa_op[3] |= 0x00800000u; // IMAGE_SAMPLE opcode with dim:2D_MSAA
+    if (!recompile_valu(cs_msaa_load_sample3, std::size(cs_msaa_load_sample3),
+                        8, 0, &unsupported_msaa).empty() ||
+        !recompile_valu(unsupported_msaa_op, std::size(unsupported_msaa_op),
+                        8, 0, &rt_msaa).empty()) {
+        printf("  [FAIL] unsupported MSAA count/opcode did not remain fail-visible\n");
+        return 1;
+    }
+    printf("  [ok]   unsupported MSAA counts and sampled opcodes remain fail-visible\n");
 
     // The same map kernel reads its two-layer RGBA atlas with the NSA SAMPLE_LZ form. Its third
     // coordinate is still a layer, despite the fixed level zero, and must select an array view too.

--- a/prosper/tests/test_recompile_coverage.cpp
+++ b/prosper/tests/test_recompile_coverage.cpp
@@ -845,6 +845,40 @@ int main() {
     CHECK(f.unsupported == 0 && f.table_dependent >= 1 && f.first_bad_fmt < 0,
           "#325: a 2D_ARRAY image_sample is recompilable-in-context (base slice), not unsupported");
 
+    // Asterix's resolve PS mixes the ordinary and exact one-extra-word NSA 2D_MSAA IMAGE_LOAD
+    // encodings. Coverage is table-less, but it can still distinguish the address shapes the real
+    // resource-aware emitter accepts from superficially similar, deliberately unsupported packets.
+    const uint32_t msaa_load_consecutive[] = {
+        0xf0000130u, 0x00000305u, 0xbf810000u,
+    };
+    const uint32_t msaa_load_nsa[] = {
+        0xf0000132u, 0x00000205u, 0x00000206u, 0xbf810000u,
+    };
+    const RecompileCoverage msaa_consecutive = recompile_coverage(
+        msaa_load_consecutive, std::size(msaa_load_consecutive));
+    const RecompileCoverage msaa_nsa = recompile_coverage(
+        msaa_load_nsa, std::size(msaa_load_nsa));
+    CHECK(msaa_consecutive.total == 1 && msaa_consecutive.table_dependent == 1 &&
+              msaa_consecutive.unsupported == 0 && msaa_nsa.total == 1 &&
+              msaa_nsa.table_dependent == 1 && msaa_nsa.unsupported == 0,
+          "exact consecutive and NSA 2D_MSAA loads report recompilable-in-context");
+
+    uint32_t msaa_load_nsa_unused[std::size(msaa_load_nsa)];
+    std::copy(std::begin(msaa_load_nsa), std::end(msaa_load_nsa),
+              msaa_load_nsa_unused);
+    msaa_load_nsa_unused[2] |= 0x00010000u;
+    const uint32_t msaa_array_load[] = {
+        0xf0000138u, 0x00000305u, 0xbf810000u, // DIM=2D_MSAA_ARRAY remains unsupported
+    };
+    const RecompileCoverage msaa_unused = recompile_coverage(
+        msaa_load_nsa_unused, std::size(msaa_load_nsa_unused));
+    const RecompileCoverage msaa_array = recompile_coverage(
+        msaa_array_load, std::size(msaa_array_load));
+    CHECK(msaa_unused.total == 1 && msaa_unused.table_dependent == 0 &&
+              msaa_unused.unsupported == 1 && msaa_array.total == 1 &&
+              msaa_array.table_dependent == 0 && msaa_array.unsupported == 1,
+          "unused NSA address bytes and 2D_MSAA_ARRAY remain honestly unsupported");
+
     const uint32_t cvt_i4[] = { 0x7e001d00u, 0xBF810000u }; // v_cvt_off_f32_i4 v0,v0
     RecompileCoverage g = recompile_coverage(cvt_i4, sizeof(cvt_i4)/sizeof(cvt_i4[0]));
     CHECK(g.total == 1 && g.alu == 1 && g.unsupported == 0,

--- a/prosper/tests/test_shader_recompile_cache.cpp
+++ b/prosper/tests/test_shader_recompile_cache.cpp
@@ -790,6 +790,45 @@ int main() {
               stats.misses == 6 && stats.hits == 1 && stats.entries == 6,
           "shader cache separates every manual shadow-comparison codegen field");
 
+    // The exact Asterix NSA 2D_MSAA IMAGE_LOAD lowers four guest samples to four host array layers.
+    // sample_count is therefore codegen state, not upload-only descriptor state: a cached 4x module
+    // must never satisfy the deliberately unsupported 2x table, while an identical 4x table must hit.
+    clear_shader_recompile_cache();
+    static const uint32_t kMsaaLoadPs[] = {
+        0x7e0a0280u,                       // v_mov_b32 v5, 0 (x)
+        0x7e0c0280u,                       // v_mov_b32 v6, 0 (y)
+        0x7e040281u,                       // v_mov_b32 v2, 1 (sample)
+        0xf0000132u, 0x00000205u, 0x00000206u, // image_load v2, [v5,v6,v2], s[0:7]
+        0xbf8c0f70u,                       // s_waitcnt vmcnt(0)
+        0xf800180fu, 0x02020202u,         // exp mrt0 v2,v2,v2,v2
+        0xbf810000u,
+    };
+    ShaderResource msaa_texture;
+    msaa_texture.cls = ResourceClass::Texture;
+    msaa_texture.format = DataFormat::Float32;
+    msaa_texture.num_components = 1;
+    msaa_texture.binding = 4;
+    msaa_texture.sgpr_base = 0;
+    msaa_texture.img_dim = 6;
+    msaa_texture.width = 1;
+    msaa_texture.height = 1;
+    msaa_texture.depth = 1;
+    msaa_texture.sample_count = 4;
+    msaa_texture.declared_mip_levels = 1;
+    ShaderResourceTable msaa_table;
+    msaa_table.resources.push_back(msaa_texture);
+    const auto msaa_4x = recompile_graphics_shader_cached(
+        ShaderProgramStage::Fragment, kMsaaLoadPs, std::size(kMsaaLoadPs), &msaa_table);
+    const auto msaa_4x_again = recompile_graphics_shader_cached(
+        ShaderProgramStage::Fragment, kMsaaLoadPs, std::size(kMsaaLoadPs), &msaa_table);
+    msaa_table.resources[0].sample_count = 2;
+    const auto msaa_2x = recompile_graphics_shader_cached(
+        ShaderProgramStage::Fragment, kMsaaLoadPs, std::size(kMsaaLoadPs), &msaa_table);
+    stats = shader_recompile_cache_stats();
+    CHECK(!msaa_4x.empty() && msaa_4x_again == msaa_4x && msaa_2x.empty() &&
+              stats.misses == 2 && stats.hits == 1 && stats.entries == 2,
+          "shader cache separates the supported 4x MSAA fetch from unsupported sample counts");
+
     // A FLAT-window's base push-constant index is embedded in the module. Keep it in the key even
     // though both variants use the same binding and exact fetch PC.
     clear_shader_recompile_cache();

--- a/prosper/tests/test_texture_sample_render.cpp
+++ b/prosper/tests/test_texture_sample_render.cpp
@@ -856,6 +856,71 @@ int main() {
     printf("  image_load(1,1) center=(%u,%u,%u)\n", okL1?rgb[0]:0, okL1?rgb[1]:0, okL1?rgb[2]:0);
     CHECK(okL1 && rgb[0] > 0x80 && rgb[1] > 0x80 && rgb[2] > 0x80, "image_load texel (1,1) yields WHITE (proves integer coords)");
 
+    // Guest 2D_MSAA IMAGE_LOAD uses an explicit integer sample coordinate. Prosper materializes the
+    // four exact guest sample planes as a single-sample 2D-array and lowers that coordinate to the
+    // host layer. Four distinct R32F values prove upload order, view shape, and shader routing together.
+    {
+        const uint32_t msaa_ps_template[] = {
+            0x7e0a0280u,                       // v5 = x = 0
+            0x7e0c0280u,                       // v6 = y = 0
+            0x7e0e0280u,                       // v7 = sample (patched below)
+            0xf0000130u, 0x00000305u,         // exact image_load v3,v[5:7],s[0:7] dmask:x 2D_MSAA
+            0x7e000303u,                       // v0 = loaded R32F bits
+            0x7e020280u, 0x7e040280u, 0x7e0602f2u,
+            0xf800000fu, 0x03020100u, 0xbf810000u,
+        };
+        ShaderResourceTable msaa_rt;
+        { ShaderResource image{}; image.cls = ResourceClass::Texture;
+          image.format = DataFormat::Float32; image.num_components = 1;
+          image.binding = 4; image.sgpr_base = 0; image.img_dim = 6;
+          image.width = 1; image.height = 1; image.depth = 1;
+          image.sample_count = 4; image.declared_mip_levels = 1;
+          msaa_rt.resources.push_back(image); }
+        const float sample_planes[4] = {0.125f, 0.375f, 0.625f, 0.875f};
+        prosper::test::FrameResource resource;
+        resource.binding = 4; resource.set = 1;
+        resource.tex_rgba = reinterpret_cast<const uint8_t*>(sample_planes);
+        resource.tex_byte_size = sizeof(sample_planes);
+        resource.tw = 1; resource.th = 1; resource.td = 1;
+        resource.img_dim = 6; resource.sample_count = 4;
+        resource.texture_format = VK_FORMAT_R32_SFLOAT;
+        resource.mag_filter = resource.min_filter = 0;
+        bool distinct_samples = true;
+        const uint8_t expected_red[4] = {32, 96, 159, 223};
+        for (uint32_t sample = 0; sample < 4; ++sample) {
+            std::vector<uint32_t> ps(std::begin(msaa_ps_template),
+                                     std::end(msaa_ps_template));
+            ps[2] = 0x7e0e0200u | (128u + sample);
+            const std::vector<uint32_t> frag = recompile_fragment(
+                ps.data(), ps.size(), &msaa_rt);
+            prosper::test::BackendDraw draw;
+            draw.vs = vert; draw.fs = frag; draw.R = {resource}; draw.vcount = 3;
+            const std::vector<uint8_t> pixels = prosper::test::render_draws_rgba(
+                {draw}, W, H);
+            const uint8_t* center = pixels.size() == static_cast<size_t>(W) * H * 4
+                ? &pixels[(static_cast<size_t>(H / 2) * W + W / 2) * 4] : nullptr;
+            distinct_samples &= center &&
+                std::abs(static_cast<int>(center[0]) - expected_red[sample]) <= 2 &&
+                center[1] < 4 && center[2] < 4;
+        }
+        CHECK(distinct_samples,
+              "2D_MSAA IMAGE_LOAD selects four distinct host array layers by guest sample index");
+        prosper::test::FrameResource short_resource = resource;
+        short_resource.tex_byte_size = sizeof(sample_planes) - sizeof(float);
+        prosper::test::BackendDraw short_draw;
+        short_draw.vs = vert;
+        short_draw.fs = recompile_fragment(
+            msaa_ps_template, std::size(msaa_ps_template), &msaa_rt);
+        short_draw.R = {short_resource}; short_draw.vcount = 3;
+        CHECK(!prosper::test::backend_texture_plane_span_valid(short_resource) &&
+                  prosper::test::render_draws_rgba({short_draw}, W, H).empty(),
+              "2D_MSAA upload rejects a short sample-plane span before Vulkan access");
+        prosper::test::FrameResource wrong_count = resource;
+        wrong_count.sample_count = 2;
+        CHECK(!prosper::test::backend_texture_plane_span_valid(wrong_count),
+              "unsupported host sample-plane counts remain fail-visible at the backend boundary");
+    }
+
     // The same image_load instruction becomes OpImageRead when its resource class is StorageImage.
     // That SPIR-V interface must be backed by a STORAGE_IMAGE descriptor over an image with STORAGE
     // usage in GENERAL layout, not the sampled texture's combined-image-sampler contract (#374).

--- a/prosper/tests/test_tile.cpp
+++ b/prosper/tests/test_tile.cpp
@@ -646,6 +646,173 @@ int main() {
         CHECK(std::memcmp(&tiled[18432],  at(0, 64), bpe) == 0, "64KB_Z_X 4B golden: element (0,64) at byte 18432");
     }
 
+    // AMD AddrLib GFX10_SW_64K_Z_X_4xaa golden, 16 pipes, 4 B/sample. S0/S1 occupy
+    // byte-offset bits 2/3, followed by x0/y0 at bits 4/5. The four values of one pixel therefore
+    // occupy bytes 0,4,8,12, while the next x/y texels begin at 16/32. This independently pins the
+    // sample lever; an ordinary 1xaa detiler aliases sample 0 and cannot satisfy these positions.
+    {
+        const uint32_t M = (uint32_t)TileMode::Sw64KbZX;
+        const uint32_t w = 64, h = 64, bpe = 4, samples = 4;
+        const size_t plane = static_cast<size_t>(w) * h;
+        std::vector<uint32_t> linear(plane * samples);
+        for (uint32_t s = 0; s < samples; ++s)
+            for (uint32_t y = 0; y < h; ++y)
+                for (uint32_t x = 0; x < w; ++x)
+                    linear[static_cast<size_t>(s) * plane + static_cast<size_t>(y) * w + x] =
+                        0xa5000000u | (s << 20) | (y << 10) | x;
+        const size_t bytes = tiled_msaa_surface_bytes(w, h, M, bpe, samples);
+        CHECK(bytes == 65536u, "64KB_Z_X 4xaa 4B: one 64x64x4 block is exactly 64 KiB");
+        std::vector<uint8_t> tiled(bytes, 0);
+        CHECK(tile_msaa_surface(tiled.data(), tiled.size(),
+                                  reinterpret_cast<const uint8_t*>(linear.data()),
+                                  w, h, M, bpe, samples),
+              "64KB_Z_X 4xaa surface tiles through the explicit sample-bit pattern");
+        auto word_at = [&](size_t byte) {
+            uint32_t value = 0; std::memcpy(&value, tiled.data() + byte, sizeof(value)); return value;
+        };
+        CHECK(word_at(0) == linear[0 * plane] && word_at(4) == linear[1 * plane] &&
+                  word_at(8) == linear[2 * plane] && word_at(12) == linear[3 * plane],
+              "64KB_Z_X 4xaa golden: sample 0/1/2/3 map to byte 0/4/8/12");
+        CHECK(word_at(16) == linear[1] && word_at(32) == linear[w],
+              "64KB_Z_X 4xaa golden: x1/y1 follow the two sample bits at byte 16/32");
+        CHECK(word_at(256) == linear[8] && word_at(4352) == linear[8 * w],
+              "64KB_Z_X 4xaa golden: pipe-rotated x8/y8 positions match AddrLib");
+        std::vector<uint32_t> back(linear.size(), 0);
+        CHECK(detile_msaa_surface(reinterpret_cast<uint8_t*>(back.data()), tiled.data(),
+                                    tiled.size(), w, h, M, bpe, samples) && back == linear,
+              "64KB_Z_X 4xaa detile restores four distinct sample planes exactly");
+    }
+
+    {
+        const uint32_t M = (uint32_t)TileMode::Sw64KbZX;
+        bool all_sizes_round_trip = true;
+        for (uint32_t bpe : {1u, 2u, 4u, 8u, 16u}) {
+            const uint32_t w = 137, h = 73, samples = 4;
+            const size_t linear_bytes = static_cast<size_t>(w) * h * samples * bpe;
+            std::vector<uint8_t> linear(linear_bytes), back(linear_bytes, 0);
+            for (size_t i = 0; i < linear.size(); ++i)
+                linear[i] = static_cast<uint8_t>(i * 109u + bpe * 17u);
+            const size_t bytes = tiled_msaa_surface_bytes(w, h, M, bpe, samples);
+            std::vector<uint8_t> tiled(bytes, 0);
+            all_sizes_round_trip &= bytes != 0 &&
+                tile_msaa_surface(tiled.data(), tiled.size(), linear.data(),
+                                  w, h, M, bpe, samples) &&
+                detile_msaa_surface(back.data(), tiled.data(), tiled.size(),
+                                    w, h, M, bpe, samples) && back == linear;
+        }
+        CHECK(all_sizes_round_trip,
+              "64KB_Z_X 4xaa round-trip is exact at every supported element size and across blocks");
+        std::vector<uint8_t> short_src(
+            tiled_msaa_surface_bytes(64, 64, M, 4, 4) - 1u, 0);
+        std::vector<uint8_t> untouched(64u * 64u * 4u * 4u, 0x5au);
+        CHECK(!detile_msaa_surface(untouched.data(), short_src.data(), short_src.size(),
+                                     64, 64, M, 4, 4) &&
+                  std::all_of(untouched.begin(), untouched.end(), [](uint8_t v) { return v == 0x5au; }),
+              "truncated MSAA allocation is rejected before any sample plane is detiled");
+        CHECK(tiled_msaa_surface_bytes(64, 64, M, 4, 2) == 0 &&
+                  tiled_msaa_surface_bytes(64, 64, (uint32_t)TileMode::Sw64KbS, 4, 4) == 0,
+              "unsupported MSAA counts and swizzle modes remain fail-visible");
+    }
+
+    // AMD AddrLib's 16-pipe GFX10 HTILE shape and PAL's exact decompressed initialization
+    // constants. This is the metadata contract that can authorize reading an ordinary R32_FLOAT
+    // base allocation for Asterix's 2D_MSAA IMAGE_LOAD; a uniform-but-nearby value is not evidence.
+    {
+        const uint32_t M = (uint32_t)TileMode::Sw64KbZX;
+        const size_t expected = gfx10_htile_msaa_metadata_bytes(1920, 1080, M, 4, true);
+        CHECK(expected == 196608u,
+              "1920x1080 16-pipe SW_64KB_Z_X HTILE occupies six 32 KiB metadata blocks");
+        CHECK(gfx10_htile_msaa_metadata_bytes(1920, 1080, M, 2, true) == 0 &&
+                  gfx10_htile_msaa_metadata_bytes(1920, 1080, M, 4, false) == 0 &&
+                  gfx10_htile_msaa_metadata_bytes(
+                      1920, 1080, (uint32_t)TileMode::Sw64KbRX, 4, true) == 0,
+              "HTILE sizing remains fail-closed outside the exact 4xaa pipe-aligned Z_X contract");
+
+        std::vector<uint32_t> htile(expected / sizeof(uint32_t), 0xfffc000fu);
+        uint32_t uniform = 0;
+        CHECK(gfx10_htile_metadata_is_decompressed(
+                  reinterpret_cast<const uint8_t*>(htile.data()), expected, expected, &uniform) &&
+                  uniform == 0xfffc000fu,
+              "uniform depth-only PAL HTILE initialization proves an uncompressed base");
+        std::fill(htile.begin(), htile.end(), 0xfffff3ffu);
+        CHECK(gfx10_htile_metadata_is_decompressed(
+                  reinterpret_cast<const uint8_t*>(htile.data()), expected, expected, &uniform) &&
+                  uniform == 0xfffff3ffu,
+              "uniform depth+stencil PAL HTILE initialization proves an uncompressed base");
+
+        std::fill(htile.begin(), htile.end(), 0xfffc000eu);
+        CHECK(!gfx10_htile_metadata_is_decompressed(
+                  reinterpret_cast<const uint8_t*>(htile.data()), expected, expected),
+              "one-bit-near PAL HTILE state cannot authorize reading base texels");
+        std::fill(htile.begin(), htile.end(), 0xfffc000fu);
+        htile[17] = 0xfffff3ffu;
+        CHECK(!gfx10_htile_metadata_is_decompressed(
+                  reinterpret_cast<const uint8_t*>(htile.data()), expected, expected),
+              "nonuniform HTILE remains compressed or ambiguous and is rejected");
+        htile[17] = 0xfffc000fu;
+        CHECK(!gfx10_htile_metadata_is_decompressed(
+                  reinterpret_cast<const uint8_t*>(htile.data()), expected - 4u, expected),
+              "short HTILE metadata cannot prove the complete surface decompressed");
+
+        // PAL GetClearValue(+0.0), depth-only, is exactly a uniform zero dword. Metadata owns the
+        // result in that state: poison/NaN base bytes must never leak into any of the four layers.
+        const uint32_t clear_w = 64, clear_h = 64;
+        const size_t clear_meta_bytes = gfx10_htile_msaa_metadata_bytes(
+            clear_w, clear_h, M, 4, true);
+        const size_t clear_base_bytes = tiled_msaa_surface_bytes(
+            clear_w, clear_h, M, 4, 4);
+        std::vector<uint32_t> zero_htile(clear_meta_bytes / sizeof(uint32_t), 0u);
+        std::vector<uint32_t> poison_base(clear_base_bytes / sizeof(uint32_t), 0x7fc00001u);
+        std::vector<uint32_t> clear_planes(
+            static_cast<size_t>(clear_w) * clear_h * 4u, 0x7fc00001u);
+        Gfx10HtileMsaaSource clear_source = Gfx10HtileMsaaSource::Unsupported;
+        CHECK(materialize_gfx10_htile_msaa_surface(
+                  reinterpret_cast<uint8_t*>(clear_planes.data()),
+                  clear_planes.size() * sizeof(uint32_t),
+                  reinterpret_cast<const uint8_t*>(poison_base.data()),
+                  poison_base.size() * sizeof(uint32_t),
+                  reinterpret_cast<const uint8_t*>(zero_htile.data()),
+                  zero_htile.size() * sizeof(uint32_t),
+                  clear_w, clear_h, M, 4, 4, true, &clear_source) &&
+                  clear_source == Gfx10HtileMsaaSource::DepthZeroFastClear &&
+                  std::all_of(clear_planes.begin(), clear_planes.end(),
+                              [](uint32_t bits) { return bits == 0u; }),
+              "uniform zero HTILE materializes exact +0.0 in every texel and all four layers "
+              "without reading poison base data");
+
+        auto rejects_zero_clear = [&](const std::vector<uint32_t>& metadata,
+                                      size_t metadata_bytes, uint32_t tile_mode,
+                                      uint32_t bytes_per_texel, uint32_t samples) {
+            std::fill(clear_planes.begin(), clear_planes.end(), 0x5a5a5a5au);
+            clear_source = Gfx10HtileMsaaSource::UncompressedBase;
+            return !materialize_gfx10_htile_msaa_surface(
+                       reinterpret_cast<uint8_t*>(clear_planes.data()),
+                       clear_planes.size() * sizeof(uint32_t),
+                       reinterpret_cast<const uint8_t*>(poison_base.data()),
+                       poison_base.size() * sizeof(uint32_t),
+                       reinterpret_cast<const uint8_t*>(metadata.data()), metadata_bytes,
+                       clear_w, clear_h, tile_mode, bytes_per_texel, samples, true,
+                       &clear_source) &&
+                   clear_source == Gfx10HtileMsaaSource::Unsupported &&
+                   std::all_of(clear_planes.begin(), clear_planes.end(),
+                               [](uint32_t bits) { return bits == 0x5a5a5a5au; });
+        };
+        std::vector<uint32_t> nonuniform_zero_htile = zero_htile;
+        nonuniform_zero_htile[17] = 1u;
+        CHECK(rejects_zero_clear(nonuniform_zero_htile, clear_meta_bytes, M, 4, 4),
+              "one nonzero HTILE dword rejects without touching output");
+        std::vector<uint32_t> unsupported_uniform_htile = zero_htile;
+        std::fill(unsupported_uniform_htile.begin(), unsupported_uniform_htile.end(), 1u);
+        CHECK(rejects_zero_clear(unsupported_uniform_htile, clear_meta_bytes, M, 4, 4),
+              "unsupported nonzero uniform HTILE remains fail-visible");
+        CHECK(rejects_zero_clear(zero_htile, clear_meta_bytes - 4u, M, 4, 4) &&
+                  rejects_zero_clear(zero_htile, clear_meta_bytes, M, 4, 2) &&
+                  rejects_zero_clear(zero_htile, clear_meta_bytes,
+                                     (uint32_t)TileMode::Sw64KbS, 4, 4) &&
+                  rejects_zero_clear(zero_htile, clear_meta_bytes, M, 8, 4),
+              "zero-clear materialization rejects short footprint, count, swizzle, and element size");
+    }
+
     // Golden positions from the addrlib GFX10_SW_64K_S pattern (gfx10SwizzlePattern.h). At 8 bpe the
     // 16 offset bits are [x0 | y0 y1 x1 x2 | y2 x3 y3 x4 | y4 x5 y5 x6] above the 3 byte bits, i.e.
     // element (1,0) -> byte 8, (0,1) -> 16, (0,2) -> 32, (2,0) -> 64... — the SW_4KB_S order continued


### PR DESCRIPTION
## Summary

- decode GFX10 2D-MSAA sample identity through T# resources, shader/cache keys, exact 4x `SW_64KB_Z_X` tiling, backend array-layer uploads, and append-only capture v44
- lower the exact consecutive-vaddr and one-extra-dword NSA `IMAGE_LOAD` forms to `OpImageFetch` over a single-sample 2D-array, with the guest sample coordinate selecting the host layer
- distinguish complete PAL-proven HTILE authorities: decompressed initialization reads the tiled base, while a uniform depth-only zero fast-clear materializes exact +0.0 without touching stale base memory; every other metadata state remains rejected
- add an Asterix status map with current evidence, Ruled out hypotheses, and the next black-frame discriminator

## Live result

The title shader at `0x20117c0900` contains four independently disassembled 2D-MSAA loads: one consecutive-vaddr packet and three one-extra NSA `[x,y,sample]` packets. On this branch all four compile and all four resources reach the live renderer. The exact 196,608-byte HTILE planes classify as PAL depth-zero fast-clears and materialize without an MSAA or recompile rejection.

A 30-second bounded run published 6/6 source-distinct frames without a stall or device loss, but all remained pure black (`crc=064567f8`). This is merge-worthy generic GPU/capture progress, **not** visible title progress: #1599 stays open, the compatibility rung remains 0, and there is no screenshot/COMPATIBILITY update because the output contains nothing beyond black. The next discriminator is a current frame bundle followed by draw-step inspection of the final composite.

A compute device loss appeared in only 2 of 6 bounded runs; four clean runs were identically black, so it is recorded as intermittent and non-causal rather than promoted to the next blocker.

## Verification

Post-rebase focused tests passed:

- `test_shader_recompile_cache`
- `test_rdna2_spirv_struct`
- `test_recompile_coverage`
- `test_tile`
- `test_gpu_capture`
- `test_game_compute` (real Vulkan, 277 assertions)
- `test_texture_sample_render`
- `test_gpu_capture_render`
- `prosper-app` build

Causal mutations:

- removing len-3 support fails the named NSA sample-layer test while len-2 survives
- aliasing the sample offsets to sample zero fails the independent golden offsets/round trip
- disabling uniform-zero recognition fails the poison-base +0.0 materialization check
- skipping the complete HTILE scan fails the named nonuniform-metadata rejection
- changing only the resource sample count separates the compiled-cache entry and preserves the expected 2x rejection

Snapshots were not run (optional for ordinary PRs, mandatory before release; this is not a release).

Refs #1599