### PR TITLE
HLE: expose validated installed add-content

### DIFF
--- a/prosper/src/hle/hle_addcontent.cpp
+++ b/prosper/src/hle/hle_addcontent.cpp
@@ -3,8 +3,10 @@
 
 #include <algorithm>
 #include <cstdio>
+#include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <iterator>
 #include <limits>
 #include <mutex>
 #include <optional>
@@ -20,6 +22,17 @@ constexpr size_t kMaxEntries = 1024;             // dlc_emu producer limit
 
 std::mutex g_inventory_mutex;
 AddcontentInventorySnapshot g_inventory;
+
+enum class BoundedFileState {
+    Missing,
+    Ready,
+    Invalid,
+};
+
+struct BoundedFile {
+    BoundedFileState state = BoundedFileState::Invalid;
+    std::string data;
+};
 
 struct PendingRecord {
     std::string section;
@@ -47,21 +60,60 @@ bool valid_entitlement_label(std::string_view value) {
     });
 }
 
-std::optional<std::string> read_bounded_file(const std::filesystem::path& path, size_t limit,
-                                             bool& exists) {
-    exists = false;
+bool is_missing_error(const std::error_code& ec) {
+    return ec == std::make_error_code(std::errc::no_such_file_or_directory);
+}
+
+bool path_is_strict_descendant(const std::filesystem::path& root,
+                               const std::filesystem::path& child) {
+    auto root_it = root.begin();
+    auto child_it = child.begin();
+    for (; root_it != root.end(); ++root_it, ++child_it) {
+        if (child_it == child.end() || *root_it != *child_it) return false;
+    }
+    return child_it != child.end();
+}
+
+// The identity-bearing files must be real regular files below /app0. Walk every relative component
+// without following symlinks, then canonicalize as a second containment check. Only a genuine ENOENT
+// is Missing; dangling symlinks, wrong types, lookup errors, escapes, and read errors are Invalid.
+BoundedFile read_bounded_file(const std::filesystem::path& root,
+                              const std::filesystem::path& relative, size_t limit) {
+    BoundedFile result;
+    std::filesystem::path current = root;
     std::error_code ec;
-    if (!std::filesystem::exists(path, ec) || ec) return std::nullopt;
-    exists = true;
-    if (!std::filesystem::is_regular_file(path, ec) || ec) return std::nullopt;
-    const uintmax_t size = std::filesystem::file_size(path, ec);
-    if (ec || size > limit || size > std::numeric_limits<size_t>::max()) return std::nullopt;
-    std::ifstream input(path, std::ios::binary);
-    if (!input) return std::nullopt;
-    std::string data(static_cast<size_t>(size), '\0');
-    if (!data.empty() && !input.read(data.data(), static_cast<std::streamsize>(data.size())))
-        return std::nullopt;
-    return data;
+    for (auto it = relative.begin(); it != relative.end(); ++it) {
+        current /= *it;
+        ec.clear();
+        const std::filesystem::file_status status = std::filesystem::symlink_status(current, ec);
+        if (status.type() == std::filesystem::file_type::not_found || is_missing_error(ec)) {
+            result.state = BoundedFileState::Missing;
+            return result;
+        }
+        if (ec || std::filesystem::is_symlink(status)) return result;
+        const bool last = std::next(it) == relative.end();
+        if ((last && !std::filesystem::is_regular_file(status)) ||
+            (!last && !std::filesystem::is_directory(status))) return result;
+    }
+
+    ec.clear();
+    const std::filesystem::path canonical_root = std::filesystem::canonical(root, ec);
+    if (ec) return result;
+    const std::filesystem::path canonical_file = std::filesystem::canonical(current, ec);
+    if (ec || !path_is_strict_descendant(canonical_root, canonical_file)) return result;
+
+    const uintmax_t size = std::filesystem::file_size(current, ec);
+    if (ec || size > limit || size > std::numeric_limits<size_t>::max()) return result;
+    std::ifstream input(current, std::ios::binary);
+    if (!input) return result;
+    result.data.assign(static_cast<size_t>(size), '\0');
+    if (!result.data.empty() &&
+        !input.read(result.data.data(), static_cast<std::streamsize>(result.data.size()))) {
+        result.data.clear();
+        return result;
+    }
+    result.state = BoundedFileState::Ready;
+    return result;
 }
 
 // Small bounded JSON reader for one authorization-bearing metadata field. It validates the document
@@ -256,6 +308,13 @@ bool parse_hex_key(std::string_view text, std::array<uint8_t, 16>& out) {
     return true;
 }
 
+void make_default_key(size_t accepted_index, std::array<uint8_t, 16>& out) {
+    const uint64_t value = 1024u + static_cast<uint64_t>(accepted_index);
+    out.fill(0);
+    for (size_t i = 0; i < sizeof(value); ++i)
+        out[i] = static_cast<uint8_t>(value >> (i * 8u));
+}
+
 bool parse_np_service_label(std::string_view text, int64_t& out) {
     if (text.empty()) return true; // dlc_emu's documented default: wildcard
     if (text == "-1") {
@@ -429,13 +488,13 @@ ParseResult parse_inventory(const std::filesystem::path& root, std::string_view 
             }
             output.guest_mount_point = input.mount_point;
         }
+        output.mountable = output.package_type == 2u && !output.guest_mount_point.empty();
         if (!input.entitlement_key.empty()) {
             if (!parse_hex_key(input.entitlement_key, output.entitlement_key)) {
                 result.error = record + " has a malformed entitlement key";
                 return result;
             }
-            output.has_entitlement_key = true;
-        }
+        } else make_default_key(result.inventory.entries.size(), output.entitlement_key);
         result.inventory.entries.push_back(std::move(output));
     }
     result.inventory.state = AddcontentInventoryState::Ready;
@@ -452,26 +511,23 @@ void addcontent_configure_for_app0(const std::string& app0_root) {
         return;
     }
     const std::filesystem::path root(app0_root);
