### PR TITLE
tools: add bounded F8 performance captures

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -81,6 +81,16 @@ if(PROSPER_SRC)
   endif()
 endif()
 
+# Bounded interactive performance capture (F8): pure host-side state + serialization shared by the
+# SDL app and the live graphics/compute backends. It deliberately has no SDL/Vulkan dependency, so
+# its ring, bounds, and atomic file contract run in ordinary headless CI.
+add_library(prosper_performance_capture STATIC frontends/shared/performance_capture.cpp)
+target_include_directories(prosper_performance_capture PUBLIC frontends/shared)
+if(PROSPER_GIT_REVISION)
+  target_compile_definitions(prosper_performance_capture
+    PRIVATE PROSPER_GIT_REVISION="${PROSPER_GIT_REVISION}")
+endif()
+
 # --- tests (agentic-first: self-checking, exit-code = truth) -------------
 enable_testing()
 find_package(Python3 COMPONENTS Interpreter QUIET)
@@ -420,6 +430,17 @@ if(TARGET prosper_core)
   add_executable(test_prosper_app_frame_grab_naming frontends/prosper-app/test_frame_grab_naming.cpp)
   target_include_directories(test_prosper_app_frame_grab_naming PRIVATE frontends/prosper-app)
   add_test(NAME prosper_app_frame_grab_naming COMMAND test_prosper_app_frame_grab_naming)
+
+  # F8's pre-trigger ring and post-trigger timing artifact: pure state machine + filesystem test,
+  # including bounded overflow accounting and temporary-to-final atomic publication.
+  add_executable(test_performance_capture frontends/shared/test_performance_capture.cpp)
+  target_link_libraries(test_performance_capture PRIVATE prosper_performance_capture)
+  add_test(NAME performance_capture COMMAND test_performance_capture)
+
+  if(Python3_Interpreter_FOUND)
+    add_test(NAME performance_capture_report_logic
+      COMMAND "${Python3_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tools/perf/test_performance_capture_report.py")
+  endif()
 
   # Library grid selection movement (#1471): arithmetic only, so the navigation rules are covered in
   # normal CI rather than by someone pressing arrow keys. No ImGui, no SDL, no window.
@@ -949,7 +970,8 @@ if(TARGET prosper_core)
                                                frontends/shared/live_compute.cpp
                                                frontends/shared/present_blit.cpp)
       target_include_directories(prosper_live_renderer PRIVATE src tests tools/boot_trace)
-      target_link_libraries(prosper_live_renderer PUBLIC prosper_core Vulkan::Vulkan)
+      target_link_libraries(prosper_live_renderer PUBLIC prosper_core Vulkan::Vulkan
+                                                   prosper_performance_capture)
       target_include_directories(prosper_live_renderer PUBLIC frontends/shared)
       # A LiveTargetPixelFormat mapping that quietly falls back to RGBA8 has now cost two titles a
       # whole render layer (#773 Dead Cells, and Syberia's black 3D menu). frontends/shared/
@@ -1080,7 +1102,8 @@ if(TARGET prosper_core)
                                                frontends/shared/live_compute.cpp
                                                frontends/shared/present_blit.cpp)
       target_include_directories(prosper_live_renderer PRIVATE src tests tools/boot_trace)
-      target_link_libraries(prosper_live_renderer PUBLIC prosper_core Vulkan::Vulkan)
+      target_link_libraries(prosper_live_renderer PUBLIC prosper_core Vulkan::Vulkan
+                                                   prosper_performance_capture)
       target_include_directories(prosper_live_renderer PUBLIC frontends/shared)
       # A LiveTargetPixelFormat mapping that quietly falls back to RGBA8 has now cost two titles a
       # whole render layer (#773 Dead Cells, and Syberia's black 3D menu). frontends/shared/
@@ -1473,7 +1496,8 @@ if(PROSPER_APP AND TARGET SDL3::SDL3)
     add_executable(prosper-app frontends/prosper-app/main.cpp frontends/prosper-app/library_ui.cpp
                                frontends/prosper-app/library_media.cpp)
     target_include_directories(prosper-app PRIVATE src third_party/stb)
-    target_link_libraries(prosper-app PRIVATE prosper_core SDL3::SDL3 Vulkan::Vulkan prosper_imgui)
+    target_link_libraries(prosper-app PRIVATE prosper_core SDL3::SDL3 Vulkan::Vulkan prosper_imgui
+                                              prosper_performance_capture)
     target_compile_definitions(prosper-app PRIVATE PROSPER_HAVE_LIBRARY_UI=1)
     # Share the live renderer with boot_trace so the window shows composited game frames (not blank).
     if(TARGET prosper_live_renderer)

--- a/prosper/docs/LINUX_RELEASE.md
+++ b/prosper/docs/LINUX_RELEASE.md
@@ -109,6 +109,7 @@ SDL3 automatically uses a connected controller as pad 0. Keyboard input is compo
 | Enter | Options |
 | Pause or F10 | Pause/resume the guest and audio at a flip boundary |
 | F11 or Alt+Enter | Toggle host-window fullscreen |
+| F8 | Capture 5 seconds before and after a performance problem to `.prperf` |
 | F9 | Capture the current frame for offline replay |
 | Escape | Exit |
 

--- a/prosper/docs/WINDOWS_RELEASE.md
+++ b/prosper/docs/WINDOWS_RELEASE.md
@@ -69,6 +69,8 @@ SDL3 automatically uses a connected controller as pad 0. Keyboard input is compo
 | Enter | Options |
 | Pause or F10 | Pause/resume the guest and audio at a flip boundary |
 | F11 or Alt+Enter | Toggle host-window fullscreen |
+| F8 | Capture 5 seconds before and after a performance problem to `.prperf` |
+| F9 | Capture the current frame for offline replay |
 | Escape | Exit |
 
 Pause/F10 is host-owned and is not forwarded to guest keyboard input. Alt+Enter is consumed by the

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -34,6 +34,7 @@
 #include "game_path.hpp"                 // dropped/picked path -> app0 root + open action, pure seam
 #include "game_library.hpp"              // scan a games dir -> titles + metadata, pure seam
 #include "frame_grab_naming.hpp"         // one stamp + one exclusively claimed name pair per F9 grab
+#include "performance_capture.hpp"        // bounded F8 pre/post performance artifact
 #include "app_config.hpp"                // persisted settings (games_dir), pure seam
 #ifdef PROSPER_HAVE_LIBRARY_UI
 #include "library_ui.hpp"                // the ImGui library grid drawn while no game is running
@@ -1283,6 +1284,8 @@ int main(int argc, char** argv) {
                     "screenshot named frame_grab_<titleId>_<date>-<time>-<ms>.* (to "
                     "PROSPER_CAPTURE_DIR, default cwd) for gpu_replay debugging "
                     "(brief hitch on press; PROSPER_CAPTURE_FRAMES>1 grabs an animation).\n");
+    fprintf(stderr, "[app] F8 = capture 5 seconds before + 5 seconds after the press into a bounded "
+                    ".prperf performance report (to PROSPER_CAPTURE_DIR, default cwd).\n");
 
     const bool frameTrace = getenv("PROSPER_APP_FRAME_TRACE") != nullptr;
     const char* stallDumpEnv = getenv("PROSPER_APP_STALL_DUMP_MS");
