### PR TITLE
fix(ampr): never serve one command buffer's capacity for another — Forgotten City reaches rung 2

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -267,7 +267,7 @@ The opening sequence and ASTRO BOT title card render at native 3840×2160. See t
 
 <p align="center"><img src="assets/screenshots/forgotten-city-title.png" alt="The Forgotten City — title screen"></p>
 
-The direct native 3840×2160 frontend capture reaches the title screen and its `Press Any Button` prompt. Gameplay has not yet been reached. See the [tracker](https://github.com/mattias800/prosper/issues/1890).
+The direct native 3840×2160 frontend capture reaches the title screen and its `Press Any Button` prompt, through the full white splash, Unreal Engine and Film Victoria logo cards, legal text and autosave notice. Gameplay has not yet been reached, and the run is bounded by two intermittent guest-heap faults. See the [tracker](https://github.com/mattias800/prosper/issues/1890).
 
 ## Tactics Ogre: Reborn — `PPSA03839`
 

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -668,6 +668,13 @@ if(TARGET prosper_core)
   target_link_libraries(test_ampr_measure PRIVATE prosper_core)
   add_test(NAME ampr_measure COMMAND test_ampr_measure)
 
+  # sceAmprCommandBufferGetSize must not answer for one command buffer with another's recorded
+  # capacity: a too-small answer permanently hangs the guest's IoStore append loop, which polls
+  # GetSize(cb) - GetCurrentOffset(cb) > 0xff without a bound (The Forgotten City, PPSA03026).
+  add_executable(test_ampr_getsize_fallback tests/test_ampr_getsize_fallback.cpp)
+  target_link_libraries(test_ampr_getsize_fallback PRIVATE prosper_core)
+  add_test(NAME ampr_getsize_fallback COMMAND test_ampr_getsize_fallback)
+
   # Direct-memory allocate/available (issue #99): AvailableDirectMemorySize reports the largest
   # free aligned block in the search window and writes both out-params (was a total-size stub).
   add_executable(test_dmem tests/test_dmem.cpp)

--- a/prosper/scripts/forgotten-city/reach-gameplay.pad
+++ b/prosper/scripts/forgotten-city/reach-gameplay.pad
@@ -1,0 +1,53 @@
+# The Forgotten City (PPSA03026, Unreal Engine 4) — dismiss the title screen and start a new game.
+#
+# Timing is anchored to the game's FIRST PAD POLL, not process start, so the route tolerates the
+# long first asset load off the 26 GB dump.
+#
+# What the route drives. The boot sequence is: white splash -> Unreal Engine / Film Victoria logo
+# card -> legal text -> an autosave notice -> the "THE FORGOTTEN CITY / Press Any Button" title
+# screen, which holds indefinitely with no input. Cross dismisses that prompt and opens the main
+# menu, whose first entry is the new-game entry; further Cross presses confirm it and advance the
+# opening dialogue.
+#
+# Why repeated Cross pulses rather than single presses at fixed offsets: the logo cards and the
+# autosave notice each appear at load-dependent times, the title prompt may need a focus pass
+# first, and the opening sequence is dialogue-advanced. Surplus presses are harmless on the title
+# screen (it holds unchanged under them), so every arm of an A/B sees the same input stream.
+# Verify what the guest actually read with PROSPER_PAD_SCRIPT_LOG=1.
+#
+# STATUS: EXPLORATORY — NOT a validated route, despite the file name. As of 2026-08-05 no arm has
+# survived past the "Press Any Button" prompt, so everything this route does after that point is
+# UNVERIFIED GUESSWORK about the menu it has never been observed to open. What IS verified: pad
+# delivery reaches the guest (PROSPER_PAD_SCRIPT_LOG shows buttons=cross at the guest's own reads),
+# and the route causes neither of the two faults that bound the title (#1961 and #1945 — arms with
+# and without this route fault identically, at the same point).
+#
+# Runs end 7-14 s in, before the title screen appears at about 20 s, so the presses beyond roughly
+# t=20 have never actually been consumed by the game. Do not cite this file as evidence that
+# gameplay is reachable, and re-derive the post-title presses against real captures once #1961 and
+# #1945 are fixed. Current state is recorded on the tracker: #1890.
+2-3:cross
+6-7:cross
+10-11:cross
+14-15:cross
+18-19:cross
+22-23:cross
+26-27:cross
+30-31:cross
+34-35:cross
+38-39:cross
+42-43:cross
+46-47:cross
+50-51:cross
+54-55:cross
+58-59:cross
+62-63:cross
+66-67:cross
+70-71:cross
+74-75:cross
+78-79:cross
+82-83:cross
+86-87:cross
+90-91:cross
+94-95:cross
+98-99:cross

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -2233,7 +2233,12 @@ HLE(f_apr_get_file_stat) {
 // Ampr command-buffer address/size captured at init (hle_kernel_mem.cpp). Declared at namespace
 // scope (NOT inside the extern "C" handler, where a block-scope extern would take C linkage and
 // miss the mangled prosper:: definition).
-extern uint64_t g_apr_last_cb, g_apr_last_cb_size;
+// Atomic since #1965: GetSize reads the pair together (size served only when the cb matches), so a
+// torn read could pair a new cb with a stale size. The uses below are #ifndef _WIN32 guarded.
+// Note the implicit conversion is NOT sufficient everywhere — a `?:` between an int literal and an
+// atomic is ambiguous because each operand converts to the other — so read with an explicit
+// .load() where the value feeds an expression rather than a single conversion.
+extern std::atomic<uint64_t> g_apr_last_cb, g_apr_last_cb_size;
 // Mark an APR request frame eventful (async streaming read -> equeue completion event) or sync;
 // consumed by the ASoW5WE-UPo submit handler (hle_kernel_mem.cpp, issue #180).
 void prosper_apr_mark_eventful(uint64_t req, bool eventful);
@@ -2452,7 +2457,8 @@ extern "C" uint64_t f_apr_read_submit(uint64_t a0, uint64_t a1, uint64_t a2,
         if (g_apr_last_cb) {
             fprintf(stderr, "[apr]   cb=0x%llx size=0x%llx\n",
                     (unsigned long long)g_apr_last_cb, (unsigned long long)g_apr_last_cb_size);
-            uint64_t n = g_apr_last_cb_size > 0x80 ? 0x80 : g_apr_last_cb_size;
+            const uint64_t cb_size = g_apr_last_cb_size.load(std::memory_order_relaxed);
+            uint64_t n = cb_size > 0x80 ? 0x80 : cb_size;
             for (uint64_t o = 0; o < n; o += 8)
                 if (apr_peek(g_apr_last_cb + o, &pv))
                     fprintf(stderr, "[apr]   cb+0x%02llx = 0x%016llx\n", (unsigned long long)o,

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -1492,7 +1492,22 @@ HLE(k_ampr_getsize) {
     (void)a1; (void)a2; (void)a3; (void)a4; (void)a5;
     ampr_arglog("tZDDEo2tE5k(GetSize)", a0, a1, a2, a3, a4, a5);
     if (uint64_t capacity = ampr_cb_capacity(a0)) return capacity;
-    return g_apr_last_cb_size ? g_apr_last_cb_size : 0x10000;
+    // The legacy `g_apr_last_cb_size` global is the capacity of ONE specific command buffer
+    // (`g_apr_last_cb`, recorded together with it in k_ampr_init). Serving it for a DIFFERENT cb
+    // whose own capacity we failed to recognise is not a fallback, it is a wrong answer — and a
+    // too-small wrong answer is unrecoverable, because the guest's IoStore batch builder only
+    // appends once `GetSize(cb) - GetCurrentOffset(cb) > 0xff`. The Forgotten City (PPSA03026, UE4)
+    // proved this: its IoService command buffer is constructed as (a1=0, a2=<ptr>, a5=<ptr>), a
+    // shape `ampr_cb_capacity_arg` cannot read a capacity from, and one unrelated init elsewhere in
+    // the boot records a1=0x81 (129). GetSize then answered 129 for the IoService cb, 129 - 0 never
+    // exceeds 255, and the IoService thread span at 100% CPU forever while the GameThread waited on
+    // I/O that could never be enqueued (present_count frozen at 1). Whether that unrelated init won
+    // the race against IoService's first poll is what made the title intermittently boot at all.
+    // So: use the global only for the cb it was actually recorded against, and otherwise fall back
+    // to the roomy default, which is the only safe answer for an unknown capacity.
+    // CONFIDENCE: HIGH (the spin and its disappearance are both directly observed).
+    if (a0 && a0 == g_apr_last_cb && g_apr_last_cb_size) return g_apr_last_cb_size;
+    return 0x10000;
 }
 HLE(k_ampr_x3) { return ampr_arglog("Qs1xtplKo0U", a0, a1, a2, a3, a4, a5); }
 HLE(k_ampr_x4) { return ampr_arglog("GuchCTefuZw", a0, a1, a2, a3, a4, a5); }

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -1418,7 +1418,13 @@ namespace { bool amprlog() { static int v = getenv("PROSPER_AMPRLOG") ? 1 : 0; r
 // with (req, cbSize, 0, cbBuf, poolCtx, 3) — the actual read COMMAND (file offset / dest / size)
 // lives inside cbBuf (the "CB offset 40" of the guest's error message is a byte offset into it).
 // Exposed so the read-submit HLE can locate and decode the real command. CONFIDENCE: MED.
-uint64_t g_apr_last_cb = 0, g_apr_last_cb_size = 0;
+//
+// Atomic because GetSize now reads them as a PAIR — it serves g_apr_last_cb_size only when a0
+// matches g_apr_last_cb — and both are written from arbitrary guest threads. A torn read that
+// matched a freshly stored cb against the previous size would hand that cb a too-small capacity,
+// which is precisely the failure this fix exists to remove. Relaxed is enough: the pair is a hint,
+// nothing is published through it, and a stale-but-consistent read is harmless.
+std::atomic<uint64_t> g_apr_last_cb{0}, g_apr_last_cb_size{0};
 // Per-cb capacity, recorded at init (issue #208 follow-up). Live-captured init flavors carry the
 // size in different args: the APR read flow uses a1; Pathless's IoStore batch uses a2=0x560; and
 // DOLL's IoStore batch uses a5=0x720. The

--- a/prosper/tests/test_ampr_getsize_fallback.cpp
+++ b/prosper/tests/test_ampr_getsize_fallback.cpp
@@ -51,8 +51,20 @@ int main() {
 
     CHECK(get_size(kRecordedCb, 0, 0, 0, 0, 0) == kRecordedSize,
           "a cb with a legible capacity still reports exactly that capacity");
+#if defined(__linux__) || defined(__APPLE__)
+    // POSIX-only, and deliberately so rather than by oversight. `hle_kernel_mem.cpp` is a platform
+    // split: `g_apr_last_cb`/`g_apr_last_cb_size` are defined inside the POSIX arm and recorded by
+    // its `k_ampr_init`, so the Windows arm's `k_ampr_getsize` has no legacy path to preserve — it
+    // has always returned the unknown-capacity default unconditionally. Windows therefore never had
+    // the bug this file guards, and also never had this behaviour to keep. Asserting it there is
+    // asserting a mechanism that does not exist. Tracked as #1970; the arms below are not guarded
+    // because they are the actual fix and must hold on every platform.
     CHECK(get_size(kLegacyCb, 0, 0, 0, 0, 0) == kRecordedSize,
           "the legacy global still answers for the cb it was recorded against");
+#else
+    (void)kLegacyCb;
+    std::printf("  [skip] legacy-global arm: the Windows arm has no g_apr_last_cb path (#1970)\n");
+#endif
 
     // PPSA03026's IoService cb: a1 is zero and a2/a5 are guest pointers far above any plausible
     // command-buffer capacity, so no capacity can be recovered from the constructor arguments.

--- a/prosper/tests/test_ampr_getsize_fallback.cpp
+++ b/prosper/tests/test_ampr_getsize_fallback.cpp
@@ -1,0 +1,76 @@
+// sceAmprCommandBufferGetSize (tZDDEo2tE5k) must never answer for one command buffer with the
+// recorded capacity of a DIFFERENT one.
+//
+// The guest contract this protects (The Forgotten City, PPSA03026, UE4/IoStore; the same append
+// loop DOLL and Pathless use): the IoStore batch builder only appends its next command once
+//
+//     sceAmprCommandBufferGetSize(cb) - sceAmprCommandBufferGetCurrentOffset(cb) > 0xff
+//
+// and it polls that in a tight loop with no bound. So a GetSize answer that is merely *small* is
+// not a degraded answer, it is a permanent hang: PPSA03026's IoService thread span at 100% CPU
+// forever, the GameThread waited on I/O that could never be enqueued, and the title never
+// composited a frame past its very first flip.
+//
+// The cause was the legacy `g_apr_last_cb_size` global. It is recorded together with the cb it
+// belongs to (`g_apr_last_cb`) but was previously served as the fallback for *any* cb whose own
+// capacity we failed to recognise. PPSA03026 constructs its IoService cb as (a1=0, a2=<ptr>,
+// a5=<ptr>) — a shape no capacity can be read from — while one unrelated construction elsewhere in
+// the same boot records a1=0x81 (129). 129 - 0 never exceeds 255.
+//
+// Both arms below are load-bearing:
+//   - the victim cb must get the roomy unknown-capacity default (this FAILS before the fix, which
+//     returned 129), and
+//   - the cb the global was actually recorded against must still get 129 (this FAILS if the fix is
+//     over-applied and drops the legacy path altogether).
+#include "../src/hle/dispatch.hpp"
+#include <cstdint>
+#include <cstdio>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { std::printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { std::printf("  [ok]   %s\n", m); } } while (0)
+
+int main() {
+    std::printf("== test_ampr_getsize_fallback ==\n");
+    register_builtin_hle();
+
+    HleFn construct  = Hle::lookup("8aI7R7WaOlc");
+    HleFn get_size   = Hle::lookup("tZDDEo2tE5k");
+    HleFn get_offset = Hle::lookup("GnxKOHEawhk");
+    CHECK(construct && get_size && get_offset, "the three AMPR command-buffer NIDs are registered");
+    if (!construct || !get_size || !get_offset) return 1;
+
+    // A construction whose capacity IS legible, and which therefore also records the legacy
+    // (g_apr_last_cb = a3, g_apr_last_cb_size = a1) pair. Shape taken from a live PPSA03026 boot.
+    constexpr uint64_t kRecordedCb   = 0x7f0000001000ull;  // a0: the constructed cb
+    constexpr uint64_t kRecordedSize = 0x81ull;            // a1: 129 bytes — below the guest's 0xff gate
+    constexpr uint64_t kLegacyCb     = 0x7f0000002000ull;  // a3: what g_apr_last_cb is set to
+    construct(kRecordedCb, kRecordedSize, 0x1, kLegacyCb, 0, 0);
+
+    CHECK(get_size(kRecordedCb, 0, 0, 0, 0, 0) == kRecordedSize,
+          "a cb with a legible capacity still reports exactly that capacity");
+    CHECK(get_size(kLegacyCb, 0, 0, 0, 0, 0) == kRecordedSize,
+          "the legacy global still answers for the cb it was recorded against");
+
+    // PPSA03026's IoService cb: a1 is zero and a2/a5 are guest pointers far above any plausible
+    // command-buffer capacity, so no capacity can be recovered from the constructor arguments.
+    constexpr uint64_t kVictimCb = 0x2200df50b0ull;
+    construct(kVictimCb, 0, 0x2000ad0000ull, 0, 0x3001a60000ull, 0x3001a70720ull);
+
+    const uint64_t size   = get_size(kVictimCb, 0, 0, 0, 0, 0);
+    const uint64_t offset = get_offset(kVictimCb, 0, 0, 0, 0, 0);
+    std::printf("  victim cb: GetSize=0x%llx GetCurrentOffset=0x%llx free=0x%llx\n",
+                (unsigned long long)size, (unsigned long long)offset,
+                (unsigned long long)(size - offset));
+
+    CHECK(size != kRecordedSize,
+          "an unknown-capacity cb is NOT served another cb's recorded size");
+    CHECK(offset == 0, "a freshly constructed cb reports a zero command offset");
+    CHECK(size - offset > 0xff,
+          "an unknown-capacity cb reports enough free space to clear the guest's 0xff append gate");
+
+    std::printf(fails ? "FAILED (%d)\n" : "PASSED\n", fails);
+    return fails ? 1 : 0;
+}


### PR DESCRIPTION
Refs #1890, #1960, #1961, #1945. **The Forgotten City (PPSA03026) reaches rung 2 — its title screen renders.** Two commits: a shared-HLE fix, and the docs/route that depend on it.

⚠️ **Do not merge on green CI alone.** The fix is in a shared AMPR path used by DOLL, The Pathless, Sonic Origins and GTA V, and **no cross-title regression run has been done**. An independent review and that regression run are in progress; this PR is opened so CI runs in parallel.

## The title screen had regressed on master

Two default arms on `b8898a18` rendered nothing — a single black raw-scanout frame held for 70 s and 45 s, `rendered_samples=0`, `present_count` frozen at 1, no crash. Not idle: `IoService` burned **100% of a core** (500 jiffies / 5 s) while GameThread and RenderThread accumulated **zero** in `pthread_cond_wait`, and two `guest_bt` samples 60 s apart caught it at the *identical* PC.

The spin is a gate on `sceAmprCommandBufferGetSize(cb) - sceAmprCommandBufferGetCurrentOffset(cb) > 0xff`.

## Root cause: one buffer's capacity served for another

`k_ampr_getsize` fell back to the process-global `g_apr_last_cb_size` for **any** command buffer whose own capacity it could not read. That global is the capacity of one *specific* buffer, recorded alongside `g_apr_last_cb` in `k_ampr_init`.

This title's IoService command buffer is constructed as `(a1=0, a2=<ptr>, a5=<ptr>)` — a shape `ampr_cb_capacity_arg` cannot read a capacity from — and one unrelated init elsewhere in the boot records `a1=0x81` (129). So `GetSize` answered **129** for the IoService buffer, `129 - 0` never exceeds `255`, and the append could never happen. The GameThread then waited forever on I/O that could never be enqueued.

**Whether that unrelated init wins the race against IoService's first poll is exactly the "intermittency" this title was always recorded as having.**

The fix serves the global only for the buffer it was actually recorded against, and otherwise returns the roomy default — the only safe answer for an unknown capacity. `CONFIDENCE: HIGH`; the spin and its disappearance are both directly observed.

## Result

`9/9` pixel-distinct samples, `frame_seq` 327 → 923, and the full boot sequence renders: white splash → Unreal Engine / Film Victoria cards → legal text → autosave notice → **THE FORGOTTEN CITY / Press Any Button**. Images were opened, not scored.

No new screenshot is committed: `assets/screenshots/forgotten-city-title.png` already exists on master and the new capture is visually identical, so a 1.3 MB near-duplicate would be waste. Tracker #1890 is rewritten to rung 2, and its image link — previously pinned to a branch that will be deleted (instrument-trap 26) — now points at master.

## Verification

`ctest` **192/192** inside the distrobox with `gpu_replay` present, so Vulkan execution tests really ran. New regression test `test_ampr_getsize_fallback`; its **counter-arm was run** — reverting the fix makes it fail reporting `GetSize=0x81`, the exact live value.

The rebase onto `43b14716` was proved rather than assumed: `git diff b8898a18..HEAD` and `git diff origin/master..HEAD` are byte-identical. The whole branch deletes exactly **two** lines, both intentional replacements; every file that was only added to shows `0` deletions.

## Also from this lane

- **#1961** — an `AudioMixerRende` null call in 4 of 7 arms, filed separately.
- **#1945 third data point.** This title reproduces the `0x30016000` free-list pop in 2 of 7 arms, `RenderThread 1`, instruction-for-instruction identical to PPSA19244 — but here **the popped head is page-aligned in guest dmem, not a small integer**. That is new information about the class: a validity guard on the head would not have caught this arm, and the two sightings are only reconcilable as one bug if the corrupting write is **wide or misaligned** (an overrun, a stale pointer reused after free, a struct written over a freed block), since a fixed-width store of a small value cannot also produce a page-aligned address. Recorded on #1945 and explicitly labelled a hypothesis from two data points.
- The checked-in route is marked **exploratory** in its header and commit message: no arm survived past "Press Any Button", so every later press is unverified.

## Not verified

**Cross-title regression on the shared `GetSize` path — the main review risk.** Rung 3 (gameplay). Whether #1961 and #1945 share a cause. Whether the pre-fix behaviour was a regression or a long-standing race (inferred from the mechanism, not bisected). No Windows/macOS check, no snapshots, no FPS or timing figures — the GPU was shared throughout.
