### PR TITLE
docs: entitlement queries answer from local inventory, never blanket-approve

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -289,6 +289,22 @@ either, and do not read `RENDER_LOOP.md`'s "Status: open" as current.
   treat every one you hit on a live boot as the next thing to implement. Find the exact failing op with
   `PROSPER_DBG=1` (`[recompile-reject] pc=… op=0x…` from the recompiler) or the `[compute] … skipped`
   lines from the live backend, then implement it with a round-trip/execution test — do not leave it skipped.
+- **Entitlement and add-content APIs answer from LOCAL INVENTORY — never blanket-approve.** When a
+  title asks whether an add-on or entitlement is owned, prosper answers from the content actually
+  declared and present locally (`src/hle/hle_addcontent.cpp` parses real entitlement labels and keys
+  and rejects malformed or duplicated ones). That is the right design for a preservation tool, and it
+  is deliberate: a compatibility layer must keep working when the licensing service it would
+  otherwise consult no longer exists, so the answer has to be derivable offline.
+  **What must never happen is making these calls return "owned" unconditionally to get a title past a
+  check.** The distinction is not cosmetic. Faithfully reimplementing a *platform* query — what system
+  software this is, whether a user is signed in — is exactly the job, the same way Wine answers
+  `GetVersionEx`. Manufacturing a positive answer to an *ownership* query is not reimplementation; it
+  is the emulator performing the circumvention itself, and it would make prosper a circumvention tool
+  rather than a compatibility layer no matter how the code were phrased.
+  This is written down because the failure mode is attractive: a title stalls at a content check, one
+  `return 1` makes it progress, and the change looks like progress in a screenshot. If a title cannot
+  advance because content is genuinely absent, that is the honest result — record it as the blocker
+  and, if the content exists locally, wire it through the inventory. `CONFIDENCE: HIGH`.
 - **PR verification and merging.** Keep each PR description self-contained: link the issue or goal, explain the
   failure scenario and behavioral contract, summarize the approach and important invariants, identify affected
   and deliberately unaffected behavior, record risks, and list the exact build/test/snapshot commands and


### PR DESCRIPTION
Writes down a rule the codebase already follows, because the failure mode is attractive enough that someone will eventually "fix" a stalled title by breaking it.

## The rule

`src/hle/hle_addcontent.cpp` answers add-content and entitlement queries from the content **actually declared and present locally** — parsing real entitlement labels and keys, rejecting malformed and duplicated ones. That is the correct design for a preservation tool, and it is deliberate: the layer has to keep working when the licensing service it would otherwise consult no longer exists, so the answer must be derivable offline.

**What must never happen is making these calls return "owned" unconditionally to get a title past a check.**

## Why the distinction needs stating

Two things look similar in a diff and are not the same:

- Faithfully reimplementing a **platform** query — what system software this is, whether a user is signed in — is exactly the job. It is what Wine does answering `GetVersionEx`.
- Manufacturing a positive answer to an **ownership** query is not reimplementation. It is the emulator performing the circumvention itself, which would make prosper a circumvention tool rather than a compatibility layer, however the code were phrased.

The reason it needs to be explicit rather than assumed: a title stalls at a content check, a single `return 1` makes it progress, and the change *looks like progress in a screenshot*. That is precisely the shape of edit this repo's other standing rules exist to catch — it reads as "handled" when it is not.

If a title cannot advance because content is genuinely absent, that is the honest result: record it as the blocker, and wire the content through the inventory if it exists locally.

## Verification

Docs-only, no code touched. `check_numbered_table.py CLAUDE.md` clean; `git diff --check` clean; no host paths; no session trailers.
