### PR TITLE
gpu: use the GDS M0 base field for append counters

### DIFF
--- a/prosper/docs/ASTROBOT_LINUX_HANDOFF_2026_07_19.md
+++ b/prosper/docs/ASTROBOT_LINUX_HANDOFF_2026_07_19.md
@@ -583,6 +583,44 @@ direct evidence of:
 
 Until those conditions hold, keep advancing the live failure frontier.
 
+## GDS M0 post-v10 result (2026-08-03)
+
+The retained high-half/low-half comparison now clears the old frame-17 stall confound; see the new
+`## Ruled out` entry below and #1732. Branch `fix/issue-1732-astro-post-v10` implements the narrow
+architectural change at both DS_APPEND/DS_CONSUME emission sites:
+
+- GDS derives its 16-bit byte base from `M0[31:16]`; `M0[15:0]` is the allocation size.
+- LDS still derives its byte base from `M0[15:0]`.
+- ADDTID is untouched.
+- Base plus instruction offset wraps at the 64 KiB LDS/GDS boundary in both straight-line and CFG
+  emission paths.
+
+The controls are mechanism-sensitive:
+
+- The CPU-only structural test compiles the same nonzero M0 value once as GDS and once as LDS, then
+  proves that the GDS module consumes it through shift-right-by-16 while the LDS module consumes it
+  through an `0xffff` mask.
+- Mutating only the GDS arm back to the old low-half extraction leaves DS_APPEND present but makes
+  the named GDS structural check fail. This reproduces the old address selection instead of deleting
+  the mechanism.
+- The production Vulkan backend executes Astro's exact `M0=0x0c600020`, offset `0x10` append plus a
+  boundary-wrap append. Its authoritative host words are
+  `[0]=0 [0x20]=1 [0x30]=0 [0x50]=0 [0xc70]=1`: the live counter lands at `0xc70`, the boundary
+  wraps to `0x20`, and neither old low-half alias is written. `test_game_compute` passes all 281
+  assertions; `test_rdna2_to_spirv` also passes, including its nonzero-high-half LDS control.
+
+The one authorized 150-second rendered title run also passes every declared mechanism criterion; full
+evidence is on #1732. The actual dumped producer module shifts SGPR-14 M0 right by 16 before each of
+its four GDS atomics. All 938 producer executions succeed, all 938 writeback blocks contain the four
+expected slots, and no Vulkan failure occurs through targeted submit 7,069. Progress reaches 924 guest
+flips and 2,773 live presents. The first argument ranges from 1 to 3,346 with both rises and falls;
+the third ranges from 1 to 10, while the other two remain one. This clears the historical producer-330
+/ submit-2349 device-loss boundary and the frame-17 stall confound by a wide margin.
+
+This is live acceptance of the GDS M0 mechanism, not a full Astro visual or performance claim. The
+run enabled extremely verbose graphics diagnostics and produced an 878 MiB log, so no FPS figure from
+it is meaningful. Continue the wider title-screen/gameplay investigation independently.
+
 ## Ruled out
 
 One line per falsified hypothesis, the evidence that killed it, and the issue/PR. Extend this rather
@@ -605,6 +643,22 @@ than re-deriving a dead answer at full cost.
   1,008 guest flips and 3,023 live presents by 173.5 seconds instead of reproducing the historical
   frame-17 stall. This rules out missing/late reset ordering and supports the high-half GDS address
   interpretation, but it is **not a fix claim**: the old stall did not reproduce on this revision.