@@ -1311,10 +1314,12 @@ int main(int argc, char** argv) {
     const std::string grabDir = getenv("PROSPER_CAPTURE_DIR") ? getenv("PROSPER_CAPTURE_DIR") : ".";
     prosper::frontend::FrameGrabNamer grabNamer;
     grabNamer.set_directory(grabDir);
+    CaptureTitle activeCaptureTitle = capture_title_for(dump);
     {
-        const CaptureTitle ct = capture_title_for(dump);
-        grabNamer.set_title(ct.id, ct.label);
+        grabNamer.set_title(activeCaptureTitle.id, activeCaptureTitle.label);
     }
+    prosper::perf::InteractivePerformanceCapture& perfCapture =
+        prosper::perf::interactive_performance_capture();
     // 0 = keep the built-in default; the timeline clamps whatever is supplied to 64..3072 MiB.
     // Parse strictly, matching the two checked parses of this same variable in gpu_timeline.cpp. An
     // unchecked strtoul truncates into uint32_t, so 4294967360 would arrive as 64 — silently the
@@ -1503,8 +1508,8 @@ int main(int argc, char** argv) {
             // A title opened after startup owns the captures from here on: name them after IT, not
             // after the empty window this process started as.
             {
-                const CaptureTitle ct = capture_title_for(root);
-                grabNamer.set_title(ct.id, ct.label);
+                activeCaptureTitle = capture_title_for(root);
+                grabNamer.set_title(activeCaptureTitle.id, activeCaptureTitle.label);
             }
 #ifdef PROSPER_HAVE_LIBRARY_UI
             // Hand the swapchain back before the guest's first frame: from here the game present path
@@ -1537,6 +1542,27 @@ int main(int argc, char** argv) {
     }
 
     while (running && !prosper_stop_requested()) {
+        // F8's only always-on work is this 4 Hz sample. `sample_due` is one atomic read, so the
+        // process CPU/RSS query is not paid on every UI-loop iteration.
+        const uint64_t perfNow = prosper::perf::monotonic_now_ns();
+        if (perfCapture.sample_due(perfNow)) {
+            perfCapture.observe_sample(prosper::perf::collect_process_sample(
+                perfNow, gpu::present_count(), gpu::present_frame_seq(), shown));
+        }
+        prosper::perf::CaptureOutcome perfOutcome;
+        if (perfCapture.take_outcome(perfOutcome)) {
+            if (perfOutcome.ok) {
+                std::fprintf(stderr,
+                    "[perf] capture written (pre=%zu post=%zu renderer=%zu compute=%zu "
+                    "dropped=%zu/%zu) -> %s\n",
+                    perfOutcome.pre_samples, perfOutcome.post_samples,
+                    perfOutcome.renderer_records, perfOutcome.compute_records,
+                    perfOutcome.renderer_dropped, perfOutcome.compute_dropped,
+                    perfOutcome.path.c_str());
+            } else {
+                std::fprintf(stderr, "[perf] F8 capture FAILED: %s\n", perfOutcome.error.c_str());
+            }
+        }
         openedThisBatch = rejectedThisBatch = false;
         SDL_Event ev;
         while (SDL_PollEvent(&ev)) {
@@ -1560,6 +1586,35 @@ int main(int argc, char** argv) {
                 key.f11 = ev.key.key == SDLK_F11;
                 key.enter = ev.key.key == SDLK_RETURN || ev.key.key == SDLK_KP_ENTER;
                 key.alt = (ev.key.mod & SDL_KMOD_ALT) != 0;
+                // Interactive performance capture: unlike F9 this retains no GPU commands, pixels,
+                // or ordinary frame dumps. It freezes the cheap rolling counter ring and enables
+                // structured renderer/compute timing only for the five seconds after this press.
+                // F8 is host-owned and is not forwarded to the guest IME/pad path.
+                if (ev.type == SDL_EVENT_KEY_DOWN && key.app_window && !ev.key.repeat &&
+                    ev.key.key == SDLK_F8) {
+                    const uint64_t armedAt = prosper::perf::monotonic_now_ns();
+                    if (perfCapture.sample_due(armedAt)) {
+                        perfCapture.observe_sample(prosper::perf::collect_process_sample(
+                            armedAt, gpu::present_count(), gpu::present_frame_seq(), shown));
+                    }
+                    const prosper::perf::CaptureArmResult armed = perfCapture.arm(
+                        grabDir, activeCaptureTitle.id, activeCaptureTitle.label,
+                        prosper::perf::build_revision(), armedAt,
+                        std::chrono::system_clock::now());
+                    if (armed.ok) {
+                        std::fprintf(stderr,
+                            "[perf] F8 #%u armed for %s: retained %zu pre-trigger samples; "
+                            "collecting %.1f seconds after the press\n",
+                            armed.index,
+                            activeCaptureTitle.label.empty() ? "the current process"
+                                                             : activeCaptureTitle.label.c_str(),
+                            armed.pre_samples, armed.post_seconds);
+                    } else {
+                        std::fprintf(stderr, "[perf] F8 #%u not armed: %s\n",
+                                     armed.index, armed.error.c_str());
+                    }
+                    continue;
+                }
                 // Interactive frame grab: F9 arms a one-shot capture of the next COMPLETE frame (every
                 // submit between the next two presents) into a replayable .prgbundle, plus a screenshot.
                 // The whole-frame bundle re-runs the frame's producer submits on replay, so renderer-owned
@@ -2165,6 +2220,7 @@ int main(int argc, char** argv) {
         }
     }
 
+    perfCapture.cancel();     // never publish a short/incomplete .prperf on a graceful early exit
     prosper_request_stop();   // signal the guest run-loop to wind down at its next boundary
     fprintf(stderr, "[app] shutting down after %llu presented frame(s)\n", (unsigned long long)shown);
     const int exitCode = (exitAfter && (int)shown < exitAfter) ? 1 : 0;

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -5,6 +5,8 @@
 #include "seed_reprove.hpp"
 #include "vulkan_device_select.hpp"
 #include "write_watch_policy.hpp"
+#include "performance_capture.hpp"      // bounded F8 post-trigger compute timing
+#include "performance_timing_policy.hpp" // F8 measures without enabling verbose timing logs
 
 #include "gpu/bc_decode.hpp"
 #include "gpu/gpu_capture.hpp"
@@ -6702,7 +6704,12 @@ bool execute_live_compute_items(const std::vector<prosper::gpu::ComputeItem>& it
     VulkanComputeContext& context = *live_context;
     g_live_compute_context = &context;
     if (context.device_lost) return false;
-    const bool timing_enabled = std::getenv("PROSPER_RENDER_TIMING") != nullptr;
+    const bool perf_capture_timing =
+        prosper::perf::interactive_performance_capture().detailed_timing_active();
+    const bool timing_log_enabled = std::getenv("PROSPER_RENDER_TIMING") != nullptr;
+    const prosper::frontend::PerformanceTimingMode timing_mode =
+        prosper::frontend::performance_timing_mode(timing_log_enabled, perf_capture_timing);
+    const bool timing_enabled = timing_mode.measure;
     const auto timing_start = timing_enabled
         ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point{};
     context.begin_write_watch_promotions();
@@ -6718,57 +6725,66 @@ bool execute_live_compute_items(const std::vector<prosper::gpu::ComputeItem>& it
         if (context.device_lost) break;
     }
     if (timing_enabled) {
-        struct TimingTotals { uint64_t calls = 0, dispatches = 0; double milliseconds = 0; };
-        static TimingTotals totals;
-        static TimingTotals window;
         const double elapsed = std::chrono::duration<double, std::milli>(
             std::chrono::steady_clock::now() - timing_start).count();
-        auto accumulate = [&](TimingTotals& timing) {
-            timing.calls++;
-            timing.dispatches += items.size();
-            timing.milliseconds += elapsed;
-        };
-        accumulate(totals);
-        accumulate(window);
-        if (totals.calls % 25 == 0) {
-            std::fprintf(stderr,
-                         "[render-timing] compute calls=%llu dispatches=%llu avg_ms=%.2f\n",
-                         (unsigned long long)totals.calls,
-                         (unsigned long long)totals.dispatches,
-                         totals.milliseconds / static_cast<double>(totals.calls));
-            std::fprintf(stderr,
-                         "[render-timing] compute_cpu_fast fills=%llu\n",
-                         (unsigned long long)g_cpu_fill_dispatches.load(
-                             std::memory_order_relaxed));
-            const ComputeMemoryPoolStats pool = context.memory_pool_stats();
-            std::fprintf(stderr,
-                         "[render-timing] compute_memory_pool hits=%llu misses=%llu cached=%zu "
-                         "%.1f MiB discarded=%llu\n",
-                         (unsigned long long)pool.hits, (unsigned long long)pool.misses,
-                         pool.cached_allocations,
-                         static_cast<double>(pool.cached_bytes) / (1024.0 * 1024.0),
-                         (unsigned long long)pool.discarded);
-            std::fprintf(stderr,
-                         "[render-timing] compute_image_source snapshots=%llu %.1f MiB "
-                         "storage_results=%llu %.1f MiB result_fallbacks=%llu %.1f MiB "
-                         "gpu_transfer_seeds=%llu\n",
-                         (unsigned long long)context.image_source_snapshot_copies,
-                         static_cast<double>(context.image_source_snapshot_bytes) /
-                             (1024.0 * 1024.0),
-                         (unsigned long long)context.storage_result_snapshot_copies,
-                         static_cast<double>(context.storage_result_snapshot_bytes) /
-                             (1024.0 * 1024.0),
-                         (unsigned long long)context.image_result_snapshot_copies,
-                         static_cast<double>(context.image_result_snapshot_bytes) /
-                             (1024.0 * 1024.0),
-                         (unsigned long long)g_compute_storage_transfer_seeds.load(
-                             std::memory_order_relaxed));
-            std::fprintf(stderr,
-                         "[render-window] compute calls=%llu dispatches=%.1f avg_ms=%.2f\n",
-                         (unsigned long long)window.calls,
-                         window.dispatches / static_cast<double>(window.calls),
-                         window.milliseconds / static_cast<double>(window.calls));
-            window = {};
+        if (perf_capture_timing) {
+            prosper::perf::ComputeTimingRecord record;
+            record.dispatches = items.size();
+            record.cpu_fast_total = g_cpu_fill_dispatches.load(std::memory_order_relaxed);
+            record.total_ms = elapsed;
+            prosper::perf::interactive_performance_capture().record_compute(record);
+        }
+        if (timing_mode.log) {
+            struct TimingTotals { uint64_t calls = 0, dispatches = 0; double milliseconds = 0; };
+            static TimingTotals totals;
+            static TimingTotals window;
+            auto accumulate = [&](TimingTotals& timing) {
+                timing.calls++;
+                timing.dispatches += items.size();
+                timing.milliseconds += elapsed;
+            };
+            accumulate(totals);
+            accumulate(window);
+            if (totals.calls % 25 == 0) {
+                std::fprintf(stderr,
+                    "[render-timing] compute calls=%llu dispatches=%llu avg_ms=%.2f\n",
+                    (unsigned long long)totals.calls,
+                    (unsigned long long)totals.dispatches,
+                    totals.milliseconds / static_cast<double>(totals.calls));
+                std::fprintf(stderr,
+                    "[render-timing] compute_cpu_fast fills=%llu\n",
+                    (unsigned long long)g_cpu_fill_dispatches.load(
+                        std::memory_order_relaxed));
+                const ComputeMemoryPoolStats pool = context.memory_pool_stats();
+                std::fprintf(stderr,
+                    "[render-timing] compute_memory_pool hits=%llu misses=%llu cached=%zu "
+                    "%.1f MiB discarded=%llu\n",
+                    (unsigned long long)pool.hits, (unsigned long long)pool.misses,
+                    pool.cached_allocations,
+                    static_cast<double>(pool.cached_bytes) / (1024.0 * 1024.0),
+                    (unsigned long long)pool.discarded);
+                std::fprintf(stderr,
+                    "[render-timing] compute_image_source snapshots=%llu %.1f MiB "
+                    "storage_results=%llu %.1f MiB result_fallbacks=%llu %.1f MiB "
+                    "gpu_transfer_seeds=%llu\n",
+                    (unsigned long long)context.image_source_snapshot_copies,
+                    static_cast<double>(context.image_source_snapshot_bytes) /
+                        (1024.0 * 1024.0),
+                    (unsigned long long)context.storage_result_snapshot_copies,
+                    static_cast<double>(context.storage_result_snapshot_bytes) /
+                        (1024.0 * 1024.0),
+                    (unsigned long long)context.image_result_snapshot_copies,
+                    static_cast<double>(context.image_result_snapshot_bytes) /
+                        (1024.0 * 1024.0),
+                    (unsigned long long)g_compute_storage_transfer_seeds.load(
+                        std::memory_order_relaxed));
+                std::fprintf(stderr,
+                    "[render-window] compute calls=%llu dispatches=%.1f avg_ms=%.2f\n",
+                    (unsigned long long)window.calls,
+                    window.dispatches / static_cast<double>(window.calls),
+                    window.milliseconds / static_cast<double>(window.calls));
+                window = {};
+            }
         }
     }
     return all_ok;

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -9,6 +9,9 @@
 #include "write_watch_policy.hpp"
 #include "live_compute.hpp"
 #include "live_target_format.hpp"       // the one LiveTargetPixelFormat mapping (exhaustive)
+#include "performance_capture.hpp"      // bounded F8 post-trigger renderer timing
+#include "performance_timing_gate.hpp"  // turn on render_runner's existing backend clocks
+#include "performance_timing_policy.hpp" // retain timing across split semantic submits
 
 #include "gpu/gpu_execute.hpp"          // DrawItem, set_submit_renderer
 #include "gpu/gpu_timeline.hpp"         // phase-gated detailed-capture policy
@@ -1118,8 +1121,19 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
             };
             static thread_local RenderTiming pending_timing;
             static thread_local std::vector<RttTimingRecord> pending_rtt_timing;
-            const bool timing_enabled = getenv("PROSPER_RENDER_TIMING") != nullptr;
-            const bool lightweight_rtt_timing = timing_enabled && getenv("PROSPER_RTT_TIMING");
+            const bool perf_capture_timing =
+                prosper::perf::interactive_performance_capture().detailed_timing_active();
+            const bool timing_log_enabled = getenv("PROSPER_RENDER_TIMING") != nullptr;
+            const prosper::frontend::PerformanceTimingMode timing_mode =
+                prosper::frontend::performance_timing_mode(timing_log_enabled,
+                                                            perf_capture_timing);
+            const bool timing_enabled = timing_mode.measure;
+            // render_runner.h cannot depend on the app capture singleton: it is also compiled into
+            // standalone Vulkan tests. This thread-local scope activates its backend clocks only
+            // inside this production callback and restores the prior state on every return path.
+            prosper::frontend::ScopedInteractivePerformanceTiming scoped_perf_timing(
+                perf_capture_timing);
+            const bool lightweight_rtt_timing = timing_mode.log && getenv("PROSPER_RTT_TIMING");
             static const uint64_t rtt_timing_min_draws = getenv("PROSPER_RTT_TIMING_MIN_DRAWS")
                 ? strtoull(getenv("PROSPER_RTT_TIMING_MIN_DRAWS"), nullptr, 0) : 0;
             if (timing_enabled && phase.first_span) {
@@ -5732,6 +5746,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                     pending_timing.total_ms += std::chrono::duration<double, std::milli>(
                         RenderClock::now() - callback_timing_start).count();
                 }
+                prosper::frontend::reset_performance_timing_after_span(
+                    pending_timing, timing_enabled, phase.final_span);
                 return {};
             }
             static const std::vector<uint8_t> empty_pixels;
@@ -5769,6 +5785,36 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                 pending_timing.callbacks++;
                 pending_timing.total_ms += std::chrono::duration<double, std::milli>(
                     RenderClock::now() - callback_timing_start).count();
+                // One record per complete semantic submit. A submit may be split into several
+                // graphics spans by interleaved compute/DMA; recording every callback would count
+                // the growing pending total repeatedly and make the capture itself misattribute time.
+                if (perf_capture_timing && phase.final_span) {
+                    prosper::perf::RendererTimingRecord record;
+                    record.callbacks = pending_timing.callbacks;
+                    record.draws = pending_timing.backend_draws;
+                    record.texture_bytes = pending_timing.texture_bytes;
+                    record.buffer_bytes = pending_timing.buffer_bytes;
+                    record.total_ms = pending_timing.total_ms;
+                    record.build_resources_ms = pending_timing.build_resources_ms;
+                    record.backend_ms = pending_timing.backend_ms;
+                    record.output_copy_ms = pending_timing.output_copy_ms;
+                    record.gpu_wait_ms = pending_timing.backend_gpu_wait_ms;
+                    record.gpu_timestamp_samples =
+                        pending_timing.backend_gpu_timestamp_samples;
+                    record.gpu_device_ms = pending_timing.backend_gpu_device_ms;
+                    record.readback_ms = pending_timing.backend_readback_ms;
+                    record.setup_resources_ms = pending_timing.backend_setup_resources_ms;
+                    record.texture_ms = pending_timing.texture_ms;
+                    record.buffer_ms = pending_timing.buffer_ms;
+                    prosper::perf::interactive_performance_capture().record_renderer(record);
+                }
+                if (!timing_mode.log) {
+                    // F8 consumes the structured record above, then leaves without touching the
+                    // lifetime aggregates or their large periodic stderr summaries.
+                    prosper::frontend::reset_performance_timing_after_span(
+                        pending_timing, timing_enabled, phase.final_span);
+                    return prosper::gpu::RenderedFrame(std::move(selected_pixels));
+                }
                 struct TimingTotals {
                     uint64_t submits = 0, callbacks = 0;
                     double total_ms = 0, prelude_ms = 0, pass_ms = 0;
@@ -6172,6 +6218,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             window.persistent_validation_bytes / (wn * 1024.0 * 1024.0));
                     window = {};
                 }
+                // The complete semantic submit has now been recorded and added to aggregate logs.
+                // Intermediate spans take the earlier return and retain this same population.
+                prosper::frontend::reset_performance_timing_after_span(
+                    pending_timing, timing_enabled, phase.final_span);
             }
             return prosper::gpu::RenderedFrame(std::move(selected_pixels));
         });

