### PR TITLE
fix(gpu): lower packed f16 max3 for Syberia

### DIFF
--- a/prosper/docs/SYBERIA_STATUS.md
+++ b/prosper/docs/SYBERIA_STATUS.md
@@ -28,6 +28,7 @@ re-derive these without contradictory new evidence.
 | Vulkan's native typed `B10G11R11_UFLOAT_PACK32` storage conversion is bit-equivalent to the guest's round-to-nearest-even R11G11B10 contract | **Falsified on RADV.** A reduced live-Vulkan 4×4×4 producer→sampled-consumer handoff held tiling (`SW_64KB_R_X`), normalized voxel-centre `SAMPLE_LZ`, dispatch order, cache priming, and all 64 voxels constant while changing only the producer representation. Shader-side `R32ui` packing matched all 64 packed words and 256 sampled channels. Native typed storage differed in **54/64 packed voxels and 92 RGB channel values** (`R=34, G=34, B=24`); all 92 native codes were lower than the CPU f11/f10 oracle, none higher, and the sampled output carried the same 92 differences. The exact packed path now remains authoritative even when native support is advertised. This proves a real conversion defect, **not** that its mostly one-ULP bias causes the visible menu overexposure; the coordinated live A/B in the next row separately tests that causal claim. | #1790 |
 | The native R11 storage rounding bias is the primary cause of the profile menu's severe overexposure | **Falsified at the restored profile-menu boot depth on the pre-#1800 branch state recorded in #1790 (the R11 change was rebased unchanged here).** Two bounded default-renderer runs changed only the exact-packed recovery switch and each retained ten five-second samples from t=170–215 s; neither used capture/RTT/resource-hash diagnostics. Source 118's exact arm directly reported the real 32³ tiled R11 LUT as `native-storage=0`, `R32_UINT`, module hash `7e01d14b7e21d0b2`; the same configuration lever's CPU-only reflection A/B produced distinct exact/native-recovery module hashes `d3509f259a1baa99` / `a7bcc1ec7d05db52`, asserted `R32ui` versus typed-float storage, and the live native run independently proved the device's typed 3D storage capability before source 118 executed. At identical rendered frame sequences 15 and 22, exact versus native-recovery images differed by normalized RMSE 0.00920 / 0.00940 (PSNR 40.73 / 40.54 dB), but both showed the same full-width, severely blown-out scene. Exact packing was slightly brighter, not corrective: mean luma was 0.80285 versus 0.80160 at frame 15 and 0.79367 versus 0.79276 at frame 22. This rules out the conversion bias as the **primary visible mechanism at this boot depth**; it does not erase the deterministic precision defect above, and it does not localize the remaining source-101→bloom→source-119 error. The runs are not a performance A/B: exact carried much broader compute tracing, and both stayed near the known ~1.4 composited fps in the sampled window. | #1790 |
 | Replay uses a stale/no-op source-101 or source-119 writeback, or source 119 numerically explodes the whole HDR frame | **Falsified for the current captured host-renderer path; this is not a PS5 hardware oracle.** Two bounded `--recompile-raw --dump-post-compute-resource` runs executed the retained mixed-operation prefix and required both descriptor-visible change and the independently recorded live raw hash. Realized compute `62:14` (source 101, operation 566) executed once after 62 earlier successful computes: its captured seed equalled its immediate-before state (`raw=89a341fece902e2e`, `linear=4313b6f00a038092`), then changed to raw `e00d49942f888cad` (**exact live-hash match**) / linear `8aeefa2a7bc15ef9`. Its 2,073,600 R11 texels contained 6,220,800 finite channels, 2,839,736 zero, 1,234,144 greater than one, no Inf/NaN, maximum 12.375, mean 0.683273. Realized compute `80:23` (source 119, operation 584) likewise executed once after 80 earlier successful computes: captured/immediate-before `15af296b7f257522` / `cdbfc7204d266c16` changed to raw `2974a84058d4feb5` (**exact live-hash match**) / linear `7ba80885c5585b55`. Its output had no zero, Inf, or NaN channels, only 2,412 greater than one, maximum 1.03125, mean 0.35676. Thus source 119 strongly compresses the source-101 HDR population instead of causing a frame-wide numeric blow-up. The source-101 distribution itself remains **unverified against PS5 hardware** and may still enter the chain incorrectly; these runs prove the host live/replay boundary and falsify the stale/no-op and whole-output-explosion mechanisms, not visual correctness. | #1790 |