+
+- **"The high-half GDS arm avoids the runaway only because Astro stalls or all four producer
+  outputs collapse to `(1,1,1)`."** False in the same retained v10 run. The uncapped
+  `PROSPER_COMPUTELOG_CODE=0x5006eac00` writeback trace contains 1,022 successful producer blocks;
+  every block has exactly one writeback for each of the four stable indirect-argument addresses.
+  `0x5074063c0` has 61 distinct tuples with `groups_x` ranging from 1 to 3,401 and both rising and
+  falling, while `0x50740a520` has 25 distinct tuples ranging from 1 to 96. The other two lists stay
+  at one, so the arm produces a mixed, changing workload rather than a blanket one-group result.
+  Independently, guest progress reaches 1,008 flips and 3,023 live presents with no Vulkan failure.
+  The exact same trace format on the retained low-half positive control has 329 successful producer
+  blocks before its first `VK_ERROR_DEVICE_LOST`: the first list grows monotonically from 1 to
+  1,006,872 and the other three from 1 to 328. The high-half arm therefore changes the counter
+  mechanism from cross-frame accumulation to bounded per-frame values; it does not merely stop the
+  subject. Retained-log SHA-256 values are `94e7ae5aaa081465c64da6ea929cb145e6f60a33d9501c1ba7a3eebb033c7b20`
+  (high v10) and `b788c537585789aeec71963fcb7fb8f0c81f9fcfac111103ee640f7308d36285`
+  (low-half control). See #1732.
 
 - **"Astro Bot's unbounded indirect dispatch (#1742) is caused by the dropped GDS counter resets."**
   False, and measured rather than argued. The guest does reset GDS counters with `DMA_DATA` packets

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -5157,6 +5157,21 @@ inline void mask_write_clobbers_pair(RegState& rs, int dst) {
     rs.sreg_srt.erase(dst); rs.sreg_srt.erase(dst + 1);
 }
 
+// DS_APPEND/DS_CONSUME use M0 as two different architectural layouts. For LDS, M0[15:0]
+// is the byte base. For GDS, M0[31:16] is the 16-bit byte base and M0[15:0] is the
+// allocation size. Astro Bot supplies M0=0x0c600020 and resets the resulting counters at
+// 0xc70..0xc7c; treating the low size field as the base instead placed them at 0x30..0x3c,
+// where they accumulated without bound (#1742). The final 16-bit mask is part of both address
+// domains and keeps base+offset arithmetic wrapping at the 64 KiB share boundary.
+uint32_t ds_append_consume_index(SpirvCompute& b, uint32_t m0, uint32_t literal, bool gds) {
+    const uint32_t base = gds
+        ? b.ibin(Op_ShiftRightLogical, m0, b.uconst(16))
+        : b.ibin(Op_BitwiseAnd, m0, b.uconst(0xffffu));
+    const uint32_t byte_addr = b.ibin(
+        Op_BitwiseAnd, b.ibin(Op_IAdd, base, b.uconst(literal)), b.uconst(0xffffu));
+    return b.ibin(Op_ShiftRightLogical, byte_addr, b.uconst(2));
+}
+
 // Emit one ALU instruction (VOP1/2/C/3 or SOP1/2) into `b`, updating `rs`. Returns true if `in` is an
 // ALU format handled here; sets ok=false if it is an ALU op this stage doesn't support yet. Non-ALU
 // formats (EXP/memory/...) return false so the stage-specific caller can handle them.
