### PR TITLE
docs(orchestration): record the wave 1 outcome

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,7 @@ shared-GPU policy, the instrument-not-the-subject list, and the dated current ha
 | *Dead Cells* `PPSA15552` | rung 6 — full-colour Prisoners' Quarters; `dead-cells-gameplay` guard | `docs/DEAD_CELLS_STATUS.md` |
 | *Blasphemous 2* `PPSA13579` | rung 6 — first playable room; `blasphemous2-gameplay` guard | `scripts/blasphemous2/README.md` |
 | *Alex Kidd in Miracle World DX* `PPSA02664` | rung 6 — resolved by #1578 (generic 4 KiB mip-tail tiling); `alexkidd-gameplay` guard | `docs/PPSA02664_BLACK_WORLD.md` (historical) |
-| *Blue Prince* `PPSA25009` | rung 5 — entrance hall matches the hardware reference; by-eye play-through still outstanding | `docs/BLUE_PRINCE_STATUS.md` |
+| *Blue Prince* `PPSA25009` | rung 6 — sustained Day One gameplay and the Mount Holly entrance hall; reviewed automatic gameplay snapshot guard (tracker #1808) | `docs/BLUE_PRINCE_STATUS.md` |
 | *Syberia: Remastered* `PPSA30140` | rung 3 — gameplay renders; menu 3D layer and gameplay composite degraded (#1619 / #1627) | `docs/SYBERIA_STATUS.md` |
 | *Dragon Quest VII Reimagined* `PPSA17942` (a.k.a. DOLL) | rung 2 — title, name entry, onboarding; composition defect and gameplay open | `docs/DRAGON_QUEST_STATUS.md` |
 | *Nikoderiko* `PPSA23760` | rung 2 — 3D world dropped; **blocked on #305**, not on the recompiler | `docs/NIKODERIKO_STATUS.md` |

--- a/prosper/docs/GAME_COMPAT_ORCHESTRATION.md
+++ b/prosper/docs/GAME_COMPAT_ORCHESTRATION.md
@@ -1565,6 +1565,36 @@ session of depth.
 | babylon-r1 | Asterix & Obelix Babylon (PPSA30490, Unity 6) | sampled 2D-MSAA resolve executes, output still black | #1884 / #1599 |
 | arcrunner-r1 | ArcRunner (PPSA21406, UE4 4.27) | real GPU submissions, then the render thread faults | #1817 / #1226 |
 
+#### Wave 1 outcome — all five merged, one rung gained, four blockers relocated
+
+| Title | Result | Landed |
+|---|---|---|
+| **The Oregon Trail** | **rung 0 → 1.** Renders `WBP_System_Disclaimer_Popup` on a *default* launch (4,009,938 non-black px). Screenshot committed. Enabled by #1933's ErrorDialog lifecycle, established by a single-variable A/B. | #1950 |
+| Asterix Babylon | Blocker moved **GPU → CPU**: the guest deadlocks in its video splash because `sceAvPlayerJumpToTime` is unimplemented and the dispatcher's default `0` reads as a successful seek. Kills the whole `DMEM_WRITE_TRACE` writer-hunt premise. | #1953 |
+| ArcRunner | The `addr=(nil)` sibling fault is **prosper's own lazy-commit zero**, not a guest lifetime bug — roughly five sessions had been classifying a value prosper wrote. The fault was never the rung-1 blocker either. | #1948 |
+| R-Type Delta | The issue's **standing recommendation** ("faithful, slower I/O timing wins the race") falsified quantitatively — it points the wrong way. Display-rate pacing also dead, on a lever-verified A/B. | #1947 |
+| Sonic Origins | Five hypotheses dead. The guest is alive, unblocked, and builds **exactly one frame forever** (22 submits / 22 draws / 14 dispatches per flip, constant over 11,274 flips). | #1952 |
+
+**Four new shared-substrate issues, three of which help titles beyond their lane:** #1944
+(lazy-commit hands the guest a zero), #1945 (guest UE4 pooled-allocator free-list corruption),
+#1949 (AvPlayer seek is missing from `VideoBackend` entirely), #1951 (APR resolve leaves later
+entries uninitialized after the first miss).
+
+**The cross-title link worth acting on.** ArcRunner (`eboot+0x127e751`) and Oregon Trail
+(`eboot+0x14600df`) both fault on `mov rax,[rcx]` with `rcx = 0x30016000`, popping a pooled-allocator
+free-list head — in **different guest binaries**. Either one shared prosper defect or one shared UE4
+guest pattern; nobody has separated those yet, and the answer decides where the fix goes. **Oregon
+Trail is now the fastest repro in the library**: 3 of 4 *default* launches die within 6 s, exit 90,
+no route or diagnostics. Work #1226 there, not on an ArcRunner boot.
+
+**Two lessons about the apparatus, both now traps.** Trap 85: an asset-load trace read as proof the
+guest executed the code using the asset — UE4 pulls a level's referenced classes through the map
+import table before any Blueprint runs, so the pre-fix arm loaded the same assets at identical
+ordinals over a 12× longer run. Trap 86: a generic-named shell redirect into the shared `~/` scratch,
+read as writing a private file. Also, recorded in the Sonic notes and worth propagating: **`.pad`
+route positions are pad reads, not seconds** — a committed 404-read route ends at t≈6.6 s in a
+~61 reads/s arm, so runs that looked input-driven were input-free through their whole steady state.
+
 ### Wave 2 (queued) — every rung-1 title, target rung 2 (title screen)
 
 The Forgotten City (PPSA03026, #1890), Sonic Racing: CrossWorlds (PPSA08804, #1895), Sonic Frontiers


### PR DESCRIPTION
Records the outcome of the 2026-08-04 rung-0 wave in the orchestration handoff. Docs only.

## All five lanes merged: #1947, #1948, #1950, #1952, #1953

| Title | Result |
|---|---|
| **The Oregon Trail** | **rung 0 → 1** — renders `WBP_System_Disclaimer_Popup` on a *default* launch, screenshot committed |
| Asterix Babylon | blocker moved **GPU → CPU**: unimplemented `sceAvPlayerJumpToTime`, dispatcher's default `0` read as a successful seek |
| ArcRunner | the `addr=(nil)` fault is **prosper's own lazy-commit zero**; ~five sessions had classified a value prosper wrote |
| R-Type Delta | the issue's **standing recommendation** falsified quantitatively — faithful slower I/O points the wrong way |
| Sonic Origins | five hypotheses dead; the guest builds **exactly one frame forever** |

## Why this belongs in the handoff rather than only in the title docs

**The cross-title link.** ArcRunner (`eboot+0x127e751`) and Oregon Trail (`eboot+0x14600df`) both fault on `mov rax,[rcx]` with `rcx = 0x30016000`, popping a pooled-allocator free-list head, in **different guest binaries**. Either one shared prosper defect or one shared UE4 guest pattern — unseparated, and the answer decides where the fix goes. **Oregon Trail is now the fastest repro in the library** (3 of 4 default launches die within 6 s, exit 90, no route or diagnostics), so #1226 should be worked there rather than on an ArcRunner boot. Neither title doc is the right place for that.

**Four new shared-substrate issues**, three helping titles beyond their lane: #1944, #1945, #1949, #1951.

**Two of the five results are corrections to previously recorded reasoning**, which is the expensive kind of knowledge: ArcRunner's null register, and R-Type's standing I/O-timing recommendation.

**Traps 85 and 86**, plus the `.pad`-positions-are-pad-reads finding — a committed 404-read route ends at t≈6.6 s in a ~61 reads/s arm, so runs that looked input-driven were input-free through their entire steady state.

## Verification

Docs-only. `check_numbered_table.py --sequential --table-header Instrument`: `14 table(s), 148 rows, contiguous and unbroken`. `git diff --check` clean. No host paths, no session trailers.

---

## Added: two stale rung claims corrected, and how I got one wrong

**Blue Prince** — the doc table said rung 5; its tracker (#1808) says **rung 6** (sustained Day One gameplay, Mount Holly entrance hall, reviewed automatic gameplay snapshot guard). CLAUDE.md makes the tracker authoritative for a title's rung, so the row was stale.

**A census I published in this document earlier today was wrong, and the mechanism matters more than the number.** I reported "6 titles at rung 1" and "5 at rung 0". I had extracted each rung with a regex for the first `Rung N` in the tracker body — and the tracker template contains a **six-rung checklist**, so the match was a checklist heading, not the assigned rung. Re-derived from each tracker's `## Current milestone` section only:

| | |
|---|---|
| rung 1 | **1** — The Oregon Trail, advanced today |
| rung 0 | **4** — ArcRunner, Asterix Babylon, R-Type Delta, Sonic Origins |
| **no rung assigned at all** | **6** — Bendy Dark Revival, Crisis Core Reunion, Little Nightmares III, Sonic Frontiers, Sonic Racing CrossWorlds, The Forgotten City |

"28 of 39 at a title screen or better" was unaffected and stands.

This changes the plan for the better: those six have **never had a bounded compatibility run on current master**, so they are the highest-value breadth targets rather than a rung-1 cohort — one boot each may place several directly at rung 1 or 2. Wave 2 is retargeted accordingly.

It is also exactly the class of error the instrument-trap list exists for — a number produced by the measuring apparatus rather than the subject — so the census now states that the rung must be read from the tracker's milestone section, not a body-wide match.
