### PR TITLE
gpu_replay: dump exact target after semantic operation

### DIFF
--- a/prosper/docs/ASTERIX_BABYLON_STATUS.md
+++ b/prosper/docs/ASTERIX_BABYLON_STATUS.md
@@ -215,15 +215,19 @@ self-validating reproduction.
   4→10, and 10→11, closing that source through four color0-to-color1 copies in the same submit. The
   bounded prefix replay subsequently found the first graphics producer already black; it did not
   reveal a useful-color-to-black boundary or justify a renderer change.
+- **The op6 fixed-function resolve turns a nonblack op4 producer black:** #1825's exact post-operation
+  selector read raw color1 destination `0x2011800000` immediately after op6 as 1920x1080 R11G11B10,
+  hash `792bed5a3f02a383`; an independent pixel census found one opaque color with RGB mean/min/max zero.
+  That matches the earlier exact op4 color0 cutoff (the same hash and pixel census), so this capture
+  contains no nonblack-to-black resolve transition. This is localization evidence only; rung remains 0.
 - **A renderer-disabled title boot as a GPU-free experiment:** live compute remains active without
   `PROSPER_RENDER` and initializes Vulkan when the title dispatches supported compute.
 
 ## Next discriminators
 
-1. Add a generic replay selector that snapshots an exact target address after an exact operation.
-   Use it on `0x2011800000` after operations 6 and 10, and print both selectors beside the output so
-   the experiment proves its own lever moved. Prefix output cannot answer this because it selects
-   color0 for a fixed resolve. This is a tool gap; no new title boot is needed.
+1. If this retained chain is pursued further, use #1825's exact selector on `0x2011800000` after op10.
+   Op6's raw color1 destination is now proven uniformly black; ordinary prefix output still cannot
+   answer op10 because it selects color0 for a fixed resolve. No new title boot is needed.
 2. Treat compute program `0x2011734400` as a candidate only if a discriminator independently proves the
    dispatch ran and reproduces its device loss; two failures in six runs are not a stable cause.
 3. If output becomes non-black, compare source-distinct/pixel-distinct frames and post a screenshot.

--- a/prosper/tests/test_gpu_replay_extent.cpp
+++ b/prosper/tests/test_gpu_replay_extent.cpp
@@ -146,6 +146,138 @@ int main() {
               "capture-extent fallback reports no target rather than a mismatched address");
     }
 
