### PR TITLE
tools(hle_calls): census every guest HLE call — and falsify #1968's premise

### DIFF
--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -162,6 +162,16 @@ the shipped runtime. Build them from `build-linux/` like everything else.
   guest thread under its **real engine thread name** (`RenderThread 1`, `TaskGraphThread`,
   `FAPREventQueueL`, …) with the prosper-side wait frame attached, which is usually enough to say
   which subsystem is stuck. See `guest_bt/README.md`.
+- **`hle_calls/`** — per-function call histogram over **every** HLE handler in the prosper binary,
+  taken from a live process over a bounded window: "which Sony functions is the guest calling *right
+  now*?". Complements `guest_bt` (which says where a thread is *parked*, and so says nothing about a
+  thread that is running). It exists because `PROSPER_SVCLOG=1` is opt-in per handler — ~1,035 handler
+  registrations against 94 `svc_log` call sites — so svc-log silence bounds the *instrumented*
+  surface, not the guest's traffic, and `PROSPER_PROGRESS_UNIMPL` counts only the handlers that do
+  **not** exist. Needs no rebuild and no gating env var: it enumerates handlers out of the binary by
+  their shared six-`unsigned long` signature and counts them with non-stopping gdb breakpoints.
+  Always pair a surprising zero with a handler you know fires — see the README's note on the
+  `hit_count` trap that made all 151 handlers read zero. See `hle_calls/README.md`.
 - **`re/pak_index.py`** — resolve UE4 `.pak` byte offsets to asset names, and decode a
   `PROSPER_FILELOG=1` run's `[apr] read-submit` stream into an ordered asset load trace. Answers
   "which map/blueprint/texture did the guest actually load, and where did loading stop?" offline,

--- a/prosper/tools/hle_calls/README.md
+++ b/prosper/tools/hle_calls/README.md
@@ -1,0 +1,70 @@
+# hle_calls
+
+**"Which Sony functions is the guest calling *right now*?"** — a per-function call histogram over
+**every** HLE handler in the prosper binary, taken from a live process over a bounded window.
+
+Reach for it when a title goes quiet — the frame loop is alive, nothing crashes, and you need to
+know what the guest is polling (or prove that it is polling nothing).
+
+## Why the existing instruments do not answer this
+
+| instrument | what it covers | the gap |
+|---|---|---|
+| `PROSPER_SVCLOG=1` | only handlers that call `svc_log` | opt-in per handler. Measured on the revision this tool was written against: **~1,035 registration sites (287 direct `register_fn` calls plus 748 through the `R("name", fn)` macro) against 94 `svc_log` call sites.** Most of the implemented Sony surface never appears in the log. |
+| `PROSPER_PROGRESS_UNIMPL=1` | per-NID counts for **unimplemented** NIDs | the exact complement — it cannot see a handler that exists. |
+| `guest_bt` | where a thread is *parked* | a thread that is running, not blocked, has no wait frame to report. |
+
+So "the stall shows only `sceUserServiceGetEvent` in the svc log" bounds the *instrumented* surface,
+not the guest's traffic. `hle_calls` closes that gap without an emulator rebuild or a gating env var:
+every handler shares the six-`unsigned long` HLE signature, so the tool enumerates them out of the
+binary with `nm` and counts them with non-stopping gdb Python breakpoints.
+
+## Usage
+
+```bash
+python3 tools/hle_calls/hle_calls.py --pid $(pgrep -x boot_trace) --ticks 400
+
+# only the libSce service layer (skip kernel / file / graphics handlers)
+python3 tools/hle_calls/hle_calls.py --pid <pid> --filter '^s_'
+```
+
+Flags: `--binary` (defaults to `/proc/<pid>/exe`), `--ticks N` (window length), `--clock SYMBOL`
+(what advances the window, default `prosper::k_usleep` — one or more entries per frame on every
+title observed so far), `--filter REGEX`, `--gdb PATH`, `--timeout SECONDS`.
+
+Output:
+
+```
+clock=prosper::k_usleep entries=400 armed=151
+      36  s_user_getevent
+      36  s_syss_getstatus
+distinct=2 total=72
+```
+
+## Reading a zero — and the trap this tool was built around
+
+An empty histogram with a **non-zero `entries`** is a real measurement: the guest entered no HLE
+handler while the clock advanced. An empty histogram with `entries=0` means the window never
+opened; that run is **void, not negative**.
+
+Always include a handler you independently know fires as a positive control before believing a
+surprising zero. `sceUserServiceGetEvent` (`s_user_getevent`) is a good default: engines poll it
+every frame.
+
+The first version of this tool read `gdb.Breakpoint.hit_count` for each handler. For a breakpoint
+whose Python `stop()` returns `False`, that reported **zero for all 151 handlers** — which reads
+exactly like "the guest called nothing at all" and was wrong. The counting now lives in the script's
+own state, and the positive control is what caught it. The same shape of mistake is why the header
+line always prints `entries` and `armed`: a result you cannot sanity-check against a known-live
+number is not a result.
+
+## Requirements
+
+Linux, `gdb` with Python support, `nm`/`c++filt`, and ptrace attach permitted
+(`kernel.yama.ptrace_scope=0`). The prosper binary must not be stripped.
+
+## Cost
+
+One trap per handler entry. On an idle/stalled guest this is free. On a title in full flight the
+trap rate can be thousands per second, which perturbs timing badly — use `--filter` to narrow the
+set, and never quote a frame rate from a run under this tool.

