### PR TITLE
fix(gpu): evaluate owned writes before eager waits

### DIFF
--- a/prosper/docs/ASTROBOT_LINUX_HANDOFF_2026_07_19.md
+++ b/prosper/docs/ASTROBOT_LINUX_HANDOFF_2026_07_19.md
@@ -712,10 +712,45 @@ made no new visual-correctness claim, so no new screenshot was warranted. Retain
 evidence remains outside git under
 `<EVIDENCE_ROOT>/astro-1732-allocation-reuse-41b37177/`.
 
+## Ordered retained-write wait result (2026-08-04)
+
+Issue #1732's post-#1924 PS-logo stall was an eager `WAIT_REG_MEM` reading a label before two
+retained producers could execute: an owned exact-base `WRITE_DATA(0)` followed by
+`RELEASE_MEM32(1)`. Candidate `88c61215`, based on master `5cecfbe8`, overlays only one or two owned
+inline dwords at the exact waited address and then applies the fixed release in command order. It
+keeps partial snapshots, unowned payloads, writes wider than the waited qword, offset writes, and
+physically aliased virtual addresses fail-closed.
+
+The exact live arm is summarized in the first `## Ruled out` entry below. It positively observed the
+new overlay and advanced from loaded and started `ps_logo` to loaded `title_controller_ship`; the
+earlier memory-effect wait blocker disappeared. It did **not** start the title level or reach
+`worldmap`, and no visual or FPS measurement was taken. The next exact frontier is a different eager
+wait dependency: every emitted rejection summary overlaps an earlier retained address-backed DMA,
+so its scalar overlay remains untouched. Do not broaden the `WRITE_DATA` model to address this.
+
+Focused `diag_ratelimit`, `eop_write`, and `agc_dcb_pm4` tests pass. Isolated mutations prove the
+supported overlay, low/high-dword order, ownership, partial/oversized bounds, exact-VA requirement,
+and reporter path are each observed by a named check. The GitHub issue carries the exact live
+revision, binary hash, bounded-run validity, and sparse diagnostic counts.
+
 ## Ruled out
 
 One line per falsified hypothesis, the evidence that killed it, and the issue/PR. Extend this rather
 than re-deriving a dead answer at full cost.
+
+- **"After exact retained `WRITE_DATA` overlays are accepted, the remaining title-load stall is
+  another instance of the same memory-effect/wait ambiguity."** False on exact candidate
+  `88c61215` in one natural, full-scale, every-submit 360-second run for #1732. The positive-control
+  reporter observed at least 16 satisfied ordered waits whose owned exact-base `WRITE_DATA(0)` was
+  followed by `RELEASE_MEM32(1)`; nine bounded summaries were emitted (ordinals 1--8 and 16).
+  The former rejection family emitted zero summaries and the capped generic log emitted zero
+  retained-memory-effect wait warnings. Astro advanced through loaded and started `ps_logo` to
+  `LevelDocument Loaded: title_controller_ship [title]`, beyond the earlier 240-second PS-logo
+  stall. It did not start that level or load `worldmap` before the bound. Every one of the 12 emitted
+  rejection summaries (ordinals 1--8, 16, 32, 64, and 128) instead had an unresolved retained
+  **address DMA** (`dma-overlaps=1`, scalar overlay untouched); the generic log reached its cap of 24
+  retained-DMA wait warnings. There was no device loss, fatal signal, or visual measurement. The
+  next question is the address-DMA dependency, not a broader `WRITE_DATA` relaxation. See #1732.
 
 - **"#1900's post-writeback DCC promotion makes the producer/consumer pair cheaper enough by itself
   to improve world-map throughput."** False in the first comparable whole-workload F8 window after

