### PR TITLE
tools: trigger F8 performance capture without desktop input

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -407,6 +407,13 @@ if(TARGET prosper_core)
   target_include_directories(test_prosper_app_capture_schedule PRIVATE frontends/prosper-app)
   add_test(NAME prosper_app_capture_schedule COMMAND test_prosper_app_capture_schedule)
 
+  add_executable(test_prosper_app_performance_capture_schedule
+    frontends/prosper-app/test_performance_capture_schedule.cpp)
+  target_include_directories(test_prosper_app_performance_capture_schedule
+    PRIVATE frontends/prosper-app)
+  add_test(NAME prosper_app_performance_capture_schedule
+    COMMAND test_prosper_app_performance_capture_schedule)
+
   add_executable(test_prosper_app_present_mode frontends/prosper-app/test_present_mode.cpp)
   target_include_directories(test_prosper_app_present_mode PRIVATE frontends/prosper-app)
   add_test(NAME prosper_app_present_mode COMMAND test_prosper_app_present_mode)

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -1616,10 +1616,6 @@ int main(int argc, char** argv) {
                     vk.gpu_present, gpu::present_frame_seq()),
                 shown));
         }
-        if (automaticPerfCapture.take_if_due(perfLoopStartNs, perfNow)) {
-            arm_performance_capture(
-                true, perfNow, (perfNow - perfLoopStartNs) / 1'000'000);
-        }
         prosper::perf::CaptureOutcome perfOutcome;
         if (perfCapture.take_outcome(perfOutcome)) {
             if (perfOutcome.ok) {
@@ -1636,6 +1632,13 @@ int main(int argc, char** argv) {
                              perfOutcome.error.c_str());
             }
             perfCaptureWasAutomatic = false;
+        }
+        // Consume a completion before starting a new automatic capture. Otherwise a user-triggered
+        // F8 outcome that completed on this same sample could be mislabeled as automatic after the
+        // new arm replaces the trigger-provenance flag.
+        if (automaticPerfCapture.take_if_due(perfLoopStartNs, perfNow)) {
+            arm_performance_capture(
+                true, perfNow, (perfNow - perfLoopStartNs) / 1'000'000);
         }
         openedThisBatch = rejectedThisBatch = false;
         SDL_Event ev;

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -35,6 +35,7 @@
 #include "game_library.hpp"              // scan a games dir -> titles + metadata, pure seam
 #include "frame_grab_naming.hpp"         // one stamp + one exclusively claimed name pair per F9 grab
 #include "performance_capture.hpp"        // bounded F8 pre/post performance artifact
+#include "performance_capture_schedule.hpp" // unattended elapsed-time trigger for the same artifact
 #include "app_config.hpp"                // persisted settings (games_dir), pure seam
 #ifdef PROSPER_HAVE_LIBRARY_UI
 #include "library_ui.hpp"                // the ImGui library grid drawn while no game is running
@@ -1320,6 +1321,66 @@ int main(int argc, char** argv) {
     }
     prosper::perf::InteractivePerformanceCapture& perfCapture =
         prosper::perf::interactive_performance_capture();
