### PR TITLE
fix(avplayer): preserve PS5 padded video pitch

### DIFF
--- a/prosper/docs/R_TYPE_DELTA_STATUS.md
+++ b/prosper/docs/R_TYPE_DELTA_STATUS.md
@@ -54,6 +54,28 @@ Two mutations prove the checks exercise both failure mechanisms. Restoring `pitc
 named R-Type footprint check fail. Keeping pitch 2048 but forcing crop right to zero leaves the
 R-Type footprint check green and makes the named GRIS right-edge-strip check fail.
 
+## Live validation
+
+Candidate `4114391c` was run for 60 seconds through the bounded #1746 startup diagnostic. The three
+byte patches applied at the expected addresses, AvPlayer opened `CRG.mp4`, allocated two 3,317,760
+byte guest texture buffers, returned those buffers alternately, and advanced timestamps. All #1753
+failure signals were absent: no `unexpected y_texture size`, no pc-52 `mimg-unresolved` from SGPR 8,
+no pc-52 `recompile-reject` for `f080030a`, and no execution reject for fragment program
+`0x2011c0d700`. No other shader/resource rejection appeared. This proves the upstream descriptor
+construction and shader-resolution defect is fixed.
+
+It does **not** establish a visual milestone. All 49 retained 1920x1080 frames were inspected. Early
+and late samples were solid clears; the only non-flat interval contained 2--75 colours per frame and
+showed broad diagonal purple/grey gradients rather than recognizable movie imagery. There is no
+screenshot because incorrect diagnostic output is not progression evidence. The remaining movie
+sampling/content frontier is tracked separately in #1807.
+
+The same candidate completed the GRIS cross-title route with 45 source-distinct and 42 pixel-distinct
+frames, maximum pixel staleness 1.0 seconds, and status `ok`. All 45 frames were inspected. The
+Nomada/Devolver opening logos and title screen have no 128-pixel right strip, horizontal stride
+corruption, or U/V colour cast. This verifies that the padded-pitch/crop contract does not regress
+the known consumer that exposed the earlier half-fix.
+
 ## Ruled out
 
 | Hypothesis | Verdict and evidence | Source |
@@ -63,10 +85,12 @@ R-Type footprint check green and makes the named GRIS right-edge-strip check fai
 | The chroma bind packet is lost by Prosper | **Falsified.** The title returns before constructing the chroma descriptor, then later binds that uninitialized slot itself. There is no valid descriptor for a packet decoder to recover. | guest `eboot+0x19d10`, this doc |
 | AvPlayer output must remain tight because padded output caused GRIS's right-edge strip | **Falsified.** GRIS subtracts the ABI crop offsets from pitch. The prior padded experiment left crop right zero; the missing crop, not the physical padding, exposed the strip. | #1393, GRIS `eboot+0xf6d5ab`, this doc |
 | Reporting pitch 2048 while retaining tight rows is sufficient | **Falsified by construction.** The title advances plane addresses by the published physical extent. The CPU fixture verifies row-by-row storage and both plane bases, not metadata alone. | `test_avplayer` |
+| The pc-52 resource rejection was the only movie-visual blocker | **Falsified live.** The size mismatch and all shader/resource rejects are gone, but retained frames contain only flat clears and low-colour gradients. The downstream frontier is #1807. | bounded `4114391c` run, #1807 |
 
-## Next live discriminator
+## Next frontier
 
-After #1746 is bypassed diagnostically, a valid run must show all of these together before claiming
-visual progress: no `unexpected y_texture size`, a constructed/bound chroma T# in slot 1, both pc 52
-and pc 57 resolving, and source-distinct non-flat movie frames. A black or flat frame is not a visual
-milestone and does not warrant a screenshot.
+#1807 owns the remaining flat/gradient movie output. Capture one gradient frame as a replayable GPU
+bundle, identify the draw using fragment program `0x2011c0d700`, and prove which AvPlayer buffer and
+timestamp fed it. Dump both resolved planes and their T# metadata, then compare source texels with a
+CPU NV12-to-RGB conversion to separate resource decode/upload, sampler-coordinate, and shader-output
+faults. A changing gradient is still not a visual milestone and does not warrant a screenshot.

--- a/prosper/docs/R_TYPE_DELTA_STATUS.md
+++ b/prosper/docs/R_TYPE_DELTA_STATUS.md
@@ -1,0 +1,72 @@
+# R-Type Delta: HD Boosted status
+
+`PPSA26414` is currently blocked first by the title's logged-in-user startup race (#1746). A local
+diagnostic that caps the title's initial sleep reaches its frame loop, where the movie conversion
+draw was then dropped at fragment-shader `IMAGE_SAMPLE` pc 52 (#1753). This note records the static
+causal chain behind that downstream failure. The startup diagnostic is not a product fix.
+
+## Movie resource failure
+
+The rejected fragment shader is `shader/movie_yuv_p.ags`. Its AGC metadata declares two direct
+textures at user SGPRs 0 and 8, two direct samplers at SGPRs 16 and 20, and one constant buffer at
+SGPR 24. The shader samples texture slot 1 / sampler slot 1 first at pc 52 (`T# s8`, `S# s20`), then
+texture slot 0 / sampler slot 0 at pc 57. The pc-52 instruction is a supported 2D `IMAGE_SAMPLE`;
+the failure is that texture slot 1 was never constructed.
+
+Guest disassembly at `eboot+0x19d10` explains why:
+
+1. The title reads `AvPlayerFrameInfoEx::video.height` at frame offset `0x1c` and `pitch` at `0x3c`.
+2. It constructs the luma R8 T# using `pitch` as the descriptor width and `height` as its height.
+3. It asks the guest AGC library for that descriptor's allocation size and requires it to equal
+   `pitch * height`.
+4. Prosper previously published a tight 1920-byte pitch. The AGC sampled-linear footprint is
+   256-byte aligned, so the descriptor occupies `2048 * 1080 = 2,211,840` bytes while the title
+   expects `1920 * 1080 = 2,073,600`. The title prints `unexpected y_texture size` and returns
+   before constructing the chroma T# in texture slot 1.
+5. The one-time initialization flag has already been cleared. Later frames bind the valid luma T#
+   and the never-constructed chroma T#, so pc 52 cannot resolve SGPR 8.
+
+The PS5 `AvPlayerVideoEx` ABI keeps physical and visible extents separate: crop offsets are four
+32-bit pixel counts at offsets 20, 24, 28 and 32, followed by the physical pitch at offset 36.
+Prosper now stages 1920 visible bytes into a 2048-byte physical row and publishes
+`crop_right_offset=128`. R-Type's own movie code subtracts left/right crop from pitch when it builds
+the visible quad, so the padding is not displayed.
+
+This is also the cross-title contract needed by GRIS. Its PS5 video wrapper computes visible width
+as `pitch - crop_left_offset - crop_right_offset`. The earlier experiment in #1393 that padded the
+pitch but left all crop fields zero correctly removed the stride corruption, but exposed the
+128-pixel tail as a right-edge strip. Padding and crop are one contract; testing only the first half
+made the correct physical layout look invalid.
+
+## CPU guard and mutation evidence
+
+`test_avplayer` supplies a 1920x1080 NV12 frame with 2048-byte decoder strides and checks all of the
+following without launching Vulkan:
+
+- the callback-owned frame ring has 2048-byte luma and chroma rows;
+- only 1920 visible bytes per row are copied and padding remains cleared;
+- stream and frame metadata publish pitch 2048, crop right 128 and zero for the other crop offsets;
+- luma and chroma guest addresses preserve exact 2048-byte layout provenance;
+- the R-Type descriptor footprint equals `pitch * height`;
+- the GRIS visible-width expression evaluates back to 1920.
+
+Two mutations prove the checks exercise both failure mechanisms. Restoring `pitch=width` makes the
+named R-Type footprint check fail. Keeping pitch 2048 but forcing crop right to zero leaves the
+R-Type footprint check green and makes the named GRIS right-edge-strip check fail.
+
+## Ruled out
+
+| Hypothesis | Verdict and evidence | Source |
+|---|---|---|
+| pc-52 `IMAGE_SAMPLE` is an unsupported shader opcode | **Falsified.** The opcode/dimension/dmask are already implemented. The exact shader metadata resolves pc 52 to direct texture slot 1 at SGPR 8 and sampler slot 1 at SGPR 20; the missing texture is upstream. | #1753, this doc |
+| SGPR 8 is a bindless or dynamically indexed resource that needs a new resolver | **Falsified.** `movie_yuv_p.ags` declares direct texture offsets 0 and 8 and direct sampler offsets 16 and 20. The title explicitly binds texture slots 0 and 1. | this doc |
+| The chroma bind packet is lost by Prosper | **Falsified.** The title returns before constructing the chroma descriptor, then later binds that uninitialized slot itself. There is no valid descriptor for a packet decoder to recover. | guest `eboot+0x19d10`, this doc |
+| AvPlayer output must remain tight because padded output caused GRIS's right-edge strip | **Falsified.** GRIS subtracts the ABI crop offsets from pitch. The prior padded experiment left crop right zero; the missing crop, not the physical padding, exposed the strip. | #1393, GRIS `eboot+0xf6d5ab`, this doc |
+| Reporting pitch 2048 while retaining tight rows is sufficient | **Falsified by construction.** The title advances plane addresses by the published physical extent. The CPU fixture verifies row-by-row storage and both plane bases, not metadata alone. | `test_avplayer` |
+
+## Next live discriminator
+
+After #1746 is bypassed diagnostically, a valid run must show all of these together before claiming
+visual progress: no `unexpected y_texture size`, a constructed/bound chroma T# in slot 1, both pc 52
+and pc 57 resolving, and source-distinct non-flat movie frames. A black or flat frame is not a visual
+milestone and does not warrant a screenshot.

