### PR TITLE
diag(dmem): correlate every allocation with a caller chain

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -681,6 +681,12 @@ if(TARGET prosper_core)
   target_link_libraries(test_dmem_caller_walk PRIVATE prosper_core)
   add_test(NAME dmem_caller_walk COMMAND test_dmem_caller_walk)
 
+  # PROSPER_DMEM_CALLER correlation (issue #1859): the full stack remains one bounded line per
+  # caller identity while every MEMLOG allocation can carry the same stable run-local ID. Pure,
+  # including explicit unknown/overflow states and concurrent interning.
+  add_executable(test_dmem_caller_chain tests/test_dmem_caller_chain.cpp)
+  add_test(NAME dmem_caller_chain COMMAND test_dmem_caller_chain)
+
   # Capped-diagnostic rate limit (issue #1761): a print budget must never be readable as a
   # population. Pins the sparse tail and the per-key budget; header-only, no GPU state.
   add_executable(test_diag_ratelimit tests/test_diag_ratelimit.cpp)

--- a/prosper/docs/ASTERIX_BABYLON_STATUS.md
+++ b/prosper/docs/ASTERIX_BABYLON_STATUS.md
@@ -192,6 +192,16 @@ unintended runs and add no independent title discriminator. In the same observed
 `--dump-shader` returned before Vulkan initialization. This apparatus finding is recorded as
 instrument trap 63 in `GAME_COMPAT_ORCHESTRATION.md`.
 
+Two independent fresh-save v46 runs on `09be7beccc93c6e2d414657c3570f877271fdcdf`
+then retained draw 0 PS binding 32's raw descriptor input. Both selected the same natural submit shape,
+reported `raw-identity=full-match`, and retained the same complete zero 128-byte span at realization and
+post-submit. A follow-up allocation-census arm again reproduced that exact v46 subject and found one unique
+containing direct mapping: `[0x2011500000,0x2012500000)`, physical allocation `0x21500000`, selected offset
+`0xdd32f0`. Caller attribution from that arm is **VOID**, not negative: 102 allocation records produced only
+two `[dmem-caller]` lines because the diagnostic silently suppresses repeated first-two-frame keys and the
+ordinary allocation line carries no correlation token. The target allocation therefore cannot safely be
+assigned either retained chain. #1599, #1859.
+
 ## Ruled out
 
 - **Unresolved T#/S# lookup:** the title-live descriptor resolves; the rejection is the sampled MIMG
@@ -255,19 +265,32 @@ instrument trap 63 in `GAME_COMPAT_ORCHESTRATION.md`.
   independently reports the selected range as `first=4 future-writer=-1`. The zero therefore exists before
   any captured GPU work can produce the composite and remains unchanged for the rest of the submit. The
   run-local address must be re-derived in future runs. #1599, #1850.
+- **A wrong descriptor decode/normalization selects a zero buffer instead of the guest-programmed input:**
+  the two independent v46 runs each reported `raw-identity=full-match` for draw 0 PS binding 32. Raw dwords
+  `122d32f0,00100020,00000008,0004dfac` independently encode the same run-local address, 16-byte stride,
+  eight records (128 bytes), format, and component count as the normalized CB. Both temporal samples and
+  the ordinary resource read all 128 bytes, found `nz=0`, and agreed on hash `306c537b2ff38983` with
+  `verdict=full-equal`; each submit had 8 draws, 6 computes, 14 operations, and no realization failures.
+  Descriptor translation preserves what the guest programmed. The missing content is upstream: either
+  the guest CPU intentionally leaves this allocation zero or an expected CPU producer does not populate
+  it. The address remains run-local even though deterministic fresh boots reused it. #1599, #1853, #1857.
 - **A renderer-disabled title boot as a GPU-free experiment:** live compute remains active without
   `PROSPER_RENDER` and initializes Vulkan when the title dispatches supported compute.
 
 ## Next discriminators
 
