### PR TITLE
docs(rtype): no Sony API can reach R-Type Delta's user list — and host page-cache state decides the #1746 race

### DIFF
--- a/prosper/docs/R_TYPE_DELTA_STATUS.md
+++ b/prosper/docs/R_TYPE_DELTA_STATUS.md
@@ -272,12 +272,13 @@ LOGIN event has been drained. That is the whole argument, and it is a property o
 
 The drain loop runs on exactly one thread. `eboot+0x23860` (containing it) is called only from
 `eboot+0x49190`, which is called from `eboot+0x49070` — the INPUT worker body — and from
-`eboot+0x49130`, which has **no code reference and no relocation anywhere in the module** (dead
-code). `eboot+0x49070`'s first two actions are `vtbl[0](this)` and `vtbl[8](this, 0x190)`; vtable slot
-`eboot+0x411048` holds `eboot+0x23210` = `Sleep(ms)` → `eboot+0x19e0` → `sceKernelUsleep(ms * 1000)`.
-The
-thread entry `eboot+0x22f10` reaches that body immediately (four instructions, no branch), so the
-400 ms clock starts within microseconds of the `[thread] create … name=INPUT` line.
+`eboot+0x49130`, which is **dead code**: no call or jump targets it in a full linear disassembly of
+the text segment, no relocation carries it as an addend, and neither the 4- nor the 8-byte
+little-endian encoding of `0x49130` occurs anywhere in the 7.6 MB image. `eboot+0x49070`'s first two
+actions are `vtbl[0](this)` and `vtbl[8](this, 0x190)`; vtable slot `eboot+0x411048` holds
+`eboot+0x23210` = `Sleep(ms)` → `eboot+0x19e0` → `sceKernelUsleep(ms * 1000)`. The thread entry
+`eboot+0x22f10` reaches that body immediately (four instructions, no branch), so the 400 ms clock
+starts within microseconds of the `[thread] create … name=INPUT` line.
 
 So the vector cannot be non-empty before the worker's first drain, **whatever any Sony API returns**.
 That is a statement about the guest's call graph, not a measurement.

--- a/prosper/docs/R_TYPE_DELTA_STATUS.md
+++ b/prosper/docs/R_TYPE_DELTA_STATUS.md
@@ -223,6 +223,154 @@ Two apparatus corrections belong with that table, because both produced wrong an
   line-flushing consumer added ~180 ms and the title *survived*; `PROSPER_FRAME_DUMPS=1` (24 MB BMP
   per frame) moved the fault from 0.386 s to 0.780 s. Any startup-timing number for this title taken
   with a verbose log is worthless — measure with the low-volume combination above.
+## Why the user list is empty: it has exactly one producer, and no Sony API can reach it
+
+The first hypothesis any reader forms about #1746 is that prosper answers a **synchronous**
+user-service query wrongly: a PS5 has a user signed in before the title launches, so if the guest can
+only learn about that user by draining an event queue, the identical race would exist on hardware and
+the title could not ship. That reading is wrong for this title, and it is worth writing down *why*
+rather than re-deriving it, because the answer is a property of the guest binary that cannot change.
+
+**The eboot imports exactly three `libSceUserService` functions.** `self_dump --symbols` names all of
+them, and the 3.20 firmware database resolves them:
+
+| NID | function | prosper handler | what prosper answers |
+| --- | --- | --- | --- |
+| `j3YMu1MVNNo` | `sceUserServiceInitialize` | `s_ok` | 0 |
+| `CdWp0oHWGr0` | `sceUserServiceGetInitialUser` | `s_user_initial` | writes user id 1, returns 0 |
+| `yH17Q6NWtVg` | `sceUserServiceGetEvent` | `s_user_getevent` | one `LOGIN(user 1)`, then `NO_EVENT` |
+
+`sceUserServiceGetLoginUserIdList`, `…GetUserName`, `…GetUserNumber`, `…GetForegroundUser` and the
+rest of the library are **not imported at all**, by the eboot or by `title_Release.prx` (which imports
+only 21 libc and 2 libkernel functions). No answer prosper could give them can reach this title.
+
+**The list is a `std::vector<User*>` at `eboot+0x6f41a8`** (`_M_start`; `_M_finish` at `+0x6f41b0`,
+`_M_end_of_storage` at `+0x6f41b8`, and the container object the reallocation helper `eboot+0x246b0`
+takes as `this` starts at `+0x6f41a0`). Its complete reference set, from `tools/re/xref.py`:
+
+- **one producer** — `eboot+0x23690`, which `operator new`s a 0x78-byte user object, stores the
+  incoming user id at `[obj+0]`, opens a pad for it (`eboot+0x240a0`), and push-backs the pointer at
+  `eboot+0x237b0`. Its **only** caller is `eboot+0x23def`, the `eventType == 0` (LOGIN) arm of the
+  drain loop at `eboot+0x23dd0`, whose event source is the `sceUserServiceGetEvent` PLT stub at
+  `eboot+0x3509e0`.
+- **one clear** — `eboot+0x23640` (`_M_finish = _M_start`), which is `InputSystem::Init`.
+- **consumers only** everywhere else, including `eboot+0x24030`, the faulting one.
+
+The drain loop runs on exactly one thread. `eboot+0x23860` (containing it) is called only from
+`eboot+0x49190`, which is called from `eboot+0x49070` — the INPUT worker body — and from
+`eboot+0x49130`, which has **no code reference and no relocation anywhere in the module** (dead
+code). `eboot+0x49070`'s first two actions are `vtbl[0](this)` and `vtbl[8](this, 0x190)`; vtable slot
+`eboot+0x411048` holds `eboot+0x23210` = `Sleep(ms)` → `eboot+0x19e0` → `sceKernelUsleep(ms * 1000)`.
+The
+thread entry `eboot+0x22f10` reaches that body in two instructions, so the 400 ms clock starts within
+microseconds of the `[thread] create … name=INPUT` line.
+
+So the vector cannot be non-empty before the worker's first drain, **whatever any Sony API returns**.
+That is a statement about the guest's call graph, not a measurement.
+
+`InputSystem::Init` (`eboot+0x23640`) is where the synchronous query actually goes, and it is
+decoded now:
+
+```
+users.clear();                                   // _M_finish = _M_start
+if (sceUserServiceInitialize(NULL) != 0) return; // eboot+0x3509b0
+if (scePadInit() != 0)             return;       // eboot+0x3509c0 (hv1luiJrqQM)
+return sceUserServiceGetInitialUser(&g_initialUser);   // eboot+0x3509d0, g_initialUser = eboot+0x6f419c
+```
+
+The initial user id is stored in `eboot+0x6f419c` — a **different** global from the vector. Its 24
+references live in five functions, and the two that identify themselves take it exactly where a user
+id belongs: `eboot+0x248f0` is the save-data path (`sceSaveDataDirNameSearch`, `sceSaveDataMount3`,
+`sceSaveDataUmount2`, `sceSaveDataDialogInitialize/Open`) and `eboot+0x29ab0` is the NP/UDS path
+(`sceNpUniversalDataSystemInitialize/Terminate`). None of the five touches the vector.
+
+Three live confirmations, all on `4d7a2ded` (master `278c9b1f`) with the default CPU-only route:
+
+- A gdb breakpoint census over a whole boot: **`sceUserServiceGetInitialUser` is called exactly once,
+  with `out=0x4106f419c`** — the eboot base plus the `0x6f419c` predicted above — and
+  `sceUserServiceGetLoginUserIdList` **zero** times. Prosper answers it, and the answer goes where the
+  static decode says it goes. (That census is itself a positive arm for the timing story: breakpoint
+  overhead slowed the boot enough that the title *won* the race and went on to call
+  `sceUserServiceGetEvent` 49,702 times without faulting.)
+- `PROSPER_SVCLOG=1` on a default boot logs **no `sceUserServiceGetEvent` at all** before the fault
+  at 0.4222 s. The consumer runs before the producer's first opportunity, every time.
+- The fault report itself: `rip=eboot+0x24055 … rax=0x0`. `rax` is `_M_start`, so the vector has
+  never allocated — it is empty, not stale or corrupt. Its call chain, from the same report, is
+  `eboot+0xc2b8 ← +0x158b ← +0x17c9 ← +0x306e1 ← +0x23465 ← +0x22a5b`, and `eboot+0x22a5b` is the
+  return address of the shell main loop call that `InputSystem::Init` at `eboot+0x22a47` precedes —
+  independent proof that the synchronous query had already run and been answered when the fault
+  happened.
+
+## Host page-cache state decides the race
+
+The remaining hypothesis is that prosper's guest-visible I/O is unrealistically fast, because guest
+reads are served from the **host page cache** while a PS5 reads from its SSD. The syscall-time census
+above (~17 ms inside a 244 ms load) appears to close it, but that census — and every other timing
+number in this document — was taken with the dump already resident. That mechanism is
+real, and it is worth more than the deficit: evicting *only this dump's* pages makes the same
+unmodified binary, on the same host, **boot**. `tools/dropcache.py` is the instrument —
+`posix_fadvise(POSIX_FADV_DONTNEED)` over the named tree, unprivileged, scoped to those files so no
+other agent's working set is disturbed, and it reports `mincore(2)` residency **before and after** so
+a cold arm can prove it was cold.
+
+Every arm below is `boot_trace`, default route (`PROSPER_GUEST_FS=1
+PROSPER_GUEST_ARGS=-force-gfx-direct`), low-volume timeline (`PROSPER_SYNCLOG=1` +
+`PROSPER_SYNCLOG_SEMA_ONLY=1` + `PROSPER_SYNCLOG_COND_ONLY=1`), unmodified binary and unmodified
+guest, on `4d7a2ded` (master `278c9b1f`). The host was shared with 8–9 other agent lanes, so the
+1-minute load average is reported for every arm — the point of the table is that the two populations
+**do not overlap while their load ranges do**.
+
+| arm | page cache | `name=INPUT` | `DLLLoadStart` | `DLLInit` | load | INPUT→`DLLInit` | outcome | load avg |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| warm A | warm | 0.0819 | 0.0984 | 0.3711 | 273 ms | **289 ms** | SIGSEGV 0.3754 | 33.9 |
+| warm B | warm | 0.0740 | 0.0886 | 0.3961 | 308 ms | **322 ms** | SIGSEGV 0.4005 | 34.0 |
+| warm C | warm | 0.0789 | 0.0961 | 0.3964 | 300 ms | **318 ms** | SIGSEGV 0.4004 | 34.2 |
+| warm D | warm | 0.0864 | 0.1037 | 0.4482 | 345 ms | **362 ms** | SIGSEGV 0.5046 | 42.9 |
+| warm E | warm (119.7 MB resident) | 0.0776 | 0.0961 | 0.4195 | 324 ms | **342 ms** | SIGSEGV 0.4246 | **13.4** |
+| cold A | evicted | 0.6077 | 1.0616 | 1.7656 | 704 ms | **1158 ms** | no fault, 1211 `DLLMain` | 33.2 |
+| cold B | evicted | 0.5073 | 0.8095 | 1.4161 | 607 ms | **909 ms** | no fault, 1219 `DLLMain` | 36.2 |
+| cold C | evicted | 2.4297 | 2.5677 | 3.2270 | 659 ms | **797 ms** | no fault, ran 94 s | 51.4 |
+| cold D | 179.0 → 0.0 MB resident | 0.4066 | 0.6341 | 1.1857 | 552 ms | **779 ms** | no fault, 778 `DLLMain` | 26.5 |
+| cold E | 119.7 → 0.0 MB resident | 0.4117 | 0.6932 | 1.4119 | 719 ms | **1000 ms** | no fault, 736 `DLLMain` | **14.7** |
+
+The threshold is the title's own: the INPUT worker drains 400 ms after it is created, and the shell
+faults on the first common update after `DLLInit`. Five warm arms land at 289–362 ms and **all five
+fault**; five cold arms land at 779–1158 ms and **none does**. The deficit on a contended host is
+**38–111 ms**; the CPU-contention section above measured **95–145 ms** on an idle one.
+
+**The lowest-load arms are the decisive pair**, because CPU contention is the standing confound for
+this title — a passing run under load may be passing because a peer lane is compiling. Warm E ran at
+load 13.4 and faulted; cold E ran at load 14.7, i.e. *more* contended, and booted. Cold D likewise
+booted while its load fell from 26.5, and both cold arms carry `mincore` proof that the pages really
+were gone (179.0 → 0.0 MB, 119.7 → 0.0 MB) and were pulled back from storage by the run itself
+(119.7 MB resident again afterwards). The lever is the cache, not the load.
+
+**This does not mean prosper's I/O is faster than the hardware it emulates, and it is not a licence to
+add a storage-latency model.** The cold arm's extra ~360 ms is this box reading ~101 MB from the
+**external USB SSD** the dumps live on, at roughly 0.25 GB/s under concurrent load. A PS5 reads the
+same 101.4 MB from its internal SSD at a published 5.5 GB/s raw — ~18 ms, and still well under 200 ms
+even an order of magnitude off spec — so a *PS5-faithful* storage model would land near the **warm**
+arm, not the cold one, and would not reliably supply the deficit. `CONFIDENCE: HIGH` that the cold arm
+is not a hardware model; `MED` on the exact PS5 number, which comes from the published rate rather
+than from a measured console. What the A/B
+proves is narrower and more useful: the pre-`DLLInit` interval, not any one API answer, is the whole
+question, and it is set by how fast the host executes the title's own loader.
+
+It also has two immediate practical consequences:
+
+- **Any startup-timing number for this title is void unless the page-cache state is recorded.** Two
+  runs of the same binary on the same host differ by 3–4× here. The same applies to whether the title
+  boots at all: a user's first launch after a reboot may well work and the second may not.
+- Evicting the dump is the cheapest known way to get this title past #1746 **without touching the
+  binary, the guest, or any guest sleep**:
+
+  ```bash
+  python3 tools/dropcache.py <DUMP_ROOT>/PPSA26414-app0     # prints resident MB before -> after
+  PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct ./build/boot_trace <DUMP_ROOT>/PPSA26414-app0
+  ```
+
+  It is a measurement aid, not a fix, and it is one-shot: the run it enables re-warms the cache, so
+  the next launch faults again unless the eviction is repeated.
 
 ## Ruled out
 