--- a/prosper/tools/hle_calls/hle_calls.py
+++ b/prosper/tools/hle_calls/hle_calls.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""hle_calls — "which Sony functions is the guest calling *right now*?"
+
+Attaches to a live prosper process and returns a per-function call histogram
+covering **every** HLE handler in the binary, over a bounded window.
+
+Why this is not `PROSPER_SVCLOG=1`: `svc_log` is opt-in per handler. On the
+revision this tool was written against, roughly 1,035 handler registrations were served
+by 94 `svc_log` call sites, so most of the implemented Sony surface is invisible
+to the svc log. "The stall shows only sceUserServiceGetEvent in the
+log" therefore bounds the *instrumented* surface, not the guest's real traffic —
+and that gap is exactly what you need closed when a title goes quiet and you
+want to know what it is polling. `PROSPER_PROGRESS_UNIMPL` has the complementary
+gap: it counts only the handlers that do NOT exist.
+
+This tool needs no emulator rebuild and no gating env var: it enumerates the
+handler symbols out of the prosper binary with `nm` (they all share the six
+`unsigned long` HLE signature) and counts them with non-stopping gdb Python
+breakpoints.
+
+Usage
+-----
+    python3 tools/hle_calls/hle_calls.py --pid $(pgrep -x boot_trace) \\
+        --binary build-linux/boot_trace --ticks 400
+
+    # only the libSce service layer, not kernel/graphics/file
+    ... --filter '^s_'
+
+Reading the result
+------------------
+The header line reports the window actually observed:
+
+    clock=prosper::k_usleep entries=400 armed=750
+
+An **empty histogram with a non-zero `entries`** is a real measurement: the
+guest entered no HLE handler while the clock advanced 400 times. An empty
+histogram with `entries=0` means the window never opened and the run says
+nothing — treat it as void, not as a negative.
+
+Include a handler you already know fires as your own positive control before
+believing a surprising zero (`sceUserServiceGetEvent` is a good one on almost
+any title: engines poll it every frame).
+
+Requirements: Linux, `gdb` with Python, `nm`, and ptrace attach permitted
+(`kernel.yama.ptrace_scope=0`). The prosper binary must not be stripped.
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import tempfile
+
+HLE_SIGNATURE = ("(unsigned long, unsigned long, unsigned long, "
+                 "unsigned long, unsigned long, unsigned long)")
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def enumerate_handlers(binary, name_filter):
+    """Every `prosper::`-scoped function with the six-arg HLE signature."""
+    nm = subprocess.run(["nm", binary], capture_output=True, text=True)
+    if nm.returncode != 0:
+        sys.exit("hle_calls: nm failed on %s: %s" % (binary, nm.stderr.strip()))
+    mangled = []
+    for line in nm.stdout.splitlines():
+        parts = line.split()
+        if len(parts) == 3 and parts[1] in ("t", "T"):
+            mangled.append((parts[0], parts[2]))
+    if not mangled:
+        sys.exit("hle_calls: no text symbols in %s (stripped build?)" % binary)
+
+    demangle = subprocess.run(["c++filt"], input="\n".join(m[1] for m in mangled),
+                              capture_output=True, text=True)
+    demangled = demangle.stdout.splitlines()
+    if len(demangled) != len(mangled):
+        sys.exit("hle_calls: c++filt returned %d names for %d symbols"
+                 % (len(demangled), len(mangled)))
+
+    pattern = re.compile(name_filter) if name_filter else None
+    seen, out = set(), []
+    for (addr, _), pretty in zip(mangled, demangled):
+        if HLE_SIGNATURE not in pretty or "prosper::" not in pretty:
+            continue
+        if "[clone .cold]" in pretty:
+            continue
+        short = pretty.split(HLE_SIGNATURE)[0]
+        short = short.replace("prosper::", "").replace("(anonymous namespace)::", "")
+        # A lambda/thunk whose *parameter list* merely contains the signature is
+        # not itself a handler; a real handler's name ends right at the '('.
+        if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", short):
+            continue
+        if pattern and not pattern.search(short):
+            continue
+        if short in seen:
+            continue
+        seen.add(short)
+        out.append((addr, short))
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--pid", type=int, required=True, help="live prosper process")
+    ap.add_argument("--binary", help="the prosper executable (default: /proc/<pid>/exe)")
+    ap.add_argument("--ticks", type=int, default=400,
+                    help="how many clock entries the window lasts (default 400)")
+    ap.add_argument("--clock", default="prosper::k_usleep",
+                    help="symbol whose entries bound the window (default prosper::k_usleep)")
+    ap.add_argument("--filter", default=None,
+                    help="regex; keep only handlers whose short name matches")
+    ap.add_argument("--gdb", default="gdb")
+    ap.add_argument("--timeout", type=int, default=600, help="seconds (default 600)")
+    args = ap.parse_args()
+
+    binary = args.binary or os.path.realpath("/proc/%d/exe" % args.pid)
+    if not os.path.exists(binary):
+        sys.exit("hle_calls: no such binary: %s" % binary)
+
+    handlers = enumerate_handlers(binary, args.filter)
+    if not handlers:
+        sys.exit("hle_calls: found no HLE handlers in %s "
+                 "(wrong binary, stripped build, or too narrow a --filter)" % binary)
+    print("hle_calls: %d handler symbols in %s" % (len(handlers), binary), file=sys.stderr)
+
+    with tempfile.NamedTemporaryFile("w", suffix=".syms", delete=False) as table:
+        for addr, name in handlers:
+            table.write("%s %s\n" % (addr, name))
+        syms_path = table.name
+
+    env = dict(os.environ)
+    env["HLE_CALLS_SYMS"] = syms_path
+    env["HLE_CALLS_CLOCK"] = args.clock
+    env["HLE_CALLS_TICKS"] = str(args.ticks)
+    cmd = [args.gdb, "-p", str(args.pid), "-batch",
+           "-x", os.path.join(HERE, "hle_calls_gdb.py")]
+    try:
+        run = subprocess.run(cmd, env=env, capture_output=True, text=True,
+                             timeout=args.timeout)
+    except subprocess.TimeoutExpired:
+        os.unlink(syms_path)
+        sys.exit("hle_calls: gdb timed out after %ds — result is void, not negative"
+                 % args.timeout)
+    os.unlink(syms_path)
+
+    body, keep = [], False
+    for line in run.stdout.splitlines():
+        if line == "HLE_CALLS_BEGIN":
+            keep = True
+            continue
+        if line == "HLE_CALLS_END":
+            keep = False
+            continue
+        if keep:
+            body.append(line)
+    if not body:
+        sys.stderr.write(run.stdout)
+        sys.stderr.write(run.stderr)
+        sys.exit("hle_calls: gdb produced no result block — VOID, not a negative")
+    print("\n".join(body))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/prosper/tools/hle_calls/hle_calls_gdb.py
+++ b/prosper/tools/hle_calls/hle_calls_gdb.py
@@ -1,0 +1,92 @@
+"""gdb-side of `hle_calls` — count every HLE handler entry over a bounded window.
+
+Loaded by `hle_calls.py` via `gdb -batch -x`. Reads its configuration from the
+environment so the driver can stay a plain subprocess call:
+
+    HLE_CALLS_SYMS    path to a "<hex-addr> <name>" table (one per line)
+    HLE_CALLS_CLOCK   symbol whose entries bound the window (default prosper::k_usleep)
+    HLE_CALLS_TICKS   how many clock entries to run for (default 400)
+
+Every handler gets a Python breakpoint whose `stop()` counts the hit and returns
+False, so the inferior is never actually stopped for the user. The count is kept
+in this script rather than read back from `Breakpoint.hit_count`: relying on
+hit_count for a non-stopping breakpoint silently reported zero for every handler
+in the first version of this tool, which reads exactly like "the guest called
+nothing" and is the trap this file exists to avoid.
+"""
+
+import os
+import gdb
+
+
+def _load_syms(path):
+    out = []
+    with open(path) as handle:
+        for line in handle:
+            parts = line.split()
+            if len(parts) != 2:
+                continue
+            out.append((int(parts[0], 16), parts[1]))
+    return out
+
+
+SYMS = _load_syms(os.environ["HLE_CALLS_SYMS"])
+CLOCK = os.environ.get("HLE_CALLS_CLOCK", "prosper::k_usleep")
+TICKS = int(os.environ.get("HLE_CALLS_TICKS", "400"))
+
+counts = {}
+state = {"ticks": 0}
+
+
+class _Counter(gdb.Breakpoint):
+    def __init__(self, addr, name):
+        super().__init__("*%#x" % addr, gdb.BP_BREAKPOINT)
+        self.silent = True
+        self.hle_name = name
+        counts[name] = 0
+
+    def stop(self):
+        counts[self.hle_name] += 1
+        return False
+
+
+class _Clock(gdb.Breakpoint):
+    def __init__(self, spec):
+        super().__init__(spec, gdb.BP_BREAKPOINT)
+        self.silent = True
+
+    def stop(self):
+        state["ticks"] += 1
+        return state["ticks"] >= TICKS
+
+
+gdb.execute("set pagination off")
+gdb.execute("set confirm off")
+
+armed = 0
+for addr, name in SYMS:
+    try:
+        _Counter(addr, name)
+        armed += 1
+    except gdb.error as exc:  # a symbol the running binary does not actually have
+        print("hle_calls: skip %s (%s)" % (name, exc))
+
+try:
+    _Clock(CLOCK)
+except gdb.error as exc:
+    raise SystemExit("hle_calls: cannot set the clock breakpoint on %s: %s" % (CLOCK, exc))
+
+print("hle_calls: armed %d handler breakpoints; window = %d entries of %s"
+      % (armed, TICKS, CLOCK))
+gdb.execute("continue")
+
+rows = sorted(((c, n) for n, c in counts.items() if c), reverse=True)
+print("HLE_CALLS_BEGIN")
+print("clock=%s entries=%d armed=%d" % (CLOCK, state["ticks"], armed))
+for count, name in rows:
+    print("%8d  %s" % (count, name))
+print("distinct=%d total=%d" % (len(rows), sum(c for c, _ in rows)))
+print("HLE_CALLS_END")
+
+gdb.execute("detach")
+gdb.execute("quit")


