### PR TITLE
docs(hle): stop the arg-0 evidence comment claiming more than it observed

### DIFF
--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -3945,13 +3945,22 @@ HLE(s_npent_getkey) {
 // each falls back to its own conservative default — whereas reporting a SKU prosper cannot derive is
 // a value the guest cannot tell from a real one.
 //
-// ARG 0 IS THE OUT POINTER, and that needed proving rather than assuming: both neighbouring exports in
-// this library (GetAddcontEntitlementInfoList, GetEntitlementKey) lead with a SceNpServiceLabel, so if
-// this one did too, writing through a0 would be writing through a label and the whole fix would be
-// inert. A live GTA V (PPSA04263) boot under PROSPER_SVCLOG settles it:
+// THE OUT POINTER LEADS (arg 0), and that needed proving rather than assuming: both neighbouring exports
+// in this library (GetAddcontEntitlementInfoList, GetEntitlementKey) lead with a SceNpServiceLabel, so
+// if this one did too, writing through a0 would be writing through a label and the whole fix would be
+// inert with every test still green. A live GTA V (PPSA04263) boot under PROSPER_SVCLOG settles it — the
+// second line is the load-bearing one, because it is an observation of the slot rather than a reading of
+// guest code:
 //   [svc] sceNpEntitlementAccessGetSkuFlag(0x7f4fc82d6e2c, 0, 0xb, 0, 0x1d, 0xb)
-// a0 is a stack address whose slot the guest had pre-seeded with 1 (its TRIAL default, per its own
-// code at eboot+0x4dfc92) and a1 is 0 — a single-argument call.
+//   [svc]   a0 -> 0001a9bf00000001 0000003ab0ba4900 …
+// a0 is a stack address, and the low dword at it is 0x00000001 — the guest's own pre-seeded TRIAL
+// default, which is what the unimplemented stub used to leave standing. Only the SHAPE of the pointer
+// carries the argument: 0x7f4f… is run-local under ASLR, so a later run will print different digits and
+// that is not a disagreement.
+// What this does NOT establish: whether a trailing SceNpServiceLabel parameter exists. An
+// (out, label = 0) two-argument form would log byte-identically, and the sibling capture in the same run
+// shows label 0 is exactly what these calls pass — GetAddcontEntitlementInfoList(0, 0, 0, 0x7f4f…, …).
+// Unresolved and immaterial here: this handler ignores a1 either way.
 //
 // CONFIDENCE: HIGH on the contract and the enum (guest-pinned in three titles).
 //


### PR DESCRIPTION
## What this is

Recovery of a commit that missed #2003. The lane pushed `1f19ecf5` **after** the reviewed head `327c42b8`, and my merge gate — correctly — merged the SHA the review named, so this landed nowhere. Cherry-picked onto master unchanged.

**Comment-only.** No behaviour, no test, no signature change. Verified: the diff is 15 insertions / 6 deletions, all inside the comment block above `s_npent_skuflag`.

## Why it matters more than a comment usually would

That comment is the project's **record of an ABI that had to be proven rather than assumed.** Both neighbouring exports in `libSceNpEntitlementAccess` (`GetAddcontEntitlementInfoList`, `GetEntitlementKey`) lead with a `SceNpServiceLabel`. Had `GetSkuFlag` done the same, writing through `a0` would have been writing through a label — the fix would have been **inert with every test still green**, because the tests are ABI-circular and cannot distinguish the two. The live observation is the only thing standing between that fix and a silent no-op, so the accuracy of how it is recorded is load-bearing.

Two things in it were wrong, both in the direction that matters.

### 1. The citation did not support the claim beside it

The quoted `[svc]` line was cited for a slot pre-seeded with `1`, and **that value is not in it** — it is in the `a0 ->` dump line that follows. Both are now quoted, with the dump line marked load-bearing, because it is an **observation of the slot** and re-checkable by shape, whereas the `eboot+0x4dfc92` reading cannot be re-checked without redoing the disassembly.

A wrong entry in the record is worse than a missing one: the next reader has no reason to doubt it, and would find the cited line does not say what it was cited for.

### 2. "a1 is 0 — a single-argument call" was one word too strong

`a1 == 0` proves the out pointer **leads**. It does not prove the call is single-argument: an `(out, label = 0)` two-argument form logs byte-identically, and the sibling `GetAddcontEntitlementInfoList(0, 0, 0, …)` capture in the same run shows label 0 is exactly what these calls pass. Now recorded as **unresolved and immaterial** — the handler ignores `a1` either way.

It also notes the pointer is **run-local under ASLR**, so different digits on a later run are not a disagreement; only its shape carries the argument. That pre-empts a phantom for the next reader who reruns the capture.

## Provenance

The wording is the **#2003 reviewer's own**, taken from the review that approved `327c42b8`. It was raised there as non-blocking, with the code explicitly called correct and only the sentence too strong — the lane chose to fix it anyway, which was the right call for a comment that *is* the record.

## Verification

```
git diff --check origin/master..HEAD  -> rc=0
git diff --stat                       -> 1 file, +15 -6, comment block only
session trailers                      -> 0
```

`ctest` was 198/198 at `1f19ecf5` in the lane's run; unchanged here, since the cherry-pick is byte-identical and touches no code.

Refs #1873, #2003