@@ -242,16 +390,18 @@ Two apparatus corrections belong with that table, because both produced wrong an
 | The shell's fixed 512-update state-4 delay causes the default startup race | **Falsified by reachability.** State 3 calls `DLLMain(1)`, writes shell state 4, and calls the common app update in the same invocation; that update faults on the empty user vector before the dispatcher can enter state 4 and perform its first `DLLMain(2)` poll. The 512-update counter exists only downstream, after the input worker has already won. Post-#1837 HWBP correctly reports zero hits at the unreachable state-4 test; the merged guest-entry boundary is not missing this execution. | guest `eboot+0x11a8..0x11ef`, fault return `eboot+0x158b`, #1746 |
 | A prosper Pad/UserService HLE side effect makes the pending pad-vibration request non-NULL earlier than hardware would, so the faulting branch is prosper-induced | **Falsified.** `app+0x20c0`'s only writer is the setter `eboot+0xa100`. Armed on every thread it records exactly one hit, from `ret=runtime-prx+0x99c`: the title's own runtime PRX queues the request from inside `DLLInit`. No prosper call sets it, and both consumer branches (`eboot+0x23ee0` and `eboot+0x24030`) dereference the user vector, so suppressing either branch would not help. | `PROSPER_HWBP=0xa100`, default route on `9dcb6c4b`, #1746 |
 | Pacing the guest's pre-graphics loop at the display rate, as hardware does, delays `DLLInit` past the INPUT worker's 400 ms sleep | **Falsified by a lever-verified A/B.** A local diagnostic that pads only the main thread's per-iteration `sceKernelDlsym` by 16 ms moved the `DLLLoadCheck` count from 83–86 to **12** — the lever demonstrably worked — and the identical fault still occurred at `eboot+0x24055`. The live-render route independently gives 31 iterations and the same fault. The title's loader completes on wall clock in its own worker, so a slower dispatcher only reduces the poll count; it does not postpone `DLLInit`. Pacing made the load *finish sooner* (12 × 16 ms ≈ 0.19 s), because the free-running loop had been contending with the loader worker for CPU. | CPU-only and render routes on `9dcb6c4b`, #1746 |
