### PR TITLE
docs(Sonic): correct complete-install classification

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ shared-GPU policy, the instrument-not-the-subject list, and the dated current ha
 | *Asterix & Obelix: Babylon Mission* `PPSA30490` | rung 0 — sampled 2D-MSAA resolve executes; output remains black (#1599) | `docs/ASTERIX_BABYLON_STATUS.md` |
 | *The Oregon Trail* `PPSA19244` | rung 0 — the guest issues no base pass; prosper decodes 100% of what it submits | `docs/OREGON_TRAIL_STATUS.md` |
 | *ArcRunner* `PPSA21406` | rung 0 — renderer bring-up reaches real GPU submissions, then the render thread faults (#1226) | `docs/ARCRUNNER_STATUS.md` |
-| *GRIS*, *Space Adventure Cobra*, *Sonic Origins* | rung 3 / rung 3 / incomplete dump | `docs/GRIS_SONIC_COBRA_BRINGUP.md` |
+| *GRIS*, *Space Adventure Cobra*, *Sonic Origins* | rung 3 / rung 3 / rung 0 — complete Sonic Origins Plus install; two UI paths unresolved (#1905) | `docs/GRIS_SONIC_COBRA_BRINGUP.md` |
 | Astro Bot, The Plucky Squire, The Pathless | active orchestration lanes | `docs/GAME_COMPAT_ORCHESTRATION.md` |
 | Every other title | — | `COMPATIBILITY.md` |
 | UE4 / IoStore bring-up (shared) | — | `docs/UE4_APR_IOSTORE_BRINGUP.md`, `docs/CROSS_ENGINE_UE4.md` |

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -22,7 +22,7 @@ closing bugs. Every title in the tested inventory has a long-lived tracker in th
 | *Evergate* | `PPSA01885` | Unity | ✅ Reaches and renders the first tutorial-room gameplay |
 | *GRIS* | `PPSA09804` | Unity / IL2CPP | ✅ Native 1920×1080 opening gameplay reached; scripted input and audio verified; `gris-gameplay` guard |
 | *Space Adventure Cobra — The Awakening* | `PPSA17337` | Unity / IL2CPP | ✅ Native 1920×1080 tutorial combat and audio verified; `cobra-gameplay` guard |
-| *Sonic Origins*&nbsp;² | `PPSA05325` | Hedgehog Engine | 🔬 Frontend loop reached; supplied update-only dump lacks its base title assets |
+| *Sonic Origins* | `PPSA05325` | Hedgehog Engine | 🔬 Complete Sonic Origins Plus base+update with four DLC packs reaches a black startup loop; two requested UI paths do not resolve (#1905) |
 | Terminator (2D)&nbsp;¹ | `PPSA25872` | Unity / IL2CPP | ✅ Main menu and attract-mode gameplay reached (user-verified) |
 | *Blue Prince* | `PPSA25009` | Unity | 🚧 Day One gameplay renders; the manor entrance hall matches the hardware reference |
 | *Grand Theft Auto V* | `PPSA04263` | RAGE | 🚧 Title and STORY/ONLINE main menu render; known UI and composition defects remain |
@@ -57,10 +57,6 @@ closing bugs. Every title in the tested inventory has a long-lived tracker in th
 | *Beneath* | `PPSA27640` | Unity / IL2CPP | 🔬 Clean 1080p opening key art renders, then the guest faults and the image stops advancing before a title screen |
 
 ¹ Exact retail game name pending confirmation.
-
-² No compatibility milestone is claimed for the incomplete Sonic dump. A merged base+update image is
-required before its title, gameplay, or audio can be evaluated. The guest also consumes an authentic
-Sonic 1 activity launch, but still needs the same base UI assets before entering the classic runtime.
 
 The dated 2026-08-02 frame-rate sweep and its measurement caveats are retained in
 [#1739](https://github.com/mattias800/prosper/issues/1739), rather than duplicated in this overview.
@@ -191,18 +187,20 @@ advertised Cx records instead of exposing stale stack entries as register writes
 
 ## Sonic Origins — `PPSA05325`
 
-The supplied 02.002.000 directory is an update image targeting 02.001.000, rather than a merged
-base+update app. Live file tracing shows that its only unresolved startup requests are
-`raw/ui/ui_startup.pac` and `raw/ui/rpl_texture/ui_title_nocopy.dds`; both are absent from the dump.
-The game otherwise initializes its renderer, connected pad, CRI sound banks, and AudioOut2 pump, but
-correctly remains in a black startup loop and emits silence without those title assets. No screenshot,
-audio, or compatibility success is claimed until a complete dump is available.
+The complete Sonic Origins Plus 02.002.000 installation contains its base executable and content,
+all four classic RSDK games, installed update state, and four DLC mounts. Its
+`targetContentVersion: 02.001.000` records update lineage; it does not mean that the assembled app is
+an update-only image. Live file tracing nevertheless finds two unresolved loose startup paths:
+`raw/ui/ui_startup.pac` and `raw/ui/rpl_texture/ui_title_nocopy.dds`. Prosper then remains in a black
+startup loop with silent AudioOut2 buffers despite initializing its renderer, connected pad, and CRI
+sound banks. This is now tracked as an archive, update-overlay, mount, or path-resolution defect in
+[#1905](https://github.com/mattias800/prosper/issues/1905), not as an incomplete user dump. No title,
+audio, or compatibility milestone is claimed yet.
 
-The update declares PS5 `launchActivity` support and contains the classic RSDK files. An exact
-`TITLE_SONIC_1_CLASSIC` Game Intent is received by the guest and its `activityId` property is consumed,
-but Sonic still requests both missing UI files before opening `raw/retro/Sonic1u.rsdk`. This rules out
-the platform activity route as a way around the incomplete content while preserving truthful default
-no-intent behavior.
+The app declares PS5 `launchActivity` support. An exact `TITLE_SONIC_1_CLASSIC` Game Intent is received
+by the guest and its `activityId` property is consumed, but Sonic still requests both unresolved UI
+paths before opening `raw/retro/Sonic1u.rsdk`. The platform activity route therefore does not bypass
+the startup-resolution blocker; truthful default no-intent behavior remains preserved.
 
 Routes, capture commands, audio evidence, and the Sonic audit are recorded in
 [`prosper/docs/GRIS_SONIC_COBRA_BRINGUP.md`](prosper/docs/GRIS_SONIC_COBRA_BRINGUP.md).

--- a/prosper/docs/GRIS_SONIC_COBRA_BRINGUP.md
+++ b/prosper/docs/GRIS_SONIC_COBRA_BRINGUP.md
@@ -9,7 +9,7 @@ and GPU captures are local diagnostics and are intentionally not committed.
 | Title | Revision | Visual milestone | Audio evidence |
 | --- | --- | --- | --- |
 | GRIS (`PPSA09804`) | 01.001.000 | Native 1920×1080 opening gameplay with scripted movement | CLEAN on current master over the first 35 seconds: `rms=0.0082`, `peak=0.1173`, duplicated grains 0.0% |
-| Sonic Origins (`PPSA05325`) | 02.002.000 update targeting 02.001.000 | Blocked: update-only dump is missing two base title assets | AudioOut2 port 17 runs, but guest PCM is zero while startup is blocked |
+| Sonic Origins (`PPSA05325`) | Complete Sonic Origins Plus 02.002.000 base+update, four DLC mounts | Black startup loop after two unresolved UI paths (#1905) | AudioOut2 port 17 runs, but guest PCM is zero while startup is blocked |
 | Space Adventure Cobra — The Awakening (`PPSA17337`) | 01.004.000 | Native 1920×1080 tutorial combat with scripted progression | CLEAN, `rms=0.0436`, `peak=0.1880`, duplicated grains 0.0% |
 
 ## Visual evidence
@@ -132,23 +132,27 @@ One line per dead hypothesis, the evidence that killed it, and where that eviden
 
 | Hypothesis | Verdict and evidence | Source |
 |---|---|---|
-| Sonic Origins' black startup loop is a prosper defect | **Falsified — it is an incomplete dump.** The supplied 02.002.000 directory is an *update* image targeting 02.001.000, not a merged base+update app. Live file tracing shows the only unresolved startup requests are `raw/ui/ui_startup.pac` and `raw/ui/rpl_texture/ui_title_nocopy.dds`, both absent. Everything else initializes — renderer, connected pad, CRI sound banks, AudioOut2 pump, 300+ flips in 100 s with no guest fault. Correct behaviour without those assets is a black loop and silence. **No compatibility milestone is claimed until a complete dump exists.** | this doc, `COMPATIBILITY.md` |
+| `targetContentVersion: 02.001.000` proves the supplied directory is update-only or incomplete | **Falsified.** The assembled 02.002.000 directory identifies itself as Sonic Origins Plus, contains the base executable/content and all four classic RSDK games, and mounts four installed DLC packs. The target version is update lineage, not a directory-completeness flag. The two unresolved loose UI requests remain real, but they are a Prosper archive/update-overlay/path-resolution question (#1905), not grounds for rejecting the game dump. | #1905, tracker #1871, this doc |
 | A PS5 `launchActivity` Game Intent routes around the missing UI assets | **Falsified.** The update does declare `launchActivity` support and ship the classic RSDK files, and the guest genuinely receives and consumes an exact `TITLE_SONIC_1_CLASSIC` intent — its `activityId` property is read and recognized. It still requests both missing UI files before it will open `raw/retro/Sonic1u.rsdk`. The activity experiment narrows the blocker; it does not bypass it. Truthful default no-intent behaviour is preserved. | this doc |
 
 ## Sonic Origins dump audit
 
 Sonic reaches a stable frontend frame loop with all decoded GPU operations realized, a connected
 scripted controller, CRI Atom banks loaded, and AudioOut2 advancing. A 100-second `boot_trace` run
-observed more than 300 flips and exercised the full route without a guest fault. It cannot reach an
-authentic title screen with the supplied files.
+observed more than 300 flips and exercised the full route without a guest fault. Prosper does not yet
+reach an authentic title screen from this complete application.
 
-The dump identifies itself as:
+The application metadata records:
 
 ```text
 contentVersion:       02.002.000
 targetContentVersion: 02.001.000
 originContentVersion: 01.000.000
 ```
+
+`targetContentVersion` describes the installed update's lineage. It must not be read as proof that
+the merged application directory contains no base title. The inventory contains Sonic 1, Sonic 2,
+Sonic 3 & Knuckles, and Sonic CD payloads plus four installed DLC mounts.
 
 With `PROSPER_FILELOG=1`, the complete unresolved-path set is:
 
@@ -157,15 +161,15 @@ With `PROSPER_FILELOG=1`, the complete unresolved-path set is:
 3 /app0/raw/ui/rpl_texture/ui_title_nocopy.dds
 ```
 
-Neither file exists anywhere under `PPSA05325-app0`. After those failures the game publishes black
-scanouts and its correctly initialized AudioOut2 buffers remain zero. This is a content-integrity
-blocker, not evidence of title compatibility. Resume the visual and audio validation with a merged
-base+02.002.000 dump containing both files; do not alias another PAC/DDS or use a black frame as a
-success screenshot.
+Neither path exists as a loose file under `PPSA05325-app0`. After those failures the game publishes
+black scanouts and its correctly initialized AudioOut2 buffers remain zero. Because the full game,
+update, and DLC are present, the next step is to identify whether Prosper is missing an archive lookup,
+update overlay, mount fallback, or path transformation. Do not alias another PAC/DDS or use a black
+frame as a success screenshot.
 
 ### Game Intent activity audit
 
-The update does contain the four classic RSDK data files, so an authentic PS5 activity launch was
+The complete app contains the four classic RSDK data files, so an authentic PS5 activity launch was
 also tested rather than assuming the normal menu was the only route. `sce_sys/param.json` permits the
 standard `launchActivity` intent. Guest disassembly independently shows that Sonic reads its
 `activityId` property and recognizes `TITLE_SONIC_1_CLASSIC` as its Sonic 1 Classic boot selection.
@@ -184,7 +188,7 @@ sceNpGameIntentGetPropertyValueString(..., "activityId", ..., 0x21)
 That route still requests `ui_startup.pac` and `ui_title_nocopy.dds` before it can transfer control to
 the classic runtime. A 30-second filtered trace never opens `raw/retro/Sonic1u.rsdk`; a 44-second
 native capture remains black after frame 1, and the active stereo float32 48 kHz port 17 capture is
-silent (`rms=0`). The activity experiment therefore narrows the blocker but does not change the
+silent (`rms=0`). The activity experiment therefore narrows the unresolved-path blocker but does not change the
 compatibility result. Reproduce it with:
 
 ```bash


### PR DESCRIPTION
## Summary

- correct the false conclusion that the Sonic Origins Plus 02.002 directory is update-only or incomplete
- record the verified inventory: base executable/content, all four classic RSDK payloads, installed update state, and four DLC mounts
- reclassify the two unresolved UI paths as a Prosper archive/update-overlay/mount/path-resolution defect tracked in #1905
- preserve the current compatibility result: black startup loop, with no title/audio/visual milestone claimed

## Evidence

The local inventory contains the base executable, `Sonic1u.rsdk`, `Sonic2u.rsdk`, `Sonic3ku.rsdk`, `SonicCDu.rsdk`, and four mounted DLC directories. `contentVersion: 02.002.000` with `targetContentVersion: 02.001.000` describes update lineage; it is not proof that the assembled application lacks its base content.

The two live unresolved requests remain:

- `raw/ui/ui_startup.pac`
- `raw/ui/rpl_texture/ui_title_nocopy.dds`

Neither exists as a loose file, so #1905 now owns determining whether Prosper is missing an archive lookup, update overlay, mount fallback, or path transformation. This PR does not add an asset alias or title-specific workaround.

## Validation

- `git diff --check`
- audited both changed documents for stale `update-only`, `incomplete dump`, and `content-integrity` claims
- confirmed no private absolute paths are published

Tracker correction: #1871
Issue: #1905
