### PR TITLE
tools: mark direct-present render count unavailable

### DIFF
--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -1547,7 +1547,10 @@ int main(int argc, char** argv) {
         const uint64_t perfNow = prosper::perf::monotonic_now_ns();
         if (perfCapture.sample_due(perfNow)) {
             perfCapture.observe_sample(prosper::perf::collect_process_sample(
-                perfNow, gpu::present_count(), gpu::present_frame_seq(), shown));
+                perfNow, gpu::present_count(),
+                prosper::frontend::rendered_frame_counter(
+                    vk.gpu_present, gpu::present_frame_seq()),
+                shown));
         }
         prosper::perf::CaptureOutcome perfOutcome;
         if (perfCapture.take_outcome(perfOutcome)) {
@@ -1595,7 +1598,10 @@ int main(int argc, char** argv) {
                     const uint64_t armedAt = prosper::perf::monotonic_now_ns();
                     if (perfCapture.sample_due(armedAt)) {
                         perfCapture.observe_sample(prosper::perf::collect_process_sample(
-                            armedAt, gpu::present_count(), gpu::present_frame_seq(), shown));
+                            armedAt, gpu::present_count(),
+                            prosper::frontend::rendered_frame_counter(
+                                vk.gpu_present, gpu::present_frame_seq()),
+                            shown));
                     }
                     const prosper::perf::CaptureArmResult armed = perfCapture.arm(
                         grabDir, activeCaptureTitle.id, activeCaptureTitle.label,

--- a/prosper/frontends/prosper-app/present_policy.hpp
+++ b/prosper/frontends/prosper-app/present_policy.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <cstdint>
+#include <optional>
+
 #include <vulkan/vulkan_core.h>
 
 // Present policy for prosper-app (#1182). Real game boots normally share the renderer's Vulkan device;
@@ -18,6 +21,15 @@ namespace prosper::frontend {
 constexpr bool request_gpu_present(const char* setting, bool test_pattern, bool has_game) {
     const bool explicitly_disabled = setting && setting[0] == '0' && setting[1] == '\0';
     return has_game && !test_pattern && !explicitly_disabled;
+}
+
+// F8's rendered-frame population is the CPU frame handoff count, not the number of successful
+// swapchain presents. Shared-device GPU present deliberately skips that handoff. Until that producer
+// exposes its own coherent completion counter, report the population as unavailable; substituting the
+// app's host-present count would manufacture equality between two different clocks.
+constexpr std::optional<uint64_t> rendered_frame_counter(bool gpu_present,
+                                                         uint64_t cpu_frame_seq) {
+    return gpu_present ? std::nullopt : std::optional<uint64_t>{cpu_frame_seq};
 }
 
 // Outcome of one present_frame attempt.

--- a/prosper/frontends/prosper-app/test_present_policy.cpp
+++ b/prosper/frontends/prosper-app/test_present_policy.cpp
@@ -30,6 +30,13 @@ int main() {
     CHECK(!request_gpu_present(nullptr, true, true));
     CHECK(!request_gpu_present(nullptr, false, false));
 
+    // `present_frame_seq()` belongs only to the CPU handoff path. A direct-present app must not
+    // serialize its flat CPU counter as a real zero-rate population, while the CPU path retains the
+    // exact counter value (including a legitimate zero).
+    CHECK(!rendered_frame_counter(true, 73).has_value());
+    CHECK(rendered_frame_counter(false, 0) == 0);
+    CHECK(rendered_frame_counter(false, 73) == 73);
+
     // Acquire: a usable image (SUCCESS or SUBOPTIMAL) → proceed to blit+present.
     CHECK(classify_acquire(VK_SUCCESS) == AcquireAction::proceed);
     CHECK(classify_acquire(VK_SUBOPTIMAL_KHR) == AcquireAction::proceed);

--- a/prosper/frontends/shared/performance_capture.cpp
+++ b/prosper/frontends/shared/performance_capture.cpp
@@ -341,8 +341,9 @@ void InteractivePerformanceCapture::publish_completed(std::unique_ptr<PendingCap
             out << ",\"rss_bytes\":";
             write_optional(out, sample.rss_bytes);
             out << ",\"guest_presents\":" << sample.guest_presents
-                << ",\"rendered_frames\":" << sample.rendered_frames
-                << ",\"host_presented_frames\":" << sample.host_presented_frames << "}\n";
+                << ",\"rendered_frames\":";
+            write_optional(out, sample.rendered_frames);
+            out << ",\"host_presented_frames\":" << sample.host_presented_frames << "}\n";
         };
         for (const ProcessSample& sample : capture->pre_samples) write_sample(sample, "pre");
         for (const ProcessSample& sample : capture->post_samples) write_sample(sample, "post");
@@ -436,7 +437,7 @@ uint64_t monotonic_now_ns() {
 }
 
 ProcessSample collect_process_sample(uint64_t monotonic_ns, uint64_t guest_presents,
-                                     uint64_t rendered_frames,
+                                     std::optional<uint64_t> rendered_frames,
                                      uint64_t host_presented_frames) {
     ProcessSample sample;
     sample.monotonic_ns = monotonic_ns;

--- a/prosper/frontends/shared/performance_capture.hpp
+++ b/prosper/frontends/shared/performance_capture.hpp
@@ -20,7 +20,9 @@ struct ProcessSample {
     std::optional<uint64_t> process_cpu_ns;
     std::optional<uint64_t> rss_bytes;
     uint64_t guest_presents = 0;
-    uint64_t rendered_frames = 0;
+    // The CPU handoff path exposes present_frame_seq(). The shared-device GPU-present path skips
+    // that handoff, so its production counter is unavailable rather than zero.
+    std::optional<uint64_t> rendered_frames;
     uint64_t host_presented_frames = 0;
 };
 
@@ -130,7 +132,7 @@ InteractivePerformanceCapture& interactive_performance_capture();
 
 uint64_t monotonic_now_ns();
 ProcessSample collect_process_sample(uint64_t monotonic_ns, uint64_t guest_presents,
-                                     uint64_t rendered_frames,
+                                     std::optional<uint64_t> rendered_frames,
                                      uint64_t host_presented_frames);
 const char* build_revision();
 

--- a/prosper/frontends/shared/test_performance_capture.cpp
+++ b/prosper/frontends/shared/test_performance_capture.cpp
@@ -147,7 +147,9 @@ int main() {
     }
 
     capture.observe_sample(sample(600, 6));
-    capture.observe_sample(sample(700, 7));
+    auto unavailable_render_count = sample(700, 7);
+    unavailable_render_count.rendered_frames.reset();
+    capture.observe_sample(unavailable_render_count);
     check(capture.detailed_timing_active(), "detailed timing stays active before the post window ends");
     capture.observe_sample(sample(800, 8));
     check(!capture.detailed_timing_active(), "the bounded post window disables detailed timing");
@@ -176,6 +178,8 @@ int main() {
           "serialized artifact contains the exact pre-trigger ring population");
     check(count_text(text, "\"type\":\"sample\",\"phase\":\"post\"") == 3,
           "serialized artifact contains the exact post-trigger population");
+    check(count_text(text, "\"rendered_frames\":null") == 1,
+          "an unavailable rendered-frame population serializes as JSON null");
     check(count_text(text, "\"type\":\"renderer\"") == 2 &&
           count_text(text, "\"type\":\"compute\"") == 1,
           "serialized detail counts match the bounded retained records");

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -229,7 +229,10 @@ the shipped runtime. Build them from `build-linux/` like everything else.
   preceding 5 seconds and enables the existing structured renderer/compute timers for the following
   5 seconds. It then atomically publishes one bounded
   `perf_capture_<titleId>_<timestamp>.prperf` under `PROSPER_CAPTURE_DIR` (default cwd). No GPU command
-  capture, screenshot, or ordinary frame dump is enabled by F8. Detailed renderer and compute records
+  capture, screenshot, or ordinary frame dump is enabled by F8. The rendered-frame counter is the
+  CPU frame-handoff population; shared-device direct GPU present skips that handoff and serializes
+  the field as unavailable (`null`), so the report must not infer a zero-rate pacing gap from it. Detailed
+  renderer and compute records
   are capped at 4096 each, and the footer reports exact retained and dropped counts — never read the
   cap as the population. Missing Vulkan timestamp samples are explicit: the report leaves GPU device
   time unavailable and reports total GPU wait without inventing a device/host-overhead split. F8

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -231,10 +231,10 @@ the shipped runtime. Build them from `build-linux/` like everything else.
   `perf_capture_<titleId>_<timestamp>.prperf` under `PROSPER_CAPTURE_DIR` (default cwd). No GPU command
   capture, screenshot, or ordinary frame dump is enabled by F8. The rendered-frame counter is the
   CPU frame-handoff population; shared-device direct GPU present skips that handoff and serializes
-  the field as unavailable (`null`), so the report must not infer a zero-rate pacing gap from it. Detailed
-  renderer and compute records
-  are capped at 4096 each, and the footer reports exact retained and dropped counts — never read the
-  cap as the population. Missing Vulkan timestamp samples are explicit: the report leaves GPU device
+  the field as unavailable (`null`), so the report must not infer a zero-rate pacing gap from it.
+  Detailed renderer and compute records are capped at 4096 each, and the footer reports exact
+  retained and dropped counts — never read the cap as the population. Missing Vulkan timestamp
+  samples are explicit: the report leaves GPU device
   time unavailable and reports total GPU wait without inventing a device/host-overhead split. F8
   enables structured timing clocks but not the existing high-volume periodic stderr timing logs. A
   graceful exit before the window completes removes the private `.part` rather than publishing a

--- a/prosper/tools/perf/test_performance_capture_report.py
+++ b/prosper/tools/perf/test_performance_capture_report.py
@@ -110,6 +110,14 @@ class PerformanceCaptureReportTests(unittest.TestCase):
         }]))
         self.assertIn("does not assign its cause", summary["pacing_note"])
 
