### PR TITLE
docs(compat): R-Type Delta reaches rung 1 — row, screenshot and the honest caveat

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -38,7 +38,7 @@ Last updated: 2026-08-05
 | *The Pathless* | `PPSA01826` | Unreal Engine 4 | 🚧 Title screen | [#1883](https://github.com/mattias800/prosper/issues/1883) |
 | *ArcRunner* | `PPSA21406` | Unreal Engine 4 | 🔬 Render bring-up, no composited frame | [#1817](https://github.com/mattias800/prosper/issues/1817) |
 | *Asterix &amp; Obelix: Babylon Mission* | `PPSA30490` | Unity 6 / IL2CPP | 🚧 Logo movies, intro cutscene, and title menu | [#1884](https://github.com/mattias800/prosper/issues/1884) |
-| *R-Type Delta: HD Boosted* | `PPSA26414` | Custom | 🔬 Startup fault before title | [#1810](https://github.com/mattias800/prosper/issues/1810) |
+| *R-Type Delta: HD Boosted* | `PPSA26414` | Custom | 🚧 Publisher logo and opening movie | [#1810](https://github.com/mattias800/prosper/issues/1810) |
 | *Nikoderiko: The Magical World* | `PPSA23760` | Unreal Engine 4 | 🚧 Title screen and EULA | [#1885](https://github.com/mattias800/prosper/issues/1885) |
 | *The Oregon Trail* | `PPSA19244` | Unreal Engine 4 | 🚧 Title screen reached and rendered | [#1886](https://github.com/mattias800/prosper/issues/1886) |
 | *Greak: Memories of Azur* | `PPSA02849` | Unity / IL2CPP | ✅ First-level gameplay | [#1887](https://github.com/mattias800/prosper/issues/1887) |
@@ -222,7 +222,11 @@ yet been reached. See the [tracker](https://github.com/mattias800/prosper/issues
 
 ## R-Type Delta: HD Boosted — `PPSA26414`
 
-The runtime PRX loads and recompiles its first graphics stages, but the title currently faults before producing a visible screen. See the [tracker](https://github.com/mattias800/prosper/issues/1810).
+<p align="center"><img src="assets/screenshots/rtype-delta-rung1-logo-and-opening-movie.png" alt="R-Type Delta — Clear River Games logo and the opening movie"></p>
+
+The Clear River Games publisher logo and the full opening movie — the R-9 fighter in its hangar — render live at 1920×1080 from the real GPU command stream. Colours are wrong: greys render green and the image carries a magenta cast ([#2005](https://github.com/mattias800/prosper/issues/2005)). After the movie every frame collapses to a single colour while the frame loop keeps advancing ([#2006](https://github.com/mattias800/prosper/issues/2006)), so the title screen is not reached.
+
+Reaching this needs the **host CPU loaded**. The title's input worker sleeps 400 ms before its first `sceUserServiceGetEvent` drain, and on a fast host prosper finishes the asset load in ~250 ms — so the shell runs first, dereferences an empty user vector and dies. Contending the CPU stretches the load to ~1133 ms and the title survives its own race. Every guest sleep is honoured exactly and every service answer is faithful; a PS5's slower core is what makes this title ship working. See the [tracker](https://github.com/mattias800/prosper/issues/1810) and [#1746](https://github.com/mattias800/prosper/issues/1746).
 
 ## Nikoderiko: The Magical World — `PPSA23760`
 


### PR DESCRIPTION
## Why

#2009 landed the rung-1 evidence and committed the screenshot, but updated only `prosper/docs/R_TYPE_DELTA_STATUS.md`. `COMPATIBILITY.md` — the public, user-facing table — still read **"Startup fault before title"** while the screenshot in the repo showed the publisher logo and the opening movie. This closes that gap.

## What the gallery entry now says

Three things, none of them flattering, all of them true:

- **The colours are wrong.** Greys render green and the image carries a magenta cast (#2005). The screenshot shows this plainly, so the caption states it rather than letting a reader assume the tint is stylistic.
- **The title screen is not reached.** After the movie every frame collapses to a single colour while the frame loop keeps advancing (#2006) — a content defect, not a hang.
- **Reaching rung 1 needs the host CPU loaded.**

## The caveat is the point, and it belongs in public

The title's input worker sleeps 400 ms before its first `sceUserServiceGetEvent` drain. prosper finishes the asset load in ~250 ms on a fast host, so the shell runs first, dereferences an empty user vector, and dies at `eboot+0x24055`. Contending the host CPU stretches the load to ~1133 ms and the title survives its own race — **unmodified binary, unmodified guest, no sleep cap, no patched bytes.**

Every guest sleep is honoured to the nanosecond and every service answer is faithful, and the title *still* loses, because being correct and fast is enough to lose this race. A PS5's slower core is what makes this title ship working.

A reader who runs this on a fast machine and hits the fault should find that documented rather than be surprised by it — and a reader who sees the screenshot should know it was not taken under default conditions. Publishing the caveat is what keeps the screenshot honest.

Note this is **not** a settled root cause: a lane is currently testing the alternative reading, that the empty user vector reflects a real prosper defect in the synchronous user-service surface rather than a timing accident. If that lands, this entry gets rewritten.

## Affected / unaffected

- **Affected:** one table row and one gallery section in `COMPATIBILITY.md`.
- **Unaffected:** no code, no test, no other title's row. The screenshot is already on master from #2009 and is referenced, not re-added.

## Verification

```
git diff --check origin/master..HEAD  -> rc=0
git diff --stat                       -> 1 file, +6 -2
session trailers                      -> 0
```

Refs #1810, #1746, #2005, #2006