### PR TITLE
diag(apr): report the actual read resolution method

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -651,11 +651,11 @@ if(TARGET prosper_core)
   target_link_libraries(test_ajm2_gapless PRIVATE prosper_core)
   add_test(NAME ajm2_gapless COMMAND test_ajm2_gapless)
 
-  # APR container registry + size-keyed read matching (issue #62): stable ids, path dedup, and
-  # the ambiguity/chunk-read refusal the read-submit path relies on. Pure, no game dump needed.
+  # APR container registry + read-source resolution (#62/#1901): stable ids, path dedup, ID-first
+  # reads, unique-size fallback, ambiguous fallback refusal, and method diagnostics. Pure; no dump.
   add_executable(test_apr_registry tests/test_apr_registry.cpp)
   target_link_libraries(test_apr_registry PRIVATE prosper_core)
-  add_test(NAME apr_registry_size_keying COMMAND test_apr_registry)
+  add_test(NAME apr_registry_resolution COMMAND test_apr_registry)
 
   # GTA V (#1139/#1142) net-new HLE regression guards: sceKernelAprGetFileStat fills the real stat
   # (#1133) and sceAudioOut2GetSpeakerArrayMemorySize returns a non-zero allocation size (#1134). The

--- a/prosper/docs/UE4_APR_IOSTORE_BRINGUP.md
+++ b/prosper/docs/UE4_APR_IOSTORE_BRINGUP.md
@@ -8,6 +8,15 @@ Boot recipe: `PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 ./boot_trace <PPSA17942-app
 (GUEST_FS: UE MallocBinned TLS caches read `%fs`; NULL_PAGE: UE's FP-chain backtrace walker
 derefs the null chain terminator).
 
+## Ruled out
+
+- **Two registered containers sharing a total byte size makes either normal APR read ambiguous —
+  false after #78.** `sceAmprAprCommandBufferReadFile` resolves the real `a3` file id first; total
+  byte size is only a legacy fallback when that id is unknown. A collision can therefore refuse
+  only the fallback, not an ID-resolved read. The stale unconditional diagnostic that led tracker
+  #1895 to treat registration warnings as read failures is corrected and regression-tested by
+  [#1901](https://github.com/mattias800/prosper/issues/1901).
+
 ## Frame loop reached; 0 draws = early-load present loop (issue #213, 2026-07-09)
 
 DOLL now boots fully and runs a **stable frame loop**. Two blockers cleared this session:

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -2026,7 +2026,7 @@ std::string prosper_apr_path_for_id(uint32_t id) {
 }
 // Register a resolved container and return its stable 1-based id. Re-resolving the same host path
 // returns the existing id (updated size) instead of a duplicate entry — a duplicate would make
-// every size-keyed read of that file look ambiguous. Exposed (not static) for the unit test.
+// unresolved-id size fallback for that file look ambiguous. Exposed (not static) for the unit test.
 uint32_t prosper_apr_register(const std::string& path, uint64_t size) {
     std::lock_guard lk(g_apr_mx);
     for (size_t i = 0; i < g_apr_files.size(); i++)
@@ -2040,10 +2040,9 @@ void prosper_apr_reset_for_test() {
     g_apr_files.clear();
 }
 // Find resolved host paths whose TOTAL size equals `size`. Returns the match count and sets
-// *out_path to the first match. The read path may only act on an unambiguous (count==1) match:
-// the APR read-request object carries the total byte count at obj+0x30 but the file id is NOT
-// legible in the captured request layout (docs/UE4_APR_IOSTORE_BRINGUP.md field map, +0x00..+0x40),
-// so size is the only correlation currently available. Exposed (not static) for the unit test.
+// *out_path to the first match. The read path resolves the real APR file id first; it may use this
+// legacy fallback only when the id is unknown and the size is unambiguous (count==1). Exposed (not
+// static) for the unit test.
 int prosper_apr_match_by_size(uint64_t size, std::string* out_path) {
     std::lock_guard lk(g_apr_mx);
     int n = 0;
@@ -2107,13 +2106,14 @@ static uint64_t apr_resolve_impl(const char* prefix, const char** paths, int cou
                                    guest.empty() ? "(null)" : guest.c_str());
             return 0x80020002ull;   // ENOENT
         }
-        // Warn loudly (unconditionally) when a DIFFERENT container shares this size: the read
-        // path is size-keyed (see f_apr_read_submit) and will refuse such reads as ambiguous.
+        // A collision does not affect normal reads, which resolve by APR file id. Keep it visible
+        // because the legacy size fallback cannot choose safely if an unknown id reaches it.
         std::string clash; int same_size = prosper_apr_match_by_size(size, &clash);
         id = prosper_apr_register(host, size);
         if (same_size > 0 && clash != host)
-            fprintf(stderr, "[apr] WARNING: %s and %s share byte size %llu — size-keyed reads of "
-                    "either will be refused as ambiguous (issue #62)\n",
+            fprintf(stderr, "[apr] WARNING: %s and %s share byte size %llu — ID-resolved reads "
+                    "remain valid; unresolved-id size fallback will be refused as ambiguous "
+                    "(issue #1901)\n",
                     host.c_str(), clash.c_str(), (unsigned long long)size);
         if (out_ids)   out_ids[i]   = id;
         if (out_sizes) out_sizes[i] = size;
@@ -2465,6 +2465,16 @@ extern "C" uint64_t f_apr_read_submit(uint64_t a0, uint64_t a1, uint64_t a2,
     // container.
     uint64_t id   = a3;
     uint64_t dest = *(uint64_t*)(req + 0x20);   // begin staging / residue; diagnostics only
+    uint64_t offset = 0;
+#ifndef _WIN32
+    offset = apr_stack_arg(entry_rsp, 0);
+#else
+    offset = a6;
+    (void)a7;
+#endif
+    const uint64_t requested_size = a5;
+    const uint64_t fallback_size = *(uint64_t*)(req + 0x30);
+    const char* resolution_method = "id";
     std::string host = prosper_apr_path_for_id((uint32_t)id);
     // Fallback when the id (a3) doesn't resolve: key by the request's total byte count, but ONLY on
     // an unambiguous match — exactly one resolved container of that size (prosper_apr_match_by_size,
@@ -2472,12 +2482,20 @@ extern "C" uint64_t f_apr_read_submit(uint64_t a0, uint64_t a1, uint64_t a2,
     // fails loudly below, rather than serving the wrong file's bytes.
     if (host.empty()) {
         std::string m;
-        if (prosper_apr_match_by_size(*(uint64_t*)(req + 0x30), &m) == 1) host = m;
-    }
-    if (host.empty()) {
-        if (filelog()) fprintf(stderr, "[apr] read-submit: no file for id=%llu\n",
-                               (unsigned long long)id);
-        return 0x80020016ull;    // record stays incomplete -> the engine reports this read as failed
+        int matches = prosper_apr_match_by_size(fallback_size, &m);
+        if (matches == 1) {
+            host = std::move(m);
+            resolution_method = "size-fallback";
+        } else {
+            if (filelog())
+                fprintf(stderr,
+                        "[apr] read-submit method=refused id=%llu offset=0x%llx "
+                        "requested=%llu fallback-size=%llu matches=%d\n",
+                        (unsigned long long)id, (unsigned long long)offset,
+                        (unsigned long long)requested_size,
+                        (unsigned long long)fallback_size, matches);
+            return 0x80020016ull;  // record stays incomplete -> the engine reports this read as failed
+        }
     }
     // Read range: a5 = byte count, and the FILE OFFSET is the 7th argument (on the guest stack).
     // Verified live with exact footer math (2026-07-08): utoc header reads pass (offset=0,
@@ -2489,9 +2507,7 @@ extern "C" uint64_t f_apr_read_submit(uint64_t a0, uint64_t a1, uint64_t a2,
     // accepted). CONFIDENCE: HIGH (offset+size confirmed on 8 live reads across 3 file kinds).
     uint64_t fsize = 0;
     { struct stat st {}; if (::stat(host.c_str(), &st) == 0) fsize = (uint64_t)st.st_size; }
-    uint64_t offset = 0;
 #ifndef _WIN32
-    offset = apr_stack_arg(entry_rsp, 0);
     uint64_t arg8 = apr_stack_arg(entry_rsp, 1);
     // arg8 discriminates the engine's ASYNC streaming reads from its sync (record-polled) reads —
     // the ONLY ReadFile-level difference found across 90-read boots (identical guest-RA chains):
@@ -2517,11 +2533,8 @@ extern "C" uint64_t f_apr_read_submit(uint64_t a0, uint64_t a1, uint64_t a2,
                             (unsigned long long)*(uint64_t*)(uintptr_t)(arg8 + o));
         }
     }
-#else
-    offset = a6;
-    (void)a7;
 #endif
-    uint64_t size = a5;
+    uint64_t size = requested_size;
     if (offset > fsize) {
         if (filelog()) fprintf(stderr, "[apr] read-submit: offset 0x%llx past EOF (file %llu) — clamped\n",
                                (unsigned long long)offset, (unsigned long long)fsize);
@@ -2633,12 +2646,14 @@ extern "C" uint64_t f_apr_read_submit(uint64_t a0, uint64_t a1, uint64_t a2,
         munmap(slot, rounded);   // failure: record stays -> guest reports it; success-into-dst: staging no longer needed
     }
     if (ok) prosper_ampr_advance(a0, (offset >> 32) ? 24 : 20);
-    if (filelog()) fprintf(stderr, "[apr] read-submit id=%llu %s -> dst=0x%llx(%s) off=0x%llx size=%llu got=%lld %s\n",
+    if (filelog()) fprintf(stderr, "[apr] read-submit id=%llu %s -> dst=0x%llx(%s) "
+                   "off=0x%llx size=%llu got=%lld %s method=%s requested=%llu\n",
                    (unsigned long long)id, host.c_str(),
                    in_dst ? (unsigned long long)a4 : (unsigned long long)(uintptr_t)slot,
                    in_dst ? "guest" : "staging",
                    (unsigned long long)offset, (unsigned long long)size, (long long)got,
-                   ok ? "OK" : "SHORT");
+                   ok ? "OK" : "SHORT", resolution_method,
+                   (unsigned long long)requested_size);
     return ok ? 0 : 0x80020016ull;
 #else
     (void)dest;
@@ -2670,11 +2685,13 @@ extern "C" uint64_t f_apr_read_submit(uint64_t a0, uint64_t a1, uint64_t a2,
     if (in_dst) ::free(slot);
     prosper_ampr_advance(a0, (offset >> 32) ? 24 : 20);
     if (filelog()) fprintf(stderr,
-        "[apr] read-submit id=%llu %s -> dst=0x%llx(%s) off=0x%llx size=%llu got=%llu OK\n",
+        "[apr] read-submit id=%llu %s -> dst=0x%llx(%s) off=0x%llx size=%llu "
+        "got=%llu OK method=%s requested=%llu\n",
         (unsigned long long)id, host.c_str(),
         in_dst ? (unsigned long long)a4 : (unsigned long long)(uintptr_t)slot,
         in_dst ? "guest" : "staging", (unsigned long long)offset,
-        (unsigned long long)size, (unsigned long long)got);
+        (unsigned long long)size, (unsigned long long)got, resolution_method,
+        (unsigned long long)requested_size);
     return 0;
 #endif
 }

--- a/prosper/tests/test_apr_registry.cpp
+++ b/prosper/tests/test_apr_registry.cpp
@@ -1,16 +1,20 @@
-// test_apr_registry — guards the APR container registry and its size-keyed read matching
-// (issue #62). The APR read-submit handler identifies WHICH file to read by total byte size,
-// because the captured read-request object carries no legible file id. That key is only sound
-// when unambiguous, so this locks in: stable 1-based id assignment, path-dedup on re-resolve
-// (a duplicate entry would make every read of that file look ambiguous), and the match counts
-// the read path uses to refuse ambiguous / unplaceable (chunk) reads instead of guessing.
+// test_apr_registry — guards APR container registration and read-source resolution (#62/#1901).
+// The read path uses the real APR file id first and consults total byte size only as a legacy
+// fallback for an unresolved id. This locks in stable ids, path dedup, valid colliding-id reads,
+// unique-size fallback, ambiguous fallback refusal, and truthful resolution-method diagnostics.
 #include <cstdio>
 #include <cstdint>
 #include <array>
+#include <cstdlib>
 #include <cstring>
 #include <filesystem>
 #include <string>
 #include <vector>
+#ifdef _WIN32
+#include <io.h>
+#else
+#include <unistd.h>
+#endif
 #ifndef _WIN32
 #include <sys/mman.h>   // mmap/munmap — WriteAddress fault-safety check (#1149/#1154)
 #endif
@@ -31,8 +35,73 @@ static int fails = 0;
 #define CHECK(cond, msg) do { if (!(cond)) { printf("  [FAIL] %s\n", msg); fails++; } \
                               else        { printf("  [ok]   %s\n", msg); } } while (0)
 
+static bool set_test_env(const char* name, const char* value) {
+#ifdef _WIN32
+    return _putenv_s(name, value) == 0;
+#else
+    return setenv(name, value, 1) == 0;
+#endif
+}
+
+static int file_descriptor(FILE* file) {
+#ifdef _WIN32
+    return _fileno(file);
+#else
+    return fileno(file);
+#endif
+}
+
+static int duplicate_descriptor(int fd) {
+#ifdef _WIN32
+    return _dup(fd);
+#else
+    return dup(fd);
+#endif
+}
+
+static int replace_descriptor(int from, int to) {
+#ifdef _WIN32
+    return _dup2(from, to);
+#else
+    return dup2(from, to);
+#endif
+}
+
+static void close_descriptor(int fd) {
+#ifdef _WIN32
+    _close(fd);
+#else
+    close(fd);
+#endif
+}
+
+template <typename Fn>
+static std::string capture_stderr(Fn&& fn) {
+    FILE* capture = std::tmpfile();
+    if (!capture) return {};
+    std::fflush(stderr);
+    const int saved_stderr = duplicate_descriptor(file_descriptor(stderr));
+    if (saved_stderr < 0 || replace_descriptor(file_descriptor(capture), file_descriptor(stderr)) < 0) {
+        if (saved_stderr >= 0) close_descriptor(saved_stderr);
+        std::fclose(capture);
+        return {};
+    }
+    fn();
+    std::fflush(stderr);
+    replace_descriptor(saved_stderr, file_descriptor(stderr));
+    close_descriptor(saved_stderr);
+    std::rewind(capture);
+    std::string output;
+    char buffer[512];
+    while (size_t n = std::fread(buffer, 1, sizeof buffer, capture))
+        output.append(buffer, n);
+    std::fclose(capture);
+    return output;
+}
+
 int main() {
     printf("== test_apr_registry ==\n");
+    CHECK(set_test_env("PROSPER_FILELOG", "1"), "APR read diagnostics enabled for regression");
     prosper_apr_reset_for_test();
 
     // Stable 1-based ids in resolve order.
@@ -87,7 +156,9 @@ int main() {
     }
     register_file_hle();
     HleFn read_file = Hle::lookup("mQ16-QdKv7k");
-    CHECK(read_file != nullptr, "AMPR read-file HLE registered");
+    HleFn resolve_plain = Hle::lookup(nid_hash("sceKernelAprResolveFilepathsToIdsAndFileSizes"));
+    CHECK(read_file != nullptr && resolve_plain != nullptr,
+          "AMPR read-file and APR resolve HLEs registered");
     std::string stub_error;
     const std::vector<ImportSlot> slots = {{"libSceAmpr", "mQ16-QdKv7k"}};
     CHECK(install_stubs(slots, 0x720000000ull, 96, &stub_error),
@@ -103,11 +174,11 @@ int main() {
     std::array<uint64_t, 3> completion{};
     constexpr size_t read_offset = 41;
     constexpr size_t read_size = 73;
-    std::array<uint8_t, read_size> destination{};
+    std::array<uint8_t, 0x90> destination{};
     uint64_t result = read_file && stub_error.empty()
         ? read_file_guest((uint64_t)(uintptr_t)request.data(), 0,
                           (uint64_t)(uintptr_t)completion.data(), fixture_id,
-                          (uint64_t)(uintptr_t)destination.data(), destination.size(),
+                          (uint64_t)(uintptr_t)destination.data(), read_size,
                           read_offset, 0, 0)
         : ~uint64_t{0};
     CHECK(result == 0, "AMPR read-file completes successfully");
@@ -116,6 +187,118 @@ int main() {
     CHECK(completion[0] == (uint64_t)(uintptr_t)destination.data() &&
               completion[1] == 0 && completion[2] == read_size,
           "AMPR completion publishes destination, success, and byte count");
+
+    // #1901: equal total sizes do not make real ID-resolved reads ambiguous. Register a second,
+    // byte-distinct fixture through the public resolve HLE so this also proves its warning describes
+    // only the unresolved-id fallback rather than falsely declaring both files unreadable.
+    const char* collision_path = "prosper-test-apr-read-collision.tmp";
+    std::array<uint8_t, expected.size()> collision_bytes{};
+    for (size_t i = 0; i < collision_bytes.size(); ++i)
+        collision_bytes[i] = (uint8_t)(i * 17u + 11u);
+    if (FILE* collision = std::fopen(collision_path, "wb")) {
+        CHECK(std::fwrite(collision_bytes.data(), 1, collision_bytes.size(), collision) ==
+                  collision_bytes.size(),
+              "write equal-size APR collision fixture");
+        std::fclose(collision);
+    } else {
+        CHECK(false, "create equal-size APR collision fixture");
+    }
+    const char* collision_paths[2] = { fixture_path, collision_path };
+    uint32_t collision_ids[2]{};
+    uint64_t collision_sizes[2]{};
+    uint32_t collision_error = ~uint32_t{0};
+    uint64_t collision_resolve_result = ~uint64_t{0};
+    const std::string collision_warning = capture_stderr([&] {
+        collision_resolve_result = resolve_plain(
+            (uint64_t)(uintptr_t)collision_paths, 2,
+            (uint64_t)(uintptr_t)collision_ids,
+            (uint64_t)(uintptr_t)collision_sizes,
+            (uint64_t)(uintptr_t)&collision_error, 0);
+    });
+    CHECK(collision_resolve_result == 0 && collision_error == 0 &&
+              collision_ids[0] == fixture_id && collision_ids[1] != collision_ids[0] &&
+              collision_sizes[0] == expected.size() && collision_sizes[1] == expected.size(),
+          "equal-size containers resolve to distinct usable ids");
+    CHECK(collision_warning.find("ID-resolved reads remain valid") != std::string::npos &&
+              collision_warning.find("unresolved-id size fallback will be refused") != std::string::npos &&
+              collision_warning.find("reads of either will be refused") == std::string::npos,
+          "collision warning describes only the conditional size fallback");
+
+    constexpr size_t method_offset = 7;
+    constexpr size_t method_size = 31;
+    auto read_with_method = [&](uint32_t id, uint64_t total_size,
+                                std::array<uint8_t, 0x90>& out,
+                                std::array<uint64_t, 3>& out_completion,
+                                uint64_t& out_result) {
+        std::array<uint8_t, 0x48> method_request{};
+        std::memcpy(method_request.data() + 0x30, &total_size, sizeof total_size);
+        return capture_stderr([&] {
+            out_result = read_file_guest(
+                (uint64_t)(uintptr_t)method_request.data(), 0,
+                (uint64_t)(uintptr_t)out_completion.data(), id,
+                (uint64_t)(uintptr_t)out.data(), method_size,
+                method_offset, 0, 0);
+        });
+    };
+
+    std::array<uint8_t, 0x90> first_id_bytes{}, second_id_bytes{};
+    std::array<uint64_t, 3> first_id_completion{}, second_id_completion{};
+    uint64_t first_id_result = ~uint64_t{0}, second_id_result = ~uint64_t{0};
+    const std::string first_id_log = read_with_method(
+        collision_ids[0], expected.size(), first_id_bytes, first_id_completion, first_id_result);
+    const std::string second_id_log = read_with_method(
+        collision_ids[1], collision_bytes.size(), second_id_bytes,
+        second_id_completion, second_id_result);
+    CHECK(first_id_result == 0 && second_id_result == 0 &&
+              std::memcmp(first_id_bytes.data(), expected.data() + method_offset, method_size) == 0 &&
+              std::memcmp(second_id_bytes.data(), collision_bytes.data() + method_offset, method_size) == 0,
+          "valid ids read the correct byte-distinct files despite a size collision");
+    CHECK(first_id_log.find("method=id") != std::string::npos &&
+              second_id_log.find("method=id") != std::string::npos,
+          "colliding valid-id reads report method=id");
+
+    // An unknown id may use total-size correlation only when exactly one registered file matches.
+    const char* unique_path = "prosper-test-apr-read-fallback.tmp";
+    std::array<uint8_t, 263> unique_bytes{};
+    for (size_t i = 0; i < unique_bytes.size(); ++i)
+        unique_bytes[i] = (uint8_t)(i * 23u + 19u);
+    if (FILE* unique = std::fopen(unique_path, "wb")) {
+        CHECK(std::fwrite(unique_bytes.data(), 1, unique_bytes.size(), unique) == unique_bytes.size(),
+              "write unique-size APR fallback fixture");
+        std::fclose(unique);
+    } else {
+        CHECK(false, "create unique-size APR fallback fixture");
+    }
+    prosper_apr_register(unique_path, unique_bytes.size());
+    constexpr uint32_t unknown_id = 0xf00dcafeu;
+    std::array<uint8_t, 0x90> fallback_bytes{};
+    std::array<uint64_t, 3> fallback_completion{};
+    uint64_t fallback_result = ~uint64_t{0};
+    const std::string fallback_log = read_with_method(
+        unknown_id, unique_bytes.size(), fallback_bytes, fallback_completion, fallback_result);
+    CHECK(fallback_result == 0 &&
+              std::memcmp(fallback_bytes.data(), unique_bytes.data() + method_offset, method_size) == 0,
+          "unknown id uses an unambiguous total-size fallback");
+    CHECK(fallback_log.find("method=size-fallback") != std::string::npos &&
+              fallback_log.find("requested=31") != std::string::npos,
+          "unique-size fallback reports its method and requested size");
+
+    std::array<uint8_t, 0x90> refused_bytes{};
+    refused_bytes.fill(0xa5);
+    std::array<uint64_t, 3> refused_completion{
+        0x1111111111111111ull, 0x2222222222222222ull, 0x3333333333333333ull};
+    uint64_t refused_result = 0;
+    const std::string refused_log = read_with_method(
+        unknown_id, expected.size(), refused_bytes, refused_completion, refused_result);
+    CHECK((uint32_t)refused_result == 0x80020016u &&
+              refused_completion[0] == 0x1111111111111111ull &&
+              refused_completion[1] == 0x2222222222222222ull &&
+              refused_completion[2] == 0x3333333333333333ull && refused_bytes[0] == 0xa5,
+          "ambiguous size fallback refuses without completing or writing the read");
+    CHECK(refused_log.find("method=refused") != std::string::npos &&
+              refused_log.find("matches=2") != std::string::npos &&
+              refused_log.find("offset=0x7") != std::string::npos,
+          "ambiguous fallback reports refusal, match count, and requested offset");
 
 #ifndef _WIN32
     // APR writes are performed by the host kernel, so they do not enter the guest SIGSEGV handler
@@ -172,11 +355,11 @@ int main() {
     std::memcpy(req_overlap.data() + 0x30, &live_ptr, 8);
     uint64_t* record = reinterpret_cast<uint64_t*>(req_overlap.data() + 0x20);  // a2 == req+0x20
     uint32_t overlap_id = prosper_apr_register(fixture_path, expected.size());
-    std::array<uint8_t, read_size> overlap_dst{};
+    std::array<uint8_t, 0x90> overlap_dst{};
     uint64_t overlap_result = read_file && stub_error.empty()
         ? read_file_guest((uint64_t)(uintptr_t)req_overlap.data(), 0,
                           (uint64_t)(uintptr_t)record, overlap_id,
-                          (uint64_t)(uintptr_t)overlap_dst.data(), overlap_dst.size(),
+                          (uint64_t)(uintptr_t)overlap_dst.data(), read_size,
                           read_offset, 0, 0)
         : ~uint64_t{0};
     uint64_t survived = 0; std::memcpy(&survived, req_overlap.data() + 0x30, 8);
@@ -191,17 +374,19 @@ int main() {
     // passes as a0; a2 remains the authority for that output record.
     std::array<uint64_t, 9> embedded_request{};
     uint64_t* embedded_record = embedded_request.data();
-    std::array<uint8_t, read_size> embedded_dst{};
+    std::array<uint8_t, 0x90> embedded_dst{};
     uint64_t embedded_result = read_file && stub_error.empty()
         ? read_file_guest((uint64_t)(uintptr_t)embedded_request.data(), 0,
                           (uint64_t)(uintptr_t)embedded_record, overlap_id,
-                          (uint64_t)(uintptr_t)embedded_dst.data(), embedded_dst.size(),
+                          (uint64_t)(uintptr_t)embedded_dst.data(), read_size,
                           read_offset, 0, 0)
         : ~uint64_t{0};
     CHECK(embedded_result == 0 && embedded_record[2] == read_size,
           "ordinary embedded completion record still publishes byte count");
 
     std::remove(fixture_path);
+    std::remove(collision_path);
+    std::remove(unique_path);
     prosper_apr_reset_for_test();
 
     // sceKernelAprResolveFilepathsWithPrefixToIdsAndFileSizes (GTA V / PPSA04263, RAGE, issue #1130):
@@ -211,7 +396,6 @@ int main() {
     // observed live at the next GetFileStat) and wild-write over its allocator. translate() passes a
     // non-mount path through unchanged, so a relative fixture path exercises the real handler.
     auto resolve_prefix = Hle::lookup(nid_hash("sceKernelAprResolveFilepathsWithPrefixToIdsAndFileSizes"));
-    auto resolve_plain  = Hle::lookup(nid_hash("sceKernelAprResolveFilepathsToIdsAndFileSizes"));
     auto resolve_ids    = Hle::lookup("WT-5NKy42fw");
     auto wait_cb        = Hle::lookup("rqwFKI4PAiM");
     CHECK(nid_hash("sceKernelAprResolveFilepathsWithPrefixToIdsAndFileSizes") == "w5fcCG+t31g",


### PR DESCRIPTION
Fixes #1901.
Refs #1895.

## Failure scenario

APR registration warns whenever two distinct containers have the same total byte size. The message says reads of either file will be refused as ambiguous, even though the current read path resolves the real APR file ID first and consults total size only when that ID is unknown.

That stale pre-#78 wording caused a registration warning in Sonic Racing: CrossWorlds' intake log to be recorded as the title's IoStore blocker without any evidence that a read attempted or refused the fallback.

## Root cause

PR #78 changed `sceAmprAprCommandBufferReadFile` from total-size-only selection to ID-first selection with a conservative size fallback. Its registration warning, source comments, and registry-test description retained the former contract, and the successful read log did not expose which selection path actually ran.

## What changed

- Make same-size registration warnings state the conditional contract: ID-resolved reads remain valid; only unresolved-ID fallback is ambiguous.
- Add `method=id|size-fallback` to successful `PROSPER_FILELOG` result lines.
- Emit `method=refused` with APR ID, requested offset/size, fallback size, and match count when fallback cannot select safely.
- Preserve the existing successful-read log prefix and fields so `tools/re/pak_index.py` remains backward compatible.
- Expand `test_apr_registry` through the real HLE entry point:
  - two byte-distinct, equal-size files both read correctly by their valid IDs;
  - an unknown ID uses a unique-size fallback;
  - an unknown ID with two size matches is refused without touching the destination or completion record;
  - every route reports its actual method and the registration warning no longer claims both files are unreadable.
- Record the falsified same-size-collision hypothesis in the APR/IoStore bring-up document.

No APR read-selection, completion, or error-return behavior changes; this PR makes the current behavior observable and its documentation truthful.

## Verification

Exact head: `5608c0cbf7f50e74e07ead067aaa0e43d8228ce8`

```bash
distrobox enter ps5ys -- bash -lc '
  cd <WORKTREE>
  TMPDIR="$PWD/build/tmpdir" cmake --build prosper/build-linux -j6 --target test_apr_registry
  cd prosper/build-linux
  TMPDIR="$PWD/../../build/tmpdir" ctest -R "^apr_registry_resolution$" --output-on-failure
  cd ..
  python3 tools/re/pak_index.py --self-test
'
```

Results:

- `apr_registry_resolution`: 1/1 passed.
- `pak_index.py --self-test`: passed.
- The existing parser also consumed four actual new-format APR result lines.
- `git diff --check`: clean.
- Commit trailer gate: zero `Claude-Session:` lines.

Mutation proof: temporarily bypassing valid-ID lookup whenever the request carried a total size reproduced the old size-first defect. The named checks `valid ids read the correct byte-distinct files despite a size collision` and `colliding valid-id reads report method=id` went red; restoring ID-first lookup returned the focused test to green.

No game dump, snapshot, title, or GPU test was run; this is a CPU-only diagnostic/test change.