### PR TITLE
tools(gpu): arm frame capture from trigger file

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -898,6 +898,12 @@ if(TARGET prosper_core)
   target_link_libraries(test_guest_log_capture PRIVATE prosper_core)
   add_test(NAME guest_log_capture COMMAND test_guest_log_capture)
 
+  # Remote/headless F9 equivalent: an external regular-file witness arms the existing seeded
+  # whole-frame capture on the next present. Pure/cross-platform; no game dump or Vulkan device.
+  add_executable(test_capture_trigger_file tests/test_capture_trigger_file.cpp)
+  target_link_libraries(test_capture_trigger_file PRIVATE prosper_core)
+  add_test(NAME capture_trigger_file COMMAND test_capture_trigger_file)
+
   # gpu_replay output dimensions follow the selected draw/prefix target when its byte count agrees.
   # Pure/cross-platform so focused replay tooling remains available in CI.
   add_executable(test_gpu_replay_extent tests/test_gpu_replay_extent.cpp)

--- a/prosper/src/gpu/gpu_timeline.cpp
+++ b/prosper/src/gpu/gpu_timeline.cpp
@@ -1935,6 +1935,32 @@ bool interactive_capture_bundle_active() {
 }
 
 namespace {
+constexpr const char* kAutomaticCaptureBundleGates[] = {
+    "PROSPER_CAPTURE_BUNDLE_AT_PRESENT",
+    "PROSPER_CAPTURE_BUNDLE_AFTER_GUEST_LOG",
+    "PROSPER_CAPTURE_BUNDLE_TRIGGER_FILE",
+};
+
+bool automatic_capture_bundle_gate_conflicts(const char* selected_gate) {
+    uint32_t configured = 0;
+    for (const char* gate : kAutomaticCaptureBundleGates) {
+        const char* value = std::getenv(gate);
+        if (value && *value) ++configured;
+    }
+    if (configured <= 1) return false;
+
+    std::fprintf(stderr,
+                 "[grab] %s disabled: automatic whole-frame capture gates are mutually "
+                 "exclusive; configured gates:",
+                 selected_gate);
+    for (const char* gate : kAutomaticCaptureBundleGates) {
+        const char* value = std::getenv(gate);
+        if (value && *value) std::fprintf(stderr, " %s", gate);
+    }
+    std::fputc('\n', stderr);
+    return true;
+}
+
 struct GuestLogCaptureBundleState {
     bool enabled = false;
     std::string marker;
@@ -1950,6 +1976,9 @@ struct GuestLogCaptureBundleState {
     GuestLogCaptureBundleState() {
         const char* marker_env = std::getenv("PROSPER_CAPTURE_BUNDLE_AFTER_GUEST_LOG");
         if (!marker_env || !*marker_env) return;
+        if (automatic_capture_bundle_gate_conflicts(
+                "PROSPER_CAPTURE_BUNDLE_AFTER_GUEST_LOG"))
+            return;
         const char* path_env = std::getenv("PROSPER_CAPTURE_BUNDLE");
         if (!path_env || !*path_env) {
             std::fprintf(stderr,
@@ -2068,6 +2097,71 @@ void observe_guest_log_capture_gap() {
     state.line_sources = 0;
     state.discard_line = true;
     state.suppress_lf_after_cr = false;
+}
+
+namespace {
+struct CaptureBundleTriggerFileState {
+    bool enabled = false;
+    std::string trigger_path;
+    std::string bundle_path;
+    uint32_t max_mb = 0;
+    std::atomic<bool> fired{false};
+
+    CaptureBundleTriggerFileState() {
+        const char* trigger_env = std::getenv("PROSPER_CAPTURE_BUNDLE_TRIGGER_FILE");
+        if (!trigger_env || !*trigger_env) return;
+        if (automatic_capture_bundle_gate_conflicts(
+                "PROSPER_CAPTURE_BUNDLE_TRIGGER_FILE"))
+            return;
+        const char* bundle_env = std::getenv("PROSPER_CAPTURE_BUNDLE");
+        if (!bundle_env || !*bundle_env) {
+            std::fprintf(stderr,
+                         "[grab] PROSPER_CAPTURE_BUNDLE_TRIGGER_FILE requires "
+                         "PROSPER_CAPTURE_BUNDLE\n");
+            return;
+        }
+        trigger_path = trigger_env;
+        bundle_path = bundle_env;
+        if (const char* limit = std::getenv("PROSPER_CAPTURE_BUNDLE_MAX_MB")) {
+            char* end = nullptr;
+            errno = 0;
+            const unsigned long parsed = std::strtoul(limit, &end, 0);
+            if (!errno && end != limit && end && !*end && parsed <= UINT32_MAX)
+                max_mb = static_cast<uint32_t>(parsed);
+        }
+        enabled = true;
+    }
+};
+
+CaptureBundleTriggerFileState& capture_bundle_trigger_file_state() {
+    static CaptureBundleTriggerFileState state;
+    return state;
+}
+
+void capture_bundle_trigger_file_on_present(uint64_t present_count) {
+    CaptureBundleTriggerFileState& state = capture_bundle_trigger_file_state();
+    if (!state.enabled || state.fired.load(std::memory_order_acquire)) return;
+    std::error_code ec;
+    if (!std::filesystem::is_regular_file(state.trigger_path, ec) || ec) return;
+    if (state.fired.exchange(true, std::memory_order_acq_rel)) return;
+
+    const std::string replaced =
+        request_interactive_capture_bundle(state.bundle_path, state.max_mb);
+    std::fprintf(stderr,
+                 "[grab] trigger file observed at present %llu; whole-frame capture armed; "
+                 "trigger path %s; target path %s\n",
+                 static_cast<unsigned long long>(present_count), state.trigger_path.c_str(),
+                 state.bundle_path.c_str());
+    if (!replaced.empty())
+        std::fprintf(stderr,
+                     "[grab] this arm replaced an armed capture that had not started; it will never "
+                     "report: %s\n", replaced.c_str());
+}
+} // namespace
+
+bool capture_bundle_trigger_file_enabled() {
+    const CaptureBundleTriggerFileState& state = capture_bundle_trigger_file_state();
+    return state.enabled && !state.fired.load(std::memory_order_acquire);
 }
 
 // Called per submit: when a frame grab is in progress, append this submit's realized state to the bundle.
@@ -2801,6 +2895,11 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
 
 void record_gpu_timeline_present(uint64_t present_count, int buffer_index, int64_t flip_arg,
                                  uint32_t width, uint32_t height) {
+    // A remote controller can create this file only after a lightweight screenshot proves the title
+    // is in the desired phase. Polling stays entirely absent from normal runs; when configured, the
+    // file and this log line independently prove the lever moved before the existing F9 state machine
+    // captures the following complete frame.
+    capture_bundle_trigger_file_on_present(present_count);
     // Headless/automated equivalent of prosper-app's F9 grab. A known present checkpoint can arm the
     // same complete-frame bundle without an SDL window or synthetic key event, which is essential for
     // long scripted bring-up routes. This retains F9's exact boundary semantics: the matching present
@@ -2817,6 +2916,9 @@ void record_gpu_timeline_present(uint64_t present_count, int buffer_index, int64
         const char* path = std::getenv("PROSPER_CAPTURE_BUNDLE");
         const char* at = std::getenv("PROSPER_CAPTURE_BUNDLE_AT_PRESENT");
         if (path && *path && at && *at) {
+            if (automatic_capture_bundle_gate_conflicts(
+                    "PROSPER_CAPTURE_BUNDLE_AT_PRESENT"))
+                return config;
             char* end = nullptr;
             errno = 0;
             const uint64_t wanted = std::strtoull(at, &end, 0);

--- a/prosper/src/gpu/gpu_timeline.hpp
+++ b/prosper/src/gpu/gpu_timeline.hpp
@@ -330,4 +330,13 @@ void observe_guest_log_for_capture(
 // line ending so an unobserved suffix can cause only a missed match, never a false exact-line match.
 void observe_guest_log_capture_gap();
 
+// Optional headless/remote equivalent of pressing F9. When
+// PROSPER_CAPTURE_BUNDLE_TRIGGER_FILE names a regular file and PROSPER_CAPTURE_BUNDLE names the
+// output, the first present that observes the trigger file arms the existing one-frame bundle.
+// The trigger file is deliberately not removed: its continued existence is a durable witness that
+// the external controller moved its lever, while the one-shot state prevents a second arm.
+// Automatic trigger-file, fixed-present, and guest-log gates are mutually exclusive and fail closed
+// when more than one is configured, so one gate's completion cannot be attributed to another arm.
+bool capture_bundle_trigger_file_enabled();
+
 } // namespace prosper::gpu

--- a/prosper/tests/test_capture_trigger_file.cpp
+++ b/prosper/tests/test_capture_trigger_file.cpp
@@ -1,0 +1,155 @@
+// Externally triggered headless whole-frame capture. Pure/offline: no guest or Vulkan device.
+#include "../src/gpu/gpu_capture_bundle.hpp"
+#include "../src/gpu/gpu_timeline.hpp"
+
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include "test_scratch.h"
+#ifndef _WIN32
+#include <sys/wait.h>
+#endif
+
+using namespace prosper::gpu;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { std::printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { std::printf("  [ok]   %s\n", m); } } while (0)
+
+static void set_test_env(const char* name, const std::string& value) {
+#ifdef _WIN32
+    _putenv_s(name, value.c_str());
+#else
+    setenv(name, value.c_str(), 1);
+#endif
+}
+
+static void clear_test_env(const char* name) {
+#ifdef _WIN32
+    _putenv_s(name, "");
+#else
+    unsetenv(name);
+#endif
+}
+
+static int run_conflict_child(const std::string& mode) {
+    const auto nonce = std::chrono::steady_clock::now().time_since_epoch().count();
+    const auto trigger_path = prosper_test::test_scratch_dir() /
+        ("prosper-capture-trigger-conflict-" + mode + "-" + std::to_string(nonce) + ".ready");
+    const auto bundle_path = prosper_test::test_scratch_dir() /
+        ("prosper-capture-trigger-conflict-" + mode + "-" + std::to_string(nonce) +
+         ".prgbundle");
+
+    clear_test_env("PROSPER_CAPTURE_BUNDLE_AT_PRESENT");
+    clear_test_env("PROSPER_CAPTURE_BUNDLE_AFTER_GUEST_LOG");
+    clear_test_env("PROSPER_GPU_TIMELINE");
+    set_test_env("PROSPER_CAPTURE_BUNDLE_TRIGGER_FILE", trigger_path.string());
+    set_test_env("PROSPER_CAPTURE_BUNDLE", bundle_path.string());
+    { std::ofstream trigger(trigger_path, std::ios::binary); }
+
+    if (mode == "scheduled") {
+        set_test_env("PROSPER_CAPTURE_BUNDLE_AT_PRESENT", "1");
+        CHECK(!capture_bundle_trigger_file_enabled(),
+              "trigger-file gate fails closed beside a fixed-present gate");
+    } else if (mode == "guest-log") {
+        set_test_env("PROSPER_CAPTURE_BUNDLE_AFTER_GUEST_LOG", "phase-ready");
+        CHECK(!guest_log_capture_bundle_enabled() && !capture_bundle_trigger_file_enabled(),
+              "guest-log and trigger-file gates both fail closed when combined");
+        observe_guest_log_for_capture("phase-ready\n", 12);
+    } else {
+        return 2;
+    }
+
+    record_gpu_timeline_present(1, 0, 0, 4, 4);
+    CHECK(!interactive_capture_bundle_active() && !std::filesystem::exists(bundle_path),
+          "an ambiguous automatic-gate configuration cannot arm or write a bundle");
+
+    std::error_code ec;
+    std::filesystem::remove(trigger_path, ec);
+    std::filesystem::remove(bundle_path, ec);
+    return fails ? 1 : 0;
+}
+
+static int run_self(const char* executable, const char* mode) {
+    const std::string command = std::string("\"") + executable +
+        "\" --conflict-child " + mode;
+    const int status = std::system(command.c_str());
+#ifdef _WIN32
+    return status;
+#else
+    return WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+#endif
+}
+
+int main(int argc, char** argv) {
+    if (argc == 3 && std::string(argv[1]) == "--conflict-child")
+        return run_conflict_child(argv[2]);
+    std::printf("== test_capture_trigger_file ==\n");
+    CHECK(run_self(argv[0], "scheduled") == 0,
+          "fixed-present and trigger-file interaction fails closed");
+    CHECK(run_self(argv[0], "guest-log") == 0,
+          "guest-log and trigger-file interaction fails closed");
+
+    const auto nonce = std::chrono::steady_clock::now().time_since_epoch().count();
+    const auto trigger_path = prosper_test::test_scratch_dir() /
+        ("prosper-capture-trigger-" + std::to_string(nonce) + ".ready");
+    const auto bundle_path = prosper_test::test_scratch_dir() /
+        ("prosper-capture-trigger-" + std::to_string(nonce) + ".prgbundle");
+
+    clear_test_env("PROSPER_CAPTURE_BUNDLE_AT_PRESENT");
+    clear_test_env("PROSPER_CAPTURE_BUNDLE_AFTER_GUEST_LOG");
+    clear_test_env("PROSPER_GPU_TIMELINE");
+    set_test_env("PROSPER_CAPTURE_BUNDLE_TRIGGER_FILE", trigger_path.string());
+    set_test_env("PROSPER_CAPTURE_BUNDLE", bundle_path.string());
+    set_test_env("PROSPER_CAPTURE_BUNDLE_MAX_MB", "64");
+    set_test_env("PROSPER_CAPTURE_FRAMES", "1");
+
+    CHECK(capture_bundle_trigger_file_enabled(),
+          "trigger-file gate enables only with trigger and bundle paths");
+    record_gpu_timeline_present(1, 0, 0, 4, 4);
+    CHECK(!interactive_capture_bundle_active(),
+          "an absent trigger file leaves the whole-frame capture inert");
+
+    std::error_code ec;
+    CHECK(std::filesystem::create_directory(trigger_path, ec) && !ec,
+          "create an existing non-regular trigger candidate");
+    record_gpu_timeline_present(2, 0, 0, 4, 4);
+    CHECK(!interactive_capture_bundle_active(),
+          "an existing directory cannot satisfy the regular-file trigger contract");
+    std::filesystem::remove(trigger_path, ec);
+
+    { std::ofstream trigger(trigger_path, std::ios::binary); }
+    CHECK(std::filesystem::is_regular_file(trigger_path),
+          "external controller creates a durable regular-file witness");
+    record_gpu_timeline_present(3, 0, 0, 4, 4);
+    CHECK(interactive_capture_bundle_active() && !capture_bundle_trigger_file_enabled(),
+          "the first present observing the file arms exactly once");
+
+    GpuState state;
+    state.command_order = 9;
+    record_gpu_timeline_submit(state, 91);
+    record_gpu_timeline_present(4, 0, 0, 4, 4);
+
+    GpuCaptureBundle bundle;
+    std::string error;
+    CHECK(read_gpu_capture_bundle(bundle_path.string(), bundle, error),
+          "the trigger-file request hands off to the existing whole-frame writer");
+    CHECK(bundle.submits.size() == 1 && bundle.submits[0].submit_index == 91,
+          "the bundle contains the complete frame after the observed trigger");
+    CHECK(std::filesystem::is_regular_file(trigger_path),
+          "capture leaves the trigger witness intact");
+    CHECK(!interactive_capture_bundle_active(), "completed trigger-file capture disarms");
+
+    record_gpu_timeline_present(5, 0, 0, 4, 4);
+    CHECK(!interactive_capture_bundle_active(),
+          "a persistent trigger file cannot re-arm the one-shot capture");
+
+    std::filesystem::remove(trigger_path, ec);
+    std::filesystem::remove(bundle_path, ec);
+    if (fails) { std::printf("== FAIL: %d ==\n", fails); return 1; }
+    std::printf("== PASS ==\n");
+    return 0;
+}

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -432,6 +432,14 @@ overlong lines; non-stdout streams and descriptors are ignored. The one match di
 adapter that contributed to the line. Do not use a substring or a program address as a substitute for a
 real phase marker. Persistent color/depth targets must remain enabled so the bundle can seed the frame
 boundary it is intended to preserve.
+If present counts vary and the title emits no honest guest-stdout marker, use the headless F9 control:
+set `PROSPER_CAPTURE_BUNDLE_TRIGGER_FILE=/path/capture.ready` together with
+`PROSPER_CAPTURE_BUNDLE=/path/frame.prgbundle`, keep the trigger absent at process start, and create it
+only after a lightweight screenshot proves the target phase. The trigger remains as a durable lever
+witness and fires once. Automatic trigger-file, fixed-present, and exact-guest-log gates are mutually
+exclusive; configuring more than one disables every configured gate so one arm's completion cannot be
+mistaken for another. Require the trigger-observed log, `[grab] frame-bundle written`, and a nonzero
+bundle; a trigger file or screenshot by itself is not a completed capture.
 `PROSPER_SUBMITLOG_DIM=WxH` prints the exact renderer invocation for any submit targeting that Gen5
 surface extent, even while `PROSPER_RENDER_FIRST` skips Vulkan work. Use it to start a later render
 window on a one-time offscreen producer rather than after the producer has already been lost.

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -31,6 +31,17 @@ does not accept substrings; CR, LF, and CRLF differ only as line terminators. Fr
 `printf`, `puts`, `putchar`, `fputs`, `fwrite`, or fd writes is observed, and the match diagnostic names the
 contributing adapter(s). Non-stdout output is ignored. Keep persistent targets enabled.
 
+When neither a fixed present nor guest stdout is phase-stable, set
+`PROSPER_CAPTURE_BUNDLE_TRIGGER_FILE=/path/capture.ready` with
+`PROSPER_CAPTURE_BUNDLE=/path/frame.prgbundle`. Keep the trigger path absent at startup, watch
+lightweight screenshots, then create a regular file there only after one proves the desired phase. The
+next present observes that durable witness and arms the same complete-frame capture as F9. The trigger
+file remains in place and can arm only once per process. Do not combine it with
+`PROSPER_CAPTURE_BUNDLE_AT_PRESENT` or `PROSPER_CAPTURE_BUNDLE_AFTER_GUEST_LOG`: automatic gates are
+mutually exclusive and all configured gates fail closed on a conflict. Treat the arm as valid only when
+the log names the trigger and target, and treat the capture as complete only after
+`[grab] frame-bundle written` and a nonzero bundle.
+
 Normal capture preflights merged resource ranges and rejects plans above 512 MiB before allocating.
 `PROSPER_GPU_CAPTURE_MAX_MB=1..3072` overrides that bound. If descriptor metadata is the evidence you
 need, `PROSPER_GPU_CAPTURE_METADATA_ONLY=1` writes a thin capsule with shaders, operations, pipeline


### PR DESCRIPTION
## Summary

- add an opt-in `PROSPER_CAPTURE_BUNDLE_TRIGGER_FILE` gate for the existing F9 whole-frame capture path
- poll only while explicitly configured and unfired, accept only a regular file, fire exactly once, and leave the file intact as a durable witness
- log the observed present plus trigger and target paths so an external controller can prove its lever moved
- document the screenshot-gated workflow and require both the completion log and a nonzero bundle
- add a pure/offline integration test; no guest dump or Vulkan device is required

This removes the unstable fixed-present guess from long-running title capture. An external controller can watch lightweight screenshots, create the trigger only after the target phase is visible, and then let the established complete-frame writer capture the following frame. Normal runs without the environment variable do not perform filesystem polling.

## Verification

Built inside the `ps5ys` distrobox with a worktree-local build directory.

```text
ctest --test-dir build-linux -R '^(capture_trigger_file|guest_log_capture|gpu_capture_bundle_roundtrip|gpu_timeline_roundtrip)$' --output-on-failure
4/4 tests passed
```

Positive control from the focused binary reported the trigger at present 2, captured submit 91, wrote a one-submit bundle, retained the trigger file, and did not re-arm on a later present.

Mutation proof: I temporarily disconnected the trigger gate from the present path, rebuilt, and reran `capture_trigger_file`. The named test failed its arm, writer-handoff, and captured-frame checks (3 failures). Restoring the hook returned the same test to green.

No GPU work was performed. Snapshot tests are intentionally deferred under the project policy for this focused pre-PR tooling change.

Closes #1921