-    bool manifest_exists = false;
-    const std::optional<std::string> manifest =
-        read_bounded_file(root / "dlc_emu.ini", kMaxManifestBytes, manifest_exists);
-    if (!manifest_exists) {
+    const BoundedFile manifest = read_bounded_file(root, "dlc_emu.ini", kMaxManifestBytes);
+    if (manifest.state == BoundedFileState::Missing) {
         next.state = AddcontentInventoryState::None;
-    } else if (!manifest) {
+    } else if (manifest.state != BoundedFileState::Ready) {
         next.state = AddcontentInventoryState::Invalid;
         std::fprintf(stderr, "[addcontent] invalid install manifest: unreadable or oversized\n");
     } else {
-        bool param_exists = false;
-        const std::optional<std::string> param =
-            read_bounded_file(root / "sce_sys" / "param.json", kMaxParamBytes, param_exists);
-        const std::optional<std::string> title_id =
-            param ? ParamJsonReader(*param).top_level_title_id() : std::nullopt;
-        if (!param_exists || !param || !title_id || !valid_title_id(*title_id)) {
+        const BoundedFile param = read_bounded_file(root, std::filesystem::path("sce_sys") /
+                                                   "param.json", kMaxParamBytes);
+        const std::optional<std::string> title_id = param.state == BoundedFileState::Ready
+            ? ParamJsonReader(param.data).top_level_title_id() : std::nullopt;
+        if (!title_id || !valid_title_id(*title_id)) {
             next.state = AddcontentInventoryState::Invalid;
             std::fprintf(stderr,
                          "[addcontent] invalid install manifest: app metadata has no valid titleId\n");
         } else {
-            ParseResult parsed = parse_inventory(root, *manifest, *title_id);
+            ParseResult parsed = parse_inventory(root, manifest.data, *title_id);
             next = std::move(parsed.inventory);
             if (next.state == AddcontentInventoryState::Invalid)
                 std::fprintf(stderr, "[addcontent] invalid install manifest: %s\n",
@@ -485,6 +541,39 @@ void addcontent_configure_for_app0(const std::string& app0_root) {
 AddcontentInventorySnapshot addcontent_inventory_snapshot() {
     std::lock_guard<std::mutex> lock(g_inventory_mutex);
     return g_inventory;
+}
+
+AddcontentMountResult addcontent_mount(uint32_t service_label, std::string_view entitlement_label,
+                                       uint64_t output_address, AddcontentMountWriter writer) {
+    std::lock_guard<std::mutex> lock(g_inventory_mutex);
+    if (g_inventory.state != AddcontentInventoryState::Ready)
+        return AddcontentMountResult::NotFound;
+    size_t index = g_inventory.entries.size();
+    for (size_t i = 0; i < g_inventory.entries.size(); ++i) {
+        const InstalledAddcontent& entry = g_inventory.entries[i];
+        if ((entry.service_label == -1 ||
+             static_cast<uint32_t>(entry.service_label) == service_label) &&
+            entry.entitlement_label == entitlement_label) {
+            index = i;
+            break;
+        }
+    }
+    if (index == g_inventory.entries.size()) return AddcontentMountResult::NotFound;
+    InstalledAddcontent& entry = g_inventory.entries[index];
+    if (!entry.mountable || entry.guest_mount_point.empty() || entry.download_status != 4)
+        return AddcontentMountResult::NotFound;
+    if (entry.mounted) return AddcontentMountResult::Busy;
+    for (const InstalledAddcontent& other : g_inventory.entries) {
+        if (other.mounted && other.guest_mount_point == entry.guest_mount_point)
+            return AddcontentMountResult::Busy;
+    }
+    std::array<char, 16> mount_point{};
+    std::memcpy(mount_point.data(), entry.guest_mount_point.data(),
+                entry.guest_mount_point.size());
+    if (!writer || !writer(output_address, mount_point.data(), mount_point.size()))
+        return AddcontentMountResult::OutputError;
+    entry.mounted = true;
+    return AddcontentMountResult::Mounted;
 }
 
 } // namespace prosper

--- a/prosper/src/hle/hle_addcontent.cpp
+++ b/prosper/src/hle/hle_addcontent.cpp
@@ -1,0 +1,490 @@
+// hle_addcontent.cpp — parse and validate the dump tool's local add-content inventory.
+#include "hle_addcontent.hpp"
+
+#include <algorithm>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <limits>
+#include <mutex>
+#include <optional>
+#include <set>
+#include <string_view>
+
+namespace prosper {
+namespace {
+
+constexpr size_t kMaxManifestBytes = 32 * 1024; // dlc_emu producer limit
+constexpr size_t kMaxParamBytes = 2 * 1024 * 1024;
+constexpr size_t kMaxEntries = 1024;             // dlc_emu producer limit
+
+std::mutex g_inventory_mutex;
+AddcontentInventorySnapshot g_inventory;
+
+struct PendingRecord {
+    std::string section;
+    std::string content_id;
+    std::string download_status;
+    std::string mount_point;
+    std::string entitlement_key;
+    std::string np_service_label;
+    std::set<std::string> seen_keys;
+};
+
+bool ascii_digit(char ch) { return ch >= '0' && ch <= '9'; }
+bool ascii_upper(char ch) { return ch >= 'A' && ch <= 'Z'; }
+bool ascii_alpha(char ch) { return ascii_upper(ch) || (ch >= 'a' && ch <= 'z'); }
+
+bool valid_title_id(std::string_view value) {
+    return value.size() == 9 && value.substr(0, 4) == "PPSA" &&
+           std::all_of(value.begin() + 4, value.end(), ascii_digit);
+}
+
+bool valid_entitlement_label(std::string_view value) {
+    if (value.empty() || value.size() > 16) return false;
+    return std::all_of(value.begin(), value.end(), [](char ch) {
+        return ascii_alpha(ch) || ascii_digit(ch);
+    });
+}
+
+std::optional<std::string> read_bounded_file(const std::filesystem::path& path, size_t limit,
+                                             bool& exists) {
+    exists = false;
+    std::error_code ec;
+    if (!std::filesystem::exists(path, ec) || ec) return std::nullopt;
+    exists = true;
+    if (!std::filesystem::is_regular_file(path, ec) || ec) return std::nullopt;
+    const uintmax_t size = std::filesystem::file_size(path, ec);
+    if (ec || size > limit || size > std::numeric_limits<size_t>::max()) return std::nullopt;
+    std::ifstream input(path, std::ios::binary);
+    if (!input) return std::nullopt;
+    std::string data(static_cast<size_t>(size), '\0');
+    if (!data.empty() && !input.read(data.data(), static_cast<std::streamsize>(data.size())))
+        return std::nullopt;
+    return data;
+}
+
+// Small bounded JSON reader for one authorization-bearing metadata field. It validates the document
+// and accepts exactly one top-level string named titleId; a textual occurrence in a nested
+// object or string must never authorize a foreign dlc_emu.ini record. Escapes in the title value are
+// rejected so its identity has one byte representation. Nesting is capped to avoid hostile recursion.
+class ParamJsonReader {
+public:
+    explicit ParamJsonReader(std::string_view input) : input_(input) {}
+
+    std::optional<std::string> top_level_title_id() {
+        skip_space();
+        if (!take('{')) return std::nullopt;
+        skip_space();
+        if (take('}')) return finish() ? title_id_ : std::nullopt;
+        for (;;) {
+            std::string key;
+            if (!parse_string(&key)) return std::nullopt;
+            skip_space();
+            if (!take(':')) return std::nullopt;
+            skip_space();
+            if (key == "titleId") {
+                if (saw_title_id_) return std::nullopt;
+                saw_title_id_ = true;
+                bool value_escaped = false;
+                std::string value;
+                if (!parse_string(&value, &value_escaped) || value_escaped) return std::nullopt;
+                title_id_ = std::move(value);
+            } else if (!skip_value(1)) {
+                return std::nullopt;
+            }
+            skip_space();
+            if (take('}')) break;
+            if (!take(',')) return std::nullopt;
+            skip_space();
+        }
+        return finish() && saw_title_id_ ? title_id_ : std::nullopt;
+    }
+
+private:
+    static bool hex_digit(char ch) {
+        return (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f') ||
+               (ch >= 'A' && ch <= 'F');
+    }
+    static uint32_t hex_value(char ch) {
+        if (ch >= '0' && ch <= '9') return static_cast<uint32_t>(ch - '0');
+        if (ch >= 'a' && ch <= 'f') return static_cast<uint32_t>(ch - 'a' + 10);
+        return static_cast<uint32_t>(ch - 'A' + 10);
+    }
+    void skip_space() {
+        while (pos_ < input_.size() &&
+               (input_[pos_] == ' ' || input_[pos_] == '\t' || input_[pos_] == '\r' ||
+                input_[pos_] == '\n')) ++pos_;
+    }
+    bool take(char expected) {
+        if (pos_ == input_.size() || input_[pos_] != expected) return false;
+        ++pos_;
+        return true;
+    }
+    bool finish() {
+        skip_space();
+        return pos_ == input_.size();
+    }
+    bool parse_string(std::string* output = nullptr, bool* escaped = nullptr) {
+        if (!take('"')) return false;
+        if (output) output->clear();
+        if (escaped) *escaped = false;
+        while (pos_ < input_.size()) {
+            const unsigned char byte = static_cast<unsigned char>(input_[pos_++]);
+            if (byte == '"') return true;
+            if (byte < 0x20) return false;
+            if (byte != '\\') {
+                if (output) output->push_back(static_cast<char>(byte));
+                continue;
+            }
+            if (escaped) *escaped = true;
+            if (pos_ == input_.size()) return false;
+            const char escape = input_[pos_++];
+            char decoded = 0;
+            switch (escape) {
+            case '"': decoded = '"'; break;
+            case '\\': decoded = '\\'; break;
+            case '/': decoded = '/'; break;
+            case 'b': decoded = '\b'; break;
+            case 'f': decoded = '\f'; break;
+            case 'n': decoded = '\n'; break;
+            case 'r': decoded = '\r'; break;
+            case 't': decoded = '\t'; break;
+            case 'u': {
+                if (input_.size() - pos_ < 4) return false;
+                uint32_t codepoint = 0;
+                for (size_t i = 0; i < 4; ++i) {
+                    const char digit = input_[pos_++];
+                    if (!hex_digit(digit)) return false;
+                    codepoint = (codepoint << 4) | hex_value(digit);
+                }
+                decoded = codepoint <= 0x7f ? static_cast<char>(codepoint) : '\x80';
+                break;
+            }
+            default: return false;
+            }
+            if (output) output->push_back(decoded);
+        }
+        return false;
+    }
+    bool skip_number() {
+        const size_t begin = pos_;
+        take('-');
+        if (take('0')) {
+            // A following decimal digit is rejected by the caller's delimiter check.
+        } else {
+            const size_t digits = pos_;
+            while (pos_ < input_.size() && ascii_digit(input_[pos_])) ++pos_;
+            if (digits == pos_) return false;
+        }
+        if (take('.')) {
+            const size_t digits = pos_;
+            while (pos_ < input_.size() && ascii_digit(input_[pos_])) ++pos_;
+            if (digits == pos_) return false;
+        }
+        if (pos_ < input_.size() && (input_[pos_] == 'e' || input_[pos_] == 'E')) {
+            ++pos_;
+            if (pos_ < input_.size() && (input_[pos_] == '+' || input_[pos_] == '-')) ++pos_;
+            const size_t digits = pos_;
+            while (pos_ < input_.size() && ascii_digit(input_[pos_])) ++pos_;
+            if (digits == pos_) return false;
+        }
+        return pos_ != begin;
+    }
+    bool skip_literal(std::string_view literal) {
+        if (input_.substr(pos_, literal.size()) != literal) return false;
+        pos_ += literal.size();
+        return true;
+    }
+    bool skip_value(unsigned depth) {
+        if (depth > 64) return false;
+        skip_space();
+        if (pos_ == input_.size()) return false;
+        if (input_[pos_] == '"') return parse_string();
+        if (input_[pos_] == '{') {
+            ++pos_;
+            skip_space();
+            if (take('}')) return true;
+            for (;;) {
+                if (!parse_string()) return false;
+                skip_space();
+                if (!take(':') || !skip_value(depth + 1)) return false;
+                skip_space();
+                if (take('}')) return true;
+                if (!take(',')) return false;
+                skip_space();
+            }
+        }
+        if (input_[pos_] == '[') {
+            ++pos_;
+            skip_space();
+            if (take(']')) return true;
+            for (;;) {
+                if (!skip_value(depth + 1)) return false;
+                skip_space();
+                if (take(']')) return true;
+                if (!take(',')) return false;
+                skip_space();
+            }
+        }
+        if (input_[pos_] == 't') return skip_literal("true");
+        if (input_[pos_] == 'f') return skip_literal("false");
+        if (input_[pos_] == 'n') return skip_literal("null");
+        return skip_number();
+    }
+
+    std::string_view input_;
+    size_t pos_ = 0;
+    bool saw_title_id_ = false;
+    std::optional<std::string> title_id_;
+};
+
+bool parse_hex_key(std::string_view text, std::array<uint8_t, 16>& out) {
+    if (text.size() != out.size() * 2) return false;
+    auto nibble = [](char ch) -> int {
+        if (ch >= '0' && ch <= '9') return ch - '0';
+        if (ch >= 'a' && ch <= 'f') return ch - 'a' + 10;
+        if (ch >= 'A' && ch <= 'F') return ch - 'A' + 10;
+        return -1;
+    };
+    for (size_t i = 0; i < out.size(); ++i) {
+        const int high = nibble(text[i * 2]);
+        const int low = nibble(text[i * 2 + 1]);
+        if (high < 0 || low < 0) return false;
+        out[i] = static_cast<uint8_t>((high << 4) | low);
+    }
+    return true;
+}
+
+bool parse_np_service_label(std::string_view text, int64_t& out) {
+    if (text.empty()) return true; // dlc_emu's documented default: wildcard
+    if (text == "-1") {
+        out = -1;
+        return true;
+    }
+    uint64_t value = 0;
+    if (text.size() > 10) return false;
+    for (char ch : text) {
+        if (!ascii_digit(ch)) return false;
+        value = value * 10 + static_cast<uint64_t>(ch - '0');
+        if (value > UINT32_MAX) return false;
+    }
+    out = static_cast<int64_t>(value);
+    return true;
+}
+
+bool canonical_child_directory(const std::filesystem::path& root,
+                               std::string_view guest_mount_point) {
+    if (guest_mount_point.size() >= 16 || guest_mount_point.substr(0, 6) != "/app0/")
+        return false;
+    const std::string_view relative = guest_mount_point.substr(6);
+    if (relative.empty() || relative.front() == '/' || relative.back() == '/' ||
+        relative.find('\\') != std::string_view::npos) return false;
+    for (size_t pos = 0; pos <= relative.size();) {
+        const size_t slash = relative.find('/', pos);
+        const size_t end = slash == std::string_view::npos ? relative.size() : slash;
+        const std::string_view component = relative.substr(pos, end - pos);
+        if (component.empty() || component == "." || component == "..") return false;
+        if (slash == std::string_view::npos) break;
+        pos = slash + 1;
+    }
+
+    std::error_code ec;
+    const std::filesystem::path canonical_root = std::filesystem::canonical(root, ec);
+    if (ec) return false;
+    const std::filesystem::path candidate =
+        std::filesystem::canonical(root / std::filesystem::path(relative), ec);
+    if (ec || !std::filesystem::is_directory(candidate, ec) || ec) return false;
+
+    auto root_it = canonical_root.begin();
+    auto child_it = candidate.begin();
+    for (; root_it != canonical_root.end(); ++root_it, ++child_it) {
+        if (child_it == candidate.end() || *root_it != *child_it) return false;
+    }
+    return child_it != candidate.end(); // the add-content root must be below, not equal to, /app0
+}
+
+struct ParseResult {
+    AddcontentInventorySnapshot inventory;
+    std::string error;
+};
+
+ParseResult parse_inventory(const std::filesystem::path& root, std::string_view manifest,
+                            std::string_view title_id) {
+    ParseResult result;
+    result.inventory.state = AddcontentInventoryState::Invalid;
+    std::vector<PendingRecord> pending;
+    PendingRecord* current = nullptr;
+
+    size_t line_number = 0;
+    for (size_t pos = 0; pos <= manifest.size();) {
+        size_t end = manifest.find('\n', pos);
+        if (end == std::string_view::npos) end = manifest.size();
+        std::string_view line = manifest.substr(pos, end - pos);
+        ++line_number;
+        if (!line.empty() && line.back() == '\r') line.remove_suffix(1);
+        if (!line.empty() && line.back() == ' ') {
+            result.error = "trailing whitespace at line " + std::to_string(line_number);
+            return result;
+        }
+        if (!line.empty() && line.front() == '[') {
+            if (line != "[PSAC]" && line != "[PSAL]") {
+                result.error = "unknown section at line " + std::to_string(line_number);
+                return result;
+            }
+            if (pending.size() == kMaxEntries) {
+                result.error = "manifest exceeds the installed-entry limit";
+                return result;
+            }
+            pending.push_back({});
+            current = &pending.back();
+            current->section = std::string(line.substr(1, 4));
+        } else if (!line.empty() && line.front() != '#' && line.front() != ';') {
+            if (!current) {
+                result.error = "property before section at line " + std::to_string(line_number);
+                return result;
+            }
+            const size_t equal = line.find('=');
+            if (equal == std::string_view::npos || equal == 0 || equal + 1 == line.size()) {
+                result.error = "malformed property at line " + std::to_string(line_number);
+                return result;
+            }
+            const std::string key(line.substr(0, equal));
+            const std::string value(line.substr(equal + 1));
+            if (!current->seen_keys.insert(key).second) {
+                result.error = "duplicate property at line " + std::to_string(line_number);
+                return result;
+            }
+            if (key == "content_id") current->content_id = value;
+            else if (key == "download_status") current->download_status = value;
+            else if (key == "mount_point") current->mount_point = value;
+            else if (key == "entitlement_key") current->entitlement_key = value;
+            else if (key == "np_service_label") current->np_service_label = value;
+            else {
+                result.error = "unknown property at line " + std::to_string(line_number);
+                return result;
+            }
+        }
+        if (end == manifest.size()) break;
+        pos = end + 1;
+    }
+    if (pending.empty()) {
+        result.error = "manifest contains no records";
+        return result;
+    }
+
+    std::set<std::string> labels;
+    std::set<std::string> content_ids;
+    std::set<std::string> mount_points;
+    for (size_t index = 0; index < pending.size(); ++index) {
+        const PendingRecord& input = pending[index];
+        const std::string record = "record " + std::to_string(index + 1);
+        // XX0000-PPSA00000_00-ENTITLEMENTLABEL is the declared add-content identity. The final
+        // 16 characters are the Sony entitlement label. API service scoping is a separate optional
+        // np_service_label property; dlc_emu defines its absent/-1 value as wildcard.
+        if (input.content_id.size() != 36 || !ascii_upper(input.content_id[0]) ||
+            !ascii_upper(input.content_id[1]) ||
+            !std::all_of(input.content_id.begin() + 2, input.content_id.begin() + 6, ascii_digit) ||
+            input.content_id[6] != '-' ||
+            input.content_id.substr(16, 4) != "_00-" ||
+            input.content_id.substr(7, 9) != title_id) {
+            result.error = record + " has an invalid or foreign content_id";
+            return result;
+        }
+        const std::string label = input.content_id.substr(20);
+        if (!valid_entitlement_label(label)) {
+            result.error = record + " has an invalid entitlement label";
+            return result;
+        }
+        if (input.download_status != "INSTALLED") {
+            result.error = record + " has an unsupported download_status";
+            return result;
+        }
+        int64_t service_label = -1;
+        if (!parse_np_service_label(input.np_service_label, service_label)) {
+            result.error = record + " has an invalid np_service_label";
+            return result;
+        }
+        if (!labels.insert(label).second) {
+            result.error = record + " duplicates an entitlement label";
+            return result;
+        }
+        if (!content_ids.insert(input.content_id).second) {
+            result.error = record + " duplicates a content_id";
+            return result;
+        }
+
+        InstalledAddcontent output;
+        output.service_label = service_label;
+        output.entitlement_label = label;
+        output.package_type = input.section == "PSAC" ? 2u : 3u;
+        if (!input.mount_point.empty()) {
+            if (!mount_points.insert(input.mount_point).second) {
+                result.error = record + " duplicates a mount point";
+                return result;
+            }
+            if (!canonical_child_directory(root, input.mount_point)) {
+                result.error = record + " has an absent or out-of-root mount point";
+                return result;
+            }
+            output.guest_mount_point = input.mount_point;
+        }
+        if (!input.entitlement_key.empty()) {
+            if (!parse_hex_key(input.entitlement_key, output.entitlement_key)) {
+                result.error = record + " has a malformed entitlement key";
+                return result;
+            }
+            output.has_entitlement_key = true;
+        }
+        result.inventory.entries.push_back(std::move(output));
+    }
+    result.inventory.state = AddcontentInventoryState::Ready;
+    return result;
+}
+
+} // namespace
+
+void addcontent_configure_for_app0(const std::string& app0_root) {
+    AddcontentInventorySnapshot next;
+    if (app0_root.empty()) {
+        std::lock_guard<std::mutex> lock(g_inventory_mutex);
+        g_inventory = std::move(next);
+        return;
+    }
+    const std::filesystem::path root(app0_root);
+    bool manifest_exists = false;
+    const std::optional<std::string> manifest =
+        read_bounded_file(root / "dlc_emu.ini", kMaxManifestBytes, manifest_exists);
+    if (!manifest_exists) {
+        next.state = AddcontentInventoryState::None;
+    } else if (!manifest) {
+        next.state = AddcontentInventoryState::Invalid;
+        std::fprintf(stderr, "[addcontent] invalid install manifest: unreadable or oversized\n");
+    } else {
+        bool param_exists = false;
+        const std::optional<std::string> param =
+            read_bounded_file(root / "sce_sys" / "param.json", kMaxParamBytes, param_exists);
+        const std::optional<std::string> title_id =
+            param ? ParamJsonReader(*param).top_level_title_id() : std::nullopt;
+        if (!param_exists || !param || !title_id || !valid_title_id(*title_id)) {
+            next.state = AddcontentInventoryState::Invalid;
+            std::fprintf(stderr,
+                         "[addcontent] invalid install manifest: app metadata has no valid titleId\n");
+        } else {
+            ParseResult parsed = parse_inventory(root, *manifest, *title_id);
+            next = std::move(parsed.inventory);
+            if (next.state == AddcontentInventoryState::Invalid)
+                std::fprintf(stderr, "[addcontent] invalid install manifest: %s\n",
+                             parsed.error.c_str());
+        }
+    }
+    std::lock_guard<std::mutex> lock(g_inventory_mutex);
+    g_inventory = std::move(next);
+}
+
+AddcontentInventorySnapshot addcontent_inventory_snapshot() {
+    std::lock_guard<std::mutex> lock(g_inventory_mutex);
+    return g_inventory;
+}
+
+} // namespace prosper

--- a/prosper/src/hle/hle_addcontent.hpp
+++ b/prosper/src/hle/hle_addcontent.hpp
@@ -1,0 +1,38 @@
+// hle_addcontent.hpp — validated host inventory for installed local PS5 add-content.
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace prosper {
+
+enum class AddcontentInventoryState {
+    None,       // no dlc_emu.ini: this title has no locally declared add-content
+    Ready,
+    Invalid,    // manifest exists but failed validation; never masquerade as "no DLC"
+};
+
+struct InstalledAddcontent {
+    int64_t service_label = -1;       // -1 = producer-defined wildcard; otherwise uint32_t
+    std::string entitlement_label;   // 1..16 validated ASCII characters
+    uint32_t package_type = 0;       // PSAC=2, PSAL=3 (SceNpEntitlementAccess ABI)
+    uint32_t download_status = 4;    // INSTALLED
+    std::string guest_mount_point;   // empty for licence-only add-content
+    std::array<uint8_t, 16> entitlement_key{};
+    bool has_entitlement_key = false;
+};
+
+struct AddcontentInventorySnapshot {
+    AddcontentInventoryState state = AddcontentInventoryState::None;
+    std::vector<InstalledAddcontent> entries;
+};
+
+// Called whenever the host /app0 root changes. The manifest is parsed once, and only fully validated
+// records are published to HLE readers. Diagnostics deliberately omit the host root (public logs must
+// not expose the developer's private directory layout).
+void addcontent_configure_for_app0(const std::string& app0_root);
+AddcontentInventorySnapshot addcontent_inventory_snapshot();
+
+} // namespace prosper

--- a/prosper/src/hle/hle_addcontent.hpp
+++ b/prosper/src/hle/hle_addcontent.hpp
@@ -2,8 +2,10 @@
 #pragma once
 
 #include <array>
+#include <cstddef>
 #include <cstdint>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace prosper {
@@ -19,9 +21,10 @@ struct InstalledAddcontent {
     std::string entitlement_label;   // 1..16 validated ASCII characters
     uint32_t package_type = 0;       // PSAC=2, PSAL=3 (SceNpEntitlementAccess ABI)
     uint32_t download_status = 4;    // INSTALLED
-    std::string guest_mount_point;   // empty for licence-only add-content
+    std::string guest_mount_point;   // validated declared path; mountable gates package policy
     std::array<uint8_t, 16> entitlement_key{};
-    bool has_entitlement_key = false;
+    bool mountable = false;           // producer default: installed PSAC with a declared path
+    bool mounted = false;             // process-local AppContent mount state
 };
 
 struct AddcontentInventorySnapshot {
@@ -34,5 +37,20 @@ struct AddcontentInventorySnapshot {
 // not expose the developer's private directory layout).
 void addcontent_configure_for_app0(const std::string& app0_root);
 AddcontentInventorySnapshot addcontent_inventory_snapshot();
+
+enum class AddcontentMountResult {
+    Mounted,
+    NotFound,
+    Busy,
+    OutputError,
+};
+
+using AddcontentMountWriter = bool (*)(uint64_t, const void*, std::size_t);
+
+// Atomically validate, write, and claim a configured mount. Successful output is the complete
+// zero-padded 16-byte SceAppContentMountPoint object; repeated mounts remain BUSY until unmount is
+// implemented. A failed guest write does not consume the mount.
+AddcontentMountResult addcontent_mount(uint32_t service_label, std::string_view entitlement_label,
+                                       uint64_t output_address, AddcontentMountWriter writer);
 
 } // namespace prosper

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -5,6 +5,7 @@
 #define _GNU_SOURCE   // pthread_getattr_np (bound the PREADLOG/DEEPTRACE stack walk to the real stack)
 #endif
 #include "dispatch.hpp"
+#include "hle_addcontent.hpp"
 #include "nid.hpp"
 #include "sce_errno.hpp"    // #1612: the guest reads FreeBSD errnos, not this host's
 #include "heap_mutex.hpp"   // #707: keep the APR mutex off macOS __DATA
@@ -747,7 +748,10 @@ namespace {
 #endif
 }
 
-void set_app0_root(const std::string& root) { g_app0 = root; }
+void set_app0_root(const std::string& root) {
+    g_app0 = root;
+    addcontent_configure_for_app0(root);
+}
 std::string resolve_guest_path(const char* guest_path) {
     if (!guest_path || !*guest_path) return {};
     std::string p = guest_path;

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -2018,9 +2018,13 @@ HLE(s_ime_kbd_info) {
 // --- app content ---
 namespace {
 constexpr uint64_t APP_CONTENT_ERROR_PARAMETER = 0x80D90002ull;
+constexpr uint64_t APP_CONTENT_ERROR_BUSY = 0x80D90003ull;
+constexpr uint64_t APP_CONTENT_ERROR_NOT_FOUND = 0x80D90005ull;
 constexpr uint64_t APP_CONTENT_ERROR_DRM_NO_ENTITLEMENT = 0x80D90007ull;
 constexpr uint64_t NP_ENTITLEMENT_ERROR_PARAMETER = 0x817D0002ull;
 constexpr uint64_t NP_ENTITLEMENT_ERROR_NO_ENTITLEMENT = 0x817D0007ull;
+// dlc_emu 0.3's NP list export compares listNum against 0x9c4 before touching either output.
+constexpr uint32_t NP_ENTITLEMENT_ADDCONT_LIST_MAX = 2500;
 
 // Direct PS5 guest evidence pins these boundaries. Sonic allocates exactly 0x1c bytes per
 // NpEntitlementAccess list entry and passes a 20-byte label to AddcontMount; Crisis Core independently
@@ -2063,7 +2067,8 @@ bool appcontent_read_label(uint64_t address, std::string& label) {
     if (!svc_copy_bytes(address, raw, sizeof(raw))) return false;
     size_t size = 0;
     while (size < 17 && raw[size]) ++size;
-    if (size == 17 || !appcontent_valid_label_text(raw, size)) return false;
+    if (size == 17 || raw[17] || raw[18] || raw[19] ||
+        !appcontent_valid_label_text(raw, size)) return false;
     label.assign(raw, size);
     return true;
 }
@@ -2100,8 +2105,8 @@ template <typename GuestInfo, typename MakeInfo>
 uint64_t addcontent_info_list(uint64_t list_address, uint64_t list_num,
                               uint64_t hit_num_address, uint32_t service_label,
                               uint64_t parameter_error, uint64_t inventory_error,
-                              MakeInfo make_info) {
-    if (list_num > UINT32_MAX) return parameter_error;
+                              uint64_t max_list_num, MakeInfo make_info) {
+    if (list_num > max_list_num) return parameter_error;
     const AddcontentInventorySnapshot inventory = addcontent_inventory_snapshot();
     if (inventory.state == AddcontentInventoryState::Invalid) return inventory_error;
 
@@ -2254,7 +2259,7 @@ HLE(s_appcontent_addcont_list) {
     if (a0 > UINT32_MAX) return APP_CONTENT_ERROR_PARAMETER;
     return addcontent_info_list<AppContentAddcontInfo>(
         a1, a2, a3, static_cast<uint32_t>(a0), APP_CONTENT_ERROR_PARAMETER,
-        APP_CONTENT_ERROR_DRM_NO_ENTITLEMENT, appcontent_info);
+        APP_CONTENT_ERROR_DRM_NO_ENTITLEMENT, UINT32_MAX, appcontent_info);
 }
 
 HLE(s_appcontent_addcont_info) {
@@ -2264,7 +2269,7 @@ HLE(s_appcontent_addcont_info) {
     const AddcontentInventorySnapshot inventory = addcontent_inventory_snapshot();
     if (inventory.state == AddcontentInventoryState::Invalid)
         return APP_CONTENT_ERROR_DRM_NO_ENTITLEMENT;
-    const InstalledAddcontent* entry = find_addcontent(inventory, static_cast<int32_t>(a0), label);
+    const InstalledAddcontent* entry = find_addcontent(inventory, static_cast<uint32_t>(a0), label);
     if (!entry) return APP_CONTENT_ERROR_DRM_NO_ENTITLEMENT;
     const AppContentAddcontInfo info = appcontent_info(*entry);
     return svc_write_bytes(a2, &info, sizeof(info)) ? 0 : APP_CONTENT_ERROR_PARAMETER;
@@ -2276,8 +2281,8 @@ HLE(s_appcontent_entitlement_key) {
         return APP_CONTENT_ERROR_PARAMETER;
     const AddcontentInventorySnapshot inventory = addcontent_inventory_snapshot();
     const InstalledAddcontent* entry = inventory.state == AddcontentInventoryState::Ready
-        ? find_addcontent(inventory, static_cast<int32_t>(a0), label) : nullptr;
-    if (!entry || !entry->has_entitlement_key) return APP_CONTENT_ERROR_DRM_NO_ENTITLEMENT;
+        ? find_addcontent(inventory, static_cast<uint32_t>(a0), label) : nullptr;
+    if (!entry) return APP_CONTENT_ERROR_DRM_NO_ENTITLEMENT;
     return svc_write_bytes(a2, entry->entitlement_key.data(), entry->entitlement_key.size())
         ? 0 : APP_CONTENT_ERROR_PARAMETER;
 }
@@ -2286,12 +2291,13 @@ HLE(s_appcontent_addcont_mount) {
     std::string label;
     if (a0 > UINT32_MAX || !appcontent_read_label(a1, label) || !svc_ptrish(a2))
         return APP_CONTENT_ERROR_PARAMETER;
-    const AddcontentInventorySnapshot inventory = addcontent_inventory_snapshot();
-    const InstalledAddcontent* entry = inventory.state == AddcontentInventoryState::Ready
-        ? find_addcontent(inventory, static_cast<int32_t>(a0), label) : nullptr;
-    if (!entry || entry->guest_mount_point.empty()) return APP_CONTENT_ERROR_DRM_NO_ENTITLEMENT;
-    return svc_write_bytes(a2, entry->guest_mount_point.c_str(), entry->guest_mount_point.size() + 1)
-        ? 0 : APP_CONTENT_ERROR_PARAMETER;
+    switch (addcontent_mount(static_cast<uint32_t>(a0), label, a2, svc_write_bytes)) {
+    case AddcontentMountResult::NotFound: return APP_CONTENT_ERROR_NOT_FOUND;
+    case AddcontentMountResult::Busy: return APP_CONTENT_ERROR_BUSY;
+    case AddcontentMountResult::OutputError: return APP_CONTENT_ERROR_PARAMETER;
+    case AddcontentMountResult::Mounted: return 0;
+    }
+    return APP_CONTENT_ERROR_NOT_FOUND;
 }
 
 // sceSystemServiceParamGetString(paramId, char* buf, size_t bufSize): fetch a system string parameter
@@ -3181,7 +3187,7 @@ HLE(s_npent_addcont_info) {
         return NP_ENTITLEMENT_ERROR_PARAMETER;
     const AddcontentInventorySnapshot inventory = addcontent_inventory_snapshot();
     const InstalledAddcontent* entry = inventory.state == AddcontentInventoryState::Ready
-        ? find_addcontent(inventory, static_cast<int32_t>(a0), label) : nullptr;
+        ? find_addcontent(inventory, static_cast<uint32_t>(a0), label) : nullptr;
     if (!entry) return NP_ENTITLEMENT_ERROR_NO_ENTITLEMENT;
     const NpAddcontEntitlementInfo info = npent_info(*entry);
     return svc_write_bytes(a2, &info, sizeof(info)) ? 0 : NP_ENTITLEMENT_ERROR_PARAMETER;
@@ -3389,12 +3395,12 @@ HLE(s_npent_addcont_list) {
     if (a0 > UINT32_MAX) return NP_ENTITLEMENT_ERROR_PARAMETER;
     return addcontent_info_list<NpAddcontEntitlementInfo>(
         a1, a2, a3, static_cast<uint32_t>(a0), NP_ENTITLEMENT_ERROR_PARAMETER,
-        NP_ENTITLEMENT_ERROR_NO_ENTITLEMENT, npent_info);
+        NP_ENTITLEMENT_ERROR_NO_ENTITLEMENT, NP_ENTITLEMENT_ADDCONT_LIST_MAX, npent_info);
 }
 // GetEntitlementKey(serviceLabel, const Label* label, Key* out) — live capture: retried 4x with
 // identical args (the garbage-consuming retry signature). Crisis Core independently consumes
-// exactly 16 bytes from the successful output. Only a validated, installed record with a declared
-// key succeeds; unknown labels and licence records without a key retain honest failure.
+// exactly 16 bytes from the successful output. Validated installed records use either their explicit
+// key or the producer's deterministic default; unknown labels retain honest failure.
 HLE(s_npent_getkey) {
     svc_log("sceNpEntitlementAccessGetEntitlementKey", a0,a1,a2,a3,a4,a5);
     std::string label;
@@ -3402,8 +3408,8 @@ HLE(s_npent_getkey) {
         return NP_ENTITLEMENT_ERROR_PARAMETER;
     const AddcontentInventorySnapshot inventory = addcontent_inventory_snapshot();
     const InstalledAddcontent* entry = inventory.state == AddcontentInventoryState::Ready
-        ? find_addcontent(inventory, static_cast<int32_t>(a0), label) : nullptr;
-    if (!entry || !entry->has_entitlement_key) return NP_ENTITLEMENT_ERROR_NO_ENTITLEMENT;
+        ? find_addcontent(inventory, static_cast<uint32_t>(a0), label) : nullptr;
+    if (!entry) return NP_ENTITLEMENT_ERROR_NO_ENTITLEMENT;
     return svc_write_bytes(a2, entry->entitlement_key.data(), entry->entitlement_key.size())
         ? 0 : NP_ENTITLEMENT_ERROR_PARAMETER;
 }

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -4,6 +4,7 @@
 // game gets consistent values instead of uninitialized memory.
 // (Game-controller input — libScePad — moved to hle_pad.cpp with a real host backend.)
 #include "dispatch.hpp"
+#include "hle_addcontent.hpp"
 #include "hle_json2.hpp"
 #include "nid.hpp"
 #include "callback_fs.hpp"
@@ -2015,6 +2016,127 @@ HLE(s_ime_kbd_info) {
 }
 
 // --- app content ---
+namespace {
+constexpr uint64_t APP_CONTENT_ERROR_PARAMETER = 0x80D90002ull;
+constexpr uint64_t APP_CONTENT_ERROR_DRM_NO_ENTITLEMENT = 0x80D90007ull;
+constexpr uint64_t NP_ENTITLEMENT_ERROR_PARAMETER = 0x817D0002ull;
+constexpr uint64_t NP_ENTITLEMENT_ERROR_NO_ENTITLEMENT = 0x817D0007ull;
+
+// Direct PS5 guest evidence pins these boundaries. Sonic allocates exactly 0x1c bytes per
+// NpEntitlementAccess list entry and passes a 20-byte label to AddcontMount; Crisis Core independently
+// allocates the same stride and consumes exactly 16 key bytes. AppContent's inherited info is the
+// label+download-status prefix. Sonic directly
+// reads `download_status` at +0x18 and accepts INSTALLED=4. Package types PSAC=2 / PSAL=3 and the
+// NP entitlement errno space are pinned to the dlc_emu producer at 43ae9aa (CONFIDENCE: HIGH).
+struct AppContentAddcontInfo {
+    char entitlement_label[20];
+    uint32_t download_status;
+};
+struct NpAddcontEntitlementInfo {
+    char entitlement_label[20];
+    uint32_t package_type;
+    uint32_t download_status;
+};
+static_assert(sizeof(AppContentAddcontInfo) == 24, "SceAppContentAddcontInfo ABI");
+static_assert(offsetof(AppContentAddcontInfo, download_status) == 20,
+              "SceAppContentAddcontInfo status offset");
+static_assert(sizeof(NpAddcontEntitlementInfo) == 28,
+              "SceNpEntitlementAccessAddcontEntitlementInfo ABI");
+static_assert(offsetof(NpAddcontEntitlementInfo, package_type) == 20 &&
+              offsetof(NpAddcontEntitlementInfo, download_status) == 24,
+              "Np add-content info field offsets");
+
+bool appcontent_valid_label_text(const char* text, size_t size) {
+    if (!size || size > 16) return false;
+    for (size_t i = 0; i < size; ++i) {
+        const char ch = text[i];
+        if (!((ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z') ||
+              (ch >= '0' && ch <= '9')))
+            return false;
+    }
+    return true;
+}
+
+bool appcontent_read_label(uint64_t address, std::string& label) {
+    if (!svc_ptrish(address)) return false;
+    char raw[20];
+    if (!svc_copy_bytes(address, raw, sizeof(raw))) return false;
+    size_t size = 0;
+    while (size < 17 && raw[size]) ++size;
+    if (size == 17 || !appcontent_valid_label_text(raw, size)) return false;
+    label.assign(raw, size);
+    return true;
+}
+
+AppContentAddcontInfo appcontent_info(const InstalledAddcontent& entry) {
+    AppContentAddcontInfo info{};
+    std::memcpy(info.entitlement_label, entry.entitlement_label.c_str(),
+                entry.entitlement_label.size() + 1);
+    info.download_status = entry.download_status;
+    return info;
+}
+
+NpAddcontEntitlementInfo npent_info(const InstalledAddcontent& entry) {
+    NpAddcontEntitlementInfo info{};
+    std::memcpy(info.entitlement_label, entry.entitlement_label.c_str(),
+                entry.entitlement_label.size() + 1);
+    info.package_type = entry.package_type;
+    info.download_status = entry.download_status;
+    return info;
+}
+
+const InstalledAddcontent* find_addcontent(const AddcontentInventorySnapshot& inventory,
+                                           uint32_t service_label,
+                                           const std::string& entitlement_label) {
+    for (const InstalledAddcontent& entry : inventory.entries) {
+        if ((entry.service_label == -1 ||
+             static_cast<uint32_t>(entry.service_label) == service_label) &&
+            entry.entitlement_label == entitlement_label) return &entry;
+    }
+    return nullptr;
+}
+
+template <typename GuestInfo, typename MakeInfo>
+uint64_t addcontent_info_list(uint64_t list_address, uint64_t list_num,
+                              uint64_t hit_num_address, uint32_t service_label,
+                              uint64_t parameter_error, uint64_t inventory_error,
+                              MakeInfo make_info) {
+    if (list_num > UINT32_MAX) return parameter_error;
+    const AddcontentInventorySnapshot inventory = addcontent_inventory_snapshot();
+    if (inventory.state == AddcontentInventoryState::Invalid) return inventory_error;
+
+    std::vector<const InstalledAddcontent*> matching;
+    for (const InstalledAddcontent& entry : inventory.entries)
+        if (entry.service_label == -1 ||
+            static_cast<uint32_t>(entry.service_label) == service_label)
+            matching.push_back(&entry);
+
+    const uint32_t capacity = static_cast<uint32_t>(list_num);
+    const uint32_t total = static_cast<uint32_t>(matching.size());
+    // Both producer list APIs define NULL-list or zero-capacity as a count query, where hitNum is
+    // mandatory. On a real list call hitNum is optional.
+    if (list_address == 0 || capacity == 0) {
+        if (!svc_ptrish(hit_num_address) ||
+            !svc_write_bytes(hit_num_address, &total, sizeof(total))) return parameter_error;
+        return 0;
+    }
+    const uint32_t written = static_cast<uint32_t>(std::min<size_t>(capacity, matching.size()));
+    if (!svc_ptrish(list_address) ||
+        written > (UINT64_MAX - list_address) / sizeof(GuestInfo)) return parameter_error;
+    for (uint32_t i = 0; i < written; ++i) {
+        const GuestInfo info = make_info(*matching[i]);
+        if (!svc_write_bytes(list_address + uint64_t{i} * sizeof(GuestInfo),
+                             &info, sizeof(info))) return parameter_error;
+    }
+    // The dlc_emu producer/reference writes min(listNum,total) entries but reports the full total in
+    // hitNum for both AppContent and NpEntitlementAccess. Pin: drakmor/dlc_emu@43ae9aa,
+    // dlc_content.cpp:1941-1965 and 2357-2385. This lets a short caller discover and retry the count.
+    if (hit_num_address && !svc_write_bytes(hit_num_address, &total, sizeof(total)))
+        return parameter_error;
+    return 0;
+}
+} // namespace
+
 // sceAppContentAppParamGetInt(paramId, int32_t* value): paramId 0 = SKU_FLAG, whose only valid values are
 // TRIAL=1 / FULL=3 (there is NO 0). Writing 0 for it made the SKU check indeterminate -> a game testing
 // `sku == FULL` drops into trial/demo mode (locked content, "buy full game" gating). Report FULL for a
@@ -2124,19 +2246,53 @@ HLE(s_appcontent_tmpmount2) {
 // value games use to size caches/allocations.
 HLE(s_appcontent_tmpspace) { if (a1) *(uint64_t*)PW(a1) = 1048576ull; return 0; }
 
-// sceAppContentGetAddcontInfoList(serviceLabel, Info* list, u32 listNum, u32* hitNum): the add-content
-// (DLC) enumeration. The game first count-queries with list=NULL/num=0 and an out pointer in a3, then
-// grows a hitNum-sized array. Was MISSING -> the return-0 stub reported success while leaving *hitNum
-// (a3) uninitialized -> the engine sized an array from heap garbage = the 34 GB OOM / heap-overflow
-// class (cf. #213). This dump has no DLC, so the truthful answer is SUCCESS with hitNum=0 (matches the
-// sibling s_npent_addcont_list). CONFIDENCE: MED (no-DLC hitNum=0 is the retail answer; import inferred).
+// sceAppContentGetAddcontInfoList(serviceLabel, Info* list, u32 listNum, u32* hitNum). A zero-capacity
+// call is the count query; a shorter caller buffer receives only its capacity while hitNum reports the
+// full matching count. With no manifest the retail no-DLC answer remains SUCCESS/hitNum=0. A malformed host
+// inventory fails rather than masquerading as a valid empty install.
 HLE(s_appcontent_addcont_list) {
-    if (!svc_ptrish(a3)) return 0x80D90002ull;   // APP_CONTENT_ERROR_PARAMETER
-    *(uint32_t*)PW(a3) = 0;                       // hitNum = 0: no add-content installed
-    return 0;
+    if (a0 > UINT32_MAX) return APP_CONTENT_ERROR_PARAMETER;
+    return addcontent_info_list<AppContentAddcontInfo>(
+        a1, a2, a3, static_cast<uint32_t>(a0), APP_CONTENT_ERROR_PARAMETER,
+        APP_CONTENT_ERROR_DRM_NO_ENTITLEMENT, appcontent_info);
 }
-// GetAddcontInfo / GetEntitlementKey / AddcontMount for an unknown label: no entitlement (offline, no DLC).
-HLE(s_appcontent_no_entitlement) { return 0x80D90007ull; }   // APP_CONTENT_ERROR_DRM_NO_ENTITLEMENT
+
+HLE(s_appcontent_addcont_info) {
+    std::string label;
+    if (a0 > UINT32_MAX || !appcontent_read_label(a1, label) || !svc_ptrish(a2))
+        return APP_CONTENT_ERROR_PARAMETER;
+    const AddcontentInventorySnapshot inventory = addcontent_inventory_snapshot();
+    if (inventory.state == AddcontentInventoryState::Invalid)
+        return APP_CONTENT_ERROR_DRM_NO_ENTITLEMENT;
+    const InstalledAddcontent* entry = find_addcontent(inventory, static_cast<int32_t>(a0), label);
+    if (!entry) return APP_CONTENT_ERROR_DRM_NO_ENTITLEMENT;
+    const AppContentAddcontInfo info = appcontent_info(*entry);
+    return svc_write_bytes(a2, &info, sizeof(info)) ? 0 : APP_CONTENT_ERROR_PARAMETER;
+}
+
+HLE(s_appcontent_entitlement_key) {
+    std::string label;
+    if (a0 > UINT32_MAX || !appcontent_read_label(a1, label) || !svc_ptrish(a2))
+        return APP_CONTENT_ERROR_PARAMETER;
+    const AddcontentInventorySnapshot inventory = addcontent_inventory_snapshot();
+    const InstalledAddcontent* entry = inventory.state == AddcontentInventoryState::Ready
+        ? find_addcontent(inventory, static_cast<int32_t>(a0), label) : nullptr;
+    if (!entry || !entry->has_entitlement_key) return APP_CONTENT_ERROR_DRM_NO_ENTITLEMENT;
+    return svc_write_bytes(a2, entry->entitlement_key.data(), entry->entitlement_key.size())
+        ? 0 : APP_CONTENT_ERROR_PARAMETER;
+}
+
+HLE(s_appcontent_addcont_mount) {
+    std::string label;
+    if (a0 > UINT32_MAX || !appcontent_read_label(a1, label) || !svc_ptrish(a2))
+        return APP_CONTENT_ERROR_PARAMETER;
+    const AddcontentInventorySnapshot inventory = addcontent_inventory_snapshot();
+    const InstalledAddcontent* entry = inventory.state == AddcontentInventoryState::Ready
+        ? find_addcontent(inventory, static_cast<int32_t>(a0), label) : nullptr;
+    if (!entry || entry->guest_mount_point.empty()) return APP_CONTENT_ERROR_DRM_NO_ENTITLEMENT;
+    return svc_write_bytes(a2, entry->guest_mount_point.c_str(), entry->guest_mount_point.size() + 1)
+        ? 0 : APP_CONTENT_ERROR_PARAMETER;
+}
 
 // sceSystemServiceParamGetString(paramId, char* buf, size_t bufSize): fetch a system string parameter
 // (e.g. the console/user nickname). The default unimplemented stub returned 0 (SUCCESS) but never wrote
@@ -3020,7 +3176,15 @@ HLE(s_gameintent_get_property_string) {
 }
 HLE(s_npent_addcont_info) {
     svc_log("sceNpEntitlementAccessGetAddcontEntitlementInfo", a0,a1,a2,a3,a4,a5);
-    return NP_ERR_SIGNED_OUT;
+    std::string label;
+    if (a0 > UINT32_MAX || !appcontent_read_label(a1, label) || !svc_ptrish(a2))
+        return NP_ENTITLEMENT_ERROR_PARAMETER;
+    const AddcontentInventorySnapshot inventory = addcontent_inventory_snapshot();
+    const InstalledAddcontent* entry = inventory.state == AddcontentInventoryState::Ready
+        ? find_addcontent(inventory, static_cast<int32_t>(a0), label) : nullptr;
+    if (!entry) return NP_ENTITLEMENT_ERROR_NO_ENTITLEMENT;
+    const NpAddcontEntitlementInfo info = npent_info(*entry);
+    return svc_write_bytes(a2, &info, sizeof(info)) ? 0 : NP_ENTITLEMENT_ERROR_PARAMETER;
 }
 
 // ===== Issue #306: honest OFFLINE console for the online/update/entitlement boot chain. =========
@@ -3216,24 +3380,32 @@ HLE(s_gameupdate_term) { svc_log("sceGameUpdateTerminate",           a0,a1,a2,a3
 //                                 u32* hitNum)
 // — the game first count-queries with list=NULL/num=0 and an out pointer in a3, then calls again
 // with a 4-entry buffer (its four addcont slots). Matches the documented PS4 signature 1:1.
-// This dump has NO additional content installed and no signed-in user, so the truthful console
-// answer is SUCCESS with hitNum=0 (DLC entitlement lookups work offline from local state; there
-// simply are none). CONFIDENCE: HIGH on the shape (live-pinned + PS4 doc agree), MED on hitNum=0
-// being the exact retail no-DLC answer.
+// Entries come only from the validated local installation inventory. A title with no dlc_emu.ini
+// retains the retail no-DLC answer SUCCESS/hitNum=0; a present but invalid manifest fails visibly.
+// CONFIDENCE: HIGH on the shape (two independent PS5 guests allocate 0x1c bytes per entry and Sonic
+// directly consumes status at +0x18). Package enum values and errno behavior are producer-pinned.
 HLE(s_npent_addcont_list) {
     svc_log("sceNpEntitlementAccessGetAddcontEntitlementInfoList", a0,a1,a2,a3,a4,a5);
-    if (svc_ptrish(a3)) *(uint32_t*)PW(a3) = 0;   // hitNum = 0: no addcont entitlements
-    return 0;
+    if (a0 > UINT32_MAX) return NP_ENTITLEMENT_ERROR_PARAMETER;
+    return addcontent_info_list<NpAddcontEntitlementInfo>(
+        a1, a2, a3, static_cast<uint32_t>(a0), NP_ENTITLEMENT_ERROR_PARAMETER,
+        NP_ENTITLEMENT_ERROR_NO_ENTITLEMENT, npent_info);
 }
 // GetEntitlementKey(serviceLabel, const Label* label, Key* out) — live capture: retried 4x with
-// identical args (the garbage-consuming retry signature). With no entitlement to derive a key
-// from, honest FAILURE beats success+garbage-key; the exact NpEntitlementAccess errno space is
-// unreferenced, so the generic Np signed-out error is used (only the sign is consumed by a clean
-// caller). With hitNum=0 above the game should no longer ask at all. CONFIDENCE: LOW on the
-// error constant, HIGH that failure is the truthful state.
+// identical args (the garbage-consuming retry signature). Crisis Core independently consumes
+// exactly 16 bytes from the successful output. Only a validated, installed record with a declared
+// key succeeds; unknown labels and licence records without a key retain honest failure.
 HLE(s_npent_getkey) {
     svc_log("sceNpEntitlementAccessGetEntitlementKey", a0,a1,a2,a3,a4,a5);
-    return NP_ERR_SIGNED_OUT;
+    std::string label;
+    if (a0 > UINT32_MAX || !appcontent_read_label(a1, label) || !svc_ptrish(a2))
+        return NP_ENTITLEMENT_ERROR_PARAMETER;
+    const AddcontentInventorySnapshot inventory = addcontent_inventory_snapshot();
+    const InstalledAddcontent* entry = inventory.state == AddcontentInventoryState::Ready
+        ? find_addcontent(inventory, static_cast<int32_t>(a0), label) : nullptr;
+    if (!entry || !entry->has_entitlement_key) return NP_ENTITLEMENT_ERROR_NO_ENTITLEMENT;
+    return svc_write_bytes(a2, entry->entitlement_key.data(), entry->entitlement_key.size())
+        ? 0 : NP_ENTITLEMENT_ERROR_PARAMETER;
 }
 
 // sceSaveDataTransferringMount (PS5-only, live-captured x4 in DOLL's save-slot menu): mount a
@@ -3367,11 +3539,12 @@ void register_service_hle() {
     Hle::register_fn("SaKib2Ug0yI", (HleFn)s_appcontent_tmpspace, "sceAppContentTemporaryDataGetAvailableSpaceKb");
     Hle::register_fn("Gl6w5i0JokY", (HleFn)s_appcontent_tmpspace, "sceAppContentDownloadDataGetAvailableSpaceKb");  // was MISSING -> garbage KB
     Hle::register_fn("bcolXMmp6qQ", (HleFn)s_ok,                  "sceAppContentTemporaryDataUnmount");
-    // add-content (DLC) enumeration — no-DLC truth (hitNum=0 / no-entitlement), NOT garbage-count OOM (#213 class)
+    // Add-content (DLC) enumeration/mount comes only from the validated installed inventory.
+    // No manifest retains no-DLC truth (hitNum=0 / no entitlement), not garbage-count OOM (#213).
     Hle::register_fn("xnd8BJzAxmk", (HleFn)s_appcontent_addcont_list,   "sceAppContentGetAddcontInfoList");
-    Hle::register_fn("m47juOmH0VE", (HleFn)s_appcontent_no_entitlement, "sceAppContentGetAddcontInfo");
-    Hle::register_fn("XTWR0UXvcgs", (HleFn)s_appcontent_no_entitlement, "sceAppContentGetEntitlementKey");
-    Hle::register_fn("VANhIWcqYak", (HleFn)s_appcontent_no_entitlement, "sceAppContentAddcontMount");
+    Hle::register_fn("m47juOmH0VE", (HleFn)s_appcontent_addcont_info,   "sceAppContentGetAddcontInfo");
+    Hle::register_fn("XTWR0UXvcgs", (HleFn)s_appcontent_entitlement_key, "sceAppContentGetEntitlementKey");
+    Hle::register_fn("VANhIWcqYak", (HleFn)s_appcontent_addcont_mount, "sceAppContentAddcontMount");
     R("sceCommonDialogInitialize", s_ok);
     R("sceCommonDialogIsUsed", s_ok);   // 0 = not in use (our dialogs auto-dismiss) - intentional, not an unimpl log
     R("sceSystemServiceParamGetInt", s_syss_param_int);   // language-aware (US English default), not blanket 0

--- a/prosper/tests/test_service_getters.cpp
+++ b/prosper/tests/test_service_getters.cpp
@@ -572,6 +572,282 @@ int main() {
         }
     }
 
+    // Installed add-content (#1909): dlc_emu.ini is the dump tool's local inventory. Enumerate only
+    // its validated records, preserve the exact PS5 guest ABI boundaries, and retain the old empty
+    // answer for titles with no manifest. A bad manifest must fail visibly instead of becoming a
+    // believable "no DLC" response.
+    {
+        namespace fs = std::filesystem;
+        const fs::path scratch = prosper_test::test_scratch_dir() /
+            ("prosper-addcontent-" + std::to_string((uintptr_t)&fails));
+        const fs::path app0 = scratch / "app0";
+        const fs::path outside = scratch / "outside";
+        std::error_code ec;
+        fs::remove_all(scratch, ec);
+        fs::create_directories(app0 / "sce_sys", ec);
+        fs::create_directories(app0 / "dlc1", ec);
+        fs::create_directories(outside, ec);
+        {
+            std::ofstream param(app0 / "sce_sys" / "param.json", std::ios::binary);
+            param << R"({"titleId":"PPSA00001"})";
+        }
+        auto write_manifest = [&](const char* text) {
+            std::ofstream manifest(app0 / "dlc_emu.ini", std::ios::binary | std::ios::trunc);
+            manifest << text;
+        };
+        write_manifest(
+            "[PSAC]\n"
+            "content_id=UP0000-PPSA00001_00-00000000000DLC01\n"
+            "download_status=INSTALLED\n"
+            "mount_point=/app0/dlc1\n"
+            "entitlement_key=000102030405060708090A0B0C0D0E0F\n"
+            "[PSAL]\n"
+            "content_id=UP0000-PPSA00001_00-00000000000DLC02\n"
+            "download_status=INSTALLED\n"
+            "entitlement_key=F0E0D0C0B0A090807060504030201000\n"
+            "[PSAC]\n"
+            "content_id=UP0000-PPSA00001_00-00000000000DLC03\n"
+            "download_status=INSTALLED\n"
+            "np_service_label=7\n");
+        set_app0_root(app0.string());
+
+        HleFn np_list = Hle::lookup("TFyU+KFBv54");
+        HleFn np_info = Hle::lookup("xddD23+8TfQ");
+        HleFn np_key = Hle::lookup("5LiMEPuW0DQ");
+        HleFn app_list = Hle::lookup("xnd8BJzAxmk");
+        HleFn app_info = Hle::lookup("m47juOmH0VE");
+        HleFn app_key = Hle::lookup("XTWR0UXvcgs");
+        HleFn app_mount = Hle::lookup("VANhIWcqYak");
+        CHECK(np_list && np_info && np_key && app_list && app_info && app_key && app_mount,
+              "NP/AppContent installed-addcontent functions registered");
+        if (np_list && np_info && np_key && app_list && app_info && app_key && app_mount) {
+            uint32_t hits = 0xdeadbeef;
+            CHECK(np_list(0, 0, 0, (uint64_t)(uintptr_t)&hits, 0, 0) == 0 && hits == 2,
+                  "NP add-content zero-capacity query reports the installed count");
+            CHECK(np_list(0, 0, 0, 0, 0, 0) == 0x817D0002ull,
+                  "NP count query requires its hitNum output");
+            hits = 0xdeadbeef;
+            CHECK(app_list(0, 0, 0, (uint64_t)(uintptr_t)&hits, 0, 0) == 0 && hits == 2,
+                  "AppContent zero-capacity query reports the installed count");
+
+            alignas(8) uint8_t np_short[36]; memset(np_short, 0xAB, sizeof(np_short));
+            hits = 0xdeadbeef;
+            CHECK(np_list(0, (uint64_t)(uintptr_t)np_short, 1,
+                          (uint64_t)(uintptr_t)&hits, 0, 0) == 0 && hits == 2,
+                  "NP short-capacity list writes one entry but reports the full matching count");
+            CHECK(strcmp((char*)np_short, "00000000000DLC01") == 0 &&
+                  *(uint32_t*)(np_short + 20) == 2 && *(uint32_t*)(np_short + 24) == 4,
+                  "NP list entry carries the PSAC type and INSTALLED status at the guest offsets");
+            bool np_short_canary = true;
+            for (size_t i = 28; i < sizeof(np_short); ++i) np_short_canary &= np_short[i] == 0xAB;
+            CHECK(np_short_canary, "NP short-capacity list writes exactly its 28-byte entry");
+
+            alignas(8) uint8_t np_exact[64]; memset(np_exact, 0xAB, sizeof(np_exact));
+            hits = 0;
+            CHECK(np_list(0, (uint64_t)(uintptr_t)np_exact, 2,
+                          (uint64_t)(uintptr_t)&hits, 0, 0) == 0 && hits == 2 &&
+                  strcmp((char*)np_exact + 28, "00000000000DLC02") == 0 &&
+                  *(uint32_t*)(np_exact + 48) == 3 && *(uint32_t*)(np_exact + 52) == 4,
+                  "NP exact-capacity list preserves order and the PSAL entry ABI");
+            bool np_exact_canary = true;
+            for (size_t i = 56; i < sizeof(np_exact); ++i) np_exact_canary &= np_exact[i] == 0xAB;
+            CHECK(np_exact_canary, "NP exact-capacity list does not overwrite its tail canary");
+            memset(np_exact, 0xAB, sizeof(np_exact));
+            CHECK(np_list(0, (uint64_t)(uintptr_t)np_exact, 2, 0, 0, 0) == 0 &&
+                  strcmp((char*)np_exact, "00000000000DLC01") == 0,
+                  "NP populated-list call permits the producer-defined optional hitNum");
+
+            alignas(8) uint8_t app_exact[56]; memset(app_exact, 0xAB, sizeof(app_exact));
+            hits = 0;
+            CHECK(app_list(0, (uint64_t)(uintptr_t)app_exact, 2,
+                           (uint64_t)(uintptr_t)&hits, 0, 0) == 0 && hits == 2 &&
+                  strcmp((char*)app_exact, "00000000000DLC01") == 0 &&
+                  *(uint32_t*)(app_exact + 20) == 4 &&
+                  strcmp((char*)app_exact + 24, "00000000000DLC02") == 0 &&
+                  *(uint32_t*)(app_exact + 44) == 4,
+                  "AppContent list writes two 24-byte label/status entries");
+            bool app_exact_canary = true;
+            for (size_t i = 48; i < sizeof(app_exact); ++i) app_exact_canary &= app_exact[i] == 0xAB;
+            CHECK(app_exact_canary, "AppContent exact-capacity list preserves its tail canary");
+
+            const char known_label[20] = "00000000000DLC01";
+            alignas(8) uint8_t one_np[36]; memset(one_np, 0xAB, sizeof(one_np));
+            CHECK(np_info(0, (uint64_t)(uintptr_t)known_label,
+                          (uint64_t)(uintptr_t)one_np, 0, 0, 0) == 0 &&
+                  *(uint32_t*)(one_np + 20) == 2 && *(uint32_t*)(one_np + 24) == 4,
+                  "NP individual info resolves a declared installed label");
+            bool one_np_canary = true;
+            for (size_t i = 28; i < sizeof(one_np); ++i) one_np_canary &= one_np[i] == 0xAB;
+            CHECK(one_np_canary, "NP individual info writes exactly 28 bytes");
+
+            alignas(8) uint8_t one_app[32]; memset(one_app, 0xAB, sizeof(one_app));
+            CHECK(app_info(0, (uint64_t)(uintptr_t)known_label,
+                           (uint64_t)(uintptr_t)one_app, 0, 0, 0) == 0 &&
+                  *(uint32_t*)(one_app + 20) == 4,
+                  "AppContent individual info resolves a declared installed label");
+            bool one_app_canary = true;
+            for (size_t i = 24; i < sizeof(one_app); ++i) one_app_canary &= one_app[i] == 0xAB;
+            CHECK(one_app_canary, "AppContent individual info writes exactly 24 bytes");
+
+            uint8_t expected_key[16];
+            for (uint8_t i = 0; i < 16; ++i) expected_key[i] = i;
+            uint8_t key_out[24]; memset(key_out, 0xAB, sizeof(key_out));
+            CHECK(np_key(0, (uint64_t)(uintptr_t)known_label,
+                         (uint64_t)(uintptr_t)key_out, 0, 0, 0) == 0 &&
+                  memcmp(key_out, expected_key, sizeof(expected_key)) == 0,
+                  "NP entitlement key returns the declared 16 key bytes");
+            bool key_canary = true;
+            for (size_t i = 16; i < sizeof(key_out); ++i) key_canary &= key_out[i] == 0xAB;
+            CHECK(key_canary, "NP entitlement key preserves bytes after its 16-byte output");
+            memset(key_out, 0xAB, sizeof(key_out));
+            CHECK(app_key(0, (uint64_t)(uintptr_t)known_label,
+                          (uint64_t)(uintptr_t)key_out, 0, 0, 0) == 0 &&
+                  memcmp(key_out, expected_key, sizeof(expected_key)) == 0,
+                  "AppContent entitlement key returns the same declared key");
+            key_canary = true;
+            for (size_t i = 16; i < sizeof(key_out); ++i) key_canary &= key_out[i] == 0xAB;
+            CHECK(key_canary, "AppContent entitlement key writes exactly 16 bytes");
+
+            char mount[24]; memset(mount, 0xAB, sizeof(mount));
+            CHECK(app_mount(0, (uint64_t)(uintptr_t)known_label,
+                            (uint64_t)(uintptr_t)mount, 0, 0, 0) == 0 &&
+                  strcmp(mount, "/app0/dlc1") == 0,
+                  "AddcontMount returns only the declared guest mount point");
+            bool mount_canary = true;
+            for (size_t i = sizeof("/app0/dlc1"); i < sizeof(mount); ++i)
+                mount_canary &= (uint8_t)mount[i] == 0xAB;
+            CHECK(mount_canary, "AddcontMount writes only its NUL-terminated path");
+
+            const char licence_label[20] = "00000000000DLC02";
+            memset(mount, 0xAB, sizeof(mount));
+            CHECK(app_mount(0, (uint64_t)(uintptr_t)licence_label,
+                            (uint64_t)(uintptr_t)mount, 0, 0, 0) != 0,
+                  "licence-only add-content cannot invent an undeclared mount point");
+            bool mount_untouched = true;
+            for (char byte : mount) mount_untouched &= (uint8_t)byte == 0xAB;
+            CHECK(mount_untouched, "failed licence-only mount leaves output untouched");
+
+            const char unknown_label[20] = "UNKNOWNADDCONT01";
+            memset(one_np, 0xAB, sizeof(one_np));
+            CHECK(np_info(0, (uint64_t)(uintptr_t)unknown_label,
+                          (uint64_t)(uintptr_t)one_np, 0, 0, 0) == 0x817D0007ull,
+                  "unknown well-formed entitlement label returns NP no-entitlement");
+            bool unknown_untouched = true;
+            for (uint8_t byte : one_np) unknown_untouched &= byte == 0xAB;
+            CHECK(unknown_untouched, "unknown entitlement leaves info output untouched");
+            char malformed_label[20]; memset(malformed_label, 'A', sizeof(malformed_label));
+            CHECK(np_info(0, (uint64_t)(uintptr_t)malformed_label,
+                  (uint64_t)(uintptr_t)one_np, 0, 0, 0) == 0x817D0002ull,
+                  "unterminated entitlement label is rejected as an invalid argument");
+
+            hits = 0xdeadbeef;
+            CHECK(np_list(42, 0, 0, (uint64_t)(uintptr_t)&hits, 0, 0) == 0 && hits == 2,
+                  "wildcard inventory entries are visible to an arbitrary caller service label");
+            hits = 0xdeadbeef;
+            CHECK(np_list(7, 0, 0, (uint64_t)(uintptr_t)&hits, 0, 0) == 0 && hits == 3,
+                  "an explicitly scoped entry is visible only to its declared service label");
+        }
+
+        auto invalid_manifest = [&](const char* text, const char* what) {
+            write_manifest(text);
+            set_app0_root(app0.string());
+            uint32_t np_hits = 0xdeadbeef, app_hits = 0xdeadbeef;
+            const bool rejected = np_list && app_list &&
+                np_list(0, 0, 0, (uint64_t)(uintptr_t)&np_hits, 0, 0) != 0 &&
+                app_list(0, 0, 0, (uint64_t)(uintptr_t)&app_hits, 0, 0) != 0 &&
+                np_hits == 0xdeadbeef && app_hits == 0xdeadbeef;
+            CHECK(rejected, what);
+        };
+        const char* one_record_manifest =
+            "[PSAC]\ncontent_id=UP0000-PPSA00001_00-00000000000DLC01\n"
+            "download_status=INSTALLED\n";
+        invalid_manifest(
+            "[PSAC]\ncontent_id=not-a-content-id\ndownload_status=INSTALLED\n",
+            "malformed content identity invalidates the whole inventory");
+        const std::string oversized_manifest =
+            std::string(one_record_manifest) + "#" + std::string(33 * 1024, 'x');
+        invalid_manifest(oversized_manifest.c_str(),
+                         "manifest beyond the producer size limit is rejected");
+        invalid_manifest(
+            "[PSAC]\ncontent_id=UP0000-PPSA00001_00-00000000000DLC01\n"
+            "download_status=INSTALLED\nmount_point=/app0/../outside\n",
+            "traversal mount point invalidates the whole inventory");
+        invalid_manifest(
+            "[PSAC]\ncontent_id=UP0000-PPSA00001_00-00000000000DLC01\n"
+            "download_status=INSTALLED\nmount_point=/download0/dlc1\n",
+            "non-app0 mount point invalidates the whole inventory");
+        invalid_manifest(
+            "[PSAC]\ncontent_id=UP0000-PPSA00001_00-00000000000DLC01\n"
+            "download_status=INSTALLED\n"
+            "[PSAC]\ncontent_id=JP0000-PPSA00001_00-00000000000DLC01\n"
+            "download_status=INSTALLED\n",
+            "duplicate service/entitlement identity invalidates the whole inventory");
+        invalid_manifest(
+            "[PSAC]\ncontent_id=UP0000-PPSA00001_00-00000000000DLC01\n"
+            "download_status=INSTALLED\ndownload_status=INSTALLED\n",
+            "duplicate manifest property invalidates the whole inventory");
+        invalid_manifest(
+            "[PSAC]\ncontent_id=UP0000-PPSA00001_00-00000000000DLC01\n"
+            "download_status=INSTALLED\nunknown_property=value\n",
+            "unknown manifest property invalidates the whole inventory");
+        invalid_manifest(
+            "[PSAC]\ncontent_id=UP0000-PPSA00001_00-00000000000DLC01\n"
+            "download_status=INSTALLED\nnp_service_label=-2\n",
+            "malformed explicit service label invalidates the whole inventory");
+        invalid_manifest(
+            "[UNKNOWN]\ncontent_id=UP0000-PPSA00001_00-00000000000DLC01\n"
+            "download_status=INSTALLED\n",
+            "unknown manifest section invalidates the whole inventory");
+        invalid_manifest(
+            "[PSAC]\ncontent_id=UP0000-PPSA00001_00-00000000000DLC01\n"
+            "download_status=INSTALLED\nmount_point=/app0/absent\n",
+            "absent declared mount directory invalidates the whole inventory");
+        const fs::path escaped = app0 / "escaped";
+        fs::create_directory_symlink(outside, escaped, ec);
+        if (!ec) {
+            invalid_manifest(
+                "[PSAC]\ncontent_id=UP0000-PPSA00001_00-00000000000DLC01\n"
+                "download_status=INSTALLED\nmount_point=/app0/escaped\n",
+                "symlinked out-of-root mount directory invalidates the whole inventory");
+        }
+
+        auto invalid_param_json = [&](const char* json, const char* what) {
+            {
+                std::ofstream param(app0 / "sce_sys" / "param.json",
+                                    std::ios::binary | std::ios::trunc);
+                param << json;
+            }
+            invalid_manifest(one_record_manifest, what);
+        };
+        invalid_param_json(R"({"nested":{"titleId":"PPSA00001"}})",
+                           "a nested titleId cannot authorize add-content inventory");
+        invalid_param_json(R"({"titleId":"PPSA00001","\u0074itleId":"PPSA00001"})",
+                           "duplicate top-level titleId spellings invalidate app metadata");
+        invalid_param_json(R"({"note":"\"titleId\":\"PPSA00001\""})",
+                           "titleId text inside a JSON string cannot authorize inventory");
+        invalid_param_json(R"({"titleId":"PPSA00001"} trailing)",
+                           "malformed trailing param.json content invalidates inventory");
+        invalid_param_json(R"({"titleId":"PPSA\u003000001"})",
+                           "escaped titleId values are rejected as ambiguous identity input");
+
+        fs::remove(app0 / "dlc_emu.ini", ec);
+        set_app0_root(app0.string());
+        if (np_list && app_list && app_mount) {
+            const char absent_label[20] = "00000000000DLC01";
+            uint32_t hits = 0xdeadbeef;
+            CHECK(np_list(0, 0, 0, (uint64_t)(uintptr_t)&hits, 0, 0) == 0 && hits == 0,
+                  "title without a manifest retains the NP no-DLC count");
+            hits = 0xdeadbeef;
+            CHECK(app_list(0, 0, 0, (uint64_t)(uintptr_t)&hits, 0, 0) == 0 && hits == 0,
+                  "title without a manifest retains the AppContent no-DLC count");
+            char mount[16]; memset(mount, 0xAB, sizeof(mount));
+            CHECK(app_mount(0, (uint64_t)(uintptr_t)absent_label,
+                            (uint64_t)(uintptr_t)mount, 0, 0, 0) != 0,
+                  "title without a manifest has no mount entitlement");
+        }
+        fs::remove_all(scratch, ec);
+    }
+
     // SystemService / AppContent / NP getters: each must WRITE its out-param with the CORRECT value —
     // returning success with an unfilled (or wrong-valued) out is the harmful-stub class whose downstream
     // effects are hard to trace (a 0.0 safe-area ratio collapses the viewport; lang 0 localizes to

--- a/prosper/tests/test_service_getters.cpp
+++ b/prosper/tests/test_service_getters.cpp
@@ -586,6 +586,7 @@ int main() {
         fs::remove_all(scratch, ec);
         fs::create_directories(app0 / "sce_sys", ec);
         fs::create_directories(app0 / "dlc1", ec);
+        fs::create_directories(app0 / "dlc2", ec);
         fs::create_directories(outside, ec);
         {
             std::ofstream param(app0 / "sce_sys" / "param.json", std::ios::binary);
@@ -600,15 +601,15 @@ int main() {
             "content_id=UP0000-PPSA00001_00-00000000000DLC01\n"
             "download_status=INSTALLED\n"
             "mount_point=/app0/dlc1\n"
-            "entitlement_key=000102030405060708090A0B0C0D0E0F\n"
             "[PSAL]\n"
             "content_id=UP0000-PPSA00001_00-00000000000DLC02\n"
             "download_status=INSTALLED\n"
-            "entitlement_key=F0E0D0C0B0A090807060504030201000\n"
+            "mount_point=/app0/dlc2\n"
             "[PSAC]\n"
             "content_id=UP0000-PPSA00001_00-00000000000DLC03\n"
             "download_status=INSTALLED\n"
-            "np_service_label=7\n");
+            "np_service_label=7\n"
+            "entitlement_key=000102030405060708090A0B0C0D0E0F\n");
         set_app0_root(app0.string());
 
         HleFn np_list = Hle::lookup("TFyU+KFBv54");
@@ -638,6 +639,9 @@ int main() {
             CHECK(strcmp((char*)np_short, "00000000000DLC01") == 0 &&
                   *(uint32_t*)(np_short + 20) == 2 && *(uint32_t*)(np_short + 24) == 4,
                   "NP list entry carries the PSAC type and INSTALLED status at the guest offsets");
+            CHECK(np_short[16] == 0 && np_short[17] == 0 && np_short[18] == 0 &&
+                  np_short[19] == 0,
+                  "NP list zero-pads the complete 20-byte entitlement-label object");
             bool np_short_canary = true;
             for (size_t i = 28; i < sizeof(np_short); ++i) np_short_canary &= np_short[i] == 0xAB;
             CHECK(np_short_canary, "NP short-capacity list writes exactly its 28-byte entry");
@@ -666,6 +670,10 @@ int main() {
                   strcmp((char*)app_exact + 24, "00000000000DLC02") == 0 &&
                   *(uint32_t*)(app_exact + 44) == 4,
                   "AppContent list writes two 24-byte label/status entries");
+            CHECK(app_exact[16] == 0 && app_exact[17] == 0 && app_exact[18] == 0 &&
+                  app_exact[19] == 0 && app_exact[40] == 0 && app_exact[41] == 0 &&
+                  app_exact[42] == 0 && app_exact[43] == 0,
+                  "AppContent list zero-pads both complete 20-byte label objects");
             bool app_exact_canary = true;
             for (size_t i = 48; i < sizeof(app_exact); ++i) app_exact_canary &= app_exact[i] == 0xAB;
             CHECK(app_exact_canary, "AppContent exact-capacity list preserves its tail canary");
@@ -689,43 +697,73 @@ int main() {
             for (size_t i = 24; i < sizeof(one_app); ++i) one_app_canary &= one_app[i] == 0xAB;
             CHECK(one_app_canary, "AppContent individual info writes exactly 24 bytes");
 
-            uint8_t expected_key[16];
-            for (uint8_t i = 0; i < 16; ++i) expected_key[i] = i;
+            const uint8_t default_key_0[16] = {0x00, 0x04};
             uint8_t key_out[24]; memset(key_out, 0xAB, sizeof(key_out));
             CHECK(np_key(0, (uint64_t)(uintptr_t)known_label,
                          (uint64_t)(uintptr_t)key_out, 0, 0, 0) == 0 &&
-                  memcmp(key_out, expected_key, sizeof(expected_key)) == 0,
-                  "NP entitlement key returns the declared 16 key bytes");
+                  memcmp(key_out, default_key_0, sizeof(default_key_0)) == 0,
+                  "NP entitlement key synthesizes producer default 1024 for accepted record zero");
             bool key_canary = true;
             for (size_t i = 16; i < sizeof(key_out); ++i) key_canary &= key_out[i] == 0xAB;
             CHECK(key_canary, "NP entitlement key preserves bytes after its 16-byte output");
             memset(key_out, 0xAB, sizeof(key_out));
             CHECK(app_key(0, (uint64_t)(uintptr_t)known_label,
                           (uint64_t)(uintptr_t)key_out, 0, 0, 0) == 0 &&
-                  memcmp(key_out, expected_key, sizeof(expected_key)) == 0,
-                  "AppContent entitlement key returns the same declared key");
+                  memcmp(key_out, default_key_0, sizeof(default_key_0)) == 0,
+                  "AppContent entitlement key returns the same producer-default key");
             key_canary = true;
             for (size_t i = 16; i < sizeof(key_out); ++i) key_canary &= key_out[i] == 0xAB;
             CHECK(key_canary, "AppContent entitlement key writes exactly 16 bytes");
 
-            char mount[24]; memset(mount, 0xAB, sizeof(mount));
+            const char second_label[20] = "00000000000DLC02";
+            const uint8_t default_key_1[16] = {0x01, 0x04};
+            memset(key_out, 0xAB, sizeof(key_out));
+            CHECK(np_key(0, (uint64_t)(uintptr_t)second_label,
+                         (uint64_t)(uintptr_t)key_out, 0, 0, 0) == 0 &&
+                  memcmp(key_out, default_key_1, sizeof(default_key_1)) == 0,
+                  "default entitlement keys advance by accepted inventory-record index");
+
+            const char explicit_label[20] = "00000000000DLC03";
+            uint8_t explicit_key[16];
+            for (uint8_t i = 0; i < 16; ++i) explicit_key[i] = i;
+            memset(key_out, 0xAB, sizeof(key_out));
+            CHECK(np_key(7, (uint64_t)(uintptr_t)explicit_label,
+                         (uint64_t)(uintptr_t)key_out, 0, 0, 0) == 0 &&
+                  memcmp(key_out, explicit_key, sizeof(explicit_key)) == 0,
+                  "an explicit manifest entitlement key overrides the producer default");
+
+            uint8_t mount[24]; memset(mount, 0xAB, sizeof(mount));
+            CHECK(app_mount(0, (uint64_t)(uintptr_t)known_label, 0x10000, 0, 0, 0) ==
+                  0x80D90002ull,
+                  "an unwritable mount output is rejected without consuming the mount state");
             CHECK(app_mount(0, (uint64_t)(uintptr_t)known_label,
                             (uint64_t)(uintptr_t)mount, 0, 0, 0) == 0 &&
-                  strcmp(mount, "/app0/dlc1") == 0,
-                  "AddcontMount returns only the declared guest mount point");
+                  strcmp((char*)mount, "/app0/dlc1") == 0,
+                  "AddcontMount returns the declared PSAC guest mount point");
+            bool mount_object_zero = true;
+            for (size_t i = sizeof("/app0/dlc1") - 1; i < 16; ++i)
+                mount_object_zero &= mount[i] == 0;
+            CHECK(mount_object_zero,
+                  "AddcontMount writes a complete zero-padded 16-byte mount-point object");
             bool mount_canary = true;
-            for (size_t i = sizeof("/app0/dlc1"); i < sizeof(mount); ++i)
-                mount_canary &= (uint8_t)mount[i] == 0xAB;
-            CHECK(mount_canary, "AddcontMount writes only its NUL-terminated path");
+            for (size_t i = 16; i < sizeof(mount); ++i) mount_canary &= mount[i] == 0xAB;
+            CHECK(mount_canary, "AddcontMount preserves bytes beyond its 16-byte output");
 
-            const char licence_label[20] = "00000000000DLC02";
             memset(mount, 0xAB, sizeof(mount));
-            CHECK(app_mount(0, (uint64_t)(uintptr_t)licence_label,
-                            (uint64_t)(uintptr_t)mount, 0, 0, 0) != 0,
-                  "licence-only add-content cannot invent an undeclared mount point");
+            CHECK(app_mount(0, (uint64_t)(uintptr_t)known_label,
+                            (uint64_t)(uintptr_t)mount, 0, 0, 0) == 0x80D90003ull,
+                  "a repeated mount of the same PSAC returns AppContent BUSY");
+            bool repeat_untouched = true;
+            for (uint8_t byte : mount) repeat_untouched &= byte == 0xAB;
+            CHECK(repeat_untouched, "a BUSY mount leaves the output object untouched");
+
+            memset(mount, 0xAB, sizeof(mount));
+            CHECK(app_mount(0, (uint64_t)(uintptr_t)second_label,
+                            (uint64_t)(uintptr_t)mount, 0, 0, 0) == 0x80D90005ull,
+                  "PSAL remains non-mountable even when its manifest declares a path");
             bool mount_untouched = true;
-            for (char byte : mount) mount_untouched &= (uint8_t)byte == 0xAB;
-            CHECK(mount_untouched, "failed licence-only mount leaves output untouched");
+            for (uint8_t byte : mount) mount_untouched &= byte == 0xAB;
+            CHECK(mount_untouched, "a non-mountable PSAL leaves mount output untouched");
 
             const char unknown_label[20] = "UNKNOWNADDCONT01";
             memset(one_np, 0xAB, sizeof(one_np));
@@ -735,10 +773,48 @@ int main() {
             bool unknown_untouched = true;
             for (uint8_t byte : one_np) unknown_untouched &= byte == 0xAB;
             CHECK(unknown_untouched, "unknown entitlement leaves info output untouched");
+            memset(mount, 0xAB, sizeof(mount));
+            CHECK(app_mount(0, (uint64_t)(uintptr_t)unknown_label,
+                            (uint64_t)(uintptr_t)mount, 0, 0, 0) == 0x80D90005ull,
+                  "unknown well-formed AddcontMount labels return AppContent NOT_FOUND");
+            bool unknown_mount_untouched = true;
+            for (uint8_t byte : mount) unknown_mount_untouched &= byte == 0xAB;
+            CHECK(unknown_mount_untouched, "unknown mount leaves its output object untouched");
             char malformed_label[20]; memset(malformed_label, 'A', sizeof(malformed_label));
             CHECK(np_info(0, (uint64_t)(uintptr_t)malformed_label,
                   (uint64_t)(uintptr_t)one_np, 0, 0, 0) == 0x817D0002ull,
                   "unterminated entitlement label is rejected as an invalid argument");
+
+            char padded_label[20]{};
+            memcpy(padded_label, known_label, sizeof(padded_label));
+            padded_label[17] = 1;
+            memset(one_np, 0xAB, sizeof(one_np));
+            CHECK(np_info(0, (uint64_t)(uintptr_t)padded_label,
+                          (uint64_t)(uintptr_t)one_np, 0, 0, 0) == 0x817D0002ull,
+                  "nonzero entitlement-label tail padding is rejected as an invalid argument");
+            bool padded_info_untouched = true;
+            for (uint8_t byte : one_np) padded_info_untouched &= byte == 0xAB;
+            CHECK(padded_info_untouched, "invalid label padding leaves info output untouched");
+            memset(mount, 0xAB, sizeof(mount));
+            CHECK(app_mount(0, (uint64_t)(uintptr_t)padded_label,
+                            (uint64_t)(uintptr_t)mount, 0, 0, 0) == 0x80D90002ull,
+                  "AddcontMount also validates all 20 bytes of the input label object");
+            bool padded_mount_untouched = true;
+            for (uint8_t byte : mount) padded_mount_untouched &= byte == 0xAB;
+            CHECK(padded_mount_untouched, "invalid label padding leaves mount output untouched");
+
+            memset(np_exact, 0xAB, sizeof(np_exact));
+            hits = 0xdeadbeef;
+            CHECK(np_list(0, (uint64_t)(uintptr_t)np_exact, 2501,
+                          (uint64_t)(uintptr_t)&hits, 0, 0) == 0x817D0002ull,
+                  "NP add-content list rejects capacities above its exact 2500-entry ABI maximum");
+            bool over_max_untouched = hits == 0xdeadbeef;
+            for (uint8_t byte : np_exact) over_max_untouched &= byte == 0xAB;
+            CHECK(over_max_untouched,
+                  "NP over-maximum rejection occurs before either guest output is written");
+            hits = 0xdeadbeef;
+            CHECK(np_list(0, 0, 2500, (uint64_t)(uintptr_t)&hits, 0, 0) == 0 && hits == 2,
+                  "NP add-content list accepts its exact 2500-entry boundary");
 
             hits = 0xdeadbeef;
             CHECK(np_list(42, 0, 0, (uint64_t)(uintptr_t)&hits, 0, 0) == 0 && hits == 2,
@@ -748,8 +824,37 @@ int main() {
                   "an explicitly scoped entry is visible only to its declared service label");
         }
 
-        auto invalid_manifest = [&](const char* text, const char* what) {
-            write_manifest(text);
+        // Sonic's real producer manifest has four installed PSAC records and omits every key.
+        // Pin that exact shape so a future parser cannot make missing keys read as no entitlement.
+        write_manifest(
+            "[PSAC]\ncontent_id=UP0000-PPSA00001_00-00000000000DLC01\n"
+            "download_status=INSTALLED\n"
+            "[PSAC]\ncontent_id=UP0000-PPSA00001_00-00000000000DLC02\n"
+            "download_status=INSTALLED\n"
+            "[PSAC]\ncontent_id=UP0000-PPSA00001_00-00000000000DLC03\n"
+            "download_status=INSTALLED\n"
+            "[PSAC]\ncontent_id=UP0000-PPSA00001_00-00000000000DLC04\n"
+            "download_status=INSTALLED\n");
+        set_app0_root(app0.string());
+        if (np_list && np_key) {
+            uint32_t hits = 0xdeadbeef;
+            CHECK(np_list(0, 0, 0, (uint64_t)(uintptr_t)&hits, 0, 0) == 0 && hits == 4,
+                  "Sonic-shaped keyless PSAC inventory enumerates all four accepted records");
+            bool all_default_keys = true;
+            for (uint8_t index = 0; index < 4; ++index) {
+                char label[20] = "00000000000DLC01";
+                label[15] = static_cast<char>('1' + index);
+                uint8_t key[16]; memset(key, 0xAB, sizeof(key));
+                const uint8_t expected[16] = {index, 0x04};
+                all_default_keys &= np_key(0, (uint64_t)(uintptr_t)label,
+                                           (uint64_t)(uintptr_t)key, 0, 0, 0) == 0;
+                all_default_keys &= memcmp(key, expected, sizeof(expected)) == 0;
+            }
+            CHECK(all_default_keys,
+                  "Sonic-shaped keyless records receive producer defaults 1024 through 1027");
+        }
+
+        auto inventory_rejected = [&](const char* what) {
             set_app0_root(app0.string());
             uint32_t np_hits = 0xdeadbeef, app_hits = 0xdeadbeef;
             const bool rejected = np_list && app_list &&
@@ -757,6 +862,10 @@ int main() {
                 app_list(0, 0, 0, (uint64_t)(uintptr_t)&app_hits, 0, 0) != 0 &&
                 np_hits == 0xdeadbeef && app_hits == 0xdeadbeef;
             CHECK(rejected, what);
+        };
+        auto invalid_manifest = [&](const char* text, const char* what) {
+            write_manifest(text);
+            inventory_rejected(what);
         };
         const char* one_record_manifest =
             "[PSAC]\ncontent_id=UP0000-PPSA00001_00-00000000000DLC01\n"
@@ -829,6 +938,49 @@ int main() {
                            "malformed trailing param.json content invalidates inventory");
         invalid_param_json(R"({"titleId":"PPSA\u003000001"})",
                            "escaped titleId values are rejected as ambiguous identity input");
+
+        // Restore real metadata before probing filesystem identity failures.
+        {
+            std::ofstream param(app0 / "sce_sys" / "param.json",
+                                std::ios::binary | std::ios::trunc);
+            param << R"({"titleId":"PPSA00001"})";
+        }
+        fs::remove(app0 / "dlc_emu.ini", ec);
+        ec.clear();
+        fs::create_directory(app0 / "dlc_emu.ini", ec);
+        if (!ec) {
+            inventory_rejected(
+                "a wrong-type manifest path fails visibly instead of becoming an empty inventory");
+            fs::remove(app0 / "dlc_emu.ini", ec);
+        }
+
+        ec.clear();
+        fs::create_symlink("missing-manifest-target", app0 / "dlc_emu.ini", ec);
+        if (!ec) {
+            inventory_rejected(
+                "a dangling manifest symlink fails visibly instead of becoming no manifest");
+            fs::remove(app0 / "dlc_emu.ini", ec);
+        }
+
+        write_manifest(one_record_manifest);
+        {
+            std::ofstream external_param(outside / "param.json",
+                                         std::ios::binary | std::ios::trunc);
+            external_param << R"({"titleId":"PPSA00001"})";
+        }
+        fs::remove(app0 / "sce_sys" / "param.json", ec);
+        ec.clear();
+        fs::create_symlink(outside / "param.json", app0 / "sce_sys" / "param.json", ec);
+        if (!ec) {
+            inventory_rejected(
+                "param.json symlinked outside app0 fails visibly despite valid target contents");
+            fs::remove(app0 / "sce_sys" / "param.json", ec);
+        }
+        {
+            std::ofstream param(app0 / "sce_sys" / "param.json",
+                                std::ios::binary | std::ios::trunc);
+            param << R"({"titleId":"PPSA00001"})";
+        }
 
         fs::remove(app0 / "dlc_emu.ini", ec);
         set_app0_root(app0.string());


### PR DESCRIPTION
Closes #1909.

## Problem

Prosper globally returned an empty add-content list and unconditional no-entitlement from mount calls. That was truthful for the original no-DLC title, but it hid locally installed DLC from every other title. Sonic Origins Plus declares four installed PSAC records and therefore stopped after its count query when Prosper wrote zero.

## What changed

- Parse the installed add-content subset of `/app0/dlc_emu.ini` when `/app0` is configured.
- Cross-check each content ID against the one unique top-level `titleId` in `sce_sys/param.json`.
- Bound input to the producer's 32 KiB / 1024-entry limits and publish records only after the complete inventory validates.
- Accept installed `[PSAC]` / `[PSAL]` records with `content_id`, `download_status`, optional `mount_point`, optional 16-byte `entitlement_key`, and optional `np_service_label`.
- Preserve the producer-defined absent/`-1` service-label wildcard while keeping explicitly declared service labels scoped.
- Reject malformed/foreign identities, duplicate labels/content IDs/mount points/properties, unknown fields/sections, malformed keys/service labels, traversal, absent mount directories, and canonical/symlink escapes. Diagnostics never expose the host root.
- Implement bounded AppContent and NpEntitlementAccess list/info/key calls plus AppContent mount. Unknown records fail with the correct subsystem error and leave outputs untouched.
- Preserve `SUCCESS + hitNum=0` and no-entitlement for titles with no manifest. A present but invalid manifest fails visibly rather than masquerading as no DLC.

This intentionally implements the installed PSAC/PSAL subset exercised by the local inventories. Other dlc_emu surfaces are rejected rather than silently guessed.

## ABI and producer evidence

- Sonic's guest call sites allocate exactly `count * 0x1c` for NP entries, consume the label at `+0`, and read installed status `4` at `+0x18`.
- Crisis Core independently allocates the same 28-byte NP stride and consumes exactly 16 bytes from a successful entitlement-key output.
- AppContent info is the 24-byte label/status prefix; mount output is a 16-byte mount-point object.
- The pinned dlc_emu producer defines PSAC/PSAL package types as 2/3, omitted `np_service_label` as wildcard, and the installed status as 4: [configuration contract](https://github.com/drakmor/dlc_emu/blob/43ae9aa406214d04cbb54c409e712ceb64f1f867/README.md#L17-L96).
- Its AppContent and NP list implementations write at most `listNum` entries while reporting the full matching total in `hitNum`: [AppContent list](https://github.com/drakmor/dlc_emu/blob/43ae9aa406214d04cbb54c409e712ceb64f1f867/src/dlc_modules/dlc_content.cpp#L1940-L1967), [NP list/info](https://github.com/drakmor/dlc_emu/blob/43ae9aa406214d04cbb54c409e712ceb64f1f867/src/dlc_modules/dlc_content.cpp#L2356-L2406).
- The NP EntitlementAccess parameter/no-entitlement values are `0x817D0002` / `0x817D0007`: [pinned definitions and real-call notes](https://github.com/idlesauce/ps4-eboot-dlc-patcher/blob/d1d1e0f0dbd5e06da45b7d8f8ca1827d34546692/prx_src/libSceNpEntitlementAccess.h#L8-L65).

## Validation

Post-rebase head: `e1522b97d7319e38be51b31264fa59e7d992bbdf` on `origin/master` `388f43fa83240dfa9659bc879c128549163b7204`.

```text
distrobox enter ps5ys -- bash -lc 'cd <WORKTREE>/prosper && \
  TMPDIR=<WORKTREE>/prosper/build-linux/tmpdir \
  cmake --build build-linux --target test_service_getters -j4 && \
  ctest --test-dir build-linux -R "^service_getters$" --output-on-failure'

1/1 Test #36: service_getters ... Passed
100% tests passed, 0 tests failed out of 1
```

The focused test covers count queries, optional `hitNum` on populated calls, short and exact capacities, producer-defined full-count semantics, 28/24/16-byte output canaries, package/status offsets, wildcard and explicit service scoping, individual info, keys, mounts, unknown/malformed labels, no-manifest behavior, foreign IDs, oversize input, duplicate declarations, malformed keys/service labels, unknown fields/sections, traversal, missing directories, symlink escape, and strict top-level `titleId` parsing.

Behavior-level mutation proof:

- Clearing published entries made the named installed-count, entitlement-key, and mount checks fail.
- Reporting `written` rather than `total` made the short-capacity full-count check fail.
- Bypassing param JSON validation made all five nested/duplicate/string-contained/trailing/escaped identity checks fail.
- Restoring the earlier guessed package values 0/1 made the PSAC, PSAL, and individual-info checks fail.
- Treating an omitted service label as 0 made both wildcard and explicit-scope checks fail.

- Corrected-head review mutations also proved fail-visible dangling-manifest handling, outside `param.json` symlink rejection, producer-default keys, reserved label padding, full 16-byte mount output, PSAC-only/repeat-mount state, and the exact NP list maximum.
All mutations were reverted and the focused suite was rerun green.

## Sonic CPU-only evidence

A bounded run with guest FS and direct graphics arguments, `PROSPER_SVCLOG=1`, `PROSPER_NO_COMPUTE=1`, no renderer, and frame dumps disabled now shows:

1. `sceNpEntitlementAccessGetAddcontEntitlementInfoList(service=0, list=NULL, listNum=0, ...)`
2. A follow-up call with a real buffer and `listNum=4`

The second call proves the guest consumed the count `4`; on unmodified master it stopped after the count query because Prosper wrote zero. No mount call appeared in the bounded CPU-only run, so this PR claims installed enumeration is unblocked, not that Sonic has mounted or rendered DLC.

No GPU execution or snapshot suite was used for this focused ordinary-development PR.