### PR TITLE
tools: add draw-scoped replay resource overrides

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -887,6 +887,13 @@ if(TARGET prosper_core)
   target_link_libraries(test_gpu_replay_shader_dump PRIVATE prosper_core)
   add_test(NAME gpu_replay_shader_dump COMMAND test_gpu_replay_shader_dump)
 
+  # Draw-scoped captured-resource replacement: strict semantic selector, exact span validation,
+  # and copy-on-write isolation when draws share tables/backing. Pure/cross-platform; no Vulkan.
+  add_executable(test_gpu_replay_resource_override
+                 tests/test_gpu_replay_resource_override.cpp)
+  target_link_libraries(test_gpu_replay_resource_override PRIVATE prosper_core)
+  add_test(NAME gpu_replay_resource_override COMMAND test_gpu_replay_resource_override)
+
   # Selected-prefix compute output inspection must distinguish captured seed bytes from the
   # descriptor-visible post-dispatch image, including tiled 2D and true 3D storage layouts.
   add_executable(test_gpu_replay_post_compute_resource

--- a/prosper/tests/test_gpu_replay_resource_override.cpp
+++ b/prosper/tests/test_gpu_replay_resource_override.cpp
@@ -1,0 +1,186 @@
+#include "../tools/gpu_replay/resource_override.hpp"
+#include "test_scratch.h"
+
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { std::printf("  [FAIL] %s\n", m); ++fails; } \
+                         else std::printf("  [ok]   %s\n", m); } while (0)
+
+int main() {
+    std::printf("== test_gpu_replay_resource_override ==\n");
+
+    tools::ResourceOverrideSelector selector;
+    CHECK(tools::parse_resource_override_selector("0x481:ps:040", selector) &&
+              selector.draw_index == 1153 &&
+              selector.stage == tools::ResourceOverrideStage::Pixel &&
+              selector.binding == 32,
+          "resource override uses strict semantic draw and explicit-base binding grammar");
+    CHECK(!tools::parse_resource_override_selector("1153:fs:32", selector) &&
+              !tools::parse_resource_override_selector("1153:ps", selector) &&
+              !tools::parse_resource_override_selector("1153:ps:32:extra", selector) &&
+              !tools::parse_resource_override_selector("1153junk:ps:32", selector) &&
+              !tools::parse_resource_override_selector("-1:ps:32", selector) &&
+              !tools::parse_resource_override_selector("1153:ps:0x100000000", selector),
+          "malformed, partial, signed, and overflowing override selectors fail closed");
+
+    std::vector<uint8_t> captured = {0x00, 0x00, 0x00, 0x00};
+    const std::vector<uint8_t> captured_expected = captured;
+    std::vector<uint8_t> neighbour = {0xaa, 0xbb, 0xcc, 0xdd};
+    auto shared_table = std::make_shared<gpu::ShaderResourceTable>();
+    gpu::ShaderResource selected_resource{};
+    selected_resource.cls = gpu::ResourceClass::ConstantBuffer;
+    selected_resource.binding = 32;
+    selected_resource.gpu_addr = 0x12345000;
+    selected_resource.size = 4;
+    selected_resource.host_data = captured.data();
+    selected_resource.host_data_size = captured.size();
+    gpu::ShaderResource neighbouring_resource = selected_resource;
+    neighbouring_resource.binding = 33;
+    neighbouring_resource.gpu_addr = 0x12346000;
+    neighbouring_resource.host_data = neighbour.data();
+    neighbouring_resource.host_data_size = neighbour.size();
+    shared_table->resources = {selected_resource, neighbouring_resource};
+
+    gpu::GpuReplayFrame replay;
+    gpu::DrawItem selected_draw;
+    selected_draw.draw_index = 1153;
+    selected_draw.vrt = shared_table;
+    selected_draw.prt = shared_table;
+    gpu::DrawItem sibling_draw;
+    sibling_draw.draw_index = 1154;
+    sibling_draw.prt = shared_table;
+    replay.items = {selected_draw, sibling_draw};
+
+    CHECK(tools::parse_resource_override_selector("1153:ps:32", selector),
+          "decimal override selector parses");
+    const auto* original_table = shared_table.get();
+    uint8_t* const original_selected_pointer = shared_table->resources[0].host_data;
+    uint8_t* const original_neighbour_pointer = shared_table->resources[1].host_data;
+    const uint64_t original_hash = gpu::gpu_capture_hash(captured);
+    const std::vector<uint8_t> replacement = {0x00, 0x3c, 0x00, 0x3c};
+    const uint64_t expected_replacement_hash = gpu::gpu_capture_hash(replacement);
+    tools::AppliedResourceOverride applied;
+    std::string error;
+    CHECK(tools::apply_resource_override(replay, selector, replacement, applied, error),
+          "draw-scoped resource override installs into a captured replay");
+
+    const auto& changed = replay.items[0].prt->resources[0];
+    CHECK(replay.items[0].prt.get() != original_table &&
+              changed.host_data == applied.replacement_bytes->data() &&
+              changed.host_data != original_selected_pointer &&
+              std::memcmp(changed.host_data, replacement.data(), replacement.size()) == 0 &&
+              gpu::gpu_capture_hash(changed.host_data,
+                                    static_cast<size_t>(changed.host_data_size)) ==
+                  expected_replacement_hash &&
+              applied.original_hash == original_hash &&
+              applied.replacement_hash == expected_replacement_hash &&
+              applied.original_hash != applied.replacement_hash,
+          "selected draw bytes and inspect-visible hash change");
+
+    const auto& sibling = replay.items[1].prt->resources[0];
+    CHECK(replay.items[1].prt.get() == original_table &&
+              sibling.host_data == original_selected_pointer &&
+              captured == captured_expected &&
+              std::memcmp(sibling.host_data, captured_expected.data(), captured_expected.size()) == 0 &&
+              gpu::gpu_capture_hash(sibling.host_data,
+                                    static_cast<size_t>(sibling.host_data_size)) == original_hash,
+          "shared sibling draw remains byte-identical after selected override");
+    CHECK(replay.items[0].vrt.get() == original_table &&
+              replay.items[0].prt->resources[1].host_data == original_neighbour_pointer &&
+              neighbour == std::vector<uint8_t>({0xaa, 0xbb, 0xcc, 0xdd}),
+          "unselected stage and binding retain their original objects and bytes");
+    CHECK(applied.target.item_index == 0 && applied.target.resource_index == 0 &&
+              applied.target.gpu_addr == 0x12345000 && applied.target.captured_size == 4,
+          "installed override reports exact draw-resource identity and captured span");
+
+    tools::AppliedResourceOverride rejected;
+    auto missing_draw = selector;
+    missing_draw.draw_index = 9999;
+    CHECK(!tools::apply_resource_override(replay, missing_draw, replacement, rejected, error) &&
+              error.find("realized draw 9999 not found") != std::string::npos,
+          "missing semantic draw fails visibly");
+    auto missing_binding = selector;
+    missing_binding.binding = 99;
+    CHECK(!tools::apply_resource_override(replay, missing_binding, replacement, rejected, error) &&
+              error.find("binding 99 not found") != std::string::npos,
+          "missing binding fails visibly");
+    CHECK(!tools::apply_resource_override(replay, selector, {1, 2, 3}, rejected, error) &&
+              error.find("selected captured span is 4 bytes") != std::string::npos,
+          "replacement size mismatch fails before changing replay state");
+    CHECK(replay.items[0].prt->resources[0].host_data == changed.host_data &&
+              gpu::gpu_capture_hash(replay.items[0].prt->resources[0].host_data, 4) ==
+                  expected_replacement_hash,
+          "failed override leaves the previously selected bytes unchanged");
+
+    const auto exact_path = prosper_test::test_scratch_dir() / "resource-override-exact.bin";
+    const auto short_path = prosper_test::test_scratch_dir() / "resource-override-short.bin";
+    {
+        std::ofstream exact(exact_path, std::ios::binary);
+        exact.write(reinterpret_cast<const char*>(replacement.data()), replacement.size());
+        std::ofstream short_file(short_path, std::ios::binary);
+        short_file.write(reinterpret_cast<const char*>(replacement.data()),
+                         replacement.size() - 1);
+    }
+    std::vector<uint8_t> loaded_override;
+    CHECK(tools::read_exact_resource_override_file(
+              exact_path.string(), replacement.size(), loaded_override, error) &&
+              loaded_override == replacement,
+          "replacement file reader accepts exactly the selected captured span");
+    CHECK(!tools::read_exact_resource_override_file(
+              short_path.string(), replacement.size(), loaded_override, error) &&
+              error.find("has 3 bytes") != std::string::npos,
+          "replacement file size mismatch fails visibly");
+    CHECK(!tools::read_exact_resource_override_file(
+              (prosper_test::test_scratch_dir() / "missing.bin").string(),
+              replacement.size(), loaded_override, error) &&
+              error.find("cannot read resource override") != std::string::npos,
+          "missing replacement file fails visibly");
+
+    gpu::GpuReplayFrame ambiguous;
+    gpu::DrawItem ambiguous_draw;
+    ambiguous_draw.draw_index = 12;
+    ambiguous_draw.prt = std::make_shared<gpu::ShaderResourceTable>();
+    ambiguous_draw.prt->resources = {selected_resource, selected_resource};
+    ambiguous.items.push_back(ambiguous_draw);
+    auto ambiguous_selector = selector;
+    ambiguous_selector.draw_index = 12;
+    CHECK(!tools::apply_resource_override(
+              ambiguous, ambiguous_selector, replacement, rejected, error) &&
+              error.find("binding 32 is ambiguous") != std::string::npos,
+          "duplicate binding fails instead of selecting an arbitrary resource");
+
+    gpu::GpuReplayFrame absent_table;
+    gpu::DrawItem absent_draw;
+    absent_draw.draw_index = 13;
+    absent_table.items.push_back(absent_draw);
+    auto absent_selector = selector;
+    absent_selector.draw_index = 13;
+    CHECK(!tools::apply_resource_override(
+              absent_table, absent_selector, replacement, rejected, error) &&
+              error.find("resource table is absent") != std::string::npos,
+          "missing stage table fails visibly");
+
+    gpu::GpuReplayFrame absent_bytes;
+    gpu::DrawItem byte_less_draw;
+    byte_less_draw.draw_index = 14;
+    byte_less_draw.prt = std::make_shared<gpu::ShaderResourceTable>();
+    auto byte_less_resource = selected_resource;
+    byte_less_resource.host_data = nullptr;
+    byte_less_resource.host_data_size = 0;
+    byte_less_draw.prt->resources.push_back(byte_less_resource);
+    absent_bytes.items.push_back(byte_less_draw);
+    auto absent_bytes_selector = selector;
+    absent_bytes_selector.draw_index = 14;
+    CHECK(!tools::apply_resource_override(
+              absent_bytes, absent_bytes_selector, replacement, rejected, error) &&
+              error.find("has no captured bytes") != std::string::npos,
+          "resource without captured bytes fails visibly");
+
+    std::printf("%s\n", fails ? "FAILED" : "ALL TESTS PASSED");
+    return fails ? 1 : 0;
+}

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -181,6 +181,8 @@ render-state resolve, executor ordering, detile) — it is the right guard for c
   /tmp/submit.prgcap                              # visual bisection filmstrip (see below)
 ./build-linux/gpu_replay --warmup-repeats 2 /tmp/submit.prgcap /tmp/converged.bmp
 ./build-linux/gpu_replay --dump-resource 18:ps:34 /tmp/texture.bin /tmp/submit.prgcap
