### PR TITLE
perf(gpu): reuse DCC producer image allocations

### DIFF
--- a/prosper/docs/ASTROBOT_LINUX_HANDOFF_2026_07_19.md
+++ b/prosper/docs/ASTROBOT_LINUX_HANDOFF_2026_07_19.md
@@ -621,10 +621,121 @@ This is live acceptance of the GDS M0 mechanism, not a full Astro visual or perf
 run enabled extremely verbose graphics diagnostics and produced an 878 MiB log, so no FPS figure from
 it is meaningful. Continue the wider title-screen/gameplay investigation independently.
 
+## DCC producer allocation reuse result (2026-08-04)
+
+PR #1900 made Astro's consumer reuse the producer's retained 4K storage image, but the producer then
+became the dominant compute frontier. A complete post-#1900 F8 window on exact master `61446754`
+localized the shift by stable SPIR-V identity: consumer `0x05975892ababe69f` fell from 30.35 to
+8.95 ms/dispatch, while producer `0xa5e27ec0def1a807` rose from 27.91 to 57.72 ms/dispatch. An exact
+producer-only phase/image arm then found that the shader and retile were unchanged: post-writeback
+cache work rose from 1.040 to 32.155 ms/dispatch because `replace_or_retain_image()` destroyed the
+consumer's exact cached image/result allocation and installed a new producer allocation every frame.
+See #1732 for the complete retained evidence chain.
+
+Commit `41b37177` replaces that allocation churn with a generic, fail-closed lease. A DCC-unsafe
+producer may reuse only an exact-key, unpinned cached image allocation. The lease immediately clears
+all source, graphics-export, and compute-transfer authority; it preserves snapshot capacity only as
+untrusted storage. `upload_skipped` remains false, so the complete guest seed is always uploaded. The
+dispatch may republish authority only after successful guest writeback and a final all-`0xff` scan of
+the writable DCC metadata plane. Missing, pinned, ambiguous/aliased, ineligible, and unresolved cases
+retain the existing transient replacement or guest-memory fallback.
+
+The focused production-backend controls were run in the required distrobox:
+
+```sh
+distrobox enter ps5ys -- bash -lc '
+  cd <WORKTREE>/build &&
+  ./test_game_compute &&
+  PROSPER_NO_ADAPTIVE_STORAGE_RESULT_VALIDATION=1 ./test_game_compute'
+
+distrobox enter ps5ys -- bash -lc '
+  cd <WORKTREE>/build && ./test_compute_timing_selector'
+
+python3 <REPO_ROOT>/prosper/tools/perf/test_compute_phase_report.py
+```
+
+The normal backend passed 315 assertions and the no-adaptive arm passed 301; the selector policy and
+offline report self-tests also passed. The defect-shaped image fixture changes the producer bytes and
+requires the consumer to observe every new byte, which proves allocation reuse did not suppress the
+mandatory upload. Independent monotonic witnesses require reuse to advance while replacement stays
+flat. A mutation disables exactly one otherwise-eligible reuse and must make the real replacement
+witness advance instead. Pinned-entry, replacement-capacity, and unresolved-final-DCC arms must leave
+both cache/export and producer-to-consumer transfer authority unpublished.
+
+The single authorized live acceptance used normal full-scale/every-submit `prosper-app`, its renderer,
+FFmpeg/VA-API, SDL audio and SDL controller backends, 540 real presents, and a 360-second hard cap. Its
+command shape was:
+
+```sh
+env -u PROSPER_RENDER_SCALE \
+    -u PROSPER_RENDER_EVERY \
+    -u PROSPER_RENDER_EVERY_FOR_MS \
+    -u PROSPER_NO_PERSISTENT_COMPUTE_IMAGE \
+    -u PROSPER_NO_NATIVE_2D_COMPUTE_TRANSFER \
+    -u PROSPER_NO_ADAPTIVE_STORAGE_RESULT_VALIDATION \
+  PROSPER_GUEST_FS=1 \
+  PROSPER_GUEST_ARGS=-force-gfx-direct \
+  PROSPER_RENDER=1 \
+  PROSPER_COMPUTE_TIMING_HASH=0xa5e27ec0def1a807 \
+  PROSPER_COMPUTE_PHASE_TIMING=1 \
+  PROSPER_COMPUTE_IMAGE_TIMING=1 \
+  PROSPER_COMPUTE_TRANSFER_PRODUCER_HASH=0xa5e27ec0def1a807 \
+  PROSPER_COMPUTE_TRANSFER_CONSUMER_HASH=0x05975892ababe69f \
+  timeout --signal=TERM --kill-after=10s 360s \
+    <WORKTREE>/build/prosper-app --dump <DUMP_ROOT>/PPSA21564-app0 --frames 540
+```
+
+The run reached `LevelDocument Loaded: worldmap [worldmap]`, exited rc 0 at 540/540 presents, and
+left corrected exact pre/post process censuses empty. The timing selector accepted, first-matched
+run-local code `0x50057b800`, and ended `seen=53443 matched=68 verdict=matched`. Both transfer hashes
+matched 68 times and reached 136 storage gates. Binding 65 reported
+`persistent=1 allocation-reused=1 upload-skipped=0 allocation_ms=0.000` on all 68 selected producer
+dispatches, while producer and consumer publication each remained authorized on all 136 storage
+results. There was no Vulkan device loss, worker fault, SIGFPE, timeout, or lingering process.
+
+The exact selected-producer result is:
+
+| phase | replacement baseline | allocation reuse | delta |
+|---|---:|---:|---:|
+| total | 60.451 ms | **27.667 ms** | -32.784 ms (-54.2%) |
+| setup | 17.938 ms | **13.265 ms** | -4.673 ms |
+| GPU dispatch | 3.112 ms | 3.697 ms | +0.585 ms |
+| writeback | 39.218 ms | **10.517 ms** | -28.701 ms |
+| retile/layout | 5.990 ms | 5.920 ms | -0.070 ms |
+| aggregate cache | 32.155 ms | **3.587 ms** | -28.568 ms (-88.8%) |
+| binding-65 cache only | 30.915 ms | **2.406 ms** | -28.509 ms (-92.2%) |
+
+This restores the producer essentially to its retained pre-#1900 cost of 26.081 ms. The final displayed
+interval was 3.7 fps versus 3.2 fps in the old selected arm, but that is context rather than a
+controlled whole-title FPS result: other compute/render work still dominates the world map. The run
+made no new visual-correctness claim, so no new screenshot was warranted. Retained title-derived
+evidence remains outside git under
+`<EVIDENCE_ROOT>/astro-1732-allocation-reuse-41b37177/`.
+
 ## Ruled out
 
 One line per falsified hypothesis, the evidence that killed it, and the issue/PR. Extend this rather
 than re-deriving a dead answer at full cost.
