### PR TITLE
gpu: wire behavior-neutral live compute authority census

### DIFF
--- a/prosper/frontends/shared/compute_authority_live_census.hpp
+++ b/prosper/frontends/shared/compute_authority_live_census.hpp
@@ -1,0 +1,234 @@
+#pragma once
+
+#include "compute_authority_census.hpp"
+#include "compute_timing_selector.hpp"
+
+#include <cstdint>
+#include <limits>
+
+namespace prosper::frontend {
+
+// Process-start selector for the live, behavior-neutral authority census.  The stable SPIR-V hash
+// names only the producer whose retained storage results are admitted.  Every later compute input,
+// write, draw, DMA, capture, and submit boundary is still observed while one result is pending.
+struct ComputeAuthorityLiveSelector {
+    bool requested = false;
+    bool valid = false;
+    uint64_t producer_hash = 0;
+    ComputeTimingSelectorParseError error = ComputeTimingSelectorParseError::Unset;
+};
+
+inline ComputeAuthorityLiveSelector parse_compute_authority_live_selector(const char* text) {
+    if (!text) return {};
+    const ComputeTimingSelectorParseResult parsed =
+        parse_compute_timing_selector_u64(text);
+    return {true, parsed.accepted(), parsed.value, parsed.error};
+}
+
+struct ComputeAuthorityLiveObservation {
+    bool selected = false;
+    bool first_match = false;
+};
+
+struct ComputeAuthorityLiveCounters {
+    uint64_t programs_seen = 0;
+    uint64_t programs_matched = 0;
+    uint64_t submits_started = 0;
+    uint64_t submits_completed = 0;
+    uint64_t interrupted_submits = 0;
+    uint64_t observations_without_submit = 0;
+    uint64_t selected_storage_outputs = 0;
+    uint64_t retained_storage_outputs = 0;
+    uint64_t synchronous_storage_outputs = 0;
+    uint64_t pending_before_submit_end = 0;
+    uint64_t pending_after_submit_end = 0;
+    ShadowComputeAuthorityCounters authority;
+    bool apparatus_valid = true;
+    bool summary_reported = false;
+};
+
+constexpr uint64_t compute_authority_saturating_add(uint64_t first, uint64_t second) {
+    return second > std::numeric_limits<uint64_t>::max() - first
+        ? std::numeric_limits<uint64_t>::max() : first + second;
+}
+
+inline void accumulate_compute_authority_counters(
+    ShadowComputeAuthorityCounters& destination,
+    const ShadowComputeAuthorityCounters& source) {
+#define PROSPER_ADD_AUTHORITY_COUNTER(name) \
+    destination.name = compute_authority_saturating_add(destination.name, source.name)
+    PROSPER_ADD_AUTHORITY_COUNTER(result_candidates);
+    PROSPER_ADD_AUTHORITY_COUNTER(admitted_results);
+    PROSPER_ADD_AUTHORITY_COUNTER(replaced_results);
+    PROSPER_ADD_AUTHORITY_COUNTER(rejected_results);
+    PROSPER_ADD_AUTHORITY_COUNTER(consumer_observations);
+    PROSPER_ADD_AUTHORITY_COUNTER(proven_gpu_keeps);
+    PROSPER_ADD_AUTHORITY_COUNTER(unrelated_keeps);
+    PROSPER_ADD_AUTHORITY_COUNTER(materializations);
+    PROSPER_ADD_AUTHORITY_COUNTER(overlap_materializations);
+    PROSPER_ADD_AUTHORITY_COUNTER(proven_gpu_image_materializations);
+    PROSPER_ADD_AUTHORITY_COUNTER(guest_image_materializations);
+    PROSPER_ADD_AUTHORITY_COUNTER(raw_buffer_materializations);
+    PROSPER_ADD_AUTHORITY_COUNTER(draw_materializations);
+    PROSPER_ADD_AUTHORITY_COUNTER(dma_materializations);
+    PROSPER_ADD_AUTHORITY_COUNTER(ordered_memory_effect_materializations);
+    PROSPER_ADD_AUTHORITY_COUNTER(capture_materializations);
+    PROSPER_ADD_AUTHORITY_COUNTER(unknown_consumer_materializations);
+    PROSPER_ADD_AUTHORITY_COUNTER(submit_end_materializations);
+    PROSPER_ADD_AUTHORITY_COUNTER(unknown_range_materializations);
+    PROSPER_ADD_AUTHORITY_COUNTER(invalid_result_materializations);
+    PROSPER_ADD_AUTHORITY_COUNTER(range_change_materializations);
+#undef PROSPER_ADD_AUTHORITY_COUNTER
+}
+
+// Per-submit wrapper around ShadowComputeAuthorityCensus.  It does not own or alter any Vulkan or
+// guest bytes: the live backend continues its existing synchronous readback/writeback.  This class
+// merely asks which exact ordered observer would have forced that writeback if GPU authority were
+// deferred in a future change.
+class ComputeAuthorityLiveCensus {
+public:
+    explicit ComputeAuthorityLiveCensus(ComputeAuthorityLiveSelector selector)
+        : selector_(selector) {}
+
+    const ComputeAuthorityLiveSelector& selector() const { return selector_; }
+    const ComputeAuthorityLiveCounters& counters() const { return counters_; }
+    bool active_submit() const { return active_; }
+    uint64_t submit_no() const { return submit_no_; }
+    bool pending() const { return active_ && submit_.state().pending(); }
+
+    void invalidate_apparatus(bool close_pending_as_unknown = false) {
+        if (!selector_.requested) return;
+        counters_.apparatus_valid = false;
+        if (close_pending_as_unknown && active_)
+            (void)submit_.observe(ShadowComputeAuthorityConsumerKind::Unknown);
+    }
+
+    ComputeAuthorityLiveObservation observe_program(uint64_t program_hash) {
+        if (!selector_.requested) return {};
+        if (!active_) {
+            counters_.apparatus_valid = false;
+            counters_.observations_without_submit = shadow_compute_authority_increment(
+                counters_.observations_without_submit);
+        }
+        counters_.programs_seen = shadow_compute_authority_increment(
+            counters_.programs_seen);
+        const bool selected = selector_.valid && program_hash == selector_.producer_hash;
+        const bool first_match = selected && counters_.programs_matched == 0;
+        if (selected)
+            counters_.programs_matched = shadow_compute_authority_increment(
+                counters_.programs_matched);
+        return {selected, first_match};
+    }
+
+    void begin_submit(uint64_t submit_no) {
+        if (!selector_.requested) return;
+        if (active_) {
+            counters_.apparatus_valid = false;
+            counters_.interrupted_submits = shadow_compute_authority_increment(
+                counters_.interrupted_submits);
+            // A missing end cannot let authority leak into the next submit.  Attribute the forced
+            // close as unknown, then still exercise the ordinary SubmitEnd invariant.
+            (void)submit_.observe(ShadowComputeAuthorityConsumerKind::Unknown);
+            close_submit();
+        }
+        active_ = true;
+        submit_no_ = submit_no;
+        submit_ = {};
+        counters_.submits_started = shadow_compute_authority_increment(
+            counters_.submits_started);
+    }
+
+    ShadowComputeAuthorityTransition observe(
+        ShadowComputeAuthorityConsumerKind kind,
+        const ShadowComputeAuthorityRange& range =
+            ShadowComputeAuthorityRange::unknown()) {
+        if (!selector_.requested) return {};
+        if (!active_) {
+            counters_.apparatus_valid = false;
+            counters_.observations_without_submit = shadow_compute_authority_increment(
+                counters_.observations_without_submit);
+            return {};
+        }
+        return submit_.observe(kind, range);
+    }
+
+    ShadowComputeAuthorityTransition record_selected_storage_output(
+        const ShadowComputeAuthorityRange& range, bool retained) {
+        if (!selector_.requested) return {};
+        counters_.selected_storage_outputs = shadow_compute_authority_increment(
+            counters_.selected_storage_outputs);
+        if (!active_) {
+            counters_.apparatus_valid = false;
+            counters_.observations_without_submit = shadow_compute_authority_increment(
+                counters_.observations_without_submit);
+            return {};
+        }
+        if (retained) {
+            counters_.retained_storage_outputs = shadow_compute_authority_increment(
+                counters_.retained_storage_outputs);
+            return submit_.note_retained_result(range);
+        }
+        counters_.synchronous_storage_outputs = shadow_compute_authority_increment(
+            counters_.synchronous_storage_outputs);
+        return submit_.observe(
+            ShadowComputeAuthorityConsumerKind::OrderedMemoryEffect, range);
+    }
+
+    ShadowComputeAuthorityTransition end_submit() {
+        if (!selector_.requested) return {};
+        if (!active_) {
+            counters_.apparatus_valid = false;
+            counters_.observations_without_submit = shadow_compute_authority_increment(
+                counters_.observations_without_submit);
+            return {};
+        }
+        return close_submit();
+    }
+
+    bool summary_valid() const {
+        return selector_.requested && selector_.valid &&
+            counters_.programs_matched != 0 &&
+            counters_.retained_storage_outputs != 0 &&
+            counters_.authority.admitted_results != 0 &&
+            counters_.apparatus_valid && !active_ &&
+            counters_.pending_after_submit_end == 0;
+    }
+
+    bool claim_summary() {
+        if (counters_.summary_reported) return false;
+        counters_.summary_reported = true;
+        return true;
+    }
+
+private:
+    ShadowComputeAuthorityTransition close_submit() {
+        const bool pending_before = submit_.state().pending();
+        const ShadowComputeAuthorityTransition transition = submit_.observe(
+            ShadowComputeAuthorityConsumerKind::SubmitEnd);
+        const bool pending_after = submit_.state().pending();
+        if (pending_before)
+            counters_.pending_before_submit_end = shadow_compute_authority_increment(
+                counters_.pending_before_submit_end);
+        if (pending_after) {
+            counters_.pending_after_submit_end = shadow_compute_authority_increment(
+                counters_.pending_after_submit_end);
+            counters_.apparatus_valid = false;
+        }
+        accumulate_compute_authority_counters(
+            counters_.authority, submit_.counters());
+        counters_.submits_completed = shadow_compute_authority_increment(
+            counters_.submits_completed);
+        active_ = false;
+        submit_no_ = 0;
+        submit_ = {};
+        return transition;
+    }
+
+    ComputeAuthorityLiveSelector selector_;
+    ComputeAuthorityLiveCounters counters_;
+    bool active_ = false;
+    uint64_t submit_no_ = 0;
+    ShadowComputeAuthorityCensus submit_;
+};
+
+} // namespace prosper::frontend

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -1,4 +1,5 @@
 #include "live_compute.hpp"
