### PR TITLE
docs(sonic-racing): rung 0 — hard-blocked by #1960, which #1965 fixes

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -112,7 +112,9 @@ No verified compatibility run has been recorded yet. See the [tracker](https://g
 
 ## Sonic Racing: CrossWorlds — `PPSA08804`
 
-No verified compatibility run has been recorded yet. See the [tracker](https://github.com/mattias800/prosper/issues/1895).
+The Unreal Engine 5 guest completes core initialization and then stalls: its `IoService` thread spins on an
+IoStore command-buffer capacity query and no frame is produced. No visual compatibility milestone is claimed
+yet. See the [tracker](https://github.com/mattias800/prosper/issues/1895).
 
 ## Terminator 2D: NO FATE — `PPSA25872`
 


### PR DESCRIPTION
Refs #1895, #1960, #1965. **Docs only** — one `COMPATIBILITY.md` status line, no shared code. Sonic Racing: CrossWorlds (PPSA08804) stays **rung 0**, but its blocker is now identified as an existing, already-fixed defect.

## Rung 0, with evidence

Native 3840×2160 `screenshot` frontend, default switches: `max_present_count=0`, `max_frame_seq=0`, `rendered_samples=0`, **0 of 6 samples saved**, no `sceVideoOut`, no AGC submit, no flip. There were literally zero captures to open — confirmed against the manifest counters and the empty output directory rather than inferred.

**Positive control, same build and session:** The Messenger booted to 4/4 pixel-distinct intro-cutscene frames, `max_present_count=10615`, image opened and real. The apparatus is not why this title produces nothing.

## This title is hard-blocked by #1960 — and #1965 unblocks the stall

The engine goes far past what the `429821c8` baseline could see (that arm was CPU-only, bounded at 20 s). UE5 core init completes, 32 threads come up, then the process deadlocks against one spinning thread:

- `IoService` burns 100% of a core — **798/800** jiffies over 8 s, **998/1000** over 10 s.
- **All 31 other threads consume exactly 0**; the guest main thread sits in `k_cond_wait`.
- **No `RenderThread`, no `RHIThread` is ever created** — no GPU work is attempted at all.
- 26 `$pc` samples across two arms put `IoService` in `sceAmprCommandBufferGetSize`/`GetCurrentOffset`, their stubs, or the guest thunk above them.

`PROSPER_AMPRLOG` names it exactly. The `IoService` command buffer `0x2400000030` is constructed `a1=0x0 a2=<ptr> a3=0x0 a4=0x1ab8 a5=<ptr>`, so no capacity is legible, and `GetSize` falls through to `g_apr_last_cb_size` — last set to **`0x40`** by an unrelated buffer. `64 - 0` never exceeds `0xff`. **361,064 `GetSize` + 361,064 `GetCurrentOffset` calls on that one buffer in a single window.**

Same mechanism as The Forgotten City, different stale value (`0x40` vs `0x81`), different engine (UE5 vs UE4). **Two independent titles, one bug.**

**A/B with #1965's exact change** applied locally (diffed byte-for-byte against the PR): 0 flips → **1 flip**, 32 → **64 threads**, and the engine reaches full RHI and media bring-up — `RenderThread 0`, `RHIThread`, `RHIFrameFlipThr`, `AgcViewportThre`, `FAsyncLoadingTh`, plus the title's CRIWARE stack — and starts submitting audio.

**The rung still does not change.** That one flip is a uniform `RGBA(0,0,0,0)` scanout, established by decoding the PNG, and 7 samples over 240 s are identical. #1965 **relocates this title's frontier; it does not clear it.** The local A/B change was reverted; nothing shared is on this branch.

## Entitlement answers, as requested

Breakpoints on prosper's own handlers; **6 of 19 fired**, which is the control that makes the negatives meaningful. Called: `scePlayGoInitialize` (→0, 24 chunks discovered), `scePlayGoOpen` (→handle 1), `scePlayGoGetChunkId`, `scePlayGoGetLocus(n=24)` (all `LOCAL_FAST`), `sceAppContentTemporaryDataMount2` (→`/temp0`), `sceNpEntitlementAccessInitialize` (→0). Two **unregistered** PlayGo NIDs were answered with the dispatcher default 0: `scePlayGoGetSupportedOptionalChunk`, `scePlayGoGetInstallChunkId`.

**Not called before the stall**, though all imported: every `sceNpEntitlementAccessRequest*`/`Poll*`, `sceAppContentInitialize`, `sceAppContentGetAddcontInfoList`, `sceAppContentGetEntitlementKey`, all `libSceNpCommerce`. So the title asks *what is installed* and never asks *what am I entitled to* — the stall is upstream of any entitlement decision, and no answer prosper could give would change this run.

## No screenshot, no route, no new issues

Nothing rendered, so nothing was committed. The title stalls long before any prompt, so no route exists. No issue filed — #1960 already covers the defect and a new one would duplicate it.

## Two trap-table candidates, deliberately not appended

Numbers deferred to avoid a concurrent-append collision (87 is taken on an unmerged branch). Both will be filed once that lands:

1. **`pgrep -x <frontend> | head -1` selects a peer lane's process on this box.** A 52-thread backtrace showed `TaskGraphThread`×21 / `PoolThread N` — **UE4** naming — while every confirmed-PID sample of this UE5 title shows `Background Work` / `IOThreadPool #N`. It was almost certainly the concurrent Forgotten City run. Compounding it, `guest_bt --initlog` flattens modules from the paths in the log you pass, so its cache filenames read as provenance for the attached process and are not. Select by matching the dump id in `/proc/<pid>/cmdline`.
2. **`PROSPER_PROGRESS`/`PROSPER_PROGRESS_UNIMPL` emit from the GPU submit path**, so the unimplemented-NID call-count census is unavailable on exactly the titles that never submit — the rung-0 titles that need it most. Same family as traps 24/39: the instrument's emission gate excludes the population being studied.

## Not verified

Windowed `prosper-app` (all runs headless); ctest; Windows/macOS; any FPS or timing figure (GPU shared); snapshots; this binary's own append-loop disassembly (the `> 0xff` gate is inferred from #1960 — what was measured directly is the 1:1 call pairing and the spin clearing when `GetSize` returns `0x10000`); whether `a4=0x1ab8` is the buffer's true capacity (`ampr_cb_capacity_arg` never inspects `a4` — a possible refinement to #1965, offered as hypothesis only); what keeps the composite empty after the first flip with #1965 applied.
