### PR TITLE
fix(agc): decline an ordered-DMA submit only on a real overlap — unblocks three titles

### DIFF
--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -3888,13 +3888,59 @@ void GpuState::apply(const Pm4Command& c) {
             // title frame REQUIRES the composite every frame on real hardware, and the condition
             // memory reads 0 throughout the title steady state, so 0 must mean "execute" here
             // ("skip when non-zero", matching PM4 SET_PREDICATION's draw-discard-on-set model).
-            if (!dma_copies.empty()) {
+            // #1982: decline only on a REAL overlap, the way the two sibling readers already do.
+            //
+            // This used to reject the whole submit whenever ANY DMA was retained, without asking
+            // whether that DMA touched the memory the jump reads. `SetRegsIndirect` (above) tests
+            // its register block against `retained_dma_destination_overlaps`, and `WaitRegMem`
+            // tests its label; only this site painted with the full brush. And because
+            // `dma_execution_rejected` discards the submit's ORDERED MEMORY EFFECTS along with the
+            // jump, the label the guest polls was never written at all — so the guest waited
+            // forever on a write prosper had decided to throw away.
+            //
+            // Two titles proved it, both stalling on the last graphics event of the run with every
+            // thread parked and the missing side ours: The Oregon Trail (PPSA19244, #1982) right
+            // after its health-warning screen, and Crisis Core (PPSA07809) with 90 threads parked
+            // through AgcRHI down to an `AgcInterruptThr` waiting on a GPU event that never came.
+            // Lifting the blanket decline took Crisis Core from guest frame ~25 to f124, mounted
+            // all nine pak containers, and doubled `present_count` within a second — and BOTH the
+            // skip-only and execute arms cleared it, which is what localises the defect to the
+            // submit-wide decline rather than to the jump.
+            //
+            // The jump reads exactly two things, so those are exactly what to test: the target
+            // segment it is about to run, and the predication condition that decides whether to run
+            // it. A retained DMA landing on either really would make the jump read stale bytes;
+            // anything else is unrelated traffic and must not cost the guest its label.
+            // CONFIDENCE: HIGH — the narrow contract is the one the sibling readers already use,
+            // and the blanket form is falsified by both titles clearing under either arm.
+            const uint64_t jump_bytes =
+                c.jump_valid ? static_cast<uint64_t>(c.jump_dwords) * 4u : 0u;
+            const bool jump_reads_dma =
+                !dma_copies.empty() &&
+                ((c.jump_addr && jump_bytes &&
+                  retained_dma_destination_overlaps(dma_copies, c.jump_addr, jump_bytes)) ||
+                 (c.jump_pred && pred_cond_addr &&
+                  retained_dma_destination_overlaps(dma_copies, pred_cond_addr, 8)));
+            const bool jump_reads_effect =
+                !ordered_memory_effects.empty() &&
+                ((c.jump_addr && jump_bytes &&
+                  retained_ordered_effect_destination_overlaps(
+                      ordered_memory_effects, c.jump_addr, jump_bytes)) ||
+                 (c.jump_pred && pred_cond_addr &&
+                  retained_ordered_effect_destination_overlaps(
+                      ordered_memory_effects, pred_cond_addr, 8)));
+            if (jump_reads_dma || jump_reads_effect) {
                 dma_execution_rejected = true;
                 static std::atomic<int> warned{0};
-                if (warned.fetch_add(1) < 24)
+                const uint64_t ord = warned.fetch_add(1) + 1;
+                if (ord <= 24 || (ord & (ord - 1)) == 0)
                     fprintf(stderr,
-                            "[agc] ordered DMA submit rejected: Jump reads target/predication "
-                            "memory after retained DMA (order=%llu)\n",
+                            "[agc] ordered DMA submit rejected #%llu: Jump reads target/predication "
+                            "memory overlapping a retained %s (target=0x%llx bytes=%llu "
+                            "cond=0x%llx order=%llu)\n",
+                            (unsigned long long)ord, jump_reads_effect ? "memory-effect" : "DMA",
+                            (unsigned long long)c.jump_addr, (unsigned long long)jump_bytes,
+                            (unsigned long long)pred_cond_addr,
                             (unsigned long long)command_order);
                 break;
             }


### PR DESCRIPTION
Refs #1982, #1962, #1959. **Shared GPU code.** The `Jump` case declined an entire ordered-DMA submit whenever *any* DMA was retained, without checking whether that DMA touched the memory the jump reads.

## The asymmetry

Three sites in `command_processor.cpp` read memory that a retained DMA might be about to write. Two of them ask whether it actually overlaps:

```cpp
SetRegsIndirect (3160)  retained_dma_destination_overlaps(dma_copies, c.regs_vaddr, regs_bytes)
WaitRegMem      (3689)  retained_dma_destination_overlaps(dma_copies, c.wm_addr, 8)
Jump            (3891)  if (!dma_copies.empty())   // ← the whole submit, unconditionally
```

That is not cosmetic, because `dma_execution_rejected` **discards the submit's ordered memory effects** along with the jump. Every fence and label write in it is thrown away, so the label the guest polls is never written and the guest waits forever on a write prosper decided to drop. The declined submit also **loses its EOP pulse rather than owing it** — a peer lane's `PROSPER_EOPLOG` census reads **2,706 FIRE, 1 SKIP(rejected), 0 OWE**, and that `0 OWE` is what proves nothing is merely late.

## Three titles, one line

| Title | Symptom |
|---|---|
| The Oregon Trail (PPSA19244) | stalls right after its health-warning screen (#1982) |
| Crisis Core (PPSA07809) | 90 threads parked, through AgcRHI down to an `AgcInterruptThr` waiting on a GPU event that never arrives |
| Little Nightmares III (PPSA05143) | submits stop dead 16 after the skip — reassigned from #1962 |

All three have every thread parked and the missing side ours.

## The fix

The jump reads exactly two things, so those are exactly what to test: the **target segment** it is about to run, and the **predication condition** deciding whether to run it. A retained DMA landing on either really would make it read stale bytes; anything else is unrelated traffic and must not cost the guest its label. This is the contract the sibling readers already use — the change makes the third site as narrow as the other two, not looser than them.

The rejection log now carries an ordinal with a sparse tail (instrument-trap 49) and names which of DMA or memory-effect overlapped, so its count can never be read as a population.

## A/B — one variable, same binary and environment

**Crisis Core:**

```
master   1 rejection (order=15092),  0 IoStore container reads
fixed    0 rejections,               6 .utoc + 6 .ucas reads
```

**Little Nightmares III:** 1 rejection → 0, and **4 distinct frames across 5 samples** where it previously froze. Its Bandai Namco splash renders correctly.

**Stated plainly: this clears the blocker, it does not by itself put either title at a title screen.** Crisis Core now faults later, and Little Nightmares III's own 100 s wall was not sampled by these runs. Both remain rung 1 / rung 0 respectively until a longer route says otherwise, so no screenshot is claimed as progression evidence.

## Corpus safety

Every reviewed guard on this build:

```
[check] alexkidd-gameplay:   OK (frames=50, richest=35386, structural_matches=50, nonblack=50)
[check] greak-gameplay:      OK (frames=90, richest=43267, structural_matches=90, nonblack=90)
[check] messenger-scene:     OK (frames=29, richest=32,    structural_matches=29, nonblack=29)
[check] dead-cells-gameplay: OK (frames=44, richest=9968,  structural_matches=44, nonblack=44)
```

`ctest` **192/192**, with `BUILD_RC` and `CTEST_RC` captured explicitly rather than through a pipe — a piped build hid a compile failure earlier today and then reported green from stale binaries.

## Not verified

Whether either title reaches a title screen with this alone. Whether the original blanket decline was protecting a case that the narrow check now lets through — the two sibling readers have used the narrow form for longer, and both titles cleared under *either* the skip-only or execute arm in the prior A/B, which is what localises the defect to the submit-wide decline rather than the jump; but I have not constructed a case where a jump genuinely reads a DMA destination. No Windows/macOS build. No new regression test for the overlap predicate itself — the four guards and the two live A/Bs are the evidence, and a focused unit test on `retained_dma_destination_overlaps` against jump ranges would be a good follow-up.