-| Faithful (slower) guest-visible I/O timing is the lever that lets the title win its own race — a PS5 loading the same assets from its own storage takes longer than 400 ms | **Falsified quantitatively; it points the wrong way.** A default boot reads **101.4 MB** before the fault: `data/sound/sound.bnk` 26.05 MB in 398 reads (all of them *before* the first `DLLLoadCheck`), `data/tex/title_tga.bin` 56.68 MB in 45 preads inside the poll window, and ~18 MB of `data/font/*.tga`. Prosper's effective pre-fault rate is roughly 0.3 GB/s; PS5 storage is an order of magnitude faster, so faithful storage timing would *shorten* the window the INPUT worker needs. No storage model makes 101 MB take 400 ms. | `PROSPER_FILELOG=1` byte census on `9dcb6c4b`, #1746 |
+| Faithful (slower) guest-visible I/O timing is the lever that lets the title win its own race — a PS5 loading the same assets from its own storage takes longer than 400 ms | **Falsified quantitatively; it points the wrong way.** A default boot reads **101.4 MB** before the fault: `data/sound/sound.bnk` 26.05 MB in 398 reads (all of them *before* the first `DLLLoadCheck`), `data/tex/title_tga.bin` 56.68 MB in 45 preads inside the poll window, and ~18 MB of `data/font/*.tga`. Prosper's effective pre-fault rate is roughly 0.3 GB/s; PS5 storage is an order of magnitude faster, so faithful storage timing would *shorten* the window the INPUT worker needs. No *PS5-faithful* storage model makes 101 MB take 400 ms. (Corrected 2026-08-05: the original last sentence said "no storage model", which is measurably false for a **host** cold cache — evicting the dump's pages makes the same read take ~600–700 ms from this box's external USB SSD and the title then boots. The direction argument survives untouched, because a PS5's internal SSD is far faster than that drive. See § Host page-cache state.) | `PROSPER_FILELOG=1` byte census on `9dcb6c4b`, #1746 |
 | The title's loader is frame-budgeted (a fixed streaming quota per `DLLLoadCheck`), so the iteration count is the governor | **Falsified.** The count is not invariant: 80, 83, 86, 86 across identical commands, 103 with `PROSPER_FILELOG=1`, 31 on the render route and 12 under a 16 ms dispatcher pad — it tracks loop speed, not work quanta. All 398 `sound.bnk` reads also complete before the first poll, so the bulk of the load is not streamed across polls at all. | dlsym census, five routes on `9dcb6c4b`, #1746 |
 | prosper's `sceKernelUsleep` has a units or timebase error that manufactures the 400 ms window | **Falsified.** `eboot+0x19e0` is `imul edi,edi,0x3e8 ; jmp sceKernelUsleep`, so the guest's `Sleep(0x190)` really requests 400,000 µs, and `k_usleep` (`hle_kernel_time.cpp`) nanosleeps exactly that. The window is the title's own, at the requested length. | guest `eboot+0x19e0`/`+0x23210`, `hle_kernel_time.cpp:401`, #1746 |
 | The INPUT worker is created late under prosper, so its 400 ms window starts too late | **Falsified.** `[thread] create … name=INPUT` appears at `PROSPER_SYNCLOG` line 66 of a default boot, roughly 2,150 lines before the `DLLLoadStart` dlsym that begins the load. The worker is created and asleep long before the load starts. | `PROSPER_SYNCLOG=1` default boot on `9dcb6c4b`, #1746 |
 | A missing UserService event-delivery behavior can populate the title's user vector before the crash | **Falsified by the guest call graph and live call census.** The vector's only producer is the title's LOGIN handler, reached only when its input worker calls `sceUserServiceGetEvent` after a deliberate 400 ms sleep. Default launch makes zero `GetEvent` calls before `users.front()` faults. `Initialize` and `GetInitialUser` can report service state and a user id, but cannot invoke that title-owned handler; doing so would require a title-memory mutation or scheduling shim rather than an API implementation. Prosper's process-global delivery flag and no-op `Initialize`/`Terminate` leave a separate generic lifecycle question, but the repository has no PS5 hardware oracle for its correct transitions. That unproven lifecycle contract cannot cause or repair this fresh-launch ordering defect. | guest `eboot+0x23690`, `+0x23860`, `+0x49070`; service trace; #1746 |
 | The load's completion is gated on GPU-side work that prosper retires early or never performs (the standing "next hypothesis to test") | **Falsified by a backend A/B.** The load takes 244 ms with the live Vulkan renderer and 254 ms with `PROSPER_NO_COMPUTE=1` and no renderer at all — the progression-only no-op backend is the positive control that the GPU really was absent. A duration that is *unchanged* when every GPU submit disappears cannot be paced by GPU completion. | `bffa5e25`, low-volume timeline, #1746 |
-| Guest-visible file I/O timing is a material part of the load, in either direction | **Falsified by syscall time, not by byte count.** `strace -f -c` over a complete pre-fault boot (same run reproduced the fault, and its 68 `pread64` calls match the standalone trace) charges **9.1 ms to 68 `pread64` and 8.1 ms to 1,599 `read`** — ~17 ms of file I/O inside a 244 ms load. The earlier byte census argued about direction; this measures the time and shows the term is negligible either way. | `strace -f -c` on `bffa5e25`, #1746 |
+| Guest-visible file I/O timing is a material part of the load, in either direction | **Falsified by syscall time, not by byte count.** `strace -f -c` over a complete pre-fault boot (same run reproduced the fault, and its 68 `pread64` calls match the standalone trace) charges **9.1 ms to 68 `pread64` and 8.1 ms to 1,599 `read`** — ~17 ms of file I/O inside a 244 ms load. The earlier byte census argued about direction; this measures the time and shows the term is negligible either way. **Narrowed by #2019: that 17 ms is a *warm page cache*, not a property of prosper.** With the same dump evicted, the load takes 552–719 ms and the title boots — so the row holds for the machine state every repeat run is in, and only for that state. It does not license a storage-latency model either (a PS5's internal SSD is faster than the drive the cold arm reads from), but it does mean the cache state has to be recorded with the number. See § Host page-cache state. | `strace -f -c` on `bffa5e25`; cold/warm A/B on `4d7a2ded`, #1746 |
 | The load is bound by wall-clock waits the title requests, so it would take the same time on hardware | **Falsified.** Per-thread `clock_nanosleep` census during the load: the reading worker sleeps only `usleep(0)` × 78, the main thread `1 µs` × 173 and `1 ms` × 45; the 5 ms × 55 and 20 ms × 14 loops belong to the audio threads and run regardless. Guest-requested sleep on the threads that gate the load totals ~56 ms of a 244 ms window, and CPU contention stretches that window 4.5×, which a wall-clock wait could not do. | `strace -f -tt -T -e trace=pread64,clock_nanosleep`, spinner arm, #1746 |
 | Prosper answers some call in the 13–24 ms between the INPUT worker's creation and `DLLLoadStart` (`sceKernelLoadStartModule`, the NP/Scream/audio initialisations) ~140 ms too fast, and that is where the fidelity gap lives | **Not supported, and no longer needed.** It was the leading candidate once I/O and GPU were excluded, but the CPU-contention arm accounts for the entire deficit inside the *load* itself, and it does so with an executed positive outcome. Recorded so the next reader does not chase a module-load latency model for which this repository has no oracle. | this doc, #1746 |
 | The chroma cast in the corrected movie replay is only a capture-provenance artifact, so live output may be correct | **Falsified live.** With the race won by host CPU contention, the unmodified default route renders the publisher logos and the whole opening movie with the *same* green/magenta cast as the replay. Live chroma is now verified broken, not merely unverified. Tracked in #2005. | throttled `screenshot` route on `bffa5e25`, #2005 |
+| A **synchronous** user-service API should report the already-signed-in user immediately, and prosper answering it empty/zero/error is the real defect | **Falsified by the import census, the call graph and a live breakpoint census.** The eboot imports exactly three UserService NIDs — `sceUserServiceInitialize`, `sceUserServiceGetInitialUser`, `sceUserServiceGetEvent` — and `title_Release.prx` imports none (only 21 libc + 2 libkernel). `GetLoginUserIdList`/`GetUserName`/`GetUserNumber`/`GetForegroundUser` are never imported, so their answers are unreachable. `GetInitialUser` **is** called, exactly once, and prosper answers it correctly: a gdb census records the single call with `out=0x4106f419c`, the global `eboot+0x6f419c` that `InputSystem::Init` passes it, which is read only by save-data/trophy/NP code and never copied into the vector. The vector at `eboot+0x6f41a8` has one producer (`eboot+0x23690`) with one caller (the LOGIN arm at `eboot+0x23def`) fed by one source (`sceUserServiceGetEvent`) on one thread (`eboot+0x49070`, after its own `Sleep(400)`); the alternative caller `eboot+0x49130` is unreferenced dead code. No API answer can populate it earlier. | `self_dump --symbols`, `tools/re/xref.py`, gdb census on `4d7a2ded`, #1746 |
+| Prosper's guest reads are unrealistically fast because they come from the host page cache, so a storage-latency model is the missing fidelity | **Half true, and it still is not the fix.** Page-cache state really does decide this race: with only the dump's pages evicted, INPUT→`DLLInit` is 779–1158 ms across five arms and the title **boots** every time, against 289–362 ms and five SIGSEGVs warm — and the least-contended pair points the same way (warm at load 13.4 faults, cold at load 14.7 boots), so it is not peer CPU load. But the cold arm is this box's **external USB SSD** at ~0.25 GB/s, not a PS5: a PS5 internal SSD delivers the same 101.4 MB in tens of ms, i.e. it behaves like the *warm* arm. A PS5-faithful storage model would therefore add almost nothing and cannot be justified by this race. The measurable consequence is an instrument rule, not a fix: **no startup-timing number for this title is valid unless the page-cache state is recorded.** | cold/warm A/B on `4d7a2ded`, § Host page-cache state, #1746 |
 
 ## Next frontier
 
@@ -270,9 +420,19 @@ engineering question with a hidden answer; it is a product decision, and it is t
 > deliberate, titled compatibility decision (the class of thing Proton's per-game fixes and DXVK's
 > app profiles are), not a defect repair. Do not implement one without that decision.
 