--- a/prosper/frontends/shared/performance_capture.cpp
+++ b/prosper/frontends/shared/performance_capture.cpp
@@ -1,0 +1,485 @@
+#include "performance_capture.hpp"
+
+#include <algorithm>
+#include <cerrno>
+#include <chrono>
+#include <climits>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <ctime>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <sstream>
+#include <system_error>
+#include <thread>
+
+#if defined(_WIN32)
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#include <fcntl.h>
+#include <io.h>
+#include <sys/stat.h>
+#else
+#include <fcntl.h>
+#include <unistd.h>
+#endif
+
+#if defined(__linux__)
+#include <unistd.h>
+#endif
+
+#ifndef PROSPER_GIT_REVISION
+#define PROSPER_GIT_REVISION "unknown"
+#endif
+
+namespace prosper::perf {
+namespace {
+
+std::string sanitize_component(std::string_view raw) {
+    std::string out;
+    out.reserve(std::min<size_t>(raw.size(), 32));
+    for (char c : raw) {
+        if (out.size() == 32) break;
+        const unsigned char u = static_cast<unsigned char>(c);
+        const bool keep = (u >= '0' && u <= '9') || (u >= 'A' && u <= 'Z') ||
+                          (u >= 'a' && u <= 'z') || c == '.' || c == '_' || c == '-';
+        out += keep ? c : '_';
+    }
+    size_t begin = 0, end = out.size();
+    while (begin < end && (out[begin] == '.' || out[begin] == '_' || out[begin] == '-')) ++begin;
+    while (end > begin && (out[end - 1] == '.' || out[end - 1] == '_' || out[end - 1] == '-')) --end;
+    return out.substr(begin, end - begin);
+}
+
+std::string local_stamp(std::chrono::system_clock::time_point when) {
+    using namespace std::chrono;
+    const auto seconds_floor = floor<seconds>(when);
+    const auto milliseconds_part = duration_cast<milliseconds>(when - seconds_floor).count();
+    const std::time_t raw = system_clock::to_time_t(seconds_floor);
+    std::tm local{};
+#if defined(_WIN32)
+    localtime_s(&local, &raw);
+#else
+    localtime_r(&raw, &local);
+#endif
+    char text[40];
+    std::snprintf(text, sizeof text, "%04d%02d%02d-%02d%02d%02d-%03d",
+                  local.tm_year + 1900, local.tm_mon + 1, local.tm_mday,
+                  local.tm_hour, local.tm_min, local.tm_sec,
+                  static_cast<int>(milliseconds_part));
+    return text;
+}
+
+std::string iso_local_time(std::chrono::system_clock::time_point when) {
+    using namespace std::chrono;
+    const auto seconds_floor = floor<seconds>(when);
+    const auto milliseconds_part = duration_cast<milliseconds>(when - seconds_floor).count();
+    const std::time_t raw = system_clock::to_time_t(seconds_floor);
+    std::tm local{};
+#if defined(_WIN32)
+    localtime_s(&local, &raw);
+#else
+    localtime_r(&raw, &local);
+#endif
+    char text[48];
+    std::snprintf(text, sizeof text, "%04d-%02d-%02dT%02d:%02d:%02d.%03d",
+                  local.tm_year + 1900, local.tm_mon + 1, local.tm_mday,
+                  local.tm_hour, local.tm_min, local.tm_sec,
+                  static_cast<int>(milliseconds_part));
+    return text;
+}
+
+bool create_exclusive(const std::string& path) {
+#if defined(_WIN32)
+    const int fd = ::_open(path.c_str(), _O_CREAT | _O_EXCL | _O_WRONLY | _O_BINARY,
+                           _S_IREAD | _S_IWRITE);
+    if (fd < 0) return false;
+    ::_close(fd);
+#else
+    const int fd = ::open(path.c_str(), O_CREAT | O_EXCL | O_WRONLY, 0644);
+    if (fd < 0) return false;
+    ::close(fd);
+#endif
+    return true;
+}
+
+std::string json_string(std::string_view value) {
+    std::ostringstream out;
+    out << '"';
+    for (const unsigned char c : value) {
+        switch (c) {
+        case '"': out << "\\\""; break;
+        case '\\': out << "\\\\"; break;
+        case '\b': out << "\\b"; break;
+        case '\f': out << "\\f"; break;
+        case '\n': out << "\\n"; break;
+        case '\r': out << "\\r"; break;
+        case '\t': out << "\\t"; break;
+        default:
+            if (c < 0x20) {
+                out << "\\u" << std::hex << std::setw(4) << std::setfill('0')
+                    << static_cast<unsigned>(c) << std::dec << std::setfill(' ');
+            } else {
+                out << static_cast<char>(c);
+            }
+        }
+    }
+    out << '"';
+    return out.str();
+}
+
+int64_t relative_ns(uint64_t timestamp, uint64_t trigger) {
+    if (timestamp >= trigger) {
+        const uint64_t delta = timestamp - trigger;
+        return delta > static_cast<uint64_t>(INT64_MAX) ? INT64_MAX : static_cast<int64_t>(delta);
+    }
+    const uint64_t delta = trigger - timestamp;
+    return delta > static_cast<uint64_t>(INT64_MAX) ? INT64_MIN : -static_cast<int64_t>(delta);
+}
+
+void write_optional(std::ostream& out, const std::optional<uint64_t>& value) {
+    if (value) out << *value;
+    else out << "null";
+}
+
+} // namespace
+
+struct InteractivePerformanceCapture::PendingCapture {
+    std::string final_path;
+    std::string part_path;
+    std::string title_id;
+    std::string title_label;
+    std::string revision;
+    std::string wall_clock;
+    uint64_t trigger_ns = 0;
+    std::vector<ProcessSample> pre_samples;
+    std::vector<ProcessSample> post_samples;
+    std::vector<RendererTimingRecord> renderer;
+    std::vector<ComputeTimingRecord> compute;
+    size_t renderer_dropped = 0;
+    size_t compute_dropped = 0;
+};
+
+InteractivePerformanceCapture::InteractivePerformanceCapture(CaptureConfig config)
+    : config_(config) {
+    if (!config_.sample_interval_ns) config_.sample_interval_ns = 1;
+    if (!config_.pre_window_ns) config_.pre_window_ns = config_.sample_interval_ns;
+    if (!config_.post_window_ns) config_.post_window_ns = config_.sample_interval_ns;
+}
+
+InteractivePerformanceCapture::~InteractivePerformanceCapture() = default;
+
+bool InteractivePerformanceCapture::sample_due(uint64_t monotonic_ns) const {
+    const uint64_t next = next_sample_ns_.load(std::memory_order_relaxed);
+    return next == 0 || monotonic_ns >= next;
+}
+
+void InteractivePerformanceCapture::observe_sample(const ProcessSample& sample) {
+    std::unique_ptr<PendingCapture> completed;
+    {
+        std::lock_guard lock(mutex_);
+        const uint64_t next = next_sample_ns_.load(std::memory_order_relaxed);
+        if (next && sample.monotonic_ns < next) return;
+        const uint64_t until_next = UINT64_MAX - sample.monotonic_ns < config_.sample_interval_ns
+            ? UINT64_MAX : sample.monotonic_ns + config_.sample_interval_ns;
+        next_sample_ns_.store(until_next, std::memory_order_relaxed);
+
+        ring_.push_back(sample);
+        while (!ring_.empty() && sample.monotonic_ns >= ring_.front().monotonic_ns &&
+               sample.monotonic_ns - ring_.front().monotonic_ns > config_.pre_window_ns)
+            ring_.pop_front();
+
+        if (pending_ && sample.monotonic_ns > pending_->trigger_ns)
+            pending_->post_samples.push_back(sample);
+        completed = finish_if_due_locked(sample.monotonic_ns);
+    }
+    if (completed) publish_completed(std::move(completed));
+}
+
+CaptureArmResult InteractivePerformanceCapture::arm(
+    const std::string& directory, const std::string& title_id,
+    const std::string& title_label, const std::string& revision,
+    uint64_t monotonic_ns, std::chrono::system_clock::time_point wall_clock) {
+    CaptureArmResult result;
+    std::lock_guard lock(mutex_);
+    result.index = ++arm_count_;
+    if (pending_) {
+        result.error = "a performance capture is already collecting its post-trigger window";
+        return result;
+    }
+
+    std::string base_dir = directory.empty() ? std::string(".") : directory;
+    while (base_dir.size() > 1 && (base_dir.back() == '/' || base_dir.back() == '\\'))
+        base_dir.pop_back();
+    std::error_code ec;
+    std::filesystem::create_directories(base_dir, ec);
+
+    std::string safe_title = sanitize_component(title_id);
+    if (safe_title.empty()) safe_title = "notitle";
+    const std::string stem = "perf_capture_" + safe_title + "_" + local_stamp(wall_clock);
+    std::string final_path, part_path;
+    bool reserved = false;
+    for (unsigned collision = 0; collision < 1000; ++collision) {
+        std::string candidate = stem;
+        if (collision) candidate += "-" + std::to_string(collision + 1);
+        final_path = base_dir + "/" + candidate + ".prperf";
+        part_path = final_path + ".part";
+        if (std::filesystem::exists(final_path, ec) && !ec) continue;
+        errno = 0;
+        if (create_exclusive(part_path)) {
+            reserved = true;
+            break;
+        }
+        if (errno == EEXIST) continue;
+        result.error = "cannot reserve performance capture: " + std::string(std::strerror(errno));
+        return result;
+    }
+    if (!reserved) {
+        result.error = "could not find a free performance-capture name";
+        return result;
+    }
+
+    pending_ = std::make_unique<PendingCapture>();
+    pending_->final_path = std::move(final_path);
+    pending_->part_path = std::move(part_path);
+    pending_->title_id = title_id;
+    pending_->title_label = title_label;
+    pending_->revision = revision;
+    pending_->wall_clock = iso_local_time(wall_clock);
+    pending_->trigger_ns = monotonic_ns;
+    const uint64_t cutoff = monotonic_ns > config_.pre_window_ns
+        ? monotonic_ns - config_.pre_window_ns : 0;
+    for (const ProcessSample& sample : ring_) {
+        if (sample.monotonic_ns >= cutoff && sample.monotonic_ns <= monotonic_ns)
+            pending_->pre_samples.push_back(sample);
+    }
+    detailed_active_.store(true, std::memory_order_relaxed);
+    result.ok = true;
+    result.pre_samples = pending_->pre_samples.size();
+    result.post_seconds = static_cast<double>(config_.post_window_ns) / 1e9;
+    return result;
+}
+
+void InteractivePerformanceCapture::record_renderer(RendererTimingRecord record) {
+    if (!detailed_timing_active()) return;
+    if (!record.monotonic_ns) record.monotonic_ns = monotonic_now_ns();
+    std::lock_guard lock(mutex_);
+    if (!pending_) return;
+    if (pending_->renderer.size() < config_.max_renderer_records)
+        pending_->renderer.push_back(record);
+    else
+        ++pending_->renderer_dropped;
+}
+
+void InteractivePerformanceCapture::record_compute(ComputeTimingRecord record) {
+    if (!detailed_timing_active()) return;
+    if (!record.monotonic_ns) record.monotonic_ns = monotonic_now_ns();
+    std::lock_guard lock(mutex_);
+    if (!pending_) return;
+    if (pending_->compute.size() < config_.max_compute_records)
+        pending_->compute.push_back(record);
+    else
+        ++pending_->compute_dropped;
+}
+
+std::unique_ptr<InteractivePerformanceCapture::PendingCapture>
+InteractivePerformanceCapture::finish_if_due_locked(uint64_t monotonic_ns) {
+    if (!pending_ || monotonic_ns < pending_->trigger_ns ||
+        monotonic_ns - pending_->trigger_ns < config_.post_window_ns)
+        return {};
+    detailed_active_.store(false, std::memory_order_relaxed);
+    return std::move(pending_);
+}
+
+void InteractivePerformanceCapture::publish_completed(std::unique_ptr<PendingCapture> capture) {
+    CaptureOutcome result;
+    result.path = capture->final_path;
+    result.pre_samples = capture->pre_samples.size();
+    result.post_samples = capture->post_samples.size();
+    result.renderer_records = capture->renderer.size();
+    result.compute_records = capture->compute.size();
+    result.renderer_dropped = capture->renderer_dropped;
+    result.compute_dropped = capture->compute_dropped;
+
+    std::ofstream out(capture->part_path, std::ios::binary | std::ios::trunc);
+    if (!out) {
+        result.error = "could not open the reserved temporary capture for writing";
+    } else {
+        const bool cpu_available = std::any_of(
+            capture->pre_samples.begin(), capture->pre_samples.end(),
+            [](const ProcessSample& sample) { return sample.process_cpu_ns.has_value(); }) ||
+            std::any_of(capture->post_samples.begin(), capture->post_samples.end(),
+            [](const ProcessSample& sample) { return sample.process_cpu_ns.has_value(); });
+        const bool rss_available = std::any_of(
+            capture->pre_samples.begin(), capture->pre_samples.end(),
+            [](const ProcessSample& sample) { return sample.rss_bytes.has_value(); }) ||
+            std::any_of(capture->post_samples.begin(), capture->post_samples.end(),
+            [](const ProcessSample& sample) { return sample.rss_bytes.has_value(); });
+        out << std::setprecision(10);
+        out << "{\"type\":\"header\",\"format\":\"prosper-performance-capture\","
+               "\"version\":1,\"title_id\":" << json_string(capture->title_id)
+            << ",\"title\":" << json_string(capture->title_label)
+            << ",\"revision\":" << json_string(capture->revision)
+            << ",\"trigger_monotonic_ns\":" << capture->trigger_ns
+            << ",\"trigger_local_time\":" << json_string(capture->wall_clock)
+            << ",\"pre_window_ns\":" << config_.pre_window_ns
+            << ",\"post_window_ns\":" << config_.post_window_ns
+            << ",\"sample_interval_ns\":" << config_.sample_interval_ns
+            << ",\"logical_cpus\":" << std::thread::hardware_concurrency()
+            << ",\"process_cpu_available\":" << (cpu_available ? "true" : "false")
+            << ",\"rss_available\":" << (rss_available ? "true" : "false") << "}\n";
+
+        const auto write_sample = [&](const ProcessSample& sample, const char* phase) {
+            out << "{\"type\":\"sample\",\"phase\":\"" << phase << "\",\"t_ns\":"
+                << relative_ns(sample.monotonic_ns, capture->trigger_ns)
+                << ",\"process_cpu_ns\":";
+            write_optional(out, sample.process_cpu_ns);
+            out << ",\"rss_bytes\":";
+            write_optional(out, sample.rss_bytes);
+            out << ",\"guest_presents\":" << sample.guest_presents
+                << ",\"rendered_frames\":" << sample.rendered_frames
+                << ",\"host_presented_frames\":" << sample.host_presented_frames << "}\n";
+        };
+        for (const ProcessSample& sample : capture->pre_samples) write_sample(sample, "pre");
+        for (const ProcessSample& sample : capture->post_samples) write_sample(sample, "post");
+
+        for (const RendererTimingRecord& record : capture->renderer) {
+            out << "{\"type\":\"renderer\",\"t_ns\":"
+                << relative_ns(record.monotonic_ns, capture->trigger_ns)
+                << ",\"callbacks\":" << record.callbacks << ",\"draws\":" << record.draws
+                << ",\"texture_bytes\":" << record.texture_bytes
+                << ",\"buffer_bytes\":" << record.buffer_bytes
+                << ",\"total_ms\":" << record.total_ms
+                << ",\"build_resources_ms\":" << record.build_resources_ms
+                << ",\"backend_ms\":" << record.backend_ms
+                << ",\"output_copy_ms\":" << record.output_copy_ms
+                << ",\"gpu_wait_ms\":" << record.gpu_wait_ms
+                << ",\"gpu_timestamp_samples\":" << record.gpu_timestamp_samples
+                << ",\"gpu_device_ms\":" << record.gpu_device_ms
+                << ",\"readback_ms\":" << record.readback_ms
+                << ",\"setup_resources_ms\":" << record.setup_resources_ms
+                << ",\"texture_ms\":" << record.texture_ms
+                << ",\"buffer_ms\":" << record.buffer_ms << "}\n";
+        }
+        for (const ComputeTimingRecord& record : capture->compute) {
+            out << "{\"type\":\"compute\",\"t_ns\":"
+                << relative_ns(record.monotonic_ns, capture->trigger_ns)
+                << ",\"dispatches\":" << record.dispatches
+                << ",\"cpu_fast_total\":" << record.cpu_fast_total
+                << ",\"total_ms\":" << record.total_ms << "}\n";
+        }
+        out << "{\"type\":\"footer\",\"complete\":true,\"pre_samples\":"
+            << capture->pre_samples.size() << ",\"post_samples\":" << capture->post_samples.size()
+            << ",\"renderer_records\":" << capture->renderer.size()
+            << ",\"compute_records\":" << capture->compute.size()
+            << ",\"renderer_dropped\":" << capture->renderer_dropped
+            << ",\"compute_dropped\":" << capture->compute_dropped << "}\n";
+        out.flush();
+        if (!out.good()) result.error = "writing the performance capture failed";
+        out.close();
+        if (result.error.empty()) {
+            std::error_code rename_error;
+            std::filesystem::rename(capture->part_path, capture->final_path, rename_error);
+            if (rename_error)
+                result.error = "could not atomically install the completed capture: " +
+                               rename_error.message();
+        }
+    }
+    result.ok = result.error.empty();
+    if (!result.ok) {
+        std::error_code ignored;
+        std::filesystem::remove(capture->part_path, ignored);
+        result.path.clear();
+    }
+    std::lock_guard lock(mutex_);
+    outcome_ = std::move(result);
+}
+
+bool InteractivePerformanceCapture::take_outcome(CaptureOutcome& outcome) {
+    std::lock_guard lock(mutex_);
+    if (!outcome_) return false;
+    outcome = std::move(*outcome_);
+    outcome_.reset();
+    return true;
+}
+
+void InteractivePerformanceCapture::cancel() {
+    std::string part;
+    {
+        std::lock_guard lock(mutex_);
+        detailed_active_.store(false, std::memory_order_relaxed);
+        if (pending_) part = pending_->part_path;
+        pending_.reset();
+    }
+    if (!part.empty()) {
+        std::error_code ignored;
+        std::filesystem::remove(part, ignored);
+    }
+}
+
+InteractivePerformanceCapture& interactive_performance_capture() {
+    static InteractivePerformanceCapture capture;
+    return capture;
+}
+
+uint64_t monotonic_now_ns() {
+    return static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(
+        std::chrono::steady_clock::now().time_since_epoch()).count());
+}
+
+ProcessSample collect_process_sample(uint64_t monotonic_ns, uint64_t guest_presents,
+                                     uint64_t rendered_frames,
+                                     uint64_t host_presented_frames) {
+    ProcessSample sample;
+    sample.monotonic_ns = monotonic_ns;
+    sample.guest_presents = guest_presents;
+    sample.rendered_frames = rendered_frames;
+    sample.host_presented_frames = host_presented_frames;
+
+#if defined(_WIN32)
+    // MSVC's std::clock measures elapsed wall time, not process CPU time. GetProcessTimes exposes
+    // the kernel + user total in 100 ns ticks and therefore preserves the report's "CPU cores"
+    // meaning on Windows instead of quietly reporting ~1.0 for an idle process.
+    FILETIME created{}, exited{}, kernel{}, user{};
+    if (::GetProcessTimes(::GetCurrentProcess(), &created, &exited, &kernel, &user)) {
+        ULARGE_INTEGER kernel_ticks{}, user_ticks{};
+        kernel_ticks.LowPart = kernel.dwLowDateTime;
+        kernel_ticks.HighPart = kernel.dwHighDateTime;
+        user_ticks.LowPart = user.dwLowDateTime;
+        user_ticks.HighPart = user.dwHighDateTime;
+        if (user_ticks.QuadPart <= UINT64_MAX - kernel_ticks.QuadPart) {
+            const uint64_t ticks = kernel_ticks.QuadPart + user_ticks.QuadPart;
+            if (ticks <= UINT64_MAX / 100) sample.process_cpu_ns = ticks * 100;
+        }
+    }
+#else
+    const std::clock_t cpu = std::clock();
+    if (cpu != static_cast<std::clock_t>(-1)) {
+        const long double ns = static_cast<long double>(cpu) * 1'000'000'000.0L / CLOCKS_PER_SEC;
+        if (ns >= 0 && ns <= static_cast<long double>(UINT64_MAX))
+            sample.process_cpu_ns = static_cast<uint64_t>(ns);
+    }
+#endif
+
+#if defined(__linux__)
+    std::ifstream statm("/proc/self/statm");
+    uint64_t total_pages = 0, resident_pages = 0;
+    if (statm >> total_pages >> resident_pages) {
+        (void)total_pages;
+        const long page_size = ::sysconf(_SC_PAGESIZE);
+        if (page_size > 0 && resident_pages <= UINT64_MAX / static_cast<uint64_t>(page_size))
+            sample.rss_bytes = resident_pages * static_cast<uint64_t>(page_size);
+    }
+#endif
+    return sample;
+}
+
+const char* build_revision() {
+    return PROSPER_GIT_REVISION;
+}
+
+} // namespace prosper::perf

