### PR TITLE
gpu: lower fragment IMAGE_GET_LOD

### DIFF
--- a/prosper/docs/HOUSE_OF_THE_DEAD_2_STATUS.md
+++ b/prosper/docs/HOUSE_OF_THE_DEAD_2_STATUS.md
@@ -25,8 +25,8 @@ ordered pair in fragment shaders.
 
 The generic 2D fragment form is now lowered to a real `OpImageQueryLod`. The accepted contract is
 deliberately narrow: ordinary non-NSA 2D texture and sampler resources, normalized coordinates,
-only x/y result channels, and no GLC or instruction modifier. Other dimensions, stages and forms
-remain visible recompiler failures.
+only x/y result channels, and no auxiliary MIMG address, cache-policy, descriptor/result, D16 or
+reserved controls. Other dimensions, stages and forms remain visible recompiler failures.
 
 Three representative failed fragment programs now recompile through their original resource
 tables: the 663-dword shader that supplied the exact instruction test produces 14,542 SPIR-V dwords
@@ -70,11 +70,18 @@ rdna2_spirv_struct
 shader_resource_contract
 ```
 
-The structural test uses the exact title-live packet `f1800108 01480809` and requires a real
-`OpImageQueryLod`; an independent compute-stage arm requires the derivative-consuming operation to
-remain rejected outside fragment shaders. Mutating the production opcode gate from `0x60` to `0x61`
-breaks the named structural check, and mutating only the table-less coverage classifier breaks the
-named coverage check. Both pass again after restoration.
+The structural test uses the exact title-live packet `f1800108 01480809` in x, y and xy dmask forms.
+It traces distinct U/V bit patterns into the real `OpImageQueryLod`, then traces clamped/raw query
+components through compact consecutive VDATA writes, EXEC predication and the fragment export. An
+isolated compute-stage arm requires the derivative-consuming operation to remain rejected outside
+fragment shaders. Exact or raw negative packets separately cover NSA, UNRM, A16, DLC, GLC, SLC,
+R128, TFE, LWE, D16 and all six reserved Table 100 bit positions in both production and table-less
+coverage.
+
+Defect-shaped mutations separately swapped U/V, swapped clamped/raw results, broke y-only VDATA
+compaction, removed EXEC predication, admitted the operation in compute, disabled each shared
+address/cache/result/reserved control family, and erased reserved-bit decode. Each mutation broke
+its named check and the clean implementation passed again after restoration.
 
 The single authorized Vulkan replay completed in 2.689 seconds with return code zero and empty
 pre/post process censuses. It recompiled all retained stages, read back the exact 1920x1080 FP16

--- a/prosper/docs/HOUSE_OF_THE_DEAD_2_STATUS.md
+++ b/prosper/docs/HOUSE_OF_THE_DEAD_2_STATUS.md
@@ -1,0 +1,82 @@
+# The House of the Dead 2: Remake status
+
+Tracking: [#1896](https://github.com/mattias800/prosper/issues/1896)
+
+Visual defect: [#1907](https://github.com/mattias800/prosper/issues/1907)
+
+Title ID: `PPSA24203`
+
+Engine: Unity / IL2CPP
+
+Current verified rung: **3 — gameplay with real GPU draws, with severe world-rendering defects**
+
+## Current symptom
+
+A fresh-save route reaches Training 1 gameplay at native 1920x1080. The HUD, weapon and ammunition
+display, crosshair, objective text, sky, changing camera frames and hit effects render, but most of
+the expected environment and actors are black, absent or reduced to sparse outlines. The published
+title and gameplay images in `COMPATIBILITY.md` remain the current visual reference.
+
+The captured gameplay frame contains 809 draws, 106 dispatches and 1,978 ordered operations. Its
+historical realization record has 1,063 failures. Of 1,056 failed fragment stages, 1,006 first
+reject at MIMG opcode `0x60`, independently disassembled as `IMAGE_GET_LOD`. AMD's RDNA2 ISA defines
+its two results as sampler-clamped and raw implicit LOD; SPIR-V `OpImageQueryLod` exposes the same
+ordered pair in fragment shaders.
+
+The generic 2D fragment form is now lowered to a real `OpImageQueryLod`. The accepted contract is
+deliberately narrow: ordinary non-NSA 2D texture and sampler resources, normalized coordinates,
+only x/y result channels, and no GLC or instruction modifier. Other dimensions, stages and forms
+remain visible recompiler failures.
+
+Three representative failed fragment programs now recompile through their original resource
+tables: the 663-dword shader that supplied the exact instruction test produces 14,542 SPIR-V dwords
+with 22 resources, and two larger scene shaders produce 10,621/11,379 dwords with 12/13 resources.
+A complete current-recompiler replay substituted all 809 vertex and fragment stages and all 106
+compute stages without retaining stored SPIR-V.
+
+## Current frontier
+
+The complete replay remains visually corrupted. The first large scene families now advance past
+`IMAGE_GET_LOD` and stop at `s_cmp_eq_u64` comparing two saved wave-mask SGPR pairs. One exact live
+sequence creates `s[44:45]` and `s[46:47]` with `s_and_b64` against EXEC, then compares the pairs.
+The fragment CFG dispatcher handles mask-versus-zero comparisons, while this two-mask form remains
+fail-visible. That is the next distinct recompiler frontier; it is not part of the `IMAGE_GET_LOD`
+change.
+
+## Ruled out
+
+- **`IMAGE_GET_LOD` being unsupported is not, by itself, the cause of the corrupt red-triangle
+  frame.** At the exact target immediately after operation 1,937/draw 1,846, a current-recompiler
+  replay changed the BMP SHA-256 from `9b579dee...` to `cb33895b...`, but the red-pixel fraction was
+  effectively unchanged (`0.486912` to `0.486932`) and human inspection showed the same corrupt
+  scene. The hypothesis that implementing the first rejection alone restores this frame is false.
+- **Draw 1,846 is not explained by non-finite or wholly clipped geometry.** Its 9,600 transformed
+  vertices are finite; 4,872 are on-screen and 4,728 clipped. Of 3,200 triangles, 3,057 are
+  non-degenerate and the screen-spanning triangles are present in the transformed output.
+- **Draw 1,846's red overwrite is not caused by alpha blending.** Its fragment alpha is constant
+  one, so the decoded normal alpha blend reduces algebraically to an overwrite.
+- **The draw's primary texture is not using the old 4 KiB detiler.** The current `SW_4KB` detile
+  produces a triangle-coherence mean of `1.08505e-05`; the prior mapping and plain Morton candidates
+  produce `0.102495` and `0.133787`. The current mapping is the coherent one.
+
+## Verification
+
+Focused CPU suites pass in the `ps5ys` distrobox:
+
+```text
+recompile_coverage
+rdna2_decode_walk
+rdna2_spirv_struct
+shader_resource_contract
+```
+
+The structural test uses the exact title-live packet `f1800108 01480809` and requires a real
+`OpImageQueryLod`; an independent compute-stage arm requires the derivative-consuming operation to
+remain rejected outside fragment shaders. Mutating the production opcode gate from `0x60` to `0x61`
+breaks the named structural check, and mutating only the table-less coverage classifier breaks the
+named coverage check. Both pass again after restoration.
+
+The single authorized Vulkan replay completed in 2.689 seconds with return code zero and empty
+pre/post process censuses. It recompiled all retained stages, read back the exact 1920x1080 FP16
+target at operation 1,937, and produced the unchanged corrupt-scene result recorded above. This is
+generic shader-coverage progress, not a title-screen, gameplay-visual or performance improvement.

--- a/prosper/src/gpu/rdna2_decode.cpp
+++ b/prosper/src/gpu/rdna2_decode.cpp
@@ -521,15 +521,27 @@ void decode_operands(Rdna2Inst& i) {
             // Image op. opcode is 8 bits: MSB in dword0 bit 0, low 7 bits in [24:18] (Table 100:
             // "combine bits zero and 18-24" — dropping bit 0 aliased IMAGE_MSAA_LOAD (128) onto
             // IMAGE_LOAD (0) and the _G16/BVH families onto wrong identities); dmask[11:8];
-            // unorm[12]; GLC[13]; dim[5:3]. dword1: VADDR base[7:0]; VDATA base[15:8]; SRSRC (T# base
-            // SGPR, ×4)[20:16]; SSAMP (S# base SGPR, ×4)[25:21].
+            // dim[5:3]; DLC[7]; unorm[12]; GLC[13]; R128[15]; TFE[16]; LWE[17]; SLC[25].
+            // dword1: VADDR base[7:0]; VDATA base[15:8]; SRSRC (T# base SGPR, ×4)[20:16];
+            // SSAMP (S# base SGPR, ×4)[25:21]; A16[30]; D16[31]. Retain the reserved holes too,
+            // so an unsupported raw packet cannot be mistaken for the ordinary form.
             // image_sample = opcode 0x20, image_load = 0x00. (Bit layout verified via llvm-mc gfx1030.)
             const uint32_t d1 = i.words[1];
             i.opcode     = ((w & 1u) << 7) | ((w >> 18) & 0x7Fu);
+            i.mimg_nsa   = (w >> 1)  & 0x3u;
             i.mimg_dmask = (w >> 8)  & 0xFu;
             i.mimg_unorm = (w >> 12) & 0x1u;
             i.mimg_glc   = (w >> 13) & 0x1u;
             i.mimg_dim   = (w >> 3)  & 0x7u;
+            i.mimg_dlc   = (w >> 7)  & 0x1u;
+            i.mimg_r128  = (w >> 15) & 0x1u;
+            i.mimg_tfe   = (w >> 16) & 0x1u;
+            i.mimg_lwe   = (w >> 17) & 0x1u;
+            i.mimg_slc   = (w >> 25) & 0x1u;
+            i.mimg_a16   = (d1 >> 30) & 0x1u;
+            i.mimg_d16   = (d1 >> 31) & 0x1u;
+            i.mimg_reserved = (w & ((1u << 6) | (1u << 14))) != 0u ||
+                              (d1 & (0xFu << 26)) != 0u;
             i.dst    = vgpr(d1 >> 8);                         // VDATA (dest base)
             i.src[0] = vgpr(d1 & 0xFFu);                      // VADDR (coord base VGPR)
             i.src[1] = sgpr(((d1 >> 16) & 0x1Fu) << 2);       // SRSRC (T# base, 8 SGPRs)

--- a/prosper/src/gpu/rdna2_decode.hpp
+++ b/prosper/src/gpu/rdna2_decode.hpp
@@ -133,13 +133,24 @@ struct Rdna2Inst {
     // OP). Bit 16 is likewise captured so an unknown flag rejects rather than silently running
     // against workgroup LDS with device-global (GDS) semantics expected.
     bool     ds_gds = false;
-    // 2D=1, 3D=2, Cube=3, 1D_ARRAY=4, 2D_ARRAY=5, ...), the unnormalized-coordinate flag, and GLC
-    // (bit 13). For image atomics, GLC means return the pre-operation value to VDATA. VDATA is in
-    // `dst`, VADDR in src[0], SRSRC (T# base SGPR) in src[1], SSAMP (S# base SGPR) in src[2].
+    // 2D=1, 3D=2, Cube=3, 1D_ARRAY=4, 2D_ARRAY=5, ...), plus every MIMG control field from ISA
+    // Table 100. Keeping the controls explicit is correctness-critical: unlike VOP encodings, MIMG
+    // never sets `has_modifier`, and silently ignoring A16/TFE/etc. changes address/result layouts.
+    // VDATA is in `dst`, VADDR in src[0], SRSRC (T# base SGPR) in src[1], SSAMP (S# base SGPR) in
+    // src[2]. `mimg_reserved` covers dword0 bits 6/14 and dword1 bits 26..29.
+    uint32_t mimg_nsa   = 0;
     uint32_t mimg_dmask = 0;
     uint32_t mimg_dim   = 0;
     bool     mimg_unorm = false;
     bool     mimg_glc   = false;
+    bool     mimg_dlc   = false;
+    bool     mimg_r128  = false;
+    bool     mimg_tfe   = false;
+    bool     mimg_lwe   = false;
+    bool     mimg_slc   = false;
+    bool     mimg_a16   = false;
+    bool     mimg_d16   = false;
+    bool     mimg_reserved = false;
 
     // VINTRP-only: the interpolated attribute (parameter location) and its component channel (0..3).
     // opcode = p1(0)/p2(1)/mov(2); dst = vdst; src[0] = vsrc (the i/j barycentric VGPR).

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -49,7 +49,7 @@ enum : uint32_t {
     Op_ImageSampleDrefImplicitLod=89, Op_ImageSampleDrefExplicitLod=90,
     Op_ImageFetch=95, Op_ImageGather=96, Op_Image=100,
     Op_ImageRead=98, Op_ImageWrite=99, Op_ImageQuerySizeLod=103, Op_ImageQuerySize=104,
-    Op_ImageQueryLevels=106,
+    Op_ImageQueryLod=105, Op_ImageQueryLevels=106,
     Op_TypeArray=28, Op_ControlBarrier=224, Op_AtomicExchange=229, Op_AtomicIAdd=234,
     Op_AtomicISub=235,
     Op_AtomicSMin=236, Op_AtomicUMin=237, Op_AtomicSMax=238, Op_AtomicUMax=239,
@@ -1427,6 +1427,23 @@ struct SpirvCompute {
         }
         uint32_t levels = id(); put(code, Op_ImageQueryLevels, {t_i32, levels, img});
         out[3] = i2u(levels);
+    }
+    // image_get_lod: return the sampler-clamped and raw implicit LOD for a hypothetical 2D sample.
+    // SPIR-V defines OpImageQueryLod's x/y results in the same order as RDNA2's VDATA[0]/[1], so the
+    // two raw FP32 values can be copied directly to the guest VGPRs. Like the hardware instruction,
+    // this consumes screen-space derivatives and is therefore fragment-only.
+    void image_get_lod_2d(uint32_t binding, uint32_t u_bits, uint32_t v_bits, uint32_t out[2]) {
+        if (!declared_image_query) { put(caps, Op_Capability, {Cap_ImageQuery}); declared_image_query = true; }
+        const uint32_t simg = tex_binding_simg[binding];
+        uint32_t si = id(); put(code, Op_Load, {simg, si, tex_var[binding]});
+        uint32_t coord = id(); put(code, Op_CompositeConstruct,
+                                   {t_v2f(), coord, bcf(u_bits), bcf(v_bits)});
+        uint32_t lod = id(); put(code, Op_ImageQueryLod, {t_v2f(), lod, si, coord});
+        for (uint32_t component = 0; component < 2; ++component) {
+            uint32_t value = id();
+            put(code, Op_CompositeExtract, {t_f32, value, lod, component});
+            out[component] = bcu(value);
+        }
     }
     // 2-component uint vector (integer texel coordinates for OpImageFetch).
     uint32_t t_v2u_cache = 0;
@@ -9568,6 +9585,34 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 return true;
             }
 
+            // IMAGE_GET_LOD (0x60): RDNA2 returns {sampler-clamped LOD, raw LOD}; SPIR-V's
+            // OpImageQueryLod returns the same pair. House of the Dead 2's Unity scene shaders use
+            // the ordinary non-NSA 2D form in fragment programs. Keep every unverified dimension,
+            // flag, address shape, and output component fail-visible rather than guessing.
+            if (in.opcode == 0x60) {
+                if (!b.is_fragment || res->cls != ResourceClass::Texture ||
+                    in.mimg_dim != SQ_DIM_2D || res->img_dim != SQ_DIM_2D ||
+                    in.len_dwords != 2u || in.mimg_unorm || in.mimg_glc || in.has_modifier ||
+                    !(in.mimg_dmask & 0x3u) || (in.mimg_dmask & ~0x3u) ||
+                    res->unnormalized || res->depth_compare ||
+                    !b.declare_texture(res->binding, Dim_2D, uint_texture)) {
+                    ok = false;
+                    return true;
+                }
+                uint32_t out[2];
+                b.image_get_lod_2d(res->binding, vread(in.src[0].value),
+                                   vread(in.src[0].value + 1), out);
+                int vd = in.dst.value, written = 0;
+                for (uint32_t component = 0; component < 2; ++component) {
+                    if (!(in.mimg_dmask & (1u << component))) continue;
+                    const uint32_t old = vreg_old(b, rs, vd + written);
+                    rs.vreg[vd + written] = out[component];
+                    predicate_write(b, rs, vd + written, old);
+                    ++written;
+                }
+                return true;
+            }
+
             // --- Sampled-texture path: image_sample* (0x20/0x24/0x25/0x27) / image_gather4_lz (0x47) /
             // image_load (0x00). 2D (any LOD variant) or 3D (implicit-LOD or LOD-0 sample); NSA allowed
             // (coords gathered below). image_sample = 0x20 (implicit-LOD), image_sample_l = 0x24
@@ -14909,6 +14954,10 @@ RecompileCoverage recompile_coverage(const uint32_t* code, size_t dwords) {
                         return i.mimg_dim == 1u && i.mimg_dmask == 1u &&
                                !i.mimg_unorm && i.len_dwords == 2u;
                     if (i.opcode == 0x0eu) return i.mimg_dim <= 2u;             // image_get_resinfo 1D/2D/3D
+                    if (i.opcode == 0x60u)                                     // fragment image_get_lod 2D
+                        return i.mimg_dim == 1u && i.len_dwords == 2u &&
+                               !i.mimg_unorm && !i.mimg_glc && !i.has_modifier &&
+                               (i.mimg_dmask & 0x3u) && !(i.mimg_dmask & ~0x3u);
                     // sample*: 2D (NSA ok); plus implicit-LOD image_sample (0x20) / LOD-0 image_sample_lz
                     // (0x27) from a 3D texture; sample_b (0x25) and gather4_lz (0x47) are 2D. 2D_ARRAY (dim 5)
                     // is accepted for all sample paths and handled as its base 2D slice (array index dropped,

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -3877,6 +3877,25 @@ bool instruction_may_change_exec(const Rdna2Inst& in) {
     return is_exec(in.dst) || is_exec(in.sdst);
 }
 
+// IMAGE_GET_LOD currently models only the ordinary FP32 sampled-image form. Keep the unsupported
+// Table 100 control families separate so each can be mutation-tested, while production and the
+// table-less coverage classifier consume one shared predicate and cannot drift apart.
+bool mimg_get_lod_has_address_controls(const Rdna2Inst& in) {
+    return in.mimg_nsa != 0u || in.mimg_unorm || in.mimg_a16;
+}
+bool mimg_get_lod_has_cache_controls(const Rdna2Inst& in) {
+    return in.mimg_dlc || in.mimg_glc || in.mimg_slc;
+}
+bool mimg_get_lod_has_result_controls(const Rdna2Inst& in) {
+    return in.mimg_r128 || in.mimg_tfe || in.mimg_lwe || in.mimg_d16;
+}
+bool mimg_get_lod_has_unmodeled_controls(const Rdna2Inst& in) {
+    return mimg_get_lod_has_address_controls(in) ||
+           mimg_get_lod_has_cache_controls(in) ||
+           mimg_get_lod_has_result_controls(in) ||
+           in.mimg_reserved;
+}
+
 // A scalar VCCZ branch tests whether ANY active lane set VCC, not this lane's bit. Stages without
 // fragment's forced wave64 vote may lower it as structured control only when the VCC producer is
 // provably uniform across the wave. Dead Cells' light loops use the narrow compiler shape
@@ -9588,11 +9607,11 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // IMAGE_GET_LOD (0x60): RDNA2 returns {sampler-clamped LOD, raw LOD}; SPIR-V's
             // OpImageQueryLod returns the same pair. House of the Dead 2's Unity scene shaders use
             // the ordinary non-NSA 2D form in fragment programs. Keep every unverified dimension,
-            // flag, address shape, and output component fail-visible rather than guessing.
+            // Table 100 control, address shape, and output component fail-visible rather than guessing.
             if (in.opcode == 0x60) {
                 if (!b.is_fragment || res->cls != ResourceClass::Texture ||
                     in.mimg_dim != SQ_DIM_2D || res->img_dim != SQ_DIM_2D ||
-                    in.len_dwords != 2u || in.mimg_unorm || in.mimg_glc || in.has_modifier ||
+                    in.len_dwords != 2u || mimg_get_lod_has_unmodeled_controls(in) ||
                     !(in.mimg_dmask & 0x3u) || (in.mimg_dmask & ~0x3u) ||
                     res->unnormalized || res->depth_compare ||
                     !b.declare_texture(res->binding, Dim_2D, uint_texture)) {
@@ -14956,7 +14975,7 @@ RecompileCoverage recompile_coverage(const uint32_t* code, size_t dwords) {
                     if (i.opcode == 0x0eu) return i.mimg_dim <= 2u;             // image_get_resinfo 1D/2D/3D
                     if (i.opcode == 0x60u)                                     // fragment image_get_lod 2D
                         return i.mimg_dim == 1u && i.len_dwords == 2u &&
-                               !i.mimg_unorm && !i.mimg_glc && !i.has_modifier &&
+                               !mimg_get_lod_has_unmodeled_controls(i) &&
                                (i.mimg_dmask & 0x3u) && !(i.mimg_dmask & ~0x3u);
                     // sample*: 2D (NSA ok); plus implicit-LOD image_sample (0x20) / LOD-0 image_sample_lz
                     // (0x27) from a 3D texture; sample_b (0x25) and gather4_lz (0x47) are 2D. 2D_ARRAY (dim 5)

--- a/prosper/tests/test_rdna2_decode.cpp
+++ b/prosper/tests/test_rdna2_decode.cpp
@@ -3,6 +3,7 @@
 // The stream mixes every major encoding class + inline literals + S_ENDPGM; the walker must classify
 // each instruction's format, compute its length (incl. literals), and terminate at S_ENDPGM.
 #include "../src/gpu/rdna2_decode.hpp"
+#include <array>
 #include <cstdio>
 #include <cstdint>
 
@@ -319,7 +320,8 @@ int main() {
     // reads exactly these bytes to gather the non-sequential coords.
     const uint32_t mimg_nsa3d[] = { 0xf0000f12u, 0x00000000u, 0x00000307u };
     Rdna2Inst n3 = rdna2_decode_one(mimg_nsa3d, 3);
-    CHECK(n3.fmt == Rdna2Format::MIMG && n3.opcode == 0x00u && n3.len_dwords == 3 && n3.mimg_dim == 2u &&
+    CHECK(n3.fmt == Rdna2Format::MIMG && n3.opcode == 0x00u && n3.len_dwords == 3 &&
+          n3.mimg_nsa == 1u && n3.mimg_dim == 2u &&
           (n3.words[1] & 0xFFu) == 0u && (n3.words[2] & 0xFFu) == 7u && ((n3.words[2] >> 8) & 0xFFu) == 3u,
           "NSA MIMG 3D captures the extra address dword; coords decode to v0,v7,v3");
     // Astro Bot's world-map ray traversal uses the maximum three NSA dwords to name eleven input
@@ -348,6 +350,47 @@ int main() {
           atomic_add.mimg_dim == 1u && atomic_add.mimg_dmask == 1u && atomic_add.mimg_glc &&
           atomic_add.dst.value == 1 && atomic_add.src[0].value == 4 && atomic_add.src[1].value == 28,
           "Astro image_atomic_add decodes the live 2D/R32 visibility packet");
+
+    // Every MIMG Table 100 control is retained independently. These are exact llvm-mc gfx1030
+    // IMAGE_GET_LOD encodings except D16, which llvm-mc rejects for this opcode; the raw D16 field
+    // still has to remain fail-visible rather than alias the ordinary FP32 result form.
+    const Rdna2Inst lod_plain = rdna2_decode_one(
+        std::array<uint32_t, 2>{0xf1800108u, 0x01480809u}.data(), 2);
+    const Rdna2Inst lod_dlc = rdna2_decode_one(
+        std::array<uint32_t, 2>{0xf1800188u, 0x01480809u}.data(), 2);
+    const Rdna2Inst lod_slc = rdna2_decode_one(
+        std::array<uint32_t, 2>{0xf3800108u, 0x01480809u}.data(), 2);
+    const Rdna2Inst lod_r128 = rdna2_decode_one(
+        std::array<uint32_t, 2>{0xf1808108u, 0x01480809u}.data(), 2);
+    const Rdna2Inst lod_tfe = rdna2_decode_one(
+        std::array<uint32_t, 2>{0xf1810108u, 0x01480809u}.data(), 2);
+    const Rdna2Inst lod_lwe = rdna2_decode_one(
+        std::array<uint32_t, 2>{0xf1820108u, 0x01480809u}.data(), 2);
+    const Rdna2Inst lod_a16 = rdna2_decode_one(
+        std::array<uint32_t, 2>{0xf1800108u, 0x41480809u}.data(), 2);
+    const Rdna2Inst lod_d16_raw = rdna2_decode_one(
+        std::array<uint32_t, 2>{0xf1800108u, 0x81480809u}.data(), 2);
+    CHECK(lod_plain.mimg_nsa == 0u && !lod_plain.mimg_unorm && !lod_plain.mimg_dlc &&
+              !lod_plain.mimg_glc && !lod_plain.mimg_slc && !lod_plain.mimg_r128 &&
+              !lod_plain.mimg_tfe && !lod_plain.mimg_lwe && !lod_plain.mimg_a16 &&
+              !lod_plain.mimg_d16 && !lod_plain.mimg_reserved,
+          "ordinary IMAGE_GET_LOD has no auxiliary MIMG controls");
+    CHECK(lod_dlc.mimg_dlc && lod_slc.mimg_slc && lod_r128.mimg_r128 &&
+              lod_tfe.mimg_tfe && lod_lwe.mimg_lwe && lod_a16.mimg_a16 &&
+              lod_d16_raw.mimg_d16,
+          "IMAGE_GET_LOD retains exact DLC/SLC/R128/TFE/LWE/A16 and raw D16 fields");
+    bool all_reserved_retained = true;
+    for (const auto words : std::array<std::array<uint32_t, 2>, 6>{
+             std::array<uint32_t, 2>{0xf1800148u, 0x01480809u}, // dword0 bit 6
+             std::array<uint32_t, 2>{0xf1804108u, 0x01480809u}, // dword0 bit 14
+             std::array<uint32_t, 2>{0xf1800108u, 0x05480809u}, // dword1 bit 26
+             std::array<uint32_t, 2>{0xf1800108u, 0x09480809u}, // dword1 bit 27
+             std::array<uint32_t, 2>{0xf1800108u, 0x11480809u}, // dword1 bit 28
+             std::array<uint32_t, 2>{0xf1800108u, 0x21480809u}, // dword1 bit 29
+         })
+        all_reserved_retained &= rdna2_decode_one(words.data(), words.size()).mimg_reserved;
+    CHECK(all_reserved_retained,
+          "all six reserved MIMG control bits are retained for fail-visible rejection");
 
     // inline-constant field decode: SGPR106 special, field 129 -> +1, 193 -> -1, 242 -> 1.0f
     CHECK(decode_src_field(0).kind == OperandKind::SGPR && decode_src_field(0).value == 0, "field 0 -> SGPR0");

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -2512,7 +2512,8 @@ int main() {
     // image_sample there must lower to OpImageSampleExplicitLod (LOD 0) or spirv-val rejects the
     // module and pipeline creation fails.
     enum : uint32_t { OpImageSampleImplicitLod = 87, OpImageSampleExplicitLod = 88,
-                      OpImageQuerySizeLod = 103, OpImageQueryLevels = 106 };
+                      OpImageQuerySizeLod = 103, OpImageQueryLod = 105,
+                      OpImageQueryLevels = 106 };
     ShaderResourceTable rt_tex;
     { ShaderResource t{}; t.cls = ResourceClass::Texture; t.binding = 4; t.img_dim = 1; /*2D*/
       t.width = 2; t.height = 2; t.sgpr_base = 8; rt_tex.resources.push_back(t); }
@@ -2554,6 +2555,37 @@ int main() {
         return 1;
     }
     printf("  [ok]   fragment image_sample still uses OpImageSampleImplicitLod\n");
+
+    // House of the Dead 2's Unity scene shaders use IMAGE_GET_LOD on ordinary 2D textures before
+    // their explicit-LOD samples. The exact instruction returns clamped/raw LOD in the selected
+    // VDATA channels. A constant replacement would hide the rejected opcode while choosing the
+    // wrong mip, so require the real derivative-consuming SPIR-V image query. SPIR-V permits that
+    // query only in a fragment stage; the same bytes must remain fail-visible in compute.
+    ShaderResourceTable rt_get_lod;
+    { ShaderResource t{}; t.cls = ResourceClass::Texture; t.binding = 4; t.img_dim = 1;
+      t.width = 1024; t.height = 1024; t.sgpr_base = 32; t.sampler_sgpr_base = 40;
+      rt_get_lod.resources.push_back(t); }
+    const uint32_t ps_get_lod[] = {
+        // Exact pc-99 words from House's 663-dword failing fragment family (f67b86713089788d).
+        0xf1800108u, 0x01480809u,           // image_get_lod v8, v[9:10], s[32:39], s[40:43], dmask:x, dim:2D
+        0xf800000fu, 0x0b0a0908u,           // exp mrt0 v8,v9,v10,v11
+        0xbf810000u,
+    };
+    const std::vector<uint32_t> get_lod_spv = recompile_fragment(
+        ps_get_lod, std::size(ps_get_lod), &rt_get_lod);
+    if (get_lod_spv.empty() || !has_opcode(get_lod_spv, OpImageQueryLod)) {
+        printf("  [FAIL] fragment IMAGE_GET_LOD did not lower to OpImageQueryLod\n");
+        return 1;
+    }
+    const uint32_t cs_get_lod[] = {
+        ps_get_lod[0], ps_get_lod[1],
+        0xbf810000u,
+    };
+    if (!recompile_valu(cs_get_lod, std::size(cs_get_lod), 0, 0, &rt_get_lod).empty()) {
+        printf("  [FAIL] compute-shell IMAGE_GET_LOD bypassed the fragment-only derivative contract\n");
+        return 1;
+    }
+    printf("  [ok]   fragment IMAGE_GET_LOD lowers to a real fragment-only image LOD query\n");
 
     // UE4/DOLL volume initialization starts by querying a 3D T# with image_get_resinfo, then uses the
     // xyz result for its dispatch bounds. This was the sole rejected opcode in that captured kernel.

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -89,6 +89,84 @@ bool has_opcode(const std::vector<uint32_t>& spv, uint32_t opcode) {
     return false;
 }
 
+// Trace IMAGE_GET_LOD all the way from two known VGPR bit patterns to the fragment output. This is
+// deliberately a dataflow check rather than an opcode-presence check: it proves coordinate
+// provenance, AMD/SPIR-V x/y component order, compact dmask-to-VDATA placement, and the EXEC select
+// that preserves an inactive lane's old VGPR value.
+bool image_query_lod_contract(const std::vector<uint32_t>& spv,
+                              uint32_t expected_u_bits, uint32_t expected_v_bits,
+                              const std::array<int, 4>& expected_export_components) {
+    constexpr uint32_t OpConstant = 43, OpVariable = 59, OpStore = 62,
+                       OpCompositeConstruct = 80, OpCompositeExtract = 81,
+                       OpBitcast = 124, OpSelect = 169, OpImageQueryLod = 105;
+    constexpr uint32_t StorageClassOutput = 3;
+    struct SelectOperands { uint32_t condition = 0, true_value = 0, false_value = 0; };
+    struct Extract { uint32_t composite = 0, component = 0; };
+    std::unordered_map<uint32_t, uint32_t> constants;
+    std::unordered_map<uint32_t, uint32_t> bitcast_sources;
+    std::unordered_map<uint32_t, std::vector<uint32_t>> composites;
+    std::unordered_map<uint32_t, Extract> extracts;
+    std::unordered_map<uint32_t, SelectOperands> selects;
+    std::unordered_set<uint32_t> outputs;
+    uint32_t query_result = 0, query_coordinate = 0, stored_output = 0;
+    for (size_t i = 5; i < spv.size();) {
+        const uint32_t op = spv[i] & 0xffffu, wc = spv[i] >> 16u;
+        if (!wc || i + wc > spv.size()) return false;
+        if (op == OpConstant && wc == 4) constants[spv[i + 2]] = spv[i + 3];
+        if (op == OpVariable && wc >= 4 && spv[i + 3] == StorageClassOutput)
+            outputs.insert(spv[i + 2]);
+        if (op == OpBitcast && wc == 4) bitcast_sources[spv[i + 2]] = spv[i + 3];
+        if (op == OpCompositeConstruct && wc >= 4)
+            composites[spv[i + 2]] = std::vector<uint32_t>(spv.begin() + i + 3,
+                                                            spv.begin() + i + wc);
+        if (op == OpCompositeExtract && wc == 5)
+            extracts[spv[i + 2]] = {spv[i + 3], spv[i + 4]};
+        if (op == OpSelect && wc == 6)
+            selects[spv[i + 2]] = {spv[i + 3], spv[i + 4], spv[i + 5]};
+        if (op == OpImageQueryLod && wc == 5) {
+            if (query_result) return false;
+            query_result = spv[i + 2];
+            query_coordinate = spv[i + 4];
+        }
+        if (op == OpStore && wc == 3 && outputs.contains(spv[i + 1])) {
+            if (stored_output) return false;
+            stored_output = spv[i + 2];
+        }
+        i += wc;
+    }
+    if (!query_result || !query_coordinate || !stored_output) return false;
+    const auto coordinate = composites.find(query_coordinate);
+    if (coordinate == composites.end() || coordinate->second.size() != 2u) return false;
+    const uint32_t expected_coordinate_bits[2] = {expected_u_bits, expected_v_bits};
+    for (uint32_t component = 0; component < 2; ++component) {
+        const auto coordinate_bitcast = bitcast_sources.find(coordinate->second[component]);
+        if (coordinate_bitcast == bitcast_sources.end()) return false;
+        const auto coordinate_constant = constants.find(coordinate_bitcast->second);
+        if (coordinate_constant == constants.end() ||
+            coordinate_constant->second != expected_coordinate_bits[component])
+            return false;
+    }
+    const auto output_vector = composites.find(stored_output);
+    if (output_vector == composites.end() || output_vector->second.size() != 4u) return false;
+    for (uint32_t output_component = 0; output_component < 4; ++output_component) {
+        const int expected_query_component = expected_export_components[output_component];
+        if (expected_query_component < 0) continue;
+        const auto output_bitcast = bitcast_sources.find(output_vector->second[output_component]);
+        if (output_bitcast == bitcast_sources.end()) return false;
+        const auto predicated_write = selects.find(output_bitcast->second);
+        if (predicated_write == selects.end() || !predicated_write->second.condition ||
+            predicated_write->second.true_value == predicated_write->second.false_value)
+            return false;
+        const auto query_bitcast = bitcast_sources.find(predicated_write->second.true_value);
+        if (query_bitcast == bitcast_sources.end()) return false;
+        const auto extract = extracts.find(query_bitcast->second);
+        if (extract == extracts.end() || extract->second.composite != query_result ||
+            extract->second.component != static_cast<uint32_t>(expected_query_component))
+            return false;
+    }
+    return true;
+}
+
 // Whether an instruction's zero-based operand has the requested literal value.
 bool has_instruction_operand(const std::vector<uint32_t>& spv, uint32_t opcode,
                              uint32_t operand_index, uint32_t value) {
@@ -2565,18 +2643,50 @@ int main() {
     { ShaderResource t{}; t.cls = ResourceClass::Texture; t.binding = 4; t.img_dim = 1;
       t.width = 1024; t.height = 1024; t.sgpr_base = 32; t.sampler_sgpr_base = 40;
       rt_get_lod.resources.push_back(t); }
-    const uint32_t ps_get_lod[] = {
-        // Exact pc-99 words from House's 663-dword failing fragment family (f67b86713089788d).
-        0xf1800108u, 0x01480809u,           // image_get_lod v8, v[9:10], s[32:39], s[40:43], dmask:x, dim:2D
-        0xf800000fu, 0x0b0a0908u,           // exp mrt0 v8,v9,v10,v11
-        0xbf810000u,
+    constexpr uint32_t lod_u_bits = 0x3e800000u; // 0.25, distinct provenance sentinels
+    constexpr uint32_t lod_v_bits = 0x3f400000u; // 0.75
+    auto compile_get_lod = [&](uint32_t dmask) {
+        const uint32_t export_mask = dmask == 3u ? 3u : 1u;
+        const std::array<uint32_t, 10> shader = {
+            0x7e1202ffu, lod_u_bits,           // v_mov_b32 v9, 0.25
+            0x7e1402ffu, lod_v_bits,           // v_mov_b32 v10, 0.75
+            0x7da40100u,                       // v_cmpx_eq_u32 v0,v0: force an EXEC-predicated write
+            0xf1800008u | (dmask << 8), 0x01480809u,
+            0xf8000000u | export_mask, 0x0b0a0908u, // export selected VDATA from v8[/v9]
+            0xbf810000u,
+        };
+        return recompile_fragment(shader.data(), shader.size(), &rt_get_lod);
     };
-    const std::vector<uint32_t> get_lod_spv = recompile_fragment(
-        ps_get_lod, std::size(ps_get_lod), &rt_get_lod);
-    if (get_lod_spv.empty() || !has_opcode(get_lod_spv, OpImageQueryLod)) {
-        printf("  [FAIL] fragment IMAGE_GET_LOD did not lower to OpImageQueryLod\n");
+    const std::vector<uint32_t> get_lod_x_spv = compile_get_lod(1u);
+    const std::vector<uint32_t> get_lod_y_spv = compile_get_lod(2u);
+    const std::vector<uint32_t> get_lod_xy_spv = compile_get_lod(3u);
+    if (get_lod_x_spv.empty() ||
+        !image_query_lod_contract(get_lod_x_spv, lod_u_bits, lod_v_bits,
+                                  std::array<int, 4>{0, -1, -1, -1})) {
+        printf("  [FAIL] IMAGE_GET_LOD dmask:x lost coordinate, clamped-LOD, or predicated VDATA flow\n");
         return 1;
     }
+    if (get_lod_y_spv.empty() ||
+        !image_query_lod_contract(get_lod_y_spv, lod_u_bits, lod_v_bits,
+                                  std::array<int, 4>{1, -1, -1, -1})) {
+        printf("  [FAIL] IMAGE_GET_LOD dmask:y did not compact raw LOD into VDATA[0]\n");
+        return 1;
+    }
+    if (get_lod_xy_spv.empty() ||
+        !image_query_lod_contract(get_lod_xy_spv, lod_u_bits, lod_v_bits,
+                                  std::array<int, 4>{0, 1, -1, -1})) {
+        printf("  [FAIL] IMAGE_GET_LOD dmask:xy lost clamped/raw order in consecutive VDATA\n");
+        return 1;
+    }
+    printf("  [ok]   IMAGE_GET_LOD preserves uv, clamped/raw x/y, compact VDATA, and EXEC predication\n");
+
+    // Exact ordinary title packet. The compute negative is intentionally isolated from every MIMG
+    // control gate: mutating only `!b.is_fragment` makes this named check fail.
+    const uint32_t ps_get_lod[] = {
+        0xf1800108u, 0x01480809u,           // House pc-99: dmask:x, ordinary FP32 2D form
+        0xf8000001u, 0x0b0a0908u,
+        0xbf810000u,
+    };
     const uint32_t cs_get_lod[] = {
         ps_get_lod[0], ps_get_lod[1],
         0xbf810000u,
@@ -2585,7 +2695,43 @@ int main() {
         printf("  [FAIL] compute-shell IMAGE_GET_LOD bypassed the fragment-only derivative contract\n");
         return 1;
     }
-    printf("  [ok]   fragment IMAGE_GET_LOD lowers to a real fragment-only image LOD query\n");
+    printf("  [ok]   compute shell rejects only the fragment-stage IMAGE_GET_LOD contract\n");
+
+    // Every non-ordinary Table 100 control remains fail-visible in both production and the
+    // table-less classifier. NSA/A16/DLC/GLC/SLC/R128/TFE/LWE are exact llvm-mc gfx1030 encodings.
+    // UNRM comes directly from Table 100 because LLVM exposes no IMAGE_GET_LOD spelling for it;
+    // LLVM rejects D16 for IMAGE_GET_LOD. Their raw fields and every reserved hole still reject.
+    struct UnsupportedGetLod {
+        const char* name;
+        std::vector<uint32_t> instruction;
+    };
+    const std::vector<UnsupportedGetLod> unsupported_get_lod = {
+        {"NSA",      {0xf180010au, 0x01480809u, 0x0000000au}},
+        {"UNRM",     {0xf1801108u, 0x01480809u}},
+        {"A16",      {0xf1800108u, 0x41480809u}},
+        {"DLC",      {0xf1800188u, 0x01480809u}},
+        {"GLC",      {0xf1802108u, 0x01480809u}},
+        {"SLC",      {0xf3800108u, 0x01480809u}},
+        {"R128",     {0xf1808108u, 0x01480809u}},
+        {"TFE",      {0xf1810108u, 0x01480809u}},
+        {"LWE",      {0xf1820108u, 0x01480809u}},
+        {"D16-raw",  {0xf1800108u, 0x81480809u}},
+        {"reserved-w0-b6",  {0xf1800148u, 0x01480809u}},
+        {"reserved-w0-b14", {0xf1804108u, 0x01480809u}},
+        {"reserved-w1-b26", {0xf1800108u, 0x05480809u}},
+        {"reserved-w1-b27", {0xf1800108u, 0x09480809u}},
+        {"reserved-w1-b28", {0xf1800108u, 0x11480809u}},
+        {"reserved-w1-b29", {0xf1800108u, 0x21480809u}},
+    };
+    for (const auto& form : unsupported_get_lod) {
+        std::vector<uint32_t> fragment = form.instruction;
+        fragment.insert(fragment.end(), {0xf8000001u, 0x0b0a0908u, 0xbf810000u});
+        if (!recompile_fragment(fragment.data(), fragment.size(), &rt_get_lod).empty()) {
+            printf("  [FAIL] IMAGE_GET_LOD %s control was accepted by production\n", form.name);
+            return 1;
+        }
+    }
+    printf("  [ok]   all unsupported IMAGE_GET_LOD controls reject in production\n");
 
     // UE4/DOLL volume initialization starts by querying a 3D T# with image_get_resinfo, then uses the
     // xyz result for its dispatch bounds. This was the sole rejected opcode in that captured kernel.

--- a/prosper/tests/test_recompile_coverage.cpp
+++ b/prosper/tests/test_recompile_coverage.cpp
@@ -845,6 +845,16 @@ int main() {
     CHECK(f.unsupported == 0 && f.table_dependent >= 1 && f.first_bad_fmt < 0,
           "#325: a 2D_ARRAY image_sample is recompilable-in-context (base slice), not unsupported");
 
+    // House of the Dead 2's exact IMAGE_GET_LOD packet needs both a fragment execution model and its
+    // captured T#/S# pair. The table-less coverage pass must classify it as context-dependent rather
+    // than keep reporting opcode 0x60 as unsupported after the production fragment lowering accepts it.
+    const uint32_t get_lod_2d[] = { 0xf1800108u, 0x01480809u, 0xbf810000u };
+    const RecompileCoverage get_lod = recompile_coverage(
+        get_lod_2d, std::size(get_lod_2d));
+    CHECK(get_lod.total == 1 && get_lod.table_dependent == 1 &&
+              get_lod.unsupported == 0 && get_lod.first_bad_fmt < 0,
+          "2D IMAGE_GET_LOD reports recompilable-in-context, not unsupported");
+
     // Asterix's resolve PS mixes the ordinary and exact one-extra-word NSA 2D_MSAA IMAGE_LOAD
     // encodings. Coverage is table-less, but it can still distinguish the address shapes the real
     // resource-aware emitter accepts from superficially similar, deliberately unsupported packets.

--- a/prosper/tests/test_recompile_coverage.cpp
+++ b/prosper/tests/test_recompile_coverage.cpp
@@ -855,6 +855,43 @@ int main() {
               get_lod.unsupported == 0 && get_lod.first_bad_fmt < 0,
           "2D IMAGE_GET_LOD reports recompilable-in-context, not unsupported");
 
+    struct UnsupportedGetLod {
+        const char* name;
+        std::vector<uint32_t> instruction;
+    };
+    const std::vector<UnsupportedGetLod> unsupported_get_lod = {
+        // NSA/A16/DLC/GLC/SLC/R128/TFE/LWE are exact llvm-mc gfx1030 encodings. UNRM comes directly
+        // from Table 100 because LLVM exposes no IMAGE_GET_LOD spelling for it; D16 is rejected for
+        // this opcode. Their raw fields and the reserved holes must not alias the ordinary contract.
+        {"NSA",      {0xf180010au, 0x01480809u, 0x0000000au}},
+        {"UNRM",     {0xf1801108u, 0x01480809u}},
+        {"A16",      {0xf1800108u, 0x41480809u}},
+        {"DLC",      {0xf1800188u, 0x01480809u}},
+        {"GLC",      {0xf1802108u, 0x01480809u}},
+        {"SLC",      {0xf3800108u, 0x01480809u}},
+        {"R128",     {0xf1808108u, 0x01480809u}},
+        {"TFE",      {0xf1810108u, 0x01480809u}},
+        {"LWE",      {0xf1820108u, 0x01480809u}},
+        {"D16-raw",  {0xf1800108u, 0x81480809u}},
+        {"reserved-w0-b6",  {0xf1800148u, 0x01480809u}},
+        {"reserved-w0-b14", {0xf1804108u, 0x01480809u}},
+        {"reserved-w1-b26", {0xf1800108u, 0x05480809u}},
+        {"reserved-w1-b27", {0xf1800108u, 0x09480809u}},
+        {"reserved-w1-b28", {0xf1800108u, 0x11480809u}},
+        {"reserved-w1-b29", {0xf1800108u, 0x21480809u}},
+    };
+    for (const auto& form : unsupported_get_lod) {
+        std::vector<uint32_t> code = form.instruction;
+        code.push_back(0xbf810000u);
+        const RecompileCoverage classified = recompile_coverage(code.data(), code.size());
+        char message[160];
+        std::snprintf(message, sizeof(message),
+                      "IMAGE_GET_LOD %s remains unsupported in table-less coverage", form.name);
+        CHECK(classified.total == 1 && classified.table_dependent == 0 &&
+                  classified.unsupported == 1,
+              message);
+    }
+
     // Asterix's resolve PS mixes the ordinary and exact one-extra-word NSA 2D_MSAA IMAGE_LOAD
     // encodings. Coverage is table-less, but it can still distinguish the address shapes the real
     // resource-aware emitter accepts from superficially similar, deliberately unsupported packets.


### PR DESCRIPTION
## What changed

- lower the verified normalized FP32 2D fragment form of RDNA2 `IMAGE_GET_LOD` to a real SPIR-V
  `OpImageQueryLod`, preserving AMD's `{clampedLOD, rawLOD}` order and compact dmask writes
- retain every RDNA2 MIMG control field separately: NSA, DLC, UNRM, GLC, R128, TFE, LWE, SLC,
  A16, D16, and all six reserved Table 100 bit positions
- reject every unmodeled address, cache-policy, descriptor/result, precision, and reserved form in
  both production recompilation and the table-less coverage classifier
- prove the accepted contract structurally from distinct U/V VGPR values through the query,
  clamped/raw extracts, compact x/y/xy VDATA writes, EXEC predication, and fragment export
- add exact production and coverage negatives for every unsupported control family and reserved bit
- retain the durable House investigation/status record, including the unchanged-frame falsification
  and the next distinct `s_cmp_eq_u64` frontier

## Why

The Training 1 capture has 1,056 failed fragment stages. `IMAGE_GET_LOD` (`MIMG op=0x60`) is the
first rejection in 1,006 of them. AMD's RDNA2 ISA defines its result as
`{clampedLOD, rawLOD}` and the individual MIMG encoding fields. Khronos defines the same x/y order,
32-bit floating coordinate/result contract, and fragment-only restriction for `OpImageQueryLod`:

- [AMD RDNA2 Shader ISA, MIMG format and IMAGE_GET_LOD](https://docs.amd.com/v/u/en-US/rdna2-shader-instruction-set-architecture)
- [Khronos SPIR-V `OpImageQueryLod`](https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpImageQueryLod)

LLVM `llvm-mc`/`llvm-objdump` with `gfx1030` independently round-tripped the ordinary packet and the
NSA/A16/DLC/GLC/SLC/R128/TFE/LWE encodings used by the negative tests. LLVM rejects D16 for this
opcode; the D16, UNRM, and reserved raw encodings still reject fail-visibly rather than aliasing the
ordinary contract.

This is real generic shader-coverage progress, but deliberately not presented as a House visual fix.
The full current-recompiler replay remains the same corrupt red-triangle scene. Large scene shaders
now advance to `s_cmp_eq_u64` between two saved wave-mask pairs; that separate CFG capability remains
fail-visible and is the next frontier.

Refs #1907.

## Review hardening

The blocking review of the original head correctly found that `has_modifier` is vacuous for MIMG and
that opcode presence did not prove the result contract. The follow-up removes that gate, decodes the
actual MIMG fields, uses one shared no-controls predicate in production and coverage, and replaces
the opcode-presence check with full SPIR-V dataflow assertions.

The production coordinate order remains `VADDR[0]` as U and `VADDR[1]` as V. A temporary mutation
that swapped them was used only to prove the test fails; it was restored before commit.

## CPU verification

Built and run inside the `ps5ys` distrobox with a worktree-local, HOME-backed `TMPDIR` after rebasing
onto exact master `5cecfbe8d1dda5d7610121791e1e306ad719df0a`:

```bash
ctest --test-dir <BUILD_DIR> --output-on-failure \
  -R '^(recompile_coverage|rdna2_decode_walk|rdna2_spirv_struct|shader_resource_contract)$'