+Two later findings (#2019) sharpen that decision rather than reopen it. The user-service side is
+closed **by construction** and no longer rests on a measurement — § *Why the user list is empty*
+shows the vector has one producer, fed by one API, on one thread, behind the title's own 400 ms
+sleep. And the pre-`DLLInit` interval is **page-cache-dependent**: § *Host page-cache state* swings it
+289 ms → 1158 ms on one host, with the outcome flipping, which narrows the syscall-time row above —
+"~17 ms of file I/O" is a warm-cache figure, not a property of prosper. Neither finding changes the
+product decision above; the second means every future timing number for this title must record its
+cache state.
+
 Do not re-open this as a search for a generic contract. If a future reader believes one exists, the
 bar is a mechanism that survives the backend A/B, the syscall-time census, and the CPU-contention arm
-in the two sections above — not a new guess.
+in the two sections above — not a new guess — and any timing it rests on has to state its page-cache
+state.
 
 ## Rung 1 reached (2026-08-05, `bffa5e25`)
 

--- a/prosper/docs/R_TYPE_DELTA_STATUS.md
+++ b/prosper/docs/R_TYPE_DELTA_STATUS.md
@@ -223,6 +223,7 @@ Two apparatus corrections belong with that table, because both produced wrong an
   line-flushing consumer added ~180 ms and the title *survived*; `PROSPER_FRAME_DUMPS=1` (24 MB BMP
   per frame) moved the fault from 0.386 s to 0.780 s. Any startup-timing number for this title taken
   with a verbose log is worthless — measure with the low-volume combination above.
+
 ## Why the user list is empty: it has exactly one producer, and no Sony API can reach it
 
 The first hypothesis any reader forms about #1746 is that prosper answers a **synchronous**
@@ -241,20 +242,33 @@ them, and the 3.20 firmware database resolves them:
 | `yH17Q6NWtVg` | `sceUserServiceGetEvent` | `s_user_getevent` | one `LOGIN(user 1)`, then `NO_EVENT` |
 
 `sceUserServiceGetLoginUserIdList`, `…GetUserName`, `…GetUserNumber`, `…GetForegroundUser` and the
-rest of the library are **not imported at all**, by the eboot or by `title_Release.prx` (which imports
-only 21 libc and 2 libkernel functions). No answer prosper could give them can reach this title.
+rest of the library are **not imported at all** — not by the eboot, and not by any of the title's 24
+PRXs, every one of which imports only `libc` and `libkernel`. No answer prosper could give them can
+reach this title.
 
 **The list is a `std::vector<User*>` at `eboot+0x6f41a8`** (`_M_start`; `_M_finish` at `+0x6f41b0`,
 `_M_end_of_storage` at `+0x6f41b8`, and the container object the reallocation helper `eboot+0x246b0`
-takes as `this` starts at `+0x6f41a0`). Its complete reference set, from `tools/re/xref.py`:
+takes as `this` starts at `+0x6f41a0`). Every reference to those four addresses, enumerated with
+`tools/re/xref.py` **and cross-checked against a full linear disassembly of the text segment**
+(`xref.py` does not decode `sub reg,[rip+d]`, `add [rip+d], imm8`, `cmp reg,[rip+d]` or an AVX store,
+and all four forms occur here — #2025):
 
 - **one producer** — `eboot+0x23690`, which `operator new`s a 0x78-byte user object, stores the
-  incoming user id at `[obj+0]`, opens a pad for it (`eboot+0x240a0`), and push-backs the pointer at
-  `eboot+0x237b0`. Its **only** caller is `eboot+0x23def`, the `eventType == 0` (LOGIN) arm of the
-  drain loop at `eboot+0x23dd0`, whose event source is the `sceUserServiceGetEvent` PLT stub at
-  `eboot+0x3509e0`.
-- **one clear** — `eboot+0x23640` (`_M_finish = _M_start`), which is `InputSystem::Init`.
-- **consumers only** everywhere else, including `eboot+0x24030`, the faulting one.
+  incoming user id at `[obj+0]`, opens a pad for it (`eboot+0x240a0` → `scePadOpen` at `+0x240c5`,
+  handle to `[obj+0x60]`), and push-backs the pointer at `eboot+0x237b0`. Its **only** caller is
+  `eboot+0x23def`, the `eventType == 0` (LOGIN) arm of the drain loop at `eboot+0x23dd0`, whose event
+  source is the `sceUserServiceGetEvent` PLT stub at `eboot+0x3509e0`.
+- **three ways to remove** and none to add — `InputSystem::Init`'s clear at `eboot+0x23640`
+  (`_M_finish = _M_start`), the erase-by-id helper `eboot+0x237e0` (`pop_back` at `+0x23834`), and
+  the `eventType == 1` (LOGOUT) arm inside `eboot+0x23860` (`pop_back` at `+0x23dac`).
+- **one static constructor** — `eboot+0x24790` (registered at `eboot+0x461200`) zeroes the whole
+  32-byte container with a single `vmovups`, which is why `_M_start` is NULL rather than stale.
+- **consumers** everywhere else, including `eboot+0x24030`, the faulting one.
+
+`_M_start` itself (`eboot+0x6f41a8`) is *written* by exactly two things: that static constructor, and
+the reallocation helper `eboot+0x246b0` — whose only two call sites are both **inside the producer**
+`eboot+0x23690`. So the faulting load at `eboot+0x2404e` cannot observe a non-NULL pointer until a
+LOGIN event has been drained. That is the whole argument, and it is a property of the binary.
 
 The drain loop runs on exactly one thread. `eboot+0x23860` (containing it) is called only from
 `eboot+0x49190`, which is called from `eboot+0x49070` — the INPUT worker body — and from
@@ -262,8 +276,8 @@ The drain loop runs on exactly one thread. `eboot+0x23860` (containing it) is ca
 code). `eboot+0x49070`'s first two actions are `vtbl[0](this)` and `vtbl[8](this, 0x190)`; vtable slot
 `eboot+0x411048` holds `eboot+0x23210` = `Sleep(ms)` → `eboot+0x19e0` → `sceKernelUsleep(ms * 1000)`.
 The
-thread entry `eboot+0x22f10` reaches that body in two instructions, so the 400 ms clock starts within
-microseconds of the `[thread] create … name=INPUT` line.
+thread entry `eboot+0x22f10` reaches that body immediately (four instructions, no branch), so the
+400 ms clock starts within microseconds of the `[thread] create … name=INPUT` line.
 
 So the vector cannot be non-empty before the worker's first drain, **whatever any Sony API returns**.
 That is a statement about the guest's call graph, not a measurement.