+#include "compute_authority_live_census.hpp"
 #include "compute_timing_selector.hpp"
 #include "compute_transfer_gate_census.hpp"
 #include "live_target_format.hpp"
@@ -3133,6 +3134,311 @@ RuntimeComputeTransferGateCensus& runtime_compute_transfer_gate_census() {
     return census;
 }
 
+const char* compute_authority_action_name(ShadowComputeAuthorityAction action) {
+    switch (action) {
+        case ShadowComputeAuthorityAction::NoPendingResult: return "no-pending";
+        case ShadowComputeAuthorityAction::TrackPendingResult: return "track";
+        case ShadowComputeAuthorityAction::ReplacePendingResult: return "replace";
+        case ShadowComputeAuthorityAction::KeepGpuAuthority: return "keep-gpu";
+        case ShadowComputeAuthorityAction::MaterializeGuestMirror: return "materialize";
+        case ShadowComputeAuthorityAction::MaterializeAndTrackResult:
+            return "materialize+track";
+        case ShadowComputeAuthorityAction::RejectResult: return "reject";
+    }
+    return "unknown";
+}
+
+const char* compute_authority_reason_name(ShadowComputeAuthorityReason reason) {
+    switch (reason) {
+        case ShadowComputeAuthorityReason::NoPendingResult: return "no-pending";
+        case ShadowComputeAuthorityReason::ResultAdmitted: return "result-admitted";
+        case ShadowComputeAuthorityReason::ResultReplaced: return "result-replaced";
+        case ShadowComputeAuthorityReason::ProvenGpuConsumer: return "proven-gpu-consumer";
+        case ShadowComputeAuthorityReason::UnrelatedConsumer: return "unrelated-consumer";
+        case ShadowComputeAuthorityReason::OverlappingGuestImageConsumer:
+            return "guest-image-overlap";
+        case ShadowComputeAuthorityReason::OverlappingRawBufferConsumer:
+            return "raw-buffer-overlap";
+        case ShadowComputeAuthorityReason::OverlappingDrawConsumer: return "draw-overlap";
+        case ShadowComputeAuthorityReason::OverlappingDmaConsumer: return "dma-overlap";
+        case ShadowComputeAuthorityReason::OverlappingOrderedMemoryEffectConsumer:
+            return "ordered-memory-effect-overlap";
+        case ShadowComputeAuthorityReason::CaptureConsumer: return "capture";
+        case ShadowComputeAuthorityReason::UnknownConsumerRange: return "unknown-range";
+        case ShadowComputeAuthorityReason::UnknownConsumer: return "unknown-consumer";
+        case ShadowComputeAuthorityReason::SubmitEnd: return "submit-end";
+        case ShadowComputeAuthorityReason::ResultRangeChanged: return "result-range-changed";
+        case ShadowComputeAuthorityReason::InvalidResultRange: return "invalid-result-range";
+    }
+    return "unknown";
+}
+
+const char* compute_authority_boundary_name(
+        prosper::gpu::ComputeAuthorityBoundaryKind kind) {
+    using Kind = prosper::gpu::ComputeAuthorityBoundaryKind;
+    switch (kind) {
+        case Kind::SubmitBegin: return "submit-begin";
+        case Kind::Draw: return "draw";
+        case Kind::Dma: return "dma";
+        case Kind::OrderedMemoryEffect: return "ordered-memory-effect";
+        case Kind::Capture: return "capture";
+        case Kind::SubmitEnd: return "submit-end";
+        case Kind::Compute: return "compute";
+    }
+    return "unknown";
+}
+
+class RuntimeComputeAuthorityCensus {
+public:
+    RuntimeComputeAuthorityCensus()
+        : census_(parse_compute_authority_live_selector(
+              std::getenv("PROSPER_COMPUTE_AUTHORITY_HASH"))) {
+        const ComputeAuthorityLiveSelector& selector = census_.selector();
+        if (!selector.requested) return;
+        if (selector.valid) {
+            std::fprintf(stderr,
+                         "[compute-authority] PROSPER_COMPUTE_AUTHORITY_HASH accepted "
+                         "producer=0x%016llx mode=exact-stable-hash shadow-only\n",
+                         static_cast<unsigned long long>(selector.producer_hash));
+        } else {
+            std::fprintf(stderr,
+                         "[compute-authority] PROSPER_COMPUTE_AUTHORITY_HASH ignored "
+                         "reason=%s; selector fails closed\n",
+                         compute_timing_selector_parse_error_name(selector.error));
+        }
+    }
+
+    ~RuntimeComputeAuthorityCensus() { report_summary(); }
+
+    bool requested() const { return census_.selector().requested; }
+
+    ComputeAuthorityLiveObservation observe_program(
+            const prosper::gpu::ComputeItem& item, uint64_t program_hash) {
+        if (!requested()) return {};
+        std::lock_guard lock(mutex_);
+        verify_submit_locked(item.submit_no, "dispatch");
+        const ComputeAuthorityLiveObservation observation =
+            census_.observe_program(program_hash);
+        if (observation.first_match) {
+            std::fprintf(stderr,
+                         "[compute-authority] first-match producer=0x%016llx "
+                         "code=0x%llx submit=%llu dispatch=%llu order=%llu seen=%llu\n",
+                         static_cast<unsigned long long>(program_hash),
+                         static_cast<unsigned long long>(item.code_addr),
+                         static_cast<unsigned long long>(item.submit_no),
+                         static_cast<unsigned long long>(item.dispatch_index),
+                         static_cast<unsigned long long>(item.command_order),
+                         static_cast<unsigned long long>(
+                             census_.counters().programs_seen));
+        }
+        return observation;
+    }
+
+    void observe_compute_access(const prosper::gpu::ComputeItem& item,
+                                uint32_t binding,
+                                ShadowComputeAuthorityConsumerKind kind,
+                                const ShadowComputeAuthorityRange& range,
+                                const char* stage) {
+        if (!requested()) return;
+        std::lock_guard lock(mutex_);
+        verify_submit_locked(item.submit_no, stage);
+        const ShadowComputeAuthorityTransition transition = census_.observe(kind, range);
+        record_detail_locked(stage, item.submit_no, item.command_order, binding,
+                             range, transition);
+    }
+
+    void record_selected_storage_output(
+            const prosper::gpu::ComputeItem& item, uint32_t binding,
+            const ShadowComputeAuthorityRange& range, bool retained) {
+        if (!requested()) return;
+        std::lock_guard lock(mutex_);
+        verify_submit_locked(item.submit_no, "storage-output");
+        const ShadowComputeAuthorityTransition transition =
+            census_.record_selected_storage_output(range, retained);
+        record_detail_locked(retained ? "retained-storage-output" :
+                                      "synchronous-storage-output",
+                             item.submit_no, item.command_order, binding,
+                             range, transition);
+    }
+
+    void observe_boundary(const prosper::gpu::ComputeAuthorityBoundary& boundary) {
+        if (!requested()) return;
+        std::lock_guard lock(mutex_);
+        using BoundaryKind = prosper::gpu::ComputeAuthorityBoundaryKind;
+        boundary_counts_[static_cast<size_t>(boundary.kind)] =
+            shadow_compute_authority_increment(
+                boundary_counts_[static_cast<size_t>(boundary.kind)]);
+        if (boundary.kind == BoundaryKind::SubmitBegin) {
+            census_.begin_submit(boundary.submit_no);
+            return;
+        }
+        verify_submit_locked(boundary.submit_no,
+                             compute_authority_boundary_name(boundary.kind));
+        const ShadowComputeAuthorityRange range = boundary.range_known
+            ? ShadowComputeAuthorityRange::from(boundary.address, boundary.bytes)
+            : ShadowComputeAuthorityRange::unknown();
+        ShadowComputeAuthorityTransition transition;
+        switch (boundary.kind) {
+            case BoundaryKind::Draw:
+                transition = census_.observe(
+                    ShadowComputeAuthorityConsumerKind::Draw, range);
+                break;
+            case BoundaryKind::Dma:
+                transition = census_.observe(
+                    ShadowComputeAuthorityConsumerKind::Dma, range);
+                break;
+            case BoundaryKind::OrderedMemoryEffect:
+                transition = census_.observe(
+                    ShadowComputeAuthorityConsumerKind::OrderedMemoryEffect, range);
+                break;
+            case BoundaryKind::Capture:
+                transition = census_.observe(
+                    ShadowComputeAuthorityConsumerKind::Capture);
+                break;
+            case BoundaryKind::SubmitEnd:
+                transition = census_.end_submit();
+                break;
+            case BoundaryKind::Compute:
+                transition = range.valid()
+                    ? census_.observe(
+                          ShadowComputeAuthorityConsumerKind::OrderedMemoryEffect, range)
+                    : census_.observe(
+                          ShadowComputeAuthorityConsumerKind::Unknown);
+                break;
+            case BoundaryKind::SubmitBegin:
+                return;
+        }
+        record_detail_locked(compute_authority_boundary_name(boundary.kind),
+                             boundary.submit_no, boundary.command_order, UINT32_MAX,
+                             range, transition);
+    }
+
+    void report_summary() {
+        if (!requested()) return;
+        std::lock_guard lock(mutex_);
+        if (!census_.claim_summary()) return;
+        const ComputeAuthorityLiveSelector& selector = census_.selector();
+        const ComputeAuthorityLiveCounters& c = census_.counters();
+        const ShadowComputeAuthorityCounters& a = c.authority;
+        const char* verdict = !selector.valid ? "INVALID-selector-not-armed" :
+            c.programs_matched == 0 ? "INVALID-zero-matches" :
+            c.retained_storage_outputs == 0 || a.admitted_results == 0
+                ? "INVALID-zero-authority-lever" :
+            census_.active_submit() ? "INVALID-unfinished-submit" :
+            !c.apparatus_valid ? "INVALID-apparatus" :
+            c.pending_after_submit_end != 0 ? "INVALID-pending-after-submit" : "matched";
+        std::fprintf(stderr,
+                     "[compute-authority] summary producer=0x%016llx reason=%s "
+                     "seen=%llu matched=%llu submits=%llu/%llu interrupted=%llu "
+                     "outside-submit=%llu active=%u selected-outputs=%llu retained=%llu "
+                     "synchronous=%llu pending-before-end=%llu pending-after-end=%llu "
+                     "verdict=%s\n",
+                     static_cast<unsigned long long>(selector.producer_hash),
+                     compute_timing_selector_parse_error_name(selector.error),
+                     static_cast<unsigned long long>(c.programs_seen),
+                     static_cast<unsigned long long>(c.programs_matched),
+                     static_cast<unsigned long long>(c.submits_completed),
+                     static_cast<unsigned long long>(c.submits_started),
+                     static_cast<unsigned long long>(c.interrupted_submits),
+                     static_cast<unsigned long long>(c.observations_without_submit),
+                     census_.active_submit() ? 1u : 0u,
+                     static_cast<unsigned long long>(c.selected_storage_outputs),
+                     static_cast<unsigned long long>(c.retained_storage_outputs),
+                     static_cast<unsigned long long>(c.synchronous_storage_outputs),
+                     static_cast<unsigned long long>(c.pending_before_submit_end),
+                     static_cast<unsigned long long>(c.pending_after_submit_end), verdict);
+        std::fprintf(stderr,
+                     "[compute-authority] summary results candidates=%llu admitted=%llu "
+                     "replaced=%llu rejected=%llu observations=%llu gpu-keeps=%llu "
+                     "unrelated-keeps=%llu materializations=%llu overlap=%llu "
+                     "guest-image=%llu raw-buffer=%llu draw=%llu dma=%llu memory-effect=%llu "
+                     "capture=%llu unknown=%llu submit-end=%llu unknown-range=%llu\n",
+                     static_cast<unsigned long long>(a.result_candidates),
+                     static_cast<unsigned long long>(a.admitted_results),
+                     static_cast<unsigned long long>(a.replaced_results),
+                     static_cast<unsigned long long>(a.rejected_results),
+                     static_cast<unsigned long long>(a.consumer_observations),
+                     static_cast<unsigned long long>(a.proven_gpu_keeps),
+                     static_cast<unsigned long long>(a.unrelated_keeps),
+                     static_cast<unsigned long long>(a.materializations),
+                     static_cast<unsigned long long>(a.overlap_materializations),
+                     static_cast<unsigned long long>(a.guest_image_materializations),
+                     static_cast<unsigned long long>(a.raw_buffer_materializations),
+                     static_cast<unsigned long long>(a.draw_materializations),
+                     static_cast<unsigned long long>(a.dma_materializations),
+                     static_cast<unsigned long long>(
+                         a.ordered_memory_effect_materializations),
+                     static_cast<unsigned long long>(a.capture_materializations),
+                     static_cast<unsigned long long>(a.unknown_consumer_materializations),
+                     static_cast<unsigned long long>(a.submit_end_materializations),
+                     static_cast<unsigned long long>(a.unknown_range_materializations));
+        std::fprintf(stderr,
+                     "[compute-authority] summary boundaries begin=%llu draw=%llu dma=%llu "
+                     "memory-effect=%llu capture=%llu end=%llu compute=%llu "
+                     "detail-events=%llu\n",
+                     static_cast<unsigned long long>(boundary_counts_[0]),
+                     static_cast<unsigned long long>(boundary_counts_[1]),
+                     static_cast<unsigned long long>(boundary_counts_[2]),
+                     static_cast<unsigned long long>(boundary_counts_[3]),
+                     static_cast<unsigned long long>(boundary_counts_[4]),
+                     static_cast<unsigned long long>(boundary_counts_[5]),
+                     static_cast<unsigned long long>(boundary_counts_[6]),
+                     static_cast<unsigned long long>(detail_events_));
+    }
+
+private:
+    void verify_submit_locked(uint64_t submit_no, const char* stage) {
+        if (!census_.active_submit() || census_.submit_no() == submit_no) return;
+        census_.invalidate_apparatus(true);
+        if (!submit_mismatch_reported_) {
+            submit_mismatch_reported_ = true;
+            std::fprintf(stderr,
+                         "[compute-authority] apparatus-invalid stage=%s active-submit=%llu "
+                         "observed-submit=%llu; pending authority closed as unknown\n",
+                         stage,
+                         static_cast<unsigned long long>(census_.submit_no()),
+                         static_cast<unsigned long long>(submit_no));
+        }
+    }
+
+    void record_detail_locked(const char* stage, uint64_t submit_no,
+                              uint64_t command_order, uint32_t binding,
+                              const ShadowComputeAuthorityRange& range,
+                              const ShadowComputeAuthorityTransition& transition) {
+        if (!transition.pending_before && !transition.pending_after &&
+            transition.action == ShadowComputeAuthorityAction::NoPendingResult)
+            return;
+        detail_events_ = shadow_compute_authority_increment(detail_events_);
+        if (detail_events_ > 16 && (detail_events_ & (detail_events_ - 1)) != 0) return;
+        std::fprintf(stderr,
+                     "[compute-authority] detail n=%llu stage=%s submit=%llu order=%llu "
+                     "binding=%s%u range=%s0x%llx+%llu action=%s reason=%s pending=%u->%u\n",
+                     static_cast<unsigned long long>(detail_events_), stage,
+                     static_cast<unsigned long long>(submit_no),
+                     static_cast<unsigned long long>(command_order),
+                     binding == UINT32_MAX ? "-" : "",
+                     binding == UINT32_MAX ? 0u : binding,
+                     range.valid() ? "" : "unknown:",
+                     static_cast<unsigned long long>(range.address),
+                     static_cast<unsigned long long>(range.bytes),
+                     compute_authority_action_name(transition.action),
+                     compute_authority_reason_name(transition.reason),
+                     transition.pending_before ? 1u : 0u,
+                     transition.pending_after ? 1u : 0u);
+    }
+
+    ComputeAuthorityLiveCensus census_;
+    std::array<uint64_t, 7> boundary_counts_{};
+    uint64_t detail_events_ = 0;
+    bool submit_mismatch_reported_ = false;
+    std::mutex mutex_;
+};
+
+RuntimeComputeAuthorityCensus& runtime_compute_authority_census() {
+    static RuntimeComputeAuthorityCensus census;
+    return census;
+}
+
 void maybe_dump_traced_compute_spirv(const prosper::gpu::ComputeItem& item, bool trace) {
     const char* path = std::getenv("PROSPER_COMPUTELOG_SPIRV");
     if (!trace || !path || !*path || item.spirv.empty()) return;
@@ -3202,6 +3508,17 @@ std::optional<bool> execute_cpu_fast_path(const prosper::gpu::ComputeItem& item)
         destination = reinterpret_cast<uint8_t*>(static_cast<uintptr_t>(resource->gpu_addr));
     }
     if (!destination) return std::nullopt;
