### PR TITLE
diag(compute): model deferred authority boundaries

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -95,6 +95,12 @@ add_executable(test_compute_timing_selector tests/test_compute_timing_selector.c
 target_include_directories(test_compute_timing_selector PRIVATE frontends/shared)
 add_test(NAME compute_timing_selector_policy COMMAND test_compute_timing_selector)
 
+# Pure fail-closed policy for a behavior-neutral census of hypothetical deferred compute results.
+# It has no Vulkan dependency and does not change the live backend's synchronous writeback.
+add_executable(test_compute_authority_census tests/test_compute_authority_census.cpp)
+target_include_directories(test_compute_authority_census PRIVATE frontends/shared)
+add_test(NAME compute_authority_census_policy COMMAND test_compute_authority_census)
+
 find_package(Python3 COMPONENTS Interpreter QUIET)
 if(Python3_Interpreter_FOUND)
   add_test(NAME re_xref_decoder

--- a/prosper/frontends/shared/compute_authority_census.hpp
+++ b/prosper/frontends/shared/compute_authority_census.hpp
@@ -23,13 +23,18 @@ struct ShadowComputeAuthorityRange {
         return {};
     }
 
+    constexpr bool valid() const {
+        return known && bytes != 0 &&
+               address <= std::numeric_limits<uint64_t>::max() - (bytes - 1);
+    }
+
     constexpr bool operator==(const ShadowComputeAuthorityRange&) const = default;
 };
 
 constexpr bool shadow_compute_authority_ranges_overlap(
     const ShadowComputeAuthorityRange& first,
     const ShadowComputeAuthorityRange& second) {
-    if (!first.known || !second.known) return false;
+    if (!first.valid() || !second.valid()) return false;
     return first.address <= second.address
         ? second.address - first.address < first.bytes
         : first.address - second.address < second.bytes;
@@ -72,8 +77,9 @@ constexpr ShadowComputeAuthorityAccess shadow_compute_authority_access(
         case ShadowComputeAuthorityConsumerKind::Unknown:
         case ShadowComputeAuthorityConsumerKind::SubmitEnd:
             return ShadowComputeAuthorityAccess::AlwaysMaterialize;
+        default:
+            return ShadowComputeAuthorityAccess::AlwaysMaterialize;
     }
-    return ShadowComputeAuthorityAccess::AlwaysMaterialize;
 }
 
 enum class ShadowComputeAuthorityAction : uint8_t {
@@ -92,8 +98,12 @@ enum class ShadowComputeAuthorityReason : uint8_t {
     ResultReplaced,
     ProvenGpuConsumer,
     UnrelatedConsumer,
-    OverlappingGuestConsumer,
+    OverlappingGuestImageConsumer,
     OverlappingRawBufferConsumer,
+    OverlappingDrawConsumer,
+    OverlappingDmaConsumer,
+    OverlappingOrderedMemoryEffectConsumer,
+    CaptureConsumer,
     UnknownConsumerRange,
     UnknownConsumer,
     SubmitEnd,
@@ -116,7 +126,7 @@ struct ShadowComputeAuthorityState {
     bool guest_mirror_current = true;
 
     constexpr bool pending() const {
-        return range.known && vulkan_result_valid && !guest_mirror_current;
+        return range.valid() && vulkan_result_valid && !guest_mirror_current;
     }
 };
 
@@ -130,9 +140,17 @@ struct ShadowComputeAuthorityCounters {
     uint64_t unrelated_keeps = 0;
     uint64_t materializations = 0;
     uint64_t overlap_materializations = 0;
+    uint64_t proven_gpu_image_materializations = 0;
+    uint64_t guest_image_materializations = 0;
     uint64_t raw_buffer_materializations = 0;
-    uint64_t unknown_materializations = 0;
+    uint64_t draw_materializations = 0;
+    uint64_t dma_materializations = 0;
+    uint64_t ordered_memory_effect_materializations = 0;
+    uint64_t capture_materializations = 0;
+    uint64_t unknown_consumer_materializations = 0;
     uint64_t submit_end_materializations = 0;
+    uint64_t unknown_range_materializations = 0;
+    uint64_t invalid_result_materializations = 0;
     uint64_t range_change_materializations = 0;
 };
 
@@ -150,7 +168,7 @@ public:
         counters_.result_candidates =
             shadow_compute_authority_increment(counters_.result_candidates);
         const bool pending_before = state_.pending();
-        if (!range.known) {
+        if (!range.valid()) {
             counters_.rejected_results =
                 shadow_compute_authority_increment(counters_.rejected_results);
             if (pending_before) {
@@ -198,14 +216,20 @@ public:
                     ShadowComputeAuthorityReason::NoPendingResult, false, false};
 
         if (kind == ShadowComputeAuthorityConsumerKind::SubmitEnd)
-            return materialize(ShadowComputeAuthorityReason::SubmitEnd);
+            return materialize_consumer(kind, ShadowComputeAuthorityReason::SubmitEnd);
 
         const ShadowComputeAuthorityAccess access =
             shadow_compute_authority_access(kind);
-        if (access == ShadowComputeAuthorityAccess::AlwaysMaterialize)
-            return materialize(ShadowComputeAuthorityReason::UnknownConsumer);
-        if (!range.known)
-            return materialize(ShadowComputeAuthorityReason::UnknownConsumerRange);
+        if (access == ShadowComputeAuthorityAccess::AlwaysMaterialize) {
+            const ShadowComputeAuthorityReason reason =
+                kind == ShadowComputeAuthorityConsumerKind::Capture
+                    ? ShadowComputeAuthorityReason::CaptureConsumer
+                    : ShadowComputeAuthorityReason::UnknownConsumer;
+            return materialize_consumer(kind, reason);
+        }
+        if (!range.valid())
+            return materialize_consumer(
+                kind, ShadowComputeAuthorityReason::UnknownConsumerRange);
 
         if (!shadow_compute_authority_ranges_overlap(state_.range, range)) {
             counters_.unrelated_keeps =
@@ -221,11 +245,32 @@ public:
                     ShadowComputeAuthorityReason::ProvenGpuConsumer, true, true};
         }
 
-        const ShadowComputeAuthorityReason reason =
-            kind == ShadowComputeAuthorityConsumerKind::RawBuffer
-                ? ShadowComputeAuthorityReason::OverlappingRawBufferConsumer
-                : ShadowComputeAuthorityReason::OverlappingGuestConsumer;
-        return materialize(reason);
+        ShadowComputeAuthorityReason reason =
+            ShadowComputeAuthorityReason::UnknownConsumer;
+        switch (kind) {
+            case ShadowComputeAuthorityConsumerKind::GuestImage:
+                reason = ShadowComputeAuthorityReason::OverlappingGuestImageConsumer;
+                break;
+            case ShadowComputeAuthorityConsumerKind::RawBuffer:
+                reason = ShadowComputeAuthorityReason::OverlappingRawBufferConsumer;
+                break;
+            case ShadowComputeAuthorityConsumerKind::Draw:
+                reason = ShadowComputeAuthorityReason::OverlappingDrawConsumer;
+                break;
+            case ShadowComputeAuthorityConsumerKind::Dma:
+                reason = ShadowComputeAuthorityReason::OverlappingDmaConsumer;
+                break;
+            case ShadowComputeAuthorityConsumerKind::OrderedMemoryEffect:
+                reason =
+                    ShadowComputeAuthorityReason::OverlappingOrderedMemoryEffectConsumer;
+                break;
+            case ShadowComputeAuthorityConsumerKind::ProvenGpuImage:
+            case ShadowComputeAuthorityConsumerKind::Capture:
+            case ShadowComputeAuthorityConsumerKind::Unknown:
+            case ShadowComputeAuthorityConsumerKind::SubmitEnd:
+                break;
+        }
+        return materialize_consumer(kind, reason);
     }
 
 private:
@@ -233,25 +278,22 @@ private:
         counters_.materializations =
             shadow_compute_authority_increment(counters_.materializations);
         switch (reason) {
-            case ShadowComputeAuthorityReason::OverlappingGuestConsumer:
-                counters_.overlap_materializations = shadow_compute_authority_increment(
-                    counters_.overlap_materializations);
-                break;
+            case ShadowComputeAuthorityReason::OverlappingGuestImageConsumer:
             case ShadowComputeAuthorityReason::OverlappingRawBufferConsumer:
+            case ShadowComputeAuthorityReason::OverlappingDrawConsumer:
+            case ShadowComputeAuthorityReason::OverlappingDmaConsumer:
+            case ShadowComputeAuthorityReason::OverlappingOrderedMemoryEffectConsumer:
                 counters_.overlap_materializations = shadow_compute_authority_increment(
                     counters_.overlap_materializations);
-                counters_.raw_buffer_materializations = shadow_compute_authority_increment(
-                    counters_.raw_buffer_materializations);
                 break;
             case ShadowComputeAuthorityReason::UnknownConsumerRange:
-            case ShadowComputeAuthorityReason::UnknownConsumer:
-            case ShadowComputeAuthorityReason::InvalidResultRange:
-                counters_.unknown_materializations = shadow_compute_authority_increment(
-                    counters_.unknown_materializations);
+                counters_.unknown_range_materializations = shadow_compute_authority_increment(
+                    counters_.unknown_range_materializations);
                 break;
-            case ShadowComputeAuthorityReason::SubmitEnd:
-                counters_.submit_end_materializations = shadow_compute_authority_increment(
-                    counters_.submit_end_materializations);
+            case ShadowComputeAuthorityReason::InvalidResultRange:
+                counters_.invalid_result_materializations =
+                    shadow_compute_authority_increment(
+                        counters_.invalid_result_materializations);
                 break;
             case ShadowComputeAuthorityReason::ResultRangeChanged:
                 counters_.range_change_materializations = shadow_compute_authority_increment(
@@ -262,14 +304,64 @@ private:
             case ShadowComputeAuthorityReason::ResultReplaced:
             case ShadowComputeAuthorityReason::ProvenGpuConsumer:
             case ShadowComputeAuthorityReason::UnrelatedConsumer:
+            case ShadowComputeAuthorityReason::CaptureConsumer:
+            case ShadowComputeAuthorityReason::UnknownConsumer:
+            case ShadowComputeAuthorityReason::SubmitEnd:
                 break;
         }
         state_.guest_mirror_current = true;
     }
 
-    constexpr ShadowComputeAuthorityTransition materialize(
+    constexpr ShadowComputeAuthorityTransition materialize_consumer(
+        ShadowComputeAuthorityConsumerKind kind,
         ShadowComputeAuthorityReason reason) {
         record_materialization(reason);
+        switch (kind) {
+            case ShadowComputeAuthorityConsumerKind::GuestImage:
+                counters_.guest_image_materializations = shadow_compute_authority_increment(
+                    counters_.guest_image_materializations);
+                break;
+            case ShadowComputeAuthorityConsumerKind::RawBuffer:
+                counters_.raw_buffer_materializations = shadow_compute_authority_increment(
+                    counters_.raw_buffer_materializations);
+                break;
+            case ShadowComputeAuthorityConsumerKind::Draw:
+                counters_.draw_materializations = shadow_compute_authority_increment(
+                    counters_.draw_materializations);
+                break;
+            case ShadowComputeAuthorityConsumerKind::Dma:
+                counters_.dma_materializations = shadow_compute_authority_increment(
+                    counters_.dma_materializations);
+                break;
+            case ShadowComputeAuthorityConsumerKind::OrderedMemoryEffect:
+                counters_.ordered_memory_effect_materializations =
+                    shadow_compute_authority_increment(
+                        counters_.ordered_memory_effect_materializations);
+                break;
+            case ShadowComputeAuthorityConsumerKind::Capture:
+                counters_.capture_materializations = shadow_compute_authority_increment(
+                    counters_.capture_materializations);
+                break;
+            case ShadowComputeAuthorityConsumerKind::Unknown:
+                counters_.unknown_consumer_materializations =
+                    shadow_compute_authority_increment(
+                        counters_.unknown_consumer_materializations);
+                break;
+            case ShadowComputeAuthorityConsumerKind::SubmitEnd:
+                counters_.submit_end_materializations = shadow_compute_authority_increment(
+                    counters_.submit_end_materializations);
+                break;
+            case ShadowComputeAuthorityConsumerKind::ProvenGpuImage:
+                counters_.proven_gpu_image_materializations =
+                    shadow_compute_authority_increment(
+                        counters_.proven_gpu_image_materializations);
+                break;
+            default:
+                counters_.unknown_consumer_materializations =
+                    shadow_compute_authority_increment(
+                        counters_.unknown_consumer_materializations);
+                break;
+        }
         return {ShadowComputeAuthorityAction::MaterializeGuestMirror,
                 reason, true, false};
     }

--- a/prosper/frontends/shared/compute_authority_census.hpp
+++ b/prosper/frontends/shared/compute_authority_census.hpp
@@ -1,0 +1,281 @@
+#pragma once
+
+#include <cstdint>
+#include <limits>
+
+namespace prosper::frontend {
+
+// Behavior-neutral model for a future deferred compute writeback. The live backend still publishes
+// every storage result synchronously; this state machine answers only whether a hypothetical pending
+// Vulkan result has reached an observer that would require the architectural guest mirror.
+struct ShadowComputeAuthorityRange {
+    uint64_t address = 0;
+    uint64_t bytes = 0;
+    bool known = false;
+
+    static constexpr ShadowComputeAuthorityRange from(uint64_t address, uint64_t bytes) {
+        const bool representable = bytes != 0 &&
+            address <= std::numeric_limits<uint64_t>::max() - (bytes - 1);
+        return {address, bytes, representable};
+    }
+
+    static constexpr ShadowComputeAuthorityRange unknown() {
+        return {};
+    }
+
+    constexpr bool operator==(const ShadowComputeAuthorityRange&) const = default;
+};
+
+constexpr bool shadow_compute_authority_ranges_overlap(
+    const ShadowComputeAuthorityRange& first,
+    const ShadowComputeAuthorityRange& second) {
+    if (!first.known || !second.known) return false;
+    return first.address <= second.address
+        ? second.address - first.address < first.bytes
+        : first.address - second.address < second.bytes;
+}
+
+enum class ShadowComputeAuthorityConsumerKind : uint8_t {
+    ProvenGpuImage,
+    GuestImage,
+    RawBuffer,
+    Draw,
+    Dma,
+    OrderedMemoryEffect,
+    Capture,
+    Unknown,
+    SubmitEnd,
+};
+
+enum class ShadowComputeAuthorityAccess : uint8_t {
+    ProvenGpu,
+    GuestMirror,
+    AlwaysMaterialize,
+};
+
+constexpr ShadowComputeAuthorityAccess shadow_compute_authority_access(
+    ShadowComputeAuthorityConsumerKind kind) {
+    switch (kind) {
+        case ShadowComputeAuthorityConsumerKind::ProvenGpuImage:
+            return ShadowComputeAuthorityAccess::ProvenGpu;
+        case ShadowComputeAuthorityConsumerKind::GuestImage:
+            return ShadowComputeAuthorityAccess::GuestMirror;
+        case ShadowComputeAuthorityConsumerKind::RawBuffer:
+            return ShadowComputeAuthorityAccess::GuestMirror;
+        case ShadowComputeAuthorityConsumerKind::Draw:
+            return ShadowComputeAuthorityAccess::GuestMirror;
+        case ShadowComputeAuthorityConsumerKind::Dma:
+            return ShadowComputeAuthorityAccess::GuestMirror;
+        case ShadowComputeAuthorityConsumerKind::OrderedMemoryEffect:
+            return ShadowComputeAuthorityAccess::GuestMirror;
+        case ShadowComputeAuthorityConsumerKind::Capture:
+        case ShadowComputeAuthorityConsumerKind::Unknown:
+        case ShadowComputeAuthorityConsumerKind::SubmitEnd:
+            return ShadowComputeAuthorityAccess::AlwaysMaterialize;
+    }
+    return ShadowComputeAuthorityAccess::AlwaysMaterialize;
+}
+
+enum class ShadowComputeAuthorityAction : uint8_t {
+    NoPendingResult,
+    TrackPendingResult,
+    ReplacePendingResult,
+    KeepGpuAuthority,
+    MaterializeGuestMirror,
+    MaterializeAndTrackResult,
+    RejectResult,
+};
+
+enum class ShadowComputeAuthorityReason : uint8_t {
+    NoPendingResult,
+    ResultAdmitted,
+    ResultReplaced,
+    ProvenGpuConsumer,
+    UnrelatedConsumer,
+    OverlappingGuestConsumer,
+    OverlappingRawBufferConsumer,
+    UnknownConsumerRange,
+    UnknownConsumer,
+    SubmitEnd,
+    ResultRangeChanged,
+    InvalidResultRange,
+};
+
+struct ShadowComputeAuthorityTransition {
+    ShadowComputeAuthorityAction action =
+        ShadowComputeAuthorityAction::NoPendingResult;
+    ShadowComputeAuthorityReason reason =
+        ShadowComputeAuthorityReason::NoPendingResult;
+    bool pending_before = false;
+    bool pending_after = false;
+};
+
+struct ShadowComputeAuthorityState {
+    ShadowComputeAuthorityRange range;
+    bool vulkan_result_valid = false;
+    bool guest_mirror_current = true;
+
+    constexpr bool pending() const {
+        return range.known && vulkan_result_valid && !guest_mirror_current;
+    }
+};
+
+struct ShadowComputeAuthorityCounters {
+    uint64_t result_candidates = 0;
+    uint64_t admitted_results = 0;
+    uint64_t replaced_results = 0;
+    uint64_t rejected_results = 0;
+    uint64_t consumer_observations = 0;
+    uint64_t proven_gpu_keeps = 0;
+    uint64_t unrelated_keeps = 0;
+    uint64_t materializations = 0;
+    uint64_t overlap_materializations = 0;
+    uint64_t raw_buffer_materializations = 0;
+    uint64_t unknown_materializations = 0;
+    uint64_t submit_end_materializations = 0;
+    uint64_t range_change_materializations = 0;
+};
+
+constexpr uint64_t shadow_compute_authority_increment(uint64_t value) {
+    return value == std::numeric_limits<uint64_t>::max() ? value : value + 1;
+}
+
+class ShadowComputeAuthorityCensus {
+public:
+    constexpr const ShadowComputeAuthorityState& state() const { return state_; }
+    constexpr const ShadowComputeAuthorityCounters& counters() const { return counters_; }
+
+    constexpr ShadowComputeAuthorityTransition note_retained_result(
+        const ShadowComputeAuthorityRange& range) {
+        counters_.result_candidates =
+            shadow_compute_authority_increment(counters_.result_candidates);
+        const bool pending_before = state_.pending();
+        if (!range.known) {
+            counters_.rejected_results =
+                shadow_compute_authority_increment(counters_.rejected_results);
+            if (pending_before) {
+                record_materialization(ShadowComputeAuthorityReason::InvalidResultRange);
+                state_ = {};
+                return {ShadowComputeAuthorityAction::MaterializeGuestMirror,
+                        ShadowComputeAuthorityReason::InvalidResultRange, true, false};
+            }
+            return {ShadowComputeAuthorityAction::RejectResult,
+                    ShadowComputeAuthorityReason::InvalidResultRange, false, false};
+        }
+
+        if (!pending_before) {
+            state_ = {range, true, false};
+            counters_.admitted_results =
+                shadow_compute_authority_increment(counters_.admitted_results);
+            return {ShadowComputeAuthorityAction::TrackPendingResult,
+                    ShadowComputeAuthorityReason::ResultAdmitted, false, true};
+        }
+
+        if (state_.range == range) {
+            counters_.replaced_results =
+                shadow_compute_authority_increment(counters_.replaced_results);
+            return {ShadowComputeAuthorityAction::ReplacePendingResult,
+                    ShadowComputeAuthorityReason::ResultReplaced, true, true};
+        }
+
+        record_materialization(ShadowComputeAuthorityReason::ResultRangeChanged);
+        state_ = {range, true, false};
+        counters_.admitted_results =
+            shadow_compute_authority_increment(counters_.admitted_results);
+        return {ShadowComputeAuthorityAction::MaterializeAndTrackResult,
+                ShadowComputeAuthorityReason::ResultRangeChanged, true, true};
+    }
+
+    constexpr ShadowComputeAuthorityTransition observe(
+        ShadowComputeAuthorityConsumerKind kind,
+        const ShadowComputeAuthorityRange& range =
+            ShadowComputeAuthorityRange::unknown()) {
+        counters_.consumer_observations =
+            shadow_compute_authority_increment(counters_.consumer_observations);
+        const bool pending_before = state_.pending();
+        if (!pending_before)
+            return {ShadowComputeAuthorityAction::NoPendingResult,
+                    ShadowComputeAuthorityReason::NoPendingResult, false, false};
+
+        if (kind == ShadowComputeAuthorityConsumerKind::SubmitEnd)
+            return materialize(ShadowComputeAuthorityReason::SubmitEnd);
+
+        const ShadowComputeAuthorityAccess access =
+            shadow_compute_authority_access(kind);
+        if (access == ShadowComputeAuthorityAccess::AlwaysMaterialize)
+            return materialize(ShadowComputeAuthorityReason::UnknownConsumer);
+        if (!range.known)
+            return materialize(ShadowComputeAuthorityReason::UnknownConsumerRange);
+
+        if (!shadow_compute_authority_ranges_overlap(state_.range, range)) {
+            counters_.unrelated_keeps =
+                shadow_compute_authority_increment(counters_.unrelated_keeps);
+            return {ShadowComputeAuthorityAction::KeepGpuAuthority,
+                    ShadowComputeAuthorityReason::UnrelatedConsumer, true, true};
+        }
+
+        if (access == ShadowComputeAuthorityAccess::ProvenGpu) {
+            counters_.proven_gpu_keeps =
+                shadow_compute_authority_increment(counters_.proven_gpu_keeps);
+            return {ShadowComputeAuthorityAction::KeepGpuAuthority,
+                    ShadowComputeAuthorityReason::ProvenGpuConsumer, true, true};
+        }
+
+        const ShadowComputeAuthorityReason reason =
+            kind == ShadowComputeAuthorityConsumerKind::RawBuffer
+                ? ShadowComputeAuthorityReason::OverlappingRawBufferConsumer
+                : ShadowComputeAuthorityReason::OverlappingGuestConsumer;
+        return materialize(reason);
+    }
+
+private:
+    constexpr void record_materialization(ShadowComputeAuthorityReason reason) {
+        counters_.materializations =
+            shadow_compute_authority_increment(counters_.materializations);
+        switch (reason) {
+            case ShadowComputeAuthorityReason::OverlappingGuestConsumer:
+                counters_.overlap_materializations = shadow_compute_authority_increment(
+                    counters_.overlap_materializations);
+                break;
+            case ShadowComputeAuthorityReason::OverlappingRawBufferConsumer:
+                counters_.overlap_materializations = shadow_compute_authority_increment(
+                    counters_.overlap_materializations);
+                counters_.raw_buffer_materializations = shadow_compute_authority_increment(
+                    counters_.raw_buffer_materializations);
+                break;
+            case ShadowComputeAuthorityReason::UnknownConsumerRange:
+            case ShadowComputeAuthorityReason::UnknownConsumer:
+            case ShadowComputeAuthorityReason::InvalidResultRange:
+                counters_.unknown_materializations = shadow_compute_authority_increment(
+                    counters_.unknown_materializations);
+                break;
+            case ShadowComputeAuthorityReason::SubmitEnd:
+                counters_.submit_end_materializations = shadow_compute_authority_increment(
+                    counters_.submit_end_materializations);
+                break;
+            case ShadowComputeAuthorityReason::ResultRangeChanged:
+                counters_.range_change_materializations = shadow_compute_authority_increment(
+                    counters_.range_change_materializations);
+                break;
+            case ShadowComputeAuthorityReason::NoPendingResult:
+            case ShadowComputeAuthorityReason::ResultAdmitted:
+            case ShadowComputeAuthorityReason::ResultReplaced:
+            case ShadowComputeAuthorityReason::ProvenGpuConsumer:
+            case ShadowComputeAuthorityReason::UnrelatedConsumer:
+                break;
+        }
+        state_.guest_mirror_current = true;
+    }
+
+    constexpr ShadowComputeAuthorityTransition materialize(
+        ShadowComputeAuthorityReason reason) {
+        record_materialization(reason);
+        return {ShadowComputeAuthorityAction::MaterializeGuestMirror,
+                reason, true, false};
+    }
+
+    ShadowComputeAuthorityState state_;
+    ShadowComputeAuthorityCounters counters_;
+};
+
+} // namespace prosper::frontend

--- a/prosper/tests/test_compute_authority_census.cpp
+++ b/prosper/tests/test_compute_authority_census.cpp
@@ -1,0 +1,175 @@
+#include "compute_authority_census.hpp"
+
+#include <array>
+#include <cstdint>
+#include <cstdio>
+#include <limits>
+
+using namespace prosper::frontend;
+
+static int failures = 0;
+#define CHECK(condition, name) do { \
+    if (condition) std::printf("  PASS %s\n", name); \
+    else { std::printf("  FAIL %s\n", name); ++failures; } \
+} while (0)
+
+int main() {
+    std::printf("shadow compute authority census policy\n");
+
+    constexpr auto atlas = ShadowComputeAuthorityRange::from(0x200000, 0x10000);
+    constexpr auto atlas_tail = ShadowComputeAuthorityRange::from(0x20f000, 0x2000);
+    constexpr auto adjacent = ShadowComputeAuthorityRange::from(0x210000, 0x1000);
+    constexpr auto unrelated = ShadowComputeAuthorityRange::from(0x400000, 0x1000);
+    constexpr auto zero = ShadowComputeAuthorityRange::from(0x200000, 0);
+    constexpr auto wrapped = ShadowComputeAuthorityRange::from(
+        std::numeric_limits<uint64_t>::max() - 3, 8);
+    CHECK(atlas.known && atlas_tail.known && adjacent.known && unrelated.known &&
+              !zero.known && !wrapped.known &&
+              shadow_compute_authority_ranges_overlap(atlas, atlas_tail) &&
+              !shadow_compute_authority_ranges_overlap(atlas, adjacent) &&
+              !shadow_compute_authority_ranges_overlap(
+                  atlas, ShadowComputeAuthorityRange::unknown()),
+          "half-open authority ranges reject zero/wrap and distinguish overlap from adjacency");
+
+    ShadowComputeAuthorityCensus chain;
+    const auto admitted = chain.note_retained_result(atlas);
+    const auto first_gpu = chain.observe(
+        ShadowComputeAuthorityConsumerKind::ProvenGpuImage, atlas);
+    const auto replaced = chain.note_retained_result(atlas);
+    const auto second_gpu = chain.observe(
+        ShadowComputeAuthorityConsumerKind::ProvenGpuImage, atlas_tail);
+    CHECK(admitted.action == ShadowComputeAuthorityAction::TrackPendingResult &&
+              admitted.reason == ShadowComputeAuthorityReason::ResultAdmitted &&
+              first_gpu.action == ShadowComputeAuthorityAction::KeepGpuAuthority &&
+              first_gpu.reason == ShadowComputeAuthorityReason::ProvenGpuConsumer &&
+              replaced.action == ShadowComputeAuthorityAction::ReplacePendingResult &&
+              second_gpu.action == ShadowComputeAuthorityAction::KeepGpuAuthority &&
+              chain.state().pending() && chain.state().vulkan_result_valid &&
+              !chain.state().guest_mirror_current &&
+              chain.counters().admitted_results == 1 &&
+              chain.counters().replaced_results == 1 &&
+              chain.counters().proven_gpu_keeps == 2 &&
+              chain.counters().materializations == 0,
+          "proven GPU consumers keep a same-range chain deferred");
+
+    ShadowComputeAuthorityCensus disjoint;
+    (void)disjoint.note_retained_result(atlas);
+    const auto disjoint_read = disjoint.observe(
+        ShadowComputeAuthorityConsumerKind::RawBuffer, unrelated);
+    CHECK(disjoint_read.action == ShadowComputeAuthorityAction::KeepGpuAuthority &&
+              disjoint_read.reason == ShadowComputeAuthorityReason::UnrelatedConsumer &&
+              disjoint.state().pending() && disjoint.counters().unrelated_keeps == 1 &&
+              disjoint.counters().materializations == 0,
+          "unrelated guest reads leave pending authority intact");
+
+    ShadowComputeAuthorityCensus raw_overlap;
+    (void)raw_overlap.note_retained_result(atlas);
+    const auto raw_read = raw_overlap.observe(
+        ShadowComputeAuthorityConsumerKind::RawBuffer, atlas_tail);
+    CHECK(raw_read.action == ShadowComputeAuthorityAction::MaterializeGuestMirror &&
+              raw_read.reason ==
+                  ShadowComputeAuthorityReason::OverlappingRawBufferConsumer &&
+              raw_read.pending_before && !raw_read.pending_after &&
+              !raw_overlap.state().pending() &&
+              raw_overlap.state().vulkan_result_valid &&
+              raw_overlap.state().guest_mirror_current &&
+              raw_overlap.counters().materializations == 1 &&
+              raw_overlap.counters().overlap_materializations == 1 &&
+              raw_overlap.counters().raw_buffer_materializations == 1,
+          "overlapping raw-buffer consumer forces guest materialization");
+
+    bool all_known_guest_observers_materialize = true;
+    constexpr std::array guest_observers{
+        ShadowComputeAuthorityConsumerKind::GuestImage,
+        ShadowComputeAuthorityConsumerKind::Draw,
+        ShadowComputeAuthorityConsumerKind::Dma,
+        ShadowComputeAuthorityConsumerKind::OrderedMemoryEffect,
+    };
+    for (const auto kind : guest_observers) {
+        ShadowComputeAuthorityCensus observer;
+        (void)observer.note_retained_result(atlas);
+        const auto transition = observer.observe(kind, atlas_tail);
+        all_known_guest_observers_materialize &=
+            transition.action == ShadowComputeAuthorityAction::MaterializeGuestMirror &&
+            transition.reason == ShadowComputeAuthorityReason::OverlappingGuestConsumer &&
+            observer.counters().overlap_materializations == 1 &&
+            observer.counters().materializations == 1 && !observer.state().pending();
+    }
+    CHECK(all_known_guest_observers_materialize,
+          "known guest-image draw DMA and memory-effect overlaps fail closed");
+
+    ShadowComputeAuthorityCensus unknown_kind;
+    (void)unknown_kind.note_retained_result(atlas);
+    const auto unknown_consumer = unknown_kind.observe(
+        ShadowComputeAuthorityConsumerKind::Unknown, unrelated);
+    ShadowComputeAuthorityCensus capture;
+    (void)capture.note_retained_result(atlas);
+    const auto capture_consumer = capture.observe(
+        ShadowComputeAuthorityConsumerKind::Capture, unrelated);
+    CHECK(unknown_consumer.action ==
+                  ShadowComputeAuthorityAction::MaterializeGuestMirror &&
+              unknown_consumer.reason == ShadowComputeAuthorityReason::UnknownConsumer &&
+              capture_consumer.action ==
+                  ShadowComputeAuthorityAction::MaterializeGuestMirror &&
+              capture_consumer.reason == ShadowComputeAuthorityReason::UnknownConsumer &&
+              unknown_kind.counters().unknown_materializations == 1 &&
+              capture.counters().unknown_materializations == 1,
+          "unknown and capture consumers materialize even with a disjoint claimed range");
+
+    ShadowComputeAuthorityCensus unknown_range;
+    (void)unknown_range.note_retained_result(atlas);
+    const auto unbounded_draw = unknown_range.observe(
+        ShadowComputeAuthorityConsumerKind::Draw,
+        ShadowComputeAuthorityRange::unknown());
+    CHECK(unbounded_draw.action ==
+                  ShadowComputeAuthorityAction::MaterializeGuestMirror &&
+              unbounded_draw.reason ==
+                  ShadowComputeAuthorityReason::UnknownConsumerRange &&
+              unknown_range.counters().unknown_materializations == 1,
+          "a guest consumer without an exact range fails closed");
+
+    ShadowComputeAuthorityCensus submit;
+    (void)submit.note_retained_result(atlas);
+    const auto submit_end = submit.observe(
+        ShadowComputeAuthorityConsumerKind::SubmitEnd);
+    const auto after_submit = submit.observe(
+        ShadowComputeAuthorityConsumerKind::SubmitEnd);
+    CHECK(submit_end.action ==
+                  ShadowComputeAuthorityAction::MaterializeGuestMirror &&
+              submit_end.reason == ShadowComputeAuthorityReason::SubmitEnd &&
+              submit_end.pending_before && !submit_end.pending_after &&
+              submit.counters().submit_end_materializations == 1 &&
+              submit.counters().materializations == 1 &&
+              after_submit.action == ShadowComputeAuthorityAction::NoPendingResult,
+          "submit end materializes each pending result exactly once");
+
+    ShadowComputeAuthorityCensus changed_range;
+    (void)changed_range.note_retained_result(atlas);
+    const auto changed = changed_range.note_retained_result(unrelated);
+    CHECK(changed.action ==
+                  ShadowComputeAuthorityAction::MaterializeAndTrackResult &&
+              changed.reason == ShadowComputeAuthorityReason::ResultRangeChanged &&
+              changed.pending_before && changed.pending_after &&
+              changed_range.state().pending() &&
+              changed_range.state().range == unrelated &&
+              changed_range.counters().materializations == 1 &&
+              changed_range.counters().range_change_materializations == 1 &&
+              changed_range.counters().admitted_results == 2,
+          "a changed result range flushes old authority before tracking the new result");
+
+    ShadowComputeAuthorityCensus rejected;
+    const auto invalid = rejected.note_retained_result(
+        ShadowComputeAuthorityRange::unknown());
+    CHECK(invalid.action == ShadowComputeAuthorityAction::RejectResult &&
+              invalid.reason == ShadowComputeAuthorityReason::InvalidResultRange &&
+              !rejected.state().pending() && rejected.counters().result_candidates == 1 &&
+              rejected.counters().rejected_results == 1,
+          "an invalid result range cannot create shadow authority");
+
+    if (failures) {
+        std::printf("%d check(s) failed\n", failures);
+        return 1;
+    }
+    std::printf("all checks passed\n");
+    return 0;
+}

--- a/prosper/tests/test_compute_authority_census.cpp
+++ b/prosper/tests/test_compute_authority_census.cpp
@@ -1,6 +1,5 @@
 #include "compute_authority_census.hpp"
 
-#include <array>
 #include <cstdint>
 #include <cstdio>
 #include <limits>
@@ -13,6 +12,19 @@ static int failures = 0;
     else { std::printf("  FAIL %s\n", name); ++failures; } \
 } while (0)
 
+static uint64_t attributed_materializations(
+    const ShadowComputeAuthorityCounters& counters) {
+    return counters.proven_gpu_image_materializations +
+           counters.guest_image_materializations +
+           counters.raw_buffer_materializations +
+           counters.draw_materializations +
+           counters.dma_materializations +
+           counters.ordered_memory_effect_materializations +
+           counters.capture_materializations +
+           counters.unknown_consumer_materializations +
+           counters.submit_end_materializations;
+}
+
 int main() {
     std::printf("shadow compute authority census policy\n");
 
@@ -23,13 +35,27 @@ int main() {
     constexpr auto zero = ShadowComputeAuthorityRange::from(0x200000, 0);
     constexpr auto wrapped = ShadowComputeAuthorityRange::from(
         std::numeric_limits<uint64_t>::max() - 3, 8);
-    CHECK(atlas.known && atlas_tail.known && adjacent.known && unrelated.known &&
-              !zero.known && !wrapped.known &&
+    constexpr ShadowComputeAuthorityRange forged_wrapped{
+        std::numeric_limits<uint64_t>::max() - 3, 8, true};
+    CHECK(atlas.valid() && atlas_tail.valid() && adjacent.valid() &&
+              unrelated.valid() && !zero.valid() && !wrapped.valid() &&
               shadow_compute_authority_ranges_overlap(atlas, atlas_tail) &&
               !shadow_compute_authority_ranges_overlap(atlas, adjacent) &&
               !shadow_compute_authority_ranges_overlap(
                   atlas, ShadowComputeAuthorityRange::unknown()),
           "half-open authority ranges reject zero/wrap and distinguish overlap from adjacency");
+    CHECK(forged_wrapped.known && !forged_wrapped.valid() &&
+              !shadow_compute_authority_ranges_overlap(atlas, forged_wrapped),
+          "a caller-forged known overflowing range is still rejected");
+
+    CHECK(shadow_compute_authority_increment(0) == 1 &&
+              shadow_compute_authority_increment(
+                  std::numeric_limits<uint64_t>::max() - 1) ==
+                  std::numeric_limits<uint64_t>::max() &&
+              shadow_compute_authority_increment(
+                  std::numeric_limits<uint64_t>::max()) ==
+                  std::numeric_limits<uint64_t>::max(),
+          "authority counters saturate at UINT64_MAX instead of wrapping");
 
     ShadowComputeAuthorityCensus chain;
     const auto admitted = chain.note_retained_result(atlas);
@@ -66,6 +92,8 @@ int main() {
     (void)raw_overlap.note_retained_result(atlas);
     const auto raw_read = raw_overlap.observe(
         ShadowComputeAuthorityConsumerKind::RawBuffer, atlas_tail);
+    const auto after_raw = raw_overlap.observe(
+        ShadowComputeAuthorityConsumerKind::Draw, atlas_tail);
     CHECK(raw_read.action == ShadowComputeAuthorityAction::MaterializeGuestMirror &&
               raw_read.reason ==
                   ShadowComputeAuthorityReason::OverlappingRawBufferConsumer &&
@@ -75,28 +103,63 @@ int main() {
               raw_overlap.state().guest_mirror_current &&
               raw_overlap.counters().materializations == 1 &&
               raw_overlap.counters().overlap_materializations == 1 &&
-              raw_overlap.counters().raw_buffer_materializations == 1,
+              raw_overlap.counters().raw_buffer_materializations == 1 &&
+              raw_overlap.counters().draw_materializations == 0 &&
+              attributed_materializations(raw_overlap.counters()) == 1 &&
+              after_raw.action == ShadowComputeAuthorityAction::NoPendingResult,
           "overlapping raw-buffer consumer forces guest materialization");
 
-    bool all_known_guest_observers_materialize = true;
-    constexpr std::array guest_observers{
-        ShadowComputeAuthorityConsumerKind::GuestImage,
-        ShadowComputeAuthorityConsumerKind::Draw,
-        ShadowComputeAuthorityConsumerKind::Dma,
-        ShadowComputeAuthorityConsumerKind::OrderedMemoryEffect,
-    };
-    for (const auto kind : guest_observers) {
-        ShadowComputeAuthorityCensus observer;
-        (void)observer.note_retained_result(atlas);
-        const auto transition = observer.observe(kind, atlas_tail);
-        all_known_guest_observers_materialize &=
-            transition.action == ShadowComputeAuthorityAction::MaterializeGuestMirror &&
-            transition.reason == ShadowComputeAuthorityReason::OverlappingGuestConsumer &&
-            observer.counters().overlap_materializations == 1 &&
-            observer.counters().materializations == 1 && !observer.state().pending();
-    }
-    CHECK(all_known_guest_observers_materialize,
-          "known guest-image draw DMA and memory-effect overlaps fail closed");
+    ShadowComputeAuthorityCensus guest_image;
+    (void)guest_image.note_retained_result(atlas);
+    const auto guest_image_read = guest_image.observe(
+        ShadowComputeAuthorityConsumerKind::GuestImage, atlas_tail);
+    CHECK(guest_image_read.action ==
+                  ShadowComputeAuthorityAction::MaterializeGuestMirror &&
+              guest_image_read.reason ==
+                  ShadowComputeAuthorityReason::OverlappingGuestImageConsumer &&
+              guest_image.counters().guest_image_materializations == 1 &&
+              guest_image.counters().overlap_materializations == 1 &&
+              guest_image.counters().materializations == 1 &&
+              attributed_materializations(guest_image.counters()) == 1,
+          "overlapping guest-image consumer is attributed exactly");
+
+    ShadowComputeAuthorityCensus draw;
+    (void)draw.note_retained_result(atlas);
+    const auto draw_read = draw.observe(
+        ShadowComputeAuthorityConsumerKind::Draw, atlas_tail);
+    CHECK(draw_read.action == ShadowComputeAuthorityAction::MaterializeGuestMirror &&
+              draw_read.reason == ShadowComputeAuthorityReason::OverlappingDrawConsumer &&
+              draw.counters().draw_materializations == 1 &&
+              draw.counters().overlap_materializations == 1 &&
+              draw.counters().materializations == 1 &&
+              attributed_materializations(draw.counters()) == 1,
+          "overlapping draw consumer is attributed exactly");
+
+    ShadowComputeAuthorityCensus dma;
+    (void)dma.note_retained_result(atlas);
+    const auto dma_read = dma.observe(
+        ShadowComputeAuthorityConsumerKind::Dma, atlas_tail);
+    CHECK(dma_read.action == ShadowComputeAuthorityAction::MaterializeGuestMirror &&
+              dma_read.reason == ShadowComputeAuthorityReason::OverlappingDmaConsumer &&
+              dma.counters().dma_materializations == 1 &&
+              dma.counters().overlap_materializations == 1 &&
+              dma.counters().materializations == 1 &&
+              attributed_materializations(dma.counters()) == 1,
+          "overlapping DMA consumer is attributed exactly");
+
+    ShadowComputeAuthorityCensus memory_effect;
+    (void)memory_effect.note_retained_result(atlas);
+    const auto memory_effect_write = memory_effect.observe(
+        ShadowComputeAuthorityConsumerKind::OrderedMemoryEffect, atlas_tail);
+    CHECK(memory_effect_write.action ==
+                  ShadowComputeAuthorityAction::MaterializeGuestMirror &&
+              memory_effect_write.reason ==
+                  ShadowComputeAuthorityReason::OverlappingOrderedMemoryEffectConsumer &&
+              memory_effect.counters().ordered_memory_effect_materializations == 1 &&
+              memory_effect.counters().overlap_materializations == 1 &&
+              memory_effect.counters().materializations == 1 &&
+              attributed_materializations(memory_effect.counters()) == 1,
+          "overlapping ordered memory effect is attributed exactly");
 
     ShadowComputeAuthorityCensus unknown_kind;
     (void)unknown_kind.note_retained_result(atlas);
@@ -106,15 +169,20 @@ int main() {
     (void)capture.note_retained_result(atlas);
     const auto capture_consumer = capture.observe(
         ShadowComputeAuthorityConsumerKind::Capture, unrelated);
+    CHECK(capture_consumer.action ==
+                  ShadowComputeAuthorityAction::MaterializeGuestMirror &&
+              capture_consumer.reason == ShadowComputeAuthorityReason::CaptureConsumer &&
+              capture.counters().capture_materializations == 1 &&
+              capture.counters().materializations == 1 &&
+              attributed_materializations(capture.counters()) == 1,
+          "capture consumer is attributed exactly even with a claimed disjoint range");
     CHECK(unknown_consumer.action ==
                   ShadowComputeAuthorityAction::MaterializeGuestMirror &&
               unknown_consumer.reason == ShadowComputeAuthorityReason::UnknownConsumer &&
-              capture_consumer.action ==
-                  ShadowComputeAuthorityAction::MaterializeGuestMirror &&
-              capture_consumer.reason == ShadowComputeAuthorityReason::UnknownConsumer &&
-              unknown_kind.counters().unknown_materializations == 1 &&
-              capture.counters().unknown_materializations == 1,
-          "unknown and capture consumers materialize even with a disjoint claimed range");
+              unknown_kind.counters().unknown_consumer_materializations == 1 &&
+              unknown_kind.counters().materializations == 1 &&
+              attributed_materializations(unknown_kind.counters()) == 1,
+          "unknown consumer is attributed exactly even with a claimed disjoint range");
 
     ShadowComputeAuthorityCensus unknown_range;
     (void)unknown_range.note_retained_result(atlas);
@@ -125,8 +193,34 @@ int main() {
                   ShadowComputeAuthorityAction::MaterializeGuestMirror &&
               unbounded_draw.reason ==
                   ShadowComputeAuthorityReason::UnknownConsumerRange &&
-              unknown_range.counters().unknown_materializations == 1,
-          "a guest consumer without an exact range fails closed");
+              unknown_range.counters().draw_materializations == 1 &&
+              unknown_range.counters().unknown_range_materializations == 1,
+          "an unbounded draw remains attributed while failing closed on its range");
+
+    ShadowComputeAuthorityCensus unbounded_gpu;
+    (void)unbounded_gpu.note_retained_result(atlas);
+    const auto unknown_gpu_range = unbounded_gpu.observe(
+        ShadowComputeAuthorityConsumerKind::ProvenGpuImage,
+        ShadowComputeAuthorityRange::unknown());
+    CHECK(unknown_gpu_range.action ==
+                  ShadowComputeAuthorityAction::MaterializeGuestMirror &&
+              unknown_gpu_range.reason ==
+                  ShadowComputeAuthorityReason::UnknownConsumerRange &&
+              unbounded_gpu.counters().proven_gpu_image_materializations == 1 &&
+              unbounded_gpu.counters().unknown_range_materializations == 1 &&
+              attributed_materializations(unbounded_gpu.counters()) == 1,
+          "an unbounded proven-GPU consumer retains exact kind attribution");
+
+    ShadowComputeAuthorityCensus invalid_kind;
+    (void)invalid_kind.note_retained_result(atlas);
+    const auto invalid_consumer = invalid_kind.observe(
+        static_cast<ShadowComputeAuthorityConsumerKind>(0xff), unrelated);
+    CHECK(invalid_consumer.action ==
+                  ShadowComputeAuthorityAction::MaterializeGuestMirror &&
+              invalid_consumer.reason == ShadowComputeAuthorityReason::UnknownConsumer &&
+              invalid_kind.counters().unknown_consumer_materializations == 1 &&
+              attributed_materializations(invalid_kind.counters()) == 1,
+          "an invalid consumer enum is attributed as unknown and fails closed");
 
     ShadowComputeAuthorityCensus submit;
     (void)submit.note_retained_result(atlas);
@@ -140,6 +234,7 @@ int main() {
               submit_end.pending_before && !submit_end.pending_after &&
               submit.counters().submit_end_materializations == 1 &&
               submit.counters().materializations == 1 &&
+              attributed_materializations(submit.counters()) == 1 &&
               after_submit.action == ShadowComputeAuthorityAction::NoPendingResult,
           "submit end materializes each pending result exactly once");
 
@@ -165,6 +260,20 @@ int main() {
               !rejected.state().pending() && rejected.counters().result_candidates == 1 &&
               rejected.counters().rejected_results == 1,
           "an invalid result range cannot create shadow authority");
+
+    ShadowComputeAuthorityCensus rejected_pending;
+    (void)rejected_pending.note_retained_result(atlas);
+    const auto invalid_pending = rejected_pending.note_retained_result(forged_wrapped);
+    CHECK(invalid_pending.action ==
+                  ShadowComputeAuthorityAction::MaterializeGuestMirror &&
+              invalid_pending.reason == ShadowComputeAuthorityReason::InvalidResultRange &&
+              invalid_pending.pending_before && !invalid_pending.pending_after &&
+              !rejected_pending.state().pending() &&
+              rejected_pending.counters().result_candidates == 2 &&
+              rejected_pending.counters().rejected_results == 1 &&
+              rejected_pending.counters().invalid_result_materializations == 1 &&
+              rejected_pending.counters().materializations == 1,
+          "a forged invalid result flushes an existing pending authority");
 
     if (failures) {
         std::printf("%d check(s) failed\n", failures);

--- a/prosper/tools/perf/mutate_compute_authority_census.sh
+++ b/prosper/tools/perf/mutate_compute_authority_census.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Per-check mutation coverage for the behavior-neutral compute-authority census.
+#
+# The mutation has the defect's exact shape: only an overlapping raw buffer is mislabeled as a
+# proven GPU consumer. It must be killed by the named raw-overlap positive control and no sibling.
+# The tracked source is never edited; the script builds a scratch copy.
+set -u
+
+HERE=$(cd "$(dirname "$0")" && pwd)
+ROOT=$(cd "$HERE/../.." && pwd)
+WORK=$(mktemp -d "${TMPDIR:-/var/tmp}/compute-authority-mutate-XXXXXX") || exit 2
+trap 'rm -rf "$WORK"' EXIT
+cp "$ROOT/frontends/shared/compute_authority_census.hpp" \
+   "$ROOT/tests/test_compute_authority_census.cpp" "$WORK/" || exit 2
+HEADER="$WORK/compute_authority_census.hpp"
+CXX_BIN=${CXX:-c++}
+
+python3 - "$HEADER" <<'PY' || exit 1
+import sys
+
+path = sys.argv[1]
+old = """        case ShadowComputeAuthorityConsumerKind::RawBuffer:
+            return ShadowComputeAuthorityAccess::GuestMirror;"""
+new = """        case ShadowComputeAuthorityConsumerKind::RawBuffer:
+            return ShadowComputeAuthorityAccess::ProvenGpu;"""
+with open(path, encoding="utf-8") as stream:
+    source = stream.read()
+if source.count(old) != 1:
+    raise SystemExit(f"mutation anchor count is {source.count(old)}, expected exactly one")
+with open(path, "w", encoding="utf-8") as stream:
+    stream.write(source.replace(old, new, 1))
+PY
+
+if ! "$CXX_BIN" -std=c++20 -Wall -Wextra -Werror -I"$WORK" \
+    "$WORK/test_compute_authority_census.cpp" -o "$WORK/test-authority"
+then
+    echo "raw overlap mutation: BUILD FAILED (mutation not observed)"
+    exit 1
+fi
+
+output=$("$WORK/test-authority" 2>&1)
+status=$?
+failed=$(printf '%s\n' "$output" | sed -n 's/^  FAIL //p')
+expected="overlapping raw-buffer consumer forces guest materialization"
+if [ "$status" -eq 0 ]; then
+    echo "raw overlap mutation: *** SURVIVED ***"
+    exit 1
+fi
+if [ "$failed" != "$expected" ]; then
+    printf 'raw overlap mutation: WRONG KILL expected "%s", got: %s\n' \
+        "$expected" "$failed"
+    exit 1
+fi
+printf 'raw overlap mutation: killed by: %s\n' "$expected"
+
+cp "$ROOT/frontends/shared/compute_authority_census.hpp" "$HEADER"
+if "$CXX_BIN" -std=c++20 -Wall -Wextra -Werror -I"$WORK" \
+       "$WORK/test_compute_authority_census.cpp" -o "$WORK/test-authority" && \
+   "$WORK/test-authority" >/dev/null
+then
+    echo "unmutated copy: suite green"
+else
+    echo "unmutated copy: SUITE NOT GREEN"
+    exit 1
+fi


### PR DESCRIPTION
## What changed

- add a pure, behavior-neutral state machine for hypothetical deferred compute-image authority
- distinguish a valid retained Vulkan result from whether the architectural guest mirror is current
- classify proven GPU consumers, unrelated ranges, overlapping guest/image/buffer/draw/DMA/memory consumers, capture, unknown consumers, and submit completion
- expose saturating counters and exact first-materialization attribution for later live census wiring
- add focused CPU policy tests and a defect-shaped raw-buffer mutation audit

## Why

Syberia chains large native Float32 atlas dispatches in one ordered submit. PR #1851 removed repeated sampled-image guest upload between steps, but every storage step still synchronously reads back, packs, retiles, and publishes the full guest allocation. Deferring that publication could be valuable, but is unsafe until every possible guest-visible observer is classified.

This first deliverable establishes the fail-closed policy without changing live rendering or synchronous writeback. Unknown, malformed, overflowing, or unbounded inputs materialize; submit completion always materializes; only explicitly proven GPU consumers or disjoint guest ranges retain authority.

## Important invariants and risk

- all public range inputs are revalidated, including forged aggregate values
- half-open adjacency is not overlap; zero and overflowing ranges are invalid
- invalid enum values fall back to unknown/materialize with attribution
- the first boundary owns attribution; a later observer cannot steal it
- counters saturate instead of wrapping during a long census
- this PR contains no runtime integration and makes no performance or visual claim

## Validation

- worktree-local distrobox focused CTests: 2/2 passed
- policy executable: 19/19 named checks passed
- defect-shaped mutation treating overlapping RawBuffer as proven GPU-safe was killed only by `overlapping raw-buffer consumer forces guest materialization`; unmodified suite passed
- independent review found and then verified fixes for forged overflowing ranges and missing unknown-range GPU attribution
- post-review rebase onto current master retained the exact stable patch ID
- `git diff --check`

Refs #1854