+
+- **"#1900's post-writeback DCC promotion makes the producer/consumer pair cheaper enough by itself
+  to improve world-map throughput."** False in the first comparable whole-workload F8 window after
+  merge. On exact master `61446754`, a normal native/default run reached `worldmap` before the
+  automatic trigger and retained a complete 5.02-second window (`pre=20 post=21 renderer=51
+  compute=1359`, zero dropped or unknown-identity records). The exact consumer fell from 30.35 to
+  8.95 ms/dispatch versus the retained pre-#1900 window, but the exact producer rose from 27.91 to
+  57.72 ms/dispatch. The pair therefore moved from 58.26 to 66.67 ms per cycle. This cross-revision
+  capture localized the frontier rather than proving a whole-build regression; do not continue
+  optimizing the old consumer or quote #1900 alone as a gameplay/FPS win. The exact producer arm and
+  allocation-reuse acceptance above close the mechanism question. See #1732.
+
+- **"The post-#1900 producer increase comes from slower shader execution or DCC retile."** False on
+  exact selected-producer arms. Before allocation reuse, GPU dispatch was 3.112 ms and retile was
+  5.990 ms, essentially their retained pre-#1900 values of 3.122 and 5.934 ms. The new cost was the
+  post-writeback cache leaf: 32.155 ms total and 30.915 ms on binding 65 alone. Reusing the exact
+  unpinned allocation at `41b37177` reduced those values to 3.587 and 2.406 ms while preserving a
+  forced upload on 68/68 dispatches; selected total fell from 60.451 to 27.667 ms. The mechanism
+  mutation restores replacement, and the ordinary shader/retile leaves do not move with it. See
+  #1732.
 
 - **"The 4K consumer keeps rebuilding a stable image because unrelated GPU-write notifications
   falsely invalidate its cache entry."** False on exact master `04c43b15` in the natural 720-present

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -209,8 +209,11 @@ namespace {
 std::atomic<uint64_t> g_buffer_gpu_result_skips{0};
 std::atomic<uint64_t> g_compute_storage_transfer_seeds{0};
 std::atomic<uint64_t> g_dcc_post_writeback_promotions{0};
+std::atomic<uint64_t> g_dcc_forced_seed_allocation_reuses{0};
+std::atomic<uint64_t> g_dcc_post_writeback_replacements{0};
 std::atomic<bool> g_fail_next_storage_readback_for_test{false};
 std::atomic<bool> g_leave_next_dcc_metadata_compressed_for_test{false};
+std::atomic<bool> g_disable_next_dcc_allocation_reuse_for_test{false};
 std::atomic<bool> g_limit_next_image_replacement_for_test{false};
 std::atomic<bool> g_zero_next_cold_storage_snapshot_minimum_for_test{false};
 std::atomic<bool> g_force_next_image_result_host_fallback_for_test{false};
@@ -1672,6 +1675,34 @@ struct VulkanComputeContext {
         return true;
     }
 
+    // DCC-compressed guest bytes cannot authorize an upload skip, but an exact unpinned cache entry
+    // still owns a perfectly compatible Vulkan allocation. Lease that allocation before preparing
+    // the mandatory seed so a changing producer does not destroy and recreate tens of MiB after
+    // every writeback. Invalidate all source/export authority immediately: only this dispatch's
+    // forced upload plus successful DCC publication may authorize the reused allocation again.
+    bool acquire_cached_image_allocation_for_forced_seed(
+        const ComputeImageCacheKey& key, VkImage& image, VkDeviceMemory& memory,
+        VkDeviceSize& allocation_bytes) {
+        auto found = image_cache.find(key);
+        if (found == image_cache.end() || found->second.pins || !found->second.image ||
+            !found->second.memory)
+            return false;
+        if (g_disable_next_dcc_allocation_reuse_for_test.exchange(
+                false, std::memory_order_acq_rel))
+            return false;
+        CachedComputeImage& cached = found->second;
+        cached.last_use = ++image_cache_clock;
+        ++cached.pins;
+        image = cached.image;
+        memory = cached.memory;
+        allocation_bytes = cached.allocation_bytes;
+        // A zero-sized snapshot carries no authority, but retaining its capacity lets successful
+        // writeback refresh the exact bytes without a second large allocation in the hot path.
+        invalidate_cached_image_source(key, true);
+        g_dcc_forced_seed_allocation_reuses.fetch_add(1, std::memory_order_relaxed);
+        return true;
+    }
+
     void invalidate_cached_image_export(const ComputeImageCacheKey& key) {
         const auto found = image_cache.find(key);
         if (found == image_cache.end()) return;
@@ -1885,6 +1916,7 @@ struct VulkanComputeContext {
         destroy_cached_image_resources(exact->second);
         exact->second = std::move(replacement);
         image_cache_bytes += allocation_bytes;
+        g_dcc_post_writeback_replacements.fetch_add(1, std::memory_order_relaxed);
         return true;
     }
 
@@ -1893,7 +1925,8 @@ struct VulkanComputeContext {
         if (found != image_cache.end() && found->second.pins) --found->second.pins;
     }
 
-    void invalidate_cached_image_source(const ComputeImageCacheKey& key) {
+    void invalidate_cached_image_source(const ComputeImageCacheKey& key,
+                                        bool preserve_snapshot_capacity = false) {
         const auto found = image_cache.find(key);
         if (found == image_cache.end()) return;
         CachedComputeImage& cached = found->second;
@@ -1901,7 +1934,9 @@ struct VulkanComputeContext {
         cached.graphics_export_valid = false;
         cached.compute_transfer_valid = false;
         cached.write_watch.reset();
-        if (!cached.source_snapshot.empty())
+        if (preserve_snapshot_capacity)
+            cached.source_snapshot.clear();
+        else if (!cached.source_snapshot.empty())
             std::vector<uint8_t>().swap(cached.source_snapshot);
         // acquire_cached_image may otherwise reuse a same-submit validation result before checking
         // content_valid. A failed post-submit readback can leave the retained image/result buffer
@@ -2340,6 +2375,9 @@ struct BoundImage {
     bool persistent = false;            // guest-backed sampled image retained across dispatches
     bool cache_candidate = false;
     bool post_writeback_promotion_candidate = false;
+    // Exact cached allocation leased for a DCC-unsafe producer. Source authority was invalidated,
+    // upload_skipped remains false, and cache publication still waits for post-writeback metadata.
+    bool forced_seed_allocation_reused = false;
     bool upload_skipped = false;         // write watch proved the cached source unchanged
     VkDeviceSize allocation_bytes = 0;
     VkDeviceSize staging_allocation_bytes = 0;
@@ -5557,6 +5595,24 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     transfer_gate_observation.role, *r, bi.binding,
                     storage_cache_gates,
                     bi.cache_candidate, bi.persistent);
+                if (!bi.cache_candidate && bi.post_writeback_promotion_candidate) {
+                    const auto cache_lookup_start = ComputeClock::now();
+                    bi.forced_seed_allocation_reused =
+                        ctx.acquire_cached_image_allocation_for_forced_seed(
+                            bi.cache_key, bi.image, bi.memory, bi.allocation_bytes);
+                    bi.persistent = bi.forced_seed_allocation_reused;
+                    if (bi.persistent)
+                        ctx.cached_image_result_buffer(
+                            bi.cache_key, bi.exact_result_bytes, bi.result_baseline);
+                    if (trace && bi.persistent)
+                        std::fprintf(stderr,
+                                     "[compute]   reused exact storage allocation with forced "
+                                     "seed binding=%u addr=0x%llx guest=%zu\n",
+                                     bi.binding, (unsigned long long)r->gpu_addr,
+                                     guest_bytes);
+                    cache_lookup_ms += std::chrono::duration<double, std::milli>(
+                        ComputeClock::now() - cache_lookup_start).count();
+                }
                 if (!(bi.persistent && bi.upload_skipped)) {
                 const size_t linear_size = (bi.seed_skip || bi.seed_from_imported != SIZE_MAX)
                     ? size_t{0} : static_cast<size_t>(linear_guest_bytes);
@@ -6167,7 +6223,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 std::fprintf(stderr,
                              "[compute-image] code=0x%llx hash=0x%016llx "
                              "binding=%u class=%s imported=%u addr=0x%llx "
-                             "persistent=%u upload-skipped=%u "
+                             "persistent=%u allocation-reused=%u upload-skipped=%u "
                              "extent=%ux%ux%u guest=%zu staging=%llu "
                              "normalized=%u texel=%u sampled-float=%u rgba8-reuse=%u "
                              "query_ms=%.3f import_ms=%.3f cache_ms=%.3f "
@@ -6177,7 +6233,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                              (unsigned long long)timing_program_hash, bi.binding,
                              bi.storage ? "storage" : "sampled", bi.imported ? 1u : 0u,
                              (unsigned long long)r->gpu_addr,
-                             bi.persistent ? 1u : 0u, bi.upload_skipped ? 1u : 0u,
+                             bi.persistent ? 1u : 0u,
+                             bi.forced_seed_allocation_reused ? 1u : 0u,
+                             bi.upload_skipped ? 1u : 0u,
                              r->width, r->height, r->depth, bi.guest_bytes,
                              (unsigned long long)sbytes,
                              image_descriptors[i].normalized_sampling ? 1u : 0u,
@@ -7484,7 +7542,20 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                          r->host_data != nullptr, bi.seed_skip, bi.guest_bytes,
                          cold_storage_result_snapshot_defer_min_bytes()))
                     ? nullptr : destination;
-                if (bi.image && bi.memory && bi.allocation_bytes &&
+                if (bi.forced_seed_allocation_reused) {
+                    // The exact cache entry was already pinned and forcibly reseeded before this
+                    // dispatch. Successful writeback plus the final all-uncompressed metadata scan
+                    // may now restore source/transfer authority without replacing its allocation.
+                    bi.cache_candidate = true;
+                    g_dcc_post_writeback_promotions.fetch_add(
+                        1, std::memory_order_relaxed);
+                    if (trace)
+                        std::fprintf(stderr,
+                                     "[compute]   promoted reused post-writeback DCC storage "
+                                     "image binding=%u addr=0x%llx allocation=%llu\n",
+                                     bi.binding, (unsigned long long)r->gpu_addr,
+                                     (unsigned long long)bi.allocation_bytes);
+                } else if (bi.image && bi.memory && bi.allocation_bytes &&
                     ctx.replace_or_retain_image(
                         bi.cache_key, bi.image, bi.memory,
                         bi.allocation_bytes, retained_source)) {
@@ -7501,6 +7572,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                      (unsigned long long)bi.allocation_bytes);
                 }
             }
+            if (bi.forced_seed_allocation_reused && !final_dcc_cache_safe)
+                ctx.invalidate_cached_image_source(bi.cache_key);
             if (bi.cache_candidate) {
                 if (bi.persistent && !promoted_after_writeback) {
                     // Guest bytes now mirror the retained image again. A changing full-overwrite
@@ -7880,6 +7953,14 @@ uint64_t live_compute_dcc_post_writeback_promotions() {
     return g_dcc_post_writeback_promotions.load(std::memory_order_relaxed);
 }
 
+uint64_t live_compute_dcc_forced_seed_allocation_reuses() {
+    return g_dcc_forced_seed_allocation_reuses.load(std::memory_order_relaxed);
+}
+
+uint64_t live_compute_dcc_post_writeback_replacements() {
+    return g_dcc_post_writeback_replacements.load(std::memory_order_relaxed);
+}
+
 bool live_compute_native_storage_3d_supported(prosper::gpu::DataFormat format,
                                               uint32_t components,
                                               uint32_t width, uint32_t height,
@@ -7915,6 +7996,11 @@ void live_compute_fail_next_storage_readback_for_test() {
 
 void live_compute_leave_next_dcc_metadata_compressed_for_test() {
     g_leave_next_dcc_metadata_compressed_for_test.store(
+        true, std::memory_order_release);
+}
+
+void live_compute_disable_next_dcc_allocation_reuse_for_test() {
+    g_disable_next_dcc_allocation_reuse_for_test.store(
         true, std::memory_order_release);
 }
 

--- a/prosper/frontends/shared/live_compute.hpp
+++ b/prosper/frontends/shared/live_compute.hpp
@@ -197,6 +197,10 @@ uint64_t live_compute_storage_transfer_seeds();
 // Monotonic count of compressed storage results admitted only after an exact successful writeback
 // published both ordinary base bytes and an all-uncompressed DCC metadata plane.
 uint64_t live_compute_dcc_post_writeback_promotions();
+// Monotonic witnesses for the compressed-producer allocation path. An exact unpinned entry can be
+// forcibly reseeded in place; all other cases retain the post-writeback replacement fallback.
+uint64_t live_compute_dcc_forced_seed_allocation_reuses();
+uint64_t live_compute_dcc_post_writeback_replacements();
 // Query the initialized live backend for the exact typed 3D storage+transfer image contract. Tests
 // use this to exercise native-volume execution only on devices that can create the Vulkan image.
 bool live_compute_native_storage_3d_supported(prosper::gpu::DataFormat format,
@@ -221,11 +225,12 @@ bool cold_storage_result_snapshot_can_defer(bool host_data, bool full_overwrite,
 // readback fails after dispatch, exercising retained-image invalidation without a Vulkan fault.
 void live_compute_fail_next_storage_readback_for_test();
 
-// Deterministic controls for post-DCC cache-promotion regressions.  The first leaves the next
-// writable metadata plane unresolved, exercising the final all-0xff recheck.  The second models a
-// real replacement cache-capacity preflight after successful writeback; both must keep the
-// transient fallback owned by the caller and publish no cache/export authority.
+// Deterministic controls for post-DCC cache-promotion regressions. The first leaves the next
+// writable metadata plane unresolved, exercising the final all-0xff recheck. The second disables
+// one eligible allocation reuse so tests prove the replacement fallback actually runs. The third
+// models a real replacement cache-capacity preflight after successful writeback.
 void live_compute_leave_next_dcc_metadata_compressed_for_test();
+void live_compute_disable_next_dcc_allocation_reuse_for_test();
 void live_compute_limit_next_image_replacement_for_test();
 
 // Deterministically lower the next eligible cold storage admission crossover to zero. This lets a

--- a/prosper/tests/test_game_compute.cpp
+++ b/prosper/tests/test_game_compute.cpp
@@ -1890,11 +1890,19 @@ int main() {
                 tile_surface(tiled_src.data(), img_src.data(), W, 1, dcc_tile, 0, 4);
                 const uint64_t pinned_promotions_before =
                     prosper::frontend::live_compute_dcc_post_writeback_promotions();
+                const uint64_t pinned_reuses_before =
+                    prosper::frontend::live_compute_dcc_forced_seed_allocation_reuses();
+                const uint64_t pinned_replacements_before =
+                    prosper::frontend::live_compute_dcc_post_writeback_replacements();
                 CHECK(prosper::frontend::execute_live_compute_items({dcc_item}),
                       "compressed producer completes while its old exact cache entry is pinned");
                 CHECK(prosper::frontend::live_compute_dcc_post_writeback_promotions() ==
-                          pinned_promotions_before,
-                      "pinned exact cache entry declines post-DCC replacement");
+                          pinned_promotions_before &&
+                          prosper::frontend::live_compute_dcc_forced_seed_allocation_reuses() ==
+                              pinned_reuses_before &&
+                          prosper::frontend::live_compute_dcc_post_writeback_replacements() ==
+                              pinned_replacements_before,
+                      "pinned exact cache entry declines reuse and post-DCC replacement");
                 pinned_import = {};
                 auto [pinned_consumer_ok, pinned_linear,
                       pinned_seeds_before, pinned_seeds_after] = run_dcc_consumer();
@@ -1904,15 +1912,19 @@ int main() {
                       "declined pinned promotion publishes no new transfer authority");
             }
 
-            // Repeat with the exact cache entry unpinned and a changed producer result.  This is
-            // the Astro frame shape: an older consumer entry exists under the same key, and the
-            // compressed producer must replace it rather than letting emplace collide.
+            // Repeat with the exact cache entry unpinned and a changed producer result. This is the
+            // Astro frame shape: an older consumer entry exists under the same key, and compressed
+            // guest bytes must be uploaded into its allocation without inheriting source authority.
             std::fill(dcc_metadata.begin(), dcc_metadata.end(), 0x40);
             for (size_t index = 0; index < img_src.size(); ++index)
                 img_src[index] = static_cast<uint8_t>(index * 13u + 0x51u);
             tile_surface(tiled_src.data(), img_src.data(), W, 1, dcc_tile, 0, 4);
             const uint64_t replacement_promotions_before =
                 prosper::frontend::live_compute_dcc_post_writeback_promotions();
+            const uint64_t allocation_reuses_before =
+                prosper::frontend::live_compute_dcc_forced_seed_allocation_reuses();
+            const uint64_t replacements_before =
+                prosper::frontend::live_compute_dcc_post_writeback_replacements();
             auto [replacement_ok, replacement_linear,
                   ordered_replacement_promotions_before,
                   ordered_replacement_promotions_after,
@@ -1922,13 +1934,17 @@ int main() {
                       replacement_promotions_before ==
                           ordered_replacement_promotions_before &&
                       ordered_replacement_promotions_after ==
-                          replacement_promotions_before + 1,
-                  "unpinned exact-key collision is replaced after successful DCC writeback");
+                          replacement_promotions_before + 1 &&
+                      prosper::frontend::live_compute_dcc_forced_seed_allocation_reuses() ==
+                          allocation_reuses_before + 1 &&
+                      prosper::frontend::live_compute_dcc_post_writeback_replacements() ==
+                          replacements_before,
+                  "unpinned exact-key allocation is reused after a mandatory producer upload");
             CHECK(replacement_ok && replacement_linear == img_src,
-                  "replacement promotion preserves changed producer bytes exactly");
+                  "forced upload into a reused allocation observes changed producer bytes exactly");
             CHECK(!native_2d_compute_transfer_available ||
                       replacement_seeds_after > replacement_seeds_before,
-                  "replacement promotion restores producer-to-consumer image reuse");
+                  "reused-allocation promotion restores producer-to-consumer image reuse");
 
             ShaderResource mismatched_dcc_output = sampled_dcc_output;
             ++mismatched_dcc_output.width;
@@ -1936,6 +1952,32 @@ int main() {
             CHECK(!prosper::frontend::import_live_compute_storage_image(
                       mismatched_dcc_output, tiled_bytes, mismatched_import),
                   "post-DCC graphics reuse requires the exact promoted cache key");
+
+            // Mutate the mechanism, not the expected output: disable one eligible reuse while
+            // leaving every cache-promotion gate intact. The changed bytes must remain exact, and
+            // the independent counters must prove that the old replacement path actually ran.
+            std::fill(dcc_metadata.begin(), dcc_metadata.end(), 0x40);
+            for (size_t index = 0; index < img_src.size(); ++index)
+                img_src[index] = static_cast<uint8_t>(index * 17u + 0x35u);
+            tile_surface(tiled_src.data(), img_src.data(), W, 1, dcc_tile, 0, 4);
+            prosper::frontend::live_compute_disable_next_dcc_allocation_reuse_for_test();
+            const uint64_t mutated_reuses_before =
+                prosper::frontend::live_compute_dcc_forced_seed_allocation_reuses();
+            const uint64_t mutated_replacements_before =
+                prosper::frontend::live_compute_dcc_post_writeback_replacements();
+            auto [mutated_ok, mutated_linear, mutated_promotions_before,
+                  mutated_promotions_after, mutated_seeds_before, mutated_seeds_after] =
+                run_dcc_ordered_handoff(nullptr);
+            CHECK(mutated_ok && mutated_linear == img_src &&
+                      mutated_promotions_after == mutated_promotions_before + 1 &&
+                      prosper::frontend::live_compute_dcc_forced_seed_allocation_reuses() ==
+                          mutated_reuses_before &&
+                      prosper::frontend::live_compute_dcc_post_writeback_replacements() ==
+                          mutated_replacements_before + 1,
+                  "disabling allocation reuse restores exact post-writeback replacement");
+            CHECK(!native_2d_compute_transfer_available ||
+                      mutated_seeds_after > mutated_seeds_before,
+                  "replacement mutation preserves producer-to-consumer image reuse");
 
             // Force the real replacement cache-limit preflight below this allocation after exact
             // writeback and DCC publication. It must leave this dispatch transient, so the next
@@ -1945,12 +1987,21 @@ int main() {
             for (size_t index = 0; index < img_src.size(); ++index)
                 img_src[index] = static_cast<uint8_t>(index * 7u + 0x23u);
             tile_surface(tiled_src.data(), img_src.data(), W, 1, dcc_tile, 0, 4);
+            prosper::frontend::live_compute_disable_next_dcc_allocation_reuse_for_test();
             prosper::frontend::live_compute_limit_next_image_replacement_for_test();
             const uint64_t refused_promotions_before =
                 prosper::frontend::live_compute_dcc_post_writeback_promotions();
+            const uint64_t refused_reuses_before =
+                prosper::frontend::live_compute_dcc_forced_seed_allocation_reuses();
+            const uint64_t refused_replacements_before =
+                prosper::frontend::live_compute_dcc_post_writeback_replacements();
             CHECK(prosper::frontend::execute_live_compute_items({dcc_item}) &&
                       prosper::frontend::live_compute_dcc_post_writeback_promotions() ==
-                          refused_promotions_before,
+                          refused_promotions_before &&
+                      prosper::frontend::live_compute_dcc_forced_seed_allocation_reuses() ==
+                          refused_reuses_before &&
+                      prosper::frontend::live_compute_dcc_post_writeback_replacements() ==
+                          refused_replacements_before,
                   "post-DCC capacity preflight preserves the transient fallback");
             auto [refused_ok, refused_linear,
                   refused_seeds_before, refused_seeds_after] = run_dcc_consumer();
@@ -1969,12 +2020,16 @@ int main() {
             prosper::frontend::live_compute_leave_next_dcc_metadata_compressed_for_test();
             const uint64_t unresolved_promotions_before =
                 prosper::frontend::live_compute_dcc_post_writeback_promotions();
+            const uint64_t unresolved_reuses_before =
+                prosper::frontend::live_compute_dcc_forced_seed_allocation_reuses();
             CHECK(prosper::frontend::execute_live_compute_items({dcc_item}) &&
                       prosper::frontend::live_compute_dcc_post_writeback_promotions() ==
                           unresolved_promotions_before &&
+                      prosper::frontend::live_compute_dcc_forced_seed_allocation_reuses() ==
+                          unresolved_reuses_before + 1 &&
                       std::any_of(dcc_metadata.begin(), dcc_metadata.end(),
                                   [](uint8_t code) { return code != 0xff; }),
-                  "unresolved post-writeback DCC metadata blocks cache acquisition");
+                  "unresolved post-writeback DCC metadata invalidates the reused allocation");
             auto [unresolved_ok, unresolved_linear,
                   unresolved_seeds_before, unresolved_seeds_after] = run_dcc_consumer();
             CHECK(unresolved_ok && unresolved_linear == img_src,


### PR DESCRIPTION
## Summary

- reuse an exact-key, unpinned cached Vulkan image allocation for DCC-unsafe compute producers
- invalidate all cached source/export/transfer authority before reuse and force a complete guest upload
- republish authority only after successful writeback and a final all-`0xff` DCC metadata scan
- add monotonic reuse/replacement witnesses, a one-shot mutation control, timing output, and defect-shaped production-backend coverage
- record the retained Astro Bot live evidence and newly ruled-out hypotheses

Refs #1732.

## Root cause

PR #1900 made Astro's 4K consumer reuse the producer's retained image, but the producer still called `replace_or_retain_image()` after every dispatch. That path destroyed the consumer's exact cached image/result allocation and installed a fresh roughly 66 MiB producer allocation every frame.

An exact producer-only phase/image arm isolated the new cost to post-writeback cache work: binding 65 rose to 30.915 ms/dispatch while shader execution and DCC retile remained essentially unchanged.

## Safety model

The new lease is intentionally narrow and fail-closed. It applies only to an exact-key, unpinned cached image allocation. Taking the lease immediately clears source, graphics-export, and compute-transfer authority. Snapshot vector capacity survives only as untrusted zero-size storage, and `upload_skipped` remains false, so the full guest seed is uploaded before dispatch.

The result is authorized again only after successful guest writeback and a final all-`0xff` scan of the writable DCC metadata plane. Missing, pinned, ambiguous/aliased, capacity-ineligible, and unresolved cases retain the existing transient replacement or guest-memory fallback.

## Verification

Focused production-backend checks inside the required distrobox:

```sh
timeout --signal=TERM --kill-after=10s 240s ./test_game_compute
PROSPER_NO_ADAPTIVE_STORAGE_RESULT_VALIDATION=1 \
  timeout --signal=TERM --kill-after=10s 240s ./test_game_compute
./test_compute_timing_selector
python3 prosper/tools/perf/test_compute_phase_report.py
```

Results:

- normal backend: PASS, 315 assertions
- no-adaptive arm: PASS, 301 assertions
- timing selector policy: all checks passed
- offline compute phase report: all cases passed
- numbered-table checker and full Markdown structure sweep: passed
- `git diff --check`: passed

The defect-shaped fixture changes producer guest bytes and requires the consumer to observe every new byte, proving that reuse does not suppress the mandatory upload. Independent witnesses require reuse to advance while replacement stays flat. A mutation disables exactly one otherwise-eligible reuse and requires the real replacement witness to advance. Pinned-entry, replacement-capacity, and unresolved-final-DCC arms must leave cache/export and producer-to-consumer transfer authority unpublished.

## Live Astro Bot evidence

The authorized full-scale/every-submit run used `prosper-app` with the renderer, FFmpeg/VA-API, SDL audio, SDL controller, 540 real presents, and a 360-second hard cap. It reached `LevelDocument Loaded: worldmap [worldmap]`, exited rc 0 at 540/540 presents, and left exact pre/post process censuses empty.

- selector: `seen=53443 matched=68 verdict=matched`
- binding 65: 68/68 `persistent=1 allocation-reused=1 upload-skipped=0 allocation_ms=0.000`
- producer and consumer publication: authorized on all 136 storage results
- no device loss, worker fault, SIGFPE, timeout, or lingering process

| phase | replacement baseline | allocation reuse | delta |
|---|---:|---:|---:|
| total | 60.451 ms | **27.667 ms** | -32.784 ms (-54.2%) |
| setup | 17.938 ms | **13.265 ms** | -4.673 ms |
| GPU dispatch | 3.112 ms | 3.697 ms | +0.585 ms |
| writeback | 39.218 ms | **10.517 ms** | -28.701 ms |
| retile/layout | 5.990 ms | 5.920 ms | -0.070 ms |
| aggregate cache | 32.155 ms | **3.587 ms** | -28.568 ms (-88.8%) |
| binding-65 cache only | 30.915 ms | **2.406 ms** | -28.509 ms (-92.2%) |

This returns the selected producer essentially to its retained pre-#1900 cost of 26.081 ms. The displayed late interval moved from 3.2 to 3.7 fps, but that is context rather than a controlled whole-title FPS result: other compute/render work still dominates the world map.

No screenshot is attached because this is a performance-only mechanism change with no new visual-correctness claim.

## Snapshot policy

Snapshot tests were not run. They are optional for ordinary development PRs, and the focused production-backend, mutation, selector, report, and live-title checks directly exercise this mechanism. Snapshot tests remain required before a release.
