### PR TITLE
diag(compute): expose storage cache gate inputs

### DIFF
--- a/prosper/docs/ASTROBOT_LINUX_HANDOFF_2026_07_19.md
+++ b/prosper/docs/ASTROBOT_LINUX_HANDOFF_2026_07_19.md
@@ -636,9 +636,25 @@ than re-deriving a dead answer at full cost.
   control attributed all 171 watched ordinary writebacks to the consumer itself with no missing
   intervals. A second uncapped gate census matched both programs 249 times and found identical
   public 3840x2160 RGBA typed-storage/device gates at that address, but the producer's binding 65 was
-  never a cache candidate or persistent while the consumer's binding 73 always was. The remaining
-  question is therefore the producer's cache-eligibility predicate (renderer ownership versus DCC
-  safety with the current diagnostics), not spurious invalidation of unchanged bytes. See #1732.
+  never a cache candidate or persistent while the consumer's binding 73 always was. This excludes
+  spurious invalidation of unchanged bytes; the later exact six-input gate census below resolves the
+  then-open renderer-ownership-versus-DCC question. See #1732.
+
+- **"Renderer ownership prevents Astro's 4K producer from retaining the image consumed by the next
+  dispatch."** False on exact diagnostic revision `a65a7a39` in one natural 720-present, full-scale,
+  every-submit arm for #1732. The self-validating transfer selector matched both exact programs 249
+  times and observed 498 storage gates for each role. Both roles reported zero renderer-owned gates,
+  while the producer reported only 249/498 DCC-safe gates and the consumer reported 498/498. The
+  first real producer gate for binding 65 at `0x520440000` was exact storage with persistent caching
+  enabled but had `dcc-cache-safe=0`, so it was neither a candidate nor persistent. The first
+  consumer gate for binding 73 at the same target had the same relevant gates except
+  `dcc-cache-safe=1`, and was both a candidate and persistent. This is consistent with the existing
+  successful producer writeback making that target's compressed metadata fully expanded (`0xff`)
+  before the consumer dispatch. The run returned normally, reached the world map, completed all 720
+  presents without device loss, and emitted exactly one bounded storage-detail record per role. Its
+  timing selector was deliberately not armed with a phase/image timer and correctly ended
+  `INVALID-zero-matches`, so this result makes no phase-timing claim. The exact cache frontier is the
+  producer's pre-dispatch compressed DCC state, not renderer ownership. See #1732.
 
 - **"A timeline submit with `dmas=0` contains no GDS counter reset."** False for timeline versions
   through v9. The timeline derived its DMA census exclusively from `GpuState::dma_copies`, the

--- a/prosper/docs/ASTROBOT_LINUX_HANDOFF_2026_07_19.md
+++ b/prosper/docs/ASTROBOT_LINUX_HANDOFF_2026_07_19.md
@@ -626,6 +626,20 @@ it is meaningful. Continue the wider title-screen/gameplay investigation indepen
 One line per falsified hypothesis, the evidence that killed it, and the issue/PR. Extend this rather
 than re-deriving a dead answer at full cost.
 
+- **"The 4K consumer keeps rebuilding a stable image because unrelated GPU-write notifications
+  falsely invalidate its cache entry."** False on exact master `04c43b15` in the natural 720-present
+  exact-hash arms for #1732. Consumer `0x5005a8100` / `0x05975892ababe69f` used the 3840x2160 target
+  at `0x520440000` 172 times: its first use skipped the upload even though producer
+  `0x50057b800` / `0xa5e27ec0def1a807` had just published an ordinary full-range GPU write in the
+  same submit, proving that the notification alone does not force a rebuild. Every one of the later
+  171 changed uses had a real intervening write from that producer, and the provenance positive
+  control attributed all 171 watched ordinary writebacks to the consumer itself with no missing
+  intervals. A second uncapped gate census matched both programs 249 times and found identical
+  public 3840x2160 RGBA typed-storage/device gates at that address, but the producer's binding 65 was
+  never a cache candidate or persistent while the consumer's binding 73 always was. The remaining
+  question is therefore the producer's cache-eligibility predicate (renderer ownership versus DCC
+  safety with the current diagnostics), not spurious invalidation of unchanged bytes. See #1732.
+
 - **"A timeline submit with `dmas=0` contains no GDS counter reset."** False for timeline versions
   through v9. The timeline derived its DMA census exclusively from `GpuState::dma_copies`, the
   ordered-execution vector for address-backed copies. Immediate fills, rejected packets, and GDS

