### PR TITLE
F8 performance capture: attribute compute cost by stable program

### DIFF
--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -6731,6 +6731,19 @@ bool execute_live_compute_items(const std::vector<prosper::gpu::ComputeItem>& it
             prosper::perf::ComputeTimingRecord record;
             record.dispatches = items.size();
             record.cpu_fast_total = g_cpu_fill_dispatches.load(std::memory_order_relaxed);
+            if (!items.empty() && items.front().code_addr && !items.front().spirv.empty()) {
+                const auto& first = items.front();
+                const bool homogeneous = std::all_of(
+                    items.begin() + 1, items.end(), [&](const auto& item) {
+                        return item.code_addr == first.code_addr && item.spirv == first.spirv;
+                    });
+                if (homogeneous) {
+                    record.program_addr = first.code_addr;
+                    record.program_hash = prosper::gpu::gpu_capture_hash(
+                        reinterpret_cast<const uint8_t*>(first.spirv.data()),
+                        first.spirv.size() * sizeof(uint32_t));
+                }
+            }
             record.total_ms = elapsed;
             prosper::perf::interactive_performance_capture().record_compute(record);
         }

--- a/prosper/frontends/shared/performance_capture.cpp
+++ b/prosper/frontends/shared/performance_capture.cpp
@@ -370,7 +370,11 @@ void InteractivePerformanceCapture::publish_completed(std::unique_ptr<PendingCap
                 << relative_ns(record.monotonic_ns, capture->trigger_ns)
                 << ",\"dispatches\":" << record.dispatches
                 << ",\"cpu_fast_total\":" << record.cpu_fast_total
-                << ",\"total_ms\":" << record.total_ms << "}\n";
+                << ",\"program_addr\":";
+            write_optional(out, record.program_addr);
+            out << ",\"program_hash\":";
+            write_optional(out, record.program_hash);
+            out << ",\"total_ms\":" << record.total_ms << "}\n";
         }
         out << "{\"type\":\"footer\",\"complete\":true,\"pre_samples\":"
             << capture->pre_samples.size() << ",\"post_samples\":" << capture->post_samples.size()

--- a/prosper/frontends/shared/performance_capture.hpp
+++ b/prosper/frontends/shared/performance_capture.hpp
@@ -51,6 +51,11 @@ struct ComputeTimingRecord {
     uint64_t monotonic_ns = 0;
     uint64_t dispatches = 0;
     uint64_t cpu_fast_total = 0;
+    // Present only when every dispatch in the retained batch uses one identical program at one
+    // run-local guest address. The SPIR-V hash is stable across address relocation and lets the
+    // offline report group the expensive programs without enabling a whole-boot compute trace.
+    std::optional<uint64_t> program_addr;
+    std::optional<uint64_t> program_hash;
     double total_ms = 0;
 };
 

--- a/prosper/frontends/shared/test_performance_capture.cpp
+++ b/prosper/frontends/shared/test_performance_capture.cpp
@@ -138,6 +138,10 @@ int main() {
         prosper::perf::ComputeTimingRecord record;
         record.monotonic_ns = 504 + i;
         record.dispatches = 7 + i;
+        if (i == 0) {
+            record.program_addr = 0x1234567800ull;
+            record.program_hash = 0xfedcba9876543210ull;
+        }
         record.total_ms = 3 + i;
         capture.record_compute(record);
     }
@@ -177,6 +181,9 @@ int main() {
           "serialized detail counts match the bounded retained records");
     check(text.find("\"gpu_timestamp_samples\":2") != std::string::npos,
           "renderer records serialize the GPU timestamp availability discriminator");
+    check(text.find("\"program_addr\":78187493376") != std::string::npos &&
+          text.find("\"program_hash\":18364758544493064720") != std::string::npos,
+          "compute records serialize the bounded program identity");
     check(text.find("\"renderer_dropped\":1,\"compute_dropped\":1") != std::string::npos,
           "footer makes detail truncation fail-visible");
     check(text.find("\"type\":\"footer\",\"complete\":true") != std::string::npos,

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -235,7 +235,10 @@ the shipped runtime. Build them from `build-linux/` like everything else.
   time unavailable and reports total GPU wait without inventing a device/host-overhead split. F8
   enables structured timing clocks but not the existing high-volume periodic stderr timing logs. A
   graceful exit before the window completes removes the private `.part` rather than publishing a
-  short final file.
+  short final file. A homogeneous compute batch also retains its run-local program address and a
+  stable SPIR-V hash; the report groups at most the ten costliest hashes by record/dispatch count,
+  total/mean/max time, and bounded address list. Mixed batches and older v1 captures report their
+  compute time as explicitly unknown identity rather than inventing a program attribution.
 
   Inspect it offline with:
 

--- a/prosper/tools/perf/performance_capture_report.py
+++ b/prosper/tools/perf/performance_capture_report.py
@@ -72,6 +72,54 @@ def _total(records, field):
                if math.isfinite(float(record.get(field, 0.0))))
 
 