--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -2770,58 +2770,323 @@ static bool retained_ordered_effect_destination_overlaps(
 
 enum class OrderedQwordOverlay { Untouched, Touched, Ambiguous };
 
+const char* ordered_wait_effect_class_name(OrderedWaitEffectClass effect_class) {
+    switch (effect_class) {
+        case OrderedWaitEffectClass::Disjoint: return "disjoint";
+        case OrderedWaitEffectClass::ImmediateDma: return "immediate-dma";
+        case OrderedWaitEffectClass::AddressDma: return "address-dma";
+        case OrderedWaitEffectClass::FixedRelease32: return "fixed-release32";
+        case OrderedWaitEffectClass::FixedRelease64: return "fixed-release64";
+        case OrderedWaitEffectClass::InterruptOnlyRelease: return "interrupt-only-release";
+        case OrderedWaitEffectClass::DynamicRelease: return "dynamic-release";
+        case OrderedWaitEffectClass::WriteData: return "write-data";
+        case OrderedWaitEffectClass::WriteDataPartial: return "write-data-partial";
+        case OrderedWaitEffectClass::WriteDataOversized: return "write-data-oversized";
+        case OrderedWaitEffectClass::WriteDataUnowned: return "write-data-unowned";
+        case OrderedWaitEffectClass::EventTimestamp: return "event-timestamp";
+        case OrderedWaitEffectClass::OffsetOverlap: return "offset-overlap";
+        case OrderedWaitEffectClass::AliasedOverlap: return "aliased-overlap";
+        case OrderedWaitEffectClass::Unsupported: return "unsupported";
+    }
+    return "unsupported";
+}
+
+const char* ordered_wait_effect_overlay_name(OrderedWaitEffectOverlay overlay) {
+    switch (overlay) {
+        case OrderedWaitEffectOverlay::None: return "none";
+        case OrderedWaitEffectOverlay::Applied: return "applied";
+        case OrderedWaitEffectOverlay::Ambiguous: return "ambiguous";
+    }
+    return "ambiguous";
+}
+
+OrderedWaitEffectDiagnostic diagnose_ordered_wait_effect(
+        const GpuState::MemoryEffect& effect, uint64_t wait_address, uint64_t value_before) {
+    OrderedWaitEffectDiagnostic diagnostic;
+    diagnostic.command_order = effect.cmd.stream_order;
+    diagnostic.value_before = value_before;
+    diagnostic.value_after = value_before;
+
+    const Pm4Command& command = effect.cmd;
+    effect_span(command, &diagnostic.address, &diagnostic.bytes);
+    if (!diagnostic.address || !diagnostic.bytes ||
+        guest_memory_topology_relation(
+            wait_address, sizeof(value_before), diagnostic.address, diagnostic.bytes) ==
+            GuestMemoryTopologyRelation::Disjoint) {
+        diagnostic.effect_class = OrderedWaitEffectClass::Disjoint;
+        diagnostic.overlay = OrderedWaitEffectOverlay::None;
+        return diagnostic;
+    }
+
+    if (command.kind == Pm4Command::Kind::DmaData) {
+        if (command.dd_dst != wait_address) {
+            diagnostic.effect_class = OrderedWaitEffectClass::OffsetOverlap;
+            return diagnostic;
+        }
+        if (dma_data_form(command) != DmaDataForm::Immediate) {
+            diagnostic.effect_class = dma_data_address_source(command)
+                ? OrderedWaitEffectClass::AddressDma
+                : OrderedWaitEffectClass::Unsupported;
+            return diagnostic;
+        }
+        const uint32_t word = static_cast<uint32_t>(command.dd_src);
+        const size_t bytes = std::min<size_t>(command.dd_bytes, sizeof(value_before));
+        for (size_t offset = 0; offset < bytes; offset += sizeof(word))
+            memcpy(reinterpret_cast<uint8_t*>(&diagnostic.value_after) + offset, &word,
+                   std::min(sizeof(word), bytes - offset));
+        diagnostic.effect_class = OrderedWaitEffectClass::ImmediateDma;
+        diagnostic.overlay = OrderedWaitEffectOverlay::Applied;
+        return diagnostic;
+    }
+
+    if (command.kind == Pm4Command::Kind::ReleaseMem) {
+        if (command.rel_addr != wait_address) {
+            diagnostic.effect_class = OrderedWaitEffectClass::OffsetOverlap;
+            return diagnostic;
+        }
+        if (command.rel_data_sel == 0) {
+            diagnostic.effect_class = OrderedWaitEffectClass::InterruptOnlyRelease;
+            diagnostic.overlay = OrderedWaitEffectOverlay::None;
+            return diagnostic;
+        }
+        if (!command.rel_value_valid) {
+            diagnostic.effect_class = OrderedWaitEffectClass::DynamicRelease;
+            return diagnostic;
+        }
+        if (command.rel_data_sel == 1) {
+            const uint32_t low = static_cast<uint32_t>(command.rel_value);
+            memcpy(&diagnostic.value_after, &low, sizeof(low));
+            diagnostic.effect_class = OrderedWaitEffectClass::FixedRelease32;
+            diagnostic.overlay = OrderedWaitEffectOverlay::Applied;
+            return diagnostic;
+        }
+        if (command.rel_data_sel == 2) {
+            diagnostic.value_after = command.rel_value;
+            diagnostic.effect_class = OrderedWaitEffectClass::FixedRelease64;
+            diagnostic.overlay = OrderedWaitEffectOverlay::Applied;
+            return diagnostic;
+        }
+        diagnostic.effect_class = OrderedWaitEffectClass::DynamicRelease;
+        return diagnostic;
+    }
+
+    if (command.kind == Pm4Command::Kind::WriteData) {
+        if (command.wd_addr != wait_address) {
+            const bool virtual_overlap =
+                wait_address <= UINT64_MAX - sizeof(value_before) &&
+                command.wd_addr <= UINT64_MAX - diagnostic.bytes &&
+                wait_address < command.wd_addr + diagnostic.bytes &&
+                command.wd_addr < wait_address + sizeof(value_before);
+            diagnostic.effect_class = virtual_overlap
+                ? OrderedWaitEffectClass::OffsetOverlap
+                : OrderedWaitEffectClass::AliasedOverlap;
+            return diagnostic;
+        }
+        // MemoryEffect deep-copies WRITE_DATA's inline dwords and rebinds cmd.wd_data after every
+        // copy/move. Prove that exact ownership before reading: a pointer into the guest command
+        // buffer may be recycled as soon as folding returns. A short vector is an incomplete
+        // snapshot, and more than the waited qword is intentionally outside this scalar model.
+        if (!command.wd_data || effect.write_data.empty() ||
+            command.wd_data != effect.write_data.data()) {
+            diagnostic.effect_class = OrderedWaitEffectClass::WriteDataUnowned;
+            return diagnostic;
+        }
+        if (effect.write_data.size() != command.wd_num) {
+            diagnostic.effect_class = OrderedWaitEffectClass::WriteDataPartial;
+            return diagnostic;
+        }
+        if (command.wd_num > sizeof(value_before) / sizeof(uint32_t)) {
+            diagnostic.effect_class = OrderedWaitEffectClass::WriteDataOversized;
+            return diagnostic;
+        }
+        diagnostic.value_after =
+            (value_before & 0xffffffff00000000ull) | effect.write_data[0];
+        if (command.wd_num == 2)
+            diagnostic.value_after =
+                static_cast<uint64_t>(effect.write_data[0]) |
+                (static_cast<uint64_t>(effect.write_data[1]) << 32);
+        diagnostic.effect_class = OrderedWaitEffectClass::WriteData;
+        diagnostic.overlay = OrderedWaitEffectOverlay::Applied;
+        return diagnostic;
+    }
+    if (command.kind == Pm4Command::Kind::EventWrite) {
+        diagnostic.effect_class = OrderedWaitEffectClass::EventTimestamp;
+        return diagnostic;
+    }
+    diagnostic.effect_class = OrderedWaitEffectClass::Unsupported;
+    return diagnostic;
+}
+
+struct OrderedQwordOverlayResult {
+    OrderedQwordOverlay overlay = OrderedQwordOverlay::Untouched;
+    OrderedWaitEffectClass reason = OrderedWaitEffectClass::Disjoint;
+    uint64_t value = 0;
+};
+
 // WAIT_REG_MEM is an eager scalar reader, but the overwhelmingly common suffix dependency is an
-// immediate DMA label initialization followed by a fixed-value release. Evaluate those exact
-// producers from the ordered journal rather than rejecting a valid
-// `DMA(A), fill(B), release(B), wait(B)` submit or reading stale B. Keep every other overlapping
-// effect fail-closed: timestamp events, partial/offset writes, and address copies need execution-
-// time semantics, not a guess.
-static OrderedQwordOverlay overlay_ordered_qword(
+// immediate DMA or owned, qword-bounded WRITE_DATA label initialization followed by a fixed-value
+// release. Evaluate those exact producers from the ordered journal rather than rejecting a valid
+// `DMA(A), write(B), release(B), wait(B)` submit or reading stale B. Keep every other overlapping
+// effect fail-closed: timestamps, offset/aliased/incompletely-owned writes, oversized writes, and
+// address copies need execution-time semantics, not a guess.
+static OrderedQwordOverlayResult overlay_ordered_qword(
         const std::vector<GpuState::MemoryEffect>& effects, uint64_t address, uint64_t* value) {
     bool touched = false;
     uint64_t result = *value;
+    OrderedWaitEffectClass last_applied = OrderedWaitEffectClass::Disjoint;
     for (const GpuState::MemoryEffect& effect : effects) {
-        const Pm4Command& command = effect.cmd;
-        if (command.kind == Pm4Command::Kind::DmaData &&
-            dma_data_dst_sel(command) == kDmaSelGds)
+        if (effect.cmd.kind == Pm4Command::Kind::DmaData &&
+            dma_data_dst_sel(effect.cmd) == kDmaSelGds)
             continue;
-        uint64_t destination = 0, effect_bytes = 0;
-        effect_span(command, &destination, &effect_bytes);
-        if (!destination || !effect_bytes) continue;
-        const GuestMemoryTopologyRelation relation = guest_memory_topology_relation(
-            address, sizeof(result), destination, effect_bytes);
-        if (relation == GuestMemoryTopologyRelation::Disjoint) continue;
-        if (command.kind == Pm4Command::Kind::DmaData) {
-            if (command.dd_dst != address ||
-                dma_data_form(command) != DmaDataForm::Immediate)
-                return OrderedQwordOverlay::Ambiguous;
-            const uint32_t word = static_cast<uint32_t>(command.dd_src);
-            const size_t bytes = std::min<size_t>(command.dd_bytes, sizeof(result));
-            for (size_t offset = 0; offset < bytes; offset += sizeof(word))
-                memcpy(reinterpret_cast<uint8_t*>(&result) + offset, &word,
-                       std::min(sizeof(word), bytes - offset));
-            touched = true;
+        const OrderedWaitEffectDiagnostic diagnostic =
+            diagnose_ordered_wait_effect(effect, address, result);
+        if (diagnostic.overlay == OrderedWaitEffectOverlay::None) {
+            if (diagnostic.effect_class != OrderedWaitEffectClass::Disjoint)
+                last_applied = diagnostic.effect_class;
             continue;
         }
-        if (command.kind == Pm4Command::Kind::ReleaseMem) {
-            if (command.rel_addr != address) return OrderedQwordOverlay::Ambiguous;
-            if (command.rel_data_sel == 0) continue; // interrupt only; no memory write
-            if (!command.rel_value_valid) return OrderedQwordOverlay::Ambiguous;
-            if (command.rel_data_sel == 1) {
-                const uint32_t low = static_cast<uint32_t>(command.rel_value);
-                memcpy(&result, &low, sizeof(low));
-            } else if (command.rel_data_sel == 2) {
-                result = command.rel_value;
-            } else {
-                return OrderedQwordOverlay::Ambiguous;
-            }
-            touched = true;
-            continue;
-        }
-        return OrderedQwordOverlay::Ambiguous;
+        if (diagnostic.overlay == OrderedWaitEffectOverlay::Ambiguous)
+            return {OrderedQwordOverlay::Ambiguous, diagnostic.effect_class, result};
+        result = diagnostic.value_after;
+        last_applied = diagnostic.effect_class;
+        touched = true;
     }
     if (touched) *value = result;
-    return touched ? OrderedQwordOverlay::Touched : OrderedQwordOverlay::Untouched;
+    return {touched ? OrderedQwordOverlay::Touched : OrderedQwordOverlay::Untouched,
+            last_applied, result};
+}
+
+static const char* ordered_qword_overlay_name(OrderedQwordOverlay overlay) {
+    switch (overlay) {
+        case OrderedQwordOverlay::Untouched: return "untouched";
+        case OrderedQwordOverlay::Touched: return "touched";
+        case OrderedQwordOverlay::Ambiguous: return "ambiguous";
+    }
+    return "ambiguous";
+}
+
+// This instrument deliberately lives behind the existing high-volume GFXLOG switch. A rejection
+// alone says only that the fail-closed guard ran; it does not say which retained operation made the
+// eager wait unknowable. Report the first eight occurrences and a power-of-two tail, with a stable
+// 1-based ordinal on every line. Each reported occurrence is additionally bounded to sixteen
+// overlapping operations, while the summary retains the complete overlap counts.
+static void diagnose_ordered_wait_rejection(
+        const Pm4Command& wait, const std::vector<GpuState::DmaCopy>& copies,
+        const std::vector<GpuState::MemoryEffect>& effects, bool readable,
+        uint64_t base_value, const OrderedQwordOverlayResult& overlay,
+        bool comparison_satisfied) {
+    if (!std::getenv("PROSPER_GFXLOG")) return;
+    static std::atomic<uint64_t> ordinal_counter{0};
+    const uint64_t ordinal = ordinal_counter.fetch_add(1, std::memory_order_relaxed) + 1;
+    if (!prosper::diag_should_print(ordinal, 8)) return;
+
+    size_t overlapping_copies = 0, overlapping_effects = 0;
+    for (const GpuState::DmaCopy& copy : copies)
+        if (guest_memory_topology_relation(
+                wait.wm_addr, sizeof(uint64_t), copy.dst, copy.bytes) !=
+            GuestMemoryTopologyRelation::Disjoint)
+            ++overlapping_copies;
+    for (const GpuState::MemoryEffect& effect : effects) {
+        const OrderedWaitEffectDiagnostic diagnostic =
+            diagnose_ordered_wait_effect(effect, wait.wm_addr, base_value);
+        if (diagnostic.effect_class != OrderedWaitEffectClass::Disjoint)
+            ++overlapping_effects;
+    }
+
+    std::fprintf(stderr,
+                 "[agc] ordered-wait rejection #%llu addr=0x%llx readable=%u "
+                 "base=0x%016llx overlaid=0x%016llx overlay=%s reason=%s "
+                 "compare=%s mask=0x%llx ref=0x%llx func=%u "
+                 "dma-overlaps=%zu effect-overlaps=%zu\n",
+                 static_cast<unsigned long long>(ordinal),
+                 static_cast<unsigned long long>(wait.wm_addr), readable ? 1u : 0u,
+                 static_cast<unsigned long long>(base_value),
+                 static_cast<unsigned long long>(overlay.value),
+                 ordered_qword_overlay_name(overlay.overlay),
+                 ordered_wait_effect_class_name(overlay.reason),
+                 overlay.overlay == OrderedQwordOverlay::Touched
+                     ? (comparison_satisfied ? "satisfied" : "unsatisfied")
+                     : "not-evaluated",
+                 static_cast<unsigned long long>(wait.wm_mask),
+                 static_cast<unsigned long long>(wait.wm_ref), wait.wm_func,
+                 overlapping_copies, overlapping_effects);
+
+    constexpr size_t kMaxDetailEffects = 16;
+    size_t detail = 0;
+    for (const GpuState::DmaCopy& copy : copies) {
+        if (guest_memory_topology_relation(
+                wait.wm_addr, sizeof(uint64_t), copy.dst, copy.bytes) ==
+            GuestMemoryTopologyRelation::Disjoint)
+            continue;
+        if (detail++ >= kMaxDetailEffects) continue;
+        std::fprintf(stderr,
+                     "[agc] ordered-wait rejection #%llu effect[%zu] kind=address-dma "
+                     "overlay=ambiguous span=0x%llx+%u order=%llu\n",
+                     static_cast<unsigned long long>(ordinal), detail,
+                     static_cast<unsigned long long>(copy.dst), copy.bytes,
+                     static_cast<unsigned long long>(copy.command_order));
+    }
+    uint64_t diagnostic_value = base_value;
+    for (const GpuState::MemoryEffect& effect : effects) {
+        const OrderedWaitEffectDiagnostic diagnostic =
+            diagnose_ordered_wait_effect(effect, wait.wm_addr, diagnostic_value);
+        if (diagnostic.effect_class == OrderedWaitEffectClass::Disjoint) continue;
+        if (detail++ < kMaxDetailEffects) {
+            std::fprintf(stderr,
+                         "[agc] ordered-wait rejection #%llu effect[%zu] kind=%s overlay=%s "
+                         "span=0x%llx+%llu order=%llu before=0x%016llx after=0x%016llx\n",
+                         static_cast<unsigned long long>(ordinal), detail,
+                         ordered_wait_effect_class_name(diagnostic.effect_class),
+                         ordered_wait_effect_overlay_name(diagnostic.overlay),
+                         static_cast<unsigned long long>(diagnostic.address),
+                         static_cast<unsigned long long>(diagnostic.bytes),
+                         static_cast<unsigned long long>(diagnostic.command_order),
+                         static_cast<unsigned long long>(diagnostic.value_before),
+                         static_cast<unsigned long long>(diagnostic.value_after));
+        }
+        if (diagnostic.overlay == OrderedWaitEffectOverlay::Applied)
+            diagnostic_value = diagnostic.value_after;
+    }
+    if (overlapping_copies + overlapping_effects > kMaxDetailEffects)
+        std::fprintf(stderr,
+                     "[agc] ordered-wait rejection #%llu effects-truncated retained=%zu shown=%zu\n",
+                     static_cast<unsigned long long>(ordinal),
+                     overlapping_copies + overlapping_effects, kMaxDetailEffects);
+}
+
+// A route progressing after a semantic change is not proof that the new lever ran. When GFXLOG is
+// armed, positively identify satisfied eager waits whose ordered scalar evaluation actually
+// consumed at least one owned WRITE_DATA overlay. This is bounded independently of rejections.
+static void diagnose_ordered_wait_acceptance(
+        const Pm4Command& wait, const std::vector<GpuState::MemoryEffect>& effects,
+        uint64_t base_value, const OrderedQwordOverlayResult& overlay) {
+    if (!std::getenv("PROSPER_GFXLOG")) return;
+    size_t write_data_overlays = 0;
+    uint64_t diagnostic_value = base_value;
+    for (const GpuState::MemoryEffect& effect : effects) {
+        const OrderedWaitEffectDiagnostic diagnostic =
+            diagnose_ordered_wait_effect(effect, wait.wm_addr, diagnostic_value);
+        if (diagnostic.overlay != OrderedWaitEffectOverlay::Applied) continue;
+        if (diagnostic.effect_class == OrderedWaitEffectClass::WriteData)
+            ++write_data_overlays;
+        diagnostic_value = diagnostic.value_after;
+    }
+    if (!write_data_overlays) return;
+
+    static std::atomic<uint64_t> ordinal_counter{0};
+    const uint64_t ordinal = ordinal_counter.fetch_add(1, std::memory_order_relaxed) + 1;
+    if (!prosper::diag_should_print(ordinal, 8)) return;
+    std::fprintf(stderr,
+                 "[agc] ordered-wait acceptance #%llu addr=0x%llx order=%llu "
+                 "base=0x%016llx overlaid=0x%016llx final=%s "
+                 "write-data-overlays=%zu effect-count=%zu\n",
+                 static_cast<unsigned long long>(ordinal),
+                 static_cast<unsigned long long>(wait.wm_addr),
+                 static_cast<unsigned long long>(wait.stream_order),
+                 static_cast<unsigned long long>(base_value),
+                 static_cast<unsigned long long>(overlay.value),
+                 ordered_wait_effect_class_name(overlay.reason),
+                 write_data_overlays, effects.size());
 }
 
 void GpuState::apply(const Pm4Command& c) {
@@ -3367,20 +3632,41 @@ void GpuState::apply(const Pm4Command& c) {
                 retained_ordered_effect_destination_overlaps(
                     ordered_memory_effects, c.wm_addr, 8);
             bool ordered_wait_satisfied = false;
-            if (wait_overlaps_effect && !wait_overlaps_dma &&
-                guest_readable(c.wm_addr, sizeof(uint64_t))) {
+            const bool wait_value_needed =
+                (wait_overlaps_effect && !wait_overlaps_dma) ||
+                (wait_overlaps_dma && std::getenv("PROSPER_GFXLOG"));
+            const bool wait_readable = wait_value_needed &&
+                c.wm_valid && c.wm_addr && !(c.wm_addr & 3) &&
+                guest_readable(c.wm_addr, sizeof(uint64_t));
+            uint64_t ordered_base_value = 0;
+            OrderedQwordOverlayResult ordered_overlay;
+            if (wait_readable) {
+                memcpy(&ordered_base_value,
+                       reinterpret_cast<const void*>(uintptr_t(c.wm_addr)),
+                       sizeof(ordered_base_value));
+                pend_overlay_qword(c.wm_addr, &ordered_base_value);
+                ordered_overlay.value = ordered_base_value;
+            } else if (wait_overlaps_dma || wait_overlaps_effect) {
+                ordered_overlay.overlay = OrderedQwordOverlay::Ambiguous;
+                ordered_overlay.reason = OrderedWaitEffectClass::Unsupported;
+            }
+            if (wait_overlaps_effect && !wait_overlaps_dma && wait_readable) {
                 uint64_t ordered_value = 0;
-                memcpy(&ordered_value, reinterpret_cast<const void*>(uintptr_t(c.wm_addr)),
-                       sizeof(ordered_value));
-                pend_overlay_qword(c.wm_addr, &ordered_value);
+                ordered_value = ordered_base_value;
+                ordered_overlay = overlay_ordered_qword(
+                    ordered_memory_effects, c.wm_addr, &ordered_value);
                 ordered_wait_satisfied =
-                    overlay_ordered_qword(
-                        ordered_memory_effects, c.wm_addr, &ordered_value) ==
-                        OrderedQwordOverlay::Touched &&
+                    ordered_overlay.overlay == OrderedQwordOverlay::Touched &&
                     wait_regmem_value_satisfied(c, ordered_value);
             }
+            if (ordered_wait_satisfied)
+                diagnose_ordered_wait_acceptance(
+                    c, ordered_memory_effects, ordered_base_value, ordered_overlay);
             if (wait_overlaps_dma || (wait_overlaps_effect && !ordered_wait_satisfied)) {
                 dma_execution_rejected = true;
+                diagnose_ordered_wait_rejection(
+                    c, dma_copies, ordered_memory_effects, wait_readable,
+                    ordered_base_value, ordered_overlay, ordered_wait_satisfied);
                 static std::atomic<int> warned{0};
                 if (warned.fetch_add(1) < 24)
                     fprintf(stderr,

--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -1888,7 +1888,17 @@ bool execute_ordered_dma_copy(const GpuState::DmaCopy& copy,
 
 // Honor a WRITE_DATA packet: copy the inline dwords to the destination address (same synchronous timing).
 static void honor_write_data(const Pm4Command& c) {
-    if (eop_writes_disabled() || !c.wd_addr || (c.wd_addr & 3) || !c.wd_data || !c.wd_num) return;
+    if (eop_writes_disabled()) return;
+    if (!c.wd_valid) {
+        static std::atomic<int> n{0};
+        if (n.fetch_add(1) < 24)
+            fprintf(stderr,
+                    "[agc] WRITE_DATA payload incomplete — write SKIPPED: addr=0x%llx "
+                    "declared=%u available=%u\n",
+                    (unsigned long long)c.wd_addr, c.wd_declared_num, c.wd_num);
+        return;
+    }
+    if (!c.wd_addr || (c.wd_addr & 3) || !c.wd_data || !c.wd_num) return;
     // #729: guard both the payload span and the 8-byte #312 pre-read below (a 4-byte label write
     // still pre-reads one qword). The deferred path's #449 guard only covers the payload size.
     uint32_t wbytes = c.wd_num * 4;
@@ -2287,7 +2297,8 @@ bool pend_overlay_qword(uint64_t addr, uint64_t* value) {
                 v = c.rel_value;
                 touched = true;
             }
-        } else if (c.kind == K::WriteData && c.wd_addr == addr && c.wd_data && c.wd_num) {
+        } else if (c.kind == K::WriteData && c.wd_valid && c.wd_addr == addr &&
+                   c.wd_data && c.wd_num) {
             const size_t n = std::min<size_t>((size_t)c.wd_num * 4, sizeof v);
             memcpy(&v, c.wd_data, n);
             touched = true;
@@ -2495,7 +2506,8 @@ void effect_span(const Pm4Command& c, uint64_t* addr, uint64_t* bytes) {
     switch (c.kind) {
         case K::ReleaseMem: *addr = c.rel_addr;   *bytes = 8; break;
         case K::EventWrite: *addr = c.event_addr; *bytes = 8; break;
-        case K::WriteData:  *addr = c.wd_addr;    *bytes = (uint64_t)c.wd_num * 4; break;
+        case K::WriteData:  *addr = c.wd_addr;
+                            *bytes = (uint64_t)c.wd_declared_num * 4; break;
         case K::DmaData:    *addr = c.dd_dst;     *bytes = c.dd_bytes; break;
         default:            *addr = 0;            *bytes = 0; break;
     }
@@ -2886,13 +2898,13 @@ OrderedWaitEffectDiagnostic diagnose_ordered_wait_effect(
         // copy/move. Prove that exact ownership before reading: a pointer into the guest command
         // buffer may be recycled as soon as folding returns. A short vector is an incomplete
         // snapshot, and more than the waited qword is intentionally outside this scalar model.
+        if (!command.wd_valid || effect.write_data.size() != command.wd_num) {
+            diagnostic.effect_class = OrderedWaitEffectClass::WriteDataPartial;
+            return diagnostic;
+        }
         if (!command.wd_data || effect.write_data.empty() ||
             command.wd_data != effect.write_data.data()) {
             diagnostic.effect_class = OrderedWaitEffectClass::WriteDataUnowned;
-            return diagnostic;
-        }
-        if (effect.write_data.size() != command.wd_num) {
-            diagnostic.effect_class = OrderedWaitEffectClass::WriteDataPartial;
             return diagnostic;
         }
         if (command.wd_num > sizeof(value_before) / sizeof(uint32_t)) {

--- a/prosper/src/gpu/command_processor.hpp
+++ b/prosper/src/gpu/command_processor.hpp
@@ -231,6 +231,45 @@ private:
     bool state_dirty_ = true;
 };
 
+// Classification shared by the ordered WAIT_REG_MEM evaluator and its default-off GFXLOG
+// diagnostic. `Applied` means this exact effect can be overlaid without executing guest memory;
+// `Ambiguous` means the submit retains its existing fail-closed rejection. Keeping the reason
+// structured makes the instrument unit-testable instead of relying on an opaque live log string.
+enum class OrderedWaitEffectClass : uint8_t {
+    Disjoint,
+    ImmediateDma,
+    AddressDma,
+    FixedRelease32,
+    FixedRelease64,
+    InterruptOnlyRelease,
+    DynamicRelease,
+    WriteData,
+    WriteDataPartial,
+    WriteDataOversized,
+    WriteDataUnowned,
+    EventTimestamp,
+    OffsetOverlap,
+    AliasedOverlap,
+    Unsupported,
+};
+
+enum class OrderedWaitEffectOverlay : uint8_t { None, Applied, Ambiguous };
+
+struct OrderedWaitEffectDiagnostic {
+    OrderedWaitEffectClass effect_class = OrderedWaitEffectClass::Unsupported;
+    OrderedWaitEffectOverlay overlay = OrderedWaitEffectOverlay::Ambiguous;
+    uint64_t address = 0;
+    uint64_t bytes = 0;
+    uint64_t command_order = 0;
+    uint64_t value_before = 0;
+    uint64_t value_after = 0;
+};
+
+OrderedWaitEffectDiagnostic diagnose_ordered_wait_effect(
+    const GpuState::MemoryEffect& effect, uint64_t wait_address, uint64_t value_before);
+const char* ordered_wait_effect_class_name(OrderedWaitEffectClass effect_class);
+const char* ordered_wait_effect_overlay_name(OrderedWaitEffectOverlay overlay);
+
 // Execute one retained address-backed DMA_DATA operation at its ordered submit position.
 // Re-validates the destination and either the raw guest source or a bounded authoritative renderer
 // snapshot immediately before the byte copy, then notifies renderer caches. Returns whether the

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -6296,11 +6296,13 @@ static OrderedSubmitResult execute_ordered_gpustate(const GpuState& st, uint32_t
                             exact = command.event_addr != 0;
                             break;
                         case Pm4Command::Kind::WriteData:
-                            notify_compute_authority_range(
-                                ComputeAuthorityBoundaryKind::OrderedMemoryEffect,
-                                submit_no, operation.command_order, command.wd_addr,
-                                static_cast<uint64_t>(command.wd_num) * 4u);
-                            exact = command.wd_addr != 0 && command.wd_num != 0;
+                            if (command.wd_valid) {
+                                notify_compute_authority_range(
+                                    ComputeAuthorityBoundaryKind::OrderedMemoryEffect,
+                                    submit_no, operation.command_order, command.wd_addr,
+                                    static_cast<uint64_t>(command.wd_num) * 4u);
+                                exact = command.wd_addr != 0 && command.wd_num != 0;
+                            }
                             break;
                         case Pm4Command::Kind::DmaData: {
                             // Selector byte 1 names the 64 KiB GDS offset domain, not guest VA.

--- a/prosper/src/gpu/pm4_decode.cpp
+++ b/prosper/src/gpu/pm4_decode.cpp
@@ -1,4 +1,5 @@
 // pm4_decode.cpp — see pm4_decode.hpp. Pure PM4 type-3 stream walker.
+#include <algorithm>
 #include <cstdio>
 #include "pm4_decode.hpp"
 
@@ -83,10 +84,11 @@ size_t decode_pm4(const uint32_t* buf, size_t dwords, std::vector<Pm4Command>& o
                     // payload: [0]=dst, [1..2]=addr lo/hi, [3]=num_dwords, [4..]=inline data dwords.
                     if (npl >= 3) c.wd_addr = (uint64_t)pl[1] | ((uint64_t)pl[2] << 32);
                     if (npl >= 4) {
-                        c.wd_num  = pl[3];
-                        uint32_t avail = (npl > 4) ? (npl - 4) : 0;   // dwords actually present in the packet
-                        if (c.wd_num > avail) c.wd_num = avail;       // never read past the packet
+                        c.wd_declared_num = pl[3];
+                        const uint32_t avail = (npl > 4) ? (npl - 4) : 0;
+                        c.wd_num = std::min(c.wd_declared_num, avail); // never read past the packet
                         c.wd_data = (c.wd_num > 0) ? &pl[4] : nullptr;
+                        c.wd_valid = c.wd_declared_num <= avail;
                     }
                     break;
                 case R_WAIT_MEM_64:

--- a/prosper/src/gpu/pm4_decode.hpp
+++ b/prosper/src/gpu/pm4_decode.hpp
@@ -163,8 +163,10 @@ struct Pm4Command {
     // address_or_offset, data*, num_dwords, …) (Kyty GraphicsDcbWriteData, Graphics.cpp:2061). Packet
     // payload: [0]=dst, [1..2]=destination address (lo/hi), [3]=num_dwords, [4..]=inline data dwords.
     uint64_t wd_addr = 0;                // WriteData: destination address
-    uint32_t wd_num = 0;                 // WriteData: number of dwords to write
+    uint32_t wd_declared_num = 0;        // WriteData: payload's declared dword count
+    uint32_t wd_num = 0;                 // WriteData: bounded inline dwords actually available
     const uint32_t* wd_data = nullptr;   // WriteData: -> the inline data dwords within the packet
+    bool wd_valid = false;               // WriteData: packet carried every declared inline dword
 
     // Flip — laid out by hle_agc.cpp agc_dcb_set_flip per sceAgcDcbSetFlip(buf, video_out_handle,
     // display_buffer_index, flip_mode, flip_arg). Packet payload: [0]=videoout handle, [1]=display

--- a/prosper/tests/test_eop_write.cpp
+++ b/prosper/tests/test_eop_write.cpp
@@ -16,9 +16,12 @@
 #include <cstdlib>   // setenv/_putenv_s: arm the #1226-retired suppression guards for this test
 #include <cstring>
 #include <chrono>
+#include <initializer_list>
+#include <string>
 #include <thread>
 #include <vector>
 #ifdef _WIN32
+#include <io.h>
 #include <windows.h>
 #else
 #include <sys/mman.h>
@@ -44,6 +47,43 @@ static int fails = 0;
 #define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
                          else       { printf("  [ok]   %s\n", m); } } while (0)
 
+#ifdef _WIN32
+static int test_fileno(FILE* stream) { return _fileno(stream); }
+static int test_dup(int descriptor) { return _dup(descriptor); }
+static int test_dup2(int source, int destination) { return _dup2(source, destination); }
+static void test_close(int descriptor) { _close(descriptor); }
+#else
+static int test_fileno(FILE* stream) { return fileno(stream); }
+static int test_dup(int descriptor) { return dup(descriptor); }
+static int test_dup2(int source, int destination) { return dup2(source, destination); }
+static void test_close(int descriptor) { close(descriptor); }
+#endif
+
+template <typename Fn>
+static std::string capture_stderr(Fn&& action) {
+    FILE* capture = std::tmpfile();
+    if (!capture) return {};
+    std::fflush(stderr);
+    const int stderr_fd = test_fileno(stderr);
+    const int saved_fd = test_dup(stderr_fd);
+    if (saved_fd < 0 || test_dup2(test_fileno(capture), stderr_fd) < 0) {
+        if (saved_fd >= 0) test_close(saved_fd);
+        std::fclose(capture);
+        return {};
+    }
+    action();
+    std::fflush(stderr);
+    test_dup2(saved_fd, stderr_fd);
+    test_close(saved_fd);
+    std::rewind(capture);
+    std::string output;
+    char chunk[2048];
+    while (const size_t bytes = std::fread(chunk, 1, sizeof(chunk), capture))
+        output.append(chunk, bytes);
+    std::fclose(capture);
+    return output;
+}
+
 // PM4 type-3 NOP-wrapped header, identical to hle_agc.cpp PM4(): len = total dwords incl. header.
 static uint32_t PM4(uint32_t len, uint32_t op, uint32_t r) {
     return 0xC0000000u | (((len - 2u) & 0x3fffu) << 16u) | ((op & 0xffu) << 8u) | ((r & (R_NUM - 1u)) << 2u);
@@ -66,6 +106,140 @@ int main() {
     prosper_rel1_forge_suppress_all_override_for_test(0);
     prosper_rel1_forge_decision_reset_for_test();
     printf("== test_eop_write ==\n");
+
+    // The default-off ordered-wait diagnostic must distinguish the exact effects that are safe to
+    // overlay from the ones that explain a fail-closed submit. These checks exercise the same
+    // classifier the live GFXLOG reporter uses. Reporter spelling is asserted separately against
+    // captured stderr, so a reporter-only mutation cannot hide behind these behavioral checks.
+    {
+        uint64_t label = 0xaaaabbbbccccddddull;
+        const uint64_t address = reinterpret_cast<uint64_t>(&label);
+
+        Pm4Command immediate{};
+        immediate.kind = Pm4Command::Kind::DmaData;
+        immediate.dd_dst = address;
+        immediate.dd_src = 0x11223344u;
+        immediate.dd_bytes = sizeof(label);
+        immediate.dd_valid = true;
+        GpuState::MemoryEffect immediate_effect(immediate, 11);
+        const OrderedWaitEffectDiagnostic immediate_diag =
+            diagnose_ordered_wait_effect(immediate_effect, address, label);
+        CHECK(immediate_diag.effect_class == OrderedWaitEffectClass::ImmediateDma &&
+                  immediate_diag.overlay == OrderedWaitEffectOverlay::Applied &&
+                  immediate_diag.value_after == 0x1122334411223344ull,
+              "ordered-wait diagnostic identifies an exact immediate DMA overlay");
+
+        Pm4Command release32{};
+        release32.kind = Pm4Command::Kind::ReleaseMem;
+        release32.rel_addr = address;
+        release32.rel_data_sel = 1;
+        release32.rel_value = 0x55667788u;
+        release32.rel_value_valid = true;
+        GpuState::MemoryEffect release32_effect(release32, 12);
+        const OrderedWaitEffectDiagnostic release32_diag =
+            diagnose_ordered_wait_effect(release32_effect, address, label);
+        CHECK(release32_diag.effect_class == OrderedWaitEffectClass::FixedRelease32 &&
+                  release32_diag.overlay == OrderedWaitEffectOverlay::Applied &&
+                  release32_diag.value_after == 0xaaaabbbb55667788ull,
+              "ordered-wait diagnostic identifies an exact fixed 32-bit release overlay");
+
+        Pm4Command release64 = release32;
+        release64.rel_data_sel = 2;
+        release64.rel_value = 0x0123456789abcdefull;
+        GpuState::MemoryEffect release64_effect(release64, 13);
+        const OrderedWaitEffectDiagnostic release64_diag =
+            diagnose_ordered_wait_effect(release64_effect, address, label);
+        CHECK(release64_diag.effect_class == OrderedWaitEffectClass::FixedRelease64 &&
+                  release64_diag.overlay == OrderedWaitEffectOverlay::Applied &&
+                  release64_diag.value_after == release64.rel_value,
+              "ordered-wait diagnostic identifies an exact fixed 64-bit release overlay");
+
+        const uint32_t write_words[] = {0x10203040u, 0x50607080u};
+        Pm4Command write{};
+        write.kind = Pm4Command::Kind::WriteData;
+        write.wd_addr = address;
+        write.wd_num = 2;
+        write.wd_data = write_words;
+        GpuState::MemoryEffect write_effect(write, 14);
+        const OrderedWaitEffectDiagnostic write_diag =
+            diagnose_ordered_wait_effect(write_effect, address, label);
+        CHECK(write_diag.effect_class == OrderedWaitEffectClass::WriteData &&
+                  write_diag.overlay == OrderedWaitEffectOverlay::Applied &&
+                  write_diag.value_after == 0x5060708010203040ull,
+              "ordered-wait overlay preserves WRITE_DATA low/high dword order");
+
+        GpuState::MemoryEffect partial_write_effect(write, 15);
+        partial_write_effect.write_data.resize(1);
+        partial_write_effect.cmd.wd_data = partial_write_effect.write_data.data();
+        const OrderedWaitEffectDiagnostic partial_write_diag =
+            diagnose_ordered_wait_effect(partial_write_effect, address, label);
+        CHECK(partial_write_diag.effect_class == OrderedWaitEffectClass::WriteDataPartial &&
+                  partial_write_diag.overlay == OrderedWaitEffectOverlay::Ambiguous &&
+                  partial_write_diag.value_after == label,
+              "ordered-wait overlay rejects an incomplete owned WRITE_DATA snapshot");
+
+        GpuState::MemoryEffect unowned_write_effect(write, 16);
+        unowned_write_effect.cmd.wd_data = write_words;
+        const OrderedWaitEffectDiagnostic unowned_write_diag =
+            diagnose_ordered_wait_effect(unowned_write_effect, address, label);
+        CHECK(unowned_write_diag.effect_class == OrderedWaitEffectClass::WriteDataUnowned &&
+                  unowned_write_diag.overlay == OrderedWaitEffectOverlay::Ambiguous &&
+                  unowned_write_diag.value_after == label,
+              "ordered-wait overlay rejects a WRITE_DATA payload outside its owned snapshot");
+
+        const uint32_t oversized_words[] = {0x10203040u, 0x50607080u, 0x90a0b0c0u};
+        Pm4Command oversized_write = write;
+        oversized_write.wd_num = 3;
+        oversized_write.wd_data = oversized_words;
+        GpuState::MemoryEffect oversized_write_effect(oversized_write, 17);
+        const OrderedWaitEffectDiagnostic oversized_write_diag =
+            diagnose_ordered_wait_effect(oversized_write_effect, address, label);
+        CHECK(oversized_write_diag.effect_class == OrderedWaitEffectClass::WriteDataOversized &&
+                  oversized_write_diag.overlay == OrderedWaitEffectOverlay::Ambiguous &&
+                  oversized_write_diag.value_after == label,
+              "ordered-wait overlay rejects WRITE_DATA wider than the waited qword");
+
+        uint64_t copy_source = 0;
+        Pm4Command address_dma = immediate;
+        address_dma.dd_src = reinterpret_cast<uint64_t>(&copy_source);
+        address_dma.dd_sels = kDmaDataAddressSource;
+        GpuState::MemoryEffect address_effect(address_dma, 18);
+        const OrderedWaitEffectDiagnostic address_diag =
+            diagnose_ordered_wait_effect(address_effect, address, label);
+        CHECK(address_diag.effect_class == OrderedWaitEffectClass::AddressDma &&
+                  address_diag.overlay == OrderedWaitEffectOverlay::Ambiguous,
+              "ordered-wait diagnostic keeps an address DMA dependency ambiguous");
+
+        Pm4Command timestamp{};
+        timestamp.kind = Pm4Command::Kind::EventWrite;
+        timestamp.event_addr = address;
+        GpuState::MemoryEffect timestamp_effect(timestamp, 19);
+        const OrderedWaitEffectDiagnostic timestamp_diag =
+            diagnose_ordered_wait_effect(timestamp_effect, address, label);
+        CHECK(timestamp_diag.effect_class == OrderedWaitEffectClass::EventTimestamp &&
+                  timestamp_diag.overlay == OrderedWaitEffectOverlay::Ambiguous,
+              "ordered-wait diagnostic keeps an event timestamp dependency ambiguous");
+
+        Pm4Command dynamic_release = release32;
+        dynamic_release.rel_data_sel = 3;
+        dynamic_release.rel_value_valid = false;
+        GpuState::MemoryEffect dynamic_effect(dynamic_release, 20);
+        const OrderedWaitEffectDiagnostic dynamic_diag =
+            diagnose_ordered_wait_effect(dynamic_effect, address, label);
+        CHECK(dynamic_diag.effect_class == OrderedWaitEffectClass::DynamicRelease &&
+                  dynamic_diag.overlay == OrderedWaitEffectOverlay::Ambiguous,
+              "ordered-wait diagnostic keeps a timestamp release dependency ambiguous");
+
+        Pm4Command offset_release = release32;
+        offset_release.rel_addr = address + sizeof(uint32_t);
+        GpuState::MemoryEffect offset_effect(offset_release, 21);
+        const OrderedWaitEffectDiagnostic offset_diag =
+            diagnose_ordered_wait_effect(offset_effect, address, label);
+        CHECK(offset_diag.effect_class == OrderedWaitEffectClass::OffsetOverlap &&
+                  offset_diag.overlay == OrderedWaitEffectOverlay::Ambiguous,
+              "ordered-wait diagnostic keeps a partial offset overlap ambiguous");
+    }
+
     // #1226: the generation and MB3-freelist suppression families are OFF by default (their
     // content/membership premises misfire on live protocols — see generation_guard() /
     // mb3_freelist_guard() in command_processor.cpp). This test verifies the suppression
@@ -74,10 +248,12 @@ int main() {
     _putenv_s("PROSPER_GENERATION_GUARD", "1");
     _putenv_s("PROSPER_MB3_FREELIST_GUARD", "1");
     _putenv_s("PROSPER_WRITE_TRAP", "0x5a5a0001");
+    _putenv_s("PROSPER_GFXLOG", "");
 #else
     setenv("PROSPER_GENERATION_GUARD", "1", 1);
     setenv("PROSPER_MB3_FREELIST_GUARD", "1", 1);
     setenv("PROSPER_WRITE_TRAP", "0x5a5a0001", 1);
+    unsetenv("PROSPER_GFXLOG");
 #endif
 
     // SDK-13 completion writes must remain invisible for the entire guest submit import. The
@@ -725,34 +901,171 @@ int main() {
                       *effect_dma_target == 0 && *effect_wait == 0,
                   "WAIT_REG_MEM rejects an unsatisfied retained immediate DMA overlay");
 
+            auto make_write_wait = [&](uint64_t write_address,
+                                       std::initializer_list<uint32_t> words,
+                                       uint64_t wait_address, uint64_t mask, uint64_t reference) {
+                std::vector<uint32_t> stream(effect_reg_stream, effect_reg_stream + 7);
+                stream.push_back(PM4(5 + words.size(), IT_NOP, R_WRITE_DATA));
+                stream.push_back(0);
+                stream.push_back((uint32_t)write_address);
+                stream.push_back((uint32_t)(write_address >> 32));
+                stream.push_back((uint32_t)words.size());
+                stream.insert(stream.end(), words.begin(), words.end());
+                stream.push_back(PM4(8, IT_NOP, R_WAIT_MEM_64));
+                stream.push_back((uint32_t)wait_address);
+                stream.push_back((uint32_t)(wait_address >> 32));
+                stream.push_back((uint32_t)mask);
+                stream.push_back((uint32_t)(mask >> 32));
+                stream.push_back((uint32_t)reference);
+                stream.push_back((uint32_t)(reference >> 32));
+                stream.push_back(3);
+                return stream;
+            };
+
+            // A retained exact-base WRITE_DATA owns its inline payload after command-buffer decode.
+            // Overlay that bounded payload in little-endian dword order before evaluating the eager
+            // wait, then execute the original copy and write in their real order.
+            *effect_dma_target = 0;
+            *effect_wait = 0;
+            std::vector<uint32_t> write_wait_stream =
+                make_write_wait(effect_wait_addr, {1}, effect_wait_addr, 0xffffffffu, 1);
+            GpuState write_wait_state;
+            run_cb(write_wait_stream.data(), write_wait_stream.size(), write_wait_state);
+            CHECK(!write_wait_state.dma_execution_rejected &&
+                      write_wait_state.ordered_memory_effects.size() == 1 &&
+                      *effect_dma_target == effect_source && *effect_wait == 1,
+                  "WAIT_REG_MEM accepts a satisfying exact owned WRITE_DATA overlay");
+
+            // The producer being deterministic is not enough: its concrete payload still has to
+            // satisfy the packet's comparison. An unsatisfied value rejects the whole submit.
+            *effect_dma_target = 0;
+            *effect_wait = 0;
+            write_wait_stream =
+                make_write_wait(effect_wait_addr, {0}, effect_wait_addr, 0xffffffffu, 1);
+            GpuState unsatisfied_write_wait;
+            run_cb(write_wait_stream.data(), write_wait_stream.size(), unsatisfied_write_wait);
+            CHECK(unsatisfied_write_wait.dma_execution_rejected &&
+                      *effect_dma_target == 0 && *effect_wait == 0,
+                  "WAIT_REG_MEM rejects an unsatisfied exact owned WRITE_DATA overlay");
+
+            // Exact-base does not mean arbitrary-width. A write extending beyond the scalar qword
+            // remains fail-closed, even when its first dword would make the wait look satisfied.
+            // Arm GFXLOG only for this run so the reporter assertion is independent of semantics.
+            *effect_dma_target = 0;
+            *effect_wait = 0;
+            write_wait_stream = make_write_wait(
+                effect_wait_addr, {1, 0, 0xdeadbeefu}, effect_wait_addr, 0xffffffffu, 1);
+#ifdef _WIN32
+            _putenv_s("PROSPER_GFXLOG", "1");
+#else
+            setenv("PROSPER_GFXLOG", "1", 1);
+#endif
+            GpuState oversized_write_wait;
+            const std::string oversized_write_wait_diagnostic = capture_stderr([&] {
+                run_cb(write_wait_stream.data(), write_wait_stream.size(), oversized_write_wait);
+            });
+#ifdef _WIN32
+            _putenv_s("PROSPER_GFXLOG", "");
+#else
+            unsetenv("PROSPER_GFXLOG");
+#endif
+            CHECK(oversized_write_wait.dma_execution_rejected &&
+                      *effect_dma_target == 0 && *effect_wait == 0,
+                  "WAIT_REG_MEM rejects WRITE_DATA wider than its waited qword");
+            CHECK(oversized_write_wait_diagnostic.find("ordered-wait rejection #1") !=
+                          std::string::npos &&
+                      oversized_write_wait_diagnostic.find(
+                          "reason=write-data-oversized") != std::string::npos &&
+                      oversized_write_wait_diagnostic.find(
+                          "dma-overlaps=0 effect-overlaps=1") !=
+                          std::string::npos &&
+                      oversized_write_wait_diagnostic.find(
+                          "effect[1] kind=write-data-oversized overlay=ambiguous") !=
+                          std::string::npos,
+                  "ordered-wait reporter names and counts the oversized WRITE_DATA blocker");
+
+            // A write at +4 overlaps only the high dword and cannot satisfy this low-half wait.
+            // Blindly treating it as an exact-base scalar replacement would accept the submit, so
+            // rejection proves the offset guard moved.
+            *effect_dma_target = 0;
+            *effect_wait = 0;
+            write_wait_stream = make_write_wait(
+                effect_wait_addr + sizeof(uint32_t), {1}, effect_wait_addr,
+                0xffffffffu, 1);
+            GpuState offset_write_wait;
+            run_cb(write_wait_stream.data(), write_wait_stream.size(), offset_write_wait);
+            CHECK(offset_write_wait.dma_execution_rejected &&
+                      *effect_dma_target == 0 && *effect_wait == 0,
+                  "WAIT_REG_MEM rejects a satisfying partial-offset WRITE_DATA overlap");
+
+            // Distinct virtual views can name the same direct-memory qword. Do not infer the
+            // WRITE_DATA byte order across that alias: the scalar model is exact-VA only.
+            auto* alias_wait = (uint64_t*)(uintptr_t)(first_view + 0x5200);
+            const uint64_t alias_write_addr = second_view + 0x5200;
+            *effect_dma_target = 0;
+            *alias_wait = 0;
+            write_wait_stream = make_write_wait(
+                alias_write_addr, {1}, (uint64_t)(uintptr_t)alias_wait, 0xffffffffu, 1);
+            GpuState aliased_write_wait;
+            run_cb(write_wait_stream.data(), write_wait_stream.size(), aliased_write_wait);
+            CHECK(aliased_write_wait.dma_execution_rejected &&
+                      *effect_dma_target == 0 && *alias_wait == 0,
+                  "WAIT_REG_MEM rejects a physically aliased WRITE_DATA overlap");
+
             // Tactics Ogre's movie submits add the completion leg between the label init and the
-            // wait: copy(A), fill(B, 0), release32(B, 1), wait(B == 1). The fixed release value is
-            // just as ordered and deterministic as the fill, so evaluate both before the eager
+            // wait: copy(A), write(B, 0), release32(B, 1), wait(B == 1). Both fixed values are
+            // ordered and deterministic, so evaluate them before the eager
             // wait instead of rejecting the whole decoded-frame upload.
             *effect_dma_target = 0;
             *effect_wait = 0;
-            uint32_t release_wait_stream[29] = {};
-            memcpy(release_wait_stream, effect_wait_stream, 14 * sizeof(uint32_t));
-            release_wait_stream[10] = 0;
-            release_wait_stream[11] = 0;
-            release_wait_stream[14] = PM4(7, IT_NOP, R_RELEASE_MEM);
-            release_wait_stream[15] = (uint32_t)effect_wait_addr;
-            release_wait_stream[16] = (uint32_t)(effect_wait_addr >> 32);
-            release_wait_stream[17] = 1;
-            release_wait_stream[18] = 1;
-            release_wait_stream[21] = PM4(8, IT_NOP, R_WAIT_MEM_64);
-            release_wait_stream[22] = (uint32_t)effect_wait_addr;
-            release_wait_stream[23] = (uint32_t)(effect_wait_addr >> 32);
-            release_wait_stream[24] = 0xffffffffu;
-            release_wait_stream[26] = 1;
-            release_wait_stream[28] = 3;
+            std::vector<uint32_t> release_wait_stream(effect_reg_stream, effect_reg_stream + 7);
+            release_wait_stream.push_back(PM4(6, IT_NOP, R_WRITE_DATA));
+            release_wait_stream.push_back(0);
+            release_wait_stream.push_back((uint32_t)effect_wait_addr);
+            release_wait_stream.push_back((uint32_t)(effect_wait_addr >> 32));
+            release_wait_stream.push_back(1);
+            release_wait_stream.push_back(0);
+            release_wait_stream.push_back(PM4(7, IT_NOP, R_RELEASE_MEM));
+            release_wait_stream.push_back((uint32_t)effect_wait_addr);
+            release_wait_stream.push_back((uint32_t)(effect_wait_addr >> 32));
+            release_wait_stream.push_back(1);
+            release_wait_stream.push_back(1);
+            release_wait_stream.push_back(0);
+            release_wait_stream.push_back(0);
+            release_wait_stream.push_back(PM4(8, IT_NOP, R_WAIT_MEM_64));
+            release_wait_stream.push_back((uint32_t)effect_wait_addr);
+            release_wait_stream.push_back((uint32_t)(effect_wait_addr >> 32));
+            release_wait_stream.push_back(0xffffffffu);
+            release_wait_stream.push_back(0);
+            release_wait_stream.push_back(1);
+            release_wait_stream.push_back(0);
+            release_wait_stream.push_back(3);
+#ifdef _WIN32
+            _putenv_s("PROSPER_GFXLOG", "1");
+#else
+            setenv("PROSPER_GFXLOG", "1", 1);
+#endif
             GpuState release_wait_state;
-            run_cb(release_wait_stream, 29, release_wait_state);
+            const std::string release_wait_diagnostic = capture_stderr([&] {
+                run_cb(release_wait_stream.data(), release_wait_stream.size(), release_wait_state);
+            });
+#ifdef _WIN32
+            _putenv_s("PROSPER_GFXLOG", "");
+#else
+            unsetenv("PROSPER_GFXLOG");
+#endif
             CHECK(!release_wait_state.dma_execution_rejected &&
                       release_wait_state.ordered_memory_effects.size() == 2,
-                  "WAIT_REG_MEM accepts the retained fill-release label protocol");
+                  "WAIT_REG_MEM accepts the retained WRITE_DATA-release label protocol");
             CHECK(*effect_dma_target == effect_source && *effect_wait == 1,
-                  "the accepted copy, fill, and release execute in command order");
+                  "the accepted copy, WRITE_DATA, and release execute in command order");
+            CHECK(release_wait_diagnostic.find("ordered-wait acceptance #1") !=
+                          std::string::npos &&
+                      release_wait_diagnostic.find("final=fixed-release32") !=
+                          std::string::npos &&
+                      release_wait_diagnostic.find(
+                          "write-data-overlays=1 effect-count=2") != std::string::npos,
+                  "ordered-wait acceptance reporter proves the WRITE_DATA overlay ran");
 
             // Both guest views are writable here, but their VA-disjoint spans overlap in the same
             // physical direct backing. Exercise both destructive physical directions; a plain VA

--- a/prosper/tests/test_eop_write.cpp
+++ b/prosper/tests/test_eop_write.cpp
@@ -158,8 +158,10 @@ int main() {
         Pm4Command write{};
         write.kind = Pm4Command::Kind::WriteData;
         write.wd_addr = address;
+        write.wd_declared_num = 2;
         write.wd_num = 2;
         write.wd_data = write_words;
+        write.wd_valid = true;
         GpuState::MemoryEffect write_effect(write, 14);
         const OrderedWaitEffectDiagnostic write_diag =
             diagnose_ordered_wait_effect(write_effect, address, label);
@@ -167,16 +169,6 @@ int main() {
                   write_diag.overlay == OrderedWaitEffectOverlay::Applied &&
                   write_diag.value_after == 0x5060708010203040ull,
               "ordered-wait overlay preserves WRITE_DATA low/high dword order");
-
-        GpuState::MemoryEffect partial_write_effect(write, 15);
-        partial_write_effect.write_data.resize(1);
-        partial_write_effect.cmd.wd_data = partial_write_effect.write_data.data();
-        const OrderedWaitEffectDiagnostic partial_write_diag =
-            diagnose_ordered_wait_effect(partial_write_effect, address, label);
-        CHECK(partial_write_diag.effect_class == OrderedWaitEffectClass::WriteDataPartial &&
-                  partial_write_diag.overlay == OrderedWaitEffectOverlay::Ambiguous &&
-                  partial_write_diag.value_after == label,
-              "ordered-wait overlay rejects an incomplete owned WRITE_DATA snapshot");
 
         GpuState::MemoryEffect unowned_write_effect(write, 16);
         unowned_write_effect.cmd.wd_data = write_words;
@@ -189,6 +181,7 @@ int main() {
 
         const uint32_t oversized_words[] = {0x10203040u, 0x50607080u, 0x90a0b0c0u};
         Pm4Command oversized_write = write;
+        oversized_write.wd_declared_num = 3;
         oversized_write.wd_num = 3;
         oversized_write.wd_data = oversized_words;
         GpuState::MemoryEffect oversized_write_effect(oversized_write, 17);
@@ -439,7 +432,9 @@ int main() {
               "WRITE_DATA copied all 3 inline dwords to the destination");
     }
 
-    // A WRITE_DATA claiming more dwords than the packet holds must clamp (never read past the packet).
+    // A WRITE_DATA claiming more dwords than the packet holds must never read past the packet or
+    // manufacture a shorter valid write. Keep the bounded available count for diagnostics, reject
+    // the whole malformed effect, and say why.
     {
         uint32_t target[4] = {0, 0, 0, 0};
         uint32_t buf[7];
@@ -448,9 +443,12 @@ int main() {
         buf[1] = 0; buf[2] = (uint32_t)(addr & 0xffffffffu); buf[3] = (uint32_t)(addr >> 32);
         buf[4] = 99;                                  // lies: claims 99 dwords, only 2 present (buf[5],buf[6])
         buf[5] = 0xDEADu; buf[6] = 0xBEEFu;
-        GpuState st; run_cb(buf, 7, st);
-        CHECK(target[0] == 0xDEADu && target[1] == 0xBEEFu && target[2] == 0 && target[3] == 0,
-              "WRITE_DATA clamped num_dwords to what the packet actually holds");
+        GpuState st;
+        const std::string diagnostic = capture_stderr([&] { run_cb(buf, 7, st); });
+        CHECK(target[0] == 0 && target[1] == 0 && target[2] == 0 && target[3] == 0 &&
+                  diagnostic.find("WRITE_DATA payload incomplete") != std::string::npos &&
+                  diagnostic.find("declared=99 available=2") != std::string::npos,
+              "WRITE_DATA rejects and reports a truncated payload without landing its prefix");
     }
 
     // Address-carrying EVENT_WRITE (#132): the widened packet ([0]=hdr [1]=event_type [2..3]=addr)
@@ -901,15 +899,17 @@ int main() {
                       *effect_dma_target == 0 && *effect_wait == 0,
                   "WAIT_REG_MEM rejects an unsatisfied retained immediate DMA overlay");
 
-            auto make_write_wait = [&](uint64_t write_address,
-                                       std::initializer_list<uint32_t> words,
-                                       uint64_t wait_address, uint64_t mask, uint64_t reference) {
+            auto make_declared_write_wait = [&](uint64_t write_address,
+                                                std::initializer_list<uint32_t> words,
+                                                uint32_t declared_words,
+                                                uint64_t wait_address, uint64_t mask,
+                                                uint64_t reference) {
                 std::vector<uint32_t> stream(effect_reg_stream, effect_reg_stream + 7);
                 stream.push_back(PM4(5 + words.size(), IT_NOP, R_WRITE_DATA));
                 stream.push_back(0);
                 stream.push_back((uint32_t)write_address);
                 stream.push_back((uint32_t)(write_address >> 32));
-                stream.push_back((uint32_t)words.size());
+                stream.push_back(declared_words);
                 stream.insert(stream.end(), words.begin(), words.end());
                 stream.push_back(PM4(8, IT_NOP, R_WAIT_MEM_64));
                 stream.push_back((uint32_t)wait_address);
@@ -920,6 +920,13 @@ int main() {
                 stream.push_back((uint32_t)(reference >> 32));
                 stream.push_back(3);
                 return stream;
+            };
+            auto make_write_wait = [&](uint64_t write_address,
+                                       std::initializer_list<uint32_t> words,
+                                       uint64_t wait_address, uint64_t mask, uint64_t reference) {
+                return make_declared_write_wait(
+                    write_address, words, (uint32_t)words.size(),
+                    wait_address, mask, reference);
             };
 
             // A retained exact-base WRITE_DATA owns its inline payload after command-buffer decode.
@@ -947,6 +954,24 @@ int main() {
             CHECK(unsatisfied_write_wait.dma_execution_rejected &&
                       *effect_dma_target == 0 && *effect_wait == 0,
                   "WAIT_REG_MEM rejects an unsatisfied exact owned WRITE_DATA overlay");
+
+            // The real decoder must preserve that this six-dword packet declares two inline words
+            // but carries only one. Clipping to the available word is necessary for memory safety,
+            // but must not manufacture a complete one-word producer that satisfies this wait.
+            *effect_dma_target = 0;
+            *effect_wait = 0;
+            write_wait_stream = make_declared_write_wait(
+                effect_wait_addr, {1}, 2, effect_wait_addr, 0xffffffffu, 1);
+            GpuState truncated_write_wait;
+            run_cb(write_wait_stream.data(), write_wait_stream.size(), truncated_write_wait);
+            const bool truncated_journal_preserved =
+                truncated_write_wait.ordered_memory_effects.size() == 1 &&
+                truncated_write_wait.ordered_memory_effects[0].cmd.wd_declared_num == 2 &&
+                truncated_write_wait.ordered_memory_effects[0].cmd.wd_num == 1 &&
+                !truncated_write_wait.ordered_memory_effects[0].cmd.wd_valid;
+            CHECK(truncated_write_wait.dma_execution_rejected && truncated_journal_preserved &&
+                      *effect_dma_target == 0 && *effect_wait == 0,
+                  "WAIT_REG_MEM rejects a real truncated WRITE_DATA before its satisfying word lands");
 
             // Exact-base does not mean arbitrary-width. A write extending beyond the scalar qword
             // remains fail-closed, even when its first dword would make the wait look satisfied.

--- a/prosper/tests/test_gpu_execute.cpp
+++ b/prosper/tests/test_gpu_execute.cpp
@@ -891,8 +891,10 @@ int main() {
         Pm4Command authority_effect;
         authority_effect.kind = Pm4Command::Kind::WriteData;
         authority_effect.wd_addr = reinterpret_cast<uint64_t>(&authority_effect_target);
+        authority_effect.wd_declared_num = 1;
         authority_effect.wd_num = 1;
         authority_effect.wd_data = &authority_effect_value;
+        authority_effect.wd_valid = true;
         nonrender.ordered_memory_effects.emplace_back(authority_effect, 18);
         const std::filesystem::path path =
             prosper_test::test_scratch_dir() / "prosper_nonrender_submit_capture.prgcap";

--- a/prosper/tests/test_pm4_decode.cpp
+++ b/prosper/tests/test_pm4_decode.cpp
@@ -23,6 +23,11 @@ struct Dcb {
     void* callback; void* user_data; uint32_t reserved_dw; uint32_t pad;
 };
 
+static uint32_t PM4(uint32_t len, uint32_t op, uint32_t r) {
+    return 0xC0000000u | (((len - 2u) & 0x3fffu) << 16u) |
+           ((op & 0xffu) << 8u) | ((r & (R_NUM - 1u)) << 2u);
+}
+
 int main() {
     printf("== test_pm4_decode ==\n");
     register_builtin_hle();
@@ -201,6 +206,43 @@ int main() {
         Dcb d5{}; d5.bottom = buf5; d5.top = buf5 + 64; d5.cursor_up = buf5; d5.cursor_down = buf5 + 64;
         uint64_t wr = wd((uint64_t)(uintptr_t)&d5, /*dst*/0, /*policy*/0, /*addr*/0, /*data*/0, /*num*/0x3FFF);
         CHECK(wr == 0 && d5.cursor_up == d5.bottom, "WriteData(num=0x3FFF) rejected (5+num overflows the length field)");
+    }
+
+    // Retain both WRITE_DATA's declared count and the bounded number of inline words present in
+    // the packet. A short packet may expose one safe-to-read word, but it is not a complete
+    // one-word write: downstream ordering must be able to keep the declared two-word effect
+    // fail-closed without ever indexing beyond this six-dword buffer.
+    {
+        const uint64_t address = 0x123456780ull;
+        uint32_t short_write[6] = {};
+        short_write[0] = PM4(6, IT_NOP, R_WRITE_DATA);
+        short_write[1] = 0;
+        short_write[2] = (uint32_t)address;
+        short_write[3] = (uint32_t)(address >> 32);
+        short_write[4] = 2;
+        short_write[5] = 0x11223344u;
+        std::vector<Pm4Command> short_ops;
+        const size_t short_consumed = decode_pm4(short_write, 6, short_ops);
+        CHECK(short_consumed == 6 && short_ops.size() == 1 &&
+                  short_ops[0].kind == K::WriteData &&
+                  short_ops[0].wd_addr == address &&
+                  short_ops[0].wd_declared_num == 2 && short_ops[0].wd_num == 1 &&
+                  short_ops[0].wd_data && short_ops[0].wd_data[0] == 0x11223344u &&
+                  !short_ops[0].wd_valid,
+              "WRITE_DATA decoder preserves a truncated declared-two/available-one payload");
+
+        uint32_t complete_write[7] = {};
+        memcpy(complete_write, short_write, sizeof short_write);
+        complete_write[0] = PM4(7, IT_NOP, R_WRITE_DATA);
+        complete_write[6] = 0x55667788u;
+        std::vector<Pm4Command> complete_ops;
+        const size_t complete_consumed = decode_pm4(complete_write, 7, complete_ops);
+        CHECK(complete_consumed == 7 && complete_ops.size() == 1 &&
+                  complete_ops[0].kind == K::WriteData &&
+                  complete_ops[0].wd_declared_num == 2 && complete_ops[0].wd_num == 2 &&
+                  complete_ops[0].wd_data && complete_ops[0].wd_data[1] == 0x55667788u &&
+                  complete_ops[0].wd_valid,
+              "WRITE_DATA decoder marks a complete declared-two payload valid");
     }
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }


### PR DESCRIPTION
## Summary

Fix the exact ordered-label dependency that stalls Astro Bot after `ps_logo`: an address-backed DMA is retained, then an owned exact-base `WRITE_DATA(0)` and `RELEASE_MEM32(1)` precede an eager `WAIT_REG_MEM(label == 1)`.

- Overlay one or two owned inline `WRITE_DATA` dwords at the exact waited address, in architectural low/high-dword order.
- Apply later fixed releases in the existing ordered scalar model before evaluating the wait.
- Keep partial snapshots, unowned payloads, writes wider than one qword, offset writes, physical aliases, address-backed DMA producers, timestamps, and dynamic releases fail-closed.
- Add bounded default-off rejection diagnostics and a positive acceptance witness so a live route proves the new lever actually ran.
- Record the exact live result and the next retained address-DMA frontier in the Astro status handoff.

Refs #1732.

## Why this shape

On the pre-fix live route, every sampled blocker had the same sequence at one label: exact 4-byte `WRITE_DATA`, exact fixed `RELEASE_MEM32(value=1)`, then equality wait with mask `0xffffffff` and reference `1`. The `MemoryEffect` journal already deep-copies and rebinds the inline write payload; this change proves that ownership and bounds before reading it. Nothing title-address-specific is added.

## Focused verification

Exact code commit: `88c612151020285930e7a1c247c2cedc6e71f75e`, based on master `5cecfbe8d1dda5d7610121791e1e306ad719df0a`.

```text
ctest --test-dir build --output-on-failure -R "^(eop_write|diag_ratelimit|agc_dcb_pm4)$"

3/3 passed
```

Behavior coverage includes satisfying and unsatisfied exact writes, `WRITE_DATA -> RELEASE32 -> WAIT`, low/high-dword order, incomplete ownership, external payload pointers, oversized writes, partial offsets, and physically aliased virtual addresses.

Isolated mutation results:

- reporter string only: exactly the named reporter check failed
- disable exact write overlay: exact-write and write/release acceptance checks failed
- reverse two dwords: exactly the low/high-order check failed
- bypass exact-VA gate: offset and physical-alias negatives failed
- trust an external payload pointer: exactly the ownership check failed
- ignore decoder completeness while retaining bounded available data: exactly the real truncated-packet wait canary failed
- clamp/apply an oversized write: pure, behavior, and reporter oversized checks failed

## Exact live route

Revision-stamped `prosper-app` SHA-256: `88825f3d120f636ab80d79efdb844c1fed76439ea8658086cb3c6d6122d9a16e`.

Natural Astro app route, full 3840x2160 scale, every submit, real renderer/compute/video backends, no pad script, 540-frame target, 360-second bound:

```text
PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct \
PROSPER_RENDER=1 PROSPER_GFXLOG=1 \
  <BUILD_DIR>/prosper-app --dump <REPO_ROOT>/testdata/PPSA21564-app0 --frames 540
```

Validity: pre-run census empty; mid-run census exactly one owned `prosper-app`; post-run census empty; embedded revision and binary hash verified; HOME-backed evidence. The intentional timeout returned 124 and the app shut down cleanly after 42 presented frames.

Result:

- The positive acceptance witness ran at least 16 times (nine sparse summaries: 1-8 and 16).
- The former `dma-overlaps=0 effect-overlaps=2` rejection family emitted zero summaries; retained-memory-effect wait warnings were zero.
- Astro loaded and started `ps_logo`, then loaded `title_controller_ship`, advancing beyond the earlier 240-second PS-logo stall.
- `title_controller_ship` did not report started and `worldmap` did not load before the bound.
- The next blocker is distinct: at least 128 ordered-wait rejections, all emitted samples overlapping retained address DMA with the scalar overlay untouched.
- No `VK_ERROR_DEVICE_LOST`, device-loss, fatal, or signal failure occurred.

This run used high-volume diagnostics and is not an FPS measurement. No visual-correctness claim or screenshot is included.

## Snapshot tests

Not run. This is focused day-to-day development, and project policy makes snapshots optional before a PR and mandatory before a release.
## Review follow-up

Blocking review `pullrequestreview-4850562246` correctly found that the decoder clipped `wd_num` to the available payload and discarded the declared count, making the original synthetic partial-vector check unreachable from a real packet.

Follow-up commit `b587d853bca0013a9edf3d88fd74c9f9f0642a4b`:

- retains `wd_declared_num`, bounded available `wd_num`, and `wd_valid` through `Pm4Command` and `MemoryEffect`
- uses only the bounded available count for payload copies and reads
- uses the declared span for dependency overlap so a clipped prefix cannot hide the intended range
- rejects and reports incomplete writes before queued scalar overlay or actual execution
- prevents incomplete ordered effects from publishing compute-authority ranges
- replaces the manually resized vector with a real six-dword packet that declares two words, carries one satisfying word, and must reject without landing either the earlier copy or its prefix
- adds decoder controls for declared-two/available-one invalid and declared-two/available-two valid packets

Post-follow-up focused result:

```text
ctest --test-dir build --output-on-failure -R "^(diag_ratelimit|pm4_decode_stream|eop_write|agc_dcb_pm4|gpu_execute)$"
5/5 passed
```

Mutation removing only the `wd_valid` completeness gate made exactly `WAIT_REG_MEM rejects a real truncated WRITE_DATA before its satisfying word lands` fail. It was then reverted and the five-test set repeated green.

No GPU rerun was performed: complete packet decode and overlay semantics are unchanged from the exact live-tested code; this follow-up only preserves and rejects malformed/truncated declarations.