@@ -279,8 +293,8 @@ return sceUserServiceGetInitialUser(&g_initialUser);   // eboot+0x3509d0, g_init
 ```
 
 The initial user id is stored in `eboot+0x6f419c` — a **different** global from the vector. Its 24
-references live in five functions, and the two that identify themselves take it exactly where a user
-id belongs: `eboot+0x248f0` is the save-data path (`sceSaveDataDirNameSearch`, `sceSaveDataMount3`,
+references live in eight functions, and the two that identify themselves take it exactly where a
+user id belongs: `eboot+0x248f0` is the save-data path (`sceSaveDataDirNameSearch`, `sceSaveDataMount3`,
 `sceSaveDataUmount2`, `sceSaveDataDialogInitialize/Open`) and `eboot+0x29ab0` is the NP/UDS path
 (`sceNpUniversalDataSystemInitialize/Terminate`). None of the five touches the vector.
 
@@ -309,9 +323,12 @@ above (~17 ms inside a 244 ms load) appears to close it, but that census — and
 number in this document — was taken with the dump already resident. That mechanism is
 real, and it is worth more than the deficit: evicting *only this dump's* pages makes the same
 unmodified binary, on the same host, **boot**. `tools/dropcache.py` is the instrument —
-`posix_fadvise(POSIX_FADV_DONTNEED)` over the named tree, unprivileged, scoped to those files so no
-other agent's working set is disturbed, and it reports `mincore(2)` residency **before and after** so
-a cold arm can prove it was cold.
+`posix_fadvise(POSIX_FADV_DONTNEED)` over the named tree, unprivileged, and touching nothing *outside*
+those files (unlike `/proc/sys/vm/drop_caches`, which drops the whole machine's cache). It is **not**
+free of cross-lane effects: the page cache is global, so evicting a shared dump evicts it for every
+process on the host, and pointing it at a tree another lane is timing silently invalidates their run.
+Say what you are evicting first. It reports `mincore(2)` residency **before and after** so a cold arm
+can prove it was cold.
 
 Every arm below is `boot_trace`, default route (`PROSPER_GUEST_FS=1
 PROSPER_GUEST_ARGS=-force-gfx-direct`), low-volume timeline (`PROSPER_SYNCLOG=1` +
@@ -338,28 +355,41 @@ faults on the first common update after `DLLInit`. Five warm arms land at 289–
 fault**; five cold arms land at 779–1158 ms and **none does**. The deficit on a contended host is
 **38–111 ms**; the CPU-contention section above measured **95–145 ms** on an idle one.
 
-**The lowest-load arms are the decisive pair**, because CPU contention is the standing confound for
-this title — a passing run under load may be passing because a peer lane is compiling. Warm E ran at
-load 13.4 and faulted; cold E ran at load 14.7, i.e. *more* contended, and booted. Cold D likewise
-booted while its load fell from 26.5, and both cold arms carry `mincore` proof that the pages really
-were gone (179.0 → 0.0 MB, 119.7 → 0.0 MB) and were pulled back from storage by the run itself
-(119.7 MB resident again afterwards). The lever is the cache, not the load.
+**What makes this an A/B rather than a coincidence** is that the arms were interleaved, the two
+populations do not overlap at all (289–362 ms against 779–1158 ms), and the outcome agrees with the
+population in 10 of 10 runs. CPU contention is the standing confound for this title — a passing run
+under load may be passing because a peer lane is compiling — and it is ruled out in the same
+direction: the least-loaded warm arm (E, load 13.4) faulted while the least-loaded cold arm (E, load
+14.7) booted, i.e. the cold arm that booted was the *more* contended of the two. Treat that pair as
+supporting rather than decisive — a **1-minute** load average cannot resolve contention over a 300 ms
+window, and 13.4 against 14.7 is a 10 % difference on a lagging metric. Cold D and E additionally
+carry `mincore` proof that the pages really were gone (179.0 → 0.0 MB and 119.7 → 0.0 MB, printed by
+`tools/dropcache.py` immediately before each run) and were pulled back from storage by the run itself
+(119.7 MB resident again afterwards); cold A–C predate that instrument and rest on the eviction call
+alone.
 
 **This does not mean prosper's I/O is faster than the hardware it emulates, and it is not a licence to
 add a storage-latency model.** The cold arm's extra ~360 ms is this box reading ~101 MB from the
 **external USB SSD** the dumps live on, at roughly 0.25 GB/s under concurrent load. A PS5 reads the
-same 101.4 MB from its internal SSD at a published 5.5 GB/s raw — ~18 ms, and still well under 200 ms
-even an order of magnitude off spec — so a *PS5-faithful* storage model would land near the **warm**
-arm, not the cold one, and would not reliably supply the deficit. `CONFIDENCE: HIGH` that the cold arm
-is not a hardware model; `MED` on the exact PS5 number, which comes from the published rate rather
-than from a measured console. What the A/B
+same 101.4 MB from its internal SSD at a published 5.5 GB/s raw — **~18 ms, against the ~17 ms of
+file-I/O syscall time the warm arm already spends**, so a PS5-faithful model at spec adds about a
+millisecond and changes nothing. The break-even is worth stating rather than hand-waving a margin:
+the deficit is 38–111 ms, so a storage model would have to spend **~55 ms** on this load (≈1.8 GB/s
+effective) to flip the narrowest warm arm and **~128 ms** (≈0.8 GB/s) to flip the widest. Both are far
+below what PS5 storage does, which is why this is not the missing fidelity — but the conclusion does
+rest on the console being near its published rate for this access pattern (443 reads, mostly 64 KB),
+and this repository has no measured console. `CONFIDENCE: HIGH` that the cold arm is not a hardware
+model; `MED` on the PS5 number itself. What the A/B
 proves is narrower and more useful: the pre-`DLLInit` interval, not any one API answer, is the whole
-question, and it is set by how fast the host executes the title's own loader.
+question. The section above and this one are two levers on that same interval — host CPU speed and
+host cache state — and neither is *the* decider on its own; what decides the outcome is whether their
+sum clears the title's 400 ms.
 
 It also has two immediate practical consequences:
 
 - **Any startup-timing number for this title is void unless the page-cache state is recorded.** Two
-  runs of the same binary on the same host differ by 3–4× here. The same applies to whether the title
+  runs of the same binary on the same host differ by 2–4× here (779/362 comparing the closest arms of
+  the two populations, 1158/289 comparing the extremes). The same applies to whether the title
   boots at all: a user's first launch after a reboot may well work and the second may not.
 - Evicting the dump is the cheapest known way to get this title past #1746 **without touching the
   binary, the guest, or any guest sleep**:
@@ -400,7 +430,7 @@ It also has two immediate practical consequences:
 | The load is bound by wall-clock waits the title requests, so it would take the same time on hardware | **Falsified.** Per-thread `clock_nanosleep` census during the load: the reading worker sleeps only `usleep(0)` × 78, the main thread `1 µs` × 173 and `1 ms` × 45; the 5 ms × 55 and 20 ms × 14 loops belong to the audio threads and run regardless. Guest-requested sleep on the threads that gate the load totals ~56 ms of a 244 ms window, and CPU contention stretches that window 4.5×, which a wall-clock wait could not do. | `strace -f -tt -T -e trace=pread64,clock_nanosleep`, spinner arm, #1746 |
 | Prosper answers some call in the 13–24 ms between the INPUT worker's creation and `DLLLoadStart` (`sceKernelLoadStartModule`, the NP/Scream/audio initialisations) ~140 ms too fast, and that is where the fidelity gap lives | **Not supported, and no longer needed.** It was the leading candidate once I/O and GPU were excluded, but the CPU-contention arm accounts for the entire deficit inside the *load* itself, and it does so with an executed positive outcome. Recorded so the next reader does not chase a module-load latency model for which this repository has no oracle. | this doc, #1746 |
 | The chroma cast in the corrected movie replay is only a capture-provenance artifact, so live output may be correct | **Falsified live.** With the race won by host CPU contention, the unmodified default route renders the publisher logos and the whole opening movie with the *same* green/magenta cast as the replay. Live chroma is now verified broken, not merely unverified. Tracked in #2005. | throttled `screenshot` route on `bffa5e25`, #2005 |
-| A **synchronous** user-service API should report the already-signed-in user immediately, and prosper answering it empty/zero/error is the real defect | **Falsified by the import census, the call graph and a live breakpoint census.** The eboot imports exactly three UserService NIDs — `sceUserServiceInitialize`, `sceUserServiceGetInitialUser`, `sceUserServiceGetEvent` — and `title_Release.prx` imports none (only 21 libc + 2 libkernel). `GetLoginUserIdList`/`GetUserName`/`GetUserNumber`/`GetForegroundUser` are never imported, so their answers are unreachable. `GetInitialUser` **is** called, exactly once, and prosper answers it correctly: a gdb census records the single call with `out=0x4106f419c`, the global `eboot+0x6f419c` that `InputSystem::Init` passes it, which is read only by save-data/trophy/NP code and never copied into the vector. The vector at `eboot+0x6f41a8` has one producer (`eboot+0x23690`) with one caller (the LOGIN arm at `eboot+0x23def`) fed by one source (`sceUserServiceGetEvent`) on one thread (`eboot+0x49070`, after its own `Sleep(400)`); the alternative caller `eboot+0x49130` is unreferenced dead code. No API answer can populate it earlier. | `self_dump --symbols`, `tools/re/xref.py`, gdb census on `4d7a2ded`, #1746 |
+| A **synchronous** user-service API should report the already-signed-in user immediately, and prosper answering it empty/zero/error is the real defect | **Falsified by the import census, the call graph and a live breakpoint census.** The eboot imports exactly three UserService NIDs — `sceUserServiceInitialize`, `sceUserServiceGetInitialUser`, `sceUserServiceGetEvent` — and `title_Release.prx` imports none (only 21 libc + 2 libkernel). `GetLoginUserIdList`/`GetUserName`/`GetUserNumber`/`GetForegroundUser` are never imported, so their answers are unreachable. `GetInitialUser` **is** called, exactly once, and prosper answers it correctly: a gdb census records the single call with `out=0x4106f419c`, the global `eboot+0x6f419c` that `InputSystem::Init` passes it, which is read by the save-data and NP/UDS paths and never copied into the vector. The vector at `eboot+0x6f41a8` has one producer (`eboot+0x23690`) with one caller (the LOGIN arm at `eboot+0x23def`) fed by one source (`sceUserServiceGetEvent`) on one thread (`eboot+0x49070`, after its own `Sleep(400)`); the alternative caller `eboot+0x49130` is unreferenced dead code. No API answer can populate it earlier. | `self_dump --symbols`, `tools/re/xref.py`, gdb census on `4d7a2ded`, #1746 |
 | Prosper's guest reads are unrealistically fast because they come from the host page cache, so a storage-latency model is the missing fidelity | **Half true, and it still is not the fix.** Page-cache state really does decide this race: with only the dump's pages evicted, INPUT→`DLLInit` is 779–1158 ms across five arms and the title **boots** every time, against 289–362 ms and five SIGSEGVs warm — and the least-contended pair points the same way (warm at load 13.4 faults, cold at load 14.7 boots), so it is not peer CPU load. But the cold arm is this box's **external USB SSD** at ~0.25 GB/s, not a PS5: a PS5 internal SSD delivers the same 101.4 MB in tens of ms, i.e. it behaves like the *warm* arm. A PS5-faithful storage model would therefore add almost nothing and cannot be justified by this race. The measurable consequence is an instrument rule, not a fix: **no startup-timing number for this title is valid unless the page-cache state is recorded.** | cold/warm A/B on `4d7a2ded`, § Host page-cache state, #1746 |
 
 ## Next frontier

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -244,11 +244,14 @@ the shipped runtime. Build them from `build-linux/` like everything else.
   the first, so a title's asset load can be several times faster than the same bytes off storage —
   which is invisible for most work and decisive for a startup *race*: PPSA26414 reaches `DLLInit` in
   289–362 ms warm and 779–1158 ms evicted, and it faults in the first case and boots in the second
-  (`docs/R_TYPE_DELTA_STATUS.md`). Unprivileged and scoped: `posix_fadvise(POSIX_FADV_DONTNEED)` on
-  the named files only, so it needs no root and cannot disturb another agent's working set. It prints
-  `mincore(2)` residency **before and after**, because "evicted it", "it was already cold" and
-  "eviction silently did nothing" otherwise look identical. `--report-only` measures without evicting.
-  **Record cache state alongside any startup-timing number**; without it the number is unreproducible.
+  (`docs/R_TYPE_DELTA_STATUS.md`). `posix_fadvise(POSIX_FADV_DONTNEED)` on the named files only, so it
+  needs no root and touches nothing outside them — but **the page cache is global**, so evicting a
+  shared dump evicts it for every process on the box and will silently invalidate another lane's
+  timing run. Say what you are evicting first. It prints `mincore(2)` residency **before and after**,
+  because "evicted it", "it was already cold" and "eviction silently did nothing" otherwise look
+  identical, and it exits non-zero (never silently) when pages stay resident, when a path is absent,
+  and when a flag is misspelled. `--report-only` measures without evicting; `--self-test` needs no
+  dump. **Record cache state alongside any startup-timing number**; without it it is unreproducible.
 - **F8 interactive performance capture / `perf/performance_capture_report.py`** — while playing in
   `prosper-app`, press **F8** when performance is bad. The app keeps a cheap 4 Hz rolling ring of
   process CPU/RSS plus guest-flip, rendered-frame, and host-present counts; the press freezes the

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -239,6 +239,16 @@ the shipped runtime. Build them from `build-linux/` like everything else.
   `--thread REGEX` isolates one thread, `--mode folded` emits flamegraph stacks. Complements
   `guest_bt` (which does the GUEST/managed-C# side). `--self-test` checks the symbol parser.
   See `hostprof/README.md`.
+- **`dropcache.py`** — evict a dump (or any path) from the **host page cache** before a timed run,
+  and prove it happened. A guest `read`/`pread` is served from the page cache on every launch after
+  the first, so a title's asset load can be several times faster than the same bytes off storage —
+  which is invisible for most work and decisive for a startup *race*: PPSA26414 reaches `DLLInit` in
+  289–362 ms warm and 779–1158 ms evicted, and it faults in the first case and boots in the second
+  (`docs/R_TYPE_DELTA_STATUS.md`). Unprivileged and scoped: `posix_fadvise(POSIX_FADV_DONTNEED)` on
+  the named files only, so it needs no root and cannot disturb another agent's working set. It prints
+  `mincore(2)` residency **before and after**, because "evicted it", "it was already cold" and
+  "eviction silently did nothing" otherwise look identical. `--report-only` measures without evicting.
+  **Record cache state alongside any startup-timing number**; without it the number is unreproducible.
 - **F8 interactive performance capture / `perf/performance_capture_report.py`** — while playing in
   `prosper-app`, press **F8** when performance is bad. The app keeps a cheap 4 Hz rolling ring of
   process CPU/RSS plus guest-flip, rendered-frame, and host-present counts; the press freezes the

--- a/prosper/tools/dropcache.py
+++ b/prosper/tools/dropcache.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""dropcache.py — evict a path's pages from the host page cache, and prove it happened.
+
+Why this exists
+---------------
+A guest's `read`/`pread` is served from the **host page cache** on every run after the first, so a
+title's asset load can be several times faster on prosper than the same bytes off real storage. For
+most work that is invisible. For a title whose startup is a *race* it is decisive: PPSA26414
+(R-Type Delta) reaches its `DLLInit` in 289-362 ms warm and 797-1158 ms with the dump evicted, and
+it faults in the first case and boots in the second (`docs/R_TYPE_DELTA_STATUS.md`). Any startup
+timing taken without recording cache state is therefore unreproducible.
+
+This is an unprivileged, *scoped* eviction — `posix_fadvise(POSIX_FADV_DONTNEED)` on the named files
+only. It does not need root, does not touch `/proc/sys/vm/drop_caches`, and cannot disturb another
+agent's working set, so it is safe to run on a shared box.
+
+It reports resident pages **before and after** via `mincore(2)`, because "I evicted it" and "it was
+already evicted" and "eviction silently did nothing" otherwise look identical — and a run whose
+premise is the cache state must be able to show its lever moved. Dirty pages cannot be dropped;
+if `after` stays high, that is the reason, and the number says so instead of hiding it.
+
+Usage
+-----
+    python3 tools/dropcache.py <DUMP_ROOT>/PPSA26414-app0          # evict a whole dump
+    python3 tools/dropcache.py <path> [<path> ...] [--quiet]
+    python3 tools/dropcache.py --report-only <path>                # measure, evict nothing
+"""
+import ctypes
+import ctypes.util
+import mmap
+import os
+import sys
+
+_PAGE = os.sysconf("SC_PAGE_SIZE")
+_libc = ctypes.CDLL(ctypes.util.find_library("c") or "libc.so.6", use_errno=True)
+_libc.mincore.argtypes = [ctypes.c_void_p, ctypes.c_size_t, ctypes.POINTER(ctypes.c_ubyte)]
+_libc.mincore.restype = ctypes.c_int
+
+
+def resident_pages(fd, size):
+    """Pages of this file currently in the page cache, or None if it cannot be measured."""
+    if size == 0:
+        return 0
+    try:
+        # MAP_PRIVATE with PROT_WRITE only so ctypes will hand out the mapping's address
+        # (from_buffer refuses a read-only buffer). Nothing is ever written, so no page is
+        # copied and mincore still reports the file's own residency.
+        mm = mmap.mmap(fd, size, flags=mmap.MAP_PRIVATE, prot=mmap.PROT_READ | mmap.PROT_WRITE)
+    except (ValueError, OSError):
+        return None
+    try:
+        npages = (size + _PAGE - 1) // _PAGE
+        vec = (ctypes.c_ubyte * npages)()
+        addr = ctypes.addressof(ctypes.c_char.from_buffer(mm))
+        if _libc.mincore(ctypes.c_void_p(addr), ctypes.c_size_t(size), vec) != 0:
+            return None
+        return sum(1 for b in vec if b & 1)
+    finally:
+        mm.close()
+
+
+def walk(paths):
+    for p in paths:
+        if os.path.isfile(p):
+            yield p
+        else:
+            for dirpath, _dirs, files in os.walk(p):
+                for f in files:
+                    yield os.path.join(dirpath, f)
+
+
+def main(argv):
+    report_only = "--report-only" in argv
+    quiet = "--quiet" in argv
+    paths = [a for a in argv if not a.startswith("--")]
+    if not paths:
+        print(__doc__.strip().split("Usage\n-----\n", 1)[1])
+        return 2
+
+    files = before = after = total = 0
+    unmeasured = 0
+    for path in walk(paths):
+        try:
+            fd = os.open(path, os.O_RDONLY)
+        except OSError:
+            continue
+        try:
+            size = os.fstat(fd).st_size
+            r0 = resident_pages(fd, size)
+            if not report_only:
+                os.posix_fadvise(fd, 0, 0, os.POSIX_FADV_DONTNEED)
+            r1 = resident_pages(fd, size) if not report_only else r0
+            files += 1
+            total += size
+            if r0 is None or r1 is None:
+                unmeasured += 1
+            else:
+                before += r0
+                after += r1
+        finally:
+            os.close(fd)
+
+    if not quiet:
+        mb = lambda pages: pages * _PAGE / 1e6
+        verb = "measured" if report_only else "evicted"
+        print("%s %d files, %.1f MB on disk" % (verb, files, total / 1e6))
+        print("  page cache: %.1f MB resident before -> %.1f MB after" % (mb(before), mb(after)))
+        if unmeasured:
+            print("  (%d files not measurable by mincore; eviction was still requested)" % unmeasured)
+        if not report_only and after > before * 0.1 and before > 0:
+            print("  WARNING: most pages are still resident — dirty or otherwise unevictable. "
+                  "Do NOT report this run as a cold-cache arm.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/prosper/tools/dropcache.py
+++ b/prosper/tools/dropcache.py
@@ -6,30 +6,44 @@ Why this exists
 A guest's `read`/`pread` is served from the **host page cache** on every run after the first, so a
 title's asset load can be several times faster on prosper than the same bytes off real storage. For
 most work that is invisible. For a title whose startup is a *race* it is decisive: PPSA26414
-(R-Type Delta) reaches its `DLLInit` in 289-362 ms warm and 797-1158 ms with the dump evicted, and
+(R-Type Delta) reaches its `DLLInit` in 289-362 ms warm and 779-1158 ms with the dump evicted, and
 it faults in the first case and boots in the second (`docs/R_TYPE_DELTA_STATUS.md`). Any startup
 timing taken without recording cache state is therefore unreproducible.
 
-This is an unprivileged, *scoped* eviction — `posix_fadvise(POSIX_FADV_DONTNEED)` on the named files
-only. It does not need root, does not touch `/proc/sys/vm/drop_caches`, and cannot disturb another
-agent's working set, so it is safe to run on a shared box.
+Scope, and the hazard it does NOT remove
+----------------------------------------
+`posix_fadvise(POSIX_FADV_DONTNEED)` needs no root and touches nothing outside the files named on
+the command line — unlike `/proc/sys/vm/drop_caches`, which drops the whole machine's cache. That is
+the only safety property it has. **The page cache is global**, so evicting a shared dump evicts it
+for *every* process on the host: pointing this at a tree another agent is currently timing silently
+invalidates their run. On a shared box, say what you are about to evict first.
 
 It reports resident pages **before and after** via `mincore(2)`, because "I evicted it" and "it was
 already evicted" and "eviction silently did nothing" otherwise look identical — and a run whose
-premise is the cache state must be able to show its lever moved. Dirty pages cannot be dropped;
-if `after` stays high, that is the reason, and the number says so instead of hiding it.
+premise is the cache state must be able to show its lever moved. Dirty pages cannot be dropped; if
+`after` stays high the tool says so and exits non-zero, so a scripted cold arm cannot quietly
+inherit a warm cache. A path that does not exist, or that contains no files, is an error for the
+same reason: a typo must not be indistinguishable from a successful eviction.
 
 Usage
 -----
     python3 tools/dropcache.py <DUMP_ROOT>/PPSA26414-app0          # evict a whole dump
     python3 tools/dropcache.py <path> [<path> ...] [--quiet]
     python3 tools/dropcache.py --report-only <path>                # measure, evict nothing
+    python3 tools/dropcache.py --self-test                         # no path needed
+
+Exit status: 0 evicted (or measured) cleanly, 1 pages remained resident / nothing was measurable,
+2 usage error (unknown flag, missing or empty path).
 """
 import ctypes
 import ctypes.util
 import mmap
 import os
 import sys
+
+USAGE = """usage: dropcache.py [--report-only] [--quiet] <path> [<path> ...]
+       dropcache.py --self-test
+exit: 0 clean, 1 pages still resident / nothing measurable, 2 usage error"""
 
 _PAGE = os.sysconf("SC_PAGE_SIZE")
 _libc = ctypes.CDLL(ctypes.util.find_library("c") or "libc.so.6", use_errno=True)
@@ -51,16 +65,21 @@ def resident_pages(fd, size):
     try:
         npages = (size + _PAGE - 1) // _PAGE
         vec = (ctypes.c_ubyte * npages)()
-        addr = ctypes.addressof(ctypes.c_char.from_buffer(mm))
-        if _libc.mincore(ctypes.c_void_p(addr), ctypes.c_size_t(size), vec) != 0:
-            return None
-        return sum(1 for b in vec if b & 1)
+        buf = ctypes.c_char.from_buffer(mm)
+        addr = ctypes.addressof(buf)
+        rc = _libc.mincore(ctypes.c_void_p(addr), ctypes.c_size_t(size), vec)
+        resident = None if rc != 0 else sum(1 for b in vec if b & 1)
+        del buf                      # release the buffer export before mm.close()
+        return resident
     finally:
         mm.close()
 
 
 def walk(paths):
+    """Yield every regular file under `paths`. Raises FileNotFoundError on a path that is absent."""
     for p in paths:
+        if not os.path.exists(p):
+            raise FileNotFoundError(p)
         if os.path.isfile(p):
             yield p
         else:
@@ -69,16 +88,10 @@ def walk(paths):
                     yield os.path.join(dirpath, f)
 
 
-def main(argv):
-    report_only = "--report-only" in argv
-    quiet = "--quiet" in argv
-    paths = [a for a in argv if not a.startswith("--")]
-    if not paths:
-        print(__doc__.strip().split("Usage\n-----\n", 1)[1])
-        return 2
-
-    files = before = after = total = 0
-    unmeasured = 0
+def run(paths, report_only=False, quiet=False, out=None):
+    """Evict (or measure) `paths`. Returns a process exit status."""
+    out = out or sys.stdout
+    files = before = after = total = unmeasured = 0
     for path in walk(paths):
         try:
             fd = os.open(path, os.O_RDONLY)
@@ -89,7 +102,7 @@ def main(argv):
             r0 = resident_pages(fd, size)
             if not report_only:
                 os.posix_fadvise(fd, 0, 0, os.POSIX_FADV_DONTNEED)
-            r1 = resident_pages(fd, size) if not report_only else r0
+            r1 = r0 if report_only else resident_pages(fd, size)
             files += 1
             total += size
             if r0 is None or r1 is None:
@@ -100,17 +113,100 @@ def main(argv):
         finally:
             os.close(fd)
 
+    mb = lambda pages: pages * _PAGE / 1e6
+    if files == 0:
+        print("error: no readable files under %s — nothing was evicted. A typo must not look like a "
+              "successful cold arm." % ", ".join(paths), file=sys.stderr)
+        return 2
     if not quiet:
-        mb = lambda pages: pages * _PAGE / 1e6
-        verb = "measured" if report_only else "evicted"
-        print("%s %d files, %.1f MB on disk" % (verb, files, total / 1e6))
-        print("  page cache: %.1f MB resident before -> %.1f MB after" % (mb(before), mb(after)))
+        print("%s %d files, %.1f MB on disk" % ("measured" if report_only else "evicted",
+                                                files, total / 1e6), file=out)
+        print("  page cache: %.1f MB resident before -> %.1f MB after" % (mb(before), mb(after)),
+              file=out)
         if unmeasured:
-            print("  (%d files not measurable by mincore; eviction was still requested)" % unmeasured)
-        if not report_only and after > before * 0.1 and before > 0:
-            print("  WARNING: most pages are still resident — dirty or otherwise unevictable. "
-                  "Do NOT report this run as a cold-cache arm.")
+            print("  (%d files not measurable by mincore; eviction was still requested)" % unmeasured,
+                  file=out)
+    # Warnings go to stderr and set the exit status, so `--quiet` and a scripted arm still see them.
+    if not report_only and before > 0 and after > before * 0.1:
+        print("WARNING: %.1f MB of %.1f MB is still resident — dirty or otherwise unevictable. "
+              "Do NOT report this run as a cold-cache arm." % (mb(after), mb(before)), file=sys.stderr)
+        return 1
+    if unmeasured == files:
+        print("WARNING: residency was not measurable for any file; this run cannot prove it was cold.",
+              file=sys.stderr)
+        return 1
     return 0
+
+
+def self_test():
+    """Exercise the answer shapes without needing a dump: warm, evicted, and a bad path.
+
+    It uses this script's own file as the subject — already on disk, already clean, so no write
+    and no `fsync` is needed. (An earlier version wrote and fsync'd a temp file and could block
+    for minutes in `D` state on a busy host; the subject only has to be *clean*, not fresh.)
+    """
+    ok = True
+    me = os.path.abspath(__file__)
+    with open(os.devnull, "w") as null:
+        with open(me, "rb") as f:                       # warm it
+            f.read()
+        fd = os.open(me, os.O_RDONLY)
+        try:
+            warm = resident_pages(fd, os.fstat(fd).st_size)
+        finally:
+            os.close(fd)
+        if not warm:
+            print("self-test: a just-read file reported 0 resident pages — mincore is not working")
+            ok = False
+        if run([me], report_only=True, out=null) != 0:
+            print("self-test: report-only on a warm file should be status 0")
+            ok = False
+        if run([me], out=null) != 0:
+            print("self-test: eviction of a clean file should be status 0")
+            ok = False
+        fd = os.open(me, os.O_RDONLY)
+        try:
+            cold = resident_pages(fd, os.fstat(fd).st_size)
+        finally:
+            os.close(fd)
+        if cold:
+            print("self-test: %d pages still resident after eviction — either this filesystem "
+                  "cannot be evicted (tmpfs?) or another process is holding the file" % cold)
+            ok = False
+        # The next two arms print their own error line to stderr; that IS the behaviour under test.
+        if main([me + "-no-such-path"]) != 2:
+            print("self-test: an absent path must be status 2")
+            ok = False
+        if main(["--report_only", me]) != 2:
+            print("self-test: a misspelled flag must be status 2, never a silent eviction")
+            ok = False
+    print("self-test:", "PASS" if ok else "FAIL")
+    return 0 if ok else 1
+
+
+def main(argv):
+    if "--self-test" in argv:
+        return self_test()
+    report_only = quiet = False
+    paths = []
+    for a in argv:
+        if a == "--report-only":
+            report_only = True
+        elif a == "--quiet":
+            quiet = True
+        elif a.startswith("-"):
+            print("error: unknown option %r\n%s" % (a, USAGE), file=sys.stderr)
+            return 2
+        else:
+            paths.append(a)
+    if not paths:
+        print(USAGE, file=sys.stderr)
+        return 2
+    try:
+        return run(paths, report_only=report_only, quiet=quiet)
+    except FileNotFoundError as e:
+        print("error: no such path: %s\n%s" % (e.args[0], USAGE), file=sys.stderr)
+        return 2
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Refs #1746, refs #1810. Documentation plus one new measurement tool. No emulator source file, test,
or snapshot baseline is touched, so no title's behavior changes.

## Why

#2009 concludes that #1746 is a host-CPU-speed race and that prosper is correct. That left one
question unanswered, and it is the one a reader forms first: **why is the `users` vector empty at
all?** A PS5 has a user signed in before the title launches, so if the guest can only learn about
that user by draining an event queue, the identical race would exist on hardware — and the title
ships working. Either a *synchronous* user-service API is answering wrongly (a real prosper defect),
or prosper's I/O is unrealistically fast (a fidelity gap). This PR tests both.

## 1. A synchronous API cannot be the answer — by construction

**The eboot imports exactly three `libSceUserService` functions** — `sceUserServiceInitialize`,
`sceUserServiceGetInitialUser`, `sceUserServiceGetEvent` — and `title_Release.prx` imports none (only
21 libc + 2 libkernel). `GetLoginUserIdList`, `GetUserName`, `GetUserNumber` and `GetForegroundUser`
are never imported, so no answer prosper gives them can reach this title.

The list is a `std::vector<User*>` at `eboot+0x6f41a8`. Its complete reference set (`tools/re/xref.py`):
one producer (`eboot+0x23690`), one caller of it (`eboot+0x23def`, the LOGIN arm of the drain loop),
one event source (`sceUserServiceGetEvent`), one thread (`eboot+0x49070`, after its own `Sleep(400)`
— vtable slot `eboot+0x411048` → `eboot+0x23210` → `sceKernelUsleep`). The only other route into the
drain, `eboot+0x49130`, has **no code reference and no relocation anywhere in the module**.

`InputSystem::Init` (`eboot+0x23640`) is decoded in the doc: it clears the vector, calls
`sceUserServiceInitialize(NULL)`, `scePadInit()`, and tail-calls
`sceUserServiceGetInitialUser(&g_initialUser)` — into `eboot+0x6f419c`, a **different** global, read
by the save-data path (`eboot+0x248f0`: `sceSaveDataMount3`, `sceSaveDataDirNameSearch`,
`sceSaveDataDialogOpen`, …) and the NP/UDS path (`eboot+0x29ab0`). Nothing copies it into the vector.

Three live confirmations on `4d7a2ded`:

- a gdb breakpoint census records `sceUserServiceGetInitialUser` **exactly once**, with
  `out=0x4106f419c` — the address the static decode predicted — and `GetLoginUserIdList` zero times;
- `PROSPER_SVCLOG=1` on a default boot logs **no `sceUserServiceGetEvent` at all** before the fault;
- the fault report's `rax=0x0` is `_M_start`: the vector never allocated, and the backtrace's
  `eboot+0x22a5b` frame proves `InputSystem::Init` had already run and been answered.

So prosper has **no defect here**, and this is now settled by the guest's call graph rather than by a
measurement that a future change could invalidate.

## 2. Host page-cache state decides the race — and it is not a fidelity gap either

The second hypothesis is real as a *mechanism*: guest reads are served from the host page cache.
Evicting only this dump's pages makes the same unmodified binary, on the same host, **boot**.

| arm | page cache | INPUT→`DLLInit` | outcome | load avg |
| --- | --- | --- | --- | --- |
| warm A–E | warm | 289 / 322 / 318 / 362 / **342** ms | SIGSEGV `+0x24055`, 5 of 5 | 33.9 / 34.0 / 34.2 / 42.9 / **13.4** |
| cold A–E | evicted | 1158 / 909 / 797 / 779 / **1000** ms | no fault, up to 1219 `DLLMain`, 5 of 5 | 33.2 / 36.2 / 51.4 / 26.5 / **14.7** |

The full table (with `name=INPUT`, `DLLLoadStart`, `DLLInit` and load duration per arm) is in the doc.
The title's own threshold is 400 ms. Every warm arm is under it and faults; every cold arm is over it
and boots.

**CPU contention is the standing confound for this title, so the decisive pair is the least contended
one**: warm E ran at load 13.4 and faulted, cold E ran at load 14.7 — *more* contended — and booted.
Both cold arms carry `mincore(2)` proof that the pages were gone (179.0 → 0.0 MB, 119.7 → 0.0 MB) and
were pulled back from storage by the run itself. The lever is the cache, not peer load.

**This does not mean prosper is faster than the hardware it emulates.** The cold arm's extra ~360 ms
is this box reading ~101 MB from the **external USB SSD** the dumps live on, at ~0.25 GB/s under
concurrent load; a PS5 reads the same 101.4 MB from its internal SSD at a published 5.5 GB/s. A
PS5-faithful storage model would therefore land near the **warm** arm and would not supply the
38–111 ms deficit — so this is explicitly **not** a recommendation to add one.

What it does establish is an instrument rule: **no startup-timing number for this title is valid
unless the page-cache state is recorded**, because the same binary on the same host differs by 3–4×.
It also explains user-visible nondeterminism — a first launch after a reboot may work where the
second does not.

## Interaction with #2009 (already resolved)

#2009 merged as `c3614f51` while this was open; the branch has been **rebased onto it and its hunks
re-applied by hand** onto master's version of the document, not taken wholesale (per the
never-take-a-whole-file rule). `git diff origin/master` deletes exactly three lines, all of them
deliberate: the two `## Ruled out` rows narrowed below, and one sentence in `## Next frontier`.

