### PR TITLE
ci: upload archives only for release tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,13 +260,10 @@ jobs:
           --out-dir "$RUNNER_TEMP/linux-release"
           --max-glibc 2.39
 
-      # Tag pushes always. On a pull request only when it carries the `ci:artifacts` label, so a
-      # build of a branch can be downloaded and opened by hand without giving every PR a
-      # release-sized artifact (#1462).
+      # Archives leave the runner only for a release tag. Pull requests still build, package, and
+      # execute the archives above, but never upload them (#1803).
       - name: Upload Linux archives
-        if: >-
-          (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
-          contains(github.event.pull_request.labels.*.name, 'ci:artifacts')
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         uses: actions/upload-artifact@v4
         with:
           name: prosper-linux-x86_64


### PR DESCRIPTION
Fixes #1803.

## What changed

- Keep building, packaging, and executing the Linux release archives on every pull request.
- Upload Linux archives only for a `v*` tag push, matching Windows artifacts and the release job.
- Remove the `ci:artifacts` pull-request label escape hatch.

## Verification

- Parsed `.github/workflows/ci.yml` with PyYAML.
- Enumerated every `actions/upload-artifact` step and asserted both use the exact tagged-push condition.
- Asserted the release-publication job uses the same condition and `ci:artifacts` no longer appears.
- `git diff --check` passes.

The PR's own Linux package job is the integrated counter-arm: package and verification should run, while `Upload Linux archives` and `Publish Release` must both report skipped.
