### PR TITLE
Fix Vulkan readback invalidation mapping range

### DIFF
--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -2196,6 +2196,20 @@ inline size_t invalidate_persistent_ds_guest_write(uint64_t addr, uint64_t size)
     return invalidated;
 }
 
+struct MappedReadbackPlan {
+    VkDeviceSize map_size = 0;
+    VkDeviceSize invalidate_size = 0;
+};
+
+// VK_WHOLE_SIZE invalidates through the end of the CURRENT MAPPING, not unconditionally through the
+// allocation. That mapping end must be atom-aligned or equal the allocation end (VUID 01389). Map the
+// whole allocation as well, so the pair remains valid when a logical readback is shorter than its
+// VkMemoryRequirements allocation (the observed shape is 60 logical bytes in a 64-byte allocation).
+constexpr MappedReadbackPlan mapped_readback_plan(VkDeviceSize logical_bytes) {
+    return logical_bytes ? MappedReadbackPlan{VK_WHOLE_SIZE, VK_WHOLE_SIZE}
+                         : MappedReadbackPlan{};
+}
+
 // Make device writes visible before the CPU reads a mapped readback buffer. A HOST_CACHED memory
 // type is not required to also be HOST_COHERENT, so every mapped READ of a TRANSFER_DST buffer must
 // invalidate first. Specified as valid on coherent memory too, so callers can invoke it
@@ -2203,12 +2217,13 @@ inline size_t invalidate_persistent_ds_guest_write(uint64_t addr, uint64_t size)
 // NOTE: this header contains a second readback allocator that requires HOST_COHERENT in every tier,
 // so its mapped reads need no invalidate. Keep that requirement, or route its reads through this
 // helper too -- relaxing it without adding invalidates would silently return stale bytes.