### PR DESCRIPTION
Refs #1891, #1968, #1967, #657. **New tool plus docs — no `src/` changes, no shared code.** Sonic Frontiers stays at **rung 1**, but #1968's premise is falsified and the frontier moves from the guest to prosper.

## #1968 said the guest stops submitting GPU work. It does not.

Measured on both sides of the `frame_seq` freeze **in the same process**, normalised to one game frame (`agc_dcb_set_flip`=1 and `sceUserServiceGetEvent`=1 in both windows, so the denominators are real):

| per frame | intro rendering | after the "freeze" |
|---|---|---|
| `agc_driver_submit_dcb` | 15 | 11 |
| `agc_dcb_draw_index_auto` | 1 | **4** |
| `agc_cb_dispatch` | 3 | **7** |
| `agc_patch_add_registers` | 109 | **340** |
| `agc_dcb_set_flip` | 1 | 1 |

**After the freeze the guest submits more work than while the logo renders.** `frame_seq` is prosper's *publish* counter, so the wall is **prosper not publishing a composited frame from work the guest is still handing it.** That relocates the frontier from guest logic to the renderer/present path.

**The original corroboration was an unlit instrument.** #1968 cited "zero AGC records in the second half" of a CPU-only arm — but a default CPU-only arm emits exactly **one** `[agc]` line for the entire run. The absence was the instrument, not the subject.

