### PR TITLE
gpu: lower House saved-mask and DPP fragment CFG paths

### DIFF
--- a/prosper/docs/HOUSE_OF_THE_DEAD_2_STATUS.md
+++ b/prosper/docs/HOUSE_OF_THE_DEAD_2_STATUS.md
@@ -45,7 +45,7 @@ while the publishing event alone selects SCC. It also executes the exact in-plac
 `v_min_u32_dpp row_shr:{1,2,4,8}` family in that common phase. Value, source activity and static
 event identity use the same subgroup source lane, and the shuffled source tag must match the
 destination tag before UMin can update the persistent VGPR. The 83-resource scene shader that
-previously stopped at pc 1,276 now recompiles completely to 288,728 SPIR-V dwords; a second copy of
+previously stopped at pc 1,276 now recompiles completely to 288,955 SPIR-V dwords; a second copy of
 both instruction families later in the same shader is covered as well.
 
 The last current-recompiler deterministic replay, made before the event-isolation review hardening

--- a/prosper/docs/HOUSE_OF_THE_DEAD_2_STATUS.md
+++ b/prosper/docs/HOUSE_OF_THE_DEAD_2_STATUS.md
@@ -38,17 +38,22 @@ compute stages without retaining stored SPIR-V.
 
 The saved-mask comparison and adjacent DPP reduction frontier is now implemented. The fragment CFG
 dispatcher proves both ordinary B64 operands are live masks on every incoming path, reduces their
-EQ/LG result over the exact guest wave and persists SCC into the later `s_cselect_b64`. It also
-executes the exact in-place `v_min_u32_dpp row_shr:{1,2,4,8}` family in a uniform common phase, with
-per-lane dispatcher-PC and EXEC participation preserved. The 83-resource scene shader that
+EQ/LG result over the exact guest wave and persists SCC into the later `s_cselect_b64`. Fragment
+cases publish a nonzero static event identity; every event's ungated mask mismatch is voted in the
+uniform common phase, so mismatch bits on lanes parked at another dispatcher PC still participate,
+while the publishing event alone selects SCC. It also executes the exact in-place
+`v_min_u32_dpp row_shr:{1,2,4,8}` family in that common phase. Value, source activity and static
+event identity use the same subgroup source lane, and the shuffled source tag must match the
+destination tag before UMin can update the persistent VGPR. The 83-resource scene shader that
 previously stopped at pc 1,276 now recompiles completely to 288,728 SPIR-V dwords; a second copy of
 both instruction families later in the same shader is covered as well.
 
-The complete deterministic replay remains byte-for-byte visually corrupted, and every retained raw
-VS, FS and compute stage substitutes successfully. There is therefore no next unsupported retained
-shader instruction to quote from this capture. The current frontier returns to draw/resource/state
-correctness: localize why the now-complete scene shaders still generate the corrupt red-triangle
-output, using the operation-1,937 replay as the deterministic discriminator.
+The last complete deterministic replay, made before the event-isolation review hardening above,
+remained byte-for-byte visually corrupted while every retained raw VS, FS and compute stage
+substituted successfully. The corrected head has not yet consumed another GPU lease. There is no
+next unsupported retained shader instruction to quote from this capture; the next useful GPU arm is
+to rerun operation 1,937 once and determine whether exact cross-PC semantics change the target before
+returning to draw/resource/state localization.
 
 ## Ruled out
 
@@ -57,11 +62,13 @@ output, using the operation-1,937 replay as the deterministic discriminator.
   replay changed the BMP SHA-256 from `9b579dee...` to `cb33895b...`, but the red-pixel fraction was
   effectively unchanged (`0.486912` to `0.486932`) and human inspection showed the same corrupt
   scene. The hypothesis that implementing the first rejection alone restores this frame is false.