```

Result: **4/4 passed** at exact head `2679f94be5abcbecaf27de2267b1aceca43b9f52`.

Named clean witnesses include:

- `IMAGE_GET_LOD preserves uv, clamped/raw x/y, compact VDATA, and EXEC predication`
- `compute shell rejects only the fragment-stage IMAGE_GET_LOD contract`
- `all unsupported IMAGE_GET_LOD controls reject in production`
- individual table-less negatives for NSA, UNRM, A16, DLC, GLC, SLC, R128, TFE, LWE, D16, and
  each of the six reserved bits

Defect-shaped mutation controls all failed their named tests and passed again after restoration:

1. swapped U/V query coordinates
2. swapped clamped/raw result extracts
3. changed compact VDATA writes to component-indexed writes (`dmask:y` witness)
4. removed the EXEC-predicated write
5. removed only the fragment-stage gate (compute witness)
6. disabled each shared address/cache/result/reserved no-controls predicate family
7. erased reserved-bit decoding (all six decoder witnesses)

No GPU was used for this review-fix pass.

## Captured-shader verification

With a deliberately invalid Vulkan ICD so the diagnostic could not initialize a device, raw retry
accepted three representative shaders that previously stopped at `IMAGE_GET_LOD`:

- 14,542 SPIR-V dwords / 22 resources
- 10,621 SPIR-V dwords / 12 resources
- 11,379 SPIR-V dwords / 13 resources

The two large scene programs then advance to their next unsupported instruction at pc 1276/1372,
independently disassembled as `s_cmp_eq_u64`. The exact live pc-1276 sequence compares
`s[44:45]` with `s[46:47]` after both pairs were produced by `s_and_b64` against EXEC.

## Exact replay discriminator

The first prepared replay incorrectly combined `--through-operation` with
`--output-target-after`; the parser rejects that combination because the latter already executes
the inclusive prefix. It exited usage-only with rc 2 in 8 ms, empty pre/post censuses and no Vulkan
initialization, so that attempt is VOID.

The corrected, single authorized arm was:

```bash
timeout --signal=TERM --kill-after=10s 10m \
  <BUILD_DIR>/gpu_replay --recompile-raw \
  --output-target-after 1937:0x2042fd0000 \
  <CAPTURE>/submit-12715.prgcap <EVIDENCE>/post-get-lod.bmp
```

Result:

- rc 0; wall time 2.689 s
- exact pre/post `prosper-app` / `gpu_replay` censuses: 0 / 0
- graphics: substituted VS 809, FS 809; kept stored VS 0, FS 0
- compute: substituted 106; kept stored 0
- exact output: operation 1,937, draw 1,846, slot 0, address `0x2042fd0000`, 1920x1080,
  format 97; backend hash `dce8e600954195f4`
- BMP SHA-256: `cb33895b8c92ac2be7f9f4c4b025670e39bb8035fed604a0ef264da57a82cc22`
- red-pixel fraction: 0.486932, versus 0.486912 in the stored-SPIR-V baseline

The output bytes differ, but human inspection shows the same corrupt red-triangle scene. This PR
therefore makes no screenshot, gameplay-visual, rung, or FPS claim.