+    def test_direct_present_unavailable_render_counter_declines_pacing_inference(self):
+        direct_present = [dict(sample, rendered_frames=None) for sample in SAMPLES]
+        summary = summarize(capture(direct_present, renderer=[{"total_ms": 1}]))
+        self.assertEqual(summary["rates"]["guest_fps"], 60)
+        self.assertEqual(summary["rates"]["host_fps"], 9)
+        self.assertIsNone(summary["rates"]["rendered_fps"])
+        self.assertIsNone(summary["pacing_note"])
+
     def test_dropped_counts_are_reported_not_added_to_population(self):
         summary = summarize(capture(SAMPLES, renderer=[{"total_ms": 1}], dropped=(7, 9)))
         self.assertEqual(summary["counts"]["renderer"], 1)


### PR DESCRIPTION
Fixes #1828

## Root cause

F8 sampled `gpu::present_frame_seq()` as `rendered_frames`. That counter advances only when the renderer hands CPU-owned pixels to `present_write_frame`. The normal shared-device GPU-present path deliberately skips that CPU handoff, so Syberia's capture recorded a flat rendered counter while renderer work and host presents both advanced. The offline report then treated an unavailable population as a real zero rate and emitted a false pacing-gap note.

The app's `shown` counter is already the host-present population. Reusing it as rendered frames would manufacture equality between two distinct clocks.