+
+    // The CPU shortcut bypasses execute_item's reflected-resource census entirely. Publish its
+    // exact write boundary before touching bytes so pending storage authority cannot survive an
+    // overlapping fast fill. With the diagnostic unarmed this is the same single atomic check as
+    // other executor boundaries; no hashing, lock, or callback copy occurs.
+    const bool authority_range_known = resource->gpu_addr != 0 && written_bytes != 0 &&
+        resource->gpu_addr <= UINT64_MAX - (written_bytes - 1);
+    prosper::gpu::notify_compute_authority_boundary({
+        prosper::gpu::ComputeAuthorityBoundaryKind::Compute,
+        item.submit_no, item.command_order, resource->gpu_addr, written_bytes,
+        authority_range_known});
 
     if (!resource->host_data && resource->gpu_addr)
         prosper::host::guest_write_watch_notify_host_write(
@@ -3379,8 +3696,11 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
     RuntimeComputeTransferGateCensus& transfer_gate_census =
         runtime_compute_transfer_gate_census();
     const bool transfer_gate_requested = transfer_gate_census.requested();
+    RuntimeComputeAuthorityCensus& authority_census =
+        runtime_compute_authority_census();
+    const bool authority_requested = authority_census.requested();
     const bool timing_address_matches = time_compute_address_matches(item);
-    if (transfer_gate_requested ||
+    if (transfer_gate_requested || authority_requested ||
         ((phase_timing_requested || image_timing_requested) && timing_address_matches)) {
         timing_program_hash = gpu_capture_hash(
             reinterpret_cast<const uint8_t*>(spirv.data()),
@@ -3394,6 +3714,10 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         transfer_gate_requested
             ? transfer_gate_census.observe(item, timing_program_hash)
             : ComputeTransferGateSelectorObservation{};
+    const ComputeAuthorityLiveObservation authority_observation =
+        authority_requested
+            ? authority_census.observe_program(item, timing_program_hash)
+            : ComputeAuthorityLiveObservation{};
     // The phase timer is also useful for buffer-only kernels. Astro Bot's heaviest dispatcher writes
     // buffers exclusively, so the historical storage-image gate hid the actual frame bottleneck.
     const bool timing_trace_only =
@@ -5551,6 +5875,54 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                  ComputeClock::now() - image_start).count());
         }
         if (!images_ready) break;
+
+        // #1854 shadow census: all bindings are now finalized, including aliases, persistent-cache
+        // reuse, and device-local compute-transfer seeds. Observe consumers before the dispatch can
+        // execute, but do not change any upload, barrier, wait, readback, or guest writeback. Writable
+        // buffers and unselected image outputs are ordered memory effects; selected storage-image
+        // results are classified only on the complete success/publish path below.
+        if (authority_requested) {
+            for (size_t i = 0; i < buffers.size(); ++i) {
+                const BoundBuffer& buffer = buffers[i];
+                if (!buffer.resource) continue;
+                const ShadowComputeAuthorityRange range =
+                    ShadowComputeAuthorityRange::from(
+                        buffer.resource->gpu_addr, buffer.guest_bytes);
+                if (descriptors[i].readable)
+                    authority_census.observe_compute_access(
+                        item, descriptors[i].binding,
+                        ShadowComputeAuthorityConsumerKind::RawBuffer,
+                        range, "compute-buffer-input");
+                if (buffer.writable)
+                    authority_census.observe_compute_access(
+                        item, descriptors[i].binding,
+                        ShadowComputeAuthorityConsumerKind::OrderedMemoryEffect,
+                        range, "compute-buffer-output");
+            }
+            for (size_t i = 0; i < images.size(); ++i) {
+                const BoundImage& image = images[i];
+                if (!image.resource) continue;
+                const ShadowComputeAuthorityRange range =
+                    ShadowComputeAuthorityRange::from(
+                        image.resource->gpu_addr, image.guest_bytes);
+                if (image_descriptors[i].readable) {
+                    const bool proven_gpu = image.compute_transfer_seed_borrowed ||
+                        (image.storage && image.persistent && image.upload_skipped);
+                    authority_census.observe_compute_access(
+                        item, image.binding,
+                        proven_gpu
+                            ? ShadowComputeAuthorityConsumerKind::ProvenGpuImage
+                            : ShadowComputeAuthorityConsumerKind::GuestImage,
+                        range, proven_gpu ? "compute-image-input-gpu" :
+                                            "compute-image-input-guest");
+                }
+                if (image.storage && !authority_observation.selected)
+                    authority_census.observe_compute_access(
+                        item, image.binding,
+                        ShadowComputeAuthorityConsumerKind::OrderedMemoryEffect,
+                        range, "compute-image-output-unselected");
+            }
+        }
         phase_setup = ComputeClock::now();
 
         // Layout: the buffer bindings (filled above) + one entry per image binding (#590).
@@ -6875,6 +7247,13 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             transfer_gate_census.record_storage_publish(
                 transfer_gate_observation.role, image.native_float_storage, unique,
                 image.cache_candidate, image.persistent, authorized);
+            if (authority_observation.selected && unique && image.resource) {
+                authority_census.record_selected_storage_output(
+                    item, image.binding,
+                    ShadowComputeAuthorityRange::from(
+                        image.resource->gpu_addr, image.guest_bytes),
+                    authorized);
+            }
             if (publish_eligible && image.graphics_sampled_usage)
                 ctx.authorize_cached_image_export(image.cache_key);
         }