-inline bool invalidate_mapped_readback(const RenderVkCtx& ctx, VkDeviceMemory memory) {
-    if (!memory) return false;
+inline bool invalidate_mapped_readback(const RenderVkCtx& ctx, VkDeviceMemory memory,
+                                       const MappedReadbackPlan& plan) {
+    if (!memory || !plan.invalidate_size) return false;
     VkMappedMemoryRange range{VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE};
     range.memory = memory;
     range.offset = 0;
-    range.size = VK_WHOLE_SIZE;   // VK_WHOLE_SIZE is exempt from the nonCoherentAtomSize size rule
+    range.size = plan.invalidate_size;
     return vkInvalidateMappedMemoryRanges(ctx.dev, 1, &range) == VK_SUCCESS;
 }
 
@@ -2471,11 +2486,12 @@ inline bool readback_persistent_color_target(uint64_t id, uint32_t width, uint32
         else backend_mark_unproven_submission();
         error = "persistent color target readback did not complete"; return false;
     }
+    const MappedReadbackPlan mapping = mapped_readback_plan(bytes);
     void* mapped = nullptr;
-    if (vkMapMemory(ctx.dev, memory, 0, bytes, 0, &mapped) != VK_SUCCESS || !mapped) {
+    if (vkMapMemory(ctx.dev, memory, 0, mapping.map_size, 0, &mapped) != VK_SUCCESS || !mapped) {
         cleanup(); error = "cannot map persistent color target readback"; return false;
     }
-    if (!invalidate_mapped_readback(ctx, memory)) {
+    if (!invalidate_mapped_readback(ctx, memory, mapping)) {
         vkUnmapMemory(ctx.dev, memory);
         cleanup(); error = "cannot invalidate persistent color target readback"; return false;
     }
@@ -2715,10 +2731,12 @@ inline bool snapshot_persistent_ds_images(std::vector<prosper::gpu::GpuCaptureDs
             }
             return false;
         }
+        const MappedReadbackPlan mapping =
+            mapped_readback_plan(depth_bytes + stencil_bytes);
         void* mapped = nullptr;
         const bool mapped_ok =
-            vkMapMemory(ctx.dev, memory, 0, depth_bytes + stencil_bytes, 0, &mapped) == VK_SUCCESS;
-        const bool invalidated = mapped_ok && invalidate_mapped_readback(ctx, memory);
+            vkMapMemory(ctx.dev, memory, 0, mapping.map_size, 0, &mapped) == VK_SUCCESS;
+        const bool invalidated = mapped_ok && invalidate_mapped_readback(ctx, memory, mapping);
         if (invalidated) {
             const auto* bytes = static_cast<const uint8_t*>(mapped);
             seed.depth.assign(bytes, bytes + depth_bytes);

--- a/prosper/tests/test_gpu_capture_render.cpp
+++ b/prosper/tests/test_gpu_capture_render.cpp
@@ -50,6 +50,20 @@ static void unset_env(const char* name) {
 #endif
 }
 
+constexpr bool mapped_readback_plan_satisfies_vuid_01389(
+        prosper::test::MappedReadbackPlan plan, VkDeviceSize allocation,
+        VkDeviceSize atom) {
+    if (!plan.map_size || !plan.invalidate_size || !allocation || !atom)
+        return false;
+    const VkDeviceSize mapping_end =
+        plan.map_size == VK_WHOLE_SIZE ? allocation : plan.map_size;
+    if (mapping_end > allocation) return false;
+    if (plan.invalidate_size == VK_WHOLE_SIZE)
+        return mapping_end == allocation || mapping_end % atom == 0;
+    return plan.invalidate_size <= mapping_end &&
+           (plan.invalidate_size == allocation || plan.invalidate_size % atom == 0);
+}
+
 int main() {
     // buffer_upload_bytes caches this override on first use. Reset it before the renderer can build
     // any buffer resource so the test always exercises the production default ceiling.
@@ -999,6 +1013,25 @@ int main() {
     CHECK(!read_gpu_capture_rtt_seed(fp16_history.guest_addr, retained_history, error) &&
           error == "render target is absent from live cache",
           "overlapping guest GPU write invalidates stale CPU FP16 history");
+
+    // #1717: this checkpoint is the exact defect shape on RADV: 4x3 D32S8 is 48 depth + 12
+    // stencil = 60 logical bytes, VkMemoryRequirements rounds the allocation to 64, and the device's
+    // nonCoherentAtomSize is 64. Invalidating VK_WHOLE_SIZE after mapping only 60 bytes violates
+    // VUID 01389; mapping the whole allocation makes its end equal the memory-object end.
+    {
+        using prosper::test::MappedReadbackPlan;
+        using prosper::test::mapped_readback_plan;
+        constexpr VkDeviceSize logical_bytes = 60;
+        constexpr VkDeviceSize allocation_bytes = 64;
+        constexpr VkDeviceSize atom_bytes = 64;
+        constexpr MappedReadbackPlan old_defect{logical_bytes, VK_WHOLE_SIZE};
+        constexpr MappedReadbackPlan fixed = mapped_readback_plan(logical_bytes);
+        CHECK(!mapped_readback_plan_satisfies_vuid_01389(
+                  old_defect, allocation_bytes, atom_bytes) &&
+                  mapped_readback_plan_satisfies_vuid_01389(
+                      fixed, allocation_bytes, atom_bytes),
+              "60-byte D32S8 readback maps through the 64-byte allocation end before invalidation");
+    }
 
     GpuCaptureDsSeed ds_seed;
     ds_seed.depth_read_base = ds_seed.depth_write_base = 0x810000;

--- a/prosper/tools/vkval/README.md
+++ b/prosper/tools/vkval/README.md
@@ -76,14 +76,12 @@ which.
 
 Checking each id separately is what catches a *partial* break. An all-absent check alone passes a
 VUID rename, or a framing change that affects some message shapes and not others, while silently
-halving what the guard can see. The two ids that genuinely cannot appear everywhere are marked
-`environment-dependent` and say why on their reason line, so the exemption is written down rather
+halving what the guard can see. The id that genuinely cannot appear everywhere is marked
+`environment-dependent` and says why on its reason line, so the exemption is written down rather
 than assumed:
 
 * `VUID-vkCmdDispatch-maintenance4-08602` is a newer check than validation layers 1.3.275, which is
-  what Ubuntu 24.04 (the CI runner) carries;
-* `VUID-VkMappedMemoryRange-size-01389` cannot trigger on lavapipe at all, whose
-  `nonCoherentAtomSize` is 1 — it was only seen on RADV.
+  what Ubuntu 24.04 (the CI runner) carries.
 
 Deleting the last allow-list entry — the intended end state — switches the check off.
 

--- a/prosper/tools/vkval/allowlist.txt
+++ b/prosper/tools/vkval/allowlist.txt
@@ -6,10 +6,10 @@
 #     fixed — delete the line, in the same change — or the scan stopped seeing things, and the
 #     second is far more likely. Both are failures until someone says which.
 #   * `environment-dependent` exempts an id from that check, and its reason line must say WHY it
-#     can be absent. Two entries below qualify; nothing else may without an argument. That is
-#     enforced, not merely asked: ctest `vkval_scan_logic` asserts this file holds exactly TWO
-#     environment-dependent entries, so flipping a `required` id to duck a failure breaks a test in
-#     another file. Adding a genuine third means editing that assertion, deliberately — the friction
+#     can be absent. One entry below qualifies; nothing else may without an argument. That is
+#     enforced, not merely asked: ctest `vkval_scan_logic` asserts this file holds exactly ONE
+#     environment-dependent entry, so flipping a `required` id to duck a failure breaks a test in
+#     another file. Adding a genuine second means editing that assertion, deliberately — the friction
 #     is the point.
 #   * The test list must be the UNION across drivers. Attribution varies: an id can reach one extra
 #     test on hardware and never on lavapipe, and a test the ledger does not record is a failure.
@@ -33,14 +33,17 @@
 #     driver, reproduced in `podman run --rm ubuntu:24.04`):  7 ids, 187 messages, 168/168 pass
 #   Fedora 44 / validation layers 1.4.341.0 / Mesa 26.1.4 RADV (STRIX_HALO):  9 ids, 51 messages
 #
-# The two ids the CI environment does not produce are the two marked environment-dependent. Neither
-# is absent because it was fixed: `maintenance4-08602` is a newer check than layers 1.3.275, and
-# `size-01389` cannot trigger on lavapipe, whose nonCoherentAtomSize is 1. Both are real on hardware.
+# The id the CI environment does not produce is marked environment-dependent. It is not absent
+# because it was fixed: `maintenance4-08602` is a newer check than layers 1.3.275.
 #
 # Amended by #1726, which FIXED `VUID-VkShaderModuleCreateInfo-pCode-08737` and deleted its entry:
 # the baseline is now 6 ids on the CI runner and 8 on Fedora/RADV (measured there at 49 messages).
 # Recorded because this header is what a future scan is compared against, and the rules below call
 # an unexplained id-count drop far more likely to be the scan breaking than a defect being fixed.
+#
+# Amended by #1717, which FIXED `VUID-VkMappedMemoryRange-size-01389` and deleted its hardware-only
+# entry. The exact 60-byte mapping mutation reproduced one finding on RADV; the fixed whole-allocation
+# mapping produced none. The ledger is therefore now 6 ids on the CI runner and 7 on Fedora/RADV.
 
 # ---- #1710: compute pipeline layout has no push-constant range, and nothing is ever pushed -----
 VUID-VkComputePipelineCreateInfo-layout-07987 | required | game_compute_exec, game_compute_exec_no_adaptive_storage_result | Compute module declares a PushConstant block while the layout declares no range (#1710)
@@ -61,6 +64,3 @@ VUID-VkPipelineShaderStageCreateInfo-stage-00715 | required | interp_render | Th
 # ---- #1716: present_blit fixture transitions a transfer-only image to SHADER_READ_ONLY_OPTIMAL --
 # 168 of the CI environment's 187 messages; the test's own header asked for this check.
 VUID-VkImageMemoryBarrier-oldLayout-01211 | required | present_blit | Fixture source images lack SAMPLED_BIT but are transitioned to SHADER_READ_ONLY_OPTIMAL (#1716)
-
-# ---- #1717: VK_WHOLE_SIZE invalidate over a non-atom-aligned mapping ----------------------------
-VUID-VkMappedMemoryRange-size-01389 | environment-dependent | gpu_capture_render_replay | invalidate_mapped_readback assumes VK_WHOLE_SIZE is exempt from the mapping-end alignment rule; it is not (#1717). Cannot trigger on lavapipe, whose nonCoherentAtomSize is 1, so every range is trivially aligned there.

--- a/prosper/tools/vkval/test_vk_validation_scan.py
+++ b/prosper/tools/vkval/test_vk_validation_scan.py
@@ -272,8 +272,8 @@ def main():
         real = scan.parse_allowlist(Path(__file__).resolve().parent / "allowlist.txt")
         check(len(real) >= 1 and all(a.reason and a.tests for a in real.values()),
               "the checked-in allowlist.txt parses, and every entry carries tests and a reason")
-        check(sum(1 for a in real.values() if a.expectation == "environment-dependent") == 2,
-              "exactly two checked-in entries claim to be environment-dependent")
+        check(sum(1 for a in real.values() if a.expectation == "environment-dependent") == 1,
+              "exactly one checked-in entry claims to be environment-dependent")
 
     # The guard must not read its own tail. ctest captures this test's stdout into the same
     # LastTest.log that vk_validation_scan.py parses, so anything printed here that LOOKS like a

--- a/prosper/tools/vkval/vk_validation_scan.py
+++ b/prosper/tools/vkval/vk_validation_scan.py
@@ -312,8 +312,8 @@ def main(argv: list[str]) -> int:
     # Checking each `required` id separately rather than only the all-absent case is what catches a
     # PARTIAL break: a rename or a framing change that affects some message shapes and not others
     # would otherwise pass while silently halving what the guard can see. `environment-dependent`
-    # entries are exempt, and their reason line has to say why (lavapipe's nonCoherentAtomSize, a
-    # check newer than layers 1.3.275) — the exemption is written down, not assumed.
+    # entries are exempt, and their reason line has to say why (currently a check newer than layers
+    # 1.3.275) — the exemption is written down, not assumed.
     if absent_required:
         print()
         print(f"[vkval] FAIL: {len(absent_required)} allow-listed id(s) marked `required` produced "


### PR DESCRIPTION
Fixes #1717.

## Root cause

`invalidate_mapped_readback` used `VK_WHOLE_SIZE`, but its callers mapped only the logical buffer bytes. Vulkan defines that invalidate size relative to the end of the current mapping. On RADV, the exercised 4×3 D32S8 checkpoint maps 60 logical bytes from a 64-byte allocation while `nonCoherentAtomSize` is 64, so the mapping end is neither atom-aligned nor the memory-object end (`VUID-VkMappedMemoryRange-size-01389`). An invalid invalidate is not required to make device writes visible to the CPU.

## What changed

- Pair whole-size invalidation with a whole-allocation mapping through one production `MappedReadbackPlan`.
- Use that plan for both persistent color-target and depth/stencil checkpoint readbacks; logical copy sizes remain unchanged.
- Pin the exact 60-byte mapping / 64-byte allocation / 64-byte atom defect shape, including the invalid old plan as a negative control.
- Remove the now-fixed hardware-only VUID from the visible Vulkan-validation ledger and update its environment-dependent count/documentation.

## Behavioral contract

The mapping now extends through the allocation end, making `VK_WHOLE_SIZE` valid without adding allocation-size or atom-rounding state to the callers. The buffer allocation, selected memory type, GPU copy extent, bytes exposed to captures, and coherent-memory behavior are unchanged. No title-specific behavior or silent fallback is introduced.

## Validation

Exact head: `8c380fb8abcd1c21aa5e0cf890f966e3e2555187`

Exact base: `e8d617619a1d10c07ddef12d1fa3557ef0f8d0b5`

The rebase from `7302a76067b23625f2daf69ba84df911886daf76` was mechanical: the stable patch ID stayed `71410dbd5f8540a6f533096a9faadef6d97e385e`, and `git range-diff` reports the old and new commits as identical.

```text
distrobox enter ps5ys -- bash -lc '
  TMPDIR=$PWD/prosper/build-linux/tmpdir \
  cmake --build prosper/build-linux -j6 --target test_gpu_capture_render
'
  built

VK_DRIVER_FILES=<LAVAPIPE_ICD> \
VK_LOADER_LAYERS_ENABLE=VK_LAYER_KHRONOS_validation \
VK_INSTANCE_LAYERS=VK_LAYER_KHRONOS_validation \
ctest --test-dir prosper/build-linux --timeout 120 --output-on-failure \
  -R '^gpu_capture_render_replay$'
  Khronos validation instance and device layers visibly inserted
  Vulkan device: llvmpipe (CPU)
  1/1 passed
  named 60/64/64 regression: passed
  VUID-VkMappedMemoryRange-size-01389: 0

ctest --test-dir prosper/build-linux --output-on-failure -R '^vkval_scan_logic$'
  1/1 passed

git diff --check origin/master...HEAD
  clean
```

The Vulkan patch at this rebased head has the same stable patch ID as the source checked on RADV STRIX_HALO with the validation layer visibly inserted:

```text
fixed whole-allocation plan:
  gpu_capture_render_replay 1/1 passed
  named 60/64/64 regression: passed
  VUID-VkMappedMemoryRange-size-01389: 0

temporary old-plan mutation {logical_bytes, VK_WHOLE_SIZE}:
  named 60/64/64 regression: failed
  VUID-VkMappedMemoryRange-size-01389: reproduced

restored fixed plan:
  gpu_capture_render_replay 1/1 passed
  named 60/64/64 regression: passed
  VUID-VkMappedMemoryRange-size-01389: 0
```

No snapshot suite was run: this is a focused Vulkan readback-contract fix, not a release or visual-baseline change.

## Risk

The host maps allocation padding in addition to the logical readback bytes. It still reads and serializes only the logical extent, and the allocation is dedicated, host-visible memory already owned by the same readback buffer.
