### PR TITLE
fix(gpu): execute address-backed memory-to-GDS copies

### DIFF
--- a/prosper/docs/ASTROBOT_LINUX_HANDOFF_2026_07_19.md
+++ b/prosper/docs/ASTROBOT_LINUX_HANDOFF_2026_07_19.md
@@ -740,7 +740,7 @@ The post-#1927 retained address DMA is now exact. In the retained run it repeate
 bit. Older raw timeline records independently establish selector 1 as the GDS offset domain. The
 packet therefore copies mapped guest memory into `GDS+0x24`; it does not write guest VA `0x24`.
 
-Candidate `37eb14e7`, based on exact master `130ad451`, implements only that generic observed form.
+PR #1931 implements only that generic observed form.
 The source must be mapped/readable or supplied as an authoritative renderer-owned snapshot; the GDS
 offset and byte count must be dword-aligned and the complete span must fit in the 64 KiB share.
 Unknown selector directions and GDS-to-memory remain fail-closed. The copy stays in the retained
@@ -755,6 +755,15 @@ three retained producers execute in command order. Separate negative checks cove
 sources, out-of-range GDS spans, misaligned offsets, non-dword byte counts, the wrong source selector,
 and the unsupported reverse direction. Five isolated mutations independently make the guest-address
 overlap, execution/data, selector, authority, and paused-stream ordering checks fail.
+
+PR #1931 also makes offline capture truthful for this operation. A full capture stores the complete
+64 KiB pre-submit GDS image even when the submit has no compute table; replay materializes that image
+as the one shared GDS instance used by both the DMA and later compute consumers. Metadata-only
+captures instead keep both endpoint backings explicitly unavailable. Capture validation and replay
+execution independently enforce the observed `dstSel=1`, `srcSel=3`, address-source form, while
+selector 2, GDS-to-memory, and forms without address-source semantics fail visibly. Defect-shaped
+capture and executor mutations each make only their corresponding named regression fail while the
+valid DMA-only and shared-instance controls remain green.
 
 The one authorized live acceptance used the normal full-scale/every-submit `prosper-app` path with
 real renderer, compute, FFmpeg/VA-API, SDL audio and SDL input backends, no pad route, a 540-present

--- a/prosper/docs/ASTROBOT_LINUX_HANDOFF_2026_07_19.md
+++ b/prosper/docs/ASTROBOT_LINUX_HANDOFF_2026_07_19.md
@@ -733,10 +733,63 @@ supported overlay, low/high-dword order, ownership, partial/oversized bounds, ex
 and reporter path are each observed by a named check. The GitHub issue carries the exact live
 revision, binary hash, bounded-run validity, and sparse diagnostic counts.
 
+## Address-backed memory-to-GDS wait result (2026-08-04)
+
+The post-#1927 retained address DMA is now exact. In the retained run it repeatedly decoded as
+`src=0x56f6e6000`, `dst=0x24`, four bytes, `dstSel=1`, `srcSel=3`, and the preserved address-source
+bit. Older raw timeline records independently establish selector 1 as the GDS offset domain. The
+packet therefore copies mapped guest memory into `GDS+0x24`; it does not write guest VA `0x24`.
+
+Candidate `37eb14e7`, based on exact master `130ad451`, implements only that generic observed form.
+The source must be mapped/readable or supplied as an authoritative renderer-owned snapshot; the GDS
+offset and byte count must be dword-aligned and the complete span must fit in the 64 KiB share.
+Unknown selector directions and GDS-to-memory remain fail-closed. The copy stays in the retained
+executor timeline, updates the shared GDS backing, and emits neither a guest-write notification nor a
+guest destination authority range. Retained GDS destinations are excluded from guest-address
+wait/indirect overlap classification and WAIT_DEFER address domains.
+
+Focused `eop_write` and `gpu_execute` tests pass. The defect-shaped CPU stream is the title's real
+shape: memory-to-`GDS+0x24`, owned `WRITE_DATA(0)`, fixed `RELEASE_MEM32(1)`, then
+`WAIT_REG_MEM(label==1)`. It proves the wait is accepted, the exact source value reaches GDS, and all
+three retained producers execute in command order. Separate negative checks cover unmapped asserted
+sources, out-of-range GDS spans, misaligned offsets, non-dword byte counts, the wrong source selector,
+and the unsupported reverse direction. Five isolated mutations independently make the guest-address
+overlap, execution/data, selector, authority, and paused-stream ordering checks fail.
+
+The one authorized live acceptance used the normal full-scale/every-submit `prosper-app` path with
+real renderer, compute, FFmpeg/VA-API, SDL audio and SDL input backends, no pad route, a 540-present
+target, and a 360-second hard bound. Exact-six pre/post GPU-process censuses were empty. Its binary
+SHA-256 was `a57aae534bb0a135105f954104824c48b53949e33b29196be28bc9b5cf5e7d7a`.
+The bounded sparse positive control emitted 21 lines (ordinals 1--16, 32, 64, 128, 256, and 512), so
+at least 512 exact memory-to-GDS executions occurred. The former ordered-wait rejection family,
+generic ordered-DMA submit rejection, invalid `dst=0x24` form, Vulkan device loss, and fatal markers
+all emitted zero matches. Astro progressed past #1927's loaded-title frontier:
+
+```text
+GAME: Level has started: title_controller_ship
+LevelDocument Loaded: worldmap [worldmap]
+```
+
+The app exited normally at 540/540 presents and reported 2.9 fps for its final interval. That number
+is an exact observation from a 601 MB high-volume GFXLOG run, not a controlled performance result;
+no throughput improvement is claimed. The run produced no image artifact and makes no new visual-
+correctness claim, so no screenshot is attached. Retained evidence is outside git under
+`<EVIDENCE_ROOT>/astro-1732-memory-gds-37eb14e/` and the complete audit trail is on #1732.
+
 ## Ruled out
 
 One line per falsified hypothesis, the evidence that killed it, and the issue/PR. Extend this rather
 than re-deriving a dead answer at full cost.
+
+- **"The post-#1927 retained address DMA writes guest memory at `0x24`, so it can genuinely overlap
+  every later guest label wait."** False on exact candidate `37eb14e7` for #1732. Raw operands and
+  selectors identify the operation as mapped memory to `GDS+0x24`, four bytes, and the CPU defect
+  stream proves that excluding this private-share destination accepts only the unrelated scalar
+  label protocol while still executing the GDS copy in order. Reintroducing guest-address overlap
+  classification makes the exact named wait check fail. In one natural 540-present app run the
+  memory-to-GDS positive ordinal reached at least 512, the former ordered-wait and ordered-DMA
+  rejection families emitted zero matches, and Astro started `title_controller_ship` then loaded
+  `worldmap`. No device loss, fatal, visual, or controlled performance claim is attached. See #1732.
 
 - **"After exact retained `WRITE_DATA` overlays are accepted, the remaining title-load stall is
   another instance of the same memory-effect/wait ambiguity."** False on exact candidate

