### PR TITLE
tools: select compute timings by stable hash

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -93,6 +93,14 @@ endif()
 
 # --- tests (agentic-first: self-checking, exit-code = truth) -------------
 enable_testing()
+
+# Pure selection/accounting policy behind the stable compute-timing hash filter. This must remain
+# runnable without prosper_core, a game dump, or Vulkan so a broken diagnostic cannot hide behind a
+# skipped execution test on a host without graphics support.
+add_executable(test_compute_timing_selector tests/test_compute_timing_selector.cpp)
+target_include_directories(test_compute_timing_selector PRIVATE frontends/shared)
+add_test(NAME compute_timing_selector_policy COMMAND test_compute_timing_selector)
+
 find_package(Python3 COMPONENTS Interpreter QUIET)
 if(Python3_Interpreter_FOUND)
   add_test(NAME re_xref_decoder

--- a/prosper/docs/FRONTEND_APP.md
+++ b/prosper/docs/FRONTEND_APP.md
@@ -368,9 +368,19 @@ Dead Cells post-parse workload while excluding its 54-56-draw loading loop.
 Selected lightweight records are formatted together and written to stderr in one batch at submit completion;
 this preserves one parseable line per target without paying a Windows console write for every target.
 Compute phase/image timing can likewise be restricted to one exact program address with
-`PROSPER_COMPUTE_TIMING_CODE=0x...`. This filter does not enable the heavier compute trace or its hashing,
-so use it for a representative long-running dispatch A/B rather than flooding every compute program's
-per-image records.
+`PROSPER_COMPUTE_TIMING_CODE=0x...`. This filter does not enable the heavier compute trace; only the
+selected timing records pay the stable-identity hash used in their output. Use it for a representative
+long-running dispatch A/B rather than flooding every compute program's per-image records. Because guest
+program addresses can move across runs,
+`PROSPER_COMPUTE_TIMING_HASH=0x...` instead selects the stable FNV-1a hash of the translated SPIR-V
+module (the same identity printed by an F8 performance-capture report). When both selectors are set,
+they are an **AND**: the current address and stable hash must both match. The hash parser accepts only a
+complete unsigned decimal or `0x` hexadecimal `uint64_t`; signs, whitespace, overflow, and trailing
+characters fail closed with an explicit `ignored` banner. An accepted selector prints one bounded
+`first-match` proof and a termination summary with `seen`/`matched`; `matched=0` is labelled
+`INVALID-zero-matches`, not evidence that the shader did not run. Selected `[compute-phase]`,
+`[compute-image]`, and `[compute-image-writeback]` lines carry both `code=` and `hash=` so copied logs
+retain their own identity.
 
 #### Reading the compute side at run scale
 

--- a/prosper/frontends/shared/compute_timing_selector.hpp
+++ b/prosper/frontends/shared/compute_timing_selector.hpp
@@ -1,0 +1,132 @@
+#pragma once
+
+#include <charconv>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <string_view>
+#include <system_error>
+
+namespace prosper::frontend {
+
+enum class ComputeTimingSelectorParseError : uint8_t {
+    None,
+    Unset,
+    Empty,
+    Sign,
+    MissingDigits,
+    InvalidDigit,
+    TrailingCharacters,
+    Overflow,
+};
+
+struct ComputeTimingSelectorParseResult {
+    uint64_t value = 0;
+    ComputeTimingSelectorParseError error = ComputeTimingSelectorParseError::Unset;
+
+    constexpr bool accepted() const {
+        return error == ComputeTimingSelectorParseError::None;
+    }
+};
+
+// Strict unsigned parsing for diagnostic selectors. std::strtoull accepts signs and leading
+// whitespace, both of which make a mistyped stable identity look armed. Decimal and 0x-prefixed
+// hexadecimal are the only accepted forms; every byte must belong to the value.
+inline ComputeTimingSelectorParseResult parse_compute_timing_selector_u64(
+    const char* text) {
+    if (!text) return {0, ComputeTimingSelectorParseError::Unset};
+    const std::string_view input(text);
+    if (input.empty()) return {0, ComputeTimingSelectorParseError::Empty};
+    if (input.front() == '+' || input.front() == '-')
+        return {0, ComputeTimingSelectorParseError::Sign};
+
+    int base = 10;
+    std::size_t prefix = 0;
+    if (input.size() >= 2 && input[0] == '0' &&
+        (input[1] == 'x' || input[1] == 'X')) {
+        base = 16;
+        prefix = 2;
+    }
+    if (prefix == input.size())
+        return {0, ComputeTimingSelectorParseError::MissingDigits};
+
+    uint64_t value = 0;
+    const char* begin = input.data() + prefix;
+    const char* end = input.data() + input.size();
+    const auto parsed = std::from_chars(begin, end, value, base);
+    if (parsed.ec == std::errc::result_out_of_range)
+        return {0, ComputeTimingSelectorParseError::Overflow};
+    if (parsed.ec == std::errc::invalid_argument)
+        return {0, ComputeTimingSelectorParseError::InvalidDigit};
+    if (parsed.ptr != end)
+        return {0, ComputeTimingSelectorParseError::TrailingCharacters};
+    return {value, ComputeTimingSelectorParseError::None};
+}
+
+inline const char* compute_timing_selector_parse_error_name(
+    ComputeTimingSelectorParseError error) {
+    switch (error) {
+        case ComputeTimingSelectorParseError::None: return "none";
+        case ComputeTimingSelectorParseError::Unset: return "unset";
+        case ComputeTimingSelectorParseError::Empty: return "empty";
+        case ComputeTimingSelectorParseError::Sign: return "sign-not-allowed";
+        case ComputeTimingSelectorParseError::MissingDigits: return "missing-digits";
+        case ComputeTimingSelectorParseError::InvalidDigit: return "invalid-digit";
+        case ComputeTimingSelectorParseError::TrailingCharacters: return "trailing-characters";
+        case ComputeTimingSelectorParseError::Overflow: return "overflow";
+    }
+    return "unknown";
+}
+
+struct ComputeTimingSelector {
+    bool address_enabled = false;
+    bool address_valid = true;
+    uint64_t address = 0;
+    bool hash_requested = false;
+    bool hash_valid = true;
+    uint64_t hash = 0;
+};
+
+// Address and stable hash are an AND when both are present. An invalid explicitly requested filter
+// fails closed; silently falling back to an unfiltered trace would turn an apparatus error into a
+// very large, plausibly useful-looking log.
+constexpr bool compute_timing_selector_matches(const ComputeTimingSelector& selector,
+                                                uint64_t code_addr,
+                                                uint64_t program_hash) {
+    if (!selector.address_valid || !selector.hash_valid) return false;
+    return (!selector.address_enabled || code_addr == selector.address) &&
+           (!selector.hash_requested || program_hash == selector.hash);
+}
+
+struct ComputeTimingSelectorCounters {
+    uint64_t seen = 0;
+    uint64_t matched = 0;
+};
+
+struct ComputeTimingSelectorObservation {
+    bool matched = false;
+    bool first_match = false;
+};
+
+constexpr uint64_t saturating_increment(uint64_t value) {
+    return value == std::numeric_limits<uint64_t>::max() ? value : value + 1;
+}
+
+inline ComputeTimingSelectorObservation observe_compute_timing_selector(
+    const ComputeTimingSelector& selector,
+    ComputeTimingSelectorCounters& counters,
+    uint64_t code_addr,
+    uint64_t program_hash) {
+    counters.seen = saturating_increment(counters.seen);
+    const bool matched = compute_timing_selector_matches(selector, code_addr, program_hash);
+    const bool first_match = matched && counters.matched == 0;
+    if (matched) counters.matched = saturating_increment(counters.matched);
+    return {matched, first_match};
+}
+
+constexpr bool compute_timing_zero_match_is_invalid(
+    const ComputeTimingSelectorCounters& counters) {
+    return counters.matched == 0;
+}
+
+} // namespace prosper::frontend

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -1,4 +1,5 @@
 #include "live_compute.hpp"
+#include "compute_timing_selector.hpp"
 #include "live_target_format.hpp"
 #include "rtt_scale.hpp"
 #include "rtt_authority.hpp"
@@ -2654,13 +2655,105 @@ bool trace_compute_item(const prosper::gpu::ComputeItem& item) {
     return true;
 }
 
-bool time_compute_item(const prosper::gpu::ComputeItem& item) {
+bool time_compute_address_matches(const prosper::gpu::ComputeItem& item) {
     const char* code_env = std::getenv("PROSPER_COMPUTE_TIMING_CODE");
     if (!code_env || !*code_env) return true;
     char* end = nullptr;
     errno = 0;
     const uint64_t wanted = std::strtoull(code_env, &end, 0);
     return !errno && end != code_env && end && !*end && item.code_addr == wanted;
+}
+
+class RuntimeComputeTimingSelector {
+public:
+    RuntimeComputeTimingSelector() {
+        const char* hash_env = std::getenv("PROSPER_COMPUTE_TIMING_HASH");
+        if (!hash_env) return;
+        hash_requested_ = true;
+        const ComputeTimingSelectorParseResult parsed =
+            parse_compute_timing_selector_u64(hash_env);
+        hash_error_ = parsed.error;
+        selector_.hash_requested = true;
+        selector_.hash_valid = parsed.accepted();
+        selector_.hash = parsed.value;
+        const char* address_env = std::getenv("PROSPER_COMPUTE_TIMING_CODE");
+        const bool address_requested = address_env && *address_env;
+        if (parsed.accepted()) {
+            std::fprintf(stderr,
+                         "[compute-timing-filter] PROSPER_COMPUTE_TIMING_HASH accepted "
+                         "value=0x%016llx mode=%s\n",
+                         static_cast<unsigned long long>(parsed.value),
+                         address_requested ? "address+hash-AND" : "hash-only");
+        } else {
+            std::fprintf(stderr,
+                         "[compute-timing-filter] PROSPER_COMPUTE_TIMING_HASH ignored "
+                         "reason=%s; selector fails closed\n",
+                         compute_timing_selector_parse_error_name(parsed.error));
+        }
+    }
+
+    ~RuntimeComputeTimingSelector() {
+        if (!hash_requested_) return;
+        std::lock_guard lock(mutex_);
+        if (!selector_.hash_valid) {
+            std::fprintf(stderr,
+                         "[compute-timing-filter] summary status=ignored reason=%s "
+                         "seen=%llu matched=%llu verdict=INVALID-selector-not-armed\n",
+                         compute_timing_selector_parse_error_name(hash_error_),
+                         static_cast<unsigned long long>(counters_.seen),
+                         static_cast<unsigned long long>(counters_.matched));
+            return;
+        }
+        std::fprintf(stderr,
+                     "[compute-timing-filter] summary status=accepted hash=0x%016llx "
+                     "seen=%llu matched=%llu verdict=%s\n",
+                     static_cast<unsigned long long>(selector_.hash),
+                     static_cast<unsigned long long>(counters_.seen),
+                     static_cast<unsigned long long>(counters_.matched),
+                     compute_timing_zero_match_is_invalid(counters_)
+                         ? "INVALID-zero-matches" : "matched");
+    }
+
+    bool matches(const prosper::gpu::ComputeItem& item, uint64_t program_hash) {
+        if (!hash_requested_) return time_compute_address_matches(item);
+
+        ComputeTimingSelector current = selector_;
+        const char* code_env = std::getenv("PROSPER_COMPUTE_TIMING_CODE");
+        if (code_env && *code_env) {
+            current.address_enabled = true;
+            char* end = nullptr;
+            errno = 0;
+            current.address = std::strtoull(code_env, &end, 0);
+            current.address_valid = !errno && end != code_env && end && !*end;
+        }
+        std::lock_guard lock(mutex_);
+        const ComputeTimingSelectorObservation observation =
+            observe_compute_timing_selector(
+                current, counters_, item.code_addr, program_hash);
+        if (observation.first_match) {
+            std::fprintf(stderr,
+                         "[compute-timing-filter] first-match hash=0x%016llx "
+                         "code=0x%llx seen=%llu matched=%llu\n",
+                         static_cast<unsigned long long>(program_hash),
+                         static_cast<unsigned long long>(item.code_addr),
+                         static_cast<unsigned long long>(counters_.seen),
+                         static_cast<unsigned long long>(counters_.matched));
+        }
+        return observation.matched;
+    }
+
+private:
+    bool hash_requested_ = false;
+    ComputeTimingSelectorParseError hash_error_ =
+        ComputeTimingSelectorParseError::Unset;
+    ComputeTimingSelector selector_;
+    ComputeTimingSelectorCounters counters_;
+    std::mutex mutex_;
+};
+
+RuntimeComputeTimingSelector& runtime_compute_timing_selector() {
+    static RuntimeComputeTimingSelector selector;
+    return selector;
 }
 
 void maybe_dump_traced_compute_spirv(const prosper::gpu::ComputeItem& item, bool trace) {
@@ -2898,13 +2991,29 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         image_descriptors.begin(), image_descriptors.end(), [](const auto& descriptor) {
             return descriptor.kind == SpirvDescriptorKind::StorageImage;
         });
+    const bool phase_timing_requested =
+        std::getenv("PROSPER_COMPUTE_PHASE_TIMING") != nullptr;
+    const bool image_timing_requested =
+        std::getenv("PROSPER_COMPUTE_IMAGE_TIMING") != nullptr;
+    // Preserve the cheap address pre-filter: an address-mismatched item never needs a stable hash.
+    // Hash-only selection has no address constraint and therefore hashes each timing candidate, as
+    // required; timing-disabled execution reaches neither this branch nor the hash walk.
+    uint64_t timing_program_hash = 0;
+    bool timing_item_selected = false;
+    if ((phase_timing_requested || image_timing_requested) &&
+        time_compute_address_matches(item)) {
+        timing_program_hash = gpu_capture_hash(
+            reinterpret_cast<const uint8_t*>(spirv.data()),
+            spirv.size() * sizeof(uint32_t));
+        timing_item_selected =
+            runtime_compute_timing_selector().matches(item, timing_program_hash);
+    }
     // The phase timer is also useful for buffer-only kernels. Astro Bot's heaviest dispatcher writes
     // buffers exclusively, so the historical storage-image gate hid the actual frame bottleneck.
     const bool timing_trace_only =
         std::getenv("PROSPER_COMPUTE_TIMING_TRACE_ONLY") != nullptr;
     const bool phase_timing =
-        std::getenv("PROSPER_COMPUTE_PHASE_TIMING") != nullptr &&
-        time_compute_item(item) &&
+        phase_timing_requested && timing_item_selected &&
         (!timing_trace_only || trace);
     if (has_storage_images && !ctx.image_support) {
         static bool warned = false;
@@ -3275,8 +3384,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             images_ready = false;
         };
         const bool image_timing =
-            std::getenv("PROSPER_COMPUTE_IMAGE_TIMING") != nullptr &&
-            time_compute_item(item) &&
+            image_timing_requested && timing_item_selected &&
             (!timing_trace_only || trace);
         for (size_t i = 0; i < image_descriptors.size() && images_ready; i++) {
             const auto image_start = ComputeClock::now();
@@ -3846,9 +3954,11 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             if (bi.alias_of != SIZE_MAX) {
                 if (image_timing)
                     std::fprintf(stderr,
-                                 "[compute-image] code=0x%llx binding=%u class=%s alias=1 "
+                                 "[compute-image] code=0x%llx hash=0x%016llx "
+                                 "binding=%u class=%s alias=1 "
                                  "extent=%ux%ux%u ms=%.3f\n",
-                                 (unsigned long long)item.code_addr, bi.binding,
+                                 (unsigned long long)item.code_addr,
+                                 (unsigned long long)timing_program_hash, bi.binding,
                                  bi.storage ? "storage" : "sampled", r->width, r->height, r->depth,
                                  std::chrono::duration<double, std::milli>(
                                      ComputeClock::now() - image_start).count());
@@ -4976,13 +5086,15 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             }
             if (image_timing)
                 std::fprintf(stderr,
-                             "[compute-image] code=0x%llx binding=%u class=%s imported=%u "
+                             "[compute-image] code=0x%llx hash=0x%016llx "
+                             "binding=%u class=%s imported=%u "
                              "extent=%ux%ux%u guest=%zu staging=%llu "
                              "normalized=%u texel=%u sampled-float=%u rgba8-reuse=%u "
                              "query_ms=%.3f import_ms=%.3f cache_ms=%.3f "
                              "staging_ms=%.3f prepare_ms=%.3f allocation_ms=%.3f "
                              "view_ms=%.3f sampler_ms=%.3f ms=%.3f\n",
-                             (unsigned long long)item.code_addr, bi.binding,
+                             (unsigned long long)item.code_addr,
+                             (unsigned long long)timing_program_hash, bi.binding,
                              bi.storage ? "storage" : "sampled", bi.imported ? 1u : 0u,
                              r->width, r->height, r->depth, bi.guest_bytes,
                              (unsigned long long)sbytes,
@@ -6283,12 +6395,14 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             image_cache_ms += image_milliseconds(notify_done, cache_done);
             if (image_timing)
                 std::fprintf(stderr,
-                             "[compute-image-writeback] code=0x%llx binding=%u addr=0x%llx "
+                             "[compute-image-writeback] code=0x%llx hash=0x%016llx "
+                             "binding=%u addr=0x%llx "
                              "fmt=%u comps=%u tile=%u bytes=%zu cache-hit=%u seed-skip=%u "
                              "poison=%u map_ms=%.3f prepare_ms=%.3f watch_ms=%.3f "
                              "pack_ms=%.3f layout_ms=%.3f notify_ms=%.3f cache_ms=%.3f "
                              "total_ms=%.3f\n",
-                             (unsigned long long)item.code_addr, bi.binding,
+                             (unsigned long long)item.code_addr,
+                             (unsigned long long)timing_program_hash, bi.binding,
                              (unsigned long long)r->gpu_addr, (unsigned)r->format, nc,
                              r->tile_mode, bi.guest_bytes, image_cache_hit ? 1u : 0u,
                              bi.seed_skip ? 1u : 0u, bi.poison_verify ? 1u : 0u,
@@ -6385,7 +6499,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             return std::chrono::duration<double, std::milli>(end - begin).count();
         };
         std::fprintf(stderr,
-                     "[compute-phase] submit=%llu code=0x%llx ok=%u "
+                     "[compute-phase] submit=%llu code=0x%llx hash=0x%016llx ok=%u "
                      "setup_ms=%.2f setup_validate_ms=%.2f setup_buffers_ms=%.2f "
                      "pipeline_ms=%.2f dispatch_ms=%.2f "
                      "writeback_ms=%.2f writeback_prepare_ms=%.2f "
@@ -6394,7 +6508,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                      "pack_ms=%.2f layout_ms=%.2f notify_ms=%.2f cache_ms=%.2f "
                      "cleanup_ms=%.2f total_ms=%.2f subgroup=%u\n",
                      (unsigned long long)item.submit_no, (unsigned long long)item.code_addr,
-                     ok ? 1u : 0u, milliseconds(phase_start, phase_setup),
+                     (unsigned long long)timing_program_hash, ok ? 1u : 0u,
+                     milliseconds(phase_start, phase_setup),
                      setup_validate_ms, setup_buffers_ms,
                      milliseconds(phase_setup, phase_pipeline),
                      milliseconds(phase_pipeline, phase_dispatch),
@@ -6807,6 +6922,9 @@ void register_live_compute() {
     static bool attempted = false;
     if (attempted) return;
     attempted = true;
+    // Parse and announce a stable timing selector at backend registration, not at the first matching
+    // dispatch. A title that never reaches compute must still prove whether the instrument armed.
+    (void)runtime_compute_timing_selector();
     const char* enabled = std::getenv("PROSPER_COMPUTE");
     if (enabled && (!std::strcmp(enabled, "0") || !std::strcmp(enabled, "off"))) {
         std::fprintf(stderr, "[compute] live execution disabled by PROSPER_COMPUTE=%s\n", enabled);

--- a/prosper/tests/test_compute_timing_selector.cpp
+++ b/prosper/tests/test_compute_timing_selector.cpp
@@ -1,0 +1,119 @@
+#include "compute_timing_selector.hpp"
+
+#include <cstdint>
+#include <cstdio>
+#include <limits>
+
+using namespace prosper::frontend;
+
+static int failures = 0;
+#define CHECK(condition, name) do { \
+    if (condition) std::printf("  PASS %s\n", name); \
+    else { std::printf("  FAIL %s\n", name); ++failures; } \
+} while (0)
+
+int main() {
+    std::printf("compute timing selector policy\n");
+
+    const auto unset = parse_compute_timing_selector_u64(nullptr);
+    const auto empty = parse_compute_timing_selector_u64("");
+    const auto decimal_zero = parse_compute_timing_selector_u64("0");
+    const auto decimal_max =
+        parse_compute_timing_selector_u64("18446744073709551615");
+    const auto hex_zero = parse_compute_timing_selector_u64("0x0");
+    const auto hex_max =
+        parse_compute_timing_selector_u64("0Xffffffffffffffff");
+    CHECK(unset.error == ComputeTimingSelectorParseError::Unset &&
+              empty.error == ComputeTimingSelectorParseError::Empty,
+          "unset and empty selectors remain distinguishable");
+    CHECK(decimal_zero.accepted() && decimal_zero.value == 0 &&
+              decimal_max.accepted() &&
+              decimal_max.value == std::numeric_limits<uint64_t>::max() &&
+              hex_zero.accepted() && hex_zero.value == 0 &&
+              hex_max.accepted() &&
+              hex_max.value == std::numeric_limits<uint64_t>::max(),
+          "decimal and hexadecimal uint64 endpoints are accepted exactly");
+
+    CHECK(parse_compute_timing_selector_u64("+1").error ==
+                  ComputeTimingSelectorParseError::Sign &&
+              parse_compute_timing_selector_u64("-1").error ==
+                  ComputeTimingSelectorParseError::Sign,
+          "unsigned selectors reject both signs");
+    CHECK(parse_compute_timing_selector_u64("0x").error ==
+                  ComputeTimingSelectorParseError::MissingDigits &&
+              parse_compute_timing_selector_u64("xyz").error ==
+                  ComputeTimingSelectorParseError::InvalidDigit,
+          "missing and invalid digits are rejected explicitly");
+    CHECK(parse_compute_timing_selector_u64("42x").error ==
+                  ComputeTimingSelectorParseError::TrailingCharacters &&
+              parse_compute_timing_selector_u64("0x2a ").error ==
+                  ComputeTimingSelectorParseError::TrailingCharacters,
+          "trailing bytes and whitespace are rejected");
+    CHECK(parse_compute_timing_selector_u64("18446744073709551616").error ==
+                  ComputeTimingSelectorParseError::Overflow &&
+              parse_compute_timing_selector_u64("0x10000000000000000").error ==
+                  ComputeTimingSelectorParseError::Overflow,
+          "decimal and hexadecimal overflow are rejected");
+
+    ComputeTimingSelector address_only;
+    address_only.address_enabled = true;
+    address_only.address = 0x1234;
+    CHECK(compute_timing_selector_matches(address_only, 0x1234, 0xaaaa) &&
+              !compute_timing_selector_matches(address_only, 0x1235, 0xaaaa),
+          "address-only selection preserves exact legacy behavior");
+    address_only.address_valid = false;
+    CHECK(!compute_timing_selector_matches(address_only, 0x1234, 0xaaaa),
+          "invalid address selectors fail closed");
+
+    ComputeTimingSelector hash_only;
+    hash_only.hash_requested = true;
+    hash_only.hash = 0xfeedface;
+    ComputeTimingSelector both = hash_only;
+    both.address_enabled = true;
+    both.address = 0x1234;
+    CHECK(compute_timing_selector_matches(hash_only, 0x9999, 0xfeedface) &&
+              compute_timing_selector_matches(both, 0x1234, 0xfeedface),
+          "stable hash match selects hash-only and address-AND-hash modes");
+    CHECK(!compute_timing_selector_matches(hash_only, 0x9999, 0xfeedfacf) &&
+              !compute_timing_selector_matches(both, 0x1234, 0xfeedfacf) &&
+              !compute_timing_selector_matches(both, 0x1235, 0xfeedface),
+          "stable hash mismatches never select");
+    hash_only.hash_valid = false;
+    CHECK(!compute_timing_selector_matches(hash_only, 0x9999, 0xfeedface),
+          "invalid hash selectors fail closed");
+
+    ComputeTimingSelectorCounters counters;
+    const auto miss = observe_compute_timing_selector(
+        both, counters, 0x1235, 0xfeedface);
+    const auto first = observe_compute_timing_selector(
+        both, counters, 0x1234, 0xfeedface);
+    const auto later = observe_compute_timing_selector(
+        both, counters, 0x1234, 0xfeedface);
+    CHECK(!miss.matched && !miss.first_match && first.matched && first.first_match &&
+              later.matched && !later.first_match &&
+              counters.seen == 3 && counters.matched == 2,
+          "seen and matched counters emit exactly one first-match proof");
+
+    ComputeTimingSelectorCounters saturated{
+        std::numeric_limits<uint64_t>::max(),
+        std::numeric_limits<uint64_t>::max()};
+    const auto saturated_match = observe_compute_timing_selector(
+        both, saturated, 0x1234, 0xfeedface);
+    CHECK(saturated_match.matched && !saturated_match.first_match &&
+              saturated.seen == std::numeric_limits<uint64_t>::max() &&
+              saturated.matched == std::numeric_limits<uint64_t>::max(),
+          "diagnostic counters saturate instead of wrapping");
+
+    ComputeTimingSelectorCounters zero_matches{7, 0};
+    ComputeTimingSelectorCounters one_match{7, 1};
+    CHECK(compute_timing_zero_match_is_invalid(zero_matches) &&
+              !compute_timing_zero_match_is_invalid(one_match),
+          "zero-match summary is apparatus-invalid");
+
+    if (failures) {
+        std::printf("%d check(s) failed\n", failures);
+        return 1;
+    }
+    std::printf("all checks passed\n");
+    return 0;
+}

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -274,6 +274,14 @@ the shipped runtime. Build them from `build-linux/` like everything else.
   model of `execute_item` stops matching the emitter. Counts here cover backend-executed dispatches
   only — CPU-fast-path fills emit no record, so add
   `[render-timing] compute_cpu_fast fills=N` before quoting a rate.
+  Restrict a rerun by the F8 report's cross-run SPIR-V identity with
+  `PROSPER_COMPUTE_TIMING_HASH=0x...`; use `PROSPER_COMPUTE_TIMING_CODE=0x...` only for a known
+  run-local address. If both are present they are an AND. The accepted/ignored banner, first-match
+  line, and termination `seen`/`matched` summary are part of the validity contract: zero matches is
+  apparatus-invalid. Every selected phase/image record carries both identities. The selector's pure
+  policy is covered by ctest `compute_timing_selector_policy`; run
+  `tools/perf/mutate_compute_timing_selector.sh` to prove the exact mismatch and zero-match checks
+  kill their corresponding mutations.
   `test_compute_phase_report.py` self-tests it (ctest `compute_phase_report_logic`), and
   `mutate_compute_phase_report.sh` checks that suite at **per-check granularity** — each mutation must
   be killed by the check written for it, because a survivor masked by red siblings is invisible when

--- a/prosper/tools/perf/mutate_compute_timing_selector.sh
+++ b/prosper/tools/perf/mutate_compute_timing_selector.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Per-check mutation coverage for the pure compute-timing selector policy.
+#
+# A green selector test proves its fixtures ran. These mutations prove that the exact checks named
+# below detect the two dangerous failure shapes: accepting the wrong stable program, and calling a
+# zero-match run valid. The tracked source is never edited; each mutation builds a scratch copy.
+set -u
+
+HERE=$(cd "$(dirname "$0")" && pwd)
+ROOT=$(cd "$HERE/../.." && pwd)
+WORK=$(mktemp -d "${TMPDIR:-/var/tmp}/compute-timing-selector-mutate-XXXXXX") || exit 2
+trap 'rm -rf "$WORK"' EXIT
+cp "$ROOT/frontends/shared/compute_timing_selector.hpp" \
+   "$ROOT/tests/test_compute_timing_selector.cpp" "$WORK/" || exit 2
+HEADER="$WORK/compute_timing_selector.hpp"
+PRISTINE="$WORK/pristine.hpp"
+cp "$HEADER" "$PRISTINE"
+CXX_BIN=${CXX:-c++}
+
+build_and_run() {
+  "$CXX_BIN" -std=c++20 -Wall -Wextra -Werror -I"$WORK" \
+    "$WORK/test_compute_timing_selector.cpp" -o "$WORK/test-selector" || return 2
+  "$WORK/test-selector" 2>&1
+}
+
+run_mutation() { # $1=name $2=exact check $3=old $4=new
+  cp "$PRISTINE" "$HEADER"
+  python3 - "$HEADER" "$3" "$4" <<'PY' || return 1
+import sys
+path, old, new = sys.argv[1:]
+with open(path, encoding="utf-8") as stream:
+    source = stream.read()
+if source.count(old) != 1:
+    raise SystemExit(f"anchor count is {source.count(old)}, expected exactly one")
+with open(path, "w", encoding="utf-8") as stream:
+    stream.write(source.replace(old, new, 1))
+PY
+  output=$(build_and_run)
+  status=$?
+  if [ "$status" -eq 2 ]; then
+    printf '  %-34s BUILD FAILED (mutation not observed)\n' "$1"
+    return 1
+  fi
+  failed=$(printf '%s\n' "$output" | sed -n 's/^  FAIL //p')
+  if [ "$status" -eq 0 ]; then
+    printf '  %-34s *** SURVIVED ***\n' "$1"
+    return 1
+  fi
+  if [ "$failed" = "$2" ]; then
+    printf '  %-34s killed by: %s\n' "$1" "$2"
+    return 0
+  fi
+  printf '  %-34s WRONG KILL expected "%s", got: %s\n' "$1" "$2" "$failed"
+  return 1
+}
+
+bad=0
+echo "per-check mutation coverage for compute timing selector"
+run_mutation "accept mismatched stable hash" "stable hash mismatches never select" \
+  '(!selector.hash_requested || program_hash == selector.hash);' \
+  '(!selector.hash_requested || (static_cast<void>(program_hash), true));' || bad=1
+run_mutation "accept a zero-match run" "zero-match summary is apparatus-invalid" \
+  'return counters.matched == 0;' \
+  'return counters.matched != 0;' || bad=1
+
+cp "$PRISTINE" "$HEADER"
+if build_and_run >/dev/null; then
+  echo "unmutated copy: suite green"
+else
+  echo "unmutated copy: SUITE NOT GREEN"; bad=1
+fi
+exit "$bad"


### PR DESCRIPTION
## Summary

- add `PROSPER_COMPUTE_TIMING_HASH=0x...` as a stable translated-SPIR-V selector for detailed compute phase/image timing
- keep the existing run-local address selector unchanged; when both selectors are present they match by AND
- make the instrument self-validating with strict parsing, accepted/ignored and first-match banners, bounded seen/matched accounting, and an explicit invalid zero-match termination verdict
- carry both `code=` and `hash=` in every selected phase/image timing record
- add a pure cross-platform policy test and per-check mutation harness, plus operator documentation

## Why

Syberia #1737's valid F8 capture localized 73.5% of compute time to stable hash `0xa57c763ae4d70d1d`, but detailed compute timing can currently select only a run-local code address. The workaround emits timing for every dispatch and discovers the current address afterward, generating a large intrusive log. This selector lets the next phase trace name the stable shader directly and makes a zero-match run visibly an apparatus failure rather than a negative result.

No title-specific address or behavior is encoded here.

## Semantics

- accepted forms: full unsigned decimal or `0x` hexadecimal `uint64_t`
- rejected forms: empty, sign, whitespace/trailing bytes, invalid digits, overflow
- a malformed explicitly requested hash selector fails closed
- `PROSPER_COMPUTE_TIMING_CODE` alone retains its existing behavior
- code + hash selectors are an AND
- the address prefilter runs before hashing; detailed-timing-disabled execution performs no stable-hash walk
- a first match is printed once; counters saturate instead of wrapping; normal termination labels `matched=0` as `INVALID-zero-matches`

## Verification

All commands ran inside distrobox `ps5ys` with a worktree-local disk-backed `TMPDIR`. No title, replay, Vulkan execution test, or GPU path was invoked.

```text
cmake -S . -B build-linux -DCMAKE_BUILD_TYPE=RelWithDebInfo
cmake --build build-linux --target test_compute_timing_selector prosper_live_renderer -j6
```

Result: both targets compiled and linked successfully.

```text
ctest --output-on-failure -R '^(compute_timing_selector_policy|compute_phase_report_logic)$'
```

Result: 2/2 passed.

```text
tools/perf/mutate_compute_timing_selector.sh
```

Result:

```text
accept mismatched stable hash   killed by: stable hash mismatches never select
accept a zero-match run         killed by: zero-match summary is apparatus-invalid
unmutated copy: suite green
```

`git diff --check`: clean.

Fixes #1838
Refs #1737
