### PR TITLE
fix(hle): answer SKU_FLAG and USER_DEFINED_PARAM_1..4 from the application's own param.json

### DIFF
--- a/prosper/src/hle/hle_addcontent.cpp
+++ b/prosper/src/hle/hle_addcontent.cpp
@@ -20,8 +20,9 @@ constexpr size_t kMaxManifestBytes = 32 * 1024; // dlc_emu producer limit
 constexpr size_t kMaxParamBytes = 2 * 1024 * 1024;
 constexpr size_t kMaxEntries = 1024;             // dlc_emu producer limit
 
-std::mutex g_inventory_mutex;
+std::mutex g_inventory_mutex;              // also guards g_app_params
 AddcontentInventorySnapshot g_inventory;
+AppParamDeclaration g_app_params;
 
 enum class BoundedFileState {
     Missing,
@@ -116,44 +117,110 @@ BoundedFile read_bounded_file(const std::filesystem::path& root,
     return result;
 }
 
-// Small bounded JSON reader for one authorization-bearing metadata field. It validates the document
-// and accepts exactly one top-level string named titleId; a textual occurrence in a nested
-// object or string must never authorize a foreign dlc_emu.ini record. Escapes in the title value are
-// rejected so its identity has one byte representation. Nesting is capped to avoid hostile recursion.
+// The declaration-bearing fields of sce_sys/param.json, all of them read from ONE parse. A second
+// parse of the same file is a second chance to disagree with the first.
+struct ParamJsonDocument {
+    bool valid = false;                        // the whole document parsed
+    std::optional<std::string> title_id;
+    std::optional<std::string> drm_type;
+    std::optional<int32_t> user_param[4];
+};
+
+// Small bounded JSON reader for the authorization- and declaration-bearing metadata fields. It
+// validates the document and accepts each recognized key at most once at the TOP LEVEL only; a
+// textual occurrence in a nested object or string must never authorize a foreign dlc_emu.ini record
+// nor stand in for the application's own declaration. Escapes in the string values are rejected so
+// each identity has one byte representation. Nesting is capped to avoid hostile recursion.
 class ParamJsonReader {
 public:
     explicit ParamJsonReader(std::string_view input) : input_(input) {}
 
+    // A malformed document yields `valid == false` and no fields at all: a file prosper cannot parse
+    // is not a file it may quote selected values out of.
+    ParamJsonDocument read() {
+        if (!parse_object()) return ParamJsonDocument{};
+        doc_.valid = true;
+        return doc_;
+    }
+
     std::optional<std::string> top_level_title_id() {
-        skip_space();
-        if (!take('{')) return std::nullopt;
-        skip_space();
-        if (take('}')) return finish() ? title_id_ : std::nullopt;
-        for (;;) {
-            std::string key;
-            if (!parse_string(&key)) return std::nullopt;
-            skip_space();
-            if (!take(':')) return std::nullopt;
-            skip_space();
-            if (key == "titleId") {
-                if (saw_title_id_) return std::nullopt;
-                saw_title_id_ = true;
-                bool value_escaped = false;
-                std::string value;
-                if (!parse_string(&value, &value_escaped) || value_escaped) return std::nullopt;
-                title_id_ = std::move(value);
-            } else if (!skip_value(1)) {
-                return std::nullopt;
-            }
-            skip_space();
-            if (take('}')) break;
-            if (!take(',')) return std::nullopt;
-            skip_space();
-        }
-        return finish() && saw_title_id_ ? title_id_ : std::nullopt;
+        const ParamJsonDocument doc = read();
+        return doc.valid ? doc.title_id : std::nullopt;
     }
 
 private:
+    // Index of userDefinedParam1..4, or -1 for any other key.
+    static int user_param_index(std::string_view key) {
+        constexpr std::string_view kPrefix = "userDefinedParam";
+        if (key.size() != kPrefix.size() + 1 || key.substr(0, kPrefix.size()) != kPrefix) return -1;
+        const char digit = key.back();
+        if (digit < '1' || digit > '4') return -1;
+        return digit - '1';
+    }
+
+    bool parse_object() {
+        skip_space();
+        if (!take('{')) return false;
+        skip_space();
+        if (take('}')) return finish();
+        for (;;) {
+            std::string key;
+            if (!parse_string(&key)) return false;
+            skip_space();
+            if (!take(':')) return false;
+            skip_space();
+            if (key == "titleId") {
+                if (doc_.title_id) return false;
+                bool value_escaped = false;
+                std::string value;
+                if (!parse_string(&value, &value_escaped) || value_escaped) return false;
+                doc_.title_id = std::move(value);
+            } else if (key == "applicationDrmType") {
+                if (doc_.drm_type) return false;
+                bool value_escaped = false;
+                std::string value;
+                if (!parse_string(&value, &value_escaped) || value_escaped) return false;
+                doc_.drm_type = std::move(value);
+            } else if (const int index = user_param_index(key); index >= 0) {
+                if (doc_.user_param[index]) return false;
+                int32_t value = 0;
+                if (!parse_int32(&value)) return false;
+                doc_.user_param[index] = value;
+            } else if (!skip_value(1)) {
+                return false;
+            }
+            skip_space();
+            if (take('}')) break;
+            if (!take(',')) return false;
+            skip_space();
+        }
+        return finish();
+    }
+
+    // A USER_DEFINED_PARAM is a signed 32-bit integer. A fraction or exponent is legal JSON but is
+    // not one of these, so it is rejected rather than truncated into a believable value; so is any
+    // magnitude outside int32_t, which cannot be reported through the guest ABI at all.
+    bool parse_int32(int32_t* out) {
+        const bool negative = take('-');
+        if (pos_ == input_.size() || !ascii_digit(input_[pos_])) return false;
+        if (input_[pos_] == '0' && pos_ + 1 < input_.size() && ascii_digit(input_[pos_ + 1]))
+            return false;                                  // JSON forbids a leading zero
+        int64_t value = 0;
+        while (pos_ < input_.size() && ascii_digit(input_[pos_])) {
+            value = value * 10 + (input_[pos_++] - '0');
+            if (value > 0x80000000ll) return false;         // bounded before it can overflow
+        }
+        if (pos_ < input_.size() &&
+            (input_[pos_] == '.' || input_[pos_] == 'e' || input_[pos_] == 'E')) return false;
+        if (negative) {
+            *out = static_cast<int32_t>(-value);            // -2147483648 is representable
+            return true;
+        }
+        if (value > 0x7fffffffll) return false;
+        *out = static_cast<int32_t>(value);
+        return true;
+    }
+
     static bool hex_digit(char ch) {
         return (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f') ||
                (ch >= 'A' && ch <= 'F');
@@ -287,9 +354,29 @@ private:
 
     std::string_view input_;
     size_t pos_ = 0;
-    bool saw_title_id_ = false;
-    std::optional<std::string> title_id_;
+    ParamJsonDocument doc_;
 };
+
+// Derive the application's SKU flag from its own applicationDrmType declaration.
+//
+// applicationDrmType names the DRM/entitlement class the application was published under. Two values
+// occur across the project's local test dumps, and guest code pins both of them to the FULL SKU:
+//   "standard"   — Crisis Core (PPSA07809) declares it and holds a predicate that is true only when
+//                  sceNpEntitlementAccessGetSkuFlag returns FULL.
+//   "upgradable" — GTA V (PPSA04263) declares it (a full-game disc carrying a PS4 cross-generation
+//                  upgrade path) and routes a TRIAL answer into its purchase-gated branch.
+// Every other spelling is left UNKNOWN on purpose. No dump available to this project declares a
+// trial, demo, or free SKU, so there is nothing to calibrate those spellings against, and inventing
+// one would either under-report a full application or over-report a limited one. The second of those
+// is the failure this project must never commit, so an unrecognised declaration fails the query
+// loudly instead of being rounded up to FULL. A free/online-only SKU of a title whose full SKU is in
+// the corpus therefore keeps its purchase gate, which is the correct answer for that dump.
+// CONFIDENCE: HIGH that these two declarations are full SKUs; the limited-SKU spellings are
+// deliberately unmapped until a dump declaring one exists to derive them from.
+std::optional<AppSkuFlag> derive_sku_flag(std::string_view drm_type) {
+    if (drm_type == "standard" || drm_type == "upgradable") return AppSkuFlag::Full;
+    return std::nullopt;
+}
 
 bool parse_hex_key(std::string_view text, std::array<uint8_t, 16>& out) {
     if (text.size() != out.size() * 2) return false;
@@ -505,12 +592,37 @@ ParseResult parse_inventory(const std::filesystem::path& root, std::string_view 
 
 void addcontent_configure_for_app0(const std::string& app0_root) {
     AddcontentInventorySnapshot next;
+    AppParamDeclaration params;
     if (app0_root.empty()) {
         std::lock_guard<std::mutex> lock(g_inventory_mutex);
         g_inventory = std::move(next);
+        g_app_params = std::move(params);
         return;
     }
     const std::filesystem::path root(app0_root);
+    // ONE param.json parse serves both readers: the add-content manifest's title authorization and
+    // the application's own SKU / user-defined-param declaration. Two parses could disagree about
+    // what the same file says; one cannot. It is read unconditionally — the app-param declaration
+    // exists whether or not this title also declares add-content.
+    const BoundedFile param = read_bounded_file(root, std::filesystem::path("sce_sys") /
+                                               "param.json", kMaxParamBytes);
+    const ParamJsonDocument doc = param.state == BoundedFileState::Ready
+        ? ParamJsonReader(param.data).read() : ParamJsonDocument{};
+    if (doc.valid) {
+        params.declared = true;
+        if (doc.drm_type) {
+            params.declared_drm_type = *doc.drm_type;
+            params.sku_flag = derive_sku_flag(params.declared_drm_type);
+            if (!params.sku_flag)
+                std::fprintf(stderr,
+                             "[appparam] unrecognised applicationDrmType \"%s\": the application's "
+                             "SKU flag stays unknown and every SKU query fails visibly\n",
+                             params.declared_drm_type.c_str());
+        }
+        for (size_t i = 0; i < 4; ++i)
+            if (doc.user_param[i]) params.user_param[i] = *doc.user_param[i];
+    }
+
     const BoundedFile manifest = read_bounded_file(root, "dlc_emu.ini", kMaxManifestBytes);
     if (manifest.state == BoundedFileState::Missing) {
         next.state = AddcontentInventoryState::None;
@@ -518,10 +630,7 @@ void addcontent_configure_for_app0(const std::string& app0_root) {
         next.state = AddcontentInventoryState::Invalid;
         std::fprintf(stderr, "[addcontent] invalid install manifest: unreadable or oversized\n");
     } else {
-        const BoundedFile param = read_bounded_file(root, std::filesystem::path("sce_sys") /
-                                                   "param.json", kMaxParamBytes);
-        const std::optional<std::string> title_id = param.state == BoundedFileState::Ready
-            ? ParamJsonReader(param.data).top_level_title_id() : std::nullopt;
+        const std::optional<std::string> title_id = doc.valid ? doc.title_id : std::nullopt;
         if (!title_id || !valid_title_id(*title_id)) {
             next.state = AddcontentInventoryState::Invalid;
             std::fprintf(stderr,
@@ -536,6 +645,12 @@ void addcontent_configure_for_app0(const std::string& app0_root) {
     }
     std::lock_guard<std::mutex> lock(g_inventory_mutex);
     g_inventory = std::move(next);
+    g_app_params = std::move(params);
+}
+
+AppParamDeclaration app_param_declaration() {
+    std::lock_guard<std::mutex> lock(g_inventory_mutex);
+    return g_app_params;
 }
 
 AddcontentInventorySnapshot addcontent_inventory_snapshot() {

--- a/prosper/src/hle/hle_addcontent.cpp
+++ b/prosper/src/hle/hle_addcontent.cpp
@@ -143,11 +143,6 @@ public:
         return doc_;
     }
 
-    std::optional<std::string> top_level_title_id() {
-        const ParamJsonDocument doc = read();
-        return doc.valid ? doc.title_id : std::nullopt;
-    }
-
 private:
     // Index of userDefinedParam1..4, or -1 for any other key.
     static int user_param_index(std::string_view key) {
@@ -621,6 +616,18 @@ void addcontent_configure_for_app0(const std::string& app0_root) {
         }
         for (size_t i = 0; i < 4; ++i)
             if (doc.user_param[i]) params.user_param[i] = *doc.user_param[i];
+    } else {
+        // No local declaration at all, so from here every sceAppContentAppParamGetInt returns
+        // NOT_FOUND and every GetSkuFlag returns NO_ENTITLEMENT. That is the honest answer, but it
+        // silently converts calls that always succeeded into calls that always fail, and it IS
+        // reachable for a real user: a dump is accepted on eboot.bin alone, so an eboot-only tree
+        // boots and loses every app-param answer with no other symptom. Name the case rather than
+        // leaving the next reader to bisect it.
+        std::fprintf(stderr,
+                     "[appparam] no usable sce_sys/param.json (%s): the application declares no SKU "
+                     "and no user-defined params, and every app-param query fails visibly\n",
+                     param.state == BoundedFileState::Missing ? "absent"
+                                                             : "unreadable, oversized or malformed");
     }
 
     const BoundedFile manifest = read_bounded_file(root, "dlc_emu.ini", kMaxManifestBytes);

--- a/prosper/src/hle/hle_addcontent.hpp
+++ b/prosper/src/hle/hle_addcontent.hpp
@@ -4,11 +4,47 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
 
 namespace prosper {
+
+// The SKU flag of the running application, as the published AppContent contract enumerates it. There
+// is deliberately no "unknown" enumerator: an application whose local declaration prosper cannot
+// recognise has no SKU to report, which is an absent std::optional, not a third value a guest could
+// mistake for data.
+//
+// Guest code in the project's local test dumps pins both values independently of any header: Crisis
+// Core (PPSA07809) holds a predicate that is true only when sceNpEntitlementAccessGetSkuFlag yields
+// exactly 3, Little Nightmares II (PPSA02154) holds one that is true only when it yields 1, and both
+// GTA V (PPSA04263) and Little Nightmares III (PPSA05143) route a 1 into their restricted-SKU branch.
+enum class AppSkuFlag : int32_t {
+    Trial = 1,   // SCE_APP_CONTENT_APPPARAM_SKU_FLAG_TRIAL
+    Full  = 3,   // SCE_APP_CONTENT_APPPARAM_SKU_FLAG_FULL
+};
+
+// What the installed application declares about ITSELF in sce_sys/param.json. Sony asks the same SKU
+// question through two libraries — sceAppContentAppParamGetInt(SKU_FLAG) and
+// sceNpEntitlementAccessGetSkuFlag — so both read this one derivation and cannot disagree.
+struct AppParamDeclaration {
+    // sce_sys/param.json was present and parsed. False means there is no local declaration to answer
+    // from at all, and every app-param query must fail rather than invent one.
+    bool declared = false;
+    // Absent when param.json declares no applicationDrmType, or declares one prosper has no evidence
+    // for. Either way the SKU is unknown and the queries fail visibly instead of reporting a value.
+    std::optional<AppSkuFlag> sku_flag;
+    // Exactly as declared, for diagnostics; empty when the key is absent.
+    std::string declared_drm_type;
+    // USER_DEFINED_PARAM_1..4. param.json omits a userDefinedParamN the publishing tool left at its
+    // default, so an absent key is a declared zero rather than missing information.
+    int32_t user_param[4]{};
+};
+
+// Published by addcontent_configure_for_app0 from the same single param.json parse the add-content
+// inventory uses. Safe to call from any guest thread.
+AppParamDeclaration app_param_declaration();
 
 enum class AddcontentInventoryState {
     None,       // no dlc_emu.ini: this title has no locally declared add-content

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -3953,8 +3953,18 @@ HLE(s_npent_getkey) {
 // a0 is a stack address whose slot the guest had pre-seeded with 1 (its TRIAL default, per its own
 // code at eboot+0x4dfc92) and a1 is 0 — a single-argument call.
 //
-// CONFIDENCE: HIGH on the contract and the enum (guest-pinned in three titles); MED on the exact errno
-// for the unknown case, which is chosen inside the producer-pinned 0x817D NpEntitlementAccess facility.
+// CONFIDENCE: HIGH on the contract and the enum (guest-pinned in three titles).
+//
+// LOW on the exact errno for the unknown-SKU case, and deliberately left admitted rather than dressed
+// up. NO_ENTITLEMENT is a semantic stretch for "prosper cannot derive this application's SKU": it is a
+// placeholder picked inside the producer-pinned 0x817D NpEntitlementAccess facility, NOT a known
+// contract, and a more precise-looking value invented here would be worse than the stretch, because
+// the next reader would treat a specific code as evidence that the contract is known.
+// What makes the placeholder safe: no caller's behaviour depends on the value. All four titles in the
+// project's local dumps test only for non-zero and fall back to their own conservative default, so the
+// observable behaviour is identical for any error in this facility.
+// What would settle it, and let this be replaced without re-deriving anything above: a title observed
+// branching on a specific error code from this call, or the value observed from real firmware.
 HLE(s_npent_skuflag) {
     svc_log("sceNpEntitlementAccessGetSkuFlag", a0,a1,a2,a3,a4,a5);
     if (!svc_ptrish(a0)) return NP_ENTITLEMENT_ERROR_PARAMETER;

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -2495,11 +2495,39 @@ uint64_t addcontent_info_list(uint64_t list_address, uint64_t list_num,
 }
 } // namespace
 
-// sceAppContentAppParamGetInt(paramId, int32_t* value): paramId 0 = SKU_FLAG, whose only valid values are
-// TRIAL=1 / FULL=3 (there is NO 0). Writing 0 for it made the SKU check indeterminate -> a game testing
-// `sku == FULL` drops into trial/demo mode (locked content, "buy full game" gating). Report FULL for a
-// legally-owned title; other params (USER_DEFINED_PARAM_1..4) stay 0 absent a param.sfo read.
-HLE(s_appcontent_int) { if (a1) *(int32_t*)PW(a1) = ((int32_t)a0 == 0) ? 3 : 0; return 0; }
+// sceAppContentAppParamGetInt(SceAppContentAppParamId paramId, int32_t* value)
+//   paramId 0 = SKU_FLAG, 1..4 = USER_DEFINED_PARAM_1..4.
+//
+// Every one of these is a property the installed application declares about ITSELF in its own
+// sce_sys/param.json, so all of them are answered from that local declaration and nothing else. The
+// previous stub hardcoded SKU_FLAG to FULL and answered every user-defined param with 0, and it is
+// the second half that gated GTA V's (PPSA04263) story mode: the title reads USER_DEFINED_PARAM_1 —
+// which its own param.json declares as 9 — stores it, and tests bit 3 to decide that its installed
+// content needs no online entitlement lookup. Answering 0 cleared that bit and sent it down the
+// online path instead, where sceNpEntitlementAccessGetSkuFlag left the guest's own pre-seeded TRIAL
+// value standing and the title offered story mode as a purchase. The declared values matter well
+// beyond that gate: Crisis Core (PPSA07809) uses USER_DEFINED_PARAM_2 as a bounded content-variant
+// index, and Little Nightmares II/III use USER_DEFINED_PARAM_1 as an index into their own
+// add-content list.
+//
+// param.json omits a userDefinedParamN the publishing tool left at its default, so an absent key is a
+// declared zero. With no parseable param.json there is no declaration at all and the query fails
+// rather than inventing one — a value invented here is indistinguishable from a real declaration to
+// every caller. CONFIDENCE: HIGH.
+HLE(s_appcontent_int) {
+    const int32_t param_id = (int32_t)a0;
+    if (param_id < 0 || param_id > 4 || !svc_ptrish(a1)) return APP_CONTENT_ERROR_PARAMETER;
+    const AppParamDeclaration decl = app_param_declaration();
+    if (!decl.declared) return APP_CONTENT_ERROR_NOT_FOUND;
+    int32_t value = 0;
+    if (param_id == 0) {
+        if (!decl.sku_flag) return APP_CONTENT_ERROR_NOT_FOUND;
+        value = (int32_t)*decl.sku_flag;
+    } else {
+        value = decl.user_param[param_id - 1];
+    }
+    return svc_write_bytes(a1, &value, sizeof(value)) ? 0 : APP_CONTENT_ERROR_PARAMETER;
+}
 
 // sceSystemServiceParamGetInt(SceSystemServiceParamId paramId, int32_t* value): a0=paramId, a1=value.
 // The system-settings a blanket-zero stub gives are mostly harmless, EXCEPT the LANGUAGE (paramId 1):
@@ -3896,6 +3924,30 @@ HLE(s_npent_getkey) {
         ? 0 : NP_ENTITLEMENT_ERROR_PARAMETER;
 }
 
+// sceNpEntitlementAccessGetSkuFlag(int32_t* skuFlag) — the SAME question
+// sceAppContentAppParamGetInt answers for paramId 0, asked through libSceNpEntitlementAccess. It is a
+// platform query about the SKU of the LOCALLY INSTALLED application, not a query about anything a
+// user purchased from a network service, so it is answered from the same one local derivation and the
+// two libraries cannot disagree.
+//
+// The NID was registered nowhere, so it fell to the dispatcher's unimplemented stub, which reports
+// SUCCESS while leaving the out pointer untouched. That is worse than a wrong value: of the four
+// titles in the project's local dumps that call this, three (PPSA07809, PPSA02154, PPSA05143) hand it
+// an uninitialized stack slot and then act on whatever residue was there, and the fourth (PPSA04263)
+// pre-seeds TRIAL and keeps it. Failing when the SKU is unknown is a path all four already handle —
+// each falls back to its own conservative default — whereas reporting a SKU prosper cannot derive is
+// a value the guest cannot tell from a real one. CONFIDENCE: HIGH on the contract and the enum
+// (guest-pinned in three titles); MED on the exact errno for the unknown case, which is chosen inside
+// the producer-pinned 0x817D NpEntitlementAccess facility.
+HLE(s_npent_skuflag) {
+    svc_log("sceNpEntitlementAccessGetSkuFlag", a0,a1,a2,a3,a4,a5);
+    if (!svc_ptrish(a0)) return NP_ENTITLEMENT_ERROR_PARAMETER;
+    const AppParamDeclaration decl = app_param_declaration();
+    if (!decl.declared || !decl.sku_flag) return NP_ENTITLEMENT_ERROR_NO_ENTITLEMENT;
+    const int32_t value = (int32_t)*decl.sku_flag;
+    return svc_write_bytes(a0, &value, sizeof(value)) ? 0 : NP_ENTITLEMENT_ERROR_PARAMETER;
+}
+
 // sceSaveDataTransferringMount (PS5-only, live-captured x4 in DOLL's save-slot menu): mount a
 // PS4-era save for transfer/import. We have no PS4 save to transfer — the truthful fresh-console
 // answer is NOT_FOUND with the result untouched. The previous success+garbage made the game read
@@ -4210,6 +4262,7 @@ void register_service_hle() {
     Hle::register_fn("TFyU+KFBv54", (HleFn)s_npent_addcont_list,
                      "sceNpEntitlementAccessGetAddcontEntitlementInfoList");
     Hle::register_fn("5LiMEPuW0DQ", (HleFn)s_npent_getkey, "sceNpEntitlementAccessGetEntitlementKey");
+    Hle::register_fn("lPDO62PpJIA", (HleFn)s_npent_skuflag, "sceNpEntitlementAccessGetSkuFlag");
     Hle::register_fn("WAzWTZm1H+I", (HleFn)s_savedata_transfermount, "sceSaveDataTransferringMount");
     Hle::register_fn("3RQ5aQfnstU", (HleFn)s_syss_noticeskip, "sceSystemServiceGetNoticeScreenSkipFlag");
     // libSceNpUniversalDataSystem — inert ids (guarded LOW-confidence out-writes).

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -2505,7 +2505,10 @@ uint64_t addcontent_info_list(uint64_t list_address, uint64_t list_num,
 // which its own param.json declares as 9 — stores it, and tests bit 3 to decide that its installed
 // content needs no online entitlement lookup. Answering 0 cleared that bit and sent it down the
 // online path instead, where sceNpEntitlementAccessGetSkuFlag left the guest's own pre-seeded TRIAL
-// value standing and the title offered story mode as a purchase. The declared values matter well
+// value standing and the title offered story mode as a purchase. That chain is only half the story on
+// current master: the param read is itself skipped because sceSysmoduleIsLoaded reports every module
+// loaded, so GTA V never runs its own sceAppContentInitialize (#2002). Both halves are needed, and a
+// three-arm A/B on #1873 shows neither alone opens the gate. The declared values matter well
 // beyond that gate: Crisis Core (PPSA07809) uses USER_DEFINED_PARAM_2 as a bounded content-variant
 // index, and Little Nightmares II/III use USER_DEFINED_PARAM_1 as an index into their own
 // add-content list.
@@ -3940,9 +3943,18 @@ HLE(s_npent_getkey) {
 // an uninitialized stack slot and then act on whatever residue was there, and the fourth (PPSA04263)
 // pre-seeds TRIAL and keeps it. Failing when the SKU is unknown is a path all four already handle —
 // each falls back to its own conservative default — whereas reporting a SKU prosper cannot derive is
-// a value the guest cannot tell from a real one. CONFIDENCE: HIGH on the contract and the enum
-// (guest-pinned in three titles); MED on the exact errno for the unknown case, which is chosen inside
-// the producer-pinned 0x817D NpEntitlementAccess facility.
+// a value the guest cannot tell from a real one.
+//
+// ARG 0 IS THE OUT POINTER, and that needed proving rather than assuming: both neighbouring exports in
+// this library (GetAddcontEntitlementInfoList, GetEntitlementKey) lead with a SceNpServiceLabel, so if
+// this one did too, writing through a0 would be writing through a label and the whole fix would be
+// inert. A live GTA V (PPSA04263) boot under PROSPER_SVCLOG settles it:
+//   [svc] sceNpEntitlementAccessGetSkuFlag(0x7f4fc82d6e2c, 0, 0xb, 0, 0x1d, 0xb)
+// a0 is a stack address whose slot the guest had pre-seeded with 1 (its TRIAL default, per its own
+// code at eboot+0x4dfc92) and a1 is 0 — a single-argument call.
+//
+// CONFIDENCE: HIGH on the contract and the enum (guest-pinned in three titles); MED on the exact errno
+// for the unknown case, which is chosen inside the producer-pinned 0x817D NpEntitlementAccess facility.
 HLE(s_npent_skuflag) {
     svc_log("sceNpEntitlementAccessGetSkuFlag", a0,a1,a2,a3,a4,a5);
     if (!svc_ptrish(a0)) return NP_ENTITLEMENT_ERROR_PARAMETER;

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -2515,6 +2515,10 @@ uint64_t addcontent_info_list(uint64_t list_address, uint64_t list_num,
 // rather than inventing one — a value invented here is indistinguishable from a real declaration to
 // every caller. CONFIDENCE: HIGH.
 HLE(s_appcontent_int) {
+    // Logged because this is the head of a causal chain that is otherwise invisible: a title stores
+    // a user-defined param in its own state and acts on it much later, so "what did prosper answer
+    // here" is the question a stalled content gate needs answered first.
+    svc_log("sceAppContentAppParamGetInt", a0,a1,a2,a3,a4,a5);
     const int32_t param_id = (int32_t)a0;
     if (param_id < 0 || param_id > 4 || !svc_ptrish(a1)) return APP_CONTENT_ERROR_PARAMETER;
     const AppParamDeclaration decl = app_param_declaration();

--- a/prosper/tests/test_service_getters.cpp
+++ b/prosper/tests/test_service_getters.cpp
@@ -1000,6 +1000,140 @@ int main() {
         fs::remove_all(scratch, ec);
     }
 
+    // App-param declaration (Refs #1873): SKU_FLAG and USER_DEFINED_PARAM_1..4 are properties the
+    // installed application declares about ITSELF in sce_sys/param.json, and Sony asks the SKU half
+    // through TWO libraries. Both must be derived from that one local declaration, and both must
+    // agree. Before this, sceAppContentAppParamGetInt hardcoded SKU_FLAG to FULL and answered every
+    // user-defined param with 0 regardless of what the title declared, while the
+    // sceNpEntitlementAccessGetSkuFlag spelling was registered nowhere and so reported success
+    // without writing the out pointer at all — which is what left GTA V (PPSA04263) reading its own
+    // pre-seeded TRIAL value and offering story mode as a purchase.
+    {
+        namespace fs = std::filesystem;
+        const fs::path scratch = prosper_test::test_scratch_dir() /
+            ("prosper-appparam-" + std::to_string((uintptr_t)&fails));
+        const fs::path app0 = scratch / "app0";
+        std::error_code ec;
+        fs::remove_all(scratch, ec);
+        fs::create_directories(app0 / "sce_sys", ec);
+        auto declare = [&](const char* json) {
+            std::ofstream param(app0 / "sce_sys" / "param.json", std::ios::binary | std::ios::trunc);
+            param << json;
+            param.close();
+            set_app0_root(app0.string());
+        };
+
+        HleFn app_param = Hle::lookup("99b82IKXpH4");   // sceAppContentAppParamGetInt
+        HleFn np_sku = Hle::lookup("lPDO62PpJIA");      // sceNpEntitlementAccessGetSkuFlag
+        CHECK(app_param && np_sku,
+              "AppContent and NpEntitlementAccess SKU queries are both registered");
+        if (app_param && np_sku) {
+            constexpr int32_t kSentinel = (int32_t)0xDEADBEEF;
+            constexpr uint64_t kAppContentParameter = 0x80D90002ull;
+            constexpr uint64_t kAppContentNotFound = 0x80D90005ull;
+            constexpr uint64_t kNpNoEntitlement = 0x817D0007ull;
+            uint64_t rc = 0, np_rc = 0;
+            // Each returns the value actually written, leaving kSentinel when the call wrote nothing.
+            auto app_value = [&](int32_t id) {
+                int32_t out = kSentinel;
+                rc = app_param((uint64_t)(uint32_t)id, (uint64_t)(uintptr_t)&out, 0, 0, 0, 0);
+                return out;
+            };
+            auto np_value = [&]() {
+                int32_t out = kSentinel;
+                np_rc = np_sku((uint64_t)(uintptr_t)&out, 0, 0, 0, 0, 0);
+                return out;
+            };
+
+            // GTA V's own declaration: an upgradable full-game disc that declares
+            // userDefinedParam1 = 9. Bit 3 of that 9 is what tells the title its installed content
+            // needs no online entitlement lookup, so answering 0 here is what gated story mode.
+            declare(R"({"titleId":"PPSA04263","applicationDrmType":"upgradable",)"
+                    R"("userDefinedParam1":9,"userDefinedParam2":0,"contentBadgeType":1})");
+            CHECK(app_value(1) == 9 && rc == 0,
+                  "USER_DEFINED_PARAM_1 reports the value param.json declares, not 0");
+            CHECK(app_value(2) == 0 && rc == 0,
+                  "an explicitly declared USER_DEFINED_PARAM_2 of 0 is reported as 0");
+            CHECK(app_value(3) == 0 && rc == 0,
+                  "an omitted USER_DEFINED_PARAM_3 is a declared zero, not a failure");
+            CHECK(app_value(0) == 3 && rc == 0,
+                  "an upgradable declaration reports the FULL SKU flag through AppContent");
+            CHECK(np_value() == 3 && np_rc == 0,
+                  "an upgradable declaration reports the FULL SKU flag through NpEntitlementAccess");
+            CHECK(app_value(0) == np_value() && rc == 0 && np_rc == 0,
+                  "AppContent and NpEntitlementAccess report the SAME SKU flag");
+
+            // Crisis Core's declaration: standard, and a userDefinedParam2 it uses as a bounded
+            // content-variant index.
+            declare(R"({"titleId":"PPSA07809","applicationDrmType":"standard",)"
+                    R"("userDefinedParam1":1,"userDefinedParam2":1})");
+            CHECK(app_value(0) == 3 && rc == 0 && np_value() == 3 && np_rc == 0,
+                  "a standard declaration reports the FULL SKU flag through both libraries");
+            CHECK(app_value(2) == 1 && rc == 0,
+                  "USER_DEFINED_PARAM_2 reports its declared content-variant index");
+
+            // MUTATION ARM. A declaration prosper has no evidence for must NOT be rounded up to
+            // FULL: an online-only/free SKU of a title whose full SKU is in the corpus has to keep
+            // its purchase gate. Both libraries fail and neither writes the out slot, which is the
+            // path every calling title already handles by falling back to its own default. This is
+            // the check that distinguishes a derivation from a hardcoded FULL.
+            declare(R"({"titleId":"PPSA04263","applicationDrmType":"onlineonly",)"
+                    R"("userDefinedParam1":9})");
+            CHECK(app_value(0) == kSentinel && rc == kAppContentNotFound,
+                  "an unrecognised applicationDrmType fails the AppContent SKU query "
+                  "instead of reporting a SKU");
+            CHECK(np_value() == kSentinel && np_rc == kNpNoEntitlement,
+                  "an unrecognised applicationDrmType fails the NpEntitlementAccess SKU query "
+                  "instead of reporting a SKU");
+            CHECK(app_value(1) == 9 && rc == 0,
+                  "an unknown SKU still reports the user-defined params the title declares");
+
+            // A title that declares no DRM type at all has no SKU to report, but its user-defined
+            // params are still declared.
+            declare(R"({"titleId":"PPSA00001","userDefinedParam4":7})");
+            CHECK(app_value(0) == kSentinel && rc == kAppContentNotFound &&
+                      np_value() == kSentinel && np_rc == kNpNoEntitlement,
+                  "an absent applicationDrmType fails both SKU queries rather than assuming FULL");
+            CHECK(app_value(4) == 7 && rc == 0,
+                  "USER_DEFINED_PARAM_4 is reported without any DRM-type declaration");
+
+            // A value that is legal JSON but not an int32 param invalidates the whole document
+            // rather than being truncated into a believable number.
+            declare(R"({"titleId":"PPSA00001","applicationDrmType":"standard","userDefinedParam1":1.5})");
+            CHECK(app_value(1) == kSentinel && rc == kAppContentNotFound &&
+                      app_value(0) == kSentinel && rc == kAppContentNotFound,
+                  "a non-integer userDefinedParam invalidates the declaration instead of truncating");
+            declare(R"({"titleId":"PPSA00001","applicationDrmType":"standard",)"
+                    R"("userDefinedParam1":1,"userDefinedParam1":2})");
+            CHECK(app_value(1) == kSentinel && rc == kAppContentNotFound,
+                  "a duplicated userDefinedParam invalidates the declaration");
+            declare(R"({"nested":{"applicationDrmType":"standard"}})");
+            CHECK(np_value() == kSentinel && np_rc == kNpNoEntitlement,
+                  "a nested applicationDrmType does not stand in for the top-level declaration");
+
+            // No parseable declaration at all: there is nothing local to derive from, and neither
+            // library may invent one.
+            fs::remove(app0 / "sce_sys" / "param.json", ec);
+            set_app0_root(app0.string());
+            CHECK(app_value(0) == kSentinel && rc == kAppContentNotFound &&
+                      app_value(1) == kSentinel && rc == kAppContentNotFound,
+                  "no param.json fails every AppContent app-param query");
+            CHECK(np_value() == kSentinel && np_rc == kNpNoEntitlement,
+                  "no param.json fails the NpEntitlementAccess SKU query");
+
+            // Argument validation.
+            declare(R"({"titleId":"PPSA04263","applicationDrmType":"upgradable"})");
+            CHECK(app_value(5) == kSentinel && rc == kAppContentParameter,
+                  "an out-of-range AppContent paramId is rejected");
+            CHECK(app_param(0, 0, 0, 0, 0, 0) == kAppContentParameter,
+                  "AppContentAppParamGetInt rejects a null output pointer");
+            CHECK(np_sku(0, 0, 0, 0, 0, 0) == 0x817D0002ull,
+                  "GetSkuFlag rejects a null output pointer");
+        }
+        fs::remove_all(scratch, ec);
+        set_app0_root(std::string());
+    }
+
     // SystemService / AppContent / NP getters: each must WRITE its out-param with the CORRECT value —
     // returning success with an unfilled (or wrong-valued) out is the harmful-stub class whose downstream
     // effects are hard to trace (a 0.0 safe-area ratio collapses the viewport; lang 0 localizes to

--- a/prosper/tests/test_service_getters.cpp
+++ b/prosper/tests/test_service_getters.cpp
@@ -1107,6 +1107,31 @@ int main() {
                     R"("userDefinedParam1":1,"userDefinedParam1":2})");
             CHECK(app_value(1) == kSentinel && rc == kAppContentNotFound,
                   "a duplicated userDefinedParam invalidates the declaration");
+            declare(R"({"titleId":"PPSA00001","applicationDrmType":"standard",)"
+                    R"("applicationDrmType":"upgradable"})");
+            CHECK(app_value(0) == kSentinel && rc == kAppContentNotFound,
+                  "a duplicated applicationDrmType invalidates the declaration");
+
+            // int32 boundaries. A userDefinedParam is a signed 32-bit value: both extremes must survive
+            // the round trip exactly, and one past either extreme must invalidate rather than wrap into
+            // a believable number.
+            declare(R"({"titleId":"PPSA00001","userDefinedParam1":2147483647,)"
+                    R"("userDefinedParam2":-2147483648,"userDefinedParam3":-1})");
+            CHECK(app_value(1) == 2147483647 && rc == 0,
+                  "USER_DEFINED_PARAM_1 round-trips INT32_MAX exactly");
+            CHECK(app_value(2) == (-2147483647 - 1) && rc == 0,
+                  "USER_DEFINED_PARAM_2 round-trips INT32_MIN exactly");
+            CHECK(app_value(3) == -1 && rc == 0,
+                  "a negative USER_DEFINED_PARAM_3 is reported as declared");
+            declare(R"({"titleId":"PPSA00001","userDefinedParam1":2147483648})");
+            CHECK(app_value(1) == kSentinel && rc == kAppContentNotFound,
+                  "a userDefinedParam one past INT32_MAX invalidates instead of wrapping");
+            declare(R"({"titleId":"PPSA00001","userDefinedParam1":-2147483649})");
+            CHECK(app_value(1) == kSentinel && rc == kAppContentNotFound,
+                  "a userDefinedParam one past INT32_MIN invalidates instead of wrapping");
+            declare(R"({"titleId":"PPSA00001","userDefinedParam1":01})");
+            CHECK(app_value(1) == kSentinel && rc == kAppContentNotFound,
+                  "a leading-zero userDefinedParam invalidates the declaration");
             declare(R"({"nested":{"applicationDrmType":"standard"}})");
             CHECK(np_value() == kSentinel && np_rc == kNpNoEntitlement,
                   "a nested applicationDrmType does not stand in for the top-level declaration");


### PR DESCRIPTION
## Goal

`Refs #1873`. prosper answered "what SKU is this installed application?" **two different ways depending
on which library the guest asked through**, and answered every `USER_DEFINED_PARAM` with a hardcoded 0
regardless of what the title declared about itself. Both are properties the installed application
states about itself in its own `sce_sys/param.json`, so both are now derived from that one local
declaration.

This is the positive half of the local-inventory rule: under-reporting what is present in the dump
removes content the user has, and the title then behaves *correctly* on a wrong answer — its own UI
explains the problem in its own words, so the defect reads as a licensing wall.

## Failure scenario

`hle_service.cpp` answered `sceAppContentAppParamGetInt` as `(paramId == 0) ? 3 : 0` — SKU_FLAG
hardcoded full, every user-defined param 0 — while `sceNpEntitlementAccessGetSkuFlag`
(`lPDO62PpJIA`) was **registered nowhere** and fell to the dispatcher's unimplemented stub
(`dispatch.cpp:176`), which reports SUCCESS while never touching the out pointer.

That silent-success stub is worse than a wrong value. Of the four titles in the project's local dumps
that call `GetSkuFlag`, three hand it an **uninitialized stack slot** and then act on whatever residue
was there:

| title | out slot before the call | what the guest does with the value |
| --- | --- | --- |
| `PPSA04263` GTA V | pre-seeded `1` (TRIAL) | `sku == 1` -> restricted-SKU branch |
| `PPSA07809` Crisis Core | **uninitialized** | predicate true only if `sku == 3` |
| `PPSA02154` Little Nightmares II | **uninitialized** | predicate true only if `sku == 1` |
| `PPSA05143` Little Nightmares III | **uninitialized** | `sku == 1` -> its class 2, else class 4 |

## Contract and derivation

One derivation, published from a **single** `param.json` parse alongside the add-content inventory, so
the AppContent and NpEntitlementAccess paths cannot disagree. If they could still diverge after this,
the defect would have moved rather than gone.

**`USER_DEFINED_PARAM_1..4`** are reported exactly as declared. `param.json` omits a
`userDefinedParamN` left at the publishing tool's default, so an absent key is a declared zero rather
than missing information. These values are load-bearing well beyond one gate: GTA V stores
`userDefinedParam1` (declared `9`) and tests bit 3 of it, Crisis Core uses `userDefinedParam2`
(declared `1`) as a bounded content-variant index, and both Little Nightmares titles use
`userDefinedParam1` as an index into their own add-content list. 14 of the 44 local dumps declare a
non-zero user param (17 non-zero declarations in total); every one was previously answered 0.

**`SKU_FLAG`** is derived from `applicationDrmType`. `"standard"` and `"upgradable"` are the only
values any local dump declares, and guest code pins both to FULL: Crisis Core (which declares
`"standard"`) holds a predicate true only when `GetSkuFlag` returns exactly **3**, while Little
Nightmares II holds one true only when it returns **1**, and GTA V and Little Nightmares III both
route a 1 into their restricted branch. That is the published AppContent enum
(`TRIAL = 1`, `FULL = 3`) confirmed by three independent guests rather than assumed from prosper's own
other stub.

**Every other spelling is left unknown on purpose.** No dump available to this project declares a
trial, demo, or free SKU, so there is nothing to calibrate those spellings against, and rounding an
unrecognised declaration up to FULL would over-report a limited one. An unknown SKU fails the query
loudly (and logs the exact declared string), which is the path all four calling titles already handle
by falling back to their own conservative default. A consequence worth stating: **a free or
online-only SKU of a title whose full SKU is in the corpus keeps its purchase gate**, which is the
correct answer for that dump and is what makes this a derivation rather than an unlock.

**No `param.json` at all** fails every app-param query rather than inventing a declaration. A value
invented here is indistinguishable from a real one to every caller.

## What decided GTA V's story-mode gate — and what did not

**`GetSkuFlag` is not the gate, and the hypothesis that it was is retired.** This PR was opened on the
reasoning that GTA V's story-mode wall came from prosper answering `SKU_FLAG` two different ways. That
reasoning identified a real defect — the one this PR fixes — but it was **not** the deciding input, and
measurement replaced it: with `GetSkuFlag` registered and correctly answering FULL(3) from the local
declaration, the STORY tab still shows "Buy Grand Theft Auto V's Story Mode." The hypothesis is retired
explicitly on #1873 so no later reader inherits it. The *class* was right (a local-inventory platform
query answered with a stub, derivable offline) which is why the policy framing below stands unchanged;
the specific call was wrong.

The gate is also **not** a PSN purchase-record query. Nothing in the deciding path calls
`RequestUnifiedEntitlementInfoList` / `PollUnifiedEntitlementInfoList`. It is the title's own
`userDefinedParam1` declaration: bit 3 tells its content-availability routine (eboot+0x4dfbf0) to skip
the entitlement query entirely and use its installed-content defaults.

That read is *itself* gated behind `sceSysmoduleIsLoaded`, which prosper answers "loaded" for every
module — so GTA V skips its own `sceAppContentInitialize` + param read. **Filed separately as #2002**
with its own three-arm A/B; it is a shared-substrate change reaching 39 of 44 dumps and deliberately
not folded in here. With both halves applied the STORY tab reaches **"Entering Story Mode: (10%)"**
instead of "Buy Grand Theft Auto V's Story Mode.", then hits an unrelated render-thread fault. That
measurement is investigation evidence from an experimental arm, not acceptance evidence for this PR.

**No rung change is claimed. GTA V remains at rung 2.**

## Per-title effect of *this* PR alone (`screenshot`, native 3840×2160)

| title | change in what the guest reads | behaviour change |
| --- | --- | --- |
| `PPSA04263` GTA V | `GetSkuFlag` 1 (TRIAL) -> 3 (FULL) | none visible; still "Buy". The param read is skipped (#2002) |
| `PPSA05143` LN3 | `GetSkuFlag` stack residue -> 3 | none visible |
| `PPSA07809` Crisis Core | `USER_DEFINED_PARAM_2` 0 -> 1, read 5x | none visible; same fault site `eboot+0x4efae55` before and after |
| `PPSA02154` LN2 | `USER_DEFINED_PARAM_1` now declared 0 | none visible; same fault site `eboot+0x48d374b` before and after |

Crisis Core and LN2 were A/B'd against the old stub specifically to confirm this PR does not cause or
move their existing faults. It does not.

## Deliberately unaffected

`sceAppContentGetAddcontInfoList`, `GetAddcontEntitlementInfoList`, `GetEntitlementKey`, and mounting
keep answering from `dlc_emu.ini` exactly as before. No entitlement or ownership answer is
manufactured anywhere, and no env switch is added.

## Risk

- `sceAppContentAppParamGetInt` now returns errors it never returned: `NOT_FOUND` when there is no
  parseable declaration, `PARAMETER` for a paramId outside 0..4 or an unwritable out pointer. All 44
  local dumps parse and derive a SKU (positive control below), so the `NOT_FOUND` path is unreachable
  for the current corpus. 38 of 44 dumps import this function.
- The `param.json` reader is stricter: it now rejects a duplicated or non-integer `userDefinedParamN`
  and a duplicated `applicationDrmType`, and a rejected document fails every app-param query. Verified
  against every real `param.json` in the corpus rather than argued.
- The trial-SKU spelling is unmapped. `CONFIDENCE: HIGH` that `"standard"`/`"upgradable"` are full
  SKUs; the limited-SKU declarations stay unmapped until a dump declaring one exists to derive from.
- `CONFIDENCE: MED` on the exact errno for the unknown-SKU case on the NP path, chosen inside the
  producer-pinned `0x817D` facility. What the value must *not* be — a reported SKU — is HIGH.

## Verification

Build and test exit codes captured separately (a pipe into `tail` discards a compile failure).

```bash
cmake -S prosper -B build-linux -G Ninja -DPROSPER_APP=ON -DPROSPER_AUDIO_SDL3=ON \
      -DPROSPER_PAD_SDL3=ON -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0
cmake --build build-linux -j12          # BUILD_RC=0
(cd build-linux && ctest -j4)           # CTEST_RC=0 — 100% tests passed out of 198
```

New checks in `service_getters` (25 assertions). **Mutation arms actually run**, each reverted after:

| mutation | named checks that go RED |
| --- | --- |
| `derive_sku_flag` -> always `Full` (i.e. a hardcode) | "an unrecognised applicationDrmType fails the AppContent SKU query instead of reporting a SKU" + its NpEntitlementAccess twin |
| `derive_sku_flag` -> always `nullopt` | the two "upgradable declaration reports the FULL SKU flag" checks, "a standard declaration reports the FULL SKU flag through both libraries", and "AppContent and NpEntitlementAccess report the SAME SKU flag" |
| declared user params dropped to 0 | "USER_DEFINED_PARAM_1 reports the value param.json declares, not 0", "USER_DEFINED_PARAM_2 reports its declared content-variant index", "USER_DEFINED_PARAM_4 is reported without any DRM-type declaration", "an unknown SKU still reports the user-defined params the title declares" |

The first arm is the one that matters: without it the change is indistinguishable from `return 3`.

**Corpus positive control.** The real derivation was run over the real `param.json` of all 44 local
dumps: **44 parsed, 44 with a derived SKU**, and the reported user params match an independent
out-of-band read of the same files (GTA V `9,0,0,0`; Crisis Core `1,1,0,0`; DQ7 `3,1,2,0`; Sonic
Origins `2,0,0,0`; The Messenger `0,0,0,1`). Nothing in the corpus regresses to the unknown path.

No snapshot guards run, per current orchestration policy (batched ~10 fixes deep).

## Follow-ups filed

- **#2002** — `sceSysmoduleIsLoaded` answers "loaded" for every module; the other half of GTA V's gate.
- **#2004** — `sceAppContentAddcontUnmount` is unregistered, so a mount/unmount/re-mount cycle is
  permanently BUSY. Found in the same census; latent today, and it makes locally present content
  unreachable once a title exercises the cycle.