+def _hex64(value):
+    return f"0x{value:016x}"
+
+
+def _compute_program_groups(records, limit=10, address_limit=8):
+    groups = {}
+    unknown_records = 0
+    unknown_dispatches = 0
+    unknown_total_ms = 0.0
+    for record in records:
+        address = record.get("program_addr")
+        program_hash = record.get("program_hash")
+        total_ms = float(record.get("total_ms", 0.0))
+        dispatches = int(record.get("dispatches", 0))
+        if not isinstance(address, int) or not isinstance(program_hash, int):
+            unknown_records += 1
+            unknown_dispatches += dispatches
+            unknown_total_ms += total_ms
+            continue
+        group = groups.setdefault(program_hash, {
+            "records": 0, "dispatches": 0, "total_ms": 0.0, "max_ms": 0.0,
+            "addresses": set(),
+        })
+        group["records"] += 1
+        group["dispatches"] += dispatches
+        group["total_ms"] += total_ms
+        group["max_ms"] = max(group["max_ms"], total_ms)
+        group["addresses"].add(address)
+
+    ranked = []
+    for program_hash, group in groups.items():
+        addresses = sorted(group.pop("addresses"))
+        group["program_hash"] = _hex64(program_hash)
+        group["mean_ms"] = group["total_ms"] / group["records"]
+        group["address_count"] = len(addresses)
+        group["addresses"] = [_hex64(address) for address in addresses[:address_limit]]
+        ranked.append(group)
+    ranked.sort(key=lambda group: (-group["total_ms"], group["program_hash"]))
+    return {
+        "group_count": len(ranked),
+        "groups_omitted": max(0, len(ranked) - limit),
+        "groups": ranked[:limit],
+        "unknown_records": unknown_records,
+        "unknown_dispatches": unknown_dispatches,
+        "unknown_total_ms": unknown_total_ms,
+    }
+
+
 def summarize(records):
     header = records[0]
     footer = next(record for record in records if record.get("type") == "footer")
@@ -97,6 +145,7 @@ def summarize(records):
 
     graphics_total = _total(renderer, "total_ms")
     compute_total = _total(compute, "total_ms")
+    compute_programs = _compute_program_groups(compute)
     measured_total = graphics_total + compute_total
     gpu_wait_total = _total(renderer, "gpu_wait_ms")
     gpu_timestamp_samples = sum(int(record.get("gpu_timestamp_samples", 0))
@@ -174,6 +223,7 @@ def summarize(records):
         "rates": rates,
         "graphics_total_ms": graphics_total,
         "compute_total_ms": compute_total,
+        "compute_programs": compute_programs,
         "gpu_timestamp_samples": gpu_timestamp_samples,
         "gpu_timestamps_available": gpu_timestamps_available,
         "components": components,
@@ -216,6 +266,19 @@ def print_summary(summary):
           f"rendered={_fmt_rate(rates['rendered_fps'])} host-presented={_fmt_rate(rates['host_fps'])}")
     print(f"measured totals: graphics={summary['graphics_total_ms']:.1f} ms "
           f"compute={summary['compute_total_ms']:.1f} ms")
+    programs = summary["compute_programs"]
+    print(f"compute identities: groups={programs['group_count']} "
+          f"unknown={programs['unknown_records']} records/{programs['unknown_total_ms']:.1f} ms")
+    for group in programs["groups"]:
+        addresses = ",".join(group["addresses"])
+        if group["address_count"] > len(group["addresses"]):
+            addresses += f",+{group['address_count'] - len(group['addresses'])}"
+        print(f"  {group['program_hash']} records={group['records']} "
+              f"dispatches={group['dispatches']} total={group['total_ms']:.1f} ms "
+              f"mean={group['mean_ms']:.2f} ms max={group['max_ms']:.2f} ms "
+              f"addresses={addresses}")
+    if programs["groups_omitted"]:
+        print(f"  ... {programs['groups_omitted']} lower-cost groups omitted")
     print(f"GPU timestamps: {summary['gpu_timestamp_samples']} samples " +
           ("(device/wait split available)" if summary["gpu_timestamps_available"] else
            "(device/wait split unavailable)"))