+    // Exact post-operation target selection is a write proof, not an address/binding lookup. This
+    // is the CPU-only policy used by --output-target-after before it asks Vulkan for a readback.
+    {
+        GpuReplayFrame exact;
+        DrawItem writer;
+        writer.draw_index = 41;
+        writer.color_targets[0] = {0x2010000000ull, 1920, 1080};
+        writer.ps.color_targets[0].format = 37; // VK_FORMAT_R8G8B8A8_UNORM
+        writer.ps.color_targets[0].write_mask = 0xf;
+        exact.items = {writer};
+        exact.operations = {{SubmitOperationKind::Draw, 41, 100, true}};
+
+        const auto selected = replay_output_target_after_operation(exact, 0, 0x2010000000ull);
+        CHECK(selected.status == OutputTargetAfterStatus::Selected &&
+                  selected.target.operation_index == 0 && selected.target.draw_index == 41 &&
+                  selected.target.slot == 0 && selected.target.guest_addr == 0x2010000000ull &&
+                  selected.target.width == 1920 && selected.target.height == 1080 &&
+                  selected.target.format == 37 && !selected.target.fixed_function_resolve,
+              "exact selector retains operation/draw/slot/address/extent/format write proof");
+
+        CHECK(replay_output_target_after_operation(exact, 1, 0x2010000000ull).status ==
+                  OutputTargetAfterStatus::InvalidOperation,
+              "exact selector distinguishes an invalid operation index");
+        exact.operations[0].kind = SubmitOperationKind::Dispatch;
+        CHECK(replay_output_target_after_operation(exact, 0, 0x2010000000ull).status ==
+                  OutputTargetAfterStatus::NonDrawOperation,
+              "exact selector distinguishes a non-draw operation");
+        exact.operations[0].kind = SubmitOperationKind::Draw;
+        exact.operations[0].realized = false;
+        CHECK(replay_output_target_after_operation(exact, 0, 0x2010000000ull).status ==
+                  OutputTargetAfterStatus::UnrealizedOperation,
+              "exact selector distinguishes an unrealized draw operation");
+        exact.operations[0].realized = true;
+        exact.operations[0].source_index = 42;
+        CHECK(replay_output_target_after_operation(exact, 0, 0x2010000000ull).status ==
+                  OutputTargetAfterStatus::DrawUnavailable,
+              "exact selector distinguishes missing realized draw state");
+        exact.operations[0].source_index = 41;
+        exact.items[0].ps.color_targets[0].write_mask = 0;
+        CHECK(replay_output_target_after_operation(exact, 0, 0x2010000000ull).status ==
+                  OutputTargetAfterStatus::NotWrittenByOperation,
+              "a merely bound target with zero effective write mask is not an output");
+        exact.items[0].ps.color_targets[0].write_mask = 0xf;
+        exact.items[0].color_targets[0].width = 0;
+        CHECK(replay_output_target_after_operation(exact, 0, 0x2010000000ull).status ==
+                  OutputTargetAfterStatus::TargetIdentityUnavailable,
+              "a written target with incomplete extent fails as unavailable identity");
+    }
+
+    // Fixed-function resolve is the deliberate exception to shader write-mask selection. Its raw
+    // color1 is the destination while color0 is an input, even though both shader masks are zero.
+    // Mutation check: removing the cb_resolve branch above must fail the first named check here.
+    {
+        GpuReplayFrame resolve;
+        DrawItem operation;
+        operation.draw_index = 77;
+        operation.color0_base = 0x2011000000ull;
+        operation.color0_width = 1280;
+        operation.color0_height = 720;
+        operation.color1_base = 0x2011800000ull;
+        operation.color1_width = 1280;
+        operation.color1_height = 720;
+        operation.ps.color0_format = 97; // VK_FORMAT_R16G16B16A16_SFLOAT
+        operation.ps.color1_format = 97;
+        operation.ps.color_write_mask = 0;
+        operation.ps.color1_write_mask = 0;
+        operation.ps.cb_resolve = true;
+        resolve.items = {operation};
+        resolve.operations = {{SubmitOperationKind::Draw, 77, 600, true}};
+
+        const auto destination =
+            replay_output_target_after_operation(resolve, 0, 0x2011800000ull);
+        CHECK(destination.status == OutputTargetAfterStatus::Selected &&
+                  destination.target.slot == 1 && destination.target.format == 97 &&
+                  destination.target.fixed_function_resolve,
+              "MODE=RESOLVE selects raw color1 destination despite zero shader write mask");
+        CHECK(replay_output_target_after_operation(resolve, 0, 0x2011000000ull).status ==
+                  OutputTargetAfterStatus::NotWrittenByOperation,
+              "MODE=RESOLVE never reports raw color0 source as an output");
+    }
+
+    // Direct callers and captures older than complete MRT arrays keep slot 0/1 in named aliases.
+    {
+        GpuReplayFrame legacy;
+        DrawItem writer;
+        writer.draw_index = 5;
+        writer.color0_base = 0x12340000ull;
+        writer.color0_width = 320;
+        writer.color0_height = 180;
+        writer.ps.color0_format = 37;
+        writer.ps.color_write_mask = 0xb;
+        legacy.items = {writer};
+        legacy.operations = {{SubmitOperationKind::Draw, 5, 10, true}};
+        const auto selected = replay_output_target_after_operation(legacy, 0, 0x12340000ull);
+        CHECK(selected.status == OutputTargetAfterStatus::Selected &&
+                  selected.target.width == 320 && selected.target.height == 180 &&
+                  selected.target.format == 37 && selected.target.slot == 0,
+              "exact selector preserves legacy named target aliases");
+    }
+
+    // Bundle operation ordinals are local to each submit. An earlier retained predecessor may have
+    // an identical op/address and still must not receive the final submit's prefix selector.
+    {
+        GpuReplayFrame earlier;
+        DrawItem old_writer;
+        old_writer.draw_index = 11;
+        old_writer.color_targets[0] = {0x2011800000ull, 64, 64};
+        old_writer.ps.color_targets[0].format = 37;
+        old_writer.ps.color_targets[0].write_mask = 0xf;
+        earlier.items = {old_writer};
+        earlier.operations = {{SubmitOperationKind::Draw, 11, 10, true}};
+
+        GpuReplayFrame final = earlier;
+        final.items[0].draw_index = 99;
+        final.items[0].color_targets[0].width = 1280;
+        final.items[0].color_targets[0].height = 720;
+        final.operations[0].source_index = 99;
+
+        const auto predecessor = replay_bundle_output_target_after_operation(
+            earlier, 3, 4, 0, 0x2011800000ull);
+        const auto selected_final = replay_bundle_output_target_after_operation(
+            final, 4, 4, 0, 0x2011800000ull);
+        CHECK(!predecessor.applies_to_submit,
+              "bundle exact selector leaves retained predecessor submit unbounded");
+        CHECK(selected_final.applies_to_submit &&
+                  selected_final.selection.status == OutputTargetAfterStatus::Selected &&
+                  selected_final.selection.target.draw_index == 99 &&
+                  selected_final.selection.target.width == 1280 &&
+                  selected_final.selection.target.height == 720,
+              "bundle exact selector plans against selected final submit only");
+    }
+
     if (fails) { std::printf("== FAIL: %d ==\n", fails); return 1; }
     std::printf("== PASS ==\n");
     return 0;

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -473,6 +473,27 @@ order and all earlier work. Prefix output uses the last executed draw target's n
 a hash-verified seeded final capsule for fast composition bisection; unlike `--draw`, it does not discard
 DMA copies, compute dispatches, or earlier draws.
 
+`--output-target-after OP:ADDR` executes that same inclusive prefix, then reads back exactly the
+render target written at guest address `ADDR` by semantic operation `OP`:
+
+```bash
+tools/gpu_replay --output-target-after 6:0x2011800000 capture.prgcap resolved.bmp
+```
+
+Selection is a write proof, not an address lookup. Ordinary draw attachments require a nonzero
+effective write mask. A fixed-function `CB_COLOR_CONTROL.MODE=RESOLVE` instead names raw color1 as
+its destination despite its zero shader mask; raw color0 is the resolve source and is rejected as
+an output. The selector retains and verifies operation, semantic draw, attachment slot, address,
+extent, and exact raw/backend Vulkan format at readback. It fails visibly and distinctly for an
+invalid operation, a non-draw or unrealized operation, an address that operation did not write, an
+incomplete target identity, or an unavailable/mismatched retained version. This is the appropriate
+probe when `--through-operation` publishes a different last draw target than the intermediate
+surface being investigated. With `--bundle`, the operation/address selector applies only to the
+final submit left after `--bundle-tail` / `--bundle-through-submit`; retained predecessor submits
+execute completely, while that final submit stops at the requested inclusive prefix. Existing
+bundle intermediate/output selectors are mutually exclusive because they name a different output
+policy.
+
 **Always read `target=` before comparing two cutoffs.** Because prefix output follows the *last executed draw
 target*, adjacent cutoffs can render two completely different buffers, and comparing them then looks like one
 surface changing. The render summary names the surface it selected:

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -5,6 +5,7 @@
 #include "gpu/gpu_execute.hpp"
 #include "gpu/shader_resources.hpp"
 #include "live_renderer.hpp"