+| The source-90/source-92 shader-recompile failures cause missing gameplay pixels | **Falsified.** Both captured packets are direct dispatches with `threads=0x0x0` and `groups=0x0x0`; they are hardware no-ops regardless of whether their shader bodies compile. A temporary diagnostic arm independently moved the lever by admitting both shaders as realized zero-group computes, while the routed gameplay image remained visually unchanged. Their unsupported instructions remain legitimate recompiler coverage work, but cannot repair this frame. | #1627 |
 
 **Still open:** what causes the restored menu layer's substantial overexposure (#1790). Recompiling
 source 101 restores the visible 3D layer on the **default** path, but does not make it visually
@@ -136,7 +137,28 @@ The screenshot tool exited 1 after saving 45/48 fresh, pixel-distinct samples be
 apparatus error, not a stale-frame or title-progress failure. All 45 saved samples advanced source and
 pixel content with zero stale seconds. The final image is retained only as local evidence; the existing
 public profile screenshot remains representative and no compatibility rung changed.
+## Live validation of gameplay `v_max3_f16` recovery — 2026-08-03
 
+A current-master gameplay capture rejected source 87 at VOP3 opcode `0x354`. `llvm-mc` identifies
+the eight exact packets as `v_max3_f16`; the first two select complementary packed-f16 source and
+destination halves (`op_sel:[0,0,1,0]` and `[1,1,0,1]`). The recompiler now decodes those selectors,
+computes a three-input numeric maximum, applies output modifiers, and preserves the unselected half
+of the destination VGPR. Exact packet, structural SPIR-V, and live-Vulkan numeric tests cover the
+two-packet pair; disabling only the emitter makes the named structural regression fail.
+
+One bounded default-renderer run followed the validated gameplay route with ordinary frame dumps
+disabled and captured exactly one live frame. Source 87 changed from an unrealized 120x68-group
+dispatch to realized compute 85 (`shader=3052/cec569003c55c45b`). The operation graph records the
+consequential dependency: operation 2057 writes a 960x540 R8 resource and operation 2059/source 89
+immediately samples that same address at binding 6. The adjacent current-master frame had 108
+realized computes and 25 failures; the fixed live frame had 109 and 23. Total draw/operation counts
+differ slightly between animated frames, so the named source and dependency edge—not the aggregate
+delta—are the decisive evidence.
+
+The fixed screenshot is visually equivalent to the baseline: the same dark, overexposed ghosted
+gameplay composite remains. This closes a real, consumed shader gap but does **not** localize or fix
+the visible #1627 defect, and it is not a reason to advance the compatibility rung or replace the
+published screenshot.
 ## The former "right ~55% is black" question — localized and fixed
 
 Before source-101 support, this was **a defect, not art direction, and not a scissor/viewport clip.**
@@ -283,14 +305,15 @@ the current default-path diagnosis.
 
 ## Causal and remaining recompiler gaps in the same frame
 
-Ten dispatches fail with `reason=shader-recompile` (`gpu_replay --inspect-only`). Per `CLAUDE.md`
-these are FATAL gaps, not acceptable skips. First-reject sites:
+The retained pre-fix profile capture reports ten dispatches with `reason=shader-recompile`
+(`gpu_replay --inspect-only`). Per `CLAUDE.md` these are FATAL gaps, not acceptable skips.
+First-reject sites (including gaps since repaired) are:
 
 | program | launch | first reject |
 |---|---|---|
 | `0x211197ea00` | 1920x1080 | pc=24 fmt=0 op=0xf |
 | `0x211197ef00` | 30720x68 | pc=4 fmt=4 op=0x8 |
-| `0x21341b1a00` (x3) | 960x544 | pc=55 fmt=9 op=0x354 |
+| `0x21341b1a00` (x3) | 960x544 | pc=55 fmt=9 op=0x354 — now supported as `v_max3_f16` |
 | `0x2111a39700` | 1920x1080 | pc=51 fmt=8 op=0xf5 |
 | `0x2111a39e00` | 1920x1088 | pc=6 fmt=0 op=0x1 |
 | `0x2111a3a400` | 120x72 | pc=36 fmt=4 op=0x8 |
@@ -307,6 +330,10 @@ the derived bloom inputs before writing a zero binding 23 for draw 469. Supporti
 Wave64 mask comparison recompiles the exact retained source with all 14 captured resources and an
 accepted descriptor contract, and the live run restores the layer. The remaining overexposure and
 other recompiler gaps remain real but are not localized here.
