### PR TITLE
docs(orchestration): batch the snapshot guards ~10 fixes deep and bisect a failure

### DIFF
--- a/prosper/docs/GAME_COMPAT_ORCHESTRATION.md
+++ b/prosper/docs/GAME_COMPAT_ORCHESTRATION.md
@@ -734,6 +734,21 @@ copy path, so a binding-miss run with the same environment is the control for a 
 
 - Focused tests are part of iteration. The full snapshot matrix is optional for ordinary development and PRs; the PR
   author decides whether it is useful.
+- **The default cadence is batched, not per-PR: run the guards once per ~10 merged fixes, then bisect a failure.**
+  Many PRs therefore merge with no guard validation at all, which is correct and intended — the guards exist to
+  replace manual play-testing of 39 titles before a release, not to certify every commit on master. A per-fix
+  cadence costs `N` guard runs; batching at `B=10` costs `N/10 + F·log₂10`, which at a 1-in-5 batch failure rate
+  is about **0.17·N** — a ~6x reduction, and still under `0.43·N` even if every batch regresses something. Both
+  cadences are linear in `N`, so this is a constant-factor win rather than a complexity-class one; it is a large
+  constant and it holds at any realistic failure rate, so do not re-derive this tradeoff per PR.
+  - **Re-run a failed guard on the same commit before spending the bisect.** A flaky guard makes `git bisect`
+    converge confidently on an innocent commit — an answer-shaped non-answer, worse than no signal. One extra
+    run protects the ~4 the bisect will spend. Guards that sample a route window are phase-sensitive, so this is
+    not a hypothetical (see the `blue-prince-hall` / `terminator-boot` note above).
+  - Automate with `git bisect run` over the guard's exit code; every candidate builds standalone because each fix
+    is its own merged commit. A batch can hold two independent regressions — bisect finds the earliest, so re-run
+    after fixing. Expect to attribute a regression to a lane that has already finished: the orchestrator owns the
+    fix, not the original author.
 - The snapshot matrix is mandatory before every release. A release delay is acceptable; day-to-day development should
   not be delayed solely to keep master regression-free.
 - Master may regress during heavy development. A correct fix may intentionally expose a different title regression.


### PR DESCRIPTION
## Why

The guards were being run **per-PR** — a four-guard matrix for a two-line renderer fix — which dominates wall-clock on a 39-title compatibility effort and slows every lane. This records the batched cadence as the default: **run the guards once per ~10 merged fixes, then bisect a failure across the batch.**

Project-owner decision (2026-08-05). This does not change any code or any guard.

## The arithmetic, recorded so it is not re-litigated per PR

| Cadence | Guard runs |
| --- | --- |
| Per fix | `N` |
| Batched at `B=10` | `N/10 + F·log₂10` |

At a 1-in-5 batch failure rate that is **≈0.17·N — a ~6x reduction**, and it stays under **0.43·N** even if *every* batch regresses something. So the policy holds at any realistic failure rate.

Worth stating precisely: both cadences are **linear in `N`**, so this is a large **constant-factor** win, not a complexity-class one. The doc says so, to keep the justification honest.

## The consequence, stated explicitly because it looks like a loss of rigor and is not

**Many PRs will now merge with no guard validation at all.** That is what the guards are for: they replace manual play-testing of 39 titles before a release. They were never a per-commit certificate — `CLAUDE.md` already states that *"snapshot results do not define whether master or an individual PR is acceptable: either may regress a guarded title, and a correct fix may even require an intentional cross-title tradeoff."* This change adds the positive cadence the doc was missing; the surrounding bullets (matrix optional for ordinary development, mandatory before every release, master may regress during heavy development) already said the negative half.

## Two safeguards, both from failures already paid for in this effort

- **Re-run a failed guard on the same commit before spending the bisect.** A flaky guard makes `git bisect` converge *confidently* on an innocent commit — worse than no signal, because it is answer-shaped. One extra run protects the ~4 the bisect spends. Route-window guards are phase-sensitive (the `blue-prince-hall` / `terminator-boot` note immediately above this section), so this is not hypothetical: a flaky test merged earlier this session failed 2-in-10 and read as stable off a single pass.
- **A batch can hold two independent regressions** — bisect finds the earliest, so re-run after fixing. Expect to attribute a regression to a lane that has already finished; the orchestrator owns the fix, not the original author. That is the accepted cost of batching: the regression is ~10 commits deep instead of 1.

`git bisect run` automates it over the guard's exit code — every candidate builds standalone, because each fix is its own merged commit.

## Affected / unaffected

- **Affected:** the documented default cadence for running `tools/snapshot/snapshot.py check` during ordinary development.
- **Unaffected:** every guard, route, and baseline; the pre-release mandatory full matrix; `snapshot.py verify` and the review requirement for new or materially changed baselines; all CI.

## Verification

Documentation only, one file, +15 lines, no table rows and no numbered instrument-trap entries — so the `Docs` gate's structure and sequential-numbering checks are untouched.

```
git diff --check origin/master..HEAD   -> rc=0
git diff --stat                        -> 1 file changed, 15 insertions(+)
```

Refs #1943