--- a/prosper/frontends/shared/performance_capture.hpp
+++ b/prosper/frontends/shared/performance_capture.hpp
@@ -1,0 +1,132 @@
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace prosper::perf {
+
+// The cheap, always-on side of F8. prosper-app samples this at 4 Hz; no renderer timing clocks,
+// resource walks, screenshots, or frame dumps run until the user actually presses F8.
+struct ProcessSample {
+    uint64_t monotonic_ns = 0;
+    std::optional<uint64_t> process_cpu_ns;
+    std::optional<uint64_t> rss_bytes;
+    uint64_t guest_presents = 0;
+    uint64_t rendered_frames = 0;
+    uint64_t host_presented_frames = 0;
+};
+
+// One live-renderer callback. These are the existing PROSPER_RENDER_TIMING intervals, recorded in a
+// compact structured form only during F8's post-trigger window.
+struct RendererTimingRecord {
+    uint64_t monotonic_ns = 0;
+    uint64_t callbacks = 0;
+    uint64_t draws = 0;
+    uint64_t texture_bytes = 0;
+    uint64_t buffer_bytes = 0;
+    double total_ms = 0;
+    double build_resources_ms = 0;
+    double backend_ms = 0;
+    double output_copy_ms = 0;
+    double gpu_wait_ms = 0;
+    uint64_t gpu_timestamp_samples = 0;
+    double gpu_device_ms = 0;
+    double readback_ms = 0;
+    double setup_resources_ms = 0;
+    double texture_ms = 0;
+    double buffer_ms = 0;
+};
+
+// One live-compute batch. CPU-fast-path dispatches are included in `dispatches`; the cumulative
+// fast-path count lets the report keep that population visible instead of silently omitting it.
+struct ComputeTimingRecord {
+    uint64_t monotonic_ns = 0;
+    uint64_t dispatches = 0;
+    uint64_t cpu_fast_total = 0;
+    double total_ms = 0;
+};
+
+struct CaptureConfig {
+    uint64_t pre_window_ns = 5'000'000'000ull;
+    uint64_t post_window_ns = 5'000'000'000ull;
+    uint64_t sample_interval_ns = 250'000'000ull;
+    size_t max_renderer_records = 4096;
+    size_t max_compute_records = 4096;
+};
+
+struct CaptureArmResult {
+    bool ok = false;
+    unsigned index = 0;
+    size_t pre_samples = 0;
+    double post_seconds = 0;
+    std::string error;
+};
+
+struct CaptureOutcome {
+    bool ok = false;
+    std::string path;
+    std::string error;
+    size_t pre_samples = 0;
+    size_t post_samples = 0;
+    size_t renderer_records = 0;
+    size_t compute_records = 0;
+    size_t renderer_dropped = 0;
+    size_t compute_dropped = 0;
+};
+
+// Thread-safe capture state. The app thread owns process samples and finalization; renderer/compute
+// threads only call the two bounded record methods while detailed_timing_active() is true.
+class InteractivePerformanceCapture {
+public:
+    explicit InteractivePerformanceCapture(CaptureConfig config = {});
+    ~InteractivePerformanceCapture();
+
+    bool sample_due(uint64_t monotonic_ns) const;
+    void observe_sample(const ProcessSample& sample);
+
+    CaptureArmResult arm(const std::string& directory, const std::string& title_id,
+                         const std::string& title_label, const std::string& revision,
+                         uint64_t monotonic_ns,
+                         std::chrono::system_clock::time_point wall_clock);
+
+    bool detailed_timing_active() const {
+        return detailed_active_.load(std::memory_order_relaxed);
+    }
+    void record_renderer(RendererTimingRecord record);
+    void record_compute(ComputeTimingRecord record);
+    bool take_outcome(CaptureOutcome& outcome);
+    void cancel();
+
+private:
+    struct PendingCapture;
+
+    std::unique_ptr<PendingCapture> finish_if_due_locked(uint64_t monotonic_ns);
+    void publish_completed(std::unique_ptr<PendingCapture> completed);
+
+    CaptureConfig config_;
+    mutable std::mutex mutex_;
+    std::deque<ProcessSample> ring_;
+    std::atomic<uint64_t> next_sample_ns_{0};
+    std::atomic<bool> detailed_active_{false};
+    std::unique_ptr<PendingCapture> pending_;
+    std::optional<CaptureOutcome> outcome_;
+    unsigned arm_count_ = 0;
+};
+
+InteractivePerformanceCapture& interactive_performance_capture();
+
+uint64_t monotonic_now_ns();
+ProcessSample collect_process_sample(uint64_t monotonic_ns, uint64_t guest_presents,
+                                     uint64_t rendered_frames,
+                                     uint64_t host_presented_frames);
+const char* build_revision();
+
+} // namespace prosper::perf

