### PR TITLE
docs(astro): record v10 GDS ordering discriminator

### DIFF
--- a/prosper/docs/ASTROBOT_LINUX_HANDOFF_2026_07_19.md
+++ b/prosper/docs/ASTROBOT_LINUX_HANDOFF_2026_07_19.md
@@ -596,6 +596,16 @@ than re-deriving a dead answer at full cost.
   PM4 order/operands/selectors plus an uncapped original count and explicit truncation flag. Older
   retained timelines cannot answer reset-versus-dispatch ordering; recapture that question with v10.
 
+- **"The four GDS resets are missing, late, or separated from producer `0x5006eac00`."** False on
+  master `fdc906d0` in the rendered high-half diagnostic run for #1732. Timeline v10 captured 1,022
+  producer submits, and every one had the same exact raw-PM4 sequence: zero GDS offsets
+  `0xc70/0xc74/0xc78/0xc7c` at producer-order deltas `-33/-31/-29/-27`, read them to guest memory at
+  `-20/-18/-16/-14`, run the producer, then read them again at `+3/+5/+7/+9`. All 7,788 recorded
+  submit journals were complete (`dma_journals_truncated=0`); the bounded 180-second run reached
+  1,008 guest flips and 3,023 live presents by 173.5 seconds instead of reproducing the historical
+  frame-17 stall. This rules out missing/late reset ordering and supports the high-half GDS address
+  interpretation, but it is **not a fix claim**: the old stall did not reproduce on this revision.
+
 - **"Astro Bot's unbounded indirect dispatch (#1742) is caused by the dropped GDS counter resets."**
   False, and measured rather than argued. The guest does reset GDS counters with `DMA_DATA` packets
   whose destination selector names a GDS offset, and prosper *was* discarding every one of them —


### PR DESCRIPTION
Refs #1732 and #1743.

## Finding

A fresh timeline-v10 capture answers the exact reset-order question that older v1-v9 evidence could
not represent. Across all **1,022** executions of producer `0x5006eac00`, every submit had the same
raw-PM4 sequence:

1. zero GDS offsets `0xc70/0xc74/0xc78/0xc7c`;
2. read those offsets to guest memory;
3. execute the producer;
4. read the same offsets again.

The order deltas from the producer were `-33/-31/-29/-27` for resets,
`-20/-18/-16/-14` for pre-reads, and `+3/+5/+7/+9` for post-reads. All 7,788 retained submit journals
were complete and `dma_journals_truncated=0`.

This falsifies the hypothesis that the resets are absent, late, or separated into another submit,
and supports the high-half GDS address interpretation. The result is added to the Astro status doc's
`Ruled out` record so future investigations do not repeat it.

## Important boundary

The historical frame-17 stall/device loss did **not** reproduce in this bounded run: it reached 1,008
guest flips and 3,023 live presents by 173.5 seconds, with all targeted producer executions reporting
success. This PR does not claim that #1732 or #1743 is fixed; it closes only this discriminator.

## Validation

- Timeline gate witness printed before execution; version reported as 10.
- 1,022/1,022 joined producer submits conformed; 0 were nonconforming.
- 7,788/7,788 raw DMA journals were complete; 0 were truncated.
- Capture bounded to 180 seconds; the reader safely ignored only the terminated final-file tail.
- Evidence hashes and sanitized paths are recorded on #1732; cross-title non-reproduction is recorded
  on #1743.
- `git diff --check` passes.

Documentation-only; no execution behavior changes.