+./build-linux/gpu_replay --override-resource 18:ps:34 ~/captures/texture.bin \
+  --inspect-only ~/captures/submit.prgcap
 ./build-linux/gpu_replay --dump-rtt-seed 0x7f9f504b0000 /tmp/history.bmp \
   --inspect-only /tmp/submit.prgcap
 ./build-linux/gpu_replay --dump-shader 18:fs /tmp/fragment.spv /tmp/submit.prgcap
@@ -456,13 +458,24 @@ These environment variables are localization probes, not fixes, and their output
 regression oracle.
 
 Every user-facing `DRAW` selector (`--draw`, `--dump-resource`, `--dump-shader`,
-`--dump-realized-shader`, `PROSPER_GEOM_PROBE`, and `PROSPER_FS_TAP`) uses the stable semantic draw ID
+`--override-resource`, `--dump-realized-shader`, `PROSPER_GEOM_PROBE`, and `PROSPER_FS_TAP`) uses
+the stable semantic draw ID
 printed as `draw[ID]` by `--inspect-only`. The adjacent `item=I` is only the compact realized-vector offset;
 it can differ after an unrealized draw and is never a selector. Mixed `operation[N]` ordinals remain a separate,
 explicit namespace used by `--through-operation`. Replay restores serialized render-target seeds before
 operation zero and uses owned resource memory; it must not dereference original guest mappings. Bundle
 operation sources are semantic draw IDs and may contain holes; tooling resolves them through each realized
 item's `draw_index`, never as offsets into the compact draw vector.
