### PR TITLE
fix(gpu): bridge D32 depth bit views into compute

### DIFF
--- a/prosper/docs/GRIS_SONIC_COBRA_BRINGUP.md
+++ b/prosper/docs/GRIS_SONIC_COBRA_BRINGUP.md
@@ -137,6 +137,7 @@ One line per dead hypothesis, the evidence that killed it, and where that eviden
 | A PS5 `launchActivity` Game Intent routes around the current black startup state | **Falsified.** The update declares `launchActivity` support and ships the classic RSDK files, and the guest genuinely receives and consumes an exact `TITLE_SONIC_1_CLASSIC` intent — its `activityId` property is read and recognized. It still remains black and does not open `raw/retro/Sonic1u.rsdk`. This proves the activity route is insufficient, not that the handled UI misses cause the black frame. Truthful default no-intent behaviour is preserved. | this doc, #1905 |
 | Consuming the four installed add-content records naturally advances Sonic into an entitlement-key or mount path and changes the startup state | **Falsified at the `f72d8f0` black-loop boot depth.** After #1916, a valid routed 60 s CPU-only arm makes the count query and a real four-entry list call, then no individual info, key, AppContent, or mount call. A native/full-cadence 90 s renderer arm remains byte-identical black across 18 direct samples and port 17 remains silent. The result is scoped to this boot state; re-run it after any fix that advances the guest. | #1905, #1916 |
 | Sonic is black because it submits no GPU work or a shader/resource stage fails realization | **Falsified for the captured present-20 frame.** A deterministic whole-frame bundle contains 36 realized operations across submits 447-468; every extracted capsule reports `failed=0` and no failure diagnostics, its temporal closure is complete, and offline replay succeeds. The complete 3840x2160 result is nevertheless uniformly black. The first live `Vulkan render FAILED` line occurs earlier on empty submit 448, so it is a missing presentable scanout result rather than a failed Vulkan operation. | #1905 |
+| Submit 463's operation-5 black target is caused solely by operation 2 sampling stale zero guest bytes for its Uint32 view of the persistent depth plane | **Falsified, while exposing and fixing a real generic interop defect.** The authoritative D32S8 depth plane at `0x2064ae0000` is uniformly `0.5`, but the old Uint32 compute path read its stale zero guest backing. A GPU-only raw-bit bridge changes operation 2's 3840x2160 binding-7 output from all zero (`ccc433ff6d980383`) to the exact depth-plane bits (`1d0ffd6fc0338383`). Operation 5 still produces the identical black `26ed8b6191338383` target with a complete six-operation closure, so the stale depth alias was real but not sufficient to explain this frame's black composite. | #1905, this doc |
 
 ## Sonic Origins dump audit
 
@@ -206,14 +207,29 @@ remain candidate inputs. Two smaller utility/static textures (`b115` and `b123`)
 so this is not a blanket-zero capture. The pre-submit payloads for the two large scene-data constant
 buffers (`b34` and `b35`) are also zero.
 
+Runtime inspection completed that first discriminator. Operation 1's output is transparent black.
+Operation 2 reads binding 6 at `0x2064ae0000` through a one-component Uint32 T#, while the
+authoritative renderer-owned D32S8 plane at that address contains `0.5` in every texel. The old path
+did not offer the persistent depth import for an integer descriptor and detiled the stale all-zero
+guest allocation instead. The generic fix preserves the raw D32 bit payload entirely on the shared
+Vulkan device: depth image to transfer buffer to an owned `R32_UINT` sampled image, with the renderer
+layout restored afterward. The production regression contrasts the same stale backing at a non-DS
+address against the exact DS address, requires `0x3f000000` rather than zero, then re-snapshots both
+D32 and stencil planes byte-exactly.
+
+On the retained submit-463 capsule, the fix moves operation 2's binding-7 linear result from all-zero
+hash `ccc433ff6d980383` to `1d0ffd6fc0338383`, exactly the captured depth-plane hash. That positive
+control proves the source lever moved. Operation 5 nevertheless remains the identical uniformly black
+target (`26ed8b6191338383`; closure `6/6`, unresolved `0`). The depth alias was therefore a real
+translation defect, but it is not the sole cause of the black composite; the remaining cause is
+downstream or independent.
+
 The dependency graph continues through submit 465: operation 16 reads `0x20168f0000` and writes
 `0x203a7d0000`, operation 17 reads that target, and operation 18 reads it and writes `0x2010870000`;
 submit 467 then reads `0x2010870000`. All operations are realized and failure-free, while the complete
 replay endpoint is black. Those edges establish ordering and dependency, not the values written by each