+#include "live_target_format.hpp"
 #include "replay_output_extent.hpp"
 #include "compute_recompile.hpp"
 #include "realized_shader_dump.hpp"
@@ -50,6 +51,7 @@ void usage(const char* argv0) {
     std::fprintf(stderr, "usage: %s [--inspect|--inspect-only|--validate|--graph] "
                          "[--graph-json PATH] [--draw N[:M]] [--draw-with-compute-prefix] "
                          "[--through-operation N] [--compute-only N] [--warmup-repeats N] "
+                         "[--output-target-after OP:ADDR] "
                          "[--bundle capture.prgbundle] [--bundle-tail N] "
                          "[--bundle-through-submit N] [--bundle-compact PATH] "
                          "[--bundle-intermediate-through-target WxH] "
@@ -158,6 +160,131 @@ std::vector<uint8_t> inspect_live_target(const prosper::gpu::LiveTargetSnapshot&
             break;
     }
     return inspect_rtt_seed(seed);
+}
+
+bool plan_exact_output_target(
+    const prosper::gpu::GpuReplayFrame& replay, size_t operation_index, uint64_t guest_addr,
+    prosper::gpu::replay_tool::OutputTargetAfterOperation& target,
+    uint64_t bundle_submit = UINT64_MAX) {
+    const auto selected = prosper::gpu::replay_tool::replay_output_target_after_operation(
+        replay, operation_index, guest_addr);
+    using Status = prosper::gpu::replay_tool::OutputTargetAfterStatus;
+    if (selected.status != Status::Selected) {
+        switch (selected.status) {
+            case Status::InvalidOperation:
+                std::fprintf(stderr, "gpu_replay: output-target operation %zu is out of range\n",
+                             operation_index);
+                break;
+            case Status::NonDrawOperation:
+                std::fprintf(stderr,
+                             "gpu_replay: output-target operation %zu is %s, not a draw\n",
+                             operation_index,
+                             operation_kind_name(replay.operations[operation_index].kind));
+                break;
+            case Status::UnrealizedOperation:
+                std::fprintf(stderr,
+                             "gpu_replay: output-target operation %zu is an unrealized draw\n",
+                             operation_index);
+                break;
+            case Status::DrawUnavailable:
+                std::fprintf(stderr,
+                             "gpu_replay: output-target operation %zu names unavailable "
+                             "realized draw=%llu\n",
+                             operation_index,
+                             static_cast<unsigned long long>(
+                                 replay.operations[operation_index].source_index));
+                break;
+            case Status::NotWrittenByOperation:
+                std::fprintf(stderr,
+                             "gpu_replay: output-target operation %zu draw=%llu does not "
+                             "write addr=%016llx\n",
+                             operation_index,
+                             static_cast<unsigned long long>(
+                                 replay.operations[operation_index].source_index),
+                             static_cast<unsigned long long>(guest_addr));
+                break;
+            case Status::TargetIdentityUnavailable:
+                std::fprintf(stderr,
+                             "gpu_replay: output-target operation %zu writes addr=%016llx "
+                             "but its exact extent/format identity is unavailable\n",
+                             operation_index, static_cast<unsigned long long>(guest_addr));
+                break;
+            case Status::Selected:
+                break;
+        }
+        return false;
+    }
+    target = selected.target;
+    char submit_tag[64] = {};
+    if (bundle_submit != UINT64_MAX)
+        std::snprintf(submit_tag, sizeof submit_tag, " submit=%llu",
+                      static_cast<unsigned long long>(bundle_submit));
+    std::fprintf(stderr,
+                 "[gpureplay] armed exact output%s op=%zu draw=%llu slot=%u addr=%016llx "
+                 "extent=%ux%u format=%u resolve=%s\n",
+                 submit_tag, target.operation_index,
+                 static_cast<unsigned long long>(target.draw_index),
+                 target.slot, static_cast<unsigned long long>(target.guest_addr), target.width,
+                 target.height, target.format, target.fixed_function_resolve ? "yes" : "no");
+    return true;
+}
+
+bool read_exact_output_target(
+    const prosper::gpu::replay_tool::OutputTargetAfterOperation& target,
+    std::vector<uint8_t>& pixels, uint64_t bundle_submit = UINT64_MAX) {
+    prosper::gpu::LiveTargetSnapshot snapshot;
+    const VkFormat requested_raw_format = static_cast<VkFormat>(target.format);
+    const VkFormat requested_backend_format =
+        prosper::test::backend_color_format(requested_raw_format);
+    if (!prosper::gpu::read_live_render_target(target.guest_addr, snapshot)) {
+        std::fprintf(stderr,
+                     "gpu_replay: exact output readback unavailable op=%zu draw=%llu slot=%u "
+                     "addr=%016llx extent=%ux%u format=%u/%u\n",
+                     target.operation_index, static_cast<unsigned long long>(target.draw_index),
+                     target.slot, static_cast<unsigned long long>(target.guest_addr), target.width,
+                     target.height, target.format,
+                     static_cast<unsigned>(requested_backend_format));
+        return false;
+    }
+    const VkFormat readback_format =
+        prosper::frontend::live_target_pixel_format_vk(snapshot.format);
+    if (snapshot.width != target.width || snapshot.height != target.height ||
+        readback_format != requested_backend_format) {
+        std::fprintf(stderr,
+                     "gpu_replay: exact output readback identity mismatch op=%zu draw=%llu "
+                     "slot=%u addr=%016llx requested=%ux%u/%u/%u actual=%ux%u/%u\n",
+                     target.operation_index, static_cast<unsigned long long>(target.draw_index),
+                     target.slot, static_cast<unsigned long long>(target.guest_addr), target.width,
+                     target.height, target.format,
+                     static_cast<unsigned>(requested_backend_format), snapshot.width,
+                     snapshot.height, static_cast<unsigned>(readback_format));
+        return false;
+    }
+    pixels = inspect_live_target(snapshot);
+    const uint64_t expected_bytes =
+        static_cast<uint64_t>(target.width) * target.height * 4u;
+    if (expected_bytes > SIZE_MAX || pixels.size() != static_cast<size_t>(expected_bytes)) {
+        std::fprintf(stderr,
+                     "gpu_replay: exact output conversion unavailable op=%zu addr=%016llx "
+                     "expected=%llu actual=%zu\n",
+                     target.operation_index, static_cast<unsigned long long>(target.guest_addr),
+                     static_cast<unsigned long long>(expected_bytes), pixels.size());
+        return false;
+    }
+    char submit_tag[64] = {};
+    if (bundle_submit != UINT64_MAX)
+        std::snprintf(submit_tag, sizeof submit_tag, " submit=%llu",
+                      static_cast<unsigned long long>(bundle_submit));
+    std::fprintf(stderr,
+                 "[gpureplay] exact output%s op=%zu draw=%llu slot=%u addr=%016llx "
+                 "extent=%ux%u format=%u/%u bytes=%zu hash=%016llx\n",
+                 submit_tag, target.operation_index,
+                 static_cast<unsigned long long>(target.draw_index),
+                 target.slot, static_cast<unsigned long long>(target.guest_addr), target.width,
+                 target.height, target.format, static_cast<unsigned>(requested_backend_format),
+                 pixels.size(),
+                 static_cast<unsigned long long>(prosper::gpu::gpu_capture_hash(pixels)));
+    return true;
 }
 
 struct PostComputeDumpRequest {
@@ -1017,6 +1144,7 @@ int replay_bundle(const std::string& path, const char* output_path, bool zero_bo
                   const std::string& compact_path,
                   uint32_t intermediate_target_width, uint32_t intermediate_target_height,
                   uint32_t output_target_width, uint32_t output_target_height,
+                  size_t output_target_after_operation, uint64_t output_target_after_addr,
                   const std::string& final_capsule_path,
                   uint64_t extract_submit_no, const std::string& extract_submit_path,
                   uint64_t find_ds_addr, bool ds_summary) {
@@ -1154,6 +1282,29 @@ int replay_bundle(const std::string& path, const char* output_path, bool zero_bo
     const bool expected_output_valid = final_capture.expected_output_valid;
     const uint64_t expected_output_bytes = final_capture.expected_output_bytes;
     const uint64_t expected_output_hash = final_capture.expected_output_hash;
+    prosper::gpu::replay_tool::OutputTargetAfterOperation exact_bundle_output_target;
+    if (output_target_after_operation != SIZE_MAX) {
+        prosper::gpu::GpuReplayFrame final_replay;
+        if (!prosper::gpu::materialize_gpu_replay(final_capture, final_replay, error)) {
+            std::fprintf(stderr, "gpu_replay: cannot materialize final bundle submit: %s\n",
+                         error.c_str());
+            return 2;
+        }
+        const size_t final_submit_index = bundle.submits.size() - 1;
+        const auto selected =
+            prosper::gpu::replay_tool::replay_bundle_output_target_after_operation(
+                final_replay, final_submit_index, final_submit_index,
+                output_target_after_operation, output_target_after_addr);
+        if (!selected.applies_to_submit) {
+            std::fprintf(stderr,
+                         "gpu_replay: exact output selector did not apply to final bundle submit\n");
+            return 2;
+        }
+        if (!plan_exact_output_target(final_replay, output_target_after_operation,
+                                      output_target_after_addr, exact_bundle_output_target,
+                                      final_metadata.submit_index))
+            return 2;
+    }
     for (const auto& [name, value] : final_capture.metadata.renderer_env)
         if (!set_environment(name, value)) {
             std::fprintf(stderr, "gpu_replay: cannot set %s\n", name.c_str()); return 2;
@@ -1206,7 +1357,21 @@ int replay_bundle(const std::string& path, const char* output_path, bool zero_bo
         for (size_t item_index = 0; item_index < replay.items.size(); ++item_index)
             draw_item_by_index[replay.items[item_index].draw_index] = item_index;
         size_t operation_limit = replay.operations.size();
-        if (i + 1 < bundle.submits.size() && intermediate_target_width) {
+        const auto exact_for_submit = output_target_after_operation != SIZE_MAX
+            ? prosper::gpu::replay_tool::replay_bundle_output_target_after_operation(
+                  replay, i, bundle.submits.size() - 1,
+                  output_target_after_operation, output_target_after_addr)
+            : prosper::gpu::replay_tool::BundleOutputTargetAfterSelection{};
+        if (exact_for_submit.applies_to_submit) {
+            if (exact_for_submit.selection.status !=
+                prosper::gpu::replay_tool::OutputTargetAfterStatus::Selected) {
+                std::fprintf(stderr,
+                             "gpu_replay: final bundle submit exact output plan changed after "
+                             "preflight validation\n");
+                return 2;
+            }
+            operation_limit = exact_for_submit.selection.target.operation_index + 1;
+        } else if (i + 1 < bundle.submits.size() && intermediate_target_width) {
             operation_limit = 0;
             for (size_t operation_index = 0; operation_index < replay.operations.size(); ++operation_index) {
                 const auto& operation = replay.operations[operation_index];
@@ -1393,6 +1558,10 @@ int replay_bundle(const std::string& path, const char* output_path, bool zero_bo
             return 2;
         }
         final_pixels = execute_frame(replay, false, operation_limit);
+        if (exact_for_submit.applies_to_submit &&
+            !read_exact_output_target(exact_bundle_output_target, final_pixels,
+                                      capture.metadata.submit_index))
+            return 2;
         if (output_target_width) {
             const auto target = prosper::gpu::replay_tool::replay_last_target_matching_extent(
                 replay, output_target_width, output_target_height, operation_limit);
@@ -1481,13 +1650,18 @@ int replay_bundle(const std::string& path, const char* output_path, bool zero_bo
                      final_pixels.size(),
                      static_cast<unsigned long long>(prosper::gpu::gpu_capture_hash(final_pixels)));
     }
+    const uint32_t dump_width = exact_bundle_output_target
+        ? exact_bundle_output_target.width
+        : output_target_width ? output_target_width : final_metadata.width;
+    const uint32_t dump_height = exact_bundle_output_target
+        ? exact_bundle_output_target.height
+        : output_target_height ? output_target_height : final_metadata.height;
     if (output_path && !final_pixels.empty() &&
         !prosper::test::dump_bmp(output_path, final_pixels,
-                                 output_target_width ? output_target_width : final_metadata.width,
-                                 output_target_height ? output_target_height : final_metadata.height)) {
+                                 dump_width, dump_height)) {
         std::fprintf(stderr, "gpu_replay: cannot write %s\n", output_path); return 2;
     }
-    if (!output_target_width && expected_output_valid &&
+    if (!output_target_width && !exact_bundle_output_target && expected_output_valid &&
         (final_pixels.size() != expected_output_bytes ||
          prosper::gpu::gpu_capture_hash(final_pixels) != expected_output_hash)) {
         std::fprintf(stderr, "gpu_replay: bundle output mismatch\n"); return 1;
@@ -1511,6 +1685,8 @@ int main(int argc, char** argv) {
     bool draw_selected = false;
     uint64_t draw_first = 0, draw_last = 0;
     int through_operation = -1;
+    size_t output_target_after_operation = SIZE_MAX;
+    uint64_t output_target_after_addr = 0;
     int compute_only = -1;
     std::string draw_steps_prefix;     // --draw-steps PREFIX: filmstrip of the composite per operation-step
     int draw_steps_every = 0;          // --draw-steps-every N (0 = auto ~30 frames)
@@ -1614,6 +1790,28 @@ int main(int argc, char** argv) {
             if (!end || *end || value < 0 || value > INT_MAX) { usage(argv[0]); return 2; }
             through_operation = static_cast<int>(value);
         }
+        else if (std::string(argv[i]) == "--output-target-after" && i + 1 < argc) {
+            const char* spec = argv[++i];
+            char* operation_end = nullptr;
+            errno = 0;
+            const unsigned long long operation = std::strtoull(spec, &operation_end, 0);
+            if (*spec == '-' || errno == ERANGE || !operation_end || operation_end == spec ||
+                *operation_end != ':' || operation >= SIZE_MAX) {
+                usage(argv[0]); return 2;
+            }
+            const char* address_begin = operation_end + 1;
+            char* address_end = nullptr;
+            errno = 0;
+            const unsigned long long address =
+                std::strtoull(address_begin, &address_end, 0);
+            if (*address_begin == '-' || errno == ERANGE || !address_end ||
+                address_end == address_begin ||
+                *address_end || !address) {
+                usage(argv[0]); return 2;
+            }
+            output_target_after_operation = static_cast<size_t>(operation);
+            output_target_after_addr = static_cast<uint64_t>(address);
+        }
         else if (std::string(argv[i]) == "--compute-only" && i + 1 < argc) {
             char* end = nullptr;
             const long value = std::strtol(argv[++i], &end, 0);
@@ -1680,6 +1878,12 @@ int main(int argc, char** argv) {
         set_environment("PROSPER_GPU_REPLAY_LEGACY_HTILE_BEFORE_STENCIL", "1");
     if (!bundle_path.empty()) {
         if (bundle_ds_summary && bundle_find_ds_addr) { usage(argv[0]); return 2; }
+        if (output_target_after_operation != SIZE_MAX &&
+            (bundle_intermediate_target_width || bundle_output_target_width ||
+             !bundle_compact_path.empty() || !bundle_final_capsule_path.empty() ||
+             !bundle_extract_submit_path.empty() || bundle_find_ds_addr || bundle_ds_summary)) {
+            usage(argv[0]); return 2;
+        }
         if (positional.size() > 1 || inspect || inspect_only || validate_only || graph_only ||
             draw_selected || draw_with_compute_prefix || through_operation >= 0 ||
             compute_only >= 0 ||
@@ -1693,6 +1897,10 @@ int main(int argc, char** argv) {
             !prepend_path.empty() || !draw_steps_prefix.empty()) {
             usage(argv[0]); return 2;
         }
+        if (output_target_after_operation != SIZE_MAX &&
+            !set_environment("PROSPER_PREFIX_INSPECT", "1")) {
+            std::fprintf(stderr, "gpu_replay: cannot set PROSPER_PREFIX_INSPECT\n"); return 2;
+        }
         return replay_bundle(bundle_path, positional.empty() ? nullptr : positional[0],
                              bundle_zero_boundary, bundle_tail, bundle_through_submit_no,
                              bundle_compact_path,
@@ -1700,6 +1908,8 @@ int main(int argc, char** argv) {
                              bundle_intermediate_target_height,
                              bundle_output_target_width,
                              bundle_output_target_height,
+                             output_target_after_operation,
+                             output_target_after_addr,
                              bundle_final_capsule_path,
                              bundle_extract_submit_no,
                              bundle_extract_submit_path,
@@ -1715,6 +1925,10 @@ int main(int argc, char** argv) {
     }
     if (positional.empty() || positional.size() > 2) { usage(argv[0]); return 2; }
     if ((draw_selected && through_operation >= 0) ||
+        (output_target_after_operation != SIZE_MAX &&
+         (draw_selected || through_operation >= 0 || compute_only >= 0 ||
+          inspect_only || validate_only || graph_only || warmup_repeats ||
+          !draw_steps_prefix.empty())) ||
         (compute_only >= 0 && (draw_selected || through_operation >= 0))) {
         usage(argv[0]); return 2;
     }
@@ -1724,7 +1938,8 @@ int main(int argc, char** argv) {
     }
     if (!post_compute_resource_spec.empty() &&
         (inspect_only || validate_only || graph_only || draw_selected ||
-         through_operation >= 0 || compute_only >= 0 || warmup_repeats ||
+         through_operation >= 0 || output_target_after_operation != SIZE_MAX ||
+         compute_only >= 0 || warmup_repeats ||
          !prepend_path.empty() || !draw_steps_prefix.empty())) {
         usage(argv[0]); return 2;
     }
@@ -1736,7 +1951,8 @@ int main(int argc, char** argv) {
     // #1330: ordered-prefix inspection modes must see the pass a prefix actually ends on, even when
     // that pass renders a non-RGBA8 target (an FP16 HDR scene). The shared live renderer publishes an
     // inspection-converted fallback only under this env, so full replays and live runs are unchanged.
-    if ((draw_selected || through_operation >= 0 || !draw_steps_prefix.empty() ||
+    if ((draw_selected || through_operation >= 0 ||
+         output_target_after_operation != SIZE_MAX || !draw_steps_prefix.empty() ||
          !post_compute_resource_spec.empty()) &&
         !set_environment("PROSPER_PREFIX_INSPECT", "1")) {
         std::fprintf(stderr, "gpu_replay: cannot set PROSPER_PREFIX_INSPECT\n"); return 2;
@@ -2550,6 +2766,13 @@ int main(int argc, char** argv) {
         allow_mismatch = true;
         std::fprintf(stderr, "[gpureplay] executing through mixed operation %d\n", through_operation);
     }
+    prosper::gpu::replay_tool::OutputTargetAfterOperation exact_output_target;
+    if (output_target_after_operation != SIZE_MAX) {
+        if (!plan_exact_output_target(replay, output_target_after_operation,
+                                      output_target_after_addr, exact_output_target))
+            return 2;
+        allow_mismatch = true;
+    }
     const auto& m = replay.metadata;
     std::fprintf(stderr, "[gpureplay] rev=%s title=%s submit=%llu %ux%u draws=%zu computes=%zu "
                          "operations=%zu shaders=%zu failed=%zu raw-shaders=%zu blobs=%zu "
@@ -2677,11 +2900,14 @@ int main(int argc, char** argv) {
         }
         return 0;
     }
-    const size_t operation_limit = through_operation >= 0
-        ? static_cast<size_t>(through_operation) + 1 : selected_operation_limit;
+    const size_t operation_limit = exact_output_target
+        ? exact_output_target.operation_index + 1
+        : through_operation >= 0
+            ? static_cast<size_t>(through_operation) + 1 : selected_operation_limit;
     const bool selected_draws_only = draw_selected && !draw_with_compute_prefix;
     std::vector<uint8_t> pixels = execute_frame(
         replay, selected_draws_only, operation_limit, post_compute_dump_ptr);
+    if (exact_output_target && !read_exact_output_target(exact_output_target, pixels)) return 2;
     if (post_compute_dump_ptr) {
         if (post_compute_dump.execution_count != 1) {
             std::fprintf(stderr,
@@ -2846,19 +3072,31 @@ int main(int argc, char** argv) {
     }
     const auto extent_mode = selected_draws_only
         ? prosper::gpu::replay_tool::OutputExtentMode::SelectedDraws
-        : (through_operation >= 0 || (draw_selected && draw_with_compute_prefix))
+        : (through_operation >= 0 || exact_output_target ||
+           (draw_selected && draw_with_compute_prefix))
             ? prosper::gpu::replay_tool::OutputExtentMode::OrderedPrefix
             : prosper::gpu::replay_tool::OutputExtentMode::Capture;
-    const auto output_extent = prosper::gpu::replay_tool::replay_output_extent(
-        replay, extent_mode, pixels.size(), operation_limit);
+    const auto output_extent = exact_output_target
+        ? prosper::gpu::replay_tool::OutputExtent{
+              exact_output_target.width, exact_output_target.height,
+              exact_output_target.guest_addr, exact_output_target.draw_index}
+        : prosper::gpu::replay_tool::replay_output_extent(
+              replay, extent_mode, pixels.size(), operation_limit);
     const uint32_t output_width = output_extent.width;
     const uint32_t output_height = output_extent.height;
     uint64_t hash = prosper::gpu::gpu_capture_hash(pixels);
     // Name the surface, not just its size. A prefix replay renders the LAST EXECUTED DRAW TARGET, so
     // adjacent `--through-operation` cutoffs can report two different buffers; without the address that
     // reads as one surface changing. `target=` makes such a comparison self-invalidating.
-    char target_tag[64] = " target=capture";
-    if (output_extent.target_addr)
+    char target_tag[192] = " target=capture";
+    if (exact_output_target)
+        std::snprintf(target_tag, sizeof target_tag,
+                      " target=%016llx op=%zu draw=%llu slot=%u format=%u",
+                      static_cast<unsigned long long>(exact_output_target.guest_addr),
+                      exact_output_target.operation_index,
+                      static_cast<unsigned long long>(exact_output_target.draw_index),
+                      exact_output_target.slot, exact_output_target.format);
+    else if (output_extent.target_addr)
         std::snprintf(target_tag, sizeof target_tag, " target=%016llx draw=%llu",
                       static_cast<unsigned long long>(output_extent.target_addr),
                       static_cast<unsigned long long>(output_extent.target_draw_index));

--- a/prosper/tools/gpu_replay/replay_output_extent.hpp
+++ b/prosper/tools/gpu_replay/replay_output_extent.hpp
@@ -39,6 +39,138 @@ struct OutputTarget {
     explicit operator bool() const { return guest_addr && width && height; }
 };
 
+// Exact render-target identity selected for post-operation inspection. Unlike OutputTarget's
+// extent-only search, this plan is tied to one semantic operation and retains the VkFormat-valued
+// raw pipeline format plus the attachment slot which proved the write. The renderer readback must
+// compare every field; looking the format up again by address would allow a later alias/version to
+// masquerade as the requested surface.
+struct OutputTargetAfterOperation {
+    size_t operation_index = SIZE_MAX;
+    uint64_t guest_addr = 0;
+    uint32_t width = 0;
+    uint32_t height = 0;
+    uint32_t format = 0;
+    uint64_t draw_index = 0;
+    uint32_t slot = UINT32_MAX;
+    bool fixed_function_resolve = false;
+
+    explicit operator bool() const {
+        return operation_index != SIZE_MAX && guest_addr && width && height && format &&
+               draw_index != UINT64_MAX && slot < kColorTargetCount;
+    }
+};
+
+enum class OutputTargetAfterStatus {
+    Selected,
+    InvalidOperation,
+    NonDrawOperation,
+    UnrealizedOperation,
+    DrawUnavailable,
+    NotWrittenByOperation,
+    TargetIdentityUnavailable,
+};
+
+struct OutputTargetAfterSelection {
+    OutputTargetAfterStatus status = OutputTargetAfterStatus::InvalidOperation;
+    OutputTargetAfterOperation target;
+};
+
+struct BundleOutputTargetAfterSelection {
+    bool applies_to_submit = false;
+    OutputTargetAfterSelection selection;
+};
+
+inline DrawItem::ColorTargetBinding replay_color_binding(const DrawItem& draw, uint32_t slot) {
+    auto binding = draw.color_targets[slot];
+    // Capture versions through v33 and direct synthetic callers retain MRT0/MRT1 in named aliases.
+    if (!binding.base && !binding.width && !binding.height && slot == 0)
+        binding = {draw.color0_base, draw.color0_width, draw.color0_height};
+    else if (!binding.base && !binding.width && !binding.height && slot == 1)
+        binding = {draw.color1_base, draw.color1_width, draw.color1_height};
+    return binding;
+}
+
+inline uint32_t replay_color_format(const DrawItem& draw, uint32_t slot) {
+    uint32_t format = draw.ps.color_targets[slot].format;
+    if (!format && slot == 0) format = draw.ps.color0_format;
+    else if (!format && slot == 1) format = draw.ps.color1_format;
+    return format;
+}
+
+inline uint32_t replay_color_write_mask(const DrawItem& draw, uint32_t slot) {
+    const auto& target = draw.ps.color_targets[slot];
+    uint32_t write_mask = target.write_mask;
+    // Mirror the live renderer's legacy-alias discriminator. A complete-MRT binding with a zero
+    // mask is intentionally not rescued by a named legacy field.
+    if (slot == 0 && !target.format && !draw.color_targets[slot].base)
+        write_mask = draw.ps.color_write_mask;
+    else if (slot == 1 && !target.format && !draw.color_targets[slot].base)
+        write_mask = draw.ps.color1_write_mask;
+    return write_mask;
+}
+
+// Select ADDR only when semantic operation OP actually writes it. An ordinary draw needs a nonzero
+// effective target write mask. CB_COLOR_CONTROL.MODE=RESOLVE is different fixed-function work: its
+// raw color1 binding is the destination even though the pixel shader exports nothing and therefore
+// has a zero shader/write mask; raw color0 is only the source and must never be reported as output.
+inline OutputTargetAfterSelection replay_output_target_after_operation(
+    const GpuReplayFrame& replay, size_t operation_index, uint64_t guest_addr) {
+    if (operation_index >= replay.operations.size())
+        return {OutputTargetAfterStatus::InvalidOperation, {}};
+    const auto& operation = replay.operations[operation_index];
+    if (operation.kind != SubmitOperationKind::Draw)
+        return {OutputTargetAfterStatus::NonDrawOperation, {}};
+    if (!operation.realized)
+        return {OutputTargetAfterStatus::UnrealizedOperation, {}};
+    const auto found = std::find_if(replay.items.begin(), replay.items.end(),
+        [&](const DrawItem& draw) { return draw.draw_index == operation.source_index; });
+    if (found == replay.items.end())
+        return {OutputTargetAfterStatus::DrawUnavailable, {}};
+
+    const DrawItem& draw = *found;
+    uint32_t selected_slot = UINT32_MAX;
+    if (draw.ps.cb_resolve) {
+        // Fixed-function resolve has exactly one color output: raw color1. Do not consider color0,
+        // and do not consult color1_write_mask (it is expected to be zero for this operation).
+        if (replay_color_binding(draw, 1).base == guest_addr) selected_slot = 1;
+    } else {
+        for (uint32_t slot = 0; slot < kColorTargetCount; ++slot) {
+            if (replay_color_binding(draw, slot).base == guest_addr &&
+                replay_color_write_mask(draw, slot)) {
+                selected_slot = slot;
+                break;
+            }
+        }
+    }
+    if (selected_slot == UINT32_MAX)
+        return {OutputTargetAfterStatus::NotWrittenByOperation, {}};
+
+    const auto binding = replay_color_binding(draw, selected_slot);
+    const uint32_t format = replay_color_format(draw, selected_slot);
+    if (!binding.base || !binding.width || !binding.height || !format)
+        return {OutputTargetAfterStatus::TargetIdentityUnavailable, {}};
+    OutputTargetAfterOperation target;
+    target.operation_index = operation_index;
+    target.guest_addr = binding.base;
+    target.width = binding.width;
+    target.height = binding.height;
+    target.format = format;
+    target.draw_index = draw.draw_index;
+    target.slot = selected_slot;
+    target.fixed_function_resolve = draw.ps.cb_resolve;
+    return {OutputTargetAfterStatus::Selected, target};
+}
+
+// Bundle operation ordinals are submit-local. Apply an exact selector only to the final submit left
+// after the caller's tail/through-submit selection; an earlier retained predecessor must execute in
+// full even if it happens to contain the same operation/address pair.
+inline BundleOutputTargetAfterSelection replay_bundle_output_target_after_operation(
+    const GpuReplayFrame& replay, size_t current_submit_index, size_t selected_final_submit_index,
+    size_t operation_index, uint64_t guest_addr) {
+    if (current_submit_index != selected_final_submit_index) return {};
+    return {true, replay_output_target_after_operation(replay, operation_index, guest_addr)};
+}
+
 // Return the last realized color target with the requested native extent in an ordered prefix.
 // A frame-ending submit may finish with an auxiliary 1x1 draw after producing its 4K scanout, so
 // byte-count inference alone cannot identify the displayed surface. Keep the choice explicit and


### PR DESCRIPTION
Closes #1825.

## Why

`--through-operation` publishes the last ordinary draw target. That cannot inspect a fixed-function `CB_COLOR_CONTROL.MODE=RESOLVE` destination: the resolve writes raw color1 despite a zero shader write mask, while the old output path follows color0. The resulting BMP can therefore look authoritative while showing the wrong surface.

## What changed

- adds `--output-target-after OP:ADDR` for capsules and retained bundles
- builds a pure CPU plan tied to the exact semantic operation, draw, attachment slot, guest address, extent, and raw Vulkan format
- treats ordinary targets as outputs only with a nonzero effective write mask
- treats MODE=RESOLVE raw color1 as the sole output and never reports color0 as an output
- preserves legacy named slot 0/1 aliases for older captures
- applies bundle selectors only to the final submit left after `--bundle-tail` / `--bundle-through-submit`; predecessors execute fully
- verifies exact extent and backend format at readback, with distinct failures for invalid operation, non-draw/unrealized operation, not-written target, incomplete identity, unavailable readback, and mismatched retained identity
- prints submit/op/draw/slot/address/extent/raw+backend format beside bytes/hash
- documents the Asterix negative localization result without changing its compatibility rung

## Retained Asterix proof

One externally capped replay of the verified #1599 F9 bundle exited 0 in 0.64 seconds:

```text
gpu_replay --bundle <BUNDLE> --bundle-tail 1 \
  --output-target-after 6:0x2011800000 <OUTPUT.bmp>

[gpureplay] armed exact output submit=180 op=6 draw=2 slot=1 addr=0000002011800000 extent=1920x1080 format=122 resolve=yes
[gpureplay] exact output submit=180 op=6 draw=2 slot=1 addr=0000002011800000 extent=1920x1080 format=122/122 bytes=8294400 hash=792bed5a3f02a383
[gpureplay] bundle-submit=180 operations=7/14 output_bytes=8294400 hash=792bed5a3f02a383
```

An independent CPU pixel census found exactly one opaque color with RGB mean/min/max and standard deviation zero. The op6 raw color1 destination is uniformly black, matching the already-black op4 producer; this capture has no useful-color-to-black resolve transition. This is localization evidence only, with no visual/rung claim. No screenshot is attached because the output is black-only.

## Validation

```text
cmake --build prosper/build-linux --target test_gpu_replay_extent gpu_replay -j8
ctest --test-dir prosper/build-linux --output-on-failure \
  -R "^(gpu_replay_output_extent|doc_table_checker)$"

2/2 passed
```

Mutation control: removing only the resolve destination exception fails exactly `MODE=RESOLVE selects raw color1 destination despite zero shader write mask`; the other 26 named checks, including both bundle-final checks and the color0-source rejection, remain green.

Snapshot tests were not run; this focused replay-tool change has direct CPU policy coverage and the project requires the full snapshot suite before releases rather than every PR.