+
+`--override-resource DRAW:vs|ps:BINDING PATH` replaces exactly one realized draw's captured
+resource span in memory. The file must have exactly the selected resource's captured byte count.
+The tool clones the selected stage table and owns the replacement separately, so other draws that
+share a table or content-deduplicated backing remain unchanged. It prints the draw, stage, binding,
+guest address, size, and stable original/replacement hashes. Combine it with `--inspect-only` to
+prove the replacement was installed without initializing Vulkan; the selected table's normal
+`hash=` field will equal the reported `new-hash`. A rendering replay still enforces the capture's
+output oracle, so add the explicit `--allow-mismatch` diagnostic option when an intentional input
+change is expected to alter the final image.
 
 `--draw-with-compute-prefix` retains every compute operation before the selected draw while discarding the
 other graphics draws. This isolates geometry whose vertex/indirect buffers are produced earlier in the same

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -11,6 +11,7 @@
 #include "realized_shader_dump.hpp"
 #include "pixel_input_linkage.hpp"
 #include "post_compute_resource.hpp"
+#include "resource_override.hpp"
 #include "render_runner.h"
 
 #include <algorithm>
@@ -65,6 +66,7 @@ void usage(const char* argv0) {
                          "[--recompile-raw] "
                          "[--prepend producer.prgcap] "
                          "[--dump-resource DRAW:vs|ps:BINDING PATH] [--allow-mismatch] "
+                         "[--override-resource DRAW:vs|ps:BINDING PATH] "
                          "[--dump-rtt-seed ADDR PATH] "
                          "[--dump-shader DRAW:vs|fs PATH] [--dump-compute N PATH] "
                          "[--dump-realized-shader DRAW:vs|vs-main|fs PATH] "
@@ -1695,6 +1697,9 @@ int main(int argc, char** argv) {
     std::string dump_spec, dump_path, shader_spec, shader_path;
     std::string compute_shader_spec, compute_shader_path;
     std::string compute_override_spec, compute_override_path;
+    bool resource_override_requested = false;
+    prosper::tools::ResourceOverrideSelector resource_override_selector;
+    std::string resource_override_path;
     std::string compute_resource_spec, compute_resource_path;
     std::string post_compute_resource_spec, post_compute_resource_path;
     std::string failed_shader_spec, failed_shader_path;
@@ -1827,6 +1832,21 @@ int main(int argc, char** argv) {
         else if (std::string(argv[i]) == "--dump-resource" && i + 2 < argc) {
             dump_spec = argv[++i]; dump_path = argv[++i];
         }
+        else if (std::string(argv[i]) == "--override-resource" && i + 2 < argc) {
+            if (resource_override_requested) {
+                std::fprintf(stderr, "gpu_replay: duplicate --override-resource\n");
+                return 2;
+            }
+            const char* selector = argv[++i];
+            if (!prosper::tools::parse_resource_override_selector(
+                    selector, resource_override_selector)) {
+                std::fprintf(stderr, "gpu_replay: invalid resource override selector %s\n",
+                             selector);
+                return 2;
+            }
+            resource_override_path = argv[++i];
+            resource_override_requested = true;
+        }
         else if (std::string(argv[i]) == "--dump-rtt-seed" && i + 2 < argc) {
             char* end = nullptr;
             rtt_seed_addr = std::strtoull(argv[++i], &end, 0);
@@ -1891,6 +1911,7 @@ int main(int argc, char** argv) {
             !shader_spec.empty() || !compute_shader_spec.empty() ||
             !realized_shader_spec.empty() ||
             !compute_override_spec.empty() ||
+            resource_override_requested ||
             !compute_resource_spec.empty() || !post_compute_resource_spec.empty() ||
             require_post_change || expected_post_hash_set || !failed_shader_spec.empty() ||
             !retry_failed_chain_spec.empty() ||
@@ -1971,6 +1992,26 @@ int main(int argc, char** argv) {
     prosper::gpu::GpuReplayFrame replay;
     if (!prosper::gpu::materialize_gpu_replay(capture, replay, error)) {
         std::fprintf(stderr, "gpu_replay: cannot materialize: %s\n", error.c_str()); return 2;
+    }
+    prosper::tools::AppliedResourceOverride applied_resource_override;
+    if (resource_override_requested) {
+        if (!prosper::tools::apply_resource_override_file(
+                replay, resource_override_selector, resource_override_path,
+                applied_resource_override, error)) {
+            std::fprintf(stderr, "gpu_replay: cannot override resource: %s\n", error.c_str());
+            return 2;
+        }
+        const auto& selector = applied_resource_override.selector;
+        const auto& target = applied_resource_override.target;
+        std::fprintf(stderr,
+                     "[resource-override] draw=%llu stage=%s binding=%u addr=%016llx "
+                     "size=%llu original-hash=%016llx new-hash=%016llx\n",
+                     static_cast<unsigned long long>(selector.draw_index),
+                     prosper::tools::resource_override_stage_name(selector.stage),
+                     selector.binding, static_cast<unsigned long long>(target.gpu_addr),
+                     static_cast<unsigned long long>(target.captured_size),
+                     static_cast<unsigned long long>(applied_resource_override.original_hash),
+                     static_cast<unsigned long long>(applied_resource_override.replacement_hash));
     }
     prosper::gpu::GpuCaptureFile prepend_capture;
     prosper::gpu::GpuReplayFrame prepend;

--- a/prosper/tools/gpu_replay/resource_override.hpp
+++ b/prosper/tools/gpu_replay/resource_override.hpp
@@ -1,0 +1,215 @@
+#pragma once
+
+#include "../../src/gpu/diagnostic_selectors.hpp"
+#include "../../src/gpu/gpu_capture.hpp"
+#include "realized_shader_dump.hpp"
+
+#include <cstdint>
+#include <fstream>
+#include <limits>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace prosper::tools {
+
+enum class ResourceOverrideStage {
+    Vertex,
+    Pixel,
+};
+
+struct ResourceOverrideSelector {
+    uint64_t draw_index = 0;
+    ResourceOverrideStage stage = ResourceOverrideStage::Vertex;
+    uint32_t binding = 0;
+};
+
+struct ResourceOverrideTarget {
+    size_t item_index = SIZE_MAX;
+    size_t resource_index = SIZE_MAX;
+    uint64_t gpu_addr = 0;
+    uint64_t captured_size = 0;
+};
+
+// Retain this object for as long as the replay may execute. The selected copied resource points at
+// replacement_bytes; keeping that ownership outside GpuReplayFrame avoids changing capture/runtime
+// data structures for a diagnostic-only operation.
+struct AppliedResourceOverride {
+    ResourceOverrideSelector selector;
+    ResourceOverrideTarget target;
+    uint64_t original_hash = 0;
+    uint64_t replacement_hash = 0;
+    std::shared_ptr<std::vector<uint8_t>> replacement_bytes;
+};
+
+inline const char* resource_override_stage_name(ResourceOverrideStage stage) {
+    return stage == ResourceOverrideStage::Vertex ? "vs" : "ps";
+}
+
+inline bool parse_resource_override_selector(std::string_view text,
+                                             ResourceOverrideSelector& selector) {
+    const size_t first_colon = text.find(':');
+    const size_t second_colon = first_colon == std::string_view::npos
+        ? std::string_view::npos : text.find(':', first_colon + 1);
+    if (first_colon == std::string_view::npos || second_colon == std::string_view::npos ||
+        text.find(':', second_colon + 1) != std::string_view::npos)
+        return false;
+
+    uint64_t draw_index = 0;
+    uint64_t binding = 0;
+    if (!gpu::parse_diagnostic_draw_id(text.substr(0, first_colon), draw_index) ||
+        !gpu::parse_diagnostic_uint64(text.substr(second_colon + 1), binding) ||
+        binding > std::numeric_limits<uint32_t>::max())
+        return false;
+
+    const std::string_view stage = text.substr(first_colon + 1,
+                                               second_colon - first_colon - 1);
+    if (stage != "vs" && stage != "ps") return false;
+    selector.draw_index = draw_index;
+    selector.stage = stage == "vs" ? ResourceOverrideStage::Vertex
+                                    : ResourceOverrideStage::Pixel;
+    selector.binding = static_cast<uint32_t>(binding);
+    return true;
+}
+
+inline bool find_resource_override_target(const gpu::GpuReplayFrame& replay,
+                                          const ResourceOverrideSelector& selector,
+                                          ResourceOverrideTarget& target,
+                                          std::string& error) {
+    const size_t item_index = replay_item_index_for_draw(replay, selector.draw_index);
+    if (item_index == SIZE_MAX) {
+        error = "realized draw " + std::to_string(selector.draw_index) + " not found";
+        return false;
+    }
+    const auto& draw = replay.items[item_index];
+    const auto& table = selector.stage == ResourceOverrideStage::Vertex ? draw.vrt : draw.prt;
+    if (!table) {
+        error = "draw " + std::to_string(selector.draw_index) + " " +
+                resource_override_stage_name(selector.stage) + " resource table is absent";
+        return false;
+    }
+
+    size_t resource_index = SIZE_MAX;
+    for (size_t index = 0; index < table->resources.size(); ++index) {
+        if (table->resources[index].binding != selector.binding) continue;
+        if (resource_index != SIZE_MAX) {
+            error = "draw " + std::to_string(selector.draw_index) + " " +
+                    resource_override_stage_name(selector.stage) + " binding " +
+                    std::to_string(selector.binding) + " is ambiguous";
+            return false;
+        }
+        resource_index = index;
+    }
+    if (resource_index == SIZE_MAX) {
+        error = "draw " + std::to_string(selector.draw_index) + " " +
+                resource_override_stage_name(selector.stage) + " binding " +
+                std::to_string(selector.binding) + " not found";
+        return false;
+    }
+
+    const auto& resource = table->resources[resource_index];
+    if (!resource.host_data || resource.host_data_size == 0) {
+        error = "draw " + std::to_string(selector.draw_index) + " " +
+                resource_override_stage_name(selector.stage) + " binding " +
+                std::to_string(selector.binding) + " has no captured bytes";
+        return false;
+    }
+    if (resource.host_data_size > std::numeric_limits<size_t>::max()) {
+        error = "selected captured resource span is too large for this host";
+        return false;
+    }
+
+    target.item_index = item_index;
+    target.resource_index = resource_index;
+    target.gpu_addr = resource.gpu_addr;
+    target.captured_size = resource.host_data_size;
+    error.clear();
+    return true;
+}
+
+inline bool read_exact_resource_override_file(const std::string& path, uint64_t expected_size,
+                                              std::vector<uint8_t>& bytes,
+                                              std::string& error) {
+    if (!expected_size || expected_size > std::numeric_limits<size_t>::max() ||
+        expected_size > static_cast<uint64_t>(std::numeric_limits<std::streamsize>::max())) {
+        error = "selected captured resource span cannot be read on this host";
+        return false;
+    }
+    std::ifstream file(path, std::ios::binary | std::ios::ate);
+    if (!file) {
+        error = "cannot read resource override " + path;
+        return false;
+    }
+    const std::streampos end = file.tellg();
+    if (end < 0 || static_cast<uint64_t>(end) != expected_size) {
+        error = "resource override " + path + " has " +
+                (end < 0 ? std::string("an unreadable size")
+                         : std::to_string(static_cast<uint64_t>(end)) + " bytes") +
+                "; selected captured span is " + std::to_string(expected_size) + " bytes";
+        return false;
+    }
+    file.seekg(0, std::ios::beg);
+    bytes.resize(static_cast<size_t>(expected_size));
+    if (!file.read(reinterpret_cast<char*>(bytes.data()),
+                   static_cast<std::streamsize>(bytes.size()))) {
+        error = "cannot read complete resource override " + path;
+        bytes.clear();
+        return false;
+    }
+    error.clear();
+    return true;
+}
+
+inline bool apply_resource_override(gpu::GpuReplayFrame& replay,
+                                    const ResourceOverrideSelector& selector,
+                                    std::vector<uint8_t> replacement,
+                                    AppliedResourceOverride& applied,
+                                    std::string& error) {
+    ResourceOverrideTarget target;
+    if (!find_resource_override_target(replay, selector, target, error)) return false;
+    if (replacement.size() != target.captured_size) {
+        error = "replacement has " + std::to_string(replacement.size()) +
+                " bytes; selected captured span is " +
+                std::to_string(target.captured_size) + " bytes";
+        return false;
+    }
+
+    auto& draw = replay.items[target.item_index];
+    auto& selected_table = selector.stage == ResourceOverrideStage::Vertex ? draw.vrt : draw.prt;
+    const auto& original_resource = selected_table->resources[target.resource_index];
+
+    AppliedResourceOverride result;
+    result.selector = selector;
+    result.target = target;
+    result.original_hash = gpu::gpu_capture_hash(
+        original_resource.host_data, static_cast<size_t>(original_resource.host_data_size));
+    result.replacement_bytes =
+        std::make_shared<std::vector<uint8_t>>(std::move(replacement));
+    result.replacement_hash = gpu::gpu_capture_hash(*result.replacement_bytes);
+
+    // Draws can deliberately share a resource-table object, while different table entries can
+    // point into one content-deduplicated capture instance. Clone the table and redirect only this
+    // copied entry: mutating either original object would contaminate sibling draws/resources.
+    auto copied_table = std::make_shared<gpu::ShaderResourceTable>(*selected_table);
+    copied_table->resources[target.resource_index].host_data = result.replacement_bytes->data();
+    selected_table = std::move(copied_table);
+    applied = std::move(result);
+    error.clear();
+    return true;
+}
+
+inline bool apply_resource_override_file(gpu::GpuReplayFrame& replay,
+                                         const ResourceOverrideSelector& selector,
+                                         const std::string& path,
+                                         AppliedResourceOverride& applied,
+                                         std::string& error) {
+    ResourceOverrideTarget target;
+    if (!find_resource_override_target(replay, selector, target, error)) return false;
+    std::vector<uint8_t> replacement;
+    if (!read_exact_resource_override_file(path, target.captured_size, replacement, error))
+        return false;
+    return apply_resource_override(replay, selector, std::move(replacement), applied, error);
+}
+
+} // namespace prosper::tools


### PR DESCRIPTION
## Summary

- add `gpu_replay --override-resource DRAW:vs|ps:BINDING PATH`
- parse semantic draw IDs and bindings with the existing strict diagnostic grammar
- require the replacement file to match the selected captured byte span exactly
- clone the selected draw's stage table and retain independent replacement storage
- report draw, stage, binding, guest address, byte size, and stable original/new hashes
- document CPU-only `--inspect-only` verification and the still-fail-visible render oracle

## Why

Graphics investigations often need a controlled A/B where one draw sees modified captured input
without changing any shader or guest behavior. Captured tables and backing bytes can be shared, so
an in-place edit would also change sibling draws and invalidate the discriminator. This tool makes
the copy-on-write boundary explicit and reusable without a title or address special case.

The override is installed immediately after capture materialization, before any path may initialize
Vulkan. Malformed selectors, missing or ambiguous resources, absent captured bytes, unreadable files,
and byte-size mismatches therefore fail before GPU execution. The option does not enable
`--allow-mismatch`; unrelated capture and final-output integrity checks remain fail-visible.

## Validation

Built inside the `ps5ys` distrobox with a worktree-local `TMPDIR` and no game dump:

```text
cmake --build prosper/build-linux --target test_gpu_replay_resource_override gpu_replay -j2
ctest --test-dir prosper/build-linux --output-on-failure \
  -R '^(gpu_replay_resource_override|gpu_replay_shader_dump|gpu_capture_roundtrip)$'

100% tests passed, 3/3
```

After rebasing onto `5c924fe6`, the focused target and `git diff --check` passed again.

Mutation checks:

- deliberately ignoring the prepared replacement made
  `selected draw bytes and inspect-visible hash change` fail
- deliberately mutating the shared table in place made
  `shared sibling draw remains byte-identical after selected override` fail

Both mutations were reverted before the final green run. No GPU replay or title-specific test was
run for this tooling PR, and this PR makes no Asterix visual-outcome claim.

Closes #1845
