### PR TITLE
docs: state the positive half of the entitlement rule — content present in the dump must be reachable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -305,6 +305,30 @@ either, and do not read `RENDER_LOOP.md`'s "Status: open" as current.
   `return 1` makes it progress, and the change looks like progress in a screenshot. If a title cannot
   advance because content is genuinely absent, that is the honest result — record it as the blocker
   and, if the content exists locally, wire it through the inventory. `CONFIDENCE: HIGH`.
+  - **The positive half of the same rule, and it is an obligation: every feature and every piece of
+    content that IS in the dump must be reachable.** Under-reporting what is present is as much a
+    defect as over-reporting it would be a circumvention — it just fails in the direction that looks
+    safe, so nobody files it. A stub that answers a local-inventory question with 0 silently removes
+    content the user has, and the title is then behaving *correctly* on a wrong answer, which is the
+    hardest kind of bug to see: the game's own UI explains the problem in the game's own words, so it
+    reads as a licensing wall rather than as our defect.
+  - **The test that separates the two cases is whether the answer is derivable from bytes in the
+    dump.** "What SKU is this installed application?" is a *platform* query about local content —
+    `param.json`'s `contentId`, `applicationCategoryType`, `applicationDrmType` all state it offline,
+    so reimplement it faithfully, exactly as `GetVersionEx` is reimplemented. "Did this person buy X?"
+    is not derivable from anything local, and no amount of engineering makes it so — stop there and
+    record the cap. Derive; never hardcode a full/owned answer. A dump that is a free or trial SKU
+    must report that SKU, and the regression test proving you derived rather than hardcoded is a
+    **mutation arm where a synthesized free-SKU declaration yields the non-full answer**. Without that
+    arm the change is indistinguishable from `return <full>`.
+  - **Answer the same question the same way through every library that exposes it.** Sony surfaces SKU
+    and add-content state through more than one library, and a divergence between them is a defect
+    even when each path looks defensible alone. Worked example (#1873): `hle_service.cpp`'s
+    `sceAppContentAppParamGetInt` answered `SKU_FLAG` as full while
+    `sceNpEntitlementAccessGetSkuFlag` was unregistered and fell to the return-0 stub — so the answer
+    depended on which library the guest happened to ask through, and *Grand Theft Auto V* asks through
+    the NP one. Put the derivation in **one** place both paths call; if two paths can still disagree
+    after a fix, the defect has moved rather than gone.
 - **PR verification and merging.** Keep each PR description self-contained: link the issue or goal, explain the
   failure scenario and behavioral contract, summarize the approach and important invariants, identify affected
   and deliberately unaffected behavior, record risks, and list the exact build/test/snapshot commands and


### PR DESCRIPTION
## Why

The entitlement rule in `CLAUDE.md` was written entirely as a **prohibition** — never blanket-approve, never manufacture a positive answer to an ownership query. That half is correct and is unchanged here.

Read alone, though, it gives no guidance for the far more common case: **a local-inventory question answered with a stub 0.** An agent applying only the prohibition will leave that alone as "licensing", or even read implementing it as forbidden. Both are wrong, and the rule's own closing clause (*"if the content exists locally, wire it through the inventory"*) was the only hint otherwise.

Project-owner direction (2026-08-05): *"SKU and purchases are important for game preservation. We need to handle that so that we enable all features and content that are available in the game dump."*

## Why this failure mode is worse than an ordinary bug

It hides behind the game's own UI. A title told its content is absent explains that **to the user, in its own words, on its own screen** — so it reads as a licensing wall rather than as our defect. Nobody files it, because it does not look like a bug. Under-reporting fails in the direction that looks safe.

*Grand Theft Auto V* (#1873) is the worked example: prosper reaches the main menu, which renders correctly, and navigating to Story Mode produces an in-game screen saying story mode is a purchase. The title is behaving **correctly on a wrong answer from us.**

## The sharper test this adds

The categories "platform query" vs "ownership query" are right but hard to apply at the call site. The operative test is:

> **Is the answer derivable from bytes in the dump?**

- **"What SKU is this installed application?"** — yes. `param.json` states it offline (`contentId`, `applicationCategoryType`, `applicationDrmType`). Reimplement it faithfully, exactly the way `GetVersionEx` is reimplemented.
- **"Did this person buy X?"** — no, and no engineering makes it so. Stop and record the cap.

## Two requirements it makes explicit

1. **Derive, never hardcode — and prove it with a mutation arm** in which a synthesized free/trial-SKU declaration yields the **non-full** answer. Without that arm the change is indistinguishable from `return <full>`, which is the thing the prohibition exists to forbid. This is the pivotal point: the same diff is either faithful reimplementation or circumvention depending only on whether the value is derived, so the test has to be able to tell them apart.
2. **Answer the same question the same way through every library that exposes it.** `hle_service.cpp:2502`'s `sceAppContentAppParamGetInt` answers `SKU_FLAG` as full, while `sceNpEntitlementAccessGetSkuFlag` (`lPDO62PpJIA`) is unregistered and falls to the return-0 stub — so the answer depends on which library the guest happens to ask through. **Four dumps import the NP one.** One shared derivation both paths call; if two paths can still disagree after a fix, the defect has moved rather than gone.

## Affected / unaffected

- **Affected:** guidance only. No code, no behaviour, no test.
- **Unaffected:** the prohibition itself is untouched — no blanket-approve, no "unlock" switch (env-gated or otherwise), and a genuinely absent-content blocker is still recorded honestly rather than worked around. Online services remain out of scope: preservation cannot depend on a service that may be shut down.

## Verification

Documentation only, one file, +24 lines, no tables and no numbered instrument-trap entries, so the `Docs` gate's structure and gapless-numbering checks are untouched.

```
git diff --check origin/master..HEAD   -> rc=0
git diff --stat                        -> 1 file changed, 24 insertions(+)
```

Refs #1873