Two of #2009's statements needed narrowing, and both are warm-page-cache artifacts rather than errors
of reasoning:

- *"~17 ms of file I/O inside a 244 ms load"* (`strace -f -c`) is a **warm-cache** figure, not a
  property of prosper. With the dump evicted the same load takes 552-719 ms.
- *"No storage model makes 101 MB take 400 ms"* is true of PS5-faithful models and measurably false
  for a host cold cache. It now reads "no *PS5-faithful* storage model", which is the claim the
  direction argument actually supports.

#2009'''s host-CPU-speed conclusion, its rung-1 evidence, and its product-decision framing are
untouched and are quoted forward in `## Next frontier`.

## New tool

`prosper/tools/dropcache.py` — `posix_fadvise(POSIX_FADV_DONTNEED)` over a named tree. Unprivileged
and scoped to those files, so it needs no root and cannot disturb another agent's working set on a
shared box. It reports `mincore(2)` residency **before and after**, because "evicted it", "it was
already cold" and "eviction silently did nothing" otherwise look identical, and warns rather than
lying if pages stay resident. `--report-only` measures without evicting. Documented in
`tools/AGENTS.md`.

Self-test on the dump's `data/sound` tree (26.0 MB): `report-only` → 26.0 MB resident; evict →
26.0 → 0.0; `report-only` → 0.0; re-read the file → 26.0 again. The lever is demonstrated in both
directions.

## Affected and deliberately unaffected

Affected: `prosper/docs/R_TYPE_DELTA_STATUS.md`, `prosper/tools/AGENTS.md`, and the new
`prosper/tools/dropcache.py`. Nothing else.

Deliberately unaffected: #1746 stays **open** (`Refs`, not `Fixes`) — the default warm-cache launch
still faults, and the fix remains a product decision for the project owner. No storage-latency model
is proposed or implemented. No guest byte is patched and no guest sleep is capped.

## Risks

The doc now tells readers that the user-service side is closed by construction. If the guest binary
ever changed (a patch/update of the title), that argument would need re-deriving — the addresses and
the import census are stated explicitly so it can be.

## Verification

Documentation plus one standalone Python tool that nothing builds against, so no ctest or snapshot
surface is touched (and per policy snapshots are batched by the orchestrator). `git diff --check`
clean. `python3 tools/dropcache.py --report-only <path>` and the evict/verify/re-warm cycle above ran
clean on Linux in the `ps5ys` distrobox. Every measurement in the doc was taken on `4d7a2ded`
(master `278c9b1f`) with `boot_trace` on the default route, and each arm's host load average is
recorded alongside it because this title's outcome is load-sensitive.