### PR TITLE
docs(crisis-core): #1959 superseded by #1965 — the wall is now #1982, a two-title gap

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -49,7 +49,7 @@ Last updated: 2026-08-05
 | *The Forgotten City* | `PPSA03026` | Unreal Engine | 🚧 Title screen | [#1890](https://github.com/mattias800/prosper/issues/1890) |
 | *Tactics Ogre: Reborn* | `PPSA03839` | — | 🚧 First tutorial battle | [#1892](https://github.com/mattias800/prosper/issues/1892) |
 | *Little Nightmares III* | `PPSA05143` | Unreal Engine 4 | 🚧 Boot splash sequence; render thread stalls before the title | [#1893](https://github.com/mattias800/prosper/issues/1893) |
-| *Crisis Core –Final Fantasy VII– Reunion* | `PPSA07809` | Unreal Engine 4 | 🔬 Engine bootstrap completes; the first synchronous package load never returns, so no frame is composited | [#1894](https://github.com/mattias800/prosper/issues/1894) |
+| *Crisis Core –Final Fantasy VII– Reunion* | `PPSA07809` | Unreal Engine 4 | 🔬 Content streams and the engine submits real draws, then a declined GPU submit freezes every thread, so the display stays black | [#1894](https://github.com/mattias800/prosper/issues/1894) |
 | *The House of the Dead 2: Remake* | `PPSA24203` | — | 🚧 Training 1 gameplay | [#1896](https://github.com/mattias800/prosper/issues/1896) |
 | *Bendy and the Dark Revival* | `PPSA27624` | Unity / IL2CPP | 🚧 Health warning and title screen; the menu's background video is not composited | [#1897](https://github.com/mattias800/prosper/issues/1897) |
 | *Beneath* | `PPSA27640` | Unity / IL2CPP | 🚧 Title screen | [#1898](https://github.com/mattias800/prosper/issues/1898) |
@@ -299,12 +299,12 @@ stops advancing the composited frame and Unreal's own watchdog ends the run
 
 ## Crisis Core –Final Fantasy VII– Reunion — `PPSA07809`
 
-The title is Unreal Engine 4.27 with IoStore packaging. It boots into a native Linux/Vulkan run and completes
-engine bootstrap — config, plugin manifest, asset registry, the global shader cache, the title's own shader
-archive and the Slate style set all load, 429 asset reads and no failures — and then the game thread blocks
-forever on its first synchronous package load. The engine never requests a single byte from the IoStore content
-container, submits exactly one command buffer carrying no draws, and composites no frame, so the display stays
-black and no screenshot is published. See the [tracker](https://github.com/mattias800/prosper/issues/1894).
+The title is Unreal Engine 4.27 with IoStore packaging. It boots into a native Linux/Vulkan run, completes
+engine bootstrap, and now streams real content: 394 reads served from the 8.49 GB IoStore container, real GPU
+draws, and nine composited frames. Then prosper declines one GPU submit it cannot order safely, and because the
+whole submit is discarded the completion the guest is waiting for is never written — all ninety guest threads
+park, from the game thread's render fence down through the render and RHI threads. Every composited frame is
+black, so no screenshot is published. See the [tracker](https://github.com/mattias800/prosper/issues/1894).
 
 ## The House of the Dead 2: Remake — `PPSA24203`
 

--- a/prosper/tools/re/README.md
+++ b/prosper/tools/re/README.md
@@ -115,3 +115,31 @@ which content is actually resident first.
 Limits: unencrypted index only, pak index versions 10-11 (the v10+ encoded-entry + full-directory
 layout). IoStore `.utoc`/`.ucas` containers are a different format and are not handled. Run
 `--self-test` to check the entry decoder, the offset lookup, and the log parser without a pak.
+
+## `gstr.py` — name a stripped function by the strings it references
+
+`xref.py from <addr>` mostly prints `lea -> 0x…` / `load -> 0x…` into read-only data, and on a
+stripped native title those data addresses are the *only* way to identify a function. Feed them to
+`gstr.py` and the function names itself:
+
+```bash
+python3 tools/re/xref.py /tmp/eboot.elf from 0x2121d9e \
+  | awk '/^   (lea|load) /{print $3}' \
+  | python3 tools/re/gstr.py /tmp/eboot.elf - --strings-only
+0x700bd18      W"nothreadtimeout"
+0x705fd1e      W"GPU has hung or crashed!"
+0x718c6ca      W"GameThread timed out waiting for RenderThread after %.02f secs"
+```
+
+— so the guest frame at `eboot+0x2121d9e` is UE4's `GameThreadWaitForTask`, i.e. that thread is
+blocked on the render-command fence, not on the async loader. Three frames identified this way
+(`Create{Vertex,Index,Structured}Buffer_RenderThread`, `FlushRHIThreadFlushResourcesTotal`,
+`r.RHICmdAsyncRHIThreadDispatch`) turned a 90-thread `guest_bt` dump on `PPSA07809` into a named
+GameThread → RenderThread → RHIThread wait chain (#1982).
+
+`strings`/`objdump`/`readelf` cannot do this: `prx_to_elf.py` writes no section header table, so they
+reject the image, and none of them maps a VADDR to a file offset. `gstr.py` resolves the address
+through the image's `PT_LOAD` headers and auto-detects UTF-16LE (UE4's `TCHAR`) as well as ASCII.
+Addresses are image-relative, like every other tool here. An address that holds no string prints
+`bytes <hex>` and one outside every `PT_LOAD` prints `<unmapped>`, so a wrong address is visibly
+wrong rather than silently empty.

--- a/prosper/tools/re/gstr.py
+++ b/prosper/tools/re/gstr.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""gstr — print the string that lives at a guest VADDR in a flattened module image.
+
+`xref.py from <addr>` answers "what does this function reference", and most of what it prints is
+`lea -> 0x…` / `load -> 0x…` into the module's read-only data. On a stripped PS5 title those data
+addresses are the *only* way to name a function: a UE4 build has no symbols, but the function that
+holds `"GameThread timed out waiting for RenderThread after %.02f secs"` can only be one function.
+Turning those addresses into text by hand is the slow step, and `objdump`/`readelf`/`strings` cannot
+do it here — `tools/il2cpp/prx_to_elf.py` writes no section header table, so the usual tools reject
+the image outright, and `strings` has no way to map a VADDR to a file offset.
+
+gstr resolves a VADDR through the image's PT_LOAD program headers and prints what is there,
+auto-detecting UTF-16LE (UE4's TCHAR) as well as ASCII.
+
+    python3 tools/re/gstr.py <flat.elf> 0x718c6ca
+    0x718c6ca    W"GameThread timed out waiting for RenderThread after %.02f secs"
+
+The intended pipeline is to feed it every data reference of a frame's function at once:
+
+    python3 tools/re/xref.py <flat.elf> from 0x2121d9e \
+      | awk '/^   (lea|load) /{print $3}' \
+      | xargs python3 tools/re/gstr.py <flat.elf> \
+      | grep '"'
+
+Flatten a module first with `python3 tools/il2cpp/prx_to_elf.py <eboot.bin> <flat.elf>`, or reuse
+the images `tools/guest_bt/guest_bt.py` already caches under `tools/guest_bt/.cache/`.
+
+Addresses are **image-relative**, matching what `xref.py` and `edis.py` print: subtract the module
+load base before querying an address taken from a live backtrace.
+
+A non-string address prints `bytes <hex>` rather than nothing, so a wrong address is visibly wrong
+instead of silently absent, and an address outside every PT_LOAD prints `<unmapped>`.
+"""
+import argparse
+import struct
+import sys
+
+MIN_LEN = 3
+PT_LOAD = 1
+
+
+def load_segments(path):
+    """Return [(vaddr, filesz, offset)] for every PT_LOAD, plus the raw image."""
+    with open(path, "rb") as f:
+        data = f.read()
+    if data[:4] != b"\x7fELF":
+        raise SystemExit("%s: not an ELF image" % path)
+    if data[4] != 2:
+        raise SystemExit("%s: only ELF64 is supported" % path)
+    (phoff,) = struct.unpack_from("<Q", data, 0x20)
+    phentsize, phnum = struct.unpack_from("<HH", data, 0x36)
+    segs = []
+    for i in range(phnum):
+        o = phoff + i * phentsize
+        (p_type,) = struct.unpack_from("<I", data, o)
+        p_offset, p_vaddr, _p_paddr, p_filesz, _p_memsz = struct.unpack_from("<QQQQQ", data, o + 8)
+        if p_type == PT_LOAD:
+            segs.append((p_vaddr, p_filesz, p_offset))
+    if not segs:
+        raise SystemExit("%s: no PT_LOAD segments" % path)
+    return segs, data
+
+
+def read_at(segs, data, va, n):
+    for vaddr, filesz, offset in segs:
+        if vaddr <= va < vaddr + filesz:
+            avail = filesz - (va - vaddr)
+            start = offset + (va - vaddr)
+            return data[start:start + min(n, avail)]
+    return b""
+
+
+def as_utf16(buf):
+    """UE4 TCHAR strings are UTF-16LE. Require a printable, NUL-terminated run."""
+    out = []
+    for i in range(0, len(buf) - 1, 2):
+        unit = buf[i] | (buf[i + 1] << 8)
+        if unit == 0:
+            break
+        if unit < 0x20 or unit > 0x7E:
+            return None
+        out.append(chr(unit))
+    else:
+        return None                      # ran off the window with no terminator
+    return "".join(out) if len(out) >= MIN_LEN else None
+
+
+def as_ascii(buf):
+    out = []
+    for byte in buf:
+        if byte == 0:
+            break
+        if byte < 0x20 or byte > 0x7E:
+            return None
+        out.append(chr(byte))
+    else:
+        return None
+    return "".join(out) if len(out) >= MIN_LEN else None
+
+
+def describe(segs, data, va, window):
+    buf = read_at(segs, data, va, window)
+    if not buf:
+        return "<unmapped>"
+    wide = as_utf16(buf)
+    if wide is not None:
+        return 'W"%s"' % wide
+    narrow = as_ascii(buf)
+    if narrow is not None:
+        return 'A"%s"' % narrow
+    return "bytes " + buf[:24].hex()
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(
+        description="print the string at an image-relative guest VADDR in a flattened module image")
+    ap.add_argument("image", help="flattened module ELF (prx_to_elf.py output, or a guest_bt cache entry)")
+    ap.add_argument("addr", nargs="*", help="image-relative addresses (0x… or decimal); '-' reads stdin")
+    ap.add_argument("--window", type=lambda s: int(s, 0), default=512,
+                    help="maximum bytes to consider per address (default 512)")
+    ap.add_argument("--strings-only", action="store_true",
+                    help="print only addresses that decode to a string")
+    args = ap.parse_args(argv)
+
+    words = args.addr
+    if not words or words == ["-"]:
+        words = sys.stdin.read().split()
+    try:
+        addrs = [int(w, 0) for w in words]
+    except ValueError as exc:
+        raise SystemExit("bad address: %s" % exc)
+
+    segs, data = load_segments(args.image)
+    for va in addrs:
+        text = describe(segs, data, va, args.window)
+        if args.strings_only and not text.startswith(('W"', 'A"')):
+            continue
+        print("0x%-12x %s" % (va, text))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Refs #1894, #1959, #1982, #1945. **Tool plus docs — no `src/` changes.** Crisis Core stays **rung 0**, but its recorded blocker no longer exists and its real wall is a two-title shared-code gap.

## #1959 does not reproduce. #1965 fixed it as a side effect.

Every defining symptom of #1959 — *"the first content load never returns"* — is gone on `afe4a2b0`:

- **394 reads served from `pakchunk0-ps5.ucas`** (offsets `0x0` → `0x15f40000`), plus 655 more from the pak. Previously **not one byte** was ever read from it.
- Real draws, DCC fast-clears at 3840×2160, and **9 composited flips**.

The cause is **#1965** — `sceAmprCommandBufferGetSize` serving one command buffer's capacity for another, so `IoService` spun and the GameThread waited forever on I/O that could never be enqueued. That is precisely #1959's endpoint, **including the detail that made it strange**: `IoService` was the one thread *executing* rather than parked. No Crisis Core–specific work was needed.

#1959 closed as superseded, with the measurement table.

**This also answers a hypothesis I put to the lane and should not have:** this is **not** the #232/#208/#210/#984 undelivered-completion family, and it should **not** be merged with the peer lane investigating that family. Recorded so nobody re-links them.

## The real wall is #1982 — now a two-title blocker

```
[agc] ordered DMA submit rejected: Jump reads target/predication memory after retained DMA (order=15092)
```

Deterministic **3/3**, same order every run, and the last graphics event of the run. **prosper discards the entire submit including its ordered memory effects**, so the label the guest polls is never written.

`guest_bt` walks **90 threads, all parked**, and the new tool names the chain: GameThread in `GameThreadWaitForTask` (render fence) → `RenderThread 1` in the RHI-thread staller inside `Create{Vertex,Index,Structured}Buffer_RenderThread` → `RHIThread` inside AgcRHI → `AgcInterruptThr` waiting on a GPU event that never arrives. **The missing side is prosper's.**

**A/B with a visible lever** (the log line changes to `jump-skipped-only`, so the arms are distinguishable rather than identical): lifting the rejection takes the boot from guest frame ~25 to **f124**, mounts **all nine** pak containers, and `present_count` goes 9 → 18 within one second. **Both `skip` and `exec` clear it**, which localises the blocker to the *submit-wide decline* rather than to the jump itself.

The env-gated lever lives in `prosper/src/gpu/command_processor.cpp` and is **deliberately not pushed** — shared GPU code needs orchestrator sequencing. Default with the env unset is byte-identical to master; `ctest` 192/192 in the distrobox with `gpu_replay` present. The verbatim patch is posted on #1982 so it is in the record rather than only in a worktree.

## #1945 is on this title after all — fourth title, same constant

My brief told the lane #1945 was not seen here. **That was an artefact of never getting far enough.** Under the mutation, the title dies in 2–8 s with `FMallocBinned3 Attempt to free an unrecognized block 30016000` on the guest **RHIThread**, in the same AgcRHI frames it had been parked in. Recorded on #1945 with the crash site and slot dump.

## Rung and graphics

**Rung 0.** No screenshot published: every composited sample is `distinct_rgb_colors=1, nonblack_rgb_pixels=0`, and two samples 120 s apart are byte-identical (`pixel_crc32=666f7b3f`). Graphics correctness cannot be assessed — there are no pixels.

Startup facts recorded for whoever picks this up: `/Game/LV_BootGame.LV_BootGame`, `GameInstanceClass=/Script/Fair.FairGameInstance`, `bUseManaStartupMovies=False`.

## The tool

`prosper/tools/re/gstr.py` — what named the thread chain above. Second RE tool landed today alongside `tools/hle_calls/`, both from lanes that needed an answer the existing toolbox could not give.

## Not verified

Whether the mutation's DMA copies contribute to the #1945 corruption — arm A never executes them, and the identical constant appearing on unmutated master elsewhere is suggestive, not proof. Whether the 7 flips *before* the rejection being black is a second defect or legitimate pre-splash black. **Whether fixing #1982 alone reaches a title screen.** Windows/macOS. Snapshots. No FPS or timing claims — shared GPU.

One self-reported process error: a `pkill` on the outer `timeout` killed its child and lost a frozen process; recovered by relaunching.
