### PR TITLE
docs(orchestration): a third merge-gate hole — a running check reports conclusion="", not null

### DIFF
--- a/prosper/docs/GAME_COMPAT_ORCHESTRATION.md
+++ b/prosper/docs/GAME_COMPAT_ORCHESTRATION.md
@@ -758,7 +758,7 @@ copy path, so a binding-miss run with the same environment is the control for a 
 - Artifacts are uploaded only for a release. A release is created only for a Git release tag. Ordinary PR CI must show
   the release-publication job skipped.
 - Keep PRs short-lived so other agents inherit generic improvements quickly.
-- **Two mechanical holes in the merge gate, both of which let a PR read as satisfied when it is not.**
+- **Three mechanical holes in the merge gate, each of which lets a PR read as satisfied when it is not.**
   - **A registered review is not the same as a comment.** `gh pr comment` creates an *issue* comment;
     only `gh pr review --comment` appears in `gh pr view --json reviews` / `pulls/N/reviews`. A review
     posted the first way is fully visible on the PR page and invisible to the gate, so the findings
@@ -793,6 +793,25 @@ copy path, so a binding-miss run with the same environment is the control for a 
     This is not hypothetical — on #1687 the head moved **twice after the branch was called frozen**,
     and a reviewer guarding on `headRefOid` correctly refused both times. Posting unconditionally
     would have left `reviews[]` showing a perfectly healthy row bound to code that had moved on.
+  - **A running check reports `conclusion=""` — an empty string, not `null` — so a pending-count gate
+    written as `select(.conclusion==null)` returns 0 while jobs are still executing.** Observed
+    directly on #1991: `macOS (x86_64 / Rosetta 2)  conclusion=  state=null  status=IN_PROGRESS`,
+    while the same query reported zero pending. This is how #1952 merged with a check unfinished; that
+    was originally written off as a command-chaining slip, and the gate itself was the cause.
+    **Gate on a terminal-success allowlist, never on a pending denylist:**
+    ```bash
+    gh pr view <N> --json statusCheckRollup --jq '
+      [.statusCheckRollup[]?] as $c
+      | { total:   ($c|length),
+          notdone: ([$c[]|select((.conclusion//"")|IN("SUCCESS","SKIPPED")|not)]|length),
+          failed:  ([$c[]|select((.conclusion//"")|IN("FAILURE","CANCELLED","TIMED_OUT","ACTION_REQUIRED"))]|length) }'
+    ```
+    Merge only on `notdone == 0 && failed == 0 && total > 0 && mergeStateStatus == "CLEAN"`. The `//""`
+    coalesce is load-bearing. **The general rule is worth more than the `gh` detail: a filter that
+    enumerates the states you consider bad silently admits every state you did not think of** — so
+    enumerate what you accept and reject the complement. Note also how this hid: on the same day two
+    merges passed the broken gate *correctly*, because their success count already equalled the full
+    job count, and a gate that happens to agree with the right answer looks like a working gate.
 - The orchestrator opens the PR with a self-contained behavioral contract, issue links, evidence, exact tests, risks,
   and known limitations. Wait for all Linux, Windows, and macOS checks before merging.
 - When a game changes from black to visible content, reaches title, reaches gameplay, or materially improves visuals,


### PR DESCRIPTION
## The defect

The merge gate counted pending checks with `select(.conclusion==null)`. GitHub reports a **still-running** job as `conclusion=""` — an empty string — with `status=IN_PROGRESS`. An empty string is not `null`, so that filter returns **zero pending while jobs are still executing**, and the merge proceeds.

Observed directly on #1991:

```
name=macOS (x86_64 / Rosetta 2)   conclusion=   state=null   status=IN_PROGRESS
```

…while the same query reported `pending=0`.

**This is the real cause of #1952 merging with a check unfinished.** That was written off at the time as a command-chaining slip — the merge was chained after the status query instead of gated on it. The chaining was untidy, but it was not the defect: the gate could not see a running job at all.

## The fix — gate on a terminal-success allowlist, never a pending denylist

```bash
gh pr view <N> --json statusCheckRollup --jq '
  [.statusCheckRollup[]?] as $c
  | { total:   ($c|length),
      notdone: ([$c[]|select((.conclusion//"")|IN("SUCCESS","SKIPPED")|not)]|length),
      failed:  ([$c[]|select((.conclusion//"")|IN("FAILURE","CANCELLED","TIMED_OUT","ACTION_REQUIRED"))]|length) }'
```

Merge only on `notdone == 0 && failed == 0 && total > 0 && mergeStateStatus == "CLEAN"`. The `//""` coalesce is load-bearing.

## The general rule, which is worth more than the `gh` detail

**A filter that enumerates the states you consider bad silently admits every state you did not think of.** Enumerate what you *accept* and reject the complement. Same family as the vacuous-gate and positive-control entries already in this document: the check was true and proved nothing.

## How it stayed hidden — the part I want on the record

On the same day, **two merges passed the broken gate and were nonetheless correct**, because their success count already equalled the full job count, so there was nothing in flight for the gate to miss. A gate that happens to agree with the right answer is indistinguishable from a working gate until the day it does not agree. That is why "it has been fine so far" is not evidence about a gate, and why this is recorded as a mechanical hole rather than as an incident.

## Affected / unaffected

- **Affected:** the documented merge-gate procedure. The parent bullet's count moves from two holes to three ("Two … both of which" → "Three … each of which").
- **Unaffected:** no code, no CI configuration, no behaviour. The two existing holes (a `gh pr comment` not registering as a review; a rebase detaching reviews from head) are unchanged.

## Verification

Documentation only, one file, +20/−1. No table rows and no numbered instrument-trap entries, so the `Docs` gate's structural and gapless-numbering checks are untouched — master's trap max stays 90.

```
git diff --check origin/master..HEAD   -> rc=0
git diff --stat                        -> 1 file changed, 20 insertions(+), 1 deletion(-)
```

Refs #1943