### PR TITLE
gpu: retain raw input witness for selected resource captures

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -1169,6 +1169,12 @@ if(TARGET prosper_core)
       add_test(NAME gpu_replay_seeded_raw_execution
         COMMAND test_gpu_replay_seed_order $<TARGET_FILE:gpu_replay>)
 
+      # Exercise the real metadata-only CLI path for v46's selected raw resource-input witness.
+      # Unit tests cover verdict policy; this process test keeps inspect formatting from silently
+      # disappearing or collapsing full-match/mismatch/unavailable into one output state.
+      add_test(NAME gpu_replay_resource_input_inspect
+        COMMAND test_gpu_capture --inspect-resource-input $<TARGET_FILE:gpu_replay>)
+
       # Capture -> serialize -> owned replay backing -> SAME live renderer -> pixels. This specifically
       # proves replay textures do not dereference the captured guest VA and still sample exact bytes.
       add_executable(test_gpu_capture_render tests/test_gpu_capture_render.cpp)

--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -101,11 +101,27 @@ void reg_watch_report(RegClass reg_class, uint32_t offset, uint32_t value, uint3
 }
 }  // namespace
 
-// PROSPER_UDPROV=1 (#305 instrument): enable per-SH-register write provenance recording.
+// Enable per-SH-register write provenance recording for #305 or selected capture #1853.
 bool udprov_enabled() {
-    static const bool on = std::getenv("PROSPER_UDPROV") != nullptr;
+    // #1853: a selected resource-input witness needs this state from the first SH write, before the
+    // capture candidate is reached. The selector is process-start configuration just like UDPROV;
+    // enabling it records the maps without enabling RESDUMP/UDPROV's high-volume live output.
+    static const bool on = std::getenv("PROSPER_UDPROV") != nullptr ||
+        std::getenv("PROSPER_GPU_CAPTURE_RESOURCE_PROVENANCE") != nullptr;
     return on;
 }
+
+namespace {
+// Test-only fault injection for the #1853 provenance collector.  Keep the public activation
+// predicate true so the mutation exercises the selected-witness consumer, but suppress both the
+// write maps and their draw snapshot.  This is intentionally queried dynamically: the focused
+// regression arms it only for its safe cross-thread fixture after the older .at()-based provenance
+// checks have completed.
+bool udprov_collection_enabled() {
+    return udprov_enabled() &&
+        std::getenv("PROSPER_TEST_DISABLE_UDPROV_COLLECTION") == nullptr;
+}
+} // namespace
 
 // Readability probe (gpu_executor.cpp, declared in gpu_execute.hpp): page-granular check that a
 // guest range is mapped, so the Jump fold below never walks an unmapped segment address.
@@ -2739,7 +2755,7 @@ void GpuState::apply(const Pm4Command& c) {
                     continue;
                 }
                 file[offset] = regs[i].value;