--- a/prosper/frontends/shared/performance_timing_gate.hpp
+++ b/prosper/frontends/shared/performance_timing_gate.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+namespace prosper::frontend {
+
+// Header-only because render_runner.h is compiled directly into many Vulkan tests that do not link
+// prosper-app's performance-capture library. The gate is thread-local because render_runner executes
+// synchronously inside the live-render callback: an app-wide flag could make an unrelated concurrent
+// replay/test caller pay for timestamps while F8 was active on a different thread.
+inline bool& interactive_performance_timing_gate() {
+    static thread_local bool enabled = false;
+    return enabled;
+}
+
+inline bool interactive_performance_timing() {
+    return interactive_performance_timing_gate();
+}
+
+// Scope the exceptional F8 backend clocks to exactly one live-render callback. Restoring the prior
+// value supports nesting and proves that no return path can leave render_runner timing spuriously on.
+class ScopedInteractivePerformanceTiming {
+public:
+    explicit ScopedInteractivePerformanceTiming(bool enabled)
+        : previous_(interactive_performance_timing_gate()) {
+        interactive_performance_timing_gate() = enabled;
+    }
+    ~ScopedInteractivePerformanceTiming() {
+        interactive_performance_timing_gate() = previous_;
+    }
+
+    ScopedInteractivePerformanceTiming(const ScopedInteractivePerformanceTiming&) = delete;
+    ScopedInteractivePerformanceTiming& operator=(const ScopedInteractivePerformanceTiming&) = delete;
+
+private:
+    bool previous_;
+};
+
+} // namespace prosper::frontend

--- a/prosper/frontends/shared/performance_timing_policy.hpp
+++ b/prosper/frontends/shared/performance_timing_policy.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+namespace prosper::frontend {
+
+struct PerformanceTimingMode {
+    bool measure = false;
+    bool log = false;
+};
+
+// F8 may enable the clocks needed by its bounded structured artifact, but only the explicit
+// PROSPER_RENDER_TIMING switch authorizes the existing high-volume periodic stderr summaries.
+inline PerformanceTimingMode performance_timing_mode(bool environment_logging,
+                                                      bool interactive_capture) {
+    return {environment_logging || interactive_capture, environment_logging};
+}
+
+// A semantic submit may contain graphics spans separated by compute/DMA. Intermediate callbacks
+// must retain the accumulated timing; only its final span consumes and clears that population.
+inline bool should_reset_performance_timing_after_span(bool timing_enabled, bool final_span) {
+    return timing_enabled && final_span;
+}
+
+template <typename Timing>
+inline void reset_performance_timing_after_span(Timing& pending, bool timing_enabled,
+                                                bool final_span) {
+    if (should_reset_performance_timing_after_span(timing_enabled, final_span)) pending = {};
+}
+
+} // namespace prosper::frontend