+
+The `0x354` row is the same instruction family recovered and validated in the routed gameplay
+capture above. Its live output is consumed, but the gameplay image remains degraded; do not infer
+that every consumed recompiler gap is the visible composite cause.
 
 ## Other observations
 

--- a/prosper/src/gpu/rdna2_decode.cpp
+++ b/prosper/src/gpu/rdna2_decode.cpp
@@ -359,9 +359,10 @@ void decode_operands(Rdna2Inst& i) {
                     break;
                 default: break;
             }
-            // v_fma_f16 VOP3: OPSEL[2:0] selects each packed source half and OPSEL[3]
+            // Scalar-f16 VOP3 operations: OPSEL[2:0] selects each packed source half and OPSEL[3]
             // selects the destination half. Reuse the packed-op selector field for this family.
-            if (i.opcode == 0x34Bu)
+            // VERIFIED(llvm-mc gfx1030): 0x354 is v_max3_f16.
+            if (i.opcode == 0x34Bu || i.opcode == 0x354u)
                 i.vop3p_opsel = static_cast<uint8_t>((w >> 11) & 0xFu);
             // V_PERMLANE16_B32 / V_PERMLANEX16_B32 overload OPSEL[0] as FI and OPSEL[1] as
             // BOUND_CTRL. OPSEL[2:3], ABS, NEG, CLAMP and OMOD remain reserved/unsupported and are

--- a/prosper/src/gpu/rdna2_decode.hpp
+++ b/prosper/src/gpu/rdna2_decode.hpp
@@ -148,7 +148,8 @@ struct Rdna2Inst {
 
     // Packed/mixed f16 selector bitmasks. For VOP3P mix ops, bit k of vop3p_opsel_hi means source k
     // reads as an f16 half selected by vop3p_opsel[k]; packed add/mul use the two masks for the low
-    // and high results. VOP3 v_fma_f16 reuses vop3p_opsel[2:0] for its sources and bit 3 for dst.
+    // and high results. VOP3 scalar-f16 operations reuse vop3p_opsel[2:0] for their sources and bit
+    // 3 for dst (currently v_fma_f16 and v_max3_f16).
     // NEG lands in src_neg[], NEG_HI (abs for mix ops) in src_abs[], and CLAMP in clamp.
     uint8_t vop3p_opsel = 0, vop3p_opsel_hi = 0;
     uint8_t vop3p_neg_hi = 0;   // packed add/mul: per-source negate for the HIGH f16 result

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -7790,7 +7790,11 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 if (in.clamp) bits = b.clamp01(bits);
                 return bits;
             };
