### PR TITLE
fix(app): honor --frames on GPU CPU fallback

### DIFF
--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -1304,7 +1304,8 @@ int main(int argc, char** argv) {
     const auto loopStarted = std::chrono::steady_clock::now();
     auto lastFrameProgress = loopStarted;
     auto nextTimedDump = loopStarted + std::chrono::milliseconds(timedDumpMs);
-    uint64_t shown = 0, lastFrameSeq = ~0ull, patFrame = 0;
+    prosper::frontend::PresentedFrameCounter shown(exitAfter);
+    uint64_t lastFrameSeq = ~0ull, patFrame = 0;
     bool havePresentedGuestFlip = false;
     uint64_t lastPresentedGuestFlip = 0;
     int gpuPrevSlot = -1;   // #1270: the GPU scanout slot presented last frame (released after its read)
@@ -2164,7 +2165,8 @@ int main(int argc, char** argv) {
                 } else if (attempt == PresentAttempt::failed) {
                     running = false;
                 } else {
-                    shown++; lastFrameProgress = std::chrono::steady_clock::now();
+                    shown.record(prosper::frontend::PresentedFrameSource::GpuScanout, running);
+                    lastFrameProgress = std::chrono::steady_clock::now();
                     havePresentedGuestFlip = true;
                     lastPresentedGuestFlip = gf.frame_seq;
                     static auto t0 = std::chrono::steady_clock::now(); static uint64_t mark = 0;
@@ -2175,7 +2177,6 @@ int main(int argc, char** argv) {
                                 (shown - mark) / (s > 0 ? s : 1), (unsigned long long)shown);
                         t0 = now; mark = shown;
                     }
-                    if (exitAfter && (int)shown >= exitAfter) running = false;
                 }
             } else if (gpu::present_frame_seq() != lastFrameSeq) {
                 // #1270 Finding 2: no GPU frame was published this iteration. On a publish MISS (front
@@ -2200,7 +2201,8 @@ int main(int argc, char** argv) {
                     else if (a == PresentAttempt::failed) running = false;
                     else {
                         lastFrameSeq = cf.frame_seq;
-                        shown++;
+                        shown.record(
+                            prosper::frontend::PresentedFrameSource::GpuCpuFallback, running);
                         lastFrameProgress = std::chrono::steady_clock::now();
                         havePresentedGuestFlip = true;
                         lastPresentedGuestFlip = cf.guest_present_count;
@@ -2232,7 +2234,8 @@ int main(int argc, char** argv) {
                 } else if (attempt == PresentAttempt::failed) {
                     running = false;
                 } else {
-                    lastFrameSeq = frame.frame_seq; shown++;
+                    lastFrameSeq = frame.frame_seq;
+                    shown.record(prosper::frontend::PresentedFrameSource::Cpu, running);
                     lastFrameProgress = std::chrono::steady_clock::now();
                     flushGrabScreenshot(frame.rgba->data(), w, h);
                     // Periodic present-rate log (every 60 presented frames).
@@ -2262,7 +2265,6 @@ int main(int argc, char** argv) {
                         }
                         t0 = now; mark = shown;
                     }
-                    if (exitAfter && (int)shown >= exitAfter) running = false;
                 }
             }
         } else {

--- a/prosper/frontends/prosper-app/present_policy.hpp
+++ b/prosper/frontends/prosper-app/present_policy.hpp
@@ -40,6 +40,39 @@ enum class PresentAttempt {
     failed,       // device/synchronization recovery failed — stop instead of waiting forever
 };
 
+// Every successful presentation path contributes to the same --frames budget.  Keep the count and
+// stop decision inseparable: a caller cannot increment the private counter while forgetting to apply
+// the limit, which was the CPU-fallback defect in #1858.  The source is explicit so focused tests can
+// prove that adding a new presentation route does not silently create a different policy.
+enum class PresentedFrameSource {
+    GpuScanout,
+    GpuCpuFallback,
+    Cpu,
+};
+
+class PresentedFrameCounter {
+public:
+    explicit constexpr PresentedFrameCounter(int exit_after)
+        : exit_after_(exit_after) {}
+
+    constexpr uint64_t count() const { return count_; }
+    constexpr operator uint64_t() const { return count_; }
+
+    constexpr void record(PresentedFrameSource source, bool& running) {
+        // All sources intentionally share one policy.  Naming the source makes a path-specific
+        // bypass observable to the defect-shaped mutation test without putting a switch here.
+        (void)source;
+        ++count_;
+        if (exit_after_ != 0 &&
+            (exit_after_ < 0 || count_ >= static_cast<uint64_t>(exit_after_)))
+            running = false;
+    }
+
+private:
+    int exit_after_ = 0;
+    uint64_t count_ = 0;
+};
+
 // What present_frame should do after a BOUNDED vkAcquireNextImageKHR.
 enum class AcquireAction { proceed, skip, recreate, fail };
 

--- a/prosper/frontends/prosper-app/test_present_policy.cpp
+++ b/prosper/frontends/prosper-app/test_present_policy.cpp
@@ -21,7 +21,46 @@ static int failures = 0;
         }                                                                      \
     } while (0)
 