## The USM path is guest software — #1973 is entirely off this title

Definitively, not by inference: the eboot's 39 `DT_NEEDED` entries contain **no `libSceVideodec2`, no `libSceAvPlayer`, no `libSceAjm`**, and neither do any of the three `sce_module/` PRXs. CRI Sofdec2 is statically linked. `sonicteam_logo_4k.usm` is `mpeg_codec=1` (Sofdec.Prime), 3840×2160, 150 frames @ 30 fps — and it **works**, read to within 512 bytes of EOF with frames compositing correctly at 4K.

This matters beyond this title: the AvPlayer decode-worker EOF work in #1973 shares no code path here, so a fix there will not help Frontiers and should not be expected to.

## Also falsified, all recorded in #1968's new `## Ruled out`

- **The movie is not the gate.** `PROSPER_DENY_SUBSTR=.usm` reaches an identical terminal state (177 vs 178 opens — the difference *is* the denied movie).
- **No thread is blocked.** `guest_bt --all` across all 60 threads: every CRI and engine worker parked in ordinary idle waits; the main thread is in the engine's own frame limiter, running normally.
- **Not a `NO_COMPUTE` artifact.** CPU-only reaches the same state in ~5 s versus ~150 s live and parks at the byte-identical guest object, so it is a valid fast proxy.
- **#1967 is not the proximate cause** — three one-shot calls early in boot, zero json2 entries during the stall. Still a real latent defect; commented there.