-producer. The next discriminator is runtime output inspection (`--output-target-after` / draw steps) at
-submit-463 operations 1, 2 and 5, then submit-465 operations 16-18 and submit 467. That will identify the
-first black-producing stage and distinguish an upstream guest/scene gate from a producer or translation
-defect without another title boot. Exact hashes and command shapes are retained in
+producer. Further localization must now inspect operation 5's shader-visible inputs and the submit-465
+chain rather than re-testing operation 2's depth authority. Exact hashes and command shapes are retained in
 [#1905](https://github.com/mattias800/prosper/issues/1905#issuecomment-5172641024) and its follow-up.
 
 ### Game Intent activity audit

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -2368,6 +2368,14 @@ struct BoundImage {
     // import time must be released.
     bool imported = false;
     bool imported_depth = false;        // borrowed persistent DS depth plane, not a color RTT
+    // A one-component Uint32 T# can alias a renderer-owned D32 depth plane byte-for-byte. Vulkan
+    // cannot create an R32_UINT view of a depth image, so keep the borrowed DS image as a transfer
+    // source and materialize the guest-declared integer view through a device buffer. This remains
+    // entirely on the shared GPU; no stale guest backing or synchronous host readback is involved.
+    bool depth_bits_source = false;
+    VkImage depth_bits_image = VK_NULL_HANDLE;
+    VkFormat depth_bits_format = VK_FORMAT_UNDEFINED;
+    uint32_t depth_bits_saved_layout = 0;
     VkFormat imported_format = VK_FORMAT_UNDEFINED;
     prosper::gpu::LiveTargetPixelFormat imported_pixel_format =
         prosper::gpu::LiveTargetPixelFormat::Rgba8Unorm;
@@ -4223,7 +4231,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         for (size_t i = 0; i < images.size(); i++) {
             // A pin is taken per successful import, so it is released per import -- including for a
             // binding that a later alias check folded into an earlier one (#1095).
-            if (images[i].imported)
+            if (images[i].imported || images[i].depth_bits_source)
                 release_live_render_target_image(images[i].imported_addr);
             if (images[i].alias_of != SIZE_MAX) continue;
             if (images[i].sampler) vkDestroySampler(ctx.device, images[i].sampler, nullptr);
@@ -4707,10 +4715,16 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             // may also consume canonical RGBA8 because byte*257/65535 == byte/255. The independent
             // extent check below still rejects a scaled image for texel fetch/query access. Other
             // aliases and numeric conversions keep the snapshot path below.
-            const bool depth_import_eligible = !bi.storage && !dim_1d && !dim_3d &&
+            const bool depth_float_import_eligible = !bi.storage && !dim_1d && !dim_3d &&
                 !dim_2d_array && r->depth == 1 && r->img_dim == 1 &&
                 r->format == DataFormat::Float32 &&
                 (r->num_components ? r->num_components : 1u) == 1u;
+            const bool depth_bits_import_eligible = !bi.storage && !dim_1d && !dim_3d &&
+                !dim_2d_array && r->depth == 1 && r->img_dim == 1 &&
+                r->format == DataFormat::Uint32 &&
+                (r->num_components ? r->num_components : 1u) == 1u;
+            const bool depth_import_eligible =
+                depth_float_import_eligible || depth_bits_import_eligible;
             // Persistent renderer images do not carry VK_IMAGE_USAGE_STORAGE_BIT, and a writable
             // storage import would also leave overlapping guest buffer aliases stale. Storage
             // descriptors therefore retain the owned-image + guest-writeback path.
@@ -4760,30 +4774,54 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         prosper::frontend::rtt_direct_import_compatible(
                             bi.storage, r->width, r->height, import.width, import.height,
                             render_scale, scalable_normalized_sampling);
-                    if (compatible_format && direct_extent && compatible_device) {
-                        bi.imported = true;
-                        bi.imported_depth = depth_import;
-                        bi.imported_format = depth_import ? depth_format : VK_FORMAT_UNDEFINED;
-                        bi.imported_pixel_format = import.format;
-                        bi.imported_transfer_dst = import.transfer_dst;
-                        bi.imported_addr = r->gpu_addr;
-                        bi.imported_width = import.width;
-                        bi.imported_height = import.height;
-                        bi.imported_saved_layout = import.layout;
-                        bi.image = static_cast<VkImage>(import.image);
-                        live_target.width = import.width;
-                        live_target.height = import.height;
-                        live_target.format = import.format;
-                        if (trace)
-                            std::fprintf(stderr,
-                                         "[compute]   bound renderer RTT in place binding=%u class=%s "
-                                         "addr=0x%llx extent=%ux%u format=%s\n",
-                                         bi.binding, bi.storage ? "storage" : "sampled",
-                                         (unsigned long long)r->gpu_addr,
-                                         import.width, import.height,
-                                         depth_import ? "depth"
-                                             : prosper::frontend::live_target_pixel_format_name(
-                                                   import.format));
+                    // Raw bit views cannot use the normalized-sampling scale exception: the
+                    // transfer below copies exact texels and deliberately performs no resampling.
+                    const bool depth_bits_extent =
+                        import.width == r->width && import.height == r->height;
+                    if (compatible_format && direct_extent && compatible_device &&
+                        (!depth_bits_import_eligible || !depth_import || depth_bits_extent)) {
+                        if (depth_import && depth_bits_import_eligible) {
+                            bi.depth_bits_source = true;
+                            bi.depth_bits_image = static_cast<VkImage>(import.image);
+                            bi.depth_bits_format = depth_format;
+                            bi.depth_bits_saved_layout = import.layout;
+                            bi.imported_addr = r->gpu_addr;
+                            bi.imported_width = import.width;
+                            bi.imported_height = import.height;
+                            if (trace)
+                                std::fprintf(stderr,
+                                             "[compute]   bridged renderer depth bits binding=%u "
+                                             "addr=0x%llx extent=%ux%u depth-format=%u "
+                                             "sampled-format=R32_UINT\n",
+                                             bi.binding,
+                                             (unsigned long long)r->gpu_addr,
+                                             import.width, import.height,
+                                             static_cast<unsigned>(depth_format));
+                        } else {
+                            bi.imported = true;
+                            bi.imported_depth = depth_import;
+                            bi.imported_format = depth_import ? depth_format : VK_FORMAT_UNDEFINED;
+                            bi.imported_pixel_format = import.format;
+                            bi.imported_transfer_dst = import.transfer_dst;
+                            bi.imported_addr = r->gpu_addr;
+                            bi.imported_width = import.width;
+                            bi.imported_height = import.height;
+                            bi.imported_saved_layout = import.layout;
+                            bi.image = static_cast<VkImage>(import.image);
+                            live_target.width = import.width;
+                            live_target.height = import.height;
+                            live_target.format = import.format;
+                            if (trace)
+                                std::fprintf(stderr,
+                                             "[compute]   bound renderer RTT in place binding=%u "
+                                             "class=%s addr=0x%llx extent=%ux%u format=%s\n",
+                                             bi.binding, bi.storage ? "storage" : "sampled",
+                                             (unsigned long long)r->gpu_addr,
+                                             import.width, import.height,
+                                             depth_import ? "depth"
+                                                 : prosper::frontend::live_target_pixel_format_name(
+                                                       import.format));
+                        }
                     } else {
                         // Not our exact contract (a different device or a stale aliased view).
                         release_live_render_target_image(r->gpu_addr);
@@ -5032,12 +5070,16 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 // when both bindings acquired the same concrete image/view format.
                 const bool same_backing_representation =
                     prior.imported == bi.imported &&
+                    prior.depth_bits_source == bi.depth_bits_source &&
                     prior.unorm_rtt_value_reuse == bi.unorm_rtt_value_reuse &&
                     (!bi.imported ||
                      (prior.image == bi.image &&
                       prior.imported_depth == bi.imported_depth &&
                       prior.imported_format == bi.imported_format &&
-                      prior.imported_pixel_format == bi.imported_pixel_format));
+                      prior.imported_pixel_format == bi.imported_pixel_format)) &&
+                    (!bi.depth_bits_source ||
+                     (prior.depth_bits_image == bi.depth_bits_image &&
+                      prior.depth_bits_format == bi.depth_bits_format));
                 const bool same_dcc_identity = p &&
                     p->max_uncompressed_block_size == r->max_uncompressed_block_size &&
                     p->max_compressed_block_size == r->max_compressed_block_size &&
@@ -5261,7 +5303,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 std::getenv("PROSPER_NO_IMPORTED_IMAGE_GUEST_BYPASS") != nullptr;
             static const bool sampled_dcc_fast_clear_disabled =
                 std::getenv("PROSPER_NO_COMPUTE_DCC_FAST_CLEAR") != nullptr;
-            if (compute_sampled_guest_prepare_required(
+            if (!bi.depth_bits_source && compute_sampled_guest_prepare_required(
                     bi.storage, renderer_owned, bi.imported,
                     imported_guest_bypass_disabled)) {
                 // Resolve and validate the guest source before allocating staging. A proven cache
@@ -5525,7 +5567,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             // directly. The old path first built a heap upload and then memcpy'd the complete result
             // here -- an extra 132 MiB CPU pass for Astro Bot's 4K RGBA32 storage representation.
             ScopedMappedMemory upload_mapping(ctx);
-            const size_t upload_size = (bi.imported || bi.seed_skip ||
+            const size_t upload_size = (bi.imported || bi.depth_bits_source || bi.seed_skip ||
                                         bi.seed_from_imported != SIZE_MAX ||
                                         bi.compute_transfer_seed_borrowed)
                 ? size_t{0} : (size_t)sbytes;
@@ -5552,7 +5594,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     images_ready = false; break;
                 }
                 upload_mapping.memory = staging_memory[i];
-                if (!bi.seed_skip && bi.seed_from_imported == SIZE_MAX &&
+                if (!bi.depth_bits_source && !bi.seed_skip &&
+                    bi.seed_from_imported == SIZE_MAX &&
                     !bi.compute_transfer_seed_borrowed &&
                     !(bi.persistent && bi.upload_skipped) &&
                     !vk_ok(ctx.map_memory(staging_memory[i], 0, sbytes,
@@ -5566,6 +5609,12 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             const auto prepare_upload_start = ComputeClock::now();
             if (bi.imported) {
                 // The renderer's sampled image is the source, so direct imports need no transfer.
+                bi.guest_bytes = 0;
+            } else if (bi.depth_bits_source) {
+                // The command buffer below copies the borrowed D32 depth plane through this
+                // binding's device buffer into its owned R32_UINT image. There are deliberately no
+                // host upload bytes to prepare: touching sampled_guest_source here would reinstate
+                // the stale guest-memory defect this bridge exists to close.
                 bi.guest_bytes = 0;
             } else if (bi.storage) {
                 if (r->tile_mode && !tile_mode_is_tiled(r->tile_mode)) {
@@ -6712,6 +6761,101 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 vkCmdPipelineBarrier(command, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
                                      VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, 0, 0, nullptr, 0, nullptr,
                                      1, &to_general);
+                continue;
+            }
+            if (bi.depth_bits_source) {
+                // D32 and R32_UINT have the same four-byte texel payload but are not Vulkan
+                // view-compatible. Preserve the guest's raw-bit alias with two transfer copies:
+                // depth image -> device buffer -> integer image. The buffer is never host-mapped.
+                const bool source_already_general = [&] {
+                    for (size_t prior = 0; prior < i; ++prior) {
+                        const BoundImage& candidate = images[prior];
+                        if (candidate.imported && candidate.alias_of == SIZE_MAX &&
+                            candidate.image == bi.depth_bits_image &&
+                            imported_barrier_owner(prior))
+                            return true;
+                    }
+                    return false;
+                }();
+                const VkImageLayout source_saved = source_already_general
+                    ? VK_IMAGE_LAYOUT_GENERAL
+                    : static_cast<VkImageLayout>(bi.depth_bits_saved_layout);
+                const VkImageAspectFlags source_aspects = VK_IMAGE_ASPECT_DEPTH_BIT |
+                    (bi.depth_bits_format == VK_FORMAT_D32_SFLOAT_S8_UINT
+                         ? VK_IMAGE_ASPECT_STENCIL_BIT : 0u);
+
+                VkImageMemoryBarrier source_to_copy{
+                    VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
+                source_to_copy.srcAccessMask = source_already_general
+                    ? VK_ACCESS_SHADER_READ_BIT
+                    : VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT |
+                          VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+                source_to_copy.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+                source_to_copy.oldLayout = source_saved;
+                source_to_copy.newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+                source_to_copy.srcQueueFamilyIndex = source_to_copy.dstQueueFamilyIndex =
+                    VK_QUEUE_FAMILY_IGNORED;
+                source_to_copy.image = bi.depth_bits_image;
+                source_to_copy.subresourceRange = {source_aspects, 0, 1, 0, 1};
+
+                VkImageMemoryBarrier target_to_copy{
+                    VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
+                target_to_copy.srcAccessMask = 0;
+                target_to_copy.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+                target_to_copy.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+                target_to_copy.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+                target_to_copy.srcQueueFamilyIndex = target_to_copy.dstQueueFamilyIndex =
+                    VK_QUEUE_FAMILY_IGNORED;
+                target_to_copy.image = bi.image;
+                target_to_copy.subresourceRange = {
+                    VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+                VkImageMemoryBarrier to_copy[2]{source_to_copy, target_to_copy};
+                vkCmdPipelineBarrier(command, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+                                     VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0,
+                                     nullptr, 2, to_copy);
+
+                VkBufferImageCopy source_copy{};
+                source_copy.imageSubresource = {
+                    VK_IMAGE_ASPECT_DEPTH_BIT, 0, 0, 1};
+                source_copy.imageExtent = {r->width, r->height, 1};
+                vkCmdCopyImageToBuffer(command, bi.depth_bits_image,
+                                       VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                                       staging[i], 1, &source_copy);
+                VkBufferMemoryBarrier buffer_ready{
+                    VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER};
+                buffer_ready.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+                buffer_ready.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+                buffer_ready.srcQueueFamilyIndex = buffer_ready.dstQueueFamilyIndex =
+                    VK_QUEUE_FAMILY_IGNORED;
+                buffer_ready.buffer = staging[i];
+                buffer_ready.size = staging_bytes[i];
+                vkCmdPipelineBarrier(command, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                                     VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 1,
+                                     &buffer_ready, 0, nullptr);
+
+                VkBufferImageCopy target_copy{};
+                target_copy.imageSubresource = {
+                    VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+                target_copy.imageExtent = {r->width, r->height, 1};
+                vkCmdCopyBufferToImage(command, staging[i], bi.image,
+                                       VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                                       1, &target_copy);
+
+                VkImageMemoryBarrier ready[2]{source_to_copy, target_to_copy};
+                ready[0].srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+                ready[0].dstAccessMask = source_already_general
+                    ? VK_ACCESS_SHADER_READ_BIT
+                    : VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT |
+                          VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+                ready[0].oldLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+                ready[0].newLayout = source_saved;
+                ready[1].srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+                ready[1].dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+                ready[1].oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+                ready[1].newLayout = VK_IMAGE_LAYOUT_GENERAL;
+                vkCmdPipelineBarrier(command, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                                     VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0, nullptr, 0,
+                                     nullptr, 2, ready);
                 continue;
             }
             if (bi.persistent && (bi.upload_skipped || bi.seed_skip)) {

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -796,11 +796,12 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                      prosper::gpu::LiveTargetImageImport& import) {
             if (!direct_bind) return false;
             drain_guest_gpu_writes(g_rtt, invalidate_ds);
-            // `allow_depth` is set only for a proven one-component Float32 2D descriptor. Prefer the
-            // matching DS plane before consulting the address-only color registry: guest allocations
-            // are reused, and a stale RttSurf at the same base must not hide the newer persistent
-            // depth image. Persistent DS entries are not evicted, and compute runs in ordered submit
-            // execution, so unlike the bounded color cache this path needs no pin.
+            // `allow_depth` is set only for a proven one-component Float32 sample or Uint32 raw-bit
+            // view of an ordinary 2D descriptor. Prefer the matching DS plane before consulting the
+            // address-only color registry: guest allocations are reused, and a stale RttSurf at the
+            // same base must not hide the newer persistent depth image. Persistent DS entries are
+            // not evicted, and compute runs in ordered submit execution, so unlike the bounded color
+            // cache this path needs no pin.
             if (request.allow_depth && request.width && request.height) {
                 const prosper::test::PersistentDsSampled sampled =
                     prosper::test::find_persistent_ds_sampled(

--- a/prosper/tests/test_gpu_capture_render.cpp
+++ b/prosper/tests/test_gpu_capture_render.cpp
@@ -10,6 +10,7 @@
 #include "render_runner.h"
 
 #include <algorithm>
+#include <array>
 #include <chrono>
 #include <cstdio>
 #include <cstdlib>
@@ -1312,6 +1313,125 @@ int main() {
     CHECK(ds_read && restored != ds_snapshot.end() && restored->depth == ds_seed.depth &&
           restored->stencil == ds_seed.stencil && restored->depth_valid && restored->stencil_valid,
           "persistent Vulkan DS snapshot reads back byte-exact checkpoint contents");
+
+    // Sonic's full-screen resolve binds a renderer-owned D32S8 depth plane through a one-component
+    // Uint32 T#. The guest asks for the raw float bit pattern (for example 0.5f == 0x3f000000), not
+    // a normalized or numerically converted depth sample. D32S8's DEPTH-aspect buffer packing is
+    // exactly four bytes per texel; stencil is a separate one-byte aspect and must not leak into the
+    // R32_UINT view. Keep deliberately stale zero guest bytes beside the authoritative Vulkan plane.
+    static const uint32_t depth_bits_copy_2d[] = {
+        0x7E080300u,             // v4 = x from the shell input
+        0x7E0A0280u,             // v5 = y = 0
+        0xF0000F08u, 0x00000004u, 0xBF8C3F70u,
+        0xF0200F08u, 0x00020004u, 0xBF810000u,
+    };
+    constexpr uint32_t DEPTH_ROW_WIDTH = 4;
+    constexpr uint32_t DEPTH_TEXELS = DEPTH_ROW_WIDTH * 3;
+    std::array<uint32_t, DEPTH_ROW_WIDTH> depth_lane_index{0, 1, 2, 3};
+    std::array<uint32_t, 4> depth_dummy{};
+    const size_t stale_depth_bytes = tiled_surface_bytes(
+        ds_seed.width, ds_seed.height, 24u, 0u, sizeof(uint32_t));
+    std::vector<uint8_t> stale_depth_backing(stale_depth_bytes, 0);
+    auto run_depth_bits_copy = [&](uint64_t source_addr,
+                                   std::array<uint32_t, DEPTH_TEXELS>& output,
+                                   uint64_t code_addr) {
+        ShaderResourceTable table;
+        auto add_buffer = [&](uint32_t binding, const void* data, uint32_t size) {
+            ShaderResource resource{};
+            resource.cls = ResourceClass::ConstantBuffer;
+            resource.binding = binding;
+            resource.gpu_addr = reinterpret_cast<uint64_t>(data);
+            resource.size = size;
+            table.resources.push_back(resource);
+        };
+        add_buffer(0, depth_lane_index.data(), sizeof(depth_lane_index));
+        add_buffer(1, depth_dummy.data(), sizeof(depth_dummy));
+        add_buffer(2, depth_dummy.data(), sizeof(depth_dummy));
+        add_buffer(3, depth_dummy.data(), sizeof(depth_dummy));
+
+        ShaderResource source{};
+        source.cls = ResourceClass::Texture;
+        source.binding = 4;
+        source.sgpr_base = 0;
+        source.img_dim = 1;
+        source.format = DataFormat::Uint32;
+        source.num_components = 1;
+        source.width = ds_seed.width;
+        source.height = ds_seed.height;
+        source.depth = 1;
+        source.tile_mode = 24;
+        source.gpu_addr = source_addr;
+        source.size = static_cast<uint32_t>(stale_depth_backing.size());
+        source.host_data = stale_depth_backing.data();
+        source.host_data_size = stale_depth_backing.size();
+        source.swizzle[0] = source.swizzle[1] =
+            source.swizzle[2] = source.swizzle[3] = 4;
+        table.resources.push_back(source);
+
+        ShaderResource destination{};
+        destination.cls = ResourceClass::StorageImage;
+        destination.binding = 5;
+        destination.sgpr_base = 8;
+        destination.img_dim = 1;
+        destination.format = DataFormat::Uint32;
+        destination.num_components = 1;
+        destination.width = ds_seed.width;
+        destination.height = ds_seed.height;
+        destination.depth = 1;
+        destination.gpu_addr = reinterpret_cast<uint64_t>(output.data());
+        destination.size = sizeof(output);
+        table.resources.push_back(destination);
+
+        const std::vector<uint32_t> spirv = recompile_valu(
+            depth_bits_copy_2d, std::size(depth_bits_copy_2d), 1, 0, &table);
+        if (spirv.empty()) return false;
+        ComputeItem compute;
+        compute.spirv = spirv;
+        compute.resources = std::make_shared<ShaderResourceTable>(std::move(table));
+        compute.launch.threads_x = DEPTH_ROW_WIDTH;
+        compute.launch.local_x = 64;
+        compute.launch.groups_x = 1;
+        compute.launch.local_y = compute.launch.local_z = 1;
+        compute.launch.groups_y = compute.launch.groups_z = 1;
+        compute.code_addr = code_addr;
+        return prosper::frontend::execute_live_compute_items({compute});
+    };
+
+    std::array<uint32_t, DEPTH_TEXELS> guest_control{};
+    CHECK(run_depth_bits_copy(ds_seed.depth_read_base + 0x1000u,
+                              guest_control, 0x19050001u) &&
+              std::all_of(guest_control.begin(), guest_control.end(),
+                          [](uint32_t value) { return value == 0; }),
+          "non-DS Uint32 alias observes the deliberately stale zero guest backing");
+    std::array<uint32_t, DEPTH_TEXELS> depth_bits_result{};
+    std::array<uint32_t, DEPTH_ROW_WIDTH> expected_depth_bits{};
+    std::memcpy(expected_depth_bits.data(), ds_seed.depth.data(), sizeof(expected_depth_bits));
+    CHECK(run_depth_bits_copy(ds_seed.depth_read_base,
+                              depth_bits_result, 0x19050002u) &&
+              std::equal(expected_depth_bits.begin(), expected_depth_bits.end(),
+                         depth_bits_result.begin()) &&
+              std::any_of(depth_bits_result.begin(),
+                          depth_bits_result.begin() + DEPTH_ROW_WIDTH,
+                          [](uint32_t value) { return value != 0; }),
+          "R32_UINT sampled alias receives exact renderer-owned D32 depth bits");
+    CHECK(std::all_of(stale_depth_backing.begin(), stale_depth_backing.end(),
+                      [](uint8_t value) { return value == 0; }),
+          "depth-bit bridge neither reads through nor mutates stale guest backing");
+
+    // A second renderer DS transfer declares the cache's tracked attachment layout as its old
+    // layout. Its byte-exact success is the observable postcondition that the compute bridge handed
+    // the borrowed image back in that layout; it also proves the stencil aspect survived untouched.
+    ds_snapshot.clear();
+    const bool ds_after_compute_read = read_all_gpu_capture_ds_seeds(ds_snapshot, error);
+    const auto restored_after_compute = std::find_if(
+        ds_snapshot.begin(), ds_snapshot.end(), [&](const auto& seed) {
+            return seed.depth_read_base == ds_seed.depth_read_base &&
+                   seed.stencil_read_base == ds_seed.stencil_read_base;
+        });
+    CHECK(ds_after_compute_read && restored_after_compute != ds_snapshot.end() &&
+              restored_after_compute->depth == ds_seed.depth &&
+              restored_after_compute->stencil == ds_seed.stencil,
+          "depth-bit bridge restores renderer DS layout and preserves both D32S8 aspects");
 
     DrawItem missing_texture = replay.items[0];
     missing_texture.prt = std::make_shared<ShaderResourceTable>();


### PR DESCRIPTION
## Summary

- preserve renderer-owned D32/D32S8 depth texels when compute samples the same plane through a one-component `Uint32` texture view
- materialize the raw-bit alias entirely on the shared Vulkan device (`DEPTH` image -> transfer buffer -> owned `R32_UINT` image), without a CPU readback or stale guest-memory fallback
- restore the borrowed renderer depth/stencil layout after the copy and keep exact alias folding/release ownership safe
- add an end-to-end D32S8 regression and record the resulting Sonic localization evidence

## Root cause

The existing persistent-depth import gate accepted only one-component `Float32` descriptors. Sonic Origins submit 463 operation 2 binds the renderer-owned D32S8 plane at `0x2064ae0000` through a one-component `Uint32` T#. The renderer's current depth values existed only in its persistent Vulkan image, while the guest backing retained captured zeroes, so compute uploaded and sampled the stale allocation.

Vulkan cannot create an `R32_UINT` view of a D32 depth image. This change therefore borrows the persistent depth image only as a transfer source. It copies the four-byte depth aspect into the binding's transfer buffer, then into an owned `R32_UINT` sampled image. D32S8 stencil bytes remain a separate aspect and are not copied into the integer view.

## Sonic discriminator

On the retained pre-submit-463 capsule:

- the depth importer is a positive control: `[dsbridge] HIT` reports the exact 3840x2160 D32S8 plane and compute reports the new raw-bit bridge
- operation 2 binding 7 changes from all zero (`ccc433ff6d980383`) to `1d0ffd6fc0338383`, exactly matching the authoritative uniform-0.5 D32 plane
- operation 5 still produces the identical uniformly black `26ed8b6191338383` target with `operations=6/6` and `unresolved=0`

This fixes a real generic authority bug but falsifies it as the sole cause of Sonic's black composite. Issue #1905 remains open for the downstream or independent cause. There is no new screenshot because the final inspected target remains uniformly black.

## Regression shape

The production Vulkan test restores a known nonzero D32S8 seed, then runs the same `Uint32` image-load copy twice:

1. a non-DS address with deliberately stale zero host backing must output zero (guest-backed control)
2. the exact persistent DS address with the same stale backing must output the raw float bit patterns, including `0.5f == 0x3f000000`

It then proves the stale backing is untouched and re-snapshots both depth and stencil byte-exactly, which covers borrowed-image layout restoration and D32S8 aspect separation.

## Validation

Built in the `ps5ys` distrobox from exact rebased master `d33a1eb4`.

```text
gpu_capture_render_replay  PASS
game_compute_exec          PASS
```

Retained Sonic evidence is under `~/prosper-artifacts/sonic-1905-depth-bits-20260804T042435Z-2384702/`.

Refs #1905