-1. Distinguish a guest-programmed zero constant from a wrong resource identity: retain the raw PS user-data
-   dwords and descriptor provenance that select draw 0 binding 32, then prove whether the run-local address
-   matches what the guest programmed. If it does, trace the last guest CPU writer before submit 181 with a
-   cross-thread-capable watch and a positive control; the captured GPU operation graph has already closed
-   every in-submit writer.
-2. Treat compute program `0x2011734400` as a candidate only if a discriminator independently proves the
+1. After #1859 lands, repeat the exact v46 selector with `PROSPER_MEMLOG=1` and
+   `PROSPER_DMEM_CALLER=1`. Accept allocation ownership only when the selected address lies in one unique
+   map, its physical allocation record carries a nonzero `caller-chain=N`, and exactly one bounded full
+   chain defines that ID. Confirm the heuristic callsite in disassembly before using it as a mapping-relative
+   selector; `unknown`, `overflow`, or a missing ID makes the arm void.
+2. With that mapping identity, build a generic process-wide CPU write watch that arms at mapping creation,
+   records initial bytes plus bounded writer RIP/thread/post-store history, proves its fault/re-arm path with
+   a cross-thread canary, and requires the later v46 selector to match its dynamically derived address. Do
+   not reuse an absolute address from another process.
+3. Treat compute program `0x2011734400` as a candidate only if a discriminator independently proves the
    dispatch ran and reproduces its device loss; two failures in six runs are not a stable cause.
-3. If output becomes non-black, compare source-distinct/pixel-distinct frames and post a screenshot.
+4. If output becomes non-black, compare source-distinct/pixel-distinct frames and post a screenshot.
    Until then, do not update `COMPATIBILITY.md` or claim rung progress.
-4. Once output is useful, route beyond 125 seconds as a regression check for #1748; do not reopen the
+5. Once output is useful, route beyond 125 seconds as a regression check for #1748; do not reopen the
    old allocator diagnosis without a newly reproduced failure.

--- a/prosper/src/hle/dmem_caller_chain.hpp
+++ b/prosper/src/hle/dmem_caller_chain.hpp
@@ -1,0 +1,138 @@
+#pragma once
+
+#include <array>
+#include <charconv>
+#include <cstddef>
+#include <cstdio>
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <utility>
+
+namespace prosper {
+
+enum class DmemCallerChainState : uint8_t {
+    Disabled,
+    Known,
+    Unknown,
+    Overflow,
+};
+
+struct DmemCallerChainResult {
+    DmemCallerChainState state = DmemCallerChainState::Disabled;
+    uint32_t id = 0;
+    bool first = false;
+};
+
+struct DmemCallerChainFrame {
+    const char* module = nullptr;
+    uint64_t offset = 0;
+};
+
+inline void append_dmem_caller_chain_number(std::string& line, uint64_t value, int base) {
+    char digits[32] = {};
+    const auto converted = std::to_chars(digits, digits + sizeof(digits), value, base);
+    if (converted.ec == std::errc{}) line.append(digits, converted.ptr);
+}
+
+// Build the whole definition before taking the output lock. Besides keeping the lock hold short,
+// this makes it impossible for another first-seen chain to splice its ID or frames into this line.
+inline std::string format_dmem_caller_chain_definition(
+        uint32_t id, uint64_t len, const DmemCallerChainFrame* frames, size_t frame_count,
+        int scanned_slots, int requested_slots) {
+    std::string line;
+    line.reserve(256);
+    line += "[dmem-caller] caller-chain=";
+    append_dmem_caller_chain_number(line, id, 10);
+    line += " alloc_main_dmem len=0x";
+    append_dmem_caller_chain_number(line, len, 16);
+    line += " from";
+    for (size_t i = 0; i < frame_count; ++i) {
+        line.push_back(' ');
+        line += frames[i].module ? frames[i].module : "<unknown-module>";
+        line += "+0x";
+        append_dmem_caller_chain_number(line, frames[i].offset, 16);
+    }
+    // A clamped scan reports a SHORTER chain, not a shallower one — say which it was (#1755).
+    if (scanned_slots < requested_slots) {
+        line += " [scan clamped to ";
+        append_dmem_caller_chain_number(line, static_cast<uint64_t>(scanned_slots), 10);
+        line.push_back('/');
+        append_dmem_caller_chain_number(line, static_cast<uint64_t>(requested_slots), 10);
+        line += " slots by stack top]";
+    }
+    line.push_back('\n');
+    return line;
+}
+
+// A single stdio call already holds the FILE lock for its duration; the explicit diagnostic lock
+// additionally keeps this contract visible and prevents future multi-call emitters from recreating
+// #1859's corrupted ID-to-chain table. All platforms use this exact writer.
+inline void write_dmem_caller_chain_line(FILE* stream, std::string_view line) {
+    static std::mutex output_mutex;
+    std::lock_guard lock(output_mutex);
+    (void)std::fwrite(line.data(), 1, line.size(), stream);
+}
+
+inline void write_dmem_caller_chain_definition(
+        FILE* stream, uint32_t id, uint64_t len, const DmemCallerChainFrame* frames,
+        size_t frame_count, int scanned_slots, int requested_slots) {
+    const std::string line = format_dmem_caller_chain_definition(
+        id, len, frames, frame_count, scanned_slots, requested_slots);
+    write_dmem_caller_chain_line(stream, line);
+}
+
+// Correlation belongs on every enabled allocation event, not only the event that owns the one-time
+// full-chain line. Keeping this decision beside the interner gives the old suppression defect a
+// focused, mutation-testable seam.
+inline bool dmem_caller_chain_correlates_allocation(const DmemCallerChainResult& result) {
+    return result.state != DmemCallerChainState::Disabled;
+}
+
+// Bounded, run-local identity for PROSPER_DMEM_CALLER's existing first-two-return-address key.
+// IDs start at one and remain stable for the life of this registry. Unknown stacks and a full
+// registry are explicit states: neither can be mistaken for a missing diagnostic line.
+template <size_t Capacity = 64>
+class DmemCallerChainInterner {
+public:
+    static_assert(Capacity > 0);
+
+    static constexpr size_t capacity() { return Capacity; }
+
+    DmemCallerChainResult intern(uint64_t first, uint64_t second) {
+        std::lock_guard lock(mutex_);
+        if (!first && !second) {
+            const bool is_first = !unknown_seen_;
+            unknown_seen_ = true;
+            return {DmemCallerChainState::Unknown, 0, is_first};
+        }
+        const std::pair<uint64_t, uint64_t> key{first, second};
+        for (size_t i = 0; i < size_; ++i)
+            if (keys_[i] == key)
+                return {DmemCallerChainState::Known, static_cast<uint32_t>(i + 1), false};
+        if (size_ == Capacity) {
+            const bool is_first = !overflow_seen_;
+            overflow_seen_ = true;
+            return {DmemCallerChainState::Overflow, 0, is_first};
+        }
+        keys_[size_] = key;
+        ++size_;
+        return {DmemCallerChainState::Known, static_cast<uint32_t>(size_), true};
+    }
+
+    size_t size() const {
+        std::lock_guard lock(mutex_);
+        return size_;
+    }
+
+private:
+    mutable std::mutex mutex_;
+    std::array<std::pair<uint64_t, uint64_t>, Capacity> keys_{};
+    size_t size_ = 0;
+    bool unknown_seen_ = false;
+    bool overflow_seen_ = false;
+};
+
+} // namespace prosper

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -4,6 +4,7 @@
 // native VM primitives and TRACK every mapping so VirtualQuery is truthful and so we can
 // log/debug the guest's address-space construction.
 #include "dispatch.hpp"
