### PR TITLE
docs(crisis-core): rung 0 — the first content load never returns

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -49,7 +49,7 @@ Last updated: 2026-08-04
 | *The Forgotten City* | `PPSA03026` | Unreal Engine | 🚧 Title screen | [#1890](https://github.com/mattias800/prosper/issues/1890) |
 | *Tactics Ogre: Reborn* | `PPSA03839` | — | 🚧 First tutorial battle | [#1892](https://github.com/mattias800/prosper/issues/1892) |
 | *Little Nightmares III* | `PPSA05143` | — | 🔬 Graphics setup; startup fault before title | [#1893](https://github.com/mattias800/prosper/issues/1893) |
-| *Crisis Core –Final Fantasy VII– Reunion* | `PPSA07809` | — | 🔬 CPU boot reaches initial AGC setup; no visual milestone | [#1894](https://github.com/mattias800/prosper/issues/1894) |
+| *Crisis Core –Final Fantasy VII– Reunion* | `PPSA07809` | Unreal Engine 4 | 🔬 Engine bootstrap completes; the first synchronous package load never returns, so no frame is composited | [#1894](https://github.com/mattias800/prosper/issues/1894) |
 | *The House of the Dead 2: Remake* | `PPSA24203` | — | 🚧 Training 1 gameplay | [#1896](https://github.com/mattias800/prosper/issues/1896) |
 | *Bendy and the Dark Revival* | `PPSA27624` | Unity / IL2CPP | 🔬 Live frame loop; the guest stops on Unity's empty transition scene, so every frame is black | [#1897](https://github.com/mattias800/prosper/issues/1897) |
 | *Beneath* | `PPSA27640` | Unity / IL2CPP | 🚧 Title screen | [#1898](https://github.com/mattias800/prosper/issues/1898) |
@@ -282,7 +282,12 @@ The CPU-only baseline reaches graphics setup, then faults on a denied low-addres
 
 ## Crisis Core –Final Fantasy VII– Reunion — `PPSA07809`
 
-No verified compatibility run has been recorded yet. See the [tracker](https://github.com/mattias800/prosper/issues/1894).
+The title is Unreal Engine 4.27 with IoStore packaging. It boots into a native Linux/Vulkan run and completes
+engine bootstrap — config, plugin manifest, asset registry, the global shader cache, the title's own shader
+archive and the Slate style set all load, 429 asset reads and no failures — and then the game thread blocks
+forever on its first synchronous package load. The engine never requests a single byte from the IoStore content
+container, submits exactly one command buffer carrying no draws, and composites no frame, so the display stays
+black and no screenshot is published. See the [tracker](https://github.com/mattias800/prosper/issues/1894).
 
 ## The House of the Dead 2: Remake — `PPSA24203`
 


### PR DESCRIPTION
Refs #1894, #1959. **One file, `COMPATIBILITY.md` (+7/−2).** First live-render contact with Crisis Core –Final Fantasy VII– Reunion (PPSA07809). Also restores a paragraph that was silently lost on master (below).

## Rung 0, with evidence

Two bounded `screenshot` arms on `b8898a18` (210 s / 14 samples and 240 s / 8 samples), UE recipe, in-container Vulkan build with `gpu_replay` present. Both agree exactly: `rendered_samples=0`, `max_frame_seq=0`, `max_present_count=1`. Every sample is 3840×2160 with **1 distinct colour and 0 non-black pixels** — a PNG was decoded and all four channels confirmed 0, not read off a metric. All guest activity ceases within the first 30 s.

**Positive control:** *The Pathless* (PPSA01826, also UE4), same binary and same env — `rendered_samples=8`, `max_frame_seq=4156`, title screen renders correctly by eye. The apparatus moves, so the zeros describe the subject.

## Engine, identified four independent ways

**Unreal Engine 4.27 with IoStore packaging.** `ue4commandline.txt` → `CCFF7R.uproject`; that `.uproject` inside `pakchunk0-ps5.pak` declares `"EngineAssociation": "UE_4.27.2Plus_Fair"`; the eboot carries `UnrealEngine4Runtime`; content ships as `.utoc`/`.ucas`. `self_dump` shows `libSceAmpr` linked; `guest_bt` reports the canonical UE4 thread set.

## The exact stopping point

`PROSPER_PROGRESS=5` emits exactly one line for the entire run: `submits=1 draws_last=0 dispatches=0 flips=0`.

The asset census is **429 reads, 42.0 MB, 0 failures, 262 distinct assets** — all engine bootstrap: global shader cache, the title's own shader archive, asset registry, plugin manifest, 189 Slate PNGs, ICU, config, localisation. **Not one read is ever issued against `pakchunk0-ps5.ucas`** (8.49 GB, every content package), although prosper resolves and registers it.

`guest_bt` walks 52 threads with no deadlock. The game thread blocks in `FEvent::Wait(MAX_uint32, false)` reached through UE4's synchronous load path — `edis.py` string resolution names the chain `StaticFindObjectFast` → `ResolveName` → `LoadPackageAsync` → virtual thunk → flush → infinite wait. `IoDispatcher` is parked in `k_eq_wait`; `RenderThread` and `RHIThread` are idle. **The first content load the title attempts never returns.**

**The `0x30016000` allocator fault was not seen**, in either arm — a third data point for #1945/#1226: this UE4 title does not reproduce it.

## A silent revert on master, restored here

Commit `1640bb30` ("docs: record first-run compatibility baselines") deleted the Crisis Core **and** Bendy CPU-baseline paragraphs that `dcf04846` had added minutes earlier, while adding its own — the take-a-file-whole trap that instrument-trap 41 exists for. Bendy's was later rewritten by `a833317a`; Crisis Core's stayed lost until this commit. I have asked for an audit of whether that commit removed anything else.

## A near-miss worth recording

The guest reads 2,550,808 bytes of `pakchunk0-ps5.utoc`, which is ~133 KB short of the header+IDs+offsets+blocks boundary **if `FIoChunkId` is 16 bytes**. It is 12: `33376×(12+10) + 151378×12 = 2,550,808` exactly. A plausible arithmetic near-fit that would have indicted prosper's read path for a guest-side non-event. Recorded as a ruled-out bullet on both #1894 and #1959.

## Not verified

Which package the game thread is loading (the `FName`/`FString` arguments are still on the guest stack — step 1 in #1959); which side of the async-loader handshake is missing; runs longer than 240 s; `PROSPER_DBG`/`PROSPER_GFXLOG` (with 0 draws and 0 dispatches a recompile-reject census would be vacuous, so this is an inference, not a measured zero); interactive `prosper-app`; capture/replay; audio; `ctest` (no code changed). No timing or FPS claims — GPU shared with three peer lanes throughout.
