### PR TITLE
docs(bendy): rung 0 — the guest stops after Unity's empty transition scene

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -51,7 +51,7 @@ Last updated: 2026-08-04
 | *Little Nightmares III* | `PPSA05143` | — | 🔬 Graphics setup; startup fault before title | [#1893](https://github.com/mattias800/prosper/issues/1893) |
 | *Crisis Core –Final Fantasy VII– Reunion* | `PPSA07809` | — | 🔬 CPU boot reaches initial AGC setup; no visual milestone | [#1894](https://github.com/mattias800/prosper/issues/1894) |
 | *The House of the Dead 2: Remake* | `PPSA24203` | — | 🚧 Training 1 gameplay | [#1896](https://github.com/mattias800/prosper/issues/1896) |
-| *Bendy and the Dark Revival* | `PPSA27624` | — | 🔬 CPU boot reaches media initialization; no visual milestone | [#1897](https://github.com/mattias800/prosper/issues/1897) |
+| *Bendy and the Dark Revival* | `PPSA27624` | Unity / IL2CPP | 🔬 Live frame loop; the guest stops on Unity's empty transition scene, so every frame is black | [#1897](https://github.com/mattias800/prosper/issues/1897) |
 | *Beneath* | `PPSA27640` | Unity / IL2CPP | 🚧 Title screen | [#1898](https://github.com/mattias800/prosper/issues/1898) |
 
 ## Screenshots and short descriptions
@@ -293,7 +293,12 @@ The route reaches Training 1 with a live rail-shooter camera, HUD, crosshair, an
 
 ## Bendy and the Dark Revival — `PPSA27624`
 
-No verified compatibility run has been recorded yet. See the [tracker](https://github.com/mattias800/prosper/issues/1897).
+The title boots into a live native Linux/Vulkan frame loop, and every composited frame is uniformly black, so no
+screenshot is published. The guest loads its Unity bootstrap scene and then `Core/2_General/Empty.unity`, never
+requests `Core/2_General/Game.unity` or any `Core/3_Sections/Section_*` scene, and submits exactly two draws per
+submit for the whole run — the empty scene rendered faithfully. Prosper rejects no shader, packet or format on this
+boot, and the sibling *Bendy and the Ink Machine* renders its menu from the same build as a positive control. See
+the [tracker](https://github.com/mattias800/prosper/issues/1897).
 
 ## Beneath — `PPSA27640`
 


### PR DESCRIPTION
Refs #1897, #1955, #1956. **One file, `COMPATIBILITY.md` (+7/−2).** First live-render contact with Bendy and the Dark Revival (PPSA27624). Prior lanes had recorded CPU/no-render baselines; this lane confirmed the stop still holds and got the graphics answer they could not.

## Rung 0, with evidence

10 samples over 100 s, unmodified `screenshot` frontend, default switches: `source-distinct=10 pixel-distinct=1 max-pixel-stale=90.0s`, every sample `crc=666f7b3f`. A retained PNG was decoded and **opened**: exactly one colour, `#000000`, across the whole 3840×2160 surface. Same `crc` as the 2026-08-03 run at `1e5d75f1`, so the state is stable across the intervening master. Black is explicitly not rung 1.

## The exact stopping point

**The guest loads its Unity bootstrap scene, then the literally-empty transition scene, and stops requesting scenes.** It opens `Media/level0` + `sharedassets0` and `Media/level1` + `sharedassets1`, then nothing. The build scene list in `Media/globalgamemanagers` (37 scenes) maps `level0` → `Core/1_Initialize/InitializeGame.unity` and `level1` → `Core/2_General/Empty.unity`; `level2` (`Core/2_General/Game.unity`) and every `Core/3_Sections/Section_S1xx_*` are never requested.

Consistently, `PROSPER_PROGRESS=2` reports **`draws_last=2` on every submit** from t=0 to t=88 s (22,191 submits / 22,191 flips / 22,053 presents). **`Empty.unity` rendered faithfully is two draws** — so prosper is drawing the scene it was given.

**Not a renderer defect.** With `PROSPER_DBG=1` the entire 30 s log is **46 lines**: zero `[recompile-reject]`, zero vertex rejects, zero `mimg`/`mubuf-unresolved`, zero skipped compute programs.

**Not a deadlock.** `tools/guest_bt --all` on a live 45 s-old process walked **79 threads**. Unity's main thread is inside `agc_driver_submit_dcb → execute_ordered_and_present`, FMOD is live, and `Loading.PreloadManager`, `Loading.AsyncRead`, 13 `Job.Worker`, 16 `Background Job.Worker`, 13 `AssetGarbageCollector`, 19 `Unity.PSN.PS5` workers and 3 `SaveData*` threads are all idle-parked in `k_wait_on_address`. The engine has nothing left to do; the render loop spins.

## The positive control is what makes those figures mean anything

Same binary, same env, no input, 90 s: the sibling **Bendy and the Ink Machine (PPSA27616)** — same Unity 2022.3.51f1, same publisher, same `ps5nggc` renderer — **renders its full-colour main menu at 3840×2160**, `draws_last=21..63`, 10 `[graphics-cfg]` lines, `pixel-distinct=3`. Instruments move and the substrate works, so every figure above is a property of the subject rather than of the apparatus.

## Two HLE defects found, one of them falsified as this title's blocker

**#1955** — `sceAvPlayerInit(Ex)`'s guest **file-replacement callback table** is declared at `hle_service.cpp:665` and carried in both init structs, but `AvpFileReplace` has exactly one reference in the entire HLE: its own declaration. `s_avp_addsourceex` reads only `d->uri.name`. So `Media/resources.resource` is opened at offset 0, where an FMOD **FSB5** bank sits, and FFmpeg correctly refuses it. This reframes the earlier FSB-v5 message without reopening that lane's correct falsification — the fix is honouring the guest's reader, not adding an FSB demuxer. Filed as a **leading hypothesis, not an established cause**: the ordering evidence is suggestive only.

**#1956** — `libSceNpTrophy2::sceNpTrophy2GetTrophyInfo` (`EwNylPdWUTM`) is **unregistered**, so it returns `SCE_OK` with the out-struct unwritten — the same bug class `hle_service.cpp:2595` documents and fixes for two siblings (#213). This title calls it **36× in 72 s**. **Falsified as this title's blocker** by a direct A/B whose lever was verified (the `36 x` entry vanished from the unimplemented table in the relinked executable) with nothing else changing: same `level0`/`level1`, same `draws_last=2`, same `crc=666f7b3f`. Both the defect and the falsification are recorded.

## No screenshot, no route, no code

Nothing renders, so no screenshot is claimable and none was committed. No route was checked in — there is no rendered state to navigate, and "input would advance it" was **not** falsified. One diagnostic A/B was run and reverted; the branch carries no code.

## Not verified

No input route tried. No IL2CPP managed symbolication (no `script.json`), so the managed method that stops requesting scenes is unnamed. No frame capture or `gpu_replay --inspect-only` of the two draws. Whether this title supplies a non-null file-replacement table — the named next experiment in #1955 — is unmeasured. `ctest` not run (no code change); Windows/macOS untested. No timing or FPS claim: the GPU was shared, submit counts are per-interval only, and the process census was 0 for all five consumers before and after every arm.
