### PR TITLE
build: refresh embedded revision after HEAD changes

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -60,18 +60,15 @@ endif()
 
 # --- core library (M1+) --------------------------------------------------
 # Loader / HLE / kernel / gpu sources accrete here per the roadmap.
+include(cmake/ProsperBuildRevision.cmake)
+prosper_add_build_revision_library(prosper_build_revision WORK_TREE "${CMAKE_SOURCE_DIR}/..")
+
 file(GLOB_RECURSE PROSPER_SRC CONFIGURE_DEPENDS src/*.cpp)
 if(PROSPER_SRC)
   add_library(prosper_core STATIC ${PROSPER_SRC})
   target_include_directories(prosper_core PUBLIC src)
-  target_link_libraries(prosper_core PUBLIC libatrac9)
+  target_link_libraries(prosper_core PUBLIC libatrac9 PRIVATE prosper_build_revision)
   target_compile_definitions(prosper_core PRIVATE PROSPER_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
-  execute_process(COMMAND git rev-parse --verify HEAD WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/.."
-                  OUTPUT_VARIABLE PROSPER_GIT_REVISION OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
-  if(NOT PROSPER_GIT_REVISION)
-    set(PROSPER_GIT_REVISION "unknown")
-  endif()
-  target_compile_definitions(prosper_core PRIVATE PROSPER_GIT_REVISION="${PROSPER_GIT_REVISION}")
   find_package(Threads REQUIRED)
   target_link_libraries(prosper_core PUBLIC Threads::Threads)
   # Windows: the guest futex HLE (sceKernelWaitOnAddress/WakeByAddress) is backed by the native Win32
@@ -86,10 +83,7 @@ endif()
 # its ring, bounds, and atomic file contract run in ordinary headless CI.
 add_library(prosper_performance_capture STATIC frontends/shared/performance_capture.cpp)
 target_include_directories(prosper_performance_capture PUBLIC frontends/shared)
-if(PROSPER_GIT_REVISION)
-  target_compile_definitions(prosper_performance_capture
-    PRIVATE PROSPER_GIT_REVISION="${PROSPER_GIT_REVISION}")
-endif()
+target_link_libraries(prosper_performance_capture PRIVATE prosper_build_revision)
 
 # --- tests (agentic-first: self-checking, exit-code = truth) -------------
 enable_testing()
@@ -131,6 +125,16 @@ if(Python3_Interpreter_FOUND)
   add_test(NAME compute_phase_report_logic
            COMMAND "${Python3_EXECUTABLE}"
                    "${CMAKE_SOURCE_DIR}/tools/perf/test_compute_phase_report.py")
+  if(GIT_EXECUTABLE)
+    add_test(NAME build_revision_refresh
+             COMMAND "${Python3_EXECUTABLE}"
+               "${CMAKE_SOURCE_DIR}/tools/revision/test_build_revision.py"
+               --cmake "${CMAKE_COMMAND}"
+               --git "${GIT_EXECUTABLE}"
+               --module "${CMAKE_SOURCE_DIR}/cmake/ProsperBuildRevision.cmake"
+               --scratch-root "${CMAKE_CURRENT_BINARY_DIR}/build-revision-regression"
+               --generator "${CMAKE_GENERATOR}")
+  endif()
 endif()
 # Path to the (gitignored) local game dump; override with -DGAME_DUMP=...
 set(GAME_DUMP "${CMAKE_SOURCE_DIR}/../PPSA24651-app0" CACHE PATH "Local PS5 game dump root")

--- a/prosper/cmake/GenerateBuildRevision.cmake
+++ b/prosper/cmake/GenerateBuildRevision.cmake
@@ -1,0 +1,29 @@
+set(PROSPER_GENERATED_REVISION "unknown")
+
+# Both ordinary clones (.git directory) and linked worktrees (.git file) have an entry at their
+# root. Requiring that entry prevents Git from walking up into an unrelated ancestor when this runs
+# in an exported/non-Git source directory, without relying on platform-sensitive path comparisons.
+if(PROSPER_REVISION_GIT_EXECUTABLE AND PROSPER_REVISION_WORK_TREE AND
+   EXISTS "${PROSPER_REVISION_WORK_TREE}/.git")
+  execute_process(
+    COMMAND "${PROSPER_REVISION_GIT_EXECUTABLE}" rev-parse --verify HEAD
+    WORKING_DIRECTORY "${PROSPER_REVISION_WORK_TREE}"
+    RESULT_VARIABLE _revision_result
+    OUTPUT_VARIABLE _revision_output
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET)
+  # A Git object id contains only hexadecimal digits. Reject unexpected output before placing it in
+  # generated C++ rather than trying to quote arbitrary command output safely.
+  if(_revision_result EQUAL 0 AND _revision_output MATCHES "^[0-9a-fA-F]+$")
+    set(PROSPER_GENERATED_REVISION "${_revision_output}")
+  endif()
+endif()
+
+# configure_file preserves the destination timestamp when its contents did not change. Therefore
+# the inexpensive revision query runs before each relevant build, but compilation and relinking
+# happen only after the resolved revision actually changes.
+configure_file(
+  "${PROSPER_REVISION_TEMPLATE}"
+  "${PROSPER_REVISION_OUTPUT}"
+  @ONLY
+  NEWLINE_STYLE UNIX)

--- a/prosper/cmake/ProsperBuildRevision.cmake
+++ b/prosper/cmake/ProsperBuildRevision.cmake
@@ -1,0 +1,36 @@
+include_guard(GLOBAL)
+
+function(prosper_add_build_revision_library target_name)
+  set(one_value_args WORK_TREE)
+  cmake_parse_arguments(PBR "" "${one_value_args}" "" ${ARGN})
+  if(NOT PBR_WORK_TREE)
+    message(FATAL_ERROR "prosper_add_build_revision_library requires WORK_TREE")
+  endif()
+
+  find_package(Git QUIET)
+
+  set(_revision_dir "${CMAKE_CURRENT_BINARY_DIR}/generated/${target_name}")
+  set(_revision_source "${_revision_dir}/build_revision.cpp")
+  set(_revision_script "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/GenerateBuildRevision.cmake")
+  set(_revision_template "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/build_revision.cpp.in")
+  set(_revision_include "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/../src")
+
+  # This target intentionally runs whenever a consumer is built. Depending only on .git/HEAD is
+  # insufficient: linked worktrees use a gitdir indirection, branch refs may be packed, and a
+  # checkout can move between refs without changing the file a generator happened to watch.
+  add_custom_target(${target_name}_refresh
+    COMMAND "${CMAKE_COMMAND}" -E make_directory "${_revision_dir}"
+    COMMAND "${CMAKE_COMMAND}"
+      "-DPROSPER_REVISION_GIT_EXECUTABLE=${GIT_EXECUTABLE}"
+      "-DPROSPER_REVISION_WORK_TREE=${PBR_WORK_TREE}"
+      "-DPROSPER_REVISION_TEMPLATE=${_revision_template}"
+      "-DPROSPER_REVISION_OUTPUT=${_revision_source}"
+      -P "${_revision_script}"
+    BYPRODUCTS "${_revision_source}"
+    VERBATIM)
+
+  set_source_files_properties("${_revision_source}" PROPERTIES GENERATED TRUE)
+  add_library(${target_name} STATIC "${_revision_source}")
+  add_dependencies(${target_name} ${target_name}_refresh)
+  target_include_directories(${target_name} PUBLIC "${_revision_include}")
+endfunction()

--- a/prosper/cmake/build_revision.cpp.in
+++ b/prosper/cmake/build_revision.cpp.in
@@ -1,0 +1,9 @@
+#include "build_revision.hpp"
+
+namespace prosper {
+
+const char* embedded_build_revision() noexcept {
+    return "@PROSPER_GENERATED_REVISION@";
+}
+
+} // namespace prosper

--- a/prosper/frontends/shared/performance_capture.cpp
+++ b/prosper/frontends/shared/performance_capture.cpp
@@ -1,4 +1,5 @@
 #include "performance_capture.hpp"
+#include "build_revision.hpp"
 
 #include <algorithm>
 #include <cerrno>
@@ -30,10 +31,6 @@
 
 #if defined(__linux__)
 #include <unistd.h>
-#endif
-
-#ifndef PROSPER_GIT_REVISION
-#define PROSPER_GIT_REVISION "unknown"
 #endif
 
 namespace prosper::perf {
@@ -484,7 +481,7 @@ ProcessSample collect_process_sample(uint64_t monotonic_ns, uint64_t guest_prese
 }
 
 const char* build_revision() {
-    return PROSPER_GIT_REVISION;
+    return ::prosper::embedded_build_revision();
 }
 
 } // namespace prosper::perf

--- a/prosper/src/build_revision.hpp
+++ b/prosper/src/build_revision.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+namespace prosper {
+
+// Revision compiled into this build. "unknown" is returned when the source tree is not a Git
+// checkout or Git was unavailable while building.
+const char* embedded_build_revision() noexcept;
+
+} // namespace prosper

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -8,6 +8,7 @@
 
 #include <mutex>
 #include "bc_decode.hpp"
+#include "build_revision.hpp"
 #include "guest_texture_layout.hpp"
 #include "rdna2_decode.hpp"
 #include "rdna2_to_spirv.hpp"
@@ -4046,11 +4047,7 @@ std::unique_ptr<PendingGpuCapture> begin_requested_gpu_capture(
     }
     GpuCaptureMetadata m; m.width = width; m.height = height;
     m.submit_index = submit_no ? submit_no : current;
-#ifdef PROSPER_GIT_REVISION
-    m.revision = PROSPER_GIT_REVISION;
-#else
-    m.revision = "unknown";
-#endif
+    m.revision = embedded_build_revision();
     if (const char* revision = std::getenv("PROSPER_CAPTURE_REVISION")) m.revision = revision;
     m.title_id = env_or_empty("PROSPER_CAPTURE_TITLE"); m.input_route = env_or_empty("PROSPER_PAD_SCRIPT");
     m.savedata_dir = env_or_empty("PROSPER_SAVEDATA_DIR");

--- a/prosper/src/gpu/gpu_timeline.cpp
+++ b/prosper/src/gpu/gpu_timeline.cpp
@@ -1,5 +1,6 @@
 #include "gpu_timeline.hpp"
 
+#include "build_revision.hpp"
 #include "gpu_capture.hpp"
 #include "gpu_capture_bundle.hpp"
 #include "gpu_dependency_graph.hpp"
@@ -198,11 +199,7 @@ struct RuntimeRecorder {
             return nullptr;
         }
         GpuTimelineMetadata metadata;
-#ifdef PROSPER_GIT_REVISION
-        metadata.revision = PROSPER_GIT_REVISION;
-#else
-        metadata.revision = "unknown";
-#endif
+        metadata.revision = embedded_build_revision();
         if (const char* revision = std::getenv("PROSPER_CAPTURE_REVISION")) metadata.revision = revision;
         metadata.title_id = env_or_empty("PROSPER_CAPTURE_TITLE");
         metadata.input_route = env_or_empty("PROSPER_PAD_SCRIPT");
@@ -1078,11 +1075,7 @@ GpuCaptureMetadata runtime_capture_metadata(uint64_t submit_no) {
     metadata.width = present_width();
     metadata.height = present_height();
     metadata.submit_index = submit_no;
-#ifdef PROSPER_GIT_REVISION
-    metadata.revision = PROSPER_GIT_REVISION;
-#else
-    metadata.revision = "unknown";
-#endif
+    metadata.revision = embedded_build_revision();
     if (const char* revision = std::getenv("PROSPER_CAPTURE_REVISION")) metadata.revision = revision;
     metadata.title_id = env_or_empty("PROSPER_CAPTURE_TITLE");
     metadata.input_route = env_or_empty("PROSPER_PAD_SCRIPT");

--- a/prosper/tools/revision/test_build_revision.py
+++ b/prosper/tools/revision/test_build_revision.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Regression for build-time revision refreshes across source-identical commits."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import time
+
+
+def run(command: list[str], *, cwd: Path, env: dict[str, str] | None = None) -> str:
+    result = subprocess.run(
+        command,
+        cwd=cwd,
+        env=env,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    return result.stdout.strip()
+
+
+def write_project(source: Path, module: Path) -> None:
+    source.mkdir(parents=True)
+    module_path = module.as_posix().replace('"', '\\"')
+    (source / "CMakeLists.txt").write_text(
+        f"""cmake_minimum_required(VERSION 3.20)
+project(build_revision_regression LANGUAGES CXX)
+include(\"{module_path}\")
+prosper_add_build_revision_library(test_build_revision WORK_TREE \"${{CMAKE_CURRENT_SOURCE_DIR}}\")
+add_executable(revision_query main.cpp)
+target_link_libraries(revision_query PRIVATE test_build_revision)
+set_target_properties(revision_query PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY \"${{CMAKE_CURRENT_BINARY_DIR}}/out\"
+  RUNTIME_OUTPUT_DIRECTORY_DEBUG \"${{CMAKE_CURRENT_BINARY_DIR}}/out\"
+  RUNTIME_OUTPUT_DIRECTORY_RELEASE \"${{CMAKE_CURRENT_BINARY_DIR}}/out\"
+  RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO \"${{CMAKE_CURRENT_BINARY_DIR}}/out\"
+  RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL \"${{CMAKE_CURRENT_BINARY_DIR}}/out\")
+""",
+        encoding="utf-8",
+    )
+    (source / "main.cpp").write_text(
+        '#include "build_revision.hpp"\n#include <cstdlib>\n#include <iostream>\n'
+        "int main() {\n"
+        '  const char* override_revision = std::getenv("PROSPER_CAPTURE_REVISION");\n'
+        "  std::cout << (override_revision ? override_revision : prosper::embedded_build_revision());\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+
+def configure(cmake: str, source: Path, build: Path, generator: str | None) -> None:
+    command = [cmake, "-S", str(source), "-B", str(build)]
+    if generator:
+        command.extend(["-G", generator])
+    run(command, cwd=source)
+
+
+def build(cmake: str, build_dir: Path) -> None:
+    run(
+        [cmake, "--build", str(build_dir), "--config", "Release", "--target", "revision_query"],
+        cwd=build_dir,
+    )
+
+
+def executable_path(build_dir: Path) -> Path:
+    return build_dir / "out" / ("revision_query.exe" if os.name == "nt" else "revision_query")
+
+
+def query(build_dir: Path, *, override: str | None = None) -> str:
+    executable = executable_path(build_dir)
+    env = os.environ.copy()
+    if override is None:
+        env.pop("PROSPER_CAPTURE_REVISION", None)
+    else:
+        env["PROSPER_CAPTURE_REVISION"] = override
+    return run([str(executable)], cwd=build_dir, env=env)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--cmake", required=True)
+    parser.add_argument("--git", required=True)
+    parser.add_argument("--module", type=Path, required=True)
+    parser.add_argument("--scratch-root", type=Path, required=True)
+    parser.add_argument("--generator")
+    args = parser.parse_args()
+
+    scratch = args.scratch_root.resolve()
+    if scratch.exists():
+        shutil.rmtree(scratch)
+    scratch.mkdir(parents=True)
+
+    source = scratch / "repo"
+    build_dir = scratch / "build"
+    write_project(source, args.module.resolve())
+    run([args.git, "init", "--quiet"], cwd=source)
+    run([args.git, "config", "user.name", "Prosper Build Test"], cwd=source)
+    run([args.git, "config", "user.email", "build-test@invalid"], cwd=source)
+    run([args.git, "add", "."], cwd=source)
+    run([args.git, "commit", "--quiet", "-m", "tree"], cwd=source)
+    revision_a = run([args.git, "rev-parse", "HEAD"], cwd=source)
+
+    configure(args.cmake, source, build_dir, args.generator)
+    build(args.cmake, build_dir)
+    if query(build_dir) != revision_a:
+        raise AssertionError("initial binary does not contain the current source revision")
+
+    generated_source = build_dir / "generated" / "test_build_revision" / "build_revision.cpp"
+    generated_mtime = generated_source.stat().st_mtime_ns
+    executable_mtime = executable_path(build_dir).stat().st_mtime_ns
+    time.sleep(1.1)  # Make an accidental rewrite observable even on coarse timestamp filesystems.
+    build(args.cmake, build_dir)
+    if generated_source.stat().st_mtime_ns != generated_mtime:
+        raise AssertionError("unchanged revision rewrote the generated source")
+    if executable_path(build_dir).stat().st_mtime_ns != executable_mtime:
+        raise AssertionError("unchanged revision relinked the consumer")
+
+    run([args.git, "commit", "--quiet", "--allow-empty", "-m", "same tree, new revision"], cwd=source)
+    revision_b = run([args.git, "rev-parse", "HEAD"], cwd=source)
+    tree_a = run([args.git, "show", "-s", "--format=%T", revision_a], cwd=source)
+    tree_b = run([args.git, "show", "-s", "--format=%T", revision_b], cwd=source)
+    if revision_a == revision_b or tree_a != tree_b:
+        raise AssertionError("test setup did not create two revisions with an identical source tree")
+
+    # This is the decisive arm: no configure and no clean between source-identical commits.
+    build(args.cmake, build_dir)
+    observed_b = query(build_dir)
+    if observed_b != revision_b:
+        raise AssertionError(
+            f"incremental build kept stale revision: expected {revision_b}, got {observed_b}"
+        )
+
+    override = "explicit-capture-revision"
+    if query(build_dir, override=override) != override:
+        raise AssertionError("PROSPER_CAPTURE_REVISION did not remain higher priority")
+
+    # Linked worktrees store a .git indirection file rather than a directory. They must resolve the
+    # worktree's own HEAD just like an ordinary clone.
+    linked_source = scratch / "linked-worktree"
+    linked_build = scratch / "linked-build"
+    run([args.git, "worktree", "add", "--quiet", "--detach", str(linked_source), revision_b], cwd=source)
+    configure(args.cmake, linked_source, linked_build, args.generator)
+    build(args.cmake, linked_build)
+    if query(linked_build) != revision_b:
+        raise AssertionError("linked-worktree build did not embed its own HEAD")
+
+    # The directory is deliberately nested below the outer checkout. The helper must not let Git
+    # walk up into that unrelated repository; exported source trees retain the unknown fallback.
+    nongit_source = scratch / "nongit"
+    nongit_build = scratch / "nongit-build"
+    write_project(nongit_source, args.module.resolve())
+    configure(args.cmake, nongit_source, nongit_build, args.generator)
+    build(args.cmake, nongit_build)
+    if query(nongit_build) != "unknown":
+        raise AssertionError("non-Git build did not use the unknown revision fallback")
+
+    print(f"build revision refreshed {revision_a[:12]} -> {revision_b[:12]} with identical trees")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except (AssertionError, subprocess.CalledProcessError) as error:
+        print(f"FAIL: {error}", file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
Fixes #1846

## Failure scenario

The capture revision was resolved by `git rev-parse HEAD` at CMake configure time and injected as a target-wide compile definition. Checking out a source-identical new commit did not change any build input, so an ordinary incremental build neither reconfigured nor relinked. F8/F9/timeline artifacts could therefore identify a stale commit until someone happened to clean or reconfigure.

Baseline reproduction built revision A, created revision B with `git commit --allow-empty`, then rebuilt the same build directory without configuring or cleaning. The binary still contained A once and B zero times:

```text
base_in_a=1 base_in_b=1 next_in_b=0
```

## Approach and invariants

- Generate the embedded revision in one tiny source/static-library target rather than compiling a revision macro into broad targets.
- Run a cheap Git query before each relevant consumer build. `configure_file` preserves the generated source timestamp when its contents are unchanged, so same-revision builds do not compile or relink; a moved HEAD recompiles only the revision object and relinks consumers.
- Require `.git` at the requested worktree root. This supports both ordinary clones (`.git` directory) and linked worktrees (`.git` file), while preventing an exported source tree from inheriting an unrelated ancestor checkout's revision.
- Preserve `unknown` when Git metadata or Git itself is unavailable.
- Preserve the existing runtime contract: `PROSPER_CAPTURE_REVISION`, when set, remains higher priority than the embedded default in GPU capture and timeline metadata.
- The generated source contains only the resolved hexadecimal object ID or `unknown`; it does not contain the checkout path.

This changes capture provenance only. It does not change capture formats, rendering, title behavior, or snapshot output.

## Regression proof

The new CPU-only `build_revision_refresh` CTest creates two commits with identical trees, performs an ordinary build of the same consumer target with no intervening configure or clean, and requires the second binary to report revision B. It also proves:

- an unchanged revision preserves both generated-source and consumer timestamps;
- an explicit capture revision wins;
- a linked worktree embeds its own HEAD;
- a non-Git tree nested below an unrelated checkout reports `unknown`.

Mutation check: temporarily returning early when the generated source already existed left the test registered and made the named test fail with `incremental build kept stale revision: expected <B>, got <A>`. The mutation was removed and the test returned green.

The first Windows MinGW CI run compiled production successfully but exposed a test-apparatus portability issue: MSYS2 Git rejected the test's `REV^{tree}` expression when launched by native Python. The test now obtains the identical tree ID via the equivalent `git show -s --format=%T REV` command. No production code changed in that correction.

## Exact-head verification

Verified commit `a9a782911a9e76ef75b1631b6e23553e8e130694` on base `4245f187685b45be4efe8b79cdebd9d939fe3ba8` inside the `ps5ys` distrobox, with `TMPDIR` under the worktree build directory and no game/GPU run:

```bash
distrobox enter ps5ys -- bash -lc '
  export TMPDIR="$PWD/prosper/build-issue-1846/tmpdir"
  cmake --build prosper/build-issue-1846 \
    --target test_gpu_capture test_gpu_capture_bundle test_gpu_timeline \
             test_gpu_timeline_capture_exit test_performance_capture -j2
  ctest --test-dir prosper/build-issue-1846 --output-on-failure \
    -R "^(gpu_capture_roundtrip|gpu_capture_bundle_roundtrip|gpu_timeline_roundtrip|gpu_timeline_capture_exit|performance_capture|build_revision_refresh)$"
'
```

Result: **6/6 passed** in 2.46 seconds.

The regression also passed directly with the Ninja generator:

```bash
python3 prosper/tools/revision/test_build_revision.py \
  --cmake "$(command -v cmake)" --git "$(command -v git)" \
  --module "$PWD/prosper/cmake/ProsperBuildRevision.cmake" \
  --scratch-root "$PWD/prosper/build-issue-1846/ninja-regression" \
  --generator Ninja
```

Result: `build revision refreshed <A> -> <B> with identical trees`.

An immediate second build of `test_performance_capture` at the same exact head ran the refresh target with **zero compile or link steps**. The resulting binary contained the exact head once. `git diff origin/master...HEAD --check` also passed.

Snapshots were not run: this is CPU-only build/provenance infrastructure and does not affect rendered output.