+    const char* automaticPerfEnv = getenv("PROSPER_PERF_CAPTURE_AFTER_MS");
+    prosper::frontend::ElapsedPerformanceCaptureTrigger automaticPerfCapture(
+        prosper::frontend::parse_performance_capture_delay_ns(automaticPerfEnv));
+    if (automaticPerfEnv) {
+        if (automaticPerfCapture.delay_ns()) {
+            std::fprintf(stderr,
+                "[perf] automatic capture scheduled by PROSPER_PERF_CAPTURE_AFTER_MS=%s "
+                "(one attempt after %llu ms of app-loop time)\n",
+                automaticPerfEnv,
+                static_cast<unsigned long long>(automaticPerfCapture.delay_ns() / 1'000'000));
+        } else {
+            std::fprintf(stderr,
+                "[perf] ignoring malformed PROSPER_PERF_CAPTURE_AFTER_MS=\"%s\" "
+                "(expected positive decimal milliseconds without overflow)\n",
+                automaticPerfEnv);
+        }
+    }
+    bool perfCaptureWasAutomatic = false;
+    auto arm_performance_capture = [&](bool automatic, uint64_t armedAt,
+                                       uint64_t automaticElapsedMs = 0) {
+        if (perfCapture.sample_due(armedAt)) {
+            perfCapture.observe_sample(prosper::perf::collect_process_sample(
+                armedAt, gpu::present_count(),
+                prosper::frontend::rendered_frame_counter(
+                    vk.gpu_present, gpu::present_frame_seq()),
+                shown));
+        }
+        const prosper::perf::CaptureArmResult armed = perfCapture.arm(
+            grabDir, activeCaptureTitle.id, activeCaptureTitle.label,
+            prosper::perf::build_revision(), armedAt,
+            std::chrono::system_clock::now());
+        if (armed.ok) perfCaptureWasAutomatic = automatic;
+        if (automatic) {
+            if (armed.ok) {
+                std::fprintf(stderr,
+                    "[perf] automatic trigger #%u fired at %llu ms for %s: retained %zu "
+                    "pre-trigger samples; collecting %.1f seconds after the trigger\n",
+                    armed.index, static_cast<unsigned long long>(automaticElapsedMs),
+                    activeCaptureTitle.label.empty() ? "the current process"
+                                                     : activeCaptureTitle.label.c_str(),
+                    armed.pre_samples, armed.post_seconds);
+            } else {
+                std::fprintf(stderr,
+                    "[perf] automatic trigger #%u fired at %llu ms but was not armed: %s\n",
+                    armed.index, static_cast<unsigned long long>(automaticElapsedMs),
+                    armed.error.c_str());
+            }
+        } else if (armed.ok) {
+            std::fprintf(stderr,
+                "[perf] F8 #%u armed for %s: retained %zu pre-trigger samples; "
+                "collecting %.1f seconds after the press\n",
+                armed.index,
+                activeCaptureTitle.label.empty() ? "the current process"
+                                                 : activeCaptureTitle.label.c_str(),
+                armed.pre_samples, armed.post_seconds);
+        } else {
+            std::fprintf(stderr, "[perf] F8 #%u not armed: %s\n",
+                         armed.index, armed.error.c_str());
+        }
+    };
     // 0 = keep the built-in default; the timeline clamps whatever is supplied to 64..3072 MiB.
     // Parse strictly, matching the two checked parses of this same variable in gpu_timeline.cpp. An
     // unchecked strtoul truncates into uint32_t, so 4294967360 would arrive as 64 — silently the
@@ -1541,6 +1602,9 @@ int main(int argc, char** argv) {
         open_folder_picker(win);
     }
 
+    // The automatic capture delay starts at app-loop entry, not process start or guest boot. This
+    // gives unattended routes one explicit, repeatable host-time origin without desktop input.
+    const uint64_t perfLoopStartNs = prosper::perf::monotonic_now_ns();
     while (running && !prosper_stop_requested()) {
         // F8's only always-on work is this 4 Hz sample. `sample_due` is one atomic read, so the
         // process CPU/RSS query is not paid on every UI-loop iteration.
@@ -1551,6 +1615,10 @@ int main(int argc, char** argv) {
                 prosper::frontend::rendered_frame_counter(
                     vk.gpu_present, gpu::present_frame_seq()),
                 shown));
+        }
+        if (automaticPerfCapture.take_if_due(perfLoopStartNs, perfNow)) {
+            arm_performance_capture(
+                true, perfNow, (perfNow - perfLoopStartNs) / 1'000'000);
         }
         prosper::perf::CaptureOutcome perfOutcome;
         if (perfCapture.take_outcome(perfOutcome)) {
@@ -1563,8 +1631,11 @@ int main(int argc, char** argv) {
                     perfOutcome.renderer_dropped, perfOutcome.compute_dropped,
                     perfOutcome.path.c_str());
             } else {
-                std::fprintf(stderr, "[perf] F8 capture FAILED: %s\n", perfOutcome.error.c_str());
+                std::fprintf(stderr, "[perf] %s capture FAILED: %s\n",
+                             perfCaptureWasAutomatic ? "automatic" : "F8",
+                             perfOutcome.error.c_str());
             }
+            perfCaptureWasAutomatic = false;
         }
         openedThisBatch = rejectedThisBatch = false;
         SDL_Event ev;
