### PR TITLE
gpu capture: retain draw-time resource provenance

### DIFF
--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -8,6 +8,7 @@
 
 #include <mutex>
 #include "bc_decode.hpp"
+#include "diagnostic_selectors.hpp"
 #include "build_revision.hpp"
 #include "guest_texture_layout.hpp"
 #include "rdna2_decode.hpp"
@@ -103,7 +104,10 @@ constexpr char kMagic[8] = {'P','R','G','P','C','A','P','\0'};
 // v44: retain each resource's guest sample count. 2D_MSAA image_load is materialized as host array
 // layers, so replay must not collapse four guest sample planes to the historical single-layer default.
 // The append-only tail covers realized draw/compute and failed-stage tables; v1-v43 default to one.
-constexpr uint32_t kVersion = 44;
+// v45 (#1849): retain one opt-in draw-time resource sample and its independently captured post-submit
+// span. The append-only record references ordinary blobs so both read counts, bytes, and hashes remain
+// auditable offline; captures without the selector append only a zero count and copy no extra bytes.
+constexpr uint32_t kVersion = 45;
 constexpr uint32_t kEndian = 0x01020304u;
 constexpr uint64_t kMaxFileBytes = 4ull << 30;
 constexpr uint64_t kMaxBlobBytes = 1ull << 30;
@@ -965,6 +969,66 @@ bool validate_dma_copies(const GpuCaptureFile& capture, std::string& error) {
         referenced.end()) {
         error = "ordered DMA record must have exactly one operation";
         return false;
+    }
+    return true;
+}
+
+bool validate_resource_provenance(const GpuCaptureFile& capture, std::string& error) {
+    if (capture.resource_provenance.size() > 1) {
+        error = "invalid resource provenance record count";
+        return false;
+    }
+    for (const auto& provenance : capture.resource_provenance) {
+        if ((provenance.stage != ShaderProgramStage::Vertex &&
+             provenance.stage != ShaderProgramStage::Fragment) ||
+            static_cast<uint32_t>(provenance.resource_class) >
+                static_cast<uint32_t>(ResourceClass::StorageImage) ||
+            !provenance.guest_addr || !provenance.requested_bytes ||
+            provenance.requested_bytes > kMaxBlobBytes ||
+            provenance.realization_blob_index >= capture.blobs.size() ||
+            provenance.post_blob_index >= capture.blobs.size()) {
+            error = "invalid resource provenance identity";
+            return false;
+        }
+        const auto& realization = capture.blobs[provenance.realization_blob_index];
+        const auto& post = capture.blobs[provenance.post_blob_index];
+        if (realization.guest_addr != provenance.guest_addr ||
+            realization.bytes.size() != provenance.requested_bytes ||
+            realization.content_hash != provenance.realization_content_hash ||
+            provenance.post_blob_offset > post.bytes.size() ||
+            provenance.requested_bytes > post.bytes.size() - provenance.post_blob_offset ||
+            gpu_capture_hash(post.bytes.data() + provenance.post_blob_offset,
+                             static_cast<size_t>(provenance.requested_bytes)) !=
+                provenance.post_content_hash) {
+            error = "invalid resource provenance blob reference";
+            return false;
+        }
+
+        const GpuCapturedResource* captured_resource = nullptr;
+        for (const auto& draw : capture.draws) {
+            if (draw.draw_index != provenance.draw_index) continue;
+            const auto& table = provenance.stage == ShaderProgramStage::Vertex
+                ? draw.vrt : draw.prt;
+            for (const auto& resource : table.resources) {
+                if (resource.resource.binding != provenance.binding) continue;
+                if (captured_resource) {
+                    error = "ambiguous resource provenance identity";
+                    return false;
+                }
+                captured_resource = &resource;
+            }
+        }
+        if (!captured_resource ||
+            captured_resource->resource.cls != provenance.resource_class ||
+            captured_resource->resource.gpu_addr != provenance.guest_addr ||
+            captured_resource->captured_size != provenance.requested_bytes ||
+            captured_resource->resource.srt_offset != provenance.srt_offset ||
+            captured_resource->resource.sgpr_base != provenance.sgpr_base ||
+            captured_resource->blob_index != provenance.post_blob_index ||
+            captured_resource->blob_offset != provenance.post_blob_offset) {
+            error = "resource provenance does not match its captured descriptor";
+            return false;
+        }
     }
     return true;
 }
@@ -2356,6 +2420,25 @@ bool serialize_gpu_capture(const GpuCaptureFile& c, std::vector<uint8_t>& bytes,
             if (!write_sample_counts(stage.resource_table)) {
                 error = "invalid resource sample count"; return false;
             }
+    // v45 appends at most one explicitly selected temporal resource audit. Both samples are ordinary
+    // capture blobs, so their independent bytes_read fields and payload hashes remain self-contained.
+    if (!validate_resource_provenance(c, error)) return false;
+    w.u32(static_cast<uint32_t>(c.resource_provenance.size()));
+    for (const auto& provenance : c.resource_provenance) {
+        w.u64(provenance.draw_index);
+        w.u8(static_cast<uint8_t>(provenance.stage));
+        w.u32(provenance.binding);
+        w.u32(static_cast<uint32_t>(provenance.resource_class));
+        w.u64(provenance.guest_addr);
+        w.u64(provenance.requested_bytes);
+        w.u32(provenance.srt_offset);
+        w.u32(provenance.sgpr_base);
+        w.u32(provenance.realization_blob_index);
+        w.u32(provenance.post_blob_index);
+        w.u64(provenance.post_blob_offset);
+        w.u64(provenance.realization_content_hash);
+        w.u64(provenance.post_content_hash);
+    }
     if (w.data.size() > kMaxFileBytes) { error = "capture file exceeds 4 GiB"; return false; }
     bytes = std::move(w.data);
     return true;
@@ -3409,6 +3492,31 @@ bool deserialize_gpu_capture(const std::vector<uint8_t>& bytes, GpuCaptureFile& 
                 error = "invalid resource DCC metadata reference"; return false;
             }
     }
+    if (version >= 45) {
+        uint32_t count = 0;
+        if (!r.u32(count) || count > 1) {
+            error = "invalid resource provenance record count";
+            return false;
+        }
+        c.resource_provenance.resize(count);
+        for (auto& provenance : c.resource_provenance) {
+            uint8_t stage = 0;
+            uint32_t resource_class = 0;
+            if (!r.u64(provenance.draw_index) || !r.u8(stage) ||
+                !r.u32(provenance.binding) || !r.u32(resource_class) ||
+                !r.u64(provenance.guest_addr) || !r.u64(provenance.requested_bytes) ||
+                !r.u32(provenance.srt_offset) || !r.u32(provenance.sgpr_base) ||
+                !r.u32(provenance.realization_blob_index) ||
+                !r.u32(provenance.post_blob_index) ||
+                !r.u64(provenance.post_blob_offset) ||
+                !r.u64(provenance.realization_content_hash) ||
+                !r.u64(provenance.post_content_hash))
+                return false;
+            provenance.stage = static_cast<ShaderProgramStage>(stage);
+            provenance.resource_class = static_cast<ResourceClass>(resource_class);
+        }
+        if (!validate_resource_provenance(c, error)) return false;
+    }
     for (auto& draw : c.draws) restore_legacy_color_target_aliases(draw);
     for (auto& diagnostic : c.failure_diagnostics)
         restore_legacy_color_target_aliases(diagnostic);