--- a/prosper/tools/perf/test_performance_capture_report.py
+++ b/prosper/tools/perf/test_performance_capture_report.py
@@ -68,6 +68,32 @@ class PerformanceCaptureReportTests(unittest.TestCase):
             renderer=[{"total_ms": 20}], compute=[{"total_ms": 80}]))
         self.assertEqual(summary["classification"], "compute")
 
+    def test_compute_programs_group_by_stable_hash_and_keep_unknown_explicit(self):
+        summary = summarize(capture(SAMPLES, compute=[
+            {"total_ms": 10, "dispatches": 1, "program_addr": 0x1000,
+             "program_hash": 0xABC},
+            {"total_ms": 20, "dispatches": 2, "program_addr": 0x2000,
+             "program_hash": 0xABC},
+            {"total_ms": 5, "dispatches": 1, "program_addr": 0x3000,
+             "program_hash": 0xDEF},
+            {"total_ms": 7, "dispatches": 3, "program_addr": None,
+             "program_hash": None},
+        ]))
+        programs = summary["compute_programs"]
+        self.assertEqual(programs["group_count"], 2)
+        self.assertEqual(programs["unknown_records"], 1)
+        self.assertEqual(programs["unknown_dispatches"], 3)
+        self.assertEqual(programs["unknown_total_ms"], 7)
+        dominant = programs["groups"][0]
+        self.assertEqual(dominant["program_hash"], "0x0000000000000abc")
+        self.assertEqual(dominant["addresses"], [
+            "0x0000000000001000", "0x0000000000002000"])
+        self.assertEqual(dominant["records"], 2)
+        self.assertEqual(dominant["dispatches"], 3)
+        self.assertEqual(dominant["total_ms"], 30)
+        self.assertEqual(dominant["mean_ms"], 15)
+        self.assertEqual(dominant["max_ms"], 20)
+
     def test_cpu_outside_renderer_classification(self):
         summary = summarize(capture(SAMPLES, renderer=[{"total_ms": 100}]))
         self.assertEqual(summary["classification"], "cpu-outside-renderer")


### PR DESCRIPTION
## Summary

- retain an optional run-local guest address and stable SPIR-V hash on F8 compute timing records
- emit identity only for homogeneous compute batches, leaving mixed and legacy records explicitly unknown
- group the offline report by stable hash with bounded top-program and address output
- preserve the existing v1 capture format and compatibility with already-recorded `.prperf` files

The first controlled Syberia save-screen capture in #1737 retained 756 one-dispatch compute records totaling 2,919.3 ms, but the original schema could not identify which guest programs owned that cost. This focused tooling change provides the missing discriminator without enabling a high-volume whole-boot trace or storing shader bodies in the artifact.

## Safety and bounds

- Identity is populated only when every item in a submitted batch has the same nonzero guest address and identical SPIR-V.
- Mixed batches and captures written before this change remain visible as unknown identity.
- The report prints at most ten program groups and eight addresses per group, while still reporting omitted group/address counts.
- Stable hashes are computed from SPIR-V already present at submission time; no guest memory reread is introduced.
- No title-specific behavior or Syberia status claim is included.

## Verification

Built in the `ps5ys` distrobox from current master `3c2fd9d5`:

```text
cmake -S prosper -B build-linux \
  -DPROSPER_APP=ON \
  -DPROSPER_AUDIO_FFMPEG=ON \
  -DPROSPER_AUDIO_SDL3=ON \
  -DPROSPER_PAD_SDL3=ON \
  -DPROSPER_VIDEO_VAAPI=ON \
  -DGAME_DUMP=<DUMP_ROOT>/PPSA30140-app0
cmake --build build-linux --target prosper-app test_performance_capture -j2
```

Focused tests:

```text
ctest --test-dir build-linux --output-on-failure \
  -R '^(performance_capture|performance_capture_report_logic)$'

2/2 passed

python3 prosper/tools/perf/test_performance_capture_report.py

Ran 11 tests — OK
```

Backward-compatibility check against the existing complete Syberia v1 artifact:

```text
records: pre=20 post=20 renderer=18 compute=756 (detail not truncated)
compute identities: groups=0 unknown=756 records/2919.3 ms
```

A deliberate mutation that suppressed every program identity failed exactly
`test_compute_programs_group_by_stable_hash_and_keep_unknown_explicit` (`0 != 2`), then the restored implementation returned the suite to green.

Closes #1830. Refs #1737, #1823, #1820.