--- a/prosper/frontends/shared/test_performance_capture.cpp
+++ b/prosper/frontends/shared/test_performance_capture.cpp
@@ -1,0 +1,214 @@
+#include "performance_capture.hpp"
+#include "performance_timing_gate.hpp"
+#include "performance_timing_policy.hpp"
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <thread>
+
+namespace {
+int failures = 0;
+int checks = 0;
+
+void check(bool condition, const char* name) {
+    ++checks;
+    if (condition) return;
+    ++failures;
+    std::cerr << "FAIL: " << name << '\n';
+}
+
+size_t count_text(const std::string& text, const std::string& needle) {
+    size_t count = 0, at = 0;
+    while ((at = text.find(needle, at)) != std::string::npos) {
+        ++count;
+        at += needle.size();
+    }
+    return count;
+}
+
+prosper::perf::ProcessSample sample(uint64_t at, uint64_t counter) {
+    prosper::perf::ProcessSample out;
+    out.monotonic_ns = at;
+    out.process_cpu_ns = counter * 70;
+    out.rss_bytes = 4096 + counter;
+    out.guest_presents = counter * 3;
+    out.rendered_frames = counter * 2;
+    out.host_presented_frames = counter;
+    return out;
+}
+} // namespace
+
+int main() {
+    namespace fs = std::filesystem;
+    using prosper::perf::CaptureConfig;
+    using prosper::perf::InteractivePerformanceCapture;
+
+    const fs::path dir = "performance_capture_test";
+    std::error_code ec;
+    fs::remove_all(dir, ec);
+    fs::create_directories(dir, ec);
+    check(!ec, "scratch directory is available");
+
+    struct SplitTiming { unsigned spans = 0; };
+    SplitTiming split{1};
+    prosper::frontend::reset_performance_timing_after_span(split, true, false);
+    check(split.spans == 1,
+          "split-submit timing retains earlier non-final spans until the final callback");
+    prosper::frontend::reset_performance_timing_after_span(split, true, true);
+    check(split.spans == 0, "split-submit timing resets after its final callback");
+    check(!prosper::frontend::interactive_performance_timing(),
+          "interactive backend timing starts disabled on the caller thread");
+    {
+        prosper::frontend::ScopedInteractivePerformanceTiming outer(true);
+        check(prosper::frontend::interactive_performance_timing(),
+              "interactive backend timing is enabled inside the live callback scope");
+        bool other_thread_timing = true;
+        std::thread ordinary_caller([&] {
+            other_thread_timing = prosper::frontend::interactive_performance_timing();
+        });
+        ordinary_caller.join();
+        check(!other_thread_timing,
+              "F8 timing cannot enable an unrelated render_runner caller on another thread");
+        {
+            prosper::frontend::ScopedInteractivePerformanceTiming nested(false);
+            check(!prosper::frontend::interactive_performance_timing(),
+                  "a nested timing scope can temporarily restore the ordinary caller policy");
+        }
+        check(prosper::frontend::interactive_performance_timing(),
+              "a nested timing scope restores its prior live-callback state");
+    }
+    check(!prosper::frontend::interactive_performance_timing(),
+          "interactive backend timing cannot leak beyond the live callback scope");
+    const auto f8_only = prosper::frontend::performance_timing_mode(false, true);
+    check(f8_only.measure && !f8_only.log,
+          "F8-only timing measures structured data without enabling periodic stderr logs");
+    const auto environment_timing = prosper::frontend::performance_timing_mode(true, false);
+    check(environment_timing.measure && environment_timing.log,
+          "PROSPER_RENDER_TIMING enables both measurement and its requested logs");
+
+    CaptureConfig config;
+    config.pre_window_ns = 500;
+    config.post_window_ns = 300;
+    config.sample_interval_ns = 100;
+    config.max_renderer_records = 2;
+    config.max_compute_records = 1;
+    InteractivePerformanceCapture capture(config);
+
+    // Six samples fill the exact inclusive 500 ns pre-trigger window. A test that only asserts the
+    // file exists would pass if the ring never ran; the exact serialized population is the mechanism.
+    for (uint64_t i = 0; i <= 5; ++i) capture.observe_sample(sample(i * 100, i));
+    check(!capture.sample_due(550), "fixed-rate ring suppresses an early process sample");
+    check(capture.sample_due(600), "fixed-rate ring requests its next process sample");
+
+    const auto wall = std::chrono::system_clock::time_point(std::chrono::milliseconds(1'722'517'353'471LL));
+    const auto armed = capture.arm(dir.string(), "PPSA30140", "Syberia \"Remastered\"",
+                                   "test-revision", 500, wall);
+    check(armed.ok, "F8 arm reserves a temporary capture");
+    check(armed.pre_samples == 6, "F8 arm freezes the actual pre-trigger ring");
+    check(capture.detailed_timing_active(), "F8 arm enables post-trigger detailed timing");
+
+    size_t part_files = 0, final_files = 0;
+    for (const auto& entry : fs::directory_iterator(dir)) {
+        part_files += entry.path().extension() == ".part";
+        final_files += entry.path().extension() == ".prperf";
+    }
+    check(part_files == 1 && final_files == 0,
+          "an active capture has only a private .part, never a partial final artifact");
+
+    const auto refused = capture.arm(dir.string(), "PPSA30140", "Syberia", "test-revision",
+                                     501, wall);
+    check(!refused.ok && refused.error.find("already") != std::string::npos,
+          "a second F8 press cannot replace an in-flight capture silently");
+
+    for (uint64_t i = 0; i < 3; ++i) {
+        prosper::perf::RendererTimingRecord record;
+        record.monotonic_ns = 501 + i;
+        record.callbacks = 1;
+        record.draws = 100 + i;
+        record.total_ms = 20 + i;
+        record.setup_resources_ms = 10 + i;
+        record.gpu_timestamp_samples = 2 + i;
+        capture.record_renderer(record);
+    }
+    for (uint64_t i = 0; i < 2; ++i) {
+        prosper::perf::ComputeTimingRecord record;
+        record.monotonic_ns = 504 + i;
+        record.dispatches = 7 + i;
+        record.total_ms = 3 + i;
+        capture.record_compute(record);
+    }
+
+    capture.observe_sample(sample(600, 6));
+    capture.observe_sample(sample(700, 7));
+    check(capture.detailed_timing_active(), "detailed timing stays active before the post window ends");
+    capture.observe_sample(sample(800, 8));
+    check(!capture.detailed_timing_active(), "the bounded post window disables detailed timing");
+
+    prosper::perf::CaptureOutcome outcome;
+    check(capture.take_outcome(outcome) && outcome.ok,
+          "a complete post window publishes one successful outcome");
+    check(outcome.pre_samples == 6 && outcome.post_samples == 3,
+          "outcome proves both pre-trigger ring and post-trigger sampler ran");
+    check(outcome.renderer_records == 2 && outcome.renderer_dropped == 1,
+          "renderer detail cap retains its limit and accounts for every dropped record");
+    check(outcome.compute_records == 1 && outcome.compute_dropped == 1,
+          "compute detail cap retains its limit and accounts for every dropped record");
+    check(fs::exists(outcome.path) && !fs::exists(outcome.path + ".part"),
+          "completion atomically replaces the temporary file with .prperf");
+
+    std::ifstream input(outcome.path, std::ios::binary);
+    std::ostringstream bytes;
+    bytes << input.rdbuf();
+    const std::string text = bytes.str();
+    check(text.find("\"format\":\"prosper-performance-capture\",\"version\":1") != std::string::npos,
+          "capture identifies its format and version");
+    check(text.find("Syberia \\\"Remastered\\\"") != std::string::npos,
+          "capture metadata is JSON escaped");
+    check(count_text(text, "\"type\":\"sample\",\"phase\":\"pre\"") == 6,
+          "serialized artifact contains the exact pre-trigger ring population");
+    check(count_text(text, "\"type\":\"sample\",\"phase\":\"post\"") == 3,
+          "serialized artifact contains the exact post-trigger population");
+    check(count_text(text, "\"type\":\"renderer\"") == 2 &&
+          count_text(text, "\"type\":\"compute\"") == 1,
+          "serialized detail counts match the bounded retained records");
+    check(text.find("\"gpu_timestamp_samples\":2") != std::string::npos,
+          "renderer records serialize the GPU timestamp availability discriminator");
+    check(text.find("\"renderer_dropped\":1,\"compute_dropped\":1") != std::string::npos,
+          "footer makes detail truncation fail-visible");
+    check(text.find("\"type\":\"footer\",\"complete\":true") != std::string::npos,
+          "final artifact carries an explicit completeness marker");
+
+    // The same title and wall-clock millisecond must not overwrite an earlier capture. The live
+    // algorithm claims `.part` exclusively, so this is a syscall property rather than check-then-write.
+    capture.observe_sample(sample(900, 9));
+    const auto collision = capture.arm(dir.string(), "PPSA30140", "Syberia", "test-revision",
+                                       900, wall);
+    check(collision.ok, "a same-stamp capture advances to a collision suffix");
+    capture.observe_sample(sample(1200, 12));
+    prosper::perf::CaptureOutcome second;
+    check(capture.take_outcome(second) && second.ok && second.path != outcome.path,
+          "a same-stamp capture publishes a distinct final path");
+    check(fs::exists(outcome.path) && fs::exists(second.path),
+          "collision handling preserves both completed captures");
+
+    // Graceful app exit removes only the unfinished private part and never creates a short final.
+    capture.observe_sample(sample(1300, 13));
+    const auto cancel_arm = capture.arm(dir.string(), "PPSA30140", "Syberia", "test-revision",
+                                        1300, wall + std::chrono::milliseconds(1));
+    check(cancel_arm.ok, "cancellation control arms");
+    capture.cancel();
+    check(!capture.detailed_timing_active(), "cancellation disables detailed timing");
+    part_files = 0;
+    for (const auto& entry : fs::directory_iterator(dir))
+        part_files += entry.path().extension() == ".part";
+    check(part_files == 0, "graceful cancellation removes the unfinished private part");
+
+    fs::remove_all(dir, ec);
+    std::cout << (failures ? "FAIL" : "PASS") << ": " << checks << " checks, "
+              << failures << " failures\n";
+    return failures ? 1 : 0;
+}

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -9,6 +9,8 @@
 #include "../src/gpu/render_state.hpp"
 #include "../frontends/shared/rtt_scale.hpp"
 #include "../frontends/shared/vulkan_device_select.hpp"
+#include "../frontends/shared/performance_timing_gate.hpp"
+#include "../frontends/shared/performance_timing_policy.hpp"
 #include <algorithm>
 #include <array>
 #include <atomic>