--- a/prosper/src/gpu/guest_texture_layout.hpp
+++ b/prosper/src/gpu/guest_texture_layout.hpp
@@ -6,9 +6,9 @@
 
 namespace prosper::gpu {
 
-// Register a guest-visible allocation whose sampled-linear rows are intentionally tightly packed.
-// The ordinary GFX10 fallback remains 256-byte aligned; this provenance is for HLE producers such as
-// AvPlayer that return CPU-staged pixels and an explicit row pitch to the title.
+// Register a guest-visible allocation whose sampled-linear rows have an exact HLE-owned pitch.
+// The ordinary GFX10 fallback remains 256-byte aligned; this provenance is for producers such as
+// AvPlayer that return CPU-staged pixels and explicitly publish their physical pitch to the title.
 void register_guest_linear_texture_layout(uint64_t base, size_t bytes,
                                           uint32_t row_pitch_bytes);
 void unregister_guest_linear_texture_layout(uint64_t base);

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -691,11 +691,16 @@ struct AvpFrameInfo {                // sceAvPlayerGetVideoData / GetAudioData o
 };
 struct AvpVideoEx {                  // AvPlayerVideoEx (in the 80B details union)
     uint32_t width, height; float aspect; uint8_t lang[4]; uint8_t reserved0[4];
-    uint32_t crop_l, crop_r, crop_t, crop_b, pitch;
+    uint32_t crop_left_offset, crop_right_offset, crop_top_offset, crop_bottom_offset, pitch;
     uint8_t luma_bd, chroma_bd, full_range, reserved1[5];
     double framerate; uint32_t colour_primaries, transfer_characteristics; uint8_t reserved2[16];
 };
-static_assert(sizeof(AvpVideoEx) == 80 && offsetof(AvpVideoEx, pitch) == 36 &&
+static_assert(sizeof(AvpVideoEx) == 80 &&
+              offsetof(AvpVideoEx, crop_left_offset) == 20 &&
+              offsetof(AvpVideoEx, crop_right_offset) == 24 &&
+              offsetof(AvpVideoEx, crop_top_offset) == 28 &&
+              offsetof(AvpVideoEx, crop_bottom_offset) == 32 &&
+              offsetof(AvpVideoEx, pitch) == 36 &&
               offsetof(AvpVideoEx, framerate) == 48, "AvPlayerVideoEx ABI");
 struct AvpFrameInfoEx {              // sceAvPlayerGetVideoDataEx out-param (larger details union)
     void* p_data; uint8_t reserved[4]; uint64_t timestamp;
@@ -750,12 +755,22 @@ struct AvpPlayer {
 std::mutex g_avp_mx;
 std::unordered_map<uint64_t, AvpPlayer> g_avp;
 
-bool avp_nv12_bytes(uint32_t width, uint32_t height, size_t& bytes) {
-    if (!width || !height || width > SIZE_MAX / height) return false;
-    const size_t y_bytes = static_cast<size_t>(width) * height;
+// PS5 AvPlayer exposes decoded NV12 as a sampled-linear surface. Its physical row pitch is aligned
+// to 256 bytes; the valid image width remains separate and the padded pixels are reported through
+// AvPlayerVideoEx::crop_right_offset. Keeping those two extents distinct is required by consumers
+// that validate an AGC texture footprint before binding its second plane.
+bool avp_video_pitch(uint32_t width, uint32_t& pitch) {
+    if (!width || width > UINT32_MAX - 255u) return false;
+    pitch = (width + 255u) & ~255u;
+    return true;
+}
+
+bool avp_nv12_bytes(uint32_t pitch, uint32_t height, size_t& bytes) {
+    if (!pitch || !height || pitch > SIZE_MAX / height) return false;
+    const size_t y_bytes = static_cast<size_t>(pitch) * height;
     const size_t uv_rows = (static_cast<size_t>(height) + 1) / 2;
-    if (width > SIZE_MAX / uv_rows) return false;
-    const size_t uv_bytes = static_cast<size_t>(width) * uv_rows;
+    if (pitch > SIZE_MAX / uv_rows) return false;
+    const size_t uv_bytes = static_cast<size_t>(pitch) * uv_rows;
     if (uv_bytes > SIZE_MAX - y_bytes) return false;
     bytes = y_bytes + uv_bytes;
     return true;
@@ -787,46 +802,57 @@ uint8_t* avp_frame_storage(AvpPlayer& player, size_t bytes, uint32_t pitch) {
 // visible NV12 rows into a guest texture buffer when one exists.  The host-vector fallback preserves
 // the old lifetime guarantee for native tests and titles that omit the replacement callbacks.
 bool avp_stage_video(AvpPlayer& player, const prosper::video::VideoFrame& frame,
-                     uint8_t*& data, uint32_t& pitch) {
+                     bool extended_layout, uint8_t*& data, uint32_t& pitch) {
     if (!frame.y || !frame.uv || frame.width == 0 || frame.height == 0) return false;
     const size_t y_stride = frame.y_stride ? frame.y_stride : frame.width;
     const size_t uv_stride = frame.uv_stride ? frame.uv_stride : frame.width;
     if (y_stride < frame.width || uv_stride < frame.width) return false;
     const size_t uv_rows = (static_cast<size_t>(frame.height) + 1) / 2;
     if (y_stride > SIZE_MAX / frame.height || uv_stride > SIZE_MAX / uv_rows) return false;
+    pitch = frame.width;
+    if (extended_layout && !avp_video_pitch(frame.width, pitch)) return false;
     size_t bytes = 0;
-    if (!avp_nv12_bytes(frame.width, frame.height, bytes)) return false;
+    if (!avp_nv12_bytes(pitch, frame.height, bytes)) return false;
     uint8_t* dst = nullptr;
     if (!player.texture_frames.empty()) {
         if (bytes > player.texture_frame_bytes) return false;
         dst = player.texture_frames[player.next_texture_frame++ % player.texture_frames.size()];
     } else {
-        dst = avp_frame_storage(player, bytes, frame.width);
+        dst = avp_frame_storage(player, bytes, pitch);
     }
     if (!dst) return false;
+    // The crop offsets keep padding invisible, but clearing it also prevents stale decoder bytes
+    // from becoming observable if a title deliberately samples outside the valid image extent.
+    memset(dst, 0, bytes);
     for (uint32_t row = 0; row < frame.height; ++row)
-        memcpy(dst + static_cast<size_t>(row) * frame.width,
+        memcpy(dst + static_cast<size_t>(row) * pitch,
                frame.y + static_cast<size_t>(row) * y_stride, frame.width);
-    uint8_t* dst_uv = dst + static_cast<size_t>(frame.width) * frame.height;
+    uint8_t* dst_uv = dst + static_cast<size_t>(pitch) * frame.height;
     for (size_t row = 0; row < uv_rows; ++row)
-        memcpy(dst_uv + row * frame.width, frame.uv + row * uv_stride, frame.width);
+        memcpy(dst_uv + row * pitch, frame.uv + row * uv_stride, frame.width);
+    // Callback storage is registered before the first pull. Refresh it here because the basic API
+    // retains its historical tight layout while GetVideoDataEx publishes the padded physical pitch.
+    avp_register_frame_layout(dst, bytes, pitch);
     data = dst;
-    pitch = frame.width;
     return true;
 }
 
-bool avp_stage_synthetic(AvpPlayer& player, uint8_t*& data) {
+bool avp_stage_synthetic(AvpPlayer& player, bool extended_layout,
+                         uint8_t*& data, uint32_t& pitch) {
+    pitch = player.width;
+    if (extended_layout && !avp_video_pitch(player.width, pitch)) return false;
     size_t need = 0;
-    if (!avp_nv12_bytes(player.width, player.height, need)) return false;
+    if (!avp_nv12_bytes(pitch, player.height, need)) return false;
     if (!player.texture_frames.empty()) {
         if (need > player.texture_frame_bytes) return false;
         data = player.texture_frames[player.next_texture_frame++ % player.texture_frames.size()];
         if (!data) return false;
     } else {
-        data = avp_frame_storage(player, need, player.width);
+        data = avp_frame_storage(player, need, pitch);
         if (!data) return false;
     }
     memset(data, 0, need);
+    avp_register_frame_layout(data, need, pitch);
     return true;
 }
 
@@ -912,8 +938,9 @@ bool avp_build_textures(const AvpMemAllocator& memory, int32_t requested,
     const bool have_allocate = memory.allocate_texture != nullptr;
     const bool have_deallocate = memory.deallocate_texture != nullptr;
     if (!have_allocate && !have_deallocate) return true; // legacy/test fallback
-    if (!have_allocate || !have_deallocate ||
-        !avp_nv12_bytes(width, height, texture_bytes) || texture_bytes > UINT32_MAX)
+    uint32_t pitch = 0;
+    if (!have_allocate || !have_deallocate || !avp_video_pitch(width, pitch) ||
+        !avp_nv12_bytes(pitch, height, texture_bytes) || texture_bytes > UINT32_MAX)
         return false;
 
     // The public API permits a caller-selected framebuffer count.  Zero requests the normal double
@@ -932,7 +959,7 @@ bool avp_build_textures(const AvpMemAllocator& memory, int32_t requested,
         }
         auto* texture = static_cast<uint8_t*>(allocation);
         textures.push_back(texture);
-        avp_register_frame_layout(texture, texture_bytes, width);
+        avp_register_frame_layout(texture, texture_bytes, pitch);
     }
     if (avp_log()) {
         fprintf(stderr,
@@ -1059,8 +1086,12 @@ HLE(s_avp_getstreaminfoex) { // s32 sceAvPlayerGetStreamInfoEx(handle, stream_id
     if (a1 >= (p.has_audio ? 2u : 1u)) return 0x806a0001ull;
     *out = {}; out->this_size = caller_size; out->type = a1 == 0 ? 1u : 2u;
     if (a1 == 0) {
+        uint32_t pitch = 0;
+        if (!avp_video_pitch(p.width, pitch)) return 0x806a0001ull;
         out->details.video.width = p.width; out->details.video.height = p.height;
-        out->details.video.aspect = (float)p.width / (float)p.height; out->details.video.pitch = p.width;
+        out->details.video.aspect = (float)p.width / (float)p.height;
+        out->details.video.crop_right_offset = pitch - p.width;
+        out->details.video.pitch = pitch;
         out->details.video.luma_bd = 8; out->details.video.chroma_bd = 8;
         out->details.video.framerate = p.fps;
     } else {
@@ -1286,7 +1317,7 @@ HLE(s_avp_getvideodata) {
             if (b->next_video(p.backend_id, vf)) {
                 uint8_t* staged = nullptr;
                 uint32_t pitch = 0;
-                if (avp_stage_video(p, vf, staged, pitch)) {
+                if (avp_stage_video(p, vf, false, staged, pitch)) {
                     fi->p_data = staged;
                     fi->timestamp = vf.pts_us / 1000;
                     p.last_ts_ms = fi->timestamp;
@@ -1301,7 +1332,8 @@ HLE(s_avp_getvideodata) {
             // frame delivery: Astro Bot never polls IsActive, so an IsActive-only counter made EOF
             // and the STOP event unreachable even though it continuously pulled video frames.
             uint8_t* staged = nullptr;
-            if (avp_stage_synthetic(p, staged)) {
+            uint32_t pitch = 0;
+            if (avp_stage_synthetic(p, false, staged, pitch)) {
                 fi->p_data = staged; fi->timestamp = p.poll * 33ull; // ~30fps PTS (ms)
                 p.last_ts_ms = fi->timestamp;
                 fi->d0 = p.width; fi->d1 = p.height; fi->d2 = 0; fi->d3 = 0;
@@ -1332,12 +1364,13 @@ HLE(s_avp_getvideodataex) {
             if (b->next_video(p.backend_id, vf)) {
                 uint8_t* staged = nullptr;
                 uint32_t pitch = 0;
-                if (avp_stage_video(p, vf, staged, pitch)) {
+                if (avp_stage_video(p, vf, true, staged, pitch)) {
                     fi->p_data = staged;
                     fi->timestamp = vf.pts_us / 1000;
                     p.last_ts_ms = fi->timestamp;
                     fi->details.video = {}; fi->details.video.width = vf.width; fi->details.video.height = vf.height;
                     fi->details.video.aspect = vf.height ? (float)vf.width / (float)vf.height : 0.0f;
+                    fi->details.video.crop_right_offset = pitch - vf.width;
                     fi->details.video.pitch = pitch;
                     fi->details.video.luma_bd = 8; fi->details.video.chroma_bd = 8;
                     fi->details.video.framerate = p.fps;
@@ -1348,11 +1381,14 @@ HLE(s_avp_getvideodataex) {
             }
         } else if (p.synthetic && p.poll < avp_synth_frames()) {
             uint8_t* staged = nullptr;
-            if (avp_stage_synthetic(p, staged)) {
+            uint32_t pitch = 0;
+            if (avp_stage_synthetic(p, true, staged, pitch)) {
                 fi->p_data = staged; fi->timestamp = p.poll * 33ull;
                 p.last_ts_ms = fi->timestamp;
                 fi->details.video = {}; fi->details.video.width = p.width; fi->details.video.height = p.height;
-                fi->details.video.aspect = (float)p.width / (float)p.height; fi->details.video.pitch = p.width;
+                fi->details.video.aspect = (float)p.width / (float)p.height;
+                fi->details.video.crop_right_offset = pitch - p.width;
+                fi->details.video.pitch = pitch;
                 fi->details.video.luma_bd = 8; fi->details.video.chroma_bd = 8;
                 fi->details.video.framerate = p.fps;
                 p.poll++; result = 1;

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -821,15 +821,21 @@ bool avp_stage_video(AvpPlayer& player, const prosper::video::VideoFrame& frame,
         dst = avp_frame_storage(player, bytes, pitch);
     }
     if (!dst) return false;
-    // The crop offsets keep padding invisible, but clearing it also prevents stale decoder bytes
-    // from becoming observable if a title deliberately samples outside the valid image extent.
-    memset(dst, 0, bytes);
-    for (uint32_t row = 0; row < frame.height; ++row)
+    // Copy visible pixels and clear only the padded tail. Clearing the entire frame before copying
+    // it would double memory traffic on every decoded frame; the crop still must not expose stale
+    // decoder bytes if a title deliberately samples beyond the valid image extent.
+    const size_t padding = static_cast<size_t>(pitch) - frame.width;
+    for (uint32_t row = 0; row < frame.height; ++row) {
         memcpy(dst + static_cast<size_t>(row) * pitch,
                frame.y + static_cast<size_t>(row) * y_stride, frame.width);
+        if (padding)
+            memset(dst + static_cast<size_t>(row) * pitch + frame.width, 0, padding);
+    }
     uint8_t* dst_uv = dst + static_cast<size_t>(pitch) * frame.height;
-    for (size_t row = 0; row < uv_rows; ++row)
+    for (size_t row = 0; row < uv_rows; ++row) {
         memcpy(dst_uv + row * pitch, frame.uv + row * uv_stride, frame.width);
+        if (padding) memset(dst_uv + row * pitch + frame.width, 0, padding);
+    }
     // Callback storage is registered before the first pull. Refresh it here because the basic API
     // retains its historical tight layout while GetVideoDataEx publishes the padded physical pitch.
     avp_register_frame_layout(dst, bytes, pitch);

--- a/prosper/tests/test_avplayer.cpp
+++ b/prosper/tests/test_avplayer.cpp
@@ -10,6 +10,7 @@
 #include "../src/hle/nid.hpp"
 #include "../src/hle/video_backend.hpp"
 #include "../src/gpu/guest_texture_layout.hpp"
+#include "../src/gpu/tile.hpp"
 #include <cstdio>
 #include <algorithm>
 #include <cstdint>
@@ -34,6 +35,9 @@ struct AvpInitData {
 struct AvpFrameInfoEx {
     void* data = nullptr; uint8_t reserved[4]{}; uint64_t timestamp = 0; uint8_t details[80]{};
 };
+struct AvpFrameInfo {
+    void* data = nullptr; uint8_t reserved[4]{}; uint64_t timestamp = 0; uint32_t details[4]{};
+};
 struct AvpStreamInfoEx {
     uint64_t size = 0; uint32_t type = 0; uint8_t reserved[4]{};
     uint8_t details[80]{}; uint64_t duration = 0;
@@ -42,18 +46,29 @@ static_assert(offsetof(AvpFrameInfoEx, details) == 24, "AvPlayerFrameInfoEx ABI"
 
 class FakeVideoBackend final : public video::VideoBackend {
 public:
-    static constexpr uint32_t kWidth = 640;
-    static constexpr uint32_t kHeight = 360;
+    // R-Type Delta's 1920x1080 movie is the discriminating case: PS5 AvPlayer exposes a
+    // 2048-byte physical pitch and crops the 128 padded pixels from the valid image extent.
+    static constexpr uint32_t kWidth = 1920;
+    static constexpr uint32_t kHeight = 1080;
+    static constexpr uint32_t kStride = 2048;
+    static constexpr size_t kUvRows = (kHeight + 1u) / 2u;
     bool fail_open = false;
     bool delivered = false;
     bool audio_delivered = false;
     int close_count = 0;
     std::string opened_path;
-    std::vector<uint8_t> nv12 = std::vector<uint8_t>(kWidth * kHeight * 3 / 2, 0x40);
+    std::vector<uint8_t> nv12 =
+        std::vector<uint8_t>(static_cast<size_t>(kStride) * (kHeight + kUvRows), 0xa5);
     std::vector<int16_t> pcm = std::vector<int16_t>(2 * 128, 0x20);
 
     FakeVideoBackend() {
-        std::fill(nv12.begin() + kWidth * kHeight, nv12.end(), 0x80);
+        for (uint32_t row = 0; row < kHeight; ++row)
+            std::fill_n(nv12.data() + static_cast<size_t>(row) * kStride, kWidth,
+                        static_cast<uint8_t>(0x40u + (row & 0x0fu)));
+        uint8_t* uv = nv12.data() + static_cast<size_t>(kStride) * kHeight;
+        for (size_t row = 0; row < kUvRows; ++row)
+            std::fill_n(uv + row * kStride, kWidth,
+                        static_cast<uint8_t>(0x80u + (row & 0x0fu)));
     }
 
     int open(const std::string& host_path) override {
@@ -69,8 +84,9 @@ public:
     }
     bool next_video(int id, video::VideoFrame& out) override {
         if (id != 17 || delivered) return false;
-        out.y = nv12.data(); out.uv = nv12.data() + kWidth * kHeight;
-        out.width = kWidth; out.height = kHeight; out.y_stride = kWidth; out.uv_stride = kWidth;
+        out.y = nv12.data();
+        out.uv = nv12.data() + static_cast<size_t>(kStride) * kHeight;
+        out.width = kWidth; out.height = kHeight; out.y_stride = kStride; out.uv_stride = kStride;
         out.pts_us = 16'667; delivered = true;
         return true;
     }
@@ -185,6 +201,7 @@ int main() {
     HleFn active = Hle::lookup(nid_hash("sceAvPlayerIsActive"));
     HleFn add    = Hle::lookup(nid_hash("sceAvPlayerAddSource"));
     HleFn start  = Hle::lookup(nid_hash("sceAvPlayerStart"));
+    HleFn video_basic = Hle::lookup(nid_hash("sceAvPlayerGetVideoData"));
     HleFn video  = Hle::lookup(nid_hash("sceAvPlayerGetVideoDataEx"));
     HleFn audio  = Hle::lookup(nid_hash("sceAvPlayerGetAudioData"));
     HleFn streams = Hle::lookup("hdTyRzCXQeQ");
@@ -192,9 +209,11 @@ int main() {
     HleFn pause   = Hle::lookup("9y5v+fGN4Wk");
     HleFn resume  = Hle::lookup("w5moABNwnRY");
     HleFn close   = Hle::lookup(nid_hash("sceAvPlayerClose"));
-    CHECK(init && initex && active && add && start && video && audio && streams && infoex && pause && resume && close,
+    CHECK(init && initex && active && add && start && video_basic && video && audio && streams &&
+              infoex && pause && resume && close,
           "AvPlayer lifecycle and stream functions registered");
-    if (!(init && initex && active && add && start && video && audio && streams && infoex && pause && resume && close)) {
+    if (!(init && initex && active && add && start && video_basic && video && audio && streams &&
+          infoex && pause && resume && close)) {
         printf("== FAIL ==\n"); return 1;
     }
 
@@ -270,21 +289,34 @@ int main() {
     const char native_source[] = "movie.mp4";
     CHECK(add(native_handle, (uint64_t)(uintptr_t)native_source, 0, 0, 0, 0) == 0,
           "native source opens through the registered backend");
+    constexpr size_t native_y_bytes =
+        static_cast<size_t>(FakeVideoBackend::kStride) * FakeVideoBackend::kHeight;
+    constexpr size_t native_frame_bytes = native_y_bytes +
+        static_cast<size_t>(FakeVideoBackend::kStride) * FakeVideoBackend::kUvRows;
     CHECK(texture_alloc_count == 3 && texture_last_align == 0x100 &&
-              texture_last_size == fake.nv12.size(),
-          "native source allocates the requested tight guest NV12 texture ring");
+              texture_last_size == native_frame_bytes,
+          "native source allocates the requested pitch-preserving guest NV12 texture ring");
     CHECK(fake.opened_path == "C:/prosper-test-app0/movie.mp4",
           "native backend receives the resolved host path, not the raw relative guest path");
     CHECK(streams(native_handle, 0, 0, 0, 0, 0) == 2,
           "native audio-bearing source enumerates video and audio streams");
     AvpStreamInfoEx native_info{}; native_info.size = sizeof(native_info);
-    uint32_t native_info_pitch = 0;
+    uint32_t native_info_width = 0, native_info_crop_left = 0, native_info_crop_right = 0;
+    uint32_t native_info_crop_top = 0, native_info_crop_bottom = 0, native_info_pitch = 0;
     CHECK(infoex(native_handle, 0, (uint64_t)(uintptr_t)&native_info, 0, 0, 0) == 0 &&
               native_info.type == 1 && native_info.duration == 2000,
           "native stream metadata and duration come from the backend");
+    memcpy(&native_info_width, native_info.details + 0, sizeof(native_info_width));
+    memcpy(&native_info_crop_left, native_info.details + 20, sizeof(native_info_crop_left));
+    memcpy(&native_info_crop_right, native_info.details + 24, sizeof(native_info_crop_right));
+    memcpy(&native_info_crop_top, native_info.details + 28, sizeof(native_info_crop_top));
+    memcpy(&native_info_crop_bottom, native_info.details + 32, sizeof(native_info_crop_bottom));
     memcpy(&native_info_pitch, native_info.details + 36, sizeof(native_info_pitch));
-    CHECK(native_info_pitch == FakeVideoBackend::kWidth,
-          "native stream metadata reports the AvPlayer tight row pitch");
+    CHECK(native_info_width == FakeVideoBackend::kWidth &&
+              native_info_pitch == FakeVideoBackend::kStride &&
+              native_info_crop_left == 0 && native_info_crop_right == 128 &&
+              native_info_crop_top == 0 && native_info_crop_bottom == 0,
+          "native stream metadata separates the 2048 physical pitch from 1920 visible pixels");
     native_info = {}; native_info.size = sizeof(native_info);
     CHECK(infoex(native_handle, 1, (uint64_t)(uintptr_t)&native_info, 0, 0, 0) == 0 &&
               native_info.type == 2,
@@ -297,28 +329,47 @@ int main() {
               native_frame.data && native_frame.data != fake.nv12.data() &&
               std::find(texture_allocations.begin(), texture_allocations.end(), native_frame.data) !=
                   texture_allocations.end() &&
-              native_frame.timestamp == 16 &&
-              memcmp(native_frame.data, fake.nv12.data(), fake.nv12.size()) == 0,
+              native_frame.timestamp == 16,
           "native decoded NV12 frame is copied into caller-owned guest texture staging");
     const auto* staged = static_cast<const uint8_t*>(native_frame.data);
     const uint64_t staged_address = static_cast<uint64_t>(reinterpret_cast<uintptr_t>(staged));
-    CHECK(gpu::guest_linear_texture_row_pitch(staged_address, FakeVideoBackend::kWidth) ==
-              FakeVideoBackend::kWidth &&
+    CHECK(staged[0] == 0x40 && staged[FakeVideoBackend::kWidth - 1] == 0x40 &&
+              staged[FakeVideoBackend::kWidth] == 0 &&
+              staged[FakeVideoBackend::kStride] == 0x41 &&
+              staged[native_y_bytes] == 0x80 &&
+              staged[native_y_bytes + FakeVideoBackend::kWidth] == 0 &&
+              staged[native_y_bytes + FakeVideoBackend::kStride] == 0x81,
+          "1920 visible bytes are copied row-by-row while luma/chroma padding remains cleared");
+    CHECK(gpu::guest_linear_texture_row_pitch(staged_address, FakeVideoBackend::kStride) ==
+              FakeVideoBackend::kStride &&
           gpu::guest_linear_texture_row_pitch(
-              staged_address + FakeVideoBackend::kWidth * FakeVideoBackend::kHeight,
-              FakeVideoBackend::kWidth) == FakeVideoBackend::kWidth,
-          "native luma and chroma addresses retain exact tight-layout provenance for GPU sampling");
+              staged_address + native_y_bytes,
+              FakeVideoBackend::kStride) == FakeVideoBackend::kStride,
+          "native luma and chroma addresses retain exact padded-layout provenance for GPU sampling");
     fake.nv12[0] = 0x7f;
     CHECK(static_cast<const uint8_t*>(native_frame.data)[0] == 0x40,
           "guest frame storage remains independent when the backend recycles its packet");
-    uint32_t native_width = 0, native_height = 0, native_pitch = 0; double native_fps = 0.0;
+    uint32_t native_width = 0, native_height = 0, native_crop_left = 0, native_crop_right = 0;
+    uint32_t native_crop_top = 0, native_crop_bottom = 0, native_pitch = 0;
+    double native_fps = 0.0;
     memcpy(&native_width, native_frame.details + 0, sizeof(native_width));
     memcpy(&native_height, native_frame.details + 4, sizeof(native_height));
+    memcpy(&native_crop_left, native_frame.details + 20, sizeof(native_crop_left));
+    memcpy(&native_crop_right, native_frame.details + 24, sizeof(native_crop_right));
+    memcpy(&native_crop_top, native_frame.details + 28, sizeof(native_crop_top));
+    memcpy(&native_crop_bottom, native_frame.details + 32, sizeof(native_crop_bottom));
     memcpy(&native_pitch, native_frame.details + 36, sizeof(native_pitch));
     memcpy(&native_fps, native_frame.details + 48, sizeof(native_fps));
     CHECK(native_width == FakeVideoBackend::kWidth && native_height == FakeVideoBackend::kHeight &&
-              native_pitch == FakeVideoBackend::kWidth && native_fps == 60.0,
-          "native frame details preserve dimensions, tight row pitch, and frame rate");
+              native_pitch == FakeVideoBackend::kStride && native_crop_left == 0 &&
+              native_crop_right == 128 && native_crop_top == 0 && native_crop_bottom == 0 &&
+              native_fps == 60.0,
+          "native frame details preserve visible dimensions, physical pitch, crop, and frame rate");
+    CHECK(gpu::linear_sampled_surface_bytes(native_pitch, native_height, 1) ==
+              static_cast<size_t>(native_pitch) * native_height,
+          "R-Type movie luma descriptor footprint matches the published pitch extent");
+    CHECK(native_pitch - native_crop_left - native_crop_right == native_width,
+          "GRIS crop offsets hide the padded tail instead of exposing a right-edge strip");
     CHECK(video(native_handle, (uint64_t)(uintptr_t)&native_frame, 0, 0, 0, 0) == 0 &&
               event_count == 3 && events[2] == 1 && !fake.audio_delivered,
           "video-only consumption of an audio-bearing source reaches EOF and fires one STOP");
@@ -329,8 +380,28 @@ int main() {
     close(native_handle, 0, 0, 0, 0, 0);
     CHECK(fake.close_count == 1 && texture_free_count == 3,
           "Close releases the native decode session and every guest texture");
-    CHECK(gpu::guest_linear_texture_row_pitch(staged_address, FakeVideoBackend::kWidth) == 0,
+    CHECK(gpu::guest_linear_texture_row_pitch(staged_address, FakeVideoBackend::kStride) == 0,
           "Close removes the released AvPlayer texture layout provenance");
+
+    // The basic API has no pitch/crop fields. Keep its historical tight fallback contract while
+    // GetVideoDataEx exposes the PS5 physical layout above.
+    uint64_t basic_handle = init((uint64_t)(uintptr_t)&data, 0, 0, 0, 0, 0);
+    CHECK(add(basic_handle, (uint64_t)(uintptr_t)native_source, 0, 0, 0, 0) == 0 &&
+              start(basic_handle, 0, 0, 0, 0, 0) == 0,
+          "basic AvPlayer source starts through the same padded-stride backend");
+    AvpFrameInfo basic_frame{};
+    CHECK(video_basic(basic_handle, (uint64_t)(uintptr_t)&basic_frame, 0, 0, 0, 0) == 1 &&
+              basic_frame.data && basic_frame.details[0] == FakeVideoBackend::kWidth &&
+              basic_frame.details[1] == FakeVideoBackend::kHeight,
+          "basic AvPlayer frame preserves its width/height-only ABI");
+    const uint64_t basic_address =
+        static_cast<uint64_t>(reinterpret_cast<uintptr_t>(basic_frame.data));
+    CHECK(gpu::guest_linear_texture_row_pitch(basic_address, FakeVideoBackend::kWidth) ==
+              FakeVideoBackend::kWidth,
+          "basic AvPlayer storage remains tight because that ABI cannot publish padding crops");
+    close(basic_handle, 0, 0, 0, 0, 0);
+    CHECK(gpu::guest_linear_texture_row_pitch(basic_address, FakeVideoBackend::kWidth) == 0,
+          "Close removes the basic AvPlayer fallback layout provenance");
     prosper::video::set_backend(nullptr);
 
     // One delivered synthetic frame, then EOF on the next pull. Astro Bot follows this path and does
@@ -360,15 +431,22 @@ int main() {
     CHECK(frame.data != nullptr, "synthetic frame has stable storage");
     const uint64_t synthetic_frame_address =
         static_cast<uint64_t>(reinterpret_cast<uintptr_t>(frame.data));
-    uint32_t width = 0, height = 0, pitch = 0; double fps = 0.0;
+    uint32_t width = 0, height = 0, crop_left = 0, crop_right = 0;
+    uint32_t crop_top = 0, crop_bottom = 0, pitch = 0;
+    double fps = 0.0;
     memcpy(&width, frame.details + 0, sizeof(width));
     memcpy(&height, frame.details + 4, sizeof(height));
+    memcpy(&crop_left, frame.details + 20, sizeof(crop_left));
+    memcpy(&crop_right, frame.details + 24, sizeof(crop_right));
+    memcpy(&crop_top, frame.details + 28, sizeof(crop_top));
+    memcpy(&crop_bottom, frame.details + 32, sizeof(crop_bottom));
     memcpy(&pitch, frame.details + 36, sizeof(pitch));
     memcpy(&fps, frame.details + 48, sizeof(fps));
-    CHECK(width == 1920 && height == 1080 && pitch == 1920 && fps == 30.0,
-          "AvPlayerVideoEx uses the published 80-byte layout");
+    CHECK(width == 1920 && height == 1080 && pitch == 2048 && crop_left == 0 &&
+              crop_right == 128 && crop_top == 0 && crop_bottom == 0 && fps == 30.0,
+          "AvPlayerVideoEx uses the published 80-byte padded-pitch/crop layout");
     CHECK(gpu::guest_linear_texture_row_pitch(synthetic_frame_address, pitch) == pitch,
-          "fallback AvPlayer storage also publishes its exact tight layout");
+          "fallback AvPlayer storage also publishes its exact physical layout");
     CHECK(pause(h2, 0, 0, 0, 0, 0) == 0 && event_count == 3 && events[2] == 4,
           "Pause reports success and fires PAUSE without deadlocking the callback");
     CHECK(video(h2, (uint64_t)(uintptr_t)&frame, 0, 0, 0, 0) == 0 && event_count == 3,


### PR DESCRIPTION
Fixes #1753. Refs #1746, #1393 and #1807.

## Failure

Past R-Type Delta's independent startup race (#1746), its movie fragment shader was rejected at
pc 52 as an unresolved `IMAGE_SAMPLE` from texture SGPR 8. Every presented frame stayed flat.

The shader opcode was already supported. `movie_yuv_p.ags` declares direct texture slots at SGPRs
0 and 8 and direct sampler slots at SGPRs 16 and 20. Guest disassembly shows the title never creates
texture slot 1: it builds the luma T#, asks AGC for its sampled-linear footprint, compares that with
`AvPlayerVideoEx.pitch * height`, prints `unexpected y_texture size`, and returns before building the
chroma T#.

Prosper published a tight 1920-byte pitch while AGC's PS5 sampled-linear footprint aligns that row
to 2048 bytes. The title therefore compared 2,073,600 expected bytes with 2,211,840 physical bytes,
cleared its one-time initialization flag, and bound an uninitialized chroma slot on every later
frame.

## Contract and approach

PS5 `AvPlayerVideoEx` separates the physical and visible extents: four 32-bit pixel crop offsets at
offsets 20/24/28/32, followed by the physical pitch at offset 36. For a 1920x1080 NV12 frame this
change:

- allocates and stages 2048-byte luma/chroma rows for `GetVideoDataEx`;
- publishes `pitch=2048` and `crop_right_offset=128` while retaining visible width 1920;
- copies only the 1920 valid bytes on each row and clears only the padded tail;
- registers both plane addresses with exact 2048-byte layout provenance;
- publishes the same pitch/crop contract through `GetStreamInfoEx` and synthetic Ex frames;
- keeps the basic `GetVideoData` path tight because that ABI has no pitch/crop fields.

This is generic AvPlayer layout behavior, not a title-address shim. Unsupported resources remain
fail-visible and no shader/resource resolver is relaxed.

## Cross-title invariant

GRIS's PS5 video wrapper explicitly computes visible width as
`pitch - crop_left_offset - crop_right_offset`. The padded experiment in #1393 removed its stride
corruption but left crop right zero, exposing the 128-byte tail as a solid strip. Padding and crop
are one contract: this change supplies both, while preserving the exact-layout U/V handling landed
for GRIS.

The basic API, ordinary guest textures, generic 256-byte fallback, capture/replay NV12 predicate,
and shader recompilation are deliberately unchanged.

## Regression guards

`test_avplayer` now feeds a real discriminating shape: 1920x1080 NV12 with 2048-byte decoder
strides. It verifies allocation size, row-by-row luma/chroma placement, cleared padding, all four crop
fields, physical pitch, both plane addresses, the R-Type footprint equality, the GRIS visible-width
expression, fallback lifetime, and the deliberately tight basic API.

Two mutations prove the named guards exercise both defects:

- restoring `pitch=width` makes `R-Type movie luma descriptor footprint matches the published pitch
  extent` fail;
- retaining pitch 2048 but forcing crop right to zero leaves that R-Type check green and makes
  `GRIS crop offsets hide the padded tail instead of exposing a right-edge strip` fail.

The full static chain and falsifications are recorded in
`prosper/docs/R_TYPE_DELTA_STATUS.md` so the SGPR/opcode investigation is not repeated.

## Risks

The affected surface is `AvPlayerVideoEx` consumers. A title that incorrectly treats pitch as its
visible width and ignores the ABI crop fields would expose padding. GRIS is the known regression
candidate and explicitly consumes the crop fields; its opening FMV is included in live validation.

This does **not** fix R-Type's earlier #1746 startup race. Live R-Type validation uses the existing
boot-trace byte-patch diagnostic to skip only the title's initial Sleep(400), and any visual result is
reported as diagnostic reachability rather than a normal-launch compatibility milestone.

## Validation

PR head: `7d1747fe` after ancestry-only rebases onto master containing #1806 and #1813.

Live-tested code head before that rebase: `4114391c6e8d0cead3bc1460d0aa1f5351b99ffd`;
the code-identical final rebased commit is `54832020`. The final commit changes only
`R_TYPE_DELTA_STATUS.md` to record those results and link #1807.

- Distrobox `ps5ys`, worktree-local Linux build:
  `cmake --build prosper/build-linux --target test_avplayer -j8` — passed.
- `ctest --test-dir prosper/build-linux --output-on-failure -R avplayer_hle` — 1/1 passed.
- Direct `test_avplayer` repeatability check — 10/10 consecutive runs passed.
- Tight-pitch mutation — named R-Type footprint check failed; crop/GRIS expression remained green.
- Zero-crop mutation — named GRIS strip check failed; R-Type footprint remained green.
- Bounded R-Type live discriminator — expected timeout after 60 seconds; all three patch bytes
  confirmed; zero size mismatch, pc-52 SGPR-8 resolution failure, pc-52 shader rejection or
  fragment-program execution rejection. AvPlayer alternated two padded buffers with advancing
  timestamps. The #1753 mechanism is fixed.
- R-Type visual inspection — all 49 retained 1920x1080 frames inspected. They contain solid clears
  or 2--75-colour diagonal/purple gradients, not recognizable FMV imagery. The downstream visual
  frontier is #1807; no compatibility rung is claimed.
- Bounded GRIS opening/title regression route — exit 0; 45 source-distinct, 42 pixel-distinct,
  maximum pixel staleness 1.0 seconds, status `ok`. All 45 frames inspected; no right strip,
  horizontal stride corruption or U/V cast.
- Final focused gate — `boot_trace`, `screenshot`, and `test_avplayer` were up to date; focused
  `avplayer_hle` passed 1/1; direct `test_avplayer` passed 10/10 consecutive runs; `git diff --check`
  passed.

## Visual evidence

None for R-Type. The bounded diagnostic route produces only incorrect flat/gradient output, so no
screenshot is attached and no visual milestone is claimed. The 45-frame GRIS cross-title route was
visually inspected at full resolution and remained clean, but it does not represent a new GRIS
compatibility milestone.