+#include "dmem_caller_chain.hpp"
 #include "nid.hpp"
 #include "sce_errno.hpp"
 #include "../host/boot_program.hpp"   // #1659: shared guest-module labelling
@@ -205,8 +206,15 @@ namespace {
         const uintptr_t slots = (hi - base) / sizeof(uint64_t);
         return slots < (uintptr_t)want ? (int)slots : want;
     }
-    void log_dmem_caller(const char* what, uint64_t len, const volatile uint64_t* frame) {
-        if (!dmem_caller_log()) return;
+    void log_main_dmem_allocation(uint64_t len, uint64_t phys,
+                                  const volatile uint64_t* frame) {
+        // Preserve the unarmed path: no stack query, interner construction, or extra formatting unless
+        // PROSPER_DMEM_CALLER was explicitly requested. MEMLOG alone keeps its historical line byte-for-byte.
+        if (!dmem_caller_log()) {
+            MLOG("alloc_main_dmem len=0x%llx -> phys=0x%llx\n",
+                 (unsigned long long)len, (unsigned long long)phys);
+            return;
+        }
         constexpr int kWant = 6;          // return addresses to report
         constexpr int kScan = 160;        // stack slots to walk
         // Never read past the mapped end of this stack (#1755).
@@ -219,35 +227,56 @@ namespace {
             if (n && ra[n - 1] == v) continue;      // collapse an adjacent duplicate spill
             ra[n++] = v;
         }
-        // Rate-limit on the chain itself: one line per distinct (first two frames) pair.
-        static std::mutex mx;
-        static std::vector<std::pair<uint64_t, uint64_t>> seen;
-        static bool announced_cap = false;
-        const std::pair<uint64_t, uint64_t> key{ n > 0 ? ra[0] : 0, n > 1 ? ra[1] : 0 };
-        {
-            std::lock_guard<std::mutex> lk(mx);
-            for (const auto& s : seen) if (s == key) return;
-            if (seen.size() >= 64) {
-                // #1755: announce the ceiling once. A silent cap makes the log read as "64 distinct
-                // call sites exist" when it means "we stopped counting" — a limit reported as a
-                // census (instrument-trap 49).
-                if (!announced_cap) {
-                    announced_cap = true;
-                    fprintf(stderr, "[dmem-caller] chain limit 64 reached;"
-                                    " further distinct call chains are NOT shown\n");
-                }
-                return;
+        static DmemCallerChainInterner<> chains;
+        const DmemCallerChainResult correlation = chains.intern(
+            n > 0 ? ra[0] : 0, n > 1 ? ra[1] : 0);
+
+        // MEMLOG is the per-allocation census. Give every one of its allocation records a correlation
+        // token; the full stack remains one line per distinct bounded ID below.
+        if (!dmem_caller_chain_correlates_allocation(correlation)) {
+            MLOG("alloc_main_dmem len=0x%llx -> phys=0x%llx\n",
+                 (unsigned long long)len, (unsigned long long)phys);
+        } else {
+            switch (correlation.state) {
+            case DmemCallerChainState::Known:
+                MLOG("alloc_main_dmem len=0x%llx -> phys=0x%llx caller-chain=%u\n",
+                     (unsigned long long)len, (unsigned long long)phys, correlation.id);
+                break;
+            case DmemCallerChainState::Unknown:
+                MLOG("alloc_main_dmem len=0x%llx -> phys=0x%llx caller-chain=unknown\n",
+                     (unsigned long long)len, (unsigned long long)phys);
+                break;
+            case DmemCallerChainState::Overflow:
+                MLOG("alloc_main_dmem len=0x%llx -> phys=0x%llx caller-chain=overflow\n",
+                     (unsigned long long)len, (unsigned long long)phys);
+                break;
+            case DmemCallerChainState::Disabled:
+                break;
             }
-            seen.push_back(key);
         }
-        fprintf(stderr, "[dmem-caller] %s len=0x%llx from", what, (unsigned long long)len);
-        for (int i = 0; i < n; i++)
-            fprintf(stderr, " %s+0x%llx", guest_module_name(ra[i]),
-                    (unsigned long long)guest_module_offset(ra[i]));
-        // A clamped scan reports a SHORTER chain, not a shallower one — say which it was (#1755).
-        if (scan < kScan)
-            fprintf(stderr, " [scan clamped to %d/%d slots by stack top]", scan, kScan);
-        fprintf(stderr, "\n");
+
+        if (!correlation.first) return;
+        if (correlation.state == DmemCallerChainState::Overflow) {
+            // The cap is a state, not a population: every later MEMLOG record says `overflow`.
+            fprintf(stderr, "[dmem-caller] caller-chain=overflow: chain limit %zu reached;"
+                            " further distinct call chains are NOT retained\n",
+                    DmemCallerChainInterner<>::capacity());
+            return;
+        }
+        if (correlation.state == DmemCallerChainState::Unknown) {
+            fprintf(stderr,
+                    "[dmem-caller] caller-chain=unknown alloc_main_dmem len=0x%llx"
+                    " from <no guest return addresses>\n",
+                    (unsigned long long)len);
+            return;
+        }
+        DmemCallerChainFrame frames[kWant] = {};
+        for (int i = 0; i < n; ++i) {
+            frames[i].module = guest_module_name(ra[i]);
+            frames[i].offset = guest_module_offset(ra[i]);
+        }
+        write_dmem_caller_chain_definition(
+            stderr, correlation.id, len, frames, static_cast<size_t>(n), scan, kScan);
     }
 
     constexpr uint32_t kVirtualQueryFlexible = 0x01;
@@ -1050,8 +1079,8 @@ HLE(k_alloc_main_dmem) {
     }
     dmem_zero(off, sz);                       // fresh allocation -> zeroed pages (console semantics)
     *(uint64_t*)a3 = off;
-    MLOG("alloc_main_dmem len=0x%llx -> phys=0x%llx\n", (unsigned long long)a0, (unsigned long long)off);
-    log_dmem_caller("alloc_main_dmem", a0, (const volatile uint64_t*)__builtin_frame_address(0));
+    log_main_dmem_allocation(a0, off,
+                             (const volatile uint64_t*)__builtin_frame_address(0));
     return 0;
 }
 
@@ -2304,8 +2333,15 @@ namespace {
         const uintptr_t slots = (hi - base) / sizeof(uint64_t);
         return slots < (uintptr_t)want ? (int)slots : want;
     }
-    void log_dmem_caller(const char* what, uint64_t len, const volatile uint64_t* frame) {
-        if (!dmem_caller_log()) return;
+    void log_main_dmem_allocation(uint64_t len, uint64_t phys,
+                                  const volatile uint64_t* frame) {
+        // Preserve the unarmed path: no stack query, interner construction, or extra formatting unless
+        // PROSPER_DMEM_CALLER was explicitly requested. MEMLOG alone keeps its historical line byte-for-byte.
+        if (!dmem_caller_log()) {
+            MLOG("alloc_main_dmem len=0x%llx -> phys=0x%llx\n",
+                 (unsigned long long)len, (unsigned long long)phys);
+            return;
+        }
         constexpr int kWant = 6;          // return addresses to report
         constexpr int kScan = 160;        // stack slots to walk
         // Never read past the mapped end of this stack (#1755).
@@ -2318,35 +2354,56 @@ namespace {
             if (n && ra[n - 1] == v) continue;      // collapse an adjacent duplicate spill
             ra[n++] = v;
         }
-        // Rate-limit on the chain itself: one line per distinct (first two frames) pair.
-        static std::mutex mx;
-        static std::vector<std::pair<uint64_t, uint64_t>> seen;
-        static bool announced_cap = false;
-        const std::pair<uint64_t, uint64_t> key{ n > 0 ? ra[0] : 0, n > 1 ? ra[1] : 0 };
-        {
-            std::lock_guard<std::mutex> lk(mx);
-            for (const auto& s : seen) if (s == key) return;
-            if (seen.size() >= 64) {
-                // #1755: announce the ceiling once. A silent cap makes the log read as "64 distinct
-                // call sites exist" when it means "we stopped counting" — a limit reported as a
-                // census (instrument-trap 49).
-                if (!announced_cap) {
-                    announced_cap = true;
-                    fprintf(stderr, "[dmem-caller] chain limit 64 reached;"
-                                    " further distinct call chains are NOT shown\n");
-                }
-                return;
+        static DmemCallerChainInterner<> chains;
+        const DmemCallerChainResult correlation = chains.intern(
+            n > 0 ? ra[0] : 0, n > 1 ? ra[1] : 0);
+
+        // MEMLOG is the per-allocation census. Give every one of its allocation records a correlation
+        // token; the full stack remains one line per distinct bounded ID below.
+        if (!dmem_caller_chain_correlates_allocation(correlation)) {
+            MLOG("alloc_main_dmem len=0x%llx -> phys=0x%llx\n",
+                 (unsigned long long)len, (unsigned long long)phys);
+        } else {
+            switch (correlation.state) {
+            case DmemCallerChainState::Known:
+                MLOG("alloc_main_dmem len=0x%llx -> phys=0x%llx caller-chain=%u\n",
+                     (unsigned long long)len, (unsigned long long)phys, correlation.id);
+                break;
+            case DmemCallerChainState::Unknown:
+                MLOG("alloc_main_dmem len=0x%llx -> phys=0x%llx caller-chain=unknown\n",
+                     (unsigned long long)len, (unsigned long long)phys);
+                break;
+            case DmemCallerChainState::Overflow:
+                MLOG("alloc_main_dmem len=0x%llx -> phys=0x%llx caller-chain=overflow\n",
+                     (unsigned long long)len, (unsigned long long)phys);
+                break;
+            case DmemCallerChainState::Disabled:
+                break;
             }
-            seen.push_back(key);
         }
-        fprintf(stderr, "[dmem-caller] %s len=0x%llx from", what, (unsigned long long)len);
-        for (int i = 0; i < n; i++)
-            fprintf(stderr, " %s+0x%llx", guest_module_name(ra[i]),
-                    (unsigned long long)guest_module_offset(ra[i]));
-        // A clamped scan reports a SHORTER chain, not a shallower one — say which it was (#1755).
-        if (scan < kScan)
-            fprintf(stderr, " [scan clamped to %d/%d slots by stack top]", scan, kScan);
-        fprintf(stderr, "\n");
+
+        if (!correlation.first) return;
+        if (correlation.state == DmemCallerChainState::Overflow) {
+            // The cap is a state, not a population: every later MEMLOG record says `overflow`.
+            fprintf(stderr, "[dmem-caller] caller-chain=overflow: chain limit %zu reached;"
+                            " further distinct call chains are NOT retained\n",
+                    DmemCallerChainInterner<>::capacity());
+            return;
+        }
+        if (correlation.state == DmemCallerChainState::Unknown) {
+            fprintf(stderr,
+                    "[dmem-caller] caller-chain=unknown alloc_main_dmem len=0x%llx"
+                    " from <no guest return addresses>\n",
+                    (unsigned long long)len);
+            return;
+        }
+        DmemCallerChainFrame frames[kWant] = {};
+        for (int i = 0; i < n; ++i) {
+            frames[i].module = guest_module_name(ra[i]);
+            frames[i].offset = guest_module_offset(ra[i]);
+        }
+        write_dmem_caller_chain_definition(
+            stderr, correlation.id, len, frames, static_cast<size_t>(n), scan, kScan);
     }
 
     // --- VA tracker + direct-memory pool: PURE logic, copied verbatim from the Linux path -----
@@ -4549,8 +4606,8 @@ HLE(k_alloc_main_dmem) {
     }
     dmem_prepare_allocation(off, sz);
     *(uint64_t*)a3 = off;
-    MLOG("alloc_main_dmem len=0x%llx -> phys=0x%llx\n", (unsigned long long)a0, (unsigned long long)off);
-    log_dmem_caller("alloc_main_dmem", a0, (const volatile uint64_t*)__builtin_frame_address(0));
+    log_main_dmem_allocation(a0, off,
+                             (const volatile uint64_t*)__builtin_frame_address(0));
     return 0;
 }
 

--- a/prosper/tests/test_dmem_caller_chain.cpp
+++ b/prosper/tests/test_dmem_caller_chain.cpp
@@ -1,0 +1,151 @@
+#include "../src/hle/dmem_caller_chain.hpp"
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cstdio>
+#include <string>
+#include <thread>
+
+using prosper::DmemCallerChainInterner;
+using prosper::DmemCallerChainFrame;
+using prosper::DmemCallerChainResult;
+using prosper::DmemCallerChainState;
+using prosper::dmem_caller_chain_correlates_allocation;
+using prosper::format_dmem_caller_chain_definition;
+using prosper::write_dmem_caller_chain_definition;
+
+static int failures = 0;
+
+static void check(bool ok, const char* name) {
+    std::printf("%s: %s\n", ok ? "PASS" : "FAIL", name);
+    if (!ok) ++failures;
+}
+
+int main() {
+    DmemCallerChainInterner<2> chains;
+
+    const DmemCallerChainResult unknown = chains.intern(0, 0);
+    const DmemCallerChainResult unknown_again = chains.intern(0, 0);
+    check(unknown.state == DmemCallerChainState::Unknown && unknown.id == 0 && unknown.first &&
+              unknown_again.state == DmemCallerChainState::Unknown && !unknown_again.first,
+          "a missing guest stack is explicitly unknown and announced once");
+
+    const DmemCallerChainResult first = chains.intern(0x41000100, 0x41000200);
+    const DmemCallerChainResult repeated = chains.intern(0x41000100, 0x41000200);
+    check(first.state == DmemCallerChainState::Known && first.id == 1 && first.first &&
+              repeated.state == DmemCallerChainState::Known && repeated.id == first.id &&
+              !repeated.first,
+          "a repeated allocation keeps the same nonzero caller-chain ID");
+    check(dmem_caller_chain_correlates_allocation(first) &&
+              dmem_caller_chain_correlates_allocation(repeated),
+          "every enabled allocation carries correlation, including repeated chains");
+
+    const DmemCallerChainResult second = chains.intern(0x41000100, 0x41000300);
+    check(second.state == DmemCallerChainState::Known && second.id == 2 && second.first &&
+              second.id != first.id,
+          "a distinct first-two-frame key receives a distinct stable ID");
+
+    const DmemCallerChainResult overflow = chains.intern(0x41000400, 0x41000500);
+    const DmemCallerChainResult overflow_again = chains.intern(0x41000600, 0x41000700);
+    check(overflow.state == DmemCallerChainState::Overflow && overflow.id == 0 && overflow.first &&
+              overflow_again.state == DmemCallerChainState::Overflow && !overflow_again.first,
+          "capacity overflow is explicit and its ceiling is announced once");
+
+    const DmemCallerChainResult retained = chains.intern(0x41000100, 0x41000200);
+    check(retained.state == DmemCallerChainState::Known && retained.id == first.id &&
+              chains.size() == 2,
+          "known correlations survive after the bounded registry fills");
+
+    DmemCallerChainInterner<> concurrent;
+    std::array<DmemCallerChainResult, 8> concurrent_results{};
+    std::array<std::thread, 8> workers;
+    for (size_t i = 0; i < workers.size(); ++i)
+        workers[i] = std::thread([&, i] {
+            concurrent_results[i] = concurrent.intern(0x44001000, 0x44002000);
+        });
+    for (auto& worker : workers) worker.join();
+    size_t first_count = 0;
+    bool all_same = true;
+    for (const auto& result : concurrent_results) {
+        first_count += result.first ? 1 : 0;
+        all_same = all_same && result.state == DmemCallerChainState::Known && result.id == 1;
+    }
+    check(all_same && first_count == 1 && concurrent.size() == 1,
+          "concurrent repeats publish one ID and one full-chain owner");
+
+    const DmemCallerChainFrame format_frames[] = {
+        {"eboot", 0x1b2454f}, {"libSceFoo", 0x7d0a00},
+    };
+    check(format_dmem_caller_chain_definition(
+              17, 0x1000000, format_frames, std::size(format_frames), 23, 160) ==
+              "[dmem-caller] caller-chain=17 alloc_main_dmem len=0x1000000 from"
+              " eboot+0x1b2454f libSceFoo+0x7d0a00"
+              " [scan clamped to 23/160 slots by stack top]\n",
+          "a full-chain definition has one exact parseable line format");
+
+    // Reproduce the reviewed failure shape: several guest threads discover DIFFERENT chains at
+    // once. The old implementation emitted each definition through a sequence of fprintf calls,
+    // so an ID prefix from one thread could be joined to frames from another. Exercise the exact
+    // production formatter/writer and require one intact independently identifiable line per ID.
+    constexpr size_t kDistinctChains = 64;
+    FILE* definitions = std::tmpfile();
+    check(definitions != nullptr, "a temporary stream is available for definition serialization");
+    if (definitions) {
+        std::array<std::array<std::string, 6>, kDistinctChains> module_names;
+        std::array<std::array<DmemCallerChainFrame, 6>, kDistinctChains> frame_sets{};
+        std::array<std::string, kDistinctChains> expected_lines;
+        for (size_t chain = 0; chain < kDistinctChains; ++chain) {
+            for (size_t frame = 0; frame < frame_sets[chain].size(); ++frame) {
+                module_names[chain][frame] = "chain" + std::to_string(chain + 1) +
+                    "_frame" + std::to_string(frame + 1) + "_" +
+                    std::string(96, static_cast<char>('a' + (chain % 26)));
+                frame_sets[chain][frame] = {
+                    module_names[chain][frame].c_str(),
+                    0x100000ull * (chain + 1) + 0x100ull * (frame + 1),
+                };
+            }
+            expected_lines[chain] = format_dmem_caller_chain_definition(
+                static_cast<uint32_t>(chain + 1), 0x1000000 + chain,
+                frame_sets[chain].data(), frame_sets[chain].size(), 160, 160);
+        }
+
+        std::atomic<size_t> ready{0};
+        std::atomic<bool> start{false};
+        std::array<std::thread, kDistinctChains> definition_workers;
+        for (size_t chain = 0; chain < kDistinctChains; ++chain) {
+            definition_workers[chain] = std::thread([&, chain] {
+                ready.fetch_add(1, std::memory_order_release);
+                while (!start.load(std::memory_order_acquire)) std::this_thread::yield();
+                write_dmem_caller_chain_definition(
+                    definitions, static_cast<uint32_t>(chain + 1), 0x1000000 + chain,
+                    frame_sets[chain].data(), frame_sets[chain].size(), 160, 160);
+            });
+        }
+        while (ready.load(std::memory_order_acquire) != kDistinctChains)
+            std::this_thread::yield();
+        start.store(true, std::memory_order_release);
+        for (auto& worker : definition_workers) worker.join();
+
+        std::fflush(definitions);
+        std::fseek(definitions, 0, SEEK_END);
+        const long output_size = std::ftell(definitions);
+        std::rewind(definitions);
+        std::string output(output_size > 0 ? static_cast<size_t>(output_size) : 0, '\0');
+        const size_t bytes_read = output.empty()
+            ? 0 : std::fread(output.data(), 1, output.size(), definitions);
+        bool intact = output_size >= 0 && bytes_read == output.size() &&
+            std::count(output.begin(), output.end(), '\n') == kDistinctChains;
+        for (const std::string& expected : expected_lines) {
+            const size_t first_match = output.find(expected);
+            intact = intact && first_match != std::string::npos &&
+                output.find(expected, first_match + 1) == std::string::npos;
+        }
+        check(intact,
+              "concurrent distinct definitions are each one complete uncorrupted line");
+        std::fclose(definitions);
+    }
+
+    std::printf("%s\n", failures ? "FAILED" : "OK");
+    return failures ? 1 : 0;
+}

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -40,14 +40,20 @@ the shipped runtime. Build them from `build-linux/` like everything else.
     / map with its size, which answers *how much* but never *who* — and the same guest allocator
     serves every subsystem, so a title whose heap grows without bound looks identical to one that is
     legitimately loading. Add **`PROSPER_DMEM_CALLER=1`** to print, once per distinct call chain, the
-    guest return addresses above each `sceKernelAllocateMainDirectMemory`:
+    guest return addresses above each `sceKernelAllocateMainDirectMemory`. The first two return
+    addresses are interned as a bounded run-local `caller-chain=N`; the full bounded chain prints
+    once, while every allocation in the `PROSPER_MEMLOG=1` census carries the same correlation ID:
     ```text
-    [dmem-caller] alloc_main_dmem len=0x1000000 from eboot+0x1b2454f eboot+0x7d0a00 eboot+0x22b1e80 …
+    [memhle] alloc_main_dmem len=0x1000000 -> phys=0x21500000 caller-chain=1
+    [dmem-caller] caller-chain=1 alloc_main_dmem len=0x1000000 from eboot+0x1b2454f eboot+0x7d0a00 eboot+0x22b1e80 …
     ```
     Feed the first address to `tools/re/edis.py` / `tools/re/xref.py` to name the caller. The walk is
     a heuristic stack scan (a stale spill slot looks exactly like a return address), so treat the
     result as a callsite **hint** to confirm against the module's disassembly — never as proof on its
-    own. Bounded to 64 distinct chains so an allocation-heavy boot cannot bury the log.
+    own. IDs are stable only within one process and the full-chain table is bounded to 64 entries so
+    an allocation-heavy boot cannot bury the log. A walk with no guest return address is recorded as
+    `caller-chain=unknown`; allocations beyond the distinct-chain limit say `caller-chain=overflow`,
+    and the ceiling is announced once. Neither state is a negative caller result.
   - **Is prosper overrunning a command-buffer reservation the guest made?** prosper's AGC builders
     append into the *guest's* buffer, and the guest reserves that buffer from the packet sizes it was
     compiled against — so a builder that emits more dwords than the real AGC function overruns it.


### PR DESCRIPTION
## Summary

Make `PROSPER_DMEM_CALLER` correlate every armed main-direct-memory allocation with a bounded, stable, run-local caller-chain identity.

The old diagnostic printed a full stack only for the first allocation at a call site, while `PROSPER_MEMLOG` printed every allocation without correlation. In Asterix #1599 that made the decisive target allocation impossible to join to its caller: the run had 102 allocation records but only two rate-limited caller lines. This patch fixes the instrument; it does not change guest memory allocation behavior.

## What changed

- intern the existing first-two-return-address key into stable run-local IDs 1..64
- append `caller-chain=N` to every armed MEMLOG allocation, including repeated chains
- expose missing stacks as `caller-chain=unknown` and bounded-cap overflow as `caller-chain=overflow`
- print each known ID's full definition once
- build each definition completely, then serialize it through one shared output lock and one `fwrite` on both POSIX and Windows
- keep known IDs resolvable after the 64-chain cap fills
- preserve the unarmed MEMLOG line byte-for-byte with no stack walk/interner/formatting
- document the generic diagnostic contract and record the old Asterix arm as VOID/ruled out

IDs are intentionally run-local and bounded; they are correlation tokens, not a population estimate.

## Why the serialization matters

Independent review found that the first version emitted one ID definition through several `fprintf` calls after releasing the interner lock. Concurrently discovered distinct guest chains could splice IDs and frames, corrupting the only ID→chain table.

The corrected production seam formats the full line before output, holds an explicit shared mutex, and emits one `fwrite`. A 64-thread distinct-chain regression exercises that exact formatter/writer and requires one intact, independently identifiable line per ID.

## Validation

From `<WORKTREE>` in the required `ps5ys` distrobox after rebase onto current master `45488dbd`:

- built Linux `prosper_core`, `test_dmem`, `test_dmem_caller_walk`, and `test_dmem_caller_chain`
- focused ctest: 3/3 passed
- distinct-chain race: 100/100 consecutive runs passed
- repeated-correlation mutation: failed only `every enabled allocation carries correlation, including repeated chains`
- old split-write/no-lock mutation: failed only `concurrent distinct definitions are each one complete uncorrupted line`
- restored copy: focused 3/3 and race 100/100 passed again
- MinGW `prosper_core` and `test_dmem_caller_chain` built, including the Windows HLE path
- `git diff HEAD^ --check`: clean
- stable patch ID remained `5569f9683d39fe371c9c56e71c57762fb7f7295e` through rebase
- full snapshot suite not run; optional for an ordinary development PR under project policy

## Independent review

The first review blocked the multi-call definition writer because distinct first-seen chains could interleave. The exact corrected patch was re-reviewed across the complete six-file diff and approved after Linux/MinGW builds, focused tests, 100 race repetitions, and both defect-shaped mutations. The reviewer will post the traceable verdict on this PR.

Refs #1859
Refs #1599