--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -1733,16 +1733,12 @@ static bool honor_dma_data(const Pm4Command& c, uint64_t retained_packet_addr = 
         return false;
     }
     if (form == DmaDataForm::GdsImmediate || form == DmaDataForm::MemoryToGds) {
-        // A GDS counter reset: the guest zeroes these offsets every frame, and the shaders that use
-        // GDS reach the same 64 KiB backing through the internal binding. Dropping the write loses
-        // guest state outright.
-        //
-        // NOT the cause of #1742 — this was the hypothesis that motivated the fix and it was tested
-        // and FALSIFIED. With these writes restored (343 per routed run, against 0 before), Astro
-        // Bot's indirect dispatch still grows 1, 1, 2, 3, 4, 5, 7, 15, 6711, 26783, 40167, 66927.
-        // Whatever accumulates that count is elsewhere; do not re-derive this.
         uint8_t* gds = compute_gds_backing();
         if (form == DmaDataForm::GdsImmediate) {
+            // A GDS counter reset: the guest zeroes these offsets every frame, and shaders reach the
+            // same 64 KiB backing through the internal binding. NOT the cause of #1742: with these
+            // immediate resets restored, Astro's indirect dispatch still grew without bound. Do not
+            // re-derive that falsified reset hypothesis.
             const uint32_t v32 = (uint32_t)c.dd_src;
             for (uint32_t i = 0; i + 4 <= c.dd_bytes; i += 4)
                 memcpy(gds + c.dd_dst + i, &v32, 4);
@@ -3623,8 +3619,10 @@ void GpuState::apply(const Pm4Command& c) {
             // FIFO behavior until a general copy appears; its suffix joins the ordered timeline.
             if (dma_data_address_source(c)) {
                 if (!c.dd_valid) { report_invalid_dma_data(c); break; }
-                // A GDS offset does not participate in WAIT_DEFER's guest-address domains.
-                const bool gated_destination = dma_data_dst_sel(c) != kDmaSelGds && defer_gate(c);
+                // A GDS offset does not participate in WAIT_DEFER's guest-address domains, but a
+                // copy downstream of this fold's unsatisfied wait still cannot overtake the stream.
+                const bool gated_destination = g_fold_deferring ||
+                    (dma_data_dst_sel(c) != kDmaSelGds && defer_gate(c));
                 const bool gated_source = !g_deferred.empty() &&
                                           addr_gated(c.dd_src, c.dd_bytes, c.queue_origin);
                 if (gated_destination || gated_source) {

--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -1621,7 +1621,7 @@ static void honor_event_write(const Pm4Command& c) {
 // packets therefore preserve sourceKind in kDmaDataAddressSource; historical packets retain the
 // established >32-bit address fallback. GDS offsets and malformed/unmapped endpoints fail closed.
 // CONFIDENCE: HIGH on immediate fill and mapped address-copy behavior; MED on the large-fill form.
-enum class DmaDataForm { Invalid, Immediate, Copy, GdsImmediate };
+enum class DmaDataForm { Invalid, Immediate, Copy, GdsImmediate, MemoryToGds };
 
 // The destination selector occupies the LOW byte of the packed `dd_sels` word: the HLE builder writes
 // `(a2 & 0xff) | ((a3 & 0xff) << 8)`, and a2 is the argument that tracks the destination DOMAIN. This
@@ -1647,6 +1647,7 @@ enum class DmaDataForm { Invalid, Immediate, Copy, GdsImmediate };
 // it, but the sample is a handful of call sites, and no shader has yet been shown to READ these
 // offsets. The guards below keep every unrecognised form fail-closed.
 static constexpr uint32_t kDmaSelGds = 1;
+static constexpr uint32_t kDmaSelMemory = 3;
 static uint32_t dma_data_dst_sel(const Pm4Command& c) { return c.dd_sels & 0xffu; }
 static uint32_t dma_data_src_sel(const Pm4Command& c) { return (c.dd_sels >> 8) & 0xffu; }
 static bool dma_data_address_source(const Pm4Command& c) {
@@ -1664,9 +1665,10 @@ static DmaDataForm dma_data_form(const Pm4Command& c, bool source_materialized =
     if (!c.dd_valid || !c.dd_bytes || c.dd_bytes > kMaxCopyBytes) return DmaDataForm::Invalid;
     // A GDS destination is an OFFSET into the 64 KiB share, not a guest address, so it is legitimately
     // below the 0x10000 floor that rejects malformed guest pointers — which is exactly why every one
-    // of these was being discarded. Only the immediate (<=32-bit source) form is accepted here: a
-    // GDS-to-memory or memory-to-GDS copy has no title evidence yet and stays fail-closed
-    // (the source guard above is what makes that true of the GDS-to-memory direction).
+    // of these was being discarded. Astro Bot now provides exact title evidence for the address
+    // sibling too: dstSel=1/srcSel=3/sourceKind=2 copies four bytes from guest memory into GDS+0x24.
+    // Keep that contract narrow; GDS-to-memory and every unrecognised selector direction stay
+    // fail-closed.
     // A GDS SOURCE would make `dd_src` a small offset, which the immediate path below cannot tell from
     // a 32-bit fill value — it would write the offset itself into guest memory. There is no title
     // evidence for that form, so reject it rather than mis-execute it. (This is a behaviour change
@@ -1675,9 +1677,11 @@ static DmaDataForm dma_data_form(const Pm4Command& c, bool source_materialized =
     if (dma_data_dst_sel(c) == kDmaSelGds) {
         const size_t gds_size = compute_gds_size();
         const bool in_range = c.dd_dst < gds_size && c.dd_bytes <= gds_size - c.dd_dst;
-        return (dma_data_immediate_source(c) && in_range && !(c.dd_dst & 3) &&
-                !(c.dd_bytes & 3))
-                   ? DmaDataForm::GdsImmediate
+        if (!in_range || (c.dd_dst & 3) || (c.dd_bytes & 3)) return DmaDataForm::Invalid;
+        if (dma_data_immediate_source(c)) return DmaDataForm::GdsImmediate;
+        return dma_data_src_sel(c) == kDmaSelMemory &&
+                       (source_materialized || guest_readable(c.dd_src, c.dd_bytes))
+                   ? DmaDataForm::MemoryToGds
                    : DmaDataForm::Invalid;
     }
     if (c.dd_dst < 0x10000) return DmaDataForm::Invalid;
@@ -1728,7 +1732,7 @@ static bool honor_dma_data(const Pm4Command& c, uint64_t retained_packet_addr = 
         report_invalid_dma_data(c);
         return false;
     }
-    if (form == DmaDataForm::GdsImmediate) {
+    if (form == DmaDataForm::GdsImmediate || form == DmaDataForm::MemoryToGds) {
         // A GDS counter reset: the guest zeroes these offsets every frame, and the shaders that use
         // GDS reach the same 64 KiB backing through the internal binding. Dropping the write loses
         // guest state outright.
@@ -1738,12 +1742,30 @@ static bool honor_dma_data(const Pm4Command& c, uint64_t retained_packet_addr = 
         // Bot's indirect dispatch still grows 1, 1, 2, 3, 4, 5, 7, 15, 6711, 26783, 40167, 66927.
         // Whatever accumulates that count is elsewhere; do not re-derive this.
         uint8_t* gds = compute_gds_backing();
-        const uint32_t v32 = (uint32_t)c.dd_src;
-        for (uint32_t i = 0; i + 4 <= c.dd_bytes; i += 4)
-            memcpy(gds + c.dd_dst + i, &v32, 4);
-        if (getenv("PROSPER_GFXLOG") || getenv("PROSPER_GDSLOG"))
-            fprintf(stderr, "[agc]   DmaData GDS fill [gds+0x%llx] := 0x%x (%u bytes)\n",
-                    (unsigned long long)c.dd_dst, v32, c.dd_bytes);
+        if (form == DmaDataForm::GdsImmediate) {
+            const uint32_t v32 = (uint32_t)c.dd_src;
+            for (uint32_t i = 0; i + 4 <= c.dd_bytes; i += 4)
+                memcpy(gds + c.dd_dst + i, &v32, 4);
+            if (getenv("PROSPER_GFXLOG") || getenv("PROSPER_GDSLOG"))
+                fprintf(stderr, "[agc]   DmaData GDS fill [gds+0x%llx] := 0x%x (%u bytes)\n",
+                        (unsigned long long)c.dd_dst, v32, c.dd_bytes);
+        } else {
+            const uint8_t* source = authoritative_source
+                ? authoritative_source
+                : reinterpret_cast<const uint8_t*>(uintptr_t(c.dd_src));
+            memcpy(gds + c.dd_dst, source, c.dd_bytes);
+            if (getenv("PROSPER_GFXLOG") || getenv("PROSPER_GDSLOG")) {
+                static std::atomic<uint64_t> ordinal{0};
+                const uint64_t n = ordinal.fetch_add(1, std::memory_order_relaxed) + 1;
+                if (prosper::diag_should_print(n, 16))
+                    fprintf(stderr,
+                            "[agc] DmaData memory-to-GDS #%llu [gds+0x%llx] <- "
+                            "[0x%llx] (%u bytes order=%llu sels=0x%x)\n",
+                            (unsigned long long)n, (unsigned long long)c.dd_dst,
+                            (unsigned long long)c.dd_src, c.dd_bytes,
+                            (unsigned long long)c.stream_order, c.dd_sels);
+            }
+        }
         return true;
     }
     uint8_t* dst = (uint8_t*)(uintptr_t)c.dd_dst;
@@ -2751,6 +2773,9 @@ int flush_deferred_streams() {
 static bool retained_dma_destination_overlaps(
         const std::vector<GpuState::DmaCopy>& copies, uint64_t address, uint64_t bytes) {
     for (const GpuState::DmaCopy& copy : copies) {
+        // GDS destinations are offsets into the private 64 KiB share, not guest VAs. Treating the
+        // live Astro Bot offset 0x24 as an unknown guest address made it overlap every wait.
+        if ((copy.sels & 0xffu) == kDmaSelGds) continue;
         if (guest_memory_topology_relation(address, bytes, copy.dst, copy.bytes) !=
             GuestMemoryTopologyRelation::Disjoint)
             return true;
@@ -3598,7 +3623,8 @@ void GpuState::apply(const Pm4Command& c) {
             // FIFO behavior until a general copy appears; its suffix joins the ordered timeline.
             if (dma_data_address_source(c)) {
                 if (!c.dd_valid) { report_invalid_dma_data(c); break; }
-                const bool gated_destination = defer_gate(c);
+                // A GDS offset does not participate in WAIT_DEFER's guest-address domains.
+                const bool gated_destination = dma_data_dst_sel(c) != kDmaSelGds && defer_gate(c);
                 const bool gated_source = !g_deferred.empty() &&
                                           addr_gated(c.dd_src, c.dd_bytes, c.queue_origin);
                 if (gated_destination || gated_source) {

--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -2518,6 +2518,11 @@ bool defer_enabled() {
 // the tail drains within the watchdog cadence anyway).
 std::array<std::unordered_set<uint64_t>, kDeferredQueueCount> g_gated_granules;             // addr >> 3
 std::array<std::vector<std::pair<uint64_t, uint64_t>>, kDeferredQueueCount> g_gated_ranges; // [lo, hi)
+// GDS has its own 64 KiB address space.  Keeping these spans separate is not merely an authority
+// concern: an immediate GDS fill deferred in one fold must order a later memory-to-GDS copy in a
+// different fold, while the numerically equal guest address remains unrelated.
+std::array<std::vector<std::pair<uint64_t, uint64_t>>, kDeferredQueueCount>
+    g_gated_gds_ranges; // [offset, offset + bytes)
 // The guest-memory span a command writes (0 bytes = writes nothing we track).
 void effect_span(const Pm4Command& c, uint64_t* addr, uint64_t* bytes) {
     using K = Pm4Command::Kind;
@@ -2531,6 +2536,17 @@ void effect_span(const Pm4Command& c, uint64_t* addr, uint64_t* bytes) {
     }
 }
 void gated_register(const Pm4Command& c) {
+    if (c.kind == Pm4Command::Kind::DmaData &&
+        dma_data_dst_sel(c) == kDmaSelGds) {
+        const uint64_t gds_size = compute_gds_size();
+        if (!c.dd_valid || !c.dd_bytes || c.dd_dst >= gds_size ||
+            c.dd_bytes > gds_size - c.dd_dst || (c.dd_dst & 3u) ||
+            (c.dd_bytes & 3u))
+            return;
+        g_gated_gds_ranges[deferred_queue(c.queue_origin)].emplace_back(
+            c.dd_dst, c.dd_dst + c.dd_bytes);
+        return;
+    }
     uint64_t a = 0, n = 0;
     effect_span(c, &a, &n);
     if (!a || !n) return;
@@ -2551,7 +2567,17 @@ bool addr_gated(uint64_t a, uint64_t n, uint8_t origin) {
         if (a < r.second && r.first < a + n) return true;
     return false;
 }
+bool gds_gated(uint64_t offset, uint64_t bytes, uint8_t origin) {
+    const uint64_t gds_size = compute_gds_size();
+    if (!bytes || offset >= gds_size || bytes > gds_size - offset) return false;
+    for (const auto& r : g_gated_gds_ranges[deferred_queue(origin)])
+        if (offset < r.second && r.first < offset + bytes) return true;
+    return false;
+}
 bool effect_gated(const Pm4Command& c) {
+    if (c.kind == Pm4Command::Kind::DmaData &&
+        dma_data_dst_sel(c) == kDmaSelGds)
+        return gds_gated(c.dd_dst, c.dd_bytes, c.queue_origin);
     uint64_t a = 0, n = 0;
     effect_span(c, &a, &n);
     return addr_gated(a, n, c.queue_origin);
@@ -2749,6 +2775,7 @@ int flush_deferred_streams() {
         // blocked peer queue cannot over-gate future work from this one.
         g_gated_granules[queue].clear();
         g_gated_ranges[queue].clear();
+        g_gated_gds_ranges[queue].clear();
         // Deliver every pulse owed by submissions from this queue. A blocked peer queue retains its
         // own pulses; an Acb completion must not wait for an unrelated Dcb barrier (and vice versa).
         uint64_t owed = g_owed_pulses[queue];
@@ -3619,10 +3646,9 @@ void GpuState::apply(const Pm4Command& c) {
             // FIFO behavior until a general copy appears; its suffix joins the ordered timeline.
             if (dma_data_address_source(c)) {
                 if (!c.dd_valid) { report_invalid_dma_data(c); break; }
-                // A GDS offset does not participate in WAIT_DEFER's guest-address domains, but a
-                // copy downstream of this fold's unsatisfied wait still cannot overtake the stream.
-                const bool gated_destination = g_fold_deferring ||
-                    (dma_data_dst_sel(c) != kDmaSelGds && defer_gate(c));
+                // Destination ordering is domain-aware: guest VAs and GDS offsets never alias one
+                // another, but either kind can carry a pending same-domain write across folds.
+                const bool gated_destination = defer_gate(c);
                 const bool gated_source = !g_deferred.empty() &&
                                           addr_gated(c.dd_src, c.dd_bytes, c.queue_origin);
                 if (gated_destination || gated_source) {

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -650,11 +650,39 @@ bool is_compute_internal_gds(const ShaderResource& r) {
 }
 
 constexpr uint32_t kCaptureDmaSelGds = 1u;
+constexpr uint32_t kCaptureDmaSelMemory = 3u;
 bool captured_dma_destination_is_gds(uint32_t sels) {
     return (sels & 0xffu) == kCaptureDmaSelGds;
 }
 bool captured_dma_source_is_gds(uint32_t sels) {
     return ((sels >> 8u) & 0xffu) == kCaptureDmaSelGds;
+}
+bool captured_dma_memory_to_gds_is_supported(const GpuCapturedDmaCopy& copy) {
+    const uint32_t source_selector = (copy.sels >> 8u) & 0xffu;
+    const bool address_source = (copy.sels & kDmaDataAddressSource) != 0 ||
+                                copy.src > UINT32_MAX;
+    return captured_dma_destination_is_gds(copy.sels) &&
+           source_selector == kCaptureDmaSelMemory && address_source;
+}
+bool capture_is_metadata_only(const GpuCaptureFile& capture) {
+    return std::any_of(capture.metadata.renderer_env.begin(),
+                       capture.metadata.renderer_env.end(), [](const auto& entry) {
+        return entry.first == "PROSPER_GPU_CAPTURE_METADATA_ONLY" &&
+               !entry.second.empty() && entry.second != "0" && entry.second != "off";
+    });
+}
+bool capture_has_internal_gds_descriptor(const GpuCaptureFile& capture) {
+    auto table_has_gds = [](const GpuCapturedTable& table) {
+        return std::any_of(table.resources.begin(), table.resources.end(),
+                           [](const GpuCapturedResource& resource) {
+            return is_compute_internal_gds(resource.resource);
+        });
+    };
+    for (const auto& draw : capture.draws)
+        if (table_has_gds(draw.vrt) || table_has_gds(draw.prt)) return true;
+    for (const auto& compute : capture.computes)
+        if (table_has_gds(compute.resources)) return true;
+    return false;
 }
 
 bool collect_intervals(const std::vector<DrawItem>& draws,
@@ -959,13 +987,40 @@ bool validate_dma_copies(const GpuCaptureFile& capture, std::string& error) {
     for (const auto& copy : capture.dma_copies) {
         const bool destination_gds = captured_dma_destination_is_gds(copy.sels);
         const bool source_gds = captured_dma_source_is_gds(copy.sels);
+        if (source_gds) {
+            error = "unsupported ordered DMA GDS source selector";
+            return false;
+        }
+        if (destination_gds && !captured_dma_memory_to_gds_is_supported(copy)) {
+            error = "unsupported ordered DMA memory-to-GDS selector form";
+            return false;
+        }
         const bool gds_destination_valid = !destination_gds ||
-            (copy.dst < 64u * 1024u && copy.bytes <= 64u * 1024u - copy.dst &&
+            (captured_dma_memory_to_gds_is_supported(copy) &&
+             copy.dst < 64u * 1024u && copy.bytes <= 64u * 1024u - copy.dst &&
              !(copy.dst & 3u) && !(copy.bytes & 3u) &&
-             copy.destination_blob_index == 0xFFFFFFFFu &&
-             copy.destination_blob_offset == 0);
+             ((copy.destination_blob_index == 0xFFFFFFFFu &&
+               copy.destination_blob_offset == 0 &&
+               (capture_is_metadata_only(capture) ||
+                capture_has_internal_gds_descriptor(capture))) ||
+              (copy.destination_blob_index != 0xFFFFFFFFu &&
+               copy.destination_blob_offset == copy.dst)));
+        if (destination_gds && copy.destination_blob_index != 0xFFFFFFFFu) {
+            if (copy.destination_blob_index >= capture.blobs.size()) {
+                error = "ordered DMA GDS destination references an invalid capture blob";
+                return false;
+            }
+            const auto& blob = capture.blobs[copy.destination_blob_index];
+            if (blob.guest_addr != 0 ||
+                (!capture_blob_payload_omitted(blob) &&
+                 (blob.bytes.size() != 64u * 1024u ||
+                  blob.bytes_read != blob.bytes.size()))) {
+                error = "ordered DMA GDS destination has an invalid pre-submit snapshot";
+                return false;
+            }
+        }
         if ((!destination_gds && !copy.dst) || !copy.src || !copy.bytes ||
-            copy.bytes > kMaxBlobBytes || source_gds || !gds_destination_valid ||
+            copy.bytes > kMaxBlobBytes || !gds_destination_valid ||
             (!destination_gds &&
              copy.dst > std::numeric_limits<uint64_t>::max() - copy.bytes) ||
             copy.src > std::numeric_limits<uint64_t>::max() - copy.bytes ||
@@ -1540,7 +1595,9 @@ bool capture_submit_items(const std::vector<DrawItem>& draws,
                           std::string& error, const CaptureRttSeedReader& rtt_reader,
                           const std::vector<OperationRealizationFailure>& failures,
                           const std::vector<GpuState::DmaCopy>& dma_copies,
-                          uint64_t resource_limit_bytes_override) {
+                          uint64_t resource_limit_bytes_override,
+                          const uint8_t* pre_submit_compute_gds,
+                          size_t pre_submit_compute_gds_bytes) {
     error.clear(); out = {}; out.format_version = kVersion; out.metadata = metadata;
     out.failure_diagnostics_available = true;
     if (draws.size() > kMaxDraws || computes.size() > kMaxComputes ||
@@ -1627,6 +1684,55 @@ bool capture_submit_items(const std::vector<DrawItem>& draws,
                            c.resources, error)) return false;
         out.computes.push_back(std::move(c));
     }
+    uint32_t gds_snapshot_blob_index = 0xFFFFFFFFu;
+    if (include_resource_data && std::any_of(
+            dma_copies.begin(), dma_copies.end(), [](const GpuState::DmaCopy& copy) {
+                return captured_dma_destination_is_gds(copy.sels);
+            })) {
+        const uint8_t* snapshot = pre_submit_compute_gds_bytes
+            ? pre_submit_compute_gds : nullptr;
+        size_t snapshot_bytes = pre_submit_compute_gds_bytes;
+        auto find_internal_snapshot = [&](const GpuCapturedTable& table) {
+            if (snapshot) return;
+            for (const auto& resource : table.resources) {
+                if (!is_compute_internal_gds(resource.resource) ||
+                    resource.internal_bytes.empty())
+                    continue;
+                snapshot = resource.internal_bytes.data();
+                snapshot_bytes = resource.internal_bytes.size();
+                return;
+            }
+        };
+        for (const auto& draw : out.draws) {
+            find_internal_snapshot(draw.vrt);
+            find_internal_snapshot(draw.prt);
+        }
+        for (const auto& compute : out.computes)
+            find_internal_snapshot(compute.resources);
+        if (!snapshot || snapshot_bytes != 64u * 1024u) {
+            error = "memory-to-GDS capture has no complete pre-submit GDS snapshot";
+            return false;
+        }
+        for (const auto& compute : out.computes) {
+            for (const auto& resource : compute.resources.resources) {
+                if (is_compute_internal_gds(resource.resource) &&
+                    !resource.internal_bytes.empty() &&
+                    (resource.internal_bytes.size() != snapshot_bytes ||
+                     std::memcmp(resource.internal_bytes.data(), snapshot,
+                                 snapshot_bytes) != 0)) {
+                    error = "compute GDS resources disagree with the pre-submit snapshot";
+                    return false;
+                }
+            }
+        }
+        GpuCaptureBlob blob;
+        blob.guest_addr = 0;
+        blob.bytes_read = snapshot_bytes;
+        blob.bytes.assign(snapshot, snapshot + snapshot_bytes);
+        blob.content_hash = gpu_capture_hash(blob.bytes);
+        gds_snapshot_blob_index = static_cast<uint32_t>(out.blobs.size());
+        out.blobs.push_back(std::move(blob));
+    }
     out.dma_copies.reserve(dma_copies.size());
     for (const auto& copy : dma_copies) {
         GpuCapturedDmaCopy captured;
@@ -1634,6 +1740,10 @@ bool capture_submit_items(const std::vector<DrawItem>& draws,
         captured.sels = copy.sels; captured.command_order = copy.command_order;
         captured.packet_addr = copy.packet_addr;
         const bool destination_gds = captured_dma_destination_is_gds(copy.sels);
+        if (include_resource_data && destination_gds) {
+            captured.destination_blob_index = gds_snapshot_blob_index;
+            captured.destination_blob_offset = copy.dst;
+        }
         if (include_resource_data &&
             ((!destination_gds && !assign_blob_range(intervals, copy.dst, copy.bytes,
                                 captured.destination_blob_index,
@@ -1756,7 +1866,8 @@ bool capture_gpustate_submit(const GpuState& state, uint64_t submit_no,
     CaptureMemoryReader ordered_reader = ordered_gpustate_capture_reader(state);
     return capture_submit_items(draws, computes, ops, actual, ordered_reader, out, error,
                                 g_rtt_seed_reader, failures, state.dma_copies,
-                                resource_limit_bytes);
+                                resource_limit_bytes, compute_gds_backing(),
+                                compute_gds_size());
 }
 
 bool capture_gpustate_target_submit(const GpuState& state, uint64_t submit_no,
@@ -1783,7 +1894,8 @@ bool capture_gpustate_target_submit(const GpuState& state, uint64_t submit_no,
     actual.width = width; actual.height = height; actual.submit_index = submit_no;
     return capture_submit_items(draws, {}, operations, actual,
                                 ordered_gpustate_capture_reader(state),
-                                out, error, g_rtt_seed_reader, {}, state.dma_copies);
+                                out, error, g_rtt_seed_reader, {}, state.dma_copies, 0,
+                                compute_gds_backing(), compute_gds_size());
 }
 
 bool serialize_gpu_capture(const GpuCaptureFile& c, std::vector<uint8_t>& bytes, std::string& error) {
@@ -3826,19 +3938,38 @@ bool materialize_gpu_replay(const GpuCaptureFile& c, GpuReplayFrame& out, std::s
         copy.packet_addr = captured.packet_addr;
         uint8_t* source = nullptr;
         if (captured_dma_destination_is_gds(captured.sels)) {
-            const auto internal = internal_instance_by_binding.find(kComputeInternalGdsBinding);
-            if (internal == internal_instance_by_binding.end()) {
-                error = "ordered DMA GDS destination has no captured internal GDS instance";
-                return false;
+            auto internal = internal_instance_by_binding.find(kComputeInternalGdsBinding);
+            if (captured.destination_blob_index != 0xFFFFFFFFu) {
+                if (captured.destination_blob_index >= out.blobs.size()) {
+                    error = "ordered DMA GDS destination references an invalid capture blob";
+                    return false;
+                }
+                const auto& blob = out.blobs[captured.destination_blob_index];
+                if (blob.bytes.size() != 64u * 1024u) {
+                    error = "ordered DMA GDS destination snapshot is unavailable";
+                    return false;
+                }
+                if (internal == internal_instance_by_binding.end()) {
+                    const size_t index = out.resource_instances.size();
+                    out.resource_instances.push_back({0, captured.destination_blob_index,
+                                                      blob.bytes});
+                    internal = internal_instance_by_binding.emplace(
+                        kComputeInternalGdsBinding, index).first;
+                } else if (out.resource_instances[internal->second].bytes != blob.bytes) {
+                    error = "compute GDS resources disagree with DMA pre-submit state";
+                    return false;
+                }
             }
-            auto& instance = out.resource_instances[internal->second].bytes;
-            if (captured.dst >= instance.size() ||
-                captured.bytes > instance.size() - captured.dst) {
-                error = "ordered DMA GDS destination exceeds captured internal GDS";
-                return false;
+            if (internal != internal_instance_by_binding.end()) {
+                auto& instance = out.resource_instances[internal->second].bytes;
+                if (captured.dst >= instance.size() ||
+                    captured.bytes > instance.size() - captured.dst) {
+                    error = "ordered DMA GDS destination exceeds captured internal GDS";
+                    return false;
+                }
+                copy.destination_data = instance.data() + captured.dst;
+                copy.destination_size = instance.size() - captured.dst;
             }
-            copy.destination_data = instance.data() + captured.dst;
-            copy.destination_size = instance.size() - captured.dst;
         } else if (!bind_range(
                        captured.destination_blob_index, captured.destination_blob_offset,
                        captured.dst, captured.bytes, copy.destination_data,
@@ -4537,7 +4668,8 @@ bool materialize_pending_gpu_capture(PendingGpuCapture& pending,
     const bool captured = capture_submit_items(
         draws, snapshot_computes, exact_operations, metadata, reader, pending.capture, error,
         g_rtt_seed_reader, failures,
-        semantic_state ? semantic_state->dma_copies : std::vector<GpuState::DmaCopy>{});
+        semantic_state ? semantic_state->dma_copies : std::vector<GpuState::DmaCopy>{}, 0,
+        pending.pre_submit_compute_gds.data(), pending.pre_submit_compute_gds.size());
     if (!captured) return false;
     pending.materialized = true;
     return !gpu_capture_ds_seed_snapshot_available() ||

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -649,6 +649,14 @@ bool is_compute_internal_gds(const ShaderResource& r) {
            r.cls == ResourceClass::ConstantBuffer && r.size == 64u * 1024u && r.stride == 4;
 }
 
+constexpr uint32_t kCaptureDmaSelGds = 1u;
+bool captured_dma_destination_is_gds(uint32_t sels) {
+    return (sels & 0xffu) == kCaptureDmaSelGds;
+}
+bool captured_dma_source_is_gds(uint32_t sels) {
+    return ((sels >> 8u) & 0xffu) == kCaptureDmaSelGds;
+}
+
 bool collect_intervals(const std::vector<DrawItem>& draws,
                        const std::vector<ComputeItem>& computes,
                        const std::vector<GpuState::DmaCopy>& dma_copies,
@@ -696,13 +704,21 @@ bool collect_intervals(const std::vector<DrawItem>& draws,
     for (const auto& d : draws) if (!add_table(d.vrt.get()) || !add_table(d.prt.get())) return false;
     for (const auto& c : computes) if (!add_table(c.resources.get())) return false;
     for (const auto& copy : dma_copies) {
-        if (!copy.dst || !copy.src || !copy.bytes ||
-            copy.dst > std::numeric_limits<uint64_t>::max() - copy.bytes ||
+        const bool destination_gds = captured_dma_destination_is_gds(copy.sels);
+        const bool source_gds = captured_dma_source_is_gds(copy.sels);
+        if ((!destination_gds && !copy.dst) || !copy.src || !copy.bytes ||
+            (!destination_gds &&
+             copy.dst > std::numeric_limits<uint64_t>::max() - copy.bytes) ||
             copy.src > std::numeric_limits<uint64_t>::max() - copy.bytes) {
             error = "ordered DMA capture range is invalid";
             return false;
         }
-        intervals.push_back({copy.dst, copy.dst + copy.bytes});
+        if (source_gds) {
+            error = "ordered DMA capture has an unsupported GDS source";
+            return false;
+        }
+        if (!destination_gds)
+            intervals.push_back({copy.dst, copy.dst + copy.bytes});
         intervals.push_back({copy.src, copy.src + copy.bytes});
     }
     std::sort(intervals.begin(), intervals.end(), [](auto a, auto b) { return a.begin < b.begin; });
@@ -941,8 +957,17 @@ bool validate_dma_copies(const GpuCaptureFile& capture, std::string& error) {
         return true;
     };
     for (const auto& copy : capture.dma_copies) {
-        if (!copy.dst || !copy.src || !copy.bytes || copy.bytes > kMaxBlobBytes ||
-            copy.dst > std::numeric_limits<uint64_t>::max() - copy.bytes ||
+        const bool destination_gds = captured_dma_destination_is_gds(copy.sels);
+        const bool source_gds = captured_dma_source_is_gds(copy.sels);
+        const bool gds_destination_valid = !destination_gds ||
+            (copy.dst < 64u * 1024u && copy.bytes <= 64u * 1024u - copy.dst &&
+             !(copy.dst & 3u) && !(copy.bytes & 3u) &&
+             copy.destination_blob_index == 0xFFFFFFFFu &&
+             copy.destination_blob_offset == 0);
+        if ((!destination_gds && !copy.dst) || !copy.src || !copy.bytes ||
+            copy.bytes > kMaxBlobBytes || source_gds || !gds_destination_valid ||
+            (!destination_gds &&
+             copy.dst > std::numeric_limits<uint64_t>::max() - copy.bytes) ||
             copy.src > std::numeric_limits<uint64_t>::max() - copy.bytes ||
             !validate_blob(copy.destination_blob_index, copy.destination_blob_offset, copy.bytes,
                            "ordered DMA destination references an invalid capture blob",
@@ -1608,11 +1633,12 @@ bool capture_submit_items(const std::vector<DrawItem>& draws,
         captured.dst = copy.dst; captured.src = copy.src; captured.bytes = copy.bytes;
         captured.sels = copy.sels; captured.command_order = copy.command_order;
         captured.packet_addr = copy.packet_addr;
+        const bool destination_gds = captured_dma_destination_is_gds(copy.sels);
         if (include_resource_data &&
-            (!assign_blob_range(intervals, copy.dst, copy.bytes,
+            ((!destination_gds && !assign_blob_range(intervals, copy.dst, copy.bytes,
                                 captured.destination_blob_index,
                                 captured.destination_blob_offset,
-                                "ordered DMA destination was not assigned to a capture blob", error) ||
+                                "ordered DMA destination was not assigned to a capture blob", error)) ||
              !assign_blob_range(intervals, copy.src, copy.bytes,
                                 captured.source_blob_index, captured.source_blob_offset,
                                 "ordered DMA source was not assigned to a capture blob", error)))
@@ -3799,13 +3825,30 @@ bool materialize_gpu_replay(const GpuCaptureFile& c, GpuReplayFrame& out, std::s
         copy.sels = captured.sels; copy.command_order = captured.command_order;
         copy.packet_addr = captured.packet_addr;
         uint8_t* source = nullptr;
-        if (!bind_range(captured.destination_blob_index, captured.destination_blob_offset,
-                        captured.dst, captured.bytes, copy.destination_data,
-                        copy.destination_size,
-                        "ordered DMA destination references an invalid capture blob",
-                        "ordered DMA destination exceeds capture blob",
-                        "ordered DMA destination blob offset exceeds its logical address") ||
-            !bind_range(captured.source_blob_index, captured.source_blob_offset,
+        if (captured_dma_destination_is_gds(captured.sels)) {
+            const auto internal = internal_instance_by_binding.find(kComputeInternalGdsBinding);
+            if (internal == internal_instance_by_binding.end()) {
+                error = "ordered DMA GDS destination has no captured internal GDS instance";
+                return false;
+            }
+            auto& instance = out.resource_instances[internal->second].bytes;
+            if (captured.dst >= instance.size() ||
+                captured.bytes > instance.size() - captured.dst) {
+                error = "ordered DMA GDS destination exceeds captured internal GDS";
+                return false;
+            }
+            copy.destination_data = instance.data() + captured.dst;
+            copy.destination_size = instance.size() - captured.dst;
+        } else if (!bind_range(
+                       captured.destination_blob_index, captured.destination_blob_offset,
+                       captured.dst, captured.bytes, copy.destination_data,
+                       copy.destination_size,
+                       "ordered DMA destination references an invalid capture blob",
+                       "ordered DMA destination exceeds capture blob",
+                       "ordered DMA destination blob offset exceeds its logical address")) {
+            return false;
+        }
+        if (!bind_range(captured.source_blob_index, captured.source_blob_offset,
                         captured.src, captured.bytes, source, copy.source_size,
                         "ordered DMA source references an invalid capture blob",
                         "ordered DMA source exceeds capture blob",

--- a/prosper/src/gpu/gpu_capture.hpp
+++ b/prosper/src/gpu/gpu_capture.hpp
@@ -217,6 +217,9 @@ struct GpuCapturedOperation {
 
 // Ordered address-backed DMA_DATA. Guest addresses preserve the semantic identity; blob references
 // bind the source and destination to their exact pre-submit backing versions for standalone replay.
+// For a selector-1 GDS destination, destination_blob_index instead names the complete shared 64 KiB
+// pre-submit GDS snapshot and destination_blob_offset is the GDS byte offset. Metadata-only captures
+// leave both endpoint indices unavailable, as they do for every other resource payload.
 struct GpuCapturedDmaCopy {
     uint64_t dst = 0, src = 0;
     uint32_t bytes = 0, sels = 0;
@@ -356,7 +359,9 @@ bool capture_submit_items(const std::vector<DrawItem>& draws,
                           std::string& error, const CaptureRttSeedReader& rtt_reader = {},
                           const std::vector<OperationRealizationFailure>& failures = {},
                           const std::vector<GpuState::DmaCopy>& dma_copies = {},
-                          uint64_t resource_limit_bytes = 0);
+                          uint64_t resource_limit_bytes = 0,
+                          const uint8_t* pre_submit_compute_gds = nullptr,
+                          size_t pre_submit_compute_gds_bytes = 0);
 bool capture_gpustate_submit(const GpuState& state, uint64_t submit_no,
                              uint32_t width, uint32_t height,
                              const GpuCaptureMetadata& metadata,

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -5394,14 +5394,29 @@ OrderedSubmitResult execute_ordered_items(const std::vector<SubmitOperation>& op
     return execute_ordered_items_impl(
         operations, draws, computes, dma_copies, render, compute, width, height,
         [](const ReplayDmaCopy& copy) {
-            const bool source_gds = ((copy.sels >> 8u) & 0xffu) == 1u;
-            const bool destination_gds = (copy.sels & 0xffu) == 1u;
+            const uint32_t source_selector = (copy.sels >> 8u) & 0xffu;
+            const uint32_t destination_selector = copy.sels & 0xffu;
+            const bool source_gds = source_selector == 1u;
+            const bool destination_gds = destination_selector == 1u;
             if (source_gds) {
                 static std::atomic<int> warned{0};
                 if (warned.fetch_add(1) < 24)
                     std::fprintf(stderr,
                                  "[gpu_replay] DMA_DATA GDS source is unsupported: "
                                  "src=0x%llx dst=0x%llx bytes=%u sels=0x%x\n",
+                                 static_cast<unsigned long long>(copy.src),
+                                 static_cast<unsigned long long>(copy.dst), copy.bytes,
+                                 copy.sels);
+                return;
+            }
+            const bool address_source = (copy.sels & kDmaDataAddressSource) != 0 ||
+                                        copy.src > UINT32_MAX;
+            if (destination_gds && (source_selector != 3u || !address_source)) {
+                static std::atomic<int> warned{0};
+                if (warned.fetch_add(1) < 24)
+                    std::fprintf(stderr,
+                                 "[gpu_replay] DMA_DATA memory-to-GDS selector form is "
+                                 "unsupported: src=0x%llx dst=0x%llx bytes=%u sels=0x%x\n",
                                  static_cast<unsigned long long>(copy.src),
                                  static_cast<unsigned long long>(copy.dst), copy.bytes,
                                  copy.sels);

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -5394,6 +5394,19 @@ OrderedSubmitResult execute_ordered_items(const std::vector<SubmitOperation>& op
     return execute_ordered_items_impl(
         operations, draws, computes, dma_copies, render, compute, width, height,
         [](const ReplayDmaCopy& copy) {
+            const bool source_gds = ((copy.sels >> 8u) & 0xffu) == 1u;
+            const bool destination_gds = (copy.sels & 0xffu) == 1u;
+            if (source_gds) {
+                static std::atomic<int> warned{0};
+                if (warned.fetch_add(1) < 24)
+                    std::fprintf(stderr,
+                                 "[gpu_replay] DMA_DATA GDS source is unsupported: "
+                                 "src=0x%llx dst=0x%llx bytes=%u sels=0x%x\n",
+                                 static_cast<unsigned long long>(copy.src),
+                                 static_cast<unsigned long long>(copy.dst), copy.bytes,
+                                 copy.sels);
+                return;
+            }
             std::vector<uint8_t> current_source;
             const LiveTargetByteReadResult source_result = read_live_render_target_bytes(
                 copy.src, copy.bytes, current_source);
@@ -5413,7 +5426,7 @@ OrderedSubmitResult execute_ordered_items(const std::vector<SubmitOperation>& op
                 copy.bytes > copy.destination_size || copy.bytes > source_size)
                 return;
             std::memmove(copy.destination_data, source, copy.bytes);
-            notify_guest_gpu_write(copy.dst, copy.bytes);
+            if (!destination_gds) notify_guest_gpu_write(copy.dst, copy.bytes);
         });
 }
 
@@ -6243,13 +6256,16 @@ static OrderedSubmitResult execute_ordered_gpustate(const GpuState& st, uint32_t
                 const GpuState::DmaCopy& copy = st.dma_copies[operation.index];
                 // Source and destination are distinct ordered consumers: a disjoint source must not
                 // hide an overlapping destination (or vice versa).
-                notify_compute_authority_range(
-                    ComputeAuthorityBoundaryKind::Dma, submit_no,
-                    operation.command_order, copy.src, copy.bytes);
+                const bool source_gds = ((copy.sels >> 8u) & 0xffu) == 1u;
+                const bool destination_gds = (copy.sels & 0xffu) == 1u;
+                if (!source_gds)
+                    notify_compute_authority_range(
+                        ComputeAuthorityBoundaryKind::Dma, submit_no,
+                        operation.command_order, copy.src, copy.bytes);
                 // Selector byte 1 names a GDS offset, not guest memory. The source still consumes a
                 // guest/render-target range, while the destination is ordered by this executor's
                 // shared GDS backing and must not manufacture a guest range at (for example) 0x24.
-                if ((copy.sels & 0xffu) != 1u)
+                if (!destination_gds)
                     notify_compute_authority_range(
                         ComputeAuthorityBoundaryKind::Dma, submit_no,
                         operation.command_order, copy.dst, copy.bytes);
@@ -6263,12 +6279,19 @@ static OrderedSubmitResult execute_ordered_gpustate(const GpuState& st, uint32_t
                                      "[agc] DMA_DATA live-target source range invalid: src=0x%llx bytes=%u\n",
                                      static_cast<unsigned long long>(copy.src), copy.bytes);
                     producer_epoch_ok = false;
+                    notify_compute_authority_unknown(
+                        ComputeAuthorityBoundaryKind::Dma, submit_no,
+                        operation.command_order);
                     break;
                 }
                 const bool executed = execute_ordered_dma_copy(
                     copy, source_result == LiveTargetByteReadResult::Success
                               ? current_source.data() : nullptr);
                 producer_epoch_ok &= executed;
+                if (!executed)
+                    notify_compute_authority_unknown(
+                        ComputeAuthorityBoundaryKind::Dma, submit_no,
+                        operation.command_order);
                 break;
             }
             case RetainedSubmitKind::ParserStall:

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -6246,9 +6246,13 @@ static OrderedSubmitResult execute_ordered_gpustate(const GpuState& st, uint32_t
                 notify_compute_authority_range(
                     ComputeAuthorityBoundaryKind::Dma, submit_no,
                     operation.command_order, copy.src, copy.bytes);
-                notify_compute_authority_range(
-                    ComputeAuthorityBoundaryKind::Dma, submit_no,
-                    operation.command_order, copy.dst, copy.bytes);
+                // Selector byte 1 names a GDS offset, not guest memory. The source still consumes a
+                // guest/render-target range, while the destination is ordered by this executor's
+                // shared GDS backing and must not manufacture a guest range at (for example) 0x24.
+                if ((copy.sels & 0xffu) != 1u)
+                    notify_compute_authority_range(
+                        ComputeAuthorityBoundaryKind::Dma, submit_no,
+                        operation.command_order, copy.dst, copy.bytes);
                 std::vector<uint8_t> current_source;
                 const LiveTargetByteReadResult source_result = read_live_render_target_bytes(
                     copy.src, copy.bytes, current_source);

--- a/prosper/tests/test_eop_write.cpp
+++ b/prosper/tests/test_eop_write.cpp
@@ -530,6 +530,144 @@ int main() {
         CHECK(gds[offset + 4] == 0xAB, "GDS fill wrote exactly the requested byte span");
     }
 
+    // #1732: Astro Bot's world-map loader emits the address-backed sibling with the exact contract
+    // dstSel=GDS, srcSel=memory, sourceKind=address. Preserve it in the ordered timeline and copy
+    // mapped source bytes into the private GDS share without publishing a fictitious guest write to
+    // address 0x24. Each assertion has a distinct mutation target: form selection, payload, bounds,
+    // and destination-domain notification.
+    {
+        uint8_t* gds = compute_gds_backing();
+        const uint32_t offset = 0x24;
+        alignas(4) uint32_t source[2] = {0xA1B2C3D4u, 0x55667788u};
+        memset(gds + offset, 0xCC, 12);
+        const uint64_t src = reinterpret_cast<uint64_t>(source);
+        uint32_t dma[7] = {};
+        dma[0] = PM4(7, IT_NOP, R_DMA_DATA);
+        dma[1] = offset; dma[2] = 0;
+        dma[3] = static_cast<uint32_t>(src); dma[4] = static_cast<uint32_t>(src >> 32);
+        dma[5] = sizeof(source);
+        dma[6] = 1u | (3u << 8) | kDmaDataAddressSource;
+        bool notified = false;
+        set_guest_gpu_write_observer([&](uint64_t, uint64_t) { notified = true; });
+        GpuState st; run_cb(dma, 7, st);
+        set_guest_gpu_write_observer({});
+        CHECK(st.dma_copies.size() == 1 && st.dma_copies[0].dst == offset &&
+                  st.dma_copies[0].src == src && st.dma_copies[0].sels == dma[6],
+              "memory-to-GDS DMA is retained with its exact address and selector contract");
+        CHECK(memcmp(gds + offset, source, sizeof(source)) == 0 &&
+                  gds[offset + sizeof(source)] == 0xCC,
+              "memory-to-GDS DMA copies the exact mapped source span in order");
+        CHECK(!notified,
+              "memory-to-GDS DMA does not publish its GDS offset as a guest-memory write");
+    }
+
+    // The exact source selector is part of the supported direction. A valid host address paired
+    // with any other source domain must not be enough to opt an unknown form into GDS execution.
+    {
+        uint8_t* gds = compute_gds_backing();
+        const uint32_t offset = 0x34;
+        uint32_t source = 0x10203040u;
+        memset(gds + offset, 0x5A, 4);
+        const uint64_t src = reinterpret_cast<uint64_t>(&source);
+        uint32_t dma[7] = {PM4(7, IT_NOP, R_DMA_DATA), offset, 0,
+                           static_cast<uint32_t>(src), static_cast<uint32_t>(src >> 32), 4,
+                           1u | (2u << 8) | kDmaDataAddressSource};
+        GpuState st; run_cb(dma, 7, st);
+        CHECK(gds[offset] == 0x5A,
+              "memory-to-GDS DMA rejects an unrecognised source selector");
+    }
+
+    // sourceKind is authoritative: an unmapped address must remain an address and fail closed, not
+    // become a repeated immediate merely because its numeric value fits in 32 bits.
+    {
+        uint8_t* gds = compute_gds_backing();
+        const uint32_t offset = 0x38;
+        memset(gds + offset, 0x6B, 4);
+        uint32_t dma[7] = {PM4(7, IT_NOP, R_DMA_DATA), offset, 0, 0x4000u, 0, 4,
+                           1u | (3u << 8) | kDmaDataAddressSource};
+        GpuState st; run_cb(dma, 7, st);
+        CHECK(st.dma_copies.size() == 1 && gds[offset] == 0x6B,
+              "memory-to-GDS DMA retains and rejects an unmapped asserted address source");
+    }
+
+    // GDS copy validation is exact, not a clamping path: reject a span crossing the 64 KiB share,
+    // a non-dword byte count, and a misaligned offset without changing any in-range sentinel.
+    {
+        uint8_t* gds = compute_gds_backing();
+        uint32_t source[2] = {0xDEADBEEFu, 0xCAFEBABEu};
+        const uint64_t src = reinterpret_cast<uint64_t>(source);
+        auto run_invalid_gds_copy = [&](uint32_t offset, uint32_t bytes, uint8_t sentinel) {
+            memset(gds + offset, sentinel, std::min<size_t>(4, compute_gds_size() - offset));
+            uint32_t dma[7] = {PM4(7, IT_NOP, R_DMA_DATA), offset, 0,
+                               static_cast<uint32_t>(src), static_cast<uint32_t>(src >> 32), bytes,
+                               1u | (3u << 8) | kDmaDataAddressSource};
+            GpuState st; run_cb(dma, 7, st);
+            return gds[offset] == sentinel;
+        };
+        CHECK(run_invalid_gds_copy(static_cast<uint32_t>(compute_gds_size()) - 4, 8, 0x71),
+              "memory-to-GDS DMA rejects an out-of-range destination span");
+        CHECK(run_invalid_gds_copy(0x44, 6, 0x72),
+              "memory-to-GDS DMA rejects a non-dword byte count");
+        CHECK(run_invalid_gds_copy(0x4A, 4, 0x73),
+              "memory-to-GDS DMA rejects a misaligned destination offset");
+    }
+
+    // Exact live defect shape from #1927: the GDS copy is unrelated to this guest label, then an
+    // owned WRITE_DATA/release pair satisfies the eager wait. GDS+0x24 used to be classified as an
+    // unknown guest address and therefore poisoned every such wait. The diagnostic is an independent
+    // positive witness that the new execution arm actually ran, rather than merely skipping overlap.
+    {
+        uint8_t* gds = compute_gds_backing();
+        const uint32_t offset = 0x24;
+        uint32_t source = 0x89ABCDEFu;
+        uint64_t label = 0;
+        const uint64_t src = reinterpret_cast<uint64_t>(&source);
+        const uint64_t label_addr = reinterpret_cast<uint64_t>(&label);
+        std::vector<uint32_t> stream;
+        stream.reserve(28);
+        stream.insert(stream.end(), {PM4(7, IT_NOP, R_DMA_DATA), offset, 0,
+                                     static_cast<uint32_t>(src), static_cast<uint32_t>(src >> 32),
+                                     4, 1u | (3u << 8) | kDmaDataAddressSource});
+        stream.insert(stream.end(), {PM4(6, IT_NOP, R_WRITE_DATA), 0,
+                                     static_cast<uint32_t>(label_addr),
+                                     static_cast<uint32_t>(label_addr >> 32), 1, 0});
+        stream.insert(stream.end(), {PM4(7, IT_NOP, R_RELEASE_MEM),
+                                     static_cast<uint32_t>(label_addr),
+                                     static_cast<uint32_t>(label_addr >> 32), 1, 1, 0, 0});
+        stream.insert(stream.end(), {PM4(8, IT_NOP, R_WAIT_MEM_64),
+                                     static_cast<uint32_t>(label_addr),
+                                     static_cast<uint32_t>(label_addr >> 32),
+                                     0xffffffffu, 0, 1, 0, 3});
+#ifdef _WIN32
+        _putenv_s("PROSPER_GDSLOG", "1");
+#else
+        setenv("PROSPER_GDSLOG", "1", 1);
+#endif
+        GpuState st;
+        const std::string diagnostic = capture_stderr(
+            [&] { run_cb(stream.data(), stream.size(), st); });
+#ifdef _WIN32
+        _putenv_s("PROSPER_GDSLOG", "");
+#else
+        unsetenv("PROSPER_GDSLOG");
+#endif
+        uint32_t copied = 0;
+        memcpy(&copied, gds + offset, sizeof(copied));
+        CHECK(!st.dma_execution_rejected && st.dma_copies.size() == 1 &&
+                  st.ordered_memory_effects.size() == 2,
+              "GDS destination does not poison an unrelated retained label wait");
+        CHECK(st.dma_copies[0].command_order <
+                      st.ordered_memory_effects[0].cmd.stream_order &&
+                  st.ordered_memory_effects[0].cmd.stream_order <
+                      st.ordered_memory_effects[1].cmd.stream_order &&
+                  copied == source && label == 1,
+              "memory-to-GDS, WRITE_DATA, and release execute in retained stream order");
+        CHECK(diagnostic.find("DmaData memory-to-GDS #1") != std::string::npos &&
+                  diagnostic.find("[gds+0x24]") != std::string::npos &&
+                  diagnostic.find("sels=0x10301") != std::string::npos,
+              "memory-to-GDS reporter proves the exact execution arm moved");
+    }
+
     // ...and the guard that made it fail-closed still rejects a genuinely malformed guest pointer:
     // a sub-0x10000 destination WITHOUT the GDS selector must remain unwritten, or the fix above
     // would have turned every malformed packet into a wild write at a low address. Assert on GDS

--- a/prosper/tests/test_gpu_capture.cpp
+++ b/prosper/tests/test_gpu_capture.cpp
@@ -2014,10 +2014,13 @@ int main(int argc, char** argv) {
     GpuCaptureFile gds_capture;
     CHECK(capture_submit_items({}, {gds_consumer}, gds_operations, meta, ordered_reader,
                                gds_capture, error, {}, {}, {gds_copy}) &&
-              gds_capture.dma_copies.size() == 1 && gds_capture.blobs.size() == 1 &&
-              gds_capture.dma_copies[0].destination_blob_index == 0xFFFFFFFFu &&
-              gds_capture.dma_copies[0].destination_blob_offset == 0,
-          "memory-to-GDS capture stores only the guest source blob");
+              gds_capture.dma_copies.size() == 1 && gds_capture.blobs.size() == 2 &&
+              gds_capture.dma_copies[0].destination_blob_index <
+                  gds_capture.blobs.size() &&
+              gds_capture.dma_copies[0].destination_blob_offset == gds_copy.dst &&
+              gds_capture.blobs[gds_capture.dma_copies[0].destination_blob_index].bytes ==
+                  initial_gds,
+          "memory-to-GDS capture retains the complete pre-submit GDS independently");
     std::vector<uint8_t> gds_capture_bytes;
     GpuCaptureFile gds_loaded;
     GpuReplayFrame gds_replay;
@@ -2055,12 +2058,108 @@ int main(int argc, char** argv) {
     CHECK(invalidations.empty(),
           "replay never publishes a GDS offset as a guest GPU write");
 
+    // A valid submit may contain the retained DMA and no compute table at all. Its standalone
+    // backing must therefore come from the pre-submit GDS snapshot, not from a coincidental
+    // same-submit consumer descriptor.
+    const std::vector<SubmitOperation> gds_dma_only_operations = {
+        {SubmitOperationKind::DmaCopy, 0, 20},
+    };
+    GpuCaptureFile gds_dma_only_capture;
+    CHECK(capture_submit_items({}, {}, gds_dma_only_operations, meta, ordered_reader,
+                               gds_dma_only_capture, error, {}, {}, {gds_copy}, 0,
+                               initial_gds.data(), initial_gds.size()) &&
+              gds_dma_only_capture.computes.empty() &&
+              gds_dma_only_capture.dma_copies.size() == 1 &&
+              gds_dma_only_capture.dma_copies[0].destination_blob_index <
+                  gds_dma_only_capture.blobs.size(),
+          "full-data memory-to-GDS capture owns a snapshot without a compute table");
+    std::vector<uint8_t> gds_dma_only_bytes;
+    GpuCaptureFile gds_dma_only_loaded;
+    GpuReplayFrame gds_dma_only_replay;
+    const bool gds_dma_only_materialized =
+        serialize_gpu_capture(gds_dma_only_capture, gds_dma_only_bytes, error) &&
+        deserialize_gpu_capture(gds_dma_only_bytes, gds_dma_only_loaded, error) &&
+        materialize_gpu_replay(gds_dma_only_loaded, gds_dma_only_replay, error);
+    const bool gds_dma_only_backed = gds_dma_only_materialized &&
+              gds_dma_only_replay.computes.empty() &&
+              gds_dma_only_replay.dma_copies.size() == 1 &&
+              gds_dma_only_replay.dma_copies[0].destination_data &&
+              gds_dma_only_replay.dma_copies[0].source_data &&
+              gds_dma_only_replay.dma_copies[0].destination_data[0] == 0x19;
+    CHECK(gds_dma_only_backed,
+          "DMA-only GDS state serializes and materializes with its exact pre-submit byte");
+    std::vector<SubmitOperation> gds_dma_only_replay_operations;
+    for (const auto& operation : gds_dma_only_replay.operations)
+        if (operation.realized)
+            gds_dma_only_replay_operations.push_back(
+                {operation.kind, static_cast<size_t>(operation.source_index),
+                 operation.command_order});
+    if (gds_dma_only_backed)
+        execute_ordered_items(gds_dma_only_replay_operations, {}, {},
+                              gds_dma_only_replay.dma_copies, {}, {}, 1, 1);
+    CHECK(gds_dma_only_backed &&
+              gds_dma_only_replay.dma_copies[0].destination_data[0] == 0xa1,
+          "DMA-only replay executes against its independently captured GDS backing");
+
+    // Thin captures retain truthful operation/selector metadata while making both omitted payloads
+    // explicitly unavailable. This is the contract used by inspect/validate/graph.
+    set_test_env("PROSPER_GPU_CAPTURE_METADATA_ONLY", "1");
+    GpuCaptureFile gds_metadata_capture;
+    const bool gds_metadata_captured = capture_submit_items(
+        {}, {}, gds_dma_only_operations, meta, ordered_reader, gds_metadata_capture, error,
+        {}, {}, {gds_copy}, 0, initial_gds.data(), initial_gds.size());
+    set_test_env("PROSPER_GPU_CAPTURE_METADATA_ONLY", nullptr);
+    std::vector<uint8_t> gds_metadata_bytes;
+    GpuCaptureFile gds_metadata_loaded;
+    GpuReplayFrame gds_metadata_replay;
+    CHECK(gds_metadata_captured && gds_metadata_capture.blobs.empty() &&
+              gds_metadata_capture.dma_copies.size() == 1 &&
+              gds_metadata_capture.dma_copies[0].source_blob_index == 0xFFFFFFFFu &&
+              gds_metadata_capture.dma_copies[0].destination_blob_index == 0xFFFFFFFFu &&
+              serialize_gpu_capture(gds_metadata_capture, gds_metadata_bytes, error) &&
+              deserialize_gpu_capture(gds_metadata_bytes, gds_metadata_loaded, error) &&
+              materialize_gpu_replay(gds_metadata_loaded, gds_metadata_replay, error) &&
+              gds_metadata_replay.dma_copies.size() == 1 &&
+              !gds_metadata_replay.dma_copies[0].source_data &&
+              !gds_metadata_replay.dma_copies[0].destination_data,
+          "metadata-only memory-to-GDS capture materializes with unavailable backings explicit");
+
     GpuCaptureFile unsupported_gds_source = gds_capture;
     unsupported_gds_source.dma_copies[0].sels = 3u | (1u << 8) |
         kDmaDataAddressSource;
     CHECK(!serialize_gpu_capture(unsupported_gds_source, gds_capture_bytes, error) &&
-              error == "invalid ordered DMA record",
+              error == "unsupported ordered DMA GDS source selector",
           "capture rejects the unsupported GDS-to-memory direction fail-visibly");
+
+    GpuCaptureFile unsupported_gds_memory_selector = gds_capture;
+    unsupported_gds_memory_selector.dma_copies[0].sels =
+        1u | (2u << 8) | kDmaDataAddressSource;
+    CHECK(!serialize_gpu_capture(unsupported_gds_memory_selector, gds_capture_bytes, error) &&
+              error == "unsupported ordered DMA memory-to-GDS selector form",
+          "serialized memory-to-GDS capture rejects source selector 2 fail-visibly");
+
+    GpuCaptureFile unsupported_gds_source_kind = gds_capture;
+    unsupported_gds_source_kind.dma_copies[0].sels = 1u | (3u << 8);
+    unsupported_gds_source_kind.dma_copies[0].src = 0x5010;
+    CHECK(!serialize_gpu_capture(unsupported_gds_source_kind, gds_capture_bytes, error) &&
+              error == "unsupported ordered DMA memory-to-GDS selector form",
+          "serialized memory-to-GDS capture requires address-source semantics");
+
+    std::array<uint8_t, 4> rejected_gds_destination = {0x55, 0x66, 0x77, 0x88};
+    const std::array<uint8_t, 4> rejected_gds_source = {0xaa, 0xbb, 0xcc, 0xdd};
+    ReplayDmaCopy rejected_gds_replay;
+    rejected_gds_replay.dst = 0x24;
+    rejected_gds_replay.src = 0x5010;
+    rejected_gds_replay.bytes = 4;
+    rejected_gds_replay.sels = 1u | (2u << 8) | kDmaDataAddressSource;
+    rejected_gds_replay.command_order = 20;
+    rejected_gds_replay.destination_data = rejected_gds_destination.data();
+    rejected_gds_replay.destination_size = rejected_gds_destination.size();
+    rejected_gds_replay.source_data = rejected_gds_source.data();
+    rejected_gds_replay.source_size = rejected_gds_source.size();
+    execute_ordered_items(gds_dma_only_operations, {}, {}, {rejected_gds_replay}, {}, {}, 1, 1);
+    CHECK((rejected_gds_destination == std::array<uint8_t, 4>{0x55, 0x66, 0x77, 0x88}),
+          "replay executor refuses a retained GDS copy with source selector 2");
 
     GpuState failed_state;
     set_pgm(failed_state, P::SPI_SHADER_PGM_LO_ES, P::SPI_SHADER_PGM_HI_ES, kDiagnosticVs);

--- a/prosper/tests/test_gpu_capture.cpp
+++ b/prosper/tests/test_gpu_capture.cpp
@@ -1986,6 +1986,82 @@ int main(int argc, char** argv) {
     CHECK((invalidations == std::vector<std::pair<uint64_t, uint64_t>>({{0x5000, 4}})),
           "replay DMA invalidates renderer caches by captured guest destination identity");
 
+    // Selector-1 destinations belong to the capture's shared internal GDS instance. They have no
+    // guest destination blob and must mutate the exact backing consumed by later compute work.
+    std::vector<uint8_t> initial_gds(64u * 1024u, 0);
+    initial_gds[0x24] = 0x19;
+    auto gds_table = std::make_shared<ShaderResourceTable>();
+    ShaderResource gds_resource{};
+    gds_resource.cls = ResourceClass::ConstantBuffer;
+    gds_resource.binding = kComputeInternalGdsBinding;
+    gds_resource.gpu_addr = 0;
+    gds_resource.size = initial_gds.size();
+    gds_resource.stride = 4;
+    gds_resource.host_data = initial_gds.data();
+    gds_resource.host_data_size = initial_gds.size();
+    gds_table->resources = {gds_resource};
+    ComputeItem gds_consumer;
+    gds_consumer.spirv = {0x07230203, 74};
+    gds_consumer.resources = gds_table;
+    gds_consumer.dispatch_index = 201;
+    gds_consumer.command_order = 30;
+    GpuState::DmaCopy gds_copy{
+        0x24, 0x5010, 4, 1u | (3u << 8) | kDmaDataAddressSource, 20, 0xabc4};
+    const std::vector<SubmitOperation> gds_operations = {
+        {SubmitOperationKind::DmaCopy, 0, 20},
+        {SubmitOperationKind::Dispatch, 201, 30},
+    };
+    GpuCaptureFile gds_capture;
+    CHECK(capture_submit_items({}, {gds_consumer}, gds_operations, meta, ordered_reader,
+                               gds_capture, error, {}, {}, {gds_copy}) &&
+              gds_capture.dma_copies.size() == 1 && gds_capture.blobs.size() == 1 &&
+              gds_capture.dma_copies[0].destination_blob_index == 0xFFFFFFFFu &&
+              gds_capture.dma_copies[0].destination_blob_offset == 0,
+          "memory-to-GDS capture stores only the guest source blob");
+    std::vector<uint8_t> gds_capture_bytes;
+    GpuCaptureFile gds_loaded;
+    GpuReplayFrame gds_replay;
+    CHECK(serialize_gpu_capture(gds_capture, gds_capture_bytes, error) &&
+              deserialize_gpu_capture(gds_capture_bytes, gds_loaded, error) &&
+              materialize_gpu_replay(gds_loaded, gds_replay, error) &&
+              gds_replay.dma_copies.size() == 1 && gds_replay.computes.size() == 1 &&
+              gds_replay.computes[0].resources &&
+              gds_replay.dma_copies[0].destination_data ==
+                  gds_replay.computes[0].resources->resources[0].host_data + 0x24,
+          "selector-1 destination round-trips into the shared captured GDS instance");
+    std::vector<SubmitOperation> gds_replay_operations;
+    for (const auto& operation : gds_replay.operations)
+        if (operation.realized)
+            gds_replay_operations.push_back({operation.kind,
+                                             static_cast<size_t>(operation.source_index),
+                                             operation.command_order});
+    std::array<uint8_t, 4> gds_observed{};
+    invalidations.clear();
+    set_guest_gpu_write_observer([&](uint64_t addr, uint64_t size) {
+        invalidations.emplace_back(addr, size);
+    });
+    execute_ordered_items(
+        gds_replay_operations, gds_replay.items, gds_replay.computes,
+        gds_replay.dma_copies, {},
+        [&](const std::vector<ComputeItem>& items) {
+            std::memcpy(gds_observed.data(),
+                        items[0].resources->resources[0].host_data + 0x24,
+                        gds_observed.size());
+            return true;
+        }, 1, 1);
+    set_guest_gpu_write_observer({});
+    CHECK((gds_observed == std::array<uint8_t, 4>{0xa1, 0, 0, 0}),
+          "later replay compute observes the ordered memory-to-GDS copy");
+    CHECK(invalidations.empty(),
+          "replay never publishes a GDS offset as a guest GPU write");
+
+    GpuCaptureFile unsupported_gds_source = gds_capture;
+    unsupported_gds_source.dma_copies[0].sels = 3u | (1u << 8) |
+        kDmaDataAddressSource;
+    CHECK(!serialize_gpu_capture(unsupported_gds_source, gds_capture_bytes, error) &&
+              error == "invalid ordered DMA record",
+          "capture rejects the unsupported GDS-to-memory direction fail-visibly");
+
     GpuState failed_state;
     set_pgm(failed_state, P::SPI_SHADER_PGM_LO_ES, P::SPI_SHADER_PGM_HI_ES, kDiagnosticVs);
     set_pgm(failed_state, P::SPI_SHADER_PGM_LO_PS, P::SPI_SHADER_PGM_HI_PS, kDiagnosticBadPs);

--- a/prosper/tests/test_gpu_execute.cpp
+++ b/prosper/tests/test_gpu_execute.cpp
@@ -719,6 +719,127 @@ int main() {
               "memory-to-GDS authority reports only the guest source, not GDS+0x24");
     }
 
+    // Renderer-owned sources need not have CPU-readable guest backing. An exact live snapshot is
+    // authoritative for this ordered copy; InvalidRange must instead preserve GDS and poison a
+    // post-stall indirect consumer, while making the failure visible to the authority census.
+    {
+        constexpr uint64_t renderer_owned_source = 0x4000;
+        const uint32_t snapshot_value = 0x4D3C2B1Au;
+        uint8_t* gds = compute_gds_backing();
+        memset(gds + 0x30, 0, sizeof(snapshot_value));
+        CHECK(!guest_readable(renderer_owned_source, sizeof(snapshot_value)),
+              "renderer-owned DMA source is deliberately not guest-readable");
+
+        set_live_target_byte_range_reader(
+            [&](uint64_t addr, uint32_t bytes, std::vector<uint8_t>& output) {
+                if (addr != renderer_owned_source || bytes != sizeof(snapshot_value))
+                    return LiveTargetByteReadResult::NotFound;
+                output.resize(bytes);
+                memcpy(output.data(), &snapshot_value, bytes);
+                return LiveTargetByteReadResult::Success;
+            });
+        GpuState ordered;
+        ordered.dma_copies.push_back({
+            0x30, renderer_owned_source, sizeof(snapshot_value),
+            1u | (3u << 8) | kDmaDataAddressSource, 100, 0});
+        std::vector<ComputeAuthorityBoundary> authority_boundaries;
+        set_compute_authority_boundary_observer(
+            [&](const ComputeAuthorityBoundary& boundary) {
+                authority_boundaries.push_back(boundary);
+            });
+        execute_ordered_and_present(ordered, W, H, 781, /*publish=*/false);
+        set_compute_authority_boundary_observer({});
+        uint32_t copied = 0;
+        memcpy(&copied, gds + 0x30, sizeof(copied));
+        CHECK(copied == snapshot_value,
+              "authoritative live snapshot supplies an otherwise unreadable memory-to-GDS source");
+        CHECK(authority_boundaries.size() == 3 &&
+                  authority_boundaries[1].kind == ComputeAuthorityBoundaryKind::Dma &&
+                  authority_boundaries[1].range_known &&
+                  authority_boundaries[1].address == renderer_owned_source &&
+                  authority_boundaries[1].bytes == sizeof(snapshot_value),
+              "renderer-owned source retains its exact guest identity in authority evidence");
+
+        const uint32_t sentinel = 0xA5A5A5A5u;
+        memcpy(gds + 0x30, &sentinel, sizeof(sentinel));
+        set_live_target_byte_range_reader(
+            [&](uint64_t addr, uint32_t bytes, std::vector<uint8_t>&) {
+                return addr == renderer_owned_source && bytes == sizeof(snapshot_value)
+                    ? LiveTargetByteReadResult::InvalidRange
+                    : LiveTargetByteReadResult::NotFound;
+            });
+        uint16_t indices[3] = {0, 1, 2};
+        uint32_t stale_args[5] = {3, 1, 0, 0, 0};
+        GpuState failed = st;
+        failed.draws.clear();
+        failed.dispatches.clear();
+        failed.dma_copies = ordered.dma_copies;
+        failed.parser_stalls.clear();
+        failed.ordered_memory_effects.clear();
+        failed.index_type = 0;
+        failed.parser_stalls.push_back({150});
+        GpuState::Draw indirect;
+        indirect.indexed = true;
+        indirect.index_base = reinterpret_cast<uint64_t>(indices);
+        indirect.indirect = true;
+        indirect.indirect_args_addr = reinterpret_cast<uint64_t>(stale_args);
+        indirect.command_order = 200;
+        failed.draws.push_back(indirect);
+        uint32_t backend_draws = 0;
+        authority_boundaries.clear();
+        set_submit_renderer([&](const std::vector<DrawItem>& items, uint32_t, uint32_t) {
+            backend_draws += static_cast<uint32_t>(items.size());
+            return RenderedFrame{};
+        });
+        set_compute_authority_boundary_observer(
+            [&](const ComputeAuthorityBoundary& boundary) {
+                authority_boundaries.push_back(boundary);
+            });
+        execute_ordered_and_present(failed, W, H, 782, /*publish=*/false);
+        set_compute_authority_boundary_observer({});
+        set_submit_renderer({});
+        set_live_target_byte_range_reader({});
+        memcpy(&copied, gds + 0x30, sizeof(copied));
+        CHECK(copied == sentinel && backend_draws == 0,
+              "InvalidRange leaves GDS unchanged and poisons the dependent indirect draw");
+        CHECK(std::any_of(authority_boundaries.begin(), authority_boundaries.end(),
+                          [](const ComputeAuthorityBoundary& boundary) {
+                              return boundary.kind == ComputeAuthorityBoundaryKind::Dma &&
+                                     !boundary.range_known;
+                          }),
+              "InvalidRange emits an explicit DMA failure boundary");
+    }
+
+    // The reverse selector form is deliberately unsupported. Its GDS source offset must never be
+    // published as guest authority, while the valid guest destination and failure stay observable.
+    {
+        uint32_t destination = 0xCAFEBABEu;
+        GpuState reverse;
+        reverse.dma_copies.push_back({
+            reinterpret_cast<uint64_t>(&destination), 0x24, sizeof(destination),
+            3u | (1u << 8) | kDmaDataAddressSource, 100, 0});
+        std::vector<ComputeAuthorityBoundary> authority_boundaries;
+        set_compute_authority_boundary_observer(
+            [&](const ComputeAuthorityBoundary& boundary) {
+                authority_boundaries.push_back(boundary);
+            });
+        execute_ordered_and_present(reverse, W, H, 783, /*publish=*/false);
+        set_compute_authority_boundary_observer({});
+        CHECK(destination == 0xCAFEBABEu,
+              "unsupported GDS-to-memory DMA fails without mutating guest memory");
+        CHECK(authority_boundaries.size() == 4 &&
+                  authority_boundaries[0].kind ==
+                      ComputeAuthorityBoundaryKind::SubmitBegin &&
+                  authority_boundaries[1].kind == ComputeAuthorityBoundaryKind::Dma &&
+                  authority_boundaries[1].range_known &&
+                  authority_boundaries[1].address ==
+                      reinterpret_cast<uint64_t>(&destination) &&
+                  authority_boundaries[2].kind == ComputeAuthorityBoundaryKind::Dma &&
+                  !authority_boundaries[2].range_known &&
+                  authority_boundaries[3].kind == ComputeAuthorityBoundaryKind::SubmitEnd,
+              "reverse DMA reports guest destination plus failure, never GDS source as a VA");
+    }
+
     {
         DrawItem draw_resource_probe;
         draw_resource_probe.command_order = 321;

--- a/prosper/tests/test_gpu_execute.cpp
+++ b/prosper/tests/test_gpu_execute.cpp
@@ -686,6 +686,39 @@ int main() {
               "authority hook preserves submit, DMA, draw audit, and end order");
     }
 
+    // #1732: an ordered memory-to-GDS DMA consumes one guest/render-target source range, but its
+    // destination is an offset in the private GDS share. Publishing GDS+0x24 as a second guest
+    // authority range reproduces the same domain confusion that used to poison Astro Bot's waits.
+    {
+        uint32_t source = 0x7A6B5C4Du;
+        uint8_t* gds = compute_gds_backing();
+        memset(gds + 0x24, 0, sizeof(source));
+        GpuState ordered;
+        ordered.dma_copies.push_back({
+            0x24, reinterpret_cast<uint64_t>(&source), sizeof(source),
+            1u | (3u << 8) | kDmaDataAddressSource, 100, 0});
+        std::vector<ComputeAuthorityBoundary> authority_boundaries;
+        set_compute_authority_boundary_observer(
+            [&](const ComputeAuthorityBoundary& boundary) {
+                authority_boundaries.push_back(boundary);
+            });
+        execute_ordered_and_present(ordered, W, H, 78, /*publish=*/false);
+        set_compute_authority_boundary_observer({});
+        uint32_t copied = 0;
+        memcpy(&copied, gds + 0x24, sizeof(copied));
+        CHECK(copied == source,
+              "production ordered executor copies mapped memory into the GDS share");
+        CHECK(authority_boundaries.size() == 3 &&
+                  authority_boundaries[0].kind ==
+                      ComputeAuthorityBoundaryKind::SubmitBegin &&
+                  authority_boundaries[1].kind == ComputeAuthorityBoundaryKind::Dma &&
+                  authority_boundaries[1].range_known &&
+                  authority_boundaries[1].address == reinterpret_cast<uint64_t>(&source) &&
+                  authority_boundaries[1].bytes == sizeof(source) &&
+                  authority_boundaries[2].kind == ComputeAuthorityBoundaryKind::SubmitEnd,
+              "memory-to-GDS authority reports only the guest source, not GDS+0x24");
+    }
+
     {
         DrawItem draw_resource_probe;
         draw_resource_probe.command_order = 321;

--- a/prosper/tests/test_wait_barrier.cpp
+++ b/prosper/tests/test_wait_barrier.cpp
@@ -300,6 +300,38 @@ int main() {
               "rejected gated DMA discards its deferred completion suffix without signaling");
     }
 
+    // GDS offsets are outside guest-address dependency domains, but they are not outside stream
+    // order. The same unsatisfied wait must still reject a downstream retained memory-to-GDS copy;
+    // otherwise excluding GDS+0x24 from address overlap would also let it overtake the barrier.
+    {
+        volatile uint64_t cond = 0;
+        uint32_t source = 0xA1B2C3D4u;
+        uint64_t completion = 0;
+        uint8_t* gds = compute_gds_backing();
+        memset(gds + 0x24, 0, sizeof(source));
+        const uint64_t src = reinterpret_cast<uint64_t>(&source);
+        uint32_t stream[8 + 7 + 7] = {};
+        emit_wait_eq(stream, reinterpret_cast<uint64_t>(&cond), 1);
+        stream[8] = PM4(7, IT_NOP, R_DMA_DATA);
+        stream[9] = 0x24;
+        stream[11] = static_cast<uint32_t>(src);
+        stream[12] = static_cast<uint32_t>(src >> 32);
+        stream[13] = sizeof(source);
+        stream[14] = 1u | (3u << 8) | kDmaDataAddressSource;
+        emit_release(stream + 15, reinterpret_cast<uint64_t>(&completion), 1);
+        GpuState st;
+        run_cb(stream, 22, st);
+        CHECK(st.dma_copies.size() == 1 && st.dma_execution_rejected,
+              "WAIT_DEFER stream gate still rejects a downstream memory-to-GDS copy");
+        cond = 1;
+        flush_deferred_streams();
+        execute_nonrender_submit_work(st);
+        uint32_t copied = 0;
+        memcpy(&copied, gds + 0x24, sizeof(copied));
+        CHECK(copied == 0 && completion == 0,
+              "rejected gated memory-to-GDS copy cannot overtake its wait or signal completion");
+    }
+
     // A copy also depends on its source. A prior gated producer to S must prevent a later
     // address DMA(S->D) from reading stale S even when D itself is in an unrelated domain.
     {

--- a/prosper/tests/test_wait_barrier.cpp
+++ b/prosper/tests/test_wait_barrier.cpp
@@ -64,6 +64,20 @@ static void emit_dma_copy(uint32_t* buf, uint64_t dst, uint64_t src, uint32_t by
     buf[3] = (uint32_t)src; buf[4] = (uint32_t)(src >> 32);
     buf[5] = bytes; buf[6] = 0;
 }
+static void emit_dma_gds_fill(uint32_t* buf, uint32_t dst_offset, uint32_t value,
+                              uint32_t bytes) {
+    buf[0] = PM4(7, IT_NOP, R_DMA_DATA);
+    buf[1] = dst_offset; buf[2] = 0;
+    buf[3] = value; buf[4] = 0;
+    buf[5] = bytes; buf[6] = 1u | (3u << 8);
+}
+static void emit_dma_memory_to_gds(uint32_t* buf, uint32_t dst_offset, uint64_t src,
+                                   uint32_t bytes) {
+    buf[0] = PM4(7, IT_NOP, R_DMA_DATA);
+    buf[1] = dst_offset; buf[2] = 0;
+    buf[3] = static_cast<uint32_t>(src); buf[4] = static_cast<uint32_t>(src >> 32);
+    buf[5] = bytes; buf[6] = 1u | (3u << 8) | kDmaDataAddressSource;
+}
 
 // Fold + drain the pipe-drain queue (upstream effects become guest-visible at a drain point).
 static size_t run_cb(const uint32_t* buf, size_t dwords, GpuState& st) {
@@ -330,6 +344,56 @@ int main() {
         memcpy(&copied, gds + 0x24, sizeof(copied));
         CHECK(copied == 0 && completion == 0,
               "rejected gated memory-to-GDS copy cannot overtake its wait or signal completion");
+    }
+
+    // GDS ordering also crosses fold boundaries. Fold A leaves a GDS immediate fill pending behind
+    // its wait. A later fold's same-span memory-to-GDS producer must not overtake it, but a copy to
+    // a disjoint GDS span remains independent and can execute immediately.
+    {
+        volatile uint64_t cond = 0;
+        const uint32_t same_span_source = 0x22222222u;
+        const uint32_t disjoint_source = 0x33333333u;
+        uint8_t* gds = compute_gds_backing();
+        memset(gds + 0x24, 0, 8);
+
+        uint32_t first_fold[8 + 7] = {};
+        emit_wait_eq(first_fold, reinterpret_cast<uint64_t>(&cond), 1);
+        emit_dma_gds_fill(first_fold + 8, 0x24, 0x11111111u, 4);
+        GpuState first_state;
+        run_cb(first_fold, 15, first_state);
+
+        uint32_t same_span_copy[7] = {};
+        emit_dma_memory_to_gds(same_span_copy, 0x24,
+                               reinterpret_cast<uint64_t>(&same_span_source), 4);
+        GpuState same_span_state;
+        run_cb(same_span_copy, 7, same_span_state);
+        CHECK(same_span_state.dma_copies.size() == 1 &&
+                  same_span_state.dma_execution_rejected,
+              "a later fold cannot overtake a pending write to the same GDS span");
+
+        uint32_t disjoint_copy[7] = {};
+        emit_dma_memory_to_gds(disjoint_copy, 0x28,
+                               reinterpret_cast<uint64_t>(&disjoint_source), 4);
+        GpuState disjoint_state;
+        run_cb(disjoint_copy, 7, disjoint_state);
+        CHECK(disjoint_state.dma_copies.size() == 1 &&
+                  !disjoint_state.dma_execution_rejected,
+              "a later fold may write a disjoint GDS span while the first span is pending");
+        execute_nonrender_submit_work(disjoint_state);
+
+        uint32_t before_release = 0, disjoint_value = 0;
+        memcpy(&before_release, gds + 0x24, 4);
+        memcpy(&disjoint_value, gds + 0x28, 4);
+        CHECK(before_release == 0 && disjoint_value == disjoint_source,
+              "only the disjoint GDS copy executes before the earlier wait releases");
+
+        cond = 1;
+        flush_deferred_streams();
+        execute_nonrender_submit_work(same_span_state);
+        uint32_t final_same_span = 0;
+        memcpy(&final_same_span, gds + 0x24, 4);
+        CHECK(final_same_span == 0x11111111u,
+              "the pending GDS fill lands in order and rejected later work cannot overwrite it");
     }
 
     // A copy also depends on its source. A prior gated producer to S must prevent a later

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -641,9 +641,13 @@ block-size fields, and metadata address. Version 12 captures the exact DCC contr
 validated single-sample/base-level SW_64KB_R_X layout; metadata-only and older capsules keep their absence
 explicit. Version 13 tags every temporal color RTT seed as `rgba8` or `rgba16f`, preserving its native byte
 width through standalone replay while reading v1..v12 seeds as the historical RGBA8 default.
-Version 14 appends address-backed `DMA_DATA` records with exact source and destination guest identities, byte
-counts, PM4 order, and content-addressed endpoint blob references. Replay mutates the same owned resource
-instances used by later draws and dispatches and invalidates renderer caches for the guest destination range;
+Version 14 appends address-backed `DMA_DATA` records with exact source and destination identities, selector
+domains, byte counts, PM4 order, and content-addressed endpoint blob references. A supported
+memory-to-GDS record (`dstSel=1`, `srcSel=3`, address source) binds its destination to a complete pre-submit
+64 KiB GDS snapshot even when that submit has no compute table; a later compute consumer aliases that same
+owned instance. Metadata-only capsules retain the record with both payload backings explicitly unavailable.
+Unknown selector directions remain fail-visible rather than replaying state that live execution rejected.
+Guest-memory copies still invalidate renderer caches for the guest destination range; GDS offsets never do.
 v1..v13 capsules remain readable and do not invent DMA operations.
 Version 37 appends each realized compute module's required subgroup size. A non-zero value recreates the exact
 `VkPipelineShaderStageRequiredSubgroupSizeCreateInfo` plus full-subgroups contract used by live rendering;


### PR DESCRIPTION
## Summary

- execute the exact address-backed `srcSel=3` memory → `dstSel=1` GDS form now emitted by Astro Bot
- keep GDS offsets out of guest-address overlap, cache notification, and authority tracking while preserving retained and WAIT_DEFER stream order
- make full offline captures own the complete pre-submit 64 KiB GDS state independently of same-submit compute, while metadata-only captures keep omitted payloads explicit
- validate the exact live selector/address-source contract independently in capture and replay
- add defect-shaped CPU coverage, bounded positive diagnostics, and the exact Astro result to the durable status/`Ruled out` record

Refs #1732.

## Exact gap

The post-#1927 retained evidence did not contain a guest-memory copy to VA `0x24`. It contained:

```text
src=0x56f6e6000 -> dst=0x24 bytes=4 dstSel=1 srcSel=3 sourceKind=address
```

Raw timeline evidence independently establishes low selector 1 as the 64 KiB GDS offset domain.
Current code retained the packet as an ordinary guest-memory `DmaCopy`. Guest topology then
classified the unmapped numeric value `0x24` as Unknown against every later guest wait, manufactured
`dma-overlaps=1`, and rejected each submit. The ordered executor also had no memory-to-GDS form, so
simply relaxing the overlap would still have dropped the real guest operation.

## Contract

This PR accepts only the observed generic direction:

- destination selector 1: GDS offset
- source selector 3 plus asserted/legacy address source: guest or renderer-owned memory
- complete mapped/readable source, or an authoritative renderer-owned source snapshot
- dword-aligned GDS offset and byte count
- complete destination span inside the 64 KiB GDS share

Unknown selector directions, GDS-to-memory, unmapped sources, partial/OOB spans, and malformed packets
remain fail-visible. The copy remains a retained submit operation. It updates the shared GDS backing
but emits no guest-write notification and no guest destination authority range. GDS offsets cannot
overlap guest wait/indirect addresses or WAIT_DEFER address domains, while an already-paused stream
still rejects a downstream copy so it cannot overtake the barrier.

`PROSPER_GDSLOG=1`/GFXLOG now emits a bounded sparse positive witness with ordinal, source, GDS
offset, bytes, command order, and selectors.

## Offline capture/replay closure

Full captures containing a memory-to-GDS DMA now retain the complete pre-submit 64 KiB GDS image in
a content-addressed backing. This works for a DMA-only submit with no compute table. When compute is
also present, the DMA destination and compute consumer materialize to the same owned instance and
the captured states must agree.

Metadata-only captures retain the ordered operation and selectors while leaving both source and
destination payloads explicitly unavailable. Capture serialization and replay execution each enforce
the exact supported `dstSel=1`, `srcSel=3`, address-source form independently. Selector 2, missing
address semantics, and the reverse GDS-source direction fail visibly.

## Verification

All commands ran inside the required `ps5ys` distrobox with a worktree-local build and `TMPDIR`.

Initial focused verification:

```text
cmake --build build --target \
  test_diag_ratelimit test_eop_write test_eop_write_sync_guard \
  test_wait_barrier test_agc_dcb test_gpu_execute prosper-app -j6

ctest --test-dir build --output-on-failure -R \
  "^(doc_table_checker|diag_ratelimit|eop_write|eop_write_sync_guard|wait_barrier|agc_dcb_pm4|gpu_execute)$"
```

Result: **7/7 passed**. Full app target also builds.

Exact current review-fix head: `ae21a6620f9a7f1d38bb677850818fbdfb580ccd`.

Clean tests at that exact head:

```text
test_gpu_capture   PASS
test_wait_barrier  PASS
test_eop_write     PASS
```

`test_gpu_execute` also passed in an exclusive-GPU run after the replay-executor guard was added;
the subsequent changes were limited to capture validation/materialization, their CPU regressions,
and documentation.

Coverage includes:

- exact memory → `GDS+0x24` data and retained-selector identity
- exact `memory-to-GDS -> WRITE_DATA(0) -> RELEASE_MEM32(1) -> WAIT(label==1)` defect shape
- command-order and positive-diagnostic witnesses
- no guest-write notification and no fictitious GDS destination authority range
- unmapped asserted source, OOB span, misaligned offset, non-dword count, wrong source selector, missing address semantics, and unsupported reverse direction
- WAIT_DEFER paused-stream non-overtake
- full DMA-only capture serialization/materialization/execution with exact pre-submit GDS bytes
- metadata-only DMA-only materialization with both omitted backings explicit
- pointer identity between the replay DMA destination and same-submit compute GDS consumer

### Self-validating mutations

Original execution-path mutations:

1. Remove the GDS destination-domain exemption: the exact unrelated-label wait and ordered-data checks fail.
2. Disable memory-to-GDS execution: overlap stays green, but copied data, order/data, and reporter checks fail.
3. Accept arbitrary source selectors: only the wrong-selector guard fails.
4. Restore a guest authority range for `GDS+0x24`: only the production authority check fails.
5. Let GDS bypass an already-paused WAIT_DEFER stream: only the two paused-stream non-overtake checks fail.

Review-fix capture/replay mutations:

1. Disable standalone GDS-snapshot materialization: only the DMA-only serialization/materialization and replay-execution checks fail; metadata-only and shared-compute controls remain green.
2. Require a captured GDS backing for metadata-only replay: only the metadata-only explicit-unavailability check fails.
3. Let capture validation accept source selector 2: only the serialized wrong-selector check fails.
4. Let the replay executor accept source selector 2: only the direct executor wrong-selector check fails.

## Natural Astro validation

One authorized full-scale/every-submit `prosper-app` run used real renderer, compute, FFmpeg/VA-API,
SDL audio, and SDL input backends; no pad route; 540-present target; 360-second hard bound. Exact-six
pre/post GPU-process censuses were empty.

The live candidate was exact commit `37eb14e79bc6e41c4aa153021293c95a921e451e`, based on master
`130ad451ad5c660f52d33b8a0408595115ecbec9`; binary SHA-256 was
`a57aae534bb0a135105f954104824c48b53949e33b29196be28bc9b5cf5e7d7a`.
The exact current head named above adds CPU-proven WAIT_DEFER ordering, self-contained capture/replay,
strict serialized selector validation, direct replay enforcement, and durable documentation after
that live run.

Results:

- 21 sparse memory-to-GDS witness lines: ordinals 1–16, 32, 64, 128, 256, and 512, proving at least 512 exact executions
- zero former ordered-wait rejection matches
- zero generic ordered-DMA submit rejection matches
- zero invalid `dst=0x24` DMA matches
- zero Vulkan device-loss or fatal matches
- normal exit at 540/540 presents
- progression beyond #1927:

```text
GAME: Level has started: title_controller_ship
LevelDocument Loaded: worldmap [worldmap]
```

The final app interval reported **2.9 fps**. This was a 601 MB high-volume GFXLOG diagnostic run,
not a controlled performance measurement, so no throughput improvement is claimed.

## Visual scope

The run produced no image artifact and makes no new visual-correctness claim. No screenshot is
attached. Existing compatibility wording already records the world-map backdrop state; this PR
proves corrected execution and control-flow progression, not corrected hub composition.

## Snapshots

Not run. Project policy makes snapshots optional for day-to-day PRs and mandatory before a release;
this focused change has direct defect-shaped CPU and live-title validation.