-                if (udprov_enabled() && c.reg_class == RegClass::Sh) {
+                if (udprov_collection_enabled() && c.reg_class == RegClass::Sh) {
                     sh_prov[offset] = command_order | kProvIndirect;
                     sh_prov_src[offset] = pack_prov_src(
                         c.queue_origin, jump_depth,
@@ -2859,7 +2875,7 @@ void GpuState::apply(const Pm4Command& c) {
             }
             for (uint32_t k = 0; k < c.reg_count && c.reg_offset + k < kRegOffsetLimit; k++)
                 file[c.reg_offset + k] = c.reg_data[k];
-            if (udprov_enabled() && c.reg_class == RegClass::Sh) {
+            if (udprov_collection_enabled() && c.reg_class == RegClass::Sh) {
                 const uint64_t src = pack_prov_src(c.queue_origin, jump_depth,
                                                    g_fold_seq.load(std::memory_order_relaxed));
                 for (uint32_t k = 0; k < c.reg_count && c.reg_offset + k < kRegOffsetLimit; k++) {
@@ -2951,7 +2967,7 @@ void GpuState::apply(const Pm4Command& c) {
                 snap->cx = cx; snap->sh = sh; snap->uc = uc; snap->index_type = index_type;
                 snap->num_instances = num_instances;
                 snap->command_order = command_order;   // #305 instrument: order at snapshot
-                if (udprov_enabled()) { snap->sh_prov = sh_prov; snap->sh_prov_src = sh_prov_src; }
+                if (udprov_collection_enabled()) { snap->sh_prov = sh_prov; snap->sh_prov_src = sh_prov_src; }
                 last_snapshot_ = std::move(snap);
                 state_dirty_ = false;
             }
@@ -3002,7 +3018,7 @@ void GpuState::apply(const Pm4Command& c) {
                 snap->cx = cx; snap->sh = sh; snap->uc = uc; snap->index_type = index_type;
                 snap->num_instances = num_instances;
                 snap->command_order = command_order;   // #305 instrument: order at snapshot
-                if (udprov_enabled()) { snap->sh_prov = sh_prov; snap->sh_prov_src = sh_prov_src; }
+                if (udprov_collection_enabled()) { snap->sh_prov = sh_prov; snap->sh_prov_src = sh_prov_src; }
                 last_snapshot_ = std::move(snap);
                 state_dirty_ = false;
             }
@@ -3045,7 +3061,7 @@ void GpuState::apply(const Pm4Command& c) {
                 snap->cx = cx; snap->sh = sh; snap->uc = uc; snap->index_type = index_type;
                 snap->num_instances = num_instances;
                 snap->command_order = command_order;   // #305 instrument: order at snapshot
-                if (udprov_enabled()) { snap->sh_prov = sh_prov; snap->sh_prov_src = sh_prov_src; }
+                if (udprov_collection_enabled()) { snap->sh_prov = sh_prov; snap->sh_prov_src = sh_prov_src; }
                 last_snapshot_ = std::move(snap);
                 state_dirty_ = false;
             }
@@ -3246,7 +3262,7 @@ void GpuState::apply(const Pm4Command& c) {
                 snap->cx = cx; snap->sh = sh; snap->uc = uc; snap->index_type = index_type;
                 snap->num_instances = num_instances;
                 snap->command_order = command_order;   // #305 instrument: order at snapshot
-                if (udprov_enabled()) { snap->sh_prov = sh_prov; snap->sh_prov_src = sh_prov_src; }
+                if (udprov_collection_enabled()) { snap->sh_prov = sh_prov; snap->sh_prov_src = sh_prov_src; }
                 last_snapshot_ = std::move(snap);
                 state_dirty_ = false;
             }
@@ -3278,7 +3294,7 @@ void GpuState::apply(const Pm4Command& c) {
                 snap->cx = cx; snap->sh = sh; snap->uc = uc; snap->index_type = index_type;
                 snap->num_instances = num_instances;
                 snap->command_order = command_order;   // #305 instrument: order at snapshot
-                if (udprov_enabled()) { snap->sh_prov = sh_prov; snap->sh_prov_src = sh_prov_src; }
+                if (udprov_collection_enabled()) { snap->sh_prov = sh_prov; snap->sh_prov_src = sh_prov_src; }
                 last_snapshot_ = std::move(snap);
                 state_dirty_ = false;
             }

--- a/prosper/src/gpu/command_processor.hpp
+++ b/prosper/src/gpu/command_processor.hpp
@@ -23,13 +23,13 @@ struct ShaderReg { uint32_t offset; uint32_t value; };
 // Folded GPU state after replaying a command stream.
 struct GpuState {
     std::unordered_map<uint32_t, uint32_t> cx, sh, uc;   // register files by offset
-    // PROSPER_UDPROV=1 (issue #305 instrument, diagnostic-only): per-SH-register last-write
-    // provenance. Resolved register VALUES cannot distinguish "this draw's bind wrote this dword"
+    // PROSPER_UDPROV=1 (issue #305) or an armed resource-provenance selector (#1853): per-SH-register
+    // last-write provenance. Resolved register VALUES cannot distinguish "this draw's bind wrote this dword"
     // from "a previous pipeline's bind wrote it and no newer write arrived" — which is exactly the
     // question the stale-user-data defect asks. Records, for each Sh offset, the command_order of
     // its most recent write with bit 63 set when that write came from the indirect
-    // (Set*RegsIndirect) path. Populated ONLY when the env var is set, so the default fold pays
-    // nothing and the per-draw snapshot copy is unchanged.
+    // (Set*RegsIndirect) path. Populated ONLY when one instrument is armed from process start, so the
+    // default fold pays nothing and the per-draw snapshot copy is unchanged.
     std::unordered_map<uint32_t, uint64_t> sh_prov;
     static constexpr uint64_t kProvIndirect = uint64_t{1} << 63;
     // Companion map for the same writes: WHERE the packet came from, which `command_order` alone
@@ -300,7 +300,7 @@ struct RegWatchEntry {
 // so one bad entry cannot silently disable a whole watch. An empty/absent setting yields no entries.
 std::vector<RegWatchEntry> parse_reg_watch(const char* setting);
 
-// PROSPER_UDPROV=1 (#305 instrument): whether GpuState::sh_prov write provenance is being recorded.
+// Whether GpuState::sh_prov write provenance is being recorded for #305 or selected capture #1853.
 bool udprov_enabled();
 
 } // namespace prosper::gpu

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -107,7 +107,10 @@ constexpr char kMagic[8] = {'P','R','G','P','C','A','P','\0'};
 // v45 (#1849): retain one opt-in draw-time resource sample and its independently captured post-submit
 // span. The append-only record references ordinary blobs so both read counts, bytes, and hashes remain
 // auditable offline; captures without the selector append only a zero count and copy no extra bytes.
-constexpr uint32_t kVersion = 45;
+// v46 (#1853): retain the selected direct V#'s four raw stage USER_DATA dwords and each dword's
+// PM4 last-write provenance. Replay decodes this input independently and compares it with the v45
+// normalized descriptor; unsupported/ambiguous paths are recorded as explicitly unavailable.
+constexpr uint32_t kVersion = 46;
 constexpr uint32_t kEndian = 0x01020304u;
 constexpr uint64_t kMaxFileBytes = 4ull << 30;
 constexpr uint64_t kMaxBlobBytes = 1ull << 30;
@@ -973,6 +976,28 @@ bool validate_dma_copies(const GpuCaptureFile& capture, std::string& error) {
     return true;
 }
 
+GpuCaptureResourceInputUnavailableReason direct_vsharp_coverage_reason(
+        const std::array<uint32_t, 4>& dwords) {
+    const DecodedBufferDescriptor decoded = decode_buffer_descriptor(dwords.data());
+    const bool format_unavailable =
+        decoded.format == DataFormat::Unknown || decoded.num_components == 0;
+    const bool size_unavailable = decoded.size_bytes == 0;
+    if (format_unavailable && size_unavailable)
+        return GpuCaptureResourceInputUnavailableReason::RawFormatAndSizeUnavailable;
+    if (format_unavailable)
+        return GpuCaptureResourceInputUnavailableReason::RawFormatUnavailable;
+    if (size_unavailable)
+        return GpuCaptureResourceInputUnavailableReason::RawSizeUnavailable;
+    return GpuCaptureResourceInputUnavailableReason::None;
+}
+
+bool is_direct_vsharp_coverage_reason(GpuCaptureResourceInputUnavailableReason reason) {
+    return reason == GpuCaptureResourceInputUnavailableReason::None ||
+        reason == GpuCaptureResourceInputUnavailableReason::RawFormatUnavailable ||
+        reason == GpuCaptureResourceInputUnavailableReason::RawSizeUnavailable ||
+        reason == GpuCaptureResourceInputUnavailableReason::RawFormatAndSizeUnavailable;
+}
+
 bool validate_resource_provenance(const GpuCaptureFile& capture, std::string& error) {
     if (capture.resource_provenance.size() > 1) {
         error = "invalid resource provenance record count";
@@ -1004,9 +1029,15 @@ bool validate_resource_provenance(const GpuCaptureFile& capture, std::string& er
             return false;
         }
 
+        const GpuCapturedDraw* captured_draw = nullptr;
         const GpuCapturedResource* captured_resource = nullptr;
         for (const auto& draw : capture.draws) {
             if (draw.draw_index != provenance.draw_index) continue;
+            if (captured_draw && captured_draw != &draw) {
+                error = "ambiguous resource provenance draw identity";
+                return false;
+            }
+            captured_draw = &draw;
             const auto& table = provenance.stage == ShaderProgramStage::Vertex
                 ? draw.vrt : draw.prt;
             for (const auto& resource : table.resources) {
@@ -1027,6 +1058,58 @@ bool validate_resource_provenance(const GpuCaptureFile& capture, std::string& er
             captured_resource->blob_index != provenance.post_blob_index ||
             captured_resource->blob_offset != provenance.post_blob_offset) {
             error = "resource provenance does not match its captured descriptor";
+            return false;
+        }
+        const auto reason_value = static_cast<uint32_t>(provenance.input_unavailable_reason);
+        if (provenance.input_mode == GpuCaptureResourceInputMode::Unavailable) {
+            if (provenance.input_unavailable_reason ==
+                    GpuCaptureResourceInputUnavailableReason::None ||
+                reason_value > static_cast<uint32_t>(
+                    GpuCaptureResourceInputUnavailableReason::MissingWriteProvenance) ||
+                provenance.input_write_provenance_mask != 0 ||
+                provenance.input_sh_register_base != 0xFFFFFFFFu ||
+                std::any_of(provenance.input_dwords.begin(), provenance.input_dwords.end(),
+                            [](uint32_t value) { return value != 0; }) ||
+                std::any_of(provenance.input_last_writes.begin(),
+                            provenance.input_last_writes.end(),
+                            [](uint64_t value) { return value != 0; }) ||
+                std::any_of(provenance.input_write_sources.begin(),
+                            provenance.input_write_sources.end(),
+                            [](uint64_t value) { return value != 0; })) {
+                error = "invalid unavailable resource input witness";
+                return false;
+            }
+        } else if (provenance.input_mode == GpuCaptureResourceInputMode::DirectVSharp) {
+            if (!captured_draw || provenance.input_write_provenance_mask != 0x0fu ||
+                provenance.input_sh_register_base > GpuState::kRegOffsetLimit - 4u ||
+                !is_direct_vsharp_coverage_reason(
+                    provenance.input_unavailable_reason) ||
+                provenance.input_unavailable_reason !=
+                    direct_vsharp_coverage_reason(provenance.input_dwords)) {
+                error = "invalid direct resource input witness";
+                return false;
+            }
+            for (const uint64_t write : provenance.input_last_writes) {
+                const uint64_t order = write & ~GpuState::kProvIndirect;
+                if (!order || order >= captured_draw->command_order) {
+                    error = "resource input write does not precede selected draw";
+                    return false;
+                }
+            }
+            for (const uint64_t source : provenance.input_write_sources) {
+                const uint8_t queue = static_cast<uint8_t>(source & 0xffu);
+                const uint8_t jump_depth = static_cast<uint8_t>((source >> 8u) & 0xffu);
+                const uint32_t fold = static_cast<uint32_t>(source >> 16u);
+                // pack_prov_src allocates bits 0..47 as q8/j8/fold32.  The command processor
+                // admits queue origins 0..3 and records Jump depth 0..8 inclusive (the parent at
+                // depth 7 may enter its final child at depth 8).  A top-level fold id is never zero.
+                if (queue > 3u || jump_depth > 8u || fold == 0u || (source >> 48u) != 0u) {
+                    error = "invalid resource input write source";
+                    return false;
+                }
+            }
+        } else {
+            error = "invalid resource input witness mode";
             return false;
         }
     }
@@ -2439,6 +2522,22 @@ bool serialize_gpu_capture(const GpuCaptureFile& c, std::vector<uint8_t>& bytes,
         w.u64(provenance.realization_content_hash);
         w.u64(provenance.post_content_hash);
     }
+    // v46 appends the input-side witness separately so every v45 record remains byte-exact. Repeat
+    // semantic identity before the raw dwords: a reordered vector must fail visibly instead of
+    // silently assigning one draw's witness to another normalized descriptor.
+    w.u32(static_cast<uint32_t>(c.resource_provenance.size()));
+    for (const auto& provenance : c.resource_provenance) {
+        w.u64(provenance.draw_index);
+        w.u8(static_cast<uint8_t>(provenance.stage));
+        w.u32(provenance.binding);
+        w.u8(static_cast<uint8_t>(provenance.input_mode));
+        w.u8(static_cast<uint8_t>(provenance.input_unavailable_reason));
+        w.u8(provenance.input_write_provenance_mask);
+        w.u32(provenance.input_sh_register_base);
+        for (const uint32_t value : provenance.input_dwords) w.u32(value);
+        for (const uint64_t write : provenance.input_last_writes) w.u64(write);
+        for (const uint64_t source : provenance.input_write_sources) w.u64(source);
+    }
     if (w.data.size() > kMaxFileBytes) { error = "capture file exceeds 4 GiB"; return false; }
     bytes = std::move(w.data);
     return true;
@@ -3517,6 +3616,36 @@ bool deserialize_gpu_capture(const std::vector<uint8_t>& bytes, GpuCaptureFile& 
         }
         if (!validate_resource_provenance(c, error)) return false;
     }
+    if (version >= 46) {
+        uint32_t count = 0;
+        if (!r.u32(count) || count != c.resource_provenance.size()) {
+            error = "invalid resource input witness record count";
+            return false;
+        }
+        for (auto& provenance : c.resource_provenance) {
+            uint64_t draw_index = 0;
+            uint8_t stage = 0, mode = 0, reason = 0, provenance_mask = 0;
+            uint32_t binding = 0;
+            if (!r.u64(draw_index) || !r.u8(stage) || !r.u32(binding) ||
+                !r.u8(mode) || !r.u8(reason) || !r.u8(provenance_mask) ||
+                !r.u32(provenance.input_sh_register_base))
+                return false;
+            if (draw_index != provenance.draw_index ||
+                stage != static_cast<uint8_t>(provenance.stage) ||
+                binding != provenance.binding) {
+                error = "resource input witness identity mismatch";
+                return false;
+            }
+            provenance.input_mode = static_cast<GpuCaptureResourceInputMode>(mode);
+            provenance.input_unavailable_reason =
+                static_cast<GpuCaptureResourceInputUnavailableReason>(reason);
+            provenance.input_write_provenance_mask = provenance_mask;
+            for (auto& value : provenance.input_dwords) if (!r.u32(value)) return false;
+            for (auto& write : provenance.input_last_writes) if (!r.u64(write)) return false;
+            for (auto& source : provenance.input_write_sources) if (!r.u64(source)) return false;
+        }
+        if (!validate_resource_provenance(c, error)) return false;
+    }
     for (auto& draw : c.draws) restore_legacy_color_target_aliases(draw);
     for (auto& diagnostic : c.failure_diagnostics)
         restore_legacy_color_target_aliases(diagnostic);
@@ -3890,9 +4019,170 @@ bool parse_gpu_capture_resource_selector(std::string_view text,
     return true;
 }
 
+const char* gpu_capture_resource_input_unavailable_reason_name(
+        GpuCaptureResourceInputUnavailableReason reason) {
+    switch (reason) {
+        case GpuCaptureResourceInputUnavailableReason::None: return "none";
+        case GpuCaptureResourceInputUnavailableReason::CapturePredatesWitness:
+            return "capture-predates-v46";
+        case GpuCaptureResourceInputUnavailableReason::NoSemanticState:
+            return "no-semantic-draw-state";
+        case GpuCaptureResourceInputUnavailableReason::NonDirectResource:
+            return "not-a-direct-vsharp";
+        case GpuCaptureResourceInputUnavailableReason::InvalidSgprRange:
+            return "invalid-direct-sgpr-range";
+        case GpuCaptureResourceInputUnavailableReason::NoRawOrigin:
+            return "no-raw-sh-origin";
+        case GpuCaptureResourceInputUnavailableReason::AmbiguousRawOrigin:
+            return "ambiguous-raw-sh-origin";
+        case GpuCaptureResourceInputUnavailableReason::MissingWriteProvenance:
+            return "missing-sh-write-provenance";
+        case GpuCaptureResourceInputUnavailableReason::RawFormatUnavailable:
+            return "raw-format-not-architecturally-available";
+        case GpuCaptureResourceInputUnavailableReason::RawSizeUnavailable:
+            return "raw-size-not-architecturally-available";
+        case GpuCaptureResourceInputUnavailableReason::RawFormatAndSizeUnavailable:
+            return "raw-format-and-size-not-architecturally-available";
+    }
+    return "invalid-unavailable-reason";
+}
+
+GpuCaptureResourceInputVerdict gpu_capture_resource_input_verdict(
+        const GpuCaptureResourceProvenance& provenance,
+        const ShaderResource& normalized_resource) {
+    if (provenance.input_mode == GpuCaptureResourceInputMode::Unavailable)
+        return GpuCaptureResourceInputVerdict::Unavailable;
+    if (provenance.input_mode != GpuCaptureResourceInputMode::DirectVSharp ||
+        provenance.input_write_provenance_mask != 0x0fu ||
+        provenance.input_sh_register_base == 0xFFFFFFFFu)
+        return GpuCaptureResourceInputVerdict::Mismatch;
+
+    // Decode only architecturally encoded V# fields. Shader-instruction formats and compatibility
+    // allocations are front-half policy, not evidence in these four raw dwords.  Compare every
+    // counterpart the raw descriptor does encode before reporting a missing field as unavailable:
+    // NUM_RECORDS=0 still proves format/components, and FORMAT=INVALID still proves byte size.
+    const DecodedBufferDescriptor decoded =
+        decode_buffer_descriptor(provenance.input_dwords.data());
+    if (normalized_resource.srt_offset != 0xFFFFFFFFu ||
+        normalized_resource.sgpr_base != provenance.sgpr_base ||
+        normalized_resource.gpu_addr != provenance.guest_addr ||
+        normalized_resource.gpu_addr != decoded.base ||
+        normalized_resource.stride != decoded.stride)
+        return GpuCaptureResourceInputVerdict::Mismatch;
+
+    const auto coverage_reason = direct_vsharp_coverage_reason(provenance.input_dwords);
+    if (provenance.input_unavailable_reason != coverage_reason)
+        return GpuCaptureResourceInputVerdict::Mismatch;
+
+    const bool format_available =
+        coverage_reason != GpuCaptureResourceInputUnavailableReason::RawFormatUnavailable &&
+        coverage_reason !=
+            GpuCaptureResourceInputUnavailableReason::RawFormatAndSizeUnavailable;
+    const bool size_available =
+        coverage_reason != GpuCaptureResourceInputUnavailableReason::RawSizeUnavailable &&
+        coverage_reason !=
+            GpuCaptureResourceInputUnavailableReason::RawFormatAndSizeUnavailable;
+    if (format_available &&
+        (normalized_resource.format != decoded.format ||
+         normalized_resource.num_components != decoded.num_components))
+        return GpuCaptureResourceInputVerdict::Mismatch;
+    if (size_available && normalized_resource.size != decoded.size_bytes)
+        return GpuCaptureResourceInputVerdict::Mismatch;
+    if (coverage_reason != GpuCaptureResourceInputUnavailableReason::None)
+        return GpuCaptureResourceInputVerdict::Unavailable;
+    return GpuCaptureResourceInputVerdict::FullMatch;
+}
+
+namespace {
+
+void capture_resource_input_witness(GpuCaptureResourceProvenance& provenance,
+                                    const ShaderResource& selected,
+                                    const DrawItem& draw,
+                                    const GpuState* semantic_state) {
+    provenance.input_mode = GpuCaptureResourceInputMode::Unavailable;
+    provenance.input_unavailable_reason =
+        GpuCaptureResourceInputUnavailableReason::NoSemanticState;
+    provenance.input_write_provenance_mask = 0;
+    provenance.input_sh_register_base = 0xFFFFFFFFu;
+    provenance.input_dwords = {};
+    provenance.input_last_writes = {};
+    provenance.input_write_sources = {};
+
+    if (selected.srt_offset != 0xFFFFFFFFu || selected.sgpr_base == 0xFFFFFFFFu) {
+        provenance.input_unavailable_reason =
+            GpuCaptureResourceInputUnavailableReason::NonDirectResource;
+        return;
+    }
+    if (selected.direct_vsharp_sh_register_base ==
+        ShaderResource::kDirectVSharpOriginAmbiguous) {
+        provenance.input_unavailable_reason =
+            GpuCaptureResourceInputUnavailableReason::AmbiguousRawOrigin;
+        return;
+    }
+    if (selected.direct_vsharp_sh_register_base ==
+        ShaderResource::kDirectVSharpOriginUnavailable) {
+        provenance.input_unavailable_reason =
+            GpuCaptureResourceInputUnavailableReason::NoRawOrigin;
+        return;
+    }
+    const uint32_t shader_user_base =
+        provenance.stage == ShaderProgramStage::Fragment ? 0u : 8u;
+    if (selected.sgpr_base < shader_user_base ||
+        selected.sgpr_base - shader_user_base > 28u) {
+        provenance.input_unavailable_reason =
+            GpuCaptureResourceInputUnavailableReason::InvalidSgprRange;
+        return;
+    }
+    if (!semantic_state || draw.draw_index >= semantic_state->draws.size()) return;
+    const GpuState& draw_state = semantic_state->state_at_draw(
+        static_cast<size_t>(draw.draw_index));
+    provenance.input_sh_register_base = selected.direct_vsharp_sh_register_base;
+    if (provenance.input_sh_register_base > GpuState::kRegOffsetLimit - 4u) {
+        provenance.input_sh_register_base = 0xFFFFFFFFu;
+        provenance.input_unavailable_reason =
+            GpuCaptureResourceInputUnavailableReason::NoRawOrigin;
+        return;
+    }
+    for (uint32_t i = 0; i < 4; ++i) {
+        const auto value = draw_state.sh.find(provenance.input_sh_register_base + i);
+        if (value == draw_state.sh.end()) {
+            provenance.input_sh_register_base = 0xFFFFFFFFu;
+            provenance.input_dwords = {};
+            provenance.input_unavailable_reason =
+                GpuCaptureResourceInputUnavailableReason::NoRawOrigin;
+            return;
+        }
+        provenance.input_dwords[i] = value->second;
+    }
+    for (uint32_t i = 0; i < 4; ++i) {
+        const uint32_t reg = provenance.input_sh_register_base + i;
+        const auto write = draw_state.sh_prov.find(reg);
+        const auto source = draw_state.sh_prov_src.find(reg);
+        if (write == draw_state.sh_prov.end() || source == draw_state.sh_prov_src.end()) {
+            provenance.input_write_provenance_mask = 0;
+            provenance.input_sh_register_base = 0xFFFFFFFFu;
+            provenance.input_dwords = {};
+            provenance.input_last_writes = {};
+            provenance.input_write_sources = {};
+            provenance.input_unavailable_reason =
+                GpuCaptureResourceInputUnavailableReason::MissingWriteProvenance;
+            return;
+        }
+        provenance.input_write_provenance_mask |= static_cast<uint8_t>(1u << i);
+        provenance.input_last_writes[i] = write->second;
+        provenance.input_write_sources[i] = source->second;
+    }
+    provenance.input_mode = GpuCaptureResourceInputMode::DirectVSharp;
+    provenance.input_unavailable_reason =
+        direct_vsharp_coverage_reason(provenance.input_dwords);
+}
+
+} // namespace
+
 void snapshot_pending_gpu_capture_draw_resource(PendingGpuCapture* pending,
                                                 const DrawItem& draw,
-                                                const CaptureMemoryReader& reader) {
+                                                const CaptureMemoryReader& reader,
+                                                const GpuState* semantic_state) {
     // This check is the normal-path cost: no table walk, allocation, or guest-memory read occurs
     // unless a capture explicitly requests one semantic resource.
     if (!pending || !pending->resource_provenance_armed ||
@@ -3948,6 +4238,7 @@ void snapshot_pending_gpu_capture_draw_resource(PendingGpuCapture* pending,
     provenance.srt_offset = selected->srt_offset;
     provenance.sgpr_base = selected->sgpr_base;
     provenance.realization_content_hash = blob.content_hash;
+    capture_resource_input_witness(provenance, *selected, draw, semantic_state);
     pending->resource_provenance_realization_blob = std::move(blob);
 }
 
@@ -4339,7 +4630,8 @@ std::unique_ptr<PendingGpuCapture> begin_requested_gpu_capture(
         // producer. Deferred capture therefore has exactly one temporal owner, the ordered executor.
         if (!defer_materialization)
             for (const auto& draw : draws)
-                snapshot_pending_gpu_capture_draw_resource(pending.get(), draw);
+                snapshot_pending_gpu_capture_draw_resource(
+                    pending.get(), draw, {}, semantic_state);
     }
     pending->output_triggered = output_triggered;
     if (output_triggered) {

--- a/prosper/src/gpu/gpu_capture.hpp
+++ b/prosper/src/gpu/gpu_capture.hpp
@@ -3,6 +3,7 @@
 
 #include "gpu_execute.hpp"
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -60,6 +61,36 @@ struct GpuCaptureResourceSelector {
     uint32_t binding = 0;
 };
 
+// Capture-v46 input-side witness for the one resource selected by
+// PROSPER_GPU_CAPTURE_RESOURCE_PROVENANCE.  The normalized ShaderResource is the front-half output;
+// these fields retain the direct V# dwords and their PM4 write provenance so replay can decode the
+// input independently.  Unsupported/ambiguous paths stay explicit instead of copying the output back
+// into a structure that merely looks independent.
+enum class GpuCaptureResourceInputMode : uint8_t {
+    Unavailable = 0,
+    DirectVSharp = 1,
+};
+
+enum class GpuCaptureResourceInputUnavailableReason : uint8_t {
+    None = 0,
+    CapturePredatesWitness = 1,
+    NoSemanticState = 2,
+    NonDirectResource = 3,
+    InvalidSgprRange = 4,
+    NoRawOrigin = 5,
+    AmbiguousRawOrigin = 6,
+    MissingWriteProvenance = 7,
+    RawFormatUnavailable = 8,
+    RawSizeUnavailable = 9,
+    RawFormatAndSizeUnavailable = 10,
+};
+
+enum class GpuCaptureResourceInputVerdict : uint8_t {
+    Unavailable = 0,
+    FullMatch = 1,
+    Mismatch = 2,
+};
+
 struct GpuCaptureResourceProvenance {
     uint64_t draw_index = 0;
     ShaderProgramStage stage = ShaderProgramStage::Vertex;
@@ -74,6 +105,16 @@ struct GpuCaptureResourceProvenance {
     uint64_t post_blob_offset = 0;
     uint64_t realization_content_hash = 0;
     uint64_t post_content_hash = 0;
+    GpuCaptureResourceInputMode input_mode = GpuCaptureResourceInputMode::Unavailable;
+    GpuCaptureResourceInputUnavailableReason input_unavailable_reason =
+        GpuCaptureResourceInputUnavailableReason::CapturePredatesWitness;
+    uint8_t input_write_provenance_mask = 0;
+    uint32_t input_sh_register_base = 0xFFFFFFFFu;
+    std::array<uint32_t, 4> input_dwords{};
+    // Same encoding as GpuState::sh_prov: bit 63 is the indirect path, remaining bits are the
+    // command order. input_write_sources uses GpuState::pack_prov_src (queue/fold/Jump depth).
+    std::array<uint64_t, 4> input_last_writes{};
+    std::array<uint64_t, 4> input_write_sources{};
 };
 
 struct GpuCaptureShaderVersion {
@@ -429,9 +470,14 @@ struct PendingGpuCapture {
 };
 bool parse_gpu_capture_resource_selector(std::string_view text,
                                          GpuCaptureResourceSelector& selector);
+GpuCaptureResourceInputVerdict gpu_capture_resource_input_verdict(
+    const GpuCaptureResourceProvenance& provenance,
+    const ShaderResource& normalized_resource);
+const char* gpu_capture_resource_input_unavailable_reason_name(
+    GpuCaptureResourceInputUnavailableReason reason);
 void snapshot_pending_gpu_capture_draw_resource(
     PendingGpuCapture* pending, const DrawItem& draw,
-    const CaptureMemoryReader& reader = {});
+    const CaptureMemoryReader& reader = {}, const GpuState* semantic_state = nullptr);
 void snapshot_pending_gpu_capture_compute_gds(PendingGpuCapture* pending,
                                               const uint8_t* data, size_t bytes);
 std::unique_ptr<PendingGpuCapture> begin_requested_gpu_capture(

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -168,6 +168,11 @@ size_t dynamic_fold_shader_dwords(uint32_t shader_size_bytes);
 // unit-testable; production callers stay inside gpu_executor.cpp.
 struct DynFetch {
     uint32_t fetch_pc; int srsrc; DecodedBufferDescriptor desc; uint32_t desc_v3;
+    // Entry user-data dword that supplied the first raw V# word, proven only when all four live
+    // descriptor words remain an unchanged consecutive seed (possibly through scalar moves) and
+    // the fetch adds no instruction/SOFFSET byte transform to the normalized descriptor base.
+    // UINT32_MAX means the descriptor was loaded, patched, or otherwise has no single SH origin.
+    uint32_t direct_user_data_index = UINT32_MAX;
     // True when the V# came from the user-data SEED fallback (never s_loaded/patched-tracked). A
     // seed entry must NOT shadow a metadata-described direct vertex buffer at the same SGPRs: the
     // by_fetch_pc dyn path models the element address as gl_VertexIndex*stride (per-attribute

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -2792,7 +2792,15 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                                 in.pc, desc_v3);
                             return;
                         }
-                        DynFetch fetch{ in.pc, srsrc, with_off(d), desc_v3, from_seed };
+                        DynFetch fetch{ in.pc, srsrc, with_off(d), desc_v3 };
+                        fetch.from_seed = from_seed;
+                        // A legal instruction/SOFFSET transform changes the normalized base without
+                        // changing the four raw seed dwords.  That transformed resource no longer has
+                        // byte-identical descriptor identity, so it cannot name the entry V# as a
+                        // direct raw witness (doing so would manufacture a mismatch in #1853).
+                        if (fetch_off == 0 && consecutive_seed_copy_range(srsrc, 4))
+                            fetch.direct_user_data_index =
+                                val_seed_origin[static_cast<size_t>(srsrc)];
                         fetch.unshifted_desc = d;
                         if (is_mtbuf) fetch.instruction_format = in.mtbuf_format;
                         fetch.index_mode = fetch_index_mode_before_write;
@@ -3834,6 +3842,17 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
             r.fetch_pc      = kv.fetch_pc;        // PER-FETCH provenance = the exact fetch instruction
             r.fetch_index_mode = kv.index_mode;
             r.srt_offset    = 0xFFFFFFFFu;
+            // The dynamic fold may resolve a descriptor loaded or patched inside the shader. Only
+            // an unchanged four-dword entry seed has one exact raw PM4 SH source. Keep the primary
+            // entry range that actually fed the fold; do not search other stage bases by whether
+            // their decoded output happens to equal this normalized resource (#1853).
+            if (kv.direct_user_data_index <= kUserSgprs - 4u) {
+                r.direct_vsharp_sh_register_base =
+                    bases[0] + range_start + kv.direct_user_data_index;
+            } else {
+                r.direct_vsharp_sh_register_base =
+                    ShaderResource::kDirectVSharpOriginAmbiguous;
+            }
             if (!d.size_bytes && is_ps) {
                 static std::mutex zero_ps_mx;
                 static std::set<std::tuple<uint64_t, uint32_t, uint32_t>> zero_ps_seen;
@@ -4055,6 +4074,26 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
                     t.resources.push_back(r);
                 }
             }
+        }
+        // Metadata-described DIRECT buffers came from this exact candidate user-data range.
+        // Dynamic-fold resources already carry either their proven primary seed or the explicit
+        // ambiguous sentinel and are therefore never overwritten here.
+        for (auto& resource : t.resources) {
+            if (resource.direct_vsharp_sh_register_base !=
+                    ShaderResource::kDirectVSharpOriginUnavailable ||
+                resource.srt_offset != 0xFFFFFFFFu ||
+                resource.sgpr_base == 0xFFFFFFFFu ||
+                (resource.cls != ResourceClass::ConstantBuffer &&
+                 resource.cls != ResourceClass::VertexBuffer))
+                continue;
+            if (resource.sgpr_base < user_sgpr_base ||
+                resource.sgpr_base - user_sgpr_base > kUserSgprs - 4u) {
+                resource.direct_vsharp_sh_register_base =
+                    ShaderResource::kDirectVSharpOriginAmbiguous;
+                continue;
+            }
+            resource.direct_vsharp_sh_register_base = base + range_start +
+                (resource.sgpr_base - user_sgpr_base);
         }
         if (t.resources.empty()) continue;
         t.vertices_per_instance = is_ps ? 0u : draw_vertex_count;
@@ -5980,7 +6019,7 @@ static OrderedSubmitResult execute_ordered_gpustate(const GpuState& st, uint32_t
                 if (realized) {
                     if (capture_trace) {
                         snapshot_pending_gpu_capture_draw_resource(
-                            capture_trace->pending_capture, item);
+                            capture_trace->pending_capture, item, {}, &st);
                         capture_trace->draws.push_back(item);
                     }
                     span.push_back(std::move(item));

--- a/prosper/src/gpu/shader_resources.hpp
+++ b/prosper/src/gpu/shader_resources.hpp
@@ -186,6 +186,15 @@ struct ShaderResource {
     uint32_t      srt_offset    = 0xFFFFFFFFu;
     uint32_t      sgpr_base     = 0xFFFFFFFFu;
 
+    // Exact input-side origin for a DIRECT four-dword V# in the PM4 SH register file. This is
+    // runtime realization provenance only; it does not affect descriptor binding or shader-cache
+    // identity. The front half sets an absolute SPI_SHADER_USER_DATA_* register when it can prove
+    // that all four descriptor words came from one entry user-data range. A shader-loaded/modified
+    // descriptor can still be a valid runtime resource but has no single raw SH origin.
+    static constexpr uint32_t kDirectVSharpOriginUnavailable = 0xFFFFFFFFu;
+    static constexpr uint32_t kDirectVSharpOriginAmbiguous = 0xFFFFFFFEu;
+    uint32_t direct_vsharp_sh_register_base = kDirectVSharpOriginUnavailable;
+
     //   * fetch_pc — PER-FETCH: the pc of the exact buffer/tbuffer format instruction this descriptor was
     //     resolved for. A single SRSRC SGPR is reloaded with a DIFFERENT V# per vertex attribute (position,
     //     uv, color, …), so keying only by sgpr_base collapses them to the first. MUBUF may fall back to

--- a/prosper/tests/test_agc_shader.cpp
+++ b/prosper/tests/test_agc_shader.cpp
@@ -1,5 +1,6 @@
 // test_agc_shader -- focused guards for sceAgcCreateShader's guest-visible side effects.
 #include "../src/hle/dispatch.hpp"
+#include "../src/gpu/gpu_capture.hpp"
 #include "../src/gpu/gpu_execute.hpp"
 #include "../src/gpu/pm4_registers.hpp"
 #include <atomic>
@@ -306,8 +307,84 @@ int main() {
     const prosper::gpu::ShaderResource* pixel_buffer = pixel_table
         ? pixel_table->by_fetch_pc(6) : nullptr;
     CHECK(pixel_buffer && pixel_buffer->cls == prosper::gpu::ResourceClass::ConstantBuffer &&
-          pixel_buffer->gpu_addr == 0x20000u && pixel_buffer->stride == 16u,
-          "pixel-stage buffer_load_format keeps its exact structured-buffer V# resource");
+          pixel_buffer->gpu_addr == 0x20000u && pixel_buffer->stride == 16u &&
+          pixel_buffer->direct_vsharp_sh_register_base ==
+              prosper::gpu::ShaderResource::kDirectVSharpOriginAmbiguous,
+          "shader-constructed pixel V# keeps its resource but no fabricated raw SH origin");
+
+    const uint32_t direct_seed_fetch[] = {
+        0xE0002000u, 0x80020100u,   // pc=0: buffer_load_format_x v1, v0, s[8:11], 0 idxen
+        0xBF810000u,
+    };
+    Shader direct_seed{};
+    direct_seed.file_header = 0x34333231u;
+    direct_seed.version = 0x18u;
+    direct_seed.shader_size = sizeof(direct_seed_fetch);
+    direct_seed.type = 1;
+    dst = nullptr;
+    rc = create_shader(reinterpret_cast<uint64_t>(&dst),
+                       reinterpret_cast<uint64_t>(&direct_seed),
+                       reinterpret_cast<uint64_t>(direct_seed_fetch), 0, 0, 0);
+    CHECK(rc == 0 && dst == &direct_seed,
+          "direct-seed pixel shader enters the AGC registry");
+    prosper::gpu::GpuState direct_seed_state;
+    constexpr uint32_t kPsUser = prosper::agc::Pm4::SPI_SHADER_USER_DATA_PS_0;
+    direct_seed_state.sh[kPsUser + 8] = 0x00020000u;
+    direct_seed_state.sh[kPsUser + 9] = 0x00100000u;
+    direct_seed_state.sh[kPsUser + 10] = 4u;
+    direct_seed_state.sh[kPsUser + 11] = (22u << 12u) | 0xFACu;
+    auto direct_seed_table = prosper::gpu::build_stage_table(
+        direct_seed_state, reinterpret_cast<uint64_t>(direct_seed_fetch), true, 4);
+    const prosper::gpu::ShaderResource* direct_seed_buffer = direct_seed_table
+        ? direct_seed_table->by_fetch_pc(0) : nullptr;
+    CHECK(direct_seed_buffer &&
+          direct_seed_buffer->direct_vsharp_sh_register_base == kPsUser + 8,
+          "front-half direct seed carries its exact absolute SH origin into the runtime table");
+
+    // A nonzero MUBUF instruction offset is a legal address transform after the raw V# seed.  The
+    // normalized resource base is shifted, so treating the unchanged seed as byte-identical raw
+    // identity would make the resource-input verdict falsely say mismatch.  Keep the resource, but
+    // make the absence of one exact raw descriptor explicit through the capture path.
+    const uint32_t offset_seed_fetch[] = {
+        0xE0002004u, 0x80020100u,   // pc=0: same direct V#, plus instruction OFFSET=4
+        0xBF810000u,
+    };
+    Shader offset_seed{};
+    offset_seed.file_header = 0x34333231u;
+    offset_seed.version = 0x18u;
+    offset_seed.shader_size = sizeof(offset_seed_fetch);
+    offset_seed.type = 1;
+    dst = nullptr;
+    rc = create_shader(reinterpret_cast<uint64_t>(&dst),
+                       reinterpret_cast<uint64_t>(&offset_seed),
+                       reinterpret_cast<uint64_t>(offset_seed_fetch), 0, 0, 0);
+    auto offset_seed_table = prosper::gpu::build_stage_table(
+        direct_seed_state, reinterpret_cast<uint64_t>(offset_seed_fetch), true, 4);
+    const prosper::gpu::ShaderResource* offset_seed_buffer = offset_seed_table
+        ? offset_seed_table->by_fetch_pc(0) : nullptr;
+    prosper::gpu::DrawItem offset_seed_draw;
+    offset_seed_draw.draw_index = 9;
+    offset_seed_draw.prt = offset_seed_table;
+    prosper::gpu::PendingGpuCapture offset_seed_pending;
+    offset_seed_pending.resource_provenance_armed = true;
+    offset_seed_pending.resource_provenance_selector = {
+        9, prosper::gpu::ShaderProgramStage::Fragment,
+        offset_seed_buffer ? offset_seed_buffer->binding : 0};
+    prosper::gpu::snapshot_pending_gpu_capture_draw_resource(
+        &offset_seed_pending, offset_seed_draw,
+        [](uint64_t, uint8_t*, size_t) { return size_t{0}; });
+    CHECK(rc == 0 && dst == &offset_seed && offset_seed_buffer &&
+              offset_seed_buffer->gpu_addr == 0x00020004u &&
+              offset_seed_buffer->direct_vsharp_sh_register_base ==
+                  prosper::gpu::ShaderResource::kDirectVSharpOriginAmbiguous &&
+              offset_seed_pending.resource_provenance.input_mode ==
+                  prosper::gpu::GpuCaptureResourceInputMode::Unavailable &&
+              offset_seed_pending.resource_provenance.input_unavailable_reason ==
+                  prosper::gpu::GpuCaptureResourceInputUnavailableReason::AmbiguousRawOrigin &&
+              prosper::gpu::gpu_capture_resource_input_verdict(
+                  offset_seed_pending.resource_provenance, *offset_seed_buffer) ==
+                  prosper::gpu::GpuCaptureResourceInputVerdict::Unavailable,
+          "nonzero fetch offset stays explicitly unavailable instead of a false raw-input mismatch");
 
     // #158: the dynamic fold must use the registered header's byte size, not a fixed 64 KiB walk.
     // The valid-looking descriptor setup and fetch deliberately sit beyond the declared one-dword

--- a/prosper/tests/test_command_provenance.cpp
+++ b/prosper/tests/test_command_provenance.cpp
@@ -5,12 +5,19 @@
 // not evidence of where it came from, so this test drives the real AGC packet builders and PM4
 // decoder, then checks the maps retained by the draw snapshots.
 #include "../src/gpu/command_processor.hpp"
+#include "../src/gpu/gpu_capture.hpp"
 #include "../src/gpu/pm4_registers.hpp"
 #include "../src/hle/dispatch.hpp"
+#include <algorithm>
+#include <array>
+#include <condition_variable>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <iterator>
+#include <memory>
+#include <mutex>
+#include <thread>
 
 using namespace prosper;
 using namespace prosper::gpu;
@@ -61,14 +68,31 @@ static uint64_t pack_reg(uint32_t offset, uint32_t value) {
     return static_cast<uint64_t>(offset) | (static_cast<uint64_t>(value) << 32u);
 }
 
+static void set_test_env(const char* name, const char* value) {
+#ifdef _WIN32
+    _putenv_s(name, value ? value : "");
+#else
+    if (value) setenv(name, value, 1); else unsetenv(name);
+#endif
+}
+
 int main() {
     std::printf("== test_command_provenance ==\n");
 #ifdef _WIN32
-    _putenv_s("PROSPER_UDPROV", "1");
+    _putenv_s("PROSPER_UDPROV", "");
+    _putenv_s("PROSPER_GPU_CAPTURE_RESOURCE_PROVENANCE", "0:ps:32");
 #else
-    setenv("PROSPER_UDPROV", "1", 1);
+    unsetenv("PROSPER_UDPROV");
+    setenv("PROSPER_GPU_CAPTURE_RESOURCE_PROVENANCE", "0:ps:32", 1);
 #endif
-    CHECK(udprov_enabled(), "PROSPER_UDPROV positive control is armed");
+    const bool selector_only_provenance =
+        std::getenv("PROSPER_UDPROV") == nullptr && udprov_enabled();
+    CHECK(selector_only_provenance,
+          "resource-provenance selector alone arms SH write provenance");
+    if (!selector_only_provenance) {
+        std::printf("== FAIL ==\n");
+        return 1;
+    }
 
     register_builtin_hle();
     auto setsh = Hle::lookup("-HOOCn0JY48");       // sceAgcDcbSetShRegistersIndirect
@@ -187,6 +211,175 @@ int main() {
                   q2_snapshot->sh.count(kUser + 0) == 0,
               "q2 state does not inherit q1/q3 graphics registers");
     }
+
+    // #1853 cross-thread positive control. A Dcb submitter writes the raw PS V#; only after an
+    // explicit hand-off does a distinct DcbFinal submitter emit the draw. The selected capture must
+    // attach the raw input to the draw's immutable semantic snapshot and name q1 as the last writer,
+    // not the host thread/q3 path that happened to issue the draw.
+    std::array<uint8_t, 32> cross_thread_bytes{};
+    const uint64_t cross_thread_addr =
+        reinterpret_cast<uint64_t>(cross_thread_bytes.data());
+    const std::array<uint32_t, 4> cross_thread_vsharp = {
+        static_cast<uint32_t>(cross_thread_addr),
+        static_cast<uint32_t>((cross_thread_addr >> 32u) & 0xffffu) | (16u << 16u),
+        1u,
+        (22u << 12u) | 0xFACu,
+    };
+    uint32_t writer_words[64]{};
+    Dcb writer_dcb = make_dcb(writer_words, std::size(writer_words));
+    for (uint32_t i = 0; i < cross_thread_vsharp.size(); ++i)
+        setsh_direct(reinterpret_cast<uint64_t>(&writer_dcb),
+                     pack_reg(P::SPI_SHADER_USER_DATA_PS_0 + i,
+                              cross_thread_vsharp[i]),
+                     0, 0, 0, 0);
+    uint32_t consumer_words[64]{};
+    Dcb consumer_dcb = make_dcb(consumer_words, std::size(consumer_words));
+    draw(reinterpret_cast<uint64_t>(&consumer_dcb), 3, 0, 0, 0, 0);
+
+    // Defect-shaped mutation: leave the selector and capture path armed, but disable the collector
+    // only for this fixture.  Earlier .at()-based provenance checks therefore remain safe, and the
+    // exact selected-witness assertion below—not the activation predicate—must be the named red.
+    const bool mutate_collection =
+        std::getenv("PROSPER_TEST_MUTATE_RESOURCE_INPUT_COLLECTION") != nullptr;
+    if (mutate_collection)
+        set_test_env("PROSPER_TEST_DISABLE_UDPROV_COLLECTION", "1");
+
+    GpuState cross_thread_state;
+    std::mutex handoff_mutex;
+    std::condition_variable handoff_cv;
+    bool writer_finished = false;
+    std::thread writer_thread([&] {
+        prosper_gpu_set_fold_origin(1);
+        run_command_buffer(writer_words, used_dwords(writer_dcb), cross_thread_state);
+        {
+            std::lock_guard<std::mutex> lock(handoff_mutex);
+            writer_finished = true;
+        }
+        handoff_cv.notify_one();
+    });
+    std::thread draw_thread([&] {
+        std::unique_lock<std::mutex> lock(handoff_mutex);
+        handoff_cv.wait(lock, [&] { return writer_finished; });
+        lock.unlock();
+        prosper_gpu_set_fold_origin(3);
+        run_command_buffer(consumer_words, used_dwords(consumer_dcb), cross_thread_state);
+    });
+    writer_thread.join();
+    draw_thread.join();
+
+    uint32_t overwrite_words[64]{};
+    Dcb overwrite_dcb = make_dcb(overwrite_words, std::size(overwrite_words));
+    for (uint32_t i = 0; i < cross_thread_vsharp.size(); ++i)
+        setsh_direct(reinterpret_cast<uint64_t>(&overwrite_dcb),
+                     pack_reg(P::SPI_SHADER_USER_DATA_PS_0 + i,
+                              cross_thread_vsharp[i] ^ 0x01010101u),
+                     0, 0, 0, 0);
+    prosper_gpu_set_fold_origin(2);
+    run_command_buffer(overwrite_words, used_dwords(overwrite_dcb), cross_thread_state);
+    const bool folded_end_was_overwritten =
+        cross_thread_state.sh.at(P::SPI_SHADER_USER_DATA_PS_0) !=
+            cross_thread_vsharp[0];
+
+    DrawItem cross_thread_draw;
+    cross_thread_draw.draw_index = 0;
+    if (!cross_thread_state.draws.empty())
+        cross_thread_draw.command_order = cross_thread_state.draws[0].command_order;
+    auto cross_thread_table = std::make_shared<ShaderResourceTable>();
+    ShaderResource cross_thread_resource;
+    cross_thread_resource.cls = ResourceClass::ConstantBuffer;
+    cross_thread_resource.format = DataFormat::Float32;
+    cross_thread_resource.num_components = 1;
+    cross_thread_resource.binding = 32;
+    cross_thread_resource.gpu_addr = cross_thread_addr;
+    cross_thread_resource.size = 16;
+    cross_thread_resource.stride = 16;
+    cross_thread_resource.sgpr_base = 0;
+    cross_thread_resource.direct_vsharp_sh_register_base =
+        P::SPI_SHADER_USER_DATA_PS_0;
+    cross_thread_draw.prt = cross_thread_table;
+    cross_thread_table->resources.push_back(cross_thread_resource);
+    PendingGpuCapture cross_thread_pending;
+    cross_thread_pending.resource_provenance_armed = true;
+    cross_thread_pending.resource_provenance_selector = {
+        0, ShaderProgramStage::Fragment, 32};
+    snapshot_pending_gpu_capture_draw_resource(
+        &cross_thread_pending, cross_thread_draw, {}, &cross_thread_state);
+
+    const auto& cross_thread_witness = cross_thread_pending.resource_provenance;
+    bool all_q1_direct_before_draw = cross_thread_witness.input_write_provenance_mask == 0x0f;
+    uint64_t writer_fold = 0;
+    for (uint32_t i = 0; all_q1_direct_before_draw && i < 4; ++i) {
+        const uint64_t write = cross_thread_witness.input_last_writes[i];
+        const Source source = unpack_source(cross_thread_witness.input_write_sources[i]);
+        if (!i) writer_fold = source.fold;
+        all_q1_direct_before_draw =
+            (write & GpuState::kProvIndirect) == 0 &&
+            (write & ~GpuState::kProvIndirect) < cross_thread_draw.command_order &&
+            source.origin == 1 && source.jump_depth == 0 && source.fold == writer_fold;
+    }
+    CHECK(cross_thread_state.draws.size() == 1 &&
+              cross_thread_witness.input_mode ==
+                  GpuCaptureResourceInputMode::DirectVSharp &&
+              cross_thread_witness.input_dwords == cross_thread_vsharp &&
+              gpu_capture_resource_input_verdict(cross_thread_witness,
+                                                 cross_thread_resource) ==
+                  GpuCaptureResourceInputVerdict::FullMatch &&
+              writer_fold != 0 && all_q1_direct_before_draw &&
+              folded_end_was_overwritten,
+          "selected draw uses immutable pre-overwrite q1 V# state and full-match identity");
+
+    if (mutate_collection) {
+        set_test_env("PROSPER_TEST_DISABLE_UDPROV_COLLECTION", nullptr);
+        prosper_gpu_set_fold_origin(0);
+        std::printf("== %s ==\n", fails ? "FAIL" : "PASS");
+        return fails ? 1 : 0;
+    }
+
+    DrawItem mismatched_draw = cross_thread_draw;
+    mismatched_draw.prt = std::make_shared<ShaderResourceTable>(*cross_thread_table);
+    auto& mismatched_resource = mismatched_draw.prt->resources[0];
+    mismatched_resource.gpu_addr += 16;
+    PendingGpuCapture mismatched_pending;
+    mismatched_pending.resource_provenance_armed = true;
+    mismatched_pending.resource_provenance_selector = {
+        0, ShaderProgramStage::Fragment, 32};
+    snapshot_pending_gpu_capture_draw_resource(
+        &mismatched_pending, mismatched_draw, {}, &cross_thread_state);
+    CHECK(mismatched_pending.resource_provenance.input_dwords ==
+              cross_thread_vsharp &&
+              gpu_capture_resource_input_verdict(
+                  mismatched_pending.resource_provenance,
+                  mismatched_resource) ==
+                  GpuCaptureResourceInputVerdict::Mismatch,
+          "raw SH origin is selected independently when normalized output mismatches");
+
+    GpuState missing_provenance_state = cross_thread_state;
+    if (!missing_provenance_state.draws.empty() &&
+        missing_provenance_state.draws[0].state) {
+        auto incomplete = std::make_shared<GpuState>(
+            *missing_provenance_state.draws[0].state);
+        incomplete->sh_prov.erase(P::SPI_SHADER_USER_DATA_PS_0 + 3);
+        missing_provenance_state.draws[0].state = std::move(incomplete);
+    }
+    PendingGpuCapture missing_provenance_pending;
+    missing_provenance_pending.resource_provenance_armed = true;
+    missing_provenance_pending.resource_provenance_selector = {
+        0, ShaderProgramStage::Fragment, 32};
+    snapshot_pending_gpu_capture_draw_resource(
+        &missing_provenance_pending, cross_thread_draw, {},
+        &missing_provenance_state);
+    const auto& missing_provenance =
+        missing_provenance_pending.resource_provenance;
+    CHECK(missing_provenance.input_mode ==
+              GpuCaptureResourceInputMode::Unavailable &&
+              missing_provenance.input_unavailable_reason ==
+                  GpuCaptureResourceInputUnavailableReason::MissingWriteProvenance &&
+              missing_provenance.input_write_provenance_mask == 0 &&
+              missing_provenance.input_sh_register_base == 0xFFFFFFFFu &&
+              std::all_of(missing_provenance.input_dwords.begin(),
+                          missing_provenance.input_dwords.end(),
+                          [](uint32_t value) { return value == 0; }),
+          "partial SH provenance stays explicitly unavailable and inert");
 
     prosper_gpu_set_fold_origin(0);
     std::printf("== %s ==\n", fails ? "FAIL" : "PASS");

--- a/prosper/tests/test_gpu_capture.cpp
+++ b/prosper/tests/test_gpu_capture.cpp
@@ -11,6 +11,9 @@
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <iterator>
+#include <string>
+#include <utility>
 #include "test_scratch.h"
 
 using namespace prosper::gpu;
@@ -76,8 +79,20 @@ static void set_test_env(const char* name, const char* value) {
 #endif
 }
 
-int main() {
+static std::string shell_quote(const std::filesystem::path& path) {
+    return "\"" + path.string() + "\"";
+}
+
+static std::string read_text_file(const std::filesystem::path& path) {
+    std::ifstream stream(path, std::ios::binary);
+    return {std::istreambuf_iterator<char>(stream), std::istreambuf_iterator<char>()};
+}
+
+int main(int argc, char** argv) {
     std::printf("== test_gpu_capture ==\n");
+    const char* inspect_tool = argc == 3 &&
+            std::strcmp(argv[1], "--inspect-resource-input") == 0
+        ? argv[2] : nullptr;
     const char* original_save0_value = std::getenv(kGpuCaptureSave0Env);
     const bool had_original_save0 = original_save0_value != nullptr;
     const std::string original_save0 = original_save0_value ? original_save0_value : "";
@@ -262,6 +277,8 @@ int main() {
     provenance_resource.size = provenance_memory.size();
     provenance_resource.stride = 16;
     provenance_resource.sgpr_base = 0;
+    provenance_resource.direct_vsharp_sh_register_base =
+        P::SPI_SHADER_USER_DATA_PS_0;
     provenance_table->resources = {provenance_resource};
     DrawItem provenance_draw = draw;
     provenance_draw.draw_index = 77;
@@ -285,6 +302,23 @@ int main() {
         "prosper_gpu_capture_resource_provenance.prgcap";
     auto provenance_pending = make_provenance_pending(provenance_path);
     snapshot_pending_gpu_capture_draw_resource(provenance_pending.get(), provenance_draw);
+    auto& input_witness = provenance_pending->resource_provenance;
+    input_witness.input_mode = GpuCaptureResourceInputMode::DirectVSharp;
+    input_witness.input_unavailable_reason =
+        GpuCaptureResourceInputUnavailableReason::None;
+    input_witness.input_write_provenance_mask = 0x0f;
+    input_witness.input_sh_register_base = P::SPI_SHADER_USER_DATA_PS_0;
+    const uint64_t provenance_addr = reinterpret_cast<uint64_t>(provenance_memory.data());
+    input_witness.input_dwords = {
+        static_cast<uint32_t>(provenance_addr),
+        static_cast<uint32_t>((provenance_addr >> 32u) & 0xffffu) | (16u << 16u),
+        1u,
+        (22u << 12u) | 0xFACu,
+    };
+    for (uint32_t i = 0; i < 4; ++i) {
+        input_witness.input_last_writes[i] = 700u + i;
+        input_witness.input_write_sources[i] = GpuState::pack_prov_src(1, 0, 91);
+    }
     for (size_t i = 0; i < provenance_memory.size(); ++i)
         provenance_memory[i] = static_cast<uint8_t>(0xa0 + i);
     const std::array<uint8_t, 16> post_bytes = provenance_memory;
@@ -322,8 +356,171 @@ int main() {
               provenance->resource_class == ResourceClass::ConstantBuffer &&
               provenance->guest_addr == reinterpret_cast<uint64_t>(provenance_memory.data()) &&
               provenance->requested_bytes == provenance_memory.size() &&
-              provenance->srt_offset == 0xFFFFFFFFu && provenance->sgpr_base == 0,
-          "resource provenance retains auditable semantic and decoded descriptor identity");
+              provenance->srt_offset == 0xFFFFFFFFu && provenance->sgpr_base == 0 &&
+              provenance->input_sh_register_base == P::SPI_SHADER_USER_DATA_PS_0 &&
+              provenance->input_write_provenance_mask == 0x0f &&
+              gpu_capture_resource_input_verdict(*provenance, provenance_resource) ==
+                  GpuCaptureResourceInputVerdict::FullMatch,
+          "resource provenance round-trips an independently decodable direct-V# input witness");
+
+    GpuCaptureFile mutated_input = provenance_loaded;
+    std::vector<uint8_t> mismatch_bytes;
+    GpuCaptureFile mismatch_loaded;
+    mutated_input.resource_provenance[0].input_dwords[0] ^= 0x100u;
+    CHECK(serialize_gpu_capture(mutated_input, mismatch_bytes, error) &&
+              deserialize_gpu_capture(mismatch_bytes, mismatch_loaded, error) &&
+              gpu_capture_resource_input_verdict(
+                  mismatch_loaded.resource_provenance[0], provenance_resource) ==
+                  GpuCaptureResourceInputVerdict::Mismatch,
+          "a raw address/output disagreement round-trips as an explicit mismatch");
+
+    GpuCaptureResourceProvenance zero_record = *provenance;
+    zero_record.input_dwords[2] = 0;
+    zero_record.input_unavailable_reason =
+        GpuCaptureResourceInputUnavailableReason::RawSizeUnavailable;
+    ShaderResource compatibility_sized = provenance_resource;
+    compatibility_sized.size = compatibility_sized.stride * 4u;
+    CHECK(gpu_capture_resource_input_verdict(zero_record, compatibility_sized) ==
+              GpuCaptureResourceInputVerdict::Unavailable,
+          "zero-record V# does not manufacture the PS compatibility allocation as raw proof");
+    ShaderResource zero_record_wrong_format = compatibility_sized;
+    zero_record_wrong_format.format = DataFormat::Uint32;
+    CHECK(gpu_capture_resource_input_verdict(zero_record, zero_record_wrong_format) ==
+              GpuCaptureResourceInputVerdict::Mismatch,
+          "zero-record V# still rejects a normalized format disagreement");
+
+    GpuCaptureResourceProvenance unknown_format = *provenance;
+    unknown_format.input_dwords[3] &= ~(0x7fu << 12u);
+    unknown_format.input_unavailable_reason =
+        GpuCaptureResourceInputUnavailableReason::RawFormatUnavailable;
+    ShaderResource shader_formatted = provenance_resource;
+    shader_formatted.format = DataFormat::Float32;
+    shader_formatted.num_components = 4;
+    CHECK(gpu_capture_resource_input_verdict(unknown_format, shader_formatted) ==
+              GpuCaptureResourceInputVerdict::Unavailable,
+          "FORMAT=INVALID V# does not manufacture shader-derived Float32x4 as raw proof");
+    ShaderResource unknown_format_wrong_size = shader_formatted;
+    unknown_format_wrong_size.size += unknown_format_wrong_size.stride;
+    CHECK(gpu_capture_resource_input_verdict(unknown_format, unknown_format_wrong_size) ==
+              GpuCaptureResourceInputVerdict::Mismatch,
+          "FORMAT=INVALID V# still rejects a normalized byte-size disagreement");
+
+    // The fixed v46 tail is 4 bytes of count plus 100 bytes per selected witness.  Mutate the
+    // serialized tail, rather than merely constructing invalid in-memory objects, so the reader's
+    // hostile-input boundary proves the exact pack contract it accepts.
+    std::vector<uint8_t> valid_v46_bytes;
+    CHECK(serialize_gpu_capture(provenance_loaded, valid_v46_bytes, error) &&
+              valid_v46_bytes.size() >= 104u,
+          "v46 resource input witness has a complete validation tail");
+    const size_t v46_tail_base = valid_v46_bytes.size() >= 104u
+        ? valid_v46_bytes.size() - 104u : 0u;
+    auto malformed_tail_rejected = [&](size_t offset,
+                                       std::initializer_list<uint8_t> replacement,
+                                       const char* wanted_error) {
+        if (valid_v46_bytes.size() < 104u ||
+            offset > valid_v46_bytes.size() - replacement.size())
+            return false;
+        std::vector<uint8_t> bytes = valid_v46_bytes;
+        std::copy(replacement.begin(), replacement.end(), bytes.begin() + offset);
+        GpuCaptureFile rejected;
+        error.clear();
+        return !deserialize_gpu_capture(bytes, rejected, error) && error == wanted_error;
+    };
+    constexpr size_t kV46BaseOffset = 20u;
+    constexpr size_t kV46SourcesOffset = 72u;
+    CHECK(malformed_tail_rejected(
+              v46_tail_base + kV46SourcesOffset,
+              {0, 0, 0, 0, 0, 0, 0, 0},
+              "invalid resource input write source"),
+          "v46 tail rejects a zero source/fold provenance word");
+    CHECK(malformed_tail_rejected(
+              v46_tail_base + kV46SourcesOffset,
+              {0xff, 0, 91, 0, 0, 0, 0, 0},
+              "invalid resource input write source"),
+          "v46 tail rejects an out-of-contract queue origin");
+    CHECK(malformed_tail_rejected(
+              v46_tail_base + kV46SourcesOffset,
+              {1, 9, 91, 0, 0, 0, 0, 0},
+              "invalid resource input write source"),
+          "v46 tail rejects a Jump depth beyond the fold recursion bound");
+    CHECK(malformed_tail_rejected(
+              v46_tail_base + kV46SourcesOffset,
+              {1, 0, 91, 0, 0, 0, 0, 0x80},
+              "invalid resource input write source"),
+          "v46 tail rejects high bits outside pack_prov_src");
+    CHECK(malformed_tail_rejected(
+              v46_tail_base + kV46BaseOffset,
+              {0xfd, 0xff, 0, 0},
+              "invalid direct resource input witness"),
+          "v46 tail rejects a four-dword SH origin outside the bounded register file");
+
+    if (inspect_tool) {
+        GpuCaptureFile inspect_mismatch = provenance_loaded;
+        inspect_mismatch.draws[0].prt.resources[0].resource.format = DataFormat::Uint32;
+        const auto inspect_mismatch_path = prosper_test::test_scratch_path(
+            "resource-input-inspect-mismatch.prgcap");
+        GpuCaptureFile inspect_unavailable = provenance_loaded;
+        inspect_unavailable.resource_provenance[0] = zero_record;
+        const auto inspect_unavailable_path = prosper_test::test_scratch_path(
+            "resource-input-inspect-unavailable.prgcap");
+        CHECK(write_gpu_capture(inspect_mismatch_path.string(), inspect_mismatch, error) &&
+                  write_gpu_capture(inspect_unavailable_path.string(), inspect_unavailable, error),
+              "gpu_replay resource-input inspect fixtures serialize");
+
+        const auto run_inspect = [&](const std::filesystem::path& capture_path,
+                                     const char* log_name) {
+            const auto log_path = prosper_test::test_scratch_path(log_name);
+            const std::string command = shell_quote(inspect_tool) + " --inspect-only " +
+                shell_quote(capture_path) + " > " + shell_quote(log_path) + " 2>&1";
+            const int status = std::system(command.c_str());
+            return std::pair<int, std::string>{status, read_text_file(log_path)};
+        };
+        const auto full = run_inspect(provenance_path, "resource-input-inspect-full.log");
+        const auto mismatch = run_inspect(
+            inspect_mismatch_path, "resource-input-inspect-mismatch.log");
+        const auto unavailable = run_inspect(
+            inspect_unavailable_path, "resource-input-inspect-unavailable.log");
+        CHECK(full.first == 0 &&
+                  full.second.find(
+                      "resource-input draw=77 stage=ps binding=32 raw-identity=full-match") !=
+                      std::string::npos &&
+                  full.second.find("writes=d700/q1,f91,j0") != std::string::npos,
+              "gpu_replay --inspect-only prints the full-match raw-input witness");
+        CHECK(mismatch.first == 0 &&
+                  mismatch.second.find(
+                      "resource-input draw=77 stage=ps binding=32 raw-identity=mismatch") !=
+                      std::string::npos,
+              "gpu_replay --inspect-only prints a raw-input mismatch");
+        CHECK(unavailable.first == 0 &&
+                  unavailable.second.find(
+                      "resource-input draw=77 stage=ps binding=32 raw-identity=unavailable "
+                      "reason=raw-size-not-architecturally-available") != std::string::npos,
+              "gpu_replay --inspect-only prints partial raw-input unavailability");
+        std::printf("== %s ==\n", fails ? "FAIL" : "PASS");
+        return fails ? 1 : 0;
+    }
+
+    std::vector<uint8_t> v45_provenance_bytes;
+    GpuCaptureFile v45_provenance_loaded;
+    CHECK(serialize_gpu_capture(provenance_loaded, v45_provenance_bytes, error) &&
+              v45_provenance_bytes.size() >=
+                  4u + 100u * provenance_loaded.resource_provenance.size(),
+          "v46 resource input tail is removable for a v45 compatibility fixture");
+    if (v45_provenance_bytes.size() >=
+            4u + 100u * provenance_loaded.resource_provenance.size()) {
+        v45_provenance_bytes.resize(
+            v45_provenance_bytes.size() -
+            (4u + 100u * provenance_loaded.resource_provenance.size()));
+        v45_provenance_bytes[8] = 45;
+        CHECK(deserialize_gpu_capture(v45_provenance_bytes, v45_provenance_loaded, error) &&
+                  v45_provenance_loaded.format_version == 45 &&
+                  v45_provenance_loaded.resource_provenance.size() == 1 &&
+                  v45_provenance_loaded.resource_provenance[0].input_mode ==
+                      GpuCaptureResourceInputMode::Unavailable &&
+                  v45_provenance_loaded.resource_provenance[0].input_unavailable_reason ==
+                      GpuCaptureResourceInputUnavailableReason::CapturePredatesWitness,
+              "v45 selected-resource capture reads with explicit raw-input unavailability");
+    }
 
     size_t default_reader_calls = 0;
     PendingGpuCapture default_pending;
@@ -357,8 +554,49 @@ int main() {
               partial_loaded.blobs[
                   partial_loaded.resource_provenance[0].post_blob_index].bytes_read >=
                   partial_loaded.resource_provenance[0].post_blob_offset +
-                      provenance_memory.size(),
-          "partial realization read remains distinguishable from guest-authored zero bytes");
+                      provenance_memory.size() &&
+              partial_loaded.resource_provenance[0].input_mode ==
+                  GpuCaptureResourceInputMode::Unavailable &&
+              partial_loaded.resource_provenance[0].input_unavailable_reason ==
+                  GpuCaptureResourceInputUnavailableReason::NoSemanticState,
+          "partial read and missing semantic input state remain independently fail-visible");
+
+    DrawItem srt_draw = provenance_draw;
+    srt_draw.prt = std::make_shared<ShaderResourceTable>();
+    ShaderResource srt_resource = provenance_resource;
+    srt_resource.srt_offset = 0;
+    srt_resource.sgpr_base = 0xFFFFFFFFu;
+    srt_resource.direct_vsharp_sh_register_base =
+        ShaderResource::kDirectVSharpOriginUnavailable;
+    srt_draw.prt->resources = {srt_resource};
+    PendingGpuCapture srt_pending;
+    srt_pending.resource_provenance_armed = true;
+    srt_pending.resource_provenance_selector = {
+        77, ShaderProgramStage::Fragment, 32};
+    snapshot_pending_gpu_capture_draw_resource(&srt_pending, srt_draw);
+    CHECK(srt_pending.resource_provenance.input_mode ==
+              GpuCaptureResourceInputMode::Unavailable &&
+              srt_pending.resource_provenance.input_unavailable_reason ==
+                  GpuCaptureResourceInputUnavailableReason::NonDirectResource,
+          "SRT-loaded V# remains explicitly unavailable to the direct-SH witness");
+
+    DrawItem ambiguous_origin_draw = provenance_draw;
+    ambiguous_origin_draw.prt = std::make_shared<ShaderResourceTable>();
+    ShaderResource ambiguous_origin_resource = provenance_resource;
+    ambiguous_origin_resource.direct_vsharp_sh_register_base =
+        ShaderResource::kDirectVSharpOriginAmbiguous;
+    ambiguous_origin_draw.prt->resources = {ambiguous_origin_resource};
+    PendingGpuCapture ambiguous_origin_pending;
+    ambiguous_origin_pending.resource_provenance_armed = true;
+    ambiguous_origin_pending.resource_provenance_selector = {
+        77, ShaderProgramStage::Fragment, 32};
+    snapshot_pending_gpu_capture_draw_resource(
+        &ambiguous_origin_pending, ambiguous_origin_draw);
+    CHECK(ambiguous_origin_pending.resource_provenance.input_mode ==
+              GpuCaptureResourceInputMode::Unavailable &&
+              ambiguous_origin_pending.resource_provenance.input_unavailable_reason ==
+                  GpuCaptureResourceInputUnavailableReason::AmbiguousRawOrigin,
+          "shader-derived or ambiguous V# origin remains explicitly unavailable");
 
     auto zero_match_pending = make_provenance_pending(
         prosper_test::test_scratch_dir() / "prosper_gpu_capture_resource_provenance_zero.prgcap");
@@ -607,6 +845,11 @@ int main() {
         return 4 + 73 * f.resource_provenance.size();
     };
 
+    // v46: count plus one 100-byte raw input/provenance witness per selected v45 record.
+    auto v46_tail = [](const GpuCaptureFile& f) -> size_t {
+        return 4 + 100 * f.resource_provenance.size();
+    };
+
     // v25 (#1240): byte length of the trailing resolve-state block.
     auto v25_tail = [](const GpuCaptureFile& f) -> size_t {
         size_t present_failures = 0;
@@ -638,6 +881,7 @@ int main() {
               v16_scissor_bytes.size() >= 25,
           "v17 capture serializes effective guest scissor state");
     if (v16_scissor_bytes.size() >= 25) {
+        v16_scissor_bytes.resize(v16_scissor_bytes.size() - v46_tail(v16_scissor_source));
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - v45_tail(v16_scissor_source));
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - v44_tail(v16_scissor_source));
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - v43_tail(v16_scissor_source));
@@ -755,7 +999,7 @@ int main() {
         deserialize_gpu_capture(msaa_bytes, msaa_loaded, error);
     if (!msaa_deserialized) std::printf("  [diag] MSAA capture deserialization: %s\n", error.c_str());
     CHECK(msaa_deserialized &&
-              msaa_loaded.format_version == 45 &&
+              msaa_loaded.format_version == 46 &&
               msaa_loaded.draws[0].vrt.resources[0].resource.sample_count == 4 &&
               msaa_loaded.blobs.size() == 2 &&
               msaa_loaded.blobs[1].bytes.size() == 32768u &&
@@ -782,7 +1026,7 @@ int main() {
     std::vector<uint8_t> mismatched_msaa_metadata = msaa_bytes;
     const uint32_t two_samples = 2;
     std::memcpy(mismatched_msaa_metadata.data() + mismatched_msaa_metadata.size() -
-                    v45_tail(msaa_capture) - 4u,
+                    v46_tail(msaa_capture) - v45_tail(msaa_capture) - 4u,
                 &two_samples, sizeof(two_samples));
     GpuCaptureFile mismatched_msaa_loaded;
     CHECK(!deserialize_gpu_capture(
@@ -805,6 +1049,7 @@ int main() {
     std::vector<uint8_t> v43_msaa_bytes;
     CHECK(serialize_gpu_capture(v43_msaa_source, v43_msaa_bytes, error),
           "current writer prepares an uncompressed v43 MSAA compatibility fixture");
+    v43_msaa_bytes.resize(v43_msaa_bytes.size() - v46_tail(v43_msaa_source));
     v43_msaa_bytes.resize(v43_msaa_bytes.size() - v45_tail(v43_msaa_source));
     v43_msaa_bytes.resize(v43_msaa_bytes.size() - v44_tail(v43_msaa_source));
     v43_msaa_bytes[8] = 43;
@@ -861,7 +1106,7 @@ int main() {
     };
     GpuCaptureFile video_capture;
     CHECK(capture_draw_items({video_draw}, meta, video_reader, video_capture, error) &&
-              video_capture.format_version == 45 && video_capture.blobs.size() == 1 &&
+              video_capture.format_version == 46 && video_capture.blobs.size() == 1 &&
               video_capture.blobs[0].bytes.size() == video_memory.size() &&
               video_capture.draws[0].prt.resources[0].captured_size == video_memory.size() &&
               video_capture.draws[0].prt.resources[0].resource.linear_row_pitch_bytes == 2048,
@@ -871,7 +1116,7 @@ int main() {
     GpuReplayFrame video_replay;
     CHECK(serialize_gpu_capture(video_capture, video_capture_bytes, error) &&
               deserialize_gpu_capture(video_capture_bytes, video_loaded, error) &&
-              video_loaded.format_version == 45 &&
+              video_loaded.format_version == 46 &&
               video_loaded.draws[0].prt.resources[0].captured_size == video_memory.size() &&
               video_loaded.draws[0].prt.resources[0].resource.linear_row_pitch_bytes == 2048 &&
               materialize_gpu_replay(video_loaded, video_replay, error) &&
@@ -894,7 +1139,7 @@ int main() {
     GpuReplayFrame upgraded_video_replay;
     CHECK(serialize_gpu_capture(legacy_video, upgraded_video_bytes, error) &&
               deserialize_gpu_capture(upgraded_video_bytes, upgraded_video, error) &&
-              upgraded_video.format_version == 45 &&
+              upgraded_video.format_version == 46 &&
               upgraded_video.draws[0].prt.resources[0].captured_size == video_chroma.size &&
               upgraded_video.draws[0].prt.resources[0].resource.linear_row_pitch_bytes == 2048 &&
               materialize_gpu_replay(upgraded_video, upgraded_video_replay, error) &&
@@ -976,7 +1221,7 @@ int main() {
           "Plucky RGBA16 32-cubed S3 capture uses its four true 3D macroblocks");
     CHECK(serialize_gpu_capture(array_layout_capture, array_layout_bytes, error) &&
               deserialize_gpu_capture(array_layout_bytes, array_layout_loaded, error) &&
-              array_layout_loaded.format_version == 45 &&
+              array_layout_loaded.format_version == 46 &&
               array_layout_loaded.draws[0].vrt.resources[0].resource.layer_stride_bytes == 720896u &&
               array_layout_loaded.draws[0].vrt.resources[0].resource.layer_mip_offset_bytes == 65536u,
           "v32 capture round-trips thin-array slice stride and selected-mip offset");
@@ -1075,6 +1320,7 @@ int main() {
           "writer rejects an out-of-bounds DCC metadata reference");
     CHECK(serialize_gpu_capture(volume_capture, volume_bytes, error),
           "recreated valid v12 DCC bytes after malformed-reference check");
+    volume_bytes.resize(volume_bytes.size() - v46_tail(volume_capture));
     volume_bytes.resize(volume_bytes.size() - v45_tail(volume_capture));
     volume_bytes.resize(volume_bytes.size() - v44_tail(volume_capture));
     volume_bytes.resize(volume_bytes.size() - v43_tail(volume_capture));
@@ -1178,6 +1424,7 @@ int main() {
     CHECK(serialize_gpu_capture(pre_v31_source, v20_bytes, error) && v20_bytes.size() >= 21,
           "v21 capture serializes the logic-op extension");
     if (v20_bytes.size() >= 21) {
+        v20_bytes.resize(v20_bytes.size() - v46_tail(pre_v31_source));
         v20_bytes.resize(v20_bytes.size() - v45_tail(pre_v31_source));
         v20_bytes.resize(v20_bytes.size() - v44_tail(pre_v31_source));
         v20_bytes.resize(v20_bytes.size() - v43_tail(pre_v31_source));
@@ -1256,6 +1503,7 @@ int main() {
         std::vector<uint8_t> v42_bytes;
         CHECK(serialize_gpu_capture(captured, v42_bytes, error),
               "v43 capture serializes before the color-state downgrade");
+        v42_bytes.resize(v42_bytes.size() - v46_tail(captured));
         v42_bytes.resize(v42_bytes.size() - v45_tail(captured));
         v42_bytes.resize(v42_bytes.size() - v44_tail(captured));
         v42_bytes.resize(v42_bytes.size() - v43_tail(captured));
@@ -1278,7 +1526,8 @@ int main() {
     std::vector<uint8_t> v24_resolve_bytes;
     GpuCaptureFile v24_resolve_loaded;
     CHECK(serialize_gpu_capture(pre_v31_source, v24_resolve_bytes, error) &&
-              v24_resolve_bytes.size() >= v45_tail(pre_v31_source) +
+              v24_resolve_bytes.size() >= v46_tail(pre_v31_source) +
+              v45_tail(pre_v31_source) +
               v44_tail(pre_v31_source) +
               v43_tail(pre_v31_source) + v42_tail(pre_v31_source) +
               v41_tail(pre_v31_source) +
@@ -1293,7 +1542,8 @@ int main() {
               v27_tail(pre_v31_source) + v26_tail(pre_v31_source) +
               v25_tail(pre_v31_source),
           "v25 capture exposes a removable trailing resolve-state block");
-    if (v24_resolve_bytes.size() >= v45_tail(pre_v31_source) +
+    if (v24_resolve_bytes.size() >= v46_tail(pre_v31_source) +
+            v45_tail(pre_v31_source) +
             v44_tail(pre_v31_source) +
             v43_tail(pre_v31_source) + v42_tail(pre_v31_source) +
             v41_tail(pre_v31_source) +
@@ -1307,6 +1557,7 @@ int main() {
             v29_tail(pre_v31_source) + v28_tail(pre_v31_source) +
             v27_tail(pre_v31_source) + v26_tail(pre_v31_source) +
             v25_tail(pre_v31_source)) {
+        v24_resolve_bytes.resize(v24_resolve_bytes.size() - v46_tail(pre_v31_source));
         v24_resolve_bytes.resize(v24_resolve_bytes.size() - v45_tail(pre_v31_source));
         v24_resolve_bytes.resize(v24_resolve_bytes.size() - v44_tail(pre_v31_source));
         v24_resolve_bytes.resize(v24_resolve_bytes.size() - v43_tail(pre_v31_source));
@@ -1406,9 +1657,10 @@ int main() {
               v37_compatible_bytes.size() >= 12,
           "current capture prepares the layout-compatible v37 fixture");
     if (v37_compatible_bytes.size() >=
-        v45_tail(captured) + v44_tail(captured) + v43_tail(captured) +
+        v46_tail(captured) + v45_tail(captured) + v44_tail(captured) + v43_tail(captured) +
             v42_tail(captured) + v41_tail(captured) +
             v40_tail(captured) + v39_tail(captured)) {
+        v37_compatible_bytes.resize(v37_compatible_bytes.size() - v46_tail(captured));
         v37_compatible_bytes.resize(v37_compatible_bytes.size() - v45_tail(captured));
         v37_compatible_bytes.resize(v37_compatible_bytes.size() - v44_tail(captured));
         v37_compatible_bytes.resize(v37_compatible_bytes.size() - v43_tail(captured));
@@ -1601,7 +1853,8 @@ int main() {
     v36_compute_source.raw_shader_versions.clear();
     CHECK(serialize_gpu_capture(v36_compute_source, v36_compute_bytes, error) &&
               v36_compute_bytes.size() >=
-                  v45_tail(v36_compute_source) + v44_tail(v36_compute_source) +
+                  v46_tail(v36_compute_source) + v45_tail(v36_compute_source) +
+                      v44_tail(v36_compute_source) +
                       v43_tail(v36_compute_source) +
                       v42_tail(v36_compute_source) + v41_tail(v36_compute_source) +
                       v40_tail(v36_compute_source) +
@@ -1609,12 +1862,14 @@ int main() {
                       v37_tail(v36_compute_source),
           "v37 capture exposes a removable compute subgroup-contract tail");
     if (v36_compute_bytes.size() >=
-        v45_tail(v36_compute_source) + v44_tail(v36_compute_source) +
+        v46_tail(v36_compute_source) + v45_tail(v36_compute_source) +
+            v44_tail(v36_compute_source) +
             v43_tail(v36_compute_source) +
             v42_tail(v36_compute_source) + v41_tail(v36_compute_source) +
             v40_tail(v36_compute_source) +
             v39_tail(v36_compute_source) +
             v37_tail(v36_compute_source)) {
+        v36_compute_bytes.resize(v36_compute_bytes.size() - v46_tail(v36_compute_source));
         v36_compute_bytes.resize(v36_compute_bytes.size() - v45_tail(v36_compute_source));
         v36_compute_bytes.resize(v36_compute_bytes.size() - v44_tail(v36_compute_source));
         v36_compute_bytes.resize(v36_compute_bytes.size() - v43_tail(v36_compute_source));
@@ -1823,7 +2078,7 @@ int main() {
     GpuCaptureFile failed_compute_loaded;
     CHECK(serialize_gpu_capture(failed_compute_capture, failed_compute_bytes, error) &&
               deserialize_gpu_capture(failed_compute_bytes, failed_compute_loaded, error) &&
-              failed_compute_loaded.format_version == 45 &&
+              failed_compute_loaded.format_version == 46 &&
               failed_compute_loaded.failure_diagnostics[0].compute_launch.threads_x == 37 &&
               failed_compute_loaded.failure_diagnostics[0].stages[0]
                       .recompile_config.user_sgprs ==
@@ -1836,7 +2091,8 @@ int main() {
 
     std::vector<uint8_t> v41_failed_compute_bytes = failed_compute_bytes;
     v41_failed_compute_bytes.resize(
-        v41_failed_compute_bytes.size() - v45_tail(failed_compute_capture) -
+        v41_failed_compute_bytes.size() - v46_tail(failed_compute_capture) -
+            v45_tail(failed_compute_capture) -
             v44_tail(failed_compute_capture) -
             v43_tail(failed_compute_capture) -
             v42_tail(failed_compute_capture));
@@ -2055,7 +2311,7 @@ int main() {
                 loaded_failed_msaa = &resource;
         }
     }
-    CHECK(failed_loaded.format_version == 45 && loaded_shadow &&
+    CHECK(failed_loaded.format_version == 46 && loaded_shadow &&
           loaded_shadow->resource.depth == 4 &&
           loaded_shadow->resource.max_uncompressed_block_size == 2 &&
           loaded_shadow->resource.max_compressed_block_size == 1 &&
@@ -2093,7 +2349,8 @@ int main() {
         // Fragment is the final stage with resources, and its MSAA descriptor is the final resource,
         // so this is exactly its v44 sample-count record rather than a preceding extension field.
         std::memcpy(malformed_failed_sample_bytes.data() +
-                        malformed_failed_sample_bytes.size() - v45_tail(failed_capture) -
+                        malformed_failed_sample_bytes.size() - v46_tail(failed_capture) -
+                            v45_tail(failed_capture) -
                             sizeof(uint32_t),
                     &invalid_samples, sizeof(invalid_samples));
     }
@@ -2107,14 +2364,17 @@ int main() {
     GpuCaptureFile v40_failed_loaded;
     CHECK(serialize_gpu_capture(failed_capture, v40_failed_bytes, error) &&
               v40_failed_bytes.size() >=
-                  v45_tail(failed_capture) + v44_tail(failed_capture) +
+                  v46_tail(failed_capture) + v45_tail(failed_capture) +
+                      v44_tail(failed_capture) +
                       v43_tail(failed_capture) +
                       v42_tail(failed_capture) + v41_tail(failed_capture),
           "v41 failed-stage resource tail is removable for a v40 compatibility fixture");
     if (v40_failed_bytes.size() >=
-        v45_tail(failed_capture) + v44_tail(failed_capture) +
+        v46_tail(failed_capture) + v45_tail(failed_capture) +
+            v44_tail(failed_capture) +
             v43_tail(failed_capture) +
             v42_tail(failed_capture) + v41_tail(failed_capture)) {
+        v40_failed_bytes.resize(v40_failed_bytes.size() - v46_tail(failed_capture));
         v40_failed_bytes.resize(v40_failed_bytes.size() - v45_tail(failed_capture));
         v40_failed_bytes.resize(v40_failed_bytes.size() - v44_tail(failed_capture));
         v40_failed_bytes.resize(v40_failed_bytes.size() - v43_tail(failed_capture));
@@ -2199,6 +2459,7 @@ int main() {
     if (v13_bytes.size() >= 32) {
         const size_t legacy_resource_count = legacy_source.draws[0].vrt.resources.size() +
                                              legacy_source.draws[0].prt.resources.size();
+        v13_bytes.resize(v13_bytes.size() - v46_tail(legacy_source));
         v13_bytes.resize(v13_bytes.size() - v45_tail(legacy_source));
         v13_bytes.resize(v13_bytes.size() - v44_tail(legacy_source));
         v13_bytes.resize(v13_bytes.size() - v43_tail(legacy_source));
@@ -2242,6 +2503,7 @@ int main() {
     if (legacy_bytes.size() >= 32) {
         const size_t legacy_resource_count = legacy_source.draws[0].vrt.resources.size() +
                                              legacy_source.draws[0].prt.resources.size();
+        legacy_bytes.resize(legacy_bytes.size() - v46_tail(legacy_source));
         legacy_bytes.resize(legacy_bytes.size() - v45_tail(legacy_source));
         legacy_bytes.resize(legacy_bytes.size() - v44_tail(legacy_source));
         legacy_bytes.resize(legacy_bytes.size() - v43_tail(legacy_source));
@@ -2311,9 +2573,9 @@ int main() {
     CHECK(deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
           !legacy_loaded.failure_diagnostics_available && legacy_loaded.failure_diagnostics.empty(),
           "v6 capture reopens with failed-operation diagnostics reported unavailable");
-    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 46;   // kVersion + 1: a future version
+    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 47;   // kVersion + 1: a future version
     CHECK(!deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
-          error == "unsupported capture version 46",
+          error == "unsupported capture version 47",
           "future capture versions fail with a concrete version error");
 
     GpuCaptureFile bad_hash = mixed;

--- a/prosper/tests/test_gpu_execute.cpp
+++ b/prosper/tests/test_gpu_execute.cpp
@@ -1327,6 +1327,11 @@ int main() {
         ordered.sh[P::SPI_SHADER_USER_DATA_PS_0 + 2] =
             static_cast<uint32_t>(cbuffer.size());
         ordered.sh[P::SPI_SHADER_USER_DATA_PS_0 + 3] = (22u << 12) | 0xFACu;
+        for (uint32_t i = 0; i < 4; ++i) {
+            const uint32_t reg = P::SPI_SHADER_USER_DATA_PS_0 + i;
+            ordered.sh_prov[reg] = 90u + i;
+            ordered.sh_prov_src[reg] = GpuState::pack_prov_src(1, 0, 77);
+        }
         GpuState::Draw draw;
         draw.index_count = 3;
         draw.command_order = 100;
@@ -1380,6 +1385,11 @@ int main() {
         const auto* post_blob = provenance &&
                 provenance->post_blob_index < captured.blobs.size()
             ? &captured.blobs[provenance->post_blob_index] : nullptr;
+        const ShaderResource* captured_normalized = nullptr;
+        if (read && !captured.draws.empty())
+            for (const auto& resource : captured.draws[0].prt.resources)
+                if (resource.resource.binding == 32)
+                    captured_normalized = &resource.resource;
         const bool exact_temporal_samples = provenance && realization_blob && post_blob &&
             provenance->draw_index == 0 &&
             provenance->stage == ShaderProgramStage::Fragment &&
@@ -1393,14 +1403,23 @@ int main() {
                        realization_blob->bytes.begin()) &&
             std::equal(post_bytes.begin(), post_bytes.end(),
                        post_blob->bytes.begin() + provenance->post_blob_offset);
-        if (!renderer_saw_resource || !compute_executed || !exact_temporal_samples)
+        const bool exact_raw_identity = provenance && captured_normalized &&
+            provenance->input_mode == GpuCaptureResourceInputMode::DirectVSharp &&
+            provenance->input_sh_register_base == P::SPI_SHADER_USER_DATA_PS_0 &&
+            provenance->input_write_provenance_mask == 0x0f &&
+            gpu_capture_resource_input_verdict(*provenance, *captured_normalized) ==
+                GpuCaptureResourceInputVerdict::FullMatch;
+        if (!renderer_saw_resource || !compute_executed || !exact_temporal_samples ||
+            !exact_raw_identity)
             std::printf("  [diag] ordered resource provenance: renderer=%d compute=%d read=%d "
-                        "error=%s records=%zu\n",
+                        "temporal=%d raw=%d error=%s records=%zu\n",
                         renderer_saw_resource ? 1 : 0, compute_executed ? 1 : 0,
-                        read ? 1 : 0, capture_error.c_str(),
+                        read ? 1 : 0, exact_temporal_samples ? 1 : 0,
+                        exact_raw_identity ? 1 : 0, capture_error.c_str(),
                         captured.resource_provenance.size());
-        CHECK(renderer_saw_resource && compute_executed && exact_temporal_samples,
-              "eager draw snapshots its selected resource once at ordered execution before mutation");
+        CHECK(renderer_saw_resource && compute_executed && exact_temporal_samples &&
+                  exact_raw_identity,
+              "ordered selected draw captures temporal bytes and matching raw direct-V# input");
         std::filesystem::remove(capture_path, filesystem_error);
     }
 

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -63,6 +63,18 @@ requested span, each sample's readable byte count, payload, and content hash. Th
 guest-authored zero bytes from an unreadable zero-filled suffix and answers whether a buffer was
 already zero when the draw consumed it or changed later in the submit.
 
+Capture v46 additionally retains the four raw stage USER_DATA dwords for an exactly attributable
+direct V# plus each dword's last PM4 write order, direct/indirect path, queue, fold, and Jump depth.
+The front half carries the exact SH origin it selected into the runtime resource table; capture does
+not search other registers for a descriptor that happens to match the normalized output.
+`--inspect-only` decodes the raw dwords independently and prints `raw-identity=full-match` when every
+architecturally encoded field matches, or `raw-identity=mismatch` when it does not. Both outcomes are
+valid captured evidence. Older capsules and indirect, transformed, ambiguous, or missing-provenance
+paths print `raw-identity=unavailable reason=...`; they are never silently reconstructed from the
+normalized output. A zero-record V# does not encode a byte size, and FORMAT=INVALID does not encode
+the shader instruction's effective format, so compatibility/shader-derived values also remain
+explicitly unavailable rather than being reported as raw proof.
+
 `--inspect-only` prints one `resource-provenance` line with `realization-read`, `post-read`, both
 hashes, and one of these verdicts:
 

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -549,6 +549,68 @@ void inspect_frame(const prosper::gpu::GpuReplayFrame& replay, uint32_t format_v
             static_cast<unsigned long long>(post_read),
             static_cast<unsigned long long>(provenance.post_content_hash),
             provenance.srt_offset, provenance.sgpr_base, verdict);
+
+        const prosper::gpu::ShaderResource* normalized = nullptr;
+        bool ambiguous = false;
+        for (const auto& draw : replay.items) {
+            if (draw.draw_index != provenance.draw_index) continue;
+            const auto& table = provenance.stage == prosper::gpu::ShaderProgramStage::Vertex
+                ? draw.vrt : draw.prt;
+            if (!table) continue;
+            for (const auto& resource : table->resources) {
+                if (resource.binding != provenance.binding) continue;
+                if (normalized) { ambiguous = true; break; }
+                normalized = &resource;
+            }
+            if (ambiguous) break;
+        }
+        const auto input_verdict = normalized && !ambiguous
+            ? prosper::gpu::gpu_capture_resource_input_verdict(provenance, *normalized)
+            : prosper::gpu::GpuCaptureResourceInputVerdict::Mismatch;
+        if (input_verdict == prosper::gpu::GpuCaptureResourceInputVerdict::Unavailable &&
+            provenance.input_mode ==
+                prosper::gpu::GpuCaptureResourceInputMode::Unavailable) {
+            std::printf(
+                "resource-input draw=%llu stage=%s binding=%u raw-identity=unavailable reason=%s\n",
+                static_cast<unsigned long long>(provenance.draw_index),
+                provenance.stage == prosper::gpu::ShaderProgramStage::Vertex ? "vs" : "ps",
+                provenance.binding,
+                prosper::gpu::gpu_capture_resource_input_unavailable_reason_name(
+                    provenance.input_unavailable_reason));
+        } else {
+            const char* input_name =
+                input_verdict == prosper::gpu::GpuCaptureResourceInputVerdict::FullMatch
+                    ? "full-match"
+                    : input_verdict == prosper::gpu::GpuCaptureResourceInputVerdict::Unavailable
+                        ? "unavailable" : "mismatch";
+            std::printf(
+                "resource-input draw=%llu stage=%s binding=%u raw-identity=%s%s%s sh-reg=%08x "
+                "dwords=%08x,%08x,%08x,%08x writes=",
+                static_cast<unsigned long long>(provenance.draw_index),
+                provenance.stage == prosper::gpu::ShaderProgramStage::Vertex ? "vs" : "ps",
+                provenance.binding, input_name,
+                input_verdict == prosper::gpu::GpuCaptureResourceInputVerdict::Unavailable
+                    ? " reason=" : "",
+                input_verdict == prosper::gpu::GpuCaptureResourceInputVerdict::Unavailable
+                    ? prosper::gpu::gpu_capture_resource_input_unavailable_reason_name(
+                          provenance.input_unavailable_reason)
+                    : "",
+                provenance.input_sh_register_base,
+                provenance.input_dwords[0], provenance.input_dwords[1],
+                provenance.input_dwords[2], provenance.input_dwords[3]);
+            for (size_t i = 0; i < provenance.input_last_writes.size(); ++i) {
+                const uint64_t write = provenance.input_last_writes[i];
+                const uint64_t source = provenance.input_write_sources[i];
+                std::printf("%s%c%llu/q%u,f%llu,j%u", i ? "," : "",
+                            (write & prosper::gpu::GpuState::kProvIndirect) ? 'i' : 'd',
+                            static_cast<unsigned long long>(
+                                write & ~prosper::gpu::GpuState::kProvIndirect),
+                            static_cast<unsigned>(source & 0xffu),
+                            static_cast<unsigned long long>(source >> 16u),
+                            static_cast<unsigned>((source >> 8u) & 0xffu));
+            }
+            std::printf("\n");
+        }
     }
     for (const auto& seed : replay.rtt_seeds) {
         const uint64_t hash = prosper::gpu::gpu_capture_hash(seed.rgba);


### PR DESCRIPTION
## Problem

Capture v45 preserves the normalized identity and draw-time/post-submit bytes for one selected resource, but not the raw stage user-data descriptor that produced it. Offline inspection therefore could not distinguish a guest-programmed V# from an incorrect front-half transform; comparing `ShaderResource` views only compared the decoder with itself.

## Design

- Bump `.prgcap` to v46 with an append-only selected-resource input witness while keeping v45 readable.
- For an unchanged direct V#, retain the absolute SH register base, four raw dwords, and each dword's last-write order/path/queue/fold/Jump provenance from the semantic draw's immutable `GpuState` snapshot.
- Arm SH provenance from process start when the selected-resource selector is present, without enabling high-volume `PROSPER_UDPROV` output. Unselected/default captures keep the existing no-read/no-copy path.
- Decode the raw V# independently during replay inspection and report `raw-identity=full-match`, `mismatch`, or `unavailable reason=...` beside the existing normalized descriptor.
- Compare all architecturally available fields before returning unavailable: `NUM_RECORDS=0` still proves format/components, while `FORMAT=INVALID` still proves size. Compatibility-derived size/format is never presented as raw proof.

## Fail-closed cases

SRT-loaded, shader-constructed/patched, ambiguous, missing-provenance, and pre-v46 inputs report explicit unavailability. A legal nonzero MUBUF instruction/SOFFSET transform also reports unavailable: its normalized base differs from the unshifted raw V# by design, so retaining that V# as byte-identical provenance would create a false mismatch.

v46 validation rejects direct witnesses a real fold cannot produce, including out-of-range four-register SH origins, zero fold identities, queue origins outside 0..3, Jump depth above 8, high packed-source garbage bits, and writes that do not precede the selected draw.

## Verification

Built and ran in the `ps5ys` distrobox:

```sh
cmake --build prosper/build-linux -j2 --target \
  test_agc_shader test_command_provenance test_gpu_capture test_gpu_execute gpu_replay
ctest --test-dir prosper/build-linux --output-on-failure \
  -R '^(agc_shader_create|command_provenance|gpu_capture_roundtrip|gpu_replay_resource_input_inspect|gpu_execute)$'
```

All 5 focused tests pass after rebasing onto `04c43b15`.

The controls exercise the real mechanisms:

- disabling provenance collection while leaving selection/capture active makes exactly `selected draw uses immutable pre-overwrite q1 V# state and full-match identity` fail;
- restoring the old nonzero-offset origin behavior makes exactly `nonzero fetch offset stays explicitly unavailable instead of a false raw-input mismatch` fail;
- mutating the real `gpu_replay --inspect-only` formatting makes its full-match, mismatch, and unavailable output checks fail;
- serialized v46 tail mutations reject zero source/fold, q255, Jump depth 9, high source bits, and an out-of-range SH base.

Independent full-diff review approved stable patch-id `1448eb301309e78fc5626c8414b06e7532f9efd7`. `git diff --check` is clean.

This is generic capture infrastructure and does not claim an Asterix visual fix, so there is no new screenshot. It supplies the independent discriminator needed for the next selected-resource capture.

Closes #1853