@@ -6988,6 +7367,7 @@ bool compute_native_2d_transfer_format_compatible(prosper::gpu::DataFormat forma
 void report_live_compute_timing_selector_summary() {
     runtime_compute_timing_selector().report_summary();
     runtime_compute_transfer_gate_census().report_summary();
+    runtime_compute_authority_census().report_summary();
 }
 
 bool import_live_compute_storage_image(const prosper::gpu::ShaderResource& sampled_resource,
@@ -7209,6 +7589,13 @@ void sampled_float16_to_unorm8_range(const uint8_t* source, uint32_t components,
 }
 
 bool execute_live_compute_items(const std::vector<prosper::gpu::ComputeItem>& items) {
+    auto fail_closed_items = [&]() {
+        for (const auto& item : items)
+            prosper::gpu::notify_compute_authority_boundary({
+                prosper::gpu::ComputeAuthorityBoundaryKind::Compute,
+                item.submit_no, item.command_order, 0, 0, false});
+        return false;
+    };
     // Keep the Vulkan device alive across dispatch spans. Constructing an instance, device, and queue for
     // every callback cost roughly 25 ms/frame on the native Windows frontend before any kernel work ran.
     // Function-local static initialization is thread-safe; AGC submit execution serializes subsequent use.
@@ -7264,7 +7651,7 @@ bool execute_live_compute_items(const std::vector<prosper::gpu::ComputeItem>& it
     }();
     if (!context_ready) {
         std::fprintf(stderr, "[compute] Vulkan initialization failed\n");
-        return false;
+        return fail_closed_items();
     }
     // The teardown handler nulls context_ptr, so a dispatch submitted from another thread once
     // exit() has begun must decline instead of dereferencing it. Read once: the handler writes this
@@ -7278,11 +7665,11 @@ bool execute_live_compute_items(const std::vector<prosper::gpu::ComputeItem>& it
         std::call_once(teardown_logged, [] {
             std::fprintf(stderr, "[compute] dispatch after Vulkan teardown — declining\n");
         });
-        return false;
+        return fail_closed_items();
     }
     VulkanComputeContext& context = *live_context;
     g_live_compute_context = &context;
-    if (context.device_lost) return false;
+    if (context.device_lost) return fail_closed_items();
     const bool perf_capture_timing =
         prosper::perf::interactive_performance_capture().detailed_timing_active();
     const bool timing_log_enabled = std::getenv("PROSPER_RENDER_TIMING") != nullptr;
@@ -7296,11 +7683,26 @@ bool execute_live_compute_items(const std::vector<prosper::gpu::ComputeItem>& it
     // backend can't bind yet, #590) must not abort the rest of the batch — that would regress
     // dispatches that executed before image bindings existed. Run all; report all-succeeded.
     bool all_ok = true;
+    RuntimeComputeAuthorityCensus& authority_census =
+        runtime_compute_authority_census();
+    const bool authority_requested = authority_census.requested();
     for (const auto& item : items) {
-        if (const std::optional<bool> cpu_result = execute_cpu_fast_path(item))
+        if (const std::optional<bool> cpu_result = execute_cpu_fast_path(item)) {
+            if (authority_requested) {
+                const uint64_t program_hash = prosper::gpu::gpu_capture_hash(
+                    reinterpret_cast<const uint8_t*>(item.spirv.data()),
+                    item.spirv.size() * sizeof(uint32_t));
+                (void)authority_census.observe_program(item, program_hash);
+            }
             all_ok &= *cpu_result;
-        else
-            all_ok &= execute_item(context, item);
+        } else {
+            const bool item_ok = execute_item(context, item);
+            all_ok &= item_ok;
+            if (!item_ok)
+                prosper::gpu::notify_compute_authority_boundary({
+                    prosper::gpu::ComputeAuthorityBoundaryKind::Compute,
+                    item.submit_no, item.command_order, 0, 0, false});
+        }
         if (context.device_lost) break;
     }
     if (timing_enabled) {
@@ -7389,6 +7791,14 @@ void register_live_compute() {
     // Parse and announce a stable timing selector at backend registration, not at the first matching
     // dispatch. A title that never reaches compute must still prove whether the instrument armed.
     (void)runtime_compute_timing_selector();
+    RuntimeComputeAuthorityCensus& authority_census =
+        runtime_compute_authority_census();
+    if (authority_census.requested()) {
+        prosper::gpu::set_compute_authority_boundary_observer(
+            [](const prosper::gpu::ComputeAuthorityBoundary& boundary) {
+                runtime_compute_authority_census().observe_boundary(boundary);
+            });
+    }
     const char* enabled = std::getenv("PROSPER_COMPUTE");
     if (enabled && (!std::strcmp(enabled, "0") || !std::strcmp(enabled, "off"))) {
         std::fprintf(stderr, "[compute] live execution disabled by PROSPER_COMPUTE=%s\n", enabled);

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -540,6 +540,35 @@ struct OperationRealizationFailure {
 
 using LiveComputeFn = std::function<bool(const std::vector<ComputeItem>& items)>;
 
+// Behavior-neutral ordered-boundary observer for the live compute-authority census (#1854).  The
+// executor reports only architectural submit positions and exact guest ranges it already owns;
+// it never asks the observer whether work should execute.  Draw ranges are deliberately unknown
+// until resource consumption is proven precisely enough to make a narrower claim.
+enum class ComputeAuthorityBoundaryKind : uint8_t {
+    SubmitBegin,
+    Draw,
+    Dma,
+    OrderedMemoryEffect,
+    Capture,
+    SubmitEnd,
+    // A compute operation that could not reach the live backend's exact finalized-resource
+    // observations, or an exact CPU-fast write range. Unknown range fails closed; a known range is
+    // treated as an ordered compute memory effect.
+    Compute,
+};
+struct ComputeAuthorityBoundary {
+    ComputeAuthorityBoundaryKind kind = ComputeAuthorityBoundaryKind::SubmitBegin;
+    uint64_t submit_no = 0;
+    uint64_t command_order = 0;
+    uint64_t address = 0;
+    uint64_t bytes = 0;
+    bool range_known = false;
+};
+using ComputeAuthorityBoundaryObserver =
+    std::function<void(const ComputeAuthorityBoundary& boundary)>;
+void set_compute_authority_boundary_observer(ComputeAuthorityBoundaryObserver observer);
+void notify_compute_authority_boundary(const ComputeAuthorityBoundary& boundary);
+
 // Guest GPU writes can change backing memory represented by a persistent host-side image. Backends
 // register one observer so guest-memory-producing backends can invalidate overlapping cached surfaces
 // without making prosper_core depend on Vulkan.

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -74,6 +74,9 @@ namespace {
 LiveRenderFn g_live;   // empty until the runtime/test registers a device-backed renderer
 LiveComputeFn g_compute;   // synchronous compute backend, registered with the live Vulkan frontend
 GuestGpuWriteObserver g_guest_gpu_write_observer;
+ComputeAuthorityBoundaryObserver g_compute_authority_boundary_observer;
+std::mutex g_compute_authority_boundary_mutex;
+std::atomic<bool> g_compute_authority_boundary_enabled{false};
 thread_local LiveRenderPhase g_live_phase;
 std::array<uint8_t, 64 * 1024> g_compute_gds{};
 
@@ -90,6 +93,34 @@ struct GuestGpuWriteJournal {
 thread_local GuestGpuWriteJournal g_guest_gpu_writes;
 std::atomic<uint64_t> g_next_guest_gpu_submit_serial{0};
 std::atomic<uint64_t> g_next_shader_analysis_identity{0};
+
+void dispatch_compute_authority_boundary(const ComputeAuthorityBoundary& boundary) {
+    // Default path: one relaxed load and no mutex/std::function copy when the opt-in diagnostic is
+    // absent. This hook sits on every ordered draw, so making an unarmed census measurable would
+    // defeat the performance investigation it exists to support.
+    if (!g_compute_authority_boundary_enabled.load(std::memory_order_relaxed)) return;
+    ComputeAuthorityBoundaryObserver observer;
+    {
+        std::lock_guard lock(g_compute_authority_boundary_mutex);
+        observer = g_compute_authority_boundary_observer;
+    }
+    if (observer) observer(boundary);
+}
+
+void notify_compute_authority_range(ComputeAuthorityBoundaryKind kind,
+                                    uint64_t submit_no, uint64_t command_order,
+                                    uint64_t address, uint64_t bytes) {
+    const bool known = address != 0 && bytes != 0 &&
+        address <= UINT64_MAX - (bytes - 1);
+    dispatch_compute_authority_boundary(
+        {kind, submit_no, command_order, address, bytes, known});
+}
+
+void notify_compute_authority_unknown(ComputeAuthorityBoundaryKind kind,
+                                      uint64_t submit_no, uint64_t command_order = 0) {
+    dispatch_compute_authority_boundary(
+        {kind, submit_no, command_order, 0, 0, false});
+}
 
 bool ranges_overlap(uint64_t a, uint64_t a_size, uint64_t b, uint64_t b_size) {
     if (!a_size || !b_size) return false;
@@ -4890,6 +4921,8 @@ static OrderedSubmitResult execute_ordered_gpustate(
 bool execute_nonrender_submit_work(const GpuState& st, uint64_t submit_no) {
     if (st.dma_copies.empty() && (!g_compute || st.dispatches.empty())) return false;
     GuestReadableSubmitScope guest_readable_scope;
+    notify_compute_authority_unknown(
+        ComputeAuthorityBoundaryKind::SubmitBegin, submit_no);
     // Compute-only submits never reach execute_ordered_and_present(), but they are exactly where an
     // unsupported dispatch can disappear before there is a realized ComputeItem to select.  Give
     // the environment capture path the same semantic pre-submit hook as rendering submits so
@@ -4920,6 +4953,8 @@ bool execute_nonrender_submit_work(const GpuState& st, uint64_t submit_no) {
         pending_capture && can_defer_capture ? &capture_trace : nullptr);
     if (pending_capture) {
         std::string error;
+        notify_compute_authority_unknown(
+            ComputeAuthorityBoundaryKind::Capture, submit_no);
         if (!finish_requested_gpu_capture(
                 std::move(pending_capture), {}, error,
                 can_defer_capture ? &capture_trace.draws : nullptr,
@@ -4929,6 +4964,8 @@ bool execute_nonrender_submit_work(const GpuState& st, uint64_t submit_no) {
                 can_defer_capture ? &capture_trace.failures : nullptr))
             std::fprintf(stderr, "[gpucap] write failed: %s\n", error.c_str());
     }
+    notify_compute_authority_unknown(
+        ComputeAuthorityBoundaryKind::SubmitEnd, submit_no);
     return !st.dma_execution_rejected &&
            (result.compute_executed || !st.dma_copies.empty() ||
             !st.ordered_memory_effects.empty());
@@ -5922,6 +5959,10 @@ static OrderedSubmitResult execute_ordered_gpustate(const GpuState& st, uint32_t
                                                      const std::vector<DrawItem>* eager_draws) {
     GuestGpuWriteSubmitScope guest_gpu_write_scope;
     if (st.dma_execution_rejected) {
+        for (const GpuState::Dispatch& dispatch : st.dispatches)
+            notify_compute_authority_unknown(
+                ComputeAuthorityBoundaryKind::Compute,
+                submit_no, dispatch.command_order);
         static std::atomic<int> warned{0};
         if (warned.fetch_add(1) < 24)
             std::fprintf(stderr,
@@ -6000,6 +6041,12 @@ static OrderedSubmitResult execute_ordered_gpustate(const GpuState& st, uint32_t
                     }
                     break;
                 }
+                // Resource realization can inspect guest descriptor/backing state.  No exact draw
+                // read range has yet been proven at this seam, so an armed authority census must
+                // fail closed before that first possible consumer rather than after rendering.
+                notify_compute_authority_unknown(
+                    ComputeAuthorityBoundaryKind::Draw,
+                    submit_no, operation.command_order);
                 DrawItem item;
                 bool realized = false;
                 OperationRealizationFailure failure;
@@ -6048,6 +6095,9 @@ static OrderedSubmitResult execute_ordered_gpustate(const GpuState& st, uint32_t
                 flush_span();
                 const bool indirect = st.dispatches[operation.index].indirect;
                 if (indirect && (!indirect_dependencies_ok || !producer_epoch_ok)) {
+                    notify_compute_authority_unknown(
+                        ComputeAuthorityBoundaryKind::Compute,
+                        submit_no, operation.command_order);
                     if (capture_trace) {
                         capture_trace->failures.push_back({
                             SubmitOperationKind::Dispatch, operation.index,
@@ -6058,6 +6108,9 @@ static OrderedSubmitResult execute_ordered_gpustate(const GpuState& st, uint32_t
                     break;
                 }
                 if (!compute) {
+                    notify_compute_authority_unknown(
+                        ComputeAuthorityBoundaryKind::Compute,
+                        submit_no, operation.command_order);
                     if (capture_trace) {
                         capture_trace->failures.push_back({
                             SubmitOperationKind::Dispatch, operation.index,
@@ -6083,9 +6136,15 @@ static OrderedSubmitResult execute_ordered_gpustate(const GpuState& st, uint32_t
                     result.compute_executed |= executed;
                     producer_epoch_ok &= executed;
                 } else if (capture_trace && failure.reason != RealizationFailureReason::None) {
+                    notify_compute_authority_unknown(
+                        ComputeAuthorityBoundaryKind::Compute,
+                        submit_no, operation.command_order);
                     capture_trace->failures.push_back(std::move(failure));
                     producer_epoch_ok = false;
                 } else {
+                    notify_compute_authority_unknown(
+                        ComputeAuthorityBoundaryKind::Compute,
+                        submit_no, operation.command_order);
                     producer_epoch_ok = false;
                 }
                 break;
@@ -6093,6 +6152,14 @@ static OrderedSubmitResult execute_ordered_gpustate(const GpuState& st, uint32_t
             case RetainedSubmitKind::DmaCopy: {
                 flush_span(true);
                 const GpuState::DmaCopy& copy = st.dma_copies[operation.index];
+                // Source and destination are distinct ordered consumers: a disjoint source must not
+                // hide an overlapping destination (or vice versa).
+                notify_compute_authority_range(
+                    ComputeAuthorityBoundaryKind::Dma, submit_no,
+                    operation.command_order, copy.src, copy.bytes);
+                notify_compute_authority_range(
+                    ComputeAuthorityBoundaryKind::Dma, submit_no,
+                    operation.command_order, copy.dst, copy.bytes);
                 std::vector<uint8_t> current_source;
                 const LiveTargetByteReadResult source_result = read_live_render_target_bytes(
                     copy.src, copy.bytes, current_source);
@@ -6120,7 +6187,64 @@ static OrderedSubmitResult execute_ordered_gpustate(const GpuState& st, uint32_t
                 break;
             case RetainedSubmitKind::MemoryEffect:
                 flush_span();
-                execute_ordered_memory_effect(st.ordered_memory_effects[operation.index]);
+                {
+                    const GpuState::MemoryEffect& effect =
+                        st.ordered_memory_effects[operation.index];
+                    const Pm4Command& command = effect.cmd;
+                    bool exact = false;
+                    switch (command.kind) {
+                        case Pm4Command::Kind::ReleaseMem:
+                            notify_compute_authority_range(
+                                ComputeAuthorityBoundaryKind::OrderedMemoryEffect,
+                                submit_no, operation.command_order, command.rel_addr,
+                                command.rel_data_sel == 1u ? 4u : 8u);
+                            exact = command.rel_addr != 0;
+                            break;
+                        case Pm4Command::Kind::EventWrite:
+                            notify_compute_authority_range(
+                                ComputeAuthorityBoundaryKind::OrderedMemoryEffect,
+                                submit_no, operation.command_order, command.event_addr, 8u);
+                            exact = command.event_addr != 0;
+                            break;
+                        case Pm4Command::Kind::WriteData:
+                            notify_compute_authority_range(
+                                ComputeAuthorityBoundaryKind::OrderedMemoryEffect,
+                                submit_no, operation.command_order, command.wd_addr,
+                                static_cast<uint64_t>(command.wd_num) * 4u);
+                            exact = command.wd_addr != 0 && command.wd_num != 0;
+                            break;
+                        case Pm4Command::Kind::DmaData: {
+                            // Selector byte 1 names the 64 KiB GDS offset domain, not guest VA.
+                            // Every other valid destination is an exact guest write range.  A
+                            // >32-bit non-GDS source is an address copy and is observed separately.
+                            const bool source_gds = ((command.dd_sels >> 8u) & 0xffu) == 1u;
+                            const bool destination_gds = (command.dd_sels & 0xffu) == 1u;
+                            if (!source_gds && command.dd_src > UINT32_MAX) {
+                                notify_compute_authority_range(
+                                    ComputeAuthorityBoundaryKind::Dma, submit_no,
+                                    operation.command_order, command.dd_src,
+                                    command.dd_bytes);
+                                exact = command.dd_bytes != 0;
+                            }
+                            if (!destination_gds) {
+                                notify_compute_authority_range(
+                                    ComputeAuthorityBoundaryKind::Dma, submit_no,
+                                    operation.command_order, command.dd_dst,
+                                    command.dd_bytes);
+                                exact = exact ||
+                                    (command.dd_dst != 0 && command.dd_bytes != 0);
+                            }
+                            break;
+                        }
+                        default:
+                            break;
+                    }
+                    if (!exact)
+                        notify_compute_authority_unknown(
+                            ComputeAuthorityBoundaryKind::OrderedMemoryEffect,
+                            submit_no, operation.command_order);
+                    execute_ordered_memory_effect(effect);
+                }
                 break;
         }
     }
@@ -6145,6 +6269,18 @@ uint8_t* compute_gds_backing()            { return g_compute_gds.data(); }
 size_t   compute_gds_size()               { return g_compute_gds.size(); }
 void set_submit_compute(LiveComputeFn fn) { g_compute = std::move(fn); }
 bool have_submit_compute()                { return static_cast<bool>(g_compute); }
+void notify_compute_authority_boundary(
+        const ComputeAuthorityBoundary& boundary) {
+    dispatch_compute_authority_boundary(boundary);
+}
+void set_compute_authority_boundary_observer(
+        ComputeAuthorityBoundaryObserver observer) {
+    std::lock_guard lock(g_compute_authority_boundary_mutex);
+    g_compute_authority_boundary_observer = std::move(observer);
+    g_compute_authority_boundary_enabled.store(
+        static_cast<bool>(g_compute_authority_boundary_observer),
+        std::memory_order_release);
+}
 
 static LiveTargetQueryFn g_live_target_query;   // registered by the live renderer (#590)
 void set_live_target_query(LiveTargetQueryFn fn) { g_live_target_query = std::move(fn); }
@@ -6333,6 +6469,8 @@ bool execute_ordered_and_present(const GpuState& st, uint32_t width, uint32_t he
     // Reuse positive page/VirtualQuery results only inside this synchronous execution window; the
     // scope is discarded before guest code can submit a later mapping generation.
     GuestReadableSubmitScope guest_readable_scope;
+    notify_compute_authority_unknown(
+        ComputeAuthorityBoundaryKind::SubmitBegin, submit_no);
     using TimingClock = std::chrono::steady_clock;
     const bool timing_enabled = std::getenv("PROSPER_RENDER_TIMING") != nullptr;
     const auto timing_start = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
@@ -6400,6 +6538,8 @@ bool execute_ordered_and_present(const GpuState& st, uint32_t width, uint32_t he
 
     if (pending_capture) {
         std::string error;
+        notify_compute_authority_unknown(
+            ComputeAuthorityBoundaryKind::Capture, submit_no);
         const std::vector<DrawItem>* capture_draws = needs_ordered_realization
             ? &capture_trace.draws : &draws;
         const std::vector<ComputeItem>* capture_computes = needs_ordered_realization
@@ -6409,6 +6549,8 @@ bool execute_ordered_and_present(const GpuState& st, uint32_t width, uint32_t he
                                           needs_ordered_realization ? &capture_trace.failures : nullptr))
             std::fprintf(stderr, "[gpucap] write failed: %s\n", error.c_str());
     }
+    notify_compute_authority_unknown(
+        ComputeAuthorityBoundaryKind::SubmitEnd, submit_no);
     const bool frame_ready = px.size() == static_cast<size_t>(width) * height * 4;
     const bool presented = frame_ready && publish;
     if (presented) present_write_frame(result.frame.storage, width, height);

--- a/prosper/tests/test_compute_authority_census.cpp
+++ b/prosper/tests/test_compute_authority_census.cpp
@@ -1,4 +1,5 @@
 #include "compute_authority_census.hpp"
+#include "compute_authority_live_census.hpp"
 
 #include <cstdint>
 #include <cstdio>
@@ -274,6 +275,150 @@ int main() {
               rejected_pending.counters().invalid_result_materializations == 1 &&
               rejected_pending.counters().materializations == 1,
           "a forged invalid result flushes an existing pending authority");
+
+    const ComputeAuthorityLiveSelector selector =
+        parse_compute_authority_live_selector("0x45e5d145e1a35af9");
+    ComputeAuthorityLiveCensus live(selector);
+    live.begin_submit(41);
+    const auto wrong_program = live.observe_program(0xee8584cf839a5b44ull);
+    const auto producer = live.observe_program(0x45e5d145e1a35af9ull);
+    const auto selected_output = live.record_selected_storage_output(atlas, true);
+    const auto gpu_consumer = live.observe(
+        ShadowComputeAuthorityConsumerKind::ProvenGpuImage, atlas);
+    const auto capture_boundary = live.observe(
+        ShadowComputeAuthorityConsumerKind::Capture);
+    const auto clean_end = live.end_submit();
+    CHECK(selector.requested && selector.valid &&
+              !wrong_program.selected && producer.selected && producer.first_match &&
+              selected_output.action ==
+                  ShadowComputeAuthorityAction::TrackPendingResult &&
+              gpu_consumer.action == ShadowComputeAuthorityAction::KeepGpuAuthority &&
+              capture_boundary.action ==
+                  ShadowComputeAuthorityAction::MaterializeGuestMirror &&
+              clean_end.action == ShadowComputeAuthorityAction::NoPendingResult &&
+              live.counters().programs_seen == 2 &&
+              live.counters().programs_matched == 1 &&
+              live.counters().selected_storage_outputs == 1 &&
+              live.counters().retained_storage_outputs == 1 &&
+              live.counters().authority.proven_gpu_keeps == 1 &&
+              live.counters().authority.capture_materializations == 1 &&
+              live.counters().pending_after_submit_end == 0 && live.summary_valid(),
+          "live exact-hash chain closes at capture and ends with zero pending authority");
+
+    ComputeAuthorityLiveCensus ordered(selector);
+    ordered.begin_submit(42);
+    (void)ordered.observe_program(selector.producer_hash);
+    (void)ordered.record_selected_storage_output(atlas, true);
+    const auto disjoint_dma_source = ordered.observe(
+        ShadowComputeAuthorityConsumerKind::Dma, unrelated);
+    const auto overlapping_dma_destination = ordered.observe(
+        ShadowComputeAuthorityConsumerKind::Dma, atlas_tail);
+    const auto ordered_end = ordered.end_submit();
+    CHECK(disjoint_dma_source.action ==
+                  ShadowComputeAuthorityAction::KeepGpuAuthority &&
+              overlapping_dma_destination.action ==
+                  ShadowComputeAuthorityAction::MaterializeGuestMirror &&
+              overlapping_dma_destination.reason ==
+                  ShadowComputeAuthorityReason::OverlappingDmaConsumer &&
+              ordered_end.action == ShadowComputeAuthorityAction::NoPendingResult &&
+              ordered.counters().authority.dma_materializations == 1 &&
+              ordered.counters().authority.unrelated_keeps == 1 &&
+              ordered.counters().pending_after_submit_end == 0 &&
+              ordered.summary_valid(),
+          "live DMA source and destination are observed separately at ordered positions");
+
+    ComputeAuthorityLiveCensus submit_only(selector);
+    submit_only.begin_submit(420);
+    (void)submit_only.observe_program(selector.producer_hash);
+    (void)submit_only.record_selected_storage_output(atlas, true);
+    const auto mandatory_submit_end = submit_only.end_submit();
+    CHECK(mandatory_submit_end.action ==
+                  ShadowComputeAuthorityAction::MaterializeGuestMirror &&
+              mandatory_submit_end.reason == ShadowComputeAuthorityReason::SubmitEnd &&
+              submit_only.counters().authority.submit_end_materializations == 1 &&
+              submit_only.counters().authority.capture_materializations == 0 &&
+              submit_only.counters().pending_before_submit_end == 1 &&
+              submit_only.counters().pending_after_submit_end == 0 &&
+              submit_only.summary_valid(),
+          "live submit end unconditionally closes pending authority with exact attribution");
+
+    ComputeAuthorityLiveCensus unknown_draw(selector);
+    unknown_draw.begin_submit(43);
+    (void)unknown_draw.observe_program(selector.producer_hash);
+    (void)unknown_draw.record_selected_storage_output(atlas, true);
+    const auto draw_boundary = unknown_draw.observe(
+        ShadowComputeAuthorityConsumerKind::Draw);
+    (void)unknown_draw.end_submit();
+    CHECK(draw_boundary.action ==
+                  ShadowComputeAuthorityAction::MaterializeGuestMirror &&
+              draw_boundary.reason ==
+                  ShadowComputeAuthorityReason::UnknownConsumerRange &&
+              unknown_draw.counters().authority.draw_materializations == 1 &&
+              unknown_draw.counters().authority.unknown_range_materializations == 1,
+          "live draw with no proven range fails closed at the exact boundary");
+
+    ComputeAuthorityLiveCensus sync_output(selector);
+    sync_output.begin_submit(44);
+    (void)sync_output.observe_program(selector.producer_hash);
+    (void)sync_output.record_selected_storage_output(atlas, true);
+    const auto synchronous_replacement =
+        sync_output.record_selected_storage_output(atlas_tail, false);
+    (void)sync_output.end_submit();
+    CHECK(synchronous_replacement.action ==
+                  ShadowComputeAuthorityAction::MaterializeGuestMirror &&
+              synchronous_replacement.reason ==
+                  ShadowComputeAuthorityReason::OverlappingOrderedMemoryEffectConsumer &&
+              sync_output.counters().selected_storage_outputs == 2 &&
+              sync_output.counters().retained_storage_outputs == 1 &&
+              sync_output.counters().synchronous_storage_outputs == 1,
+          "a selected output without retained authority remains a visible synchronous write");
+
+    ComputeAuthorityLiveCensus zero_match(selector);
+    zero_match.begin_submit(45);
+    (void)zero_match.observe_program(0xee8584cf839a5b44ull);
+    (void)zero_match.end_submit();
+    CHECK(!zero_match.summary_valid(),
+          "a live authority run with zero producer matches is apparatus-invalid");
+
+    ComputeAuthorityLiveCensus zero_output(selector);
+    zero_output.begin_submit(451);
+    (void)zero_output.observe_program(selector.producer_hash);
+    (void)zero_output.end_submit();
+    CHECK(zero_output.counters().programs_matched == 1 &&
+              zero_output.counters().retained_storage_outputs == 0 &&
+              zero_output.counters().authority.admitted_results == 0 &&
+              !zero_output.summary_valid(),
+          "a matched producer with no admitted retained result is apparatus-invalid");
+
+    ComputeAuthorityLiveCensus invalid_selector(
+        parse_compute_authority_live_selector("0xnot-a-hash"));
+    invalid_selector.begin_submit(46);
+    CHECK(!invalid_selector.observe_program(selector.producer_hash).selected,
+          "an invalid live selector fails closed instead of selecting a producer");
+    (void)invalid_selector.end_submit();
+    CHECK(!invalid_selector.summary_valid(),
+          "an invalid live selector cannot produce a valid census verdict");
+
+    ComputeAuthorityLiveCensus interrupted(selector);
+    interrupted.begin_submit(47);
+    (void)interrupted.observe_program(selector.producer_hash);
+    (void)interrupted.record_selected_storage_output(atlas, true);
+    interrupted.begin_submit(48);
+    (void)interrupted.end_submit();
+    CHECK(interrupted.counters().interrupted_submits == 1 &&
+              interrupted.counters().authority.unknown_consumer_materializations == 1 &&
+              interrupted.counters().pending_after_submit_end == 0 &&
+              !interrupted.summary_valid(),
+          "a nested submit start closes pending authority and invalidates the apparatus");
+
+    ComputeAuthorityLiveCensus no_submit(selector);
+    (void)no_submit.observe(ShadowComputeAuthorityConsumerKind::Draw);
+    CHECK(no_submit.counters().observations_without_submit == 1 &&
+              !no_submit.summary_valid(),
+          "a boundary outside a live submit is counted and fails closed");
+
+    CHECK(live.claim_summary() && !live.claim_summary(),
+          "explicit and destructor-style live summaries can publish only once");
 
     if (failures) {
         std::printf("%d check(s) failed\n", failures);

--- a/prosper/tests/test_game_compute.cpp
+++ b/prosper/tests/test_game_compute.cpp
@@ -671,10 +671,19 @@ int main() {
         if (addr == buffer.gpu_addr && size == buffer.size)
             ++cpu_fill_write_notifications;
     });
+    std::vector<ComputeAuthorityBoundary> cpu_fill_authority_boundaries;
+    bool cpu_fill_boundary_preceded_write = false;
+    set_compute_authority_boundary_observer(
+        [&](const ComputeAuthorityBoundary& boundary) {
+            cpu_fill_authority_boundaries.push_back(boundary);
+            cpu_fill_boundary_preceded_write = !result.empty() &&
+                result.front() == 0xddddddddu;
+        });
     const uint64_t cpu_fills_before =
         prosper::frontend::live_compute_cpu_fill_dispatches();
     CHECK(prosper::frontend::execute_live_compute_items({cpu_fill_item}),
           "exact buffer-fill program executes through the CPU fast path");
+    set_compute_authority_boundary_observer({});
     set_guest_gpu_write_observer({});
     bool cpu_fill_matches = true;
     for (uint32_t record = 0; record < records && cpu_fill_matches; ++record)
@@ -687,7 +696,13 @@ int main() {
     CHECK(cpu_fill_matches && cpu_fill_padding_untouched &&
               cpu_fill_write_notifications == 1 &&
               prosper::frontend::live_compute_cpu_fill_dispatches() ==
-                  cpu_fills_before + 1,
+                  cpu_fills_before + 1 && cpu_fill_boundary_preceded_write &&
+              cpu_fill_authority_boundaries.size() == 1 &&
+              cpu_fill_authority_boundaries[0].kind ==
+                  ComputeAuthorityBoundaryKind::Compute &&
+              cpu_fill_authority_boundaries[0].range_known &&
+              cpu_fill_authority_boundaries[0].address == buffer.gpu_addr &&
+              cpu_fill_authority_boundaries[0].bytes == records * 16u,
           "CPU fill matches Vulkan, preserves padded lanes, and invalidates the declared range");
 
     ShaderResourceTable narrow_stride_rt = rt;
@@ -2242,8 +2257,19 @@ int main() {
         unsupported_tiled_item.launch.local_y = unsupported_tiled_item.launch.local_z = 1;
         unsupported_tiled_item.launch.groups_y = unsupported_tiled_item.launch.groups_z = 1;
         unsupported_tiled_item.code_addr = 0x590594;
-        CHECK(!prosper::frontend::execute_live_compute_items({unsupported_tiled_item}),
-              "unknown nonzero tile mode is rejected before storage writeback");
+        std::vector<ComputeAuthorityBoundary> failed_compute_boundaries;
+        set_compute_authority_boundary_observer(
+            [&](const ComputeAuthorityBoundary& boundary) {
+                failed_compute_boundaries.push_back(boundary);
+            });
+        const bool unsupported_executed =
+            prosper::frontend::execute_live_compute_items({unsupported_tiled_item});
+        set_compute_authority_boundary_observer({});
+        CHECK(!unsupported_executed && failed_compute_boundaries.size() == 1 &&
+                  failed_compute_boundaries[0].kind ==
+                      ComputeAuthorityBoundaryKind::Compute &&
+                  !failed_compute_boundaries[0].range_known,
+              "failed live compute emits one fail-closed boundary before returning false");
     }
 
     // A renderer-owned color target is newer than its guest backing. Recompile the same copy kernel

--- a/prosper/tests/test_gpu_execute.cpp
+++ b/prosper/tests/test_gpu_execute.cpp
@@ -646,14 +646,40 @@ int main() {
             (uint64_t)(uintptr_t)copied_indices, (uint64_t)(uintptr_t)source_indices,
             sizeof(copied_indices), 0, 100, 0});
         std::vector<uint32_t> submitted_indices;
+        std::vector<ComputeAuthorityBoundary> authority_boundaries;
+        set_compute_authority_boundary_observer(
+            [&](const ComputeAuthorityBoundary& boundary) {
+                authority_boundaries.push_back(boundary);
+            });
         set_submit_renderer([&](const std::vector<DrawItem>& items, uint32_t, uint32_t) {
             if (!items.empty()) submitted_indices = items.front().indices;
             return RenderedFrame{};
         });
         execute_ordered_and_present(ordered, W, H, 77, /*publish=*/false);
         set_submit_renderer({});
+        set_compute_authority_boundary_observer({});
         CHECK(submitted_indices == std::vector<uint32_t>({0, 1, 2}),
               "DMA-backed index buffer is realized after the ordered copy in the production path");
+        CHECK(authority_boundaries.size() == 5 &&
+                  authority_boundaries[0].kind ==
+                      ComputeAuthorityBoundaryKind::SubmitBegin &&
+                  authority_boundaries[0].submit_no == 77 &&
+                  authority_boundaries[1].kind == ComputeAuthorityBoundaryKind::Dma &&
+                  authority_boundaries[1].range_known &&
+                  authority_boundaries[1].address ==
+                      reinterpret_cast<uint64_t>(source_indices) &&
+                  authority_boundaries[1].bytes == sizeof(source_indices) &&
+                  authority_boundaries[2].kind == ComputeAuthorityBoundaryKind::Dma &&
+                  authority_boundaries[2].range_known &&
+                  authority_boundaries[2].address ==
+                      reinterpret_cast<uint64_t>(copied_indices) &&
+                  authority_boundaries[2].bytes == sizeof(copied_indices) &&
+                  authority_boundaries[3].kind == ComputeAuthorityBoundaryKind::Draw &&
+                  !authority_boundaries[3].range_known &&
+                  authority_boundaries[3].command_order == 200 &&
+                  authority_boundaries[4].kind ==
+                      ComputeAuthorityBoundaryKind::SubmitEnd,
+              "authority hook preserves submit, DMA source/destination, draw, and end order");
     }
 
     // Indirect arguments are generated memory, not command-fold inputs. Supply them through an
@@ -821,6 +847,14 @@ int main() {
         unresolved_dispatch.indirect_args_addr = 0xdead00000000ull;
         unresolved_dispatch.command_order = 19;
         nonrender.dispatches.push_back(unresolved_dispatch);
+        uint32_t authority_effect_target = 0;
+        const uint32_t authority_effect_value = 0x1854cafeu;
+        Pm4Command authority_effect;
+        authority_effect.kind = Pm4Command::Kind::WriteData;
+        authority_effect.wd_addr = reinterpret_cast<uint64_t>(&authority_effect_target);
+        authority_effect.wd_num = 1;
+        authority_effect.wd_data = &authority_effect_value;
+        nonrender.ordered_memory_effects.emplace_back(authority_effect, 18);
         const std::filesystem::path path =
             prosper_test::test_scratch_dir() / "prosper_nonrender_submit_capture.prgcap";
         std::error_code filesystem_error;
@@ -833,12 +867,18 @@ int main() {
         setenv("PROSPER_GPU_CAPTURE_METADATA_ONLY", "1", 1);
 #endif
         uint32_t compute_calls = 0;
+        std::vector<ComputeAuthorityBoundary> nonrender_authority_boundaries;
+        set_compute_authority_boundary_observer(
+            [&](const ComputeAuthorityBoundary& boundary) {
+                nonrender_authority_boundaries.push_back(boundary);
+            });
         set_submit_compute([&](const std::vector<ComputeItem>& items) {
             compute_calls += static_cast<uint32_t>(items.size());
             return !items.empty();
         });
         const bool executed = execute_nonrender_submit_work(nonrender, 1441);
         set_submit_compute({});
+        set_compute_authority_boundary_observer({});
 #ifdef _WIN32
         _putenv_s("PROSPER_GPU_CAPTURE", "");
         _putenv_s("PROSPER_GPU_CAPTURE_METADATA_ONLY", "");
@@ -883,6 +923,27 @@ int main() {
                       std::vector<uint32_t>(std::begin(kNoopCs), std::end(kNoopCs)) &&
                   !captured.expected_output_valid,
               "ordered capture retains exact direct and unresolved indirect compute evidence");
+        CHECK(nonrender_authority_boundaries.size() == 5 &&
+                  nonrender_authority_boundaries[0].kind ==
+                      ComputeAuthorityBoundaryKind::SubmitBegin &&
+                  nonrender_authority_boundaries[0].submit_no == 1441 &&
+                  nonrender_authority_boundaries[1].kind ==
+                      ComputeAuthorityBoundaryKind::OrderedMemoryEffect &&
+                  nonrender_authority_boundaries[1].range_known &&
+                  nonrender_authority_boundaries[1].address ==
+                      reinterpret_cast<uint64_t>(&authority_effect_target) &&
+                  nonrender_authority_boundaries[1].bytes == sizeof(uint32_t) &&
+                  nonrender_authority_boundaries[1].command_order == 18 &&
+                  authority_effect_target == authority_effect_value &&
+                  nonrender_authority_boundaries[2].kind ==
+                      ComputeAuthorityBoundaryKind::Compute &&
+                  !nonrender_authority_boundaries[2].range_known &&
+                  nonrender_authority_boundaries[2].command_order == 19 &&
+                  nonrender_authority_boundaries[3].kind ==
+                      ComputeAuthorityBoundaryKind::Capture &&
+                  nonrender_authority_boundaries[4].kind ==
+                      ComputeAuthorityBoundaryKind::SubmitEnd,
+              "non-render authority hook fail-closes unrealized compute before capture and end");
         std::filesystem::remove(path, filesystem_error);
 
         // A partial exact trace can identify an operation whose source index happens to exist in

--- a/prosper/tools/perf/mutate_compute_authority_census.sh
+++ b/prosper/tools/perf/mutate_compute_authority_census.sh
@@ -11,8 +11,11 @@ ROOT=$(cd "$HERE/../.." && pwd)
 WORK=$(mktemp -d "${TMPDIR:-/var/tmp}/compute-authority-mutate-XXXXXX") || exit 2
 trap 'rm -rf "$WORK"' EXIT
 cp "$ROOT/frontends/shared/compute_authority_census.hpp" \
+   "$ROOT/frontends/shared/compute_authority_live_census.hpp" \
+   "$ROOT/frontends/shared/compute_timing_selector.hpp" \
    "$ROOT/tests/test_compute_authority_census.cpp" "$WORK/" || exit 2
 HEADER="$WORK/compute_authority_census.hpp"
+LIVE_HEADER="$WORK/compute_authority_live_census.hpp"
 CXX_BIN=${CXX:-c++}
 
 python3 - "$HEADER" <<'PY' || exit 1
@@ -53,7 +56,95 @@ if [ "$failed" != "$expected" ]; then
 fi
 printf 'raw overlap mutation: killed by: %s\n' "$expected"
 
+# The live wrapper's unconditional submit close is an ordered visibility boundary, not cleanup
+# bookkeeping. Misattributing it as capture has the historical defect's shape: pending authority is
+# still closed, so a weak pending=0-only test would stay green. The exact named attribution check
+# must be the sole kill.
 cp "$ROOT/frontends/shared/compute_authority_census.hpp" "$HEADER"
+cp "$ROOT/frontends/shared/compute_authority_live_census.hpp" "$LIVE_HEADER"
+python3 - "$LIVE_HEADER" <<'PY' || exit 1
+import sys
+
+path = sys.argv[1]
+old = """        const ShadowComputeAuthorityTransition transition = submit_.observe(
+            ShadowComputeAuthorityConsumerKind::SubmitEnd);"""
+new = """        const ShadowComputeAuthorityTransition transition = submit_.observe(
+            ShadowComputeAuthorityConsumerKind::Capture);"""
+with open(path, encoding="utf-8") as stream:
+    source = stream.read()
+if source.count(old) != 1:
+    raise SystemExit(f"mutation anchor count is {source.count(old)}, expected exactly one")
+with open(path, "w", encoding="utf-8") as stream:
+    stream.write(source.replace(old, new, 1))
+PY
+
+if ! "$CXX_BIN" -std=c++20 -Wall -Wextra -Werror -I"$WORK" \
+    "$WORK/test_compute_authority_census.cpp" -o "$WORK/test-authority"
+then
+    echo "submit-end attribution mutation: BUILD FAILED (mutation not observed)"
+    exit 1
+fi
+
+output=$("$WORK/test-authority" 2>&1)
+status=$?
+failed=$(printf '%s\n' "$output" | sed -n 's/^  FAIL //p')
+expected="live submit end unconditionally closes pending authority with exact attribution"
+if [ "$status" -eq 0 ]; then
+    echo "submit-end attribution mutation: *** SURVIVED ***"
+    exit 1
+fi
+if [ "$failed" != "$expected" ]; then
+    printf 'submit-end attribution mutation: WRONG KILL expected "%s", got: %s\n' \
+        "$expected" "$failed"
+    exit 1
+fi
+printf 'submit-end attribution mutation: killed by: %s\n' "$expected"
+
+# A hash match is not evidence that the proposed deferred-authority lever ever moved. Remove both
+# retained/admitted requirements while keeping exact selection intact; only the zero-output fixture
+# may kill this defect-shaped false-positive verdict.
+cp "$ROOT/frontends/shared/compute_authority_census.hpp" "$HEADER"
+cp "$ROOT/frontends/shared/compute_authority_live_census.hpp" "$LIVE_HEADER"
+python3 - "$LIVE_HEADER" <<'PY' || exit 1
+import sys
+
+path = sys.argv[1]
+old = """            counters_.retained_storage_outputs != 0 &&
+            counters_.authority.admitted_results != 0 &&"""
+new = """            true &&
+            true &&"""
+with open(path, encoding="utf-8") as stream:
+    source = stream.read()
+if source.count(old) != 1:
+    raise SystemExit(f"mutation anchor count is {source.count(old)}, expected exactly one")
+with open(path, "w", encoding="utf-8") as stream:
+    stream.write(source.replace(old, new, 1))
+PY
+
+if ! "$CXX_BIN" -std=c++20 -Wall -Wextra -Werror -I"$WORK" \
+    "$WORK/test_compute_authority_census.cpp" -o "$WORK/test-authority"
+then
+    echo "zero-authority-lever mutation: BUILD FAILED (mutation not observed)"
+    exit 1
+fi
+
+output=$("$WORK/test-authority" 2>&1)
+status=$?
+failed=$(printf '%s\n' "$output" | sed -n 's/^  FAIL //p')
+expected="a matched producer with no admitted retained result is apparatus-invalid"
+if [ "$status" -eq 0 ]; then
+    echo "zero-authority-lever mutation: *** SURVIVED ***"
+    exit 1
+fi
+if [ "$failed" != "$expected" ]; then
+    printf 'zero-authority-lever mutation: WRONG KILL expected "%s", got: %s\n' \
+        "$expected" "$failed"
+    exit 1
+fi
+printf 'zero-authority-lever mutation: killed by: %s\n' "$expected"
+
+cp "$ROOT/frontends/shared/compute_authority_census.hpp" "$HEADER"
+cp "$ROOT/frontends/shared/compute_authority_live_census.hpp" "$LIVE_HEADER"
 if "$CXX_BIN" -std=c++20 -Wall -Wextra -Werror -I"$WORK" \
        "$WORK/test_compute_authority_census.cpp" -o "$WORK/test-authority" && \
    "$WORK/test-authority" >/dev/null


### PR DESCRIPTION
## Summary

Wire the existing shadow compute-authority model into the live ordered renderer as a behavior-neutral census.

This gives issue #1854 a self-validating way to identify the first real observer that would force Syberia's selected storage-image result back into guest memory before we attempt deferred writeback. The current synchronous readback/writeback behavior is unchanged.

## What changed

- add a process-start stable-SPIR-V-hash selector for one compute producer
- wrap each ordered submit in a bounded live authority census
- observe compute inputs and outputs, draws, DMA, captures, ordered memory effects, submit completion, and fail-closed execution boundaries
- publish first-detail diagnostics plus an uncapped terminal summary
- require the selected producer, a retained storage output, and an actually admitted authority result before a summary can be valid
- cover CPU-fast, unrealized/failing/early-exit, and successful finalized compute paths
- saturate counters and keep the unarmed path to one relaxed atomic check

This is instrumentation only: it neither defers nor skips writeback and claims no performance improvement yet.

## Validation

From `<WORKTREE>` inside the required `ps5ys` distrobox:

```sh
export TMPDIR="$PWD/.tmp"
mkdir -p "$TMPDIR"
cmake --build prosper/build-linux -j2 --target   prosper_live_renderer   test_game_compute   test_compute_authority_census   test_gpu_execute
ctest --test-dir prosper/build-linux --output-on-failure   -R '^(compute_timing_selector_policy|compute_authority_census_policy|gpu_execute)$'
prosper/tools/perf/mutate_compute_authority_census.sh
```

Results:

- all four targets built
- focused CPU tests: 3/3 passed
- raw-overlap mutation: killed by its exact named check
- submit-end attribution mutation: killed by its exact named check
- zero-authority-lever mutation: killed by its exact named check
- unmutated mutation copy: passed
- `git diff --check`: clean
- `test_game_compute` was compiled but not executed before publication because it is Vulkan/GPU-heavy and the shared GPU was assigned to the Astro lane
- full snapshot suite not run; it is optional for an ordinary development PR under project policy

## Independent review

The first review found two real issues:

1. missing CPU-fast and failed/unrealized/early-exit compute boundaries
2. a possible valid verdict even when no retained/admitted authority lever moved

Both are fixed in this head with fail-closed boundaries, production-path fixtures, and a defect-shaped zero-lever mutation. Independent re-review approved stable patch ID `0dd729fc310e4277619f2493dc3915af297cd90d`. The reviewer will post the traceable approval on this PR.

Refs #1854