@@ -3424,6 +3532,7 @@ bool materialize_gpu_replay(const GpuCaptureFile& c, GpuReplayFrame& out, std::s
     out.rtt_seeds = c.rtt_seeds; out.ds_seeds = c.ds_seeds;
     out.raw_shader_versions = c.raw_shader_versions;
     out.failure_diagnostics = c.failure_diagnostics;
+    out.resource_provenance = c.resource_provenance;
     out.failure_diagnostics_available = c.failure_diagnostics_available;
     out.expected_output_valid = c.expected_output_valid;
     out.expected_output_hash = c.expected_output_hash; out.expected_output_bytes = c.expected_output_bytes;
@@ -3758,6 +3867,90 @@ bool gpu_capture_output_nonzero_matches(const std::vector<uint8_t>& output, size
            (!max_nonzero || nonzero <= max_nonzero);
 }
 
+bool parse_gpu_capture_resource_selector(std::string_view text,
+                                         GpuCaptureResourceSelector& selector) {
+    const size_t first_colon = text.find(':');
+    const size_t second_colon = first_colon == std::string_view::npos
+        ? std::string_view::npos : text.find(':', first_colon + 1);
+    if (first_colon == std::string_view::npos || second_colon == std::string_view::npos ||
+        text.find(':', second_colon + 1) != std::string_view::npos)
+        return false;
+    uint64_t draw_index = 0, binding = 0;
+    if (!parse_diagnostic_draw_id(text.substr(0, first_colon), draw_index) ||
+        !parse_diagnostic_uint64(text.substr(second_colon + 1), binding) ||
+        binding > std::numeric_limits<uint32_t>::max())
+        return false;
+    const std::string_view stage = text.substr(first_colon + 1,
+                                               second_colon - first_colon - 1);
+    if (stage != "vs" && stage != "ps") return false;
+    selector.draw_index = draw_index;
+    selector.stage = stage == "vs" ? ShaderProgramStage::Vertex
+                                    : ShaderProgramStage::Fragment;
+    selector.binding = static_cast<uint32_t>(binding);
+    return true;
+}
+
+void snapshot_pending_gpu_capture_draw_resource(PendingGpuCapture* pending,
+                                                const DrawItem& draw,
+                                                const CaptureMemoryReader& reader) {
+    // This check is the normal-path cost: no table walk, allocation, or guest-memory read occurs
+    // unless a capture explicitly requests one semantic resource.
+    if (!pending || !pending->resource_provenance_armed ||
+        !pending->resource_provenance_error.empty() ||
+        draw.draw_index != pending->resource_provenance_selector.draw_index)
+        return;
+    const auto& selector = pending->resource_provenance_selector;
+    const auto& table = selector.stage == ShaderProgramStage::Vertex ? draw.vrt : draw.prt;
+    if (!table) return;
+
+    const ShaderResource* selected = nullptr;
+    for (const auto& resource : table->resources) {
+        if (resource.binding != selector.binding) continue;
+        if (selected) {
+            pending->resource_provenance_error =
+                "selected draw resource binding is ambiguous";
+            return;
+        }
+        selected = &resource;
+    }
+    if (!selected) return;
+    if (++pending->resource_provenance_matches != 1) {
+        pending->resource_provenance_error =
+            "selected draw resource matched more than once";
+        return;
+    }
+
+    const uint64_t bytes = gpu_capture_resource_footprint(*selected);
+    if (!selected->gpu_addr || !bytes || bytes > kMaxBlobBytes ||
+        bytes > std::numeric_limits<size_t>::max()) {
+        pending->resource_provenance_error =
+            "selected draw resource has no bounded guest byte span";
+        return;
+    }
+    GpuCaptureBlob blob;
+    blob.guest_addr = selected->gpu_addr;
+    blob.bytes.resize(static_cast<size_t>(bytes), 0);
+    const CaptureMemoryReader exact_reader = reader ? reader : CaptureMemoryReader(
+        [](uint64_t addr, uint8_t* destination, size_t size) {
+            return read_capture_guest_memory(addr, destination, size);
+        });
+    blob.bytes_read = std::min<uint64_t>(
+        exact_reader(blob.guest_addr, blob.bytes.data(), blob.bytes.size()), blob.bytes.size());
+    blob.content_hash = gpu_capture_hash(blob.bytes);
+
+    auto& provenance = pending->resource_provenance;
+    provenance.draw_index = draw.draw_index;
+    provenance.stage = selector.stage;
+    provenance.binding = selector.binding;
+    provenance.resource_class = selected->cls;
+    provenance.guest_addr = selected->gpu_addr;
+    provenance.requested_bytes = bytes;
+    provenance.srt_offset = selected->srt_offset;
+    provenance.sgpr_base = selected->sgpr_base;
+    provenance.realization_content_hash = blob.content_hash;
+    pending->resource_provenance_realization_blob = std::move(blob);
+}
+
 namespace {
 CaptureMemoryReader pending_capture_reader(const PendingGpuCapture& pending) {
     return [&pending](uint64_t addr, uint8_t* destination, size_t bytes) -> size_t {
@@ -3783,6 +3976,97 @@ CaptureMemoryReader pending_capture_reader(const PendingGpuCapture& pending) {
         }
         return copied;
     };
+}
+
+const char* resource_provenance_stage_name(ShaderProgramStage stage) {
+    return stage == ShaderProgramStage::Vertex ? "vs" : "ps";
+}
+
+bool validate_pending_resource_provenance(const PendingGpuCapture& pending,
+                                          std::string& error) {
+    if (!pending.resource_provenance_armed) return true;
+    if (!pending.resource_provenance_error.empty()) {
+        error = "resource provenance selector failed: " +
+                pending.resource_provenance_error;
+        return false;
+    }
+    if (pending.resource_provenance_matches != 1) {
+        const auto& selector = pending.resource_provenance_selector;
+        error = "resource provenance selector " + std::to_string(selector.draw_index) + ":" +
+                resource_provenance_stage_name(selector.stage) + ":" +
+                std::to_string(selector.binding) + " matched " +
+                std::to_string(pending.resource_provenance_matches) + " resources";
+        return false;
+    }
+    return true;
+}
+
+bool finalize_pending_resource_provenance(PendingGpuCapture& pending,
+                                          std::string& error) {
+    if (!pending.resource_provenance_armed) return true;
+    if (!validate_pending_resource_provenance(pending, error)) return false;
+    auto& provenance = pending.resource_provenance;
+    const GpuCapturedDraw* selected_draw = nullptr;
+    for (const auto& draw : pending.capture.draws) {
+        if (draw.draw_index != provenance.draw_index) continue;
+        if (selected_draw) {
+            error = "captured provenance draw identity is ambiguous";
+            return false;
+        }
+        selected_draw = &draw;
+    }
+    if (!selected_draw) {
+        error = "captured provenance draw is absent after materialization";
+        return false;
+    }
+    const auto& table = provenance.stage == ShaderProgramStage::Vertex
+        ? selected_draw->vrt : selected_draw->prt;
+    const GpuCapturedResource* selected_resource = nullptr;
+    for (const auto& resource : table.resources) {
+        if (resource.resource.binding != provenance.binding) continue;
+        if (selected_resource) {
+            error = "captured provenance resource identity is ambiguous";
+            return false;
+        }
+        selected_resource = &resource;
+    }
+    if (!selected_resource ||
+        selected_resource->resource.cls != provenance.resource_class ||
+        selected_resource->resource.gpu_addr != provenance.guest_addr ||
+        selected_resource->captured_size != provenance.requested_bytes ||
+        selected_resource->resource.srt_offset != provenance.srt_offset ||
+        selected_resource->resource.sgpr_base != provenance.sgpr_base) {
+        error = "captured provenance descriptor changed after draw realization";
+        return false;
+    }
+    if (selected_resource->blob_index >= pending.capture.blobs.size()) {
+        error = "captured provenance resource has no post-submit blob";
+        return false;
+    }
+    const auto& post_blob = pending.capture.blobs[selected_resource->blob_index];
+    if (selected_resource->blob_offset > post_blob.bytes.size() ||
+        provenance.requested_bytes > post_blob.bytes.size() - selected_resource->blob_offset) {
+        error = "captured provenance post-submit span exceeds its blob";
+        return false;
+    }
+    const auto& realization_blob = pending.resource_provenance_realization_blob;
+    if (realization_blob.guest_addr != provenance.guest_addr ||
+        realization_blob.bytes.size() != provenance.requested_bytes ||
+        realization_blob.content_hash != gpu_capture_hash(realization_blob.bytes)) {
+        error = "captured provenance realization sample is inconsistent";
+        return false;
+    }
+
+    provenance.post_blob_index = selected_resource->blob_index;
+    provenance.post_blob_offset = selected_resource->blob_offset;
+    provenance.post_content_hash = gpu_capture_hash(
+        post_blob.bytes.data() + selected_resource->blob_offset,
+        static_cast<size_t>(provenance.requested_bytes));
+    provenance.realization_blob_index =
+        static_cast<uint32_t>(pending.capture.blobs.size());
+    pending.capture.blobs.push_back(std::move(pending.resource_provenance_realization_blob));
+    pending.capture.resource_provenance.push_back(provenance);
+    return true;
 }
 
 std::vector<ComputeItem> with_pending_gds_snapshot(
@@ -4039,6 +4323,24 @@ std::unique_ptr<PendingGpuCapture> begin_requested_gpu_capture(
     auto pending = std::make_unique<PendingGpuCapture>();
     pending->materialized = false;
     pending->path = interactive ? interactive_path : std::string(env_path);
+    if (const char* selector = std::getenv(kGpuCaptureResourceProvenanceEnv);
+        selector && *selector) {
+        if (!parse_gpu_capture_resource_selector(
+                selector, pending->resource_provenance_selector)) {
+            std::fprintf(stderr,
+                         "[gpucap] resource provenance NOT ARMED: invalid selector %s\n",
+                         selector);
+            return {};
+        }
+        pending->resource_provenance_armed = true;
+        // A submit may prepare graphics eagerly yet still execute through the ordered path because
+        // it contains compute. In that shape the eager DrawItem is only a realization cache: sampling
+        // it here both double-matches the later ordered hook and observes bytes before an earlier
+        // producer. Deferred capture therefore has exactly one temporal owner, the ordered executor.
+        if (!defer_materialization)
+            for (const auto& draw : draws)
+                snapshot_pending_gpu_capture_draw_resource(pending.get(), draw);
+    }
     pending->output_triggered = output_triggered;
     if (output_triggered) {
         pending->output_min_nonzero = static_cast<size_t>(std::strtoull(output_min_env, nullptr, 0));
@@ -4096,7 +4398,8 @@ std::unique_ptr<PendingGpuCapture> begin_requested_gpu_capture(
     // pre-submit snapshots above are the deliberate exception: known DMA endpoints cannot be
     // recovered after execution, while every unrelated guest resource and renderer cache remains
     // untouched for rejected candidates.
-    if (output_triggered || defer_materialization) return pending;
+    if (output_triggered || defer_materialization || pending->resource_provenance_armed)
+        return pending;
     std::string error;
     if (!materialize_pending_gpu_capture(*pending, draws, computes, operations,
                                          semantic_state, exact_failures, error)) {
@@ -4147,11 +4450,13 @@ bool finish_requested_gpu_capture(std::unique_ptr<PendingGpuCapture> pending,
             error = "output-triggered capture is missing its synchronous submit state";
             return false;
         }
+        if (!validate_pending_resource_provenance(*pending, error)) return false;
         static const std::vector<ComputeItem> no_computes;
         if (!materialize_pending_gpu_capture(*pending, *draws,
                                              computes ? *computes : no_computes,
                                              *operations, semantic_state, exact_failures, error))
             return false;
+        if (!finalize_pending_resource_provenance(*pending, error)) return false;
         if (g_output_capture_claimed.exchange(true, std::memory_order_acq_rel)) return true;
         std::fprintf(stderr,
                      "[gpucap] captured output match submit %llu: %zu draws, %zu computes, "
@@ -4167,11 +4472,13 @@ bool finish_requested_gpu_capture(std::unique_ptr<PendingGpuCapture> pending,
             error = "deferred capture is missing its exact submit realization";
             return false;
         }
+        if (!validate_pending_resource_provenance(*pending, error)) return false;
         static const std::vector<ComputeItem> no_computes;
         if (!materialize_pending_gpu_capture(*pending, *draws,
                                              computes ? *computes : no_computes,
                                              *operations, semantic_state, exact_failures, error))
             return false;
+        if (!finalize_pending_resource_provenance(*pending, error)) return false;
         std::fprintf(stderr,
                      "[gpucap] captured deferred submit %llu: %zu draws, %zu computes, "
                      "%zu operations, %zu failures -> %s\n",

--- a/prosper/src/gpu/gpu_capture.hpp
+++ b/prosper/src/gpu/gpu_capture.hpp
@@ -8,6 +8,7 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace prosper::gpu {
@@ -27,6 +28,8 @@ inline constexpr const char* kGpuReplayScanoutAddressEnv =
     "PROSPER_GPU_REPLAY_SCANOUT_ADDR";
 inline constexpr const char* kGpuCaptureSave0Env = "PROSPER_SAVE0";
 inline constexpr const char* kGpuCaptureDefaultSave0Root = "/tmp/prosper-savedata0";
+inline constexpr const char* kGpuCaptureResourceProvenanceEnv =
+    "PROSPER_GPU_CAPTURE_RESOURCE_PROVENANCE";
 
 // Preserve the exact registered front-buffer identity as replay metadata. The replay process has no
 // live VideoOut registry, so extent alone cannot distinguish scanout from same-sized intermediates.
@@ -45,6 +48,32 @@ struct GpuCaptureBlob {
     uint64_t bytes_read = 0;
     uint64_t content_hash = 0;
     std::vector<uint8_t> bytes;
+};
+
+// An opt-in temporal audit for one realized graphics resource. The decoded identity is fixed when
+// the draw is realized; the two blob references retain bytes sampled at that point and by ordinary
+// deferred capture materialization after the submit. Keeping both reads makes a zero-filled short
+// read distinguishable from guest-visible zero data and exposes resource reuse after realization.
+struct GpuCaptureResourceSelector {
+    uint64_t draw_index = 0;
+    ShaderProgramStage stage = ShaderProgramStage::Vertex;
+    uint32_t binding = 0;
+};
+
+struct GpuCaptureResourceProvenance {
+    uint64_t draw_index = 0;
+    ShaderProgramStage stage = ShaderProgramStage::Vertex;
+    uint32_t binding = 0;
+    ResourceClass resource_class = ResourceClass::ConstantBuffer;
+    uint64_t guest_addr = 0;
+    uint64_t requested_bytes = 0;
+    uint32_t srt_offset = 0xFFFFFFFFu;
+    uint32_t sgpr_base = 0xFFFFFFFFu;
+    uint32_t realization_blob_index = 0xFFFFFFFFu;
+    uint32_t post_blob_index = 0xFFFFFFFFu;
+    uint64_t post_blob_offset = 0;
+    uint64_t realization_content_hash = 0;
+    uint64_t post_content_hash = 0;
 };
 
 struct GpuCaptureShaderVersion {
@@ -259,6 +288,7 @@ struct GpuCaptureFile {
     std::vector<GpuCapturedDmaCopy> dma_copies;
     std::vector<GpuCapturedOperation> operations;
     std::vector<GpuCapturedOperationFailure> failure_diagnostics;
+    std::vector<GpuCaptureResourceProvenance> resource_provenance;
     bool failure_diagnostics_available = false;
     bool expected_output_valid = false;
     uint64_t expected_output_hash = 0;
@@ -320,6 +350,7 @@ struct GpuReplayFrame {
     std::vector<GpuCapturedOperation> operations;
     std::vector<GpuCaptureRawShaderVersion> raw_shader_versions;
     std::vector<GpuCapturedOperationFailure> failure_diagnostics;
+    std::vector<GpuCaptureResourceProvenance> resource_provenance;
     bool failure_diagnostics_available = false;
     bool expected_output_valid = false;
     uint64_t expected_output_hash = 0;
@@ -389,7 +420,18 @@ struct PendingGpuCapture {
     // post-producer operation realization during finish.
     std::vector<MemorySnapshot> pre_submit_memory;
     std::vector<uint8_t> pre_submit_compute_gds;
+    bool resource_provenance_armed = false;
+    GpuCaptureResourceSelector resource_provenance_selector;
+    uint32_t resource_provenance_matches = 0;
+    std::string resource_provenance_error;
+    GpuCaptureResourceProvenance resource_provenance;
+    GpuCaptureBlob resource_provenance_realization_blob;
 };
+bool parse_gpu_capture_resource_selector(std::string_view text,
+                                         GpuCaptureResourceSelector& selector);
+void snapshot_pending_gpu_capture_draw_resource(
+    PendingGpuCapture* pending, const DrawItem& draw,
+    const CaptureMemoryReader& reader = {});
 void snapshot_pending_gpu_capture_compute_gds(PendingGpuCapture* pending,
                                               const uint8_t* data, size_t bytes);
 std::unique_ptr<PendingGpuCapture> begin_requested_gpu_capture(

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -4839,6 +4839,7 @@ struct OrderedGpustateCaptureTrace {
     std::vector<DrawItem> draws;
     std::vector<ComputeItem> computes;
     std::vector<OperationRealizationFailure> failures;
+    PendingGpuCapture* pending_capture = nullptr;
 };
 
 static OrderedSubmitResult execute_ordered_gpustate(
@@ -4874,6 +4875,7 @@ bool execute_nonrender_submit_work(const GpuState& st, uint64_t submit_no) {
     snapshot_pending_gpu_capture_compute_gds(
         pending_capture.get(), g_compute_gds.data(), g_compute_gds.size());
     OrderedGpustateCaptureTrace capture_trace;
+    capture_trace.pending_capture = pending_capture.get();
     const OrderedSubmitResult result = execute_ordered_gpustate(
         st, 0, 0, submit_no, {}, g_compute,
         pending_capture && can_defer_capture ? &capture_trace : nullptr);
@@ -5976,7 +5978,11 @@ static OrderedSubmitResult execute_ordered_gpustate(const GpuState& st, uint32_t
                     failure_known = capture_trace != nullptr;
                 }
                 if (realized) {
-                    if (capture_trace) capture_trace->draws.push_back(item);
+                    if (capture_trace) {
+                        snapshot_pending_gpu_capture_draw_resource(
+                            capture_trace->pending_capture, item);
+                        capture_trace->draws.push_back(item);
+                    }
                     span.push_back(std::move(item));
                 } else if (capture_trace) {
                     // The reason used to die here: this path simply broke, and gpu_capture later
@@ -6344,6 +6350,7 @@ bool execute_ordered_and_present(const GpuState& st, uint32_t width, uint32_t he
     snapshot_pending_gpu_capture_compute_gds(
         pending_capture.get(), g_compute_gds.data(), g_compute_gds.size());
     OrderedGpustateCaptureTrace capture_trace;
+    capture_trace.pending_capture = pending_capture.get();
     OrderedSubmitResult result = needs_ordered_realization
         ? execute_ordered_gpustate(st, width, height, submit_no, g_live, g_compute,
                                    pending_capture ? &capture_trace : nullptr,

--- a/prosper/tests/test_gpu_capture.cpp
+++ b/prosper/tests/test_gpu_capture.cpp
@@ -236,6 +236,153 @@ int main() {
           captured.draws[0].system_inputs == draw.system_inputs,
           "realized draw captures the exact fixed-function pixel-stage ABI");
 
+    // #1849: one opt-in semantic resource snapshot must sample the bytes at draw realization,
+    // independently of ordinary deferred materialization after the submit.
+    GpuCaptureResourceSelector provenance_selector;
+    CHECK(parse_gpu_capture_resource_selector("0x4d:ps:040", provenance_selector) &&
+              provenance_selector.draw_index == 77 &&
+              provenance_selector.stage == ShaderProgramStage::Fragment &&
+              provenance_selector.binding == 32,
+          "resource provenance parser shares strict base-0 semantic selector rules");
+    CHECK(!parse_gpu_capture_resource_selector("77:fs:32", provenance_selector) &&
+              !parse_gpu_capture_resource_selector("77:ps", provenance_selector) &&
+              !parse_gpu_capture_resource_selector("-1:ps:32", provenance_selector) &&
+              !parse_gpu_capture_resource_selector("77:ps:0x100000000", provenance_selector),
+          "resource provenance parser rejects malformed, signed, and oversized selectors");
+
+    std::array<uint8_t, 16> provenance_memory{};
+    for (size_t i = 0; i < provenance_memory.size(); ++i)
+        provenance_memory[i] = static_cast<uint8_t>(0x10 + i);
+    const std::array<uint8_t, 16> realization_bytes = provenance_memory;
+    auto provenance_table = std::make_shared<ShaderResourceTable>();
+    ShaderResource provenance_resource;
+    provenance_resource.cls = ResourceClass::ConstantBuffer;
+    provenance_resource.binding = 32;
+    provenance_resource.gpu_addr = reinterpret_cast<uint64_t>(provenance_memory.data());
+    provenance_resource.size = provenance_memory.size();
+    provenance_resource.stride = 16;
+    provenance_resource.sgpr_base = 0;
+    provenance_table->resources = {provenance_resource};
+    DrawItem provenance_draw = draw;
+    provenance_draw.draw_index = 77;
+    provenance_draw.command_order = 777;
+    provenance_draw.vrt.reset();
+    provenance_draw.prt = provenance_table;
+    const std::vector<DrawItem> provenance_draws = {provenance_draw};
+    const std::vector<SubmitOperation> provenance_operations = {
+        {SubmitOperationKind::Draw, 77, 777},
+    };
+    auto make_provenance_pending = [&](const std::filesystem::path& path) {
+        auto pending = std::make_unique<PendingGpuCapture>();
+        pending->materialized = false;
+        pending->path = path.string();
+        pending->capture.metadata = meta;
+        pending->resource_provenance_armed = true;
+        pending->resource_provenance_selector = {77, ShaderProgramStage::Fragment, 32};
+        return pending;
+    };
+    const auto provenance_path = prosper_test::test_scratch_dir() /
+        "prosper_gpu_capture_resource_provenance.prgcap";
+    auto provenance_pending = make_provenance_pending(provenance_path);
+    snapshot_pending_gpu_capture_draw_resource(provenance_pending.get(), provenance_draw);
+    for (size_t i = 0; i < provenance_memory.size(); ++i)
+        provenance_memory[i] = static_cast<uint8_t>(0xa0 + i);
+    const std::array<uint8_t, 16> post_bytes = provenance_memory;
+    GpuCaptureFile provenance_loaded;
+    CHECK(finish_requested_gpu_capture(
+              std::move(provenance_pending), {}, error, &provenance_draws, nullptr,
+              &provenance_operations) &&
+              read_gpu_capture(provenance_path.string(), provenance_loaded, error) &&
+              provenance_loaded.resource_provenance.size() == 1,
+          "selected resource provenance persists one exact temporal audit");
+    const auto* provenance = provenance_loaded.resource_provenance.size() == 1
+        ? &provenance_loaded.resource_provenance.front() : nullptr;
+    const auto* realization_blob = provenance &&
+            provenance->realization_blob_index < provenance_loaded.blobs.size()
+        ? &provenance_loaded.blobs[provenance->realization_blob_index] : nullptr;
+    const auto* post_blob = provenance &&
+            provenance->post_blob_index < provenance_loaded.blobs.size()
+        ? &provenance_loaded.blobs[provenance->post_blob_index] : nullptr;
+    CHECK(provenance && realization_blob && post_blob &&
+              realization_blob->bytes_read == provenance_memory.size() &&
+              post_blob->bytes_read >= provenance->post_blob_offset + provenance_memory.size() &&
+              std::equal(realization_bytes.begin(), realization_bytes.end(),
+                         realization_blob->bytes.begin()) &&
+              std::equal(post_bytes.begin(), post_bytes.end(),
+                         post_blob->bytes.begin() + provenance->post_blob_offset) &&
+              provenance->realization_content_hash ==
+                  gpu_capture_hash(realization_bytes.data(), realization_bytes.size()) &&
+              provenance->post_content_hash ==
+                  gpu_capture_hash(post_bytes.data(), post_bytes.size()) &&
+              provenance->realization_content_hash != provenance->post_content_hash,
+          "selected snapshot retains draw-time A and independently reports post-submit B");
+    CHECK(provenance && provenance->draw_index == 77 &&
+              provenance->stage == ShaderProgramStage::Fragment &&
+              provenance->binding == 32 &&
+              provenance->resource_class == ResourceClass::ConstantBuffer &&
+              provenance->guest_addr == reinterpret_cast<uint64_t>(provenance_memory.data()) &&
+              provenance->requested_bytes == provenance_memory.size() &&
+              provenance->srt_offset == 0xFFFFFFFFu && provenance->sgpr_base == 0,
+          "resource provenance retains auditable semantic and decoded descriptor identity");
+
+    size_t default_reader_calls = 0;
+    PendingGpuCapture default_pending;
+    snapshot_pending_gpu_capture_draw_resource(
+        &default_pending, provenance_draw,
+        [&](uint64_t, uint8_t*, size_t) -> size_t {
+            ++default_reader_calls;
+            return 0;
+        });
+    CHECK(default_reader_calls == 0 && default_pending.resource_provenance_matches == 0 &&
+              default_pending.resource_provenance_realization_blob.bytes.empty(),
+          "disabled provenance performs no resource read, allocation, or byte copy");
+
+    const auto partial_path = prosper_test::test_scratch_dir() /
+        "prosper_gpu_capture_resource_provenance_partial.prgcap";
+    auto partial_pending = make_provenance_pending(partial_path);
+    snapshot_pending_gpu_capture_draw_resource(
+        partial_pending.get(), provenance_draw,
+        [&](uint64_t, uint8_t* destination, size_t) -> size_t {
+            std::memcpy(destination, provenance_memory.data(), 4);
+            return 4;
+        });
+    GpuCaptureFile partial_loaded;
+    CHECK(finish_requested_gpu_capture(
+              std::move(partial_pending), {}, error, &provenance_draws, nullptr,
+              &provenance_operations) &&
+              read_gpu_capture(partial_path.string(), partial_loaded, error) &&
+              partial_loaded.resource_provenance.size() == 1 &&
+              partial_loaded.blobs[
+                  partial_loaded.resource_provenance[0].realization_blob_index].bytes_read == 4 &&
+              partial_loaded.blobs[
+                  partial_loaded.resource_provenance[0].post_blob_index].bytes_read >=
+                  partial_loaded.resource_provenance[0].post_blob_offset +
+                      provenance_memory.size(),
+          "partial realization read remains distinguishable from guest-authored zero bytes");
+
+    auto zero_match_pending = make_provenance_pending(
+        prosper_test::test_scratch_dir() / "prosper_gpu_capture_resource_provenance_zero.prgcap");
+    zero_match_pending->resource_provenance_selector.binding = 99;
+    snapshot_pending_gpu_capture_draw_resource(zero_match_pending.get(), provenance_draw);
+    CHECK(!finish_requested_gpu_capture(
+              std::move(zero_match_pending), {}, error, &provenance_draws, nullptr,
+              &provenance_operations) &&
+              error.find("matched 0 resources") != std::string::npos,
+          "zero-match resource provenance selector fails visibly before capture write");
+
+    DrawItem ambiguous_draw = provenance_draw;
+    ambiguous_draw.prt = std::make_shared<ShaderResourceTable>(*provenance_table);
+    ambiguous_draw.prt->resources.push_back(provenance_resource);
+    const std::vector<DrawItem> ambiguous_draws = {ambiguous_draw};
+    auto ambiguous_pending = make_provenance_pending(
+        prosper_test::test_scratch_dir() / "prosper_gpu_capture_resource_provenance_ambiguous.prgcap");
+    snapshot_pending_gpu_capture_draw_resource(ambiguous_pending.get(), ambiguous_draw);
+    CHECK(!finish_requested_gpu_capture(
+              std::move(ambiguous_pending), {}, error, &ambiguous_draws, nullptr,
+              &provenance_operations) &&
+              error.find("ambiguous") != std::string::npos,
+          "multiple-match resource provenance selector fails visibly before capture write");
+
     DrawItem pcrel_draw = draw;
     pcrel_draw.vs_guest_addr = reinterpret_cast<uint64_t>(kDiagnosticPcrelVs);
     pcrel_draw.vs_chain_guest_addr = 0;
@@ -454,6 +601,12 @@ int main() {
         return 4 + 4 * rc;
     };
 
+    // v45: count plus one fixed-size selected resource-provenance record. The sampled bytes live in
+    // ordinary capture blobs, so the tail itself remains fixed-size per record.
+    auto v45_tail = [](const GpuCaptureFile& f) -> size_t {
+        return 4 + 73 * f.resource_provenance.size();
+    };
+
     // v25 (#1240): byte length of the trailing resolve-state block.
     auto v25_tail = [](const GpuCaptureFile& f) -> size_t {
         size_t present_failures = 0;
@@ -485,6 +638,7 @@ int main() {
               v16_scissor_bytes.size() >= 25,
           "v17 capture serializes effective guest scissor state");
     if (v16_scissor_bytes.size() >= 25) {
+        v16_scissor_bytes.resize(v16_scissor_bytes.size() - v45_tail(v16_scissor_source));
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - v44_tail(v16_scissor_source));
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - v43_tail(v16_scissor_source));
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - v42_tail(v16_scissor_source));
@@ -601,7 +755,7 @@ int main() {
         deserialize_gpu_capture(msaa_bytes, msaa_loaded, error);
     if (!msaa_deserialized) std::printf("  [diag] MSAA capture deserialization: %s\n", error.c_str());
     CHECK(msaa_deserialized &&
-              msaa_loaded.format_version == 44 &&
+              msaa_loaded.format_version == 45 &&
               msaa_loaded.draws[0].vrt.resources[0].resource.sample_count == 4 &&
               msaa_loaded.blobs.size() == 2 &&
               msaa_loaded.blobs[1].bytes.size() == 32768u &&
@@ -627,7 +781,8 @@ int main() {
           "offline replay owns the complete zero-HTILE plane needed for fast-clear materialization");
     std::vector<uint8_t> mismatched_msaa_metadata = msaa_bytes;
     const uint32_t two_samples = 2;
-    std::memcpy(mismatched_msaa_metadata.data() + mismatched_msaa_metadata.size() - 4u,
+    std::memcpy(mismatched_msaa_metadata.data() + mismatched_msaa_metadata.size() -
+                    v45_tail(msaa_capture) - 4u,
                 &two_samples, sizeof(two_samples));
     GpuCaptureFile mismatched_msaa_loaded;
     CHECK(!deserialize_gpu_capture(
@@ -650,6 +805,7 @@ int main() {
     std::vector<uint8_t> v43_msaa_bytes;
     CHECK(serialize_gpu_capture(v43_msaa_source, v43_msaa_bytes, error),
           "current writer prepares an uncompressed v43 MSAA compatibility fixture");
+    v43_msaa_bytes.resize(v43_msaa_bytes.size() - v45_tail(v43_msaa_source));
     v43_msaa_bytes.resize(v43_msaa_bytes.size() - v44_tail(v43_msaa_source));
     v43_msaa_bytes[8] = 43;
     v43_msaa_bytes[9] = v43_msaa_bytes[10] = v43_msaa_bytes[11] = 0;
@@ -705,7 +861,7 @@ int main() {
     };
     GpuCaptureFile video_capture;
     CHECK(capture_draw_items({video_draw}, meta, video_reader, video_capture, error) &&
-              video_capture.format_version == 44 && video_capture.blobs.size() == 1 &&
+              video_capture.format_version == 45 && video_capture.blobs.size() == 1 &&
               video_capture.blobs[0].bytes.size() == video_memory.size() &&
               video_capture.draws[0].prt.resources[0].captured_size == video_memory.size() &&
               video_capture.draws[0].prt.resources[0].resource.linear_row_pitch_bytes == 2048,
@@ -715,7 +871,7 @@ int main() {
     GpuReplayFrame video_replay;
     CHECK(serialize_gpu_capture(video_capture, video_capture_bytes, error) &&
               deserialize_gpu_capture(video_capture_bytes, video_loaded, error) &&
-              video_loaded.format_version == 44 &&
+              video_loaded.format_version == 45 &&
               video_loaded.draws[0].prt.resources[0].captured_size == video_memory.size() &&
               video_loaded.draws[0].prt.resources[0].resource.linear_row_pitch_bytes == 2048 &&
               materialize_gpu_replay(video_loaded, video_replay, error) &&
@@ -738,7 +894,7 @@ int main() {
     GpuReplayFrame upgraded_video_replay;
     CHECK(serialize_gpu_capture(legacy_video, upgraded_video_bytes, error) &&
               deserialize_gpu_capture(upgraded_video_bytes, upgraded_video, error) &&
-              upgraded_video.format_version == 44 &&
+              upgraded_video.format_version == 45 &&
               upgraded_video.draws[0].prt.resources[0].captured_size == video_chroma.size &&
               upgraded_video.draws[0].prt.resources[0].resource.linear_row_pitch_bytes == 2048 &&
               materialize_gpu_replay(upgraded_video, upgraded_video_replay, error) &&
@@ -820,7 +976,7 @@ int main() {
           "Plucky RGBA16 32-cubed S3 capture uses its four true 3D macroblocks");
     CHECK(serialize_gpu_capture(array_layout_capture, array_layout_bytes, error) &&
               deserialize_gpu_capture(array_layout_bytes, array_layout_loaded, error) &&
-              array_layout_loaded.format_version == 44 &&
+              array_layout_loaded.format_version == 45 &&
               array_layout_loaded.draws[0].vrt.resources[0].resource.layer_stride_bytes == 720896u &&
               array_layout_loaded.draws[0].vrt.resources[0].resource.layer_mip_offset_bytes == 65536u,
           "v32 capture round-trips thin-array slice stride and selected-mip offset");
@@ -919,6 +1075,7 @@ int main() {
           "writer rejects an out-of-bounds DCC metadata reference");
     CHECK(serialize_gpu_capture(volume_capture, volume_bytes, error),
           "recreated valid v12 DCC bytes after malformed-reference check");
+    volume_bytes.resize(volume_bytes.size() - v45_tail(volume_capture));
     volume_bytes.resize(volume_bytes.size() - v44_tail(volume_capture));
     volume_bytes.resize(volume_bytes.size() - v43_tail(volume_capture));
     volume_bytes.resize(volume_bytes.size() - v42_tail(volume_capture));
@@ -1021,6 +1178,7 @@ int main() {
     CHECK(serialize_gpu_capture(pre_v31_source, v20_bytes, error) && v20_bytes.size() >= 21,
           "v21 capture serializes the logic-op extension");
     if (v20_bytes.size() >= 21) {
+        v20_bytes.resize(v20_bytes.size() - v45_tail(pre_v31_source));
         v20_bytes.resize(v20_bytes.size() - v44_tail(pre_v31_source));
         v20_bytes.resize(v20_bytes.size() - v43_tail(pre_v31_source));
         v20_bytes.resize(v20_bytes.size() - v42_tail(pre_v31_source));
@@ -1098,6 +1256,7 @@ int main() {
         std::vector<uint8_t> v42_bytes;
         CHECK(serialize_gpu_capture(captured, v42_bytes, error),
               "v43 capture serializes before the color-state downgrade");
+        v42_bytes.resize(v42_bytes.size() - v45_tail(captured));
         v42_bytes.resize(v42_bytes.size() - v44_tail(captured));
         v42_bytes.resize(v42_bytes.size() - v43_tail(captured));
         v42_bytes[8] = 42; v42_bytes[9] = v42_bytes[10] = v42_bytes[11] = 0;
@@ -1119,7 +1278,8 @@ int main() {
     std::vector<uint8_t> v24_resolve_bytes;
     GpuCaptureFile v24_resolve_loaded;
     CHECK(serialize_gpu_capture(pre_v31_source, v24_resolve_bytes, error) &&
-          v24_resolve_bytes.size() >= v44_tail(pre_v31_source) +
+              v24_resolve_bytes.size() >= v45_tail(pre_v31_source) +
+              v44_tail(pre_v31_source) +
               v43_tail(pre_v31_source) + v42_tail(pre_v31_source) +
               v41_tail(pre_v31_source) +
               v40_tail(pre_v31_source) +
@@ -1133,7 +1293,8 @@ int main() {
               v27_tail(pre_v31_source) + v26_tail(pre_v31_source) +
               v25_tail(pre_v31_source),
           "v25 capture exposes a removable trailing resolve-state block");
-    if (v24_resolve_bytes.size() >= v44_tail(pre_v31_source) +
+    if (v24_resolve_bytes.size() >= v45_tail(pre_v31_source) +
+            v44_tail(pre_v31_source) +
             v43_tail(pre_v31_source) + v42_tail(pre_v31_source) +
             v41_tail(pre_v31_source) +
             v40_tail(pre_v31_source) +
@@ -1146,6 +1307,7 @@ int main() {
             v29_tail(pre_v31_source) + v28_tail(pre_v31_source) +
             v27_tail(pre_v31_source) + v26_tail(pre_v31_source) +
             v25_tail(pre_v31_source)) {
+        v24_resolve_bytes.resize(v24_resolve_bytes.size() - v45_tail(pre_v31_source));
         v24_resolve_bytes.resize(v24_resolve_bytes.size() - v44_tail(pre_v31_source));
         v24_resolve_bytes.resize(v24_resolve_bytes.size() - v43_tail(pre_v31_source));
         v24_resolve_bytes.resize(v24_resolve_bytes.size() - v42_tail(pre_v31_source));
@@ -1244,8 +1406,10 @@ int main() {
               v37_compatible_bytes.size() >= 12,
           "current capture prepares the layout-compatible v37 fixture");
     if (v37_compatible_bytes.size() >=
-        v44_tail(captured) + v43_tail(captured) + v42_tail(captured) + v41_tail(captured) +
+        v45_tail(captured) + v44_tail(captured) + v43_tail(captured) +
+            v42_tail(captured) + v41_tail(captured) +
             v40_tail(captured) + v39_tail(captured)) {
+        v37_compatible_bytes.resize(v37_compatible_bytes.size() - v45_tail(captured));
         v37_compatible_bytes.resize(v37_compatible_bytes.size() - v44_tail(captured));
         v37_compatible_bytes.resize(v37_compatible_bytes.size() - v43_tail(captured));
         v37_compatible_bytes.resize(v37_compatible_bytes.size() - v42_tail(captured));
@@ -1437,18 +1601,21 @@ int main() {
     v36_compute_source.raw_shader_versions.clear();
     CHECK(serialize_gpu_capture(v36_compute_source, v36_compute_bytes, error) &&
               v36_compute_bytes.size() >=
-                  v44_tail(v36_compute_source) + v43_tail(v36_compute_source) +
+                  v45_tail(v36_compute_source) + v44_tail(v36_compute_source) +
+                      v43_tail(v36_compute_source) +
                       v42_tail(v36_compute_source) + v41_tail(v36_compute_source) +
                       v40_tail(v36_compute_source) +
                       v39_tail(v36_compute_source) +
                       v37_tail(v36_compute_source),
           "v37 capture exposes a removable compute subgroup-contract tail");
     if (v36_compute_bytes.size() >=
-        v44_tail(v36_compute_source) + v43_tail(v36_compute_source) +
+        v45_tail(v36_compute_source) + v44_tail(v36_compute_source) +
+            v43_tail(v36_compute_source) +
             v42_tail(v36_compute_source) + v41_tail(v36_compute_source) +
             v40_tail(v36_compute_source) +
             v39_tail(v36_compute_source) +
             v37_tail(v36_compute_source)) {
+        v36_compute_bytes.resize(v36_compute_bytes.size() - v45_tail(v36_compute_source));
         v36_compute_bytes.resize(v36_compute_bytes.size() - v44_tail(v36_compute_source));
         v36_compute_bytes.resize(v36_compute_bytes.size() - v43_tail(v36_compute_source));
         v36_compute_bytes.resize(v36_compute_bytes.size() - v42_tail(v36_compute_source));
@@ -1656,7 +1823,7 @@ int main() {
     GpuCaptureFile failed_compute_loaded;
     CHECK(serialize_gpu_capture(failed_compute_capture, failed_compute_bytes, error) &&
               deserialize_gpu_capture(failed_compute_bytes, failed_compute_loaded, error) &&
-              failed_compute_loaded.format_version == 44 &&
+              failed_compute_loaded.format_version == 45 &&
               failed_compute_loaded.failure_diagnostics[0].compute_launch.threads_x == 37 &&
               failed_compute_loaded.failure_diagnostics[0].stages[0]
                       .recompile_config.user_sgprs ==
@@ -1669,7 +1836,8 @@ int main() {
 
     std::vector<uint8_t> v41_failed_compute_bytes = failed_compute_bytes;
     v41_failed_compute_bytes.resize(
-        v41_failed_compute_bytes.size() - v44_tail(failed_compute_capture) -
+        v41_failed_compute_bytes.size() - v45_tail(failed_compute_capture) -
+            v44_tail(failed_compute_capture) -
             v43_tail(failed_compute_capture) -
             v42_tail(failed_compute_capture));
     v41_failed_compute_bytes[8] = 41;
@@ -1887,7 +2055,7 @@ int main() {
                 loaded_failed_msaa = &resource;
         }
     }
-    CHECK(failed_loaded.format_version == 44 && loaded_shadow &&
+    CHECK(failed_loaded.format_version == 45 && loaded_shadow &&
           loaded_shadow->resource.depth == 4 &&
           loaded_shadow->resource.max_uncompressed_block_size == 2 &&
           loaded_shadow->resource.max_compressed_block_size == 1 &&
@@ -1925,7 +2093,8 @@ int main() {
         // Fragment is the final stage with resources, and its MSAA descriptor is the final resource,
         // so this is exactly its v44 sample-count record rather than a preceding extension field.
         std::memcpy(malformed_failed_sample_bytes.data() +
-                        malformed_failed_sample_bytes.size() - sizeof(uint32_t),
+                        malformed_failed_sample_bytes.size() - v45_tail(failed_capture) -
+                            sizeof(uint32_t),
                     &invalid_samples, sizeof(invalid_samples));
     }
     GpuCaptureFile malformed_failed_sample_loaded;
@@ -1938,12 +2107,15 @@ int main() {
     GpuCaptureFile v40_failed_loaded;
     CHECK(serialize_gpu_capture(failed_capture, v40_failed_bytes, error) &&
               v40_failed_bytes.size() >=
-                  v44_tail(failed_capture) + v43_tail(failed_capture) +
+                  v45_tail(failed_capture) + v44_tail(failed_capture) +
+                      v43_tail(failed_capture) +
                       v42_tail(failed_capture) + v41_tail(failed_capture),
           "v41 failed-stage resource tail is removable for a v40 compatibility fixture");
     if (v40_failed_bytes.size() >=
-        v44_tail(failed_capture) + v43_tail(failed_capture) +
+        v45_tail(failed_capture) + v44_tail(failed_capture) +
+            v43_tail(failed_capture) +
             v42_tail(failed_capture) + v41_tail(failed_capture)) {
+        v40_failed_bytes.resize(v40_failed_bytes.size() - v45_tail(failed_capture));
         v40_failed_bytes.resize(v40_failed_bytes.size() - v44_tail(failed_capture));
         v40_failed_bytes.resize(v40_failed_bytes.size() - v43_tail(failed_capture));
         v40_failed_bytes.resize(v40_failed_bytes.size() - v42_tail(failed_capture));
@@ -2027,6 +2199,7 @@ int main() {
     if (v13_bytes.size() >= 32) {
         const size_t legacy_resource_count = legacy_source.draws[0].vrt.resources.size() +
                                              legacy_source.draws[0].prt.resources.size();
+        v13_bytes.resize(v13_bytes.size() - v45_tail(legacy_source));
         v13_bytes.resize(v13_bytes.size() - v44_tail(legacy_source));
         v13_bytes.resize(v13_bytes.size() - v43_tail(legacy_source));
         v13_bytes.resize(v13_bytes.size() - v42_tail(legacy_source));
@@ -2069,6 +2242,7 @@ int main() {
     if (legacy_bytes.size() >= 32) {
         const size_t legacy_resource_count = legacy_source.draws[0].vrt.resources.size() +
                                              legacy_source.draws[0].prt.resources.size();
+        legacy_bytes.resize(legacy_bytes.size() - v45_tail(legacy_source));
         legacy_bytes.resize(legacy_bytes.size() - v44_tail(legacy_source));
         legacy_bytes.resize(legacy_bytes.size() - v43_tail(legacy_source));
         legacy_bytes.resize(legacy_bytes.size() - v42_tail(legacy_source));
@@ -2137,9 +2311,9 @@ int main() {
     CHECK(deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
           !legacy_loaded.failure_diagnostics_available && legacy_loaded.failure_diagnostics.empty(),
           "v6 capture reopens with failed-operation diagnostics reported unavailable");
-    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 45;   // kVersion + 1: a future version
+    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 46;   // kVersion + 1: a future version
     CHECK(!deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
-          error == "unsupported capture version 45",
+          error == "unsupported capture version 46",
           "future capture versions fail with a concrete version error");
 
     GpuCaptureFile bad_hash = mixed;

--- a/prosper/tests/test_gpu_execute.cpp
+++ b/prosper/tests/test_gpu_execute.cpp
@@ -12,9 +12,11 @@
 #include "render_runner.h"
 #include "test_scratch.h"
 #include <algorithm>
+#include <array>
 #include <cstdio>
 #include <cstdint>
 #include <cstdlib>
+#include <cstring>
 #include <filesystem>
 #include <memory>
 #include <string>
@@ -40,6 +42,14 @@ alignas(256) static const uint32_t kVs[] = {
 alignas(256) static const uint32_t kPs[] = {
     0x7E000280u, 0x7E0202F2u, 0x7E040280u, 0x7E0602F2u, 0xF800180Fu, 0x03020100u, 0xBF810000u,
 };
+// Byte-identical shader at a distinct program address. The test renderer registers kPs with a
+// descriptor-free header during setup, and the production registry intentionally resolves the
+// oldest header for a recycled address. A distinct identity lets the provenance integration test
+// exercise its one-cbuffer declaration instead of accidentally reusing that earlier header.
+alignas(256) static uint32_t kResourcePs[] = {
+    0x7E000280u, 0x7E0202F2u, 0x7E040280u, 0x7E0602F2u, 0xF800180Fu, 0x03020100u, 0xBF810000u,
+};
+alignas(256) static uint32_t kResourceNoopCs[] = {0xBF810000u};
 // Descriptor-free clear-RG helper emitted by AGC for CB_COLOR_CONTROL.DCC_DECOMPRESS. Hardware
 // interprets its export as a metadata operation; it must not run as an ordinary Vulkan color shader.
 alignas(256) static const uint32_t kDccPs[] = {
@@ -51,6 +61,14 @@ static void set_pgm(GpuState& st, uint32_t lo_off, uint32_t hi_off, const void* 
     uint64_t a = (uint64_t)(uintptr_t)p;
     st.sh[lo_off] = (uint32_t)((a >> 8) & 0xFFFFFFFFu);
     st.sh[hi_off] = (uint32_t)((a >> 40) & 0xFFu);
+}
+
+static void set_test_env(const char* name, const char* value) {
+#ifdef _WIN32
+    _putenv_s(name, value ? value : "");
+#else
+    if (value) setenv(name, value, 1); else unsetenv(name);
+#endif
 }
 
 int main() {
@@ -1236,6 +1254,154 @@ int main() {
               "#1636: the new reasons have names, so gpu_replay --inspect-only can print them");
         std::error_code cleanup;
         std::filesystem::remove(capture_path, cleanup);
+    }
+
+    // #1849: a submit with direct draws plus compute prepares its draws eagerly, but executes them
+    // through the ordered path. The selected temporal resource must be sampled exactly once at that
+    // ordered draw position—not during eager preparation and not after the renderer mutates it.
+    // Keeping this registration last lets these stack-backed synthetic AGC headers remain valid for
+    // the process-lifetime registry through every subsequent lookup.
+    {
+        auto create_shader = prosper::Hle::lookup("f3dg2CSgRKY");
+        ShaderReg pixel_registers[2] = {
+            {P::SPI_SHADER_PGM_LO_PS, 0}, {P::SPI_SHADER_PGM_HI_PS, 0},
+        };
+        AgcShaderSharp cbuffer_sharp[1];
+        cbuffer_sharp[0].bits = 0;  // one four-dword V# at PS user SGPR 0
+        AgcShaderUserData pixel_user_data{};
+        pixel_user_data.sharp_resource_offset[3] = cbuffer_sharp;
+        pixel_user_data.sharp_resource_count[3] = 1;
+        AgcShaderHeader pixel_header{};
+        pixel_header.file_header = 0x34333231u;
+        pixel_header.version = 0x18;
+        pixel_header.user_data = &pixel_user_data;
+        pixel_header.sh_registers = pixel_registers;
+        pixel_header.shader_size = sizeof(kResourcePs);
+        pixel_header.type = 1;
+        pixel_header.num_sh_registers = 2;
+
+        ShaderReg compute_registers[2] = {
+            {P::COMPUTE_PGM_LO, 0}, {P::COMPUTE_PGM_HI, 0},
+        };
+        AgcShaderHeader compute_header{};
+        compute_header.file_header = 0x34333231u;
+        compute_header.version = 0x18;
+        compute_header.sh_registers = compute_registers;
+        compute_header.shader_size = sizeof(kResourceNoopCs);
+        compute_header.type = 0;
+        compute_header.num_sh_registers = 2;
+
+        void* registered_pixel = nullptr;
+        void* registered_compute = nullptr;
+        CHECK(create_shader &&
+                  create_shader(reinterpret_cast<uint64_t>(&registered_pixel),
+                                reinterpret_cast<uint64_t>(&pixel_header),
+                                reinterpret_cast<uint64_t>(kResourcePs), 0, 0, 0) == 0 &&
+                  registered_pixel == &pixel_header &&
+                  create_shader(reinterpret_cast<uint64_t>(&registered_compute),
+                                reinterpret_cast<uint64_t>(&compute_header),
+                                reinterpret_cast<uint64_t>(kResourceNoopCs), 0, 0, 0) == 0 &&
+                  registered_compute == &compute_header,
+              "register draw and compute programs for ordered temporal capture");
+
+        std::array<uint8_t, 16> cbuffer{};
+        for (size_t i = 0; i < cbuffer.size(); ++i)
+            cbuffer[i] = static_cast<uint8_t>(0x20 + i);
+        const auto realization_bytes = cbuffer;
+        std::array<uint8_t, 16> post_bytes{};
+        for (size_t i = 0; i < post_bytes.size(); ++i)
+            post_bytes[i] = static_cast<uint8_t>(0xb0 + i);
+
+        GpuState ordered = st;
+        ordered.draws.clear();
+        ordered.dispatches.clear();
+        ordered.dma_copies.clear();
+        ordered.ordered_memory_effects.clear();
+        ordered.sh[P::SPI_SHADER_PGM_LO_PS] = pixel_registers[0].value;
+        ordered.sh[P::SPI_SHADER_PGM_HI_PS] = pixel_registers[1].value;
+        const uint64_t cbuffer_addr = reinterpret_cast<uint64_t>(cbuffer.data());
+        ordered.sh[P::SPI_SHADER_USER_DATA_PS_0 + 0] =
+            static_cast<uint32_t>(cbuffer_addr);
+        ordered.sh[P::SPI_SHADER_USER_DATA_PS_0 + 1] =
+            static_cast<uint32_t>((cbuffer_addr >> 32) & 0xffffu);
+        ordered.sh[P::SPI_SHADER_USER_DATA_PS_0 + 2] =
+            static_cast<uint32_t>(cbuffer.size());
+        ordered.sh[P::SPI_SHADER_USER_DATA_PS_0 + 3] = (22u << 12) | 0xFACu;
+        GpuState::Draw draw;
+        draw.index_count = 3;
+        draw.command_order = 100;
+        ordered.draws.push_back(draw);
+        auto dispatch_state = std::make_shared<GpuState>();
+        dispatch_state->sh[P::COMPUTE_PGM_LO] = compute_registers[0].value;
+        dispatch_state->sh[P::COMPUTE_PGM_HI] = compute_registers[1].value;
+        GpuState::Dispatch dispatch;
+        dispatch.threads_x = dispatch.threads_y = dispatch.threads_z = 1;
+        dispatch.command_order = 200;
+        dispatch.state = dispatch_state;
+        ordered.dispatches.push_back(dispatch);
+
+        const auto capture_path = prosper_test::test_scratch_dir() /
+            "prosper_ordered_resource_provenance.prgcap";
+        std::error_code filesystem_error;
+        std::filesystem::remove(capture_path, filesystem_error);
+        const char* original_selector_value =
+            std::getenv(kGpuCaptureResourceProvenanceEnv);
+        const bool had_original_selector = original_selector_value != nullptr;
+        const std::string original_selector =
+            original_selector_value ? original_selector_value : "";
+        set_test_env(kGpuCaptureResourceProvenanceEnv, "0:ps:32");
+        request_interactive_gpu_capture(capture_path.string());
+        bool renderer_saw_resource = false;
+        bool compute_executed = false;
+        set_submit_renderer([&](const std::vector<DrawItem>& items, uint32_t, uint32_t) {
+            renderer_saw_resource = !items.empty() && items.front().prt &&
+                items.front().prt->by_binding(32) != nullptr;
+            cbuffer = post_bytes;
+            return RenderedFrame{};
+        });
+        set_submit_compute([&](const std::vector<ComputeItem>& items) {
+            compute_executed = !items.empty();
+            return compute_executed;
+        });
+        execute_ordered_and_present(ordered, W, H, 781, /*publish=*/false);
+        set_submit_renderer({});
+        set_submit_compute({});
+        set_test_env(kGpuCaptureResourceProvenanceEnv,
+                     had_original_selector ? original_selector.c_str() : nullptr);
+
+        GpuCaptureFile captured;
+        std::string capture_error;
+        const bool read = read_gpu_capture(capture_path.string(), captured, capture_error);
+        const auto* provenance = read && captured.resource_provenance.size() == 1
+            ? &captured.resource_provenance.front() : nullptr;
+        const auto* realization_blob = provenance &&
+                provenance->realization_blob_index < captured.blobs.size()
+            ? &captured.blobs[provenance->realization_blob_index] : nullptr;
+        const auto* post_blob = provenance &&
+                provenance->post_blob_index < captured.blobs.size()
+            ? &captured.blobs[provenance->post_blob_index] : nullptr;
+        const bool exact_temporal_samples = provenance && realization_blob && post_blob &&
+            provenance->draw_index == 0 &&
+            provenance->stage == ShaderProgramStage::Fragment &&
+            provenance->binding == 32 &&
+            provenance->resource_class == ResourceClass::ConstantBuffer &&
+            provenance->guest_addr == cbuffer_addr &&
+            provenance->requested_bytes == cbuffer.size() &&
+            realization_blob->bytes_read == cbuffer.size() &&
+            post_blob->bytes_read >= provenance->post_blob_offset + cbuffer.size() &&
+            std::equal(realization_bytes.begin(), realization_bytes.end(),
+                       realization_blob->bytes.begin()) &&
+            std::equal(post_bytes.begin(), post_bytes.end(),
+                       post_blob->bytes.begin() + provenance->post_blob_offset);
+        if (!renderer_saw_resource || !compute_executed || !exact_temporal_samples)
+            std::printf("  [diag] ordered resource provenance: renderer=%d compute=%d read=%d "
+                        "error=%s records=%zu\n",
+                        renderer_saw_resource ? 1 : 0, compute_executed ? 1 : 0,
+                        read ? 1 : 0, capture_error.c_str(),
+                        captured.resource_provenance.size());
+        CHECK(renderer_saw_resource && compute_executed && exact_temporal_samples,
+              "eager draw snapshots its selected resource once at ordered execution before mutation");
+        std::filesystem::remove(capture_path, filesystem_error);
     }
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -43,6 +43,38 @@ guest pitch while retaining their historical tight byte span.
 The `vs=` and `fs=` summaries identify whether each recompiled shader is retained as `owned` or
 `shared`; their size and hash always describe the accessor-selected words the renderer consumes.
 
+## Draw-time resource provenance
+
+Set `PROSPER_GPU_CAPTURE_RESOURCE_PROVENANCE=DRAW:vs|ps:BINDING` while taking a capsule with
+`PROSPER_GPU_CAPTURE` or F9 to retain one resource at two independently observed times. `DRAW` is
+the semantic draw ID printed as `draw[ID]` by `--inspect-only`, `vs`/`ps` selects the stage, and
+`BINDING` is the binding printed in that stage's resource table. Numbers use the same strict base-0
+syntax as the other diagnostic selectors, so decimal and `0x` hexadecimal are accepted but signs,
+trailing text, and values outside their field widths are rejected.
+
+The selector must match exactly one realized resource. A zero match, duplicate draw identity, or
+duplicate binding fails the capture visibly instead of producing ambiguous evidence. With the
+variable unset, capture performs no extra resource-table walk, allocation, or byte copy.
+
+The first sample is taken at the selected draw's ordered realization point: earlier in-submit
+producers have completed, while the renderer and later work have not run. The ordinary resource
+blob is read independently after submit execution. Capture v45 records the descriptor identity,
+requested span, each sample's readable byte count, payload, and content hash. This distinguishes
+guest-authored zero bytes from an unreadable zero-filled suffix and answers whether a buffer was
+already zero when the draw consumed it or changed later in the submit.
+
+`--inspect-only` prints one `resource-provenance` line with `realization-read`, `post-read`, both
+hashes, and one of these verdicts:
+
+- `short-read`: at least one sample did not read the complete requested span; do not compare its
+  zero-filled suffix as guest data.
+- `full-equal`: both complete samples have the same content hash.
+- `full-changed`: both complete samples differ between draw realization and post-submit capture.
+
+For example, `PROSPER_GPU_CAPTURE_RESOURCE_PROVENANCE=77:ps:32` audits fragment binding 32 of
+semantic draw 77. The selector is observational: it never substitutes resource bytes or changes
+what replay binds.
+
 Build from `prosper/`, using the worktree-local Linux build:
 
 ```bash

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -521,6 +521,35 @@ void inspect_table(const char* stage, const prosper::gpu::ShaderResourceTable* t
 }
 
 void inspect_frame(const prosper::gpu::GpuReplayFrame& replay, uint32_t format_version) {
+    for (const auto& provenance : replay.resource_provenance) {
+        const auto& realization = replay.blobs[provenance.realization_blob_index];
+        const auto& post = replay.blobs[provenance.post_blob_index];
+        const uint64_t realization_read = std::min<uint64_t>(
+            provenance.requested_bytes, realization.bytes_read);
+        const uint64_t post_read = post.bytes_read > provenance.post_blob_offset
+            ? std::min<uint64_t>(provenance.requested_bytes,
+                                 post.bytes_read - provenance.post_blob_offset)
+            : 0;
+        const char* verdict = realization_read != provenance.requested_bytes ||
+                              post_read != provenance.requested_bytes
+            ? "short-read"
+            : provenance.realization_content_hash == provenance.post_content_hash
+                ? "full-equal" : "full-changed";
+        std::printf(
+            "resource-provenance draw=%llu stage=%s binding=%u class=%s addr=%016llx "
+            "bytes=%llu realization-read=%llu hash=%016llx post-read=%llu hash=%016llx "
+            "srt=%08x sgpr=%08x verdict=%s\n",
+            static_cast<unsigned long long>(provenance.draw_index),
+            provenance.stage == prosper::gpu::ShaderProgramStage::Vertex ? "vs" : "ps",
+            provenance.binding, class_name(provenance.resource_class),
+            static_cast<unsigned long long>(provenance.guest_addr),
+            static_cast<unsigned long long>(provenance.requested_bytes),
+            static_cast<unsigned long long>(realization_read),
+            static_cast<unsigned long long>(provenance.realization_content_hash),
+            static_cast<unsigned long long>(post_read),
+            static_cast<unsigned long long>(provenance.post_content_hash),
+            provenance.srt_offset, provenance.sgpr_base, verdict);
+    }
     for (const auto& seed : replay.rtt_seeds) {
         const uint64_t hash = prosper::gpu::gpu_capture_hash(seed.rgba);
         const char* format = seed.format == prosper::gpu::GpuCaptureColorFormat::Rgba16Float


### PR DESCRIPTION
## Summary

- add a strict opt-in `DRAW:vs|ps:BINDING` selector for one realized graphics resource
- retain an independent sample at the ordered draw point and the normal post-submit sample
- serialize the temporal audit in capture v45 and report `short-read`, `full-equal`, or `full-changed` through `gpu_replay --inspect-only`
- keep the default path at zero extra resource walks, allocations, or byte copies
- document the workflow for future title investigations

## Why

Asterix's captured final composite writes every pixel from a zero constant buffer, but an ordinary capsule could not establish whether that buffer was already zero when the draw executed or was paired with later bytes during deferred materialization. This generic instrument makes that temporal distinction auditable without substituting data or adding a title-specific path.

The ordered hook matters for submits that prepare direct draws eagerly but execute through the ordered path because compute is present. The implementation gives that path exactly one temporal owner so an earlier producer is observed before the draw and the selector cannot double-match.

Closes #1849.

## Validation

Built inside the `ps5ys` distrobox with worktree-local temporary/build directories:

- `cmake --build build-linux --target test_gpu_capture test_gpu_execute gpu_replay -j2`
- full `test_gpu_capture`: PASS
- full `test_gpu_execute` on explicit llvmpipe CPU Vulkan: PASS
- exact mutation removing only the ordered snapshot hook: suite failed and the named eager-draw/ordered-compute provenance check turned red
- `git diff --check 908c9eef...9d97bcb2`: PASS

Snapshot tests were not run; this is an opt-in diagnostic/capture-format change, and ordinary PR snapshots are optional under project policy.