@@ -9886,11 +9901,8 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             if (in.opcode == 0x3d || in.opcode == 0x3e) {
                 auto m0 = rs.sreg.find(124);
                 if (!allow_wave || m0 == rs.sreg.end()) { ok = false; return true; }
-                const uint32_t base = b.ibin(Op_BitwiseAnd, m0->second, b.uconst(0xFFFFu));
-                const uint32_t byte_addr = b.ibin(
-                    Op_BitwiseAnd, b.ibin(Op_IAdd, base, b.uconst(in.literal)),
-                    b.uconst(0xFFFFu));
-                const uint32_t idx = b.ibin(Op_ShiftRightLogical, byte_addr, b.uconst(2));
+                const uint32_t idx = ds_append_consume_index(
+                    b, m0->second, in.literal, in.ds_gds);
                 const uint32_t old = vreg_old(b, rs, in.dst.value);
                 if (b.is_fragment && in.ds_gds) {
                     rs.vreg[in.dst.value] = b.native_gds_append(
@@ -12515,9 +12527,8 @@ bool emit_cfg_state_machine(
             const auto event = append_event_for_pc.find(append->pc);
             if (m0 == state.sreg.end() || event == append_event_for_pc.end()) return false;
             if (!append->ds_gds) b.declare_lds();
-            const uint32_t base = b.ibin(Op_BitwiseAnd, m0->second, b.uconst(0xffffu));
-            const uint32_t byte_addr = b.ibin(Op_IAdd, base, b.uconst(append->literal));
-            const uint32_t idx = b.ibin(Op_ShiftRightLogical, byte_addr, b.uconst(2));
+            const uint32_t idx = ds_append_consume_index(
+                b, m0->second, append->literal, append->ds_gds);
             if (b.native_subgroup_size) {
                 const uint32_t result = append->ds_gds
                     ? b.native_gds_append(idx, state.exec, append->opcode == 0x3d)

--- a/prosper/tests/test_game_compute.cpp
+++ b/prosper/tests/test_game_compute.cpp
@@ -1078,6 +1078,45 @@ int main() {
     CHECK(gds_notifications == 0,
           "GPU-internal GDS writeback does not invalidate guest address zero");
 
+    // Astro Bot's four indirect-list counters prove the GDS M0 layout independently of the LDS
+    // append tests: M0[31:16] is the byte base and M0[15:0] is the allocation size. The exact live
+    // value 0x0c600020 plus offset 0x10 must append at 0xc70, not at the old low-half address 0x30.
+    // A second kernel crosses the 64 KiB boundary, proving that base+offset wraps in the GDS domain.
+    static const uint32_t gds_m0_high_append[] = {
+        0xbefc03ffu, 0x0c600020u,  // s_mov_b32 m0, {base=0xc60,size=0x20}
+        0xd8fa0010u, 0x00000000u,  // ds_append v0 offset:0x10 gds -> 0xc70
+        0xbf810000u,
+    };
+    static const uint32_t gds_m0_wrap_append[] = {
+        0xbefc03ffu, 0xfff00020u,  // s_mov_b32 m0, {base=0xfff0,size=0x20}
+        0xd8fa0030u, 0x00000000u,  // ds_append v0 offset:0x30 gds -> 0x20 after wrap
+        0xbf810000u,
+    };
+    gds_initial.fill(0);
+    const auto* gds_m0_words = reinterpret_cast<const uint32_t*>(gds_initial.data());
+    CHECK(gds_m0_words[0] == 0 && gds_m0_words[0x20 / 4] == 0 &&
+              gds_m0_words[0x30 / 4] == 0 && gds_m0_words[0x50 / 4] == 0 &&
+              gds_m0_words[0xc70 / 4] == 0,
+          "GDS M0 fixture starts with zeroed authoritative host backing");
+    // Match Astro's 1x1x1 producer. The earlier store fixture intentionally used the default
+    // 64-lane workgroup; leaving that config in place here would append 64 active lanes while the
+    // launch metadata claimed one, making the address assertion depend on an unrelated count.
+    gds_config.local_x = 1;
+    ComputeItem gds_high_append = make_gds_item(
+        gds_m0_high_append, std::size(gds_m0_high_append), 1, 30);
+    ComputeItem gds_wrap_append = make_gds_item(
+        gds_m0_wrap_append, std::size(gds_m0_wrap_append), 1, 40);
+    CHECK(!gds_high_append.spirv.empty() && !gds_wrap_append.spirv.empty(),
+          "GDS append kernels with nonzero M0 base recompile");
+    CHECK(prosper::frontend::execute_live_compute_items({gds_high_append, gds_wrap_append}),
+          "production compute backend executes GDS M0 base and wrap kernels");
+    printf("  GDS M0 words [0]=%u [0x20]=%u [0x30]=%u [0x50]=%u [0xc70]=%u\n",
+           gds_m0_words[0], gds_m0_words[0x20 / 4], gds_m0_words[0x30 / 4],
+           gds_m0_words[0x50 / 4], gds_m0_words[0xc70 / 4]);
+    CHECK(gds_m0_words[0xc70 / 4] == 1 && gds_m0_words[0x20 / 4] == 1 &&
+              gds_m0_words[0x30 / 4] == 0 && gds_m0_words[0x50 / 4] == 0,
+          "GDS append uses M0 high-half base, wraps at 64 KiB, and rejects low-half aliases");
+
     // --- #590: the live backend's storage-IMAGE path. The same 1D image-copy kernel that
     // test_storage_image_copy proves against the raw harness, executed through the PRODUCTION
     // backend with Unorm8x4 guest-style backing — exercising the full chain: channel unpack

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -106,6 +106,35 @@ bool has_instruction_operand(const std::vector<uint32_t>& spv, uint32_t opcode,
     return false;
 }
 
+// Prove that one binary SPIR-V instruction consumes the two requested literal constants. This is
+// stronger than checking that the constants and opcode merely coexist elsewhere in the module.
+bool binary_uses_literal_operands(const std::vector<uint32_t>& spv, uint32_t opcode,
+                                  uint32_t lhs_literal, uint32_t rhs_literal) {
+    constexpr uint32_t OpConstant = 43;
+    std::unordered_map<uint32_t, uint32_t> constants;
+    if (spv.size() < 5) return false;
+    for (size_t i = 5; i < spv.size();) {
+        const uint32_t op = spv[i] & 0xffffu, wc = spv[i] >> 16u;
+        if (!wc || i + wc > spv.size()) return false;
+        if (op == OpConstant && wc == 4) constants[spv[i + 2]] = spv[i + 3];
+        i += wc;
+    }
+    for (size_t i = 5; i < spv.size();) {
+        const uint32_t op = spv[i] & 0xffffu, wc = spv[i] >> 16u;
+        if (!wc || i + wc > spv.size()) return false;
+        // Integer binary: {result type, result id, lhs id, rhs id}.
+        if (op == opcode && wc == 5) {
+            const auto lhs = constants.find(spv[i + 3]);
+            const auto rhs = constants.find(spv[i + 4]);
+            if (lhs != constants.end() && rhs != constants.end() &&
+                lhs->second == lhs_literal && rhs->second == rhs_literal)
+                return true;
+        }
+        i += wc;
+    }
+    return false;
+}
+
 bool has_select_with_false_constant(const std::vector<uint32_t>& spv, uint32_t literal) {
     constexpr uint32_t OpConstant = 43, OpSelect = 169;
     std::unordered_set<uint32_t> matching_constants;
@@ -391,6 +420,54 @@ int main() {
         return 1;
     }
     printf("  [ok]   signed kernel SPIR-V declares signed i32 with a nonzero id\n");
+
+    // M0 has different layouts for DS_APPEND/DS_CONSUME in the two address domains. Astro Bot's
+    // live GDS value must be shifted to obtain M0[31:16]; the same value in an ordinary LDS append
+    // must be masked to M0[15:0]. These are mutation controls for each other: swapping either field
+    // makes one of the two named checks fail while leaving the instruction present.
+    constexpr uint32_t OpShiftRightLogical = 194, OpBitwiseAnd = 199;
+    const uint32_t m0_gds_append[] = {
+        0xbefc03ffu, 0x0c600020u,
+        0xd8fa0010u, 0x00000000u, // ds_append v0 offset:0x10 gds
+        0xbf810000u,
+    };
+    const uint32_t m0_lds_append[] = {
+        0xbefc03ffu, 0x0c600020u,
+        0xd8f80010u, 0x00000000u, // ds_append v0 offset:0x10 (LDS)
+        0xbf810000u,
+    };
+    ShaderResourceTable m0_gds_table;
+    ShaderResource m0_gds_resource;
+    m0_gds_resource.cls = ResourceClass::ConstantBuffer;
+    m0_gds_resource.format = DataFormat::Uint32;
+    m0_gds_resource.num_components = 1;
+    m0_gds_resource.binding = kComputeInternalGdsBinding;
+    m0_gds_resource.size = 64 * 1024;
+    m0_gds_resource.stride = 4;
+    m0_gds_table.resources.push_back(m0_gds_resource);
+    ComputeShaderConfig m0_config;
+    const auto m0_gds_spv = recompile_compute(
+        m0_gds_append, std::size(m0_gds_append), &m0_gds_table, m0_config);
+    const auto m0_lds_spv = recompile_compute(
+        m0_lds_append, std::size(m0_lds_append), nullptr, m0_config);
+    if (m0_gds_spv.empty() ||
+        !binary_uses_literal_operands(
+            m0_gds_spv, OpShiftRightLogical, 0x0c600020u, 16u) ||
+        binary_uses_literal_operands(
+            m0_gds_spv, OpBitwiseAnd, 0x0c600020u, 0xffffu)) {
+        printf("  [FAIL] GDS append did not derive its byte base from M0[31:16]\n");
+        return 1;
+    }
+    printf("  [ok]   GDS append derives its byte base from M0[31:16]\n");
+    if (m0_lds_spv.empty() ||
+        !binary_uses_literal_operands(
+            m0_lds_spv, OpBitwiseAnd, 0x0c600020u, 0xffffu) ||
+        binary_uses_literal_operands(
+            m0_lds_spv, OpShiftRightLogical, 0x0c600020u, 16u)) {
+        printf("  [FAIL] LDS append did not derive its byte base from M0[15:0]\n");
+        return 1;
+    }
+    printf("  [ok]   LDS append keeps its byte base in M0[15:0]\n");
 
     // Fixed-offset private spill/fill must also produce structurally valid graphics-stage modules.
     // This exercises Function-variable placement in the fragment and vertex shells, independently

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -2082,7 +2082,7 @@ int main() {
         0x7e000f00u,               // v_cvt_u32_f32 v0, v0 (lane number input)
         0x7e04028au, 0x7e060280u,  // v2=10, v3=byte address 0
         0x7e1002ffu, 0x00000063u,  // v8=99 fallback for inactive lanes
-        0xbefc0380u,               // s_mov_b32 m0, 0
+        0xbefc03ffu, 0x00010000u,  // s_mov_b32 m0, 0x10000 (LDS base is low half = 0)
         0x7da40080u,               // v_cmpx_eq_u32 0, v0 (lane zero initializes)
         0xd8340010u, 0x00000203u,  // ds_write_b32 v3, v2 offset:0x10
         0xbefe04c1u, 0xbf8a0000u,  // restore EXEC; barrier
@@ -2108,7 +2108,7 @@ int main() {
     else
         printf("\n");
     CHECK(got32b5.size()==WG && bad32b5==0,
-          "kernel 32b5 atomically adds popcount(EXEC), broadcasts old counter, and predicates VDST");
+          "kernel 32b5 uses M0 low half for LDS, atomically adds popcount(EXEC), and predicates VDST");
 
     // Kernel 32b6: ordinary LDS DS_CONSUME is the inverse operation. Start at 50, make the
     // first 16 lanes valid, and consume once. Active lanes observe old=50 and all lanes read the new


### PR DESCRIPTION
## Summary

- derive `DS_APPEND` / `DS_CONSUME` GDS counter addresses from `M0[31:16]`
- preserve the existing LDS address layout in `M0[15:0]`
- share the address calculation between the straight-line and CFG emitters
- add CPU structural, exact compute, and Vulkan execution controls
- record the live Astro Bot discriminator and post-fix title-run evidence

Astro Bot supplies `M0=0x0c600020` and resets four GDS counters at byte offsets `0xc70..0xc7c`. The old implementation treated the low allocation-size field as the byte base, placing the counters at `0x30..0x3c`. Those counters accumulated until the world-map loader's compute submission lost the Vulkan device. The corrected GDS interpretation selects the high 16-bit base; LDS append/consume continues to use the low 16-bit base.

## Validation

- `test_rdna2_spirv_struct`: PASS, including separate named GDS-high-half and LDS-low-half checks
- `test_game_compute`: PASS (281 assertions), including the authoritative four-counter result `[0]=0 [0x20]=1 [0x30]=0 [0x50]=0 [0xc70]=1`
- `test_rdna2_to_spirv`: PASS, including the LDS high-bits control
- mutation control: changing only the GDS arm back to the low half makes the named structural GDS check fail
- live low-half control: 329 producers succeed, then producer 330 fails with `VK_ERROR_DEVICE_LOST`
- live fixed title run (150 seconds): 938 producers, 938 successes, zero failures, 924 flips, 2,773 presents, and no Vulkan/device-loss report
- the live four-slot blocks remain complete and varying rather than collapsing to a constant result
- dumped title shader SPIR-V confirms the `>> 16`, 16-bit wrapping, `/ 4`, and GDS atomic path in the actual guest shader

No FPS claim is made: the targeted graphics diagnostic produced an 878 MiB log and materially perturbs performance. This PR changes compute correctness/device-loss behavior and makes no visual milestone claim, so there is no new screenshot.

Refs #1732, #1742, #1743, #1751
