### PR TITLE
gpu: promote DCC storage after exact writeback

### DIFF
--- a/prosper/frontends/shared/compute_transfer_gate_census.hpp
+++ b/prosper/frontends/shared/compute_transfer_gate_census.hpp
@@ -31,6 +31,28 @@ constexpr bool compute_storage_cache_gate_candidate(
            inputs.persistent_enabled;
 }
 
+// A compressed writable target cannot enter the persistent cache before dispatch because its base
+// bytes are not yet authoritative.  A successful ordinary writeback changes that fact: it publishes
+// exact base bytes and marks the complete DCC plane uncompressed.  Admit that result only when DCC
+// was the sole failed normal gate, the metadata plane is writable, and this binding owns the image's
+// writeback obligation.  The caller still has to prove fence completion, exact data/metadata
+// publication, and a final all-0xff metadata state before retaining the image.
+struct ComputeStoragePostWritebackPromotionInputs {
+    ComputeStorageCacheGateInputs pre_dispatch{};
+    bool writable_dcc_metadata = false;
+    bool unique_alias_owner = false;
+    bool exact_cache_key = false;
+};
+
+constexpr bool compute_storage_post_writeback_promotion_candidate(
+    const ComputeStoragePostWritebackPromotionInputs& inputs) {
+    const ComputeStorageCacheGateInputs& gates = inputs.pre_dispatch;
+    return !gates.renderer_owned && !gates.dcc_cache_safe &&
+           !gates.poison_verify && (gates.exact_storage || gates.seed_skip) &&
+           gates.persistent_enabled && inputs.writable_dcc_metadata &&
+           inputs.unique_alias_owner && inputs.exact_cache_key;
+}
+
 struct ComputeTransferGateSelector {
     bool requested = false;
     bool valid = false;

--- a/prosper/frontends/shared/compute_transfer_gate_census.hpp
+++ b/prosper/frontends/shared/compute_transfer_gate_census.hpp
@@ -41,16 +41,15 @@ struct ComputeStoragePostWritebackPromotionInputs {
     ComputeStorageCacheGateInputs pre_dispatch{};
     bool writable_dcc_metadata = false;
     bool unique_alias_owner = false;
-    bool exact_cache_key = false;
 };
 
 constexpr bool compute_storage_post_writeback_promotion_candidate(
     const ComputeStoragePostWritebackPromotionInputs& inputs) {
     const ComputeStorageCacheGateInputs& gates = inputs.pre_dispatch;
     return !gates.renderer_owned && !gates.dcc_cache_safe &&
-           !gates.poison_verify && (gates.exact_storage || gates.seed_skip) &&
+           !gates.poison_verify && gates.exact_storage &&
            gates.persistent_enabled && inputs.writable_dcc_metadata &&
-           inputs.unique_alias_owner && inputs.exact_cache_key;
+           inputs.unique_alias_owner;
 }
 
 struct ComputeTransferGateSelector {

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -211,7 +211,7 @@ std::atomic<uint64_t> g_compute_storage_transfer_seeds{0};
 std::atomic<uint64_t> g_dcc_post_writeback_promotions{0};
 std::atomic<bool> g_fail_next_storage_readback_for_test{false};
 std::atomic<bool> g_leave_next_dcc_metadata_compressed_for_test{false};
-std::atomic<bool> g_fail_next_dcc_promotion_admission_for_test{false};
+std::atomic<bool> g_limit_next_image_replacement_for_test{false};
 std::atomic<bool> g_zero_next_cold_storage_snapshot_minimum_for_test{false};
 std::atomic<bool> g_force_next_image_result_host_fallback_for_test{false};
 std::atomic<bool> g_fail_next_image_result_buffer_retain_for_test{false};
@@ -1826,7 +1826,12 @@ struct VulkanComputeContext {
             return retain_image(key, image, memory, allocation_bytes, source);
         if (exact->second.pins) return false;
 
-        const VkDeviceSize limit = persistent_compute_image_limit(this->memory);
+        VkDeviceSize limit = persistent_compute_image_limit(this->memory);
+        // Exercise the real capacity preflight, rather than bypassing this function at its caller.
+        // The exact entry must remain untouched when the incoming allocation cannot fit.
+        if (g_limit_next_image_replacement_for_test.exchange(
+                false, std::memory_order_acq_rel))
+            limit = allocation_bytes ? allocation_bytes - 1u : 0u;
         if (allocation_bytes > limit || exact->second.allocation_bytes > image_cache_bytes)
             return false;
         const VkDeviceSize retained_without_exact =
@@ -5137,6 +5142,18 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     adaptive_storage_result_validation_enabled();
                 const bool transfer_native_defined =
                     transfer_native_format != VK_FORMAT_UNDEFINED;
+                if (trace)
+                    std::fprintf(stderr,
+                                 "[compute]   native transfer gate binding=%u dimension=%u "
+                                 "hostless=%u format-match=%u validation=%u defined=%u "
+                                 "storage-format=%u sampled-format=%u\n",
+                                 bi.binding, native_transfer_dimension ? 1u : 0u,
+                                 transfer_hostless ? 1u : 0u,
+                                 transfer_format_match ? 1u : 0u,
+                                 transfer_validation_enabled ? 1u : 0u,
+                                 transfer_native_defined ? 1u : 0u,
+                                 static_cast<unsigned>(transfer_native_format),
+                                 static_cast<unsigned>(image_format));
                 ComputeTransferBorrowResult transfer_borrow_result =
                     ComputeTransferBorrowResult::NotAttempted;
                 if (bi.cache_candidate) {
@@ -5350,7 +5367,6 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         storage_cache_gates,
                         bi.dcc_metadata && bi.dcc_metadata_bytes,
                         bi.alias_of == SIZE_MAX,
-                        true,
                     });
                 if (bi.cache_candidate) {
                     const auto cache_lookup_start = ComputeClock::now();
@@ -7288,9 +7304,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             const bool final_dcc_cache_safe = bi.dcc_metadata && bi.dcc_metadata_bytes &&
                 std::all_of(bi.dcc_metadata, bi.dcc_metadata + bi.dcc_metadata_bytes,
                             [](uint8_t value) { return value == 0xff; });
-            if (bi.post_writeback_promotion_candidate && final_dcc_cache_safe &&
-                !g_fail_next_dcc_promotion_admission_for_test.exchange(
-                    false, std::memory_order_acq_rel)) {
+            if (bi.post_writeback_promotion_candidate && final_dcc_cache_safe) {
                 const uint8_t* retained_source =
                     (adaptive_storage_result_validation_enabled() &&
                      cold_storage_result_snapshot_can_defer(
@@ -7641,8 +7655,8 @@ void live_compute_leave_next_dcc_metadata_compressed_for_test() {
         true, std::memory_order_release);
 }
 
-void live_compute_fail_next_dcc_promotion_admission_for_test() {
-    g_fail_next_dcc_promotion_admission_for_test.store(
+void live_compute_limit_next_image_replacement_for_test() {
+    g_limit_next_image_replacement_for_test.store(
         true, std::memory_order_release);
 }
 

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -208,7 +208,10 @@ namespace {
 
 std::atomic<uint64_t> g_buffer_gpu_result_skips{0};
 std::atomic<uint64_t> g_compute_storage_transfer_seeds{0};
+std::atomic<uint64_t> g_dcc_post_writeback_promotions{0};
 std::atomic<bool> g_fail_next_storage_readback_for_test{false};
+std::atomic<bool> g_leave_next_dcc_metadata_compressed_for_test{false};
+std::atomic<bool> g_fail_next_dcc_promotion_admission_for_test{false};
 std::atomic<bool> g_zero_next_cold_storage_snapshot_minimum_for_test{false};
 std::atomic<bool> g_force_next_image_result_host_fallback_for_test{false};
 std::atomic<bool> g_fail_next_image_result_buffer_retain_for_test{false};
@@ -1308,11 +1311,7 @@ struct VulkanComputeContext {
         if (!device) return;
         for (auto& [key, cached] : image_cache) {
             (void)key;
-            cached.write_watch.reset();
-            if (cached.image) vkDestroyImage(device, cached.image, nullptr);
-            if (cached.memory) release_memory(cached.memory);
-            if (cached.result_buffer) vkDestroyBuffer(device, cached.result_buffer, nullptr);
-            if (cached.result_memory) release_memory(cached.result_memory);
+            destroy_cached_image_resources(cached);
         }
         image_cache.clear();
         image_cache_bytes = 0;
@@ -1572,6 +1571,18 @@ struct VulkanComputeContext {
         return true;
     }
 
+    void destroy_cached_image_resources(CachedComputeImage& cached) {
+        cached.write_watch.reset();
+        if (cached.image) vkDestroyImage(device, cached.image, nullptr);
+        if (cached.memory) release_memory(cached.memory);
+        if (cached.result_buffer) vkDestroyBuffer(device, cached.result_buffer, nullptr);
+        if (cached.result_memory) release_memory(cached.result_memory);
+        cached.image = VK_NULL_HANDLE;
+        cached.memory = VK_NULL_HANDLE;
+        cached.result_buffer = VK_NULL_HANDLE;
+        cached.result_memory = VK_NULL_HANDLE;
+    }
+
     bool make_image_cache_room(VkDeviceSize bytes) {
         const VkDeviceSize limit = persistent_compute_image_limit(memory);
         if (bytes > limit) return false;
@@ -1584,13 +1595,7 @@ struct VulkanComputeContext {
                     victim = it;
             }
             if (victim == image_cache.end()) return false;
-            victim->second.write_watch.reset();
-            if (victim->second.image) vkDestroyImage(device, victim->second.image, nullptr);
-            if (victim->second.memory) release_memory(victim->second.memory);
-            if (victim->second.result_buffer)
-                vkDestroyBuffer(device, victim->second.result_buffer, nullptr);
-            if (victim->second.result_memory)
-                release_memory(victim->second.result_memory);
+            destroy_cached_image_resources(victim->second);
             image_cache_bytes -= victim->second.allocation_bytes;
             image_cache.erase(victim);
         }
@@ -1803,6 +1808,77 @@ struct VulkanComputeContext {
                 cached, source, key.guest_bytes, key.storage);
         auto [it, inserted] = image_cache.emplace(key, std::move(cached));
         if (!inserted) return false;
+        image_cache_bytes += allocation_bytes;
+        return true;
+    }
+
+    // A compressed producer can follow a consumer that already retained the same exact storage
+    // identity.  The producer's transient image must replace that stale entry after successful DCC
+    // writeback; plain emplace would decline on the collision and forfeit the producer-to-consumer
+    // device-local handoff.  Never disturb a pinned entry.  Preflight all required eviction before
+    // mutating the cache so capacity failure preserves both the old cache authority and the caller's
+    // transient fallback.
+    bool replace_or_retain_image(const ComputeImageCacheKey& key,
+                                 VkImage image, VkDeviceMemory memory,
+                                 VkDeviceSize allocation_bytes, const uint8_t* source) {
+        auto exact = image_cache.find(key);
+        if (exact == image_cache.end())
+            return retain_image(key, image, memory, allocation_bytes, source);
+        if (exact->second.pins) return false;
+
+        const VkDeviceSize limit = persistent_compute_image_limit(this->memory);
+        if (allocation_bytes > limit || exact->second.allocation_bytes > image_cache_bytes)
+            return false;
+        const VkDeviceSize retained_without_exact =
+            image_cache_bytes - exact->second.allocation_bytes;
+        const VkDeviceSize allowed_without_exact = limit - allocation_bytes;
+        if (retained_without_exact > allowed_without_exact) {
+            VkDeviceSize reclaimable = 0;
+            for (const auto& [candidate_key, cached] : image_cache) {
+                if (candidate_key == key || cached.pins) continue;
+                if (cached.allocation_bytes >=
+                    retained_without_exact - allowed_without_exact - reclaimable) {
+                    reclaimable = retained_without_exact - allowed_without_exact;
+                    break;
+                }
+                reclaimable += cached.allocation_bytes;
+            }
+            if (reclaimable < retained_without_exact - allowed_without_exact)
+                return false;
+        }
+
+        CachedComputeImage replacement;
+        replacement.image = image;
+        replacement.memory = memory;
+        replacement.allocation_bytes = allocation_bytes;
+        replacement.last_use = ++image_cache_clock;
+        replacement.pins = 1;
+        if (!key.host_data)
+            replacement.validation_snapshot = prosper::gpu::guest_gpu_write_snapshot();
+        if (source)
+            remember_image_source_snapshot(
+                replacement, source, key.guest_bytes, key.storage);
+
+        // Capacity was preflighted while the exact entry remained protected.  Evict only the
+        // required other entries; the exact entry's bytes are replaced, not added a second time.
+        while (image_cache_bytes - exact->second.allocation_bytes > allowed_without_exact) {
+            auto victim = image_cache.end();
+            for (auto it = image_cache.begin(); it != image_cache.end(); ++it) {
+                if (it->first == key || it->second.pins) continue;
+                if (victim == image_cache.end() ||
+                    it->second.last_use < victim->second.last_use)
+                    victim = it;
+            }
+            if (victim == image_cache.end()) return false;
+            destroy_cached_image_resources(victim->second);
+            image_cache_bytes -= victim->second.allocation_bytes;
+            image_cache.erase(victim);
+        }
+        exact = image_cache.find(key);
+        if (exact == image_cache.end() || exact->second.pins) return false;
+        image_cache_bytes -= exact->second.allocation_bytes;
+        destroy_cached_image_resources(exact->second);
+        exact->second = std::move(replacement);
         image_cache_bytes += allocation_bytes;
         return true;
     }
@@ -2258,6 +2334,7 @@ struct BoundImage {
     bool imported_transfer_dst = false;
     bool persistent = false;            // guest-backed sampled image retained across dispatches
     bool cache_candidate = false;
+    bool post_writeback_promotion_candidate = false;
     bool upload_skipped = false;         // write watch proved the cached source unchanged
     VkDeviceSize allocation_bytes = 0;
     VkDeviceSize staging_allocation_bytes = 0;
@@ -5261,12 +5338,22 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     persistent_compute_image_enabled(
                         sbytes, ComputeImageCacheClass::storage),
                 };
+                // Build the same exact identity used by ordinary admission before choosing either
+                // path.  A compressed target may become eligible only after successful writeback;
+                // deriving a second, looser key there could replace an unrelated cached image.
+                bi.cache_key = storage_image_cache_key(
+                    *r, static_cast<uint32_t>(guest_bytes), image_format);
                 bi.cache_candidate =
                     compute_storage_cache_gate_candidate(storage_cache_gates);
+                bi.post_writeback_promotion_candidate =
+                    compute_storage_post_writeback_promotion_candidate({
+                        storage_cache_gates,
+                        bi.dcc_metadata && bi.dcc_metadata_bytes,
+                        bi.alias_of == SIZE_MAX,
+                        true,
+                    });
                 if (bi.cache_candidate) {
                     const auto cache_lookup_start = ComputeClock::now();
-                    bi.cache_key = storage_image_cache_key(
-                        *r, static_cast<uint32_t>(guest_bytes), image_format);
                     bi.persistent = ctx.acquire_cached_image(
                         bi.cache_key, resource_bytes_for(r, guest_bytes), image_validation_epoch,
                         bi.image, bi.memory, bi.upload_skipped,
@@ -6525,7 +6612,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                      VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, 0, 0, nullptr, 0,
                                      nullptr, 1, &mirror_to_general);
             }
-            if (bi.cache_candidate || bi.persistent) {
+            if (bi.cache_candidate || bi.persistent ||
+                bi.post_writeback_promotion_candidate) {
                 VkImageMemoryBarrier to_general = to_src;
                 to_general.srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
                 to_general.dstAccessMask = VK_ACCESS_SHADER_READ_BIT |
@@ -7159,18 +7247,28 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                    item.submit_no, item.dispatch_index,
                                    item.command_order, item.code_addr);
             if (bi.dcc_metadata && bi.dcc_metadata_bytes) {
-                std::memset(bi.dcc_metadata, 0xff, bi.dcc_metadata_bytes);
-                notify_guest_gpu_write(r->metadata_addr, bi.dcc_metadata_bytes);
-                if (!r->dcc_metadata_host_data && writer_provenance_enabled())
-                    record_guest_write(GuestWriterKind::ComputeBuffer,
-                                       r->metadata_addr, bi.dcc_metadata_bytes,
-                                       item.submit_no, item.dispatch_index,
-                                       item.command_order, item.code_addr);
-                if (trace)
+                const bool leave_compressed_for_test =
+                    g_leave_next_dcc_metadata_compressed_for_test.exchange(
+                        false, std::memory_order_acq_rel);
+                if (!leave_compressed_for_test) {
+                    std::memset(bi.dcc_metadata, 0xff, bi.dcc_metadata_bytes);
+                    notify_guest_gpu_write(r->metadata_addr, bi.dcc_metadata_bytes);
+                    if (!r->dcc_metadata_host_data && writer_provenance_enabled())
+                        record_guest_write(GuestWriterKind::ComputeBuffer,
+                                           r->metadata_addr, bi.dcc_metadata_bytes,
+                                           item.submit_no, item.dispatch_index,
+                                           item.command_order, item.code_addr);
+                    if (trace)
+                        std::fprintf(stderr,
+                                     "[compute]   DCC uncompressed binding=%u meta=0x%llx "
+                                     "bytes=%zu code=0xff\n",
+                                     bi.binding, (unsigned long long)r->metadata_addr,
+                                     bi.dcc_metadata_bytes);
+                } else if (trace) {
                     std::fprintf(stderr,
-                                 "[compute]   DCC uncompressed binding=%u meta=0x%llx bytes=%zu code=0xff\n",
-                                 bi.binding, (unsigned long long)r->metadata_addr,
-                                 bi.dcc_metadata_bytes);
+                                 "[compute]   injected unresolved DCC writeback binding=%u\n",
+                                 bi.binding);
+                }
             }
             if (bi.mirror_result_to_imported) {
                 const BoundImage& mirror = images[bi.seed_from_imported];
@@ -7186,8 +7284,38 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             }
             const auto notify_done = ComputeClock::now();
             bool retain_gpu_result_baseline = false;
+            bool promoted_after_writeback = false;
+            const bool final_dcc_cache_safe = bi.dcc_metadata && bi.dcc_metadata_bytes &&
+                std::all_of(bi.dcc_metadata, bi.dcc_metadata + bi.dcc_metadata_bytes,
+                            [](uint8_t value) { return value == 0xff; });
+            if (bi.post_writeback_promotion_candidate && final_dcc_cache_safe &&
+                !g_fail_next_dcc_promotion_admission_for_test.exchange(
+                    false, std::memory_order_acq_rel)) {
+                const uint8_t* retained_source =
+                    (adaptive_storage_result_validation_enabled() &&
+                     cold_storage_result_snapshot_can_defer(
+                         r->host_data != nullptr, bi.seed_skip, bi.guest_bytes,
+                         cold_storage_result_snapshot_defer_min_bytes()))
+                    ? nullptr : destination;
+                if (bi.image && bi.memory && bi.allocation_bytes &&
+                    ctx.replace_or_retain_image(
+                        bi.cache_key, bi.image, bi.memory,
+                        bi.allocation_bytes, retained_source)) {
+                    bi.cache_candidate = true;
+                    bi.persistent = true;
+                    promoted_after_writeback = true;
+                    g_dcc_post_writeback_promotions.fetch_add(
+                        1, std::memory_order_relaxed);
+                    if (trace)
+                        std::fprintf(stderr,
+                                     "[compute]   promoted post-writeback DCC storage image "
+                                     "binding=%u addr=0x%llx allocation=%llu\n",
+                                     bi.binding, (unsigned long long)r->gpu_addr,
+                                     (unsigned long long)bi.allocation_bytes);
+                }
+            }
             if (bi.cache_candidate) {
-                if (bi.persistent) {
+                if (bi.persistent && !promoted_after_writeback) {
                     // Guest bytes now mirror the retained image again. A changing full-overwrite
                     // target needs no source snapshot; the first repeated result retains one exact
                     // baseline, and subsequent identical GPU skips do not recopy it.
@@ -7471,6 +7599,10 @@ uint64_t live_compute_storage_transfer_seeds() {
     return g_compute_storage_transfer_seeds.load(std::memory_order_relaxed);
 }
 
+uint64_t live_compute_dcc_post_writeback_promotions() {
+    return g_dcc_post_writeback_promotions.load(std::memory_order_relaxed);
+}
+
 bool live_compute_native_storage_3d_supported(prosper::gpu::DataFormat format,
                                               uint32_t components,
                                               uint32_t width, uint32_t height,
@@ -7502,6 +7634,16 @@ bool cold_storage_result_snapshot_can_defer(bool host_data, bool full_overwrite,
 
 void live_compute_fail_next_storage_readback_for_test() {
     g_fail_next_storage_readback_for_test.store(true, std::memory_order_release);
+}
+
+void live_compute_leave_next_dcc_metadata_compressed_for_test() {
+    g_leave_next_dcc_metadata_compressed_for_test.store(
+        true, std::memory_order_release);
+}
+
+void live_compute_fail_next_dcc_promotion_admission_for_test() {
+    g_fail_next_dcc_promotion_admission_for_test.store(
+        true, std::memory_order_release);
 }
 
 void live_compute_zero_next_cold_storage_snapshot_minimum_for_test() {

--- a/prosper/frontends/shared/live_compute.hpp
+++ b/prosper/frontends/shared/live_compute.hpp
@@ -196,10 +196,10 @@ void live_compute_fail_next_storage_readback_for_test();
 
 // Deterministic controls for post-DCC cache-promotion regressions.  The first leaves the next
 // writable metadata plane unresolved, exercising the final all-0xff recheck.  The second models a
-// cache-capacity refusal after successful writeback; both must keep the transient fallback owned by
-// the caller and publish no cache/export authority.
+// real replacement cache-capacity preflight after successful writeback; both must keep the
+// transient fallback owned by the caller and publish no cache/export authority.
 void live_compute_leave_next_dcc_metadata_compressed_for_test();
-void live_compute_fail_next_dcc_promotion_admission_for_test();
+void live_compute_limit_next_image_replacement_for_test();
 
 // Deterministically lower the next eligible cold storage admission crossover to zero. This lets a
 // compact production-backend fixture execute the real deferral predicate and retention branch.

--- a/prosper/frontends/shared/live_compute.hpp
+++ b/prosper/frontends/shared/live_compute.hpp
@@ -167,6 +167,9 @@ bool compute_native_2d_transfer_format_compatible(prosper::gpu::DataFormat forma
 // Monotonic count of sampled 2D/3D images seeded from an exact retained native storage result with a
 // device-local image copy instead of a guest-memory conversion/upload.
 uint64_t live_compute_storage_transfer_seeds();
+// Monotonic count of compressed storage results admitted only after an exact successful writeback
+// published both ordinary base bytes and an all-uncompressed DCC metadata plane.
+uint64_t live_compute_dcc_post_writeback_promotions();
 // Query the initialized live backend for the exact typed 3D storage+transfer image contract. Tests
 // use this to exercise native-volume execution only on devices that can create the Vulkan image.
 bool live_compute_native_storage_3d_supported(prosper::gpu::DataFormat format,
@@ -190,6 +193,13 @@ bool cold_storage_result_snapshot_can_defer(bool host_data, bool full_overwrite,
 // Deterministic failure injection for the storage-image recovery regression test. The next storage
 // readback fails after dispatch, exercising retained-image invalidation without a Vulkan fault.
 void live_compute_fail_next_storage_readback_for_test();
+
+// Deterministic controls for post-DCC cache-promotion regressions.  The first leaves the next
+// writable metadata plane unresolved, exercising the final all-0xff recheck.  The second models a
+// cache-capacity refusal after successful writeback; both must keep the transient fallback owned by
+// the caller and publish no cache/export authority.
+void live_compute_leave_next_dcc_metadata_compressed_for_test();
+void live_compute_fail_next_dcc_promotion_admission_for_test();
 
 // Deterministically lower the next eligible cold storage admission crossover to zero. This lets a
 // compact production-backend fixture execute the real deferral predicate and retention branch.

--- a/prosper/tests/test_compute_timing_selector.cpp
+++ b/prosper/tests/test_compute_timing_selector.cpp
@@ -146,6 +146,46 @@ int main() {
     CHECK(!compute_storage_cache_gate_candidate(cache_gates),
           "persistent cache disable blocks storage cache candidate");
 
+    const ComputeStoragePostWritebackPromotionInputs promotion_eligible{
+        {false, false, false, true, false, true}, true, true, true};
+    CHECK(compute_storage_post_writeback_promotion_candidate(promotion_eligible),
+          "post-writeback promotion accepts DCC as the sole failed normal cache gate");
+    ComputeStoragePostWritebackPromotionInputs promotion_gates = promotion_eligible;
+    promotion_gates.pre_dispatch.renderer_owned = true;
+    CHECK(!compute_storage_post_writeback_promotion_candidate(promotion_gates),
+          "renderer ownership blocks post-writeback promotion");
+    promotion_gates = promotion_eligible;
+    promotion_gates.pre_dispatch.dcc_cache_safe = true;
+    CHECK(!compute_storage_post_writeback_promotion_candidate(promotion_gates),
+          "an already-safe DCC target uses the normal cache path instead of promotion");
+    promotion_gates = promotion_eligible;
+    promotion_gates.pre_dispatch.poison_verify = true;
+    CHECK(!compute_storage_post_writeback_promotion_candidate(promotion_gates),
+          "poison verification blocks post-writeback promotion");
+    promotion_gates = promotion_eligible;
+    promotion_gates.pre_dispatch.exact_storage = false;
+    CHECK(!compute_storage_post_writeback_promotion_candidate(promotion_gates),
+          "nonexact storage without a seed-skip proof blocks post-writeback promotion");
+    promotion_gates.pre_dispatch.seed_skip = true;
+    CHECK(compute_storage_post_writeback_promotion_candidate(promotion_gates),
+          "seed skip satisfies the post-writeback representation gate");
+    promotion_gates = promotion_eligible;
+    promotion_gates.pre_dispatch.persistent_enabled = false;
+    CHECK(!compute_storage_post_writeback_promotion_candidate(promotion_gates),
+          "disabled persistence blocks post-writeback promotion");
+    promotion_gates = promotion_eligible;
+    promotion_gates.writable_dcc_metadata = false;
+    CHECK(!compute_storage_post_writeback_promotion_candidate(promotion_gates),
+          "missing writable DCC metadata blocks post-writeback promotion");
+    promotion_gates = promotion_eligible;
+    promotion_gates.unique_alias_owner = false;
+    CHECK(!compute_storage_post_writeback_promotion_candidate(promotion_gates),
+          "a folded alias cannot take the owner's post-writeback obligation");
+    promotion_gates = promotion_eligible;
+    promotion_gates.exact_cache_key = false;
+    CHECK(!compute_storage_post_writeback_promotion_candidate(promotion_gates),
+          "a mismatched cache identity blocks post-writeback promotion");
+
     ComputeTransferGateSelector gate_selector{
         true, true, 0x2c595d5aada78398ull, 0xa57c763ae4d70d1dull};
     ComputeTransferGateSelectorCounters gate_counters;

--- a/prosper/tests/test_compute_timing_selector.cpp
+++ b/prosper/tests/test_compute_timing_selector.cpp
@@ -147,7 +147,7 @@ int main() {
           "persistent cache disable blocks storage cache candidate");
 
     const ComputeStoragePostWritebackPromotionInputs promotion_eligible{
-        {false, false, false, true, false, true}, true, true, true};
+        {false, false, false, true, false, true}, true, true};
     CHECK(compute_storage_post_writeback_promotion_candidate(promotion_eligible),
           "post-writeback promotion accepts DCC as the sole failed normal cache gate");
     ComputeStoragePostWritebackPromotionInputs promotion_gates = promotion_eligible;
@@ -165,10 +165,10 @@ int main() {
     promotion_gates = promotion_eligible;
     promotion_gates.pre_dispatch.exact_storage = false;
     CHECK(!compute_storage_post_writeback_promotion_candidate(promotion_gates),
-          "nonexact storage without a seed-skip proof blocks post-writeback promotion");
+          "nonexact storage blocks post-writeback promotion");
     promotion_gates.pre_dispatch.seed_skip = true;
-    CHECK(compute_storage_post_writeback_promotion_candidate(promotion_gates),
-          "seed skip satisfies the post-writeback representation gate");
+    CHECK(!compute_storage_post_writeback_promotion_candidate(promotion_gates),
+          "seed skip cannot make a nonexact storage representation exportable");
     promotion_gates = promotion_eligible;
     promotion_gates.pre_dispatch.persistent_enabled = false;
     CHECK(!compute_storage_post_writeback_promotion_candidate(promotion_gates),
@@ -181,11 +181,6 @@ int main() {
     promotion_gates.unique_alias_owner = false;
     CHECK(!compute_storage_post_writeback_promotion_candidate(promotion_gates),
           "a folded alias cannot take the owner's post-writeback obligation");
-    promotion_gates = promotion_eligible;
-    promotion_gates.exact_cache_key = false;
-    CHECK(!compute_storage_post_writeback_promotion_candidate(promotion_gates),
-          "a mismatched cache identity blocks post-writeback promotion");
-
     ComputeTransferGateSelector gate_selector{
         true, true, 0x2c595d5aada78398ull, 0xa57c763ae4d70d1dull};
     ComputeTransferGateSelectorCounters gate_counters;

--- a/prosper/tests/test_game_compute.cpp
+++ b/prosper/tests/test_game_compute.cpp
@@ -1709,23 +1709,50 @@ int main() {
             resource.dcc_metadata_host_data_size = dcc_metadata.size();
         }
     }
-    std::vector<uint32_t> dcc_spirv = recompile_valu(
-        image_copy_2d, sizeof(image_copy_2d) / sizeof(image_copy_2d[0]), 1, 0, &dcc_rt);
-    CHECK(!dcc_spirv.empty(), "2D storage copy recompiles for a DCC-enabled tiled destination");
+    ComputeShaderConfig dcc_config;
+    dcc_config.user_sgprs.resize(16);
+    dcc_config.local_x = W;
+    dcc_config.local_y = dcc_config.local_z = 1;
+    dcc_config.threads_x = W;
+    dcc_config.threads_y = dcc_config.threads_z = 1;
+    dcc_config.native_storage_format_support =
+        native_storage_format_support_bit(DataFormat::Unorm8, 4);
+    std::vector<uint32_t> dcc_spirv = recompile_compute(
+        image_copy_2d, std::size(image_copy_2d), &dcc_rt, dcc_config);
+    const DescriptorValidationReport dcc_report = validate_spirv_descriptor_interface(
+        dcc_spirv, &dcc_rt, 0, SpirvShaderStage::Compute, false);
+    const SpirvDescriptorBinding* dcc_output_binding =
+        find_spirv_descriptor_binding(dcc_report, 0, 5);
+    const bool dcc_shape_ok = !dcc_spirv.empty() && dcc_report.ok() &&
+        dcc_output_binding && dcc_output_binding->storage_float &&
+        dcc_output_binding->writable;
+    CHECK(dcc_shape_ok,
+          "DCC producer recompiles to exact typed writable storage for sampled export");
     ComputeItem dcc_item;
     dcc_item.spirv = dcc_spirv;
     dcc_item.resources = std::make_shared<ShaderResourceTable>(dcc_rt);
     dcc_item.launch.threads_x = W;
+    dcc_item.launch.threads_y = dcc_item.launch.threads_z = 1;
     dcc_item.launch.local_x = 64;
     dcc_item.launch.groups_x = 1;
     dcc_item.launch.local_y = dcc_item.launch.local_z = 1;
     dcc_item.launch.groups_y = dcc_item.launch.groups_z = 1;
     dcc_item.code_addr = 0x719dcc;
-    if (!dcc_spirv.empty()) {
+    if (dcc_shape_ok) {
+        // The first sighting of a write-only storage kernel is deliberately a poison proving
+        // frame.  Promotion must stay fail-closed until that execution proves full coverage; then
+        // restore a compressed metadata state and require the proven seed-skip execution to publish
+        // the exact post-writeback image.
         const uint64_t promotions_before =
             prosper::frontend::live_compute_dcc_post_writeback_promotions();
         CHECK(prosper::frontend::execute_live_compute_items({dcc_item}),
-              "live backend writes the tiled DCC storage image");
+              "live backend proves coverage while writing the tiled DCC storage image");
+        CHECK(prosper::frontend::live_compute_dcc_post_writeback_promotions() ==
+                  promotions_before,
+              "poison-proving DCC writeback publishes no cache authority");
+        std::fill(dcc_metadata.begin(), dcc_metadata.end(), 0x40);
+        CHECK(prosper::frontend::execute_live_compute_items({dcc_item}),
+              "proven full-coverage backend rewrites the tiled DCC storage image");
         CHECK(prosper::frontend::live_compute_dcc_post_writeback_promotions() ==
                   promotions_before + 1,
               "successful exact DCC writeback promotes its transient storage image");
@@ -1780,6 +1807,8 @@ int main() {
         dcc_consumer_item.resources =
             std::make_shared<ShaderResourceTable>(dcc_consumer_rt);
         dcc_consumer_item.code_addr = 0x719dce;
+        ShaderResource sampled_dcc_output = dcc_output ? *dcc_output : ShaderResource{};
+        sampled_dcc_output.cls = ResourceClass::Texture;
         const auto run_dcc_consumer = [&]() {
             std::fill(dcc_copy_dst.begin(), dcc_copy_dst.end(), 0x6d);
             const uint64_t seeds_before =
@@ -1793,22 +1822,66 @@ int main() {
                            W, 1, dcc_tile, 0, 4);
             return std::tuple{executed, copied_linear, seeds_before, seeds_after};
         };
+        const auto run_dcc_ordered_handoff =
+            [&](prosper::frontend::LiveComputeImageImport* graphics_import) {
+                std::fill(dcc_copy_dst.begin(), dcc_copy_dst.end(), 0x6d);
+                ComputeItem ordered_producer = dcc_item;
+                ordered_producer.dispatch_index = 701;
+                ordered_producer.command_order = 10;
+                ComputeItem ordered_consumer = dcc_consumer_item;
+                ordered_consumer.dispatch_index = 702;
+                ordered_consumer.command_order = 20;
+                DrawItem ordered_draw;
+                ordered_draw.draw_index = 703;
+                ordered_draw.command_order = 30;
+                const uint64_t promotions_before =
+                    prosper::frontend::live_compute_dcc_post_writeback_promotions();
+                const uint64_t seeds_before =
+                    prosper::frontend::live_compute_storage_transfer_seeds();
+                const OrderedSubmitResult ordered = execute_ordered_items(
+                    {{SubmitOperationKind::Dispatch, ordered_producer.dispatch_index,
+                      ordered_producer.command_order},
+                     {SubmitOperationKind::Dispatch, ordered_consumer.dispatch_index,
+                      ordered_consumer.command_order},
+                     {SubmitOperationKind::Draw, ordered_draw.draw_index,
+                      ordered_draw.command_order}},
+                    {ordered_draw}, {ordered_producer, ordered_consumer},
+                    [&](const std::vector<DrawItem>&, uint32_t, uint32_t) {
+                        if (graphics_import)
+                            (void)prosper::frontend::import_live_compute_storage_image(
+                                sampled_dcc_output, tiled_bytes, *graphics_import);
+                        return RenderedFrame{};
+                    },
+                    [&](const std::vector<ComputeItem>& items) {
+                        return prosper::frontend::execute_live_compute_items(items);
+                    },
+                    1, 1);
+                const uint64_t promotions_after =
+                    prosper::frontend::live_compute_dcc_post_writeback_promotions();
+                const uint64_t seeds_after =
+                    prosper::frontend::live_compute_storage_transfer_seeds();
+                std::vector<uint8_t> copied_linear(W * 4, 0);
+                detile_surface(copied_linear.data(), dcc_copy_dst.data(),
+                               W, 1, dcc_tile, 0, 4);
+                return std::tuple{ordered.compute_executed, copied_linear,
+                                  promotions_before, promotions_after,
+                                  seeds_before, seeds_after};
+            };
         if (!dcc_consumer_spirv.empty()) {
-            auto [consumer_ok, copied_linear, seeds_before, seeds_after] =
-                run_dcc_consumer();
-            CHECK(consumer_ok && copied_linear == img_src,
+            std::fill(dcc_metadata.begin(), dcc_metadata.end(), 0x40);
+            prosper::frontend::LiveComputeImageImport pinned_import;
+            auto [consumer_ok, copied_linear, ordered_promotions_before,
+                  ordered_promotions_after, seeds_before, seeds_after] =
+                run_dcc_ordered_handoff(&pinned_import);
+            CHECK(consumer_ok && copied_linear == img_src &&
+                      ordered_promotions_after == ordered_promotions_before + 1,
                   "post-DCC sampled consumer receives every exact producer byte");
             CHECK(!native_2d_compute_transfer_available || seeds_after > seeds_before,
                   "post-DCC producer seeds its sampled consumer on-GPU");
             CHECK(native_2d_compute_transfer_available || seeds_after == seeds_before,
                   "disabled native transfer keeps the post-DCC sampled guest fallback");
 
-            ShaderResource sampled_dcc_output = *dcc_output;
-            sampled_dcc_output.cls = ResourceClass::Texture;
-            prosper::frontend::LiveComputeImageImport pinned_import;
-            CHECK(prosper::frontend::import_live_compute_storage_image(
-                      sampled_dcc_output, tiled_bytes, pinned_import) &&
-                      pinned_import.valid(),
+            CHECK(pinned_import.valid(),
                   "post-DCC graphics import pins the exact promoted cache entry");
             if (pinned_import.valid()) {
                 std::fill(dcc_metadata.begin(), dcc_metadata.end(), 0x40);
@@ -1840,12 +1913,17 @@ int main() {
             tile_surface(tiled_src.data(), img_src.data(), W, 1, dcc_tile, 0, 4);
             const uint64_t replacement_promotions_before =
                 prosper::frontend::live_compute_dcc_post_writeback_promotions();
-            CHECK(prosper::frontend::execute_live_compute_items({dcc_item}) &&
-                      prosper::frontend::live_compute_dcc_post_writeback_promotions() ==
+            auto [replacement_ok, replacement_linear,
+                  ordered_replacement_promotions_before,
+                  ordered_replacement_promotions_after,
+                  replacement_seeds_before, replacement_seeds_after] =
+                run_dcc_ordered_handoff(nullptr);
+            CHECK(replacement_ok &&
+                      replacement_promotions_before ==
+                          ordered_replacement_promotions_before &&
+                      ordered_replacement_promotions_after ==
                           replacement_promotions_before + 1,
                   "unpinned exact-key collision is replaced after successful DCC writeback");
-            auto [replacement_ok, replacement_linear,
-                  replacement_seeds_before, replacement_seeds_after] = run_dcc_consumer();
             CHECK(replacement_ok && replacement_linear == img_src,
                   "replacement promotion preserves changed producer bytes exactly");
             CHECK(!native_2d_compute_transfer_available ||
@@ -1859,20 +1937,21 @@ int main() {
                       mismatched_dcc_output, tiled_bytes, mismatched_import),
                   "post-DCC graphics reuse requires the exact promoted cache key");
 
-            // A capacity refusal happens after exact writeback and DCC publication.  It must leave
-            // this dispatch transient, so the next sampled use reads the correct guest fallback
-            // without inheriting the older exact-key entry's transfer authority.
+            // Force the real replacement cache-limit preflight below this allocation after exact
+            // writeback and DCC publication. It must leave this dispatch transient, so the next
+            // sampled use reads the correct guest fallback without inheriting the older exact-key
+            // entry's transfer authority.
             std::fill(dcc_metadata.begin(), dcc_metadata.end(), 0x40);
             for (size_t index = 0; index < img_src.size(); ++index)
                 img_src[index] = static_cast<uint8_t>(index * 7u + 0x23u);
             tile_surface(tiled_src.data(), img_src.data(), W, 1, dcc_tile, 0, 4);
-            prosper::frontend::live_compute_fail_next_dcc_promotion_admission_for_test();
+            prosper::frontend::live_compute_limit_next_image_replacement_for_test();
             const uint64_t refused_promotions_before =
                 prosper::frontend::live_compute_dcc_post_writeback_promotions();
             CHECK(prosper::frontend::execute_live_compute_items({dcc_item}) &&
                       prosper::frontend::live_compute_dcc_post_writeback_promotions() ==
                           refused_promotions_before,
-                  "post-DCC cache admission failure preserves the transient fallback");
+                  "post-DCC capacity preflight preserves the transient fallback");
             auto [refused_ok, refused_linear,
                   refused_seeds_before, refused_seeds_after] = run_dcc_consumer();
             CHECK(refused_ok && refused_linear == img_src,
@@ -1940,7 +2019,6 @@ int main() {
                   failed_sampled_output, tiled_bytes, failed_import),
               "failed DCC readback publishes no graphics cache authority");
     }
-
     // Two storage views may share base texels while only one carries DCC state. They are not safe
     // Vulkan-image aliases: collapsing the compressed view onto an uncompressed owner drops its
     // separate metadata writeback obligation and leaves later sampled users reading stale DCC.

--- a/prosper/tests/test_game_compute.cpp
+++ b/prosper/tests/test_game_compute.cpp
@@ -16,6 +16,7 @@
 #include <cstring>
 #include <limits>
 #include <string>
+#include <tuple>
 #include <vector>
 
 #ifdef _WIN32
@@ -1711,18 +1712,23 @@ int main() {
     std::vector<uint32_t> dcc_spirv = recompile_valu(
         image_copy_2d, sizeof(image_copy_2d) / sizeof(image_copy_2d[0]), 1, 0, &dcc_rt);
     CHECK(!dcc_spirv.empty(), "2D storage copy recompiles for a DCC-enabled tiled destination");
+    ComputeItem dcc_item;
+    dcc_item.spirv = dcc_spirv;
+    dcc_item.resources = std::make_shared<ShaderResourceTable>(dcc_rt);
+    dcc_item.launch.threads_x = W;
+    dcc_item.launch.local_x = 64;
+    dcc_item.launch.groups_x = 1;
+    dcc_item.launch.local_y = dcc_item.launch.local_z = 1;
+    dcc_item.launch.groups_y = dcc_item.launch.groups_z = 1;
+    dcc_item.code_addr = 0x719dcc;
     if (!dcc_spirv.empty()) {
-        ComputeItem dcc_item;
-        dcc_item.spirv = dcc_spirv;
-        dcc_item.resources = std::make_shared<ShaderResourceTable>(dcc_rt);
-        dcc_item.launch.threads_x = W;
-        dcc_item.launch.local_x = 64;
-        dcc_item.launch.groups_x = 1;
-        dcc_item.launch.local_y = dcc_item.launch.local_z = 1;
-        dcc_item.launch.groups_y = dcc_item.launch.groups_z = 1;
-        dcc_item.code_addr = 0x719dcc;
+        const uint64_t promotions_before =
+            prosper::frontend::live_compute_dcc_post_writeback_promotions();
         CHECK(prosper::frontend::execute_live_compute_items({dcc_item}),
               "live backend writes the tiled DCC storage image");
+        CHECK(prosper::frontend::live_compute_dcc_post_writeback_promotions() ==
+                  promotions_before + 1,
+              "successful exact DCC writeback promotes its transient storage image");
         std::vector<uint8_t> dcc_linear(W * 4, 0);
         detile_surface(dcc_linear.data(), tiled_dst.data(), W, 1, dcc_tile, 0, 4);
         CHECK(dcc_linear == img_src,
@@ -1730,6 +1736,209 @@ int main() {
         CHECK(std::all_of(dcc_metadata.begin(), dcc_metadata.end(),
                           [](uint8_t code) { return code == 0xff; }),
               "DCC storage writeback publishes uniform uncompressed metadata");
+
+        // Consume the just-published target through an ordinary sampled descriptor.  Guest bytes
+        // are the correctness oracle; the monotonic seed counter independently proves that the
+        // consumer borrowed the producer's retained Vulkan image instead of uploading those bytes.
+        std::vector<uint8_t> dcc_copy_dst(tiled_bytes, 0x6d);
+        ShaderResourceTable dcc_consumer_rt = irt;
+        const ShaderResource* dcc_output = nullptr;
+        for (const ShaderResource& resource : dcc_rt.resources)
+            if (resource.binding == 5) dcc_output = &resource;
+        for (ShaderResource& resource : dcc_consumer_rt.resources) {
+            if (!dcc_output || (resource.binding != 4 && resource.binding != 5)) continue;
+            const uint32_t binding = resource.binding;
+            const uint32_t sgpr_base = resource.sgpr_base;
+            resource = *dcc_output;
+            resource.binding = binding;
+            resource.sgpr_base = sgpr_base;
+            if (binding == 4) {
+                resource.cls = ResourceClass::Texture;
+                resource.gpu_addr = reinterpret_cast<uint64_t>(tiled_dst.data());
+                resource.swizzle[0] = 4;
+                resource.swizzle[1] = 5;
+                resource.swizzle[2] = 6;
+                resource.swizzle[3] = 7;
+            } else {
+                resource.cls = ResourceClass::StorageImage;
+                resource.gpu_addr = reinterpret_cast<uint64_t>(dcc_copy_dst.data());
+                resource.compression_enabled = false;
+                resource.write_compress_enabled = false;
+                resource.meta_pipe_aligned = false;
+                resource.metadata_addr = 0;
+                resource.dcc_metadata_size = 0;
+                resource.dcc_metadata_host_data = nullptr;
+                resource.dcc_metadata_host_data_size = 0;
+            }
+        }
+        const std::vector<uint32_t> dcc_consumer_spirv = recompile_valu(
+            image_copy_2d, std::size(image_copy_2d), 1, 0, &dcc_consumer_rt);
+        CHECK(!dcc_consumer_spirv.empty(),
+              "post-DCC sampled consumer recompiles against the exact producer descriptor");
+        ComputeItem dcc_consumer_item = dcc_item;
+        dcc_consumer_item.spirv = dcc_consumer_spirv;
+        dcc_consumer_item.resources =
+            std::make_shared<ShaderResourceTable>(dcc_consumer_rt);
+        dcc_consumer_item.code_addr = 0x719dce;
+        const auto run_dcc_consumer = [&]() {
+            std::fill(dcc_copy_dst.begin(), dcc_copy_dst.end(), 0x6d);
+            const uint64_t seeds_before =
+                prosper::frontend::live_compute_storage_transfer_seeds();
+            const bool executed = prosper::frontend::execute_live_compute_items(
+                {dcc_consumer_item});
+            const uint64_t seeds_after =
+                prosper::frontend::live_compute_storage_transfer_seeds();
+            std::vector<uint8_t> copied_linear(W * 4, 0);
+            detile_surface(copied_linear.data(), dcc_copy_dst.data(),
+                           W, 1, dcc_tile, 0, 4);
+            return std::tuple{executed, copied_linear, seeds_before, seeds_after};
+        };
+        if (!dcc_consumer_spirv.empty()) {
+            auto [consumer_ok, copied_linear, seeds_before, seeds_after] =
+                run_dcc_consumer();
+            CHECK(consumer_ok && copied_linear == img_src,
+                  "post-DCC sampled consumer receives every exact producer byte");
+            CHECK(!native_2d_compute_transfer_available || seeds_after > seeds_before,
+                  "post-DCC producer seeds its sampled consumer on-GPU");
+            CHECK(native_2d_compute_transfer_available || seeds_after == seeds_before,
+                  "disabled native transfer keeps the post-DCC sampled guest fallback");
+
+            ShaderResource sampled_dcc_output = *dcc_output;
+            sampled_dcc_output.cls = ResourceClass::Texture;
+            prosper::frontend::LiveComputeImageImport pinned_import;
+            CHECK(prosper::frontend::import_live_compute_storage_image(
+                      sampled_dcc_output, tiled_bytes, pinned_import) &&
+                      pinned_import.valid(),
+                  "post-DCC graphics import pins the exact promoted cache entry");
+            if (pinned_import.valid()) {
+                std::fill(dcc_metadata.begin(), dcc_metadata.end(), 0x40);
+                for (size_t index = 0; index < img_src.size(); ++index)
+                    img_src[index] = static_cast<uint8_t>(index * 29u + 11u);
+                tile_surface(tiled_src.data(), img_src.data(), W, 1, dcc_tile, 0, 4);
+                const uint64_t pinned_promotions_before =
+                    prosper::frontend::live_compute_dcc_post_writeback_promotions();
+                CHECK(prosper::frontend::execute_live_compute_items({dcc_item}),
+                      "compressed producer completes while its old exact cache entry is pinned");
+                CHECK(prosper::frontend::live_compute_dcc_post_writeback_promotions() ==
+                          pinned_promotions_before,
+                      "pinned exact cache entry declines post-DCC replacement");
+                pinned_import = {};
+                auto [pinned_consumer_ok, pinned_linear,
+                      pinned_seeds_before, pinned_seeds_after] = run_dcc_consumer();
+                CHECK(pinned_consumer_ok && pinned_linear == img_src,
+                      "declined pinned promotion preserves the exact guest fallback");
+                CHECK(pinned_seeds_after == pinned_seeds_before,
+                      "declined pinned promotion publishes no new transfer authority");
+            }
+
+            // Repeat with the exact cache entry unpinned and a changed producer result.  This is
+            // the Astro frame shape: an older consumer entry exists under the same key, and the
+            // compressed producer must replace it rather than letting emplace collide.
+            std::fill(dcc_metadata.begin(), dcc_metadata.end(), 0x40);
+            for (size_t index = 0; index < img_src.size(); ++index)
+                img_src[index] = static_cast<uint8_t>(index * 13u + 0x51u);
+            tile_surface(tiled_src.data(), img_src.data(), W, 1, dcc_tile, 0, 4);
+            const uint64_t replacement_promotions_before =
+                prosper::frontend::live_compute_dcc_post_writeback_promotions();
+            CHECK(prosper::frontend::execute_live_compute_items({dcc_item}) &&
+                      prosper::frontend::live_compute_dcc_post_writeback_promotions() ==
+                          replacement_promotions_before + 1,
+                  "unpinned exact-key collision is replaced after successful DCC writeback");
+            auto [replacement_ok, replacement_linear,
+                  replacement_seeds_before, replacement_seeds_after] = run_dcc_consumer();
+            CHECK(replacement_ok && replacement_linear == img_src,
+                  "replacement promotion preserves changed producer bytes exactly");
+            CHECK(!native_2d_compute_transfer_available ||
+                      replacement_seeds_after > replacement_seeds_before,
+                  "replacement promotion restores producer-to-consumer image reuse");
+
+            ShaderResource mismatched_dcc_output = sampled_dcc_output;
+            ++mismatched_dcc_output.width;
+            prosper::frontend::LiveComputeImageImport mismatched_import;
+            CHECK(!prosper::frontend::import_live_compute_storage_image(
+                      mismatched_dcc_output, tiled_bytes, mismatched_import),
+                  "post-DCC graphics reuse requires the exact promoted cache key");
+
+            // A capacity refusal happens after exact writeback and DCC publication.  It must leave
+            // this dispatch transient, so the next sampled use reads the correct guest fallback
+            // without inheriting the older exact-key entry's transfer authority.
+            std::fill(dcc_metadata.begin(), dcc_metadata.end(), 0x40);
+            for (size_t index = 0; index < img_src.size(); ++index)
+                img_src[index] = static_cast<uint8_t>(index * 7u + 0x23u);
+            tile_surface(tiled_src.data(), img_src.data(), W, 1, dcc_tile, 0, 4);
+            prosper::frontend::live_compute_fail_next_dcc_promotion_admission_for_test();
+            const uint64_t refused_promotions_before =
+                prosper::frontend::live_compute_dcc_post_writeback_promotions();
+            CHECK(prosper::frontend::execute_live_compute_items({dcc_item}) &&
+                      prosper::frontend::live_compute_dcc_post_writeback_promotions() ==
+                          refused_promotions_before,
+                  "post-DCC cache admission failure preserves the transient fallback");
+            auto [refused_ok, refused_linear,
+                  refused_seeds_before, refused_seeds_after] = run_dcc_consumer();
+            CHECK(refused_ok && refused_linear == img_src,
+                  "declined admission preserves exact producer bytes through guest memory");
+            CHECK(refused_seeds_after == refused_seeds_before,
+                  "declined admission publishes no producer transfer authority");
+
+            // The final metadata scan is an independent promotion gate.  Model an unresolved DCC
+            // plane after otherwise successful data writeback and require both correct guest bytes
+            // and absence of cache/transfer publication.
+            std::fill(dcc_metadata.begin(), dcc_metadata.end(), 0x40);
+            for (size_t index = 0; index < img_src.size(); ++index)
+                img_src[index] = static_cast<uint8_t>(index * 43u + 3u);
+            tile_surface(tiled_src.data(), img_src.data(), W, 1, dcc_tile, 0, 4);
+            prosper::frontend::live_compute_leave_next_dcc_metadata_compressed_for_test();
+            const uint64_t unresolved_promotions_before =
+                prosper::frontend::live_compute_dcc_post_writeback_promotions();
+            CHECK(prosper::frontend::execute_live_compute_items({dcc_item}) &&
+                      prosper::frontend::live_compute_dcc_post_writeback_promotions() ==
+                          unresolved_promotions_before &&
+                      std::any_of(dcc_metadata.begin(), dcc_metadata.end(),
+                                  [](uint8_t code) { return code != 0xff; }),
+                  "unresolved post-writeback DCC metadata blocks cache acquisition");
+            auto [unresolved_ok, unresolved_linear,
+                  unresolved_seeds_before, unresolved_seeds_after] = run_dcc_consumer();
+            CHECK(unresolved_ok && unresolved_linear == img_src,
+                  "unresolved DCC promotion keeps the ordinary sampled guest fallback correct");
+            CHECK(unresolved_seeds_after == unresolved_seeds_before,
+                  "unresolved DCC metadata publishes no transfer authority");
+        }
+
+        // A failed readback on a fresh compressed target reaches neither base-byte publication nor
+        // DCC promotion/export.  Use a fresh identity so an older valid cache entry cannot satisfy
+        // the negative import control.
+        std::vector<uint8_t> failed_dcc_dst(tiled_bytes, 0x77);
+        const std::vector<uint8_t> failed_dcc_before = failed_dcc_dst;
+        std::vector<uint8_t> failed_dcc_metadata(metadata_bytes, 0x40);
+        ShaderResourceTable failed_dcc_rt = dcc_rt;
+        ShaderResource failed_sampled_output;
+        for (ShaderResource& resource : failed_dcc_rt.resources) {
+            if (resource.binding != 5) continue;
+            resource.gpu_addr = reinterpret_cast<uint64_t>(failed_dcc_dst.data());
+            resource.metadata_addr = 0x207cef8000ull;
+            resource.dcc_metadata_host_data = failed_dcc_metadata.data();
+            resource.dcc_metadata_host_data_size = failed_dcc_metadata.size();
+            failed_sampled_output = resource;
+            failed_sampled_output.cls = ResourceClass::Texture;
+        }
+        ComputeItem failed_dcc_item = dcc_item;
+        failed_dcc_item.resources =
+            std::make_shared<ShaderResourceTable>(failed_dcc_rt);
+        failed_dcc_item.code_addr = 0x719dcf;
+        prosper::frontend::live_compute_fail_next_storage_readback_for_test();
+        const uint64_t failed_promotions_before =
+            prosper::frontend::live_compute_dcc_post_writeback_promotions();
+        CHECK(!prosper::frontend::execute_live_compute_items({failed_dcc_item}) &&
+                  prosper::frontend::live_compute_dcc_post_writeback_promotions() ==
+                      failed_promotions_before &&
+                  failed_dcc_dst == failed_dcc_before &&
+                  std::all_of(failed_dcc_metadata.begin(), failed_dcc_metadata.end(),
+                              [](uint8_t code) { return code == 0x40; }),
+              "failed DCC readback publishes neither guest bytes, metadata, nor promotion");
+        prosper::frontend::LiveComputeImageImport failed_import;
+        CHECK(!prosper::frontend::import_live_compute_storage_image(
+                  failed_sampled_output, tiled_bytes, failed_import),
+              "failed DCC readback publishes no graphics cache authority");
     }
 
     // Two storage views may share base texels while only one carries DCC state. They are not safe


### PR DESCRIPTION
## Summary

- admit a compressed **exact typed-storage** image to the persistent compute cache only after a successful fence, exact guest-byte writeback, DCC metadata publication, and a final all-`0xff` metadata check
- compute the ordinary storage key before dispatch and safely replace only an unpinned identical entry
- keep promotion generic and fail-closed: renderer-owned, poison-proving, non-exact, nonpersistent, folded-alias, missing-metadata, unresolved-DCC, pinned, or capacity-refused shapes remain transient
- preserve the existing success-only compute-transfer and graphics-export publication path

This implements the narrow generic frontier proved in #1732: Astro Bot producer binding 65 and consumer binding 73 have the same exact native 4K storage contract, but the producer is blocked solely by compressed pre-dispatch DCC metadata. Ordinary successful writeback already publishes exact base bytes and marks that metadata uncompressed.

## Ownership and failure behavior

The prior consumer may already own the identical key. Replacement preflights the real cache limit while protecting that entry, declines if it is pinned, and on success releases its image, memory, result baseline, write watch, validation/export state, and byte accounting before installing the new exact image. A failed readback, unresolved metadata plane, pin, or capacity refusal cannot publish new cache or export authority.

The implementation deliberately excludes raw seed-skip images: their portable Vulkan representation is not format-identical to the sampled consumer and therefore cannot provide this device-local handoff.

## Verification

Run in the `ps5ys` distrobox with a worktree-local disk-backed `TMPDIR`:

- `compute_timing_selector_policy`, `game_compute_exec`, and `game_compute_exec_no_adaptive_storage_result` each passed 5 consecutive runs on RADV
- the production fixture reflects an exact typed DCC producer, proves the first poison/coverage frame publishes nothing, then runs producer -> sampled consumer -> graphics import inside one real ordered submit
- the fixture covers exact bytes, the monotonic device-local transfer counter, first admission, unpinned exact-key replacement, real pinned refusal, real replacement capacity preflight, unresolved non-`0xff` metadata, failed readback/no export, mismatched-key rejection, and the existing mixed-DCC alias obligation
- defect-shaped mutation removing only the exact-typed-storage gate made exactly `nonexact storage blocks post-writeback promotion` and `seed skip cannot make a nonexact storage representation exportable` fail; restoring the gate returned the policy test to green
- `git diff --check`: pass

## Review corrections

The first draft's compiled-but-unrun fixture was invalid: it omitted logical Y/Z thread counts, expected promotion during the intentionally non-promotable proving frame, hard-coded a pseudo exact-key lever, and injected capacity refusal outside the real replacement mechanism. Exact head `da7a02765d3090f52c084b64545b402839ebae08` fixes all four and received independent approval on that SHA.

## Exact-head Astro acceptance

One bounded normal `prosper-app` run exercised the reviewed head at native/default scale and cadence with renderer, SDL audio/pad, and FFmpeg active. It exited naturally after 720 real presented frames and reached `worldmap`.

- selector verdict: producer and consumer each matched 250 times; each reached 500 storage gates
- the producer entered with only 250/500 DCC-safe/cache-candidate gates, but after exact writeback all **500/500** results were publish-candidate, persistent, and authorized
- consumer publication remained 500/500 persistent and authorized
- zero device loss, worker fault, SIGFPE, timeout, or lingering Prosper/replay process
- app SHA-256 `d088ce606115b16e600f42a00d1d8bbcb8424de186a3e934ef147b56f599219c`; log SHA-256 `73504ec717e6c73c60241e27acb3023ad2afc6d046d86ba74970284ee5328cc9`

Displayed world-map rate settled at about 3.2-3.3 FPS. This selector run is not a controlled before/after benchmark, so it makes no FPS improvement claim; it proves correct live activation and a clean world-map route. Full exact evidence is recorded on #1732.

Refs #1732
