### PR TITLE
docs: keep Sonic black-frame cause open

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ shared-GPU policy, the instrument-not-the-subject list, and the dated current ha
 | *Asterix & Obelix: Babylon Mission* `PPSA30490` | rung 0 — sampled 2D-MSAA resolve executes; output remains black (#1599) | `docs/ASTERIX_BABYLON_STATUS.md` |
 | *The Oregon Trail* `PPSA19244` | rung 0 — the guest issues no base pass; prosper decodes 100% of what it submits | `docs/OREGON_TRAIL_STATUS.md` |
 | *ArcRunner* `PPSA21406` | rung 0 — renderer bring-up reaches real GPU submissions, then the render thread faults (#1226) | `docs/ARCRUNNER_STATUS.md` |
-| *GRIS*, *Space Adventure Cobra*, *Sonic Origins* | rung 3 / rung 3 / rung 0 — complete Sonic Origins Plus install; two UI paths unresolved (#1905) | `docs/GRIS_SONIC_COBRA_BRINGUP.md` |
+| *GRIS*, *Space Adventure Cobra*, *Sonic Origins* | rung 3 / rung 3 / rung 0 — complete Sonic Origins Plus install; black-frame cause open (#1905) | `docs/GRIS_SONIC_COBRA_BRINGUP.md` |
 | Astro Bot, The Plucky Squire, The Pathless | active orchestration lanes | `docs/GAME_COMPAT_ORCHESTRATION.md` |
 | Every other title | — | `COMPATIBILITY.md` |
 | UE4 / IoStore bring-up (shared) | — | `docs/UE4_APR_IOSTORE_BRINGUP.md`, `docs/CROSS_ENGINE_UE4.md` |

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -22,7 +22,7 @@ closing bugs. Every title in the tested inventory has a long-lived tracker in th
 | *Evergate* | `PPSA01885` | Unity | ✅ Reaches and renders the first tutorial-room gameplay |
 | *GRIS* | `PPSA09804` | Unity / IL2CPP | ✅ Native 1920×1080 opening gameplay reached; scripted input and audio verified; `gris-gameplay` guard |
 | *Space Adventure Cobra — The Awakening* | `PPSA17337` | Unity / IL2CPP | ✅ Native 1920×1080 tutorial combat and audio verified; `cobra-gameplay` guard |
-| *Sonic Origins* | `PPSA05325` | Hedgehog Engine | 🔬 Complete Sonic Origins Plus base+update with four DLC packs reaches a black startup loop; two requested UI paths do not resolve (#1905) |
+| *Sonic Origins* | `PPSA05325` | Hedgehog Engine | 🔬 Complete Sonic Origins Plus base+update with four DLC packs reaches a black startup loop; its root cause remains open (#1905) |
 | Terminator (2D)&nbsp;¹ | `PPSA25872` | Unity / IL2CPP | ✅ Main menu and attract-mode gameplay reached (user-verified) |
 | *Blue Prince* | `PPSA25009` | Unity | 🚧 Day One gameplay renders; the manor entrance hall matches the hardware reference |
 | *Grand Theft Auto V* | `PPSA04263` | RAGE | 🚧 Title and STORY/ONLINE main menu render; known UI and composition defects remain |
@@ -188,19 +188,23 @@ advertised Cx records instead of exposing stale stack entries as register writes
 ## Sonic Origins — `PPSA05325`
 
 The complete Sonic Origins Plus 02.002.000 installation contains its base executable and content,
-all four classic RSDK games, installed update state, and four DLC mounts. Its
+all four classic RSDK games, installed update state, and four DLC payloads with mount records. Its
 `targetContentVersion: 02.001.000` records update lineage; it does not mean that the assembled app is
-an update-only image. Live file tracing nevertheless finds two unresolved loose startup paths:
-`raw/ui/ui_startup.pac` and `raw/ui/rpl_texture/ui_title_nocopy.dds`. Prosper then remains in a black
+an update-only image. Live file tracing finds two early loose-file misses,
+`raw/ui/ui_startup.pac` and `raw/ui/rpl_texture/ui_title_nocopy.dds`, but the guest handles both
+failures and continues loading its real UI, fonts, language packs, and audio banks. They therefore
+do not establish the cause of the later black frame; an absent optional resource could still affect
+a particular visual, but the stronger startup-blocker claim is falsified. Prosper remains in a black
 startup loop with silent AudioOut2 buffers despite initializing its renderer, connected pad, and CRI
-sound banks. This is now tracked as an archive, update-overlay, mount, or path-resolution defect in
-[#1905](https://github.com/mattias800/prosper/issues/1905), not as an incomplete user dump. No title,
-audio, or compatibility milestone is claimed yet.
+sound banks, so [#1905](https://github.com/mattias800/prosper/issues/1905) keeps the root cause open.
+Installed-DLC enumeration is a separate Prosper gap (#1909) and occurs after these absolute base-app
+requests. No title, audio, or compatibility milestone is claimed yet.
 
 The app declares PS5 `launchActivity` support. An exact `TITLE_SONIC_1_CLASSIC` Game Intent is received
 by the guest and its `activityId` property is consumed, but Sonic still requests both unresolved UI
-paths before opening `raw/retro/Sonic1u.rsdk`. The platform activity route therefore does not bypass
-the startup-resolution blocker; truthful default no-intent behavior remains preserved.
+paths and does not open `raw/retro/Sonic1u.rsdk`. The platform activity route therefore does not
+bypass the current black startup state, but it does not make the handled file misses causal;
+truthful default no-intent behavior remains preserved.
 
 Routes, capture commands, audio evidence, and the Sonic audit are recorded in
 [`prosper/docs/GRIS_SONIC_COBRA_BRINGUP.md`](prosper/docs/GRIS_SONIC_COBRA_BRINGUP.md).

--- a/prosper/docs/GRIS_SONIC_COBRA_BRINGUP.md
+++ b/prosper/docs/GRIS_SONIC_COBRA_BRINGUP.md
@@ -9,7 +9,7 @@ and GPU captures are local diagnostics and are intentionally not committed.
 | Title | Revision | Visual milestone | Audio evidence |
 | --- | --- | --- | --- |
 | GRIS (`PPSA09804`) | 01.001.000 | Native 1920×1080 opening gameplay with scripted movement | CLEAN on current master over the first 35 seconds: `rms=0.0082`, `peak=0.1173`, duplicated grains 0.0% |
-| Sonic Origins (`PPSA05325`) | Complete Sonic Origins Plus 02.002.000 base+update, four DLC mounts | Black startup loop after two unresolved UI paths (#1905) | AudioOut2 port 17 runs, but guest PCM is zero while startup is blocked |
+| Sonic Origins (`PPSA05325`) | Complete Sonic Origins Plus 02.002.000 base+update, four DLC payloads with mount records | Black startup loop; root cause remains open (#1905) | AudioOut2 port 17 runs, but guest PCM remains zero in the black state |
 | Space Adventure Cobra — The Awakening (`PPSA17337`) | 01.004.000 | Native 1920×1080 tutorial combat with scripted progression | CLEAN, `rms=0.0436`, `peak=0.1880`, duplicated grains 0.0% |
 
 ## Visual evidence
@@ -132,8 +132,9 @@ One line per dead hypothesis, the evidence that killed it, and where that eviden
 
 | Hypothesis | Verdict and evidence | Source |
 |---|---|---|
-| `targetContentVersion: 02.001.000` proves the supplied directory is update-only or incomplete | **Falsified.** The assembled 02.002.000 directory identifies itself as Sonic Origins Plus, contains the base executable/content and all four classic RSDK games, and mounts four installed DLC packs. The target version is update lineage, not a directory-completeness flag. The two unresolved loose UI requests remain real, but they are a Prosper archive/update-overlay/path-resolution question (#1905), not grounds for rejecting the game dump. | #1905, tracker #1871, this doc |
-| A PS5 `launchActivity` Game Intent routes around the missing UI assets | **Falsified.** The update does declare `launchActivity` support and ship the classic RSDK files, and the guest genuinely receives and consumes an exact `TITLE_SONIC_1_CLASSIC` intent — its `activityId` property is read and recognized. It still requests both missing UI files before it will open `raw/retro/Sonic1u.rsdk`. The activity experiment narrows the blocker; it does not bypass it. Truthful default no-intent behaviour is preserved. | this doc |
+| `targetContentVersion: 02.001.000` proves the supplied directory is update-only or incomplete | **Falsified.** The assembled 02.002.000 directory identifies itself as Sonic Origins Plus, contains the base executable/content and all four classic RSDK games, and includes four installed DLC payloads with mount records. The target version is update lineage, not a directory-completeness flag. The two loose UI misses remain real, but they are not grounds for rejecting the game dump. | #1905, tracker #1871, this doc |
+| The two early `/app0/raw/ui/...` ENOENT results are a terminal archive, update-overlay, mount, or path-resolution blocker | **Falsified as the asserted startup blocker.** On current master, both failures are handled before entitlement enumeration; the guest then makes 142 successful APR resolve calls across 38 other unique UI, font, language, and audio paths without a fault. A later DLC mount cannot explain the earlier absolute base-app misses. The absent resources may still affect an individual visual if used conditionally, but the black-frame root cause remains open. | #1905, tracker #1871 |
+| A PS5 `launchActivity` Game Intent routes around the current black startup state | **Falsified.** The update declares `launchActivity` support and ships the classic RSDK files, and the guest genuinely receives and consumes an exact `TITLE_SONIC_1_CLASSIC` intent — its `activityId` property is read and recognized. It still remains black and does not open `raw/retro/Sonic1u.rsdk`. This proves the activity route is insufficient, not that the handled UI misses cause the black frame. Truthful default no-intent behaviour is preserved. | this doc, #1905 |
 
 ## Sonic Origins dump audit
 
@@ -152,20 +153,28 @@ originContentVersion: 01.000.000
 
 `targetContentVersion` describes the installed update's lineage. It must not be read as proof that
 the merged application directory contains no base title. The inventory contains Sonic 1, Sonic 2,
-Sonic 3 & Knuckles, and Sonic CD payloads plus four installed DLC mounts.
+Sonic 3 & Knuckles, and Sonic CD payloads plus four installed DLC payloads with mount records.
 
-With `PROSPER_FILELOG=1`, the complete unresolved-path set is:
+With `PROSPER_FILELOG=1`, the complete unresolved-path set in a bounded current-master CPU run is:
 
 ```text
-3 /app0/raw/ui/ui_startup.pac
-3 /app0/raw/ui/rpl_texture/ui_title_nocopy.dds
+/app0/raw/ui/ui_startup.pac
+/app0/raw/ui/rpl_texture/ui_title_nocopy.dds
 ```
 
-Neither path exists as a loose file under `PPSA05325-app0`. After those failures the game publishes
-black scanouts and its correctly initialized AudioOut2 buffers remain zero. Because the full game,
-update, and DLC are present, the next step is to identify whether Prosper is missing an archive lookup,
-update overlay, mount fallback, or path transformation. Do not alias another PAC/DDS or use a black
-frame as a success screenshot.
+Neither path exists as a loose file under `PPSA05325-app0`, but ENOENT is handled. Immediately after
+the second failure the guest successfully resolves `ui_resident.pac`, `ui_text_texture.pac`,
+`scalablefont.pac`, its CRI banks, every common-language PAC, and the bitmap font. The 35-second run
+records 148 successful resolve calls across 40 unique paths; 142 calls across 38 unique paths occur
+after the second miss, with no guest fault. Entitlement enumeration happens later, so the later
+entitlement/DLC-mount path cannot explain these earlier absolute `/app0/raw/...` requests; the trace
+does not establish that an archive or update overlay should have supplied them. Installed-DLC
+enumeration is independently incomplete in Prosper (#1909), but it is not this temporal cause.
+
+The game still publishes black scanouts and its correctly initialized AudioOut2 buffers remain zero.
+That root cause is open: the absent resources may still affect a visual if the guest uses them
+conditionally, but the trace does not support treating their handled absence as the startup blocker.
+Do not alias another PAC/DDS or use a black frame as a success screenshot.
 
 ### Game Intent activity audit
 
@@ -185,11 +194,13 @@ sceNpGameIntentReceiveIntent
 sceNpGameIntentGetPropertyValueString(..., "activityId", ..., 0x21)
 ```
 
-That route still requests `ui_startup.pac` and `ui_title_nocopy.dds` before it can transfer control to
-the classic runtime. A 30-second filtered trace never opens `raw/retro/Sonic1u.rsdk`; a 44-second
+That route still requests `ui_startup.pac` and `ui_title_nocopy.dds`, but those failures are handled
+and do not by themselves explain why control does not reach the classic runtime. A 30-second filtered
+trace never opens `raw/retro/Sonic1u.rsdk`; a 44-second
 native capture remains black after frame 1, and the active stereo float32 48 kHz port 17 capture is
-silent (`rms=0`). The activity experiment therefore narrows the unresolved-path blocker but does not change the
-compatibility result. Reproduce it with:
+silent (`rms=0`). The activity experiment therefore proves that the requested activity is not
+sufficient to escape the black state; it does not change the compatibility result or identify the
+black-frame cause. Reproduce it with:
 
 ```bash
 PROSPER_GAME_INTENT_ACTIVITY_ID=TITLE_SONIC_1_CLASSIC \


### PR DESCRIPTION
Refs #1905
Refs #1871

## What changed

- Records that the complete Sonic Origins Plus 02.002 installation handles both early loose-file `ENOENT` results and continues loading real UI, font, language, and audio content.
- Reopens the black-frame cause instead of presenting archive/update-overlay/path resolution as established.
- Preserves the important distinction between a possible visual effect from an absent resource and the falsified claim that these two misses terminate startup.
- Corrects DLC wording to describe the installed payloads and mount records; #1909 tracks the separate later entitlement/Addcont HLE gap.

## Evidence

CPU-only current-master run; no Vulkan renderer or GPU access was used:

```bash
distrobox enter ps5ys -- bash -lc '
  timeout 35s env \
    PROSPER_GUEST_FS=1 \
    PROSPER_GUEST_ARGS=-force-gfx-direct \
    PROSPER_FILELOG=1 \
    PROSPER_SVCLOG=1 \
    PROSPER_PROGRESS_UNIMPL=1 \
    PROSPER_NO_FRAME_DUMPS=1 \
    build/boot_trace <DUMP_ROOT>/PPSA05325-app0
'
```

The only APR misses were `/app0/raw/ui/ui_startup.pac` and `/app0/raw/ui/rpl_texture/ui_title_nocopy.dds`. After the second miss the guest completed 142 successful resolve calls across 38 unique paths, including resident/text UI PACs, scalable and bitmap fonts, language PACs, and CRI banks, with no guest fault. The later entitlement call cannot be the temporal cause of those earlier absolute base-app misses.

Private trace SHA-256: `d05b5a57fdb4593863c2bcd541cd03b1f67d17efa447129cd14158f850cba9a5`.

No title/gameplay milestone or screenshot is claimed; the observed output remains black.

## Validation

- `python3 prosper/tools/docs/check_numbered_table.py --github --sequential --table-header Instrument prosper/docs/GAME_COMPAT_ORCHESTRATION.md`
- `git ls-files '*.md' -z | xargs -0 python3 prosper/tools/docs/check_numbered_table.py --github`
- `ctest --test-dir build -R '^doc_table_checker$' --output-on-failure`

All passed.