## What changed

- Make the F8 rendered-frame field optional while preserving format version 1 and existing integer captures.
- Select the counter at the actual app presentation path: CPU handoff keeps the exact `present_frame_seq()`; shared-device GPU present supplies unavailable.
- Serialize unavailable rendered-frame samples as JSON `null`.
- Keep the reporter conservative: its existing null handling prints rendered rate as unavailable and declines the production/presentation-gap inference.
- Document the counter population boundary in `tools/AGENTS.md`.

## Behavioral checks

- The direct-present source is unavailable, never a fabricated zero.
- The CPU path preserves exact values, including a legitimate zero.
- The capture serializer emits JSON null for unavailable samples.
- With guest flips and host presents advancing but rendered frames unavailable, the report derives guest/host rates, leaves rendered FPS unavailable, and emits no pacing note.
- Existing v1 integer samples remain readable and continue to derive rendered rates.

## Verification

All build and test commands ran inside the `ps5ys` distrobox with a worktree-local `TMPDIR`.

```bash
cmake -S prosper -B prosper/build-linux \
  -DPROSPER_APP=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo
cmake --build prosper/build-linux -j6 \
  --target test_performance_capture test_prosper_app_present_policy prosper-app
ctest --test-dir prosper/build-linux --output-on-failure \
  -R "^(doc_table_checker|performance_capture|performance_capture_report_logic|prosper_app_present_policy)$"
```

Result: 4/4 focused tests passed; `prosper-app` built successfully. `git diff --check` is clean.

Mechanism mutation: forcing the direct-present selector to return the CPU `present_frame_seq()` failed exactly `!rendered_frame_counter(true, 73).has_value()` in `prosper_app_present_policy`. The mutation was restored, rebuilt, and the final focused suite passed.

## Scope

CPU/static only. No title boot, GPU run, screenshot, or snapshot suite was used; this change fixes diagnostic population semantics and has no visual output.