-            if (in.opcode == 0x34B) {                                // v_fma_f16: one selected packed half
+            if (in.opcode == 0x34B || in.opcode == 0x354) {
+                // Scalar f16 VOP3: one selected half from each packed source and one independently
+                // selected destination half. The opposite destination half is preserved. The
+                // `v_max3_f16` occurs eight times in Syberia's nonzero 960x544 gameplay composite
+                // dispatch; llvm-mc gfx1030 identifies opcode 0x354 exactly.
                 auto f16src = [&](int k) {
                     const Operand& operand = in.src[k];
                     uint32_t raw = val(operand);
@@ -7805,8 +7809,14 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     if (in.src_neg[k]) value = b.fneg(value);
                     return value;
                 };
-                uint32_t result = fresult(
-                    b.fbin(Op_FAdd, b.fbin(Op_FMul, f16src(0), f16src(1)), f16src(2)));
+                uint32_t result = 0;
+                if (in.opcode == 0x34B) {                            // v_fma_f16
+                    result = b.fbin(Op_FAdd, b.fbin(Op_FMul, f16src(0), f16src(1)), f16src(2));
+                } else {                                             // v_max3_f16
+                    result = b.fext2(Glsl_NMax,
+                                     b.fext2(Glsl_NMax, f16src(0), f16src(1)), f16src(2));
+                }
+                result = fresult(result);
                 uint32_t r16 = b.pack_half_lo(result);
                 vreg[in.dst.value] = (in.vop3p_opsel & 8u)
                     ? b.ibin(Op_BitwiseOr, b.ibin(Op_BitwiseAnd, old_d, b.uconst(0x0000FFFFu)),

--- a/prosper/tests/test_rdna2_decode.cpp
+++ b/prosper/tests/test_rdna2_decode.cpp
@@ -286,6 +286,17 @@ int main() {
     Rdna2Inst v3n = rdna2_decode_one(vop3_nolit, 2);
     CHECK(v3n.fmt == Rdna2Format::VOP3 && v3n.len_dwords == 2 && !v3n.has_literal,
           "VOP3 without a literal src is 2 dwords");
+    // Exact Syberia source-87 low/high pair. llvm-mc gfx1030 prints OPSEL [0,0,1,0] and
+    // [1,1,0,1]; the fourth bit selects which packed destination half is replaced.
+    const uint32_t max3_f16_lo[] = { 0xd7542009u, 0x045a2d17u };
+    const uint32_t max3_f16_hi[] = { 0xd7545809u, 0x045e2d17u };
+    const Rdna2Inst max3_lo = rdna2_decode_one(max3_f16_lo, 2);
+    const Rdna2Inst max3_hi = rdna2_decode_one(max3_f16_hi, 2);
+    CHECK(max3_lo.fmt == Rdna2Format::VOP3 && max3_lo.opcode == 0x354u &&
+              max3_lo.vop3p_opsel == 0x4u &&
+              max3_hi.fmt == Rdna2Format::VOP3 && max3_hi.opcode == 0x354u &&
+              max3_hi.vop3p_opsel == 0xbu,
+          "Syberia v_max3_f16 retains all source and destination OPSEL bits");
     // VOPC-as-VOP3 uses the same 64-bit packet prefix but its low dword0 field is an SGPR-mask
     // destination, never a VGPR. Exact Astro world-map encoding, round-tripped with llvm-mc gfx1010.
     const uint32_t vopc_e64_u64[] = { 0xd4e4006au, 0x0001006au };

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -938,6 +938,30 @@ int main() {
     portable_wave64_compute_config.local_x = 128;
     portable_wave64_compute_config.wave_size = 64;
 
+    // Syberia source 87 is a real 960x544 dispatch whose only generic-coverage rejects are eight
+    // v_max3_f16 instructions. Keep the first exact low/high pair: OPSEL chooses different source
+    // halves for each result and the second instruction writes the high destination half. The decode
+    // test pins those bitmasks; require both exact packet shapes here, and let the Vulkan test
+    // independently check their packed result.
+    const uint32_t syberia_max3_f16_pair[] = {
+        0x7e2c02ffu, 0x40003c00u,            // v_mov_b32 v22,{2.0h,1.0h}
+        0x7e2e02ffu, 0x38004200u,            // v_mov_b32 v23,{0.5h,3.0h}
+        0x7e1202ffu, 0x12345678u,            // v_mov_b32 v9,old packed destination
+        0xd7542009u, 0x045a2d17u,            // max3_f16 v9,v23.lo,v22.lo,v22.hi -> v9.lo
+        0xd7545809u, 0x045e2d17u,            // max3_f16 v9,v23.hi,v22.hi,v23.lo -> v9.hi
+        0xbf810000u,
+    };
+    const auto syberia_max3_f16_spv = recompile_compute(
+        syberia_max3_f16_pair, std::size(syberia_max3_f16_pair), nullptr,
+        portable_wave64_compute_config);
+    if (syberia_max3_f16_spv.empty() ||
+        !type_result_ids_are_nonzero(syberia_max3_f16_spv, nullptr) ||
+        !phi_ids_are_nonzero(syberia_max3_f16_spv)) {
+        printf("  [FAIL] Syberia v_max3_f16 OPSEL pair did not emit valid SPIR-V\n");
+        return 1;
+    }
+    printf("  [ok]   Syberia v_max3_f16 OPSEL pair emits valid SPIR-V\n");
+
     // Exercise the ordinary integer-B64 emitter separately from the mask-domain vote below.
     // Exact llvm-mc gfx1010 encoding: v_cmp_gt_u64_e64 vcc_lo,s[0:1],0.
     const uint32_t wave64_u64_compare[] = {

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -2451,6 +2451,26 @@ int main() {
     CHECK(got32o2.size()==1 && bits_of(got32o2[0])==0x1234ca48u,
           "kernel 32o2 applies VOP3 output scaling before f16 packing");
 
+    // Kernel 32o3: Syberia's exact source-87 v_max3_f16 pair selects different low/high source
+    // halves and independently writes both destination halves. This is the first-reject shape in a
+    // nonzero 960x544 gameplay dispatch; checking the packed word catches a decoder that accepts the
+    // opcode but silently drops OPSEL or opposite-half preservation.
+    const uint32_t code32o3[] = {
+        0x7e2c02ffu, 0x40003c00u,            // v22={2.0h,1.0h}
+        0x7e2e02ffu, 0x38004200u,            // v23={0.5h,3.0h}
+        0x7e1202ffu, 0x12345678u,            // v9=old packed destination
+        0xd7542009u, 0x045a2d17u,            // v9.lo=max(v23.lo,v22.lo,v22.hi)=3
+        0xd7545809u, 0x045e2d17u,            // v9.hi=max(v23.hi,v22.hi,v23.lo)=3
+        0xbf810000u,
+    };
+    std::vector<uint32_t> spv32o3 = recompile_valu(
+        code32o3, std::size(code32o3), 0, 9);
+    CHECK(!spv32o3.empty(), "recompiled kernel 32o3 (Syberia v_max3_f16 OPSEL pair) -> SPIR-V");
+    std::vector<float> got32o3 = prosper::test::run_compute(
+        spv32o3, std::vector<float>(1), 1, 1);
+    CHECK(got32o3.size()==1 && bits_of(got32o3[0])==0x42004200u,
+          "kernel 32o3 selects and preserves packed f16 halves exactly");
+
     // Kernel 32p: exact live v_cndmask_b32_sdwa selects src1 WORD_0 through VCC, writes WORD_1,
     // and preserves the destination's low half.
     const uint32_t code32p[] = {


### PR DESCRIPTION
## Summary

- decode scalar-f16 source and destination OPSEL bits for VOP3 `v_max3_f16`
- lower the three-input numeric maximum while preserving the unselected destination half
- cover exact Syberia packets with decoder, structural SPIR-V, and live-Vulkan numeric regressions
- record the live producer/consumer edge, unchanged image, and the source-90/source-92 falsification

## Root cause and impact

A routed Syberia gameplay frame contains a nonzero 960x544 compute dispatch at source 87. Its eight `v_max3_f16` packets (VOP3 opcode `0x354`) were unsupported, so the whole dispatch remained unrealized. `llvm-mc gfx1030` identifies the exact first pair and its complementary `op_sel` source/destination half selections.

This patch makes that real dispatch execute. It is a generic RDNA2 recompiler fix rather than a title-address exception or silent skip.

## Author verification

Current PR head: `be1606134d43f62930d7fa9038a7d1c140581d98` (rebased onto `master` `dad8f518c83e1fdd42aa817527a4c55fd3ee1c16`; the rebase added only #1822 renderer/docs changes and preserved both Syberia evidence sections)

- `cmake --build build-linux --target test_rdna2_decode test_rdna2_spirv_struct -j2` — pass in the `ps5ys` distrobox on the exact head
- `./build-linux/test_rdna2_decode` — pass; exact low/high packets retain OPSEL `0x4` / `0xb`
- `./build-linux/test_rdna2_spirv_struct` — pass; the exact packet pair emits structurally valid SPIR-V
- emitter mutation with the regression retained — named Syberia structural test fails, proving the test exercises the new mechanism
- `./build-linux/test_rdna2_to_spirv` on hardware Vulkan — full exact-head suite pass: 583 `[ok]`, zero failures; named kernel 32o3 recompiles the Syberia `v_max3_f16` OPSEL pair and selects/preserves the packed f16 halves exactly
- `gpu_replay --recompile-raw --retry-failed-dispatches` on three retained gameplay captures — source 87 recompiles to 3,052 SPIR-V dwords and passes its six-resource descriptor contract in all three
- one bounded default-renderer run through `scripts/syberia/reach-gameplay.pad`, with ordinary frame dumps disabled and exactly one F9 capture — source 87 is realized as compute 85 at 120x68 groups
- operation graph — operation 2057 writes a 960x540 R8 surface that operation 2059/source 89 immediately samples at binding 6
- `git diff --check origin/master...HEAD` — clean on the exact head

The adjacent current-master frame has 108 realized computes and 25 failures; the fixed live frame has 109 and 23. Animated frames have slightly different draw/operation totals, so the named source transition and resource edge are the decisive evidence.

## Visual result and remaining work

The captured gameplay image is visually equivalent to current master: the dark, overexposed ghosted composite remains. This repairs a consumed shader gap but does not claim to fix or close #1627, advance the compatibility rung, or justify replacing the published screenshot.

Source 90 and source 92 were separately ruled out as visible causes: both captured packets are direct zero-thread/zero-group dispatches. A temporary diagnostic arm made both shaders realized zero-group computes without changing the routed image. Their instruction gaps remain legitimate coverage work, but cannot affect this frame.

Refs #1627