@@ -2832,7 +2834,11 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                                                   std::span<const BackendDraw> logical_ds_draws = {},
                                                   BackendMrtOutputs* mrt_outputs = nullptr) {
     using TimingClock = std::chrono::steady_clock;
-    const bool timing_enabled = getenv("PROSPER_RENDER_TIMING") != nullptr;
+    const bool timing_log_enabled = getenv("PROSPER_RENDER_TIMING") != nullptr;
+    const prosper::frontend::PerformanceTimingMode timing_mode =
+        prosper::frontend::performance_timing_mode(
+            timing_log_enabled, prosper::frontend::interactive_performance_timing());
+    const bool timing_enabled = timing_mode.measure;
     const auto timing_start = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
     if (timing_enabled) backend_render_timing_stats_storage() = {};
     BackendColorTargetStats& color_target_stats = backend_color_target_stats_storage();
@@ -6404,6 +6410,9 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         call_timing.res_buffer_copy_ms = res_buffer_copy_ms;
         call_timing.res_descriptor_ms = res_descriptor_ms;
         call_timing.setup_pipeline_ms = setup_pipeline_ms;
+        // The live F8 caller consumes call_timing above. Only the explicit environment switch owns
+        // the backend lifetime aggregates and optional periodic stderr windows below.
+        if (!timing_mode.log) return out;
         struct TimingTotals {
             uint64_t calls = 0, draws = 0;
             uint64_t command_buffers = 0, queue_submits = 0, fence_waits = 0;

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -223,6 +223,32 @@ the shipped runtime. Build them from `build-linux/` like everything else.
   `--thread REGEX` isolates one thread, `--mode folded` emits flamegraph stacks. Complements
   `guest_bt` (which does the GUEST/managed-C# side). `--self-test` checks the symbol parser.
   See `hostprof/README.md`.
+- **F8 interactive performance capture / `perf/performance_capture_report.py`** — while playing in
+  `prosper-app`, press **F8** when performance is bad. The app keeps a cheap 4 Hz rolling ring of
+  process CPU/RSS plus guest-flip, rendered-frame, and host-present counts; the press freezes the
+  preceding 5 seconds and enables the existing structured renderer/compute timers for the following
+  5 seconds. It then atomically publishes one bounded
+  `perf_capture_<titleId>_<timestamp>.prperf` under `PROSPER_CAPTURE_DIR` (default cwd). No GPU command
+  capture, screenshot, or ordinary frame dump is enabled by F8. Detailed renderer and compute records
+  are capped at 4096 each, and the footer reports exact retained and dropped counts — never read the
+  cap as the population. Missing Vulkan timestamp samples are explicit: the report leaves GPU device
+  time unavailable and reports total GPU wait without inventing a device/host-overhead split. F8
+  enables structured timing clocks but not the existing high-volume periodic stderr timing logs. A
+  graceful exit before the window completes removes the private `.part` rather than publishing a
+  short final file.
+
+  Inspect it offline with:
+
+  ```bash
+  python3 tools/perf/performance_capture_report.py capture.prperf
+  ```
+
+  The report separates evidence for CPU work outside the timed renderer, renderer resource work,
+  GPU device/wait/readback cost, compute batches, and frame-pacing gaps. It deliberately reports
+  unavailable/inconclusive fields instead of inventing a verdict. This is a broad localizer, not a
+  stack sampler: after it points at host CPU, use `hostprof`; after it points at a graphics phase,
+  use the existing focused timing/capture tools. The always-on pre-trigger cost is one atomic due
+  check per app loop and one process sample every 250 ms; detailed clocks run only post-trigger.
 - **`perf/compute_phase_report.py`** — roll up the **compute** side of a run, the way
   `PROSPER_RENDER_TIMING` already rolls up graphics. `PROSPER_COMPUTE_PHASE_TIMING=1` and
   `PROSPER_COMPUTE_IMAGE_TIMING=1` emit a 17-timer decomposition *per dispatch*, which is unreadable

--- a/prosper/tools/perf/performance_capture_report.py
+++ b/prosper/tools/perf/performance_capture_report.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Inspect a bounded prosper F8 `.prperf` performance capture.
+
+The capture is evidence, not an oracle. This report separates cheap process/frame-pacing counters
+from post-trigger renderer/compute timings and says "inconclusive" when the required population is
+missing. It never interprets a dropped/capped record count as the real event count.
+"""
+
+import argparse
+import json
+import math
+import sys
+
+
+class CaptureError(ValueError):
+    pass
+
+
+def load_capture(path):
+    records = []
+    try:
+        with open(path, "r", encoding="utf-8") as stream:
+            for line_number, line in enumerate(stream, 1):
+                if not line.strip():
+                    continue
+                try:
+                    records.append(json.loads(line))
+                except json.JSONDecodeError as exc:
+                    raise CaptureError(f"line {line_number}: invalid JSON: {exc}") from exc
+    except OSError as exc:
+        raise CaptureError(str(exc)) from exc
+    validate_capture(records)
+    return records
+
+
+def validate_capture(records):
+    if not records:
+        raise CaptureError("empty capture")
+    header = records[0]
+    if (header.get("type"), header.get("format"), header.get("version")) != (
+            "header", "prosper-performance-capture", 1):
+        raise CaptureError("not a supported prosper performance capture")
+    footers = [record for record in records if record.get("type") == "footer"]
+    if len(footers) != 1 or not footers[0].get("complete"):
+        raise CaptureError("capture is incomplete (missing complete footer)")
+    footer = footers[0]
+    actual = {
+        "pre_samples": sum(r.get("type") == "sample" and r.get("phase") == "pre" for r in records),
+        "post_samples": sum(r.get("type") == "sample" and r.get("phase") == "post" for r in records),
+        "renderer_records": sum(r.get("type") == "renderer" for r in records),
+        "compute_records": sum(r.get("type") == "compute" for r in records),
+    }
+    for key, value in actual.items():
+        if footer.get(key) != value:
+            raise CaptureError(f"footer {key}={footer.get(key)!r}, but file contains {value}")
+    for key in ("renderer_dropped", "compute_dropped"):
+        if not isinstance(footer.get(key), int) or footer[key] < 0:
+            raise CaptureError(f"footer has invalid {key}")
+
+
+def _counter_rate(samples, field, seconds):
+    if len(samples) < 2 or seconds <= 0:
+        return None
+    first, last = samples[0].get(field), samples[-1].get(field)
+    if first is None or last is None or last < first:
+        return None
+    return (last - first) / seconds
+
+
+def _total(records, field):
+    return sum(float(record.get(field, 0.0)) for record in records
+               if math.isfinite(float(record.get(field, 0.0))))
+
+
+def summarize(records):
+    header = records[0]
+    footer = next(record for record in records if record.get("type") == "footer")
+    post = sorted((record for record in records
+                   if record.get("type") == "sample" and record.get("phase") == "post"),
+                  key=lambda record: record.get("t_ns", 0))
+    renderer = [record for record in records if record.get("type") == "renderer"]
+    compute = [record for record in records if record.get("type") == "compute"]
+
+    seconds = None
+    if len(post) >= 2 and post[-1].get("t_ns", 0) > post[0].get("t_ns", 0):
+        seconds = (post[-1]["t_ns"] - post[0]["t_ns"]) / 1e9
+    cpu_cores = _counter_rate(post, "process_cpu_ns", seconds or 0) if seconds else None
+    if cpu_cores is not None:
+        cpu_cores /= 1e9
+
+    rates = {
+        "guest_fps": _counter_rate(post, "guest_presents", seconds or 0) if seconds else None,
+        "rendered_fps": _counter_rate(post, "rendered_frames", seconds or 0) if seconds else None,
+        "host_fps": _counter_rate(post, "host_presented_frames", seconds or 0) if seconds else None,
+    }
+    rss = [record.get("rss_bytes") for record in post if record.get("rss_bytes") is not None]
+
+    graphics_total = _total(renderer, "total_ms")
+    compute_total = _total(compute, "total_ms")
+    measured_total = graphics_total + compute_total
+    gpu_wait_total = _total(renderer, "gpu_wait_ms")
+    gpu_timestamp_samples = sum(int(record.get("gpu_timestamp_samples", 0))
+                                for record in renderer)
+    # A zero device duration has meaning only when Vulkan actually returned timestamps. If any
+    # record paid a GPU wait without timestamp samples, keep the whole wait unsplit rather than
+    # manufacturing "overhead = wait - 0" from unavailable device evidence.
+    gpu_timestamps_available = gpu_timestamp_samples > 0 and all(
+        float(record.get("gpu_wait_ms", 0.0)) <= 0 or
+        int(record.get("gpu_timestamp_samples", 0)) > 0
+        for record in renderer)
+    gpu_device_total = _total(renderer, "gpu_device_ms") if gpu_timestamps_available else None
+    gpu_wait_overhead = (max(0.0, gpu_wait_total - gpu_device_total)
+                         if gpu_timestamps_available else None)
+    components = {
+        # setup_resources is nested in backend, while build_resources is the frontend materializer.
+        "renderer-resource": _total(renderer, "build_resources_ms") +
+                             _total(renderer, "setup_resources_ms"),
+        "gpu-wait": gpu_wait_total,
+        "gpu-device": gpu_device_total,
+        "gpu-wait-overhead": gpu_wait_overhead,
+        "readback": _total(renderer, "readback_ms"),
+        "compute": compute_total,
+    }
+    classification_components = {
+        "renderer-resource": components["renderer-resource"],
+        "readback": components["readback"],
+        "compute": components["compute"],
+    }
+    if gpu_timestamps_available:
+        classification_components["gpu-device"] = gpu_device_total
+        classification_components["gpu-wait-overhead"] = gpu_wait_overhead
+    else:
+        classification_components["gpu-wait"] = gpu_wait_total
+
+    classification = "inconclusive"
+    reason = "the capture does not contain enough post-trigger process and timing data"
+    wall_ms = (seconds or 0) * 1000.0
+    if measured_total > 0:
+        largest, cost = max(classification_components.items(), key=lambda item: item[1])
+        share = cost / measured_total
+        if share >= 0.40:
+            classification = largest
+            reason = f"{largest} is the largest measured component ({cost:.1f} ms, {share:.0%})"
+        elif cpu_cores is not None and cpu_cores >= 0.80 and wall_ms and measured_total < wall_ms * 0.40:
+            classification = "cpu-outside-renderer"
+            reason = (f"the process used {cpu_cores:.2f} CPU cores while measured renderer/compute "
+                      f"work covered only {measured_total / wall_ms:.0%} of the sampled wall window")
+        else:
+            reason = "measured work is split across components; no component reaches the 40% evidence threshold"
+    elif cpu_cores is not None and cpu_cores >= 0.80:
+        classification = "cpu-outside-renderer"
+        reason = (f"the process used {cpu_cores:.2f} CPU cores with no retained renderer/compute "
+                  "timing records")
+
+    pacing_note = None
+    if rates["guest_fps"] is not None and rates["rendered_fps"] is not None:
+        if rates["guest_fps"] > max(1.0, rates["rendered_fps"] * 1.5):
+            pacing_note = ("guest flips materially outpace rendered frames; the capture proves a "
+                           "production/presentation gap but does not assign its cause")
+    if footer["renderer_dropped"] or footer["compute_dropped"]:
+        truncation = (f"detail truncated: renderer dropped {footer['renderer_dropped']}, "
+                      f"compute dropped {footer['compute_dropped']}")
+    else:
+        truncation = "detail not truncated"
+
+    return {
+        "title_id": header.get("title_id", ""),
+        "title": header.get("title", ""),
+        "revision": header.get("revision", "unknown"),
+        "seconds": seconds,
+        "cpu_cores": cpu_cores,
+        "rss_min": min(rss) if rss else None,
+        "rss_max": max(rss) if rss else None,
+        "rates": rates,
+        "graphics_total_ms": graphics_total,
+        "compute_total_ms": compute_total,
+        "gpu_timestamp_samples": gpu_timestamp_samples,
+        "gpu_timestamps_available": gpu_timestamps_available,
+        "components": components,
+        "classification": classification,
+        "reason": reason,
+        "pacing_note": pacing_note,
+        "truncation": truncation,
+        "counts": {
+            "pre": footer["pre_samples"],
+            "post": footer["post_samples"],
+            "renderer": footer["renderer_records"],
+            "compute": footer["compute_records"],
+        },
+    }
+
+
+def _fmt_rate(value):
+    return "unavailable" if value is None else f"{value:.2f}/s"
+
+
+def print_summary(summary):
+    label = summary["title"] or summary["title_id"] or "untitled process"
+    print(f"prosper F8 performance capture: {label}")
+    print(f"revision: {summary['revision']}")
+    counts = summary["counts"]
+    print(f"records: pre={counts['pre']} post={counts['post']} "
+          f"renderer={counts['renderer']} compute={counts['compute']} ({summary['truncation']})")
+    if summary["seconds"] is None:
+        print("post sample window: unavailable (fewer than two ordered samples)")
+    else:
+        print(f"post sample window: {summary['seconds']:.2f} s")
+    cpu = summary["cpu_cores"]
+    print("process CPU: " + ("unavailable" if cpu is None else f"{cpu:.2f} cores"))
+    if summary["rss_min"] is None:
+        print("RSS: unavailable on this platform/run")
+    else:
+        print(f"RSS: {summary['rss_min'] / 2**20:.1f}..{summary['rss_max'] / 2**20:.1f} MiB")
+    rates = summary["rates"]
+    print(f"rates: guest flips={_fmt_rate(rates['guest_fps'])} "
+          f"rendered={_fmt_rate(rates['rendered_fps'])} host-presented={_fmt_rate(rates['host_fps'])}")
+    print(f"measured totals: graphics={summary['graphics_total_ms']:.1f} ms "
+          f"compute={summary['compute_total_ms']:.1f} ms")
+    print(f"GPU timestamps: {summary['gpu_timestamp_samples']} samples " +
+          ("(device/wait split available)" if summary["gpu_timestamps_available"] else
+           "(device/wait split unavailable)"))
+    print("components: " + " ".join(
+        f"{key}=unavailable" if value is None else f"{key}={value:.1f}ms"
+        for key, value in summary["components"].items()))
+    print(f"primary evidence: {summary['classification']} — {summary['reason']}")
+    if summary["pacing_note"]:
+        print(f"pacing: {summary['pacing_note']}")
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("capture", help="completed .prperf file")
+    parser.add_argument("--json", action="store_true", help="emit the derived summary as JSON")
+    args = parser.parse_args(argv)
+    try:
+        summary = summarize(load_capture(args.capture))
+    except CaptureError as exc:
+        print(f"performance_capture_report: {exc}", file=sys.stderr)
+        return 2
+    if args.json:
+        json.dump(summary, sys.stdout, indent=2, sort_keys=True)
+        print()
+    else:
+        print_summary(summary)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/prosper/tools/perf/test_performance_capture_report.py
+++ b/prosper/tools/perf/test_performance_capture_report.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+
+import unittest
+
+from performance_capture_report import CaptureError, summarize, validate_capture
+
+
+def capture(post=None, renderer=None, compute=None, dropped=(0, 0)):
+    post = post or []
+    renderer = renderer or []
+    compute = compute or []
+    records = [{
+        "type": "header", "format": "prosper-performance-capture", "version": 1,
+        "title_id": "TEST00001", "title": "Test Title", "revision": "abc123",
+    }]
+    records.extend({"type": "sample", "phase": "post", **sample} for sample in post)
+    records.extend({"type": "renderer", **record} for record in renderer)
+    records.extend({"type": "compute", **record} for record in compute)
+    records.append({
+        "type": "footer", "complete": True,
+        "pre_samples": 0, "post_samples": len(post),
+        "renderer_records": len(renderer), "compute_records": len(compute),
+        "renderer_dropped": dropped[0], "compute_dropped": dropped[1],
+    })
+    return records
+
+
+SAMPLES = [
+    {"t_ns": 0, "process_cpu_ns": 10, "rss_bytes": 100,
+     "guest_presents": 0, "rendered_frames": 0, "host_presented_frames": 0},
+    {"t_ns": 1_000_000_000, "process_cpu_ns": 1_000_000_010, "rss_bytes": 200,
+     "guest_presents": 60, "rendered_frames": 10, "host_presented_frames": 9},
+]
+
+
+class PerformanceCaptureReportTests(unittest.TestCase):
+    def test_gpu_device_classification(self):
+        summary = summarize(capture(SAMPLES, renderer=[{
+            "total_ms": 100, "gpu_device_ms": 60, "gpu_wait_ms": 65,
+            "gpu_timestamp_samples": 2,
+            "build_resources_ms": 5, "setup_resources_ms": 5, "readback_ms": 2,
+        }]))
+        self.assertEqual(summary["classification"], "gpu-device")
+        self.assertIn("60%", summary["reason"])
+        self.assertTrue(summary["gpu_timestamps_available"])
+        self.assertEqual(summary["components"]["gpu-wait-overhead"], 5)
+
+    def test_gpu_wait_stays_unsplit_when_device_timestamps_are_unavailable(self):
+        summary = summarize(capture(SAMPLES, renderer=[{
+            "total_ms": 100, "gpu_device_ms": 0, "gpu_wait_ms": 65,
+            "gpu_timestamp_samples": 0,
+        }]))
+        self.assertEqual(summary["classification"], "gpu-wait")
+        self.assertFalse(summary["gpu_timestamps_available"])
+        self.assertEqual(summary["components"]["gpu-wait"], 65)
+        self.assertIsNone(summary["components"]["gpu-device"])
+        self.assertIsNone(summary["components"]["gpu-wait-overhead"])
+
+    def test_renderer_resource_classification(self):
+        summary = summarize(capture(SAMPLES, renderer=[{
+            "total_ms": 100, "gpu_device_ms": 10, "gpu_wait_ms": 12,
+            "build_resources_ms": 25, "setup_resources_ms": 25, "readback_ms": 2,
+        }]))
+        self.assertEqual(summary["classification"], "renderer-resource")
+
+    def test_compute_classification(self):
+        summary = summarize(capture(SAMPLES,
+            renderer=[{"total_ms": 20}], compute=[{"total_ms": 80}]))
+        self.assertEqual(summary["classification"], "compute")
+
+    def test_cpu_outside_renderer_classification(self):
+        summary = summarize(capture(SAMPLES, renderer=[{"total_ms": 100}]))
+        self.assertEqual(summary["classification"], "cpu-outside-renderer")
+        self.assertAlmostEqual(summary["cpu_cores"], 1.0, places=3)
+
+    def test_inconclusive_without_post_population(self):
+        summary = summarize(capture())
+        self.assertEqual(summary["classification"], "inconclusive")
+        self.assertIsNone(summary["seconds"])
+
+    def test_pacing_gap_is_evidence_not_cause(self):
+        summary = summarize(capture(SAMPLES, renderer=[{
+            "total_ms": 100, "gpu_device_ms": 60, "gpu_timestamp_samples": 1,
+        }]))
+        self.assertIn("does not assign its cause", summary["pacing_note"])
+
+    def test_dropped_counts_are_reported_not_added_to_population(self):
+        summary = summarize(capture(SAMPLES, renderer=[{"total_ms": 1}], dropped=(7, 9)))
+        self.assertEqual(summary["counts"]["renderer"], 1)
+        self.assertEqual(summary["truncation"], "detail truncated: renderer dropped 7, compute dropped 9")
+
+    def test_footer_must_match_actual_population(self):
+        records = capture(SAMPLES)
+        records[-1]["post_samples"] = 99
+        with self.assertRaisesRegex(CaptureError, "post_samples"):
+            validate_capture(records)
+
+    def test_incomplete_file_is_rejected(self):
+        records = capture(SAMPLES)
+        records.pop()
+        with self.assertRaisesRegex(CaptureError, "incomplete"):
+            validate_capture(records)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Fixes #1820

## What changed

- Add an F8 hotkey to `prosper-app` for a bounded interactive performance capture.
- Keep a cheap 4 Hz rolling ring containing process CPU, RSS, guest flips, rendered frames, and host presents.
- Retain five seconds before the press and enable structured renderer/backend GPU and compute clocks for five seconds after it.
- Publish only complete `.prperf` JSONL artifacts through a private `.part` file and same-directory atomic rename.
- Cap renderer and compute details at 4096 records each with exact dropped counts.
- Add `tools/perf/performance_capture_report.py` to validate the artifact and conservatively localize CPU work, renderer resources, GPU wait/device work, compute, and pacing gaps.
- Document F8 on Linux and Windows and in the tool playbook. F9 frame capture remains independent.

## Behavioral contract

The always-on path performs one atomic due check per app loop and one process sample every 250 ms. Detailed clocks run only after F8 is pressed. F8-only timing collects structured records without enabling the existing high-volume `[render-timing]` or `[render-window]` summaries.

Split graphics spans retain their accumulated timing until the final span. The render_runner timing gate is thread-local and scoped to one live-render callback, so it cannot leak to another caller or thread.

GPU device time is available only when Vulkan timestamp samples exist. When they do not, the report exposes device and device/overhead split as unavailable and reports total GPU wait without inventing a split.

A graceful exit removes an unfinished `.part`; a completed final artifact has a validated header/version, exact footer populations, completeness marker, and explicit truncation counts.

## Verification

All build and test commands ran inside the `ps5ys` distrobox with a worktree-local `TMPDIR`.

```bash
cmake -S prosper -B prosper/build-linux \
  -DPROSPER_APP=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo
cmake --build prosper/build-linux -j6 \
  --target test_performance_capture prosper-app
ctest --test-dir prosper/build-linux --output-on-failure \
  -R "^(performance_capture|performance_capture_report_logic)$"
```

Result: 2/2 focused tests passed.

- `performance_capture`: 39 exact state, scope, bound, collision, serialization, and atomic-publication checks.
- `performance_capture_report_logic`: 10 availability, classification, truncation, and validation tests.
- MinGW C++20 `-Wall -Wextra` compile checks passed for the capture implementation and policy test.
- `git diff --check origin/master..HEAD`: clean.

Mechanism mutations:

1. Making the pre-window predicate impossible failed exactly the three pre-ring population checks.
2. Changing the renderer cap from `<` to `<=` failed exactly the three retained-count/footer bound checks.
3. Resetting timing after every span failed only `split-submit timing retains earlier non-final spans until the final callback`.
4. Merging the F8 measure and logging gates failed only `F8-only timing measures structured data without enabling periodic stderr logs`.
5. Removing scoped timing-gate restoration failed `a nested timing scope restores its prior live-callback state`.
6. Removing GPU timestamp availability failed `test_gpu_wait_stays_unsplit_when_device_timestamps_are_unavailable`.

Every mutation was restored before the final green build.

## Live smoke status

A bounded Syberia run on exact head reached the normal app window, renderer, and compute paths and honored the 150 second process cap. Cleanup passed: no Prosper GPU process remained and no unfinished `.part` was left. The ordinary run emitted no periodic timing summaries.

The actual F8 key and completed live artifact smoke is **inconclusive**, not passed or failed. No human key event arrived before the cap, and native Wayland prevented X11 tooling from positively matching the Prosper PID/title for a safe targeted injection. No unverified global input was sent. A later human F8 press is still needed to validate the live key route and real-title report population.

## Scope notes

- Snapshot tests were not run. They are optional before ordinary PRs and are not useful coverage for this host-side interactive tooling.
- No screenshot is included because this is nonvisual diagnostic infrastructure.
- The report is a broad localizer, not a stack sampler; host CPU findings should be followed with `hostprof`, and graphics findings with the focused replay/timing tools.