@@ -1596,29 +1667,7 @@ int main(int argc, char** argv) {
                 if (ev.type == SDL_EVENT_KEY_DOWN && key.app_window && !ev.key.repeat &&
                     ev.key.key == SDLK_F8) {
                     const uint64_t armedAt = prosper::perf::monotonic_now_ns();
-                    if (perfCapture.sample_due(armedAt)) {
-                        perfCapture.observe_sample(prosper::perf::collect_process_sample(
-                            armedAt, gpu::present_count(),
-                            prosper::frontend::rendered_frame_counter(
-                                vk.gpu_present, gpu::present_frame_seq()),
-                            shown));
-                    }
-                    const prosper::perf::CaptureArmResult armed = perfCapture.arm(
-                        grabDir, activeCaptureTitle.id, activeCaptureTitle.label,
-                        prosper::perf::build_revision(), armedAt,
-                        std::chrono::system_clock::now());
-                    if (armed.ok) {
-                        std::fprintf(stderr,
-                            "[perf] F8 #%u armed for %s: retained %zu pre-trigger samples; "
-                            "collecting %.1f seconds after the press\n",
-                            armed.index,
-                            activeCaptureTitle.label.empty() ? "the current process"
-                                                             : activeCaptureTitle.label.c_str(),
-                            armed.pre_samples, armed.post_seconds);
-                    } else {
-                        std::fprintf(stderr, "[perf] F8 #%u not armed: %s\n",
-                                     armed.index, armed.error.c_str());
-                    }
+                    arm_performance_capture(false, armedAt);
                     continue;
                 }
                 // Interactive frame grab: F9 arms a one-shot capture of the next COMPLETE frame (every

--- a/prosper/frontends/prosper-app/performance_capture_schedule.hpp
+++ b/prosper/frontends/prosper-app/performance_capture_schedule.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <charconv>
+#include <cstdint>
+#include <limits>
+#include <string_view>
+#include <system_error>
+
+namespace prosper::frontend {
+
+// Parse the explicit unattended-performance-capture delay. Zero remains the disabled/invalid
+// sentinel: automatic capture is opt-in, and a malformed value must never capture a later phase
+// than the operator intended.
+inline uint64_t parse_performance_capture_delay_ns(const char* value) {
+    if (!value || !*value) return 0;
+    const std::string_view text(value);
+    uint64_t milliseconds = 0;
+    const auto parsed = std::from_chars(
+        text.data(), text.data() + text.size(), milliseconds, 10);
+    constexpr uint64_t kNanosecondsPerMillisecond = 1'000'000;
+    if (parsed.ec != std::errc{} || parsed.ptr != text.data() + text.size() ||
+        !milliseconds ||
+        milliseconds > std::numeric_limits<uint64_t>::max() / kNanosecondsPerMillisecond)
+        return 0;
+    return milliseconds * kNanosecondsPerMillisecond;
+}
+
+// A due trigger is consumed before its caller attempts to arm the capture. Thus an arm failure is
+// fail-visible and one-shot instead of retrying every app-loop iteration and silently capturing a
+// later phase. Comparing by subtraction only after `now >= start` makes clock reversal safe.
+class ElapsedPerformanceCaptureTrigger {
+public:
+    explicit ElapsedPerformanceCaptureTrigger(uint64_t delay_ns) : delay_ns_(delay_ns) {}
+
+    bool take_if_due(uint64_t start_ns, uint64_t now_ns) {
+        if (!delay_ns_ || attempted_ || now_ns < start_ns || now_ns - start_ns < delay_ns_)
+            return false;
+        attempted_ = true;
+        return true;
+    }
+
+    uint64_t delay_ns() const { return delay_ns_; }
+
+private:
+    uint64_t delay_ns_ = 0;
+    bool attempted_ = false;
+};
+
+} // namespace prosper::frontend

--- a/prosper/frontends/prosper-app/test_performance_capture_schedule.cpp
+++ b/prosper/frontends/prosper-app/test_performance_capture_schedule.cpp
@@ -1,0 +1,58 @@
+#include "performance_capture_schedule.hpp"
+
+#include <cstdio>
+#include <limits>
+
+using prosper::frontend::ElapsedPerformanceCaptureTrigger;
+using prosper::frontend::parse_performance_capture_delay_ns;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { std::printf("  [FAIL] %s\n", m); ++fails; } \
+                         else       { std::printf("  [ok]   %s\n", m); } } while (0)
+
+int main() {
+    std::printf("== test_prosper_app_performance_capture_schedule ==\n");
+    CHECK(parse_performance_capture_delay_ns(nullptr) == 0,
+          "unset delay disables automatic performance capture");
+    CHECK(parse_performance_capture_delay_ns("") == 0,
+          "empty delay is rejected");
+    CHECK(parse_performance_capture_delay_ns("0") == 0,
+          "zero delay is rejected");
+    CHECK(parse_performance_capture_delay_ns("+1") == 0,
+          "signed positive delay is rejected");
+    CHECK(parse_performance_capture_delay_ns("-1") == 0,
+          "negative delay is rejected");
+    CHECK(parse_performance_capture_delay_ns("5000x") == 0,
+          "trailing text is rejected");
+    CHECK(parse_performance_capture_delay_ns("5000") == 5'000'000'000ull,
+          "positive decimal milliseconds convert exactly to nanoseconds");
+    CHECK(parse_performance_capture_delay_ns("18446744073709") ==
+              18'446'744'073'709'000'000ull,
+          "largest whole-millisecond delay is accepted without truncation");
+    CHECK(parse_performance_capture_delay_ns("18446744073710") == 0,
+          "nanosecond conversion overflow is rejected");
+    CHECK(parse_performance_capture_delay_ns("18446744073709551616") == 0,
+          "decimal parse overflow is rejected");
+
+    ElapsedPerformanceCaptureTrigger disabled(0);
+    CHECK(!disabled.take_if_due(100, std::numeric_limits<uint64_t>::max()),
+          "disabled schedule never fires");
+
+    ElapsedPerformanceCaptureTrigger scheduled(500);
+    CHECK(!scheduled.take_if_due(1'000, 999),
+          "clock reversal cannot fire the automatic trigger");
+    CHECK(!scheduled.take_if_due(1'000, 1'499),
+          "automatic trigger waits before its elapsed deadline");
+    CHECK(scheduled.take_if_due(1'000, 1'500),
+          "automatic trigger fires exactly at its elapsed deadline");
+    CHECK(!scheduled.take_if_due(1'000, 2'000),
+          "automatic trigger remains one-shot after the arm attempt");
+
+    ElapsedPerformanceCaptureTrigger skipped_deadline(500);
+    CHECK(skipped_deadline.take_if_due(1'000, 1'900),
+          "a delayed app loop consumes the first iteration after the deadline");
+
+    if (fails) { std::printf("== FAIL: %d ==\n", fails); return 1; }
+    std::printf("== PASS ==\n");
+    return 0;
+}

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -243,6 +243,13 @@ the shipped runtime. Build them from `build-linux/` like everything else.
   total/mean/max time, and bounded address list. Mixed batches and older v1 captures report their
   compute time as explicitly unknown identity rather than inventing a program attribution.
 
+  For unattended agent runs, set `PROSPER_PERF_CAPTURE_AFTER_MS=N` to make one automatic arm
+  attempt after `N` milliseconds from entry into the app loop. This uses the exact F8 artifact path
+  and five-second pre/post windows without desktop focus, synthetic input, screenshots, frame dumps,
+  or GPU command capture. The value must be a positive decimal integer whose nanosecond conversion
+  fits in 64 bits. Startup logs whether the setting was accepted or ignored, and the trigger line
+  proves when the one-shot attempt fired. A failed arm is not retried at a later phase.
+
   Inspect it offline with:
 
   ```bash


### PR DESCRIPTION
Fixes #1834
Refs #1737

## Motivation

The bounded F8 `.prperf` capture works, but unattended agent runs previously needed desktop focus or input injection to arm it. A Syberia follow-up attempted to send F8 with `xdotool` under Wayland; SDL received no key event, there was no arm line, `.part`, or final artifact, and the apparatus could not prove its lever moved. Desktop input automation is not a safe or repeatable profiling trigger.

## Behavioral contract

`prosper-app` now accepts an explicit opt-in `PROSPER_PERF_CAPTURE_AFTER_MS=N`:

- only positive decimal milliseconds are accepted; empty, zero, signs, trailing text, parse overflow, and nanosecond-conversion overflow are rejected;
- elapsed time begins at entry into the app loop and uses the same monotonic clock as performance samples;
- clock reversal cannot fire the trigger;
- the due event is consumed before the arm attempt, so a failed arm is fail-visible and never retries into a later phase;
- startup prints whether the setting was accepted or ignored, and a distinct automatic-trigger line proves the one-shot lever fired; and
- F8 and automatic capture share one arm path, preserving the existing five-second pre/post windows, bounded detail records, atomic `.part` publication, artifact format, and interactive F8 behavior.

A completion is consumed before a new automatic arm in the same app-loop iteration, so an earlier F8 outcome cannot inherit the new capture's trigger provenance.

The automatic trigger enables no screenshot, ordinary frame dump, GPU command capture, desktop focus change, or synthetic input.

## Implementation

- Add a pure parse/schedule seam plus 16 named CPU checks.
- Route both F8 and elapsed-time triggers through one `prosper-app` arm lambda.
- Register the pure test in CMake and document the unattended workflow in `tools/AGENTS.md`.

## Verification

All builds and tests ran inside the `ps5ys` distrobox with a worktree-local `TMPDIR` off `/tmp`.

```bash
cmake -S prosper -B prosper/build-linux -DPROSPER_APP=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo
cmake --build prosper/build-linux -j6 --target \
  test_prosper_app_performance_capture_schedule \
  test_performance_capture test_prosper_app_present_policy prosper-app
ctest --test-dir prosper/build-linux --output-on-failure -R \
  "^(prosper_app_performance_capture_schedule|performance_capture|performance_capture_report_logic|prosper_app_present_policy|doc_table_checker)$"
```

Result: **5/5 focused tests passed**, and `prosper-app` built successfully. `git diff --check` is clean.

Causal mutation: removing only the scheduler's `attempted_` guard made the test executable exit 1 with exactly one named failure:

```text
[FAIL] automatic trigger remains one-shot after the arm attempt
```

The guard was restored, affected targets rebuilt, and the final 5/5 suite passed.

## Scope

CPU/static only. No GUI session, title boot, GPU run, xdotool/input automation, screenshot, or snapshot suite was used. The first Syberia capture with this trigger belongs to the separate #1737 investigation after this infrastructure change lands.