## The tool: `prosper/tools/hle_calls/`

Answers *"which Sony functions is the guest calling right now"* across **every** handler. It closes a real gap: `PROSPER_SVCLOG` has **94 `svc_log` call sites against ~1,035 handler registrations**, so the existing instrument is blind to roughly 90% of the surface — which is exactly how #1968's premise survived. This tool produced the table above.

Per CLAUDE.md's "build tools, don't avoid them": it generalises to any title and any handler, and it is what turns "the guest went quiet" from a guess into a measurement.

## Two VOID results, recorded as void rather than negative

Both were caught by their own positive controls, which is the point of having them:

- gdb `WP_ACCESS` watchpoints **never armed** — the positive control also read zero, which is what exposed it.
- The first handler sweep relied on `gdb.Breakpoint.hit_count`, which **reports zero for non-stopping breakpoints**. It read "151 handlers, all zero" before the control caught it.

Both are written into the tool's README so the next user does not repeat them. Also recorded: the object at `eboot+0x1897a40` looks like a stalled boot task and is actually an allocator registration — the address itself is the main loop's should-I-exit predicate, correctly answering no.

## Graphics

The intro renders **correctly** — volumetric light streaks over grass and a sharp, correctly-coloured SONIC TEAM logo at 3840×2160. No new screenshot: the tracker already carries both captures and no title screen exists to add.

## Not verified

**Why prosper stops publishing** — that is the open frontier and it is untouched. Whether #657's skipped `64x64x6` cubemap-shaped dispatch contributes, now a live candidate since the failure is renderer-side. Audio output correctness (`audio2_ctx_push` runs at an unchanged 105/frame, but no PCM was analysed). Input response; the checked-in route was never exercised past the wall.