+#define CHECK_NAMED(cond, name)                                                \
+    do {                                                                       \
+        if (!(cond)) {                                                         \
+            std::fprintf(stderr, "FAIL %s\n", name);                         \
+            ++failures;                                                        \
+        }                                                                      \
+    } while (0)
+
+static bool stops_on_third_presented_frame(PresentedFrameSource source) {
+    PresentedFrameCounter shown(3);
+    bool running = true;
+    shown.record(source, running);
+    if (!running || shown.count() != 1) return false;
+    shown.record(source, running);
+    if (!running || shown.count() != 2) return false;
+    shown.record(source, running);
+    return !running && shown.count() == 3;
+}
+
 int main() {
+    CHECK_NAMED(stops_on_third_presented_frame(PresentedFrameSource::GpuScanout),
+                "direct GPU scanout honors the presented-frame limit");
+    CHECK_NAMED(stops_on_third_presented_frame(PresentedFrameSource::GpuCpuFallback),
+                "GPU CPU fallback honors the same presented-frame limit");
+    CHECK_NAMED(stops_on_third_presented_frame(PresentedFrameSource::Cpu),
+                "ordinary CPU presentation honors the presented-frame limit");
+
+    PresentedFrameCounter unlimited(0);
+    bool unlimited_running = true;
+    for (unsigned i = 0; i < 5; ++i)
+        unlimited.record(PresentedFrameSource::GpuCpuFallback, unlimited_running);
+    CHECK(unlimited_running && unlimited.count() == 5);
+
+    // Preserve the old atoi/nonzero CLI semantics for a malformed negative count: it stops after
+    // the first successful presentation instead of becoming an accidental unlimited run.
+    PresentedFrameCounter negative_limit(-1);
+    bool negative_running = true;
+    negative_limit.record(PresentedFrameSource::Cpu, negative_running);
+    CHECK(!negative_running && negative_limit.count() == 1);
+
     // GPU presentation is the normal game policy because adoption has a safe CPU fallback. Keep the
     // explicit zero override for driver diagnosis and never request it without a renderer-owned game.
     CHECK(request_gpu_present(nullptr, false, true));

--- a/prosper/tools/perf/mutate_present_frame_limit.sh
+++ b/prosper/tools/perf/mutate_present_frame_limit.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+HERE=$(cd "$(dirname "$0")" && pwd)
+ROOT=$(cd "$HERE/../.." && pwd)
+WORK=$(mktemp -d "${TMPDIR:-/var/tmp}/present-frame-limit-mutate-XXXXXX") || exit 2
+trap 'rm -rf "$WORK"' EXIT
+
+cp "$ROOT/frontends/prosper-app/present_policy.hpp" \
+   "$ROOT/frontends/prosper-app/test_present_policy.cpp" "$WORK/" || exit 2
+
+python3 - "$WORK/present_policy.hpp" <<'PY' || exit 1
+import sys
+
+path = sys.argv[1]
+old = """        (void)source;
+        ++count_;"""
+new = """        if (source == PresentedFrameSource::GpuCpuFallback) {
+            ++count_;
+            return;
+        }
+        ++count_;"""
+with open(path, encoding="utf-8") as stream:
+    source = stream.read()
+if source.count(old) != 1:
+    raise SystemExit(f"mutation anchor count is {source.count(old)}, expected exactly one")
+with open(path, "w", encoding="utf-8") as stream:
+    stream.write(source.replace(old, new, 1))
+PY
+
+CXX_BIN=${CXX:-c++}
+VULKAN_CFLAGS=$(pkg-config --cflags vulkan 2>/dev/null || true)
+if ! "$CXX_BIN" -std=c++20 -Wall -Wextra -Werror $VULKAN_CFLAGS -I"$WORK" \
+        "$WORK/test_present_policy.cpp" -o "$WORK/test-present-policy"; then
+    echo "CPU-fallback frame-limit mutation: BUILD FAILED (mutation not observed)"
+    exit 1
+fi
+
+output=$("$WORK/test-present-policy" 2>&1)
+status=$?
+failed=$(printf '%s\n' "$output" | sed -n 's/^FAIL //p')
+expected="GPU CPU fallback honors the same presented-frame limit"
+if [ "$status" -eq 0 ]; then
+    echo "CPU-fallback frame-limit mutation: *** SURVIVED ***"
+    exit 1
+fi
+if [ "$failed" != "$expected" ]; then
+    printf 'CPU-fallback frame-limit mutation: WRONG KILL expected "%s", got: %s\n' \
+        "$expected" "$failed"
+    exit 1
+fi
+printf 'CPU-fallback frame-limit mutation: killed by: %s\n' "$expected"


### PR DESCRIPTION
## Outcome

`prosper-app --frames N` now stops after exactly `N` successful presentations on all three app presentation paths, including the GPU-present CPU fallback that previously ignored the limit.

Closes #1858.

## Implementation

- Centralize successful-presentation counting and the stop decision in a private `PresentedFrameCounter`.
- Make each path identify itself as direct GPU scanout, GPU CPU fallback, or ordinary CPU presentation while sharing one policy.
- Preserve the existing unlimited (`0`) and malformed-negative CLI behavior.
- Add a focused policy test and a defect-shaped mutation that bypasses only the GPU CPU fallback stop; only the named fallback check fails.

## Verification

Built inside the `ps5ys` distrobox with a worktree-local build and TMPDIR:

```text
cmake --build prosper/build-1858 --target test_prosper_app_present_policy prosper-app -j6
ctest --test-dir prosper/build-1858 -R '^prosper_app_present_policy$' --output-on-failure
# 1/1 passed

prosper/tools/perf/mutate_present_frame_limit.sh
# killed by: GPU CPU fallback honors the same presented-frame limit
```

Natural Asterix validation on exact parent `09be7beccc93c6e2d414657c3570f877271fdcdf` plus this commit:

- `--frames 85`: exit 0 at exactly 85 presented frames.
- Capture-triggering `--frames 200`: wrote the exact deferred submit-181 capsule (8 draws, 6 computes, 14 operations, 0 failures), then exit 0 at exactly 200 presented frames.
- Before this change, two independent identical capture runs required the 60/90-second outer timeout and shut down after 1,753–3,118 frames.

No snapshot suite was run: this ordinary focused PR changes app-loop termination only, with a unit test, mutation test, full app build, and natural title reproduction. No screenshot is appropriate because there is no visual-output change.