-- **The saved-mask EQ/LG comparisons and adjacent DPP unsigned-minimum row reductions being
-  unsupported are not, by themselves, the cause of the corrupt frame.** After both exact live
-  families recompiled completely, the operation-1,937 target kept backend hash
-  `dce8e600954195f4`; its BMP was byte-for-byte identical to the prior post-`IMAGE_GET_LOD` image
-  (SHA-256 `cb33895b...`, red-pixel fraction `0.486932`).
+- **Merely admitting the saved-mask EQ/LG comparisons and adjacent DPP unsigned-minimum row
+  reductions with the pre-review lowering was not sufficient.** That operation-1,937 replay kept
+  backend hash `dce8e600954195f4`; its BMP was byte-for-byte identical to the prior
+  post-`IMAGE_GET_LOD` image (SHA-256 `cb33895b...`, red-pixel fraction `0.486932`). Review then
+  found that pair votes ran inside lane-divergent switch cases and that DPP neighbor mailboxes lacked
+  static-event isolation. The old replay therefore does **not** rule out the corrected semantics
+  changing the frame; do not quote it as a negative result for the hardened lowering.
   [#1907](https://github.com/mattias800/prosper/issues/1907)
 - **Draw 1,846 is not explained by non-finite or wholly clipped geometry.** Its 9,600 transformed
   vertices are finite; 4,872 are on-screen and 4,728 clipped. Of 3,200 triangles, 3,057 are
@@ -102,17 +109,24 @@ trace the one required whole-wave vote through the dispatcher's Function-memory 
 later scalar select. High-half overwrite, numeric-pair and path-dependent-join controls prevent a
 stale or non-mask pair from acquiring that lowering. Production mutations that removed EQ
 admission, inverted its polarity or weakened the two-source MUST proof each broke the corresponding
-named dataflow check.
+named dataflow check. A second defect-shaped fixture places disjoint EQ and LG pairs at alternate
+static dispatcher PCs. It proves both votes execute after the switch merge from ungated persistent
+mask loads, tags 1 and 2 select the matching polarity, tag 0 remains reserved for no pending event,
+and SCC still reaches `s_cselect_b64`. Gating the vote predicate by the current event makes the named
+Wave32/Wave64 divergent-PC check red.
 
 The DPP test uses the exact `v_min_u32_dpp v3,v3,v3 row_shr:{1,2,4,8}` packets in the same crossing
 graphics CFG for both wave sizes. It proves the shared dynamic amount feeds both the row-bound check
 and lane subtraction, pending plus EXEC gate source participation, and subgroup shuffle feeds UMin
-and the persistent VGPR store. Opcode, distinct-source and amount packet mutations fail the exact
-contract; production mutations to opcode admission, row direction and divergent-PC participation
-each make the named House DPP check red.
+and the persistent VGPR store. A four-way alternate-site fixture proves tags 1/2/3/4 are published,
+tag 0 is reserved, value/activity/event use the same shuffle lane and source-event equality reaches
+the final write in Wave32 and Wave64. Opcode, distinct-source and amount packet mutations fail the
+exact contract; production mutations to opcode admission, row direction, source participation and
+static-event equality each make the named House DPP check red.
 
-The current authorized Vulkan replay completed in 2.803 seconds with return code zero and empty
+The last authorized Vulkan replay completed in 2.803 seconds with return code zero and empty
 pre/post process censuses. It substituted all 809 VS/FS pairs and 106 compute stages with zero stored
 modules retained, read back the exact 1920x1080 FP16 target at operation 1,937, and produced the
-byte-identical corrupt-scene result recorded above. This is generic shader-coverage progress, not a
-title-screen, gameplay-visual or performance improvement.
+byte-identical corrupt-scene result recorded above. It predates the common-phase/event-isolation
+review fixes and must not be treated as visual evidence for the corrected head. This remains generic
+shader-coverage progress, not a title-screen, gameplay-visual or performance improvement.

--- a/prosper/docs/HOUSE_OF_THE_DEAD_2_STATUS.md
+++ b/prosper/docs/HOUSE_OF_THE_DEAD_2_STATUS.md
@@ -36,12 +36,19 @@ compute stages without retaining stored SPIR-V.
 
 ## Current frontier
 
-The complete replay remains visually corrupted. The first large scene families now advance past
-`IMAGE_GET_LOD` and stop at `s_cmp_eq_u64` comparing two saved wave-mask SGPR pairs. One exact live
-sequence creates `s[44:45]` and `s[46:47]` with `s_and_b64` against EXEC, then compares the pairs.
-The fragment CFG dispatcher handles mask-versus-zero comparisons, while this two-mask form remains
-fail-visible. That is the next distinct recompiler frontier; it is not part of the `IMAGE_GET_LOD`
-change.
+The saved-mask comparison and adjacent DPP reduction frontier is now implemented. The fragment CFG
+dispatcher proves both ordinary B64 operands are live masks on every incoming path, reduces their
+EQ/LG result over the exact guest wave and persists SCC into the later `s_cselect_b64`. It also
+executes the exact in-place `v_min_u32_dpp row_shr:{1,2,4,8}` family in a uniform common phase, with
+per-lane dispatcher-PC and EXEC participation preserved. The 83-resource scene shader that
+previously stopped at pc 1,276 now recompiles completely to 288,728 SPIR-V dwords; a second copy of
+both instruction families later in the same shader is covered as well.
+
+The complete deterministic replay remains byte-for-byte visually corrupted, and every retained raw
+VS, FS and compute stage substitutes successfully. There is therefore no next unsupported retained
+shader instruction to quote from this capture. The current frontier returns to draw/resource/state
+correctness: localize why the now-complete scene shaders still generate the corrupt red-triangle
+output, using the operation-1,937 replay as the deterministic discriminator.
 
 ## Ruled out
 
@@ -50,6 +57,12 @@ change.
   replay changed the BMP SHA-256 from `9b579dee...` to `cb33895b...`, but the red-pixel fraction was
   effectively unchanged (`0.486912` to `0.486932`) and human inspection showed the same corrupt
   scene. The hypothesis that implementing the first rejection alone restores this frame is false.
+- **The saved-mask EQ/LG comparisons and adjacent DPP unsigned-minimum row reductions being
+  unsupported are not, by themselves, the cause of the corrupt frame.** After both exact live
+  families recompiled completely, the operation-1,937 target kept backend hash
+  `dce8e600954195f4`; its BMP was byte-for-byte identical to the prior post-`IMAGE_GET_LOD` image
+  (SHA-256 `cb33895b...`, red-pixel fraction `0.486932`).
+  [#1907](https://github.com/mattias800/prosper/issues/1907)
 - **Draw 1,846 is not explained by non-finite or wholly clipped geometry.** Its 9,600 transformed
   vertices are finite; 4,872 are on-screen and 4,728 clipped. Of 3,200 triangles, 3,057 are
   non-degenerate and the screen-spanning triangles are present in the transformed output.
@@ -67,6 +80,7 @@ Focused CPU suites pass in the `ps5ys` distrobox:
 recompile_coverage
 rdna2_decode_walk
 rdna2_spirv_struct
+spv_validate
 shader_resource_contract
 ```
 
@@ -83,7 +97,22 @@ compaction, removed EXEC predication, admitted the operation in compute, disable
 address/cache/result/reserved control family, and erased reserved-bit decode. Each mutation broke
 its named check and the clean implementation passed again after restoration.
 
-The single authorized Vulkan replay completed in 2.689 seconds with return code zero and empty
-pre/post process censuses. It recompiled all retained stages, read back the exact 1920x1080 FP16
-target at operation 1,937, and produced the unchanged corrupt-scene result recorded above. This is
-generic shader-coverage progress, not a title-screen, gameplay-visual or performance improvement.
+The saved-mask tests use the exact House EQ/LG encodings in Wave32 and Wave64 arbitrary CFGs. They
+trace the one required whole-wave vote through the dispatcher's Function-memory SCC and into the
+later scalar select. High-half overwrite, numeric-pair and path-dependent-join controls prevent a
+stale or non-mask pair from acquiring that lowering. Production mutations that removed EQ
+admission, inverted its polarity or weakened the two-source MUST proof each broke the corresponding
+named dataflow check.
+
+The DPP test uses the exact `v_min_u32_dpp v3,v3,v3 row_shr:{1,2,4,8}` packets in the same crossing
+graphics CFG for both wave sizes. It proves the shared dynamic amount feeds both the row-bound check
+and lane subtraction, pending plus EXEC gate source participation, and subgroup shuffle feeds UMin
+and the persistent VGPR store. Opcode, distinct-source and amount packet mutations fail the exact
+contract; production mutations to opcode admission, row direction and divergent-PC participation
+each make the named House DPP check red.
+
+The current authorized Vulkan replay completed in 2.803 seconds with return code zero and empty
+pre/post process censuses. It substituted all 809 VS/FS pairs and 106 compute stages with zero stored
+modules retained, read back the exact 1920x1080 FP16 target at operation 1,937, and produced the
+byte-identical corrupt-scene result recorded above. This is generic shader-coverage progress, not a
+title-screen, gameplay-visual or performance improvement.

--- a/prosper/docs/HOUSE_OF_THE_DEAD_2_STATUS.md
+++ b/prosper/docs/HOUSE_OF_THE_DEAD_2_STATUS.md
@@ -48,12 +48,12 @@ destination tag before UMin can update the persistent VGPR. The 83-resource scen
 previously stopped at pc 1,276 now recompiles completely to 288,728 SPIR-V dwords; a second copy of
 both instruction families later in the same shader is covered as well.
 
-The last complete deterministic replay, made before the event-isolation review hardening above,
-remained byte-for-byte visually corrupted while every retained raw VS, FS and compute stage
-substituted successfully. The corrected head has not yet consumed another GPU lease. There is no
-next unsupported retained shader instruction to quote from this capture; the next useful GPU arm is
-to rerun operation 1,937 once and determine whether exact cross-PC semantics change the target before
-returning to draw/resource/state localization.
+The last current-recompiler deterministic replay, made before the event-isolation review hardening
+above, remained byte-for-byte visually corrupted while every retained raw VS, FS and compute stage
+substituted successfully. No current-recompiler Vulkan replay of the corrected lowering has been
+run. There is no next unsupported retained shader instruction to quote from this capture; the next
+useful GPU arm is to rerun operation 1,937 once and determine whether exact cross-PC semantics change
+the target before returning to draw/resource/state localization.
 
 ## Ruled out
 

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -747,7 +747,7 @@ struct SpirvCompute {
         return result;
     }
     uint32_t subgroup_row_shr_dynamic(uint32_t value, uint32_t active,
-                                      uint32_t amount,
+                                      uint32_t amount, uint32_t event = 0,
                                       uint32_t* valid_lane = nullptr) {
         mark_subgroup_min16();
         const uint32_t lane = subgroup_local_id();
@@ -761,14 +761,22 @@ struct SpirvCompute {
         const uint32_t shifted = subgroup_shuffle(value, source_lane);
         const uint32_t source_active = subgroup_shuffle(
             sel(active, uconst(1), uconst(0)), source_lane);
-        const uint32_t valid = land(in_bounds,
+        uint32_t valid = land(in_bounds,
             ucmp(Op_INotEqual, source_active, uconst(0)));
+        // A lane-local graphics dispatcher can have adjacent lanes parked at distinct static DPP
+        // instructions in the same common phase.  Shuffling only ACTIVE would let one instruction
+        // consume a neighbour published by another instruction.  Carry the static event tag through
+        // the identical shuffle and require it to match the destination lane's event.
+        if (event) {
+            const uint32_t source_event = subgroup_shuffle(event, source_lane);
+            valid = land(valid, ucmp(Op_IEqual, source_event, event));
+        }
         if (valid_lane) *valid_lane = valid;
         return sel(valid, shifted, value);
     }
     uint32_t subgroup_row_shr(uint32_t value, uint32_t active, uint32_t amount,
                               uint32_t* valid_lane = nullptr) {
-        return subgroup_row_shr_dynamic(value, active, uconst(amount), valid_lane);
+        return subgroup_row_shr_dynamic(value, active, uconst(amount), 0, valid_lane);
     }
     uint32_t subgroup_quad_permute(uint32_t value, uint32_t ctrl) {
         const uint32_t lane = subgroup_local_id();
@@ -11502,6 +11510,7 @@ bool emit_cfg_state_machine(
     bool has_lds_append = false;
     std::unordered_set<uint32_t> swizzle_pcs;
     std::unordered_set<uint32_t> fragment_dpp_min_row_shr_pcs;
+    std::unordered_map<uint32_t, uint32_t> fragment_dpp_min_event_for_pc;
     std::set<int> fragment_dpp_min_row_shr_dsts;
     for (size_t i = 0; i < ins.size(); ++i) {
         const auto& in = ins[i];
@@ -11531,6 +11540,8 @@ bool emit_cfg_state_machine(
         }
         if (fragment_dpp_min_row_shr(in)) {
             fragment_dpp_min_row_shr_pcs.insert(in.pc);
+            fragment_dpp_min_event_for_pc.emplace(
+                in.pc, static_cast<uint32_t>(fragment_dpp_min_event_for_pc.size() + 1));
             fragment_dpp_min_row_shr_dsts.insert(in.dst.value);
             start_set.insert(in.pc);
             if (i + 1 < ins.size() && ins[i + 1].pc <= end_pc)
@@ -12117,6 +12128,29 @@ bool emit_cfg_state_machine(
         }
     }
 
+    // Fragment scalar PCs are lane-local in the dispatcher.  A saved-mask pair comparison must
+    // nevertheless vote over every lane in the guest wave, including lanes currently executing a
+    // different switch case.  Give every proven static comparison an identity and retain its exact
+    // operands/polarity for the uniform common-phase votes emitted below.
+    struct SavedMaskPairCompareEvent {
+        int first = -1;
+        int second = -1;
+        uint32_t opcode = 0;
+    };
+    std::unordered_map<uint32_t, uint32_t> saved_mask_pair_event_for_pc;
+    std::vector<SavedMaskPairCompareEvent> saved_mask_pair_events;
+    if (b.is_fragment) {
+        for (const auto& in : ins) {
+            if (in.is_end) break;
+            if (!proven_saved_mask_pair_compare_pcs.contains(in.pc)) continue;
+            const auto sources = saved_mask_pair_compare_sources(in);
+            if (sources[0] < 0) continue;
+            saved_mask_pair_events.push_back({sources[0], sources[1], in.opcode});
+            saved_mask_pair_event_for_pc.emplace(
+                in.pc, static_cast<uint32_t>(saved_mask_pair_events.size()));
+        }
+    }
+
     std::vector<std::unordered_set<int>> scalar_may_write_in(starts.size());
     std::vector<bool> scalar_reachable(starts.size(), false);
     if (!scalar_may_write_in.empty()) {
@@ -12321,6 +12355,11 @@ bool emit_cfg_state_machine(
     const uint32_t swizzle_source_var = b.function_var(b.t_u32, ptr_u32);
     const uint32_t swizzle_source_lane_var = b.function_var(b.t_u32, ptr_u32);
     const uint32_t swizzle_dst_var = b.function_var(b.t_u32, ptr_u32);
+    const bool has_saved_mask_pair_events = !saved_mask_pair_events.empty();
+    const uint32_t saved_mask_pair_pending_var = has_saved_mask_pair_events
+        ? b.function_var(b.t_bool, ptr_bool) : 0;
+    const uint32_t saved_mask_pair_event_var = has_saved_mask_pair_events
+        ? b.function_var(b.t_u32, ptr_u32) : 0;
     const bool has_dpp_min_row_shr = !fragment_dpp_min_row_shr_pcs.empty();
     const uint32_t dpp_min_pending_var = has_dpp_min_row_shr
         ? b.function_var(b.t_bool, ptr_bool) : 0;
@@ -12331,6 +12370,8 @@ bool emit_cfg_state_machine(
     const uint32_t dpp_min_amount_var = has_dpp_min_row_shr
         ? b.function_var(b.t_u32, ptr_u32) : 0;
     const uint32_t dpp_min_dst_var = has_dpp_min_row_shr
+        ? b.function_var(b.t_u32, ptr_u32) : 0;
+    const uint32_t dpp_min_event_var = has_dpp_min_row_shr
         ? b.function_var(b.t_u32, ptr_u32) : 0;
 
     const uint32_t zero = b.uconst(0), no = b.bfalse(), yes = b.btrue();
@@ -12379,10 +12420,13 @@ bool emit_cfg_state_machine(
     b.store_function(swizzle_source_var, zero);
     b.store_function(swizzle_source_lane_var, zero);
     b.store_function(swizzle_dst_var, zero);
+    if (has_saved_mask_pair_events)
+        b.store_function(saved_mask_pair_event_var, zero);
     if (has_dpp_min_row_shr) {
         b.store_function(dpp_min_source_var, zero);
         b.store_function(dpp_min_amount_var, zero);
         b.store_function(dpp_min_dst_var, zero);
+        b.store_function(dpp_min_event_var, zero);
     }
 
     auto load_state = [&](uint32_t dispatch = UINT32_MAX) {
@@ -12533,9 +12577,14 @@ bool emit_cfg_state_machine(
     }
     b.store_function(swizzle_pending_var, no);
     b.store_function(swizzle_active_var, no);
+    if (has_saved_mask_pair_events) {
+        b.store_function(saved_mask_pair_pending_var, no);
+        b.store_function(saved_mask_pair_event_var, zero);
+    }
     if (has_dpp_min_row_shr) {
         b.store_function(dpp_min_pending_var, no);
         b.store_function(dpp_min_active_var, no);
+        b.store_function(dpp_min_event_var, zero);
     }
     b.emit_loopmerge(loop_merge, loop_continue);
     b.emit_branch(switch_header);
@@ -12833,6 +12882,9 @@ bool emit_cfg_state_machine(
         if (dpp_min_row_shr) {
             if (!fragment_dpp_min_row_shr(*dpp_min_row_shr))
                 return reject_cfg(dpp_min_row_shr->pc, "dpp-min-row-shr-contract");
+            const auto event = fragment_dpp_min_event_for_pc.find(dpp_min_row_shr->pc);
+            if (event == fragment_dpp_min_event_for_pc.end())
+                return reject_cfg(dpp_min_row_shr->pc, "dpp-min-row-shr-event");
             const auto source = state.vreg.find(dpp_min_row_shr->src[0].value);
             b.store_function(dpp_min_pending_var, yes);
             b.store_function(dpp_min_active_var, state.exec);
@@ -12842,6 +12894,7 @@ bool emit_cfg_state_machine(
                 b.uconst(static_cast<uint32_t>(dpp_min_row_shr->dpp_ctrl - 0x110u)));
             b.store_function(dpp_min_dst_var,
                 b.uconst(static_cast<uint32_t>(dpp_min_row_shr->dst.value)));
+            b.store_function(dpp_min_event_var, b.uconst(event->second));
         }
         if (mask_compare) {
             if (b.is_vertex) {
@@ -12895,30 +12948,38 @@ bool emit_cfg_state_machine(
             }
         }
         if (saved_mask_pair_compare) {
-            const auto sources =
-                saved_mask_pair_compare_sources(*saved_mask_pair_compare);
-            const auto first = state.sreg_bool.find(sources[0]);
-            const auto second = state.sreg_bool.find(sources[1]);
-            if (first == state.sreg_bool.end() || second == state.sreg_bool.end())
-                return reject_cfg(saved_mask_pair_compare->pc,
-                                  "missing-saved-mask-pair-compare-source");
-            const uint32_t mismatch = b.bsel(
-                first->second, b.logical_not(second->second), second->second);
-            if (b.native_subgroup_size || b.is_fragment) {
-                const uint32_t different = b.is_fragment
-                    ? b.fragment_wave_any(mismatch)
-                    : b.native_wave_any(mismatch);
-                if (!different)
+            if (b.is_fragment) {
+                const auto event =
+                    saved_mask_pair_event_for_pc.find(saved_mask_pair_compare->pc);
+                if (event == saved_mask_pair_event_for_pc.end())
                     return reject_cfg(saved_mask_pair_compare->pc,
-                                      "saved-mask-pair-vote");
-                state.scc = saved_mask_pair_compare->opcode == 0x12
-                    ? b.logical_not(different) : different;
+                                      "saved-mask-pair-event");
+                b.store_function(saved_mask_pair_pending_var, yes);
+                b.store_function(saved_mask_pair_event_var, b.uconst(event->second));
             } else {
-                b.store_function(vote_pending_var, yes);
-                b.store_function(vote_value_var, mismatch);
-                b.store_function(vote_invert_var,
-                    saved_mask_pair_compare->opcode == 0x12 ? yes : no);
-                b.store_function(vote_to_scc_var, yes);
+                const auto sources =
+                    saved_mask_pair_compare_sources(*saved_mask_pair_compare);
+                const auto first = state.sreg_bool.find(sources[0]);
+                const auto second = state.sreg_bool.find(sources[1]);
+                if (first == state.sreg_bool.end() || second == state.sreg_bool.end())
+                    return reject_cfg(saved_mask_pair_compare->pc,
+                                      "missing-saved-mask-pair-compare-source");
+                const uint32_t mismatch = b.bsel(
+                    first->second, b.logical_not(second->second), second->second);
+                if (b.native_subgroup_size) {
+                    const uint32_t different = b.native_wave_any(mismatch);
+                    if (!different)
+                        return reject_cfg(saved_mask_pair_compare->pc,
+                                          "saved-mask-pair-vote");
+                    state.scc = saved_mask_pair_compare->opcode == 0x12
+                        ? b.logical_not(different) : different;
+                } else {
+                    b.store_function(vote_pending_var, yes);
+                    b.store_function(vote_value_var, mismatch);
+                    b.store_function(vote_invert_var,
+                        saved_mask_pair_compare->opcode == 0x12 ? yes : no);
+                    b.store_function(vote_to_scc_var, yes);
+                }
             }
         }
         if (vopc_mask_compare) {
@@ -13147,8 +13208,42 @@ bool emit_cfg_state_machine(
         }
     }
 
+    // Fragment saved-mask pair comparisons execute their subgroup votes here, outside the
+    // lane-divergent dispatcher switch.  Every invocation evaluates every static event from the
+    // persistent mask register file, so a mismatch bit remains visible even when that lane is
+    // currently parked at another guest PC.  The publishing lane's event tag selects the exact
+    // operand pair and EQ/LG polarity whose result updates its SCC.
+    if (has_saved_mask_pair_events) {
+        const uint32_t pending =
+            b.load_function(b.t_bool, saved_mask_pair_pending_var);
+        const uint32_t event =
+            b.load_function(b.t_u32, saved_mask_pair_event_var);
+        for (size_t index = 0; index < saved_mask_pair_events.size(); ++index) {
+            const auto& compare = saved_mask_pair_events[index];
+            const auto first_var = mv.find(compare.first);
+            const auto second_var = mv.find(compare.second);
+            if (first_var == mv.end() || second_var == mv.end())
+                return reject_cfg(0, "missing-saved-mask-pair-common-source");
+            const uint32_t first = b.load_function(b.t_bool, first_var->second);
+            const uint32_t second = b.load_function(b.t_bool, second_var->second);
+            const uint32_t mismatch = b.bsel(
+                first, b.logical_not(second), second);
+            const uint32_t different = b.fragment_wave_any(mismatch);
+            if (!different) return reject_cfg(0, "saved-mask-pair-common-vote");
+            const uint32_t result = compare.opcode == 0x12
+                ? b.logical_not(different) : different;
+            const uint32_t selected = b.land(
+                pending,
+                b.ucmp(Op_IEqual, event,
+                       b.uconst(static_cast<uint32_t>(index + 1))));
+            const uint32_t old = b.load_function(b.t_bool, scc_var);
+            b.store_function(scc_var, b.bsel(selected, result, old));
+        }
+    }
+
     // Fragment DPP V_MIN_U32 common phase. A graphics dispatcher's PC is lane-local, so a source
-    // lane is eligible only when it published this same DPP event and its EXEC bit is active. The
+    // lane is eligible only when it published this same static DPP event and its EXEC bit is active.
+    // The source's event tag is shuffled beside its value and compared with the destination tag. The
     // unbounded ROW_SHR contract disables out-of-row/inactive-source lanes and preserves VDST;
     // active destination lanes reduce the shifted neighbor with their unchanged local value.
     if (!fragment_dpp_min_row_shr_pcs.empty()) {
@@ -13158,7 +13253,8 @@ bool emit_cfg_state_machine(
         uint32_t valid_source = 0;
         const uint32_t shifted = b.subgroup_row_shr_dynamic(
             source, b.land(pending, active),
-            b.load_function(b.t_u32, dpp_min_amount_var), &valid_source);
+            b.load_function(b.t_u32, dpp_min_amount_var),
+            b.load_function(b.t_u32, dpp_min_event_var), &valid_source);
         const uint32_t result = b.uext2(Glsl_UMin, shifted, source);
         const uint32_t write = b.land(b.land(pending, active), valid_source);
         const uint32_t dst = b.load_function(b.t_u32, dpp_min_dst_var);

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -746,17 +746,18 @@ struct SpirvCompute {
             {t_u32, result, uconst(Scope_Subgroup), value, lane});
         return result;
     }
-    uint32_t subgroup_row_shr(uint32_t value, uint32_t active, uint32_t amount,
-                              uint32_t* valid_lane = nullptr) {
+    uint32_t subgroup_row_shr_dynamic(uint32_t value, uint32_t active,
+                                      uint32_t amount,
+                                      uint32_t* valid_lane = nullptr) {
         mark_subgroup_min16();
         const uint32_t lane = subgroup_local_id();
         const uint32_t row_lane = ibin(Op_BitwiseAnd, lane, uconst(15));
-        const uint32_t in_bounds = ucmp(Op_UGreaterThanEqual, row_lane, uconst(amount));
+        const uint32_t in_bounds = ucmp(Op_UGreaterThanEqual, row_lane, amount);
         // Keep the shuffle index valid even for row-leading lanes. FI=0 also makes an EXEC-inactive
         // source invalid. The caller uses `valid` to preserve VDST for BOUND_CTRL=0; returning VALUE
         // here is only a safe placeholder for the disabled lane, not its architectural result.
         const uint32_t source_lane = sel(in_bounds,
-            ibin(Op_ISub, lane, uconst(amount)), lane);
+            ibin(Op_ISub, lane, amount), lane);
         const uint32_t shifted = subgroup_shuffle(value, source_lane);
         const uint32_t source_active = subgroup_shuffle(
             sel(active, uconst(1), uconst(0)), source_lane);
@@ -764,6 +765,10 @@ struct SpirvCompute {
             ucmp(Op_INotEqual, source_active, uconst(0)));
         if (valid_lane) *valid_lane = valid;
         return sel(valid, shifted, value);
+    }
+    uint32_t subgroup_row_shr(uint32_t value, uint32_t active, uint32_t amount,
+                              uint32_t* valid_lane = nullptr) {
+        return subgroup_row_shr_dynamic(value, active, uconst(amount), valid_lane);
     }
     uint32_t subgroup_quad_permute(uint32_t value, uint32_t ctrl) {
         const uint32_t lane = subgroup_local_id();
@@ -11352,6 +11357,23 @@ bool emit_cfg_state_machine(
         return {in.src[0].value, in.src[1].value};
     };
 
+    // House of the Dead 2 reduces an unsigned value in place across one architectural DPP row
+    // immediately after the two saved-mask comparisons above. Keep this dispatcher escape hatch
+    // exact: fragment V_MIN_U32, unbounded ROW_SHR, full-mask/no-modifier DPP16 (proved by the
+    // decoder's has_dpp contract), and one physical VGPR used as VDST/SRC0/SRC1. The subgroup
+    // operation itself is emitted in the common phase below so lanes taking other CFG cases still
+    // participate without supplying a false neighbor.
+    auto fragment_dpp_min_row_shr = [&](const Rdna2Inst& in) {
+        return b.is_fragment && in.fmt == Rdna2Format::VOP2 &&
+            in.opcode == 0x13 && in.has_dpp && !in.dpp_bound_ctrl &&
+            in.dpp_ctrl >= 0x111u && in.dpp_ctrl <= 0x11fu &&
+            in.dst.kind == OperandKind::VGPR &&
+            in.src[0].kind == OperandKind::VGPR &&
+            in.src[1].kind == OperandKind::VGPR &&
+            in.dst.value == in.src[0].value &&
+            in.dst.value == in.src[1].value;
+    };
+
     // VOPC e64 can compare a complete 64-bit scalar mask as integer data. Generated Wave64 code
     // uses `v_cmp_gt_u64 vcc,vcc,0` to broadcast (old VCC != 0) back into every active VCC lane.
     // The per-invocation mask representation has no 64-bit scalar payload, but the comparison is
@@ -11479,6 +11501,8 @@ bool emit_cfg_state_machine(
     bool has_gds_append = false;
     bool has_lds_append = false;
     std::unordered_set<uint32_t> swizzle_pcs;
+    std::unordered_set<uint32_t> fragment_dpp_min_row_shr_pcs;
+    std::set<int> fragment_dpp_min_row_shr_dsts;
     for (size_t i = 0; i < ins.size(); ++i) {
         const auto& in = ins[i];
         if (in.is_end) break;
@@ -11501,6 +11525,13 @@ bool emit_cfg_state_machine(
         }
         if (in.fmt == Rdna2Format::DS && in.opcode == 0x35) {
             swizzle_pcs.insert(in.pc);
+            start_set.insert(in.pc);
+            if (i + 1 < ins.size() && ins[i + 1].pc <= end_pc)
+                start_set.insert(ins[i + 1].pc);
+        }
+        if (fragment_dpp_min_row_shr(in)) {
+            fragment_dpp_min_row_shr_pcs.insert(in.pc);
+            fragment_dpp_min_row_shr_dsts.insert(in.dst.value);
             start_set.insert(in.pc);
             if (i + 1 < ins.size() && ins[i + 1].pc <= end_pc)
                 start_set.insert(ins[i + 1].pc);
@@ -12133,6 +12164,7 @@ bool emit_cfg_state_machine(
             synchronized_block[block] = synchronized_block[block] ||
                 mbcnt_event_for_pc.contains(in.pc) || append_event_for_pc.contains(in.pc) ||
                 swizzle_pcs.contains(in.pc) ||
+                fragment_dpp_min_row_shr_pcs.contains(in.pc) ||
                 mask_zero_compare_candidate_source(in) >= 0 ||
                 exec_saved_mask_compare_source(in) >= 0 ||
                 saved_mask_pair_compare_sources(in)[0] >= 0 ||
@@ -12289,6 +12321,17 @@ bool emit_cfg_state_machine(
     const uint32_t swizzle_source_var = b.function_var(b.t_u32, ptr_u32);
     const uint32_t swizzle_source_lane_var = b.function_var(b.t_u32, ptr_u32);
     const uint32_t swizzle_dst_var = b.function_var(b.t_u32, ptr_u32);
+    const bool has_dpp_min_row_shr = !fragment_dpp_min_row_shr_pcs.empty();
+    const uint32_t dpp_min_pending_var = has_dpp_min_row_shr
+        ? b.function_var(b.t_bool, ptr_bool) : 0;
+    const uint32_t dpp_min_active_var = has_dpp_min_row_shr
+        ? b.function_var(b.t_bool, ptr_bool) : 0;
+    const uint32_t dpp_min_source_var = has_dpp_min_row_shr
+        ? b.function_var(b.t_u32, ptr_u32) : 0;
+    const uint32_t dpp_min_amount_var = has_dpp_min_row_shr
+        ? b.function_var(b.t_u32, ptr_u32) : 0;
+    const uint32_t dpp_min_dst_var = has_dpp_min_row_shr
+        ? b.function_var(b.t_u32, ptr_u32) : 0;
 
     const uint32_t zero = b.uconst(0), no = b.bfalse(), yes = b.btrue();
     for (const auto& kv : vv) {
@@ -12336,6 +12379,11 @@ bool emit_cfg_state_machine(
     b.store_function(swizzle_source_var, zero);
     b.store_function(swizzle_source_lane_var, zero);
     b.store_function(swizzle_dst_var, zero);
+    if (has_dpp_min_row_shr) {
+        b.store_function(dpp_min_source_var, zero);
+        b.store_function(dpp_min_amount_var, zero);
+        b.store_function(dpp_min_dst_var, zero);
+    }
 
     auto load_state = [&](uint32_t dispatch = UINT32_MAX) {
         RegState state;
@@ -12485,6 +12533,10 @@ bool emit_cfg_state_machine(
     }
     b.store_function(swizzle_pending_var, no);
     b.store_function(swizzle_active_var, no);
+    if (has_dpp_min_row_shr) {
+        b.store_function(dpp_min_pending_var, no);
+        b.store_function(dpp_min_active_var, no);
+    }
     b.emit_loopmerge(loop_merge, loop_continue);
     b.emit_branch(switch_header);
     b.emit_label(switch_header);
@@ -12529,6 +12581,7 @@ bool emit_cfg_state_machine(
         const Rdna2Inst* mbcnt = nullptr;
         const Rdna2Inst* append = nullptr;
         const Rdna2Inst* swizzle = nullptr;
+        const Rdna2Inst* dpp_min_row_shr = nullptr;
         const Rdna2Inst* mask_compare = nullptr;
         const Rdna2Inst* exec_saved_mask_compare = nullptr;
         const Rdna2Inst* saved_mask_pair_compare = nullptr;
@@ -12545,6 +12598,7 @@ bool emit_cfg_state_machine(
             const Rdna2Inst* block_mbcnt = nullptr;
             const Rdna2Inst* block_append = nullptr;
             const Rdna2Inst* block_swizzle = nullptr;
+            const Rdna2Inst* block_dpp_min_row_shr = nullptr;
             const Rdna2Inst* block_mask_compare = nullptr;
             const Rdna2Inst* block_exec_saved_mask_compare = nullptr;
             const Rdna2Inst* block_saved_mask_pair_compare = nullptr;
@@ -12567,6 +12621,16 @@ bool emit_cfg_state_machine(
                 }
                 if (in.fmt == Rdna2Format::DS && in.opcode == 0x35) {
                     block_swizzle = &in;
+                    break;
+                }
+                if (fragment_dpp_min_row_shr_pcs.contains(in.pc)) {
+                    if (getenv("PROSPER_DBG"))
+                        std::fprintf(stderr,
+                                     "[graphics-cfg-dpp-min-row-shr] "
+                                     "pc=%u vgpr=v%d amount=%u\n",
+                                     in.pc, in.dst.value,
+                                     static_cast<uint32_t>(in.dpp_ctrl - 0x110u));
+                    block_dpp_min_row_shr = &in;
                     break;
                 }
                 const int mask_compare_source =
@@ -12653,7 +12717,8 @@ bool emit_cfg_state_machine(
             const bool last = member + 1 == dispatch_blocks[dispatch].size();
             if (!last) {
                 // Group construction admits only one-successor plain blocks before the tail.
-                if (block_mbcnt || block_append || block_swizzle || block_mask_compare ||
+                if (block_mbcnt || block_append || block_swizzle ||
+                    block_dpp_min_row_shr || block_mask_compare ||
                     block_exec_saved_mask_compare || block_saved_mask_pair_compare ||
                     block_vopc_mask_compare ||
                     block_b64_mask_scc_vote ||
@@ -12666,6 +12731,7 @@ bool emit_cfg_state_machine(
             mbcnt = block_mbcnt;
             append = block_append;
             swizzle = block_swizzle;
+            dpp_min_row_shr = block_dpp_min_row_shr;
             mask_compare = block_mask_compare;
             exec_saved_mask_compare = block_exec_saved_mask_compare;
             saved_mask_pair_compare = block_saved_mask_pair_compare;
@@ -12763,6 +12829,19 @@ bool emit_cfg_state_machine(
             b.store_function(swizzle_source_lane_var, source_lane);
             b.store_function(swizzle_dst_var,
                 b.uconst(static_cast<uint32_t>(swizzle->dst.value)));
+        }
+        if (dpp_min_row_shr) {
+            if (!fragment_dpp_min_row_shr(*dpp_min_row_shr))
+                return reject_cfg(dpp_min_row_shr->pc, "dpp-min-row-shr-contract");
+            const auto source = state.vreg.find(dpp_min_row_shr->src[0].value);
+            b.store_function(dpp_min_pending_var, yes);
+            b.store_function(dpp_min_active_var, state.exec);
+            b.store_function(dpp_min_source_var,
+                source == state.vreg.end() ? zero : source->second);
+            b.store_function(dpp_min_amount_var,
+                b.uconst(static_cast<uint32_t>(dpp_min_row_shr->dpp_ctrl - 0x110u)));
+            b.store_function(dpp_min_dst_var,
+                b.uconst(static_cast<uint32_t>(dpp_min_row_shr->dst.value)));
         }
         if (mask_compare) {
             if (b.is_vertex) {
@@ -12916,6 +12995,10 @@ bool emit_cfg_state_machine(
         } else if (swizzle) {
             if (!set_next(swizzle->pc + swizzle->len_dwords))
                 return reject_cfg(swizzle->pc, "swizzle-successor");
+        } else if (dpp_min_row_shr) {
+            if (!set_next(dpp_min_row_shr->pc + dpp_min_row_shr->len_dwords))
+                return reject_cfg(dpp_min_row_shr->pc,
+                                  "dpp-min-row-shr-successor");
         } else if (mask_compare) {
             if (!set_next(mask_compare->pc + mask_compare->len_dwords))
                 return reject_cfg(mask_compare->pc, "mask-compare-successor");
@@ -13059,6 +13142,50 @@ bool emit_cfg_state_machine(
                 swizzle_pending,
                 b.ucmp(Op_IEqual, swizzle_dst,
                        b.uconst(static_cast<uint32_t>(kv.first.first))));
+            const uint32_t old = b.load_function(b.t_bool, kv.second);
+            b.store_function(kv.second, b.bsel(selected, no, old));
+        }
+    }
+
+    // Fragment DPP V_MIN_U32 common phase. A graphics dispatcher's PC is lane-local, so a source
+    // lane is eligible only when it published this same DPP event and its EXEC bit is active. The
+    // unbounded ROW_SHR contract disables out-of-row/inactive-source lanes and preserves VDST;
+    // active destination lanes reduce the shifted neighbor with their unchanged local value.
+    if (!fragment_dpp_min_row_shr_pcs.empty()) {
+        const uint32_t pending = b.load_function(b.t_bool, dpp_min_pending_var);
+        const uint32_t active = b.load_function(b.t_bool, dpp_min_active_var);
+        const uint32_t source = b.load_function(b.t_u32, dpp_min_source_var);
+        uint32_t valid_source = 0;
+        const uint32_t shifted = b.subgroup_row_shr_dynamic(
+            source, b.land(pending, active),
+            b.load_function(b.t_u32, dpp_min_amount_var), &valid_source);
+        const uint32_t result = b.uext2(Glsl_UMin, shifted, source);
+        const uint32_t write = b.land(b.land(pending, active), valid_source);
+        const uint32_t dst = b.load_function(b.t_u32, dpp_min_dst_var);
+        for (int reg : fragment_dpp_min_row_shr_dsts) {
+            const auto kv = vv.find(reg);
+            if (kv == vv.end()) return reject_cfg(0, "missing-dpp-min-row-shr-dst");
+            const uint32_t selected = b.land(
+                write, b.ucmp(Op_IEqual, dst,
+                              b.uconst(static_cast<uint32_t>(reg))));
+            const uint32_t old = b.load_function(b.t_u32, kv->second);
+            b.store_function(kv->second, b.sel(selected, result, old));
+        }
+        // A physical VGPR definition ends scalar lane-spill lifetimes even when EXEC suppresses
+        // this lane's data write, matching predicate_write and the DS_SWIZZLE common phase above.
+        for (const auto& kv : lv) {
+            if (!fragment_dpp_min_row_shr_dsts.contains(kv.first.first)) continue;
+            const uint32_t selected = b.land(
+                pending, b.ucmp(Op_IEqual, dst,
+                                b.uconst(static_cast<uint32_t>(kv.first.first))));
+            const uint32_t old = b.load_function(b.t_u32, kv.second);
+            b.store_function(kv.second, b.sel(selected, zero, old));
+        }
+        for (const auto& kv : lmv) {
+            if (!fragment_dpp_min_row_shr_dsts.contains(kv.first.first)) continue;
+            const uint32_t selected = b.land(
+                pending, b.ucmp(Op_IEqual, dst,
+                                b.uconst(static_cast<uint32_t>(kv.first.first))));
             const uint32_t old = b.load_function(b.t_bool, kv.second);
             b.store_function(kv.second, b.bsel(selected, no, old));
         }

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -11335,6 +11335,23 @@ bool emit_cfg_state_machine(
         return -1;
     };
 
+    // Unity fragment programs also compare two ordinary saved B64 mask pairs.  Keep candidate
+    // discovery syntactic so block splitting does not depend on a path-local register lifetime;
+    // the MUST dataflow below separately proves that BOTH pairs are masks at the exact compare.
+    // A numeric pair, an EXEC/VCC special pair, or a path-dependent mask/data join therefore does
+    // not enter this lowering and falls back to the ordinary scalar emitter (or rejects visibly).
+    auto saved_mask_pair_compare_sources = [&](const Rdna2Inst& in)
+            -> std::array<int, 2> {
+        if (in.fmt != Rdna2Format::SOPC ||
+            (in.opcode != 0x12 && in.opcode != 0x13) ||
+            in.src[0].kind != OperandKind::SGPR ||
+            in.src[1].kind != OperandKind::SGPR ||
+            in.src[0].value < 0 || in.src[0].value > 105 ||
+            in.src[1].value < 0 || in.src[1].value > 105)
+            return {-1, -1};
+        return {in.src[0].value, in.src[1].value};
+    };
+
     // VOPC e64 can compare a complete 64-bit scalar mask as integer data. Generated Wave64 code
     // uses `v_cmp_gt_u64 vcc,vcc,0` to broadcast (old VCC != 0) back into every active VCC lane.
     // The per-invocation mask representation has no 64-bit scalar payload, but the comparison is
@@ -11494,6 +11511,11 @@ bool emit_cfg_state_machine(
                 start_set.insert(ins[i + 1].pc);
         }
         if (exec_saved_mask_compare_source(in) >= 0) {
+            start_set.insert(in.pc);
+            if (i + 1 < ins.size() && ins[i + 1].pc <= end_pc)
+                start_set.insert(ins[i + 1].pc);
+        }
+        if (saved_mask_pair_compare_sources(in)[0] >= 0) {
             start_set.insert(in.pc);
             if (i + 1 < ins.size() && ins[i + 1].pc <= end_pc)
                 start_set.insert(ins[i + 1].pc);
@@ -11661,6 +11683,7 @@ bool emit_cfg_state_machine(
     std::vector<std::set<int>> b64_mask_in(starts.size());
     std::vector<std::set<int>> b64_mask_ambiguous_in(starts.size());
     std::vector<bool> b32_mask_reachable(starts.size(), false);
+    std::unordered_set<uint32_t> proven_saved_mask_pair_compare_pcs;
     if (b.allow_b32_masks && !starts.empty()) {
         b32_mask_in.front().insert(
             initial.sreg_bool_b32.begin(), initial.sreg_bool_b32.end());
@@ -11712,6 +11735,19 @@ bool emit_cfg_state_machine(
             const uint32_t hi = block + 1 < starts.size() ? starts[block + 1] : UINT32_MAX;
             for (const auto& in : ins) {
                 if (in.pc < lo || in.pc >= hi || in.is_end) continue;
+
+                const auto compare_sources = saved_mask_pair_compare_sources(in);
+                if (compare_sources[0] >= 0) {
+                    const bool proven =
+                        b64_masks.contains(compare_sources[0]) &&
+                        b64_masks.contains(compare_sources[1]) &&
+                        !b64_ambiguous.contains(compare_sources[0]) &&
+                        !b64_ambiguous.contains(compare_sources[1]);
+                    if (proven)
+                        proven_saved_mask_pair_compare_pcs.insert(in.pc);
+                    else
+                        proven_saved_mask_pair_compare_pcs.erase(in.pc);
+                }
 
                 // The dispatcher may use a false backing value for a physical VCC lifetime that is
                 // provably dead. Do not let that implementation placeholder become observable: every
@@ -11933,10 +11969,11 @@ bool emit_cfg_state_machine(
     // Wave64 dispatcher Bool variables hold values, not lifetime tags. A scalar overwrite stores
     // false for a dead mask, and an unfiltered load at a later case can therefore make mere map
     // membership look like a valid saved mask. Prove the B64 mask domain separately at every
-    // EXEC-vs-saved-mask comparison: mask producers generate the fact, every overlapping half/pair
-    // scalar write kills it, and joins retain it only when all reachable predecessors agree.
+    // Wave64 whole-mask comparisons (EXEC-vs-saved or saved-vs-saved): mask producers generate the
+    // fact, every overlapping half/pair scalar write kills it, and joins retain it only when all
+    // reachable predecessors agree.
     std::unordered_set<uint32_t> proven_exec_saved_mask_compare_pcs;
-    if (b.is_compute && b.wave_size == 64 && !starts.empty()) {
+    if ((b.is_compute || b.is_fragment) && b.wave_size == 64 && !starts.empty()) {
         std::vector<std::set<int>> wave64_b64_mask_in(starts.size());
         std::vector<bool> wave64_b64_reachable(starts.size(), false);
         for (const auto& mask : initial.sreg_bool)
@@ -11950,6 +11987,10 @@ bool emit_cfg_state_machine(
             const int compare_source = exec_saved_mask_compare_source(in);
             if (record_compare && compare_source >= 0 && masks.contains(compare_source))
                 proven_exec_saved_mask_compare_pcs.insert(in.pc);
+            const auto pair_compare = saved_mask_pair_compare_sources(in);
+            if (record_compare && pair_compare[0] >= 0 &&
+                masks.contains(pair_compare[0]) && masks.contains(pair_compare[1]))
+                proven_saved_mask_pair_compare_pcs.insert(in.pc);
 
             auto source_is_mask = [&](const Operand& source) {
                 if (source.kind == OperandKind::InlineInt) return true;
@@ -12094,6 +12135,7 @@ bool emit_cfg_state_machine(
                 swizzle_pcs.contains(in.pc) ||
                 mask_zero_compare_candidate_source(in) >= 0 ||
                 exec_saved_mask_compare_source(in) >= 0 ||
+                saved_mask_pair_compare_sources(in)[0] >= 0 ||
                 vopc_mask_zero_compare_source(in) >= 0 ||
                 b64_mask_scc_vote_pcs.contains(in.pc);
             conditional_block[block] = conditional_block[block] ||
@@ -12489,6 +12531,7 @@ bool emit_cfg_state_machine(
         const Rdna2Inst* swizzle = nullptr;
         const Rdna2Inst* mask_compare = nullptr;
         const Rdna2Inst* exec_saved_mask_compare = nullptr;
+        const Rdna2Inst* saved_mask_pair_compare = nullptr;
         const Rdna2Inst* vopc_mask_compare = nullptr;
         const Rdna2Inst* b64_mask_scc_vote = nullptr;
         const uint32_t final_block = dispatch_blocks[dispatch].back();
@@ -12504,6 +12547,7 @@ bool emit_cfg_state_machine(
             const Rdna2Inst* block_swizzle = nullptr;
             const Rdna2Inst* block_mask_compare = nullptr;
             const Rdna2Inst* block_exec_saved_mask_compare = nullptr;
+            const Rdna2Inst* block_saved_mask_pair_compare = nullptr;
             const Rdna2Inst* block_vopc_mask_compare = nullptr;
             const Rdna2Inst* block_b64_mask_scc_vote = nullptr;
             for (const auto& in : ins) {
@@ -12547,6 +12591,23 @@ bool emit_cfg_state_machine(
                                      "pc=%u source=s%d op=0x%x\n",
                                      in.pc, exec_saved_mask_source, in.opcode);
                     block_exec_saved_mask_compare = &in;
+                    break;
+                }
+                const auto saved_pair_sources =
+                    saved_mask_pair_compare_sources(in);
+                if (saved_pair_sources[0] >= 0 &&
+                    proven_saved_mask_pair_compare_pcs.contains(in.pc) &&
+                    state.sreg_bool.contains(saved_pair_sources[0]) &&
+                    state.sreg_bool.contains(saved_pair_sources[1])) {
+                    if (getenv("PROSPER_DBG"))
+                        std::fprintf(stderr,
+                                     "[%s-saved-mask-pair-compare] "
+                                     "pc=%u sources=s[%d:%d],s[%d:%d] op=0x%x\n",
+                                     b.is_compute ? "compute" : "graphics",
+                                     in.pc, saved_pair_sources[0], saved_pair_sources[0] + 1,
+                                     saved_pair_sources[1], saved_pair_sources[1] + 1,
+                                     in.opcode);
+                    block_saved_mask_pair_compare = &in;
                     break;
                 }
                 const int vopc_mask_compare_source =
@@ -12593,7 +12654,8 @@ bool emit_cfg_state_machine(
             if (!last) {
                 // Group construction admits only one-successor plain blocks before the tail.
                 if (block_mbcnt || block_append || block_swizzle || block_mask_compare ||
-                    block_exec_saved_mask_compare || block_vopc_mask_compare ||
+                    block_exec_saved_mask_compare || block_saved_mask_pair_compare ||
+                    block_vopc_mask_compare ||
                     block_b64_mask_scc_vote ||
                     (block_terminator && (block_terminator->is_end ||
                                           block_terminator->opcode != 0x02)))
@@ -12606,6 +12668,7 @@ bool emit_cfg_state_machine(
             swizzle = block_swizzle;
             mask_compare = block_mask_compare;
             exec_saved_mask_compare = block_exec_saved_mask_compare;
+            saved_mask_pair_compare = block_saved_mask_pair_compare;
             vopc_mask_compare = block_vopc_mask_compare;
             b64_mask_scc_vote = block_b64_mask_scc_vote;
         }
@@ -12752,6 +12815,33 @@ bool emit_cfg_state_machine(
                 b.store_function(vote_to_scc_var, yes);
             }
         }
+        if (saved_mask_pair_compare) {
+            const auto sources =
+                saved_mask_pair_compare_sources(*saved_mask_pair_compare);
+            const auto first = state.sreg_bool.find(sources[0]);
+            const auto second = state.sreg_bool.find(sources[1]);
+            if (first == state.sreg_bool.end() || second == state.sreg_bool.end())
+                return reject_cfg(saved_mask_pair_compare->pc,
+                                  "missing-saved-mask-pair-compare-source");
+            const uint32_t mismatch = b.bsel(
+                first->second, b.logical_not(second->second), second->second);
+            if (b.native_subgroup_size || b.is_fragment) {
+                const uint32_t different = b.is_fragment
+                    ? b.fragment_wave_any(mismatch)
+                    : b.native_wave_any(mismatch);
+                if (!different)
+                    return reject_cfg(saved_mask_pair_compare->pc,
+                                      "saved-mask-pair-vote");
+                state.scc = saved_mask_pair_compare->opcode == 0x12
+                    ? b.logical_not(different) : different;
+            } else {
+                b.store_function(vote_pending_var, yes);
+                b.store_function(vote_value_var, mismatch);
+                b.store_function(vote_invert_var,
+                    saved_mask_pair_compare->opcode == 0x12 ? yes : no);
+                b.store_function(vote_to_scc_var, yes);
+            }
+        }
         if (vopc_mask_compare) {
             if (b.is_vertex) {
                 if (getenv("PROSPER_DBG"))
@@ -12834,6 +12924,11 @@ bool emit_cfg_state_machine(
                           exec_saved_mask_compare->len_dwords))
                 return reject_cfg(exec_saved_mask_compare->pc,
                                   "exec-saved-mask-compare-successor");
+        } else if (saved_mask_pair_compare) {
+            if (!set_next(saved_mask_pair_compare->pc +
+                          saved_mask_pair_compare->len_dwords))
+                return reject_cfg(saved_mask_pair_compare->pc,
+                                  "saved-mask-pair-compare-successor");
         } else if (vopc_mask_compare) {
             if (!set_next(vopc_mask_compare->pc + vopc_mask_compare->len_dwords))
                 return reject_cfg(vopc_mask_compare->pc,

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -109,28 +109,200 @@ bool wave_vote_reaches_later_select(const std::vector<uint32_t>& spv,
                                     bool expect_inverted) {
     constexpr uint32_t OpLoad = 61, OpStore = 62, OpLogicalNot = 168,
                        OpSelect = 169, OpGroupNonUniformAny = 335;
-    std::unordered_set<uint32_t> direct_values, inverted_values;
-    std::unordered_set<uint32_t> vote_variables;
+    struct Select { uint32_t result = 0, condition = 0, yes = 0, no = 0; };
+    std::unordered_set<uint32_t> votes, values, variables;
+    std::vector<std::array<uint32_t, 2>> logical_nots, stores, loads;
+    std::vector<Select> selects;
     for (size_t i = 5; i < spv.size();) {
         const uint32_t op = spv[i] & 0xffffu, wc = spv[i] >> 16u;
         if (!wc || i + wc > spv.size()) return false;
         if (op == OpGroupNonUniformAny && wc >= 4)
-            direct_values.insert(spv[i + 2]);
-        if (op == OpLogicalNot && wc == 4) {
-            if (direct_values.contains(spv[i + 3]))
-                inverted_values.insert(spv[i + 2]);
-            if (inverted_values.contains(spv[i + 3]))
-                direct_values.insert(spv[i + 2]);
-        }
-        const auto& expected_values = expect_inverted ? inverted_values : direct_values;
-        if (op == OpStore && wc == 3 && expected_values.contains(spv[i + 2]))
-            vote_variables.insert(spv[i + 1]);
-        if (op == OpLoad && wc == 4 && vote_variables.contains(spv[i + 3]))
-            (expect_inverted ? inverted_values : direct_values).insert(spv[i + 2]);
-        if (op == OpSelect && wc == 6 &&
-            (expect_inverted ? inverted_values : direct_values).contains(spv[i + 3]))
-            return true;
+            votes.insert(spv[i + 2]);
+        if (op == OpLogicalNot && wc == 4)
+            logical_nots.push_back({spv[i + 2], spv[i + 3]});
+        if (op == OpStore && wc == 3)
+            stores.push_back({spv[i + 1], spv[i + 2]});
+        if (op == OpLoad && wc == 4)
+            loads.push_back({spv[i + 2], spv[i + 3]});
+        if (op == OpSelect && wc == 6)
+            selects.push_back({spv[i + 2], spv[i + 3], spv[i + 4], spv[i + 5]});
         i += wc;
+    }
+    if (expect_inverted) {
+        for (const auto& negate : logical_nots)
+            if (votes.contains(negate[1])) values.insert(negate[0]);
+    } else {
+        values = votes;
+    }
+    bool changed = true;
+    while (changed) {
+        changed = false;
+        for (const auto& select : selects)
+            if ((values.contains(select.yes) || values.contains(select.no)) &&
+                values.insert(select.result).second)
+                changed = true;
+        for (const auto& store : stores)
+            if (values.contains(store[1]) && variables.insert(store[0]).second)
+                changed = true;
+        for (const auto& load : loads)
+            if (variables.contains(load[1]) && values.insert(load[0]).second)
+                changed = true;
+    }
+    return std::any_of(selects.begin(), selects.end(),
+        [&](const Select& select) { return values.contains(select.condition); });
+}
+
+// Prove the defect-shaped saved-mask lowering: two distinct static comparisons publish event tags
+// from alternate dispatcher cases, while both subgroup votes execute after the switch merge from
+// ungated persistent mask loads.  Each event gate must select its own EQ/LG polarity into one SCC
+// variable, whose later load controls s_cselect.  A vote left inside a lane-local case, or a vote
+// predicate gated by the publishing lane's PC, fails this dataflow/location check.
+bool saved_mask_pair_votes_use_uniform_event_phase(const std::vector<uint32_t>& spv) {
+    constexpr uint32_t OpConstant = 43, OpLoad = 61, OpStore = 62,
+                       OpLabel = 248, OpSelectionMerge = 247, OpSwitch = 251,
+                       OpIEqual = 170, OpLogicalNot = 168, OpLogicalAnd = 167,
+                       OpSelect = 169, OpGroupNonUniformAny = 335;
+    struct Select { uint32_t condition = 0, yes = 0, no = 0; size_t position = 0; };
+    struct Pair { uint32_t first = 0, second = 0; };
+    struct Vote { uint32_t result = 0, predicate = 0; size_t position = 0; };
+    std::unordered_map<uint32_t, uint32_t> constants, loads, logical_nots;
+    std::unordered_map<uint32_t, Pair> logical_ands, equals;
+    std::unordered_map<uint32_t, Select> selects;
+    std::vector<std::array<uint32_t, 2>> stores;
+    std::vector<Vote> votes;
+    uint32_t last_selection_merge = 0, switch_merge = 0;
+    size_t switch_position = 0, common_position = 0;
+    if (spv.size() < 5) return false;
+    for (size_t i = 5; i < spv.size();) {
+        const uint32_t op = spv[i] & 0xffffu, wc = spv[i] >> 16u;
+        if (!wc || i + wc > spv.size()) return false;
+        if (op == OpConstant && wc == 4)
+            constants[spv[i + 2]] = spv[i + 3];
+        else if (op == OpLoad && wc == 4)
+            loads[spv[i + 2]] = spv[i + 3];
+        else if (op == OpStore && wc == 3)
+            stores.push_back({spv[i + 1], spv[i + 2]});
+        else if (op == OpLogicalNot && wc == 4)
+            logical_nots[spv[i + 2]] = spv[i + 3];
+        else if (op == OpLogicalAnd && wc == 5)
+            logical_ands[spv[i + 2]] = {spv[i + 3], spv[i + 4]};
+        else if (op == OpIEqual && wc == 5)
+            equals[spv[i + 2]] = {spv[i + 3], spv[i + 4]};
+        else if (op == OpSelect && wc == 6)
+            selects[spv[i + 2]] = {spv[i + 3], spv[i + 4], spv[i + 5], i};
+        else if (op == OpGroupNonUniformAny && wc == 5)
+            votes.push_back({spv[i + 2], spv[i + 4], i});
+        else if (op == OpSelectionMerge && wc >= 3)
+            last_selection_merge = spv[i + 1];
+        else if (op == OpSwitch && last_selection_merge) {
+            switch_merge = last_selection_merge;
+            switch_position = i;
+        } else if (op == OpLabel && wc == 2 && switch_merge &&
+                   spv[i + 1] == switch_merge && i > switch_position)
+            common_position = i;
+        i += wc;
+    }
+    if (votes.size() != 2 || !switch_position || !common_position) return false;
+
+    std::unordered_set<uint32_t> mask_pointers;
+    std::unordered_set<uint32_t> event_tags;
+    uint32_t event_pointer = 0, pending_pointer = 0, scc_pointer = 0;
+    bool saw_direct = false, saw_inverted = false;
+    for (const Vote& vote : votes) {
+        if (vote.position <= common_position) return false;
+        const auto mismatch = selects.find(vote.predicate);
+        if (mismatch == selects.end()) return false;
+        const auto first = loads.find(mismatch->second.condition);
+        const auto second = loads.find(mismatch->second.no);
+        const auto negated_second = logical_nots.find(mismatch->second.yes);
+        if (first == loads.end() || second == loads.end() ||
+            negated_second == logical_nots.end() ||
+            negated_second->second != mismatch->second.no ||
+            first->second == second->second)
+            return false;
+        mask_pointers.insert(first->second);
+        mask_pointers.insert(second->second);
+
+        const auto inverted = std::find_if(
+            logical_nots.begin(), logical_nots.end(),
+            [&](const auto& item) { return item.second == vote.result; });
+        const uint32_t direct_result = vote.result;
+        const uint32_t inverted_result = inverted == logical_nots.end() ? 0 : inverted->first;
+        bool selected_vote = false;
+        for (const auto& selected : selects) {
+            if (selected.second.position <= vote.position) continue;
+            const bool direct = selected.second.yes == direct_result;
+            const bool inverse = inverted_result && selected.second.yes == inverted_result;
+            if (!direct && !inverse) continue;
+            const auto gate = logical_ands.find(selected.second.condition);
+            if (gate == logical_ands.end()) continue;
+            uint32_t pending_load = 0, equality_id = 0;
+            if (loads.contains(gate->second.first) && equals.contains(gate->second.second)) {
+                pending_load = gate->second.first;
+                equality_id = gate->second.second;
+            } else if (loads.contains(gate->second.second) &&
+                       equals.contains(gate->second.first)) {
+                pending_load = gate->second.second;
+                equality_id = gate->second.first;
+            } else {
+                continue;
+            }
+            const Pair equal = equals.at(equality_id);
+            uint32_t event_load = 0, event_constant = 0;
+            if (loads.contains(equal.first) && constants.contains(equal.second)) {
+                event_load = equal.first;
+                event_constant = equal.second;
+            } else if (loads.contains(equal.second) && constants.contains(equal.first)) {
+                event_load = equal.second;
+                event_constant = equal.first;
+            } else {
+                continue;
+            }
+            const uint32_t this_event_pointer = loads.at(event_load);
+            const uint32_t this_pending_pointer = loads.at(pending_load);
+            if ((event_pointer && event_pointer != this_event_pointer) ||
+                (pending_pointer && pending_pointer != this_pending_pointer))
+                return false;
+            event_pointer = this_event_pointer;
+            pending_pointer = this_pending_pointer;
+            event_tags.insert(constants.at(event_constant));
+
+            const auto stored = std::find_if(
+                stores.begin(), stores.end(),
+                [&](const auto& store) { return store[1] == selected.first; });
+            if (stored == stores.end()) continue;
+            if (scc_pointer && scc_pointer != (*stored)[0]) return false;
+            scc_pointer = (*stored)[0];
+            saw_direct |= direct;
+            saw_inverted |= inverse;
+            selected_vote = true;
+            break;
+        }
+        if (!selected_vote) return false;
+    }
+    if (mask_pointers.size() != 4 || event_tags.size() != 2 ||
+        !event_tags.contains(1) || !event_tags.contains(2) ||
+        !event_pointer || !pending_pointer || event_pointer == pending_pointer ||
+        !scc_pointer || !saw_direct || !saw_inverted)
+        return false;
+    std::unordered_set<uint32_t> published_event_tags;
+    for (const auto& store : stores) {
+        if (store[0] != event_pointer) continue;
+        const auto value = constants.find(store[1]);
+        if (value != constants.end()) published_event_tags.insert(value->second);
+    }
+    if (!published_event_tags.contains(0) || !published_event_tags.contains(1) ||
+        !published_event_tags.contains(2))
+        return false;
+
+    for (const auto& load : loads) {
+        if (load.second != scc_pointer) continue;
+        const auto consumed = std::find_if(
+            selects.begin(), selects.end(),
+            [&](const auto& selected) {
+                return selected.second.condition == load.first;
+            });
+        if (consumed != selects.end()) return true;
     }
     return false;
 }
@@ -138,19 +310,23 @@ bool wave_vote_reaches_later_select(const std::vector<uint32_t>& spv,
 // Prove the complete common-phase lowering for House's in-place DPP minimum reduction. The four
 // dispatcher cases must publish shifts 1/2/4/8 into one mailbox; one uniform subgroup phase must use
 // that dynamic amount for both the row bound and lane subtraction, gate source participation by
-// two persisted bools (pending + EXEC), feed the shuffle into UMin, and store the selected result
-// back to a Function VGPR. Opcode presence alone would miss direction and divergent-PC mistakes.
+// two persisted bools (pending + EXEC), and shuffle a static event tag beside value/activity. The
+// source event must equal the destination event on the write path before UMin reaches a Function
+// VGPR. Opcode presence alone would miss direction and divergent-PC cross-site contamination.
 bool dpp_min_row_shr_updates_dispatch_vgpr(const std::vector<uint32_t>& spv) {
     constexpr uint32_t OpConstant = 43, OpExtInst = 12, OpLoad = 61, OpStore = 62,
                        OpISub = 130, OpLogicalAnd = 167, OpSelect = 169,
-                       OpUGreaterThanEqual = 174, OpGroupNonUniformShuffle = 345,
+                       OpIEqual = 170, OpUGreaterThanEqual = 174,
+                       OpGroupNonUniformShuffle = 345,
                        GlslUMin = 38;
     struct Select { uint32_t condition = 0, yes = 0, no = 0; };
+    struct Shuffle { uint32_t result = 0, value = 0, lane = 0; };
     std::unordered_map<uint32_t, uint32_t> constants, load_pointer;
     std::unordered_map<uint32_t, std::array<uint32_t, 2>> logical_ands;
+    std::unordered_map<uint32_t, std::array<uint32_t, 2>> equals;
     std::unordered_map<uint32_t, Select> selects;
     std::vector<std::array<uint32_t, 2>> stores;
-    std::vector<uint32_t> shuffle_values;
+    std::vector<Shuffle> shuffles;
     std::unordered_set<uint32_t> shuffle_derived, umin_results;
     std::unordered_set<uint32_t> amount_bound_uses, amount_subtract_uses;
     if (spv.size() < 5) return false;
@@ -165,6 +341,8 @@ bool dpp_min_row_shr_updates_dispatch_vgpr(const std::vector<uint32_t>& spv) {
             stores.push_back({spv[i + 1], spv[i + 2]});
         else if (op == OpLogicalAnd && wc == 5)
             logical_ands[spv[i + 2]] = {spv[i + 3], spv[i + 4]};
+        else if (op == OpIEqual && wc == 5)
+            equals[spv[i + 2]] = {spv[i + 3], spv[i + 4]};
         else if (op == OpSelect && wc == 6) {
             selects[spv[i + 2]] = {spv[i + 3], spv[i + 4], spv[i + 5]};
             if (shuffle_derived.contains(spv[i + 4]) ||
@@ -172,7 +350,7 @@ bool dpp_min_row_shr_updates_dispatch_vgpr(const std::vector<uint32_t>& spv) {
                 shuffle_derived.insert(spv[i + 2]);
         } else if (op == OpGroupNonUniformShuffle && wc == 6) {
             shuffle_derived.insert(spv[i + 2]);
-            shuffle_values.push_back(spv[i + 4]);
+            shuffles.push_back({spv[i + 2], spv[i + 4], spv[i + 5]});
         } else if (op == OpExtInst && wc == 7 && spv[i + 4] == GlslUMin &&
                    (shuffle_derived.contains(spv[i + 5]) ||
                     shuffle_derived.contains(spv[i + 6]))) {
@@ -184,7 +362,7 @@ bool dpp_min_row_shr_updates_dispatch_vgpr(const std::vector<uint32_t>& spv) {
         }
         i += wc;
     }
-    if (opcode_count(spv, OpGroupNonUniformShuffle) != 2 || umin_results.empty())
+    if (opcode_count(spv, OpGroupNonUniformShuffle) != 3 || umin_results.empty())
         return false;
 
     std::unordered_map<uint32_t, std::unordered_set<uint32_t>> stored_constants;
@@ -206,8 +384,8 @@ bool dpp_min_row_shr_updates_dispatch_vgpr(const std::vector<uint32_t>& spv) {
     }
 
     bool pending_and_exec_gate = false;
-    for (uint32_t value : shuffle_values) {
-        const auto select = selects.find(value);
+    for (const auto& shuffle : shuffles) {
+        const auto select = selects.find(shuffle.value);
         if (select == selects.end()) continue;
         const auto one = constants.find(select->second.yes);
         const auto zero = constants.find(select->second.no);
@@ -225,9 +403,49 @@ bool dpp_min_row_shr_updates_dispatch_vgpr(const std::vector<uint32_t>& spv) {
         }
     }
 
+    // The event mailbox contains one distinct nonzero tag per static DPP site. Its load is shuffled
+    // with the exact same source-lane id as value/activity, then compared against the destination
+    // lane's unshuffled tag. Track that equality through every LogicalAnd into the final VGPR write.
+    uint32_t event_match = 0;
+    std::unordered_set<uint32_t> shuffle_lanes;
+    for (const auto& shuffle : shuffles) shuffle_lanes.insert(shuffle.lane);
+    for (const auto& shuffle : shuffles) {
+        const auto event_load = load_pointer.find(shuffle.value);
+        if (event_load == load_pointer.end()) continue;
+        const auto tags = stored_constants.find(event_load->second);
+        if (tags == stored_constants.end() || !tags->second.contains(0) ||
+            !tags->second.contains(1) || !tags->second.contains(2) ||
+            !tags->second.contains(3) || !tags->second.contains(4))
+            continue;
+        for (const auto& equal : equals) {
+            const bool exact_pair =
+                (equal.second[0] == shuffle.result && equal.second[1] == shuffle.value) ||
+                (equal.second[1] == shuffle.result && equal.second[0] == shuffle.value);
+            if (exact_pair) {
+                event_match = equal.first;
+                break;
+            }
+        }
+        if (event_match) break;
+    }
+    std::unordered_set<uint32_t> event_guarded;
+    if (event_match) event_guarded.insert(event_match);
+    bool changed = true;
+    while (changed) {
+        changed = false;
+        for (const auto& value : logical_ands) {
+            if ((event_guarded.contains(value.second[0]) ||
+                 event_guarded.contains(value.second[1])) &&
+                event_guarded.insert(value.first).second)
+                changed = true;
+        }
+    }
+
     bool min_reaches_store = false;
     for (const auto& select : selects) {
-        if (!umin_results.contains(select.second.yes)) continue;
+        if (!umin_results.contains(select.second.yes) ||
+            !event_guarded.contains(select.second.condition))
+            continue;
         if (std::any_of(stores.begin(), stores.end(), [&](const auto& store) {
                 return store[1] == select.first;
             })) {
@@ -235,7 +453,8 @@ bool dpp_min_row_shr_updates_dispatch_vgpr(const std::vector<uint32_t>& spv) {
             break;
         }
     }
-    return exact_amount && pending_and_exec_gate && min_reaches_store;
+    return exact_amount && pending_and_exec_gate && event_match &&
+        shuffle_lanes.size() == 1 && min_reaches_store;
 }
 
 // Trace IMAGE_GET_LOD all the way from two known VGPR bit patterns to the fragment output. This is
@@ -2472,6 +2691,43 @@ int main() {
     }
     printf("  [ok]   saved-mask EQ/LG votes persist into s_cselect in Wave32 and Wave64 CFGs\n");
 
+    // Two alternate saved-pair comparison sites model adjacent fragment lanes parked at distinct
+    // dispatcher PCs.  Event 1 is EQ over s[44:45]/s[46:47], while event 2 is LG over the disjoint
+    // s[52:53]/s[54:55] pair.  A mismatch bit may live on a lane currently taking the other case,
+    // so both complete-pair votes must be unconditional after the switch merge; only the SCC write
+    // is selected by the publishing lane's nonzero event tag.
+    std::vector<uint32_t> saved_mask_pair_divergent_sites = {
+        0xbe9e047eu,                         // pc0:  s_mov_b64 s[30:31],exec
+        0x87ac1e7eu,                         // pc1:  s_and_b64 s[44:45],exec,s[30:31]
+        0x7c020300u,                         // pc2:  v_cmp_lt_f32 vcc,v0,v1
+        0x87ae1e6au,                         // pc3:  s_and_b64 s[46:47],vcc,s[30:31]
+        0x87b41e7eu,                         // pc4:  s_and_b64 s[52:53],exec,s[30:31]
+        0x87b61e6au,                         // pc5:  s_and_b64 s[54:55],vcc,s[30:31]
+        0xbf060100u,                         // pc6:  s_cmp_eq_u32 s0,s1
+        0xbf840002u,                         // pc7:  alternate event -> pc10
+        0xbf122e2cu,                         // pc8:  event 1: EQ s[44:45],s[46:47]
+        0xbf820001u,                         // pc9:  join -> pc11
+        0xbf133634u,                         // pc10: event 2: LG s[52:53],s[54:55]
+        0xbf800000u,                         // pc11: SCC-preserving join
+        0x85b0807eu,                         // pc12: s_cselect_b64 s[48:49],exec,0
+        0xbefe0430u,                         // pc13: s_mov_b64 exec,s[48:49]
+    };
+    saved_mask_pair_divergent_sites.insert(
+        saved_mask_pair_divergent_sites.end(), std::begin(fragment_scalar_cfg_dispatch),
+        std::end(fragment_scalar_cfg_dispatch));
+    const auto saved_mask_pair_divergent_wave64_spv = recompile_fragment(
+        saved_mask_pair_divergent_sites.data(), saved_mask_pair_divergent_sites.size());
+    const auto saved_mask_pair_divergent_wave32_spv = recompile_fragment_wave32_for_test(
+        saved_mask_pair_divergent_sites.data(), saved_mask_pair_divergent_sites.size());
+    if (!saved_mask_pair_votes_use_uniform_event_phase(
+            saved_mask_pair_divergent_wave64_spv) ||
+        !saved_mask_pair_votes_use_uniform_event_phase(
+            saved_mask_pair_divergent_wave32_spv)) {
+        printf("  [FAIL] divergent-PC saved-mask votes escaped uniform event isolation\n");
+        return 1;
+    }
+    printf("  [ok]   divergent-PC saved-mask bits vote in uniform Wave32/64 event phases\n");
+
     // Every physical/dataflow obligation is independently load-bearing. A write to either half of
     // a saved pair ends that lifetime; a numeric replacement is not reinterpreted as a mask; and a
     // producer skipped on one reachable predecessor cannot establish a mask at the join.
@@ -2517,8 +2773,8 @@ int main() {
 
     // The exact House shader next performs four in-place unsigned minima across DPP row-right
     // neighbors. Keep them inside the same crossing graphics CFG fixture: the dispatcher must
-    // publish each lane's source and shift, execute two subgroup shuffles in its uniform common
-    // phase (value + source-activity), persist the UMin, and do so for both fragment wave sizes.
+    // publish each lane's source, shift, and event, execute three subgroup shuffles in its uniform
+    // common phase (value + source-activity + event), persist the UMin, and do so for both sizes.
     auto saved_mask_pair_dpp_shader = [&]() {
         std::vector<uint32_t> shader(
             std::begin(fragment_saved_mask_pair_prelude),
@@ -2544,6 +2800,44 @@ int main() {
             type_result_ids_are_nonzero(spirv, nullptr) &&
             phi_ids_are_nonzero(spirv);
     };
+
+    // Four alternate static DPP sites make the cross-PC hazard explicit.  A source lane parked at
+    // row_shr:2/4/8 must never satisfy a destination executing row_shr:1 (and vice versa), even when
+    // both publish active data in the same common phase.  Value, activity, and event identity must
+    // use one source-lane shuffle; the event equality is load-bearing on the VGPR write path.
+    std::vector<uint32_t> fragment_dpp_min_divergent_sites(
+        std::begin(fragment_saved_mask_pair_prelude),
+        std::end(fragment_saved_mask_pair_prelude));
+    fragment_dpp_min_divergent_sites.insert(
+        fragment_dpp_min_divergent_sites.end(), {
+            0x7e060287u,                         // pc8:  v_mov_b32 v3,7
+            0xbf060100u,                         // pc9:  s_cmp_eq_u32 s0,s1
+            0xbf840003u,                         // pc10: alternate event -> pc14
+            0x260606fau, 0xff011103u,            // pc11: event 1 row_shr:1
+            0xbf820002u,                         // pc13: join -> pc16
+            0x260606fau, 0xff011203u,            // pc14: event 2 row_shr:2
+            0xbf800000u,                         // pc16: first join
+            0xbf060100u,                         // pc17: s_cmp_eq_u32 s0,s1
+            0xbf840003u,                         // pc18: alternate event -> pc22
+            0x260606fau, 0xff011403u,            // pc19: event 3 row_shr:4
+            0xbf820002u,                         // pc21: join -> pc24
+            0x260606fau, 0xff011803u,            // pc22: event 4 row_shr:8
+            0xbf800000u,                         // pc24: second join
+        });
+    fragment_dpp_min_divergent_sites.insert(
+        fragment_dpp_min_divergent_sites.end(),
+        std::begin(fragment_scalar_cfg_dispatch), std::end(fragment_scalar_cfg_dispatch));
+    const auto fragment_dpp_min_divergent_wave64_spv = recompile_fragment(
+        fragment_dpp_min_divergent_sites.data(), fragment_dpp_min_divergent_sites.size());
+    const auto fragment_dpp_min_divergent_wave32_spv = recompile_fragment_wave32_for_test(
+        fragment_dpp_min_divergent_sites.data(), fragment_dpp_min_divergent_sites.size());
+    if (!dpp_min_module_is_exact(fragment_dpp_min_divergent_wave64_spv, 64) ||
+        !dpp_min_module_is_exact(fragment_dpp_min_divergent_wave32_spv, 32)) {
+        printf("  [FAIL] divergent-PC DPP sources escaped static-event isolation\n");
+        return 1;
+    }
+    printf("  [ok]   divergent-PC DPP sources require matching Wave32/64 static events\n");
+
     std::vector<uint32_t> fragment_dpp_min_row = saved_mask_pair_dpp_shader();
     const auto fragment_dpp_min_row_wave64_spv = recompile_fragment(
         fragment_dpp_min_row.data(), fragment_dpp_min_row.size());

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -135,6 +135,109 @@ bool wave_vote_reaches_later_select(const std::vector<uint32_t>& spv,
     return false;
 }
 
+// Prove the complete common-phase lowering for House's in-place DPP minimum reduction. The four
+// dispatcher cases must publish shifts 1/2/4/8 into one mailbox; one uniform subgroup phase must use
+// that dynamic amount for both the row bound and lane subtraction, gate source participation by
+// two persisted bools (pending + EXEC), feed the shuffle into UMin, and store the selected result
+// back to a Function VGPR. Opcode presence alone would miss direction and divergent-PC mistakes.
+bool dpp_min_row_shr_updates_dispatch_vgpr(const std::vector<uint32_t>& spv) {
+    constexpr uint32_t OpConstant = 43, OpExtInst = 12, OpLoad = 61, OpStore = 62,
+                       OpISub = 130, OpLogicalAnd = 167, OpSelect = 169,
+                       OpUGreaterThanEqual = 174, OpGroupNonUniformShuffle = 345,
+                       GlslUMin = 38;
+    struct Select { uint32_t condition = 0, yes = 0, no = 0; };
+    std::unordered_map<uint32_t, uint32_t> constants, load_pointer;
+    std::unordered_map<uint32_t, std::array<uint32_t, 2>> logical_ands;
+    std::unordered_map<uint32_t, Select> selects;
+    std::vector<std::array<uint32_t, 2>> stores;
+    std::vector<uint32_t> shuffle_values;
+    std::unordered_set<uint32_t> shuffle_derived, umin_results;
+    std::unordered_set<uint32_t> amount_bound_uses, amount_subtract_uses;
+    if (spv.size() < 5) return false;
+    for (size_t i = 5; i < spv.size();) {
+        const uint32_t op = spv[i] & 0xffffu, wc = spv[i] >> 16u;
+        if (!wc || i + wc > spv.size()) return false;
+        if (op == OpConstant && wc == 4)
+            constants[spv[i + 2]] = spv[i + 3];
+        else if (op == OpLoad && wc == 4)
+            load_pointer[spv[i + 2]] = spv[i + 3];
+        else if (op == OpStore && wc == 3)
+            stores.push_back({spv[i + 1], spv[i + 2]});
+        else if (op == OpLogicalAnd && wc == 5)
+            logical_ands[spv[i + 2]] = {spv[i + 3], spv[i + 4]};
+        else if (op == OpSelect && wc == 6) {
+            selects[spv[i + 2]] = {spv[i + 3], spv[i + 4], spv[i + 5]};
+            if (shuffle_derived.contains(spv[i + 4]) ||
+                shuffle_derived.contains(spv[i + 5]))
+                shuffle_derived.insert(spv[i + 2]);
+        } else if (op == OpGroupNonUniformShuffle && wc == 6) {
+            shuffle_derived.insert(spv[i + 2]);
+            shuffle_values.push_back(spv[i + 4]);
+        } else if (op == OpExtInst && wc == 7 && spv[i + 4] == GlslUMin &&
+                   (shuffle_derived.contains(spv[i + 5]) ||
+                    shuffle_derived.contains(spv[i + 6]))) {
+            umin_results.insert(spv[i + 2]);
+        } else if (op == OpUGreaterThanEqual && wc == 5) {
+            amount_bound_uses.insert(spv[i + 4]);
+        } else if (op == OpISub && wc == 5) {
+            amount_subtract_uses.insert(spv[i + 4]);
+        }
+        i += wc;
+    }
+    if (opcode_count(spv, OpGroupNonUniformShuffle) != 2 || umin_results.empty())
+        return false;
+
+    std::unordered_map<uint32_t, std::unordered_set<uint32_t>> stored_constants;
+    for (const auto& store : stores) {
+        const auto value = constants.find(store[1]);
+        if (value != constants.end()) stored_constants[store[0]].insert(value->second);
+    }
+    bool exact_amount = false;
+    for (const auto& load : load_pointer) {
+        const auto values = stored_constants.find(load.second);
+        if (values != stored_constants.end() && values->second.contains(1) &&
+            values->second.contains(2) && values->second.contains(4) &&
+            values->second.contains(8) &&
+            amount_bound_uses.contains(load.first) &&
+            amount_subtract_uses.contains(load.first)) {
+            exact_amount = true;
+            break;
+        }
+    }
+
+    bool pending_and_exec_gate = false;
+    for (uint32_t value : shuffle_values) {
+        const auto select = selects.find(value);
+        if (select == selects.end()) continue;
+        const auto one = constants.find(select->second.yes);
+        const auto zero = constants.find(select->second.no);
+        const auto both = logical_ands.find(select->second.condition);
+        if (one == constants.end() || one->second != 1 ||
+            zero == constants.end() || zero->second != 0 ||
+            both == logical_ands.end())
+            continue;
+        const auto first = load_pointer.find(both->second[0]);
+        const auto second = load_pointer.find(both->second[1]);
+        if (first != load_pointer.end() && second != load_pointer.end() &&
+            first->second != second->second) {
+            pending_and_exec_gate = true;
+            break;
+        }
+    }
+
+    bool min_reaches_store = false;
+    for (const auto& select : selects) {
+        if (!umin_results.contains(select.second.yes)) continue;
+        if (std::any_of(stores.begin(), stores.end(), [&](const auto& store) {
+                return store[1] == select.first;
+            })) {
+            min_reaches_store = true;
+            break;
+        }
+    }
+    return exact_amount && pending_and_exec_gate && min_reaches_store;
+}
+
 // Trace IMAGE_GET_LOD all the way from two known VGPR bit patterns to the fragment output. This is
 // deliberately a dataflow check rather than an opcode-presence check: it proves coordinate
 // provenance, AMD/SPIR-V x/y component order, compact dmask-to-VDATA placement, and the EXEC select
@@ -2411,6 +2514,66 @@ int main() {
     }
     printf("  [ok]   saved-mask pair compare rejects half-overwrite/numeric mutations and "
            "does not vote across joins\n");
+
+    // The exact House shader next performs four in-place unsigned minima across DPP row-right
+    // neighbors. Keep them inside the same crossing graphics CFG fixture: the dispatcher must
+    // publish each lane's source and shift, execute two subgroup shuffles in its uniform common
+    // phase (value + source-activity), persist the UMin, and do so for both fragment wave sizes.
+    auto saved_mask_pair_dpp_shader = [&]() {
+        std::vector<uint32_t> shader(
+            std::begin(fragment_saved_mask_pair_prelude),
+            std::end(fragment_saved_mask_pair_prelude));
+        shader.insert(shader.end(), {
+            0x7e060287u,                         // v_mov_b32 v3,7
+            0x260606fau, 0xff011103u,            // v_min_u32_dpp v3,v3,v3 row_shr:1
+            0x260606fau, 0xff011203u,            // row_shr:2
+            0x260606fau, 0xff011403u,            // row_shr:4
+            0x260606fau, 0xff011803u,            // row_shr:8
+        });
+        shader.insert(shader.end(), std::begin(fragment_scalar_cfg_dispatch),
+                      std::end(fragment_scalar_cfg_dispatch));
+        return shader;
+    };
+    auto dpp_min_module_is_exact = [&](const std::vector<uint32_t>& spirv,
+                                       uint32_t wave_size) {
+        return !spirv.empty() && has_opcode(spirv, 251) &&
+            dpp_min_row_shr_updates_dispatch_vgpr(spirv) &&
+            fragment_spirv_required_subgroup_size(spirv) == wave_size &&
+            (fragment_spirv_required_subgroup_features(spirv) &
+             kFragmentSubgroupShuffle) &&
+            type_result_ids_are_nonzero(spirv, nullptr) &&
+            phi_ids_are_nonzero(spirv);
+    };
+    std::vector<uint32_t> fragment_dpp_min_row = saved_mask_pair_dpp_shader();
+    const auto fragment_dpp_min_row_wave64_spv = recompile_fragment(
+        fragment_dpp_min_row.data(), fragment_dpp_min_row.size());
+    const auto fragment_dpp_min_row_wave32_spv = recompile_fragment_wave32_for_test(
+        fragment_dpp_min_row.data(), fragment_dpp_min_row.size());
+    if (!dpp_min_module_is_exact(fragment_dpp_min_row_wave64_spv, 64) ||
+        !dpp_min_module_is_exact(fragment_dpp_min_row_wave32_spv, 32)) {
+        printf("  [FAIL] House DPP minimum did not persist through the Wave32/64 CFG common phase\n");
+        return 1;
+    }
+
+    std::vector<uint32_t> dpp_min_wrong_opcode = fragment_dpp_min_row;
+    dpp_min_wrong_opcode[9] = 0x280606fau; // v_max_u32 is outside the exact contract
+    std::vector<uint32_t> dpp_min_distinct_source = fragment_dpp_min_row;
+    dpp_min_distinct_source[10] = 0xff011104u; // src0=v4, while VDST/SRC1 remain v3
+    std::vector<uint32_t> dpp_min_wrong_amount = fragment_dpp_min_row;
+    dpp_min_wrong_amount[10] = 0xff011203u; // duplicates :2; loses exact :1/:2/:4/:8 chain
+    const auto wrong_opcode_spv = recompile_fragment(
+        dpp_min_wrong_opcode.data(), dpp_min_wrong_opcode.size());
+    const auto distinct_source_spv = recompile_fragment(
+        dpp_min_distinct_source.data(), dpp_min_distinct_source.size());
+    const auto wrong_amount_spv = recompile_fragment(
+        dpp_min_wrong_amount.data(), dpp_min_wrong_amount.size());
+    if (dpp_min_row_shr_updates_dispatch_vgpr(wrong_opcode_spv) ||
+        dpp_min_row_shr_updates_dispatch_vgpr(distinct_source_spv) ||
+        dpp_min_row_shr_updates_dispatch_vgpr(wrong_amount_spv)) {
+        printf("  [FAIL] DPP minimum admitted an opcode/source/amount mutation\n");
+        return 1;
+    }
+    printf("  [ok]   House DPP minimum preserves row direction, CFG participation, and VGPR dataflow\n");
 
     // Astro Bot's world-map material PS reaches the same graphics CFG dispatcher with an
     // s_orn2_saveexec_b64 whose destination is VCC. Keep a saved EXEC source live across dispatcher

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -89,6 +89,52 @@ bool has_opcode(const std::vector<uint32_t>& spv, uint32_t opcode) {
     return false;
 }
 
+uint32_t opcode_count(const std::vector<uint32_t>& spv, uint32_t opcode) {
+    uint32_t count = 0;
+    if (spv.size() < 5) return count;
+    for (size_t i = 5; i < spv.size();) {
+        const uint32_t op = spv[i] & 0xffffu, wc = spv[i] >> 16u;
+        if (!wc || i + wc > spv.size()) return 0;
+        count += op == opcode;
+        i += wc;
+    }
+    return count;
+}
+
+// Prove that a subgroup vote is persisted through the CFG dispatcher's bool register file and then
+// consumed as the condition of a later OpSelect.  This is the structural shape of a scalar mask
+// comparison followed by s_cselect: opcode presence alone would not prove that SCC survived the
+// dispatcher boundary or that the select read the newly-produced condition.
+bool wave_vote_reaches_later_select(const std::vector<uint32_t>& spv,
+                                    bool expect_inverted) {
+    constexpr uint32_t OpLoad = 61, OpStore = 62, OpLogicalNot = 168,
+                       OpSelect = 169, OpGroupNonUniformAny = 335;
+    std::unordered_set<uint32_t> direct_values, inverted_values;
+    std::unordered_set<uint32_t> vote_variables;
+    for (size_t i = 5; i < spv.size();) {
+        const uint32_t op = spv[i] & 0xffffu, wc = spv[i] >> 16u;
+        if (!wc || i + wc > spv.size()) return false;
+        if (op == OpGroupNonUniformAny && wc >= 4)
+            direct_values.insert(spv[i + 2]);
+        if (op == OpLogicalNot && wc == 4) {
+            if (direct_values.contains(spv[i + 3]))
+                inverted_values.insert(spv[i + 2]);
+            if (inverted_values.contains(spv[i + 3]))
+                direct_values.insert(spv[i + 2]);
+        }
+        const auto& expected_values = expect_inverted ? inverted_values : direct_values;
+        if (op == OpStore && wc == 3 && expected_values.contains(spv[i + 2]))
+            vote_variables.insert(spv[i + 1]);
+        if (op == OpLoad && wc == 4 && vote_variables.contains(spv[i + 3]))
+            (expect_inverted ? inverted_values : direct_values).insert(spv[i + 2]);
+        if (op == OpSelect && wc == 6 &&
+            (expect_inverted ? inverted_values : direct_values).contains(spv[i + 3]))
+            return true;
+        i += wc;
+    }
+    return false;
+}
+
 // Trace IMAGE_GET_LOD all the way from two known VGPR bit patterns to the fragment output. This is
 // deliberately a dataflow check rather than an opcode-presence check: it proves coordinate
 // provenance, AMD/SPIR-V x/y component order, compact dmask-to-VDATA placement, and the EXEC select
@@ -2235,6 +2281,136 @@ int main() {
         return 1;
     }
     printf("  [ok]   complex fragment CFG lowers wave-mask comparisons to exact wave64 votes\n");
+
+    // House of the Dead 2's large scene fragments reach this exact mask relationship inside the
+    // graphics CFG dispatcher:
+    //   s[44:45] = EXEC & s[30:31]
+    //   s[46:47] = VCC  & s[30:31]
+    //   SCC = (s[44:45] ==/!= s[46:47]); s[48:49] = SCC ? EXEC : 0
+    // Both operands are complete saved masks, so the scalar comparison is one exact whole-wave
+    // ANY(mask0 xor mask1) vote. Keep the later s_cselect and EXEC copy: they prove the vote's SCC
+    // survives a dispatcher case boundary and is consumed, rather than merely appearing in SPIR-V.
+    const uint32_t fragment_saved_mask_pair_prelude[] = {
+        0xbe9e047eu,                         // s_mov_b64 s[30:31],exec
+        0x87ac1e7eu,                         // s_and_b64 s[44:45],exec,s[30:31]
+        0x7c020300u,                         // v_cmp_lt_f32 vcc,v0,v1
+        0x87ae1e6au,                         // s_and_b64 s[46:47],vcc,s[30:31]
+        0xbf122e2cu,                         // exact live s_cmp_eq_u64 s[44:45],s[46:47]
+        0xbf800000u,                         // SCC-preserving scheduled nop
+        0x85b0807eu,                         // s_cselect_b64 s[48:49],exec,0
+        0xbefe0430u,                         // s_mov_b64 exec,s[48:49]
+    };
+    // Crossing scalar branch regions force the same arbitrary graphics CFG dispatcher without
+    // introducing any additional subgroup vote. That makes the exact one-vote EQ/LG polarity below
+    // a self-checking dataflow witness rather than an opcode census hidden behind red siblings.
+    const uint32_t fragment_scalar_cfg_dispatch[] = {
+        0x7e040280u,                         // pc0:  v_mov_b32 v2,0
+        0x7e060280u,                         // pc1:  v_mov_b32 v3,0
+        0x7e080280u,                         // pc2:  v_mov_b32 v4,0
+        0x7e0a0280u,                         // pc3:  v_mov_b32 v5,0
+        0xbf068080u,                         // pc4:  s_cmp_eq_u32 0,0
+        0xbf840003u,                         // pc5:  s_cbranch_scc0 -> pc9
+        0xbf068080u,                         // pc6:  s_cmp_eq_u32 0,0
+        0xbf840002u,                         // pc7:  s_cbranch_scc0 -> pc10 (crossing region)
+        0x7e040281u,                         // pc8:  v_mov_b32 v2,1
+        0x7e060281u,                         // pc9:  v_mov_b32 v3,1
+        0xbf068080u,                         // pc10: s_cmp_eq_u32 0,0
+        0xbf840003u,                         // pc11: s_cbranch_scc0 -> alternate export at pc15
+        0xf800180fu, 0x05040302u,            // pc12: exp mrt0 v2,v3,v4,v5 done vm
+        0xbf820003u,                         // pc14: s_branch -> verified tail exit at pc18
+        0xf800180fu, 0x05040302u,            // pc15: alternate exp mrt0 v2,v3,v4,v5 done vm
+        0xbf810000u,                         // pc17: s_endpgm
+        0xbf810000u,                         // pc18: branch-target s_endpgm
+    };
+    auto saved_mask_pair_shader = [&]() {
+        std::vector<uint32_t> shader(
+            std::begin(fragment_saved_mask_pair_prelude),
+            std::end(fragment_saved_mask_pair_prelude));
+        shader.insert(shader.end(), std::begin(fragment_scalar_cfg_dispatch),
+                      std::end(fragment_scalar_cfg_dispatch));
+        return shader;
+    };
+    auto mask_pair_module_is_exact = [&](const std::vector<uint32_t>& spirv,
+                                         uint32_t wave_size, bool inverted) {
+        return !spirv.empty() && has_opcode(spirv, 251) &&
+            opcode_count(spirv, 335) == 1 &&
+            fragment_spirv_required_subgroup_size(spirv) == wave_size &&
+            wave_vote_reaches_later_select(spirv, inverted) &&
+            type_result_ids_are_nonzero(spirv, nullptr) &&
+            phi_ids_are_nonzero(spirv);
+    };
+    std::vector<uint32_t> fragment_saved_mask_pair_eq = saved_mask_pair_shader();
+    const auto fragment_saved_mask_pair_eq_spv = recompile_fragment(
+        fragment_saved_mask_pair_eq.data(), fragment_saved_mask_pair_eq.size());
+    if (!mask_pair_module_is_exact(fragment_saved_mask_pair_eq_spv, 64,
+                                   /*inverted EQ vote*/true)) {
+        printf("  [FAIL] House saved-mask equality did not feed CFG-persisted SCC in Wave64\n");
+        return 1;
+    }
+    std::vector<uint32_t> fragment_saved_mask_pair_lg = fragment_saved_mask_pair_eq;
+    fragment_saved_mask_pair_lg[4] = 0xbf132e2cu; // s_cmp_lg_u64 s[44:45],s[46:47]
+    const auto fragment_saved_mask_pair_lg_spv = recompile_fragment(
+        fragment_saved_mask_pair_lg.data(), fragment_saved_mask_pair_lg.size());
+    if (!mask_pair_module_is_exact(fragment_saved_mask_pair_lg_spv, 64,
+                                   /*direct LG vote*/false)) {
+        printf("  [FAIL] saved-mask inequality did not feed CFG-persisted SCC in Wave64\n");
+        return 1;
+    }
+    const auto fragment_wave32_saved_mask_pair_eq_spv =
+        recompile_fragment_wave32_for_test(
+            fragment_saved_mask_pair_eq.data(), fragment_saved_mask_pair_eq.size());
+    const auto fragment_wave32_saved_mask_pair_lg_spv =
+        recompile_fragment_wave32_for_test(
+            fragment_saved_mask_pair_lg.data(), fragment_saved_mask_pair_lg.size());
+    if (!mask_pair_module_is_exact(fragment_wave32_saved_mask_pair_eq_spv, 32, true) ||
+        !mask_pair_module_is_exact(fragment_wave32_saved_mask_pair_lg_spv, 32, false)) {
+        printf("  [FAIL] saved-mask EQ/LG lost the complete-pair contract in Wave32\n");
+        return 1;
+    }
+    printf("  [ok]   saved-mask EQ/LG votes persist into s_cselect in Wave32 and Wave64 CFGs\n");
+
+    // Every physical/dataflow obligation is independently load-bearing. A write to either half of
+    // a saved pair ends that lifetime; a numeric replacement is not reinterpreted as a mask; and a
+    // producer skipped on one reachable predecessor cannot establish a mask at the join.
+    std::vector<uint32_t> saved_mask_high_overwrite = fragment_saved_mask_pair_eq;
+    saved_mask_high_overwrite.insert(saved_mask_high_overwrite.begin() + 4, 0xbead0380u);
+    if (!recompile_fragment(saved_mask_high_overwrite.data(),
+                            saved_mask_high_overwrite.size()).empty()) {
+        printf("  [FAIL] high-half scalar overwrite retained a stale saved-mask pair\n");
+        return 1;
+    }
+    std::vector<uint32_t> saved_mask_numeric_replacement = fragment_saved_mask_pair_eq;
+    saved_mask_numeric_replacement.insert(
+        saved_mask_numeric_replacement.begin() + 4,
+        {0xbeae0381u, 0xbeaf0380u});          // numeric s[46:47] = 1
+    if (!recompile_fragment(saved_mask_numeric_replacement.data(),
+                            saved_mask_numeric_replacement.size()).empty()) {
+        printf("  [FAIL] numeric SGPR pair was reinterpreted as a saved wave mask\n");
+        return 1;
+    }
+    std::vector<uint32_t> saved_mask_path_dependent = {
+        0xbe9e047eu,                         // s_mov_b64 s[30:31],exec
+        0x87ac1e7eu,                         // s_and_b64 s[44:45],exec,s[30:31]
+        0xbf060100u,                         // pc2: s_cmp_eq_u32 s0,s1
+        0xbf840001u,                         // pc3: edge skips s46 -> compare at pc5
+        0x87ae1e6au,                         // pc4: s_and_b64 s[46:47],vcc,s[30:31]
+        0xbf122e2cu,                         // pc5: joined s[46:47] lifetime is path-dependent
+        0xbf800000u,                         // pc6: SCC-preserving nop
+        0x85b0807eu,                         // pc7: consumes comparison SCC
+        0xbefe0430u,
+    };
+    saved_mask_path_dependent.insert(
+        saved_mask_path_dependent.end(), std::begin(fragment_scalar_cfg_dispatch),
+        std::end(fragment_scalar_cfg_dispatch));
+    const auto saved_mask_path_dependent_spv = recompile_fragment(
+        saved_mask_path_dependent.data(), saved_mask_path_dependent.size());
+    if (wave_vote_reaches_later_select(saved_mask_path_dependent_spv,
+                                       /*inverted EQ vote*/true)) {
+        printf("  [FAIL] path-dependent saved-mask vote reached a later select\n");
+        return 1;
+    }
+    printf("  [ok]   saved-mask pair compare rejects half-overwrite/numeric mutations and "
+           "does not vote across joins\n");
 
     // Astro Bot's world-map material PS reaches the same graphics CFG dispatcher with an
     // s_orn2_saveexec_b64 whose destination is VCC. Keep a saved EXEC source live across dispatcher


### PR DESCRIPTION
## What changed

- Lower proven `s_cmp_{eq,lg}_u64` comparisons between two ordinary saved B64 wave-mask pairs in the fragment CFG dispatcher.
- Execute every admitted pair mismatch vote after the lane-divergent switch merge from persistent, ungated mask operands. A nonzero static event selects only the matching EQ/LG result into SCC; event zero remains the reset/no-event value.
- Lower the exact in-place fragment `v_min_u32_dpp row_shr:{1,2,4,8}` family through a uniform common phase. Value, source activity, and static instruction identity follow the same shuffled source lane; the source event must match the destination event before UMin may update the persistent VGPR.
- Keep numeric, overwritten, path-dependent, different-register, different-opcode, bounded, modified, and non-row-right forms fail-visible.
- Add defect-shaped Wave32/Wave64 structural coverage and record the exact replay frontier in `HOUSE_OF_THE_DEAD_2_STATUS.md`.

## Why

After #1926, the large House of the Dead 2 scene fragment advanced past `IMAGE_GET_LOD` and stopped at two saved-mask comparisons. Once those were admitted, the adjacent failures were four in-place DPP unsigned-minimum row reductions. Review then found two cross-lane hazards in the initial lowering: pair votes ran inside lane-divergent dispatcher cases, and DPP neighbor mailboxes did not distinguish static instruction sites. This head fixes both hazards generically.

The exact captured 83-resource shader now recompiles completely. This is real shader-coverage progress, but there is no visual, rung, FPS, title-screen, or gameplay-improvement claim yet. The last Vulkan replay predates the event-isolation fixes, so a current-recompiler replay remains the next GPU discriminator.

Refs #1907.

## Rebase state

Exact head: `bc014c0ae04181fb038069760fa04c72d209d471`

Exact base tested: `9ed87856c2e4ad669cd1d6e927407c4a137373cd`

The five pre-rebase commits were patch-identical in `git range-diff`; the sixth commit only corrects the retained shader result from 288,728 to 288,955 SPIR-V dwords.

## Exact captured-shader proof

Inside the `ps5ys` distrobox with a worktree-local disk-backed `TMPDIR`:

```text
<BUILD_DIR>/gpu_replay <CAPTURE>/submit-12715.prgcap --retry-failed-stage 1029:1
```

Result on the exact head: `1029:1 recompiled resources=83 spirv-dwords=288955 contract=accepted`.

## CPU verification

```text
cmake --build <BUILD_DIR> --target test_rdna2_spirv_struct gpu_replay -j2
<BUILD_DIR>/test_rdna2_spirv_struct
ctest --test-dir <BUILD_DIR> --output-on-failure -R "^(recompile_coverage|rdna2_decode_walk|rdna2_spirv_struct|spv_validate|shader_resource_contract)$"
```

Results on the exact head:

- `test_rdna2_spirv_struct`: PASS, including the named divergent-PC saved-mask and DPP static-event checks.
- Focused CTest selection: 5/5 passed.
- `git diff --check`: passed.
- Complete three-file diff inspected; no private host paths or forbidden trailers.

Snapshot tests were not run. This ordinary development PR changes no snapshot route or baseline.

## Structural and mutation controls

The saved-mask tests use exact House EQ/LG encodings in Wave32 and Wave64 arbitrary CFGs. They trace the whole-wave vote through Function-memory SCC into the later scalar select. A second fixture places disjoint EQ and LG pairs at alternate static PCs and proves both votes execute after the merge from ungated mask loads, while tags 1 and 2 select the matching polarity. High-half overwrite, numeric-pair, and path-dependent-join controls prevent stale or non-mask data from acquiring this lowering.

The DPP test uses exact `v_min_u32_dpp v3,v3,v3 row_shr:{1,2,4,8}` packets. It proves the dynamic amount feeds both the row bound and lane subtraction, pending plus EXEC gates participation, and subgroup shuffle feeds UMin and the persistent VGPR store. A four-way alternate-site fixture proves tags 1/2/3/4, value/activity/event source-lane identity, and source/destination event equality in both wave sizes.

Before the patch-identical rebase, production mutations independently made their exact named checks red for saved-mask admission, vote polarity, two-source MUST proof, DPP opcode admission, row direction, participation, pair-vote event gating, and DPP event equality. Clean production then passed again. Packet controls additionally reject high-half overwrite, numeric replacement, path-dependent joins, wrong DPP opcode, distinct physical source, and a missing `row_shr:1` step.

## Replay scope

The last authorized Vulkan replay completed successfully and substituted all 809 vertex/fragment stages and 106 compute stages with no stored modules retained, but it ran before the common-phase/static-event review fixes. Its byte-identical corrupt result therefore does not falsify the corrected semantics and is not visual evidence for this head. No GPU test was used during this rebase verification.