--- a/prosper/frontends/shared/compute_transfer_gate_census.hpp
+++ b/prosper/frontends/shared/compute_transfer_gate_census.hpp
@@ -81,14 +81,17 @@ inline ComputeTransferGateSelectorObservation observe_compute_transfer_gate_sele
     return {role, first_match};
 }
 
-inline void record_compute_transfer_storage_gate_observation(
+inline bool record_compute_transfer_storage_gate_observation(
     ComputeTransferGateRole role,
     ComputeTransferGateSelectorCounters& counters) {
     uint64_t* observations = role == ComputeTransferGateRole::Producer
         ? &counters.producer_storage_gate_observations
         : role == ComputeTransferGateRole::Consumer
             ? &counters.consumer_storage_gate_observations : nullptr;
-    if (observations) *observations = saturating_increment(*observations);
+    if (!observations) return false;
+    const bool first_observation = *observations == 0;
+    *observations = saturating_increment(*observations);
+    return first_observation;
 }
 
 constexpr bool compute_transfer_gate_selector_is_invalid(

--- a/prosper/frontends/shared/compute_transfer_gate_census.hpp
+++ b/prosper/frontends/shared/compute_transfer_gate_census.hpp
@@ -12,6 +12,25 @@ enum class ComputeTransferGateRole : uint8_t {
     Consumer,
 };
 
+// Keep the storage-image cache decision and its diagnostic inputs together.  A transfer-gate
+// census must expose every input to this policy: reporting only the derived candidate bit cannot
+// distinguish a real eligibility difference from an instrument that never observed the gate.
+struct ComputeStorageCacheGateInputs {
+    bool renderer_owned = false;
+    bool dcc_cache_safe = false;
+    bool poison_verify = false;
+    bool exact_storage = false;
+    bool seed_skip = false;
+    bool persistent_enabled = false;
+};
+
+constexpr bool compute_storage_cache_gate_candidate(
+    const ComputeStorageCacheGateInputs& inputs) {
+    return !inputs.renderer_owned && inputs.dcc_cache_safe &&
+           !inputs.poison_verify && (inputs.exact_storage || inputs.seed_skip) &&
+           inputs.persistent_enabled;
+}
+
 struct ComputeTransferGateSelector {
     bool requested = false;
     bool valid = false;
@@ -36,6 +55,8 @@ struct ComputeTransferGateSelectorCounters {
     uint64_t seen = 0;
     uint64_t producer_matches = 0;
     uint64_t consumer_matches = 0;
+    uint64_t producer_storage_gate_observations = 0;
+    uint64_t consumer_storage_gate_observations = 0;
     bool summary_reported = false;
 };
 
@@ -60,12 +81,24 @@ inline ComputeTransferGateSelectorObservation observe_compute_transfer_gate_sele
     return {role, first_match};
 }
 
+inline void record_compute_transfer_storage_gate_observation(
+    ComputeTransferGateRole role,
+    ComputeTransferGateSelectorCounters& counters) {
+    uint64_t* observations = role == ComputeTransferGateRole::Producer
+        ? &counters.producer_storage_gate_observations
+        : role == ComputeTransferGateRole::Consumer
+            ? &counters.consumer_storage_gate_observations : nullptr;
+    if (observations) *observations = saturating_increment(*observations);
+}
+
 constexpr bool compute_transfer_gate_selector_is_invalid(
     const ComputeTransferGateSelector& selector,
     const ComputeTransferGateSelectorCounters& counters) {
     return selector.requested &&
            (!selector.valid || selector.producer_hash == selector.consumer_hash ||
-            counters.producer_matches == 0 || counters.consumer_matches == 0);
+            counters.producer_matches == 0 || counters.consumer_matches == 0 ||
+            counters.producer_storage_gate_observations == 0 ||
+            counters.consumer_storage_gate_observations == 0);
 }
 
 inline bool claim_compute_transfer_gate_selector_summary(

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -3012,10 +3012,11 @@ public:
                               uint32_t binding,
                               const ComputeStorageCacheGateInputs& inputs,
                               bool cache_candidate,
-                              bool persistent_setup, bool detail) {
+                              bool persistent_setup) {
         if (role == ComputeTransferGateRole::None) return;
         std::lock_guard lock(mutex_);
-        record_compute_transfer_storage_gate_observation(role, counters_);
+        const bool detail =
+            record_compute_transfer_storage_gate_observation(role, counters_);
         ComputeTransferGateStats& stats = stats_for(role);
         increment_gate_counter(stats.storage_cache_evaluated);
         increment_gate_counter(stats.storage_renderer_owned, inputs.renderer_owned);
@@ -5285,8 +5286,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 transfer_gate_census.record_storage_cache(
                     transfer_gate_observation.role, *r, bi.binding,
                     storage_cache_gates,
-                    bi.cache_candidate, bi.persistent,
-                    transfer_gate_observation.first_match);
+                    bi.cache_candidate, bi.persistent);
                 if (!(bi.persistent && bi.upload_skipped)) {
                 const size_t linear_size = (bi.seed_skip || bi.seed_from_imported != SIZE_MAX)
                     ? size_t{0} : static_cast<size_t>(linear_guest_bytes);

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -2820,6 +2820,12 @@ struct ComputeTransferGateStats {
     uint64_t storage_native_semantic = 0;
     uint64_t storage_native_device = 0;
     uint64_t storage_cache_evaluated = 0;
+    uint64_t storage_renderer_owned = 0;
+    uint64_t storage_dcc_cache_safe = 0;
+    uint64_t storage_poison_verify = 0;
+    uint64_t storage_exact = 0;
+    uint64_t storage_seed_skip = 0;
+    uint64_t storage_persistent_enabled = 0;
     uint64_t storage_cache_candidate = 0;
     uint64_t storage_persistent_setup = 0;
     uint64_t storage_publish_evaluated = 0;
@@ -3003,20 +3009,38 @@ public:
 
     void record_storage_cache(ComputeTransferGateRole role,
                               const prosper::gpu::ShaderResource& resource,
-                              uint32_t binding, bool cache_candidate,
+                              uint32_t binding,
+                              const ComputeStorageCacheGateInputs& inputs,
+                              bool cache_candidate,
                               bool persistent_setup, bool detail) {
         if (role == ComputeTransferGateRole::None) return;
         std::lock_guard lock(mutex_);
+        record_compute_transfer_storage_gate_observation(role, counters_);
         ComputeTransferGateStats& stats = stats_for(role);
         increment_gate_counter(stats.storage_cache_evaluated);
+        increment_gate_counter(stats.storage_renderer_owned, inputs.renderer_owned);
+        increment_gate_counter(stats.storage_dcc_cache_safe, inputs.dcc_cache_safe);
+        increment_gate_counter(stats.storage_poison_verify, inputs.poison_verify);
+        increment_gate_counter(stats.storage_exact, inputs.exact_storage);
+        increment_gate_counter(stats.storage_seed_skip, inputs.seed_skip);
+        increment_gate_counter(stats.storage_persistent_enabled,
+                               inputs.persistent_enabled);
         increment_gate_counter(stats.storage_cache_candidate, cache_candidate);
         increment_gate_counter(stats.storage_persistent_setup, persistent_setup);
         if (detail) {
             std::fprintf(stderr,
                          "[compute-transfer-gates] detail role=%s stage=storage-cache "
-                         "binding=%u addr=0x%llx cache-candidate=%u persistent=%u\n",
+                         "binding=%u addr=0x%llx renderer-owned=%u dcc-cache-safe=%u "
+                         "poison-verify=%u exact-storage=%u seed-skip=%u "
+                         "persistent-enabled=%u cache-candidate=%u persistent=%u\n",
                          compute_transfer_gate_role_name(role), binding,
                          static_cast<unsigned long long>(resource.gpu_addr),
+                         inputs.renderer_owned ? 1u : 0u,
+                         inputs.dcc_cache_safe ? 1u : 0u,
+                         inputs.poison_verify ? 1u : 0u,
+                         inputs.exact_storage ? 1u : 0u,
+                         inputs.seed_skip ? 1u : 0u,
+                         inputs.persistent_enabled ? 1u : 0u,
                          cache_candidate ? 1u : 0u, persistent_setup ? 1u : 0u);
         }
     }
@@ -3043,13 +3067,18 @@ public:
         std::fprintf(stderr,
                      "[compute-transfer-gates] summary producer=0x%016llx "
                      "consumer=0x%016llx seen=%llu producer-matched=%llu "
-                     "consumer-matched=%llu verdict=%s producer-reason=%s "
+                     "consumer-matched=%llu producer-storage-gates=%llu "
+                     "consumer-storage-gates=%llu verdict=%s producer-reason=%s "
                      "consumer-reason=%s\n",
                      static_cast<unsigned long long>(selector_.producer_hash),
                      static_cast<unsigned long long>(selector_.consumer_hash),
                      static_cast<unsigned long long>(counters_.seen),
                      static_cast<unsigned long long>(counters_.producer_matches),
                      static_cast<unsigned long long>(counters_.consumer_matches),
+                     static_cast<unsigned long long>(
+                         counters_.producer_storage_gate_observations),
+                     static_cast<unsigned long long>(
+                         counters_.consumer_storage_gate_observations),
                      invalid ? "INVALID" : "matched",
                      compute_timing_selector_parse_error_name(producer_error_),
                      compute_timing_selector_parse_error_name(consumer_error_));
@@ -3069,7 +3098,9 @@ private:
                      "[compute-transfer-gates] summary role=%s reflected=%llu storage=%llu "
                      "sampled=%llu dim2d=%llu nonarrayed=%llu nonmsaa=%llu ordinary2d=%llu "
                      "storage-float=%llu native-semantic=%llu native-device=%llu "
-                     "storage-cache-eval=%llu storage-candidate=%llu "
+                     "storage-cache-eval=%llu renderer-owned=%llu "
+                     "dcc-cache-safe=%llu poison-verify=%llu exact-storage=%llu "
+                     "seed-skip=%llu persistent-enabled=%llu storage-candidate=%llu "
                      "storage-persistent-setup=%llu publish-eval=%llu publish-native=%llu "
                      "publish-unique=%llu publish-candidate=%llu publish-persistent=%llu "
                      "publish-authorized=%llu\n",
@@ -3085,6 +3116,12 @@ private:
                      static_cast<unsigned long long>(s.storage_native_semantic),
                      static_cast<unsigned long long>(s.storage_native_device),
                      static_cast<unsigned long long>(s.storage_cache_evaluated),
+                     static_cast<unsigned long long>(s.storage_renderer_owned),
+                     static_cast<unsigned long long>(s.storage_dcc_cache_safe),
+                     static_cast<unsigned long long>(s.storage_poison_verify),
+                     static_cast<unsigned long long>(s.storage_exact),
+                     static_cast<unsigned long long>(s.storage_seed_skip),
+                     static_cast<unsigned long long>(s.storage_persistent_enabled),
                      static_cast<unsigned long long>(s.storage_cache_candidate),
                      static_cast<unsigned long long>(s.storage_persistent_setup),
                      static_cast<unsigned long long>(s.storage_publish_evaluated),
@@ -5214,9 +5251,17 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     (bi.dcc_metadata && bi.dcc_metadata_bytes &&
                      std::all_of(bi.dcc_metadata, bi.dcc_metadata + bi.dcc_metadata_bytes,
                                  [](uint8_t value) { return value == 0xff; }));
-                bi.cache_candidate = !renderer_owned && dcc_cache_safe &&
-                    !bi.poison_verify && (bi.exact_storage_bytes() || bi.seed_skip) &&
-                    persistent_compute_image_enabled(sbytes, ComputeImageCacheClass::storage);
+                const ComputeStorageCacheGateInputs storage_cache_gates{
+                    renderer_owned,
+                    dcc_cache_safe,
+                    bi.poison_verify,
+                    bi.exact_storage_bytes(),
+                    bi.seed_skip,
+                    persistent_compute_image_enabled(
+                        sbytes, ComputeImageCacheClass::storage),
+                };
+                bi.cache_candidate =
+                    compute_storage_cache_gate_candidate(storage_cache_gates);
                 if (bi.cache_candidate) {
                     const auto cache_lookup_start = ComputeClock::now();
                     bi.cache_key = storage_image_cache_key(
@@ -5239,6 +5284,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 }
                 transfer_gate_census.record_storage_cache(
                     transfer_gate_observation.role, *r, bi.binding,
+                    storage_cache_gates,
                     bi.cache_candidate, bi.persistent,
                     transfer_gate_observation.first_match);
                 if (!(bi.persistent && bi.upload_skipped)) {

--- a/prosper/tests/test_compute_timing_selector.cpp
+++ b/prosper/tests/test_compute_timing_selector.cpp
@@ -169,11 +169,20 @@ int main() {
           "dual transfer selectors prove each exact hash and first match independently");
     CHECK(compute_transfer_gate_selector_is_invalid(gate_selector, gate_counters),
           "hash matches without storage gate observations are apparatus-invalid");
-    record_compute_transfer_storage_gate_observation(
-        ComputeTransferGateRole::Producer, gate_counters);
+    const bool delayed_producer_detail =
+        record_compute_transfer_storage_gate_observation(
+            ComputeTransferGateRole::Producer, gate_counters);
+    (void)observe_compute_transfer_gate_selector(
+        gate_selector, gate_counters, gate_selector.producer_hash);
+    const bool repeated_producer_detail =
+        record_compute_transfer_storage_gate_observation(
+            ComputeTransferGateRole::Producer, gate_counters);
+    CHECK(delayed_producer_detail && !repeated_producer_detail &&
+              gate_counters.producer_storage_gate_observations == 2,
+          "storage detail survives an earlier hash-only match and emits exactly once");
     CHECK(compute_transfer_gate_selector_is_invalid(gate_selector, gate_counters),
           "one-sided storage gate observation is apparatus-invalid");
-    record_compute_transfer_storage_gate_observation(
+    (void)record_compute_transfer_storage_gate_observation(
         ComputeTransferGateRole::Consumer, gate_counters);
     CHECK(!compute_transfer_gate_selector_is_invalid(gate_selector, gate_counters),
           "dual transfer selector requires both hashes and storage gate observations");

--- a/prosper/tests/test_compute_timing_selector.cpp
+++ b/prosper/tests/test_compute_timing_selector.cpp
@@ -118,6 +118,34 @@ int main() {
               !compute_timing_zero_match_is_invalid(one_match),
           "zero-match summary is apparatus-invalid");
 
+    const ComputeStorageCacheGateInputs cache_eligible{
+        false, true, false, true, false, true};
+    CHECK(compute_storage_cache_gate_candidate(cache_eligible),
+          "storage cache candidate accepts all gates with exact storage");
+    ComputeStorageCacheGateInputs cache_gates = cache_eligible;
+    cache_gates.renderer_owned = true;
+    CHECK(!compute_storage_cache_gate_candidate(cache_gates),
+          "renderer ownership blocks storage cache candidate");
+    cache_gates = cache_eligible;
+    cache_gates.dcc_cache_safe = false;
+    CHECK(!compute_storage_cache_gate_candidate(cache_gates),
+          "DCC unsafety blocks storage cache candidate");
+    cache_gates = cache_eligible;
+    cache_gates.poison_verify = true;
+    CHECK(!compute_storage_cache_gate_candidate(cache_gates),
+          "poison verification blocks storage cache candidate");
+    cache_gates = cache_eligible;
+    cache_gates.exact_storage = false;
+    CHECK(!compute_storage_cache_gate_candidate(cache_gates),
+          "neither exact storage nor seed skip blocks storage cache candidate");
+    cache_gates.seed_skip = true;
+    CHECK(compute_storage_cache_gate_candidate(cache_gates),
+          "seed skip satisfies the storage representation gate");
+    cache_gates = cache_eligible;
+    cache_gates.persistent_enabled = false;
+    CHECK(!compute_storage_cache_gate_candidate(cache_gates),
+          "persistent cache disable blocks storage cache candidate");
+
     ComputeTransferGateSelector gate_selector{
         true, true, 0x2c595d5aada78398ull, 0xa57c763ae4d70d1dull};
     ComputeTransferGateSelectorCounters gate_counters;
@@ -139,8 +167,16 @@ int main() {
               gate_counters.producer_matches == 2 &&
               gate_counters.consumer_matches == 1,
           "dual transfer selectors prove each exact hash and first match independently");
+    CHECK(compute_transfer_gate_selector_is_invalid(gate_selector, gate_counters),
+          "hash matches without storage gate observations are apparatus-invalid");
+    record_compute_transfer_storage_gate_observation(
+        ComputeTransferGateRole::Producer, gate_counters);
+    CHECK(compute_transfer_gate_selector_is_invalid(gate_selector, gate_counters),
+          "one-sided storage gate observation is apparatus-invalid");
+    record_compute_transfer_storage_gate_observation(
+        ComputeTransferGateRole::Consumer, gate_counters);
     CHECK(!compute_transfer_gate_selector_is_invalid(gate_selector, gate_counters),
-          "dual transfer selector accepts only when both hashes matched");
+          "dual transfer selector requires both hashes and storage gate observations");
 
     ComputeTransferGateSelectorCounters missing_consumer;
     (void)observe_compute_transfer_gate_selector(

--- a/prosper/tools/perf/mutate_compute_timing_selector.sh
+++ b/prosper/tools/perf/mutate_compute_timing_selector.sh
@@ -5,7 +5,8 @@
 # below detect the dangerous failure shapes: accepting the wrong stable program, calling a
 # zero-match run valid, publishing both the explicit and destructor summaries, ignoring a raw
 # cache-eligibility gate, or declaring a transfer comparison valid when its gate was never
-# observed. The tracked source is never edited; each mutation builds a scratch copy.
+# observed, or disarming storage detail at the hash match rather than the real gate. The tracked
+# source is never edited; each mutation builds a scratch copy.
 set -u
 
 HERE=$(cd "$(dirname "$0")" && pwd)
@@ -90,6 +91,11 @@ run_mutation "accept unobserved storage gates" \
   "$TRANSFER_HEADER" \
   '            counters.consumer_storage_gate_observations == 0);' \
   '            false);' || bad=1
+run_mutation "lose delayed storage detail" \
+  "storage detail survives an earlier hash-only match and emits exactly once" \
+  "$TRANSFER_HEADER" \
+  '    const bool first_observation = *observations == 0;' \
+  '    const bool first_observation = false;' || bad=1
 
 restore_headers
 if build_and_run >/dev/null; then

--- a/prosper/tools/perf/mutate_compute_timing_selector.sh
+++ b/prosper/tools/perf/mutate_compute_timing_selector.sh
@@ -2,9 +2,10 @@
 # Per-check mutation coverage for the pure compute-timing selector policy.
 #
 # A green selector test proves its fixtures ran. These mutations prove that the exact checks named
-# below detect the three dangerous failure shapes: accepting the wrong stable program, calling a
-# zero-match run valid, and publishing both the explicit and destructor summaries. The tracked
-# source is never edited; each mutation builds a scratch copy.
+# below detect the dangerous failure shapes: accepting the wrong stable program, calling a
+# zero-match run valid, publishing both the explicit and destructor summaries, ignoring a raw
+# cache-eligibility gate, or declaring a transfer comparison valid when its gate was never
+# observed. The tracked source is never edited; each mutation builds a scratch copy.
 set -u
 
 HERE=$(cd "$(dirname "$0")" && pwd)
@@ -12,10 +13,14 @@ ROOT=$(cd "$HERE/../.." && pwd)
 WORK=$(mktemp -d "${TMPDIR:-/var/tmp}/compute-timing-selector-mutate-XXXXXX") || exit 2
 trap 'rm -rf "$WORK"' EXIT
 cp "$ROOT/frontends/shared/compute_timing_selector.hpp" \
+   "$ROOT/frontends/shared/compute_transfer_gate_census.hpp" \
    "$ROOT/tests/test_compute_timing_selector.cpp" "$WORK/" || exit 2
-HEADER="$WORK/compute_timing_selector.hpp"
-PRISTINE="$WORK/pristine.hpp"
-cp "$HEADER" "$PRISTINE"
+TIMING_HEADER="$WORK/compute_timing_selector.hpp"
+TRANSFER_HEADER="$WORK/compute_transfer_gate_census.hpp"
+TIMING_PRISTINE="$WORK/compute_timing_selector.pristine.hpp"
+TRANSFER_PRISTINE="$WORK/compute_transfer_gate_census.pristine.hpp"
+cp "$TIMING_HEADER" "$TIMING_PRISTINE"
+cp "$TRANSFER_HEADER" "$TRANSFER_PRISTINE"
 CXX_BIN=${CXX:-c++}
 
 build_and_run() {
@@ -24,9 +29,14 @@ build_and_run() {
   "$WORK/test-selector" 2>&1
 }
 
-run_mutation() { # $1=name $2=exact check $3=old $4=new
-  cp "$PRISTINE" "$HEADER"
-  python3 - "$HEADER" "$3" "$4" <<'PY' || return 1
+restore_headers() {
+  cp "$TIMING_PRISTINE" "$TIMING_HEADER"
+  cp "$TRANSFER_PRISTINE" "$TRANSFER_HEADER"
+}
+
+run_mutation() { # $1=name $2=exact check $3=header $4=old $5=new
+  restore_headers
+  python3 - "$3" "$4" "$5" <<'PY' || return 1
 import sys
 path, old, new = sys.argv[1:]
 with open(path, encoding="utf-8") as stream:
@@ -58,17 +68,30 @@ PY
 bad=0
 echo "per-check mutation coverage for compute timing selector"
 run_mutation "accept mismatched stable hash" "stable hash mismatches never select" \
+  "$TIMING_HEADER" \
   '(!selector.hash_requested || program_hash == selector.hash);' \
   '(!selector.hash_requested || (static_cast<void>(program_hash), true));' || bad=1
 run_mutation "accept a zero-match run" "zero-match summary is apparatus-invalid" \
+  "$TIMING_HEADER" \
   'return counters.matched == 0;' \
   'return counters.matched != 0;' || bad=1
 run_mutation "allow duplicate summaries" \
   "explicit report and destructor fallback emit exactly once" \
+  "$TIMING_HEADER" \
   'if (counters.summary_reported) return false;' \
   'if (false) return false;' || bad=1
+run_mutation "ignore renderer ownership gate" \
+  "renderer ownership blocks storage cache candidate" \
+  "$TRANSFER_HEADER" \
+  'return !inputs.renderer_owned && inputs.dcc_cache_safe &&' \
+  'return inputs.dcc_cache_safe &&' || bad=1
+run_mutation "accept unobserved storage gates" \
+  "one-sided storage gate observation is apparatus-invalid" \
+  "$TRANSFER_HEADER" \
+  '            counters.consumer_storage_gate_observations == 0);' \
+  '            false);' || bad=1
 
-cp "$PRISTINE" "$HEADER"
+restore_headers
 if build_and_run >/dev/null; then
   echo "unmutated copy: suite green"
 else


### PR DESCRIPTION
## Summary

Expose every input to the persistent storage-image cache gate for an exact producer/consumer stable-hash pair, and make the selector reject runs that never reach a real per-role storage gate.

This is behavior-neutral instrumentation for Astro Bot #1732. It does not change cache eligibility, rendering, or writeback.

## What changed

- centralize the existing storage-cache candidate expression beside its six boolean inputs
- add exact producer/consumer selector roles and uncapped match/storage-gate counters
- emit bounded first-detail only when each role reaches its first actual storage gate
- report renderer ownership, DCC safety, poison verification, exact-storage, seed-skip, persistent enablement, candidate, and persistence
- fail the terminal verdict when either program or either storage gate was never observed
- add focused policy fixtures and six defect-shaped mutation arms
- record the decisive DCC frontier in Astro's `## Ruled out` history

No title-address special case or output skip is added.

## Decisive live result

One natural full-resolution/every-submit run on the exact diagnostic code completed 720 presents in about 187 seconds, reached the world map, exited 0, and left no process or device loss. Retained log SHA-256:

`f69afd28ff7d975352a4a6dc08a1863f9ccbf073c29c58d9f4e4ba2ed85146c5`

The self-validating transfer selector matched both exact programs 249 times and observed 498 storage gates per role.

At the same 4K target:

- producer binding 65: `renderer-owned=0 dcc-cache-safe=0 exact-storage=1 persistent-enabled=1 cache-candidate=0 persistent=0`
- consumer binding 73: `renderer-owned=0 dcc-cache-safe=1 exact-storage=1 persistent-enabled=1 cache-candidate=1 persistent=1`

This falsifies renderer ownership as the blocker. The exact frontier is compressed DCC metadata before producer execution; successful writeback marks it uncompressed, after which the consumer becomes cache-safe. Full retained evidence is on #1732.

The separate timing selector was accepted but phase/image timing was not enabled, so its terminal verdict correctly remained `INVALID-zero-matches`; this PR makes no phase-timing claim.

## Validation

From `<WORKTREE>` inside the required `ps5ys` distrobox:

- built `prosper_live_renderer` and `test_compute_timing_selector`
- `compute_timing_selector_policy`: 1/1 passed
- all six mutation arms were killed by their intended named check
- unmutated copy passed
- `git diff --check origin/master...HEAD`: clean
- all three stable patch IDs remained byte-for-byte unchanged through rebase onto master `45488dbd`
- full snapshot suite not run; optional for an ordinary development PR under project policy

## Review history

An initial independent review found that detail output could disarm on the first hash match before an actual storage gate. That was fixed by retaining detail eligibility until the first real per-role storage observation. Re-review approved the two code patches before rebase; their stable patch IDs are unchanged. A reviewer will inspect the exact PR head, including the documentation commit, and post the traceable verdict here.

Refs #1732
